### PR TITLE
fix(macos): finish capture cleanup before starting new work

### DIFF
--- a/apps/macos/Sources/OpenClaw/AudioInputDeviceObserver.swift
+++ b/apps/macos/Sources/OpenClaw/AudioInputDeviceObserver.swift
@@ -1,3 +1,5 @@
+import AudioToolbox
+import AVFoundation
 import CoreAudio
 import Foundation
 import OSLog
@@ -100,6 +102,47 @@ final class AudioInputDeviceObserver: @unchecked Sendable {
             selectedUID: selectedUID,
             availableUIDs: self.aliveInputDeviceUIDs(),
             defaultUID: self.defaultInputDeviceUID())
+    }
+
+    static func bindSelectedInputIfNeeded(
+        _ selection: AudioInputDeviceResolution,
+        to input: AVAudioInputNode,
+        logger: Logger,
+        context: String) -> AudioInputDeviceResolution
+    {
+        guard selection.shouldBindSelectedDevice, let selectedUID = selection.resolvedUID else {
+            return selection
+        }
+        guard let audioUnit = input.audioUnit,
+              var deviceID = self.inputDeviceID(forUID: selectedUID)
+        else {
+            logger.warning("\(context, privacy: .public) selected input could not be resolved; using system default")
+            return self.defaultFallback(for: selection)
+        }
+
+        let status = AudioUnitSetProperty(
+            audioUnit,
+            kAudioOutputUnitProperty_CurrentDevice,
+            kAudioUnitScope_Global,
+            0,
+            &deviceID,
+            UInt32(MemoryLayout<AudioObjectID>.size))
+        guard status == noErr else {
+            logger.warning(
+                "\(context, privacy: .public) selected input binding failed status=\(status); using system default")
+            return self.defaultFallback(for: selection)
+        }
+        logger
+            .info(
+                "\(context, privacy: .public) selected input bound uid=\(selectedUID, privacy: .private(mask: .hash))")
+        return selection
+    }
+
+    private static func defaultFallback(for selection: AudioInputDeviceResolution) -> AudioInputDeviceResolution {
+        AudioInputDeviceResolution(
+            selectedUID: selection.selectedUID,
+            resolvedUID: self.resolveSelection(nil).resolvedUID,
+            fellBackToSystemDefault: selection.selectedUID != nil)
     }
 
     /// Returns true when the system default input device exists and is alive with input channels.

--- a/apps/macos/Sources/OpenClaw/CameraCaptureService.swift
+++ b/apps/macos/Sources/OpenClaw/CameraCaptureService.swift
@@ -139,20 +139,6 @@ actor CameraCaptureService {
             try await self.ensureAccess(for: .audio)
         }
 
-        let prepared = try await CameraCapturePipelineSupport.prepareWarmMovieSession(
-            options: CameraMovieSessionOptions(
-                preferFrontCamera: facing == .front,
-                deviceId: deviceId,
-                includeAudio: includeAudio,
-                durationMs: durationMs),
-            pickCamera: { preferFrontCamera, deviceId in
-                try Self.pickCamera(facing: preferFrontCamera ? .front : .back, deviceId: deviceId)
-            },
-            mapSetupError: Self.mapMovieSetupError)
-        let session = prepared.session
-        let output = prepared.output
-        defer { session.stopRunning() }
-
         let tmpMovURL = FileManager().temporaryDirectory
             .appendingPathComponent("openclaw-camera-\(UUID().uuidString).mov")
         defer { try? FileManager().removeItem(at: tmpMovURL) }
@@ -164,17 +150,29 @@ actor CameraCaptureService {
             return FileManager().temporaryDirectory
                 .appendingPathComponent("openclaw-camera-\(UUID().uuidString).mp4")
         }()
-        // Ensure we don't fail exporting due to an existing file.
-        try? FileManager().removeItem(at: outputURL)
-
         let logger = self.logger
