### PR TITLE
fix(update): offer owner-confirmed updates from chat

### DIFF
--- a/docs/channels/pairing.md
+++ b/docs/channels/pairing.md
@@ -71,6 +71,19 @@ Manually allowlisted senders are not automatically command owners. If an
 authorized sender has no owner access, owner-only commands reply with the exact
 `openclaw config set commands.ownerAllowFrom` command for the operator to run.
 
+### Set up an owner without DM pairing
+
+Run `openclaw channels add` and complete the channel setup. When no command owner
+exists, the wizard offers **Set up my operator account** separately from chat
+access. Enter your personal user ID and confirm the exact account that may
+administer this installation. **Skip for now** leaves ownership unchanged.
+
+This also works for Discord servers and other group channels with DMs disabled.
+An owner can use `/update`, restart the Gateway, change configuration, and approve
+commands. Ownership does not grant chat access: existing channel and group access
+rules still apply. The wizard never promotes chat allowlists automatically or
+replaces an existing owner.
+
 <Note>
 WhatsApp's login QR links a WhatsApp account to OpenClaw. DM access requests
 approve people who message that account. These are separate flows.

--- a/docs/install/updating.md
+++ b/docs/install/updating.md
@@ -167,10 +167,21 @@ starting the Gateway.
 
 ### From chat
 
-The OpenClaw owner can say "update" (the agent uses the `gateway` action
-`update.run`) or send `/update`. The candidate validates while the old Gateway
-serves, and an already-current update restarts it only when plugins change. Update runs can send
-these notices in that chat as the Gateway observes the recorded milestones:
+Send `/update` to update OpenClaw from Discord or another connected chat. This
+owner-only command works with the default tool profiles; it does not require
+adding the `gateway` tool to an allowlist.
+
+A direct request such as "update OpenClaw" offers an **Update now** button where
+the channel supports buttons, with `/update` as the text fallback. Offering the
+button does not start an update. Clicking it runs the same command under the
+clicking user's current permissions. A rejected click does not invalidate the
+button; every click is a fresh owner-checked command. For other wording, the agent can guide you
+to `/update`; agents explicitly granted the `gateway` tool can also use
+`update.run` for a user-requested update.
+
+The candidate validates while the old Gateway serves, and an already-current
+update restarts it only when plugins change. Update runs can send these notices
+in that chat as the Gateway observes the recorded milestones:
 
 1. An acknowledgement when the update is accepted.
 2. `⏳ Restarting the gateway now (v<from> → v<to>)…` when activation is recorded before the Gateway stops.
