### PR TITLE
fix(auto-reply): preserve final answers after failed streamed blocks

### DIFF
--- a/src/agents/embedded-agent-runner/run-entry.cleanup.test.ts
+++ b/src/agents/embedded-agent-runner/run-entry.cleanup.test.ts
@@ -61,6 +61,7 @@ it.each(cleanupCases)(
                   readDeliveryEvidence: () => ({
                     hasDirectlySentBlockReply: false,
                     hasBlockReplyPipelineOutput: false,
+                    hasRetryBlockedDelivery: false,
                   }),
                 },
           sessionOverride: { kind: "preserve" },

--- a/src/agents/embedded-agent-runner/run-entry.custody.test.ts
+++ b/src/agents/embedded-agent-runner/run-entry.custody.test.ts
@@ -1,0 +1,80 @@
+import { expect, it, vi } from "vitest";
+import { runEmbeddedAgentEntry } from "./run-entry.js";
+import { initialAttemptOptions, type FallbackRunnerParams } from "./run-entry.test-support.js";
+import type { EmbeddedAgentRunResult } from "./types.js";
+
+const runFallback = vi.hoisted(() => vi.fn());
+vi.mock("../model-fallback-runner.js", () => ({
+  runWithModelFallback: (params: FallbackRunnerParams) => runFallback(params),
+}));
+
+it.each(["uncertain", "confirmed", "released", "stop-reason"] as const)(
+  "runEmbeddedAgentEntry rechecks %s delivery after result classification",
+  async (settlement) => {
+    const evidence = {
+      hasDirectlySentBlockReply: false,
+      hasBlockReplyPipelineOutput: false,
+      hasRetryBlockedDelivery: false,
+    };
+    runFallback.mockImplementationOnce(async (params: FallbackRunnerParams) => {
+      const result = await params.run(params.provider, params.model, initialAttemptOptions(params));
+      evidence.hasRetryBlockedDelivery = settlement === "uncertain" || settlement === "stop-reason";
+      evidence.hasDirectlySentBlockReply = settlement === "confirmed";
+      const classification = await params.classifyResult?.({
+        result,
+        provider: params.provider,
+        model: params.model,
+        attempt: 1,
+        total: 2,
+      });
+      if (settlement === "released") {
+        expect(classification).toMatchObject({ code: "empty_result" });
+      } else if (settlement === "stop-reason") {
+        expect(classification).toEqual({ stopReason: "agent_run_terminal_timeout" });
+      } else {
+        expect(classification).toBeUndefined();
+      }
+      return {
+        outcome: "completed" as const,
+        result,
+        provider: params.provider,
+        model: params.model,
+        attempts: [],
+      };
+    });
+    await runEmbeddedAgentEntry({
+      selection: { cfg: {}, provider: "provider", model: "model" },
+      identity: { runId: "settle-delivery", agentId: "main", sessionId: "session-1" },
+      harness: {
+        workspaceDir: process.cwd(),
+        preparation: { kind: "direct" },
+        resolveRuntimeOverride: () => "openclaw",
+      },
+      behavior: { kind: "channel-delivery", readDeliveryEvidence: () => evidence },
+      sessionOverride: { kind: "preserve" },
+      runCandidate: async (provider, model, options) => {
+        const result: EmbeddedAgentRunResult = {
+          payloads: [],
+          meta: {
+            durationMs: 1,
+            providerStarted: true,
+            agentHarnessResultClassification: "empty",
+            agentMeta: { sessionId: "session-1", provider, model },
+          },
+        };
+        evidence.hasRetryBlockedDelivery = true;
+        expect(options.classifyResult(result)).toBeUndefined();
+        evidence.hasRetryBlockedDelivery = false;
+        expect(options.classifyResult(result)).toMatchObject({ code: "empty_result" });
+        evidence.hasRetryBlockedDelivery = true;
+        expect(options.classifyResult(result)).toBeUndefined();
+        evidence.hasRetryBlockedDelivery = false;
+        expect(options.classifyResult(result)).toMatchObject({ code: "empty_result" });
+        if (settlement === "stop-reason") {
+          result.meta.modelFallbackStopReason = "agent_run_terminal_timeout";
+        }
+        return result;
+      },
+    });
+  },
+);

