### PR TITLE
fix(heartbeat): recover tombstoned isolated sessions

### DIFF
--- a/src/cron/isolated-agent/session.test.ts
+++ b/src/cron/isolated-agent/session.test.ts
@@ -185,6 +185,30 @@ describe("resolveCronSession", () => {
     expect(result.sessionEntry.heartbeatIsolatedBaseSessionKey).toBeUndefined();
   });
 
+  it("rolls a tombstoned isolated heartbeat session into a fresh run", () => {
+    const result = resolveWithStoredEntry({
+      sessionKey: "agent:main:main:heartbeat",
+      entry: {
+        sessionId: "tombstoned-heartbeat-session-id",
+        updatedAt: NOW_MS - 1000,
+        abortedLastRun: true,
+        mainRestartRecovery: {
+          cycleId: "recovery-cycle",
+          revision: 22,
+          chargedAttempts: 22,
+          tombstone: { reason: "recovery-exhausted" },
+        },
+        heartbeatIsolatedBaseSessionKey: "agent:main:main",
+      },
+      forceNew: true,
+    });
+
+    expect(result.isNewSession).toBe(true);
+    expect(result.sessionEntry.sessionId).not.toBe("tombstoned-heartbeat-session-id");
+    expect(result.sessionEntry.abortedLastRun).toBeUndefined();
+    expect(result.sessionEntry.mainRestartRecovery).toBeUndefined();
+  });
+
   it("keeps an initializing isolated heartbeat blocked during forced rollover", () => {
     expect(() =>
       resolveWithStoredEntry({

--- a/src/cron/isolated-agent/session.ts
+++ b/src/cron/isolated-agent/session.ts
@@ -173,12 +173,15 @@ export function resolveCronSession(params: {
   // Guard the run's target row even when a differing source session seeds the
   // carried preferences. A forced isolated heartbeat may replace its archived
   // synthetic row, but trusted initialization must still finish first.
-  const canRollArchivedHeartbeat =
+  const canRollIsolatedHeartbeat =
     params.forceNew === true &&
-    targetEntry?.archivedAt !== undefined &&
-    targetEntry.initializationPending !== true &&
+    targetEntry?.initializationPending !== true &&
     Boolean(targetEntry.heartbeatIsolatedBaseSessionKey?.trim());
-  const sessionWorkStartError = resolveSessionWorkStartError(params.sessionKey, targetEntry);
+  const canRollArchivedHeartbeat =
+    canRollIsolatedHeartbeat && targetEntry?.archivedAt !== undefined;
+  const sessionWorkStartError = resolveSessionWorkStartError(params.sessionKey, targetEntry, {
+    allowRestartTombstoneReplacement: canRollIsolatedHeartbeat,
+  });
   if (sessionWorkStartError && !canRollArchivedHeartbeat) {
     throw new Error(sessionWorkStartError);
   }


### PR DESCRIPTION
## Problem

A failed isolated heartbeat can retain a restart-recovery tombstone and block every later forced heartbeat rollover.

## Solution

Permit forced rollover only for an initialized isolated heartbeat session; the fresh rollover drops the stale recovery state.

## Validation

- `node scripts/run-vitest.mjs src/cron/isolated-agent/session.test.ts`
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/cron/isolated-agent/session.ts src/cron/isolated-agent/session.test.ts`