### PR TITLE
fix: stop closed terminal tabs from reopening

### DIFF
--- a/docs/web/control-ui/panels.md
+++ b/docs/web/control-ui/panels.md
@@ -77,6 +77,8 @@ Eligibility is per session and per host. Gateway-local sessions start the provid
 
 Standalone operator sessions, including the main terminal page and terminal focus presentation, are connection-owned. Leaving the main terminal route does not close its PTY; returning to its terminal session URL reattaches it. The main page and the dock keep separate terminal tabs. A page reload, laptop sleep, or network blip detaches one on the Gateway instead of killing it, and the same browser tab reattaches on reconnect with recent output replayed. Detached connection-owned sessions are killed after `gateway.terminal.detachedSessionTimeoutSeconds` (default 300 seconds; `0` restores kill-on-disconnect). Attaching one of these sessions remains tmux-style take-over.
 
+Closing a connecting tab cancels that opening or attachment request. Other tabs and queued requests remain available, and a late response does not reopen the cancelled tab or display its error.
+
 Conversation-owned sessions opened from a Chat session's Terminal panel are not bound to a browser connection. `terminal.attach` adds each browser as a viewer without taking ownership, and closing an established viewer tab detaches only that browser. Conversation-owned PTYs remain until the exact-session agent closes them, their shell exits, the session is archived, policy disables them, or the Gateway shuts down. `terminal.list` marks each entry as connection- or agent-owned.
 
 All Gateway terminal PTYs are process-local. A Gateway restart ends them; the

