### PR TITLE
perf(models): index thinking lookups per catalog request

### DIFF
--- a/src/agents/model-thinking-default-core.ts
+++ b/src/agents/model-thinking-default-core.ts
@@ -3,7 +3,10 @@ import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalLowercaseString,
 } from "@openclaw/normalization-core/string-coerce";
-import { resolveThinkingDefaultForModel } from "../auto-reply/thinking.js";
+import {
+  resolveThinkingDefaultForModel,
+  type ThinkingCatalogResolver,
+} from "../auto-reply/thinking.js";
 import type { ThinkLevel } from "../auto-reply/thinking.shared.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { ProviderThinkingPolicySource } from "../plugins/provider-thinking.types.js";
@@ -61,6 +64,7 @@ export function resolveConfiguredThinkingDefaultCore(params: {
 export function resolveThinkingDefaultCore(
   params: ThinkingDefaultParams & {
     providerPolicySource?: ProviderThinkingPolicySource;
+    catalogResolver?: ThinkingCatalogResolver;
   },
 ): ThinkLevel {
   const normalizedProvider = normalizeProviderId(params.provider);
@@ -121,6 +125,7 @@ export function resolveThinkingDefaultCore(
     provider: params.provider,
     model: params.model,
     catalog,
+    catalogResolver: params.catalogResolver,
     agentRuntime: params.agentRuntime,
     providerPolicySource: params.providerPolicySource,
   });

--- a/src/auto-reply/thinking.test.ts
+++ b/src/auto-reply/thinking.test.ts
@@ -29,6 +29,25 @@ beforeEach(() => {
   providerRuntimeMocks.resolveProviderThinkingProfile.mockReturnValue(undefined);
 });
 
+function mockQwenThinkingCatalog(id: string) {
+  providerRuntimeMocks.resolveProviderThinkingProfile.mockImplementation(({ context }) =>
+    context.reasoning === true && context.compat?.thinkingFormat === "qwen-chat-template"
+      ? {
+          levels: [{ id: "off" }, { id: "low", label: "on" }],
+          defaultLevel: "off",
+        }
+      : undefined,
+  );
+  return [
+    {
+      provider: "vllm",
+      id,
+      reasoning: true,
+      compat: { thinkingFormat: "qwen-chat-template" },
+    },
+  ];
+}
+
 describe("normalizeThinkLevel", () => {
   it("normalizes the documented none alias to off", () => {
     expect(normalizeThinkLevel("none")).toBe("off");
@@ -377,22 +396,7 @@ describe("listThinkingLevels", () => {
   });
 
   it("passes catalog compat into provider thinking profiles", () => {
-    providerRuntimeMocks.resolveProviderThinkingProfile.mockImplementation(({ context }) =>
-      context.reasoning === true && context.compat?.thinkingFormat === "qwen-chat-template"
-        ? {
-            levels: [{ id: "off" }, { id: "low", label: "on" }],
-            defaultLevel: "off",
-          }
-        : undefined,
-    );
-    const catalog = [
-      {
-        provider: "vllm",
-        id: "Qwen/Qwen3-8B",
-        reasoning: true,
-        compat: { thinkingFormat: "qwen-chat-template" },
-      },
-    ];
+    const catalog = mockQwenThinkingCatalog("Qwen/Qwen3-8B");
 
     expect(listThinkingLevelLabels("vllm", "Qwen/Qwen3-8B", catalog)).toEqual(["off", "on"]);
     for (const level of ["high", "adaptive"] as const) {
@@ -701,22 +705,7 @@ describe("listThinkingLevels", () => {
   });
 
   it("matches provider-qualified catalog ids for provider thinking profiles", () => {
-    providerRuntimeMocks.resolveProviderThinkingProfile.mockImplementation(({ context }) =>
-      context.reasoning === true && context.compat?.thinkingFormat === "qwen-chat-template"
-        ? {
-            levels: [{ id: "off" }, { id: "low", label: "on" }],
-            defaultLevel: "off",
-          }
-        : undefined,
-    );
-    const catalog = [
-      {
-        provider: "vllm",
-        id: "vllm/Qwen/Qwen3-8B",
-        reasoning: true,
-        compat: { thinkingFormat: "qwen-chat-template" },
-      },
-    ];
+    const catalog = mockQwenThinkingCatalog("vllm/Qwen/Qwen3-8B");
 
     expect(listThinkingLevelLabels("vllm", "Qwen/Qwen3-8B", catalog)).toEqual(["off", "on"]);
     expect(

--- a/src/auto-reply/thinking.test.ts
+++ b/src/auto-reply/thinking.test.ts
@@ -10,6 +10,8 @@ vi.mock("../plugins/provider-thinking.js", () => ({
 }));
 
 const {
+  createThinkingCatalogResolver,
+  resolveThinkingProfile,
   listThinkingLevelLabels,
   listThinkingLevelOptions,
   listThinkingLevels,
@@ -75,6 +77,40 @@ describe("normalizeThinkLevel", () => {
     expect(normalizeThinkLevel("ULTRA")).toBe("ultra");
     expect(normalizeThinkLevel("ultrathink")).toBe("high");
   });
+});
+
+describe("prepared thinking catalog identity", () => {
+  it.each([
+    { provider: " demo ", model: " Mixed ", expected: ["high"] },
+    { provider: "demo", model: "demo/Mixed", expected: ["high"] },
+    { provider: "demo", model: "mixed", expected: ["off", "minimal", "low", "medium", "high"] },
+    { provider: "demo-cli", model: "Mixed", expected: ["off", "minimal", "low", "medium", "high"] },
+    { provider: "demo", model: "DEMO/Mixed", expected: ["off"] },
+  ])(
+    "preserves first-match and case rules for $provider/$model",
+    ({ provider, model, expected }) => {
+      const catalog = [
+        {
+          provider: " DEMO ",
+          id: "demo/Mixed",
+          reasoning: true,
+          thinkingLevelMap: { off: null, minimal: null, low: null, medium: null },
+        },
+        { provider: "demo", id: "Mixed", reasoning: false },
+        { provider: "demo", id: "DEMO/Mixed", reasoning: false },
+      ];
+      const catalogResolver = createThinkingCatalogResolver(catalog);
+      for (const prepared of [undefined, catalogResolver]) {
+        const profile = resolveThinkingProfile({
+          provider,
+          model,
+          catalog,
+          catalogResolver: prepared,
+        });
+        expect(profile.levels.map(({ id }) => id)).toEqual(expected);
+      }
+    },
+  );
 });
 
 describe("listThinkingLevels", () => {

--- a/src/auto-reply/thinking.ts
+++ b/src/auto-reply/thinking.ts
@@ -70,16 +70,51 @@ function buildCatalogModelKey(provider: string, model: string): string {
     : `${providerId}/${modelId}`;
 }
 
-function resolveThinkingCatalogEntry(params: {
+type ThinkingCatalogQuery = {
   provider?: string | null;
   model?: string | null;
-  catalog?: ThinkingCatalogEntry[];
-}): ThinkingCatalogEntry | undefined {
+};
+
+export type ThinkingCatalogResolver = (
+  params: ThinkingCatalogQuery,
+) => ThinkingCatalogEntry | undefined;
+
+function resolveThinkingCatalogKey(params: ThinkingCatalogQuery): string | undefined {
   const providerRaw = normalizeOptionalString(params.provider);
   const normalizedProvider = providerRaw ? normalizeProviderId(providerRaw) : "";
   const modelId = normalizeOptionalString(params.model) ?? "";
-  const selectedCatalogKey =
-    normalizedProvider && modelId ? buildCatalogModelKey(normalizedProvider, modelId) : undefined;
+  return normalizedProvider && modelId
+    ? buildCatalogModelKey(normalizedProvider, modelId)
+    : undefined;
+}
+
+/** Indexes one prepared catalog while retaining its first matching row and policy owner. */
+export function createThinkingCatalogResolver(
+  catalog: readonly ThinkingCatalogEntry[],
+): ThinkingCatalogResolver {
+  const byKey = new Map<string, ThinkingCatalogEntry>();
+  for (const entry of catalog) {
+    const key = buildCatalogModelKey(normalizeProviderId(entry.provider), entry.id);
+    if (!byKey.has(key)) {
+      byKey.set(key, entry);
+    }
+  }
+  return (params) => {
+    const key = resolveThinkingCatalogKey(params);
+    return key === undefined ? undefined : byKey.get(key);
+  };
+}
+
+function resolveThinkingCatalogEntry(
+  params: ThinkingCatalogQuery & {
+    catalog?: ThinkingCatalogEntry[];
+    catalogResolver?: ThinkingCatalogResolver;
+  },
+): ThinkingCatalogEntry | undefined {
+  if (params.catalogResolver) {
+    return params.catalogResolver(params);
+  }
+  const selectedCatalogKey = resolveThinkingCatalogKey(params);
   const selected = params.catalog?.find(
     (entry) =>
       selectedCatalogKey !== undefined &&
@@ -92,6 +127,7 @@ function resolveThinkingPolicyContext(params: {
   provider?: string | null;
   model?: string | null;
   catalog?: ThinkingCatalogEntry[];
+  catalogResolver?: ThinkingCatalogResolver;
   agentRuntime?: string | null;
   configuredReasoning?: boolean;
 }) {
@@ -214,6 +250,7 @@ export function resolveThinkingProfile(params: {
   provider?: string | null;
   model?: string | null;
   catalog?: ThinkingCatalogEntry[];
+  catalogResolver?: ThinkingCatalogResolver;
   agentRuntime?: string | null;
   configuredReasoning?: boolean;
   providerPolicySource?: ProviderThinkingPolicySource;
@@ -346,6 +383,7 @@ export function resolveThinkingDefaultForModel(params: {
   provider: string;
   model: string;
   catalog?: ThinkingCatalogEntry[];
+  catalogResolver?: ThinkingCatalogResolver;
   agentRuntime?: string | null;
   providerPolicySource?: ProviderThinkingPolicySource;
 }): ThinkLevel {
@@ -353,6 +391,7 @@ export function resolveThinkingDefaultForModel(params: {
     provider: params.provider,
     model: params.model,
     catalog: params.catalog,
+    catalogResolver: params.catalogResolver,
     agentRuntime: params.agentRuntime,
     providerPolicySource: params.providerPolicySource,
   });
@@ -410,6 +449,7 @@ export function resolveSupportedThinkingLevel(params: {
   model?: string | null;
   level: ThinkLevel;
   catalog?: ThinkingCatalogEntry[];
+  catalogResolver?: ThinkingCatalogResolver;
   agentRuntime?: string | null;
   configuredReasoning?: boolean;
   providerPolicySource?: ProviderThinkingPolicySource;
@@ -418,6 +458,7 @@ export function resolveSupportedThinkingLevel(params: {
     provider: params.provider,
     model: params.model,
     catalog: params.catalog,
+    catalogResolver: params.catalogResolver,
     agentRuntime: params.agentRuntime,
     configuredReasoning: params.configuredReasoning,
     providerPolicySource: params.providerPolicySource,

--- a/src/gateway/server-methods/models-list-result.ts
+++ b/src/gateway/server-methods/models-list-result.ts
@@ -48,6 +48,7 @@ import {
 import { isPreparedModelCatalogFull } from "../../agents/prepared-model-runtime.full-catalog.js";
 import { preparedModelRuntimeConfigsMatch } from "../../agents/prepared-model-runtime.js";
 import { resolveDefaultAgentWorkspaceDir } from "../../agents/workspace.js";
+import { createThinkingCatalogResolver } from "../../auto-reply/thinking.js";
 import { getRuntimeConfig, getRuntimeConfigSourceSnapshot } from "../../config/config.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { PluginMetadataSnapshot } from "../../plugins/plugin-metadata-snapshot.types.js";
@@ -121,6 +122,7 @@ function createPublicModelsListProjector(params: {
   preserveUnknownAvailability?: boolean;
   apiKeyCapabilities?: ApiKeyProviderCapabilities;
 }) {
+  const catalogResolver = createThinkingCatalogResolver(params.thinkingCatalog);
   // Route rows retain identity across reads; keep display/thinking work outside the hot overlay.
   const prepared = new WeakMap<ModelCatalogEntry, ModelsListEntryWithCapabilities>();
   return (
@@ -157,6 +159,7 @@ function createPublicModelsListProjector(params: {
               model: entry.id,
               agentRuntime: selectedRuntime?.id ?? "openclaw",
               modelCatalog: params.thinkingCatalog,
+              catalogResolver,
               configuredReasoning: publicEntry.configuredReasoning ?? publicEntry.reasoning,
               thinkingPolicyProvider: publicEntry.thinkingPolicyProvider,
             });

--- a/src/gateway/session-utils-model.thinking-default.test.ts
+++ b/src/gateway/session-utils-model.thinking-default.test.ts
@@ -1,5 +1,12 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import type { ModelCatalogEntry } from "../agents/model-catalog.types.js";
+import { createThinkingCatalogResolver } from "../auto-reply/thinking.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import {
+  PREPARED_THINKING_POLICY,
+  type PreparedThinkingPolicy,
+  type ThinkingCatalogPolicyCarrier,
+} from "../plugins/provider-thinking-catalog.js";
 import type { ProviderThinkingRegistry } from "../plugins/provider-thinking.types.js";
 import { resolveGatewayModelThinkingProfile } from "./session-utils-model.js";
 
@@ -117,5 +124,110 @@ describe.each([
     });
     expect(profile.thinkingDefault).toBe(expected);
     expect(profile.thinkingLevels.map(({ id }) => id)).toContain(expected);
+  });
+});
+
+describe.each([false, true])("Gateway thinking catalog indexed=%s", (indexed) => {
+  it.each([
+    { configured: false, configuredReasoning: undefined, expected: "low" },
+    { configured: true, configuredReasoning: undefined, expected: "high" },
+    { configured: false, configuredReasoning: false, expected: "off" },
+  ])("keeps logical defaults separate from donor levels: %j", (scenario) => {
+    const logicalPolicy = vi.fn<PreparedThinkingPolicy>(() => ({
+      levels: [{ id: "off" }, { id: "medium" }, { id: "high" }],
+      defaultLevel: "medium",
+    }));
+    const donorPolicy = vi.fn<PreparedThinkingPolicy>(() => ({
+      levels: [{ id: "off" }, { id: "low", label: "On" }, { id: "high" }],
+      defaultLevel: "high",
+    }));
+    const catalog: (ModelCatalogEntry & ThinkingCatalogPolicyCarrier)[] = [
+      {
+        provider: "logical",
+        id: "Reasoner",
+        name: "Logical",
+        reasoning: true,
+        [PREPARED_THINKING_POLICY]: logicalPolicy,
+      },
+      {
+        provider: "donor",
+        id: "Reasoner",
+        name: "Donor",
+        reasoning: true,
+        [PREPARED_THINKING_POLICY]: donorPolicy,
+      },
+    ];
+    const cfg: OpenClawConfig = scenario.configured
+      ? {
+          agents: {
+            defaults: {
+              models: {
+                "logical/Reasoner": { params: { thinking: "high" } },
+                "donor/Reasoner": { params: { thinking: "off" } },
+              },
+            },
+          },
+        }
+      : {};
+    const profile = resolveGatewayModelThinkingProfile({
+      cfg,
+      agentId: "main",
+      provider: "logical",
+      model: "Reasoner",
+      thinkingPolicyProvider: "donor",
+      agentRuntime: "openclaw",
+      modelCatalog: catalog,
+      catalogResolver: indexed ? createThinkingCatalogResolver(catalog) : undefined,
+      configuredReasoning: scenario.configuredReasoning,
+    });
+    expect(profile.thinkingLevels).toEqual(
+      scenario.configuredReasoning === false
+        ? [{ id: "off", label: "off" }]
+        : [
+            { id: "off", label: "off" },
+            { id: "low", label: "On" },
+            { id: "high", label: "high" },
+          ],
+    );
+    expect(profile.thinkingDefault).toBe(scenario.expected);
+    expect(logicalPolicy).toHaveBeenCalledTimes(scenario.configured ? 0 : 1);
+    expect(donorPolicy).toHaveBeenCalledTimes(2);
+  });
+
+  it("retains an authoritative absent policy across all default and clamp reads", () => {
+    const otherPolicy = vi.fn<PreparedThinkingPolicy>(() => ({
+      levels: [{ id: "high" }],
+      defaultLevel: "high",
+    }));
+    const catalog: (ModelCatalogEntry & ThinkingCatalogPolicyCarrier)[] = [
+      {
+        provider: "captured-null",
+        id: "Reasoner",
+        name: "Reasoner",
+        reasoning: true,
+        [PREPARED_THINKING_POLICY]: null,
+      },
+    ];
+    const profile = resolveGatewayModelThinkingProfile({
+      cfg: {},
+      agentId: "main",
+      provider: "captured-null",
+      model: "Reasoner",
+      agentRuntime: "openclaw",
+      modelCatalog: catalog,
+      catalogResolver: indexed ? createThinkingCatalogResolver(catalog) : undefined,
+      providerPolicySource: {
+        providers: [{ provider: { id: "captured-null", resolveThinkingProfile: otherPolicy } }],
+      },
+    });
+    expect(profile.thinkingLevels.map(({ id }) => id)).toEqual([
+      "off",
+      "minimal",
+      "low",
+      "medium",
+      "high",
+    ]);
+    expect(profile.thinkingDefault).toBe("medium");
+    expect(otherPolicy).not.toHaveBeenCalled();
   });
 });

--- a/src/gateway/session-utils-model.ts
+++ b/src/gateway/session-utils-model.ts
@@ -24,7 +24,6 @@ import {
   parseModelRef,
   resolveConfiguredModelRef,
   resolveDefaultModelForAgent,
-  resolveThinkingDefault,
 } from "../agents/model-selection.js";
 import { resolveThinkingDefaultCore } from "../agents/model-thinking-default-core.js";
 import { publishedModelCatalogOwnerMatchesAgent } from "../agents/prepared-model-catalog-owner.js";
@@ -37,6 +36,7 @@ import {
   normalizeThinkLevel,
   resolveSupportedThinkingLevel,
   resolveThinkingProfile,
+  type ThinkingCatalogResolver,
 } from "../auto-reply/thinking.js";
 import { tryResolveLegacyCompatibilityAgentId } from "../config/legacy.default-agent-owner.js";
 import { resolveAgentMainSessionKey, type SessionEntry } from "../config/sessions.js";
@@ -61,6 +61,7 @@ function listGatewayThinkingLevelOptions(params: {
   provider: string;
   model: string;
   modelCatalog?: ModelCatalogEntry[];
+  catalogResolver?: ThinkingCatalogResolver;
   agentRuntime: string;
   configuredReasoning?: boolean;
   providerPolicySource?: ThinkingProviderPolicySource;
@@ -69,6 +70,7 @@ function listGatewayThinkingLevelOptions(params: {
     provider: params.provider,
     model: params.model,
     catalog: params.modelCatalog,
+    catalogResolver: params.catalogResolver,
     agentRuntime: params.agentRuntime,
     configuredReasoning: params.configuredReasoning,
     providerPolicySource: params.providerPolicySource,
@@ -81,6 +83,7 @@ function resolveGatewaySessionThinkingLevel(params: {
   model: string;
   level: NonNullable<ReturnType<typeof normalizeThinkLevel>>;
   modelCatalog?: ModelCatalogEntry[];
+  catalogResolver?: ThinkingCatalogResolver;
   agentRuntime: string;
   configuredReasoning?: boolean;
   providerPolicySource?: ThinkingProviderPolicySource;
@@ -107,6 +110,7 @@ function resolveGatewaySessionThinkingLevel(params: {
     model: params.model,
     level: params.level,
     catalog: params.modelCatalog,
+    catalogResolver: params.catalogResolver,
     agentRuntime: params.agentRuntime,
     configuredReasoning: params.configuredReasoning,
     providerPolicySource: params.providerPolicySource,
@@ -120,6 +124,7 @@ function resolveGatewaySessionThinkingDefault(params: {
   model: string;
   agentId?: string;
   modelCatalog?: ModelCatalogEntry[];
+  catalogResolver?: ThinkingCatalogResolver;
   agentRuntime: string;
   configuredReasoning?: boolean;
   providerPolicySource?: ThinkingProviderPolicySource;
@@ -127,22 +132,16 @@ function resolveGatewaySessionThinkingDefault(params: {
   const agentThinkingDefault = params.agentId
     ? resolveAgentConfig(params.cfg, params.agentId)?.thinkingDefault
     : undefined;
-  const resolveDefault =
-    params.providerPolicySource !== undefined && params.providerPolicySource !== "active-or-bundled"
-      ? (defaultParams: Parameters<typeof resolveThinkingDefault>[0]) =>
-          resolveThinkingDefaultCore({
-            ...defaultParams,
-            providerPolicySource: params.providerPolicySource,
-          })
-      : resolveThinkingDefault;
   const defaultLevel =
     agentThinkingDefault ??
-    resolveDefault({
+    resolveThinkingDefaultCore({
       cfg: params.cfg,
       provider: params.provider,
       model: params.model,
       catalog: params.modelCatalog,
+      catalogResolver: params.catalogResolver,
       agentRuntime: params.agentRuntime,
+      providerPolicySource: params.providerPolicySource,
     });
   return resolveGatewaySessionThinkingLevel({
     provider: params.thinkingPolicyProvider ?? params.provider,
@@ -150,6 +149,7 @@ function resolveGatewaySessionThinkingDefault(params: {
     model: params.model,
     level: defaultLevel,
     modelCatalog: params.modelCatalog,
+    catalogResolver: params.catalogResolver,
     agentRuntime: params.agentRuntime,
     configuredReasoning: params.configuredReasoning,
     providerPolicySource: params.providerPolicySource,
@@ -165,6 +165,7 @@ export function resolveGatewayModelThinkingProfile(params: {
   configuredReasoning?: boolean;
   thinkingPolicyProvider?: string;
   modelCatalog?: ModelCatalogEntry[];
+  catalogResolver?: ThinkingCatalogResolver;
   rowContext?: SessionListRowContext;
   sessionKey?: string;
   providerPolicySource?: ThinkingProviderPolicySource;
@@ -202,6 +203,7 @@ export function resolveGatewayModelThinkingProfile(params: {
     provider: thinkingPolicyProvider,
     model: params.model,
     modelCatalog: params.modelCatalog,
+    catalogResolver: params.catalogResolver,
     agentRuntime,
     configuredReasoning: params.configuredReasoning,
     providerPolicySource: params.providerPolicySource,
@@ -217,6 +219,7 @@ export function resolveGatewayModelThinkingProfile(params: {
             model: params.model,
             agentId: params.agentId,
             modelCatalog: params.modelCatalog,
+            catalogResolver: params.catalogResolver,
             agentRuntime,
             configuredReasoning: params.configuredReasoning,
             providerPolicySource: params.providerPolicySource,


### PR DESCRIPTION
## What Problem This Solves

Large configured model catalogs can make model selection wait noticeably for the Gateway's catalog response. This reduces the work needed to produce thinking controls for those catalogs.

## Why This Change Was Made

Prepare one thinking-catalog index per existing public model-list projector and reuse it when resolving levels, defaults, and supported-level normalization. The index retains the first matching original row and its captured provider policy, including an authoritative absence. Logical-model defaults and donor-provider policy remain separate; strict default matching and the Gateway's canonical capability lookup keep their existing contracts.

The formatted production diff adds 52 lines net (+68/-16). That growth provides the request-scoped index and explicit plumbing through the existing owners; it does not add a process-wide cache, configuration, or persistence. Two of those lines are formatter-only layout changes from the measured +50-line proposal.

## User Impact

Fresh model-catalog responses are faster in the measured large-catalog default/all cases while preserving the same public metadata, thinking levels, labels, defaults, and provider-policy ownership. Small-catalog CPU/memory costs and provider-config results are mixed; this is not a universal CPU, memory, or end-to-end UI speedup claim.

## Evidence

**Measurement:** [Linux run](https://github.com/openclaw/openclaw/actions/runs/34656231400) at `fc7f3c65100a3cd90a9a07a367b28f51a9af7720`, Node v24.19.0. Seven cases ran in B1/C1/C2/B2 order, with two warmups and three measured requests per child: 28 timing children total. Each measured `buildModelsListResult` call includes request preparation and index construction.

The two comparisons below preserve both execution orders. Values are baseline → candidate request-wall medians; percentages mean lower latency.

| 1,024-row view | B1 → C1 | B2 → C2 |
| --- | --- | --- |
| default | 525.14 → 427.64 ms (18.57%) | 546.09 → 391.32 ms (28.34%) |
| all | 577.50 → 384.62 ms (33.40%) | 584.25 → 403.66 ms (30.91%) |
| provider-config | 614.87 → 609.53 ms (0.87%) | 625.22 → 402.48 ms (35.63%) |
| all, reversed catalog | 484.04 → 397.76 ms (17.82%) | 553.50 → 442.51 ms (20.05%) |

Adverse controls are retained. At 32 rows, first-order default CPU rose 8.58 → 27.85 ms and all-view CPU rose 5.38 → 18.56 ms; request RSS rose 4.27% and 3.26%, respectively. First-order 32/all wall time was 7.27% slower; the opposite order was 19.04% faster. For 1,024/provider-config, request RSS rose 4.42% / 2.95% and native peak RSS rose 4.04% / 8.82%. Whole-process timings also varied—for example, first-order 1,024/default native wall time was 17.69% slower—and include imports and untimed checks. Those observations are not dismissed as proven noise, and three samples per child do not establish tail latency.

All measurement input/output bytes, frozen-input checks, policy-symbol ownership, and publication/revocation checks passed. An untimed fixture also exercised the registered `models.list` handler, checking configured defaults/clamping, reasoning opt-out, captured function/null policies against conflicting ambient hooks, expected provider-call counts, public-field filtering, and zero discovery.

**Author-base validation:** [Separate Linux run](https://github.com/openclaw/openclaw/actions/runs/34660978123) at `c38897f5544081974bc13632c2f1a17337b52ba7`: **168 selected tests passed across nine files**—90 thinking-profile, 14 configured-default, 29 Gateway thinking/runtime, and 35 models-list boundary tests. The other **165 model-selection assertions were intentionally filtered out and skipped**, not counted as passing proof. The same six file contents used for that validation were subsequently committed unchanged as `edaddcc65e011e949cfd24c9d4f96801e37e046d`.

Formatting and the earlier changed gates passed. The changed gate then stopped at the known base-owned graph overflow: `config-cli: 721 test roots exceeds the 720 limit`. Later selected gates did not run; validation is **not fully green**. No cap, baseline, source, or assertion was changed to bypass this failure.

All six original files are byte-identical between the measurement and author bases, and all four formatted production owners emit identical JavaScript to the measured proposal. Dependency declarations and the lockfile are unchanged. A fresh managed Codex P2 review completed scoped-clean with no actionable findings; it does not replace the unfinished changed gates.

Both exact framed archives were recovered and verified. All 32 measurement native children (28 timing, three setup, one removal) and all 11 validation native children closed with their monitors joined and no supervisor problems. The measurement worktree was restored and removed. The validation driver retained its worktree after the gate failure; its dedicated lease was explicitly stopped after archive recovery. Both leases were independently confirmed stopped. No measurement or validation retry was used.

**Current-head qualification:** The branch now includes main `bca261d5583d12f73ed67f9f9df73089d68a0aca`, retaining #145395's unsupported-adaptive policy. The production index patch is unchanged; it still selects the same first profile row and preserves downstream policy. The earlier 168-test run and benchmark data remain historical under their original source labels.

The current test-only follow-up reuses one fixture for two identical Qwen mock/catalog setups. Every case and assertion remains, including the prepared-index and adaptive-policy coverage. Formatting leaves 998 counted lines against the unchanged 1,000-line limit. All 83 tests in the complete thinking test file passed with no filtering or skips, and fresh full-scope Codex P2 review is clean. The original type-aware core lint attempt exceeded its fixed 6 GiB RSS envelope and returned no lint verdict; the following remote whitespace check did not run. The local whitespace check passed. This failure remains recorded, and required exact-head CI still has to pass. All observed native children closed and the dedicated Testbox was explicitly stopped and independently confirmed completed. No benchmark was rerun.
