### PR TITLE
fix(codex): retain completions until task persistence succeeds

### DIFF
--- a/extensions/codex/src/app-server/native-subagent-monitor.live.test.ts
+++ b/extensions/codex/src/app-server/native-subagent-monitor.live.test.ts
@@ -4,6 +4,9 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
 import type {
+  AgentHarnessScopedCreateRunningTaskRunParams,
+  AgentHarnessScopedFinalizeTaskRunParams,
+  AgentHarnessScopedSetDeliveryStatusParams,
   AgentHarnessTaskRecord,
   AgentHarnessTaskRuntimeScope,
 } from "openclaw/plugin-sdk/agent-harness-task-runtime";
@@ -32,12 +35,44 @@ type RecordedDelivery = {
 function createDeliveryRecorder(taskRecords: AgentHarnessTaskRecord[] = []) {
   const deliveries: RecordedDelivery[] = [];
   const taskRuntime = {
-    tryCreateRunningTaskRun: (params: { runId?: string }) =>
-      ({ runId: params.runId }) as AgentHarnessTaskRecord,
+    tryCreateRunningTaskRun: (params: AgentHarnessScopedCreateRunningTaskRunParams) => {
+      const existing = taskRecords.find((task) => task.runId === params.runId);
+      if (existing) {
+        return existing;
+      }
+      const task: AgentHarnessTaskRecord = {
+        taskId: params.runId,
+        runtime: "subagent",
+        taskKind: "codex-native",
+        scopeKind: "session",
+        ownerKey: "live:streamed",
+        requesterSessionKey: "live:streamed",
+        status: "running",
+        deliveryStatus: "not_applicable",
+        notifyPolicy: "silent",
+        createdAt: Date.now(),
+        runId: params.runId,
+        task: params.task,
+      };
+      taskRecords.push(task);
+      return task;
+    },
     recordTaskRunProgressByRunId: () => [],
-    finalizeTaskRunByRunId: () => [],
+    finalizeTaskRunByRunId: (params: AgentHarnessScopedFinalizeTaskRunParams) => {
+      const task = taskRecords.find((record) => record.runId === params.runId);
+      if (!task) {
+        return [];
+      }
+      task.status = params.status;
+      task.endedAt = params.endedAt;
+      task.terminalSummary = params.terminalSummary ?? undefined;
+      return [task];
+    },
     listTaskRecords: () => taskRecords,
-    setDetachedTaskDeliveryStatusByRunId: () => [],
+    setDetachedTaskDeliveryStatusByRunId: (params: AgentHarnessScopedSetDeliveryStatusParams) => {
+      const task = taskRecords.find((record) => record.runId === params.runId);
+      return task ? [Object.assign(task, params)] : [];
+    },
   };
   return {
     deliveries,

--- a/extensions/codex/src/app-server/native-subagent-monitor.test.ts
+++ b/extensions/codex/src/app-server/native-subagent-monitor.test.ts
@@ -3,6 +3,7 @@ import { onAgentEvent } from "openclaw/plugin-sdk/agent-harness-runtime";
 import type {
   AgentHarnessScopedSetDeliveryStatusParams,
   AgentHarnessTaskRecord,
+  AgentHarnessTaskRuntime,
   AgentHarnessTaskRuntimeScope,
 } from "openclaw/plugin-sdk/agent-harness-task-runtime";
 import { describe, expect, it, onTestFinished, vi } from "vitest";
@@ -151,10 +152,21 @@ function createRuntime() {
     createRunningTaskRun,
     tryCreateRunningTaskRun: vi.fn((params) => createRunningTaskRun(params)),
     recordTaskRunProgressByRunId: vi.fn(() => []),
-    finalizeTaskRunByRunId: vi.fn(() => []),
+    finalizeTaskRunByRunId: vi.fn<AgentHarnessTaskRuntime["finalizeTaskRunByRunId"]>((params) => [
+      {
+        ...taskRecord({
+          childThreadId: "child-thread",
+          status: params.status,
+          endedAt: params.endedAt,
+        }),
+        runId: params.runId,
+      },
+    ]),
     listTaskRecords: vi.fn((): AgentHarnessTaskRecord[] => []),
     setDetachedTaskDeliveryStatusByRunId: vi.fn(
-      (_params: AgentHarnessScopedSetDeliveryStatusParams): AgentHarnessTaskRecord[] => [],
+      (params: AgentHarnessScopedSetDeliveryStatusParams): AgentHarnessTaskRecord[] => [
+        { ...taskRecord({ childThreadId: "child-thread", status: "succeeded" }), ...params },
+      ],
     ),
   };
   return {
@@ -2454,6 +2466,170 @@ describe("CodexNativeSubagentMonitor", () => {
       vi.useRealTimers();
     }
   });
+
+  it.each([
+    { failure: "empty", close: "client" },
+    { failure: "throw", close: "client" },
+    { failure: "empty", close: "child" },
+    { failure: "throw", close: "child" },
+  ] as const)(
+    "retries $failure finalization across $close close without losing the accepted completion",
+    async ({ failure, close }) => {
+      vi.useFakeTimers();
+      try {
+        const client = createClient();
+        const runtime = createRuntime();
+        const monitor = new CodexNativeSubagentMonitor(client as never, runtime, {
+          recoveryPollDelaysMs: [],
+          completionDeliveryRetryDelaysMs: [10],
+          completionDeliveryMaxRetries: 1,
+        });
+        await registerDetachedChild(client, monitor);
+        let task = taskRecord({ childThreadId: "child-thread" });
+        runtime.listTaskRecords.mockImplementation(() => [task]);
+        let failing = true;
+        runtime.finalizeTaskRunByRunId.mockImplementation((params) => {
+          if (failing) {
+            if (failure === "throw") {
+              throw new Error("synthetic task write failure");
+            }
+            return [];
+          }
+          task = {
+            ...task,
+            status: params.status,
+            endedAt: params.endedAt,
+            terminalSummary: params.terminalSummary ?? undefined,
+          };
+          return [task];
+        });
+        const acceptedAt = Date.now();
+        await client.notify(nativeCompletionNotification({ result: "original completion" }));
+        await client.notify(nativeCompletionNotification({ result: "later duplicate" }));
+        expect(runtime.deliverAgentHarnessTaskCompletion).not.toHaveBeenCalled();
+        expect(runtime.setDetachedTaskDeliveryStatusByRunId).not.toHaveBeenCalled();
+        expect(task.status).toBe("running");
+
+        if (close === "client") {
+          client.close();
+        } else {
+          await client.notify(closeAgentNotification({ method: "item/completed" }));
+        }
+        await vi.advanceTimersByTimeAsync(30);
+        expect(runtime.finalizeTaskRunByRunId).toHaveBeenCalledTimes(4);
+        expect(runtime.setDetachedTaskDeliveryStatusByRunId).not.toHaveBeenCalled();
+        failing = false;
+        await vi.advanceTimersByTimeAsync(10);
+        expect(task).toMatchObject({
+          status: "succeeded",
+          endedAt: acceptedAt,
+          terminalSummary: "original completion",
+        });
+        expect(runtime.deliverAgentHarnessTaskCompletion).toHaveBeenCalledExactlyOnceWith(
+          expect.objectContaining({ result: "original completion" }),
+        );
+        expect(runtime.setDetachedTaskDeliveryStatusByRunId).toHaveBeenLastCalledWith(
+          expect.objectContaining({ deliveryStatus: "delivered" }),
+        );
+        client.close();
+      } finally {
+        vi.useRealTimers();
+      }
+    },
+  );
+
+  it.each([
+    { phase: "pending", failure: "empty" },
+    { phase: "pending", failure: "throw" },
+    { phase: "delivered", failure: "empty" },
+    { phase: "delivered", failure: "throw" },
+  ] as const)(
+    "retries $failure $phase persistence without repeating delivery",
+    async ({ phase, failure }) => {
+      vi.useFakeTimers();
+      try {
+        const client = createClient();
+        const runtime = createRuntime();
+        const monitor = new CodexNativeSubagentMonitor(client as never, runtime, {
+          recoveryPollDelaysMs: [],
+          completionDeliveryRetryDelaysMs: [10],
+        });
+        await registerDetachedChild(client, monitor);
+        let task = taskRecord({ childThreadId: "child-thread" });
+        runtime.listTaskRecords.mockImplementation(() => [task]);
+        runtime.finalizeTaskRunByRunId.mockImplementation((params) => {
+          task = {
+            ...task,
+            status: params.status,
+            endedAt: params.endedAt,
+            terminalSummary: params.terminalSummary ?? undefined,
+          };
+          return [task];
+        });
+        let failing = true;
+        runtime.setDetachedTaskDeliveryStatusByRunId.mockImplementation((params) => {
+          if (failing && params.deliveryStatus === phase) {
+            if (failure === "throw") {
+              throw new Error("synthetic delivery status failure");
+            }
+            return [];
+          }
+          task = { ...task, deliveryStatus: params.deliveryStatus };
+          return [task];
+        });
+        await client.notify(nativeCompletionNotification());
+        expect(task.status).toBe("succeeded");
+        expect(task.deliveryStatus).toBe(phase === "pending" ? "not_applicable" : "pending");
+        expect(runtime.deliverAgentHarnessTaskCompletion).toHaveBeenCalledTimes(
+          phase === "pending" ? 0 : 1,
+        );
+        await client.notify(closeAgentNotification({ method: "item/completed" }));
+        failing = false;
+        await vi.advanceTimersByTimeAsync(10);
+        expect(task.deliveryStatus).toBe("delivered");
+        expect(runtime.finalizeTaskRunByRunId).toHaveBeenCalledTimes(1);
+        expect(runtime.deliverAgentHarnessTaskCompletion).toHaveBeenCalledTimes(1);
+        client.close();
+      } finally {
+        vi.useRealTimers();
+      }
+    },
+  );
+
+  it.each(["removed", "cancelled", "retired"] as const)(
+    "does not revive a %s completion owner",
+    async (outcome) => {
+      vi.useFakeTimers();
+      try {
+        const client = createClient();
+        const runtime = createRuntime();
+        const monitor = new CodexNativeSubagentMonitor(client as never, runtime, {
+          recoveryPollDelaysMs: [],
+          completionDeliveryRetryDelaysMs: [10],
+        });
+        await registerDetachedChild(client, monitor);
+        runtime.listTaskRecords.mockReturnValue([taskRecord({ childThreadId: "child-thread" })]);
+        runtime.finalizeTaskRunByRunId.mockReturnValue([]);
+        await client.notify(nativeCompletionNotification());
+        expect(runtime.deliverAgentHarnessTaskCompletion).not.toHaveBeenCalled();
+        if (outcome === "retired") {
+          monitor.retireParent("parent-thread");
+        } else {
+          runtime.listTaskRecords.mockReturnValue(
+            outcome === "removed"
+              ? []
+              : [taskRecord({ childThreadId: "child-thread", status: "cancelled" })],
+          );
+        }
+        await vi.advanceTimersByTimeAsync(100);
+        expect(runtime.finalizeTaskRunByRunId).toHaveBeenCalledTimes(outcome === "retired" ? 1 : 2);
+        expect(runtime.deliverAgentHarnessTaskCompletion).not.toHaveBeenCalled();
+        client.close();
+      } finally {
+        vi.useRealTimers();
+      }
+    },
+  );
 
   it("bounds permanently non-durable completion retries", async () => {
     vi.useFakeTimers();

--- a/extensions/codex/src/app-server/native-subagent-monitor.test.ts
+++ b/extensions/codex/src/app-server/native-subagent-monitor.test.ts
@@ -155,7 +155,7 @@ function createRuntime() {
     finalizeTaskRunByRunId: vi.fn<AgentHarnessTaskRuntime["finalizeTaskRunByRunId"]>((params) => [
       {
         ...taskRecord({
-          childThreadId: "child-thread",
+          childThreadId: params.runId.slice("codex-thread:".length),
           status: params.status,
           endedAt: params.endedAt,
         }),
@@ -165,7 +165,13 @@ function createRuntime() {
     listTaskRecords: vi.fn((): AgentHarnessTaskRecord[] => []),
     setDetachedTaskDeliveryStatusByRunId: vi.fn(
       (params: AgentHarnessScopedSetDeliveryStatusParams): AgentHarnessTaskRecord[] => [
-        { ...taskRecord({ childThreadId: "child-thread", status: "succeeded" }), ...params },
+        {
+          ...taskRecord({
+            childThreadId: params.runId.slice("codex-thread:".length),
+            status: "succeeded",
+          }),
+          ...params,
+        },
       ],
     ),
   };
@@ -2470,6 +2476,7 @@ describe("CodexNativeSubagentMonitor", () => {
   it.each([
     { failure: "empty", close: "client" },
     { failure: "throw", close: "client" },
+    { failure: "other-task", close: "client" },
     { failure: "empty", close: "child" },
     { failure: "throw", close: "child" },
   ] as const)(
@@ -2492,6 +2499,9 @@ describe("CodexNativeSubagentMonitor", () => {
           if (failing) {
             if (failure === "throw") {
               throw new Error("synthetic task write failure");
+            }
+            if (failure === "other-task") {
+              return [{ ...task, taskId: "different-task" }];
             }
             return [];
           }
@@ -2596,7 +2606,7 @@ describe("CodexNativeSubagentMonitor", () => {
     },
   );
 
-  it.each(["removed", "cancelled", "retired"] as const)(
+  it.each(["removed", "cancelled", "retired", "replaced"] as const)(
     "does not revive a %s completion owner",
     async (outcome) => {
       vi.useFakeTimers();
@@ -2614,6 +2624,13 @@ describe("CodexNativeSubagentMonitor", () => {
         expect(runtime.deliverAgentHarnessTaskCompletion).not.toHaveBeenCalled();
         if (outcome === "retired") {
           monitor.retireParent("parent-thread");
+        } else if (outcome === "replaced") {
+          const replacement = {
+            ...taskRecord({ childThreadId: "child-thread", status: "succeeded" }),
+            taskId: "replacement-task",
+          };
+          runtime.listTaskRecords.mockReturnValue([replacement]);
+          runtime.finalizeTaskRunByRunId.mockReturnValue([replacement]);
         } else {
           runtime.listTaskRecords.mockReturnValue(
             outcome === "removed"
@@ -2622,7 +2639,9 @@ describe("CodexNativeSubagentMonitor", () => {
           );
         }
         await vi.advanceTimersByTimeAsync(100);
-        expect(runtime.finalizeTaskRunByRunId).toHaveBeenCalledTimes(outcome === "retired" ? 1 : 2);
+        expect(runtime.finalizeTaskRunByRunId).toHaveBeenCalledTimes(
+          outcome === "cancelled" ? 2 : 1,
+        );
         expect(runtime.deliverAgentHarnessTaskCompletion).not.toHaveBeenCalled();
         client.close();
       } finally {
@@ -2630,6 +2649,34 @@ describe("CodexNativeSubagentMonitor", () => {
       }
     },
   );
+
+  it("does not retry delivery after the original task row is replaced", async () => {
+    vi.useFakeTimers();
+    try {
+      const client = createClient();
+      const runtime = createRuntime();
+      const monitor = new CodexNativeSubagentMonitor(client as never, runtime, {
+        recoveryPollDelaysMs: [],
+        completionDeliveryRetryDelaysMs: [10],
+      });
+      await registerDetachedChild(client, monitor);
+      const original = taskRecord({ childThreadId: "child-thread" });
+      runtime.listTaskRecords.mockReturnValue([original]);
+      runtime.deliverAgentHarnessTaskCompletion.mockResolvedValue({
+        delivered: false,
+        path: "direct",
+        error: "retry delivery",
+      });
+      await client.notify(nativeCompletionNotification());
+      expect(runtime.deliverAgentHarnessTaskCompletion).toHaveBeenCalledTimes(1);
+      runtime.listTaskRecords.mockReturnValue([{ ...original, taskId: "replacement-task" }]);
+      await vi.advanceTimersByTimeAsync(100);
+      expect(runtime.deliverAgentHarnessTaskCompletion).toHaveBeenCalledTimes(1);
+      client.close();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 
   it("bounds permanently non-durable completion retries", async () => {
     vi.useFakeTimers();
@@ -2713,6 +2760,55 @@ describe("CodexNativeSubagentMonitor", () => {
     );
     client.close();
   });
+
+  it.each(["succeeded", "failed"] as const)(
+    "retries rejected finalization of a recovered %s task awaiting delivery",
+    async (status) => {
+      vi.useFakeTimers();
+      try {
+        const client = createClient();
+        client.setThreadRead(
+          "child-thread",
+          threadRead({
+            status: status === "succeeded" ? "completed" : "failed",
+            result: "recovered terminal result",
+            error: status === "failed" ? "recovered terminal result" : undefined,
+          }),
+        );
+        const runtime = createRuntime();
+        const task = taskRecord({
+          childThreadId: "child-thread",
+          status,
+          deliveryStatus: "pending",
+          endedAt: Date.now(),
+        });
+        runtime.listTaskRecords.mockReturnValue([task]);
+        runtime.finalizeTaskRunByRunId.mockReturnValueOnce([]).mockReturnValue([task]);
+        runtime.setDetachedTaskDeliveryStatusByRunId.mockImplementation((params) => {
+          task.deliveryStatus = params.deliveryStatus;
+          return [task];
+        });
+        const monitor = new CodexNativeSubagentMonitor(client as never, runtime, {
+          recoveryPollDelaysMs: [],
+          completionDeliveryRetryDelaysMs: [10],
+        });
+        const parent = registerParent(monitor);
+        await vi.advanceTimersByTimeAsync(0);
+        expect(runtime.finalizeTaskRunByRunId).toHaveBeenCalledTimes(1);
+        expect(task.deliveryStatus).toBe("pending");
+        parent.unregister();
+        expect(runtime.deliverAgentHarnessTaskCompletion).not.toHaveBeenCalled();
+        await vi.advanceTimersByTimeAsync(10);
+        expect(runtime.deliverAgentHarnessTaskCompletion).toHaveBeenCalledExactlyOnceWith(
+          expect.objectContaining({ status, result: "recovered terminal result" }),
+        );
+        expect(task.deliveryStatus).toBe("delivered");
+        client.close();
+      } finally {
+        vi.useRealTimers();
+      }
+    },
+  );
 
   it("reconciles queued task rows owned by the registered requester", async () => {
     const client = createClient();

--- a/extensions/codex/src/app-server/native-subagent-monitor.ts
+++ b/extensions/codex/src/app-server/native-subagent-monitor.ts
@@ -98,7 +98,9 @@ type ChildState = {
   recoveryInFlight?: Promise<boolean>;
   terminal: boolean;
   fallbackCompletion?: RecoveredCompletion;
-  pendingCompletion?: CodexNativeSubagentCompletion;
+  pendingCompletion?: RecoveredCompletion;
+  completionTaskPhase?: "finalize" | "delivery";
+  subscriptionClosed?: true;
   nativeCompletionDelivered: boolean;
   completionDeliveryAttempt: number;
   completionDeliveryTimer?: ReturnType<typeof setTimeout>;
@@ -983,6 +985,20 @@ class Monitor {
   }
 
   private retireChild(state: ParentState, childState: ChildState, summary: string): void {
+    if (
+      childState.pendingCompletion &&
+      childState.completionTaskPhase &&
+      !this.retiredParentStates.has(state)
+    ) {
+      // Closing the native child does not discard its already accepted result.
+      // Persistence keeps its owner, but must not warm a closed subscription later.
+      childState.subscriptionClosed = true;
+      this.releaseDirectChild(childState);
+      this.clearRecoveryTimers(childState);
+      this.updateChildThreadOwnership("release", childState.childThreadId, this.releaseChildThread);
+      this.releaseClientRetentionIfIdle();
+      return;
+    }
     if (!childState.terminal) {
       childState.terminal = true;
       const revision = this.threadStatusRevisions.get(childState.childThreadId);
@@ -1222,11 +1238,9 @@ class Monitor {
     if (childState.terminal) {
       return;
     }
-    if (!this.claimCompletionDelivery(state, childState)) {
-      this.unregisterChild(childState);
-      return;
-    }
     childState.terminal = true;
+    childState.pendingCompletion = { ...completion, completedAt: eventAt };
+    childState.completionTaskPhase = "finalize";
     const revision = this.threadStatusRevisions.get(childState.childThreadId);
     if (revision) {
       revision.terminal = true;
@@ -1234,30 +1248,67 @@ class Monitor {
     this.releaseDirectChild(childState);
     this.clearRecoveryTimers(childState);
     state.mirror?.markAuthoritativeCompletion(completion.childThreadId);
-    state.taskRuntime?.finalizeTaskRunByRunId({
-      runId: codexNativeSubagentRunId(completion.childThreadId),
-      status: completion.status,
-      endedAt: eventAt,
-      lastEventAt: eventAt,
-      ...(completion.status === "succeeded" ? {} : { error: completion.result }),
-      progressSummary: completion.result,
-      terminalSummary: completion.result,
-    });
-    if (!state.requesterSessionKey || !state.taskRuntimeScope) {
-      this.unregisterChild(childState);
-      return;
-    }
-    if (childState.nativeCompletionDelivered) {
-      this.finishCompletionDelivery(state, childState);
-      return;
-    }
-    childState.pendingCompletion = completion;
-    state.taskRuntime?.setDetachedTaskDeliveryStatusByRunId({
-      runId: codexNativeSubagentRunId(completion.childThreadId),
-      deliveryStatus: "pending",
-    });
-    this.releaseClientRetentionIfIdle();
     await this.deliverPendingCompletion(state, childState);
+  }
+
+  private persistPendingCompletion(state: ParentState, child: ChildState): boolean {
+    const completion = child.pendingCompletion;
+    if (!completion) {
+      return false;
+    }
+    const runId = codexNativeSubagentRunId(completion.childThreadId);
+    if (child.completionTaskPhase === "finalize") {
+      if (!this.claimCompletionDelivery(state, child)) {
+        this.unregisterChild(child);
+        return false;
+      }
+      const eventAt = completion.completedAt ?? this.now();
+      const updated = state.taskRuntime?.finalizeTaskRunByRunId({
+        runId,
+        status: completion.status,
+        endedAt: eventAt,
+        lastEventAt: eventAt,
+        ...(completion.status === "succeeded" ? {} : { error: completion.result }),
+        progressSummary: completion.result,
+        terminalSummary: completion.result,
+      });
+      if (state.taskRuntime && !updated?.some((task) => task.runId === runId)) {
+        const current = state.taskRuntime.listTaskRecords().find((task) => task.runId === runId);
+        // An absent row or an existing terminal decision must not be recreated.
+        if (!current || (current.status !== "queued" && current.status !== "running")) {
+          this.unregisterChild(child);
+          return false;
+        }
+        throw new Error("Codex native subagent task finalization was not persisted.");
+      }
+      child.completionTaskPhase = "delivery";
+    }
+    if (!state.requesterSessionKey || !state.taskRuntimeScope) {
+      this.unregisterChild(child);
+      return false;
+    }
+    if (child.completionTaskPhase === "delivery") {
+      const updated = state.taskRuntime?.setDetachedTaskDeliveryStatusByRunId({
+        runId,
+        deliveryStatus: child.nativeCompletionDelivered ? "delivered" : "pending",
+      });
+      if (state.taskRuntime && !updated?.some((task) => task.runId === runId)) {
+        if (!state.taskRuntime.listTaskRecords().some((task) => task.runId === runId)) {
+          this.unregisterChild(child);
+          return false;
+        }
+        throw new Error("Codex native subagent task delivery status was not persisted.");
+      }
+      child.completionTaskPhase = undefined;
+      child.completionDeliveryAttempt = 0;
+    }
+    if (child.nativeCompletionDelivered) {
+      child.pendingCompletion = undefined;
+      this.unregisterChild(child);
+      return false;
+    }
+    this.releaseClientRetentionIfIdle();
+    return true;
   }
 
   private async deliverPendingCompletion(
@@ -1265,12 +1316,12 @@ class Monitor {
     childState: ChildState,
   ): Promise<void> {
     const completion = childState.pendingCompletion;
-    if (!completion || !state.requesterSessionKey || !state.taskRuntimeScope) {
-      return;
-    }
-    // Codex owns completion input from registration through reply finalization,
-    // including turn startup before its id is bound. Only wake detached parents.
-    if (state.owners.size > 0) {
+    if (
+      !completion ||
+      this.childStates.get(childState.childThreadId) !== childState ||
+      this.parentStates.get(state.parentThreadId) !== state ||
+      this.retiredParentStates.has(state)
+    ) {
       return;
     }
     if (childState.deliveringCompletion || childState.completionDeliveryTimer) {
@@ -1278,6 +1329,14 @@ class Monitor {
     }
     childState.deliveringCompletion = true;
     try {
+      if (!this.persistPendingCompletion(state, childState)) {
+        return;
+      }
+      // Foreground parents already receive native completion input. Persist the
+      // result now, but only wake a detached parent after its last owner leaves.
+      if (state.owners.size > 0 || !state.taskRuntimeScope) {
+        return;
+      }
       const delivery = await this.runtime.deliverAgentHarnessTaskCompletion({
         scope: state.taskRuntimeScope,
         childSessionKey: codexNativeSubagentRunId(completion.childThreadId),
@@ -1298,7 +1357,9 @@ class Monitor {
         return;
       }
       if (isDurableAgentHarnessCompletionDelivery(delivery)) {
-        this.finishCompletionDelivery(state, childState);
+        childState.nativeCompletionDelivered = true;
+        childState.completionTaskPhase = "delivery";
+        this.persistPendingCompletion(state, childState);
         return;
       }
       const error = delivery.error ?? "completion delivery did not produce a parent response";
@@ -1316,12 +1377,14 @@ class Monitor {
         return;
       }
       const message = formatErrorMessage(error);
-      state.taskRuntime?.setDetachedTaskDeliveryStatusByRunId({
-        runId: codexNativeSubagentRunId(completion.childThreadId),
-        deliveryStatus: "pending",
-        error: message,
-      });
       this.scheduleCompletionDeliveryRetry(childState, message);
+      if (!childState.completionTaskPhase) {
+        state.taskRuntime?.setDetachedTaskDeliveryStatusByRunId({
+          runId: codexNativeSubagentRunId(completion.childThreadId),
+          deliveryStatus: "pending",
+          error: message,
+        });
+      }
       embeddedAgentLog.warn("Failed to deliver Codex native subagent completion", {
         parentThreadId: state.parentThreadId,
         childThreadId: completion.childThreadId,
@@ -1354,13 +1417,13 @@ class Monitor {
   }
 
   private finishCompletionDelivery(state: ParentState, child: ChildState): void {
-    child.pendingCompletion = undefined;
-    child.completionDeliveryAttempt = 0;
-    state.taskRuntime?.setDetachedTaskDeliveryStatusByRunId({
-      runId: codexNativeSubagentRunId(child.childThreadId),
-      deliveryStatus: "delivered",
-    });
-    this.unregisterChild(child);
+    child.nativeCompletionDelivered = true;
+    child.completionTaskPhase ??= "delivery";
+    if (child.completionDeliveryTimer) {
+      clearTimeout(child.completionDeliveryTimer);
+      child.completionDeliveryTimer = undefined;
+    }
+    void this.deliverPendingCompletion(state, child);
   }
 
   private deliverDetachedCompletions(state: ParentState): void {
@@ -1379,7 +1442,10 @@ class Monitor {
     ) {
       return;
     }
-    if (childState.completionDeliveryAttempt >= this.completionDeliveryMaxRetries) {
+    if (
+      !childState.completionTaskPhase &&
+      childState.completionDeliveryAttempt >= this.completionDeliveryMaxRetries
+    ) {
       const state = this.parentStates.get(childState.parentThreadId);
       state?.taskRuntime?.setDetachedTaskDeliveryStatusByRunId({
         runId: codexNativeSubagentRunId(childState.childThreadId),
@@ -1625,7 +1691,12 @@ class Monitor {
     options: { retainSubscription?: boolean } = {},
   ): void {
     this.releaseDirectChild(childState);
-    if (childState.terminal && options.retainSubscription !== false && !this.disposed) {
+    if (
+      childState.terminal &&
+      !childState.subscriptionClosed &&
+      options.retainSubscription !== false &&
+      !this.disposed
+    ) {
       // Completed Codex children intentionally remain reusable. Transfer their
       // auto-subscription into the shared bounded warm-thread owner, not oblivion.
       this.updateChildThreadOwnership("retain", childState.childThreadId, this.retainChildThread);

--- a/extensions/codex/src/app-server/native-subagent-monitor.ts
+++ b/extensions/codex/src/app-server/native-subagent-monitor.ts
@@ -100,6 +100,7 @@ type ChildState = {
   fallbackCompletion?: RecoveredCompletion;
   pendingCompletion?: RecoveredCompletion;
   completionTaskPhase?: "finalize" | "delivery";
+  completionTaskId?: string;
   subscriptionClosed?: true;
   nativeCompletionDelivered: boolean;
   completionDeliveryAttempt: number;
@@ -1257,6 +1258,14 @@ class Monitor {
       return false;
     }
     const runId = codexNativeSubagentRunId(completion.childThreadId);
+    if (
+      child.completionTaskId &&
+      state.taskRuntime?.listTaskRecords().find((task) => task.runId === runId)?.taskId !==
+        child.completionTaskId
+    ) {
+      this.unregisterChild(child);
+      return false;
+    }
     if (child.completionTaskPhase === "finalize") {
       if (!this.claimCompletionDelivery(state, child)) {
         this.unregisterChild(child);
@@ -1272,10 +1281,23 @@ class Monitor {
         progressSummary: completion.result,
         terminalSummary: completion.result,
       });
-      if (state.taskRuntime && !updated?.some((task) => task.runId === runId)) {
+      if (
+        state.taskRuntime &&
+        !updated?.some(
+          (task) =>
+            task.runId === runId &&
+            (!child.completionTaskId || task.taskId === child.completionTaskId),
+        )
+      ) {
         const current = state.taskRuntime.listTaskRecords().find((task) => task.runId === runId);
-        // An absent row or an existing terminal decision must not be recreated.
-        if (!current || (current.status !== "queued" && current.status !== "running")) {
+        // Recovery can rewrite an already-terminal outcome still awaiting delivery.
+        // Only absence or a conflicting terminal decision retires this projection.
+        if (
+          !current ||
+          (current.status !== completion.status &&
+            current.status !== "queued" &&
+            current.status !== "running")
+        ) {
           this.unregisterChild(child);
           return false;
         }
@@ -1292,7 +1314,14 @@ class Monitor {
         runId,
         deliveryStatus: child.nativeCompletionDelivered ? "delivered" : "pending",
       });
-      if (state.taskRuntime && !updated?.some((task) => task.runId === runId)) {
+      if (
+        state.taskRuntime &&
+        !updated?.some(
+          (task) =>
+            task.runId === runId &&
+            (!child.completionTaskId || task.taskId === child.completionTaskId),
+        )
+      ) {
         if (!state.taskRuntime.listTaskRecords().some((task) => task.runId === runId)) {
           this.unregisterChild(child);
           return false;
@@ -1796,13 +1825,11 @@ class Monitor {
       return owner === childState;
     }
     const runId = codexNativeSubagentRunId(childState.childThreadId);
-    if (
-      state.taskRuntime
-        ?.listTaskRecords()
-        .some((task) => task.runId === runId && task.deliveryStatus === "delivered")
-    ) {
+    const task = state.taskRuntime?.listTaskRecords().find((record) => record.runId === runId);
+    if (task?.deliveryStatus === "delivered") {
       return false;
     }
+    childState.completionTaskId = task?.taskId;
     // Delivery no longer needs the app-server client. Keep one process owner
     // across client replacement so fallback steering cannot inject twice.
     completionDeliveryOwners.set(key, childState);

--- a/extensions/codex/src/app-server/shared-client.test.ts
+++ b/extensions/codex/src/app-server/shared-client.test.ts
@@ -2,6 +2,10 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { embeddedAgentLog } from "openclaw/plugin-sdk/agent-harness-runtime";
+import type {
+  AgentHarnessTaskRecord,
+  AgentHarnessTaskRuntime,
+} from "openclaw/plugin-sdk/agent-harness-task-runtime";
 import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import { withTempDir } from "openclaw/plugin-sdk/test-env";
 import { SemVer } from "semver";
@@ -2473,12 +2477,40 @@ describe("shared Codex app-server client", () => {
     await sendInitializeResult(harness, "openclaw/0.149.0 (Linux; test)");
     const client = await clientPromise;
     const deliverCompletion = vi.fn(async () => ({ delivered: true, path: "direct" as const }));
-    const taskRuntime = {
-      tryCreateRunningTaskRun: vi.fn(() => ({ taskId: "child-thread" })),
+    const task: AgentHarnessTaskRecord = {
+      taskId: "child-thread",
+      runId: "codex-thread:child-thread",
+      runtime: "subagent",
+      taskKind: "codex-native",
+      ownerKey: "agent:main:main",
+      requesterSessionKey: "agent:main:main",
+      scopeKind: "session",
+      task: "inspect the repo",
+      status: "running",
+      deliveryStatus: "not_applicable",
+      notifyPolicy: "silent",
+      createdAt: Date.now(),
+    };
+    let created = false;
+    const createTask = vi.fn(() => {
+      created = true;
+      return task;
+    });
+    const taskRuntime: AgentHarnessTaskRuntime = {
+      createRunningTaskRun: createTask,
+      tryCreateRunningTaskRun: createTask,
       recordTaskRunProgressByRunId: vi.fn(() => []),
-      finalizeTaskRunByRunId: vi.fn(() => []),
-      listTaskRecords: vi.fn(() => []),
-      setDetachedTaskDeliveryStatusByRunId: vi.fn(() => []),
+      finalizeTaskRunByRunId: vi.fn((params) => {
+        task.status = params.status;
+        task.endedAt = params.endedAt;
+        task.terminalSummary = params.terminalSummary ?? undefined;
+        return [task];
+      }),
+      listTaskRecords: vi.fn(() => (created ? [task] : [])),
+      setDetachedTaskDeliveryStatusByRunId: vi.fn((params) => {
+        task.deliveryStatus = params.deliveryStatus;
+        return [task];
+      }),
     };
     const retainClient = vi.fn(() => retainSharedCodexAppServerClientIfCurrent(client));
     const monitor = new codexNativeSubagentMonitorRuntime.Monitor(
@@ -2486,13 +2518,13 @@ describe("shared Codex app-server client", () => {
       {
         createAgentHarnessTaskRuntime: vi.fn(() => taskRuntime),
         deliverAgentHarnessTaskCompletion: deliverCompletion,
-      } as never,
+      },
       { retainClient },
     );
     monitor.registerParent({
       parentThreadId: "parent-thread",
       requesterSessionKey: "agent:main:main",
-      taskRuntimeScope: {} as never,
+      taskRuntimeScope: { requesterSessionKey: "agent:main:main" },
       agentId: "main",
     });
 
@@ -2557,6 +2589,11 @@ describe("shared Codex app-server client", () => {
     expect(deliverCompletion).toHaveBeenCalledWith(
       expect.objectContaining({ childSessionId: "child-thread", result: "child final result" }),
     );
+    expect(task).toMatchObject({
+      status: "succeeded",
+      deliveryStatus: "delivered",
+      terminalSummary: "child final result",
+    });
     expect(harness.process.stdin.destroyed).toBe(true);
   });
 


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where a completed Codex native subagent could remain running in OpenClaw's task list or lose its completion after a temporary SQLite write failure. The monitor retired its completion bookkeeping before checking whether finalization actually persisted, including when the task runtime returned an empty result.

## Why This Change Was Made

Keep the original completion and timestamp with the existing monitor until finalization and delivery status are persisted. Retry the unfinished phase without repeating a durable announcement. Normal child close releases its subscription while retaining pending persistence; parent retirement and removed or already-terminal task records still prevent obsolete work from being recreated.

## User Impact

Completed native subagent tasks recover from temporary storage failures without losing their result or sending it twice. The synchronous harness API, native protocol semantics, SQLite schema, and existing announcement retry limit remain unchanged.

## Evidence

133 focused monitor, mirror, and shared-client lifetime cases pass. The shared-client fixture now records successful task writes instead of returning an empty result; its final task state is asserted. Regression coverage exercises empty and thrown writes, duplicate completion notifications, native child/client close, and removed, cancelled, or retired owners. The original ordering and the child-close failure were verified with failing regression tests before their respective repairs.

Standalone real-timer proofs use the actual scoped task runtime and isolated SQLite databases. A temporary trigger rejects terminal upserts three times; after either client close or native child close, the next write succeeds, one synthetic delivery occurs, and a fresh SQLite connection confirms the original summary/timestamp with succeeded/delivered state. No provider credentials or native-agent sends are used. The provider live-test recorder was updated to model applied task records; that provider test was not run.

Independent P2 review is clean after addressing child-close and matching-terminal recovery findings. Recovery pins the original task UUID within the scoped native run, checks that identity before retrying persistence or announcement delivery, and requires an acknowledgement for that same record. Tests reject same-run replacements and partial acknowledgements from sibling metadata rows. Actual SQLite tests seed both succeeded/pending and failed/pending records, reject three upserts, then verify one delivery and the original UUID, timestamp, and summary after reopening. The changed-scope checks include production and test typechecks, formatting, and routed boundary guards.

After a patch-identical rebase onto current main containing the independent UI fix in #145415, the focused tests, the actual SQLite native-child-close/reopen proof, and the complete local changed-scope gate passed, including all Knip scans.

The branch also contains the independently landed UI test correction from #145540; no UI changes are part of this PR.
