### PR TITLE
fix(plugins): preserve registration descriptor identity

### DIFF
--- a/src/gateway/server/plugins-http.test.ts
+++ b/src/gateway/server/plugins-http.test.ts
@@ -2,6 +2,7 @@
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
 import type { Duplex } from "node:stream";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { PluginInstance } from "../../plugins/plugin-instance.js";
 import { createEmptyPluginRegistry } from "../../plugins/registry.js";
 import { setActivePluginRegistry } from "../../plugins/runtime.js";
 import { getPluginRuntimeGatewayRequestScope } from "../../plugins/runtime/gateway-request-scope.js";
@@ -183,6 +184,26 @@ async function invokeCanvasGatewayUpgrade(params: { gatewayAuthSatisfied: boolea
 describe("createGatewayPluginRequestHandler", () => {
   afterEach(() => {
     setActivePluginRegistry(createEmptyPluginRegistry());
+  });
+
+  it("fences an identity-preserved route after its plugin instance retires", async () => {
+    const instance = new PluginInstance("identity-route");
+    const routeHandler = instance.adopt(vi.fn(async () => true));
+    const log = createPluginLog();
+    const handler = createGatewayPluginRequestHandler({
+      registry: createGatewayTestRegistry({
+        httpRoutes: [createRoute({ path: "/identity", handler: routeHandler })],
+      }),
+      log,
+    });
+    await instance.dispose();
+
+    const { res } = makeMockHttpResponse();
+    await expect(handler({ url: "/identity" } as IncomingMessage, res)).resolves.toBe(true);
+    expect(routeHandler).not.toHaveBeenCalled();
+    expect(log.warn).toHaveBeenCalledWith(
+      expect.stringContaining("Plugin identity-route was reloaded or disabled"),
+    );
   });
 
   it("keeps unauthenticated plugin routes off operator runtime scopes", async () => {

--- a/src/gateway/server/plugins-http.ts
+++ b/src/gateway/server/plugins-http.ts
@@ -7,6 +7,7 @@ import {
 } from "../../../packages/gateway-protocol/src/client-info.js";
 import { PROTOCOL_VERSION } from "../../../packages/gateway-protocol/src/index.js";
 import type { createSubsystemLogger } from "../../logging/subsystem.js";
+import { getPluginValueInstance } from "../../plugins/plugin-instance-scope.js";
 import type { PluginHttpRouteRegistration, PluginRegistry } from "../../plugins/registry.js";
 import { withPluginRuntimeGatewayRequestScope } from "../../plugins/runtime/gateway-request-scope.js";
 import { rejectWebSocketUpgrade } from "../../shared/websocket-upgrade-reject.js";
@@ -42,6 +43,11 @@ export {
 
 type SubsystemLogger = ReturnType<typeof createSubsystemLogger>;
 type PluginRouteRuntimeScope = Parameters<typeof withPluginRuntimeGatewayRequestScope>[0];
+
+function runPluginRouteValue<T>(value: object, run: () => T): T {
+  const instance = getPluginValueInstance(value);
+  return instance ? instance.runConsumer(run) : run();
+}
 
 function resolvePluginRoutePathContextForRequest(
   req: IncomingMessage,
@@ -269,7 +275,7 @@ export function createGatewayPluginRequestHandler(params: {
               gatewayRequestOperatorScopes,
               gatewayRequestClientIp: dispatchContext?.gatewayRequestClientIp,
             }),
-            async () => route.handler(req, res),
+            async () => runPluginRouteValue(route.handler, () => route.handler(req, res)),
           )) !== false;
         // Entitled trusted-operator routes delegate substantive work through Gateway dispatch.
         // An outer root would make gateway.suspend.prepare nested and permanently unreachable.
@@ -349,7 +355,10 @@ export function createGatewayPluginUpgradeHandler(params: {
                 gatewayRequestOperatorScopes,
                 gatewayRequestClientIp: dispatchContext?.gatewayRequestClientIp,
               }),
-              async () => route.handleUpgrade?.(req, socket, head),
+              async () => {
+                const handleUpgrade = route.handleUpgrade!;
+                return runPluginRouteValue(handleUpgrade, () => handleUpgrade(req, socket, head));
+              },
             )) !== false,
         );
         if (handled) {

--- a/src/plugins/api-facades.ts
+++ b/src/plugins/api-facades.ts
@@ -25,6 +25,22 @@ type PluginApiFacadeSource = Pick<
   | "unscheduleSessionTurnsByTag"
 >;
 
+const identitySensitiveRegistrations = new Set([
+  "registerCompactionProvider",
+  "registerHttpRoute",
+  "registerImageGenerationProvider",
+  "registerMediaUnderstandingProvider",
+  "registerMigrationProvider",
+  "registerMusicGenerationProvider",
+  "registerRealtimeTranscriptionProvider",
+  "registerRealtimeVoiceProvider",
+  "registerSpeechProvider",
+  "registerTranscriptSourceProvider",
+  "registerVideoGenerationProvider",
+  "registerWebFetchProvider",
+  "registerWebSearchProvider",
+]);
+
 /** Attaches nested facade namespaces to the flat plugin API implementation. */
 export function attachPluginApiFacades<T extends object>(
   api: T & PluginApiFacadeSource & Partial<PluginApiFacadeFields>,
@@ -88,7 +104,9 @@ export function instrumentPluginInstanceApi(
             Reflect.apply(
               value,
               target,
-              args.map((arg) => instance.wrap(arg)),
+              args.map((arg) =>
+                identitySensitiveRegistrations.has(key) ? instance.adopt(arg) : instance.wrap(arg),
+              ),
             ),
           );
       },

--- a/src/plugins/compaction-provider.test.ts
+++ b/src/plugins/compaction-provider.test.ts
@@ -2,6 +2,7 @@
 import { afterEach, describe, expect, it } from "vitest";
 import { getCompactionProvider, type CompactionProvider } from "./compaction-provider.js";
 import { createPluginRecord } from "./loader-records.js";
+import { getPluginInstance } from "./plugin-instance-scope.js";
 import { createPluginRegistry } from "./registry.js";
 import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "./runtime.js";
 import type { PluginRuntime } from "./runtime/types.js";
@@ -46,18 +47,18 @@ function makeProvider(id: string, label?: string): CompactionProvider {
 describe("compaction provider registry", () => {
   it("reads providers registered through the plugin API from the active registry", async () => {
     const pluginRegistry = createTestRegistry();
+    const record = createRecord("owner");
     const provider = makeProvider("owned");
-    pluginRegistry
-      .createApi(createRecord("owner"), { config: {} })
-      .registerCompactionProvider(provider);
+    pluginRegistry.createApi(record, { config: {} }).registerCompactionProvider(provider);
     setActivePluginRegistry(pluginRegistry.registry);
 
     expect(pluginRegistry.registry.compactionProviders).toEqual([
       { provider, ownerPluginId: "owner" },
     ]);
-    await expect(getCompactionProvider("owned")?.summarize({ messages: [] })).resolves.toBe(
-      "summary-from-owned",
-    );
+    const resolved = getCompactionProvider("owned");
+    await expect(resolved?.summarize({ messages: [] })).resolves.toBe("summary-from-owned");
+    await getPluginInstance(record)?.dispose();
+    expect(() => resolved?.summarize({ messages: [] })).toThrow(/reloaded|disabled|retiring/);
   });
 
   it("keeps the first provider when another plugin registers the same id", () => {

--- a/src/plugins/compaction-provider.ts
+++ b/src/plugins/compaction-provider.ts
@@ -1,9 +1,12 @@
+import { getPluginValueInstance } from "./plugin-instance-scope.js";
 import type { CompactionProvider } from "./registry-contribution-types.js";
 import { requireActivePluginRegistry } from "./runtime.js";
 
 export type { CompactionProvider } from "./registry-contribution-types.js";
 
 export function getCompactionProvider(id: string): CompactionProvider | undefined {
-  return requireActivePluginRegistry().compactionProviders.find((entry) => entry.provider.id === id)
-    ?.provider;
+  const provider = requireActivePluginRegistry().compactionProviders.find(
+    (entry) => entry.provider.id === id,
+  )?.provider;
+  return provider ? (getPluginValueInstance(provider)?.wrap(provider) ?? provider) : undefined;
 }

--- a/src/plugins/migration-provider-runtime.ts
+++ b/src/plugins/migration-provider-runtime.ts
@@ -11,6 +11,7 @@ import {
   resolveMigrationProviderPublicArtifacts,
   type MigrationProviderArtifactPlugin,
 } from "./migration-provider-public-artifacts.js";
+import { getPluginValueInstance } from "./plugin-instance-scope.js";
 import type { MigrationProviderPlugin } from "./types.js";
 
 type MigrationProviderPluginResolution = {
@@ -139,11 +140,13 @@ export async function withPluginMigrationProviders<T>(
     ...(compatConfig === undefined ? {} : { config: compatConfig }),
     onlyPluginIds: resolution.pluginIds,
   });
+  const providers = mergeMigrationProviders(
+    activeProviders,
+    acquisition.registry.migrationProviders,
+  ).map((provider) => getPluginValueInstance(provider)?.wrap(provider) ?? provider);
   let result: T;
   try {
-    result = await run(
-      mergeMigrationProviders(activeProviders, acquisition.registry.migrationProviders),
-    );
+    result = await run(providers);
   } catch (error) {
     const failures = [error];
     try {

--- a/src/plugins/plugin-instance-scope.ts
+++ b/src/plugins/plugin-instance-scope.ts
@@ -19,6 +19,7 @@ export interface PluginInstanceHandle extends PluginInvocationInstance, PluginIn
   readonly owner?: PluginInstanceOwner;
   toolRegistrationComplete: boolean;
   runConsumer<T>(consume: () => T): T;
+  adopt<T>(value: T): T;
   retainConsumer(
     invoke?: <T>(run: () => T) => T,
     registry?: PluginRegistry,

--- a/src/plugins/plugin-instance.ts
+++ b/src/plugins/plugin-instance.ts
@@ -118,6 +118,29 @@ export class PluginInstance {
     return this.invoke(run, this.lease(true, registry));
   }
 
+  /** Associates an identity-sensitive public value without replacing it with a view. */
+  adopt<T>(value: T): T {
+    const seen = new WeakSet<object>();
+    const visit = (candidate: unknown) => {
+      if (
+        !candidate ||
+        (typeof candidate !== "object" && typeof candidate !== "function") ||
+        seen.has(candidate)
+      ) {
+        return;
+      }
+      seen.add(candidate);
+      valueInstances.set(candidate, this);
+      for (const descriptor of Object.values(Object.getOwnPropertyDescriptors(candidate))) {
+        if ("value" in descriptor) {
+          visit(descriptor.value);
+        }
+      }
+    };
+    visit(value);
+    return value;
+  }
+
   createRegistryView(registry: PluginRegistry, invoke: <T>(run: () => T) => T): <T>(value: T) => T {
     return this.createValueView(<T>(run: () => T) =>
       invoke(() => this.runInRegistry(registry, run)),

--- a/src/plugins/registry-registrars-providers.ts
+++ b/src/plugins/registry-registrars-providers.ts
@@ -16,6 +16,7 @@ import { validateWorkerProviderContract } from "./worker-provider-registry.js";
 export function createProviderRegistrars(state: PluginRegistryState) {
   const {
     registry,
+    createIdentityRegistration,
     createRegistration,
     pushDiagnostic,
     reportRegistrationError,
@@ -217,7 +218,7 @@ export function createProviderRegistrars(state: PluginRegistryState) {
         ownedIds.push(id);
       }
       params.registrations.push(
-        createRegistration(record, {
+        createIdentityRegistration(record, {
           provider,
         }),
       );

--- a/src/plugins/registry-state.ts
+++ b/src/plugins/registry-state.ts
@@ -65,6 +65,16 @@ function createRegistration<T extends object>(record: PluginRecord, contribution
   };
 }
 
+function createIdentityRegistration<T extends object>(record: PluginRecord, contribution: T) {
+  return {
+    pluginId: record.id,
+    pluginName: record.name,
+    ...(getPluginInstance(record)?.adopt(contribution) ?? contribution),
+    source: record.source,
+    rootDir: record.rootDir,
+  };
+}
+
 export function createPluginRegistryState(registryParams: PluginRegistryParams) {
   const registry = createEmptyPluginRegistry();
   const nativeCatalogGates = new WeakMap<
@@ -116,6 +126,7 @@ export function createPluginRegistryState(registryParams: PluginRegistryParams) 
     getHostCronService: () => registryParams.hostServices?.cron,
     pluginsWithChannelRegistrationConflict: new Set<string>(),
     createRegistration,
+    createIdentityRegistration,
     pushDiagnostic,
     reportRegistrationError,
     reportRegistrationWarning,


### PR DESCRIPTION
## Summary
- preserve exact descriptor and handler identity for plugin registrations that expose public registry values
- keep retired-instance execution fencing at capability resolution and HTTP dispatch boundaries
- cover compaction and HTTP lifecycle revocation without proxying public registration objects

## Release-validation evidence
- fixes the Full Validation plugin registration identity and Gateway Discord transcript-provider identity failures from run 34647360664
- 321 focused gateway/plugin tests pass on current main
- `check:changed` production and test typechecks pass; the only unskipped dead-code failure is the pre-existing current-main `ui/src/pages/new-session/cloud-target.ts` unused exports