### PR TITLE
refactor(telegram): await sticker cache storage

### DIFF
--- a/extensions/telegram/src/action-runtime.test.ts
+++ b/extensions/telegram/src/action-runtime.test.ts
@@ -931,6 +931,37 @@ describe("handleTelegramAction", () => {
     expect(sendStickerTelegram).not.toHaveBeenCalled();
   });
 
+  it("returns sticker search results from asynchronous storage", async () => {
+    telegramActionRuntime.searchStickers = vi.fn(async () => [
+      {
+        fileId: "fox-file",
+        fileUniqueId: "fox-id",
+        description: "A waving fox",
+        cachedAt: "2026-01-26T12:00:00.000Z",
+      },
+    ]);
+    const result = await handleTelegramAction(
+      { action: "searchSticker", query: "fox" },
+      telegramConfig({ actions: { sticker: true } }),
+    );
+    expect(resultDetails(result)).toEqual({
+      ok: true,
+      count: 1,
+      stickers: [{ fileId: "fox-file", description: "A waving fox" }],
+    });
+  });
+
+  it("returns sticker statistics from asynchronous storage", async () => {
+    const stats = {
+      count: 2,
+      oldestAt: "2026-01-20T12:00:00.000Z",
+      newestAt: "2026-01-26T12:00:00.000Z",
+    };
+    telegramActionRuntime.getCacheStats = vi.fn(async () => stats);
+    const result = await handleTelegramAction({ action: "stickerCacheStats" }, telegramConfig({}));
+    expect(resultDetails(result)).toEqual({ ok: true, ...stats });
+  });
+
   it("sends stickers when enabled", async () => {
     const cfg = {
       channels: { telegram: { botToken: "tok", actions: { sticker: true } } },

--- a/extensions/telegram/src/action-runtime.ts
+++ b/extensions/telegram/src/action-runtime.ts
@@ -1048,7 +1048,7 @@ export async function handleTelegramAction(
       readPositiveIntegerParam(params, "limit", {
         message: "limit must be a positive integer.",
       }) ?? 5;
-    const results = telegramActionRuntime.searchStickers(query, limit);
+    const results = await telegramActionRuntime.searchStickers(query, limit);
     return jsonResult({
       ok: true,
       count: results.length,
@@ -1062,7 +1062,7 @@ export async function handleTelegramAction(
   }
 
   if (action === "stickerCacheStats") {
-    const stats = telegramActionRuntime.getCacheStats();
+    const stats = await telegramActionRuntime.getCacheStats();
     return jsonResult({ ok: true, ...stats });
   }
 

--- a/extensions/telegram/src/bot-message-dispatch.context-recovery.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.context-recovery.test.ts
@@ -1,3 +1,5 @@
+import { setImmediate } from "node:timers/promises";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import { finalizeInboundContext } from "openclaw/plugin-sdk/reply-dispatch-runtime";
 import { expect, it, vi } from "vitest";
 import {
@@ -21,6 +23,7 @@ import {
   resolveMarkdownTableMode,
 } from "./bot-message-dispatch.test-harness.js";
 import type { TelegramMessageContext } from "./bot-message-dispatch.test-harness.js";
+import { cacheSticker } from "./sticker-cache.js";
 
 describeTelegramDispatch("dispatchTelegramMessage context-recovery", () => {
   it("keeps a new sticker description through canonical reply-context finalization", async () => {
@@ -42,7 +45,21 @@ describeTelegramDispatch("dispatchTelegramMessage context-recovery", () => {
       StickerMediaIncluded: true,
     });
 
-    await dispatchWithContext({ context: createContext({ ctxPayload }) });
+    const writeStarted = createDeferred<void>();
+    const finishWrite = createDeferred<void>();
+    vi.mocked(cacheSticker).mockImplementationOnce(() => {
+      writeStarted.resolve();
+      return finishWrite.promise;
+    });
+    const pending = dispatchWithContext({ context: createContext({ ctxPayload }) });
+    try {
+      await writeStarted.promise;
+      await setImmediate();
+      expect(dispatchReplyWithBufferedBlockDispatcher).not.toHaveBeenCalled();
+    } finally {
+      finishWrite.resolve();
+      await pending;
+    }
     const replyContext = finalizeInboundContext(ctxPayload);
 
     expect(replyContext.agentText).toBe(

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -210,7 +210,7 @@ async function prepareTelegramSticker(params: {
     context.ctxPayload.BodyForAgent = context.ctxPayload.agentText;
     context.ctxPayload.SkipStickerMediaUnderstanding = true;
   }
-  cacheSticker({
+  await cacheSticker({
     fileId: sticker.fileId,
     fileUniqueId: sticker.fileUniqueId,
     emoji: sticker.emoji,

--- a/extensions/telegram/src/bot.media.stickers-and-fragments.e2e.test.ts
+++ b/extensions/telegram/src/bot.media.stickers-and-fragments.e2e.test.ts
@@ -107,7 +107,7 @@ describe("telegram stickers", () => {
         }),
       );
 
-      getCachedStickerSpy.mockReturnValue({
+      getCachedStickerSpy.mockResolvedValue({
         fileId: "old_file_id",
         fileUniqueId: "sticker_unique_456",
         emoji: "😴",

--- a/extensions/telegram/src/bot/delivery.resolve-media.ts
+++ b/extensions/telegram/src/bot/delivery.resolve-media.ts
@@ -407,7 +407,7 @@ async function resolveStickerMedia(params: {
   });
 
   // Check sticker cache for existing description
-  const cached = sticker.file_unique_id ? getCachedSticker(sticker.file_unique_id) : null;
+  const cached = sticker.file_unique_id ? await getCachedSticker(sticker.file_unique_id) : null;
   if (cached) {
     logVerbose(`telegram: sticker cache hit for ${sticker.file_unique_id}`);
     const fileId = sticker.file_id ?? cached.fileId;
@@ -415,7 +415,7 @@ async function resolveStickerMedia(params: {
     const setName = sticker.set_name ?? cached.setName;
     if (fileId !== cached.fileId || emoji !== cached.emoji || setName !== cached.setName) {
       // Refresh cached sticker metadata on hits so sends/searches use latest file_id.
-      cacheSticker({
+      await cacheSticker({
         ...cached,
         fileId,
         emoji,

--- a/extensions/telegram/src/sticker-cache-store.ts
+++ b/extensions/telegram/src/sticker-cache-store.ts
@@ -1,5 +1,4 @@
-// Telegram plugin module implements sticker cache store behavior.
-import type { PluginStateSyncKeyedStore } from "openclaw/plugin-sdk/plugin-state-runtime";
+import type { PluginStateKeyedStore } from "openclaw/plugin-sdk/plugin-state-runtime";
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { getTelegramRuntime } from "./runtime.js";
@@ -12,22 +11,22 @@ import {
 
 export type { CachedSticker };
 
-type TelegramStickerCacheStore = PluginStateSyncKeyedStore<CachedSticker>;
+type TelegramStickerCacheStore = PluginStateKeyedStore<CachedSticker>;
 
 function openStickerCacheStore(): TelegramStickerCacheStore {
-  return getTelegramRuntime().state.openSyncKeyedStore<CachedSticker>({
+  return getTelegramRuntime().state.openKeyedStore<CachedSticker>({
     namespace: TELEGRAM_STICKER_CACHE_NAMESPACE,
     maxEntries: TELEGRAM_STICKER_CACHE_MAX_ENTRIES,
   });
 }
 
-function readStickerCacheStore<T>(
+async function readStickerCacheStore<T>(
   operation: string,
-  read: (store: TelegramStickerCacheStore) => T,
+  read: (store: TelegramStickerCacheStore) => Promise<T>,
   fallback: T,
-): T {
+): Promise<T> {
   try {
-    return read(openStickerCacheStore());
+    return await read(openStickerCacheStore());
   } catch (err) {
     logVerbose(`telegram sticker cache ${operation} failed: ${String(err)}`);
     return fallback;
@@ -37,19 +36,21 @@ function readStickerCacheStore<T>(
 /**
  * Get a cached sticker by its unique ID.
  */
-export function getCachedSticker(fileUniqueId: string): CachedSticker | null {
-  return readStickerCacheStore("lookup", (store) => store.lookup(fileUniqueId) ?? null, null);
+export async function getCachedSticker(fileUniqueId: string): Promise<CachedSticker | null> {
+  return readStickerCacheStore(
+    "lookup",
+    async (store) => (await store.lookup(fileUniqueId)) ?? null,
+    null,
+  );
 }
 
 /**
  * Add or update a sticker in the cache.
  */
-export function cacheSticker(sticker: CachedSticker): void {
-  readStickerCacheStore(
+export async function cacheSticker(sticker: CachedSticker): Promise<void> {
+  await readStickerCacheStore(
     "register",
-    (store) => {
-      store.register(sticker.fileUniqueId, normalizeCachedStickerForStore(sticker));
-    },
+    (store) => store.register(sticker.fileUniqueId, normalizeCachedStickerForStore(sticker)),
     undefined,
   );
 }
@@ -57,11 +58,11 @@ export function cacheSticker(sticker: CachedSticker): void {
 /**
  * Search cached stickers by text query (fuzzy match on description + emoji + setName).
  */
-export function searchStickers(query: string, limit = 10): CachedSticker[] {
+export async function searchStickers(query: string, limit = 10): Promise<CachedSticker[]> {
   const queryLower = normalizeLowercaseStringOrEmpty(query);
   const results: Array<{ sticker: CachedSticker; score: number }> = [];
 
-  for (const { value: sticker } of readStickerCacheStore(
+  for (const { value: sticker } of await readStickerCacheStore(
     "entries",
     (store) => store.entries(),
     [],
@@ -107,10 +108,10 @@ export function searchStickers(query: string, limit = 10): CachedSticker[] {
 /**
  * Get all cached stickers (for debugging/listing).
  */
-export function getAllCachedStickers(): CachedSticker[] {
+export async function getAllCachedStickers(): Promise<CachedSticker[]> {
   return readStickerCacheStore(
     "entries",
-    (store) => store.entries().map((entry) => entry.value),
+    async (store) => (await store.entries()).map((entry) => entry.value),
     [],
   );
 }
@@ -118,8 +119,12 @@ export function getAllCachedStickers(): CachedSticker[] {
 /**
  * Get cache statistics.
  */
-export function getCacheStats(): { count: number; oldestAt?: string; newestAt?: string } {
-  const stickers = getAllCachedStickers();
+export async function getCacheStats(): Promise<{
+  count: number;
+  oldestAt?: string;
+  newestAt?: string;
+}> {
+  const stickers = await getAllCachedStickers();
   if (stickers.length === 0) {
     return { count: 0 };
   }

--- a/extensions/telegram/src/sticker-cache.test.ts
+++ b/extensions/telegram/src/sticker-cache.test.ts
@@ -1,7 +1,8 @@
-import type { PluginStateSyncKeyedStore } from "openclaw/plugin-sdk/plugin-state-runtime";
-// Telegram tests cover sticker cache plugin behavior.
+import { setImmediate } from "node:timers/promises";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
+import type { PluginStateKeyedStore } from "openclaw/plugin-sdk/plugin-state-runtime";
 import {
-  createPluginStateSyncKeyedStoreForTests,
+  createPluginStateKeyedStoreForTests,
   resetPluginStateStoreForTests,
 } from "openclaw/plugin-sdk/plugin-state-test-runtime";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -19,28 +20,28 @@ vi.mock("openclaw/plugin-sdk/state-paths", () => ({
 }));
 
 describe("sticker-cache", () => {
-  type StickerEntry = NonNullable<ReturnType<typeof stickerCache.getCachedSticker>>;
-  let store: PluginStateSyncKeyedStore<StickerEntry>;
+  type StickerEntry = stickerCache.CachedSticker;
+  let store: PluginStateKeyedStore<StickerEntry>;
 
-  function installStore(nextStore: PluginStateSyncKeyedStore<StickerEntry>): void {
+  function installStore(nextStore: PluginStateKeyedStore<StickerEntry>): void {
     store = nextStore;
     setTelegramRuntime({
       state: {
-        openSyncKeyedStore: (() => store) as TelegramRuntime["state"]["openSyncKeyedStore"],
+        openKeyedStore: (() => store) as TelegramRuntime["state"]["openKeyedStore"],
       },
       channel: {},
     } as TelegramRuntime);
   }
 
-  beforeEach(() => {
+  beforeEach(async () => {
     resetPluginStateStoreForTests({ closeDatabase: false });
     installStore(
-      createPluginStateSyncKeyedStoreForTests("telegram", {
+      createPluginStateKeyedStoreForTests("telegram", {
         namespace: TELEGRAM_STICKER_CACHE_NAMESPACE,
         maxEntries: TELEGRAM_STICKER_CACHE_MAX_ENTRIES,
       }),
     );
-    store.clear();
+    await store.clear();
   });
 
   afterEach(() => {
@@ -49,12 +50,12 @@ describe("sticker-cache", () => {
   });
 
   describe("getCachedSticker", () => {
-    it("returns null for unknown ID", () => {
-      const result = stickerCache.getCachedSticker("unknown-id");
+    it("returns null for unknown ID", async () => {
+      const result = await stickerCache.getCachedSticker("unknown-id");
       expect(result).toBeNull();
     });
 
-    it("returns cached sticker after cacheSticker", () => {
+    it("returns cached sticker after cacheSticker", async () => {
       const sticker = {
         fileId: "file123",
         fileUniqueId: "unique123",
@@ -64,13 +65,13 @@ describe("sticker-cache", () => {
         cachedAt: "2026-01-26T12:00:00.000Z",
       };
 
-      stickerCache.cacheSticker(sticker);
-      const result = stickerCache.getCachedSticker("unique123");
+      await stickerCache.cacheSticker(sticker);
+      const result = await stickerCache.getCachedSticker("unique123");
 
       expect(result).toEqual(sticker);
     });
 
-    it("returns null after backing store is cleared", () => {
+    it("returns null after backing store is cleared", async () => {
       const sticker = {
         fileId: "file123",
         fileUniqueId: "unique123",
@@ -78,35 +79,36 @@ describe("sticker-cache", () => {
         cachedAt: "2026-01-26T12:00:00.000Z",
       };
 
-      stickerCache.cacheSticker(sticker);
-      const cachedSticker = stickerCache.getCachedSticker("unique123");
+      await stickerCache.cacheSticker(sticker);
+      const cachedSticker = await stickerCache.getCachedSticker("unique123");
       if (!cachedSticker) {
         throw new Error("expected cached Telegram sticker");
       }
       expect(cachedSticker.fileUniqueId).toBe("unique123");
 
-      store.clear();
+      await store.clear();
 
-      expect(stickerCache.getCachedSticker("unique123")).toBeNull();
+      expect(await stickerCache.getCachedSticker("unique123")).toBeNull();
     });
 
-    it("treats plugin-state lookup failures as cache misses", () => {
+    it("treats plugin-state lookup failures as cache misses", async () => {
       installStore({
-        ...createPluginStateSyncKeyedStoreForTests("telegram", {
+        ...createPluginStateKeyedStoreForTests("telegram", {
           namespace: TELEGRAM_STICKER_CACHE_NAMESPACE,
           maxEntries: TELEGRAM_STICKER_CACHE_MAX_ENTRIES,
         }),
-        lookup() {
+        async lookup() {
+          await Promise.resolve();
           throw new Error("lookup failed");
         },
       });
 
-      expect(stickerCache.getCachedSticker("unique123")).toBeNull();
+      expect(await stickerCache.getCachedSticker("unique123")).toBeNull();
     });
   });
 
   describe("cacheSticker", () => {
-    it("adds entry to cache", () => {
+    it("adds entry to cache", async () => {
       const sticker = {
         fileId: "file456",
         fileUniqueId: "unique456",
@@ -114,15 +116,15 @@ describe("sticker-cache", () => {
         cachedAt: "2026-01-26T12:00:00.000Z",
       };
 
-      stickerCache.cacheSticker(sticker);
+      await stickerCache.cacheSticker(sticker);
 
-      const all = stickerCache.getAllCachedStickers();
+      const all = await stickerCache.getAllCachedStickers();
       expect(all).toHaveLength(1);
       expect(all[0]).toEqual(sticker);
     });
 
-    it("omits undefined optional fields before storing", () => {
-      stickerCache.cacheSticker({
+    it("omits undefined optional fields before storing", async () => {
+      await stickerCache.cacheSticker({
         fileId: "file-undefined",
         fileUniqueId: "unique-undefined",
         emoji: undefined,
@@ -132,7 +134,7 @@ describe("sticker-cache", () => {
         receivedFrom: undefined,
       });
 
-      expect(stickerCache.getCachedSticker("unique-undefined")).toStrictEqual({
+      expect(await stickerCache.getCachedSticker("unique-undefined")).toStrictEqual({
         fileId: "file-undefined",
         fileUniqueId: "unique-undefined",
         description: "Sticker with omitted fields",
@@ -140,7 +142,7 @@ describe("sticker-cache", () => {
       });
     });
 
-    it("updates existing entry", () => {
+    it("updates existing entry", async () => {
       const original = {
         fileId: "file789",
         fileUniqueId: "unique789",
@@ -154,40 +156,82 @@ describe("sticker-cache", () => {
         cachedAt: "2026-01-26T13:00:00.000Z",
       };
 
-      stickerCache.cacheSticker(original);
-      stickerCache.cacheSticker(updated);
+      await stickerCache.cacheSticker(original);
+      await stickerCache.cacheSticker(updated);
 
-      const result = stickerCache.getCachedSticker("unique789");
+      const result = await stickerCache.getCachedSticker("unique789");
       expect(result?.description).toBe("Updated description");
       expect(result?.fileId).toBe("file789-new");
     });
 
-    it("does not throw when plugin-state writes fail", () => {
+    it("settles only after the backing write commits", async () => {
+      const backingStore = store;
+      const entered = createDeferred<void>();
+      const release = createDeferred<void>();
       installStore({
-        ...createPluginStateSyncKeyedStoreForTests("telegram", {
+        ...backingStore,
+        async register(key, value, options) {
+          entered.resolve();
+          await release.promise;
+          await backingStore.register(key, value, options);
+        },
+      });
+      const sticker = {
+        fileId: "delayed-file",
+        fileUniqueId: "delayed-unique",
+        description: "A delayed sticker",
+        cachedAt: "2026-01-26T12:00:00.000Z",
+      };
+      let settled = false;
+      const pending = stickerCache.cacheSticker(sticker).then(() => {
+        settled = true;
+      });
+      try {
+        await entered.promise;
+        await setImmediate();
+        expect(settled).toBe(false);
+        expect(await stickerCache.getCachedSticker(sticker.fileUniqueId)).toBeNull();
+      } finally {
+        release.resolve();
+        await pending;
+      }
+      resetPluginStateStoreForTests();
+      installStore(
+        createPluginStateKeyedStoreForTests("telegram", {
           namespace: TELEGRAM_STICKER_CACHE_NAMESPACE,
           maxEntries: TELEGRAM_STICKER_CACHE_MAX_ENTRIES,
         }),
-        register() {
+      );
+      expect(await stickerCache.getCachedSticker(sticker.fileUniqueId)).toEqual(sticker);
+    });
+
+    it("does not throw when plugin-state writes fail", async () => {
+      installStore({
+        ...createPluginStateKeyedStoreForTests("telegram", {
+          namespace: TELEGRAM_STICKER_CACHE_NAMESPACE,
+          maxEntries: TELEGRAM_STICKER_CACHE_MAX_ENTRIES,
+        }),
+        async register() {
+          await Promise.resolve();
           throw new Error("write failed");
         },
       });
 
-      expect(() =>
+      await expect(
         stickerCache.cacheSticker({
           fileId: "file-failure",
           fileUniqueId: "unique-failure",
           description: "Write failure should not block sticker handling",
           cachedAt: "2026-01-26T13:00:00.000Z",
         }),
-      ).not.toThrow();
+      ).resolves.toBeUndefined();
     });
   });
 
   describe("searchStickers", () => {
-    beforeEach(() => {
+    beforeEach(async () => {
       // Seed cache with test stickers
-      stickerCache.cacheSticker({
+      await stickerCache.cacheSticker({
         fileId: "fox1",
         fileUniqueId: "fox-unique-1",
         emoji: "🦊",
@@ -195,7 +239,7 @@ describe("sticker-cache", () => {
         description: "A cute orange fox waving hello",
         cachedAt: "2026-01-26T10:00:00.000Z",
       });
-      stickerCache.cacheSticker({
+      await stickerCache.cacheSticker({
         fileId: "fox2",
         fileUniqueId: "fox-unique-2",
         emoji: "🦊",
@@ -203,7 +247,7 @@ describe("sticker-cache", () => {
         description: "A fox sleeping peacefully",
         cachedAt: "2026-01-26T11:00:00.000Z",
       });
-      stickerCache.cacheSticker({
+      await stickerCache.cacheSticker({
         fileId: "cat1",
         fileUniqueId: "cat-unique-1",
         emoji: "🐱",
@@ -211,7 +255,7 @@ describe("sticker-cache", () => {
         description: "A cat sitting on a keyboard",
         cachedAt: "2026-01-26T12:00:00.000Z",
       });
-      stickerCache.cacheSticker({
+      await stickerCache.cacheSticker({
         fileId: "dog1",
         fileUniqueId: "dog-unique-1",
         emoji: "🐶",
@@ -221,8 +265,8 @@ describe("sticker-cache", () => {
       });
     });
 
-    it("finds stickers by description substring", () => {
-      const results = stickerCache.searchStickers("fox");
+    it("finds stickers by description substring", async () => {
+      const results = await stickerCache.searchStickers("fox");
       expect(results).toHaveLength(2);
       expect(results.map((sticker) => sticker.fileUniqueId)).toEqual([
         "fox-unique-1",
@@ -230,8 +274,8 @@ describe("sticker-cache", () => {
       ]);
     });
 
-    it("finds stickers by emoji", () => {
-      const results = stickerCache.searchStickers("🦊");
+    it("finds stickers by emoji", async () => {
+      const results = await stickerCache.searchStickers("🦊");
       expect(results).toHaveLength(2);
       expect(results.map((sticker) => sticker.fileUniqueId)).toEqual([
         "fox-unique-1",
@@ -239,8 +283,8 @@ describe("sticker-cache", () => {
       ]);
     });
 
-    it("finds stickers by set name", () => {
-      const results = stickerCache.searchStickers("CuteFoxes");
+    it("finds stickers by set name", async () => {
+      const results = await stickerCache.searchStickers("CuteFoxes");
       expect(results).toHaveLength(2);
       expect(results.map((sticker) => sticker.fileUniqueId)).toEqual([
         "fox-unique-1",
@@ -248,117 +292,119 @@ describe("sticker-cache", () => {
       ]);
     });
 
-    it("respects limit parameter", () => {
-      const results = stickerCache.searchStickers("fox", 1);
+    it("respects limit parameter", async () => {
+      const results = await stickerCache.searchStickers("fox", 1);
       expect(results).toHaveLength(1);
     });
 
-    it("ranks exact matches higher", () => {
+    it("ranks exact matches higher", async () => {
       // "waving" appears in "fox waving hello" - should be ranked first
-      const results = stickerCache.searchStickers("waving");
+      const results = await stickerCache.searchStickers("waving");
       expect(results).toHaveLength(1);
       expect(results[0]?.fileUniqueId).toBe("fox-unique-1");
     });
 
-    it("returns empty array for no matches", () => {
-      const results = stickerCache.searchStickers("elephant");
+    it("returns empty array for no matches", async () => {
+      const results = await stickerCache.searchStickers("elephant");
       expect(results).toHaveLength(0);
     });
 
-    it("is case insensitive", () => {
-      const results = stickerCache.searchStickers("FOX");
+    it("is case insensitive", async () => {
+      const results = await stickerCache.searchStickers("FOX");
       expect(results).toHaveLength(2);
     });
 
-    it("matches multiple words", () => {
-      const results = stickerCache.searchStickers("cat keyboard");
+    it("matches multiple words", async () => {
+      const results = await stickerCache.searchStickers("cat keyboard");
       expect(results).toHaveLength(1);
       expect(results[0]?.fileUniqueId).toBe("cat-unique-1");
     });
 
-    it("returns no matches when plugin-state search reads fail", () => {
+    it("returns no matches when plugin-state search reads fail", async () => {
       installStore({
-        ...createPluginStateSyncKeyedStoreForTests("telegram", {
+        ...createPluginStateKeyedStoreForTests("telegram", {
           namespace: TELEGRAM_STICKER_CACHE_NAMESPACE,
           maxEntries: TELEGRAM_STICKER_CACHE_MAX_ENTRIES,
         }),
-        entries() {
+        async entries() {
+          await Promise.resolve();
           throw new Error("entries failed");
         },
       });
 
-      expect(stickerCache.searchStickers("fox")).toStrictEqual([]);
+      expect(await stickerCache.searchStickers("fox")).toStrictEqual([]);
     });
   });
 
   describe("getAllCachedStickers", () => {
-    it("returns empty array when cache is empty", () => {
-      const result = stickerCache.getAllCachedStickers();
+    it("returns empty array when cache is empty", async () => {
+      const result = await stickerCache.getAllCachedStickers();
       expect(result).toStrictEqual([]);
     });
 
-    it("returns empty array when plugin-state list reads fail", () => {
+    it("returns empty array when plugin-state list reads fail", async () => {
       installStore({
-        ...createPluginStateSyncKeyedStoreForTests("telegram", {
+        ...createPluginStateKeyedStoreForTests("telegram", {
           namespace: TELEGRAM_STICKER_CACHE_NAMESPACE,
           maxEntries: TELEGRAM_STICKER_CACHE_MAX_ENTRIES,
         }),
-        entries() {
+        async entries() {
+          await Promise.resolve();
           throw new Error("entries failed");
         },
       });
 
-      expect(stickerCache.getAllCachedStickers()).toStrictEqual([]);
+      expect(await stickerCache.getAllCachedStickers()).toStrictEqual([]);
     });
 
-    it("returns all cached stickers", () => {
-      stickerCache.cacheSticker({
+    it("returns all cached stickers", async () => {
+      await stickerCache.cacheSticker({
         fileId: "a",
         fileUniqueId: "a-unique",
         description: "Sticker A",
         cachedAt: "2026-01-26T10:00:00.000Z",
       });
-      stickerCache.cacheSticker({
+      await stickerCache.cacheSticker({
         fileId: "b",
         fileUniqueId: "b-unique",
         description: "Sticker B",
         cachedAt: "2026-01-26T11:00:00.000Z",
       });
 
-      const result = stickerCache.getAllCachedStickers();
+      const result = await stickerCache.getAllCachedStickers();
       expect(result).toHaveLength(2);
     });
   });
 
   describe("getCacheStats", () => {
-    it("returns count 0 when cache is empty", () => {
-      const stats = stickerCache.getCacheStats();
+    it("returns count 0 when cache is empty", async () => {
+      const stats = await stickerCache.getCacheStats();
       expect(stats.count).toBe(0);
       expect(stats.oldestAt).toBeUndefined();
       expect(stats.newestAt).toBeUndefined();
     });
 
-    it("returns correct stats with cached stickers", () => {
-      stickerCache.cacheSticker({
+    it("returns correct stats with cached stickers", async () => {
+      await stickerCache.cacheSticker({
         fileId: "old",
         fileUniqueId: "old-unique",
         description: "Old sticker",
         cachedAt: "2026-01-20T10:00:00.000Z",
       });
-      stickerCache.cacheSticker({
+      await stickerCache.cacheSticker({
         fileId: "new",
         fileUniqueId: "new-unique",
         description: "New sticker",
         cachedAt: "2026-01-26T10:00:00.000Z",
       });
-      stickerCache.cacheSticker({
+      await stickerCache.cacheSticker({
         fileId: "mid",
         fileUniqueId: "mid-unique",
         description: "Middle sticker",
         cachedAt: "2026-01-23T10:00:00.000Z",
       });
 
-      const stats = stickerCache.getCacheStats();
+      const stats = await stickerCache.getCacheStats();
       expect(stats.count).toBe(3);
       expect(stats.oldestAt).toBe("2026-01-20T10:00:00.000Z");
       expect(stats.newestAt).toBe("2026-01-26T10:00:00.000Z");


### PR DESCRIPTION
## What Problem This Solves

Telegram sticker lookup, metadata refresh, search, and statistics still used the synchronous plugin-state API. Their asynchronous message and action handlers could not safely consume a delayed storage implementation.

## Why This Change Was Made

Use the existing asynchronous keyed-store contract and await each bundled caller. Cache failures remain best-effort: delayed lookup failures become misses, list failures return empty results, and failed writes do not fail sticker handling. Successful writes settle before their callers continue.

The namespace, 10,000-entry limit, canonical row format, search scoring/order, and timestamp statistics stay unchanged. These helpers belong to the private bundled Telegram plugin; the deprecated public synchronous plugin-state API remains available to external plugins through its existing compatibility window. This is preparation for the shared storage worker migration: native SQLite execution in the shared KV owner is still synchronous.

## User Impact

Existing sticker behavior is preserved. Telegram can adopt a delayed storage owner without returning promises as action results or losing cache-error handling. No schema, configuration, retention, protocol, or package version changes.

## Evidence

- Six focused test files passed: 242 cases covering real SQLite cache operations, selection, actions, media resolution, and dispatch.
- A deferred-write regression verifies that cache completion waits for persistence and the sticker survives a database close/reopen; delayed failures keep the prior best-effort results.
- Two separate processes wrote and reopened 32 synthetic stickers using the real keyed store. Lookups, search order, statistics, and SQLite integrity checks passed. Local descriptive timings: 177 ms for writes; 89 ms for reopen plus reads/search/statistics. No event-loop performance claim.
- Independent Codex review: no actionable P0–P2 findings.
- Eight media E2E cases passed, including awaited cache-hit metadata refresh; the final affected three-file rerun passed 181 cases after switching test fixtures to the existing deferred-promise helper.
- Removing the awaits made seven regression cases fail and exposed a rejected write, as expected. The correct source was restored before final verification.
- The full E2E build passed. Fresh processes using the compiled Telegram API and real keyed store also passed the same 32-record persistence/search/statistics/integrity probe (760 ms write, 263 ms reopened reads under load).
- These are isolated synthetic storage and caller-boundary checks; no Telegram credentials or real messages were used.
- The full changed-file gate passed: production/test typechecks, lint, formatting, plugin boundaries, export/deprecation guards, storage guards, and import-cycle checks.


Rebased onto main containing the picker CI repair in #145415. The commit diff and all eight changed files are byte-identical to the reviewed candidate. On the new base, 26 selected cache/caller cases and the fresh-process 32-record SQLite reopen/search/statistics/integrity probe passed. Earlier full-build, compiled-probe, focused-test and changed-gate evidence above predates this patch-identical rebase; current-head CI covers the new composition.
