### PR TITLE
perf(plugins): build public surface fallback paths lazily

### DIFF
--- a/src/plugins/public-surface-runtime.ts
+++ b/src/plugins/public-surface-runtime.ts
@@ -115,16 +115,23 @@ export function resolvePluginRootPublicSurfacePath(params: {
     artifactBasename,
     ...sourceArtifacts.filter((artifact) => !isTypeScriptPackageEntry(artifact)),
   ];
-  return (
-    [
-      ...(entryDir ? entryArtifacts.map((artifact) => path.join(entryDir, artifact)) : []),
-      ...preferredArtifacts.map((artifact) => path.join(pluginRoot, artifact)),
-      path.join(pluginRoot, artifactBasename),
-      path.join(pluginRoot, "dist", artifactBasename),
-      ...(entryDir ? sourceArtifacts.map((artifact) => path.join(entryDir, artifact)) : []),
-      ...sourceArtifacts.map((artifact) => path.join(pluginRoot, artifact)),
-    ].find(exists) ?? null
-  );
+  for (const [directory, artifacts] of [
+    [entryDir, entryArtifacts],
+    [pluginRoot, [...preferredArtifacts, artifactBasename, path.join("dist", artifactBasename)]],
+    [entryDir, sourceArtifacts],
+    [pluginRoot, sourceArtifacts],
+  ] as const) {
+    if (!directory) {
+      continue;
+    }
+    for (const artifact of artifacts) {
+      const candidate = path.join(directory, artifact);
+      if (exists(candidate)) {
+        return candidate;
+      }
+    }
+  }
+  return null;
 }
 
 function resolvePublicSurfaceFromBundledDir(params: {


### PR DESCRIPTION
## What Problem This Solves

Repeated plugin public-artifact reads incur avoidable overhead, particularly when the public API is available at the first candidate location. This affects both ordinary installed artifacts and APIs served from a captured plugin instance.

## Why This Change Was Made

Construct fallback paths as they are examined instead of constructing the entire list before selecting its first match. The existing resolver still owns candidate order, source/build preference, captured module membership, path validation, aliases and retirement. The change adds no cache, generator, SDK surface or persistence behavior.

## User Impact

Warm public-artifact loads do less path-processing work. Plugin selection and lifecycle behavior remain unchanged. This is a scoped loader improvement, not a claim of faster whole-Gateway startup or uniformly faster cold loads.

## Evidence

One paired Linux/Node 24.19 measurement used the real `loadPluginPublicArtifactModuleSync` boundary with eight tiny generated packages, four fresh B1/C1/C2/B2 processes, two warmup batches and seven measured batches per case. All 34,592 loads passed export-shape, module-identity, captured-source deletion and retirement assertions. Independent comparison of the retained raw outputs passed all 24 cross-phase case comparisons and generated-fixture parity.

Warm median wall time per load, including the unchanged probe wrapper:

| Case | B1 → C1 | B2 → C2 |
| --- | ---: | ---: |
| Root JS | 6.973 → 4.318 µs | 7.887 → 5.017 µs |
| Dist JS | 7.227 → 5.664 µs | 7.350 → 5.571 µs |
| Captured TS with stale JS present | 20.239 → 13.706 µs | 21.146 → 14.166 µs |
| Captured nested TS | 21.120 → 17.488 µs | 22.538 → 15.909 µs |
| Captured built JS | 19.791 → 15.396 µs | 20.841 → 15.740 µs |
| Captured alias TS | 20.482 → 13.966 µs | 21.870 → 14.393 µs |

Adverse controls are retained: late MJS wall time changed +2.9%/−9.4%; missing-surface CPU increased 11.6% in the reverse pair; captured built-JS CPU increased 2.2% in the first pair. First artifact-load timings after imports and fixture setup were mixed—for example, captured nested TS changed 3.874 → 4.102 ms and 4.482 → 4.491 ms. These are not per-case cold-process measurements. Native process totals include imports, fixture setup, verification and disposal and are not substituted for load timings.

Measurement used base `5478669f2b0`; the author base is `c38897f5544`. The resolver baseline and all 35 pinned supporting source/toolchain inputs are unchanged between them. Formatting with the matching formatter changed no candidate bytes; emitted JavaScript is byte-identical to the measured version.

Validation at the author base passed **59 existing tests**, with no failures or skips:

- `public-surface-runtime.test.ts`: 16 passed.
- `public-surface-loader.test.ts`: 22 passed.
- `public-surface-generation.test.ts`: 21 passed.

Formatting passed. Independent Codex review returned **scoped-clean through P2**. The repository changed-check dry run selected `core`, `coreTests` and `bundledChannelConfigMetadata`; the remaining selected type, lint, metadata and other gates still require hosted CI and are not claimed as completed here.

The [measurement run](https://github.com/openclaw/openclaw/actions/runs/34660610541) and [validation run](https://github.com/openclaw/openclaw/actions/runs/34661300974) each ran once without retries or raised limits. All nine measurement and eight validation native receipts closed with joined monitors. Both wrappers restored their baseline source, verified clean worktrees and removed them normally. Both dedicated Testbox leases were stopped and independently confirmed absent. No production Gateway or user state was used.

**Current-head qualification:** Head `e7818643549d` preserves this PR's authored patch on main `bca261d5583d`, including the shared `retainedMachine` typecheck repair (#145540). Benchmarks, earlier validation, and prior draft-state notes remain historical under their original source labels; no benchmark was rerun for this rebase. Exact-head CI is required before landing.
