### PR TITLE
fix(macos): discard stale browser import presentation

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -2741,7 +2741,7 @@
     {"id":"native.apple.2282d2bdeca50246","source":"Next Match","surface":"apple","sites":[{"kind":"ui-call","path":"apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatTranscriptSearch.swift"}]},
     {"id":"native.apple.de0f4838e9554464","source":"Next match (⌘G)","surface":"apple","sites":[{"kind":"ui-modifier","path":"apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatTranscriptSearch.swift"}]},
     {"id":"native.apple.f5f840287aa988ff","source":"Next up","surface":"apple","sites":[{"kind":"ui-localized-call","path":"apps/ios/WatchApp/Sources/WatchInboxView.swift"}]},
-    {"id":"native.apple.fedfabab4844f04b","source":"No Chrome, Brave, Edge, or Chromium profile with cookies was found on this Mac.","surface":"apple","sites":[{"kind":"ui-localized-call","path":"apps/macos/Sources/OpenClaw/BrowserProfileImportModel.swift"}]},
+    {"id":"native.apple.fedfabab4844f04b","source":"No Chrome, Brave, Edge, or Chromium profile with cookies was found on this Mac.","surface":"apple","sites":[{"kind":"ui-localized-call-multiline","path":"apps/macos/Sources/OpenClaw/BrowserProfileImportModel.swift"}]},
     {"id":"native.apple.37db63fd5d16b721","source":"No Gateways saved","surface":"apple","sites":[{"kind":"ui-call","path":"apps/macos/Sources/OpenClaw/GatewaySettings.swift"}]},
     {"id":"native.apple.531ebef3784c2b3e","source":"No Results","surface":"apple","sites":[{"kind":"ui-localized-call","path":"apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionSidebar.swift"}]},
     {"id":"native.apple.cb16b17de2bb55f4","source":"No Sound","surface":"apple","sites":[{"kind":"conditional-branch","path":"apps/macos/Sources/OpenClaw/VoiceWakeChime.swift"}]},

