### PR TITLE
fix(update): pin recovery targets and avoid repeated checks

### DIFF
--- a/src/cli/update-cli/update-command-recovery.test.ts
+++ b/src/cli/update-cli/update-command-recovery.test.ts
@@ -1,7 +1,8 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import * as snapshots from "../../infra/sqlite-snapshot-source.js";
 import {
   createRetainedUpdateRecovery,
   storeRetainedUpdateRecovery,
@@ -15,16 +16,134 @@ import {
   closeOpenClawStateDatabaseForTest,
   openOpenClawStateDatabase,
 } from "../../state/openclaw-state-db.js";
+import { resolveOpenClawStateSqlitePath } from "../../state/openclaw-state-db.paths.js";
 import type { UpdateCommandOptions } from "./shared.js";
 import { continueMigratedUpdateInFreshProcess } from "./update-command-migrated.js";
 import {
   finishSuccessfulPackageSwitch,
   validConfigSnapshot,
 } from "./update-command-post-update.test-support.js";
+import { assertUpdateCommandPackageFinalization } from "./update-command-recovery.js";
 import { completeUpdateCommandRun } from "./update-command-run.js";
+import { resolveSettledUpdateCommandResult } from "./update-command-terminal.js";
 
 const dirs = useAutoCleanupTempDirTracker(afterEach);
 afterEach(() => closeOpenClawStateDatabaseForTest());
+afterEach(() => vi.restoreAllMocks());
+
+describe("package finalization recovery targets", () => {
+  function target() {
+    const root = dirs.make("finalization-recovery-target-");
+    const env = { OPENCLAW_STATE_DIR: root };
+    const run: NonNullable<UpdateCommandOptions["run"]> = {
+      runId: createUpdateRun({ trigger: "cli" }, { env }).runId,
+      env,
+    };
+    const params: Parameters<typeof assertUpdateCommandPackageFinalization>[0] & {
+      root: string;
+    } = {
+      root,
+      opts: { run },
+      result: { status: "ok", mode: "npm", steps: [], durationMs: 0 },
+    };
+    return { run, params, databasePath: resolveOpenClawStateSqlitePath(env) };
+  }
+
+  it.each(
+    (["entry", "settlement"] as const).flatMap((phase) =>
+      (["run-only", "same-target", "distinct-target", "retargeted"] as const).map((kind) => ({
+        phase,
+        kind,
+      })),
+    ),
+  )("inspects each selected recovery target once at $phase ($kind)", async ({ phase, kind }) => {
+    const first = target();
+    const other = kind === "distinct-target" || kind === "retargeted" ? target() : undefined;
+    if (kind === "same-target") {
+      first.params.ownedManagedUpdateEnv = {
+        ...first.run.env,
+        OPENCLAW_STATE_DIR: first.params.root + path.sep + ".",
+      };
+    } else if (kind === "distinct-target") {
+      first.params.ownedManagedUpdateEnv = other!.run.env;
+    }
+    closeOpenClawStateDatabaseForTest();
+    const prepare = vi.spyOn(snapshots, "prepareSqliteReadOnlyLocationSync");
+    if (kind === "retargeted") {
+      const lstat = fs.lstat.bind(fs);
+      vi.spyOn(fs, "lstat").mockImplementation(async (...args) => {
+        const result = await lstat(...args);
+        if (String(args[0]) === path.dirname(first.databasePath)) {
+          first.run.env.OPENCLAW_STATE_DIR = other!.params.root;
+        }
+        return result;
+      });
+    }
+    if (phase === "entry") {
+      await expect(assertUpdateCommandPackageFinalization(first.params)).resolves.toBeUndefined();
+    } else {
+      await expect(
+        resolveSettledUpdateCommandResult(first.params, first.params.result),
+      ).resolves.toEqual({ result: first.params.result, settlementFailed: false });
+    }
+    const recoveryPaths =
+      kind === "distinct-target"
+        ? [other!.databasePath, first.databasePath]
+        : kind === "retargeted"
+          ? [first.databasePath, other!.databasePath]
+          : [first.databasePath];
+    expect(prepare.mock.calls.map(([pathname]) => pathname)).toEqual([
+      ...recoveryPaths,
+      // Settlement still needs its independent terminal-history read.
+      ...(phase === "settlement" ? [resolveOpenClawStateSqlitePath(first.run.env)] : []),
+    ]);
+  });
+
+  it.each(["first-read", "distinct-read", "run-replaced", "fence-replaced"] as const)(
+    "retains the original executor after recovery admission (%s)",
+    async (boundary) => {
+      const first = target();
+      const other = boundary === "distinct-read" ? target() : undefined;
+      if (other) {
+        first.params.ownedManagedUpdateEnv = other.run.env;
+      }
+      let current = true;
+      first.run.executorFence = {
+        assertCurrent() {
+          if (!current) {
+            throw new Error("original finalizer authority lost");
+          }
+        },
+      };
+      const replacementFence = { assertCurrent: vi.fn() };
+      closeOpenClawStateDatabaseForTest();
+      const lstat = fs.lstat.bind(fs);
+      vi.spyOn(fs, "lstat").mockImplementation(async (...args) => {
+        const result = await lstat(...args);
+        if (String(args[0]) === path.dirname(first.databasePath)) {
+          if (boundary === "run-replaced") {
+            first.params.opts.run = { ...first.run };
+          } else if (boundary === "fence-replaced") {
+            first.run.executorFence = replacementFence;
+          } else {
+            current = false;
+          }
+        }
+        return result;
+      });
+      await expect(assertUpdateCommandPackageFinalization(first.params)).rejects.toMatchObject({
+        name: "UpdateCommandPendingRecoveryFailure",
+        cause: {
+          message:
+            boundary === "run-replaced" || boundary === "fence-replaced"
+              ? "Package finalization lost its original executor."
+              : "original finalizer authority lost",
+        },
+      });
+      expect(replacementFence.assertCurrent).not.toHaveBeenCalled();
+    },
+  );
+});
 
 async function fixture(rollback = false) {
   const root = dirs.make("terminal-consumer-");

--- a/src/cli/update-cli/update-command-recovery.ts
+++ b/src/cli/update-cli/update-command-recovery.ts
@@ -4,6 +4,7 @@ import {
   loadUpdateRecovery,
   UpdateRecoveryRequiredError,
 } from "../../infra/update-run-recovery.js";
+import { resolveOpenClawStateSqlitePath } from "../../state/openclaw-state-db.paths.js";
 import type { UpdateCommandOptions } from "./shared.js";
 import type { FinishUpdateParams } from "./update-command-finish-types.js";
 import { UpdateCommandPendingRecoveryFailure } from "./update-command-result.js";
@@ -49,11 +50,12 @@ export async function assertUpdateCommandPackageFinalization(
         "Full-state checkpoint recovery is deferred; retained state was left unchanged.",
       );
     }
-    await assertUpdateRecoveryAdmission({
-      env: params.ownedManagedUpdateEnv ?? params.opts.run?.env,
-    });
+    const env = params.ownedManagedUpdateEnv ?? params.opts.run?.env;
+    // Keep the first target stable if selectors change during admission.
+    const targetPath = resolveOpenClawStateSqlitePath(env);
+    await assertUpdateRecoveryAdmission({ env, path: targetPath });
     assertCurrent();
-    if (run) {
+    if (run && resolveOpenClawStateSqlitePath(run.env) !== targetPath) {
       await assertUpdateRecoveryAdmission({ env: run.env });
       assertCurrent();
     }

--- a/src/cli/update-cli/update-command-rollback-executor.test.ts
+++ b/src/cli/update-cli/update-command-rollback-executor.test.ts
@@ -6,6 +6,7 @@ import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js"
 import { createConfigIO } from "../../config/config.js";
 import { createRetainedPackageSwap } from "../../infra/package-update-swap.test-support.js";
 import { readUpdateStateSchemaVersions } from "../../infra/update-candidate-state.js";
+import { createRetainedUpdateRecovery } from "../../infra/update-retained-recovery.test-support.js";
 import { createUpdateRun, getUpdateRun } from "../../infra/update-run-ledger.js";
 import { OPENCLAW_STATE_SCHEMA_VERSION } from "../../state/openclaw-state-db-contract.js";
 import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
@@ -20,6 +21,51 @@ async function readPreviousConfig(env: NodeJS.ProcessEnv) {
 }
 
 describe("package rollback executor ownership", () => {
+  it("checks the new history target after its admission environment changes", async () => {
+    const env = { OPENCLAW_STATE_DIR: dirs.make("rollback-first-target-") };
+    const run = { runId: createUpdateRun({ trigger: "cli" }, { env }).runId, env };
+    const pendingEnv = { OPENCLAW_STATE_DIR: dirs.make("rollback-pending-target-") };
+    const pendingRun = createUpdateRun({ trigger: "cli" }, { env: pendingEnv });
+    const root = dirs.make("rollback-target-package-");
+    const runtime = { root, nodePath: process.execPath, version: "1.0.0", buildId: null };
+    createRetainedUpdateRecovery(
+      { runId: pendingRun.runId, from: runtime, to: runtime },
+      { env: pendingEnv },
+    );
+    const configSnapshot = await readPreviousConfig(env);
+    closeOpenClawStateDatabaseForTest();
+    const files = [resolveOpenClawStateSqlitePath(env), resolveOpenClawStateSqlitePath(pendingEnv)];
+    const before = await Promise.all(files.map((file) => fs.readFile(file)));
+    let changed = false;
+    const lstat = fs.lstat.bind(fs);
+    const observation = vi.spyOn(fs, "lstat").mockImplementation(async (...args) => {
+      const result = await lstat(...args);
+      if (String(args[0]) === path.dirname(files[0]!)) {
+        changed = true;
+        env.OPENCLAW_STATE_DIR = pendingEnv.OPENCLAW_STATE_DIR;
+      }
+      return result;
+    });
+    try {
+      const result = await rollbackFailedUpdate({
+        result: { status: "error", mode: "npm", root, steps: [], durationMs: 0 },
+        previousRoot: root,
+        rollbackBlockedReason: "state-migrated-no-rollback",
+        configSnapshot,
+        opts: { run },
+        timeoutMs: 1000,
+      });
+      expect(changed).toBe(true);
+      expect(result).toMatchObject({
+        rolledBack: false,
+        pendingRecoveryReason: expect.stringContaining(pendingRun.runId),
+      });
+      expect(await Promise.all(files.map((file) => fs.readFile(file)))).toEqual(before);
+    } finally {
+      observation.mockRestore();
+    }
+  });
+
   it("preserves the real package and recovery material when its executor is lost during observation", async () => {
     const base = dirs.make("rollback-real-executor-");
     const { packageRoot, transaction } = await createRetainedPackageSwap(base);

--- a/src/cli/update-cli/update-command-rollback.ts
+++ b/src/cli/update-cli/update-command-rollback.ts
@@ -87,14 +87,12 @@ export async function rollbackFailedUpdate(params: {
       assertCurrent();
       // A lost live context (including the same run ID) is not permission to
       // fall back to legacy rollback, even when publication removed the main DB.
-      await assertUpdateRecoveryAdmission({ env });
+      const targetPath = resolveOpenClawStateSqlitePath(env);
+      await assertUpdateRecoveryAdmission({ env, path: targetPath });
       assertCurrent();
       // Service authority and diagnostic history can select distinct state
       // roots. Neither may contain pending recovery before legacy mutation.
-      if (
-        opts.run &&
-        resolveOpenClawStateSqlitePath(opts.run.env) !== resolveOpenClawStateSqlitePath(env)
-      ) {
+      if (opts.run && resolveOpenClawStateSqlitePath(opts.run.env) !== targetPath) {
         await assertUpdateRecoveryAdmission({ env: opts.run.env });
         assertCurrent();
       }

--- a/src/cli/update-cli/update-command-terminal.ts
+++ b/src/cli/update-cli/update-command-terminal.ts
@@ -7,6 +7,7 @@ import { assertUpdateRecoveryAdmission } from "../../infra/update-run-recovery-a
 import { readCurrentGitUpdateRecovery } from "../../infra/update-runner-git-recovery.js";
 import type { UpdateRunResult, UpdateStepResult } from "../../infra/update-runner.js";
 import { defaultRuntime } from "../../runtime.js";
+import { resolveOpenClawStateSqlitePath } from "../../state/openclaw-state-db.paths.js";
 import { exitCliAfterOutput } from "../one-shot-exit.js";
 import { printResult } from "./progress.js";
 import type { UpdateCommandOptions } from "./shared.js";
@@ -129,11 +130,14 @@ export async function resolveSettledUpdateCommandResult(
   // The mutation owner is now closed. This is diagnostic publication only,
   // never authority to reopen displaced state or replace another terminal row.
   try {
-    await assertUpdateRecoveryAdmission({
-      env: params.ownedManagedUpdateEnv ?? params.opts.run?.env,
-    });
+    const env = params.ownedManagedUpdateEnv ?? params.opts.run?.env;
+    // Keep the first target stable if selectors change during admission.
+    const targetPath = resolveOpenClawStateSqlitePath(env);
+    await assertUpdateRecoveryAdmission({ env, path: targetPath });
     if (params.opts.run) {
-      await assertUpdateRecoveryAdmission({ env: params.opts.run.env });
+      if (resolveOpenClawStateSqlitePath(params.opts.run.env) !== targetPath) {
+        await assertUpdateRecoveryAdmission({ env: params.opts.run.env });
+      }
       const prior = getUpdateRun(params.opts.run.runId, { env: params.opts.run.env });
       if (prior && prior.status !== "running" && settlementFailed) {
         throw new Error("Update history was already finalized by another owner.");

--- a/src/infra/update-run-recovery-admission.test.ts
+++ b/src/infra/update-run-recovery-admission.test.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
+import asyncFs from "node:fs/promises";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import { createRetainedCheckpointFixture } from "./update-retained-checkpoint.test-support.js";
@@ -9,6 +10,7 @@ import { assertUpdateRecoveryAdmission } from "./update-run-recovery-admission.j
 
 const dirs = useAutoCleanupTempDirTracker(afterEach);
 afterEach(() => closeOpenClawStateDatabaseForTest());
+afterEach(() => vi.restoreAllMocks());
 
 describe("package-only recovery admission", () => {
   it("admits absent state without creating it", async () => {
@@ -16,6 +18,34 @@ describe("package-only recovery admission", () => {
     await assertUpdateRecoveryAdmission({ env: { OPENCLAW_STATE_DIR: root } });
     expect(fs.existsSync(root)).toBe(false);
   });
+
+  it.each([false, true])(
+    "keeps the selected recovery directory and file together (explicit path=%s)",
+    async (explicitPath) => {
+      const f = createRetainedCheckpointFixture(dirs.make("update-admission-target-"));
+      const replacement = path.join(dirs.make("update-admission-replacement-"), "absent");
+      const before = fs.readFileSync(f.file);
+      let changed = false;
+      const lstat = asyncFs.lstat.bind(asyncFs);
+      vi.spyOn(asyncFs, "lstat").mockImplementation(async (...args) => {
+        const result = await lstat(...args);
+        if (String(args[0]) === path.dirname(f.file)) {
+          changed = true;
+          f.env.OPENCLAW_STATE_DIR = replacement;
+        }
+        return result;
+      });
+      await expect(
+        assertUpdateRecoveryAdmission(explicitPath ? { ...f.options, path: f.file } : f.options),
+      ).rejects.toMatchObject({
+        name: "UpdateRecoveryRequiredError",
+        record: { runId: f.run.runId },
+      });
+      expect(changed).toBe(true);
+      expect(fs.readFileSync(f.file)).toEqual(before);
+      expect(fs.existsSync(replacement)).toBe(false);
+    },
+  );
 
   it.each(["sealed", "unsealed", "displaced", "orphan beside canonical"] as const)(
     "refuses %s checkpoint state without changing retained bytes",

--- a/src/infra/update-run-recovery-admission.ts
+++ b/src/infra/update-run-recovery-admission.ts
@@ -30,5 +30,5 @@ export async function assertUpdateRecoveryAdmission(
       "Interrupted shared-database publication is read-only while full-state recovery is deferred",
     );
   }
-  assertNoPendingUpdateRecovery(options);
+  assertNoPendingUpdateRecovery({ ...options, path: databasePath });
 }


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled for this PR.

</details>

## What Problem This Solves

Resolves a problem where updates repeated recovery inspection against the same state database. A state selector changing during an in-flight inspection could also leave the directory check and database read targeting different locations.

## Why This Change Was Made

Pin the initially resolved database path through recovery admission, then inspect the run's current target separately only when it differs. Apply the same comparison in rollback so a changed history target is still checked. Entry and settlement remain separate checks, with the existing executor revalidation and terminal-history guard preserved.

## User Impact

Updates perform less redundant recovery inspection while retaining pending-recovery refusal. There are no schema, store-format, retention, or operator-option changes.

## Evidence

- Real SQLite tests with closed handles show same-target entry snapshot preparations dropping **2 → 1**. Settlement drops **3 → 2**, retaining its independent terminal-history read. Cached open handles can already avoid snapshot preparation; this is direct work reduction, not a whole-CI wall-time claim.
- Same-target and changed-target controls fail before the fix; all **12** focused target/authority cases pass afterward. The admission producer's retarget regression goes from **1 failed / 6 passed** to **7 passed**. With the producer pin applied, rollback's new-target regression goes from **1 failed / 4 passed** to **5 passed**.
- **66 final tests passed**: 59 CLI owner/sibling cases plus 7 admission cases. Final `check:changed` passed, including core and core-test types, formatting, lint, and guards.
- Independent P0–P2 review found no actionable findings. The published-driver validation below also passed.

### Published-driver validation and review follow-through

[Package Acceptance 34666545812](https://github.com/openclaw/openclaw/actions/runs/34666545812) passed on candidate `6fa9a33f06424f7f2c789c3edcce20530e196b49`, built as 2026.9.4, using trusted tooling `47ce03dbc6994435af783fecf13d5586e7b307f4`. The installed published 2026.9.3 updater completed the `legacy-operator-state` upgrade scenario in 467 seconds with zero retries. State survival, candidate schemas and automatic migration, cron owners, mobile pairing, Gateway health, the synthetic operator turn and plugin availability all passed. A second update was already-current with no package mutations or repair; Doctor was clean. This is installed-package Docker proof, not a live provider run.

[Retained scenario artifact](https://github.com/openclaw/openclaw/actions/runs/34666545812/artifacts/10289354425). Candidate tarball SHA-256: `ecce4c8d071740749ea8e090426ba1755baa8eaa88d823fe9e2d8ec9ef882132`. Package integrity and the npm 12 installer acceptance also passed. [Ordinary CI 34666230978](https://github.com/openclaw/openclaw/actions/runs/34666230978) is green on that exact head.

This fulfills the fresh ClawSweeper review's published-driver validation requirement and Rank-up move. The focused real-SQLite regressions separately verify refusal and preservation of pending recovery material, including changed target selectors; the successful-upgrade scenario does not replace those checks.
