### PR TITLE
fix(deps): remove six published transitive advisories

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -144,6 +144,9 @@ overrides:
   yauzl: 3.4.0
   protobufjs: 8.8.0
   uuid: 14.0.2
+  hono@<4.13.5: 4.13.7
+  joi@>=18.0.0 <18.2.5: 18.2.8
+  js-yaml@>=4.0.0 <4.3.2: 4.3.2
 
 packageExtensionsChecksum: sha256-zZ8fyodhMTumshonC7kktCqTPsiHL3UAyS9vltFAlMo=
 
@@ -3643,7 +3646,7 @@ packages:
     resolution: {integrity: sha512-ELuehkj5VCBdgEw9zs+ivkKwyzzUCSQuE96YmiPvn1ECBoZCczbFXJLeEGMTYjphP6gydh4pHMqEYPVMYUVgQg==}
     engines: {node: '>=20'}
     peerDependencies:
-      hono: ^4
+      hono: 4.13.7
 
   '@iconify/types@2.0.0':
     resolution: {integrity: sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==}
@@ -7186,8 +7189,8 @@ packages:
     resolution: {integrity: sha512-nbfWpyRMcMrPMmDwJB+dhX/eiaPKtc2RB+0QZskqJ3WjRA/FDS0e9hZrx8EC/lbEv8gXy98FcDbNa/dspAaJMg==}
     engines: {node: '>=12.0.0'}
 
-  hono@4.13.4:
-    resolution: {integrity: sha512-AGEwKIyRMHRv1t8Wjwa3LHxQ61X5CqrdFT+4BRNTpqS5aJNnpl5WLjADb7vFlJzI/8uK7T5QLVApCMQKNa3LgQ==}
+  hono@4.13.7:
+    resolution: {integrity: sha512-c8/gF9ac8Y78/agExVocyLevgR+JlpNB444Py0FSX8pJoPdYUfUzRcXtYEYGwt6l19qIlVZPN5Mfsw9jFShmQQ==}
     engines: {node: '>=16.9.0'}
 
   hookable@6.1.1:
@@ -7431,8 +7434,8 @@ packages:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
 
-  joi@18.2.3:
-    resolution: {integrity: sha512-N5A3KTWQpPWT4ExxxPlUx7WmykGXRzhNidWhV41d6Abu9YfI2NyWCJuxdPnslJCPWtbRpSVOWSnSS6GakLM/Rg==}
+  joi@18.2.8:
+    resolution: {integrity: sha512-G2TX62h58ZHuwqetJgP2F4ualakqAmZtBYe3jWen7gxQRw5xApX6crnFtuB91WC0c3ESBnva+kGSnb3+6pIQDQ==}
     engines: {node: '>= 20'}
 
   jose@4.15.9:
@@ -7447,8 +7450,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.3.1:
-    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
+  js-yaml@4.3.2:
+    resolution: {integrity: sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==}
     hasBin: true
 
   jscpd-darwin-arm64@5.1.2:
@@ -10974,9 +10977,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@hono/node-server@2.1.1(hono@4.13.4)':
+  '@hono/node-server@2.1.1(hono@4.13.7)':
     dependencies:
-      hono: 4.13.4
+      hono: 4.13.7
 
   '@iconify/types@2.0.0': {}
 
@@ -11412,7 +11415,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.30.0(supports-color@10.2.2)(zod@4.4.3)':
     dependencies:
-      '@hono/node-server': 2.1.1(hono@4.13.4)
+      '@hono/node-server': 2.1.1(hono@4.13.7)
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
       content-type: 1.0.5
@@ -11422,7 +11425,7 @@ snapshots:
       eventsource-parser: 3.1.1
       express: 5.2.1(supports-color@10.2.2)
       express-rate-limit: 8.6.2(express@5.2.1(supports-color@10.2.2))(supports-color@10.2.2)
-      hono: 4.13.4
+      hono: 4.13.7
       jose: 6.2.11
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -13630,7 +13633,7 @@ snapshots:
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.1
-      js-yaml: 4.3.1
+      js-yaml: 4.3.2
       parse-json: 5.2.0
     optionalDependencies:
       typescript: 6.0.3
@@ -14597,7 +14600,7 @@ snapshots:
 
   highlight.js@11.12.0: {}
 
-  hono@4.13.4: {}
+  hono@4.13.7: {}
 
   hookable@6.1.1: {}
 
@@ -14837,7 +14840,7 @@ snapshots:
 
   jiti@2.7.0: {}
 
-  joi@18.2.3:
+  joi@18.2.8:
     dependencies:
       '@hapi/address': 5.1.1
       '@hapi/formula': 3.0.2
@@ -14855,7 +14858,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.3.1:
+  js-yaml@4.3.2:
     dependencies:
       argparse: 2.0.1
 
