### PR TITLE
fix(state): retain read-only snapshots until native cleanup succeeds

### DIFF
--- a/src/state/openclaw-state-db-cache.ts
+++ b/src/state/openclaw-state-db-cache.ts
@@ -38,11 +38,13 @@ import { assertSupportedStateSchemaVersion } from "./openclaw-state-db-schema-ve
 
 const cachedDatabases = new Map<string, OpenClawStateDatabase>();
 type StateDatabaseHandle = Pick<OpenClawStateDatabase, "db" | "path"> &
-  Partial<Pick<OpenClawStateDatabase, "walMaintenance">>;
+  Partial<Pick<OpenClawStateDatabase, "walMaintenance">> & {
+    afterClose?: () => undefined;
+  };
 type OpenClawStateDatabaseCloseOptions = NonNullable<
   Parameters<OpenClawStateDatabase["walMaintenance"]["close"]>[0]
 > & { busyTimeoutMs?: number };
-// Failed native closes stay disposal-owned, never eligible for a successful cache hit.
+// Failed native closes and dependent cleanup stay disposal-owned, never cache hits.
 const retainedDatabaseHandles = new Map<DatabaseSync, StateDatabaseHandle>();
 let unregisterRetainedExitClose: (() => void) | undefined;
 // Statements retain their native database; key by the plain lifecycle owner so
@@ -112,7 +114,16 @@ function closeOpenClawStateDatabaseHandle(
   } catch (error) {
     errors.push(error);
   }
