### PR TITLE
refactor(tests): reuse field assertions in devices CLI tests

### DIFF
--- a/src/cli/devices-cli.test.ts
+++ b/src/cli/devices-cli.test.ts
@@ -3,6 +3,7 @@ import { Command } from "commander";
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { stripAnsi } from "../../packages/terminal-core/src/ansi.js";
+import { expectObjectFields } from "../test-utils/mock-call-assertions.js";
 import { registerDevicesCli } from "./devices-cli.js";
 
 const mocks = vi.hoisted(() => ({
@@ -199,19 +200,13 @@ const nodeApprovalErrorCases = [
   },
 ];
 
-function expectRecordFields(record: Record<string, unknown>, fields: Record<string, unknown>) {
-  for (const [key, value] of Object.entries(fields)) {
-    expect(record[key]).toEqual(value);
-  }
-}
-
 function requireGatewayCall(index: number): Record<string, unknown> {
   const call = (callGateway.mock.calls as unknown[][])[index]?.[0];
   return requireRecord(call, `gateway call ${index + 1}`);
 }
 
 function expectGatewayCall(index: number, fields: Record<string, unknown>) {
-  expectRecordFields(requireGatewayCall(index), fields);
+  expectObjectFields(requireGatewayCall(index), fields);
 }
 
 function hasGatewayMethod(method: string): boolean {


### PR DESCRIPTION
## What Problem This Solves

Devices CLI tests duplicate a field-comparison loop already provided by the shared test helper.

## Why This Change Was Made

Use `expectObjectFields` inside the existing adapter while preserving its object guard, all 22 assertion sites, and cleanup.

## User Impact

No production behavior change or test cases added/removed. One test file adds 2 lines and removes 7.

## Evidence

The complete Devices and lazy-registration suites passed before and after: 74 cases per phase (72 + 2). Displayed native case identities, order, and statuses match; full source test bodies and tables are unchanged. Independent review found no actionable P0–P2 issues.

All 20 normal changed-file checks passed, including formatting, typechecking, lint, and dead-code scans. Source and dependency bytes remained unchanged through proof.
