### PR TITLE
improve(ui): reduce startup JavaScript for GitHub publication

### DIFF
--- a/ui/src/lib/sessions/pull-request-state.test.ts
+++ b/ui/src/lib/sessions/pull-request-state.test.ts
@@ -6,7 +6,10 @@ import type { GatewaySessionRow, SessionsListResult } from "../../api/types.ts";
 import type { ApplicationGatewayPhase } from "../../app/gateway.ts";
 import { createTestGatewayClient } from "../../test-helpers/gateway-client.ts";
 import { gatewayHelloForMethods } from "../../test-helpers/gateway-methods.ts";
-import type { GitHubPublicationOptions } from "./github-publication-controller.ts";
+import {
+  GitHubPublicationController,
+  type GitHubPublicationOptions,
+} from "./github-publication-controller.ts";
 import { createTestSessionCapability } from "./session-capability.test-support.ts";
 import type { GitHubPublicationBinding, SessionGateway } from "./session-capability.ts";
 
@@ -169,7 +172,11 @@ function publicationHarness() {
     updatedAt: 1,
   });
   const attach = (session = row("publication")) => {
-    const binding = sessions.githubPublication.attach(session, vi.fn())!;
+    const binding = sessions.githubPublication.attach(
+      session,
+      vi.fn(),
+      GitHubPublicationController,
+    )!;
     binding.sync({
       canWrite: true,
       personalReady: true,

--- a/ui/src/lib/sessions/session-capability.ts
+++ b/ui/src/lib/sessions/session-capability.ts
@@ -27,7 +27,10 @@ import type { AuthenticatedUser } from "../../app/user-profile.ts";
 import type { GatewayConnectionScope } from "../gateway-connection-lifecycle.ts";
 import type { SessionCreateOutcome, SessionCreateParams } from "./create.ts";
 import type { SessionGroupSettings } from "./custom-groups.ts";
-import type { GitHubPublicationPresentationBinding } from "./github-publication-controller.ts";
+import type {
+  GitHubPublicationController,
+  GitHubPublicationPresentationBinding,
+} from "./github-publication-controller.ts";
 import type { SessionArchivedFilter } from "./navigation.ts";
 import type { SessionPatchRoute } from "./patch.ts";
 import type { SessionChangedResult, SessionReconcileOptions } from "./reconcile.ts";
@@ -172,7 +175,12 @@ export type GitHubPublicationBinding = GitHubPublicationPresentationBinding & {
 
 export type SessionCapability = {
   readonly githubPublication: {
-    attach: (row: GatewaySessionRow, changed: () => void) => GitHubPublicationBinding | null;
+    // The lazy presentation supplies code; this session owner keeps operation custody.
+    attach: (
+      row: GatewaySessionRow,
+      changed: () => void,
+      Controller: typeof GitHubPublicationController,
+    ) => GitHubPublicationBinding | null;
   };
   readonly state: SessionState;
   /** Advances only when a canonical sessions.list result is published. */

--- a/ui/src/lib/sessions/session-github-publication.ts
+++ b/ui/src/lib/sessions/session-github-publication.ts
@@ -1,7 +1,7 @@
 import type { GatewaySessionRow, SessionsListResult } from "../../api/types.ts";
 import { t } from "../../i18n/index.ts";
 import { isGatewayMethodAdvertised } from "../gateway-methods.ts";
-import { GitHubPublicationController } from "./github-publication-controller.ts";
+import type { GitHubPublicationController } from "./github-publication-controller.ts";
 import {
   readSessionChangedEvent,
   reconcileSessionChanged,
@@ -95,7 +95,11 @@ export function createSessionGitHubPublication(host: Host) {
     sessions: [row],
   });
   return {
-    attach(row: GatewaySessionRow, changed: () => void): GitHubPublicationBinding | null {
+    attach(
+      row: GatewaySessionRow,
+      changed: () => void,
+      Controller: typeof GitHubPublicationController,
+    ): GitHubPublicationBinding | null {
       const connection = host.connection.capture();
       if (!connection) {
         return null;
@@ -120,7 +124,7 @@ export function createSessionGitHubPublication(host: Host) {
             host.connection.isCurrent(connection) &&
             identity(host.snapshot()) === owner &&
             host.deletionState(candidate.row) !== "confirmed",
-          controller: new GitHubPublicationController({
+          controller: new Controller({
             client: connection.client,
             target: route,
             isCurrent: () => candidate.current(),

--- a/ui/src/pages/chat/chat-pane-render.ts
+++ b/ui/src/pages/chat/chat-pane-render.ts
@@ -20,6 +20,7 @@ import {
   resolveChatPaneObserverRunId,
 } from "../../lib/observer-digest.ts";
 import { hasSessionPresenceViewers } from "../../lib/presence-users.ts";
+import { GitHubPublicationController } from "../../lib/sessions/github-publication-controller.ts";
 import {
   buildAgentMainSessionKey,
   resolveUiConfiguredMainKey,
@@ -293,6 +294,7 @@ export class ChatPane extends ChatPaneLayoutRender {
         this.githubPublication = this.context.sessions.githubPublication.attach(
           publicationRow,
           () => this.requestUpdate(),
+          GitHubPublicationController,
         );
       }
       const publication = this.githubPublication;
@@ -656,9 +658,7 @@ export class ChatPane extends ChatPaneLayoutRender {
       onAgentChange: (agentId) => {
         this.onPaneSessionChange?.(this.paneId, buildAgentMainSessionKey({ agentId }));
       },
-      onSessionSelect: (next) => {
-        this.onPaneSessionChange?.(this.paneId, next);
-      },
+      onSessionSelect: (next) => this.onPaneSessionChange?.(this.paneId, next),
       canvasPluginSurfaceUrl: state.canvasPluginSurfaceUrl,
       boardProvider: board.provider,
       onOpenSidebar: state.handleOpenSidebar,


### PR DESCRIPTION
## What Problem This Solves

Control UI startup exceeded its JavaScript size budget because the session capability eagerly imported the GitHub publication controller, even before a chat presentation needed it.

## Why This Change Was Made

The already-lazy chat presentation now supplies the existing controller constructor. The session owner still creates, retains, and reconciles the controller synchronously, preserving publication state across detach/re-attach, account selection, consent, and recovery. No new asynchronous initialization is introduced.

## User Impact

Initial startup downloads 1,501 fewer gzip bytes of JavaScript. The request count stays at eight, and publication behavior and the existing startup budget remain unchanged.

## Evidence

Measured against [main at ee641013ec25](https://github.com/openclaw/openclaw/commit/ee641013ec25853f96e8894ce5a094a93440835d) with identical Node 24.20.0, Vite 8.2.2, Pako 3.0.1, fixed comparison build identity, and disabled Git metadata lookup:

| Startup JavaScript | Before | After |
| --- | ---: | ---: |
| Gzip bytes | 354,498 | 352,997 |
| Raw bytes | 1,150,769 | 1,145,719 |
| Requests | 8 | 8 |

The unchanged enforcement limit is 354,270 gzip bytes; the result has 1,273 bytes of headroom. Built source maps confirm the controller is absent from the startup bundle.

Validation passed: 73 focused publication/controller/pane tests, 23 synthetic Chromium publication/menu/reconnect scenarios, the final menu/reconnect rerun, UI builds and all 882 finalized compressed sidecars, the full changed-file gate, and fresh isolated Codex review with no actionable findings. The inspected synthetic before/after captures below are byte-identical and show preserved UI appearance.

After a patch-identical rebase onto [main at 47ce03dbc699](https://github.com/openclaw/openclaw/commit/47ce03dbc6994435af783fecf13d5586e7b307f4), the same toolchain measured 353,297 startup gzip bytes with eight requests; all 884 compressed sidecars and the 73 focused tests passed again. The initial hosted run passed its performance check but encountered the unrelated environment-picker issues repaired by #145415. The refreshed head includes that prerequisite.

![Before: synthetic sidebar identity menu](https://github.com/user-attachments/assets/0bee964f-d07b-4e3d-9c89-8b80d36ad3e0)

![After: unchanged synthetic sidebar identity menu](https://github.com/user-attachments/assets/7ab28f14-28e3-4d17-9bb2-4799d039f534)
