### PR TITLE
perf(transcripts): reuse the final export byte count

### DIFF
--- a/src/transcripts/library.ts
+++ b/src/transcripts/library.ts
@@ -196,7 +196,8 @@ export async function exportTranscriptLibrary(
         : summary
           ? `${renderTranscriptsMarkdown({ ...summary, title, transcript: parts, utteranceCount: entry.utteranceCount })}\n\nSummary covers ${summary.utteranceCount} saved utterances.\n`
           : `# ${title}\n\nSession: ${sanitizeTerminalText(entry.session.sessionId)}\nStarted: ${entry.session.startedAt}\n\n## Transcript\n${parts.map((line) => `- ${line}`).join("\n")}\n`;
-  assertTranscriptByteLimit(body, TRANSCRIPTS_EXPORT_MAX_BYTES, true);
+  const bodySizeBytes = Buffer.byteLength(body, "utf8");
+  assertTranscriptByteCount(bodySizeBytes, TRANSCRIPTS_EXPORT_MAX_BYTES, true);
   const digest = createHash("sha256").update(entry.selector).digest("hex").slice(0, 12);
   const filename = `transcript-${safeTranscriptPathSegment(entry.session.startedAt.slice(0, 10))}-${digest}.${params.format === "markdown" ? "md" : "jsonl"}`;
   return {
@@ -208,6 +209,6 @@ export async function exportTranscriptLibrary(
         : "application/x-ndjson;charset=utf-8",
     encoding: "base64",
     data: Buffer.from(body, "utf8").toString("base64"),
-    sizeBytes: Buffer.byteLength(body, "utf8"),
+    sizeBytes: bodySizeBytes,
   };
 }


### PR DESCRIPTION
## What Problem This Solves

Transcript downloads perform avoidable work after assembling the complete export. This change removes one repeated scan of the finished UTF-8 content, with measured wall-time improvements for the large Markdown fixture in both process orders.

## Why This Change Was Made

Reuse the final byte count already required by the download-limit check in the returned `sizeBytes` field. The same strict limit check still runs before encoding; SQLite row bounds, accumulated-content bounds, projection, formatting, filenames, returned bytes, errors, snapshot ownership, and iterator cleanup remain unchanged. There is no storage, migration, update, or authorization change.

## User Impact

Download content and limits are unchanged. The change adds one local variable and removes the second final-content byte scan. The measured benefit is scoped: the results do **not** establish a general speedup for all exports or for the Gateway/CLI as a whole.

## Evidence

[Focused Linux validation](https://github.com/openclaw/openclaw/actions/runs/34664023702) passed all **37 tests across two files**, with none skipped or unselected: `src/transcripts/library.test.ts` and `src/transcripts/library.async.test.ts`. Formatting passed. Fresh managed Codex P2 review reported no actionable findings. The matching formatter made no byte changes, and esbuild emitted identical JavaScript before and after formatting.

The changed-check dry run passed and selected the core/coreTests lanes; it did **not** execute the full changed gate. This PR remains draft while the shared lint repair is pending. Hosted lint, typechecking, and the remaining required PR checks must complete before landing.

[One bounded Linux measurement](https://github.com/openclaw/openclaw/actions/runs/34663399036) used the real `exportTranscriptLibrary` operation and canonical SQLite store writers, with fresh B1/C1/C2/B2 processes, two warmup batches, and seven measured batches. All 1,336 calls completed. Complete input and returned-byte/error graphs matched across all four phases; each timed batch also checked its complete final return outside timing. Exact 4 MiB downloads succeeded and one-byte-over-limit downloads failed in both formats. Those boundary controls were not timed. All native children and database finalizers completed, the owned worktrees were removed, and both dedicated Testbox leases were stopped and verified absent.

Per-call wall medians below are milliseconds; CPU columns show the median percentage change. Negative changes mean less time. Small-case batches contained eight exports; large-case batches contained two.

| Fixture | B1 → C1 wall ms | Wall change | B2 → C2 wall ms | Wall change | CPU change B1/C1; B2/C2 |
| --- | ---: | ---: | ---: | ---: | ---: |
| Empty JSONL | 1.767 → 1.814 | +2.66% | 1.754 → 1.803 | +2.75% | −3.42%; +12.07% |
| Short Unicode JSONL | 1.727 → 1.759 | +1.82% | 1.749 → 1.736 | −0.75% | +3.24%; −2.89% |
| Short Markdown | 1.728 → 1.772 | +2.50% | 1.740 → 1.762 | +1.26% | +2.74%; +4.63% |
| Canonical notes plus full Markdown | 1.764 → 1.710 | −3.08% | 1.956 → 1.798 | −8.08% | −2.55%; −3.86% |
| Escaped/multibyte JSONL, 852,560 bytes | 9.332 → 8.736 | −6.39% | 7.241 → 8.645 | +19.38% | −8.01%; +19.83% |
| Large Markdown, 3,136,665 bytes | 7.787 → 7.044 | −9.54% | 7.975 → 7.452 | −6.56% | −9.54%; +0.41% |

The adverse cases are retained: empty and short Markdown wall medians increased, the reverse-order Unicode case regressed, and large Markdown CPU was essentially flat in reverse order. Whole-child wall time changed +1.33%/−4.26%; user CPU −0.004%/−6.18%; system CPU −0.47%/−6.36%. Kernel peak RSS changed −3.81%/+3.19%, and sampled process-tree peak RSS −7.49%/+8.27%. Native resources include imports, fixture setup, and parity checks, which are outside per-call timing. This is one four-process comparison, not a population confidence estimate; the small canonical-notes gain should not be generalized.

Measurements remain pinned to `c38897f5544081974bc13632c2f1a17337b52ba7`; focused validation and review use author base `c2a48c74dc4d915d2ef1dfb706e7c3612ea6ee6a`. The candidate, transcript export/store/limit/projection/summary owners, protocol, and package toolchain are unchanged between those bases. Relevant dependency differences add an unrelated cron first-use table/type and change config-write/legacy-audit-migration handling; the export fixture invokes neither workflow. These differences are recorded rather than presenting the earlier timings as measurements of the newer base.

**Current-head qualification:** Head `ca43cf37ac78` preserves this PR's authored patch on main `bca261d5583d`, including the shared `retainedMachine` typecheck repair (#145540). Benchmarks, earlier validation, and prior draft-state notes remain historical under their original source labels; no benchmark was rerun for this rebase. Exact-head CI is required before landing.
