### PR TITLE
fix(memory): explain unpromoted candidates in dreaming reports

### DIFF
--- a/docs/concepts/dreaming.md
+++ b/docs/concepts/dreaming.md
@@ -22,6 +22,11 @@ Dreaming is enabled by default. Set
 - **Human-readable output** in `DREAMS.md` (or an existing `dreams.md`) and optional phase report files under `memory/dreaming/<phase>/YYYY-MM-DD.md`.
 
 Long-term promotion still writes only to `MEMORY.md`.
+Deep reports summarize why ranked candidates were not promoted, using counts by
+rejection category without copying rejected snippets or source identifiers.
+These counts cover candidates that reached promotion; they do not describe
+entries excluded during ranking. A candidate that changes during the final
+apply check keeps a general change reason rather than an inferred cause.
 An empty sweep records completion in plugin state without creating memory or
 dreaming files, so it does not complete a new workspace's first-run setup.
 Existing daily notes can still receive managed phase-block updates.

--- a/extensions/memory-core/src/dreaming-consolidation.test.ts
+++ b/extensions/memory-core/src/dreaming-consolidation.test.ts
@@ -785,6 +785,47 @@ describe("memory consolidation", () => {
     expect(subagent.complete).not.toHaveBeenCalled();
   });
 
+  it("reports a candidate removed from the recall store before consolidation as changed", async () => {
+    const workspaceDir = await createTempWorkspace("memory-consolidation-removed-recall-");
+    const notePath = path.join(workspaceDir, "memory", "2026-07-01.md");
+    const memoryPath = path.join(workspaceDir, "MEMORY.md");
+    await fs.mkdir(path.dirname(notePath), { recursive: true });
+    await fs.writeFile(notePath, "User prefers green tea.\n", "utf8");
+    await fs.writeFile(memoryPath, "# Memory\n\n- Original fact.\n", "utf8");
+    const candidates = await recordConsolidationRecall(workspaceDir);
+    const promoted = candidates[0];
+    if (!promoted) {
+      throw new Error("expected ranked candidate");
+    }
+    await shortTermTestState.writeRawRecallStore(workspaceDir, {
+      version: 1,
+      updatedAt: "2026-07-02T10:01:00.000Z",
+      entries: {},
+    });
+    const subagent = createSubagent("{}");
+
+    const applied = await applyShortTermPromotions({
+      workspaceDir,
+      candidates,
+      minScore: 0,
+      minRecallCount: 0,
+      minUniqueQueries: 0,
+      consolidation: { subagent, logger },
+      nowMs: Date.parse("2026-07-02T10:00:00.000Z"),
+    });
+
+    expect(applied.applied).toBe(0);
+    expect(applied.rejectedCandidates).toEqual([
+      expect.objectContaining({
+        candidate: expect.objectContaining({ key: promoted.key }),
+        category: "candidate changed",
+        reason: "candidate changed during apply",
+      }),
+    ]);
+    expect(subagent.complete).not.toHaveBeenCalled();
+    await expect(fs.readFile(memoryPath, "utf8")).resolves.toBe("# Memory\n\n- Original fact.\n");
+  });
+
   it("rejects a candidate downgraded in the recall store during consolidation", async () => {
     const workspaceDir = await createTempWorkspace("memory-consolidation-provenance-race-");
     const notePath = path.join(workspaceDir, "memory", "2026-07-01.md");

--- a/extensions/memory-core/src/dreaming-consolidation.test.ts
+++ b/extensions/memory-core/src/dreaming-consolidation.test.ts
@@ -852,6 +852,12 @@ describe("memory consolidation", () => {
     });
 
     expect(applied.applied).toBe(0);
+    expect(applied.rejectedCandidates).toEqual([
+      expect.objectContaining({
+        category: "candidate changed",
+        reason: "candidate changed during apply",
+      }),
+    ]);
     await expect(fs.readFile(memoryPath, "utf8")).resolves.toBe("# Memory\n\n- Original fact.\n");
   });
 
