### PR TITLE
fix: stabilize native relay deadline test

### DIFF
--- a/src/agents/harness/native-hook-relay.lifecycle.test.ts
+++ b/src/agents/harness/native-hook-relay.lifecycle.test.ts
@@ -319,6 +319,7 @@ it("does not start transport when locator lookup consumes the caller deadline", 
       },
     );
     const startedAt = Date.now();
+    const clock = vi.spyOn(Date, "now").mockReturnValue(startedAt);
     const invocation = invokeNativeHookRelayBridge({
       provider: "codex",
       relayId: relay.relayId,
@@ -330,7 +331,7 @@ it("does not start transport when locator lookup consumes the caller deadline", 
     void invocation.catch(() => undefined);
     await entered.promise;
     const connect = vi.spyOn(Agent.prototype, "createConnection");
-    const clock = vi.spyOn(Date, "now").mockReturnValue(startedAt + 101);
+    clock.mockReturnValue(startedAt + 101);
     try {
       resume.resolve();
       await expect(invocation).rejects.toThrow("timed out");


### PR DESCRIPTION
## What Problem This Solves

Resolves intermittent CI failures in the native relay deadline test when runner scheduling separates the fixture and client clock reads.

## Why This Change Was Made

Freeze the existing mock clock before invoking the client, then advance that same clock after locator lookup is held. Both sides now measure the same 100ms budget; the timeout rejection and zero-connection assertions stay intact.

## User Impact

Test-only correction. Production deadline enforcement, native hook behavior and cleanup are unchanged.

## Evidence

- [The failing CI case](https://github.com/openclaw/openclaw/actions/runs/34656237618/job/103449791922) was reproduced on exact official baseline `92c01b7e86deee9d5430eb754983f40dd4eabbbd`, with the original test and client unchanged. The normal control passed; a task-only synchronous 20ms pause before real client entry reproduced the same successful-response-versus-rejection failure. The measured client budget was still 20ms. The original CI clock gap was not recorded.
- The corrected test passes the same scheduling probe, and both full native relay test files pass: **138 tests, no failures or skips**. This [remote run](https://github.com/openclaw/openclaw/actions/runs/34658512696) exercised the existing SQLite locator and loopback transport; it used synthetic state only.
- Formatting, conflict checks, line-count ratchet, assertion safety and targeted lint passed. Independent scoped review found no P0–P2 issues.
- Exact head: `4e389f3e3b9cbc26d1f75a6f20a8396b60851a5d`. The full changed-file gate passed, including the affected TypeScript graph. [Hosted CI](https://github.com/openclaw/openclaw/actions/runs/34659713995) passed all 26 executed jobs and all 14 lifecycle cases on the actual merge. [ClawSweeper](https://github.com/openclaw/openclaw/pull/145421#issuecomment-5641981862) completed its exact-head review at Platinum with no findings.
