### PR TITLE
fix(plugins): keep rebuilt bundled plugins on git installs instead of npm refreshes with a mismatched SDK

### DIFF
--- a/docs/cli/plugins/uninstall-and-update.md
+++ b/docs/cli/plugins/uninstall-and-update.md
@@ -45,6 +45,8 @@ openclaw plugins update openclaw-codex-app-server --acknowledge-install-policy-w
 
 Updates apply to tracked plugin installs in the managed plugin index and tracked hook-pack installs in shared SQLite state. They reuse the source that the user already chose when installing the plugin, so they do not require a second source acknowledgement.
 
+On source installations, a selected plugin built with the host stays in use. Named updates, `--all`, and stable/beta core updates report why the registry copy was not admitted and leave its dormant install record unchanged. Package ownership checks still apply to plugins being updated; explicit plugin paths retain their selection priority.
+
 `update --all` reports and skips orphaned path-source install records so remaining plugins can update. Remove an orphan record with `openclaw plugins uninstall <id>` when its files are no longer needed.
 
 <AccordionGroup>

--- a/docs/install/updating.md
+++ b/docs/install/updating.md
@@ -133,6 +133,12 @@ not a self-contained package artifact. Use `openclaw update --channel dev` to
 switch to the supported checkout and build flow. Other explicit package specs
 keep their package-manager behavior.
 
+On source installs, Doctor and plugin updates keep plugins built with the host.
+A registry plugin with the same version string can target a different SDK, so
+it does not replace the source build without matching SDK build evidence.
+Existing registry generations remain on disk; convergence reports the bundled
+selection and skips their refresh. `OPENCLAW_DEV_SOURCE_ROOT` is not required.
+
 Managed npm plugins on the beta channel use the same newest-of-beta/latest
 selection, including official plugins such as `@openclaw/codex`. An older beta
 tag cannot hold a plugin behind the current stable release. Startup repair

--- a/docs/plugins/architecture.md
+++ b/docs/plugins/architecture.md
@@ -537,7 +537,7 @@ For bundled workspace package names, keep the plugin id anchored in the npm name
 <Note>
 **Trust note:** `plugins.allow` permits **plugin ids** to load; it does not verify source provenance or choose which same-id copy loads. An auto-discovered workspace plugin does not shadow a bundled plugin merely because that id is enabled or allowlisted.
 
