### PR TITLE
fix(msteams): find SDK sign-in handlers through app.oauthHandlers

### DIFF
--- a/extensions/msteams/src/monitor.lifecycle.sso-oauthhandlers.test.ts
+++ b/extensions/msteams/src/monitor.lifecycle.sso-oauthhandlers.test.ts
@@ -18,7 +18,9 @@ const registerMSTeamsHandlers = vi.hoisted(() =>
 const isSigninInvokeAuthorized = vi.hoisted(() => vi.fn(async () => true));
 const isCardActionInvokeAuthorized = vi.hoisted(() => vi.fn(async () => true));
 const runMSTeamsFileConsentInvokeHandler = vi.hoisted(() => vi.fn(async () => {}));
-const loadMSTeamsSdkWithAuth = vi.hoisted(() => vi.fn(async () => ({ app: {} })));
+const loadMSTeamsSdkWithAuth = vi.hoisted(() =>
+  vi.fn(async (_creds?: unknown, _options?: Record<string, unknown>) => ({ app: {} })),
+);
 
 const ssoTokenStore = vi.hoisted(() => ({
   get: vi.fn(async () => null),
@@ -175,7 +177,7 @@ describe("monitorMSTeamsProvider SSO oauthHandlers delegate", () => {
       on: ReturnType<typeof vi.fn>;
     };
     const tokenExchangeHandler = app.on.mock.calls.find(
-      (call: [string, unknown]) => call[0] === "signin.token-exchange",
+      (call: unknown[]) => call[0] === "signin.token-exchange",
     )?.[1];
     if (typeof tokenExchangeHandler !== "function") {
       throw new Error("expected signin token-exchange handler");

--- a/extensions/msteams/src/monitor.lifecycle.sso-oauthhandlers.test.ts
+++ b/extensions/msteams/src/monitor.lifecycle.sso-oauthhandlers.test.ts
@@ -1,0 +1,194 @@
+// Msteams tests cover monitor.lifecycle plugin behavior for the SDK 2.0.x
+// oauthHandlers sign-in delegate shape.
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig, RuntimeEnv } from "../runtime-api.js";
+import type { MSTeamsConversationStore } from "./conversation-store.js";
+import type { MSTeamsActivityHandler } from "./monitor-handler.js";
+import type { MSTeamsMessageHandlerDeps } from "./monitor-handler.types.js";
+import type { MSTeamsPollStore } from "./polls.js";
+
+type RegisterMSTeamsHandlersMock = (
+  handler: MSTeamsActivityHandler,
+  deps: MSTeamsMessageHandlerDeps,
+) => MSTeamsActivityHandler;
+
+const registerMSTeamsHandlers = vi.hoisted(() =>
+  vi.fn<RegisterMSTeamsHandlersMock>((handler) => handler),
+);
+const isSigninInvokeAuthorized = vi.hoisted(() => vi.fn(async () => true));
+const isCardActionInvokeAuthorized = vi.hoisted(() => vi.fn(async () => true));
+const runMSTeamsFileConsentInvokeHandler = vi.hoisted(() => vi.fn(async () => {}));
+const loadMSTeamsSdkWithAuth = vi.hoisted(() => vi.fn(async () => ({ app: {} })));
+
+const ssoTokenStore = vi.hoisted(() => ({
+  get: vi.fn(async () => null),
+  save: vi.fn(async () => {}),
+  remove: vi.fn(async () => false),
+}));
+
+vi.mock("./monitor-handler.js", () => ({
+  isCardActionInvokeAuthorized,
+  isSigninInvokeAuthorized,
+  registerMSTeamsHandlers,
+}));
+
+vi.mock("./file-consent-invoke.js", () => ({
+  runMSTeamsFileConsentInvokeHandler,
+}));
+
+vi.mock("./runtime.js", () => ({
+  getMSTeamsRuntime: () => ({
+    logging: {
+      getChildLogger: () => ({
+        info: vi.fn(),
+        error: vi.fn(),
+        warn: vi.fn(),
+        debug: vi.fn(),
+      }),
+    },
+    channel: {
+      text: {
+        resolveTextChunkLimit: () => 4000,
+      },
+    },
+  }),
+}));
+
+vi.mock("./sso-token-store.js", () => ({
+  createMSTeamsSsoTokenStoreFs: () => ssoTokenStore,
+}));
+
+vi.mock("./sdk.js", () => ({
+  loadMSTeamsSdkWithAuth: (creds?: unknown, options?: Record<string, unknown>) =>
+    loadMSTeamsSdkWithAuth(creds, options),
+  createMSTeamsTokenProvider: () => ({
+    getAccessToken: vi.fn().mockResolvedValue("mock-token"),
+  }),
+  createMSTeamsExpressAdapter: vi.fn(async () => ({
+    registerRoute: vi.fn(),
+    start: vi.fn().mockResolvedValue(undefined),
+    stop: vi.fn().mockResolvedValue(undefined),
+  })),
+}));
+
+// The ingress mock support registers its vi.mock at import time; it must be
+// imported before ./monitor.js pulls in the real msteams-ingress module.
+import { getMSTeamsIngressMockState } from "./monitor-ingress-mock.test-support.js";
+import { monitorMSTeamsProvider } from "./monitor.js";
+
+async function waitForMSTeamsTestState(assertion: () => void | Promise<void>): Promise<void> {
+  await vi.waitFor(assertion, { interval: 1 });
+}
+
+function createConfig(port: number): OpenClawConfig {
+  return {
+    channels: {
+      msteams: {
+        enabled: true,
+        appId: "app-id",
+        appPassword: "app-password", // pragma: allowlist secret
+        tenantId: "tenant-id",
+        webhook: {
+          port,
+          path: "/api/messages",
+        },
+      },
+    },
+  } as OpenClawConfig;
+}
+
+function createRuntime(): RuntimeEnv {
+  return {
+    log: vi.fn(),
+    error: vi.fn(),
+    exit: (code: number): never => {
+      throw new Error(`exit ${code}`);
+    },
+  };
+}
+
+function createStores() {
+  return {
+    conversationStore: {} as MSTeamsConversationStore,
+    pollStore: {} as MSTeamsPollStore,
+  };
+}
+
+describe("monitorMSTeamsProvider SSO oauthHandlers delegate", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+    isSigninInvokeAuthorized.mockReset().mockResolvedValue(true);
+    isCardActionInvokeAuthorized.mockReset().mockResolvedValue(true);
+    runMSTeamsFileConsentInvokeHandler.mockReset().mockResolvedValue(undefined);
+    getMSTeamsIngressMockState().instances.length = 0;
+    ssoTokenStore.get.mockClear();
+    ssoTokenStore.save.mockClear();
+    ssoTokenStore.remove.mockClear();
+  });
+
+  it("reaches the SDK sign-in handlers through app.oauthHandlers (SDK 2.0.x shape)", async () => {
+    const abort = new AbortController();
+    const cfg = createConfig(0);
+    const msteamsCfg = cfg.channels?.msteams;
+    if (!msteamsCfg) {
+      throw new Error("Expected Microsoft Teams config fixture");
+    }
+    cfg.channels!.msteams = { ...msteamsCfg, sso: { enabled: true, connectionName: "graph" } };
+
+    // @microsoft/teams.apps 2.0.x defines these handlers as arrow-function
+    // class fields on OauthHandlers, reached via `app.oauthHandlers` — not on
+    // the App instance itself.
+    const oauthHandlers = {
+      onTokenExchange: vi.fn(async () => ({ status: 200 })),
+      onVerifyState: vi.fn(async () => ({ status: 200 })),
+    };
+    loadMSTeamsSdkWithAuth.mockImplementationOnce(async () => ({
+      app: {
+        on: vi.fn(),
+        event: vi.fn(),
+        oauthHandlers,
+        initialize: vi.fn(async () => {}),
+        tokenManager: {
+          getBotToken: vi.fn(async () => ({ toString: (): string => "bot-token" })),
+          getGraphToken: vi.fn(async () => ({ toString: (): string => "graph-token" })),
+        },
+      },
+    }));
+
+    const task = monitorMSTeamsProvider({
+      cfg,
+      runtime: createRuntime(),
+      abortSignal: abort.signal,
+      conversationStore: createStores().conversationStore,
+      pollStore: createStores().pollStore,
+    });
+
+    await waitForMSTeamsTestState(() => {
+      expect(registerMSTeamsHandlers).toHaveBeenCalled();
+    });
+
+    const sdkResultPromise = loadMSTeamsSdkWithAuth.mock.results[0]?.value;
+    if (!sdkResultPromise) {
+      throw new Error("expected loadMSTeamsSdkWithAuth result");
+    }
+    const app = (await sdkResultPromise).app as {
+      on: ReturnType<typeof vi.fn>;
+    };
+    const tokenExchangeHandler = app.on.mock.calls.find(
+      (call: [string, unknown]) => call[0] === "signin.token-exchange",
+    )?.[1];
+    if (typeof tokenExchangeHandler !== "function") {
+      throw new Error("expected signin token-exchange handler");
+    }
+
+    const exchangeResult = await tokenExchangeHandler({
+      activity: { from: { id: "29:oauth", aadObjectId: "aad-oauth" } },
+    });
+
+    expect(exchangeResult).toEqual({ status: 200 });
+    expect(oauthHandlers.onTokenExchange).toHaveBeenCalledTimes(1);
+
+    abort.abort();
+    await task;
+  });
+});

--- a/extensions/msteams/src/monitor.ts
+++ b/extensions/msteams/src/monitor.ts
@@ -468,12 +468,23 @@ export async function monitorMSTeamsProvider(
     const sdkSigninApp = app as MSTeamsApp & {
       onTokenExchange?: (ctx: unknown) => Promise<unknown>;
       onVerifyState?: (ctx: unknown) => Promise<unknown>;
+      oauthHandlers?: {
+        onTokenExchange?: (ctx: unknown) => Promise<unknown>;
+        onVerifyState?: (ctx: unknown) => Promise<unknown>;
+      };
     };
-    const delegate = sdkSigninApp[delegateName];
+    // @microsoft/teams.apps moved the sign-in handlers from the App instance
+    // onto app.oauthHandlers; accept either placement so a pinned SDK bump
+    // does not silently break the exchange. Both placements bind their own
+    // `this` (arrow-function class fields in 2.0.x), but call the owner we
+    // found the handler on so instance-method shapes keep working too.
+    const owner =
+      sdkSigninApp[delegateName] !== undefined ? sdkSigninApp : sdkSigninApp.oauthHandlers;
+    const delegate = owner?.[delegateName];
     if (typeof delegate !== "function") {
       throw new Error(`Teams SDK ${delegateName} handler is unavailable`);
     }
-    return delegate.call(sdkSigninApp, ctx);
+    return delegate.call(owner, ctx);
   };
 
   // Replace the SDK's default sign-in invoke routes with an authz gate that


### PR DESCRIPTION
## What Problem This Solves

In `@openclaw/msteams` 2026.9.4, every Teams SSO token exchange fails with `Teams SDK onTokenExchange handler is unavailable`. The sign-in invoke handlers are looked up on the SDK `App` instance, but `@microsoft/teams.apps` 2.0.15 (which the plugin pins exactly) defines `onTokenExchange` / `onVerifyState` as arrow-function class fields on the `OauthHandlers` class, reached through `app.oauthHandlers` — the `App` instance no longer exposes them (`dist/app.js` routes them as `this.oauthHandlers.onTokenExchange(ctx)`).

Because `app.onTokenExchange` is `undefined`, the guard throws and every `signin/tokenExchange` invoke fails. Teams abandons the sign-in, no SSO token is ever stored, and the OAuth card is not a workaround since the card only triggers the exchange that is broken. Reported in #145182 with a regression from 2026.7.1 (where the handlers were still on the `App` instance) and logs showing `Sign-in failure: invokeerror`.

## Solution

`handleSdkSigninInvoke` (`extensions/msteams/src/monitor.ts`) now looks the delegate up on the `App` instance first and falls back to `app.oauthHandlers`, then calls the owner the handler was found on. Accepting either placement keeps older pinned SDKs working, and the runtime `typeof delegate === "function"` guard is unchanged, so a missing handler still fails loudly instead of silently.

## Impact

Teams SSO sign-in invokes reach the SDK's real handlers again on the pinned SDK 2.0.15, so a successful exchange stores the delegated token in the SSO token store and downstream consumers get their token.

## Evidence

New regression test `reaches the SDK sign-in handlers through app.oauthHandlers (SDK 2.0.x shape)` (`monitor.lifecycle.sso-oauthhandlers.test.ts`) drives the real `monitorMSTeamsProvider` route registration with an app mock in the exact 2.0.15 shape (handlers only on `app.oauthHandlers`):

- **Pre-fix** (production change reverted, test present): the registered `signin.token-exchange` handler throws `Teams SDK onTokenExchange handler is unavailable` from `monitor.ts:474` — the exact production error from the report.
- **Post-fix**: the full `monitor.lifecycle.test.ts` (18/18) plus the new file pass, with the new test asserting the exchange result `{ status: 200 }` and `oauthHandlers.onTokenExchange` called once; the existing `blocks SDK SSO token exchange before the SDK calls Bot Framework` and `gates SDK SSO invoke routes and persists successful signin events` tests still pass, confirming the authz gate and the App-instance (older SDK) placement are untouched.
- `monitor.test.ts`, `monitor-status.test.ts`, `monitor-handler.*.test.ts`, `sso-token-store.test.ts`, and `oauth.test.ts` pass unchanged (48/48); `tsgo -p tsconfig.extensions.json` and type-aware lint pass on the touched files.

## Revision 2 (review findings)

- Declared the hoisted SDK mock's `_creds` / `_options` parameters (`monitor.lifecycle.sso-oauthhandlers.test.ts`), matching the existing lifecycle fixture, so the delegate wrapper passing `creds, options` no longer trips TS2554 under the extension test typecheck. Pre-fix: `tsgo -p test/tsconfig/tsconfig.extensions.test.json` fails on this file; post-fix: clean.
- Fixed the same file's `app.on.mock.calls.find` callback annotation to `unknown[]` (repo convention, e.g. `src/commands/status.test.ts:90`); the `[string, unknown]` tuple annotation is not assignable under strict function types and also failed the same typecheck.

Closes #145182

🤖 Generated with [Claude Code](https://claude.com/claude-code)
