### PR TITLE
perf(ai): collect root schema definitions once

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -1427,7 +1427,7 @@ packages/ai/src/providers/anthropic-tool-projection.ts	2
 packages/ai/src/providers/anthropic-usage.ts	3
 packages/ai/src/providers/anthropic.ts	6
 packages/ai/src/providers/azure-openai-responses.ts	1
-packages/ai/src/providers/clean-for-gemini.ts	15
+packages/ai/src/providers/clean-for-gemini.ts	12
 packages/ai/src/providers/google-shared.ts	3
 packages/ai/src/providers/mistral.ts	6
 packages/ai/src/providers/openai-chatgpt-responses-protocol.ts	1

--- a/packages/ai/src/providers/agent-tools-parameter-schema.ts
+++ b/packages/ai/src/providers/agent-tools-parameter-schema.ts
@@ -560,10 +560,10 @@ function inlineLocalToolSchemaRefs(schema: unknown): TSchema {
   if (!schema || typeof schema !== "object") {
     return schema as TSchema;
   }
-  const defs = extendSchemaDefs(undefined, schema as Record<string, unknown>);
+  const schemaRecord = schema as Record<string, unknown>;
   return inlineLocalSchemaRefsWithDefs(
     schema,
-    defs,
+    Array.isArray(schema) ? extendSchemaDefs(undefined, schemaRecord) : undefined,
     undefined,
     {
       unresolvedLocalRefs: false,

--- a/packages/ai/src/providers/clean-for-gemini.ts
+++ b/packages/ai/src/providers/clean-for-gemini.ts
@@ -489,13 +489,5 @@ function flattenUnionFallback(
 }
 
 export function cleanSchemaForGemini(schema: unknown): TSchema {
-  if (!schema || typeof schema !== "object") {
-    return schema as TSchema;
-  }
-  if (Array.isArray(schema)) {
-    return schema.map(cleanSchemaForGemini) as TSchema;
-  }
-
-  const defs = extendSchemaDefs(undefined, schema as Record<string, unknown>);
-  return cleanSchemaForGeminiWithDefs(schema, defs, undefined) as TSchema;
+  return cleanSchemaForGeminiWithDefs(schema, undefined, undefined) as TSchema;
 }

--- a/src/agents/agent-tools.schema.test.ts
+++ b/src/agents/agent-tools.schema.test.ts
@@ -403,6 +403,27 @@ describe("normalizeToolParameterSchema", () => {
     });
   });
 
+  it.each(["own", "inherited"] as const)(
+    "inlines definitions attached to %s array roots",
+    (kind) => {
+      const schemas = [{ $ref: "#/$defs/Value" }, { $ref: "#/definitions/Value" }];
+      const definitions = {
+        $defs: { Value: { type: "string" } },
+        definitions: { Value: { type: "integer" } },
+      };
+      if (kind === "own") {
+        Object.assign(schemas, definitions);
+      } else {
+        Object.setPrototypeOf(schemas, Object.assign(Object.create(Array.prototype), definitions));
+      }
+
+      expect(normalizeToolParameterSchema(schemas)).toEqual([
+        { type: "string" },
+        { type: "integer" },
+      ]);
+    },
+  );
+
   it("inlines nested local $ref schemas for provider-neutral tools", () => {
     expect(
       normalizeToolParameterSchema({


### PR DESCRIPTION
## What Problem This Solves

Preparing provider tools does unnecessary work when schemas carry reusable definitions. Both the generic reference inliner and the Gemini cleaner collect root definitions in their wrapper, then immediately collect them again in the recursive implementation. Large definition inventories pay for duplicate map construction before normalization begins.

## Why This Change Was Made

Let each existing recursive implementation prepare object-root definitions once. The generic wrapper keeps its primitive guard and its existing definition seed for array roots, including own and inherited `$defs`/`definitions`. Nested scope, namespace precedence, reference-cycle handling, root-document tracking, and cache lifetimes remain unchanged. The change removes eight production lines and adds two contract cases for preserved array-root behavior.

## User Impact

Definition-heavy tool schemas require less preparation work, with unchanged normalized output. In a four-process B1/C1/C2/B2 comparison on one Linux Testbox, the mean of retained per-phase medians improved by 54.2%/56.3% for the synthetic 1,024-definition Gemini hook cases and 58.5% for the neutral generic case.

The controls were not uniformly faster: the generic Gemini many-reference case was 4.10% slower, and the separate warm-cache control was 7.01% slower. These are scoped schema-normalization measurements; end-to-end provider latency was not measured. All 27 complete input, output, and control sets matched across the four phases.

## Evidence

- Formatting and 128 selected tests passed: 127 cleaner/generic/SDK schema tests plus the registered Google direct/CLI provider schema case. The new cases protect existing array-definition behavior; they do not claim a pre-existing bug.
- The changed gate passed conflict-marker and max-lines checks, then required shrinking the assertion-safety baseline from 15 to 12 after three assertions were removed. That exact shrink was applied. The targeted assertion-safety guard subsequently passed across 3,899 files.
- Independent review found no actionable P0–P2 issues. Measured production bytes remain unchanged.
- The full changed graph was not restarted; checks after the original ratchet stop remain for CI. No performance rerun was performed. Native child closure and Testbox shutdown were verified, and the original failure evidence remains retained.

**Current-head qualification:** Head `f4de999e965d` preserves this PR's authored patch on main `bca261d5583d`, including the shared `retainedMachine` typecheck repair (#145540). Benchmarks, earlier validation, and prior draft-state notes remain historical under their original source labels; no benchmark was rerun for this rebase. Exact-head CI is required before landing.