--- a/src/agents/embedded-agent-runner/run-entry.test.ts
+++ b/src/agents/embedded-agent-runner/run-entry.test.ts
@@ -259,6 +259,7 @@ describe("runEmbeddedAgentEntry", () => {
                 readDeliveryEvidence: () => ({
                   hasDirectlySentBlockReply: false,
                   hasBlockReplyPipelineOutput: false,
+                  hasRetryBlockedDelivery: false,
                 }),
               }
             : {
@@ -545,6 +546,7 @@ describe("runEmbeddedAgentEntry", () => {
         readDeliveryEvidence: () => ({
           hasDirectlySentBlockReply: false,
           hasBlockReplyPipelineOutput: false,
+          hasRetryBlockedDelivery: false,
         }),
       },
       sessionOverride: { kind: "preserve" },
@@ -622,7 +624,6 @@ describe("runEmbeddedAgentEntry", () => {
       );
       expect(state.finalizedAttempts).toEqual(committed ? ["candidate"] : []);
       expect(state.discardedAttempts).toEqual(committed ? [] : ["candidate"]);
-      expect(hasCommittedSideEffect).toHaveBeenCalledOnce();
     },
   );
 
@@ -816,6 +817,7 @@ describe("runEmbeddedAgentEntry", () => {
           readDeliveryEvidence: () => ({
             hasDirectlySentBlockReply: true,
             hasBlockReplyPipelineOutput: false,
+            hasRetryBlockedDelivery: false,
           }),
         },
         sessionOverride: { kind: "preserve" },
@@ -877,6 +879,7 @@ describe("runEmbeddedAgentEntry", () => {
         readDeliveryEvidence: () => ({
           hasDirectlySentBlockReply: false,
           hasBlockReplyPipelineOutput: false,
+          hasRetryBlockedDelivery: false,
         }),
       },
       sessionOverride: { kind: "preserve" },

--- a/src/agents/embedded-agent-runner/run-entry.ts
+++ b/src/agents/embedded-agent-runner/run-entry.ts
@@ -67,6 +67,7 @@ type RunEntryHarnessPreparation =
     };
 
 type DeliveryEvidence = {
+  hasRetryBlockedDelivery: boolean;
   hasDirectlySentBlockReply: boolean;
   hasBlockReplyPipelineOutput: boolean;
 };
@@ -433,12 +434,16 @@ export async function runEmbeddedAgentEntry<T extends EmbeddedAgentRunResult>(
   // delivered its reply, producing a duplicate visible answer (#113788). Consult the
   // same live delivery evidence the result classifier already uses so both exit
   // paths suppress fallback after a delivered reply.
-  const canFallbackAfterError = committedSideEffect
+  const canFallback = committedSideEffect
     ? () => !committedSideEffect()
     : readChannelDeliveryEvidence
       ? () => {
           const evidence = readChannelDeliveryEvidence();
-          return !evidence.hasDirectlySentBlockReply && !evidence.hasBlockReplyPipelineOutput;
+          return (
+            !evidence.hasDirectlySentBlockReply &&
+            !evidence.hasBlockReplyPipelineOutput &&
+            !evidence.hasRetryBlockedDelivery
+          );
         }
       : undefined;
   try {
@@ -501,9 +506,11 @@ export async function runEmbeddedAgentEntry<T extends EmbeddedAgentRunResult>(
             classifyResult: ({ result }: { result: RunEntryCandidate<T> }) =>
               result.result.meta.modelFallbackStopReason
                 ? { stopReason: result.result.meta.modelFallbackStopReason }
-                : result.classification,
+                : canFallback?.() === false
+                  ? undefined
+                  : result.classification,
           }),
-      ...(canFallbackAfterError ? { canFallbackAfterError } : {}),
+      ...(canFallback ? { canFallbackAfterError: canFallback } : {}),
       ...(params.behavior.kind === "maintenance"
         ? {}
         : {
@@ -533,6 +540,10 @@ export async function runEmbeddedAgentEntry<T extends EmbeddedAgentRunResult>(
           | { result: EmbeddedAgentRunResult; value: ModelFallbackResultClassification }
           | undefined;
         const classifyResult = (result: EmbeddedAgentRunResult) => {
+          // Custody can settle between classification and finalization; never cache its veto.
+          if (canFallback?.() === false) {
+            return undefined;
+          }
           if (!classified || classified.result !== result) {
             const classification =
               params.behavior.kind === "maintenance"
@@ -551,10 +562,7 @@ export async function runEmbeddedAgentEntry<T extends EmbeddedAgentRunResult>(
             // returns a replacement that must not inherit its predecessor's decision.
             classified = {
               result,
-              value:
-                effectiveClassification && committedSideEffect?.()
-                  ? undefined
-                  : effectiveClassification,
+              value: effectiveClassification,
             };
           }
           return classified.value;

--- a/src/auto-reply/dispatch.block-streaming-recovery.test.ts
+++ b/src/auto-reply/dispatch.block-streaming-recovery.test.ts
@@ -29,25 +29,32 @@ it.each([
   "timeout",
   "all-ambiguous",
   "timeout-media",
+  "ambiguous-media",
+  "recovery-owned-media",
+  "all-ambiguous-media",
 ] as const)(
   "dispatchInboundMessageWithBufferedDispatcher settles %s streamed blocks before final suppression",
   async (scenario) => {
     const timesOut = scenario === "timeout" || scenario === "timeout-media";
+    const allAmbiguous = scenario === "all-ambiguous" || scenario === "all-ambiguous-media";
+    const uncertainMedia =
+      scenario === "ambiguous-media" ||
+      scenario === "recovery-owned-media" ||
+      scenario === "all-ambiguous-media";
     const responseText =
-      scenario === "timeout-media" ? `${finalText}\nMEDIA:${finalMediaUrl}` : finalText;
+      scenario === "timeout-media" || uncertainMedia
+        ? `${finalText}\nMEDIA:${finalMediaUrl}`
+        : finalText;
     const state = await createOpenClawTestState({
       label: "block-streaming-recovery",
       env: { OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1" },
     });
-    const requests: string[] = [];
+    const requests: Array<{ method?: string; url?: string }> = [];
     const attempted: Array<{ kind: string; text: string | undefined; mediaUrls?: string[] }> = [];
     const delivered: Array<{ kind: string; text: string | undefined; mediaUrls?: string[] }> = [];
-    const server = createServer(async (request, response) => {
-      const chunks: Buffer[] = [];
-      for await (const chunk of request) {
-        chunks.push(Buffer.from(chunk));
-      }
-      requests.push(Buffer.concat(chunks).toString());
+    const server = createServer((request, response) => {
+      requests.push({ method: request.method, url: request.url });
+      request.resume();
       response.writeHead(200, { "content-type": "text/event-stream" });
       for (const text of [responseText.slice(0, 180), responseText.slice(180)]) {
         response.write(
@@ -161,27 +168,31 @@ it.each([
             attempted.push(call);
             if (info.kind === "block") {
               blocks++;
-              if (scenario === "all-ambiguous") {
+              if (allAmbiguous) {
                 throw new Error("transport response lost after send");
               }
               if (scenario === "concurrent" && blocks === 1) {
                 blockStarted.resolve();
                 await releaseBlock.promise;
               }
-              if (blocks === 2) {
+              if (uncertainMedia ? payload.mediaUrls?.includes(finalMediaUrl) : blocks === 2) {
                 if (timesOut) {
                   await releaseBlock.promise;
                   delivered.push(call);
                   return { visibleReplySent: true };
                 }
-                if (scenario === "recovery-owned") {
+                if (scenario === "recovery-owned" || scenario === "recovery-owned-media") {
                   const error = new OutboundDeliveryError("retained for recovery", {
                     cause: noSend,
                   });
                   error.queueCustody = "held";
                   throw error;
                 }
-                if (scenario === "ambiguous" || scenario === "mixed") {
+                if (
+                  scenario === "ambiguous" ||
+                  scenario === "ambiguous-media" ||
+                  scenario === "mixed"
+                ) {
                   throw new Error("transport response lost after send");
                 }
                 if (scenario === "deferred-rejection") {
@@ -238,15 +249,39 @@ it.each([
         JSON.stringify({
           scenario,
           requests: requests.length,
+          requestEndpoints: requests,
           attempted,
           delivered,
           result,
           concurrentElapsedMs,
         }),
       );
-      expect(requests.length).toBeGreaterThan(0);
+      expect(requests).toEqual(
+        scenario === "concurrent"
+          ? [
+              { method: "POST", url: "/v1/chat/completions" },
+              { method: "POST", url: "/v1/chat/completions" },
+            ]
+          : [{ method: "POST", url: "/v1/chat/completions" }],
+      );
       expect(blocks).toBeGreaterThanOrEqual(2);
-      if (scenario === "timeout-media") {
+      if (uncertainMedia) {
+        const mediaAttempts = attempted.filter((call) => call.mediaUrls?.includes(finalMediaUrl));
+        expect(mediaAttempts).toEqual([
+          expect.objectContaining({ kind: "block", mediaUrls: [finalMediaUrl] }),
+        ]);
+        expect(mediaAttempts[0]?.text).not.toBe(finalText);
+        expect(delivered.filter((call) => call.mediaUrls?.length)).toEqual([]);
+        expect(result.settledReceipt?.counts.block.delivered).toBe(allAmbiguous ? 0 : blocks - 1);
+        expect(attempted.filter((call) => call.kind === "final")).toEqual([]);
+        if (scenario === "recovery-owned-media") {
+          expect(result.settledReceipt?.hasPendingDelivery).toBe(true);
+        } else {
+          expect(result.settledReceipt?.counts.block.failedAfterSend).toBe(
+            allAmbiguous ? blocks : 1,
+          );
+        }
+      } else if (scenario === "timeout-media") {
         expect(blocks).toBe(2);
         expect(attempted.filter((call) => call.kind === "final")).toEqual([
           { kind: "final", text: undefined, mediaUrls: [finalMediaUrl] },

--- a/src/auto-reply/dispatch.block-streaming-recovery.test.ts
+++ b/src/auto-reply/dispatch.block-streaming-recovery.test.ts
@@ -1,0 +1,293 @@
+import { createServer } from "node:http";
+import { expect, it } from "vitest";
+import { createDeferred, withTestTimeout } from "../../test/helpers/promise.js";
+import { setRuntimeConfigSnapshot } from "../config/config.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import {
+  applyGatewayLaneConcurrency,
+  resolveGatewayLaneConcurrency,
+} from "../gateway/server-lanes.js";
+import {
+  OutboundDeliveryError,
+  PlatformMessageNotDispatchedError,
+} from "../infra/outbound/deliver-types.js";
+import { resetCommandQueueStateForTest } from "../process/command-queue.test-support.js";
+import { createOpenClawTestState } from "../test-utils/openclaw-test-state.js";
+import { dispatchInboundMessageWithBufferedDispatcher } from "./dispatch.js";
+
+const finalText = "```ts\n" + "const answer = 42;\n".repeat(20) + "```";
+const finalMediaUrl = "https://example.test/final.png";
+
+it.each([
+  "rejected",
+  "confirmed",
+  "ambiguous",
+  "recovery-owned",
+  "deferred-rejection",
+  "mixed",
+  "concurrent",
+  "timeout",
+  "all-ambiguous",
+  "timeout-media",
+] as const)(
+  "dispatchInboundMessageWithBufferedDispatcher settles %s streamed blocks before final suppression",
+  async (scenario) => {
+    const timesOut = scenario === "timeout" || scenario === "timeout-media";
+    const responseText =
+      scenario === "timeout-media" ? `${finalText}\nMEDIA:${finalMediaUrl}` : finalText;
+    const state = await createOpenClawTestState({
+      label: "block-streaming-recovery",
+      env: { OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1" },
+    });
+    const requests: string[] = [];
+    const attempted: Array<{ kind: string; text: string | undefined; mediaUrls?: string[] }> = [];
+    const delivered: Array<{ kind: string; text: string | undefined; mediaUrls?: string[] }> = [];
+    const server = createServer(async (request, response) => {
+      const chunks: Buffer[] = [];
+      for await (const chunk of request) {
+        chunks.push(Buffer.from(chunk));
+      }
+      requests.push(Buffer.concat(chunks).toString());
+      response.writeHead(200, { "content-type": "text/event-stream" });
+      for (const text of [responseText.slice(0, 180), responseText.slice(180)]) {
+        response.write(
+          `data: ${JSON.stringify({
+            id: "completion-fixture",
+            object: "chat.completion.chunk",
+            choices: [{ index: 0, delta: { role: "assistant", content: text } }],
+          })}\n\n`,
+        );
+      }
+      response.end(
+        `data: ${JSON.stringify({
+          id: "completion-fixture",
+          object: "chat.completion.chunk",
+          choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+        })}\n\ndata: [DONE]\n\n`,
+      );
+    });
+    try {
+      await new Promise<void>((resolve) => {
+        server.listen(0, "127.0.0.1", resolve);
+      });
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        throw new Error("fixture server did not bind");
+      }
+      const cfg = {
+        agents: {
+          ownership: "explicit",
+          entries: { main: {} },
+          defaults: {
+            workspace: state.workspaceDir,
+            skipBootstrap: true,
+            heartbeat: { every: "0m" },
+            model: { primary: "fixture/answer" },
+            models: { "fixture/answer": { agentRuntime: { id: "openclaw" } } },
+            blockStreamingDefault: "on",
+            blockStreamingChunk: { minChars: 80, maxChars: 160 },
+            blockStreamingCoalesce: { minChars: 1, maxChars: 160, idleMs: 0 },
+          },
+        },
+        models: {
+          mode: "replace",
+          providers: {
+            fixture: {
+              baseUrl: `http://127.0.0.1:${address.port}/v1`,
+              apiKey: "synthetic-test-key",
+              api: "openai-completions",
+              request: { allowPrivateNetwork: true },
+              models: [
+                {
+                  id: "answer",
+                  name: "Answer",
+                  reasoning: false,
+                  input: ["text"],
+                  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                  contextWindow: 128000,
+                  maxTokens: 4096,
+                },
+              ],
+            },
+          },
+        },
+        channels: { discord: { streaming: { mode: "off", block: { enabled: true } } } },
+        messages: { visibleReplies: "automatic" },
+        plugins: { slots: { memory: "none" } },
+        tools: { profile: "minimal" },
+      } satisfies OpenClawConfig;
+      await state.writeConfig(cfg);
+      setRuntimeConfigSnapshot(cfg);
+      applyGatewayLaneConcurrency(resolveGatewayLaneConcurrency(cfg));
+      let blocks = 0;
+      const blockStarted = createDeferred();
+      const releaseBlock = createDeferred();
+      let concurrentElapsedMs: number | undefined;
+      const noSend = new PlatformMessageNotDispatchedError("channel rejected the continuation", {
+        cause: new Error("transport unavailable before send"),
+      });
+      const dispatchParams = {
+        ctx: {
+          Body: "Show the complete example.",
+          From: "discord:user:1001",
+          To: "discord:channel:2001",
+          SessionKey: `agent:main:discord:direct:${scenario}`,
+          MessageSid: `request-${scenario}`,
+          Provider: "discord",
+          Surface: "discord",
+          ChatType: "direct",
+          CommandAuthorized: true,
+        },
+        cfg,
+      };
+      const dispatch = dispatchInboundMessageWithBufferedDispatcher({
+        ...dispatchParams,
+        replyOptions: {
+          blockReplyTimeoutMs: timesOut ? 50 : undefined,
+          onAgentRunTerminalOutcome: () => {
+            if (timesOut) {
+              releaseBlock.resolve();
+            }
+          },
+        },
+        dispatcherOptions: {
+          propagateRetryableNoSendFailure: true,
+          deliver: async (payload, info) => {
+            const call = {
+              kind: info.kind,
+              text: payload.text,
+              ...(payload.mediaUrls?.length ? { mediaUrls: payload.mediaUrls } : {}),
+            };
+            attempted.push(call);
+            if (info.kind === "block") {
+              blocks++;
+              if (scenario === "all-ambiguous") {
+                throw new Error("transport response lost after send");
+              }
+              if (scenario === "concurrent" && blocks === 1) {
+                blockStarted.resolve();
+                await releaseBlock.promise;
+              }
+              if (blocks === 2) {
+                if (timesOut) {
+                  await releaseBlock.promise;
+                  delivered.push(call);
+                  return { visibleReplySent: true };
+                }
+                if (scenario === "recovery-owned") {
+                  const error = new OutboundDeliveryError("retained for recovery", {
+                    cause: noSend,
+                  });
+                  error.queueCustody = "held";
+                  throw error;
+                }
+                if (scenario === "ambiguous" || scenario === "mixed") {
+                  throw new Error("transport response lost after send");
+                }
+                if (scenario === "deferred-rejection") {
+                  return { finalization: Promise.reject(noSend) };
+                }
+                if (scenario !== "confirmed") {
+                  throw noSend;
+                }
+              }
+              if (scenario === "mixed" && blocks === 3) {
+                throw noSend;
+              }
+            }
+            delivered.push(call);
+            return { visibleReplySent: true };
+          },
+        },
+      });
+      if (scenario === "concurrent") {
+        let otherDispatch:
+          | ReturnType<typeof dispatchInboundMessageWithBufferedDispatcher>
+          | undefined;
+        try {
+          await withTestTimeout(blockStarted.promise, 10000, "first transport start");
+          const started = performance.now();
+          otherDispatch = dispatchInboundMessageWithBufferedDispatcher({
+            ...dispatchParams,
+            ctx: {
+              ...dispatchParams.ctx,
+              SessionKey: "agent:main:discord:direct:1002",
+              From: "discord:user:1002",
+              MessageSid: "request-2",
+            },
+            dispatcherOptions: { deliver: async () => ({ visibleReplySent: true }) },
+          });
+          const other = await withTestTimeout(
+            otherDispatch,
+            10000,
+            "other conversation during held transport",
+          );
+          concurrentElapsedMs = performance.now() - started;
+          expect(other.settledReceipt?.anyVisibleDelivered).toBe(true);
+          expect(other.settledReceipt?.counts.block.delivered).toBe(3);
+          expect(other.settledReceipt?.counts.final.delivered).toBe(0);
+          expect(delivered).toEqual([]);
+        } finally {
+          releaseBlock.resolve();
+          await dispatch;
+          await otherDispatch;
+        }
+      }
+      const result = await dispatch;
+      console.log(
+        JSON.stringify({
+          scenario,
+          requests: requests.length,
+          attempted,
+          delivered,
+          result,
+          concurrentElapsedMs,
+        }),
+      );
+      expect(requests.length).toBeGreaterThan(0);
+      expect(blocks).toBeGreaterThanOrEqual(2);
+      if (scenario === "timeout-media") {
+        expect(blocks).toBe(2);
+        expect(attempted.filter((call) => call.kind === "final")).toEqual([
+          { kind: "final", text: undefined, mediaUrls: [finalMediaUrl] },
+        ]);
+        expect(delivered.filter((call) => call.mediaUrls?.length)).toEqual([
+          { kind: "final", text: undefined, mediaUrls: [finalMediaUrl] },
+        ]);
+        expect(result.settledReceipt?.counts.final.delivered).toBe(1);
+        expect(result.settledReceipt?.counts.block.delivered).toBe(2);
+      } else if (
+        scenario === "rejected" ||
+        scenario === "deferred-rejection" ||
+        scenario === "concurrent"
+      ) {
+        expect(delivered).toContainEqual({ kind: "final", text: finalText });
+        expect(result.settledReceipt?.counts.block.failedBeforeSend).toBe(1);
+        expect(result.settledReceipt?.counts.final.delivered).toBe(1);
+      } else {
+        expect(attempted.filter((call) => call.kind === "final")).toEqual([]);
+        expect(result.settledReceipt?.counts.final.delivered).toBe(0);
+        if (scenario === "confirmed" || scenario === "timeout") {
+          expect(result.settledReceipt?.counts.block.delivered).toBe(blocks);
+          if (scenario === "timeout") {
+            expect(blocks).toBe(2);
+          }
+        } else if (scenario === "recovery-owned") {
+          expect(result.settledReceipt?.hasPendingDelivery).toBe(true);
+        } else {
+          expect(result.settledReceipt?.counts.block.failedAfterSend).toBe(
+            scenario === "all-ambiguous" ? blocks : 1,
+          );
+        }
+      }
+    } finally {
+      server.closeAllConnections();
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+      await state.cleanup();
+      resetCommandQueueStateForTest();
+    }
+  },
+  60000,
+);

--- a/src/auto-reply/dispatch.block-streaming-recovery.test.ts
+++ b/src/auto-reply/dispatch.block-streaming-recovery.test.ts
@@ -17,6 +17,7 @@ import { dispatchInboundMessageWithBufferedDispatcher } from "./dispatch.js";
 
 const finalText = "```ts\n" + "const answer = 42;\n".repeat(20) + "```";
 const finalMediaUrl = "https://example.test/final.png";
+const mediaCaption = "Here is the generated image.";
 
 it.each([
   "rejected",
@@ -32,17 +33,29 @@ it.each([
   "ambiguous-media",
   "recovery-owned-media",
   "all-ambiguous-media",
+  "direct-ambiguous-media",
+  "direct-recovery-owned-media",
+  "direct-confirmed-media",
+  "direct-rejected-media",
+  "direct-no-delivery",
 ] as const)(
   "dispatchInboundMessageWithBufferedDispatcher settles %s streamed blocks before final suppression",
   async (scenario) => {
     const timesOut = scenario === "timeout" || scenario === "timeout-media";
+    const directMedia =
+      scenario === "direct-ambiguous-media" ||
+      scenario === "direct-recovery-owned-media" ||
+      scenario === "direct-confirmed-media" ||
+      scenario === "direct-rejected-media" ||
+      scenario === "direct-no-delivery";
     const allAmbiguous = scenario === "all-ambiguous" || scenario === "all-ambiguous-media";
     const uncertainMedia =
       scenario === "ambiguous-media" ||
       scenario === "recovery-owned-media" ||
       scenario === "all-ambiguous-media";
-    const responseText =
-      scenario === "timeout-media" || uncertainMedia
+    const responseText = directMedia
+      ? mediaCaption
+      : scenario === "timeout-media" || uncertainMedia
         ? `${finalText}\nMEDIA:${finalMediaUrl}`
         : finalText;
     const state = await createOpenClawTestState({
@@ -50,30 +63,98 @@ it.each([
       env: { OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1" },
     });
     const requests: Array<{ method?: string; url?: string }> = [];
+    const toolRequestBodies: string[] = [];
     const attempted: Array<{ kind: string; text: string | undefined; mediaUrls?: string[] }> = [];
     const delivered: Array<{ kind: string; text: string | undefined; mediaUrls?: string[] }> = [];
     const server = createServer((request, response) => {
       requests.push({ method: request.method, url: request.url });
-      request.resume();
-      response.writeHead(200, { "content-type": "text/event-stream" });
-      for (const text of [responseText.slice(0, 180), responseText.slice(180)]) {
-        response.write(
+      const sendResponse = () => {
+        response.writeHead(200, { "content-type": "text/event-stream" });
+        if (directMedia && requests.length === 1) {
+          response.end(
+            `data: ${JSON.stringify({
+              id: "completion-fixture",
+              object: "chat.completion.chunk",
+              choices: [
+                {
+                  index: 0,
+                  delta: {
+                    role: "assistant",
+                    tool_calls: [
+                      {
+                        index: 0,
+                        id: "media-call",
+                        type: "function",
+                        function: { name: "fixture_media", arguments: "{}" },
+                      },
+                    ],
+                  },
+                  finish_reason: "tool_calls",
+                },
+              ],
+            })}\n\ndata: [DONE]\n\n`,
+          );
+          return;
+        }
+        for (const text of [responseText.slice(0, 180), responseText.slice(180)]) {
+          response.write(
+            `data: ${JSON.stringify({
+              id: "completion-fixture",
+              object: "chat.completion.chunk",
+              choices: [{ index: 0, delta: { role: "assistant", content: text } }],
+            })}\n\n`,
+          );
+        }
+        response.end(
           `data: ${JSON.stringify({
             id: "completion-fixture",
             object: "chat.completion.chunk",
-            choices: [{ index: 0, delta: { role: "assistant", content: text } }],
-          })}\n\n`,
+            choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+          })}\n\ndata: [DONE]\n\n`,
         );
+      };
+      if (directMedia) {
+        const chunks: string[] = [];
+        request.setEncoding("utf8");
+        request.on("data", (chunk: string) => {
+          chunks.push(chunk);
+        });
+        request.on("end", () => {
+          toolRequestBodies.push(chunks.join(""));
+          sendResponse();
+        });
+      } else {
+        request.resume();
+        sendResponse();
       }
-      response.end(
-        `data: ${JSON.stringify({
-          id: "completion-fixture",
-          object: "chat.completion.chunk",
-          choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
-        })}\n\ndata: [DONE]\n\n`,
-      );
     });
     try {
+      const toolPluginPath = state.statePath("media-plugin", "index.cjs");
+      if (directMedia) {
+        await state.writeJson("media-plugin/openclaw.plugin.json", {
+          id: "fixture-media",
+          configSchema: { type: "object", additionalProperties: false, properties: {} },
+          contracts: { tools: ["fixture_media"] },
+        });
+        await state.writeText(
+          "media-plugin/index.cjs",
+          `module.exports = {
+          id: "fixture-media",
+          register(api) {
+            api.registerTool({
+              name: "fixture_media", label: "Fixture media", description: "Generate a fixture image",
+              parameters: { type: "object", properties: {} },
+              async execute() {
+                return {
+                  content: [{ type: "text", text: "Fixture generated image." }],
+                  details: { media: { mediaUrls: [${JSON.stringify(finalMediaUrl)}] } },
+                };
+              },
+            });
+          },
+        };`,
+        );
+      }
       await new Promise<void>((resolve) => {
         server.listen(0, "127.0.0.1", resolve);
       });
@@ -91,7 +172,7 @@ it.each([
             heartbeat: { every: "0m" },
             model: { primary: "fixture/answer" },
             models: { "fixture/answer": { agentRuntime: { id: "openclaw" } } },
-            blockStreamingDefault: "on",
+            blockStreamingDefault: directMedia ? "off" : "on",
             blockStreamingChunk: { minChars: 80, maxChars: 160 },
             blockStreamingCoalesce: { minChars: 1, maxChars: 160, idleMs: 0 },
           },
@@ -118,10 +199,13 @@ it.each([
             },
           },
         },
-        channels: { discord: { streaming: { mode: "off", block: { enabled: true } } } },
+        channels: { discord: { streaming: { mode: "off", block: { enabled: !directMedia } } } },
         messages: { visibleReplies: "automatic" },
-        plugins: { slots: { memory: "none" } },
-        tools: { profile: "minimal" },
+        plugins: {
+          slots: { memory: "none" },
+          ...(directMedia ? { allow: ["fixture-media"], load: { paths: [toolPluginPath] } } : {}),
+        },
+        tools: { profile: "minimal", ...(directMedia ? { alsoAllow: ["fixture_media"] } : {}) },
       } satisfies OpenClawConfig;
       await state.writeConfig(cfg);
       setRuntimeConfigSnapshot(cfg);
@@ -166,8 +250,28 @@ it.each([
               ...(payload.mediaUrls?.length ? { mediaUrls: payload.mediaUrls } : {}),
             };
             attempted.push(call);
+            if (scenario === "direct-no-delivery" && info.kind === "final") {
+              throw noSend;
+            }
             if (info.kind === "block") {
               blocks++;
+              if (directMedia && payload.mediaUrls?.includes(finalMediaUrl)) {
+                if (scenario === "direct-confirmed-media") {
+                  delivered.push(call);
+                  return { visibleReplySent: true };
+                }
+                if (scenario === "direct-rejected-media" || scenario === "direct-no-delivery") {
+                  throw noSend;
+                }
+                if (scenario === "direct-recovery-owned-media") {
+                  const error = new OutboundDeliveryError("retained for recovery", {
+                    cause: noSend,
+                  });
+                  error.queueCustody = "held";
+                  throw error;
+                }
+                throw new Error("transport response lost after send");
+              }
               if (allAmbiguous) {
                 throw new Error("transport response lost after send");
               }
@@ -244,6 +348,25 @@ it.each([
           await otherDispatch;
         }
       }
+      if (scenario === "direct-no-delivery") {
+        await expect(dispatch).rejects.toBe(noSend);
+        console.log(
+          JSON.stringify({
+            scenario,
+            requests: requests.length,
+            attempted,
+            delivered,
+            outcome: "retryable-no-send",
+          }),
+        );
+        expect(toolRequestBodies[1]).toContain("Fixture generated image.");
+        expect(attempted).toEqual([
+          { kind: "block", text: mediaCaption, mediaUrls: [finalMediaUrl] },
+          { kind: "final", text: mediaCaption },
+        ]);
+        expect(delivered).toEqual([]);
+        return;
+      }
       const result = await dispatch;
       console.log(
         JSON.stringify({
@@ -257,15 +380,41 @@ it.each([
         }),
       );
       expect(requests).toEqual(
-        scenario === "concurrent"
+        scenario === "concurrent" || directMedia
           ? [
               { method: "POST", url: "/v1/chat/completions" },
               { method: "POST", url: "/v1/chat/completions" },
             ]
           : [{ method: "POST", url: "/v1/chat/completions" }],
       );
-      expect(blocks).toBeGreaterThanOrEqual(2);
-      if (uncertainMedia) {
+      expect(blocks).toBeGreaterThanOrEqual(directMedia ? 1 : 2);
+      if (directMedia) {
+        expect(toolRequestBodies[0]).toContain('"fixture_media"');
+        expect(toolRequestBodies[1]).toContain("Fixture generated image.");
+        expect(attempted).toEqual([
+          { kind: "block", text: mediaCaption, mediaUrls: [finalMediaUrl] },
+          ...(scenario === "direct-rejected-media" ? [{ kind: "final", text: mediaCaption }] : []),
+        ]);
+        if (scenario === "direct-confirmed-media") {
+          expect(delivered).toEqual([
+            { kind: "block", text: mediaCaption, mediaUrls: [finalMediaUrl] },
+          ]);
+        } else if (scenario === "direct-rejected-media") {
+          expect(delivered).toEqual([{ kind: "final", text: mediaCaption }]);
+          expect(result.settledReceipt?.counts.block.failedBeforeSend).toBe(1);
+          expect(result.settledReceipt?.hasPendingDelivery).not.toBe(true);
+        } else {
+          expect(delivered).toEqual([]);
+        }
+        expect(result.settledReceipt?.counts.final.delivered).toBe(
+          scenario === "direct-rejected-media" ? 1 : 0,
+        );
+        if (scenario === "direct-recovery-owned-media") {
+          expect(result.settledReceipt?.hasPendingDelivery).toBe(true);
+        } else if (scenario === "direct-ambiguous-media") {
+          expect(result.settledReceipt?.counts.block.failedAfterSend).toBe(1);
+        }
+      } else if (uncertainMedia) {
         const mediaAttempts = attempted.filter((call) => call.mediaUrls?.includes(finalMediaUrl));
         expect(mediaAttempts).toEqual([
           expect.objectContaining({ kind: "block", mediaUrls: [finalMediaUrl] }),

--- a/src/auto-reply/dispatch.block-streaming-recovery.test.ts
+++ b/src/auto-reply/dispatch.block-streaming-recovery.test.ts
@@ -18,6 +18,7 @@ import { dispatchInboundMessageWithBufferedDispatcher } from "./dispatch.js";
 const finalText = "```ts\n" + "const answer = 42;\n".repeat(20) + "```";
 const finalMediaUrl = "https://example.test/final.png";
 const mediaCaption = "Here is the generated image.";
+const fallbackText = "The backup produced a second answer.";
 
 it.each([
   "rejected",
@@ -38,10 +39,20 @@ it.each([
   "direct-confirmed-media",
   "direct-rejected-media",
   "direct-no-delivery",
+  "fallback-ambiguous",
+  "fallback-recovery-owned",
+  "fallback-rejected",
+  "fallback-direct-ambiguous",
+  "fallback-direct-recovery-owned",
+  "fallback-direct-rejected",
 ] as const)(
   "dispatchInboundMessageWithBufferedDispatcher settles %s streamed blocks before final suppression",
   async (scenario) => {
     const timesOut = scenario === "timeout" || scenario === "timeout-media";
+    const fallback = scenario.startsWith("fallback-");
+    const fallbackDirect = scenario.startsWith("fallback-direct-");
+    const fallbackRejected = fallback && scenario.endsWith("-rejected");
+    const fallbackRecoveryOwned = fallback && scenario.endsWith("-recovery-owned");
     const directMedia =
       scenario === "direct-ambiguous-media" ||
       scenario === "direct-recovery-owned-media" ||
@@ -62,14 +73,79 @@ it.each([
       label: "block-streaming-recovery",
       env: { OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1" },
     });
-    const requests: Array<{ method?: string; url?: string }> = [];
+    const requests: Array<{ method?: string; url?: string; model?: string }> = [];
     const toolRequestBodies: string[] = [];
     const attempted: Array<{ kind: string; text: string | undefined; mediaUrls?: string[] }> = [];
     const delivered: Array<{ kind: string; text: string | undefined; mediaUrls?: string[] }> = [];
+    const fallbackEvents: string[] = [];
     const server = createServer((request, response) => {
-      requests.push({ method: request.method, url: request.url });
+      const requestRecord: { method?: string; url?: string; model?: string } = {
+        method: request.method,
+        url: request.url,
+      };
+      requests.push(requestRecord);
       const sendResponse = () => {
         response.writeHead(200, { "content-type": "text/event-stream" });
+        if (fallback) {
+          const backup = requestRecord.model === "backup";
+          fallbackEvents.push(`request:${requestRecord.model}`);
+          const text = backup ? fallbackText : `${finalText}\nMEDIA:${finalMediaUrl}`;
+          const item = {
+            id: "message-fixture",
+            type: "message",
+            role: "assistant",
+            phase: "final_answer",
+            status: "completed",
+            content: [{ type: "output_text", text, annotations: [] }],
+          };
+          for (const event of [
+            {
+              type: "response.created",
+              response: { id: "response-fixture", status: "in_progress" },
+            },
+            {
+              type: "response.output_item.added",
+              output_index: 0,
+              item: { ...item, status: "in_progress", content: [] },
+            },
+            {
+              type: "response.output_text.delta",
+              item_id: item.id,
+              output_index: 0,
+              content_index: 0,
+              delta: text,
+            },
+            {
+              type: "response.output_text.done",
+              item_id: item.id,
+              output_index: 0,
+              content_index: 0,
+              text,
+            },
+            { type: "response.output_item.done", output_index: 0, item },
+          ]) {
+            response.write(`event: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`);
+          }
+          const terminal = {
+            type: backup ? "response.completed" : "response.failed",
+            response: {
+              id: "response-fixture",
+              model: requestRecord.model,
+              status: backup ? "completed" : "failed",
+              output: [item],
+              ...(backup
+                ? {}
+                : {
+                    error: {
+                      code: "insufficient_balance",
+                      message: "Insufficient balance. Top up to continue.",
+                    },
+                  }),
+            },
+          };
+          response.end(`event: ${terminal.type}\ndata: ${JSON.stringify(terminal)}\n\n`);
+          return;
+        }
         if (directMedia && requests.length === 1) {
           response.end(
             `data: ${JSON.stringify({
@@ -113,14 +189,20 @@ it.each([
           })}\n\ndata: [DONE]\n\n`,
         );
       };
-      if (directMedia) {
+      if (directMedia || fallback) {
         const chunks: string[] = [];
         request.setEncoding("utf8");
         request.on("data", (chunk: string) => {
           chunks.push(chunk);
         });
         request.on("end", () => {
-          toolRequestBodies.push(chunks.join(""));
+          const body = chunks.join("");
+          if (fallback) {
+            const parsed: { model: string } = JSON.parse(body);
+            requestRecord.model = parsed.model;
+          } else {
+            toolRequestBodies.push(body);
+          }
           sendResponse();
         });
       } else {
@@ -170,9 +252,17 @@ it.each([
             workspace: state.workspaceDir,
             skipBootstrap: true,
             heartbeat: { every: "0m" },
-            model: { primary: "fixture/answer" },
-            models: { "fixture/answer": { agentRuntime: { id: "openclaw" } } },
-            blockStreamingDefault: directMedia ? "off" : "on",
+            model: {
+              primary: "fixture/answer",
+              ...(fallback ? { fallbacks: ["fixture-backup/backup"] } : {}),
+            },
+            models: {
+              "fixture/answer": { agentRuntime: { id: "openclaw" } },
+              ...(fallback
+                ? { "fixture-backup/backup": { agentRuntime: { id: "openclaw" } } }
+                : {}),
+            },
+            blockStreamingDefault: directMedia || fallbackDirect ? "off" : "on",
             blockStreamingChunk: { minChars: 80, maxChars: 160 },
             blockStreamingCoalesce: { minChars: 1, maxChars: 160, idleMs: 0 },
           },
@@ -183,7 +273,7 @@ it.each([
             fixture: {
               baseUrl: `http://127.0.0.1:${address.port}/v1`,
               apiKey: "synthetic-test-key",
-              api: "openai-completions",
+              api: fallback ? "openai-responses" : "openai-completions",
               request: { allowPrivateNetwork: true },
               models: [
                 {
@@ -197,9 +287,34 @@ it.each([
                 },
               ],
             },
+            ...(fallback
+              ? {
+                  "fixture-backup": {
+                    baseUrl: `http://127.0.0.1:${address.port}/v1`,
+                    apiKey: "synthetic-backup-key",
+                    api: "openai-responses" as const,
+                    request: { allowPrivateNetwork: true },
+                    models: [
+                      {
+                        id: "backup",
+                        name: "Backup",
+                        reasoning: false,
+                        input: ["text" as const],
+                        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                        contextWindow: 128000,
+                        maxTokens: 4096,
+                      },
+                    ],
+                  },
+                }
+              : {}),
           },
         },
-        channels: { discord: { streaming: { mode: "off", block: { enabled: !directMedia } } } },
+        channels: {
+          discord: {
+            streaming: { mode: "off", block: { enabled: !directMedia && !fallbackDirect } },
+          },
+        },
         messages: { visibleReplies: "automatic" },
         plugins: {
           slots: { memory: "none" },
@@ -250,6 +365,18 @@ it.each([
               ...(payload.mediaUrls?.length ? { mediaUrls: payload.mediaUrls } : {}),
             };
             attempted.push(call);
+            if (fallback && info.kind === "block" && payload.text !== fallbackText) {
+              fallbackEvents.push("primary-block");
+              if (fallbackRejected) {
+                throw noSend;
+              }
+              if (fallbackRecoveryOwned) {
+                const error = new OutboundDeliveryError("retained for recovery", { cause: noSend });
+                error.queueCustody = "held";
+                throw error;
+              }
+              throw new Error("transport response lost after send");
+            }
             if (scenario === "direct-no-delivery" && info.kind === "final") {
               throw noSend;
             }
@@ -365,6 +492,40 @@ it.each([
           { kind: "final", text: mediaCaption },
         ]);
         expect(delivered).toEqual([]);
+        return;
+      }
+      if (fallback) {
+        let providerFailure: unknown;
+        const result = await dispatch.catch((error: unknown) => {
+          providerFailure = error;
+          return undefined;
+        });
+        console.log(
+          JSON.stringify({
+            scenario,
+            requests,
+            fallbackEvents,
+            attempted,
+            delivered,
+            result,
+            providerFailure:
+              providerFailure instanceof Error ? providerFailure.message : providerFailure,
+          }),
+        );
+        expect(fallbackEvents).toContain("primary-block");
+        if (fallbackRejected) {
+          expect(requests.map((entry) => entry.model)).toEqual(["answer", "backup"]);
+          expect(delivered.some((call) => call.text === fallbackText)).toBe(true);
+          expect(providerFailure).toBeUndefined();
+        } else {
+          expect(requests.map((entry) => entry.model)).toEqual(["answer"]);
+          expect(attempted.some((call) => call.text === fallbackText)).toBe(false);
+          if (result) {
+            expect(result.settledReceipt?.hasPendingDelivery).toBe(true);
+          } else {
+            expect(providerFailure).toBeInstanceOf(Error);
+          }
+        }
         return;
       }
       const result = await dispatch;

--- a/src/auto-reply/reply/agent-runner-core.ts
+++ b/src/auto-reply/reply/agent-runner-core.ts
@@ -41,7 +41,7 @@ import type { InternalGetReplyOptions } from "./get-reply.types.js";
 import { normalizeReplyPayload } from "./normalize-reply.js";
 import { sanitizePendingFinalDeliveryText } from "./pending-final-delivery-state.js";
 import { type FollowupRun, type QueueSettings, scheduleFollowupDrain } from "./queue.js";
-import { normalizeReplyPayloadDirectives } from "./reply-delivery.js";
+import { normalizeReplyPayloadDirectives, type DirectBlockDelivery } from "./reply-delivery.js";
 import { isReplyOperationSuperseded } from "./reply-operation-abort.js";
 import { type ReplyOperation, runAfterReplyOperationClear } from "./reply-run-registry.js";
 import { resolveRoutedDeliveryThreadId } from "./routed-delivery-thread.js";
@@ -208,10 +208,12 @@ export function hasSuccessfulTerminalSourceReplyDelivery(params: {
     didStreamTerminalReply?: () => boolean;
     isAborted: () => boolean;
   } | null;
-  directlySentBlockPayloads?: ReplyPayload[];
+  directBlockDeliveries?: DirectBlockDelivery[];
 }): boolean {
-  const sentTerminalBlock = params.directlySentBlockPayloads?.some(
-    (payload) =>
+  const sentTerminalBlock = params.directBlockDeliveries?.some(
+    ({ payload, outcome, pending }) =>
+      outcome === "delivered" &&
+      !pending &&
       isReplyPayloadTerminalContent(payload) &&
       normalizeReplyPayload(payload, { applyChannelTransforms: false }) !== null,
   );

--- a/src/auto-reply/reply/agent-runner-core.ts
+++ b/src/auto-reply/reply/agent-runner-core.ts
@@ -197,7 +197,7 @@ export function hasSuccessfulSourceReplyDelivery(params: {
   messagingToolSentTargets?: unknown[];
 }): boolean {
   return (
-    (params.blockReplyPipeline?.didStream() && !params.blockReplyPipeline.isAborted()) ||
+    params.blockReplyPipeline?.didStream() ||
     (params.directlySentBlockKeys?.size ?? 0) > 0 ||
     hasVisibleCommittedMessagingToolDeliveryEvidence(params)
   );
@@ -216,9 +216,7 @@ export function hasSuccessfulTerminalSourceReplyDelivery(params: {
       normalizeReplyPayload(payload, { applyChannelTransforms: false }) !== null,
   );
   return (
-    (params.blockReplyPipeline?.didStreamTerminalReply?.() === true &&
-      !params.blockReplyPipeline.isAborted()) ||
-    sentTerminalBlock === true
+    params.blockReplyPipeline?.didStreamTerminalReply?.() === true || sentTerminalBlock === true
   );
 }
 

--- a/src/auto-reply/reply/agent-runner-execution-results.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution-results.test.ts
@@ -282,7 +282,7 @@ describe("executeAgentTurn: result and tool delivery", () => {
           attempt: 1,
           total: 2,
         }),
-      ).toBeNull();
+      ).toBeUndefined();
       return {
         result,
         provider: "openai",
@@ -314,6 +314,7 @@ describe("executeAgentTurn: result and tool delivery", () => {
       didStream: vi.fn(() => false),
       isAborted: vi.fn(() => false),
       hasSentPayload: vi.fn(() => false),
+      hasRetryBlockedDelivery: () => false,
       getSentMediaUrls: vi.fn(() => []),
     };
     state.runEmbeddedAgentMock.mockResolvedValueOnce({ payloads: [], meta: {} });
@@ -330,7 +331,7 @@ describe("executeAgentTurn: result and tool delivery", () => {
           attempt: 1,
           total: 2,
         }),
-      ).toBeNull();
+      ).toBeUndefined();
       return {
         result,
         provider: "openai",

--- a/src/auto-reply/reply/agent-runner-execution.test-support.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test-support.ts
@@ -349,7 +349,7 @@ export async function getExecuteAgentTurnForTest() {
         didLogHeartbeatStrip: outcome.didLogHeartbeatStrip,
         autoCompactionCount: outcome.autoCompactionCount,
         directlySentBlockKeys: outcome.directlySentBlockKeys,
-        directlySentBlockPayloads: outcome.directlySentBlockPayloads,
+        directBlockDeliveries: outcome.directBlockDeliveries,
         terminalFailurePayload: outcome.terminalFailurePayload,
         postCompactionModelFailure: outcome.postCompactionModelFailure,
       };

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -356,6 +356,7 @@ async function executeAgentTurnInternalLoop(
         state: fallbackCycleState,
         presentation,
         directlySentBlockKeys,
+        directBlockDeliveries,
         notifyAgentRunStart,
         signalExecutionPhaseForTyping,
         notifyUserAboutCompaction,

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -46,7 +46,6 @@ import {
   getPluginRuntimeGatewayRequestScope,
 } from "../../plugins/runtime/gateway-request-scope.js";
 import { isInternalMessageChannel } from "../../utils/message-channel.js";
-import type { ReplyPayload } from "../types.js";
 import {
   clearRecoveredAutoFallbackPrimaryProbeSelection,
   resolveRunAfterAutoFallbackPrimaryProbeRecheck,
@@ -76,6 +75,7 @@ import { prepareChannelRunAdmission } from "./channel-run-admission.js";
 import { shouldNotifyUserAboutCompaction } from "./compaction-notice.js";
 import { type CurrentTurnImages, resolveCurrentTurnImages } from "./current-turn-images.js";
 import type { FollowupRun } from "./queue.js";
+import type { DirectBlockDelivery } from "./reply-delivery.js";
 import type { ReplyMediaContext } from "./reply-media-paths.js";
 import { createReplyMediaContext } from "./reply-media-paths.runtime.js";
 import { resolveReplyOperationAbortReason } from "./reply-operation-abort.js";
@@ -129,7 +129,7 @@ async function executeAgentTurnInternalLoop(
   const heartbeatState = { didLogStrip: false };
   // Track payloads sent directly (not via pipeline) during tool flush to avoid duplicates.
   const directlySentBlockKeys = new Set<string>();
-  const directlySentBlockPayloads: Array<ReplyPayload | undefined> = [];
+  const directBlockDeliveries: DirectBlockDelivery[] = [];
   const runnableRun = resolveRunAfterAutoFallbackPrimaryProbeRecheck({
     run: params.followupRun.run,
     entry: params.activeSessionStore?.[params.sessionKey ?? ""] ?? params.getActiveSessionEntry(),
@@ -341,7 +341,7 @@ async function executeAgentTurnInternalLoop(
         turn: params,
         replyMediaContext,
         directlySentBlockKeys,
-        directlySentBlockPayloads,
+        directBlockDeliveries,
         heartbeatState,
       });
       const cycle = await executeAgentFallbackCycle({
@@ -518,9 +518,7 @@ async function executeAgentTurnInternalLoop(
     didLogHeartbeatStrip: heartbeatState.didLogStrip,
     autoCompactionCount: compaction.count,
     directlySentBlockKeys: directlySentBlockKeys.size > 0 ? directlySentBlockKeys : undefined,
-    directlySentBlockPayloads: directlySentBlockPayloads.filter(
-      (payload): payload is ReplyPayload => payload !== undefined,
-    ),
+    directBlockDeliveries,
     ...(terminalFailurePayload ? { terminalFailurePayload } : {}),
     ...(terminalRunFailed && fallbackCycleState.postCompactionModelAttempted
       ? { postCompactionModelFailure: true as const }
@@ -697,7 +695,7 @@ async function executeAgentTurnOutcome(params: AgentTurnParams): Promise<AgentTu
         ...completedCompaction(),
         didLogHeartbeatStrip: internal.didLogHeartbeatStrip,
         directlySentBlockKeys: internal.directlySentBlockKeys,
-        directlySentBlockPayloads: internal.directlySentBlockPayloads,
+        directBlockDeliveries: internal.directBlockDeliveries,
       },
     };
   } catch (error) {

--- a/src/auto-reply/reply/agent-runner-execution.types.ts
+++ b/src/auto-reply/reply/agent-runner-execution.types.ts
@@ -9,6 +9,7 @@ import type { ReplyPayload } from "../types.js";
 import type { BlockReplyPipeline } from "./block-reply-pipeline.js";
 import type { InternalGetReplyOptions } from "./get-reply.types.js";
 import type { FollowupRun } from "./queue.js";
+import type { DirectBlockDelivery } from "./reply-delivery.js";
 import type { ReplyMediaContext } from "./reply-media-paths.js";
 import type { ReplyOperation } from "./reply-run-registry.js";
 import type { TypingSignaler } from "./typing-mode.js";
@@ -56,8 +57,8 @@ export type AgentTurnInternalResult =
       autoCompactionCount: number;
       /** Payload keys sent directly (not via pipeline) during tool flush. */
       directlySentBlockKeys?: Set<string>;
-      /** Payloads successfully sent directly during tool flush. */
-      directlySentBlockPayloads?: ReplyPayload[];
+      /** Delivery receipts for direct tool-flush payloads, including retry custody. */
+      directBlockDeliveries?: DirectBlockDelivery[];
       /** Prepared terminal failure, appended only after delivery evidence settles. */
       terminalFailurePayload?: ReplyPayload;
       postCompactionModelFailure?: true;
@@ -80,7 +81,7 @@ type SettledAgentTurnBase = {
   compaction?: AgentTurnCompaction;
   didLogHeartbeatStrip: boolean;
   directlySentBlockKeys?: Set<string>;
-  directlySentBlockPayloads?: ReplyPayload[];
+  directBlockDeliveries?: DirectBlockDelivery[];
 };
 
 export type SettledAgentTurn = SettledAgentTurnBase &

--- a/src/auto-reply/reply/agent-runner-fallback-candidate.ts
+++ b/src/auto-reply/reply/agent-runner-fallback-candidate.ts
@@ -31,6 +31,7 @@ import {
   resolveRunFastModeForFallbackCandidate,
   resolveRunThinkingLevelForFallbackCandidate,
 } from "./agent-runner-utils.js";
+import { hasBlockReplyDeliveryCustody } from "./block-reply-delivery.js";
 import { beginReplyOperationFinalizationWork } from "./reply-run-finalization-lease.js";
 import {
   bindSourceReplyDeliveryRuntime,
@@ -183,6 +184,9 @@ export async function runAgentFallbackCandidates(params: AgentFallbackCycleParam
       behavior: {
         kind: "channel-delivery",
         readDeliveryEvidence: () => ({
+          hasRetryBlockedDelivery:
+            turn.blockReplyPipeline?.hasRetryBlockedDelivery() === true ||
+            params.directBlockDeliveries.some(hasBlockReplyDeliveryCustody),
           hasDirectlySentBlockReply: params.directlySentBlockKeys.size > 0,
           hasBlockReplyPipelineOutput: Boolean(
             turn.blockReplyPipeline?.hasBuffered() || turn.blockReplyPipeline?.didStream(),

--- a/src/auto-reply/reply/agent-runner-fallback-cycle.types.ts
+++ b/src/auto-reply/reply/agent-runner-fallback-cycle.types.ts
@@ -20,6 +20,7 @@ import type {
 import type { createAgentTurnPresentation } from "./agent-runner-presentation.js";
 import type { AgentTurnTimingTracker } from "./agent-runner-turn-timing.js";
 import type { FollowupRun } from "./queue.js";
+import type { DirectBlockDelivery } from "./reply-delivery.js";
 
 /** Inputs prepared once per fallback candidate and consumed by either runtime adapter. */
 export type AgentFallbackCandidateCommonParams = {
@@ -114,6 +115,7 @@ export type AgentFallbackCycleParams = {
   state: AgentFallbackCycleState;
   presentation: ReturnType<typeof createAgentTurnPresentation>;
   directlySentBlockKeys: Set<string>;
+  directBlockDeliveries: DirectBlockDelivery[];
   notifyAgentRunStart: () => void;
   signalExecutionPhaseForTyping: NonNullable<RunEmbeddedAgentParams["onExecutionPhase"]>;
   notifyUserAboutCompaction: boolean;

--- a/src/auto-reply/reply/agent-runner-payloads.test.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.test.ts
@@ -26,6 +26,7 @@ import type { ReplyPayload } from "../types.js";
 import { buildReplyPayloads } from "./agent-runner-payloads.js";
 import { createBlockReplyContentKey, createBlockReplyPipeline } from "./block-reply-pipeline.js";
 import { normalizeReplyPayload } from "./normalize-reply.js";
+import type { DirectBlockDelivery } from "./reply-delivery.js";
 import { createReplyToModeFilterForChannel } from "./reply-threading.js";
 
 const baseParams = {
@@ -57,7 +58,7 @@ type DirectBlockDedupeCase = {
   name: string;
   keyPayloads: Array<Parameters<typeof createBlockReplyContentKey>[0]>;
   payloads: TestReplyPayloadParams["payloads"];
-  directlySentBlockPayloads?: TestReplyPayloadParams["directlySentBlockPayloads"];
+  directBlockPayloads?: ReplyPayload[];
   params?: Partial<TestReplyPayloadParams>;
   expected?: Record<string, unknown>;
 };
@@ -1380,7 +1381,7 @@ describe("buildReplyPayloads media filter integration", () => {
     ...[false, true].map((blockStreamingEnabled) => ({
       name: `drops a final caption already sent with direct media (streaming: ${blockStreamingEnabled})`,
       keyPayloads: [{ text: "response", mediaUrl: "/tmp/fetched.png" }],
-      directlySentBlockPayloads: [
+      directBlockPayloads: [
         setReplyPayloadMetadata(
           { text: "response", mediaUrl: "/tmp/fetched.png" },
           { assistantMessageIndex: 1 },
@@ -1392,7 +1393,7 @@ describe("buildReplyPayloads media filter integration", () => {
     {
       name: "preserves the same caption from a different assistant message",
       keyPayloads: [{ text: "response", mediaUrl: "/tmp/fetched.png" }],
-      directlySentBlockPayloads: [
+      directBlockPayloads: [
         setReplyPayloadMetadata(
           { text: "response", mediaUrl: "/tmp/fetched.png" },
           { assistantMessageIndex: 1 },
@@ -1416,7 +1417,7 @@ describe("buildReplyPayloads media filter integration", () => {
     {
       name: "keeps only final media when the text was sent as a direct block",
       keyPayloads: [{ text: "response" }],
-      directlySentBlockPayloads: [{ text: "response" }],
+      directBlockPayloads: [{ text: "response" }],
       payloads: [{ text: "response\n\nMEDIA:/tmp/generated.png" }],
       expected: {
         text: undefined,
@@ -1427,7 +1428,7 @@ describe("buildReplyPayloads media filter integration", () => {
     {
       name: "keeps only final media after a direct block without a streaming pipeline",
       keyPayloads: [{ text: "response" }],
-      directlySentBlockPayloads: [{ text: "response" }],
+      directBlockPayloads: [{ text: "response" }],
       payloads: [{ text: "response\n\nMEDIA:/tmp/generated.png" }],
       params: { blockStreamingEnabled: true },
       expected: {
@@ -1446,7 +1447,7 @@ describe("buildReplyPayloads media filter integration", () => {
     {
       name: "keeps only final media after multiple direct text blocks",
       keyPayloads: [{ text: "Preview" }, { text: " below" }],
-      directlySentBlockPayloads: [{ text: "Preview" }, { text: " below" }],
+      directBlockPayloads: [{ text: "Preview" }, { text: " below" }],
       payloads: [{ text: "Preview below\n\nMEDIA:/tmp/generated.png" }],
       params: { blockStreamingEnabled: true },
       expected: {
@@ -1458,7 +1459,7 @@ describe("buildReplyPayloads media filter integration", () => {
     {
       name: "keeps only final media after repeated identical direct text blocks",
       keyPayloads: [{ text: "ha" }],
-      directlySentBlockPayloads: [{ text: "ha" }, { text: "ha" }],
+      directBlockPayloads: [{ text: "ha" }, { text: "ha" }],
       payloads: [{ text: "haha\n\nMEDIA:/tmp/generated.png" }],
       params: { blockStreamingEnabled: true },
       expected: {
@@ -1470,7 +1471,7 @@ describe("buildReplyPayloads media filter integration", () => {
     {
       name: "keeps only media not already sent with a direct block",
       keyPayloads: [{ text: "response", mediaUrl: "/tmp/already.png" }],
-      directlySentBlockPayloads: [{ text: "response", mediaUrl: "/tmp/already.png" }],
+      directBlockPayloads: [{ text: "response", mediaUrl: "/tmp/already.png" }],
       payloads: [{ text: "response", mediaUrls: ["/tmp/already.png", "/tmp/new.png"] }],
       params: { blockStreamingEnabled: true },
       expected: { text: undefined, mediaUrl: undefined, mediaUrls: ["/tmp/new.png"] },
@@ -1478,15 +1479,22 @@ describe("buildReplyPayloads media filter integration", () => {
     {
       name: "ignores direct status notices when matching final text",
       keyPayloads: [{ text: "Compacting", isStatusNotice: true }, { text: "response" }],
-      directlySentBlockPayloads: [{ text: "response" }],
+      directBlockPayloads: [{ text: "response" }],
       payloads: [{ text: "response\n\nMEDIA:/tmp/generated.png" }],
       params: { blockStreamingEnabled: true },
       expected: { text: undefined, mediaUrls: ["/tmp/generated.png"] },
     },
-  ])("$name", async ({ keyPayloads, payloads, directlySentBlockPayloads, params, expected }) => {
+  ])("$name", async ({ keyPayloads, payloads, directBlockPayloads, params, expected }) => {
     const { replyPayloads } = await buildTestReplyPayloads({
       directlySentBlockKeys: new Set(keyPayloads.map(createBlockReplyContentKey)),
-      ...(directlySentBlockPayloads ? { directlySentBlockPayloads } : {}),
+      ...(directBlockPayloads
+        ? {
+            directBlockDeliveries: directBlockPayloads.map((payload): DirectBlockDelivery => ({
+              payload,
+              outcome: "delivered",
+            })),
+          }
+        : {}),
       payloads,
       ...params,
     });
@@ -1498,8 +1506,11 @@ describe("buildReplyPayloads media filter integration", () => {
   });
 
   it("preserves final text when internal whitespace changed", async () => {
-    const directlySentBlockPayloads = [
-      setReplyPayloadMetadata({ text: "constx=1" }, { assistantMessageIndex: 1 }),
+    const directBlockDeliveries: DirectBlockDelivery[] = [
+      {
+        payload: setReplyPayloadMetadata({ text: "constx=1" }, { assistantMessageIndex: 1 }),
+        outcome: "delivered",
+      },
     ];
     const finalPayload = setReplyPayloadMetadata(
       { text: "const x = 1\n\nMEDIA:/tmp/generated.png" },
@@ -1508,7 +1519,7 @@ describe("buildReplyPayloads media filter integration", () => {
 
     const { replyPayloads } = await buildTestReplyPayloads({
       blockStreamingEnabled: true,
-      directlySentBlockPayloads,
+      directBlockDeliveries,
       payloads: [finalPayload],
     });
 
@@ -1532,7 +1543,10 @@ describe("buildReplyPayloads media filter integration", () => {
 
     const { replyPayloads } = await buildTestReplyPayloads({
       blockStreamingEnabled: true,
-      directlySentBlockPayloads: [firstDirect, secondDirect],
+      directBlockDeliveries: [
+        { payload: firstDirect, outcome: "delivered" },
+        { payload: secondDirect, outcome: "delivered" },
+      ],
       payloads: [firstFinal, secondFinal],
     });
 

--- a/src/auto-reply/reply/agent-runner-payloads.test.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.test.ts
@@ -24,7 +24,7 @@ import {
 } from "../reply-payload.js";
 import type { ReplyPayload } from "../types.js";
 import { buildReplyPayloads } from "./agent-runner-payloads.js";
-import { createBlockReplyContentKey, createBlockReplyPipeline } from "./block-reply-pipeline.js";
+import { createBlockReplyPipeline } from "./block-reply-pipeline.js";
 import { normalizeReplyPayload } from "./normalize-reply.js";
 import type { DirectBlockDelivery } from "./reply-delivery.js";
 import { createReplyToModeFilterForChannel } from "./reply-threading.js";
@@ -56,9 +56,8 @@ type ReplyRouteDedupeCase = {
 
 type DirectBlockDedupeCase = {
   name: string;
-  keyPayloads: Array<Parameters<typeof createBlockReplyContentKey>[0]>;
   payloads: TestReplyPayloadParams["payloads"];
-  directBlockPayloads?: ReplyPayload[];
+  directBlockPayloads: ReplyPayload[];
   params?: Partial<TestReplyPayloadParams>;
   expected?: Record<string, unknown>;
 };
@@ -962,6 +961,7 @@ describe("buildReplyPayloads media filter integration", () => {
       flush: async () => {},
       stop: () => {},
       hasBuffered: () => false,
+      hasRetryBlockedDelivery: () => false,
       getSentMediaUrls: () => ["file:///tmp/voice.ogg"],
     };
 
@@ -1000,6 +1000,7 @@ describe("buildReplyPayloads media filter integration", () => {
       flush: async () => {},
       stop: () => {},
       hasBuffered: () => false,
+      hasRetryBlockedDelivery: () => false,
       getSentMediaUrls: () => ["file:///tmp/outbound/voice.ogg"],
     };
 
@@ -1022,6 +1023,7 @@ describe("buildReplyPayloads media filter integration", () => {
       flush: async () => {},
       stop: () => {},
       hasBuffered: () => false,
+      hasRetryBlockedDelivery: () => false,
       getSentMediaUrls: () => [],
     };
     // The pipeline streamed some partial content, but the final text payload was
@@ -1049,6 +1051,7 @@ describe("buildReplyPayloads media filter integration", () => {
       flush: async () => {},
       stop: () => {},
       hasBuffered: () => false,
+      hasRetryBlockedDelivery: () => false,
       getSentMediaUrls: () => [],
     };
     // The final text-only payload matches what the pipeline already sent,
@@ -1073,6 +1076,7 @@ describe("buildReplyPayloads media filter integration", () => {
       flush: async () => {},
       stop: () => {},
       hasBuffered: () => false,
+      hasRetryBlockedDelivery: () => false,
       getSentMediaUrls: () => [],
     };
 
@@ -1095,6 +1099,7 @@ describe("buildReplyPayloads media filter integration", () => {
       flush: async () => {},
       stop: () => {},
       hasBuffered: () => false,
+      hasRetryBlockedDelivery: () => false,
       getSentMediaUrls: () => [],
     };
     const presentation = {
@@ -1124,6 +1129,7 @@ describe("buildReplyPayloads media filter integration", () => {
       flush: async () => {},
       stop: () => {},
       hasBuffered: () => false,
+      hasRetryBlockedDelivery: () => false,
       getSentMediaUrls: () => [],
     };
 
@@ -1149,6 +1155,7 @@ describe("buildReplyPayloads media filter integration", () => {
       flush: async () => {},
       stop: () => {},
       hasBuffered: () => false,
+      hasRetryBlockedDelivery: () => false,
       getSentMediaUrls: () => ["/tmp/generated.png"],
     };
 
@@ -1195,6 +1202,7 @@ describe("buildReplyPayloads media filter integration", () => {
       flush: async () => {},
       stop: () => {},
       hasBuffered: () => false,
+      hasRetryBlockedDelivery: () => false,
       getSentMediaUrls: () => [],
     };
 
@@ -1380,7 +1388,6 @@ describe("buildReplyPayloads media filter integration", () => {
   it.each<DirectBlockDedupeCase>([
     ...[false, true].map((blockStreamingEnabled) => ({
       name: `drops a final caption already sent with direct media (streaming: ${blockStreamingEnabled})`,
-      keyPayloads: [{ text: "response", mediaUrl: "/tmp/fetched.png" }],
       directBlockPayloads: [
         setReplyPayloadMetadata(
           { text: "response", mediaUrl: "/tmp/fetched.png" },
@@ -1392,7 +1399,6 @@ describe("buildReplyPayloads media filter integration", () => {
     })),
     {
       name: "preserves the same caption from a different assistant message",
-      keyPayloads: [{ text: "response", mediaUrl: "/tmp/fetched.png" }],
       directBlockPayloads: [
         setReplyPayloadMetadata(
           { text: "response", mediaUrl: "/tmp/fetched.png" },
@@ -1402,21 +1408,9 @@ describe("buildReplyPayloads media filter integration", () => {
       payloads: [setReplyPayloadMetadata({ text: "response" }, { assistantMessageIndex: 2 })],
       expected: { text: "response" },
     },
-    {
-      name: "deduplicates final payloads against directly sent block keys regardless of replyToId",
-      keyPayloads: [{ text: "response", replyToId: "post-1" }],
-      payloads: [{ text: "response" }],
-      params: { blockStreamingEnabled: false, blockReplyPipeline: null, replyToMode: "off" },
-    },
-    {
-      name: "deduplicates final payloads against directly sent block keys when streaming is enabled without a pipeline",
-      keyPayloads: [{ text: "response", replyToId: "post-1" }],
-      payloads: [{ text: "response" }],
-      params: { blockStreamingEnabled: true, blockReplyPipeline: null, replyToMode: "off" },
-    },
+
     {
       name: "keeps only final media when the text was sent as a direct block",
-      keyPayloads: [{ text: "response" }],
       directBlockPayloads: [{ text: "response" }],
       payloads: [{ text: "response\n\nMEDIA:/tmp/generated.png" }],
       expected: {
@@ -1427,7 +1421,6 @@ describe("buildReplyPayloads media filter integration", () => {
     },
     {
       name: "keeps only final media after a direct block without a streaming pipeline",
-      keyPayloads: [{ text: "response" }],
       directBlockPayloads: [{ text: "response" }],
       payloads: [{ text: "response\n\nMEDIA:/tmp/generated.png" }],
       params: { blockStreamingEnabled: true },
@@ -1437,16 +1430,9 @@ describe("buildReplyPayloads media filter integration", () => {
         mediaUrls: ["/tmp/generated.png"],
       },
     },
-    {
-      name: "keeps unmatched text finals when unrelated direct blocks were sent",
-      keyPayloads: [{ mediaUrl: "/tmp/other.png" }],
-      payloads: [{ text: "new final response" }],
-      params: { blockStreamingEnabled: true },
-      expected: { text: "new final response" },
-    },
+
     {
       name: "keeps only final media after multiple direct text blocks",
-      keyPayloads: [{ text: "Preview" }, { text: " below" }],
       directBlockPayloads: [{ text: "Preview" }, { text: " below" }],
       payloads: [{ text: "Preview below\n\nMEDIA:/tmp/generated.png" }],
       params: { blockStreamingEnabled: true },
@@ -1458,7 +1444,6 @@ describe("buildReplyPayloads media filter integration", () => {
     },
     {
       name: "keeps only final media after repeated identical direct text blocks",
-      keyPayloads: [{ text: "ha" }],
       directBlockPayloads: [{ text: "ha" }, { text: "ha" }],
       payloads: [{ text: "haha\n\nMEDIA:/tmp/generated.png" }],
       params: { blockStreamingEnabled: true },
@@ -1470,7 +1455,6 @@ describe("buildReplyPayloads media filter integration", () => {
     },
     {
       name: "keeps only media not already sent with a direct block",
-      keyPayloads: [{ text: "response", mediaUrl: "/tmp/already.png" }],
       directBlockPayloads: [{ text: "response", mediaUrl: "/tmp/already.png" }],
       payloads: [{ text: "response", mediaUrls: ["/tmp/already.png", "/tmp/new.png"] }],
       params: { blockStreamingEnabled: true },
@@ -1478,23 +1462,17 @@ describe("buildReplyPayloads media filter integration", () => {
     },
     {
       name: "ignores direct status notices when matching final text",
-      keyPayloads: [{ text: "Compacting", isStatusNotice: true }, { text: "response" }],
-      directBlockPayloads: [{ text: "response" }],
+      directBlockPayloads: [{ text: "Compacting", isStatusNotice: true }, { text: "response" }],
       payloads: [{ text: "response\n\nMEDIA:/tmp/generated.png" }],
       params: { blockStreamingEnabled: true },
       expected: { text: undefined, mediaUrls: ["/tmp/generated.png"] },
     },
-  ])("$name", async ({ keyPayloads, payloads, directBlockPayloads, params, expected }) => {
+  ])("$name", async ({ payloads, directBlockPayloads, params, expected }) => {
     const { replyPayloads } = await buildTestReplyPayloads({
-      directlySentBlockKeys: new Set(keyPayloads.map(createBlockReplyContentKey)),
-      ...(directBlockPayloads
-        ? {
-            directBlockDeliveries: directBlockPayloads.map((payload): DirectBlockDelivery => ({
-              payload,
-              outcome: "delivered",
-            })),
-          }
-        : {}),
+      directBlockDeliveries: directBlockPayloads.map((payload): DirectBlockDelivery => ({
+        payload,
+        outcome: "delivered",
+      })),
       payloads,
       ...params,
     });

--- a/src/auto-reply/reply/agent-runner-payloads.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.ts
@@ -364,6 +364,9 @@ export async function buildReplyPayloads(params: {
     if (payload.isError || payload.isFallbackNotice) {
       return payload;
     }
+    if (params.blockReplyPipeline?.isFinalPayloadRetryBlocked?.(payload)) {
+      return null;
+    }
     const reply = resolveSendableOutboundReplyParts(payload);
     if (!reply.hasMedia) {
       // Aggregate coverage suppresses plain text split across streamed blocks; rich content needs
@@ -390,10 +393,14 @@ export async function buildReplyPayloads(params: {
       mediaUrls: undefined,
       audioAsVoice: undefined,
     });
-    const textWasSent = params.blockReplyPipeline?.hasSentPayload(textOnlyPayload)
-      ? true
-      : hasDirectlySentText(textOnlyPayload);
-    if (!textWasSent) {
+    const textShouldBeOmitted =
+      params.blockReplyPipeline?.hasSentPayload(textOnlyPayload) ||
+      params.blockReplyPipeline?.isFinalPayloadRetryBlocked?.(
+        copyReplyPayloadMetadata(payload, { text: payload.text }),
+      )
+        ? true
+        : hasDirectlySentText(textOnlyPayload);
+    if (!textShouldBeOmitted) {
       return payload;
     }
     return copyReplyPayloadMetadata(payload, {

--- a/src/auto-reply/reply/agent-runner-payloads.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.ts
@@ -424,11 +424,12 @@ export async function buildReplyPayloads(params: {
               : (preserveUnsentMediaAfterBlockSend(payload) ?? []),
           )
         : dedupedPayloads;
-  const blockSentMediaUrls = await normalizeSentMediaUrlsForDedupe({
+  const blockMediaUrlsToOmit = await normalizeSentMediaUrlsForDedupe({
     sentMediaUrls: [
       ...(params.blockStreamingEnabled
         ? (params.blockReplyPipeline?.getSentMediaUrls() ?? [])
         : []),
+      ...(params.blockReplyPipeline?.getRetryBlockedMediaUrls?.() ?? []),
       ...(params.directlySentBlockPayloads ?? []).flatMap(
         (payload) => resolveSendableOutboundReplyParts(payload).mediaUrls,
       ),
@@ -436,10 +437,10 @@ export async function buildReplyPayloads(params: {
     normalizeMediaPaths: params.normalizeMediaPaths,
   });
   const filteredPayloads =
-    blockSentMediaUrls.length > 0
+    blockMediaUrlsToOmit.length > 0
       ? (await loadReplyPayloadsDedupeRuntime()).filterMessagingToolMediaDuplicates({
           payloads: contentSuppressedPayloads,
-          sentMediaUrls: blockSentMediaUrls,
+          sentMediaUrls: blockMediaUrlsToOmit,
         })
       : contentSuppressedPayloads;
   return {

--- a/src/auto-reply/reply/agent-runner-payloads.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.ts
@@ -167,8 +167,6 @@ export async function buildReplyPayloads(params: {
   silentExpected?: boolean;
   blockStreamingEnabled: boolean;
   blockReplyPipeline: BlockReplyPipeline | null;
-  /** Payload keys sent directly (not via pipeline) during tool flush. */
-  directlySentBlockKeys?: Set<string>;
   /** Direct receipts distinguish confirmed sends from retained retry custody. */
   directBlockDeliveries?: DirectBlockDelivery[];
   replyToMode: ReplyToMode;
@@ -341,17 +339,12 @@ export async function buildReplyPayloads(params: {
   const isDirectBlockRetryBlocked = (payload: ReplyPayload) => {
     const contentKey = createBlockReplyContentKey(payload);
     const assistantMessageIndex = getReplyPayloadMetadata(payload)?.assistantMessageIndex;
-    return (
-      (!params.directBlockDeliveries?.length &&
-        params.directlySentBlockKeys?.has(contentKey) === true) ||
-      retryBlockedDirectPayloads.some(
-        (sentPayload) =>
-          isReplyPayloadTerminalContent(sentPayload) &&
-          (assistantMessageIndex === undefined ||
-            getReplyPayloadMetadata(sentPayload)?.assistantMessageIndex ===
-              assistantMessageIndex) &&
-          createBlockReplyContentKey(sentPayload) === contentKey,
-      )
+    return retryBlockedDirectPayloads.some(
+      (sentPayload) =>
+        isReplyPayloadTerminalContent(sentPayload) &&
+        (assistantMessageIndex === undefined ||
+          getReplyPayloadMetadata(sentPayload)?.assistantMessageIndex === assistantMessageIndex) &&
+        createBlockReplyContentKey(sentPayload) === contentKey,
     );
   };
   const isDirectTextRetryBlocked = (payload: ReplyPayload): boolean => {
@@ -424,7 +417,7 @@ export async function buildReplyPayloads(params: {
             ? []
             : (preserveUnsentMediaAfterBlockSend(payload) ?? []),
         )
-      : params.directlySentBlockKeys?.size || retryBlockedDirectPayloads.length > 0
+      : retryBlockedDirectPayloads.length > 0
         ? dedupedPayloads.flatMap((payload) =>
             isDirectBlockRetryBlocked(payload)
               ? []

--- a/src/auto-reply/reply/agent-runner-payloads.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.ts
@@ -15,6 +15,7 @@ import { stripHeartbeatToken } from "../heartbeat.js";
 import {
   copyReplyPayloadMetadata,
   getReplyPayloadMetadata,
+  isReplyPayloadTerminalContent,
   setReplyPayloadMetadata,
 } from "../reply-payload.js";
 import type { OriginatingChannelType } from "../templating.js";
@@ -23,7 +24,8 @@ import type { ReplyPayload, ReplyThreadingPolicy } from "../types.js";
 import { formatBunFetchSocketError, isBunFetchSocketError } from "./agent-runner-utils.js";
 import { createBlockReplyContentKey, type BlockReplyPipeline } from "./block-reply-pipeline.js";
 import { resolveOriginMessageProvider } from "./origin-routing.js";
-import { normalizeReplyPayloadDirectives } from "./reply-delivery.js";
+import { normalizeReplyPayloadDirectives, type DirectBlockDelivery } from "./reply-delivery.js";
+import { shouldRetryReplyDispatch } from "./reply-dispatch-outcome.js";
 import {
   applyReplyThreading,
   isRenderablePayload,
@@ -167,8 +169,8 @@ export async function buildReplyPayloads(params: {
   blockReplyPipeline: BlockReplyPipeline | null;
   /** Payload keys sent directly (not via pipeline) during tool flush. */
   directlySentBlockKeys?: Set<string>;
-  /** Payloads successfully sent directly during tool flush. */
-  directlySentBlockPayloads?: ReplyPayload[];
+  /** Direct receipts distinguish confirmed sends from retained retry custody. */
+  directBlockDeliveries?: DirectBlockDelivery[];
   replyToMode: ReplyToMode;
   replyToChannel?: OriginatingChannelType;
   currentMessageId?: string;
@@ -316,48 +318,53 @@ export async function buildReplyPayloads(params: {
       );
     }
   }
-  const directlySentTextFragmentsByAssistantMessage = new Map<number | undefined, string[]>();
-  for (const sentPayload of params.directlySentBlockPayloads ?? []) {
+  const retryBlockedDirectPayloads = (params.directBlockDeliveries ?? [])
+    .filter((delivery) => delivery.pending || !shouldRetryReplyDispatch(delivery.outcome))
+    .map((delivery) => delivery.payload);
+  const directTextFragmentsByAssistantMessage = new Map<number | undefined, string[]>();
+  for (const sentPayload of retryBlockedDirectPayloads) {
+    if (!isReplyPayloadTerminalContent(sentPayload)) {
+      continue;
+    }
     const sentText = sentPayload.text ?? resolveSendableOutboundReplyParts(sentPayload).trimmedText;
     if (!sentText) {
       continue;
     }
     const assistantMessageIndex = getReplyPayloadMetadata(sentPayload)?.assistantMessageIndex;
-    const fragments = directlySentTextFragmentsByAssistantMessage.get(assistantMessageIndex);
+    const fragments = directTextFragmentsByAssistantMessage.get(assistantMessageIndex);
     if (fragments) {
       fragments.push(sentText);
     } else {
-      directlySentTextFragmentsByAssistantMessage.set(assistantMessageIndex, [sentText]);
+      directTextFragmentsByAssistantMessage.set(assistantMessageIndex, [sentText]);
     }
   }
-  const isDirectlySentBlockPayload = (payload: ReplyPayload) => {
+  const isDirectBlockRetryBlocked = (payload: ReplyPayload) => {
     const contentKey = createBlockReplyContentKey(payload);
-    if (!params.directlySentBlockKeys?.has(contentKey)) {
-      return false;
-    }
     const assistantMessageIndex = getReplyPayloadMetadata(payload)?.assistantMessageIndex;
     return (
-      assistantMessageIndex === undefined ||
-      !params.directlySentBlockPayloads?.length ||
-      params.directlySentBlockPayloads.some(
+      (!params.directBlockDeliveries?.length &&
+        params.directlySentBlockKeys?.has(contentKey) === true) ||
+      retryBlockedDirectPayloads.some(
         (sentPayload) =>
-          getReplyPayloadMetadata(sentPayload)?.assistantMessageIndex === assistantMessageIndex &&
+          isReplyPayloadTerminalContent(sentPayload) &&
+          (assistantMessageIndex === undefined ||
+            getReplyPayloadMetadata(sentPayload)?.assistantMessageIndex ===
+              assistantMessageIndex) &&
           createBlockReplyContentKey(sentPayload) === contentKey,
       )
     );
   };
-  const hasDirectlySentText = (payload: ReplyPayload): boolean => {
-    if (isDirectlySentBlockPayload(payload)) {
+  const isDirectTextRetryBlocked = (payload: ReplyPayload): boolean => {
+    if (isDirectBlockRetryBlocked(payload)) {
       return true;
     }
     const text = resolveSendableOutboundReplyParts(payload).trimmedText;
-    if (!text || !params.directlySentBlockPayloads?.length) {
+    if (!text || !retryBlockedDirectPayloads.length) {
       return false;
     }
     const normalizedText = text.trim();
     const assistantMessageIndex = getReplyPayloadMetadata(payload)?.assistantMessageIndex;
-    const applicableFragments =
-      directlySentTextFragmentsByAssistantMessage.get(assistantMessageIndex);
+    const applicableFragments = directTextFragmentsByAssistantMessage.get(assistantMessageIndex);
     return applicableFragments ? applicableFragments.join("").trim() === normalizedText : false;
   };
   const preserveUnsentMediaAfterBlockSend = (payload: ReplyPayload): ReplyPayload | null => {
@@ -378,7 +385,7 @@ export async function buildReplyPayloads(params: {
       );
       const wasSent = hasRichContent
         ? params.blockReplyPipeline?.hasSentExactPayload?.(payload)
-        : params.blockReplyPipeline?.hasSentPayload(payload) || hasDirectlySentText(payload);
+        : params.blockReplyPipeline?.hasSentPayload(payload) || isDirectTextRetryBlocked(payload);
       if (wasSent) {
         return null;
       }
@@ -399,7 +406,7 @@ export async function buildReplyPayloads(params: {
         copyReplyPayloadMetadata(payload, { text: payload.text }),
       )
         ? true
-        : hasDirectlySentText(textOnlyPayload);
+        : isDirectTextRetryBlocked(textOnlyPayload);
     if (!textShouldBeOmitted) {
       return payload;
     }
@@ -413,13 +420,13 @@ export async function buildReplyPayloads(params: {
     ? dedupedPayloads.flatMap((payload) => preserveUnsentMediaAfterBlockSend(payload) ?? [])
     : params.blockStreamingEnabled
       ? dedupedPayloads.flatMap((payload) =>
-          params.blockReplyPipeline?.hasSentPayload(payload) || isDirectlySentBlockPayload(payload)
+          params.blockReplyPipeline?.hasSentPayload(payload) || isDirectBlockRetryBlocked(payload)
             ? []
             : (preserveUnsentMediaAfterBlockSend(payload) ?? []),
         )
-      : params.directlySentBlockKeys?.size
+      : params.directlySentBlockKeys?.size || retryBlockedDirectPayloads.length > 0
         ? dedupedPayloads.flatMap((payload) =>
-            isDirectlySentBlockPayload(payload)
+            isDirectBlockRetryBlocked(payload)
               ? []
               : (preserveUnsentMediaAfterBlockSend(payload) ?? []),
           )
@@ -430,7 +437,7 @@ export async function buildReplyPayloads(params: {
         ? (params.blockReplyPipeline?.getSentMediaUrls() ?? [])
         : []),
       ...(params.blockReplyPipeline?.getRetryBlockedMediaUrls?.() ?? []),
-      ...(params.directlySentBlockPayloads ?? []).flatMap(
+      ...retryBlockedDirectPayloads.flatMap(
         (payload) => resolveSendableOutboundReplyParts(payload).mediaUrls,
       ),
     ],

--- a/src/auto-reply/reply/agent-runner-presentation.test.ts
+++ b/src/auto-reply/reply/agent-runner-presentation.test.ts
@@ -70,7 +70,7 @@ function createPresentation(
     turn,
     replyMediaContext: { normalizePayload: async (payload) => payload },
     directlySentBlockKeys: new Set(),
-    directlySentBlockPayloads: [],
+    directBlockDeliveries: [],
     heartbeatState: { didLogStrip: false },
   });
 }

--- a/src/auto-reply/reply/agent-runner-presentation.ts
+++ b/src/auto-reply/reply/agent-runner-presentation.ts
@@ -13,7 +13,7 @@ import {
 } from "../tokens.js";
 import type { ReplyPayload } from "../types.js";
 import type { AgentTurnParams } from "./agent-runner-execution.types.js";
-import { createBlockReplyDeliveryHandler } from "./reply-delivery.js";
+import { createBlockReplyDeliveryHandler, type DirectBlockDelivery } from "./reply-delivery.js";
 import type { ReplyMediaContext } from "./reply-media-paths.js";
 import { hasCommittedReplyOperationOutcome } from "./reply-run-registry.js";
 
@@ -36,7 +36,7 @@ export function createAgentTurnPresentation(params: {
   turn: AgentTurnParams;
   replyMediaContext: ReplyMediaContext;
   directlySentBlockKeys: Set<string>;
-  directlySentBlockPayloads: Array<ReplyPayload | undefined>;
+  directBlockDeliveries: DirectBlockDelivery[];
   heartbeatState: { didLogStrip: boolean };
 }): AgentTurnPresentation {
   const classifyStreamingPartial = (payload: ReplyPayload): { text?: string; skip: boolean } => {
@@ -147,7 +147,7 @@ export function createAgentTurnPresentation(params: {
         blockStreamingEnabled: params.turn.blockStreamingEnabled,
         blockReplyPipeline,
         directlySentBlockKeys: params.directlySentBlockKeys,
-        directlySentBlockPayloads: params.directlySentBlockPayloads,
+        directBlockDeliveries: params.directBlockDeliveries,
       })
     : undefined;
 

--- a/src/auto-reply/reply/agent-runner-result-accounting.ts
+++ b/src/auto-reply/reply/agent-runner-result-accounting.ts
@@ -112,7 +112,7 @@ export async function accountAgentTurn(context: AgentTurnAccountingContext) {
   const fallbackExhausted = execution.fallback.exhausted;
   const fallbackAttempts = execution.fallback.attempts;
   const directlySentBlockKeys = execution.directlySentBlockKeys;
-  const directlySentBlockPayloads = execution.directlySentBlockPayloads;
+  const directBlockDeliveries = execution.directBlockDeliveries;
   const terminalFailurePayload = execution.terminalFailurePayload;
   const { autoCompactionCount, didLogHeartbeatStrip } = execution;
 
@@ -345,7 +345,7 @@ export async function accountAgentTurn(context: AgentTurnAccountingContext) {
     contextTokensUsed,
     didLogHeartbeatStrip,
     directlySentBlockKeys,
-    directlySentBlockPayloads,
+    directBlockDeliveries,
     fallbackAttempts,
     fallbackExhausted,
     fallbackTransition,

--- a/src/auto-reply/reply/agent-runner-result-payloads.ts
+++ b/src/auto-reply/reply/agent-runner-result-payloads.ts
@@ -53,6 +53,7 @@ import type { PendingContinuationSettlement } from "./get-reply.types.js";
 import { attachMcpAppChannelAction } from "./mcp-app-channel-action.js";
 import { attachMcpConnectChannelAction } from "./mcp-connect-channel-action.js";
 import { normalizeReplyPayload } from "./normalize-reply.js";
+import { shouldRetryReplyDispatch } from "./reply-dispatch-outcome.js";
 import { createReplyToModeFilterForChannel } from "./reply-threading.js";
 import { buildSessionsYieldAcknowledgmentPayload } from "./sessions-yield-acknowledgment.js";
 import { resolveStrandedReplyRecovery } from "./stranded-reply-recovery.js";
@@ -89,7 +90,7 @@ export async function prepareReplyAgentPayloads(state: {
     configuredFallbackModel,
     contextTokensUsed,
     directlySentBlockKeys,
-    directlySentBlockPayloads,
+    directBlockDeliveries,
     fallbackAttempts,
     fallbackExhausted,
     fallbackTransition,
@@ -149,7 +150,7 @@ export async function prepareReplyAgentPayloads(state: {
   const successfulTerminalDelivery =
     hasSuccessfulTerminalSourceReplyDelivery({
       blockReplyPipeline,
-      directlySentBlockPayloads,
+      directBlockDeliveries,
     }) || hasCompletedTerminalDeliveryEvidence(runResult);
   // Compaction notices are progress, not a terminal reply. Dispatcher-backed
   // delivery settles after this run returns, so it cannot prove turn completion here.
@@ -180,7 +181,13 @@ export async function prepareReplyAgentPayloads(state: {
           committedMessagingToolSourceReplyDelivery ||
           runResult.didSendDeterministicApprovalPrompt === true,
       });
-  const retryBlockedSourceReply = blockReplyPipeline?.hasRetryBlockedTerminalDelivery?.() === true;
+  const retryBlockedSourceReply =
+    blockReplyPipeline?.hasRetryBlockedTerminalDelivery?.() === true ||
+    directBlockDeliveries?.some(
+      ({ payload, outcome, pending }) =>
+        isReplyPayloadTerminalContent(payload) &&
+        (pending || (outcome !== "delivered" && !shouldRetryReplyDispatch(outcome))),
+    ) === true;
   const emptyInteractiveReplyPayload =
     terminalFailurePayload || retryBlockedSourceReply
       ? undefined
@@ -278,7 +285,7 @@ export async function prepareReplyAgentPayloads(state: {
       blockStreamingEnabled,
       blockReplyPipeline,
       directlySentBlockKeys,
-      directlySentBlockPayloads,
+      directBlockDeliveries,
       replyToMode,
       replyToChannel,
       currentMessageId,

--- a/src/auto-reply/reply/agent-runner-result-payloads.ts
+++ b/src/auto-reply/reply/agent-runner-result-payloads.ts
@@ -49,11 +49,11 @@ import {
 import type { accountAgentTurn } from "./agent-runner-result-accounting.js";
 import type { FinalizeReplyAgentRunInput } from "./agent-runner-result.types.js";
 import { resolveResponseUsageLine } from "./agent-runner-usage-line.js";
+import { hasBlockReplyDeliveryCustody } from "./block-reply-delivery.js";
 import type { PendingContinuationSettlement } from "./get-reply.types.js";
 import { attachMcpAppChannelAction } from "./mcp-app-channel-action.js";
 import { attachMcpConnectChannelAction } from "./mcp-connect-channel-action.js";
 import { normalizeReplyPayload } from "./normalize-reply.js";
-import { shouldRetryReplyDispatch } from "./reply-dispatch-outcome.js";
 import { createReplyToModeFilterForChannel } from "./reply-threading.js";
 import { buildSessionsYieldAcknowledgmentPayload } from "./sessions-yield-acknowledgment.js";
 import { resolveStrandedReplyRecovery } from "./stranded-reply-recovery.js";
@@ -184,9 +184,8 @@ export async function prepareReplyAgentPayloads(state: {
   const retryBlockedSourceReply =
     blockReplyPipeline?.hasRetryBlockedTerminalDelivery?.() === true ||
     directBlockDeliveries?.some(
-      ({ payload, outcome, pending }) =>
-        isReplyPayloadTerminalContent(payload) &&
-        (pending || (outcome !== "delivered" && !shouldRetryReplyDispatch(outcome))),
+      (delivery) =>
+        isReplyPayloadTerminalContent(delivery.payload) && hasBlockReplyDeliveryCustody(delivery),
     ) === true;
   const emptyInteractiveReplyPayload =
     terminalFailurePayload || retryBlockedSourceReply
@@ -284,7 +283,6 @@ export async function prepareReplyAgentPayloads(state: {
       silentExpected: followupRun.run.silentExpected,
       blockStreamingEnabled,
       blockReplyPipeline,
-      directlySentBlockKeys,
       directBlockDeliveries,
       replyToMode,
       replyToChannel,

--- a/src/auto-reply/reply/agent-runner-result-payloads.ts
+++ b/src/auto-reply/reply/agent-runner-result-payloads.ts
@@ -180,20 +180,24 @@ export async function prepareReplyAgentPayloads(state: {
           committedMessagingToolSourceReplyDelivery ||
           runResult.didSendDeterministicApprovalPrompt === true,
       });
-  const emptyInteractiveReplyPayload = terminalFailurePayload
-    ? undefined
-    : buildEmptyInteractiveReplyPayload({
-        isInteractive,
-        isHeartbeat,
-        silentExpected: followupRun.run.silentExpected,
-        allowEmptyAssistantReplyAsSilent: followupRun.run.allowEmptyAssistantReplyAsSilent,
-        hasPendingContinuation: pendingContinuation,
-        hasExplicitSilentReply: deliberateSilentTerminalReply,
-        hasCommittedDelivery: successfulTerminalDelivery,
-        hasIntentionalTerminalCompletion: hasIntentionalTerminalCompletion(runResult),
-        sessionCtx,
-        cfg,
-      });
+  const retryBlockedSourceReply = rawPayloadArray.some((payload) =>
+    blockReplyPipeline?.isFinalPayloadRetryBlocked?.(payload),
+  );
+  const emptyInteractiveReplyPayload =
+    terminalFailurePayload || retryBlockedSourceReply
+      ? undefined
+      : buildEmptyInteractiveReplyPayload({
+          isInteractive,
+          isHeartbeat,
+          silentExpected: followupRun.run.silentExpected,
+          allowEmptyAssistantReplyAsSilent: followupRun.run.allowEmptyAssistantReplyAsSilent,
+          hasPendingContinuation: pendingContinuation,
+          hasExplicitSilentReply: deliberateSilentTerminalReply,
+          hasCommittedDelivery: successfulTerminalDelivery,
+          hasIntentionalTerminalCompletion: hasIntentionalTerminalCompletion(runResult),
+          sessionCtx,
+          cfg,
+        });
   const buildStrandedRetryMissingDeliveryDiagnostic = (): ReplyPayload | undefined => {
     if (!sessionKey || !storePath || followupRun.strandedReplyRetry !== true) {
       return undefined;
@@ -498,9 +502,7 @@ export async function prepareReplyAgentPayloads(state: {
       (payload.isCommentary !== true || opts?.commentaryPayloadsEnabled === true) &&
       normalizeReplyPayload(payload, { applyChannelTransforms: false }) !== null,
   );
-  const hasDeliveredBlockStream = Boolean(
-    blockReplyPipeline?.didStream() && !blockReplyPipeline.isAborted(),
-  );
+  const hasDeliveredBlockStream = Boolean(blockReplyPipeline?.didStream());
   const canDeliverStandaloneFallbackNotice =
     hasDeliveredBlockStream || successfulSideEffectDelivery;
   if (

--- a/src/auto-reply/reply/agent-runner-result-payloads.ts
+++ b/src/auto-reply/reply/agent-runner-result-payloads.ts
@@ -180,9 +180,7 @@ export async function prepareReplyAgentPayloads(state: {
           committedMessagingToolSourceReplyDelivery ||
           runResult.didSendDeterministicApprovalPrompt === true,
       });
-  const retryBlockedSourceReply = rawPayloadArray.some((payload) =>
-    blockReplyPipeline?.isFinalPayloadRetryBlocked?.(payload),
-  );
+  const retryBlockedSourceReply = blockReplyPipeline?.hasRetryBlockedTerminalDelivery?.() === true;
   const emptyInteractiveReplyPayload =
     terminalFailurePayload || retryBlockedSourceReply
       ? undefined

--- a/src/auto-reply/reply/block-reply-delivery.ts
+++ b/src/auto-reply/reply/block-reply-delivery.ts
@@ -1,7 +1,17 @@
 import { AsyncLocalStorage } from "node:async_hooks";
-import type { ReplyDispatchDeliveryOutcome } from "./reply-dispatch-outcome.js";
+import {
+  shouldRetryReplyDispatch,
+  type ReplyDispatchDeliveryOutcome,
+} from "./reply-dispatch-outcome.js";
 
 type BlockReplyDelivery = { outcome: ReplyDispatchDeliveryOutcome; pending?: boolean };
+
+export function hasBlockReplyDeliveryCustody(delivery: BlockReplyDelivery): boolean {
+  return (
+    delivery.pending === true ||
+    (delivery.outcome !== "delivered" && !shouldRetryReplyDispatch(delivery.outcome))
+  );
+}
 
 // Invocation identity survives payload normalization without changing channel callback contracts.
 const deliveries = new AsyncLocalStorage<{ settlement?: Promise<BlockReplyDelivery> }>();

--- a/src/auto-reply/reply/block-reply-delivery.ts
+++ b/src/auto-reply/reply/block-reply-delivery.ts
@@ -1,0 +1,23 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+import type { ReplyDispatchDeliveryOutcome } from "./reply-dispatch-outcome.js";
+
+type BlockReplyDelivery = { outcome: ReplyDispatchDeliveryOutcome; pending?: boolean };
+
+// Invocation identity survives payload normalization without changing channel callback contracts.
+const deliveries = new AsyncLocalStorage<{ settlement?: Promise<BlockReplyDelivery> }>();
+
+export function setBlockReplyDelivery(delivery: Promise<BlockReplyDelivery>): void {
+  const context = deliveries.getStore();
+  if (context) {
+    context.settlement = delivery;
+  }
+}
+
+export async function deliverBlockReply(
+  send: () => Promise<void> | void,
+): Promise<BlockReplyDelivery> {
+  const context: { settlement?: Promise<BlockReplyDelivery> } = {};
+  await deliveries.run(context, send);
+  // Direct transport callbacks complete delivery themselves; queued dispatch supplies its receipt.
+  return context.settlement ?? { outcome: "delivered" };
+}

--- a/src/auto-reply/reply/block-reply-pipeline.test.ts
+++ b/src/auto-reply/reply/block-reply-pipeline.test.ts
@@ -554,30 +554,6 @@ describe("createBlockReplyPipeline content coverage dedup", () => {
     },
   );
 
-  it("does not acknowledge source from a rejected fenced block", async () => {
-    const pipeline = createBlockReplyPipeline({
-      onBlockReply: async (payload) => {
-        if (payload.text === "```ts\n1;\n```") {
-          throw new Error("channel rejected the continuation");
-        }
-      },
-      timeoutMs: 5000,
-    });
-    pipeline.enqueue(
-      setReplyPayloadMetadata(
-        { text: "```ts\nconst x = \n```" },
-        { blockSourceText: "```ts\nconst x = " },
-      ),
-    );
-    pipeline.enqueue(
-      setReplyPayloadMetadata({ text: "```ts\n1;\n```" }, { blockSourceText: "1;\n```" }),
-    );
-    await pipeline.flush({ force: true });
-
-    expect(pipeline.hasSentPayload({ text: "```ts\nconst x = 1;\n```" })).toBe(false);
-    expect(pipeline.hasSentPayload({ text: "```ts\nconst x = " })).toBe(true);
-  });
-
   it("merges source coverage through ordinary text and a media continuation", async () => {
     const sent: ReplyPayload[] = [];
     const pipeline = createBlockReplyPipeline({

--- a/src/auto-reply/reply/block-reply-pipeline.ts
+++ b/src/auto-reply/reply/block-reply-pipeline.ts
@@ -14,12 +14,9 @@ import {
 } from "../reply-payload.js";
 import type { ReplyPayload } from "../types.js";
 import { createBlockReplyCoalescer } from "./block-reply-coalescer.js";
-import { deliverBlockReply } from "./block-reply-delivery.js";
+import { deliverBlockReply, hasBlockReplyDeliveryCustody } from "./block-reply-delivery.js";
 import type { BlockStreamingCoalescing } from "./block-streaming.js";
-import {
-  resolveReplyDispatchErrorOutcome,
-  shouldRetryReplyDispatch,
-} from "./reply-dispatch-outcome.js";
+import { resolveReplyDispatchErrorOutcome } from "./reply-dispatch-outcome.js";
 
 /** Streaming block reply pipeline that tracks sent content and media. */
 export type BlockReplyPipeline = {
@@ -37,6 +34,7 @@ export type BlockReplyPipeline = {
   getSentMediaUrls: () => readonly string[];
   getRetryBlockedMediaUrls?: () => readonly string[];
   hasRetryBlockedTerminalDelivery?: () => boolean;
+  hasRetryBlockedDelivery: () => boolean;
 };
 
 /** Optional buffering strategy used before payloads enter block delivery. */
@@ -360,9 +358,6 @@ export function createBlockReplyPipeline(params: {
       : [blockAttemptsByMessage.get(index) ?? []];
   };
   const normalizeSource = (text: string) => text.replace(/\s+/g, "");
-  const isRetryBlocked = (attempt: BlockAttempt) =>
-    attempt.pending ||
-    (attempt.outcome !== "delivered" && !shouldRetryReplyDispatch(attempt.outcome));
   const matchesSource = (payload: ReplyPayload, attempts: BlockAttempt[]) => {
     const reply = resolveSendableOutboundReplyParts(payload);
     return (
@@ -391,7 +386,7 @@ export function createBlockReplyPipeline(params: {
       const textOnly = !hasOutboundReplyContent({ ...payload, text: undefined });
       for (const group of matchingAttempts(payload)) {
         const attempts = group.filter((attempt) => attempt.terminal);
-        const blocked = attempts.filter(isRetryBlocked);
+        const blocked = attempts.filter(hasBlockReplyDeliveryCustody);
         const sourcePrefix = normalizeSource(attempts.map((attempt) => attempt.source).join(""));
         if (
           blocked.some((attempt) => attempt.contentKey === contentKey) ||
@@ -428,15 +423,19 @@ export function createBlockReplyPipeline(params: {
       return false;
     },
     getSentMediaUrls: () => Array.from(sentMediaUrls),
+    hasRetryBlockedDelivery: () =>
+      Array.from(blockAttemptsByMessage.values()).some((attempts) =>
+        attempts.some(hasBlockReplyDeliveryCustody),
+      ),
     hasRetryBlockedTerminalDelivery: () =>
       Array.from(blockAttemptsByMessage.values()).some((attempts) =>
-        attempts.some((attempt) => attempt.terminal && isRetryBlocked(attempt)),
+        attempts.some((attempt) => attempt.terminal && hasBlockReplyDeliveryCustody(attempt)),
       ),
     getRetryBlockedMediaUrls: () =>
       Array.from(
         new Set(
           Array.from(blockAttemptsByMessage.values()).flatMap((attempts) =>
-            attempts.filter(isRetryBlocked).flatMap((attempt) => attempt.mediaUrls),
+            attempts.filter(hasBlockReplyDeliveryCustody).flatMap((attempt) => attempt.mediaUrls),
           ),
         ),
       ),

--- a/src/auto-reply/reply/block-reply-pipeline.ts
+++ b/src/auto-reply/reply/block-reply-pipeline.ts
@@ -35,6 +35,8 @@ export type BlockReplyPipeline = {
   hasSentExactPayload?: (payload: ReplyPayload) => boolean;
   isFinalPayloadRetryBlocked?: (payload: ReplyPayload) => boolean;
   getSentMediaUrls: () => readonly string[];
+  getRetryBlockedMediaUrls?: () => readonly string[];
+  hasRetryBlockedTerminalDelivery?: () => boolean;
 };
 
 /** Optional buffering strategy used before payloads enter block delivery. */
@@ -130,6 +132,8 @@ export function createBlockReplyPipeline(params: {
   type BlockAttempt = Awaited<ReturnType<typeof deliverBlockReply>> & {
     source: string;
     contentKey: string;
+    mediaUrls: readonly string[];
+    terminal: boolean;
   };
   const blockAttemptsByMessage = new Map<number | undefined, BlockAttempt[]>();
   let bufferedAssistantMessageIndex: number | undefined;
@@ -170,13 +174,13 @@ export function createBlockReplyPipeline(params: {
       outcome: "cancelled",
       source: blockSourceText ?? reply.trimmedText,
       contentKey,
+      mediaUrls: reply.mediaUrls,
+      terminal: isTerminalContent,
     };
-    if (isTerminalContent) {
-      const index = getReplyPayloadMetadata(payload)?.assistantMessageIndex;
-      const attempts = blockAttemptsByMessage.get(index) ?? [];
-      attempts.push(attempt);
-      blockAttemptsByMessage.set(index, attempts);
-    }
+    const index = getReplyPayloadMetadata(payload)?.assistantMessageIndex;
+    const attempts = blockAttemptsByMessage.get(index) ?? [];
+    attempts.push(attempt);
+    blockAttemptsByMessage.set(index, attempts);
 
     // Preserve outbound order by chaining sends; abort after timeout to avoid stale blocks.
     const fallbackAbortController = new AbortController();
@@ -356,6 +360,9 @@ export function createBlockReplyPipeline(params: {
       : [blockAttemptsByMessage.get(index) ?? []];
   };
   const normalizeSource = (text: string) => text.replace(/\s+/g, "");
+  const isRetryBlocked = (attempt: BlockAttempt) =>
+    attempt.pending ||
+    (attempt.outcome !== "delivered" && !shouldRetryReplyDispatch(attempt.outcome));
   const matchesSource = (payload: ReplyPayload, attempts: BlockAttempt[]) => {
     const reply = resolveSendableOutboundReplyParts(payload);
     return (
@@ -382,12 +389,9 @@ export function createBlockReplyPipeline(params: {
       const reply = resolveSendableOutboundReplyParts(payload);
       const text = normalizeSource(reply.trimmedText);
       const textOnly = !hasOutboundReplyContent({ ...payload, text: undefined });
-      for (const attempts of matchingAttempts(payload)) {
-        const blocked = attempts.filter(
-          (attempt) =>
-            attempt.pending ||
-            (attempt.outcome !== "delivered" && !shouldRetryReplyDispatch(attempt.outcome)),
-        );
+      for (const group of matchingAttempts(payload)) {
+        const attempts = group.filter((attempt) => attempt.terminal);
+        const blocked = attempts.filter(isRetryBlocked);
         const sourcePrefix = normalizeSource(attempts.map((attempt) => attempt.source).join(""));
         if (
           blocked.some((attempt) => attempt.contentKey === contentKey) ||
@@ -413,7 +417,9 @@ export function createBlockReplyPipeline(params: {
         if (
           matchesSource(
             payload,
-            attempts.filter((attempt) => attempt.outcome === "delivered" && !attempt.pending),
+            attempts.filter(
+              (attempt) => attempt.terminal && attempt.outcome === "delivered" && !attempt.pending,
+            ),
           )
         ) {
           return true;
@@ -422,5 +428,17 @@ export function createBlockReplyPipeline(params: {
       return false;
     },
     getSentMediaUrls: () => Array.from(sentMediaUrls),
+    hasRetryBlockedTerminalDelivery: () =>
+      Array.from(blockAttemptsByMessage.values()).some((attempts) =>
+        attempts.some((attempt) => attempt.terminal && isRetryBlocked(attempt)),
+      ),
+    getRetryBlockedMediaUrls: () =>
+      Array.from(
+        new Set(
+          Array.from(blockAttemptsByMessage.values()).flatMap((attempts) =>
+            attempts.filter(isRetryBlocked).flatMap((attempt) => attempt.mediaUrls),
+          ),
+        ),
+      ),
   };
 }

--- a/src/auto-reply/reply/block-reply-pipeline.ts
+++ b/src/auto-reply/reply/block-reply-pipeline.ts
@@ -14,7 +14,12 @@ import {
 } from "../reply-payload.js";
 import type { ReplyPayload } from "../types.js";
 import { createBlockReplyCoalescer } from "./block-reply-coalescer.js";
+import { deliverBlockReply } from "./block-reply-delivery.js";
 import type { BlockStreamingCoalescing } from "./block-streaming.js";
+import {
+  resolveReplyDispatchErrorOutcome,
+  shouldRetryReplyDispatch,
+} from "./reply-dispatch-outcome.js";
 
 /** Streaming block reply pipeline that tracks sent content and media. */
 export type BlockReplyPipeline = {
@@ -28,6 +33,7 @@ export type BlockReplyPipeline = {
   isAborted: () => boolean;
   hasSentPayload: (payload: ReplyPayload) => boolean;
   hasSentExactPayload?: (payload: ReplyPayload) => boolean;
+  isFinalPayloadRetryBlocked?: (payload: ReplyPayload) => boolean;
   getSentMediaUrls: () => readonly string[];
 };
 
@@ -121,7 +127,11 @@ export function createBlockReplyPipeline(params: {
   const pendingKeys = new Set<string>();
   const seenKeys = new Set<string>();
   const bufferedPayloads: ReplyPayload[] = [];
-  const streamedTextFragmentsByMessage = new Map<number | undefined, string[]>();
+  type BlockAttempt = Awaited<ReturnType<typeof deliverBlockReply>> & {
+    source: string;
+    contentKey: string;
+  };
+  const blockAttemptsByMessage = new Map<number | undefined, BlockAttempt[]>();
   let bufferedAssistantMessageIndex: number | undefined;
   let sendChain: Promise<void> = Promise.resolve();
   let aborted = false;
@@ -154,6 +164,19 @@ export function createBlockReplyPipeline(params: {
       return;
     }
     pendingKeys.add(payloadKey);
+    const isTerminalContent = isReplyPayloadTerminalContent(payload);
+    const reply = resolveSendableOutboundReplyParts(payload);
+    const attempt: BlockAttempt = {
+      outcome: "cancelled",
+      source: blockSourceText ?? reply.trimmedText,
+      contentKey,
+    };
+    if (isTerminalContent) {
+      const index = getReplyPayloadMetadata(payload)?.assistantMessageIndex;
+      const attempts = blockAttemptsByMessage.get(index) ?? [];
+      attempts.push(attempt);
+      blockAttemptsByMessage.set(index, attempts);
+    }
 
     // Preserve outbound order by chaining sends; abort after timeout to avoid stale blocks.
     const fallbackAbortController = new AbortController();
@@ -163,39 +186,38 @@ export function createBlockReplyPipeline(params: {
         if (aborted) {
           return false;
         }
-        await runAbortableTimeout(
+        attempt.outcome = "failed-deliver";
+        attempt.pending = true;
+        return await runAbortableTimeout(
           async (signal) => {
             timeoutSignal = signal;
-            await onBlockReply(payload, {
-              abortSignal: signal ?? fallbackAbortController.signal,
-              timeoutMs,
-            });
+            return await deliverBlockReply(() =>
+              onBlockReply(payload, {
+                abortSignal: signal ?? fallbackAbortController.signal,
+                timeoutMs,
+              }),
+            );
           },
           timeoutMs || undefined,
           "block reply delivery",
         );
-        return true;
       })
-      .then((didSend) => {
-        if (!didSend) {
+      .then((delivery) => {
+        if (!delivery) {
+          return;
+        }
+        Object.assign(attempt, delivery, { pending: delivery.pending === true });
+        const isStatusNotice = isReplyPayloadStatusNotice(payload);
+        if (delivery.outcome !== "delivered" || delivery.pending) {
           return;
         }
         sentKeys.add(payloadKey);
-        const isStatusNotice = isReplyPayloadStatusNotice(payload);
-        const isTerminalContent = isReplyPayloadTerminalContent(payload);
         if (isTerminalContent) {
           sentContentKeys.add(contentKey);
           sentContentKeys.add(createIndexedBlockReplyContentKey(payload));
         }
-        const reply = resolveSendableOutboundReplyParts(payload);
         for (const mediaUrl of reply.mediaUrls) {
           sentMediaUrls.add(mediaUrl);
-        }
-        if (isTerminalContent && reply.trimmedText) {
-          const assistantMessageIndex = getReplyPayloadMetadata(payload)?.assistantMessageIndex;
-          const fragments = streamedTextFragmentsByMessage.get(assistantMessageIndex) ?? [];
-          fragments.push(blockSourceText ?? reply.trimmedText);
-          streamedTextFragmentsByMessage.set(assistantMessageIndex, fragments);
         }
         if (!isStatusNotice) {
           didStream = true;
@@ -215,6 +237,8 @@ export function createBlockReplyPipeline(params: {
           }
           return;
         }
+        attempt.outcome = resolveReplyDispatchErrorOutcome(err);
+        attempt.pending = false;
         logVerbose(`block reply delivery failed: ${String(err)}`);
       })
       .finally(() => {
@@ -325,6 +349,24 @@ export function createBlockReplyPipeline(params: {
     coalescer?.stop();
   };
 
+  const matchingAttempts = (payload: ReplyPayload) => {
+    const index = getReplyPayloadMetadata(payload)?.assistantMessageIndex;
+    return index === undefined
+      ? blockAttemptsByMessage.values()
+      : [blockAttemptsByMessage.get(index) ?? []];
+  };
+  const normalizeSource = (text: string) => text.replace(/\s+/g, "");
+  const matchesSource = (payload: ReplyPayload, attempts: BlockAttempt[]) => {
+    const reply = resolveSendableOutboundReplyParts(payload);
+    return (
+      !reply.hasMedia &&
+      Boolean(reply.trimmedText) &&
+      attempts.length > 0 &&
+      normalizeSource(attempts.map((attempt) => attempt.source).join("")) ===
+        normalizeSource(reply.trimmedText)
+    );
+  };
+
   return {
     enqueue,
     flush,
@@ -335,6 +377,30 @@ export function createBlockReplyPipeline(params: {
     isAborted: () => aborted,
     hasSentExactPayload: (payload) =>
       sentContentKeys.has(createIndexedBlockReplyContentKey(payload)),
+    isFinalPayloadRetryBlocked: (payload) => {
+      const contentKey = createBlockReplyContentKey(payload);
+      const reply = resolveSendableOutboundReplyParts(payload);
+      const text = normalizeSource(reply.trimmedText);
+      const textOnly = !hasOutboundReplyContent({ ...payload, text: undefined });
+      for (const attempts of matchingAttempts(payload)) {
+        const blocked = attempts.filter(
+          (attempt) =>
+            attempt.pending ||
+            (attempt.outcome !== "delivered" && !shouldRetryReplyDispatch(attempt.outcome)),
+        );
+        const sourcePrefix = normalizeSource(attempts.map((attempt) => attempt.source).join(""));
+        if (
+          blocked.some((attempt) => attempt.contentKey === contentKey) ||
+          (textOnly &&
+            blocked.length > 0 &&
+            sourcePrefix.length > 0 &&
+            text.startsWith(sourcePrefix))
+        ) {
+          return true;
+        }
+      }
+      return false;
+    },
     hasSentPayload: (payload) => {
       const payloadKey = createIndexedBlockReplyContentKey(payload);
       if (sentContentKeys.has(payloadKey)) {
@@ -343,19 +409,13 @@ export function createBlockReplyPipeline(params: {
       if (!didStream) {
         return false;
       }
-      const reply = resolveSendableOutboundReplyParts(payload);
-      if (reply.hasMedia || !reply.trimmedText) {
-        return false;
-      }
-      const normalize = (text: string) => text.replace(/\s+/g, "");
-      const target = normalize(reply.trimmedText);
-      const assistantMessageIndex = getReplyPayloadMetadata(payload)?.assistantMessageIndex;
-      const streamedFragments =
-        assistantMessageIndex === undefined
-          ? streamedTextFragmentsByMessage.values()
-          : [streamedTextFragmentsByMessage.get(assistantMessageIndex) ?? []];
-      for (const fragments of streamedFragments) {
-        if (fragments.length > 0 && normalize(fragments.join("")) === target) {
+      for (const attempts of matchingAttempts(payload)) {
+        if (
+          matchesSource(
+            payload,
+            attempts.filter((attempt) => attempt.outcome === "delivered" && !attempt.pending),
+          )
+        ) {
           return true;
         }
       }

--- a/src/auto-reply/reply/dispatch-from-config.choose-route.ts
+++ b/src/auto-reply/reply/dispatch-from-config.choose-route.ts
@@ -22,6 +22,7 @@ import {
   type ReplyPayload,
 } from "../reply-payload.js";
 import { renderPostCompactionModelFailurePayload } from "./agent-runner-failure-reply.js";
+import { setBlockReplyDelivery } from "./block-reply-delivery.js";
 import { createBlockReplyContentKey } from "./block-reply-pipeline.js";
 import {
   DispatchReplyOperationAbortedError,
@@ -201,6 +202,7 @@ export async function chooseDispatchRoute(state: PrepareDispatchOperationReadySt
   type BlockDelivery = { outcome: ReplyDispatchDeliveryOutcome; pending?: boolean };
   const blockDeliveryOutcomes = new Map<string, Array<Promise<BlockDelivery>>>();
   const recordBlockOutcome = (payload: ReplyPayload, outcome: Promise<BlockDelivery>) => {
+    setBlockReplyDelivery(outcome);
     const key = createBlockReplyContentKey(payload);
     const outcomes = blockDeliveryOutcomes.get(key) ?? [];
     outcomes.push(outcome);

--- a/src/auto-reply/reply/dispatch-from-config.execute.ts
+++ b/src/auto-reply/reply/dispatch-from-config.execute.ts
@@ -16,6 +16,7 @@ import {
   readAskUserQuestionId,
 } from "../reply-payload.js";
 import { buildTerminalAgentRunFailureReplyPayload } from "./agent-runner-failure-reply.js";
+import { setBlockReplyDelivery } from "./block-reply-delivery.js";
 import { takeCommandSessionMetadataChanges } from "./command-session-metadata.js";
 import { runWithDispatchAbortSignal } from "./dispatch-from-config.abort.js";
 import { handleAcpDispatchTailAfterReset } from "./dispatch-from-config.acp-tail.js";
@@ -447,6 +448,7 @@ export async function executeDispatch(state: PrepareDispatchExecutionReadyState)
                   }
                 },
                 onBlockReply: (inputPayload, context) => {
+                  setBlockReplyDelivery(Promise.resolve({ outcome: "cancelled" }));
                   // A monitor decides notify only after its structured final result.
                   if (state.replyOperationRunState.heartbeat) {
                     return Promise.resolve();

--- a/src/auto-reply/reply/dispatch-from-config.execute.ts
+++ b/src/auto-reply/reply/dispatch-from-config.execute.ts
@@ -601,9 +601,11 @@ export async function executeDispatch(state: PrepareDispatchExecutionReadyState)
                       markInboundDedupeReplayUnsafe();
                       const delivery = state.sendTrackedBlockReply(normalizedPayload);
                       if (delivery.queued) {
-                        // Capture admission's drain; concurrent or aborted waiters must
-                        // not consume another callback's delivery obligation.
-                        const pending = dispatcher.waitForIdle().then(() => undefined);
+                        // This block's receipt owns its settlement. A turn-wide no-send
+                        // verdict is premature while a recovery final can still arrive.
+                        const pending = (delivery.outcome ?? dispatcher.waitForIdle()).then(
+                          () => undefined,
+                        );
                         void pending.catch(() => undefined);
                         state.progressState.pendingDirectBlockReplyDelivery = pending;
                       }

--- a/src/auto-reply/reply/dispatch-from-config.execute.ts
+++ b/src/auto-reply/reply/dispatch-from-config.execute.ts
@@ -151,6 +151,12 @@ export async function executeDispatch(state: PrepareDispatchExecutionReadyState)
                       // delivery even when this dispatch has already returned.
                       try {
                         await waitForPendingDirectBlockReplyDelivery();
+                        if (
+                          dispatcher.getFailedCounts().block > 0 &&
+                          state.turnLedger.canAttemptFallback()
+                        ) {
+                          await dispatcher.waitForIdle();
+                        }
                       } catch (error) {
                         try {
                           await params.replyOptions?.onQueuedFollowupSettled?.();

--- a/src/auto-reply/reply/dispatch-from-config.owner-settlement.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.owner-settlement.test.ts
@@ -243,9 +243,10 @@ describe("dispatchReplyFromConfig owner settlement", () => {
       "subsequent block",
       "aborted progress",
       "tool-only reply",
+      "cancelled block and tool-only reply",
       "no pending reply",
     ] as const)(
-      "settles queued presentation after %s through retained callbacks",
+      "dispatchReplyFromConfig settles queued presentation after %s through retained callbacks",
       async (phase) => {
         type ResolverOptions = import("./get-reply.types.js").InternalGetReplyOptions;
         let retained: ResolverOptions | undefined;
@@ -263,6 +264,12 @@ describe("dispatchReplyFromConfig owner settlement", () => {
         const dispatcher = createReplyDispatcher({
           humanDelay: { mode: "custom", minMs: 1, maxMs: 1 },
           beforeDeliver: async (payload) => {
+            if (
+              phase === "cancelled block and tool-only reply" &&
+              payload.text === "initial reply"
+            ) {
+              return null;
+            }
             if (payload.text === "queued reply" && phase === "before delivery") {
               entered.resolve();
               await release.promise;
@@ -292,6 +299,9 @@ describe("dispatchReplyFromConfig owner settlement", () => {
           replyResolver: async (_ctx, opts) => {
             retained = opts;
             await opts?.onBlockReply?.({ text: "initial reply" });
+            if (phase === "cancelled block and tool-only reply") {
+              opts?.onDeliberateSilentTerminalReply?.();
+            }
             resolverEntered.resolve();
             if (phase === "aborted progress") {
               await returnResolver.promise;
@@ -308,7 +318,7 @@ describe("dispatchReplyFromConfig owner settlement", () => {
           dispatcher.markComplete();
           await dispatcher.waitForIdle();
           if (phase !== "no pending reply") {
-            if (phase === "tool-only reply") {
+            if (phase === "tool-only reply" || phase === "cancelled block and tool-only reply") {
               dispatcher.sendToolResult({ text: "queued reply" });
             } else {
               await retained?.onBlockReply?.({ text: "queued reply" });
@@ -345,15 +355,20 @@ describe("dispatchReplyFromConfig owner settlement", () => {
           await progress;
           await dispatch;
           const receipt = await dispatcher.waitForIdle();
-          const noPendingBlock = phase === "no pending reply" || phase === "tool-only reply";
+          const noPendingBlock =
+            phase === "no pending reply" ||
+            phase === "tool-only reply" ||
+            phase === "cancelled block and tool-only reply";
           expect(cleanedUpBeforeDelivery).toBe(noPendingBlock ? 1 : 0);
           expect(onQueuedFollowupSettled).toHaveBeenCalledOnce();
           expect(receipt?.counts.block.delivered).toBe(
-            noPendingBlock || phase === "transport failure"
-              ? 1
-              : phase === "subsequent block"
-                ? 3
-                : 2,
+            phase === "cancelled block and tool-only reply"
+              ? 0
+              : noPendingBlock || phase === "transport failure"
+                ? 1
+                : phase === "subsequent block"
+                  ? 3
+                  : 2,
           );
           expect(receipt?.counts.block.failedAfterSend).toBe(phase === "transport failure" ? 1 : 0);
           if (phase === "transport failure") {

--- a/src/auto-reply/reply/get-reply-directive-aliases.test.ts
+++ b/src/auto-reply/reply/get-reply-directive-aliases.test.ts
@@ -287,7 +287,7 @@ describe("reply directive resolution", () => {
       blockStreamingEnabled: result.result.blockStreamingEnabled,
       blockReplyPipeline: null,
       directlySentBlockKeys: new Set(),
-      directlySentBlockPayloads: [],
+      directBlockDeliveries: [],
     });
     const { emit, subscription } = createSubscribedSessionHarness({
       runId: "media-caption-directives",

--- a/src/auto-reply/reply/reply-delivery.test.ts
+++ b/src/auto-reply/reply/reply-delivery.test.ts
@@ -83,7 +83,6 @@ describe("createBlockReplyDeliveryHandler", () => {
         didLogHeartbeatStrip: false,
         blockStreamingEnabled,
         blockReplyPipeline: null,
-        directlySentBlockKeys,
         directBlockDeliveries,
         replyToMode: "off",
       });
@@ -121,7 +120,6 @@ describe("createBlockReplyDeliveryHandler", () => {
       didLogHeartbeatStrip: false,
       blockStreamingEnabled: true,
       blockReplyPipeline: null,
-      directlySentBlockKeys,
       directBlockDeliveries,
       replyToMode: "off",
     });

--- a/src/auto-reply/reply/reply-delivery.test.ts
+++ b/src/auto-reply/reply/reply-delivery.test.ts
@@ -7,6 +7,7 @@ import { buildReplyPayloads } from "./agent-runner-payloads.js";
 import { createBlockReplyContentKey } from "./block-reply-pipeline.js";
 import {
   createBlockReplyDeliveryHandler,
+  type DirectBlockDelivery,
   normalizeReplyPayloadDirectives,
 } from "./reply-delivery.js";
 import type { TypingSignaler } from "./typing-mode.js";
@@ -36,7 +37,7 @@ describe("createBlockReplyDeliveryHandler", () => {
       blockStreamingEnabled: true,
       blockReplyPipeline: { enqueue } as unknown as BlockReplyPipelineLike,
       directlySentBlockKeys: new Set<string>(),
-      directlySentBlockPayloads: [],
+      directBlockDeliveries: [],
     };
 
     await createBlockReplyDeliveryHandler(baseParams)(payload);
@@ -57,7 +58,7 @@ describe("createBlockReplyDeliveryHandler", () => {
     async ({ flag, blockStreamingEnabled }) => {
       const delivered: ReplyPayload[] = [];
       const directlySentBlockKeys = new Set<string>();
-      const directlySentBlockPayloads: Array<ReplyPayload | undefined> = [];
+      const directBlockDeliveries: DirectBlockDelivery[] = [];
       const handler = createBlockReplyDeliveryHandler({
         onBlockReply: async (payload) => {
           delivered.push(payload);
@@ -72,7 +73,7 @@ describe("createBlockReplyDeliveryHandler", () => {
         blockStreamingEnabled,
         blockReplyPipeline: null,
         directlySentBlockKeys,
-        directlySentBlockPayloads,
+        directBlockDeliveries,
       });
 
       await handler({ text: "Same answer", [flag]: true });
@@ -83,9 +84,7 @@ describe("createBlockReplyDeliveryHandler", () => {
         blockStreamingEnabled,
         blockReplyPipeline: null,
         directlySentBlockKeys,
-        directlySentBlockPayloads: directlySentBlockPayloads.filter(
-          (payload): payload is ReplyPayload => payload !== undefined,
-        ),
+        directBlockDeliveries,
         replyToMode: "off",
       });
 
@@ -97,7 +96,7 @@ describe("createBlockReplyDeliveryHandler", () => {
 
   it("keeps a matching final answer from a different directly sent assistant message", async () => {
     const directlySentBlockKeys = new Set<string>();
-    const directlySentBlockPayloads: Array<ReplyPayload | undefined> = [];
+    const directBlockDeliveries: DirectBlockDelivery[] = [];
     const handler = createBlockReplyDeliveryHandler({
       onBlockReply: async () => {},
       normalizeStreamingText: (payload) => ({ text: payload.text, skip: false }),
@@ -108,7 +107,7 @@ describe("createBlockReplyDeliveryHandler", () => {
       blockStreamingEnabled: true,
       blockReplyPipeline: null,
       directlySentBlockKeys,
-      directlySentBlockPayloads,
+      directBlockDeliveries,
     });
 
     await handler(setReplyPayloadMetadata({ text: "Same answer" }, { assistantMessageIndex: 0 }));
@@ -123,9 +122,7 @@ describe("createBlockReplyDeliveryHandler", () => {
       blockStreamingEnabled: true,
       blockReplyPipeline: null,
       directlySentBlockKeys,
-      directlySentBlockPayloads: directlySentBlockPayloads.filter(
-        (payload): payload is ReplyPayload => payload !== undefined,
-      ),
+      directBlockDeliveries,
       replyToMode: "off",
     });
 
@@ -151,7 +148,7 @@ describe("createBlockReplyDeliveryHandler", () => {
       blockStreamingEnabled: false,
       blockReplyPipeline: null,
       directlySentBlockKeys,
-      directlySentBlockPayloads: [],
+      directBlockDeliveries: [],
     });
 
     await handler({
@@ -189,7 +186,7 @@ describe("createBlockReplyDeliveryHandler", () => {
       blockStreamingEnabled: false,
       blockReplyPipeline: null,
       directlySentBlockKeys,
-      directlySentBlockPayloads: [],
+      directBlockDeliveries: [],
     });
 
     await handler({
@@ -226,7 +223,7 @@ describe("createBlockReplyDeliveryHandler", () => {
       blockStreamingEnabled: false,
       blockReplyPipeline: null,
       directlySentBlockKeys,
-      directlySentBlockPayloads: [],
+      directBlockDeliveries: [],
     });
 
     await handler({
@@ -270,7 +267,7 @@ describe("createBlockReplyDeliveryHandler", () => {
       blockStreamingEnabled: false,
       blockReplyPipeline: null,
       directlySentBlockKeys,
-      directlySentBlockPayloads: [],
+      directBlockDeliveries: [],
     });
 
     await handler({ presentation });
@@ -302,7 +299,7 @@ describe("createBlockReplyDeliveryHandler", () => {
       blockStreamingEnabled: false,
       blockReplyPipeline: null,
       directlySentBlockKeys: new Set(),
-      directlySentBlockPayloads: [],
+      directBlockDeliveries: [],
     });
 
     await handler({ text: "text only" });
@@ -325,7 +322,7 @@ describe("createBlockReplyDeliveryHandler", () => {
       blockStreamingEnabled: true,
       blockReplyPipeline,
       directlySentBlockKeys: new Set(),
-      directlySentBlockPayloads: [],
+      directBlockDeliveries: [],
     });
 
     await handler({ text: "\n\n  Hello from stream" });
@@ -358,7 +355,7 @@ describe("createBlockReplyDeliveryHandler", () => {
       blockStreamingEnabled: true,
       blockReplyPipeline,
       directlySentBlockKeys: new Set(),
-      directlySentBlockPayloads: [],
+      directBlockDeliveries: [],
     });
 
     await handler({ text: "reset intro" });
@@ -454,7 +451,7 @@ describe("createBlockReplyDeliveryHandler", () => {
       blockStreamingEnabled: true,
       blockReplyPipeline,
       directlySentBlockKeys: new Set(),
-      directlySentBlockPayloads: [],
+      directBlockDeliveries: [],
     });
 
     await handler({ text: "Result", mediaUrl: "./image.png" });
@@ -492,7 +489,7 @@ describe("createBlockReplyDeliveryHandler", () => {
       blockStreamingEnabled: true,
       blockReplyPipeline,
       directlySentBlockKeys: new Set(),
-      directlySentBlockPayloads: [],
+      directBlockDeliveries: [],
     });
 
     await handler({ text: "NO_REPLY", mediaUrls: ["./missing.png", "./survived.png"] });
@@ -524,7 +521,7 @@ describe("createBlockReplyDeliveryHandler", () => {
       blockStreamingEnabled: true,
       blockReplyPipeline,
       directlySentBlockKeys: new Set(),
-      directlySentBlockPayloads: [],
+      directBlockDeliveries: [],
     });
 
     const payload = setReplyPayloadMetadata({ text: "Alpha" }, { assistantMessageIndex: 7 });
@@ -556,7 +553,7 @@ describe("createBlockReplyDeliveryHandler", () => {
 
   it("records concurrent direct block deliveries in emission order", async () => {
     const resolvers: Array<() => void> = [];
-    const directlySentBlockPayloads: Array<ReplyPayload | undefined> = [];
+    const directBlockDeliveries: DirectBlockDelivery[] = [];
     const handler = createBlockReplyDeliveryHandler({
       onBlockReply: () =>
         new Promise<void>((resolve) => {
@@ -570,7 +567,7 @@ describe("createBlockReplyDeliveryHandler", () => {
       blockStreamingEnabled: true,
       blockReplyPipeline: null,
       directlySentBlockKeys: new Set(),
-      directlySentBlockPayloads,
+      directBlockDeliveries,
     });
 
     const first = handler({ text: "first" });
@@ -580,6 +577,6 @@ describe("createBlockReplyDeliveryHandler", () => {
     resolvers[0]?.();
     await first;
 
-    expect(directlySentBlockPayloads.map((payload) => payload?.text)).toEqual(["first", "second"]);
+    expect(directBlockDeliveries.map(({ payload }) => payload.text)).toEqual(["first", "second"]);
   });
 });

--- a/src/auto-reply/reply/reply-delivery.ts
+++ b/src/auto-reply/reply/reply-delivery.ts
@@ -8,6 +8,7 @@ import {
 } from "../reply-payload.js";
 import { SILENT_REPLY_TOKEN } from "../tokens.js";
 import type { BlockReplyContext, ReplyPayload, ReplyThreadingPolicy } from "../types.js";
+import { deliverBlockReply } from "./block-reply-delivery.js";
 import type { BlockReplyPipeline } from "./block-reply-pipeline.js";
 import { createBlockReplyContentKey } from "./block-reply-pipeline.js";
 import { parseReplyDirectives } from "./reply-directives.js";
@@ -79,8 +80,12 @@ async function sendDirectBlockReply(params: {
 }) {
   const deliveryIndex = params.directlySentBlockPayloads.length;
   params.directlySentBlockPayloads.push(undefined);
-  await params.onBlockReply(params.payload);
-  if (isReplyPayloadTerminalContent(params.trackingPayload)) {
+  const delivery = await deliverBlockReply(() => params.onBlockReply(params.payload));
+  if (
+    delivery.outcome === "delivered" &&
+    !delivery.pending &&
+    isReplyPayloadTerminalContent(params.trackingPayload)
+  ) {
     params.directlySentBlockKeys.add(createBlockReplyContentKey(params.trackingPayload));
     params.directlySentBlockPayloads[deliveryIndex] = params.trackingPayload;
   }

--- a/src/auto-reply/reply/reply-delivery.ts
+++ b/src/auto-reply/reply/reply-delivery.ts
@@ -12,10 +12,15 @@ import { deliverBlockReply } from "./block-reply-delivery.js";
 import type { BlockReplyPipeline } from "./block-reply-pipeline.js";
 import { createBlockReplyContentKey } from "./block-reply-pipeline.js";
 import { parseReplyDirectives } from "./reply-directives.js";
+import { resolveReplyDispatchErrorOutcome } from "./reply-dispatch-outcome.js";
 import { applyReplyTagsToPayload, isRenderablePayload } from "./reply-payloads.js";
 import type { TypingSignaler } from "./typing-mode.js";
 
 type ReplyDirectiveParseMode = "always" | "auto" | "never";
+
+export type DirectBlockDelivery = Awaited<ReturnType<typeof deliverBlockReply>> & {
+  payload: ReplyPayload;
+};
 
 /** Parses inline reply directives into payload fields and silent-reply state. */
 export function normalizeReplyPayloadDirectives(params: {
@@ -74,20 +79,29 @@ export function normalizeReplyPayloadDirectives(params: {
 async function sendDirectBlockReply(params: {
   onBlockReply: (payload: ReplyPayload, context?: BlockReplyContext) => Promise<void> | void;
   directlySentBlockKeys: Set<string>;
-  directlySentBlockPayloads: Array<ReplyPayload | undefined>;
-  trackingPayload: ReplyPayload;
+  directBlockDeliveries: DirectBlockDelivery[];
   payload: ReplyPayload;
 }) {
-  const deliveryIndex = params.directlySentBlockPayloads.length;
-  params.directlySentBlockPayloads.push(undefined);
-  const delivery = await deliverBlockReply(() => params.onBlockReply(params.payload));
+  const attempt: DirectBlockDelivery = {
+    payload: params.payload,
+    outcome: "failed-deliver",
+    pending: true,
+  };
+  params.directBlockDeliveries.push(attempt);
+  const delivery = await deliverBlockReply(() => params.onBlockReply(params.payload)).catch(
+    (error: unknown) => {
+      attempt.outcome = resolveReplyDispatchErrorOutcome(error);
+      attempt.pending = false;
+      throw error;
+    },
+  );
+  Object.assign(attempt, delivery, { pending: delivery.pending === true });
   if (
     delivery.outcome === "delivered" &&
     !delivery.pending &&
-    isReplyPayloadTerminalContent(params.trackingPayload)
+    isReplyPayloadTerminalContent(params.payload)
   ) {
-    params.directlySentBlockKeys.add(createBlockReplyContentKey(params.trackingPayload));
-    params.directlySentBlockPayloads[deliveryIndex] = params.trackingPayload;
+    params.directlySentBlockKeys.add(createBlockReplyContentKey(params.payload));
   }
 }
 
@@ -105,7 +119,7 @@ export function createBlockReplyDeliveryHandler(params: {
   blockStreamingEnabled: boolean;
   blockReplyPipeline: BlockReplyPipeline | null;
   directlySentBlockKeys: Set<string>;
-  directlySentBlockPayloads: Array<ReplyPayload | undefined>;
+  directBlockDeliveries: DirectBlockDelivery[];
 }): (payload: ReplyPayload) => Promise<void> {
   return async (payload) => {
     // Suppressed display lanes must not enter delivery bookkeeping: callers use
@@ -187,17 +201,8 @@ export function createBlockReplyDeliveryHandler(params: {
     // Use pipeline if available (block streaming enabled), otherwise send directly.
     if (params.blockStreamingEnabled && params.blockReplyPipeline) {
       params.blockReplyPipeline.enqueue(blockPayload);
-    } else if (params.blockStreamingEnabled) {
-      // Send directly when flushing before tool execution (no pipeline but streaming enabled).
-      // Track sent key to avoid duplicate in final payloads.
-      await sendDirectBlockReply({
-        onBlockReply: params.onBlockReply,
-        directlySentBlockKeys: params.directlySentBlockKeys,
-        directlySentBlockPayloads: params.directlySentBlockPayloads,
-        trackingPayload: blockPayload,
-        payload: blockPayload,
-      });
     } else if (
+      params.blockStreamingEnabled ||
       blockHasNonTextContent ||
       blockPayload.isReasoning === true ||
       blockPayload.isCommentary === true
@@ -207,8 +212,7 @@ export function createBlockReplyDeliveryHandler(params: {
       await sendDirectBlockReply({
         onBlockReply: params.onBlockReply,
         directlySentBlockKeys: params.directlySentBlockKeys,
-        directlySentBlockPayloads: params.directlySentBlockPayloads,
-        trackingPayload: blockPayload,
+        directBlockDeliveries: params.directBlockDeliveries,
         payload: blockPayload,
       });
     }


### PR DESCRIPTION
Related: #143722, #145540, #145463, #145466, #145415, #145430.

## What Problem This Solves

If one streamed block succeeded and a later block failed before sending, the complete final answer could disappear. An uncertain send could instead trigger a competing backup answer.

## Why This Change Was Made

Reply delivery records confirmed, missing, and unsettled sends separately. Final filtering credits only confirmed delivery and preserves a complete answer after proven failure. Model fallback reads current delivery and recovery ownership before starting another candidate, preventing duplicate text or attachments while a send may still complete.

## User Impact

Proven missing blocks can recover with the full answer. Uncertain or queued sends do not produce competing answers. Existing provider error notices remain visible. No configuration, protocol, or stored format changes.

Consumers: final reply filtering and model fallback now use delivery outcomes instead of queued-block coverage.

## Evidence

Registered dispatch regressions failed before the fix. All 656 focused tests passed. Telegram controlled block cancellation delivered the complete final answer afterward. Eight streaming-on/off runs distinguished uncertain acknowledgement from proven no-send; four routed offline/restart runs verified queued recovery without a backup answer. These used controlled faults, not a platform outage. Final continuous integration passed on the unchanged contribution.
