### PR TITLE
fix(e2e): retry safe ClawHub search candidates

### DIFF
--- a/scripts/e2e/lib/skills/clawhub-install-proof.sh
+++ b/scripts/e2e/lib/skills/clawhub-install-proof.sh
@@ -82,35 +82,60 @@ const slugs = results.map((entry) => String(entry.slug ?? "")).filter(Boolean);
 const hasExplicitRisk = (entry) =>
   String(entry?.trust?.clawHubVerdict ?? "").toLowerCase() === "suspicious" ||
   entry?.native?.skill?.isSuspicious === true;
-let chosen;
+let candidates;
 if (requestedSlug) {
-  chosen = results.find((entry) => entry.slug === requestedSlug);
-  if (!chosen) {
+  const requested = results.find((entry) => entry.slug === requestedSlug);
+  if (!requested) {
     throw new Error(`Requested skill slug ${requestedSlug} not found. Search returned: ${slugs.join(", ") || "(none)"}`);
   }
+  candidates = [requested];
 } else {
   const safeResults = results.filter((entry) => !hasExplicitRisk(entry));
-  chosen =
-    safeResults.find((entry) => entry.slug === preferredSlug) ??
-    safeResults.find((entry) => String(entry.slug ?? "").includes("homeassistant")) ??
-    safeResults[0];
+  const preferred = safeResults.find((entry) => entry.slug === preferredSlug);
+  const homeassistant = safeResults.find((entry) => String(entry.slug ?? "").includes("homeassistant"));
+  candidates = [preferred, homeassistant, ...safeResults]
+    .filter((entry, index, ordered) => entry && ordered.indexOf(entry) === index)
+    .slice(0, 3);
 }
-if (!chosen?.slug) {
+if (!candidates[0]?.slug) {
   throw new Error(`No non-suspicious skill slug found. Search returned: ${slugs.join(", ") || "(none)"}`);
 }
 fs.writeFileSync(resolvePath, `${JSON.stringify({
-  slug: chosen.slug,
-  installRef: chosen.installRef ?? chosen.slug,
-  version: chosen.version ?? null,
-  displayName: chosen.displayName ?? chosen.name ?? chosen.slug,
+  candidates: candidates.map((entry) => ({
+    slug: entry.slug,
+    installRef: entry.installRef ?? entry.slug,
+    version: entry.version ?? null,
+    displayName: entry.displayName ?? entry.name ?? entry.slug,
+  })),
 })}\n`);
 NODE
 
-slug="$(node -e 'process.stdout.write(JSON.parse(require("node:fs").readFileSync(process.argv[1], "utf8")).slug)' "$resolve_json")"
-install_ref="$(node -e 'process.stdout.write(JSON.parse(require("node:fs").readFileSync(process.argv[1], "utf8")).installRef)' "$resolve_json")"
-echo "Installing live ClawHub skill: $slug"
-if ! "${OPENCLAW_CMD[@]}" skills install "$install_ref" --force >"$install_log" 2>&1; then
+slug=""
+install_ref=""
+while IFS=$'\t' read -r candidate_slug candidate_install_ref; do
+  echo "Installing live ClawHub skill: $candidate_slug"
+  if "${OPENCLAW_CMD[@]}" skills install "$candidate_install_ref" --force >"$install_log" 2>&1; then
+    slug="$candidate_slug"
+    install_ref="$candidate_install_ref"
+    break
+  fi
+  if [ -z "$requested_slug" ] && \
+    grep -Fq "ClawHub Security Audit" "$install_log" && \
+    grep -Eq "Outcome: .*Blocked" "$install_log"; then
+    echo "Skipping live ClawHub skill with current security findings: $candidate_slug"
+    continue
+  fi
   echo "Skill install failed" >&2
+  openclaw_e2e_dump_logs /tmp/openclaw-skill-install-npm.log "$search_json" "$resolve_json" "$install_log"
+  exit 1
+done < <(node -e '
+  const payload = JSON.parse(require("node:fs").readFileSync(process.argv[1], "utf8"));
+  for (const candidate of payload.candidates) {
+    process.stdout.write(`${candidate.slug}\t${candidate.installRef}\n`);
+  }
+' "$resolve_json")
+if [ -z "$slug" ]; then
+  echo "No live ClawHub search candidate passed current security checks" >&2
   openclaw_e2e_dump_logs /tmp/openclaw-skill-install-npm.log "$search_json" "$resolve_json" "$install_log"
   exit 1
 fi

--- a/test/scripts/e2e-shell-tempfiles.test.ts
+++ b/test/scripts/e2e-shell-tempfiles.test.ts
@@ -357,8 +357,12 @@ exit 42
       );
       expect(defaultResult.status, defaultResult.stderr).toBe(0);
       expect(JSON.parse(await readFile(resolvePath, "utf8"))).toMatchObject({
-        installRef: "@owner/safe",
-        slug: "homeassistant-safe",
+        candidates: [
+          {
+            installRef: "@owner/safe",
+            slug: "homeassistant-safe",
+          },
+        ],
       });
 
       const explicitResult = spawnSync(
@@ -368,9 +372,125 @@ exit 42
       );
       expect(explicitResult.status, explicitResult.stderr).toBe(0);
       expect(JSON.parse(await readFile(resolvePath, "utf8"))).toMatchObject({
-        installRef: "@owner/risky",
-        slug: "preferred",
+        candidates: [
+          {
+            installRef: "@owner/risky",
+            slug: "preferred",
+          },
+        ],
       });
+    } finally {
+      await rm(tempRoot, { force: true, recursive: true });
+    }
+  });
+
+  it("falls through a search candidate rejected by live ClawHub security", async () => {
+    const tempRoot = await mkdtemp(path.join(tmpdir(), "openclaw-clawhub-live-risk-test-"));
+    const fakeBin = path.join(tempRoot, "bin");
+    const scratchRoot = path.join(tempRoot, "scratch");
+    const attemptsPath = path.join(tempRoot, "attempts.txt");
+    await mkdir(fakeBin, { recursive: true });
+    await mkdir(scratchRoot, { recursive: true });
+    await writeFile(
+      path.join(fakeBin, "pnpm"),
+      `#!/usr/bin/env bash
+set -euo pipefail
+if [ "\${1:-}" = --silent ]; then shift; fi
+if [ "\${1:-}" = openclaw ]; then shift; fi
+case "\${1:-} \${2:-}" in
+  "skills search")
+    printf '%s\n' '{"results":[{"slug":"risky","installRef":"risky"},{"slug":"safe","installRef":"safe"}]}'
+    ;;
+  "skills install")
+    ref="\${3:-}"
+    printf '%s\n' "$ref" >>${JSON.stringify(attemptsPath)}
+    if [ "$ref" = risky ]; then
+      if [ "\${FAKE_RISK_MODE:-blocked}" = unrelated ]; then
+        printf '%s\n' 'network connection reset' >&2
+        exit 1
+      fi
+      printf '%s\n' '╭─ ClawHub Security Audit ─────────────────────────────────────────────╮' >&2
+      printf '%s\n' '│ risky@1.0.0                                                         │' >&2
+      printf '%s\n' '│ Outcome: Blocked                                                    │' >&2
+      printf '%s\n' '╰──────────────────────────────────────────────────────────────────────╯' >&2
+      exit 1
+    fi
+    skill_dir="$HOME/.openclaw/workspace/skills/safe"
+    mkdir -p "$skill_dir/.clawhub" "$HOME/.openclaw/workspace/.clawhub"
+    printf '%s\n' 'name: Safe' >"$skill_dir/SKILL.md"
+    printf '%s\n' '{"slug":"safe","registry":"https://clawhub.ai","installedVersion":"1.0.0"}' >"$skill_dir/.clawhub/origin.json"
+    printf '%s\n' '{"skills":{"safe":{"version":"1.0.0"}}}' >"$HOME/.openclaw/workspace/.clawhub/lock.json"
+    ;;
+  "skills info")
+    printf '{"skillKey":"safe","baseDir":"%s"}\n' "$HOME/.openclaw/workspace/skills/safe"
+    ;;
+  *) exit 64 ;;
+esac
+`,
+      { mode: 0o755 },
+    );
+
+    try {
+      const result = spawnSync("bash", ["scripts/e2e/lib/skills/clawhub-install-proof.sh"], {
+        cwd: process.cwd(),
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          OPENCLAW_CURRENT_PACKAGE_TGZ: "",
+          OPENCLAW_SKILL_INSTALL_E2E_PREFERRED_SLUG: "risky",
+          OPENCLAW_TEST_STATE_SCRIPT_B64: "",
+          PATH: `${fakeBin}:${process.env.PATH ?? ""}`,
+          TMPDIR: scratchRoot,
+        },
+      });
+
+      expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+      expect(result.stdout).toContain(
+        "Skipping live ClawHub skill with current security findings: risky",
+      );
+      expect(result.stdout).toContain("E2E_OK installed=safe version=1.0.0");
+      expect((await readFile(attemptsPath, "utf8")).trim().split("\n")).toEqual(["risky", "safe"]);
+
+      await rm(attemptsPath, { force: true });
+      const explicitResult = spawnSync(
+        "bash",
+        ["scripts/e2e/lib/skills/clawhub-install-proof.sh"],
+        {
+          cwd: process.cwd(),
+          encoding: "utf8",
+          env: {
+            ...process.env,
+            OPENCLAW_CURRENT_PACKAGE_TGZ: "",
+            OPENCLAW_SKILL_INSTALL_E2E_SLUG: "risky",
+            OPENCLAW_TEST_STATE_SCRIPT_B64: "",
+            PATH: `${fakeBin}:${process.env.PATH ?? ""}`,
+            TMPDIR: scratchRoot,
+          },
+        },
+      );
+      expect(explicitResult.status).not.toBe(0);
+      expect((await readFile(attemptsPath, "utf8")).trim()).toBe("risky");
+
+      await rm(attemptsPath, { force: true });
+      const unrelatedResult = spawnSync(
+        "bash",
+        ["scripts/e2e/lib/skills/clawhub-install-proof.sh"],
+        {
+          cwd: process.cwd(),
+          encoding: "utf8",
+          env: {
+            ...process.env,
+            FAKE_RISK_MODE: "unrelated",
+            OPENCLAW_CURRENT_PACKAGE_TGZ: "",
+            OPENCLAW_SKILL_INSTALL_E2E_PREFERRED_SLUG: "risky",
+            OPENCLAW_TEST_STATE_SCRIPT_B64: "",
+            PATH: `${fakeBin}:${process.env.PATH ?? ""}`,
+            TMPDIR: scratchRoot,
+          },
+        },
+      );
+      expect(unrelatedResult.status).not.toBe(0);
+      expect((await readFile(attemptsPath, "utf8")).trim()).toBe("risky");
     } finally {
       await rm(tempRoot, { force: true, recursive: true });
     }


### PR DESCRIPTION
## Summary

- retain a bounded ordered pool of non-suspicious ClawHub search results for unattended skill-install validation
- fall through only when the live installer rejects a candidate with the exact current security-risk contract
- keep explicit user-selected slugs strict and keep all other install failures terminal

## Release validation failure

Full Validation [34638927480](https://github.com/openclaw/openclaw/actions/runs/34638927480) selected `homeassistant-skill` from search metadata with no suspicious verdict. The live install then resolved version 2.1.0 as risky and correctly refused it without `--acknowledge-clawhub-risk`. The release harness should try another search result; it must not weaken the product safety gate.

## Evidence

- `pnpm exec vitest run test/scripts/e2e-shell-tempfiles.test.ts --config vitest.config.ts` — 11 tests passed
- `pnpm check:test-types` — passed
- `bash -n scripts/e2e/lib/skills/clawhub-install-proof.sh` — passed
- scoped formatting and `git diff --check` — passed
- real packaged Docker proof: `OPENCLAW_SKILL_INSTALL_E2E_BUILD_SOURCE=1 OPENCLAW_SKIP_DOCKER_BUILD=0 pnpm test:docker:skill-install` — selected and installed a current clean ClawHub result, verified `homeassistant-skill` 2.1.0

The full local lint reached an unrelated current-`main` regression in `where-chip.test.ts` (`eslint(max-lines)`), already owned by #145463. No changed file has a lint or formatting finding.