-  if (database.db.isOpen) {
+  let cleanupPending = false;
+  if (!database.db.isOpen) {
+    try {
+      database.afterClose?.();
+    } catch (error) {
+      errors.push(error);
+      cleanupPending = true;
+    }
+  }
+  if (database.db.isOpen || cleanupPending) {
     retainedDatabaseHandles.set(database.db, database);
     unregisterRetainedExitClose ??= registerSqliteCacheExitClose(closeOpenClawStateDatabase);
   } else {

--- a/src/state/openclaw-state-db-read-connection.ts
+++ b/src/state/openclaw-state-db-read-connection.ts
@@ -1,0 +1,73 @@
+import { openNodeSqliteDatabase } from "../infra/node-sqlite.js";
+import { createSqliteLifecycleAggregateError } from "../infra/sqlite-coordinator.js";
+import type { PreparedSqliteReadOnlyLocation } from "../infra/sqlite-readonly-location.js";
+import { openClawStateDatabaseCache } from "./openclaw-state-db-cache.js";
+import {
+  OPENCLAW_SQLITE_BUSY_TIMEOUT_MS,
+  type OpenClawStateDatabase,
+} from "./openclaw-state-db-contract.js";
+import { openTrackedStateDatabase } from "./openclaw-state-db-handle.js";
+
+export type OpenClawStateReadConnection = {
+  database: Pick<OpenClawStateDatabase, "db" | "path">;
+  close: () => boolean;
+};
+
+class SnapshotCleanupIncompleteError extends Error {}
+
+/** Own one native reader; callers retain their runtime or maintenance schema policy. */
+export function openOpenClawStateReadConnection(
+  pathname: string,
+  source: string | PreparedSqliteReadOnlyLocation,
+): OpenClawStateReadConnection {
+  const snapshot = typeof source === "string" ? undefined : source;
+  const location = typeof source === "string" ? source : source.location;
+  // The first catalog read needs the busy handler; installing a later PRAGMA is too late.
+  const options = { readOnly: true, timeout: OPENCLAW_SQLITE_BUSY_TIMEOUT_MS };
+  let db: OpenClawStateDatabase["db"];
+  try {
+    db =
+      location === pathname
+        ? openTrackedStateDatabase(pathname, options)
+        : openNodeSqliteDatabase(location, options);
+  } catch (error) {
+    snapshot?.cleanup();
+    throw error;
+  }
+  let closed = false;
+  const database = {
+    db,
+    path: pathname,
+    afterClose: (): undefined => {
+      if (snapshot && !snapshot.cleanup()) {
+        throw new SnapshotCleanupIncompleteError("Shared-state snapshot cleanup is incomplete.");
+      }
+      closed = true;
+      return undefined;
+    },
+  };
+  return {
+    database: { db, path: pathname },
+    close() {
+      if (closed) {
+        return false;
+      }
+      // A failed close remains owned for retry, including private snapshot handles.
+      const errors = openClawStateDatabaseCache.closeOpenClawStateDatabaseHandle(database);
+      if (errors.length === 1 && errors[0] instanceof SnapshotCleanupIncompleteError) {
+        return false;
+      }
+      if (errors.length === 1) {
+        throw errors[0];
+      }
+      if (errors.length > 1) {
+        throw createSqliteLifecycleAggregateError(
+          errors,
+          "Shared-state reader cleanup failed.",
+          errors[0],
+        );
+      }
+      return true;
+    },
+  };
+}

--- a/src/state/openclaw-state-db-readonly.ts
+++ b/src/state/openclaw-state-db-readonly.ts
@@ -3,22 +3,20 @@ import { statSync } from "node:fs";
 import path from "node:path";
 import type { DatabaseSync } from "node:sqlite";
 import { isPromiseLike } from "@openclaw/normalization-core/promise-like";
-import { clearNodeSqliteKyselyCacheForDatabase } from "../infra/kysely-sync-cache-state.js";
-import { openNodeSqliteDatabase } from "../infra/node-sqlite.js";
 import { SqliteCoordinatorError } from "../infra/sqlite-coordinator.js";
+import type { PreparedSqliteReadOnlyLocation } from "../infra/sqlite-readonly-location.js";
 import {
   prepareSqliteReadOnlyLocation,
   prepareSqliteReadOnlyLocationSync,
 } from "../infra/sqlite-snapshot-source.js";
 import { resolveGlobalSingleton } from "../shared/global-singleton.js";
 import { openClawStateDatabaseCache } from "./openclaw-state-db-cache.js";
-import {
-  OPENCLAW_SQLITE_BUSY_TIMEOUT_MS,
-  type OpenClawStateDatabaseOptions,
-  type OpenClawStateDatabase,
+import type {
+  OpenClawStateDatabaseOptions,
+  OpenClawStateDatabase,
 } from "./openclaw-state-db-contract.js";
 import { openDanglingWorkshopIndexReadAdmission } from "./openclaw-state-db-dangling-workshop-index.js";
-import { openTrackedStateDatabase } from "./openclaw-state-db-handle.js";
+import { openOpenClawStateReadConnection } from "./openclaw-state-db-read-connection.js";
 import { assertSupportedStateSchemaVersion } from "./openclaw-state-db-schema-version.js";
 import { resolveOpenClawStateSqlitePath } from "./openclaw-state-db.paths.js";
 
@@ -108,20 +106,15 @@ function withFreshOpenClawStateDatabaseReadOnly<T>(
   const prepared = isArtifactPreservingStateRead()
     ? prepareSqliteReadOnlyLocationSync(pathname)
     : undefined;
-  try {
-    return withOpenClawStateReadOnlyLocation(operation, pathname, prepared?.location ?? pathname);
-  } finally {
-    prepared?.cleanup();
-  }
+  return withOpenClawStateReadOnlyLocation(operation, pathname, prepared ?? pathname);
 }
 
-function openOpenClawStateReadOnlyLocation(pathname: string, location: string) {
-  // Install the busy handler before legacy catalog admission reads sqlite_schema.
-  const options = { readOnly: true, timeout: OPENCLAW_SQLITE_BUSY_TIMEOUT_MS };
-  const liveSource = location === pathname;
-  const db = liveSource
-    ? openTrackedStateDatabase(pathname, options)
-    : openNodeSqliteDatabase(location, options);
+function openOpenClawStateReadOnlyLocation(
+  pathname: string,
+  source: string | PreparedSqliteReadOnlyLocation,
+) {
+  const connection = openOpenClawStateReadConnection(pathname, source);
+  const { db } = connection.database;
   let closeSchemaReadAdmission: (() => void) | undefined;
   const close = () => {
     const errors: unknown[] = [];
@@ -130,17 +123,10 @@ function openOpenClawStateReadOnlyLocation(pathname: string, location: string) {
     } catch (error) {
       errors.push(error);
     }
-    if (liveSource) {
-      errors.push(
-        ...openClawStateDatabaseCache.closeOpenClawStateDatabaseHandle({ db, path: pathname }),
-      );
-    } else {
-      try {
-        clearNodeSqliteKyselyCacheForDatabase(db);
-        db.close();
-      } catch (error) {
-        errors.push(error);
-      }
+    try {
+      connection.close();
+    } catch (error) {
+      errors.push(error);
     }
     if (errors.length === 1) {
       throw errors[0];
@@ -156,17 +142,18 @@ function openOpenClawStateReadOnlyLocation(pathname: string, location: string) {
     close();
     throw error;
   }
-  return { database: { db, path: pathname }, close };
+  return { database: connection.database, close };
 }
 
 function withOpenClawStateReadOnlyLocation<T>(
   operation: (database: OpenClawStateReadOnlyDatabase) => T,
   pathname: string,
-  location: string,
+  source: string | PreparedSqliteReadOnlyLocation,
 ): T {
-  const opened = openOpenClawStateReadOnlyLocation(pathname, location);
+  const opened = openOpenClawStateReadOnlyLocation(pathname, source);
   try {
     const result = operation(opened.database);
+    const location = typeof source === "string" ? source : source.location;
     if (location === pathname && isPromiseLike(result)) {
       throw new SqliteCoordinatorError("SQLite source read must remain synchronous");
     }
@@ -272,9 +259,10 @@ export function withExistingOpenClawStateDatabaseArtifactPreservingReadOnlyAsync
     try {
       // Verification can quarantine the live path while the snapshot child is running.
       openClawStateDatabaseCache.assertOpenClawStateDatabaseFreshOpenAllowedAtPath(pathname, env);
-      return withOpenClawStateReadOnlyLocation(operation, pathname, prepared.location);
-    } finally {
+    } catch (error) {
       prepared.cleanup();
+      throw error;
     }
+    return withOpenClawStateReadOnlyLocation(operation, pathname, prepared);
   });
 }

--- a/src/state/openclaw-state-db.test.ts
+++ b/src/state/openclaw-state-db.test.ts
@@ -6186,6 +6186,101 @@ INSERT INTO macos_port_guardian_records VALUES (4242, 18789, '/usr/bin/ssh', 're
     expect(database?.walMaintenance.close()).toBe(false);
   });
 
+  it("retains a read-only snapshot until its failed native close succeeds", async () => {
+    const stateDir = createTempStateDir();
+    const databasePath = materializeCurrentStateDatabase(stateDir);
+    const database = await openExistingOpenClawStateDatabaseReadOnly({ path: databasePath });
+    if (!database) {
+      throw new Error("Expected the existing state snapshot");
+    }
+    const privatePath = database.db.location();
+    if (!privatePath) {
+      throw new Error("Expected a filesystem-backed snapshot");
+    }
+    const privateDirectory = path.dirname(privatePath);
+    const failure = new Error("snapshot native close failed");
+    const close = vi.spyOn(database.db, "close").mockImplementationOnce(() => {
+      throw failure;
+    });
+    try {
+      expect(() => database.walMaintenance.close()).toThrow(failure);
+      expect(database.db.isOpen).toBe(true);
+      expect(fs.existsSync(privateDirectory)).toBe(true);
+      expect(database.walMaintenance.close()).toBe(true);
+      expect(database.db.isOpen).toBe(false);
+      expect(fs.existsSync(privateDirectory)).toBe(false);
+      expect(database.walMaintenance.close()).toBe(false);
+    } finally {
+      close.mockRestore();
+      database.walMaintenance.close();
+    }
+  });
+
+  it("retains refused snapshot cleanup for lifecycle retry without hiding the schema error", async () => {
+    const stateDir = createTempStateDir();
+    const databasePath = materializeCurrentStateDatabase(stateDir);
+    const { DatabaseSync } = requireNodeSqlite();
+    const futureVersion = OPENCLAW_STATE_SCHEMA_VERSION + 1;
+    const source = new DatabaseSync(databasePath);
+    source.exec(`PRAGMA user_version = ${futureVersion}`);
+    source.close();
+    const readers = new Set<DatabaseSync>();
+    let privateDirectory: string | undefined;
+    let refuseClose = true;
+    const sqlite = await import("../infra/node-sqlite.js");
+    const openNative = sqlite.openNodeSqliteDatabase;
+    const open = vi
+      .spyOn(sqlite, "openNodeSqliteDatabase")
+      .mockImplementation((location, options) => {
+        const reader = openNative(location, options);
+        const readerPath = reader.location();
+        if (
+          options?.readOnly &&
+          readerPath &&
+          readerPath !== databasePath &&
+          reader.prepare("PRAGMA user_version").get()?.user_version === futureVersion
+        ) {
+          readers.add(reader);
+          privateDirectory = path.dirname(readerPath);
+          const closeNative = reader.close.bind(reader);
+          reader.close = () => {
+            if (refuseClose) {
+              throw new Error("refused snapshot native close failed");
+            }
+            closeNative();
+          };
+        }
+        return reader;
+      });
+    try {
+      await expect(
+        openExistingOpenClawStateDatabaseReadOnly({ path: databasePath }),
+      ).rejects.toMatchObject({ name: "SqliteSchemaVersionError" });
+      const reader = readers.values().next().value;
+      if (!reader || !privateDirectory) {
+        throw new Error("Expected the refused private snapshot reader");
+      }
+      expect(reader.isOpen).toBe(true);
+      expect(fs.existsSync(privateDirectory)).toBe(true);
+      refuseClose = false;
+      closeOpenClawStateDatabaseForTest();
+      expect(reader.isOpen).toBe(false);
+      expect(fs.existsSync(privateDirectory)).toBe(false);
+    } finally {
+      refuseClose = false;
+      open.mockRestore();
+      try {
+        closeOpenClawStateDatabaseForTest();
+      } finally {
+        for (const reader of readers) {
+          if (reader.isOpen) {
+            reader.close();
+          }
+        }
+      }
+    }
+  });
+
   it("reads committed live WAL rows without changing source database content", async () => {
     const stateDir = createTempStateDir();
     const writer = openOpenClawStateDatabase({ env: { OPENCLAW_STATE_DIR: stateDir } });

--- a/src/state/openclaw-state-db.ts
+++ b/src/state/openclaw-state-db.ts
@@ -62,6 +62,7 @@ import {
 import { openUnpublishedStateDatabase } from "./openclaw-state-db-open.js";
 import * as operatorApprovalMigration from "./openclaw-state-db-operator-approval-migration.js";
 import { ensureOpenClawStatePermissions } from "./openclaw-state-db-permissions.js";
+import { openOpenClawStateReadConnection } from "./openclaw-state-db-read-connection.js";
 import { withExistingOpenClawStateDatabaseReadOnly } from "./openclaw-state-db-readonly.js";
 import {
   ensureAdditiveStateColumns,
@@ -451,17 +452,9 @@ export async function openExistingOpenClawStateDatabaseReadOnly(
   }
   assertOpenClawStateDatabaseFreshOpenAllowed(options);
   const prepared = await prepareSqliteReadOnlyLocation(pathname);
-  let db: DatabaseSync;
+  const connection = openOpenClawStateReadConnection(pathname, prepared);
+  const { db } = connection.database;
   try {
-    db = openNodeSqliteDatabase(prepared.location, {
-      readOnly: true,
-    });
-  } catch (error) {
-    prepared.cleanup();
-    throw error;
-  }
-  try {
-    db.exec(`PRAGMA busy_timeout = ${OPENCLAW_SQLITE_BUSY_TIMEOUT_MS};`);
     assertSupportedStateSchemaVersion(db, pathname);
     assertSqliteIntegrity(db, pathname);
     if (readStateSchemaContentVersion(db) === OPENCLAW_STATE_SCHEMA_VERSION) {
@@ -469,15 +462,12 @@ export async function openExistingOpenClawStateDatabaseReadOnly(
     }
   } catch (error) {
     try {
-      clearNodeSqliteKyselyCacheForDatabase(db);
-      db.close();
+      connection.close();
     } catch {
       // Preserve the verification failure that explains why the database was refused.
     }
-    prepared.cleanup();
     throw error;
   }
-  let cleanupComplete = false;
   return {
     db,
     path: pathname,
@@ -485,21 +475,7 @@ export async function openExistingOpenClawStateDatabaseReadOnly(
       checkpoint: () => false,
       // Cleanup can fail transiently after the database closes. Keep the
       // close contract retryable until one call finishes both responsibilities.
-      close: () => {
-        const wasOpen = db.isOpen;
-        if (!wasOpen && cleanupComplete) {
-          return false;
-        }
-        try {
-          if (wasOpen) {
-            clearNodeSqliteKyselyCacheForDatabase(db);
-            db.close();
-          }
-        } finally {
-          cleanupComplete = prepared.cleanup();
-        }
-        return cleanupComplete;
-      },
+      close: connection.close,
     },
   };
 }


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where read-only shared-state inspection removed its temporary snapshot even when SQLite failed to close the connection. A refused schema or integrity check could also leave an open reader without an owner able to finish cleanup.

## Why This Change Was Made

Runtime and maintenance readers now share the existing native connection-close owner. Snapshot cleanup runs only after the native handle closes, and failed close or artifact cleanup stays retained for lifecycle retry. Runtime schema admission and maintenance integrity validation keep their existing policies, including preservation of the original validation error and the Boolean close/retry contract.

## User Impact

Read-only state inspection retains its snapshot while SQLite still needs it, then releases the handle and temporary files when cleanup succeeds. This change consolidates native reader ownership; it does not move SQLite execution to a worker or change schema, configuration, or dependencies.

## Evidence

Both new entry-point regressions failed on the original base because the snapshot directory disappeared while the native connection remained open, and passed with this fix. The reviewed patch passed 267 applicable owner/sibling tests (one preexisting Linux-only case skipped on macOS), changed-code checks including core and test typechecks, lint, dead exports and schema/import guards, and isolated Codex review with no actionable findings.

Source-native smoke passed on Node 24.20.0, Node 26.8.1, and Bun 1.4.2, covering missing-file behavior, warm/cold read parity, close-failure retention, lifecycle retry, reopen, and file exclusion. The single-commit rebase onto current main is patch-identical; focused close/retry regressions were rerun on the resulting graph. No full package build or worker-execution proof is claimed.

Exact-head [CI run 34654820481](https://github.com/openclaw/openclaw/actions/runs/34654820481) passed. Its first attempt failed an unchanged OpenAI speech timeout case; all four focused timeout cases passed locally, and one unchanged failed-job rerun passed. The native review artifacts and exact-head ClawSweeper review have no actionable findings.