-        var delegate: MovieFileDelegate?
-        let recordedURL: URL = try await withCheckedThrowingContinuation { cont in
-            let d = MovieFileDelegate(cont, logger: logger)
-            delegate = d
-            output.startRecording(to: tmpMovURL, recordingDelegate: d)
-        }
-        withExtendedLifetime(delegate) {}
+        let recordedURL = try await CameraCapturePipelineSupport.withWarmMovieSession(
+            options: CameraMovieSessionOptions(
+                preferFrontCamera: facing == .front,
+                deviceId: deviceId,
+                includeAudio: includeAudio,
+                durationMs: durationMs),
+            pickCamera: { preferFrontCamera, deviceId in
+                try Self.pickCamera(facing: preferFrontCamera ? .front : .back, deviceId: deviceId)
+            },
+            mapSetupError: Self.mapMovieSetupError,
+            operation: { output in
+                // Replace the export destination only after camera setup succeeds.
+                try? FileManager().removeItem(at: outputURL)
+                var delegate: MovieFileDelegate?
+                let recordedURL: URL = try await withCheckedThrowingContinuation { cont in
+                    let captureDelegate = MovieFileDelegate(cont, logger: logger)
+                    delegate = captureDelegate
+                    output.startRecording(to: tmpMovURL, recordingDelegate: captureDelegate)
+                }
+                withExtendedLifetime(delegate) {}
+                return recordedURL
+            })
         try await Self.exportToMP4(inputURL: recordedURL, outputURL: outputURL)
         return (path: outputURL.path, durationMs: durationMs, hasAudio: includeAudio)
     }
@@ -234,33 +232,10 @@ actor CameraCaptureService {
         }
         export.shouldOptimizeForNetworkUse = true
 
-        if #available(macOS 15.0, *) {
-            do {
-                try await export.export(to: outputURL, as: .mp4)
-                return
-            } catch {
-                throw CameraError.exportFailed(error.localizedDescription)
-            }
-        } else {
-            export.outputURL = outputURL
-            export.outputFileType = .mp4
-
-            try await withCheckedThrowingContinuation(isolation: nil) { (cont: CheckedContinuation<Void, Error>) in
-                export.exportAsynchronously {
-                    cont.resume(returning: ())
-                }
-            }
-
-            switch export.status {
-            case .completed:
-                return
-            case .failed:
-                throw CameraError.exportFailed(export.error?.localizedDescription ?? "export failed")
-            case .cancelled:
-                throw CameraError.exportFailed("export cancelled")
-            default:
-                throw CameraError.exportFailed("export did not complete (\(export.status.rawValue))")
-            }
+        do {
+            try await export.export(to: outputURL, as: .mp4)
+        } catch {
+            throw CameraError.exportFailed(error.localizedDescription)
         }
     }
 