@@ -201,9 +212,16 @@ restart; `--json` exposes the `activeRun` and `lastRun` records. See
 queries.
 
 The sender must be in [`commands.ownerAllowFrom`](/tools/slash-commands#configuration).
-`/update` also requires `commands.restart` (enabled by default).
+Being allowed to chat does not grant owner permissions. If your account is not
+an owner, the reply explains how the Gateway operator can connect it. Channel
+setup and [pairing](/channels/pairing) distinguish owner access from chat access;
+existing allowed users are not automatically promoted.
+`/update` also requires `commands.restart` (enabled by default), and command
+access restrictions still apply. Chat updates use the hosting installation's
+configured update channel and install method.
 Agents must never run `npm install -g openclaw` or stop the Gateway service
-from a chat shell; use the update action so restart and notification stay coordinated.
+from a chat shell; use `/update` or the update action so restart and notification
+stay coordinated.
 
 ## Stale update history
 

--- a/docs/start/wizard.md
+++ b/docs/start/wizard.md
@@ -220,7 +220,11 @@ Local mode (default) walks through these steps:
    token SecretRef path: `--gateway-token-ref-env <ENV_VAR>`.
 4. **Channels** - built-in and official plugin chat channels, including
    Discord, Feishu, Google Chat, iMessage, Mattermost, Microsoft Teams,
-   QQ Bot, Signal, Slack, Telegram, WhatsApp, and more.
+   QQ Bot, Signal, Slack, Telegram, WhatsApp, and more. When no command owner
+   exists, completed channel setup offers a separate operator-account step for
+   `/update` and other administration. Enter your own user ID and confirm it, or
+   skip. This works in servers and groups without DM pairing and does not promote
+   chat allowlists. See [command owner setup](/channels/pairing#set-up-an-owner-without-dm-pairing).
 5. **Web search** - configures an optional search provider.
 6. **Skills** - installs recommended skills and their optional dependencies.
 7. **Daemon** - installs a LaunchAgent (macOS), a systemd user unit

--- a/docs/tools/slash-commands.md
+++ b/docs/tools/slash-commands.md
@@ -339,8 +339,15 @@ user skill directly.
     | `/plugins list\|inspect\|show\|get\|install\|enable\|disable` | `commands.plugins: true` | Inspect or mutate plugin state. Owner-only for writes. Alias: `/plugin` |
     | `/debug show\|set\|unset\|reset` | `commands.debug: true` | Runtime-only config overrides. Owner-only |
     | `/restart` | `commands.restart: true` (default) | Restart OpenClaw |
-    | `/update` | `commands.restart: true` (default), owner | Update OpenClaw and restart; receive a completion or failure notice in the same chat |
+    | `/update` | `commands.restart: true` (default), owner | Update OpenClaw using its configured update channel; works with default tool profiles and sends a completion or failure notice in the same chat |
     | `/send on\|off\|inherit` | owner | Set send policy |
+
+    A direct "update OpenClaw" request offers an **Update now** button where
+    supported, or the `/update` command to send. The button runs `/update` as
+    the clicking user; the update starts only after that owner action. Chat
+    access alone does not grant permission to update. See
+    [Updating from chat](/install/updating#from-chat).
+
   </Accordion>
 
   <Accordion title="Voice, TTS, channel control">

--- a/extensions/discord/src/monitor/monitor.test.ts
+++ b/extensions/discord/src/monitor/monitor.test.ts
@@ -1,5 +1,6 @@
 // Discord tests cover monitor plugin behavior.
 import { ChannelType } from "discord-api-types/v10";
+import { resolveCommandAuthorization } from "openclaw/plugin-sdk/command-auth-native";
 import type { DiscordAccountConfig, OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import {
   buildPluginBindingApprovalCustomId,
@@ -12,15 +13,16 @@ import { registerPluginInteractiveHandler } from "openclaw/plugin-sdk/plugin-run
 import { getActivePluginRegistry } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { clearDiscordComponentEntriesForTest } from "../components-registry.test-support.js";
-import type { DiscordComponentEntry, DiscordModalEntry } from "../components.js";
 import type { DiscordInteractiveHandlerContext } from "../interactive-dispatch.js";
-import type {
-  ButtonInteraction,
-  ComponentData,
-  ModalInteraction,
-  StringSelectMenuInteraction,
-} from "../internal/discord.js";
+import type { ButtonInteraction, ComponentData, ModalInteraction } from "../internal/discord.js";
 import { createDiscordSendReceipt } from "../send.receipt.js";
+import {
+  createButtonEntry,
+  createComponentButtonInteraction,
+  createComponentSelectInteraction,
+  createModalEntry,
+  createModalInteraction,
+} from "../test-support/component-interactions.test-support.js";
 import {
   dispatchPluginInteractiveHandlerMock,
   dispatchReplyMock,
@@ -50,6 +52,8 @@ let registerDiscordComponentEntries: typeof import("../components-registry.js").
 let resolveDiscordComponentEntryWithPersistence: typeof import("../components-registry.js").resolveDiscordComponentEntryWithPersistence;
 let resolveDiscordModalEntryWithPersistence: typeof import("../components-registry.js").resolveDiscordModalEntryWithPersistence;
 let sendComponents: typeof import("../send.components.js");
+let buildDiscordComponentMessage: typeof import("../components.js").buildDiscordComponentMessage;
+let buildDiscordPresentationComponents: typeof import("../shared-interactive.js").buildDiscordPresentationComponents;
 
 let lastDispatchCtx: Record<string, unknown> | undefined;
 
@@ -142,123 +146,24 @@ describe("discord component interactions", () => {
       ...overrides,
     }) as ComponentContext;
 
-  const createComponentInteractionBase = () => {
-    const reply = vi.fn().mockResolvedValue(undefined);
-    const defer = vi.fn().mockResolvedValue(undefined);
-    const rest = {
-      get: vi.fn().mockResolvedValue({ type: ChannelType.DM }),
-      post: vi.fn().mockResolvedValue({}),
-      patch: vi.fn().mockResolvedValue({}),
-      delete: vi.fn().mockResolvedValue(undefined),
-    };
-    return {
-      reply,
-      defer,
-      client: { rest },
-      user: { id: "123456789", username: "AgentUser", discriminator: "0001" },
-      message: { id: "msg-1" },
-    };
-  };
-
-  const createComponentButtonInteraction = (overrides: Partial<ButtonInteraction> = {}) => {
-    const base = createComponentInteractionBase();
-    const interaction = {
-      rawData: { channel_id: "dm-channel", id: "interaction-1" },
-      customId: "occomp:cid=btn_1",
-      ...base,
-      ...overrides,
-    } as unknown as ButtonInteraction;
-    return { interaction, defer: base.defer, reply: base.reply };
-  };
-
-  const createComponentSelectInteraction = (
-    overrides: Partial<StringSelectMenuInteraction> = {},
-  ) => {
-    const base = createComponentInteractionBase();
-    const interaction = {
-      rawData: { channel_id: "dm-channel", id: "interaction-select-1" },
-      customId: "occomp:cid=sel_1",
-      values: ["alpha"],
-      ...base,
-      ...overrides,
-    } as unknown as StringSelectMenuInteraction;
-    return { interaction, defer: base.defer, reply: base.reply };
-  };
-
-  const createModalInteraction = (overrides: Partial<ModalInteraction> = {}) => {
-    const reply = vi.fn().mockResolvedValue(undefined);
-    const acknowledge = vi.fn().mockResolvedValue(undefined);
-    const rest = {
-      get: vi.fn().mockResolvedValue({ type: ChannelType.DM }),
-      post: vi.fn().mockResolvedValue({}),
-      patch: vi.fn().mockResolvedValue({}),
-      delete: vi.fn().mockResolvedValue(undefined),
-    };
-    const fields = {
-      getText: (key: string) => (key === "fld_1" ? "Casey" : undefined),
-      getStringSelect: (_key: string) => undefined,
-      getRoleSelect: (_key: string) => [],
-      getUserSelect: (_key: string) => [],
-    };
-    const interaction = {
-      rawData: { channel_id: "dm-channel", id: "interaction-2" },
-      user: { id: "123456789", username: "AgentUser", discriminator: "0001" },
-      customId: "ocmodal:mid=mdl_1",
-      fields,
-      acknowledge,
-      reply,
-      client: { rest },
-      ...overrides,
-    } as unknown as ModalInteraction;
-    return { interaction, acknowledge, reply };
-  };
-
-  const createButtonEntry = (
-    overrides: Partial<DiscordComponentEntry> = {},
-  ): DiscordComponentEntry => ({
-    id: "btn_1",
-    kind: "button",
-    label: "Approve",
-    messageId: "msg-1",
-    sessionKey: "session-1",
-    agentId: "agent-1",
-    accountId: "default",
-    ...overrides,
-  });
-
-  const createModalEntry = (overrides: Partial<DiscordModalEntry> = {}): DiscordModalEntry => ({
-    id: "mdl_1",
-    title: "Details",
-    messageId: "msg-2",
-    sessionKey: "session-2",
-    agentId: "agent-2",
-    accountId: "default",
-    fields: [
-      {
-        id: "fld_1",
-        name: "name",
-        label: "Name",
-        type: "text",
-      },
-    ],
-    ...overrides,
-  });
-
   const createGuildComponentContext = (allowFrom: string[]) =>
     createComponentContext({ cfg: createCfg(), allowFrom });
   const createGuildPluginButton = (allowFrom: string[]) =>
     createDiscordComponentButton(createGuildComponentContext(allowFrom));
 
-  const createGuildPluginButtonInteraction = (interactionId: string) =>
-    createComponentButtonInteraction({
-      rawData: {
-        channel_id: "guild-channel",
-        guild_id: "guild-1",
-        id: interactionId,
-        member: { roles: [] },
-      } as unknown as ButtonInteraction["rawData"],
-      guild: { id: "guild-1", name: "Test Guild" } as unknown as ButtonInteraction["guild"],
-    });
+  const createGuildPluginButtonInteraction = (interactionId: string, senderId?: string) =>
+    createComponentButtonInteraction(
+      {
+        rawData: {
+          channel_id: "guild-channel",
+          guild_id: "guild-1",
+          id: interactionId,
+          member: { roles: [] },
+        } as unknown as ButtonInteraction["rawData"],
+        guild: { id: "guild-1", name: "Test Guild" } as unknown as ButtonInteraction["guild"],
+      },
+      senderId,
+    );
 
   async function expectPluginGuildInteractionAuth(isAuthorizedSender: boolean) {
     const pluginId = "qa-discord-interactive-binding";
@@ -367,6 +272,8 @@ describe("discord component interactions", () => {
       resolveDiscordModalEntryWithPersistence,
     } = await import("../components-registry.js"));
     sendComponents = await import("../send.components.js");
+    ({ buildDiscordComponentMessage } = await import("../components.js"));
+    ({ buildDiscordPresentationComponents } = await import("../shared-interactive.js"));
   });
 
   beforeEach(() => {
@@ -457,13 +364,17 @@ describe("discord component interactions", () => {
   });
 
   it.each([
-    [undefined, "text", "text-slash", "/login choice token 0"],
-    ["command", "native", "native", "/login choice token 0"],
-    ["callback", "text", "text-slash", 'Clicked "Approve".'],
+    [undefined, "text", "text-slash", "/update"],
+    ["command", "native", "native", "/update"],
+    ["callback", "text", "text-slash", 'Clicked "Update now".'],
   ] as const)(
     "routes %s callbacks with text commands disabled",
     async (callbackDataKind, source, kind, body) => {
-      const entry = createButtonEntry({ callbackData: "/login choice token 0", callbackDataKind });
+      const entry = createButtonEntry({
+        label: "Update now",
+        callbackData: "/update",
+        callbackDataKind,
+      });
       registerDiscordComponentEntries({ entries: [entry], modals: [] });
       const ctx = createComponentContext();
       ctx.cfg.commands = { text: false };
@@ -475,12 +386,91 @@ describe("discord component interactions", () => {
       expect(reply).toHaveBeenCalledWith({ content: "✓", ephemeral: true });
       expect(lastDispatchCtx).toMatchObject({
         BodyForAgent: body,
+        SenderId: "123456789",
         CommandSource: source,
         CommandTurn: { kind, source, body },
       });
       expect(dispatchReplyMock).toHaveBeenCalledTimes(1);
     },
   );
+
+  it.each([
+    { name: "owner", senderId: "123456789", revoke: false },
+    { name: "chat member", senderId: "987654321", revoke: false },
+    { name: "revoked owner", senderId: "123456789", revoke: true },
+  ])("keeps Update now usable after the $name clicks", async (testCase) => {
+    const users = ["123456789", "987654321"];
+    const guildEntries = { "guild-1": { users } };
+    const discordConfig = createDiscordConfig({ groupPolicy: "allowlist", guilds: guildEntries });
+    const ctx = createComponentContext({
+      cfg: { channels: { discord: discordConfig } },
+      discordConfig,
+      guildEntries,
+      allowFrom: users,
+    });
+    ctx.cfg.commands = {
+      text: false,
+      ownerAllowFrom: ["discord:123456789"],
+      allowFrom: { discord: ["*"] },
+    };
+    const spec = buildDiscordPresentationComponents({
+      blocks: [
+        {
+          type: "buttons",
+          buttons: [
+            {
+              label: "Update now",
+              reusable: true,
+              action: { type: "command", command: "/update" },
+            },
+          ],
+        },
+      ],
+    });
+    if (!spec) {
+      throw new Error("Expected an update button presentation");
+    }
+    const rendered = buildDiscordComponentMessage({ spec });
+    const entry = rendered.entries[0];
+    if (!entry) {
+      throw new Error("Expected an update button registration");
+    }
+    registerDiscordComponentEntries({ entries: rendered.entries, modals: rendered.modals });
+    const currentOwner = testCase.revoke ? "987654321" : "123456789";
+    ctx.cfg.commands.ownerAllowFrom = [`discord:${currentOwner}`];
+    const button = createDiscordComponentButton(ctx);
+    for (const [index, senderId] of [testCase.senderId, currentOwner].entries()) {
+      dispatchReplyMock.mockClear();
+      const { interaction } = createGuildPluginButtonInteraction(`update-click-${index}`, senderId);
+      await button.run(interaction, { cid: entry.id } as ComponentData);
+      expect(dispatchReplyMock).toHaveBeenCalledOnce();
+      const dispatched = dispatchReplyMock.mock.calls[0]?.[0];
+      if (!dispatched) {
+        throw new Error("Expected the update click to reach command dispatch");
+      }
+      expect(dispatched.ctx).toMatchObject({
+        SenderId: senderId,
+        ChatType: "channel",
+        CommandAuthorized: true,
+        CommandSource: "native",
+        CommandTurn: { kind: "native", source: "native", body: "/update" },
+      });
+      expect(
+        resolveCommandAuthorization({
+          ctx: dispatched.ctx,
+          cfg: ctx.cfg,
+          commandAuthorized: dispatched.ctx.CommandAuthorized === true,
+        }),
+      ).toMatchObject({
+        senderId,
+        isAuthorizedSender: true,
+        senderIsOwner: senderId === currentOwner,
+      });
+      await expect(
+        resolveDiscordComponentEntryWithPersistence({ id: entry.id, consume: false }),
+      ).resolves.not.toBeNull();
+    }
+  });
 
   it("preserves selected values for select fallback when no plugin handler matches", async () => {
     registerDiscordComponentEntries({

--- a/extensions/discord/src/test-support/component-interactions.test-support.ts
+++ b/extensions/discord/src/test-support/component-interactions.test-support.ts
@@ -1,0 +1,115 @@
+import { ChannelType } from "discord-api-types/v10";
+import { vi } from "vitest";
+import type { DiscordComponentEntry, DiscordModalEntry } from "../components.js";
+import type {
+  ButtonInteraction,
+  ModalInteraction,
+  StringSelectMenuInteraction,
+} from "../internal/discord.js";
+
+const createComponentInteractionBase = (senderId = "123456789") => {
+  const reply = vi.fn().mockResolvedValue(undefined);
+  const defer = vi.fn().mockResolvedValue(undefined);
+  const rest = {
+    get: vi.fn().mockResolvedValue({ type: ChannelType.DM }),
+    post: vi.fn().mockResolvedValue({}),
+    patch: vi.fn().mockResolvedValue({}),
+    delete: vi.fn().mockResolvedValue(undefined),
+  };
+  return {
+    reply,
+    defer,
+    client: { rest },
+    user: { id: senderId, username: "AgentUser", discriminator: "0001" },
+    message: { id: "msg-1" },
+  };
+};
+
+export const createComponentButtonInteraction = (
+  overrides: Partial<ButtonInteraction> = {},
+  senderId?: string,
+) => {
+  const base = createComponentInteractionBase(senderId);
+  const interaction = {
+    rawData: { channel_id: "dm-channel", id: "interaction-1" },
+    customId: "occomp:cid=btn_1",
+    ...base,
+    ...overrides,
+  } as unknown as ButtonInteraction;
+  return { interaction, defer: base.defer, reply: base.reply };
+};
+
+export const createComponentSelectInteraction = (
+  overrides: Partial<StringSelectMenuInteraction> = {},
+) => {
+  const base = createComponentInteractionBase();
+  const interaction = {
+    rawData: { channel_id: "dm-channel", id: "interaction-select-1" },
+    customId: "occomp:cid=sel_1",
+    values: ["alpha"],
+    ...base,
+    ...overrides,
+  } as unknown as StringSelectMenuInteraction;
+  return { interaction, defer: base.defer, reply: base.reply };
+};
+
+export const createModalInteraction = (overrides: Partial<ModalInteraction> = {}) => {
+  const reply = vi.fn().mockResolvedValue(undefined);
+  const acknowledge = vi.fn().mockResolvedValue(undefined);
+  const rest = {
+    get: vi.fn().mockResolvedValue({ type: ChannelType.DM }),
+    post: vi.fn().mockResolvedValue({}),
+    patch: vi.fn().mockResolvedValue({}),
+    delete: vi.fn().mockResolvedValue(undefined),
+  };
+  const fields = {
+    getText: (key: string) => (key === "fld_1" ? "Casey" : undefined),
+    getStringSelect: (_key: string) => undefined,
+    getRoleSelect: (_key: string) => [],
+    getUserSelect: (_key: string) => [],
+  };
+  const interaction = {
+    rawData: { channel_id: "dm-channel", id: "interaction-2" },
+    user: { id: "123456789", username: "AgentUser", discriminator: "0001" },
+    customId: "ocmodal:mid=mdl_1",
+    fields,
+    acknowledge,
+    reply,
+    client: { rest },
+    ...overrides,
+  } as unknown as ModalInteraction;
+  return { interaction, acknowledge, reply };
+};
+
+export const createButtonEntry = (
+  overrides: Partial<DiscordComponentEntry> = {},
+): DiscordComponentEntry => ({
+  id: "btn_1",
+  kind: "button",
+  label: "Approve",
+  messageId: "msg-1",
+  sessionKey: "session-1",
+  agentId: "agent-1",
+  accountId: "default",
+  ...overrides,
+});
+
+export const createModalEntry = (
+  overrides: Partial<DiscordModalEntry> = {},
+): DiscordModalEntry => ({
+  id: "mdl_1",
+  title: "Details",
+  messageId: "msg-2",
+  sessionKey: "session-2",
+  agentId: "agent-2",
+  accountId: "default",
+  fields: [
+    {
+      id: "fld_1",
+      name: "name",
+      label: "Name",
+      type: "text",
+    },
+  ],
+  ...overrides,
+});

--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -1324,11 +1324,9 @@ describe("buildAgentSystemPrompt", () => {
         "Gateway restart, config, channels, plugins, agents, models/providers: ask `openclaw`.",
       );
       expect(prompt).toContain(
-        "Never run npm install -g openclaw or stop the gateway service via exec.",
+        "Never run openclaw update, npm install -g openclaw, or stop/restart the gateway service via exec.",
       );
-      expect(prompt).toContain(
-        "Updates need the OpenClaw owner: tell the user to run `openclaw update` in a terminal or use the Control UI.",
-      );
+      expect(prompt).toContain("For a chat update request, direct the user to `/update`.");
       expect(prompt).not.toContain("System controls unavailable");
       expect(prompt).toContain(
         "Default to subagents for internal work; use `visible:true` only for a separate session the user requests or needs to revisit and steer independently.",
@@ -1336,16 +1334,44 @@ describe("buildAgentSystemPrompt", () => {
     },
   );
 
-  it.each([{ toolNames: ["exec"] }, { toolNames: [] }])(
-    "keeps updates out of exec without gateway ($toolNames)",
+  it.each([{ toolNames: ["exec"] }, { toolNames: ["message"] }, { toolNames: [] }])(
+    "keeps chat updates discoverable without gateway ($toolNames)",
     ({ toolNames }) => {
       const prompt = buildAgentSystemPrompt({ workspaceDir: "/tmp/openclaw", toolNames });
       expect(prompt).toContain(
-        "System controls unavailable. Updates and restarts need the OpenClaw owner: tell the user to run `openclaw update` in a terminal or use the Control UI. Never run npm install -g openclaw or stop the gateway service via exec.",
+        "In a connected chat, the owner can send `/update` with commands.restart enabled (the default), regardless of the agent's tool profile.",
       );
+      expect(prompt).toContain("For a chat update request, direct the user to `/update`.");
+      expect(prompt).toContain("Outside chat, use the Control UI or ask the operator");
+      expect(prompt).toContain("Missing chat ownership needs owner setup");
+      expect(prompt).toContain(
+        "Never run openclaw update, npm install -g openclaw, or stop/restart the gateway service via exec.",
+      );
+      expect(prompt).not.toContain("System controls unavailable");
       expect(prompt).not.toContain("update.run");
     },
   );
+
+  it.each([true, false])("offers an update button only with message presentation (%s)", (rich) => {
+    const plain = buildAgentSystemPrompt({ workspaceDir: "/tmp/openclaw", toolNames: ["message"] });
+    const prompt = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+      toolNames: ["message"],
+      messageTool: {
+        name: "message",
+        parameters: { type: "object", properties: rich ? { presentation: {} } : {} },
+      },
+    });
+    expect(prompt.split(SYSTEM_PROMPT_CACHE_BOUNDARY)[0]).toBe(
+      plain.split(SYSTEM_PROMPT_CACHE_BOUNDARY)[0],
+    );
+    expect(prompt.includes('Offer an "Update now" button')).toBe(rich);
+    if (rich) {
+      expect(prompt).toContain('action {type:"command",command:"/update"}');
+      expect(prompt).toContain("reusable:true");
+      expect(prompt).toContain("clicking user's current owner permissions");
+    }
+  });
 
   it("keeps update and delegated controls distinct when both tools are present", () => {
     const prompt = buildAgentSystemPrompt({

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -1313,10 +1313,11 @@ export function buildAgentSystemPrompt(params: {
           : "",
       [
         "For the Gateway hosting this session:",
+        "In a connected chat, the owner can send `/update` with commands.restart enabled (the default), regardless of the agent's tool profile.",
         hasGateway
           ? "Update OpenClaw: `gateway` action update.run, only on explicit user request; restart and completion notice are automatic."
-          : `${hasOpenClaw ? "Updates" : "System controls unavailable. Updates and restarts"} need the OpenClaw owner: tell the user to run \`openclaw update\` in a terminal or use the Control UI.`,
-        `Never run ${hasGateway ? "openclaw update, npm install -g openclaw, or stop/restart" : "npm install -g openclaw or stop"} the gateway service via exec.`,
+          : "For a chat update request, direct the user to `/update`. Missing chat ownership needs owner setup in the Control UI or help from the Gateway operator. Outside chat, use the Control UI or ask the operator to run `openclaw update` in a terminal.",
+        "Never run openclaw update, npm install -g openclaw, or stop/restart the gateway service via exec.",
       ].join(" "),
       ...(hasExec
         ? [

--- a/src/agents/ui-presentation-prompt.ts
+++ b/src/agents/ui-presentation-prompt.ts
@@ -17,11 +17,26 @@ export function buildUiPresentationPrompt(params: {
     messageProperties && Object.hasOwn(messageProperties, "clawhub")
       ? params.messageTool?.name
       : undefined;
-  if (!showWidgetToolName && !dashboardToolName && !portalToolName && !clawHubMessageToolName) {
+  const interactiveMessageToolName =
+    messageProperties && Object.hasOwn(messageProperties, "presentation")
+      ? params.messageTool?.name
+      : undefined;
+  if (
+    !showWidgetToolName &&
+    !dashboardToolName &&
+    !portalToolName &&
+    !clawHubMessageToolName &&
+    !interactiveMessageToolName
+  ) {
     return "";
   }
   return [
     "## UI Presentation",
+    ...(interactiveMessageToolName
+      ? [
+          `Offer an "Update now" button with reusable:true when directing the user to /update in the current chat, using \`${interactiveMessageToolName}\` presentation action {type:"command",command:"/update"}; keep \`/update\` as the text fallback. Each click uses the clicking user's current owner permissions.`,
+        ]
+      : []),
     ...(clawHubMessageToolName
       ? [
           `\`${clawHubMessageToolName}\`: When the user asks to install an integration or whether you can perform an action, check ClawHub first with \`${clawHubMessageToolName}(action="send", clawhub={query:"capability"})\`, omitting channel and target. This presents official plugin or skill cards, including when it is already installed. Report availability and installation state from the result. An installed desktop app does not establish that its OpenClaw plugin is installed. Treat an unqualified service install request as an OpenClaw capability request unless the user explicitly asks for a desktop app.`,

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -101,6 +101,7 @@ import { mergeSkillFilters } from "./skill-filter.js";
 import { stageRemoteInboundMediaIfNeeded } from "./stage-remote-inbound-media.js";
 import { isStaleHeartbeatAutoFallbackOverride } from "./stored-model-override.js";
 import { createTypingController } from "./typing.js";
+import { resolveUpdateRequestReply } from "./update-request.js";
 
 type ResetCommandAction = "new" | "reset";
 
@@ -354,6 +355,12 @@ export async function getReplyFromConfig(
   });
   const agentSessionKey = initialAgentScope.agentSessionKey;
   const agentId = initialAgentScope.agentId;
+  const updateRequestReply = opts?.isHeartbeat
+    ? undefined
+    : resolveUpdateRequestReply({ ctx: finalized, cfg, agentId, sessionKey: agentSessionKey });
+  if (updateRequestReply) {
+    return markReplyPayloadForSourceSuppressionDelivery(updateRequestReply);
+  }
   if (
     preparedReplyDispatchRuntime &&
     !publishedModelCatalogOwnerMatchesAgent(preparedReplyDispatchRuntime, agentId)

--- a/src/auto-reply/reply/get-reply.update-request.test.ts
+++ b/src/auto-reply/reply/get-reply.update-request.test.ts
@@ -1,0 +1,172 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { setActivePluginRegistry } from "../../plugins/runtime.js";
+import {
+  createChannelTestPluginBase,
+  createTestRegistry,
+} from "../../test-utils/channel-plugins.js";
+import { getReplyPayloadMetadata } from "../reply-payload.js";
+import type { MsgContext } from "../templating.js";
+import { resolveDefaultModel } from "./directive-handling.defaults.js";
+import { markCompleteReplyConfig } from "./get-reply-fast-path.test-support.js";
+import { getReplyFromConfig } from "./get-reply.js";
+
+vi.mock("./directive-handling.defaults.js", () => ({
+  resolveDefaultModel: vi.fn(() => {
+    throw new Error("No working model is configured");
+  }),
+}));
+
+function updateContext(overrides: Partial<MsgContext> = {}): MsgContext {
+  return {
+    Provider: "discord",
+    Surface: "discord",
+    ChatType: "channel",
+    SessionKey: "agent:main:discord:channel:maintenance",
+    SenderId: "123456789",
+    From: "discord:channel:maintenance",
+    To: "channel:maintenance",
+    Body: "Update OpenClaw",
+    BodyForCommands: "Update OpenClaw",
+    CommandAuthorized: true,
+    ...overrides,
+  };
+}
+
+function updateConfig(overrides: Partial<OpenClawConfig> = {}): OpenClawConfig {
+  return markCompleteReplyConfig({
+    commands: { ownerAllowFrom: ["discord:123456789"] },
+    ...overrides,
+  });
+}
+
+describe("chat update requests before inference", () => {
+  beforeEach(() => {
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "discord",
+          source: "test",
+          plugin: createChannelTestPluginBase({
+            id: "discord",
+            capabilities: { chatTypes: ["direct", "group"], nativeCommands: true },
+          }),
+        },
+      ]),
+    );
+    vi.clearAllMocks();
+  });
+  afterEach(() => setActivePluginRegistry(createTestRegistry([])));
+
+  it.each(["coding", "messaging", "minimal", "full"] as const)(
+    "offers an owner confirmation with the %s profile and no working model",
+    async (profile) => {
+      const reply = await getReplyFromConfig(
+        updateContext(),
+        undefined,
+        updateConfig({ tools: { profile } }),
+      );
+      expect(reply).toMatchObject({
+        text: expect.stringContaining("configured release channel"),
+        presentation: {
+          blocks: [
+            {
+              type: "buttons",
+              buttons: [
+                {
+                  label: "Update now",
+                  reusable: true,
+                  action: { type: "command", command: "/update" },
+                },
+              ],
+            },
+          ],
+        },
+      });
+      expect(reply).toMatchObject({ text: expect.stringContaining("send `/update`") });
+      expect(getReplyPayloadMetadata(reply!)).toMatchObject({
+        deliverDespiteSourceReplySuppression: true,
+      });
+      expect(resolveDefaultModel).not.toHaveBeenCalled();
+    },
+  );
+
+  it("offers a native update button when text slash commands are disabled", async () => {
+    const reply = await getReplyFromConfig(
+      updateContext(),
+      undefined,
+      updateConfig({ commands: { ownerAllowFrom: ["discord:123456789"], text: false } }),
+    );
+    expect(reply).toHaveProperty("presentation");
+    expect(resolveDefaultModel).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    "Please update OpenClaw.",
+    "Can you please update OpenClaw?",
+    "Could you please update OpenClaw?",
+    "Could you update OpenClaw please?",
+    "Would you update OpenClaw, please?",
+    "Update OpenClaw now, please.",
+    "update OpenClaw now!",
+  ])("offers confirmation for a complete request: %s", async (body) => {
+    const reply = await getReplyFromConfig(
+      updateContext({ BodyForCommands: body }),
+      undefined,
+      updateConfig(),
+    );
+    expect(reply).toHaveProperty("presentation");
+    expect(resolveDefaultModel).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { BodyForCommands: "Please explain this:\nUpdate OpenClaw" },
+    { BodyForCommands: "Update OpenClaw docs" },
+    { BodyForCommands: "Don't update OpenClaw" },
+    { BodyForCommands: "Read this attachment", BodyForAgent: "Update OpenClaw" },
+    { BodyForCommands: "Summarize this", ReplyToBody: "Update OpenClaw" },
+    { CommandInterpretationSuppressed: true },
+    { InternalTurnSource: "cron" },
+    { InputProvenance: { kind: "inter_session", sourceTool: "sessions_send" } },
+    { CommandAuthorized: false },
+  ] satisfies Partial<MsgContext>[])(
+    "leaves unrelated or non-user input to ordinary reply handling: %j",
+    async (context) => {
+      await expect(
+        getReplyFromConfig(updateContext(context), undefined, updateConfig()),
+      ).rejects.toThrow("No working model is configured");
+    },
+  );
+
+  it.each([{ ownerAllowFrom: [] }, { ownerAllowFrom: ["discord:987654321"] }])(
+    "explains missing owner identity without treating chat access as ownership (%j)",
+    async ({ ownerAllowFrom }) => {
+      const reply = await getReplyFromConfig(
+        updateContext(),
+        undefined,
+        updateConfig({ commands: { ownerAllowFrom } }),
+      );
+      expect(reply).toMatchObject({ text: expect.stringContaining("not configured as an owner") });
+      expect(reply).toMatchObject({ text: expect.stringContaining("discord:123456789") });
+      expect(reply).not.toHaveProperty("presentation");
+      expect(JSON.stringify(reply)).not.toContain("987654321");
+      expect(JSON.stringify(reply).includes("openclaw channels add")).toBe(
+        ownerAllowFrom.length === 0,
+      );
+    },
+  );
+
+  it.each([{ restart: false }, { allowFrom: { discord: ["987654321"] } }])(
+    "honors explicit command restrictions: %j",
+    async (restriction) => {
+      const reply = await getReplyFromConfig(
+        updateContext(),
+        undefined,
+        updateConfig({ commands: { ownerAllowFrom: ["discord:123456789"], ...restriction } }),
+      );
+      expect(reply).not.toHaveProperty("presentation");
+      expect(reply).toMatchObject({ text: expect.stringMatching(/disabled|not allowed/) });
+      expect(resolveDefaultModel).not.toHaveBeenCalled();
+    },
+  );
+});

--- a/src/auto-reply/reply/update-request.ts
+++ b/src/auto-reply/reply/update-request.ts
@@ -1,0 +1,77 @@
+import {
+  formatCommandOwnerHint,
+  hasConfiguredCommandOwners,
+} from "../../commands/doctor-command-owner.js";
+import { isRestartEnabled } from "../../config/commands.flags.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import type { ReplyPayload } from "../reply-payload.js";
+import type { FinalizedRuntimeMsgContext } from "../templating.js";
+import { buildCommandContext } from "./commands-context.js";
+import { resolveCommandContextText } from "./context-text.js";
+
+/** Offer a command, never execute an update from natural-language or model text. */
+export function resolveUpdateRequestReply(params: {
+  ctx: FinalizedRuntimeMsgContext;
+  cfg: OpenClawConfig;
+  agentId: string;
+  sessionKey?: string;
+}): ReplyPayload | undefined {
+  const { ctx, cfg } = params;
+  const text = resolveCommandContextText(ctx);
+  if (
+    !/\bupdate\s+openclaw\b/i.test(text) ||
+    ctx.InternalTurnSource ||
+    (ctx.InputProvenance && ctx.InputProvenance.kind !== "external_user") ||
+    !ctx.CommandAuthorized
+  ) {
+    return undefined;
+  }
+  const command = buildCommandContext({
+    ctx,
+    cfg,
+    agentId: params.agentId,
+    sessionKey: params.sessionKey,
+    isGroup: ctx.ChatType === "group" || ctx.ChatType === "channel",
+    triggerBodyNormalized: text,
+    commandAuthorized: ctx.CommandAuthorized,
+  });
+  if (
+    !/^(?:please\s+)?(?:(?:can|could|would)\s+you\s+(?:please\s+)?)?update\s+openclaw(?:\s+now)?(?:,?\s+please)?[.!?]*$/i.test(
+      command.commandBodyNormalized.trim(),
+    )
+  ) {
+    return undefined;
+  }
+  if (!command.senderIsOwner) {
+    const setupHint = hasConfiguredCommandOwners(cfg)
+      ? ""
+      : " The operator can use channel setup in the Control UI or run `openclaw channels add` to set up their own account for administration.";
+    return {
+      text: `Your chat account can talk to OpenClaw, but is not configured as an owner. ${formatCommandOwnerHint({ channel: command.channel, id: command.senderId })}${setupHint}`,
+    };
+  }
+  if (!command.isAuthorizedSender) {
+    return { text: "Updates are not allowed for this account by the command access policy." };
+  }
+  if (!isRestartEnabled(cfg)) {
+    return { text: "Updates from chat are disabled (commands.restart=false)." };
+  }
+  return {
+    text: "Update this OpenClaw installation using its configured release channel? It may restart the Gateway. Select Update now or send `/update` to continue.",
+    presentation: {
+      blocks: [
+        {
+          type: "buttons",
+          buttons: [
+            {
+              label: "Update now",
+              style: "primary",
+              reusable: true,
+              action: { type: "command", command: "/update" },
+            },
+          ],
+        },
+      ],
+    },
+  };
+}

--- a/src/commands/doctor-command-owner.test.ts
+++ b/src/commands/doctor-command-owner.test.ts
@@ -47,8 +47,9 @@ describe("command owner health", () => {
     expect(note).toHaveBeenCalledWith(
       [
         "No command owner is configured.",
-        "A command owner is the human operator account allowed to run owner-only commands and approve dangerous actions, including /diagnostics, /export-session, /export-trajectory, /config, and exec approvals.",
-        "CLI pairing approval records the first command owner. Control UI approval has an owner checkbox; otherwise set commands.ownerAllowFrom.",
+        "A command owner is your trusted human operator account, allowed to update OpenClaw with /update, restart the Gateway, change configuration, and approve commands. Chat allowlists do not grant this authority.",
+        "Run openclaw channels add and complete a channel's setup to choose your operator account, including servers and groups without DM pairing.",
+        "CLI pairing approval records the first command owner. Control UI pairing approval has a separate owner checkbox.",
         "Fix: set commands.ownerAllowFrom to your channel user id, for example openclaw config set commands.ownerAllowFrom '[\"telegram:123456789\"]'",
         "Restart the gateway after changing this if it is already running.",
       ].join("\n"),

--- a/src/commands/doctor-command-owner.ts
+++ b/src/commands/doctor-command-owner.ts
@@ -101,8 +101,9 @@ export function noteCommandOwnerHealth(cfg: OpenClawConfig): void {
   note(
     [
       "No command owner is configured.",
-      "A command owner is the human operator account allowed to run owner-only commands and approve dangerous actions, including /diagnostics, /export-session, /export-trajectory, /config, and exec approvals.",
-      "CLI pairing approval records the first command owner. Control UI approval has an owner checkbox; otherwise set commands.ownerAllowFrom.",
+      "A command owner is your trusted human operator account, allowed to update OpenClaw with /update, restart the Gateway, change configuration, and approve commands. Chat allowlists do not grant this authority.",
+      `Run ${formatCliCommand("openclaw channels add")} and complete a channel's setup to choose your operator account, including servers and groups without DM pairing.`,
+      "CLI pairing approval records the first command owner. Control UI pairing approval has a separate owner checkbox.",
       `Fix: set commands.ownerAllowFrom to your channel user id, for example ${formatCliCommand("openclaw config set commands.ownerAllowFrom '[\"telegram:123456789\"]'")}`,
       "Restart the gateway after changing this if it is already running.",
     ].join("\n"),

--- a/src/commands/onboard-channels.e2e.test.ts
+++ b/src/commands/onboard-channels.e2e.test.ts
@@ -618,6 +618,251 @@ describe("setupChannels", () => {
     }));
     vi.mocked(loadChannelSetupPluginRegistrySnapshotForChannel).mockClear();
   });
+
+  it.each([
+    {
+      name: "explicitly confirmed",
+      configureOwner: true,
+      confirmOwner: true,
+      owners: undefined,
+      expected: ["discord:123456789012345678"],
+    },
+    {
+      name: "skipped",
+      configureOwner: false,
+      confirmOwner: false,
+      owners: undefined,
+      expected: undefined,
+    },
+    {
+      name: "declined at confirmation",
+      configureOwner: true,
+      confirmOwner: false,
+      owners: undefined,
+      expected: undefined,
+    },
+    {
+      name: "already configured",
+      configureOwner: true,
+      confirmOwner: true,
+      owners: ["telegram:existing-owner"],
+      expected: ["telegram:existing-owner"],
+    },
+  ])(
+    "keeps Discord guild-only owner setup $name",
+    async ({ configureOwner, confirmOwner, owners, expected }) => {
+      const channels: OpenClawConfig["channels"] = {
+        discord: {
+          enabled: true,
+          dm: { enabled: false },
+          allowFrom: ["987654321098765432"],
+          guilds: { "234567890123456789": { users: ["987654321098765432"] } },
+        },
+      };
+      setActivePluginRegistry(
+        createTestRegistry([
+          {
+            pluginId: "discord",
+            source: "test",
+            plugin: {
+              ...createChannelTestPluginBase({
+                id: "discord",
+                label: "Discord",
+                capabilities: { chatTypes: ["direct", "group"] },
+              }),
+              setupWizard: {
+                channel: "discord",
+                getStatus: async () => ({ channel: "discord", configured: true, statusLines: [] }),
+                configure: async ({ cfg }: { cfg: OpenClawConfig }) => ({
+                  cfg,
+                  accountId: "default",
+                }),
+                configureInteractive: async ({ cfg }: { cfg: OpenClawConfig }) => ({
+                  cfg,
+                  accountId: "default",
+                }),
+              },
+            },
+          },
+        ]),
+      );
+      const prompter = createPrompter({
+        select: vi.fn(async ({ message, options }: Parameters<WizardPrompter["select"]>[0]) => {
+          if (message === "Set up administration from your own chat account?") {
+            const label = configureOwner ? "Set up my operator account" : "Skip for now";
+            const option = options.find((entry) => entry.label === label);
+            if (!option) {
+              throw new Error(`missing owner setup choice: ${label}`);
+            }
+            return option.value;
+          }
+          throw new Error(`unexpected selection: ${message}`);
+        }) as WizardPrompter["select"],
+        text: vi.fn(async () => "123456789012345678"),
+        confirm: vi.fn(async () => confirmOwner),
+      });
+      const next = await runSetupChannels(
+        { channels, commands: { restart: false, ownerAllowFrom: owners } },
+        prompter,
+        {
+          initialSelection: ["discord"],
+          finishAfterInitialSelection: true,
+          skipDmPolicyPrompt: true,
+        },
+      );
+
+      expect(next.commands?.ownerAllowFrom).toEqual(expected);
+      expect(next.commands?.restart).toBe(false);
+      expect(next.channels).toEqual(channels);
+      if (!owners) {
+        const setupPrompt = vi
+          .mocked(prompter.select)
+          .mock.calls.find(
+            ([prompt]) => prompt.message === "Set up administration from your own chat account?",
+          )?.[0];
+        expect(
+          setupPrompt?.options.find((option) => option.value === setupPrompt.initialValue)?.label,
+        ).toBe("Skip for now");
+      }
+      if (owners || !configureOwner) {
+        expect(prompter.text).not.toHaveBeenCalled();
+        expect(prompter.confirm).not.toHaveBeenCalled();
+      } else {
+        expect(prompter.text).toHaveBeenCalledWith(
+          expect.objectContaining({
+            message: "Your personal Discord user ID (not a bot, server, or channel ID)",
+          }),
+        );
+        expect(vi.mocked(prompter.text).mock.calls[0]?.[0].initialValue).toBeUndefined();
+        expect(prompter.confirm).toHaveBeenCalledWith({
+          message:
+            "This is my account: allow discord:123456789012345678 to administer this installation?",
+          initialValue: false,
+        });
+      }
+    },
+  );
+
+  it.each([
+    "configured",
+    "skipped",
+    "incomplete",
+    "removed",
+    "disabled",
+    "account-disabled",
+    "unverifiable",
+  ] as const)("offers owner setup only for final configured channels: %s", async (outcome) => {
+    let setupReturned = false;
+    const setupWizard: ChannelSetupWizardAdapter = {
+      channel: "discord",
+      getStatus: async ({ cfg }) => {
+        if (setupReturned && outcome === "unverifiable") {
+          throw new Error("controlled status failure");
+        }
+        return {
+          channel: "discord",
+          configured: Boolean(cfg.channels?.discord?.token),
+          statusLines: [],
+        };
+      },
+      configure: async ({ cfg }) => {
+        setupReturned = true;
+        return {
+          cfg: {
+            ...cfg,
+            channels: {
+              ...cfg.channels,
+              discord: {
+                ...cfg.channels?.discord,
+                ...(outcome === "incomplete" ? {} : { token: "synthetic-token" }),
+                ...(outcome === "account-disabled"
+                  ? { accounts: { secondary: { enabled: false } } }
+                  : {}),
+              },
+            },
+          },
+          accountId: outcome === "account-disabled" ? "secondary" : "default",
+        };
+      },
+      ...(outcome === "skipped" ? { configureInteractive: async () => "skip" as const } : {}),
+    };
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "discord",
+          source: "test",
+          plugin: {
+            ...createChannelTestPluginBase({
+              id: "discord",
+              label: "Discord",
+              config: {
+                resolveAccount: (cfg, accountId) =>
+                  cfg.channels?.discord?.accounts?.[accountId ?? "default"] ??
+                  cfg.channels?.discord ??
+                  {},
+                deleteAccount: ({ cfg }) => {
+                  const channels = { ...cfg.channels };
+                  delete channels.discord;
+                  return { ...cfg, channels };
+                },
+                setAccountEnabled: ({ cfg, enabled }) => ({
+                  ...cfg,
+                  channels: {
+                    ...cfg.channels,
+                    discord: { ...cfg.channels?.discord, enabled },
+                  },
+                }),
+              },
+            }),
+            setupWizard,
+          },
+        },
+      ]),
+    );
+    const choices = [
+      "discord",
+      ...(outcome === "removed" || outcome === "disabled" ? ["discord"] : []),
+      "__done__",
+    ];
+    const prompter = createPrompter({
+      select: vi.fn(async ({ message, options }: Parameters<WizardPrompter["select"]>[0]) => {
+        if (message === "Select a channel") {
+          return choices.shift();
+        }
+        if (message === "Discord already configured. What do you want to do?") {
+          return outcome === "removed" ? "delete" : "disable";
+        }
+        if (message === "Set up administration from your own chat account?") {
+          return options.find((option) => option.label === "Set up my operator account")?.value;
+        }
+        throw new Error(`unexpected selection: ${message}`);
+      }) as WizardPrompter["select"],
+      text: vi.fn(async () => "123456789012345678"),
+      confirm: vi.fn(async () => true),
+    });
+    const next = await runSetupChannels(
+      { channels: { discord: { enabled: true, allowFrom: ["987654321098765432"] } } },
+      prompter,
+      { allowDisable: true, skipDmPolicyPrompt: true },
+    );
+
+    expect(next.commands?.ownerAllowFrom).toEqual(
+      outcome === "configured" ? ["discord:123456789012345678"] : undefined,
+    );
+    expect(next.channels?.discord?.token).toBe(
+      ["skipped", "incomplete", "removed"].includes(outcome) ? undefined : "synthetic-token",
+    );
+    if (outcome !== "configured") {
+      expect(prompter.text).not.toHaveBeenCalled();
+    }
+    if (outcome === "unverifiable") {
+      expect(prompter.note).toHaveBeenCalledWith(
+        expect.stringContaining("controlled status failure"),
+        "Channel status",
+      );
+    }
+  });
+
   it("continues Telegram setup when the plugin registry is empty", async () => {
     // Simulate missing registry entries (the scenario reported in #25545).
     setActivePluginRegistry(createEmptyPluginRegistry());

--- a/src/flows/channel-setup.prompts.ts
+++ b/src/flows/channel-setup.prompts.ts
@@ -8,6 +8,10 @@ import type {
   ChannelSetupWizardAdapter,
 } from "../channels/plugins/setup-wizard-types.js";
 import { formatCliCommand } from "../cli/command-format.js";
+import {
+  formatCommandOwnerFromChannelSender,
+  hasConfiguredCommandOwners,
+} from "../commands/doctor-command-owner.js";
 import type { ChannelChoice } from "../commands/onboard-types.js";
 import type { DmPolicy } from "../config/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
@@ -21,6 +25,64 @@ type ConfiguredChannelAction = "update" | "disable" | "delete" | "skip";
 /** Formats account ids for channel setup prompts. */
 export function formatAccountLabel(accountId: string): string {
   return accountId === DEFAULT_ACCOUNT_ID ? "default (primary)" : accountId;
+}
+
+/** Separates the operator's administrative identity from channel chat access. */
+export async function maybeConfigureCommandOwner(params: {
+  cfg: OpenClawConfig;
+  channels: Array<{ id: ChannelChoice; label: string }>;
+  prompter: WizardPrompter;
+}): Promise<OpenClawConfig> {
+  const { cfg, channels, prompter } = params;
+  if (hasConfiguredCommandOwners(cfg) || channels.length === 0) {
+    return cfg;
+  }
+  await prompter.note(
+    t("wizard.channels.commandOwnerHelp"),
+    t("wizard.channels.commandOwnerTitle"),
+  );
+  const configure = await prompter.select<"setup" | "skip">({
+    message: t("wizard.channels.commandOwnerSetup"),
+    options: [
+      { value: "setup", label: t("wizard.channels.commandOwnerOwnAccount") },
+      { value: "skip", label: t("common.skipForNow") },
+    ],
+    initialValue: "skip",
+  });
+  if (configure !== "setup") {
+    return cfg;
+  }
+  const channelId =
+    channels.length === 1
+      ? channels[0]!.id
+      : await prompter.select({
+          message: t("wizard.channels.commandOwnerChannel"),
+          options: channels
+            .toSorted((a, b) => a.label.localeCompare(b.label))
+            .map(({ id, label }) => ({ value: id, label })),
+        });
+  const channel = channels.find(({ id }) => id === channelId)!;
+  const id = (
+    await prompter.text({
+      message: t("wizard.channels.commandOwnerUserId", { label: channel.label }),
+      validate: (value) =>
+        !value.trim() || /[\s*]/.test(value.trim())
+          ? t("wizard.channels.commandOwnerInvalidId")
+          : undefined,
+    })
+  ).trim();
+  const owner = formatCommandOwnerFromChannelSender({ channel: channel.id, id });
+  if (!owner) {
+    return cfg;
+  }
+  const confirmed = await prompter.confirm({
+    message: t("wizard.channels.commandOwnerConfirm", { owner }),
+    initialValue: false,
+  });
+  if (!confirmed) {
+    return cfg;
+  }
+  return { ...cfg, commands: { ...cfg.commands, ownerAllowFrom: [owner] } };
 }
 
 /** Asks what to do with an already-configured channel account. */

--- a/src/flows/channel-setup.test.ts
+++ b/src/flows/channel-setup.test.ts
@@ -199,7 +199,8 @@ vi.mock("../config/channel-configured.js", () => ({
 }));
 
 vi.mock("./channel-setup.prompts.js", () => ({
-  maybeConfigureDmPolicies: vi.fn(),
+  maybeConfigureCommandOwner: vi.fn(async ({ cfg }: { cfg: OpenClawConfig }) => cfg),
+  maybeConfigureDmPolicies: vi.fn(async ({ cfg }: { cfg: OpenClawConfig }) => cfg),
   promptConfiguredAction: vi.fn(),
   promptRemovalAccountId: vi.fn(),
   formatAccountLabel: vi.fn(),
@@ -919,7 +920,7 @@ describe("setupChannels workspace shadow exclusion", () => {
         configured: false,
         statusLines: [],
       })
-      .mockRejectedValueOnce(new Error("controlled status failure"));
+      .mockRejectedValue(new Error("controlled status failure"));
     const externalChatPlugin = makeExternalChatSetupPlugin({
       getStatus,
       configure: vi.fn(async ({ cfg }) => ({
@@ -943,7 +944,6 @@ describe("setupChannels workspace shadow exclusion", () => {
     expect(result).toMatchObject({
       channels: { "external-chat": { token: "configured" } },
     });
-    expect(getStatus).toHaveBeenCalledTimes(2);
     expect(note).toHaveBeenCalledWith(
       "Status unavailable (controlled status failure).\n" +
         "Retry: openclaw channels status --channel external-chat",

--- a/src/flows/channel-setup.ts
+++ b/src/flows/channel-setup.ts
@@ -24,6 +24,7 @@ import {
   getTrustedChannelPluginCatalogEntry,
   listTrustedChannelPluginCatalogEntries,
 } from "../commands/channel-setup/trusted-catalog.js";
+import { hasConfiguredCommandOwners } from "../commands/doctor-command-owner.js";
 import type { ChannelChoice } from "../commands/onboard-types.js";
 import { isChannelConfigured } from "../config/channel-configured.js";
 import { createConfigIO } from "../config/io.factory.js";
@@ -45,6 +46,7 @@ import {
 } from "./channel-setup-navigation.js";
 import {
   formatAccountLabel,
+  maybeConfigureCommandOwner,
   maybeConfigureDmPolicies,
   promptConfiguredAction,
   promptRemovalAccountId,
@@ -350,17 +352,18 @@ export async function setupChannels(
     return undefined;
   };
 
-  const resolveDisabledHint = (channel: ChannelChoice): string | undefined => {
-    const configDisabledHint = resolveConfigDisabledHint(channel);
-    if (configDisabledHint || deferStatusUntilSelection) {
-      return configDisabledHint;
-    }
+  const resolveAccountDisabledHint = (
+    channel: ChannelChoice,
+    accountId?: string,
+  ): string | undefined => {
     const plugin = getVisibleChannelPlugin(channel);
     if (!plugin) {
       return undefined;
     }
-    const accountId = resolveChannelDefaultAccountId({ plugin, cfg: next });
-    const account = plugin.config.resolveAccount(next, accountId);
+    const account = plugin.config.resolveAccount(
+      next,
+      accountId ?? resolveChannelDefaultAccountId({ plugin, cfg: next }),
+    );
     let enabled: boolean | undefined;
     if (plugin.config.isEnabled) {
       enabled = plugin.config.isEnabled(account, next);
@@ -368,6 +371,12 @@ export async function setupChannels(
       enabled = (account as { enabled?: boolean }).enabled;
     }
     return enabled === false ? "disabled" : undefined;
+  };
+  const resolveDisabledHint = (channel: ChannelChoice): string | undefined => {
+    const configDisabledHint = resolveConfigDisabledHint(channel);
+    return configDisabledHint || deferStatusUntilSelection
+      ? configDisabledHint
+      : resolveAccountDisabledHint(channel);
   };
 
   const getChannelEntries = () => {
@@ -419,10 +428,11 @@ export async function setupChannels(
   const refreshStatus = async (channel: ChannelChoice) => {
     const adapter = getVisibleSetupFlowAdapter(channel);
     if (!adapter) {
-      return;
+      return undefined;
     }
     const status = await adapter.getStatus({ cfg: next, options, accountOverrides });
     statusByChannel.set(channel, status);
+    return status;
   };
 
   const enableBundledPluginForSetup = async (channel: ChannelChoice): Promise<boolean> => {
@@ -1059,6 +1069,30 @@ export async function setupChannels(
     });
   }
 
-  return next;
+  if (hasConfiguredCommandOwners(next)) {
+    return next;
+  }
+  const ownerChannels: Array<{ id: ChannelChoice; label: string }> = [];
+  for (const id of selection) {
+    try {
+      if (
+        resolveConfigDisabledHint(id) ||
+        resolveAccountDisabledHint(id, accountIdsByChannel.get(id))
+      ) {
+        continue;
+      }
+      // A later setup action can remove or disable an earlier selection.
+      const status = await refreshStatus(id);
+      if (status?.configured) {
+        ownerChannels.push({ id, label: getVisibleChannelPlugin(id)?.meta.label ?? id });
+      }
+    } catch (error) {
+      await prompter.note(
+        `Status unavailable (${sanitizeTerminalText(formatErrorMessage(error))}).\nRetry: ${formatCliCommand(`openclaw channels status --channel ${id}`)}`,
+        t("wizard.channels.statusTitle"),
+      );
+    }
+  }
+  return await maybeConfigureCommandOwner({ cfg: next, channels: ownerChannels, prompter });
 }
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/wizard/i18n/locales/en.ts
+++ b/src/wizard/i18n/locales/en.ts
@@ -503,6 +503,15 @@ export const en = {
     },
     channels: {
       account: "{label} account",
+      commandOwnerTitle: "Administration from chat",
+      commandOwnerHelp:
+        "Chat access lets someone talk to your agent. A command owner can also update OpenClaw, restart the Gateway, change configuration, and approve commands. Choose only your own trusted operator account. This works in servers and groups without DM pairing; it does not grant chat access or change channel access rules.",
+      commandOwnerSetup: "Set up administration from your own chat account?",
+      commandOwnerOwnAccount: "Set up my operator account",
+      commandOwnerChannel: "Which channel has your operator account?",
+      commandOwnerUserId: "Your personal {label} user ID (not a bot, server, or channel ID)",
+      commandOwnerInvalidId: "Enter one user ID without spaces or wildcards.",
+      commandOwnerConfirm: "This is my account: allow {owner} to administer this installation?",
       configuredAction: "{label} already configured. What do you want to do?",
       configuredDeleteUnsupported: "{label} does not support deleting config entries.",
       configureDmPolicies: "Configure DM access policies now? (default: pairing)",

--- a/src/wizard/i18n/locales/zh-CN.ts
+++ b/src/wizard/i18n/locales/zh-CN.ts
@@ -486,6 +486,15 @@ export const zh_CN = {
       allReadyTitle: "所有技能已就绪",
     },
     channels: {
+      commandOwnerTitle: "通过聊天管理",
+      commandOwnerHelp:
+        "聊天访问权限允许用户与你的代理交谈。命令所有者还可以更新 OpenClaw、重启 Gateway、更改配置并批准命令。请仅选择你自己信任的管理员账号。服务器和群组无需 DM 配对也可使用此功能；它不会授予聊天访问权限或更改频道访问规则。",
+      commandOwnerSetup: "设置通过你自己的聊天账号进行管理？",
+      commandOwnerOwnAccount: "设置我的管理员账号",
+      commandOwnerChannel: "你的管理员账号位于哪个频道？",
+      commandOwnerUserId: "你的个人 {label} 用户 ID（不是机器人、服务器或频道 ID）",
+      commandOwnerInvalidId: "请输入一个不含空格或通配符的用户 ID。",
+      commandOwnerConfirm: "这是我的账号：允许 {owner} 管理此安装？",
       account: "{label} 账号",
       configuredAction: "{label} 已配置。你想怎么处理？",
       configuredDeleteUnsupported: "{label} 不支持删除配置项。",

--- a/src/wizard/i18n/locales/zh-TW.ts
+++ b/src/wizard/i18n/locales/zh-TW.ts
@@ -486,6 +486,15 @@ export const zh_TW = {
       allReadyTitle: "所有技能已就緒",
     },
     channels: {
+      commandOwnerTitle: "透過聊天管理",
+      commandOwnerHelp:
+        "聊天存取權限允許使用者與你的代理交談。命令擁有者還可以更新 OpenClaw、重新啟動 Gateway、變更設定並核准命令。請僅選擇你自己信任的管理員帳號。伺服器和群組無需 DM 配對也可使用此功能；它不會授予聊天存取權限或變更頻道存取規則。",
+      commandOwnerSetup: "設定透過你自己的聊天帳號進行管理？",
+      commandOwnerOwnAccount: "設定我的管理員帳號",
+      commandOwnerChannel: "你的管理員帳號位於哪個頻道？",
+      commandOwnerUserId: "你的個人 {label} 使用者 ID（不是機器人、伺服器或頻道 ID）",
+      commandOwnerInvalidId: "請輸入一個不含空格或萬用字元的使用者 ID。",
+      commandOwnerConfirm: "這是我的帳號：允許 {owner} 管理此安裝？",
       account: "{label} 帳號",
       configuredAction: "{label} 已設定。你想怎麼處理？",
       configuredDeleteUnsupported: "{label} 不支援刪除設定項。",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where people asking to update OpenClaw from Discord or another chat were sent to a server terminal because their default agent profile did not expose the Gateway tool. Server-only channel setups could also leave the operator without an explicit chat owner identity.

## Why This Change Was Made

A complete request such as “update OpenClaw” now offers an Update now button and a copyable `/update` fallback before model preparation. The reusable suggestion has no update side effect: the button carries a typed command through the existing channel command handler, which checks the clicking user's current ownership and command permissions on every click. A rejected click cannot invalidate the control for an owner. Tool profiles, configuration-read grants, and the updater remain unchanged.

Channel setup separately offers administration for the operator's own account, including Discord servers with DMs disabled. Setup defaults to Skip, starts with a blank user ID, and requires confirmation of the exact account. Only enabled channels verified as configured at the end of setup are offered. Existing owners and channel access rules are preserved; allowlisted users are never automatically promoted. Doctor and agent guidance explain the available update and owner-setup paths.

## User Impact

Owners can request a chat update without editing tool allowlists. The direct confirmation works without inference; generic chat guidance points to `/update`, while qualified or multi-action requests remain normal agent input. Quoted, unrelated, suppressed, and internal inputs stay on their existing paths. Command restrictions and the canonical updater's restart, recovery, and outcome reporting continue to apply.

Compatibility: the owner setting and ID format already shipped in `v2026.9.2`; no migration or backfill is required ([source and preservation proof](https://github.com/openclaw/openclaw/pull/145527#issuecomment-5642910795)).

Update behavior: this change only repairs candidate-side discovery and channel onboarding. It does not change the installed update driver, install targets, configuration schema, or update migrations. Older installations need to install the fixed version through an already available update surface once.

## Evidence

- Regression before fix: all four profile cases reached model preparation instead of an update confirmation.
- Focused suites pass: update request/command handling, current owner revocation, channel setup, wizard locales, prompt cache/schema behavior, Codex prompt consumers, and Discord component dispatch. Coverage includes all four tool profiles, native buttons with text commands disabled, polite request wording, guest/revoked-owner clicks followed by an owner on the same control, and incomplete, removed, disabled, and unverifiable setup candidates.
- The exact published head passes [CI run 34667461299](https://github.com/openclaw/openclaw/actions/runs/34667461299), including build, selected tests, security, and Control UI performance. Local changed-file checks, focused suites, and all seven prompt snapshots also pass.
- AI-assisted implementation with independent Codex review through P2; final review reports no actionable findings. Review prompted fixes for native buttons with text commands disabled, polite request wording, reusable owner controls, and final configured-channel validation.
- Synthetic Control UI proof uses the actual shared owner setup helper, WizardSession, and source renderer against a mock Gateway. Verified five wizard requests, default Skip, blank ID, exact-account confirmation, preserved channel config, and no browser errors.
- Discord boundary proof covers native command serialization, actual clicking identity, non-owner/revoked-owner checks, and opaque callbacks. No live Discord message or production update was performed.

Before: channel setup ended without owner setup.

![Before: channel setup completion](https://github.com/user-attachments/assets/f6f8ab76-2880-4d7a-ba63-6f36e4a08a3c)

After: optional owner setup defaults to Skip.

![After: optional owner setup](https://github.com/user-attachments/assets/8baddb87-1e7c-42ab-94a7-23451528f709)

The exact account requires confirmation.

![After: exact account confirmation](https://github.com/user-attachments/assets/7a176c9e-12b0-43b1-b95b-dda7860c1419)
