### PR TITLE
refactor(acp): share session metadata reads

### DIFF
--- a/src/acp/runtime/session-meta.test.ts
+++ b/src/acp/runtime/session-meta.test.ts
@@ -557,6 +557,10 @@ describe("ACP session metadata SQLite store", () => {
           sessionKey: storeSessionKey,
         })?.acp?.runtimeSessionName,
       ).toBe("codex-normalized");
+      expect(
+        readAcpSessionMeta({ cfg, databasePath, sessionKey: `  ${rawSessionKey}  ` })
+          ?.runtimeSessionName,
+      ).toBe("codex-normalized");
       expect(fs.existsSync(storePath)).toBe(false);
       const legacyEmbeddedEntry = readStoredAcpSessionEntry({
         storePath,
@@ -734,6 +738,7 @@ describe("ACP session metadata SQLite store", () => {
       });
 
       expect(readAcpSessionEntry({ cfg, databasePath, sessionKey })?.acp).toBeUndefined();
+      expect(readAcpSessionMeta({ cfg, databasePath, sessionKey })).toBeUndefined();
       expect(await listAcpSessionEntries({ cfg, databasePath })).toHaveLength(0);
 
       writeAcpSessionMetaForMigration({

--- a/src/acp/runtime/session-meta.ts
+++ b/src/acp/runtime/session-meta.ts
@@ -107,38 +107,11 @@ export function readAcpSessionMeta(params: {
   env?: NodeJS.ProcessEnv;
   databasePath?: string;
 }): SessionAcpMeta | undefined {
-  const sessionKey = params.sessionKey.trim();
-  if (!sessionKey) {
-    return undefined;
-  }
-  const storeEntry = readSessionEntryFromStore({
-    sessionKey,
-    agentId: params.agentId,
-    cfg: params.cfg,
-    env: params.env,
+  return readAcpSessionEntry({
+    ...params,
+    sessionKey: params.sessionKey.trim(),
     clone: false,
-  });
-  if (!storeEntry.storePath) {
-    return undefined;
-  }
-  const row = withExistingOpenClawStateDatabaseReadOnly(
-    ({ db }) =>
-      resolveReadableAcpSessionRow({
-        row: selectAcpSessionRowForStoreEntry(
-          db,
-          storeEntry.storeSessionKey,
-          storeEntry.agentId,
-          storeEntry.cfg,
-          storeEntry.entry,
-        ),
-        entry: storeEntry.entry,
-      }),
-    { env: params.env, path: params.databasePath },
-  );
-  if (!row) {
-    return undefined;
-  }
-  return rowToAcpSessionMeta(row);
+  })?.acp;
 }
 
 export function readAcpSessionMetaForEntry(params: {
@@ -414,21 +387,14 @@ export function readAcpSessionEntry(params: {
   if (!storeEntry.storePath) {
     return null;
   }
-  const row = withExistingOpenClawStateDatabaseReadOnly(
-    ({ db }) =>
-      resolveReadableAcpSessionRow({
-        row: selectAcpSessionRowForStoreEntry(
-          db,
-          storeEntry.storeSessionKey,
-          storeEntry.agentId,
-          storeEntry.cfg,
-          storeEntry.entry,
-        ),
-        entry: storeEntry.entry,
-      }),
-    { env: params.env, path: params.databasePath },
-  );
-  const acp = row ? rowToAcpSessionMeta(row) : undefined;
+  const acp = readAcpSessionMetaForEntry({
+    sessionKey: storeEntry.storeSessionKey,
+    agentId: storeEntry.agentId,
+    cfg: storeEntry.cfg,
+    entry: storeEntry.entry,
+    env: params.env,
+    databasePath: params.databasePath,
+  });
   return {
     cfg: storeEntry.cfg,
     agentId: storeEntry.agentId,


### PR DESCRIPTION
Closes #145497

<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled.

</details>

## What Problem This Solves

ACP metadata-only and full-entry reads duplicate session-store resolution, SQLite selection, and lifecycle checks. Maintaining separate copies makes behavior changes easier to apply inconsistently. This is a maintainer-requested consolidation.

## Why This Change Was Made

Metadata-only reads now use the existing session-entry reader, which delegates its prepared entry to the canonical metadata reader. The change removes 34 production code lines; including five assertion lines added to existing tests, maintained source shrinks by 29 code lines and 644 bytes.

## User Impact

No user-visible behavior change is intended. Reads retain trimmed keys, canonical session selection, agent ownership, clone behavior, read-only database routing, and lifecycle checks. Prepared-entry reads reuse the same entry snapshot without another session-store lookup. Public APIs and stored data formats are unchanged.

## Evidence

The original implementation and tests passed 23 cases across two files. The candidate passed the same 23 cases after extending two existing tests with whitespace-padded metadata-only lookup and stale lifecycle rejection assertions. The full changed-file gate passed, and isolated Codex review of the exact patch returned no findings.

The two-file patch is unchanged after refreshing onto main `7c0dfa5150809b92a9bbc0d32cdc7366b17ac388`. This includes the upstream UI fixes in #145415 and preserves later main changes. The [previous CI run](https://github.com/openclaw/openclaw/actions/runs/34665225413) remains failed: its merge with main encountered the shared oversized test file, unused UI exports, and cursor-policy failure fixed upstream. The previous exact-head hosted review found no actionable issues.

The retained local proof covers the candidate based on `9252b5911bab1482c91dddebcddfcc76d0204906`; it was not rerun against the newer shared-state integration. No live ACP backend or upgrade test was run. [CI passed](https://github.com/openclaw/openclaw/actions/runs/34670782669) for refreshed head `d9ddd247b2b97ea64fa395cc898fe63a9f62e1f7`. The [completed hosted review](https://github.com/openclaw/openclaw/pull/145498#issuecomment-5642605308), revision 2 for that head, found no actionable correctness or security issues.
