### PR TITLE
fix(deps): update nodemailer security overrides

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -130,8 +130,9 @@ overrides:
   form-data: 4.0.6
   werift-ice@0.2.2>ip: npm:neoip@3.1.0
   ip-address: 10.7.0
-  mailauth@5.0.3>nodemailer: 9.1.1
+  mailauth@5.0.3>nodemailer: 10.0.8
   mailauth@5.0.3>undici: 8.10.2
+  mailparser@3.9.20>nodemailer: 10.0.8
   minimatch: 10.2.6
   path-to-regexp: 8.4.2
   qs: 6.16.0
@@ -8190,9 +8191,9 @@ packages:
     resolution: {integrity: sha512-M6Rm/bbG6De/gKGxOpeOobx/dnGuP0dz40adqx38boqHhlWssBJZgLCPBNtb9NkrmnKYiV04xELq+R6PFOnoLA==}
     engines: {node: '>=4.4.0'}
 
-  nodemailer@9.1.1:
-    resolution: {integrity: sha512-izw9mVKFix6YSnC9eLgV6g1opl9DUlRio9ZNcq+Wu9Ujn2UwF+8Nl0B8nz22kEC+CTZCvinkxwJ0DeFbb6NwcQ==}
-    engines: {node: '>=6.0.0'}
+  nodemailer@10.0.8:
+    resolution: {integrity: sha512-uCZ0AtFDI46sHwJ6mhwNuIoA/KiTC0ZCzX7g01941+H9VMIXEiZjtgjQkzoBRTeQba0cIrKfwk31q99PfcIMRw==}
+    engines: {node: '>=20.0.0'}
 
   normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
@@ -15249,7 +15250,7 @@ snapshots:
       ipaddr.js: 2.5.0
       joi: 18.2.3
       libmime: 5.4.1
-      nodemailer: 9.1.1
+      nodemailer: 10.0.8
       punycode.js: 2.3.1
       tldts: 7.4.10
       undici: 8.10.2
@@ -15263,7 +15264,7 @@ snapshots:
       iconv-lite: 0.7.3
       libmime: 5.4.3
       linkify-it: 5.0.2
-      nodemailer: 9.1.1
+      nodemailer: 10.0.8
       punycode.js: 2.3.1
       tlds: 1.261.0
 
@@ -15857,7 +15858,7 @@ snapshots:
 
   node-wav@0.0.2: {}
 
-  nodemailer@9.1.1: {}
+  nodemailer@10.0.8: {}
 
   normalize-path@3.0.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -29,6 +29,8 @@ minimumReleaseAgeExclude:
   # Bot API 10.3 types replace OpenClaw's temporary rich-message bridge.
   - "@grammyjs/types@5.0.0"
   - "grammy@1.46.0"
+  # GHSA-prgh-xp8r-p3m5 / GHSA-v53p-9fqp-m79j security fixes; remove after 2026-09-18.
+  - "nodemailer@10.0.8"
 
 # Isolated installs let pnpm reuse whole-package APFS clones instead of relinking every file.
 nodeLinker: isolated
@@ -62,9 +64,10 @@ overrides:
   form-data: 4.0.6
   "werift-ice@0.2.2>ip": "npm:neoip@3.1.0"
   ip-address: 10.7.0
-  "mailauth@5.0.3>nodemailer": 9.1.1
+  "mailauth@5.0.3>nodemailer": 10.0.8
   # Mailauth pins vulnerable Undici; remove when its direct dependency is fixed.
   "mailauth@5.0.3>undici": 8.10.2
+  "mailparser@3.9.20>nodemailer": 10.0.8
   minimatch: 10.2.6
   path-to-regexp: 8.4.2
   qs: 6.16.0


### PR DESCRIPTION
## Summary

- force `mailauth` and `mailparser` onto patched `nodemailer@10.0.8`
- admit the fresh security release through the dependency cooldown
- remove both HIGH nodemailer advisories from the npm release gate

## Release evidence

The npm preflight for Full Validation run 34647360664 failed on `GHSA-prgh-xp8r-p3m5` and `GHSA-v53p-9fqp-m79j`. Current `main` still resolved `nodemailer@9.1.1` before this change.

## Verification

- `pnpm deps:vuln:gate`
- `pnpm test:extension imap` (53/53)
- `pnpm install --lockfile-only --ignore-scripts` (lockfile unchanged)

`pnpm check:changed` completed all dependency, typecheck, and extension-relevant gates; its final core lint shard stopped only on the unrelated existing `ui/src/pages/new-session/where-chip.test.ts` max-lines violation.