@@ -15258,7 +15261,7 @@ snapshots:
       commander: 15.0.0
       fast-xml-parser: 5.11.1
       ipaddr.js: 2.5.0
-      joi: 18.2.3
+      joi: 18.2.8
       libmime: 5.4.1
       nodemailer: 9.1.1
       punycode.js: 2.3.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -77,6 +77,9 @@ overrides:
   yauzl: 3.4.0
   protobufjs: 8.8.0
   uuid: 14.0.2
+  hono@<4.13.5: 4.13.7
+  joi@>=18.0.0 <18.2.5: 18.2.8
+  js-yaml@>=4.0.0 <4.3.2: 4.3.2
 
 allowBuilds:
   "@google/genai": true


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where OpenClaw installations resolve six published dependency
advisories through transitive packages:

- Hono 4.13.4: GHSA-gqvv-2mrq-wpjv, GHSA-g6gw-c38x-mqfc, and GHSA-crvj-82cr-hjcx
- Joi 18.2.3: GHSA-6w3j-5fw6-r9vr and GHSA-gg4h-3hg2-grpc
- js-yaml 4.3.1: GHSA-2883-xcg3-v3hh

The Hono and Joi findings are in the production dependency graph. The js-yaml
finding is development-only.

## Why This Change Was Made

Adds range-scoped workspace overrides that move only affected releases to patched
versions: Hono 4.13.7, Joi 18.2.8, and js-yaml 4.3.2. Regenerating the pnpm lockfile
changes only those package nodes and their dependent snapshot references; no source,
configuration API, or runtime behavior is otherwise changed.

## User Impact

Installations no longer resolve the six known vulnerable package versions. Existing
package consumers keep their declared semver contracts, while unaffected future
versions are not forced through a blanket override.

## Evidence

- `pnpm audit --json`: before, 6 findings (1 high, 3 moderate, 2 low); after, 0.
- `pnpm audit --prod --audit-level low --json`: 0 production findings after the update.
- Dynamic Hono probes confirm literal URL fragments are not interpreted as query
  input and deeply nested dot-form bodies are rejected by the nesting limit.
- Dynamic Joi prototype-pollution probes leave `Object.prototype` unchanged and
  reject unsafe template/regex rename targets.
- Dynamic js-yaml merge-key exhaustion probe is stopped by `maxTotalMergeKeys`.
- `pnpm install --frozen-lockfile --lockfile-only --ignore-scripts`: passed.
- `pnpm deps:npm-lock:check:changed`: all 95 generated npm package locks validated.
- Dependency pin guard: 674 declarations across 182 manifests, 0 violations.
- Package patch guard: 6 approved patches, no new pnpm patches.
- Targeted formatting and `git diff --check`: passed.
- Independent AutoReview at P1 threshold: scoped-clean, no actionable findings.

No TypeScript source changes are present.

### Supported-Node Runtime Evidence

The patched package graph was checked on supported Node 24.19.0 in a clean,
secretless directory. Installation used pnpm 12.3.4 with lifecycle scripts disabled.
Probe inputs were:

- Hono: literal target `http://localhost/#ignored?role=admin`; a 150-segment
  dot-notation form key; and SSG parameter `a/b/../../../outside` with a recording
  filesystem adapter.
- Joi: an own `__proto__` custom-message key and a regex/template rename of
  `x-__proto__` with `multiple: true`.
- js-yaml: 20 empty merge-source mappings with `maxTotalMergeKeys: 10`.

```text
$ node --version
v24.19.0

$ pnpm install --ignore-scripts --no-frozen-lockfile
dependencies:
+ hono 4.13.7
+ joi 18.2.8
+ js-yaml 4.3.2
Done in 536ms using pnpm v12.3.4

$ node probe.mjs
node=v24.19.0
hono=4.13.7
joi=18.2.8
js-yaml=4.3.2
hono fragment-query probe: PASS (parameter after # ignored)
hono dot-notation depth probe: PASS (deep body rejected)
hono SSG traversal probe: PASS (outside write rejected)
joi custom-message prototype probe: PASS (Object.prototype unchanged)
joi rename-target prototype probe: PASS (validated prototype unchanged)
js-yaml empty-merge budget probe: PASS (limit enforced)

$ pnpm audit --json
vulnerabilities: info=0 low=0 moderate=0 high=0 critical=0
advisoryCount=0

$ pnpm audit --prod --audit-level low --json
vulnerabilities: info=0 low=0 moderate=0 high=0 critical=0
advisoryCount=0
```


## Review Status

Because `pnpm-lock.yaml` is CODEOWNED by `@openclaw/openclaw-secops`, the
repository dependency guard requires current admin/secops approval for this head
before merge. This PR does not request or bypass that approval.

