### PR TITLE
perf(terminal): avoid scanning long health status details

### DIFF
--- a/packages/terminal-core/src/health-style.ts
+++ b/packages/terminal-core/src/health-style.ts
@@ -14,12 +14,12 @@ export function styleHealthChannelLine(line: string, rich: boolean): string {
     return line;
   }
 
-  const label = line.slice(0, colon + 1);
   const detail = line.slice(colon + 1).trimStart();
-  const normalized = normalizeLowercaseStringOrEmpty(detail);
+  // Only the longest recognized status prefix needs case normalization.
+  const normalized = normalizeLowercaseStringOrEmpty(detail.slice(0, "not configured".length));
 
   const applyPrefix = (prefix: string, color: (value: string) => string) =>
-    `${label} ${color(detail.slice(0, prefix.length))}${detail.slice(prefix.length)}`;
+    `${line.slice(0, colon + 1)} ${color(detail.slice(0, prefix.length))}${detail.slice(prefix.length)}`;
 
   if (normalized.startsWith("failed")) {
     return applyPrefix("failed", theme.error);


### PR DESCRIPTION
## What Problem This Solves

Long channel-health diagnostics are lowercased in full to choose the color of a short status prefix. Unknown statuses also construct a label that is immediately discarded.

## Why This Change Was Made

Normalize only the longest recognized prefix and construct the label only when a known status is styled. Keep the existing normalizer, matching order, whitespace handling, original status spelling, and suffix bytes. Production line count is unchanged.

## User Impact

Less string-processing work for long rich terminal diagnostics. Output is unchanged; this does not make provider health probes or the whole health command uniformly faster.

## Evidence

One Linux/Node 24.19.0 comparison used four fresh processes in original/candidate/candidate/original order. All 16 timed formatter/styler cases and 154 complete output-parity cases matched, including case, whitespace, partial-word prefixes and Unicode. Native processes closed and the temporary worktree and Testbox were cleaned up.

For eight 2,048-character failure diagnostics, the pooled wall median fell from 11.994 to 5.188 microseconds per formatter/styler invocation. Eight healthy rich lines fell from 9.662 to 7.994 microseconds. Short direct controls regressed: known statuses cost about 0.10 microseconds more, and unknown statuses about 0.07–0.08 microseconds more, in both orders. The unchanged long plain-output control also regressed; all adverse values and native wall/CPU/RSS results are retained. No general plain-output or memory improvement is claimed.

All 93 existing health-format and health CLI tests passed. Formatting, diff checks, and independent Codex review through P2 passed. The local changed-plan command was refused before launching a child by its existing disk-admission floor; full selected checks are not claimed locally, and exact-head hosted CI remains required before landing. No limits, assertions, or timing expectations were weakened.

Release-note context stays in this PR because the changelog is release-owned.

**Current-head qualification:** Head `6edec74dc107` preserves this PR's authored patch on main `bca261d5583d`, including the shared `retainedMachine` typecheck repair (#145540). Benchmarks, earlier validation, and prior draft-state notes remain historical under their original source labels; no benchmark was rerun for this rebase. Exact-head CI is required before landing.
