### PR TITLE
fix(gateway): resume suspension leases within their expiry budget

### DIFF
--- a/docs/gateway/external-apps.md
+++ b/docs/gateway/external-apps.md
@@ -243,7 +243,10 @@ With `drain: true`, the same suspension owner instead keeps admission closed
 and cron scheduling paused until existing work settles. Already-owned cron
 completion and reconciliation continue.
 
-Both draining and ready leases last two minutes. Repeat `prepare` before
+Both draining and ready leases share a two-minute budget starting before work
+inspection. Preparation that exhausts that budget resumes scheduling and fails
+instead of returning an expired lease. Clock rollback does not extend the budget.
+Repeat `prepare` before
 `expiresAtMs` with the same `requestId`, terminal policy, and drain mode to renew
 the same `suspensionId` unless a restart handoff is armed; changing any of those values conflicts with the
 existing lease. Use `status` for routine polling and reserve `prepare` for

--- a/src/infra/gateway-suspend-coordinator.test.ts
+++ b/src/infra/gateway-suspend-coordinator.test.ts
@@ -786,28 +786,160 @@ describe("gateway suspend coordinator", () => {
     },
   );
 
-  it.each([false, true])("auto-resumes an abandoned lease at expiry (drain: %s)", (drain) => {
-    vi.useFakeTimers();
+  it.each(
+    [false, true].flatMap((drain) =>
+      [0, SUSPEND_TTL_MS / 2].flatMap((preparationMs) =>
+        [false, true].map((rollbackClock) => ({ drain, preparationMs, rollbackClock })),
+      ),
+    ),
+  )(
+    "auto-resumes at the original expiry (drain: $drain, preparation: $preparationMs ms, clock rollback: $rollbackClock)",
+    ({ drain, preparationMs, rollbackClock }) => {
+      vi.useFakeTimers();
+      try {
+        const resumeScheduling = vi.fn();
+        const expiresAtMs = Date.now() + SUSPEND_TTL_MS;
+        expect(
+          prepareGatewaySuspend({
+            requestId: "request-expiry",
+            drain,
+            pauseScheduling: vi.fn(),
+            resumeScheduling,
+            inspect: inspectors({
+              getQueueSize: () => {
+                vi.advanceTimersByTime(preparationMs);
+                if (rollbackClock) {
+                  vi.setSystemTime(Date.now() - preparationMs);
+                }
+                return Number(drain);
+              },
+            }),
+            createSuspensionId: () => "suspension-expiry",
+          }),
+        ).toMatchObject({ status: drain ? "draining" : "ready", expiresAtMs });
+
+        vi.advanceTimersByTime(SUSPEND_TTL_MS - preparationMs - 1);
+        expect(resumeScheduling).not.toHaveBeenCalled();
+        vi.advanceTimersByTime(1);
+        expect(resumeScheduling).toHaveBeenCalledOnce();
+        expect(isGatewayWorkAdmissionClosed()).toBe(false);
+        expect(getGatewaySuspendStatus("suspension-expiry")).toEqual({ status: "running" });
+      } finally {
+        resetGatewaySuspendCoordinatorForLifecycleRestart();
+        vi.useRealTimers();
+      }
+    },
+  );
+
+  it.each(
+    ["status", "renewal"].flatMap((operation) =>
+      [0, 1].map((remainingWork) => ({ operation, remainingWork })),
+    ),
+  )(
+    "expires after a slow draining inspection (operation: $operation, remaining work: $remainingWork)",
+    ({ operation, remainingWork }) => {
+      vi.useFakeTimers();
+      try {
+        const resumeScheduling = vi.fn();
+        const params = {
+          requestId: "slow-drain-inspection",
+          drain: true,
+          pauseScheduling: vi.fn(),
+          resumeScheduling,
+          inspect: inspectors({
+            getQueueSize: vi
+              .fn()
+              .mockReturnValueOnce(1)
+              .mockImplementation(() => {
+                // Synchronous inspection prevents an expired timer from being delivered.
+                vi.setSystemTime(Date.now() + SUSPEND_TTL_MS);
+                return remainingWork;
+              }),
+          }),
+          createSuspensionId: () => "slow-drain-inspection",
+        };
+        expect(prepareGatewaySuspend(params)).toMatchObject({ status: "draining" });
+        if (operation === "status") {
+          expect(getGatewaySuspendStatus("slow-drain-inspection")).toEqual({ status: "running" });
+        } else {
+          expect(() => prepareGatewaySuspend(params)).toThrow(
+            "gateway suspension changed during preparation",
+          );
+        }
+        expect(resumeScheduling).toHaveBeenCalledOnce();
+        expect(isGatewayWorkAdmissionClosed()).toBe(false);
+      } finally {
+        resetGatewaySuspendCoordinatorForLifecycleRestart();
+        vi.useRealTimers();
+      }
+    },
+  );
+
+  it("automatically resumes a short remaining budget with real timers", async () => {
+    let elapsedInspectionMs = 0;
+    const resumeScheduling = vi.fn();
     try {
-      const resumeScheduling = vi.fn();
-      prepareGatewaySuspend({
-        requestId: "request-expiry",
-        drain,
+      const result = prepareGatewaySuspend({
+        requestId: "real-timer-expiry",
         pauseScheduling: vi.fn(),
         resumeScheduling,
-        inspect: inspectors({ getQueueSize: () => Number(drain) }),
-        createSuspensionId: () => "suspension-expiry",
+        nowMs: () => Date.now() + elapsedInspectionMs,
+        inspect: inspectors({
+          getQueueSize: () => {
+            elapsedInspectionMs = SUSPEND_TTL_MS - 100;
+            return 0;
+          },
+        }),
       });
-
-      vi.advanceTimersByTime(SUSPEND_TTL_MS);
-
-      expect(getGatewaySuspendStatus("suspension-expiry")).toEqual({ status: "running" });
-      expect(resumeScheduling).toHaveBeenCalledOnce();
+      expect(result).toMatchObject({ status: "ready" });
+      expect(isGatewayWorkAdmissionClosed()).toBe(true);
+      await vi.waitFor(() => expect(resumeScheduling).toHaveBeenCalledOnce());
       expect(isGatewayWorkAdmissionClosed()).toBe(false);
     } finally {
-      vi.useRealTimers();
+      resetGatewaySuspendCoordinatorForLifecycleRestart();
     }
   });
+
+  it.each(
+    [false, true].flatMap((drain) =>
+      ["inspection", "lease setup"].map((phase) => ({ drain, phase })),
+    ),
+  )(
+    "resumes instead of returning an already-expired lease (drain: $drain, phase: $phase)",
+    ({ drain, phase }) => {
+      vi.useFakeTimers();
+      try {
+        const resumeScheduling = vi.fn();
+        expect(() =>
+          prepareGatewaySuspend({
+            requestId: "expired-inspection",
+            drain,
+            pauseScheduling: vi.fn(),
+            resumeScheduling,
+            inspect: inspectors({
+              getQueueSize: () => {
+                if (phase === "inspection") {
+                  vi.advanceTimersByTime(SUSPEND_TTL_MS);
+                }
+                return Number(drain);
+              },
+            }),
+            createSuspensionId: () => {
+              if (phase === "lease setup") {
+                vi.advanceTimersByTime(SUSPEND_TTL_MS);
+              }
+              return "expired-inspection";
+            },
+          }),
+        ).toThrow("gateway suspension expired during preparation");
+        expect(resumeScheduling).toHaveBeenCalledOnce();
+        expect(isGatewayWorkAdmissionClosed()).toBe(false);
+        expect(getGatewaySuspendStatus("expired-inspection")).toEqual({ status: "running" });
+      } finally {
+        vi.useRealTimers();
+      }
+    },
+  );
 
   it("ignores an already-queued expiry callback after the same drain lease is renewed", () => {
     vi.useFakeTimers();

--- a/src/infra/gateway-suspend-coordinator.ts
+++ b/src/infra/gateway-suspend-coordinator.ts
@@ -59,6 +59,7 @@ type HeldGatewaySuspension = GatewaySuspendCoordinatorEntryBase & {
   drain: boolean;
   suspensionId: string;
   expiresAtMs: number;
+  deadlineAtMs: number;
   inspect?: Partial<GatewayActiveWorkInspectors>;
   handoff?: GatewaySuspendHandoffOwner;
   phase:
@@ -178,7 +179,7 @@ function scheduleRecoveryRetry(entry: GatewaySuspendCoordinatorEntry): void {
 function normalizeExpiredHeldSuspension(
   held: HeldGatewaySuspension,
 ): GatewaySuspendCoordinatorEntry | null {
-  if (held.nowMs() < held.expiresAtMs) {
+  if (held.nowMs() < held.expiresAtMs && performance.now() < held.deadlineAtMs) {
     return held;
   }
   resumeAndReopen(held);
@@ -225,7 +226,15 @@ function resumeSchedulingBeforeReopen(params: {
 
 function armExpiry(held: Omit<HeldGatewaySuspension, "kind">): HeldGatewaySuspension {
   const entry: HeldGatewaySuspension = { kind: "held", ...held };
-  scheduleEntry(entry, GATEWAY_SUSPEND_TTL_MS, () => {
+  // Inspection consumes the lease budget even if the wall clock moves back.
+  const remainingMs = Math.min(
+    entry.expiresAtMs - entry.nowMs(),
+    entry.deadlineAtMs - performance.now(),
+  );
+  if (remainingMs <= 0) {
+    throw new Error("gateway suspension expired during preparation");
+  }
+  scheduleEntry(entry, Math.ceil(remainingMs), () => {
     if (COORDINATOR_STATE.current === entry) {
       resumeAndReopen(entry);
     }
@@ -235,6 +244,7 @@ function armExpiry(held: Omit<HeldGatewaySuspension, "kind">): HeldGatewaySuspen
 
 function renewHeldSuspension(held: HeldGatewaySuspension, nowMs: number): void {
   held.expiresAtMs = nowMs + GATEWAY_SUSPEND_TTL_MS;
+  held.deadlineAtMs = performance.now() + GATEWAY_SUSPEND_TTL_MS;
   scheduleEntry(held, GATEWAY_SUSPEND_TTL_MS, () => {
     if (COORDINATOR_STATE.current === held) {
       resumeAndReopen(held);
@@ -242,7 +252,9 @@ function renewHeldSuspension(held: HeldGatewaySuspension, nowMs: number): void {
   });
 }
 
-function refreshHeldSuspension(held: HeldGatewaySuspension): HeldGatewaySuspension["phase"] {
+function refreshHeldSuspension(
+  held: HeldGatewaySuspension,
+): HeldGatewaySuspension["phase"] | undefined {
   if (held.phase.status === "ready") {
     return held.phase;
   }
@@ -250,6 +262,9 @@ function refreshHeldSuspension(held: HeldGatewaySuspension): HeldGatewaySuspensi
   const snapshot = createGatewayActiveWorkSnapshot(held.inspect, {
     ignoreTerminalSessions: held.terminalPolicy === "terminate",
   });
+  if (COORDINATOR_STATE.current !== held || normalizeExpiredHeldSuspension(held) !== held) {
+    return undefined;
+  }
   if (!snapshot.idle) {
     held.phase.snapshot = snapshot;
     return held.phase;
@@ -263,7 +278,7 @@ function refreshHeldSuspension(held: HeldGatewaySuspension): HeldGatewaySuspensi
 
 function heldPrepareResult(
   held: HeldGatewaySuspension,
-  phase: HeldGatewaySuspension["phase"] = refreshHeldSuspension(held),
+  phase: HeldGatewaySuspension["phase"],
 ): GatewaySuspendPrepareWireResult {
   const result = {
     suspensionId: held.suspensionId,
@@ -294,6 +309,7 @@ export function prepareGatewaySuspend(params: {
     ignoreTerminalSessions: terminalPolicy === "terminate",
   };
   const nowMs = (params.nowMs ?? Date.now)();
+  const deadlineAtMs = performance.now() + GATEWAY_SUSPEND_TTL_MS;
   const current = COORDINATOR_STATE.current;
   if (current?.kind === "recovering") {
     return schedulerRecoveryResult();
@@ -315,7 +331,14 @@ export function prepareGatewaySuspend(params: {
       existing.nowMs = params.nowMs ?? Date.now;
       renewHeldSuspension(existing, nowMs);
     }
-    return heldPrepareResult(existing);
+    const phase = refreshHeldSuspension(existing);
+    if (!phase) {
+      if (COORDINATOR_STATE.current?.kind === "recovering") {
+        return schedulerRecoveryResult();
+      }
+      throw new Error("gateway suspension changed during preparation");
+    }
+    return heldPrepareResult(existing, phase);
   }
 
   const owner = {};
@@ -349,6 +372,12 @@ export function prepareGatewaySuspend(params: {
     params.pauseScheduling();
     schedulingPaused = true;
     const snapshot = createGatewayActiveWorkSnapshot(params.inspect, activeWorkOptions);
+    if (
+      (params.nowMs ?? Date.now)() >= nowMs + GATEWAY_SUSPEND_TTL_MS ||
+      performance.now() >= deadlineAtMs
+    ) {
+      throw new Error("gateway suspension expired during preparation");
+    }
     if (!snapshot.idle && !drain) {
       const resumed = resumeSchedulingBeforeReopen({
         owner,
@@ -383,6 +412,7 @@ export function prepareGatewaySuspend(params: {
       drain,
       suspensionId,
       expiresAtMs,
+      deadlineAtMs,
       inspect: params.inspect,
       phase: snapshot.idle
         ? { status: "ready", snapshot }
@@ -423,6 +453,7 @@ function handoffRefusal(held: HeldGatewaySuspension, owner: GatewaySuspendHandof
   if (
     COORDINATOR_STATE.current !== held ||
     held.nowMs() >= held.expiresAtMs ||
+    performance.now() >= held.deadlineAtMs ||
     !owner.isCurrent()
   ) {
     return "gateway suspension or host iteration changed";
@@ -494,6 +525,9 @@ export function getGatewaySuspendStatus(suspensionId: string): GatewaySuspendSta
     return { status: "conflict", expiresAtMs: held.expiresAtMs };
   }
   const phase = refreshHeldSuspension(held);
+  if (!phase) {
+    return getGatewaySuspendStatus(suspensionId);
+  }
   if (phase.status === "draining") {
     return {
       status: "draining",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where hosting controllers could see the Gateway remain suspended past the advertised lease expiry when work inspection takes time. A draining status poll or renewal could also return readiness after its inspection consumed the remaining lease budget.

## Why This Change Was Made

The existing synchronous implementation calculated `expiresAtMs` before inspection but started a full two-minute timer afterward. Use the remaining budget for automatic resume, retain an elapsed-time deadline across wall-clock rollback, and check expiry after initial and draining inspections. Expired work follows the existing scheduler-resume and recovery paths.

Public prepare/status return shapes and synchronous inspectors remain unchanged. The two-minute policy, renewal behavior, and configuration surface are unchanged.

## User Impact

The advertised expiry and automatic resume agree even after slow inspection. Controllers receive an expired/changed preparation error or a running/recovering status instead of an already-expired lease.

## Evidence

- The initial regression failed in all four slow-inspection cases on unmodified main.
- The polling/renewal follow-up failed in all four cases before its repair.
- Full coordinator suite: 54 tests passed, including real Node timers with a synthetic short remaining budget, clock rollback, renewal, scheduler recovery, and cleanup.
- Final lease-setup regression: both cases failed before the arming-boundary guard.
- Isolated P2 review completed with no remaining actionable findings.
- Initial CI and local checks found unrelated main UI lint/dead-export failures. This PR is now rebased onto main containing #145415, which repairs those prerequisites; the unchanged expiry patch passed all 54 tests again on the refreshed head.
- Documentation checks passed: 13,472 internal links (0 broken) and 1,229 configuration examples validated.
- Full changed-file gate passed on refreshed commit `4577a2232276`, including all dead-export scans, core/test typechecks, scoped lint, and runtime guards.
