### PR TITLE
docs(openai): explain Advanced Account Security recovery

### DIFF
--- a/docs/providers/openai/setup.md
+++ b/docs/providers/openai/setup.md
@@ -253,6 +253,35 @@ sidebarTitle: "Setup"
     Run `openclaw doctor --fix` to migrate older legacy OpenAI Codex prefix
     profile ids and order entries before relying on profile ordering.
 
+    ### Advanced Account Security recovery
+
+    OpenAI's [Advanced Account Security](https://help.openai.com/en/articles/20001221-advanced-account-security)
+    enrollment signs you out of existing devices and may require interactive
+    sign-in more often. Complete a fresh browser OAuth login with your passkey
+    or security key for the same OpenClaw agent and profile that owns the
+    failing route:
+
+    ```bash
+    openclaw models auth login --provider openai
+    openclaw models status --agent <id> --probe --probe-provider openai
+    ```
+
+    If you use multiple profiles, include the same `--agent <id>` and
+    `--profile-id` selectors used by that route. A standalone `codex login`
+    updates native Codex user-home credentials; it does not replace an
+    OpenClaw-managed OAuth profile. Native user-home authentication is a
+    separate, explicitly configured mode described in the
+    [Codex harness authentication reference](/plugins/codex-harness-reference/auth).
+
+    Verify the intended agent, runtime, and model with a real request. A model
+    listing or successful browser callback alone does not prove that the
+    selected profile can access the model. If a fresh login still fails, record
+    the sanitized error and stage: browser or security-key interaction,
+    localhost callback, token exchange, refresh, or model request. Keep
+    model-specific authorization errors separate from general account-login
+    failures. Do not disable Advanced Account Security, copy tokens, delete
+    credential stores, or silently switch to API-key billing as recovery steps.
+
     ### Status indicator
 
     Chat `/status` shows which model runtime is active for the current

--- a/docs/providers/openai/setup.md
+++ b/docs/providers/openai/setup.md
@@ -262,12 +262,14 @@ sidebarTitle: "Setup"
     failing route:
 
     ```bash
-    openclaw models auth login --provider openai
+    openclaw models auth login --agent <id> --provider openai
     openclaw models status --agent <id> --probe --probe-provider openai
     ```
 
-    If you use multiple profiles, include the same `--agent <id>` and
-    `--profile-id` selectors used by that route. A standalone `codex login`
+    If you use multiple profiles, include the same `--agent <id>` selector
+    used by that route. The selectors differ between the two commands: login
+    names its profiles with `--profile-id`, while `models status` probes
+    select profiles with `--probe-profile`. A standalone `codex login`
     updates native Codex user-home credentials; it does not replace an
     OpenClaw-managed OAuth profile. Native user-home authentication is a
     separate, explicitly configured mode described in the


### PR DESCRIPTION
Fixes #145438

## What Problem This Solves

The OpenAI setup guide did not explain recovery after enabling Advanced Account Security (AAS). Users could be signed out of existing devices and then confuse a native `codex login` with the separate OpenClaw-managed OAuth profile used by their agent.

## Why This Change Was Made

Adds a focused AAS recovery subsection to the existing OpenAI OAuth troubleshooting guide. It documents enrollment-wide sign-out, fresh OpenClaw browser OAuth with the enrolled passkey or security key, agent/profile selection, the distinction between native Codex home authentication and OpenClaw-managed credentials, and the evidence needed when recovery still fails.

## User Impact

Operators can recover an OpenClaw-managed OpenAI profile after AAS enrollment without disabling AAS, copying tokens, deleting credential stores, or silently switching billing modes. The guide also directs them to verify the actual agent/runtime/model request and report the failing authentication stage.

## Evidence

- Verified the AAS enrollment and sign-out behavior against the linked OpenAI help documentation in issue #145438.
- Cross-checked OpenClaw's existing OAuth commands and the Codex harness authentication reference.
- `pnpm docs:check-i18n-glossary` passed.
- `git diff --check` passed.

No runtime, auth store, provider behavior, or SDK code changed.
