### PR TITLE
refactor(gateway): remove agent handler test dependency bag

### DIFF
--- a/src/gateway/server-methods/agents-mutate.test.ts
+++ b/src/gateway/server-methods/agents-mutate.test.ts
@@ -7,7 +7,7 @@ import { expectDefined } from "@openclaw/normalization-core";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { AgentDeletionAuthorityRollbackError } from "../../agents/agent-lifecycle-registry.js";
 import { WORKSPACE_BOOTSTRAP_FILENAMES } from "../../agents/workspace.js";
-import { FsSafeError } from "../../infra/fs-safe.js";
+import { FsSafeError, root } from "../../infra/fs-safe.js";
 /* ------------------------------------------------------------------ */
 /* Mocks                                                              */
 /* ------------------------------------------------------------------ */
@@ -384,14 +384,14 @@ vi.mock("node:fs/promises", async () => {
 /* Import after mocks are set up                                      */
 /* ------------------------------------------------------------------ */
 
-const { testing: agentsTesting, agentsHandlers } = await import("./agents.js");
+const { agentsHandlers } = await import("./agents.js");
 
 /* ------------------------------------------------------------------ */
 /* Helpers                                                            */
 /* ------------------------------------------------------------------ */
 
 beforeEach(() => {
-  agentsTesting.resetDepsForTests();
+  vi.mocked(root).mockReset();
   mocks.omitConfigMutationResult = false;
   mocks.sharedAuthStoreOwnership = { location: "legacy-main" };
   mocks.migrateLegacyMainSessionKeys.mockReset().mockResolvedValue({
@@ -675,19 +675,6 @@ function mockWorkspaceStateRead(params: {
   errorCode?: string;
   rawContent?: string;
 }) {
-  agentsTesting.setDepsForTests({
-    isWorkspaceSetupCompleted: async () => {
-      if (params.errorCode) {
-        throw createErrnoError(params.errorCode);
-      }
-      if (typeof params.rawContent === "string") {
-        throw new SyntaxError("Expected property name or '}' in JSON");
-      }
-      return (
-        typeof params.setupCompletedAt === "string" && params.setupCompletedAt.trim().length > 0
-      );
-    },
-  });
   mocks.isWorkspaceSetupCompleted.mockImplementation(async () => {
     if (params.errorCode) {
       throw createErrnoError(params.errorCode);
@@ -1148,8 +1135,8 @@ describe("agents.update", () => {
       dir: "/resolved/new/workspace",
       identityPathCreated: true,
     });
-    agentsTesting.setDepsForTests({
-      root: makeRootForTest({
+    vi.mocked(root).mockImplementation(
+      makeRootForTest({
         read: async ({ rootDir, relativePath }) => {
           const filePath = `${String(rootDir)}/${String(relativePath)}`;
           if (filePath === "/workspace/test-agent/IDENTITY.md") {
@@ -1195,7 +1182,7 @@ describe("agents.update", () => {
           throw createEnoentError();
         },
       }),
-    });
+    );
 
     const { respond, promise } = makeCall("agents.update", {
       agentId: "test-agent",
@@ -1218,8 +1205,8 @@ describe("agents.update", () => {
       dir: "/resolved/new/workspace",
       identityPathCreated: false,
     });
-    agentsTesting.setDepsForTests({
-      root: makeRootForTest({
+    vi.mocked(root).mockImplementation(
+      makeRootForTest({
         read: async ({ rootDir, relativePath }) => {
           const filePath = `${String(rootDir)}/${String(relativePath)}`;
           if (filePath === "/workspace/test-agent/IDENTITY.md") {
@@ -1263,7 +1250,7 @@ describe("agents.update", () => {
           throw createEnoentError();
         },
       }),
-    });
+    );
 
     const { respond, promise } = makeCall("agents.update", {
       agentId: "test-agent",
@@ -1298,13 +1285,13 @@ describe("agents.update", () => {
   });
 
   it("treats unsafe IDENTITY.md reads as invalid update requests", async () => {
-    agentsTesting.setDepsForTests({
-      root: makeRootForTest({
+    vi.mocked(root).mockImplementation(
+      makeRootForTest({
         read: async () => {
           throw new FsSafeError("invalid-path", "path is not a regular file under root");
         },
       }),
-    });
+    );
 
     const { respond, promise } = makeCall("agents.update", {
       agentId: "test-agent",
@@ -1321,7 +1308,7 @@ describe("agents.update", () => {
     const rootRead = vi.fn(async () => {
       throw new FsSafeError("not-found", "file not found");
     });
-    agentsTesting.setDepsForTests({ root: makeRootForTest({ read: rootRead }) });
+    vi.mocked(root).mockImplementation(makeRootForTest({ read: rootRead }));
 
     const { promise } = makeCall("agents.update", {
       agentId: "test-agent",
@@ -2299,14 +2286,12 @@ describe("agents.delete", () => {
     mocks.resolveRegisteredAgentIdForDir.mockImplementation((pathname?: string) =>
       pathname === journal.agentDir ? "test-agent" : undefined,
     );
-    agentsTesting.setDepsForTests({
-      root: (async (rootDir: string) => ({
-        rootReal: rootDir.startsWith(canonicalRoot)
-          ? rootDir.replace(canonicalRoot, unrelatedRoot)
-          : rootDir,
-        stat: async (relativePath: string) => await mocks.rootStat({ rootDir, relativePath }),
-      })) as never,
-    });
+    vi.mocked(root).mockImplementation((async (rootDir: string) => ({
+      rootReal: rootDir.startsWith(canonicalRoot)
+        ? rootDir.replace(canonicalRoot, unrelatedRoot)
+        : rootDir,
+      stat: async (relativePath: string) => await mocks.rootStat({ rootDir, relativePath }),
+    })) as never);
 
     const { respond, promise } = makeCall("agents.delete", { agentId: "test-agent" });
     await promise;
@@ -3274,7 +3259,7 @@ describe("agents.files.list", () => {
     const rootStat = vi.fn(async () => {
       throw createEnoentError();
     });
-    agentsTesting.setDepsForTests({ root: makeRootForTest({ stat: rootStat }) });
+    vi.mocked(root).mockImplementation(makeRootForTest({ stat: rootStat }));
 
     const { respond, promise } = makeCall("agents.files.list", { agentId: "main" });
     await promise;
@@ -3297,7 +3282,7 @@ describe("agents.files.list", () => {
       }
       throw createEnoentError();
     });
-    agentsTesting.setDepsForTests({ root: makeRootForTest({ stat: rootStat }) });
+    vi.mocked(root).mockImplementation(makeRootForTest({ stat: rootStat }));
 
     const { respond, promise } = makeCall("agents.files.list", { agentId: "main" });
     await promise;
@@ -3314,13 +3299,13 @@ describe("agents.files.list", () => {
   // Clients merge the get response over the listed entry, so dropping the flag here
   // made a picked optional file re-render as a fault in the Control UI.
   it("carries expectedAbsent through agents.files.get for a missing file", async () => {
-    agentsTesting.setDepsForTests({
-      root: makeRootForTest({
+    vi.mocked(root).mockImplementation(
+      makeRootForTest({
         read: async () => {
           throw new FsSafeError("not-found", "no such file");
         },
       }),
-    });
+    );
 
     const { respond, promise } = makeCall("agents.files.get", {
       agentId: "main",
@@ -3352,7 +3337,7 @@ describe("agents.files.list", () => {
       }
       throw createEnoentError();
     });
-    agentsTesting.setDepsForTests({ root: makeRootForTest({ open: rootOpen, stat: rootStat }) });
+    vi.mocked(root).mockImplementation(makeRootForTest({ open: rootOpen, stat: rootStat }));
 
     const { respond, promise } = makeCall("agents.files.list", { agentId: "main" });
     await promise;
@@ -3373,7 +3358,7 @@ describe("agents.files.list", () => {
     const rootStat = vi.fn(async () => {
       throw createErrnoError("helper-unavailable");
     });
-    agentsTesting.setDepsForTests({ root: makeRootForTest({ stat: rootStat }) });
+    vi.mocked(root).mockImplementation(makeRootForTest({ stat: rootStat }));
     mocks.fsLstat.mockImplementation(async (filePath: unknown) => {
       if (filePath === "/workspace/main/AGENTS.md") {
         return makeFileStat({ size: 23, mtimeMs: 6789 });
@@ -3410,8 +3395,8 @@ describe("agents.files.get/set symlink safety", () => {
 
   function mockWorkspaceEscapeSymlink() {
     const safeOpenError = new FsSafeError("invalid-path", "path escapes workspace root");
-    agentsTesting.setDepsForTests({
-      root: makeRootForTest({
+    vi.mocked(root).mockImplementation(
+      makeRootForTest({
         open: async () => {
           throw safeOpenError;
         },
@@ -3419,14 +3404,14 @@ describe("agents.files.get/set symlink safety", () => {
           throw safeOpenError;
         },
       }),
-    });
+    );
     mocks.rootWrite.mockRejectedValue(safeOpenError);
   }
 
   function mockInWorkspaceSymlinkAlias() {
     const safeOpenError = new FsSafeError("invalid-path", "path is not a regular file under root");
-    agentsTesting.setDepsForTests({
-      root: makeRootForTest({
+    vi.mocked(root).mockImplementation(
+      makeRootForTest({
         open: async () => {
           throw safeOpenError;
         },
@@ -3434,7 +3419,7 @@ describe("agents.files.get/set symlink safety", () => {
           throw safeOpenError;
         },
       }),
-    });
+    );
     mocks.rootWrite.mockRejectedValue(safeOpenError);
   }
 
@@ -3462,8 +3447,8 @@ describe("agents.files.get/set symlink safety", () => {
 
   function mockHardlinkedWorkspaceAlias() {
     const safeOpenError = new FsSafeError("invalid-path", "hardlinked path not allowed");
-    agentsTesting.setDepsForTests({
-      root: makeRootForTest({
+    vi.mocked(root).mockImplementation(
+      makeRootForTest({
         open: async () => {
           throw safeOpenError;
         },
@@ -3471,7 +3456,7 @@ describe("agents.files.get/set symlink safety", () => {
           throw safeOpenError;
         },
       }),
-    });
+    );
     mocks.rootWrite.mockRejectedValue(safeOpenError);
   }
 
@@ -3495,7 +3480,7 @@ describe("agents.files.get/set symlink safety", () => {
       realPath: "/workspace/test-agent/AGENTS.md",
       stat: makeFileStat({ size: 5 }),
     }));
-    agentsTesting.setDepsForTests({ root: makeRootForTest({ read: rootRead }) });
+    vi.mocked(root).mockImplementation(makeRootForTest({ read: rootRead }));
 
     const { respond, promise } = makeCall("agents.files.get", {
       agentId: "main",

--- a/src/gateway/server-methods/agents.ts
+++ b/src/gateway/server-methods/agents.ts
@@ -130,31 +130,6 @@ const CORE_FILE_NAMES_POST_ONBOARDING = CORE_FILE_NAMES.filter(
   (name) => name !== DEFAULT_BOOTSTRAP_FILENAME,
 );
 
-const agentsHandlerDeps = {
-  root,
-  isWorkspaceSetupCompleted,
-};
-
-export const testing = {
-  setDepsForTests(
-    overrides: Partial<{
-      root: typeof root;
-      isWorkspaceSetupCompleted: typeof isWorkspaceSetupCompleted;
-    }>,
-  ) {
-    if (overrides.isWorkspaceSetupCompleted) {
-      agentsHandlerDeps.isWorkspaceSetupCompleted = overrides.isWorkspaceSetupCompleted;
-    }
-    if (overrides.root) {
-      agentsHandlerDeps.root = overrides.root;
-    }
-  },
-  resetDepsForTests() {
-    agentsHandlerDeps.root = root;
-    agentsHandlerDeps.isWorkspaceSetupCompleted = isWorkspaceSetupCompleted;
-  },
-};
-
 // Writes stay capped to canonical workspace files, and deliberately remain wider
 // than the listed core files: IDENTITY.md is not offered as an editor tab but is
 // still writable for clients that manage it directly.
@@ -251,7 +226,7 @@ async function statWorkspaceFileSafely(
 
 async function openWorkspaceRootSafely(workspaceDir: string): Promise<WorkspaceRoot | null> {
   try {
-    return await agentsHandlerDeps.root(workspaceDir);
+    return await root(workspaceDir);
   } catch {
     return null;
   }
@@ -363,7 +338,7 @@ function cleanupPathIdentity(stat: { dev?: number | bigint; ino?: number | bigin
 
 async function statAgentCleanupPath(cleanupPath: AgentDeleteCleanupPath) {
   const parentPath = cleanupPath.parentPath;
-  const parentRoot = await agentsHandlerDeps.root(parentPath, {
+  const parentRoot = await root(parentPath, {
     hardlinks: "reject",
     symlinks: "reject",
   });
@@ -728,7 +703,7 @@ async function writeWorkspaceFileOrRespond(params: {
 }): Promise<boolean> {
   await fs.mkdir(params.workspaceDir, { recursive: true });
   try {
-    const workspaceRoot = await agentsHandlerDeps.root(params.workspaceDir);
+    const workspaceRoot = await root(params.workspaceDir);
     await workspaceRoot.write(params.name, params.content, { encoding: "utf8" });
   } catch (err) {
     if (err instanceof FsSafeError) {
@@ -785,7 +760,7 @@ async function readWorkspaceFileContent(
   name: string,
 ): Promise<string | undefined> {
   try {
-    const workspaceRoot = await agentsHandlerDeps.root(workspaceDir);
+    const workspaceRoot = await root(workspaceDir);
     const safeRead = await workspaceRoot.read(name, {
       hardlinks: "reject",
       nonBlockingRead: true,
@@ -1532,7 +1507,7 @@ export const agentsHandlers: GatewayRequestHandlers = {
     const workspaceDir = resolveAgentWorkspaceDir(cfg, agentId);
     let hideBootstrap = false;
     try {
-      hideBootstrap = await agentsHandlerDeps.isWorkspaceSetupCompleted(workspaceDir);
+      hideBootstrap = await isWorkspaceSetupCompleted(workspaceDir);
     } catch {
       // Fall back to showing BOOTSTRAP if workspace state cannot be read.
     }
@@ -1555,7 +1530,7 @@ export const agentsHandlers: GatewayRequestHandlers = {
     const filePath = path.join(workspaceDir, name);
     let safeRead: ReadResult;
     try {
-      const workspaceRoot = await agentsHandlerDeps.root(workspaceDir);
+      const workspaceRoot = await root(workspaceDir);
       safeRead = await workspaceRoot.read(name, {
         hardlinks: "reject",
         nonBlockingRead: true,
@@ -1608,7 +1583,7 @@ export const agentsHandlers: GatewayRequestHandlers = {
     let workspaceRoot: WorkspaceRoot;
     let conflict: { currentHash: string | undefined } | undefined;
     try {
-      workspaceRoot = await agentsHandlerDeps.root(workspaceDir);
+      workspaceRoot = await root(workspaceDir);
       const writeRoot = workspaceRoot;
       const expectedHash = params.expectedHash?.toLowerCase();
       conflict = await enqueueWorkspaceFileUpdate(async () => {


### PR DESCRIPTION
## What Problem This Solves

Gateway agent handlers carry a mutable dependency bag and exported setters used only by tests, even though those tests already have partial module mocks for the same dependencies. This maintainer-requested cleanup removes that extra test-only runtime surface.

## Why This Change Was Made

Call the existing imported `root` and `isWorkspaceSetupCompleted` functions directly, and configure the existing module mocks in the tests. Arguments, awaits, error handling and cleanup/retirement ordering remain unchanged. The upstream asynchronous workspace cleanup and deletion-retirement regression are preserved.

Production: **+7/-32, net -25**. Tests: **+36/-51, net -15**. Exactly two files change; no new dependency or compatibility layer is introduced.

## User Impact

No intended user-visible behavior change. Agent creation, workspace files, bootstrap checks and deletion retain their existing contracts. This does not change RPC/configuration surfaces, database schemas, migrations, authentication policy or provider selection.

## Evidence

Current evidence is bound to candidate `3fb23e8456a42a72058aa8ed94d36dbcf0049c73`, raw parent `7f5a5231dca1bdde6f4f33614a9d5a16ab177055`. The failure-driven refresh preserves the two reviewed cleanup afterimages while incorporating the canonical startup split in #145430 and test-root rebalance in #145431. It does not claim runtime coverage of every later main change.

- **Current units:** the normal four-suite runner passed **141 cases** on clean `3fb`: 7 agent-file cases, 105 mutation cases, 7 catalog-scope cases and 22 session-read cases, using Node 26.8.2 and TypeBox 1.3.26. The earlier original → test-only → candidate comparison passed 141 cases in each role at parent `8ac24c73`; it remains historical evidence, not a new original-production unit run at `7f`.
- **Fresh real Gateway pair:** the unchanged two-case fixture passed separately with original `7f` production plus the migrated test retained, then exact candidate `3fb`, on separate configured Linux Testboxes. Both used Node 24.19.0/pnpm 12.3.4 and TypeBox 1.3.26. It exercised database delete/recreate/registration and external-state workspace deletion through a real Gateway and client. [Original lifecycle run](https://github.com/openclaw/openclaw/actions/runs/34686829119) · [Candidate lifecycle run](https://github.com/openclaw/openclaw/actions/runs/34688116048). Native results were exit 0; role maps differ only at the production handler, runtime/dependency measurements match, and both leases completed. These links identify lifecycle runs, not substitutes for the retained native reports.
- **Current normal changed gate:** all **29 checks** passed, including core production types, serial core-test graphs, scoped lint and all three unused-export scans. [Gate lifecycle run](https://github.com/openclaw/openclaw/actions/runs/34690844849). The native wrapper returned 0 and stopped its one-shot lease. The normal gate used its existing `origin/main` snapshot; no base, resource or provider override was added. Two warning-only upstream temporary-directory notices were retained without edits.
- **Fresh independent reviews:** separate branch and raw-parent exact-commit Codex reviews each completed **eight validated passes through P2 with no findings**, retaining all **215 complete source/dependency/evidence inputs**, including the lockfile, actual bundled Vitest implementation and TypeBox contracts. Source, index and all supplied dependency/proof inputs remained unchanged.

The earlier [CI run on `a234`](https://github.com/openclaw/openclaw/actions/runs/34659911500) failed its startup-size check at **354,519 bytes against 354,270**, plus the aggregate failure. Its tested merge differed from its main parent only in the two Agents files, but that alone does not establish a source-derived performance cause. The original failure is retained; no budget was raised and no blind CI retry was used. **[Exact-head PR CI for `3fb`](https://github.com/openclaw/openclaw/actions/runs/34694490188) passed on attempt 1:** 114 successful jobs and 17 skipped, including the performance check. The completed exact-head ClawSweeper review has no findings or before-merge moves. Native artifact validation passed; mandatory hosted preparation and normal merge checks remain pending. This does not claim merge completion.

The Gateway fixture uses its existing minimal Gateway with default `sidecarStartup: "start"`, not deferred startup, and retains its health/provider/config test seams. It does not establish live provider authentication, Trash destination-content bytes, raw client-close-event behavior, exhaustive process/temporary-namespace cleanup, or an existing-user schema upgrade. Observed workers/listeners were gone at completion; sampling counts and timings differ between roles, with no broader security or performance claim.

Earlier tooling refusals remain recorded. The old review helper's large-input refusal was preserved and the supported project workflow retained every semantic input. One candidate preflight produced a valid remote tuple and native exit 0 but its local observer returned 1 after an unclassified subprocess status; no product test ran on that lease. It was stopped normally. A separately reviewed metadata-only observer correction preceded a fresh lease and the first candidate product run; it did not alter the fixture, assertions, provider or timeout. The install likewise retained native success alongside an initial observer rejection of legitimate own-root workspace symlinks, resolved by additive read-only containment verification without replaying install. Portal-sync warnings and all original failures remain distinct from successful native command exits. No accepted product or review dispatch was replayed.
