### PR TITLE
fix(audio): preserve complete voice-note transcription

### DIFF
--- a/docs/providers/deepgram.md
+++ b/docs/providers/deepgram.md
@@ -111,6 +111,11 @@ it to Deepgram's `/v2/listen` WebSocket endpoint.
 Set `tools.media.models[].model` to either Flux model in the getting-started
 configuration above.
 
+Voice-note conversion processes the complete audio file, including notes longer
+than 20 minutes. Decoded audio uses a private temporary file, which is removed
+after the transcription attempt. The configured input-size and request-timeout
+limits still apply; failed conversion or upload does not return a partial transcript.
+
 Flux supports `eager_eot_threshold`, `eot_threshold`, `eot_timeout_ms`,
 `keyterm`, `language_hint`, `mip_opt_out`, `numerals`, `profanity_filter`,
 `redact`, and `tag` in `providerOptions.deepgram`. OpenClaw ignores batch-only

--- a/extensions/deepgram/audio-flux.live.test.ts
+++ b/extensions/deepgram/audio-flux.live.test.ts
@@ -1,0 +1,117 @@
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
+import { expectDefined } from "@openclaw/normalization-core";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
+import type { MediaUnderstandingProvider } from "openclaw/plugin-sdk/media-understanding";
+import { createTestPluginApi } from "openclaw/plugin-sdk/plugin-test-api";
+import { expect, it } from "vitest";
+import { WebSocketServer } from "ws";
+import plugin from "./index.js";
+
+// Exercises index.ts registration -> transcribeAudio -> real ffmpeg -> provider socket.
+// Requires ffmpeg; the endpoint is local and no provider credential is used.
+it("transcribes audio beyond twenty minutes while another transcription completes", async () => {
+  const providers: MediaUnderstandingProvider[] = [];
+  plugin.register(
+    createTestPluginApi({
+      registerMediaUnderstandingProvider: (provider) => providers.push(provider),
+    }),
+  );
+  const transcribeAudio = expectDefined(providers[0]?.transcribeAudio, "registered transcription");
+  const pcm = Buffer.alloc(1500 * 16_000 * 2);
+  const marker = Buffer.alloc(16_000 * 2, 23);
+  marker.copy(pcm, 1260 * 16_000 * 2);
+  const header = Buffer.alloc(44);
+  header.write("RIFF", 0);
+  header.writeUInt32LE(36 + pcm.length, 4);
+  header.write("WAVEfmt ", 8);
+  header.writeUInt32LE(16, 16);
+  header.writeUInt16LE(1, 20);
+  header.writeUInt16LE(1, 22);
+  header.writeUInt32LE(16_000, 24);
+  header.writeUInt32LE(32_000, 28);
+  header.writeUInt16LE(2, 32);
+  header.writeUInt16LE(16, 34);
+  header.write("data", 36);
+  header.writeUInt32LE(pcm.length, 40);
+
+  const firstFrame = createDeferred<void>();
+  const releaseTranscript = createDeferred<void>();
+  const server = createServer((request, response) => {
+    request.resume();
+    request.on("end", () => {
+      response.setHeader("content-type", "application/json");
+      response.end(
+        JSON.stringify({
+          results: { channels: [{ alternatives: [{ transcript: "short note" }] }] },
+        }),
+      );
+    });
+  });
+  const sockets = new WebSocketServer({ server });
+  const frames: Buffer[] = [];
+  sockets.on("connection", (socket) => {
+    socket.on("message", (data, binary) => {
+      if (binary) {
+        frames.push(
+          Array.isArray(data)
+            ? Buffer.concat(data)
+            : Buffer.isBuffer(data)
+              ? data
+              : Buffer.from(data),
+        );
+        firstFrame.resolve();
+        return;
+      }
+      if (JSON.parse(data.toString()).type === "CloseStream") {
+        void releaseTranscript.promise.then(() => {
+          const received = Buffer.concat(frames);
+          const includesMarker = received.subarray(1260 * 32_000, 1261 * 32_000).equals(marker);
+          socket.send(
+            JSON.stringify({
+              type: "TurnInfo",
+              event: "EndOfTurn",
+              transcript: includesMarker ? "late marker" : "prefix only",
+            }),
+          );
+          socket.close(1000);
+        });
+      }
+    });
+  });
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const { port } = server.address() as AddressInfo;
+  const request = {
+    apiKey: "fixture-key",
+    baseUrl: `http://127.0.0.1:${port}/v1`,
+    fileName: "long.wav",
+    buffer: Buffer.concat([header, pcm]),
+    request: { allowPrivateNetwork: true },
+    timeoutMs: 20_000,
+  };
+  try {
+    const long = transcribeAudio({ ...request, model: "flux-general-en" });
+    await Promise.race([firstFrame.promise, long]);
+    const short = await transcribeAudio({
+      ...request,
+      buffer: Buffer.from("short audio"),
+      model: "nova-3",
+    });
+    expect(short.text).toBe("short note");
+    releaseTranscript.resolve();
+    expect((await long).text).toBe("late marker");
+    const received = Buffer.concat(frames);
+    expect(received.length).toBe(pcm.length);
+    expect(received.equals(pcm)).toBe(true);
+  } finally {
+    releaseTranscript.resolve();
+    for (const socket of sockets.clients) {
+      socket.terminate();
+    }
+    await new Promise<void>((resolve) => {
+      sockets.close(() => server.close(() => resolve()));
+    });
+  }
+}, 30_000);

