### PR TITLE
refactor(macos): remove unused presentation status work

### DIFF
--- a/apps/macos/Sources/OpenClaw/CanvasManager.swift
+++ b/apps/macos/Sources/OpenClaw/CanvasManager.swift
@@ -30,25 +30,14 @@ final class CanvasManager {
         path: String? = nil,
         placement: CanvasPlacement? = nil) throws -> String
     {
-        try self.showDetailed(
-            sessionKey: sessionKey,
-            target: path,
-            placement: placement).directory
-    }
-
-    func showDetailed(
-        sessionKey: String,
-        target: String? = nil,
-        placement: CanvasPlacement? = nil) throws -> CanvasShowResult
-    {
         Self.logger.debug(
             """
-            showDetailed start session=\(sessionKey, privacy: .public) \
-            hasTarget=\(target != nil) \
+            show session=\(sessionKey, privacy: .public) \
+            hasTarget=\(path != nil) \
             placement=\(placement != nil)
             """)
         let anchorProvider = self.defaultAnchorProvider ?? Self.mouseAnchorProvider
-        let normalizedTarget = target?
+        let normalizedTarget = path?
             .trimmingCharacters(in: .whitespacesAndNewlines)
             .nonEmpty
         let ensured = try ensureController(sessionKey: sessionKey)
@@ -61,35 +50,19 @@ final class CanvasManager {
             // Existing session: only navigate when an explicit target was provided.
             if let normalizedTarget {
                 controller.load(target: normalizedTarget)
-                self.refreshDebugStatus()
-                return self.makeShowResult(
-                    directory: controller.directoryPath,
-                    target: target,
-                    effectiveTarget: normalizedTarget)
             }
 
             self.refreshDebugStatus()
-            return CanvasShowResult(
-                directory: controller.directoryPath,
-                target: target,
-                effectiveTarget: nil,
-                status: .shown,
-                url: nil)
+            return controller.directoryPath
         }
 
         controller.applyPreferredPlacement(placement)
 
         // New session: default to the local document root.
-        let effectiveTarget = normalizedTarget ?? "/"
-        Self.logger.debug("showDetailed showCanvas hasExplicitTarget=\(normalizedTarget != nil)")
-        controller.showCanvas(path: effectiveTarget)
-        Self.logger.debug("showDetailed showCanvas done")
+        controller.showCanvas(path: normalizedTarget ?? "/")
         self.refreshDebugStatus()
 
-        return self.makeShowResult(
-            directory: controller.directoryPath,
-            target: target,
-            effectiveTarget: effectiveTarget)
+        return controller.directoryPath
     }
 
     func hide(sessionKey: String) {
@@ -158,108 +131,16 @@ final class CanvasManager {
         self.panelController = nil
         self.panelSessionKey = nil
 
-        Self.logger.debug("ensureController ensure canvas root dir")
         try FileManager().createDirectory(at: Self.canvasRoot, withIntermediateDirectories: true)
-        Self.logger.debug("ensureController init CanvasWindowController")
         let controller = try CanvasWindowController(
             sessionKey: session,
             root: Self.canvasRoot,
             presentation: .panel(anchorProvider: anchorProvider))
-        Self.logger.debug("ensureController CanvasWindowController init done")
         controller.onVisibilityChanged = { [weak self] visible in
             self?.onPanelVisibilityChanged?(visible)
         }
         self.panelController = controller
         self.panelSessionKey = session
         return (controller, true)
-    }
-
-    private static func directURL(for target: String?) -> URL? {
-        guard let target else { return nil }
-        let trimmed = target.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return nil }
-
-        guard let url = URL(string: trimmed), let scheme = url.scheme?.lowercased() else { return nil }
-        return scheme == "https" || scheme == "http" || CanvasScheme.allSchemes.contains(scheme)
-            ? url
-            : nil
-    }
-
-    private func makeShowResult(
-        directory: String,
-        target: String?,
-        effectiveTarget: String) -> CanvasShowResult
-    {
-        if let url = Self.directURL(for: effectiveTarget) {
-            return CanvasShowResult(
-                directory: directory,
-                target: target,
-                effectiveTarget: effectiveTarget,
-                status: .web,
-                url: url.absoluteString)
-        }
-
-        let sessionDir = URL(fileURLWithPath: directory)
-        let status = Self.localStatus(sessionDir: sessionDir, target: effectiveTarget)
-        let host = sessionDir.lastPathComponent
-        let canvasURL = CanvasScheme.makeURL(session: host, path: effectiveTarget)?.absoluteString
-        return CanvasShowResult(
-            directory: directory,
-            target: target,
-            effectiveTarget: effectiveTarget,
-            status: status,
-            url: canvasURL)
-    }
-
-    private static func localStatus(sessionDir: URL, target: String) -> CanvasShowStatus {
-        let fm = FileManager()
-        let trimmed = target.trimmingCharacters(in: .whitespacesAndNewlines)
-        let withoutQuery = trimmed.split(separator: "?", maxSplits: 1, omittingEmptySubsequences: false).first
-            .map(String.init) ?? trimmed
-        var path = withoutQuery
-        if path.hasPrefix("/") {
-            path.removeFirst()
-        }
-        path = path.removingPercentEncoding ?? path
-
-        // Root special-case: resolve an existing index document.
-        if path.isEmpty {
-            let a = sessionDir.appendingPathComponent("index.html", isDirectory: false)
-            let b = sessionDir.appendingPathComponent("index.htm", isDirectory: false)
-            if fm.fileExists(atPath: a.path) || fm.fileExists(atPath: b.path) {
-                return .ok
-            }
-            return .notFound
-        }
-
-        // Direct file or directory.
-        var candidate = sessionDir.appendingPathComponent(path, isDirectory: false)
-        var isDir: ObjCBool = false
-        if fm.fileExists(atPath: candidate.path, isDirectory: &isDir) {
-            if isDir.boolValue {
-                return Self.indexExists(in: candidate) ? .ok : .notFound
-            }
-            return .ok
-        }
-
-        // Directory index behavior ("/yolo" -> "yolo/index.html") if directory exists.
-        if !path.isEmpty, !path.hasSuffix("/") {
-            candidate = sessionDir.appendingPathComponent(path, isDirectory: true)
-            if fm.fileExists(atPath: candidate.path, isDirectory: &isDir), isDir.boolValue {
-                return Self.indexExists(in: candidate) ? .ok : .notFound
-            }
-        }
-
-        return .notFound
-    }
-
-    private static func indexExists(in dir: URL) -> Bool {
-        let fm = FileManager()
-        let a = dir.appendingPathComponent("index.html", isDirectory: false)
-        if fm.fileExists(atPath: a.path) {
-            return true
-        }
-        let b = dir.appendingPathComponent("index.htm", isDirectory: false)
-        return fm.fileExists(atPath: b.path)
     }
 }

