### PR TITLE
fix(macos): keep Browser visible beside nonoverlapping menus

### DIFF
--- a/docs/platforms/macos.md
+++ b/docs/platforms/macos.md
@@ -199,6 +199,8 @@ Use the tab strip to select or close a page, the URL bar to navigate, and the ba
 
 The titlebar controls follow the app sidebar: while it is expanded, back/forward sit at its right edge next to the sidebar toggle; while it is collapsed, they make way for a search button (opens the command palette) and a new-session button.
 
+Mac tabs stay visible when a menu or hover card opens elsewhere in the dashboard. A tab's page temporarily hides only when the menu overlaps its Browser pane, or while a modal dialog or the command palette is open, and returns when the obstruction clears.
+
 Drag the empty header space or title in the docked OpenClaw chat panel to move the app window. Its dock-position and close buttons remain clickable.
 
 Right-click an external link in the dashboard to choose **Open in Browser Panel**, **Open in Default Browser**, or **Copy Link**. Modified clicks still open the default browser. New-window links inside a Mac tab open another Mac tab; pointer-activated downloads hand off to the default browser. Responses WebKit cannot display hand off only for pointer-activated main-frame navigation; other non-displayable responses are cancelled silently. Regular browser-hosted Control UI pages keep their normal link and context-menu behavior unless you enable the Browser panel link preference.

