### PR TITLE
fix(macos): observe fast child process exits reliably

### DIFF
--- a/apps/macos/Sources/OpenClaw/BoundedProcess.swift
+++ b/apps/macos/Sources/OpenClaw/BoundedProcess.swift
@@ -1,5 +1,4 @@
 import Darwin
-import Dispatch
 import Foundation
 import Subprocess
 
@@ -18,97 +17,6 @@ enum BoundedProcess {
     private enum DeadlineOutcome: Sendable {
         case exited
         case timedOut
-    }
-
-    private final class ProcessExitSignal: @unchecked Sendable {
-        private let lock = NSLock()
-        private let processIdentifier: pid_t
-        private let source: DispatchSourceProcess?
-        private var continuation: CheckedContinuation<Void, Never>?
-        private var finished = false
-
-        init(processIdentifier: pid_t) {
-            self.processIdentifier = processIdentifier
-            if Self.hasExited(processIdentifier) {
-                self.source = nil
-                self.finished = true
-                return
-            }
-            let source = DispatchSource.makeProcessSource(
-                identifier: processIdentifier,
-                eventMask: .exit,
-                queue: .global(qos: .utility))
-            self.source = source
-            source.setEventHandler { [weak self] in
-                self?.finish()
-            }
-            source.resume()
-            // The child can exit between the initial waitid probe and kqueue
-            // registration. Recheck after resume so that race cannot consume
-            // the full timeout when no NOTE_EXIT event is delivered.
-            if Self.hasExited(processIdentifier) {
-                self.finish()
-            }
-        }
-
-        func wait() async {
-            await withTaskCancellationHandler {
-                await withCheckedContinuation { continuation in
-                    self.lock.lock()
-                    guard !self.finished else {
-                        self.lock.unlock()
-                        continuation.resume()
-                        return
-                    }
-                    self.continuation = continuation
-                    self.lock.unlock()
-                }
-            } onCancel: {
-                self.finish()
-            }
-        }
-
-        func pollUntilExit() async {
-            while !Task.isCancelled {
-                do {
-                    try await Task.sleep(for: .milliseconds(50))
-                } catch {
-                    return
-                }
-                if Self.hasExited(self.processIdentifier) {
-                    self.finish()
-                    return
-                }
-            }
-        }
-
-        func hasExited() -> Bool {
-            Self.hasExited(self.processIdentifier)
-        }
-
-        private func finish() {
-            self.lock.lock()
-            guard !self.finished else {
-                self.lock.unlock()
-                return
-            }
-            self.finished = true
-            let continuation = self.continuation
-            self.continuation = nil
-            self.lock.unlock()
-            self.source?.cancel()
-            continuation?.resume()
-        }
-
-        private static func hasExited(_ processIdentifier: pid_t) -> Bool {
-            while true {
-                var info = siginfo_t()
-                if waitid(P_PID, id_t(processIdentifier), &info, WEXITED | WNOHANG | WNOWAIT) == 0 {
-                    return info.si_pid != 0 || info.si_signo != 0
-                }
-                guard errno == EINTR else { return false }
-            }
-        }
     }
 
     static func run(
@@ -141,17 +49,11 @@ enum BoundedProcess {
             output: .bytes(limit: self.outputLimit),
             error: standardError)
         { execution in
-            let exitSignal = ProcessExitSignal(
+            let exitSignal = ChildProcessExit(
                 processIdentifier: pid_t(execution.processIdentifier.value))
             let deadline = await withTaskGroup(of: DeadlineOutcome.self) { group in
                 group.addTask {
                     await exitSignal.wait()
-                    return .exited
-                }
-                // Keep normal exits event-driven, but recover promptly if
-                // kqueue misses NOTE_EXIT under heavy concurrent spawning.
-                group.addTask {
-                    await exitSignal.pollUntilExit()
                     return .exited
                 }
                 group.addTask {

--- a/apps/macos/Sources/OpenClaw/ChildProcessExit.swift
+++ b/apps/macos/Sources/OpenClaw/ChildProcessExit.swift
@@ -1,0 +1,107 @@
+import Darwin
+import Dispatch
+import Foundation
+
+/// Observes one unreaped child until exit or cancellation; it never signals or reaps it.
+final class ChildProcessExit: @unchecked Sendable {
+    private let lock = NSLock()
+    private let processIdentifier: pid_t
+    private let source: DispatchSourceProcess?
+    private var continuation: CheckedContinuation<Void, Never>?
+    private var finished = false
+
+    init(processIdentifier: pid_t, queue: DispatchQueue = .global(qos: .utility)) {
+        self.processIdentifier = processIdentifier
+        if Self.hasExited(processIdentifier) {
+            self.source = nil
+            self.finished = true
+            return
+        }
+        let source = DispatchSource.makeProcessSource(
+            identifier: processIdentifier,
+            eventMask: .exit,
+            queue: queue)
+        self.source = source
+        source.setEventHandler { [weak self] in
+            self?.finish()
+        }
+        source.resume()
+        // The child can exit between the initial waitid probe and kqueue
+        // registration. Recheck after resume so that race cannot consume
+        // the full timeout when no NOTE_EXIT event is delivered.
+        if Self.hasExited(processIdentifier) {
+            self.finish()
+        }
+    }
+
+    func wait() async {
+        await withTaskGroup(of: Void.self) { group in
+            group.addTask { await self.waitForSignal() }
+            group.addTask { await self.pollUntilExit() }
+            defer { group.cancelAll() }
+            _ = await group.next()
+        }
+    }
+
+    private func waitForSignal() async {
+        await withTaskCancellationHandler {
+            await withCheckedContinuation { continuation in
+                self.lock.lock()
+                guard !self.finished else {
+                    self.lock.unlock()
+                    continuation.resume()
+                    return
+                }
+                self.continuation = continuation
+                self.lock.unlock()
+            }
+        } onCancel: {
+            self.finish()
+        }
+    }
+
+    /// Recover missed NOTE_EXIT events without making launchers own a second observer.
+    private func pollUntilExit() async {
+        while !Task.isCancelled {
+            do {
+                try await Task.sleep(for: .milliseconds(50))
+            } catch {
+                return
+            }
+            if Self.hasExited(self.processIdentifier) {
+                self.finish()
+                return
+            }
+        }
+    }
+
+    func hasExited() -> Bool {
+        Self.hasExited(self.processIdentifier)
+    }
+
+    private func finish() {
+        self.lock.lock()
+        guard !self.finished else {
+            self.lock.unlock()
+            return
+        }
+        self.finished = true
+        let continuation = self.continuation
+        self.continuation = nil
+        self.lock.unlock()
+        self.source?.cancel()
+        continuation?.resume()
+    }
+
+    /// Subprocess owns reaping after its body completes. WNOWAIT keeps that
+    /// status available and pins the process-group identity during cleanup.
+    static func hasExited(_ processIdentifier: pid_t) -> Bool {
+        while true {
+            var info = siginfo_t()
+            if waitid(P_PID, id_t(processIdentifier), &info, WEXITED | WNOHANG | WNOWAIT) == 0 {
+                return info.si_pid != 0 || info.si_signo != 0
+            }
+            guard errno == EINTR else { return false }
+        }
+    }
+}

--- a/apps/macos/Sources/OpenClaw/ManagedProcess.swift
+++ b/apps/macos/Sources/OpenClaw/ManagedProcess.swift
@@ -82,12 +82,6 @@ final class ManagedProcess: @unchecked Sendable {
         func finish() {
             self.lock.withLock { self.finished = true }
         }
-
-        static func hasExited(_ processIdentifier: pid_t) -> Bool {
-            var info = siginfo_t()
-            return waitid(P_PID, id_t(processIdentifier), &info, WEXITED | WNOHANG | WNOWAIT) == 0 &&
-                info.si_pid != 0
-        }
     }
 
     private let state: State
@@ -151,7 +145,7 @@ final class ManagedProcess: @unchecked Sendable {
                     }
                     exitSource.setEventHandler(handler: didExit)
                     exitSource.resume()
-                    if State.hasExited(pid) { didExit() }
+                    if ChildProcessExit.hasExited(pid) { didExit() }
                     var wakeIterator = wakeEvents.makeAsyncIterator()
                     let wakeReason = await wakeIterator.next() ?? .terminate(gracefully: true)
                     exitSource.cancel()
@@ -161,7 +155,7 @@ final class ManagedProcess: @unchecked Sendable {
                         try? await Task.sleep(for: .milliseconds(50))
                     }
 
-                    guard !State.hasExited(pid),
+                    guard !ChildProcessExit.hasExited(pid),
                           case let .terminate(gracefully: graceful) = wakeReason
                     else {
                         // The unreaped leader pins the group identity while descendants are killed.
@@ -255,7 +249,7 @@ final class ManagedProcess: @unchecked Sendable {
     {
         let deadline = ContinuousClock.now.advanced(by: timeout)
         while ContinuousClock.now < deadline {
-            if State.hasExited(processIdentifier) { return true }
+            if ChildProcessExit.hasExited(processIdentifier) { return true }
             if state?.shouldAbortGracefulTermination == true { return false }
             do {
                 try await Task.sleep(for: .milliseconds(10))
@@ -263,6 +257,6 @@ final class ManagedProcess: @unchecked Sendable {
                 return false
             }
         }
-        return State.hasExited(processIdentifier)
+        return ChildProcessExit.hasExited(processIdentifier)
     }
 }

--- a/apps/macos/Sources/OpenClaw/ShellExecutor.swift
+++ b/apps/macos/Sources/OpenClaw/ShellExecutor.swift
@@ -103,55 +103,6 @@ enum ShellExecutor {
         }
     }
 
-    private final class ProcessExitSignal: @unchecked Sendable {
-        private let lock = NSLock()
-        private let source: DispatchSourceProcess
-        private var continuation: CheckedContinuation<Void, Never>?
-        private var finished = false
-
-        init(processIdentifier: pid_t) {
-            self.source = DispatchSource.makeProcessSource(
-                identifier: processIdentifier,
-                eventMask: .exit,
-                queue: .global(qos: .userInitiated))
-            self.source.setEventHandler { [weak self] in
-                self?.finish()
-            }
-            self.source.resume()
-        }
-
-        func wait() async {
-            await withTaskCancellationHandler {
-                await withCheckedContinuation { continuation in
-                    self.lock.lock()
-                    guard !self.finished else {
-                        self.lock.unlock()
-                        continuation.resume()
-                        return
-                    }
-                    self.continuation = continuation
-                    self.lock.unlock()
-                }
-            } onCancel: {
-                self.finish()
-            }
-        }
-
-        private func finish() {
-            self.lock.lock()
-            guard !self.finished else {
-                self.lock.unlock()
-                return
-            }
-            self.finished = true
-            let continuation = self.continuation
-            self.continuation = nil
-            self.lock.unlock()
-            self.source.cancel()
-            continuation?.resume()
-        }
-    }
-
     private static func environment(from values: [String: String]?) -> Environment {
         guard let values else { return .inherit }
         var converted: [Environment.Key: String] = [:]
@@ -259,8 +210,10 @@ enum ShellExecutor {
     {
         let processIdentifier = pid_t(execution.processIdentifier.value)
         return await withTaskCancellationHandler {
+            let exitSignal = ChildProcessExit(
+                processIdentifier: processIdentifier,
+                queue: .global(qos: .userInitiated))
             let deadline = await withTaskGroup(of: DeadlineOutcome.self) { group in
-                let exitSignal = ProcessExitSignal(processIdentifier: processIdentifier)
                 group.addTask {
                     await exitSignal.wait()
                     return .exited
@@ -277,7 +230,7 @@ enum ShellExecutor {
                 return await group.next() ?? .exited
             }
 
-            guard deadline == .timedOut else { return false }
+            guard deadline == .timedOut, !exitSignal.hasExited() else { return false }
             try? execution.send(signal: .terminate, toProcessGroup: true)
             try? await Task.sleep(for: .milliseconds(100))
             // The group leader may have exited on TERM. Keep the body alive until

--- a/apps/macos/Tests/OpenClawIPCTests/ShellExecutorTimeoutTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ShellExecutorTimeoutTests.swift
@@ -20,6 +20,36 @@ struct ShellExecutorTimeoutTests {
     /// This is a fixture budget, not the timeout behavior under test.
     private static let fixtureTimeout: TimeInterval = 1.0
 
+    @Test(arguments: [false, true])
+    func `parallel instant exits preserve their exit status`(streaming: Bool) async {
+        await withTaskGroup(of: Void.self) { group in
+            for index in 0..<32 {
+                group.addTask {
+                    let exitCode = index.isMultiple(of: 2) ? 0 : 7
+                    let command = ["/bin/sh", "-c", "exit \(exitCode)"]
+                    // Process startup under concurrent load is not a latency assertion.
+                    let result = if streaming {
+                        await ShellExecutor.runStreamingDetailed(
+                            command: command,
+                            cwd: nil,
+                            env: nil,
+                            timeout: 30,
+                            onStandardOutputLine: { _ in })
+                    } else {
+                        await ShellExecutor.runDetailed(
+                            command: command,
+                            cwd: nil,
+                            env: nil,
+                            timeout: 30)
+                    }
+                    #expect(!result.timedOut)
+                    #expect(result.exitCode == exitCode)
+                    #expect(result.success == (exitCode == 0))
+                }
+            }
+        }
+    }
+
     @Test func `streaming captures both streams while delivering stdout lines`() async {
         let recorder = ShellLineRecorder()
         let result = await ShellExecutor.runStreamingDetailed(


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a command that exited immediately could be reported as timed out if the process-exit notification was missed. The macOS command runners had separate observers with different handling of this race.

## Why This Change Was Made

ChildProcessExit consolidates the non-reaping exit probe, event registration race check, cancellation, and missed-notification polling. BoundedProcess and ShellExecutor use it while retaining their own output, timeout, and termination policies. ManagedProcess uses only the common probe and keeps its distinct graceful-shutdown lifecycle. The observer joins its polling work before swift-subprocess reaps the child.

## User Impact

Fast successful and failing commands retain their real exit result. Existing command timeout, cancellation, process-group cleanup, and output limits stay with their current owners.

## Evidence

- Added real concurrent immediate-exit cases for both ShellExecutor output paths in ShellExecutorTimeoutTests; existing BoundedProcess, ManagedProcess, and cancellation suites remain intact.
- Lead inspected the installed swift-subprocess body/monitor/reaping order to verify that WNOWAIT preserves exit status and process identity through cleanup.
- Swift app/test build, lint/format, native localization verification, and git diff --check passed. Independent Codex P2 review is scoped-clean; cross-lane review found no additional conflict.
- Required CI and native tests passed on this exact head: [CI run34661529545](https://github.com/openclaw/openclaw/actions/runs/34661529545). No operator state, app, Gateway, or full native suite was used locally. The missed-event race has source and regression coverage; no deterministic negative-control execution is claimed.
