### PR TITLE
test(onboard): align custom provider activation proof

### DIFF
--- a/src/commands/onboard-guided.custom-provider.e2e.test.ts
+++ b/src/commands/onboard-guided.custom-provider.e2e.test.ts
@@ -4,6 +4,8 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createWizardPrompter } from "../../test/helpers/wizard-prompter.js";
+import { resolveAgentDir } from "../agents/agent-scope-config.js";
+import { loadAuthProfileStoreWithoutExternalProfiles } from "../agents/auth-profiles/store-runtime.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { captureFullEnv, setTestEnvValue } from "../test-utils/env.js";
 
@@ -198,6 +200,9 @@ async function runCustomSetup(scenario: Scenario) {
     activationResults,
     textPrompts: vi.mocked(prompter.text).mock.calls,
     config: JSON.parse(await fs.readFile(configPath, "utf8")) as OpenClawConfig,
+    authProfiles: loadAuthProfileStoreWithoutExternalProfiles(
+      resolveAgentDir(initialConfig, "main"),
+    ).profiles,
     output: JSON.stringify([
       runtime.log.mock.calls,
       runtime.error.mock.calls,
@@ -209,7 +214,7 @@ async function runCustomSetup(scenario: Scenario) {
 describe("guided custom provider activation", () => {
   it.each<Scenario>([
     { protocol: "openai" as const },
-    { protocol: "openai-responses" as const, secretRef: true },
+    { protocol: "openai-responses" as const },
     { protocol: "anthropic" as const },
     { protocol: "openai" as const, authless: true },
     { protocol: "openai", surface: "gateway", isLocalGateway: true },
@@ -222,16 +227,26 @@ describe("guided custom provider activation", () => {
       expect(setup.result).toEqual(
         expect.arrayContaining(["Inference verified: fixture-custom/fixture-model"]),
       );
-      expect(setup.requests).toEqual([
-        expect.objectContaining({ stream: false, authorized: true }),
-        expect.objectContaining({ stream: true, authorized: true }),
-      ]);
-      expect(setup.config.models?.providers?.["fixture-custom"]?.apiKey).toEqual(
+      expect(setup.requests).toEqual([expect.objectContaining({ stream: true, authorized: true })]);
+      expect(setup.config.models?.providers?.["fixture-custom"]?.apiKey).toBeUndefined();
+      expect(Object.values(setup.authProfiles)).toEqual(
         scenario.authless
-          ? undefined
-          : scenario.secretRef
-            ? { source: "env", provider: "default", id: "CUSTOM_SETUP_FIXTURE_KEY" }
-            : setup.credential,
+          ? []
+          : [
+              expect.objectContaining({
+                type: "api_key",
+                provider: "fixture-custom",
+                ...(scenario.secretRef
+                  ? {
+                      keyRef: {
+                        source: "env",
+                        provider: "default",
+                        id: "CUSTOM_SETUP_FIXTURE_KEY",
+                      },
+                    }
+                  : { key: setup.credential }),
+              }),
+            ],
       );
       expect(setup.config.agents?.defaults?.model).toContain("fixture-custom/fixture-model");
       expect(setup.config.agents?.defaults?.models?.["fixture-custom/fixture-model"]?.alias).toBe(
@@ -244,6 +259,32 @@ describe("guided custom provider activation", () => {
     },
   );
 
+  it("saves an unresolved SecretRef without promoting the prior route", async () => {
+    const setup = await runCustomSetup({ protocol: "openai-responses", secretRef: true });
+    expect(setup.requests).toEqual([]);
+    expect(setup.result).toBeNull();
+    expect(setup.config).toEqual(setup.initialConfig);
+    expect(Object.values(setup.authProfiles)).toEqual([
+      expect.objectContaining({
+        type: "api_key",
+        provider: "fixture-custom",
+        keyRef: {
+          source: "env",
+          provider: "default",
+          id: "CUSTOM_SETUP_FIXTURE_KEY",
+        },
+      }),
+    ]);
+    expect(setup.activationResults).toEqual([
+      expect.objectContaining({
+        ok: false,
+        status: "unknown",
+        disposition: "rejected-before-promotion",
+      }),
+    ]);
+    expect(setup.output).not.toContain(setup.credential);
+  });
+
   it.each<Scenario>([
     { protocol: "openai", outcome: "fail" },
     { protocol: "openai", outcome: "cancel" },
@@ -254,7 +295,7 @@ describe("guided custom provider activation", () => {
     { timeout: 300_000 },
     async (scenario) => {
       const setup = await runCustomSetup(scenario);
-      expect(setup.requests).toHaveLength(2);
+      expect(setup.requests).toHaveLength(1);
       expect(setup.result).toBeNull();
       expect(setup.config).toEqual(setup.initialConfig);
       expect(setup.output).not.toContain(setup.credential);
@@ -267,9 +308,9 @@ describe("guided custom provider activation", () => {
     },
   );
 
-  it("preserves the prior route when custom prompts are cancelled after endpoint verification", async () => {
+  it("preserves the prior route when custom prompts are cancelled before deferred verification", async () => {
     const setup = await runCustomSetup({ protocol: "openai", outcome: "prompt-cancel" });
-    expect(setup.requests).toEqual([expect.objectContaining({ stream: false, authorized: true })]);
+    expect(setup.requests).toEqual([]);
     expect(setup.cancelled).toBe(true);
     expect(setup.config).toEqual(setup.initialConfig);
   });
@@ -346,6 +387,13 @@ function writeCompletion(response: ServerResponse, protocol: Scenario["protocol"
       item_id: item.id,
       delta: "OK",
     },
+    {
+      type: "response.output_text.done",
+      output_index: 0,
+      content_index: 0,
+      item_id: item.id,
+      text: "OK",
+    },
     { type: "response.output_item.done", output_index: 0, item },
     {
       type: "response.completed",
@@ -358,5 +406,7 @@ function writeCompletion(response: ServerResponse, protocol: Scenario["protocol"
       },
     },
   ];
-  response.end(events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join(""));
+  response.end(
+    `${events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join("")}data: [DONE]\n\n`,
+  );
 }


### PR DESCRIPTION
## Summary
- align custom-provider onboarding E2E with the single streaming verification request
- assert credentials persist in auth profiles instead of inline provider config
- cover unresolved SecretRef rejection without weakening runtime materialization
- complete the Responses streaming fixture

## Validation
- focused custom-provider onboarding E2E: 13/13 passed
- formatting and changed-file checks passed locally