-For intentional local overrides, use `plugins.load.paths` to select the plugin path. Tracked global installs can also override ordinary bundled copies, while bundled plugins from `OPENCLAW_DEV_SOURCE_ROOT` retain priority over tracked globals. See [Discovery precedence](/plugins/manifest/package-json#discovery-precedence-duplicate-plugin-ids) for the full order.
+For intentional local overrides, use `plugins.load.paths` to select the plugin path. Tracked global installs can also override ordinary bundled copies. On source installs, plugins built with the host retain priority over tracked globals, including when `OPENCLAW_DEV_SOURCE_ROOT` is unset. Matching package versions alone do not prove that a registry plugin matches a source build's SDK. See [Discovery precedence](/plugins/manifest/package-json#discovery-precedence-duplicate-plugin-ids) for the full order.
 
 A configured path or install record pointing to the host’s own bundled plugin tree retains bundled provenance, including source and compiled entries; a different local copy does not inherit trust from its name or allowlist entry. Checkout runners supply the development selector automatically, including for compiled plugins. See [development debugging](</help/debugging#dev-profile-%2B-dev-gateway-(--dev)>).
 

--- a/docs/plugins/manifest/package-json.md
+++ b/docs/plugins/manifest/package-json.md
@@ -120,7 +120,7 @@ OpenClaw discovers plugins from explicit `plugins.load.paths` entries, the curre
 If two distinct plugin roots share the same `id`, only the **highest-precedence** manifest is kept; lower-precedence duplicates are dropped instead of loading beside it. Precedence, highest to lowest:
 
 1. **Config-selected** — a path explicitly selected in `plugins.load.paths`
-2. **Development-source bundled** — a bundled plugin inside the checkout selected by `OPENCLAW_DEV_SOURCE_ROOT`
+2. **Source-checkout bundled** — a compiled bundled plugin inside the running host's source checkout, or a bundled plugin inside the checkout selected by `OPENCLAW_DEV_SOURCE_ROOT`
 3. **Global install matching a tracked install record** — an installed global candidate whose path matches its install record, managed by `openclaw plugins install`/`openclaw plugins update`
 4. **Bundled** — other plugins shipped with OpenClaw
 5. **Workspace** — plugins discovered relative to the current workspace

--- a/src/cli/plugins-update-command.ts
+++ b/src/cli/plugins-update-command.ts
@@ -20,6 +20,7 @@ import type { PluginInstallRecord } from "../config/types.plugins.js";
 import { readHookInstalls } from "../hooks/installs.js";
 import { updateNpmInstalledHookPacks } from "../hooks/update.js";
 import { normalizeUpdateChannel, resolveRegistryUpdateChannel } from "../infra/update-channels.js";
+import { resolveSourceCheckoutBundledPluginIds } from "../plugins/bundled-sources.js";
 import {
   resolveCombinedPluginAndHookConfigMutationPreflight,
   resolveInstallConfigMutationPreflights,
@@ -253,6 +254,10 @@ async function runPluginUpdateCommandUnlocked(
     config: cfgWithPluginInstallRecords,
     installRecords: pluginInstallRecords,
   });
+  const sourceBundledIds = resolveSourceCheckoutBundledPluginIds({
+    config: cfgWithPluginInstallRecords,
+    installRecords: pluginInstallRecords,
+  });
   const installOwnerByPluginId = new Map<string, string>();
   const rejectedPluginIds = new Map<string, string>();
   const ownershipResolver = createInstalledPluginOwnershipResolver(installedPluginIndex);
@@ -260,6 +265,9 @@ async function runPluginUpdateCommandUnlocked(
     ...installedPluginIndex.plugins.map((plugin) => plugin.pluginId),
     ...Object.keys(pluginInstallRecords),
   ])) {
+    if (sourceBundledIds.has(pluginId)) {
+      continue;
+    }
     const ownership = ownershipResolver.resolveLifecycle(pluginId);
     if (!ownership.ok) {
       rejectedPluginIds.set(pluginId, ownership.error);
@@ -291,9 +299,11 @@ async function runPluginUpdateCommandUnlocked(
     defaultRuntime.error(pluginSelection.error);
     return defaultRuntime.exit(1);
   }
+  // Dormant records still reach the updater for notices, but no package mutation.
+  const packageUpdateIds = pluginSelection.pluginIds.filter((id) => !sourceBundledIds.has(id));
   const packageUpdateSnapshotResult = capturePluginPackageUpdateSnapshot({
     index: installedPluginIndex,
-    installOwners: pluginSelection.pluginIds,
+    installOwners: packageUpdateIds,
   });
   if (!packageUpdateSnapshotResult.ok) {
     defaultRuntime.error(packageUpdateSnapshotResult.error);
@@ -328,7 +338,7 @@ async function runPluginUpdateCommandUnlocked(
 
   const pluginUpdateMayMutate =
     !params.opts.dryRun &&
-    pluginSelection.pluginIds.some((pluginId) => {
+    packageUpdateIds.some((pluginId) => {
       return mayMutatePluginInstallRecord(
         pluginInstallRecords[pluginId],
         pluginSelection.specOverrides?.[pluginId],
@@ -361,7 +371,7 @@ async function runPluginUpdateCommandUnlocked(
     const pluginReferencesMayBeUnresolved =
       Object.hasOwn(parsedConfig, "$include") ||
       containsConfigIncludeDirective(mutationSnapshot.snapshot.sourceConfig.plugins);
-    const pluginIdMigrationMayMutate = pluginSelection.pluginIds.some((pluginId) => {
+    const pluginIdMigrationMayMutate = packageUpdateIds.some((pluginId) => {
       return (
         pluginInstallRecordMayMigrateConfigId({
           pluginId,
@@ -372,7 +382,7 @@ async function runPluginUpdateCommandUnlocked(
           pluginConfigReferencesId(mutationSnapshot.snapshot.sourceConfig, pluginId))
       );
     });
-    const pluginLoadPathMayMutate = pluginSelection.pluginIds.some((pluginId) =>
+    const pluginLoadPathMayMutate = packageUpdateIds.some((pluginId) =>
       configReferencesNpmInstallPath({
         config: cfg,
         install: pluginInstallRecords[pluginId],
@@ -538,7 +548,7 @@ async function runPluginUpdateCommandUnlocked(
         const currentInstallRecords = await loadInstalledPluginIndexInstallRecords();
         const currentSnapshot = capturePluginPackageUpdateSnapshot({
           index: installedPluginIndex,
-          installOwners: pluginSelection.pluginIds,
+          installOwners: packageUpdateIds,
         });
         if (
           !isDeepStrictEqual(currentInstallRecords, persistedPluginInstallRecords) ||

--- a/src/cli/update-cli/update-command-convergence.ts
+++ b/src/cli/update-cli/update-command-convergence.ts
@@ -238,7 +238,8 @@ export async function convergeUpdatePlugins(params: {
         ...(postCorePluginUpdate?.warnings ?? []).filter(
           (warning) => warning.reason === "plugin-target-unavailable",
         ),
-        ...(postCorePluginUpdate?.npm.outcomes ?? []).filter(
+        // Committed handoff files can acknowledge success without npm details.
+        ...(postCorePluginUpdate?.npm?.outcomes ?? []).filter(
           (outcome) => outcome.code === "source-bundled-plugin",
         ),
       ];

--- a/src/cli/update-cli/update-command-convergence.ts
+++ b/src/cli/update-cli/update-command-convergence.ts
@@ -234,9 +234,14 @@ export async function convergeUpdatePlugins(params: {
           ],
         };
       }
-      const pluginAdvisories = (postCorePluginUpdate?.warnings ?? []).filter(
-        (warning) => warning.reason === "plugin-target-unavailable",
-      );
+      const pluginAdvisories = [
+        ...(postCorePluginUpdate?.warnings ?? []).filter(
+          (warning) => warning.reason === "plugin-target-unavailable",
+        ),
+        ...(postCorePluginUpdate?.npm.outcomes ?? []).filter(
+          (outcome) => outcome.code === "source-bundled-plugin",
+        ),
+      ];
       resultWithPostUpdate = {
         ...resultWithPostUpdate,
         steps: [

--- a/src/commands/doctor/shared/missing-configured-plugin-install.candidates.ts
+++ b/src/commands/doctor/shared/missing-configured-plugin-install.candidates.ts
@@ -58,7 +58,7 @@ export type DownloadableInstallCandidate = {
 export type BundledPluginPackageDescriptor = {
   name?: string;
   packageName?: string;
-  sourceCheckout?: boolean;
+  preserveExternalInstallRecord?: boolean;
 };
 
 /** Keep doctor diagnostics and actual package repair on the same discovery snapshot. */
@@ -94,12 +94,21 @@ export async function resolveConfiguredPluginInstallContext(params: {
   });
   const bundledPluginsById = new Map<string, BundledPluginPackageDescriptor>(
     currentBundledPlugins.flatMap((plugin) => {
+      const external = isExternallyDistributedPlugin(plugin);
       const sourceCheckout = isBundledPluginInsideDevSourceRoot({
         rootDir: plugin.rootDir,
         env: params.env,
       });
-      return !isExternallyDistributedPlugin(plugin) || sourceCheckout
-        ? [[plugin.pluginId, { packageName: plugin.packageName, sourceCheckout }] as const]
+      return !external || sourceCheckout
+        ? [
+            [
+              plugin.pluginId,
+              {
+                packageName: plugin.packageName,
+                preserveExternalInstallRecord: external && sourceCheckout,
+              },
+            ] as const,
+          ]
         : [];
     }),
   );

--- a/src/commands/doctor/shared/missing-configured-plugin-install.candidates.ts
+++ b/src/commands/doctor/shared/missing-configured-plugin-install.candidates.ts
@@ -8,6 +8,7 @@ import {
   normalizeUpdateChannel,
   resolveRegistryUpdateChannel,
 } from "../../../infra/update-channels.js";
+import { isBundledPluginInsideDevSourceRoot } from "../../../plugins/dev-source-root.js";
 import {
   resolveDefaultPluginExtensionsDir,
   resolvePluginInstallDir,
@@ -57,6 +58,7 @@ export type DownloadableInstallCandidate = {
 export type BundledPluginPackageDescriptor = {
   name?: string;
   packageName?: string;
+  sourceCheckout?: boolean;
 };
 
 /** Keep doctor diagnostics and actual package repair on the same discovery snapshot. */
@@ -91,9 +93,15 @@ export async function resolveConfiguredPluginInstallContext(params: {
     configuredChannelIds: params.configuredChannelIds,
   });
   const bundledPluginsById = new Map<string, BundledPluginPackageDescriptor>(
-    currentBundledPlugins
-      .filter((plugin) => !isExternallyDistributedPlugin(plugin))
-      .map((plugin) => [plugin.pluginId, { packageName: plugin.packageName }] as const),
+    currentBundledPlugins.flatMap((plugin) => {
+      const sourceCheckout = isBundledPluginInsideDevSourceRoot({
+        rootDir: plugin.rootDir,
+        env: params.env,
+      });
+      return !isExternallyDistributedPlugin(plugin) || sourceCheckout
+        ? [[plugin.pluginId, { packageName: plugin.packageName, sourceCheckout }] as const]
+        : [];
+    }),
   );
   const configuredPluginIdsWithStaleDescriptors =
     collectConfiguredPluginIdsWithMissingChannelConfigDescriptors({

--- a/src/commands/doctor/shared/missing-configured-plugin-install.repair.ts
+++ b/src/commands/doctor/shared/missing-configured-plugin-install.repair.ts
@@ -260,7 +260,7 @@ async function repairMissingPluginInstallsWithLease(
     if (!bundled || !recordMatchesBundledPackage(record, bundled)) {
       continue;
     }
-    if (bundled.sourceCheckout) {
+    if (bundled.preserveExternalInstallRecord) {
       const message = formatSourceBundledPluginNotice(pluginId);
       notices.push(message);
       sourceOutcomes.push({

--- a/src/commands/doctor/shared/missing-configured-plugin-install.repair.ts
+++ b/src/commands/doctor/shared/missing-configured-plugin-install.repair.ts
@@ -8,6 +8,7 @@ import {
   normalizePluginsConfig,
   resolveEffectiveEnableState,
 } from "../../../plugins/config-state.js";
+import { formatSourceBundledPluginNotice } from "../../../plugins/dev-source-root.js";
 import { PLUGIN_INSTALL_ERROR_CODE } from "../../../plugins/install-types.js";
 import { writePersistedInstalledPluginIndexInstallRecords } from "../../../plugins/installed-plugin-index-records.js";
 import { isPayloadMissing } from "../../../plugins/payload-verification.js";
@@ -214,6 +215,7 @@ async function repairMissingPluginInstallsWithLease(
     warnings.push(message);
     params.onWarning?.({ message, ...(pluginId ? { pluginId } : {}) });
   };
+  const sourceOutcomes: PluginUpdateOutcome[] = [];
   const deferredRepairDetails: string[] = [];
   const failedPlugins = new Map<string, PluginUpdateOutcome | undefined>();
   const repairedPluginIds = new Set<string>();
@@ -256,6 +258,17 @@ async function repairMissingPluginInstallsWithLease(
   for (const [pluginId, record] of Object.entries(records)) {
     const bundled = bundledPluginsById.get(pluginId);
     if (!bundled || !recordMatchesBundledPackage(record, bundled)) {
+      continue;
+    }
+    if (bundled.sourceCheckout) {
+      const message = formatSourceBundledPluginNotice(pluginId);
+      notices.push(message);
+      sourceOutcomes.push({
+        pluginId,
+        status: "unchanged",
+        code: "source-bundled-plugin",
+        message,
+      });
       continue;
     }
     if (nextRecords === records) {
@@ -489,7 +502,10 @@ async function repairMissingPluginInstallsWithLease(
     await writePersistedInstalledPluginIndexInstallRecords(nextRecords, persistedIndexOptions);
   }
   const pluginInventoryChanged = nextRecords !== persistedRecords || repairedPluginIds.size > 0;
-  const outcomes = [...failedPlugins.values()].filter((outcome) => outcome !== undefined);
+  const outcomes = [
+    ...sourceOutcomes,
+    ...[...failedPlugins.values()].filter((outcome) => outcome !== undefined),
+  ];
   return {
     changes,
     warnings,

--- a/src/commands/doctor/shared/missing-configured-plugin-install.test.ts
+++ b/src/commands/doctor/shared/missing-configured-plugin-install.test.ts
@@ -176,7 +176,7 @@ vi.mock("../../../plugins/capability-consent.js", async (importOriginal) => ({
 
 function mockCurrentBundledPlugin(pluginId: string, packageName: string): void {
   mocks.loadInstalledPluginIndex.mockReturnValue({
-    plugins: [{ pluginId, origin: "bundled", packageName }],
+    plugins: [{ pluginId, origin: "bundled", packageName, rootDir: `/tmp/bundled/${pluginId}` }],
     diagnostics: [],
     installRecords: {},
   });

--- a/src/commands/doctor/shared/missing-configured-plugin-install.test.ts
+++ b/src/commands/doctor/shared/missing-configured-plugin-install.test.ts
@@ -174,9 +174,13 @@ vi.mock("../../../plugins/capability-consent.js", async (importOriginal) => ({
   prepareManagedPluginArtifactConsentHandler,
 }));
 
-function mockCurrentBundledPlugin(pluginId: string, packageName: string): void {
+function mockCurrentBundledPlugin(
+  pluginId: string,
+  packageName: string,
+  rootDir = `/tmp/bundled/${pluginId}`,
+): void {
   mocks.loadInstalledPluginIndex.mockReturnValue({
-    plugins: [{ pluginId, origin: "bundled", packageName, rootDir: `/tmp/bundled/${pluginId}` }],
+    plugins: [{ pluginId, origin: "bundled", packageName, rootDir }],
     diagnostics: [],
     installRecords: {},
   });
@@ -2016,6 +2020,13 @@ describe("repairMissingConfiguredPluginInstalls", () => {
   });
 
   it("removes stale managed install records when the configured plugin is bundled", async () => {
+    const sourceRoot = tempDirs.make("openclaw-bundled-record-retirement-");
+    fs.writeFileSync(path.join(sourceRoot, "package.json"), JSON.stringify({ name: "openclaw" }));
+    fs.mkdirSync(path.join(sourceRoot, "src"));
+    fs.mkdirSync(path.join(sourceRoot, "extensions"));
+    const bundledRoot = path.join(sourceRoot, "dist", "extensions", "bundleddemo");
+    fs.mkdirSync(bundledRoot, { recursive: true });
+    const env = { ...testEnv, OPENCLAW_DEV_SOURCE_ROOT: sourceRoot };
     const records = {
       bundleddemo: {
         source: "npm",
@@ -2051,7 +2062,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
         },
       ],
     });
-    mockCurrentBundledPlugin("bundleddemo", "@openclaw/bundleddemo");
+    mockCurrentBundledPlugin("bundleddemo", "@openclaw/bundleddemo", bundledRoot);
 
     const { repairMissingConfiguredPluginInstalls } =
       await import("./missing-configured-plugin-install.js");
@@ -2066,7 +2077,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
           bundleddemo: { enabled: true, homeserver: "https://bundleddemo.example.org" },
         },
       },
-      env: testEnv,
+      env,
     });
 
     expect(mocks.updateNpmInstalledPlugins).not.toHaveBeenCalled();
@@ -2076,7 +2087,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
       {},
       {
         config: expect.any(Object),
-        env: testEnv,
+        env,
       },
     );
     expect(result).toEqual({

--- a/src/commands/doctor/shared/post-core-plugin-convergence.source-checkout.test.ts
+++ b/src/commands/doctor/shared/post-core-plugin-convergence.source-checkout.test.ts
@@ -1,0 +1,300 @@
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../../test/helpers/temp-dir.js";
+import type { OpenClawConfig } from "../../../config/types.openclaw.js";
+import type { PluginInstallRecord } from "../../../config/types.plugins.js";
+import {
+  filterRecordsToActive,
+  runActivePluginPayloadSmokeCheck,
+} from "../../../plugins/active-payload-verification.js";
+import { resolvePluginNpmGenerationProjectDir } from "../../../plugins/install-paths.js";
+import {
+  readPersistedInstalledPluginIndexInstallRecords,
+  writePersistedInstalledPluginIndexInstallRecords,
+} from "../../../plugins/installed-plugin-index-records.js";
+import { loadPluginManifestRegistryCore } from "../../../plugins/manifest-registry.js";
+import { createPluginCache, withPluginCache } from "../../../plugins/plugin-cache.js";
+import { closeOpenClawStateDatabaseByPath } from "../../../state/openclaw-state-db.js";
+import { resolveOpenClawStateSqlitePath } from "../../../state/openclaw-state-db.paths.js";
+import { runPostCorePluginConvergence } from "./post-core-plugin-convergence.js";
+
+const mocks = vi.hoisted(() => ({
+  hostRoot: "",
+  resolveNpmSpecMetadata:
+    vi.fn<typeof import("../../../infra/install-source-utils.js").resolveNpmSpecMetadata>(),
+  installPluginFromNpmSpec:
+    vi.fn<typeof import("../../../plugins/install.js").installPluginFromNpmSpec>(),
+}));
+
+vi.mock("../../../infra/openclaw-root.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../../infra/openclaw-root.js")>()),
+  resolveOpenClawPackageRootSync: () => mocks.hostRoot,
+  resolveOpenClawPackageRoot: async () => mocks.hostRoot,
+}));
+
+vi.mock("../../../infra/install-source-utils.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../../infra/install-source-utils.js")>()),
+  resolveNpmSpecMetadata: mocks.resolveNpmSpecMetadata,
+}));
+
+vi.mock("../../../plugins/install.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../../plugins/install.js")>()),
+  installPluginFromNpmSpec: mocks.installPluginFromNpmSpec,
+}));
+
+const HOST_VERSION = "2026.9.4";
+const NEW_EXPORT = "registerNativeHookRelayForBundledRuntime";
+const OLD_EXPORT = "registerRetainedNativeHookRelayForBundledRuntime";
+
+function writeJson(filePath: string, value: unknown): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, JSON.stringify(value));
+}
+
+function writeCodexPackage(params: {
+  root: string;
+  hostRoot: string;
+  version: string;
+  sdkExport: string;
+}): string {
+  writeJson(path.join(params.root, "package.json"), {
+    name: "@openclaw/codex",
+    version: params.version,
+    type: "module",
+    peerDependencies: { openclaw: ">=2026.9.4" },
+    openclaw: {
+      extensions: ["./dist/index.js"],
+      install: { npmSpec: "@openclaw/codex", defaultChoice: "npm" },
+      compat: { pluginApi: ">=2026.9.4" },
+      build: { openclawVersion: HOST_VERSION },
+    },
+  });
+  writeJson(path.join(params.root, "openclaw.plugin.json"), {
+    id: "codex",
+    version: params.version,
+    configSchema: { type: "object" },
+  });
+  const entry = path.join(params.root, "dist", "index.js");
+  fs.mkdirSync(path.dirname(entry), { recursive: true });
+  fs.writeFileSync(
+    entry,
+    `import { ${params.sdkExport} } from "openclaw/plugin-sdk/native-hook-relay-runtime";
+export function runTurn() { return ${params.sdkExport}(); }
+export default { id: "codex", register() {} };
+`,
+  );
+  fs.mkdirSync(path.join(params.root, "node_modules"), { recursive: true });
+  fs.symlinkSync(
+    params.hostRoot,
+    path.join(params.root, "node_modules", "openclaw"),
+    process.platform === "win32" ? "junction" : "dir",
+  );
+  return entry;
+}
+
+function importAndRun(entry: string, env: NodeJS.ProcessEnv) {
+  return spawnSync(
+    process.execPath,
+    [
+      "--input-type=module",
+      "--eval",
+      "const plugin = await import(process.argv[1]); process.stdout.write(plugin.runTurn());",
+      pathToFileURL(entry).href,
+    ],
+    { encoding: "utf8", env: { ...env, PATH: process.env.PATH } },
+  );
+}
+
+describe("post-core convergence on source checkouts", () => {
+  const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it.each([
+    { version: "2026.9.3", selector: false, corrupt: false },
+    { version: HOST_VERSION, selector: false, corrupt: false },
+    { version: "2026.9.3", selector: true, corrupt: false },
+    { version: HOST_VERSION, selector: true, corrupt: false },
+    { version: HOST_VERSION, selector: false, corrupt: true },
+  ])(
+    "keeps the rebuilt plugin with npm $version (selector=$selector, corrupt=$corrupt)",
+    async ({ version, selector, corrupt }) => {
+      const root = tempDirs.make("openclaw-source-convergence-");
+      const hostRoot = path.join(root, "host");
+      const stateDir = path.join(root, "state");
+      const bundledDir = path.join(hostRoot, "dist", "extensions", "codex");
+      mocks.hostRoot = hostRoot;
+      writeJson(path.join(hostRoot, "package.json"), {
+        name: "openclaw",
+        version: HOST_VERSION,
+        type: "module",
+        exports: {
+          "./plugin-sdk/native-hook-relay-runtime":
+            "./dist/plugin-sdk/native-hook-relay-runtime.js",
+        },
+      });
+      fs.mkdirSync(path.join(hostRoot, "src"), { recursive: true });
+      fs.mkdirSync(path.join(hostRoot, "extensions"), { recursive: true });
+      fs.writeFileSync(path.join(hostRoot, "pnpm-workspace.yaml"), "packages: []\n");
+      const sdkDir = path.join(hostRoot, "dist", "plugin-sdk");
+      fs.mkdirSync(sdkDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(sdkDir, "native-hook-relay-runtime.js"),
+        `export function ${NEW_EXPORT}() { return "synthetic turn completed"; }\n`,
+      );
+      writeCodexPackage({
+        root: bundledDir,
+        hostRoot,
+        version: HOST_VERSION,
+        sdkExport: NEW_EXPORT,
+      });
+      const npmRoot = resolvePluginNpmGenerationProjectDir({
+        npmDir: path.join(stateDir, "npm"),
+        packageName: "@openclaw/codex",
+        generationKey: `@openclaw/codex@${version}`,
+      });
+      writeJson(path.join(npmRoot, "package.json"), {
+        dependencies: { "@openclaw/codex": version },
+      });
+      const npmDir = path.join(npmRoot, "node_modules", "@openclaw", "codex");
+      const npmEntry = writeCodexPackage({
+        root: npmDir,
+        hostRoot,
+        version,
+        sdkExport: OLD_EXPORT,
+      });
+      const env: NodeJS.ProcessEnv = {
+        HOME: root,
+        OPENCLAW_HOME: root,
+        OPENCLAW_STATE_DIR: stateDir,
+        OPENCLAW_VERSION: HOST_VERSION,
+        OPENCLAW_COMPATIBILITY_HOST_VERSION: HOST_VERSION,
+        OPENCLAW_BUNDLED_PLUGINS_DIR: path.dirname(bundledDir),
+        OPENCLAW_DISABLE_BUNDLED_PLUGINS: undefined,
+        OPENCLAW_TEST_TRUST_BUNDLED_PLUGINS_DIR: "1",
+        OPENCLAW_DEV_SOURCE_ROOT: selector ? hostRoot : undefined,
+      };
+      for (const [key, value] of Object.entries(env)) {
+        vi.stubEnv(key, value);
+      }
+      const cfg: OpenClawConfig = {
+        update: { channel: "dev" },
+        plugins: { allow: ["codex"], entries: { codex: { enabled: true } } },
+      };
+      const records: Record<string, PluginInstallRecord> = {
+        codex: {
+          source: "npm",
+          spec: "@openclaw/codex",
+          installPath: npmDir,
+          version,
+          resolvedName: "@openclaw/codex",
+          resolvedVersion: version,
+          resolvedSpec: `@openclaw/codex@${version}`,
+        },
+      };
+      const metadata = {
+        name: "@openclaw/codex",
+        version: HOST_VERSION,
+        resolvedSpec: `@openclaw/codex@${HOST_VERSION}`,
+      };
+      mocks.resolveNpmSpecMetadata.mockResolvedValue({ ok: true, metadata });
+      mocks.installPluginFromNpmSpec.mockResolvedValue({
+        ok: true,
+        pluginId: "codex",
+        targetDir: npmDir,
+        version: HOST_VERSION,
+        extensions: ["./dist/index.js"],
+        npmResolution: metadata,
+      });
+
+      try {
+        await withPluginCache(createPluginCache(), async () => {
+          const published = importAndRun(npmEntry, env);
+          expect(published.status).not.toBe(0);
+          expect(published.stderr).toContain(`does not provide an export named '${OLD_EXPORT}'`);
+          await writePersistedInstalledPluginIndexInstallRecords(records, { config: cfg, env });
+        });
+        if (corrupt) {
+          fs.writeFileSync(path.join(npmDir, "package.json"), "{invalid package json");
+        }
+        const npmPackageBefore = fs.readFileSync(path.join(npmDir, "package.json"), "utf8");
+
+        await withPluginCache(createPluginCache(), async () => {
+          const result = await runPostCorePluginConvergence({
+            cfg,
+            env,
+            compatibilityHostVersion: HOST_VERSION,
+          });
+          expect.soft(mocks.resolveNpmSpecMetadata).not.toHaveBeenCalled();
+          expect.soft(mocks.installPluginFromNpmSpec).not.toHaveBeenCalled();
+          expect.soft(result.installRecords).toEqual(records);
+          expect.soft(result.errored).toBe(false);
+          expect.soft(result.smokeFailures).toEqual([]);
+          expect.soft(result.warnings).toEqual([]);
+          expect.soft(result.outcomes).toContainEqual(
+            expect.objectContaining({
+              pluginId: "codex",
+              status: "unchanged",
+              code: "source-bundled-plugin",
+            }),
+          );
+          expect.soft(result.changes.join("\n")).not.toContain("Refreshed stale configured plugin");
+          expect
+            .soft(fs.readFileSync(path.join(npmDir, "package.json"), "utf8"))
+            .toBe(npmPackageBefore);
+          expect.soft(readPersistedInstalledPluginIndexInstallRecords({ env })).toEqual(records);
+          const registry = loadPluginManifestRegistryCore({ config: cfg, env });
+          const selected = registry.plugins.find((plugin) => plugin.id === "codex");
+          expect.soft(selected).toMatchObject({ origin: "bundled", rootDir: bundledDir });
+          if (!selected) {
+            throw new Error("Codex disappeared during source checkout convergence");
+          }
+          const loaded = importAndRun(selected.source, env);
+          expect.soft(loaded.status, loaded.stderr).toBe(0);
+          expect.soft(loaded.stdout).toBe("synthetic turn completed");
+          const startup = await runActivePluginPayloadSmokeCheck({ cfg, records, env });
+          expect(startup.failures).toEqual([]);
+          if (version === HOST_VERSION && !selector && !corrupt) {
+            const override = path.join(root, "selected-plugin");
+            fs.symlinkSync(npmDir, override, process.platform === "win32" ? "junction" : "dir");
+            const selectedConfig: OpenClawConfig = {
+              ...cfg,
+              plugins: { ...cfg.plugins, load: { paths: [override] } },
+            };
+            expect(filterRecordsToActive({ cfg: selectedConfig, records, env })).toEqual(records);
+            const sourceOnlyDir = path.join(hostRoot, "extensions", "codex");
+            writeCodexPackage({
+              root: sourceOnlyDir,
+              hostRoot,
+              version: HOST_VERSION,
+              sdkExport: NEW_EXPORT,
+            });
+            withPluginCache(createPluginCache(), () => {
+              const sourceOnlyRegistry = loadPluginManifestRegistryCore({
+                config: cfg,
+                env: { ...env, OPENCLAW_BUNDLED_PLUGINS_DIR: path.dirname(sourceOnlyDir) },
+                installRecords: records,
+              });
+              expect(
+                sourceOnlyRegistry.plugins.find((plugin) => plugin.id === "codex"),
+              ).toMatchObject({
+                origin: "global",
+                rootDir: npmDir,
+              });
+            });
+          }
+        });
+      } finally {
+        closeOpenClawStateDatabaseByPath(resolveOpenClawStateSqlitePath(env));
+      }
+    },
+  );
+});

--- a/src/commands/doctor/shared/post-core-plugin-convergence.source-checkout.test.ts
+++ b/src/commands/doctor/shared/post-core-plugin-convergence.source-checkout.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../../test/helpers/temp-dir.js";
+import { runPluginUpdateCommand } from "../../../cli/plugins-update-command.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import type { PluginInstallRecord } from "../../../config/types.plugins.js";
 import {
@@ -17,16 +18,35 @@ import {
 } from "../../../plugins/installed-plugin-index-records.js";
 import { loadPluginManifestRegistryCore } from "../../../plugins/manifest-registry.js";
 import { createPluginCache, withPluginCache } from "../../../plugins/plugin-cache.js";
+import { convergePluginReleaseCohort } from "../../../plugins/update-cohort.js";
 import { closeOpenClawStateDatabaseByPath } from "../../../state/openclaw-state-db.js";
 import { resolveOpenClawStateSqlitePath } from "../../../state/openclaw-state-db.paths.js";
 import { runPostCorePluginConvergence } from "./post-core-plugin-convergence.js";
 
 const mocks = vi.hoisted(() => ({
   hostRoot: "",
+  getRuntimeConfig: vi.fn<() => OpenClawConfig>(),
+  log: vi.fn(),
+  error: vi.fn(),
   resolveNpmSpecMetadata:
     vi.fn<typeof import("../../../infra/install-source-utils.js").resolveNpmSpecMetadata>(),
   installPluginFromNpmSpec:
     vi.fn<typeof import("../../../plugins/install.js").installPluginFromNpmSpec>(),
+}));
+
+vi.mock("../../../config/config.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../../config/config.js")>()),
+  getRuntimeConfig: mocks.getRuntimeConfig,
+}));
+
+vi.mock("../../../runtime.js", () => ({
+  defaultRuntime: {
+    log: mocks.log,
+    error: mocks.error,
+    exit: (code: number) => {
+      throw new Error(`CLI exited with ${code}: ${mocks.error.mock.lastCall?.join(" ")}`);
+    },
+  },
 }));
 
 vi.mock("../../../infra/openclaw-root.js", async (importOriginal) => ({
@@ -119,14 +139,20 @@ describe("post-core convergence on source checkouts", () => {
   });
 
   it.each([
-    { version: "2026.9.3", selector: false, corrupt: false },
-    { version: HOST_VERSION, selector: false, corrupt: false },
-    { version: "2026.9.3", selector: true, corrupt: false },
-    { version: HOST_VERSION, selector: true, corrupt: false },
-    { version: HOST_VERSION, selector: false, corrupt: true },
+    { version: "2026.9.3", selector: false, corrupt: false, flow: "doctor" },
+    { version: HOST_VERSION, selector: false, corrupt: false, flow: "doctor" },
+    { version: "2026.9.3", selector: true, corrupt: false, flow: "doctor" },
+    { version: HOST_VERSION, selector: true, corrupt: false, flow: "doctor" },
+    { version: HOST_VERSION, selector: false, corrupt: true, flow: "doctor" },
+    ...["cli named", "cli all", "stable", "beta"].map((flow) => ({
+      version: HOST_VERSION,
+      selector: false,
+      corrupt: false,
+      flow,
+    })),
   ])(
-    "keeps the rebuilt plugin with npm $version (selector=$selector, corrupt=$corrupt)",
-    async ({ version, selector, corrupt }) => {
+    "keeps the rebuilt plugin with npm $version (selector=$selector, corrupt=$corrupt, flow=$flow)",
+    async ({ version, selector, corrupt, flow }) => {
       const root = tempDirs.make("openclaw-source-convergence-");
       const hostRoot = path.join(root, "host");
       const stateDir = path.join(root, "state");
@@ -189,6 +215,7 @@ describe("post-core convergence on source checkouts", () => {
         update: { channel: "dev" },
         plugins: { allow: ["codex"], entries: { codex: { enabled: true } } },
       };
+      mocks.getRuntimeConfig.mockReturnValue(cfg);
       const records: Record<string, PluginInstallRecord> = {
         codex: {
           source: "npm",
@@ -262,6 +289,28 @@ describe("post-core convergence on source checkouts", () => {
           expect.soft(loaded.stdout).toBe("synthetic turn completed");
           const startup = await runActivePluginPayloadSmokeCheck({ cfg, records, env });
           expect(startup.failures).toEqual([]);
+          if (flow === "cli named" || flow === "cli all") {
+            await runPluginUpdateCommand({
+              ...(flow === "cli named" ? { id: "codex" } : {}),
+              opts: { all: flow === "cli all", dryRun: true },
+            });
+            expect(mocks.error).not.toHaveBeenCalled();
+            expect(mocks.log.mock.calls.flat().join("\n")).toContain('Kept bundled plugin "codex"');
+          } else if (flow === "stable" || flow === "beta") {
+            const cohort = await convergePluginReleaseCohort({
+              config: { ...cfg, plugins: { ...cfg.plugins, installs: records } },
+              channel: flow,
+              coreVersion: HOST_VERSION,
+              timeoutMs: 60_000,
+              env,
+            });
+            expect(cohort.config.plugins?.installs).toEqual(records);
+            expect(cohort.updateOutcomes).toContainEqual(
+              expect.objectContaining({ pluginId: "codex", code: "source-bundled-plugin" }),
+            );
+          }
+          expect(mocks.resolveNpmSpecMetadata).not.toHaveBeenCalled();
+          expect(mocks.installPluginFromNpmSpec).not.toHaveBeenCalled();
           if (version === HOST_VERSION && !selector && !corrupt) {
             const override = path.join(root, "selected-plugin");
             fs.symlinkSync(npmDir, override, process.platform === "win32" ? "junction" : "dir");

--- a/src/commands/doctor/shared/post-core-plugin-convergence.test.ts
+++ b/src/commands/doctor/shared/post-core-plugin-convergence.test.ts
@@ -863,7 +863,7 @@ describe("runPostCorePluginConvergence", () => {
   });
 
   it("hands repair's post-mutation records straight to the smoke check (no second disk read)", async () => {
-    const records = { brave: { source: "npm" as const, installPath: "/p/brave" } };
+    const records = { external: { source: "npm" as const, installPath: "/p/external" } };
     mocks.repairMissingConfiguredPluginInstalls.mockResolvedValue({
       changes: ["Repaired"],
       warnings: [],
@@ -871,7 +871,7 @@ describe("runPostCorePluginConvergence", () => {
     });
     await runPostCorePluginConvergence({
       cfg: {
-        plugins: { entries: { brave: { enabled: true } } },
+        plugins: { entries: { external: { enabled: true } } },
       } as unknown as OpenClawConfig,
       env: {},
     });
@@ -979,6 +979,7 @@ describe("filterRecordsToActive", () => {
       },
     };
     const filtered = filterRecordsToActive({
+      env: { OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1" },
       cfg: {
         plugins: {
           enabled: true,

--- a/src/commands/doctor/shared/post-core-plugin-convergence.ts
+++ b/src/commands/doctor/shared/post-core-plugin-convergence.ts
@@ -263,7 +263,7 @@ export async function runPostCorePluginConvergence(params: {
     records,
     env,
   });
-  const smokeRecords = filterRecordsToActive({ cfg: params.cfg, records });
+  const smokeRecords = filterRecordsToActive({ cfg: params.cfg, records, env });
   const resolveInstallRecordPaths = (
     installRecords: Record<string, PluginInstallRecord>,
   ): Set<string> =>

--- a/src/plugins/active-payload-verification.ts
+++ b/src/plugins/active-payload-verification.ts
@@ -1,10 +1,11 @@
-// Boot-local plugin payload verification without repair, install, or catalog imports.
+// Boot-local plugin payload verification without repair or install operations.
 import {
   createPluginInstallRecordMap,
   setPluginInstallRecordMapEntry,
 } from "../config/plugin-install-record-map.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { PluginInstallRecord } from "../config/types.plugins.js";
+import { resolveSourceCheckoutBundledPluginIds } from "./bundled-sources.js";
 import { normalizePluginsConfig, resolveEffectiveEnableState } from "./config-state.js";
 import {
   resolveTrustedSourceLinkedOfficialClawHubSpec,
@@ -22,7 +23,7 @@ export async function runActivePluginPayloadSmokeCheck(params: {
   env: NodeJS.ProcessEnv;
 }): Promise<PluginPayloadSmokeResult> {
   return await runPluginPayloadSmokeCheck({
-    records: filterRecordsToActive({ cfg: params.cfg, records: params.records }),
+    records: filterRecordsToActive(params),
     env: params.env,
   });
 }
@@ -31,11 +32,22 @@ export async function runActivePluginPayloadSmokeCheck(params: {
 export function filterRecordsToActive(params: {
   cfg: OpenClawConfig;
   records: Record<string, PluginInstallRecord>;
+  env?: NodeJS.ProcessEnv;
 }): Record<string, PluginInstallRecord> {
+  const env = params.env ?? process.env;
   const normalizedPluginConfig = normalizePluginsConfig(params.cfg.plugins);
+  const sourceBundledIds = resolveSourceCheckoutBundledPluginIds({
+    config: params.cfg,
+    installRecords: params.records,
+    env,
+  });
   const filtered = createPluginInstallRecordMap<PluginInstallRecord>();
   for (const [pluginId, record] of Object.entries(params.records)) {
     if (!record || typeof record !== "object") {
+      continue;
+    }
+    if (sourceBundledIds.has(pluginId)) {
+      // A dormant registry generation must not quarantine the selected source-built plugin.
       continue;
     }
     const enableState = resolveEffectiveEnableState({

--- a/src/plugins/bundled-dir.ts
+++ b/src/plugins/bundled-dir.ts
@@ -41,7 +41,7 @@ function resolveDisabledBundledPluginsDir(): string {
   return DISABLED_BUNDLED_PLUGINS_DIR;
 }
 
-function isSourceCheckoutRoot(packageRoot: string): boolean {
+export function isSourceCheckoutRoot(packageRoot: string): boolean {
   return (
     pluginCacheExistsSync(path.join(packageRoot, "pnpm-workspace.yaml")) &&
     pluginCacheExistsSync(path.join(packageRoot, "src")) &&

--- a/src/plugins/bundled-sources.ts
+++ b/src/plugins/bundled-sources.ts
@@ -2,8 +2,15 @@
 import path from "node:path";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { PluginInstallRecord } from "../config/types.plugins.js";
 import { getGatewayPluginMetadataSnapshot } from "./current-plugin-metadata-state.js";
+import {
+  isBundledPluginInsideDevSourceRoot,
+  resolveBundledPluginSourceRoot,
+} from "./dev-source-root.js";
 import { discoverOpenClawPlugins, type PluginDiscoveryResult } from "./discovery.js";
+import { loadPluginManifestRegistryCore } from "./manifest-registry.js";
 import { loadPluginManifest } from "./manifest.js";
 
 export type BundledPluginSource = {
@@ -14,6 +21,40 @@ export type BundledPluginSource = {
   configSchema?: Record<string, unknown>;
   requiresConfig?: boolean;
 };
+
+/** Use loader precedence, including explicit paths, when deciding which registry installs are dormant. */
+export function resolveSourceCheckoutBundledPluginIds(params: {
+  config: OpenClawConfig;
+  installRecords: Record<string, PluginInstallRecord>;
+  env?: NodeJS.ProcessEnv;
+  bundledSources?: ReadonlyMap<string, BundledPluginSource>;
+}): ReadonlySet<string> {
+  const env = params.env ?? process.env;
+  if (!resolveBundledPluginSourceRoot(env)) {
+    return new Set();
+  }
+  const bundled = params.bundledSources ?? resolveBundledPluginSources({ env });
+  const sourceIds = new Set(
+    [...bundled]
+      .filter(([, source]) =>
+        isBundledPluginInsideDevSourceRoot({ rootDir: source.localPath, env }),
+      )
+      .map(([pluginId]) => pluginId),
+  );
+  if (sourceIds.size === 0) {
+    return sourceIds;
+  }
+  return new Set(
+    loadPluginManifestRegistryCore({ ...params, env })
+      .plugins.filter(
+        (plugin) =>
+          sourceIds.has(plugin.id) &&
+          plugin.origin === "bundled" &&
+          isBundledPluginInsideDevSourceRoot({ rootDir: plugin.rootDir, env }),
+      )
+      .map((plugin) => plugin.id),
+  );
+}
 
 type BundledPluginLookup =
   | { kind: "localPath"; value: string }

--- a/src/plugins/dev-source-root.ts
+++ b/src/plugins/dev-source-root.ts
@@ -1,8 +1,10 @@
 // Resolves development source roots for local plugin installs.
 import fs from "node:fs";
 import path from "node:path";
+import { resolveOpenClawPackageRootSync } from "../infra/openclaw-root.js";
+import { isPathInside } from "../infra/path-guards.js";
 import { resolveUserPath } from "../utils.js";
-import { isPluginInPackageBundledRoots } from "./bundled-dir.js";
+import { isPluginInPackageBundledRoots, isSourceCheckoutRoot } from "./bundled-dir.js";
 import { pluginCacheExistsSync, pluginCacheRealpathSync } from "./plugin-cache-files.js";
 import { getPluginCache } from "./plugin-cache.js";
 
@@ -40,17 +42,50 @@ export function resolveOpenClawDevSourceRoot(env: NodeJS.ProcessEnv = process.en
   return result;
 }
 
+/** Source builds own their bundled SDK consumers even without an explicit development selector. */
+export function resolveBundledPluginSourceRoot(
+  env: NodeJS.ProcessEnv = process.env,
+): string | null {
+  const selected = resolveOpenClawDevSourceRoot(env);
+  if (selected) {
+    return selected;
+  }
+  const hostRoot = resolveOpenClawPackageRootSync({ moduleUrl: import.meta.url });
+  return hostRoot && isSourceCheckoutRoot(hostRoot) ? hostRoot : null;
+}
+
+export function formatSourceBundledPluginNotice(pluginId: string): string {
+  return `Kept bundled plugin "${pluginId}" from the OpenClaw source build; the registry artifact has no matching host SDK build identity. Matching version strings do not establish SDK compatibility.`;
+}
+
 /** Prioritizes already-bundled candidates; the selector itself never grants provenance. */
 export function isBundledPluginInsideDevSourceRoot(params: {
   rootDir: string;
   env: NodeJS.ProcessEnv;
 }): boolean {
-  const devSourceRoot = resolveOpenClawDevSourceRoot(params.env);
+  const devSourceRoot = resolveBundledPluginSourceRoot(params.env);
   if (!devSourceRoot) {
     return false;
   }
-  return isPluginInPackageBundledRoots({
-    packageRoot: devSourceRoot,
-    rootDir: resolveUserPath(params.rootDir, params.env),
-  });
+  if (
+    !isPluginInPackageBundledRoots({
+      packageRoot: devSourceRoot,
+      rootDir: resolveUserPath(params.rootDir, params.env),
+    })
+  ) {
+    return false;
+  }
+  if (resolveOpenClawDevSourceRoot(params.env)) {
+    return true;
+  }
+  // Raw source can opt out of host builds; only compiled bundles gain automatic priority.
+  const hostRoot = pluginCacheRealpathSync(devSourceRoot);
+  const pluginRoot = pluginCacheRealpathSync(resolveUserPath(params.rootDir, params.env));
+  return Boolean(
+    hostRoot &&
+    pluginRoot &&
+    ["dist", "dist-runtime"].some((tree) =>
+      isPathInside(path.join(hostRoot, tree, "extensions"), pluginRoot),
+    ),
+  );
 }

--- a/src/plugins/plugin-registry-snapshot.ts
+++ b/src/plugins/plugin-registry-snapshot.ts
@@ -12,7 +12,10 @@ import {
   resolvePluginControlPlaneWorkspace,
 } from "./control-plane-workspace.js";
 import { getCurrentPluginMetadataSnapshot } from "./current-plugin-metadata-snapshot.js";
-import { resolveOpenClawDevSourceRoot } from "./dev-source-root.js";
+import {
+  isBundledPluginInsideDevSourceRoot,
+  resolveOpenClawDevSourceRoot,
+} from "./dev-source-root.js";
 import { discoverConfiguredPluginLoadPaths, type PluginDiscoveryResult } from "./discovery.js";
 import { resolvePluginDoctorContractArtifact } from "./doctor-contract-artifact.js";
 import { safeFileSignature, safeHashFile } from "./installed-plugin-index-hash.js";
@@ -339,6 +342,7 @@ function requiresDerivedRegistryValidation(
   env: NodeJS.ProcessEnv,
   hasStalePluginFiles: () => boolean,
 ): boolean {
+  const bundledRoot = resolveBundledPluginsDir(env);
   return (
     // Capture file freshness before any other reason starts derived discovery.
     // Otherwise that discovery can cache the old bytes and hide a concurrent replacement.
@@ -350,6 +354,8 @@ function requiresDerivedRegistryValidation(
     params.installRecords !== undefined ||
     // Persisted source selection cannot encode this process's development checkout preference.
     resolveOpenClawDevSourceRoot(env) !== null ||
+    (bundledRoot !== undefined &&
+      isBundledPluginInsideDevSourceRoot({ rootDir: bundledRoot, env })) ||
     normalizePluginsConfig(params.config?.plugins).loadPaths.length > 0 ||
     hasMissingConfigPathActivationMetadata(index) ||
     hasMissingInstalledPluginOwnerMetadata(index, env) ||

--- a/src/plugins/update-cohort.ts
+++ b/src/plugins/update-cohort.ts
@@ -1,5 +1,6 @@
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { UpdateChannel } from "../infra/update-channels.js";
+import { resolveSourceCheckoutBundledPluginIds } from "./bundled-sources.js";
 import type { PluginCapabilityConsentHandler } from "./capability-consent.js";
 import type { ExternalizedBundledPluginBridge } from "./externalized-bundled-plugins.js";
 import { resolvePluginInstallOwnerMigrations } from "./install-transaction.js";
@@ -60,7 +61,14 @@ export async function convergePluginReleaseCohort(params: {
   let config = sync.config;
   let changed = sync.changed;
   let npmChanged = false;
-  const installOwners = Object.keys(config.plugins?.installs ?? {});
+  const sourceBundledIds = resolveSourceCheckoutBundledPluginIds({
+    config,
+    installRecords: config.plugins?.installs ?? {},
+    env: params.env,
+  });
+  const installOwners = Object.keys(config.plugins?.installs ?? {}).filter(
+    (id) => !sourceBundledIds.has(id),
+  );
   // Without prior package owners there is no retired child policy to reconcile.
   const beforeIndex = installOwners.length
     ? withPluginCache(createPluginCache(), () =>

--- a/src/plugins/update-installed.ts
+++ b/src/plugins/update-installed.ts
@@ -1,27 +1,25 @@
 import { PLUGIN_CAPABILITY_CONSENT_REQUIRED } from "../../packages/gateway-protocol/src/capability-consent-error-details.js";
 import { formatCliCommand } from "../cli/command-format.js";
-import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resolveNpmSpecMetadata } from "../infra/install-source-utils.js";
 import { parseRegistryNpmSpec } from "../infra/npm-registry-spec.js";
 import {
   readInstalledPackageManifest,
   readInstalledPackageVersion,
 } from "../infra/package-update-utils.js";
-import type { UpdateChannel } from "../infra/update-channels.js";
 import { resolveUserPath } from "../utils.js";
-import { resolveBundledPluginSources } from "./bundled-sources.js";
 import {
-  capturePluginCapabilityConsentHandlerErrors,
-  type PluginCapabilityConsentHandler,
-} from "./capability-consent.js";
+  resolveBundledPluginSources,
+  resolveSourceCheckoutBundledPluginIds,
+} from "./bundled-sources.js";
+import { capturePluginCapabilityConsentHandlerErrors } from "./capability-consent.js";
 import { buildClawHubPluginInstallRecordFields } from "./clawhub-install-records.js";
 import { normalizePluginsConfig, resolveEffectiveEnableState } from "./config-state.js";
+import { formatSourceBundledPluginNotice } from "./dev-source-root.js";
 import {
   isUnavailablePluginSource,
   NpmChannelResolutionError,
   resolveNpmInstallSpecsForUpdateChannel,
 } from "./install-channel-specs.js";
-import type { InstallSafetyOverrides } from "./install-security-scan.types.js";
 import { copyPluginInstallTransactionRequest } from "./install-transaction.js";
 import { PLUGIN_INSTALL_ERROR_CODE, resolvePluginInstallDir } from "./install.js";
 import { buildNpmResolutionInstallFields, recordPluginInstall } from "./installs.js";
@@ -75,10 +73,9 @@ import {
   resolveTrustedOfficialPrereleaseFallbackMetadataForUpdate,
   shouldBypassTrustedOfficialUnchangedNpmCheck,
   shouldSkipUnchangedNpmInstall,
-  type PluginUpdateIntegrityDriftParams,
-  type PluginUpdateLogger,
   type PluginUpdateOutcome,
   type PluginUpdateSummary,
+  type UpdateInstalledPluginsParams,
 } from "./update-source.js";
 import {
   createPluginUpdateTransactionState,
@@ -88,28 +85,9 @@ import {
 } from "./update-summary.js";
 import { reconcileUnchangedUpdate } from "./update-unchanged.js";
 
-export async function updateNpmInstalledPlugins(params: {
-  config: OpenClawConfig;
-  logger?: PluginUpdateLogger;
-  pluginIds?: string[];
-  skipIds?: Set<string>;
-  skipDisabledPlugins?: boolean;
-  syncOfficialPluginInstalls?: boolean;
-  disableOnFailure?: boolean;
-  retainOnUnavailable?: boolean;
-  timeoutMs?: number;
-  dryRun?: boolean;
-  updateChannel?: UpdateChannel;
-  officialPluginUpdateChannel?: UpdateChannel;
-  coreVersion?: string;
-  versionBoundPluginIds?: ReadonlySet<string>;
-  onInstallPolicyWarning?: InstallSafetyOverrides["onInstallPolicyWarning"];
-  specOverrides?: Record<string, string>;
-  onIntegrityDrift?: (params: PluginUpdateIntegrityDriftParams) => boolean | Promise<boolean>;
-  onCapabilityConsent?: PluginCapabilityConsentHandler;
-  beforePersistentEffect?: () => void | Promise<void>;
-  packagePluginIds?: Readonly<Record<string, readonly string[]>>;
-}): Promise<PluginUpdateSummary> {
+export async function updateNpmInstalledPlugins(
+  params: UpdateInstalledPluginsParams,
+): Promise<PluginUpdateSummary> {
   const logger = params.logger ?? {};
   const retainOnUnavailable = params.retainOnUnavailable === true;
   const consentCallbacks = capturePluginCapabilityConsentHandlerErrors(params.onCapabilityConsent);
@@ -119,6 +97,11 @@ export async function updateNpmInstalledPlugins(params: {
     ? normalizePluginsConfig(params.config.plugins)
     : undefined;
   const bundled = resolveBundledPluginSources({});
+  const sourceBundledIds = resolveSourceCheckoutBundledPluginIds({
+    config: params.config,
+    installRecords: installs,
+    bundledSources: bundled,
+  });
   const outcomes: PluginUpdateOutcome[] = [];
   const transactionState = createPluginUpdateTransactionState(params);
   let next = params.config;
@@ -162,6 +145,13 @@ export async function updateNpmInstalledPlugins(params: {
     const record = Object.hasOwn(installs, pluginId) ? installs[pluginId] : undefined;
     if (!record) {
       recordSkippedOutcome(pluginId, `No install record for "${pluginId}".`);
+      continue;
+    }
+
+    if (sourceBundledIds.has(pluginId)) {
+      const message = formatSourceBundledPluginNotice(pluginId);
+      outcomes.push({ pluginId, status: "unchanged", code: "source-bundled-plugin", message });
+      logger.warn?.(message);
       continue;
     }
 

--- a/src/plugins/update-source.ts
+++ b/src/plugins/update-source.ts
@@ -23,6 +23,7 @@ import {
 } from "../infra/package-update-utils.js";
 import type { UpdateChannel } from "../infra/update-channels.js";
 import { resolveCompatibilityHostVersion } from "../version.js";
+import type { PluginCapabilityConsentHandler } from "./capability-consent.js";
 import { isUnavailableClawHubTarget } from "./clawhub-error-codes.js";
 import type { ExternalizedBundledPluginBridge } from "./externalized-bundled-plugins.js";
 import {
@@ -30,6 +31,7 @@ import {
   resolveDefaultNpmSpec,
   resolveNpmInstallSpecsForUpdateChannel,
 } from "./install-channel-specs.js";
+import type { InstallSafetyOverrides } from "./install-security-scan.types.js";
 import { checkMinHostVersion } from "./min-host-version.js";
 import * as officialInstallRecords from "./official-external-install-records.js";
 import {
@@ -90,6 +92,29 @@ export type PluginUpdateIntegrityDriftParams = {
   resolvedSpec?: string;
   resolvedVersion?: string;
   dryRun: boolean;
+};
+
+export type UpdateInstalledPluginsParams = {
+  config: OpenClawConfig;
+  logger?: PluginUpdateLogger;
+  pluginIds?: string[];
+  skipIds?: Set<string>;
+  skipDisabledPlugins?: boolean;
+  syncOfficialPluginInstalls?: boolean;
+  disableOnFailure?: boolean;
+  retainOnUnavailable?: boolean;
+  timeoutMs?: number;
+  dryRun?: boolean;
+  updateChannel?: UpdateChannel;
+  officialPluginUpdateChannel?: UpdateChannel;
+  coreVersion?: string;
+  versionBoundPluginIds?: ReadonlySet<string>;
+  onInstallPolicyWarning?: InstallSafetyOverrides["onInstallPolicyWarning"];
+  specOverrides?: Record<string, string>;
+  onIntegrityDrift?: (params: PluginUpdateIntegrityDriftParams) => boolean | Promise<boolean>;
+  onCapabilityConsent?: PluginCapabilityConsentHandler;
+  beforePersistentEffect?: () => void | Promise<void>;
+  packagePluginIds?: Readonly<Record<string, readonly string[]>>;
 };
 
 export type UpdatablePluginInstallRecord = PluginInstallRecord & {

--- a/src/plugins/update.test.ts
+++ b/src/plugins/update.test.ts
@@ -155,7 +155,8 @@ vi.mock("../state/claw-package-lifecycle-lease.js", () => ({
   ) => withClawPackageLifecycleLeaseMock(artifact, operation, options),
 }));
 
-vi.mock("./bundled-sources.js", () => ({
+vi.mock("./bundled-sources.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./bundled-sources.js")>()),
   resolveBundledPluginSources: (...args: unknown[]) => resolveBundledPluginSourcesMock(...args),
 }));
 


### PR DESCRIPTION
Fixes #145266

## What Problem This Solves

Fixes an issue where users updating a git/dev installation would lose every Codex harness turn after Doctor refreshed the plugin from npm. The published plugin and rebuilt host could share `2026.9.4` while importing and exporting different Plugin SDK symbols. Retained npm records could also make named plugin updates, `--all`, and stable/beta release-cohort convergence fail with missing package-owner metadata after selecting the rebuilt bundle.

## Why This Change Was Made

Compiled bundled plugins from the running source checkout retain priority without requiring `OPENCLAW_DEV_SOURCE_ROOT`. Doctor and plugin updates keep those builds and record why the registry artifact was not admitted: current package metadata has no matching SDK build identity, and matching version strings are insufficient.

The existing manifest selection owner determines which registry payloads are dormant. Update planning carries that selection through package-mutation preflight, while active packages retain strict ownership and reconciliation checks. Dormant records still reach the updater for an explanatory unchanged outcome. A damaged unused npm generation cannot quarantine the selected bundle.

External npm records and payloads remain available; explicit plugin paths and the existing development selector retain their precedence. Unbuilt source copies do not gain automatic priority. Ordinary bundled plugins retain their existing stale-record cleanup. Status-only post-core acknowledgments remain valid when detailed npm outcomes are absent.

## User Impact

Git/dev updates keep using the plugin rebuilt with the host SDK, including when an older or same-version npm installation remains recorded. Named and bulk plugin updates and stable/beta source updates no longer reject that dormant record as an active package. Package-host updates retain their registry behavior. Selection notices appear in update outcomes and the existing update ledger.

Thanks @DonnieFi for the report and artifact-skew evidence.

## Evidence

Head `7eebcd4a85098b782b5240b01c2c5000dd558161` includes the reviewed preflight fixup and passed [CI run 34673248789](https://github.com/openclaw/openclaw/actions/runs/34673248789). The exact-head watcher reports GREEN with zero pending checks; five superseded check records remain in the aggregate GitHub rollup. Native review-artifact validation and hosted CI/Testbox preparation passed without changing the head. Its predecessor `893e9d86523fdd8cd1a8ce4e33692eb189d39568` also passed [CI run 34670330882](https://github.com/openclaw/openclaw/actions/runs/34670330882).

The source-checkout boundary fixture covers older and equal-version npm records, the development selector present and absent, a corrupt dormant payload, explicit symlink selection, and an unbuilt source control. The original selection regression failed before the original repair. The added entrypoint regressions failed on `893e9d86523` before the preflight fixup:

```text
node scripts/run-vitest.mjs src/commands/doctor/shared/post-core-plugin-convergence.source-checkout.test.ts
Before preflight fixup: 4 failed | 5 passed
Named CLI, --all, stable, beta: Plugin "codex" has no authoritative package-owner metadata.
After: 9 passed

node scripts/run-vitest.mjs src/commands/doctor/shared/post-core-plugin-convergence.source-checkout.test.ts src/cli/plugins-cli.update.test.ts src/plugins/update-cohort.test.ts src/plugins/update-cohort.integration.test.ts src/plugins/plugin-package-update.test.ts
88 tests passed across 5 files; 4 Vitest shards passed.

node scripts/check-changed.mjs
Passed, including core/test typechecks, changed-file lint, unused-export scans,
and zero runtime import cycles.
```

The CLI entrypoint cases use dry-run with real manifest selection, isolated persisted install records, ownership preflight, and updater behavior. The stable/beta cases execute release-cohort convergence against synthetic source and registry artifacts. Existing ambiguous-ownership and package-reconciliation regressions pass. A lint-only fixture rewrite preserved the same cases, and the final regression rerun passed all 9 tests. `git diff --check` passed. Independent review of the original patch and the preflight fixup is scoped-clean at P1; the intervening rebases were verified mechanical.

Previously recorded real-artifact replay through original and repaired post-core convergence, followed by a built-CLI Codex turn:

```text
Before: Refreshed stale configured plugin "codex" from @openclaw/codex.
Import: does not provide an export named 'registerRetainedNativeHookRelayForBundledRuntime'
After: Kept bundled plugin "codex" from the OpenClaw source build;
       the registry artifact has no matching host SDK build identity.
Turn: QA_CODEX_AUTH_PRODUCT_PROOF_OK; harness codex; exit 0
```

That turn uses a synthetic app-server transport and isolated state without real provider credentials. Doctor also passes with the published post-core marker. Earlier validation passed 401 Doctor/updater tests, the focused status-only post-core cases, and all 153 public Plugin SDK build subpaths. These earlier results are supporting evidence, not a fresh full build of the fixup.

## ClawSweeper review

- Applied the dormant-install preflight finding in both update entrypoints, with failing-before/passing-after regressions. Active-package ownership remains strict.
- Deferred the broader published-driver install/service-switch and fresh-install matrix. Existing explicit-path and unbuilt-source controls remain covered, but no full old-driver upgrade campaign is claimed. A previously recorded non-blocking harness-dispose warning remains after the successful synthetic turn.

No baselines, limits, or assertions were weakened. No dependencies, schema changes, or changelog edits were added.
