### PR TITLE
docs(openai): document Advanced Account Security OAuth recovery

### DIFF
--- a/docs/providers/openai/setup.md
+++ b/docs/providers/openai/setup.md
@@ -212,6 +212,27 @@ sidebarTitle: "Setup"
 
     ### Check and recover Codex OAuth routing
 
+    #### After enabling Advanced Account Security
+
+    If you enroll the ChatGPT account in [Advanced Account Security](https://help.openai.com/en/articles/20001221-advanced-account-security), OpenAI signs you out of all devices after initial setup and may require interactive sign-in more often. This account-session behavior does not by itself mean that OpenClaw is incompatible with Advanced Account Security.
+
+    For an OpenClaw-managed profile, complete a fresh browser OAuth login through OpenClaw with the enrolled passkey or security key. Select the same agent that owns the failing route and, when you use multiple logins, the same profile:
+
+    ```bash
+    openclaw models auth login --provider openai --agent <id>
+    openclaw models auth login --provider openai --agent <id> --profile-id openai:<profile>
+    ```
+
+    A standalone `codex login` updates native Codex user-home auth; it does not replace an OpenClaw-managed credential. Use the documented [native user-home mode](/plugins/codex-harness-reference/auth#auth-and-environment-isolation) only when `appServer.homeScope: "user"` is intentional.
+
+    After signing in, verify the intended agent, runtime, and model with a real request. A model listing or a successful browser callback alone does not prove model access:
+
+    ```bash
+    openclaw models status --agent <id> --probe --probe-provider openai
+    ```
+
+    If a fresh login still fails, record the exact sanitized error and stage: browser or security-key interaction, localhost callback, token exchange, refresh, or model request. Separate a model-specific authorization error from a general account-login failure.
+
     ```bash
     openclaw models status
     openclaw models auth list --provider openai


### PR DESCRIPTION
## What Problem This Solves

Users who enable OpenAI Advanced Account Security can follow the generic OAuth recovery steps but cannot tell that enrollment signs out existing sessions, which credential owner to refresh, or how to verify the intended OpenClaw route.

Fixes #145438

## Why This Change Was Made

Adds a focused recovery subsection covering AAS session behavior, OpenClaw-managed agent/profile sign-in, and the separate native Codex user-home mode. It also asks users to verify access with a real request and record the sanitized failure stage without changing runtime or security policy.

## User Impact

Users can recover OpenAI OAuth after AAS enrollment without mistaking standalone Codex authentication or a model listing for OpenClaw access.

## Evidence

- `pnpm format:docs:check` — passed (1,283 files)
- `pnpm lint:docs` — passed (1,282 files, 0 issues)
- `pnpm docs:check-mdx` — passed (1,296 files)
- `pnpm docs:check-links` — passed (13,474 internal links, 0 broken)
- `git diff --check` — passed
- Existing auth contract: `docs/plugins/codex-harness-reference/auth.md` remains the source of truth for OpenClaw-managed credentials and intentional native user-home mode.

```text
Docs formatting clean (1,283 files).
markdownlint: 0 issues in 0 files
Docs MDX check passed (1,296 files)
checked_internal_links=13474
broken_links=0
git diff --check: passed
```

AI-assisted: built with Codex
