### PR TITLE
perf(models): index configured overrides per catalog projection

### DIFF
--- a/src/agents/model-catalog-route.test.ts
+++ b/src/agents/model-catalog-route.test.ts
@@ -11,7 +11,7 @@ import type { ProviderDefaultThinkingPolicyContext } from "../plugins/provider-t
 import {
   type ModelCatalogRoutePolicy,
   projectModelCatalogEntryForRoute,
-  resolveConfiguredModelCatalogOverrides,
+  createConfiguredModelCatalogOverridesResolver,
 } from "./model-catalog-route.js";
 import type { ModelCatalogEntry, ModelCatalogSnapshot } from "./model-catalog.types.js";
 
@@ -267,7 +267,7 @@ describe("projectModelCatalogEntryForRoute", () => {
         },
       },
     } as unknown as OpenClawConfig;
-    const overrides = resolveConfiguredModelCatalogOverrides({ cfg, entry: platformEntry });
+    const overrides = createConfiguredModelCatalogOverridesResolver({ cfg })(platformEntry);
 
     expect(
       projectModelCatalogEntryForRoute({
@@ -318,7 +318,7 @@ describe("projectModelCatalogEntryForRoute", () => {
     };
 
     expect(
-      resolveConfiguredModelCatalogOverrides({ cfg, entry: { ...platformEntry, id } }),
+      createConfiguredModelCatalogOverridesResolver({ cfg })({ ...platformEntry, id }),
     ).toEqual({
       name: id,
       contextWindow: 32_000,
@@ -381,14 +381,12 @@ describe("projectModelCatalogEntryForRoute", () => {
         },
       };
 
-      for (const id of ["gpt-5.5", "openai/gpt-5.5"]) {
-        expect(
-          resolveConfiguredModelCatalogOverrides({
-            cfg,
-            entry: { ...platformEntry, id },
-            policy: canonicalPolicy,
-          }),
-        ).toEqual(
+      const resolveOverrides = createConfiguredModelCatalogOverridesResolver({
+        cfg,
+        policy: canonicalPolicy,
+      });
+      for (const id of ["gpt-5.5", "openai/gpt-5.5", "gpt-5.5"]) {
+        expect(resolveOverrides({ ...platformEntry, id })).toEqual(
           exact
             ? {
                 name: "Logical row",
@@ -410,6 +408,40 @@ describe("projectModelCatalogEntryForRoute", () => {
     },
   );
 
+  it("keeps reused lookups scoped to raw provider spelling without retaining query entries", () => {
+    const cfg: OpenClawConfig = {
+      models: {
+        providers: {
+          custom: {
+            baseUrl: "",
+            models: ["first", "second"].map((id) => ({
+              id,
+              name: id,
+              reasoning: false,
+              input: ["text"],
+              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+              maxTokens: 4096,
+            })),
+          },
+        },
+      },
+    };
+    const policy: ModelCatalogRoutePolicy = {
+      ...routePolicy,
+      resolveIdentity: ({ provider, id }) => ({
+        id: id === "alias" ? (provider === "CUSTOM" ? "second" : "first") : id,
+        key: JSON.stringify([provider, id]),
+      }),
+    };
+    const resolveOverrides = createConfiguredModelCatalogOverridesResolver({ cfg, policy });
+    const query = { provider: "custom", id: "first" };
+    expect(resolveOverrides(query)?.name).toBe("first");
+    query.provider = "CUSTOM";
+    query.id = "alias";
+    expect(resolveOverrides(query)?.name).toBe("second");
+    expect(resolveOverrides({ provider: "custom", id: "alias" })?.name).toBe("first");
+  });
+
   it("preserves literal provider-scoped model ids", () => {
     const cfg = {
       models: {
@@ -423,11 +455,7 @@ describe("projectModelCatalogEntryForRoute", () => {
     const literalEntry = { ...platformEntry, id: "openai/acme-model" };
 
     expect(
-      resolveConfiguredModelCatalogOverrides({
-        cfg,
-        entry: literalEntry,
-        policy: routePolicy,
-      }),
+      createConfiguredModelCatalogOverridesResolver({ cfg, policy: routePolicy })(literalEntry),
     ).toEqual({ name: "Configured Acme" });
   });
 });

--- a/src/agents/model-catalog-route.ts
+++ b/src/agents/model-catalog-route.ts
@@ -3,9 +3,10 @@ import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import { isCanonicalDottedDecimalIPv4, isLoopbackIpAddress } from "@openclaw/net-policy/ip";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import {
-  findConfiguredProviderModel,
+  createConfiguredProviderModelResolver,
   resolveMergedModelProviderConfig,
 } from "../config/model-provider-config.js";
+import type { ModelDefinitionConfig } from "../config/types.models.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { ProviderModelRouteCandidate } from "../plugin-sdk/provider-model-types.js";
 import {
@@ -56,38 +57,52 @@ type ModelCatalogLogicalOverrides = Partial<
   >
 >;
 
-/** Reads explicit logical capability overrides without re-resolving auth. */
-export function resolveConfiguredModelCatalogOverrides(params: {
+/** Prepares configured-row indexes for one stable catalog config and policy projection. */
+export function createConfiguredModelCatalogOverridesResolver(params: {
   cfg: OpenClawConfig;
-  entry: Pick<ModelCatalogEntry, "provider" | "id">;
   policy?: ModelCatalogRoutePolicy;
-}): ModelCatalogLogicalOverrides | undefined {
-  const provider = normalizeProviderId(params.entry.provider);
-  const providerConfig = resolveMergedModelProviderConfig(params.cfg, provider);
-  if (!providerConfig?.models?.length) {
-    return undefined;
-  }
-  const surface = resolveProviderModelPolicySurface(provider);
-  const normalizeConfiguredModelId = (modelId: string) =>
-    params.policy?.resolveIdentity({ provider: params.entry.provider, id: modelId })?.id ??
-    resolveProviderModelCatalogId({ provider, modelId, surface }) ??
-    modelId.trim();
-  const model = findConfiguredProviderModel(
-    providerConfig,
-    provider,
-    normalizeConfiguredModelId(params.entry.id),
-    normalizeConfiguredModelId,
-  );
-  const overrides: ModelCatalogLogicalOverrides = {
-    ...(model?.name ? { name: model.name } : {}),
-    ...(model?.contextWindow !== undefined ? { contextWindow: model.contextWindow } : {}),
-    ...(model?.contextTokens !== undefined ? { contextTokens: model.contextTokens } : {}),
-    ...(model?.reasoning !== undefined ? { reasoning: model.reasoning } : {}),
-    ...(model?.reasoning !== undefined ? { configuredReasoning: model.reasoning } : {}),
-    ...(model?.thinkingLevelMap ? { thinkingLevelMap: model.thinkingLevelMap } : {}),
-    ...(model?.input !== undefined ? { input: model.input } : {}),
+}): (
+  entry: Pick<ModelCatalogEntry, "provider" | "id">,
+) => ModelCatalogLogicalOverrides | undefined {
+  const modelsByProvider = new Map<
+    string,
+    (modelId: string) => ModelDefinitionConfig | undefined
+  >();
+  return (entry) => {
+    const providerId = entry.provider;
+    let findModel = modelsByProvider.get(providerId);
+    if (!findModel) {
+      const provider = normalizeProviderId(providerId);
+      const providerConfig = resolveMergedModelProviderConfig(params.cfg, provider);
+      if (!providerConfig?.models?.length) {
+        return undefined;
+      }
+      const surface = resolveProviderModelPolicySurface(provider);
+      const normalizeConfiguredModelId = (modelId: string) =>
+        params.policy?.resolveIdentity({ provider: providerId, id: modelId })?.id ??
+        resolveProviderModelCatalogId({ provider, modelId, surface }) ??
+        modelId.trim();
+      const resolveModel = createConfiguredProviderModelResolver(
+        providerConfig,
+        provider,
+        normalizeConfiguredModelId,
+      );
+      findModel = (modelId) => resolveModel(normalizeConfiguredModelId(modelId));
+      // Policy callbacks receive the original spelling, even when config keys normalize alike.
+      modelsByProvider.set(providerId, findModel);
+    }
+    const model = findModel(entry.id);
+    const overrides: ModelCatalogLogicalOverrides = {
+      ...(model?.name ? { name: model.name } : {}),
+      ...(model?.contextWindow !== undefined ? { contextWindow: model.contextWindow } : {}),
+      ...(model?.contextTokens !== undefined ? { contextTokens: model.contextTokens } : {}),
+      ...(model?.reasoning !== undefined ? { reasoning: model.reasoning } : {}),
+      ...(model?.reasoning !== undefined ? { configuredReasoning: model.reasoning } : {}),
+      ...(model?.thinkingLevelMap ? { thinkingLevelMap: model.thinkingLevelMap } : {}),
+      ...(model?.input !== undefined ? { input: model.input } : {}),
+    };
+    return Object.keys(overrides).length > 0 ? overrides : undefined;
   };
-  return Object.keys(overrides).length > 0 ? overrides : undefined;
 }
 
 function sameLogicalModel(

--- a/src/agents/model-catalog-view.ts
+++ b/src/agents/model-catalog-view.ts
@@ -27,7 +27,7 @@ import {
 } from "./model-catalog-browse.js";
 import {
   projectModelCatalogEntryForRoute,
-  resolveConfiguredModelCatalogOverrides,
+  createConfiguredModelCatalogOverridesResolver,
   type ModelCatalogRouteProjection,
 } from "./model-catalog-route.js";
 import type { ModelCatalogEntry, ModelCatalogSnapshot } from "./model-catalog.types.js";
@@ -57,6 +57,10 @@ export function createModelCatalogView(params: {
   }
   const variantsOf = (entry: Pick<ModelCatalogEntry, "provider" | "id">) =>
     variantsByKey.get(resolveModelCatalogIdentityKey(entry));
+  const resolveOverrides = createConfiguredModelCatalogOverridesResolver({
+    cfg: params.cfg,
+    policy: openAIModelCatalogRoutePolicy,
+  });
   return {
     logicalEntries: dedupeByKey(params.catalog, resolveModelCatalogIdentityKey),
     variantsOf,
@@ -72,11 +76,7 @@ export function createModelCatalogView(params: {
               }
             : { kind: "unresolved", policy: openAIModelCatalogRoutePolicy };
       const variants = variantsOf(entry);
-      const overrides = resolveConfiguredModelCatalogOverrides({
-        cfg: params.cfg,
-        entry,
-        policy: openAIModelCatalogRoutePolicy,
-      });
+      const overrides = resolveOverrides(entry);
       return projectModelCatalogEntryForRoute({
         entry,
         projection,

--- a/src/agents/model-catalog-visibility.ts
+++ b/src/agents/model-catalog-visibility.ts
@@ -14,7 +14,7 @@ import {
   type ModelCatalogRoutePolicy,
   type ModelCatalogRouteProjection,
   projectModelCatalogEntryForRoute,
-  resolveConfiguredModelCatalogOverrides,
+  createConfiguredModelCatalogOverridesResolver,
 } from "./model-catalog-route.js";
 import type { ModelCatalogEntry } from "./model-catalog.js";
 import { dedupeModelCatalogEntries } from "./model-selection-shared.js";
@@ -158,10 +158,14 @@ export async function prepareLogicalVisibleModelCatalog(
     }
   }
   const catalogKeys = new Set(params.catalog.map(keyOf));
+  const resolveOverrides = createConfiguredModelCatalogOverridesResolver({
+    cfg: params.cfg,
+    policy: params.routePolicy,
+  });
   const projections = new Map<
     ModelCatalogEntry,
     {
-      overrides: ReturnType<typeof resolveConfiguredModelCatalogOverrides>;
+      overrides: ReturnType<typeof resolveOverrides>;
       rows: Map<
         | ModelCatalogRouteProjection["kind"]
         | Extract<ModelCatalogRouteProjection, { kind: "selected" }>["route"],
@@ -185,11 +189,7 @@ export async function prepareLogicalVisibleModelCatalog(
         let cached = projections.get(entry);
         if (!cached) {
           cached = {
-            overrides: resolveConfiguredModelCatalogOverrides({
-              cfg: params.cfg,
-              entry,
-              policy: params.routePolicy,
-            }),
+            overrides: resolveOverrides(entry),
             rows: new Map(),
           };
           projections.set(entry, cached);

--- a/src/agents/model-selection.catalog-overlay.test.ts
+++ b/src/agents/model-selection.catalog-overlay.test.ts
@@ -9,7 +9,7 @@ import { prepareModelCatalogThinkingPolicies } from "../plugins/provider-thinkin
 import {
   type ModelCatalogRoutePolicy,
   projectModelCatalogEntryForRoute,
-  resolveConfiguredModelCatalogOverrides,
+  createConfiguredModelCatalogOverridesResolver,
 } from "./model-catalog-route.js";
 import type { ModelCatalogEntry, ModelCatalogSnapshot } from "./model-catalog.types.js";
 import { modelTransportRoutesMatch } from "./model-compat-catalog.js";
@@ -245,11 +245,10 @@ describe("configured catalog route overlays", () => {
         entry: selected,
         projection: { kind: "selected", route, policy: routePolicy },
         catalog: catalog.routeVariants,
-        overrides: resolveConfiguredModelCatalogOverrides({
+        overrides: createConfiguredModelCatalogOverridesResolver({
           cfg: source.config,
-          entry: selected,
           policy: routePolicy,
-        }),
+        })(selected),
       });
       const hasMatchingDonor = !clearsCapturedMetadata && !missingRouteField;
       expect(projected).toMatchObject({

--- a/src/config/model-provider-config.ts
+++ b/src/config/model-provider-config.ts
@@ -130,7 +130,7 @@ export function resolveMergedModelProviderModels<T extends { id: string }>(param
   return models;
 }
 
-function createConfiguredProviderModelResolver<T extends { id: string }>(
+export function createConfiguredProviderModelResolver<T extends { id: string }>(
   providerConfig: { models?: readonly T[] } | undefined,
   provider: string,
   canonicalizeModelId?: (modelId: string) => string,

--- a/src/gateway/server-methods/models-list-result.arcee.test.ts
+++ b/src/gateway/server-methods/models-list-result.arcee.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import { expect, it } from "vitest";
 import { resolveModelWithRegistry } from "../../agents/embedded-agent-runner/model.registry-resolution.js";
 import { resolveModelProviderAuthConfig } from "../../agents/model-auth-provider-route.js";
-import { resolveConfiguredModelCatalogOverrides } from "../../agents/model-catalog-route.js";
+import { createConfiguredModelCatalogOverridesResolver } from "../../agents/model-catalog-route.js";
 import type { ModelCatalogEntry } from "../../agents/model-catalog.types.js";
 import { AuthStorage } from "../../agents/sessions/auth-storage.js";
 import { ModelRegistry } from "../../agents/sessions/model-registry.js";
@@ -188,10 +188,13 @@ it("keeps exact authored identities ahead of provider-owned wire aliases", () =>
       providers: { arcee: { baseUrl: "https://api.arcee.ai/api/v1", models } },
     },
   };
+  const resolveOverrides = createConfiguredModelCatalogOverridesResolver({ cfg });
   for (const { id } of models) {
-    expect(
-      resolveConfiguredModelCatalogOverrides({ cfg, entry: { provider: "arcee", id } }),
-    ).toMatchObject({ name: "Exact row", contextWindow: 65536, reasoning: true });
+    expect(resolveOverrides({ provider: "arcee", id })).toMatchObject({
+      name: "Exact row",
+      contextWindow: 65536,
+      reasoning: true,
+    });
   }
   expect(
     findConfiguredProviderModel({ models }, "arcee", "trinity-large-thinking", normalize),

--- a/src/plugins/provider-model-routes.installed.test.ts
+++ b/src/plugins/provider-model-routes.installed.test.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { resolveModelProviderAuthConfig } from "../agents/model-auth-provider-route.js";
-import { resolveConfiguredModelCatalogOverrides } from "../agents/model-catalog-route.js";
+import { createConfiguredModelCatalogOverridesResolver } from "../agents/model-catalog-route.js";
 import type { ModelCatalogEntry, ModelCatalogSnapshot } from "../agents/model-catalog.types.js";
 import { getModelRefStatus, resolveModelRefFromString } from "../agents/model-selection.js";
 import { createModelVisibilityPolicy } from "../agents/model-visibility-policy.js";
@@ -384,9 +384,9 @@ describe("installed Arcee catalog identity", () => {
         },
       };
       expect(
-        resolveConfiguredModelCatalogOverrides({
-          cfg,
-          entry: { provider: "arcee", id: "trinity-large-thinking" },
+        createConfiguredModelCatalogOverridesResolver({ cfg })({
+          provider: "arcee",
+          id: "trinity-large-thinking",
         }),
       ).toMatchObject({ name: "Authored route", contextWindow: 32768 });
       const projected = resolveModelProviderAuthConfig({


### PR DESCRIPTION
## What Problem This Solves

Model-list requests spend unnecessary time preparing results when providers have large configured catalogs. Browsing those models repeats work for each returned row.

## Why This Change Was Made

Reuse the existing configured-model resolver once per catalog projection in both logical visibility and catalog views. The resolver retains exact/literal/canonical/legacy precedence and first-row duplicate-field merging. Indexes stay with one config/policy projection; raw provider spellings remain distinct, and query objects are not retained. Replacement configurations create new views.

## User Impact

Configured model catalogs require less request-time CPU while returning the same model metadata, routes and availability behavior. Five nonempty cases improved wall and CPU medians in both measured orders; pooled request wall reductions ranged from 12.31% to 42.92%.

## Evidence

- Formatting passed. All 120 focused tests across ten files passed, with no failures or skips, including both production callers, exact/alias/legacy precedence, duplicate merging, raw provider spelling and publication revocation.
- Independent P2 review found no actionable findings. The subsequent formatting-only wrapping emitted identical JavaScript under esbuild 0.28.2.
- The changed-file plan passed. The full changed gate remains incomplete: supervision stopped it at the core tsgo graph boundary after 65 cumulative observed processes exceeded the fixed 64-process cap. All observed children/groups closed and the lease was stopped. The failed worktree was retained until lease termination; normal worktree removal is not claimed. [Validation run](https://github.com/openclaw/openclaw/actions/runs/34659774725).

Measured the real `buildModelsListResult` boundary on base `fc7f3c65100`, with fresh index construction inside each request, actual thinking-policy preparation before freezing, two warmups and ten measured calls per child. Full output bytes, frozen inputs, policy Symbols and both-caller controls matched across retained phases.

| Complete nonempty case | Baseline → candidate wall median | Pooled reduction |
|---|---:|---:|
| 32 models, all, unrestricted | 6.833 → 4.481 ms | 34.43% |
| 1,024 models, all, unrestricted | 594.078 → 339.070 ms | 42.92% |
| 1,024 models, all, exact allowlist | 652.280 → 388.950 ms | 40.37% |
| 256 models, default, wildcard | 73.519 → 61.026 ms | 16.99% |
| 256 models, configured, wildcard | 66.323 → 58.157 ms | 12.31% |

These are descriptive medians from two process repetitions per variant, with material process-to-process variation. Imports, assertions and behavioral controls are excluded from request timings; RSS measures whole-process resident state, not per-request allocations.

Costs and limits are retained: the empty-catalog case increased by about 0.036 ms pooled (17.07% wall and 10.74% CPU); configured-view RSS increased 5.68%, and exact-allowlist RSS had mixed signs (+1.31% pooled). The fixed 360-second campaign deadline interrupted the final reverse-order baseline, leaving 27 complete children out of 28. That reverse case lacks a complete second-order comparison and is excluded from the five-case paired claim. Cold-process measurements also have mixed orders. No universal improvement or complete benchmark campaign is claimed. [Measurement run](https://github.com/openclaw/openclaw/actions/runs/34655861180).

**Current-head qualification:** Head `d078034091cf` preserves this PR's authored patch on main `bca261d5583d`, including the shared `retainedMachine` typecheck repair (#145540). Benchmarks, earlier validation, and prior draft-state notes remain historical under their original source labels; no benchmark was rerun for this rebase. Exact-head CI is required before landing.
