### PR TITLE
fix: report config failures after saving accurately

### DIFF
--- a/docs/cli/config.md
+++ b/docs/cli/config.md
@@ -556,6 +556,11 @@ Effective changes to `plugins.entries` (or any subpath) require a restart, since
 
 `openclaw config set` and other OpenClaw-owned config writers validate the full post-change config before committing it to disk. If the new payload fails schema validation or looks like a destructive clobber, the active config is left alone and the rejected payload is saved beside it as `openclaw.json.rejected.*`.
 
+If the file is saved but later processing fails, the error names the written file
+and reports whether the write was rolled back. This can name an included file
+when that file owns the edited setting. If rollback did not happen or could not
+be confirmed, inspect the named file and the active config before retrying.
+
 OpenClaw-owned writes that change config reserialize JSON5 as standard JSON. When the source contains comments, the writer warns immediately before removing them; use a direct editor when preserving comments matters.
 
 <Warning>

--- a/docs/cli/doctor/running.md
+++ b/docs/cli/doctor/running.md
@@ -28,9 +28,14 @@ For read-only diagnosis, use `--lint` or bare `--json`. Ordinary `doctor`, inclu
 
 When ordinary `doctor` asks **Apply recommended config repairs now?**, it checks
 that the selected root config file still matches the source of that proposal.
-If its contents or selected path changed, Doctor preserves the newer file,
+If its contents or selected path changed before the write, Doctor preserves the newer file,
 leaves the pending config fixes unwritten, and exits with an error. Rerun
 `openclaw doctor` to review an updated proposal.
+
+If saving succeeds but later processing fails, Doctor stops with an error, names
+the file that was written, and reports whether the write was rolled back. When it was not rolled
+back or recovery could not be confirmed, inspect that file and the active config
+before rerunning Doctor.
 
 If the shared state database uses a newer schema, Doctor refuses before offering
 an interactive update because update admission also needs that database. Run

--- a/src/cli/update-cli/update-command-rollback.test-support.ts
+++ b/src/cli/update-cli/update-command-rollback.test-support.ts
@@ -1,0 +1,65 @@
+import fs from "node:fs";
+import { expect } from "vitest";
+import { setRuntimeConfigSnapshotRefreshHandler, writeConfigFile } from "../../config/config.js";
+import { hashConfigRaw } from "../../config/io.read-helpers.js";
+import type { ConfigWriteOptions } from "../../config/io.types.js";
+import type { ConfigFileSnapshot, OpenClawConfig } from "../../config/types.js";
+import type { UpdateRunResult } from "../../infra/update-runner.js";
+import type { UpdateConfigSnapshot } from "./update-command-config-snapshot.js";
+
+export async function writeWithRefreshFailure(
+  nextConfig: OpenClawConfig,
+  writeOptions: ConfigWriteOptions & { baseSnapshot: ConfigFileSnapshot },
+  originalRaw: string,
+): Promise<Error> {
+  const configPath = writeOptions.baseSnapshot.path;
+  let doctorError: Error | undefined;
+  setRuntimeConfigSnapshotRefreshHandler({
+    preflight: () => undefined,
+    refresh: () => {
+      expect(JSON.parse(fs.readFileSync(configPath, "utf8"))).toMatchObject({
+        meta: { migrations: { modelPolicyAllowlist: true } },
+        wizard: { lastRunCommand: "doctor" },
+      });
+      throw new Error("Doctor runtime activation refused");
+    },
+  });
+  try {
+    await writeConfigFile(nextConfig, writeOptions);
+  } catch (error) {
+    if (!(error instanceof Error)) {
+      throw error;
+    }
+    doctorError = error;
+  } finally {
+    setRuntimeConfigSnapshotRefreshHandler(null);
+  }
+  if (!doctorError) {
+    throw new Error("Doctor config write completed without the expected refresh failure");
+  }
+  expect(doctorError).toMatchObject({
+    name: "ConfigWritePostCommitError",
+    configPath,
+    rollbackStatus: "restored",
+  });
+  expect(fs.readFileSync(configPath, "utf8")).toBe(originalRaw);
+  return doctorError;
+}
+
+export function expectDoctorRollback(
+  activationConfig: UpdateConfigSnapshot | undefined,
+  result: UpdateRunResult,
+  configPath: string,
+  originalRaw: string,
+): void {
+  expect(activationConfig).toMatchObject({
+    path: configPath,
+    raw: originalRaw,
+    hash: hashConfigRaw(originalRaw),
+    doctorOwned: true,
+  });
+  expect(result).toMatchObject({
+    status: "error",
+    recovery: { serviceRestartSafe: true, packageRollbackVerified: true },
+  });
+}

--- a/src/cli/update-cli/update-command-rollback.test.ts
+++ b/src/cli/update-cli/update-command-rollback.test.ts
@@ -9,6 +9,7 @@ import { stopChildProcess } from "../../../test/helpers/stop-child-process.js";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import { createConfigIO } from "../../config/config.js";
 import { hashConfigRaw } from "../../config/io.read-helpers.js";
