### PR TITLE
fix(cli): reject extra empty arguments in routed commands

### DIFF
--- a/docs/cli/config.md
+++ b/docs/cli/config.md
@@ -108,6 +108,9 @@ the same batch.
 
 Reads a value from the redacted config snapshot (secrets never print). `--json` prints the same redacted value as JSON; otherwise strings/numbers/booleans print bare and objects/arrays print as formatted JSON.
 
+Pass exactly one config path. Extra arguments, including an empty quoted argument (`""`),
+are rejected; they do not suppress validation of later options.
+
 A schema-valid but unset path explains that the runtime default applies; an unknown path suggests
 `openclaw config schema`. With `--json`, both use the standard [CLI JSON failure envelope](/cli#json-failures)
 on stdout and exit with status 1. Without `--json`, diagnostics remain on stderr.

--- a/src/cli/config-cli.test.ts
+++ b/src/cli/config-cli.test.ts
@@ -1452,6 +1452,17 @@ describe("config cli", () => {
   });
 
   describe("config get", () => {
+    it.each([
+      { args: ["gateway.port", ""], code: "commander.excessArguments" },
+      { args: ["gateway.port", "", "--json"], code: "commander.excessArguments" },
+      { args: ["gateway.port", "", "--unknown"], code: "commander.unknownOption" },
+    ])("rejects malformed getter argv $args before reading config", async ({ args, code }) => {
+      await expect(runConfigCommand(["config", "get", ...args])).rejects.toMatchObject({ code });
+      expect(mockReadConfigFileSnapshot).not.toHaveBeenCalled();
+      expect(mockWriteConfigFile).not.toHaveBeenCalled();
+      expect(mockLog).not.toHaveBeenCalled();
+    });
+
     it("reads the valid configuration without observing persistent health state", async () => {
       setGatewaySnapshot();
 

--- a/src/cli/program/route-args.test.ts
+++ b/src/cli/program/route-args.test.ts
@@ -165,6 +165,36 @@ describe("route-args", () => {
       parse: parseAgentsListRouteArgs,
       argv: ["node", "openclaw", "agents", "--wat"],
     },
+    {
+      name: "config get empty excess operand",
+      parse: parseConfigGetRouteArgs,
+      argv: ["node", "openclaw", "config", "get", "gateway.port", ""],
+    },
+    {
+      name: "config get unknown flag after an empty operand",
+      parse: parseConfigGetRouteArgs,
+      argv: ["node", "openclaw", "config", "get", "gateway.port", "", "--unknown"],
+    },
+    {
+      name: "config get extra path after an empty operand",
+      parse: parseConfigGetRouteArgs,
+      argv: ["node", "openclaw", "config", "get", "gateway.port", "", "gateway.bind"],
+    },
+    {
+      name: "config unset empty excess operand",
+      parse: parseConfigUnsetRouteArgs,
+      argv: ["node", "openclaw", "config", "unset", "gateway.port", "", "--dry-run"],
+    },
+    {
+      name: "health empty excess operand",
+      parse: parseHealthRouteArgs,
+      argv: ["node", "openclaw", "health", ""],
+    },
+    {
+      name: "agents list empty excess operand",
+      parse: parseAgentsListRouteArgs,
+      argv: ["node", "openclaw", "agents", "list", ""],
+    },
   ])("defers unsupported routed argv: $name", ({ parse, argv }) => {
     expect(parse(argv)).toBeNull();
   });

--- a/src/cli/program/routes.test.ts
+++ b/src/cli/program/routes.test.ts
@@ -1,6 +1,10 @@
 // Program route tests cover CLI route table registration and dispatch.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { defaultRuntime } from "../../runtime.js";
+import {
+  applyCliExecutionStartupPresentation,
+  ensureCliExecutionBootstrap,
+} from "../command-execution-startup.js";
 import { tryRouteCli } from "../route.js";
 
 const runConfigGetMock = vi.hoisted(() => vi.fn(async () => {}));
@@ -246,8 +250,29 @@ describe("program routes", () => {
       argv: routeArgv("agents list --wat"),
     },
     { path: ["agents"], argv: routeArgv("agents --wat") },
-  ])("returns false instead of handling unknown routed option for $path", async ({ argv }) => {
+    {
+      path: ["config", "get"],
+      argv: ["node", "openclaw", "config", "get", "gateway.port", ""],
+    },
+    {
+      path: ["config", "get"],
+      argv: ["node", "openclaw", "config", "get", "gateway.port", "", "--unknown"],
+    },
+    {
+      path: ["config", "unset"],
+      argv: ["node", "openclaw", "config", "unset", "gateway.port", "", "--dry-run"],
+    },
+    {
+      path: ["agents", "list"],
+      argv: ["node", "openclaw", "agents", "list", ""],
+    },
+  ])("defers unsupported routed arguments before startup for $path", async ({ argv }) => {
     await expectRunFalse(argv);
+    expect(applyCliExecutionStartupPresentation).not.toHaveBeenCalled();
+    expect(ensureCliExecutionBootstrap).not.toHaveBeenCalled();
+    expect(runConfigGetMock).not.toHaveBeenCalled();
+    expect(runConfigUnsetMock).not.toHaveBeenCalled();
+    expect(agentsListCommandMock).not.toHaveBeenCalled();
   });
 
   it("routes status --json through the lean JSON command", async () => {

--- a/src/infra/cli-root-options.ts
+++ b/src/infra/cli-root-options.ts
@@ -145,7 +145,7 @@ function parseCommandArgsWithRootOptions(
 
   for (let index = 0; index < args.length; index += 1) {
     const arg = args[index];
-    if (arg === undefined || (!arg && options.mode !== "command-path")) {
+    if (arg === undefined) {
       break;
     }
     if (!literal && arg === FLAG_TERMINATOR) {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running `openclaw config get gateway.port "" --unknown` would receive the config value and a successful exit instead of an argument error. An empty extra argument silently hid the rest of the invocation from conservative CLI routing.

## Why This Change Was Made

The shared route scanner now preserves empty operands rather than treating them as end-of-input. Existing route arity and option validation then defer malformed invocations to Commander before routed startup or command execution. The same repair covers other routed commands; command-discovery mode already preserved these operands.

Production is **1 line added / 1 removed, net 0**. The obsolete early-termination condition is removed, with no replacement parser, configuration option or compatibility path. Tests are +67/-1 and documentation is +3. Update, Doctor, service, storage and plugin-loading behavior are unchanged.

## User Impact

Malformed invocations fail with exit status 1 and the existing argument diagnostic/help guidance, including errors after an empty operand. Valid number and boolean getters retain their text and JSON output. The config reference now states that exactly one path is accepted, including rejection of empty extra arguments.

## Evidence

- Baseline at `fc7f3c65100a3cd90a9a07a367b28f51a9af7720`: six route-parser and four dispatch regressions failed for the intended reason; existing Commander rejection controls passed. The same parser defect is present in stable `v2026.9.4`.
- Candidate: **137 focused tests passed** across root-option parsing, route parsing/dispatch and registered config getters. The getter filter left 225 unrelated tests unselected. Coverage includes config unset, health and agents-list siblings, root/literal-option behavior, and rejection before routed startup.
- Full changed-file checks and `pnpm build ciArtifacts` passed. Independent managed review reported no actionable P0–P2 findings.
- Ordinary built CLI comparison used nine isolated synthetic cases per accepted phase. Baseline returned `18789`/exit 0 for all four malformed calls. Candidate rejected all four with natural exit 1, the existing `ok:false` / `cli_error` stdout envelope and stderr guidance. Validation and number/false getters with and without `--json` passed in both phases. Config bytes, runtime seals and process cleanup were verified.
- An initial candidate proof attempt incorrectly expected empty stdout without `--json`. Source inspection confirmed that config getters already own machine output; the corrected proof requires the existing failure envelope and human diagnostic together. The failed attempt is retained and excluded from the accepted comparison.

Build and local execution evidence were captured on the reviewed precommit source tree; commit binding is checked separately. Hosted CI remains required before native landing.

CI recovery: the first hosted run failed in untouched New Session tests/exports. Current main repairs those failures in `6f883894311d0b634ab6e3de75b56da838812f72`. The branch was mechanically rebased onto `da762af0e80c9fe6a61422dc5591ab24e5c9a3ce`; `git range-diff` confirms the repair is unchanged, production remains +1/-1, and all 137 focused tests passed again with refreshed frozen dependencies. Original build/CLI observations remain attributed to their original precommit tree; they are not represented as a new-base rerun.

The next hosted run exposed a second untouched UI error (`retainedMachine` TS2304). Main fixed that as well. A second mechanical rebase onto `31848a15205a1aab75165e91c994af851962e0e8` preserves the patch by `git range-diff`; all 137 focused tests passed again. Current head `1f84b75783b911f75a1891ce77b0d67ac2bde858` has green [CI run 34670852347](https://github.com/openclaw/openclaw/actions/runs/34670852347). Original build and live observations remain bound to their original source tree.
