### PR TITLE
fix(ci): rebalance core test shard ownership

### DIFF
--- a/test/tsconfig/tsconfig.core.test.commands.json
+++ b/test/tsconfig/tsconfig.core.test.commands.json
@@ -6,6 +6,8 @@
   "include": [
     "../../src/agents/command/**/*.test.ts",
     "../../src/agents/command/**/*.test.tsx",
+    "../../src/cli/program/**/*.test.ts",
+    "../../src/cli/program/**/*.test.tsx",
     "../../src/commands/**/*.test.ts",
     "../../src/commands/**/*.test.tsx",
     "../../src/tui/**/*.test.ts",

--- a/test/tsconfig/tsconfig.core.test.config-cli.json
+++ b/test/tsconfig/tsconfig.core.test.config-cli.json
@@ -14,6 +14,7 @@
     "../../dist",
     "../../**/dist/**",
     "../../src/cli/daemon-cli/**",
+    "../../src/cli/program/**",
     "../../src/config/sessions/session-cold-storage*.test.ts",
     "../../src/config/sessions/session-accessor.sqlite-cold-read.test.ts"
   ]


### PR DESCRIPTION
## What Problem This Solves

Core boundary CI now fails because the config-cli test shard has 721 roots, exceeding its existing 720-root cap. This blocks unrelated pull requests before their later checks can run.

## Why This Change Was Made

Move the coherent CLI program and command-registration subtree into the existing commands shard. The paired include/exclude change preserves every test exactly once: config-cli becomes 680 roots, commands becomes 701. All 17 shards, 19 graph descriptors, build-info owners, workflow fanout and the 720-root cap remain unchanged.

## User Impact

Restores the existing CI boundary without omitting tests or increasing resource limits. This is CI maintenance, with no product behavior change or runtime performance claim.

## Evidence

- The exact failing CI base and current inspected main already contain the overflow. This change is independent of the schema/model optimizations that encountered it.
- Static ownership comparison preserves all 9,910 canonical roots exactly once; precisely 41 roots move and the other 15 shard ownership sets remain unchanged.
- The actual compiler boundary check passed in 39.09 seconds. Separate config-cli and commands typechecks passed in 43.31 and 43.94 seconds, within unchanged 300-second/6-GiB limits.
- Independent Codex review is scoped-clean through P2. Diff check passes. Repository formatting excludes JSON, so no formatter ignore was overridden.
- The first validation attempt selected an inapplicable formatter command and stopped before compiler checks; that failure is retained. The corrected validation used the existing compiler owner to parse configurations. Its complete archive and native closure records were recovered; sources were restored, the clean worktree removed, and the isolated Testbox confirmed stopped.

[Focused validation run](https://github.com/openclaw/openclaw/actions/runs/34661738872). Broader hosted CI remains required before landing. No test assertions, baselines or caps were weakened.
