### PR TITLE
refactor(android): share scoped composer send interception

### DIFF
--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatComposerLayoutTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatComposerLayoutTest.kt
@@ -1202,25 +1202,7 @@ class ChatComposerLayoutTest {
     val height = mutableStateOf(720.dp)
     val viewModel = showChat(viewportWidth = 720.dp, viewportHeight = { height.value }, fontScale = { 1.5f }, useChatShell = true)
     val owner = viewModel.captureChatShareOwner()
-    val sent = ConcurrentLinkedQueue<JsonObject>()
-    val requestField = ChatController::class.java.getDeclaredField("requestGatewayForGateway").apply { isAccessible = true }
-
-    @Suppress("UNCHECKED_CAST")
-    val originalRequest = requestField.get(controller) as suspend (String, String, String?) -> String
-    val request: suspend (String, String, String?) -> String = { gatewayId, method, params ->
-      if (method == "chat.send") {
-        val payload = Json.parseToJsonElement(requireNotNull(params)).jsonObject
-        sent.add(payload)
-        buildJsonObject {
-          put("runId", payload.getValue("idempotencyKey"))
-          put("status", JsonPrimitive("started"))
-        }.toString()
-      } else {
-        originalRequest(gatewayId, method, params)
-      }
-    }
-    try {
-      requestField.set(controller, request)
+    withChatSendRequests { sent ->
       composeRule.runOnIdle {
         viewModel.chatComposerState.addAttachments(
           owner,
@@ -1298,6 +1280,30 @@ class ChatComposerLayoutTest {
       }
       assertEquals(JsonPrimitive(edited), sent.single()["message"])
       editor.assert(SemanticsMatcher.expectValue(SemanticsProperties.EditableText, AnnotatedString("")))
+    }
+  }
+
+  private fun withChatSendRequests(assertions: (ConcurrentLinkedQueue<JsonObject>) -> Unit) {
+    val sent = ConcurrentLinkedQueue<JsonObject>()
+    val requestField = ChatController::class.java.getDeclaredField("requestGatewayForGateway").apply { isAccessible = true }
+
+    @Suppress("UNCHECKED_CAST")
+    val originalRequest = requestField.get(controller) as suspend (String, String, String?) -> String
+    val request: suspend (String, String, String?) -> String = { gatewayId, method, params ->
+      if (method == "chat.send") {
+        val payload = Json.parseToJsonElement(requireNotNull(params)).jsonObject
+        sent.add(payload)
+        buildJsonObject {
+          put("runId", payload.getValue("idempotencyKey"))
+          put("status", JsonPrimitive("started"))
+        }.toString()
+      } else {
+        originalRequest(gatewayId, method, params)
+      }
+    }
+    try {
+      requestField.set(controller, request)
+      assertions(sent)
     } finally {
       requestField.set(controller, originalRequest)
     }
@@ -1362,25 +1368,7 @@ class ChatComposerLayoutTest {
     val height = mutableStateOf(720.dp)
     val viewModel = showChat(viewportWidth = 720.dp, viewportHeight = { height.value }, useChatShell = true)
     val owner = viewModel.captureChatShareOwner()
-    val sent = ConcurrentLinkedQueue<JsonObject>()
-    val requestField = ChatController::class.java.getDeclaredField("requestGatewayForGateway").apply { isAccessible = true }
-
-    @Suppress("UNCHECKED_CAST")
-    val originalRequest = requestField.get(controller) as suspend (String, String, String?) -> String
-    val request: suspend (String, String, String?) -> String = { gatewayId, method, params ->
-      if (method == "chat.send") {
-        val payload = Json.parseToJsonElement(requireNotNull(params)).jsonObject
-        sent.add(payload)
-        buildJsonObject {
-          put("runId", payload.getValue("idempotencyKey"))
-          put("status", JsonPrimitive("started"))
-        }.toString()
-      } else {
-        originalRequest(gatewayId, method, params)
-      }
-    }
-    try {
-      requestField.set(controller, request)
+    withChatSendRequests { sent ->
       val editor = composeRule.onNode(hasSetTextAction())
       val draft = "Visible draft"
       editor.performClick().performTextReplacement(draft)
@@ -1416,8 +1404,6 @@ class ChatComposerLayoutTest {
       composeRule.waitUntil { composeRule.runOnIdle { sent.isNotEmpty() } }
       assertEquals(listOf(JsonPrimitive(edited)), sent.map { it["message"] })
       editor.assert(SemanticsMatcher.expectValue(SemanticsProperties.EditableText, AnnotatedString("")))
-    } finally {
-      requestField.set(controller, originalRequest)
     }
   }
 
@@ -4368,25 +4354,7 @@ class ChatComposerLayoutTest {
     val owner = viewModel.captureChatShareOwner()
     assertTrue("The fixture must have an active run", controller.pendingRunCount.value > 0)
     assertTrue("The composer must have a routable controller owner", controller.isCurrentComposerOwner(owner))
-    val sent = ConcurrentLinkedQueue<JsonObject>()
-    val requestField = ChatController::class.java.getDeclaredField("requestGatewayForGateway").apply { isAccessible = true }
-
-    @Suppress("UNCHECKED_CAST")
-    val originalRequest = requestField.get(controller) as suspend (String, String, String?) -> String
-    val request: suspend (String, String, String?) -> String = { gatewayId, method, params ->
-      if (method == "chat.send") {
-        val payload = Json.parseToJsonElement(requireNotNull(params)).jsonObject
-        sent.add(payload)
-        buildJsonObject {
-          put("runId", payload.getValue("idempotencyKey"))
-          put("status", JsonPrimitive("started"))
-        }.toString()
-      } else {
-        originalRequest(gatewayId, method, params)
-      }
-    }
-    try {
-      requestField.set(controller, request)
+    withChatSendRequests { sent ->
       val draft = "Physical follow-up"
       val editor = composeRule.onNode(hasSetTextAction())
       editor.performClick()
@@ -4403,8 +4371,6 @@ class ChatComposerLayoutTest {
       }
       assertEquals(List(expectedSends) { JsonPrimitive(draft) }, sent.map { it["message"] })
       editor.assert(SemanticsMatcher.expectValue(SemanticsProperties.EditableText, AnnotatedString(if (expectedSends == 0) draft else "")))
-    } finally {
-      requestField.set(controller, originalRequest)
     }
   }
 


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

Three Android composer test flows repeat the same scoped chat-send interception and restoration. That repeated harness code makes the IME, Details-panel, and physical-Enter scenarios harder to follow and maintain.

## Why This Change Was Made

Extract the existing interception into one private, synchronous `withChatSendRequests` helper. Each invocation retains its own capture queue, delegates other methods to the original suspend callback, and restores that callback in `finally`. All six scenarios keep their complete action and assertion bodies in place. No production seam, dispatcher, or additional reflection is introduced.

## User Impact

No user-visible behavior changes or runtime improvement claimed. The test file loses 34 lines while retaining its platform and lifecycle coverage.

## Evidence

- Source inverse reconstruction reproduces the original file byte-for-byte after expanding the three helper calls. Whitespace checks, 11 feasible non-Android mapped checks, and independent review through P2 passed.
- Baseline Android Play CI [34659583792](https://github.com/openclaw/openclaw/actions/runs/34659583792) tested checkout `aa0ad4c78044f389460de42caa798ad5f75c86a9`. Its retained class XML reports 102 tests with zero failures, errors, or skips, including all six affected scenarios. Relevant Android, workflow, and toolchain inputs match this candidate's base.
- Candidate [CI 34664952319](https://github.com/openclaw/openclaw/actions/runs/34664952319) passed Android Play, third-party, Wear, ktlint, and the required CI gate. These were hosted checks; Android tooling was not installed or run locally.
- The candidate Play job tested merge checkout `8018f5941a6c636745e105e89988c323f50b2993`, whose entire Git tree matches PR head `061dda6b433826b4d7177fd64d30ad7d73928563`. Its [JUnit artifact](https://github.com/openclaw/openclaw/actions/runs/34664952319/artifacts/10289280961) has the same 102 class case names and results as the saved baseline: zero failures, errors, or skips, including all six affected scenarios. The checkout logs, artifact digests, and unchanged Android workflow/toolchain inputs were verified.
