### PR TITLE
fix(android): Chat actions menu flickers closed on some phones

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/FoldAwareDropdownMenu.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/FoldAwareDropdownMenu.kt
@@ -255,10 +255,25 @@ private class MenuOpening(
   ): IntOffset {
     owner.refresh()
     val admitted = bounds
-    if (anchorBounds != geometry.anchor || admitted?.size != popupContentSize) owner.cancel(this)
-    return admitted?.topLeft ?: geometry.available.topLeft
+    if (anchorBounds != geometry.anchor) {
+      owner.cancel(this)
+    } else if (admitted != null && !foldAwarePopupSizeCompatible(admitted.size, popupContentSize)) {
+      owner.cancel(this)
+    } else if (admitted != null && admitted.size != popupContentSize) {
+      // Compose popup measure can report ±1px vs the admitted layout size.
+      bounds = IntRect(admitted.topLeft, popupContentSize)
+    }
+    return bounds?.topLeft ?: geometry.available.topLeft
   }
 }
+
+/** True when popup content matches the admitted size within one-pixel measure noise. */
+internal fun foldAwarePopupSizeCompatible(
+  admitted: IntSize,
+  content: IntSize,
+): Boolean =
+  kotlin.math.abs(admitted.width - content.width) <= 1 &&
+    kotlin.math.abs(admitted.height - content.height) <= 1
 
 private class AnchoredMenuOwner {
   var opening by mutableStateOf<MenuOpening?>(null)

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/FoldAwareDropdownMenu.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/FoldAwareDropdownMenu.kt
@@ -157,7 +157,8 @@ private fun MenuBody(
         }
       },
     ) { measurables, constraints ->
-      val padding = 16.dp.roundToPx()
+      // Match Compose PaddingNode: vertical 8.dp rounds each edge, not 16.dp once.
+      val padding = 2 * 8.dp.roundToPx()
       val limit = minOf(constraints.maxWidth, opening.geometry.available.width, 280.dp.roundToPx())
       if (opening.terminal || measurables.isEmpty() || limit < 112.dp.roundToPx()) {
         owner.cancel(opening)
@@ -261,7 +262,8 @@ private class MenuOpening(
       owner.cancel(this)
     } else if (admitted != null && admitted.size != popupContentSize) {
       // Compose popup measure can report ±1px vs the admitted layout size.
-      bounds = IntRect(admitted.topLeft, popupContentSize)
+      // Re-place so a 1px growth at the safe edge still fits (or flips above the anchor).
+      bounds = IntRect(owner.place(geometry, popupContentSize), popupContentSize)
     }
     return bounds?.topLeft ?: geometry.available.topLeft
   }
@@ -274,6 +276,26 @@ internal fun foldAwarePopupSizeCompatible(
 ): Boolean =
   kotlin.math.abs(admitted.width - content.width) <= 1 &&
     kotlin.math.abs(admitted.height - content.height) <= 1
+
+/** Place a menu of [size] relative to [anchor] inside [available], preferring below then above. */
+internal fun foldAwareMenuTopLeft(
+  available: IntRect,
+  anchor: IntRect,
+  size: IntSize,
+  direction: LayoutDirection,
+): IntOffset {
+  val start = if (direction == LayoutDirection.Ltr) anchor.left else anchor.right - size.width
+  val end = if (direction == LayoutDirection.Ltr) anchor.right - size.width else anchor.left
+  val x =
+    listOf(start, end).firstOrNull { it >= available.left && it + size.width <= available.right }
+      ?: start.coerceIn(available.left, (available.right - size.width).coerceAtLeast(available.left))
+  val y =
+    listOf(anchor.bottom, anchor.top - size.height).firstOrNull {
+      it >= available.top && it + size.height <= available.bottom
+    }
+      ?: anchor.bottom.coerceIn(available.top, (available.bottom - size.height).coerceAtLeast(available.top))
+  return IntOffset(x, y)
+}
 
 private class AnchoredMenuOwner {
   var opening by mutableStateOf<MenuOpening?>(null)
@@ -361,6 +383,11 @@ private class AnchoredMenuOwner {
       next.token == current.geometry.token && next.display == current.geometry.display &&
       next.available.contains(current.bounds ?: current.geometry.available) && itemLayout() == current.items
 
+  fun place(
+    geometry: MenuGeometry,
+    size: IntSize,
+  ): IntOffset = foldAwareMenuTopLeft(geometry.available, geometry.anchor, size, direction)
+
   fun admit(
     current: MenuOpening,
     size: IntSize,
@@ -368,17 +395,7 @@ private class AnchoredMenuOwner {
   ): Boolean {
     if (!valid(current, geometry())) return false
     if (current.bounds == null) {
-      val available = current.geometry.available
-      val anchor = current.geometry.anchor
-      val start = if (direction == LayoutDirection.Ltr) anchor.left else anchor.right - size.width
-      val end = if (direction == LayoutDirection.Ltr) anchor.right - size.width else anchor.left
-      val x =
-        listOf(start, end).firstOrNull { it >= available.left && it + size.width <= available.right }
-          ?: start.coerceIn(available.left, available.right - size.width)
-      val y =
-        listOf(anchor.bottom, anchor.top - size.height).firstOrNull { it >= available.top && it + size.height <= available.bottom }
-          ?: anchor.bottom.coerceIn(available.top, available.bottom - size.height)
-      current.bounds = IntRect(IntOffset(x, y), size)
+      current.bounds = IntRect(place(current.geometry, size), size)
       current.rowLayout = rows
     }
     return current.bounds?.size == size && current.rowLayout?.hasSameLayout(rows) == true

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/FoldAwareDropdownMenuTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/FoldAwareDropdownMenuTest.kt
@@ -47,6 +47,7 @@ import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
 import androidx.compose.ui.test.performSemanticsAction
 import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import androidx.core.graphics.Insets
@@ -139,6 +140,16 @@ class FoldAwareDropdownMenuTest {
     WindowInfoTracker.reset()
     WindowMetricsCalculator.reset()
     Settings.Global.putString(RuntimeEnvironment.getApplication().contentResolver, Settings.Global.ANIMATOR_DURATION_SCALE, animatorScale)
+  }
+
+  @Test
+  fun popupSizeCompatibleAllowsOnePixelMeasureNoise() {
+    val admitted = IntSize(560, 720)
+    assertTrue(foldAwarePopupSizeCompatible(admitted, IntSize(560, 720)))
+    assertTrue(foldAwarePopupSizeCompatible(admitted, IntSize(560, 721)))
+    assertTrue(foldAwarePopupSizeCompatible(admitted, IntSize(559, 720)))
+    assertFalse(foldAwarePopupSizeCompatible(admitted, IntSize(560, 722)))
+    assertFalse(foldAwarePopupSizeCompatible(admitted, IntSize(558, 720)))
   }
 
   @Test

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/FoldAwareDropdownMenuTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/FoldAwareDropdownMenuTest.kt
@@ -47,6 +47,8 @@ import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
 import androidx.compose.ui.test.performSemanticsAction
 import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntRect
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
@@ -110,6 +112,7 @@ class FoldAwareDropdownMenuTest {
   private var y by mutableStateOf(80.dp)
   private var direction by mutableStateOf(LayoutDirection.Ltr)
   private var fontScale by mutableStateOf(1f)
+  private var densityOverride by mutableStateOf<Float?>(null)
   private var labels by mutableStateOf(listOf("Refresh", "Last action"))
   private lateinit var activity: Activity
   private lateinit var host: View
@@ -150,6 +153,48 @@ class FoldAwareDropdownMenuTest {
     assertTrue(foldAwarePopupSizeCompatible(admitted, IntSize(559, 720)))
     assertFalse(foldAwarePopupSizeCompatible(admitted, IntSize(560, 722)))
     assertFalse(foldAwarePopupSizeCompatible(admitted, IntSize(558, 720)))
+  }
+
+  @Test
+  fun verticalMenuPaddingRoundsEachEdgeAtFractionalDensity() {
+    val density = Density(2.8125f)
+    with(density) {
+      assertEquals("PaddingNode sums round(8)+round(8)", 46, 2 * 8.dp.roundToPx())
+      assertEquals("Single 16.dp round disagrees at this density", 45, 16.dp.roundToPx())
+    }
+  }
+
+  @Test
+  fun menuTopLeftFlipsAboveWhenOnePixelTallerWouldOverflowBottom() {
+    val available = IntRect(0, 0, 1000, 800)
+    val anchor = IntRect(372, 372, 485, 485)
+    assertEquals(
+      IntOffset(372, 485),
+      foldAwareMenuTopLeft(available, anchor, IntSize(200, 315), LayoutDirection.Ltr),
+    )
+    assertEquals(
+      IntOffset(372, 56),
+      foldAwareMenuTopLeft(available, anchor, IntSize(200, 316), LayoutDirection.Ltr),
+    )
+  }
+
+  @Test
+  fun nonIntegerDensityBottomEdgeMenuStaysOpenAndSelects() {
+    // Window fixtures stay mdpi pixels (~800 tall); dp positions must scale with the override.
+    densityOverride = 2.8125f
+    labels = listOf("Refresh", "Last action", "Third action")
+    x = 40.dp
+    y = 200.dp
+    showMenu()
+    open()
+    val popup = nativePopup()
+    val bounds = screenBounds(popup)
+    assertTrue(popup.isAttachedToWindow)
+    assertTrue("Correct padding admission must keep the menu inside the window", bounds.bottom <= 800)
+    composeRule.onNodeWithText("Refresh").performClick()
+    composeRule.waitForIdle()
+    assertEquals(listOf("0"), actions)
+    assertFalse(popup.isAttachedToWindow)
   }
 
   @Test
@@ -537,7 +582,7 @@ class FoldAwareDropdownMenuTest {
       }
       CompositionLocalProvider(
         LocalLayoutDirection provides direction,
-        LocalDensity provides Density(currentDensity.density, fontScale),
+        LocalDensity provides Density(densityOverride ?: currentDensity.density, fontScale),
       ) {
         ClawDesignTheme {
           Box(Modifier.fillMaxSize(), contentAlignment = AbsoluteAlignment.TopLeft) {

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/SettingsScreensContrastTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/SettingsScreensContrastTest.kt
@@ -365,14 +365,15 @@ class SettingsScreensContrastTest {
         .single()
     try {
       disconnectAndReconnectStatusControl(model, showHeader = true)
-      composeRule.onNodeWithContentDescription(readyDescription).assertIsDisplayed()
+      // The session title can resolve after reconnect; the health status is the invariant.
+      composeRule.onNode(chatStatusMatcher(showHeader = true, value = "Ready")).assertIsDisplayed()
 
       composeRule.runOnIdle {
         gateway.healthReady = false
         model.refreshChat()
       }
       awaitConnectedHealthFailure(model, showHeader = true)
-      composeRule.onNodeWithContentDescription(readyDescription.removeSuffix(ready) + nativeString("Not ready")).assertIsDisplayed()
+      composeRule.onNode(chatStatusMatcher(showHeader = true, value = "Not ready")).assertIsDisplayed()
     } catch (failure: AssertionError) {
       runCatching {
         println("Chat header failure: initialHeader=$readyDescription, connected=${model.gatewayConnectionDisplay.value.isConnected}, health=${model.chatHealthOk.value}")


### PR DESCRIPTION
Closes #145504

## What Problem This Solves

Fixes an issue where users opening Chat actions (`⋯`) would see the menu flicker and immediately close on some phones (reproduced on Samsung Galaxy S24 FE / SM-S721W with the `2026.8.2` third-party debug build).

## Why This Change Was Made

Two related admission bugs in `FoldAwareDropdownMenu`:

1. **Exact-size cancel:** Compose popup measure can report content **1px** taller/wider than the admitted size; the menu canceled itself on every open.
2. **Padding rounding (roboclaw P2):** Admission used `16.dp.roundToPx()` once, while `padding(vertical = 8.dp)` rounds each edge (`2 * 8.dp.roundToPx()`). At density `2.8125` that is 45 vs 46 — admitting the short height can place the menu flush to the safe bottom, then the real 1px growth overflows and `valid()` closes it again even when above-anchor placement would fit.

Fix: admit with PaddingNode-matching vertical padding, tolerate ±1px measure noise, and **re-place** when size syncs so a 1px growth still fits (or flips above the anchor).

The follow-up health-test correction checks reconnect status independently of session-title updates.

## User Impact

Chat actions stays open until the user picks an item, taps outside, or presses back on devices that hit the 1px / fractional-density mismatch.

## Evidence

### Before (affected phone)

Scrubbed screen recording (status bar cropped; no chat content / device identifiers):

- Video: https://github.com/DonnieFi/openclaw/releases/download/evidence-145504-chat-actions-flicker/ellipses-flicker-scrubbed.mp4
- Frame sheet: https://github.com/DonnieFi/openclaw/releases/download/evidence-145504-chat-actions-flicker/before-flicker-contact-sheet.png

Matching scrubbed cancel path (sizes only):

```
FoldAwareMenu: open-admit size=560x720
FoldAwareMenu: admit-bounds size=560x720
FoldAwareMenu: cancel:popup-size-mismatch admitted=560x720 content=560x721
FoldAwareMenu: close dismissExpanded=true
```

### After (same phone, patched debug APK)

Chat actions menu **stays open** on a fresh New chat (S24 FE / `ai.openclaw.app.debug`). Status bar cropped:

![After: Chat actions menu open](https://github.com/DonnieFi/openclaw/releases/download/evidence-145504-chat-actions-flicker/after-menu-open-scrubbed.png)

Direct link: https://github.com/DonnieFi/openclaw/releases/download/evidence-145504-chat-actions-flicker/after-menu-open-scrubbed.png

### Tests

`FoldAwareDropdownMenuTest` (third-party debug unit):

- `popupSizeCompatibleAllowsOnePixelMeasureNoise`
- `verticalMenuPaddingRoundsEachEdgeAtFractionalDensity` (documents 45 vs 46 at density 2.8125)
- `menuTopLeftFlipsAboveWhenOnePixelTallerWouldOverflowBottom` (roboclaw 315→316 / y=485→56 case)
- `nonIntegerDensityBottomEdgeMenuStaysOpenAndSelects` (open + select at density 2.8125)


### Current-head CI

[CI for `e13fed0a0953`](https://github.com/openclaw/openclaw/actions/runs/34710373211) passes the Play, Third-party, Wear, Kotlin lint, and aggregate CI gates. The Play and Third-party XML reports each include 14 passing dropdown tests and 8 passing settings/health tests.

Worked on by: @IWhatsskill
