### PR TITLE
fix(control-ui): repair picker lint and action cursor

### DIFF
--- a/ui/src/pages/new-session/where-chip.test.ts
+++ b/ui/src/pages/new-session/where-chip.test.ts
@@ -850,39 +850,10 @@ describe("Where chip", () => {
   });
 
   it("omits automatic placement when no devices are paired and Auto is off", () => {
-    const state = resolveWhereChip({
+    const emptyContainer = renderPicker(false, undefined, {
       environments: [],
       cloudProfiles: [],
-      cloudProfileId: "",
-      deviceId: "",
     });
-    const emptyContainer = document.createElement("div");
-    render(
-      renderWhereChip({
-        state,
-        gatewayName: "",
-        environmentQuery: "",
-        onEnvironmentQueryInput: vi.fn(),
-        cloudProfileId: "",
-        deviceId: "",
-        worktreeAvailable: true,
-        submitting: false,
-        pendingPlacement: false,
-        popoverOpen: true,
-        popoverHiding: false,
-        isAdmin: false,
-        onGuardTransition: vi.fn(),
-        onPopoverShow: vi.fn(),
-        onPopoverHide: vi.fn(),
-        onPopoverAfterHide: vi.fn(),
-        onSelectDevice: vi.fn(),
-        onSelectAutoDevice: vi.fn(),
-        onSelectCloudProfile: vi.fn(),
-        onConnectMachine: vi.fn(),
-        onManageCloudWorkers: () => undefined,
-      }),
-      emptyContainer,
-    );
     expect(emptyContainer.querySelector('[data-value="auto-device"]')).toBeNull();
   });
 

--- a/ui/src/styles/new-session.css
+++ b/ui/src/styles/new-session.css
@@ -1544,7 +1544,7 @@ wa-popover.new-session-page__where-popover::part(body) {
     border-radius: var(--radius-sm);
     color: var(--muted);
     background: transparent;
-    cursor: pointer;
+    cursor: var(--cursor-action);
   }
 
   .new-session-page__touch-details svg {


### PR DESCRIPTION
## What Problem This Solves

Unrelated PRs inherit two New Session CI failures: the Where chip test file exceeds its existing 1,000-line lint limit, and the environment-details button uses an unconditional pointer cursor instead of the shared action token.

## Why This Change Was Made

Reuse the existing picker fixture in the empty-device/Auto-off test, retaining every test and assertion. The file falls from 1,020 to 991 counted lines without a suppression or limit change. Use `var(--cursor-action)` for the existing details button, matching adjacent in-page actions.

## User Impact

The environment-details action follows the shared cursor policy. Its rendering, accessible-label attribute, button type, and dimensions remain unchanged. Navigation links retain their pointer cursor.

## Evidence

- All 65 tests in the complete Where chip file passed with no filtering or skips; the hosted changed-test job also passed those tests before reporting the separate cursor-policy failure.
- The complete, unchanged cursor-policy test and original stylesheet lint passed on the combined candidate. Formatting and whitespace checks passed.
- A separate Chromium component proof used the actual menu-item renderer, actual base token and exact before/after CSS under positively asserted coarse-pointer emulation. The details cursor changed from pointer to default; the sibling action remained default and the navigation control remained pointer. Geometry stayed 32 by 32, with no page or cleanup errors.
- Independent Codex review of both changes is scoped-clean through P2.
- The original type-aware lint attempt exceeded its unchanged 6 GiB process-tree RSS limit and produced no lint verdict. That failure remains recorded; the later policy/style checks do not turn it into a pass. Required CI on the final head remains necessary before landing.
- The [isolated cursor validation](https://github.com/openclaw/openclaw/actions/runs/34666434288) completed; all 13 native children and monitors closed, the worktree was removed normally, and the dedicated Testbox is confirmed completed.

## Before and After

These inspected captures contain only synthetic component data. The annotations show actual computed CSS values; they do not capture an OS pointer. The fixture displays an untranslated label key, so this is not localization, full-app or native-device proof.

![Before: environment details uses pointer](https://github.com/user-attachments/assets/dc9e9261-2c8f-4ec3-b0f2-81acc4df330e)

![After: environment details uses the shared default action cursor](https://github.com/user-attachments/assets/c3af7106-19f9-4d05-9965-5643e376151d)

This is a supporting CI repair, with no runtime performance claim.
