### PR TITLE
fix: isolate loader tests that simulate missing native hooks

### DIFF
--- a/src/plugins/loader.lazy-alias.test.ts
+++ b/src/plugins/loader.lazy-alias.test.ts
@@ -1,8 +1,10 @@
+import { execFile } from "node:child_process";
 import fs from "node:fs";
-import Module, { createRequire } from "node:module";
+import { createRequire } from "node:module";
 import os from "node:os";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
+import { promisify } from "node:util";
 import { Command } from "commander";
 import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
 import { registerSubCliByNameCore } from "../cli/program/register.subclis-core.js";
@@ -87,24 +89,38 @@ describe("native plugin alias preparation", () => {
         "external/index.ts",
         'export { value } from "openclaw/plugin-sdk/used";',
       );
-      const rootDir = path.dirname(source);
-      const record = createPluginRecord({ id: "external", rootDir, source, origin: "global" });
-      const registry = createEmptyPluginRegistry();
-      registry.plugins.push(record);
-      const hooks = Object.getOwnPropertyDescriptor(Module, "registerHooks");
-      Object.defineProperty(Module, "registerHooks", { value: undefined, configurable: true });
-      vi.stubEnv("NODE_ENV", environment);
-      try {
-        const load = createPluginModuleLoader({ devSourceRoot: f.root, pluginSdkResolution });
-        expect(load(source, { record, rootDir, registry })).toMatchObject({ value: expected });
-      } finally {
-        if (hooks) {
-          Object.defineProperty(Module, "registerHooks", hooks);
-        } else {
-          Reflect.deleteProperty(Module, "registerHooks");
-        }
-        await getPluginInstance(record)?.dispose();
-      }
+      // Native resolver hooks live for the process. A no-hook runtime must not
+      // mark this worker's resolver installed before the native-alias cases run.
+      const probe = writeFile(
+        f.root,
+        "no-native-hooks.mts",
+        [
+          'import Module from "node:module";',
+          'import path from "node:path";',
+          'Object.defineProperty(Module, "registerHooks", { value: undefined, configurable: true });',
+          `const { createPluginModuleLoader } = await import(${JSON.stringify(pathToFileURL(path.resolve("src/plugins/loader-module-runtime.ts")).href)});`,
+          `const { getPluginInstance } = await import(${JSON.stringify(pathToFileURL(path.resolve("src/plugins/plugin-instance-scope.ts")).href)});`,
+          `const { createPluginRecord } = await import(${JSON.stringify(pathToFileURL(path.resolve("src/plugins/status.test-helpers.ts")).href)});`,
+          `const { createEmptyPluginRegistry } = await import(${JSON.stringify(pathToFileURL(path.resolve("src/plugins/registry-empty.ts")).href)});`,
+          `const source = ${JSON.stringify(source)};`,
+          "const rootDir = path.dirname(source);",
+          'const record = createPluginRecord({ id: "external", rootDir, source, origin: "global" });',
+          "const registry = createEmptyPluginRegistry();",
+          "registry.plugins.push(record);",
+          "try {",
+          `  const load = createPluginModuleLoader({ devSourceRoot: ${JSON.stringify(f.root)}, pluginSdkResolution: ${JSON.stringify(pluginSdkResolution)} });`,
+          "  console.log(JSON.stringify(load(source, { record, rootDir, registry })));",
+          "} finally {",
+          "  await getPluginInstance(record)?.dispose();",
+          "}",
+        ].join("\n"),
+      );
+      const { stdout } = await promisify(execFile)(
+        process.execPath,
+        ["--import", pathToFileURL(path.resolve("scripts/tsx.mjs")).href, probe],
+        { env: { ...process.env, NODE_ENV: environment } },
+      );
+      expect(JSON.parse(stdout)).toMatchObject({ value: expected });
     },
   );
 


### PR DESCRIPTION
## What Problem This Solves

Fixes a deterministic loader-test failure that blocks validation of #145321. Two tests simulate a runtime without `Module.registerHooks`. They restore the API afterward, but the SDK resolver's process-wide installed flag remains set. Nine subsequent native-alias/ESM cases then run without the ESM hook.

Related: #145321 and #144252.

## Why This Change Was Made

Run the two existing no-hook source/dist preference probes in joined child Node processes using the repository's tsx preload. The plugin test lane shares process state, so restoring the API or moving tests to another ordinary file is insufficient.

No production code changes, resolver reset hook, test exception, assertion removal, or hosted rerun. This is the narrowly scoped validation prerequisite for the settlement fix and the plugin-update producer work.

## User Impact

No runtime behavior changes. CI can exercise the no-hook fallback and native ESM alias contracts together without one test's simulated runtime disabling another test's resolver.

## Evidence

- Unmodified main `fc7f3c65100a3cd90a9a07a367b28f51a9af7720`, Node 24.19 on macOS: 9 failures / 25 passes, matching the recorded #145321 Node 24.19 Linux CI errors and cases.
- Same nine failing cases without the no-hook predecessors: 9 passes / 25 filtered. This isolates the process-state contamination.
- With this fixture correction, the complete file passes all 34 original cases on Node 24.19.
- Exact-source P0/P1/P2 review is clean. Changed-file typechecking and static checks passed through the interrupted gate plus its finite continuation.

Five relevant loader source files match settlement head `e90c79c597c8b90d23573576ec5c4f5c18659340`. The local reproduction is macOS evidence, not a claimed Linux replay or permission to bypass required CI.
