### PR TITLE
fix(ci): rebalance config-cli test roots into state-logging

### DIFF
--- a/test/tsconfig/tsconfig.core.test.config-cli.json
+++ b/test/tsconfig/tsconfig.core.test.config-cli.json
@@ -14,7 +14,6 @@
     "../../dist",
     "../../**/dist/**",
     "../../src/cli/daemon-cli/**",
-    "../../src/config/sessions/session-cold-storage*.test.ts",
-    "../../src/config/sessions/session-accessor.sqlite-cold-read.test.ts"
+    "../../src/config/sessions/**"
   ]
 }

--- a/test/tsconfig/tsconfig.core.test.state-logging.json
+++ b/test/tsconfig/tsconfig.core.test.state-logging.json
@@ -12,7 +12,7 @@
     "../../src/shared/**/*.test.tsx",
     "../../src/infra/update-managed-service-handoff-database.test.ts",
     "../../src/infra/package-update-activation-journal.test.ts",
-    "../../src/config/sessions/session-cold-storage*.test.ts",
-    "../../src/config/sessions/session-accessor.sqlite-cold-read.test.ts"
+    "../../src/config/sessions/**/*.test.ts",
+    "../../src/config/sessions/**/*.test.tsx"
   ]
 }


### PR DESCRIPTION
## What Problem This Solves

`origin/main` is red on `check-additional-boundaries`: the `config-cli` core test typecheck shard holds 721 test roots against its 720-root memory bound (main run [34659892235](https://github.com/openclaw/openclaw/actions/runs/34659892235)). PR CI builds the merge commit, so every open PR inherits the failure. Same shape as #139645.

## Why This Change Was Made

Move the `src/config/sessions` test roots from `config-cli` to `state-logging`, which already owned the cold-storage subset of that directory and has the most headroom. Only the two shard include/exclude lists change; the 720-root bound and exactly-once coverage stay enforced.

## User Impact

PRs stop inheriting this unrelated failure from `main`. No runtime behavior change.

## Evidence

Reproduced on current `origin/main` (45bd3a0e6834) before the change, then verified after:

```sh
node --import ./scripts/tsx.mjs scripts/check-tsgo-core-boundary.mts
node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.state-logging.json
```

| Shard | Roots before | Roots after |
| --- | ---: | ---: |
| config-cli | 721 | 579 |
| state-logging | 207 | 349 |

Before: exit 1, `config-cli: 721 test roots exceeds the 720 limit`. After: boundary check exit 0; the state-logging shard typechecks clean with the moved roots.

Note: main is separately over the Control UI startup budget; #145316 carries the approved baseline rebase for that lane.
