### PR TITLE
fix(ci): resolve performance targets with split config schemas

### DIFF
--- a/.github/workflows/openclaw-performance.yml
+++ b/.github/workflows/openclaw-performance.yml
@@ -122,6 +122,7 @@ jobs:
           sparse-checkout: |
             package.json
             src/config/zod-schema.agent-defaults.ts
+            src/config/zod-schema.agent-defaults-base.ts
           sparse-checkout-cone-mode: false
           fetch-depth: 1
           persist-credentials: false
@@ -174,6 +175,14 @@ jobs:
 
           if [[ -z "$kova_ref" || -z "$kova_config_contract" ]]; then
             schema_path="${TARGET_CHECKOUT_DIR}/src/config/zod-schema.agent-defaults.ts"
+            # Follow the shipped composition only when the wrapper has no inline contract.
+            if [[ -f "$schema_path" ]] &&
+              ! grep -Fqx '    mediaModels: z' "$schema_path" &&
+              ! grep -Fqx '    imageGenerationModel: AgentToolModelSchema.optional(),' "$schema_path" &&
+              grep -Fqx 'import { AgentDefaultsBaseSchema } from "./zod-schema.agent-defaults-base.js";' "$schema_path" &&
+              grep -Fqx 'export const AgentDefaultsSchema = AgentDefaultsBaseSchema.safeExtend({' "$schema_path"; then
+              schema_path="${TARGET_CHECKOUT_DIR}/src/config/zod-schema.agent-defaults-base.ts"
+            fi
             if [[ -f "$schema_path" ]]; then
               schema_content="$(cat "$schema_path")"
             elif [[ -z "$kova_ref" ]]; then

--- a/test/scripts/openclaw-performance-workflow.test.ts
+++ b/test/scripts/openclaw-performance-workflow.test.ts
@@ -1,5 +1,5 @@
 // Openclaw Performance Workflow tests cover openclaw performance workflow script behavior.
