### PR TITLE
Attribute Codex usage to OpenClaw tasks

### DIFF
--- a/extensions/codex/src/app-server/protocol.ts
+++ b/extensions/codex/src/app-server/protocol.ts
@@ -159,6 +159,7 @@ export type CodexTurnEnvironmentParams = JsonObject & {
 };
 
 export type CodexThreadStartParams = JsonObject & {
+  threadSource?: string | null;
   input?: CodexUserInput[];
   cwd?: string;
   projectId?: string | null;
@@ -393,6 +394,7 @@ type CodexTurnInterruptParams = JsonObject & {
 
 export type CodexTurnStartParams = JsonObject & {
   threadId: string;
+  turnTrigger?: string | null;
   input: CodexUserInput[];
   /** Native 0.153.4 flattens these entries into its Responses turn-metadata object. */
   responsesapiClientMetadata?: Record<string, string> | null;

--- a/extensions/codex/src/app-server/thread-lifecycle.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.test.ts
@@ -65,6 +65,43 @@ type CodexThreadLifecycleTimingLogger = NonNullable<
 const PROGRESS_CARD_SYSTEM_PROMPT =
   "During multi-step work, keep your progress card current with the progress_card tool; the user follows it instead of reading the transcript.";
 
+describe("Codex usage attribution", () => {
+  it("labels new OpenClaw threads without rewriting resumed thread attribution", () => {
+    const params = createAttemptParams({ provider: "openai" });
+    const appServer = createAppServerOptions() as never;
+    const start = buildThreadStartParams(params, { appServer, cwd: "/repo", dynamicTools: [] });
+    const resume = buildThreadResumeParams(params, { appServer, threadId: "thread-1" });
+
+    expect(start.threadSource).toBe("openclaw");
+    expect(resume).not.toHaveProperty("threadSource");
+  });
+
+  it.each(["user", "cron", "heartbeat", "manual", "memory", "overflow"] as const)(
+    "preserves the %s run trigger on each new turn",
+    (trigger) => {
+      const params = { ...createAttemptParams({ provider: "openai" }), trigger };
+      const request = buildTurnStartParams(params, {
+        appServer: createAppServerOptions() as never,
+        threadId: "existing-thread",
+        cwd: "/repo",
+      });
+
+      expect(request.turnTrigger).toBe(trigger);
+    },
+  );
+
+  it("does not guess a human trigger when the caller supplied none", () => {
+    const params = { ...createAttemptParams({ provider: "openai" }), trigger: undefined };
+    const request = buildTurnStartParams(params, {
+      appServer: createAppServerOptions() as never,
+      threadId: "existing-thread",
+      cwd: "/repo",
+    });
+
+    expect(request).not.toHaveProperty("turnTrigger");
+  });
+});
+
 describe("Codex incognito thread persistence", () => {
   it("marks only incognito-shaped harness sessions ephemeral", () => {
     const appServer = createAppServerOptions() as never;

--- a/extensions/codex/src/app-server/thread-requests.ts
+++ b/extensions/codex/src/app-server/thread-requests.ts
@@ -247,6 +247,7 @@ export function buildThreadStartParams(
       : {}),
     personality: CODEX_NATIVE_PERSONALITY_NONE,
     serviceName: "OpenClaw",
+    threadSource: "openclaw",
     ...resolveCodexThreadEnvironmentSelection(options),
     // Codex 0.146 accepts canonical typed function and namespace specs natively.
     dynamicTools: [...options.dynamicTools],

--- a/extensions/codex/src/app-server/turn-params.ts
+++ b/extensions/codex/src/app-server/turn-params.ts
@@ -142,6 +142,7 @@ export function buildTurnStartParams(
   }
   return {
     threadId: options.threadId,
+    ...(params.trigger ? { turnTrigger: params.trigger } : {}),
     // codex-rs/app-server-protocol/src/protocol/v2/turn.rs:292-324 at 91d6f48992ad defines
     // UserInput::Skill; skills/src/selection.rs:60-92 blocks those names from duplicate text
     // selection while leaving unmatched Codex-native-only names scannable.

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md.diff
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md.diff
@@ -1,5 +1,5 @@
---- telegram-direct-codex-message-tool.md	sha256=1e84581fe19b96f31b106d75dd1d767b614574e647eccac09d43abb3bc6ed2a6
-+++ discord-group-codex-message-tool.md	sha256=0378572b5673260b4bdbbcd819c457ef0326e8b21c86c8deffee44dd303c9195
+--- telegram-direct-codex-message-tool.md	sha256=2475be00b6677cc61504cd75ba4d13b047048e8f5fec0fb684d53f542ef80179
++++ discord-group-codex-message-tool.md	sha256=17a9e3b5986e800bf68ffe2c4ec52a1c1f76d9a5117e6d73e720087aec6269e1
 @@ -1,1 +1,1 @@
 -# Telegram Direct Codex Message Tool Turn
 +# Discord Group Codex Message Tool Turn
@@ -16,47 +16,47 @@
 @@ -30,1 +30,1 @@
 -  "toolSnapshot": "codex-dynamic-tools.telegram-direct.json",
 +  "toolSnapshot": "codex-dynamic-tools.discord-group.json",
-@@ -137,1 +137,1 @@
+@@ -138,1 +138,1 @@
 -  "threadId": "thread-telegram-direct-codex-message-tool"
 +  "threadId": "thread-discord-group-codex-message-tool"
-@@ -148,1 +148,1 @@
+@@ -149,1 +149,1 @@
 -      "value": "{\"sender\":{\"id\":\"1000001\",\"name\":\"Pash\",\"username\":\"pash\"}}"
 +      "value": "{\"sender\":{\"id\":\"424242\",\"name\":\"Pash\",\"username\":\"pash\"}}"
-@@ -183,1 +183,1 @@
--  "threadId": "thread-telegram-direct-codex-message-tool"
-+  "threadId": "thread-discord-group-codex-message-tool"
-@@ -222,1 +222,1 @@
+@@ -184,1 +184,1 @@
+-  "threadId": "thread-telegram-direct-codex-message-tool",
++  "threadId": "thread-discord-group-codex-message-tool",
+@@ -224,1 +224,1 @@
 -    "dynamicToolsFrom": "codex-dynamic-tools.telegram-direct.json",
 +    "dynamicToolsFrom": "codex-dynamic-tools.discord-group.json",
-@@ -235,1 +235,1 @@
+@@ -237,1 +237,1 @@
 -    "chars": 882,
 +    "chars": 881,
-@@ -255,2 +255,2 @@
+@@ -257,2 +257,2 @@
 -    "chars": 58613,
 -    "roughTokens": 14654
 +    "chars": 59169,
 +    "roughTokens": 14793
-@@ -259,2 +259,2 @@
+@@ -261,2 +261,2 @@
 -    "chars": 2629,
 -    "roughTokens": 658
 +    "chars": 3577,
 +    "roughTokens": 895
-@@ -267,2 +267,2 @@
+@@ -269,2 +269,2 @@
 -    "chars": 26463,
 -    "roughTokens": 6616
 +    "chars": 27781,
 +    "roughTokens": 6946
-@@ -271,2 +271,2 @@
+@@ -273,2 +273,2 @@
 -    "chars": 85078,
 -    "roughTokens": 21270
 +    "chars": 86952,
 +    "roughTokens": 21738
-@@ -275,2 +275,2 @@
+@@ -277,2 +277,2 @@
 -    "chars": 793,
 -    "roughTokens": 199
 +    "chars": 1164,
 +    "roughTokens": 291
-@@ -502,4 +502,4 @@
+@@ -504,4 +504,4 @@
 -  "channel": "telegram",
 -  "provider": "telegram",
 -  "surface": "telegram",
@@ -65,24 +65,24 @@
 +  "provider": "discord",
 +  "surface": "discord",
 +  "chat_type": "group"
-@@ -510,1 +510,3 @@
+@@ -512,1 +512,3 @@
 -You are in a Telegram direct conversation. Normal final replies are private and are not automatically sent to this conversation. To post visible output here, use the message tool with action=send; the target defaults to this conversation. If no visible direct response is needed, do not call message(action=send). Your normal final answer stays private and will not be posted to the conversation.
 +You are in a Discord group chat. Normal final replies are private and are not automatically sent to this group chat. To post visible output here, use the message tool with action=send; the target defaults to this group chat. Be a good group participant: mostly lurk and follow the conversation; reply only when directly addressed or you can add clear value. Emoji reactions are welcome when available. Write like a human. Avoid Markdown tables. Minimize empty lines and use normal chat conventions, not document-style spacing. Don't type literal \n sequences; use real line breaks sparingly. If addressed to someone else, stay silent unless invited or correcting key facts. Discord: wrap bare URLs like <https://example.com> to suppress embeds. When subagent or session-spawn tools are available and a directly requested group-chat task will require several tool calls, prefer delegating bounded side investigations early so the channel gets a responsive path forward. Keep the critical path local, avoid subagents for simple one-step work, and only surface concise group-visible updates when they add value. If no visible group response is needed, do not call message(action=send).
 +
 +Activation: trigger-only (you are invoked only when explicitly mentioned; recent context may be included). Address the specific sender noted in the message context.
-@@ -520,1 +522,1 @@
+@@ -522,1 +524,1 @@
 -<external_openclaw_current_sender>{"sender":{"id":"1000001","name":"Pash","username":"pash"}}</external_openclaw_current_sender>
 +<external_openclaw_current_sender>{"sender":{"id":"424242","name":"Pash","username":"pash"}}</external_openclaw_current_sender>
-@@ -562,1 +564,1 @@
+@@ -564,1 +566,1 @@
 -{"chat_id":"user:1000001","message_id":"tg-msg-0001","sender":{"id":"1000001","name":"Pash","username":"pash"}}
 +{"chat_id":"channel:987654321","message_id":"discord-msg-0001","conversation_label":"OpenClaw/#agent-sandbox","sender":{"id":"424242","name":"Pash","username":"pash"},"group_subject":"OpenClaw maintainers","group_channel":"#agent-sandbox","group_space":"OpenClaw","is_group_chat":true,"was_mentioned":true,"history_count":2}
-@@ -565,1 +567,5 @@
+@@ -567,1 +569,5 @@
 -Can you check whether the nightly build finished and tell me what happened?
 +Chat history since last reply: ⟦openclaw:ctx⟧
 +Peter: I pushed the Discord-side message-tool bridge.
 +Pash: @OpenClaw please verify the Codex happy path too.
 +
 +can you audit whether this prompt path has conflicting silence instructions?
-@@ -570,1 +576,1 @@
+@@ -572,1 +578,1 @@
 -Full JSON: `codex-dynamic-tools.telegram-direct.json`
 +Full tool overrides: `codex-dynamic-tools.discord-group.json` (base: `codex-dynamic-tools.telegram-direct.json`)

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
@@ -102,7 +102,8 @@
   "model": "gpt-5.5",
   "personality": "none",
   "sandbox": "danger-full-access",
-  "serviceName": "OpenClaw"
+  "serviceName": "OpenClaw",
+  "threadSource": "openclaw"
 }
 ```
 
@@ -180,7 +181,8 @@
   "sandboxPolicy": {
     "type": "dangerFullAccess"
   },
-  "threadId": "thread-telegram-direct-codex-message-tool"
+  "threadId": "thread-telegram-direct-codex-message-tool",
+  "turnTrigger": "user"
 }
 ```
 

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md.diff
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md.diff
@@ -1,5 +1,5 @@
---- telegram-direct-codex-message-tool.md	sha256=1e84581fe19b96f31b106d75dd1d767b614574e647eccac09d43abb3bc6ed2a6
-+++ telegram-heartbeat-codex-tool.md	sha256=86221f853223a94be7191b791bb5fda202db462741b74de55fed9e5e9ad20f8e
+--- telegram-direct-codex-message-tool.md	sha256=2475be00b6677cc61504cd75ba4d13b047048e8f5fec0fb684d53f542ef80179
++++ telegram-heartbeat-codex-tool.md	sha256=004dd538094b6838132330854911d9b4c10df4de6230396440700ac4d43acaa6
 @@ -1,1 +1,1 @@
 -# Telegram Direct Codex Message Tool Turn
 +# Telegram Direct Codex Heartbeat Tool Turn
@@ -15,64 +15,66 @@
 +  "trigger": "heartbeat"
 @@ -98,0 +99,1 @@
 +    "heartbeat_respond",
-@@ -137,1 +138,1 @@
+@@ -138,1 +139,1 @@
 -  "threadId": "thread-telegram-direct-codex-message-tool"
 +  "threadId": "thread-telegram-heartbeat-codex-tool"
-@@ -146,4 +146,0 @@
+@@ -147,4 +147,0 @@
 -    "openclaw_current_sender": {
 -      "kind": "untrusted",
 -      "value": "{\"sender\":{\"id\":\"1000001\",\"name\":\"Pash\",\"username\":\"pash\"}}"
 -    },
-@@ -183,1 +180,1 @@
--  "threadId": "thread-telegram-direct-codex-message-tool"
-+  "threadId": "thread-telegram-heartbeat-codex-tool"
-@@ -222,1 +219,1 @@
+@@ -184,2 +181,2 @@
+-  "threadId": "thread-telegram-direct-codex-message-tool",
+-  "turnTrigger": "user"
++  "threadId": "thread-telegram-heartbeat-codex-tool",
++  "turnTrigger": "heartbeat"
+@@ -224,1 +221,1 @@
 -    "dynamicToolsFrom": "codex-dynamic-tools.telegram-direct.json",
 +    "dynamicToolsFrom": "codex-dynamic-tools.heartbeat-turn.json",
-@@ -235,2 +232,2 @@
+@@ -237,2 +234,2 @@
 -    "chars": 882,
 -    "roughTokens": 221
 +    "chars": 752,
 +    "roughTokens": 188
-@@ -255,2 +252,2 @@
+@@ -257,2 +254,2 @@
 -    "chars": 58613,
 -    "roughTokens": 14654
 +    "chars": 60106,
 +    "roughTokens": 15027
-@@ -267,2 +264,2 @@
+@@ -269,2 +266,2 @@
 -    "chars": 26463,
 -    "roughTokens": 6616
 +    "chars": 26675,
 +    "roughTokens": 6669
-@@ -271,2 +268,2 @@
+@@ -273,2 +270,2 @@
 -    "chars": 85078,
 -    "roughTokens": 21270
 +    "chars": 86783,
 +    "roughTokens": 21696
-@@ -275,2 +272,2 @@
+@@ -277,2 +274,2 @@
 -    "chars": 793,
 -    "roughTokens": 199
 +    "chars": 1135,
 +    "roughTokens": 284
-@@ -517,6 +513,0 @@
+@@ -519,6 +515,0 @@
 -### User: OpenClaw Additional Context (openclaw_current_sender)
 -
 -```text
 -<external_openclaw_current_sender>{"sender":{"id":"1000001","name":"Pash","username":"pash"}}</external_openclaw_current_sender>
 -```
 -
-@@ -562,1 +553,1 @@
+@@ -564,1 +555,1 @@
 -{"chat_id":"user:1000001","message_id":"tg-msg-0001","sender":{"id":"1000001","name":"Pash","username":"pash"}}
 +{"chat_id":"user:1000001","message_id":"heartbeat-0001","sender":{"id":"1000001","name":"Pash","username":"pash"}}
-@@ -565,1 +556,1 @@
+@@ -567,1 +558,1 @@
 -Can you check whether the nightly build finished and tell me what happened?
 +Follow the heartbeat monitor scratch context when provided. Recurring tasks are automations; create or change their schedules with the automations tool, not heartbeat scratch. Do not infer or repeat old tasks from prior chats. Use heartbeat_respond to report the wake outcome. Set notify=false when nothing needs the user's attention. Set notify=true with notificationText only when the user should be interrupted.
-@@ -570,1 +561,1 @@
+@@ -572,1 +563,1 @@
 -Full JSON: `codex-dynamic-tools.telegram-direct.json`
 +Full tool overrides: `codex-dynamic-tools.heartbeat-turn.json` (base: `codex-dynamic-tools.telegram-direct.json`)
-@@ -590,0 +582,1 @@
+@@ -592,0 +584,1 @@
 +  "heartbeat_respond",
-@@ -741,0 +734,39 @@
+@@ -743,0 +736,39 @@
 +  },
 +  {
 +    "description": "Accept heartbeat result for post-turn handling. `notify=false` no visible send. `notify=true` needs concise notificationText. Scratch is monitor prose only.",


### PR DESCRIPTION
Codex usage reports could not identify OpenClaw task threads or tell what started their turns, even though OpenClaw already records the run trigger.

Mark new task threads with `threadSource: "openclaw"` and pass the existing run trigger to `turn/start`. Resuming a thread preserves its original source, and callers without a known trigger leave it unspecified.

This brings [#145327](https://github.com/openclaw/openclaw/pull/145327) from the release branch to main after verification on deployed instances.