--- a/apps/macos/Sources/OpenClaw/DashboardWindowController+DeviceSettings.swift
+++ b/apps/macos/Sources/OpenClaw/DashboardWindowController+DeviceSettings.swift
@@ -49,7 +49,6 @@ extension DashboardWindowController {
         case let .requestPermission(id):
             if let capability = id.capability {
                 _ = await PermissionManager.ensure([capability], interactive: true)
-                await PermissionMonitor.shared.refreshNow()
             }
         case let .openSystemSettings(id):
             if let capability = id.capability {

--- a/apps/macos/Sources/OpenClaw/NodeMode/MacNodeRuntime.swift
+++ b/apps/macos/Sources/OpenClaw/NodeMode/MacNodeRuntime.swift
@@ -497,9 +497,9 @@ extension MacNodeRuntime {
             }
             let sessionKey = self.mainSessionKey
             try await MainActor.run {
-                _ = try CanvasManager.shared.showDetailed(
+                _ = try CanvasManager.shared.show(
                     sessionKey: sessionKey,
-                    target: effectiveURL,
+                    path: effectiveURL,
                     placement: placement)
             }
             return BridgeInvokeResponse(id: req.id, ok: true)

--- a/apps/macos/Sources/OpenClaw/PermissionManager.swift
+++ b/apps/macos/Sources/OpenClaw/PermissionManager.swift
@@ -412,23 +412,3 @@ final class LocationPermissionRequester: NSObject, CLLocationManagerDelegate {
         }
     }
 }
-
-@MainActor
-final class PermissionMonitor {
-    static let shared = PermissionMonitor()
-
-    private var status: [Capability: CapabilityAuthorizationStatus] = [:]
-    private var isChecking = false
-
-    func refreshNow() async {
-        if self.isChecking { return }
-        self.isChecking = true
-        defer { self.isChecking = false }
-
-        let latest = await PermissionManager.authorizationStatus()
-        if latest != self.status {
-            self.status = latest
-            NotificationCenter.default.post(name: .openclawPermissionsChanged, object: nil)
-        }
-    }
-}

--- a/apps/macos/Sources/OpenClawIPC/IPC.swift
+++ b/apps/macos/Sources/OpenClawIPC/IPC.swift
@@ -57,47 +57,6 @@ public struct CanvasPlacement: Codable, Sendable {
     }
 }
 
