### PR TITLE
fix(ui): settings navigation skeleton mirrors the loaded sidebar

### DIFF
--- a/ui/src/app/app-host-pairing-access.test.ts
+++ b/ui/src/app/app-host-pairing-access.test.ts
@@ -3,6 +3,7 @@
 import { render, type TemplateResult } from "lit";
 import { afterEach, describe, expect, it, onTestFinished, vi } from "vitest";
 import type { GatewayBrowserClient } from "../api/gateway.ts";
+import { visibleSettingsNavigationGroups } from "../app-navigation.ts";
 import "../components/app-sidebar.ts";
 import { waitForFast } from "../test-helpers/wait-for.ts";
 import type { ApplicationRuntime } from "./bootstrap.ts";
@@ -270,7 +271,20 @@ describe("application shell pairing access", () => {
       '.settings-sidebar__loading[role="status"][aria-busy="true"]',
     );
     expect(loadingSkeleton?.getAttribute("aria-label")).toBe("Loading…");
-    expect(loadingSkeleton?.querySelectorAll(".settings-sidebar__loading-row")).toHaveLength(7);
+    // Legacy operator auth (no scopes) resolves to admin access, so the skeleton
+    // must draw the full admin navigation.
+    const expectedItems = visibleSettingsNavigationGroups(true).reduce(
+      (count, group) => count + group.routes.length,
+      0,
+    );
+    expect(loadingSkeleton?.querySelectorAll(".settings-sidebar__loading-item")).toHaveLength(
+      expectedItems,
+    );
+    expect(
+      loadingSkeleton?.querySelectorAll(
+        ".settings-sidebar__loading-item .settings-sidebar__loading-icon",
+      ),
+    ).toHaveLength(expectedItems);
     expect(loadRenderer).toHaveBeenCalledOnce();
   });
 

--- a/ui/src/components/settings-sidebar-lazy.ts
+++ b/ui/src/components/settings-sidebar-lazy.ts
@@ -1,5 +1,5 @@
 import { html, nothing } from "lit";
-import { titleForRoute } from "../app-navigation.ts";
+import { titleForRoute, visibleSettingsNavigationGroups } from "../app-navigation.ts";
 import { t } from "../i18n/index.ts";
 import { icons } from "./icons.ts";
 
@@ -60,19 +60,42 @@ export function renderLazySettingsSidebar(
               ${t("common.retry")}
             </button>
           </div>`
-        : html`<div
-            class="settings-loading-skeleton settings-sidebar__loading"
-            role="status"
-            aria-busy="true"
-            aria-label=${t("common.loading")}
-          >
-            <div class="settings-sidebar__loading-rows" aria-hidden="true">
-              ${Array.from(
-                { length: 7 },
-                () => html`<span class="skeleton settings-sidebar__loading-row"></span>`,
-              )}
-            </div>
-          </div>`
+        : renderSettingsSidebarSkeleton(props)
     }
   </aside>`;
+}
+
+// Mirrors renderSettingsSidebar: search field, then the same navigation groups
+// (label + icon/label rows) the loaded sidebar will draw, so nothing shifts once
+// the module lands.
+function renderSettingsSidebarSkeleton(props: SettingsSidebarProps) {
+  const groups = visibleSettingsNavigationGroups(
+    Boolean(props.canAdmin),
+    props.nativeDeviceSettings ?? null,
+  );
+  return html`<div class="settings-sidebar__search" aria-hidden="true">
+      <span class="skeleton settings-sidebar__loading-search"></span>
+    </div>
+    <nav
+      class="settings-sidebar__nav settings-loading-skeleton settings-sidebar__loading"
+      role="status"
+      aria-busy="true"
+      aria-label=${t("common.loading")}
+    >
+      ${groups.map(
+        (group) => html`<div class="settings-sidebar__group" aria-hidden="true">
+          ${
+            group.labelKey
+              ? html`<span class="skeleton settings-sidebar__loading-group-label"></span>`
+              : nothing
+          }
+          ${group.routes.map(
+            () => html`<span class="settings-sidebar__item settings-sidebar__loading-item">
+              <span class="skeleton settings-sidebar__loading-icon"></span>
+              <span class="skeleton settings-sidebar__loading-label"></span>
+            </span>`,
+          )}
+        </div>`,
+      )}
+    </nav>`;
 }

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -546,27 +546,45 @@ html:is(.openclaw-native-macos, .openclaw-native-nav, .openclaw-native-web-chrom
   line-height: 1.45;
 }
 
