### PR TITLE
fix(linux): recover disconnected sessions and preserve update delivery

### DIFF
--- a/.agents/skills/release-openclaw-maintainer/references/platform-publication.md
+++ b/.agents/skills/release-openclaw-maintainer/references/platform-publication.md
@@ -6,6 +6,97 @@ explicitly and call each complete only after its assets and updater evidence
 verify. Beta skips native publication unless requested; extended-stable never
 inherits these platforms.
 
+## Linux companion
+
+`Linux App Release Request` and `Linux App Release` own Linux bundle
+publication. Keep the `linux-stable` control tag fixed and its release
+prerelease/non-latest. The download landing page is
+`https://github.com/openclaw/openclaw/releases/tag/linux-stable`; the updater
+reads `/releases/download/linux-stable/latest.json`. Versioned bundles remain
+on their original release, not copied onto unrelated core releases.
+
+The publication helper separates two operations:
+
+- `publish` verifies signed, publicly available assets and preserves immutable
+  `OpenClaw-<version>-linux.json` bytes carrying source, tooling, and channel
+  SHAs plus asset identities. It forward-promotes the canonical manifest,
+  then mirrors it.
+- `mirror` binds the selected core tag/SHA and actual latest release around
+  writes. It copies the verified canonical manifest bytes without rebuilding
+  Linux bundles.
+
+Preserve successful manifest bytes, including `pub_date`, on retry. Identical
+versioned bytes may be reused; conflicting bundle bytes or same-version
+manifest bytes must stop. Verify public availability, signatures, identity,
+and readback, not just authenticated access to draft assets or a signature
+field in JSON. Reconcile partial canonical/mirror success without claiming
+transactional writes or uninterrupted feed availability.
+
+After GitHub finalization, core makes only a bounded detached mirror-only
+dispatch to the existing Linux release workflow for the legacy
+`/releases/latest/download/latest.json` mirror. Do not place a waiting mirror
+job inside the core parent's top-level concurrency or wait for its completion
+there. Dispatch acceptance is not mirror success: verify the detached outcome
+and manifest readback separately. This path does not change native-build
+admission. Keep mirroring until explicit retirement, including core releases
+without a new Linux build. Dispatch or mirror failures must be visibly degraded
+and recoverable without blocking npm, Docker, GitHub finalization, or
+main closeout. Do not treat core success as mirror success or republish core
+packages to repair the mirror. Canonical release notes link to the latest
+published Linux companion, not a promise of Linux assets for every core tag.
+
+Control-release initialization, mirror activation, version selection, and
+public asset writes require publication approval. Keep source repair, feed
+restoration, and binary migration as separate outcomes. Migrating an original
+legacy AppImage requires a separately approved greater-base release with
+signed public assets and isolated upgrade/relaunch proof through the binary's
+actual legacy endpoint and signing key. A new source endpoint or restored
+manifest alone cannot supply that proof. Package-managed installs keep their
+package-manager/download path; leave opt-in macOS/Windows Tauri test channels
+unchanged.
+
+### Missing canonical manifest
+
+If replacement deletes `linux-stable/latest.json` and its upload is interrupted,
+normal publication and mirroring must fail closed. `mirror` cannot recover a
+missing canonical manifest. Do not reset the channel or infer a recovery target
+from the newest release, release-body text, or a supplied version/hash.
+
+Recovery requires explicit release-owner approval and one bounded, coordinated
+operation:
+
+1. Establish the last verified canonical version and exact bytes. Reconcile all
+   intervening publication evidence, including failed or interrupted promotions,
+   to establish the version floor using the existing release ordering contract.
+   Missing or ambiguous history remains stopped; an immutable manifest's
+   existence alone does not prove it was the authorized canonical version.
+2. Agree on an exclusive recovery window with the Linux publication and core
+   release owners. Record the operator and deadline, hold competing publish and
+   mirror dispatches, and finish or explicitly resolve queued/running writers.
+   Serialize the recovery with those publication writers; do not proceed until
+   concurrent writes are excluded. This is owner coordination, not a new
+   scheduler or a waiting job inside core's top-level concurrency.
+3. Select and approve the exact immutable `OpenClaw-<version>-linux.json` bytes
+   against that history and floor. Verify its digest, source/tooling/channel
+   identities, versioned release ID, public asset inventory, and signed-bundle
+   evidence. Do not regenerate its signature, `pub_date`, or JSON.
+4. Freshly read the channel release ID, fixed tag SHA, and complete asset
+   inventory. Confirm the approved identities and canonical absence immediately
+   before one owner-controlled upload of the verified bytes as `latest.json`.
+   If an asset appears, identities or inventory move, or the deadline expires,
+   stop for reconciliation rather than overwrite or retry automatically.
+5. Read the canonical manifest back publicly and compare its exact bytes.
+   Recheck the channel identity and resulting inventory. Only after this passes,
+   use the normal mirror path with fresh core tag/SHA, release ID, and actual
+   latest-selector checks. Verify the public legacy endpoint against the same
+   bytes and recheck its release identity; dispatch acceptance is not readback.
+6. Retain the separate canonical and legacy outcomes before releasing the
+   recovery window. A failed legacy readback remains visibly degraded even if
+   canonical restoration succeeded; do not reset either endpoint to conceal it.
+
+This procedure supplies no standing public-write authority and no automatic
+recovery mode. Any further attempt needs fresh owner reconciliation.
+
 ## macOS
 
 An explicit stable or full release request includes macOS publication unless

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -42,3 +42,6 @@ paths:
   .github/workflows/docker-channel-promote.yml:
     ignore:
       - 'unexpected key "queue" for "concurrency" section'
+  .github/workflows/linux-app-release.yml:
+    ignore:
+      - 'unexpected key "queue" for "concurrency" section'

--- a/.github/workflows/linux-app-release.yml
+++ b/.github/workflows/linux-app-release.yml
@@ -1,6 +1,28 @@
 name: Linux App Release
 
 on:
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: "Published core tag to reconcile (mirror only; no native build)"
+        required: true
+        type: string
+      source_sha:
+        description: "Exact published core source SHA"
+        required: true
+        type: string
+      tooling_sha:
+        description: "Exact protected parent workflow SHA"
+        required: true
+        type: string
+      release_publish_run_id:
+        description: "Core publication run that dispatched this mirror"
+        required: true
+        type: string
+      release_publish_run_attempt:
+        description: "Exact core publication attempt"
+        required: true
+        type: string
   workflow_run: # zizmor: ignore[dangerous-triggers] main-only release builder; exact successful request/main identity is validated before selected-tag execution, while signing and publication stay in fresh jobs
     workflows: ["Linux App Release Request"]
     branches: [main]
@@ -9,7 +31,7 @@ on:
 permissions: {}
 
 concurrency:
-  group: linux-app-release-${{ github.event.workflow_run.id }}
+  group: linux-app-release-${{ github.event.workflow_run.id || github.run_id }}
   cancel-in-progress: false
 
 env:
@@ -25,6 +47,7 @@ jobs:
   validate_release:
     name: Validate release tag
     if: >-
+      github.event_name == 'workflow_run' &&
       github.repository == 'openclaw/openclaw' &&
       github.event.workflow_run.repository.full_name == 'openclaw/openclaw' &&
       github.event.workflow_run.event == 'workflow_dispatch' &&
@@ -780,15 +803,57 @@ jobs:
       - build_macos
       - build_windows
       - sign_desktop
-    # One shared desktop-test channel asset must not race across release tags.
+    # All Linux channel writers share this queue, including detached core mirrors.
     concurrency:
       group: linux-app-release-publish
+      queue: max
       cancel-in-progress: false
     runs-on: ubuntu-22.04
     timeout-minutes: 10
     permissions:
       contents: write
     steps:
+      - name: Checkout trusted Linux publication tooling
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.workflow_sha }}
+          fetch-depth: 1
+          persist-credentials: false
+          sparse-checkout: |
+            apps/linux/src-tauri/tauri.conf.json
+            scripts/linux-app-channel.mjs
+            scripts/lib/release-version.mjs
+            scripts/lib/record-shared.mjs
+            scripts/release-tooling-identity.mjs
+          sparse-checkout-cone-mode: false
+
+      - name: Verify trusted publication tooling identity
+        env:
+          GH_TOKEN: ${{ github.token }}
+          WORKFLOW_FULL_REF: ${{ github.ref }}
+          WORKFLOW_REF: ${{ github.ref_name }}
+          WORKFLOW_SHA: ${{ github.workflow_sha }}
+        run: |
+          set -euo pipefail
+          node scripts/release-tooling-identity.mjs verify \
+            --repository "$GITHUB_REPOSITORY" \
+            --workflow-ref "$WORKFLOW_REF" \
+            --workflow-full-ref "$WORKFLOW_FULL_REF" \
+            --workflow-sha "$WORKFLOW_SHA"
+
+      - name: Install pinned public signature verifier
+        run: |
+          set -euo pipefail
+          archive="${RUNNER_TEMP}/minisign.tar.gz"
+          mkdir -p "${RUNNER_TEMP}/minisign"
+          curl --fail --location --silent --show-error --proto '=https' --proto-redir '=https' \
+            --connect-timeout 10 --max-time 120 "$MINISIGN_URL" -o "$archive"
+          printf '%s  %s\n' "$MINISIGN_ARCHIVE_SHA256" "$archive" | sha256sum --check -
+          tar -xzf "$archive" -C "${RUNNER_TEMP}/minisign" --strip-components=2 minisign-linux/x86_64/minisign
+          printf '%s  %s\n' "$MINISIGN_BINARY_SHA256" "${RUNNER_TEMP}/minisign/minisign" | sha256sum --check -
+          chmod 0555 "${RUNNER_TEMP}/minisign/minisign"
+          echo "${RUNNER_TEMP}/minisign" >> "$GITHUB_PATH"
+
       - name: Download Debian bundle
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
@@ -830,30 +895,15 @@ jobs:
             cp dist/input/windows/release/* dist/release/
           fi
 
-          # Generate this before latest.json so it covers only downloadable bundles.
+          # Checksums cover only the immutable downloadable bundles.
           (cd dist/release && sha256sum ./* > SHA256SUMS.linux-app.txt)
           cat dist/release/SHA256SUMS.linux-app.txt
 
-          linux_signature=$(cat "dist/input/linux/signatures/OpenClaw-${version}-amd64.AppImage.sig")
           url_base="https://github.com/${GITHUB_REPOSITORY}/releases/download/${RELEASE_TAG}"
-          pub_date=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-          # Capture the full body (no early-closing pipe under pipefail), then
-          # truncate to 2000 Unicode chars inside jq so we never split a
-          # multibyte character or SIGPIPE the release-view command.
-          notes=$(gh release view "${RELEASE_TAG}" --repo "${GITHUB_REPOSITORY}" --json body --jq '.body // ""')
-          # latest.json is always the stable Linux channel. Desktop test builds
-          # use a separate manifest that Linux-only releases leave untouched.
-          jq -n \
-            --arg version "${version}" \
-            --arg notes "${notes}" \
-            --arg pub_date "${pub_date}" \
-            --arg linux_signature "${linux_signature}" \
-            --arg linux_url "${url_base}/OpenClaw-${version}-amd64.AppImage" \
-            '{version: $version, notes: ($notes | .[0:2000]), pub_date: $pub_date, platforms: {"linux-x86_64": {signature: $linux_signature, url: $linux_url}}}' \
-            > dist/release/latest.json
-          cat dist/release/latest.json
-
           if [[ "${DESKTOP_TEST_BUNDLES}" == "true" ]]; then
+            release_json=$(gh release view "${RELEASE_TAG}" --repo "${GITHUB_REPOSITORY}" --json body,publishedAt)
+            pub_date=$(jq -er '.publishedAt' <<< "$release_json")
+            notes=$(jq -r '.body // ""' <<< "$release_json")
             macos_signature=$(cat "dist/input/macos/signatures/OpenClaw-${version}-darwin-aarch64.app.tar.gz.sig")
             windows_signature=$(cat "dist/input/windows/signatures/OpenClaw-${version}-windows-x86_64.exe.sig")
             jq -n \
@@ -869,16 +919,22 @@ jobs:
             cat dist/release/latest-desktop-test.json
           fi
 
-      - name: Attach bundles to the release
+      - name: Publish immutable bundles, canonical Linux channel, and legacy mirror
         env:
+          DESKTOP_TEST_BUNDLES: ${{ needs.validate_release.outputs.desktop_test_bundles }}
           GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ needs.validate_release.outputs.release_tag }}
+          TAG_SHA: ${{ needs.validate_release.outputs.tag_sha }}
+          WORKFLOW_SHA: ${{ github.workflow_sha }}
         run: |
           set -euo pipefail
-          gh release upload "${RELEASE_TAG}" \
-            --repo "${GITHUB_REPOSITORY}" \
-            --clobber \
-            dist/release/*
+          printf '%s  %s\n' "$MINISIGN_BINARY_SHA256" "${RUNNER_TEMP}/minisign/minisign" | sha256sum --check -
+          node scripts/linux-app-channel.mjs publish \
+            --tag "$RELEASE_TAG" --source-sha "$TAG_SHA" --tooling-sha "$WORKFLOW_SHA" \
+            --assets dist/release \
+            --signature "dist/input/linux/signatures/OpenClaw-${RELEASE_TAG#v}-amd64.AppImage.sig" \
+            --public-key-config apps/linux/src-tauri/tauri.conf.json \
+            --desktop-test "$DESKTOP_TEST_BUNDLES" | tee "$RUNNER_TEMP/linux-publication.json"
 
       - name: Publish desktop test update channel
         if: ${{ needs.validate_release.outputs.desktop_test_bundles == 'true' }}
@@ -922,3 +978,91 @@ jobs:
             --repo "${GITHUB_REPOSITORY}" \
             --clobber \
             dist/release/latest-desktop-test.json
+
+      - name: Record incomplete Linux publication
+        if: ${{ failure() }}
+        run: |
+          echo "::warning::Linux publication is incomplete. Inspect canonical and legacy readbacks before retry; immutable bundle conflicts must not be overwritten."
+          echo "- Linux channel: incomplete; reconcile this run. Core publication remains independent." >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Retain Linux publication result
+        if: ${{ always() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: linux-publication-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/linux-publication.json
+          if-no-files-found: warn
+
+  mirror_legacy:
+    name: Reconcile legacy Linux updater metadata
+    if: ${{ github.event_name == 'workflow_dispatch' && github.repository == 'openclaw/openclaw' }}
+    # The core parent dispatches and exits. Waiting here cannot hold its release train.
+    concurrency:
+      group: linux-app-release-publish
+      queue: max
+      cancel-in-progress: false
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
+    permissions:
+      actions: read
+      contents: write
+    steps:
+      - name: Checkout trusted Linux mirror tooling
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.workflow_sha }}
+          fetch-depth: 1
+          persist-credentials: false
+          sparse-checkout: |
+            apps/linux/src-tauri/tauri.conf.json
+            scripts/linux-app-channel.mjs
+            scripts/lib/release-version.mjs
+            scripts/lib/record-shared.mjs
+            scripts/release-tooling-identity.mjs
+          sparse-checkout-cone-mode: false
+
+      - name: Verify detached mirror dispatch identity
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EXPECTED_TOOLING_SHA: ${{ inputs.tooling_sha }}
+          PARENT_RUN_ID: ${{ inputs.release_publish_run_id }}
+          PARENT_RUN_ATTEMPT: ${{ inputs.release_publish_run_attempt }}
+          WORKFLOW_FULL_REF: ${{ github.ref }}
+          WORKFLOW_REF: ${{ github.ref_name }}
+          WORKFLOW_SHA: ${{ github.workflow_sha }}
+        run: |
+          set -euo pipefail
+          [[ "$WORKFLOW_FULL_REF" == refs/tags/release-publish/* && "$EXPECTED_TOOLING_SHA" == "$WORKFLOW_SHA" ]]
+          node scripts/release-tooling-identity.mjs verify \
+            --repository "$GITHUB_REPOSITORY" \
+            --workflow-ref "$WORKFLOW_REF" --workflow-full-ref "$WORKFLOW_FULL_REF" \
+            --workflow-sha "$WORKFLOW_SHA" \
+            --release-publish-run-id "$PARENT_RUN_ID" \
+            --release-publish-run-attempt "$PARENT_RUN_ATTEMPT" \
+            --release-publish-ref "$WORKFLOW_REF" --release-publish-full-ref "$WORKFLOW_FULL_REF" \
+            --release-publish-parent-state-policy active-or-success
+
+      - name: Mirror verified canonical bytes to the actual core latest
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
+          TAG_SHA: ${{ inputs.source_sha }}
+        run: |
+          set -euo pipefail
+          node scripts/linux-app-channel.mjs mirror \
+            --tag "$RELEASE_TAG" --source-sha "$TAG_SHA" \
+            --public-key-config apps/linux/src-tauri/tauri.conf.json | tee "$RUNNER_TEMP/linux-mirror.json"
+
+      - name: Record degraded legacy Linux bridge
+        if: ${{ failure() }}
+        run: |
+          echo "::warning::Legacy Linux update delivery is degraded; core publication remains complete. Reconcile canonical/latest identity and rerun this mirror-only dispatch."
+          echo "- Legacy Linux bridge: incomplete. Dispatch acceptance was not mirror success; inspect this run before recovery." >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Retain Linux mirror result
+        if: ${{ always() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: linux-mirror-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/linux-mirror.json
+          if-no-files-found: warn

--- a/.github/workflows/openclaw-release-publish.yml
+++ b/.github/workflows/openclaw-release-publish.yml
@@ -1422,7 +1422,7 @@ jobs:
           changelog_file="${RUNNER_TEMP}/CHANGELOG.md"
           notes_file="${RUNNER_TEMP}/release-notes.md"
           git show "${TARGET_SHA}:CHANGELOG.md" > "${changelog_file}"
-          node --import tsx scripts/render-github-release-notes.mts \
+          node --import tsx .release-harness/scripts/render-github-release-notes.mts \
             --changelog "${changelog_file}" \
             --tag "${RELEASE_TAG}" \
             --repository "${GITHUB_REPOSITORY}" \
@@ -1930,30 +1930,110 @@ jobs:
   finalize_github_release:
     name: Finalize GitHub release
     # Apps attach independently after npm and Gateway Docker evidence is complete.
-    needs: [publish, publish_docker]
+    needs: [resolve_release_target, publish, publish_docker]
     if: ${{ always() && inputs.publish_openclaw_npm && needs.publish.result == 'success' && (needs.publish_docker.result == 'success' || (contains(inputs.tag, '-alpha.') && needs.publish_docker.result == 'skipped')) }}
     runs-on: ubuntu-latest
     environment: npm-release
+    timeout-minutes: 10
     permissions:
       contents: write
     steps:
+      - name: Checkout trusted core finalization tooling
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.workflow_sha }}
+          fetch-depth: 1
+          persist-credentials: false
+          sparse-checkout: |
+            scripts/linux-app-channel.mjs
+            scripts/lib/release-version.mjs
+          sparse-checkout-cone-mode: false
+
       - name: Publish the verified draft release
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ inputs.tag }}
+          TARGET_SHA: ${{ needs.resolve_release_target.outputs.sha }}
+          RELEASE_NPM_DIST_TAG: ${{ inputs.npm_dist_tag }}
         run: |
           set -euo pipefail
-          expected_prerelease=false
-          if [[ "${RELEASE_TAG}" == *"-alpha."* || "${RELEASE_TAG}" == *"-beta."* ]]; then
-            expected_prerelease=true
+          make_latest=false
+          if [[ "$RELEASE_NPM_DIST_TAG" == "latest" ]]; then
+            make_latest=true
           fi
-          gh release edit "${RELEASE_TAG}" --repo "${GITHUB_REPOSITORY}" --draft=false
-          release_json="$(gh release view "${RELEASE_TAG}" --repo "${GITHUB_REPOSITORY}" --json isDraft,isPrerelease)"
-          if [[ "$(printf '%s' "${release_json}" | jq -r '.isDraft')" != "false" ]] || \
-            [[ "$(printf '%s' "${release_json}" | jq -r '.isPrerelease')" != "${expected_prerelease}" ]]; then
-            echo "Published GitHub release state does not match the requested draft/prerelease classification." >&2
-            exit 1
-          fi
+          node scripts/linux-app-channel.mjs finalize-core \
+            --tag "$RELEASE_TAG" --source-sha "$TARGET_SHA" --latest "$make_latest" |
+            tee "$RUNNER_TEMP/core-finalization.json"
+
+      - name: Retain core finalization result
+        if: ${{ always() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: core-finalization-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/core-finalization.json
+          if-no-files-found: warn
+
+  dispatch_linux_mirror:
+    name: Dispatch legacy Linux mirror after publication
+    needs: [resolve_release_target, finalize_github_release]
+    if: ${{ !cancelled() && needs.finalize_github_release.result == 'success' && inputs.npm_dist_tag == 'latest' && !contains(inputs.tag, '-alpha.') && !contains(inputs.tag, '-beta.') }}
+    # Never wait for the shared Linux metadata queue inside this workflow's
+    # release-train concurrency group. Dispatch acceptance is not mirror success.
+    continue-on-error: true
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      actions: write
+      contents: read
+    steps:
+      - name: Checkout trusted Linux dispatch tooling
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.workflow_sha }}
+          sparse-checkout: scripts
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Dispatch detached Linux mirror
+        timeout-minutes: 3
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PARENT_WORKFLOW_SHA: ${{ github.workflow_sha }}
+          RELEASE_TAG: ${{ inputs.tag }}
+          TARGET_SHA: ${{ needs.resolve_release_target.outputs.sha }}
+        run: |
+          set -euo pipefail
+          source scripts/lib/release-publish-children.sh
+          jq -n --arg tag "$RELEASE_TAG" --arg sha "$TARGET_SHA" \
+            '{tag: $tag, sourceSha: $sha, state: "dispatch-failed"}' \
+            > "$RUNNER_TEMP/linux-mirror-dispatch.json"
+          verify_release_tag_target
+          CHILD_WORKFLOW_REF="$(resolve_child_workflow_ref "${GITHUB_REF}")"
+          linux_mirror_run_id="$(dispatch_workflow_at_ref "$CHILD_WORKFLOW_REF" "$PARENT_WORKFLOW_SHA" \
+            linux-app-release.yml \
+            -f release_tag="$RELEASE_TAG" -f source_sha="$TARGET_SHA" \
+            -f tooling_sha="$PARENT_WORKFLOW_SHA" \
+            -f release_publish_run_id="$GITHUB_RUN_ID" \
+            -f release_publish_run_attempt="$GITHUB_RUN_ATTEMPT")"
+          jq --arg runId "$linux_mirror_run_id" \
+            '. + {state: "dispatched", childRunId: $runId, mirrorVerified: false}' \
+            "$RUNNER_TEMP/linux-mirror-dispatch.json" > "$RUNNER_TEMP/linux-mirror-dispatch.next.json"
+          mv "$RUNNER_TEMP/linux-mirror-dispatch.next.json" "$RUNNER_TEMP/linux-mirror-dispatch.json"
+          echo "- Legacy Linux bridge: dispatched, not yet verified. Follow the child run; cancellation, queue overflow, timeout, or failed readback requires reconciliation." >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Record failed Linux mirror dispatch
+        if: ${{ failure() }}
+        run: |
+          echo "::warning::Legacy Linux mirror dispatch failed; npm and GitHub publication remain complete. Reconcile the Linux App Release mirror-only route."
+          echo "- Legacy Linux bridge: degraded; inspect dispatch evidence before recovery." >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Retain Linux mirror dispatch evidence
+        if: ${{ always() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: linux-mirror-dispatch-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/linux-mirror-dispatch.json
+          if-no-files-found: warn
 
   publish_windows:
     name: Dispatch Windows assets after publication

--- a/apps/linux/README.md
+++ b/apps/linux/README.md
@@ -12,6 +12,9 @@ Debian 12 meet that ABI floor. RHEL 9 and Rocky Linux 9 ship glibc 2.34, so
 they cannot run the published AppImage. Extraction does not bypass this
 requirement.
 
+See [Desktop compatibility](https://docs.openclaw.ai/platforms/linux#desktop-compatibility)
+for package updates, desktop limitations, and native-app distinctions.
+
 ## Linux prerequisites
 
 Debian and Ubuntu development packages:
@@ -94,6 +97,14 @@ to loopback when possible. See the
 [remote access guide](https://docs.openclaw.ai/gateway/remote) for Gateway
 authentication and network requirements.
 
+Use **Connection Settings** in the native tray menu to edit a remote connection.
+Opening settings reads only the saved address and transport settings; it does not
+resolve credentials, and token and password fields stay empty. **Retry** reconnects
+to the saved remote Gateway with freshly resolved credentials without rewriting
+configuration or installing or starting a local service. Opening the remote
+dashboard does not prove Gateway availability or successful authentication; check
+the dashboard for HTTP errors, authentication prompts, and Gateway readiness.
+
 After connecting, Model Setup discovers AI access available to the selected
 Gateway and shows it as a choice. Discovery never imports or copies an account,
 and the companion never selects, tests, installs, or saves a provider until you
@@ -132,11 +143,25 @@ the additional sign-in options.
 
 ## Updates
 
-The companion checks the latest GitHub release shortly after launch and from **Check for Updates** in the tray menu. AppImage installs download and verify the signed update in place, then wait for **Restart to update**. Package-managed installs such as `.deb` stay owned by the system package manager and link to the release download page instead of replacing installed files. The macOS and Windows test builds use a separate opt-in desktop-test update channel; macOS self-updates like the AppImage build, while Windows downloads the update first and runs its installer only after **Restart to update**.
+The Linux updater targets
+`https://github.com/openclaw/openclaw/releases/download/linux-stable/latest.json`
+shortly after launch and from **Check for Updates** in the tray menu. This
+channel follows the latest published Linux companion independently of core
+releases. AppImage installs download and verify the signed update in place,
+then wait for **Restart to update**.
+
+Package-managed installs such as `.deb` stay owned by the system package manager
+and link to the [Linux download page](https://github.com/openclaw/openclaw/releases/tag/linux-stable)
+instead of replacing installed files. The macOS and Windows test builds use a
+separate opt-in desktop-test update channel; macOS self-updates like the
+AppImage build, while Windows downloads the update first and runs its installer
+only after **Restart to update**.
 
 ## Quick Chat widgets
 
 Quick Chat advertises the Gateway `inline-widgets` capability and renders hosted `show_widget` results in isolated child WebViews. The parent Quick Chat WebView is the only one granted Tauri commands; widget WebViews match no capability and therefore have no IPC access. Quick Chat accepts only assistant-message widget previews under the capability-scoped `/__openclaw__/canvas/documents/` route, blocks navigation away from the original document, uses nonpersistent WebViews, and keeps stable widget instances while switching among multiple previews. Connections that require a custom Gateway TLS leaf pin remain text-only because the platform WebView cannot bind that pin. Like the other native clients, Quick Chat does not expose the Control UI `sendPrompt` bridge.
+
+Retrying an unchanged Quick Chat draft after a connection error reuses its original idempotency key while the Gateway and agent remain unchanged. If the Gateway confirms the turn already completed, Quick Chat attempts to recover the matching reply from bounded session history instead of resending it. Unavailable or incomplete history produces an error; further retries of that unchanged draft on the same configured Gateway only retry recovery. Widget previews can refresh access after reconnecting to the same configured Gateway, but switching Gateways prevents old previews from using the new connection's access, even after switching back to the original URL.
 
 ## Installer resource
 
@@ -206,6 +231,11 @@ validation does not publish a release.
 
 ## Releases
 
+Linux bundle publication is independent of core releases. A stable core tag
+does not by itself guarantee Linux release assets. The
+[latest published Linux companion](https://github.com/openclaw/openclaw/releases/tag/linux-stable)
+links to the bundles on their versioned release.
+
 Manually dispatch `Linux App Release Request` from `main`. Provide the existing
 stable release tag in `tag`; prerelease tags are rejected because their semver
 suffix breaks Debian upgrade ordering. Enable the optional
@@ -217,3 +247,20 @@ the validated release tag SHA and attaches the bundles to that tag's GitHub
 release with a `SHA256SUMS.linux-app.txt` checksum file. The tag commit must be
 reachable from `main` or its matching `release/YYYY.M.PATCH` branch; numeric
 correction tags use the base version's release branch.
+
+Publication verifies signed, publicly available assets and preserves the exact
+`OpenClaw-<version>-linux.json` manifest bytes, including source, tooling, and
+channel SHAs and asset identities. The `linux-stable` control release advances
+the canonical `latest.json` without moving versioned bundles or relabeling old
+binaries as a new core release.
+
+Older installed companions use `/releases/latest/download/latest.json`.
+Maintain an exact-byte compatibility mirror on the actual latest core release
+until explicit retirement. After core GitHub finalization, core makes a bounded
+detached mirror-only dispatch to the existing Linux release workflow; dispatch
+acceptance is not mirror success. Dispatch or mirror failures are visibly
+degraded and need reconciliation, but do not block core publication. Restoring
+metadata does not migrate an installed binary to the new endpoint; that requires a separately
+approved signed upgrade. See the
+[Linux publication policy](https://docs.openclaw.ai/reference/RELEASING#linux-companion-publication)
+for rollout and verification requirements.

--- a/apps/linux/src-tauri/src/gateway.rs
+++ b/apps/linux/src-tauri/src/gateway.rs
@@ -19,6 +19,28 @@ pub struct GatewaySnapshot {
 }
 
 impl GatewaySnapshot {
+    pub(crate) fn remote_opening() -> Self {
+        Self {
+            phase: "remoteOpening",
+            installed: false,
+            running: false,
+            reachable: false,
+            status: "Opening remote dashboard".to_string(),
+            detail: Some(
+                "Gateway authentication and readiness are shown in the dashboard.".to_string(),
+            ),
+        }
+    }
+
+    pub(crate) fn remote_error(detail: impl Into<String>) -> Self {
+        Self {
+            phase: "remoteError",
+            status: "Remote connection unavailable".to_string(),
+            detail: Some(detail.into()),
+            ..Self::remote_opening()
+        }
+    }
+
     pub fn unconfigured() -> Self {
         Self {
             phase: "unconfigured",
@@ -86,10 +108,17 @@ struct DaemonStatus {
 }
 
 #[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
 struct ServiceStatus {
-    loaded: bool,
+    loaded: Option<bool>,
+    load_state: Option<ServiceLoadState>,
     command: Option<serde_json::Value>,
     runtime: Option<ServiceRuntime>,
+}
+
+#[derive(Deserialize)]
+struct ServiceLoadState {
+    detail: Option<String>,
 }
 
 #[derive(Deserialize)]
@@ -127,7 +156,27 @@ pub fn status(cli: &OpenClawCli) -> Result<GatewaySnapshot, String> {
     let value = cli
         .json::<DaemonStatus, _, _>(["gateway", "status", "--json"])
         .map_err(|error| error.to_string())?;
-    let installed = value.service.command.is_some() || value.service.loaded;
+    let reachable = value.rpc.as_ref().is_some_and(|rpc| rpc.ok);
+    // A failed service inspection is not evidence that installation is missing.
+    // A healthy RPC can still attach without inspecting or changing the service.
+    if !reachable && value.service.loaded.is_none() {
+        let service_detail = value
+            .service
+            .load_state
+            .as_ref()
+            .and_then(|state| state.detail.as_deref())
+            .unwrap_or("The CLI could not determine the Gateway service state.");
+        let rpc_detail = value
+            .rpc
+            .as_ref()
+            .and_then(|rpc| rpc.error.as_deref())
+            .unwrap_or("The Gateway RPC probe did not report a healthy connection.");
+        return Err(format!(
+            "{service_detail}\n{rpc_detail}\nRun `openclaw gateway status` in a terminal \
+             to inspect service access and Gateway credentials, then retry."
+        ));
+    }
+    let installed = value.service.command.is_some() || value.service.loaded == Some(true);
     let runtime_status = value
         .service
         .runtime
@@ -135,7 +184,6 @@ pub fn status(cli: &OpenClawCli) -> Result<GatewaySnapshot, String> {
         .and_then(|runtime| runtime.status.as_deref())
         .unwrap_or("stopped");
     let running = runtime_status == "running";
-    let reachable = value.rpc.as_ref().is_some_and(|rpc| rpc.ok);
     let (phase, status) = if reachable {
         ("connected", "Connected")
     } else if !installed {
@@ -283,6 +331,10 @@ fn dashboard_token(dashboard_url: &str) -> Result<Option<String>, String> {
         .map(|(_, value)| value.into_owned())
         .filter(|value| !value.is_empty()))
 }
+
+#[cfg(all(test, unix))]
+#[path = "gateway_status_tests.rs"]
+mod status_tests;
 
 #[cfg(test)]
 mod dashboard_tests {

--- a/apps/linux/src-tauri/src/gateway_operation_queue.rs
+++ b/apps/linux/src-tauri/src/gateway_operation_queue.rs
@@ -1,7 +1,7 @@
 use crate::gateway::{GatewayAction, GatewaySnapshot};
 use crate::installer::InstallChannel;
 use crate::remote_gateway::RemoteGatewayRequest;
-use std::sync::mpsc;
+use std::sync::{mpsc, Arc, Mutex};
 use std::thread;
 use tokio::sync::oneshot;
 
@@ -9,31 +9,42 @@ pub(crate) enum GatewayOperation {
     Connect,
     ConnectExplicitLocal,
     ConnectRemote(RemoteGatewayRequest),
+    RetryRemote,
     Install(InstallChannel),
     Action(GatewayAction),
+    RecoverRemote { child_id: u64 },
 }
 
 struct QueuedGatewayOperation {
     operation: GatewayOperation,
     reply: Option<oneshot::Sender<Result<GatewaySnapshot, String>>>,
+    selection: u64,
 }
 
 pub(crate) struct GatewayOperationQueue {
     sender: mpsc::Sender<QueuedGatewayOperation>,
+    selection: Arc<Mutex<u64>>,
 }
 
 impl GatewayOperationQueue {
     pub(crate) fn new<F, E>(sink: F, show_error: E) -> Self
     where
-        F: Fn(GatewayOperation) -> Result<GatewaySnapshot, String> + Send + Sync + 'static,
+        F: Fn(GatewayOperation, u64) -> Result<GatewaySnapshot, String> + Send + Sync + 'static,
         E: Fn(&str) + Send + Sync + 'static,
     {
         let (sender, receiver) = mpsc::channel::<QueuedGatewayOperation>();
+        let selection = Arc::new(Mutex::new(0));
+        let current = Arc::clone(&selection);
         thread::Builder::new()
             .name("openclaw-gateway-operations".to_string())
             .spawn(move || {
                 for request in receiver {
-                    let result = sink(request.operation);
+                    if matches!(request.operation, GatewayOperation::RecoverRemote { .. })
+                        && *current.lock().expect("selection") != request.selection
+                    {
+                        continue;
+                    }
+                    let result = sink(request.operation, request.selection);
                     if let Some(reply) = request.reply {
                         let _ = reply.send(result);
                     } else if let Err(error) = result {
@@ -42,11 +53,33 @@ impl GatewayOperationQueue {
                 }
             })
             .expect("gateway operation worker should start");
-        Self { sender }
+        Self { sender, selection }
+    }
+
+    pub(crate) fn selection_is_current(&self, expected: u64) -> bool {
+        *self.selection.lock().expect("selection") == expected
+    }
+
+    pub(crate) fn while_current<T>(&self, expected: u64, publish: impl FnOnce() -> T) -> Option<T> {
+        let selection = self.selection.lock().expect("selection");
+        (*selection == expected).then(publish)
+    }
+
+    pub(crate) fn invalidate_recovery(&self) {
+        let mut selection = self.selection.lock().expect("selection");
+        *selection = selection.wrapping_add(1);
+    }
+
+    pub(crate) fn submit_recovery(&self, selection: u64, child_id: u64) {
+        let _ = self.sender.send(QueuedGatewayOperation {
+            operation: GatewayOperation::RecoverRemote { child_id },
+            reply: None,
+            selection,
+        });
     }
 
     pub(crate) fn submit_connect(&self) {
-        self.submit_detached(GatewayOperation::ConnectExplicitLocal);
+        self.submit_detached(GatewayOperation::Connect);
     }
 
     pub(crate) fn submit_action(&self, action: GatewayAction) {
@@ -58,22 +91,32 @@ impl GatewayOperationQueue {
         operation: GatewayOperation,
     ) -> Result<GatewaySnapshot, String> {
         let (reply, receiver) = oneshot::channel();
-        self.sender
-            .send(QueuedGatewayOperation {
-                operation,
-                reply: Some(reply),
-            })
-            .map_err(|_| "Gateway operation queue is unavailable.".to_string())?;
+        self.submit(operation, Some(reply))?;
         receiver
             .await
             .map_err(|_| "Gateway operation worker stopped unexpectedly.".to_string())?
     }
 
     fn submit_detached(&self, operation: GatewayOperation) {
-        let _ = self.sender.send(QueuedGatewayOperation {
-            operation,
-            reply: None,
-        });
+        let _ = self.submit(operation, None);
+    }
+
+    fn submit(
+        &self,
+        operation: GatewayOperation,
+        reply: Option<oneshot::Sender<Result<GatewaySnapshot, String>>>,
+    ) -> Result<(), String> {
+        // Invalidate automatic work at submission, while retaining every
+        // explicit operation in channel order.
+        let mut selection = self.selection.lock().expect("selection");
+        *selection = selection.wrapping_add(1);
+        self.sender
+            .send(QueuedGatewayOperation {
+                operation,
+                reply,
+                selection: *selection,
+            })
+            .map_err(|_| "Gateway operation queue is unavailable.".to_string())
     }
 }
 
@@ -95,9 +138,9 @@ mod tests {
     fn executes_every_rapid_submission_in_order() {
         let (sender, receiver) = mpsc::channel();
         let queue = GatewayOperationQueue::new(
-            move |operation| {
+            move |operation, _| {
                 let observed = match operation {
-                    GatewayOperation::ConnectExplicitLocal => 0,
+                    GatewayOperation::Connect => 0,
                     GatewayOperation::Action(GatewayAction::Stop) => 1,
                     _ => panic!("unexpected operation"),
                 };
@@ -130,14 +173,14 @@ mod tests {
         let worker_contention = Arc::clone(&contention);
         let (observed_sender, observed_receiver) = mpsc::channel();
         let queue = Arc::new(GatewayOperationQueue::new(
-            move |operation| {
+            move |operation, _| {
                 let observed = match operation {
                     GatewayOperation::Action(GatewayAction::Stop) => {
                         worker_contention.wait();
                         thread::sleep(Duration::from_millis(100));
                         ObservedOperation::Stop
                     }
-                    GatewayOperation::ConnectExplicitLocal => ObservedOperation::Connect,
+                    GatewayOperation::Connect => ObservedOperation::Connect,
                     _ => panic!("unexpected operation"),
                 };
                 observed_sender.send(observed).expect("record operation");
@@ -164,6 +207,47 @@ mod tests {
                     .recv_timeout(Duration::from_secs(1))
                     .expect("operation should execute")
             })
+            .collect::<Vec<_>>();
+        assert_eq!(
+            observed,
+            [ObservedOperation::Stop, ObservedOperation::Connect]
+        );
+    }
+
+    #[test]
+    fn selection_submission_invalidates_queued_recovery_without_dropping_explicit_work() {
+        let entered = Arc::new(Barrier::new(2));
+        let release = Arc::new(Barrier::new(2));
+        let worker_entered = Arc::clone(&entered);
+        let worker_release = Arc::clone(&release);
+        let (sender, receiver) = mpsc::channel();
+        let queue = GatewayOperationQueue::new(
+            move |operation, _| {
+                let observed = match operation {
+                    GatewayOperation::Action(GatewayAction::Stop) => {
+                        worker_entered.wait();
+                        worker_release.wait();
+                        ObservedOperation::Stop
+                    }
+                    GatewayOperation::Connect => ObservedOperation::Connect,
+                    _ => panic!("obsolete recovery executed"),
+                };
+                sender.send(observed).unwrap();
+                Err("fixture".to_string())
+            },
+            |_| {},
+        );
+        queue.submit_action(GatewayAction::Stop);
+        entered.wait();
+        queue.submit_recovery(1, 23);
+        queue.submit_connect();
+        assert!(
+            !queue.selection_is_current(1),
+            "invalidation must precede execution"
+        );
+        release.wait();
+        let observed = (0..2)
+            .map(|_| receiver.recv_timeout(Duration::from_secs(5)).unwrap())
             .collect::<Vec<_>>();
         assert_eq!(
             observed,

--- a/apps/linux/src-tauri/src/gateway_sleep.rs
+++ b/apps/linux/src-tauri/src/gateway_sleep.rs
@@ -32,8 +32,10 @@ struct HeldSuspension {
 struct CycleState {
     suspension: Option<HeldSuspension>,
     generation: u64,
+    abandoned: bool,
 }
 
+#[derive(Clone)]
 pub(crate) struct GatewaySleepCycleController {
     request_id: String,
     current_route: Arc<dyn Fn() -> Option<GatewaySleepRoute> + Send + Sync>,
@@ -42,7 +44,7 @@ pub(crate) struct GatewaySleepCycleController {
     refresh: Arc<dyn Fn() -> RefreshFuture + Send + Sync>,
     retry_delay: Arc<dyn Fn(Duration) -> DelayFuture + Send + Sync>,
     log: Arc<dyn Fn(String) + Send + Sync>,
-    state: Mutex<CycleState>,
+    state: Arc<Mutex<CycleState>>,
 }
 
 impl GatewaySleepCycleController {
@@ -75,87 +77,129 @@ impl GatewaySleepCycleController {
             refresh: Arc::new(move || Box::pin(refresh())),
             retry_delay: Arc::new(move |delay| Box::pin(retry_delay(delay))),
             log: Arc::new(log),
-            state: Mutex::new(CycleState::default()),
+            state: Arc::new(Mutex::new(CycleState::default())),
         }
     }
 
-    pub(crate) async fn will_sleep(&self) {
+    pub(crate) fn will_sleep(&self) -> (Option<u64>, impl Future<Output = ()> + '_) {
         // The production route closure exposes only locally owned loopback gateways.
-        let Some(route) = (self.current_route)() else {
-            return;
-        };
+        let route = (self.current_route)();
+        // Return this preparation's identity before it can suspend, so its guard
+        // never guesses a generation from state that another cycle may have changed.
         let generation = {
             let mut state = self
                 .state
                 .lock()
                 .expect("gateway sleep state mutex poisoned");
-            state.generation = state.generation.wrapping_add(1);
-            state.generation
+            if state.abandoned || route.is_none() {
+                None
+            } else {
+                state.generation = state.generation.wrapping_add(1);
+                Some(state.generation)
+            }
         };
-        match (self.prepare)(self.request_id.clone(), route.clone()).await {
-            Ok(SleepPrepareOutcome::Ready { suspension_id }) => {
-                if (self.current_route)().as_ref() != Some(&route) {
-                    self.log_route_changed();
+        (generation, async move {
+            let (Some(route), Some(generation)) = (route, generation) else {
+                return;
+            };
+            match (self.prepare)(self.request_id.clone(), route.clone()).await {
+                Ok(SleepPrepareOutcome::Ready { suspension_id }) => {
+                    if (self.current_route)().as_ref() != Some(&route) {
+                        self.log_route_changed();
+                        return;
+                    }
+                    let late = {
+                        let mut state = self
+                            .state
+                            .lock()
+                            .expect("gateway sleep state mutex poisoned");
+                        // Terminal loss is not a wake, even if prepare completed late.
+                        if state.abandoned {
+                            return;
+                        }
+                        if generation == state.generation {
+                            state.suspension = Some(HeldSuspension {
+                                id: suspension_id.clone(),
+                                route: route.clone(),
+                            });
+                            false
+                        } else {
+                            true
+                        }
+                    };
+                    if late {
+                        // Wake or a newer cycle won the race; do not leave the late lease active.
+                        if let Err(error) = (self.resume)(suspension_id, route).await {
+                            (self.log)(format!("gateway sleep preparation failed: {error}"));
+                        }
+                    }
+                }
+                Ok(SleepPrepareOutcome::Busy) => {
+                    (self.log)(
+                        "gateway sleep preparation skipped because the gateway is busy".into(),
+                    );
+                }
+                Err(error) => {
+                    (self.log)(format!("gateway sleep preparation failed: {error}"));
+                }
+            }
+        })
+    }
+
+    pub(crate) fn did_wake(&self) -> impl Future<Output = ()> + Send + 'static {
+        // Bind at the real wake signal, not when a spawned task eventually polls.
+        let observed_generation = self
+            .state
+            .lock()
+            .expect("gateway sleep state mutex poisoned")
+            .generation;
+        let controller = self.clone();
+        async move {
+            // Clear only the observed cycle. A newer sleep owns its own lease.
+            let (suspension, generation) = {
+                let mut state = controller
+                    .state
+                    .lock()
+                    .expect("gateway sleep state mutex poisoned");
+                if state.abandoned || state.generation != observed_generation {
                     return;
                 }
-                let late = {
-                    let mut state = self
-                        .state
-                        .lock()
-                        .expect("gateway sleep state mutex poisoned");
-                    if generation == state.generation {
-                        state.suspension = Some(HeldSuspension {
-                            id: suspension_id.clone(),
-                            route: route.clone(),
-                        });
-                        false
-                    } else {
-                        true
-                    }
-                };
-                if late {
-                    // Wake or a newer cycle won the race; do not leave the late lease active.
-                    if let Err(error) = (self.resume)(suspension_id, route).await {
-                        (self.log)(format!("gateway sleep preparation failed: {error}"));
-                    }
+                let suspension = state.suspension.take();
+                state.generation = state.generation.wrapping_add(1);
+                (suspension, state.generation)
+            };
+            if (controller.current_route)().is_none() {
+                if suspension.is_some() {
+                    controller.log_route_changed();
                 }
+                return;
             }
-            Ok(SleepPrepareOutcome::Busy) => {
-                (self.log)("gateway sleep preparation skipped because the gateway is busy".into());
-            }
-            Err(error) => {
-                (self.log)(format!("gateway sleep preparation failed: {error}"));
+
+            // The pre-sleep transport is normally dead; reconnect before attempting resume.
+            (controller.refresh)().await;
+            if let Some(suspension) = suspension {
+                if (controller.current_route)().as_ref() == Some(&suspension.route) {
+                    controller.resume_with_retries(suspension, generation).await;
+                } else {
+                    controller.log_route_changed();
+                }
             }
         }
     }
 
-    pub(crate) async fn did_wake(&self) {
-        // Clear first so a second wake or failed resume cannot reuse this cycle's lease.
-        let (suspension, generation) = {
-            let mut state = self
-                .state
-                .lock()
-                .expect("gateway sleep state mutex poisoned");
-            let suspension = state.suspension.take();
-            state.generation = state.generation.wrapping_add(1);
-            (suspension, state.generation)
-        };
-        if (self.current_route)().is_none() {
-            if suspension.is_some() {
-                self.log_route_changed();
-            }
+    pub(crate) fn abandon(&self, generation: u64) {
+        // Losing a still-sleeping cycle retires this listener's controller;
+        // a guard already transferred to real wake recovery must not call this.
+        let mut state = self
+            .state
+            .lock()
+            .expect("gateway sleep state mutex poisoned");
+        if state.generation != generation {
             return;
         }
-
-        // The pre-sleep transport is normally dead; reconnect before attempting resume.
-        (self.refresh)().await;
-        if let Some(suspension) = suspension {
-            if (self.current_route)().as_ref() == Some(&suspension.route) {
-                self.resume_with_retries(suspension, generation).await;
-            } else {
-                self.log_route_changed();
-            }
-        }
+        state.abandoned = true;
+        state.suspension = None;
+        state.generation = state.generation.wrapping_add(1);
     }
 
     fn log_route_changed(&self) {
@@ -258,7 +302,7 @@ mod tests {
             |_| {},
         );
 
-        controller.will_sleep().await;
+        controller.will_sleep().1.await;
         controller.did_wake().await;
         controller.did_wake().await;
 
@@ -294,7 +338,7 @@ mod tests {
             move |message| recorded_logs.lock().unwrap().push(message),
         );
 
-        controller.will_sleep().await;
+        controller.will_sleep().1.await;
         controller.did_wake().await;
 
         assert_eq!(resumes.load(Ordering::SeqCst), 0);
@@ -330,7 +374,7 @@ mod tests {
             move |message| recorded_logs.lock().unwrap().push(message),
         );
 
-        controller.will_sleep().await;
+        controller.will_sleep().1.await;
         controller.did_wake().await;
 
         assert_eq!(resumes.load(Ordering::SeqCst), 0);
@@ -370,7 +414,7 @@ mod tests {
             move |message| recorded_logs.lock().unwrap().push(message),
         );
 
-        controller.will_sleep().await;
+        controller.will_sleep().1.await;
         *route.lock().unwrap() = Some(local_route("ws://127.0.0.1:19001", 2));
         controller.did_wake().await;
 
@@ -411,7 +455,7 @@ mod tests {
             move |message| recorded_logs.lock().unwrap().push(message),
         );
 
-        controller.will_sleep().await;
+        controller.will_sleep().1.await;
         *route.lock().unwrap() = None;
         controller.did_wake().await;
         *route.lock().unwrap() = Some(local_route("ws://127.0.0.1:18789", 3));
@@ -423,12 +467,13 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn late_prepare_response_resumes_only_on_its_original_route() {
-        for (replacement, unchanged) in [
-            (Some(local_route("ws://127.0.0.1:18789", 1)), true),
-            (Some(local_route("ws://127.0.0.1:19001", 2)), false),
-            (None, false),
-            (Some(local_route("ws://127.0.0.1:18789", 3)), false),
+    async fn late_prepare_response_resumes_only_after_wake_on_its_original_route() {
+        for (replacement, unchanged, abandoned) in [
+            (Some(local_route("ws://127.0.0.1:18789", 1)), true, false),
+            (Some(local_route("ws://127.0.0.1:19001", 2)), false, false),
+            (None, false, false),
+            (Some(local_route("ws://127.0.0.1:18789", 3)), false, false),
+            (Some(local_route("ws://127.0.0.1:18789", 1)), true, true),
         ] {
             let route = route_state(Some("ws://127.0.0.1:18789"));
             let (release, receiver) = oneshot::channel();
@@ -439,6 +484,8 @@ mod tests {
             let prepare_started_sender = Arc::clone(&started);
             let resumed_ids = Arc::new(Mutex::new(Vec::new()));
             let resumed = Arc::clone(&resumed_ids);
+            let refreshes = Arc::new(AtomicUsize::new(0));
+            let refreshed = Arc::clone(&refreshes);
             let controller = Arc::new(GatewaySleepCycleController::new(
                 "linux-sleep-test-run".into(),
                 current_route(&route),
@@ -462,28 +509,41 @@ mod tests {
                     resumed.lock().unwrap().push(id);
                     async { Ok(()) }
                 },
-                || async {},
+                move || {
+                    refreshed.fetch_add(1, Ordering::SeqCst);
+                    async {}
+                },
                 no_delay,
                 |_| {},
             ));
 
-            let sleeping = {
-                let controller = Arc::clone(&controller);
-                tokio::spawn(async move { controller.will_sleep().await })
-            };
-            prepare_started.await.unwrap();
-            controller.did_wake().await;
+            let (generation, sleeping) = controller.will_sleep();
+            tokio::pin!(sleeping);
+            tokio::select! {
+                started = prepare_started => started.unwrap(),
+                _ = &mut sleeping => panic!("preparation completed before release"),
+            }
+            if abandoned {
+                controller.abandon(generation.unwrap());
+                // A subsequent call must not revive this listener's controller.
+                controller.will_sleep().1.await;
+            } else {
+                controller.did_wake().await;
+            }
             *route.lock().unwrap() = replacement.clone();
             release.send(()).unwrap();
-            sleeping.await.unwrap();
+            sleeping.await;
             controller.did_wake().await;
 
-            let expected = if unchanged {
+            let expected = if unchanged && !abandoned {
                 vec!["late-suspension"]
             } else {
                 vec![]
             };
             assert_eq!(*resumed_ids.lock().unwrap(), expected, "{replacement:?}");
+            if abandoned {
+                assert_eq!(refreshes.load(Ordering::SeqCst), 0);
+            }
         }
     }
 
@@ -528,7 +588,7 @@ mod tests {
                 |_| {},
             );
 
-            controller.will_sleep().await;
+            controller.will_sleep().1.await;
             controller.did_wake().await;
 
             assert_eq!(
@@ -563,7 +623,7 @@ mod tests {
             move |message| recorded_logs.lock().unwrap().push(message),
         );
 
-        controller.will_sleep().await;
+        controller.will_sleep().1.await;
         controller.did_wake().await;
 
         assert_eq!(attempts.load(Ordering::SeqCst), 3);
@@ -596,16 +656,74 @@ mod tests {
             || async {},
             move |_| {
                 let controller = delay_slot.lock().unwrap().as_ref().unwrap().clone();
-                async move { controller.will_sleep().await }
+                async move { controller.will_sleep().1.await }
             },
             |_| {},
         ));
         *controller_slot.lock().unwrap() = Some(Arc::clone(&controller));
 
-        controller.will_sleep().await;
+        controller.will_sleep().1.await;
         controller.did_wake().await;
 
         assert_eq!(attempts.load(Ordering::SeqCst), 1);
+        controller_slot.lock().unwrap().take();
+    }
+
+    #[tokio::test]
+    async fn unpolled_wake_and_stale_abandon_preserve_newer_cycle() {
+        for abandon_newer in [false, true] {
+            let route = route_state(Some("ws://127.0.0.1:18789"));
+            let prepares = Arc::new(AtomicUsize::new(0));
+            let prepared = Arc::clone(&prepares);
+            let resumed_ids = Arc::new(Mutex::new(Vec::new()));
+            let resumed = Arc::clone(&resumed_ids);
+            let refreshes = Arc::new(AtomicUsize::new(0));
+            let refreshed = Arc::clone(&refreshes);
+            let controller = GatewaySleepCycleController::new(
+                "linux-sleep-test-run".into(),
+                current_route(&route),
+                move |_, _| {
+                    let id = prepared.fetch_add(1, Ordering::SeqCst);
+                    async move {
+                        Ok(SleepPrepareOutcome::Ready {
+                            suspension_id: format!("suspension-{id}"),
+                        })
+                    }
+                },
+                move |id, _| {
+                    resumed.lock().unwrap().push(id);
+                    async { Ok(()) }
+                },
+                move || {
+                    refreshed.fetch_add(1, Ordering::SeqCst);
+                    async {}
+                },
+                no_delay,
+                |_| {},
+            );
+            let (old_generation, old_preparation) = controller.will_sleep();
+            old_preparation.await;
+            let old_wake = controller.did_wake();
+            let (new_generation, new_preparation) = controller.will_sleep();
+            new_preparation.await;
+
+            old_wake.await;
+            controller.abandon(old_generation.unwrap());
+            assert!(resumed_ids.lock().unwrap().is_empty());
+            assert_eq!(refreshes.load(Ordering::SeqCst), 0);
+            if abandon_newer {
+                controller.abandon(new_generation.unwrap());
+            }
+            controller.did_wake().await;
+
+            if abandon_newer {
+                assert!(resumed_ids.lock().unwrap().is_empty());
+                assert_eq!(refreshes.load(Ordering::SeqCst), 0);
+            } else {
+                assert_eq!(*resumed_ids.lock().unwrap(), ["suspension-1"]);
+                assert_eq!(refreshes.load(Ordering::SeqCst), 1);
+            }
+        }
     }
 
     #[tokio::test]
@@ -630,7 +748,7 @@ mod tests {
             |_| {},
         );
 
-        controller.will_sleep().await;
+        controller.will_sleep().1.await;
         controller.did_wake().await;
         controller.did_wake().await;
 

--- a/apps/linux/src-tauri/src/gateway_sleep_logind_listener.rs
+++ b/apps/linux/src-tauri/src/gateway_sleep_logind_listener.rs
@@ -8,6 +8,20 @@ use zbus::zvariant::OwnedFd;
 pub(crate) type BeginSleepCycleHook = Arc<dyn Fn() -> bool + Send + Sync>;
 pub(crate) type EndSleepCycleHook = Arc<dyn Fn() + Send + Sync>;
 
+struct SleepCycleGuard {
+    abandon: Option<(Arc<GatewaySleepCycleController>, u64)>,
+    end: EndSleepCycleHook,
+}
+
+impl Drop for SleepCycleGuard {
+    fn drop(&mut self) {
+        if let Some((controller, generation)) = &self.abandon {
+            controller.abandon(*generation);
+        }
+        (self.end)();
+    }
+}
+
 #[zbus::proxy(
     default_service = "org.freedesktop.login1",
     default_path = "/org/freedesktop/login1",
@@ -45,7 +59,7 @@ async fn run_listener_on_connection(
         .await
         .map_err(|error| format!("could not subscribe to PrepareForSleep: {error}"))?;
     let mut inhibitor = Some(acquire_inhibitor(&proxy).await?);
-    let mut cycle_began = false;
+    let mut cycle = None;
 
     while let Some(signal) = signals.next().await {
         let sleeping = signal
@@ -53,23 +67,34 @@ async fn run_listener_on_connection(
             .map_err(|error| format!("invalid PrepareForSleep signal: {error}"))?
             .sleeping;
         if sleeping {
-            cycle_began = begin_sleep_cycle();
-            controller.will_sleep().await;
+            if cycle.is_none() && begin_sleep_cycle() {
+                cycle = Some(SleepCycleGuard {
+                    abandon: None,
+                    end: Arc::clone(&end_sleep_cycle),
+                });
+            }
+            let (generation, preparation) = controller.will_sleep();
+            if let Some(cycle) = cycle.as_mut() {
+                cycle.abandon = generation.map(|generation| (Arc::clone(&controller), generation));
+            }
+            preparation.await;
             // Releasing the delay inhibitor lets logind continue into sleep.
             inhibitor.take();
         } else {
-            let controller = Arc::clone(&controller);
-            let end_sleep_cycle = Arc::clone(&end_sleep_cycle);
-            let began = cycle_began;
-            cycle_began = false;
+            let cycle = cycle.take().map(|mut cycle| {
+                // Real wake transfers recovery authority before the task can poll.
+                // Later listener loss must not abandon this already-observed wake.
+                cycle.abandon = None;
+                cycle
+            });
+            let recovery = controller.did_wake();
             // Spawn wake recovery before touching logind again: a slow or hung
             // Inhibit call must not delay reconnect/resume. Spawning also keeps
             // the signal loop consuming so a new sleep cycle can abort retries.
             tauri::async_runtime::spawn(async move {
-                controller.did_wake().await;
-                if began {
-                    end_sleep_cycle();
-                }
+                // Keep this cycle's depth until recovery ends, including cancellation.
+                let _cycle = cycle;
+                recovery.await;
             });
             // A failed re-acquire only loses the pre-sleep delay window; keep the
             // listener alive so later sleep/wake cycles are still handled.

--- a/apps/linux/src-tauri/src/gateway_status_tests.rs
+++ b/apps/linux/src-tauri/src/gateway_status_tests.rs
@@ -1,0 +1,271 @@
+use super::ensure_ready;
+use crate::cli::OpenClawCli;
+use serde_json::{json, Value};
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::PathBuf;
+use std::process::Command;
+
+const CHILD: &str = "OPENCLAW_STATUS_CONTRACT_CHILD";
+const TEST: &str = "gateway::status_tests::cli_service_status_lifecycle_contract";
+const BROWSER_URL: &str = "http://127.0.0.1:18789/#bootstrapToken=fixture-status-grant";
+const INSPECTION_ERROR: &str = "systemctl is-enabled timed out";
+const RPC_ERROR: &str = "Gateway authentication failed: fixture token rejected";
+const CLI: &str = r#"#!/bin/sh
+root=$(dirname "$0")
+printf '%s\n' "$*" >> "$root/calls"
+case "$*" in
+  --version) printf '0.0.0-test\n' ;;
+  'gateway status --json')
+    if test -f "$root/started"; then
+      cat "$root/healthy.json"
+    elif test -f "$root/installed"; then
+      cat "$root/stopped.json"
+    else
+      cat "$root/status.json"
+    fi ;;
+  'gateway install --json')
+    touch "$root/installed"
+    printf '{"ok":true}\n' ;;
+  'gateway start --json')
+    touch "$root/started"
+    printf '{"ok":true}\n' ;;
+  'dashboard --json --no-open') cat "$root/dashboard.json" ;;
+  *) printf 'Unexpected fixture CLI invocation\n' >&2; exit 1 ;;
+esac
+"#;
+
+struct TestDirectory(PathBuf);
+
+impl Drop for TestDirectory {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.0);
+    }
+}
+
+enum Expected {
+    Ready { install: bool, start: bool },
+    Unknown { inspection: bool, auth: bool },
+    Invalid,
+}
+
+fn status(loaded: Value, running: bool, reachable: bool) -> Value {
+    json!({
+        "service": {
+            "loaded": loaded,
+            "command": null,
+            "runtime": {"status": if running { "running" } else { "stopped" }},
+        },
+        "rpc": {"ok": reachable}
+    })
+}
+
+#[test]
+fn cli_service_status_lifecycle_contract() {
+    // A fresh process owns CLI discovery and HOME; parallel Rust tests never
+    // observe a temporary override or share this test's service-call recorder.
+    if let Some(root) = std::env::var_os(CHILD) {
+        let cli = OpenClawCli::discover().expect("discover isolated fixture CLI");
+        let result = match ensure_ready(&cli) {
+            Ok(ready) => json!({
+                "ok": true,
+                "reachable": ready.snapshot.reachable,
+                "phase": ready.snapshot.phase,
+                "dashboardUrl": ready.dashboard_url,
+            }),
+            Err(error) => json!({"ok": false, "error": error}),
+        };
+        fs::write(
+            PathBuf::from(root).join("result.json"),
+            serde_json::to_vec(&result).unwrap(),
+        )
+        .expect("record ensure_ready result");
+        return;
+    }
+
+    let mut unknown = status(Value::Null, false, false);
+    unknown["service"]["loadState"] = json!({"status": "unknown", "detail": INSPECTION_ERROR});
+    unknown["service"]["runtime"]["status"] = json!("unknown");
+    unknown["rpc"]["error"] = json!(RPC_ERROR);
+    let mut unknown_healthy = unknown.clone();
+    unknown_healthy["rpc"] = json!({"ok": true});
+    let mut unknown_with_command = unknown.clone();
+    unknown_with_command["service"]["command"] =
+        json!({"programArguments": ["openclaw", "gateway"]});
+    let mut missing_loaded = status(Value::Null, false, false);
+    missing_loaded["service"]
+        .as_object_mut()
+        .unwrap()
+        .remove("loaded");
+
+    let cases = [
+        (
+            "unknown-healthy",
+            unknown_healthy.to_string(),
+            Expected::Ready {
+                install: false,
+                start: false,
+            },
+        ),
+        (
+            "unknown-unreachable-no-command",
+            unknown.to_string(),
+            Expected::Unknown {
+                inspection: true,
+                auth: true,
+            },
+        ),
+        (
+            "unknown-unreachable-with-command",
+            unknown_with_command.to_string(),
+            Expected::Unknown {
+                inspection: true,
+                auth: true,
+            },
+        ),
+        (
+            "known-absent",
+            status(json!(false), false, false).to_string(),
+            Expected::Ready {
+                install: true,
+                start: true,
+            },
+        ),
+        (
+            "loaded-stopped",
+            status(json!(true), false, false).to_string(),
+            Expected::Ready {
+                install: false,
+                start: true,
+            },
+        ),
+        (
+            "healthy-unmanaged",
+            status(json!(false), true, true).to_string(),
+            Expected::Ready {
+                install: false,
+                start: false,
+            },
+        ),
+        (
+            "healthy-managed",
+            status(json!(true), true, true).to_string(),
+            Expected::Ready {
+                install: false,
+                start: false,
+            },
+        ),
+        (
+            "missing-loaded",
+            missing_loaded.to_string(),
+            Expected::Unknown {
+                inspection: false,
+                auth: false,
+            },
+        ),
+        (
+            "malformed-loaded",
+            status(json!("false"), false, false).to_string(),
+            Expected::Invalid,
+        ),
+        (
+            "missing-service",
+            json!({"rpc": {"ok": false}}).to_string(),
+            Expected::Invalid,
+        ),
+        ("malformed-json", "{invalid".to_string(), Expected::Invalid),
+    ];
+    let mut failures = Vec::new();
+    for (name, initial_status, expected) in cases {
+        let directory = TestDirectory(
+            std::env::temp_dir().join(format!("openclaw-status-contract-{}", uuid::Uuid::new_v4())),
+        );
+        let root = &directory.0;
+        fs::create_dir(root).unwrap();
+        fs::set_permissions(root, fs::Permissions::from_mode(0o700)).unwrap();
+        let executable = root.join("openclaw");
+        fs::write(&executable, CLI).unwrap();
+        fs::set_permissions(&executable, fs::Permissions::from_mode(0o700)).unwrap();
+        fs::write(root.join("status.json"), initial_status).unwrap();
+        fs::write(
+            root.join("healthy.json"),
+            status(json!(true), true, true).to_string(),
+        )
+        .unwrap();
+        fs::write(
+            root.join("stopped.json"),
+            status(json!(true), false, false).to_string(),
+        )
+        .unwrap();
+        fs::write(
+            root.join("dashboard.json"),
+            json!({
+                "ok": true,
+                "url": "http://127.0.0.1:18789/#token=fixture-status-token",
+                "browserUrl": BROWSER_URL,
+                "wsUrl": "ws://127.0.0.1:18789",
+            })
+            .to_string(),
+        )
+        .unwrap();
+        let output = Command::new(std::env::current_exe().unwrap())
+            .args(["--exact", TEST, "--nocapture"])
+            .env_clear()
+            .env(CHILD, root)
+            .env("HOME", root)
+            .env("PATH", "/usr/bin:/bin")
+            .env("OPENCLAW_DESKTOP_CLI", &executable)
+            .output()
+            .expect("run isolated ensure_ready contract");
+        assert!(
+            output.status.success(),
+            "{name}: fixture child failed: {}{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let result: Value =
+            serde_json::from_slice(&fs::read(root.join("result.json")).unwrap()).unwrap();
+        let calls = fs::read_to_string(root.join("calls")).unwrap();
+        let lifecycle: Vec<_> = calls
+            .lines()
+            .filter(|call| *call != "--version" && *call != "gateway status --json")
+            .collect();
+        let mut expected_calls = Vec::new();
+        let valid = match expected {
+            Expected::Ready { install, start } => {
+                if install {
+                    expected_calls.push("gateway install --json");
+                }
+                if start {
+                    expected_calls.push("gateway start --json");
+                }
+                expected_calls.push("dashboard --json --no-open");
+                result["ok"] == true
+                    && result["reachable"] == true
+                    && result["phase"] == "connected"
+                    && result["dashboardUrl"] == BROWSER_URL
+            }
+            Expected::Unknown { inspection, auth } => {
+                let error = result["error"].as_str().unwrap_or("");
+                result["ok"] == false
+                    && error.contains("openclaw gateway status")
+                    && !error.contains("invalid JSON")
+                    && (!inspection || error.contains(INSPECTION_ERROR))
+                    && (!auth || error.contains(RPC_ERROR))
+            }
+            Expected::Invalid => result["ok"] == false,
+        };
+        let passed = valid && lifecycle == expected_calls;
+        println!(
+            "{} {name}: result={result}; lifecycle={lifecycle:?}",
+            if passed { "PASS" } else { "FAIL" }
+        );
+        if !passed {
+            failures.push(name);
+        }
+    }
+    assert!(
+        failures.is_empty(),
+        "CLI status contract failures: {failures:?}"
+    );
+}

--- a/apps/linux/src-tauri/src/gateway_ws.rs
+++ b/apps/linux/src-tauri/src/gateway_ws.rs
@@ -222,6 +222,7 @@ pub(crate) struct AgentsListResult {
 
 #[derive(Clone)]
 struct CachedAgents {
+    generation: GatewayGeneration,
     fetched_at: Instant,
     result: AgentsListResult,
 }
@@ -260,6 +261,26 @@ pub(crate) struct ChatSendResult {
     #[serde(flatten)]
     pub(crate) target: ChatRoutingTarget,
     pub(crate) run_id: String,
+    pub(crate) status: String,
+    pub(crate) gateway_generation: GatewayGeneration,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) recovered_messages: Option<Vec<Value>>,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(transparent)]
+pub(crate) struct GatewayGeneration(u64);
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct ChatHistoryPage {
+    pub(crate) session_key: String,
+    pub(crate) session_id: String,
+    pub(crate) messages: Vec<Value>,
+    pub(crate) has_more: Option<bool>,
+    pub(crate) offset: Option<u64>,
+    pub(crate) next_offset: Option<u64>,
+    pub(crate) total_messages: Option<u64>,
 }
 
 #[derive(Deserialize)]
@@ -296,9 +317,19 @@ struct SuspendResumeResponse {
 
 enum GatewayRequest {
     AgentsList,
-    ChatSend(ChatSendParams),
+    ChatSend {
+        params: ChatSendParams,
+        generation: GatewayGeneration,
+    },
     RefreshCanvasSurface {
         observed_url: Option<String>,
+        generation: GatewayGeneration,
+    },
+    ChatHistory {
+        target: ChatRoutingTarget,
+        generation: GatewayGeneration,
+        offset: Option<u64>,
+        deadline: Instant,
     },
     #[cfg(target_os = "linux")]
     SuspendPrepare {
@@ -316,6 +347,7 @@ enum GatewayResponse {
     AgentsList(AgentsListResult),
     ChatSend(ChatSendAck),
     CanvasSurface(Option<String>),
+    ChatHistory(ChatHistoryPage),
     #[cfg(target_os = "linux")]
     SuspendPrepare(SuspendPrepareResponse),
     #[cfg(target_os = "linux")]
@@ -429,9 +461,11 @@ impl RequestFailure {
     }
 }
 
-#[derive(Clone, Default)]
-struct CanvasSurfaceState {
+#[derive(Clone, Default, Serialize)]
+pub(crate) struct CanvasSurfaceState {
+    #[serde(rename = "gatewayGeneration")]
     generation: u64,
+    #[serde(rename = "canvasSurfaceUrl")]
     url: Option<String>,
 }
 
@@ -463,6 +497,49 @@ impl GatewayClient {
         }
     }
 
+    pub(crate) fn generation(&self) -> GatewayGeneration {
+        GatewayGeneration(self.inner.config_generation.load(Ordering::SeqCst))
+    }
+
+    pub(crate) fn with_generation<T>(
+        &self,
+        generation: GatewayGeneration,
+        action: impl FnOnce() -> Result<T, String>,
+    ) -> Result<T, String> {
+        let _config = self
+            .inner
+            .config
+            .lock()
+            .map_err(|_| "Gateway configuration is unavailable.".to_string())?;
+        if self.generation() != generation {
+            return Err("Gateway changed during the Quick Chat request.".to_string());
+        }
+        action()
+    }
+
+    // Call this on the native UI thread, never around work that waits for that thread.
+    pub(crate) fn with_canvas_surface<T>(
+        &self,
+        generation: GatewayGeneration,
+        surface_url: &str,
+        action: impl FnOnce() -> Result<T, String>,
+    ) -> Result<T, String> {
+        self.with_generation(generation, || {
+            let surface = self
+                .inner
+                .canvas_surface
+                .lock()
+                .map_err(|_| "Gateway Canvas surface is unavailable.".to_string())?;
+            if !self.is_connected()
+                || surface.generation != generation.0
+                || surface.url.as_deref() != Some(surface_url)
+            {
+                return Err("Gateway Canvas owner or capability changed.".to_string());
+            }
+            action()
+        })
+    }
+
     pub fn configure(&self, app: &AppHandle, config: GatewayWsConfig) {
         self.set_configuration(app, Some(config));
     }
@@ -472,15 +549,10 @@ impl GatewayClient {
     }
 
     fn set_configuration(&self, app: &AppHandle, config: Option<GatewayWsConfig>) {
-        let generation = self.replace_configuration(config);
-        *self
-            .inner
-            .agents_cache
-            .lock()
-            .expect("gateway agents cache mutex poisoned") = None;
-        self.set_canvas_surface_url(generation, None);
+        self.replace_configuration(config);
         self.inner.reconnect_paused.store(false, Ordering::SeqCst);
         self.set_connection_state(app, GatewayConnectionState::Down, None);
+        self.emit_connection_state(app);
         self.resume_reconnect();
     }
 
@@ -492,7 +564,24 @@ impl GatewayClient {
             .lock()
             .expect("gateway config mutex poisoned");
         *current = config;
-        self.inner.config_generation.fetch_add(1, Ordering::SeqCst) + 1
+        let generation = self.inner.config_generation.fetch_add(1, Ordering::SeqCst) + 1;
+        *self
+            .inner
+            .agents_cache
+            .lock()
+            .expect("gateway agents cache mutex poisoned") = None;
+        *self
+            .inner
+            .canvas_surface
+            .lock()
+            .expect("gateway canvas surface mutex poisoned") = CanvasSurfaceState {
+            generation,
+            url: None,
+        };
+        self.inner
+            .connection_state
+            .store(GatewayConnectionState::Down as u64, Ordering::SeqCst);
+        generation
     }
 
     pub fn activate(&self, app: AppHandle) {
@@ -512,26 +601,13 @@ impl GatewayClient {
     }
 
     pub fn emit_current_state(&self, webview: &Webview) -> Result<(), String> {
-        let notice = self
-            .inner
-            .connection_notice
-            .lock()
-            .map_err(|_| "Gateway connection notice is unavailable.".to_string())?
-            .clone();
         webview
-            .emit(
-                GATEWAY_STATE_EVENT,
-                GatewayStateEvent::new(
-                    self.connection_state(),
-                    notice,
-                    self.canvas_surface_url(),
-                    self.user_accent(),
-                ),
-            )
+            .emit(GATEWAY_STATE_EVENT, self.state_event())
             .map_err(|error| format!("Could not report Gateway connectivity: {error}"))
     }
 
     pub async fn agents_list(&self) -> Result<AgentsListResult, String> {
+        let generation = self.generation();
         if !self.is_connected() {
             return Err("Gateway unreachable — retrying".to_string());
         }
@@ -541,17 +617,20 @@ impl GatewayClient {
                 .lock()
                 .map_err(|_| "Gateway agent cache is unavailable.".to_string())?
                 .as_ref()
-                .filter(|cached| cached.fetched_at.elapsed() < AGENTS_CACHE_TTL)
+                .filter(|cached| {
+                    cached.generation == generation
+                        && cached.fetched_at.elapsed() < AGENTS_CACHE_TTL
+                })
                 .map(|cached| cached.result.clone())
         };
         if let Some(result) = cached {
-            return Ok(result);
+            return self.with_generation(generation, || Ok(result));
         }
         let response = self.request(GatewayRequest::AgentsList).await?;
         let GatewayResponse::AgentsList(result) = response else {
             return Err("Gateway returned the wrong response for agents.list.".to_string());
         };
-        self.cache_agents(result.clone());
+        self.cache_agents(generation, result.clone())?;
         Ok(result)
     }
 
@@ -562,37 +641,80 @@ impl GatewayClient {
         scope: &str,
         main_key: &str,
         idempotency_key: &str,
+        generation: GatewayGeneration,
     ) -> Result<ChatSendResult, String> {
+        self.with_generation(generation, || Ok(()))?;
         let target = routing_target(scope, selected_agent_id, main_key);
         let response = self
-            .request(GatewayRequest::ChatSend(ChatSendParams {
-                session_key: target.session_key.clone(),
-                agent_id: target.agent_id.clone(),
-                message,
-                idempotency_key: idempotency_key.to_string(),
-            }))
+            .request(GatewayRequest::ChatSend {
+                params: ChatSendParams {
+                    session_key: target.session_key.clone(),
+                    agent_id: target.agent_id.clone(),
+                    message,
+                    idempotency_key: idempotency_key.to_string(),
+                },
+                generation,
+            })
             .await?;
         let GatewayResponse::ChatSend(ack) = response else {
             return Err("Gateway returned the wrong response for chat.send.".to_string());
         };
         classify_chat_ack(&ack)?;
+        if ack.run_id != idempotency_key {
+            return Err("Gateway acknowledged a different Quick Chat run.".to_string());
+        }
+        self.with_generation(generation, || Ok(()))?;
         Ok(ChatSendResult {
             target,
             run_id: ack.run_id,
+            status: ack.status,
+            gateway_generation: generation,
+            recovered_messages: None,
         })
     }
 
-    pub async fn refresh_canvas_surface(&self) -> Result<Option<String>, String> {
+    pub(crate) async fn chat_history(
+        &self,
+        target: &ChatRoutingTarget,
+        generation: GatewayGeneration,
+        offset: Option<u64>,
+        deadline: Instant,
+    ) -> Result<ChatHistoryPage, String> {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        let response = tokio::time::timeout(
+            remaining,
+            self.request_with_budget(
+                GatewayRequest::ChatHistory {
+                    target: target.clone(),
+                    generation,
+                    offset,
+                    deadline,
+                },
+                Some(remaining),
+            ),
+        )
+        .await
+        .map_err(|_| "Reply recovery timed out waiting for Gateway history.".to_string())??;
+        self.with_generation(generation, || Ok(()))?;
+        let GatewayResponse::ChatHistory(page) = response else {
+            return Err("Gateway returned the wrong response for chat.history.".to_string());
+        };
+        Ok(page)
+    }
+
+    pub(crate) async fn refresh_canvas_surface(
+        &self,
+        generation: GatewayGeneration,
+        observed_url: String,
+    ) -> Result<CanvasSurfaceState, String> {
         let observed = self.canvas_surface_state();
-        if observed.url.is_none() {
-            return Ok(None);
-        }
-        if self.inner.config_generation.load(Ordering::SeqCst) != observed.generation {
+        if observed.generation != generation.0 || observed.url.as_deref() != Some(&observed_url) {
             return Err("Gateway Canvas surface generation changed before refresh.".to_string());
         }
         let response = self
             .request(GatewayRequest::RefreshCanvasSurface {
                 observed_url: observed.url.clone(),
+                generation,
             })
             .await?;
         let GatewayResponse::CanvasSurface(refreshed) = response else {
@@ -603,19 +725,18 @@ impl GatewayClient {
         let Some(refreshed) = refreshed else {
             return Err("Gateway did not return a refreshed Canvas surface.".to_string());
         };
-        let mut current = self
-            .inner
-            .canvas_surface
-            .lock()
-            .map_err(|_| "Gateway Canvas surface state is unavailable.".to_string())?;
-        if self.inner.config_generation.load(Ordering::SeqCst) != observed.generation
-            || current.generation != observed.generation
-            || current.url != observed.url
-        {
-            return Err("Gateway Canvas surface changed during refresh.".to_string());
-        }
-        current.url = Some(refreshed.clone());
-        Ok(Some(refreshed))
+        self.with_generation(generation, || {
+            let mut current = self
+                .inner
+                .canvas_surface
+                .lock()
+                .map_err(|_| "Gateway Canvas surface state is unavailable.".to_string())?;
+            if current.generation != observed.generation || current.url != observed.url {
+                return Err("Gateway Canvas surface changed during refresh.".to_string());
+            }
+            current.url = Some(refreshed);
+            Ok(current.clone())
+        })
     }
 
     #[cfg(target_os = "linux")]
@@ -900,7 +1021,7 @@ impl GatewayClient {
         .map_err(RequestFailure::transport)?;
         let config_changed = AtomicBool::new(false);
         let dispatch = |frame: &Value| {
-            dispatch_chat_event(app, frame);
+            dispatch_chat_event(app, frame, GatewayGeneration(generation));
             if frame.get("type").and_then(Value::as_str) == Some("event")
                 && frame.get("event").and_then(Value::as_str) == Some("config.changed")
             {
@@ -913,7 +1034,6 @@ impl GatewayClient {
             params,
             REQUEST_TIMEOUT,
             &dispatch,
-            #[cfg(target_os = "linux")]
             None,
         )
         .await
@@ -942,9 +1062,15 @@ impl GatewayClient {
         if self.inner.config_generation.load(Ordering::SeqCst) != generation {
             return Ok(());
         }
-        self.cache_agents(agents);
+        self.cache_agents(GatewayGeneration(generation), agents)
+            .map_err(|message| RequestFailure::method_with_details(message, None))?;
         self.set_user_accent(generation, accent);
-        self.set_connection_state(app, GatewayConnectionState::Up, None);
+        self.set_connection_state_for_generation(
+            app,
+            GatewayConnectionState::Up,
+            None,
+            GatewayGeneration(generation),
+        );
         let mut last_gateway_activity = Instant::now();
 
         loop {
@@ -962,7 +1088,7 @@ impl GatewayClient {
                     return Ok(());
                 }
                 if self.set_user_accent(generation, accent) {
-                    self.emit_connection_state(app, GatewayConnectionState::Up, None);
+                    self.emit_connection_state(app);
                 }
                 last_gateway_activity = Instant::now();
             }
@@ -1070,51 +1196,75 @@ impl GatewayClient {
             .map_err(RequestFailure::transport)
     }
 
-    fn cache_agents(&self, result: AgentsListResult) {
-        *self
-            .inner
-            .agents_cache
-            .lock()
-            .expect("gateway agents cache mutex poisoned") = Some(CachedAgents {
-            fetched_at: Instant::now(),
-            result,
-        });
+    fn cache_agents(
+        &self,
+        generation: GatewayGeneration,
+        result: AgentsListResult,
+    ) -> Result<(), String> {
+        self.with_generation(generation, || {
+            *self
+                .inner
+                .agents_cache
+                .lock()
+                .map_err(|_| "Gateway agent cache is unavailable.".to_string())? =
+                Some(CachedAgents {
+                    generation,
+                    fetched_at: Instant::now(),
+                    result,
+                });
+            Ok(())
+        })
     }
 
     fn set_canvas_surface_url(&self, generation: u64, url: Option<String>) {
-        let mut surface = self
-            .inner
-            .canvas_surface
-            .lock()
-            .expect("gateway canvas surface mutex poisoned");
-        if self.inner.config_generation.load(Ordering::SeqCst) == generation {
+        let _ = self.with_generation(GatewayGeneration(generation), || {
+            let mut surface = self
+                .inner
+                .canvas_surface
+                .lock()
+                .map_err(|_| "Gateway Canvas surface is unavailable.".to_string())?;
             *surface = CanvasSurfaceState { generation, url };
-        }
+            Ok(())
+        });
     }
 
     fn canvas_surface_state(&self) -> CanvasSurfaceState {
-        self.inner
+        let _config = self
+            .inner
+            .config
+            .lock()
+            .expect("gateway config mutex poisoned");
+        let surface = self
+            .inner
             .canvas_surface
             .lock()
             .expect("gateway canvas surface mutex poisoned")
-            .clone()
-    }
-
-    fn canvas_surface_url(&self) -> Option<String> {
-        self.canvas_surface_state().url
+            .clone();
+        let generation = self.inner.config_generation.load(Ordering::SeqCst);
+        if surface.generation == generation {
+            surface
+        } else {
+            CanvasSurfaceState {
+                generation,
+                url: None,
+            }
+        }
     }
 
     fn set_user_accent(&self, generation: u64, accent: Option<String>) -> bool {
-        let mut current = self
-            .inner
-            .user_accent
-            .lock()
-            .expect("gateway user accent mutex poisoned");
-        if self.inner.config_generation.load(Ordering::SeqCst) != generation || *current == accent {
-            return false;
-        }
-        *current = accent;
-        true
+        self.with_generation(GatewayGeneration(generation), || {
+            let mut current = self
+                .inner
+                .user_accent
+                .lock()
+                .expect("gateway user accent mutex poisoned");
+            if *current == accent {
+                return Ok(false);
+            }
+            *current = accent;
+            Ok(true)
+        })
+        .unwrap_or(false)
     }
 
     fn user_accent(&self) -> Option<String> {
@@ -1139,50 +1289,104 @@ impl GatewayClient {
         state: GatewayConnectionState,
         notice: Option<String>,
     ) {
-        if state != GatewayConnectionState::Up {
-            *self
-                .inner
-                .agents_cache
-                .lock()
-                .expect("gateway agents cache mutex poisoned") = None;
-            self.set_canvas_surface_url(self.inner.config_generation.load(Ordering::SeqCst), None);
-            self.set_user_accent(self.inner.config_generation.load(Ordering::SeqCst), None);
-        }
-        let notice_changed = {
-            let mut current = self
-                .inner
-                .connection_notice
-                .lock()
-                .expect("gateway connection notice mutex poisoned");
-            if *current == notice {
-                false
-            } else {
-                *current = notice.clone();
-                true
-            }
-        };
-        let state_changed = self
-            .inner
-            .connection_state
-            .swap(state as u64, Ordering::SeqCst)
-            != state as u64;
-        if !state_changed && !notice_changed {
-            return;
-        }
-        self.emit_connection_state(app, state, notice);
+        self.set_connection_state_for_generation(app, state, notice, self.generation());
     }
 
-    fn emit_connection_state(
+    fn set_connection_state_for_generation(
         &self,
         app: &AppHandle,
         state: GatewayConnectionState,
         notice: Option<String>,
+        generation: GatewayGeneration,
     ) {
-        let _ = app.emit_to(
-            QUICKCHAT_LABEL,
-            GATEWAY_STATE_EVENT,
-            GatewayStateEvent::new(state, notice, self.canvas_surface_url(), self.user_accent()),
-        );
+        let event = self.with_generation(generation, || {
+            if state != GatewayConnectionState::Up {
+                *self
+                    .inner
+                    .agents_cache
+                    .lock()
+                    .expect("gateway agents cache mutex poisoned") = None;
+                *self
+                    .inner
+                    .canvas_surface
+                    .lock()
+                    .expect("gateway canvas surface mutex poisoned") = CanvasSurfaceState {
+                    generation: generation.0,
+                    url: None,
+                };
+                *self
+                    .inner
+                    .user_accent
+                    .lock()
+                    .expect("gateway accent mutex poisoned") = None;
+            }
+            let notice_changed = {
+                let mut current = self
+                    .inner
+                    .connection_notice
+                    .lock()
+                    .expect("gateway connection notice mutex poisoned");
+                if *current == notice {
+                    false
+                } else {
+                    *current = notice.clone();
+                    true
+                }
+            };
+            let state_changed = self
+                .inner
+                .connection_state
+                .swap(state as u64, Ordering::SeqCst)
+                != state as u64;
+            if !state_changed && !notice_changed {
+                return Ok(None);
+            }
+            let surface = self
+                .inner
+                .canvas_surface
+                .lock()
+                .expect("gateway canvas surface mutex poisoned");
+            Ok(Some(GatewayStateEvent::new(
+                state,
+                notice,
+                surface.url.clone(),
+                self.user_accent(),
+                generation,
+            )))
+        });
+        if let Ok(Some(event)) = event {
+            let _ = app.emit_to(QUICKCHAT_LABEL, GATEWAY_STATE_EVENT, event);
+        }
+    }
+
+    fn state_event(&self) -> GatewayStateEvent {
+        let _config = self
+            .inner
+            .config
+            .lock()
+            .expect("gateway config mutex poisoned");
+        let surface = self
+            .inner
+            .canvas_surface
+            .lock()
+            .expect("gateway canvas surface mutex poisoned");
+        let notice = self
+            .inner
+            .connection_notice
+            .lock()
+            .expect("gateway notice mutex poisoned")
+            .clone();
+        GatewayStateEvent::new(
+            self.connection_state(),
+            notice,
+            surface.url.clone(),
+            self.user_accent(),
+            self.generation(),
+        )
+    }
+
+    fn emit_connection_state(&self, app: &AppHandle) {
+        let _ = app.emit_to(QUICKCHAT_LABEL, GATEWAY_STATE_EVENT, self.state_event());
     }
 }
 
@@ -1190,6 +1394,7 @@ impl GatewayClient {
 #[serde(rename_all = "camelCase")]
 struct GatewayStateEvent {
     state: &'static str,
+    gateway_generation: GatewayGeneration,
     #[serde(skip_serializing_if = "Option::is_none")]
     notice: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1204,9 +1409,11 @@ impl GatewayStateEvent {
         notice: Option<String>,
         canvas_surface_url: Option<String>,
         accent: Option<String>,
+        gateway_generation: GatewayGeneration,
     ) -> Self {
         Self {
             state: state.event_name(),
+            gateway_generation,
             notice,
             canvas_surface_url,
             accent,
@@ -1407,11 +1614,13 @@ async fn wait_for_connect_challenge(
     .map_err(|_| RequestFailure::transport("Gateway connect challenge timed out."))?
 }
 
-#[cfg(target_os = "linux")]
-struct SleepDispatch<'a> {
+struct RequestDispatch<'a> {
     client: &'a GatewayClient,
-    route: &'a GatewaySleepRoute,
+    generation: GatewayGeneration,
     connection_generation: u64,
+    deadline: Option<Instant>,
+    #[cfg(target_os = "linux")]
+    sleep_route: Option<&'a GatewaySleepRoute>,
 }
 
 async fn request_on_socket<T, F>(
@@ -1420,7 +1629,7 @@ async fn request_on_socket<T, F>(
     params: Value,
     budget: Duration,
     dispatch: &F,
-    #[cfg(target_os = "linux")] sleep: Option<SleepDispatch<'_>>,
+    authority: Option<RequestDispatch<'_>>,
 ) -> Result<T, RequestFailure>
 where
     T: DeserializeOwned,
@@ -1436,36 +1645,47 @@ where
     {
         // Read current authority after transport readiness, and hold it through enqueue.
         // The socket generation also fences commands queued for a replaced connection.
-        #[cfg(target_os = "linux")]
-        let current = sleep.as_ref().map(|sleep| {
-            sleep
+        let current = authority.as_ref().map(|authority| {
+            authority
                 .client
                 .inner
                 .config
                 .lock()
                 .expect("gateway config mutex poisoned")
         });
-        #[cfg(target_os = "linux")]
-        if let Some(sleep) = sleep.as_ref() {
-            let owned = current
-                .as_ref()
-                .and_then(|current| current.as_ref())
-                .is_some_and(|config| {
-                    config.ownership == GatewayOwnership::Local
-                        && config.ws_url == sleep.route.ws_url
-                        && is_loopback_ws_url(&config.ws_url)
-                });
-            if !owned
-                || sleep.route.generation != sleep.connection_generation
-                || sleep.client.inner.config_generation.load(Ordering::SeqCst)
-                    != sleep.route.generation
+        if let Some(authority) = authority.as_ref() {
+            let owner_changed = authority.client.generation() != authority.generation
+                || authority.connection_generation != authority.generation.0;
+            #[cfg(target_os = "linux")]
+            if let Some(route) = authority.sleep_route {
+                let owned = current
+                    .as_ref()
+                    .and_then(|current| current.as_ref())
+                    .is_some_and(|config| {
+                        config.ownership == GatewayOwnership::Local
+                            && config.ws_url == route.ws_url
+                            && is_loopback_ws_url(&config.ws_url)
+                    });
+                if owner_changed || !owned {
+                    return Err(RequestFailure::method_with_details(
+                        "Gateway sleep route changed; lease will self-expire.",
+                        None,
+                    ));
+                }
+            }
+            if owner_changed
+                || authority
+                    .deadline
+                    .is_some_and(|deadline| Instant::now() >= deadline)
             {
                 return Err(RequestFailure::method_with_details(
-                    "Gateway sleep route changed; lease will self-expire.",
+                    "Gateway request owner changed or recovery deadline expired.",
                     None,
                 ));
             }
         }
+        // Keep the configuration guard alive through the actual socket enqueue.
+        let _current = current;
         Pin::new(&mut *socket)
             .start_send(Message::Text(encoded.into()))
             .map_err(|error| {
@@ -1520,14 +1740,12 @@ async fn perform_request<F>(
 where
     F: Fn(&Value),
 {
-    #[cfg(not(target_os = "linux"))]
-    let _ = (client, connection_generation);
     let budget = budget.unwrap_or(REQUEST_TIMEOUT);
     match request {
         GatewayRequest::AgentsList => request_agents_list(socket, budget, dispatch)
             .await
             .map(GatewayResponse::AgentsList),
-        GatewayRequest::ChatSend(params) => {
+        GatewayRequest::ChatSend { params, generation } => {
             let params = serde_json::to_value(params).map_err(|error| {
                 RequestFailure::transport(format!("Could not encode chat.send: {error}"))
             })?;
@@ -1537,13 +1755,67 @@ where
                 params,
                 budget,
                 dispatch,
-                #[cfg(target_os = "linux")]
-                None,
+                Some(RequestDispatch {
+                    client,
+                    generation,
+                    connection_generation,
+                    deadline: None,
+                    #[cfg(target_os = "linux")]
+                    sleep_route: None,
+                }),
             )
             .await
             .map(GatewayResponse::ChatSend)
         }
-        GatewayRequest::RefreshCanvasSurface { observed_url } => {
+        GatewayRequest::ChatHistory {
+            target,
+            generation,
+            offset,
+            deadline,
+        } => {
+            let mut params = json!({
+                "sessionKey": target.session_key,
+                "limit": 200,
+                "maxBytes": 262144,
+                "maxChars": 65536,
+            });
+            if let Some(agent_id) = target.agent_id {
+                params["agentId"] = Value::String(agent_id);
+            }
+            if let Some(offset) = offset {
+                params["offset"] = json!(offset);
+            }
+            // Decode this optional method as data so unsupported/malformed history cannot
+            // turn a successfully completed send into a broken connection or another send.
+            let value: Value = request_on_socket(
+                socket,
+                "chat.history",
+                params,
+                budget,
+                dispatch,
+                Some(RequestDispatch {
+                    client,
+                    generation,
+                    connection_generation,
+                    deadline: Some(deadline),
+                    #[cfg(target_os = "linux")]
+                    sleep_route: None,
+                }),
+            )
+            .await?;
+            serde_json::from_value(value)
+                .map(GatewayResponse::ChatHistory)
+                .map_err(|_| {
+                    RequestFailure::method_with_details(
+                        "Gateway history does not support bounded Quick Chat recovery.",
+                        None,
+                    )
+                })
+        }
+        GatewayRequest::RefreshCanvasSurface {
+            observed_url,
+            generation,
+        } => {
             let mut params = json!({ "surface": "canvas" });
             if let Some(observed_url) = observed_url {
                 params["observedUrl"] = Value::String(observed_url);
@@ -1554,8 +1826,14 @@ where
                 params,
                 budget,
                 dispatch,
-                #[cfg(target_os = "linux")]
-                None,
+                Some(RequestDispatch {
+                    client,
+                    generation,
+                    connection_generation,
+                    deadline: None,
+                    #[cfg(target_os = "linux")]
+                    sleep_route: None,
+                }),
             )
             .await?;
             let canvas = response
@@ -1572,10 +1850,12 @@ where
             json!({ "requestId": request_id }),
             budget,
             dispatch,
-            Some(SleepDispatch {
+            Some(RequestDispatch {
                 client,
-                route: &route,
+                generation: GatewayGeneration(route.generation),
+                sleep_route: Some(&route),
                 connection_generation,
+                deadline: None,
             }),
         )
         .await
@@ -1590,10 +1870,12 @@ where
             json!({ "suspensionId": suspension_id }),
             budget,
             dispatch,
-            Some(SleepDispatch {
+            Some(RequestDispatch {
                 client,
-                route: &route,
+                generation: GatewayGeneration(route.generation),
+                sleep_route: Some(&route),
                 connection_generation,
+                deadline: None,
             }),
         )
         .await
@@ -1626,16 +1908,7 @@ async fn request_agents_list<F>(
 where
     F: Fn(&Value),
 {
-    request_on_socket(
-        socket,
-        "agents.list",
-        json!({}),
-        budget,
-        dispatch,
-        #[cfg(target_os = "linux")]
-        None,
-    )
-    .await
+    request_on_socket(socket, "agents.list", json!({}), budget, dispatch, None).await
 }
 
 async fn request_gateway_accent<F>(
@@ -1651,7 +1924,6 @@ where
         json!({}),
         REQUEST_TIMEOUT,
         dispatch,
-        #[cfg(target_os = "linux")]
         None,
     )
     .await?;
@@ -1870,21 +2142,723 @@ where
     }
 }
 
-fn dispatch_chat_event<R: tauri::Runtime>(app: &AppHandle<R>, frame: &Value) {
+fn dispatch_chat_event<R: tauri::Runtime>(
+    app: &AppHandle<R>,
+    frame: &Value,
+    generation: GatewayGeneration,
+) {
     if frame.get("type").and_then(Value::as_str) != Some("event")
         || frame.get("event").and_then(Value::as_str) != Some("chat")
     {
         return;
     }
-    if let Some(payload) = frame.get("payload") {
-        // Payload stays raw so the WebView can mirror Gateway delta assembly without native drift.
-        let _ = app.emit_to(QUICKCHAT_LABEL, CHAT_EVENT, payload.clone());
+    if let Some(payload) = frame.get("payload").and_then(Value::as_object) {
+        let mut payload = payload.clone();
+        // Stamp the socket that delivered this event, not whichever route is active now.
+        payload.insert("gatewayGeneration".to_string(), json!(generation));
+        let _ = app.emit_to(QUICKCHAT_LABEL, CHAT_EVENT, payload);
     }
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use super::*;
+
+    pub(crate) struct RpcFixture {
+        pub(crate) client: GatewayClient,
+        requests: mpsc::Receiver<(Value, oneshot::Sender<Result<Value, String>>)>,
+        frames: Arc<Mutex<Vec<Value>>>,
+        driver: tokio::task::JoinHandle<()>,
+        server: tokio::task::JoinHandle<()>,
+    }
+
+    impl RpcFixture {
+        pub(crate) async fn new() -> Self {
+            let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+            let url = format!("ws://{}", listener.local_addr().unwrap());
+            let (requests_tx, requests) = mpsc::channel(16);
+            let frames = Arc::new(Mutex::new(Vec::new()));
+            let received = frames.clone();
+            let server = tokio::spawn(async move {
+                loop {
+                    let Ok((stream, _)) = listener.accept().await else {
+                        break;
+                    };
+                    let Ok(mut socket) = tokio_tungstenite::accept_async(stream).await else {
+                        continue;
+                    };
+                    while let Some(Ok(message)) = socket.next().await {
+                        if !message.is_text() {
+                            continue;
+                        }
+                        let frame: Value =
+                            serde_json::from_str(message.to_text().unwrap()).unwrap();
+                        received.lock().unwrap().push(frame.clone());
+                        let (reply, response) = oneshot::channel();
+                        if requests_tx.send((frame.clone(), reply)).await.is_err() {
+                            return;
+                        }
+                        let Ok(payload) = response.await else {
+                            break;
+                        };
+                        let response = match payload {
+                            Ok(payload) => {
+                                json!({"type": "res", "id": frame["id"], "ok": true, "payload": payload})
+                            }
+                            Err(message) => {
+                                json!({"type": "res", "id": frame["id"], "ok": false, "error": {"message": message}})
+                            }
+                        };
+                        if socket
+                            .send(Message::Text(response.to_string().into()))
+                            .await
+                            .is_err()
+                        {
+                            break;
+                        }
+                    }
+                }
+            });
+            let (socket, _) = connect_async(&url).await.unwrap();
+            let client = GatewayClient::new();
+            let generation = client.replace_configuration(Some(GatewayWsConfig::new(
+                url,
+                None,
+                None,
+                None,
+                GatewayOwnership::Remote,
+            )));
+            let driver = Self::start_driver(&client, generation, socket);
+            Self {
+                client,
+                requests,
+                frames,
+                driver,
+                server,
+            }
+        }
+
+        fn start_driver(
+            client: &GatewayClient,
+            generation: u64,
+            mut socket: GatewaySocket,
+        ) -> tokio::task::JoinHandle<()> {
+            let (commands, mut receiver) = mpsc::channel(16);
+            *client.inner.commands.lock().unwrap() = Some(commands);
+            client
+                .inner
+                .connection_state
+                .store(GatewayConnectionState::Up as u64, Ordering::SeqCst);
+            let driver_client = client.clone();
+            tokio::spawn(async move {
+                while let Some(command) = receiver.recv().await {
+                    if let DriverCommand::Request {
+                        request,
+                        budget,
+                        reply,
+                    } = command
+                    {
+                        let result = perform_request(
+                            &driver_client,
+                            generation,
+                            &mut socket,
+                            request,
+                            budget,
+                            &|_| {},
+                        )
+                        .await
+                        .map_err(|failure| failure.message);
+                        let _ = reply.send(result);
+                    }
+                }
+            })
+        }
+
+        pub(crate) async fn reconnect(&mut self) {
+            self.driver.abort();
+            let _ = (&mut self.driver).await;
+            *self.client.inner.agents_cache.lock().unwrap() = None;
+            let url = self
+                .client
+                .inner
+                .config
+                .lock()
+                .unwrap()
+                .as_ref()
+                .unwrap()
+                .ws_url
+                .clone();
+            let generation = self.client.generation();
+            let (socket, _) = connect_async(&url).await.unwrap();
+            self.driver = Self::start_driver(&self.client, generation.0, socket);
+        }
+
+        pub(crate) async fn request(
+            &mut self,
+            method: &str,
+        ) -> (Value, oneshot::Sender<Result<Value, String>>) {
+            let request = tokio::time::timeout(Duration::from_secs(2), self.requests.recv())
+                .await
+                .expect("RPC fixture deadline")
+                .expect("RPC fixture closed");
+            assert_eq!(request.0["method"], method);
+            request
+        }
+
+        pub(crate) async fn no_request(&mut self) {
+            let (reply, response) = oneshot::channel();
+            let commands = self.client.inner.commands.lock().unwrap().clone().unwrap();
+            commands
+                .send(DriverCommand::Request {
+                    request: GatewayRequest::AgentsList,
+                    budget: Some(Duration::from_secs(1)),
+                    reply,
+                })
+                .await
+                .unwrap();
+            self.request("agents.list").await.1.send(Ok(json!({
+                "defaultId": "work", "mainKey": "main", "scope": "global", "agents": [{"id": "work"}],
+            }))).unwrap();
+            assert!(
+                response.await.unwrap().is_ok(),
+                "accepted marker delimits prior socket frames"
+            );
+        }
+
+        pub(crate) fn chat_frames(&self) -> Vec<Value> {
+            self.frames
+                .lock()
+                .unwrap()
+                .iter()
+                .filter(|frame| frame["method"] == "chat.send")
+                .cloned()
+                .collect()
+        }
+
+        pub(crate) async fn wait_until_queued(&self) {
+            let commands = self.client.inner.commands.lock().unwrap().clone().unwrap();
+            tokio::time::timeout(Duration::from_secs(1), async {
+                while commands.capacity() == 16 {
+                    tokio::task::yield_now().await;
+                }
+            })
+            .await
+            .expect("request queued behind held response");
+        }
+
+        pub(crate) fn replace_route(&self) {
+            let config = self.client.inner.config.lock().unwrap().clone();
+            self.client.replace_configuration(config);
+        }
+
+        pub(crate) fn set_surface(&self, url: &str) {
+            self.client
+                .set_canvas_surface_url(self.client.generation().0, Some(url.to_string()));
+            self.client
+                .inner
+                .connection_state
+                .store(GatewayConnectionState::Up as u64, Ordering::SeqCst);
+        }
+    }
+
+    impl Drop for RpcFixture {
+        fn drop(&mut self) {
+            self.driver.abort();
+            self.server.abort();
+        }
+    }
+
+    #[tokio::test]
+    async fn chat_send_never_recaptures_a_replaced_callers_generation() {
+        let mut fixture = RpcFixture::new().await;
+        let caller = fixture.client.generation();
+        fixture.replace_route();
+        fixture.reconnect().await;
+        let current = fixture.client.generation();
+        assert_ne!(caller, current);
+        assert!(fixture
+            .client
+            .chat_send(
+                "old draft".into(),
+                "work",
+                "global",
+                "main",
+                "old-key",
+                caller,
+            )
+            .await
+            .is_err());
+        let client = fixture.client.clone();
+        let send = tokio::spawn(async move {
+            client
+                .chat_send(
+                    "new draft".into(),
+                    "work",
+                    "global",
+                    "main",
+                    "new-key",
+                    current,
+                )
+                .await
+        });
+        let (frame, reply) = fixture.request("chat.send").await;
+        assert_eq!(frame["params"]["message"], "new draft");
+        reply
+            .send(Ok(json!({"runId": "new-key", "status": "started"})))
+            .unwrap();
+        assert!(send.await.unwrap().is_ok());
+        fixture.no_request().await;
+        assert_eq!(fixture.chat_frames().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn chat_dispatch_requires_both_caller_and_connection_generation() {
+        for case in ["current", "stale-caller", "stale-connection"] {
+            let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+            let url = format!("ws://{}", listener.local_addr().unwrap());
+            let client = GatewayClient::new();
+            let config =
+                GatewayWsConfig::new(url.clone(), None, None, None, GatewayOwnership::Remote);
+            client.replace_configuration(Some(config.clone()));
+            let original = client.generation();
+            if case == "stale-caller" {
+                client.replace_configuration(Some(config.clone()));
+            }
+            let connection = client.generation();
+            let server = tokio::spawn(async move {
+                let (stream, _) = listener.accept().await.unwrap();
+                let mut socket = tokio_tungstenite::accept_async(stream).await.unwrap();
+                let mut frames = vec![];
+                while let Some(Ok(message)) = socket.next().await {
+                    if !message.is_text() {
+                        continue;
+                    }
+                    let frame: Value = serde_json::from_str(message.to_text().unwrap()).unwrap();
+                    let payload = if frame["method"] == "chat.send" {
+                        json!({"runId": frame["params"]["idempotencyKey"], "status": "started"})
+                    } else {
+                        json!({"defaultId": "work", "mainKey": "main", "scope": "global", "agents": []})
+                    };
+                    socket
+                        .send(Message::Text(
+                            json!({
+                                "type": "res", "id": frame["id"], "ok": true, "payload": payload,
+                            })
+                            .to_string()
+                            .into(),
+                        ))
+                        .await
+                        .unwrap();
+                    frames.push(frame);
+                }
+                frames
+            });
+            let (mut socket, _) = connect_async(&url).await.unwrap();
+            if case == "stale-connection" {
+                client.replace_configuration(Some(config));
+            }
+            let caller = if case == "stale-caller" {
+                original
+            } else {
+                client.generation()
+            };
+            let result = perform_request(
+                &client,
+                connection.0,
+                &mut socket,
+                GatewayRequest::ChatSend {
+                    generation: caller,
+                    params: ChatSendParams {
+                        session_key: "global".into(),
+                        agent_id: Some("work".into()),
+                        message: "bound draft".into(),
+                        idempotency_key: "same-key".into(),
+                    },
+                },
+                None,
+                &|_| {},
+            )
+            .await;
+            assert_eq!(result.is_ok(), case == "current", "{case}");
+            if let Err(failure) = result {
+                assert!(
+                    !failure.disconnect,
+                    "authority rejection is not a transport failure"
+                );
+            }
+            request_agents_list(&mut socket, Duration::from_secs(1), &|_| {})
+                .await
+                .unwrap_or_else(|failure| panic!("marker failed: {}", failure.message));
+            socket.close(None).await.unwrap();
+            let frames = tokio::time::timeout(Duration::from_secs(1), server)
+                .await
+                .unwrap()
+                .unwrap();
+            assert_eq!(frames.last().unwrap()["method"], "agents.list");
+            let chat = frames
+                .iter()
+                .filter(|frame| frame["method"] == "chat.send")
+                .collect::<Vec<_>>();
+            assert_eq!(chat.len(), usize::from(case == "current"), "{case}");
+            if let Some(frame) = chat.first() {
+                assert_eq!(frame["params"]["idempotencyKey"], "same-key");
+                assert!(frame["params"].get("generation").is_none());
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn history_dispatch_revalidates_owner_and_queue_deadline() {
+        for replace in [false, true] {
+            let mut fixture = RpcFixture::new().await;
+            let client = fixture.client.clone();
+            let blocking = tokio::spawn(async move { client.agents_list().await });
+            let (_, release) = fixture.request("agents.list").await;
+            let client = fixture.client.clone();
+            let generation = client.generation();
+            let history = tokio::spawn(async move {
+                client
+                    .chat_history(
+                        &routing_target("global", "work", "main"),
+                        generation,
+                        None,
+                        Instant::now() + Duration::from_millis(50),
+                    )
+                    .await
+            });
+            fixture.wait_until_queued().await;
+            if replace {
+                fixture.replace_route();
+            } else {
+                assert!(history.await.unwrap().unwrap_err().contains("timed out"));
+                release
+                    .send(Ok(json!({
+                        "defaultId": "work", "mainKey": "main", "scope": "global",
+                        "agents": [{"id": "work"}],
+                    })))
+                    .unwrap();
+                assert!(blocking.await.unwrap().is_ok());
+                fixture.no_request().await;
+                continue;
+            }
+            release
+                .send(Ok(json!({
+                    "defaultId": "work", "mainKey": "main", "scope": "global",
+                    "agents": [{"id": "work"}],
+                })))
+                .unwrap();
+            assert!(
+                blocking.await.unwrap().is_err(),
+                "stale catalog cannot write the cache"
+            );
+            assert!(history.await.unwrap().is_err());
+            assert!(fixture.client.inner.agents_cache.lock().unwrap().is_none());
+            fixture.no_request().await;
+        }
+    }
+
+    #[tokio::test]
+    async fn canvas_refresh_keeps_same_owner_and_rejects_replacement_response() {
+        for replace in [false, true] {
+            let mut fixture = RpcFixture::new().await;
+            let original = "https://gateway.example/__openclaw__/cap/original";
+            let refreshed = "https://gateway.example/__openclaw__/cap/refreshed";
+            fixture.set_surface(original);
+            let client = fixture.client.clone();
+            let generation = client.generation();
+            let refresh = tokio::spawn(async move {
+                client
+                    .refresh_canvas_surface(generation, original.to_string())
+                    .await
+            });
+            let (request, reply) = fixture.request("plugin.surface.refresh").await;
+            assert_eq!(request["params"]["observedUrl"], original);
+            if replace {
+                fixture.replace_route();
+                fixture.set_surface(original);
+            }
+            reply
+                .send(Ok(json!({"pluginSurfaceUrls": {"canvas": refreshed}})))
+                .unwrap();
+            let result = refresh.await.unwrap();
+            if replace {
+                assert!(result.is_err());
+                assert_eq!(
+                    fixture.client.canvas_surface_state().url.as_deref(),
+                    Some(original)
+                );
+                assert!(fixture
+                    .client
+                    .with_canvas_surface(generation, original, || Ok(()))
+                    .is_err());
+            } else {
+                assert!(result.is_ok());
+                assert!(fixture
+                    .client
+                    .with_canvas_surface(generation, refreshed, || Ok(()))
+                    .is_ok());
+                assert!(fixture
+                    .client
+                    .with_canvas_surface(generation, original, || Ok(()))
+                    .is_err());
+            }
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    #[ignore = "requires an isolated native X11 display and session bus"]
+    fn quickchat_dispatch_rejects_route_change_after_driver_wait() {
+        use futures_util::FutureExt;
+        use std::future::Future;
+        use std::task::Poll;
+
+        struct IdentityDirectory(std::path::PathBuf);
+
+        impl Drop for IdentityDirectory {
+            fn drop(&mut self) {
+                let _ = std::fs::remove_dir_all(&self.0);
+            }
+        }
+
+        struct SocketTask(tokio::task::JoinHandle<Vec<Value>>);
+
+        impl Drop for SocketTask {
+            fn drop(&mut self) {
+                self.0.abort();
+            }
+        }
+
+        async fn run_case(app: &AppHandle, case: &str) -> Value {
+            let directory = IdentityDirectory(
+                std::env::temp_dir().join(format!("openclaw-chat-dispatch-{}", Uuid::new_v4())),
+            );
+            std::fs::create_dir(&directory.0).expect("create isolated identity directory");
+            let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+                .await
+                .expect("bind original Gateway fixture");
+            let replacement_listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+                .await
+                .expect("reserve replacement Gateway address");
+            let url = format!("ws://{}", listener.local_addr().unwrap());
+            let replacement_url = format!("ws://{}", replacement_listener.local_addr().unwrap());
+            let config = GatewayWsConfig::new(url, None, None, None, GatewayOwnership::Remote);
+            let client = GatewayClient::new();
+            // Use a real identity store without reading or writing the operator's app config.
+            *client.inner.identity.lock().unwrap() = Some(
+                GatewayDeviceIdentityStore::load_or_create(directory.0.join("identity.json"))
+                    .expect("create isolated Gateway identity"),
+            );
+            client.configure(app, config.clone());
+            let generation = client.inner.config_generation.load(Ordering::SeqCst);
+            let (commands, mut receiver) = mpsc::channel(16);
+            *client.inner.commands.lock().unwrap() = Some(commands.clone());
+            let mut server = SocketTask(tokio::spawn(async move {
+                let (stream, _) = listener.accept().await.expect("accept native client");
+                let mut socket = tokio_tungstenite::accept_async(stream)
+                    .await
+                    .expect("accept WebSocket handshake");
+                socket
+                    .send(Message::Text(
+                        json!({
+                            "type": "event",
+                            "event": "connect.challenge",
+                            "payload": { "nonce": "fixture-nonce", "ts": 1_800_000_000_000_u64 },
+                        })
+                        .to_string()
+                        .into(),
+                    ))
+                    .await
+                    .expect("send connect challenge");
+                let mut frames = Vec::new();
+                while let Some(Ok(Message::Text(text))) = socket.next().await {
+                    let frame: Value = serde_json::from_str(&text).expect("request frame");
+                    let payload = match frame["method"].as_str().expect("request method") {
+                        "connect" => json!({
+                            "type": "hello-ok",
+                            "protocol": MAX_PROTOCOL_VERSION,
+                            "features": { "methods": ["agents.list", "chat.send"] },
+                            "auth": {},
+                            "policy": { "tickIntervalMs": 30_000 },
+                        }),
+                        "agents.list" => json!({
+                            "defaultId": "main",
+                            "mainKey": "main",
+                            "scope": "per-sender",
+                            "agents": [{ "id": "main" }],
+                        }),
+                        "config.get" => json!({ "config": {} }),
+                        "chat.send" => json!({
+                            "runId": frame["params"]["idempotencyKey"],
+                            "status": "started",
+                        }),
+                        method => panic!("unexpected fixture method: {method}"),
+                    };
+                    socket
+                        .send(Message::Text(
+                            json!({
+                                "type": "res", "id": frame["id"], "ok": true, "payload": payload,
+                            })
+                            .to_string()
+                            .into(),
+                        ))
+                        .await
+                        .expect("send fixture response");
+                    frames.push(frame);
+                }
+                frames
+            }));
+            let mut driver =
+                Box::pin(client.connect_and_serve(app, &config, generation, &mut receiver));
+
+            // Poll the production future through its handshake into the suspended select.
+            // It is deliberately not spawned, so enqueue/reconfigure cannot repoll it early.
+            futures_util::future::poll_fn(|cx| {
+                match driver.as_mut().poll(cx) {
+                    Poll::Ready(Ok(())) => panic!("driver exited before its command wait"),
+                    Poll::Ready(Err(failure)) => {
+                        panic!("driver handshake failed: {}", failure.message)
+                    }
+                    Poll::Pending => {}
+                }
+                if client.is_connected() {
+                    Poll::Ready(())
+                } else {
+                    Poll::Pending
+                }
+            })
+            .await;
+            let mut send = Box::pin(client.chat_send(
+                "route-bound fixture message".into(),
+                "main",
+                "per-sender",
+                "main",
+                "fixture-chat-request",
+                GatewayGeneration(generation),
+            ));
+            assert!(futures_util::poll!(send.as_mut()).is_pending());
+            assert_eq!(
+                commands.capacity(),
+                15,
+                "chat must be queued before replacement"
+            );
+            match case {
+                "unchanged" => {}
+                "replacement" | "roundtrip" => {
+                    client.configure(
+                        app,
+                        GatewayWsConfig::new(
+                            replacement_url,
+                            None,
+                            None,
+                            None,
+                            GatewayOwnership::Remote,
+                        ),
+                    );
+                    if case == "roundtrip" {
+                        client.configure(app, config.clone());
+                    }
+                }
+                _ => unreachable!(),
+            }
+            let current_generation = client.inner.config_generation.load(Ordering::SeqCst);
+            if case == "unchanged" {
+                assert_eq!(current_generation, generation);
+            } else {
+                assert!(current_generation > generation);
+            }
+
+            let mut response = None;
+            tokio::select! {
+                result = driver.as_mut() => {
+                    result.unwrap_or_else(|failure| panic!("driver failed: {}", failure.message));
+                }
+                result = send.as_mut() => {
+                    response = Some(result);
+                    client.resume_reconnect();
+                    driver.as_mut().await.unwrap_or_else(|failure| {
+                        panic!("driver failed during cleanup: {}", failure.message)
+                    });
+                }
+            }
+            drop(driver);
+            // A stopped driver may leave an undispatched request for its owner's cleanup.
+            while let Ok(command) = receiver.try_recv() {
+                reject_disconnected_command(command);
+            }
+            let response = match response {
+                Some(response) => response,
+                None => send.await,
+            };
+            let frames = (&mut server.0).await.expect("fixture server completed");
+            let methods = frames
+                .iter()
+                .map(|frame| frame["method"].clone())
+                .collect::<Vec<_>>();
+            assert_eq!(&methods[..3], &["connect", "agents.list", "config.get"]);
+            let chat_frames = frames
+                .into_iter()
+                .filter(|frame| frame["method"] == "chat.send")
+                .collect::<Vec<_>>();
+            json!({
+                "case": case,
+                "driverWaitObserved": true,
+                "initialGeneration": generation,
+                "currentGeneration": current_generation,
+                "methods": methods,
+                "chatFrames": chat_frames,
+                "sendSucceeded": response.is_ok(),
+                "sendError": response.err(),
+            })
+        }
+
+        let (completed, result) = std::sync::mpsc::channel();
+        let app = tauri::Builder::default()
+            .any_thread()
+            .setup(move |app| {
+                tauri::WindowBuilder::new(app, QUICKCHAT_LABEL)
+                    .visible(false)
+                    .build()?;
+                let handle = app.handle().clone();
+                tauri::async_runtime::spawn(async move {
+                    let outcome = std::panic::AssertUnwindSafe(async {
+                        tokio::time::timeout(Duration::from_secs(20), async {
+                            let mut cases = Vec::new();
+                            for case in ["unchanged", "replacement", "roundtrip"] {
+                                cases.push(run_case(&handle, case).await);
+                            }
+                            cases
+                        })
+                        .await
+                        .expect("bounded native driver fixture")
+                    })
+                    .catch_unwind()
+                    .await;
+                    let _ = completed.send(outcome);
+                    handle.exit(0);
+                });
+                Ok(())
+            })
+            .build(tauri::generate_context!())
+            .expect("build native driver fixture");
+        assert_eq!(app.run_return(|_, _| {}), 0);
+        let cases = result
+            .recv_timeout(Duration::from_secs(1))
+            .expect("native driver fixture result")
+            .unwrap_or_else(|panic| std::panic::resume_unwind(panic));
+        for case in &cases {
+            println!("C01 {}", serde_json::to_string(case).unwrap());
+        }
+        assert_eq!(cases[0]["chatFrames"].as_array().unwrap().len(), 1);
+        assert_eq!(cases[0]["sendSucceeded"], true, "unchanged route control");
+        for case in &cases[1..] {
+            assert!(
+                case["chatFrames"].as_array().unwrap().is_empty(),
+                "chat.send crossed route replacement after the driver wait: {case}"
+            );
+            assert_eq!(case["sendSucceeded"], false);
+        }
+    }
 
     #[cfg(unix)]
     mod dashboard_handoff {
@@ -2109,16 +3083,22 @@ esac
             ("agents.list", GatewayRequest::AgentsList),
             (
                 "chat.send",
-                GatewayRequest::ChatSend(ChatSendParams {
-                    session_key: "agent:main:main".into(),
-                    agent_id: None,
-                    message: "hello".into(),
-                    idempotency_key: "fixture-request".into(),
-                }),
+                GatewayRequest::ChatSend {
+                    params: ChatSendParams {
+                        session_key: "agent:main:main".into(),
+                        agent_id: None,
+                        message: "hello".into(),
+                        idempotency_key: "fixture-request".into(),
+                    },
+                    generation: GatewayGeneration(generation),
+                },
             ),
             (
                 "plugin.surface.refresh",
-                GatewayRequest::RefreshCanvasSurface { observed_url: None },
+                GatewayRequest::RefreshCanvasSurface {
+                    observed_url: None,
+                    generation: GatewayGeneration(generation),
+                },
             ),
             #[cfg(target_os = "linux")]
             (
@@ -2483,7 +3463,7 @@ esac
                 .await;
                 let controller = controller(&fixture.client, |_| std::future::ready(()));
                 let cycle = async {
-                    controller.will_sleep().await;
+                    controller.will_sleep().1.await;
                     controller.did_wake().await;
                 };
                 fixture.drive(cycle).await;
@@ -2567,6 +3547,13 @@ esac
                 SleepSocketFixture::switch_route(&fixture.client, "roundtrip");
                 let client = fixture.client.clone();
                 let route = client.sleep_route().unwrap();
+                assert_eq!(client.connection_state(), GatewayConnectionState::Down);
+                assert_ne!(route.generation, fixture.generation);
+                // Model the current route Up while dispatch retains the previous socket.
+                client
+                    .inner
+                    .connection_state
+                    .store(GatewayConnectionState::Up as u64, Ordering::SeqCst);
                 let mut request = Box::pin(sleep_request(&client, route, resume));
                 assert!(futures_util::poll!(&mut request).is_pending());
                 let command = fixture.next_request().await;
@@ -2583,7 +3570,7 @@ esac
                     let mut fixture =
                         SleepSocketFixture::new(dashboard_handoff::local_ws_config).await;
                     let controller = controller(&fixture.client, |_| std::future::ready(()));
-                    let mut sleeping = Box::pin(controller.will_sleep());
+                    let mut sleeping = Box::pin(controller.will_sleep().1);
                     assert!(futures_util::poll!(&mut sleeping).is_pending());
                     let command = fixture.next_request().await;
                     fixture.dispatch(command).await;
@@ -2614,7 +3601,7 @@ esac
                     }
                     std::future::ready(())
                 });
-                fixture.drive(controller.will_sleep()).await;
+                fixture.drive(controller.will_sleep().1).await;
                 fixture.fail_resume.store(true, Ordering::SeqCst);
                 fixture.drive(controller.did_wake()).await;
                 let frames = fixture.finish().await;
@@ -2982,6 +3969,7 @@ esac
             None,
             Some("https://gateway.example/__openclaw__/cap/fixture-capability".to_string()),
             Some("#abc123".to_string()),
+            GatewayGeneration(7),
         ))
         .expect("serialize gateway state");
 
@@ -2990,6 +3978,7 @@ esac
             "https://gateway.example/__openclaw__/cap/fixture-capability"
         );
         assert_eq!(event["accent"], "#abc123");
+        assert_eq!(event["gatewayGeneration"], 7);
         assert!(event.get("canvas_surface_url").is_none());
     }
 
@@ -3088,10 +4077,17 @@ esac
                 Some("Gateway requires a credential — open the dashboard on the gateway host")
             );
             assert_eq!(
-                serde_json::to_value(GatewayStateEvent::new(state, notice, None, None))
-                    .expect("serialize credential-required state"),
+                serde_json::to_value(GatewayStateEvent::new(
+                    state,
+                    notice,
+                    None,
+                    None,
+                    GatewayGeneration(1)
+                ))
+                .expect("serialize credential-required state"),
                 json!({
                     "state": "credential-required",
+                    "gatewayGeneration": 1,
                     "notice": "Gateway requires a credential — open the dashboard on the gateway host"
                 })
             );
@@ -3205,10 +4201,13 @@ esac
         let result = ChatSendResult {
             target: routing_target("global", "work", "main"),
             run_id: "run-1".to_string(),
+            status: "started".to_string(),
+            gateway_generation: GatewayGeneration(1),
+            recovered_messages: None,
         };
         assert_eq!(
             serde_json::to_value(result).expect("serialized chat send result"),
-            json!({ "sessionKey": "global", "agentId": "work", "runId": "run-1" })
+            json!({ "sessionKey": "global", "agentId": "work", "runId": "run-1", "status": "started", "gatewayGeneration": 1 })
         );
     }
 }

--- a/apps/linux/src-tauri/src/main.rs
+++ b/apps/linux/src-tauri/src/main.rs
@@ -23,13 +23,13 @@ use cli::{CliError, OpenClawCli};
 use gateway::{GatewayAction, GatewaySnapshot, ReadyGateway};
 use gateway_operation_queue::{GatewayOperation, GatewayOperationQueue};
 use installer::InstallChannel;
-use remote_gateway::{RemoteConnectionSource, RemoteGatewayRequest};
+use remote_gateway::{RemoteConnectionSource, RemoteGatewayRequest, TunnelRoute};
 use serde::Serialize;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::{mpsc, Arc, Mutex};
 use std::thread;
 use std::time::Duration;
-use tauri::webview::{NewWindowResponse, WebviewBuilder};
+use tauri::webview::{NewWindowResponse, PageLoadEvent, WebviewBuilder};
 use tauri::{
     AppHandle, Emitter, LogicalPosition, Manager, State, Url, WebviewUrl, WebviewWindow,
     WebviewWindowBuilder,
@@ -308,12 +308,23 @@ mod native_browser_tests {
     }
 }
 
+#[cfg(target_os = "linux")]
+struct RemoteDashboardPresentation {
+    webview: tauri::Webview,
+    target: Url,
+    selection: u64,
+    generation: u64,
+}
+
 #[derive(Default)]
 struct NavigationState {
-    // One lock owns both fields so the intent check and WebView navigation cannot interleave.
+    // Navigation commits run on the main thread; workers only prepare connections.
     remote_dashboard: bool,
     watch_generation: u64,
     onboarding_pending: bool,
+    remote_snapshot: Option<GatewaySnapshot>,
+    #[cfg(target_os = "linux")]
+    remote_presentation: Option<RemoteDashboardPresentation>,
 }
 
 impl NavigationState {
@@ -388,8 +399,9 @@ struct DesktopInner {
     pending_approvals: Mutex<pending_approvals::PendingApprovalState>,
     local_url: Url,
     tray: Mutex<Option<Arc<tray::TrayHandles>>>,
-    remote_tunnel: Mutex<Option<remote_gateway::SshTunnel>>,
+    remote_tunnels: remote_gateway::TunnelManager,
     quitting: AtomicBool,
+    ssh_shutdown_complete: AtomicBool,
 }
 
 #[derive(Clone)]
@@ -407,8 +419,9 @@ impl DesktopState {
                 pending_approvals: Mutex::new(pending_approvals::PendingApprovalState::default()),
                 local_url,
                 tray: Mutex::new(None),
-                remote_tunnel: Mutex::new(None),
+                remote_tunnels: remote_gateway::TunnelManager::default(),
                 quitting: AtomicBool::new(false),
+                ssh_shutdown_complete: AtomicBool::new(false),
             }),
         }
     }
@@ -433,14 +446,83 @@ impl DesktopState {
         self.with_tray(|tray| tray.refresh_update_action(app));
     }
 
-    pub fn connect(&self, app: &AppHandle) -> Result<GatewaySnapshot, String> {
-        self.connect_selected(app, false)
+    #[cfg(target_os = "linux")]
+    pub(crate) fn present_remote_dashboard(&self, app: &AppHandle) -> Result<bool, String> {
+        let navigation = self.inner.navigation.lock().expect("navigation");
+        if self.is_quitting() {
+            return Ok(true);
+        }
+        let Some(presentation) = navigation.remote_presentation.as_ref() else {
+            // Settings and failed child restoration still own remote navigation.
+            return Ok(navigation.remote_dashboard);
+        };
+        if !navigation.remote_dashboard || navigation.watch_generation != presentation.generation {
+            return Ok(true);
+        }
+        // A passive open must not replace the owner of in-flight native requests.
+        app.state::<GatewayOperationQueue>()
+            .while_current(presentation.selection, || {
+                presentation
+                    .webview
+                    .navigate(presentation.target.clone())
+                    .map(|_| true)
+                    .map_err(|_| {
+                        "Could not reload the remote dashboard. Open Connection Settings to retry."
+                            .to_string()
+                    })
+            })
+            .unwrap_or(Ok(true))
+    }
+
+    fn on_main<T: Send + 'static>(
+        &self,
+        app: &AppHandle,
+        action: impl FnOnce(DesktopState, AppHandle) -> Result<T, String> + Send + 'static,
+    ) -> Result<T, String> {
+        let (sender, receiver) = mpsc::channel();
+        let state = self.clone();
+        let current_app = app.clone();
+        app.run_on_main_thread(move || {
+            let _ = sender.send(action(state, current_app));
+        })
+        .map_err(|_| "The desktop event loop is unavailable.".to_string())?;
+        receiver
+            .recv()
+            .map_err(|_| "The desktop operation was interrupted.".to_string())?
+    }
+
+    pub fn connect(&self, app: &AppHandle, selection: u64) -> Result<GatewaySnapshot, String> {
+        let result = self.connect_selected(app, false, selection);
+        if let Err(error) = &result {
+            if remote_gateway::saved_settings()?.is_some() {
+                return self.remote_failure(app, error.clone(), selection, None);
+            }
+        }
+        result
+    }
+
+    fn retry_remote(&self, app: &AppHandle, selection: u64) -> Result<GatewaySnapshot, String> {
+        let _operation = self.inner.operation.lock().expect("Gateway operation");
+        let result = remote_gateway::load_saved_remote()
+            .and_then(|request| {
+                request.ok_or_else(|| {
+                    "No remote Gateway is saved. Edit the connection settings.".to_string()
+                })
+            })
+            .and_then(|request| {
+                self.connect_remote_locked(app, request, RemoteConnectionSource::Saved, selection)
+            });
+        match result {
+            Ok(snapshot) => Ok(snapshot),
+            Err(error) => self.remote_failure(app, error, selection, None),
+        }
     }
 
     fn connect_selected(
         &self,
         app: &AppHandle,
         explicit_local: bool,
+        selection: u64,
     ) -> Result<GatewaySnapshot, String> {
         let _operation = self
             .inner
@@ -449,8 +531,21 @@ impl DesktopState {
             .map_err(|_| "Gateway operation lock is unavailable.".to_string())?;
         if !explicit_local {
             if let Some(remote) = remote_gateway::load_saved_remote()? {
-                return self.connect_remote_locked(app, remote, RemoteConnectionSource::Saved);
+                return self.connect_remote_locked(
+                    app,
+                    remote,
+                    RemoteConnectionSource::Saved,
+                    selection,
+                );
             }
+            self.on_main(app, move |state, app| {
+                let mut navigation = state.inner.navigation.lock().expect("navigation");
+                app.state::<GatewayOperationQueue>()
+                    .while_current(selection, || {
+                        navigation.permit_local(true, None);
+                    });
+                Ok(())
+            })?;
         }
         let cli = self.resolve_cli();
         if !explicit_local && !remote_gateway::has_configured_gateway()? {
@@ -472,11 +567,7 @@ impl DesktopState {
             Err(error) => return Err(error.to_string()),
         };
         if explicit_local {
-            self.inner
-                .remote_tunnel
-                .lock()
-                .map_err(|_| "Remote Gateway tunnel lock is unavailable.".to_string())?
-                .take();
+            self.inner.remote_tunnels.clear();
         }
         let ready = gateway::ensure_ready(&cli)?;
         self.finish_local_connection(app, cli, ready)
@@ -569,47 +660,58 @@ impl DesktopState {
         cli: OpenClawCli,
         ready: ReadyGateway,
     ) -> Result<GatewaySnapshot, String> {
-        app.state::<gateway_ws::GatewayClient>()
-            .configure(app, ready.gateway_ws);
         let navigated = self.navigate_local(app, &ready.dashboard_url, false, None, true, true)?;
-        self.update_tray(&ready.snapshot);
         if navigated {
+            app.state::<gateway_ws::GatewayClient>()
+                .configure(app, ready.gateway_ws);
+            self.update_tray(&ready.snapshot);
             self.start_watchdog(app.clone(), cli);
         }
         Ok(ready.snapshot)
     }
 
-    pub fn connect_explicit_local(&self, app: &AppHandle) -> Result<GatewaySnapshot, String> {
-        let mut navigation = self
-            .inner
-            .navigation
-            .lock()
-            .map_err(|_| "Dashboard navigation lock is unavailable.".to_string())?;
-        navigation.permit_local(true, None);
-        // First-run setup owns the pending bootstrap reply. Replacing its page
-        // drops the error callback and leaves a reconnect screen with no watchdog.
-        if !self.main_window_has_local_content(&main_window(app)?) {
-            let mut url = self.inner.local_url.clone();
-            url.query_pairs_mut()
-                .clear()
-                .append_pair("mode", "reconnecting");
-            self.navigate_locked(app, url, false)?;
-        }
-        drop(navigation);
-        self.connect_selected(app, true)
+    pub fn connect_explicit_local(
+        &self,
+        app: &AppHandle,
+        selection: u64,
+    ) -> Result<GatewaySnapshot, String> {
+        self.on_main(app, |state, app| {
+            state
+                .inner
+                .navigation
+                .lock()
+                .expect("navigation")
+                .permit_local(true, None);
+            // Keep the first-run page that owns the pending bootstrap reply.
+            if !state.main_window_has_local_content(&main_window(&app)?) {
+                let mut url = state.inner.local_url.clone();
+                url.query_pairs_mut()
+                    .clear()
+                    .append_pair("mode", "reconnecting");
+                state.navigate_locked(&app, url, false)?;
+            }
+            Ok(())
+        })?;
+        self.connect_selected(app, true, selection)
     }
 
     pub(crate) fn connect_remote(
         &self,
         app: &AppHandle,
         request: RemoteGatewayRequest,
+        selection: u64,
     ) -> Result<GatewaySnapshot, String> {
         let _operation = self
             .inner
             .operation
             .lock()
             .map_err(|_| "Gateway operation lock is unavailable.".to_string())?;
-        self.connect_remote_locked(app, request, RemoteConnectionSource::Submitted)
+        let result =
+            self.connect_remote_locked(app, request, RemoteConnectionSource::Submitted, selection);
+        if let Err(error) = &result {
+            let _ = self.remote_failure(app, error.clone(), selection, None);
+        }
+        result
     }
 
     fn connect_remote_locked(
@@ -617,22 +719,48 @@ impl DesktopState {
         app: &AppHandle,
         mut request: RemoteGatewayRequest,
         source: RemoteConnectionSource,
+        selection: u64,
     ) -> Result<GatewaySnapshot, String> {
-        remote_gateway::validate_request(&request)?;
-        let mut active_tunnel = self
+        if self.is_quitting() {
+            return Err("OpenClaw is quitting.".to_string());
+        }
+        let view_generation = self
             .inner
-            .remote_tunnel
+            .navigation
             .lock()
-            .map_err(|_| "Remote Gateway tunnel lock is unavailable.".to_string())?;
-        active_tunnel.take();
+            .expect("navigation")
+            .watch_generation;
+        remote_gateway::validate_request(&request)?;
+        let work = if request.transport == "ssh" || self.inner.remote_tunnels.has_route() {
+            Some(self.inner.remote_tunnels.begin()?)
+        } else {
+            None
+        };
+        let reusable = (request.transport == "ssh")
+            .then(|| self.inner.remote_tunnels.reusable(&request))
+            .flatten();
         let (tunnel, gateway_url) = if request.transport == "ssh" {
-            let saved_url = request
-                .url
-                .as_deref()
-                .map(remote_gateway::normalize_gateway_url)
-                .transpose()?;
-            let (tunnel, url) = remote_gateway::start_tunnel(&request, saved_url.as_ref())?;
-            (Some(tunnel), url)
+            if let Some(route) = &reusable {
+                (None, route.url.clone())
+            } else {
+                let saved_url = request
+                    .url
+                    .as_deref()
+                    .map(remote_gateway::normalize_gateway_url)
+                    .transpose()?;
+                let (tunnel, url) =
+                    remote_gateway::start_tunnel(&request, saved_url.as_ref(), || {
+                        self.is_quitting()
+                            || self
+                                .inner
+                                .navigation
+                                .lock()
+                                .expect("navigation")
+                                .watch_generation
+                                != view_generation
+                    })?;
+                (Some(tunnel), url)
+            }
         } else {
             let raw = request
                 .url
@@ -643,28 +771,72 @@ impl DesktopState {
         remote_gateway::resolve_remote_tls_fingerprint(&mut request, &gateway_url)?;
         let target = remote_gateway::dashboard_url(&gateway_url)?;
         let script = native_auth_initialization_script(&target, &gateway_url, &request)?;
+        if self.is_quitting()
+            || self
+                .inner
+                .navigation
+                .lock()
+                .expect("navigation")
+                .watch_generation
+                != view_generation
+        {
+            return Err("The connection was superseded by navigation.".to_string());
+        }
         remote_gateway::save_config_at(
             &remote_gateway::config_path()?,
             &request,
             &gateway_url,
             source,
         )?;
-        *active_tunnel = tunnel;
-        drop(active_tunnel);
-
-        app.state::<gateway_ws::GatewayClient>()
-            .configure(app, remote_ws_config(&request, &gateway_url));
-        self.navigate_authenticated_remote(app, target, script)?;
-        let snapshot = GatewaySnapshot {
-            phase: "connected",
-            installed: false,
-            running: false,
-            reachable: true,
-            status: "Connected to remote Gateway".to_string(),
-            detail: None,
-        };
-        self.update_tray(&snapshot);
-        Ok(snapshot)
+        let pending = Arc::new(Mutex::new(tunnel));
+        let commit_pending = Arc::clone(&pending);
+        let result = self.on_main(app, move |state, app| {
+            if state.is_quitting()
+                || state
+                    .inner
+                    .navigation
+                    .lock()
+                    .expect("navigation")
+                    .watch_generation
+                    != view_generation
+            {
+                return Err("The connection was superseded by navigation.".to_string());
+            }
+            if request.transport == "ssh" {
+                state.inner.remote_tunnels.publish(
+                    &mut commit_pending.lock().expect("pending SSH"),
+                    TunnelRoute {
+                        id: 0,
+                        selection,
+                        request: request.clone(),
+                        url: gateway_url.clone(),
+                    },
+                    reusable.as_ref().map(|route| route.id),
+                    true,
+                )?;
+            } else {
+                *commit_pending.lock().expect("pending SSH") = state.inner.remote_tunnels.take();
+            }
+            app.state::<gateway_ws::GatewayClient>()
+                .configure(&app, remote_ws_config(&request, &gateway_url));
+            // The submitting view will be destroyed. Its IPC reply cannot own
+            // completion, and a listening SSH port does not prove Gateway health.
+            let snapshot = GatewaySnapshot::remote_opening();
+            {
+                let mut navigation = state.inner.navigation.lock().expect("navigation");
+                navigation.select_remote();
+                navigation.remote_snapshot = Some(snapshot.clone());
+            }
+            state.update_tray(&snapshot);
+            state.navigate_authenticated_remote(&app, target, script, selection)?;
+            Ok(snapshot)
+        });
+        // Includes retired and cancelled children. No native thread or state
+        // lock waits for a subprocess to exit.
+        let retired = pending.lock().expect("pending SSH").take();
+        drop(retired);
+        drop(work);
+        result
     }
 
     fn navigate_authenticated_remote(
@@ -672,6 +844,7 @@ impl DesktopState {
         app: &AppHandle,
         dashboard: Url,
         script: String,
+        selection: u64,
     ) -> Result<(), String> {
         let window = app
             .get_window("main")
@@ -679,48 +852,246 @@ impl DesktopState {
         let size = window
             .inner_size()
             .map_err(|_| "Could not measure the Gateway window.".to_string())?;
-        let mut navigation = self
+        let generation = self
             .inner
             .navigation
             .lock()
-            .map_err(|_| "Dashboard navigation lock is unavailable.".to_string())?;
+            .expect("navigation")
+            .watch_generation;
         let old_webview = app
             .get_webview("main")
             .ok_or_else(|| "Main dashboard view is unavailable.".to_string())?;
-        navigation.select_remote();
         // Keep the native window alive: only its child changes so tray ownership,
         // geometry and close-to-tray behavior survive auth-bound script injection.
         old_webview
             .close()
             .map_err(|_| "Could not replace the Gateway dashboard view.".to_string())?;
         let browser_app = app.clone();
-        let builder = WebviewBuilder::new("main", WebviewUrl::External(dashboard))
+        let load_state = self.clone();
+        let builder = WebviewBuilder::new("main", WebviewUrl::External(dashboard.clone()))
             .initialization_script(script)
+            .on_page_load(move |view, payload| {
+                let state = load_state.clone();
+                let app = view.app_handle().clone();
+                let loaded = matches!(payload.event(), PageLoadEvent::Finished);
+                let callback_app = app.clone();
+                let on_load = move || {
+                    let mut navigation = state.inner.navigation.lock().expect("navigation");
+                    if state.is_quitting()
+                        || navigation.watch_generation != generation
+                        || navigation
+                            .remote_snapshot
+                            .as_ref()
+                            .is_some_and(|snapshot| snapshot.phase == "remoteError")
+                    {
+                        return;
+                    }
+                    let snapshot = callback_app.state::<GatewayOperationQueue>().while_current(
+                        selection,
+                        || {
+                            let mut snapshot = GatewaySnapshot::remote_opening();
+                            if loaded {
+                                // Document loading does not prove HTTP or authenticated readiness.
+                                snapshot.phase = "remoteDashboard";
+                                snapshot.status = "Remote dashboard".to_string();
+                            }
+                            navigation.remote_snapshot = Some(snapshot.clone());
+                            snapshot
+                        },
+                    );
+                    drop(navigation);
+                    if let Some(snapshot) = snapshot {
+                        state.update_tray(&snapshot);
+                    }
+                };
+                // Wry may invoke this inline while navigation holds its owner guards.
+                #[cfg(target_os = "linux")]
+                gtk::glib::idle_add_once(on_load);
+                #[cfg(not(target_os = "linux"))]
+                let _ = app.run_on_main_thread(on_load);
+            })
             .on_new_window(move |url, _features| {
                 open_external_browser(&browser_app, &url);
                 NewWindowResponse::Deny
             })
             .auto_resize();
-        if window
-            .add_child(builder, LogicalPosition::new(0, 0), size)
-            .is_err()
+        let remote_webview = match window.add_child(builder, LogicalPosition::new(0, 0), size) {
+            Ok(webview) => webview,
+            Err(_) => {
+                self.inner
+                    .navigation
+                    .lock()
+                    .expect("navigation")
+                    .cancel_watchdog();
+                let browser_app = app.clone();
+                let mut local = self.inner.local_url.clone();
+                local
+                    .query_pairs_mut()
+                    .append_pair("mode", "connectionSettings");
+                let restore = WebviewBuilder::new("main", WebviewUrl::External(local))
+                    .on_new_window(move |url, _features| {
+                        open_external_browser(&browser_app, &url);
+                        NewWindowResponse::Deny
+                    })
+                    .auto_resize();
+                let _ = window.add_child(restore, LogicalPosition::new(0, 0), size);
+                return Err(
+                    "Could not open the remote Gateway dashboard. Try connecting again."
+                        .to_string(),
+                );
+            }
+        };
+        #[cfg(target_os = "linux")]
         {
-            navigation.remote_dashboard = false;
-            let browser_app = app.clone();
-            let restore = WebviewBuilder::new("main", WebviewUrl::App("index.html".into()))
-                .on_new_window(move |url, _features| {
-                    open_external_browser(&browser_app, &url);
-                    NewWindowResponse::Deny
-                })
-                .auto_resize();
-            let _ = window.add_child(restore, LogicalPosition::new(0, 0), size);
-            return Err(
-                "Could not open the remote Gateway dashboard. Try connecting again.".to_string(),
-            );
+            let mut navigation = self.inner.navigation.lock().expect("navigation");
+            if !self.is_quitting()
+                && navigation.remote_dashboard
+                && navigation.watch_generation == generation
+            {
+                app.state::<GatewayOperationQueue>()
+                    .while_current(selection, || {
+                        navigation.remote_presentation = Some(RemoteDashboardPresentation {
+                            webview: remote_webview,
+                            target: dashboard,
+                            selection,
+                            generation,
+                        });
+                    });
+            }
         }
-        drop(navigation);
+        #[cfg(not(target_os = "linux"))]
+        drop(remote_webview);
         tray::show_window(app);
         Ok(())
+    }
+
+    fn remote_failure(
+        &self,
+        app: &AppHandle,
+        error: String,
+        selection: u64,
+        child: Option<u64>,
+    ) -> Result<GatewaySnapshot, String> {
+        self.on_main(app, move |state, app| {
+            let snapshot = GatewaySnapshot::remote_error(error);
+            if state.is_quitting()
+                || !app
+                    .state::<GatewayOperationQueue>()
+                    .selection_is_current(selection)
+                || child.is_some_and(|child| !state.inner.remote_tunnels.route_is_current(child))
+            {
+                return Ok(snapshot);
+            }
+            state
+                .inner
+                .navigation
+                .lock()
+                .expect("navigation")
+                .remote_snapshot = Some(snapshot.clone());
+            state.update_tray(&snapshot);
+            Ok(snapshot)
+        })
+    }
+
+    pub(crate) fn show_connection_settings(&self, app: &AppHandle) -> Result<(), String> {
+        app.state::<GatewayOperationQueue>().invalidate_recovery();
+        // Called on the native event thread. Keep the transport alive while
+        // replacing only the dashboard with the local correction form.
+        self.inner
+            .navigation
+            .lock()
+            .expect("navigation")
+            .select_remote();
+        let mut url = self.inner.local_url.clone();
+        url.query_pairs_mut()
+            .clear()
+            .append_pair("mode", "connectionSettings");
+        self.navigate_locked(app, url, true)
+    }
+
+    fn start_tunnel_monitor(&self, app: AppHandle) {
+        let state = self.clone();
+        thread::spawn(move || {
+            while !state.is_quitting() {
+                if let Some((route, recover)) = state.inner.remote_tunnels.exited() {
+                    if recover {
+                        app.state::<GatewayOperationQueue>()
+                            .submit_recovery(route.selection, route.id);
+                    } else {
+                        let _ = state.remote_failure(&app,
+                            "The SSH connection closed again. Open Connection Settings to retry or edit it.".to_string(),
+                            route.selection, Some(route.id));
+                    }
+                }
+                thread::sleep(Duration::from_millis(200));
+            }
+        });
+    }
+
+    fn recover_remote(
+        &self,
+        app: &AppHandle,
+        selection: u64,
+        child_id: u64,
+    ) -> Result<GatewaySnapshot, String> {
+        let _operation = self.inner.operation.lock().expect("Gateway operation");
+        let Some(route) = self.inner.remote_tunnels.route(child_id) else {
+            return Ok(GatewaySnapshot::remote_opening());
+        };
+        let cancelled = || {
+            self.is_quitting()
+                || !app
+                    .state::<GatewayOperationQueue>()
+                    .selection_is_current(selection)
+                || !self.inner.remote_tunnels.route_is_current(child_id)
+        };
+        if cancelled() {
+            return Ok(GatewaySnapshot::remote_opening());
+        }
+        let _work = self.inner.remote_tunnels.begin()?;
+        let tunnel = remote_gateway::start_tunnel(&route.request, Some(&route.url), cancelled);
+        match tunnel {
+            Err(error) => self.remote_failure(app, error, selection, Some(child_id)),
+            Ok((tunnel, url)) => {
+                let pending = Arc::new(Mutex::new(Some(tunnel)));
+                let commit_pending = Arc::clone(&pending);
+                let result = self.on_main(app, move |state, app| {
+                    let published =
+                        app.state::<GatewayOperationQueue>()
+                            .while_current(selection, || {
+                                state.inner.remote_tunnels.publish(
+                                    &mut commit_pending.lock().expect("pending SSH"),
+                                    TunnelRoute { url, ..route },
+                                    Some(child_id),
+                                    false,
+                                )
+                            });
+                    let Some(published) = published else {
+                        return Ok(GatewaySnapshot::remote_opening());
+                    };
+                    published?;
+                    // Same route, same document and native client generation. A
+                    // replacement gets no further automatic retry until user intent.
+                    app.state::<gateway_ws::GatewayClient>().resume_reconnect();
+                    let mut snapshot = GatewaySnapshot::remote_opening();
+                    snapshot.status = "Remote dashboard".to_string();
+                    state
+                        .inner
+                        .navigation
+                        .lock()
+                        .expect("navigation")
+                        .remote_snapshot = Some(snapshot.clone());
+                    state.update_tray(&snapshot);
+                    Ok(snapshot)
+                });
+                let retired = pending.lock().expect("pending SSH").take();
+                drop(retired);
+                match result {
+                    Ok(snapshot) => Ok(snapshot),
+                    Err(error) => self.remote_failure(app, error, selection, Some(child_id)),
+                }
+            }
+        }
     }
 
     pub fn show_error(&self, app: &AppHandle, _error: &str) {
@@ -729,12 +1100,27 @@ impl DesktopState {
         tray::show_window(app);
     }
 
-    pub fn quit(&self) {
-        self.inner.quitting.store(true, Ordering::SeqCst);
-        self.cancel_watchdog();
-        if let Ok(mut tunnel) = self.inner.remote_tunnel.lock() {
-            tunnel.take();
+    pub fn quit(&self, app: &AppHandle) {
+        self.quit_with_code(app, 0);
+    }
+
+    fn quit_with_code(&self, app: &AppHandle, code: i32) {
+        if self.inner.quitting.swap(true, Ordering::SeqCst) {
+            return;
         }
+        self.cancel_watchdog();
+        app.state::<GatewayOperationQueue>().invalidate_recovery();
+        self.inner.remote_tunnels.close();
+        let state = self.clone();
+        let app = app.clone();
+        thread::spawn(move || {
+            state.inner.remote_tunnels.wait_closed();
+            state
+                .inner
+                .ssh_shutdown_complete
+                .store(true, Ordering::SeqCst);
+            app.exit(code);
+        });
     }
 
     fn is_quitting(&self) -> bool {
@@ -828,7 +1214,7 @@ impl DesktopState {
         }
     }
 
-    // Caller holds the navigation lock, keeping the final arbitration check and navigation atomic.
+    // Called on the event thread after arbitration, without holding state locks.
     fn navigate_locked(
         &self,
         app: &AppHandle,
@@ -853,27 +1239,39 @@ impl DesktopState {
         reveal_window: bool,
         dashboard: bool,
     ) -> Result<bool, String> {
-        let mut navigation = self
-            .inner
-            .navigation
-            .lock()
-            .map_err(|_| "Dashboard navigation lock is unavailable.".to_string())?;
-        if !navigation.permit_local(force, expected_generation) {
-            return Ok(false);
-        }
-        let onboarding_was_pending = dashboard && navigation.onboarding_pending;
-        let url = if dashboard {
-            navigation.prepare_dashboard_url(target)?
-        } else {
-            Url::parse(target).map_err(|_| "Dashboard returned an invalid URL.".to_string())?
-        };
-        if let Err(error) = self.navigate_locked(app, url, reveal_window) {
-            if onboarding_was_pending {
-                navigation.mark_onboarding_pending();
+        let target = target.to_string();
+        self.on_main(app, move |state, app| {
+            let mut navigation = state.inner.navigation.lock().expect("navigation");
+            if state.is_quitting() || !navigation.permit_local(force, expected_generation) {
+                return Ok(false);
             }
-            return Err(error);
-        }
-        Ok(true)
+            let onboarding_was_pending = dashboard && navigation.onboarding_pending;
+            let url = if dashboard {
+                navigation.prepare_dashboard_url(&target)?
+            } else {
+                Url::parse(&target).map_err(|_| "Dashboard returned an invalid URL.".to_string())?
+            };
+            drop(navigation);
+            if let Err(error) = state.navigate_locked(&app, url, reveal_window) {
+                if onboarding_was_pending {
+                    state
+                        .inner
+                        .navigation
+                        .lock()
+                        .expect("navigation")
+                        .mark_onboarding_pending();
+                }
+                return Err(error);
+            }
+            #[cfg(target_os = "linux")]
+            {
+                let mut navigation = state.inner.navigation.lock().expect("navigation");
+                if !navigation.remote_dashboard {
+                    navigation.remote_presentation = None;
+                }
+            }
+            Ok(true)
+        })
     }
 
     fn show_local(
@@ -1192,15 +1590,49 @@ fn build_info(app: AppHandle) -> BuildInfo {
 
 #[tauri::command]
 async fn bootstrap(
+    state: State<'_, DesktopState>,
     operations: State<'_, GatewayOperationQueue>,
     explicit_local: Option<bool>,
-) -> Result<GatewaySnapshot, String> {
-    let operation = if explicit_local == Some(true) {
+    connection_settings: Option<bool>,
+    remote_retry: Option<bool>,
+) -> Result<BootstrapReply, String> {
+    if connection_settings == Some(true) {
+        operations.invalidate_recovery();
+        state.cancel_watchdog();
+        return Ok(BootstrapReply::Settings {
+            remote: remote_gateway::saved_settings()?,
+            detail: state
+                .inner
+                .navigation
+                .lock()
+                .expect("navigation")
+                .remote_snapshot
+                .as_ref()
+                .filter(|snapshot| snapshot.phase == "remoteError")
+                .and_then(|snapshot| snapshot.detail.clone()),
+        });
+    }
+    let operation = if remote_retry == Some(true) {
+        GatewayOperation::RetryRemote
+    } else if explicit_local == Some(true) {
         GatewayOperation::ConnectExplicitLocal
     } else {
         GatewayOperation::Connect
     };
-    operations.execute(operation).await
+    operations
+        .execute(operation)
+        .await
+        .map(BootstrapReply::Gateway)
+}
+
+#[derive(Serialize)]
+#[serde(untagged)]
+enum BootstrapReply {
+    Gateway(GatewaySnapshot),
+    Settings {
+        remote: Option<remote_gateway::RemoteSettings>,
+        detail: Option<String>,
+    },
 }
 
 #[tauri::command]
@@ -1321,19 +1753,25 @@ fn main() {
         let error_state = state.clone();
         // Every caller of the operation mutex enters this queue so UI source cannot reorder work.
         app.manage(GatewayOperationQueue::new(
-            move |operation| match operation {
-                GatewayOperation::Connect => operation_state.connect(&operation_app),
+            move |operation, selection| match operation {
+                GatewayOperation::Connect => operation_state.connect(&operation_app, selection),
                 GatewayOperation::ConnectExplicitLocal => {
-                    operation_state.connect_explicit_local(&operation_app)
+                    operation_state.connect_explicit_local(&operation_app, selection)
                 }
                 GatewayOperation::ConnectRemote(request) => {
-                    operation_state.connect_remote(&operation_app, request)
+                    operation_state.connect_remote(&operation_app, request, selection)
+                }
+                GatewayOperation::RetryRemote => {
+                    operation_state.retry_remote(&operation_app, selection)
                 }
                 GatewayOperation::Install(channel) => {
                     operation_state.install_cli(&operation_app, channel)
                 }
                 GatewayOperation::Action(action) => {
                     operation_state.gateway_action(&operation_app, action)
+                }
+                GatewayOperation::RecoverRemote { child_id } => {
+                    operation_state.recover_remote(&operation_app, selection, child_id)
                 }
             },
             move |error| error_state.show_error(&error_app, error),
@@ -1354,6 +1792,7 @@ fn main() {
         app.manage(quickchat_state.clone());
         app.manage(updater::UpdaterState::default());
         state.set_tray(tray::build(app, state.clone(), global_shortcuts_supported)?);
+        state.start_tunnel_monitor(app.handle().clone());
         Ok(())
     });
     let builder = builder.invoke_handler(tauri::generate_handler![
@@ -1417,13 +1856,18 @@ fn main() {
         .build(tauri::generate_context!())
         .expect("OpenClaw desktop app failed");
     app.run(|app, event| {
+        if let tauri::RunEvent::ExitRequested { api, code, .. } = &event {
+            if let Some(state) = app.try_state::<DesktopState>() {
+                if !state.inner.ssh_shutdown_complete.load(Ordering::SeqCst) {
+                    api.prevent_exit();
+                    state.quit_with_code(app, code.unwrap_or(0));
+                }
+            }
+        }
         #[cfg(target_os = "linux")]
         if matches!(event, tauri::RunEvent::Exit) {
             if let Some(bridge) = app.try_state::<gateway_sleep_logind::SleepBridge>() {
                 bridge.shutdown();
-            }
-            if let Some(state) = app.try_state::<DesktopState>() {
-                state.quit();
             }
         }
         #[cfg(not(target_os = "linux"))]

--- a/apps/linux/src-tauri/src/quickchat.rs
+++ b/apps/linux/src-tauri/src/quickchat.rs
@@ -1,11 +1,16 @@
-use crate::gateway_ws::{AgentsListResult, ChatSendResult, GatewayClient};
+use crate::gateway_ws::{
+    AgentsListResult, ChatHistoryPage, ChatSendResult, GatewayClient, GatewayGeneration,
+};
 use crate::quickchat_widgets::QuickChatWidgetState;
 use crate::{tray, DesktopState};
 use serde::Serialize;
+use serde_json::Value;
+use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
 use tauri::{
     AppHandle, Emitter, LogicalSize, Manager, PhysicalPosition, State, Webview, WebviewUrl,
     WebviewWindowBuilder, Window,
@@ -21,6 +26,8 @@ const QUICKCHAT_SHORTCUT_DISABLED_MARKER: &str = "quickchat-shortcut-disabled";
 const QUICKCHAT_WIDTH: f64 = 640.0;
 const QUICKCHAT_HEIGHT: f64 = 92.0;
 const QUICKCHAT_EXPANDED_HEIGHT: f64 = 360.0;
+const RECOVERY_TIMEOUT: Duration = Duration::from_secs(15);
+const RECOVERY_MAX_BYTES: usize = 256 * 1024;
 
 #[derive(Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -54,6 +61,10 @@ struct QuickChatRetryIdentity {
     scope: String,
     main_key: String,
     idempotency_key: String,
+    gateway_generation: GatewayGeneration,
+    attempt: Uuid,
+    terminal: Option<ChatSendResult>,
+    session_id: Option<String>,
 }
 
 pub(crate) struct QuickChatShortcutPreference {
@@ -93,24 +104,27 @@ impl QuickChatState {
         &self.widget_state
     }
 
-    fn send_idempotency_key(
+    fn begin_send(
         &self,
         message: &str,
         agent_id: &str,
         scope: &str,
         main_key: &str,
-    ) -> Result<String, String> {
+        gateway_generation: GatewayGeneration,
+    ) -> Result<QuickChatRetryIdentity, String> {
         let mut retry = self
             .retry_identity
             .lock()
             .map_err(|_| "Quick Chat retry state is unavailable.".to_string())?;
-        if let Some(current) = retry.as_ref() {
+        if let Some(current) = retry.as_mut() {
             if current.message == message
+                && current.gateway_generation == gateway_generation
                 && current.agent_id == agent_id
                 && current.scope == scope
                 && current.main_key == main_key
             {
-                return Ok(current.idempotency_key.clone());
+                current.attempt = Uuid::new_v4();
+                return Ok(current.clone());
             }
         }
         let idempotency_key = Uuid::new_v4().to_string();
@@ -120,28 +134,217 @@ impl QuickChatState {
             scope: scope.to_string(),
             main_key: main_key.to_string(),
             idempotency_key: idempotency_key.clone(),
+            gateway_generation,
+            attempt: Uuid::new_v4(),
+            terminal: None,
+            session_id: None,
         });
-        Ok(idempotency_key)
+        Ok(retry.as_ref().expect("retry initialized").clone())
     }
 
-    fn clear_send_retry(&self, idempotency_key: &str) {
+    fn clear_send_retry(&self, identity: &QuickChatRetryIdentity) {
         if let Ok(mut retry) = self.retry_identity.lock() {
             if retry
                 .as_ref()
-                .is_some_and(|current| current.idempotency_key == idempotency_key)
+                .is_some_and(|current| current.attempt == identity.attempt)
             {
                 *retry = None;
             }
         }
     }
 
+    fn update_retry<T>(
+        &self,
+        identity: &QuickChatRetryIdentity,
+        update: impl FnOnce(&mut QuickChatRetryIdentity) -> Result<T, String>,
+    ) -> Result<T, String> {
+        let mut retry = self
+            .retry_identity
+            .lock()
+            .map_err(|_| "Quick Chat retry state is unavailable.".to_string())?;
+        let current = retry
+            .as_mut()
+            .filter(|current| current.attempt == identity.attempt)
+            .ok_or_else(|| "A newer Quick Chat request replaced this retry.".to_string())?;
+        update(current)
+    }
+
+    async fn send(
+        &self,
+        gateway: &GatewayClient,
+        message: String,
+    ) -> Result<ChatSendResult, String> {
+        let message = message.trim().to_string();
+        if message.is_empty() {
+            return Err("Message cannot be empty.".to_string());
+        }
+        let generation = gateway.generation();
+        let generation = gateway.with_generation(generation, || Ok(generation))?;
+        // Once the server confirms completion, every retry is history-only, even if
+        // its dedupe entry expires or the agent catalog changes during recovery.
+        let terminal_retry = {
+            let mut retry = self
+                .retry_identity
+                .lock()
+                .map_err(|_| "Quick Chat retry state is unavailable.".to_string())?;
+            retry
+                .as_mut()
+                .filter(|current| {
+                    current.gateway_generation == generation
+                        && current.message == message
+                        && current.terminal.is_some()
+                })
+                .map(|current| {
+                    current.attempt = Uuid::new_v4();
+                    current.clone()
+                })
+        };
+        let (identity, mut result) = if let Some(identity) = terminal_retry {
+            let result = identity.terminal.clone().expect("terminal retry");
+            (identity, result)
+        } else {
+            let (agent, catalog) = self.selected_agent(gateway, MissingSelection::Fail).await?;
+            let identity = gateway.with_generation(generation, || {
+                self.begin_send(
+                    &message,
+                    &agent.id,
+                    &catalog.scope,
+                    &catalog.main_key,
+                    generation,
+                )
+            })?;
+            let result = gateway
+                .chat_send(
+                    message,
+                    &identity.agent_id,
+                    &identity.scope,
+                    &identity.main_key,
+                    &identity.idempotency_key,
+                    identity.gateway_generation,
+                )
+                .await?;
+            gateway.with_generation(generation, || {
+                if result.gateway_generation != generation
+                    || result.run_id != identity.idempotency_key
+                {
+                    return Err("Gateway acknowledged a different Quick Chat request.".to_string());
+                }
+                if result.status == "ok" {
+                    self.update_retry(&identity, |current| {
+                        current.terminal = Some(result.clone());
+                        Ok(())
+                    })?;
+                }
+                Ok(())
+            })?;
+            (identity, result)
+        };
+        if result.status == "ok" {
+            let deadline = Instant::now() + RECOVERY_TIMEOUT;
+            let recovered = tokio::time::timeout(
+                RECOVERY_TIMEOUT, self.recover_reply(gateway, &identity, &result, deadline),
+            ).await.map_err(|_| "Reply recovery timed out.".to_string())
+                .and_then(|result| result)
+                .map_err(|error| format!(
+                    "The message completed, but its reply could not be recovered. Retry to load the reply without sending again. {error}"
+                ))?;
+            result.recovered_messages = Some(recovered);
+        }
+        gateway.with_generation(generation, || {
+            self.update_retry(&identity, |_| Ok(()))?;
+            self.clear_send_retry(&identity);
+            Ok(result)
+        })
+    }
+
+    async fn recover_reply(
+        &self,
+        gateway: &GatewayClient,
+        identity: &QuickChatRetryIdentity,
+        result: &ChatSendResult,
+        deadline: Instant,
+    ) -> Result<Vec<Value>, String> {
+        let mut offset = None;
+        let mut messages = Vec::new();
+        let mut accepted_bytes = 0;
+        let mut snapshot = None;
+        for _ in 0..2 {
+            let page = gateway
+                .chat_history(
+                    &result.target,
+                    identity.gateway_generation,
+                    offset,
+                    deadline,
+                )
+                .await?;
+            gateway.with_generation(identity.gateway_generation, || {
+                self.update_retry(identity, |current| {
+                    if page.session_key != result.target.session_key || page.session_id.is_empty() {
+                        return Err(
+                            "Gateway history returned a different routing target.".to_string()
+                        );
+                    }
+                    if current
+                        .session_id
+                        .as_ref()
+                        .is_some_and(|id| id != &page.session_id)
+                    {
+                        return Err(
+                            "The physical session changed during reply recovery.".to_string()
+                        );
+                    }
+                    current.session_id = Some(page.session_id.clone());
+                    Ok(())
+                })
+            })?;
+            let bytes = serde_json::to_vec(&page.messages)
+                .map_err(|_| "Gateway history could not be read.".to_string())?
+                .len();
+            accepted_bytes += bytes;
+            if page.messages.len() > 200 || accepted_bytes > RECOVERY_MAX_BYTES {
+                return Err("Gateway history exceeded the Quick Chat recovery limit.".to_string());
+            }
+            let bounds = recovery_page_bounds(&page, offset)?;
+            let current_snapshot = (bounds.source.clone(), bounds.total);
+            if snapshot
+                .as_ref()
+                .is_some_and(|previous| previous != &current_snapshot)
+            {
+                return Err("Gateway history changed during reply recovery.".to_string());
+            }
+            snapshot = Some(current_snapshot);
+            let next_offset = page.next_offset;
+            let has_more = page.has_more == Some(true);
+            let mut older = page.messages;
+            older.append(&mut messages);
+            messages = older;
+            if let Some(recovered) = recovered_reply_messages(&messages, &identity.idempotency_key)?
+            {
+                return Ok(recovered);
+            }
+            if !has_more {
+                break;
+            }
+            // A replay cursor means the oldest raw record lost projected siblings.
+            // Do not join two partial views and infer that all commentary was recovered.
+            if !bounds.oldest_complete {
+                return Err(
+                    "Gateway history split a reply record at the page boundary.".to_string()
+                );
+            }
+            offset = next_offset;
+        }
+        Err("The exact user turn and completed reply were not found within the bounded history window.".to_string())
+    }
+
     async fn agent_catalog(
         &self,
         gateway: &GatewayClient,
     ) -> Result<(AgentsListResult, Vec<QuickChatAgent>), String> {
+        let generation = gateway.generation();
         let catalog = gateway.agents_list().await?;
         let agents = build_agents(&catalog)?;
-        {
+        gateway.with_generation(generation, || {
             let mut selection = self
                 .selected_agent_id
                 .lock()
@@ -152,7 +355,8 @@ impl QuickChatState {
             {
                 *selection = None;
             }
-        }
+            Ok(())
+        })?;
         Ok((catalog, agents))
     }
 
@@ -183,21 +387,37 @@ impl QuickChatState {
         agent_id: &str,
     ) -> Result<QuickChatAgent, String> {
         let agent_id = agent_id.trim();
+        let generation = gateway.generation();
         let agents = self.agents(gateway).await?;
         let selected = agents
             .iter()
             .find(|agent| agent.id == agent_id)
             .cloned()
             .ok_or_else(|| format!("Unknown Quick Chat agent \"{agent_id}\"."))?;
-        *self
-            .selected_agent_id
-            .lock()
-            .map_err(|_| "Quick Chat agent selection is unavailable.".to_string())? =
-            if selected.is_default {
+        gateway.with_generation(generation, || {
+            let mut selection = self
+                .selected_agent_id
+                .lock()
+                .map_err(|_| "Quick Chat agent selection is unavailable.".to_string())?;
+            let mut retry = self
+                .retry_identity
+                .lock()
+                .map_err(|_| "Quick Chat retry state is unavailable.".to_string())?;
+            // Explicitly changing agents also invalidates a pending ACK's retry identity.
+            // Passive catalog changes and selecting the same resolved agent retain it.
+            if retry
+                .as_ref()
+                .is_some_and(|current| current.agent_id != selected.id)
+            {
+                *retry = None;
+            }
+            *selection = if selected.is_default {
                 None
             } else {
                 Some(selected.id.clone())
             };
+            Ok(())
+        })?;
         Ok(selected)
     }
 
@@ -259,6 +479,252 @@ impl QuickChatState {
 enum MissingSelection {
     FallBackToDefault,
     Fail,
+}
+
+struct RecoveryPosition<'a> {
+    id: &'a str,
+    source: &'a str,
+    seq: u64,
+    raw_seq: u64,
+}
+
+fn recovery_position(message: &Value) -> Result<RecoveryPosition<'_>, String> {
+    let metadata = &message["__openclaw"];
+    let position = &metadata["transcriptPosition"];
+    let id = metadata["id"].as_str().filter(|id| !id.is_empty());
+    let source = position["source"]
+        .as_str()
+        .filter(|source| !source.is_empty() && source.len() <= 128);
+    let seq = metadata["seq"].as_u64().filter(|seq| *seq > 0);
+    match (id, source, seq, position["rawSeq"].as_u64()) {
+        (Some(id), Some(source), Some(seq), Some(raw_seq)) => Ok(RecoveryPosition {
+            id,
+            source,
+            seq,
+            raw_seq,
+        }),
+        _ => Err("Gateway history lacks stable transcript identity and order.".to_string()),
+    }
+}
+
+struct RecoveryPageBounds {
+    source: String,
+    total: u64,
+    oldest_complete: bool,
+}
+
+fn recovery_page_bounds(
+    page: &ChatHistoryPage,
+    offset: Option<u64>,
+) -> Result<RecoveryPageBounds, String> {
+    if page.offset != offset && !(offset.is_none() && page.offset == Some(0)) {
+        return Err("Gateway history returned a different page offset.".to_string());
+    }
+    let total = page
+        .total_messages
+        .filter(|total| *total > 0)
+        .ok_or_else(|| "Gateway history lacks bounded pagination metadata.".to_string())?;
+    let newest = total
+        .checked_sub(offset.unwrap_or(0))
+        .ok_or_else(|| "Gateway history returned an invalid page offset.".to_string())?;
+    let mut positions = page
+        .messages
+        .iter()
+        .map(recovery_position)
+        .collect::<Result<Vec<_>, _>>()?;
+    positions.sort_by_key(|position| position.seq);
+    let first = positions
+        .first()
+        .ok_or_else(|| "Gateway history contains no recoverable transcript records.".to_string())?;
+    let source = first.source.to_string();
+    for position in &positions {
+        if position.source != source || position.seq > newest {
+            return Err(
+                "Gateway history changed its transcript source or page window.".to_string(),
+            );
+        }
+    }
+    for pair in positions.windows(2) {
+        let (left, right) = (&pair[0], &pair[1]);
+        if (left.seq == right.seq && (left.id != right.id || left.raw_seq != right.raw_seq))
+            || (left.seq < right.seq && (left.raw_seq >= right.raw_seq || left.id == right.id))
+        {
+            return Err("Gateway history returned conflicting transcript order.".to_string());
+        }
+    }
+    let record_offset = total - first.seq + 1;
+    let oldest_complete = match (page.has_more, page.next_offset) {
+        (Some(false), None) => true,
+        (Some(true), Some(next)) if next > offset.unwrap_or(0) && next < total => {
+            if next != record_offset && next != record_offset - 1 {
+                return Err(
+                    "Gateway history returned an inconsistent continuation offset.".to_string(),
+                );
+            }
+            next == record_offset
+        }
+        _ => return Err("Gateway history pagination did not advance.".to_string()),
+    };
+    Ok(RecoveryPageBounds {
+        source,
+        total,
+        oldest_complete,
+    })
+}
+
+fn recovery_identity_matches(fields: &[Option<&Value>], expected: &str) -> Result<bool, String> {
+    let claims_identity = fields
+        .iter()
+        .flatten()
+        .any(|value| value.as_str() == Some(expected));
+    if claims_identity
+        && fields
+            .iter()
+            .flatten()
+            .any(|value| value.as_str() != Some(expected))
+    {
+        return Err("Gateway history returned conflicting reply identities.".to_string());
+    }
+    Ok(claims_identity)
+}
+
+fn reject_incomplete_history_message(message: &Value) -> Result<(), String> {
+    let placeholder = |text: &str| {
+        text == "[chat.history omitted: message too large]"
+            || text.starts_with("[chat.history unavailable:")
+    };
+    if message["__openclaw"]["truncated"].as_bool() == Some(true)
+        || message["content"].as_str().is_some_and(placeholder)
+        || message["text"].as_str().is_some_and(placeholder)
+        || message["content"].as_array().is_some_and(|blocks| {
+            blocks
+                .iter()
+                .any(|block| block["text"].as_str().is_some_and(placeholder))
+        })
+    {
+        return Err("The completed reply was truncated in Gateway history.".to_string());
+    }
+    Ok(())
+}
+
+fn is_completed_history_reply(message: &Value) -> bool {
+    let transcript_only = (message["provider"] == "openclaw"
+        && message["model"] == "delivery-mirror")
+        || matches!(
+            message["openclawDeliveryMirror"]["kind"].as_str(),
+            Some(
+                "channel-final"
+                    | "channel-final-suppressed"
+                    | "message-tool-source-reply"
+                    | "cron-direct-delivery-context"
+            )
+        );
+    matches!(message["stopReason"].as_str(), Some("stop" | "length"))
+        && !transcript_only
+        && message.get("openclawStreamFallback").is_none()
+        && message.get("openclawAbort").is_none()
+        && !message["content"].as_array().is_some_and(|blocks| {
+            blocks.iter().any(|block| {
+                matches!(
+                    block["type"].as_str(),
+                    Some("toolCall" | "toolUse" | "functionCall")
+                )
+            })
+        })
+}
+
+fn recovered_reply_messages(messages: &[Value], key: &str) -> Result<Option<Vec<Value>>, String> {
+    let mut ordered = messages
+        .iter()
+        .map(|message| recovery_position(message).map(|position| (position, message)))
+        .collect::<Result<Vec<_>, _>>()?;
+    ordered.sort_by_key(|(position, _)| position.raw_seq);
+    let mut anchor: Option<(&RecoveryPosition<'_>, &Value)> = None;
+    let user_key = format!("{key}:user");
+    for (position, message) in &ordered {
+        if message["role"] == "user"
+            && recovery_identity_matches(
+                &[
+                    message.get("idempotencyKey"),
+                    message["__openclaw"].get("idempotencyKey"),
+                ],
+                &user_key,
+            )?
+        {
+            reject_incomplete_history_message(message)?;
+            if anchor.is_some_and(|(previous, value)| {
+                previous.id != position.id
+                    || previous.raw_seq != position.raw_seq
+                    || value != *message
+            }) {
+                return Err("Gateway history returned conflicting user turn anchors.".to_string());
+            }
+            anchor = Some((position, message));
+        }
+    }
+    let mut recovered = Vec::new();
+    let mut identities = HashMap::new();
+    let mut completed = false;
+    for (position, message) in &ordered {
+        if message.get("role").and_then(Value::as_str) != Some("assistant") {
+            continue;
+        }
+        let metadata = message.get("__openclaw");
+        let keys = [
+            metadata.and_then(|meta| meta.get("runId")),
+            metadata.and_then(|meta| meta.get("idempotencyKey")),
+            message.get("idempotencyKey"),
+        ];
+        if !recovery_identity_matches(&keys, key)? {
+            continue;
+        }
+        reject_incomplete_history_message(message)?;
+        let Some((anchor, _)) = anchor else { continue };
+        if position.source != anchor.source {
+            return Err("Gateway history changed during reply recovery.".to_string());
+        }
+        if position.raw_seq <= anchor.raw_seq {
+            continue;
+        }
+        if message.get("stopReason").and_then(Value::as_str) == Some("error") {
+            return Err("Gateway history contains a failed reply.".to_string());
+        }
+        {
+            // A projected commentary item and the final row can share the transcript ID.
+            let item = message
+                .get("openclawStreamFallback")
+                .and_then(|fallback| fallback.get("itemId"))
+                .and_then(Value::as_str);
+            let identity = (position.id.to_string(), item.map(str::to_string));
+            if let Some(previous) = identities.insert(identity, message) {
+                if previous != message {
+                    return Err("Gateway history returned conflicting reply records.".to_string());
+                }
+                continue;
+            }
+        }
+        let content = message.get("content");
+        let presentable = content
+            .and_then(Value::as_str)
+            .is_some_and(|text| !text.is_empty())
+            || message
+                .get("text")
+                .and_then(Value::as_str)
+                .is_some_and(|text| !text.is_empty())
+            || content.and_then(Value::as_array).is_some_and(|blocks| {
+                blocks.iter().any(|block| {
+                    matches!(
+                        block.get("type").and_then(Value::as_str),
+                        Some("text" | "canvas")
+                    )
+                })
+            });
+        if presentable {
+            completed = is_completed_history_reply(message);
+            recovered.push((*message).clone());
+        }
+    }
+    Ok((completed && !recovered.is_empty()).then_some(recovered))
 }
 
 fn resolve_selected_agent(
@@ -631,29 +1097,7 @@ pub async fn quickchat_send(
     message: String,
 ) -> Result<ChatSendResult, String> {
     require_quickchat_webview(&webview)?;
-    let message = message.trim().to_string();
-    if message.is_empty() {
-        return Err("Message cannot be empty.".to_string());
-    }
-    // Strict resolution: a vanished pin fails instead of silently rerouting to default.
-    let (agent, catalog) = state
-        .selected_agent(gateway.inner(), MissingSelection::Fail)
-        .await?;
-    let idempotency_key =
-        state.send_idempotency_key(&message, &agent.id, &catalog.scope, &catalog.main_key)?;
-    let result = gateway
-        .chat_send(
-            message,
-            &agent.id,
-            &catalog.scope,
-            &catalog.main_key,
-            &idempotency_key,
-        )
-        .await;
-    if result.is_ok() {
-        state.clear_send_retry(&idempotency_key);
-    }
-    result
+    state.send(gateway.inner(), message).await
 }
 
 #[tauri::command]
@@ -822,7 +1266,900 @@ pub fn quickchat_show_dashboard(webview: Webview, app: AppHandle) -> Result<(), 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::gateway_ws::tests::RpcFixture;
+    use serde_json::json;
     use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn start_send(
+        state: &QuickChatState,
+        fixture: &RpcFixture,
+        message: &str,
+    ) -> tokio::task::JoinHandle<Result<ChatSendResult, String>> {
+        let state = state.clone();
+        let gateway = fixture.client.clone();
+        let message = message.to_string();
+        tokio::spawn(async move { state.send(&gateway, message).await })
+    }
+
+    async fn answer_catalog(fixture: &mut RpcFixture) {
+        fixture
+            .request("agents.list")
+            .await
+            .1
+            .send(Ok(json!({
+                "defaultId": "work", "mainKey": "main", "scope": "global",
+                "agents": [{"id": "work", "name": "Work"}],
+            })))
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn catalog_completion_cannot_relabel_a_draft_after_route_replacement() {
+        for replacements in [1, 2] {
+            let mut fixture = RpcFixture::new().await;
+            let state = QuickChatState::new(true);
+            let sending = start_send(&state, &fixture, "original draft");
+            let (_, reply) = fixture.request("agents.list").await;
+            for _ in 0..replacements {
+                fixture.replace_route();
+            }
+            reply
+                .send(Ok(json!({
+                    "defaultId": "work", "mainKey": "main", "scope": "global",
+                    "agents": [{"id": "work"}],
+                })))
+                .unwrap();
+            assert!(sending.await.unwrap().is_err());
+            fixture.no_request().await;
+            assert!(fixture.chat_frames().is_empty());
+        }
+    }
+
+    #[tokio::test]
+    async fn reconnect_without_reconfiguration_retains_the_failed_draft_key() {
+        let mut fixture = RpcFixture::new().await;
+        let state = QuickChatState::new(true);
+        let owner = fixture.client.generation();
+        let first = start_send(&state, &fixture, "same draft");
+        answer_catalog(&mut fixture).await;
+        let (request, reply) = fixture.request("chat.send").await;
+        let key = request["params"]["idempotencyKey"].clone();
+        drop(reply); // Close the real fixture transport without acknowledging this send.
+        assert!(first.await.unwrap().is_err());
+        fixture.reconnect().await;
+        assert_eq!(fixture.client.generation(), owner);
+        let retry = start_send(&state, &fixture, "same draft");
+        answer_catalog(&mut fixture).await;
+        let (request, reply) = fixture.request("chat.send").await;
+        assert_eq!(request["params"]["idempotencyKey"], key);
+        reply
+            .send(Ok(json!({"runId": key, "status": "in_flight"})))
+            .unwrap();
+        assert!(retry.await.unwrap().is_ok());
+        fixture.no_request().await;
+        assert_eq!(fixture.chat_frames().len(), 2);
+    }
+
+    #[tokio::test]
+    async fn old_history_completion_cannot_clear_a_newer_failed_draft() {
+        let mut fixture = RpcFixture::new().await;
+        let state = QuickChatState::new(true);
+        let first = start_send(&state, &fixture, "first draft");
+        answer_catalog(&mut fixture).await;
+        let (request, reply) = fixture.request("chat.send").await;
+        let first_key = request["params"]["idempotencyKey"].clone();
+        reply
+            .send(Ok(json!({"runId": first_key, "status": "ok"})))
+            .unwrap();
+        let (_, history) = fixture.request("chat.history").await;
+        let newer = start_send(&state, &fixture, "newer draft");
+        fixture.wait_until_queued().await;
+        history
+            .send(Ok(history_page(
+                json!([{
+                    "role": "assistant", "content": "old answer", "idempotencyKey": first_key,
+                }]),
+                "physical",
+                false,
+                None,
+            )))
+            .unwrap();
+        assert!(first
+            .await
+            .unwrap()
+            .unwrap_err()
+            .contains("newer Quick Chat request"));
+        let (request, reply) = fixture.request("chat.send").await;
+        let newer_key = request["params"]["idempotencyKey"].clone();
+        reply.send(Err("second ACK unavailable".into())).unwrap();
+        assert!(newer.await.unwrap().is_err());
+        let retry = start_send(&state, &fixture, "newer draft");
+        let (request, reply) = fixture.request("chat.send").await;
+        assert_eq!(request["params"]["idempotencyKey"], newer_key);
+        reply
+            .send(Ok(json!({"runId": newer_key, "status": "started"})))
+            .unwrap();
+        assert!(retry.await.unwrap().is_ok());
+        fixture.no_request().await;
+    }
+
+    fn history_page(messages: Value, session: &str, more: bool, next: Option<u64>) -> Value {
+        json!({
+            "sessionKey": "global", "sessionId": session, "messages": messages,
+            "hasMore": more, "nextOffset": next, "totalMessages": 1000,
+        })
+    }
+
+    fn history_record(mut message: Value, seq: u64) -> Value {
+        if message["__openclaw"]["id"].is_null() {
+            message["__openclaw"]["id"] = json!(format!("row-{seq}"));
+        }
+        message["__openclaw"]["seq"] = json!(seq);
+        message["__openclaw"]["transcriptPosition"] =
+            json!({"source": "transcript-generation-1", "rawSeq": seq * 2});
+        message
+    }
+
+    fn history_anchor(key: &str, seq: u64) -> Value {
+        history_record(
+            json!({
+                "role": "user", "content": "hello", "idempotencyKey": format!("{key}:user"),
+                "__openclaw": {"idempotencyKey": format!("{key}:user")},
+            }),
+            seq,
+        )
+    }
+
+    fn history_reply(key: &str, seq: u64, text: &str) -> Value {
+        history_record(
+            json!({
+                "role": "assistant", "content": text, "stopReason": "stop",
+                "__openclaw": {"runId": key},
+            }),
+            seq,
+        )
+    }
+
+    #[tokio::test]
+    async fn terminal_retries_recover_exact_history_without_resending() {
+        let mut fixture = RpcFixture::new().await;
+        let state = QuickChatState::new(true);
+        let first = start_send(&state, &fixture, "hello");
+        answer_catalog(&mut fixture).await;
+        let (request, reply) = fixture.request("chat.send").await;
+        let key = request["params"]["idempotencyKey"]
+            .as_str()
+            .unwrap()
+            .to_string();
+        reply.send(Err("ACK unavailable".to_string())).unwrap();
+        assert!(first.await.unwrap().is_err());
+
+        let retry = start_send(&state, &fixture, "hello");
+        let (request, reply) = fixture.request("chat.send").await;
+        assert_eq!(request["params"]["idempotencyKey"], key);
+        reply
+            .send(Ok(json!({"runId": key, "status": "ok"})))
+            .unwrap();
+        let (request, reply) = fixture.request("chat.history").await;
+        assert_eq!(
+            request["params"],
+            json!({
+                "sessionKey": "global", "agentId": "work",
+                "limit": 200, "maxBytes": 262144, "maxChars": 65536,
+            })
+        );
+        reply
+            .send(Ok(history_page(
+                json!([history_record(
+                    json!({
+                        "role": "assistant", "content": "partial",
+                        "__openclaw": {"runId": key, "truncated": true, "reason": "display-cap"},
+                    }),
+                    999
+                )]),
+                "physical-a",
+                false,
+                None,
+            )))
+            .unwrap();
+        assert!(retry.await.unwrap().unwrap_err().contains("truncated"));
+
+        let retry = start_send(&state, &fixture, "hello");
+        let (_, reply) = fixture.request("chat.history").await;
+        reply
+            .send(Ok(history_page(
+                json!([{
+                    "role": "assistant", "content": "wrong physical session",
+                    "idempotencyKey": key,
+                }]),
+                "physical-b",
+                false,
+                None,
+            )))
+            .unwrap();
+        assert!(retry
+            .await
+            .unwrap()
+            .unwrap_err()
+            .contains("physical session changed"));
+
+        let retry = start_send(&state, &fixture, "hello");
+        let (_, reply) = fixture.request("chat.history").await;
+        reply
+            .send(Err("unknown method chat.history".to_string()))
+            .unwrap();
+        assert!(retry
+            .await
+            .unwrap()
+            .unwrap_err()
+            .contains("without sending again"));
+        // A method-level recovery failure must not mark the connection broken.
+        assert!(fixture.client.agents_list().await.is_ok());
+
+        let retry = start_send(&state, &fixture, "hello");
+        let (_, reply) = fixture.request("chat.history").await;
+        let final_message = history_record(
+            json!({
+                "role": "assistant", "content": [{"type": "text", "text": "Final answer"}],
+                "stopReason": "stop",
+                "__openclaw": {"id": "row-final", "idempotencyKey": key},
+            }),
+            984,
+        );
+        reply
+            .send(Ok(history_page(
+                json!([final_message]),
+                "physical-a",
+                true,
+                Some(17),
+            )))
+            .unwrap();
+        let (request, reply) = fixture.request("chat.history").await;
+        assert_eq!(request["params"]["offset"], 17);
+        assert!(request["params"].get("sessionId").is_none());
+        assert!(request["params"].get("cursor").is_none());
+        let mut older = history_page(
+            json!([
+                history_reply("other", 980, "Not this run"),
+                history_anchor(&key, 981),
+                history_record(
+                    json!({
+                        "role": "assistant", "content": "Commentary", "__openclaw": {"runId": key},
+                        "openclawStreamFallback": {"source": "segment", "itemId": "commentary-1"},
+                    }),
+                    983
+                ),
+            ]),
+            "physical-a",
+            true,
+            Some(21),
+        );
+        older["offset"] = json!(17);
+        reply.send(Ok(older)).unwrap();
+        let recovered = retry.await.unwrap().unwrap().recovered_messages.unwrap();
+        assert_eq!(recovered.len(), 2);
+        assert_eq!(recovered[0]["content"], "Commentary");
+        assert_eq!(recovered[1]["content"][0]["text"], "Final answer");
+        fixture.no_request().await;
+        // Completion clears only this attempt; an intentional new turn gets a fresh key.
+        let next = start_send(&state, &fixture, "hello");
+        let (request, reply) = fixture.request("chat.send").await;
+        let next_key = request["params"]["idempotencyKey"].as_str().unwrap();
+        assert_ne!(next_key, key);
+        reply
+            .send(Ok(json!({"runId": next_key, "status": "started"})))
+            .unwrap();
+        assert!(next.await.unwrap().is_ok());
+    }
+
+    #[tokio::test]
+    async fn explicit_agent_selection_owns_retry_invalidation() {
+        #[derive(Clone, Copy, Debug)]
+        enum Selection {
+            SameAgent,
+            UnknownAgent,
+            PassiveCatalog,
+            SameAgentBecomesDefault,
+            DifferentAgent,
+            PendingAck,
+            PendingHistory,
+        }
+        for selection in [
+            Selection::SameAgent,
+            Selection::UnknownAgent,
+            Selection::PassiveCatalog,
+            Selection::SameAgentBecomesDefault,
+            Selection::DifferentAgent,
+            Selection::PendingAck,
+            Selection::PendingHistory,
+        ] {
+            let mut fixture = RpcFixture::new().await;
+            let state = QuickChatState::new(true);
+            let selecting = {
+                let state = state.clone();
+                let gateway = fixture.client.clone();
+                tokio::spawn(async move { state.select_agent(&gateway, "work").await })
+            };
+            fixture
+                .request("agents.list")
+                .await
+                .1
+                .send(Ok(json!({
+                    "defaultId": "personal", "mainKey": "main", "scope": "global",
+                    "agents": [{"id": "work"}, {"id": "personal"}],
+                })))
+                .unwrap();
+            assert_eq!(selecting.await.unwrap().unwrap().id, "work");
+
+            let mut first = Some(start_send(&state, &fixture, "hello"));
+            let (request, reply) = fixture.request("chat.send").await;
+            assert_eq!(request["params"]["agentId"], "work");
+            let key = request["params"]["idempotencyKey"]
+                .as_str()
+                .unwrap()
+                .to_string();
+            let mut pending = if matches!(selection, Selection::PendingAck) {
+                Some(reply)
+            } else {
+                reply
+                    .send(Ok(json!({"runId": key, "status": "ok"})))
+                    .unwrap();
+                let (_, reply) = fixture.request("chat.history").await;
+                if matches!(selection, Selection::PendingHistory) {
+                    Some(reply)
+                } else {
+                    let mut truncated = history_reply(&key, 3, "partial");
+                    truncated["__openclaw"]["truncated"] = json!(true);
+                    reply
+                        .send(Ok(history_page(
+                            json!([truncated]),
+                            "physical-work",
+                            false,
+                            None,
+                        )))
+                        .unwrap();
+                    assert!(first
+                        .take()
+                        .unwrap()
+                        .await
+                        .unwrap()
+                        .unwrap_err()
+                        .contains("truncated"));
+                    None
+                }
+            };
+
+            match selection {
+                Selection::SameAgent => {
+                    assert_eq!(
+                        state
+                            .select_agent(&fixture.client, "work")
+                            .await
+                            .unwrap()
+                            .id,
+                        "work"
+                    );
+                }
+                Selection::UnknownAgent => {
+                    assert!(state
+                        .select_agent(&fixture.client, "missing")
+                        .await
+                        .err()
+                        .unwrap()
+                        .contains("Unknown Quick Chat agent"));
+                }
+                Selection::PassiveCatalog | Selection::SameAgentBecomesDefault => {
+                    // A reconnect clears the real catalog cache without changing its owner.
+                    let generation = fixture.client.generation();
+                    fixture.reconnect().await;
+                    assert_eq!(fixture.client.generation(), generation);
+                    let refreshing = {
+                        let state = state.clone();
+                        let gateway = fixture.client.clone();
+                        tokio::spawn(async move { state.agents(&gateway).await })
+                    };
+                    fixture
+                        .request("agents.list")
+                        .await
+                        .1
+                        .send(Ok(json!({
+                            "defaultId": "work", "mainKey": "changed", "scope": "per-sender",
+                            "agents": [{"id": "work"}, {"id": "personal"}],
+                        })))
+                        .unwrap();
+                    assert!(refreshing.await.unwrap().is_ok());
+                    if matches!(selection, Selection::SameAgentBecomesDefault) {
+                        let selected = state.select_agent(&fixture.client, "work").await.unwrap();
+                        assert!(selected.is_default);
+                    }
+                }
+                _ => {
+                    assert_eq!(
+                        state
+                            .select_agent(&fixture.client, "personal")
+                            .await
+                            .unwrap()
+                            .id,
+                        "personal"
+                    );
+                }
+            }
+            if matches!(selection, Selection::PendingAck) {
+                pending
+                    .take()
+                    .unwrap()
+                    .send(Ok(json!({"runId": key, "status": "ok"})))
+                    .unwrap();
+                let mut first = first.take().unwrap();
+                // B must not replace A's retry before the selection invalidation is tested.
+                let result = tokio::select! {
+                    result = &mut first => result.unwrap(),
+                    _ = fixture.request("chat.history") => {
+                        panic!("an invalidated A ACK must not request history");
+                    }
+                };
+                assert!(result.unwrap_err().contains("newer Quick Chat request"));
+                fixture.no_request().await;
+            }
+            let retry = start_send(&state, &fixture, "hello");
+            if let Some(reply) = pending {
+                fixture.wait_until_queued().await;
+                reply
+                    .send(Ok(history_page(
+                        json!([history_anchor(&key, 1), history_reply(&key, 3, "A reply")]),
+                        "physical-work",
+                        false,
+                        None,
+                    )))
+                    .unwrap();
+                assert!(first
+                    .take()
+                    .unwrap()
+                    .await
+                    .unwrap()
+                    .unwrap_err()
+                    .contains("newer Quick Chat request"));
+            }
+            if matches!(
+                selection,
+                Selection::DifferentAgent | Selection::PendingAck | Selection::PendingHistory
+            ) {
+                let (request, reply) = fixture.request("chat.send").await;
+                assert_eq!(request["params"]["agentId"], "personal");
+                let new_key = request["params"]["idempotencyKey"]
+                    .as_str()
+                    .unwrap()
+                    .to_string();
+                assert_ne!(new_key, key);
+                reply.send(Err("B ACK unavailable".into())).unwrap();
+                assert!(retry.await.unwrap().is_err());
+                let retry = start_send(&state, &fixture, "hello");
+                let (request, reply) = fixture.request("chat.send").await;
+                assert_eq!(request["params"]["agentId"], "personal");
+                assert_eq!(request["params"]["idempotencyKey"], new_key);
+                reply
+                    .send(Ok(json!({"runId": new_key, "status": "started"})))
+                    .unwrap();
+                assert!(retry.await.unwrap().is_ok());
+                fixture.no_request().await;
+                assert_eq!(fixture.chat_frames().len(), 3);
+            } else {
+                let (request, reply) = fixture.request("chat.history").await;
+                assert_eq!(request["params"]["agentId"], "work");
+                assert_eq!(request["params"]["sessionKey"], "global");
+                reply
+                    .send(Ok(history_page(
+                        json!([history_anchor(&key, 1), history_reply(&key, 3, "A reply")]),
+                        "physical-work",
+                        false,
+                        None,
+                    )))
+                    .unwrap();
+                let recovered = retry.await.unwrap().unwrap();
+                assert_eq!(recovered.run_id, key);
+                assert_eq!(recovered.target.agent_id.as_deref(), Some("work"));
+                assert_eq!(
+                    recovered.recovered_messages.unwrap()[0]["content"],
+                    "A reply"
+                );
+                fixture.no_request().await;
+                assert_eq!(fixture.chat_frames().len(), 1);
+            }
+            eprintln!("explicit selection control passed: {selection:?}");
+        }
+    }
+
+    #[test]
+    fn history_identity_rejects_conflicts_and_preserves_distinct_commentary() {
+        let key = "exact-run";
+        for identity in [
+            json!({"__openclaw": {"runId": key}}),
+            json!({"__openclaw": {"idempotencyKey": key}}),
+            json!({"idempotencyKey": key}),
+        ] {
+            let mut message = identity;
+            message["role"] = json!("assistant");
+            message["content"] = json!("answer");
+            message["stopReason"] = json!("stop");
+            assert_eq!(
+                recovered_reply_messages(
+                    &[history_anchor(key, 1), history_record(message, 3)],
+                    key
+                )
+                .unwrap()
+                .unwrap()
+                .len(),
+                1
+            );
+        }
+        for identity in [
+            json!({"__openclaw": {"runId": key, "idempotencyKey": "different"}}),
+            json!({"__openclaw": {"runId": key}, "idempotencyKey": "different"}),
+            json!({"__openclaw": {"runId": format!("{key}:user")}}),
+            json!({"__openclaw": {"id": key}}),
+            json!({"idempotencyKey": format!(" {key} ")}),
+        ] {
+            let mut message = identity;
+            message["role"] = json!("assistant");
+            message["content"] = json!("must not recover");
+            let result = recovered_reply_messages(
+                &[history_anchor(key, 1), history_record(message, 3)],
+                key,
+            );
+            assert!(result.is_err() || result.unwrap().is_none());
+        }
+        let mut messages = vec![history_anchor(key, 1)];
+        for (id, item, seq) in [
+            ("same", Some("a"), 3),
+            ("same", Some("b"), 3),
+            ("same", None, 3),
+            ("distinct", None, 5),
+        ] {
+            let mut message = history_record(
+                json!({
+                    "role": "assistant", "content": "equal text",
+                    "__openclaw": {"id": id, "runId": key},
+                }),
+                seq,
+            );
+            if let Some(item) = item {
+                message["openclawStreamFallback"] = json!({"itemId": item, "source": "segment"});
+            } else {
+                message["stopReason"] = json!("stop");
+            }
+            messages.push(message);
+        }
+        messages.push(messages[1].clone());
+        assert_eq!(
+            recovered_reply_messages(&messages, key)
+                .unwrap()
+                .unwrap()
+                .len(),
+            4
+        );
+        messages[5]["content"] = json!("conflicting overlap");
+        assert!(recovered_reply_messages(&messages, key)
+            .unwrap_err()
+            .contains("conflicting"));
+        for reason in ["display-cap", "oversized"] {
+            assert!(recovered_reply_messages(&[history_anchor(key, 1), history_record(json!({
+                "role": "assistant", "content": "[chat.history omitted: message too large]",
+                "__openclaw": {"idempotencyKey": key, "truncated": true, "reason": reason},
+            }), 3)], key).unwrap_err().contains("truncated"));
+        }
+    }
+
+    async fn assert_anchor_recovery_case(case: &str) {
+        let mut fixture = RpcFixture::new().await;
+        let state = QuickChatState::new(true);
+        let mut send = start_send(&state, &fixture, "hello");
+        answer_catalog(&mut fixture).await;
+        let (request, reply) = fixture.request("chat.send").await;
+        let key = request["params"]["idempotencyKey"]
+            .as_str()
+            .unwrap()
+            .to_string();
+        reply
+            .send(Ok(json!({"runId": key, "status": "ok"})))
+            .unwrap();
+        let (_, reply) = fixture.request("chat.history").await;
+        let anchor = history_anchor(&key, 995);
+        let mut final_message = history_reply(&key, 997, "Saved answer");
+        if case.starts_with("injected") {
+            final_message = history_record(
+                json!({
+                    "role": "assistant", "content": [{"type": "text", "text": "Saved answer"}],
+                    "api": "openai-responses", "provider": "openclaw", "model": "gateway-injected",
+                    "stopReason": "stop", "idempotencyKey": key,
+                    "__openclaw": {"idempotencyKey": key},
+                }),
+                997,
+            );
+            assert!(final_message["__openclaw"].get("runId").is_none());
+        }
+        let commentary = history_record(
+            json!({
+                "role": "assistant", "content": "Commentary", "__openclaw": {"runId": key},
+                "openclawStreamFallback": {"source": "segment", "itemId": "commentary-a"},
+            }),
+            996,
+        );
+        let joined = matches!(
+            case,
+            "two-page" | "source-drift" | "total-drift" | "offset-drift"
+        );
+        let mut messages = vec![anchor.clone(), commentary.clone(), final_message.clone()];
+        match case {
+            "length" => messages[2]["stopReason"] = json!("length"),
+            "missing-anchor" => {
+                messages[0]["idempotencyKey"] = json!("unrelated:user");
+                messages[0]["__openclaw"]["idempotencyKey"] = json!("unrelated:user");
+            }
+            "late-media" => {
+                messages[0]["idempotencyKey"] = json!(format!("{key}:user:late-media"));
+                messages[0]["__openclaw"]["idempotencyKey"] =
+                    json!(format!("{key}:user:late-media"));
+            }
+            "user-run-id" => {
+                messages[0]
+                    .as_object_mut()
+                    .unwrap()
+                    .remove("idempotencyKey");
+                messages[0]["__openclaw"]
+                    .as_object_mut()
+                    .unwrap()
+                    .remove("idempotencyKey");
+                messages[0]["__openclaw"]["runId"] = json!(key);
+            }
+            "anchor-conflict" => messages[0]["idempotencyKey"] = json!("different:user"),
+            "assistant-conflict" => messages[1]["idempotencyKey"] = json!("different"),
+            "commentary-only" => {
+                messages[2].as_object_mut().unwrap().remove("stopReason");
+                messages[2]["openclawStreamFallback"] =
+                    json!({"source": "segment", "itemId": "last"});
+            }
+            "transcript-only" => {
+                messages[2]["provider"] = json!("openclaw");
+                messages[2]["model"] = json!("delivery-mirror");
+            }
+            "wrong-final" => messages[2]["__openclaw"]["runId"] = json!("other"),
+            "before-anchor" => {
+                messages = vec![
+                    history_reply(&key, 990, "Before this user turn"),
+                    anchor.clone(),
+                ];
+            }
+            "anchor-truncated" => messages[0]["__openclaw"]["truncated"] = json!(true),
+            "reply-truncated" => messages[2]["__openclaw"]["truncated"] = json!(true),
+            "placeholder" => {
+                messages[2]["content"] = json!("[chat.history omitted: message too large]");
+            }
+            "missing-position" => {
+                messages[0]["__openclaw"]
+                    .as_object_mut()
+                    .unwrap()
+                    .remove("transcriptPosition");
+            }
+            "injected-aborted" => messages[2]["stopReason"] = json!("aborted"),
+            "injected-abort-marker" => messages[2]["openclawAbort"] = json!({"aborted": true}),
+            "injected-commentary" => {
+                messages[2]["openclawStreamFallback"] =
+                    json!({"source": "segment", "itemId": "injected-commentary"});
+            }
+            "injected-tool" => {
+                messages[2]["content"].as_array_mut().unwrap().push(json!({
+                    "type": "toolCall", "id": "fixture-tool", "name": "fixture", "arguments": {},
+                }));
+            }
+            "injected-wrong-key" => {
+                messages[2]["idempotencyKey"] = json!("other-run");
+                messages[2]["__openclaw"]["idempotencyKey"] = json!("other-run");
+            }
+            "injected-provenance" => {
+                messages[2]["openclawDeliveryMirror"] = json!({"kind": "channel-final"});
+            }
+            _ => {}
+        }
+        if joined || case == "split" {
+            messages = vec![final_message.clone()];
+        }
+        let success = matches!(case, "recent" | "length" | "two-page" | "injected");
+        let mut page = history_page(
+            json!(messages),
+            "physical",
+            success || joined || case == "split",
+            if joined {
+                Some(4)
+            } else if case == "split" {
+                Some(3)
+            } else if success {
+                Some(6)
+            } else {
+                None
+            },
+        );
+        if case == "split" {
+            // The server asks to replay seq 997: this tail is only part of that record.
+            page["nextOffset"] = json!(3);
+        }
+        reply.send(Ok(page)).unwrap();
+        if joined {
+            let (request, reply) = fixture.request("chat.history").await;
+            assert_eq!(request["params"]["offset"], 4, "{case}");
+            let mut older = history_page(json!([anchor, commentary]), "physical", true, Some(6));
+            older["offset"] = json!(4);
+            match case {
+                "source-drift" => {
+                    for message in older["messages"].as_array_mut().unwrap() {
+                        message["__openclaw"]["transcriptPosition"]["source"] =
+                            json!("transcript-generation-2");
+                    }
+                }
+                "total-drift" => older["totalMessages"] = json!(1001),
+                "offset-drift" => older["offset"] = json!(5),
+                _ => {}
+            }
+            reply.send(Ok(older)).unwrap();
+        }
+        let result = tokio::select! {
+            result = &mut send => result.unwrap(),
+            _ = fixture.request("chat.history"), if success && !joined => {
+                panic!("{case}: a complete recent turn must not request older history");
+            }
+        };
+        if success {
+            let recovered = result
+                .unwrap_or_else(|error| panic!("{case}: {error}"))
+                .recovered_messages
+                .unwrap();
+            assert_eq!(recovered.len(), 2, "{case}");
+            assert_eq!(recovered[0]["content"], "Commentary", "{case}");
+            let content = &recovered[1]["content"];
+            assert_eq!(
+                content.as_str().or_else(|| content[0]["text"].as_str()),
+                Some("Saved answer"),
+                "{case}"
+            );
+        } else {
+            assert!(
+                result.unwrap_err().contains("without sending again"),
+                "{case}"
+            );
+            // Even a rejected window remains terminal: retry must only load history.
+            let retry = start_send(&state, &fixture, "hello");
+            let (_, reply) = fixture.request("chat.history").await;
+            final_message["content"] = json!("Recovered on history-only retry");
+            reply
+                .send(Ok(history_page(
+                    json!([history_anchor(&key, 995), final_message,]),
+                    "physical",
+                    true,
+                    Some(6),
+                )))
+                .unwrap();
+            assert!(retry.await.unwrap().is_ok(), "{case}");
+        }
+        fixture.no_request().await;
+        assert_eq!(fixture.chat_frames().len(), 1, "{case}");
+    }
+
+    #[tokio::test]
+    async fn anchored_history_recovers_recent_turns_without_exhausting_the_session() {
+        for case in ["recent", "length", "two-page", "injected"] {
+            assert_anchor_recovery_case(case).await;
+        }
+    }
+
+    #[tokio::test]
+    async fn anchored_history_rejects_incomplete_windows_without_resending() {
+        for case in [
+            "missing-anchor",
+            "late-media",
+            "user-run-id",
+            "anchor-conflict",
+            "assistant-conflict",
+            "commentary-only",
+            "transcript-only",
+            "wrong-final",
+            "before-anchor",
+            "split",
+            "anchor-truncated",
+            "reply-truncated",
+            "placeholder",
+            "source-drift",
+            "total-drift",
+            "offset-drift",
+            "missing-position",
+            "injected-aborted",
+            "injected-abort-marker",
+            "injected-commentary",
+            "injected-tool",
+            "injected-wrong-key",
+            "injected-provenance",
+        ] {
+            assert_anchor_recovery_case(case).await;
+        }
+    }
+
+    #[tokio::test]
+    async fn mismatched_ack_does_not_mark_the_draft_terminal() {
+        let mut fixture = RpcFixture::new().await;
+        let state = QuickChatState::new(true);
+        let first = start_send(&state, &fixture, "hello");
+        answer_catalog(&mut fixture).await;
+        let (request, reply) = fixture.request("chat.send").await;
+        let key = request["params"]["idempotencyKey"].clone();
+        reply
+            .send(Ok(json!({"runId": "different-run", "status": "ok"})))
+            .unwrap();
+        assert!(first.await.unwrap().unwrap_err().contains("different"));
+        let retry = start_send(&state, &fixture, "hello");
+        let (request, reply) = fixture.request("chat.send").await;
+        assert_eq!(request["params"]["idempotencyKey"], key);
+        reply
+            .send(Ok(json!({"runId": key, "status": "started"})))
+            .unwrap();
+        assert!(retry.await.unwrap().is_ok());
+        fixture.no_request().await;
+    }
+
+    #[tokio::test]
+    async fn history_recovery_rejects_oversized_and_partial_pages() {
+        for case in ["bytes", "count", "nonadvancing", "partial"] {
+            let mut fixture = RpcFixture::new().await;
+            let state = QuickChatState::new(true);
+            let send = start_send(&state, &fixture, "hello");
+            answer_catalog(&mut fixture).await;
+            let (request, reply) = fixture.request("chat.send").await;
+            let key = request["params"]["idempotencyKey"].clone();
+            reply
+                .send(Ok(json!({"runId": key, "status": "ok"})))
+                .unwrap();
+            let (_, reply) = fixture.request("chat.history").await;
+            let message = history_record(
+                json!({
+                    "role": "assistant", "content": "partial answer", "__openclaw": {"runId": key},
+                }),
+                1000,
+            );
+            let page = match case {
+                "bytes" => history_page(
+                    json!([{
+                        "role": "assistant", "content": "x".repeat(RECOVERY_MAX_BYTES + 1),
+                        "__openclaw": {"runId": key},
+                    }]),
+                    "physical",
+                    false,
+                    None,
+                ),
+                "count" => history_page(json!(vec![message.clone(); 201]), "physical", false, None),
+                "nonadvancing" => history_page(json!([message.clone()]), "physical", true, Some(0)),
+                "partial" => history_page(json!([message.clone()]), "physical", true, Some(1)),
+                _ => unreachable!(),
+            };
+            reply.send(Ok(page)).unwrap();
+            if case == "partial" {
+                let (request, reply) = fixture.request("chat.history").await;
+                assert_eq!(request["params"]["offset"], 1);
+                let mut older = history_page(
+                    json!([history_record(message, 999)]),
+                    "physical",
+                    true,
+                    Some(2),
+                );
+                older["offset"] = json!(1);
+                reply.send(Ok(older)).unwrap();
+            }
+            assert!(
+                send.await
+                    .unwrap()
+                    .unwrap_err()
+                    .contains("without sending again"),
+                "{case}"
+            );
+            fixture.no_request().await;
+        }
+    }
 
     fn assert_position(actual: (f64, f64), expected: (f64, f64)) {
         assert!((actual.0 - expected.0).abs() < 1e-9);
@@ -853,24 +2190,28 @@ mod tests {
     #[test]
     fn unchanged_failed_draft_reuses_idempotency_key() {
         let state = QuickChatState::new(true);
+        let generation = GatewayClient::new().generation();
         let first = state
-            .send_idempotency_key("hello", "main", "per-sender", "main")
+            .begin_send("hello", "main", "per-sender", "main", generation)
             .expect("first key");
         let retry = state
-            .send_idempotency_key("hello", "main", "per-sender", "main")
+            .begin_send("hello", "main", "per-sender", "main", generation)
             .expect("retry key");
         let edited = state
-            .send_idempotency_key("hello again", "main", "per-sender", "main")
+            .begin_send("hello again", "main", "per-sender", "main", generation)
             .expect("edited key");
 
-        assert_eq!(first, retry);
-        assert_ne!(first, edited);
+        assert_eq!(first.idempotency_key, retry.idempotency_key);
+        assert_ne!(first.idempotency_key, edited.idempotency_key);
+        state.clear_send_retry(&first);
+        assert!(state.update_retry(&edited, |_| Ok(())).is_ok());
         state.clear_send_retry(&edited);
         assert_ne!(
             state
-                .send_idempotency_key("hello again", "main", "per-sender", "main")
-                .expect("post-ack key"),
-            edited
+                .begin_send("hello again", "main", "per-sender", "main", generation)
+                .expect("post-ack key")
+                .idempotency_key,
+            edited.idempotency_key
         );
     }
 

--- a/apps/linux/src-tauri/src/quickchat_widgets.rs
+++ b/apps/linux/src-tauri/src/quickchat_widgets.rs
@@ -1,4 +1,4 @@
-use crate::gateway_ws::GatewayClient;
+use crate::gateway_ws::{CanvasSurfaceState, GatewayClient, GatewayGeneration};
 use crate::quickchat::{position_quickchat, require_quickchat_webview, QuickChatState};
 #[cfg(target_os = "linux")]
 use gtk::prelude::*;
@@ -127,6 +127,20 @@ fn resize_window_if_needed(window: &Window, height: f64) -> Result<bool, String>
         .set_size(LogicalSize::new(QUICKCHAT_WIDTH, height))
         .map_err(|error| format!("Could not resize Quick Chat for widgets: {error}"))?;
     Ok(true)
+}
+
+async fn on_main_thread<T: Send + 'static>(
+    app: &AppHandle,
+    action: impl FnOnce() -> Result<T, String> + Send + 'static,
+) -> Result<T, String> {
+    let (reply, response) = tokio::sync::oneshot::channel();
+    app.run_on_main_thread(move || {
+        let _ = reply.send(action());
+    })
+    .map_err(|error| format!("Could not schedule Quick Chat widget update: {error}"))?;
+    response
+        .await
+        .map_err(|_| "Quick Chat closed before its widget update.".to_string())?
 }
 
 #[cfg(target_os = "linux")]
@@ -399,6 +413,9 @@ impl QuickChatWidgetState {
         session_id: &str,
         renderer_epoch: u64,
         generation: u64,
+        gateway: &GatewayClient,
+        gateway_generation: GatewayGeneration,
+        surface_url: Option<String>,
     ) -> Result<(), String> {
         Self::validate_session_id(session_id)?;
         let mut state = self.inner.lock().await;
@@ -415,6 +432,7 @@ impl QuickChatWidgetState {
         if widgets.len() > QUICKCHAT_WIDGET_MAX_COUNT {
             return Err("Quick Chat received too many widgets.".to_string());
         }
+        gateway.with_generation(gateway_generation, || Ok(()))?;
         let mut keys = HashSet::new();
         let mut visible_count = 0;
         let mut prepared = Vec::with_capacity(widgets.len());
@@ -424,7 +442,15 @@ impl QuickChatWidgetState {
             }
             visible_count += usize::from(widget.visible);
             let url = validate_widget_layout(&widget)?;
-            let label = widget_view_label(&widget);
+            let surface = surface_url
+                .as_deref()
+                .ok_or_else(|| "Quick Chat widget has no current Canvas capability.".to_string())?;
+            if !widget_belongs_to_surface(&url, surface) {
+                return Err(
+                    "Quick Chat widget belongs to a different Canvas capability.".to_string(),
+                );
+            }
+            let label = widget_view_label(&widget, gateway_generation);
             prepared.push((widget, label, url));
         }
         if visible_count > 1 {
@@ -468,10 +494,21 @@ impl QuickChatWidgetState {
                         if widget.sandbox == "strict" {
                             builder = builder.disable_javascript();
                         }
-                        let webview =
-                            window.add_child(builder, position, size).map_err(|error| {
-                                format!("Could not create Quick Chat widget: {error}")
-                            })?;
+                        let owner = gateway.clone();
+                        let surface = surface_url.clone().expect("widget surface validated");
+                        let child_window = window.clone();
+                        let webview = on_main_thread(app, move || {
+                            // Tauri/Wry dispatches inline on its event thread. Acquire authority
+                            // there, not on a worker waiting for that thread to create the child.
+                            owner.with_canvas_surface(gateway_generation, &surface, || {
+                                child_window
+                                    .add_child(builder, position, size)
+                                    .map_err(|error| {
+                                        format!("Could not create Quick Chat widget: {error}")
+                                    })
+                            })
+                        })
+                        .await?;
                         created.insert(label.clone());
                         webview
                     }
@@ -492,15 +529,23 @@ impl QuickChatWidgetState {
                 }
             }
 
-            for (visible, webview) in &reconciled {
-                let result = if *visible {
-                    webview.show()
-                } else {
-                    webview.hide()
-                };
-                result.map_err(|error| {
-                    format!("Could not update Quick Chat widget visibility: {error}")
-                })?;
+            for (visible, webview) in reconciled {
+                let owner = gateway.clone();
+                let surface = surface_url.clone().expect("widget surface validated");
+                on_main_thread(app, move || {
+                    if visible {
+                        owner.with_canvas_surface(gateway_generation, &surface, || {
+                            webview.show().map_err(|error| {
+                                format!("Could not show Quick Chat widget: {error}")
+                            })
+                        })
+                    } else {
+                        webview
+                            .hide()
+                            .map_err(|error| format!("Could not hide Quick Chat widget: {error}"))
+                    }
+                })
+                .await?;
             }
             // Growing for widgets must re-anchor the window so its bottom edge stays in the work area.
             if resize_window_if_needed(&window, quickchat_window_height(has_widgets, expanded))? {
@@ -526,9 +571,13 @@ impl QuickChatWidgetState {
 pub async fn quickchat_refresh_widget_surface(
     webview: Webview,
     gateway: State<'_, GatewayClient>,
-) -> Result<Option<String>, String> {
+    gateway_generation: GatewayGeneration,
+    observed_url: String,
+) -> Result<CanvasSurfaceState, String> {
     require_quickchat_webview(&webview)?;
-    gateway.refresh_canvas_surface().await
+    gateway
+        .refresh_canvas_surface(gateway_generation, observed_url)
+        .await
 }
 
 #[tauri::command]
@@ -536,12 +585,15 @@ pub async fn quickchat_sync_widgets(
     webview: Webview,
     app: AppHandle,
     state: State<'_, QuickChatState>,
+    gateway: State<'_, GatewayClient>,
     widgets: Vec<QuickChatWidgetLayout>,
     has_widgets: bool,
     expanded: bool,
     session_id: String,
     renderer_epoch: u64,
     generation: u64,
+    gateway_generation: GatewayGeneration,
+    surface_url: Option<String>,
 ) -> Result<(), String> {
     require_quickchat_webview(&webview)?;
     state
@@ -555,8 +607,25 @@ pub async fn quickchat_sync_widgets(
             &session_id,
             renderer_epoch,
             generation,
+            gateway.inner(),
+            gateway_generation,
+            surface_url,
         )
         .await
+}
+
+fn widget_belongs_to_surface(url: &Url, surface: &str) -> bool {
+    let Ok(surface) = Url::parse(surface) else {
+        return false;
+    };
+    !has_url_userinfo(&surface)
+        && surface.query().is_none()
+        && surface.fragment().is_none()
+        && url.origin() == surface.origin()
+        && url.path().starts_with(&format!(
+            "{}/__openclaw__/canvas/documents/",
+            surface.path().trim_end_matches('/')
+        ))
 }
 
 fn percent_decode_once(raw: &str) -> Option<String> {
@@ -696,8 +765,10 @@ fn validate_widget_layout(widget: &QuickChatWidgetLayout) -> Result<Url, String>
     validate_widget_url(&widget.url)
 }
 
-fn widget_view_label(widget: &QuickChatWidgetLayout) -> String {
+fn widget_view_label(widget: &QuickChatWidgetLayout, generation: GatewayGeneration) -> String {
     let mut hasher = Sha256::new();
+    hasher.update(serde_json::to_vec(&generation).expect("Gateway generation serializes"));
+    hasher.update([0]);
     hasher.update(widget.key.as_bytes());
     hasher.update([0]);
     hasher.update(widget.url.as_bytes());
@@ -830,17 +901,18 @@ mod tests {
             "https://gateway.example/__openclaw__/cap/fixture-capability/__openclaw__/canvas/documents/second/index.html",
             "scripts",
         );
-        let first_label = widget_view_label(&first);
+        let generation = GatewayClient::new().generation();
+        let first_label = widget_view_label(&first, generation);
         let desired_before = HashMap::from([(first.key.clone(), first_label.clone())]);
         let desired_after = HashMap::from([
-            (first.key.clone(), widget_view_label(&first)),
-            (second.key.clone(), widget_view_label(&second)),
+            (first.key.clone(), widget_view_label(&first, generation)),
+            (second.key.clone(), widget_view_label(&second, generation)),
         ]);
 
         assert_eq!(desired_after.get("first"), desired_before.get("first"));
         let mut navigated = first.clone();
         navigated.url.push_str("?revision=2");
-        assert_ne!(widget_view_label(&navigated), first_label);
+        assert_ne!(widget_view_label(&navigated, generation), first_label);
     }
 
     #[test]
@@ -865,5 +937,224 @@ mod tests {
         assert!(same_widget_document(&fragment, &allowed));
         assert!(!same_widget_document(&other, &allowed));
         assert!(!same_widget_document(&userinfo_url, &allowed));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    #[ignore = "requires an isolated native X11 display and session bus"]
+    fn native_children_revalidate_gateway_before_create_and_show() {
+        use crate::gateway_ws::tests::RpcFixture;
+        use crate::quickchat::QUICKCHAT_LABEL;
+        use futures_util::FutureExt;
+        use std::time::Duration;
+        use tokio::io::AsyncWriteExt;
+
+        async fn pause_ui(app: &AppHandle) -> std::sync::mpsc::Sender<()> {
+            let (entered, waiting) = tokio::sync::oneshot::channel();
+            let (release, paused) = std::sync::mpsc::channel();
+            app.run_on_main_thread(move || {
+                let _ = entered.send(());
+                let _ = paused.recv_timeout(Duration::from_secs(5));
+            })
+            .unwrap();
+            waiting.await.unwrap();
+            release
+        }
+
+        async fn child_visible(app: &AppHandle, label: &str, hide: bool) -> bool {
+            let visible = Arc::new(AtomicBool::new(false));
+            let observed = visible.clone();
+            with_gtk_widget(
+                &app.get_webview(label).expect("native child"),
+                move |widget| {
+                    if hide {
+                        widget.hide();
+                    }
+                    observed.store(widget.is_visible(), Ordering::SeqCst);
+                    Ok(())
+                },
+            )
+            .await
+            .unwrap();
+            visible.load(Ordering::SeqCst)
+        }
+
+        async fn exercise(app: AppHandle) {
+            let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+            let root = format!(
+                "http://{}/__openclaw__/cap/fixture",
+                listener.local_addr().unwrap()
+            );
+            let http = tokio::spawn(async move {
+                while let Ok((mut stream, _)) = listener.accept().await {
+                    let _ = stream.write_all(b"HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nContent-Length: 13\r\nConnection: close\r\n\r\n<p>widget</p>").await;
+                }
+            });
+            struct HttpTask(tokio::task::JoinHandle<()>);
+            impl Drop for HttpTask {
+                fn drop(&mut self) {
+                    self.0.abort();
+                }
+            }
+            let _http = HttpTask(http);
+            let primary = app.get_webview(QUICKCHAT_LABEL).unwrap();
+            for phase in ["current", "before-create", "before-show"] {
+                let fixture = RpcFixture::new().await;
+                fixture.set_surface(&root);
+                let gateway = &fixture.client;
+                let owner = gateway.generation();
+                let state = QuickChatWidgetState::default();
+                state.start_session(&primary, phase, 1).await.unwrap();
+                state
+                    .set_visible(&primary.window(), true, phase, 1, 1, &AtomicBool::new(true))
+                    .await
+                    .unwrap();
+                let widget = test_widget(
+                    phase,
+                    &format!("{root}/__openclaw__/canvas/documents/{phase}/index.html"),
+                    "strict",
+                );
+                let label = widget_view_label(&widget, owner);
+                let mut sync = Box::pin(state.sync(
+                    &primary,
+                    &app,
+                    vec![widget.clone()],
+                    true,
+                    true,
+                    phase,
+                    1,
+                    1,
+                    gateway,
+                    owner,
+                    Some(root.clone()),
+                ));
+                if phase == "current" {
+                    sync.as_mut().await.unwrap();
+                    assert!(child_visible(&app, &label, false).await);
+                    drop(sync);
+                    let rotated = format!("{root}-rotated");
+                    fixture.set_surface(&rotated);
+                    let mut refreshed = widget.clone();
+                    refreshed.url = refreshed.url.replacen(&root, &rotated, 1);
+                    state
+                        .sync(
+                            &primary,
+                            &app,
+                            vec![refreshed.clone()],
+                            true,
+                            true,
+                            phase,
+                            1,
+                            1,
+                            gateway,
+                            owner,
+                            Some(rotated.clone()),
+                        )
+                        .await
+                        .unwrap();
+                    assert!(
+                        child_visible(&app, &widget_view_label(&refreshed, owner), false).await
+                    );
+                    assert!(app.get_webview(&label).is_none());
+                    assert!(
+                        state
+                            .sync(
+                                &primary,
+                                &app,
+                                vec![widget],
+                                true,
+                                true,
+                                phase,
+                                1,
+                                1,
+                                gateway,
+                                owner,
+                                Some(root.clone()),
+                            )
+                            .await
+                            .is_err(),
+                        "retired capability must not recreate a child"
+                    );
+                    state
+                        .set_visible(
+                            &primary.window(),
+                            false,
+                            phase,
+                            1,
+                            2,
+                            &AtomicBool::new(false),
+                        )
+                        .await
+                        .unwrap();
+                } else {
+                    if phase == "before-show" {
+                        // Poll the real sync once per native stage. UI barriers complete child
+                        // creation and GTK layout without polling the future into its show stage.
+                        assert!(futures_util::poll!(sync.as_mut()).is_pending());
+                        on_main_thread(&app, || Ok(())).await.unwrap();
+                        assert!(futures_util::poll!(sync.as_mut()).is_pending());
+                        on_main_thread(&app, || Ok(())).await.unwrap();
+                        assert!(!child_visible(&app, &label, true).await);
+                    }
+                    let release = pause_ui(&app).await;
+                    assert!(futures_util::poll!(sync.as_mut()).is_pending());
+                    fixture.replace_route();
+                    fixture.set_surface(&root); // Same URL/capability cannot restore the old owner.
+                    release.send(()).unwrap();
+                    on_main_thread(&app, || Ok(())).await.unwrap();
+                    if phase == "before-show" {
+                        assert!(
+                            !child_visible(&app, &label, false).await,
+                            "stale show reached GTK"
+                        );
+                    } else {
+                        assert!(
+                            app.get_webview(&label).is_none(),
+                            "stale create reached GTK"
+                        );
+                    }
+                    assert!(sync.await.is_err());
+                    on_main_thread(&app, || Ok(())).await.unwrap();
+                    assert!(app.get_webview(&label).is_none());
+                }
+                println!("F11_NATIVE {phase}: passed");
+            }
+        }
+
+        let (finished, result) = std::sync::mpsc::channel();
+        let app = tauri::Builder::default()
+            .any_thread()
+            .setup(move |app| {
+                tauri::WebviewWindowBuilder::new(
+                    app,
+                    QUICKCHAT_LABEL,
+                    WebviewUrl::External(Url::parse("about:blank").unwrap()),
+                )
+                .visible(false)
+                .build()?;
+                let handle = app.handle().clone();
+                tauri::async_runtime::spawn(async move {
+                    let outcome = std::panic::AssertUnwindSafe(tokio::time::timeout(
+                        Duration::from_secs(25),
+                        exercise(handle.clone()),
+                    ))
+                    .catch_unwind()
+                    .await;
+                    let _ = finished.send(outcome);
+                    handle.exit(0);
+                });
+                Ok(())
+            })
+            .build(tauri::generate_context!())
+            .expect("native Quick Chat fixture");
+        app.run_return(|_, _| {});
+        match result
+            .recv_timeout(Duration::from_secs(2))
+            .expect("native result")
+        {
+            Ok(Ok(())) => {}
+            Ok(Err(error)) => panic!("native widget proof timed out: {error}"),
+            Err(panic) => std::panic::resume_unwind(panic),
+        }
     }
 }

--- a/apps/linux/src-tauri/src/remote_gateway.rs
+++ b/apps/linux/src-tauri/src/remote_gateway.rs
@@ -7,6 +7,7 @@ use std::io::{ErrorKind, Read, Write};
 use std::net::{IpAddr, SocketAddr, TcpListener, TcpStream};
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
+use std::sync::{Condvar, Mutex};
 use std::thread;
 use std::time::{Duration, Instant};
 use tauri::Url;
@@ -22,6 +23,195 @@ impl Drop for SshTunnel {
     fn drop(&mut self) {
         let _ = self.child.kill();
         let _ = self.child.wait();
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct TunnelRoute {
+    pub id: u64,
+    pub selection: u64,
+    pub request: RemoteGatewayRequest,
+    pub url: Url,
+}
+
+struct ManagedTunnel {
+    route: TunnelRoute,
+    child: Option<SshTunnel>,
+    recover: bool,
+}
+
+#[derive(Default)]
+struct TunnelState {
+    closing: bool,
+    preparing: usize,
+    next_id: u64,
+    active: Option<ManagedTunnel>,
+}
+
+#[derive(Default)]
+pub(crate) struct TunnelManager {
+    state: Mutex<TunnelState>,
+    idle: Condvar,
+}
+
+// Registration precedes spawn; shutdown waits only for owned SSH work, not
+// unrelated operations queued behind an installer.
+pub(crate) struct TunnelWork<'a>(&'a TunnelManager);
+
+impl Drop for TunnelWork<'_> {
+    fn drop(&mut self) {
+        let mut state = self.0.state.lock().expect("tunnel state");
+        state.preparing -= 1;
+        self.0.idle.notify_all();
+    }
+}
+
+impl TunnelManager {
+    pub fn begin(&self) -> Result<TunnelWork<'_>, String> {
+        let mut state = self.state.lock().expect("tunnel state");
+        if state.closing {
+            return Err("OpenClaw is quitting.".to_string());
+        }
+        state.preparing += 1;
+        Ok(TunnelWork(self))
+    }
+
+    pub fn has_route(&self) -> bool {
+        self.state.lock().expect("tunnel state").active.is_some()
+    }
+
+    pub fn reusable(&self, request: &RemoteGatewayRequest) -> Option<TunnelRoute> {
+        let mut state = self.state.lock().expect("tunnel state");
+        let active = state.active.as_mut()?;
+        if active.route.request.ssh_target != request.ssh_target
+            || active
+                .route
+                .request
+                .remote_port
+                .unwrap_or(DEFAULT_GATEWAY_PORT)
+                != request.remote_port.unwrap_or(DEFAULT_GATEWAY_PORT)
+            || request.url.as_deref().is_some_and(|url| {
+                normalize_gateway_url(url).ok().as_ref() != Some(&active.route.url)
+            })
+            || active.child.as_mut()?.child.try_wait().ok()?.is_some()
+        {
+            return None;
+        }
+        Some(active.route.clone())
+    }
+
+    pub fn route_is_current(&self, id: u64) -> bool {
+        let state = self.state.lock().expect("tunnel state");
+        !state.closing
+            && state
+                .active
+                .as_ref()
+                .is_some_and(|active| active.route.id == id)
+    }
+
+    pub fn route(&self, id: u64) -> Option<TunnelRoute> {
+        let state = self.state.lock().expect("tunnel state");
+        state
+            .active
+            .as_ref()
+            .filter(|active| active.route.id == id)
+            .map(|active| active.route.clone())
+    }
+
+    pub fn publish(
+        &self,
+        child: &mut Option<SshTunnel>,
+        mut route: TunnelRoute,
+        replacing: Option<u64>,
+        recover: bool,
+    ) -> Result<TunnelRoute, String> {
+        let mut state = self.state.lock().expect("tunnel state");
+        if state.closing
+            || replacing.is_some_and(|id| {
+                !state
+                    .active
+                    .as_ref()
+                    .is_some_and(|active| active.route.id == id)
+            })
+        {
+            return Err("The SSH connection was superseded.".to_string());
+        }
+        if child.is_none() {
+            let active = state
+                .active
+                .as_mut()
+                .ok_or("The SSH connection is unavailable.")?;
+            if !active
+                .child
+                .as_mut()
+                .is_some_and(|tunnel| matches!(tunnel.child.try_wait(), Ok(None)))
+            {
+                return Err("The SSH connection closed. Retry the connection.".to_string());
+            }
+            active.route.request = route.request;
+            active.route.selection = route.selection;
+            active.recover = recover;
+            return Ok(active.route.clone());
+        }
+        state.next_id = state.next_id.wrapping_add(1);
+        route.id = state.next_id;
+        let old = state.active.replace(ManagedTunnel {
+            route: route.clone(),
+            child: child.take(),
+            recover,
+        });
+        // Return the retired child to the preparing worker for kill/wait.
+        *child = old.and_then(|active| active.child);
+        Ok(route)
+    }
+
+    pub fn exited(&self) -> Option<(TunnelRoute, bool)> {
+        let mut state = self.state.lock().expect("tunnel state");
+        if state.closing {
+            return None;
+        }
+        let active = state.active.as_mut()?;
+        // Only an observed child exit authorizes automatic recovery.
+        if active.child.as_mut()?.child.try_wait().ok()?.is_none() {
+            return None;
+        }
+        let child = active.child.take();
+        let recover = std::mem::replace(&mut active.recover, false);
+        let route = active.route.clone();
+        drop(state);
+        drop(child);
+        Some((route, recover))
+    }
+
+    pub fn clear(&self) {
+        let old = {
+            let mut state = self.state.lock().expect("tunnel state");
+            state.preparing += 1;
+            state.active.take()
+        };
+        let _work = TunnelWork(self);
+        drop(old);
+    }
+
+    pub fn take(&self) -> Option<SshTunnel> {
+        self.state
+            .lock()
+            .expect("tunnel state")
+            .active
+            .take()
+            .and_then(|active| active.child)
+    }
+
+    pub fn close(&self) {
+        self.state.lock().expect("tunnel state").closing = true;
+    }
+
+    pub fn wait_closed(&self) {
+        self.clear();
+        let mut state = self.state.lock().expect("tunnel state");
+        while state.preparing != 0 {
+            state = self.idle.wait(state).expect("tunnel state");
+        }
     }
 }
 
@@ -444,6 +634,53 @@ pub(crate) fn load_saved_remote() -> Result<Option<RemoteGatewayRequest>, String
     load_saved_remote_at(&config_path()?)
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct RemoteSettings {
+    transport: String,
+    url: Option<String>,
+    ssh_target: Option<String>,
+    remote_port: Option<u16>,
+}
+
+pub(crate) fn saved_settings() -> Result<Option<RemoteSettings>, String> {
+    saved_settings_at(&config_path()?)
+}
+
+fn saved_settings_at(path: &Path) -> Result<Option<RemoteSettings>, String> {
+    let Some(root) = read_config(path)? else {
+        return Ok(None);
+    };
+    if root.pointer("/gateway/mode").and_then(Value::as_str) != Some("remote") {
+        return Ok(None);
+    }
+    let remote = root.pointer("/gateway/remote");
+    let string = |key| {
+        remote
+            .and_then(|remote| remote.get(key))
+            .and_then(Value::as_str)
+    };
+    // This is a projection, not a connection attempt. Never resolve or return
+    // credentials, even when their provider is broken.
+    let url = string("url").and_then(|raw| {
+        let mut url = Url::parse(raw).ok()?;
+        let _ = url.set_username("");
+        let _ = url.set_password(None);
+        url.set_query(None);
+        url.set_fragment(None);
+        Some(url.to_string())
+    });
+    Ok(Some(RemoteSettings {
+        transport: string("transport").unwrap_or("direct").to_string(),
+        url,
+        ssh_target: string("sshTarget").map(str::to_string),
+        remote_port: remote
+            .and_then(|remote| remote.get("remotePort"))
+            .and_then(Value::as_u64)
+            .and_then(|port| u16::try_from(port).ok()),
+    }))
+}
+
 fn load_saved_remote_at(path: &Path) -> Result<Option<RemoteGatewayRequest>, String> {
     let Some(root) = read_config(path)? else {
         return Ok(None);
@@ -654,7 +891,11 @@ fn available_port(preferred: u16, target: &str) -> Result<u16, String> {
 pub(crate) fn start_tunnel(
     request: &RemoteGatewayRequest,
     saved_url: Option<&Url>,
+    cancelled: impl Fn() -> bool,
 ) -> Result<(SshTunnel, Url), String> {
+    if cancelled() {
+        return Err("The SSH connection was superseded.".to_string());
+    }
     let raw_target = request
         .ssh_target
         .as_deref()
@@ -686,7 +927,10 @@ pub(crate) fn start_tunnel(
     if let Some(ssh_port) = ssh_port {
         command.args(["-p", &ssh_port.to_string()]);
     }
-    let mut child = command
+    if cancelled() {
+        return Err("The SSH connection was superseded.".to_string());
+    }
+    let child = command
         .args([
             "-o",
             "BatchMode=yes",
@@ -716,30 +960,34 @@ pub(crate) fn start_tunnel(
         .stderr(Stdio::piped())
         .spawn()
         .map_err(|error| format!("Could not start the SSH tunnel: {error}"))?;
+    let mut tunnel = SshTunnel { child };
     let deadline = Instant::now() + TUNNEL_READY_TIMEOUT;
     let local_address = SocketAddr::from(([127, 0, 0, 1], local_port));
     loop {
-        if TcpStream::connect_timeout(&local_address, Duration::from_millis(150)).is_ok() {
-            let url = Url::parse(&format!("ws://127.0.0.1:{local_port}"))
-                .map_err(|_| "Could not construct local SSH tunnel URL.".to_string())?;
-            return Ok((SshTunnel { child }, url));
+        if cancelled() {
+            return Err("The SSH connection was superseded.".to_string());
         }
-        if let Some(exit) = child
+        if let Some(exit) = tunnel
+            .child
             .try_wait()
             .map_err(|error| format!("Could not inspect SSH tunnel: {error}"))?
         {
-            let output = child
-                .wait_with_output()
-                .map_err(|error| format!("Could not inspect SSH tunnel failure: {error}"))?;
-            let detail = crate::cli::output_tail(&output.stderr)
+            let mut stderr = Vec::new();
+            if let Some(mut pipe) = tunnel.child.stderr.take() {
+                let _ = pipe.read_to_end(&mut stderr);
+            }
+            let detail = crate::cli::output_tail(&stderr)
                 .unwrap_or_else(|| format!("SSH exited with {exit}."));
             return Err(format!(
                 "SSH connection failed: {detail}. Verify the host key and SSH key authentication."
             ));
         }
+        if TcpStream::connect_timeout(&local_address, Duration::from_millis(150)).is_ok() {
+            let url = Url::parse(&format!("ws://127.0.0.1:{local_port}"))
+                .map_err(|_| "Could not construct local SSH tunnel URL.".to_string())?;
+            return Ok((tunnel, url));
+        }
         if Instant::now() >= deadline {
-            let _ = child.kill();
-            let _ = child.wait();
             return Err(
                 "SSH tunnel did not become ready. Verify the host and SSH key.".to_string(),
             );
@@ -1082,6 +1330,14 @@ mod tests {
                     .expect("insecure secret fixture");
                 assert!(load_saved_remote_at(&path).is_err());
                 assert_eq!(read_config(&path).unwrap().unwrap(), config);
+                let before_settings = fs::read(&path).expect("saved bytes");
+                let settings = serde_json::to_value(saved_settings_at(&path).unwrap().unwrap())
+                    .expect("credential-free settings");
+                assert_eq!(settings["url"], config["gateway"]["remote"]["url"]);
+                assert!(settings.get("token").is_none());
+                assert!(settings.get("password").is_none());
+                assert!(settings.get("secrets").is_none());
+                assert_eq!(fs::read(&path).unwrap(), before_settings);
 
                 // Explicit submission replaces the ref even when the value matches its last resolution.
                 let mut input = request();
@@ -1204,6 +1460,110 @@ mod tests {
                 fs::remove_dir_all(path.parent().unwrap()).expect("cleanup");
             }
         }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn owned_child_exit_is_reported_once_and_replacement_does_not_churn() {
+        fn pending_child() -> (Option<SshTunnel>, std::process::ChildStdin) {
+            let mut child = Command::new("/bin/cat")
+                .stdin(Stdio::piped())
+                .stdout(Stdio::null())
+                .spawn()
+                .expect("owned child");
+            let input = child.stdin.take().expect("child input");
+            (Some(SshTunnel { child }), input)
+        }
+        fn exit(manager: &TunnelManager) -> (TunnelRoute, bool) {
+            let deadline = Instant::now() + Duration::from_secs(5);
+            loop {
+                if let Some(event) = manager.exited() {
+                    return event;
+                }
+                assert!(
+                    Instant::now() < deadline,
+                    "owned child exit was not observed"
+                );
+                thread::sleep(Duration::from_millis(10));
+            }
+        }
+
+        let manager = TunnelManager::default();
+        let work = manager.begin().expect("register preparation");
+        let url = Url::parse("ws://127.0.0.1:18789").unwrap();
+        let route = TunnelRoute {
+            id: 0,
+            selection: 7,
+            request: request(),
+            url: url.clone(),
+        };
+        let (mut child, input) = pending_child();
+        let first = manager
+            .publish(&mut child, route, None, true)
+            .expect("publish initial child");
+        assert!(child.is_none());
+        assert!(
+            manager.exited().is_none(),
+            "live child must not authorize recovery"
+        );
+        drop(input);
+        let (dead, recover) = exit(&manager);
+        assert_eq!(dead.id, first.id);
+        assert!(recover);
+        assert!(
+            manager.exited().is_none(),
+            "one child exit must queue only once"
+        );
+
+        let (mut replacement, input) = pending_child();
+        let second = manager
+            .publish(&mut replacement, dead, Some(first.id), false)
+            .expect("publish replacement");
+        assert!(!manager.route_is_current(first.id));
+        assert_eq!(second.url, url);
+        drop(input);
+        let (dead, recover) = exit(&manager);
+        assert_eq!(dead.id, second.id);
+        assert!(!recover, "a failed replacement must require explicit Retry");
+        assert!(manager.exited().is_none());
+
+        let (mut stale, _input) = pending_child();
+        assert!(manager
+            .publish(&mut stale, dead, Some(first.id), true)
+            .is_err());
+        assert!(
+            stale.is_some(),
+            "cancelled child must return to its preparing owner"
+        );
+        drop(stale);
+        drop(work);
+        manager.close();
+        assert!(manager.begin().is_err(), "shutdown must exclude new spawns");
+        manager.wait_closed();
+        assert!(!manager.has_route());
+    }
+
+    #[test]
+    fn shutdown_ack_waits_for_preparing_ssh_owner() {
+        use std::sync::{mpsc, Arc};
+        let manager = Arc::new(TunnelManager::default());
+        let work = manager.begin().expect("in-flight SSH preparation");
+        manager.close();
+        let (started_tx, started_rx) = mpsc::channel();
+        let (done_tx, done_rx) = mpsc::channel();
+        let closing = Arc::clone(&manager);
+        let waiter = thread::spawn(move || {
+            started_tx.send(()).unwrap();
+            closing.wait_closed();
+            done_tx.send(()).unwrap();
+        });
+        started_rx.recv_timeout(Duration::from_secs(5)).unwrap();
+        assert!(done_rx.try_recv().is_err());
+        drop(work);
+        done_rx
+            .recv_timeout(Duration::from_secs(5))
+            .expect("SSH shutdown acknowledgement");
+        waiter.join().unwrap();
     }
 
     fn existing_json5_config(path: &Path) {

--- a/apps/linux/src-tauri/src/tray.rs
+++ b/apps/linux/src-tauri/src/tray.rs
@@ -4,7 +4,7 @@ use crate::quickchat;
 use crate::DesktopState;
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 use tauri::menu::{CheckMenuItem, MenuBuilder, MenuItem};
 use tauri::tray::{MouseButton, MouseButtonState, TrayIcon, TrayIconBuilder, TrayIconEvent};
 use tauri::{App, AppHandle, Manager};
@@ -12,6 +12,7 @@ use tauri_plugin_autostart::ManagerExt;
 use tauri_plugin_global_shortcut::GlobalShortcutExt;
 
 const OPEN_ID: &str = "open-dashboard";
+const CONNECTION_SETTINGS_ID: &str = "connection-settings";
 const QUICKCHAT_ID: &str = "quickchat";
 const CHECK_UPDATES_ID: &str = "check-for-updates";
 const UPDATE_ACTION_ID: &str = "update-action";
@@ -30,7 +31,7 @@ const QUIT_ID: &str = "quit";
 pub struct TrayHandles {
     _tray: TrayIcon<tauri::Wry>,
     status: MenuItem<tauri::Wry>,
-    status_line: Mutex<StatusLine>,
+    status_line: Arc<Mutex<StatusLine>>,
     update_action: MenuItem<tauri::Wry>,
     quickchat_shortcut: Option<CheckMenuItem<tauri::Wry>>,
     start: MenuItem<tauri::Wry>,
@@ -41,6 +42,9 @@ pub struct TrayHandles {
 struct StatusLine {
     gateway: String,
     pending_count: usize,
+    installed: bool,
+    running: bool,
+    reachable: bool,
 }
 
 #[cfg(any(target_os = "linux", test))]
@@ -85,23 +89,44 @@ impl TrayHandles {
     pub fn update(&self, snapshot: &GatewaySnapshot) {
         let mut status_line = self.status_line.lock().expect("tray status mutex poisoned");
         status_line.gateway.clone_from(&snapshot.status);
+        status_line.installed = snapshot.installed;
+        status_line.running = snapshot.running;
+        status_line.reachable = snapshot.reachable;
         if !snapshot.reachable {
             status_line.pending_count = 0;
         }
-        let _ = self.status.set_text(status_line.text());
-        let _ = self
-            .start
-            .set_enabled(snapshot.installed && !snapshot.running && !snapshot.reachable);
-        let _ = self
-            .stop
-            .set_enabled(snapshot.installed && snapshot.running);
-        let _ = self.restart.set_enabled(snapshot.installed);
+        drop(status_line);
+        self.refresh_status(self._tray.app_handle());
     }
 
     pub fn update_pending_count(&self, count: usize) {
-        let mut status_line = self.status_line.lock().expect("tray status mutex poisoned");
-        status_line.pending_count = count;
-        let _ = self.status.set_text(status_line.text());
+        self.status_line
+            .lock()
+            .expect("tray status mutex poisoned")
+            .pending_count = count;
+        self.refresh_status(self._tray.app_handle());
+    }
+
+    fn refresh_status(&self, app: &AppHandle) {
+        let state = Arc::clone(&self.status_line);
+        let status = self.status.clone();
+        let start = self.start.clone();
+        let stop = self.stop.clone();
+        let restart = self.restart.clone();
+        let _ = app.run_on_main_thread(move || {
+            let current = state.lock().expect("tray status mutex poisoned");
+            let (text, installed, running, reachable) = (
+                current.text(),
+                current.installed,
+                current.running,
+                current.reachable,
+            );
+            drop(current);
+            let _ = status.set_text(text);
+            let _ = start.set_enabled(installed && !running && !reachable);
+            let _ = stop.set_enabled(installed && running);
+            let _ = restart.set_enabled(installed);
+        });
     }
 
     pub fn set_quickchat_shortcut_checked(&self, checked: bool) {
@@ -201,6 +226,7 @@ pub fn build(
         .separator()
         .text(QUICKCHAT_ID, "Quick Chat")
         .text(OPEN_ID, "Open Dashboard")
+        .text(CONNECTION_SETTINGS_ID, "Connection Settings")
         .text(CHECK_UPDATES_ID, "Check for Updates")
         .item(&update_action)
         .item(&start_at_login);
@@ -295,10 +321,13 @@ pub fn build(
     Ok(TrayHandles {
         _tray: tray,
         status,
-        status_line: Mutex::new(StatusLine {
+        status_line: Arc::new(Mutex::new(StatusLine {
             gateway: "Checking…".to_string(),
             pending_count: 0,
-        }),
+            installed: false,
+            running: false,
+            reachable: false,
+        })),
         update_action,
         quickchat_shortcut,
         start,
@@ -316,8 +345,35 @@ pub fn show_window(app: &AppHandle) {
 }
 
 pub fn open_dashboard(app: &AppHandle) {
-    show_window(app);
-    app.state::<GatewayOperationQueue>().submit_connect();
+    #[cfg(target_os = "linux")]
+    {
+        let current_app = app.clone();
+        if let Err(error) = app.run_on_main_thread(move || {
+            let state = current_app.state::<DesktopState>();
+            if state.is_quitting() {
+                return;
+            }
+            let presented = state.present_remote_dashboard(&current_app);
+            show_window(&current_app);
+            match presented {
+                Ok(true) => {}
+                Ok(false) => current_app
+                    .state::<GatewayOperationQueue>()
+                    .submit_connect(),
+                Err(error) => {
+                    eprintln!("{error}");
+                    crate::notify::notify(&current_app, "OpenClaw", &error);
+                }
+            }
+        }) {
+            eprintln!("Could not open the dashboard: {error}");
+        }
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        show_window(app);
+        app.state::<GatewayOperationQueue>().submit_connect();
+    }
 }
 
 fn handle_menu(
@@ -330,11 +386,15 @@ fn handle_menu(
 ) {
     match id {
         QUIT_ID => {
-            state.quit();
-            app.exit(0);
+            state.quit(app);
         }
         QUICKCHAT_ID => quickchat::toggle_quickchat(app),
         OPEN_ID => open_dashboard(app),
+        CONNECTION_SETTINGS_ID => {
+            if let Err(error) = state.show_connection_settings(app) {
+                eprintln!("Could not open Connection Settings: {error}");
+            }
+        }
         CHECK_UPDATES_ID => {
             show_window(app);
             crate::updater::spawn_check(app.clone());

--- a/apps/linux/src-tauri/src/updater.rs
+++ b/apps/linux/src-tauri/src/updater.rs
@@ -14,12 +14,64 @@ pub(crate) const PROGRESS_EVENT: &str = "updater://progress";
 pub(crate) const READY_EVENT: &str = "updater://ready";
 pub(crate) const ERROR_EVENT: &str = "updater://error";
 
+#[cfg(target_os = "linux")]
+const RELEASE_URL: &str = "https://github.com/openclaw/openclaw/releases/tag/linux-stable";
+#[cfg(any(target_os = "macos", target_os = "windows"))]
 const RELEASE_URL: &str = "https://github.com/openclaw/openclaw/releases/latest";
 #[cfg(any(target_os = "macos", target_os = "windows"))]
 // Test desktop builds need a channel that Linux-only releases never replace.
 const DESKTOP_TEST_UPDATE_ENDPOINT: &str =
     "https://github.com/openclaw/openclaw/releases/download/desktop-test/latest-desktop-test.json";
 const AUTO_CHECK_DELAY: Duration = Duration::from_secs(3);
+
+#[cfg(any(target_os = "linux", test))]
+fn calendar_release_key(version: &str) -> Option<(u64, u64, u64, u8, u64)> {
+    // Keep recognition and safe integer bounds aligned with scripts/lib/release-version.mjs.
+    const MAX_SAFE_INTEGER: u64 = 9_007_199_254_740_991;
+    let positive_part = |part: &str| {
+        if part.is_empty() || part.starts_with('0') || !part.bytes().all(|b| b.is_ascii_digit()) {
+            return None;
+        }
+        part.parse::<u64>().ok().filter(|n| *n <= MAX_SAFE_INTEGER)
+    };
+    let (base, prerelease) = match version.split_once('-') {
+        Some((base, prerelease)) => (base, Some(prerelease)),
+        None => (version, None),
+    };
+    let mut parts = base.split('.');
+    let year = parts.next()?;
+    if year.len() != 4 || !year.bytes().all(|b| b.is_ascii_digit()) {
+        return None;
+    }
+    let year = year.parse().ok()?;
+    let month = positive_part(parts.next()?)?;
+    let patch = positive_part(parts.next()?)?;
+    if month > 12 || parts.next().is_some() {
+        return None;
+    }
+    let (rank, sequence) = match prerelease {
+        None => (2, 0),
+        Some(value) => match value.split_once('.') {
+            Some(("alpha", number)) => (0, positive_part(number)?),
+            Some(("beta", number)) => (1, positive_part(number)?),
+            Some(_) => return None,
+            None => (2, positive_part(value)?),
+        },
+    };
+    Some((year, month, patch, rank, sequence))
+}
+
+#[cfg(any(target_os = "linux", test))]
+fn release_is_newer<T: Ord + std::fmt::Display>(current: &T, candidate: &T) -> bool {
+    match (
+        calendar_release_key(&current.to_string()),
+        calendar_release_key(&candidate.to_string()),
+    ) {
+        (Some(current), Some(candidate)) => candidate > current,
+        // Preserve Tauri's exact comparator, including build metadata, outside the calendar grammar.
+        _ => candidate > current,
+    }
+}
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum InstallKind {
@@ -319,7 +371,10 @@ async fn run_check(app: AppHandle, manual: bool) {
     };
     let manual_requested = || manual_pending.load(Ordering::Acquire);
     #[cfg(target_os = "linux")]
-    let updater = app.updater();
+    let updater = app
+        .updater_builder()
+        .version_comparator(|current, candidate| release_is_newer(&current, &candidate.version))
+        .build();
     #[cfg(any(target_os = "macos", target_os = "windows"))]
     let updater = app
         .updater_builder()
@@ -631,6 +686,116 @@ fn manual_notification_body(version: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[derive(serde::Deserialize)]
+    struct ReleaseVersionCases {
+        ordered: Vec<ReleaseVersionCase>,
+        unrecognized: Vec<String>,
+    }
+
+    #[derive(serde::Deserialize)]
+    struct ReleaseVersionCase {
+        current: String,
+        candidate: String,
+        ordering: i8,
+    }
+
+    fn release_version_cases() -> ReleaseVersionCases {
+        serde_json::from_str(include_str!("../../tests/release_version_cases.json")).unwrap()
+    }
+
+    fn remote_release(
+        version: &str,
+    ) -> Result<tauri_plugin_updater::RemoteRelease, serde_json::Error> {
+        serde_json::from_value(serde_json::json!({
+            "version": version,
+            "platforms": {},
+        }))
+    }
+
+    #[test]
+    fn release_version_correction_replaces_base() {
+        let current = remote_release("2026.9.3").unwrap().version;
+        let candidate = remote_release("2026.9.3-1").unwrap().version;
+        assert!(
+            candidate < current,
+            "the locked vendor default treats the correction as a prerelease"
+        );
+        assert!(
+            release_is_newer(&current, &candidate),
+            "base -> correction must offer the correction"
+        );
+    }
+
+    #[test]
+    fn release_version_shared_calendar_cases() {
+        for case in release_version_cases().ordered {
+            let current = remote_release(&case.current).unwrap().version;
+            let candidate = remote_release(&case.candidate).unwrap().version;
+            assert_eq!(
+                release_is_newer(&current, &candidate),
+                case.ordering > 0,
+                "{} -> {}",
+                case.current,
+                case.candidate,
+            );
+            assert_eq!(
+                release_is_newer(&candidate, &current),
+                case.ordering < 0,
+                "{} -> {}",
+                case.candidate,
+                case.current,
+            );
+        }
+    }
+
+    #[test]
+    fn release_version_unrecognized_versions_keep_vendor_order() {
+        for version in release_version_cases().unrecognized {
+            let candidate = remote_release(&version).unwrap().version;
+            assert_eq!(
+                calendar_release_key(&candidate.to_string()),
+                None,
+                "{version}"
+            );
+            for current in ["2026.9.3", "2026.9.3-1", version.as_str()] {
+                let current = remote_release(current).unwrap().version;
+                assert_eq!(
+                    release_is_newer(&current, &candidate),
+                    candidate > current,
+                    "{current} -> {candidate}",
+                );
+                assert_eq!(
+                    release_is_newer(&candidate, &current),
+                    current > candidate,
+                    "{candidate} -> {current}",
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn release_version_vendor_parsing_is_preserved() {
+        for version in [
+            "2026.9",
+            "2026.09.3",
+            "2026.9.03",
+            "2026.9.3-01",
+            "2026.9.3-beta.01",
+            "2026.9.3-",
+            "2026.9.3+",
+            "2026.9.18446744073709551616",
+            " 2026.9.3",
+            "2026.9.3 ",
+            "V2026.9.3",
+        ] {
+            assert!(remote_release(version).is_err(), "{version}");
+        }
+        let current = remote_release("2026.9.3").unwrap().version;
+        let candidate = remote_release("v2026.9.3-1").unwrap().version;
+        assert_eq!(candidate.to_string(), "2026.9.3-1");
+        assert!(release_is_newer(&current, &candidate));
+    }
 
     #[test]
     fn install_kind_covers_every_platform_path() {

--- a/apps/linux/src-tauri/tauri.conf.json
+++ b/apps/linux/src-tauri/tauri.conf.json
@@ -15,7 +15,7 @@
     "updater": {
       "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDRDODJFMzU1QTQ0MUMwNkYKUldSdndFR2tWZU9DVE9RYnlIcHFoNG1xUlQzUlloa0plQmZjY0dPbHpjWlEzWFozdmt0cHBlY2gK",
       "endpoints": [
-        "https://github.com/openclaw/openclaw/releases/latest/download/latest.json"
+        "https://github.com/openclaw/openclaw/releases/download/linux-stable/latest.json"
       ]
     }
   },

--- a/apps/linux/src-tauri/tests/logind_sleep.rs
+++ b/apps/linux/src-tauri/tests/logind_sleep.rs
@@ -12,7 +12,7 @@ use std::os::fd::OwnedFd as StdOwnedFd;
 use std::os::unix::net::UnixStream;
 use std::path::PathBuf;
 use std::process::{Child, Command, Stdio};
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 use tokio::sync::mpsc;
 use uuid::Uuid;
@@ -20,6 +20,8 @@ use zbus::object_server::SignalEmitter;
 use zbus::zvariant::OwnedFd;
 
 const LOGIN1_PATH: &str = "/org/freedesktop/login1";
+static SYSTEM_BUS_TEST_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+static WAKE_RUNTIME: OnceLock<tokio::runtime::Runtime> = OnceLock::new();
 
 #[derive(Debug, Eq, PartialEq)]
 enum MockEvent {
@@ -166,7 +168,83 @@ async fn next_event(events: &mut mpsc::UnboundedReceiver<MockEvent>) -> MockEven
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[ignore = "requires Linux and dbus-daemon; run with cargo test -- --ignored logind"]
 async fn logind_full_sleep_cycle_releases_and_reacquires_inhibitor() {
-    let Some((_daemon, address)) = spawn_dbus_daemon() else {
+    exercise_logind_listener(None, WakeProgress::None).await;
+}
+
+#[derive(Clone, Copy, Debug)]
+enum TerminalLoss {
+    StreamEnded,
+    InvalidSignal,
+    Cancelled,
+    CancelledPreparing,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum WakeProgress {
+    None,
+    BeforePoll,
+    RefreshPending,
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "requires Linux and dbus-daemon; run with cargo test -- --ignored logind"]
+async fn logind_stream_end_retires_cycle_without_wake() {
+    exercise_logind_listener(Some(TerminalLoss::StreamEnded), WakeProgress::None).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "requires Linux and dbus-daemon; run with cargo test -- --ignored logind"]
+async fn logind_invalid_signal_retires_cycle_without_wake() {
+    exercise_logind_listener(Some(TerminalLoss::InvalidSignal), WakeProgress::None).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "requires Linux and dbus-daemon; run with cargo test -- --ignored logind"]
+async fn logind_cancellation_retires_cycle_without_wake() {
+    for loss in [TerminalLoss::Cancelled, TerminalLoss::CancelledPreparing] {
+        exercise_logind_listener(Some(loss), WakeProgress::None).await;
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "requires Linux and dbus-daemon; run with cargo test -- --ignored logind"]
+async fn logind_terminal_loss_preserves_unpolled_wake() {
+    for loss in [
+        TerminalLoss::StreamEnded,
+        TerminalLoss::InvalidSignal,
+        TerminalLoss::Cancelled,
+    ] {
+        exercise_logind_listener(Some(loss), WakeProgress::BeforePoll).await;
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "requires Linux and dbus-daemon; run with cargo test -- --ignored logind"]
+async fn logind_terminal_loss_preserves_refreshing_wake() {
+    for loss in [
+        TerminalLoss::StreamEnded,
+        TerminalLoss::InvalidSignal,
+        TerminalLoss::Cancelled,
+    ] {
+        exercise_logind_listener(Some(loss), WakeProgress::RefreshPending).await;
+    }
+}
+
+async fn exercise_logind_listener(terminal_loss: Option<TerminalLoss>, wake: WakeProgress) {
+    // DBUS_SYSTEM_BUS_ADDRESS is process-global, including under default-parallel Cargo.
+    let _serial = SYSTEM_BUS_TEST_LOCK.lock().await;
+    // The listener runs on the test runtime; one distinct wake worker lets the
+    // fixture hold recovery before its first poll without changing production hooks.
+    WAKE_RUNTIME.get_or_init(|| {
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(1)
+            .enable_all()
+            .build()
+            .expect("create fixture wake runtime");
+        tauri::async_runtime::set(runtime.handle().clone());
+        runtime
+    });
+    let Some((mut daemon, address)) = spawn_dbus_daemon() else {
         return;
     };
     let _system_bus = SystemBusAddress::set(&address);
@@ -190,6 +268,9 @@ async fn logind_full_sleep_cycle_releases_and_reacquires_inhibitor() {
     let prepare_events = event_tx.clone();
     let refresh_events = event_tx.clone();
     let resume_events = event_tx.clone();
+    let block_prepare = matches!(terminal_loss, Some(TerminalLoss::CancelledPreparing));
+    let release_refresh = Arc::new(tokio::sync::Notify::new());
+    let refresh_barrier = Arc::clone(&release_refresh);
     let controller = Arc::new(GatewaySleepCycleController::new(
         "logind-proof".into(),
         || {
@@ -202,6 +283,9 @@ async fn logind_full_sleep_cycle_releases_and_reacquires_inhibitor() {
             let events = prepare_events.clone();
             async move {
                 let _ = events.send(MockEvent::Prepare);
+                if block_prepare {
+                    std::future::pending::<()>().await;
+                }
                 Ok(SleepPrepareOutcome::Ready {
                     suspension_id: "mock-suspension".into(),
                 })
@@ -216,8 +300,12 @@ async fn logind_full_sleep_cycle_releases_and_reacquires_inhibitor() {
         },
         move || {
             let events = refresh_events.clone();
+            let barrier = Arc::clone(&refresh_barrier);
             async move {
                 let _ = events.send(MockEvent::Refresh);
+                if wake == WakeProgress::RefreshPending {
+                    barrier.notified().await;
+                }
             }
         },
         |_| std::future::ready(()),
@@ -232,7 +320,11 @@ async fn logind_full_sleep_cycle_releases_and_reacquires_inhibitor() {
     let end_sleep_cycle: EndSleepCycleHook = Arc::new(move || {
         let _ = end_events.send(MockEvent::DriverDeactivated);
     });
-    let listener = tokio::spawn(run_listener(controller, begin_sleep_cycle, end_sleep_cycle));
+    let listener = tokio::spawn(run_listener(
+        Arc::clone(&controller),
+        begin_sleep_cycle,
+        end_sleep_cycle,
+    ));
 
     assert_eq!(
         next_event(&mut events).await,
@@ -248,10 +340,110 @@ async fn logind_full_sleep_cycle_releases_and_reacquires_inhibitor() {
         .expect("emit sleep signal");
     assert_eq!(next_event(&mut events).await, MockEvent::DriverActivated);
     assert_eq!(next_event(&mut events).await, MockEvent::Prepare);
-    assert_eq!(
-        next_event(&mut events).await,
-        MockEvent::InhibitorReleased(1)
-    );
+    if !block_prepare {
+        assert_eq!(
+            next_event(&mut events).await,
+            MockEvent::InhibitorReleased(1)
+        );
+    }
+
+    if let Some(loss) = terminal_loss {
+        let mut wake_gate = None;
+        if wake == WakeProgress::BeforePoll {
+            let (entered, waiting) = tokio::sync::oneshot::channel();
+            let (release, blocked) = std::sync::mpsc::channel();
+            let gate = tauri::async_runtime::spawn(async move {
+                entered.send(()).expect("announce blocked wake worker");
+                blocked
+                    .recv_timeout(Duration::from_secs(3))
+                    .expect("wake worker was not released");
+            });
+            tokio::time::timeout(Duration::from_secs(3), waiting)
+                .await
+                .expect("wake worker did not reach gate")
+                .expect("wake worker gate dropped");
+            wake_gate = Some((release, gate));
+        }
+        if wake != WakeProgress::None {
+            MockLogin1::prepare_for_sleep(interface.signal_emitter(), false)
+                .await
+                .expect("emit real wake before terminal loss");
+            if wake == WakeProgress::BeforePoll {
+                assert_eq!(
+                    next_event(&mut events).await,
+                    MockEvent::InhibitorAcquired(2)
+                );
+            } else {
+                let waking = [next_event(&mut events).await, next_event(&mut events).await];
+                assert!(waking.contains(&MockEvent::Refresh));
+                assert!(waking.contains(&MockEvent::InhibitorAcquired(2)));
+            }
+        }
+        match loss {
+            TerminalLoss::StreamEnded => {
+                daemon.child.kill().expect("stop private system bus");
+                daemon.child.wait().expect("reap private system bus");
+            }
+            TerminalLoss::InvalidSignal => {
+                service
+                    .emit_signal(
+                        None::<&str>,
+                        LOGIN1_PATH,
+                        "org.freedesktop.login1.Manager",
+                        "PrepareForSleep",
+                        &("not a boolean",),
+                    )
+                    .await
+                    .expect("emit malformed sleep signal");
+            }
+            TerminalLoss::Cancelled | TerminalLoss::CancelledPreparing => listener.abort(),
+        }
+        let stopped = tokio::time::timeout(Duration::from_secs(3), listener)
+            .await
+            .expect("terminal listener did not stop");
+        match loss {
+            TerminalLoss::Cancelled | TerminalLoss::CancelledPreparing => {
+                assert!(stopped.unwrap_err().is_cancelled());
+            }
+            _ => assert!(stopped.unwrap().is_err(), "{loss:?}"),
+        }
+        if wake != WakeProgress::None {
+            // Recovery is still pending when the listener exits. Its cycle must
+            // remain owned by the wake task, not abandoned or ended by the listener.
+            assert_eq!(
+                next_event(&mut events).await,
+                MockEvent::InhibitorReleased(2)
+            );
+            if let Some((release, gate)) = wake_gate {
+                release.send(()).expect("release unpolled wake");
+                gate.await.expect("reap wake worker gate");
+                assert_eq!(next_event(&mut events).await, MockEvent::Refresh);
+            } else {
+                release_refresh.notify_one();
+            }
+            assert_eq!(next_event(&mut events).await, MockEvent::Resume);
+            assert_eq!(next_event(&mut events).await, MockEvent::DriverDeactivated);
+            assert!(
+                events.try_recv().is_err(),
+                "duplicate wake cleanup: {loss:?}"
+            );
+            return;
+        }
+        if block_prepare {
+            let cleanup = [next_event(&mut events).await, next_event(&mut events).await];
+            assert!(cleanup.contains(&MockEvent::DriverDeactivated));
+            assert!(cleanup.contains(&MockEvent::InhibitorReleased(1)));
+        } else {
+            assert_eq!(next_event(&mut events).await, MockEvent::DriverDeactivated);
+        }
+        // A terminal controller cannot turn a stale notification into wake recovery.
+        controller.did_wake().await;
+        assert!(
+            events.try_recv().is_err(),
+            "terminal loss must not refresh, resume, or release the driver twice: {loss:?}"
+        );
+        return;
+    }
 
     MockLogin1::prepare_for_sleep(interface.signal_emitter(), false)
         .await
@@ -278,4 +470,5 @@ async fn logind_full_sleep_cycle_releases_and_reacquires_inhibitor() {
     );
 
     listener.abort();
+    assert!(listener.await.unwrap_err().is_cancelled());
 }

--- a/apps/linux/tests/release_version_cases.json
+++ b/apps/linux/tests/release_version_cases.json
@@ -1,0 +1,63 @@
+{
+  "ordered": [
+    { "current": "2026.9.3", "candidate": "2026.9.3-1", "ordering": 1 },
+    { "current": "2026.9.3-1", "candidate": "2026.9.3-2", "ordering": 1 },
+    { "current": "2026.9.3-2", "candidate": "2026.9.4", "ordering": 1 },
+    { "current": "2026.9.3-2", "candidate": "2026.9.3-2", "ordering": 0 },
+    { "current": "2026.9.3-2", "candidate": "2026.9.3", "ordering": -1 },
+    { "current": "2026.9.3", "candidate": "2026.9.3", "ordering": 0 },
+    { "current": "2026.9.3-alpha.2", "candidate": "2026.9.3-alpha.10", "ordering": 1 },
+    { "current": "2026.9.3-alpha.10", "candidate": "2026.9.3-beta.1", "ordering": 1 },
+    { "current": "2026.9.3-beta.2", "candidate": "2026.9.3-beta.10", "ordering": 1 },
+    { "current": "2026.9.3-beta.10", "candidate": "2026.9.3", "ordering": 1 },
+    { "current": "2026.9.3-beta.1", "candidate": "2026.9.3-beta.1", "ordering": 0 },
+    { "current": "2026.9.3-2", "candidate": "2026.9.3-10", "ordering": 1 },
+    { "current": "2026.9.3-10", "candidate": "2026.9.4-alpha.1", "ordering": 1 },
+    { "current": "2026.9.32", "candidate": "2026.9.33", "ordering": 1 },
+    { "current": "2026.9.33", "candidate": "2026.10.1", "ordering": 1 },
+    { "current": "2026.12.34", "candidate": "2027.1.1", "ordering": 1 },
+    {
+      "current": "9999.12.9007199254740990",
+      "candidate": "9999.12.9007199254740991",
+      "ordering": 1
+    },
+    {
+      "current": "2026.9.3-9007199254740990",
+      "candidate": "2026.9.3-9007199254740991",
+      "ordering": 1
+    },
+    {
+      "current": "2026.9.3-alpha.9007199254740990",
+      "candidate": "2026.9.3-alpha.9007199254740991",
+      "ordering": 1
+    },
+    {
+      "current": "2026.9.3-beta.9007199254740990",
+      "candidate": "2026.9.3-beta.9007199254740991",
+      "ordering": 1
+    }
+  ],
+  "unrecognized": [
+    "0.1.0",
+    "999.12.1",
+    "10000.1.1",
+    "2026.0.1",
+    "2026.13.1",
+    "2026.9.0",
+    "2026.9.9007199254740992",
+    "2026.9.3-0",
+    "2026.9.3-alpha.0",
+    "2026.9.3-beta.0",
+    "2026.9.3-9007199254740992",
+    "2026.9.3-alpha.9007199254740992",
+    "2026.9.3-beta.9007199254740992",
+    "2026.9.3-18446744073709551616",
+    "2026.9.3-rc.1",
+    "2026.9.3-dev",
+    "2026.9.3-Beta.1",
+    "2026.9.3-beta",
+    "2026.9.3-beta.1.extra",
+    "2026.9.3+build.2",
+    "2026.9.3-1+build.2"
+  ]
+}

--- a/apps/linux/ui/index.html
+++ b/apps/linux/ui/index.html
@@ -158,6 +158,7 @@
 
         <div id="action-controls" class="controls hidden">
           <button id="primary-action" class="primary">Try again</button>
+          <button id="edit-connection" class="button-subtle hidden" type="button">Edit connection</button>
         </div>
 
         <section id="discovery" class="discovery" aria-labelledby="discovery-title">

--- a/apps/linux/ui/main.js
+++ b/apps/linux/ui/main.js
@@ -16,6 +16,7 @@ const elements = {
   footerMode: document.querySelector("#footer-mode"),
   gatewayList: document.querySelector("#gateway-list"),
   discoveryStatus: document.querySelector("#discovery-status"),
+  editConnection: document.querySelector("#edit-connection"),
   installButton: document.querySelector("#install-button"),
   installControls: document.querySelector("#install-controls"),
   installLog: document.querySelector("#install-log"),
@@ -38,6 +39,7 @@ const elements = {
   remoteUrlField: document.querySelector("#remote-url-field"),
   setupBack: document.querySelector("#setup-back"),
   setupContinue: document.querySelector("#setup-continue"),
+  setupNavigation: document.querySelector(".setup-navigation"),
   statusDot: document.querySelector("#status-dot"),
   title: document.querySelector("#title"),
   updateAction: document.querySelector("#update-action"),
@@ -59,6 +61,7 @@ let firstRunPhase = null;
 let selectedConnection = "local";
 let remoteTransport = "direct";
 let remoteConnectionPending = false;
+let editingConnection = false;
 
 function show(element, visible) {
   element.classList.toggle("hidden", !visible);
@@ -82,6 +85,7 @@ function render({
   }
   show(elements.installControls, showInstall);
   show(elements.actionControls, false);
+  show(elements.editConnection, false);
   show(elements.welcomeScreen, false);
   show(elements.connectionChoices, false);
   show(elements.discovery, true);
@@ -282,6 +286,8 @@ async function connect() {
         elements.channel.value = "dev";
       }
       renderWelcome();
+    } else if (snapshot.phase === "remoteError") {
+      renderRemoteRetry(snapshot.detail);
     }
   } catch (error) {
     renderRetry(friendlyError(error));
@@ -313,6 +319,9 @@ function renderConnectionChoices() {
 }
 
 function selectConnection(connection) {
+  if (editingConnection && connection !== "remote") {
+    return;
+  }
   selectedConnection = connection;
   const isRemote = connection === "remote";
   elements.connectionLocal.classList.toggle("selected", !isRemote);
@@ -404,7 +413,7 @@ async function connectRemoteGateway() {
   remoteConnectionPending = true;
   elements.remoteConnect.disabled = true;
   elements.setupContinue.disabled = true;
-  showRemoteFeedback("Checking your Gateway connection…", false);
+  showRemoteFeedback("Preparing the remote dashboard…", false);
 
   try {
     await invoke("connect_remote_gateway", {
@@ -415,7 +424,7 @@ async function connectRemoteGateway() {
       password: elements.remotePassword.value || null,
       remotePort: isDirect ? null : remotePort,
     });
-    showRemoteFeedback("Gateway connected. Opening OpenClaw…", false);
+    showRemoteFeedback("Opening the remote dashboard…", false);
   } catch (error) {
     const message = friendlyError(error);
     if (/auth|token|password|unauthori[sz]ed|forbidden|401|403/i.test(message)) {
@@ -433,6 +442,75 @@ function showRemoteFeedback(message, isError) {
   elements.remoteFeedback.textContent = message;
   elements.remoteFeedback.classList.toggle("error", isError);
   show(elements.remoteFeedback, true);
+}
+
+function renderRemoteRetry(message) {
+  editingConnection = true;
+  renderAction(
+    {
+      actionLabel: "Retry",
+      description: message || "Open Connection Settings to check the remote Gateway.",
+      dot: "error",
+      eyebrow: "REMOTE GATEWAY",
+      title: "Connection needs attention",
+    },
+    retryRemote,
+  );
+  show(elements.discovery, false);
+  show(elements.editConnection, true);
+}
+
+async function retryRemote() {
+  elements.primaryAction.disabled = true;
+  try {
+    // Retry the saved route, resolving credentials afresh without saving the
+    // editor's empty secret fields or selecting a local service.
+    const snapshot = await invoke("bootstrap", { remoteRetry: true });
+    if (snapshot.phase === "remoteError") {
+      renderRemoteRetry(snapshot.detail);
+    }
+  } catch (error) {
+    renderRemoteRetry(friendlyError(error));
+  } finally {
+    elements.primaryAction.disabled = false;
+  }
+}
+
+async function editConnection() {
+  editingConnection = true;
+  render({
+    description: "Update the remote Gateway address or authentication.",
+    dot: "idle",
+    eyebrow: "REMOTE GATEWAY",
+    title: "Connection Settings",
+  });
+  show(elements.connectionChoices, true);
+  show(elements.connectionLocal, false);
+  elements.connectionLocal.disabled = true;
+  show(elements.connectionRemote, false);
+  show(elements.setupNavigation, false);
+  selectConnection("remote");
+  elements.remoteToken.value = "";
+  elements.remotePassword.value = "";
+  elements.remoteAuth.open = false;
+  try {
+    const settings = await invoke("bootstrap", { connectionSettings: true });
+    const remote = settings.remote;
+    selectRemoteTransport(remote?.transport === "ssh" ? "ssh" : "direct");
+    elements.remoteUrl.value = remote?.url || "";
+    elements.remoteSshTarget.value = remote?.sshTarget || "";
+    elements.remotePort.value = remote?.remotePort || 18789;
+    if (settings.detail) {
+      showRemoteFeedback(settings.detail, true);
+    }
+    if (remote) {
+      primaryAction = retryRemote;
+      elements.primaryAction.textContent = "Retry";
+      show(elements.actionControls, true);
+    }
+  } catch (error) {
+    showRemoteFeedback(friendlyError(error), true);
+  }
 }
 
 async function install() {
@@ -528,6 +606,9 @@ for (const input of [
 elements.primaryAction.addEventListener("click", () => {
   void primaryAction?.();
 });
+elements.editConnection.addEventListener("click", () => {
+  void editConnection();
+});
 elements.updateAction.addEventListener("click", () => {
   void updateAction?.();
 });
@@ -569,14 +650,20 @@ await listen("updater://ready", ({ payload }) => {
   });
 });
 await listen("updater://available-manual", ({ payload }) => {
+  const openDownloadPage = () =>
+    invoke("open_release_page").catch((error) => {
+      if (updateAction !== openDownloadPage || elements.updateBanner.classList.contains("hidden")) {
+        return;
+      }
+      renderUpdate({
+        action: openDownloadPage,
+        actionLabel: "Open download page",
+        message: friendlyError(error),
+        title: "Could not open release page",
+      });
+    });
   renderUpdate({
-    action: () =>
-      invoke("open_release_page").catch((error) => {
-        renderUpdate({
-          message: friendlyError(error),
-          title: "Could not open release page",
-        });
-      }),
+    action: openDownloadPage,
     actionLabel: "Open download page",
     message: payload.notes || "Install the latest system package from the release page.",
     title: `Update available v${payload.version}`,
@@ -593,7 +680,9 @@ void refreshGateways();
 window.setInterval(() => void refreshGateways(), 2000);
 
 const mode = new URLSearchParams(window.location.search).get("mode");
-if (mode === "missingCli") {
+if (mode === "connectionSettings") {
+  await editConnection();
+} else if (mode === "missingCli") {
   render({
     description: "Install the OpenClaw CLI to connect to a local Gateway.",
     dot: "idle",

--- a/apps/linux/ui/quickchat.js
+++ b/apps/linux/ui/quickchat.js
@@ -294,6 +294,7 @@ function nextVisibilityOperation() {
 }
 let sendError = "";
 let gatewayState = "down";
+let gatewayGeneration = null;
 let gatewayNotice = "";
 let canvasSurfaceUrl = null;
 let canvasSurfaceObservedUrl = null;
@@ -343,6 +344,12 @@ function renderStatus() {
 }
 
 function setGatewayState(payload) {
+  if (!Number.isSafeInteger(payload?.gatewayGeneration) ||
+      (gatewayGeneration !== null && payload.gatewayGeneration < gatewayGeneration)) {
+    return;
+  }
+  const ownerChanged = gatewayGeneration !== payload.gatewayGeneration;
+  gatewayGeneration = payload.gatewayGeneration;
   const wasUp = gatewayState === "up";
   gatewayState = payload?.state || "down";
   gatewayNotice = typeof payload?.notice === "string" ? payload.notice : "";
@@ -355,18 +362,16 @@ function setGatewayState(payload) {
     gatewayState === "up" && typeof payload?.canvasSurfaceUrl === "string"
       ? payload.canvasSurfaceUrl
       : null;
-  if (nextCanvasSurfaceUrl !== canvasSurfaceObservedUrl) {
+  if (ownerChanged || nextCanvasSurfaceUrl !== canvasSurfaceObservedUrl) {
     canvasSurfaceObservedUrl = nextCanvasSurfaceUrl;
     canvasSurfaceUrl = nextCanvasSurfaceUrl;
     canvasSurfaceRefreshedAt = nextCanvasSurfaceUrl ? Date.now() : 0;
     canvasSurfaceRetryAt = 0;
     window.clearTimeout(canvasSurfaceRetryTimer);
     canvasSurfaceRetryTimer = null;
-    if (!nextCanvasSurfaceUrl) {
-      canvasSurfaceRefreshPromise = null;
-    }
+    canvasSurfaceRefreshPromise = null;
   }
-  if (gatewayState !== "up") {
+  if (ownerChanged || gatewayState !== "up") {
     gatewayDisconnectSequence += 1;
     terminalizeDisconnectedReply();
   }
@@ -375,7 +380,7 @@ function setGatewayState(payload) {
   if (activeReply?.widgets.length) {
     renderReplyWidgets();
   }
-  if (gatewayState === "up" && !wasUp) {
+  if (gatewayState === "up" && (!wasUp || ownerChanged)) {
     void refreshAgents();
   }
 }
@@ -489,15 +494,23 @@ function refreshCanvasSurface() {
     return canvasSurfaceRefreshPromise;
   }
   const requestedObservedUrl = canvasSurfaceObservedUrl;
+  const requestedGeneration = gatewayGeneration;
   if (!requestedObservedUrl || Date.now() < canvasSurfaceRetryAt) {
     return Promise.resolve(canvasSurfaceUrl);
   }
-  canvasSurfaceRefreshPromise = invoke("quickchat_refresh_widget_surface")
+  const pending = invoke("quickchat_refresh_widget_surface", {
+    gatewayGeneration: requestedGeneration,
+    observedUrl: requestedObservedUrl,
+  })
     .then((refreshed) => {
-      if (canvasSurfaceObservedUrl !== requestedObservedUrl) {
+      if (gatewayGeneration !== requestedGeneration ||
+          canvasSurfaceObservedUrl !== requestedObservedUrl ||
+          canvasSurfaceRefreshPromise !== pending) {
         return canvasSurfaceUrl;
       }
-      const next = typeof refreshed === "string" && refreshed.trim() ? refreshed : null;
+      const next = refreshed?.gatewayGeneration === requestedGeneration &&
+        typeof refreshed.canvasSurfaceUrl === "string" && refreshed.canvasSurfaceUrl.trim()
+        ? refreshed.canvasSurfaceUrl : null;
       if (next) {
         canvasSurfaceObservedUrl = next;
         canvasSurfaceUrl = next;
@@ -510,13 +523,18 @@ function refreshCanvasSurface() {
       return canvasSurfaceUrl;
     })
     .catch(() => {
-      if (canvasSurfaceObservedUrl === requestedObservedUrl) {
+      if (gatewayGeneration === requestedGeneration &&
+          canvasSurfaceObservedUrl === requestedObservedUrl &&
+          canvasSurfaceRefreshPromise === pending) {
         canvasSurfaceUrl = null;
         canvasSurfaceRetryAt = Date.now() + CANVAS_SURFACE_REFRESH_RETRY_MS;
       }
       return canvasSurfaceUrl;
     })
     .finally(() => {
+      if (gatewayGeneration !== requestedGeneration || canvasSurfaceRefreshPromise !== pending) {
+        return;
+      }
       canvasSurfaceRefreshPromise = null;
       if (activeReply?.widgets.length) {
         renderReplyWidgets();
@@ -529,17 +547,63 @@ function refreshCanvasSurface() {
         scheduleCanvasSurfaceRetry();
       }
     });
+  canvasSurfaceRefreshPromise = pending;
   return canvasSurfaceRefreshPromise;
 }
 
 let widgetSyncScheduled = false;
-let widgetSyncPromise = Promise.resolve();
+let widgetSyncPromise = null;
+let pendingWidgetSync = null;
+let widgetSyncSequence = 0;
+
+function widgetSyncIsCurrent(snapshot) {
+  return !hiding &&
+    snapshot.generation === visibilitySequence &&
+    snapshot.sessionId === rendererSessionId &&
+    snapshot.rendererEpoch === rendererEpoch &&
+    snapshot.gatewayGeneration !== null &&
+    snapshot.gatewayGeneration === gatewayGeneration &&
+    snapshot.surfaceUrl === canvasSurfaceUrl;
+}
+
+function drainWidgetSync() {
+  if (widgetSyncPromise || !pendingWidgetSync) {
+    return;
+  }
+  const pending = (async () => {
+    while (pendingWidgetSync) {
+      const snapshot = pendingWidgetSync;
+      const sequence = widgetSyncSequence;
+      pendingWidgetSync = null;
+      if (!widgetSyncIsCurrent(snapshot)) {
+        continue;
+      }
+      try {
+        await invoke("quickchat_sync_widgets", snapshot);
+      } catch (error) {
+        if (sequence === widgetSyncSequence && widgetSyncIsCurrent(snapshot)) {
+          sendError = friendlyError(error, "Could not render the widget.");
+          renderStatus();
+        }
+      }
+    }
+  })();
+  widgetSyncPromise = pending;
+  void pending.finally(() => {
+    if (widgetSyncPromise === pending) {
+      widgetSyncPromise = null;
+      drainWidgetSync();
+    }
+  });
+}
 
 function scheduleWidgetSync() {
+  // An upcoming frame supersedes even a captured snapshot waiting behind native work.
+  widgetSyncSequence += 1;
+  pendingWidgetSync = null;
   if (widgetSyncScheduled) {
     return;
   }
-  const generation = visibilitySequence;
   widgetSyncScheduled = true;
   window.requestAnimationFrame(() => {
     widgetSyncScheduled = false;
@@ -548,9 +612,12 @@ function scheduleWidgetSync() {
     const host = elements.replyWidgets.querySelector(".inline-widget-host");
     const rect = host?.getBoundingClientRect();
     const layouts = [];
-    if (rect && rect.width > 0 && rect.height > 0) {
+    const owner = gatewayGeneration;
+    const surface = canvasSurfaceUrl;
+    if (activeReply?.gatewayGeneration === owner && gatewayState === "up" &&
+        rect && rect.width > 0 && rect.height > 0) {
       for (const widget of widgets) {
-        const url = resolveInlineWidgetUrl(canvasSurfaceUrl, widget.target);
+        const url = resolveInlineWidgetUrl(surface, widget.target);
         if (!url) {
           continue;
         }
@@ -566,22 +633,17 @@ function scheduleWidgetSync() {
         });
       }
     }
-    widgetSyncPromise = widgetSyncPromise
-      .catch(() => {})
-      .then(() =>
-        invoke("quickchat_sync_widgets", {
-          widgets: layouts,
-          hasWidgets: widgets.length > 0,
-          expanded: !elements.reply.hidden || Boolean(openPopover),
-          sessionId: rendererSessionId,
-          rendererEpoch,
-          generation,
-        }),
-      )
-      .catch(/** @param {unknown} error */ (error) => {
-        sendError = friendlyError(error, "Could not render the widget.");
-        renderStatus();
-      });
+    pendingWidgetSync = {
+      widgets: layouts,
+      hasWidgets: widgets.length > 0,
+      expanded: !elements.reply.hidden || Boolean(openPopover),
+      sessionId: rendererSessionId,
+      rendererEpoch,
+      generation: visibilitySequence,
+      gatewayGeneration: owner,
+      surfaceUrl: surface,
+    };
+    drainWidgetSync();
   });
 }
 
@@ -631,7 +693,8 @@ function renderReplyWidgets() {
   title.textContent = widget.title;
   card.append(title);
 
-  if (!resolveInlineWidgetUrl(canvasSurfaceUrl, widget.target)) {
+  if (activeReply.gatewayGeneration !== gatewayGeneration ||
+      !resolveInlineWidgetUrl(canvasSurfaceUrl, widget.target)) {
     const unavailable = document.createElement("div");
     unavailable.className = "inline-widget-unavailable";
     unavailable.textContent = "Widget unavailable until the Gateway reconnects.";
@@ -701,6 +764,7 @@ function replyTargetMatches(target, payload) {
 function startReply(target, identity, runId) {
   activeReply = {
     runId,
+    gatewayGeneration: target.gatewayGeneration,
     target: {
       sessionKey: target.sessionKey,
       agentId: typeof target.agentId === "string" ? target.agentId : null,
@@ -730,7 +794,9 @@ function applyChatEvent(payload) {
   }
   // The chat.send ACK owns this reply. Exact runId equality is primary; the routing target remains
   // a secondary guard so concurrent turns from other surfaces never enter this reply area.
-  if (payload?.runId !== activeReply.runId || !replyTargetMatches(activeReply.target, payload)) {
+  if (payload?.gatewayGeneration !== activeReply.gatewayGeneration ||
+      activeReply.gatewayGeneration !== gatewayGeneration ||
+      payload?.runId !== activeReply.runId || !replyTargetMatches(activeReply.target, payload)) {
     return;
   }
   if (activeReply.terminal) {
@@ -776,6 +842,29 @@ function applyChatEvent(payload) {
     scrollReplyToEnd();
   }
   updateSendButton();
+}
+
+function applyRecoveredReply(result) {
+  if (activeReply?.terminal || result.status !== "ok") return;
+  if (!Array.isArray(result.recoveredMessages) || result.recoveredMessages.length === 0) {
+    throw new Error("The completed reply could not be recovered.");
+  }
+  const content = [];
+  for (const message of result.recoveredMessages) {
+    const text = chatMessageText(message);
+    if (text) content.push({ type: "text", text });
+    if (Array.isArray(message.content)) {
+      content.push(...message.content.filter((block) => block?.type === "canvas"));
+    }
+  }
+  applyChatEvent({
+    gatewayGeneration: result.gatewayGeneration,
+    sessionKey: result.sessionKey,
+    agentId: result.agentId,
+    runId: result.runId,
+    state: "final",
+    message: { role: "assistant", content },
+  });
 }
 
 function handleChatEvent(payload) {
@@ -833,21 +922,26 @@ function renderAgentList() {
   }
 }
 
-async function refreshIdentity() {
+async function refreshIdentity(owner = gatewayGeneration) {
   try {
-    renderIdentity(await invoke("quickchat_identity"));
+    const identity = await invoke("quickchat_identity");
+    if (gatewayGeneration === owner) renderIdentity(identity);
   } catch {
-    renderIdentity({ id: "", name: "Agent", isDefault: true });
+    if (gatewayGeneration === owner) renderIdentity({ id: "", name: "Agent", isDefault: true });
   }
 }
 
 async function refreshAgents() {
+  const owner = gatewayGeneration;
   try {
-    agents = await invoke("quickchat_agents");
+    const next = await invoke("quickchat_agents");
+    if (gatewayGeneration !== owner) return;
+    agents = next;
   } catch {
+    if (gatewayGeneration !== owner) return;
     agents = [];
   }
-  await refreshIdentity();
+  await refreshIdentity(owner);
 }
 
 async function selectAgent(agentId) {
@@ -855,12 +949,16 @@ async function selectAgent(agentId) {
     return;
   }
   selectingAgent = true;
+  const owner = gatewayGeneration;
   updateSendButton();
   try {
     await invoke("quickchat_select_agent", { agentId });
-    await refreshIdentity();
+    if (gatewayGeneration !== owner) return;
+    await refreshIdentity(owner);
+    if (gatewayGeneration !== owner) return;
     closePopover();
   } catch (error) {
+    if (gatewayGeneration !== owner) return;
     sendError = friendlyError(error, "Could not select that agent.");
     renderStatus();
   } finally {
@@ -1099,6 +1197,7 @@ async function send(openDashboard) {
   sending = true;
   const sendDisconnectSequence = gatewayDisconnectSequence;
   const sendVisibilitySequence = visibilitySequence;
+  const sendGeneration = gatewayGeneration;
   clearReply();
   pendingChatEvents = [];
   void invoke("quickchat_set_expanded", { expanded: false });
@@ -1113,6 +1212,9 @@ async function send(openDashboard) {
     }
     if (typeof result.runId !== "string" || !result.runId) {
       throw new Error("Gateway accepted the message without a run ID.");
+    }
+    if (result.gatewayGeneration !== sendGeneration || gatewayGeneration !== sendGeneration) {
+      throw new Error("Gateway changed before the Quick Chat reply was accepted.");
     }
     sending = false;
     sendError = "";
@@ -1129,6 +1231,7 @@ async function send(openDashboard) {
     for (const payload of bufferedEvents) {
       applyChatEvent(payload);
     }
+    applyRecoveredReply(result);
     if (gatewayDisconnectSequence !== sendDisconnectSequence || gatewayState !== "up") {
       terminalizeDisconnectedReply();
     }

--- a/docs/platforms/linux.md
+++ b/docs/platforms/linux.md
@@ -29,13 +29,40 @@ Gateways. It:
 - discovers nearby Bonjour Gateways and opens each Control UI in a route-scoped window, so several
   Gateway dashboards can stay connected and be used simultaneously
 - opens the Gateway-served Control UI with its resolved authentication URL
-- opens Model Setup for an unconfigured local or remote Gateway, automatically
-  tests available AI credentials, and verifies an existing model before
-  opening the dashboard
+- opens Model Setup for an unconfigured local or remote Gateway, discovers
+  available AI access, and waits for your explicit action before selecting,
+  testing, installing, or saving a provider
 - continues into guided onboarding after connecting a new model; onboarding can
   import detected Claude Code, Codex, or Hermes memories into the agent workspace
   (the same import stays available later under Settings → Import Memory)
 - remains available from the system tray when its window is closed
+
+### Desktop compatibility
+
+Published AMD64 AppImages are built on Ubuntu 22.04 and require glibc 2.35 or
+newer plus a `libstdc++` that provides `GLIBCXX_3.4.30`. Ubuntu 22.04 and
+Debian 12 meet that ABI floor. RHEL 9 and Rocky Linux 9 ship glibc 2.34, so
+they cannot run the published AppImage. Extracting the AppImage does not bypass
+this requirement.
+
+`.deb` installs stay owned by the system package manager; installing the download
+does not add an APT repository. AppImages use the signed in-app updater.
+
+Global shortcuts are available on X11. On Wayland, use the tray's **Quick Chat**
+entry when your desktop provides a tray host; global shortcuts are unavailable.
+Tray access is a shortcut fallback, not a native Wayland compatibility guarantee.
+
+The shell does not grant microphone capture to its embedded WebKitGTK WebView,
+so `getUserMedia` is expected to fail there. Open the Gateway's Control UI in a
+regular browser for [Talk mode](/nodes/talk).
+
+The desktop connects as a Gateway operator, not a node host. Device commands
+belong to the [CLI node host](/cli/node) and its
+[Linux Node plugin](/platforms/linux#node-capabilities).
+
+The [native macOS app](/platforms/macos) and [Windows Hub](/platforms/windows)
+are separate applications, not this shell's opt-in macOS and Windows Tauri test
+bundles. See their platform pages for requirements and capabilities.
 
 ### First-run setup
 
@@ -65,11 +92,13 @@ shared-store references must be resolved on their owning Gateway host.
 SSH uses your existing OpenSSH authentication and host-key verification. See
 [Remote access](/gateway/remote) for secure Gateway configuration.
 
-After the connection succeeds, Model Setup checks for existing AI credentials,
-offers provider sign-in or API-key entry when needed, and requires a successful
-model response before opening the agent. An already configured Gateway opens
-its normal dashboard after verification; newly configured access continues into
-guided onboarding.
+After the connection succeeds, Model Setup discovers AI access available to the
+selected Gateway and shows it as a choice. Discovery does not import or copy an
+account. On a fresh visit, the companion does not select, test, install, or save
+a provider until you choose its action. Provider sign-in or API-key entry is
+offered when needed, and a successful model response is required before opening
+the agent. An already configured Gateway opens its normal dashboard after
+verification; newly configured access continues into guided onboarding.
 
 If the Gateway confirms that a live model test failed before saving the model
 and credentials, close the error and retry or choose another connection.
@@ -112,26 +141,29 @@ the Gateway; remote Gateway routes are left untouched. If logind or the system
 bus is unavailable, the sleep hook disables itself and the app continues
 normally.
 
-Realtime voice Talk inside the companion's embedded WebView is not validated:
-the shell does not grant microphone capture to the WebKitGTK WebView, so
-`getUserMedia` is expected to fail there. Until that lands, open the Gateway's
-Control UI in a regular browser for [Talk mode](/nodes/talk).
+### Download
 
-Stable releases built from `main` or their matching `release/YYYY.M.PATCH` branch
-ship `.deb` and AppImage bundles as assets on the
-[GitHub release](https://github.com/openclaw/openclaw/releases) for the tag,
+Start with the
+[latest published Linux companion](https://github.com/openclaw/openclaw/releases/tag/linux-stable).
+The `linux-stable` channel links to versioned Linux bundles; it does not imply
+that the latest core release has a Linux build.
+
+When Linux bundles are published for a stable tag, the `.deb` and AppImage are
+attached to its [GitHub release](https://github.com/openclaw/openclaw/releases),
 named `OpenClaw-<version>-amd64.deb` and `OpenClaw-<version>-amd64.AppImage`,
-with a `SHA256SUMS.linux-app.txt` checksum file next to them. Download the
-`.deb` and install it with `sudo apt install ./OpenClaw-<version>-amd64.deb`,
+with a `SHA256SUMS.linux-app.txt` checksum file next to them. Linux publication
+runs through `Linux App Release Request` and `Linux App Release` independently
+of core releases. The tag must be reachable from `main` or its matching
+`release/YYYY.M.PATCH` branch.
+
+The Linux updater uses the channel's `latest.json`, independently of core
+release timing. Older installed versions retain their legacy feed until a
+signed upgrade changes it; see [Linux publication policy](/reference/RELEASING#linux-companion-publication).
+
+Download the `.deb` and install it with `sudo apt install ./OpenClaw-<version>-amd64.deb`,
 or mark the AppImage executable and run it directly. The AppImage runtime
 needs FUSE 2 (`sudo apt install libfuse2`, or `libfuse2t64` on Ubuntu 24.04+);
 without it, run the AppImage with `APPIMAGE_EXTRACT_AND_RUN=1`.
-
-Published AMD64 AppImages are built on Ubuntu 22.04 and require glibc 2.35 or
-newer plus a `libstdc++` that provides `GLIBCXX_3.4.30`. Ubuntu 22.04 and
-Debian 12 meet that ABI floor. RHEL 9 and Rocky Linux 9 ship glibc 2.34, so
-they cannot run the published AppImage. Extracting the AppImage does not bypass
-this requirement.
 
 ### Media codecs
 
@@ -179,10 +211,11 @@ apps/linux/scripts/finalize-appimage.sh \
   apps/linux/src-tauri/target/release/bundle/appimage
 ```
 
-The `Linux App` CI workflow uploads the same bundles as the
-`openclaw-linux-companion` artifact for pull requests touching the app and for
-manual runs. See `apps/linux/README.md` in the repository for Linux build
-dependencies and development commands.
+The `Linux App` workflow checks affected pull requests without building bundles.
+Manual runs build and upload the `.deb` and AppImage as the
+`openclaw-linux-companion` workflow artifact; they do not publish a release.
+See `apps/linux/README.md` in the repository for Linux build dependencies and
+development commands.
 
 ### Quick Chat
 

--- a/docs/reference/RELEASING.md
+++ b/docs/reference/RELEASING.md
@@ -46,6 +46,54 @@ Tideclaw alpha builds are a separate internal prerelease track (npm dist-tag `al
 - If a beta tag has been pushed or published and needs a fix, maintainers cut the next `-beta.N` tag instead of deleting or recreating the old one
 - Detailed release procedure, approvals, credentials, and recovery notes are maintainer-only
 
+## Linux companion publication
+
+Linux bundles publish independently through `Linux App Release Request` and
+`Linux App Release`. Core release completion does not guarantee Linux assets.
+The [latest published Linux companion](https://github.com/openclaw/openclaw/releases/tag/linux-stable)
+links to immutable versioned bundles. `linux-stable` is a fixed control tag with
+a prerelease, non-latest release, not an application version; do not move its
+tag when promoting the channel.
+
+The canonical Linux updater endpoint is
+`https://github.com/openclaw/openclaw/releases/download/linux-stable/latest.json`.
+Linux publication verifies signed, publicly available assets, preserves the
+immutable `OpenClaw-<version>-linux.json` manifest, then forward-promotes the
+channel and mirrors its exact bytes. Reuse successful manifest bytes, including
+`pub_date`, on retry. Conflicting versioned assets or same-version manifest
+bytes must stop publication rather than be overwritten.
+
+If canonical replacement is interrupted after deletion, normal publication and
+mirroring stop; `mirror` does not recreate a missing canonical manifest. The
+release owner must reconcile the last verified canonical state and all
+intervening publication evidence, establish the version floor, and coordinate
+one bounded recovery window excluding concurrent writers. Restore only approved
+immutable manifest bytes after fresh channel release-ID, tag-SHA, and inventory
+checks, then verify public canonical readback before mirroring and checking the
+legacy endpoint. Ambiguous history remains stopped. Neither the newest release
+nor a supplied version/hash authorizes a reset.
+
+Older clients use `/releases/latest/download/latest.json`. After regular core
+GitHub release finalization, core makes only a bounded detached mirror-only
+dispatch to the existing Linux release workflow. The mirror job must not wait
+inside the core parent's top-level concurrency; core does not wait for mirror
+completion. The mirror binds the core tag/SHA and rechecks the actual latest
+selector around writes. Keep this maintenance until explicit retirement.
+Dispatch acceptance is not mirror success. Dispatch or mirror failures must
+be visibly reported as degraded and reconciled without
+blocking npm, Docker, GitHub finalization, or main closeout. A successful core
+release with a degraded mirror is not a successful Linux update-feed repair.
+
+Keep source repair, public feed restoration, and installed-client migration
+separate. Initializing the control release, activating mirroring, publishing
+assets, and selecting a migration version require publication approval. A
+legacy-client migration needs a separately approved greater-base release,
+signed public assets, and an isolated original-AppImage upgrade and relaunch
+through its actual legacy endpoint and signing key. A source endpoint change
+or metadata-only restoration does not prove that migration. Package-managed
+installs retain their package-manager/download path; opt-in macOS and Windows
+Tauri test bundles retain their separate channel.
+
 ## Monthly Gateway extended-stable publication
 
 For completed month `YYYY.M`, create `extended-stable/YYYY.M.33` and publish

--- a/scripts/lib/release-publish-children.sh
+++ b/scripts/lib/release-publish-children.sh
@@ -536,7 +536,7 @@ guard_existing_public_release() {
   release_body_file="${RUNNER_TEMP}/existing-public-release-body.md"
   printf '%s' "${release_body}" > "${release_body_file}"
   has_canonical_body="false"
-  if canonical_release_body_matches "${release_body_file}"; then
+  if canonical_release_body_matches "${release_body_file}" true; then
     has_canonical_body="true"
   fi
 
@@ -700,14 +700,14 @@ render_github_release_notes() {
   local metadata_file="${3:-}"
   local changelog_file="${RUNNER_TEMP}/CHANGELOG.md"
   local -a render_args=(
-    node --import tsx scripts/render-github-release-notes.mts
+    node --import tsx "${GITHUB_WORKSPACE}/.release-harness/scripts/render-github-release-notes.mts"
     --changelog "${changelog_file}"
     --tag "${RELEASE_TAG}"
     --repository "${GITHUB_REPOSITORY}"
     --output "${output_file}"
   )
 
-  git show "${TARGET_SHA}:CHANGELOG.md" > "${changelog_file}"
+  git show "${TARGET_SHA}:CHANGELOG.md" > "${changelog_file}" || return 1
   if [[ -n "${verification_file}" ]]; then
     render_args+=(--verification-file "${verification_file}")
   fi
@@ -739,32 +739,20 @@ verify_release_tag_target() {
 
 canonical_release_body_matches() {
   local body_file="$1"
+  local allow_previous_canonical="${2:-false}"
   local changelog_file="${RUNNER_TEMP}/release-body-changelog.md"
-  git show "${TARGET_SHA}:CHANGELOG.md" > "${changelog_file}"
-  RELEASE_BODY_FILE="${body_file}" \
-    RELEASE_CHANGELOG_FILE="${changelog_file}" \
-    RELEASE_REPOSITORY="${GITHUB_REPOSITORY}" \
-    RELEASE_TAG="${RELEASE_TAG}" \
-    node --import tsx --input-type=module <<'NODE'
-import { readFileSync } from "node:fs";
-import {
-  releaseNotesVersionForTag,
-  verifyGithubReleaseNotes,
-} from "./scripts/render-github-release-notes.mts";
-
-const body = readFileSync(process.env.RELEASE_BODY_FILE, "utf8");
-const changelog = readFileSync(process.env.RELEASE_CHANGELOG_FILE, "utf8");
-const result = verifyGithubReleaseNotes({
-  body,
-  changelog,
-  version: releaseNotesVersionForTag(process.env.RELEASE_TAG),
-  tag: process.env.RELEASE_TAG,
-  repository: process.env.RELEASE_REPOSITORY,
-});
-if (!result.matches) {
-  process.exitCode = 1;
-}
-NODE
+  local -a verify_args=(
+    node --import tsx "${GITHUB_WORKSPACE}/.release-harness/scripts/render-github-release-notes.mts"
+    --changelog "${changelog_file}"
+    --tag "${RELEASE_TAG}"
+    --repository "${GITHUB_REPOSITORY}"
+    --verify-body "${body_file}"
+  )
+  git show "${TARGET_SHA}:CHANGELOG.md" > "${changelog_file}" || return 1
+  if [[ "${allow_previous_canonical}" == "true" ]]; then
+    verify_args+=(--allow-previous-canonical)
+  fi
+  "${verify_args[@]}"
 }
 
 create_or_update_github_release() {
@@ -783,16 +771,17 @@ create_or_update_github_release() {
 
   if existing_state="$(gh release view "${RELEASE_TAG}" --repo "$GITHUB_REPOSITORY" --json isDraft,body 2>/dev/null)"; then
     # A public page only reaches this call after
-    # guard_existing_public_release accepted it as canonical; leave
-    # it untouched so a failed resume cannot strip its verification
-    # proof before the proof append re-runs.
+    # guard_existing_public_release accepted it as current or previous canonical
+    # notes. Preserve its proof until proof append also writes the Linux link.
     if [[ "$(printf '%s' "${existing_state}" | jq -r '.isDraft')" != "true" ]]; then
       existing_body_file="${RUNNER_TEMP}/existing-public-release-notes.md"
       printf '%s' "$(printf '%s' "${existing_state}" | jq -r '.body')" > "${existing_body_file}"
-      if canonical_release_body_matches "${existing_body_file}"; then
+      if canonical_release_body_matches "${existing_body_file}" true; then
         echo "- GitHub release: existing public page left untouched until proof append" >> "$GITHUB_STEP_SUMMARY"
         return 0
       fi
+      echo "Public release notes are no longer canonical; refusing to overwrite them." >&2
+      return 1
     fi
     # Latest promotion is invalid while this existing release remains a draft.
     gh release edit "${RELEASE_TAG}" --repo "$GITHUB_REPOSITORY" \

--- a/scripts/linux-app-channel.mjs
+++ b/scripts/linux-app-channel.mjs
@@ -1,0 +1,1101 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+  closeSync,
+  copyFileSync,
+  lstatSync,
+  mkdtempSync,
+  openSync,
+  readFileSync,
+  readSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import { parseArgs } from "node:util";
+import {
+  classifyReleaseTrain,
+  compareReleaseVersions,
+  parseReleaseVersion,
+} from "./lib/release-version.mjs";
+
+const REPOSITORY = "openclaw/openclaw";
+const CHANNEL = "linux-stable";
+const INITIAL_BODY = "OpenClaw Linux update channel. Publication is not complete.";
+const METADATA_LIMIT = 1024 * 1024;
+const BUNDLE_LIMIT = 2 * 1024 * 1024 * 1024;
+const SHA = /^[0-9a-f]{40}$/u;
+const DIGEST = /^[0-9a-f]{64}$/u;
+
+function digest(bytes) {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+function fileDigest(path) {
+  const hash = createHash("sha256");
+  const fd = openSync(path, "r");
+  const buffer = Buffer.alloc(1024 * 1024);
+  try {
+    for (let count; (count = readSync(fd, buffer, 0, buffer.length, null)) !== 0;) {
+      hash.update(buffer.subarray(0, count));
+    }
+    return hash.digest("hex");
+  } finally {
+    closeSync(fd);
+  }
+}
+
+function command(binary, args, timeout = 60_000) {
+  return execFileSync(binary, args, {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+    timeout,
+    killSignal: "SIGKILL",
+    maxBuffer: 2 * METADATA_LIMIT,
+    env: {
+      ...process.env,
+      GH_PROMPT_DISABLED: "1",
+      TAURI_SIGNING_PRIVATE_KEY: "",
+      TAURI_SIGNING_PRIVATE_KEY_PASSWORD: "",
+    },
+  });
+}
+
+function regularVersion(version) {
+  const parsed = parseReleaseVersion(version);
+  assert(
+    parsed && parsed.version === version && classifyReleaseTrain(parsed) === "stable",
+    `Not a canonical regular Linux release: ${version}`,
+  );
+  return version;
+}
+
+function releaseVersion(tag) {
+  assert(typeof tag === "string" && tag.startsWith("v"), "Expected a versioned release tag");
+  return regularVersion(tag.slice(1));
+}
+
+function assetUrl(tag, name) {
+  return `https://github.com/${REPOSITORY}/releases/download/${tag}/${name}`;
+}
+
+function manifestName(version) {
+  return `OpenClaw-${version}-linux.json`;
+}
+
+function bundleNames(version) {
+  return {
+    appimage: `OpenClaw-${version}-amd64.AppImage`,
+    deb: `OpenClaw-${version}-amd64.deb`,
+    desktop: [
+      `OpenClaw-${version}-darwin-aarch64.dmg`,
+      `OpenClaw-${version}-darwin-aarch64.app.tar.gz`,
+      `OpenClaw-${version}-windows-x86_64.exe`,
+    ],
+    checksums: "SHA256SUMS.linux-app.txt",
+  };
+}
+
+function asset(release, name) {
+  const matches = release.assets.filter((entry) => entry.name === name);
+  assert(matches.length <= 1, `Duplicate asset ${name} on ${release.tag_name}`);
+  return matches[0];
+}
+
+function identity(release) {
+  return [release.id, release.tag_name, release.draft, release.prerelease];
+}
+
+function assetIdentity(entry) {
+  return (
+    entry && [
+      entry.id,
+      entry.name,
+      entry.size,
+      entry.state,
+      entry.digest,
+      entry.browser_download_url,
+    ]
+  );
+}
+
+class GitHub {
+  constructor(directory) {
+    this.directory = directory;
+    this.sequence = 0;
+  }
+
+  temp(name) {
+    return join(this.directory, `${++this.sequence}-${name}`);
+  }
+
+  api(endpoint, missing = false) {
+    try {
+      return JSON.parse(command("gh", ["api", `repos/${REPOSITORY}/${endpoint}`]));
+    } catch (error) {
+      if (missing && /\bHTTP 404\b/u.test(String(error.stderr))) {
+        return null;
+      }
+      throw error;
+    }
+  }
+
+  release(tag, missing = false) {
+    const release = this.api(`releases/tags/${encodeURIComponent(tag)}`, missing);
+    if (!release) {
+      return null;
+    }
+    assert(
+      Number.isSafeInteger(release.id) &&
+        release.id > 0 &&
+        release.tag_name === tag &&
+        typeof release.draft === "boolean" &&
+        typeof release.prerelease === "boolean",
+      "Release identity is invalid",
+    );
+    const assets = [];
+    for (let page = 1; page <= 5; page++) {
+      const rows = this.api(`releases/${release.id}/assets?per_page=100&page=${page}`);
+      assert(Array.isArray(rows) && rows.length <= 100, "Invalid asset inventory");
+      assets.push(...rows);
+      if (rows.length < 100) {
+        return { ...release, assets };
+      }
+    }
+    throw new Error("Release asset inventory exceeds the publication bound");
+  }
+
+  latest() {
+    const latest = this.api("releases/latest", true);
+    if (!latest) {
+      return null;
+    }
+    const release = this.release(latest.tag_name);
+    assert.equal(release.id, latest.id, "Latest release changed during observation");
+    return release;
+  }
+
+  source(tag, missing = false) {
+    const ref = this.api(`git/ref/tags/${encodeURIComponent(tag)}`, missing);
+    if (!ref) {
+      return null;
+    }
+    let object = ref.object;
+    for (let depth = 0; depth < 5; depth++) {
+      assert(object && SHA.test(object.sha), "Invalid release tag object");
+      if (object.type === "commit") {
+        return object.sha;
+      }
+      assert.equal(object.type, "tag", "Release tag must resolve to a commit");
+      object = this.api(`git/tags/${object.sha}`).object;
+    }
+    throw new Error("Release tag nesting exceeds the publication bound");
+  }
+
+  download(url, limit) {
+    const path = this.temp("download");
+    command(
+      "curl",
+      [
+        "--disable",
+        "--fail",
+        "--location",
+        "--silent",
+        "--show-error",
+        "--proto",
+        "=https",
+        "--proto-redir",
+        "=https",
+        "--connect-timeout",
+        "10",
+        "--max-time",
+        "90",
+        "--max-filesize",
+        String(limit),
+        "--output",
+        path,
+        url,
+      ],
+      95_000,
+    );
+    const stat = lstatSync(path);
+    assert(stat.isFile() && stat.size > 0 && stat.size <= limit, "Invalid public download");
+    return path;
+  }
+
+  publicAsset(release, entry, limit = METADATA_LIMIT) {
+    assert(
+      Number.isSafeInteger(entry.id) &&
+        entry.id > 0 &&
+        Number.isSafeInteger(entry.size) &&
+        entry.size > 0 &&
+        entry.size <= limit &&
+        entry.state === "uploaded",
+      `Invalid asset identity: ${entry.name}`,
+    );
+    const url = assetUrl(release.tag_name, entry.name);
+    assert.equal(entry.browser_download_url, url, "Unexpected public asset URL");
+    const path = this.download(url, limit);
+    assert.equal(lstatSync(path).size, entry.size, "Public asset size mismatch");
+    if (entry.digest != null) {
+      assert.equal(entry.digest, `sha256:${fileDigest(path)}`, "Public asset digest mismatch");
+    }
+    return path;
+  }
+
+  metadata(release, name) {
+    const entry = asset(release, name);
+    return entry ? readFileSync(this.publicAsset(release, entry)) : null;
+  }
+
+  unchanged(release, source) {
+    const fresh = this.release(release.tag_name);
+    assert.deepEqual(identity(fresh), identity(release), "Release identity changed before write");
+    assert.equal(this.source(release.tag_name), source, "Release source changed before write");
+    return fresh;
+  }
+
+  upload(release, source, name, path, mutable = false, beforeWrite = () => {}) {
+    const bytesHash = fileDigest(path);
+    const previous = asset(release, name);
+    if (previous) {
+      const old = this.publicAsset(release, previous, BUNDLE_LIMIT);
+      if (fileDigest(old) === bytesHash) {
+        return;
+      }
+      assert(mutable, `Immutable asset conflict: ${name}`);
+    }
+    const uploadDirectory = mkdtempSync(join(this.directory, "upload-"));
+    const uploadPath = join(uploadDirectory, name);
+    copyFileSync(path, uploadPath);
+    const fresh = this.unchanged(release, source);
+    assert.deepEqual(
+      assetIdentity(asset(fresh, name)),
+      assetIdentity(previous),
+      `Asset changed before write: ${name}`,
+    );
+    beforeWrite();
+    if (previous) {
+      command("gh", [
+        "api",
+        "--method",
+        "DELETE",
+        `repos/${REPOSITORY}/releases/assets/${previous.id}`,
+      ]);
+      beforeWrite();
+    }
+    // No clobber/retry: uncertain replacement must be reconciled from a fresh inventory.
+    command(
+      "gh",
+      ["release", "upload", release.tag_name, "--repo", REPOSITORY, uploadPath],
+      120_000,
+    );
+    const published = this.unchanged(release, source);
+    const uploaded = asset(published, name);
+    assert(uploaded, `Upload missing from release: ${name}`);
+    assert.equal(
+      fileDigest(this.publicAsset(published, uploaded, BUNDLE_LIMIT)),
+      bytesHash,
+      `Public upload readback failed: ${name}`,
+    );
+  }
+}
+
+function parseManifest(bytes, publicKey) {
+  assert(bytes.length <= METADATA_LIMIT, "Linux manifest is too large");
+  const manifest = JSON.parse(bytes);
+  const version = regularVersion(manifest.version);
+  const names = bundleNames(version);
+  assert.deepEqual(
+    Object.keys(manifest.platforms),
+    ["linux-x86_64"],
+    "Linux stable currently requires exactly the admitted AMD64 platform",
+  );
+  const platform = manifest.platforms["linux-x86_64"];
+  assert.equal(
+    platform.url,
+    assetUrl(`v${version}`, names.appimage),
+    "Manifest bundle URL mismatch",
+  );
+  assert(
+    typeof platform.signature === "string" &&
+      platform.signature.length > 0 &&
+      platform.signature.length <= 16_384,
+    "Invalid manifest signature",
+  );
+  const proof = manifest.linuxPublication;
+  assert(
+    proof?.schemaVersion === 1 &&
+      SHA.test(proof.sourceSha) &&
+      SHA.test(proof.toolingSha) &&
+      SHA.test(proof.channelSha) &&
+      Number.isSafeInteger(proof.releaseId) &&
+      proof.releaseId > 0,
+    "Missing Linux publisher identity",
+  );
+  assert.equal(
+    proof.publicKeySha256,
+    digest(Buffer.from(publicKey, "base64")),
+    "Linux publication trust root changed",
+  );
+  assert(
+    Array.isArray(proof.assets) && [3, 6].includes(proof.assets.length),
+    "Incomplete publication asset identity",
+  );
+  const expected = [
+    names.appimage,
+    names.deb,
+    names.checksums,
+    ...(proof.assets.length === 6 ? names.desktop : []),
+  ].toSorted();
+  assert.deepEqual(
+    proof.assets.map((entry) => entry.name).toSorted(),
+    expected,
+    "Unexpected publication assets",
+  );
+  for (const entry of proof.assets) {
+    assert(
+      Number.isSafeInteger(entry.id) &&
+        entry.id > 0 &&
+        Number.isSafeInteger(entry.size) &&
+        entry.size > 0 &&
+        entry.size <= BUNDLE_LIMIT &&
+        DIGEST.test(entry.sha256),
+      "Invalid publication asset identity",
+    );
+  }
+  return manifest;
+}
+
+function parseLegacyManifest(bytes) {
+  const manifest = JSON.parse(bytes);
+  assert.deepEqual(
+    Object.keys(manifest).toSorted(),
+    ["notes", "platforms", "pub_date", "version"],
+    "Unrecognized legacy Linux manifest",
+  );
+  const version = regularVersion(manifest.version);
+  assert(
+    typeof manifest.notes === "string" &&
+      typeof manifest.pub_date === "string" &&
+      Number.isFinite(Date.parse(manifest.pub_date)),
+    "Invalid legacy manifest fields",
+  );
+  assert.deepEqual(
+    Object.keys(manifest.platforms),
+    ["linux-x86_64"],
+    "Unrecognized legacy Linux platforms",
+  );
+  const platform = manifest.platforms["linux-x86_64"];
+  assert.deepEqual(
+    Object.keys(platform).toSorted(),
+    ["signature", "url"],
+    "Unrecognized legacy Linux platform fields",
+  );
+  assert.equal(
+    platform.url,
+    assetUrl(`v${version}`, bundleNames(version).appimage),
+    "Legacy Linux bundle URL mismatch",
+  );
+  assert(
+    typeof platform.signature === "string" &&
+      platform.signature.length > 0 &&
+      platform.signature.length <= 16_384 &&
+      /^[A-Za-z0-9+/]+={0,2}$/u.test(platform.signature),
+    "Invalid legacy Linux signature encoding",
+  );
+  return manifest;
+}
+
+function publishedManifest(github, bytes, publicKey) {
+  const manifest = parseManifest(bytes, publicKey);
+  const proof = manifest.linuxPublication;
+  const release = github.release(`v${manifest.version}`);
+  assert(
+    !release.draft && !release.prerelease && release.id === proof.releaseId,
+    "Linux bundles must belong to the identified public stable release",
+  );
+  assert.equal(github.source(release.tag_name), proof.sourceSha, "Published Linux source changed");
+  assert.deepEqual(
+    github.metadata(release, manifestName(manifest.version)),
+    bytes,
+    "Canonical bytes differ from the immutable Linux publication",
+  );
+  // Core consumes the publisher's verified immutable asset IDs, not a claimed signature field.
+  // GitHub replacement creates a new ID. Check its digest too when the API supplies one.
+  for (const entry of proof.assets) {
+    const current = asset(release, entry.name);
+    assert(
+      current &&
+        current.id === entry.id &&
+        current.size === entry.size &&
+        current.state === "uploaded" &&
+        current.browser_download_url === assetUrl(release.tag_name, entry.name) &&
+        (current.digest == null || current.digest === `sha256:${entry.sha256}`),
+      `Published Linux asset changed: ${entry.name}`,
+    );
+  }
+  return manifest;
+}
+
+function channelBody(version) {
+  const names = bundleNames(version);
+  return (
+    `Latest published Linux companion: v${version}\n\n` +
+    `- [AppImage](${assetUrl(`v${version}`, names.appimage)})\n` +
+    `- [Debian package](${assetUrl(`v${version}`, names.deb)})\n`
+  );
+}
+
+function updateChannelBody(github, release, source, version) {
+  const body = channelBody(version);
+  if (release.body === body) {
+    return;
+  }
+  const path = github.temp("channel-notes.md");
+  writeFileSync(path, body, { flag: "wx" });
+  github.unchanged(release, source);
+  command("gh", [
+    "release",
+    "edit",
+    CHANNEL,
+    "--repo",
+    REPOSITORY,
+    "--prerelease",
+    "--latest=false",
+    "--notes-file",
+    path,
+  ]);
+  assert.equal(github.release(CHANNEL).body, body, "Linux download-page readback failed");
+}
+
+function canonical(github, publicKey) {
+  const release = github.release(CHANNEL);
+  assert(!release.draft && release.prerelease, "Linux channel must be public and prerelease");
+  const bytes = github.metadata(release, "latest.json");
+  assert(
+    bytes,
+    "Linux channel manifest is missing; reconcile the interrupted publication from retained promotion evidence",
+  );
+  const manifest = publishedManifest(github, bytes, publicKey);
+  assert.equal(
+    github.source(CHANNEL),
+    manifest.linuxPublication.channelSha,
+    "Linux channel tag moved",
+  );
+  return { release, bytes, manifest };
+}
+
+function mirror(github, publicKey, target) {
+  const latest = github.latest();
+  assert(latest, "No public core latest release exists");
+  releaseVersion(latest.tag_name);
+  assert(!latest.draft && !latest.prerelease, "Core latest is not a public regular release");
+  const source = github.source(latest.tag_name);
+  if (target && (target.tag !== latest.tag_name || target.source !== source)) {
+    // A resume of an older release must never promote or modify it.
+    const expected = github.release(target.tag);
+    assert.equal(github.source(target.tag), target.source, "Selected core tag moved");
+    assert(!expected.draft && !expected.prerelease, "Selected core release is not public");
+    return { state: "skipped-not-latest", tag: target.tag };
+  }
+  const verifyLatest = () => {
+    assert.deepEqual(
+      identity(github.latest()),
+      identity(latest),
+      "Core latest changed before mirror",
+    );
+    assert.equal(
+      github.source(latest.tag_name),
+      source,
+      "Core latest source changed before mirror",
+    );
+  };
+  const selected = canonical(github, publicKey);
+  const previousBytes = github.metadata(latest, "latest.json");
+  if (previousBytes && !previousBytes.equals(selected.bytes)) {
+    const previous = JSON.parse(previousBytes);
+    const legacy = !Object.hasOwn(previous, "linuxPublication");
+    const owned = legacy
+      ? parseLegacyManifest(previousBytes)
+      : publishedManifest(github, previousBytes, publicKey);
+    const comparison = compareReleaseVersions(selected.manifest.version, owned.version);
+    assert(comparison >= 0, "Legacy endpoint already carries a newer Linux manifest");
+    if (legacy) {
+      const origin = github.release(`v${owned.version}`);
+      assert(!origin.draft && !origin.prerelease, "Legacy manifest origin is not public stable");
+      assert.deepEqual(
+        github.metadata(origin, "latest.json"),
+        previousBytes,
+        "Legacy manifest differs from its public versioned origin",
+      );
+      const bundle = asset(origin, bundleNames(owned.version).appimage);
+      assert(
+        bundle &&
+          Number.isSafeInteger(bundle.id) &&
+          bundle.id > 0 &&
+          bundle.size > 0 &&
+          bundle.state === "uploaded" &&
+          bundle.browser_download_url === owned.platforms["linux-x86_64"].url,
+        "Legacy manifest has no matching public bundle",
+      );
+      if (comparison === 0) {
+        const originalFields = { ...selected.manifest };
+        delete originalFields.linuxPublication;
+        assert.deepEqual(
+          owned,
+          originalFields,
+          "Same-version legacy bootstrap changed original manifest fields",
+        );
+      }
+    } else {
+      assert.equal(
+        owned.linuxPublication.channelSha,
+        selected.manifest.linuxPublication.channelSha,
+        "Legacy endpoint belongs to a different Linux channel identity",
+      );
+      assert(comparison > 0, "Same-version canonical manifest conflict at legacy endpoint");
+    }
+  }
+  const beforeWrite = () => {
+    assert.deepEqual(
+      canonical(github, publicKey).bytes,
+      selected.bytes,
+      "Canonical Linux manifest changed before mirror",
+    );
+    verifyLatest();
+  };
+  beforeWrite();
+  const path = github.temp("latest.json");
+  writeFileSync(path, selected.bytes, { flag: "wx" });
+  github.upload(latest, source, "latest.json", path, true, beforeWrite);
+  assert.deepEqual(identity(github.latest()), identity(latest), "Core latest changed after mirror");
+  assert.deepEqual(
+    canonical(github, publicKey).bytes,
+    selected.bytes,
+    "Canonical Linux manifest changed after mirror",
+  );
+  updateChannelBody(
+    github,
+    selected.release,
+    selected.manifest.linuxPublication.channelSha,
+    selected.manifest.version,
+  );
+  const publicPath = github.download(
+    `https://github.com/${REPOSITORY}/releases/latest/download/latest.json`,
+    METADATA_LIMIT,
+  );
+  assert.deepEqual(readFileSync(publicPath), selected.bytes, "Legacy endpoint readback failed");
+  assert.deepEqual(
+    identity(github.latest()),
+    identity(latest),
+    "Core latest changed during readback",
+  );
+  assert.equal(
+    github.source(latest.tag_name),
+    source,
+    "Core latest source changed during readback",
+  );
+  return {
+    state: "mirrored",
+    tag: latest.tag_name,
+    releaseId: latest.id,
+    sourceSha: source,
+    version: selected.manifest.version,
+    manifestSha256: digest(selected.bytes),
+  };
+}
+
+function finalizeCore(github, options) {
+  const version = options.tag.slice(1);
+  const parsed = parseReleaseVersion(version);
+  assert(
+    parsed &&
+      parsed.version === version &&
+      ["stable", "alpha", "beta"].includes(classifyReleaseTrain(parsed)),
+    "Unsupported core GitHub release train",
+  );
+  assert(["true", "false"].includes(options.latest), "Expected explicit core latest intent");
+  const prerelease = parsed.channel !== "stable";
+  assert(!prerelease || options.latest === "false", "Prereleases cannot become core latest");
+  // gh release view also discovers drafts by their pending tag; REST's tag route does not.
+  const discovered = JSON.parse(
+    command("gh", [
+      "release",
+      "view",
+      options.tag,
+      "--repo",
+      REPOSITORY,
+      "--json",
+      "databaseId,tagName,isDraft,isPrerelease",
+    ]),
+  );
+  const release = {
+    id: discovered.databaseId,
+    tag_name: discovered.tagName,
+    draft: discovered.isDraft,
+    prerelease: discovered.isPrerelease,
+  };
+  assert(
+    Number.isSafeInteger(release.id) &&
+      release.id > 0 &&
+      release.tag_name === options.tag &&
+      typeof release.draft === "boolean" &&
+      typeof release.prerelease === "boolean",
+    "Selected core release identity is invalid",
+  );
+  assert.equal(release.prerelease, prerelease, "Selected core prerelease classification changed");
+  assert.equal(github.source(options.tag), options["source-sha"], "Selected core tag moved");
+  const latest = github.latest();
+  const latestSource = latest ? github.source(latest.tag_name) : null;
+  let makeLatest = options.latest === "true";
+  if (latest) {
+    assert(!latest.draft && !latest.prerelease, "Core latest is not a public regular release");
+    const latestVersion = releaseVersion(latest.tag_name);
+    if (makeLatest && compareReleaseVersions(version, latestVersion) < 0) {
+      makeLatest = false;
+    }
+    assert(
+      makeLatest || latest.id !== release.id,
+      "Non-latest finalization must not demote the current latest release",
+    );
+  }
+  const verifyLatest = () => {
+    const fresh = github.latest();
+    assert.deepEqual(
+      fresh ? identity(fresh) : null,
+      latest ? identity(latest) : null,
+      "Core latest changed before finalization",
+    );
+    if (latest) {
+      assert.equal(github.source(latest.tag_name), latestSource, "Core latest tag moved");
+    }
+  };
+  assert.deepEqual(
+    identity(github.api(`releases/${release.id}`)),
+    identity(release),
+    "Release identity changed before write",
+  );
+  assert.equal(github.source(options.tag), options["source-sha"], "Selected core tag moved");
+  verifyLatest();
+  // Address the admitted release ID, never a re-resolved replacement with the same tag.
+  command("gh", [
+    "api",
+    "--method",
+    "PATCH",
+    `repos/${REPOSITORY}/releases/${release.id}`,
+    "--field",
+    "draft=false",
+    "--raw-field",
+    `make_latest=${makeLatest}`,
+  ]);
+  const published = github.release(options.tag);
+  assert.deepEqual(
+    identity(published),
+    [release.id, options.tag, false, prerelease],
+    "Finalized core release identity mismatch",
+  );
+  assert.equal(github.source(options.tag), options["source-sha"], "Finalized core tag moved");
+  const actualLatest = github.latest();
+  const expectedLatest = makeLatest ? published : latest;
+  assert.deepEqual(
+    actualLatest ? identity(actualLatest) : null,
+    expectedLatest ? identity(expectedLatest) : null,
+    "Core latest readback mismatch",
+  );
+  if (actualLatest) {
+    assert.equal(
+      github.source(actualLatest.tag_name),
+      makeLatest ? options["source-sha"] : latestSource,
+      "Core latest source readback mismatch",
+    );
+  }
+  return {
+    state: "finalized",
+    tag: options.tag,
+    releaseId: release.id,
+    sourceSha: options["source-sha"],
+    madeLatest: makeLatest,
+    latestReleaseId: actualLatest?.id ?? null,
+    latestTag: actualLatest?.tag_name ?? null,
+  };
+}
+
+function publish(github, options, publicKey) {
+  const version = releaseVersion(options.tag);
+  const names = bundleNames(version);
+  const release = github.release(options.tag);
+  assert(
+    !release.draft && !release.prerelease,
+    "Publish Linux bundles only to a public stable release",
+  );
+  assert.equal(github.source(options.tag), options["source-sha"], "Linux release source mismatch");
+  const directory = resolve(options.assets);
+  const desktop = options["desktop-test"] === "true";
+  const expected = [
+    names.appimage,
+    names.deb,
+    names.checksums,
+    ...(desktop ? names.desktop : []),
+  ].toSorted();
+  assert.deepEqual(
+    readdirSync(directory).toSorted(),
+    [...expected, ...(desktop ? ["latest-desktop-test.json"] : [])].toSorted((a, b) =>
+      a < b ? -1 : a > b ? 1 : 0,
+    ),
+    "Release directory does not match the admitted bundle inventory",
+  );
+  const inputs = expected.map((name) => {
+    const path = join(directory, name);
+    const stat = lstatSync(path);
+    assert(
+      stat.isFile() && stat.size > 0 && stat.size <= BUNDLE_LIMIT,
+      `Invalid release input: ${name}`,
+    );
+    return { name, path, size: stat.size, sha256: fileDigest(path) };
+  });
+  const checksums = inputs
+    .filter((entry) => entry.name !== names.checksums)
+    .map((entry) => `${entry.sha256}  ./${entry.name}`)
+    .toSorted()
+    .join("\n");
+  assert.equal(
+    readFileSync(join(directory, names.checksums), "utf8")
+      .trimEnd()
+      .split("\n")
+      .toSorted()
+      .join("\n"),
+    checksums,
+    "Bundle checksum inventory mismatch",
+  );
+  const signature = readFileSync(options.signature, "utf8").trim();
+  assert(signature.length > 0 && signature.length <= 16_384, "Invalid AppImage signature input");
+  const signaturePath = github.temp("appimage.minisig");
+  const publicKeyPath = github.temp("updater.pub");
+  writeFileSync(signaturePath, Buffer.from(signature, "base64"), { flag: "wx" });
+  writeFileSync(publicKeyPath, Buffer.from(publicKey, "base64"), { flag: "wx" });
+  command("minisign", [
+    "-Vm",
+    join(directory, names.appimage),
+    "-x",
+    signaturePath,
+    "-p",
+    publicKeyPath,
+  ]);
+
+  // Detect every immutable conflict before uploading any missing file.
+  for (const entry of inputs) {
+    const previous = asset(release, entry.name);
+    if (previous) {
+      assert.equal(
+        fileDigest(github.publicAsset(release, previous, BUNDLE_LIMIT)),
+        entry.sha256,
+        `Immutable asset conflict: ${entry.name}`,
+      );
+    }
+  }
+  for (const entry of inputs) {
+    github.upload(
+      github.unchanged(release, options["source-sha"]),
+      options["source-sha"],
+      entry.name,
+      entry.path,
+    );
+  }
+  const published = github.unchanged(release, options["source-sha"]);
+  const assets = inputs.map((entry) => {
+    const current = asset(published, entry.name);
+    assert(current, `Missing public bundle: ${entry.name}`);
+    assert.equal(
+      fileDigest(github.publicAsset(published, current, BUNDLE_LIMIT)),
+      entry.sha256,
+      `Public bundle differs from signed input: ${entry.name}`,
+    );
+    return { id: current.id, name: entry.name, size: entry.size, sha256: entry.sha256 };
+  });
+  let channel = github.release(CHANNEL, true);
+  const creatingChannel = channel === null;
+  if (!channel) {
+    const retainedTag = github.source(CHANNEL, true);
+    assert(
+      retainedTag === null || retainedTag === options["source-sha"],
+      "Existing Linux channel tag has a different source; reconcile before creating its release",
+    );
+    command("gh", [
+      "release",
+      "create",
+      CHANNEL,
+      "--repo",
+      REPOSITORY,
+      "--target",
+      options["source-sha"],
+      "--prerelease",
+      "--latest=false",
+      "--title",
+      "OpenClaw Linux update channel",
+      "--notes",
+      INITIAL_BODY,
+    ]);
+    channel = github.release(CHANNEL);
+  }
+  assert(!channel.draft && channel.prerelease, "Linux channel must be public and prerelease");
+  const channelSha = github.source(CHANNEL);
+  const currentBytes = github.metadata(channel, "latest.json");
+  let current;
+  if (currentBytes) {
+    current = publishedManifest(github, currentBytes, publicKey);
+    assert.equal(current.linuxPublication.channelSha, channelSha, "Linux channel tag moved");
+  } else {
+    assert(
+      creatingChannel && channel.body === INITIAL_BODY && channelSha === options["source-sha"],
+      "Missing channel metadata is not a new channel; reconcile before publishing",
+    );
+  }
+  const existing = github.metadata(published, manifestName(version));
+  let bytes = existing;
+  if (existing) {
+    const retained = publishedManifest(github, existing, publicKey);
+    assert.equal(retained.version, version, "Versioned manifest identity mismatch");
+    assert.equal(
+      retained.linuxPublication.channelSha,
+      channelSha,
+      "Channel identity changed on replay",
+    );
+    assert.deepEqual(retained.linuxPublication.assets, assets, "Bundle identity changed on replay");
+    // Re-signing identical bytes can change the trusted timestamp comment. Verify
+    // and retain the original signature instead of regenerating immutable metadata.
+    writeFileSync(
+      signaturePath,
+      Buffer.from(retained.platforms["linux-x86_64"].signature, "base64"),
+    );
+    command("minisign", [
+      "-Vm",
+      join(directory, names.appimage),
+      "-x",
+      signaturePath,
+      "-p",
+      publicKeyPath,
+    ]);
+  } else {
+    assert(
+      typeof published.published_at === "string" &&
+        Number.isFinite(Date.parse(published.published_at)),
+      "Public release publication date is required",
+    );
+    let originalFields;
+    const legacyBytes = github.metadata(published, "latest.json");
+    if (legacyBytes) {
+      if (Object.hasOwn(JSON.parse(legacyBytes), "linuxPublication")) {
+        publishedManifest(github, legacyBytes, publicKey);
+      } else {
+        const legacy = parseLegacyManifest(legacyBytes);
+        if (legacy.version === version) {
+          originalFields = legacy;
+          writeFileSync(
+            signaturePath,
+            Buffer.from(legacy.platforms["linux-x86_64"].signature, "base64"),
+          );
+          command("minisign", [
+            "-Vm",
+            join(directory, names.appimage),
+            "-x",
+            signaturePath,
+            "-p",
+            publicKeyPath,
+          ]);
+        }
+      }
+    }
+    bytes = Buffer.from(
+      `${JSON.stringify(
+        {
+          ...(originalFields ?? {
+            version,
+            notes: Array.from(published.body ?? "")
+              .slice(0, 2000)
+              .join(""),
+            pub_date: published.published_at,
+            platforms: {
+              "linux-x86_64": {
+                signature,
+                url: assetUrl(options.tag, names.appimage),
+              },
+            },
+          }),
+          linuxPublication: {
+            schemaVersion: 1,
+            sourceSha: options["source-sha"],
+            toolingSha: options["tooling-sha"],
+            channelSha,
+            releaseId: published.id,
+            publicKeySha256: digest(Buffer.from(publicKey, "base64")),
+            assets,
+          },
+        },
+        null,
+        2,
+      )}\n`,
+    );
+    const path = github.temp("versioned-linux.json");
+    writeFileSync(path, bytes, { flag: "wx" });
+    github.upload(published, options["source-sha"], manifestName(version), path);
+  }
+  const comparison = current ? compareReleaseVersions(version, current.version) : 1;
+  if (comparison === 0) {
+    assert.deepEqual(bytes, currentBytes, "Same-version canonical manifest conflict");
+  }
+  if (comparison >= 0) {
+    const path = github.temp("canonical-linux.json");
+    writeFileSync(path, bytes, { flag: "wx" });
+    console.error(
+      JSON.stringify({
+        state: "canonical-publication-intent",
+        version,
+        manifestSha256: digest(bytes),
+        previousVersion: current?.version ?? null,
+        previousManifestSha256: currentBytes ? digest(currentBytes) : null,
+      }),
+    );
+    github.upload(channel, channelSha, "latest.json", path, true);
+    updateChannelBody(github, channel, channelSha, version);
+    assert.deepEqual(canonical(github, publicKey).bytes, bytes, "Linux channel readback failed");
+  }
+  if (desktop) {
+    const desktopName = "latest-desktop-test.json";
+    const desktopPath = join(directory, desktopName);
+    const candidate = JSON.parse(readFileSync(desktopPath, "utf8"));
+    assert.equal(candidate.version, version, "Desktop test manifest version mismatch");
+    assert.deepEqual(
+      Object.keys(candidate.platforms).toSorted(),
+      ["darwin-aarch64", "windows-x86_64"],
+      "Unexpected desktop test platforms",
+    );
+    const previous = github.metadata(github.unchanged(release, options["source-sha"]), desktopName);
+    if (previous) {
+      const retained = JSON.parse(previous);
+      assert.equal(retained.version, candidate.version, "Desktop test manifest version changed");
+      assert.deepEqual(
+        Object.keys(retained.platforms).toSorted(),
+        Object.keys(candidate.platforms).toSorted(),
+        "Desktop test platforms changed",
+      );
+      for (const [platform, name] of [
+        ["darwin-aarch64", names.desktop[1]],
+        ["windows-x86_64", names.desktop[2]],
+      ]) {
+        assert.equal(
+          retained.platforms[platform].url,
+          candidate.platforms[platform].url,
+          "Desktop test bundle URL changed",
+        );
+        const previousSignature = retained.platforms[platform].signature;
+        assert(
+          typeof previousSignature === "string" &&
+            previousSignature.length > 0 &&
+            previousSignature.length <= 16_384,
+          "Invalid retained desktop signature",
+        );
+        writeFileSync(signaturePath, Buffer.from(previousSignature, "base64"));
+        command("minisign", [
+          "-Vm",
+          join(directory, name),
+          "-x",
+          signaturePath,
+          "-p",
+          publicKeyPath,
+        ]);
+      }
+      // Keep the previously published date/notes on an identical bundle replay.
+      writeFileSync(desktopPath, previous);
+    }
+    github.upload(
+      github.unchanged(release, options["source-sha"]),
+      options["source-sha"],
+      desktopName,
+      desktopPath,
+    );
+  }
+  return {
+    state: comparison < 0 ? "kept-newer-channel" : "published",
+    version,
+    manifestSha256: digest(bytes),
+    legacy: mirror(github, publicKey),
+  };
+}
+
+function main() {
+  const { values, positionals } = parseArgs({
+    allowPositionals: true,
+    options: Object.fromEntries(
+      [
+        "tag",
+        "source-sha",
+        "tooling-sha",
+        "assets",
+        "signature",
+        "public-key-config",
+        "desktop-test",
+        "latest",
+      ].map((name) => [name, { type: "string" }]),
+    ),
+  });
+  const [mode] = positionals;
+  assert(
+    positionals.length === 1 && ["publish", "mirror", "finalize-core"].includes(mode),
+    "Usage: linux-app-channel.mjs publish|mirror|finalize-core --tag TAG --source-sha SHA [mode options]",
+  );
+  assert(SHA.test(values["source-sha"]), "Expected the approved source SHA");
+  assert(typeof values.tag === "string" && values.tag.startsWith("v"), "Expected a release tag");
+  if (mode !== "finalize-core") {
+    releaseVersion(values.tag);
+  }
+  if (mode === "publish") {
+    assert(
+      SHA.test(values["tooling-sha"]) &&
+        values.assets &&
+        values.signature &&
+        ["true", "false"].includes(values["desktop-test"]),
+      "Missing Linux publication inputs",
+    );
+  }
+  let publicKey;
+  if (mode !== "finalize-core") {
+    const config = JSON.parse(readFileSync(values["public-key-config"], "utf8"));
+    publicKey = config.plugins?.updater?.pubkey;
+    assert(
+      typeof publicKey === "string" &&
+        publicKey.length > 0 &&
+        publicKey.length <= 4096 &&
+        /^[A-Za-z0-9+/]+={0,2}$/u.test(publicKey),
+      "Expected the trusted updater public key",
+    );
+  }
+  const directory = mkdtempSync(join(tmpdir(), "openclaw-linux-channel-"));
+  try {
+    const github = new GitHub(directory);
+    const result =
+      mode === "finalize-core"
+        ? finalizeCore(github, values)
+        : mode === "publish"
+          ? publish(github, values, publicKey)
+          : mirror(github, publicKey, { tag: values.tag, source: values["source-sha"] });
+    process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
+  try {
+    main();
+  } catch (error) {
+    console.error(`Release publication incomplete; reconcile before retry: ${error.message}`);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/render-github-release-notes.mts
+++ b/scripts/render-github-release-notes.mts
@@ -8,6 +8,7 @@ import {
   validateReleaseNotesRepository as validateRepository,
   validateReleaseNotesTag as validateTag,
 } from "./lib/release-notes-compaction.mjs";
+import { classifyReleaseTrain, parseReleaseVersion } from "./lib/release-version.mjs";
 
 type ShippedBaselineExclusion = {
   ref: string;
@@ -302,13 +303,16 @@ export function releaseNotesSectionForTag(changelog: unknown, version: unknown, 
   }
 }
 
-export function renderGithubReleaseNotes({
-  changelog,
-  version,
-  tag,
-  repository,
-  verification = "",
-}: ReleaseNotesTarget & { verification?: string }) {
+function renderReleaseNotes(
+  {
+    changelog,
+    version,
+    tag,
+    repository,
+    verification = "",
+  }: ReleaseNotesTarget & { verification?: string },
+  includeLinuxLink: boolean,
+) {
   assertString(repository, "repository");
   assertString(tag, "tag");
   assertString(version, "version");
@@ -318,14 +322,20 @@ export function renderGithubReleaseNotes({
   if (tagVersion !== version) {
     fail(`release tag ${tag} requires CHANGELOG.md version ${tagVersion}, got ${version}`);
   }
+  const parsedVersion = parseReleaseVersion(tag.slice(1));
+  const linuxLink =
+    includeLinuxLink && parsedVersion && classifyReleaseTrain(parsedVersion) === "stable"
+      ? `### Linux companion\n\nDownload the [latest published Linux companion](https://github.com/${repository}/releases/tag/linux-stable).`
+      : "";
   const section = releaseNotesSectionForTag(changelog, version, tag);
-  const mode = fitsGithubReleaseBody(section) ? "full" : "compact";
-  const baseBody = mode === "full" ? section : compactReleaseNotes(section, repository, tag)?.body;
-  if (baseBody === undefined) {
+  const mode = fitsGithubReleaseBody(joinBody(section, linuxLink)) ? "full" : "compact";
+  const notes = mode === "full" ? section : compactReleaseNotes(section, repository, tag)?.body;
+  if (notes === undefined) {
     fail(
       "release notes exceed GitHub's body limit and cannot be compacted without a complete contribution record",
     );
   }
+  const baseBody = joinBody(notes, linuxLink);
   if (!fitsGithubReleaseBody(baseBody)) {
     const size = githubReleaseBodySize(baseBody);
     fail(
@@ -346,21 +356,17 @@ export function renderGithubReleaseNotes({
   };
 }
 
-export function verifyGithubReleaseNotes({
-  body,
-  changelog,
-  version,
-  tag,
-  repository,
-}: ReleaseNotesTarget & { body: unknown }) {
+export function renderGithubReleaseNotes(options: ReleaseNotesTarget & { verification?: string }) {
+  return renderReleaseNotes(options, true);
+}
+
+function verifyReleaseNotes(
+  { body, changelog, version, tag, repository }: ReleaseNotesTarget & { body: unknown },
+  includeLinuxLink: boolean,
+) {
   assertString(body, "release body");
   const normalizedBody = body.trimEnd();
-  const base = renderGithubReleaseNotes({
-    changelog,
-    version,
-    tag,
-    repository,
-  });
+  const base = renderReleaseNotes({ changelog, version, tag, repository }, includeLinuxLink);
   if (normalizedBody === base.body) {
     return {
       ...base,
@@ -373,13 +379,7 @@ export function verifyGithubReleaseNotes({
     ? normalizedBody.slice(base.body.length + 2)
     : "";
   const expected = verification
-    ? renderGithubReleaseNotes({
-        changelog,
-        version,
-        tag,
-        repository,
-        verification,
-      })
+    ? renderReleaseNotes({ changelog, version, tag, repository, verification }, includeLinuxLink)
     : base;
   return {
     ...expected,
@@ -388,12 +388,30 @@ export function verifyGithubReleaseNotes({
   };
 }
 
+export function verifyGithubReleaseNotes({
+  allowPreviousCanonical = false,
+  ...options
+}: ReleaseNotesTarget & { body: unknown; allowPreviousCanonical?: boolean }) {
+  const current = verifyReleaseNotes(options, true);
+  if (!current.matches && allowPreviousCanonical) {
+    // Only the regular-release Linux link differs. Re-render the old form so
+    // its original compaction and proof-tail limits remain part of admission.
+    const previous = verifyReleaseNotes(options, false);
+    if (previous.matches) {
+      return { ...previous, previousCanonical: true };
+    }
+  }
+  return { ...current, previousCanonical: false };
+}
+
 function usage() {
   return `Usage:
   node --import tsx scripts/render-github-release-notes.mts \\
     --changelog <path> --tag <tag> --repository <owner/repo> \\
     [--version <version>] [--verification-file <path>] [--output <path>] \\
     [--metadata-output <path>]
+  Verification uses the same target arguments:
+    --verify-body <path> [--allow-previous-canonical]
 `;
 }
 
@@ -406,13 +424,21 @@ function parseArgs(argv: string[]) {
     ["--verification-file", "verificationFile"],
     ["--output", "output"],
     ["--metadata-output", "metadataOutput"],
+    ["--verify-body", "verifyBody"],
   ] as const satisfies ReadonlyArray<readonly [string, string]>;
   type ValueOption = (typeof valueOptions)[number][1];
-  const options: Partial<Record<ValueOption, string>> & { help?: true } = {};
+  const options: Partial<Record<ValueOption, string>> & {
+    help?: true;
+    allowPreviousCanonical?: true;
+  } = {};
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index];
     if (arg === "--help" || arg === "-h") {
       options.help = true;
+      continue;
+    }
+    if (arg === "--allow-previous-canonical") {
+      options.allowPreviousCanonical = true;
       continue;
     }
     const option = valueOptions.find(([flag]) => flag === arg);
@@ -436,6 +462,15 @@ function parseArgs(argv: string[]) {
     if (options.metadataOutput && !options.output) {
       fail("--metadata-output requires --output");
     }
+    if (options.allowPreviousCanonical && !options.verifyBody) {
+      fail("--allow-previous-canonical requires --verify-body");
+    }
+    if (
+      options.verifyBody &&
+      (options.output || options.metadataOutput || options.verificationFile)
+    ) {
+      fail("--verify-body cannot be combined with rendering output or verification-file options");
+    }
   }
   return options;
 }
@@ -451,14 +486,33 @@ function main() {
     fail("release notes arguments were not validated");
   }
   const changelog = readFileSync(changelogPath, "utf8");
-  const verification = options.verificationFile
-    ? readFileSync(options.verificationFile, "utf8")
-    : "";
-  const rendered = renderGithubReleaseNotes({
+  const target = {
     changelog,
     version: options.version ?? releaseNotesVersionForTag(tag),
     tag,
     repository,
+  };
+  if (options.verifyBody) {
+    const result = verifyGithubReleaseNotes({
+      ...target,
+      body: readFileSync(options.verifyBody, "utf8"),
+      allowPreviousCanonical: options.allowPreviousCanonical === true,
+    });
+    if (!result.matches) {
+      fail("Release body does not match canonical release notes.");
+    }
+    if (result.previousCanonical) {
+      process.stderr.write(
+        "release-notes: previous canonical body; Linux link pending proof append\n",
+      );
+    }
+    return;
+  }
+  const verification = options.verificationFile
+    ? readFileSync(options.verificationFile, "utf8")
+    : "";
+  const rendered = renderGithubReleaseNotes({
+    ...target,
     verification,
   });
   if (options.output) {

--- a/test/linux-dashboard-recovery.test.ts
+++ b/test/linux-dashboard-recovery.test.ts
@@ -2,25 +2,37 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import vm from "node:vm";
 import { test } from "vitest";
+import { createDeferred } from "./helpers/promise.js";
 
 const dashboardSource = readFileSync(new URL("../apps/linux/ui/main.js", import.meta.url), "utf8");
 
 function fakeElement() {
   const classes = new Set(["hidden"]);
+  const listeners = new Map<string, () => void>();
   return {
     className: "",
     classList: {
       contains: (name: string) => classes.has(name),
       toggle(name: string, force?: boolean) {
         const enabled = force ?? !classes.has(name);
-        if (enabled) classes.add(name);
-        else classes.delete(name);
+        if (enabled) {
+          classes.add(name);
+        } else {
+          classes.delete(name);
+        }
       },
     },
     disabled: false,
     textContent: "",
     value: "stable",
-    addEventListener() {},
+    addEventListener(name: string, listener: () => void) {
+      listeners.set(name, listener);
+    },
+    click() {
+      const listener = listeners.get("click");
+      assert.ok(listener);
+      listener();
+    },
     append() {},
     removeAttribute() {},
     replaceChildren() {},
@@ -28,13 +40,16 @@ function fakeElement() {
   };
 }
 
-test("missing CLI mode offers installation without retrying bootstrap", async () => {
+async function mountDashboard(search: string, openReleasePage = () => Promise.resolve()) {
   const elements = new Map<string, ReturnType<typeof fakeElement>>();
   const invoked: string[] = [];
+  const listeners = new Map<string, (event: { payload: Record<string, unknown> }) => void>();
   const document = {
     createElement: fakeElement,
     querySelector(selector: string) {
-      if (!elements.has(selector)) elements.set(selector, fakeElement());
+      if (!elements.has(selector)) {
+        elements.set(selector, fakeElement());
+      }
       return elements.get(selector);
     },
   };
@@ -43,13 +58,26 @@ test("missing CLI mode offers installation without retrying bootstrap", async ()
       core: {
         invoke(command: string) {
           invoked.push(command);
-          if (command === "discover_gateways") return Promise.resolve([]);
+          if (command === "discover_gateways") {
+            return Promise.resolve([]);
+          }
+          if (command === "open_release_page") {
+            return openReleasePage();
+          }
           return Promise.resolve({ phase: "connected" });
         },
       },
-      event: { listen: async () => () => {} },
+      event: {
+        async listen(
+          name: string,
+          listener: (event: { payload: Record<string, unknown> }) => void,
+        ) {
+          listeners.set(name, listener);
+          return () => {};
+        },
+      },
     },
-    location: { search: "?mode=missingCli" },
+    location: { search },
     setInterval() {},
   };
 
@@ -59,36 +87,88 @@ test("missing CLI mode offers installation without retrying bootstrap", async ()
     window,
   });
 
-  assert.equal(elements.get("#title")?.textContent, "OpenClaw needs the CLI");
-  assert.equal(elements.get("#install-controls")?.classList.contains("hidden"), false);
+  return {
+    invoked,
+    element: (selector: string) => {
+      const element = elements.get(selector);
+      assert.ok(element);
+      return element;
+    },
+    emit: (name: string, payload: Record<string, unknown> = {}) => {
+      const listener = listeners.get(name);
+      assert.ok(listener);
+      listener({ payload });
+    },
+  };
+}
+
+test("missing CLI mode offers installation without retrying bootstrap", async () => {
+  const { element, invoked } = await mountDashboard("?mode=missingCli");
+
+  assert.equal(element("#title").textContent, "OpenClaw needs the CLI");
+  assert.equal(element("#install-controls").classList.contains("hidden"), false);
   assert.equal(invoked.includes("bootstrap"), false);
 });
 
 test("CLI recovery errors offer both retry and reinstall", async () => {
-  const elements = new Map<string, ReturnType<typeof fakeElement>>();
-  const document = {
-    createElement: fakeElement,
-    querySelector(selector: string) {
-      if (!elements.has(selector)) elements.set(selector, fakeElement());
-      return elements.get(selector);
-    },
-  };
-  const window = {
-    __TAURI__: {
-      core: { invoke: () => Promise.resolve([]) },
-      event: { listen: async () => () => {} },
-    },
-    location: { search: "?mode=error" },
-    setInterval() {},
-  };
+  const { element } = await mountDashboard("?mode=error");
 
-  await vm.runInNewContext(`(async () => { ${dashboardSource}\n})()`, {
-    document,
-    URLSearchParams,
-    window,
-  });
+  assert.equal(element("#primary-action").textContent, "Try again");
+  assert.equal(element("#action-controls").classList.contains("hidden"), false);
+  assert.equal(element("#install-controls").classList.contains("hidden"), false);
+});
 
-  assert.equal(elements.get("#primary-action")?.textContent, "Try again");
-  assert.equal(elements.get("#action-controls")?.classList.contains("hidden"), false);
-  assert.equal(elements.get("#install-controls")?.classList.contains("hidden"), false);
+test("failed release-page opening retains an explicit download-page retry", async () => {
+  const opening = createDeferred();
+  let attempts = 0;
+  const { element, emit, invoked } = await mountDashboard("?mode=missingCli", () =>
+    ++attempts === 1 ? opening.promise : Promise.resolve(),
+  );
+  emit("updater://available-manual", { version: "2026.9.10" });
+  assert.equal(element("#update-action").textContent, "Open download page");
+  element("#update-action").click();
+  opening.reject(new Error("Browser unavailable"));
+  await opening.promise.catch(() => {});
+
+  assert.equal(element("#update-title").textContent, "Could not open release page");
+  assert.equal(element("#update-message").textContent, "Browser unavailable");
+  assert.equal(element("#update-action").classList.contains("hidden"), false);
+  assert.equal(element("#update-action").textContent, "Open download page");
+  assert.equal(attempts, 1);
+  element("#update-action").click();
+  assert.equal(attempts, 2);
+  assert.equal(invoked.filter((command) => command === "open_release_page").length, 2);
+});
+
+test("late release-page failure preserves a newer update action", async () => {
+  const opening = createDeferred();
+  const { element, emit, invoked } = await mountDashboard(
+    "?mode=missingCli",
+    () => opening.promise,
+  );
+  emit("updater://available-manual", { version: "2026.9.10" });
+  element("#update-action").click();
+  emit("updater://ready", { version: "2026.9.11" });
+  opening.reject(new Error("Browser unavailable"));
+  await opening.promise.catch(() => {});
+
+  assert.equal(element("#update-title").textContent, "Update ready");
+  assert.equal(element("#update-action").textContent, "Restart to update");
+  assert.equal(element("#update-action").classList.contains("hidden"), false);
+  element("#update-action").click();
+  assert.equal(invoked.at(-1), "relaunch");
+});
+
+test("late release-page failure does not reopen a dismissed update banner", async () => {
+  const opening = createDeferred();
+  const { element, emit } = await mountDashboard("?mode=missingCli", () => opening.promise);
+  emit("updater://available-manual", { version: "2026.9.10" });
+  element("#update-action").click();
+  element("#update-dismiss").click();
+  assert.equal(element("#update-banner").classList.contains("hidden"), true);
+  opening.reject(new Error("Browser unavailable"));
+  await opening.promise.catch(() => {});
+
+  assert.equal(element("#update-banner").classList.contains("hidden"), true);
+  assert.equal(element("#update-title").textContent, "Update available v2026.9.10");
 });

--- a/test/linux-quickchat-stream.test.ts
+++ b/test/linux-quickchat-stream.test.ts
@@ -128,7 +128,25 @@ function createQuickChatHarness(): Record<string, any> {
   const browserBindingsEnd = quickchatSource.indexOf("elements.input.addEventListener");
   assert.notEqual(browserBindingsEnd, -1, "quickchat browser binding boundary");
   const elements = new Map();
-  let resolveSend;
+  const sends: Array<{
+    resolve: (value: unknown) => void;
+    reject: (error: Error) => void;
+  }> = [];
+  const calls: Array<{ method: string; args: Record<string, any> }> = [];
+  const refreshes: Array<{
+    resolve: (value: unknown) => void;
+    reject: (error: Error) => void;
+  }> = [];
+  let deferRefresh = false;
+  const widgetSyncs: Array<{
+    args: Record<string, any>;
+    resolve: () => void;
+    reject: (error: Error) => void;
+  }> = [];
+  let deferWidgetSync = false;
+  let activeWidgetSyncs = 0;
+  let maxActiveWidgetSyncs = 0;
+  const windowListeners = new Map<string, () => void>();
   let syncedWidgets: unknown[] = [];
   let syncedHasWidgets = false;
   let syncedExpanded = false;
@@ -138,9 +156,26 @@ function createQuickChatHarness(): Record<string, any> {
   let widgetSurfaceRefreshFails = false;
   let widgetSurfaceRefreshResult = "https://gateway.example/__openclaw__/cap/refreshed-capability";
   let fakeNow = 1_000_000;
-  const sendResult = new Promise((resolve) => {
-    resolveSend = resolve;
-  });
+  let timerId = 0;
+  const timers = new Map<number, { at: number; callback: () => void }>();
+  const frames = new Map<number, () => void>();
+  const microtasks = async () => {
+    for (let i = 0; i < 16; i += 1) {
+      await Promise.resolve();
+    }
+  };
+  const drain = async () => {
+    for (let batch = 0; batch < 32; batch += 1) {
+      await microtasks();
+      if (frames.size === 0) {
+        return;
+      }
+      const callbacks = [...frames.values()];
+      frames.clear();
+      callbacks.forEach((callback) => callback());
+    }
+    assert.fail("renderer exceeded 32 RAF batches");
+  };
   const Date = { now: () => fakeNow };
   const window = {
     __TAURI__: {
@@ -156,14 +191,25 @@ function createQuickChatHarness(): Record<string, any> {
             generation?: number;
           },
         ) {
+          calls.push({ method, args: args ?? {} });
           if (method === "quickchat_send") {
-            return sendResult;
+            return new Promise((resolve, reject) => {
+              sends.push({ resolve, reject });
+            });
           }
           if (method === "quickchat_refresh_widget_surface") {
             widgetSurfaceRefreshCount += 1;
+            if (deferRefresh) {
+              return new Promise((resolve, reject) => {
+                refreshes.push({ resolve, reject });
+              });
+            }
             return widgetSurfaceRefreshFails
               ? Promise.reject(new Error("refresh failed"))
-              : Promise.resolve(widgetSurfaceRefreshResult);
+              : Promise.resolve({
+                  gatewayGeneration: (args as Record<string, unknown>)?.gatewayGeneration ?? 1,
+                  canvasSurfaceUrl: widgetSurfaceRefreshResult,
+                });
           }
           if (method === "quickchat_sync_widgets") {
             syncedWidgets = args?.widgets ?? [];
@@ -171,19 +217,47 @@ function createQuickChatHarness(): Record<string, any> {
             syncedExpanded = args?.expanded === true;
             syncedGeneration = args?.generation ?? 0;
             widgetSyncCount += 1;
+            if (deferWidgetSync) {
+              activeWidgetSyncs += 1;
+              maxActiveWidgetSyncs = Math.max(maxActiveWidgetSyncs, activeWidgetSyncs);
+              return new Promise<void>((resolve, reject) => {
+                widgetSyncs.push({ args: structuredClone(args ?? {}), resolve, reject });
+              }).finally(() => {
+                activeWidgetSyncs -= 1;
+              });
+            }
           }
-          return Promise.resolve(null);
+          if (method === "quickchat_agents") {
+            return Promise.resolve([]);
+          }
+          if (method === "quickchat_identity") {
+            return Promise.resolve({ id: "work", name: "Work", isDefault: true });
+          }
+          return Promise.resolve(true);
         },
       },
       event: { listen: async () => () => {} },
     },
-    addEventListener() {},
-    clearTimeout() {},
+    addEventListener(name: string, callback: () => void) {
+      windowListeners.set(name, callback);
+    },
+    clearTimeout(id: number) {
+      timers.delete(id);
+    },
     matchMedia: () => ({ matches: true }),
     requestAnimationFrame(callback: () => void) {
-      callback();
+      const id = ++timerId;
+      frames.set(id, callback);
+      return id;
     },
-    setTimeout: () => 1,
+    cancelAnimationFrame(id: number) {
+      frames.delete(id);
+    },
+    setTimeout(callback: () => void, ms: number) {
+      const id = ++timerId;
+      timers.set(id, { at: fakeNow + ms, callback });
+      return id;
+    },
   };
   const document = {
     body: createFakeElement(),
@@ -197,8 +271,23 @@ function createQuickChatHarness(): Record<string, any> {
       return elements.get(selector);
     },
   };
-  const advanceTime = (ms: number) => {
-    fakeNow += ms;
+  const advanceTime = async (ms: number) => {
+    const until = fakeNow + ms;
+    for (let batch = 0; batch < 128; batch += 1) {
+      await drain();
+      const next = [...timers.entries()]
+        .filter(([, timer]) => timer.at <= until)
+        .toSorted((a, b) => a[1].at - b[1].at || a[0] - b[0])[0];
+      if (!next) {
+        fakeNow = until;
+        await drain();
+        return;
+      }
+      fakeNow = next[1].at;
+      timers.delete(next[0]);
+      next[1].callback();
+    }
+    assert.fail("renderer exceeded 128 timer batches");
   };
   const browserContext: Record<string, any> = {
     advanceTime,
@@ -212,25 +301,25 @@ function createQuickChatHarness(): Record<string, any> {
     `${quickchatSource.slice(0, browserBindingsEnd)}
 this.harness = {
   send,
-  handleChatEvent,
+  handleChatEvent(payload) { handleChatEvent({gatewayGeneration: 1, ...payload}); },
   nextVisibilityOperation,
   requestHide,
   clearReply,
-  setGatewayUp(surface = "https://gateway.example/__openclaw__/cap/fixture-capability") {
-    gatewayState = "up";
-    canvasSurfaceObservedUrl = surface;
-    canvasSurfaceUrl = surface;
-    canvasSurfaceRefreshedAt = Date.now();
-    canvasSurfaceRetryAt = 0;
-    if (visibilitySequence === 0) visibilitySequence = 1;
+  setGatewayUp(surface = "https://gateway.example/__openclaw__/cap/fixture-capability", gatewayGeneration = 1) {
+    setGatewayState({state: "up", canvasSurfaceUrl: surface, gatewayGeneration});
+    if (visibilitySequence === 0) reveal();
   },
-  advanceTime(ms) { advanceTime(ms); },
-  emitGatewayState(payload) { setGatewayState(payload); },
+  advanceTime(ms) { return advanceTime(ms); },
+  emitGatewayState(payload) { setGatewayState({gatewayGeneration: 1, ...payload}); },
   accent() { return document.documentElement.style.getPropertyValue("--accent"); },
   setMessage(value) { elements.input.value = value; },
   pendingCount() { return pendingChatEvents.length; },
   activeRunId() { return activeReply?.runId ?? null; },
   replyText() { return elements.replyText.textContent; },
+  readOnly() { return elements.input.readOnly; },
+  thinking() { return !elements.replyThinking.hidden; },
+  draft() { return elements.input.value; },
+  error() { return elements.status.textContent; },
   reveal,
   expireCanvasSurface() { canvasSurfaceRefreshedAt = 0; canvasSurfaceRetryAt = 0; },
   allowCanvasSurfaceRetry() { canvasSurfaceRetryAt = 0; },
@@ -241,12 +330,64 @@ this.harness = {
   );
   return {
     ...(browserContext.harness as Record<string, (...args: any[]) => any>),
-    resolveSend,
+    resolveSend: (value: Record<string, unknown>, index = sends.length - 1) => {
+      const pending = sends[index];
+      assert.ok(pending, "send invocation exists");
+      pending.resolve({ gatewayGeneration: 1, status: "started", ...value });
+    },
+    rejectSend: (message: string, index = sends.length - 1) => {
+      const pending = sends[index];
+      assert.ok(pending, "send invocation exists");
+      pending.reject(new Error(message));
+    },
+    sendCount: () => sends.length,
+    calls,
+    drain,
+    flushWidgets: async () => {
+      await drain();
+      await browserContext.harness.flushWidgets();
+      await drain();
+    },
+    deferRefresh: () => {
+      deferRefresh = true;
+    },
+    resolveRefresh: (value: unknown, index = refreshes.length - 1) => {
+      const pending = refreshes[index];
+      assert.ok(pending, "refresh invocation exists");
+      pending.resolve(value);
+    },
+    rejectRefresh: (index = refreshes.length - 1) => {
+      const pending = refreshes[index];
+      assert.ok(pending, "refresh invocation exists");
+      pending.reject(new Error("stale refresh failed"));
+    },
     syncedWidgets: () => syncedWidgets,
     syncedHasWidgets: () => syncedHasWidgets,
     syncedExpanded: () => syncedExpanded,
     syncedGeneration: () => syncedGeneration,
     widgetSyncCount: () => widgetSyncCount,
+    deferWidgetSync: () => {
+      deferWidgetSync = true;
+    },
+    widgetSyncs: () => widgetSyncs.map(({ args }) => args),
+    activeWidgetSyncs: () => activeWidgetSyncs,
+    maxActiveWidgetSyncs: () => maxActiveWidgetSyncs,
+    resolveWidgetSync: (index: number) => {
+      assert.ok(widgetSyncs[index], "widget sync invocation exists");
+      widgetSyncs[index].resolve();
+    },
+    rejectWidgetSync: (index: number) => {
+      assert.ok(widgetSyncs[index], "widget sync invocation exists");
+      widgetSyncs[index].reject(new Error("widget sync failed"));
+    },
+    resizeWidget: (x: number) => {
+      const host = elements.get("#reply-widgets")?.querySelector(".inline-widget-host");
+      assert.ok(host, "rendered widget host exists");
+      host.getBoundingClientRect = () => ({ x, y: 174, width: 540, height: 160 });
+      const resize = windowListeners.get("resize");
+      assert.ok(resize, "renderer registered its resize handler");
+      resize();
+    },
     widgetSurfaceRefreshCount: () => widgetSurfaceRefreshCount,
     setWidgetSurfaceRefreshFails: (value: boolean) => {
       widgetSurfaceRefreshFails = value;
@@ -590,6 +731,420 @@ test("widget URLs stay inside the capability-scoped Canvas host", () => {
   );
 });
 
+test("a cached terminal retry presents the recovered reply and unlocks without another event", async () => {
+  const harness = createQuickChatHarness();
+  harness.setGatewayUp();
+  harness.setMessage("recover my reply");
+  const first = harness.send(false);
+  harness.rejectSend("ACK connection closed");
+  await first;
+  assert.equal(harness.draft(), "recover my reply");
+  harness.emitGatewayState({ state: "down" });
+  await harness.drain();
+  harness.setGatewayUp();
+  const retry = harness.send(false);
+  harness.resolveSend({
+    sessionKey: "global",
+    agentId: "work",
+    runId: "retained-key",
+    status: "ok",
+    recoveredMessages: [
+      { role: "assistant", content: [{ type: "text", text: "The saved answer." }] },
+    ],
+  });
+  await retry;
+  await harness.advanceTime(450);
+  assert.equal(harness.replyText(), "The saved answer.");
+  assert.equal(harness.thinking(), false);
+  assert.equal(harness.readOnly(), false);
+  harness.handleChatEvent({
+    sessionKey: "global",
+    agentId: "work",
+    runId: "other-run",
+    state: "final",
+    message: { role: "assistant", content: "unrelated" },
+  });
+  assert.equal(harness.replyText(), "The saved answer.");
+  harness.setMessage("next turn");
+  const next = harness.send(false);
+  assert.equal(harness.sendCount(), 3);
+  harness.resolveSend({ sessionKey: "global", agentId: "work", runId: "next-key" });
+  await next;
+  await harness.advanceTime(450);
+  assert.equal(harness.readOnly(), true, "ordinary started ACK still waits for its final");
+  harness.handleChatEvent({
+    sessionKey: "global",
+    agentId: "work",
+    runId: "other-run",
+    state: "final",
+  });
+  assert.equal(harness.readOnly(), true);
+  harness.handleChatEvent({
+    sessionKey: "global",
+    agentId: "work",
+    runId: "next-key",
+    state: "final",
+  });
+  assert.equal(harness.readOnly(), false);
+});
+
+test("a buffered matching final wins over terminal history recovery", async () => {
+  const harness = createQuickChatHarness();
+  harness.setGatewayUp();
+  harness.setMessage("answer");
+  const sending = harness.send(false);
+  harness.handleChatEvent({
+    sessionKey: "global",
+    agentId: "work",
+    runId: "reply-key",
+    state: "final",
+    message: { role: "assistant", content: "Live final" },
+  });
+  harness.resolveSend({
+    sessionKey: "global",
+    agentId: "work",
+    runId: "reply-key",
+    status: "ok",
+    recoveredMessages: [{ role: "assistant", content: "Recovered text" }],
+  });
+  await sending;
+  await harness.advanceTime(450);
+  assert.equal(harness.replyText(), "Live final");
+  assert.equal(harness.readOnly(), false);
+});
+
+function widgetFinal(gatewayGeneration = 1) {
+  return {
+    gatewayGeneration,
+    sessionKey: "global",
+    agentId: "work",
+    runId: "widget-owner-run",
+    state: "final",
+    message: {
+      role: "assistant",
+      content: [
+        {
+          type: "canvas",
+          preview: {
+            kind: "canvas",
+            surface: "assistant_message",
+            render: "url",
+            sandbox: "strict",
+            url: "/__openclaw__/canvas/documents/owner-a/index.html",
+          },
+        },
+      ],
+    },
+  };
+}
+
+function updateWidgetKeys(harness: Record<string, any>, keys: string[]) {
+  const event = widgetFinal();
+  event.state = "delta";
+  const first = event.message.content[0];
+  assert.ok(first);
+  const preview = first.preview;
+  event.message.content = keys.map((key) => ({
+    type: "canvas",
+    preview: {
+      ...preview,
+      viewId: key,
+      url: `/__openclaw__/canvas/documents/${key}/index.html`,
+    },
+  }));
+  harness.handleChatEvent(event);
+}
+
+async function createSlowWidgetHarness() {
+  const harness = createQuickChatHarness();
+  harness.setGatewayUp();
+  harness.setMessage("show widgets");
+  const sending = harness.send(false);
+  harness.resolveSend({ sessionKey: "global", agentId: "work", runId: "widget-owner-run" });
+  await sending;
+  await harness.flushWidgets();
+  harness.deferWidgetSync();
+  updateWidgetKeys(harness, ["first"]);
+  await harness.drain();
+  assert.equal(harness.widgetSyncs().length, 1);
+  return harness;
+}
+
+for (const kind of ["geometry", "structure"] as const) {
+  test(`widget sync coalesces six ${kind} frames into initial and latest state`, async () => {
+    const harness = await createSlowWidgetHarness();
+    // Six distinct RAF batches including the initial in-flight state.
+    for (let frame = 1; frame <= 5; frame += 1) {
+      if (kind === "structure") {
+        updateWidgetKeys(harness, frame === 2 ? [] : [`widget-${frame}`]);
+      }
+      if (kind === "geometry" || frame !== 2) {
+        harness.resizeWidget(52 + frame);
+      }
+      await harness.drain();
+    }
+    assert.equal(harness.widgetSyncs().length, 1);
+    assert.equal(harness.activeWidgetSyncs(), 1);
+    harness.resolveWidgetSync(0);
+    await harness.drain();
+    const latest = harness.widgetSyncs()[1];
+    assert.equal(latest.widgets[0].x, 57);
+    assert.equal(latest.widgets[0].key, kind === "geometry" ? "first" : "widget-5");
+    assert.equal(latest.hasWidgets, true);
+    assert.equal(latest.expanded, true);
+    assert.equal(latest.sessionId, harness.widgetSyncs()[0].sessionId);
+    assert.equal(latest.rendererEpoch, harness.widgetSyncs()[0].rendererEpoch);
+    harness.resolveWidgetSync(1);
+    await harness.drain();
+    assert.equal(harness.widgetSyncs().length, 2);
+    assert.equal(harness.activeWidgetSyncs(), 0);
+    assert.equal(harness.maxActiveWidgetSyncs(), 1);
+  });
+}
+
+test("widget sync retains a latest empty compact state", async () => {
+  const harness = await createSlowWidgetHarness();
+  harness.resizeWidget(56);
+  await harness.drain();
+  harness.clearReply();
+  await harness.drain();
+  harness.resolveWidgetSync(0);
+  await harness.drain();
+  const latest = harness.widgetSyncs()[1];
+  assert.deepEqual(latest.widgets, []);
+  assert.equal(latest.hasWidgets, false);
+  assert.equal(latest.expanded, false);
+  harness.resolveWidgetSync(1);
+  await harness.drain();
+  assert.equal(harness.widgetSyncs().length, 2);
+});
+
+test("widget sync allows a newer reply to supersede a pending clear", async () => {
+  const harness = await createSlowWidgetHarness();
+  harness.handleChatEvent({ ...widgetFinal(), message: { role: "assistant", content: [] } });
+  await harness.advanceTime(450);
+  harness.setMessage("new reply");
+  const sending = harness.send(false);
+  await harness.drain();
+  harness.resolveSend({ sessionKey: "global", agentId: "work", runId: "new-run" });
+  await sending;
+  harness.handleChatEvent({ ...widgetFinal(), runId: "new-run" });
+  await harness.drain();
+  harness.resolveWidgetSync(0);
+  await harness.drain();
+  assert.equal(harness.widgetSyncs()[1].widgets.length, 1);
+  assert.match(harness.widgetSyncs()[1].widgets[0].url, /documents\/owner-a/u);
+  harness.resolveWidgetSync(1);
+  await harness.drain();
+  assert.equal(harness.widgetSyncs().length, 2);
+});
+
+for (const transition of ["hide", "reveal"] as const) {
+  test(`widget sync drops pending pre-${transition} visibility state`, async () => {
+    const harness = await createSlowWidgetHarness();
+    harness.resizeWidget(56);
+    await harness.drain();
+    await harness.requestHide();
+    if (transition === "hide") {
+      await harness.advanceTime(45);
+      assert.ok(
+        harness.calls.some(({ method }: { method: string }) => method === "quickchat_hide"),
+      );
+    } else {
+      harness.reveal();
+      await harness.drain();
+    }
+    harness.resolveWidgetSync(0);
+    await harness.drain();
+    const latest = harness.widgetSyncs()[1];
+    assert.equal(latest.generation, transition === "hide" ? 2 : 3);
+    assert.equal(latest.widgets.length, transition === "hide" ? 0 : 1);
+    harness.resolveWidgetSync(1);
+    await harness.drain();
+    assert.equal(harness.widgetSyncs().length, 2);
+  });
+}
+
+for (const transition of ["owner", "surface"] as const) {
+  test(`widget sync preserves ${transition} fencing while work is pending`, async () => {
+    const harness = await createSlowWidgetHarness();
+    harness.resizeWidget(56);
+    await harness.drain();
+    const originalSurface = harness.widgetSyncs()[0].surfaceUrl;
+    if (transition === "owner") {
+      harness.setGatewayUp("https://gateway.example/__openclaw__/cap/other", 2);
+      await harness.drain();
+      harness.setGatewayUp(originalSurface, 3);
+    } else {
+      harness.emitGatewayState({ state: "down" });
+      await harness.drain();
+      harness.setGatewayUp("https://gateway.example/__openclaw__/cap/rotated", 1);
+    }
+    await harness.drain();
+    harness.rejectWidgetSync(0);
+    await harness.drain();
+    const latest = harness.widgetSyncs()[1];
+    assert.equal(latest.gatewayGeneration, transition === "owner" ? 3 : 1);
+    assert.equal(latest.widgets.length, transition === "owner" ? 0 : 1);
+    if (transition === "surface") {
+      assert.match(latest.widgets[0].url, /\/cap\/rotated\//u);
+    }
+    assert.equal(harness.error(), "");
+    harness.resolveWidgetSync(1);
+    await harness.drain();
+    assert.equal(harness.widgetSyncs().length, 2);
+  });
+}
+
+test("widget sync drains the latest state after rejection without replaying the failure", async () => {
+  const harness = await createSlowWidgetHarness();
+  for (const x of [54, 57]) {
+    harness.resizeWidget(x);
+    await harness.drain();
+  }
+  harness.rejectWidgetSync(0);
+  await harness.drain();
+  assert.equal(harness.widgetSyncs()[1].widgets[0].x, 57);
+  assert.equal(harness.error(), "", "a superseded sync must not overwrite current status");
+  harness.resolveWidgetSync(1);
+  await harness.drain();
+  assert.equal(harness.widgetSyncs().length, 2);
+  assert.equal(harness.maxActiveWidgetSyncs(), 1);
+});
+
+test("widget sync reports a current failure once and accepts later work", async () => {
+  const harness = await createSlowWidgetHarness();
+  harness.rejectWidgetSync(0);
+  await harness.drain();
+  assert.equal(harness.error(), "widget sync failed");
+  assert.equal(harness.widgetSyncs().length, 1, "failure does not retry itself");
+  harness.resizeWidget(57);
+  await harness.drain();
+  assert.equal(harness.widgetSyncs()[1].widgets[0].x, 57);
+  harness.resolveWidgetSync(1);
+  await harness.drain();
+  assert.equal(harness.activeWidgetSyncs(), 0);
+});
+
+for (const timing of ["same-frame", "awaiting-frame"] as const) {
+  test(`widget sync uses the latest ${timing} bounds`, async () => {
+    const harness = await createSlowWidgetHarness();
+    harness.resizeWidget(54);
+    if (timing === "awaiting-frame") {
+      await harness.drain();
+    }
+    harness.resizeWidget(57);
+    if (timing === "same-frame") {
+      await harness.drain();
+    }
+    harness.resolveWidgetSync(0);
+    await harness.drain();
+    assert.equal(harness.widgetSyncs()[1].widgets[0].x, 57);
+    harness.resolveWidgetSync(1);
+    await harness.drain();
+    assert.equal(harness.widgetSyncs().length, 2);
+  });
+}
+
+test("retained widgets reconnect only to their original generation, including same-URL roundtrips", async () => {
+  const harness = createQuickChatHarness();
+  const surfaceA = "https://gateway.example/__openclaw__/cap/owner-a";
+  harness.setGatewayUp(surfaceA, 1);
+  harness.setMessage("widget");
+  const sending = harness.send(false);
+  harness.resolveSend({ sessionKey: "global", agentId: "work", runId: "widget-owner-run" });
+  await sending;
+  harness.handleChatEvent(widgetFinal());
+  await harness.flushWidgets();
+  assert.ok(harness.syncedWidgets()[0]?.url.includes("/cap/owner-a/"));
+  harness.emitGatewayState({ state: "down" });
+  await harness.flushWidgets();
+  assert.equal(harness.syncedWidgets().length, 0);
+  harness.setGatewayUp("https://gateway.example/__openclaw__/cap/owner-a-rotated", 1);
+  await harness.flushWidgets();
+  assert.ok(harness.syncedWidgets()[0]?.url.includes("/cap/owner-a-rotated/"));
+  const switchedAt = harness.calls.length;
+  harness.emitGatewayState({ state: "down", gatewayGeneration: 2 });
+  await harness.flushWidgets();
+  harness.setGatewayUp("https://gateway.example/__openclaw__/cap/owner-b", 2);
+  await harness.flushWidgets();
+  harness.setGatewayUp(surfaceA, 3);
+  await harness.flushWidgets();
+  const laterLayouts = harness.calls
+    .slice(switchedAt)
+    .filter((call: { method: string }) => call.method === "quickchat_sync_widgets")
+    .flatMap((call: { args: { widgets: unknown[] } }) => call.args.widgets);
+  assert.equal(
+    laterLayouts.length,
+    0,
+    "an A document must never acquire B or replacement-A authority",
+  );
+});
+
+for (const outcome of ["success", "failure"] as const) {
+  test(`a stale Canvas refresh ${outcome} cannot settle the new owner's refresh`, async () => {
+    const harness = createQuickChatHarness();
+    harness.deferRefresh();
+    harness.setGatewayUp();
+    harness.expireCanvasSurface();
+    harness.setMessage("A widget");
+    const first = harness.send(false);
+    harness.resolveSend({ sessionKey: "global", agentId: "work", runId: "widget-owner-run" });
+    await first;
+    harness.handleChatEvent(widgetFinal());
+    await harness.advanceTime(450);
+    assert.equal(harness.widgetSurfaceRefreshCount(), 1);
+    harness.emitGatewayState({ state: "down", gatewayGeneration: 2 });
+    await harness.drain();
+    harness.setGatewayUp("https://gateway.example/__openclaw__/cap/owner-b", 2);
+    harness.expireCanvasSurface();
+    harness.setMessage("B widget");
+    const second = harness.send(false);
+    harness.resolveSend({
+      gatewayGeneration: 2,
+      sessionKey: "global",
+      agentId: "work",
+      runId: "widget-owner-run",
+    });
+    await second;
+    const event = widgetFinal(2);
+    const widget = event.message.content[0];
+    assert.ok(widget);
+    widget.preview.url = "/__openclaw__/canvas/documents/owner-b/index.html";
+    harness.handleChatEvent(event);
+    await harness.drain();
+    assert.equal(harness.widgetSurfaceRefreshCount(), 2);
+    if (outcome === "success") {
+      harness.resolveRefresh(
+        {
+          gatewayGeneration: 1,
+          canvasSurfaceUrl: "https://gateway.example/__openclaw__/cap/stale-a",
+        },
+        0,
+      );
+    } else {
+      harness.rejectRefresh(0);
+    }
+    await harness.advanceTime(0);
+    assert.equal(
+      harness.widgetSurfaceRefreshCount(),
+      2,
+      "old finally must not clear the new promise",
+    );
+    harness.resolveRefresh(
+      {
+        gatewayGeneration: 2,
+        canvasSurfaceUrl: "https://gateway.example/__openclaw__/cap/fresh-b",
+      },
+      1,
+    );
+    await harness.flushSurfaceRefresh();
+    await harness.flushWidgets();
+    assert.equal(harness.syncedWidgets().length, 1);
+    assert.match(harness.syncedWidgets()[0].url, /fresh-b.*documents\/owner-b/u);
+  });
+}
+
 test("pre-ack frames replay once for only the acknowledged run", async () => {
   const harness = createQuickChatHarness();
   harness.setGatewayUp();
@@ -813,9 +1368,11 @@ test("unchanged gateway state does not renew a failed Canvas capability", async 
   await harness.flushSurfaceRefresh();
   assert.equal(harness.widgetSurfaceRefreshCount(), 1);
   harness.emitGatewayState({ state: "up", canvasSurfaceUrl: surface, notice: "unchanged" });
-  harness.advanceTime(5_000);
+  await harness.advanceTime(4_999);
+  assert.equal(harness.widgetSurfaceRefreshCount(), 1);
+  assert.equal(harness.syncedWidgets().length, 0);
   harness.setWidgetSurfaceRefreshFails(false);
-  harness.allowCanvasSurfaceRetry();
+  await harness.advanceTime(1);
   harness.handleChatEvent({
     sessionKey: "global",
     agentId: "work",

--- a/test/release-version.test.ts
+++ b/test/release-version.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import releaseVersionCases from "../apps/linux/tests/release_version_cases.json" with { type: "json" };
 import {
   classifyReleaseTrain,
   collectReleaseVersionFloorErrors,
@@ -38,10 +39,15 @@ describe("release version policy", () => {
     expect(collectReleaseVersionFloorErrors("2026.7.1")).toEqual([]);
   });
 
-  it("orders prereleases, finals, and corrections", () => {
-    expect(compareReleaseVersions("2026.3.29-alpha.2", "2026.3.29-beta.1")).toBe(-1);
-    expect(compareReleaseVersions("2026.3.29-beta.1", "2026.3.29")).toBe(-1);
-    expect(compareReleaseVersions("2026.3.29-2", "2026.3.29")).toBe(1);
+  it.each(releaseVersionCases.ordered)(
+    "orders shared desktop release $current -> $candidate",
+    ({ current, candidate, ordering }) => {
+      expect(compareReleaseVersions(candidate, current)).toBe(ordering);
+    },
+  );
+
+  it.each(releaseVersionCases.unrecognized)("leaves %s outside calendar ordering", (version) => {
+    expect(parseReleaseVersion(version)).toBeNull();
   });
 
   it.each([

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -17938,13 +17938,18 @@ it("pins simple release admission owners before selected checkout and preserves 
   expect(Object.keys(request.on.workflow_dispatch.inputs)).toEqual(["tag", "desktop-test-bundles"]);
   expect(request.jobs.validate_request.permissions).toBeUndefined();
   expect(JSON.stringify(request)).not.toContain("${{ secrets.");
-  expect(linux.on).toEqual({
-    workflow_run: {
-      workflows: ["Linux App Release Request"],
-      branches: ["main"],
-      types: ["completed"],
-    },
+  expect(linux.on.workflow_run).toEqual({
+    workflows: ["Linux App Release Request"],
+    branches: ["main"],
+    types: ["completed"],
   });
+  expect(Object.keys(linux.on.workflow_dispatch.inputs)).toEqual([
+    "release_tag",
+    "source_sha",
+    "tooling_sha",
+    "release_publish_run_id",
+    "release_publish_run_attempt",
+  ]);
   const releaseDocs = expectDefined(
     readFileSync("apps/linux/README.md", "utf8").split("## Releases\n")[1],
     "Linux release documentation",
@@ -17953,8 +17958,8 @@ it("pins simple release admission owners before selected checkout and preserves 
   expect(releaseDocs).toContain("stable release tag in `tag`");
   expect(releaseDocs).toMatch(/optional\s+`desktop-test-bundles` input/u);
   expect(releaseDocs).toMatch(/successful request automatically triggers `Linux App Release`/u);
-  expect(releaseDocs).not.toContain("release-publish/");
   expect(linux.permissions).toEqual({});
+  expect(linux.jobs.validate_release.if).toContain("github.event_name == 'workflow_run'");
   expect(linux.jobs.validate_release.if).toContain(
     "github.event.workflow_run.repository.full_name == 'openclaw/openclaw'",
   );
@@ -17998,8 +18003,9 @@ it("pins simple release admission owners before selected checkout and preserves 
           (job as { permissions?: { contents?: string } }).permissions?.contents === "write",
       )
       .map(([name]) => name),
-  ).toEqual(["publish"]);
+  ).toEqual(["publish", "mirror_legacy"]);
   expect(linux.jobs.publish.permissions).toEqual({ contents: "write" });
+  expect(linux.jobs.mirror_legacy.permissions).toEqual({ actions: "read", contents: "write" });
   expect(
     Object.entries(linux.jobs)
       .filter(([, job]) => JSON.stringify(job).includes("${{ secrets.TAURI_SIGNING_PRIVATE_KEY"))
@@ -18476,19 +18482,74 @@ it("pins simple release admission owners before selected checkout and preserves 
   });
   const publishLinuxBundles = expectDefined(
     (linux.jobs.publish.steps as WorkflowStep[]).find(
-      ({ name }) => name === "Assemble release assets and updater manifest",
+      ({ name }) =>
+        name === "Publish immutable bundles, canonical Linux channel, and legacy mirror",
     ),
     "Linux release publication step",
   );
+  expect(publishLinuxBundles.env).toMatchObject({
+    RELEASE_TAG: "${{ needs.validate_release.outputs.release_tag }}",
+    TAG_SHA: "${{ needs.validate_release.outputs.tag_sha }}",
+    WORKFLOW_SHA: "${{ github.workflow_sha }}",
+  });
+  expect(publishLinuxBundles.run).toContain("node scripts/linux-app-channel.mjs publish");
   expect(publishLinuxBundles.run).toContain(
-    'linux_signature=$(cat "dist/input/linux/signatures/OpenClaw-${version}-amd64.AppImage.sig")',
+    '--signature "dist/input/linux/signatures/OpenClaw-${RELEASE_TAG#v}-amd64.AppImage.sig"',
   );
   expect(publishLinuxBundles.run).toContain(
-    '--arg linux_url "${url_base}/OpenClaw-${version}-amd64.AppImage"',
+    "--public-key-config apps/linux/src-tauri/tauri.conf.json",
   );
-  expect(publishLinuxBundles.run).toContain(
-    '"linux-x86_64": {signature: $linux_signature, url: $linux_url}',
+  expect(publishLinuxBundles.run).not.toContain("--clobber");
+  for (const [jobName, checkoutName] of [
+    ["publish", "Checkout trusted Linux publication tooling"],
+    ["mirror_legacy", "Checkout trusted Linux mirror tooling"],
+  ] as const) {
+    const writer = linux.jobs[jobName];
+    expect(writer.concurrency).toEqual({
+      group: "linux-app-release-publish",
+      queue: "max",
+      "cancel-in-progress": false,
+    });
+    expect(writer["timeout-minutes"]).toBe(10);
+    const checkout = expectDefined(
+      (writer.steps as WorkflowStep[]).find(({ name }) => name === checkoutName),
+      `${jobName} trusted checkout`,
+    );
+    expect(checkout.with).toMatchObject({
+      ref: "${{ github.workflow_sha }}",
+      "persist-credentials": false,
+      "sparse-checkout-cone-mode": false,
+    });
+    expect(String(checkout.with?.["sparse-checkout"]).trim().split("\n")).toEqual([
+      "apps/linux/src-tauri/tauri.conf.json",
+      "scripts/linux-app-channel.mjs",
+      "scripts/lib/release-version.mjs",
+      "scripts/lib/record-shared.mjs",
+      "scripts/release-tooling-identity.mjs",
+    ]);
+  }
+  const mirrorSteps = linux.jobs.mirror_legacy.steps as WorkflowStep[];
+  const mirrorIdentity = expectDefined(
+    mirrorSteps.find(({ name }) => name === "Verify detached mirror dispatch identity"),
+    "detached mirror identity",
   );
+  expect(mirrorIdentity.run).toContain('"$EXPECTED_TOOLING_SHA" == "$WORKFLOW_SHA"');
+  expect(mirrorIdentity.run).toContain("refs/tags/release-publish/");
+  expect(mirrorIdentity.run).toContain('--release-publish-run-id "$PARENT_RUN_ID"');
+  expect(mirrorIdentity.run).toContain('--release-publish-run-attempt "$PARENT_RUN_ATTEMPT"');
+  expect(mirrorIdentity.run).toContain("--release-publish-parent-state-policy active-or-success");
+  expect(mirrorIdentity.run).not.toContain("--allow-prevalidated-ref");
+  const mirrorWrite = expectDefined(
+    mirrorSteps.find(
+      ({ name }) => name === "Mirror verified canonical bytes to the actual core latest",
+    ),
+    "detached mirror command",
+  );
+  expect(mirrorSteps.indexOf(mirrorIdentity)).toBeLessThan(mirrorSteps.indexOf(mirrorWrite));
+  expect(mirrorWrite.run).toContain("node scripts/linux-app-channel.mjs mirror");
+  expect(mirrorWrite.run).toContain('--tag "$RELEASE_TAG" --source-sha "$TAG_SHA"');
+  expect(linux.jobs.mirror_legacy.if).toContain("github.event_name == 'workflow_dispatch'");
+  expect(linux.jobs.mirror_legacy).not.toHaveProperty("needs");
   const appImageToolsPath = "apps/linux/scripts/tauri-appimage-tools.sh";
   const appImageTools = readFileSync(appImageToolsPath, "utf8");
   const appImageToolsManifest = readFileSync(

--- a/test/scripts/linux-app-channel.test.ts
+++ b/test/scripts/linux-app-channel.test.ts
@@ -1,0 +1,1144 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { chmodSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { expect, it } from "vitest";
+import { createScriptTestHarness } from "./test-helpers.js";
+
+const { createTempDir } = createScriptTestHarness();
+const cli = resolve("scripts/linux-app-channel.mjs");
+const tag = "v2026.9.3";
+const nextTag = "v2026.9.4";
+const channel = "linux-stable";
+const publicKey = Buffer.from("fixture public key\n").toString("base64");
+const signature = Buffer.from("fixture signature\n").toString("base64");
+
+type Asset = {
+  id: number;
+  name: string;
+  label?: string;
+  size: number;
+  state: string;
+  digest: string;
+  browser_download_url: string;
+  bytes: string;
+};
+type Release = {
+  id: number;
+  tag_name: string;
+  source: string;
+  draft: boolean;
+  prerelease: boolean;
+  body: string;
+  published_at: string;
+  assets: Asset[];
+};
+type Call = {
+  tool: string;
+  action: string;
+  tag?: string;
+  name?: string;
+  url?: string;
+  releaseId?: number;
+  makeLatest?: boolean;
+};
+type Transition = {
+  kind: "replace-release" | "move-tag" | "select-latest";
+  tag: string;
+};
+type Fault = {
+  point: "download" | "upload-before" | "upload-after" | "upload-readback" | "legacy-readback";
+  tag: string;
+  name: string;
+};
+type State = {
+  releases: Release[];
+  latest: string | null;
+  nextId: number;
+  calls: Call[];
+  verifierExit: number;
+  fault?: Fault;
+  corruptDownload?: { tag: string; name: string };
+  replaceReleaseAfterDownload?: { tag: string; name: string };
+  latestAfterDelete?: string;
+  latestAfterUpload?: string;
+  afterSourceRead?: { tag: string; change: Transition };
+  afterPatch?: Transition;
+  releaseResponseTag?: { tag: string; value: string };
+};
+
+function hash(bytes: string | Buffer) {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+function sourceSha(value: string) {
+  return hash(value).slice(0, 40);
+}
+
+function downloadUrl(releaseTag: string, name: string) {
+  return `https://github.com/openclaw/openclaw/releases/download/${releaseTag}/${name}`;
+}
+
+function legacyManifest(releaseTag = tag, notes = "Fixture release notes") {
+  return Buffer.from(
+    JSON.stringify({
+      version: releaseTag.slice(1),
+      notes,
+      pub_date: "2026-09-03T12:00:00Z",
+      platforms: {
+        "linux-x86_64": {
+          signature,
+          url: downloadUrl(releaseTag, `OpenClaw-${releaseTag.slice(1)}-amd64.AppImage`),
+        },
+      },
+    }),
+  );
+}
+
+function releaseFrom(state: State, releaseTag: string) {
+  const release = state.releases.find((entry) => entry.tag_name === releaseTag);
+  assert.ok(release, `Missing fixture release ${releaseTag}`);
+  return release;
+}
+
+function replaceAsset(state: State, releaseTag: string, name: string, bytes: Buffer) {
+  const release = releaseFrom(state, releaseTag);
+  release.assets = release.assets.filter((entry) => entry.name !== name);
+  const asset: Asset = {
+    id: state.nextId++,
+    name,
+    size: bytes.length,
+    state: "uploaded",
+    digest: `sha256:${hash(bytes)}`,
+    browser_download_url: downloadUrl(releaseTag, name),
+    bytes: bytes.toString("base64"),
+  };
+  release.assets.push(asset);
+  return asset;
+}
+
+// This models external CRUD and command contracts, not the channel promotion policy.
+// minisign is a controllable process boundary here, not cryptographic verification.
+const commandFixture = String.raw`
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const { createHash } = require("node:crypto");
+const statePath = process.env.CHANNEL_FIXTURE_STATE;
+const state = JSON.parse(fs.readFileSync(statePath, "utf8"));
+const tool = path.basename(process.argv[1]);
+const args = process.argv.slice(2);
+const save = () => fs.writeFileSync(statePath, JSON.stringify(state));
+const fail = (message, status = 1) => {
+  save();
+  console.error(message);
+  process.exit(status);
+};
+const answer = (value) => {
+  save();
+  if (value !== undefined) process.stdout.write(JSON.stringify(value));
+};
+const release = (tag) => {
+  const value = state.releases.find((entry) => entry.tag_name === tag);
+  if (!value) fail("HTTP 404: release not found");
+  return value;
+};
+const publicAsset = ({ bytes, ...entry }) => entry;
+const publicRelease = ({ source, assets, ...entry }) => entry;
+const flag = (name) => args[args.indexOf(name) + 1];
+const fault = (point, tag, name) => {
+  if (state.fault?.point !== point || state.fault.tag !== tag || state.fault.name !== name) return false;
+  delete state.fault;
+  return true;
+};
+const transition = (change) => {
+  if (change.kind === "select-latest") state.latest = change.tag;
+  else if (change.kind === "replace-release") {
+    const owner = release(change.tag);
+    owner.id = state.nextId++;
+    owner.assets = [];
+  } else if (change.kind === "move-tag") release(change.tag).source = "c".repeat(40);
+  else assert.fail("Unsupported fixture transition");
+  state.calls.push({ tool: "fixture", action: change.kind, tag: change.tag });
+};
+try {
+  if (tool === "gh" && args[0] === "api") {
+    const prefix = "repos/openclaw/openclaw/";
+    const endpoint = args.find((argument) => argument.startsWith(prefix));
+    assert(endpoint, "Unexpected fixture repository");
+    const route = endpoint.slice(prefix.length);
+    const method = args.includes("--method") ? flag("--method") : "GET";
+    assert(["GET", "PATCH", "DELETE"].includes(method), "Unsupported fixture method");
+    state.calls.push({ tool, action: method, url: route });
+    if (method === "PATCH") {
+      const match = /^releases\/(\d+)$/.exec(route);
+      assert(match, "Unsupported patch endpoint");
+      assert.equal(flag("--field"), "draft=false");
+      const latest = flag("--raw-field");
+      assert(["make_latest=true", "make_latest=false"].includes(latest));
+      const owner = state.releases.find((entry) => entry.id === Number(match[1]));
+      if (!owner) fail("HTTP 404: release not found");
+      const makeLatest = latest === "make_latest=true";
+      if (makeLatest && owner.prerelease) fail("HTTP 422: prerelease cannot be latest");
+      Object.assign(state.calls.at(-1), { tag: owner.tag_name, releaseId: owner.id, makeLatest });
+      owner.draft = false;
+      if (makeLatest) state.latest = owner.tag_name;
+      const response = publicRelease(owner);
+      if (state.afterPatch) {
+        const change = state.afterPatch;
+        delete state.afterPatch;
+        transition(change);
+      }
+      answer(response);
+    } else if (method === "DELETE") {
+      const match = /^releases\/assets\/(\d+)$/.exec(route);
+      assert(match, "Unsupported mutation");
+      const owner = state.releases.find((entry) => entry.assets.some((asset) => asset.id === Number(match[1])));
+      assert(owner, "Missing deleted asset");
+      const entry = owner.assets.find((asset) => asset.id === Number(match[1]));
+      Object.assign(state.calls.at(-1), { tag: owner.tag_name, name: entry.name });
+      owner.assets = owner.assets.filter((asset) => asset.id !== entry.id);
+      if (state.latestAfterDelete) {
+        state.latest = state.latestAfterDelete;
+        delete state.latestAfterDelete;
+      }
+      answer();
+    } else if (route === "releases/latest") {
+      if (!state.latest) fail("HTTP 404: latest not found");
+      answer(publicRelease(release(state.latest)));
+    } else if (route.startsWith("releases/tags/")) {
+      const tag = decodeURIComponent(route.slice("releases/tags/".length));
+      const owner = release(tag);
+      if (owner.draft) fail("HTTP 404: release by tag is not published");
+      const response = publicRelease(owner);
+      if (state.releaseResponseTag?.tag === tag) response.tag_name = state.releaseResponseTag.value;
+      answer(response);
+    } else if (route.startsWith("git/ref/tags/")) {
+      const tag = decodeURIComponent(route.slice("git/ref/tags/".length));
+      const owner = release(tag);
+      const response = { object: { type: "commit", sha: owner.source } };
+      if (state.afterSourceRead?.tag === tag) {
+        const change = state.afterSourceRead.change;
+        delete state.afterSourceRead;
+        transition(change);
+      }
+      answer(response);
+    } else if (/^releases\/\d+$/.test(route)) {
+      const owner = state.releases.find((entry) => entry.id === Number(route.slice("releases/".length)));
+      if (!owner) fail("HTTP 404: release not found");
+      const response = publicRelease(owner);
+      if (state.releaseResponseTag?.tag === owner.tag_name) response.tag_name = state.releaseResponseTag.value;
+      answer(response);
+    } else {
+      const match = /^releases\/(\d+)\/assets\?per_page=100&page=(\d+)$/.exec(route);
+      assert(match, "Unsupported fixture API");
+      const owner = state.releases.find((entry) => entry.id === Number(match[1]));
+      assert(owner, "Missing asset owner");
+      const start = (Number(match[2]) - 1) * 100;
+      answer(owner.assets.slice(start, start + 100).map(publicAsset));
+    }
+  } else if (tool === "gh" && args[0] === "release") {
+    assert.equal(flag("--repo"), "openclaw/openclaw");
+    const action = args[1];
+    const tag = args[2];
+    if (action === "view") {
+      state.calls.push({ tool, action, tag });
+      const owner = release(tag);
+      const fields = {
+        databaseId: owner.id,
+        tagName: state.releaseResponseTag?.tag === tag ? state.releaseResponseTag.value : owner.tag_name,
+        isDraft: owner.draft,
+        isPrerelease: owner.prerelease,
+      };
+      const selected = flag("--json").split(",");
+      assert(selected.every((name) => Object.hasOwn(fields, name)), "Unsupported release view field");
+      if (args.includes("--jq")) {
+        assert.equal(flag("--jq"), ".databaseId");
+        assert(selected.includes("databaseId"));
+        answer(owner.id);
+      } else {
+        answer(Object.fromEntries(selected.map((name) => [name, fields[name]])));
+      }
+    } else if (action === "create") {
+      assert(!state.releases.some((entry) => entry.tag_name === tag), "Release already exists");
+      assert(args.includes("--prerelease") && args.includes("--latest=false"));
+      state.calls.push({ tool, action, tag });
+      state.releases.push({
+        id: state.nextId++, tag_name: tag, source: flag("--target"),
+        draft: false, prerelease: true, body: flag("--notes"),
+        published_at: "2026-09-03T12:00:00Z", assets: [],
+      });
+      answer();
+    } else if (action === "edit") {
+      assert(args.includes("--prerelease") && args.includes("--latest=false"));
+      state.calls.push({ tool, action, tag });
+      release(tag).body = fs.readFileSync(flag("--notes-file"), "utf8");
+      answer();
+    } else {
+      assert.equal(action, "upload", "Unsupported fixture release command");
+      assert(!args.includes("--clobber"), "Fixture refuses implicit asset replacement");
+      const spec = args.at(-1);
+      const separator = spec.indexOf("#");
+      const file = separator < 0 ? spec : spec.slice(0, separator);
+      const label = separator < 0 ? undefined : spec.slice(separator + 1);
+      // gh's #suffix is a display label; the asset name is the file basename.
+      const name = path.basename(file);
+      state.calls.push({ tool, action, tag, name });
+      if (fault("upload-before", tag, name)) fail("fixture upload refused");
+      const owner = release(tag);
+      if (owner.assets.some((entry) => entry.name === name)) fail("HTTP 422: asset already exists");
+      const bytes = fs.readFileSync(file);
+      owner.assets.push({
+        id: state.nextId++, name, label, size: bytes.length, state: "uploaded",
+        digest: "sha256:" + createHash("sha256").update(bytes).digest("hex"),
+        browser_download_url: "https://github.com/openclaw/openclaw/releases/download/" + tag + "/" + name,
+        bytes: bytes.toString("base64"),
+      });
+      if (state.latestAfterUpload) {
+        state.latest = state.latestAfterUpload;
+        delete state.latestAfterUpload;
+      }
+      if (fault("upload-readback", tag, name)) state.corruptDownload = { tag, name };
+      if (fault("upload-after", tag, name)) fail("fixture lost upload acknowledgement");
+      answer();
+    }
+  } else if (tool === "curl") {
+    const url = args.at(-1);
+    const parsed = new URL(url);
+    assert.equal(parsed.origin, "https://github.com");
+    const legacy = parsed.pathname === "/openclaw/openclaw/releases/latest/download/latest.json";
+    const match = /^\/openclaw\/openclaw\/releases\/download\/([^/]+)\/([^/]+)$/.exec(parsed.pathname);
+    assert(legacy || match, "Unexpected public download");
+    const tag = legacy ? state.latest : decodeURIComponent(match[1]);
+    const name = legacy ? "latest.json" : decodeURIComponent(match[2]);
+    state.calls.push({ tool, action: "download", tag, name, url });
+    const owner = release(tag);
+    const entry = owner.assets.find((asset) => asset.name === name);
+    if (owner.draft || !entry || fault("download", tag, name)) fail("HTTP 404: public asset unavailable");
+    let bytes = Buffer.from(entry.bytes, "base64");
+    if ((state.corruptDownload?.tag === tag && state.corruptDownload.name === name) ||
+        (legacy && fault("legacy-readback", tag, name))) {
+      delete state.corruptDownload;
+      bytes = Buffer.alloc(bytes.length, 120);
+    }
+    assert(bytes.length <= Number(flag("--max-filesize")), "Fixture download exceeds limit");
+    fs.writeFileSync(flag("--output"), bytes);
+    if (state.replaceReleaseAfterDownload?.tag === tag &&
+        state.replaceReleaseAfterDownload.name === name) {
+      delete state.replaceReleaseAfterDownload;
+      owner.id = state.nextId++;
+      owner.assets = [];
+      state.calls.push({ tool: "fixture", action: "replace-release", tag });
+    }
+    answer();
+  } else if (tool === "minisign") {
+    state.calls.push({ tool, action: "verify" });
+    for (const option of ["-Vm", "-x", "-p"]) {
+      assert(args.includes(option) && fs.readFileSync(flag(option)).length > 0);
+    }
+    if (state.verifierExit) fail("fixture signature verification refused", state.verifierExit);
+    answer();
+  } else {
+    fail("Unsupported fixture command");
+  }
+} catch (error) {
+  fail("Fixture contract failure: " + error.message);
+}
+`;
+
+function fixture() {
+  const root = createTempDir("linux-channel-");
+  const bin = join(root, "bin");
+  mkdirSync(bin);
+  for (const name of ["gh", "curl", "minisign"]) {
+    const file = join(bin, name);
+    writeFileSync(file, `#!${process.execPath}\n${commandFixture}`);
+    chmodSync(file, 0o755);
+  }
+  const statePath = join(root, "state.json");
+  writeFileSync(
+    statePath,
+    JSON.stringify({
+      releases: [],
+      latest: tag,
+      nextId: 1,
+      calls: [],
+      verifierExit: 0,
+    } satisfies State),
+  );
+  const config = join(root, "tauri.conf.json");
+  writeFileSync(config, JSON.stringify({ plugins: { updater: { pubkey: publicKey } } }));
+  const signaturePath = join(root, "appimage.sig");
+  writeFileSync(signaturePath, signature);
+  const directories = new Map<string, string>();
+  const state = (): State => JSON.parse(readFileSync(statePath, "utf8"));
+  const update = (change: (value: State) => void) => {
+    const value = state();
+    change(value);
+    writeFileSync(statePath, JSON.stringify(value));
+  };
+  const addRelease = (releaseTag: string, latest = false) =>
+    update((value) => {
+      value.releases.push({
+        id: value.nextId++,
+        tag_name: releaseTag,
+        source: sourceSha(releaseTag),
+        draft: false,
+        prerelease: false,
+        body: "Fixture release notes",
+        published_at: "2026-09-03T12:00:00Z",
+        assets: [],
+      });
+      if (latest) {
+        value.latest = releaseTag;
+      }
+    });
+  addRelease(tag);
+  const addDraft = (releaseTag = nextTag, prerelease = false) => {
+    addRelease(releaseTag);
+    update((value) => {
+      Object.assign(releaseFrom(value, releaseTag), { draft: true, prerelease });
+    });
+    return releaseFrom(state(), releaseTag);
+  };
+  const inputs = (releaseTag: string) => {
+    const existing = directories.get(releaseTag);
+    if (existing) {
+      return existing;
+    }
+    const directory = join(root, releaseTag);
+    mkdirSync(directory);
+    const version = releaseTag.slice(1);
+    const names = [`OpenClaw-${version}-amd64.AppImage`, `OpenClaw-${version}-amd64.deb`];
+    const checksums = names.map((name) => {
+      const bytes = Buffer.from(`fixture bytes: ${name}\n`);
+      writeFileSync(join(directory, name), bytes);
+      return `${hash(bytes)}  ./${name}`;
+    });
+    writeFileSync(join(directory, "SHA256SUMS.linux-app.txt"), `${checksums.join("\n")}\n`);
+    directories.set(releaseTag, directory);
+    return directory;
+  };
+  const seedLegacy = (releaseTag = tag) => {
+    const directory = inputs(releaseTag);
+    const bytes = legacyManifest(releaseTag);
+    update((value) => {
+      for (const name of readdirSync(directory)) {
+        replaceAsset(value, releaseTag, name, readFileSync(join(directory, name)));
+      }
+      replaceAsset(value, releaseTag, "latest.json", bytes);
+    });
+    return bytes;
+  };
+  const run = (mode: "publish" | "mirror" | "finalize-core", releaseTag = tag, latest?: string) => {
+    const args = [cli, mode, "--tag", releaseTag, "--source-sha", sourceSha(releaseTag)];
+    if (mode === "finalize-core") {
+      if (latest !== undefined) {
+        args.push("--latest", latest);
+      }
+    } else {
+      args.push("--public-key-config", config);
+    }
+    if (mode === "publish") {
+      args.push(
+        "--assets",
+        inputs(releaseTag),
+        "--signature",
+        signaturePath,
+        "--tooling-sha",
+        "b".repeat(40),
+        "--desktop-test",
+        "false",
+      );
+    }
+    const result = spawnSync(process.execPath, args, {
+      cwd: root,
+      encoding: "utf8",
+      env: {
+        PATH: `${bin}:${dirname(process.execPath)}`,
+        HOME: root,
+        TMPDIR: root,
+        CHANNEL_FIXTURE_STATE: statePath,
+      },
+      timeout: 30_000,
+      killSignal: "SIGKILL",
+      maxBuffer: 2 * 1024 * 1024,
+    });
+    expect(result.error).toBeUndefined();
+    return result;
+  };
+  const bytes = (releaseTag: string, name: string) => {
+    const entry = releaseFrom(state(), releaseTag).assets.find((asset) => asset.name === name);
+    assert.ok(entry, `Missing fixture asset ${releaseTag}/${name}`);
+    return Buffer.from(entry.bytes, "base64");
+  };
+  const mutations = () =>
+    state().calls.filter(
+      (call) =>
+        call.tool === "gh" && ["upload", "DELETE", "PATCH", "create", "edit"].includes(call.action),
+    );
+  return { state, update, addRelease, addDraft, inputs, seedLegacy, run, bytes, mutations };
+}
+
+function succeeded(result: ReturnType<ReturnType<typeof fixture>["run"]>) {
+  expect(result.status, result.stderr).toBe(0);
+  const output: unknown = JSON.parse(result.stdout);
+  return output;
+}
+
+function failed(result: ReturnType<ReturnType<typeof fixture>["run"]>, message: string) {
+  expect(result.status).toBe(1);
+  expect(result.stderr).toContain(message);
+  expect(result.stdout.trim()).toBe("");
+}
+
+it("publishes immutable named assets and an exact canonical and legacy manifest", () => {
+  const f = fixture();
+  expect(succeeded(f.run("publish"))).toMatchObject({ state: "published", version: "2026.9.3" });
+  const manifest = f.bytes(tag, "OpenClaw-2026.9.3-linux.json");
+  expect(f.bytes(channel, "latest.json")).toEqual(manifest);
+  expect(f.bytes(tag, "latest.json")).toEqual(manifest);
+  expect(
+    releaseFrom(f.state(), tag)
+      .assets.map((asset) => asset.name)
+      .toSorted(),
+  ).toEqual(
+    [
+      "OpenClaw-2026.9.3-amd64.AppImage",
+      "OpenClaw-2026.9.3-amd64.deb",
+      "OpenClaw-2026.9.3-linux.json",
+      "SHA256SUMS.linux-app.txt",
+      "latest.json",
+    ].toSorted(),
+  );
+  expect(releaseFrom(f.state(), channel)).toMatchObject({ draft: false, prerelease: true });
+  expect(f.state().latest).toBe(tag);
+});
+
+it("initializes from the original legacy schema without changing its publication fields", () => {
+  const f = fixture();
+  const original = f.seedLegacy();
+  f.update((state) => {
+    Object.assign(releaseFrom(state, tag), {
+      published_at: "2026-09-04T12:00:00Z",
+      body: "Later core release notes",
+    });
+  });
+  succeeded(f.run("publish"));
+  const manifest = f.bytes(channel, "latest.json");
+  expect(JSON.parse(manifest.toString())).toMatchObject(JSON.parse(original.toString()));
+  expect(manifest).not.toEqual(original);
+  expect(f.bytes(tag, "latest.json")).toEqual(manifest);
+  expect(f.bytes(tag, "OpenClaw-2026.9.3-linux.json")).toEqual(manifest);
+});
+
+it("mirrors a new core latest without a new Linux build or bundle download", () => {
+  const f = fixture();
+  succeeded(f.run("publish"));
+  const canonical = f.bytes(channel, "latest.json");
+  const originalAssets = releaseFrom(f.state(), tag).assets;
+  f.addRelease(nextTag, true);
+  f.update((state) => {
+    state.calls = [];
+  });
+  expect(succeeded(f.run("mirror", nextTag))).toMatchObject({
+    state: "mirrored",
+    tag: nextTag,
+    version: "2026.9.3",
+    manifestSha256: hash(canonical),
+  });
+  expect(f.bytes(nextTag, "latest.json")).toEqual(canonical);
+  expect(f.bytes(channel, "latest.json")).toEqual(canonical);
+  expect(releaseFrom(f.state(), tag).assets).toEqual(originalAssets);
+  expect(f.mutations()).toEqual([
+    { tool: "gh", action: "upload", tag: nextTag, name: "latest.json" },
+  ]);
+  expect(f.state().calls.some((call) => call.tool === "minisign")).toBe(false);
+  expect(
+    f
+      .state()
+      .calls.filter((call) => call.tool === "curl")
+      .every((call) => call.name?.endsWith(".json")),
+  ).toBe(true);
+});
+
+it.each(["Linux first", "core first"])("converges when publishing %s", (order) => {
+  const f = fixture();
+  succeeded(f.run("publish"));
+  f.addRelease(nextTag);
+  if (order === "Linux first") {
+    succeeded(f.run("publish", nextTag));
+    f.update((state) => {
+      state.latest = nextTag;
+    });
+    succeeded(f.run("mirror", nextTag));
+  } else {
+    f.update((state) => {
+      state.latest = nextTag;
+    });
+    succeeded(f.run("mirror", nextTag));
+    expect(JSON.parse(f.bytes(nextTag, "latest.json").toString())).toMatchObject({
+      version: "2026.9.3",
+    });
+    succeeded(f.run("publish", nextTag));
+  }
+  const manifest = f.bytes(nextTag, "OpenClaw-2026.9.4-linux.json");
+  expect(f.bytes(channel, "latest.json")).toEqual(manifest);
+  expect(f.bytes(nextTag, "latest.json")).toEqual(manifest);
+});
+
+it("reuses exact publication bytes and asset identities on replay", () => {
+  const f = fixture();
+  succeeded(f.run("publish"));
+  const manifest = f.bytes(channel, "latest.json");
+  const assets = releaseFrom(f.state(), tag).assets;
+  f.update((state) => {
+    Object.assign(releaseFrom(state, tag), {
+      published_at: "2026-09-04T12:00:00Z",
+      body: "Later release notes",
+    });
+    state.calls = [];
+  });
+  succeeded(f.run("publish"));
+  expect(f.bytes(channel, "latest.json")).toEqual(manifest);
+  expect(releaseFrom(f.state(), tag).assets).toEqual(assets);
+  expect(f.mutations().filter((call) => call.action !== "edit")).toEqual([]);
+});
+
+it("rejects an immutable bundle conflict before uploading missing assets", () => {
+  const f = fixture();
+  f.update((state) => {
+    replaceAsset(state, tag, "OpenClaw-2026.9.3-amd64.deb", Buffer.from("different bundle"));
+  });
+  failed(f.run("publish"), "Immutable asset conflict");
+  expect(f.mutations()).toEqual([]);
+});
+
+it("rejects same-version canonical bytes that differ from the immutable publication", () => {
+  const f = fixture();
+  succeeded(f.run("publish"));
+  const changed = Buffer.concat([f.bytes(channel, "latest.json"), Buffer.from("\n")]);
+  f.update((state) => {
+    replaceAsset(state, channel, "latest.json", changed);
+    state.calls = [];
+  });
+  failed(f.run("publish"), "Canonical bytes differ from the immutable Linux publication");
+  expect(f.mutations()).toEqual([]);
+});
+
+it("keeps a newer canonical version when replaying an older Linux publication", () => {
+  const f = fixture();
+  succeeded(f.run("publish"));
+  f.addRelease(nextTag, true);
+  succeeded(f.run("publish", nextTag));
+  const newer = f.bytes(channel, "latest.json");
+  expect(succeeded(f.run("publish"))).toMatchObject({ state: "kept-newer-channel" });
+  expect(f.bytes(channel, "latest.json")).toEqual(newer);
+  expect(f.bytes(nextTag, "latest.json")).toEqual(newer);
+});
+
+it("requires the external signature verifier before any publication mutation", () => {
+  const f = fixture();
+  f.update((state) => {
+    state.verifierExit = 1;
+  });
+  failed(f.run("publish"), "fixture signature verification refused");
+  expect(f.state().calls.filter((call) => call.tool === "minisign")).toHaveLength(1);
+  expect(f.mutations()).toEqual([]);
+});
+
+it("rejects an authenticated asset inventory whose bundle is not publicly downloadable", () => {
+  const f = fixture();
+  const name = "OpenClaw-2026.9.3-amd64.AppImage";
+  const bytes = readFileSync(join(f.inputs(tag), name));
+  f.update((state) => {
+    replaceAsset(state, tag, name, bytes);
+    state.fault = { point: "download", tag, name };
+  });
+  failed(f.run("publish"), "HTTP 404: public asset unavailable");
+  expect(f.mutations()).toEqual([]);
+});
+
+it("rejects corrupted public bundle readback before publishing channel metadata", () => {
+  const f = fixture();
+  f.update((state) => {
+    state.fault = { point: "upload-readback", tag, name: "OpenClaw-2026.9.3-amd64.AppImage" };
+  });
+  failed(f.run("publish"), "Public asset digest mismatch");
+  expect(f.state().releases.some((release) => release.tag_name === channel)).toBe(false);
+});
+
+it("does not adopt a replacement release ID between immutable bundle uploads", () => {
+  const f = fixture();
+  const originalId = releaseFrom(f.state(), tag).id;
+  const name = "OpenClaw-2026.9.3-amd64.AppImage";
+  f.update((state) => {
+    state.replaceReleaseAfterDownload = { tag, name };
+  });
+  failed(f.run("publish"), "Release identity changed before write");
+  expect(f.state().calls).toContainEqual({ tool: "fixture", action: "replace-release", tag });
+  expect(releaseFrom(f.state(), tag).id).not.toBe(originalId);
+  expect(releaseFrom(f.state(), tag).assets).toEqual([]);
+  expect(f.mutations()).toEqual([{ tool: "gh", action: "upload", tag, name }]);
+});
+
+it("refuses retry after versioned-only ACK loss leaves the canonical manifest missing", () => {
+  const f = fixture();
+  const name = "OpenClaw-2026.9.3-linux.json";
+  f.update((state) => {
+    state.fault = { point: "upload-after", tag, name };
+  });
+  failed(f.run("publish"), "fixture lost upload acknowledgement");
+  const retained = releaseFrom(f.state(), tag).assets.find((asset) => asset.name === name);
+  assert.ok(retained);
+  const writes = f.mutations();
+  expect(releaseFrom(f.state(), channel).assets).toEqual([]);
+  failed(f.run("publish"), "Missing channel metadata is not a new channel");
+  expect(releaseFrom(f.state(), tag).assets.find((asset) => asset.name === name)).toEqual(retained);
+  expect(releaseFrom(f.state(), channel).assets).toEqual([]);
+  expect(f.mutations()).toEqual(writes);
+});
+
+it("reconciles a committed canonical upload with a lost acknowledgement", () => {
+  const f = fixture();
+  const owner = channel;
+  const name = "latest.json";
+  f.update((state) => {
+    state.fault = { point: "upload-after", tag: owner, name };
+  });
+  failed(f.run("publish"), "fixture lost upload acknowledgement");
+  const retained = releaseFrom(f.state(), owner).assets.find((asset) => asset.name === name);
+  assert.ok(retained);
+  succeeded(f.run("publish"));
+  expect(releaseFrom(f.state(), owner).assets.find((asset) => asset.name === name)).toEqual(
+    retained,
+  );
+  expect(f.bytes(tag, "latest.json")).toEqual(f.bytes(channel, "latest.json"));
+  expect(
+    f
+      .state()
+      .calls.filter((call) => call.action === "upload" && call.tag === owner && call.name === name),
+  ).toHaveLength(1);
+});
+
+it("reports an interrupted legacy replacement and reconciles it without rebuilding", () => {
+  const f = fixture();
+  succeeded(f.run("publish"));
+  const canonical = f.bytes(channel, "latest.json");
+  f.addRelease(nextTag, true);
+  f.update((state) => {
+    const original = legacyManifest();
+    replaceAsset(state, tag, "latest.json", original);
+    replaceAsset(state, nextTag, "latest.json", original);
+    state.fault = { point: "upload-before", tag: nextTag, name: "latest.json" };
+    state.calls = [];
+  });
+  failed(f.run("mirror", nextTag), "fixture upload refused");
+  expect(releaseFrom(f.state(), nextTag).assets).toEqual([]);
+  expect(f.bytes(channel, "latest.json")).toEqual(canonical);
+  expect(succeeded(f.run("mirror", nextTag))).toMatchObject({ state: "mirrored" });
+  expect(f.bytes(nextTag, "latest.json")).toEqual(canonical);
+  expect(f.state().calls.some((call) => call.tool === "minisign")).toBe(false);
+});
+
+it("keeps normal publish and mirror fail-closed after canonical deletion interrupts promotion", () => {
+  const f = fixture();
+  succeeded(f.run("publish"));
+  const previous = f.bytes(channel, "latest.json");
+  f.addRelease(nextTag, true);
+  f.update((state) => {
+    state.fault = { point: "upload-before", tag: channel, name: "latest.json" };
+    state.calls = [];
+  });
+  failed(f.run("publish", nextTag), "fixture upload refused");
+  const retained = f.bytes(nextTag, "OpenClaw-2026.9.4-linux.json");
+  expect(f.mutations()).toContainEqual({
+    tool: "gh",
+    action: "DELETE",
+    tag: channel,
+    name: "latest.json",
+    url: expect.stringMatching(/^releases\/assets\/\d+$/),
+  });
+  expect(releaseFrom(f.state(), channel).assets).toEqual([]);
+  expect(f.bytes(tag, "latest.json")).toEqual(previous);
+  f.update((state) => {
+    state.calls = [];
+  });
+  for (const [mode, message] of [
+    ["publish", "Missing channel metadata is not a new channel"],
+    ["mirror", "Linux channel manifest is missing"],
+  ] as const) {
+    failed(f.run(mode, nextTag), message);
+    expect(f.mutations()).toEqual([]);
+    expect(releaseFrom(f.state(), channel).assets).toEqual([]);
+    expect(f.bytes(nextTag, "OpenClaw-2026.9.4-linux.json")).toEqual(retained);
+  }
+});
+
+it.each([
+  { kind: "arbitrary JSON", message: "Unrecognized legacy Linux manifest" },
+  {
+    kind: "newer legacy version",
+    message: "Legacy endpoint already carries a newer Linux manifest",
+  },
+  {
+    kind: "same-version legacy conflict",
+    message: "Same-version legacy bootstrap changed original manifest fields",
+  },
+  {
+    kind: "same-version canonical conflict",
+    message: "Canonical bytes differ from the immutable Linux publication",
+  },
+])("does not replace existing latest metadata containing $kind", ({ kind, message }) => {
+  const f = fixture();
+  succeeded(f.run("publish"));
+  const canonical = f.bytes(channel, "latest.json");
+  f.addRelease(nextTag, true);
+  let previous = Buffer.from(JSON.stringify({ version: "2026.9.3", unrelated: true }));
+  if (kind === "newer legacy version") {
+    previous = f.seedLegacy(nextTag);
+  } else if (kind === "same-version legacy conflict") {
+    previous = legacyManifest(tag, "Conflicting Linux publication notes");
+    f.update((state) => {
+      replaceAsset(state, tag, "latest.json", previous);
+    });
+  } else if (kind === "same-version canonical conflict") {
+    previous = Buffer.concat([canonical, Buffer.from("\n")]);
+  }
+  f.update((state) => {
+    replaceAsset(state, nextTag, "latest.json", previous);
+    state.calls = [];
+  });
+  failed(f.run("mirror", nextTag), message);
+  expect(f.mutations()).toEqual([]);
+  expect(f.bytes(nextTag, "latest.json")).toEqual(previous);
+  expect(f.bytes(channel, "latest.json")).toEqual(canonical);
+});
+
+it("does not report mirror success when the public latest endpoint readback differs", () => {
+  const f = fixture();
+  succeeded(f.run("publish"));
+  f.addRelease(nextTag, true);
+  f.update((state) => {
+    state.fault = { point: "legacy-readback", tag: nextTag, name: "latest.json" };
+  });
+  failed(f.run("mirror", nextTag), "Legacy endpoint readback failed");
+  expect(succeeded(f.run("mirror", nextTag))).toMatchObject({ state: "mirrored" });
+});
+
+it("stops a replacement if the latest selector changes after deletion", () => {
+  const f = fixture();
+  succeeded(f.run("publish"));
+  f.addRelease(nextTag, true);
+  f.update((state) => {
+    const original = legacyManifest();
+    replaceAsset(state, tag, "latest.json", original);
+    replaceAsset(state, nextTag, "latest.json", original);
+    state.latestAfterDelete = tag;
+    state.calls = [];
+  });
+  failed(f.run("mirror", nextTag), "Core latest changed before mirror");
+  expect(f.state().calls.filter((call) => call.action === "upload")).toEqual([]);
+  expect(f.state().latest).toBe(tag);
+});
+
+it("rejects a latest-selector change after upload instead of claiming a fresh mirror", () => {
+  const f = fixture();
+  succeeded(f.run("publish"));
+  f.addRelease(nextTag, true);
+  f.update((state) => {
+    state.latestAfterUpload = tag;
+  });
+  failed(f.run("mirror", nextTag), "Core latest changed after mirror");
+  expect(f.state().latest).toBe(tag);
+});
+
+it("does not mutate a selected core release that is no longer latest", () => {
+  const f = fixture();
+  succeeded(f.run("publish"));
+  f.addRelease(nextTag, true);
+  f.update((state) => {
+    state.calls = [];
+  });
+  expect(succeeded(f.run("mirror"))).toEqual({ state: "skipped-not-latest", tag });
+  expect(f.mutations()).toEqual([]);
+});
+
+it("refuses mirroring before canonical initialization without creating a release", () => {
+  const f = fixture();
+  failed(f.run("mirror"), "HTTP 404: release not found");
+  expect(f.mutations()).toEqual([]);
+});
+
+it.each(["v2026.9.3-alpha.1", "v2026.9.3-beta.1", "v2026.6.33"])(
+  "rejects non-regular target %s before touching GitHub",
+  (releaseTag) => {
+    const f = fixture();
+    failed(f.run("mirror", releaseTag), "Not a canonical regular Linux release");
+    expect(f.state().calls).toEqual([]);
+  },
+);
+
+it.each(["asset replaced", "source changed", "draft release"])(
+  "rejects publisher identity drift: %s",
+  (change) => {
+    const f = fixture();
+    succeeded(f.run("publish"));
+    const appimage = f.bytes(tag, "OpenClaw-2026.9.3-amd64.AppImage");
+    f.update((state) => {
+      if (change === "asset replaced") {
+        replaceAsset(state, tag, "OpenClaw-2026.9.3-amd64.AppImage", appimage);
+      } else if (change === "source changed") {
+        releaseFrom(state, tag).source = "c".repeat(40);
+      } else {
+        releaseFrom(state, tag).draft = true;
+      }
+      state.calls = [];
+    });
+    const message =
+      change === "asset replaced"
+        ? "Published Linux asset changed"
+        : change === "source changed"
+          ? "Selected core tag moved"
+          : "HTTP 404: release by tag is not published";
+    failed(f.run("mirror"), message);
+    expect(f.mutations()).toEqual([]);
+  },
+);
+
+it.each([null, tag])(
+  "finalizes a draft by ID with prior latest %s and no Linux channel",
+  (latest) => {
+    const f = fixture();
+    const draft = f.addDraft();
+    f.update((state) => {
+      state.latest = latest;
+    });
+    expect(succeeded(f.run("finalize-core", nextTag, "true"))).toEqual({
+      state: "finalized",
+      tag: nextTag,
+      releaseId: draft.id,
+      sourceSha: draft.source,
+      madeLatest: true,
+      latestReleaseId: draft.id,
+      latestTag: nextTag,
+    });
+    expect(f.mutations()).toEqual([
+      {
+        tool: "gh",
+        action: "PATCH",
+        url: `releases/${draft.id}`,
+        tag: nextTag,
+        releaseId: draft.id,
+        makeLatest: true,
+      },
+    ]);
+    expect(releaseFrom(f.state(), nextTag)).toMatchObject({ draft: false, prerelease: false });
+    expect(f.state().calls.every((call) => call.tool === "gh")).toBe(true);
+    expect(f.state().releases.some((entry) => entry.tag_name === channel)).toBe(false);
+  },
+);
+
+it.each([
+  { releaseTag: nextTag, prerelease: false },
+  { releaseTag: "v2026.9.4-alpha.1", prerelease: true },
+  { releaseTag: "v2026.9.4-beta.1", prerelease: true },
+])("honors explicit non-latest finalization of $releaseTag", ({ releaseTag, prerelease }) => {
+  const f = fixture();
+  const previous = releaseFrom(f.state(), tag);
+  const draft = f.addDraft(releaseTag, prerelease);
+  expect(succeeded(f.run("finalize-core", releaseTag, "false"))).toEqual({
+    state: "finalized",
+    tag: releaseTag,
+    releaseId: draft.id,
+    sourceSha: draft.source,
+    madeLatest: false,
+    latestReleaseId: previous.id,
+    latestTag: tag,
+  });
+  expect(releaseFrom(f.state(), releaseTag)).toMatchObject({ draft: false, prerelease });
+  expect(f.state().latest).toBe(tag);
+  expect(f.mutations()).toEqual([
+    {
+      tool: "gh",
+      action: "PATCH",
+      url: `releases/${draft.id}`,
+      tag: releaseTag,
+      releaseId: draft.id,
+      makeLatest: false,
+    },
+  ]);
+});
+
+it("finalizes an older release without taking latest back from a newer publication", () => {
+  const f = fixture();
+  f.addRelease(nextTag, true);
+  const previous = releaseFrom(f.state(), nextTag);
+  expect(succeeded(f.run("finalize-core", tag, "true"))).toMatchObject({
+    state: "finalized",
+    tag,
+    madeLatest: false,
+    latestReleaseId: previous.id,
+    latestTag: nextTag,
+  });
+  expect(f.mutations()).toHaveLength(1);
+  expect(f.mutations()[0]).toMatchObject({ action: "PATCH", tag, makeLatest: false });
+  expect(f.state().latest).toBe(nextTag);
+});
+
+it("can resume the current public latest by its retained release ID", () => {
+  const f = fixture();
+  const original = releaseFrom(f.state(), tag);
+  expect(succeeded(f.run("finalize-core", tag, "true"))).toEqual({
+    state: "finalized",
+    tag,
+    releaseId: original.id,
+    sourceSha: original.source,
+    madeLatest: true,
+    latestReleaseId: original.id,
+    latestTag: tag,
+  });
+  expect(releaseFrom(f.state(), tag)).toEqual(original);
+});
+
+it("refuses non-latest finalization that would demote the current latest", () => {
+  const f = fixture();
+  failed(f.run("finalize-core", tag, "false"), "Non-latest finalization must not demote");
+  expect(f.mutations()).toEqual([]);
+  expect(f.state().latest).toBe(tag);
+});
+
+it.each([
+  {
+    releaseTag: "v2026.6.33",
+    latest: "false",
+    message: "Unsupported core GitHub release train",
+  },
+  {
+    releaseTag: "v2026.9.04",
+    latest: "true",
+    message: "Unsupported core GitHub release train",
+  },
+  {
+    releaseTag: nextTag,
+    latest: undefined,
+    message: "Expected explicit core latest intent",
+  },
+  {
+    releaseTag: nextTag,
+    latest: "legacy",
+    message: "Expected explicit core latest intent",
+  },
+  {
+    releaseTag: "v2026.9.4-beta.1",
+    latest: "true",
+    message: "Prereleases cannot become core latest",
+  },
+])("rejects finalization admission $releaseTag/$latest", ({ releaseTag, latest, message }) => {
+  const f = fixture();
+  failed(f.run("finalize-core", releaseTag, latest), message);
+  expect(f.state().calls).toEqual([]);
+});
+
+it.each([
+  { kind: "source", message: "Selected core tag moved" },
+  { kind: "tag", message: "Selected core release identity is invalid" },
+  { kind: "prerelease", message: "Selected core prerelease classification changed" },
+])("rejects an unapproved draft $kind before finalization", ({ kind, message }) => {
+  const f = fixture();
+  f.addDraft();
+  f.update((state) => {
+    if (kind === "source") {
+      releaseFrom(state, nextTag).source = "c".repeat(40);
+    } else if (kind === "prerelease") {
+      releaseFrom(state, nextTag).prerelease = true;
+    } else {
+      state.releaseResponseTag = { tag: nextTag, value: "v2026.9.5" };
+    }
+  });
+  failed(f.run("finalize-core", nextTag, "true"), message);
+  expect(f.mutations()).toEqual([]);
+  expect(releaseFrom(f.state(), nextTag).draft).toBe(true);
+});
+
+it.each([
+  {
+    kind: "selected release replaced",
+    trigger: nextTag,
+    change: { kind: "replace-release", tag: nextTag },
+    message: "HTTP 404: release not found",
+  },
+  {
+    kind: "selected source moved",
+    trigger: nextTag,
+    change: { kind: "move-tag", tag: nextTag },
+    message: "Selected core tag moved",
+  },
+  {
+    kind: "latest selector moved",
+    trigger: tag,
+    change: { kind: "select-latest", tag: "v2026.9.5" },
+    message: "Core latest changed before finalization",
+  },
+  {
+    kind: "latest source moved",
+    trigger: tag,
+    change: { kind: "move-tag", tag },
+    message: "Core latest tag moved",
+  },
+] satisfies { kind: string; trigger: string; change: Transition; message: string }[])(
+  "does not finalize after $kind between admission and mutation",
+  ({ trigger, change, message }) => {
+    const f = fixture();
+    f.addDraft();
+    f.addRelease("v2026.9.5");
+    f.update((state) => {
+      state.afterSourceRead = { tag: trigger, change };
+    });
+    failed(f.run("finalize-core", nextTag, "true"), message);
+    expect(f.state().afterSourceRead).toBeUndefined();
+    expect(f.state().calls).toContainEqual({
+      tool: "fixture",
+      action: change.kind,
+      tag: change.tag,
+    });
+    expect(f.mutations()).toEqual([]);
+  },
+);
+
+it.each([
+  {
+    change: { kind: "replace-release", tag: nextTag },
+    message: "Finalized core release identity mismatch",
+  },
+  {
+    change: { kind: "move-tag", tag: nextTag },
+    message: "Finalized core tag moved",
+  },
+  {
+    change: { kind: "select-latest", tag },
+    message: "Core latest readback mismatch",
+  },
+] satisfies { change: Transition; message: string }[])(
+  "does not report finalization success after readback drift: $change.kind",
+  ({ change, message }) => {
+    const f = fixture();
+    const draft = f.addDraft();
+    f.update((state) => {
+      state.afterPatch = change;
+    });
+    failed(f.run("finalize-core", nextTag, "true"), message);
+    expect(f.state().afterPatch).toBeUndefined();
+    expect(f.mutations()).toEqual([
+      {
+        tool: "gh",
+        action: "PATCH",
+        url: `releases/${draft.id}`,
+        tag: nextTag,
+        releaseId: draft.id,
+        makeLatest: true,
+      },
+    ]);
+  },
+);

--- a/test/scripts/release-no-push-workflow.test.ts
+++ b/test/scripts/release-no-push-workflow.test.ts
@@ -1959,6 +1959,7 @@ describe("release validation no-push transport", () => {
       ).run,
     ).toContain("Full release validation target SHA mismatch");
     expect(job(releasePublish, "finalize_github_release").needs).toEqual([
+      "resolve_release_target",
       "publish",
       "publish_docker",
     ]);
@@ -2031,6 +2032,75 @@ describe("release validation no-push transport", () => {
       expect(evaluate("publish_docker"), JSON.stringify(scenario)).toBe(scenario.publishDocker);
       expect(evaluate("finalize_github_release"), JSON.stringify(scenario)).toBe(scenario.finalize);
     }
+  });
+
+  it("detaches the Linux compatibility mirror without holding core finalization on its queue", () => {
+    const workflow = readWorkflow(".github/workflows/openclaw-release-publish.yml");
+    const dispatch = job(workflow, "dispatch_linux_mirror");
+    expect(dispatch.needs).toEqual(["resolve_release_target", "finalize_github_release"]);
+    expect(dispatch).toMatchObject({
+      "continue-on-error": true,
+      "timeout-minutes": 5,
+      permissions: { actions: "write", contents: "read" },
+    });
+    expect(dispatch).not.toHaveProperty("concurrency");
+    expect(JSON.stringify(workflow)).not.toContain("linux-app-release-publish");
+    const finalizer = job(workflow, "finalize_github_release");
+    expect(finalizer.needs).toEqual(["resolve_release_target", "publish", "publish_docker"]);
+    expect(finalizer).not.toHaveProperty("concurrency");
+    expect(step(finalizer, "Checkout trusted core finalization tooling").with).toMatchObject({
+      ref: "${{ github.workflow_sha }}",
+      "persist-credentials": false,
+      "sparse-checkout": "scripts/linux-app-channel.mjs\nscripts/lib/release-version.mjs\n",
+    });
+    const finalize = step(finalizer, "Publish the verified draft release");
+    expect(finalize.env).toMatchObject({
+      TARGET_SHA: "${{ needs.resolve_release_target.outputs.sha }}",
+      RELEASE_NPM_DIST_TAG: "${{ inputs.npm_dist_tag }}",
+    });
+    expect(finalize.run).toContain("node scripts/linux-app-channel.mjs finalize-core");
+    expect(finalize.run).toContain('--source-sha "$TARGET_SHA" --latest "$make_latest"');
+    expect(finalize.run).not.toContain("gh release edit");
+    for (const [tag, distTag, finalized, cancelled, expected] of [
+      ["v2026.9.3", "latest", "success", false, true],
+      ["v2026.9.3-1", "latest", "success", false, true],
+      ["v2026.9.3-beta.1", "beta", "success", false, false],
+      ["v2026.9.3-alpha.1", "alpha", "success", false, false],
+      ["v2026.9.33", "extended-stable", "success", false, false],
+      ["v2026.9.3", "latest", "failure", false, false],
+      ["v2026.9.3", "latest", "success", true, false],
+    ] as const) {
+      expect(
+        runInNewContext(dispatch.if!.slice(3, -2), {
+          cancelled: () => cancelled,
+          contains: (value: string, search: string) => value.includes(search),
+          inputs: { tag, npm_dist_tag: distTag },
+          needs: { finalize_github_release: { result: finalized } },
+        }),
+        tag,
+      ).toBe(expected);
+    }
+    expect(step(dispatch, "Checkout trusted Linux dispatch tooling").with).toMatchObject({
+      ref: "${{ github.workflow_sha }}",
+      "persist-credentials": false,
+    });
+    const command = step(dispatch, "Dispatch detached Linux mirror");
+    expect(command).toMatchObject({ "timeout-minutes": 3 });
+    expect(command.run).toContain('resolve_child_workflow_ref "${GITHUB_REF}"');
+    expect(command.run).toContain(
+      'dispatch_workflow_at_ref "$CHILD_WORKFLOW_REF" "$PARENT_WORKFLOW_SHA"',
+    );
+    expect(command.run).toContain("linux-app-release.yml");
+    expect(command.run).toContain('-f source_sha="$TARGET_SHA"');
+    expect(command.run).toContain('-f release_publish_run_attempt="$GITHUB_RUN_ATTEMPT"');
+    expect(command.run).toContain('state: "dispatched"');
+    expect(command.run).toContain("mirrorVerified: false");
+    expect(command.run).not.toMatch(/gh run watch|wait_for|linux-app-channel\.mjs/u);
+    const notes = step(job(workflow, "publish"), "Prepare GitHub release notes");
+    expect(notes.run).toContain('git show "${TARGET_SHA}:CHANGELOG.md"');
+    expect(notes.run).toContain(
+      "node --import tsx .release-harness/scripts/render-github-release-notes.mts",
+    );
   });
 
   it("fails a missing required local live image before any registry pull", () => {

--- a/test/scripts/release-publish-draft.test.ts
+++ b/test/scripts/release-publish-draft.test.ts
@@ -1,10 +1,254 @@
 import { spawnSync } from "node:child_process";
-import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { join, resolve } from "node:path";
 import { expect, it } from "vitest";
 import { createScriptTestHarness } from "./test-helpers.js";
 
 const { createTempDir } = createScriptTestHarness();
+
+function releaseNotesFixture() {
+  const root = createTempDir("release-publish-notes-");
+  const tooling = join(root, ".release-harness");
+  const sourceSha = "a".repeat(40);
+  const releaseTag = "v2026.9.2";
+  const previousBody = "## 2026.9.2\n\n- Candidate changelog notes.";
+  const proof = `### Release verification\n\n- release SHA: \`${sourceSha}\``;
+  mkdirSync(join(root, "scripts/lib"), { recursive: true });
+  mkdirSync(join(tooling, "scripts/lib"), { recursive: true });
+  for (const file of [
+    "scripts/render-github-release-notes.mts",
+    "scripts/lib/release-notes-compaction.mjs",
+    "scripts/lib/release-version.mjs",
+  ]) {
+    copyFileSync(resolve(file), join(tooling, file));
+    writeFileSync(join(root, file), 'throw new Error("selected tag tooling executed");\n');
+  }
+  symlinkSync(resolve("node_modules"), join(root, "node_modules"), "dir");
+  writeFileSync(join(root, "CHANGELOG.md"), "Wrong working-copy changelog.\n");
+  writeFileSync(join(tooling, "CHANGELOG.md"), "Wrong tooling changelog.\n");
+  const changelog = join(root, "target-changelog.md");
+  writeFileSync(changelog, `# Changelog\n\n${previousBody}\n`);
+  const notes = join(root, "notes.md");
+  const metadata = join(root, "metadata.json");
+  const proofFile = join(root, "proof.md");
+  writeFileSync(proofFile, proof);
+  const releaseState = join(root, "release.json");
+  const mutationLog = join(root, "mutations");
+  const run = (command: string) =>
+    spawnSync(
+      "bash",
+      [
+        "-c",
+        `
+source "$OWNER_SCRIPT"
+git() {
+  [[ "$#" == 2 && "$1" == show && "$2" == "$TARGET_SHA:CHANGELOG.md" ]] || return 1
+  cat "$TARGET_CHANGELOG"
+}
+gh() {
+  if [[ "$1 $2" == "release view" ]]; then
+    cat "$RELEASE_STATE"
+    return
+  fi
+  printf '%s\\n' "$@" >> "$MUTATION_LOG"
+}
+${command}
+`,
+      ],
+      {
+        cwd: root,
+        encoding: "utf8",
+        timeout: 15_000,
+        env: {
+          PATH: process.env.PATH,
+          HOME: root,
+          OWNER_SCRIPT: resolve("scripts/lib/release-publish-children.sh"),
+          GITHUB_WORKSPACE: root,
+          RUNNER_TEMP: root,
+          GITHUB_STEP_SUMMARY: join(root, "summary"),
+          GITHUB_REPOSITORY: "fixture/repository",
+          GITHUB_REF: "refs/tags/release-publish/aaaaaaaaaaaa-1",
+          PARENT_WORKFLOW_SHA: "b".repeat(40),
+          TARGET_SHA: sourceSha,
+          TARGET_CHANGELOG: changelog,
+          RELEASE_TAG: releaseTag,
+          RELEASE_NPM_DIST_TAG: "latest",
+          PUBLISH_OPENCLAW_NPM: "true",
+          NOTES_FILE: notes,
+          METADATA_FILE: metadata,
+          PROOF_FILE: proofFile,
+          RELEASE_STATE: releaseState,
+          MUTATION_LOG: mutationLog,
+        },
+      },
+    );
+  return {
+    root,
+    tooling,
+    changelog,
+    notes,
+    metadata,
+    previousBody,
+    proof,
+    mutationLog,
+    run,
+    publicBody(body: string, withEvidence = true) {
+      writeFileSync(notes, body);
+      writeFileSync(
+        releaseState,
+        JSON.stringify({
+          isDraft: false,
+          body,
+          assets: withEvidence
+            ? [{ name: `openclaw-${releaseTag.slice(1)}-dependency-evidence.zip` }]
+            : [],
+          url: `https://github.com/fixture/repository/releases/tag/${releaseTag}`,
+        }),
+      );
+    },
+  };
+}
+
+it("uses the trusted renderer closure and TARGET_SHA changelog for generation and verification", () => {
+  const fixture = releaseNotesFixture();
+  const result = fixture.run(`
+render_github_release_notes "$NOTES_FILE" "$PROOF_FILE" "$METADATA_FILE"
+canonical_release_body_matches "$NOTES_FILE"
+`);
+
+  expect(result.status, result.stderr).toBe(0);
+  const body = readFileSync(fixture.notes, "utf8");
+  expect(body).toContain(fixture.previousBody);
+  expect(body).toContain(
+    "[latest published Linux companion](https://github.com/fixture/repository/releases/tag/linux-stable)",
+  );
+  expect(body).toContain(fixture.proof);
+  expect(JSON.parse(readFileSync(fixture.metadata, "utf8"))).toMatchObject({
+    mode: "full",
+    verificationIncluded: true,
+  });
+  fixture.publicBody(body);
+  const resumed = fixture.run(`
+guard_existing_public_release
+verify_release_tag_target() { :; }
+prepared_release_notes_file="$NOTES_FILE"
+create_or_update_github_release
+`);
+  expect(resumed.status, resumed.stderr).toBe(0);
+  expect(resumed.stderr).not.toContain("previous canonical body");
+  expect(existsSync(fixture.mutationLog)).toBe(false);
+});
+
+it.each(["with-proof", "compact-with-proof", "at-body-limit"])(
+  "resumes a previous canonical public body %s without stripping evidence before proof append",
+  (kind) => {
+    const fixture = releaseNotesFixture();
+    let previousBody = `${fixture.previousBody}\n\n${fixture.proof}`;
+    if (kind !== "with-proof") {
+      const prefix = `${fixture.previousBody}\n\n### Complete contribution record\n\n`;
+      const section =
+        prefix + "x".repeat(kind === "at-body-limit" ? 125_000 - prefix.length : 130_000);
+      writeFileSync(fixture.changelog, section);
+      previousBody =
+        kind === "at-body-limit"
+          ? section
+          : `${prefix}The full contribution record is available in the tag-pinned [CHANGELOG.md](https://github.com/fixture/repository/blob/v2026.9.2/CHANGELOG.md#complete-contribution-record).\n\n${fixture.proof}`;
+    }
+    fixture.publicBody(previousBody);
+    const result = fixture.run(`
+if canonical_release_body_matches "$NOTES_FILE"; then
+  echo "Strict verification accepted the previous body" >&2
+  exit 99
+fi
+guard_existing_public_release
+verify_release_tag_target() { :; }
+prepared_release_notes_file="$NOTES_FILE"
+create_or_update_github_release
+render_github_release_notes "$NOTES_FILE" "$PROOF_FILE" "$METADATA_FILE"
+canonical_release_body_matches "$NOTES_FILE"
+`);
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stderr).toContain("Release body does not match canonical release notes.");
+    expect(result.stderr).toContain("previous canonical body; Linux link pending proof append");
+    expect(existsSync(fixture.mutationLog)).toBe(false);
+    const migrated = readFileSync(fixture.notes, "utf8");
+    expect(migrated).toContain("/releases/tag/linux-stable");
+    expect(migrated).toContain(fixture.proof);
+    if (kind !== "with-proof") {
+      expect(JSON.parse(readFileSync(fixture.metadata, "utf8"))).toMatchObject({
+        mode: "compact",
+        verificationIncluded: true,
+      });
+    }
+  },
+);
+
+it.each(["divergent", "wrong-linux-link", "wrong-proof-sha", "missing-evidence"])(
+  "rejects %s previous public notes before any mutation",
+  (kind) => {
+    const fixture = releaseNotesFixture();
+    const proof =
+      kind === "wrong-proof-sha"
+        ? fixture.proof.replaceAll("a".repeat(40), "c".repeat(40))
+        : fixture.proof;
+    let notes =
+      kind === "divergent"
+        ? fixture.previousBody.replace("Candidate changelog notes.", "Unrelated release notes.")
+        : fixture.previousBody;
+    if (kind === "wrong-linux-link") {
+      notes +=
+        "\n\n### Linux companion\n\nDownload the [latest published Linux companion](https://github.com/fixture/repository/releases/tag/unrelated).";
+    }
+    fixture.publicBody(`${notes}\n\n${proof}`, kind !== "missing-evidence");
+    const result = fixture.run(`
+canonical_status=0
+canonical_release_body_matches "$NOTES_FILE" true || canonical_status=$?
+printf 'canonical-status=%s\\n' "$canonical_status"
+guard_existing_public_release
+`);
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toContain(
+      `canonical-status=${kind === "divergent" || kind === "wrong-linux-link" ? 1 : 0}`,
+    );
+    expect(result.stderr).toContain("without complete postpublish evidence");
+    expect(result.stderr).not.toContain("selected tag tooling executed");
+    expect(result.stderr).not.toContain("does not provide an export");
+    if (kind === "wrong-proof-sha" || kind === "missing-evidence") {
+      expect(result.stderr).toContain("previous canonical body; Linux link pending proof append");
+      expect(result.stderr).not.toContain("Release body does not match canonical release notes.");
+    } else {
+      expect(result.stderr).toContain("Release body does not match canonical release notes.");
+    }
+    expect(existsSync(fixture.mutationLog)).toBe(false);
+  },
+);
+
+it("refuses public body drift after the resume guard instead of overwriting it", () => {
+  const fixture = releaseNotesFixture();
+  fixture.publicBody(`${fixture.previousBody}\n\n${fixture.proof}`);
+  const result = fixture.run(`
+guard_existing_public_release
+jq '.body |= sub("Candidate changelog notes."; "Unrelated release notes.")' "$RELEASE_STATE" > "$RUNNER_TEMP/changed-release.json"
+mv "$RUNNER_TEMP/changed-release.json" "$RELEASE_STATE"
+verify_release_tag_target() { :; }
+prepared_release_notes_file="$NOTES_FILE"
+create_or_update_github_release
+`);
+
+  expect(result.status).toBe(1);
+  expect(result.stderr).toContain("previous canonical body; Linux link pending proof append");
+  expect(result.stderr).toContain("Public release notes are no longer canonical");
+  expect(existsSync(fixture.mutationLog)).toBe(false);
+});
 
 it.each([
   { existing: "draft", distTag: "latest", command: "edit" },

--- a/test/scripts/render-github-release-notes.test.ts
+++ b/test/scripts/render-github-release-notes.test.ts
@@ -131,6 +131,70 @@ describe("GitHub release-note rendering", () => {
     );
   });
 
+  it.each([
+    { releaseTag: "v2026.7.1", linked: true },
+    { releaseTag: "v2026.7.1-2", linked: true },
+    { releaseTag: "v2026.7.1-alpha.1", linked: false },
+    { releaseTag: "v2026.7.1-beta.3", linked: false },
+    { releaseTag: "v2026.7.33", linked: false },
+    { releaseTag: "v2026.7.33-1", linked: false },
+  ])("scopes the Linux companion link for $releaseTag", ({ releaseTag, linked }) => {
+    const releaseVersion = releaseNotesVersionForTag(releaseTag);
+    const changelog = `## ${releaseVersion}\n\n- Core release notes.`;
+    const rendered = renderGithubReleaseNotes({
+      changelog,
+      version: releaseVersion,
+      tag: releaseTag,
+      repository,
+    });
+
+    expect(
+      rendered.body.includes(
+        "[latest published Linux companion](https://github.com/openclaw/openclaw/releases/tag/linux-stable)",
+      ),
+    ).toBe(linked);
+    expect(
+      verifyGithubReleaseNotes({
+        body: rendered.body,
+        changelog,
+        version: releaseVersion,
+        tag: releaseTag,
+        repository,
+      }).matches,
+    ).toBe(true);
+  });
+
+  it("counts the mandatory Linux link before choosing full or compact notes", () => {
+    const releaseTag = `v${version}`;
+    const seed = renderGithubReleaseNotes({
+      changelog: changelogFor("x"),
+      version,
+      tag: releaseTag,
+      repository,
+    });
+    const exactRecordLength = GITHUB_RELEASE_BODY_MAX_BYTES - seed.size.bytes + 1;
+    const render = (recordLength: number) =>
+      renderGithubReleaseNotes({
+        changelog: changelogFor("x".repeat(recordLength)),
+        version,
+        tag: releaseTag,
+        repository,
+        verification: "### Release verification\n\n- Proof.",
+      });
+    const exact = render(exactRecordLength);
+    const over = render(exactRecordLength + 1);
+
+    expect(exact.mode).toBe("full");
+    expect(exact.size.bytes).toBe(GITHUB_RELEASE_BODY_MAX_BYTES);
+    expect(exact.verificationOmitted).toBe(true);
+    expect(over.mode).toBe("compact");
+    expect(over.verificationIncluded).toBe(true);
+    for (const rendered of [exact, over]) {
+      expect(rendered.body.includes("/releases/tag/linux-stable")).toBe(true);
+      expect(rendered.size.bytes).toBeLessThanOrEqual(GITHUB_RELEASE_BODY_MAX_BYTES);
+    }
+  });
+
   it("replaces an oversized contribution record with a tag-pinned link", () => {
     const oversizedRecord = `- **PR #123** ${"record-only-detail ".repeat(9_000)}`;
     const rendered = renderGithubReleaseNotes({


### PR DESCRIPTION
## Replacement Stack

Superseded by these eight **draft** PRs, in dependency order. Each child targets
the preceding branch; the complete signed stack preserves this PR's original
tree, including file modes. This is an organizational split, not a merge or
release. The original branch and commit remain available.

1. Local Gateway status: https://github.com/openclaw/openclaw/pull/146045
2. Sleep lifecycle: https://github.com/openclaw/openclaw/pull/146046
3. Remote recovery/navigation: https://github.com/openclaw/openclaw/pull/146047
4. Quick Chat recovery: https://github.com/openclaw/openclaw/pull/146048
5. Widget ownership/coalescing: https://github.com/openclaw/openclaw/pull/146049
6. Updater ordering/retry: https://github.com/openclaw/openclaw/pull/146050
7. Linux support documentation: https://github.com/openclaw/openclaw/pull/146051
8. Release delivery: https://github.com/openclaw/openclaw/pull/146052

The known Connection Settings local-navigation P2 remains explicitly unresolved
in layer 3. Public feed activation and signed installed-client migration remain
unperformed in layer 8. Existing platform/proof limitations remain unchanged;
the split does not imply new native validation or green CI.

Original description preserved below.

---


Related: https://github.com/openclaw/openclaw/issues/127486
Related: https://github.com/openclaw/openclaw/issues/127466

<details>
<summary>Additional instructions</summary>

This PR uses a branch in `openclaw/openclaw`, which maintainers with repository
push access can update. This PR is intentionally a draft.

</details>

## What Problem This Solves

Fixes issues where Linux companion users can get stuck after a failed remote
connection, lose their selected route when opening the dashboard, or leave
Quick Chat waiting after the Gateway has already completed a retried turn.
It also addresses stale widget access, sleep-listener failure recovery, and
pending UI state accumulating behind a slow update.

Linux update delivery currently depends on the latest core release carrying
Linux metadata, and ordinary SemVer ordering can skip calendar correction
releases.

## Why This Change Was Made

Keep connection selection and generation ownership intact through queued
operations, reconnects, dashboard presentation, and Quick Chat retries; recover
only the exact completed turn and prevent retained widgets from using another
Gateway's access. Retire terminal sleep guards without consuming a later wake,
coalesce pending UI state, and reuse the existing calendar-version ordering
contract with the vendor fallback preserved.

Separate Linux update metadata into `linux-stable`, retain an ongoing
exact-byte legacy mirror, and detach mirror delivery from core finalization.
Publication checks bind the selected source, release and asset identities;
failures remain visible and require reconciliation. Support and first-run docs
now distinguish implemented behavior from unqualified platform capabilities.

## User Impact

- Remote users retain a usable settings/retry path without implicitly starting a
  local Gateway. Opening a healthy dashboard preserves an in-flight Quick Chat
  retry's identity.
- An unchanged Quick Chat retry recovers a matching completed reply when bounded
  history permits; unavailable or incomplete history remains an explicit error.
- Terminal sleep-listener failures do not leave recovery blocked, and slow UI
  updates retain only the active state and the latest pending state.
- Correction releases use the existing OpenClaw ordering contract. Linux feed
  independence and legacy compatibility are implemented, but **public channel
  activation and installed-client migration have not been performed**.

No version, dependency, protocol or supported-platform expansion is included.
No release publication, signing, merge or public activation is authorized by
this draft. Existing clients still require separately authorized feed repair
and a signed migration; changing future clients' endpoint does not migrate them.

## Evidence

- Native before/after recovery evidence covers remote route/status handling,
  settings/retry, owned SSH failures, and the dashboard/Quick Chat interaction.
  The isolated real-Gateway lost-ACK flow recovered the original completed turn
  without creating a second provider turn. Captures were inspected.
- [Native sleep/version run](https://github.com/openclaw/openclaw/actions/runs/34461350778):
  sleep controls and the calendar comparator regression passed, including
  the intended original vendor-ordering failure and four candidate Rust cases.
  Shared version vectors passed 70 focused JavaScript tests. Pending-state
  recovery also has intended original failures and focused candidate coverage.
- Release tooling: 223 distinct passing cases, including stateful CLI boundary
  fixtures and all 23 finalizer cases. These fixtures do not constitute real
  GitHub publication or cryptographic signature verification.
- [Final scripts/root TypeScript run](https://github.com/openclaw/openclaw/actions/runs/34477051974)
  passed on an isolated physical dependency tree. Targeted lint/format checks and the complete workflow-check wrapper
  passed, including the approved Linux-only actionlint queue exception.
- Fresh independent review of the full 36-file candidate completed in two
  partitions and returned `scoped-clean` at P0, with final source verification
  passing. This is a P0-scoped result, not a new lower-severity review.
- An earlier pinned candidate produced unsigned Ubuntu 22.04 AMD64 packages and
  passed ABI checks plus 12 Ubuntu 22.04/Debian 12 loader probes. This is not a
  final-candidate package build, install/upgrade, or complete packaged-GUI claim.

Native repair proof used isolated X11/Xvfb with the recorded functional graphics
profile and explicit focus. It does not qualify default graphics, native
Wayland, ARM64, microphone/media output, or macOS/Windows parity. Exact
CachyOS/Fedora blank-window and affected attachment/auth retests remain
incomplete because matching reporter environment/auth inputs are missing;
isolated HTTP evidence does not prove real Tailscale identity or attachment
painting. No claim is made that existing shipped AppImages contain this patch.
