### PR TITLE
fix(ui): restore environment picker checks

### DIFF
--- a/ui/src/pages/new-session/cloud-target.test.ts
+++ b/ui/src/pages/new-session/cloud-target.test.ts
@@ -2,11 +2,7 @@
 
 import { render } from "lit";
 import { describe, expect, it, vi } from "vitest";
-import {
-  renderSessionMenuItem,
-  renderCloudProfileMenuItems,
-  renderCloudConfiguration,
-} from "./cloud-target.ts";
+import { renderSessionMenuItem, renderCloudProfileMenuItems } from "./cloud-target.ts";
 
 describe("cloud target menu", () => {
   it("renders explicit remediation commands on separate lines", () => {
@@ -157,13 +153,14 @@ describe("cloud target menu", () => {
   ])("renders a single machine as fixed provider configuration", ({ machine, expected }) => {
     const container = document.createElement("div");
     render(
-      renderCloudConfiguration({
-        profile: { id: "aws", providerId: "aws" },
-        operatingSystems: [],
-        machines: [machine],
+      renderCloudProfileMenuItems({
+        profiles: [{ id: "aws", providerId: "aws", machines: [machine] }],
+        selectedId: "aws",
         selectedOs: "",
         selectedMachine: machine.id,
+        compact: true,
         submitting: false,
+        onSelect: vi.fn(),
         onSelectOs: vi.fn(),
         onSelectMachine: vi.fn(),
       }),
@@ -210,43 +207,58 @@ describe("cloud target menu", () => {
     const onSelectMachine = vi.fn();
     const onSelectOs = vi.fn();
     const params = {
-      profile: { id: "aws", providerId: "aws" },
-      operatingSystems: [
-        { id: "linux", label: "Linux" },
-        { id: "macos", label: "macOS" },
+      profiles: [
+        {
+          id: "aws",
+          providerId: "aws",
+          operatingSystems: [
+            { id: "linux", label: "Linux" },
+            { id: "macos", label: "macOS" },
+          ],
+          machines: [
+            { id: "small", label: "Small" },
+            { id: "large", label: "Large" },
+          ],
+        },
       ],
-      machines: [
-        { id: "small", label: "Small" },
-        { id: "large", label: "Large" },
-      ],
+      selectedId: "aws",
       selectedOs: "linux",
       selectedMachine: "small",
+      compact: true,
       submitting: false,
+      onSelect: vi.fn(),
       onSelectMachine,
       onSelectOs,
     };
-    render(renderCloudConfiguration(params), container);
+    render(renderCloudProfileMenuItems(params), container);
     container.querySelector<HTMLButtonElement>('[data-value="machine:large"]')!.click();
     container.querySelector<HTMLButtonElement>('[data-value="os:macos"]')!.click();
     expect(onSelectMachine).toHaveBeenCalledExactlyOnceWith("large");
     expect(onSelectOs).toHaveBeenCalledExactlyOnceWith("macos");
-    render(renderCloudConfiguration({ ...params, submitting: true }), container);
+    render(renderCloudProfileMenuItems({ ...params, submitting: true }), container);
     expect([...container.querySelectorAll("button")].every((button) => button.disabled)).toBe(true);
   });
 
   it("omits unavailable OS choices even when they are the current selection", () => {
     const container = document.createElement("div");
     render(
-      renderCloudConfiguration({
-        profile: { id: "aws", providerId: "aws" },
-        operatingSystems: [
-          { id: "linux", label: "Linux" },
-          { id: "windows", label: "Windows", disabledReason: "Install WSL2" },
+      renderCloudProfileMenuItems({
+        profiles: [
+          {
+            id: "aws",
+            providerId: "aws",
+            operatingSystems: [
+              { id: "linux", label: "Linux" },
+              { id: "windows", label: "Windows", disabledReason: "Install WSL2" },
+            ],
+          },
         ],
-        machines: [],
+        selectedId: "aws",
         selectedOs: "windows",
         selectedMachine: "",
+        compact: true,
         submitting: false,
+        onSelect: vi.fn(),
         onSelectMachine: vi.fn(),
         onSelectOs: vi.fn(),
       }),
@@ -257,7 +269,9 @@ describe("cloud target menu", () => {
     expect(fixedOs?.tagName).toBe("SPAN");
     expect(fixedOs?.hasAttribute("aria-pressed")).toBe(false);
     expect(container.querySelector('[data-value="os:windows"]')).toBeNull();
-    expect(container.querySelector('[aria-pressed="true"]')).toBeNull();
+    expect(
+      container.querySelector('.new-session-page__cloud-configuration [aria-pressed="true"]'),
+    ).toBeNull();
   });
 
   it("disables cloud profiles with the runtime preflight reason", () => {

--- a/ui/src/pages/new-session/cloud-target.ts
+++ b/ui/src/pages/new-session/cloud-target.ts
@@ -238,23 +238,6 @@ export function renderSessionMenuItem(params: SessionMenuItemOptions, submitting
     : row;
 }
 
-export function renderConnectMachineMenuItem(params: { disabled: boolean; onSelect: () => void }) {
-  return html`
-    <div class="session-menu__separator" role="separator"></div>
-    <button
-      type="button"
-      class="session-menu__item new-session-page__connect-machine"
-      data-value="connect-machine"
-      aria-pressed="false"
-      ?disabled=${params.disabled}
-      @click=${params.onSelect}
-    >
-      <span class="session-menu__icon" aria-hidden="true">${icons.link}</span>
-      <span class="session-menu__text">${t("newSession.connectMachine")}</span>
-    </button>
-  `;
-}
-
 export function renderCloudProfileMenuItems(params: {
   profiles: readonly DraftCloudProfile[];
   selectedId: string;
@@ -373,7 +356,7 @@ function machineShapeText(machine: DraftMachineOption): string | undefined {
   return memory ? t("newSession.machineMemory", { memory }) : undefined;
 }
 
-export function renderCloudConfiguration(params: {
+function renderCloudConfiguration(params: {
   profile: DraftCloudProfile;
   suggested?: boolean;
   operatingSystems: readonly DraftOperatingSystem[];

--- a/ui/src/pages/new-session/where-chip.test.ts
+++ b/ui/src/pages/new-session/where-chip.test.ts
@@ -850,39 +850,10 @@ describe("Where chip", () => {
   });
 
   it("omits automatic placement when no devices are paired and Auto is off", () => {
-    const state = resolveWhereChip({
+    const emptyContainer = renderPicker(false, undefined, {
       environments: [],
       cloudProfiles: [],
-      cloudProfileId: "",
-      deviceId: "",
     });
-    const emptyContainer = document.createElement("div");
-    render(
-      renderWhereChip({
-        state,
-        gatewayName: "",
-        environmentQuery: "",
-        onEnvironmentQueryInput: vi.fn(),
-        cloudProfileId: "",
-        deviceId: "",
-        worktreeAvailable: true,
-        submitting: false,
-        pendingPlacement: false,
-        popoverOpen: true,
-        popoverHiding: false,
-        isAdmin: false,
-        onGuardTransition: vi.fn(),
-        onPopoverShow: vi.fn(),
-        onPopoverHide: vi.fn(),
-        onPopoverAfterHide: vi.fn(),
-        onSelectDevice: vi.fn(),
-        onSelectAutoDevice: vi.fn(),
-        onSelectCloudProfile: vi.fn(),
-        onConnectMachine: vi.fn(),
-        onManageCloudWorkers: () => undefined,
-      }),
-      emptyContainer,
-    );
     expect(emptyContainer.querySelector('[data-value="auto-device"]')).toBeNull();
   });
 

--- a/ui/src/styles/new-session.css
+++ b/ui/src/styles/new-session.css
@@ -815,8 +815,7 @@ wa-popover.new-session-page__where-popover::part(body) {
   overflow-y: auto;
 }
 
-.new-session-page__environment-option,
-.new-session-page__connect-machine {
+.new-session-page__environment-option {
   min-height: 28px;
   gap: 8px;
   padding: 3px 8px;
@@ -837,9 +836,7 @@ wa-popover.new-session-page__where-popover::part(body) {
 }
 
 .new-session-page__environment-option .session-menu__icon,
-.new-session-page__connect-machine .session-menu__icon,
-.new-session-page__environment-option .session-menu__icon svg,
-.new-session-page__connect-machine .session-menu__icon svg {
+.new-session-page__environment-option .session-menu__icon svg {
   width: 14px;
   height: 14px;
 }
@@ -851,8 +848,7 @@ wa-popover.new-session-page__where-popover::part(body) {
   font-size: var(--control-ui-text-sm);
 }
 
-.new-session-page__environment-picker > .session-menu__separator,
-.new-session-page__environment-picker > .new-session-page__connect-machine {
+.new-session-page__environment-picker > .session-menu__separator {
   flex-shrink: 0;
 }
 
@@ -870,10 +866,6 @@ wa-popover.new-session-page__where-popover::part(body) {
   stroke-width: 1.7px;
   stroke-linecap: round;
   stroke-linejoin: round;
-}
-
-.new-session-page__connect-machine .session-menu__icon {
-  color: var(--muted);
 }
 
 .connect-machine-dialog {


### PR DESCRIPTION
Related: #145183

## What Problem This Solves

Resolves a problem where environment picker changes made unused-export and file-size checks fail, blocking otherwise unrelated pull requests.

## Why This Change Was Made

Remove the obsolete Connect menu renderer and its unused CSS, and keep cloud configuration rendering private to the profile menu. Its existing tests now exercise that production entry point. Reuse the existing empty-device fixture in the Where picker test to bring the file below its current limit without removing cases or changing assertions.

## User Impact

No visible UI change. The active Connect button, cloud defaults, configuration choices, and submission behavior are preserved.

## Evidence

- All 78 existing cloud-target and Where picker rendering tests pass.
- Required changed checks pass, including UI/core-test types, i18n verification, unused-export scans, lint, and styles.
- Independent Codex review found no actionable P0–P2 findings.
- The previous max-lines failure is visible in [the affected CI job](https://github.com/openclaw/openclaw/actions/runs/34662468172/job/103467785676). The fixture cleanup removes 29 nonblank lines without a suppression or limit change.
