### PR TITLE
feat: show Git changes and PR previews in Activity

### DIFF
--- a/docs/web/control-ui/settings.md
+++ b/docs/web/control-ui/settings.md
@@ -371,6 +371,7 @@ The page redacts credential-bearing URL-like values before rendering and quotes 
 Open **Activity** from the sidebar's page picker, or visit `/activity` under the Control UI's base path. It has two tabs plus a deep-link inspector:
 
 - **Sessions** shows recent session activity grouped by day, with search, time, and people filters. Active rows offer **Inspect run** when the Gateway has recorded a run reference.
+- Sessions with a GitHub checkout show associated branch PRs and their added/removed line counts. Hover or keyboard-focus a PR to preview its details, or select it to open GitHub. Before an open PR exists, the branch shows its diff against the default branch, including uncommitted work. These are checkout/PR statistics, not cumulative session edit counts; unavailable counts stay hidden, and retained stale data carries a warning.
 - **Live activity** shows running and queued sessions above the ephemeral browser-local tool stream. The session snapshot comes from the Gateway; the tool stream uses the same `session.tool` and tool events that power Chat tool cards.
 - **Run inspector** is deep-link only and reads the Gateway's durable, immutable `audit.run.inspect` safe-only projection. The RPC contains required `decisionDisplays` and never a raw `decisions` field. Use **Inspect run** on an active session or the run ID link in Live activity, or open `/activity?view=run&run=<percent-encoded-run-id>` directly. Reloading or revisiting the link queries the Gateway again; it never reconstructs identity from Live activity.
 