-// MARK: - Canvas show result
-
-public enum CanvasShowStatus: String, Codable, Sendable {
-    /// Panel was shown, but no navigation occurred (no target passed and session already existed).
-    case shown
-    /// Target was a direct URL (http(s) or file).
-    case web
-    /// Local canvas target resolved to an existing file.
-    case ok
-    /// Local canvas target did not resolve to a file (404 page).
-    case notFound
-    /// Local scaffold fallback (e.g., no index.html present).
-    case welcome
-}
-
-public struct CanvasShowResult: Codable, Sendable {
-    /// Session directory on disk (e.g. `~/Library/Application Support/OpenClaw/canvas/<session>/`).
-    public var directory: String
-    /// Target as provided by the caller (may be nil/empty).
-    public var target: String?
-    /// Target actually navigated to (nil when no navigation occurred; defaults to "/" for a newly created session).
-    public var effectiveTarget: String?
-    public var status: CanvasShowStatus
-    /// URL that was loaded (nil when no navigation occurred).
-    public var url: String?
-
-    public init(
-        directory: String,
-        target: String?,
-        effectiveTarget: String?,
-        status: CanvasShowStatus,
-        url: String?)
-    {
-        self.directory = directory
-        self.target = target
-        self.effectiveTarget = effectiveTarget
-        self.status = status
-        self.url = url
-    }
-}
-
 // MARK: - Responses
 
 public struct Response: Codable, Sendable {


### PR DESCRIPTION
## What Problem This Solves

Canvas presentation performs filesystem/status work whose results no caller uses, and requesting a device permission immediately runs a second full permission scan. These obsolete projections add main-thread work and competing status paths to the native app.

## Why This Change Was Made

CanvasManager now exposes one presentation operation returning the directory its caller actually consumes. The Canvas scheme handler remains the content-resolution owner; unused URL/index/status probes are deleted. PermissionManager remains the permission-change notification owner, and the unused PermissionMonitor snapshot is removed.

## User Impact

Presentation, navigation, placement, permission requests, and bridge responses stay the same with less redundant work. The orphaned Canvas status/result types are also removed: their legacy CLI producer and decoder were retired together in December 2025, with compatibility explicitly excluded by that migration. This is a maintainer-requested architecture cleanup, not a UI appearance change.

## Evidence

- Complete callsite search and source review: no remaining showDetailed or PermissionMonitor use; node canvas.present still returns its existing successful response.
- Swift app and test build, Swift lint/format, and git diff --check pass.
- Deslop completed; independent Codex review through P2 is scoped-clean.
- No new helper-mirroring tests; existing Canvas, node, and permission boundary tests passed in required native CI. No native suite or app was run against operator state.
- 181 net production lines removed; no config, storage, protocol, dependency or user-facing copy changes.

The first dead-code scan caught the orphaned Canvas result types. Historical review verified the complete legacy contract retirement; the current and tagged node protocol returns only its existing successful response. Removed the types with fresh P2 review rather than adding a scan ignore. The initial required native CI run passed before this final deletion; refreshed exact-head CI also passed.

Final exact-head [CI run34661779261](https://github.com/openclaw/openclaw/actions/runs/34661779261) and the macOS Periphery scan passed at c9fe25f8bef080f6accff081c7174bf7612c3115.