--- a/ui/src/components/terminal/terminal-panel-cancellation.test.ts
+++ b/ui/src/components/terminal/terminal-panel-cancellation.test.ts
@@ -1,0 +1,268 @@
+/* @vitest-environment jsdom */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../../test/helpers/promise.ts";
+import { i18n } from "../../i18n/index.ts";
+import { createStorageMock } from "../../test-helpers/storage.ts";
+import { waitForFast } from "../../test-helpers/wait-for.ts";
+import type { TerminalGatewayClient } from "./terminal-connection.ts";
+import {
+  createTerminalController,
+  defineTestTerminalPanelElement,
+  terminalOpenResult,
+  type CreateGhosttyTerminalMock,
+} from "./terminal-panel.test-support.ts";
+import type { OpenClawTerminalPanel } from "./terminal-panel.ts";
+import { TerminalIntentQueue } from "./terminal-pending-actions.ts";
+
+vi.mock("../../app/sw-refresh.runtime.ts", () => ({
+  refreshControlUiServiceWorker: vi.fn(async () => false),
+}));
+
+const createGhosttyTerminalMock: CreateGhosttyTerminalMock = vi.fn();
+const TERMINAL_PANEL_ELEMENT_NAME = defineTestTerminalPanelElement(createGhosttyTerminalMock);
+const panels: OpenClawTerminalPanel[] = [];
+const releaseResponses: Array<() => void> = [];
+
+function mountTerminalPanel(client: TerminalGatewayClient): OpenClawTerminalPanel {
+  const panel = document.createElement(TERMINAL_PANEL_ELEMENT_NAME) as OpenClawTerminalPanel;
+  panel.client = client;
+  panel.available = true;
+  panels.push(panel);
+  document.body.append(panel);
+  return panel;
+}
+
+describe("terminal panel pending cancellation", () => {
+  beforeEach(async () => {
+    vi.stubGlobal("localStorage", createStorageMock());
+    vi.stubGlobal("sessionStorage", createStorageMock());
+    await i18n.setLocale("en");
+  });
+
+  afterEach(async () => {
+    for (const panel of panels) {
+      panel.closeTerminalPanel();
+    }
+    document.body.replaceChildren();
+    for (const release of releaseResponses) {
+      release();
+    }
+    await Promise.all(panels.map((panel) => panel.updateComplete));
+    panels.length = 0;
+    releaseResponses.length = 0;
+    createGhosttyTerminalMock.mockReset();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it.each(
+    (["open", "attach"] as const).flatMap((kind) => [
+      { kind, outcome: "resolve", cancelled: true, reconnect: false, page: true },
+      { kind, outcome: "reject", cancelled: true, reconnect: false, page: true },
+      { kind, outcome: "reject", cancelled: false, reconnect: false, page: true },
+      { kind, outcome: "resolve", cancelled: true, reconnect: true, page: false },
+    ]),
+  )(
+    "settles $kind $outcome without reviving a cancelled tab (cancelled: $cancelled, reconnect: $reconnect, page: $page)",
+    async ({ kind, outcome, cancelled, reconnect, page }) => {
+      const queueCalls = vi.spyOn(TerminalIntentQueue.prototype, "queue");
+      createGhosttyTerminalMock.mockImplementation(async () => createTerminalController());
+      const response = (sessionId: string) => ({
+        ...terminalOpenResult(sessionId),
+        buffer: "",
+        seq: 0,
+      });
+      const pending = createDeferred<ReturnType<typeof response>>();
+      releaseResponses.push(() => pending.resolve(response("cleanup-session")));
+      const requests: Array<{ method: string; params: unknown }> = [];
+      const targetMethod = `terminal.${kind}`;
+      const client: TerminalGatewayClient = {
+        forceReconnect: () => {},
+        request: <T>(method: string, params?: unknown) => {
+          requests.push({ method, params });
+          if (method === targetMethod) {
+            return (
+              requests.filter((request) => request.method === targetMethod).length === 1
+                ? pending.promise
+                : Promise.resolve(response("unexpected-replay"))
+            ) as Promise<T>;
+          }
+          return Promise.resolve({}) as Promise<T>;
+        },
+        addEventListener: () => () => {},
+      };
+      const panel = document.createElement(TERMINAL_PANEL_ELEMENT_NAME) as OpenClawTerminalPanel;
+      panel.client = client;
+      panel.available = true;
+      panel.page = panel.fullscreen = panel.embedded = page;
+      panel.routeTarget = kind === "attach" ? { sessionId: "pending-session" } : null;
+      panels.push(panel);
+      document.body.append(panel);
+      if (!page) {
+        window.dispatchEvent(
+          new CustomEvent("openclaw:terminal-toggle", {
+            detail: {
+              open: true,
+              ...(kind === "attach" ? { terminalSessionId: "pending-session" } : {}),
+            },
+          }),
+        );
+      }
+      await waitForFast(() =>
+        expect(requests.filter((request) => request.method === targetMethod)).toHaveLength(1),
+      );
+      if (cancelled) {
+        panel.renderRoot.querySelector<HTMLButtonElement>(".tabstrip-tab__close")!.click();
+        await panel.updateComplete;
+        expect(panel.renderRoot.querySelector(".tabstrip-tab")).toBeNull();
+        expect(panel.renderRoot.querySelector(".tp-error")).toBeNull();
+      }
+      if (reconnect) {
+        expect(panel.terminalPanelOpen).toBe(false);
+        panel.client = null;
+        panel.available = false;
+        await panel.updateComplete;
+        panel.client = client;
+        panel.available = true;
+        await panel.updateComplete;
+      }
+      if (outcome === "resolve") {
+        pending.resolve(response("pending-session"));
+      } else {
+        pending.reject(new Error("terminal request failed"));
+      }
+      await Promise.all(queueCalls.mock.results.map((result) => result.value));
+      await waitForFast(() =>
+        expect(
+          panel.terminalPanelOpen
+            ? panel.renderRoot.querySelector<HTMLButtonElement>(".tabstrip-new")?.disabled
+            : false,
+        ).toBe(false),
+      );
+      expect(requests.filter((request) => request.method === targetMethod)).toHaveLength(1);
+      expect(panel.renderRoot.querySelector(".tabstrip-tab")).toBeNull();
+      expect(panel.terminalPanelOpen).toBe(page);
+      if (cancelled) {
+        expect(panel.renderRoot.querySelector(".tp-error")).toBeNull();
+      } else {
+        expect(panel.renderRoot.querySelector(".tp-error")?.textContent).toContain(
+          "terminal request failed",
+        );
+      }
+      expect(requests.filter((request) => request.method === "terminal.close")).toEqual(
+        outcome === "resolve"
+          ? [{ method: "terminal.close", params: { sessionId: "pending-session" } }]
+          : [],
+      );
+    },
+  );
+
+  it.each([
+    { transition: "queued attach", healthy: true },
+    { transition: "queued attach", healthy: false },
+    { transition: "reconnect", healthy: true },
+  ] as const)(
+    "preserves other work after a pending tab closes before $transition (healthy sibling: $healthy)",
+    async ({ transition, healthy }) => {
+      createGhosttyTerminalMock.mockImplementation(async () => createTerminalController());
+      const healthyController = createTerminalController();
+      createGhosttyTerminalMock.mockResolvedValueOnce(healthyController);
+      const pending = createDeferred<ReturnType<typeof terminalOpenResult>>();
+      releaseResponses.push(() => pending.resolve(terminalOpenResult("cleanup-session")));
+      const requests: Array<{ method: string; params: unknown }> = [];
+      const pendingOpenIndex = healthy ? 2 : 1;
+      let openCount = 0;
+      const client: TerminalGatewayClient = {
+        forceReconnect: () => {},
+        request: <T>(method: string, params?: unknown) => {
+          requests.push({ method, params });
+          if (method === "terminal.open") {
+            openCount += 1;
+            return (
+              openCount === pendingOpenIndex
+                ? pending.promise
+                : Promise.resolve(terminalOpenResult(openCount === 1 ? "healthy" : "replayed"))
+            ) as Promise<T>;
+          }
+          if (method === "terminal.list") {
+            return Promise.resolve({
+              sessions: [{ ...terminalOpenResult("healthy"), attached: false, createdAtMs: 1 }],
+            }) as Promise<T>;
+          }
+          if (method === "terminal.attach") {
+            const { sessionId } = params as { sessionId: string };
+            return Promise.resolve({
+              ...terminalOpenResult(sessionId),
+              buffer: "ready",
+              seq: 5,
+            }) as Promise<T>;
+          }
+          return Promise.resolve({}) as Promise<T>;
+        },
+        addEventListener: () => () => {},
+      };
+      const panel = mountTerminalPanel(client);
+      panel.toggle();
+      if (healthy) {
+        await waitForFast(() =>
+          expect(panel.renderRoot.querySelector<HTMLButtonElement>(".tabstrip-new")?.disabled).toBe(
+            false,
+          ),
+        );
+        panel.renderRoot.querySelector<HTMLButtonElement>(".tabstrip-new")!.click();
+      }
+      await waitForFast(() => expect(openCount).toBe(pendingOpenIndex));
+      if (transition === "queued attach") {
+        window.dispatchEvent(
+          new CustomEvent("openclaw:terminal-toggle", {
+            detail: { open: true, terminalSessionId: "queued-session" },
+          }),
+        );
+        expect(requests.filter((request) => request.method === "terminal.attach")).toHaveLength(0);
+      }
+      panel.renderRoot
+        .querySelector<HTMLButtonElement>(".is-connecting + .tabstrip-tab__close")!
+        .click();
+      await panel.updateComplete;
+      expect(panel.terminalPanelOpen).toBe(true);
+      if (transition === "reconnect") {
+        panel.client = null;
+        panel.available = false;
+        await panel.updateComplete;
+        await waitForFast(() => expect(healthyController.dispose).toHaveBeenCalledOnce());
+        panel.client = client;
+        panel.available = true;
+        await panel.updateComplete;
+      }
+      pending.resolve(terminalOpenResult("cancelled-session"));
+      await waitForFast(() => {
+        expect(panel.renderRoot.querySelector<HTMLButtonElement>(".tabstrip-new")?.disabled).toBe(
+          false,
+        );
+        expect(
+          openCount > pendingOpenIndex ||
+            requests.filter((request) => request.method === "terminal.attach").length === 1,
+        ).toBe(true);
+      });
+      expect(openCount).toBe(pendingOpenIndex);
+      expect(requests.filter((request) => request.method === "terminal.attach")).toEqual([
+        {
+          method: "terminal.attach",
+          params: { sessionId: transition === "reconnect" ? "healthy" : "queued-session" },
+        },
+      ]);
+      expect(panel.renderRoot.querySelector(".tp-error")).toBeNull();
+      expect(JSON.parse(sessionStorage.getItem("openclaw.terminal.sessions.v1") ?? "[]")).toEqual(
+        transition === "reconnect"
+          ? ["healthy"]
+          : healthy
+            ? ["healthy", "queued-session"]
+            : ["queued-session"],
+      );
+      expect(requests.filter((request) => request.method === "terminal.close")).toEqual([
+        { method: "terminal.close", params: { sessionId: "cancelled-session" } },
+      ]);
+    },
+  );
+});

--- a/ui/src/components/terminal/terminal-panel-restore.test.ts
+++ b/ui/src/components/terminal/terminal-panel-restore.test.ts
@@ -14,6 +14,7 @@ import {
   type CreateGhosttyTerminalMock,
 } from "./terminal-panel.test-support.ts";
 import type { OpenClawTerminalPanel } from "./terminal-panel.ts";
+import { TerminalIntentQueue } from "./terminal-pending-actions.ts";
 import type { TerminalTaskQueue } from "./terminal-task-queue.ts";
 
 vi.mock("../../app/sw-refresh.runtime.ts", () => ({
@@ -84,16 +85,20 @@ function createGateway(sessionIds = ["session-a", "session-b"]) {
   };
 }
 
-function mountPanel(client: TerminalGatewayClient) {
+function mountPanel(
+  client: TerminalGatewayClient,
+  options: { page?: boolean; open?: boolean } = {},
+) {
   const panel = document.createElement(PANEL_TAG) as OpenClawTerminalPanel;
   panel.client = client;
   panel.available = true;
+  panel.page = panel.fullscreen = panel.embedded = options.page === true;
   const sessions = (panel as unknown as { terminalSessions: TerminalPanelSessionController })
     .terminalSessions;
   const mountedPanel = { panel, sessions };
   mounted.push(mountedPanel);
   document.body.append(panel);
-  if (!panel.terminalPanelOpen) {
+  if (!panel.terminalPanelOpen && options.open !== false) {
     panel.toggle();
   }
   return mountedPanel;
@@ -237,6 +242,188 @@ describe("terminal persisted restore", () => {
       });
       expect(sessions.tabs.map((tab) => tab.gatewaySessionId)).toEqual([remaining]);
       expect(savedIds()).toEqual([remaining]);
+    },
+  );
+
+  it.each(
+    (["resolve", "reject"] as const).flatMap((outcome) =>
+      (["dock", "page"] as const).flatMap((surface) => [
+        { outcome, surface, keepSibling: false },
+        { outcome, surface, keepSibling: true },
+      ]),
+    ),
+  )(
+    "finishes the cancelled restore on $surface after $outcome (keep sibling: $keepSibling)",
+    async ({ outcome, surface, keepSibling }) => {
+      const queueCalls = vi.spyOn(TerminalIntentQueue.prototype, "queue");
+      const page = surface === "page";
+      const storageKey = page ? `${STORAGE_KEY}:page:null` : STORAGE_KEY;
+      const sessionIds = keepSibling ? ["session-a", "session-b"] : ["session-a"];
+      sessionStorage.setItem(storageKey, JSON.stringify(sessionIds));
+      const gateway = createGateway(sessionIds);
+      const { panel } = mountPanel(gateway.client, { page });
+      const first = await waitForAttach(gateway, 0);
+      panel.renderRoot.querySelector<HTMLButtonElement>(".tabstrip-tab__close")!.click();
+      await panel.updateComplete;
+      expect(panel.terminalPanelOpen).toBe(page || keepSibling);
+      expect(JSON.parse(sessionStorage.getItem(storageKey) ?? "[]")).toEqual(
+        keepSibling ? ["session-b"] : [],
+      );
+      if (outcome === "resolve") {
+        first.resolve(attachResult(first.sessionId));
+      } else {
+        first.reject(new Error("closed restore request failed"));
+      }
+      if (keepSibling) {
+        const second = await waitForAttach(gateway, 1);
+        second.resolve(attachResult(second.sessionId));
+      }
+      await Promise.all(queueCalls.mock.results.map((result) => result.value));
+      await waitForFast(() =>
+        expect(
+          panel.terminalPanelOpen
+            ? panel.renderRoot.querySelector<HTMLButtonElement>(".tabstrip-new")?.disabled
+            : false,
+        ).toBe(false),
+      );
+      expect(panel.terminalPanelOpen).toBe(page || keepSibling);
+      expect(gateway.requests.filter((request) => request.method === "terminal.open")).toEqual([]);
+      expect(gateway.attaches.map((request) => request.sessionId)).toEqual(sessionIds);
+      expect(panel.renderRoot.querySelectorAll(".tabstrip-tab")).toHaveLength(keepSibling ? 1 : 0);
+      expect(panel.renderRoot.querySelector(".tp-error")).toBeNull();
+      expect(JSON.parse(sessionStorage.getItem(storageKey) ?? "[]")).toEqual(
+        keepSibling ? ["session-b"] : [],
+      );
+      expect(gateway.requests.filter((request) => request.method === "terminal.close")).toEqual(
+        outcome === "resolve"
+          ? [{ method: "terminal.close", params: { sessionId: "session-a" } }]
+          : [],
+      );
+    },
+  );
+
+  it.each(
+    (["reconnect", "remount"] as const).flatMap((transition) =>
+      (["resolve", "reject"] as const).map((outcome) => ({ transition, outcome })),
+    ),
+  )(
+    "does not replace the cancelled dock restore across $transition before $outcome",
+    async ({ transition, outcome }) => {
+      const queueCalls = vi.spyOn(TerminalIntentQueue.prototype, "queue");
+      sessionStorage.setItem(STORAGE_KEY, JSON.stringify(["session-a"]));
+      const gateway = createGateway(["session-a"]);
+      let current = mountPanel(gateway.client);
+      const first = await waitForAttach(gateway, 0);
+      current.panel.renderRoot.querySelector<HTMLButtonElement>(".tabstrip-tab__close")!.click();
+      await current.panel.updateComplete;
+      expect(savedIds()).toEqual([]);
+      if (transition === "remount") {
+        current.panel.remove();
+        current = mountPanel(gateway.client, { open: false });
+      } else {
+        current.panel.client = null;
+        current.panel.available = false;
+        await current.panel.updateComplete;
+        current.panel.client = gateway.client;
+        current.panel.available = true;
+      }
+      await current.panel.updateComplete;
+      if (outcome === "resolve") {
+        first.resolve(attachResult(first.sessionId));
+      } else {
+        first.reject(new Error("cancelled old restore failed"));
+      }
+      await Promise.all(queueCalls.mock.results.map((result) => result.value));
+      await waitForFast(() =>
+        expect(
+          current.panel.terminalPanelOpen
+            ? current.panel.renderRoot.querySelector<HTMLButtonElement>(".tabstrip-new")?.disabled
+            : false,
+        ).toBe(false),
+      );
+      expect(current.panel.terminalPanelOpen).toBe(false);
+      expect(current.panel.renderRoot.querySelector(".tp-error")).toBeNull();
+      expect(gateway.requests.filter(({ method }) => method === "terminal.open")).toEqual([]);
+      expect(gateway.requests.filter(({ method }) => method === "terminal.close")).toEqual(
+        outcome === "resolve"
+          ? [{ method: "terminal.close", params: { sessionId: "session-a" } }]
+          : [],
+      );
+    },
+  );
+
+  it("opens a persisted catalog request after its restored tab is cancelled", async () => {
+    const catalog = { catalogId: "catalog-a", hostId: "host-a", threadId: "thread-a" };
+    sessionStorage.setItem(STORAGE_KEY, JSON.stringify(["session-a"]));
+    sessionStorage.setItem(
+      "openclaw.terminal.actions.v1",
+      JSON.stringify([{ kind: "catalog", agentId: "agent-a", catalog }]),
+    );
+    const gateway = createGateway(["session-a"]);
+    const { panel } = mountPanel(gateway.client);
+    const first = await waitForAttach(gateway, 0);
+    panel.renderRoot.querySelector<HTMLButtonElement>(".tabstrip-tab__close")!.click();
+    first.resolve(attachResult(first.sessionId));
+    await waitForFast(() =>
+      expect(gateway.requests.filter(({ method }) => method === "terminal.open")).toHaveLength(1),
+    );
+    gateway.emit({
+      event: "terminal.data",
+      payload: { sessionId: "replacement", seq: 5, data: "ready" },
+    });
+    await waitForFast(() =>
+      expect(panel.renderRoot.querySelector<HTMLButtonElement>(".tabstrip-new")?.disabled).toBe(
+        false,
+      ),
+    );
+    expect(gateway.requests).toContainEqual({
+      method: "terminal.open",
+      params: { agentId: "agent-a", catalog, cols: 100, rows: 30 },
+    });
+    expect(panel.terminalPanelOpen).toBe(true);
+    expect(panel.renderRoot.querySelector(".tp-error")).toBeNull();
+    expect(savedIds()).toEqual(["replacement"]);
+  });
+
+  it.each(["resolve", "reject"] as const)(
+    "keeps a queued attach visible after a cancelled restore and follower %s",
+    async (outcome) => {
+      sessionStorage.setItem(STORAGE_KEY, JSON.stringify(["session-a"]));
+      const gateway = createGateway();
+      const { panel } = mountPanel(gateway.client);
+      const first = await waitForAttach(gateway, 0);
+      window.dispatchEvent(
+        new CustomEvent("openclaw:terminal-toggle", {
+          detail: { open: true, terminalSessionId: "session-b" },
+        }),
+      );
+      panel.renderRoot.querySelector<HTMLButtonElement>(".tabstrip-tab__close")!.click();
+      first.resolve(attachResult(first.sessionId));
+      const follower = await waitForAttach(gateway, 1);
+      if (outcome === "resolve") {
+        follower.resolve(attachResult(follower.sessionId));
+      } else {
+        follower.reject(new Error("queued attach failed"));
+      }
+      await waitForFast(() =>
+        expect(panel.renderRoot.querySelector<HTMLButtonElement>(".tabstrip-new")?.disabled).toBe(
+          false,
+        ),
+      );
+      expect(panel.terminalPanelOpen).toBe(true);
+      expect(gateway.attaches.map((request) => request.sessionId)).toEqual([
+        "session-a",
+        "session-b",
+      ]);
+      expect(gateway.requests.filter((request) => request.method === "terminal.open")).toEqual([]);
+      expect(savedIds()).toEqual(outcome === "resolve" ? ["session-b"] : []);
+      if (outcome === "resolve") {
+        expect(panel.renderRoot.querySelector(".tp-error")).toBeNull();
+      } else {
+        expect(panel.renderRoot.querySelector(".tp-error")?.textContent).toContain(
+          "queued attach failed",
+        );
+      }
     },
   );
 

--- a/ui/src/components/terminal/terminal-panel-session-controller.ts
+++ b/ui/src/components/terminal/terminal-panel-session-controller.ts
@@ -36,6 +36,8 @@ import { TerminalTaskQueue } from "./terminal-task-queue.ts";
 type TerminalRestoreBatch = {
   operation: TerminalOperation;
   pending: Map<string, TerminalPanelSessionTab | undefined>;
+  userClosedTab: boolean;
+  cancelIntent?: () => void;
 };
 
 /** Owns gateway PTY sessions and the Ghostty controllers bound to them. */
@@ -66,13 +68,27 @@ export class TerminalPanelSessionController implements TerminalPanelSessionContr
       bootQueue: this.bootQueue,
       currentGeneration: () => this.lifecycleGeneration,
       canRun: () => this.terminalActionsCanRun(),
-      attach: (sessionId, agentOwned) => this.attachSessionNow(sessionId, agentOwned),
-      open: (catalog, agentId) => this.openSessionNow(catalog, agentId),
-      reattach: () => this.reattachPersistedSessions(),
-      ensureInitial: (agentId) => this.ensureInitialSession(agentId),
+      attach: (sessionId, agentOwned, cancel) =>
+        this.attachSessionNow(sessionId, agentOwned, cancel),
+      open: (catalog, agentId, cancel) => this.openSessionNow(catalog, agentId, cancel),
+      reattach: (cancel) => this.reattachPersistedSessions(cancel),
+      cancelledRestoreCompleted: () => {
+        if (!this.error) {
+          this.closeEmptyPanel();
+        }
+      },
+      ensureInitial: async (agentId, cancel) => {
+        if (this.tabs.length === 0) {
+          const target = this.host.page ? this.host.routeTarget : null;
+          return target && "sessionId" in target
+            ? this.attachSessionNow(target.sessionId, false, cancel)
+            : this.openSessionNow(target?.catalog, agentId, cancel);
+        }
+        return this.terminalActionsCanRun();
+      },
       hasTabs: () => this.tabs.length > 0,
       requestUpdate: () => this.host.requestUpdate(),
-      setBooting: (booting) => this.updateControllerState("booting", booting),
+      setBooting: (booting) => this.updateControllerState({ booting }),
       timeoutMs: () => this.host.catalogReadyTimeoutMs,
       showTimeout: () => {
         refreshError = this.setError(t("terminal.refreshRequired"));
@@ -89,7 +105,7 @@ export class TerminalPanelSessionController implements TerminalPanelSessionContr
       isCurrent: (tab) => this.tabs.includes(tab),
       onReady: (tab) => {
         delete tab.pendingOpen;
-        this.updateControllerState("tabs", [...this.tabs]);
+        this.updateControllerState({ tabs: [...this.tabs] });
         this.persistSessions();
       },
       onTimeout: (tab) => {
@@ -101,16 +117,13 @@ export class TerminalPanelSessionController implements TerminalPanelSessionContr
     });
   }
 
-  private updateControllerState<Key extends keyof TerminalPanelSessionControllerState>(
-    key: Key,
-    value: TerminalPanelSessionControllerState[Key],
-  ): void {
-    Object.assign(this, { [key]: value });
+  private updateControllerState(state: Partial<TerminalPanelSessionControllerState>): void {
+    Object.assign(this, state);
     this.host.requestUpdate();
   }
 
   setError(text: string | null, retryAction?: TerminalPanelOpenAction): TerminalPanelError | null {
-    this.updateControllerState("error", text ? { text, retryAction } : null);
+    this.updateControllerState({ error: text ? { text, retryAction } : null });
     return this.error;
   }
 
@@ -136,7 +149,7 @@ export class TerminalPanelSessionController implements TerminalPanelSessionContr
     this.intentQueue.bindHost(this.intentHost);
     // Read after binding: the queue reloads its persisted record for the first
     // panel in a document, so an earlier read would miss a carried-over intent.
-    this.updateControllerState("booting", this.intentQueue.hasActions);
+    this.updateControllerState({ booting: this.intentQueue.hasActions });
   }
 
   disconnectHost(): void {
@@ -220,9 +233,8 @@ export class TerminalPanelSessionController implements TerminalPanelSessionContr
       }, release);
   }
 
-  async restoreSessions(): Promise<void> {
-    const agentId = this.host.agentId?.trim() || null;
-    await this.intentQueue.queue({ kind: "restore", agentId });
+  restoreSessions(): Promise<void> {
+    return this.intentQueue.queue({ kind: "restore", agentId: this.host.agentId?.trim() || null });
   }
 
   private terminalActionsCanRun(): boolean {
@@ -245,28 +257,29 @@ export class TerminalPanelSessionController implements TerminalPanelSessionContr
     return this.intentQueue.waitingForRefresh;
   }
 
-  private async reattachPersistedSessions(): Promise<void> {
+  private async reattachPersistedSessions(cancelIntent?: () => void): Promise<boolean> {
     const operation = this.captureTerminalOperation();
     if (!operation || this.tabs.length > 0) {
-      return;
+      return false;
     }
     const persisted = loadPersistedTerminalSessionIds(this.storageScope);
     if (persisted.length === 0) {
-      return;
+      return false;
     }
     // Readiness can persist an adopted tab while later attaches are still pending.
     // Retain those ids until this generation resolves or deliberately removes them.
     const restore: TerminalRestoreBatch = {
       operation,
       pending: new Map(persisted.map((sessionId) => [sessionId, undefined])),
+      userClosedTab: false,
+      cancelIntent,
     };
     this.pendingRestore = restore;
-    this.updateControllerState("booting", true);
+    this.updateControllerState({ booting: true });
     try {
-      const connection = this.connectionFor(operation);
-      const listed = await connection.list();
+      const listed = await this.connectionFor(operation).list();
       if (!this.isTerminalOperationCurrent(operation, restore)) {
-        return;
+        return false;
       }
       const known = new Map(listed.map((session) => [session.sessionId, session]));
       for (const sessionId of restore.pending.keys()) {
@@ -282,7 +295,7 @@ export class TerminalPanelSessionController implements TerminalPanelSessionContr
           );
         }
         if (!this.isTerminalOperationCurrent(operation, restore)) {
-          return;
+          return false;
         }
         restore.pending.delete(sessionId);
         this.persistSessions();
@@ -293,25 +306,16 @@ export class TerminalPanelSessionController implements TerminalPanelSessionContr
     } finally {
       if (this.isTerminalOperationCurrent(operation, restore)) {
         this.pendingRestore = null;
-        this.updateControllerState("booting", false);
+        this.updateControllerState({ booting: false });
         // Completed failures keep the existing pruning policy, including list failure.
         this.persistSessions();
       }
     }
+    return this.isTerminalOperationCurrent(operation) && restore.userClosedTab;
   }
 
   private get storageScope(): string {
     return this.host.page ? `:page:${JSON.stringify(this.host.routeTarget)}` : "";
-  }
-
-  private async ensureInitialSession(agentId: string | null): Promise<boolean> {
-    if (this.tabs.length === 0) {
-      const target = this.host.page ? this.host.routeTarget : null;
-      return target && "sessionId" in target
-        ? this.attachSessionNow(target.sessionId, false)
-        : this.openSessionNow(target && "catalog" in target ? target.catalog : undefined, agentId);
-    }
-    return this.terminalActionsCanRun();
   }
 
   async listSessions(): Promise<TerminalSessionInfo[] | null> {
@@ -319,48 +323,40 @@ export class TerminalPanelSessionController implements TerminalPanelSessionContr
     if (!operation) {
       return null;
     }
-    try {
-      const sessions = await this.connectionFor(operation).list();
-      return this.isTerminalOperationCurrent(operation) ? sessions : null;
-    } catch {
-      return this.isTerminalOperationCurrent(operation) ? [] : null;
-    }
+    const sessions = await this.connectionFor(operation)
+      .list()
+      .catch(() => []);
+    return this.isTerminalOperationCurrent(operation) ? sessions : null;
   }
 
   async attachSessionById(sessionId: string, agentOwned = false): Promise<void> {
     await this.intentQueue.queue({ kind: "attach", sessionId, agentOwned });
   }
 
-  private async attachSessionNow(sessionId: string, agentOwned: boolean): Promise<boolean> {
+  private async attachSessionNow(
+    sessionId: string,
+    agentOwned: boolean,
+    cancelIntent: () => void,
+  ): Promise<boolean> {
     const existing = this.tabs.find((tab) => tab.gatewaySessionId === sessionId);
     if (existing) {
       this.switchTo(existing.id);
       return true;
     }
-    const operation = this.captureTerminalOperation();
+    const operation = this.captureTerminalOperation(cancelIntent);
     if (!operation) {
       return false;
     }
-    this.updateControllerState("booting", true);
-    this.setError(null);
+    this.updateControllerState({ booting: true, error: null });
     try {
       const attached = await this.attachSession(sessionId, operation, agentOwned);
-      if (attached) {
-        if (this.activeId) {
-          this.switchTo(this.activeId);
-        }
-        return true;
+      if (attached && this.activeId) {
+        this.switchTo(this.activeId);
       }
-      if (!this.isTerminalOperationCurrent(operation)) {
-        return false;
-      }
-      if (!this.error) {
-        this.setError(t("terminal.attachFailed"));
-      }
-      return true;
+      return attached || this.isTerminalOperationCurrent(operation);
     } finally {
       if (this.isTerminalOperationCurrent(operation)) {
-        this.updateControllerState("booting", false);
+        this.updateControllerState({ booting: false });
       }
     }
   }
@@ -390,8 +386,8 @@ export class TerminalPanelSessionController implements TerminalPanelSessionContr
     // Replay and close can precede adoption; associate the placeholder privately,
     // without making an unadopted gatewaySessionId usable by input or resize.
     options.restore?.batch.pending.set(options.restore.sessionId, boot.tab);
-    this.updateControllerState("tabs", [...this.tabs, boot.tab]);
-    this.updateControllerState("activeId", boot.tab.id);
+    boot.tab.cancelPendingIntent = operation.cancelIntent;
+    this.updateControllerState({ tabs: [...this.tabs, boot.tab], activeId: boot.tab.id });
     return boot;
   }
 
@@ -402,6 +398,7 @@ export class TerminalPanelSessionController implements TerminalPanelSessionContr
     agentOwned = false,
   ): void {
     this.retireRestoredTab(tab);
+    delete tab.cancelPendingIntent;
     tab.gatewaySessionId = result.sessionId;
     tab.shellName = result.title ?? shellBasename(result.shell);
     tab.shell = result.shell;
@@ -425,19 +422,17 @@ export class TerminalPanelSessionController implements TerminalPanelSessionContr
         this.readiness.markReady(tab);
       }
     }
-    this.updateControllerState("tabs", [...this.tabs]);
+    this.updateControllerState({ tabs: [...this.tabs] });
     this.persistSessions();
   }
 
   private removeTab(tab: TerminalPanelSessionTab): void {
     this.disposeTab(tab);
-    this.updateControllerState(
-      "tabs",
-      this.tabs.filter((entry) => entry.id !== tab.id),
-    );
-    if (this.activeId === tab.id) {
-      this.updateControllerState("activeId", this.tabs.at(-1)?.id ?? null);
-    }
+    const tabs = this.tabs.filter((entry) => entry.id !== tab.id);
+    this.updateControllerState({
+      tabs,
+      activeId: this.activeId === tab.id ? (tabs.at(-1)?.id ?? null) : this.activeId,
+    });
   }
 
   openSession(): Promise<void> {
@@ -447,13 +442,13 @@ export class TerminalPanelSessionController implements TerminalPanelSessionContr
   private async openSessionNow(
     catalog: TerminalPanelCatalogReference | undefined,
     agentId: string | null,
+    cancelIntent: () => void,
   ): Promise<boolean> {
-    const operation = this.captureTerminalOperation();
+    const operation = this.captureTerminalOperation(cancelIntent);
     if (!operation) {
       return false;
     }
-    this.updateControllerState("booting", true);
-    this.setError(null);
+    this.updateControllerState({ booting: true, error: null });
     const action: TerminalPanelOpenAction = catalog
       ? { kind: "catalog", agentId, catalog }
       : { kind: "open", agentId };
@@ -476,6 +471,7 @@ export class TerminalPanelSessionController implements TerminalPanelSessionContr
         boot.sink,
       );
       if (!this.isTerminalOperationCurrent(operation) || boot.tab.cancelled) {
+        const cancelledByUser = boot.tab.cancelled === "close";
         // The tab's close button was clicked while the open RPC was in flight.
         // The server session is live and its sink registered; close it now or
         // it survives invisibly (eating the session cap) until disconnect.
@@ -484,7 +480,7 @@ export class TerminalPanelSessionController implements TerminalPanelSessionContr
           boot.tab.cancelled = "lifecycle";
           this.removeTab(boot.tab);
         }
-        return false;
+        return cancelledByUser;
       }
       this.adoptSession(boot.tab, result, ownerSessionKey !== undefined);
       boot.tab.controller.terminal.focus();
@@ -499,17 +495,19 @@ export class TerminalPanelSessionController implements TerminalPanelSessionContr
       if (!this.isTerminalOperationCurrent(operation)) {
         return false;
       }
-      this.setError(
-        terminalOpenErrorText(error),
-        error instanceof TerminalOpenTimeoutError ||
-          error instanceof TerminalOpenUnusableSessionError
-          ? action
-          : undefined,
-      );
+      if (createdTab?.cancelled !== "close") {
+        this.setError(
+          terminalOpenErrorText(error),
+          error instanceof TerminalOpenTimeoutError ||
+            error instanceof TerminalOpenUnusableSessionError
+            ? action
+            : undefined,
+        );
+      }
       return true;
     } finally {
       if (this.isTerminalOperationCurrent(operation)) {
-        this.updateControllerState("booting", false);
+        this.updateControllerState({ booting: false });
       }
     }
   }
