### PR TITLE
fix(workers): reduce startup delay for prepared GitHub repositories

### DIFF
--- a/src/gateway/control-ui-github-api.test.ts
+++ b/src/gateway/control-ui-github-api.test.ts
@@ -7,6 +7,7 @@ import {
   fetchGitHubApi,
   fetchGitHubJson,
   formatControlUiGitHubPreviewError,
+  readGitHubGraphQLResponse,
   readGitHubJsonResponse,
 } from "./control-ui-github-api.js";
 
@@ -110,15 +111,22 @@ describe("Control UI GitHub failures", () => {
       sibling: "/search/code?q=second",
       independent: "/search/repositories",
     },
+    ...[403, 200].map((status) => ({
+      resource: "graphql",
+      limited: "/graphql",
+      sibling: "/graphql",
+      independent: "/repos/owner/repo",
+      status,
+    })),
   ])(
     "shares $resource quota cooldown without blocking other buckets or credentials",
-    async ({ resource, limited, sibling, independent }) => {
+    async ({ resource, limited, sibling, independent, ...options }) => {
       const clock = vi.spyOn(Date, "now").mockReturnValue(1_800_000_000_000);
       const fetchMock = vi
         .fn<typeof fetch>()
         .mockResolvedValueOnce(
-          new Response(null, {
-            status: 403,
+          new Response(JSON.stringify({ errors: [{ type: "RATE_LIMITED" }] }), {
+            status: "status" in options ? options.status : 403,
             headers: {
               "x-ratelimit-resource": resource,
               "x-ratelimit-remaining": "0",
@@ -127,10 +135,21 @@ describe("Control UI GitHub failures", () => {
           }),
         )
         .mockImplementation(async () => new Response("{}"));
-      const request = async (path: string, token = "quota-token") =>
-        readGitHubJsonResponse(
-          await fetchGitHubApi(`https://api.github.com${path}`, fetchMock, token),
+      const request = async (path: string, token = "quota-token") => {
+        const response = await fetchGitHubApi(
+          `https://api.github.com${path}`,
+          fetchMock,
+          token,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          path === "/graphql" ? { query: "query { viewer { login } }", variables: {} } : undefined,
         );
+        return path === "/graphql"
+          ? readGitHubGraphQLResponse(response, fetchMock, token)
+          : readGitHubJsonResponse(response);
+      };
       await expect(request(limited)).rejects.toMatchObject({
         statusCode: 429,
         retryAfterMs: 90_000,
@@ -175,11 +194,49 @@ describe("Control UI GitHub failures", () => {
         fetchGitHubJson("https://api.github.com/user/1", fetchMock),
       ).rejects.toMatchObject({ statusCode: 429 });
       expect(fetchMock).toHaveBeenCalledOnce();
+      await expect(
+        fetchGitHubApi("https://api.github.com/graphql", fetchMock, undefined),
+      ).rejects.toMatchObject({ statusCode: 429 });
+      expect(fetchMock).toHaveBeenCalledOnce();
       clock.mockReturnValue(1_800_000_000_000 + delay);
       await expect(
         fetchGitHubJson("https://api.github.com/user/1", fetchMock),
       ).rejects.toMatchObject({ statusCode: 429 });
       expect(fetchMock).toHaveBeenCalledTimes(2);
+    },
+  );
+
+  it.each([undefined, "42"])(
+    "retains a GraphQL HTTP 403 quota error with remaining=%s across REST reads",
+    async (remaining) => {
+      vi.spyOn(Date, "now").mockReturnValue(1_800_000_000_000);
+      const fetchMock = vi.fn<typeof fetch>(
+        async () =>
+          new Response(
+            JSON.stringify({ errors: [{ type: "RATE_LIMITED", message: "private-diagnostic" }] }),
+            { status: 403, headers: remaining ? { "x-ratelimit-remaining": remaining } : {} },
+          ),
+      );
+      const response = await fetchGitHubApi(
+        "https://api.github.com/graphql",
+        fetchMock,
+        "quota-token",
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        { query: "query { viewer { login } }", variables: {} },
+      );
+      await expect(
+        readGitHubGraphQLResponse(response, fetchMock, "quota-token"),
+      ).rejects.toMatchObject({
+        statusCode: 429,
+        retryAfterMs: 60_000,
+      });
+      await expect(
+        fetchGitHubApi("https://api.github.com/repos/owner/repo", fetchMock, "quota-token"),
+      ).rejects.toMatchObject({ statusCode: 429 });
+      expect(fetchMock).toHaveBeenCalledOnce();
     },
   );
 

--- a/src/gateway/control-ui-github-api.ts
+++ b/src/gateway/control-ui-github-api.ts
@@ -1,5 +1,6 @@
 import { createHash } from "node:crypto";
 import { parseStrictNonNegativeInteger } from "@openclaw/normalization-core/number-coercion";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { getRuntimeConfigSnapshot } from "../config/runtime-snapshot.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { readResponseWithLimit } from "../infra/http-body.js";
@@ -55,6 +56,15 @@ export class ControlUiGitHubError extends Error {
 class ControlUiGitHubTransportError extends ControlUiGitHubError {
   constructor(message: string) {
     super(502, message, { retryable: true });
+  }
+}
+
+export class GitHubGraphQLUnavailableError extends ControlUiGitHubError {
+  constructor(upstreamStatus: number) {
+    super(403, "GitHub GraphQL access is unavailable for the selected credential", {
+      upstreamStatus,
+      retryable: false,
+    });
   }
 }
 
@@ -167,12 +177,37 @@ export function githubApiCredentialCacheScope(token: string | undefined): string
 }
 
 function githubApiResource(url: URL): string {
-  // GitHub separates code search, other REST searches, and non-search REST.
-  return url.pathname === "/search/code"
-    ? "code_search"
-    : url.pathname.startsWith("/search/")
-      ? "search"
-      : "core";
+  // GitHub separates GraphQL, code search, other searches, and non-search REST.
+  return url.pathname === "/graphql"
+    ? "graphql"
+    : url.pathname === "/search/code"
+      ? "code_search"
+      : url.pathname.startsWith("/search/")
+        ? "search"
+        : "core";
+}
+
+function retainGitHubCooldown(
+  fetchImpl: typeof fetch,
+  credentialScope: string,
+  resource: string,
+  response: Response,
+  error: ControlUiGitHubError,
+): ControlUiGitHubError {
+  const cooldowns = transportCooldowns.get(fetchImpl) ?? new Map<string, ControlUiGitHubError>();
+  transportCooldowns.set(fetchImpl, cooldowns);
+  // Exhausted primary quota is resource-specific; secondary limits can span APIs.
+  const resourceKey =
+    response.headers.get("x-ratelimit-remaining") === "0"
+      ? (response.headers.get("x-ratelimit-resource") ?? resource)
+      : "*";
+  const key = `${credentialScope}:${resourceKey}`;
+  const previous = activeGitHubCooldown(cooldowns, key);
+  const retained =
+    previous && (previous.retryAfterMs ?? 0) > (error.retryAfterMs ?? 0) ? previous : error;
+  cooldowns.set(key, retained);
+  pruneMapToMaxSize(cooldowns, GITHUB_QUOTA_CACHE_LIMIT);
+  return retained;
 }
 
 function activeGitHubCooldown(
@@ -223,11 +258,15 @@ export async function fetchGitHubApi(
   identity?: { revalidate: () => Promise<void>; assertSelected: () => void },
   etag?: string,
   callerSignal?: AbortSignal,
+  graphql?: { query: string; variables: Record<string, string> },
 ): Promise<Response> {
   callerSignal?.throwIfAborted();
   const initialUrl = safeGitHubApiUrl(rawUrl);
   if (!initialUrl) {
     throw new ControlUiGitHubError(502, "Invalid GitHub API URL");
+  }
+  if (graphql && (initialUrl.href !== `${GITHUB_API_ORIGIN}/graphql` || !token || etag)) {
+    throw new ControlUiGitHubError(502, "Invalid authenticated GitHub GraphQL request");
   }
   let url: URL = initialUrl;
   const credentialScope = githubApiCredentialCacheScope(token);
@@ -257,7 +296,12 @@ export async function fetchGitHubApi(
     let response: Response;
     try {
       response = await fetchImpl(url.href, {
-        headers: { ...githubApiHeaders(token), ...(etag ? { "If-None-Match": etag } : {}) },
+        headers: {
+          ...githubApiHeaders(token),
+          ...(etag ? { "If-None-Match": etag } : {}),
+          ...(graphql ? { "Content-Type": "application/json" } : {}),
+        },
+        ...(graphql ? { method: "POST", body: JSON.stringify(graphql) } : {}),
         redirect: "manual",
         signal,
       });
@@ -268,19 +312,13 @@ export async function fetchGitHubApi(
       );
     }
     if (isGitHubRateLimitResponse(response)) {
-      const error = githubResponseError(response);
-      // Exhausted primary quota is resource-specific. Secondary limits can
-      // span REST resources, so a rate limit without that signal pauses all.
-      const resourceKey =
-        response.headers.get("x-ratelimit-remaining") === "0"
-          ? (response.headers.get("x-ratelimit-resource") ?? resource)
-          : "*";
-      const key = `${credentialScope}:${resourceKey}`;
-      const previous = activeGitHubCooldown(cooldowns, key);
-      const retained =
-        previous && (previous.retryAfterMs ?? 0) > (error.retryAfterMs ?? 0) ? previous : error;
-      cooldowns.set(key, retained);
-      pruneMapToMaxSize(cooldowns, GITHUB_QUOTA_CACHE_LIMIT);
+      const retained = retainGitHubCooldown(
+        fetchImpl,
+        credentialScope,
+        resource,
+        response,
+        githubResponseError(response),
+      );
       await discardResponse(response);
       throw retained;
     }
@@ -298,6 +336,9 @@ export async function fetchGitHubApi(
     // callers still verify the final response repository before returning it.
     await discardResponse(response);
     await beforeRedirect?.(nextUrl);
+    if (graphql) {
+      throw new ControlUiGitHubError(502, "GitHub GraphQL returned an unexpected redirect");
+    }
     url = nextUrl;
   }
 }
@@ -339,8 +380,8 @@ function githubResponseErrorStatus(response: Response): number {
   return 502;
 }
 
-function githubResponseError(response: Response): ControlUiGitHubError {
-  const status = githubResponseErrorStatus(response);
+function githubResponseError(response: Response, graphqlRateLimited = false): ControlUiGitHubError {
+  const status = graphqlRateLimited ? 429 : githubResponseErrorStatus(response);
   let retryAtMs: number | undefined;
   if (status === 429) {
     const now = Date.now();
@@ -365,6 +406,72 @@ function githubResponseError(response: Response): ControlUiGitHubError {
     upstreamStatus: response.status,
     retryAtMs,
   });
+}
+
+/** GraphQL can report failed queries and exhausted quota in an HTTP 200 response. */
+export async function readGitHubGraphQLResponse(
+  response: Response,
+  fetchImpl: typeof fetch,
+  token: string,
+  maxBytes?: number,
+): Promise<unknown> {
+  const value =
+    response.status === 403 && !isGitHubRateLimitResponse(response)
+      ? await readGitHubJsonBody(response, maxBytes)
+      : await readGitHubJsonResponse(response, maxBytes);
+  const noData =
+    isRecord(value) &&
+    (value.data === undefined ||
+      value.data === null ||
+      (isRecord(value.data) && Object.values(value.data).every((field) => field === null)));
+  if (isRecord(value) && value.errors !== undefined) {
+    if (
+      Array.isArray(value.errors) &&
+      value.errors.some((error) => isRecord(error) && error.type === "RATE_LIMITED")
+    ) {
+      throw retainGitHubCooldown(
+        fetchImpl,
+        githubApiCredentialCacheScope(token),
+        "graphql",
+        response,
+        githubResponseError(response, true),
+      );
+    }
+    if (
+      Array.isArray(value.errors) &&
+      value.errors.length > 0 &&
+      value.errors.every(
+        (error) =>
+          isRecord(error) && (error.type === "FORBIDDEN" || error.type === "INSUFFICIENT_SCOPES"),
+      ) &&
+      noData
+    ) {
+      throw new GitHubGraphQLUnavailableError(response.status);
+    }
+    if (!Array.isArray(value.errors) || value.errors.length > 0) {
+      throw new ControlUiGitHubError(
+        502,
+        "GitHub GraphQL request failed; check repository access",
+        {
+          retryable: false,
+        },
+      );
+    }
+  }
+  if (!response.ok) {
+    if (
+      response.status === 403 &&
+      noData &&
+      isRecord(value) &&
+      value.errors === undefined &&
+      (value.message === "Resource not accessible by integration" ||
+        value.message === "Resource not accessible by personal access token")
+    ) {
+      throw new GitHubGraphQLUnavailableError(response.status);
+    }
+    throw githubResponseError(response);
+  }
+  return value;
 }
 
 // Optional host auth raises quota and unlocks private-repo reads, but an
@@ -405,6 +512,13 @@ export async function readGitHubJsonResponse(
     await discardResponse(response);
     throw githubResponseError(response);
   }
+  return readGitHubJsonBody(response, maxBytes);
+}
+
+async function readGitHubJsonBody(
+  response: Response,
+  maxBytes = GITHUB_JSON_MAX_BYTES,
+): Promise<unknown> {
   let body: Buffer;
   try {
     body = await readBoundedResponse(response, maxBytes);

--- a/src/gateway/worker-environments/repository-project-admission.integration.test.ts
+++ b/src/gateway/worker-environments/repository-project-admission.integration.test.ts
@@ -32,6 +32,7 @@ it("admits public source without a native CLI and fences later configured identi
   // configuration absence and durable agent ownership use their real owners.
   const fetchMock = vi.fn<typeof fetch>(async (input, init) => {
     const request = new Request(input, init);
+    expect(request.method).toBe("GET");
     expect(request.headers.has("authorization")).toBe(false);
     const pathname = new URL(request.url).pathname;
     let body: unknown;
@@ -65,6 +66,13 @@ it("admits public source without a native CLI and fences later configured identi
   expect(admitted.project.baseCommit).toBe(commit);
   expect(admitted.project.source.owner.identity).toEqual({ source: "anonymous" });
   await expect(admitted.revalidate()).resolves.toBeUndefined();
+  const reopened = await prepareRepositoryWorkerProjectSource({
+    expected: admitted.project,
+    namespace: "public-source-test",
+    getConfig: () => config,
+    assertCurrent: () => {},
+  });
+  expect(reopened.project).toEqual(admitted.project);
   expect(admitted).not.toHaveProperty("readGitToken");
   expect(fetchMock).toHaveBeenCalled();
   await fs.writeFile(path.join(nativeConfig, "config.yml"), "{}\n");

--- a/src/gateway/worker-environments/repository-project-admission.test.ts
+++ b/src/gateway/worker-environments/repository-project-admission.test.ts
@@ -52,6 +52,15 @@ describe("repository project admission", () => {
   let truncated: boolean;
   let unavailable: boolean;
   let fetchImpl: ReturnType<typeof vi.fn<typeof fetch>>;
+  const repositoryNode = () => ({
+    __typename: "Repository",
+    node_id: repositoryId,
+    clone_url: repositoryUrl.replace(/\.git$/u, ""),
+    private: privateRepository,
+    object: { __typename: "Commit", sha: commit, tree: { sha: rootTree } },
+  });
+  const requestPaths = () =>
+    fetchImpl.mock.calls.map(([input]) => new URL(new Request(input).url).pathname);
 
   beforeEach(() => {
     selection = { source: "system-configured", profileId: `ghp_${"1".repeat(32)}`, accountId: 1 };
@@ -90,7 +99,12 @@ describe("repository project admission", () => {
     fetchImpl = vi.fn<typeof fetch>(async (input) => {
       const url = new URL(new Request(input).url);
       let value: unknown;
-      if (url.pathname === "/repos/acme/project") {
+      if (url.pathname === "/graphql") {
+        if (unavailable) {
+          return new Response(null, { status: 404 });
+        }
+        value = { data: { node: repositoryNode() } };
+      } else if (url.pathname === "/repos/acme/project") {
         if (unavailable) {
           return new Response(null, { status: 404 });
         }
@@ -173,6 +187,199 @@ describe("repository project admission", () => {
       fetchImpl.mock.calls.every(([url]) => !new Request(url).url.includes("/commits/heads")),
     ).toBe(true);
   });
+
+  it("uses seven reads across discovery, pinned admission, and post-binding revalidation", async () => {
+    const admitted = await prepareRepositoryWorkerProjectSource({
+      ...initial,
+      knownRecipe: (project) => ({ project, setupRecipe: recipe }),
+    });
+    const restored = await prepareRepositoryWorkerProjectSource({
+      namespace: initial.namespace,
+      getConfig: initial.getConfig,
+      assertCurrent: initial.assertCurrent,
+      expected: admitted.project,
+      knownRecipe: (project) => ({ project, setupRecipe: recipe }),
+    });
+    await restored.revalidate();
+    expect(restored.project).toEqual(admitted.project);
+    expect(requestPaths()).toEqual([
+      "/repos/acme/project",
+      "/repos/acme/project/commits/heads%2Fmain",
+      "/repos/acme/project",
+      "/graphql",
+      "/repos/acme/project",
+      "/graphql",
+      "/repos/acme/project",
+    ]);
+    for (const [requestInput, init] of fetchImpl.mock.calls.filter(([input]) =>
+      new Request(input).url.endsWith("/graphql"),
+    )) {
+      const request = new Request(requestInput, init);
+      expect(request.method).toBe("POST");
+      expect(request.headers.get("content-type")).toBe("application/json");
+      expect(request.headers.get("authorization")).toBe(`Bearer ${token}`);
+      const body = await request.json();
+      expect(body.variables).toEqual({ repositoryId, commit });
+      expect(body.query).toMatch(
+        /node\(id: \$repositoryId\)[\s\S]*on Repository[\s\S]*object\(oid: \$commit\)/u,
+      );
+      expect(body.query).not.toMatch(/repository\(owner:/u);
+    }
+  });
+
+  it.each(["refill", "revalidate"] as const)(
+    "rejects invalid GraphQL repository/object metadata during %s without a REST fallback",
+    async (phase) => {
+      const admitted = await prepareRepositoryWorkerProjectSource(initial);
+      const node = repositoryNode();
+      const responses = [
+        {},
+        { data: null },
+        { data: { node: null } },
+        { data: { node: { ...node, __typename: "User" } } },
+        { data: { node: { ...node, node_id: "R_replaced_project" } } },
+        { data: { node: { ...node, clone_url: "https://github.com/acme/another" } } },
+        { data: { node: { ...node, private: undefined } } },
+        { data: { node: { ...node, private: true } } },
+        { data: { node: { ...node, object: null } } },
+        { data: { node: { ...node, object: { ...node.object, __typename: "Tree" } } } },
+        { data: { node: { ...node, object: { ...node.object, sha: "e".repeat(40) } } } },
+        { data: { node: { ...node, object: { ...node.object, tree: null } } } },
+        { data: { node: { ...node, object: { ...node.object, tree: { sha: "invalid" } } } } },
+        { data: { node }, errors: [{ type: "FORBIDDEN" }] },
+        { data: { node }, errors: [{ type: "INTERNAL", message: "private-diagnostic" }] },
+        { data: { node }, errors: {} },
+        { errors: [{ type: "FORBIDDEN" }, { type: "INTERNAL" }] },
+      ];
+      for (const response of responses) {
+        fetchImpl.mockClear().mockResolvedValueOnce(new Response(JSON.stringify(response)));
+        const pending =
+          phase === "revalidate"
+            ? admitted.revalidate()
+            : prepareRepositoryWorkerProjectSource({
+                namespace: initial.namespace,
+                getConfig: initial.getConfig,
+                assertCurrent: initial.assertCurrent,
+                expected: admitted.project,
+                knownRecipe: (project) => ({ project, setupRecipe: recipe }),
+              });
+        await expect(pending).rejects.toThrow();
+        expect(requestPaths()).toEqual(["/graphql"]);
+      }
+    },
+  );
+
+  it.each(["repository", "visibility", "access"] as const)(
+    "rejects %s changes after the immutable-node read",
+    async (change) => {
+      const admitted = await prepareRepositoryWorkerProjectSource(initial);
+      const response = { data: { node: repositoryNode() } };
+      fetchImpl.mockClear().mockImplementationOnce(async () => {
+        if (change === "repository") {
+          repositoryId = "R_recreated_project";
+        }
+        if (change === "visibility") {
+          privateRepository = true;
+        }
+        if (change === "access") {
+          unavailable = true;
+        }
+        return new Response(JSON.stringify(response));
+      });
+      await expect(admitted.revalidate()).rejects.toThrow();
+      expect(requestPaths()).toEqual(["/graphql", "/repos/acme/project"]);
+    },
+  );
+
+  it.each(["http forbidden", "forbidden", "insufficient scopes"] as const)(
+    "preserves the complete REST fence for a public token with %s GraphQL access",
+    async (refusal) => {
+      const admitted = await prepareRepositoryWorkerProjectSource(initial);
+      fetchImpl.mockClear().mockResolvedValueOnce(
+        refusal === "http forbidden"
+          ? new Response(
+              JSON.stringify({ message: "Resource not accessible by personal access token" }),
+              { status: 403 },
+            )
+          : new Response(
+              JSON.stringify({
+                data: null,
+                errors: [{ type: refusal === "forbidden" ? "FORBIDDEN" : "INSUFFICIENT_SCOPES" }],
+              }),
+            ),
+      );
+      await expect(admitted.revalidate()).resolves.toBeUndefined();
+      expect(requestPaths()).toEqual([
+        "/graphql",
+        "/repos/acme/project",
+        `/repos/acme/project/git/commits/${commit}`,
+        "/repos/acme/project",
+      ]);
+    },
+  );
+
+  it.each(["agent", "identity", "credential", "caller"] as const)(
+    "rejects %s revocation after successful or refused GraphQL reads without falling back",
+    async (revoked) => {
+      const admitted = await prepareRepositoryWorkerProjectSource(initial);
+      const originalToken = token;
+      for (const status of [200, 403]) {
+        selected = true;
+        token = originalToken;
+        mocks.matchesAgentLifecycleBinding.mockReturnValue(true);
+        const controller = new AbortController();
+        fetchImpl.mockClear().mockImplementationOnce(async () => {
+          if (revoked === "agent") {
+            mocks.matchesAgentLifecycleBinding.mockReturnValue(false);
+          }
+          if (revoked === "identity") {
+            selected = false;
+          }
+          if (revoked === "credential") {
+            token = "replaced-credential";
+          }
+          if (revoked === "caller") {
+            controller.abort();
+          }
+          return new Response(
+            JSON.stringify(
+              status === 403
+                ? { message: "Resource not accessible by personal access token" }
+                : { data: { node: repositoryNode() } },
+            ),
+            { status },
+          );
+        });
+        await expect(admitted.revalidate(controller.signal)).rejects.toThrow();
+        expect(requestPaths()).toEqual(["/graphql"]);
+      }
+    },
+  );
+
+  it.each<{ label: string; status: number; body?: string; headers?: Record<string, string> }>([
+    { label: "authentication", status: 401, body: "{}" },
+    { label: "missing endpoint", status: 404, body: "{}" },
+    { label: "upstream failure", status: 500, body: "{}" },
+    { label: "malformed JSON", status: 200, body: "{" },
+    { label: "ambiguous forbidden", status: 403, body: "{}" },
+    { label: "empty forbidden", status: 403 },
+    {
+      label: "quota at HTTP 403",
+      status: 403,
+      headers: { "x-ratelimit-remaining": "42" },
+      body: JSON.stringify({ errors: [{ type: "RATE_LIMITED" }] }),
+    },
+    { label: "quota", status: 200, body: JSON.stringify({ errors: [{ type: "RATE_LIMITED" }] }) },
+    { label: "redirect", status: 307, headers: { location: "https://api.github.com/graphql" } },
+  ])(
+    "does not reinterpret $label as unavailable GraphQL capability",
+    async ({ status, body, headers }) => {
+      const admitted = await prepareRepositoryWorkerProjectSource(initial);
+      fetchImpl.mockClear().mockResolvedValueOnce(new Response(body, { status, headers }));
+      await expect(admitted.revalidate()).rejects.toThrow();
+      expect(requestPaths()).toEqual(["/graphql"]);
+    },
+  );
 
   it.each([undefined, recipe])(
     "reuses an exact known recipe %s without Git tree reads",

--- a/src/gateway/worker-environments/repository-project-admission.ts
+++ b/src/gateway/worker-environments/repository-project-admission.ts
@@ -17,6 +17,8 @@ import {
   discardResponse,
   fetchGitHubApi,
   GITHUB_API_ORIGIN,
+  GitHubGraphQLUnavailableError,
+  readGitHubGraphQLResponse,
   readGitHubJsonResponse,
 } from "../control-ui-github-api.js";
 import { requestCurrentGitHubOAuthRefresh } from "../github-oauth-lifecycle.js";
@@ -29,6 +31,21 @@ const GitObject = /^[a-f0-9]{40}$/u;
 // Commit lookup requests one changed file; trees are nonrecursive and inspect
 // only the root and .openclaw directory. Oversized/truncated metadata is not absence.
 const METADATA_MAX_BYTES = 1024 * 1024;
+// Bind object resolution to the immutable repository, never its reusable name.
+const PINNED_REPOSITORY_QUERY = `query PinnedRepository($repositoryId: ID!, $commit: GitObjectID!) {
+  node(id: $repositoryId) {
+    __typename
+    ... on Repository {
+      node_id: id
+      clone_url: url
+      private: isPrivate
+      object(oid: $commit) {
+        __typename
+        ... on Commit { sha: oid tree { sha: oid } }
+      }
+    }
+  }
+}`;
 type AdmissionRequest = {
   namespace: string;
   getConfig: () => OpenClawConfig;
@@ -130,21 +147,26 @@ export async function prepareRepositoryWorkerProjectSource(params: AdmissionRequ
     readIdentity: typeof identity,
     assertOwner: () => void,
     signal?: AbortSignal,
+    graphql?: { query: string; variables: Record<string, string> },
   ): Promise<unknown> => {
     assertOwner();
     const response = await fetchGitHubApi(
-      endpoint + suffix,
+      graphql ? `${GITHUB_API_ORIGIN}/graphql` : endpoint + suffix,
       fetch,
       readIdentity.token,
       async () => sourceChanged(),
       readIdentity,
       undefined,
       signal,
+      graphql,
     );
     let value: unknown;
     try {
       assertOwner();
-      value = await readGitHubJsonResponse(response, METADATA_MAX_BYTES);
+      value =
+        graphql && readIdentity.token
+          ? await readGitHubGraphQLResponse(response, fetch, readIdentity.token, METADATA_MAX_BYTES)
+          : await readGitHubJsonResponse(response, METADATA_MAX_BYTES);
     } finally {
       await discardResponse(response);
     }
@@ -152,12 +174,7 @@ export async function prepareRepositoryWorkerProjectSource(params: AdmissionRequ
     assertOwner();
     return value;
   };
-  const readRepository = async (
-    readIdentity: typeof identity,
-    assertOwner: () => void,
-    signal?: AbortSignal,
-  ) => {
-    const value = await read("", readIdentity, assertOwner, signal);
+  const repositoryMetadata = (value: unknown, readIdentity: typeof identity) => {
     if (
       !isRecord(value) ||
       typeof value.node_id !== "string" ||
@@ -175,7 +192,61 @@ export async function prepareRepositoryWorkerProjectSource(params: AdmissionRequ
       private: value.private,
     };
   };
-  const metadata = await readRepository(identity, assertAdmission, params.signal);
+  const readRepository = async (
+    readIdentity: typeof identity,
+    assertOwner: () => void,
+    signal?: AbortSignal,
+  ) => repositoryMetadata(await read("", readIdentity, assertOwner, signal), readIdentity);
+  const readPinnedRepository = async (
+    repositoryId: string,
+    baseCommit: string,
+    readIdentity: typeof identity,
+    assertOwner: () => void,
+    signal?: AbortSignal,
+  ) => {
+    if (!readIdentity.token) {
+      return undefined;
+    }
+    let value: unknown;
+    try {
+      value = await read("", readIdentity, assertOwner, signal, {
+        query: PINNED_REPOSITORY_QUERY,
+        variables: { repositoryId, commit: baseCommit },
+      });
+    } catch (error) {
+      // Native classic tokens can read public REST metadata without the
+      // public_repo scope required by GraphQL. Preserve the full REST fence.
+      if (!(error instanceof GitHubGraphQLUnavailableError)) {
+        throw error;
+      }
+      await readIdentity.revalidate();
+      assertOwner();
+      return undefined;
+    }
+    const node = isRecord(value) && isRecord(value.data) ? value.data.node : undefined;
+    if (!isRecord(node) || node.__typename !== "Repository" || node.node_id !== repositoryId) {
+      sourceChanged();
+    }
+    const metadata = repositoryMetadata(node, readIdentity);
+    const commit = node.object;
+    // Missing objects return null without GraphQL errors, including absent SHAs.
+    if (!isRecord(commit) || commit.__typename !== "Commit" || objectSha(commit) !== baseCommit) {
+      sourceChanged();
+    }
+    objectSha(commit.tree);
+    return { metadata, commit };
+  };
+  const pinnedRepository = expected
+    ? await readPinnedRepository(
+        expected.source.repositoryId,
+        expected.baseCommit,
+        identity,
+        assertAdmission,
+        params.signal,
+      )
+    : undefined;
+  const metadata =
+    pinnedRepository?.metadata ?? (await readRepository(identity, assertAdmission, params.signal));
   const repositoryId = metadata.repositoryId;
   if (expected && repositoryId !== expected.source.repositoryId) {
     sourceChanged();
@@ -193,12 +264,14 @@ export async function prepareRepositoryWorkerProjectSource(params: AdmissionRequ
     throw new Error("GitHub repository has no valid source reference; select a branch or commit.");
   }
   const pinned = request.baseCommit ?? (GitObject.test(requestedRef) ? requestedRef : undefined);
-  const commit = await read(
-    pinned ? `/git/commits/${pinned}` : `/commits/${encodeURIComponent(requestedRef)}?per_page=1`,
-    identity,
-    assertAdmission,
-    params.signal,
-  );
+  const commit =
+    pinnedRepository?.commit ??
+    (await read(
+      pinned ? `/git/commits/${pinned}` : `/commits/${encodeURIComponent(requestedRef)}?per_page=1`,
+      identity,
+      assertAdmission,
+      params.signal,
+    ));
   const baseCommit = objectSha(commit);
   if (pinned && baseCommit !== pinned) {
     sourceChanged();
@@ -290,12 +363,25 @@ export async function prepareRepositoryWorkerProjectSource(params: AdmissionRequ
     if (!isDeepStrictEqual(current.selection, owner.identity)) {
       sourceChanged();
     }
-    const before = await readRepository(current, assertSource, signal);
+    const currentPinnedRepository = await readPinnedRepository(
+      repositoryId,
+      baseCommit,
+      current,
+      assertSource,
+      signal,
+    );
+    const before =
+      currentPinnedRepository?.metadata ?? (await readRepository(current, assertSource, signal));
     if (before.private !== metadata.private || before.repositoryId !== repositoryId) {
       sourceChanged();
     }
-    const observed = await read(`/git/commits/${baseCommit}`, current, assertSource, signal);
-    if (objectSha(observed) !== baseCommit) {
+    const observed =
+      currentPinnedRepository?.commit ??
+      (await read(`/git/commits/${baseCommit}`, current, assertSource, signal));
+    if (
+      objectSha(observed) !== baseCommit ||
+      (currentPinnedRepository && objectSha(currentPinnedRepository.commit.tree) !== tree)
+    ) {
       sourceChanged();
     }
     const after = await readRepository(current, assertSource, signal);


### PR DESCRIPTION
Closes #145472. Related: #145302 and #145331.

## What Problem This Solves

Users starting a prepared GitHub repository worker still wait for nine sequential source-metadata requests across initial admission, pre-bind admission, and post-bind revalidation. A live Daytona ready-reserve sample spent about 3.2 seconds of its 5.97-second activation in these checks.

## Why This Change Was Made

For authenticated pinned reads with a known repository ID, resolve the repository and commit through the immutable Repository node, then confirm the repository again through REST. This keeps the commit associated with the correct repository instance and preserves all three admission gates and their current identity/ownership checks.

The existing GitHub transport also owns GraphQL response decoding and quota cooldowns. Explicit, wholly refused permission responses can use the complete original REST sequence so scope-limited native credentials keep working. Partial/malformed data, missing commits, identity or visibility changes, cancellation, and quota errors do not trigger that fallback.

## User Impact

The normal authenticated ready path uses seven metadata requests instead of nine, with no configuration change. First-time name/branch discovery and anonymous reads retain their existing REST behavior.

## Evidence

- Live calls through the changed admission owner completed three initial/pre-bind/revalidation cycles with seven requests each; the unchanged owner used nine. Both used an isolated managed credential and a synthetic private repository.
- The changed owner rejected a real missing commit after one GraphQL request, with no REST fallback. Cancellation and a removed agent were rejected before network access.
- The preceding full Daytona replay verified ready reuse, isolation, accepted deletion restoration, restart-preserved expiry, and cleanup of four workers and one snapshot. It measured 8.39 seconds to first output for a fresh ready worker and 7.87 seconds for restoration, using synthetic inference. Those are baseline samples for the landed startup changes, not end-to-end timings for this PR.
- 223 owner/sibling tests passed across ten suites; 91 affected tests passed on the final candidate. The complete changed gate, both typecheck lanes, lint, and independent review through P2 passed.

CI follow-up: [initial run 34664259938](https://github.com/openclaw/openclaw/actions/runs/34664259938) exposed three inherited New Session picker failures. Their canonical repair landed in #145415 (`57674ef82592b712a17507539b6f89609d8547c2`) with green required CI. This branch is now rebased onto repaired main; all five admission-source/test files are byte-identical to the reviewed and live-tested candidate. Required CI passed in [run 34667350270, attempt 2](https://github.com/openclaw/openclaw/actions/runs/34667350270). One unrelated intermittent OpenAI speech response-body timeout required a single unchanged job rerun; no source, assertions, or timeouts were changed for it. Fresh verification of the inherited picker repairs also passed 79 owner/cursor tests.
