### PR TITLE
refactor(secrets): share static auth-profile secret collection

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -3430,7 +3430,6 @@ src/secrets/plan.ts	4
 src/secrets/private-plan-file.ts	1
 src/secrets/provider-env-vars.ts	1
 src/secrets/resolve.ts	1
-src/secrets/runtime-auth-collectors.ts	2
 src/secrets/runtime-command-secrets.ts	4
 src/secrets/runtime-config-collectors-core.ts	7
 src/secrets/runtime-config-collectors-memory.ts	1

--- a/src/secrets/runtime-auth-collectors.ts
+++ b/src/secrets/runtime-auth-collectors.ts
@@ -15,20 +15,10 @@ import {
 } from "./runtime-shared.js";
 import { isNonEmptyString } from "./shared.js";
 
-type ApiKeyCredentialLike = AuthProfileCredential & {
-  type: "api_key";
-  key?: string;
-  keyRef?: unknown;
-};
-
-type TokenCredentialLike = AuthProfileCredential & {
-  type: "token";
-  token?: string;
-  tokenRef?: unknown;
-};
+type StaticProfileCredential = Extract<AuthProfileCredential, { type: "api_key" | "token" }>;
 
 function resolveAuthProfileOwnerContract(
-  profile: ApiKeyCredentialLike | TokenCredentialLike,
+  profile: StaticProfileCredential,
   context: ResolverContext,
 ): unknown {
   const providerId = normalizeOptionalLowercaseString(profile.provider) ?? profile.provider;
@@ -53,8 +43,8 @@ function collectAuthStoreSecretInputAssignment(
   }
 }
 
