### PR TITLE
refactor(slack): await presence cooldown persistence

### DIFF
--- a/extensions/slack/src/monitor/presence-cooldown-store.test.ts
+++ b/extensions/slack/src/monitor/presence-cooldown-store.test.ts
@@ -35,6 +35,10 @@ describe("openSlackPresenceCooldownStore", () => {
         clock.mockReturnValue(now + 8 * 60 * 60 * 1_000);
         expect(await reopened.lookup("default:T123:U123")).toBeUndefined();
         expect(await reopened.registerIfAbsent("default:T123:U123", now + 1)).toBe(true);
+        expect(await reopened.deleteIf?.("default:T123:U123", (value) => value === now)).toBe(
+          false,
+        );
+        expect(await reopened.lookup("default:T123:U123")).toBe(now + 1);
       } finally {
         clock.mockRestore();
         resetPluginStateStoreForTests();

--- a/extensions/slack/src/monitor/presence-cooldown-store.test.ts
+++ b/extensions/slack/src/monitor/presence-cooldown-store.test.ts
@@ -1,18 +1,52 @@
+import type { OpenKeyedStoreOptions } from "openclaw/plugin-sdk/plugin-state-runtime";
+import {
+  createPluginStateKeyedStoreForTests,
+  resetPluginStateStoreForTests,
+} from "openclaw/plugin-sdk/plugin-state-test-runtime";
+import { withOpenClawTestState } from "openclaw/plugin-sdk/test-state";
 import { describe, expect, it, vi } from "vitest";
 
-const openSyncKeyedStore = vi.hoisted(() => vi.fn(() => ({})));
+const openKeyedStore = vi.hoisted(() => vi.fn((_options: OpenKeyedStoreOptions) => ({})));
 
 vi.mock("../runtime.js", () => ({
-  getSlackRuntime: () => ({ state: { openSyncKeyedStore } }),
+  getSlackRuntime: () => ({ state: { openKeyedStore } }),
 }));
 
 import { openSlackPresenceCooldownStore } from "./presence-cooldown-store.js";
 
 describe("openSlackPresenceCooldownStore", () => {
+  it("retains cooldowns across a SQLite reopen and expires them after eight hours", async () => {
+    await withOpenClawTestState({ label: "slack-presence-cooldown" }, async () => {
+      openKeyedStore.mockImplementation((options) =>
+        createPluginStateKeyedStoreForTests<number>("slack", options),
+      );
+      const now = Date.now();
+      const clock = vi.spyOn(Date, "now").mockReturnValue(now);
+      try {
+        const store = openSlackPresenceCooldownStore();
+        expect(await store.registerIfAbsent("default:T123:U123", now)).toBe(true);
+        resetPluginStateStoreForTests();
+        const reopened = openSlackPresenceCooldownStore();
+        expect(await reopened.lookup("default:T123:U123")).toBe(now);
+        expect(await reopened.registerIfAbsent("default:T123:U123", now)).toBe(false);
+        expect(await reopened.registerIfAbsent("default:T456:U123", now)).toBe(true);
+        clock.mockReturnValue(now + 8 * 60 * 60 * 1_000 - 1);
+        expect(await reopened.lookup("default:T123:U123")).toBe(now);
+        clock.mockReturnValue(now + 8 * 60 * 60 * 1_000);
+        expect(await reopened.lookup("default:T123:U123")).toBeUndefined();
+        expect(await reopened.registerIfAbsent("default:T123:U123", now + 1)).toBe(true);
+      } finally {
+        clock.mockRestore();
+        resetPluginStateStoreForTests();
+        openKeyedStore.mockReset().mockReturnValue({});
+      }
+    });
+  });
+
   it("preserves active cooldowns by rejecting new users at capacity", () => {
     openSlackPresenceCooldownStore();
 
-    expect(openSyncKeyedStore).toHaveBeenCalledWith(
+    expect(openKeyedStore).toHaveBeenCalledWith(
       expect.objectContaining({
         maxEntries: 25_000,
         overflowPolicy: "reject-new",

--- a/extensions/slack/src/monitor/presence-cooldown-store.ts
+++ b/extensions/slack/src/monitor/presence-cooldown-store.ts
@@ -1,12 +1,12 @@
 // Slack plugin module persists presence-greeting cooldowns across gateway restarts.
-import type { PluginStateSyncKeyedStore } from "openclaw/plugin-sdk/plugin-state-runtime";
+import type { PluginStateKeyedStore } from "openclaw/plugin-sdk/plugin-state-runtime";
 import { getSlackRuntime } from "../runtime.js";
 import { SLACK_PRESENCE_GREETING_COOLDOWN_MS } from "./presence-monitor.js";
 
 const SLACK_PRESENCE_COOLDOWN_MAX_ENTRIES = 25_000;
 
-export function openSlackPresenceCooldownStore(): PluginStateSyncKeyedStore<number> {
-  return getSlackRuntime().state.openSyncKeyedStore<number>({
+export function openSlackPresenceCooldownStore(): PluginStateKeyedStore<number> {
+  return getSlackRuntime().state.openKeyedStore<number>({
     namespace: "presence-greeting-cooldowns",
     maxEntries: SLACK_PRESENCE_COOLDOWN_MAX_ENTRIES,
     overflowPolicy: "reject-new",

--- a/extensions/slack/src/monitor/presence-monitor.test.ts
+++ b/extensions/slack/src/monitor/presence-monitor.test.ts
@@ -11,7 +11,7 @@ import {
 
 const AUTO_MAX_PARTICIPANTS = 8;
 
-function createCooldownStore(): PluginStateKeyedStore<number> {
+function createCooldownStore() {
   const values = new Map<string, number>();
   return {
     register: async (key, value) => void values.set(key, value),
@@ -29,9 +29,13 @@ function createCooldownStore(): PluginStateKeyedStore<number> {
       return value;
     },
     delete: async (key) => values.delete(key),
+    deleteIf: async (key, predicate) => {
+      const value = values.get(key);
+      return value !== undefined && predicate(value) ? values.delete(key) : false;
+    },
     entries: async () => [],
     clear: async () => values.clear(),
-  };
+  } satisfies PluginStateKeyedStore<number>;
 }
 
 function createPrepared(params: {
@@ -569,7 +573,7 @@ describe("Slack presence monitor", () => {
     }
   });
 
-  it.each(["publish", "stop", "ineligible", "expired", "queue-refused"] as const)(
+  it.each(["publish", "stop", "ineligible", "expired", "queue-refused", "replaced"] as const)(
     "waits for cooldown persistence and drains cleanup when %s",
     async (outcome) => {
       const reservation = createDeferred<boolean>();
@@ -577,19 +581,28 @@ describe("Slack presence monitor", () => {
       const cleanup = createDeferred<boolean>();
       const cleanupStarted = createDeferred<void>();
       const cooldownStore = createCooldownStore();
-      cooldownStore.registerIfAbsent = () => {
+      cooldownStore.registerIfAbsent = async (key, value) => {
+        await cooldownStore.register(key, value);
         reservationStarted.resolve();
         return reservation.promise;
       };
-      cooldownStore.delete = () => {
+      const deleteEntry = cooldownStore.delete.bind(cooldownStore);
+      cooldownStore.delete = async (key) => {
         cleanupStarted.resolve();
-        return cleanup.promise;
+        await cleanup.promise;
+        return await deleteEntry(key);
+      };
+      const deleteIf = cooldownStore.deleteIf.bind(cooldownStore);
+      cooldownStore.deleteIf = async (key, predicate) => {
+        cleanupStarted.resolve();
+        await cleanup.promise;
+        return await deleteIf(key, predicate);
       };
       const getPresence = vi
         .fn()
         .mockResolvedValueOnce({ presence: "away" })
         .mockResolvedValueOnce({ presence: "active" });
-      const enqueue = vi.fn(() => outcome !== "queue-refused");
+      const enqueue = vi.fn(() => outcome !== "queue-refused" && outcome !== "replaced");
       const wake = vi.fn();
       let now = 1_000;
       const monitor = createSlackPresenceMonitor({
@@ -635,6 +648,9 @@ describe("Slack presence monitor", () => {
         await Promise.resolve();
         expect(stopSettled).toBe(false);
         expect(wake).not.toHaveBeenCalled();
+        if (outcome === "replaced") {
+          await cooldownStore.register("default:workspace:U123", now + 1);
+        }
         cleanup.resolve(true);
       }
       await polling;
@@ -648,11 +664,40 @@ describe("Slack presence monitor", () => {
         expect(wake).toHaveBeenCalledOnce();
       } else {
         expect(stopSettled).toBe(true);
-        expect(enqueue).toHaveBeenCalledTimes(outcome === "queue-refused" ? 1 : 0);
+        expect(enqueue).toHaveBeenCalledTimes(
+          outcome === "queue-refused" || outcome === "replaced" ? 1 : 0,
+        );
+        expect(await cooldownStore.lookup("default:workspace:U123")).toBe(
+          outcome === "replaced" ? now + 1 : undefined,
+        );
         expect(wake).not.toHaveBeenCalled();
       }
     },
   );
+
+  it("keeps the cooldown until expiry when an older store lacks conditional deletion", async () => {
+    const cooldownStore: PluginStateKeyedStore<number> = createCooldownStore();
+    delete cooldownStore.deleteIf;
+    const monitor = createSlackPresenceMonitor({
+      accountId: "default",
+      accountConfig: { mode: "auto" },
+      client: {
+        getPresence: vi
+          .fn()
+          .mockResolvedValueOnce({ presence: "away" })
+          .mockResolvedValueOnce({ presence: "active" }),
+      } as never,
+      cooldownStore,
+      enqueue: () => false,
+      wake: vi.fn(),
+      nowMs: () => 1_000,
+    });
+    monitor.observe(createPrepared({ userId: "U123" }));
+    await monitor.pollOnce();
+    await monitor.pollOnce();
+    await monitor.stop();
+    expect(await cooldownStore.lookup("default:workspace:U123")).toBe(1_000);
+  });
 
   it("does not publish when cooldown persistence rejects", async () => {
     const cooldownStore = createCooldownStore();

--- a/extensions/slack/src/monitor/presence-monitor.test.ts
+++ b/extensions/slack/src/monitor/presence-monitor.test.ts
@@ -1,5 +1,6 @@
 import { WebAPIRateLimitedError } from "@slack/web-api";
-import type { PluginStateSyncKeyedStore } from "openclaw/plugin-sdk/plugin-state-runtime";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
+import type { PluginStateKeyedStore } from "openclaw/plugin-sdk/plugin-state-runtime";
 import { describe, expect, it, vi } from "vitest";
 import type { PreparedSlackMessage } from "./message-handler/types.js";
 import {
@@ -10,26 +11,26 @@ import {
 
 const AUTO_MAX_PARTICIPANTS = 8;
 
-function createCooldownStore(): PluginStateSyncKeyedStore<number> {
+function createCooldownStore(): PluginStateKeyedStore<number> {
   const values = new Map<string, number>();
   return {
-    register: (key, value) => void values.set(key, value),
-    registerIfAbsent: (key, value) => {
+    register: async (key, value) => void values.set(key, value),
+    registerIfAbsent: async (key, value) => {
       if (values.has(key)) {
         return false;
       }
       values.set(key, value);
       return true;
     },
-    lookup: (key) => values.get(key),
-    consume: (key) => {
+    lookup: async (key) => values.get(key),
+    consume: async (key) => {
       const value = values.get(key);
       values.delete(key);
       return value;
     },
-    delete: (key) => values.delete(key),
-    entries: () => [],
-    clear: () => values.clear(),
+    delete: async (key) => values.delete(key),
+    entries: async () => [],
+    clear: async () => values.clear(),
   };
 }
 
@@ -566,6 +567,119 @@ describe("Slack presence monitor", () => {
       await polling;
       vi.useRealTimers();
     }
+  });
+
+  it.each(["publish", "stop", "ineligible", "expired", "queue-refused"] as const)(
+    "waits for cooldown persistence and drains cleanup when %s",
+    async (outcome) => {
+      const reservation = createDeferred<boolean>();
+      const reservationStarted = createDeferred<void>();
+      const cleanup = createDeferred<boolean>();
+      const cleanupStarted = createDeferred<void>();
+      const cooldownStore = createCooldownStore();
+      cooldownStore.registerIfAbsent = () => {
+        reservationStarted.resolve();
+        return reservation.promise;
+      };
+      cooldownStore.delete = () => {
+        cleanupStarted.resolve();
+        return cleanup.promise;
+      };
+      const getPresence = vi
+        .fn()
+        .mockResolvedValueOnce({ presence: "away" })
+        .mockResolvedValueOnce({ presence: "active" });
+      const enqueue = vi.fn(() => outcome !== "queue-refused");
+      const wake = vi.fn();
+      let now = 1_000;
+      const monitor = createSlackPresenceMonitor({
+        accountId: "default",
+        accountConfig: { mode: "auto" },
+        client: { getPresence } as never,
+        cooldownStore,
+        enqueue,
+        wake,
+        nowMs: () => now,
+      });
+      monitor.observe(createPrepared({ userId: "U123" }));
+      await monitor.pollOnce();
+      const polling = monitor.pollOnce();
+      await reservationStarted.promise;
+      expect(enqueue).not.toHaveBeenCalled();
+      expect(wake).not.toHaveBeenCalled();
+      expect(monitor.pollOnce() === polling).toBe(true);
+      let stopping: Promise<void> | undefined;
+      let stopSettled = false;
+      if (outcome === "stop") {
+        stopping = monitor.stop().then(() => {
+          stopSettled = true;
+        });
+      } else if (outcome === "ineligible") {
+        for (let index = 0; index < AUTO_MAX_PARTICIPANTS; index += 1) {
+          monitor.observe(createPrepared({ userId: `UOTHER${index}` }));
+        }
+      } else if (outcome === "expired") {
+        now += 24 * 60 * 60 * 1_000;
+      } else if (outcome === "publish") {
+        now += 1;
+        monitor.observe(
+          createPrepared({ userId: "U123", channelId: "DNEW", sessionKey: "session:new" }),
+        );
+      }
+      reservation.resolve(true);
+      if (outcome !== "publish") {
+        await cleanupStarted.promise;
+        stopping ??= monitor.stop().then(() => {
+          stopSettled = true;
+        });
+        await Promise.resolve();
+        expect(stopSettled).toBe(false);
+        expect(wake).not.toHaveBeenCalled();
+        cleanup.resolve(true);
+      }
+      await polling;
+      await stopping;
+      if (outcome === "publish") {
+        expect(enqueue).toHaveBeenCalledWith(
+          expect.stringContaining('channel_id="DNEW"'),
+          expect.objectContaining({ sessionKey: "session:new" }),
+          expect.anything(),
+        );
+        expect(wake).toHaveBeenCalledOnce();
+      } else {
+        expect(stopSettled).toBe(true);
+        expect(enqueue).toHaveBeenCalledTimes(outcome === "queue-refused" ? 1 : 0);
+        expect(wake).not.toHaveBeenCalled();
+      }
+    },
+  );
+
+  it("does not publish when cooldown persistence rejects", async () => {
+    const cooldownStore = createCooldownStore();
+    cooldownStore.registerIfAbsent = vi.fn().mockRejectedValue(new Error("storage unavailable"));
+    const enqueue = vi.fn(() => true);
+    const wake = vi.fn();
+    const error = vi.fn();
+    const monitor = createSlackPresenceMonitor({
+      accountId: "default",
+      accountConfig: { mode: "auto" },
+      client: {
+        getPresence: vi
+          .fn()
+          .mockResolvedValueOnce({ presence: "away" })
+          .mockResolvedValueOnce({ presence: "active" }),
+      } as never,
+      cooldownStore,
+      enqueue,
+      wake,
+      error,
+    });
+    monitor.observe(createPrepared({ userId: "U123" }));
+    await monitor.pollOnce();
+    await monitor.pollOnce();
+    expect(enqueue).not.toHaveBeenCalled();
+    expect(wake).not.toHaveBeenCalled();
+    expect(error).toHaveBeenCalledWith(expect.stringContaining("cooldown persistence failed"));
   });
 
   it("quiesces an in-flight poll before stop returns", async () => {

--- a/extensions/slack/src/monitor/presence-monitor.ts
+++ b/extensions/slack/src/monitor/presence-monitor.ts
@@ -288,7 +288,7 @@ export function createSlackPresenceMonitor(params: {
     pruneTargets(nowMs());
     const target = stopped ? undefined : resolveTarget();
     if (!target) {
-      await params.cooldownStore.delete(cooldownKey);
+      await params.cooldownStore.deleteIf?.(cooldownKey, (current) => current === now);
       return;
     }
     const queued = enqueue(formatSlackPresenceEvent(target, userId, awayObservation), target, {
@@ -301,7 +301,7 @@ export function createSlackPresenceMonitor(params: {
       },
     });
     if (!queued) {
-      await params.cooldownStore.delete(cooldownKey);
+      await params.cooldownStore.deleteIf?.(cooldownKey, (current) => current === now);
       return;
     }
     wake({

--- a/extensions/slack/src/monitor/presence-monitor.ts
+++ b/extensions/slack/src/monitor/presence-monitor.ts
@@ -2,7 +2,7 @@
 import { type WebClient, WebAPIRateLimitedError } from "@slack/web-api";
 import type { SlackAccountConfig } from "openclaw/plugin-sdk/config-contracts";
 import { requestHeartbeat } from "openclaw/plugin-sdk/heartbeat-runtime";
-import type { PluginStateSyncKeyedStore } from "openclaw/plugin-sdk/plugin-state-runtime";
+import type { PluginStateKeyedStore } from "openclaw/plugin-sdk/plugin-state-runtime";
 import { enqueueRoutedSystemEvent } from "openclaw/plugin-sdk/system-event-runtime";
 import { withTimeout } from "openclaw/plugin-sdk/text-utility-runtime";
 import { formatSlackTarget } from "../target-parsing.js";
@@ -169,7 +169,7 @@ export function createSlackPresenceMonitor(params: {
   accountConfig?: SlackPresenceEventsConfig;
   client?: SlackPresenceClient;
   resolveClient?: (teamId?: string) => SlackPresenceClient;
-  cooldownStore: PluginStateSyncKeyedStore<number>;
+  cooldownStore: PluginStateKeyedStore<number>;
   log?: (message: string) => void;
   error?: (message: string) => void;
   nowMs?: () => number;
@@ -251,20 +251,23 @@ export function createSlackPresenceMonitor(params: {
     pruneTargets(now);
   };
 
-  const emitTransition = (
+  const emitTransition = async (
     subject: PresenceSubject,
     awayObservation: { observedAwayAtMs: number; observedActiveAtMs: number },
   ) => {
     const { teamId, userId } = subject;
-    const target = Array.from(targets.values())
-      .filter(
-        (candidate) =>
-          candidate.teamId === teamId &&
-          candidate.participants.has(userId) &&
-          isTargetEligible(candidate),
-      )
-      .toSorted((a, b) => (b.participants.get(userId) ?? 0) - (a.participants.get(userId) ?? 0))[0];
-    if (!target) {
+    const resolveTarget = () =>
+      Array.from(targets.values())
+        .filter(
+          (candidate) =>
+            candidate.teamId === teamId &&
+            candidate.participants.has(userId) &&
+            isTargetEligible(candidate),
+        )
+        .toSorted(
+          (a, b) => (b.participants.get(userId) ?? 0) - (a.participants.get(userId) ?? 0),
+        )[0];
+    if (!resolveTarget()) {
       return;
     }
     const workspaceKey = teamId ?? "workspace";
@@ -272,7 +275,7 @@ export function createSlackPresenceMonitor(params: {
     const now = awayObservation.observedActiveAtMs;
     let reserved: boolean;
     try {
-      reserved = params.cooldownStore.registerIfAbsent(cooldownKey, now, {
+      reserved = await params.cooldownStore.registerIfAbsent(cooldownKey, now, {
         ttlMs: SLACK_PRESENCE_GREETING_COOLDOWN_MS,
       });
     } catch (err) {
@@ -280,6 +283,12 @@ export function createSlackPresenceMonitor(params: {
       return;
     }
     if (!reserved) {
+      return;
+    }
+    pruneTargets(nowMs());
+    const target = stopped ? undefined : resolveTarget();
+    if (!target) {
+      await params.cooldownStore.delete(cooldownKey);
       return;
     }
     const queued = enqueue(formatSlackPresenceEvent(target, userId, awayObservation), target, {
@@ -292,7 +301,7 @@ export function createSlackPresenceMonitor(params: {
       },
     });
     if (!queued) {
-      params.cooldownStore.delete(cooldownKey);
+      await params.cooldownStore.delete(cooldownKey);
       return;
     }
     wake({
@@ -379,7 +388,7 @@ export function createSlackPresenceMonitor(params: {
             : { presence: "active" };
         presenceByUser.set(subjectKey, observation);
         if (previous?.presence === "away" && next === "active") {
-          emitTransition(subject, {
+          await emitTransition(subject, {
             observedAwayAtMs: previous.firstObservedAtMs,
             observedActiveAtMs: observedAtMs,
           });

--- a/extensions/slack/src/monitor/provider.auth-test-token.test.ts
+++ b/extensions/slack/src/monitor/provider.auth-test-token.test.ts
@@ -4,7 +4,7 @@ import type { AddressInfo } from "node:net";
 import { WebClient } from "@slack/web-api";
 import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import type { OpenKeyedStoreOptions } from "openclaw/plugin-sdk/plugin-state-runtime";
-import { createPluginStateSyncKeyedStoreForTests } from "openclaw/plugin-sdk/plugin-state-test-runtime";
+import { createPluginStateKeyedStoreForTests } from "openclaw/plugin-sdk/plugin-state-test-runtime";
 import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { assertSlackDetachedTargetAllowed } from "../detached-target-admission.js";
 import { getSlackInstallationKind } from "../installation-identity-state.js";
@@ -476,8 +476,8 @@ describe("presence polling transport", () => {
       enterprise_id: "E1",
       is_enterprise_install: true,
     });
-    getSlackRuntime().state.openSyncKeyedStore = <T>(options: OpenKeyedStoreOptions) =>
-      createPluginStateSyncKeyedStoreForTests<T>("slack", {
+    getSlackRuntime().state.openKeyedStore = <T>(options: OpenKeyedStoreOptions) =>
+      createPluginStateKeyedStoreForTests<T>("slack", {
         ...options,
         env: options.env ?? process.env,
       });
@@ -513,8 +513,8 @@ describe("presence polling transport", () => {
         },
       },
     });
-    getSlackRuntime().state.openSyncKeyedStore = <T>(options: OpenKeyedStoreOptions) =>
-      createPluginStateSyncKeyedStoreForTests<T>("slack", {
+    getSlackRuntime().state.openKeyedStore = <T>(options: OpenKeyedStoreOptions) =>
+      createPluginStateKeyedStoreForTests<T>("slack", {
         ...options,
         env: options.env ?? process.env,
       });


### PR DESCRIPTION
Related: #145158

## What Problem This Solves

Slack presence polling still uses the deprecated synchronous plugin-state API. An asynchronous storage owner would otherwise let a presence greeting publish before its durable cooldown reservation settles, and let shutdown return while reservation cleanup is still pending.

## Why This Change Was Made

Move the presence cooldown store and its monitor onto `openKeyedStore`. The existing active poll awaits reservation and unused-reservation cleanup, and resolves the newest eligible conversation again after the storage wait. Shutdown drains that same poll before returning. Cleanup conditionally deletes only its own reservation timestamp, preserving a newer cooldown if the original expires while cleanup is pending. Supported older hosts without conditional deletion retain the unused cooldown until its normal expiry.

This is the maintainer-requested bundled-caller migration following sync API deprecation. The namespace, 25,000-entry reject-new policy, eight-hour TTL, and account/workspace/user keys are unchanged. The shared plugin-state owner still executes SQLite synchronously internally; this PR prepares this consumer for its subsequent worker cutover.

## User Impact

Presence events keep their existing routing and cooldown behavior. A storage wait cannot publish a greeting after the monitor has stopped or its conversation has expired or exceeded the automatic participant limit. A newer eligible conversation observed during that wait becomes the publication target.

## Evidence

- 51 cases across the presence monitor, cooldown store, and provider lifecycle suites pass on Node 24.20.0 (136.28 seconds on the current-main composition). Coverage includes workspace partitioning, away-to-active observations, current routing, cooldown suppression, rate limits, and provider shutdown against a real local HTTP endpoint.
- Delayed reservation cases prove no early enqueue/wake, current-target selection, stopped/ineligible/expired cancellation, and drainage of refused enqueue cleanup. The early-publication regression fails against the original monitor because it enqueues before the reservation Promise resolves.
- Synthetic real SQLite proof writes through the plugin's store factory, closes and reopens the database, preserves the cooldown, admits another workspace key, and verifies expiry at the eight-hour boundary. No Slack credentials, network messages, or real Gateway state were used.
- The full changed-file gate passes, including extension production/test typechecks, lint, plugin boundaries, export scans, and storage/import guards.
- The cleanup replacement regression fails the earlier candidate because unconditional deletion removes the newer row. Current tests preserve that row and cover older hosts without the optional conditional-deletion method. Final five-file P2 autoreview is scoped-clean.

Rebased without patch changes onto current main containing #145415. Both commits are patch-identical and all five changed file hashes match the prior reviewed source. The focused/provider suite, Claw review, and current-head CI pass for this composition.

The [current exact-head CI run](https://github.com/openclaw/openclaw/actions/runs/34666649373) passed after one targeted retry recovered a dependency artifact download connection reset. No source, dependency, or UI budget changes were needed for that retry.