@@ -561,14 +559,14 @@ export class TerminalPanelSessionController implements TerminalPanelSessionContr
       if (prepared) {
         void prepared.connection.close(prepared.result.sessionId);
       }
-      if (!this.isTerminalOperationCurrent(operation, restore)) {
+      if (!this.isTerminalOperationCurrent(operation, restore, createdTab)) {
         return false;
       }
       const sessionGone =
         restore && createdConnection
           ? await this.confirmRestoredSessionGone(createdConnection, sessionId, restore)
           : false;
-      if (!this.isTerminalOperationCurrent(operation, restore)) {
+      if (!this.isTerminalOperationCurrent(operation, restore, createdTab)) {
         return false;
       }
       if (createdTab && !createdTab.gatewaySessionId && this.tabs.includes(createdTab)) {
@@ -590,17 +588,14 @@ export class TerminalPanelSessionController implements TerminalPanelSessionContr
     sessionId: string,
     restore: TerminalRestoreBatch,
   ): Promise<boolean> {
-    try {
-      const sessions = await connection.list();
-      return (
-        this.isTerminalOperationCurrent(restore.operation, restore) &&
-        !sessions.some((session) => session.sessionId === sessionId)
-      );
-    } catch {
-      // A failed confirmation cannot turn a transport or authorization error
-      // into an authoritative terminal exit.
-      return false;
-    }
+    // A failed confirmation cannot turn a transport or authorization error
+    // into an authoritative terminal exit.
+    const sessions = await connection.list().catch(() => null);
+    return (
+      sessions !== null &&
+      this.isTerminalOperationCurrent(restore.operation, restore) &&
+      !sessions.some((session) => session.sessionId === sessionId)
+    );
   }
 
   /** Keeps a dead persisted session visible without replaying bytes from a missing PTY. */
@@ -646,7 +641,7 @@ export class TerminalPanelSessionController implements TerminalPanelSessionContr
     }
     // The connection drops its own sink on exit delivery, so no release() here —
     // the session id may not be recorded yet when an early exit is replayed.
-    this.updateControllerState("tabs", [...this.tabs]);
+    this.updateControllerState({ tabs: [...this.tabs] });
     this.persistSessions();
   }
 
