### PR TITLE
refactor(control-ui): share settings navigation grouping

### DIFF
--- a/ui/src/app-navigation.ts
+++ b/ui/src/app-navigation.ts
@@ -226,23 +226,25 @@ const SETTINGS_NAVIGATION_GROUPS = [
   },
 ] as const satisfies readonly SettingsNavigationGroup[];
 
-const NON_ADMIN_SETTINGS_NAVIGATION_GROUPS = [
-  { labelKey: null, routes: ["profile", "appearance", "notifications"] },
-  { labelKey: "nav.settingsGroupDevice", routes: ["device", "device-permissions"] },
-  {
-    labelKey: "nav.settingsGroupConnections",
-    routes: ["connection", "channels", "talk", "devices"],
-  },
-  {
-    labelKey: "nav.settingsGroupAgents",
-    routes: ["agents", "model-providers", "plugin-settings", "skill-settings", "memory"],
-  },
-  { labelKey: "nav.settingsGroupSecurity", routes: ["approvals"] },
-  {
-    labelKey: "nav.settingsGroupSystem",
-    routes: ["advanced", "debug", "logs", "updates", "about"],
-  },
-] as const satisfies readonly SettingsNavigationGroup[];
+const NON_ADMIN_SETTINGS_ROUTES: ReadonlySet<NavigationRouteId> = new Set([
+  "profile",
+  "appearance",
+  "notifications",
+  "connection",
+  "channels",
+  "talk",
+  "devices",
+  "agents",
+  "model-providers",
+  "plugin-settings",
+  "skill-settings",
+  "memory",
+  "approvals",
+  "advanced",
+  "debug",
+  "logs",
+  "about",
+]);
 
 export function isSettingsNavigationRouteVisible(
   routeId: NavigationRouteId,
@@ -255,12 +257,7 @@ export function isSettingsNavigationRouteVisible(
   if (routeId === "updates") {
     return canAdmin || nativeDeviceSettings !== null;
   }
-  return (
-    canAdmin ||
-    NON_ADMIN_SETTINGS_NAVIGATION_GROUPS.some((group) =>
-      group.routes.some((candidate) => candidate === routeId),
-    )
-  );
+  return canAdmin || NON_ADMIN_SETTINGS_ROUTES.has(routeId);
 }
 
 export function deviceSettingsGroupLabelKey(
@@ -285,18 +282,15 @@ export function visibleSettingsNavigationGroups(
   canAdmin: boolean,
   nativeDeviceSettings: NativeDeviceSettingsCapability | null = null,
 ): readonly SettingsNavigationGroup[] {
-  const groups = canAdmin ? SETTINGS_NAVIGATION_GROUPS : NON_ADMIN_SETTINGS_NAVIGATION_GROUPS;
-  return groups
-    .map((group) => ({
-      labelKey:
-        group.labelKey === "nav.settingsGroupDevice"
-          ? deviceSettingsGroupLabelKey(nativeDeviceSettings?.snapshot)
-          : group.labelKey,
-      routes: group.routes.filter((route) =>
-        isSettingsNavigationRouteVisible(route, canAdmin, nativeDeviceSettings),
-      ),
-    }))
-    .filter((group) => group.routes.length > 0);
+  return SETTINGS_NAVIGATION_GROUPS.map((group) => ({
+    labelKey:
+      group.labelKey === "nav.settingsGroupDevice"
+        ? deviceSettingsGroupLabelKey(nativeDeviceSettings?.snapshot)
+        : group.labelKey,
+    routes: group.routes.filter((route) =>
+      isSettingsNavigationRouteVisible(route, canAdmin, nativeDeviceSettings),
+    ),
+  })).filter((group) => group.routes.length > 0);
 }
 
 // Settings subpages render with settings chrome but stay out of the sidebar.


### PR DESCRIPTION
## What Problem This Solves

Settings navigation carries a separate non-admin copy of the same group labels and route ordering, then scans that copy again for visibility checks. This adds startup code and makes future navigation changes update two representations.

## Why This Change Was Made

Use one ordered settings-group table and an explicit non-admin route allowlist. Keep the existing native-device and Updates exceptions, unknown-route rejection, searchable subpages, translated headings, and public results unchanged. The change removes six production lines without adding a cache or changing authorization.

## User Impact

No intended behavior change. The measured HTML startup JavaScript footprint is 325 raw bytes smaller. **This is a cleanup and small footprint reduction, not a runtime speedup.**

## Evidence

On source `c38897f5544081974bc13632c2f1a17337b52ba7`, one Linux Chromium comparison ran fresh B1/C1/C2/B2 production builds with an identical frozen toolchain and fixed build identity. All 114 existing tests passed, as did all eight browser scenarios in all four phases. Complete recorded navigation/settings/palette/locale semantics matched, and all 60 corresponding screenshots were byte-identical. All 11 unique images were inspected and contain synthetic fixtures only. Injected native bridge cases are Linux Chromium contract proof, not physical macOS/iOS device proof.

**Adverse timings remain:** viewer-chat readiness changed from 540.30 to 648.75 ms (+20.1%) and from 507.26 to 634.77 ms (+25.1%). Viewer-new palette opening changed from 133.31 to 145.95 ms (+9.5%) and from 109.19 to 121.48 ms (+11.3%). Whole build/browser user CPU was mixed (−1.0%, +0.8%). These observations are not assigned a cause or erased by another run.

HTML-startup raw JS fell from 1,150,893 to 1,150,568 B. Gzip fell from 354,550 B to 354,497/354,517 B; the two candidate builds show compression/output variation, so there is no single exact gzip saving. All four phases still exceeded the pinned 354,270 B enforcement limit. This PR does not change a baseline or claim to fix that budget failure. The observed post-ready request graph also shrank slightly; associated sidecar footprints are not actual wire-transfer measurements.

The earlier standalone callback-serialization and fixed-clock Resource Timing harness failures remain preserved. The completed run used the existing UI Vitest transform path and boot-manifest request-event collection. All observed processes closed, source restoration and normal worktree removal succeeded, and the Testbox was independently verified completed. [Proof run](https://github.com/openclaw/openclaw/actions/runs/34665680387).

The measured source predates intended author base `b6073553b799d81cb4805cc6111e73545d9b5d24`. The navigation owner, direct callers/tests and dependency/toolchain inputs are unchanged, but 32 other UI files changed; the timing and whole-bundle values above remain historical. At author base `b6073553b799d81cb4805cc6111e73545d9b5d24`, the exact candidate passed one-file formatting and all 114 existing tests, and a fresh managed Codex P2 review was scoped-clean. The changed-check dry-run command exited successfully with its complete plan on stderr. Its validation wrapper nevertheless failed because it incorrectly expected the marker on stdout; that overall failure is preserved without retry. No actual selected typecheck/lint/guard gates ran; they remain deferred to exact-head CI. The failure path retained its worktree until the verified VM stop, rather than performing normal worktree removal. [Current-base validation command evidence](https://github.com/openclaw/openclaw/actions/runs/34666866883).

## Before and After

These synthetic viewer captures are from the historical c388 comparison above. The before/after image bytes are identical; they do not claim new-head browser timing or appearance proof.

![Before: settings navigation](https://github.com/user-attachments/assets/5e516972-a507-48fd-82f1-98898305d0e1)

![After: identical settings navigation](https://github.com/user-attachments/assets/a1632ec0-9454-4630-abf5-bb2c82f37b6b)

**Current-head qualification:** Head `d3bd07851180` preserves this PR's authored patch on main `bca261d5583d`, including the shared `retainedMachine` typecheck repair (#145540). Benchmarks, earlier validation, and prior draft-state notes remain historical under their original source labels; no benchmark was rerun for this rebase. Exact-head CI is required before landing.
