### PR TITLE
fix: restore new-session picker CI checks

### DIFF
--- a/ui/src/e2e/chat-model-controls.e2e.test.ts
+++ b/ui/src/e2e/chat-model-controls.e2e.test.ts
@@ -255,27 +255,12 @@ suite.define(() => {
         await expect.poll(() => more.isVisible()).toBe(false);
         await expect.poll(() => account.isVisible()).toBe(true);
         await expect.poll(() => trigger.getAttribute("aria-expanded")).toBe("false");
-        const refreshRequests = await gateway.getRequests("users.listModelAccounts");
-        if (input === "keyboard") {
-          await gateway.deferNext("users.listModelAccounts", {});
-        }
+        const loadedInventoryRequests = await gateway.getRequests("users.listModelAccounts");
         await trigger.press("Enter");
         await expect.poll(() => more.isVisible()).toBe(true);
-        if (input === "keyboard") {
-          await gateway.waitForRequest("users.listModelAccounts", {
-            after: refreshRequests.length,
-          });
-          const loading = picker.locator('[data-chat-account-option="loading"]');
-          await expect.poll(() => loading.isVisible()).toBe(true);
-          await more.focus();
-          await gateway.resolveDeferred("users.listModelAccounts", {
-            profileId: "test-person",
-            accounts: [personal],
-            nextCursor: "accounts-page-2",
-            links: [{ provider: "openai", authProfileId: work.authProfileId, updatedAt: 1 }],
-          });
-          await expect.poll(() => loading.isVisible()).toBe(false);
-        }
+        expect(await gateway.getRequests("users.listModelAccounts")).toHaveLength(
+          loadedInventoryRequests.length,
+        );
         expect(
           await picker
             .locator('[data-chat-account-option="current"]')
@@ -284,7 +269,7 @@ suite.define(() => {
         const inventoryRequests = await gateway.getRequests("users.listModelAccounts");
         await gateway.deferNext("users.listModelAccounts", { cursor: "accounts-page-2" });
         if (input === "keyboard") {
-          // Refresh must preserve the action focused before Loading disappeared.
+          await more.focus();
           await page.keyboard.press("Enter");
           expect(page.url()).toContain("/chat/");
         } else {
@@ -295,11 +280,20 @@ suite.define(() => {
         });
         expect(nextPage.params).toEqual({ cursor: "accounts-page-2" });
         await expect.poll(() => trigger.getAttribute("aria-expanded")).toBe("true");
+        const loading = picker.locator('[data-chat-account-option="loading"]');
+        await expect.poll(() => loading.isVisible()).toBe(true);
+        if (input === "keyboard") {
+          // Inserting Loading must preserve the focused pagination action.
+          await expect
+            .poll(() => more.evaluate((option) => option === document.activeElement))
+            .toBe(true);
+        }
         await gateway.resolveDeferred("users.listModelAccounts", {
           profileId: "test-person",
           accounts: [work],
           links: [{ provider: "openai", authProfileId: work.authProfileId, updatedAt: 1 }],
         });
+        await expect.poll(() => loading.isVisible()).toBe(false);
         const workOption = picker.locator(
           `[data-chat-account-option="account:${work.authProfileId}"]`,
         );

--- a/ui/src/e2e/new-session-page.cloud-dispatch.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.cloud-dispatch.e2e.test.ts
@@ -1,6 +1,7 @@
 import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { asNullableRecord } from "@openclaw/normalization-core/record-coerce";
+import type { Page } from "playwright";
 import { expect, it } from "vitest";
 import { createDeferred } from "../../../test/helpers/promise.js";
 import { CLOUD_PROFILE_RETRY_DELAYS_MS } from "../pages/new-session/cloud-profile-discovery.ts";
@@ -31,6 +32,19 @@ const suite = createNewSessionPageE2eSuite();
 const SESSION_PLACEMENT_STARTUP_RUNTIME_REQUEST =
   /\/assets\/session-placement-startup\.runtime-[^/?]+\.js(?:\?.*)?$/;
 
+async function openWherePicker(page: Page) {
+  const picker = page.locator("wa-popover.new-session-page__where-popover");
+  const afterShow = picker.evaluate(
+    (element) =>
+      new Promise<void>((resolve) => {
+        element.addEventListener("wa-after-show", () => resolve(), { once: true });
+      }),
+  );
+  await page.locator("#new-session-where-trigger").click();
+  await afterShow;
+  return picker;
+}
+
 suite.define(() => {
   it("dispatches an optionless cloud profile without a machine override", async () => {
     await suite.withPage({ locale: "en-US", serviceWorkers: "block" }, async ({ page }) => {
@@ -52,7 +66,10 @@ suite.define(() => {
               {
                 id: "aws",
                 providerId: "crabbox",
-                machines: [{ id: "fast", label: "Fast" }],
+                machines: [
+                  { id: "standard", label: "Standard", default: true },
+                  { id: "fast", label: "Fast" },
+                ],
               },
               { id: "machine0", providerId: "crabbox" },
             ],
@@ -70,21 +87,19 @@ suite.define(() => {
       await page.goto(`${suite.server.baseUrl}new`);
       await gateway.waitForRequest("environments.list");
       const trigger = page.locator("#new-session-where-trigger");
-      const place = page.locator("wa-popover.new-session-page__where-popover");
-      await trigger.click();
+      const place = await openWherePicker(page);
       await place.getByRole("button", { name: "aws", exact: true }).click();
-      await trigger.click();
-      await place.getByRole("button", { name: "Fast", exact: true }).click();
+      await place.locator('[data-value="machine:fast"]').click();
       await expect.poll(() => trigger.getAttribute("data-machine-class")).toBe("fast");
-      await place.getByRole("button", { name: "machine0", exact: true }).click();
+      const optionless = place.getByRole("button", { name: "machine0", exact: true });
+      await optionless.click();
       await expect.poll(() => trigger.getAttribute("data-cloud-profile")).toBe("machine0");
       await expect.poll(() => trigger.getAttribute("data-machine-class")).toBeNull();
-      await trigger.click();
+      expect(await optionless.isEnabled()).toBe(true);
+      expect(await optionless.getAttribute("aria-pressed")).toBe("true");
       await expect
-        .poll(() => place.getByRole("button", { name: "machine0", exact: true }).isDisabled())
-        .toBe(false);
-      expect(await place.getByText("Machine", { exact: true }).count()).toBe(0);
-      expect(await place.locator('[data-value^="machine:"]').count()).toBe(0);
+        .poll(() => place.locator(".new-session-page__cloud-configuration:visible").count())
+        .toBe(0);
       await captureUiProof(suite, page, "optionless-cloud-profile.png");
       await page.keyboard.press("Escape");
 
@@ -227,16 +242,15 @@ suite.define(() => {
         })),
       ).toEqual({ hasSubtleCrypto: true, isSecureContext: true });
       await gateway.waitForRequest("environments.list");
-      await page.locator("#new-session-where-trigger").click();
-      const place = page.locator("wa-popover.new-session-page__where-popover");
+      const place = await openWherePicker(page);
       await place.getByRole("button", { name: "aws", exact: true }).click();
       const trigger = page.locator("#new-session-where-trigger");
       await expect.poll(() => trigger.getAttribute("data-cloud-profile")).toBe("aws");
-      await trigger.click();
       await place.getByText("Machine", { exact: true }).waitFor();
-      await place.getByRole("button", { name: /Fast/ }).click();
+      await place.locator('[data-value="machine:fast"]').click();
       await expect.poll(() => trigger.getAttribute("data-machine-class")).toBe("fast");
-      await pollLocatorText(trigger.locator(".new-session-page__trigger-label")).toBe("aws · Fast");
+      await pollLocatorText(trigger.locator(".new-session-page__trigger-label")).toBe("aws");
+      await expect.poll(() => trigger.getAttribute("aria-label")).toContain("aws, Fast");
       await page.keyboard.press("Escape");
       const checkoutTrigger = page.locator("#new-session-checkout-trigger");
       const checkout = page.locator("wa-popover.new-session-page__checkout-popover");
@@ -362,12 +376,14 @@ suite.define(() => {
       await expect.poll(() => startButton.isDisabled()).toBe(false);
 
       if (captureUiProofEnabled) {
-        await trigger.click();
+        await openWherePicker(page);
         await writeFile(
           path.join(suite.artifactDir, "cloud-profile-refresh-retention", "01-before-refresh.png"),
-          await takeControlUiViewportScreenshot(page, place.locator('wa-popup [part="popup"]'), [
-            place.getByRole("button", { name: "aws", exact: true }),
-          ]),
+          await takeControlUiViewportScreenshot(
+            page,
+            place.locator(".new-session-page__environment-picker"),
+            [place.locator('[data-value="cloud:aws"]')],
+          ),
         );
         await page.keyboard.press("Escape");
       }
@@ -411,15 +427,19 @@ suite.define(() => {
       );
       await expect.poll(() => trigger.getAttribute("data-cloud-profile")).toBe("aws");
       await expect.poll(() => trigger.getAttribute("data-machine-class")).toBe("fast");
-      await pollLocatorText(trigger.locator(".new-session-page__trigger-label")).toBe("aws · Fast");
+      await pollLocatorText(trigger.locator(".new-session-page__trigger-label")).toBe("aws");
+      await expect.poll(() => trigger.getAttribute("aria-label")).toContain("aws, Fast");
       await expect.poll(() => startButton.isDisabled()).toBe(false);
-      await trigger.click();
-      const retainedCloudProfile = place.getByRole("button", { name: "aws", exact: true });
+      await openWherePicker(page);
+      const retainedCloudProfile = place.locator('[data-value="cloud:aws"]');
       await expect.poll(() => retainedCloudProfile.isDisabled()).toBe(false);
-      await expect
-        .poll(() => tooltipTitleText(retainedCloudProfile))
-        .toBe("Cloud worker provider: crabbox");
-      await expect.poll(() => place.getByRole("button", { name: /Fast/ }).isVisible()).toBe(true);
+      await pollLocatorText(
+        retainedCloudProfile.locator(".new-session-page__selected-summary"),
+      ).toBe("Fast");
+      await retainedCloudProfile.hover();
+      const retainedCloudMachine = place.locator('[data-value="machine:fast"]');
+      await retainedCloudMachine.waitFor();
+      expect(await retainedCloudMachine.getAttribute("aria-pressed")).toBe("true");
       if (captureUiProofEnabled) {
         await writeFile(
           path.join(
@@ -427,9 +447,11 @@ suite.define(() => {
             "cloud-profile-refresh-retention",
             "03-after-retry-exhaustion.png",
           ),
-          await takeControlUiViewportScreenshot(page, place.locator('wa-popup [part="popup"]'), [
-            retainedCloudProfile,
-          ]),
+          await takeControlUiViewportScreenshot(
+            page,
+            place.locator(".new-session-page__cloud-configuration"),
+            [retainedCloudProfile, retainedCloudMachine],
+          ),
         );
       }
       await page.keyboard.press("Escape");

--- a/ui/src/e2e/new-session-page.cloud-os.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.cloud-os.e2e.test.ts
@@ -40,7 +40,14 @@ suite.define(() => {
         await gateway.waitForRequest("environments.list");
         const trigger = page.locator("#new-session-where-trigger");
         const picker = page.locator("wa-popover.new-session-page__where-popover");
+        const afterShow = picker.evaluate(
+          (element) =>
+            new Promise<void>((resolve) => {
+              element.addEventListener("wa-after-show", () => resolve(), { once: true });
+            }),
+        );
         await trigger.click();
+        await afterShow;
         await picker.getByRole("button", { name: "aws", exact: true }).click();
         await picker.locator('[data-value="cloud:aws"]').hover();
         await picker.locator('[data-value="machine:standard"]').waitFor();
@@ -51,7 +58,7 @@ suite.define(() => {
               path.join(suite.artifactDir, fileName),
               await takeControlUiElementScreenshot(
                 page,
-                picker.locator('wa-popup [part="popup"]'),
+                picker.locator(".new-session-page__cloud-configuration"),
                 [picker.locator('[data-value="machine:standard"]')],
               ),
             );
@@ -76,14 +83,13 @@ suite.define(() => {
         const linux = picker.locator('[data-value="os:linux"]');
         await picker.locator('[data-value="cloud:aws"]').hover();
         await linux.waitFor();
-        expect(await linux.isEnabled()).toBe(true);
-        expect(await linux.getAttribute("aria-pressed")).toBe("true");
+        expect(await linux.textContent()).toBe("Linux");
+        expect(await picker.getByRole("button", { name: "Linux", exact: true }).count()).toBe(0);
         for (const os of ["macos", "windows"]) {
           const option = picker.locator(`[data-value="os:${os}"]`);
           expect(await option.count()).toBe(0);
         }
         await capturePicker("02-after-unavailable-operating-systems.png");
-        await linux.click();
         await page.keyboard.press("Escape");
         await page.locator(".new-session-page__message").fill("Continue on Linux");
         await page.getByRole("button", { name: "Start session" }).click();

--- a/ui/src/e2e/new-session-page.cloud-startup.recovery.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.cloud-startup.recovery.e2e.test.ts
@@ -123,7 +123,15 @@ suite.define(() => {
     try {
       await page.goto(`${suite.server.baseUrl}new`);
       await gateway.waitForRequest("environments.list");
+      const where = page.locator("wa-popover.new-session-page__where-popover");
+      const afterShow = where.evaluate(
+        (element) =>
+          new Promise<void>((resolve) => {
+            element.addEventListener("wa-after-show", () => resolve(), { once: true });
+          }),
+      );
       await page.locator("#new-session-where-trigger").click();
+      await afterShow;
       await page.locator('[data-value="cloud:aws"]').hover();
       await page.locator('[data-value="machine:fast"]').click();
       await expect

--- a/ui/src/e2e/new-session-page.device-dispatch.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.device-dispatch.e2e.test.ts
@@ -71,8 +71,8 @@ suite.define(() => {
             ),
         )
         .toEqual([
-          "gateway",
           "auto-device",
+          "gateway",
           "device:paired-runner",
           "device:offline-runner",
           "cloud:aws",
@@ -82,7 +82,7 @@ suite.define(() => {
           .locator(".new-session-page__environment-heading")
           .allTextContents()
           .then((headings) => headings.map((heading) => heading.replace(/\s+/g, " ").trim())),
-      ).toEqual(["Local", "Your devices", "Cloud"]);
+      ).toEqual(["Your devices", "Cloud"]);
       const auto = destinations.locator('[data-value="auto-device"]');
       expect(await auto.getAttribute("aria-pressed")).toBe("false");
       expect(await destinations.getByRole("button", { name: /^aws(?: · .+)?$/ }).count()).toBe(1);

--- a/ui/src/e2e/new-session-page.operator-scopes.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.operator-scopes.e2e.test.ts
@@ -95,7 +95,7 @@ suite.define(() => {
       const where = page.locator("wa-popover.new-session-page__where-popover");
       await where.getByRole("button", { name: /Writer runner/u }).waitFor();
       expect(await where.locator('[data-value="cloud:aws"]').count()).toBe(0);
-      expect(await where.locator('[data-value="connect-machine"]').count()).toBe(0);
+      expect(await where.locator('[data-action="connect-machine"]').count()).toBe(0);
       await page.keyboard.press("Escape");
       await effort.click();
       const fastMode = page.locator("[data-chat-speed-toggle]");
@@ -186,7 +186,7 @@ suite.define(() => {
       const where = page.locator("wa-popover.new-session-page__where-popover");
       await where.locator('[data-value="device:writer-runner"]').waitFor();
       await where.locator('[data-value="cloud:aws"]').waitFor();
-      await where.locator('[data-value="connect-machine"]').waitFor();
+      await where.locator('[data-action="connect-machine"]').waitFor();
     } finally {
       await context.close();
     }

--- a/ui/src/e2e/new-session-page.projects-places.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.projects-places.e2e.test.ts
@@ -196,12 +196,14 @@ suite.define(() => {
         await page.goto(`${suite.server.baseUrl}new`);
         await gateway.waitForRequest("system.info");
         const trigger = page.locator("#new-session-where-trigger");
-        await pollLocatorText(trigger.locator(".new-session-page__trigger-label")).toBe("Local");
+        await pollLocatorText(trigger.locator(".new-session-page__trigger-label")).toBe(
+          late === "recovery scope" ? "QA-Gateway" : "Local",
+        );
         const place = page.locator("wa-popover.new-session-page__where-popover");
         const local = place.locator('[data-value="gateway"]');
         if (late === "recovery scope") {
           await trigger.click();
-          await expect.poll(() => tooltipTitleText(local)).toBe("Gateway · QA-Gateway");
+          await expect.poll(() => tooltipTitleText(local)).toBe("QA-Gateway Runs on your gateway");
           const catalogRequests = (await gateway.getRequests("environments.list")).length;
           await page.evaluate(() => window.dispatchEvent(new Event("test-release-recovery-scope")));
           await waitForGatewayRecoveryScope(page);
@@ -218,8 +220,11 @@ suite.define(() => {
         if (late === "system info") {
           await expect.poll(() => pathInput.getAttribute("placeholder")).toBe("Gateway · local");
           await gateway.resolveDeferred("system.info", systemInfo);
-          await expect.poll(() => tooltipTitleText(local)).toBe("Gateway · QA-Gateway");
+          await expect.poll(() => tooltipTitleText(local)).toBe("QA-Gateway Runs on your gateway");
         }
+        await pollLocatorText(trigger.locator(".new-session-page__trigger-label")).toBe(
+          "QA-Gateway",
+        );
         await expect.poll(() => pathInput.getAttribute("placeholder")).toBe("Gateway · QA-Gateway");
         await captureProjectUiProof(suite, page, `gateway-name-${late.replaceAll(" ", "-")}.png`, {
           surface: page.locator('.new-session-page__project-popover wa-popup [part="popup"]'),
@@ -228,9 +233,11 @@ suite.define(() => {
 
         await page.keyboard.press("Escape");
         await replaceGatewayClient(page);
-        await pollLocatorText(trigger.locator(".new-session-page__trigger-label")).toBe("Local");
+        await pollLocatorText(trigger.locator(".new-session-page__trigger-label")).toBe(
+          "QA-Gateway",
+        );
         await trigger.click();
-        await expect.poll(() => tooltipTitleText(local)).toBe("Gateway · QA-Gateway");
+        await expect.poll(() => tooltipTitleText(local)).toBe("QA-Gateway Runs on your gateway");
       } finally {
         try {
           await captureProjectUiProof(
@@ -361,10 +368,7 @@ suite.define(() => {
       expect(await page.locator("#new-session-checkout-trigger").count()).toBe(0);
       await page.locator("#new-session-where-trigger").click();
       const where = page.locator("wa-popover.new-session-page__where-popover");
-      const cloud = where.getByRole("button", {
-        name: "aws · Cloud needs a Git checkout",
-        exact: true,
-      });
+      const cloud = where.locator('[data-value="cloud:aws"]');
       await cloud.waitFor();
       expect(await cloud.isDisabled()).toBe(true);
       await expect.poll(() => tooltipTitleText(cloud)).toBe("Cloud needs a Git checkout");

--- a/ui/src/e2e/new-session-page.workspace-validation.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.workspace-validation.e2e.test.ts
@@ -379,10 +379,7 @@ suite.define(() => {
       const start = page.getByRole("button", { name: "Start session" });
       await expect.poll(() => start.isDisabled()).toBe(true);
       await whereTrigger.click();
-      const cloud = where.getByRole("button", {
-        name: "aws · Couldn't verify Git for this folder. Choose it again to retry.",
-        exact: true,
-      });
+      const cloud = where.locator('[data-value="cloud:aws"]');
       expect(await cloud.isDisabled()).toBe(true);
       await expect
         .poll(() => tooltipTitleText(cloud))

--- a/ui/src/pages/new-session/cloud-target.test.ts
+++ b/ui/src/pages/new-session/cloud-target.test.ts
@@ -2,11 +2,7 @@
 
 import { render } from "lit";
 import { describe, expect, it, vi } from "vitest";
-import {
-  renderSessionMenuItem,
-  renderCloudProfileMenuItems,
-  renderCloudConfiguration,
-} from "./cloud-target.ts";
+import { renderSessionMenuItem, renderCloudProfileMenuItems } from "./cloud-target.ts";
 
 describe("cloud target menu", () => {
   it("renders explicit remediation commands on separate lines", () => {
@@ -157,10 +153,11 @@ describe("cloud target menu", () => {
   ])("renders a single machine as fixed provider configuration", ({ machine, expected }) => {
     const container = document.createElement("div");
     render(
-      renderCloudConfiguration({
-        profile: { id: "aws", providerId: "aws" },
-        operatingSystems: [],
-        machines: [machine],
+      renderCloudProfileMenuItems({
+        profiles: [{ id: "aws", providerId: "aws", operatingSystems: [], machines: [machine] }],
+        selectedId: "aws",
+        compact: true,
+        onSelect: vi.fn(),
         selectedOs: "",
         selectedMachine: machine.id,
         submitting: false,
@@ -209,41 +206,59 @@ describe("cloud target menu", () => {
     const container = document.createElement("div");
     const onSelectMachine = vi.fn();
     const onSelectOs = vi.fn();
+    const onSelect = vi.fn();
     const params = {
-      profile: { id: "aws", providerId: "aws" },
-      operatingSystems: [
-        { id: "linux", label: "Linux" },
-        { id: "macos", label: "macOS" },
+      profiles: [
+        {
+          id: "aws",
+          providerId: "aws",
+          operatingSystems: [
+            { id: "linux", label: "Linux" },
+            { id: "macos", label: "macOS" },
+          ],
+          machines: [
+            { id: "small", label: "Small" },
+            { id: "large", label: "Large" },
+          ],
+        },
       ],
-      machines: [
-        { id: "small", label: "Small" },
-        { id: "large", label: "Large" },
-      ],
+      selectedId: "aws",
+      compact: true,
+      onSelect,
       selectedOs: "linux",
       selectedMachine: "small",
       submitting: false,
       onSelectMachine,
       onSelectOs,
     };
-    render(renderCloudConfiguration(params), container);
+    render(renderCloudProfileMenuItems(params), container);
     container.querySelector<HTMLButtonElement>('[data-value="machine:large"]')!.click();
     container.querySelector<HTMLButtonElement>('[data-value="os:macos"]')!.click();
     expect(onSelectMachine).toHaveBeenCalledExactlyOnceWith("large");
     expect(onSelectOs).toHaveBeenCalledExactlyOnceWith("macos");
-    render(renderCloudConfiguration({ ...params, submitting: true }), container);
+    expect(onSelect).not.toHaveBeenCalled();
+    render(renderCloudProfileMenuItems({ ...params, submitting: true }), container);
     expect([...container.querySelectorAll("button")].every((button) => button.disabled)).toBe(true);
   });
 
   it("omits unavailable OS choices even when they are the current selection", () => {
     const container = document.createElement("div");
     render(
-      renderCloudConfiguration({
-        profile: { id: "aws", providerId: "aws" },
-        operatingSystems: [
-          { id: "linux", label: "Linux" },
-          { id: "windows", label: "Windows", disabledReason: "Install WSL2" },
+      renderCloudProfileMenuItems({
+        profiles: [
+          {
+            id: "aws",
+            providerId: "aws",
+            operatingSystems: [
+              { id: "linux", label: "Linux" },
+              { id: "windows", label: "Windows", disabledReason: "Install WSL2" },
+            ],
+            machines: [],
+          },
         ],
-        machines: [],
+        selectedId: "aws",
+        compact: true,
+        onSelect: vi.fn(),
         selectedOs: "windows",
         selectedMachine: "",
         submitting: false,
@@ -257,7 +272,9 @@ describe("cloud target menu", () => {
     expect(fixedOs?.tagName).toBe("SPAN");
     expect(fixedOs?.hasAttribute("aria-pressed")).toBe(false);
     expect(container.querySelector('[data-value="os:windows"]')).toBeNull();
-    expect(container.querySelector('[aria-pressed="true"]')).toBeNull();
+    expect(
+      container.querySelector('.new-session-page__cloud-configuration [aria-pressed="true"]'),
+    ).toBeNull();
   });
 
   it("disables cloud profiles with the runtime preflight reason", () => {

--- a/ui/src/pages/new-session/cloud-target.ts
+++ b/ui/src/pages/new-session/cloud-target.ts
@@ -238,23 +238,6 @@ export function renderSessionMenuItem(params: SessionMenuItemOptions, submitting
     : row;
 }
 
-export function renderConnectMachineMenuItem(params: { disabled: boolean; onSelect: () => void }) {
-  return html`
-    <div class="session-menu__separator" role="separator"></div>
-    <button
-      type="button"
-      class="session-menu__item new-session-page__connect-machine"
-      data-value="connect-machine"
-      aria-pressed="false"
-      ?disabled=${params.disabled}
-      @click=${params.onSelect}
-    >
-      <span class="session-menu__icon" aria-hidden="true">${icons.link}</span>
-      <span class="session-menu__text">${t("newSession.connectMachine")}</span>
-    </button>
-  `;
-}
-
 export function renderCloudProfileMenuItems(params: {
   profiles: readonly DraftCloudProfile[];
   selectedId: string;
@@ -373,7 +356,7 @@ function machineShapeText(machine: DraftMachineOption): string | undefined {
   return memory ? t("newSession.machineMemory", { memory }) : undefined;
 }
 
-export function renderCloudConfiguration(params: {
+function renderCloudConfiguration(params: {
   profile: DraftCloudProfile;
   suggested?: boolean;
   operatingSystems: readonly DraftOperatingSystem[];

--- a/ui/src/pages/new-session/where-chip.test.ts
+++ b/ui/src/pages/new-session/where-chip.test.ts
@@ -23,6 +23,40 @@ function capacityCaption(row: Element | null | undefined) {
     ?.textContent?.trim();
 }
 
+function renderResolvedPicker(
+  state: Parameters<typeof renderWhereChip>[0]["state"],
+  isAdmin: boolean,
+) {
+  const container = document.createElement("div");
+  render(
+    renderWhereChip({
+      state,
+      gatewayName: "",
+      environmentQuery: "",
+      onEnvironmentQueryInput: vi.fn(),
+      cloudProfileId: "",
+      deviceId: "",
+      worktreeAvailable: true,
+      submitting: false,
+      pendingPlacement: false,
+      popoverOpen: true,
+      popoverHiding: false,
+      isAdmin,
+      onGuardTransition: vi.fn(),
+      onPopoverShow: vi.fn(),
+      onPopoverHide: vi.fn(),
+      onPopoverAfterHide: vi.fn(),
+      onSelectDevice: vi.fn(),
+      onSelectAutoDevice: vi.fn(),
+      onSelectCloudProfile: vi.fn(),
+      onConnectMachine: vi.fn(),
+      onManageCloudWorkers: () => undefined,
+    }),
+    container,
+  );
+  return container;
+}
+
 function renderPicker(
   isAdmin: boolean,
   autoPlacementMode?: "least-busy" | "eligible-order",
@@ -856,33 +890,7 @@ describe("Where chip", () => {
       cloudProfileId: "",
       deviceId: "",
     });
-    const emptyContainer = document.createElement("div");
-    render(
-      renderWhereChip({
-        state,
-        gatewayName: "",
-        environmentQuery: "",
-        onEnvironmentQueryInput: vi.fn(),
-        cloudProfileId: "",
-        deviceId: "",
-        worktreeAvailable: true,
-        submitting: false,
-        pendingPlacement: false,
-        popoverOpen: true,
-        popoverHiding: false,
-        isAdmin: false,
-        onGuardTransition: vi.fn(),
-        onPopoverShow: vi.fn(),
-        onPopoverHide: vi.fn(),
-        onPopoverAfterHide: vi.fn(),
-        onSelectDevice: vi.fn(),
-        onSelectAutoDevice: vi.fn(),
-        onSelectCloudProfile: vi.fn(),
-        onConnectMachine: vi.fn(),
-        onManageCloudWorkers: () => undefined,
-      }),
-      emptyContainer,
-    );
+    const emptyContainer = renderResolvedPicker(state, false);
     expect(emptyContainer.querySelector('[data-value="auto-device"]')).toBeNull();
   });
 
@@ -921,33 +929,7 @@ describe("Where chip", () => {
       cloudProfileId: "",
       deviceId: "",
     });
-    const container = document.createElement("div");
-    render(
-      renderWhereChip({
-        state,
-        gatewayName: "",
-        environmentQuery: "",
-        onEnvironmentQueryInput: vi.fn(),
-        cloudProfileId: "",
-        deviceId: "",
-        worktreeAvailable: true,
-        submitting: false,
-        pendingPlacement: false,
-        popoverOpen: true,
-        popoverHiding: false,
-        isAdmin: false,
-        onGuardTransition: vi.fn(),
-        onPopoverShow: vi.fn(),
-        onPopoverHide: vi.fn(),
-        onPopoverAfterHide: vi.fn(),
-        onSelectDevice: vi.fn(),
-        onSelectAutoDevice: vi.fn(),
-        onSelectCloudProfile: vi.fn(),
-        onConnectMachine: vi.fn(),
-        onManageCloudWorkers: () => undefined,
-      }),
-      container,
-    );
+    const container = renderResolvedPicker(state, false);
 
     const automatic = container.querySelector<HTMLButtonElement>('[data-value="auto-device"]');
     expect(automatic?.disabled).toBe(true);
@@ -1041,33 +1023,7 @@ describe("Where chip", () => {
         deviceId: "",
         devicePlacement,
       });
-      const container = document.createElement("div");
-      render(
-        renderWhereChip({
-          state,
-          gatewayName: "",
-          environmentQuery: "",
-          onEnvironmentQueryInput: vi.fn(),
-          cloudProfileId: "",
-          deviceId: "",
-          worktreeAvailable: true,
-          submitting: false,
-          pendingPlacement: false,
-          popoverOpen: true,
-          popoverHiding: false,
-          isAdmin: true,
-          onGuardTransition: vi.fn(),
-          onPopoverShow: vi.fn(),
-          onPopoverHide: vi.fn(),
-          onPopoverAfterHide: vi.fn(),
-          onSelectDevice: vi.fn(),
-          onSelectAutoDevice: vi.fn(),
-          onSelectCloudProfile: vi.fn(),
-          onConnectMachine: vi.fn(),
-          onManageCloudWorkers: () => undefined,
-        }),
-        container,
-      );
+      const container = renderResolvedPicker(state, true);
 
       const device = container.querySelector<HTMLButtonElement>('[data-value="device:runner"]');
       expect(device?.matches(':disabled, [aria-disabled="true"]')).toBe(disabled);

--- a/ui/src/styles/new-session.css
+++ b/ui/src/styles/new-session.css
@@ -1544,7 +1544,7 @@ wa-popover.new-session-page__where-popover::part(body) {
     border-radius: var(--radius-sm);
     color: var(--muted);
     background: transparent;
-    cursor: pointer;
+    cursor: var(--cursor-action);
   }
 
   .new-session-page__touch-details svg {


### PR DESCRIPTION
Related: #145183, #145316, #145496

## What Problem This Solves

Resolves a problem where Control UI checks fail after the environment-picker and account-menu changes, blocking unrelated PRs. The picker leaves two unused exports, uses a link cursor for an action, and duplicates enough setup to exceed its test-file limit. Browser checks also still target the former picker controls or wait for an account refresh that the current owner intentionally avoids.

## Why This Change Was Made

Remove the uncalled Connect renderer, keep cloud configuration private to its production profile renderer, use the shared action-cursor token, and consolidate three identical picker setups. Preserve the original configuration scenarios and all 112 where-chip assertions.

Update browser flows to use the grouped device list, header Connect action, profile-side configuration and fixed single-OS label. Cloud selection, workspace rejection, dispatch payloads, retry identity, attachments and send ordering stay checked. Account reopening now checks loaded-inventory reuse, while the real deferred second page protects keyboard focus and chat-scoped account selection. Tooltip interactions wait for the existing picker `wa-after-show` focus handoff.

## User Impact

Picker actions follow the Control UI's default-arrow policy. Device, cloud and account selection behavior remains intact, and the affected CI checks can validate the current interface. No timeout, retry, ignore, baseline, budget or production behavior change is included in the browser-test follow-up.

## Evidence

- Reproduced the exact unused-export guard on current main `e4129b6375e3179be5d9ed0a56a35f2871f4e73b`: both cloud exports failed the production scan; the Connect renderer also failed the full-tree scan.
- The original five-file cohort changed from 99/100 passing to 100/100 with identical ordered case names. Baseline lint reproduced 1,020 counted lines against the 1,000 limit; fixture consolidation removed 45 counted code lines without dropping assertions.
- At original PR head `96588a4c27c2eaf64845429e274bf7ab9e9f56ff`, the eight-file browser cohort reproduced 10 failures and passed 59 tests. The repaired cohort passes **69/69 across all eight files**. Exact CI also reported a hidden cloud-recovery control; that case passed locally before repair and now uses the established after-show readiness event rather than a timing delay.
- Changed checks pass, including the UI E2E type graph, all three unused-export scans with zero entries, lint, formatting, i18n and unchanged ratchets.
- Fresh independent review of the complete PR delta found no actionable P0–P2 findings. `git diff --check` passes.
- The previous exact-head CI failures are retained in [run 34663431068](https://github.com/openclaw/openclaw/actions/runs/34663431068). Fresh hosted CI for this follow-up is pending.

The original synthetic before/after captures below show the same picker and selected Large cloud machine. Computed coarse-pointer cursor changes from `pointer` to `default`; the browser-test follow-up adds no visual change.

![Before: synthetic device and cloud picker](https://github.com/user-attachments/assets/96708341-9eec-4fb4-a9e5-e0c4b15113bd)

![Before: Large cloud machine selected](https://github.com/user-attachments/assets/6e42383b-6a88-4d38-8672-eb3b0c168cb1)

![After: synthetic device and cloud picker](https://github.com/user-attachments/assets/1abf4d96-d9df-46e7-bd9d-9beb8b8f53fe)

![After: Large cloud machine selected](https://github.com/user-attachments/assets/fc0a7347-8b6e-423e-9f6e-82709cf3026b)
