### PR TITLE
fix(ui): keep touch details cursor policy compliant

### DIFF
--- a/ui/src/styles/new-session.css
+++ b/ui/src/styles/new-session.css
@@ -1536,7 +1536,6 @@ wa-popover.new-session-page__where-popover::part(body) {
     border-radius: var(--radius-sm);
     color: var(--muted);
     background: transparent;
-    cursor: var(--cursor-action);
   }
 
   .new-session-page__touch-details svg {


### PR DESCRIPTION
## Summary
- remove the unconditional action cursor from the coarse-pointer details control
- keep the global cursor policy limited to links and explicit new-tab controls

## Validation
- `pnpm exec vitest run --config vitest.config.ts ui/src/styles/cursor-policy.node.test.ts`
- `pnpm exec oxfmt --check ui/src/styles/new-session.css`
- `git diff --check`

## Release validation
This fixes the repeated `checks-node-compact-large-5` failure observed across the full-release remediation PRs.
