### PR TITLE
fix(anthropic): correct pooled Fable reasoning levels

### DIFF
--- a/docs/providers/anthropic.md
+++ b/docs/providers/anthropic.md
@@ -471,10 +471,14 @@ stored `adaptive` selections resolve to the provider's `high` default. Custom
 routing namespaces such as `Claude Gateway/claude-fable-5-1`.
 
 `anthropic/claude-mythos-5` is a limited-access model with the same always-on
-adaptive-thinking contract. OpenClaw defaults to `high`, maps `/think off` and
-`/think minimal` to `low`, and omits caller-selected sampling parameters.
+adaptive-thinking and five-effort contract. OpenClaw defaults to `high`, maps
+stored `off` and `minimal` settings to `low`, and omits caller-selected sampling parameters.
 The catalog publishes its 1,000,000-token context window, 128,000-token output
 limit, image input, and `$10/$50` input/output pricing.
+
+For Fable and Mythos, new `/think minimal` and `/think adaptive` directives are
+rejected with the supported choices. Use `/think low` and `/think high`,
+respectively; the remapping above applies to previously stored settings.
 
 Claude Opus 4.8 keeps thinking off by default in OpenClaw. When you explicitly
 enable adaptive thinking with `/think high|xhigh|max`, OpenClaw sends

