### PR TITLE
feat(ui): show native Gateway shortcuts in the sidebar menu

### DIFF
--- a/docs/platforms/mac/webchat.md
+++ b/docs/platforms/mac/webchat.md
@@ -112,9 +112,11 @@ Inline widgets also load from that window's Gateway.
 
 ### Gateway picker
 
-The dashboard header shows a Gateway picker when the Mac app has at least two
-configured Gateways. Choose a Gateway to replace the current dashboard in the
-same window, or Option-click it to open a separate dashboard window. **Set as
+The sidebar identity menu lists the Mac app's configured Gateways, with health,
+primary, and current-selection indicators. The first nine rows show **⌘1–9**
+shortcuts in native Gateway menu order; later rows have no shortcut hint.
+Choose a Gateway to replace the current dashboard in the same window, or
+Command-click or Control-click it to open a separate dashboard window. **Set as
 primary…** makes the viewed token-authenticated profile the Mac app's primary
 Gateway after confirmation. The app replaces the primary Gateway's credentials
 and closes its native chat window; independent saved-profile windows stay open.

--- a/ui/src/components/app-sidebar-agent-menu.ts
+++ b/ui/src/components/app-sidebar-agent-menu.ts
@@ -429,14 +429,13 @@ function renderIdentityGateways(onClose: SidebarIdentityMenuParams["onClose"]) {
   const current = snapshot?.gateways.find((gateway) => gateway.id === snapshot.currentId);
   return html`
     <div class="sidebar-customize-menu__title">${t("nav.gateway.sectionLabel")}</div>
-    ${snapshot?.gateways.map((gateway) => {
+    ${snapshot?.gateways.map((gateway, index) => {
       const selected = gateway.id === snapshot.currentId;
-      const healthLabel =
-        gateway.health === "ok"
-          ? t("nav.gateway.connected")
-          : gateway.health === "error"
-            ? t("nav.gateway.unreachable")
-            : t("nav.gateway.unknown");
+      const healthLabel = {
+        ok: t("nav.gateway.connected"),
+        error: t("nav.gateway.unreachable"),
+        unknown: t("nav.gateway.unknown"),
+      }[gateway.health];
       const openWindow = (event: MouseEvent) => {
         if (event.metaKey || event.ctrlKey) {
           event.preventDefault();
@@ -464,6 +463,7 @@ function renderIdentityGateways(onClose: SidebarIdentityMenuParams["onClose"]) {
         <span class="sidebar-customize-menu__text">${gateway.name}</span>
         <span slot="details" class="sidebar-gateway-details">
           ${gateway.isPrimary ? html`<span class="sidebar-gateway-primary">${t("nav.gateway.primaryTag")}</span>` : nothing}
+          ${index < 9 ? html`<kbd class="session-menu__shortcut" aria-hidden="true">⌘${index + 1}</kbd>` : nothing}
           ${selected ? html`<span class="sidebar-gateway-check" aria-hidden="true">${icons.check}</span>` : nothing}
         </span>
       </wa-dropdown-item>`;

--- a/ui/src/components/app-sidebar-native-gateways.test.ts
+++ b/ui/src/components/app-sidebar-native-gateways.test.ts
@@ -77,6 +77,14 @@ describe("AppSidebar native Gateway menu", () => {
     expect(
       rows.map((row) => row.querySelector(".sidebar-gateway-health")?.getAttribute("aria-label")),
     ).toEqual(["Connected", "Unreachable", "Unknown status"]);
+    expect(rows.map((row) => row.querySelector('[slot="details"] kbd')?.textContent)).toEqual([
+      "⌘1",
+      "⌘2",
+      "⌘3",
+    ]);
+    for (const row of rows) {
+      expect(row.querySelector("kbd")?.getAttribute("aria-hidden")).toBe("true");
+    }
     expect(rows[0]!.querySelector(".sidebar-gateway-primary")?.textContent).toBe("primary");
     expect(rows[1]!.querySelector(".sidebar-gateway-primary")).toBeNull();
     expect(rows[1]!.querySelector(".sidebar-gateway-check")).not.toBeNull();
@@ -112,5 +120,18 @@ describe("AppSidebar native Gateway menu", () => {
     expect(
       singleMenu.querySelector('wa-dropdown-item[value="command:gateway-settings"]'),
     ).not.toBeNull();
+
+    snapshot.gateways = Array.from({ length: 10 }, (_, index) => ({
+      ...snapshot.gateways[0]!,
+      id: `gateway-${index + 1}`,
+      name: `Gateway ${index + 1}`,
+    }));
+    snapshot.currentId = "gateway-1";
+    publish();
+    await sidebar.updateComplete;
+    const manyRows = sidebar.querySelectorAll('wa-dropdown-item[value^="gateway:"]');
+    expect(manyRows).toHaveLength(10);
+    expect(manyRows[8]!.querySelector('[slot="details"] kbd')?.textContent).toBe("⌘9");
+    expect(manyRows[9]!.querySelector("kbd")).toBeNull();
   });
 });


### PR DESCRIPTION
## What Problem This Solves

The Mac app's native Gateways menu binds ⌘1–9 to switch Gateways (and ⌘⌥1–9 to open one in a new window), but the sidebar Gateway menu added in #145341 gave no hint that those shortcuts exist.

## Why This Change Was Made

Each Gateway row in the sidebar identity menu now shows a `⌘N` hint for the first nine rows, in native menu order (the injected snapshot is the same ordered list the native menu is built from). Rows beyond nine show no hint. The hint is display-only and aria-hidden: the native NSMenu key equivalents already fire while the dashboard is focused, so the web adds no key handling. The health-label nested ternary became a lookup map to keep production LOC neutral. The webchat docs paragraph that still described the old header picker now describes the sidebar menu and the shortcuts.

## User Impact

Mac users discover the ⌘1–9 Gateway switching from the menu itself. No behavior change for the browser-hosted Control UI.

## Evidence

Synthetic fixtures only, Chromium with the native bridge injected before load, light appearance, device scale factor 2.

| Before | After |
| --- | --- |
| ![Gateway menu without shortcut hints](https://github.com/user-attachments/assets/06a1431e-e3f7-433e-ae2f-332533a6df50) | ![Gateway menu with ⌘1–⌘3 hints](https://github.com/user-attachments/assets/148170d3-d059-4677-ba28-4154b2b94805) |

Production LOC: neutral (+7/−7 in the menu module). Tests: +21. Docs: +5/−3.

```sh
node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-isolated.config.ts --configLoader runner ui/src/components/app-sidebar-native-gateways.test.ts
node scripts/run-vitest.mjs run --config test/vitest/vitest.ui.config.ts --configLoader runner ui/src/components/app-sidebar.test.ts ui/src/components/sidebar-footer-layout.browser.test.ts
pnpm tsgo:ui
```

All pass (focused menu test asserts ⌘1–⌘3, ⌘9 on the ninth row, no hint on the tenth, and that hints are aria-hidden). A scratch Playwright run drove the real menu and re-verified the bridge messages (select, open-window, open-settings). `check-changed` reported TUI test typecheck errors (`getBounds` on `OverlayHandle`) in files this PR does not touch; they come from a stale local dependency install after the lockfile refresh on main, so exact-head CI is authoritative for that lane.
