### PR TITLE
refactor: simplify state database admission checks

### DIFF
--- a/src/state/agent-deletion-journal.ts
+++ b/src/state/agent-deletion-journal.ts
@@ -83,38 +83,32 @@ export type AgentDeletionJournalEntry = {
   deleteFiles: boolean;
 };
 
+function readAgentDeletionPathFenceRows(database: OpenClawStateDatabase["db"]) {
+  const db = getNodeSqliteKysely<AgentDeletionDatabase>(database);
+  return executeSqliteQuerySync(
+    database,
+    db
+      .selectFrom("agent_deletion_journal")
+      .select([
+        "agent_id",
+        "operation_id",
+        "agent_dir",
+        "workspace_dir",
+        "sessions_dir",
+        "database_paths_json",
+        "cleanup_paths_json",
+        "cleanup_completed",
+      ]),
+  ).rows;
+}
+
 export function prepareAgentDeletionPathFence(
   claim: { agentId: string; path: string; fenceAgentId?: string },
   options: OpenClawStateDatabaseOptions = {},
 ): AgentDeletionPathFenceSnapshot {
-  let rows: Array<{
-    agent_id: string;
-    operation_id: string;
-    agent_dir: string;
-    workspace_dir: string;
-    sessions_dir: string;
-    database_paths_json: string;
-    cleanup_paths_json: string;
-    cleanup_completed: number;
-  }> = [];
-  runOpenClawStateWriteTransaction((database) => {
+  const rows = runOpenClawStateWriteTransaction((database) => {
     ensureAgentDeletionJournalSchema(database.db);
-    const db = getNodeSqliteKysely<AgentDeletionDatabase>(database.db);
-    rows = executeSqliteQuerySync(
-      database.db,
-      db
-        .selectFrom("agent_deletion_journal")
-        .select([
-          "agent_id",
-          "operation_id",
-          "agent_dir",
-          "workspace_dir",
-          "sessions_dir",
-          "database_paths_json",
-          "cleanup_paths_json",
-          "cleanup_completed",
-        ]),
-    ).rows;
+    return readAgentDeletionPathFenceRows(database.db);
   }, options);
   const env = options.env ?? process.env;
   return {
@@ -158,22 +152,7 @@ export function assertAgentDeletionPathFence(
 ): void {
   const database = state.db;
   ensureAgentDeletionJournalSchema(database);
-  const db = getNodeSqliteKysely<AgentDeletionDatabase>(database);
-  const journalRows = executeSqliteQuerySync(
-    database,
-    db
-      .selectFrom("agent_deletion_journal")
-      .select([
-        "agent_id",
-        "operation_id",
-        "agent_dir",
-        "workspace_dir",
-        "sessions_dir",
-        "database_paths_json",
-        "cleanup_paths_json",
-        "cleanup_completed",
-      ]),
-  ).rows;
+  const journalRows = readAgentDeletionPathFenceRows(database);
   const snapshotJournal = snapshot.entries
     .map((entry) =>
       [

--- a/src/state/openclaw-agent-db.test.ts
+++ b/src/state/openclaw-agent-db.test.ts
@@ -18,15 +18,14 @@ import { readSqliteNumberPragma } from "../infra/sqlite-pragma.test-support.js";
 import { runSqliteImmediateTransactionSync } from "../infra/sqlite-transaction.js";
 import { VERSION } from "../version.js";
 import {
-  assertAgentDeletionPathFence,
   beginAgentDeletionJournal,
   claimCompletedAgentDeletionJournal,
   completeAgentDeletionJournalInDatabase,
-  prepareAgentDeletionPathFence,
   removeAgentDeletionJournal,
   updateAgentDeletionJournalDatabasePaths,
   updateAgentDeletionJournalCleanupPaths,
 } from "./agent-deletion-journal.js";
+import * as agentDeletionJournal from "./agent-deletion-journal.js";
 import { AGENT_MEDIA_SCHEMA_VERSION } from "./openclaw-agent-db-contract.js";
 import {
   assertNoOpenClawAgentDatabaseLeases,
@@ -988,44 +987,109 @@ describe("openclaw agent database", () => {
     removeAgentDeletionJournal(deletion.agentId, deletion.operationId, { env });
   });
 
-  it("rejects a database claim prepared before deletion cleanup completes", () => {
-    const stateDir = createTempStateDir();
-    const env = { OPENCLAW_STATE_DIR: stateDir };
-    const agentDir = path.join(stateDir, "agents", "deleted", "agent");
-    const databasePath = path.join(agentDir, "survivor.sqlite");
-    const deletion = beginAgentDeletionJournal(
-      {
-        operationId: "deletion",
-        deleteFiles: true,
-        agentId: "deleted",
-        agentDir,
-        workspaceDir: path.join(stateDir, "workspace-deleted"),
-        sessionsDir: path.join(stateDir, "sessions-deleted"),
-      },
-      { env },
-    );
-    const fence = prepareAgentDeletionPathFence(
-      { agentId: "survivor", path: databasePath },
-      { env },
-    );
-
-    runOpenClawStateWriteTransaction(
-      (sharedStateDatabase) =>
-        completeAgentDeletionJournalInDatabase(
-          sharedStateDatabase,
-          deletion.agentId,
-          deletion.operationId,
-        ),
-      { env },
-    );
-
-    expect(() =>
-      runOpenClawStateWriteTransaction(
-        (database) => assertAgentDeletionPathFence(database, fence),
-        { env },
-      ),
-    ).toThrow("deletion journal changed");
-  });
+  describe.each(["registration", "lease claim", "lease drain"] as const)(
+    "deletion journal fencing at %s",
+    (caller) => {
+      it.each([
+        {
+          column: "database_paths_json",
+          value: "[1]",
+          afterPrepare: false,
+          error: "Invalid agent deletion database path journal.",
+        },
+        {
+          column: "cleanup_paths_json",
+          value: "[1]",
+          afterPrepare: false,
+          error: "Invalid agent deletion cleanup path journal.",
+        },
+        {
+          column: "operation_id",
+          value: "replacement",
+          afterPrepare: true,
+          error: "deletion journal changed",
+        },
+        {
+          column: "cleanup_completed",
+          value: 1,
+          afterPrepare: true,
+          error: "deletion journal changed",
+        },
+      ])("refuses a changed $column (after preparation: $afterPrepare)", (change) => {
+        const stateDir = createTempStateDir();
+        const env = { OPENCLAW_STATE_DIR: stateDir };
+        const claim = { agentId: "survivor", path: path.join(stateDir, "survivor.sqlite"), env };
+        const leaseId =
+          caller === "lease drain" ? claimOpenClawAgentDatabaseLease(claim) : undefined;
+        const deletion = beginAgentDeletionJournal(
+          {
+            operationId: "deletion",
+            deleteFiles: true,
+            agentId: "deleted",
+            agentDir: path.join(stateDir, "agents", "deleted", "agent"),
+            workspaceDir: path.join(stateDir, "workspace-deleted"),
+            sessionsDir: path.join(stateDir, "sessions-deleted"),
+          },
+          { env },
+        );
+        const { DatabaseSync } = requireNodeSqlite();
+        const writer = new DatabaseSync(resolveOpenClawStateSqlitePath(env));
+        const registrations = writer.prepare(
+          "SELECT * FROM agent_databases ORDER BY agent_id, path",
+        );
+        const leases = writer.prepare("SELECT * FROM agent_database_leases ORDER BY lease_id");
+        const beforeRegistrations = registrations.all();
+        const beforeLeases = leases.all();
+        const mutate = () =>
+          writer
+            .prepare(`UPDATE agent_deletion_journal SET ${change.column} = ? WHERE agent_id = ?`)
+            .run(change.value, deletion.agentId);
+        const prepare = agentDeletionJournal.prepareAgentDeletionPathFence;
+        const preparation = change.afterPrepare
+          ? vi
+              .spyOn(agentDeletionJournal, "prepareAgentDeletionPathFence")
+              .mockImplementationOnce((...args) => {
+                const fence = prepare(...args);
+                // Commit through another connection after preparation releases its transaction.
+                mutate();
+                return fence;
+              })
+          : undefined;
+        try {
+          if (!change.afterPrepare) {
+            mutate();
+          }
+          expect(() => {
+            if (caller === "registration") {
+              registerOpenClawAgentDatabase(claim);
+            } else if (caller === "lease claim") {
+              claimOpenClawAgentDatabaseLease(claim);
+            } else {
+              assertNoOpenClawAgentDatabaseLeases(deletion.agentId, { env });
+            }
+          }).toThrow(change.error);
+          expect(registrations.all()).toEqual(beforeRegistrations);
+          expect(leases.all()).toEqual(beforeLeases);
+          expect(
+            writer
+              .prepare(`SELECT ${change.column} FROM agent_deletion_journal WHERE agent_id = ?`)
+              .get(deletion.agentId),
+          ).toEqual({ [change.column]: change.value });
+        } finally {
+          preparation?.mockRestore();
+          writer.close();
+          if (leaseId) {
+            releaseOpenClawAgentDatabaseLease(leaseId, { env });
+          }
+          removeAgentDeletionJournal(
+            deletion.agentId,
+            change.column === "operation_id" ? "replacement" : deletion.operationId,
+            { env },
+          );
+        }
+      });
+    },
+  );
 
   it("resolves under the per-agent state directory", () => {
     const stateDir = createTempStateDir();

--- a/src/state/openclaw-state-db-maintenance.ts
+++ b/src/state/openclaw-state-db-maintenance.ts
@@ -259,101 +259,20 @@ function assertOpenClawStateDatabaseVersionForMigration(
   });
 }
 
-/** Require every stable v5 table before the v6 additive migration can run. */
-function assertOpenClawStateDatabaseV5ForMigration(
-  database: DatabaseSync,
-  options: { pathname: string },
-): void {
-  assertOpenClawStateDatabaseVersionForMigration(database, { ...options, version: 5 });
-}
-
-/** Require every stable v6 table before the v7 retirement migration can run. */
-function assertOpenClawStateDatabaseV6ForMigration(
-  database: DatabaseSync,
-  options: { pathname: string },
-): void {
-  assertOpenClawStateDatabaseVersionForMigration(database, { ...options, version: 6 });
-}
-
-/** Require every stable v7 table before the v8 placement migration can run. */
-function assertOpenClawStateDatabaseV7ForMigration(
-  database: DatabaseSync,
-  options: { pathname: string },
-): void {
-  assertOpenClawStateDatabaseVersionForMigration(database, { ...options, version: 7 });
-}
-
-/** Require every stable v8 table before the v9 registry migration can run. */
-function assertOpenClawStateDatabaseV8ForMigration(
-  database: DatabaseSync,
-  options: { pathname: string },
-): void {
-  assertOpenClawStateDatabaseVersionForMigration(database, { ...options, version: 8 });
-}
-
-/** Require every stable v9 table before the v10 retirement migration can run. */
-function assertOpenClawStateDatabaseV9ForMigration(
-  database: DatabaseSync,
-  options: { pathname: string },
-): void {
-  assertOpenClawStateDatabaseVersionForMigration(database, { ...options, version: 9 });
-}
-
-/** Require every stable v10 table before the v11 curator retirement can run. */
-function assertOpenClawStateDatabaseV10ForMigration(
-  database: DatabaseSync,
-  options: { pathname: string },
-): void {
-  assertOpenClawStateDatabaseVersionForMigration(database, { ...options, version: 10 });
-}
-
-/** Require every stable v11 table before singleton state folds into the v12 store. */
-function assertOpenClawStateDatabaseV11ForMigration(
-  database: DatabaseSync,
-  options: { pathname: string },
-): void {
-  assertOpenClawStateDatabaseVersionForMigration(database, { ...options, version: 11 });
-}
-
-/** Require every stable v12 table before wide rows become JSON-canonical. */
-function assertOpenClawStateDatabaseV12ForMigration(
-  database: DatabaseSync,
-  options: { pathname: string },
-): void {
-  assertOpenClawStateDatabaseVersionForMigration(database, { ...options, version: 12 });
-}
-
 /** Keep historical migration gates beside their version-specific ownership assertions. */
-export const openClawStateMigrationAssertions = new Map([
-  [5, assertOpenClawStateDatabaseV5ForMigration],
-  [6, assertOpenClawStateDatabaseV6ForMigration],
-  [7, assertOpenClawStateDatabaseV7ForMigration],
-  [8, assertOpenClawStateDatabaseV8ForMigration],
-  [9, assertOpenClawStateDatabaseV9ForMigration],
-  [10, assertOpenClawStateDatabaseV10ForMigration],
-  [11, assertOpenClawStateDatabaseV11ForMigration],
-  [12, assertOpenClawStateDatabaseV12ForMigration],
-  [
-    13,
-    (database: DatabaseSync, options: { pathname: string }) =>
-      assertOpenClawStateDatabaseVersionForMigration(database, { ...options, version: 13 }),
-  ],
-  [
-    14,
-    (database: DatabaseSync, options: { pathname: string }) =>
-      assertOpenClawStateDatabaseVersionForMigration(database, { ...options, version: 14 }),
-  ],
-  [
-    15,
-    (database: DatabaseSync, options: { pathname: string }) =>
-      assertOpenClawStateDatabaseVersionForMigration(database, { ...options, version: 15 }),
-  ],
-  [
-    16,
-    (database: DatabaseSync, options: { pathname: string }) =>
-      assertOpenClawStateDatabaseVersionForMigration(database, { ...options, version: 16 }),
-  ],
-]);
+export const openClawStateMigrationAssertions = new Map<
+  number,
+  (database: DatabaseSync, options: { pathname: string }) => void
+>(
+  ([5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16] as const).map(
+    (version) =>
+      [
+        version,
+        (database: DatabaseSync, options: { pathname: string }) =>
+          assertOpenClawStateDatabaseVersionForMigration(database, { ...options, version }),
+      ] as const,
+  ),
+);
 
 export function markCurrentStateSchemaVersion(
   db: DatabaseSync,

--- a/src/state/openclaw-state-db.test.ts
+++ b/src/state/openclaw-state-db.test.ts
@@ -40,6 +40,8 @@ import {
 } from "./config-machine-state.js";
 import { OPENCLAW_AGENT_SCHEMA_VERSION } from "./openclaw-agent-db-contract.js";
 import { listOpenClawRegisteredAgentDatabases } from "./openclaw-agent-db-registry.js";
+import { assertOpenClawDatabasesReady } from "./openclaw-database-preflight.js";
+import { snapshotPreflightSourceManifest } from "./openclaw-database-preflight.test-support.js";
 import {
   FIRST_USE_STATE_TABLES,
   OPENCLAW_STATE_SCHEMA_VERSION,
@@ -281,7 +283,7 @@ function replaceManagedImageRecordsWithLegacyTable(
 const LEGACY_SESSION_WATCH_SCHEMA_VERSION = 3;
 const LEGACY_AMBIENT_WATCH_PREFIX = "ambient-group-watch:";
 
-function markStateDatabaseVersion(database: DatabaseSync, version: 5 | 6 | 7): void {
+function markStateDatabaseVersion(database: DatabaseSync, version: number): void {
   database.exec(`
     PRAGMA user_version = ${version};
     UPDATE schema_meta SET schema_version = ${version} WHERE meta_key = 'primary';
@@ -5371,34 +5373,61 @@ INSERT INTO macos_port_guardian_records VALUES (4242, 18789, '/usr/bin/ssh', 're
   });
 
   it.each(
-    ([5, 6] as const).flatMap((version) =>
-      (["runtime open", "doctor repair"] as const).map((migrationPath) => ({
+    ([5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16] as const).flatMap((version) =>
+      (["runtime open", "doctor repair", "startup admission"] as const).map((migrationPath) => ({
         migrationPath,
         version,
       })),
     ),
   )(
-    "rejects a missing stable v$version table before the v7 migration through $migrationPath",
-    ({ migrationPath, version }) => {
+    "rejects a missing stable v$version table before migration through $migrationPath",
+    async ({ migrationPath, version }) => {
       const stateDir = createTempStateDir();
       const options = { env: { OPENCLAW_STATE_DIR: stateDir } };
       const databasePath = materializeCurrentStateDatabase(stateDir);
 
       const { DatabaseSync } = requireNodeSqlite();
+      if (migrationPath === "startup admission") {
+        const intact = new DatabaseSync(databasePath);
+        markStateDatabaseVersion(intact, version);
+        intact.close();
+        const before = snapshotPreflightSourceManifest(stateDir);
+        await expect(
+          assertOpenClawDatabasesReady({
+            env: options.env,
+            operation: "gateway-startup",
+            config: {},
+          }),
+        ).resolves.toBeUndefined();
+        expect(snapshotPreflightSourceManifest(stateDir)).toEqual(before);
+      }
       const damaged = new DatabaseSync(databasePath);
       damaged.exec("DROP TABLE apns_registration_tombstones;");
       markStateDatabaseVersion(damaged, version);
+      const schemaBefore = hashSqliteSchema(damaged);
+      const metadataBefore = damaged.prepare("SELECT * FROM schema_meta ORDER BY meta_key").all();
       damaged.close();
 
+      const message = `SQLite schema is incomplete or noncanonical for ${databasePath}: missing table apns_registration_tombstones; run openclaw doctor --fix to repair it.`;
       if (migrationPath === "runtime open") {
-        expect(() => openOpenClawStateDatabase(options)).toThrow(
-          /missing table apns_registration_tombstones/iu,
-        );
-      } else {
+        expect(() => openOpenClawStateDatabase(options)).toThrow(new Error(message));
+      } else if (migrationPath === "doctor repair") {
         expect(repairOpenClawStateDatabaseSchema(options)).toEqual({
           changes: [],
-          warnings: [expect.stringContaining("missing table apns_registration_tombstones")],
+          warnings: [
+            `Failed migrating shared state database schema at ${databasePath}: Error: ${message}`,
+          ],
         });
+      } else {
+        const before = snapshotPreflightSourceManifest(stateDir);
+        await expect(
+          assertOpenClawDatabasesReady({
+            env: options.env,
+            operation: "gateway-startup",
+            config: {},
+          }),
+        ).rejects.toThrow(new Error(message));
+        expect(snapshotPreflightSourceManifest(stateDir)).toEqual(before);
       }
 
       const after = new DatabaseSync(databasePath, { readOnly: true });
@@ -5411,6 +5440,10 @@ INSERT INTO macos_port_guardian_records VALUES (4242, 18789, '/usr/bin/ssh', 're
             .get(),
         ).toBeUndefined();
         expect(readSqliteNumberPragma(after, "user_version")).toBe(version);
+        expect(hashSqliteSchema(after)).toBe(schemaBefore);
+        expect(after.prepare("SELECT * FROM schema_meta ORDER BY meta_key").all()).toEqual(
+          metadataBefore,
+        );
       } finally {
         after.close();
       }


### PR DESCRIPTION
Closes #145474

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

Maintainers need consistent upgrade and deletion checks across State database open, Doctor, startup, registration, and lease workflows. Repeated admission wiring makes those paths harder to maintain together.

## Why This Change Was Made

The same twelve migration versions now share one assertion callback definition. One private reader owns the deletion-journal projection, retaining separate reads during preparation and inside authoritative admission transactions. Schemas, migrations, authority checks, path normalization, and recovery behavior stay unchanged.

## User Impact

No intended user-visible behavior change. The change removes **87 production code lines** and adds **98 test code lines**: **+11 maintained code lines overall**, five fewer physical lines. The tests cover real admission callers.

## Evidence

- [Current-head CI 34670196713](https://github.com/openclaw/openclaw/actions/runs/34670196713) passed: **116 successful jobs, 15 skipped**, including the required `openclaw/ci-gate` and all three UI checks that failed on the preceding base.
- The [current-head published-upgrade job](https://github.com/openclaw/openclaw/actions/runs/34670196713/job/103490115091) passed `openclaw@2026.9.3` / legacy-operator-state / auto-auth in **202 seconds**. Its tested merge `e5e637cb5d57ed2e5f2001a228df2ceacf23711a` contains head `546fce8190cecc667d180eaa8c242cee14d537fa` and base `658ae6189ea97d12cce52d458219b580bdaea7d9`.
- Retained local proof: **471 passed across eight State suites**, five unchanged platform skips; expanded tests also passed against original production. Coverage includes 36 migration refusal cases, 12 deletion-fence cases, 72 original/candidate gate outcomes, eleven unsupported-key lookups, and both transaction-bound journal reads per caller. The selected changed gate and independent P2 review passed.
- Maintainer review accepted source continuity and [ClawSweeper revision 3](https://github.com/openclaw/openclaw/pull/145475#issuecomment-5642470538) at the current head, with no findings or before-merge actions.

Local proof remains bound to `bc21739e1d5e8961277d4775068255fe58f19e3c` and patch SHA-256 `fc42396badd8fc65e01cce994654f11c0f7651ffa0bced88708c396fbe4231c1` (macOS arm64, Node 24.20.0, SQLite 3.53.4). Current head mechanically refreshes that accepted patch onto `7c0dfa5150809b92a9bbc0d32cdc7366b17ac388`. Its stable patch ID is unchanged, both production files remain byte-identical, and the complete tree matches the independently precomputed composition, preserving unrelated main additions. No local test or P2 rerun is claimed.

The [preceding CI failure](https://github.com/openclaw/openclaw/actions/runs/34664315524) and [prior successful upgrade job](https://github.com/openclaw/openclaw/actions/runs/34664315524/job/103473126250) remain retained. The three failures were inherited UI issues repaired upstream in #145415; all now pass on this head.

Proof limits: gate-dispatch fixtures relabel a canonical schema; historical-layout siblings provide separate upgrade coverage. The current upgrade log confirms the actual baseline, tested checkout, candidate package path, selected lane, and success. No survivor summary artifact was retained, so individual schema, package-digest, and PID receipts were not independently inspected. Maintainer review accepted this explicit limit. Error names/messages are preserved; private wrapper stack names change.
