### PR TITLE
fix: claude-cli replies are discarded when a plugin hot reload lands mid-turn

### DIFF
--- a/src/agents/cli-runner/execute.plugin-reload.test.ts
+++ b/src/agents/cli-runner/execute.plugin-reload.test.ts
@@ -90,25 +90,25 @@ describe("plugin-owned CLI turns across a plugin hot reload", () => {
     const { context, admission } = await preparePluginContext(execute);
     const consumer = context.pluginExecutionConsumer;
     expect(consumer).toBeDefined();
+    let outcome: { ok: true; text: string } | { ok: false; error: unknown } | undefined;
+    const run = executePreparedCliRun(context).then(
+      (value) => {
+        outcome = { ok: true, text: value.text };
+      },
+      (error: unknown) => {
+        outcome = { ok: false, error };
+      },
+    );
+    let disposal: ReturnType<typeof owner.dispose> | undefined;
     try {
-      const run = executePreparedCliRun(context);
       await vi.waitFor(() => expect(started).toBe(true));
 
-      const disposal = owner.dispose();
+      disposal = owner.dispose();
       await vi.advanceTimersByTimeAsync(5_001);
       expect(owner.acceptingCalls).toBe(false);
       finish.resolve();
 
       // Settle under fake timers so a regression fails on its own error instead of hanging.
-      let outcome: { ok: true; text: string } | { ok: false; error: unknown } | undefined;
-      void run.then(
-        (value) => {
-          outcome = { ok: true, text: value.text };
-        },
-        (error: unknown) => {
-          outcome = { ok: false, error };
-        },
-      );
       await vi.waitFor(() => expect(outcome).toBeDefined(), { timeout: 30_000, interval: 100 });
       expect(outcome, "CLI run did not settle after its plugin instance retired").toEqual({
         ok: true,
@@ -120,7 +120,11 @@ describe("plugin-owned CLI turns across a plugin hot reload", () => {
       consumer!.release();
       await expect(disposal).resolves.toEqual({ errors: [] });
     } finally {
+      // A failed assertion must not strand the iterator or its retained owner.
+      finish.resolve();
+      consumer?.release();
       admission.close();
+      await Promise.allSettled([run, disposal ?? owner.dispose()]);
     }
   });
 });

--- a/src/agents/cli-runner/execute.plugin-reload.test.ts
+++ b/src/agents/cli-runner/execute.plugin-reload.test.ts
@@ -1,0 +1,126 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../test/helpers/promise.js";
+import type { CliBackendConfig, CliBackendExecute } from "../../plugins/cli-backend.types.js";
+import { PluginInstance } from "../../plugins/plugin-instance.js";
+import { prepareSystemAgentRunAdmission } from "../admitted-run-context.js";
+import { createTestAdmittedRunContext } from "../admitted-run-context.test-support.js";
+import { executePreparedCliRun } from "./execute.js";
+import { retainCliPluginExecutionConsumer } from "./execution-target.js";
+import type { PreparedCliRunContext } from "./types.js";
+
+const SUCCESS_RESULT = {
+  type: "result",
+  subtype: "success",
+  is_error: false,
+  result: "completed",
+  session_id: "sdk-session",
+};
+
+async function preparePluginContext(execute: CliBackendExecute): Promise<{
+  context: PreparedCliRunContext;
+  admission: ReturnType<typeof prepareSystemAgentRunAdmission>;
+}> {
+  const backend: CliBackendConfig = {
+    command: "/bin/sh",
+    args: [],
+    output: "jsonl",
+    jsonlDialect: "claude-stream-json",
+    input: "stdin",
+    sessionMode: "existing",
+  };
+  const runId = "plugin-reload-run";
+  const context: PreparedCliRunContext = {
+    params: {
+      admittedRunContext: createTestAdmittedRunContext(runId),
+      sessionId: "s1",
+      sessionFile: "/tmp/session.jsonl",
+      workspaceDir: "/tmp",
+      prompt: "hi",
+      provider: "claude-cli",
+      model: "opus",
+      thinkLevel: "low",
+      timeoutMs: 120_000,
+      runId,
+    },
+    started: Date.now(),
+    workspaceDir: "/tmp",
+    backendResolved: { id: "claude-cli", config: backend, bundleMcp: false, pluginId: "anthropic" },
+    executionTarget: { kind: "plugin", execute },
+    pluginExecutionConsumer: retainCliPluginExecutionConsumer(execute),
+    preparedBackend: { backend, env: {} },
+    reusableCliSession: { mode: "none" },
+    hadSessionFile: false,
+    contextEngineConfig: {},
+    modelId: "opus",
+    normalizedModel: "opus",
+    contextWindowInfo: { tokens: 150_000, referenceTokens: 200_000, source: "modelsConfig" },
+    systemPrompt: "You are a helpful assistant.",
+    systemPromptReport: {} as PreparedCliRunContext["systemPromptReport"],
+    claudeSkillsPluginArgs: [],
+    authEpochVersion: 2,
+  };
+  const admission = prepareSystemAgentRunAdmission({}, runId, "main", "plugin-reload-test");
+  context.params.admittedRunContext = await admission.admit("plugin-harness");
+  return { context, admission };
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("plugin-owned CLI turns across a plugin hot reload", () => {
+  it("delivers a turn that outlives its backend instance's retirement", async () => {
+    // A hot reload retires the previous plugin instance while the CLI turn is
+    // still running; the finished reply and the turn's cleanup must still go
+    // through instead of failing once the bounded call drain expires (#144809).
+    vi.useFakeTimers();
+    const owner = new PluginInstance("anthropic");
+    const finish = createDeferred();
+    let started = false;
+    const execute = owner.wrap<CliBackendExecute>(async function* () {
+      yield { type: "system", subtype: "init", session_id: "sdk-session" };
+      started = true;
+      await finish.promise;
+      yield SUCCESS_RESULT;
+    });
+    const cleanup = owner.wrap(async () => {
+      cleaned = true;
+    });
+    let cleaned = false;
+    const { context, admission } = await preparePluginContext(execute);
+    const consumer = context.pluginExecutionConsumer;
+    expect(consumer).toBeDefined();
+    try {
+      const run = executePreparedCliRun(context);
+      await vi.waitFor(() => expect(started).toBe(true));
+
+      const disposal = owner.dispose();
+      await vi.advanceTimersByTimeAsync(5_001);
+      expect(owner.acceptingCalls).toBe(false);
+      finish.resolve();
+
+      // Settle under fake timers so a regression fails on its own error instead of hanging.
+      let outcome: { ok: true; text: string } | { ok: false; error: unknown } | undefined;
+      void run.then(
+        (value) => {
+          outcome = { ok: true, text: value.text };
+        },
+        (error: unknown) => {
+          outcome = { ok: false, error };
+        },
+      );
+      await vi.waitFor(() => expect(outcome).toBeDefined(), { timeout: 30_000, interval: 100 });
+      expect(outcome, "CLI run did not settle after its plugin instance retired").toEqual({
+        ok: true,
+        text: "completed",
+      });
+      // Prepared cleanup runs inside the same retained scope before releasing it.
+      await consumer!.run(cleanup);
+      expect(cleaned).toBe(true);
+      consumer!.release();
+      await expect(disposal).resolves.toEqual({ errors: [] });
+    } finally {
+      admission.close();
+    }
+  });
+});

--- a/src/agents/cli-runner/execute.ts
+++ b/src/agents/cli-runner/execute.ts
@@ -669,7 +669,12 @@ export async function executePreparedCliRun(
         // would run inside the source session. Force a fresh spawn.
         await restartCliLiveSession(context);
       }
-      return await executeAttempt();
+      // The prepared context's retained consumer keeps this attempt's plugin calls
+      // admitted while a plugin hot reload retires the backend's previous instance.
+      const pluginExecutionConsumer = context.pluginExecutionConsumer;
+      return await (pluginExecutionConsumer
+        ? pluginExecutionConsumer.run(executeAttempt)
+        : executeAttempt());
     });
     if (completedOutput.sessionId) {
       observeForkSuccessor(completedOutput.sessionId);

--- a/src/agents/cli-runner/execute.ts
+++ b/src/agents/cli-runner/execute.ts
@@ -651,30 +651,31 @@ export async function executePreparedCliRun(
     });
   };
   try {
-    completedOutput = await enqueueCliRun(queueKey, async () => {
-      assertCurrent();
-      if (params.lifecycleGeneration) {
-        assertAgentRunLifecycleGenerationCurrent(params.lifecycleGeneration);
-      }
-      diagnostics?.emitStarted();
-      if (params.forkCliSessionOnResume && useResume) {
-        if (!params.persistCliSessionForkSuccessor) {
-          throw new Error("CLI session fork successor persistence is unavailable");
+    completedOutput = await enqueueCliRun(queueKey, () => {
+      const runQueuedAttempt = async () => {
+        assertCurrent();
+        if (params.lifecycleGeneration) {
+          assertAgentRunLifecycleGenerationCurrent(params.lifecycleGeneration);
         }
-        forkResumeClaimed = (await params.claimCliSessionFork?.()) === true;
-        if (!forkResumeClaimed) {
-          throw new Error("CLI session fork marker is no longer available");
+        diagnostics?.emitStarted();
+        if (params.forkCliSessionOnResume && useResume) {
+          if (!params.persistCliSessionForkSuccessor) {
+            throw new Error("CLI session fork successor persistence is unavailable");
+          }
+          forkResumeClaimed = (await params.claimCliSessionFork?.()) === true;
+          if (!forkResumeClaimed) {
+            throw new Error("CLI session fork marker is no longer available");
+          }
+          // The fork argument only applies at process startup; a cached warm child
+          // would run inside the source session. Force a fresh spawn.
+          await restartCliLiveSession(context);
         }
-        // The fork argument only applies at process startup; a cached warm child
-        // would run inside the source session. Force a fresh spawn.
-        await restartCliLiveSession(context);
-      }
-      // The prepared context's retained consumer keeps this attempt's plugin calls
-      // admitted while a plugin hot reload retires the backend's previous instance.
-      const pluginExecutionConsumer = context.pluginExecutionConsumer;
-      return await (pluginExecutionConsumer
-        ? pluginExecutionConsumer.run(executeAttempt)
-        : executeAttempt());
+        return await executeAttempt();
+      };
+      // The retained consumer keeps every plugin call of this queued attempt, including
+      // a fork-on-resume live-session restart, admitted across a plugin hot reload.
+      const consumer = context.pluginExecutionConsumer;
+      return consumer ? consumer.run(runQueuedAttempt) : runQueuedAttempt();
     });
     if (completedOutput.sessionId) {
       observeForkSuccessor(completedOutput.sessionId);

--- a/src/agents/cli-runner/execution-target.ts
+++ b/src/agents/cli-runner/execution-target.ts
@@ -1,5 +1,7 @@
 import { createAbortError } from "../../infra/abort-signal.js";
 import type { CliBackendExecute } from "../../plugins/cli-backend.types.js";
+import { getPluginValueInstance } from "../../plugins/plugin-instance-scope.js";
+import type { PluginInstanceConsumer } from "../../plugins/plugin-instance.types.js";
 import { resolveAdmittedRunActiveAssertion } from "../admitted-run-context.js";
 import type { CliExecutionTarget, PreparedCliRunContext, RunCliAgentParams } from "./types.js";
 
@@ -43,4 +45,26 @@ export function resolveCliExecutionTarget(context: {
   return context.execute && context.params.controlOperation !== "compact"
     ? { kind: "plugin", execute: context.execute }
     : { kind: "process" };
+}
+
+/**
+ * A plugin hot reload retires the previous backend instance after a bounded call
+ * drain and then rejects its calls, which discarded turns that finished later.
+ * A retained consumer keeps every plugin call of one prepared turn (execution
+ * stream, lifecycle parser, text transforms, cleanup) admitted on that instance
+ * until the turn's cleanup releases it; the owner's physical cleanup waits for it.
+ */
+export function retainCliPluginExecutionConsumer(
+  execute: CliBackendExecute | undefined,
+): PluginInstanceConsumer | undefined {
+  const owner = execute ? getPluginValueInstance(execute) : undefined;
+  if (!owner) {
+    return undefined;
+  }
+  try {
+    return owner.retainConsumer();
+  } catch {
+    // The owner is already retiring; the ordinary call path reports that itself.
+    return undefined;
+  }
 }

--- a/src/agents/cli-runner/prepare.ts
+++ b/src/agents/cli-runner/prepare.ts
@@ -157,7 +157,11 @@ import {
   type BundledCliBackendAuthPolicy,
 } from "./cli-backend-auth-policy.js";
 import { getCliLiveSessionGeneration } from "./cli-live-session-registry.js";
-import { createCliRunCurrentAssertion, resolveCliExecutionTarget } from "./execution-target.js";
+import {
+  createCliRunCurrentAssertion,
+  resolveCliExecutionTarget,
+  retainCliPluginExecutionConsumer,
+} from "./execution-target.js";
 import { buildCliAgentSystemPrompt, isClaudeCliBackendId, normalizeCliModel } from "./helpers.js";
 import { prepareCliHistoryBoundary } from "./history-boundary.js";
 import { cliBackendLog } from "./log.js";
@@ -1737,13 +1741,21 @@ async function prepareCliRunContextWithinReadFence(
       }
       throw error;
     }
+    const pluginExecutionConsumer = retainCliPluginExecutionConsumer(preparedExecution?.execute);
     const preparedBackendCleanup =
-      cleanupPreparedBackend || preparedExecution?.cleanup
+      cleanupPreparedBackend || preparedExecution?.cleanup || pluginExecutionConsumer
         ? async () => {
             try {
-              await preparedExecution?.cleanup?.();
+              const cleanupExecution = () => preparedExecution?.cleanup?.();
+              await (pluginExecutionConsumer
+                ? pluginExecutionConsumer.run(cleanupExecution)
+                : cleanupExecution());
             } finally {
-              await cleanupPreparedBackend?.();
+              try {
+                await cleanupPreparedBackend?.();
+              } finally {
+                pluginExecutionConsumer?.release();
+              }
             }
           }
         : undefined;
@@ -2243,6 +2255,7 @@ async function prepareCliRunContextWithinReadFence(
         backendResolved,
         preparedBackend: preparedBackendFinal,
         executionTarget,
+        ...(pluginExecutionConsumer ? { pluginExecutionConsumer } : {}),
         reusableCliSession,
         hadSessionFile: false,
         contextEngineConfig: runConfig,
@@ -2396,6 +2409,7 @@ async function prepareCliRunContextWithinReadFence(
       backendResolved,
       preparedBackend: preparedBackendFinal,
       executionTarget,
+      ...(pluginExecutionConsumer ? { pluginExecutionConsumer } : {}),
       reusableCliSession,
       ...(managedClaudeLiveSessionGeneration
         ? { requiredClaudeLiveSessionGeneration: managedClaudeLiveSessionGeneration }

--- a/src/agents/cli-runner/types.ts
+++ b/src/agents/cli-runner/types.ts
@@ -39,6 +39,7 @@ import type {
   CliBackendPromptContext,
 } from "../../plugins/cli-backend.types.js";
 import type { PluginHookChannelContext } from "../../plugins/hook-types.js";
+import type { PluginInstanceConsumer } from "../../plugins/plugin-instance.types.js";
 import type { SpawnSecretInput } from "../../process/supervisor/types.js";
 import type { InputProvenance } from "../../sessions/input-provenance.js";
 import type { UserTurnTranscriptRecorder } from "../../sessions/user-turn-transcript.js";
@@ -383,6 +384,8 @@ export type PreparedCliRunContext = {
   backendResolved: ResolvedCliBackend;
   preparedBackend: CliPreparedBackend;
   executionTarget: CliExecutionTarget;
+  /** Keeps a plugin-owned turn admitted on its backend instance across a plugin hot reload. */
+  pluginExecutionConsumer?: PluginInstanceConsumer;
   reusableCliSession: CliReusableSession;
   /** Resume is safe only while the exact managed Claude stdio child still exists. */
   requiredClaudeLiveSessionGeneration?: string;

--- a/test/e2e/qa-lab/runtime/reply-run-plugin-reload.product-proof.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/reply-run-plugin-reload.product-proof.e2e.test.ts
@@ -103,6 +103,12 @@ async function waitFor<T>(
   throw new Error(`timed out waiting for ${label}`);
 }
 
+type PatchOutcome = { ok: true; result: unknown } | { ok: false; error: string };
+
+// oxlint-disable-next-line no-control-regex -- terminal color escapes in Gateway logs
+const ANSI_ESCAPE = /\x1b\[[0-9;]*m/g;
+const stripAnsi = (line: string) => line.replace(ANSI_ESCAPE, "");
+
 function readLog(file: string): string {
   try {
     return fs.readFileSync(file, "utf8");
@@ -190,6 +196,7 @@ describe.runIf(process.env.OPENCLAW_E2E_PLUGIN_RELOAD_PROOF === "1")(
         const { gateway } = harness;
         const stdoutLog = path.join(gateway.tempRoot, "gateway.stdout.log");
         const stderrLog = path.join(gateway.tempRoot, "gateway.stderr.log");
+        const readGatewayLogs = () => `${readLog(stdoutLog)}\n${readLog(stderrLog)}`;
         const record: Record<string, unknown> = { turnMs: TURN_MS, tempRoot: gateway.tempRoot };
 
         state.addInboundMessage({
@@ -232,28 +239,92 @@ describe.runIf(process.env.OPENCLAW_E2E_PLUGIN_RELOAD_PROOF === "1")(
             { timeoutMs: 900_000 },
           )
           .then(
-            (result) => {
-              record.patchResult = result;
-              record.patchResolvedAt = new Date().toISOString();
-            },
-            (error: unknown) => {
-              record.patchError = String(error);
-              record.patchResolvedAt = new Date().toISOString();
-            },
-          );
+            (result): PatchOutcome => ({ ok: true, result }),
+            (error: unknown): PatchOutcome => ({ ok: false, error: String(error) }),
+          )
+          .then((outcome) => {
+            record.patchOutcome = outcome;
+            record.patchResolvedAt = new Date().toISOString();
+            return outcome;
+          });
         record.patchedAt = new Date().toISOString();
 
         await waitFor(
           "channel reload deferral log line",
           () =>
-            /requires channel reload|deferring until/.test(
-              `${readLog(stdoutLog)}\n${readLog(stderrLog)}`,
-            )
-              ? true
-              : undefined,
+            /requires channel reload|deferring until/.test(readGatewayLogs()) ? true : undefined,
           60_000,
         );
         record.deferralSeen = true;
+
+        // The reload must observably commit its plugin replacement before the CLI
+        // result exists; otherwise the turn never exercised retirement.
+        const turnFinishedPath = path.join(fakeDir, "turn-finished.json");
+        const appliedLine = await waitFor(
+          "committed plugin reload before the CLI result",
+          () => {
+            if (fs.existsSync(turnFinishedPath)) {
+              throw new Error(
+                "CLI turn finished before the plugin reload applied; retirement was not exercised",
+              );
+            }
+            const line = readGatewayLogs()
+              .split("\n")
+              .map(stripAnsi)
+              .find(
+                (candidate) =>
+                  candidate.includes("config hot reload applied (") &&
+                  candidate.includes("plugins.allow"),
+              );
+            return line ?? undefined;
+          },
+          TURN_MS + 60_000,
+          2_000,
+        );
+        record.appliedLine = appliedLine;
+        const configAfter = (await gateway.call("config.get", {})) as {
+          hash?: string;
+          appliedConfigHash?: string | null;
+          configRevisionHash?: string;
+          config?: {
+            plugins?: { allow?: string[] };
+            channels?: Record<string, { pollTimeoutMs?: number }>;
+          };
+        };
+        record.configAfter = {
+          hash: configAfter.hash,
+          appliedConfigHash: configAfter.appliedConfigHash,
+          configRevisionHash: configAfter.configRevisionHash,
+          allow: configAfter.config?.plugins?.allow,
+          pollTimeoutMs: configAfter.config?.channels?.[CHANNEL_ID]?.pollTimeoutMs,
+        };
+        // appliedConfigHash is published by the reload/restart publication; the
+        // forced qa-channel restart is refused under its own active turn, so a
+        // recovery restart stays pending and that hash is not asserted here. The
+        // committed content plus the applied log line are the replacement evidence.
+        expect(configAfter.hash).not.toBe(configBefore.hash);
+        expect(configAfter.config?.plugins?.allow).toContain("discord");
+        expect(configAfter.config?.channels?.[CHANNEL_ID]?.pollTimeoutMs).toBe(700);
+        // config.patch must settle before the CLI result. It may report that the
+        // committed change still needs a recovery restart (the forced qa-channel
+        // restart under its own active turn is refused), but a rejected or
+        // pending replacement fails the proof.
+        const patchOutcome = await Promise.race([
+          patchPromise,
+          delay(60_000).then((): PatchOutcome => ({
+            ok: false,
+            error: "config.patch still pending",
+          })),
+        ]);
+        if (fs.existsSync(turnFinishedPath)) {
+          throw new Error("CLI turn finished before config.patch settled");
+        }
+        if (
+          !patchOutcome.ok &&
+          !patchOutcome.error.includes("persisted and updated the active Gateway")
+        ) {
+          throw new Error(`config.patch did not commit the replacement: ${patchOutcome.error}`);
+        }
 
         const finished = await waitFor(
           "fake claude turn finish",
@@ -269,7 +340,7 @@ describe.runIf(process.env.OPENCLAW_E2E_PLUGIN_RELOAD_PROOF === "1")(
           .getSnapshot()
           .messages.filter((message) => message.direction === "outbound")
           .map((message) => ({ accountId: message.accountId, text: message.text }));
-        const stdout = `${readLog(stdoutLog)}\n${readLog(stderrLog)}`;
+        const stdout = readGatewayLogs();
         const interesting = stdout
           .split("\n")
           .filter((line) =>
@@ -288,6 +359,12 @@ describe.runIf(process.env.OPENCLAW_E2E_PLUGIN_RELOAD_PROOF === "1")(
         console.log(JSON.stringify(record, null, 2));
 
         expect(finished).toBe(true);
+        const cliTurnLine = interesting.find((line) => line.includes("] cli turn: "));
+        expect(cliTurnLine).toBeDefined();
+        const appliedAt = Date.parse(appliedLine.slice(0, 29));
+        const cliTurnAt = Date.parse((cliTurnLine ?? "").slice(0, 29));
+        expect(Number.isFinite(appliedAt) && Number.isFinite(cliTurnAt)).toBe(true);
+        expect(appliedAt).toBeLessThan(cliTurnAt);
         expect(interesting.some((line) => line.includes("reloading channels anyway"))).toBe(true);
         expect(
           interesting.some((line) =>

--- a/test/e2e/qa-lab/runtime/reply-run-plugin-reload.product-proof.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/reply-run-plugin-reload.product-proof.e2e.test.ts
@@ -7,7 +7,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   createQaBusState,
   createQaChannelTransport,
@@ -135,6 +135,7 @@ afterEach(async () => {
     errors.push(error);
   } finally {
     bus = undefined;
+    vi.unstubAllEnvs();
   }
   if (errors.length > 0) {
     throw new AggregateError(errors, "reload repro cleanup failed");
@@ -153,9 +154,9 @@ describe.runIf(process.env.OPENCLAW_E2E_PLUGIN_RELOAD_PROOF === "1")(
         const fakeDir = fs.mkdtempSync(path.join(fakeRoot, "fake-claude-"));
         const fakeBin = path.join(fakeDir, "claude");
         fs.writeFileSync(fakeBin, FAKE_CLAUDE, { mode: 0o755 });
-        process.env.PATH = `${fakeDir}${path.delimiter}${process.env.PATH ?? ""}`;
-        process.env.FAKE_CLAUDE_DIR = fakeDir;
-        process.env.FAKE_CLAUDE_TURN_MS = String(TURN_MS);
+        vi.stubEnv("PATH", `${fakeDir}${path.delimiter}${process.env.PATH ?? ""}`);
+        vi.stubEnv("FAKE_CLAUDE_DIR", fakeDir);
+        vi.stubEnv("FAKE_CLAUDE_TURN_MS", String(TURN_MS));
 
         const state = createQaBusState();
         const transport = createQaChannelTransport(state);
@@ -333,9 +334,14 @@ describe.runIf(process.env.OPENCLAW_E2E_PLUGIN_RELOAD_PROOF === "1")(
           2_000,
         ).catch((error: unknown) => String(error));
         record.turnFinished = finished;
-        await delay(20_000);
-
-        await Promise.race([patchPromise, delay(30_000)]);
+        await waitFor(
+          "outbound reply after CLI completion",
+          () =>
+            state.getSnapshot().messages.some((message) => message.direction === "outbound")
+              ? true
+              : undefined,
+          20_000,
+        );
         const outbound = state
           .getSnapshot()
           .messages.filter((message) => message.direction === "outbound")

--- a/test/e2e/qa-lab/runtime/reply-run-plugin-reload.product-proof.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/reply-run-plugin-reload.product-proof.e2e.test.ts
@@ -1,0 +1,306 @@
+// Product proof for #144809: a plugin hot reload that lands after the 300 s
+// channel-reload deferral must not discard the reply of a claude-cli turn that
+// is still running. Runs a real Gateway with a fake `claude` executable on PATH
+// that speaks the stdio protocol and answers only after the reload has applied.
+import { randomUUID } from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  createQaBusState,
+  createQaChannelTransport,
+  startQaBusServer,
+} from "../../../../extensions/qa-lab/api.js";
+import { createQaLiveLaneGateway } from "../../../../extensions/qa-lab/runtime-api.js";
+import { stopQaGatewayFixture } from "../../../helpers/qa-gateway-cleanup.js";
+
+const CHANNEL_ID = "qa-channel";
+const ACCOUNT_ID = "default";
+const PEER_ID = "reload-peer";
+const CLI_MODEL = "claude-cli/claude-opus-5";
+const TURN_MS = Number(process.env.OPENCLAW_E2E_PLUGIN_RELOAD_PROOF_TURN_MS ?? 340_000);
+
+type GatewayHarness = Awaited<ReturnType<ReturnType<typeof createQaLiveLaneGateway>["start"]>>;
+
+let gatewayOwner: ReturnType<typeof createQaLiveLaneGateway> | undefined;
+let harness: GatewayHarness | undefined;
+let bus: Awaited<ReturnType<typeof startQaBusServer>> | undefined;
+
+const FAKE_CLAUDE = String.raw`#!/usr/bin/env node
+// Minimal claude-stdio protocol: initialize handshake, one user turn, delayed result.
+const fs = require("node:fs");
+const path = require("node:path");
+const { createInterface } = require("node:readline");
+const dir = process.env.FAKE_CLAUDE_DIR;
+const log = (line) => fs.appendFileSync(path.join(dir, "fake-claude.log"), new Date().toISOString() + " pid=" + process.pid + " " + line + "\n");
+const argv = process.argv.slice(2);
+if (argv.includes("--version")) { process.stdout.write("2.1.300 (Claude Code)\n"); process.exit(0); }
+if (argv[0] === "auth" && argv[1] === "status") {
+  process.stdout.write(JSON.stringify({ loggedIn: true, authMethod: "claude.ai", email: "qa@example.com" }) + "\n");
+  process.exit(0);
+}
+log("spawn argv=" + JSON.stringify(argv));
+const send = (value) => process.stdout.write(JSON.stringify(value) + "\n");
+const sessionIdx = argv.indexOf("--session-id");
+const sessionId = sessionIdx >= 0 ? argv[sessionIdx + 1] : require("node:crypto").randomUUID();
+const turnMs = Number(process.env.FAKE_CLAUDE_TURN_MS || "340000");
+let resultEmitted = false;
+for (const sig of ["SIGTERM", "SIGINT", "SIGHUP"]) {
+  process.on(sig, () => { log("signal " + sig + (resultEmitted ? " (exit)" : " (ignored, turn in flight)")); if (resultEmitted) process.exit(0); });
+}
+process.stdin.on("end", () => { log("stdin end"); if (resultEmitted) process.exit(0); });
+setInterval(() => {}, 60_000);
+const rl = createInterface({ input: process.stdin });
+rl.on("line", (line) => {
+  let message;
+  try { message = JSON.parse(line); } catch { log("non-json line bytes=" + line.length); return; }
+  if (message.type === "control_request" && message.request && message.request.subtype === "initialize") {
+    log("initialize received");
+    send({ type: "control_response", response: { subtype: "success", request_id: message.request_id, response: { commands: [], models: [] } } });
+    return;
+  }
+  if (message.type === "control_request") {
+    log("control_request subtype=" + (message.request && message.request.subtype) + " request_id=" + message.request_id);
+    send({ type: "control_response", response: { subtype: "success", request_id: message.request_id, response: {} } });
+    return;
+  }
+  if (message.type === "control_cancel_request") { log("control_cancel_request " + message.request_id); return; }
+  if (message.type === "user") {
+    const content = message.message && message.message.content;
+    log("user turn received uuid=" + message.uuid + " contentHead=" + JSON.stringify(String(typeof content === "string" ? content : JSON.stringify(content)).slice(0, 120)));
+    fs.writeFileSync(path.join(dir, "turn-started.json"), JSON.stringify({ pid: process.pid, at: Date.now() }));
+    send({ type: "system", subtype: "init", session_id: sessionId, model: "claude-opus-5", tools: [], cwd: process.cwd() });
+    setTimeout(() => {
+      const text = "fake-claude reply " + sessionId;
+      send({ type: "assistant", message: { id: "msg_1", role: "assistant", model: "claude-opus-5", content: [{ type: "text", text }] }, session_id: sessionId });
+      send({ type: "result", subtype: "success", is_error: false, result: text, session_id: sessionId, duration_ms: turnMs, num_turns: 1, usage: { input_tokens: 10, output_tokens: 5 } });
+      resultEmitted = true;
+      log("turn finished (result emitted)");
+      fs.writeFileSync(path.join(dir, "turn-finished.json"), JSON.stringify({ pid: process.pid, at: Date.now() }));
+    }, turnMs);
+    return;
+  }
+  log("other message type=" + message.type);
+});
+`;
+
+async function waitFor<T>(
+  label: string,
+  probe: () => T | undefined | Promise<T | undefined>,
+  timeoutMs: number,
+  intervalMs = 500,
+): Promise<T> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const value = await probe();
+    if (value !== undefined) {
+      return value;
+    }
+    await delay(intervalMs);
+  }
+  throw new Error(`timed out waiting for ${label}`);
+}
+
+function readLog(file: string): string {
+  try {
+    return fs.readFileSync(file, "utf8");
+  } catch {
+    return "";
+  }
+}
+
+afterEach(async () => {
+  const errors: unknown[] = [];
+  try {
+    if (gatewayOwner) {
+      await stopQaGatewayFixture(gatewayOwner);
+    }
+  } catch (error) {
+    errors.push(error);
+  } finally {
+    harness = undefined;
+    gatewayOwner = undefined;
+  }
+  try {
+    await bus?.stop();
+  } catch (error) {
+    errors.push(error);
+  } finally {
+    bus = undefined;
+  }
+  if (errors.length > 0) {
+    throw new AggregateError(errors, "reload repro cleanup failed");
+  }
+});
+
+describe.runIf(process.env.OPENCLAW_E2E_PLUGIN_RELOAD_PROOF === "1")(
+  "claude-cli reply survives a plugin hot reload landing mid-turn (#144809)",
+  () => {
+    it(
+      "delivers the reply of a turn that outlives the forced plugin reload",
+      { timeout: 1_200_000 },
+      async () => {
+        const fakeRoot = process.env.OPENCLAW_E2E_PLUGIN_RELOAD_PROOF_DIR ?? os.tmpdir();
+        fs.mkdirSync(fakeRoot, { recursive: true });
+        const fakeDir = fs.mkdtempSync(path.join(fakeRoot, "fake-claude-"));
+        const fakeBin = path.join(fakeDir, "claude");
+        fs.writeFileSync(fakeBin, FAKE_CLAUDE, { mode: 0o755 });
+        process.env.PATH = `${fakeDir}${path.delimiter}${process.env.PATH ?? ""}`;
+        process.env.FAKE_CLAUDE_DIR = fakeDir;
+        process.env.FAKE_CLAUDE_TURN_MS = String(TURN_MS);
+
+        const state = createQaBusState();
+        const transport = createQaChannelTransport(state);
+        bus = await startQaBusServer({ state });
+        gatewayOwner = createQaLiveLaneGateway();
+        harness = await gatewayOwner.start({
+          repoRoot: process.cwd(),
+          providerMode: "mock-openai",
+          primaryModel: "mock-openai/gpt-5.6-luna",
+          alternateModel: "mock-openai/gpt-5.6-luna-alt",
+          transport,
+          transportBaseUrl: bus.baseUrl,
+          controlUiEnabled: false,
+          mutateConfig: (config) => ({
+            ...config,
+            plugins: {
+              ...config.plugins,
+              allow: [...new Set([...(config.plugins?.allow ?? []), "anthropic"])],
+              entries: { ...config.plugins?.entries, anthropic: { enabled: true } },
+            },
+            agents: {
+              ...config.agents,
+              defaults: {
+                ...config.agents?.defaults,
+                model: CLI_MODEL,
+                models: { ...config.agents?.defaults?.models, [CLI_MODEL]: {} },
+                modelPolicy: {
+                  allow: [...(config.agents?.defaults?.modelPolicy?.allow ?? []), CLI_MODEL],
+                },
+              },
+              entries: {
+                ...config.agents?.entries,
+                qa: { ...config.agents?.entries?.qa, model: CLI_MODEL },
+              },
+            },
+          }),
+        });
+        const { gateway } = harness;
+        const stdoutLog = path.join(gateway.tempRoot, "gateway.stdout.log");
+        const stderrLog = path.join(gateway.tempRoot, "gateway.stderr.log");
+        const record: Record<string, unknown> = { turnMs: TURN_MS, tempRoot: gateway.tempRoot };
+
+        state.addInboundMessage({
+          accountId: ACCOUNT_ID,
+          conversation: { kind: "direct", id: PEER_ID },
+          senderId: PEER_ID,
+          text: `reload repro ${randomUUID()}`,
+        });
+        const started = await waitFor(
+          "fake claude turn start",
+          () => (fs.existsSync(path.join(fakeDir, "turn-started.json")) ? true : undefined),
+          90_000,
+        );
+        record.turnStartedAt = new Date().toISOString();
+        expect(started).toBe(true);
+        await delay(5_000);
+
+        const configBefore = (await gateway.call("config.get", {})) as {
+          hash?: string;
+          config?: { plugins?: { allow?: string[] } };
+        };
+        const allowBefore = configBefore.config?.plugins?.allow ?? [];
+        record.allowBefore = allowBefore;
+        // Mirror the reporter: a channel-affecting change plus a plugins.* change
+        // (plugins.* forces reloadPlugins + disposeMcpRuntimes in the reload plan).
+        const patchRaw = {
+          channels: { [CHANNEL_ID]: { pollTimeoutMs: 700 } },
+          plugins: { allow: [...new Set([...allowBefore, "discord"])] },
+        };
+        // config.patch blocks until the deferred reload applies (300 s), so do not await it.
+        const patchPromise = gateway
+          .call(
+            "config.patch",
+            {
+              raw: JSON.stringify(patchRaw),
+              baseHash: configBefore.hash,
+              replacePaths: ["plugins.allow"],
+              restartDelayMs: 0,
+            },
+            { timeoutMs: 900_000 },
+          )
+          .then(
+            (result) => {
+              record.patchResult = result;
+              record.patchResolvedAt = new Date().toISOString();
+            },
+            (error: unknown) => {
+              record.patchError = String(error);
+              record.patchResolvedAt = new Date().toISOString();
+            },
+          );
+        record.patchedAt = new Date().toISOString();
+
+        await waitFor(
+          "channel reload deferral log line",
+          () =>
+            /requires channel reload|deferring until/.test(
+              `${readLog(stdoutLog)}\n${readLog(stderrLog)}`,
+            )
+              ? true
+              : undefined,
+          60_000,
+        );
+        record.deferralSeen = true;
+
+        const finished = await waitFor(
+          "fake claude turn finish",
+          () => (fs.existsSync(path.join(fakeDir, "turn-finished.json")) ? true : undefined),
+          TURN_MS + 120_000,
+          2_000,
+        ).catch((error: unknown) => String(error));
+        record.turnFinished = finished;
+        await delay(20_000);
+
+        await Promise.race([patchPromise, delay(30_000)]);
+        const outbound = state
+          .getSnapshot()
+          .messages.filter((message) => message.direction === "outbound")
+          .map((message) => ({ accountId: message.accountId, text: message.text }));
+        const stdout = `${readLog(stdoutLog)}\n${readLog(stderrLog)}`;
+        const interesting = stdout
+          .split("\n")
+          .filter((line) =>
+            /authority snapshot|\[reload\]|cli turn|cli-backend|Embedded agent|failed before|aborted|reply run|stopping qa-channel|restarting qa-channel|channel reload/i.test(
+              line,
+            ),
+          )
+          .map((line) => line.replace(/\[[0-9;]*m/g, "").slice(0, 400));
+        record.outbound = outbound;
+        record.gatewayLines = interesting;
+        record.fakeClaudeLog = readLog(path.join(fakeDir, "fake-claude.log"));
+        record.stderrTail = readLog(stderrLog).slice(-2000);
+        const verdictPath = path.join(fakeDir, "verdict.json");
+        fs.writeFileSync(verdictPath, JSON.stringify(record, null, 2));
+        console.log(`PLUGIN_RELOAD_PROOF ${verdictPath}`);
+        console.log(JSON.stringify(record, null, 2));
+
+        expect(finished).toBe(true);
+        expect(interesting.some((line) => line.includes("reloading channels anyway"))).toBe(true);
+        expect(
+          interesting.some((line) =>
+            line.includes("stopping qa-channel channel before plugin reload"),
+          ),
+        ).toBe(true);
+        expect(
+          interesting.filter((line) => /stream is closed|failed before reply/.test(line)),
+        ).toEqual([]);
+        expect(outbound.map((message) => message.text)).toEqual([
+          expect.stringMatching(/^fake-claude reply /),
+        ]);
+      },
+    );
+  },
+);

--- a/test/e2e/qa-lab/runtime/reply-run-plugin-reload.product-proof.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/reply-run-plugin-reload.product-proof.e2e.test.ts
@@ -1,6 +1,6 @@
-// Product proof for #144809: a plugin hot reload that lands after the 300 s
-// channel-reload deferral must not discard the reply of a claude-cli turn that
-// is still running. Runs a real Gateway with a fake `claude` executable on PATH
+// Product proof for the reload path in #144809: replacing the active backend
+// during a channel config reload must not discard an admitted claude-cli reply.
+// Runs a real Gateway with a fake `claude` executable on PATH
 // that speaks the stdio protocol and answers only after the reload has applied.
 import { randomUUID } from "node:crypto";
 import fs from "node:fs";
@@ -175,7 +175,10 @@ describe.runIf(process.env.OPENCLAW_E2E_PLUGIN_RELOAD_PROOF === "1")(
             plugins: {
               ...config.plugins,
               allow: [...new Set([...(config.plugins?.allow ?? []), "anthropic"])],
-              entries: { ...config.plugins?.entries, anthropic: { enabled: true } },
+              entries: {
+                ...config.plugins?.entries,
+                anthropic: { enabled: true, subagent: { allowModelOverride: true } },
+              },
             },
             agents: {
               ...config.agents,
@@ -219,22 +222,22 @@ describe.runIf(process.env.OPENCLAW_E2E_PLUGIN_RELOAD_PROOF === "1")(
           hash?: string;
           config?: { plugins?: { allow?: string[] } };
         };
-        const allowBefore = configBefore.config?.plugins?.allow ?? [];
-        record.allowBefore = allowBefore;
-        // Mirror the reporter: a channel-affecting change plus a plugins.* change
-        // (plugins.* forces reloadPlugins + disposeMcpRuntimes in the reload plan).
+        const pluginsBefore = (await gateway.call("plugins.list", {})) as { generation: number };
+        record.generationBefore = pluginsBefore.generation;
+        // A per-plugin entry change explicitly replaces Anthropic; unrelated allowlist
+        // changes retain it. Tighten an unused fixture policy while preserving the
+        // channel change that exercises active-work deferral and channel restart.
         const patchRaw = {
           channels: { [CHANNEL_ID]: { pollTimeoutMs: 700 } },
-          plugins: { allow: [...new Set([...allowBefore, "discord"])] },
+          plugins: { entries: { anthropic: { subagent: { allowModelOverride: false } } } },
         };
-        // config.patch blocks until the deferred reload applies (300 s), so do not await it.
+        // Observe publication while config.patch awaits the reload's channel tail.
         const patchPromise = gateway
           .call(
             "config.patch",
             {
               raw: JSON.stringify(patchRaw),
               baseHash: configBefore.hash,
-              replacePaths: ["plugins.allow"],
               restartDelayMs: 0,
             },
             { timeoutMs: 900_000 },
@@ -275,7 +278,7 @@ describe.runIf(process.env.OPENCLAW_E2E_PLUGIN_RELOAD_PROOF === "1")(
               .find(
                 (candidate) =>
                   candidate.includes("config hot reload applied (") &&
-                  candidate.includes("plugins.allow"),
+                  candidate.includes("plugins.entries.anthropic"),
               );
             return line ?? undefined;
           },
@@ -288,7 +291,7 @@ describe.runIf(process.env.OPENCLAW_E2E_PLUGIN_RELOAD_PROOF === "1")(
           appliedConfigHash?: string | null;
           configRevisionHash?: string;
           config?: {
-            plugins?: { allow?: string[] };
+            plugins?: { entries?: { anthropic?: { subagent?: { allowModelOverride?: boolean } } } };
             channels?: Record<string, { pollTimeoutMs?: number }>;
           };
         };
@@ -296,7 +299,7 @@ describe.runIf(process.env.OPENCLAW_E2E_PLUGIN_RELOAD_PROOF === "1")(
           hash: configAfter.hash,
           appliedConfigHash: configAfter.appliedConfigHash,
           configRevisionHash: configAfter.configRevisionHash,
-          allow: configAfter.config?.plugins?.allow,
+          anthropic: configAfter.config?.plugins?.entries?.anthropic,
           pollTimeoutMs: configAfter.config?.channels?.[CHANNEL_ID]?.pollTimeoutMs,
         };
         // appliedConfigHash is published by the reload/restart publication; the
@@ -304,7 +307,18 @@ describe.runIf(process.env.OPENCLAW_E2E_PLUGIN_RELOAD_PROOF === "1")(
         // recovery restart stays pending and that hash is not asserted here. The
         // committed content plus the applied log line are the replacement evidence.
         expect(configAfter.hash).not.toBe(configBefore.hash);
-        expect(configAfter.config?.plugins?.allow).toContain("discord");
+        expect(configAfter.config?.plugins?.entries?.anthropic?.subagent?.allowModelOverride).toBe(
+          false,
+        );
+        const pluginsAfter = (await gateway.call("plugins.list", {})) as {
+          generation: number;
+          plugins: Array<{ id: string; runtime: { state: string } }>;
+        };
+        record.generationAfter = pluginsAfter.generation;
+        expect(pluginsAfter.generation).toBeGreaterThan(pluginsBefore.generation);
+        expect(
+          pluginsAfter.plugins.find((plugin) => plugin.id === "anthropic")?.runtime.state,
+        ).toBe("active");
         expect(configAfter.config?.channels?.[CHANNEL_ID]?.pollTimeoutMs).toBe(700);
         // config.patch must settle before the CLI result. It may report that the
         // committed change still needs a recovery restart (the forced qa-channel
@@ -326,6 +340,27 @@ describe.runIf(process.env.OPENCLAW_E2E_PLUGIN_RELOAD_PROOF === "1")(
         ) {
           throw new Error(`config.patch did not commit the replacement: ${patchOutcome.error}`);
         }
+
+        // This owner-emitted observation names the retired backend, not merely a
+        // changed registry: its physical cleanup is waiting for this admitted turn.
+        const retirementLine = await waitFor(
+          "retired Anthropic instance before the CLI result",
+          () => {
+            if (fs.existsSync(turnFinishedPath)) {
+              throw new Error("CLI turn finished before Anthropic retirement was observed");
+            }
+            return readGatewayLogs()
+              .split("\n")
+              .map(stripAnsi)
+              .find((line) =>
+                line.includes(
+                  "Plugin anthropic cleanup is deferred until its admitted turn finishes.",
+                ),
+              );
+          },
+          20_000,
+        );
+        record.retirementLine = retirementLine;
 
         const finished = await waitFor(
           "fake claude turn finish",
@@ -371,12 +406,16 @@ describe.runIf(process.env.OPENCLAW_E2E_PLUGIN_RELOAD_PROOF === "1")(
         const cliTurnAt = Date.parse((cliTurnLine ?? "").slice(0, 29));
         expect(Number.isFinite(appliedAt) && Number.isFinite(cliTurnAt)).toBe(true);
         expect(appliedAt).toBeLessThan(cliTurnAt);
-        expect(interesting.some((line) => line.includes("reloading channels anyway"))).toBe(true);
-        expect(
-          interesting.some((line) =>
-            line.includes("stopping qa-channel channel before plugin reload"),
-          ),
-        ).toBe(true);
+        const channelRestartLine = interesting.find((line) =>
+          line.includes("restarting qa-channel channel"),
+        );
+        expect(channelRestartLine).toBeDefined();
+        const channelRestartAt = Date.parse((channelRestartLine ?? "").slice(0, 29));
+        expect(Number.isFinite(channelRestartAt)).toBe(true);
+        expect(channelRestartAt).toBeLessThan(cliTurnAt);
+        const retiredAt = Date.parse(retirementLine.slice(0, 29));
+        expect(Number.isFinite(retiredAt)).toBe(true);
+        expect(retiredAt).toBeLessThan(cliTurnAt);
         expect(
           interesting.filter((line) => /stream is closed|failed before reply/.test(line)),
         ).toEqual([]);


### PR DESCRIPTION
Related: #144809 — fixes the demonstrated plugin-replacement reply-loss path; the no-config-event failures remain outside this PR.

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes the demonstrated reload path in #144809: an admitted long-running `claude-cli` turn can lose its completed reply when its backend plugin instance is replaced mid-turn. The retained-consumer repair keeps that prepared backend available through execution and cleanup. The reporter also described failures without nearby config events; those are not claimed fixed here. Current selective reload preserves unchanged plugin instances, so the regression lane explicitly changes the active Anthropic entry instead of assuming any `plugins.*` change retires it.

## Why This Change Was Made

A plugin hot reload disposes the previous plugin instance after a bounded 5 s call drain and then rejects that instance's ordinary calls and streams. The Claude CLI turn kept running inside the old instance, so its execution stream, JSONL lifecycle parser, output text transforms, and prepared-backend cleanup all hit `Plugin anthropic stream is closed` / `Plugin anthropic was reloaded or disabled` once the drain expired, and the finished turn was reported as a failure. The plugin instance already distinguishes retained consumers ("physical cleanup waits for those consumers to close") from ordinary calls, so the prepared CLI run now retains one consumer on the backend's owning instance for the whole turn: acquired when the plugin execution is prepared, entered around the queued execution attempt, and released after the prepared-backend cleanup. Nested plugin calls made inside that scope join the consumer's admission, so the retired instance keeps serving this turn until it settles while new turns already route to the reloaded instance. No reload timing, threshold, or config surface changes.

Non-goals: this does not change when a channel or plugin reload is applied over active work, and it does not cover the two reporter failures that had no config event nearby.

## User Impact

Long `claude-cli` turns survive a plugin hot reload that lands mid-turn: the reply is delivered instead of being replaced by a generic failure. The covered backend-replacement path preserves the in-flight answer; this is not a claim that all config-related or unrelated delivery failures are fixed.

## Evidence

- Regression test `src/agents/cli-runner/execute.plugin-reload.test.ts`: runs `executePreparedCliRun` against a plugin-owned backend whose instance is disposed mid-turn, advances past the 5 s drain deadline, then finishes the turn. Without the execution-scope entry the run never settles (`CLI run did not settle after its plugin instance retired`); with the fix it resolves with the reply text, the prepared cleanup still runs inside the retained scope, and the instance disposal completes with no errors. `execute-plugin.test.ts`, `cli-runner.reliability.test.ts`, and `btw.test.ts` stay green (182 + 38 tests). `node scripts/check-changed.mjs` lanes (core tsgo graph boundary, typecheck core/core tests/test root, dead export scan, lint core changed files, lint scripts, and the guard lanes) pass; the `lint test root changed file` lane passes with its exact command on the e2e file (`node scripts/run-oxlint.mjs --tsconfig test/tsconfig/tsconfig.test.root.json …`, exit 0).
- Current real-Gateway proof lane `test/e2e/qa-lab/runtime/reply-run-plugin-reload.product-proof.e2e.test.ts`: qa-channel transport plus an injected fake `claude` executable speaking the actual CLI stdio protocol, with a 340-second delayed result. The repair explicitly changes `plugins.entries.anthropic.subagent.allowModelOverride` alongside `channels.qa-channel.pollTimeoutMs`. It checks changed config, plugin generation advancement, an active replacement, the owner-emitted deferred-cleanup observation for Anthropic, reload/channel-restart ordering before CLI completion, successful outbound reply, and absence of stream-closed/failed-before-reply errors. This is isolated mock-channel/provider Gateway evidence, not an authenticated live-provider test.

  **Historical evidence below:** the older allowlist-trigger runs predate the selective-reload fixture repair. Their 300-second channel-deferral ordering is historical, not the ordering asserted by the current lane.
  Before the fix (`main` @ 24109cc97c2, ej-devbox, 2026-09-11):

```
22:42:02 [agent/cli-backend] cli live session start: provider=claude-cli model=claude-opus-5 activeSessions=1
22:42:08 [reload] config change requires channel reload (qa-channel) — deferring until 1 operation(s), 1 reply(ies), 1 embedded run(s) complete
22:47:09 [reload] channel reload timeout after 300336ms with 1 operation(s), 1 reply(ies), 1 embedded run(s) still active; reloading channels anyway
22:47:09 [gateway/channels] stopping qa-channel channel before plugin reload
22:47:15 [reload] config hot reload applied (plugins.allow, channels.qa-channel.pollTimeoutMs)
22:47:19 [plugins/cleanup] Plugin anthropic cleanup failed: Plugin anthropic still has active calls after 5000ms
22:47:42 [agent/cli-backend] cli terminal failure: provider=claude-cli model=claude-opus-5 durationMs=341607 error=Plugin anthropic stream is closed
22:47:42 Embedded agent failed before reply: Plugin anthropic stream is closed
```

  Outbound message: `⚠️ Something went wrong while processing your request. Please try again, or use /new to start a fresh session.` The fake CLI received no signal or interrupt and emitted its `result` record normally. The same scenario without the `plugins.*` change (channel reload only) delivered the reply, which isolates the plugin retirement as the trigger. A stream-only retained consumer moved the failure to the next plugin call (`CLI backend claude-cli JSONL lifecycle parser failed: Plugin anthropic was reloaded or disabled; use its current tools.`), which is why the scope covers the whole prepared turn.

  After the fix (historical branch revision, 2026-09-12):

```
00:18:38 [agent/cli-backend] cli live session start: provider=claude-cli model=claude-opus-5 activeSessions=1
00:18:44 [reload] config change requires channel reload (qa-channel) — deferring until 1 operation(s), 1 reply(ies), 1 embedded run(s) complete
00:23:45 [reload] channel reload timeout after 300141ms with 1 operation(s), 1 reply(ies), 1 embedded run(s) still active; reloading channels anyway
00:23:45 [gateway/channels] stopping qa-channel channel before plugin reload
00:23:51 [reload] config hot reload applied (plugins.allow, channels.qa-channel.pollTimeoutMs)
00:24:18 [agent/cli-backend] cli turn: provider=claude-cli model=claude-opus-5 durationMs=340211 outBytes=54 outHash=d89df11fa99f
```

  Outbound message: `fake-claude reply 5e3f6ff2-…`; no `stream is closed`, `reloaded or disabled`, or `failed before reply` lines, and no `Plugin anthropic cleanup failed` warning. Test result: `✓ delivers the reply of a turn that outlives the forced plugin reload (403824ms)`.

  Tightened lane (commit with the committed-replacement checks), ordering evidence from the run on 2026-09-12:

```
04:37:37 [reload] channel reload timeout after 300421ms with 1 operation(s), 1 reply(ies), 1 embedded run(s), 1 gateway request(s), 1 background task run(s) still active; reloading channels anyway
04:37:37 [gateway/channels] stopping qa-channel channel before plugin reload
04:37:42 [gateway/channels] restarting qa-channel channel
04:37:42 [gateway/channels] failed to restart qa-channel channel during hot reload: qa-channel[default] replacement not admitted: task-owned
04:37:42 [reload] config hot reload applied (plugins.allow, channels.qa-channel.pollTimeoutMs)
04:38:10 [agent/cli-backend] cli turn: provider=claude-cli model=claude-opus-5 durationMs=340720 outBytes=54 outHash=05b89693e3be
```

  Historical tightened-lane run on revision 4cecab07057, same ordering:

```
04:46:50 [reload] channel reload timeout after 300178ms with 1 operation(s), 1 reply(ies), 1 embedded run(s), 1 gateway request(s), 1 background task run(s) still active; reloading channels anyway
04:46:50 [gateway/channels] stopping qa-channel channel before plugin reload
04:46:57 [reload] config hot reload applied (plugins.allow, channels.qa-channel.pollTimeoutMs)
04:47:23 [agent/cli-backend] cli turn: provider=claude-cli model=claude-opus-5 durationMs=340250 outBytes=54 outHash=f165455e8d3b
```

  `config.get` after the applied line: new `hash`, `plugins.allow` = `["qa-lab", "qa-channel", "anthropic", "discord"]`, `channels.qa-channel.pollTimeoutMs` = 700; `config.patch` settled at 04:46:57.440 with the persisted-but-recovery-restart-pending outcome (the forced qa-channel restart under its own active turn is refused with `replacement not admitted: task-owned`). Outbound message: `fake-claude reply ddd607eb-…`. Test result: `✓ delivers the reply of a turn that outlives the forced plugin reload (428524ms)`.
- Autoreview (Codex, P0–P2 threshold) on the branch diff: scoped-clean, no actionable findings; the reviewer could not see the prepare-failure path, which was checked separately: `prepareCliRunContext` runs `cleanupPreparedResources` in its `catch`, and the consumer is acquired immediately before that cleanup is assigned with no await in between.
- Historical side observation, unchanged by this PR: forcing the qa-channel restart under an active turn fails with `replacement not admitted: task-owned` and escalates to a deferred Gateway restart once the turn completes.


## Selective-reload regression repair — September 12, 2026

Test-only follow-up `e0a3015f175c6606213f7e05738a19990433144a` against production head `4f5d256d9f42170d6b211407931dedb40600c960`: +60/-21 test lines, no production changes. Addresses the current ClawSweeper finding and rank-up request to replace the actual active backend and observe retirement before completion.

Positive run: exit 0. Plugin generation advanced 2 → 3; `config.patch` succeeded. Observed local timestamps (UTC−07:00):

```text
07:32:22.634 CLI turn started
07:32:28.346 Plugin anthropic cleanup is deferred until its admitted turn finishes.
07:32:28.998 restarting qa-channel channel
07:32:34.057 config hot reload applied (plugins.entries.anthropic.subagent.allowModelOverride, channels.qa-channel.pollTimeoutMs)
07:38:02.617 cli turn completed (340560ms)
Outbound: fake-claude reply <synthetic session id>
```

Negative control: identical fixture with only the four production retention changes reversed, exit 1: `CLI turn finished before Anthropic retirement was observed`. This demonstrates that the lane rejects the no-retention variant. It stopped at that assertion, so this run does **not** independently establish the eventual outbound error or reproduce the historical stream-closed signature. Production restoration completed with exit 0 and `git diff --quiet HEAD -- src` verified no remaining production differences.

```bash
OPENCLAW_E2E_PLUGIN_RELOAD_PROOF=1 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=900000   node scripts/run-vitest.mjs run --config test/vitest/vitest.e2e.config.ts   test/e2e/qa-lab/runtime/reply-run-plugin-reload.product-proof.e2e.test.ts
node scripts/check-changed.mjs -- test/e2e/qa-lab/runtime/reply-run-plugin-reload.product-proof.e2e.test.ts
git diff --cached --check
```

Changed-file checks completed successfully (exit 0), including test-root typecheck, dead-export scans, guards, and lint. The normal pre-commit formatter/content hook passed.

Fresh staged-candidate autoreview against pinned merge base `0325f01ac8e1b35c1d8af69f7b0c0da0d8d60f92`: scoped-clean at P0–P2, no actionable findings. Exact-head hosted CI remains a separate landing gate; the earlier candidate had three failed test shards and is not treated as cleared by local proof or passing main comparisons.
