### PR TITLE
refactor(tests): reuse runtime spies in Signal SSE tests

### DIFF
--- a/extensions/signal/src/sse-reconnect.real-server.test.ts
+++ b/extensions/signal/src/sse-reconnect.real-server.test.ts
@@ -2,6 +2,7 @@ import { createServer, type Server } from "node:http";
 import type { AddressInfo } from "node:net";
 import type { ChannelAccountSnapshot } from "openclaw/plugin-sdk/channel-contract";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { createRuntimeSpies } from "../../test-support/runtime-spies.js";
 import { runSignalSseLoop, type SignalStatusSink } from "./sse-reconnect.js";
 
 const servers: Server[] = [];
@@ -42,10 +43,6 @@ afterEach(async () => {
   );
 });
 
-function createRuntime() {
-  return { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
-}
-
 describe("runSignalSseLoop native HTTP boundary", () => {
   it("publishes one terminal status and stops after a permanent rejection", async () => {
     const abort = new AbortController();
@@ -64,7 +61,7 @@ describe("runSignalSseLoop native HTTP boundary", () => {
       baseUrl: endpoint.baseUrl,
       account: "+15555550100",
       abortSignal: abort.signal,
-      runtime: createRuntime(),
+      runtime: createRuntimeSpies(),
       onEvent: vi.fn(),
       statusSink,
     });
@@ -89,7 +86,7 @@ describe("runSignalSseLoop native HTTP boundary", () => {
       baseUrl: endpoint.baseUrl,
       account: "+15555550100",
       abortSignal: abort.signal,
-      runtime: createRuntime(),
+      runtime: createRuntimeSpies(),
       onEvent: vi.fn(),
       policy: { initialMs: 1, maxMs: 1, factor: 1, jitter: 0 },
       statusSink: (patch) => {

--- a/extensions/signal/src/sse-reconnect.test.ts
+++ b/extensions/signal/src/sse-reconnect.test.ts
@@ -1,14 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createRuntimeSpies } from "../../test-support/runtime-spies.js";
 
 const streamSignalEvents = vi.hoisted(() => vi.fn());
 
 vi.mock("./client-adapter.js", () => ({ streamSignalEvents }));
 
 import { runSignalSseLoop } from "./sse-reconnect.js";
-
-function createRuntime() {
-  return { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
-}
 
 describe("runSignalSseLoop lifecycle", () => {
   beforeEach(() => {
@@ -29,7 +26,7 @@ describe("runSignalSseLoop lifecycle", () => {
     await runSignalSseLoop({
       baseUrl: "http://signal.test",
       abortSignal: abort.signal,
-      runtime: createRuntime(),
+      runtime: createRuntimeSpies(),
       onEvent: vi.fn(),
       statusSink,
     });
@@ -56,7 +53,7 @@ describe("runSignalSseLoop lifecycle", () => {
     await runSignalSseLoop({
       baseUrl: "http://signal.test",
       abortSignal: abort.signal,
-      runtime: createRuntime(),
+      runtime: createRuntimeSpies(),
       onEvent: vi.fn(),
       statusSink,
     });


### PR DESCRIPTION
## What Problem This Solves

Signal SSE tests duplicate runtime mocks already provided by the shared plugin test helper.

## Why This Change Was Made

Reuse `createRuntimeSpies` at the existing allocation sites. Preserve reconnect, rejection/recovery, abort, and cleanup assertions.

## User Impact

No production behavior change or test cases added/removed. Two test files add 6 lines and remove 12.

## Evidence

All 12 cases passed before and after: four SSE cases and eight client-adapter cases, with identical native inventory, order, and statuses. Independent review found no actionable P0–P2 issues.

All 19 normal changed-file checks passed, including formatting, typechecking, lint, and dead-code scans. Source and dependency bytes remained unchanged through proof.
