### PR TITLE
refactor(logging): retire the obsolete configuration test hook

### DIFF
--- a/src/logging.ts
+++ b/src/logging.ts
@@ -20,7 +20,6 @@ import {
   getResolvedLoggerSettings,
   isFileLogLevelEnabled,
   resetLogger,
-  setLoggerConfigLoaderForTests,
   setLoggerOverride,
   toPinoLikeLogger,
 } from "./logging/logger.js";
@@ -50,7 +49,6 @@ export {
   getResolvedLoggerSettings,
   isFileLogLevelEnabled,
   resetLogger,
-  setLoggerConfigLoaderForTests,
   setLoggerOverride,
   toPinoLikeLogger,
   createSubsystemLogger,

--- a/src/logging/console.ts
+++ b/src/logging/console.ts
@@ -3,10 +3,11 @@ import util from "node:util";
 import { stripAnsi } from "../../packages/terminal-core/src/ansi.js";
 import { clearActiveProgressLine } from "../../packages/terminal-core/src/progress-line.js";
 import { isVerbose } from "../global-state.js";
+import { readLoggingConfig } from "./config.js";
 import { resolveEnvLogLevelOverride } from "./env-log-level.js";
 import { formatJsonConsoleLine } from "./json-console-line.js";
 import { type LogLevel, normalizeLogLevel } from "./levels.js";
-import { getLogger, readLoggerConfig } from "./logger.js";
+import { getLogger } from "./logger.js";
 import { redactSensitiveText } from "./redact.js";
 import { loggingState } from "./state.js";
 import { formatTimestamp } from "./timestamps.js";
@@ -54,7 +55,7 @@ function resolveConsoleSettings(): ConsoleSettings {
     return { level: "silent", style: normalizeConsoleStyle(undefined) };
   }
 
-  const cfg = (loggingState.overrideSettings as LoggerSettings | null) ?? readLoggerConfig();
+  const cfg = (loggingState.overrideSettings as LoggerSettings | null) ?? readLoggingConfig();
   const level = envLevel ?? normalizeConsoleLevel(cfg?.consoleLevel);
   const style = normalizeConsoleStyle(cfg?.consoleStyle);
   return { level, style };

--- a/src/logging/level-filter.test.ts
+++ b/src/logging/level-filter.test.ts
@@ -17,6 +17,8 @@ let envSnapshot: ReturnType<typeof captureEnv> | undefined;
 let logging: typeof import("../logging.js");
 
 beforeAll(async () => {
+  // A sibling may retain an older logger; this suite observes its own config mock.
+  vi.resetModules();
   logging = await import("../logging.js");
 });
 
@@ -46,7 +48,6 @@ describe("resolved logging settings cache", () => {
   it("loads file settings once per logger generation", () => {
     process.env.OPENCLAW_TEST_FILE_LOG = "1";
     readLoggingConfigMock.mockReturnValue({ level: "silent" });
-    logging.setLoggerConfigLoaderForTests(readLoggingConfigMock);
 
     logging.getLogger();
     logging.getLogger();
@@ -65,7 +66,6 @@ describe("resolved logging settings cache", () => {
   it("reuses settings resolved by the file-level admission check when building the logger", () => {
     process.env.OPENCLAW_TEST_FILE_LOG = "1";
     readLoggingConfigMock.mockReturnValue({ level: "silent" });
-    logging.setLoggerConfigLoaderForTests(readLoggingConfigMock);
 
     expect(logging.isFileLogLevelEnabled("info")).toBe(false);
     logging.getLogger();
@@ -76,7 +76,6 @@ describe("resolved logging settings cache", () => {
   it("loads console settings once per logger generation", () => {
     process.env.OPENCLAW_TEST_CONSOLE = "1";
     readLoggingConfigMock.mockReturnValue({ consoleLevel: "silent" });
-    logging.setLoggerConfigLoaderForTests(readLoggingConfigMock);
     logging.setLoggerOverride(null);
     readLoggingConfigMock.mockClear();
 

--- a/src/logging/logger-settings.test.ts
+++ b/src/logging/logger-settings.test.ts
@@ -5,8 +5,14 @@ import { captureEnv } from "../test-utils/env.js";
 
 let envSnapshot: ReturnType<typeof captureEnv> | undefined;
 let logging: typeof import("../logging.js");
+let loggingConfig: typeof import("./config.js");
+let applyLoggingConfig: typeof import("./logger.js").applyLoggingConfig;
 
 beforeAll(async () => {
+  // Bind the observer and both settings consumers to the same module generation.
+  vi.resetModules();
+  loggingConfig = await import("./config.js");
+  ({ applyLoggingConfig } = await import("./logger.js"));
   logging = await import("../logging.js");
 });
 
@@ -23,14 +29,12 @@ afterEach(() => {
   envSnapshot = undefined;
   logging.resetLogger();
   logging.setLoggerOverride(null);
-  logging.setLoggerConfigLoaderForTests();
   vi.restoreAllMocks();
 });
 
 describe("getResolvedLoggerSettings", () => {
   it("uses a silent fast path in default Vitest mode without config reads", () => {
-    const readLoggingConfig = vi.fn(() => undefined);
-    logging.setLoggerConfigLoaderForTests(readLoggingConfig);
+    const readLoggingConfig = vi.spyOn(loggingConfig, "readLoggingConfig");
 
     const settings = logging.getResolvedLoggerSettings();
 
@@ -40,14 +44,16 @@ describe("getResolvedLoggerSettings", () => {
 
   it("reads logging config when test file logging is explicitly enabled", () => {
     process.env.OPENCLAW_TEST_FILE_LOG = "1";
-    logging.setLoggerConfigLoaderForTests(() => ({
+    const readLoggingConfig = vi.spyOn(loggingConfig, "readLoggingConfig");
+    applyLoggingConfig({
       level: "debug",
       file: "/tmp/openclaw-configured.log",
       maxFileBytes: 2048,
-    }));
+    });
 
     const settings = logging.getResolvedLoggerSettings();
 
+    expect(readLoggingConfig).toHaveBeenCalledOnce();
     expect(settings.level).toBe("debug");
     expect(settings.file).toBe("/tmp/openclaw-configured.log");
     expect(settings.maxFileBytes).toBe(2048);
@@ -55,7 +61,7 @@ describe("getResolvedLoggerSettings", () => {
 
   it("uses defaults when no logging config is available", () => {
     process.env.OPENCLAW_TEST_FILE_LOG = "1";
-    logging.setLoggerConfigLoaderForTests(() => undefined);
+    applyLoggingConfig(undefined);
 
     const settings = logging.getResolvedLoggerSettings();
 

--- a/src/logging/logger.browser-import.test.ts
+++ b/src/logging/logger.browser-import.test.ts
@@ -74,9 +74,13 @@ describe("logging/logger import", () => {
     expect(module.DEFAULT_LOG_DIR).toBe("/tmp/openclaw");
     expect(module.DEFAULT_LOG_FILE).toBe("/tmp/openclaw/openclaw.log");
 
-    module.setLoggerConfigLoaderForTests(() => undefined);
-    expect(path.dirname(module.getResolvedLoggerSettings().file)).toBe(secureLogDir);
-    expect(resolvePreferredOpenClawTmpDir).toHaveBeenCalledOnce();
+    module.applyLoggingConfig(undefined);
+    try {
+      expect(path.dirname(module.getResolvedLoggerSettings().file)).toBe(secureLogDir);
+      expect(resolvePreferredOpenClawTmpDir).toHaveBeenCalledOnce();
+    } finally {
+      module.resetLogger();
+    }
   });
 
   it("disables file logging when imported in a browser-like environment", async () => {

--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -55,7 +55,6 @@ type ResolvedSettings = {
 type ResolvedRuntimeSettings = ResolvedSettings & { rolling: boolean };
 export type LoggerResolvedSettings = ResolvedSettings;
 type TsLogRecord = Record<string, unknown>;
-type LoggerConfigLoader = () => OpenClawConfig["logging"] | undefined;
 
 type DiagnosticLogCode = {
   line?: number;
@@ -64,9 +63,6 @@ type DiagnosticLogCode = {
 
 const MAX_DIAGNOSTIC_LOG_BINDINGS_JSON_CHARS = 8 * 1024;
 const MAX_DIAGNOSTIC_LOG_MESSAGE_CHARS = 4 * 1024;
-
-const loadLoggerConfigDefault: LoggerConfigLoader = () => readLoggingConfig();
-let loadLoggerConfig: LoggerConfigLoader = loadLoggerConfigDefault;
 
 function invalidateLoggerSettings(): void {
   loggingState.cachedLogger = null;
@@ -81,14 +77,6 @@ export function applyLoggingConfig(config: OpenClawConfig["logging"] | undefined
   invalidateLoggerSettings();
 }
 
-export function setLoggerConfigLoaderForTests(loader?: LoggerConfigLoader): void {
-  loadLoggerConfig = loader ?? loadLoggerConfigDefault;
-  invalidateLoggerSettings();
-}
-
-export function readLoggerConfig(): OpenClawConfig["logging"] | undefined {
-  return loadLoggerConfig();
-}
 const MAX_DIAGNOSTIC_LOG_ATTRIBUTE_COUNT = 32;
 const MAX_DIAGNOSTIC_LOG_ATTRIBUTE_VALUE_CHARS = 2 * 1024;
 const MAX_DIAGNOSTIC_LOG_NAME_CHARS = 120;
@@ -533,7 +521,7 @@ function resolveSettings(): ResolvedRuntimeSettings {
   }
 
   const cfg: OpenClawConfig["logging"] | LoggerSettings | undefined =
-    (loggingState.overrideSettings as LoggerSettings | null) ?? loadLoggerConfig();
+    (loggingState.overrideSettings as LoggerSettings | null) ?? readLoggingConfig();
   const defaultLevel =
     process.env.VITEST === "true" && process.env.OPENCLAW_TEST_FILE_LOG !== "1" ? "silent" : "info";
   const fromConfig = normalizeLogLevel(cfg?.level, defaultLevel);
@@ -734,7 +722,6 @@ export function resetLogger() {
   loggingState.appliedConfig = APPLIED_LOGGING_CONFIG_UNOWNED;
   loggingState.overrideSettings = null;
   invalidateLoggingConfigCache();
-  loadLoggerConfig = loadLoggerConfigDefault;
   loggerHostnameState.resolver = defaultLoggerHostnameResolver;
   loggerHostnameState.cached = null;
   invalidateLoggerSettings();


### PR DESCRIPTION
Related: #108440, #121845

## What Problem This Solves

Logging tests still depended on a mutable configuration-reader hook left behind
after the public SDK retirement. That kept a second internal route to logging
configuration and made the tests depend on a path production does not customize.
This is a maintainer-requested cleanup, not a claim of a new user-facing defect.

## Why This Change Was Made

Logger and console settings now call the existing `readLoggingConfig` owner
directly. The obsolete loader slot, test setter, and forwarding function are
removed; retained tests use real config application or observe the canonical
reader with the correct module generation.

The setter was historically public. Its SDK reachability was already narrowed
by [the runtime-barrel cleanup](https://github.com/openclaw/openclaw/commit/dde90a345a621b3d7cf544b7a16ffaf726077313)
and [the text-runtime retirement](https://github.com/openclaw/openclaw/commit/dceb2c343c44b284087df2eeea67ebb394a0d6c7),
both present in the checked `v2026.8.1` stable tag. This removes the remaining
internal implementation, not a newly supported API. `resetLogger` and
`setLoggerOverride` remain intact.

## User Impact

No intentional user-visible change. Applied/unowned config handling, selector
and settings caches, override/reset behavior, console formatting, browser-safe
imports, and retained logger/child/Pino reload behavior are preserved. No config,
environment, persistence, schema, protocol, or dependency surface changes.

Production: **+4 / −18 = −14 lines**. Tests: **+21 / −12 = +9 lines**.

## Evidence

- The normal seven-file logging run passed **113/113** on the original,
  test-only port, candidate, and final restored candidate. Per-file ordered
  case identities/statuses match; no globally identical worker order is claimed.
- The retained suite includes **8 real-file reload cases**, including warm
  module copies and retained root, child, nested, and Pino loggers.
- Three test-only counterfactuals each produced exactly **1 intended failure
  and 112 passes**: a stale observer saw 0 rather than 1 reader call; real `info`
  input failed the `debug` expectation; omitting override clearing left 1 rather
  than 2 reads. Each was restored before the final 113/113 run.
- The normal six-file changed gate passed **all 30 selected checks** on Linux
  Node 24.19.0/pnpm 12.3.4, including production and test type graphs, formatting,
  lint, dead-export scans, import cycles, and repository guards:
  [configured Testbox run](https://github.com/openclaw/openclaw/actions/runs/34663222853).
  The command exited 0 and its one-shot lease completed; provider cleanup can
  make the backing Actions Testbox step appear cancelled.
- The six tested afterimages are byte-identical to signed commit
  `32415bc35d983ee1814c44e4bbd9761b56af0cb6`. Independent Codex reviews of the
  working candidate and that exact commit completed three passes each with
  **no P0–P2 findings**.

No additional full runtime/package build was run; none was selected by the
changed gate. Exact-head PR CI is separate from the evidence above and will be
reported by the PR's attached checks.