@@ -916,6 +922,12 @@ describe("memory consolidation", () => {
     });
 
     expect(applied.applied).toBe(0);
+    expect(applied.rejectedCandidates).toEqual([
+      expect.objectContaining({
+        category: "candidate changed",
+        reason: "candidate changed during apply",
+      }),
+    ]);
     await expect(fs.readFile(memoryPath, "utf8")).resolves.toBe("# Memory\n\n- Original fact.\n");
     const recallStore = await shortTermTestState.readRecallStore(
       workspaceDir,

--- a/extensions/memory-core/src/dreaming.test.ts
+++ b/extensions/memory-core/src/dreaming.test.ts
@@ -23,7 +23,8 @@ import {
 } from "openclaw/plugin-sdk/system-event-runtime";
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import { registerShortTermPromotionDreaming } from "./dreaming.js";
-import { createMemoryCoreTestHarness } from "./test-helpers.js";
+import { recordShortTermRecalls } from "./short-term-promotion.js";
+import { createMemoryCoreTestHarness, shortTermTestState } from "./test-helpers.js";
 
 // `runDreamingSweepPhases` is the only binding the dreaming trigger imports from this module.
 const runDreamingSweepPhasesMock = vi.hoisted(() =>
@@ -1316,6 +1317,103 @@ describe("dreaming service reconciliation", () => {
     });
     expectLogContains(logger.warn, "failed=0, degraded=1, narrativesPending=0");
   });
