### PR TITLE
fix(doctor): stop flagging relocated Workshop skills during full lint

### DIFF
--- a/docs/cli/doctor/lint.md
+++ b/docs/cli/doctor/lint.md
@@ -84,6 +84,9 @@ receive `openclaw doctor --fix` guidance, not a guarantee that every backup will
 be retired. Preserved roots require manual review of workspace ownership, backup
 manifests, and workspace migration blockers. If both kinds remain, Doctor reports
 both next steps. Do not delete preserved backups to clear the warning.
+The check uses the configured agent directories and actual filesystem paths even
+when lint reads a private state snapshot. Correctly placed Workshop targets do
+not need relocation merely because lint uses a temporary directory.
 
 ## Check selection
 

--- a/src/commands/doctor-lint.state-isolation.test.ts
+++ b/src/commands/doctor-lint.state-isolation.test.ts
@@ -93,7 +93,7 @@ describe("doctor lint state isolation", () => {
   });
 
   it.each([false, true])(
-    "classifies real Workshop targets during isolated lint (external=%s)",
+    "runDoctorLintCli --all classifies registered Workshop targets (external=%s)",
     async (external) => {
       await withOpenClawTestState({ prefix: "openclaw-doctor-lint-workshop-" }, async (state) => {
         const customDir = state.path("custom-agent");
@@ -171,7 +171,7 @@ describe("doctor lint state isolation", () => {
   );
 
   it.each([false, true])(
-    "retains Workshop backup and automation findings in the snapshot (custom partition=%s)",
+    "runDoctorLintCli --all retains registered Workshop history findings (custom partition=%s)",
     async (customPartition) => {
       await withOpenClawTestState(
         { prefix: "openclaw-doctor-lint-workshop-history-" },

--- a/src/commands/doctor-lint.state-isolation.test.ts
+++ b/src/commands/doctor-lint.state-isolation.test.ts
@@ -17,9 +17,13 @@ import { operatorMcpOAuthIdentity } from "../agents/mcp-oauth-identity.js";
 import { createMcpOAuthClientProvider } from "../agents/mcp-oauth-provider.js";
 import { resolveMcpOAuthAccessToken } from "../agents/mcp-oauth.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { resolveCronJobsStorePathFromConfig, saveCronStore } from "../cron/store.js";
 import { clearHealthChecksForTest } from "../flows/health-check-registry.js";
 import type { HealthCheckContext } from "../flows/health-checks.js";
 import { requestDevicePairing } from "../infra/device-pairing.js";
+import { createSkillProposalEvent } from "../skills/workshop/plugin-hooks.js";
+import { appendSkillProposalEvent } from "../skills/workshop/store-sqlite-event.js";
+import { importLegacySkillProposal } from "../skills/workshop/store.js";
 import { writeConfigMachineState } from "../state/config-machine-state-write.js";
 import { readConfigMachineState } from "../state/config-machine-state.js";
 import { closeOpenClawStateDatabaseByPath } from "../state/openclaw-state-db-cache.js";
@@ -31,6 +35,7 @@ import {
 import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
 import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import { collectDoctorFindings, runDoctorLintCli } from "./doctor-lint.js";
+import { createAppliedLegacyProposal } from "./doctor-skill-workshop-sqlite.test-support.js";
 
 const mocks = vi.hoisted(() => ({
   resolveDoctorContributionHealthChecks: vi.fn(),
@@ -86,6 +91,189 @@ describe("doctor lint state isolation", () => {
     closeOpenClawStateDatabaseForTest();
     restoreEnv(originalEnv);
   });
+
+  it.each([false, true])(
+    "classifies real Workshop targets during isolated lint (external=%s)",
+    async (external) => {
+      await withOpenClawTestState({ prefix: "openclaw-doctor-lint-workshop-" }, async (state) => {
+        const customDir = state.path("custom-agent");
+        await state.writeConfig({
+          agents: { entries: { main: { default: true }, custom: { agentDir: customDir } } },
+          memory: { search: { enabled: false } },
+        });
+        const targets = [
+          { id: "canonical-main", owner: "main", root: state.agentDir("main") },
+          { id: "canonical-custom", owner: "custom", root: customDir },
+          ...(external ? [{ id: "external", owner: "main", root: state.path("outside") }] : []),
+        ];
+        for (const { id, owner, root } of targets) {
+          const skillDir = path.join(root, "workshop-skills", id);
+          const content = `---\nname: ${id}\ndescription: Saved test procedure\n---\n`;
+          const record = createAppliedLegacyProposal({
+            id,
+            title: id,
+            description: "Saved test procedure",
+            content,
+            target: { skillKey: id, skillDir },
+          });
+          fs.mkdirSync(skillDir, { recursive: true });
+          fs.writeFileSync(record.target.skillFile, content);
+          importLegacySkillProposal({ record, ownerAgentId: owner, store: { env: state.env } });
+        }
+        const databasePath = resolveOpenClawStateSqlitePath(state.env);
+        closeOpenClawStateDatabaseByPath(databasePath);
+        const before = snapshotSqliteFamily(databasePath);
+        const filesBefore = fs
+          .readdirSync(state.stateDir, { recursive: true, encoding: "utf8" })
+          .toSorted((left, right) => left.localeCompare(right));
+        const skillContents = targets.map(({ id, root }) =>
+          fs.readFileSync(path.join(root, "workshop-skills", id, "SKILL.md"), "utf8"),
+        );
+        const check = await selectWorkshopCheckWithUnavailableSource(databasePath);
+        mocks.sqliteOpen.mockClear();
+        const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+        try {
+          const exitCode = await runDoctorLintCli(runtime, { json: true, includeAllChecks: true });
+          const report = JSON.parse(String(stdout.mock.calls.at(-1)?.[0]));
+          expect(exitCode).toBe(external ? 1 : 0);
+          if (external) {
+            expect(report.findings).toEqual([
+              expect.objectContaining({
+                checkId: check.id,
+                message: expect.stringContaining("1 proposal target outside agent directories"),
+              }),
+            ]);
+            expect(report.findings[0].message).toContain(state.path("outside"));
+            expect(report.findings[0].message).not.toContain("canonical-main");
+            expect(report.findings[0].message).not.toContain("canonical-custom");
+          } else {
+            expect(report.findings).toEqual([]);
+          }
+          expect(mocks.sqliteOpen).toHaveBeenCalled();
+          expect(mocks.sqliteOpen.mock.calls.every(([file]) => file !== databasePath)).toBe(true);
+          expect(snapshotSqliteFamily(databasePath)).toEqual(before);
+          expect(
+            fs
+              .readdirSync(state.stateDir, { recursive: true, encoding: "utf8" })
+              .toSorted((left, right) => left.localeCompare(right)),
+          ).toEqual(filesBefore);
+          expect(
+            targets.map(({ id, root }) =>
+              fs.readFileSync(path.join(root, "workshop-skills", id, "SKILL.md"), "utf8"),
+            ),
+          ).toEqual(skillContents);
+          expect(process.env.OPENCLAW_STATE_DIR).toBe(state.stateDir);
+        } finally {
+          stdout.mockRestore();
+        }
+      });
+    },
+  );
+
+  it.each([false, true])(
+    "retains Workshop backup and automation findings in the snapshot (custom partition=%s)",
+    async (customPartition) => {
+      await withOpenClawTestState(
+        { prefix: "openclaw-doctor-lint-workshop-history-" },
+        async (state) => {
+          const config: OpenClawConfig = {
+            agents: { entries: { main: { workspace: state.workspaceDir } } },
+            memory: { search: { enabled: false } },
+          };
+          await state.writeConfig(config);
+          const legacyDir = path.join(state.workspaceDir, "skills", "relocated");
+          const destination = path.join(state.agentDir("main"), "workshop-skills", "relocated");
+          const record = createAppliedLegacyProposal({
+            id: "relocated",
+            title: "Relocated procedure",
+            description: "Saved test procedure",
+            content: "# Saved procedure\n",
+            target: { skillKey: "relocated", skillDir: destination },
+          });
+          fs.mkdirSync(destination, { recursive: true });
+          fs.writeFileSync(record.target.skillFile, "# Saved procedure\n");
+          importLegacySkillProposal({ record, ownerAgentId: "main", store: { env: state.env } });
+          appendSkillProposalEvent(
+            openOpenClawStateDatabase({ env: state.env }).db,
+            createSkillProposalEvent({
+              record,
+              type: "applied",
+              payload: { targetSkillFile: path.join(legacyDir, "SKILL.md") },
+            }),
+          );
+          if (customPartition) {
+            writeConfigMachineState("cron.store", "~/custom-jobs.json");
+          }
+          await saveCronStore(resolveCronJobsStorePathFromConfig(config, state.env), {
+            version: 1,
+            jobs: [
+              {
+                id: "legacy-command",
+                name: "Legacy command",
+                agentId: "main",
+                enabled: true,
+                createdAtMs: 1,
+                updatedAtMs: 1,
+                schedule: { kind: "every", everyMs: 86400000 },
+                sessionTarget: "isolated",
+                wakeMode: "now",
+                payload: { kind: "command", argv: ["node", "check.js"], cwd: legacyDir },
+                state: {},
+              },
+            ],
+          });
+          const backup = await state.writeJson(
+            "skill-workshop/collection-backups/0123456789abcdef/retained/manifest.json",
+            {
+              schema: "openclaw.skill-collection-backup.v1",
+              id: "retained",
+              createdAt: "2026-09-01T00:00:00.000Z",
+              workspaceDir: state.workspaceDir,
+              skillDirs: [],
+              resultSkillDirs: [],
+              resultSkillHashes: {},
+            },
+          );
+          const databasePath = resolveOpenClawStateSqlitePath(state.env);
+          closeOpenClawStateDatabaseByPath(databasePath);
+          const before = snapshotSqliteFamily(databasePath);
+          const backupBefore = fs.readFileSync(backup, "utf8");
+          await selectWorkshopCheckWithUnavailableSource(databasePath);
+          mocks.sqliteOpen.mockClear();
+          const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+          try {
+            await expect(
+              runDoctorLintCli(runtime, { json: true, includeAllChecks: true }),
+            ).resolves.toBe(1);
+            const report = JSON.parse(String(stdout.mock.calls.at(-1)?.[0]));
+            expect(report.findings).toHaveLength(2);
+            expect(report.findings).toEqual(
+              expect.arrayContaining([
+                expect.objectContaining({
+                  target: "legacy-command",
+                  path: "payload.cwd",
+                  fixHint: expect.stringContaining(destination),
+                }),
+                expect.objectContaining({
+                  path: "skills.workshop",
+                  message: expect.stringContaining(
+                    "0 proposal targets outside agent directories () and 1 legacy collection backup root",
+                  ),
+                }),
+              ]),
+            );
+            expect(mocks.sqliteOpen).toHaveBeenCalled();
+            expect(mocks.sqliteOpen.mock.calls.every(([file]) => file !== databasePath)).toBe(true);
+            expect(snapshotSqliteFamily(databasePath)).toEqual(before);
+            expect(fs.readFileSync(backup, "utf8")).toBe(backupBefore);
+            expect(fs.readFileSync(record.target.skillFile, "utf8")).toBe("# Saved procedure\n");
+          } finally {
+            stdout.mockRestore();
+          }
+        },
+      );
+    },
+  );
 
   it.each([
     { label: "--all", selection: "all", profile: undefined, isolated: true },
@@ -647,6 +835,34 @@ describe("doctor lint state isolation", () => {
     }
   });
 });
+
+async function selectWorkshopCheckWithUnavailableSource(databasePath: string) {
+  const actual = await vi.importActual<typeof import("../flows/doctor-health-contributions.js")>(
+    "../flows/doctor-health-contributions.js",
+  );
+  const check = (await actual.resolveDoctorContributionHealthChecks()).find(
+    (entry) => entry.id === "core/doctor/skill-workshop-relocation",
+  );
+  if (!check) {
+    throw new Error("skill-workshop-relocation contribution is missing");
+  }
+  mocks.resolveDoctorContributionHealthChecks.mockResolvedValue([
+    {
+      ...check,
+      async detect(ctx: HealthCheckContext) {
+        // Lint has already copied state; findings must survive without reopening its source.
+        const retainedPath = `${databasePath}.retained`;
+        fs.renameSync(databasePath, retainedPath);
+        try {
+          return await check.detect(ctx);
+        } finally {
+          fs.renameSync(retainedPath, databasePath);
+        }
+      },
+    },
+  ]);
+  return check;
+}
 
 function snapshotSqliteFamily(databasePath: string): Array<{ path: string; sha256: string }> {
   return ["", "-journal", "-shm", "-wal"]

--- a/src/commands/doctor-skill-workshop-automations.ts
+++ b/src/commands/doctor-skill-workshop-automations.ts
@@ -80,6 +80,7 @@ async function existingPath(filename: string): Promise<string | undefined> {
 export async function inspectWorkshopAutomationReferences(params: {
   config: OpenClawConfig;
   env: NodeJS.ProcessEnv;
+  stateEnv?: NodeJS.ProcessEnv;
   records: readonly LegacyWorkshopProposal[];
   appliedEvents: readonly SkillProposalEvent[];
 }): Promise<WorkshopAutomationReference[]> {
@@ -123,9 +124,10 @@ export async function inspectWorkshopAutomationReferences(params: {
   if (relocations.size === 0) {
     return [];
   }
+  const stateEnv = params.stateEnv ?? params.env;
   const { store } = await loadCronJobsStoreWithConfigJobsReadOnly(
-    resolveCronJobsStorePathFromConfig(params.config, params.env),
-    params.env,
+    resolveCronJobsStorePathFromConfig(params.config, params.env, stateEnv),
+    stateEnv,
   );
   const references: WorkshopAutomationReference[] = [];
   const orderedRelocations = [...relocations].toSorted(([left], [right]) =>

--- a/src/commands/doctor-skill-workshop-sqlite.ts
+++ b/src/commands/doctor-skill-workshop-sqlite.ts
@@ -90,9 +90,12 @@ export type LegacyWorkshopMigrationInspection = {
 export async function inspectLegacySkillWorkshopMigration(params: {
   config: OpenClawConfig;
   env?: NodeJS.ProcessEnv;
+  // Lint's private database snapshot does not change persisted filesystem targets.
+  stateEnv?: NodeJS.ProcessEnv;
 }): Promise<LegacyWorkshopMigrationInspection> {
   const env = params.env ?? process.env;
-  const { records, appliedEvents } = await readWorkshopMigrationRecords(env, true);
+  const stateEnv = params.stateEnv ?? env;
+  const { records, appliedEvents } = await readWorkshopMigrationRecords(stateEnv, true);
   // Lint needs ownership counts, not adoption verification through writable recovery readers.
   const { external } = classifyWorkshopRelocation(
     records.filter(({ record }) => !isReadOnlyRehearsalProposal(record, env)),
@@ -103,6 +106,7 @@ export async function inspectLegacySkillWorkshopMigration(params: {
   const automationReferences = await inspectWorkshopAutomationReferences({
     config: params.config,
     env,
+    stateEnv,
     records,
     appliedEvents,
   });

--- a/src/cron/store.ts
+++ b/src/cron/store.ts
@@ -84,8 +84,12 @@ function resolveDefaultCronStorePath(env: NodeJS.ProcessEnv): string {
 }
 
 /** Resolves the cron jobs store path, expanding home-relative user input. */
-export function resolveCronJobsStorePath(storePath?: string, env: NodeJS.ProcessEnv = process.env) {
-  const selected = storePath?.trim() || readCronStoreStatePath(env);
+export function resolveCronJobsStorePath(
+  storePath?: string,
+  env: NodeJS.ProcessEnv = process.env,
+  stateEnv: NodeJS.ProcessEnv = env,
+) {
+  const selected = storePath?.trim() || readCronStoreStatePath(stateEnv);
   if (selected) {
     const raw = selected.trim();
     if (raw.startsWith("~")) {
@@ -100,9 +104,10 @@ export function resolveCronJobsStorePath(storePath?: string, env: NodeJS.Process
 export function resolveCronJobsStorePathFromConfig(
   cfg: { cron?: unknown },
   env: NodeJS.ProcessEnv = process.env,
+  stateEnv: NodeJS.ProcessEnv = env,
 ): string {
   const store = (cfg.cron as { store?: unknown } | undefined)?.store;
-  return resolveCronJobsStorePath(typeof store === "string" ? store : undefined, env);
+  return resolveCronJobsStorePath(typeof store === "string" ? store : undefined, env, stateEnv);
 }
 
 /** Loads cron jobs plus config/runtime sidecars from the SQLite-backed store. */

--- a/src/flows/doctor-core-checks.ts
+++ b/src/flows/doctor-core-checks.ts
@@ -359,7 +359,8 @@ const skillWorkshopRelocationCheck: HealthCheck = {
       await import("../commands/doctor-skill-workshop-sqlite.js");
     const inspection = await inspectLegacySkillWorkshopMigration({
       config: ctx.cfg,
-      env: process.env,
+      env: ctx.env,
+      stateEnv: process.env,
     });
     const automationFindings = (inspection.automationReferences ?? []).map((reference) => ({
       checkId: SKILL_WORKSHOP_RELOCATION_CHECK_ID,


### PR DESCRIPTION
## What Problem This Solves

Running `openclaw doctor --lint --all` after a successful Skill Workshop relocation could report correctly placed skills as external and suggest another repair.

Closes #142583.
Original fix by @raydeStar; report by @GitHoubi.

## Why This Change Was Made

Full lint compared saved skill locations against its temporary database directory. The Workshop inspector now reads the private database snapshot while resolving skill locations and scheduled references against the original filesystem.

## User Impact

Correctly relocated skills in default or custom agent directories no longer trigger this false warning. Genuine external targets, preserved backups, and stale scheduled references remain visible.
Existing proposal data and database structure remain unchanged after an update.

## Evidence

- Before: the full CLI check falsely flagged a default-agent skill relocated by the published 2026.9.4 Doctor; the direct skill check accepted it.
- After: the same full CLI check accepted both default and custom agent locations. A deliberately external target and stale scheduled references still produced findings.
- The published updater installed the fix successfully. A fresh process accepted the surviving proposals without changing their data or database structure.
- Repeated lint preserved the initialized fixture. Unrelated fixture warnings still caused a nonzero exit; this proves removal of the false Workshop warning.

## Consumers

- Full Doctor lint: checks Workshop locations and scheduled references against the correct filesystem.

