### PR TITLE
test(health): decouple snapshot assertions from host timing

### DIFF
--- a/src/commands/health.snapshot.test.ts
+++ b/src/commands/health.snapshot.test.ts
@@ -429,6 +429,8 @@ describe("collectGatewayHealthSnapshot", () => {
   });
 
   beforeEach(() => {
+    // Snapshot contents must not depend on host scheduling; deadline tests advance time explicitly.
+    vi.useFakeTimers({ toFake: ["Date"] });
     // Session rows are mocked, but the collector still resolves their physical store.
     sessionStorePath = path.join(
       tempDirs.make("openclaw-health-snapshot-sessions-"),
@@ -447,6 +449,7 @@ describe("collectGatewayHealthSnapshot", () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     vi.unstubAllGlobals();
     vi.unstubAllEnvs();
     tempDirs.cleanup();


### PR DESCRIPTION
Refs #145044

<details>
<summary>Additional instructions</summary>

This is a maintainer-directed CI repair on a branch in the upstream repository.

</details>

## What Problem This Solves

Resolves a problem where the health snapshot content test fails during a busy CI shard even though the runtime-state merge is correct. In [run 34656048696, job 103448885035](https://github.com/openclaw/openclaw/actions/runs/34656048696/job/103448885035), the assertion expected `telegram.running === true` but received `undefined`; the test took 165 ms against a collector deadline clamped to 50 ms.

## Why This Change Was Made

Freeze only `Date` in the snapshot fixture and restore real timers after every test. Native timers and asynchronous imports stay live, and every timeout argument and assertion stays unchanged. The separate collector deadline suite continues to advance fake time explicitly and verify expiration, queued admission, and retained probe permits.

A controlled 100 ms scheduling pause in the existing synthetic probe reproduced the exact assertion without any sibling tests. Its returned account was the explicit `health collection timed out after 50ms` result, which omits runtime fields. The same pause passed after the fixture clock change. The diagnostic pause and logging were then removed.

## User Impact

No production behavior changes. Snapshot-content checks no longer depend on whether the test worker gets CPU time within a 50 ms window, so unrelated update-repair PRs avoid this source of false CI failures.

## Evidence

- Recovered the original CI file list and confirmed its nine-file prefix through `health.snapshot.test.ts`. The unmodified local replay passed 110 files / 1,464 tests, with one skipped test.
- Final CI-prefix replay: 9 files / 332 tests passed, one skipped; the observed file order exactly matched the original CI prefix. Command: `CI=true OPENCLAW_VITEST_MAX_WORKERS=2 OPENCLAW_VITEST_INCLUDE_FILE=<recovered-ci-prefix.json> node scripts/run-vitest.mjs --config test/vitest/vitest.commands.config.ts --no-cache --reporter verbose`. The prefix is `backup-verify`, `migrate`, `status`, `triage`, `gateway-status`, `status.summary`, `tasks`, `health`, then `health.snapshot` under `src/commands/`.
- Controlled scheduling-pause regression, using `node scripts/run-vitest.mjs src/commands/health.snapshot.test.ts`: before, 1 failed / 15 passed with `expected undefined to be true` and an explicit timeout record; after, 16 passed with `running`, `connected`, and the successful probe preserved.
- Final source, diagnostic removed: `node scripts/run-vitest.mjs src/commands/health.snapshot.test.ts` — 16 passed.
- `node scripts/run-vitest.mjs src/gateway/health/collector.deadline.test.ts` — 4 passed.
- `node scripts/check-changed.mjs` — passed, including commands test types, lint, formatting, and all guards.
- Fresh P1 autoreview: scoped-clean, no accepted/actionable findings.
- Exact-head [CI run 34660894685](https://github.com/openclaw/openclaw/actions/runs/34660894685) completed: `checks-node-changed` passed. The unrelated [`check-test-types` preflight](https://github.com/openclaw/openclaw/actions/runs/34660894685/job/103463095044) failed with `config-cli: 721 test roots exceeds the 720 limit`; `openclaw/ci-gate` consequently failed. CI checked merge `dd70f8c28177f20229cb424e10e06c2d31bd3a34` onto main `a0bd289bfa07ac289467bd8a87cacd5eeb6bbd46`. This three-line change adds no files, imports, or roots and does not edit the shard configuration. The capacity guard is preserved for a separate maintainer repair.

Known limits: the unmodified CI failure did not recur in the first local shard replay, so no sibling-state leak is claimed. Local proof uses macOS / Node 26; the original CI used Linux / Node 24. One later CI test file no longer exists on current main; the entire prefix preceding the reported failure is present and matched. History confirms #144252 did not modify the snapshot test or collector.


## ClawSweeper review

The completed review of `d893cd997df04d9d8a824d7bbf23cb7c21bb08de` found no actionable correctness or security issues. No fixups or skips are needed; the existing deadline suite retains explicit expiration coverage.
