### PR TITLE
refactor: simplify progress and picker rendering ownership

### DIFF
--- a/extensions/slack/src/progress-blocks.test.ts
+++ b/extensions/slack/src/progress-blocks.test.ts
@@ -949,19 +949,6 @@ describe("native Slack progress stream chunks", () => {
     ).toBeUndefined();
   });
 
-  it("updates native Slack progress without creating duplicate plan blocks", () => {
-    expect(
-      buildSlackProgressStreamChunks({
-        title: "Shelling",
-        lines: [itemLine("tool one", "Tool one"), itemLine("tool two", "Tool two")],
-      }),
-    ).toEqual([
-      planUpdate("Shelling"),
-      taskUpdate(contentTaskId("item"), "tool one", "in_progress"),
-      taskUpdate(contentTaskId("item"), "tool two", "in_progress"),
-    ]);
-  });
-
   it("marks unfinished native Slack progress tasks complete for finalization", () => {
     expect(
       buildSlackProgressStreamChunks({

--- a/extensions/slack/src/progress-blocks.ts
+++ b/extensions/slack/src/progress-blocks.ts
@@ -213,32 +213,20 @@ function buildNativeTasks(params: {
   return tasks;
 }
 
-function buildProgressAttentionTasks(
-  lines: readonly ChannelProgressDraftLine[],
+function formatProgressAttentionTitle(
+  line: ChannelProgressDraftLine,
   finalStatus: "complete" | "error" | undefined,
-): SlackPlanTask[] {
-  const contentIdOccurrences = new Map<string, number>();
-  // Attention follows the compositor window; Block Kit limits apply after projection.
-  return lines.flatMap((line) => {
-    const approval = line.kind === "approval";
-    if (
-      approval
-        ? line.status !== "requested" || finalStatus !== undefined
-        : lineTaskStatus(line) !== "error"
-    ) {
-      return [];
-    }
-    const title = approval
-      ? `Approval required: ${line.detail || line.label}`
-      : [...new Set([line.label, line.detail, line.status].filter(Boolean))].join(" — ");
-    const recovered = !approval && finalStatus === "complete";
-    const task: SlackPlanTask = {
-      id: `${SLACK_ATTENTION_TASK_PREFIX}${resolveLineTaskIdentity(line, contentIdOccurrences)}`,
-      title: compactTitle(recovered ? `Recovered: ${title}` : title),
-      status: approval ? "pending" : (finalStatus ?? "error"),
-    };
-    return [task];
-  });
+): string | undefined {
+  if (line.kind === "approval") {
+    return line.status === "requested" && finalStatus === undefined
+      ? compactTitle(`Approval required: ${line.detail || line.label}`)
+      : undefined;
+  }
+  if (lineTaskStatus(line) !== "error") {
+    return undefined;
+  }
+  const title = [...new Set([line.label, line.detail, line.status].filter(Boolean))].join(" — ");
+  return compactTitle(finalStatus === "complete" ? `Recovered: ${title}` : title);
 }
 
 function formatTaskDiffOutput(diffStat: SlackProgressDiffStat | undefined): string | undefined {
@@ -266,7 +254,18 @@ export function buildSlackProgressStreamChunks(params: {
     plan: params.plan,
     maxLineChars: params.maxLineChars,
   });
-  const attention = buildProgressAttentionTasks(approvals, params.finalInProgressStatus);
+  const contentIdOccurrences = new Map<string, number>();
+  const attention: SlackPlanTask[] = [];
+  for (const line of approvals) {
+    const title = formatProgressAttentionTitle(line, params.finalInProgressStatus);
+    if (title !== undefined) {
+      attention.push({
+        id: `${SLACK_ATTENTION_TASK_PREFIX}${resolveLineTaskIdentity(line, contentIdOccurrences)}`,
+        title,
+        status: "pending",
+      });
+    }
+  }
   const headline = params.title?.trim() || params.label?.trim();
   const newest = tasks.at(-1);
   const title = compactChunkText(
@@ -383,9 +382,10 @@ export function buildSlackProgressCardBlocks(params: {
   const icon = params.state === "working" ? "🔄" : params.state === "success" ? "✅" : "❌";
   const finalStatus =
     params.state === "working" ? undefined : params.state === "success" ? "complete" : "error";
-  const attention = buildProgressAttentionTasks(params.lines, finalStatus).map((task) =>
-    escapeSlackMrkdwn(task.title),
-  );
+  const attention = params.lines.flatMap((line) => {
+    const title = formatProgressAttentionTitle(line, finalStatus);
+    return title === undefined ? [] : [escapeSlackMrkdwn(title)];
+  });
   const sections = [
     `${icon} *${renderProgressCardText(params.title.trim() || "Working", "bold")}*`,
     narration ? `_${renderProgressCardText(narration, "italic")}_` : "",

--- a/src/channels/progress-draft-compositor.ts
+++ b/src/channels/progress-draft-compositor.ts
@@ -189,7 +189,6 @@ export function createChannelProgressDraftCompositor(params: {
     const linesRenderedByChannel =
       params.rendersRollingLinesNatively === true && Boolean(narration || planSteps?.length);
     return formatChannelProgressDraftTextForStreaming({
-      toolProgress: !quietProgress,
       presentation: params.presentation,
       entry: params.entry,
       lines: linesRenderedByChannel ? [] : draftLines,
@@ -416,7 +415,6 @@ export function createChannelProgressDraftCompositor(params: {
     const shouldStartImmediately = shouldStoreLine && isChannelProgressAttentionLine(progressLine);
     const nextLines = shouldStoreLine
       ? mergeChannelProgressDraftLineForStreaming(lines, progressLine, {
-          toolProgress: !quietProgress,
           maxLines: resolveChannelProgressDraftMaxLines(params.entry),
         })
       : lines;
@@ -703,7 +701,6 @@ export function createChannelProgressDraftCompositor(params: {
           },
           {
             maxLines: resolveChannelProgressDraftMaxLines(params.entry),
-            toolProgress: !quietProgress,
           },
         );
       } else if (priorIndex >= 0) {
@@ -711,7 +708,6 @@ export function createChannelProgressDraftCompositor(params: {
         lines[priorIndex] = displayLine;
       } else {
         lines = mergeChannelProgressDraftLineForStreaming(lines, displayLine, {
-          toolProgress: !quietProgress,
           maxLines: resolveChannelProgressDraftMaxLines(params.entry),
         });
       }
@@ -756,7 +752,6 @@ export function createChannelProgressDraftCompositor(params: {
         prefix: false,
       };
       lines = mergeChannelProgressDraftLineForStreaming(lines, line, {
-        toolProgress: !quietProgress,
         maxLines: resolveChannelProgressDraftMaxLines(params.entry),
       });
       if (!itemId) {

--- a/src/channels/streaming.ts
+++ b/src/channels/streaming.ts
@@ -1234,13 +1234,8 @@ export function mergeChannelProgressDraftLine<TLine extends string | ChannelProg
 
 export function mergeChannelProgressDraftLineForStreaming<
   TLine extends string | ChannelProgressDraftLine,
->(lines: TLine[], line: TLine, params: { maxLines: number; toolProgress: boolean }): TLine[] {
-  return mergeProgressDraftLine(
-    lines,
-    line,
-    params.maxLines,
-    params.toolProgress ? isChannelProgressPriorityLine : isChannelProgressAttentionLine,
-  );
+>(lines: TLine[], line: TLine, params: { maxLines: number }): TLine[] {
+  return mergeProgressDraftLine(lines, line, params.maxLines, isChannelProgressPriorityLine);
 }
 
 function mergeProgressDraftLine<TLine extends string | ChannelProgressDraftLine>(
@@ -1381,7 +1376,7 @@ type ChannelProgressDraftTextParams = {
   formatLine?: (line: string) => string;
   /** Prefix used for plain progress lines that lack their own icon. */
   bullet?: string;
-  /** Short narration paragraph; when present it replaces the tool lines. */
+  /** Status headline rendered above the plan and activity rows. */
   narration?: string;
   /** Latest full plan snapshot, rendered independently from rolling tool lines. */
   plan?: readonly AgentPlanStep[];
@@ -1393,14 +1388,9 @@ export function formatChannelProgressDraftText(params: ChannelProgressDraftTextP
 }
 
 export function formatChannelProgressDraftTextForStreaming(
-  params: ChannelProgressDraftTextParams & { toolProgress: boolean },
+  params: ChannelProgressDraftTextParams,
 ): string {
-  return formatProgressDraftText(
-    params,
-    params.toolProgress && params.presentation !== "summary"
-      ? isChannelProgressPriorityLine
-      : isChannelProgressAttentionLine,
-  );
+  return formatProgressDraftText(params, isChannelProgressPriorityLine);
 }
 
 function formatProgressDraftText(

--- a/ui/src/e2e/new-session-page.places-live.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.places-live.e2e.test.ts
@@ -35,44 +35,80 @@ suite.define(() => {
     }
   });
 
-  it("shows advertised cloud machines when hovering a profile", async () => {
-    const context = await suite.browser.newContext({ locale: "en-US", serviceWorkers: "block" });
-    const page = await context.newPage();
-    const gateway = await installMockGateway(page, {
-      workspace: WORKSPACE,
-      workspaceGit: true,
-      methodResponses: {
-        "environments.list": {
-          environments: [],
-          profiles: [
-            {
-              id: "aws",
-              providerId: "crabbox",
-              executionMode: "worker-turn",
-              executionModes: ["worker-turn"],
-              machines: [
-                { id: "standard", label: "Standard", default: true },
-                { id: "fast", label: "Fast" },
-              ],
-            },
-          ],
+  it.each(["hover", "click"] as const)(
+    "keeps cloud machines usable when the picker finishes opening after a profile %s",
+    async (input) => {
+      const context = await suite.browser.newContext({ locale: "en-US", serviceWorkers: "block" });
+      const page = await context.newPage();
+      const gateway = await installMockGateway(page, {
+        workspace: WORKSPACE,
+        workspaceGit: true,
+        methodResponses: {
+          "environments.list": {
+            environments: [],
+            profiles: [
+              {
+                id: "aws",
+                providerId: "crabbox",
+                executionMode: "worker-turn",
+                executionModes: ["worker-turn"],
+                machines: [
+                  { id: "standard", label: "Standard", default: true },
+                  { id: "fast", label: "Fast" },
+                ],
+              },
+            ],
+          },
+          "worktrees.branches": { branches: [], repositoryStatus: "git" },
         },
-        "worktrees.branches": { branches: [], repositoryStatus: "git" },
-      },
-    });
-    try {
-      await page.goto(`${suite.server.baseUrl}new`);
-      await gateway.waitForRequest("environments.list");
-      const where = page.locator("#new-session-where-trigger");
-      await where.click();
-      const picker = page.locator("wa-popover.new-session-page__where-popover");
-      const profile = picker.locator('[data-value="cloud:aws"]');
-      await profile.hover();
-      await picker.locator('[data-value="machine:fast"]').waitFor();
-    } finally {
-      await context.close();
-    }
-  });
+      });
+      try {
+        await page.goto(`${suite.server.baseUrl}new`);
+        await gateway.waitForRequest("environments.list");
+        const picker = page.locator("wa-popover.new-session-page__where-popover");
+        await picker.evaluate((element) =>
+          (element as HTMLElement).style.setProperty("--show-duration", "60s"),
+        );
+        const where = page.locator("#new-session-where-trigger");
+        await where.click();
+        const popup = picker.locator('wa-popup [part="popup"]').first();
+        await expect
+          .poll(() => popup.evaluate((element) => element.getAnimations().length))
+          .toBe(1);
+        // Hold the actual opening animation until the user has opened cloud configuration.
+        await popup.evaluate((element) => {
+          const animation = element.getAnimations()[0]!;
+          animation.pause();
+          animation.currentTime = Number(animation.effect!.getComputedTiming().duration) - 1;
+        });
+        await expect
+          .poll(() =>
+            picker.getByRole("searchbox").evaluate((element) => element.matches(":focus")),
+          )
+          .toBe(true);
+        const profile = picker.locator('[data-value="cloud:aws"]');
+        await profile[input]();
+        const fast = picker.locator('[data-value="machine:fast"]');
+        await fast.waitFor();
+        await popup.evaluate((element) =>
+          Promise.all(
+            element.getAnimations().map((animation) => {
+              animation.finish();
+              return animation.finished;
+            }),
+          ),
+        );
+        if (input === "click") {
+          expect(await profile.evaluate((element) => element.matches(":focus"))).toBe(true);
+        }
+        await fast.click();
+        await expect.poll(() => where.getAttribute("data-cloud-profile")).toBe("aws");
+        await expect.poll(() => where.getAttribute("data-machine-class")).toBe("fast");
+      } finally {
+        await context.close();
+      }
+    },
+  );
 
   it("keeps an explicitly selected cloud destination when its runtime becomes incompatible", async () => {
     const context = await suite.browser.newContext({ locale: "en-US", serviceWorkers: "block" });

--- a/ui/src/pages/new-session/where-chip.test.ts
+++ b/ui/src/pages/new-session/where-chip.test.ts
@@ -95,17 +95,6 @@ function renderPicker(
 }
 
 describe("Where chip", () => {
-  it("focuses environment search only after the enclosing picker opens", () => {
-    const container = renderPicker(true);
-    const popover = container.querySelector("wa-popover")!;
-    const search = container.querySelector<HTMLInputElement>('input[type="search"]')!;
-    const focus = vi.spyOn(search, "focus");
-    search.dispatchEvent(new CustomEvent("wa-after-show", { bubbles: true }));
-    expect(focus).not.toHaveBeenCalled();
-    popover.dispatchEvent(new CustomEvent("wa-after-show"));
-    expect(focus).toHaveBeenCalledOnce();
-  });
-
   it.each([
     { label: "Work MacBook Pro", platform: "darwin", icon: deviceIcons.laptop, form: "laptop" },
     {

--- a/ui/src/pages/new-session/where-chip.ts
+++ b/ui/src/pages/new-session/where-chip.ts
@@ -318,13 +318,6 @@ export function renderWhereChip(params: {
         }
         params.onPopoverShow();
       }}
-      @wa-after-show=${(event: Event) => {
-        if (event.target === event.currentTarget && event.currentTarget instanceof HTMLElement) {
-          event.currentTarget
-            .querySelector<HTMLInputElement>('input[type="search"]')
-            ?.focus({ preventScroll: true });
-        }
-      }}
       @wa-hide=${(event: Event) => {
         if (event.target === event.currentTarget) {
           params.onPopoverHide();


### PR DESCRIPTION
Related: #145345, #140037, #145183

## What Problem This Solves

Maintainer-requested cleanup after #145345. The compositor already filters quiet tool rows, but internal layout helpers still carried another `toolProgress` switch. Slack's Block Kit renderer constructed native task identities and status objects only to discard everything except their titles.

Validation also exposed a real picker focus race: WebAwesome initially focused search, the user opened cloud configuration, then OpenClaw focused search again after the outer animation and dismissed the cloud card.

## Why This Change Was Made

Keep visibility with the compositor and let internal streaming helpers arrange already-admitted rows. Preserve shipped SDK merge/format helpers and legacy behavior. Share Slack attention-title formatting while constructing stable approval task identities only for native streams; Block Kit renders titles directly. The native attention loop remains approval-only; tool failures keep their work-task and reconciliation path.

Remove the duplicate picker after-show focus handler. WebAwesome already owns the input's native `autofocus` before the opening animation. Retain that single focus owner so animation completion cannot overwrite a later user interaction.

Remove one duplicate native-chunk test left after separate start/update builders were unified. Replace the handler-only focus unit test with real browser coverage of initial search focus, retained clicked-profile focus, and machine selection across the actual opening animation. Hover coverage remains alongside the new click variant.

## User Impact

Quiet progress stays quiet. Approvals retain their identities and lifecycle, and explicitly enabled diagnostics retain failure/recovery text. Block Kit avoids unused native ID hashing and task-object construction.

Fast cloud selection keeps its configuration card open when the outer picker finishes animating. Search still receives initial focus through WebAwesome's native behavior.

No public SDK, configuration, schema, dependency, transport, baseline, ignore-list, or CI-limit change. The final seven-file diff removes 22 production lines and adds 12 net test lines.

## Evidence

- 159 progress baseline tests passed before editing; 441 focused tests passed after cleanup across public streaming helpers, compositor quiet/plan/visibility, Slack native and Block Kit renderers, full Slack dispatch, and Telegram rendering.
- Full changed-file checks passed for the progress cleanup, including production/test types, lint, import cycles, and repository guards. Independent P0–P2 review was clean.
- Personally inspected WebAwesome's installed `WaPopover.handleOpenChange`: native autofocus runs before the opening animation; `wa-after-show` follows it. A deterministic real-browser trace reproduces the competing owner: native search focus at 589.7 ms, cloud-profile focus at 627.5 ms, outer after-show at 646.1 ms, duplicate search focus at 646.4 ms, cloud tooltip hide at 648.4 ms.
- The regression controls the browser's actual opening Animation, rather than sleeping or fabricating a completion event. Original source fails the clicked-profile focus assertion; removal passes hover/click cases, all 12 focus/recovery browser scenarios, and 64 remaining picker unit cases. Targeted lint, formatting, and diff checks pass.
- Fresh independent P0–P2 review of the focus cutover is clean. No timeout, skip, expectation baseline, or policy gate was relaxed. No live-channel capture is claimed; UI proof uses real browser flows with a mocked Gateway.

### CI and rebase context

Earlier CI inherited main's UI budget, test-shard overflow, picker lint/dead exports, and stale browser assertions. Their owning fixes landed in #145316, #145431, and #145415. Overlapping support commits were dropped during rebase so this PR preserves current main's fixes and additional assertions. The cloud cleanup originally considered from @obviyus's #145448 is not duplicated in this final diff.

Completed [run 34664436330](https://github.com/openclaw/openclaw/actions/runs/34664436330) passed every job except the cloud-recovery browser shard and its aggregate gate. The deterministic focus fix above addresses that remaining failure. Rebase onto `47ce03dbc6994435af783fecf13d5586e7b307f4` preserves both remaining patches exactly (`git range-diff`), resolving overlap without reverting main's work. Final exact-head [CI run34666421507](https://github.com/openclaw/openclaw/actions/runs/34666421507) completed successfully on `dbabf8dcfc3ee27350a473552cc05fccae6134ea`, including the formerly failing cloud-recovery browser flow and the new focus regression. ClawSweeper also reviewed this exact head with no actionable findings.