--- a/ui/src/components/github-link-hovercard.runtime.ts
+++ b/ui/src/components/github-link-hovercard.runtime.ts
@@ -578,6 +578,14 @@ export class GitHubLinkHovercardProvider extends ReactiveElement {
     trigger: "focus" | "pointer",
     delay: number,
   ): void {
+    let owner: Element | null = anchor.parentElement;
+    while (owner && !(owner instanceof GitHubLinkHovercardProvider)) {
+      owner = owner.parentElement;
+    }
+    // Nested providers own their agent scope even when intent bubbles to the app provider.
+    if (owner !== this) {
+      return;
+    }
     this.activate(anchor, target, delay);
     this.activeTrigger = trigger;
     if (trigger === "pointer") {

--- a/ui/src/components/github-link-hovercard.test.ts
+++ b/ui/src/components/github-link-hovercard.test.ts
@@ -578,6 +578,40 @@ describe("openclaw-github-link-hovercard-provider", () => {
     },
   );
 
+  it.each(["pointer", "focus"])(
+    "uses only the nearest provider's agent for nested %s intent",
+    async (trigger) => {
+      const request = vi.fn().mockResolvedValue(issuePreviewResponse());
+      const client = { request } as unknown as GatewayBrowserClient;
+      const outer = createLink(ISSUE_HREF);
+      outer.provider.client = client;
+      outer.provider.agentId = "selected-agent";
+      const inner = createLink(ISSUE_HREF);
+      inner.provider.client = client;
+      inner.provider.agentId = "row-agent";
+      outer.provider.append(inner.provider);
+
+      if (trigger === "pointer") {
+        await hover(inner.anchor);
+      } else {
+        inner.anchor.focus();
+        await vi.advanceTimersByTimeAsync(0);
+      }
+
+      expect(request).toHaveBeenCalledTimes(1);
+      expect(request.mock.calls[0]?.[1]).toMatchObject({ agentId: "row-agent" });
+      expect(document.querySelectorAll(".github-link-hovercard")).toHaveLength(1);
+      expect(titleLinkInCard()?.textContent).toBe("Keep hover previews reachable");
+      inner.anchor.dispatchEvent(new KeyboardEvent("keydown", { bubbles: true, key: "Escape" }));
+      expect(hovercard()).toBeNull();
+
+      await hover(outer.anchor);
+      expect(request).toHaveBeenCalledTimes(2);
+      expect(request.mock.calls[1]?.[1]).toMatchObject({ agentId: "selected-agent" });
+      expect(document.querySelectorAll(".github-link-hovercard")).toHaveLength(1);
+    },
+  );
+
   it("shares the first displayed success across providers while suppressing cached failures", async () => {
     const first = createDeferred<ReturnType<typeof issuePreviewResponse>>();
     const failure = createDeferred<ReturnType<typeof issuePreviewResponse>>();

--- a/ui/src/e2e/activity-session-git.e2e.test.ts
+++ b/ui/src/e2e/activity-session-git.e2e.test.ts
@@ -1,0 +1,270 @@
+import { writeFile } from "node:fs/promises";
+import path from "node:path";
+import { asNullableRecord } from "@openclaw/normalization-core/record-coerce";
+import type { Locator, Page } from "playwright";
+import { expect, it } from "vitest";
+import {
+  CONTROL_UI_SESSION_PULL_REQUESTS_CHANGED_EVENT,
+  type ControlUiGitHubPreview,
+  type ControlUiSessionPullRequestsChanged,
+} from "../../../src/gateway/control-ui-contract.js";
+import { SESSION_PULL_REQUESTS_SUBSCRIBE_METHOD } from "../lib/session-pull-requests.ts";
+import { takeControlUiViewportScreenshot } from "../test-helpers/control-ui-e2e-screenshot.ts";
+import {
+  defaultControlUiFeatureMethods,
+  installMockGateway,
+  waitForControlUiRoute,
+} from "../test-helpers/control-ui-e2e.ts";
+import { chatSessionListResponse } from "./chat-flow.test-support.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+
+const suite = createControlUiE2eSuite({ name: "Activity session Git details" });
+const captureUiProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
+const keys = {
+  frontend: "agent:main:activity-frontend",
+  review: "agent:reviewer:activity-review",
+  branch: "agent:main:activity-branch",
+  notes: "agent:main:activity-notes",
+};
+const repository = { owner: "example", repo: "control-ui" };
+const pullRequest = {
+  ...repository,
+  number: 42,
+  branch: "feature/activity-details",
+  title: "Show Git progress in the activity feed",
+  url: "https://github.com/example/control-ui/pull/42",
+  state: "open" as const,
+  additions: 184,
+  deletions: 27,
+};
+const reviewRequest = {
+  ...repository,
+  repo: "gateway",
+  number: 17,
+  branch: "fix/reconnect-session-state",
+  title: "Keep session state after reconnecting",
+  url: "https://github.com/example/gateway/pull/17",
+  state: "draft" as const,
+};
+const preview: ControlUiGitHubPreview = {
+  ...repository,
+  repo: reviewRequest.repo,
+  kind: "pull",
+  number: reviewRequest.number,
+  title: reviewRequest.title,
+  login: "casey-example",
+  state: "open",
+  draft: true,
+  additions: 63,
+  deletions: 8,
+  changedFiles: 4,
+  createdAt: "2026-09-10T12:00:00Z",
+  updatedAt: "2026-09-11T12:00:00Z",
+};
+
+async function capture(page: Page, filename: string, content: readonly Locator[]) {
+  if (captureUiProof) {
+    await writeFile(
+      path.join(suite.artifactDir, filename),
+      await takeControlUiViewportScreenshot(page, page.locator(".shell"), content),
+    );
+  }
+}
+
+suite.define(() => {
+  it("shows pushed changes and scoped PR previews without taking over session navigation", async () => {
+    await suite.withPage(
+      {
+        colorScheme: "light",
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { width: 1440, height: 1000 },
+      },
+      async ({ context, page }) => {
+        await context.route("https://github.com/**", (route) =>
+          route.fulfill({
+            contentType: "text/html",
+            body: "<!doctype html><title>Synthetic pull request destination</title>",
+          }),
+        );
+        const now = Date.now();
+        const sessions = chatSessionListResponse(
+          [
+            [keys.frontend, "Activity feed improvements", "Alex Morgan", "main"],
+            [keys.review, "Review Gateway reconnection", "Casey Brooks", "reviewer"],
+            [keys.branch, "Polish responsive navigation", "Sam Rivera", "main"],
+            [keys.notes, "Release planning notes", "Alex Morgan", "main"],
+          ].map(([key, label, owner, agentId], index) => ({
+            key,
+            label,
+            agentId,
+            kind: "direct",
+            updatedAt: now - (index + 1) * 60_000,
+            createdActor: { type: "human", id: owner, label: owner },
+          })),
+        );
+        const gateway = await installMockGateway(page, {
+          featureMethods: [
+            ...defaultControlUiFeatureMethods,
+            SESSION_PULL_REQUESTS_SUBSCRIBE_METHOD,
+          ],
+          methodResponses: {
+            "sessions.list": {
+              cases: [
+                { match: { includePeople: true }, response: sessions },
+                { response: chatSessionListResponse([]) },
+              ],
+            },
+            [SESSION_PULL_REQUESTS_SUBSCRIBE_METHOD]: { subscribed: true },
+            "controlUi.githubPreview": {
+              cases: [
+                { match: { owner: "example", repo: "gateway", number: 17 }, response: preview },
+                { response: { ...preview, ...pullRequest } },
+              ],
+            },
+          },
+        });
+        const watchedKeys = async () => {
+          const requests = await gateway.getRequests(SESSION_PULL_REQUESTS_SUBSCRIBE_METHOD);
+          return asNullableRecord(requests.at(-1)?.params)?.sessionKeys;
+        };
+        await page.goto(`${suite.server.baseUrl}activity`);
+        await waitForControlUiRoute(page, { pathname: "/activity", routeId: "activity" });
+        const activity = page.locator("openclaw-activity-page");
+        const row = (key: string) =>
+          activity.locator(".activity-feed__session-row").filter({
+            has: page.locator(`[data-activity-session="${key}"]`),
+          });
+        await expect.poll(() => activity.locator("[data-activity-session]").count()).toBe(4);
+        await expect.poll(watchedKeys).toEqual(expect.arrayContaining(Object.values(keys)));
+
+        const snapshots: ControlUiSessionPullRequestsChanged = {
+          sessions: {
+            [keys.frontend]: {
+              pullRequests: [
+                pullRequest,
+                {
+                  ...pullRequest,
+                  number: 39,
+                  state: "merged",
+                  url: "https://github.com/example/control-ui/pull/39",
+                  additions: 46,
+                  deletions: 12,
+                },
+              ],
+              branch: { ...repository, branch: pullRequest.branch, additions: 205, deletions: 31 },
+              rateLimited: false,
+              status: "ready",
+            },
+            [keys.review]: { pullRequests: [reviewRequest], rateLimited: false, status: "ready" },
+            [keys.branch]: {
+              pullRequests: [],
+              branch: {
+                ...repository,
+                branch: "feature/responsive-navigation-and-keyboard-shortcuts",
+                additions: 1_284,
+                deletions: 96,
+              },
+              rateLimited: true,
+              status: "rate-limited",
+            },
+            [keys.notes]: { pullRequests: [], rateLimited: false, status: "ready" },
+          },
+        };
+        await gateway.emitGatewayEvent(CONTROL_UI_SESSION_PULL_REQUESTS_CHANGED_EVENT, snapshots);
+        const openPr = row(keys.frontend).locator('.activity-feed__pr[data-state="open"]');
+        await expect.poll(() => openPr.textContent()).toContain("control-ui#42");
+        expect(await openPr.locator(".activity-feed__additions").textContent()).toBe("+184");
+        expect(await openPr.locator(".activity-feed__deletions").textContent()).toBe("−27");
+        expect(
+          await row(keys.frontend).locator('.activity-feed__pr[data-state="merged"]').count(),
+        ).toBe(1);
+        expect(await row(keys.frontend).locator(".activity-feed__branch").count()).toBe(0);
+        expect(
+          await openPr.evaluate((element) => element.closest("[data-activity-session]")),
+        ).toBeNull();
+
+        const draftPr = row(keys.review).locator('.activity-feed__pr[data-state="draft"]');
+        await expect.poll(() => draftPr.textContent()).toContain("gateway#17");
+        expect(
+          await draftPr.locator(".activity-feed__additions, .activity-feed__deletions").count(),
+        ).toBe(0);
+        expect(await row(keys.notes).locator(".activity-feed__git").count()).toBe(0);
+        const branch = row(keys.branch).locator(".activity-feed__branch");
+        await expect
+          .poll(() => branch.textContent())
+          .toContain("feature/responsive-navigation-and-keyboard-shortcuts");
+        expect(await branch.locator(".activity-feed__additions").textContent()).toBe("+1,284");
+        expect(await branch.locator(".activity-feed__deletions").textContent()).toBe("−96");
+        await row(keys.branch)
+          .getByRole("img", { name: "Git status may be out of date" })
+          .waitFor();
+        await capture(page, "01-desktop-activity-git.png", [openPr, branch]);
+
+        const card = page.locator(".github-link-hovercard");
+        await draftPr.hover();
+        await expect.poll(() => card.textContent()).toContain(reviewRequest.title);
+        const request = await gateway.waitForRequest("controlUi.githubPreview", {
+          match: { owner: "example", repo: "gateway", number: 17 },
+        });
+        expect(request.params).toMatchObject({ agentId: "reviewer", kind: "pull" });
+        expect(await draftPr.getAttribute("href")).toBe(reviewRequest.url);
+        expect(await draftPr.getAttribute("target")).toBe("_blank");
+        await capture(page, "02-desktop-pr-hover.png", [card]);
+        await page.mouse.move(1, 1);
+        await expect.poll(() => card.count()).toBe(0);
+
+        await page.setViewportSize({ width: 390, height: 844 });
+        await draftPr.scrollIntoViewIfNeeded();
+        await expect
+          .poll(() => activity.evaluate((element) => element.scrollWidth - element.clientWidth))
+          .toBeLessThanOrEqual(1);
+        await capture(page, "03-mobile-activity-git.png", [draftPr]);
+        await draftPr.focus();
+        await expect.poll(() => card.textContent()).toContain(reviewRequest.title);
+        const bounds = await card.boundingBox();
+        expect(bounds).not.toBeNull();
+        expect(bounds!.x).toBeGreaterThanOrEqual(0);
+        expect(bounds!.x + bounds!.width).toBeLessThanOrEqual(390);
+        await capture(page, "04-mobile-pr-focus.png", [card]);
+        await page.keyboard.press("Escape");
+        await expect.poll(() => card.count()).toBe(0);
+        expect(await draftPr.evaluate((element) => element === document.activeElement)).toBe(true);
+        const popupPromise = page.waitForEvent("popup");
+        await page.keyboard.press("Enter");
+        const popup = await popupPromise;
+        await popup.waitForLoadState("domcontentloaded");
+        expect(popup.url()).toBe(reviewRequest.url);
+        expect(new URL(page.url()).pathname).toBe("/activity");
+        await popup.close();
+
+        await gateway.emitGatewayEvent(CONTROL_UI_SESSION_PULL_REQUESTS_CHANGED_EVENT, {
+          sessions: {
+            [keys.frontend]: {
+              ...snapshots.sessions[keys.frontend],
+              pullRequests: [{ ...pullRequest, state: "merged", additions: 192, deletions: 30 }],
+            },
+          },
+        });
+        const updatedPr = row(keys.frontend).locator('.activity-feed__pr[data-state="merged"]');
+        await expect
+          .poll(() => updatedPr.locator(".activity-feed__additions").textContent())
+          .toBe("+192");
+        expect(await updatedPr.locator(".activity-feed__deletions").textContent()).toBe("−30");
+        await expect
+          .poll(() => row(keys.frontend).locator(".activity-feed__branch").textContent())
+          .toContain(pullRequest.branch);
+
+        const sessionLink = row(keys.notes).locator("[data-activity-session]");
+        const href = await sessionLink.getAttribute("href");
+        expect(href).toBeTruthy();
+        const destination = new URL(href!, page.url());
+        await sessionLink.click();
+        await expect.poll(() => new URL(page.url()).pathname).toBe(destination.pathname);
+        await expect.poll(() => new URL(page.url()).search).toBe(destination.search);
+        await expect.poll(watchedKeys).not.toEqual(expect.arrayContaining([keys.review]));
+        expect(await page.locator("openclaw-activity-session-git").count()).toBe(0);
+      },
+    );
+  });
+});

--- a/ui/src/e2e/activity-session-git.e2e.test.ts
+++ b/ui/src/e2e/activity-session-git.e2e.test.ts
@@ -89,12 +89,14 @@ suite.define(() => {
         );
         const now = Date.now();
         const sessions = chatSessionListResponse(
-          ([
-            [keys.frontend, "Activity feed improvements", "Alex Morgan", "main"],
-            [keys.review, "Review Gateway reconnection", "Casey Brooks", "reviewer"],
-            [keys.branch, "Polish responsive navigation", "Sam Rivera", "main"],
-            [keys.notes, "Release planning notes", "Alex Morgan", "main"],
-          ] as const).map(([key, label, owner, agentId], index) => ({
+          (
+            [
+              [keys.frontend, "Activity feed improvements", "Alex Morgan", "main"],
+              [keys.review, "Review Gateway reconnection", "Casey Brooks", "reviewer"],
+              [keys.branch, "Polish responsive navigation", "Sam Rivera", "main"],
+              [keys.notes, "Release planning notes", "Alex Morgan", "main"],
+            ] as const
+          ).map(([key, label, owner, agentId], index) => ({
             key,
             label,
             agentId,

--- a/ui/src/e2e/activity-session-git.e2e.test.ts
+++ b/ui/src/e2e/activity-session-git.e2e.test.ts
@@ -89,12 +89,12 @@ suite.define(() => {
         );
         const now = Date.now();
         const sessions = chatSessionListResponse(
-          [
+          ([
             [keys.frontend, "Activity feed improvements", "Alex Morgan", "main"],
             [keys.review, "Review Gateway reconnection", "Casey Brooks", "reviewer"],
             [keys.branch, "Polish responsive navigation", "Sam Rivera", "main"],
             [keys.notes, "Release planning notes", "Alex Morgan", "main"],
-          ].map(([key, label, owner, agentId], index) => ({
+          ] as const).map(([key, label, owner, agentId], index) => ({
             key,
             label,
             agentId,

--- a/ui/src/i18n/locales/en-activity.ts
+++ b/ui/src/i18n/locales/en-activity.ts
@@ -5,6 +5,15 @@ import { en } from "./en.ts";
 // diagnostic inspector does not tax every Control UI startup.
 const enActivity = {
   activity: {
+    git: {
+      pullRequest: "{repository} pull request #{number}: {title} ({state})",
+      branchDiff: "{branch}: changes against the default branch, including uncommitted work",
+      stale: "Git status may be out of date",
+      open: "Open",
+      draft: "Draft",
+      merged: "Merged",
+      closed: "Closed",
+    },
     title: "Activity",
     visibleCount: "{visible} of {total}",
     search: "Search",

--- a/ui/src/pages/activity/session-activity-git.ts
+++ b/ui/src/pages/activity/session-activity-git.ts
@@ -1,0 +1,135 @@
+import { html, nothing } from "lit";
+import { property } from "lit/decorators.js";
+import type { ControlUiSessionPullRequest } from "../../../../src/gateway/control-ui-contract.js";
+import type { ApplicationContext } from "../../app/context.ts";
+import "../../components/github-link-hovercard-registration.ts";
+import { icons } from "../../components/icons.ts";
+import { t } from "../../i18n/index.ts";
+import { registerActivityEnglish } from "../../i18n/locales/en-activity.ts";
+import { sessionPullRequestsForGateway } from "../../lib/session-pull-requests.ts";
+import { OpenClawLightDomElement } from "../../lit/openclaw-element.ts";
+import { SubscriptionsController } from "../../lit/subscriptions-controller.ts";
+
+registerActivityEnglish();
+
+function renderDiff(item: { additions?: number; deletions?: number }) {
+  return html`${
+    item.additions === undefined
+      ? nothing
+      : html`<span class="activity-feed__additions">+${item.additions.toLocaleString()}</span>`
+  }${
+    item.deletions === undefined
+      ? nothing
+      : html`<span class="activity-feed__deletions">−${item.deletions.toLocaleString()}</span>`
+  }`;
+}
+
+function renderPullRequest(pr: ControlUiSessionPullRequest) {
+  const icon = {
+    open: icons.gitPullRequest,
+    draft: icons.gitPullRequestDraft,
+    merged: icons.gitMerge,
+    closed: icons.gitPullRequestClosed,
+  }[pr.state];
+  return html`<a
+    class="activity-feed__pr"
+    data-state=${pr.state}
+    href=${pr.url}
+    target="_blank"
+    rel="noopener noreferrer"
+    aria-label=${t("activity.git.pullRequest", {
+      repository: `${pr.owner}/${pr.repo}`,
+      number: String(pr.number),
+      title: pr.title,
+      state: t(`activity.git.${pr.state}`),
+    })}
+  >
+    <span class="activity-feed__git-icon" aria-hidden="true">${icon}</span>
+    <span class="activity-feed__git-label">${pr.repo}#${pr.number}</span>
+    ${renderDiff(pr)}
+  </a>`;
+}
+
+class ActivitySessionGit extends OpenClawLightDomElement {
+  @property({ attribute: false }) context!: ApplicationContext;
+  @property() sessionKey = "";
+  @property() agentId = "";
+
+  private readonly subscriptions = new SubscriptionsController(this).effect(
+    () => this.context?.gateway,
+    (gateway) => {
+      const store = sessionPullRequestsForGateway(gateway);
+      const stopStore = store.subscribe(() => this.requestUpdate());
+      const stopGateway = gateway.subscribe(() => this.requestUpdate());
+      return () => {
+        store.unwatch(this);
+        stopStore();
+        stopGateway();
+      };
+    },
+  );
+
+  override willUpdate() {
+    if (!this.isConnected) {
+      return;
+    }
+    sessionPullRequestsForGateway(this.context.gateway).watch(this, [this.sessionKey], {
+      foreground: true,
+    });
+  }
+
+  override disconnectedCallback() {
+    this.subscriptions.clear();
+    super.disconnectedCallback();
+  }
+
+  override render() {
+    const gateway = this.context.gateway;
+    const snapshot = sessionPullRequestsForGateway(gateway).get(this.sessionKey);
+    if (!snapshot) {
+      return nothing;
+    }
+    const branch = snapshot.pullRequests.some((pr) => pr.state === "open" || pr.state === "draft")
+      ? undefined
+      : snapshot.branch;
+    if (!branch && snapshot.pullRequests.length === 0) {
+      return nothing;
+    }
+    const stale = snapshot.status !== "ready" || gateway.snapshot.phase !== "connected";
+    return html`<openclaw-github-link-hovercard-provider
+      .client=${gateway.snapshot.client}
+      .agentId=${this.agentId}
+    >
+      <div class="activity-feed__git">
+        ${
+          branch
+            ? html`<span
+                class="activity-feed__branch"
+                title=${t("activity.git.branchDiff", { branch: branch.branch })}
+              >
+                <span class="activity-feed__git-icon" aria-hidden="true">${icons.gitBranch}</span>
+                <span class="activity-feed__git-label">${branch.branch}</span>
+                ${renderDiff(branch)}
+              </span>`
+            : nothing
+        }
+        ${snapshot.pullRequests.map(renderPullRequest)}
+        ${
+          stale
+            ? html`<span
+                class="activity-feed__git-stale"
+                role="img"
+                aria-label=${t("activity.git.stale")}
+                title=${t("activity.git.stale")}
+                >${icons.alertTriangle}</span
+              >`
+            : nothing
+        }
+      </div>
+    </openclaw-github-link-hovercard-provider>`;
+  }
+}
+
+if (!customElements.get("openclaw-activity-session-git")) {
+  customElements.define("openclaw-activity-session-git", ActivitySessionGit);
+}

--- a/ui/src/pages/activity/session-activity-view.browser.test.ts
+++ b/ui/src/pages/activity/session-activity-view.browser.test.ts
@@ -38,7 +38,11 @@ it.each([
       context: {
         basePath: "",
         navigate: vi.fn(),
-        gateway: { snapshot: { hello: null } },
+        gateway: {
+          snapshot: { hello: null, client: null, phase: "stopped" },
+          subscribe: () => () => {},
+          subscribeEvents: () => () => {},
+        },
         agents: { state: { agentsList: { defaultId: "main", mainKey: "main" } } },
         agentSelection: { state: { selectedId: "main" } },
         sessions: { state: { result: { sessions: [] } } },

--- a/ui/src/pages/activity/session-activity-view.test.ts
+++ b/ui/src/pages/activity/session-activity-view.test.ts
@@ -41,7 +41,11 @@ function props({
     context: {
       basePath: "",
       navigate: vi.fn(),
-      gateway: { snapshot: { hello: null } },
+      gateway: {
+        snapshot: { hello: null, client: null, phase: "stopped" },
+        subscribe: () => () => {},
+        subscribeEvents: () => () => {},
+      },
       agents: { state: { agentsList: { defaultId: "main", mainKey: "main" } } },
       agentSelection: { state: { selectedId: "main" } },
       sessions: { state: { result: { sessions: [] } } },

--- a/ui/src/pages/activity/session-activity-view.ts
+++ b/ui/src/pages/activity/session-activity-view.ts
@@ -20,7 +20,12 @@ import {
   resolveSessionPreferredFace,
   sessionNavigationTarget,
 } from "../../lib/sessions/route-navigation.ts";
-import { resolveUiConfiguredMainKey } from "../../lib/sessions/session-key.ts";
+import {
+  parseAgentSessionKey,
+  resolveUiConfiguredMainKey,
+  scopedSessionArtifactKey,
+} from "../../lib/sessions/session-key.ts";
+import "./session-activity-git.ts";
 import { activityRunInspectorHref } from "./run-inspector-model.ts";
 import {
   ACTIVITY_TIME_FILTERS,
@@ -240,6 +245,10 @@ function dayLabel(timestamp: number | null, now = Date.now()): string {
 }
 
 function renderSessionLink(context: ApplicationContext, row: GatewaySessionRow) {
+  const agentId =
+    parseAgentSessionKey(row.key)?.agentId ??
+    row.agentId ??
+    resolveSessionNavigationAgentId(context);
   const face = resolveSessionPreferredFace(row);
   const target = sessionNavigationTarget({
     face,
@@ -324,6 +333,11 @@ function renderSessionLink(context: ApplicationContext, row: GatewaySessionRow) 
         }
       </span>
     </a>
+    <openclaw-activity-session-git
+      .context=${context}
+      .sessionKey=${scopedSessionArtifactKey(row.key, agentId)}
+      .agentId=${agentId}
+    ></openclaw-activity-session-git>
     ${
       activeObserverRunId
         ? html`<a

--- a/ui/src/styles/activity.css
+++ b/ui/src/styles/activity.css
@@ -382,6 +382,81 @@ a.activity-current-work__row:hover {
   position: relative;
 }
 
+.activity-feed__git {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  padding: 0 var(--space-4) var(--space-3) calc(var(--space-4) + 28px + var(--space-3));
+  font-size: var(--control-ui-text-xs);
+}
+
+.activity-feed__pr,
+.activity-feed__branch {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  max-width: 100%;
+  min-width: 0;
+  padding: 3px 7px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  color: var(--text);
+  background: var(--bg-elevated);
+  line-height: 1.4;
+}
+
+.activity-feed__pr:hover,
+.activity-feed__pr:focus-visible {
+  border-color: var(--border-strong);
+  background: var(--bg-hover);
+  text-decoration: none;
+}
+
+.activity-feed__git-label {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.activity-feed__git-icon,
+.activity-feed__git-stale {
+  display: inline-flex;
+  flex: none;
+  color: var(--muted);
+}
+
+.activity-feed__git-icon svg,
+.activity-feed__git-stale svg {
+  width: 14px;
+  height: 14px;
+}
+
+.activity-feed__pr[data-state="open"] .activity-feed__git-icon,
+.activity-feed__additions {
+  color: var(--ok);
+}
+
+.activity-feed__pr[data-state="merged"] .activity-feed__git-icon {
+  color: var(--pr-merged);
+}
+
+.activity-feed__pr[data-state="closed"] .activity-feed__git-icon,
+.activity-feed__deletions {
+  color: var(--danger);
+}
+
+.activity-feed__additions,
+.activity-feed__deletions {
+  flex: none;
+  font-variant-numeric: tabular-nums;
+}
+
+.activity-feed__git-stale {
+  color: var(--warn);
+}
+
 .activity-feed__session-row + .activity-feed__session-row,
 .activity-feed__automation-group + .activity-feed__session-row,
 .activity-feed__session-row + .activity-feed__automation-group {


### PR DESCRIPTION
Closes #145529

## What Problem This Solves

Activity lists sessions without their code-change counts or associated pull requests, so users have to open each session to inspect Git progress.

## Why This Change Was Made

Activity now consumes the existing shared session PR snapshot store for its rendered rows. Compact PR chips show added/removed lines and open GitHub independently of the session link; hovering or keyboard-focusing a chip opens the existing rich preview in that row's agent scope. Branch diffs appear before an open/draft PR exists, including local work after a previous PR was merged.

The shared hover provider now respects the nearest nested provider, preventing duplicate cards and requests through the app's selected-agent identity. The Gateway remains the owner of discovery, polling, and snapshots; this adds no RPC, configuration, or persistence.

## User Impact

Users can scan Git changes and open or preview associated PRs directly from Activity on desktop and mobile. Unknown line counts stay hidden, and stale snapshots carry a warning. Counts describe the associated checkout/PR, not cumulative session edits or arbitrary PR mentions in messages.

## Evidence

- Independent autoreview: scoped clean through P2, including follow-up test type/format corrections.
- `node scripts/check-changed.mjs` passed, including core-test/UI type checks, lint/style checks, UI i18n, dependency guards, and dead-export scans.
- 112 focused tests passed with the frozen lockfile dependencies: Activity rendering and browser refresh, session PR snapshots, GitHub hover cards, and the full Activity Git E2E flow.
- The nested pointer/focus regression failed on the original provider with two requests instead of one, then passed with the ownership fix.
- Full Control UI boot with a synthetic Gateway passed: scoped subscriptions, pushed updates, open/merged/draft states, missing counts, branch stats, stale warning, pointer/focus previews, external PR navigation, session navigation, and watch cleanup at 1440 px and 390 px.
- Screenshots below use inspected synthetic fixtures; the before capture runs the original Activity implementation at the same viewport. No live Gateway was modified. The optional existing-Chrome check encountered an extension relay discovery timeout; browser evidence comes from the mocked-Gateway lane.

The previous CI attempt exposed the unrelated missing `retainedMachine` test variable introduced on main by #145463. After #145540 repaired it, this branch was refreshed onto the repaired main with an identical feature patch; the UI-test typecheck and Activity E2E passed again.

### Before

![Activity before Git details](https://github.com/user-attachments/assets/64896923-970f-4662-8396-c3fb7a95b8a6)

### After

![Activity with PR and branch change counts](https://github.com/user-attachments/assets/70cb3964-68d5-40a0-ab78-0e871ea07598)

### PR preview

![Activity PR hover preview](https://github.com/user-attachments/assets/b59b908b-e6cd-4b8e-85ee-913120051a1f)

### Mobile keyboard preview

![Activity PR keyboard preview on mobile](https://github.com/user-attachments/assets/3f7d9ca0-8602-437b-b886-c56272285cf4)
