### PR TITLE
refactor(ui): remove unused cloud target exports

### DIFF
--- a/ui/src/pages/new-session/cloud-target.test.ts
+++ b/ui/src/pages/new-session/cloud-target.test.ts
@@ -2,11 +2,7 @@
 
 import { render } from "lit";
 import { describe, expect, it, vi } from "vitest";
-import {
-  renderSessionMenuItem,
-  renderCloudProfileMenuItems,
-  renderCloudConfiguration,
-} from "./cloud-target.ts";
+import { renderSessionMenuItem, renderCloudProfileMenuItems } from "./cloud-target.ts";
 
 describe("cloud target menu", () => {
   it("renders explicit remediation commands on separate lines", () => {
@@ -157,15 +153,13 @@ describe("cloud target menu", () => {
   ])("renders a single machine as fixed provider configuration", ({ machine, expected }) => {
     const container = document.createElement("div");
     render(
-      renderCloudConfiguration({
-        profile: { id: "aws", providerId: "aws" },
-        operatingSystems: [],
-        machines: [machine],
-        selectedOs: "",
+      renderCloudProfileMenuItems({
+        profiles: [{ id: "aws", providerId: "aws", machines: [machine] }],
+        selectedId: "aws",
+        compact: true,
         selectedMachine: machine.id,
         submitting: false,
-        onSelectOs: vi.fn(),
-        onSelectMachine: vi.fn(),
+        onSelect: vi.fn(),
       }),
       container,
     );
@@ -210,45 +204,57 @@ describe("cloud target menu", () => {
     const onSelectMachine = vi.fn();
     const onSelectOs = vi.fn();
     const params = {
-      profile: { id: "aws", providerId: "aws" },
-      operatingSystems: [
-        { id: "linux", label: "Linux" },
-        { id: "macos", label: "macOS" },
+      profiles: [
+        {
+          id: "aws",
+          providerId: "aws",
+          operatingSystems: [
+            { id: "linux", label: "Linux" },
+            { id: "macos", label: "macOS" },
+          ],
+          machines: [
+            { id: "small", label: "Small" },
+            { id: "large", label: "Large" },
+          ],
+        },
       ],
-      machines: [
-        { id: "small", label: "Small" },
-        { id: "large", label: "Large" },
-      ],
+      selectedId: "aws",
+      compact: true,
       selectedOs: "linux",
       selectedMachine: "small",
       submitting: false,
       onSelectMachine,
       onSelectOs,
+      onSelect: vi.fn(),
     };
-    render(renderCloudConfiguration(params), container);
+    render(renderCloudProfileMenuItems(params), container);
     container.querySelector<HTMLButtonElement>('[data-value="machine:large"]')!.click();
     container.querySelector<HTMLButtonElement>('[data-value="os:macos"]')!.click();
     expect(onSelectMachine).toHaveBeenCalledExactlyOnceWith("large");
     expect(onSelectOs).toHaveBeenCalledExactlyOnceWith("macos");
-    render(renderCloudConfiguration({ ...params, submitting: true }), container);
+    render(renderCloudProfileMenuItems({ ...params, submitting: true }), container);
     expect([...container.querySelectorAll("button")].every((button) => button.disabled)).toBe(true);
   });
 
   it("omits unavailable OS choices even when they are the current selection", () => {
     const container = document.createElement("div");
     render(
-      renderCloudConfiguration({
-        profile: { id: "aws", providerId: "aws" },
-        operatingSystems: [
-          { id: "linux", label: "Linux" },
-          { id: "windows", label: "Windows", disabledReason: "Install WSL2" },
+      renderCloudProfileMenuItems({
+        profiles: [
+          {
+            id: "aws",
+            providerId: "aws",
+            operatingSystems: [
+              { id: "linux", label: "Linux" },
+              { id: "windows", label: "Windows", disabledReason: "Install WSL2" },
+            ],
+          },
         ],
-        machines: [],
+        selectedId: "aws",
+        compact: true,
         selectedOs: "windows",
-        selectedMachine: "",
         submitting: false,
-        onSelectMachine: vi.fn(),
-        onSelectOs: vi.fn(),
+        onSelect: vi.fn(),
       }),
       container,
     );
@@ -257,7 +263,9 @@ describe("cloud target menu", () => {
     expect(fixedOs?.tagName).toBe("SPAN");
     expect(fixedOs?.hasAttribute("aria-pressed")).toBe(false);
     expect(container.querySelector('[data-value="os:windows"]')).toBeNull();
-    expect(container.querySelector('[aria-pressed="true"]')).toBeNull();
+    expect(
+      container.querySelector('.new-session-page__cloud-configuration [aria-pressed="true"]'),
+    ).toBeNull();
   });
 
   it("disables cloud profiles with the runtime preflight reason", () => {

--- a/ui/src/pages/new-session/cloud-target.ts
+++ b/ui/src/pages/new-session/cloud-target.ts
@@ -238,23 +238,6 @@ export function renderSessionMenuItem(params: SessionMenuItemOptions, submitting
     : row;
 }
 
-export function renderConnectMachineMenuItem(params: { disabled: boolean; onSelect: () => void }) {
-  return html`
-    <div class="session-menu__separator" role="separator"></div>
-    <button
-      type="button"
-      class="session-menu__item new-session-page__connect-machine"
-      data-value="connect-machine"
-      aria-pressed="false"
-      ?disabled=${params.disabled}
-      @click=${params.onSelect}
-    >
-      <span class="session-menu__icon" aria-hidden="true">${icons.link}</span>
-      <span class="session-menu__text">${t("newSession.connectMachine")}</span>
-    </button>
-  `;
-}
-
 export function renderCloudProfileMenuItems(params: {
   profiles: readonly DraftCloudProfile[];
   selectedId: string;
@@ -373,7 +356,7 @@ function machineShapeText(machine: DraftMachineOption): string | undefined {
   return memory ? t("newSession.machineMemory", { memory }) : undefined;
 }
 
-export function renderCloudConfiguration(params: {
+function renderCloudConfiguration(params: {
   profile: DraftCloudProfile;
   suggested?: boolean;
   operatingSystems: readonly DraftOperatingSystem[];

--- a/ui/src/styles/new-session.css
+++ b/ui/src/styles/new-session.css
@@ -815,8 +815,7 @@ wa-popover.new-session-page__where-popover::part(body) {
   overflow-y: auto;
 }
 
-.new-session-page__environment-option,
-.new-session-page__connect-machine {
+.new-session-page__environment-option {
   min-height: 28px;
   gap: 8px;
   padding: 3px 8px;
@@ -837,9 +836,7 @@ wa-popover.new-session-page__where-popover::part(body) {
 }
 
 .new-session-page__environment-option .session-menu__icon,
-.new-session-page__connect-machine .session-menu__icon,
-.new-session-page__environment-option .session-menu__icon svg,
-.new-session-page__connect-machine .session-menu__icon svg {
+.new-session-page__environment-option .session-menu__icon svg {
   width: 14px;
   height: 14px;
 }
@@ -851,8 +848,7 @@ wa-popover.new-session-page__where-popover::part(body) {
   font-size: var(--control-ui-text-sm);
 }
 
-.new-session-page__environment-picker > .session-menu__separator,
-.new-session-page__environment-picker > .new-session-page__connect-machine {
+.new-session-page__environment-picker > .session-menu__separator {
   flex-shrink: 0;
 }
 
@@ -870,10 +866,6 @@ wa-popover.new-session-page__where-popover::part(body) {
   stroke-width: 1.7px;
   stroke-linecap: round;
   stroke-linejoin: round;
-}
-
-.new-session-page__connect-machine .session-menu__icon {
-  color: var(--muted);
 }
 
 .connect-machine-dialog {


### PR DESCRIPTION
## Problem

`pnpm deadcode:exports` fails on main after #145183 (`b9050029efe97266108667536e25b1a806e6dafd`). The environment-picker change replaced the connect-machine menu item with a device-header action but left its renderer exported. It also exported the cloud configuration renderer solely for direct tests.

## Fix

Delete the unused connect-machine renderer and its unused CSS selectors. Keep cloud configuration private and exercise it through the existing profile-menu renderer. Preserve the live device-header action, connect dialog, and move-session menu.

The production cleanup removes 25 net lines. No baseline, ignore list, test case, runtime behavior, or visible styling changes.

## Consumers

- `renderConnectMachineMenuItem` has no remaining import, call, barrel, or dynamic reference. #145183 removed its last caller from `ui/src/pages/new-session/where-chip.ts`; that file now renders the live `data-action="connect-machine"` button directly.
- `.new-session-page__connect-machine` appears only in the deleted renderer and the removed stylesheet selectors. Other selectors in those rules keep their declarations. `connect-machine-dialog` styles remain live and unchanged.
- `renderCloudConfiguration` remains private to `ui/src/pages/new-session/cloud-target.ts`, called by `renderCloudProfileMenuItems`. Its only external import was `cloud-target.test.ts`, now removed.
- `renderCloudProfileMenuItems` is consumed by `where-chip.ts` in compact mode and `ui/src/components/session-placement-move-dialog.ts` in noncompact mode. `target-controls.ts` connects the Where picker to the New Session page. These production callers are unchanged.
- `renderCloudMachineMenuItems` and `renderCloudOsMenuItems` retain their exports for the move-session dialog. `requestPlaceCatalog` and the connect-machine dialog owner are unchanged.
- Repository searches cover `src/`, `extensions/`, `ui/`, `apps/`, `docs/`, and `packages/`. No schema, plugin manifest, public option, or stored value uses the removed export or class. The remaining private function name is intentional; its implementation and internal caller are not retired.

## Contention

None. No lock, queue, transaction, shared writer, asynchronous work, or concurrency policy changes.

## Invalidation

None. No cache or derived-state lifecycle changes; policy reload, config reload, and Gateway restart behavior is unchanged.

## Tests

- `pnpm deadcode:exports`: baseline `6cb7280a4e85d655c51312fca4db1c9269f3b551` exits 1 with both reported production exports; candidate exits 0 with zero entries in script, production, and full-tree scans.
- Existing UI tests: **80 passed** across `cloud-target.test.ts`, `where-chip.test.ts`, and `session-placement-move-dialog.test.ts` using `vitest run --config ui/vitest.config.ts --maxWorkers=2`.
- Test entry point: the six rewritten cases now render `renderCloudProfileMenuItems`, the production renderer used by the registered New Session page's Where picker. The unchanged Where-picker and move-dialog tests cover its callers and sibling mode.
- Mutation proof: both original and rewritten cases fail for the same six assertions when fixed-machine rendering, unavailable-OS filtering, and submitting disablement are intentionally broken. The temporary changes were restored and are not in this PR.
- Native formatter and repository precommit hook pass. Independent source review found no actionable issue.
- Older-host/previous-state, real-config Gateway startup, and channel proof are not applicable: no SDK, updater, Doctor, persistence, config loading, login, catalog, or product behavior changes. Removed CSS has no live renderer; there is no appearance change to capture.

## Deletion ledger

- Delete `renderConnectMachineMenuItem` and its `.new-session-page__connect-machine` selectors: obsolete after #145183; no live behavior removed.
- Remove only the export of `renderCloudConfiguration`; retain its implementation and internal production caller.
- Preserve all four single-machine cases, the choices/disabled-state case, and the unavailable-selected-OS case through `renderCloudProfileMenuItems`. No test is deleted or skipped. The no-selected-OS assertion is scoped to configuration content because the surrounding profile is now rendered and selected.

## Structural dependencies

#145431 owns the separate config-cli root overflow and is merged. #145430 owns the separate UI startup-size repair. This PR does not change either limit or claim a waiver for either gate.
