### PR TITLE
refactor(comfy): reuse guarded JSON test responses

### DIFF
--- a/extensions/comfy/image-generation-provider.test.ts
+++ b/extensions/comfy/image-generation-provider.test.ts
@@ -6,6 +6,7 @@ import { buildComfyImageGenerationProvider } from "./image-generation-provider.j
 import {
   buildComfyConfig,
   buildLegacyComfyConfig,
+  fetchGuardJson,
   mockComfyCloudJobResponses,
   mockComfyProviderApiKey,
   parseComfyJsonBody,
@@ -91,31 +92,18 @@ function mockLocalImageResponses(
   },
 ) {
   fetchWithSsrFGuardMock
-    .mockResolvedValueOnce({
-      response: new Response(JSON.stringify({ prompt_id: promptId }), {
-        status: 200,
-        headers: { "content-type": "application/json" },
-      }),
-      release: vi.fn(async () => {}),
-    })
-    .mockResolvedValueOnce({
-      response: new Response(
-        JSON.stringify({
-          [promptId]: {
-            outputs: {
-              "9": {
-                images: [{ filename: "generated.png", subfolder: "", type: "output" }],
-              },
+    .mockResolvedValueOnce(fetchGuardJson({ prompt_id: promptId }))
+    .mockResolvedValueOnce(
+      fetchGuardJson({
+        [promptId]: {
+          outputs: {
+            "9": {
+              images: [{ filename: "generated.png", subfolder: "", type: "output" }],
             },
           },
-        }),
-        {
-          status: 200,
-          headers: { "content-type": "application/json" },
         },
-      ),
-      release: vi.fn(async () => {}),
-    })
+      }),
+    )
     .mockResolvedValueOnce({
       response: new Response(download.body, {
         status: 200,
@@ -392,31 +380,18 @@ describe("comfy image-generation provider", () => {
 
   it("submits a local workflow, waits for history, and downloads images", async () => {
     fetchWithSsrFGuardMock
-      .mockResolvedValueOnce({
-        response: new Response(JSON.stringify({ prompt_id: "local-prompt-1" }), {
-          status: 200,
-          headers: { "content-type": "application/json" },
-        }),
-        release: vi.fn(async () => {}),
-      })
-      .mockResolvedValueOnce({
-        response: new Response(
-          JSON.stringify({
-            "local-prompt-1": {
-              outputs: {
-                "9": {
-                  images: [{ filename: "generated.png", subfolder: "", type: "output" }],
-                },
+      .mockResolvedValueOnce(fetchGuardJson({ prompt_id: "local-prompt-1" }))
+      .mockResolvedValueOnce(
+        fetchGuardJson({
+          "local-prompt-1": {
+            outputs: {
+              "9": {
+                images: [{ filename: "generated.png", subfolder: "", type: "output" }],
               },
             },
-          }),
-          {
-            status: 200,
-            headers: { "content-type": "application/json" },
           },
-        ),
-        release: vi.fn(async () => {}),
-      })
+        }),
+      )
       .mockResolvedValueOnce({
         response: new Response(Buffer.from("png-data"), {
           status: 200,
@@ -918,20 +893,8 @@ describe("comfy image-generation provider", () => {
       .mockReturnValueOnce(0)
       .mockReturnValueOnce(MAX_TIMER_TIMEOUT_MS + 1);
     fetchWithSsrFGuardMock
-      .mockResolvedValueOnce({
-        response: new Response(JSON.stringify({ prompt_id: "local-prompt-1" }), {
-          status: 200,
-          headers: { "content-type": "application/json" },
-        }),
-        release: vi.fn(async () => {}),
-      })
-      .mockResolvedValueOnce({
-        response: new Response(JSON.stringify({ "local-prompt-1": { outputs: {} } }), {
-          status: 200,
-          headers: { "content-type": "application/json" },
-        }),
-        release: vi.fn(async () => {}),
-      });
+      .mockResolvedValueOnce(fetchGuardJson({ prompt_id: "local-prompt-1" }))
+      .mockResolvedValueOnce(fetchGuardJson({ "local-prompt-1": { outputs: {} } }));
 
     try {
       const provider = buildComfyImageGenerationProvider();
@@ -961,31 +924,18 @@ describe("comfy image-generation provider", () => {
 
   it("rejects generated image downloads that exceed the configured media cap", async () => {
     fetchWithSsrFGuardMock
-      .mockResolvedValueOnce({
-        response: new Response(JSON.stringify({ prompt_id: "local-prompt-1" }), {
-          status: 200,
-          headers: { "content-type": "application/json" },
-        }),
-        release: vi.fn(async () => {}),
-      })
-      .mockResolvedValueOnce({
-        response: new Response(
-          JSON.stringify({
-            "local-prompt-1": {
-              outputs: {
-                "9": {
-                  images: [{ filename: "generated.png", subfolder: "", type: "output" }],
-                },
+      .mockResolvedValueOnce(fetchGuardJson({ prompt_id: "local-prompt-1" }))
+      .mockResolvedValueOnce(
+        fetchGuardJson({
+          "local-prompt-1": {
+            outputs: {
+              "9": {
+                images: [{ filename: "generated.png", subfolder: "", type: "output" }],
               },
             },
-          }),
-          {
-            status: 200,
-            headers: { "content-type": "application/json" },
           },
-        ),
-        release: vi.fn(async () => {}),
-      })
+        }),
+      )
       .mockResolvedValueOnce({
         response: new Response(Buffer.from("too-large"), {
           status: 200,
@@ -1093,38 +1043,19 @@ describe("comfy image-generation provider", () => {
 
   it("uploads reference images for local edit workflows", async () => {
     fetchWithSsrFGuardMock
-      .mockResolvedValueOnce({
-        response: new Response(JSON.stringify({ name: "upload.png" }), {
-          status: 200,
-          headers: { "content-type": "application/json" },
-        }),
-        release: vi.fn(async () => {}),
-      })
-      .mockResolvedValueOnce({
-        response: new Response(JSON.stringify({ prompt_id: "local-edit-1" }), {
-          status: 200,
-          headers: { "content-type": "application/json" },
-        }),
-        release: vi.fn(async () => {}),
-      })
-      .mockResolvedValueOnce({
-        response: new Response(
-          JSON.stringify({
-            "local-edit-1": {
-              outputs: {
-                "9": {
-                  images: [{ filename: "edited.png", subfolder: "", type: "output" }],
-                },
+      .mockResolvedValueOnce(fetchGuardJson({ name: "upload.png" }))
+      .mockResolvedValueOnce(fetchGuardJson({ prompt_id: "local-edit-1" }))
+      .mockResolvedValueOnce(
+        fetchGuardJson({
+          "local-edit-1": {
+            outputs: {
+              "9": {
+                images: [{ filename: "edited.png", subfolder: "", type: "output" }],
               },
             },
-          }),
-          {
-            status: 200,
-            headers: { "content-type": "application/json" },
           },
-        ),
-        release: vi.fn(async () => {}),
-      })
+        }),
+      )
       .mockResolvedValueOnce({
         response: new Response(Buffer.from("edited-data"), {
           status: 200,

--- a/extensions/comfy/music-generation-provider.test.ts
+++ b/extensions/comfy/music-generation-provider.test.ts
@@ -2,6 +2,7 @@
 import { expectExplicitMusicGenerationCapabilities } from "openclaw/plugin-sdk/provider-test-contracts";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { buildComfyMusicGenerationProvider } from "./music-generation-provider.js";
+import { fetchGuardJson } from "./test-helpers.js";
 
 const { fetchWithSsrFGuardMock } = vi.hoisted(() => ({
   fetchWithSsrFGuardMock: vi.fn(),
@@ -28,31 +29,18 @@ describe("comfy music-generation provider", () => {
 
   it("runs a music workflow and returns audio outputs", async () => {
     fetchWithSsrFGuardMock
-      .mockResolvedValueOnce({
-        response: new Response(JSON.stringify({ prompt_id: "music-job-1" }), {
-          status: 200,
-          headers: { "content-type": "application/json" },
-        }),
-        release: vi.fn(async () => {}),
-      })
-      .mockResolvedValueOnce({
-        response: new Response(
-          JSON.stringify({
-            "music-job-1": {
-              outputs: {
-                "9": {
-                  audio: [{ filename: "song.mp3", subfolder: "", type: "output" }],
-                },
+      .mockResolvedValueOnce(fetchGuardJson({ prompt_id: "music-job-1" }))
+      .mockResolvedValueOnce(
+        fetchGuardJson({
+          "music-job-1": {
+            outputs: {
+              "9": {
+                audio: [{ filename: "song.mp3", subfolder: "", type: "output" }],
               },
             },
-          }),
-          {
-            status: 200,
-            headers: { "content-type": "application/json" },
           },
-        ),
-        release: vi.fn(async () => {}),
-      })
+        }),
+      )
       .mockResolvedValueOnce({
         response: new Response(Buffer.from("music-bytes"), {
           status: 200,
@@ -105,31 +93,18 @@ describe("comfy music-generation provider", () => {
 
   it("rejects generated music downloads that exceed the configured media cap", async () => {
     fetchWithSsrFGuardMock
-      .mockResolvedValueOnce({
-        response: new Response(JSON.stringify({ prompt_id: "music-job-1" }), {
-          status: 200,
-          headers: { "content-type": "application/json" },
-        }),
-        release: vi.fn(async () => {}),
-      })
-      .mockResolvedValueOnce({
-        response: new Response(
-          JSON.stringify({
-            "music-job-1": {
-              outputs: {
-                "9": {
-                  audio: [{ filename: "song.mp3", subfolder: "", type: "output" }],
-                },
+      .mockResolvedValueOnce(fetchGuardJson({ prompt_id: "music-job-1" }))
+      .mockResolvedValueOnce(
+        fetchGuardJson({
+          "music-job-1": {
+            outputs: {
+              "9": {
+                audio: [{ filename: "song.mp3", subfolder: "", type: "output" }],
               },
             },
-          }),
-          {
-            status: 200,
-            headers: { "content-type": "application/json" },
           },
-        ),
-        release: vi.fn(async () => {}),
-      })
+        }),
+      )
       .mockResolvedValueOnce({
         response: new Response(Buffer.from("too-large"), {
           status: 200,

--- a/extensions/comfy/test-helpers.ts
+++ b/extensions/comfy/test-helpers.ts
@@ -88,7 +88,7 @@ export function mockComfyCloudJobResponses(
     );
 }
 
-function fetchGuardJson(body: unknown) {
+export function fetchGuardJson(body: unknown) {
   return fetchGuardResponse(
     new Response(JSON.stringify(body), {
       status: 200,

--- a/extensions/comfy/video-generation-provider.test.ts
+++ b/extensions/comfy/video-generation-provider.test.ts
@@ -3,6 +3,7 @@ import { expectExplicitVideoGenerationCapabilities } from "openclaw/plugin-sdk/p
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   buildComfyConfig,
+  fetchGuardJson,
   mockComfyCloudJobResponses,
   mockComfyProviderApiKey,
   parseComfyJsonBody,
@@ -39,27 +40,14 @@ function mockLocalVideoResponses(params: {
   };
 }) {
   fetchWithSsrFGuardMock
-    .mockResolvedValueOnce({
-      response: new Response(JSON.stringify({ prompt_id: params.promptId }), {
-        status: 200,
-        headers: { "content-type": "application/json" },
-      }),
-      release: vi.fn(async () => {}),
-    })
-    .mockResolvedValueOnce({
-      response: new Response(
-        JSON.stringify({
-          [params.promptId]: {
-            outputs: params.outputs,
-          },
-        }),
-        {
-          status: 200,
-          headers: { "content-type": "application/json" },
+    .mockResolvedValueOnce(fetchGuardJson({ prompt_id: params.promptId }))
+    .mockResolvedValueOnce(
+      fetchGuardJson({
+        [params.promptId]: {
+          outputs: params.outputs,
         },
-      ),
-      release: vi.fn(async () => {}),
-    });
+      }),
+    );
 
   if (params.download) {
     fetchWithSsrFGuardMock.mockResolvedValueOnce({
@@ -124,31 +112,18 @@ describe("comfy video-generation provider", () => {
 
   it("submits a local workflow, waits for history, and downloads videos", async () => {
     fetchWithSsrFGuardMock
-      .mockResolvedValueOnce({
-        response: new Response(JSON.stringify({ prompt_id: "local-video-1" }), {
-          status: 200,
-          headers: { "content-type": "application/json" },
-        }),
-        release: vi.fn(async () => {}),
-      })
-      .mockResolvedValueOnce({
-        response: new Response(
-          JSON.stringify({
-            "local-video-1": {
-              outputs: {
-                "9": {
-                  gifs: [{ filename: "generated.mp4", subfolder: "", type: "output" }],
-                },
+      .mockResolvedValueOnce(fetchGuardJson({ prompt_id: "local-video-1" }))
+      .mockResolvedValueOnce(
+        fetchGuardJson({
+          "local-video-1": {
+            outputs: {
+              "9": {
+                gifs: [{ filename: "generated.mp4", subfolder: "", type: "output" }],
               },
             },
-          }),
-          {
-            status: 200,
-            headers: { "content-type": "application/json" },
           },
-        ),
-        release: vi.fn(async () => {}),
-      })
+        }),
+      )
       .mockResolvedValueOnce({
         response: new Response(Buffer.from("mp4-data"), {
           status: 200,
@@ -319,31 +294,18 @@ describe("comfy video-generation provider", () => {
 
   it("rejects generated video downloads that exceed the configured media cap", async () => {
     fetchWithSsrFGuardMock
-      .mockResolvedValueOnce({
-        response: new Response(JSON.stringify({ prompt_id: "local-video-1" }), {
-          status: 200,
-          headers: { "content-type": "application/json" },
-        }),
-        release: vi.fn(async () => {}),
-      })
-      .mockResolvedValueOnce({
-        response: new Response(
-          JSON.stringify({
-            "local-video-1": {
-              outputs: {
-                "9": {
-                  gifs: [{ filename: "generated.mp4", subfolder: "", type: "output" }],
-                },
+      .mockResolvedValueOnce(fetchGuardJson({ prompt_id: "local-video-1" }))
+      .mockResolvedValueOnce(
+        fetchGuardJson({
+          "local-video-1": {
+            outputs: {
+              "9": {
+                gifs: [{ filename: "generated.mp4", subfolder: "", type: "output" }],
               },
             },
-          }),
-          {
-            status: 200,
-            headers: { "content-type": "application/json" },
           },
-        ),
-        release: vi.fn(async () => {}),
-      })
+        }),
+      )
       .mockResolvedValueOnce({
         response: new Response(Buffer.from("too-large"), {
           status: 200,


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

Comfy's image, video, and music tests repeat the same guarded JSON response construction even though the plugin already has a shared fixture for it. That boilerplate obscures the response bodies and request sequence each scenario exercises.

## Why This Change Was Made

Export and reuse the existing `fetchGuardJson` test helper at 21 sites. Every response body and queue position stays explicit, and each call still creates its own Response, headers, and asynchronous release mock. Binary responses, custom release assertions, malformed data, real transport coverage, and policy inputs remain explicit.

## User Impact

No user-visible or production behavior changes. This removes 132 lines from tests while preserving all 116 assertion sites in the three provider suites.

## Evidence

- All 70 cases passed before and after across the image, video, music, plugin registration, and header integration suites, with identical case names and statuses.
- Expanding the 21 calls and removing the imports reconstructs the original test files exactly after formatting; the existing helper changes only by adding its export.
- Evaluating the actual helper body confirmed equal JSON bytes, status, headers, construction order, and fresh per-call response/header/release objects for every migrated fixture.
- Mapped changed-file checks and independent review through P2 passed.