--- a/ui/src/components/browser/browser-panel-native-presentation.ts
+++ b/ui/src/components/browser/browser-panel-native-presentation.ts
@@ -50,13 +50,16 @@ export class BrowserPanelNativePresentation {
     this.connected = true;
     // Native responder focus can route back to this panel without DOM events.
     this.hostElement?.setAttribute("data-native-browser-scope", this.scope);
-    this.unsubscribeOcclusion = subscribeNativeOverlayOcclusion((occluded) => {
-      this.occluded = occluded;
-      if (occluded) {
-        this.hide();
-      }
-      this.schedule();
-    });
+    this.unsubscribeOcclusion = subscribeNativeOverlayOcclusion(
+      (occluded) => {
+        this.occluded = occluded;
+        if (occluded) {
+          this.hide();
+        }
+        this.schedule();
+      },
+      () => this.stage?.getBoundingClientRect() ?? null,
+    );
     document.addEventListener("scroll", this.schedule, true);
     window.addEventListener("resize", this.schedule);
     this.update();

--- a/ui/src/components/browser/browser-panel-native.test.ts
+++ b/ui/src/components/browser/browser-panel-native.test.ts
@@ -8,6 +8,7 @@ import type {
 import { startNativeLinkRouting } from "../../app/native-link-routing.ts";
 import { acquireNativeOverlayOcclusion } from "../../lib/native-overlay-occlusion.ts";
 import { createStorageMock } from "../../test-helpers/storage.ts";
+import { promoteToPopoverTopLayer } from "../menu-surface.ts";
 import {
   createBrowserClient,
   createInspectedNode,
@@ -698,6 +699,41 @@ describe("native Browser panel ownership", () => {
     expect(controller.activeTargetId).toBeNull();
     expect(controller.tabs).toEqual([]);
     expect(controller.urlDraft).toBe("");
+  });
+
+  it("keeps a native tab visible beside a hovercard and tracks overlap as either surface moves", async () => {
+    const native = fakeNativeBrowser([nativeTab("mac-one")]);
+    const { host, controller } = controllerFixture();
+    const stage = host.renderRoot.querySelector<HTMLElement>(".bp-stage")!;
+    let stageRect = new DOMRect(600, 100, 500, 600);
+    vi.spyOn(stage, "getBoundingClientRect").mockImplementation(() => stageRect);
+    flushFrames();
+    native.postMessage.mockClear();
+    const card = document.createElement("div");
+    let cardRect = new DOMRect(200, 200, 300, 200);
+    vi.spyOn(card, "getBoundingClientRect").mockImplementation(() => cardRect);
+    document.body.append(card);
+    promoteToPopoverTopLayer(card);
+    flushFrames();
+    expect(native.postMessage).not.toHaveBeenCalled();
+
+    // Only the edge overlaps; center-point hit testing alone cannot catch it.
+    cardRect = new DOMRect(400, 200, 300, 200);
+    flushFrames();
+    expect(native.messages().at(-1)).toMatchObject({ type: "present", visible: false });
+    stageRect = new DOMRect(700, 100, 500, 600);
+    controller.hostUpdated();
+    flushFrames();
+    flushFrames();
+    expect(native.messages().at(-1)).toMatchObject({ type: "present", visible: true });
+
+    cardRect = new DOMRect(650, 200, 300, 200);
+    flushFrames();
+    expect(native.messages().at(-1)).toMatchObject({ type: "present", visible: false });
+    card.remove();
+    await Promise.resolve();
+    flushFrames();
+    expect(native.messages().at(-1)).toMatchObject({ type: "present", visible: true });
   });
 
   it("deduplicates presentations, hides a covered stage, and restores only after every occluder closes", () => {

--- a/ui/src/components/command-palette.test.ts
+++ b/ui/src/components/command-palette.test.ts
@@ -65,7 +65,7 @@ describe("CommandPalette lifecycle", () => {
       ),
     );
     const changes = vi.fn();
-    const unsubscribe = subscribeNativeOverlayOcclusion(changes);
+    const unsubscribe = subscribeNativeOverlayOcclusion(changes, () => null);
     try {
       palette.openPalette();
       await palette.updateComplete;

--- a/ui/src/components/menu-surface.browser.test.ts
+++ b/ui/src/components/menu-surface.browser.test.ts
@@ -1,5 +1,6 @@
 import { html, render } from "lit";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, onTestFinished, vi } from "vitest";
+import { subscribeNativeOverlayOcclusion } from "../lib/native-overlay-occlusion.ts";
 import "@awesome.me/webawesome/dist/styles/themes/default.css";
 import { renderComposerLibraryMenu } from "../pages/chat/components/chat-composer-library-menu.ts";
 import { renderChatComposerPlusMenu } from "../pages/chat/components/chat-composer-plus-menu.ts";
@@ -25,8 +26,10 @@ const originalTheme = document.documentElement.getAttribute("data-theme");
 const originalThemeMode = document.documentElement.getAttribute("data-theme-mode");
 const originalClasses = document.documentElement.className;
 
-afterEach(() => {
+afterEach(async () => {
   document.body.replaceChildren();
+  await Promise.resolve();
+  vi.unstubAllGlobals();
   if (originalTheme === null) {
     document.documentElement.removeAttribute("data-theme");
   } else {
@@ -101,6 +104,21 @@ describe.skipIf(!hasPopoverApi)("sidebar menu stacking", () => {
 
   it("paints a plain menu hosted in openclaw-menu-surface above the resizer divider", async () => {
     await useDesktopViewport();
+    vi.stubGlobal("webkit", { messageHandlers: { openclawBrowser: { postMessage: vi.fn() } } });
+    const nearby: boolean[] = [];
+    const distant: boolean[] = [];
+    onTestFinished(
+      subscribeNativeOverlayOcclusion(
+        (occluded) => nearby.push(occluded),
+        () => new DOMRect(300, 100, 200, 400),
+      ),
+    );
+    onTestFinished(
+      subscribeNativeOverlayOcclusion(
+        (occluded) => distant.push(occluded),
+        () => new DOMRect(900, 100, 300, 400),
+      ),
+    );
     const { nav, divider } = mountShell();
     const surface = document.createElement("openclaw-menu-surface");
     const menu = createSortMenu();
@@ -111,6 +129,13 @@ describe.skipIf(!hasPopoverApi)("sidebar menu stacking", () => {
     const hit = hitTestOnDivider(menu, divider);
     expect(hit).not.toBeNull();
     expect(menu.contains(hit)).toBe(true);
+    expect(surface.getBoundingClientRect().width).toBe(0);
+    menu.style.left = "250px";
+    await expect.poll(() => nearby).toEqual([false, true]);
+    expect(distant).toEqual([false]);
+    menu.style.left = "850px";
+    await expect.poll(() => nearby).toEqual([false, true, false]);
+    await expect.poll(() => distant).toEqual([false, true]);
   });
 
   it("paints a Web Awesome dropdown above the divider through its own popover", async () => {

--- a/ui/src/components/menu-surface.test.ts
+++ b/ui/src/components/menu-surface.test.ts
@@ -76,18 +76,21 @@ describe("native overlay occlusion for menus", () => {
   it("keeps overlapping surfaces occluded until their close or removal, including shadow roots", async () => {
     bridge.available = true;
     const changes = vi.fn();
-    unsubscribe = subscribeNativeOverlayOcclusion(changes);
+    unsubscribe = subscribeNativeOverlayOcclusion(changes, () => new DOMRect(0, 0, 500, 500));
     const host = document.createElement("div");
     document.body.append(host);
     const root = host.attachShadow({ mode: "open" });
     const first = document.createElement("div");
     const second = document.createElement("div");
+    first.getBoundingClientRect = () => new DOMRect(10, 10, 100, 100);
+    second.getBoundingClientRect = () => new DOMRect(20, 20, 100, 100);
     root.append(first, second);
     first.showPopover = vi.fn();
     promoteToPopoverTopLayer(first);
     promoteToPopoverTopLayer(first);
     // Fallback surfaces must also occlude: native webviews cover in-page menus.
     promoteToPopoverTopLayer(second);
+    await new Promise(requestAnimationFrame);
     expect(changes.mock.calls).toEqual([[false], [true]]);
 
     const closed = new Event("toggle");
@@ -99,6 +102,7 @@ describe("native overlay occlusion for menus", () => {
     expect(changes.mock.calls).toEqual([[false], [true], [false]]);
 
     promoteToPopoverTopLayer(first);
+    await new Promise(requestAnimationFrame);
     host.remove();
     await Promise.resolve();
     expect(changes.mock.calls).toEqual([[false], [true], [false], [true], [false]]);

--- a/ui/src/components/modal-dialog.test.ts
+++ b/ui/src/components/modal-dialog.test.ts
@@ -78,7 +78,7 @@ describe("openclaw-modal-dialog", () => {
 
   it("occludes native tabs through nested dialogs, closing animations, and removal", async () => {
     const changes = vi.fn();
-    const unsubscribe = subscribeNativeOverlayOcclusion(changes);
+    const unsubscribe = subscribeNativeOverlayOcclusion(changes, () => null);
     try {
       const { modal, webAwesomeDialog } = await renderModal();
       const nested = document.createElement("openclaw-modal-dialog");

--- a/ui/src/components/web-awesome-dropdown.browser.test.ts
+++ b/ui/src/components/web-awesome-dropdown.browser.test.ts
@@ -85,13 +85,16 @@ async function closed(f: Fixture) {
   expect(f.menu.getAnimations()).toHaveLength(0);
 }
 
-function observeNativeOcclusion(native = true) {
+function observeNativeOcclusion(
+  native = true,
+  getBounds = () => new DOMRect(0, 0, innerWidth, innerHeight),
+) {
   vi.stubGlobal(
     "webkit",
     native ? { messageHandlers: { openclawBrowser: { postMessage: vi.fn() } } } : undefined,
   );
   const states: boolean[] = [];
-  onTestFinished(subscribeNativeOverlayOcclusion((occluded) => states.push(occluded)));
+  onTestFinished(subscribeNativeOverlayOcclusion((occluded) => states.push(occluded), getBounds));
   return states;
 }
 
@@ -103,6 +106,37 @@ afterEach(async () => {
 });
 
 describe.runIf(browserMode)("Web Awesome dropdown lifecycle", () => {
+  it("ignores a distant menu but follows its submenu through overlap and closing", async () => {
+    const { page } = await import("vitest/browser");
+    await page.viewport(1280, 800);
+    let bounds = new DOMRect(900, 100, 300, 500);
+    const states = observeNativeOcclusion(true, () => bounds);
+    const f = await fixture();
+    await open(f);
+    expect(states).toEqual([false]);
+    await f.parent.openSubmenu();
+    const submenu = f.parent.shadowRoot!.querySelector<HTMLElement>('[part="submenu"]')!;
+    const rect = submenu.getBoundingClientRect();
+    // The native pane touches only the submenu, beyond the main menu's edge.
+    bounds = new DOMRect(rect.right - 10, rect.top, 100, rect.height);
+    expect(bounds.left).toBeGreaterThan(f.menu.getBoundingClientRect().right);
+    await expect.poll(() => states).toEqual([false, true]);
+    await duringElementAnimation(
+      submenu,
+      "hide",
+      () => {
+        f.parent.submenuOpen = false;
+      },
+      async () => {
+        await frame();
+        expect(states).toEqual([false, true]);
+      },
+    );
+    await expect.poll(() => states).toEqual([false, true, false]);
+    f.dropdown.open = false;
+    await closed(f);
+  });
+
   it("occludes native browser views from trigger opening through the complete hide animation", async () => {
     const { page } = await import("vitest/browser");
     const states = observeNativeOcclusion();

--- a/ui/src/components/web-awesome.ts
+++ b/ui/src/components/web-awesome.ts
@@ -118,7 +118,20 @@ function startDropdownLabelSync(event: Event) {
   queueMicrotask(() => {
     // SAFETY: The registered wa-dropdown host exposes its boolean open property.
     if (!event.defaultPrevented && (dropdown as HTMLElement & { open: boolean }).open) {
-      occludeNativeBrowserSurface(dropdown, "wa-after-hide");
+      occludeNativeBrowserSurface(dropdown, "wa-after-hide", function* () {
+        const menu = dropdown.shadowRoot?.querySelector('[part="menu"]');
+        if (menu) {
+          yield menu;
+        }
+        // The host bounds belong to the trigger. Submenus have their own
+        // top-layer rectangles, including while their hide animation runs.
+        for (const item of dropdown.querySelectorAll("wa-dropdown-item")) {
+          const submenu = item.shadowRoot?.querySelector('[part="submenu"]');
+          if (submenu) {
+            yield submenu;
+          }
+        }
+      });
     }
   });
   // Reopening must restore the menu before Web Awesome moves focus into it.

--- a/ui/src/lib/native-overlay-occlusion.test.ts
+++ b/ui/src/lib/native-overlay-occlusion.test.ts
@@ -22,12 +22,12 @@ afterEach(() => {
 describe("native overlay occlusion", () => {
   it("stays occluded until every overlay releases and tolerates repeated releases", () => {
     const changes = vi.fn();
-    cleanups.push(subscribeNativeOverlayOcclusion(changes));
+    cleanups.push(subscribeNativeOverlayOcclusion(changes, () => null));
     const first = acquireNativeOverlayOcclusion();
     const second = acquireNativeOverlayOcclusion();
     cleanups.push(first, second);
     const lateSubscriber = vi.fn();
-    const unsubscribe = subscribeNativeOverlayOcclusion(lateSubscriber);
+    const unsubscribe = subscribeNativeOverlayOcclusion(lateSubscriber, () => null);
     cleanups.push(unsubscribe);
 
     expect(changes.mock.calls).toEqual([[false], [true]]);
@@ -44,7 +44,7 @@ describe("native overlay occlusion", () => {
   it("does not acquire or subscribe without the native browser bridge", () => {
     bridge.available = false;
     const changes = vi.fn();
-    cleanups.push(subscribeNativeOverlayOcclusion(changes));
+    cleanups.push(subscribeNativeOverlayOcclusion(changes, () => null));
     const release = acquireNativeOverlayOcclusion();
     release();
     release();

--- a/ui/src/lib/native-overlay-occlusion.ts
+++ b/ui/src/lib/native-overlay-occlusion.ts
@@ -1,12 +1,56 @@
 import { hasNativeBrowserBridge } from "../app/native-browser-host.ts";
 
-const listeners = new Set<(occluded: boolean) => void>();
+type SurfaceElements = () => Iterable<Element>;
+const surfaces = new Set<SurfaceElements>();
+const listeners = new Set<() => void>();
 let activeOverlays = 0;
+let frame: number | null = null;
 
-function notify(occluded: boolean) {
+function notify() {
   for (const listener of listeners) {
-    listener(occluded);
+    listener();
   }
+}
+
+function trackSurfaceLayout() {
+  if (surfaces.size === 0 || listeners.size === 0) {
+    if (frame !== null) {
+      cancelAnimationFrame(frame);
+      frame = null;
+    }
+    return;
+  }
+  if (frame === null) {
+    // Menus are positioned after promotion; keep following layout and closing
+    // animations only while transient surfaces and native presenters coexist.
+    frame = requestAnimationFrame(() => {
+      frame = null;
+      notify();
+      trackSurfaceLayout();
+    });
+  }
+}
+
+function overlapsSurface(bounds: DOMRectReadOnly): boolean {
+  for (const elements of surfaces) {
+    for (const element of elements()) {
+      if (!element.isConnected) {
+        continue;
+      }
+      const rect = element.getBoundingClientRect();
+      if (
+        rect.width > 0 &&
+        rect.height > 0 &&
+        rect.left < bounds.right &&
+        rect.right > bounds.left &&
+        rect.top < bounds.bottom &&
+        rect.bottom > bounds.top
+      ) {
+        return true;
+      }
+    }
+  }
+  return false;
 }
 
 /** Native web views sit above the page, including its browser top layer. */
@@ -16,7 +60,7 @@ export function acquireNativeOverlayOcclusion(): () => void {
   }
   activeOverlays += 1;
   if (activeOverlays === 1) {
-    notify(true);
+    notify();
   }
   let released = false;
   return () => {
@@ -26,20 +70,36 @@ export function acquireNativeOverlayOcclusion(): () => void {
     released = true;
     activeOverlays -= 1;
     if (activeOverlays === 0) {
-      notify(false);
+      notify();
     }
   };
 }
 
-export function subscribeNativeOverlayOcclusion(listener: (occluded: boolean) => void): () => void {
+export function subscribeNativeOverlayOcclusion(
+  listener: (occluded: boolean) => void,
+  getBounds: () => DOMRectReadOnly | null,
+): () => void {
   if (!hasNativeBrowserBridge()) {
     listener(false);
     return () => {};
   }
-  listeners.add(listener);
-  listener(activeOverlays > 0);
+  let previous: boolean | undefined;
+  const update = () => {
+    const bounds = getBounds();
+    const occluded =
+      activeOverlays > 0 ||
+      Boolean(bounds && bounds.width > 0 && bounds.height > 0 && overlapsSurface(bounds));
+    if (occluded !== previous) {
+      previous = occluded;
+      listener(occluded);
+    }
+  };
+  listeners.add(update);
+  update();
+  trackSurfaceLayout();
   return () => {
-    listeners.delete(listener);
+    listeners.delete(update);
+    trackSurfaceLayout();
   };
 }
 
@@ -49,11 +109,13 @@ const occludingSurfaces = new WeakSet<HTMLElement>();
 export function occludeNativeBrowserSurface(
   element: HTMLElement,
   closeEvent: "toggle" | "wa-after-hide" = "toggle",
+  elements: SurfaceElements = () => [element, ...element.querySelectorAll("*")],
 ) {
   if (!hasNativeBrowserBridge() || !element.isConnected || occludingSurfaces.has(element)) {
     return;
   }
-  const release = acquireNativeOverlayOcclusion();
+  surfaces.add(elements);
+  trackSurfaceLayout();
   const observer = new MutationObserver(() => {
     if (!element.isConnected) {
       cleanup();
@@ -72,7 +134,9 @@ export function occludeNativeBrowserSurface(
     observer.disconnect();
     element.removeEventListener(closeEvent, onClose);
     occludingSurfaces.delete(element);
-    release();
+    surfaces.delete(elements);
+    notify();
+    trackSurfaceLayout();
   };
   occludingSurfaces.add(element);
   element.addEventListener(closeEvent, onClose);


### PR DESCRIPTION
Related: #145108

## What Problem This Solves

Fixes an issue where opening a sidebar hover card or menu would blank the Mac app's Browser pane even when the two surfaces were far apart.

## Why This Change Was Made

The dashboard previously treated every transient menu as a window-wide obstruction. It now compares each native Browser stage with the actual menu rectangles, including fixed children of zero-size popover hosts and Web Awesome submenus. One shared animation-frame loop follows layout only while transient surfaces and native presenters coexist, and publishes visibility changes only when overlap changes. Modal dialogs and the command palette retain their global occlusion behavior.

## User Impact

Mac tabs stay visible beside unrelated sidebar details and menus. A page still temporarily hides when a menu actually covers it, including during closing animations, and returns once the obstruction clears. The existing native bridge and Swift view owner are unchanged.

## Evidence

- The new native-bridge regression failed against the original implementation: a distant hover card sent `present { visible: false }`. It passes with the fix and also verifies partial overlap, stage movement, edge contact, and removal.
- Focused verification: 112 unit tests and 54 real-Chromium tests passed, covering multiple panes, zero-size menu wrappers, shadow-root removal/reconnection, submenus, canceled opening/closing, fast reopen, and modal lifetimes.
- Before/after captures use a sanitized synthetic fixture running the real dashboard menu and native presentation code; the colored page represents the native bridge's visibility result. These are browser-boundary evidence, not captures of a rebuilt native app.
- Independent Codex review: no actionable P0–P2 findings. The complete `node scripts/check-changed.mjs` gate passes on the rebased branch, including core-test/UI type checks, dead-export scans, oxlint/stylelint, formatting, and repository guards. Diff whitespace checks pass.
- Initial hosted CI exposed pre-existing New Session dead exports, cursor policy, test length and stale end-to-end flows, plus a stale keyboard-account test. These were repaired upstream in #145415 (`57674ef8259`); this PR was rebased onto main containing that fix. The browser patch is byte-equivalent by stable patch ID, and all 166 focused tests passed again after rebase. Temporary duplicate cleanup was discarded, so none of those unrelated repairs are part of this PR.
- The translation-input timeout from the first CI run did not reproduce locally: all seven targeted CLI validation cases passed without changing timeouts or assertions.


![Before: distant sidebar card blanks the native browser (synthetic bridge fixture)](https://github.com/user-attachments/assets/5c294097-aa9c-4482-9076-e093ebf0f2ce)

![After: the same card leaves the native browser visible (synthetic bridge fixture)](https://github.com/user-attachments/assets/9cdeda2a-88e4-407f-93cd-d277b663a456)

![Overlapping menus still hide the native browser (synthetic bridge fixture)](https://github.com/user-attachments/assets/ec609b69-8f1b-48c7-9c80-c28255215ee8)
