### PR TITLE
fix: tool output goes missing when a tool produces no output

### DIFF
--- a/src/agents/harness/tool-result-middleware.test.ts
+++ b/src/agents/harness/tool-result-middleware.test.ts
@@ -636,6 +636,54 @@ describe("createAgentToolResultMiddlewareRunner", () => {
     });
   });
 
+  it("preserves empty output from a nested tool_result instead of failing closed", async () => {
+    // A tool that legitimately produced no output (`echo` printing nothing, reading an
+    // empty file) still returns a valid text block whose text is "". Flattening used to
+    // drop that block, leaving zero blocks, which the validator read as invalid and
+    // turned into a post-processing error. Empty output must stay empty output.
+    const runner = createAgentToolResultMiddlewareRunner({ runtime: "openclaw" }, [
+      (eventValue) => ({ result: eventValue.result }),
+    ]);
+
+    const result = await runner.applyToolResultMiddleware({
+      toolCallId: "call-1",
+      toolName: "exec",
+      args: {},
+      result: {
+        content: [{ type: "tool_result", content: [{ type: "text", text: "" }] }],
+        details: {},
+      } as never,
+    });
+
+    expect(result).toEqual({
+      content: [{ type: "text", text: "" }],
+      details: {},
+    });
+  });
+
+  it("still fails closed when nested content is malformed rather than empty", async () => {
+    // The empty-output carve-out above must not weaken the fail-closed path: content
+    // that flattens to nothing because it is malformed still has to be rejected.
+    const runner = createAgentToolResultMiddlewareRunner({ runtime: "openclaw" }, [
+      (eventValue) => ({ result: eventValue.result }),
+    ]);
+
+    const result = await runner.applyToolResultMiddleware({
+      toolCallId: "call-1",
+      toolName: "exec",
+      args: {},
+      result: {
+        content: [{ type: "tool_result", content: [null] }],
+        details: {},
+      } as never,
+    });
+
+    expect(result).toEqual({
+      content: [{ type: "text", text: "Tool output unavailable due to post-processing error." }],
+      details: { status: "error", middlewareError: true },
+    });
+  });
+
   it("accepts well-formed middleware results", async () => {
     const runner = createAgentToolResultMiddlewareRunner({ runtime: "codex" }, [
       (eventValue, ctx) => ({

--- a/src/agents/harness/tool-result-middleware.ts
+++ b/src/agents/harness/tool-result-middleware.ts
@@ -212,6 +212,13 @@ function coerceMiddlewareContentArray(
   options: MiddlewareToolResultCoerceOptions = {},
 ): MiddlewareContentBlock[] {
   const blocks: MiddlewareContentBlock[] = [];
+  // A tool that legitimately produced no output (`echo` with nothing to print,
+  // reading an empty file) still returns a valid text block whose text is "".
+  // `appendMiddlewareContentBlock` skips those while merging, which is correct
+  // mid-array but collapses an all-empty nested result to zero blocks. The
+  // caller reads zero blocks as "invalid" and fails the result closed, so empty
+  // output would surface as a post-processing error instead of empty output.
+  let sawValidEmptyText = false;
   for (const entry of content.slice(0, MAX_MIDDLEWARE_CONTENT_BLOCKS)) {
     if (blocks.length >= MAX_MIDDLEWARE_CONTENT_BLOCKS) {
       break;
@@ -221,8 +228,17 @@ function coerceMiddlewareContentArray(
     for (const block of text
       ? [{ type: "text" as const, text: truncateUtf16Safe(text, MAX_MIDDLEWARE_TEXT_CHARS) }]
       : coerced) {
+      if (block.type === "text" && !block.text) {
+        sawValidEmptyText = true;
+      }
       appendMiddlewareContentBlock(blocks, block);
     }
+  }
+  // Preserve emptiness only when every block was a valid-but-empty text block.
+  // Content that coerced to nothing because it was malformed still returns [],
+  // keeping the fail-closed path intact for genuinely invalid middleware output.
+  if (blocks.length === 0 && sawValidEmptyText) {
+    return [{ type: "text", text: "" }];
   }
   return blocks;
 }


### PR DESCRIPTION
Related: #105528

## What Problem This Solves

Fixes an issue where a tool result that contains no text is turned into an error message instead of being shown as empty.

When a tool result arrives wrapped in a nested `tool_result` block, and the text inside it is empty, the assistant does not show empty output. It shows "Tool output unavailable due to post-processing error." Nothing actually went wrong. The tool simply had nothing to say.

This only happens in sessions where a tool-result middleware is registered. Sessions without one, including sub-agents, are unaffected, so the problem looks intermittent.

## Why This Change Was Made

When a tool finishes, its result passes through a middleware step that flattens nested content. A result with no text still carries a valid text block that happens to be empty. The flattening step dropped that block, which left nothing behind. The checker treats "nothing at all" as broken output, so it swapped the result for an error.

The change keeps an empty result as an empty result instead of discarding it.

The carve-out is deliberately narrow. It applies only when every block was a valid but empty piece of text. Content that ends up empty because it was genuinely malformed is still rejected exactly as before, so the existing safety behaviour does not change.

## User Impact

A tool that returns nothing now reads as nothing, which is the truth, instead of an error that suggests a failure occurred.

To be accurate about scope: I have not traced which specific tool emitters produce an empty nested text block in practice. Nested `tool_result` is clearly an expected input shape at this layer, since the existing test file already covers several variants of it. Worth noting that the `exec` tool substitutes a "(no output)" placeholder on its completion path, so a plain `exec` command that prints nothing is unlikely to be the trigger.

## Evidence

Added two tests to `src/agents/harness/tool-result-middleware.test.ts`:

- one showing an empty result is preserved rather than converted into an error
- one showing genuinely malformed content still fails closed, so the existing protection is intact

The middleware test file passes, 27 tests including the 25 that were already there:

```
Test Files  1 passed (1)
     Tests  27 passed (27)
```

Before the change, that input returned:

```
{"content":[{"type":"text","text":"Tool output unavailable due to post-processing error."}],
 "details":{"status":"error","middlewareError":true}}
```

After the change it returns:

```
{"content":[{"type":"text","text":""}],"details":{}}
```

I found this while reading the code path #105528 points at, and it produces the same class of symptom that issue describes. I could not reproduce #105528 itself end to end, so I am not claiming this is its cause. It is a real bug on that path regardless, which is why this is linked as related rather than as a fix for it.