+import type { OpenClawConfig } from "../../config/types.js";
 import { FILE_LOCK_TIMEOUT_ERROR_CODE, withFileLock } from "../../infra/file-lock.js";
 import { readUpdateStateSchemaVersions } from "../../infra/update-candidate-state.js";
 import {
@@ -475,7 +476,7 @@ describe("verified package rollback", () => {
             const io = createConfigIO({ env: process.env, pluginValidation: "skip" });
             const input = await io.readConfigFileSnapshot();
             if (change !== "doctor-unchanged") {
-              const nextConfig = {
+              const nextConfig: OpenClawConfig = {
                 ...(input.sourceConfigBeforeMigrations ?? input.sourceConfig),
                 meta: {
                   migrations: { modelPolicyAllowlist: true },

--- a/src/cli/update-cli/update-command-rollback.test.ts
+++ b/src/cli/update-cli/update-command-rollback.test.ts
@@ -64,6 +64,10 @@ import * as updateShared from "./shared.js";
 import { inspectActivatedUpdateState } from "./update-command-migrated.js";
 import * as packageModule from "./update-command-package.js";
 import { rollbackFailedUpdate } from "./update-command-rollback.js";
+import {
+  expectDoctorRollback,
+  writeWithRefreshFailure,
+} from "./update-command-rollback.test-support.js";
 import { completeUpdateCommandRun } from "./update-command-run.js";
 import { resolveUpdateResultNextAction } from "./update-recovery-guidance.js";
 
@@ -350,6 +354,7 @@ describe("verified package rollback", () => {
         ]),
     { change: "doctor", previousVerified: true, restored: true, service: "stopped" },
     { change: "doctor-unchanged", previousVerified: true, restored: true, service: "stopped" },
+    { change: "doctor-compensated", previousVerified: true, restored: true, service: "stopped" },
     { change: "doctor-missing-input", previousVerified: true, restored: false, service: "stopped" },
     { change: "doctor-include", previousVerified: true, restored: true, service: "stopped" },
     { change: "doctor-include-edit", previousVerified: true, restored: false, service: "stopped" },
@@ -446,7 +451,7 @@ describe("verified package rollback", () => {
       }
       const result: UpdateRunResult = {
         status: "error",
-        reason: "version-mismatch",
+        reason: change === "doctor-compensated" ? "doctor-failed" : "version-mismatch",
         mode: "npm",
         root: change === "unknown-runtime" ? undefined : candidateRoot,
         before: { version: "2026.9.1" },
@@ -459,6 +464,7 @@ describe("verified package rollback", () => {
       if (change.startsWith("doctor")) {
         fs.writeFileSync(path.join(candidateRoot, "dist/entry.js"), "export {};\n");
         vi.spyOn(updateShared, "runUpdateStep").mockImplementationOnce(async (step) => {
+          let doctorError: Error | undefined;
           if (change === "doctor-input-edit") {
             fs.writeFileSync(
               configPath,
@@ -469,27 +475,30 @@ describe("verified package rollback", () => {
             const io = createConfigIO({ env: process.env, pluginValidation: "skip" });
             const input = await io.readConfigFileSnapshot();
             if (change !== "doctor-unchanged") {
-              await io.writeConfigFile(
-                {
-                  ...(input.sourceConfigBeforeMigrations ?? input.sourceConfig),
-                  meta: {
-                    migrations: { modelPolicyAllowlist: true },
-                    lastTouchedVersion: "2026.9.3",
-                  },
-                  agents: {
-                    defaults: {
-                      ...authored.agents.defaults,
-                      modelPolicy: { allow: ["openai/gpt-5.6-luna"] },
-                    },
-                  },
-                  wizard: { lastRunVersion: "2026.9.3", lastRunCommand: "doctor" },
+              const nextConfig = {
+                ...(input.sourceConfigBeforeMigrations ?? input.sourceConfig),
+                meta: {
+                  migrations: { modelPolicyAllowlist: true },
+                  lastTouchedVersion: "2026.9.3",
                 },
-                {
-                  baseSnapshot: input,
-                  lastTouchedVersionOverride: "2026.9.3",
-                  skipPluginValidation: true,
+                agents: {
+                  defaults: {
+                    ...authored.agents.defaults,
+                    modelPolicy: { allow: ["openai/gpt-5.6-luna"] },
+                  },
                 },
-              );
+                wizard: { lastRunVersion: "2026.9.3", lastRunCommand: "doctor" },
+              };
+              const writeOptions = {
+                baseSnapshot: input,
+                lastTouchedVersionOverride: "2026.9.3",
+                skipPluginValidation: true,
+              };
+              if (change === "doctor-compensated") {
+                doctorError = await writeWithRefreshFailure(nextConfig, writeOptions, originalRaw);
+              } else {
+                await io.writeConfigFile(nextConfig, writeOptions);
+              }
             }
             if (change === "doctor-capture-edit") {
               operatorEdit();
@@ -497,7 +506,7 @@ describe("verified package rollback", () => {
             await writeUpdatePostInstallDoctorResult({
               resultPath: step.env!.OPENCLAW_UPDATE_POST_INSTALL_DOCTOR_RESULT_PATH!,
               result: {
-                status: "ok",
+                status: doctorError ? "error" : "ok",
                 configHash: capture.hash,
                 ...(change === "doctor-missing-input"
                   ? {}
@@ -510,10 +519,11 @@ describe("verified package rollback", () => {
             command: "doctor",
             cwd: candidateRoot,
             durationMs: 1,
-            exitCode: 0,
+            exitCode: doctorError ? 1 : 0,
+            ...(doctorError ? { stderrTail: doctorError.message } : {}),
           };
         });
-        await packageModule.runPackageUpdateDoctor({
+        const doctorStep = await packageModule.runPackageUpdateDoctor({
           root: candidateRoot,
           timeoutMs: 1_000,
           progress: {},
@@ -522,6 +532,17 @@ describe("verified package rollback", () => {
             activationConfig = snapshot;
           },
         });
+        if (change === "doctor-compensated") {
+          if (!doctorStep) {
+            throw new Error("Doctor compensation did not return an update step");
+          }
+          expect(doctorStep).toMatchObject({
+            exitCode: 1,
+            stderrTail: expect.stringContaining("Doctor runtime activation refused"),
+          });
+          expect(doctorStep.advisory).toBeUndefined();
+          result.steps.push(doctorStep);
+        }
         expect(fs.readFileSync(`${configPath}.pre-update`, "utf8")).toBe(originalRaw);
         const inspected = { ...result, status: "ok" as const };
         expect(
@@ -678,7 +699,12 @@ describe("verified package rollback", () => {
         expect(rollback).toHaveBeenCalledOnce();
         expect(fs.readFileSync(configPath, "utf8")).toBe(originalRaw);
       }
-      if (change === "doctor" || change === "doctor-unchanged" || change === "doctor-include") {
+      if (
+        change === "doctor" ||
+        change === "doctor-unchanged" ||
+        change === "doctor-compensated" ||
+        change === "doctor-include"
+      ) {
         expect(fs.readFileSync(configPath, "utf8")).toBe(originalRaw);
         if (process.platform !== "win32") {
           expect(fs.statSync(configPath).mode & 0o777).toBe(0o600);
@@ -702,6 +728,7 @@ describe("verified package rollback", () => {
           change === "readonly-config" ||
           change === "doctor" ||
           change === "doctor-unchanged" ||
+          change === "doctor-compensated" ||
           change === "doctor-include" ||
           change === "doctor-restore-edit" ||
           change === "identity-read-failed" ||
@@ -729,8 +756,11 @@ describe("verified package rollback", () => {
         expect(outcome.result).toMatchObject({
           root: previousRoot,
           after: result.before,
-          reason: "version-mismatch",
+          reason: change === "doctor-compensated" ? "doctor-failed" : "version-mismatch",
         });
+        if (change === "doctor-compensated") {
+          expectDoctorRollback(activationConfig, outcome.result, configPath, originalRaw);
+        }
         expect(mocks.stop.mock.invocationCallOrder[0]).toBeLessThan(
           rollback.mock.invocationCallOrder[0]!,
         );

--- a/src/commands/doctor-config-flow.conflict.test.ts
+++ b/src/commands/doctor-config-flow.conflict.test.ts
@@ -1,3 +1,4 @@
+import fsNode from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -42,6 +43,7 @@ describe("Doctor repair confirmation conflicts", () => {
   afterEach(() => {
     noteMock.mockClear();
     closeOpenClawStateDatabaseForTest();
+    vi.restoreAllMocks();
   });
 
   it.each([
@@ -137,6 +139,104 @@ describe("Doctor repair confirmation conflicts", () => {
           expectConflictWarning();
         });
       });
+    });
+  });
+
+  it("reports a saved repair when the preferred config appears during post-write audit metadata", async () => {
+    await withDoctorConfigPreflightHome(async (home) => {
+      const stateDir = path.join(home, "doctor-state");
+      const configPath = path.join(stateDir, "clawdbot.json");
+      const preferredPath = path.join(stateDir, "openclaw.json");
+      await fs.mkdir(stateDir);
+      const config = createRepairableConfig(home);
+      const original = JSON.stringify(config, null, 2);
+      const preferred = JSON.stringify(
+        {
+          ...config,
+          browser: { enabled: false },
+          logging: { ...config.logging, level: "debug" },
+        },
+        null,
+        2,
+      );
+      await fs.writeFile(configPath, original);
+
+      await withEnvAsync(
+        {
+          OPENCLAW_CONFIG_PATH: undefined,
+          OPENCLAW_PROFILE: undefined,
+          OPENCLAW_STATE_DIR: stateDir,
+          OPENCLAW_TEST_FAST: undefined,
+          OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+        },
+        async () => {
+          let confirmationShown = false;
+          const ctx = await prepareDoctorContext(configPath, {
+            options: {},
+            confirm: async ({ message }) => {
+              expect(message).toBe("Apply recommended config repairs now?");
+              confirmationShown = true;
+              return true;
+            },
+          });
+          expect(confirmationShown).toBe(true);
+
+          let committed = false;
+          let preferredCheckedAfterRename = false;
+          let sourceRecheckedAfterRename = false;
+          let preferredCreated = false;
+          const rename = fsNode.promises.rename.bind(fsNode.promises);
+          vi.spyOn(fsNode.promises, "rename").mockImplementation(async (source, destination) => {
+            await rename(source, destination);
+            if (destination === configPath) {
+              committed = true;
+            }
+          });
+          const existsSync = fsNode.existsSync.bind(fsNode);
+          vi.spyOn(fsNode, "existsSync").mockImplementation((target) => {
+            const exists = existsSync(target);
+            if (committed && target === preferredPath && !exists) {
+              preferredCheckedAfterRename = true;
+            }
+            if (preferredCheckedAfterRename && target === configPath && exists) {
+              sourceRecheckedAfterRename = true;
+            }
+            return exists;
+          });
+          const stat = fsNode.promises.stat.bind(fsNode.promises);
+          vi.spyOn(fsNode.promises, "stat").mockImplementation(async (...args) => {
+            const result = await stat(...args);
+            // Skip the atomic primitive's publication verification; the first
+            // ownership check must pass before the later audit stat loses selection.
+            if (sourceRecheckedAfterRename && !preferredCreated && args[0] === configPath) {
+              await fs.writeFile(preferredPath, preferred, { flag: "wx" });
+              preferredCreated = true;
+            }
+            return result;
+          });
+
+          const failure = await runInitialConfigWriteHealth(ctx).catch((error: unknown) => error);
+
+          expect(preferredCreated).toBe(true);
+          const saved = JSON.parse(await fs.readFile(configPath, "utf8"));
+          expect(saved.browser).toEqual({ enabled: false });
+          expect(saved.logging.level).toBe("info");
+          await expect(fs.readFile(preferredPath, "utf8")).resolves.toBe(preferred);
+          await expect(fs.readFile(`${configPath}.bak`, "utf8")).resolves.toBe(original);
+          expect(failure).toBeInstanceOf(Error);
+          expect(failure).toMatchObject({
+            name: "ConfigWritePostCommitError",
+            configPath,
+            rollbackStatus: "not-restored",
+          });
+          expect(failure).toHaveProperty("message", expect.stringContaining("was written"));
+          const warnings = noteMock.mock.calls
+            .filter(([, title]) => title === "Doctor warnings")
+            .map(([message]) => message)
+            .join("\n");
+          expect(warnings).not.toContain("config fixes were not written");
+        },
+      );
     });
   });
 });

--- a/src/commands/doctor-gateway-services.test.ts
+++ b/src/commands/doctor-gateway-services.test.ts
@@ -6,6 +6,7 @@ import { err, ok, type Result } from "@openclaw/normalization-core/result";
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
+import { ConfigWritePostCommitError } from "../config/io.write-errors.js";
 import type { LaunchctlResult } from "../daemon/launchd-exec.js";
 import { withEnvAsync } from "../test-utils/env.js";
 import { withTempDir } from "../test-utils/temp-dir.js";
@@ -936,6 +937,39 @@ describe("maybeRepairGatewayServiceConfig", () => {
       expect(mocks.install).toHaveBeenCalledTimes(1);
     });
   });
+
+  it.each(["ordinary", "post-commit"] as const)(
+    "stops service repair after a %s token persistence error",
+    async (kind) => {
+      await withEnvAsync({ OPENCLAW_GATEWAY_TOKEN: "env-token" }, async () => {
+        setupGatewayTokenRepairScenario();
+        const cfg: OpenClawConfig = { gateway: {} };
+        const runtime = makeDoctorIo();
+        const cause = new Error("token persistence failed");
+        const failure =
+          kind === "post-commit"
+            ? new ConfigWritePostCommitError({
+                configPath: "/tmp/openclaw.json",
+                rollbackStatus: "not-restored",
+                cause,
+              })
+            : cause;
+        mocks.replaceConfigFile.mockRejectedValueOnce(failure);
+
+        const repair = maybeRepairGatewayServiceConfig(cfg, "local", runtime, makeDoctorPrompts());
+        if (kind === "post-commit") {
+          await expect(repair).rejects.toBe(failure);
+        } else {
+          await expect(repair).resolves.toBe(cfg);
+          expect(runtime.error).toHaveBeenCalledWith(
+            expect.stringContaining("Failed to persist gateway.auth.token before service repair:"),
+          );
+        }
+        expect(mocks.stage).not.toHaveBeenCalled();
+        expect(mocks.install).not.toHaveBeenCalled();
+      });
+    },
+  );
 
   it("does not flag entrypoint mismatch when symlink and realpath match", async () => {
     setupGatewayEntrypointRepairScenario({

--- a/src/commands/doctor-gateway-services.ts
+++ b/src/commands/doctor-gateway-services.ts
@@ -9,6 +9,7 @@ import {
 import { SUPPORTED_NODE_VERSIONS } from "../../node-version.mjs";
 import { note } from "../../packages/terminal-core/src/note.js";
 import { replaceConfigFile, type OpenClawConfig } from "../config/config.js";
+import { ConfigWritePostCommitError } from "../config/io.write-errors.js";
 import { isDefaultInstallIdentity, resolveGatewayPort, resolveIsNixMode } from "../config/paths.js";
 import { resolveSecretInputRef } from "../config/types.secrets.js";
 import { formatGatewayHeapLimitReport, inspectGatewayHeapLimit } from "../daemon/gateway-heap.js";
@@ -919,6 +920,9 @@ export async function maybeRepairGatewayServiceConfig(
         "Gateway",
       );
     } catch (err) {
+      if (err instanceof ConfigWritePostCommitError) {
+        throw err;
+      }
       runtime.error(`Failed to persist gateway.auth.token before service repair: ${String(err)}`);
       return cfg;
     }

--- a/src/config/io.runtime.ts
+++ b/src/config/io.runtime.ts
@@ -23,6 +23,7 @@ import type {
   ReadConfigFileSnapshotWithPluginMetadataResult,
 } from "./io.types.js";
 import { ConfigRuntimeRefreshError, configWritePostCommitRollback } from "./io.types.js";
+import { ConfigWritePostCommitError, type ConfigWriteRollbackStatus } from "./io.write-errors.js";
 import { rollbackConfigFileWriteIfUnchanged } from "./io.write-safety.js";
 import { formatConfigIssueSummary } from "./issue-format.js";
 import { ConfigMutationConflictError } from "./mutation-conflict.js";
@@ -453,12 +454,12 @@ async function finalizeCommittedConfigWrite(params: {
     }
     if (!stableEnvGeneration) {
       canonicalReadFailure = new ConfigRuntimeRefreshError(
-        `Config was written to ${io.configPath}, but the active config environment changed during every canonical reread`,
+        "the active config environment changed during every canonical reread",
       );
     }
   } catch (error) {
     canonicalReadFailure = new ConfigRuntimeRefreshError(
-      `Config was written to ${io.configPath}, but the canonical reread failed: ${formatErrorMessage(error)}`,
+      `canonical reread failed: ${formatErrorMessage(error)}`,
       { cause: error },
     );
   } finally {
@@ -520,12 +521,10 @@ async function finalizeCommittedConfigWrite(params: {
       preflightResult: params.runtimePreflightResult,
       deferRuntimeActivation,
       createRefreshError: (detail, cause) =>
-        new ConfigRuntimeRefreshError(
-          `Config was written to ${io.configPath}, but runtime snapshot refresh failed: ${detail}`,
-          { cause },
-        ),
+        new ConfigRuntimeRefreshError(`runtime snapshot refresh failed: ${detail}`, { cause }),
     });
   } catch (error) {
+    let rollbackStatus: ConfigWriteRollbackStatus = "unknown";
     try {
       const rolledBackConfig = await rollbackConfigFileWriteIfUnchanged({
         configPath: io.configPath,
@@ -534,6 +533,7 @@ async function finalizeCommittedConfigWrite(params: {
         fsModule: fs,
         assertCurrent: params.assertPostCommitCurrent,
       });
+      rollbackStatus = rolledBackConfig ? "restored" : "not-restored";
       if (rolledBackConfig) {
         restoreEnvChangesIfUnchanged({
           env: io.env,
@@ -543,12 +543,21 @@ async function finalizeCommittedConfigWrite(params: {
         params.rollbackWriteEffects?.();
       }
     } catch (rollbackError) {
-      throw new ConfigRuntimeRefreshError(
-        `${formatErrorMessage(error)} Rollback failed: ${formatErrorMessage(rollbackError)}`,
-        { cause: error },
-      );
+      throw new ConfigWritePostCommitError({
+        configPath: io.configPath,
+        rollbackStatus,
+        cause: new AggregateError(
+          [error, rollbackError],
+          `${formatErrorMessage(error)} Recovery failed: ${formatErrorMessage(rollbackError)}`,
+          { cause: rollbackError },
+        ),
+      });
     }
-    throw error;
+    throw new ConfigWritePostCommitError({
+      configPath: io.configPath,
+      rollbackStatus,
+      cause: error,
+    });
   }
   return writeResult;
 }

--- a/src/config/io.runtime.ts
+++ b/src/config/io.runtime.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import { formatErrorMessage } from "../infra/errors.js";
+import { recordUpdateDoctorConfigWrite } from "../infra/update-doctor-result.js";
 import { cloneEnvWithPlatformSemantics, createConfigRuntimeEnvBase } from "./config-env-vars.js";
 import { resolveManagedUnsetPathsForWrite } from "./config-path-mutation.js";
 import { assertConfigWriteAllowedInCurrentMode } from "./config-write-guard.js";
@@ -8,6 +9,7 @@ import { GATEWAY_CONFIG_SELECTION_ENV_KEYS } from "./gateway-env-selection.js";
 import { createConfigIO } from "./io.factory.js";
 import {
   createManagedRuntimeEnvBase,
+  hashConfigRaw,
   replaceEnvSnapshot,
   resolveManagedRuntimeEnvBaseline,
   restoreEnvChangesIfUnchanged,
@@ -535,6 +537,12 @@ async function finalizeCommittedConfigWrite(params: {
       });
       rollbackStatus = rolledBackConfig ? "restored" : "not-restored";
       if (rolledBackConfig) {
+        params.assertPostCommitCurrent?.();
+        recordUpdateDoctorConfigWrite(
+          io.configPath,
+          writeResult.persistedHash,
+          hashConfigRaw(baseSnapshot.raw),
+        );
         restoreEnvChangesIfUnchanged({
           env: io.env,
           before: envBeforeCanonicalRead,

--- a/src/config/io.write-config.test.ts
+++ b/src/config/io.write-config.test.ts
@@ -1666,9 +1666,15 @@ describe("config io write", () => {
         { baseSnapshot: snapshot, assertConfigPathForWrite },
       );
       await expect(pending).rejects.toThrow("config path changed since last load");
-      await expect(pending).rejects.toBeInstanceOf(ConfigMutationConflictError);
-      await expect(pending).rejects.toHaveProperty("retryable", false);
-      await expect(pending).rejects.toBe(originalConflict);
+      const failure = await pending.catch((error: unknown) => error);
+      expect(failure).toMatchObject({
+        name: "ConfigWritePostCommitError",
+        configPath,
+        rollbackStatus: "restored",
+        cause: expect.any(ConfigMutationConflictError),
+      });
+      expect(failure).toHaveProperty("cause.retryable", false);
+      expect(requireRecord(failure, "post-commit config write error").cause).toBe(originalConflict);
 
       await expect(fs.readFile(configPath, "utf-8")).resolves.toBe(originalRaw);
       expect(listConfigAuditRecordsForTests({ env: io.env, homedir: () => home })).toEqual(
@@ -4119,8 +4125,14 @@ describe("config io write", () => {
         },
       );
       await expect(pending).rejects.toThrow("config path changed since last load");
-      await expect(pending).rejects.toBeInstanceOf(ConfigMutationConflictError);
-      await expect(pending).rejects.toHaveProperty("retryable", false);
+      const failure = await pending.catch((error: unknown) => error);
+      expect(failure).toMatchObject({
+        name: "ConfigWritePostCommitError",
+        configPath,
+        rollbackStatus: "restored",
+        cause: expect.any(ConfigMutationConflictError),
+      });
+      expect(failure).toHaveProperty("cause.retryable", false);
 
       expect(rollbackReadUsedInjectedFs).toBe(true);
       await expect(fs.readFile(configPath, "utf-8")).resolves.toBe(initialRaw);

--- a/src/config/io.write-errors.ts
+++ b/src/config/io.write-errors.ts
@@ -1,8 +1,36 @@
 // Formats stable user-facing config write failures.
+import { formatErrorMessage } from "../infra/errors.js";
 import type { ConfigValidationIssue } from "./types.js";
 
 const CONFIG_VALIDATION_FAILED_CODE = "CONFIG_VALIDATION_FAILED";
 const CONFIG_INCLUDE_OWNERSHIP_CODE = "CONFIG_INCLUDE_OWNERSHIP";
+
+export type ConfigWriteRollbackStatus = "restored" | "not-restored" | "unknown";
+
+/** A completed file write must not be handled as a retryable pre-write refusal. */
+export class ConfigWritePostCommitError extends Error {
+  readonly configPath: string;
+  readonly rollbackStatus: ConfigWriteRollbackStatus;
+
+  constructor(params: {
+    configPath: string;
+    rollbackStatus: ConfigWriteRollbackStatus;
+    cause: unknown;
+  }) {
+    const recovery = {
+      restored: "The config write was rolled back.",
+      "not-restored": "The write was not rolled back. Inspect the current config before retrying.",
+      unknown: "Rollback could not be confirmed. Inspect the current config before retrying.",
+    }[params.rollbackStatus];
+    super(
+      `Config was written to ${params.configPath}, but post-write processing failed: ${formatErrorMessage(params.cause)}\n${recovery}`,
+      { cause: params.cause },
+    );
+    this.name = "ConfigWritePostCommitError";
+    this.configPath = params.configPath;
+    this.rollbackStatus = params.rollbackStatus;
+  }
+}
 
 function hasConfigWriteErrorCode(error: unknown, code: string): error is Error {
   return (

--- a/src/config/io.write-reread.test.ts
+++ b/src/config/io.write-reread.test.ts
@@ -182,6 +182,11 @@ describe("writeConfigFile canonical reread", () => {
             },
           ).catch((error: unknown) => error);
           expect(failure).toBeInstanceOf(Error);
+          expect(failure).toMatchObject({
+            name: "ConfigWritePostCommitError",
+            configPath,
+            rollbackStatus: revoke ? "unknown" : "restored",
+          });
           expect(failure).toHaveProperty(
             "message",
             expect.stringMatching(/runtime snapshot refresh failed/),
@@ -268,15 +273,28 @@ describe("writeConfigFile canonical reread", () => {
               : writer === "runtime"
                 ? writeConfigFile(nextConfig, options)
                 : replaceConfigFile({ snapshot, writeOptions: options, nextConfig });
-          await expect(pending).rejects.toThrow(
-            writer === "direct" ? /config path changed/ : /runtime snapshot refresh failed/,
+          const failure = await pending.catch((error: unknown) => error);
+          expect(failure).toBeInstanceOf(Error);
+          expect(failure).toMatchObject({
+            name: "ConfigWritePostCommitError",
+            configPath,
+            rollbackStatus: authority === "ordinary" ? "restored" : "unknown",
+          });
+          expect(failure).toHaveProperty(
+            "message",
+            expect.stringMatching(
+              writer === "direct" ? /config path changed/ : /runtime snapshot refresh failed/,
+            ),
           );
           if (writer === "direct") {
-            await expect(pending).rejects.toBeInstanceOf(ConfigMutationConflictError);
-            await expect(pending).rejects.toMatchObject({
-              message: "config path changed since last load",
-              retryable: false,
-            });
+            expect(failure).toHaveProperty("cause", expect.any(ConfigMutationConflictError));
+            expect(failure).toHaveProperty(
+              "cause",
+              expect.objectContaining({
+                message: "config path changed since last load",
+                retryable: false,
+              }),
+            );
             expect(listConfigAuditRecordsForTests({ env: io.env, homedir: () => home })).toEqual(
               priorAudit,
             );

--- a/src/config/io.write-reread.test.ts
+++ b/src/config/io.write-reread.test.ts
@@ -7,6 +7,7 @@ import {
   releaseUpdateCommandPreflightForHandoff,
   withUpdateCommandExecutor,
 } from "../cli/update-cli/update-command-executor.js";
+import { captureUpdateDoctorConfigWrites } from "../infra/update-doctor-result.js";
 import {
   captureManagedUpdateLeaseDatabaseIdentity,
   createManagedHandoffLeaseDatabase,
@@ -16,6 +17,7 @@ import { withEnvAsync } from "../test-utils/env.js";
 import { readConfigSnapshotAuditRecord } from "./config-journal-snapshot.js";
 import { listConfigAuditRecordsForTests } from "./io.audit.test-support.js";
 import { createConfigIO } from "./io.factory.js";
+import { hashConfigRaw } from "./io.read-helpers.js";
 import { readConfigFileSnapshotForWrite, writeConfigFile } from "./io.runtime.js";
 import type { ConfigWriteOptions } from "./io.types.js";
 import { replaceConfigFile } from "./mutate.js";
@@ -171,16 +173,22 @@ describe("writeConfigFile canonical reread", () => {
             },
           });
 
-          const failure = await writeConfigFile(
-            { gateway: { mode: "local", port: 19001 } },
-            {
-              ...writeOptions,
-              assertCurrent,
-              baseSnapshot: snapshot,
-              observe: false,
-              skipPluginValidation: true,
+          const { failure, capture } = await captureUpdateDoctorConfigWrites(
+            configPath,
+            async (writeCapture) => {
+              const writeFailure = await writeConfigFile(
+                { gateway: { mode: "local", port: 19001 } },
+                {
+                  ...writeOptions,
+                  assertCurrent,
+                  baseSnapshot: snapshot,
+                  observe: false,
+                  skipPluginValidation: true,
+                },
+              ).catch((error: unknown) => error);
+              return { failure: writeFailure, capture: writeCapture };
             },
-          ).catch((error: unknown) => error);
+          );
           expect(failure).toBeInstanceOf(Error);
           expect(failure).toMatchObject({
             name: "ConfigWritePostCommitError",
@@ -208,6 +216,9 @@ describe("writeConfigFile canonical reread", () => {
               await expect(fs.stat(configPath)).rejects.toMatchObject({ code: "ENOENT" });
             }
           }
+          expect(capture.hash).toBe(
+            hashConfigRaw(revoke ? String(committedRaw) : existed ? original : null),
+          );
         }),
       );
     },

--- a/src/config/io.write.ts
+++ b/src/config/io.write.ts
@@ -61,7 +61,11 @@ import type {
 } from "./io.types.js";
 import { ConfigRuntimeRefreshError, configWritePostCommitRollback } from "./io.types.js";
 import { logConfigWarningsOnce } from "./io.warnings.js";
-import { createConfigValidationFailedError } from "./io.write-errors.js";
+import {
+  ConfigWritePostCommitError,
+  createConfigValidationFailedError,
+  type ConfigWriteRollbackStatus,
+} from "./io.write-errors.js";
 import { resolvePersistCandidateForWrite } from "./io.write-prepare.js";
 import {
   assertBaseSnapshotStillCurrent,
@@ -454,6 +458,8 @@ export async function writeConfigFileFromContext(
     });
   await preCommitRuntimePreflight(sourceConfigForPreflight);
 
+  let committed = false;
+  let rollbackStatus: ConfigWriteRollbackStatus = "not-restored";
   try {
     const beforeCommit = options.beforeCommit;
     const guardedFs = createGuardedConfigFileSystem(
@@ -512,23 +518,27 @@ export async function writeConfigFileFromContext(
         });
       },
     });
+    committed = true;
     try {
       options.assertConfigPathForWrite?.();
     } catch (error) {
       try {
         // A post-publication refusal cannot grant a stale executor compensation.
         sourceGuard?.();
-        await rollbackConfigFileWriteIfUnchanged({
+        const rolledBack = await rollbackConfigFileWriteIfUnchanged({
           configPath,
           previousSnapshot: snapshot,
           committedHash: nextHash,
           fsModule: deps.fs,
           assertCurrent: sourceGuard,
         });
+        rollbackStatus = rolledBack ? "restored" : "not-restored";
       } catch (rollbackError) {
-        throw new ConfigRuntimeRefreshError(
-          `${formatErrorMessage(error)} Rollback failed: ${formatErrorMessage(rollbackError)}`,
-          { cause: error },
+        rollbackStatus = "unknown";
+        throw new AggregateError(
+          [error, rollbackError],
+          `${formatErrorMessage(error)} Recovery failed: ${formatErrorMessage(rollbackError)}`,
+          { cause: rollbackError },
         );
       }
       throw error;
@@ -620,25 +630,41 @@ export async function writeConfigFileFromContext(
       },
     };
   } catch (error) {
+    let failure = error;
     try {
-      sourceGuard?.();
-    } catch (ownershipError) {
-      if (ownershipError === error) {
+      try {
+        sourceGuard?.();
+      } catch (ownershipError) {
+        if (ownershipError === error) {
+          throw error;
+        }
+        throw new AggregateError(
+          [error, ownershipError],
+          "Config write failed after source ownership changed",
+          { cause: ownershipError },
+        );
+      }
+      try {
+        writeOptions.assertConfigPathForWrite?.();
+      } catch {
+        // Lost path provenance forbids auditing, but does not replace the original failure.
         throw error;
       }
-      throw new AggregateError(
-        [error, ownershipError],
-        "Config write failed after source ownership changed",
-        { cause: ownershipError },
-      );
+      try {
+        await appendWriteAudit("failed", error);
+      } catch (auditError) {
+        throw new AggregateError(
+          [error, auditError],
+          `${formatErrorMessage(error)} Failure auditing failed: ${formatErrorMessage(auditError)}`,
+          { cause: auditError },
+        );
+      }
+    } catch (failureDuringAudit) {
+      failure = failureDuringAudit;
     }
-    try {
-      writeOptions.assertConfigPathForWrite?.();
-    } catch {
-      // Lost path provenance forbids auditing, but does not replace the original failure.
-      throw error;
+    if (!committed) {
+      throw failure;
     }
-    await appendWriteAudit("failed", error);
-    throw error;
+    throw new ConfigWritePostCommitError({ configPath, rollbackStatus, cause: failure });
   }
 }

--- a/src/config/mutate.test.ts
+++ b/src/config/mutate.test.ts
@@ -1450,7 +1450,21 @@ describe("config mutate helpers", () => {
         await write;
         expect(JSON.parse(await fs.readFile(leafPath, "utf-8"))).toEqual(nextConfig.plugins);
       } else {
-        await expect(write).rejects.toThrow(ConfigMutationConflictError);
+        if (changeAt === "reread") {
+          await expect(write).rejects.toBeInstanceOf(Error);
+          await expect(write).rejects.not.toBeInstanceOf(ConfigMutationConflictError);
+          await expect(write).rejects.toMatchObject({
+            name: "ConfigWritePostCommitError",
+            configPath: leafPath,
+            rollbackStatus: "restored",
+            cause: expect.objectContaining({
+              name: "ConfigMutationConflictError",
+              retryable: true,
+            }),
+          });
+        } else {
+          await expect(write).rejects.toThrow(ConfigMutationConflictError);
+        }
         await expect(fs.readFile(leafPath, "utf-8")).resolves.toBe(leafRaw);
       }
       await expect(fs.readFile(configPath, "utf-8")).resolves.toBe(rootRaw);
@@ -2591,26 +2605,37 @@ describe("config mutate helpers", () => {
       }
     };
 
-    await expect(
-      replaceConfigFile({
-        baseHash: snapshot.hash,
-        snapshot,
-        writeOptions: {
-          expectedConfigPath: snapshot.path,
-          assertConfigPathForWrite,
-          includeFileTargetsForWrite: { [pluginsPath]: await resolveIncludeTarget(pluginsPath) },
-        },
-        nextConfig: {
-          plugins: {
-            entries: {
-              demo: { enabled: true },
-            },
+    const operation = replaceConfigFile({
+      baseHash: snapshot.hash,
+      snapshot,
+      writeOptions: {
+        expectedConfigPath: snapshot.path,
+        assertConfigPathForWrite,
+        includeFileTargetsForWrite: { [pluginsPath]: await resolveIncludeTarget(pluginsPath) },
+      },
+      nextConfig: {
+        plugins: {
+          entries: {
+            demo: { enabled: true },
           },
         },
+      },
+    });
+    await expect(operation).rejects.toBeInstanceOf(Error);
+    await expect(operation).rejects.not.toBeInstanceOf(ConfigMutationConflictError);
+    await expect(operation).rejects.toMatchObject({
+      name: "ConfigWritePostCommitError",
+      configPath: pluginsPath,
+      rollbackStatus: "restored",
+      cause: expect.objectContaining({
+        name: "ConfigMutationConflictError",
+        message: "config path changed since last load",
       }),
-    ).rejects.toThrow("config path changed since last load");
+    });
 
     await expect(fs.readFile(pluginsPath, "utf-8")).resolves.toBe(initialPluginsRaw);
+    await expect(fs.readFile(`${pluginsPath}.bak`, "utf-8")).resolves.toBe(initialPluginsRaw);
+    await expect(fs.readFile(configPath, "utf-8")).resolves.toBe(snapshot.raw);
   });
 
   it.each(["active path", "refreshed snapshot path"] as const)(
@@ -2657,23 +2682,95 @@ describe("config mutate helpers", () => {
         };
       });
 
-      await expect(
-        replaceConfigFile({
-          baseHash: snapshot.hash,
-          snapshot,
-          io: { ...ioMocks, env: {} },
-          writeOptions: {
-            expectedConfigPath: snapshot.path,
-            assertConfigPathForWrite,
-            includeFileTargetsForWrite: { [pluginsPath]: await resolveIncludeTarget(pluginsPath) },
-          },
-          nextConfig,
+      const operation = replaceConfigFile({
+        baseHash: snapshot.hash,
+        snapshot,
+        io: { ...ioMocks, env: {} },
+        writeOptions: {
+          expectedConfigPath: snapshot.path,
+          assertConfigPathForWrite,
+          includeFileTargetsForWrite: { [pluginsPath]: await resolveIncludeTarget(pluginsPath) },
+        },
+        nextConfig,
+      });
+      await expect(operation).rejects.toBeInstanceOf(Error);
+      await expect(operation).rejects.not.toBeInstanceOf(ConfigMutationConflictError);
+      await expect(operation).rejects.toMatchObject({
+        name: "ConfigWritePostCommitError",
+        configPath: pluginsPath,
+        rollbackStatus: "restored",
+        cause: expect.objectContaining({
+          name: "ConfigMutationConflictError",
+          message: "config path changed since last load",
         }),
-      ).rejects.toThrow("config path changed since last load");
+      });
 
       await expect(fs.readFile(pluginsPath, "utf-8")).resolves.toBe(initialPluginsRaw);
+      await expect(fs.readFile(`${pluginsPath}.bak`, "utf-8")).resolves.toBe(initialPluginsRaw);
+      await expect(fs.readFile(configPath, "utf-8")).resolves.toBe(snapshot.raw);
     },
   );
+
+  it("does not retry a committed include write after its post-write read conflicts", async () => {
+    const home = await suiteRootTracker.make("include-post-write-retry");
+    const { configPath, pluginsPath } = await createPluginIncludeFixture(home);
+    const initialPluginsRaw = `${JSON.stringify({ entries: {} }, null, 2)}\n`;
+    await fs.writeFile(pluginsPath, initialPluginsRaw, "utf-8");
+    const concurrentRootRaw = `${JSON.stringify(
+      {
+        plugins: { $include: "./config/plugins.json5" },
+        logging: { level: "debug" },
+      },
+      null,
+      2,
+    )}\n`;
+    const env = { ...process.env };
+    const io = createActualConfigIO({
+      configPath,
+      env,
+      observe: false,
+      pluginValidation: "skip",
+    });
+    let savedRootEdit = false;
+    const readConfigFileSnapshotForWrite: ConfigIOReadForWrite = async (options) => {
+      if (!savedRootEdit && (await fs.readFile(pluginsPath, "utf-8")) !== initialPluginsRaw) {
+        await fs.writeFile(configPath, concurrentRootRaw, "utf-8");
+        savedRootEdit = true;
+      }
+      return await io.readConfigFileSnapshotForWrite(options);
+    };
+    const transform = vi.fn((config: OpenClawConfig) => ({
+      nextConfig: {
+        ...config,
+        plugins: {
+          ...config.plugins,
+          entries: { ...config.plugins?.entries, demo: { enabled: true } },
+        },
+      },
+    }));
+
+    const operation = transformConfigFileWithRetry({
+      io: { ...io, env, readConfigFileSnapshotForWrite },
+      writeOptions: { observe: false, skipPluginValidation: true },
+      transform,
+    });
+    await expect(operation).rejects.toBeInstanceOf(Error);
+    await expect(operation).rejects.not.toBeInstanceOf(ConfigMutationConflictError);
+    await expect(operation).rejects.toMatchObject({
+      name: "ConfigWritePostCommitError",
+      configPath: pluginsPath,
+      rollbackStatus: "restored",
+      cause: expect.objectContaining({
+        name: "ConfigMutationConflictError",
+        message: "config changed while preparing include write",
+      }),
+    });
+    expect(transform).toHaveBeenCalledOnce();
+    await expect(fs.readFile(configPath, "utf-8")).resolves.toBe(concurrentRootRaw);
+    await expect(fs.readFile(pluginsPath, "utf-8")).resolves.toBe(initialPluginsRaw);
+    await expect(fs.readFile(`${pluginsPath}.bak`, "utf-8")).resolves.toBe(initialPluginsRaw);
+    await expect(fs.stat(`${pluginsPath}.bak.1`)).rejects.toMatchObject({ code: "ENOENT" });
+  });
 
   it.runIf(process.platform !== "win32")(
     "does not create a missing include through a parent symlink swapped during preflight",
@@ -3007,31 +3104,41 @@ describe("config mutate helpers", () => {
         writeOptions: { expectedConfigPath: configPath },
       };
     });
+    const refreshError = new Error("lost include secret");
 
     try {
       delete env[envKey];
       setRuntimeConfigSnapshotRefreshHandler({
         preflight: () => true,
         refresh: () => {
-          throw new Error("lost include secret");
+          throw refreshError;
         },
       });
 
-      await expect(
-        replaceConfigFile({
-          baseHash: snapshot.hash,
-          snapshot,
-          io: { ...ioMocks, env },
-          writeOptions: {
-            expectedConfigPath: snapshot.path,
-            assertConfigPathForWrite: allowConfigPathWrite,
-            includeFileTargetsForWrite: { [pluginsPath]: await resolveIncludeTarget(pluginsPath) },
-          },
-          nextConfig,
-        }),
-      ).rejects.toThrow(/runtime snapshot refresh failed: lost include secret/);
+      const operation = replaceConfigFile({
+        baseHash: snapshot.hash,
+        snapshot,
+        io: { ...ioMocks, env },
+        writeOptions: {
+          expectedConfigPath: snapshot.path,
+          assertConfigPathForWrite: allowConfigPathWrite,
+          includeFileTargetsForWrite: { [pluginsPath]: await resolveIncludeTarget(pluginsPath) },
+        },
+        nextConfig,
+      });
+      await expect(operation).rejects.toBeInstanceOf(Error);
+      await expect(operation).rejects.not.toBeInstanceOf(ConfigMutationConflictError);
+      await expect(operation).rejects.toMatchObject({
+        name: "ConfigWritePostCommitError",
+        configPath: pluginsPath,
+        rollbackStatus: "restored",
+        message: expect.stringMatching(/runtime snapshot refresh failed: lost include secret/),
+        cause: expect.objectContaining({ cause: refreshError }),
+      });
 
       await expect(fs.readFile(pluginsPath, "utf-8")).resolves.toBe(initialPluginsRaw);
+      await expect(fs.readFile(`${pluginsPath}.bak`, "utf-8")).resolves.toBe(initialPluginsRaw);
+      await expect(fs.readFile(configPath, "utf-8")).resolves.toBe(snapshot.raw);
       expect(env[envKey]).toBeUndefined();
     } finally {
       setRuntimeConfigSnapshotRefreshHandler(null);
@@ -3042,7 +3149,8 @@ describe("config mutate helpers", () => {
   it("does not overwrite concurrent include edits during failed refresh rollback", async () => {
     const home = await suiteRootTracker.make("include-runtime-refresh-concurrent");
     const { configPath, pluginsPath } = await createPluginIncludeFixture(home);
-    await fs.writeFile(pluginsPath, `${JSON.stringify({ entries: {} }, null, 2)}\n`, "utf-8");
+    const initialPluginsRaw = `${JSON.stringify({ entries: {} }, null, 2)}\n`;
+    await fs.writeFile(pluginsPath, initialPluginsRaw, "utf-8");
     const concurrentPluginsRaw = `${JSON.stringify(
       { entries: { concurrent: { enabled: true } } },
       null,
@@ -3070,30 +3178,40 @@ describe("config mutate helpers", () => {
       }),
       writeOptions: { expectedConfigPath: configPath },
     });
+    const refreshError = new Error("lost include secret");
 
     try {
       setRuntimeConfigSnapshotRefreshHandler({
         preflight: () => true,
         refresh: async () => {
           await fs.writeFile(pluginsPath, concurrentPluginsRaw, "utf-8");
-          throw new Error("lost include secret");
+          throw refreshError;
         },
       });
 
-      await expect(
-        replaceConfigFile({
-          baseHash: snapshot.hash,
-          snapshot,
-          writeOptions: {
-            expectedConfigPath: snapshot.path,
-            assertConfigPathForWrite: allowConfigPathWrite,
-            includeFileTargetsForWrite: { [pluginsPath]: await resolveIncludeTarget(pluginsPath) },
-          },
-          nextConfig,
-        }),
-      ).rejects.toThrow(/runtime snapshot refresh failed: lost include secret/);
+      const operation = replaceConfigFile({
+        baseHash: snapshot.hash,
+        snapshot,
+        writeOptions: {
+          expectedConfigPath: snapshot.path,
+          assertConfigPathForWrite: allowConfigPathWrite,
+          includeFileTargetsForWrite: { [pluginsPath]: await resolveIncludeTarget(pluginsPath) },
+        },
+        nextConfig,
+      });
+      await expect(operation).rejects.toBeInstanceOf(Error);
+      await expect(operation).rejects.not.toBeInstanceOf(ConfigMutationConflictError);
+      await expect(operation).rejects.toMatchObject({
+        name: "ConfigWritePostCommitError",
+        configPath: pluginsPath,
+        rollbackStatus: "not-restored",
+        message: expect.stringMatching(/runtime snapshot refresh failed: lost include secret/),
+        cause: expect.objectContaining({ cause: refreshError }),
+      });
 
       await expect(fs.readFile(pluginsPath, "utf-8")).resolves.toBe(concurrentPluginsRaw);
+      await expect(fs.readFile(`${pluginsPath}.bak`, "utf-8")).resolves.toBe(initialPluginsRaw);
+      await expect(fs.readFile(configPath, "utf-8")).resolves.toBe(snapshot.raw);
     } finally {
       setRuntimeConfigSnapshotRefreshHandler(null);
     }

--- a/src/config/mutate.ts
+++ b/src/config/mutate.ts
@@ -52,6 +52,7 @@ import {
   rejectConfigNonFiniteNumbers,
   resolveManagedRuntimeEnvBaseline,
 } from "./io.read-helpers.js";
+import { ConfigWritePostCommitError, type ConfigWriteRollbackStatus } from "./io.write-errors.js";
 import { injectExplicitlySetPaths, projectConfigWriteSource } from "./io.write-prepare.js";
 import { warnIfJSON5CommentsWillBeStripped } from "./json5-comments.js";
 import {
@@ -727,12 +728,30 @@ async function writeRootBoundJsonFile(params: {
     await params.assertIncludeGraphForWrite(hashConfigIncludeRaw(content));
     params.assertConfigPathForWrite();
   } catch (error) {
-    await rollbackJsonFileWriteIfUnchanged({
-      target: targetAtCommit,
-      previousRaw: currentRaw,
-      committedHash: hashConfigIncludeRaw(content),
+    let rollbackStatus: ConfigWriteRollbackStatus = "unknown";
+    try {
+      const rolledBack = await rollbackJsonFileWriteIfUnchanged({
+        target: targetAtCommit,
+        previousRaw: currentRaw,
+        committedHash: hashConfigIncludeRaw(content),
+      });
+      rollbackStatus = rolledBack ? "restored" : "not-restored";
+    } catch (rollbackError) {
+      throw new ConfigWritePostCommitError({
+        configPath: targetAtCommit.absolutePath,
+        rollbackStatus,
+        cause: new AggregateError(
+          [error, rollbackError],
+          `${formatErrorMessage(error)} Recovery failed: ${formatErrorMessage(rollbackError)}`,
+          { cause: rollbackError },
+        ),
+      });
+    }
+    throw new ConfigWritePostCommitError({
+      configPath: targetAtCommit.absolutePath,
+      rollbackStatus,
+      cause: error,
     });
-    throw error;
   }
 }
 
@@ -968,7 +987,7 @@ async function tryWriteIncludeOwnedConfigMutation(params: {
         }
         if (!persistedHash) {
           throw new Error(
-            `Config was written to ${params.snapshot.path}, but no persisted hash was available.`,
+            `No persisted config hash was available after rereading ${params.snapshot.path}.`,
           );
         }
 
@@ -1022,19 +1041,18 @@ async function tryWriteIncludeOwnedConfigMutation(params: {
           deferRuntimeActivation,
           formatRefreshError: (error) => formatErrorMessage(error),
           createRefreshError: (detail, cause) =>
-            new Error(
-              `Config was written to ${params.snapshot.path}, but runtime snapshot refresh failed: ${detail}`,
-              { cause },
-            ),
+            new Error(`runtime snapshot refresh failed: ${detail}`, { cause }),
         });
         return { persistedHash, persistedConfig: refreshedSnapshot.sourceConfig };
       } catch (error) {
+        let rollbackStatus: ConfigWriteRollbackStatus = "unknown";
         try {
           const rolledBack = await rollbackJsonFileWriteIfUnchanged({
             target: includeTarget,
             previousRaw: previousIncludeRaw,
             committedHash: committedIncludeHash,
           });
+          rollbackStatus = rolledBack ? "restored" : "not-restored";
           if (rolledBack) {
             restoreEnvChangesIfUnchanged({
               env: writeEnv,
@@ -1043,12 +1061,21 @@ async function tryWriteIncludeOwnedConfigMutation(params: {
             });
           }
         } catch (rollbackError) {
-          throw new Error(
-            `${formatErrorMessage(error)} Rollback failed: ${formatErrorMessage(rollbackError)}`,
-            { cause: rollbackError },
-          );
+          throw new ConfigWritePostCommitError({
+            configPath: includeTarget.absolutePath,
+            rollbackStatus,
+            cause: new AggregateError(
+              [error, rollbackError],
+              `${formatErrorMessage(error)} Recovery failed: ${formatErrorMessage(rollbackError)}`,
+              { cause: rollbackError },
+            ),
+          });
         }
-        throw error;
+        throw new ConfigWritePostCommitError({
+          configPath: includeTarget.absolutePath,
+          rollbackStatus,
+          cause: error,
+        });
       }
     },
     writeEnv,

--- a/src/flows/doctor-health-contributions.test.ts
+++ b/src/flows/doctor-health-contributions.test.ts
@@ -4,6 +4,7 @@ import nodePath from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createDoctorConfigSnapshot } from "../commands/doctor-config-snapshot.test-helpers.js";
 import type { DoctorPrompter } from "../commands/doctor-prompter.js";
+import { ConfigWritePostCommitError } from "../config/io.write-errors.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { LEGACY_SECRETREF_ENV_MARKER_PREFIX } from "../config/types.secrets.js";
 import { fetchNpmPackageTargetStatus } from "../infra/update-check-package-target.js";
@@ -960,6 +961,35 @@ describe("doctor health contributions", () => {
       "doctor:test-failure run failed: media migration required",
     ]);
     expect(mocks.note).toHaveBeenCalledBefore(laterRun);
+  });
+
+  it("stops after an optional contribution fails after writing config", async () => {
+    const laterRun = vi.fn(async () => undefined);
+    const ctx = createDoctorContext({ env: {} });
+    const failure = new ConfigWritePostCommitError({
+      configPath: ctx.configPath,
+      rollbackStatus: "not-restored",
+      cause: new Error("config path changed since last load"),
+    });
+
+    await expect(
+      runDoctorHealthContributionList(ctx, [
+        createDoctorHealthContribution({
+          id: "doctor:test-config-write",
+          label: "Test config write",
+          run: async () => {
+            throw failure;
+          },
+        }),
+        createDoctorHealthContribution({
+          id: "doctor:test-later",
+          label: "Test later",
+          run: laterRun,
+        }),
+      ]),
+    ).rejects.toBe(failure);
+
+    expect(laterRun).not.toHaveBeenCalled();
   });
 
   it("rejects a failed initial config write before later work runs", async () => {

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -4,6 +4,7 @@ import fs from "node:fs";
 import { isDeepStrictEqual } from "node:util";
 import { shouldManageGatewayService } from "../commands/doctor-service-repair-policy.js";
 import { emitDoctorNotes } from "../commands/doctor/emit-notes.js";
+import { ConfigWritePostCommitError } from "../config/io.write-errors.js";
 import {
   DoctorStateMigrationRefusalError,
   throwIfDoctorStateMigrationRefused,
@@ -563,7 +564,11 @@ async function runDoctorHealthContributionList(
         return;
       }
     } catch (error) {
-      if (contribution.required || error instanceof DoctorStateMigrationRefusalError) {
+      if (
+        contribution.required ||
+        error instanceof DoctorStateMigrationRefusalError ||
+        error instanceof ConfigWritePostCommitError
+      ) {
         throw error;
       }
       const { note } = await loadNoteModule();


### PR DESCRIPTION
Related: #145140

## What Problem This Solves

Doctor could report that accepted config repairs were not written after the file had already been saved. Creating a preferred config path during post-save processing, for example, left the repair in the originally selected file but produced a no-write warning. An optional repair could also swallow a failure after saving and continue with a misleading completion.

## Why This Change Was Made

Config write owners now distinguish a completed file write from a refusal before saving. Failures after a root or included-file save carry the actual target, original cause, and file rollback outcome through runtime refresh and Doctor; they cannot enter the pre-write conflict retry path. Existing write authority, outside-edit checks, rollback timing, and ordinary recoverable warnings remain in place.

When runtime finalization restores the failed write's previous config, Doctor records those restored bytes in the existing updater receipt. This prevents an updater from misclassifying Doctor's own restoration as an outside edit. No updater protocol fields or rollback admission rules change.

## User Impact

Doctor stops when processing fails after saving and reports whether that write was restored, was not restored, or could not be confirmed. Operators can inspect the named file and active config before retrying. Other config-writer callers receive the same outcome reporting. CLI and Doctor documentation explain the distinction.

During an update, restored config remains eligible for normal package and service recovery when the existing ownership and compatibility checks pass. The failed Doctor step remains an error even when recovery succeeds. If a database migration prevents package rollback, the compatible candidate stays installed and the Gateway stays stopped. Restoration of one failed config write does not undo earlier successful repairs; the original whole-update config remains in the pre-update backup.

## Evidence

- The real Doctor CLI reproduced the false no-write warning on base `bad814efcab67d2c9c2057a2a9db176e9292f1ed`. The repaired legacy file, exact original backup, and newer preferred config were checked independently. The corrected flow exits 1, identifies the saved file and not-rolled-back outcome, and preserves all three expected contents.
- The original baseline regression run exposed exactly 19 expected failures. The updater correction separately reproduced two stale restored-hash failures and one refused recovery on the previous implementation, with 49 controls passing and no skips.
- All 896 affected cases across nine test files pass remotely on `65aad57846fe5f9ce5b5554a3b4710a8f3d8058d`, including missing-file restoration, revoked ownership, and outside-edit controls. Final head `1af1a56220417670697381df55074db0030dc59a` adds only an erased type import and config annotation to the rollback test; an independent comparison confirms byte-identical emitted JavaScript and unchanged production source. The complete remote changed-path gate passes on that final head, including all 17 core-test type graphs, production types, lint, formatting, docs, and boundaries.
- The published `openclaw@2026.9.3` updater successfully installed the immutable candidate. A subsequent manual Gateway start reported the matching candidate version/build ID and passed live/ready probes. Three legacy sessions migrated, with config and plugin state preserved.
- A second real published-updater cell used the proposed merge with main `8cf6001608a203dfd7f56a357cc97952d52d656a` (tree `939adf68e0469edaab8a794b38acf00ce0581325`). A filesystem-only fault after saving made Doctor and the ordinary update command exit 1. The error named the written file and confirmed that write was rolled back; actual config bytes and the updater receipt agreed. Read-only observations proved agent database schema 19 before Doctor and schema 20 before the fault and afterward. The candidate package remained installed, the Gateway was stopped, and session, transcript, cron, workspace, and pre-update backup data were preserved. The update reported `state-migrated-no-rollback` with `serviceRestartSafe: false`. This was an unpublished verification composition, not a release.
- Fresh source review found no actionable P0–P2 defects. [Final-head hosted CI](https://github.com/openclaw/openclaw/actions/runs/34659508797) completed with its affected tests and static checks passing. Its sole underlying failure was the independently reproduced main-branch UI startup-size budget failure, tracked separately by #145430; this patch changes no UI or budget inputs.

The regression covers failures after the filesystem writer returns successfully. It does not redefine uncertain failures inside the filesystem primitive or extend Doctor's proposal guard to later writes.
