### PR TITLE
test(status): complete prepared catalog mock

### DIFF
--- a/test/helpers/auto-reply/trigger-handling-test-harness.ts
+++ b/test/helpers/auto-reply/trigger-handling-test-harness.ts
@@ -131,6 +131,8 @@ const installModelCatalogMock = () =>
 installModelCatalogMock();
 
 vi.doMock("../../../src/agents/prepared-model-catalog.js", () => ({
+  getPreparedModelCatalogOwnerSnapshot: () => undefined,
+  materializePreparedModelCatalogOwner: (owner: object) => owner,
   readPreparedModelCatalog: (...args: unknown[]) =>
     modelCatalogMocks.readPreparedModelCatalog(...args),
   loadPreparedModelCatalogSnapshot: async (...args: unknown[]) => {


### PR DESCRIPTION
## Summary
- include the prepared catalog owner helpers in the trigger-handling test mock
- keep `/status` exercising its successful non-agent path after status began reading prepared catalog ownership

## Validation
- focused `/status` E2E case (1/1 passed against current main with this patch)
- `pnpm exec oxfmt --check test/helpers/auto-reply/trigger-handling-test-harness.ts`
- `git diff --check`