### PR TITLE
fix(copilot): preserve subagent results after persistence failures

### DIFF
--- a/docs/plugins/copilot.md
+++ b/docs/plugins/copilot.md
@@ -260,6 +260,11 @@ unvalidated so the next run creates a fresh SDK session instead of trusting a
 partial transcript. Only the post-append transcript update notification is
 best-effort and logged.
 
+Native subagent task updates retain their original completion or failure result
+when task persistence fails. A later terminal event or parent cleanup retries
+that same result instead of replacing it with cancellation. Bookkeeping is
+retired only after the tracked task is durably terminal or no longer exists.
+
 ## Side questions (`/btw`)
 
 `/btw` is **not** native on this harness. `createCopilotAgentHarness()`

--- a/extensions/copilot/src/attempt-cleanup.ts
+++ b/extensions/copilot/src/attempt-cleanup.ts
@@ -62,6 +62,7 @@ export function deferBackgroundCompactionCleanup(params: {
 }): Promise<"aborted" | "completed" | "deadline"> {
   return (async () => {
     let outcome: "aborted" | "completed" | "deadline" = "deadline";
+    let finalizationError: Error | undefined;
     try {
       outcome = await awaitDeferredCleanupBeforeDeadline({
         abortSignal: params.abortSignal,
@@ -75,7 +76,11 @@ export function deferBackgroundCompactionCleanup(params: {
         await cancelBackgroundCompactionBeforeTeardown(params.session);
         params.bridge.settleCompactionWait();
       }
-      params.finalizeNativeSubagents?.();
+      try {
+        params.finalizeNativeSubagents?.();
+      } catch (error) {
+        finalizationError = toCopilotError(error);
+      }
       params.bridge.detach();
       try {
         await params.session.disconnect();
@@ -94,6 +99,9 @@ export function deferBackgroundCompactionCleanup(params: {
       try {
         await params.pool.release(params.handle);
       } catch {}
+    }
+    if (finalizationError) {
+      throw finalizationError;
     }
     return outcome;
   })();

--- a/extensions/copilot/src/attempt-execution.ts
+++ b/extensions/copilot/src/attempt-execution.ts
@@ -625,7 +625,11 @@ export async function runCopilotExecution(context: {
     } else {
       await bridge?.awaitCompactionChain();
       await bridge?.awaitAgentEventChain();
-      nativeSubagentTaskMirror?.finalizeActiveRuns();
+      try {
+        nativeSubagentTaskMirror?.finalizeActiveRuns();
+      } catch (error) {
+        promptError ??= toCopilotError(error);
+      }
       cleanupToolBridge?.();
       await cleanupByokProxy?.();
       bridge?.detach();

--- a/extensions/copilot/src/attempt.test.ts
+++ b/extensions/copilot/src/attempt.test.ts
@@ -18,6 +18,12 @@ import {
   type AnyAgentTool,
   type SandboxContext,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
+import * as agentHarnessTaskRuntime from "openclaw/plugin-sdk/agent-harness-task-runtime";
+import type {
+  AgentHarnessTaskRecord,
+  AgentHarnessTaskRuntime,
+  AgentHarnessTaskRuntimeScope,
+} from "openclaw/plugin-sdk/agent-harness-task-runtime";
 import { toErrorObject as toLintErrorObject } from "openclaw/plugin-sdk/error-runtime";
 import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import {
@@ -3113,6 +3119,83 @@ describe("runCopilotAttempt", () => {
     expect(session.disconnect).toHaveBeenCalledTimes(1);
     expect(pool["release"]).toHaveBeenCalledTimes(1);
   });
+
+  it.each([false, true])(
+    "cleans up after native task finalization fails (deferred: %s)",
+    async (deferred) => {
+      const failure = new Error("native task persistence failed");
+      const task: AgentHarnessTaskRecord = {
+        taskId: "native-task",
+        runId: "copilot-agent:call-1",
+        runtime: "subagent",
+        taskKind: "copilot-native",
+        requesterSessionKey: "agent:main:main",
+        ownerKey: "agent:main:main",
+        scopeKind: "session",
+        task: "inspect",
+        status: "running",
+        notifyPolicy: "silent",
+        deliveryStatus: "not_applicable",
+        createdAt: 0,
+      };
+      const runtime: AgentHarnessTaskRuntime = {
+        createRunningTaskRun: () => task,
+        tryCreateRunningTaskRun: () => task,
+        recordTaskRunProgressByRunId: () => [],
+        finalizeTaskRunByRunId: () => {
+          throw failure;
+        },
+        setDetachedTaskDeliveryStatusByRunId: () => [],
+        listTaskRecords: () => [task],
+      };
+      vi.spyOn(agentHarnessTaskRuntime, "createAgentHarnessTaskRuntime").mockReturnValue(runtime);
+      const sdk = makeFakeSdk((session) => {
+        session.sendAndWait.mockImplementationOnce(async () => {
+          session.emit("user.message", { content: "hello" });
+          session.emit("subagent.started", {
+            agentDescription: "inspect",
+            agentDisplayName: "Worker",
+            agentName: "worker",
+            toolCallId: "call-1",
+          });
+          if (deferred) {
+            session.emit("session.compaction_start", {});
+          }
+          return makeAssistantMessageEvent("done");
+        });
+      });
+      const pool = makeFakePool(sdk);
+      const onDeferredCompaction = vi.fn<(params: { cleanup: Promise<unknown> }) => void>();
+      const outcome = await runCopilotAttempt(
+        makeParams({
+          agentHarnessTaskRuntimeScope: {} as AgentHarnessTaskRuntimeScope,
+        }),
+        { pool, onDeferredCompaction },
+      ).then(
+        (result) => ({ result, error: undefined }),
+        (error: unknown) => ({ result: undefined, error }),
+      );
+      const session = requireSession(sdk);
+      if (deferred) {
+        const cleanup = expectDefined(
+          onDeferredCompaction.mock.calls[0]?.[0].cleanup,
+          "deferred cleanup",
+        );
+        session.emit("session.compaction_complete", { success: true });
+        session.emit("session.idle", {});
+        await expect(cleanup).rejects.toBe(failure);
+      } else {
+        expect(outcome.error).toBeUndefined();
+        expect(
+          projectAgentRunAttemptTerminal(expectDefined(outcome.result, "attempt result").terminal)
+            .promptError,
+        ).toBe(failure);
+      }
+      expect(session.disconnect).toHaveBeenCalledOnce();
+      expect(pool.release).toHaveBeenCalledOnce();
+      expect(session.off).toHaveBeenCalledTimes(session.on.mock.calls.length);
+    },
+  );
 
   it("cleanup on disconnect throw", async () => {
     const primaryError = new Error("send failed");

--- a/extensions/copilot/src/event-bridge.test.ts
+++ b/extensions/copilot/src/event-bridge.test.ts
@@ -1,9 +1,28 @@
 import type { SessionEvent } from "@github/copilot-sdk";
 // Copilot tests cover event bridge plugin behavior.
 import { expectDefined } from "@openclaw/normalization-core";
+import type {
+  AgentHarnessTaskRecord,
+  AgentHarnessTaskRuntime,
+  AgentHarnessTaskRuntimeScope,
+} from "openclaw/plugin-sdk/agent-harness-task-runtime";
 import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { attachEventBridge, type SessionLike } from "./event-bridge.js";
+import { createCopilotNativeSubagentTaskMirror } from "./native-subagent-task-mirror.js";
+
+const nativeTaskRuntime = vi.hoisted<{
+  current?: Pick<
+    AgentHarnessTaskRuntime,
+    "tryCreateRunningTaskRun" | "finalizeTaskRunByRunId" | "listTaskRecords"
+  >;
+}>(() => ({}));
+
+vi.mock("openclaw/plugin-sdk/agent-harness-task-runtime", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("openclaw/plugin-sdk/agent-harness-task-runtime")>();
+  return { ...actual, createAgentHarnessTaskRuntime: () => nativeTaskRuntime.current };
+});
 
 const MODEL_REF = {
   api: "openai-responses",
@@ -123,6 +142,98 @@ afterEach(() => {
 });
 
 describe("attachEventBridge", () => {
+  it.each([
+    { terminal: "subagent.completed", failureMode: "empty" },
+    { terminal: "subagent.failed", failureMode: "throw" },
+  ] as const)(
+    "retries the original $terminal result after a swallowed $failureMode callback",
+    async ({ terminal, failureMode }) => {
+      const session = createFakeSession();
+      let now = 100;
+      let task: AgentHarnessTaskRecord | undefined;
+      let attempts = 0;
+      nativeTaskRuntime.current = {
+        tryCreateRunningTaskRun(params) {
+          task = {
+            taskId: "owned-task",
+            runId: params.runId,
+            runtime: "subagent",
+            taskKind: "copilot-native",
+            requesterSessionKey: "agent:parent:session",
+            ownerKey: "agent:parent:session",
+            scopeKind: "session",
+            task: params.task,
+            status: "running",
+            deliveryStatus: "not_applicable",
+            notifyPolicy: "silent",
+            createdAt: now,
+          };
+          return task;
+        },
+        finalizeTaskRunByRunId(params) {
+          attempts += 1;
+          if (attempts === 1) {
+            if (failureMode === "throw") {
+              throw new Error("store unavailable");
+            }
+            return [];
+          }
+          task = {
+            ...expectDefined(task, "persisted native task"),
+            status: params.status,
+            endedAt: params.endedAt,
+            lastEventAt: params.lastEventAt,
+            error: params.error,
+            terminalSummary: params.terminalSummary ?? undefined,
+          };
+          return [task];
+        },
+        listTaskRecords: () => (task ? [task] : []),
+      };
+      const mirror = expectDefined(
+        createCopilotNativeSubagentTaskMirror({
+          now: () => now,
+          scope: {} as AgentHarnessTaskRuntimeScope,
+        }),
+        "native task mirror",
+      );
+      const bridge = attachEventBridge(session, {
+        getSdkSessionId: () => "sdk-session-id",
+        isAborted: () => false,
+        onNativeSubagentEvent: (event) => mirror.handleEvent(event),
+      });
+      const data = {
+        agentDescription: "inspect",
+        agentDisplayName: "Researcher",
+        agentName: "researcher",
+        toolCallId: "call-1",
+      };
+      session.emit("subagent.started", makeEvent("subagent.started", data));
+      session.emit(
+        terminal,
+        makeEvent(terminal, { ...data, error: "child failed", totalTokens: 30 }),
+      );
+      expect(task?.status).toBe("running");
+      expect(attempts).toBe(1);
+      bridge.detach();
+      now = 200;
+      mirror.finalizeActiveRuns();
+      expect(task).toMatchObject({
+        status: terminal === "subagent.completed" ? "succeeded" : "failed",
+        endedAt: 100,
+        lastEventAt: 100,
+        error: terminal === "subagent.failed" ? "child failed" : undefined,
+        terminalSummary:
+          terminal === "subagent.completed"
+            ? "Subagent completed (30 tokens)."
+            : "Subagent failed.",
+      });
+      await session.disconnect();
+      mirror.finalizeActiveRuns();
+      expect(attempts).toBe(2);
+    },
+  );
+
   it("assistant.message_delta accumulates text per messageId in arrival order", () => {
     const session = createFakeSession();
     const bridge = attachEventBridge(session, {

--- a/extensions/copilot/src/native-subagent-task-mirror.test.ts
+++ b/extensions/copilot/src/native-subagent-task-mirror.test.ts
@@ -36,15 +36,49 @@ function makeEvent<T extends NativeSubagentEventType>(
 }
 
 function createRuntime() {
-  const task = {} as AgentHarnessTaskRecord;
-  return {
-    tryCreateRunningTaskRun: vi.fn(() => task),
-    recordTaskRunProgressByRunId: vi.fn(() => []),
-    finalizeTaskRunByRunId: vi.fn(() => []),
+  const records = new Map<string, AgentHarnessTaskRecord>();
+  const runtime = {
+    tryCreateRunningTaskRun: vi.fn<AgentHarnessTaskRuntime["tryCreateRunningTaskRun"]>((params) => {
+      const task: AgentHarnessTaskRecord = {
+        taskId: `task-${params.runId}`,
+        runtime: "subagent",
+        taskKind: "copilot-native",
+        runId: params.runId,
+        requesterSessionKey: "agent:parent:session",
+        ownerKey: "agent:parent:session",
+        scopeKind: "session",
+        task: params.task,
+        status: "running",
+        deliveryStatus: "not_applicable",
+        notifyPolicy: "silent",
+        createdAt: 0,
+      };
+      records.set(task.taskId, task);
+      return task;
+    }),
+    finalizeTaskRunByRunId: vi.fn<AgentHarnessTaskRuntime["finalizeTaskRunByRunId"]>((params) => {
+      const current = [...records.values()].find((task) => task.runId === params.runId);
+      if (!current) {
+        return [];
+      }
+      const task: AgentHarnessTaskRecord = {
+        ...current,
+        status: params.status,
+        endedAt: params.endedAt,
+        lastEventAt: params.lastEventAt,
+        error: params.error,
+        progressSummary: params.progressSummary ?? undefined,
+        terminalSummary: params.terminalSummary ?? undefined,
+      };
+      records.set(task.taskId, task);
+      return [task];
+    }),
+    listTaskRecords: vi.fn<AgentHarnessTaskRuntime["listTaskRecords"]>(() => [...records.values()]),
   } satisfies Pick<
     AgentHarnessTaskRuntime,
-    "tryCreateRunningTaskRun" | "recordTaskRunProgressByRunId" | "finalizeTaskRunByRunId"
+    "tryCreateRunningTaskRun" | "finalizeTaskRunByRunId" | "listTaskRecords"
   >;
+  return { ...runtime, records };
 }
 
 function createMirror(
@@ -218,4 +252,126 @@ describe("CopilotNativeSubagentTaskMirror", () => {
       terminalSummary: "Subagent cancelled.",
     });
   });
+
+  it.each([
+    { terminal: "subagent.completed", failureMode: "throw" },
+    { terminal: "subagent.completed", failureMode: "empty" },
+    { terminal: "subagent.failed", failureMode: "throw" },
+    { terminal: "subagent.failed", failureMode: "empty" },
+  ] as const)(
+    "retries the original $terminal result after $failureMode",
+    ({ terminal, failureMode }) => {
+      const runtime = createRuntime();
+      let now = 100;
+      const mirror = createMirror(runtime, { now: () => now });
+      const data = {
+        agentDescription: "inspect",
+        agentDisplayName: "Researcher",
+        agentName: "researcher",
+        toolCallId: "call-retry",
+      };
+      mirror.handleEvent(makeEvent("subagent.started", data, "child-retry"));
+      if (failureMode === "throw") {
+        runtime.finalizeTaskRunByRunId.mockImplementationOnce(() => {
+          throw new Error("store unavailable");
+        });
+      } else {
+        runtime.finalizeTaskRunByRunId.mockReturnValueOnce([]);
+      }
+      const completed = makeEvent(
+        "subagent.completed",
+        { ...data, totalTokens: 30 },
+        "child-retry",
+      );
+      const failed = makeEvent(
+        "subagent.failed",
+        { ...data, error: "child failed" },
+        "child-retry",
+      );
+      expect(() =>
+        mirror.handleEvent(terminal === "subagent.completed" ? completed : failed),
+      ).toThrow(failureMode === "throw" ? "store unavailable" : "did not persist");
+      expect([...runtime.records.values()][0]?.status).toBe("running");
+      now = 200;
+      mirror.handleEvent(terminal === "subagent.completed" ? failed : completed);
+      expect([...runtime.records.values()]).toEqual([
+        expect.objectContaining({
+          taskId: "task-copilot-agent:child-retry",
+          status: terminal === "subagent.completed" ? "succeeded" : "failed",
+          endedAt: 100,
+          lastEventAt: 100,
+          error: terminal === "subagent.failed" ? "child failed" : undefined,
+          terminalSummary:
+            terminal === "subagent.completed"
+              ? "Subagent completed (30 tokens)."
+              : "Subagent failed.",
+        }),
+      ]);
+      mirror.handleEvent(completed);
+      mirror.finalizeActiveRuns();
+      expect(runtime.finalizeTaskRunByRunId).toHaveBeenCalledTimes(2);
+    },
+  );
+
+  it("finalizes every active child and retains failed cancellation for retry", () => {
+    const runtime = createRuntime();
+    let now = 100;
+    const mirror = createMirror(runtime, { now: () => now });
+    for (const toolCallId of ["call-1", "call-2"]) {
+      mirror.handleEvent(
+        makeEvent("subagent.started", {
+          agentDescription: "inspect",
+          agentDisplayName: "Researcher",
+          agentName: "researcher",
+          toolCallId,
+        }),
+      );
+    }
+    runtime.finalizeTaskRunByRunId.mockImplementationOnce(() => {
+      throw new Error("store unavailable");
+    });
+    expect(() => mirror.finalizeActiveRuns()).toThrow("store unavailable");
+    expect([...runtime.records.values()].map((task) => task.status)).toEqual([
+      "running",
+      "cancelled",
+    ]);
+    now = 200;
+    mirror.finalizeActiveRuns();
+    expect([...runtime.records.values()]).toEqual([
+      expect.objectContaining({ status: "cancelled", endedAt: 100 }),
+      expect.objectContaining({ status: "cancelled", endedAt: 100 }),
+    ]);
+    expect(runtime.finalizeTaskRunByRunId).toHaveBeenCalledTimes(3);
+  });
+
+  it.each(["removed", "replacement", "terminal"] as const)(
+    "accepts empty finalization only when the owned task is %s",
+    (disposition) => {
+      const runtime = createRuntime();
+      const mirror = createMirror(runtime);
+      const data = {
+        agentDescription: "inspect",
+        agentDisplayName: "Researcher",
+        agentName: "researcher",
+        toolCallId: "call-1",
+      };
+      mirror.handleEvent(makeEvent("subagent.started", data));
+      const task = [...runtime.records.values()][0];
+      if (!task) {
+        throw new Error("Expected persisted native task");
+      }
+      runtime.records.delete(task.taskId);
+      if (disposition === "replacement") {
+        runtime.records.set("replacement", { ...task, taskId: "replacement" });
+      } else if (disposition === "terminal") {
+        runtime.records.set(task.taskId, { ...task, status: "cancelled", endedAt: 50 });
+      }
+      mirror.handleEvent(makeEvent("subagent.completed", data));
+      mirror.finalizeActiveRuns();
+      expect(runtime.finalizeTaskRunByRunId).not.toHaveBeenCalled();
+      expect([...runtime.records.values()].map((record) => record.status)).toEqual(
+        disposition === "removed" ? [] : [disposition === "terminal" ? "cancelled" : "running"],
+      );
+    },
+  );
 });

--- a/extensions/copilot/src/native-subagent-task-mirror.ts
+++ b/extensions/copilot/src/native-subagent-task-mirror.ts
@@ -2,6 +2,7 @@ import type { SessionEvent } from "@github/copilot-sdk";
 import {
   createAgentHarnessTaskRuntime,
   type AgentHarnessTaskRuntime,
+  type AgentHarnessScopedFinalizeTaskRunParams,
   type AgentHarnessTaskRuntimeScope,
 } from "openclaw/plugin-sdk/agent-harness-task-runtime";
 
@@ -15,7 +16,7 @@ type CopilotNativeSubagentEvent = Extract<
 
 type TaskLifecycleRuntime = Pick<
   AgentHarnessTaskRuntime,
-  "tryCreateRunningTaskRun" | "recordTaskRunProgressByRunId" | "finalizeTaskRunByRunId"
+  "tryCreateRunningTaskRun" | "finalizeTaskRunByRunId" | "listTaskRecords"
 >;
 
 export function createCopilotNativeSubagentTaskMirror(params: {
@@ -43,8 +44,10 @@ export function createCopilotNativeSubagentTaskMirror(params: {
 class CopilotNativeSubagentTaskMirror {
   private readonly runIdByAgentId = new Map<string, string>();
   private readonly runIdByToolCallId = new Map<string, string>();
-  private readonly terminalRunIds = new Set<string>();
-  private readonly activeRunIds = new Set<string>();
+  private readonly activeRuns = new Map<
+    string,
+    { taskId: string; terminal?: AgentHarnessScopedFinalizeTaskRunParams }
+  >();
   private readonly now: () => number;
 
   constructor(
@@ -73,19 +76,25 @@ class CopilotNativeSubagentTaskMirror {
 
   finalizeActiveRuns(): void {
     const eventAt = this.now();
-    for (const runId of this.activeRunIds) {
-      this.terminalRunIds.add(runId);
-      this.runtime.finalizeTaskRunByRunId({
-        runId,
-        status: "cancelled",
-        endedAt: eventAt,
-        lastEventAt: eventAt,
-        error: "Subagent ended with its parent attempt.",
-        progressSummary: "Subagent cancelled with its parent attempt.",
-        terminalSummary: "Subagent cancelled.",
-      });
+    let failure: { error: unknown } | undefined;
+    for (const runId of this.activeRuns.keys()) {
+      try {
+        this.finalizeRun({
+          runId,
+          status: "cancelled",
+          endedAt: eventAt,
+          lastEventAt: eventAt,
+          error: "Subagent ended with its parent attempt.",
+          progressSummary: "Subagent cancelled with its parent attempt.",
+          terminalSummary: "Subagent cancelled.",
+        });
+      } catch (error) {
+        failure ??= { error };
+      }
     }
-    this.activeRunIds.clear();
+    if (failure) {
+      throw failure.error;
+    }
   }
 
   private handleStarted(
@@ -124,21 +133,15 @@ class CopilotNativeSubagentTaskMirror {
     } else {
       this.runIdByToolCallId.set(toolCallId, runId);
     }
-    this.terminalRunIds.delete(runId);
-    this.activeRunIds.add(runId);
+    this.activeRuns.set(runId, { taskId: taskRecord.taskId });
   }
 
   private handleCompleted(
     event: Extract<CopilotNativeSubagentEvent, { type: "subagent.completed" }>,
     runId: string,
   ): void {
-    if (this.terminalRunIds.has(runId)) {
-      return;
-    }
     const eventAt = this.now();
-    this.terminalRunIds.add(runId);
-    this.activeRunIds.delete(runId);
-    this.runtime.finalizeTaskRunByRunId({
+    this.finalizeRun({
       runId,
       status: "succeeded",
       endedAt: eventAt,
@@ -152,13 +155,8 @@ class CopilotNativeSubagentTaskMirror {
     event: Extract<CopilotNativeSubagentEvent, { type: "subagent.failed" }>,
     runId: string,
   ): void {
-    if (this.terminalRunIds.has(runId)) {
-      return;
-    }
     const eventAt = this.now();
-    this.terminalRunIds.add(runId);
-    this.activeRunIds.delete(runId);
-    this.runtime.finalizeTaskRunByRunId({
+    this.finalizeRun({
       runId,
       status: "failed",
       endedAt: eventAt,
@@ -167,6 +165,29 @@ class CopilotNativeSubagentTaskMirror {
       progressSummary: "Subagent failed.",
       terminalSummary: "Subagent failed.",
     });
+  }
+
+  private finalizeRun(params: AgentHarnessScopedFinalizeTaskRunParams): void {
+    const run = this.activeRuns.get(params.runId);
+    if (!run) {
+      return;
+    }
+    // A failed projection keeps its observed result; teardown must not replace it with cancellation.
+    run.terminal ??= params;
+    const matchesRun = (task: { taskId: string; runId?: string }) =>
+      task.taskId === run.taskId && task.runId === params.runId;
+    const before = this.runtime.listTaskRecords().find(matchesRun);
+    if (!before || (before.status !== "queued" && before.status !== "running")) {
+      this.activeRuns.delete(params.runId);
+      return;
+    }
+    const updated = this.runtime.finalizeTaskRunByRunId(run.terminal);
+    const current = updated.find(matchesRun) ?? this.runtime.listTaskRecords().find(matchesRun);
+    // An empty result can mean failed persistence or an authoritative retirement/status fence.
+    if (current?.status === "queued" || current?.status === "running") {
+      throw new Error(`Native subagent task finalization did not persist: ${params.runId}`);
+    }
+    this.activeRuns.delete(params.runId);
   }
 
   private resolveRunId(event: CopilotNativeSubagentEvent): string {


### PR DESCRIPTION
Related: #144592

## What Problem This Solves

Fixes an issue where native Copilot subagent tasks could remain running or lose their original completion result when task persistence failed. A failure during parent cleanup could also prevent the SDK session and pooled client from being released.

## Why This Change Was Made

Retain each active task's identity and first observed terminal payload until finalization persists or the exact task is authoritatively retired. Later terminal events and parent cleanup retry that retained result; cleanup attempts every child and still releases session resources when a finalization error must be reported.

The existing task registry remains authoritative. This changes no harness API return types, task/flow storage owner, schema, configuration, or SDK version. Native mirror and harness operations remain synchronous.

## User Impact

A transient task-storage failure no longer converts a completed or failed native child into cancellation during cleanup. Retries preserve its original status, timestamp, and summary, and stale events do not finalize a replacement task. Persistent failures remain visible while normal session cleanup completes.

## Evidence

- The new retry and cleanup regressions failed on unchanged main for the intended bookkeeping/resource-lifetime failures. After the repair, all 208 cases across the complete mirror, event bridge, and attempt test files pass.
- Real SQLite proof used the production mirror, host-issued scope, and task runtime in isolated synthetic state. SQLite refused the initial terminal writes; after write access was restored, cleanup persisted the original success and failure results with their original timestamps and summaries. Closing and reopening the database verified both rows and integrity `ok`.
- The complete changed-file gate passes on the refreshed candidate, including formatting, production/test types, lint, all unused-export scans, plugin-boundary checks, database/media/sidecar guards and zero runtime import cycles.
- Isolated Codex review through P2 is clean; the rebase preserves the reviewed patch and every authored file byte-for-byte.

The native proof covers local task persistence and retry, not a live Copilot provider run. No real credentials, provider requests, or GitHub messages were used for validation. This is a focused persistence-bookkeeping repair and does not introduce the broader asynchronous task API migration.

Validated head: `30708924aa684964b09a1c155ded9f4e25f6a39c`, rebased patch-identically onto `47ce03dbc6994435af783fecf13d5586e7b307f4`, which includes the shared UI repairs from #145415. All seven authored file hashes are unchanged. All 208 affected cases and the full changed-file gate pass on this composition; exact-head hosted CI remains required for landing.
