### PR TITLE
perf(agents): skip preparing discarded terminal answers

### DIFF
--- a/src/agents/embedded-agent-runner/run/payloads.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.ts
@@ -263,103 +263,103 @@ export function buildEmbeddedRunPayloads(params: {
   if (reasoningText) {
     replyItems.push({ text: reasoningText, isReasoning: true });
   }
-  const fallbackAnswerText = assistantForPayload
-    ? extractAssistantVisibleText(assistantForPayload)
-    : "";
-  const fallbackRawAnswerText = resolveRawAssistantAnswerText(assistantForPayload);
-  const rawAnswerDirectiveState = fallbackRawAnswerText
-    ? parseReplyDirectives(fallbackRawAnswerText)
-    : null;
-  const rawAnswerHasMedia =
-    (rawAnswerDirectiveState?.mediaUrls?.length ?? 0) > 0 || rawAnswerDirectiveState?.audioAsVoice;
-  const normalizedAssistantTexts =
-    rawAnswerHasMedia &&
-    nonEmptyAssistantTexts.length > 0 &&
-    !params.assistantTexts.some((text) => {
-      const parsed = parseReplyDirectives(text);
-      return (parsed.mediaUrls?.length ?? 0) > 0 || parsed.audioAsVoice;
-    })
-      ? normalizeTextForComparison(nonEmptyAssistantTexts.join("\n\n"))
-      : "";
-  const shouldPreferRawAnswerText =
-    rawAnswerHasMedia &&
-    (!nonEmptyAssistantTexts.length ||
-      (normalizedAssistantTexts.length > 0 &&
-        normalizedAssistantTexts ===
-          normalizeTextForComparison(rawAnswerDirectiveState?.text ?? "")));
-  // When streamed text lost media directives but the canonical assistant answer
-  // still contains them, keep the raw answer so attachments are not dropped.
-  const fallbackAnswerSourceText =
-    shouldPreferRawAnswerText && fallbackRawAnswerText ? fallbackRawAnswerText : fallbackAnswerText;
-  const fallbackAnswerDirectiveState =
-    fallbackAnswerSourceText === fallbackRawAnswerText
-      ? rawAnswerDirectiveState
-      : fallbackAnswerSourceText
-        ? parseReplyDirectives(fallbackAnswerSourceText)
-        : null;
-  const normalizedFallbackAnswerSourceText = fallbackAnswerDirectiveState
-    ? normalizeTextForComparison(fallbackAnswerDirectiveState.text)
-    : "";
-  const shouldUseCanonicalFinalAnswer =
-    !lastAssistantNeedsErrorSurface &&
-    fallbackAnswerSourceText.length > 0 &&
-    normalizedFallbackAnswerSourceText.length > 0;
-  const hasAssistantTextPayload = nonEmptyAssistantTexts.length > 0;
-  const answerTexts =
-    suppressAssistantArtifacts || runAborted || lastAssistantNeedsErrorSurface
-      ? []
-      : shouldUseCanonicalFinalAnswer
-        ? [fallbackAnswerSourceText]
-        : shouldPreferRawAnswerText && fallbackRawAnswerText
-          ? [fallbackRawAnswerText]
-          : hasAssistantTextPayload
-            ? nonEmptyAssistantTexts
-            : fallbackAnswerText
-              ? [fallbackAnswerText]
-              : [];
-  const preparedAnswerDirectives =
-    shouldUseCanonicalFinalAnswer || shouldPreferRawAnswerText || !hasAssistantTextPayload
-      ? fallbackAnswerDirectiveState
-      : null;
   let hasUserFacingReply =
     Boolean(errorText) ||
     completedSourceReplyViaMessageTool ||
     params.heartbeatToolResponse?.notify === true;
-  for (const text of answerTexts) {
-    const {
-      text: cleanedText,
-      mediaUrls,
-      audioAsVoice,
-      replyToId,
-      replyToTag,
-      replyToCurrent,
-    } = preparedAnswerDirectives ?? parseReplyDirectives(text);
-    const ttsFacts = shouldUseCanonicalFinalAnswer ? storedDelivery?.tts : undefined;
-    const delivery = shouldUseCanonicalFinalAnswer
-      ? {
-          audioAsVoice: storedDelivery?.audioAsVoice,
-          replyToCurrent: storedDelivery?.replyToCurrent,
-          replyToId: storedDelivery?.replyToId,
-          replyToTag: Boolean(storedDelivery?.replyToCurrent || storedDelivery?.replyToId),
-        }
-      : { audioAsVoice, replyToId, replyToTag, replyToCurrent };
-    if (
-      !cleanedText &&
-      (!mediaUrls || mediaUrls.length === 0) &&
-      !delivery.audioAsVoice &&
-      !ttsFacts
-    ) {
-      continue;
+  if (!suppressAssistantArtifacts && !runAborted && !lastAssistantNeedsErrorSurface) {
+    const fallbackAnswerText = assistantForPayload
+      ? extractAssistantVisibleText(assistantForPayload)
+      : "";
+    const fallbackRawAnswerText = resolveRawAssistantAnswerText(assistantForPayload);
+    const rawAnswerDirectiveState = fallbackRawAnswerText
+      ? parseReplyDirectives(fallbackRawAnswerText)
+      : null;
+    const rawAnswerHasMedia =
+      (rawAnswerDirectiveState?.mediaUrls?.length ?? 0) > 0 ||
+      rawAnswerDirectiveState?.audioAsVoice;
+    const normalizedAssistantTexts =
+      rawAnswerHasMedia &&
+      nonEmptyAssistantTexts.length > 0 &&
+      !params.assistantTexts.some((text) => {
+        const parsed = parseReplyDirectives(text);
+        return (parsed.mediaUrls?.length ?? 0) > 0 || parsed.audioAsVoice;
+      })
+        ? normalizeTextForComparison(nonEmptyAssistantTexts.join("\n\n"))
+        : "";
+    const shouldPreferRawAnswerText =
+      rawAnswerHasMedia &&
+      (!nonEmptyAssistantTexts.length ||
+        (normalizedAssistantTexts.length > 0 &&
+          normalizedAssistantTexts ===
+            normalizeTextForComparison(rawAnswerDirectiveState?.text ?? "")));
+    // When streamed text lost media directives but the canonical assistant answer
+    // still contains them, keep the raw answer so attachments are not dropped.
+    const fallbackAnswerSourceText =
+      shouldPreferRawAnswerText && fallbackRawAnswerText
+        ? fallbackRawAnswerText
+        : fallbackAnswerText;
+    const fallbackAnswerDirectiveState =
+      fallbackAnswerSourceText === fallbackRawAnswerText
+        ? rawAnswerDirectiveState
+        : fallbackAnswerSourceText
+          ? parseReplyDirectives(fallbackAnswerSourceText)
+          : null;
+    const normalizedFallbackAnswerSourceText = fallbackAnswerDirectiveState
+      ? normalizeTextForComparison(fallbackAnswerDirectiveState.text)
+      : "";
+    const shouldUseCanonicalFinalAnswer =
+      fallbackAnswerSourceText.length > 0 && normalizedFallbackAnswerSourceText.length > 0;
+    const hasAssistantTextPayload = nonEmptyAssistantTexts.length > 0;
+    const answerTexts = shouldUseCanonicalFinalAnswer
+      ? [fallbackAnswerSourceText]
+      : shouldPreferRawAnswerText && fallbackRawAnswerText
+        ? [fallbackRawAnswerText]
+        : hasAssistantTextPayload
+          ? nonEmptyAssistantTexts
+          : fallbackAnswerText
+            ? [fallbackAnswerText]
+            : [];
+    const preparedAnswerDirectives =
+      shouldUseCanonicalFinalAnswer || shouldPreferRawAnswerText || !hasAssistantTextPayload
+        ? fallbackAnswerDirectiveState
+        : null;
+    for (const text of answerTexts) {
+      const {
+        text: cleanedText,
+        mediaUrls,
+        audioAsVoice,
+        replyToId,
+        replyToTag,
+        replyToCurrent,
+      } = preparedAnswerDirectives ?? parseReplyDirectives(text);
+      const ttsFacts = shouldUseCanonicalFinalAnswer ? storedDelivery?.tts : undefined;
+      const delivery = shouldUseCanonicalFinalAnswer
+        ? {
+            audioAsVoice: storedDelivery?.audioAsVoice,
+            replyToCurrent: storedDelivery?.replyToCurrent,
+            replyToId: storedDelivery?.replyToId,
+            replyToTag: Boolean(storedDelivery?.replyToCurrent || storedDelivery?.replyToId),
+          }
+        : { audioAsVoice, replyToId, replyToTag, replyToCurrent };
+      if (
+        !cleanedText &&
+        (!mediaUrls || mediaUrls.length === 0) &&
+        !delivery.audioAsVoice &&
+        !ttsFacts
+      ) {
+        continue;
+      }
+      const replyPayload = {
+        text: cleanedText,
+        media: mediaUrls,
+        ...delivery,
+      };
+      replyItems.push(
+        ttsFacts ? setReplyPayloadMetadata(replyPayload, { tts: ttsFacts }) : replyPayload,
+      );
+      hasUserFacingReply = true;
     }
-    const replyPayload = {
-      text: cleanedText,
-      media: mediaUrls,
-      ...delivery,
-    };
-    replyItems.push(
-      ttsFacts ? setReplyPayloadMetadata(replyPayload, { tts: ttsFacts }) : replyPayload,
-    );
-    hasUserFacingReply = true;
   }
   if (params.lastToolError) {
     // A restart intentionally aborts the active tool while the Gateway takes over.


### PR DESCRIPTION
## What Problem This Solves

OpenClaw still prepares assistant answers after existing delivery rules have already determined that those answers will not be emitted. Suppressed, aborted, and failed turns can therefore spend time extracting and parsing discarded answer text.

## Why This Change Was Made

Move the existing answer eligibility condition before answer preparation, then remove the redundant empty-answer branch and error predicate inside it. Keep reasoning, errors, warnings, tool replies, usage bookkeeping, and normal answer delivery in their existing owners. Production line count is unchanged.

## User Impact

Less terminal-processing work when an assistant answer is suppressed or discarded. Output content, order, metadata, and delivery eligibility remain unchanged. This is a scoped optimization, not a general provider or Gateway latency claim.

## Evidence

Four fresh Linux/Node 24.19.0 processes exercised the actual terminal-preparation entry point with 54 cases at 4/32/128 KiB, two warmups and seven measured calls per case: 1,944 calls total. All complete input/result graphs matched, including undefined values, own-key order, aliases and reply metadata; the lead independently decoded and compared all 162 cross-phase graph pairs.

All 33 non-emission cases improved in both orders. At 128 KiB, suppressed completion improved from 3.245 to 1.118 ms and 2.178 to 1.191 ms; provider-error processing improved from 12.233 to 0.796 ms and 8.521 to 0.728 ms.

Controls are mixed and retained. Ordinary 4 KiB and 32 KiB answers regressed in both orders by about 1–3 microseconds and 19–75 microseconds respectively. Ordinary 128 KiB answers improved 2.6% in one order and regressed 26.9% in the other. Responses and media controls also changed direction. Whole-process wall/RSS results were mixed; there is no general memory claim. The comparison used an earlier pinned main with unchanged terminal owner source; author-base dependency updates are not attributed to this patch.

All 153 existing tests across the six payload, error, recovery, terminal-preparation and media files passed on the author base. Independent Codex review is clean through P2. Thirteen selected changed-check stages completed before the fixed supervisor's cumulative process cap interrupted the core tsgo boundary; later gates are not claimed as completed. One child lacked closure confirmation, so the retained Testbox was explicitly stopped after its complete failure archive was downloaded and hash-verified. No timeout, assertion, resource limit or source change was used to force validation. Exact-head hosted CI remains required before landing.

The changelog is release-owned; this PR preserves the scoped performance context for release notes.