--- a/extensions/deepgram/audio-flux.live.test.ts
+++ b/extensions/deepgram/audio-flux.live.test.ts
@@ -52,18 +52,17 @@ it("transcribes audio beyond twenty minutes while another transcription complete
   const frames: Buffer[] = [];
   sockets.on("connection", (socket) => {
     socket.on("message", (data, binary) => {
+      const bytes = Array.isArray(data)
+        ? Buffer.concat(data)
+        : Buffer.isBuffer(data)
+          ? data
+          : Buffer.from(data);
       if (binary) {
-        frames.push(
-          Array.isArray(data)
-            ? Buffer.concat(data)
-            : Buffer.isBuffer(data)
-              ? data
-              : Buffer.from(data),
-        );
+        frames.push(bytes);
         firstFrame.resolve();
         return;
       }
-      if (JSON.parse(data.toString()).type === "CloseStream") {
+      if (JSON.parse(bytes.toString("utf8")).type === "CloseStream") {
         void releaseTranscript.promise.then(() => {
           const received = Buffer.concat(frames);
           const includesMarker = received.subarray(1260 * 32_000, 1261 * 32_000).equals(marker);

--- a/extensions/deepgram/audio-flux.test.ts
+++ b/extensions/deepgram/audio-flux.test.ts
@@ -1,15 +1,23 @@
+import { writeFile } from "node:fs/promises";
 import { createServer } from "node:http";
 import type { AddressInfo } from "node:net";
+import { expectDefined } from "@openclaw/normalization-core";
 import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
-import type { AudioTranscriptionRequest } from "openclaw/plugin-sdk/media-understanding";
+import type {
+  AudioTranscriptionRequest,
+  MediaUnderstandingProvider,
+} from "openclaw/plugin-sdk/media-understanding";
+import { createTestPluginApi } from "openclaw/plugin-sdk/plugin-test-api";
 import { asOptionalRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { RawData, WebSocket } from "ws";
 import { WebSocketServer } from "ws";
 import { isDeepgramFluxModel } from "./audio-flux.js";
-import { transcribeDeepgramAudio } from "./audio.js";
+import plugin from "./index.js";
 
-const runCommandBuffered = vi.hoisted(() => vi.fn());
+const runCommandBuffered = vi.hoisted(() =>
+  vi.fn<typeof import("openclaw/plugin-sdk/process-runtime").runCommandBuffered>(),
+);
 const prepareWebSocket = vi.hoisted(() => vi.fn<() => Promise<void>>());
 
 vi.mock("openclaw/plugin-sdk/media-runtime", async (importOriginal) => ({
@@ -29,6 +37,16 @@ vi.mock("openclaw/plugin-sdk/provider-http", async (importOriginal) => {
 });
 
 const cleanups: Array<() => Promise<void>> = [];
+const registeredProviders: MediaUnderstandingProvider[] = [];
+plugin.register(
+  createTestPluginApi({
+    registerMediaUnderstandingProvider: (provider) => registeredProviders.push(provider),
+  }),
+);
+const transcribeAudio = expectDefined(
+  registeredProviders[0]?.transcribeAudio,
+  "registered audio transcription callback",
+);
 
 function parseClientMessage(data: RawData): Record<string, unknown> | undefined {
   if (typeof data !== "string" && !Buffer.isBuffer(data)) {
@@ -96,15 +114,20 @@ function fluxRequest(
   };
 }
 
-function mockDecodedPcm(pcm: Buffer): void {
-  runCommandBuffered.mockResolvedValueOnce({
-    stdout: pcm,
+async function writeDecodedPcm(argv: string[], pcm: Buffer) {
+  await writeFile(expectDefined(argv.at(-1), "decoder output path"), pcm);
+  return {
+    stdout: Buffer.alloc(0),
     stderr: Buffer.alloc(0),
     code: 0,
     signal: null,
     killed: false,
-    termination: "exit",
-  });
+    termination: "exit" as const,
+  };
+}
+
+function mockDecodedPcm(pcm: Buffer): void {
+  runCommandBuffered.mockImplementationOnce((argv) => writeDecodedPcm(argv, pcm));
 }
 
 describe("Deepgram Flux audio", () => {
@@ -123,17 +146,10 @@ describe("Deepgram Flux audio", () => {
     const releasePreparation = createDeferred<void>();
     const flushed = createDeferred<void>();
     const server = await createFluxServer({ onCloseStream: () => flushed.resolve() });
-    runCommandBuffered.mockImplementationOnce(async () => {
+    runCommandBuffered.mockImplementationOnce(async (argv) => {
       decodeStarted.resolve();
       await releaseDecode.promise;
-      return {
-        stdout: Buffer.alloc(10, 1),
-        stderr: Buffer.alloc(0),
-        code: 0,
-        signal: null,
-        killed: false,
-        termination: "exit",
-      };
+      return await writeDecodedPcm(argv, Buffer.alloc(10, 1));
     });
     prepareWebSocket.mockImplementationOnce(async () => {
       preparationStarted.resolve();
@@ -141,11 +157,11 @@ describe("Deepgram Flux audio", () => {
     });
     vi.useFakeTimers({ toFake: ["Date", "setTimeout", "clearTimeout"] });
     let failure: unknown;
-    const transcription = transcribeDeepgramAudio(
-      fluxRequest(server.baseUrl, { timeoutMs: 1000 }),
-    ).catch((error: unknown) => {
-      failure = error;
-    });
+    const transcription = transcribeAudio(fluxRequest(server.baseUrl, { timeoutMs: 1000 })).catch(
+      (error: unknown) => {
+        failure = error;
+      },
+    );
 
     await decodeStarted.promise;
     await vi.advanceTimersByTimeAsync(200);
@@ -157,9 +173,9 @@ describe("Deepgram Flux audio", () => {
     await vi.advanceTimersByTimeAsync(499);
     expect(failure).toBeUndefined();
     await vi.advanceTimersByTimeAsync(1);
+    await transcription;
     expect(failure).toBeInstanceOf(Error);
     expect(failure).toMatchObject({ message: expect.stringContaining("timed out") });
-    await transcription;
   });
 
   it("routes documented Flux models only", () => {
@@ -198,7 +214,7 @@ describe("Deepgram Flux audio", () => {
         },
       });
 
-      const result = await transcribeDeepgramAudio(
+      const result = await transcribeAudio(
         fluxRequest(server.baseUrl, {
           model,
           language,
@@ -232,21 +248,6 @@ describe("Deepgram Flux audio", () => {
       expect(requestUrl?.searchParams.has("smart_format")).toBe(false);
       expect(server.audioFrames.map((frame) => frame.byteLength)).toEqual([2560, 2560, 880]);
       expect(Buffer.concat(server.audioFrames)).toEqual(pcm);
-      expect(runCommandBuffered).toHaveBeenCalledWith(
-        expect.arrayContaining([
-          "/usr/bin/ffmpeg",
-          "-t",
-          "1200",
-          "-c:a",
-          "pcm_s16le",
-          "-ar",
-          "16000",
-        ]),
-        expect.objectContaining({
-          maxOutputBytes: { stdout: 38_400_000, stderr: 65_536 },
-          terminateOnOutputError: true,
-        }),
-      );
     },
   );
 
@@ -255,7 +256,7 @@ describe("Deepgram Flux audio", () => {
     const server = await createFluxServer({
       onCloseStream: (socket) => socket.send(payload),
     });
-    await expect(transcribeDeepgramAudio(fluxRequest(server.baseUrl))).rejects.toThrow(
+    await expect(transcribeAudio(fluxRequest(server.baseUrl))).rejects.toThrow(
       "malformed JSON response",
     );
   });
@@ -272,7 +273,7 @@ describe("Deepgram Flux audio", () => {
           }),
         ),
     });
-    await expect(transcribeDeepgramAudio(fluxRequest(server.baseUrl))).rejects.toThrow(
+    await expect(transcribeAudio(fluxRequest(server.baseUrl))).rejects.toThrow(
       "transcript exceeds size limit",
     );
   });
@@ -287,9 +288,7 @@ describe("Deepgram Flux audio", () => {
       onCloseStream: () => undefined,
     });
     await expect(
-      transcribeDeepgramAudio(
-        fluxRequest(server.baseUrl, { request: { allowPrivateNetwork: false } }),
-      ),
+      transcribeAudio(fluxRequest(server.baseUrl, { request: { allowPrivateNetwork: false } })),
     ).rejects.toThrow(/private|loopback|blocked/iu);
     expect(opened).toBe(false);
   });

--- a/extensions/deepgram/audio-flux.ts
+++ b/extensions/deepgram/audio-flux.ts
@@ -1,8 +1,6 @@
 // Deepgram Flux voice-note transcription uses the provider's one-shot WebSocket protocol.
-import {
-  MEDIA_FFMPEG_MAX_AUDIO_DURATION_SECS,
-  resolveFfmpegBin,
-} from "openclaw/plugin-sdk/media-runtime";
+import { open } from "node:fs/promises";
+import { resolveFfmpegBin } from "openclaw/plugin-sdk/media-runtime";
 import type {
   AudioTranscriptionRequest,
   AudioTranscriptionResult,
@@ -15,14 +13,13 @@ import {
   requireTranscriptionText,
 } from "openclaw/plugin-sdk/provider-http";
 import { asOptionalRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { resolvePreferredOpenClawTmpDir, tempWorkspace } from "openclaw/plugin-sdk/temp-path";
 
 const DEEPGRAM_FLUX_SAMPLE_RATE = 16_000;
 // Deepgram recommends 80 ms chunks. 16 kHz mono linear16 contains 32 bytes per millisecond.
 const DEEPGRAM_FLUX_AUDIO_CHUNK_BYTES = 2_560;
 const DEEPGRAM_FLUX_MAX_MESSAGE_BYTES = 1024 * 1024;
 const DEEPGRAM_FLUX_MAX_TRANSCRIPT_BYTES = 256 * 1024;
-const DEEPGRAM_FLUX_MAX_PCM_BYTES =
-  DEEPGRAM_FLUX_SAMPLE_RATE * 2 * MEDIA_FFMPEG_MAX_AUDIO_DURATION_SECS;
 const DEEPGRAM_FLUX_QUERY_KEYS = new Set([
   "eager_eot_threshold",
   "eot_threshold",
@@ -128,9 +125,10 @@ function sendSocketFrame(socket: DeepgramFluxSocket, data: Buffer | string): Pro
 
 async function decodeDeepgramFluxAudio(params: {
   buffer: Buffer;
+  outputPath: string;
   signal?: AbortSignal;
   timeoutMs: number;
-}): Promise<Buffer> {
+}): Promise<void> {
   const result = await runCommandBuffered(
     [
       resolveFfmpegBin(),
@@ -139,8 +137,6 @@ async function decodeDeepgramFluxAudio(params: {
       "error",
       "-i",
       "pipe:0",
-      "-t",
-      String(MEDIA_FFMPEG_MAX_AUDIO_DURATION_SECS),
       "-vn",
       "-sn",
       "-dn",
@@ -152,21 +148,18 @@ async function decodeDeepgramFluxAudio(params: {
       "1",
       "-f",
       "s16le",
-      "pipe:1",
+      params.outputPath,
     ],
     {
       input: params.buffer,
-      maxOutputBytes: { stdout: DEEPGRAM_FLUX_MAX_PCM_BYTES, stderr: 64 * 1024 },
+      maxOutputBytes: 64 * 1024,
       signal: params.signal,
       terminateOnOutputError: true,
       timeoutMs: params.timeoutMs,
     },
   );
   if (result.termination === "exit" && result.code === 0) {
-    return result.stdout;
-  }
-  if (result.termination === "output-limit") {
-    throw new Error("Audio transcription failed: decoded audio exceeds size limit");
+    return;
   }
   const detail = result.stderr.toString("utf8").trim();
   throw new Error(
@@ -188,12 +181,20 @@ export async function transcribeDeepgramFluxAudio(params: {
     deadline,
     defaultTimeoutMs: params.request.timeoutMs,
   });
-  const pcm = await decodeDeepgramFluxAudio({
+  // Keep complete decoded audio off the heap; the workspace owns cleanup on every exit.
+  await using workspace = await tempWorkspace({
+    rootDir: resolvePreferredOpenClawTmpDir(),
+    prefix: "audio-transcription-",
+  });
+  const pcmPath = workspace.path("audio.pcm");
+  await decodeDeepgramFluxAudio({
     buffer: params.request.buffer,
+    outputPath: pcmPath,
     signal: params.request.signal,
     timeoutMs: resolveTimeoutMs(),
   });
-  if (pcm.byteLength === 0) {
+  await using pcm = await open(pcmPath, "r");
+  if ((await pcm.stat()).size === 0) {
     throw new Error("Audio transcription failed: decoded audio is empty");
   }
 
@@ -240,11 +241,19 @@ export async function transcribeDeepgramFluxAudio(params: {
     socket.on("open", () => {
       void (async () => {
         try {
-          for (let offset = 0; offset < pcm.byteLength; offset += DEEPGRAM_FLUX_AUDIO_CHUNK_BYTES) {
-            await sendSocketFrame(
-              socket,
-              pcm.subarray(offset, offset + DEEPGRAM_FLUX_AUDIO_CHUNK_BYTES),
-            );
+          const frame = Buffer.alloc(DEEPGRAM_FLUX_AUDIO_CHUNK_BYTES);
+          for (;;) {
+            if (settled) {
+              return;
+            }
+            const { bytesRead } = await pcm.read(frame);
+            if (bytesRead === 0 || settled) {
+              break;
+            }
+            await sendSocketFrame(socket, frame.subarray(0, bytesRead));
+          }
+          if (settled) {
+            return;
           }
           await sendSocketFrame(socket, JSON.stringify({ type: "CloseStream" }));
           closeStreamSent = true;


### PR DESCRIPTION
## What Problem This Solves

Long voice notes could return a successful transcript that silently omitted audio after 20 minutes.

## Why This Change Was Made

The streaming transcription decoder converts the complete recording to a temporary file and uploads it in small frames. This reverses the duration cutoff introduced in #141836 while retaining input-size limits, deadlines, cancellation, and cleanup.

## User Impact

Long recordings can deliver their complete transcript without keeping the full decoded audio in memory. No configuration change is required.

## Evidence

The real CLI received all 25 minutes after the fix, including speech at minute 21; the baseline received only 20 minutes. Registered transcription tests cover the real decoder, concurrent requests, protocol errors, and cleanup. Telegram voice-note delivery preserved the late words in the agent input. The same plugin flow passed on installed v2026.9.4 state. These runs used a controlled transcription endpoint.

Consumers: voice-note transcription and the audio CLI now receive the complete recording.
