### PR TITLE
refactor(ui): share hovercard keyboard handling

### DIFF
--- a/ui/src/components/github-link-hovercard.runtime.ts
+++ b/ui/src/components/github-link-hovercard.runtime.ts
@@ -384,9 +384,6 @@ export class GitHubLinkHovercardProvider extends ReactiveElement {
   private activeTrigger: "focus" | "pointer" | null = null;
   private readonly hovercard = new PortaledHovercardController(() => this.close());
   private stopI18n: (() => void) | null = null;
-  // Spans the synchronous focus() that hands focus back to the trigger, so the
-  // card the user just dismissed cannot reopen under them (handleCardKeyDown).
-  private suppressFocusOpen = false;
   private readonly previewTask = new Task(this, {
     autoRun: false,
     args: () => [this.activeTarget] as const,
@@ -414,7 +411,7 @@ export class GitHubLinkHovercardProvider extends ReactiveElement {
     this.addEventListener("pointerout", this.handlePointerOut);
     this.addEventListener("focusin", this.handleFocusIn);
     this.addEventListener("focusout", this.handleFocusOut);
-    this.addEventListener("keydown", this.handleKeyDown);
+    this.addEventListener("keydown", this.hovercard.handleTriggerKeyDown);
     this.addEventListener("click", this.handleClick);
     this.stopI18n ??= i18n.subscribe(() => this.requestUpdate());
   }
@@ -424,7 +421,7 @@ export class GitHubLinkHovercardProvider extends ReactiveElement {
     this.removeEventListener("pointerout", this.handlePointerOut);
     this.removeEventListener("focusin", this.handleFocusIn);
     this.removeEventListener("focusout", this.handleFocusOut);
-    this.removeEventListener("keydown", this.handleKeyDown);
+    this.removeEventListener("keydown", this.hovercard.handleTriggerKeyDown);
     this.removeEventListener("click", this.handleClick);
     this.stopI18n?.();
     this.stopI18n = null;
@@ -507,7 +504,7 @@ export class GitHubLinkHovercardProvider extends ReactiveElement {
   };
 
   private readonly handleFocusIn = (event: Event) => {
-    if (this.suppressFocusOpen) {
+    if (this.hovercard.restoringFocus) {
       return;
     }
     const anchor = githubLinkAnchorFromEvent(event);
@@ -527,45 +524,6 @@ export class GitHubLinkHovercardProvider extends ReactiveElement {
     }
     this.hovercard.focusInside = false;
     this.scheduleIntentClose();
-  };
-
-  private readonly handleKeyDown = (event: KeyboardEvent) => {
-    if (event.key === "Escape") {
-      this.close();
-      return;
-    }
-    // The card is portaled to document.body and never lands next to its trigger
-    // in the tab sequence; forward Tab in, and let the card hand focus back
-    // (handleCardKeyDown), so its links stay keyboard-reachable at all.
-    if (event.key !== "Tab" || event.shiftKey || event.target !== this.activeAnchor) {
-      return;
-    }
-    const [first] = this.hovercard.focusables();
-    if (!first) {
-      return;
-    }
-    event.preventDefault();
-    first.focus();
-  };
-
-  private readonly handleCardKeyDown = (event: KeyboardEvent) => {
-    if (event.key !== "Escape" && event.key !== "Tab") {
-      return;
-    }
-    // Tab moves between the card's own links normally and only exits at the edge
-    // of that run: the card has no tab-sequence neighbour, so leaving it lands on
-    // the trigger like Escape does instead of dropping focus to the document.
-    const focusables = this.hovercard.focusables();
-    const edge = event.shiftKey ? focusables[0] : focusables.at(-1);
-    if (event.key === "Tab" && document.activeElement !== edge) {
-      return;
-    }
-    event.preventDefault();
-    const anchor = this.activeAnchor;
-    this.close();
-    this.suppressFocusOpen = true;
-    anchor?.focus({ preventScroll: true });
-    this.suppressFocusOpen = false;
   };
 
   private readonly handleClick = () => {
@@ -642,7 +600,7 @@ export class GitHubLinkHovercardProvider extends ReactiveElement {
     } else {
       // The provider's delegated listeners do not see the portaled card.
       card.addEventListener("pointerleave", this.handleCardPointerLeave);
-      card.addEventListener("keydown", this.handleCardKeyDown);
+      card.addEventListener("keydown", this.hovercard.handleCardKeyDown);
       this.hovercard.markTrigger(anchor);
       this.hovercard.mount(anchor, card, "vertical", true, () => render(nothing, card));
     }

--- a/ui/src/components/github-link-hovercard.test.ts
+++ b/ui/src/components/github-link-hovercard.test.ts
@@ -846,7 +846,7 @@ describe("openclaw-github-link-hovercard-provider", () => {
     expect(hovercard()).toBeNull();
   });
 
-  it("moves keyboard focus through the card's links and hands it back at the edges", async () => {
+  it.each([false, true])("hands focus back at Tab edges (shiftKey=%s)", async (shiftKey) => {
     const { anchor } = createIssueLink();
 
     anchor.focus();
@@ -866,11 +866,11 @@ describe("openclaw-github-link-hovercard-provider", () => {
     expect(insideTab.defaultPrevented).toBe(false);
     expect(hovercard()).not.toBeNull();
 
-    // Leaving the last link returns focus to the trigger with the card closed,
+    // Leaving either outer edge returns focus to the trigger with the card closed,
     // and that returned focus must not immediately reopen what was dismissed.
-    const last = cardLinks().at(-1);
-    last?.focus();
-    last?.dispatchEvent(new KeyboardEvent("keydown", { bubbles: true, key: "Tab" }));
+    const edge = shiftKey ? cardLinks()[0] : cardLinks().at(-1);
+    edge?.focus();
+    edge?.dispatchEvent(new KeyboardEvent("keydown", { bubbles: true, key: "Tab", shiftKey }));
     expect(hovercard()).toBeNull();
     expect(document.activeElement).toBe(anchor);
     await vi.advanceTimersByTimeAsync(GITHUB_HOVERCARD_CLOSE_DELAY_MS * 2);

--- a/ui/src/components/portaled-hovercard.ts
+++ b/ui/src/components/portaled-hovercard.ts
@@ -12,6 +12,7 @@ export class PortaledHovercardController {
   focusInside = false;
   cardFocusInside = false;
   explicitHold = false;
+  restoringFocus = false;
 
   private closeTimer: number | null = null;
   private exitCleanup: (() => void) | null = null;
@@ -48,7 +49,48 @@ export class PortaledHovercardController {
   constructor(
     private readonly close: () => void,
     private readonly closeDelayMs = 120,
+    private readonly dismiss: () => void = close,
   ) {}
+
+  readonly handleTriggerKeyDown = (event: KeyboardEvent) => {
+    if (event.key === "Escape") {
+      this.dismiss();
+      return;
+    }
+    // A portal is outside its trigger's tab sequence. Enter at the first link,
+    // then let native Tab traversal own the links inside the card.
+    if (event.key !== "Tab" || event.shiftKey || event.target !== this.trigger) {
+      return;
+    }
+    const first = this.focusables()[0];
+    if (first) {
+      event.preventDefault();
+      first.focus();
+    }
+  };
+
+  readonly handleCardKeyDown = (event: KeyboardEvent) => {
+    if (event.key !== "Escape" && event.key !== "Tab") {
+      return;
+    }
+    const focusables = this.focusables();
+    const edge = event.shiftKey ? focusables[0] : focusables.at(-1);
+    if (event.key === "Tab" && document.activeElement !== edge) {
+      return;
+    }
+    event.preventDefault();
+    // Capture before dismissal retires the trigger; focus must not reopen the
+    // card being dismissed. Scheduled pointer exit may animate, keyboard exit does not.
+    const trigger = this.trigger;
+    this.dismiss();
+    this.returnFocus(trigger);
+  };
+
+  returnFocus(trigger: HTMLElement | null): void {
+    this.restoringFocus = true;
+    trigger?.focus({ preventScroll: true });
+    this.restoringFocus = false;
+  }
 
   get held(): boolean {
     return (

--- a/ui/src/components/session-progress-hovercard.runtime.ts
+++ b/ui/src/components/session-progress-hovercard.runtime.ts
@@ -65,7 +65,6 @@ export class SessionProgressHovercardProvider extends ReactiveElement {
       ? scopedSessionArtifactKey(this.activeSession.sessionKey, this.activeSession.agentId)
       : null;
   }
-  private suppressFocusOpen = false;
   private open = false;
   private delayed = true;
   private animateNextOpen = true;
@@ -74,6 +73,7 @@ export class SessionProgressHovercardProvider extends ReactiveElement {
   private readonly hovercard = new PortaledHovercardController(
     () => this.close(true),
     CLOSE_DELAY_MS,
+    () => this.close(),
   );
   private readonly sessionLinkTitler = new SessionLinkTitler(this);
   private loadGeneration = 0;
@@ -141,7 +141,7 @@ export class SessionProgressHovercardProvider extends ReactiveElement {
     this.addEventListener("pointerout", this.handlePointerOut);
     this.addEventListener("focusin", this.handleFocusIn);
     this.addEventListener("focusout", this.handleFocusOut);
-    this.addEventListener("keydown", this.handleKeyDown);
+    this.addEventListener("keydown", this.hovercard.handleTriggerKeyDown);
     this.addEventListener("click", this.handleClick);
     this.addEventListener(SESSION_MENU_OPEN_EVENT, this.handleSessionMenuOpen);
     this.sessionLinkTitler.connect();
@@ -153,7 +153,7 @@ export class SessionProgressHovercardProvider extends ReactiveElement {
     this.removeEventListener("pointerout", this.handlePointerOut);
     this.removeEventListener("focusin", this.handleFocusIn);
     this.removeEventListener("focusout", this.handleFocusOut);
-    this.removeEventListener("keydown", this.handleKeyDown);
+    this.removeEventListener("keydown", this.hovercard.handleTriggerKeyDown);
     this.removeEventListener("click", this.handleClick);
     this.removeEventListener(SESSION_MENU_OPEN_EVENT, this.handleSessionMenuOpen);
     this.sessionLinkTitler.disconnect();
@@ -240,7 +240,7 @@ export class SessionProgressHovercardProvider extends ReactiveElement {
   };
 
   private readonly handleFocusIn = (event: FocusEvent) => {
-    if (this.suppressFocusOpen) {
+    if (this.hovercard.restoringFocus) {
       return;
     }
     const target = sessionProgressHoverTargetFromEvent(event);
@@ -264,21 +264,6 @@ export class SessionProgressHovercardProvider extends ReactiveElement {
     }
     this.hovercard.focusInside = false;
     this.hovercard.scheduleClose();
-  };
-
-  private readonly handleKeyDown = (event: KeyboardEvent) => {
-    if (event.key === "Escape") {
-      this.close();
-      return;
-    }
-    if (event.key !== "Tab" || event.shiftKey || event.target !== this.activeTrigger) {
-      return;
-    }
-    const first = this.cardFocusables()[0];
-    if (first) {
-      event.preventDefault();
-      first.focus();
-    }
   };
 
   private readonly handleClick = (event: Event) => {
@@ -469,7 +454,7 @@ export class SessionProgressHovercardProvider extends ReactiveElement {
         ? document.activeElement
         : null;
     const focusedCardIndex = focusedCardElement
-      ? this.cardFocusables().indexOf(focusedCardElement)
+      ? this.hovercard.focusables().indexOf(focusedCardElement)
       : -1;
     const focusedHref =
       focusedCardElement instanceof HTMLAnchorElement ? focusedCardElement.href : null;
@@ -509,7 +494,7 @@ export class SessionProgressHovercardProvider extends ReactiveElement {
     }
     if (mountedCard) {
       if (focusedCardElement && !card.contains(document.activeElement)) {
-        const focusables = this.cardFocusables();
+        const focusables = this.hovercard.focusables();
         const nextFocused =
           (focusedHref
             ? focusables.find(
@@ -520,9 +505,7 @@ export class SessionProgressHovercardProvider extends ReactiveElement {
           nextFocused.focus({ preventScroll: true });
         } else {
           this.hovercard.cardFocusInside = false;
-          this.suppressFocusOpen = true;
-          this.activeTrigger?.focus({ preventScroll: true });
-          this.suppressFocusOpen = false;
+          this.hovercard.returnFocus(this.activeTrigger);
           this.hovercard.focusInside = document.activeElement === this.activeTrigger;
         }
       }
@@ -530,7 +513,7 @@ export class SessionProgressHovercardProvider extends ReactiveElement {
       return;
     }
     card.addEventListener("pointerleave", this.handleCardPointerLeave);
-    card.addEventListener("keydown", this.handleCardKeyDown);
+    card.addEventListener("keydown", this.hovercard.handleCardKeyDown);
     this.hovercard.mount(target, card, sessionProgressHoverPlacementForTarget(target), false, () =>
       render(nothing, card),
     );
@@ -548,27 +531,6 @@ export class SessionProgressHovercardProvider extends ReactiveElement {
     this.hovercard.pointerOverCard = false;
     this.hovercard.scheduleClose();
   };
-
-  private readonly handleCardKeyDown = (event: KeyboardEvent) => {
-    if (event.key !== "Escape" && event.key !== "Tab") {
-      return;
-    }
-    const focusables = this.cardFocusables();
-    const edge = event.shiftKey ? focusables[0] : focusables.at(-1);
-    if (event.key === "Tab" && document.activeElement !== edge) {
-      return;
-    }
-    event.preventDefault();
-    const trigger = this.activeTrigger;
-    this.close();
-    this.suppressFocusOpen = true;
-    trigger?.focus({ preventScroll: true });
-    this.suppressFocusOpen = false;
-  };
-
-  private cardFocusables(): HTMLElement[] {
-    return this.hovercard.focusables();
-  }
 
   private personActivity(): PersonActivityRouting | undefined {
     const context = this.applicationContext;


### PR DESCRIPTION
## What Problem This Solves

GitHub-link and session-progress hovercards implement the same keyboard traversal and dismissal rules separately. That duplication makes it easier for one card to drift when focus handling changes.

## Why This Change Was Made

Move the shared trigger/card keyboard handlers and guarded focus restoration into the existing `PortaledHovercardController`, and remove the duplicate implementations from both consumers. Session keyboard dismissal still closes immediately, while scheduled pointer exits retain their animated close path. The People hovercard keeps its distinct keyboard handling.

Production change: **+54 / −92 lines (net −38)**. Test change: **+5 / −5 (net 0)**, expanding the existing edge test into a forward/backward Tab table. This four-file patch adds no dependency, configuration, protocol, storage, or public API change.

## User Impact

No intentional visual or behavioral change. Forward Tab enters a hovercard, traversal between its links stays native, Tab/Shift+Tab at the outer edges and Escape dismiss it, and focus returns without reopening the card.

## Evidence

Current validated commit: `75f7ab5eb92cbde8937bcced72afca3d28c08a7b`, tree `9bc65adf5396f119b19fce02811f081ae45af0ac`, based on `bf630269dbf8c0821885a46c0a58ca33aba1d1a0`. The four-file patch and net production reduction are unchanged by the refresh; upstream prefetch and nearest-provider protections remain intact.

- Five focused unit files: **161 passed** on the refreshed source.
- Four complete bundled Chromium suites (`github-link-hovercard`, `session-progress-hovercard`, `people-activity-card`, and `chat-model-controls`): **44 passed**, including both pointer and keyboard account selection and the current pagination/focus assertions. A fresh bundled UI build, complete source/runtime binding, 72 PNGs and three finalized videos were retained. These used Linux Node 24.19.0, Chromium 144.0.7559.0 and the repository's normal Playwright/FFmpeg prerequisites.
- The normal four-file changed-code gate completed **all 20 required checks**, including core-test/UI types, formatting, lint and guards, through configured Blacksmith Testbox. The [associated runner](https://github.com/openclaw/openclaw/actions/runs/34686792965) is the delegated session lifecycle; the native wrapper returned 0 and stopped its one-shot lease.
- A fresh complete P0–P2 managed review of exact commit `75f7ab5` and its current source/dependency context returned no actionable findings across all eight passes.

The focused unit command was `node scripts/run-vitest.mjs ui/src/components/github-link-hovercard.test.ts ui/src/components/tooltip.test.ts ui/src/components/session-progress-hovercard-target.test.ts ui/src/components/session-hovercard.test.ts ui/src/components/menu-surface.test.ts`. The changed gate used `node scripts/check-changed.mjs --` followed by the four changed files.

The [old-head CI run](https://github.com/openclaw/openclaw/actions/runs/34661060724) is retained as failed: a config-test graph boundary and an account-keyboard test's stale reload expectation blocked it. This failure-driven refresh includes the already-landed graph repair (#145431) and account-fixture/pagination fixes (#145405 and #145436), without introducing a competing test repair. The current 44-case browser run and full changed gate passed. [Hosted CI for exact refreshed head `75f7ab5`](https://github.com/openclaw/openclaw/actions/runs/34688818034) also completed **SUCCESS: 88 successful jobs and 13 skipped**, including every executed UI shard, real Gateway UI, performance, build artifacts and the required `openclaw/ci-gate`.

Historical paired proof remains separate: on the original `f551` baseline, the pristine five-file units passed 155 cases; original and candidate with the same test table each passed 156. Three complete bundled browser suites passed 30 cases on each role with matching inventories and source/runtime bindings. Those older results are not relabeled as current-head runs.

Earlier prerequisite and transport failures were retained separately from the successful proof. The canonical installer supplied missing FFmpeg, and the normal wrapper retained its source-sync behavior. No proof timeout, worker/resource limit, provider, or runtime override was added. These are synthetic mocked-Gateway browser checks, not live-backend, native-window, or full-package proof. No pixel/timing or browser-version parity is claimed. Initial pre-ready frames and viewport-resize padding remain in the recordings; Activity navigation is asserted by URL, not claimed as a fully painted final video frame.

### Before and after

Retained historical paired captures from the original baseline and `07c` candidate: the same native keyboard scenario with the title link focused. The relative-age label advances from 69d to 70d. These are not screenshots of the refreshed `75f7` run or a pixel-identity comparison.

![Before: GitHub hovercard title link focused by Tab](https://github.com/user-attachments/assets/6ff2d4a8-7ba6-4c0c-9b33-14ac7fc25cd5)

![After: GitHub hovercard title link focused by Tab](https://github.com/user-attachments/assets/a4311155-ef94-4f1d-bd64-208842a01a05)