@@ -655,27 +650,29 @@ export class TerminalPanelSessionController implements TerminalPanelSessionContr
     if (!tab) {
       return;
     }
+    tab.cancelled = "close";
+    tab.cancelPendingIntent?.();
     this.retireRestoredTab(tab);
     this.host.terminalPanelUploadController.cancelForTab(tab);
     if (tab.gatewaySessionId && tab.status !== "exited") {
       void this.connection?.close(tab.gatewaySessionId);
-    } else if (!tab.gatewaySessionId && tab.status !== "exited") {
-      // Open still in flight: no session id to close yet. Flag it so the open
-      // continuation closes the server session as soon as the RPC resolves.
-      tab.cancelled = "close";
     }
     this.removeTab(tab);
     this.persistSessions();
+    this.closeEmptyPanel();
+  }
+
+  private closeEmptyPanel(): void {
     // Fullscreen documents (mobile WebViews) have no toggle to reopen a closed
     // panel, so closing the last tab keeps the panel with an empty tab strip
     // (the "+" button stays reachable) instead of leaving a dead blank page.
-    if (this.tabs.length === 0 && !this.host.fullscreen) {
+    if (this.tabs.length === 0 && !this.host.fullscreen && !this.intentQueue.hasActions) {
       this.host.closeTerminalPanel();
     }
   }
 
   switchTo(tabId: string): void {
-    this.updateControllerState("activeId", tabId);
+    this.updateControllerState({ activeId: tabId });
     const tab = this.tabs.find((entry) => entry.id === tabId);
     void focusTerminalSession(tab, this.host.updateComplete);
   }
@@ -685,7 +682,11 @@ export class TerminalPanelSessionController implements TerminalPanelSessionContr
     if (restore && this.isTerminalOperationCurrent(restore.operation, restore)) {
       for (const [sessionId, pendingTab] of restore.pending) {
         if (pendingTab === tab) {
+          restore.userClosedTab ||= tab.cancelled === "close";
           restore.pending.delete(sessionId);
+          if (tab.cancelled === "close" && restore.pending.size === 0) {
+            restore.cancelIntent?.();
+          }
           break;
         }
       }
@@ -708,7 +709,7 @@ export class TerminalPanelSessionController implements TerminalPanelSessionContr
     persistTerminalSessionIds([...ids], this.storageScope);
   }
 
-  private captureTerminalOperation(): TerminalOperation | null {
+  private captureTerminalOperation(cancelIntent?: () => void): TerminalOperation | null {
     const client = this.host.client;
     if (
       this.intentQueue.fenced ||
@@ -723,12 +724,14 @@ export class TerminalPanelSessionController implements TerminalPanelSessionContr
       generation: this.lifecycleGeneration,
       client,
       signal: this.lifecycleAbortController.signal,
+      cancelIntent,
     };
   }
 
   private isTerminalOperationCurrent(
     operation: TerminalOperation,
     restore?: TerminalRestoreBatch,
+    tab?: TerminalPanelSessionTab,
   ): boolean {
     return (
       this.host.isConnected &&
@@ -737,6 +740,7 @@ export class TerminalPanelSessionController implements TerminalPanelSessionContr
       this.activeClient === operation.client &&
       this.lifecycleGeneration === operation.generation &&
       (!restore || this.pendingRestore === restore) &&
+      tab?.cancelled !== "close" &&
       !operation.signal.aborted
     );
   }
@@ -764,7 +768,7 @@ export class TerminalPanelSessionController implements TerminalPanelSessionContr
     if (this.error?.retryAction) {
       this.setError(this.error.text);
     }
-    this.updateControllerState("booting", false);
+    this.updateControllerState({ booting: false });
     this.host.terminalPanelUploadController.dispose();
     for (const tab of this.tabs) {
       // No terminal.close here: this teardown runs for disconnects,
@@ -778,8 +782,7 @@ export class TerminalPanelSessionController implements TerminalPanelSessionContr
       tab.cancelled = "lifecycle";
       this.disposeTab(tab);
     }
-    this.updateControllerState("tabs", []);
-    this.updateControllerState("activeId", null);
+    this.updateControllerState({ tabs: [], activeId: null });
     this.host.resetTerminalSessionPicker();
     // Drop the gateway subscription with the tabs so the listener never outlives
     // the connection (disconnect/disable/element-removal all route through here).

--- a/ui/src/components/terminal/terminal-panel-session-types.ts
+++ b/ui/src/components/terminal/terminal-panel-session-types.ts
@@ -20,6 +20,8 @@ export type TerminalPanelSessionTab = TerminalPanelTab &
     shell: string;
     host: HTMLDivElement;
     pendingOpen?: TerminalPanelOpenAction;
+    /** Retires only the queued intent that booted this placeholder. */
+    cancelPendingIntent?: () => void;
     /** Why an in-flight open/attach must not adopt this disposed terminal. */
     cancelled?: "close" | "lifecycle";
   };
@@ -33,6 +35,7 @@ export type TerminalOperation = {
   generation: number;
   client: TerminalGatewayClient;
   signal: AbortSignal;
+  cancelIntent?: () => void;
 };
 
 export type TerminalPanelCatalogReference = {

--- a/ui/src/components/terminal/terminal-pending-actions.ts
+++ b/ui/src/components/terminal/terminal-pending-actions.ts
@@ -13,13 +13,15 @@ export type TerminalIntentHost = {
   bootQueue: Pick<TerminalTaskQueue, "enqueue">;
   currentGeneration: () => number;
   canRun: () => boolean;
-  attach: (sessionId: string, agentOwned: boolean) => Promise<boolean>;
+  attach: (sessionId: string, agentOwned: boolean, cancelIntent: () => void) => Promise<boolean>;
   open: (
     catalog: TerminalPanelCatalogReference | undefined,
     agentId: string | null,
+    cancelIntent: () => void,
   ) => Promise<boolean>;
-  reattach: () => Promise<void>;
-  ensureInitial: (agentId: string | null) => Promise<boolean>;
+  reattach: (cancelIntent?: () => void) => Promise<boolean>;
+  cancelledRestoreCompleted: () => void;
+  ensureInitial: (agentId: string | null, cancelIntent: () => void) => Promise<boolean>;
   hasTabs: () => boolean;
   requestUpdate: () => void;
   setBooting: (booting: boolean) => void;
@@ -200,14 +202,13 @@ export class TerminalIntentQueue {
         if (!action || !isCurrent() || !this.canRun(host)) {
           return;
         }
-        const completed = await this.execute(host, action);
+        const completed = await this.execute(host, action, () => this.retireAction(action));
         if (!completed || !isCurrent()) {
           return;
         }
-        const index = this.actions.indexOf(action);
-        if (index !== -1) {
-          this.actions.splice(index, 1);
-          this.persist();
+        this.retireAction(action);
+        if (completed === "cancelled-restore" && this.host === host) {
+          host.cancelledRestoreCompleted();
         }
       });
     } finally {
@@ -218,6 +219,14 @@ export class TerminalIntentQueue {
       } else if (this.actions.length === 0 && current && !current.hasTabs()) {
         current.setBooting(false);
       }
+    }
+  }
+
+  private retireAction(action: TerminalPanelAction): void {
+    const index = this.actions.indexOf(action);
+    if (index !== -1) {
+      this.actions.splice(index, 1);
+      this.persist();
     }
   }
 
@@ -237,22 +246,28 @@ export class TerminalIntentQueue {
     return !this.refreshPending && host.canRun();
   }
 
-  private async execute(host: TerminalIntentHost, action: TerminalPanelAction): Promise<boolean> {
+  private async execute(
+    host: TerminalIntentHost,
+    action: TerminalPanelAction,
+    cancelIntent: () => void,
+  ): Promise<boolean | "cancelled-restore"> {
     if (action.kind === "attach") {
-      return host.attach(action.sessionId, action.agentOwned);
+      return host.attach(action.sessionId, action.agentOwned, cancelIntent);
     }
     if (action.kind === "open") {
-      return host.open(undefined, action.agentId);
+      return host.open(undefined, action.agentId, cancelIntent);
     }
-    await host.reattach();
+    const userClosedTab = await host.reattach(action.kind === "restore" ? cancelIntent : undefined);
     // A second panel mounting mid-flight must not strand this action: the host
     // that started it is still connected, so it finishes what it began.
     if (!this.canRun(host)) {
       return false;
     }
     return action.kind === "catalog"
-      ? host.open(action.catalog, action.agentId)
-      : host.ensureInitial(action.agentId);
+      ? host.open(action.catalog, action.agentId, cancelIntent)
+      : userClosedTab
+        ? "cancelled-restore"
+        : host.ensureInitial(action.agentId, cancelIntent);
   }
 
   private clearRefreshTimer(): void {


### PR DESCRIPTION
Related: #145222

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where users closed a connecting terminal tab but it reopened, or displayed a stale error, after its opening or attachment request completed. Cancelling a restored tab could also start a replacement shell or leave an empty dock open across reconnects.

## Why This Change Was Made

The existing terminal queue retires each closed placeholder's exact request. Restored tabs keep their batch owner, which cancels the generic restore when the final pending ID is explicitly closed, preserving remaining tabs, queued work, and independent catalog requests.

## User Impact

A closed connecting tab stays closed when its response arrives. The empty ordinary dock closes immediately; fullscreen terminals retain the new-tab button, and genuine failures still display their errors. Fresh initialization of an already-empty terminal page remains a separate lifecycle behavior.

## Evidence

- Reproduced the cancellation and restore races before their repairs. All 112 terminal, restore, reconnect, upload, queue, and handoff tests pass across eight files, including queued-request and catalog controls.
- Changed checks and the Control UI build pass, including typechecks, lint, and bundle limits.
- Eight Chromium cases cover deferred open, attach, and restored-session success and failure on terminal routes and the ordinary dock. They verify immediate dock retirement, request counts, late-session cleanup, and no reopened tab or stale error. These use a synthetic Gateway and launch no real PTY or provider.
- Independent P2 review completed four passes with no actionable findings.

Cancelled opening after its late successful response:

| Before | After |
| --- | --- |
| ![Closed opening starts another tab](https://github.com/user-attachments/assets/74317445-6fb0-48cd-a06a-82f3dd780543) | ![Closed opening leaves an empty, usable terminal](https://github.com/user-attachments/assets/fe1ce675-8b0c-49d3-a46c-e9dc5bd1c048) |

Cancelled attachment after its late failure:

| Before | After |
| --- | --- |
| ![Closed attachment displays a stale error](https://github.com/user-attachments/assets/0ff3ebb5-5c24-4c0c-8056-e529468dba4c) | ![Closed attachment stays closed without an error](https://github.com/user-attachments/assets/916ee411-b6d4-4fda-bac3-f9e020d656cc) |
