### PR TITLE
refactor(ai): reuse completions stream test fixtures

### DIFF
--- a/packages/ai/src/transports/openai-completions-stream.reasoning-and-buffering.test.ts
+++ b/packages/ai/src/transports/openai-completions-stream.reasoning-and-buffering.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it } from "vitest";
-import { createZeroUsage } from "../usage.test-support.js";
 import { processCompletionsStream } from "./openai-completions-stream.js";
 import {
   createAssistantOutput,
@@ -177,16 +176,7 @@ describe("openai completions stream", () => {
       baseUrl: "https://openrouter.ai/api/v1",
     });
 
-    const output = {
-      role: "assistant" as const,
-      content: [],
-      api: model.api,
-      provider: model.provider,
-      model: model.id,
-      usage: createZeroUsage(),
-      stopReason: "stop" as const,
-      timestamp: Date.now(),
-    };
+    const output = createAssistantOutput(model);
 
     const stream: { push(event: unknown): void } = { push() {} };
 
@@ -209,13 +199,7 @@ describe("openai completions stream", () => {
       }),
     ] as const;
 
-    async function* mockStream() {
-      for (const chunk of mockChunks) {
-        yield chunk as never;
-      }
-    }
-
-    await processCompletionsStream(mockStream(), output, model, stream);
+    await processCompletionsStream(streamChunks(mockChunks), output, model, stream);
 
     expect(output.content).toHaveLength(3);
     expectRecordFields(output.content[0], { type: "text", text: "Visible first." });
@@ -289,16 +273,7 @@ describe("openai completions stream", () => {
       baseUrl: "https://openrouter.ai/api/v1",
     });
 
-    const output = {
-      role: "assistant" as const,
-      content: [],
-      api: model.api,
-      provider: model.provider,
-      model: model.id,
-      usage: createZeroUsage(),
-      stopReason: "stop" as const,
-      timestamp: Date.now(),
-    };
+    const output = createAssistantOutput(model);
 
     const stream: { push(event: unknown): void } = { push() {} };
 
@@ -318,13 +293,7 @@ describe("openai completions stream", () => {
       }),
     ] as const;
 
-    async function* mockStream() {
-      for (const chunk of mockChunks) {
-        yield chunk as never;
-      }
-    }
-
-    await processCompletionsStream(mockStream(), output, model, stream);
+    await processCompletionsStream(streamChunks(mockChunks), output, model, stream);
 
     expect(output.content).toHaveLength(2);
     expectRecordFields(output.content[0], { type: "text", text: "Visible answer." });

--- a/packages/ai/src/transports/openai-completions-stream.reasoning-details.test.ts
+++ b/packages/ai/src/transports/openai-completions-stream.reasoning-details.test.ts
@@ -1,6 +1,5 @@
 import { expectDefined } from "@openclaw/normalization-core";
 import { describe, expect, it } from "vitest";
