### PR TITLE
test(ui): fix retained machine capture reference

### DIFF
--- a/ui/src/e2e/new-session-page.cloud-dispatch.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.cloud-dispatch.e2e.test.ts
@@ -435,7 +435,7 @@ suite.define(() => {
           await takeControlUiViewportScreenshot(
             page,
             place.locator(".new-session-page__cloud-configuration"),
-            [retainedCloudProfile, retainedMachine],
+            [retainedCloudProfile, place.locator('[data-value="machine:fast"]')],
           ),
         );
       }


### PR DESCRIPTION
Refs #145463 #145436

## What Problem This Solves

The merged New Session cloud-dispatch proof fails with `ReferenceError: retainedMachine is not defined` when `OPENCLAW_CAPTURE_UI_PROOF=1` is enabled. The two independently passing PRs composed a new screenshot reference with an earlier removal of that local variable.

## Why This Change Was Made

Use the same scoped Fast-machine locator that the test already uses immediately above the capture. This is a one-line repair; interaction, selection and dispatch assertions remain intact.

## User Impact

Restores the synthetic capture flow without changing production UI or timing limits.

## Evidence

Reproduced the failure on merged main `da762af0e80c9fe6a61422dc5591ab24e5c9a3ce`. The repaired cloud-dispatch case passes with capture enabled in 22.16 seconds, and its synthetic screenshot was inspected. The other three capture cases passed during that merged-main replay.

Targeted type-aware lint, the UI E2E typecheck, `git diff --check`, and fresh P2 autoreview passed. No retries, timeouts, assertions, snapshots, or production behavior changed.