-function collectApiKeyProfileAssignment(params: {
-  profile: ApiKeyCredentialLike;
+function collectStaticProfileAssignment(params: {
+  profile: StaticProfileCredential;
   profileId: string;
   store: AuthProfileStore;
   agentDir: string;
@@ -63,42 +53,51 @@ function collectApiKeyProfileAssignment(params: {
   context: ResolverContext;
 }): void {
   const ownerContract = resolveAuthProfileOwnerContract(params.profile, params.context);
-  const {
-    explicitRef: keyRef,
-    inlineRef: inlineKeyRef,
-    ref: resolvedKeyRef,
-  } = resolveSecretInputRef({
-    value: params.profile.key,
-    refValue: params.profile.keyRef,
+  const profile = params.profile;
+  const field = profile.type === "api_key" ? "key" : "token";
+  const { explicitRef, inlineRef, ref } = resolveSecretInputRef({
+    value: profile.type === "api_key" ? profile.key : profile.token,
+    refValue: profile.type === "api_key" ? profile.keyRef : profile.tokenRef,
     defaults: params.defaults,
   });
-  if (!resolvedKeyRef) {
+  if (!ref) {
     return;
   }
-  // Inline SecretRefs are normalized into keyRef so runtime snapshots preserve the
-  // explicit auth-profile ref surface instead of leaving a template string in key.
-  if (!keyRef && inlineKeyRef) {
-    params.profile.keyRef = inlineKeyRef;
+  // Promote inline refs before eligibility reads the authoritative ref field.
+  if (!explicitRef && inlineRef) {
+    if (profile.type === "api_key") {
+      profile.keyRef = inlineRef;
+    } else {
+      profile.tokenRef = inlineRef;
+    }
   }
-  if (keyRef && isNonEmptyString(params.profile.key)) {
+  if (explicitRef && isNonEmptyString(profile.type === "api_key" ? profile.key : profile.token)) {
     pushWarning(params.context, {
       code: "SECRETS_REF_OVERRIDES_PLAINTEXT",
-      path: `${params.agentDir}.auth-profiles.${params.profileId}.key`,
-      message: `auth-profiles ${params.profileId}: keyRef is set; runtime will ignore plaintext key.`,
+      path: `${params.agentDir}.auth-profiles.${params.profileId}.${field}`,
+      message: `auth-profiles ${params.profileId}: ${field}Ref is set; runtime will ignore plaintext ${field}.`,
     });
   }
+  const setValue =
+    profile.type === "api_key"
+      ? (value: string | undefined) => {
+          profile.key = value;
+        }
+      : (value: string | undefined) => {
+          profile.token = value;
+        };
   // Only successful runtime materialization may populate the authoritative secret slot.
-  params.profile.key = undefined;
+  setValue(undefined);
   const eligibility = resolveAuthProfileEligibility({
     cfg: params.context.sourceConfig,
     authAliasLookupParams: params.authAliasLookupParams,
     store: params.store,
-    provider: params.profile.provider,
+    provider: profile.provider,
     profileId: params.profileId,
   });
   collectAuthStoreSecretInputAssignment({
-    value: resolvedKeyRef,
-    path: `${params.agentDir}.auth-profiles.${params.profileId}.key`,
+    value: ref,
+    path: `${params.agentDir}.auth-profiles.${params.profileId}.${field}`,
     expected: "string",
     defaults: params.defaults,
     context: params.context,
@@ -112,77 +111,10 @@ function collectApiKeyProfileAssignment(params: {
       contract: ownerContract,
     },
     apply: (value) => {
-      params.profile.key = String(value);
+      setValue(String(value));
     },
     applyUnavailable: () => {
-      params.profile.key = undefined;
-    },
-  });
-}
-
-function collectTokenProfileAssignment(params: {
-  profile: TokenCredentialLike;
-  profileId: string;
-  store: AuthProfileStore;
-  agentDir: string;
-  defaults: SecretDefaults | undefined;
-  authAliasLookupParams: ProviderAuthAliasLookupParams;
-  context: ResolverContext;
-}): void {
-  const ownerContract = resolveAuthProfileOwnerContract(params.profile, params.context);
-  const {
-    explicitRef: tokenRef,
-    inlineRef: inlineTokenRef,
-    ref: resolvedTokenRef,
-  } = resolveSecretInputRef({
-    value: params.profile.token,
-    refValue: params.profile.tokenRef,
-    defaults: params.defaults,
-  });
-  if (!resolvedTokenRef) {
-    return;
-  }
-  // Token profiles follow the same precedence contract as API keys: explicit refs win over
-  // plaintext and inline refs are promoted to the dedicated ref field.
-  if (!tokenRef && inlineTokenRef) {
-    params.profile.tokenRef = inlineTokenRef;
-  }
-  if (tokenRef && isNonEmptyString(params.profile.token)) {
-    pushWarning(params.context, {
-      code: "SECRETS_REF_OVERRIDES_PLAINTEXT",
-      path: `${params.agentDir}.auth-profiles.${params.profileId}.token`,
-      message: `auth-profiles ${params.profileId}: tokenRef is set; runtime will ignore plaintext token.`,
-    });
-  }
-  // Only successful runtime materialization may populate the authoritative secret slot.
-  params.profile.token = undefined;
-  const eligibility = resolveAuthProfileEligibility({
-    cfg: params.context.sourceConfig,
-    authAliasLookupParams: params.authAliasLookupParams,
-    store: params.store,
-    provider: params.profile.provider,
-    profileId: params.profileId,
-  });
-  collectAuthStoreSecretInputAssignment({
-    value: resolvedTokenRef,
-    path: `${params.agentDir}.auth-profiles.${params.profileId}.token`,
-    expected: "string",
-    defaults: params.defaults,
-    context: params.context,
-    active: eligibility.eligible,
-    inactiveReason: `auth profile is not eligible (${eligibility.reasonCode}); skipping resolution until it becomes eligible.`,
-    owner: {
-      ownerKind: "account",
-      ownerId: resolveAuthProfileSecretOwnerId(params),
-      requiredForGateway: false,
-      disposition: "isolate",
-      contract: ownerContract,
-    },
-    apply: (value) => {
-      params.profile.token = String(value);
-    },
-    applyUnavailable: () => {
-      params.profile.token = undefined;
+      setValue(undefined);
     },
   });
 }
@@ -207,21 +139,9 @@ export function collectAuthStoreAssignments(params: {
       : {}),
   };
   for (const [profileId, profile] of Object.entries(params.store.profiles)) {
-    if (profile.type === "api_key") {
-      collectApiKeyProfileAssignment({
-        profile: profile as ApiKeyCredentialLike,
-        profileId,
-        store: params.store,
-        agentDir: params.agentDir,
-        defaults,
-        authAliasLookupParams,
-        context: params.context,
-      });
-      continue;
-    }
-    if (profile.type === "token") {
-      collectTokenProfileAssignment({
-        profile: profile as TokenCredentialLike,
+    if (profile.type === "api_key" || profile.type === "token") {
+      collectStaticProfileAssignment({
+        profile,
         profileId,
         store: params.store,
         agentDir: params.agentDir,

--- a/src/secrets/runtime-core-snapshots.test.ts
+++ b/src/secrets/runtime-core-snapshots.test.ts
@@ -413,14 +413,36 @@ describe("secrets runtime snapshot core lanes", () => {
             token: "old-gh",
             tokenRef: { source: "env", provider: "default", id: "GITHUB_TOKEN" },
           },
+          "openai:literal": { type: "api_key", provider: "openai", key: "literal-key" },
+          "custom:literal": { type: "token", provider: "custom", token: "literal-token" },
+          "custom:expired": {
+            type: "token",
+            provider: "custom",
+            expires: 1,
+            tokenRef: { source: "env", provider: "default", id: "FIXTURE_EXPIRED_TOKEN" },
+          },
         }),
     });
 
-    const warningPaths = snapshot.warnings.map((warning) => warning.path);
-    expect(warningPaths).toContain("/tmp/openclaw-agent-main.auth-profiles.openai:default.key");
-    expect(warningPaths).toContain(
-      "/tmp/openclaw-agent-main.auth-profiles.github-copilot:default.token",
-    );
+    expect(snapshot.warnings).toEqual([
+      {
+        code: "SECRETS_REF_OVERRIDES_PLAINTEXT",
+        path: "/tmp/openclaw-agent-main.auth-profiles.openai:default.key",
+        message: "auth-profiles openai:default: keyRef is set; runtime will ignore plaintext key.",
+      },
+      {
+        code: "SECRETS_REF_OVERRIDES_PLAINTEXT",
+        path: "/tmp/openclaw-agent-main.auth-profiles.github-copilot:default.token",
+        message:
+          "auth-profiles github-copilot:default: tokenRef is set; runtime will ignore plaintext token.",
+      },
+      {
+        code: "SECRETS_REF_IGNORED_INACTIVE_SURFACE",
+        path: "/tmp/openclaw-agent-main.auth-profiles.custom:expired.token",
+        message:
+          "/tmp/openclaw-agent-main.auth-profiles.custom:expired.token: auth profile is not eligible (expired); skipping resolution until it becomes eligible.",
+      },
+    ]);
     const openAiProfile = snapshot.authStores[0]?.store.profiles["openai:default"] as
       | Record<string, unknown>
       | undefined;
@@ -431,6 +453,14 @@ describe("secrets runtime snapshot core lanes", () => {
       | undefined;
     expect(copilotProfile?.type).toBe("token");
     expect(copilotProfile?.token).toBe("ghp-env-token");
+    expect(snapshot.authStores[0]?.store.profiles["openai:literal"]).toMatchObject({
+      key: "literal-key",
+    });
+    expect(snapshot.authStores[0]?.store.profiles["custom:literal"]).toMatchObject({
+      token: "literal-token",
+    });
+    expect(snapshot.authStores[0]?.store.profiles["custom:expired"]).not.toHaveProperty("token");
+    expect(snapshot.degradedOwners).toEqual([]);
   });
 
   it("can materialize auth stores without resolving unrelated config refs", async () => {


### PR DESCRIPTION
Closes #145358

<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled.

</details>

## What Problem This Solves

API-key and static-token profiles duplicate the same secret-reference collection sequence. Separate copies make precedence, warnings, eligibility and deferred assignments easier to change inconsistently. This is a maintainer-requested consolidation.

## Why This Change Was Made

One typed collector now serves both profile types, preserving ownership and assignment order. The change removes 74 production code lines; including the strengthened existing test, maintained source shrinks by 44 code lines. The separate assertion ledger loses only the retired two-cast allowance.

## User Impact

No user-visible behavior change is intended. Reference precedence, warning text/order, token expiry, literal credentials and resolved values retain their existing behavior. Update behavior is unchanged: this consolidates in-memory collection and changes no updater, Doctor, service, migration or plugin-loading contract.

## Evidence

The strengthened snapshot test passed before the production change and afterward: the same 46 cases across five files, with no failures or skips. The complete three-file changed gate and `pnpm build` passed. Isolated Codex review returned no findings.

This proof covers the accepted candidate based on `bc21739e1d5e8961277d4775068255fe58f19e3c`. A read-only check against main `abe0065574d313ecde402a953e6fb3d22dfe3ece` confirms the patch applies and the collector, five test files and direct source dependencies are unchanged. Main has newer dependency/tool versions and adjacent plugin-loader changes; the earlier proof is not a test run against that integration state. No live provider/Gateway or published-driver test was run; the new published-driver rule does not apply to this collector-only refactor. [Published-head CI](https://github.com/openclaw/openclaw/actions/runs/34654494549) passed for `40eea605b465fb78b2e4b979e6025ed25cc92518`; the exact-head check rollup is green. The completed ClawSweeper review for that head reports no actionable findings.