--- a/apps/macos/Sources/OpenClaw/BrowserProfileImportModel.swift
+++ b/apps/macos/Sources/OpenClaw/BrowserProfileImportModel.swift
@@ -76,6 +76,7 @@ final class BrowserProfileImportModel {
 
     enum ForceRefreshOutcome: Equatable {
         case offering
+        case superseded
         case unavailable(title: String, message: String)
     }
 
@@ -85,8 +86,8 @@ final class BrowserProfileImportModel {
 
     private(set) var phase: Phase = .hidden
     private(set) var importAvailable = false
-    /// Bumped by setPhase; see refresh(force:) for the staleness contract.
     @ObservationIgnored private var phaseGeneration = 0
+    @ObservationIgnored private var availabilityGeneration = 0
     /// A dismissal must stick for this app session even while its
     /// fire-and-forget persistence write is pending or lost — otherwise the
     /// next automatic poll reads the still-null server state and re-offers.
@@ -113,19 +114,20 @@ final class BrowserProfileImportModel {
 
     /// Read availability without changing the banner or overriding a remembered dismissal.
     func refreshAvailability() async {
+        self.availabilityGeneration += 1
+        let generation = self.availabilityGeneration
         guard self.isLocalMode() else {
             self.importAvailable = false
             return
         }
         let status: BrowserProfileImportStatus? = try? await self.request(
             method: "GET", path: "/system-profile-import/status", timeoutMs: 5000)
+        guard self.availabilityGeneration == generation else { return }
         self.importAvailable = self.isLocalMode() && status.map { Self.shouldOffer(status: $0, force: true) } == true
     }
 
-    /// Every phase change goes through here. The generation lets an awaited
-    /// status poll detect that a dismissal, import, or fresher poll happened
-    /// while it was in flight — "phase is .hidden again" alone cannot tell a
-    /// just-dismissed banner apart from one that never appeared.
+    /// Phase changes and refresh starts invalidate earlier presentation work,
+    /// even when a mode switch or dismissal leaves the banner hidden again.
     private func setPhase(_ phase: Phase) {
         self.phase = phase
         self.phaseGeneration += 1
@@ -176,26 +178,19 @@ final class BrowserProfileImportModel {
                         localized: "Switch this Mac app to a local Gateway before importing browser cookies.")),
                 false)
         }
+        if case .importing = self.phase { return (.offering, false) }
+        guard shouldApply() else { return (.superseded, false) }
+        self.phaseGeneration += 1
         let generation = self.phaseGeneration
+        self.availabilityGeneration += 1
+        let availabilityGeneration = self.availabilityGeneration
         do {
             let status: BrowserProfileImportStatus = try await self.request(
                 method: "GET",
                 path: "/system-profile-import/status")
-            self.importAvailable = self.isLocalMode() && Self.shouldOffer(status: status, force: true)
-            // The status await interleaves with user actions. Idle polls apply
-            // only if nothing changed since they started (a dismissal mid-poll
-            // must stay dismissed); a forced refresh wins over everything
-            // except an import that is already running.
-            if force {
-                if case .importing = self.phase { return (.offering, true) }
-            } else {
-                // The sidebar may close while the host-local status request is
-                // in flight. Never surface its automatic offer after that UI
-                // owner has gone away.
-                guard self.phaseGeneration == generation, shouldApply() else {
-                    return (.offering, false)
-                }
-            }
+            guard self.phaseGeneration == generation, self.availabilityGeneration == availabilityGeneration,
+                  self.isOnboarded(), self.isLocalMode(), shouldApply() else { return (.superseded, false) }
+            self.importAvailable = Self.shouldOffer(status: status, force: true)
             guard Self.shouldOffer(status: status, force: force) else {
                 self.setPhase(.hidden)
                 let message = status.enabled
@@ -210,10 +205,9 @@ final class BrowserProfileImportModel {
             self.setPhase(.offering(status))
             return (.offering, true)
         } catch {
-            // Same interleaving rule: a failed poll only clears state it owns.
-            if force, self.phaseGeneration == generation {
-                if case .importing = self.phase {} else { self.setPhase(.hidden) }
-            }
+            guard self.phaseGeneration == generation, self.availabilityGeneration == availabilityGeneration,
+                  self.isOnboarded(), self.isLocalMode(), shouldApply() else { return (.superseded, false) }
+            if force { self.setPhase(.hidden) }
             return (
                 .unavailable(
                     title: String(localized: "Browser import unavailable"),
@@ -223,8 +217,9 @@ final class BrowserProfileImportModel {
     }
 
     func importProfile(_ profile: BrowserSystemProfile) async {
-        guard case let .offering(status) = self.phase else { return }
+        guard self.isOnboarded(), self.isLocalMode(), case let .offering(status) = self.phase else { return }
         self.setPhase(.importing(profile: profile, target: status.suggestedTarget))
+        let generation = self.phaseGeneration
         do {
             let body: [String: AnyCodable] = [
                 "browser": AnyCodable(profile.browser),
@@ -237,14 +232,17 @@ final class BrowserProfileImportModel {
                 path: "/profiles/import",
                 body: body,
                 timeoutMs: 120_000)
+            // The Gateway import may finish after its banner context has gone away.
+            guard self.phaseGeneration == generation, self.isOnboarded(), self.isLocalMode() else { return }
             self.setPhase(.imported(result))
         } catch {
+            guard self.phaseGeneration == generation, self.isOnboarded(), self.isLocalMode() else { return }
             self.setPhase(.failed(message: error.localizedDescription, retry: status))
         }
     }
 
     func retry() {
-        guard case let .failed(_, status) = self.phase else { return }
+        guard self.isOnboarded(), self.isLocalMode(), case let .failed(_, status) = self.phase else { return }
         self.setPhase(.offering(status))
     }
 
@@ -270,6 +268,7 @@ final class BrowserProfileImportModel {
     /// import system profiles, so the banner withdraws on mode switches.
     func handleConnectionModeChange() {
         guard !self.isLocalMode() else { return }
+        self.availabilityGeneration += 1
         self.importAvailable = false
         self.setPhase(.hidden)
     }
@@ -302,11 +301,3 @@ final class BrowserProfileImportModel {
             timeoutMs: request.timeoutMs)
     }
 }
-
-#if DEBUG
-extension BrowserProfileImportModel {
-    func _testSetPhase(_ phase: Phase) {
-        self.setPhase(phase)
-    }
-}
-#endif

--- a/apps/macos/Sources/OpenClaw/BrowserProfileImportModel.swift
+++ b/apps/macos/Sources/OpenClaw/BrowserProfileImportModel.swift
@@ -92,6 +92,7 @@ final class BrowserProfileImportModel {
     private(set) var phase: Phase = .hidden
     private(set) var importAvailable = false
     @ObservationIgnored private var phaseGeneration = 0
+    @ObservationIgnored private var pendingForcedRefreshGeneration: Int?
     @ObservationIgnored private var statusRequest: StatusRequest?
     /// A dismissal must stick for this app session even while its
     /// fire-and-forget persistence write is pending or lost — otherwise the
@@ -145,6 +146,7 @@ final class BrowserProfileImportModel {
     private func setPhase(_ phase: Phase) {
         self.phase = phase
         self.phaseGeneration += 1
+        self.pendingForcedRefreshGeneration = nil
     }
 
     /// First inline-browser open trigger. Only fills an empty banner slot so a
@@ -194,8 +196,16 @@ final class BrowserProfileImportModel {
         }
         if case .importing = self.phase { return (.offering, false) }
         guard shouldApply() else { return (.superseded, false) }
+        // Automatic offers must not consume a pending explicit re-offer.
+        guard force || self.pendingForcedRefreshGeneration == nil else { return (.superseded, false) }
         self.phaseGeneration += 1
         let generation = self.phaseGeneration
+        if force { self.pendingForcedRefreshGeneration = generation }
+        defer {
+            if self.pendingForcedRefreshGeneration == generation {
+                self.pendingForcedRefreshGeneration = nil
+            }
+        }
         var request = self.startStatusRequest()
         while true {
             let result = await request.task.result

--- a/apps/macos/Sources/OpenClaw/BrowserProfileImportModel.swift
+++ b/apps/macos/Sources/OpenClaw/BrowserProfileImportModel.swift
@@ -80,6 +80,11 @@ final class BrowserProfileImportModel {
         case unavailable(title: String, message: String)
     }
 
+    private struct StatusRequest {
+        let id = UUID()
+        let task: Task<BrowserProfileImportStatus, Error>
+    }
+
     typealias Transport = @MainActor (BrowserProfileImportRequest) async throws -> Data
 
     static let shared = BrowserProfileImportModel()
@@ -87,7 +92,7 @@ final class BrowserProfileImportModel {
     private(set) var phase: Phase = .hidden
     private(set) var importAvailable = false
     @ObservationIgnored private var phaseGeneration = 0
-    @ObservationIgnored private var availabilityGeneration = 0
+    @ObservationIgnored private var statusRequest: StatusRequest?
     /// A dismissal must stick for this app session even while its
     /// fire-and-forget persistence write is pending or lost — otherwise the
     /// next automatic poll reads the still-null server state and re-offers.
@@ -114,16 +119,25 @@ final class BrowserProfileImportModel {
 
     /// Read availability without changing the banner or overriding a remembered dismissal.
     func refreshAvailability() async {
-        self.availabilityGeneration += 1
-        let generation = self.availabilityGeneration
         guard self.isLocalMode() else {
+            self.statusRequest = nil
             self.importAvailable = false
             return
         }
-        let status: BrowserProfileImportStatus? = try? await self.request(
-            method: "GET", path: "/system-profile-import/status", timeoutMs: 5000)
-        guard self.availabilityGeneration == generation else { return }
+        let request = self.startStatusRequest(timeoutMs: 5000)
+        let status = try? await request.task.value
+        guard self.statusRequest?.id == request.id else { return }
         self.importAvailable = self.isLocalMode() && status.map { Self.shouldOffer(status: $0, force: true) } == true
+    }
+
+    private func startStatusRequest(timeoutMs: Double? = nil) -> StatusRequest {
+        let request = StatusRequest(task: Task {
+            guard self.isLocalMode() else { throw CancellationError() }
+            return try await self.request(
+                method: "GET", path: "/system-profile-import/status", timeoutMs: timeoutMs)
+        })
+        self.statusRequest = request
+        return request
     }
 
     /// Phase changes and refresh starts invalidate earlier presentation work,
@@ -182,37 +196,42 @@ final class BrowserProfileImportModel {
         guard shouldApply() else { return (.superseded, false) }
         self.phaseGeneration += 1
         let generation = self.phaseGeneration
-        self.availabilityGeneration += 1
-        let availabilityGeneration = self.availabilityGeneration
-        do {
-            let status: BrowserProfileImportStatus = try await self.request(
-                method: "GET",
-                path: "/system-profile-import/status")
-            guard self.phaseGeneration == generation, self.availabilityGeneration == availabilityGeneration,
-                  self.isOnboarded(), self.isLocalMode(), shouldApply() else { return (.superseded, false) }
-            self.importAvailable = Self.shouldOffer(status: status, force: true)
-            guard Self.shouldOffer(status: status, force: force) else {
-                self.setPhase(.hidden)
-                let message = status.enabled
-                    ? String(
-                        localized: "No Chrome, Brave, Edge, or Chromium profile with cookies was found on this Mac.")
-                    : String(
-                        localized: "System browser profile import is disabled in the local Gateway configuration.")
-                return (
-                    .unavailable(title: String(localized: "No browser login available"), message: message),
-                    true)
+        var request = self.startStatusRequest()
+        while true {
+            let result = await request.task.result
+            guard self.phaseGeneration == generation, self.isOnboarded(), self.isLocalMode(), shouldApply(),
+                  let latestRequest = self.statusRequest else { return (.superseded, false) }
+            // Availability reads update the facts, not the user's presentation intent.
+            // Join the latest read so an explicit action uses its profiles and target.
+            if latestRequest.id != request.id {
+                request = latestRequest
+                continue
             }
-            self.setPhase(.offering(status))
-            return (.offering, true)
-        } catch {
-            guard self.phaseGeneration == generation, self.availabilityGeneration == availabilityGeneration,
-                  self.isOnboarded(), self.isLocalMode(), shouldApply() else { return (.superseded, false) }
-            if force { self.setPhase(.hidden) }
-            return (
-                .unavailable(
-                    title: String(localized: "Browser import unavailable"),
-                    message: error.localizedDescription),
-                false)
+            do {
+                let status = try result.get()
+                self.importAvailable = Self.shouldOffer(status: status, force: true)
+                guard Self.shouldOffer(status: status, force: force) else {
+                    self.setPhase(.hidden)
+                    let message = status.enabled
+                        ? String(localized: """
+                        No Chrome, Brave, Edge, or Chromium profile with cookies was found on this Mac.
+                        """)
+                        : String(
+                            localized: "System browser profile import is disabled in the local Gateway configuration.")
+                    return (
+                        .unavailable(title: String(localized: "No browser login available"), message: message),
+                        true)
+                }
+                self.setPhase(.offering(status))
+                return (.offering, true)
+            } catch {
+                if force { self.setPhase(.hidden) }
+                return (
+                    .unavailable(
+                        title: String(localized: "Browser import unavailable"),
+                        message: error.localizedDescription),
+                    false)
+            }
         }
     }
 
@@ -268,7 +287,7 @@ final class BrowserProfileImportModel {
     /// import system profiles, so the banner withdraws on mode switches.
     func handleConnectionModeChange() {
         guard !self.isLocalMode() else { return }
-        self.availabilityGeneration += 1
+        self.statusRequest = nil
         self.importAvailable = false
         self.setPhase(.hidden)
     }

--- a/apps/macos/Sources/OpenClaw/DashboardWindowController+DeviceSettings.swift
+++ b/apps/macos/Sources/OpenClaw/DashboardWindowController+DeviceSettings.swift
@@ -221,6 +221,7 @@ extension DashboardWindowController {
             guard !Task.isCancelled, self.isWindowOpen else { return }
             switch outcome {
             case .offering: self.show()
+            case .superseded: break
             case let .unavailable(title, message):
                 let alert = NSAlert()
                 alert.messageText = title

--- a/apps/macos/Tests/OpenClawIPCTests/BrowserProfileImportModelTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/BrowserProfileImportModelTests.swift
@@ -24,6 +24,7 @@ private final class BrowserImportTransportStub {
     var requests: [BrowserProfileImportRequest] = []
     var failingPaths: Set<String> = []
     var beforeStatusResponse: (@MainActor () async -> Void)?
+    var beforeImportResponse: (@MainActor () async -> Void)?
     var statusJSON = """
     {
       "enabled": true,
@@ -43,16 +44,20 @@ private final class BrowserImportTransportStub {
             transport: { [weak self] request in
                 guard let self else { throw StubError() }
                 self.requests.append(request)
+                let statusJSON = self.statusJSON
+                let shouldFail = self.failingPaths.contains(request.path)
                 if request.path == "/system-profile-import/status", let hook = self.beforeStatusResponse {
                     self.beforeStatusResponse = nil
                     await hook()
                 }
-                if self.failingPaths.contains(request.path) {
-                    throw StubError()
+                if request.path == "/profiles/import", let hook = self.beforeImportResponse {
+                    self.beforeImportResponse = nil
+                    await hook()
                 }
+                if shouldFail { throw StubError() }
                 switch request.path {
                 case "/system-profile-import/status":
-                    return Data(self.statusJSON.utf8)
+                    return Data(statusJSON.utf8)
                 case "/profiles/import":
                     return Data(#"{"into":"imported","cookies":{"total":412,"imported":409}}"#.utf8)
                 default:
@@ -266,7 +271,8 @@ struct BrowserProfileImportModelTests {
         let forced = Self.status(
             profiles: [Self.chromeProfile],
             state: BrowserProfileImportOutcome(status: .dismissed))
-        model._testSetPhase(.offering(forced))
+        stub.statusJSON = stub.statusJSON.replacingOccurrences(of: "null", with: #"{"status":"dismissed"}"#)
+        await model.refresh(force: true)
 
         gate.continuation?.resume()
         #expect(await !idle.value)
@@ -308,13 +314,202 @@ struct BrowserProfileImportModelTests {
 
         // A faster poll offered the banner and the user dismissed it while the
         // slow poll was still waiting on its (pre-dismissal) status payload.
-        model._testSetPhase(.offering(Self.status(profiles: [Self.chromeProfile])))
+        await model.refresh(force: true)
         model.dismiss()
         #expect(model.phase == .hidden)
 
         gate.continuation?.resume()
         _ = await idle.value
         #expect(model.phase == .hidden)
+    }
+
+    @Test(arguments: [false, true], [false, true])
+    func `forced refresh cannot publish after a mode change`(fails: Bool, returnsToLocal: Bool) async {
+        let stub = BrowserImportTransportStub()
+        let eligibility = BrowserImportEligibilityGate()
+        eligibility.isLocalMode = true
+        let model = stub.makeModel(isLocalMode: { eligibility.isLocalMode })
+        let gate = ContinuationBox()
+        stub.beforeStatusResponse = {
+            await withCheckedContinuation { gate.continuation = $0 }
+        }
+        if fails { stub.failingPaths = ["/system-profile-import/status"] }
+        let refresh = Task { await model.refresh(force: true) }
+        while gate.continuation == nil {
+            await Task.yield()
+        }
+
+        eligibility.isLocalMode = false
+        model.handleConnectionModeChange()
+        if returnsToLocal {
+            eligibility.isLocalMode = true
+            model.handleConnectionModeChange()
+        }
+        gate.continuation?.resume()
+        #expect(await refresh.value == .superseded)
+        #expect(model.phase == .hidden)
+        #expect(!model.importAvailable)
+        if returnsToLocal {
+            stub.failingPaths = []
+            #expect(await model.requestAutomaticOfferIfEligible())
+        }
+    }
+
+    @Test func `newer forced refresh owns the banner before either response arrives`() async {
+        let stub = BrowserImportTransportStub()
+        let model = stub.makeModel()
+        let olderGate = ContinuationBox()
+        stub.beforeStatusResponse = {
+            await withCheckedContinuation { olderGate.continuation = $0 }
+        }
+        let older = Task { await model.refresh(force: true) }
+        while olderGate.continuation == nil {
+            await Task.yield()
+        }
+
+        let newerGate = ContinuationBox()
+        stub.statusJSON = stub.statusJSON.replacingOccurrences(of: "null", with: #"{"status":"dismissed"}"#)
+        stub.beforeStatusResponse = {
+            await withCheckedContinuation { newerGate.continuation = $0 }
+        }
+        let newer = Task { await model.refresh(force: true) }
+        while newerGate.continuation == nil {
+            await Task.yield()
+        }
+        olderGate.continuation?.resume()
+        #expect(await older.value == .superseded)
+        #expect(model.phase == .hidden)
+        #expect(!model.importAvailable)
+
+        newerGate.continuation?.resume()
+        #expect(await newer.value == .offering)
+        #expect(model.phase == .offering(Self.status(
+            profiles: [Self.chromeProfile],
+            state: BrowserProfileImportOutcome(status: .dismissed))))
+    }
+
+    @Test(arguments: [false, true], [false, true])
+    func `older status response cannot replace newer availability`(
+        olderOffersBanner: Bool,
+        newerOffersBanner: Bool) async
+    {
+        let stub = BrowserImportTransportStub()
+        let model = stub.makeModel()
+        let gate = ContinuationBox()
+        stub.beforeStatusResponse = {
+            await withCheckedContinuation { gate.continuation = $0 }
+        }
+        let older = Task {
+            if olderOffersBanner {
+                _ = await model.refresh(force: true)
+            } else {
+                await model.refreshAvailability()
+            }
+        }
+        while gate.continuation == nil {
+            await Task.yield()
+        }
+
+        stub.statusJSON = stub.statusJSON.replacingOccurrences(of: #""enabled": true"#, with: #""enabled": false"#)
+        if newerOffersBanner {
+            await model.refresh(force: true)
+        } else {
+            await model.refreshAvailability()
+        }
+        #expect(!model.importAvailable)
+        gate.continuation?.resume()
+        await older.value
+        #expect(!model.importAvailable)
+        #expect(model.phase == .hidden)
+    }
+
+    @Test func `availability response stays withdrawn across a local mode round trip`() async {
+        let stub = BrowserImportTransportStub()
+        let eligibility = BrowserImportEligibilityGate()
+        eligibility.isLocalMode = true
+        let model = stub.makeModel(isLocalMode: { eligibility.isLocalMode })
+        let gate = ContinuationBox()
+        stub.beforeStatusResponse = {
+            await withCheckedContinuation { gate.continuation = $0 }
+        }
+        let availability = Task { await model.refreshAvailability() }
+        while gate.continuation == nil {
+            await Task.yield()
+        }
+        eligibility.isLocalMode = false
+        model.handleConnectionModeChange()
+        eligibility.isLocalMode = true
+        model.handleConnectionModeChange()
+        gate.continuation?.resume()
+        await availability.value
+        #expect(!model.importAvailable)
+    }
+
+    @Test(arguments: [false, true])
+    func `import completion cannot replace a newer local offer after a mode change`(fails: Bool) async {
+        let stub = BrowserImportTransportStub()
+        let eligibility = BrowserImportEligibilityGate()
+        eligibility.isLocalMode = true
+        let model = stub.makeModel(isLocalMode: { eligibility.isLocalMode })
+        await model.refresh(force: true)
+        if fails { stub.failingPaths = ["/profiles/import"] }
+        let gate = ContinuationBox()
+        stub.beforeImportResponse = {
+            await withCheckedContinuation { gate.continuation = $0 }
+        }
+        let importing = Task { await model.importProfile(Self.chromeProfile) }
+        while gate.continuation == nil {
+            await Task.yield()
+        }
+
+        eligibility.isLocalMode = false
+        model.handleConnectionModeChange()
+        #expect(model.phase == .hidden)
+        eligibility.isLocalMode = true
+        model.handleConnectionModeChange()
+        await model.refresh(force: true)
+        let currentPhase = BrowserProfileImportModel.Phase.offering(Self.status(profiles: [Self.chromeProfile]))
+        #expect(model.phase == currentPhase)
+        gate.continuation?.resume()
+        await importing.value
+        #expect(model.phase == currentPhase)
+        #expect(stub.requests(for: "/profiles/import").count == 1)
+    }
+
+    @Test func `forced refresh leaves an active import in control of its result`() async {
+        let stub = BrowserImportTransportStub()
+        let model = stub.makeModel()
+        await model.refresh(force: true)
+        let gate = ContinuationBox()
+        stub.beforeImportResponse = {
+            await withCheckedContinuation { gate.continuation = $0 }
+        }
+        let importing = Task { await model.importProfile(Self.chromeProfile) }
+        while gate.continuation == nil {
+            await Task.yield()
+        }
+
+        let requestCount = stub.requests.count
+        #expect(await model.refresh(force: true) == .offering)
+        #expect(stub.requests.count == requestCount)
+        #expect(model.phase == .importing(profile: Self.chromeProfile, target: "imported"))
+        await model.refreshAvailability()
+        gate.continuation?.resume()
+        await importing.value
+        #expect(model.phase == .imported(BrowserProfileImportResult(
+            into: "imported",
+            cookies: .init(total: 412, imported: 409))))
+    }
+
+    @Test func `import rechecks local eligibility before dispatch`() async {
+        let stub = BrowserImportTransportStub()
+        let eligibility = BrowserImportEligibilityGate()
+        eligibility.isLocalMode = true
+        let model = stub.makeModel(isLocalMode: { eligibility.isLocalMode })
+        await model.refresh(force: true)
+        eligibility.isLocalMode = false
+        await model.importProfile(Self.chromeProfile)
+        #expect(stub.requests(for: "/profiles/import").isEmpty)
     }
 
     @Test func `idle refresh never clobbers a visible outcome`() async {

--- a/apps/macos/Tests/OpenClawIPCTests/BrowserProfileImportModelTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/BrowserProfileImportModelTests.swift
@@ -423,6 +423,53 @@ struct BrowserProfileImportModelTests {
         #expect(model.phase == .hidden)
     }
 
+    @Test(arguments: [false, true], [false, true])
+    func `availability reads preserve a pending forced offer using the latest status`(
+        availabilityFinishesFirst: Bool,
+        profileChanges: Bool) async throws
+    {
+        let stub = BrowserImportTransportStub()
+        let model = stub.makeModel()
+        let offerGate = ContinuationBox()
+        stub.beforeStatusResponse = {
+            await withCheckedContinuation { offerGate.continuation = $0 }
+        }
+        let offer = Task { await model.refresh(force: true) }
+        while offerGate.continuation == nil {
+            await Task.yield()
+        }
+
+        let latestStatus = BrowserProfileImportStatus(
+            enabled: true,
+            systemProfiles: [profileChanges
+                ? BrowserSystemProfile(browser: "brave", id: "Profile 1", name: "Work", hasCookies: true)
+                : Self.chromeProfile],
+            state: nil,
+            suggestedTarget: profileChanges ? "work-logins" : "imported")
+        stub.statusJSON = try String(decoding: JSONEncoder().encode(latestStatus), as: UTF8.self)
+        let availabilityGate = ContinuationBox()
+        stub.beforeStatusResponse = {
+            await withCheckedContinuation { availabilityGate.continuation = $0 }
+        }
+        let availability = Task { await model.refreshAvailability() }
+        while availabilityGate.continuation == nil {
+            await Task.yield()
+        }
+
+        if availabilityFinishesFirst {
+            availabilityGate.continuation?.resume()
+            await availability.value
+            offerGate.continuation?.resume()
+        } else {
+            offerGate.continuation?.resume()
+            availabilityGate.continuation?.resume()
+            await availability.value
+        }
+        #expect(await offer.value == .offering)
+        #expect(model.phase == .offering(latestStatus))
+        #expect(model.importAvailable)
+    }
+
     @Test func `availability response stays withdrawn across a local mode round trip`() async {
         let stub = BrowserImportTransportStub()
         let eligibility = BrowserImportEligibilityGate()

--- a/apps/macos/Tests/OpenClawIPCTests/BrowserProfileImportModelTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/BrowserProfileImportModelTests.swift
@@ -355,6 +355,32 @@ struct BrowserProfileImportModelTests {
         }
     }
 
+    @Test(arguments: [BrowserProfileImportDisposition.dismissed, .imported])
+    func `automatic offers cannot supersede a pending forced reoffer`(
+        disposition: BrowserProfileImportDisposition) async throws
+    {
+        let stub = BrowserImportTransportStub()
+        let status = Self.status(
+            profiles: [Self.chromeProfile],
+            state: BrowserProfileImportOutcome(status: disposition))
+        stub.statusJSON = try String(decoding: JSONEncoder().encode(status), as: UTF8.self)
+        let model = stub.makeModel()
+        let gate = ContinuationBox()
+        stub.beforeStatusResponse = {
+            await withCheckedContinuation { gate.continuation = $0 }
+        }
+        let forced = Task { await model.refresh(force: true) }
+        while gate.continuation == nil {
+            await Task.yield()
+        }
+
+        #expect(await !model.requestAutomaticOfferIfEligible())
+        #expect(stub.requests(for: "/system-profile-import/status").count == 1)
+        gate.continuation?.resume()
+        #expect(await forced.value == .offering)
+        #expect(model.phase == .offering(status))
+    }
+
     @Test func `newer forced refresh owns the banner before either response arrives`() async {
         let stub = BrowserImportTransportStub()
         let model = stub.makeModel()
@@ -380,6 +406,8 @@ struct BrowserProfileImportModelTests {
         #expect(await older.value == .superseded)
         #expect(model.phase == .hidden)
         #expect(!model.importAvailable)
+        #expect(await !model.requestAutomaticOfferIfEligible())
+        #expect(stub.requests(for: "/system-profile-import/status").count == 2)
 
         newerGate.continuation?.resume()
         #expect(await newer.value == .offering)

--- a/docs/platforms/macos.md
+++ b/docs/platforms/macos.md
@@ -209,6 +209,8 @@ Right-click an external link in the dashboard to choose **Open in Browser Panel*
 
 The first time a Mac tab opens while the app runs against a local Gateway, the dashboard shows a dismissible banner when a Chrome-family profile with cookies exists on the Mac. The banner offers to copy those cookies into an isolated managed profile that agents use for browsing. Choose a profile from its **Import** control (Touch ID may be required); progress and the imported-cookie count appear inline, and only cookies are copied — passwords never leave the source browser. Dismissing the banner records the choice; **Dashboard → Settings → This Mac → Browser** can re-open the native import flow while a local Gateway and eligible profile are available. See [Browser](/cli/browser) for the underlying import flow and the `browser.allowSystemProfileImport` gate.
 
+Switching away from Local mode hides the import banner and discards pending status or banner results. An import already sent to the local Gateway may still finish there; switching modes does not undo copied cookies. Returning to Local mode lets you request a fresh offer from **Settings → This Mac → Browser**.
+
 ## Sync cookies to a remote computer
 
 Import copies cookies once into a profile on the same Mac. When your Gateway and agent browser run on a **separate computer** (a dedicated box, a headless Linux host, or a cloud container), turn on cookie sync so this Mac keeps that remote browser signed in to the sites you choose.


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users switching Gateway modes or making a newer browser-import request could see an obsolete offer, availability result, failure, or success banner appear when an earlier request finished. A stale explicit request could also bring the dashboard forward again.

## Why This Change Was Made

BrowserProfileImportModel owns presentation intent separately from the latest status request. A pending explicit offer consumes the newest status facts, so an activation or another dashboard availability read cannot silently discard it. Automatic offers also yield to a pending explicit request, including when persisted state records a dismissal or prior import. Phase changes and newer explicit requests retire that priority; an older completion cannot clear its successor. Results publish only while the phase and local-mode context remain current. A superseded explicit request has its own outcome, and the dashboard caller leaves it alone. Refreshes preserve an active import; an already dispatched Gateway import still finishes even if its banner context disappears.

## User Impact

Browser import follows the current local Gateway context and latest user intent. Mode changes withdraw stale presentation without pretending to roll back an import already sent to the Gateway. No UI appearance, import endpoint, or persistence contract changes.

## Evidence

- Added continuation-controlled regression coverage in BrowserProfileImportModelTests for mode changes and round trips, concurrent forced refreshes, both availability readers, import success/failure after context changes, active-import refresh, eligibility before dispatch, and automatic attempts during a pending explicit re-offer for both dismissed and imported persisted states.
- Removed the production-only test phase setter; existing tests now use the actual refresh entry point.
- Swift app/test build, lint/format, and git diff --check passed. Required [CI run34671752848](https://github.com/openclaw/openclaw/actions/runs/34671752848) passed on final head `4c6a38080452b11f1cd42fa05b4e98b04036b850`, including native Swift tests. The earlier model suite also passed in a disposable VM; no operator app, Gateway, or local full native suite was used.
- Deslop completed. Independent Codex P2 review is scoped-clean after fixing cross-reader availability ordering preserving explicit intent during background reads, and preventing automatic offers from superseding pending explicit intent. The final priority repair also passed fresh independent P2 review. Lead verified complete caller cutover and exact patch identity.

Native localization verification passes. The generated inventory records only the unchanged long message becoming a multiline Swift literal to satisfy lint; its text and localization ID are unchanged.