-.settings-sidebar__loading {
-  padding: 10px 12px;
-}
-
-.settings-sidebar__loading-rows {
-  display: grid;
-  gap: 12px;
-}
-
-.settings-sidebar__loading-row {
+/* Loading skeleton reuses __nav/__group/__item geometry; only the fills are placeholders. */
+.settings-sidebar__loading-search {
   display: block;
-  width: 82%;
+  width: 100%;
+  height: 34px;
+}
+
+.settings-sidebar__loading-group-label {
+  display: block;
+  width: 64px;
+  height: 9px;
+  margin: 2px 9px 8px;
+  border-radius: var(--radius-sm);
+}
+
+.settings-sidebar__loading-item {
+  pointer-events: none;
+}
+
+.settings-sidebar__loading-icon {
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+  border-radius: 4px;
+}
+
+.settings-sidebar__loading-label {
+  display: block;
+  width: 58%;
   height: 12px;
+  border-radius: var(--radius-sm);
 }
 
-.settings-sidebar__loading-row:nth-child(3n + 2) {
+.settings-sidebar__loading-item:nth-child(3n) .settings-sidebar__loading-label {
+  width: 46%;
+}
+
+.settings-sidebar__loading-item:nth-child(3n + 2) .settings-sidebar__loading-label {
   width: 68%;
-}
-
-.settings-sidebar__loading-row:nth-child(3n) {
-  width: 74%;
 }
 
 .settings-sidebar__group {


### PR DESCRIPTION
Closes #145414

## What Problem This Solves

Fixes an issue where users entering Settings would see, in the navigation column, seven plain 12px bars with alternating widths while the sidebar module loads, then the whole column reflowed into a search field and grouped icon + label rows once it landed.

## Why This Change Was Made

The lazy sidebar fallback now draws the same structure `renderSettingsSidebar` renders: the search field, then every group from `visibleSettingsNavigationGroups` with a heading placeholder and one icon + label row per route, inside the real `settings-sidebar__nav` / `__group` / `__item` geometry. Row count and grouping come from the navigation registry with the same `canAdmin` and native-device inputs the loaded sidebar uses, so the skeleton cannot drift from the navigation. The mobile embed-list presentation keeps its text loading state.

## User Impact

The Settings navigation loading state has the shape of the navigation it becomes. The placeholder follows the visible navigation groups while the module loads.

## Evidence

### Before and after

Actual Control UI in Chromium against the mock Gateway, with the `settings-sidebar.ts` module request held. Dark theme, sidebar column cropped. Every image was inspected.

<table>
<tr><th>Before (skeleton)</th><th>After (skeleton)</th><th>After (loaded, same run)</th></tr>
<tr>
<td><a href="https://github.com/user-attachments/assets/5616cdb0-922c-4151-9b5f-5892ba57eef5"><img src="https://github.com/user-attachments/assets/5616cdb0-922c-4151-9b5f-5892ba57eef5" alt="Before (skeleton)" width="295"></a></td>
<td><a href="https://github.com/user-attachments/assets/439686a3-46a6-446f-a641-9825b602ed34"><img src="https://github.com/user-attachments/assets/439686a3-46a6-446f-a641-9825b602ed34" alt="After (skeleton)" width="295"></a></td>
<td><a href="https://github.com/user-attachments/assets/63356e78-ff4e-4305-938c-be2f7d869700"><img src="https://github.com/user-attachments/assets/63356e78-ff4e-4305-938c-be2f7d869700" alt="After (loaded, same run)" width="295"></a></td>
</tr>
</table>

### Validation

- `node scripts/check-changed.mjs -- ui/src/components/settings-sidebar-lazy.ts ui/src/styles/layout.css ui/src/app/app-host-pairing-access.test.ts` on the Testbox: coercion guard, dead-export scan, core lint and UI style lint passed.
- `node scripts/run-vitest.mjs ui/src/app/app-host-pairing-access.test.ts`: 16 passed. The loading-state case now asserts one icon + label row per navigation route (from the registry) instead of a hard-coded seven bars.
- Production diff: +66/−25. Test diff: +15/−1.



## Risk and coverage

The changed surface is the full-page Settings loading placeholder. The application shell supplies explicit access and native-device capability values to the shared navigation registry. Source review covered the loaded sidebar handoff, administrator and non-administrator route selection, native `embed-list` and `embed-page` loading paths, failed-load retry, and exit navigation. The existing shell test covers the administrator loading state and accessible loading announcement.

The three Chromium captures demonstrate the desktop dark-theme presentation. They do not establish pixel-perfect alignment for every text scale, translation, or native device. Native-device and non-administrator paths were checked in source; new device-specific browser captures were not run for this landing.
