### PR TITLE
fix: keep newer model choices when a page refresh finishes

### DIFF
--- a/ui/src/pages/model-providers/catalog-discovery.ts
+++ b/ui/src/pages/model-providers/catalog-discovery.ts
@@ -19,6 +19,8 @@ type DiscoveryGateway = {
 };
 
 export type CatalogDiscoveryController = {
+  /** Latest picker request, including one that has already settled. */
+  readonly generation: number;
   /** Whether a discovery request is currently in flight. */
   readonly discovering: boolean;
   /** A user-facing retry hint when discovery failed; null while clean. */
@@ -46,8 +48,12 @@ export function createCatalogDiscoveryController(
   let pending: AbortController | null = null;
   let error: string | null = null;
   let requestedDiscovery = false;
+  let generation = 0;
 
   const controller: CatalogDiscoveryController = {
+    get generation() {
+      return generation;
+    },
     get discovering() {
       return pending !== null;
     },
@@ -91,6 +97,7 @@ export function createCatalogDiscoveryController(
       options.getAgentId() === agentId &&
       options.getAgentEpoch() === agentEpoch;
     pending = request;
+    generation += 1;
     error = null;
     requestedDiscovery = true;
     options.requestUpdate();

--- a/ui/src/pages/model-providers/model-providers-page.catalog.test.ts
+++ b/ui/src/pages/model-providers/model-providers-page.catalog.test.ts
@@ -707,12 +707,11 @@ describe("ModelProvidersPage catalog discovery", () => {
   it.each(["completed", "pending"] as const)(
     "keeps newer picker discovery %s when an older core refresh completes",
     async (discoveryState) => {
-      const { context, request, discover, catalogRequest, runtimeConfig } = createCatalogHarness();
+      const { context, request, discover, readPublished, catalogRequest, runtimeConfig } =
+        createCatalogHarness();
       const refreshedConfig = {
-        ...savedModelConfig,
         agents: {
           defaults: {
-            ...savedModelConfig.agents.defaults,
             model: {
               ...savedModelConfig.agents.defaults.model,
               primary: "openai/prepared-utility",
@@ -722,18 +721,29 @@ describe("ModelProvidersPage catalog discovery", () => {
       };
       const coreConfig = deferred<{ config: typeof refreshedConfig; hash: string }>();
       const pickerDiscovery = deferred<ModelCatalogResult>();
+      readPublished.mockReturnValue({
+        ...preparedCatalog,
+        defaultModels: { automaticUtilityModel: "openai/prepared-utility" },
+      });
       const newer: ModelCatalogResult = {
         models: [
           ...preparedCatalog.models,
           { id: "newer", name: "Newer model", provider: "openai", available: true },
         ],
+        defaultModels: { automaticUtilityModel: "openai/newer" },
         providerOutcomes: [{ provider: "openai", status: "ready" }],
       };
-      discover.mockResolvedValueOnce(preparedCatalog).mockReturnValueOnce(pickerDiscovery.promise);
+      discover
+        .mockResolvedValueOnce({
+          ...preparedCatalog,
+          defaultModels: { automaticUtilityModel: "openai/prepared-fallback" },
+        })
+        .mockReturnValueOnce(pickerDiscovery.promise);
       const page = appendPage(context);
       try {
         await waitForFast(() => expect(page.data?.config).toEqual(savedModelConfig));
         await drainPageUpdates(page);
+        expect(page.data?.automaticUtilityModel).toBe("openai/prepared-utility");
         let configRequested = false;
         request.mockImplementation((method: string, params?: { refresh?: boolean }) => {
           if (method === "config.get") {
@@ -765,6 +775,12 @@ describe("ModelProvidersPage catalog discovery", () => {
         coreConfig.resolve({ config: refreshedConfig, hash: "refreshed-model-config" });
         await waitForFast(() => expect(page.data?.config).toEqual(refreshedConfig));
         await drainPageUpdates(page);
+        expect(page.data?.automaticUtilityModel).toBe(
+          discoveryState === "completed" ? "openai/newer" : "openai/prepared-utility",
+        );
+        expect(
+          page.querySelector("#model-providers-utility-model .picker-select__label")?.textContent,
+        ).toBe(discoveryState === "completed" ? "Auto · Newer model" : "Auto · Prepared utility");
         expect(
           modelPickers(page)[0]
             ?.querySelector('[role="option"][aria-selected="true"]')
@@ -779,6 +795,10 @@ describe("ModelProvidersPage catalog discovery", () => {
           await drainPageUpdates(page);
         }
         expect(page.querySelector('[role="option"][data-value="openai/newer"]')).not.toBeNull();
+        expect(page.data?.automaticUtilityModel).toBe("openai/newer");
+        expect(
+          page.querySelector("#model-providers-utility-model .picker-select__label")?.textContent,
+        ).toBe("Auto · Newer model");
         expect(page.data?.providerOutcomes).toEqual(newer.providerOutcomes);
         expect(page.querySelector(".model-providers__catalog-progress")).toBeNull();
         expect(runtimeConfig.patch).not.toHaveBeenCalled();

--- a/ui/src/pages/model-providers/model-providers-page.catalog.test.ts
+++ b/ui/src/pages/model-providers/model-providers-page.catalog.test.ts
@@ -704,6 +704,92 @@ describe("ModelProvidersPage catalog discovery", () => {
     },
   );
 
+  it.each(["completed", "pending"] as const)(
+    "keeps newer picker discovery %s when an older core refresh completes",
+    async (discoveryState) => {
+      const { context, request, discover, catalogRequest, runtimeConfig } = createCatalogHarness();
+      const refreshedConfig = {
+        ...savedModelConfig,
+        agents: {
+          defaults: {
+            ...savedModelConfig.agents.defaults,
+            model: {
+              ...savedModelConfig.agents.defaults.model,
+              primary: "openai/prepared-utility",
+            },
+          },
+        },
+      };
+      const coreConfig = deferred<{ config: typeof refreshedConfig; hash: string }>();
+      const pickerDiscovery = deferred<ModelCatalogResult>();
+      const newer: ModelCatalogResult = {
+        models: [
+          ...preparedCatalog.models,
+          { id: "newer", name: "Newer model", provider: "openai", available: true },
+        ],
+        providerOutcomes: [{ provider: "openai", status: "ready" }],
+      };
+      discover.mockResolvedValueOnce(preparedCatalog).mockReturnValueOnce(pickerDiscovery.promise);
+      const page = appendPage(context);
+      try {
+        await waitForFast(() => expect(page.data?.config).toEqual(savedModelConfig));
+        await drainPageUpdates(page);
+        let configRequested = false;
+        request.mockImplementation((method: string, params?: { refresh?: boolean }) => {
+          if (method === "config.get") {
+            configRequested = true;
+            return coreConfig.promise;
+          }
+          return catalogRequest(method, params);
+        });
+
+        page.querySelector<HTMLButtonElement>('button[aria-label="Refresh"]')!.click();
+        await waitForFast(() => {
+          expect(configRequested).toBe(true);
+          expect(discover).toHaveBeenCalledOnce();
+        });
+        await drainPageUpdates(page);
+        expect(
+          modelPickers(page)[0]?.querySelector<HTMLButtonElement>(".picker-select__trigger")
+            ?.disabled,
+        ).toBe(false);
+        await openModelPicker(page);
+        expect(discover).toHaveBeenCalledTimes(2);
+        if (discoveryState === "completed") {
+          pickerDiscovery.resolve(newer);
+          await waitForFast(() => expect(page.data?.models).toEqual(newer.models));
+          await drainPageUpdates(page);
+          expect(page.querySelector('[role="option"][data-value="openai/newer"]')).not.toBeNull();
+        }
+
+        coreConfig.resolve({ config: refreshedConfig, hash: "refreshed-model-config" });
+        await waitForFast(() => expect(page.data?.config).toEqual(refreshedConfig));
+        await drainPageUpdates(page);
+        expect(
+          modelPickers(page)[0]
+            ?.querySelector('[role="option"][aria-selected="true"]')
+            ?.getAttribute("data-value"),
+        ).toBe("openai/prepared-utility");
+        if (discoveryState === "pending") {
+          expect(
+            page.querySelector('.model-providers__catalog-progress[role="status"]'),
+          ).not.toBeNull();
+          pickerDiscovery.resolve(newer);
+          await waitForFast(() => expect(page.data?.models).toEqual(newer.models));
+          await drainPageUpdates(page);
+        }
+        expect(page.querySelector('[role="option"][data-value="openai/newer"]')).not.toBeNull();
+        expect(page.data?.providerOutcomes).toEqual(newer.providerOutcomes);
+        expect(page.querySelector(".model-providers__catalog-progress")).toBeNull();
+        expect(runtimeConfig.patch).not.toHaveBeenCalled();
+      } finally {
+        coreConfig.resolve({ config: refreshedConfig, hash: "refreshed-model-config" });
+        pickerDiscovery.resolve(newer);
+        page.remove();
+      }
+    },
+  );
+
   it.each([
     { replacement: "core refresh", catalogRequests: 3, discoveries: 3, publicationReads: 1 },
     { replacement: "route data", catalogRequests: 2, discoveries: 2, publicationReads: 1 },

--- a/ui/src/pages/model-providers/model-providers-page.ts
+++ b/ui/src/pages/model-providers/model-providers-page.ts
@@ -105,6 +105,7 @@ export class ModelProvidersPage extends OpenClawLightDomElement {
           ? {
               ...data,
               models: current.models,
+              automaticUtilityModel: current.automaticUtilityModel,
               providerOutcomes: current.providerOutcomes,
               catalogError: current.catalogError,
             }
@@ -613,10 +614,9 @@ export class ModelProvidersPage extends OpenClawLightDomElement {
       asConfigRecord(runtimeState.configForm ?? runtimeState.configSnapshot?.config) ??
       asConfigRecord(data.config) ??
       {};
-    const agentsDefaults = asConfigRecord(asConfigRecord(configObject.agents)?.defaults);
     const configuredDefaults = {
       ...config.defaults,
-      ...readModelBehaviorConfig(agentsDefaults),
+      ...readModelBehaviorConfig(asConfigRecord(asConfigRecord(configObject.agents)?.defaults)),
     };
     const defaults = this.defaultsDraft ?? configuredDefaults;
     const stageDefaults = (patch: Partial<DefaultsDraft>) => {

--- a/ui/src/pages/model-providers/model-providers-page.ts
+++ b/ui/src/pages/model-providers/model-providers-page.ts
@@ -84,9 +84,11 @@ export class ModelProvidersPage extends OpenClawLightDomElement {
   // Global config writes survive agent switches; their card state does not.
   private agentEpoch = 0;
   private probeEpochs = new Map<string, number>();
+  private coreCatalogGeneration = 0;
   private readonly core = new ModelProviderCoreLoader(this, {
     onStart: (reason) => {
       this.catalogDiscovery.reset({ preserveHistory: reason === "publication" });
+      this.coreCatalogGeneration = this.catalogDiscovery.generation;
       this.supplemental.beginCoreRefresh(reason === "forced");
       if (reason === "forced") {
         this.querySelectorAll<ModelAccountUsage>("openclaw-model-account-usage").forEach(
@@ -94,9 +96,20 @@ export class ModelProvidersPage extends OpenClawLightDomElement {
         );
       }
     },
-    onComplete: ({ client, data, reason }) => {
-      this.catalogDiscovery.reset({ preserveHistory: reason === "publication" });
-      this.supplemental.adoptCoreData(client, data);
+    onComplete: ({ client, data }) => {
+      const current = this.data;
+      // Pickers remain usable during core loading, so their newer catalog owns the view.
+      this.supplemental.adoptCoreData(
+        client,
+        current && this.catalogDiscovery.generation !== this.coreCatalogGeneration
+          ? {
+              ...data,
+              models: current.models,
+              providerOutcomes: current.providerOutcomes,
+              catalogError: current.catalogError,
+            }
+          : data,
+      );
     },
     refreshPublication: () => void this.refresh("publication"),
   });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users opening a model picker during a refresh in **Settings → Models** could lose newly discovered choices, see discovery stop, or see the **Auto** utility model revert when the older page refresh finished.

## Why This Change Was Made

The page respects the newer picker request when it applies a refresh. Model choices, the resolved Auto utility model, progress, and catalog errors stay with that request while the refresh updates provider and configuration data. A later page refresh continues to retire older picker work.

## User Impact

Model pickers remain usable during refresh. New choices and the Auto model stay consistent, pending discovery can finish, and refreshed default-model selections still appear.

## Evidence

The completed and pending ordering regressions distinguish the initial, older refresh, and newer discovery results. Both fail without preserving the automatic utility value and pass with the fix. All **166 tests across seven related suites** pass, including publication, inverse ordering, current Auto labels, and other default-model controls. UI types, all 17 core-test type graphs, lint, formatting, and the final canonical changed-file checks pass.

Real Chromium proof uses a synthetic Gateway and the actual Refresh button and picker on current main. The refreshed primary selection appears in both versions. The repaired version preserves the correct Auto value and newer catalog or pending progress, then adopts the pending discovery when it completes. Both runs finish without page errors or configuration writes; final source and index bytes are restored after baseline capture.

| Newer discovery when the older refresh finishes | Before | After |
| --- | --- | --- |
| Already completed | ![Auto reverts to the stale fallback](https://github.com/user-attachments/assets/99468255-29f4-4608-a89b-6f31ff099088) | ![Auto keeps the newer discovered model](https://github.com/user-attachments/assets/3d7d13b7-b9e7-4e80-aa3e-44a6675a42fa) |
| Still pending | ![Auto reverts and discovery progress disappears](https://github.com/user-attachments/assets/99468255-29f4-4608-a89b-6f31ff099088) | ![Auto and discovery progress remain current](https://github.com/user-attachments/assets/df4183b4-c1ac-4325-9b3c-005dc8db414a) |

The two baseline states produce byte-identical screenshots, so they share one image above. Independent P2 review found no actionable findings. Browser proof uses a synthetic Gateway; no live provider or operator Gateway is exercised.
