### PR TITLE
refactor(tests): remove retired test API publication entries

### DIFF
--- a/test/repository-test-api-publications.ts
+++ b/test/repository-test-api-publications.ts
@@ -33,7 +33,6 @@ const publications: Record<string, string | symbol> = {
   "src/agents/embedded-agent-runner/context-engine-maintenance.ts": Symbol.for(
     "openclaw.contextEngineMaintenanceTestApi",
   ),
-  "src/agents/embedded-agent-runner/extra-params.ts": Symbol.for("openclaw.extraParamsTestApi"),
   "src/agents/embedded-agent-runner/runs.ts": Symbol.for("openclaw.embeddedRunsTestApi"),
   "src/agents/embedded-agent-tool-media.ts": Symbol.for("openclaw.embeddedSubscribeToolsTestApi"),
   "src/agents/mcp-ui-resource.ts": Symbol.for("openclaw.mcpUiResourceTestApi"),
@@ -80,9 +79,6 @@ const publications: Record<string, string | symbol> = {
   ),
   "src/commands/doctor-sandbox.ts": Symbol.for("openclaw.doctorSandboxTestApi"),
   "src/commands/doctor-session-snapshots.ts": Symbol.for("openclaw.doctorSessionSnapshotsTestApi"),
-  "src/commands/doctor-whatsapp-responsiveness.ts": Symbol.for(
-    "openclaw.doctorWhatsappResponsivenessTestApi",
-  ),
   "src/commands/doctor/shared/codex-native-assets.ts": Symbol.for(
     "openclaw.codexNativeAssetsTestApi",
   ),


### PR DESCRIPTION
## What Problem This Solves

The shared test runner still lists two test API publications that their source modules no longer create.

## Why This Change Was Made

Remove the retired extra-parameter and Doctor responsiveness entries from the exact publication table. Keep live publications and all runner lifecycle checks unchanged.

## User Impact

No production change or test cases added or removed. One test-support file removes four lines.

## Evidence

On the original base, both complete outer suites passed before and after: nine cases (one runner case and eight Doctor cases), with identical native inventory, order, and statuses. The runner retains its ordered inner proof: 45 passed, one skipped, and the intentional collection failure. Those inner assertions are not added to the outer count.

The unchanged patch has been refreshed onto `746fa369` to include the canonical fixes for the earlier shared CI failures. All nine outer cases pass on the refreshed head, retaining the same observed inventory. A fresh independent review found no actionable findings. All 16 normal changed-file checks passed, including root test types, lint, and the three dead-export scans. Fresh hosted CI remains required; the original before/after evidence stays attributed to its original base.