--- a/docs/providers/anthropic.md
+++ b/docs/providers/anthropic.md
@@ -459,9 +459,16 @@ increase; see [current model pricing](https://platform.claude.com/docs/en/about-
 
 `anthropic/claude-fable-5-1` and `anthropic/claude-fable-5` always use adaptive
 thinking and default to `high` effort. Anthropic does not allow thinking to be
-disabled for these models, so `/think off` and `/think minimal` map to `low`
+disabled for these models, so stored `off` and `minimal` settings map to `low`
 effort instead. OpenClaw also omits caller-selected sampling parameters for
 both Fable versions.
+
+Fable effort controls offer `low`, `medium`, `high`, `xhigh`, and `max`, matching
+[Anthropic's effort levels](https://platform.claude.com/docs/en/build-with-claude/effort).
+Adaptive thinking is always on; it is not a separate effort choice. Existing
+stored `adaptive` selections resolve to the provider's `high` default. Custom
+`anthropic-messages` providers use the same profile, including model IDs with
+routing namespaces such as `Claude Gateway/claude-fable-5-1`.
 
 `anthropic/claude-mythos-5` is a limited-access model with the same always-on
 adaptive-thinking contract. OpenClaw defaults to `high`, maps `/think off` and

--- a/docs/tools/thinking.md
+++ b/docs/tools/thinking.md
@@ -22,7 +22,7 @@ title: "Thinking levels"
 - Provider notes:
   - Thinking menus and pickers are provider-profile driven. Provider plugins declare the exact level set for the selected model, including labels such as binary `on`.
   - `adaptive`, `xhigh`, `max`, and `ultra` are only advertised for provider/model/runtime profiles that support them. Typed directives for unsupported levels are rejected with that model's valid options.
-  - Existing stored unsupported levels are remapped by provider profile rank. When `adaptive` is not selectable, it uses the provider's declared default, or falls back to `medium` when no default is declared. `xhigh` and `max` fall back to the largest supported non-off level for the selected model.
+  - Existing stored unsupported levels are remapped by provider profile rank. When `adaptive` is not selectable, it uses the provider's declared non-off default; otherwise its ranked fallback preserves enabled thinking, usually `medium`. `xhigh` and `max` fall back to the largest supported non-off level for the selected model.
   - Anthropic Claude 4.6 models default to `adaptive` when no explicit thinking level is set.
   - Anthropic Claude Opus 4.8 and Opus 4.7 keep thinking off unless you explicitly set a thinking level. Opus 4.8's provider-owned effort default is `high` after adaptive thinking is enabled.
   - Anthropic Claude Opus 4.7+ maps `/think xhigh` to adaptive thinking plus `output_config.effort: "xhigh"`, because `/think` is a thinking directive and `xhigh` is the Opus effort setting.

--- a/docs/tools/thinking.md
+++ b/docs/tools/thinking.md
@@ -22,7 +22,7 @@ title: "Thinking levels"
 - Provider notes:
   - Thinking menus and pickers are provider-profile driven. Provider plugins declare the exact level set for the selected model, including labels such as binary `on`.
   - `adaptive`, `xhigh`, `max`, and `ultra` are only advertised for provider/model/runtime profiles that support them. Typed directives for unsupported levels are rejected with that model's valid options.
-  - Existing stored unsupported levels are remapped by provider profile rank. `adaptive` falls back to `medium` on non-adaptive models, while `xhigh` and `max` fall back to the largest supported non-off level for the selected model.
+  - Existing stored unsupported levels are remapped by provider profile rank. When `adaptive` is not selectable, it uses the provider's declared default, or falls back to `medium` when no default is declared. `xhigh` and `max` fall back to the largest supported non-off level for the selected model.
   - Anthropic Claude 4.6 models default to `adaptive` when no explicit thinking level is set.
   - Anthropic Claude Opus 4.8 and Opus 4.7 keep thinking off unless you explicitly set a thinking level. Opus 4.8's provider-owned effort default is `high` after adaptive thinking is enabled.
   - Anthropic Claude Opus 4.7+ maps `/think xhigh` to adaptive thinking plus `output_config.effort: "xhigh"`, because `/think` is a thinking directive and `xhigh` is the Opus effort setting.

--- a/extensions/anthropic/index.test.ts
+++ b/extensions/anthropic/index.test.ts
@@ -735,7 +735,7 @@ describe("anthropic provider replay hooks", () => {
       } as never);
       expect(levelIds(profile)).toStrictEqual(
         checksCliPolicy
-          ? ["minimal", "low", "medium", "high", "xhigh", "adaptive", "max"]
+          ? ["low", "medium", "high", "xhigh", "max"]
           : ["off", "minimal", "low", "medium", "high", "xhigh", "adaptive", "max"],
       );
       expect(requireRecord(profile, `${modelId} thinking profile`).defaultLevel).toBe("high");

--- a/extensions/anthropic/provider-policy-api.test.ts
+++ b/extensions/anthropic/provider-policy-api.test.ts
@@ -164,7 +164,7 @@ describe("anthropic provider policy public artifact", () => {
   });
 
   it.each(["claude-fable-5", "claude-fable-5-1", "claude-mythos-5"])(
-    "exposes the mandatory-adaptive %s thinking profile",
+    "exposes only native efforts for the mandatory-adaptive %s thinking profile",
     (modelId) => {
       const profile = resolveThinkingProfile({
         provider: "anthropic",
@@ -172,15 +172,7 @@ describe("anthropic provider policy public artifact", () => {
       });
 
       expect(profile).toEqual({
-        levels: [
-          { id: "minimal" },
-          { id: "low" },
-          { id: "medium" },
-          { id: "high" },
-          { id: "xhigh" },
-          { id: "adaptive" },
-          { id: "max" },
-        ],
+        levels: [{ id: "low" }, { id: "medium" }, { id: "high" }, { id: "xhigh" }, { id: "max" }],
         defaultLevel: "high",
         preserveWhenCatalogReasoningFalse: true,
       });

--- a/extensions/microsoft-foundry/index.test.ts
+++ b/extensions/microsoft-foundry/index.test.ts
@@ -1847,15 +1847,7 @@ assert.equal(afterOldest, 130, "the evicted account must refresh through az");
       }),
     ).toMatchObject({
       defaultLevel: "high",
-      levels: [
-        { id: "minimal" },
-        { id: "low" },
-        { id: "medium" },
-        { id: "high" },
-        { id: "xhigh" },
-        { id: "adaptive" },
-        { id: "max" },
-      ],
+      levels: [{ id: "low" }, { id: "medium" }, { id: "high" }, { id: "xhigh" }, { id: "max" }],
     });
     for (const modelName of ["claude-opus-4-6", "claude-sonnet-4-6"]) {
       expect(

--- a/packages/ai/src/providers/anthropic.test.ts
+++ b/packages/ai/src/providers/anthropic.test.ts
@@ -1924,6 +1924,20 @@ describe("Anthropic provider", () => {
     },
   );
 
+  it.each(["low", "medium", "high", "xhigh", "max"] as const)(
+    "preserves pooled Fable %s effort and its routed model id",
+    async (reasoning) => {
+      const id = "Claude Gateway/claude-fable-5-1";
+      const { payload } = await captureSimpleAnthropicPayload(
+        { id, name: "Pooled Fable", provider: "proxy" },
+        { reasoning },
+      );
+      expect(payload.model).toBe(id);
+      expect(payload.thinking).toMatchObject({ type: "adaptive" });
+      expect(payload.output_config).toEqual({ effort: reasoning });
+    },
+  );
+
   const adaptiveThinkingCases: AnthropicAdaptiveThinkingTestCase[] = [
     {
       name: "uses the Claude Opus 5 adaptive-thinking request contract",

--- a/packages/llm-core/src/model-contracts/anthropic.test.ts
+++ b/packages/llm-core/src/model-contracts/anthropic.test.ts
@@ -4,6 +4,8 @@ import { bindsClaudeThinkingPrefix } from "./anthropic.js";
 describe("bindsClaudeThinkingPrefix", () => {
   it.each([
     [{ id: "claude-fable-5-1" }, true],
+    [{ id: "Claude Gateway/claude-fable-5-1" }, true],
+    [{ id: "Claude Gateway/claude-sonnet-5" }, false],
     [{ id: "claude-mythos-5-1" }, false],
     [{ id: "anthropic/claude-fable-5.1" }, true],
     [{ id: "us.anthropic.claude-fable-5-1-v1:0" }, true],

--- a/packages/llm-core/src/model-contracts/anthropic.ts
+++ b/packages/llm-core/src/model-contracts/anthropic.ts
@@ -16,15 +16,7 @@ function normalizeClaudeModelId(modelId?: string): string {
 }
 
 export const CLAUDE_FABLE_5_THINKING_PROFILE = {
-  levels: [
-    { id: "minimal" },
-    { id: "low" },
-    { id: "medium" },
-    { id: "high" },
-    { id: "xhigh" },
-    { id: "adaptive" },
-    { id: "max" },
-  ],
+  levels: [{ id: "low" }, { id: "medium" }, { id: "high" }, { id: "xhigh" }, { id: "max" }],
   defaultLevel: "high",
   preserveWhenCatalogReasoningFalse: true,
 } as const;
@@ -52,10 +44,10 @@ export function resolveClaudeModelIdentity(ref: ClaudeModelRef): string {
   const configuredCanonicalModelId =
     typeof ref.params?.canonicalModelId === "string" ? ref.params.canonicalModelId : undefined;
   const normalized = normalizeClaudeModelId(configuredCanonicalModelId ?? ref.id);
-  const match = /(?:^|[-/])claude-/.exec(normalized);
-  return match
-    ? normalized.slice((match.index ?? 0) + (match[0].startsWith("claude-") ? 0 : 1))
-    : normalized;
+  // Routing namespaces can themselves start with "Claude"; only the final
+  // path component identifies the backing model.
+  const match = /(?:^|[-/])(claude-[^/]+)$/.exec(normalized);
+  return match?.[1] ?? normalized;
 }
 
 /** Resolve Claude Fable 5 through direct ids, cloud ids, or deployment metadata. */

--- a/src/auto-reply/thinking.test.ts
+++ b/src/auto-reply/thinking.test.ts
@@ -359,14 +359,16 @@ describe("listThinkingLevels", () => {
     ];
 
     expect(listThinkingLevelLabels("vllm", "Qwen/Qwen3-8B", catalog)).toEqual(["off", "on"]);
-    expect(
-      resolveSupportedThinkingLevel({
-        provider: "vllm",
-        model: "Qwen/Qwen3-8B",
-        level: "high",
-        catalog,
-      }),
-    ).toBe("low");
+    for (const level of ["high", "adaptive"] as const) {
+      expect(
+        resolveSupportedThinkingLevel({
+          provider: "vllm",
+          model: "Qwen/Qwen3-8B",
+          level,
+          catalog,
+        }),
+      ).toBe("low");
+    }
   });
 
   it("uses canonical Fable params when no provider thinking profile exists", () => {
@@ -849,6 +851,7 @@ describe("listThinkingLevels", () => {
   it("maps unsupported adaptive to medium and unsupported xhigh to high", () => {
     providerRuntimeMocks.resolveProviderThinkingProfile.mockReturnValue({
       levels: [{ id: "off" }, { id: "minimal" }, { id: "low" }, { id: "medium" }, { id: "high" }],
+      defaultLevel: "off",
     });
 
     expect(

--- a/src/auto-reply/thinking.test.ts
+++ b/src/auto-reply/thinking.test.ts
@@ -381,10 +381,8 @@ describe("listThinkingLevels", () => {
     ];
 
     expect(listThinkingLevels("microsoft-foundry", "company-fable", catalog)).toEqual([
-      "minimal",
       "low",
       "medium",
-      "adaptive",
       "high",
       "xhigh",
       "max",
@@ -866,6 +864,17 @@ describe("listThinkingLevels", () => {
         model: "gpt-4.1-mini",
         level: "xhigh",
       }),
+    ).toBe("high");
+  });
+
+  it("uses the provider default for a stored adaptive level when adaptive is not selectable", () => {
+    providerRuntimeMocks.resolveProviderThinkingProfile.mockReturnValue({
+      levels: ["low", "medium", "high", "xhigh", "max"].map((id) => ({ id })),
+      defaultLevel: "high",
+    });
+
+    expect(
+      resolveSupportedThinkingLevel({ provider: "proxy", model: "reasoner", level: "adaptive" }),
     ).toBe("high");
   });
 

--- a/src/auto-reply/thinking.ts
+++ b/src/auto-reply/thinking.ts
@@ -392,7 +392,7 @@ function resolveSupportedThinkingLevelFromProfile(
   if (profile.levels.some((entry) => entry.id === level)) {
     return level;
   }
-  if (level === "adaptive" && profile.defaultLevel) {
+  if (level === "adaptive" && profile.defaultLevel && profile.defaultLevel !== "off") {
     return profile.defaultLevel;
   }
   const requestedRank = THINKING_LEVEL_RANKS[level];

--- a/src/auto-reply/thinking.ts
+++ b/src/auto-reply/thinking.ts
@@ -392,6 +392,9 @@ function resolveSupportedThinkingLevelFromProfile(
   if (profile.levels.some((entry) => entry.id === level)) {
     return level;
   }
+  if (level === "adaptive" && profile.defaultLevel) {
+    return profile.defaultLevel;
+  }
   const requestedRank = THINKING_LEVEL_RANKS[level];
   const ranked = profile.levels.toSorted((a, b) => b.rank - a.rank);
   return (

--- a/src/gateway/server-methods/models.test.ts
+++ b/src/gateway/server-methods/models.test.ts
@@ -384,6 +384,40 @@ function requestModelsList(params: {
 }
 
 describe("models.list", () => {
+  it.each(["claude-fable-5-1", "Claude Gateway/claude-fable-5-1"])(
+    "publishes the native Fable effort ladder for %s on a custom Messages provider",
+    async (id) => {
+      const { request, respond } = requestModelsList({
+        view: "all",
+        loadGatewayModelCatalog: vi.fn(async () => [
+          {
+            id,
+            name: "Pooled Fable",
+            provider: "proxy",
+            api: "anthropic-messages",
+            reasoning: true,
+          },
+        ]),
+      });
+
+      await request;
+
+      expect(respond.mock.calls[0]?.[1]).toMatchObject({
+        models: [
+          {
+            id,
+            provider: "proxy",
+            thinkingLevels: ["low", "medium", "high", "xhigh", "max"].map((level) => ({
+              id: level,
+              label: level,
+            })),
+            thinkingDefault: "high",
+          },
+        ],
+      });
+    },
+  );
+
   it("loads the requested agent catalog", async () => {
     const loadGatewayModelCatalog = vi.fn(async () => [
       { id: "writer-model", name: "Writer Model", provider: "test" },

--- a/src/plugin-sdk/provider-model-shared.test.ts
+++ b/src/plugin-sdk/provider-model-shared.test.ts
@@ -462,8 +462,7 @@ describe("resolveClaudeThinkingProfile", () => {
         defaultLevel: "high",
         preserveWhenCatalogReasoningFalse: true,
       });
-      expectLevelIdsInclude(profile, ["xhigh", "adaptive", "max"]);
-      expect(readLevelIds(profile)).not.toContain("off");
+      expect(readLevelIds(profile)).toEqual(["low", "medium", "high", "xhigh", "max"]);
     },
   );
 


### PR DESCRIPTION
## What Problem This Solves

Users selecting pooled Fable through a custom Anthropic Messages provider saw Off / Minimal / Low / Medium / High instead of the model's native efforts. The same recognition failure could send manual thinking instead of Fable's required adaptive mode.

## Why This Change Was Made

The shared Claude resolver now identifies the backing model from the final routing-path component, so a namespace such as `Claude Gateway/claude-fable-5-1` cannot be mistaken for the model itself. Outgoing requests retain the original routed ID. The shared Fable/Mythos profile exposes the five native efforts, with High as the default.

Previously stored Adaptive selections use an enabled provider default. Off-default providers retain their ranked enabled-thinking fallback, preserving vLLM Qwen's On behavior. Documentation distinguishes saved-setting remapping from new directives: existing Minimal/Off selections map to Low and Adaptive maps to High on Fable/Mythos; new Minimal/Adaptive directives must use Low/High.

## User Impact

Pooled and direct Fable routes offer Low, Medium, High, XHigh, and Max. Adaptive thinking is always enabled and is not a separate effort choice. The shared Mythos profile follows the same native contract.

## Evidence

- [Anthropic effort documentation](https://platform.claude.com/docs/en/build-with-claude/effort) confirms the five values and High default. Its [thinking support table](https://platform.claude.com/docs/en/build-with-claude/thinking-troubleshooting) documents Fable as adaptive-only and always on.
- Namespaced identity, outgoing thinking mode, and model metadata regressions failed before the fix. The real `models.list` handler now exposes the correct profile, and all five efforts reach captured Anthropic payloads while preserving the routing ID.
- Local proof: 439 scoped model/provider tests and 42 shared SDK contract tests passed. All 131 thinking/Gateway cases were rerun after fixing the adaptive-to-off regression, including two compatibility cases that failed before the guard. Changed-file checks, targeted types/lint/formatting, and independent review through P3 passed.
- Landing absorbed main's independent CI repairs in #145316, #145431, and #145415. The final 12-file diff is limited to the model contract, saved-setting remapping, regression coverage, and documentation. Its reviewed model patch is byte-identical across the final rebase.
- Candidate live provider inference and deployment were not performed. Gateway-handler and request-boundary tests cover the changed contract; hosted CI for the final revision remains required before merge.