--- a/apps/macos/Sources/OpenClaw/DeviceMicrophonePanel.swift
+++ b/apps/macos/Sources/OpenClaw/DeviceMicrophonePanel.swift
@@ -17,6 +17,7 @@ final class DeviceMicrophoneTestModel {
     private var isActive = false
     private var testTask: Task<Void, Never>?
     private var meterTask: Task<Void, Never>?
+    private var meterStopTask: Task<Void, Never>?
 
     init(state: AppState) {
         self.state = state
@@ -27,7 +28,12 @@ final class DeviceMicrophoneTestModel {
         self.isActive = true
         MicRefreshSupport.startObserver(self.micObserver) { [weak self] in
             guard let self, self.isActive else { return }
-            MicRefreshSupport.schedule(refreshTask: &self.meterTask) { [weak self] in
+            let previousMeterTask = self.meterTask
+            previousMeterTask?.cancel()
+            self.meterTask = Task { [weak self] in
+                await previousMeterTask?.value
+                guard !Task.isCancelled else { return }
+                try? await Task.sleep(for: .milliseconds(300))
                 await self?.restartMeter()
             }
         }
@@ -39,13 +45,19 @@ final class DeviceMicrophoneTestModel {
         self.isActive = false
         self.testTask?.cancel()
         self.testTask = nil
-        self.meterTask?.cancel()
+        let meterTask = self.meterTask
+        meterTask?.cancel()
         self.meterTask = nil
         self.tester.stop()
         self.micObserver.stop()
         self.isTesting = false
         self.state.voiceWakeMeterActive = false
-        Task { await self.meter.stop() }
+        let previousStop = self.meterStopTask
+        self.meterStopTask = Task { [meter = self.meter] in
+            await previousStop?.value
+            await meterTask?.value
+            await meter.stop()
+        }
     }
 
     func toggleTest() {
@@ -121,16 +133,16 @@ final class DeviceMicrophoneTestModel {
     }
 
     private func restartMeter() async {
-        guard self.isActive else { return }
+        guard !Task.isCancelled, self.isActive else { return }
+        await self.meterStopTask?.value
+        guard !Task.isCancelled, self.isActive else { return }
         self.meterError = nil
         await self.meter.stop()
         guard !Task.isCancelled, self.isActive else { return }
         do {
             try await self.meter.start { [weak self] level in
-                Task { @MainActor in
-                    guard let self, self.isActive else { return }
-                    self.meterLevel = level
-                }
+                guard let self, self.isActive else { return }
+                self.meterLevel = level
             }
             guard !Task.isCancelled, self.isActive else {
                 await self.meter.stop()

--- a/apps/macos/Sources/OpenClaw/MacRealtimeTalkAudioCapture.swift
+++ b/apps/macos/Sources/OpenClaw/MacRealtimeTalkAudioCapture.swift
@@ -1,4 +1,3 @@
-import AudioToolbox
 @preconcurrency import AVFoundation
 import CoreAudio
 import Foundation
@@ -125,7 +124,8 @@ final class MacRealtimeTalkAudioCapture: RealtimeTalkAudioCapturing {
             try input.setVoiceProcessingEnabled(true)
         }
 
-        let activeResolution = self.bindSelectedInputIfNeeded(selection, to: input)
+        let activeResolution = AudioInputDeviceObserver.bindSelectedInputIfNeeded(
+            selection, to: input, logger: self.logger, context: "realtime")
         guard activeResolution.resolvedUID != nil else {
             throw MacRealtimeTalkAudioCaptureError.inputUnavailable
         }
@@ -153,46 +153,6 @@ final class MacRealtimeTalkAudioCapture: RealtimeTalkAudioCapturing {
         engine.prepare()
         try engine.start()
         self.activeInputResolution = activeResolution
-    }
-
-    private func bindSelectedInputIfNeeded(
-        _ selection: AudioInputDeviceResolution,
-        to input: AVAudioInputNode) -> AudioInputDeviceResolution
-    {
-        guard selection.shouldBindSelectedDevice, let selectedUID = selection.resolvedUID else {
-            return selection
-        }
-        guard let audioUnit = input.audioUnit,
-              var deviceID = AudioInputDeviceObserver.inputDeviceID(forUID: selectedUID)
-        else {
-            self.logger.warning("realtime selected input could not be resolved; using system default")
-            return self.defaultFallback(for: selection)
-        }
-
-        let status = AudioUnitSetProperty(
-            audioUnit,
-            kAudioOutputUnitProperty_CurrentDevice,
-            kAudioUnitScope_Global,
-            0,
-            &deviceID,
-            UInt32(MemoryLayout<AudioObjectID>.size))
-        guard status == noErr else {
-            self.logger.warning(
-                "realtime selected input binding failed status=\(status); using system default")
-            return self.defaultFallback(for: selection)
-        }
-        self.logger.info(
-            "realtime selected input bound uid=\(selectedUID, privacy: .private(mask: .hash))")
-        return selection
-    }
-
-    private func defaultFallback(
-        for selection: AudioInputDeviceResolution) -> AudioInputDeviceResolution
-    {
-        AudioInputDeviceResolution(
-            selectedUID: selection.selectedUID,
-            resolvedUID: AudioInputDeviceObserver.resolveSelection(nil).resolvedUID,
-            fellBackToSystemDefault: selection.selectedUID != nil)
     }
 
     private func startDeviceObserver() {

--- a/apps/macos/Sources/OpenClaw/MicLevelMonitor.swift
+++ b/apps/macos/Sources/OpenClaw/MicLevelMonitor.swift
@@ -6,61 +6,74 @@ import SwiftUI
 actor MicLevelMonitor {
     private let logger = Logger(subsystem: "ai.openclaw", category: "voicewake.meter")
     private var engine: AVAudioEngine?
-    private var update: (@Sendable (Double) -> Void)?
-    private var running = false
+    private var update: (@MainActor @Sendable (Double) -> Void)?
+    private var deliveryTask: Task<Void, Never>?
+    private var captureGeneration: UInt64 = 0
     private var smoothedLevel: Double = 0
     private var lastUpdate = ContinuousClock.now
     private var lastPublishedLevel: Double = 0
     private let minimumUpdateInterval: Duration = .milliseconds(125)
     private let minimumLevelDelta = 0.02
 
-    func start(onLevel: @Sendable @escaping (Double) -> Void) async throws {
-        self.update = onLevel
-        if self.running { return }
+    func start(onLevel: @MainActor @Sendable @escaping (Double) -> Void) async throws {
+        if self.engine != nil {
+            self.update = onLevel
+            return
+        }
         self.logger.info(
             "mic level monitor start (\(AudioInputDeviceObserver.defaultInputDeviceSummary(), privacy: .public))")
         self.lastUpdate = .now
         self.lastPublishedLevel = self.smoothedLevel
         guard AudioInputDeviceObserver.hasUsableDefaultInputDevice() else {
-            self.engine = nil
             throw NSError(
                 domain: "MicLevelMonitor",
                 code: 1,
                 userInfo: [NSLocalizedDescriptionKey: "No usable audio input device available"])
         }
         let engine = AVAudioEngine()
-        self.engine = engine
         let input = engine.inputNode
         let format = input.outputFormat(forBus: 0)
         guard format.channelCount > 0, format.sampleRate > 0 else {
-            self.engine = nil
             throw NSError(
                 domain: "MicLevelMonitor",
                 code: 1,
                 userInfo: [NSLocalizedDescriptionKey: "No audio input available"])
         }
-        input.removeTap(onBus: 0)
+        self.captureGeneration &+= 1
+        let generation = self.captureGeneration
         input.installTap(onBus: 0, bufferSize: 512, format: format) { [weak self] buffer, _ in
             guard let self else { return }
             let level = TalkAudioLevel.normalized(rms: TalkAudioLevel.rms(buffer: buffer))
-            Task { await self.push(level: level) }
+            Task { await self.push(level: level, generation: generation) }
         }
         engine.prepare()
-        try engine.start()
-        self.running = true
+        do {
+            try engine.start()
+        } catch {
+            input.removeTap(onBus: 0)
+            engine.stop()
+            throw error
+        }
+        self.engine = engine
+        self.update = onLevel
     }
 
-    func stop() {
-        guard self.running else { return }
+    func stop() async {
+        self.captureGeneration &+= 1
+        let deliveryTask = self.deliveryTask
+        self.deliveryTask = nil
+        deliveryTask?.cancel()
+        self.update = nil
         if let engine {
             engine.inputNode.removeTap(onBus: 0)
             engine.stop()
         }
         self.engine = nil
-        self.running = false
+        await deliveryTask?.value
     }
 
-    private func push(level: Double) {
+    private func push(level: Double, generation: UInt64) {
+        guard self.engine != nil, generation == self.captureGeneration else { return }
         self.smoothedLevel = (self.smoothedLevel * 0.45) + (level * 0.55)
         guard let update else { return }
         let now = ContinuousClock.now
@@ -70,7 +83,11 @@ actor MicLevelMonitor {
         self.lastUpdate = now
         let value = self.smoothedLevel
         self.lastPublishedLevel = value
-        Task { @MainActor in update(value) }
+        self.deliveryTask?.cancel()
+        self.deliveryTask = Task { @MainActor in
+            guard !Task.isCancelled else { return }
+            update(value)
+        }
     }
 }
 

--- a/apps/macos/Sources/OpenClaw/MicRefreshSupport.swift
+++ b/apps/macos/Sources/OpenClaw/MicRefreshSupport.swift
@@ -2,26 +2,11 @@ import Foundation
 import SwiftUI
 
 enum MicRefreshSupport {
-    private static let refreshDelayNs: UInt64 = 300_000_000
-
     static func startObserver(_ observer: AudioInputDeviceObserver, triggerRefresh: @escaping @MainActor () -> Void) {
         observer.start {
             Task { @MainActor in
                 triggerRefresh()
             }
-        }
-    }
-
-    @MainActor
-    static func schedule(
-        refreshTask: inout Task<Void, Never>?,
-        action: @escaping @MainActor () async -> Void)
-    {
-        refreshTask?.cancel()
-        refreshTask = Task { @MainActor in
-            try? await Task.sleep(nanoseconds: self.refreshDelayNs)
-            guard !Task.isCancelled else { return }
-            await action()
         }
     }
 

--- a/apps/macos/Sources/OpenClaw/TalkModeRuntime.swift
+++ b/apps/macos/Sources/OpenClaw/TalkModeRuntime.swift
@@ -1,4 +1,3 @@
-import AudioToolbox
 import AVFoundation
 import Foundation
 import OpenClawChatUI
@@ -519,36 +518,6 @@ actor TalkModeRuntime {
         await sendAndSpeak(text)
     }
 
-    private func bindSelectedInputIfNeeded(
-        _ selection: AudioInputDeviceResolution,
-        to input: AVAudioInputNode) -> AudioInputDeviceResolution
-    {
-        guard selection.shouldBindSelectedDevice, let selectedUID = selection.resolvedUID else {
-            return selection
-        }
-        guard let audioUnit = input.audioUnit,
-              var deviceID = AudioInputDeviceObserver.inputDeviceID(forUID: selectedUID)
-        else {
-            self.logger.warning("talk selected input could not be resolved; using system default")
-            return self.defaultFallback(for: selection)
-        }
-
-        let status = AudioUnitSetProperty(
-            audioUnit,
-            kAudioOutputUnitProperty_CurrentDevice,
-            kAudioUnitScope_Global,
-            0,
-            &deviceID,
-            UInt32(MemoryLayout<AudioObjectID>.size))
-        guard status == noErr else {
-            self.logger.warning(
-                "talk selected input binding failed status=\(status); using system default")
-            return self.defaultFallback(for: selection)
-        }
-        self.logger.info("talk selected input bound uid=\(selectedUID, privacy: .private(mask: .hash))")
-        return selection
-    }
-
     private func prepareStartedRecognitionCapture(
         selection: AudioInputDeviceResolution,
         enableVoiceProcessing: Bool)
@@ -564,7 +533,8 @@ actor TalkModeRuntime {
                 try input.setVoiceProcessingEnabled(true)
             }
 
-            let activeResolution = self.bindSelectedInputIfNeeded(selection, to: input)
+            let activeResolution = AudioInputDeviceObserver.bindSelectedInputIfNeeded(
+                selection, to: input, logger: self.logger, context: "talk")
             guard activeResolution.resolvedUID != nil else {
                 throw TalkAudioInputError.unavailable
             }
@@ -598,13 +568,6 @@ actor TalkModeRuntime {
             audioEngine.stop()
             throw error
         }
-    }
-
-    private func defaultFallback(for selection: AudioInputDeviceResolution) -> AudioInputDeviceResolution {
-        AudioInputDeviceResolution(
-            selectedUID: selection.selectedUID,
-            resolvedUID: AudioInputDeviceObserver.resolveSelection(nil).resolvedUID,
-            fellBackToSystemDefault: selection.selectedUID != nil)
     }
 }
 

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/CameraCapturePipelineSupport.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/CameraCapturePipelineSupport.swift
@@ -85,29 +85,6 @@ public enum CameraCapturePipelineSupport {
         }
     }
 
-    public static func prepareWarmMovieSession(
-        options: CameraMovieSessionOptions,
-        pickCamera: (_ preferFrontCamera: Bool, _ deviceId: String?) throws -> AVCaptureDevice,
-        mapSetupError: (CameraSessionConfigurationError) -> Error) async throws
-        -> (session: AVCaptureSession, output: AVCaptureMovieFileOutput)
-    {
-        try Task.checkCancellation()
-        let prepared = try self.prepareMovieSession(
-            options: options,
-            pickCamera: pickCamera,
-            mapSetupError: mapSetupError)
-        try Task.checkCancellation()
-        prepared.session.startRunning()
-        do {
-            try await self.warmUpCaptureSession()
-            try Task.checkCancellation()
-        } catch {
-            prepared.session.stopRunning()
-            throw error
-        }
-        return prepared
-    }
-
     public static func withWarmMovieSession<T>(
         options: CameraMovieSessionOptions,
         pickCamera: (_ preferFrontCamera: Bool, _ deviceId: String?) throws -> AVCaptureDevice,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where rapidly closing and reopening the microphone test panel could let an earlier shutdown stop the new capture. Failed meter startup also left cleanup dependent on a separate running flag, and camera recording held the capture session open during MP4 export.

## Why This Change Was Made

The microphone panel drains its previous startup and shutdown work before starting a new meter. MicLevelMonitor owns successful engine startup, failed-start cleanup, and cancellable delivery to the main actor. Camera recording uses the existing shared warm-session owner and finishes capture before exporting. Both Talk capture paths use the same selected-device binding implementation while retaining their distinct capture lifetimes.

The retired debounce helper and unscoped warm-session API are removed. Package/distribution, caller, docs and historical review establish no supported external contract for that unused API. The live lifecycle owner, setup primitive, options and all tests remain.

## User Impact

Microphone test reopen follows the current panel lifecycle, and old callbacks cannot update a new capture. Camera export no longer extends recording-session ownership. Device selection, fallback behavior, permission checks, recording duration, and export format remain unchanged. The unreachable pre-macOS 15 export branch is also removed.

## Evidence

- Final required [CI run 34665165348](https://github.com/openclaw/openclaw/actions/runs/34665165348) passed at `0c74df3623475257c39512fb5ec3a2b917d0d7fa`.
- Both consumer scans and the shared intersection passed in [workflow 34665165328, attempt 2](https://github.com/openclaw/openclaw/actions/runs/34665165328). This completed an earlier canceled iOS scan; no source or checks were weakened.
- App/test builds, Swift lint/format, localization verification and diff checks passed individually and with the other Mac architecture changes combined.
- Fresh independent Codex P2 reviews are scoped-clean after resolving panel shutdown ordering and completing the helper retirements identified by Periphery.
- Existing audio/Talk/shared-camera tests remain intact. No hardware-mocking production seam was added. Actual microphone startup failure and camera indicator/export timing were not observed on hardware; the proof does not claim that coverage.
- No operator app, Gateway, permissions, or Keychain state was used. A separate disposable-VM app smoke could not produce a valid runtime measurement because the temporary debug-binary/release-scaffold assembly had resource lookup mismatches; its focused tests are separate evidence.