+
+  it.each([
+    { label: "all rejected", rejected: 1, promoted: 0 },
+    { label: "mixed outcomes", rejected: 1, promoted: 1 },
+    { label: "many private candidates", rejected: 40, promoted: 0 },
+  ])(
+    "reports bounded rejection counts through the cron hook: $label",
+    async ({ rejected, promoted }) => {
+      const workspaceDir = await createTempWorkspace("openclaw-dreaming-rejections-");
+      const nowMs = Date.now();
+      const sourcePath = `memory/.dreams/session-corpus/${new Date(nowMs).toISOString().slice(0, 10)}.txt`;
+      const snippets = Array.from(
+        { length: rejected + promoted },
+        (_, index) => `Private project detail number ${index}: keep the release checklist current.`,
+      );
+      await fs.mkdir(path.dirname(path.join(workspaceDir, sourcePath)), { recursive: true });
+      await fs.writeFile(path.join(workspaceDir, sourcePath), snippets.join("\n"));
+      const originalMemory = "# Long-Term Memory\n\nKeep this existing preference.\n";
+      await fs.writeFile(path.join(workspaceDir, "MEMORY.md"), originalMemory);
+      await recordShortTermRecalls({
+        workspaceDir,
+        query: "private synthetic query",
+        nowMs,
+        results: snippets.map((snippet, index) => ({
+          path: sourcePath,
+          source: "memory",
+          startLine: index + 1,
+          endLine: index + 1,
+          score: 0.95,
+          snippet,
+          provenance: {
+            originClass: "agent",
+            sessionKind: index >= rejected ? "interactive" : "cron",
+            observedAt: nowMs,
+          },
+        })),
+      });
+      const store = await shortTermTestState.readRecallStore(
+        workspaceDir,
+        new Date(nowMs).toISOString(),
+      );
+      expect(Object.keys(store.entries)).toHaveLength(rejected + promoted);
+      const { api, harness, logger } = createDreamingTestContext({
+        config: createDreamingConfig(
+          {
+            enabled: true,
+            timezone: "UTC",
+            phases: {
+              light: { enabled: false },
+              rem: { enabled: false },
+              deep: { limit: 50, minScore: 0, minRecallCount: 0, minUniqueQueries: 0 },
+            },
+          },
+          { agents: { defaults: { workspace: workspaceDir } } },
+        ),
+      });
+      registerShortTermPromotionDreamingForTest(api);
+      await triggerDreamingServiceStart(api, { config: api.config, getCron: () => harness.cron });
+      const payload = requireAgentTurnPayload(requireAddCall(harness, 0).payload);
+      await getBeforeAgentReplyHandler(api.on)(
+        { cleanedBody: payload.message },
+        { trigger: "cron", agentId: "main", workspaceDir },
+      );
+      expect(logger.error).not.toHaveBeenCalled();
+      const reportDir = path.join(workspaceDir, "memory", "dreaming", "deep");
+      const reports = await fs.readdir(reportDir);
+      expect(reports).toHaveLength(1);
+      const report = await fs.readFile(
+        path.join(reportDir, expectDefined(reports[0], "deep report filename")),
+        "utf-8",
+      );
+      expect(report).toContain(
+        `- Ranked ${rejected + promoted} candidate(s) for durable promotion.`,
+      );
+      expect(report).toContain(`- Promoted ${promoted} candidate(s) into MEMORY.md.`);
+      expect(report).toContain(
+        `- Not promoted: ${rejected} candidate(s) (consolidation origin/session: ${rejected}).`,
+      );
+      expect(report.split("\n").filter((line) => line.startsWith("- Not promoted:"))).toHaveLength(
+        1,
+      );
+      expect(report.length).toBeLessThan(400);
+      for (const privateValue of [...snippets, sourcePath, ...Object.keys(store.entries)]) {
+        expect(report).not.toContain(privateValue);
+      }
+      expect(report).not.toMatch(/score=|threshold|sessionKind|originClass/);
+      const memory = await fs.readFile(path.join(workspaceDir, "MEMORY.md"), "utf-8");
+      if (promoted === 0) {
+        expect(memory).toBe(originalMemory);
+      } else {
+        expect(memory).toContain(expectDefined(snippets[rejected], "promoted snippet"));
+      }
+      for (const snippet of snippets.slice(0, rejected)) {
+        expect(memory).not.toContain(snippet);
+      }
+    },
+  );
 
   it("does not create memory/ or DREAMS.md on an empty workspace sweep", async () => {
     const workspaceDir = await createTempWorkspace("openclaw-dreaming-empty-sweep-");

--- a/extensions/memory-core/src/dreaming.ts
+++ b/extensions/memory-core/src/dreaming.ts
@@ -24,6 +24,7 @@ import { peekSystemEventEntries } from "openclaw/plugin-sdk/system-event-runtime
 import { appendFailedDreamingEvent } from "./dreaming-events.js";
 import type { NarrativePhaseData } from "./dreaming-narrative.js";
 import { formatErrorMessage, includesSystemEventToken } from "./dreaming-shared.js";
+import type { PromotionRejectionCategory } from "./short-term-promotion-types.js";
 
 const RUNTIME_CRON_RECONCILE_INTERVAL_MS = 60_000;
 const HEARTBEAT_ISOLATED_SESSION_SUFFIX = ":heartbeat";
@@ -647,6 +648,19 @@ async function runShortTermDreamingPromotionIfTriggered(params: {
       });
       totalApplied += applied.applied;
       reportLines.push(`- Promoted ${applied.applied} candidate(s) into MEMORY.md.`);
+      if (applied.rejectedCandidates.length > 0) {
+        const rejectionCounts = new Map<PromotionRejectionCategory, number>();
+        for (const { category } of applied.rejectedCandidates) {
+          rejectionCounts.set(category, (rejectionCounts.get(category) ?? 0) + 1);
+        }
+        const summary = [...rejectionCounts]
+          .sort(([left], [right]) => left.localeCompare(right))
+          .map(([category, count]) => `${category}: ${count}`)
+          .join(", ");
+        reportLines.push(
+          `- Not promoted: ${applied.rejectedCandidates.length} candidate(s) (${summary}).`,
+        );
+      }
       if (params.config.verboseLogging) {
         const appliedSummary =
           applied.appliedCandidates.length > 0

--- a/extensions/memory-core/src/dreaming.ts
+++ b/extensions/memory-core/src/dreaming.ts
@@ -654,7 +654,7 @@ async function runShortTermDreamingPromotionIfTriggered(params: {
           rejectionCounts.set(category, (rejectionCounts.get(category) ?? 0) + 1);
         }
         const summary = [...rejectionCounts]
-          .sort(([left], [right]) => left.localeCompare(right))
+          .toSorted(([left], [right]) => left.localeCompare(right))
           .map(([category, count]) => `${category}: ${count}`)
           .join(", ");
         reportLines.push(

--- a/extensions/memory-core/src/short-term-promotion-apply.ts
+++ b/extensions/memory-core/src/short-term-promotion-apply.ts
@@ -298,11 +298,13 @@ export async function applyShortTermPromotions(
     return isPromotionOriginBlocked(candidate)
       ? reject(candidate.key, "origin", `origin filter (${candidate.provenance?.originClass})`)
       : options.consolidation && (!latest || !isConsolidationCandidateEligible(candidate))
-        ? reject(
-            candidate.key,
-            "consolidation origin/session",
-            "consolidation origin/session filter",
-          )
+        ? latest
+          ? reject(
+              candidate.key,
+              "consolidation origin/session",
+              "consolidation origin/session filter",
+            )
+          : false
         : isContaminatedDreamingSnippet(candidate.snippet)
           ? reject(candidate.key, "contamination", "contamination filter")
           : candidate.promotedAt || latest?.promotedAt

--- a/extensions/memory-core/src/short-term-promotion-apply.ts
+++ b/extensions/memory-core/src/short-term-promotion-apply.ts
@@ -48,6 +48,7 @@ import {
   type ApplyShortTermPromotionsOptions,
   type ApplyShortTermPromotionsResult,
   type PromotionCandidate,
+  type PromotionRejectionCategory,
   type ShortTermRecallEntry,
 } from "./short-term-promotion-types.js";
 import {
@@ -275,38 +276,66 @@ export async function applyShortTermPromotions(
     // sacrifices trusted lines in a mixed file so untrusted text cannot promote.
     return withDailyFileQuarantine(authoritative, dailyProvenanceByPath);
   });
-  const rejectionReasons = new Map<string, string>();
+  const rejections = new Map<string, { reason: string; category: PromotionRejectionCategory }>();
+  const reject = (key: string, category: PromotionRejectionCategory, reason: string): false => {
+    rejections.set(key, { category, reason });
+    return false;
+  };
+  const describeRejection = (candidate: PromotionCandidate) => ({
+    candidate,
+    ...(rejections.get(candidate.key) ?? {
+      // Late revalidation has several causes; do not attribute a more specific gate.
+      category: "candidate changed" as const,
+      reason: "candidate changed during apply",
+    }),
+  });
   const eligible = currentCandidates.filter((candidate) => {
     const latest = store.entries[candidate.key];
     // Explicit untrusted/system origins never promote on ANY path (append or
     // consolidation): recall frequency must never launder externally-derived
     // content into MEMORY.md. Workspace memory files index as 'agent', so
     // legitimate daily-note candidates stay eligible.
-    const reason = isPromotionOriginBlocked(candidate)
-      ? `origin filter (${candidate.provenance?.originClass})`
+    return isPromotionOriginBlocked(candidate)
+      ? reject(candidate.key, "origin", `origin filter (${candidate.provenance?.originClass})`)
       : options.consolidation && (!latest || !isConsolidationCandidateEligible(candidate))
-        ? "consolidation origin/session filter"
+        ? reject(
+            candidate.key,
+            "consolidation origin/session",
+            "consolidation origin/session filter",
+          )
         : isContaminatedDreamingSnippet(candidate.snippet)
-          ? "contamination filter"
+          ? reject(candidate.key, "contamination", "contamination filter")
           : candidate.promotedAt || latest?.promotedAt
-            ? "already promoted"
+            ? reject(candidate.key, "already promoted", "already promoted")
             : candidate.score < minScore
-              ? `score threshold (${candidate.score.toFixed(3)} < ${minScore})`
+              ? reject(
+                  candidate.key,
+                  "score threshold",
+                  `score threshold (${candidate.score.toFixed(3)} < ${minScore})`,
+                )
               : candidate.signalCount < minRecallCount
-                ? `signal threshold (${candidate.signalCount} < ${minRecallCount})`
+                ? reject(
+                    candidate.key,
+                    "signal threshold",
+                    `signal threshold (${candidate.signalCount} < ${minRecallCount})`,
+                  )
                 : candidate.uniqueQueries < minUniqueQueries
-                  ? `query threshold (${candidate.uniqueQueries} < ${minUniqueQueries})`
+                  ? reject(
+                      candidate.key,
+                      "query threshold",
+                      `query threshold (${candidate.uniqueQueries} < ${minUniqueQueries})`,
+                    )
                   : maxAgeDays >= 0 && candidate.ageDays > maxAgeDays
-                    ? `age threshold (${candidate.ageDays.toFixed(1)}d > ${maxAgeDays}d)`
-                    : undefined;
-    if (reason) {
-      rejectionReasons.set(candidate.key, reason);
-    }
-    return !reason;
+                    ? reject(
+                        candidate.key,
+                        "age threshold",
+                        `age threshold (${candidate.ageDays.toFixed(1)}d > ${maxAgeDays}d)`,
+                      )
+                    : true;
   });
   const selected = eligible.slice(0, limit);
   for (const candidate of eligible.slice(limit)) {
-    rejectionReasons.set(candidate.key, `selection limit (${limit})`);
+    reject(candidate.key, "selection limit", `selection limit (${limit})`);
   }
 
   const rehydratedSelected: PromotionCandidate[] = [];
@@ -328,8 +357,13 @@ export async function applyShortTermPromotions(
       rehydratedSelected.push(rehydrated);
       plannedSourceFingerprints.set(candidate.key, sourceFingerprintAfter);
     } else {
-      rejectionReasons.set(
+      reject(
         candidate.key,
+        !rehydrated
+          ? "source rehydration"
+          : sourceFingerprintBefore !== sourceFingerprintAfter
+            ? "source changed"
+            : "contamination",
         !rehydrated
           ? "source rehydration failed"
           : sourceFingerprintBefore !== sourceFingerprintAfter
@@ -346,10 +380,7 @@ export async function applyShortTermPromotions(
       appended: 0,
       reconciledExisting: 0,
       appliedCandidates: [],
-      rejectedCandidates: currentCandidates.map((candidate) => ({
-        candidate,
-        reason: rejectionReasons.get(candidate.key) ?? "candidate changed during apply",
-      })),
+      rejectedCandidates: currentCandidates.map(describeRejection),
       compactedSections: 0,
       compactedDates: [],
     };
@@ -692,10 +723,7 @@ export async function applyShortTermPromotions(
     appliedCandidates: committedCandidates,
     rejectedCandidates: currentCandidates
       .filter((candidate) => !committedCandidates.some((applied) => applied.key === candidate.key))
-      .map((candidate) => ({
-        candidate,
-        reason: rejectionReasons.get(candidate.key) ?? "candidate changed during apply",
-      })),
+      .map(describeRejection),
     compactedSections: compactedDates.length,
     compactedDates,
   };

--- a/extensions/memory-core/src/short-term-promotion-types.ts
+++ b/extensions/memory-core/src/short-term-promotion-types.ts
@@ -177,6 +177,21 @@ export type ApplyShortTermPromotionsOptions = {
   };
 };
 
+/** Fixed diagnostic labels; never include candidate identifiers or threshold values. */
+export type PromotionRejectionCategory =
+  | "origin"
+  | "consolidation origin/session"
+  | "contamination"
+  | "already promoted"
+  | "score threshold"
+  | "signal threshold"
+  | "query threshold"
+  | "age threshold"
+  | "selection limit"
+  | "source rehydration"
+  | "source changed"
+  | "candidate changed";
+
 export type ApplyShortTermPromotionsResult = {
   memoryPath: string;
   applied: number;
@@ -186,6 +201,7 @@ export type ApplyShortTermPromotionsResult = {
   rejectedCandidates: Array<{
     candidate: PromotionCandidate;
     reason: string;
+    category: PromotionRejectionCategory;
   }>;
   /** Number of older promotion sections compacted out to honor the budget. */
   compactedSections: number;

--- a/extensions/memory-core/src/short-term-promotion.test.ts
+++ b/extensions/memory-core/src/short-term-promotion.test.ts
@@ -1557,6 +1557,7 @@ describe("short-term promotion", () => {
 
     expect(applied.applied).toBe(0);
     expect(applied.rejectedCandidates[0]?.reason).toContain("signal threshold");
+    expect(applied.rejectedCandidates[0]?.category).toBe("signal threshold");
   });
 
   it("does not let recall days satisfy the apply-time query gate", async (workspaceDir) => {
@@ -1596,6 +1597,7 @@ describe("short-term promotion", () => {
 
     expect(applied.applied).toBe(0);
     expect(applied.rejectedCandidates[0]?.reason).toBe("query threshold (0 < 3)");
+    expect(applied.rejectedCandidates[0]?.category).toBe("query threshold");
   });
 
   it("does not rank contaminated dreaming snippets from an existing short-term store", async (workspaceDir) => {
@@ -1757,6 +1759,7 @@ describe("short-term promotion", () => {
 
     expect(applied.applied).toBe(0);
     expect(applied.rejectedCandidates[0]?.reason).toContain("age threshold");
+    expect(applied.rejectedCandidates[0]?.category).toBe("age threshold");
     await expectEnoent(fs.readFile(path.join(workspaceDir, "MEMORY.md"), "utf-8"));
   });
 
@@ -1800,6 +1803,7 @@ describe("short-term promotion", () => {
 
     expect(applied.applied).toBe(0);
     expect(applied.rejectedCandidates[0]?.reason).toBe("contamination filter");
+    expect(applied.rejectedCandidates[0]?.category).toBe("contamination");
     await expectEnoent(fs.readFile(path.join(workspaceDir, "MEMORY.md"), "utf-8"));
   });
 
@@ -1861,6 +1865,7 @@ describe("short-term promotion", () => {
     const applied = await applyAllCandidates(workspaceDir, ranked);
     expect(applied.applied).toBe(0);
     expect(applied.rejectedCandidates[0]?.reason).toBe("origin filter (untrusted)");
+    expect(applied.rejectedCandidates[0]?.category).toBe("origin");
     await expectEnoent(fs.readFile(path.join(workspaceDir, "MEMORY.md"), "utf-8"));
   });
 


### PR DESCRIPTION
Related: #121232

## What Problem This Solves

Resolves a problem where operators reading a scheduled deep dreaming report see ranked candidates and zero promotions without an explanation of why promotion rejected them. Mixed outcomes also omit the reasons for candidates that were not promoted.

## Why This Change Was Made

The promotion owner now records a fixed rejection category alongside each existing detailed reason. The existing deep report aggregates those categories into one bounded line, such as `Not promoted: 2 candidate(s) (consolidation origin/session: 2).` This preserves promotion gates, gate order, and existing CLI reason text while keeping rejected snippets, source identifiers, and threshold values out of the new summary.

The summary covers ranked candidates that reach the applier. It does not explain records excluded during ranking, and late revalidation retains a general `candidate changed` reason. This addresses the diagnostic portion of #121232, not every eligibility concern in that issue. No new storage, configuration, or schema is introduced.

## User Impact

Operators can distinguish promotion filters from a lack of candidates and investigate the recorded cause without weakening promotion rules. Empty sweeps continue to avoid creating memory or dreaming files.

## Evidence

- Reproduced through the registered cron hook with a real temporary SQLite recall store and the normal report writer. Before the fix, three regression cases failed specifically because the explanation was missing despite correct ranked/promoted totals.
- After the fix, all 294 tests across dreaming, promotion, consolidation, markdown reporting, and CLI behavior passed. Coverage includes rejected-only and mixed outcomes, many private candidates, bounded reports, unchanged memory for rejected-only runs, and late concurrent changes.
- Independent review found no actionable defects in the patch.
- Validation uses isolated synthetic state. The real scheduled runtime proof below was captured after the fix; no production sweep was forced and the patch has not been deployed in a released runtime.
- Extension production and test typechecks, formatting, plugin boundaries, and the six doctor contract tests passed. The aggregate changed-file check stopped on existing unused exports in `ui/src/pages/new-session/cloud-target.ts`: `renderCloudConfiguration` and `renderConnectMachineMenuItem`. Running the same scan with this entire patch reversed reproduced the identical failures on base `34cdbaf303542717f5521ef4da504d57e20b644c`; the reviewed commit was then restored exactly. These baseline failures are not treated as a passing aggregate check.
- Targeted extension lint and the remaining storage, media, runtime-sidecar, and import-cycle guards passed when run separately after the aggregate check stopped. A final `toSorted()` lint correction was followed by another passing run of all 34 dreaming tests and a formatting check.


### Real scheduled runtime proof (pre-rebase head, unchanged patch)

On September 12, 2026 at 01:46:00 UTC, the actual Gateway scheduler ran the plugin-managed `Memory Dreaming Promotion` cron job in an isolated local setup. The supported `pnpm openclaw` launcher built commit `495e0ca616ecce79cec04c2a7b9cf1985fb8f2bd` (OpenClaw 2026.9.4). This was a natural minute-boundary execution, not `automations run`, a test scheduler, a mocked plugin API, or a direct hook invocation.

Setup: isolated home/config/state/workspace, loopback-only Gateway, no credentials, no channels configured, and delivery mode `none`. Light, REM, and deep phases stayed enabled with normal promotion thresholds (minimum score 0.75, three recalls, three queries). The only schedule change in this isolated fixture was `dreaming.frequency: "* * * * *"`; separate phase reports were enabled. A preparation script used the real recall/state owners to seed one synthetic session-corpus candidate with 12 distinct recalls and explicit agent/cron provenance. It did not call promotion or the report writer. The real phases then ingested, repaired, ranked, applied, and wrote the report.

Actual deep report:

```text
# Deep Sleep

- Repaired recall artifacts: rewrote recall store.
- Ranked 1 candidate(s) for durable promotion.
- Promoted 0 candidate(s) into MEMORY.md.
- Not promoted: 1 candidate(s) (consolidation origin/session: 1).
```

The native automation receipt recorded `action: finished`, `status: ok`, `completionStatus: succeeded`, duration 1016 ms, and `deliveryStatus: not-requested`. The synthetic MEMORY.md remained byte-for-byte equal to its initial content. The isolated Gateway was stopped after capturing the receipt/report, and its listening port was verified closed.

Limit: narrative generation logged missing-auth fallbacks for light/REM and `Async work scope is closed` for deep. This is proof of the real scheduled rejection report, not successful LLM narratives, all-green health, or production acceptance. No credentials were added to mask these outcomes.

### Data compatibility

This patch does not change a persistent data model: `category` belongs to the returned rejection diagnostic, not a recall record or SQLite row. The existing store writer still persists `latestStore`; the rejection objects are constructed separately in the return value. Schema, migrations, table definitions, namespaces, embedding metadata, config shape, and stored-record types are unchanged by the seven-file diff. Existing detailed `reason` values remain unchanged; CLI JSON gains an additive category field and textual CLI output keeps using `reason`.

The real run retained schema version 17. Inspecting its 21 stored memory-core values found zero `category` keys. A consolidated SQLite backup passed the supported read-only `database preflight` command with `status: exact`, target/found version 17, no issues, and `requiresWrite: false`. This verifies the diagnostic does not require a new migration; it does not claim compatibility of unrelated changes between older releases and this checkout.

### Prior CI failures outside this patch

CI run 34663155555 evaluated synthetic merge `dd81cc424ef4ad8307c1eabddf50c3dfd362e0bd` against upstream `6983dd95cb1f8606423df72cfa8819866dad156d`; its diff against that upstream parent contains only these seven dreaming files. Three UI checks fail:

- [Dependency check](https://github.com/openclaw/openclaw/actions/runs/34663155555/job/103469822060): the two unused `cloud-target.ts` exports described above; identical failure reproduced with the whole patch reversed to its base.
- [Core lint 4](https://github.com/openclaw/openclaw/actions/runs/34663155555/job/103469821877): unchanged `where-chip.test.ts` has 1020 lines, exceeding 1000. The targeted lint command reproduces the same error locally.
- [UI test shard](https://github.com/openclaw/openclaw/actions/runs/34663155555/job/103469823609): unchanged `new-session.css` has unconditional pointer selector `.new-session-page__touch-details`. The exact cursor-policy test reproduces it locally.

The relevant UI inputs were not changed by this PR or by the four intervening upstream commits since its original base. The aggregate CI gate is failing; these findings are documented, not waived or counted as passing checks.


### Rebase and maintainer follow-up

Rebased onto upstream `dda647045420956f7900180c5ca32d457dbc4973`, which contains the upstream UI repairs for the preceding CI failures. The contributor patch remained identical through `c2e48b8a3bd6fcf9e4b88484934eea6e6e0c90fa`; all 295 focused tests and the complete selected changed-file check passed there, including both typecheck lanes, lint, dead-export scans, and storage/import guards.

Current head: `610be988d614c9deaf7b8eaaea981b7dbb4a4068`. An independent autoreview found one adjacent classification defect: when the ranked `latest` recall disappeared before consolidation, the rejection was reported as `consolidation origin/session` even though its provenance had not failed. The maintainer follow-up now classifies that race as `candidate changed`. Its regression failed on the prior implementation and passes on this head. The two focused files pass 123 tests, and the native focused review-test gate passes. This changes only returned diagnostics; it does not change promotion eligibility, storage, schema, configuration, or the report bound.

Exact-head hosted CI run 34694214855 completed successfully on `610be988d614c9deaf7b8eaaea981b7dbb4a4068`.

The runtime captures remain explicitly attributed to the SHAs that executed them.

### Pre-follow-up scheduled proof

Repeated the supported real Gateway flow on `c2e48b8a3bd6fcf9e4b88484934eea6e6e0c90fa`, reusing the isolated synthetic state created and exercised by the previous build. The scheduler naturally started the run at 2026-09-12T03:53:59.831Z and completed in 798 ms (`status: ok`, `completionStatus: succeeded`, `deliveryStatus: not-requested`). The deep report again recorded 1 ranked, 0 promoted, and 1 consolidation origin/session rejection. MEMORY.md remained byte-for-byte unchanged and the state schema remained 17. The same disclosed narrative fallbacks occurred; the isolated Gateway was stopped after capture. This pre-follow-up runtime proof confirms that the previous build's synthetic state is readable without inventing a migration for the diagnostic field.

### ClawSweeper disposition

The exact-head ClawSweeper review found no actionable patch defect and accepted the real behavior proof. Its remaining `Add data-model compatibility proof` checkbox is skipped as inapplicable because the same review verifies the actual boundary: `category` exists only on returned rejection diagnostics, while `latestStore` remains the persisted value and stored recall records are unchanged. The schema-17 inspection, zero persisted `category` keys, and exact read-only database preflight above provide the relevant compatibility evidence. No migration or unrelated persistence change is warranted.
