### PR TITLE
refactor(ui): remove retired environment separator style

### DIFF
--- a/ui/src/styles/new-session.css
+++ b/ui/src/styles/new-session.css
@@ -848,10 +848,6 @@ wa-popover.new-session-page__where-popover::part(body) {
   font-size: var(--control-ui-text-sm);
 }
 
-.new-session-page__environment-picker > .session-menu__separator {
-  flex-shrink: 0;
-}
-
 .new-session-page__menu-chevron {
   display: inline-flex;
   margin-left: auto;


### PR DESCRIPTION
Related: #145415

## What Problem This Solves

Removes an obsolete environment-picker separator style left behind when the retired Connect row was removed.

## Why This Change Was Made

The substantive renderer, cursor, and test-fixture cleanup from the original version of this PR has already landed in #145415. This revision preserves that implementation and its stronger Connect-button test. Only the unused direct-child separator rule remains: the current picker renders a search label and an environment list, with no matching separator child.

## User Impact

No intended rendering or behavior change. Production: +0/-4; tests unchanged; no cases removed by this PR.

## Evidence

The original residual was tested on base `47ce03d`: 79/79 cases passed before and after deletion, with matching observed inventories. The current revision retains the same four-line removal on `746fa369`, including upstream's later cursor-style and test changes. All 78 current cases pass (64 picker, 13 cloud-configuration, one cursor-policy); main independently removed the older focus case. Fresh independent review is clean through P2, and all 17 normal changed-file checks passed, including core/UI types, i18n, formatting, and styles.

The previous hosted run exposed an undefined test locator, fixed on main by #145540, and a real-Gateway Send-button lookup timeout. The exact CI merge `ca05ff59` was rebuilt and its unchanged three-case Gateway suite passed locally. This macOS/Node 26 diagnostic does not establish Linux CI or full-job concurrency parity, and the original timeout remains unexplained; fresh hosted CI is required. No assertions, timeouts, or approval behavior were weakened.

<details>
<summary>Original investigation captures (historical context)</summary>

These captures belong to the earlier, larger investigation now covered by #145415. They are retained as historical context, not a new visual run or a cursor fix claimed by this four-line residual.

![Original before: synthetic touch-details layout](https://github.com/user-attachments/assets/b42d5b7d-d2d4-45c1-892d-66cefc155892)

![Original after: identical touch-details layout](https://github.com/user-attachments/assets/c6ae3e12-17a8-4478-a53f-bc45b398c648)

</details>
