### PR TITLE
fix(backup): avoid stalls on hardlink-dense state

### DIFF
--- a/src/fleet/backup.runtime.ts
+++ b/src/fleet/backup.runtime.ts
@@ -12,7 +12,7 @@ import {
   ArchiveSecurityError,
   extractArchive,
 } from "../infra/archive.js";
-import { createBackupLinkCache } from "../infra/backup-volatile-stat-cache.js";
+import { createBackupTarLinkOptions } from "../infra/backup-volatile-stat-cache.js";
 import {
   getPublishFileExclusiveFailureDetails,
   publishFileNoClobber,
@@ -302,7 +302,7 @@ export async function backupFleetCell(params: {
           gzip: true,
           portable: true,
           preservePaths: true,
-          linkCache: createBackupLinkCache(),
+          ...createBackupTarLinkOptions(),
           filter,
           onWriteEntry: (entry) => {
             entry.path = remapArchivePath(entry.path, manifestPath, dataTarget, authTarget);

--- a/src/infra/backup-create.hardlinks.test.ts
+++ b/src/infra/backup-create.hardlinks.test.ts
@@ -1,0 +1,64 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import * as tar from "tar";
+import { describe, expect, it, vi } from "vitest";
+import { backupVerifyCommand } from "../commands/backup-verify.js";
+import type { RuntimeEnv } from "../runtime.js";
+import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
+import { createBackupArchive } from "./backup-create.js";
+
+describe("backup hardlink traversal", () => {
+  it("completes and verifies a dense hardlink tree without emitting Link entries", async () => {
+    await withOpenClawTestState(
+      {
+        layout: "state-only",
+        prefix: "openclaw-backup-hardlink-tree-",
+        scenario: "minimal",
+      },
+      async (state) => {
+        const sourceDir = state.statePath(
+          "agents",
+          "main",
+          "agent",
+          "codex-home",
+          "home",
+          ".cache",
+          "pnpm",
+        );
+        const targetPath = path.join(sourceDir, "target.txt");
+        await fs.mkdir(sourceDir, { recursive: true });
+        await fs.writeFile(targetPath, "backup payload");
+        await Promise.all(
+          Array.from({ length: 8 }, (_, index) =>
+            fs.link(targetPath, path.join(sourceDir, `hardlink-${index}.txt`)),
+          ),
+        );
+
+        const result = await createBackupArchive({
+          output: state.path("backup.tar.gz"),
+          includeWorkspace: false,
+        });
+        const entries: Array<{ path: string; type: string }> = [];
+        await tar.t({
+          file: result.archivePath,
+          gzip: true,
+          onentry: (entry) => {
+            if (entry.path.includes("/.cache/pnpm/")) {
+              entries.push({ path: entry.path, type: entry.type });
+            }
+            entry.resume();
+          },
+        });
+
+        expect(entries.filter((entry) => entry.type === "File")).toHaveLength(9);
+        expect(entries.filter((entry) => entry.type === "Link")).toHaveLength(0);
+        const runtime: RuntimeEnv = { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
+        await expect(
+          backupVerifyCommand(runtime, { archive: result.archivePath }),
+        ).resolves.toMatchObject({
+          ok: true,
+        });
+      },
+    );
+  }, 30_000);
+});

--- a/src/infra/backup-create.ts
+++ b/src/infra/backup-create.ts
@@ -41,7 +41,7 @@ import {
 } from "./backup-sqlite-snapshot.js";
 import { writeTarArchiveWithRetry } from "./backup-tar-retry.js";
 import {
-  createBackupLinkCache,
+  createBackupTarLinkOptions,
   createBackupVolatileStatCache,
 } from "./backup-volatile-stat-cache.js";
 import { isErrno } from "./errors.js";
@@ -651,7 +651,7 @@ export async function createBackupArchive(
                 gzip: true,
                 portable: true,
                 preservePaths: true,
-                linkCache: createBackupLinkCache(),
+                ...createBackupTarLinkOptions(),
                 statCache: createBackupVolatileStatCache(
                   (sourcePath) =>
                     plan.inventory.isVolatile(sourcePath) ||

--- a/src/infra/backup-volatile-stat-cache.ts
+++ b/src/infra/backup-volatile-stat-cache.ts
@@ -46,6 +46,16 @@ export function createBackupVolatileStatCache(
   return new BackupVolatileStatCache(isVolatilePath);
 }
 
-export function createBackupLinkCache(): Map<BackupLinkCacheKey, string> {
-  return new BackupLinkCache();
+export function createBackupTarLinkOptions(): {
+  jobs: 1;
+  linkCache: Map<BackupLinkCacheKey, string>;
+} {
+  return {
+    // Backup archives deliberately dereference hardlinks. With concurrent
+    // node-tar jobs, several paths for one unseen inode can enter its
+    // pending-link queue and never regain an owner. Serial entry creation
+    // preserves independently restorable files and guarantees progress.
+    jobs: 1,
+    linkCache: new BackupLinkCache(),
+  };
 }


### PR DESCRIPTION
Related: #136318

## Status — superseded by merged upstream repair

[PR #146700](https://github.com/openclaw/openclaw/pull/146700), merged September 13 at [`b10035faa9d3`](https://github.com/openclaw/openclaw/commit/b10035faa9d3e0683bef2eb085a0c260e8e40cb5), now fixes the same pending-hardlink deadlock for both state and fleet backups. It projects regular-file `nlink` to 1 before node-tar schedules hardlink work and removes the no-op link cache. This preserves independently restorable file entries without reducing traversal concurrency. This PR's serialization patch is therefore no longer needed on current main.

## What Problem This Solved

State backups containing dense hardlink trees could stop making progress and fail the five-minute archive watchdog, including with `--no-include-workspace` when the tree belongs to retained agent state. Two real 2026.9.3 attempts stopped at 56,507,111,424 raw bytes / 27,553,361,877 compressed bytes.

## User Impact

The original patch let the affected state backup complete and verify while preserving ordinary `File` entries instead of restore-hostile `Link` entries. Current main now provides that behavior through the merged repair above; no new exclusion or verification relaxation is needed.

## Evidence

### Current upstream verification — September 14

Pinned main: [`6d5861700489`](https://github.com/openclaw/openclaw/commit/6d586170048982bd6c5ebc3cdc08bbd003f47a1d). An isolated checkout used the exact upstream production tree plus this PR's unchanged dense-hardlink regression. No serialization patch was present.

```text
node scripts/run-vitest.mjs run src/infra/backup-create.hardlinks.test.ts src/fleet/backup.runtime.test.ts --maxWorkers 2

src/fleet/backup.runtime.test.ts: 31 passed
src/infra/backup-create.hardlinks.test.ts: 1 passed
  completes and verifies a dense hardlink tree without emitting Link entries: 432ms
passed 2 Vitest shards in 24.17s
```

The regression creates nine names sharing one inode, invokes the real archive creator, asserts nine `File` entries and zero `Link` entries, and verifies the completed archive. This is targeted synthetic filesystem/command coverage, not a new full-state backup on current main.

### Existing completed real backup — September 12

This addresses the earlier review request for inspectable after-fix production output. The retained schema-matched 2026.9.3 build included this PR's serialization repair. Selected fields from the actual successful `backup create --no-include-workspace --verify --json` receipt:

```json
{
  "createdAt": "2026-09-12T16:03:43.986Z",
  "dryRun": false,
  "includeWorkspace": false,
  "onlyConfig": false,
  "verified": true
}
```

Retained published archive metadata, rechecked September 14:

```text
archive exists: true
archive size: 27880971752 bytes
previous repeated stall boundary: 27553361877 bytes
above previous boundary: 327609875 bytes
```

Private paths, asset inventories, and unrelated output are omitted. The `verified: true` result is from the completed original create-and-verify command; the September 14 metadata check did not rerun that large backup or reverify its archive bytes. This historical recovery evidence is distinct from the current-main regression above.
