### PR TITLE
fix(feishu): deliver captioned media with block streaming disabled

### DIFF
--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -1539,6 +1539,163 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     expect(sendMediaFeishuMock).not.toHaveBeenCalled();
   });
 
+  it.each(["partial", "off"] as const)(
+    "delivers captioned media blocks with block streaming disabled and preview mode %s",
+    async (mode) => {
+      resolveFeishuAccountMock.mockReturnValue({
+        ...createReplyAccount("auto", mode, "feishu"),
+        config: { renderMode: "auto", streaming: { mode, block: { enabled: false } } },
+      });
+      sendMessageFeishuMock.mockResolvedValueOnce({ messageId: "om_caption" });
+      sendMediaFeishuMock.mockResolvedValueOnce({ messageId: "om_image" });
+      const { result, options } = createDispatcherHarness({
+        sendTarget: "user:ou_sender",
+        replyToMessageId: "om_inbound",
+      });
+      const text = "**Chart ready**\n- The hourly trend is attached.";
+      const delivery = await options.deliver(
+        { text, mediaUrls: ["https://example.com/chart.png"] },
+        { kind: "block" },
+      );
+      await options.onIdle?.();
+
+      expect(result.replyOptions.disableBlockStreaming).toBe(true);
+      expect(sendMessageFeishuMock).toHaveBeenCalledTimes(1);
+      expectMockArgFields(sendMessageFeishuMock, "media caption", {
+        to: "user:ou_sender",
+        replyToMessageId: "om_inbound",
+        text,
+      });
+      expect(sendMediaFeishuMock).toHaveBeenCalledTimes(1);
+      expectMockArgFields(sendMediaFeishuMock, "block attachment", {
+        to: "user:ou_sender",
+        replyToMessageId: "om_inbound",
+        mediaUrl: "https://example.com/chart.png",
+      });
+      expect(delivery).toMatchObject({
+        visibleReplySent: true,
+        content: text,
+        messageIds: ["om_caption", "om_image"],
+      });
+      expect(streamingInstances).toHaveLength(0);
+      await expect(result.ensureNoVisibleReplyFallback("completed")).resolves.toBe(false);
+      expect(sendMessageFeishuMock).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it("preserves text-only block suppression before a normal final", async () => {
+    useNonStreamingAutoAccount();
+    const { options } = createDispatcherHarness();
+    const block = await options.deliver({ text: "intermediate prose" }, { kind: "block" });
+    expect(block).toMatchObject({ visibleReplySent: false });
+    expect(sendMessageFeishuMock).not.toHaveBeenCalled();
+
+    await options.deliver({ text: "final answer" }, { kind: "final" });
+    expect(sendMessageFeishuMock).toHaveBeenCalledTimes(1);
+    expectMockArgFields(sendMessageFeishuMock, "final answer", { text: "final answer" });
+  });
+
+  it("completes an existing preview for a captioned media block without duplicating its text", async () => {
+    sendMediaFeishuMock.mockResolvedValueOnce({ messageId: "om_image" });
+    const { result, options } = createDispatcherHarness();
+    result.replyOptions.onPartialReply?.({ text: "Chart ready" });
+    const text = "Chart ready. The hourly trend is attached.";
+
+    const delivery = await options.deliver(
+      { text, mediaUrl: "https://example.com/chart.png" },
+      { kind: "block" },
+    );
+    await options.onIdle?.();
+    expect(sendMessageFeishuMock).not.toHaveBeenCalled();
+    await expect(delivery?.finalization).resolves.toMatchObject({
+      visibleReplySent: true,
+      content: text,
+      messageIds: ["om_stream", "om_image"],
+    });
+    expect(requireStreamingInstance(0).closeWithResult).toHaveBeenCalledWith(text, {
+      note: "Agent: agent",
+    });
+    expect(sendMediaFeishuMock).toHaveBeenCalledTimes(1);
+    await expect(result.ensureNoVisibleReplyFallback("completed")).resolves.toBe(false);
+  });
+
+  it("retains the completed media-block preview when its attachment fails", async () => {
+    sendMediaFeishuMock.mockRejectedValueOnce(new Error("attachment rejected"));
+    const { result, options } = createDispatcherHarness();
+    result.replyOptions.onPartialReply?.({ text: "Chart ready" });
+    const text = "Chart ready. The hourly trend is attached.";
+
+    await expect(
+      options.deliver({ text, mediaUrl: "https://example.com/chart.png" }, { kind: "block" }),
+    ).rejects.toMatchObject({
+      cause: { message: "attachment rejected" },
+      deliveryResult: {
+        visibleReplySent: true,
+        content: text,
+        messageIds: ["om_stream"],
+      },
+    });
+    expect(requireStreamingInstance(0).closeWithResult).toHaveBeenCalledWith(text, {
+      note: "Agent: agent",
+    });
+    expect(sendMessageFeishuMock).not.toHaveBeenCalled();
+    expect(sendMediaFeishuMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("replaces a longer media-block preview with the final caption", async () => {
+    const { result, options } = createDispatcherHarness();
+    const text = "Chart ready. The hourly trend is attached.";
+    result.replyOptions.onPartialReply?.({ text: `${text} Extra draft.` });
+
+    const delivery = await options.deliver(
+      { text, mediaUrl: "https://example.com/chart.png" },
+      { kind: "block" },
+    );
+    await options.onIdle?.();
+    await delivery?.finalization;
+    expect(requireStreamingInstance(0).closeWithResult).toHaveBeenCalledWith(text, {
+      note: "Agent: agent",
+    });
+    expect(sendMessageFeishuMock).not.toHaveBeenCalled();
+  });
+
+  it("propagates a caption rejection before sending a non-streaming media block", async () => {
+    const error = new Error("caption rejected");
+    sendMessageFeishuMock.mockRejectedValueOnce(error);
+    const { result, options } = createDispatcherHarness();
+
+    await expect(
+      options.deliver(
+        { text: "chart caption", mediaUrl: "https://example.com/chart.png" },
+        { kind: "block" },
+      ),
+    ).rejects.toBe(error);
+    expect(sendMediaFeishuMock).not.toHaveBeenCalled();
+    expect(result.getVisibleReplyState().visibleReplySent).toBe(false);
+  });
+
+  it("retains only the accepted caption when a non-streaming media block fails", async () => {
+    sendMessageFeishuMock.mockResolvedValueOnce({ messageId: "om_caption" });
+    sendMediaFeishuMock.mockRejectedValueOnce(new Error("attachment rejected"));
+    const { options } = createDispatcherHarness();
+
+    await expect(
+      options.deliver(
+        { text: "chart caption", mediaUrl: "https://example.com/chart.png" },
+        { kind: "block" },
+      ),
+    ).rejects.toMatchObject({
+      cause: { message: "attachment rejected" },
+      deliveryResult: {
+        visibleReplySent: true,
+        content: "chart caption",
+        messageIds: ["om_caption"],
+      },
+    });
+    expect(sendMessageFeishuMock).toHaveBeenCalledTimes(1);
+    expect(sendMediaFeishuMock).toHaveBeenCalledTimes(1);
+  });
+
   it("disables block streaming by default to prevent silent reply drops", () => {
     const result = createFeishuReplyDispatcher({
       cfg: {} as never,

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -1402,11 +1402,16 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
         (info?.kind === "block" && coreBlockStreamingEnabled && renderMode !== "raw") ||
         (renderMode === "auto" && shouldUseCard(text));
       const useStaticCard = hasText && cardRenderingRequested && withinCardTableLimit(text);
+      const reuseMediaBlockPreview =
+        info?.kind === "block" &&
+        hasMedia &&
+        !coreBlockStreamingEnabled &&
+        activeStreamingGeneration !== undefined;
       const useStreamingCard =
         hasText &&
         streamingEnabled &&
         !finalTextExceedsStreamingLimit &&
-        (info?.kind === "final" || cardRenderingRequested);
+        (info?.kind === "final" || cardRenderingRequested || reuseMediaBlockPreview);
       const skipTextForDuplicateFinal =
         !hasIndependentPresentation &&
         info?.kind === "final" &&
@@ -1496,7 +1501,9 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
         // Later finals replace stream text. Each presentation fallback owns a
         // separate message; ordinary blocks retain their streaming policy.
         if (hasPresentationFallback || (info?.kind === "block" && !useStreamingCard)) {
-          if (hasPresentationFallback || coreBlockStreamingEnabled) {
+          // Core delivers attachments as blocks even when text block streaming is disabled.
+          // Their caption and media must both be accepted before final-payload deduplication.
+          if (hasPresentationFallback || coreBlockStreamingEnabled || hasMedia) {
             const firstChunkMentions =
               info?.kind === "final" || (info?.kind === "block" && !sentIndependentBlockText)
                 ? mentionTargets
@@ -1539,14 +1546,13 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
           (streaming?.isActive() || matchingInFlightClose !== undefined)
         ) {
           if (activeStreamingGeneration !== undefined) {
-            if (info?.kind === "block") {
+            if (info?.kind === "block" && !reuseMediaBlockPreview) {
               // Some runtimes emit block payloads without onPartial/final callbacks.
               // Mirror block text into streamText so onIdle close still sends content.
               queueStreamingUpdate(text, { mode: "delta", dedupeWithLastPartial: true });
             }
-            if (info?.kind === "final") {
-              // Final payloads can be cumulative snapshots or independent
-              // notices. Preserve both when the latter arrives after an answer.
+            if (info?.kind === "final" || reuseMediaBlockPreview) {
+              // Final payloads and non-streaming media captions replace their preview.
               streamText = text;
               hasStreamingFinalText = true;
               snapshotBaseText = "";


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Feishu users receive a missing or delayed caption and attachment when text block streaming is disabled. For example, a plain caption plus a chart is delivered by core as a media-bearing block, but Feishu skips that block unless card rendering is selected. An existing preview can also retain draft text instead of the final caption.

On the affected 2026.9.3/2026.9.4 core path, a skipped block could additionally cause the final payload to be deduplicated and the user to receive the no-reply fallback. The newer core delivery-receipt fixes in #145428 and #148301 protect final fallback independently; this PR fixes Feishu's handling of the original media-bearing block.

## Why This Change Was Made

Deliver captioned media blocks through the existing Feishu caption and attachment senders. If the turn already has an active preview, finish that same preview with the authoritative caption, replacing any longer draft. Preserve text-only block suppression, existing partial-delivery error handling, and the public SDK contract.

## User Impact

Users receive the caption and attachment with block streaming disabled. A preview can finish correctly even when core does not send a separate final payload. No configuration migration is required.

## Evidence

- Head `04aa4879282`: all **195 dispatcher tests passed**, including two new tests using the real reply dispatcher queue, `markComplete()`, `waitForIdle()`, and deferred delivery finalization. These prove completion without an extra final payload; they do not inject a duplicate final.
- Targeted type-aware lint, Feishu package type checking, and formatting passed. Independent code review found no blockers.
- **2026.9.3 test-environment backport:** with matching existing patches and test helper compatibility, the old dispatcher fails all seven selected media regressions. Applying only the Feishu production patch makes **239 dispatcher and streaming-card tests pass**. The changed production file passes lint. Seven old test-file `no-misused-promises` findings reproduce identically after restoring the baseline test file; the full backport test-file lint lane is not claimed green.
- The isolated Linux ARM64 source build produced the plugin archive with SHA-256 `e698709b52508f5129d185e925bac0f40cbc22aa42b5f7c68df505af0d171d3d`. The reviewed artifact was deployed through the existing managed-package patch workflow on a dedicated test account, preserving the installed core and semantic configuration. All archived files were verified against the installed package, and the actual loaded root was bound to that package. Gateway readiness and the Feishu channel connection passed, with zero reconnect attempts. This proves installed artifact identity and startup, **not inbound/model-loop or live-message delivery behavior**.
- **Current-head hosted CI passed:** [`openclaw/ci-gate`](https://github.com/openclaw/openclaw/actions/runs/34928338394/job/104253214151) completed successfully for `04aa487928236d8a99a938dd273b39e532d53084`, with no failed or pending checks. This head adds tests only to the previously reviewed production change at `114be5dd4836972c6b29b3d741b002416435d5b5`.
- **Historical real Feishu proof, September 12, 2026:** the same production change passed all three cases below through the actual source dispatcher, plugin runtime, Feishu SDK, media loader, and CardKit, with real message API readback and no transport mocks.

| Historical live case | API-read result |
| --- | --- |
| Preview off, block disabled | One accepted caption post and one accepted native image |
| Partial preview mode without an existing preview, block disabled | One accepted caption post and one accepted native image |
| Partial mode with a longer existing preview, block disabled | The same card changed to the shorter final caption, draft suffix disappeared, streaming mode closed, and the native image arrived |

Each historical case had two accepted message IDs and visible-reply state true. Readback found exactly one marker-bearing caption in the bounded window. Image assertions cover returned receipts, not an audit of unrelated images. The recorded source producer SHA-256 was `1635e9c249a4ac53d50ac4640b78c7b05c4904f543c077e2bf6aa5d126b764f8`.

The historical live proof exercises the source dispatcher and real transport, not normal inbound/model processing or the installed Gateway bundle. The September 15 test deployment does not add a new live-message claim. API readback is not a client screenshot. Failure injection is covered by automated tests. No production service, configuration, or managed Skill is changed by this PR validation.

An earlier broad Windows lane on the pre-rebase revision was not green: 100/102 files passed, with doctor cleanup `EPERM` failures and one setup SecretRef expectation that reproduced on the clean base. The focused results above are the current-head checks.