-import { createZeroUsage } from "../usage.test-support.js";
 import { processCompletionsStream } from "./openai-completions-stream.js";
 import {
   type OpenAICompletionsOutput,
@@ -20,16 +19,7 @@ describe("openai completions stream", () => {
       baseUrl: "https://openrouter.ai/api/v1",
     });
 
-    const output: OpenAICompletionsOutput = {
-      role: "assistant" as const,
-      content: [],
-      api: model.api,
-      provider: model.provider,
-      model: model.id,
-      usage: createZeroUsage(),
-      stopReason: "stop" as const,
-      timestamp: Date.now(),
-    };
+    const output: OpenAICompletionsOutput = createAssistantOutput(model);
 
     const stream: { push(event: unknown): void } = { push() {} };
 
@@ -55,13 +45,7 @@ describe("openai completions stream", () => {
       makeCompletionsChunk({}, "stop"),
     ] as const;
 
-    async function* mockStream() {
-      for (const chunk of mockChunks) {
-        yield chunk as never;
-      }
-    }
-
-    await processCompletionsStream(mockStream(), output, model, stream);
+    await processCompletionsStream(streamChunks(mockChunks), output, model, stream);
 
     const thinkingBlock = expectDefined(output.content[0], "output.content[0] test invariant") as {
       type: string;
@@ -87,16 +71,7 @@ describe("openai completions stream", () => {
       baseUrl: "https://api.mistral.ai/v1",
     });
 
-    const output = {
-      role: "assistant" as const,
-      content: [],
-      api: model.api,
-      provider: model.provider,
-      model: model.id,
-      usage: createZeroUsage(),
-      stopReason: "stop" as const,
-      timestamp: Date.now(),
-    };
+    const output = createAssistantOutput(model);
 
     const stream: { push(event: unknown): void } = { push() {} };
     const mockChunks = [
@@ -118,13 +93,7 @@ describe("openai completions stream", () => {
       makeCompletionsChunk({}, "stop"),
     ] as const;
 
-    async function* mockStream() {
-      for (const chunk of mockChunks) {
-        yield chunk as never;
-      }
-    }
-
-    await processCompletionsStream(mockStream(), output, model, stream);
+    await processCompletionsStream(streamChunks(mockChunks), output, model, stream);
 
     expect(output.content).toEqual([
       { type: "thinking", thinking: "Need to think." },
@@ -268,16 +237,7 @@ describe("openai completions stream", () => {
       contextWindow: 128000,
     });
 
-    const output = {
-      role: "assistant" as const,
-      content: [],
-      api: model.api,
-      provider: model.provider,
-      model: model.id,
-      usage: createZeroUsage(),
-      stopReason: "stop" as const,
-      timestamp: Date.now(),
-    };
+    const output = createAssistantOutput(model);
 
     const stream: { push(event: unknown): void } = { push() {} };
 
@@ -294,13 +254,7 @@ describe("openai completions stream", () => {
       makeCompletionsChunk({}, "tool_call"),
     ] as const;
 
-    async function* mockStream() {
-      for (const chunk of mockChunks) {
-        yield chunk as never;
-      }
-    }
-
-    await processCompletionsStream(mockStream(), output, model, stream);
+    await processCompletionsStream(streamChunks(mockChunks), output, model, stream);
 
     expect(output.stopReason).toBe("toolUse");
     const toolCall = (output.content as Array<{ type?: string }>).find(

--- a/packages/ai/src/transports/openai-completions-stream.tool-assembly.test.ts
+++ b/packages/ai/src/transports/openai-completions-stream.tool-assembly.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it } from "vitest";
-import { createZeroUsage } from "../usage.test-support.js";
 import { processCompletionsStream } from "./openai-completions-stream.js";
 import {
   createAssistantOutput,
@@ -19,16 +18,7 @@ describe("openai completions stream", () => {
       contextWindow: 1000000,
     });
 
-    const output = {
-      role: "assistant" as const,
-      content: [],
-      api: model.api,
-      provider: model.provider,
-      model: model.id,
-      usage: createZeroUsage(),
-      stopReason: "stop" as const,
-      timestamp: Date.now(),
-    };
+    const output = createAssistantOutput(model);
 
     const stream = {
       push: () => {},
@@ -40,13 +30,7 @@ describe("openai completions stream", () => {
       makeCompletionsChunk({ tool_calls: [] as never[] }, "tool_calls" as const),
     ] as const;
 
-    async function* mockStream() {
-      for (const chunk of mockChunks) {
-        yield chunk as never;
-      }
-    }
-
-    await processCompletionsStream(mockStream(), output, model, stream);
+    await processCompletionsStream(streamChunks(mockChunks), output, model, stream);
 
     expect(output.stopReason).toBe("stop");
     expect(

--- a/packages/ai/src/transports/openai-completions-stream.tool-calls.test.ts
+++ b/packages/ai/src/transports/openai-completions-stream.tool-calls.test.ts
@@ -36,13 +36,7 @@ describe("openai completions stream", () => {
       }),
     ] as const;
 
-    async function* mockStream() {
-      for (const chunk of mockChunks) {
-        yield chunk as never;
-      }
-    }
-
-    await processCompletionsStream(mockStream(), output, model, stream, {
+    await processCompletionsStream(streamChunks(mockChunks), output, model, stream, {
       sawStreamDONE: () => true,
     });
 
@@ -134,13 +128,7 @@ describe("openai completions stream", () => {
       ),
     ] as const;
 
-    async function* mockStream() {
-      for (const chunk of mockChunks) {
-        yield chunk as never;
-      }
-    }
-
-    await processCompletionsStream(mockStream(), output, model, stream);
+    await processCompletionsStream(streamChunks(mockChunks), output, model, stream);
 
     expect(output.stopReason).toBe("stop");
     expect(
@@ -380,13 +368,7 @@ describe("openai completions stream", () => {
         "tool_calls",
       ),
     ] as const;
-    async function* mockStream() {
-      for (const chunk of chunks) {
-        yield chunk as never;
-      }
-    }
-
-    await processCompletionsStream(mockStream(), output, model, stream);
+    await processCompletionsStream(streamChunks(chunks), output, model, stream);
 
     const toolStart = events.find((event) => event.type === "toolcall_start") as
       | { partial?: { content?: Array<{ type?: string; textSignature?: string }> } }
@@ -421,13 +403,7 @@ describe("openai completions stream", () => {
         "stop",
       ),
     ] as const;
-    async function* mockStream() {
-      for (const chunk of chunks) {
-        yield chunk as never;
-      }
-    }
-
-    await processCompletionsStream(mockStream(), output, model, { push() {} });
+    await processCompletionsStream(streamChunks(chunks), output, model, { push() {} });
 
     expect(output.stopReason).toBe("stop");
     expect(output.content).toStrictEqual([{ type: "text", text: "Here is the answer." }]);
@@ -447,13 +423,7 @@ describe("openai completions stream", () => {
       makeCompletionsChunk({ role: "assistant" as const, content: "Ordinary answer." }),
       makeCompletionsChunk({ tool_calls: [] }, "stop"),
     ] as const;
-    async function* mockStream() {
-      for (const chunk of chunks) {
-        yield chunk as never;
-      }
-    }
-
-    await processCompletionsStream(mockStream(), output, model, { push() {} });
+    await processCompletionsStream(streamChunks(chunks), output, model, { push() {} });
 
     expect(output.content).toStrictEqual([{ type: "text", text: "Ordinary answer." }]);
   });
@@ -476,13 +446,7 @@ describe("openai completions stream", () => {
       makeCompletionsChunk({ content: "Just a text reply." }, "stop"),
     ] as const;
 
-    async function* mockStream() {
-      for (const chunk of mockChunks) {
-        yield chunk as never;
-      }
-    }
-
-    await processCompletionsStream(mockStream(), output, model, stream);
+    await processCompletionsStream(streamChunks(mockChunks), output, model, stream);
 
     expect(output.stopReason).toBe("stop");
     expect(output.content).toHaveLength(1);

--- a/packages/ai/src/transports/openai-completions-stream.usage.test.ts
+++ b/packages/ai/src/transports/openai-completions-stream.usage.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it, vi } from "vitest";
-import { createZeroUsage } from "../usage.test-support.js";
 import { processCompletionsStream } from "./openai-completions-stream.js";
 import {
   type CapturedStreamEvent,
@@ -149,16 +148,7 @@ describe("openai completions stream", () => {
       contextWindow: 128000,
       maxTokens: 4096,
     });
-    const output = {
-      role: "assistant" as const,
-      content: [],
-      api: model.api,
-      provider: model.provider,
-      model: model.id,
-      usage: createZeroUsage(),
-      stopReason: "stop" as const,
-      timestamp: Date.now(),
-    };
+    const output = createAssistantOutput(model);
     const stream: { push(event: unknown): void } = { push() {} };
 
     async function* mockStream() {
@@ -368,16 +358,7 @@ describe("openai completions stream", () => {
       contextWindow: 128000,
       maxTokens: 4096,
     });
-    const output = {
-      role: "assistant" as const,
-      content: [],
-      api: model.api,
-      provider: model.provider,
-      model: model.id,
-      usage: createZeroUsage(),
-      stopReason: "stop" as const,
-      timestamp: Date.now(),
-    };
+    const output = createAssistantOutput(model);
     const stream: { push(event: unknown): void } = { push() {} };
 
     async function* mockStream() {


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

Five completions-stream test suites repeat output-message fixtures and simple array-yield generators already provided by their shared test support module. The duplication obscures the provider-specific chunks and expectations.

## Why This Change Was Made

Reuse the existing `createAssistantOutput` at eight sites and `streamChunks` at twelve sites. All five suites already import the needed helpers. Keep the output type annotation, scenario-specific models/chunks, complete call arguments, independent expectations, dynamic usage/abort generators, and real SSE server coverage unchanged. No production code or helper implementation changes.

## User Impact

No user-visible behavior change or runtime improvement claimed. This removes 148 test lines while preserving every case and assertion.

## Evidence

- The original four-suite baseline passed 31 cases and the unchanged tool-calls sibling baseline passed 15. The combined five-suite candidate passed **46 cases**, with identical case names and statuses (9 reasoning/buffering, 6 reasoning-details, 3 tool-assembly, 15 tool-calls, 13 usage).
- Exact inverse reconstruction restores all five original files, including 69 direct `expect` sites, 18 `expectRecordFields` calls, both real SSE server blocks, and the `sawStreamDONE` option.
- Actual helper-body checks preserve output values, nested allocation freshness, model-field/usage/timestamp evaluation order, lazy iteration, early return, and thrown-error cleanup.
- The full mapped changed-file gate and fresh independent review of the combined five-file diff through P2 passed.