-import { spawnSync } from "node:child_process";
+import { execFileSync, spawnSync } from "node:child_process";
 import {
   chmodSync,
   existsSync,
@@ -82,6 +82,90 @@ function findStep(name: string, job = "kova"): WorkflowStep {
 
 function kovaMatrixEntries(): Array<Record<string, string>> {
   return readWorkflow().jobs?.kova?.strategy?.matrix?.include ?? [];
+}
+
+function runTargetMetadataResolution({
+  schema,
+  baseSchema,
+  version = "2026.9.4",
+  kovaRef = "",
+  contract = "",
+}: {
+  schema?: string;
+  baseSchema?: string;
+  version?: string;
+  kovaRef?: string;
+  contract?: string;
+}) {
+  const root = tempDirs.make("openclaw-kova-target-metadata-");
+  const git = (...args: string[]) =>
+    execFileSync("git", ["-c", "core.hooksPath=/dev/null", ...args], {
+      cwd: root,
+      encoding: "utf8",
+      stdio: ["pipe", "pipe", "pipe"],
+    }).trim();
+  mkdirSync(join(root, "src/config"), { recursive: true });
+  writeFileSync(join(root, "package.json"), JSON.stringify({ version }));
+  writeFileSync(join(root, "unselected.ts"), 'throw new Error("unselected source executed");\n');
+  for (const [name, content] of [
+    ["agent-defaults", schema],
+    ["agent-defaults-base", baseSchema],
+  ] as const) {
+    if (content !== undefined) {
+      writeFileSync(
+        join(root, `src/config/zod-schema.${name}.ts`),
+        `throw new Error("target metadata executed");\n${content}`,
+      );
+    }
+  }
+  git("init", "-q");
+  git("add", ".");
+  git(
+    "-c",
+    "user.name=Fixture",
+    "-c",
+    "user.email=fixture@example.com",
+    "-c",
+    "commit.gpgsign=false",
+    "commit",
+    "-qm",
+    "target metadata",
+  );
+  const sha = git("rev-parse", "HEAD");
+  const checkout = findStep("Checkout target metadata", "resolve_target");
+  execFileSync("git", ["sparse-checkout", "set", "--no-cone", "--stdin"], {
+    cwd: root,
+    encoding: "utf8",
+    input: checkout.with?.["sparse-checkout"],
+  });
+  expect(existsSync(join(root, "unselected.ts"))).toBe(false);
+  expect(existsSync(join(root, "node_modules"))).toBe(false);
+  const output = join(root, "output");
+  const step = findStep("Resolve OpenClaw target ref", "resolve_target");
+  const result = spawnSync("bash", ["-c", step.run ?? ""], {
+    cwd: root,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      ...readWorkflow().env,
+      CI_GIT_OWNER: resolvePath(".github/actions/git-owner/owner.py"),
+      GITHUB_OUTPUT: output,
+      GITHUB_REF_NAME: "main",
+      KOVA_REF_INPUT: kovaRef,
+      KOVA_CONFIG_CONTRACT_INPUT: contract,
+      TARGET_CHECKOUT_DIR: root,
+      TARGET_REF_INPUT: "fixture-target",
+    },
+  });
+  const outputs = Object.fromEntries(
+    existsSync(output)
+      ? readFileSync(output, "utf8")
+          .trim()
+          .split("\n")
+          .map((line) => line.split("=", 2))
+      : [],
+  );
+  return { outputs, result, sha };
 }
 
 function runCandidateTrustClassification({
@@ -267,7 +351,7 @@ describe("OpenClaw performance workflow", () => {
       "${{ inputs.kova_config_contract }}",
     );
     expect(targetCheckout.with?.["sparse-checkout"]).toBe(
-      "package.json\nsrc/config/zod-schema.agent-defaults.ts\n",
+      "package.json\nsrc/config/zod-schema.agent-defaults.ts\nsrc/config/zod-schema.agent-defaults-base.ts\n",
     );
     expect(resolveTarget.run).toContain(
       'schema_path="${TARGET_CHECKOUT_DIR}/src/config/zod-schema.agent-defaults.ts"',
@@ -326,6 +410,129 @@ describe("OpenClaw performance workflow", () => {
       "KOVA_SCENARIO_TIMEOUT_MS: ${{ inputs.profile == 'release' && '900000' || '300000' }}",
     );
     expect(workflow).toContain("Kova live OpenAI GPT 5.6 agent turn");
+  });
+
+  describe("target metadata layouts", () => {
+    const canonical = "    mediaModels: z\n";
+    const legacy = "    imageGenerationModel: AgentToolModelSchema.optional(),\n";
+    const linked = [
+      'import { AgentDefaultsBaseSchema } from "./zod-schema.agent-defaults-base.js";',
+      "export const AgentDefaultsSchema = AgentDefaultsBaseSchema.safeExtend({",
+      "});",
+      "",
+    ].join("\n");
+    const unknown = "export const AgentDefaultsSchema = z.object({});\n";
+    const cases = [
+      { name: "inline canonical", schema: canonical, expectedContract: "canonical" },
+      { name: "inline legacy", schema: legacy, expectedContract: "legacy-list" },
+      {
+        name: "linked split canonical",
+        schema: linked,
+        baseSchema: canonical,
+        expectedContract: "canonical",
+      },
+      {
+        name: "legacy wrapper before conflicting canonical base",
+        schema: linked + legacy,
+        baseSchema: canonical,
+        expectedContract: "legacy-list",
+      },
+      {
+        name: "canonical wrapper before conflicting legacy base",
+        schema: linked + canonical,
+        baseSchema: legacy,
+        expectedContract: "canonical",
+      },
+      { name: "missing wrapper", baseSchema: canonical, error: "Unable to inspect" },
+      { name: "missing linked base", schema: linked, error: "Unable to inspect" },
+      {
+        name: "unrecognized linked base",
+        schema: linked,
+        baseSchema: unknown,
+        error: "no recognized",
+      },
+      {
+        name: "dormant base beside unknown wrapper",
+        schema: unknown,
+        baseSchema: canonical,
+        error: "no recognized",
+      },
+      {
+        name: "imported but unused base",
+        schema: linked.split("\n")[0] + "\n" + unknown,
+        baseSchema: canonical,
+        error: "no recognized",
+      },
+      {
+        name: "different imported base",
+        schema: linked.replace("./zod-schema.agent-defaults-base.js", "./other.js"),
+        baseSchema: canonical,
+        error: "no recognized",
+      },
+      {
+        name: "custom ref with missing linked base",
+        schema: linked,
+        kovaRef: "custom-producer",
+        expectedContract: "",
+      },
+      {
+        name: "custom ref and contract without metadata",
+        kovaRef: "custom-producer",
+        contract: "custom-contract",
+        expectedContract: "custom-contract",
+      },
+      {
+        name: "explicit contract with default ref",
+        schema: linked,
+        baseSchema: canonical,
+        contract: "custom-contract",
+        expectedContract: "custom-contract",
+      },
+      {
+        name: "historical release pin",
+        schema: legacy,
+        version: "2026.7.33",
+        expectedContract: "legacy-list",
+        expectedRef: "18c9eb8c3950a35794d196f4e40ad471e9308e27",
+      },
+    ];
+    posixIt.each(cases)("resolves $name without executing target metadata", (fixture) => {
+      const { outputs, result, sha } = runTargetMetadataResolution(fixture);
+      if (fixture.error) {
+        expect(result.status, result.stderr + result.stdout).toBe(1);
+        expect(result.stdout).toContain(fixture.error);
+        expect(result.stdout).toContain("Kova config-fixture contract");
+        expect(outputs).toEqual({});
+        return;
+      }
+      expect(result.status, result.stderr + result.stdout).toBe(0);
+      const expectedRef =
+        fixture.expectedRef ?? fixture.kovaRef ?? readWorkflow().env?.KOVA_CANONICAL_CONFIG_REF;
+      expect(outputs).toEqual({
+        checkout_ref: sha,
+        tested_ref: "fixture-target",
+        tested_sha: sha,
+        kova_ref: expectedRef,
+        kova_config_contract: fixture.expectedContract,
+        kova_ref_trusted_for_live: String(
+          expectedRef === readWorkflow().env?.KOVA_TRUSTED_LIVE_REF,
+        ),
+      });
+    });
+
+    posixIt("resolves the checked-in schema from sparse committed metadata", () => {
+      const { outputs, result, sha } = runTargetMetadataResolution({
+        schema: readFileSync("src/config/zod-schema.agent-defaults.ts", "utf8"),
+        baseSchema: readFileSync("src/config/zod-schema.agent-defaults-base.ts", "utf8"),
+      });
+      expect(result.status, result.stderr + result.stdout).toBe(0);
+      expect(outputs).toMatchObject({
+        checkout_ref: sha,
+        tested_sha: sha,
+        kova_ref: "c2de7c24ea835ea054c416f8bf19d3cb22f104e9",
+        kova_config_contract: "canonical",
+      });
+    });
   });
 
   it("keeps live credentials away from custom Kova refs", () => {


### PR DESCRIPTION
Closes https://github.com/openclaw/openclaw/issues/145363

Related: https://github.com/openclaw/openclaw/pull/143986

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

This is a same-repository branch; maintainer updates use repository permissions.

</details>

## What Problem This Solves

Resolves a problem where release performance validation stops before benchmarks
when a target stores its agent-default configuration fields in the split base
schema. The failure occurred in
[this performance child](https://github.com/openclaw/openclaw/actions/runs/34647515545/job/103421747963)
of [Full Release Validation](https://github.com/openclaw/openclaw/actions/runs/34647360664).

## Why This Change Was Made

Include the base schema in the existing metadata checkout and inspect it only
when the wrapper uses the known import and composition. Inline canonical and
legacy layouts retain precedence; unrelated base files cannot select a contract.
Default producer selection still rejects missing or unrecognized metadata
without publishing resolved outputs.

Custom producer overrides, historical pins, credentials, cache eligibility,
benchmark gates, and artifact-only behavior are unchanged. Target source is read
as metadata, never imported or executed.

## User Impact

Targets using the split schema can reach performance validation with the same
Kova pin and exact target SHA. This does not change runtime configuration or
establish that their benchmarks pass.

The broader isolation work in
[127240](https://github.com/openclaw/openclaw/pull/127240) remains separate; this
fix is not a replacement or prerequisite for that draft. Its workflow can
incorporate this metadata repair independently.

## Evidence

- Causal RED/GREEN through the actual workflow body and Git sparse checkout:
  the failing target and current source both rejected the missing split layout
  before the fix and resolved the same pinned producer and exact SHA afterward.
- Full workflow test owner: 58 passed, including split, inline, legacy, dormant
  and conflicting bases, missing metadata, custom overrides, historical pins,
  target-execution rejection sentinels, and existing trust/artifact controls.
- Selected changed-file gates, workflow validation, and diff-check passed.
  Independent review found no actionable issues in the two-file change.
- [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34655254086)
  passed, including the required `openclaw/ci-gate`. Superseded checks are not
  represented as passing results.
- Local metadata-boundary proof only. No new full-release run, benchmark,
  live-provider call, report publication, or paid operation was performed.
