### PR TITLE
fix(ci): review sandbox composition scan finding

### DIFF
--- a/scripts/lib/plugin-npm-security-scan.mts
+++ b/scripts/lib/plugin-npm-security-scan.mts
@@ -176,6 +176,10 @@ CURRENT_OPTIONAL_REVIEWED_PACKED_FINDING_COUNTS.set(
   "@openclaw/codex:dangerous-exec:src/doctor.test.ts",
   1,
 );
+CURRENT_OPTIONAL_REVIEWED_PACKED_FINDING_COUNTS.set(
+  "@openclaw/codex:dangerous-exec:src/app-server/sandbox-exec-server.fs-bridge-composition.test.ts",
+  1,
+);
 
 const CURRENT_SECURITY_INVENTORY_POLICY: PluginSecurityInventoryPolicy = {
   layout: CURRENT_REVIEWED_RELEASE_LAYOUT,

--- a/test/scripts/plugin-npm-security-scan.test.ts
+++ b/test/scripts/plugin-npm-security-scan.test.ts
@@ -499,6 +499,32 @@ describe("scripts/lib/plugin-npm-security-scan.mts", () => {
     },
   );
 
+  it("reviews the inert sandbox composition fixture only for current packages", async () => {
+    const packageName = "@openclaw/codex";
+    const fixturePath = "src/app-server/sandbox-exec-server.fs-bridge-composition.test.ts";
+    const fixtureKey = `${packageName}:dangerous-exec:${fixturePath}`;
+    const artifact = writePluginArtifact({
+      extensionId: "codex",
+      packageName,
+      files: {
+        [fixturePath]:
+          'import { spawn } from "node:child_process";\nspawn("sh", ["-c", "printf ok"]);\n',
+      },
+    });
+
+    const current = await scanPublishablePluginPackages([artifact.artifact]);
+    expect(current.scanErrors).toEqual([]);
+    expect(current.packageResults[0]?.reviewedCriticalFindings).toEqual([fixtureKey]);
+    expect(current.packageResults[0]?.unexpectedCriticalFindings).toEqual([]);
+
+    const frozen = await scanPublishablePluginPackages([artifact.artifact], "release/2026.9.3");
+    expect(frozen.scanErrors).toEqual([]);
+    expect(frozen.packageResults[0]?.reviewedCriticalFindings).toEqual([]);
+    expect(frozen.packageResults[0]?.unexpectedCriticalFindings).toMatchObject([
+      { path: fixturePath, ruleId: "dangerous-exec" },
+    ]);
+  });
+
   it.each([1, 2])(
     "reviews exactly one current hardware probe, preserving frozen policy: %s",
     async (count) => {


### PR DESCRIPTION
## Summary

- admit the Codex sandbox composition test fixture as one reviewed current-package finding
- keep the allowance out of frozen release inventories
- prove current packages accept exactly the inert fixture while frozen `2026.9.3` packages still reject it

## Release evidence

Full Validation run 34647360664 failed plugin npm security scan on `extensions/codex/src/app-server/sandbox-exec-server.fs-bridge-composition.test.ts`. The test intentionally launches a local `sh -c` child to verify exact sandbox shell composition; the scanner policy had not been updated when that fixture was added.

## Verification

- `pnpm exec vitest run test/scripts/plugin-npm-security-scan.test.ts` (30/30)
- `OPENCLAW_CHECK_CHANGED_SKIP_DEADCODE=1 pnpm check:changed`

The unskipped dead-export scan is independently red on current `main` for unused Control UI exports outside this change.