### PR TITLE
fix: keep session test typechecks below the shard limit

### DIFF
--- a/test/tsconfig/tsconfig.core.test.config-cli.json
+++ b/test/tsconfig/tsconfig.core.test.config-cli.json
@@ -14,7 +14,6 @@
     "../../dist",
     "../../**/dist/**",
     "../../src/cli/daemon-cli/**",
-    "../../src/config/sessions/session-cold-storage*.test.ts",
-    "../../src/config/sessions/session-accessor.sqlite-cold-read.test.ts"
+    "../../src/config/sessions/**"
   ]
 }

--- a/test/tsconfig/tsconfig.core.test.state-logging.json
+++ b/test/tsconfig/tsconfig.core.test.state-logging.json
@@ -12,7 +12,7 @@
     "../../src/shared/**/*.test.tsx",
     "../../src/infra/update-managed-service-handoff-database.test.ts",
     "../../src/infra/package-update-activation-journal.test.ts",
-    "../../src/config/sessions/session-cold-storage*.test.ts",
-    "../../src/config/sessions/session-accessor.sqlite-cold-read.test.ts"
+    "../../src/config/sessions/**/*.test.ts",
+    "../../src/config/sessions/**/*.test.tsx"
   ]
 }


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the core typecheck boundary fails on current main because the config/CLI shard has 721 test roots, exceeding its 720-root limit. This blocks unrelated changes before their validation can finish.

## Why This Change Was Made

Assign all session-store tests to the existing state/logging shard, which already owns the cold-session storage tests. Replace the narrow session exclusions and inclusions with matching subtree patterns so new session tests have one clear typecheck owner.

## User Impact

Developer validation can run again with the same root limit, shard count, compiler options, and CI fanout. Runtime behavior is unchanged.

## Evidence

The existing boundary guard fails on the original main checkout with 721 config/CLI roots. After this change, config/CLI has 579 roots and state/logging has 349. The complete canonical-root ownership and extension-import boundary passes, confirming that every test remains assigned exactly once across the existing 17 shards. Both affected typechecks and the full changed-scope gate pass. Independent P2 review is clean.
