### PR TITLE
test(sdk): expect worker environment profiles

### DIFF
--- a/packages/sdk/src/app-sdk-composed-resources.e2e.test.ts
+++ b/packages/sdk/src/app-sdk-composed-resources.e2e.test.ts
@@ -563,6 +563,7 @@ async function proveDeterministicGatewayContracts(): Promise<void> {
       status: "starting",
       worker: {
         providerId: "testbox",
+        profileId: "development",
         leaseId: "lease-sdk-e2e",
         state: "requested",
         ageMs: 9_000,
@@ -585,6 +586,7 @@ async function proveDeterministicGatewayContracts(): Promise<void> {
       status: "available",
       worker: {
         providerId: "testbox",
+        profileId: "development",
         leaseId: "lease-sdk-e2e",
         state: "ready",
         ageMs: 9_000,


### PR DESCRIPTION
## Summary
- update the App SDK composed environment proof for the profile identity now exposed on worker records
- assert the profile on both create and list projections

## Validation
- `packages/sdk/src/app-sdk-composed-resources.e2e.test.ts` (1/1 passed against current main with this patch)
- `pnpm exec oxfmt --check packages/sdk/src/app-sdk-composed-resources.e2e.test.ts`
- `git diff --check`