### PR TITLE
fix(ui): remove framing around single fullscreen dashboard widgets

### DIFF
--- a/docs/web/dashboards.md
+++ b/docs/web/dashboards.md
@@ -134,7 +134,9 @@ never needs the agent.
 - **Dashboard view.** The board can occupy the main area or a resizable side
   panel. With Dashboard active in the side panel, choose **Swap** in the task
   toolbar, then **Focus** for a dashboard-only view. **Restore split** brings
-  the side panel back.
+  the side panel back. A tab with one full-width widget fills the focused
+  dashboard edge to edge, without a card border or surrounding padding.
+  Restoring the split or adding another widget brings back the normal spacing.
 - **Agent parity.** The agent's `dashboard` tool creates or updates trusted
   plugin widgets, moves, resizes, and removes widgets, manages tabs, switches
   the visible tab, and requests a split or expanded dashboard with

--- a/ui/src/components/board/board-view-sizing.test.ts
+++ b/ui/src/components/board/board-view-sizing.test.ts
@@ -66,7 +66,9 @@ describe("board widget sizing", () => {
     const expected = exactBoardWidgetHeightPx(widget, 300, boardChromeRowPx());
     const section = () => cell?.querySelector<HTMLElement>(".board-widget");
     await vi.waitFor(() => {
-      expect(section()?.getAttribute("style")).toContain(`height: ${expected}px`);
+      expect(section()?.getAttribute("style")).toContain(
+        `height: calc(${expected}px - var(--board-widget-height-trim, 0px))`,
+      );
       expect(section()?.getAttribute("style")).toContain("align-self: start");
     });
     // Gestures manipulate the quantized cell, so the card fills it again.
@@ -90,7 +92,9 @@ describe("board widget sizing", () => {
 
     await vi.waitFor(() => {
       const section = cell?.querySelector<HTMLElement>(".board-widget");
-      expect(section?.getAttribute("style")).toContain("height: 10026px");
+      expect(section?.getAttribute("style")).toContain(
+        "height: calc(10026px - var(--board-widget-height-trim, 0px))",
+      );
       expect(section?.getAttribute("style")).toContain("span 148");
     });
   });

--- a/ui/src/components/board/board-view.browser.test.ts
+++ b/ui/src/components/board/board-view.browser.test.ts
@@ -3,6 +3,7 @@ import { buildWidgetDocument } from "../../../../src/canvas/wrap.js";
 import { BOARD_GRID_GAP, BOARD_GRID_ROW_HEIGHT } from "../../lib/board/grid.ts";
 import type { BoardSnapshot } from "../../lib/board/types.ts";
 import "../../styles/base.css";
+import "../../styles/chat/board.css";
 import "./board-view.ts";
 
 type OpenClawBoardView = HTMLElementTagNameMap["openclaw-board-view"];
@@ -42,13 +43,16 @@ const source: BoardSnapshot = {
   ],
 };
 
-async function mount(applyOps = vi.fn(async () => undefined)): Promise<OpenClawBoardView> {
+async function mount(
+  applyOps = vi.fn(async () => undefined),
+  parent: HTMLElement = document.body,
+): Promise<OpenClawBoardView> {
   const view = document.createElement("openclaw-board-view");
   view.snapshot = structuredClone(source);
   view.activeTabId = "main";
   view.widgetFrameUrl = () => "about:blank";
   view.callbacks = { applyOps, grant: vi.fn(async () => undefined), selectTab: vi.fn() };
-  document.body.append(view);
+  parent.append(view);
   await view.updateComplete;
   await Promise.all(
     [...view.querySelectorAll("openclaw-board-widget-cell")].map((cell) => cell.updateComplete),
@@ -430,13 +434,30 @@ describe.skipIf(!hasBrowserLayout)("openclaw-board-view browser layout", () => {
     expect(getComputedStyle(second).borderTopColor).not.toBe("rgba(0, 0, 0, 0)");
   });
 
-  it.each(["card", "full-bleed", "frameless"] as const)(
-    "keeps a %s widget stable when its content fills the iframe viewport",
-    async (presentation) => {
-      const view = await mount();
+  it.each(
+    (["card", "full-bleed", "frameless"] as const).flatMap((presentation) => [
+      { presentation, surface: "grid" },
+      { presentation, surface: "focused singleton" },
+    ]),
+  )(
+    "keeps a $presentation widget stable in a $surface when its content fills the iframe viewport",
+    async ({ presentation, surface }) => {
+      const focused = surface === "focused singleton";
+      const host = document.createElement("div");
+      const parent = document.createElement("div");
+      if (focused) {
+        host.className = "sidebar-region sidebar-region--open sidebar-region--expanded";
+        host.style.width = "1200px";
+        parent.className = "board-session-surface__board";
+        parent.style.height = "500px";
+        host.append(parent);
+        document.body.append(host);
+      }
+      const view = await mount(undefined, focused ? parent : document.body);
       view.snapshot = {
         ...structuredClone(source),
-        widgets: [{ ...source.widgets[0]!, presentation }],
+        ...(focused ? { tabs: [source.tabs[0]!] } : {}),
+        widgets: [{ ...source.widgets[0]!, presentation, ...(focused ? { sizeW: 12 } : {}) }],
       };
       await view.updateComplete;
       const cell = view.querySelector("openclaw-board-widget-cell")!;
@@ -456,15 +477,38 @@ describe.skipIf(!hasBrowserLayout)("openclaw-board-view browser layout", () => {
           "<style>body{min-height:100vh}</style><main>Dashboard content</main>",
         );
         await vi.waitFor(() => expect(reports.length).toBeGreaterThan(0));
-        // Each host resize can trigger another content report; allow repeated
-        // layout cycles so a missing border cannot silently shrink the frame.
-        for (let index = 0; index < 12; index += 1) {
-          await new Promise<void>((resolve) => {
-            requestAnimationFrame(() => resolve());
-          });
+        for (const expanded of focused ? [true, false, true] : [false]) {
+          if (focused) {
+            host.classList.toggle("sidebar-region--expanded", expanded);
+          }
+          // Each host resize can trigger another content report; allow repeated
+          // layout cycles so changing the shell cannot shrink or grow the frame.
+          for (let index = 0; index < 12; index += 1) {
+            await new Promise<void>((resolve) => {
+              requestAnimationFrame(() => resolve());
+            });
+          }
+          expect(frame.getBoundingClientRect().height).toBeCloseTo(initialHeight, 0);
+          expect(reports.every((height) => height === initialHeight)).toBe(true);
+          expect(view.querySelector("iframe")).toBe(frame);
+          if (focused) {
+            const widget = cell.querySelector<HTMLElement>(".board-widget")!;
+            const body = cell.querySelector<HTMLElement>(".board-widget__body")!;
+            expect(getComputedStyle(widget).borderTopWidth).toBe(expanded ? "0px" : "1px");
+            expect(getComputedStyle(body).paddingTop).toBe(
+              !expanded && presentation === "card" ? "12px" : "0px",
+            );
+            if (expanded) {
+              expect(getComputedStyle(widget).borderRadius).toBe("0px");
+              expect(getComputedStyle(body).borderRadius).toBe("0px");
+              const bounds = frame.getBoundingClientRect();
+              const available = parent.getBoundingClientRect();
+              expect(bounds.left).toBeCloseTo(available.left, 0);
+              expect(bounds.top).toBeCloseTo(available.top, 0);
+              expect(bounds.right).toBeCloseTo(available.right, 0);
+            }
+          }
         }
-        expect(frame.getBoundingClientRect().height).toBeCloseTo(initialHeight, 0);
-        expect(reports.every((height) => height === initialHeight)).toBe(true);
       } finally {
         window.removeEventListener("message", recordSize);
       }

--- a/ui/src/components/board/board-view.ts
+++ b/ui/src/components/board/board-view.ts
@@ -637,7 +637,10 @@ class OpenClawBoardView extends OpenClawLightDomElement {
     const activeTabId = activeTab?.tabId ?? this.activeTabId;
     const widgets = activeTab ? orderedWidgets(snapshot, activeTab.tabId) : [];
     return html`
-      <section class="board-view" aria-label=${t("board.label")}>
+      <section
+        class=${`board-view ${widgets.length === 1 && widgets[0]?.sizeW === BOARD_GRID_COLUMNS ? "board-view--single-full-width" : ""}`}
+        aria-label=${t("board.label")}
+      >
         ${renderBoardTabs({
           tabs,
           activeTabId,

--- a/ui/src/components/board/board-widget-cell.ts
+++ b/ui/src/components/board/board-widget-cell.ts
@@ -454,7 +454,9 @@ class OpenClawBoardWidgetCell extends OpenClawLightDomElement {
           this.fitAutoContent ? BOARD_DOCUMENT_AUTO_MAX_ROWS : undefined,
         );
     const exactHeightStyle =
-      exactHeightPx === undefined ? "" : ` height: ${exactHeightPx}px; align-self: start;`;
+      exactHeightPx === undefined
+        ? ""
+        : ` height: calc(${exactHeightPx}px - var(--board-widget-height-trim, 0px)); align-self: start;`;
     return html`
       <section
         class=${`board-widget ${this.dragging ? "board-widget--dragging" : ""} ${presentation ? `board-widget--${presentation}` : ""}`}

--- a/ui/src/e2e/dashboard-fullscreen.e2e.test.ts
+++ b/ui/src/e2e/dashboard-fullscreen.e2e.test.ts
@@ -516,10 +516,29 @@ suite.define(() => {
 
   it("makes dashboard main and restores chat after focus", async () => {
     await suite.withPage({ serviceWorkers: "block" }, async ({ page }) => {
+      const widgetUrl = `${suite.server.baseUrl}__widget/seamless-dashboard`;
+      await page.route(widgetUrl, (route) =>
+        route.fulfill({
+          contentType: "text/html",
+          body: buildWidgetDocument(
+            "Release overview",
+            `<style>body{min-height:100vh;background:#e8f0ee;color:#193e35}main{padding:32px}h1{font-size:48px}</style>
+            <main><p>RELEASE OVERVIEW</p><h1>Everything in view.</h1><p>One dashboard, one uninterrupted canvas.</p>
+            <input aria-label="Release note" placeholder="Release note"></main>`,
+          ),
+        }),
+      );
+      const singleWidget = {
+        ...boardSnapshot,
+        tabs: [boardSnapshot.tabs[0]],
+        widgets: [
+          { ...boardSnapshot.widgets[0], sizeW: 12, grantState: "none", frameUrl: widgetUrl },
+        ],
+      };
       const gateway = await installMockGateway(page, {
         sessionKey,
         featureMethods: ["board.get"],
-        methodResponses: { "board.get": boardSnapshot },
+        methodResponses: { "board.get": singleWidget },
       });
       await rememberMainTab(page);
       await page.goto(controlUiSessionUrl(suite.server.baseUrl, sessionKey, "dashboard"));
@@ -528,13 +547,60 @@ suite.define(() => {
       await page.locator(".board-session-surface").waitFor();
       await expect.poll(() => page.locator(".sidebar-region--expanded").count()).toBe(0);
       await page.locator(".chat-thread").waitFor();
+      const widget = page.locator('[data-widget-name="status"]');
+      const frame = widget.locator("iframe");
+      const note = page.frameLocator('[data-widget-name="status"] iframe').getByRole("textbox");
+      await note.fill("Keep this draft");
+      const frameHandle = await frame.elementHandle();
       await focusChatSidePanel(page);
       await expect.poll(() => page.locator(".sidebar-region--expanded").count()).toBe(1);
       await expect.poll(() => page.locator(".chat-thread").isHidden()).toBe(true);
+      await page.mouse.move(0, 0);
+      await page.screenshot({ path: `${suite.artifactDir}/single-widget-focused.png` });
+      const frameInsets = () =>
+        frame.evaluate((element) => {
+          const board = element.closest("openclaw-board-view")!;
+          const outer = board.getBoundingClientRect();
+          const inner = element.getBoundingClientRect();
+          return {
+            left: inner.left - outer.left,
+            right: outer.right - inner.right,
+            top: inner.top - outer.top,
+          };
+        });
+      await expect.poll(frameInsets).toEqual({ left: 0, right: 0, top: 0 });
+      expect(await widget.evaluate((element) => getComputedStyle(element).borderTopWidth)).toBe(
+        "0px",
+      );
+      expect(await widget.evaluate((element) => getComputedStyle(element).borderRadius)).toBe(
+        "0px",
+      );
       await page.getByRole("button", { name: "Restore split", exact: true }).click();
       await expect.poll(() => page.locator(".sidebar-region--expanded").count()).toBe(0);
       await page.locator('.sidebar-region__primary[data-region="side"] .chat-thread').waitFor();
       await page.locator('[data-panel-slot="dashboard"][data-region="main"]').waitFor();
+      expect(await widget.evaluate((element) => getComputedStyle(element).borderTopWidth)).toBe(
+        "1px",
+      );
+      expect(await frame.evaluate((element, previous) => element === previous, frameHandle)).toBe(
+        true,
+      );
+      expect(await note.inputValue()).toBe("Keep this draft");
+      await page.getByRole("button", { name: "Focus", exact: true }).click();
+      await frame.waitFor({ state: "visible" });
+      await expect.poll(frameInsets).toEqual({ left: 0, right: 0, top: 0 });
+      await gateway.setMethodResponse("board.get", {
+        ...singleWidget,
+        revision: 2,
+        widgets: [...singleWidget.widgets, boardSnapshot.widgets[1]],
+      });
+      await gateway.emitGatewayEvent("board.changed", { sessionKey });
+      await expect.poll(() => page.locator(".board-widget").count()).toBe(2);
+      expect(await widget.evaluate((element) => getComputedStyle(element).borderTopWidth)).toBe(
+        "1px",
+      );
+      expect((await frameInsets()).left).toBeGreaterThan(0);
+      expect(await note.inputValue()).toBe("Keep this draft");
     });
   });
 

--- a/ui/src/styles/board.css
+++ b/ui/src/styles/board.css
@@ -560,6 +560,43 @@ openclaw-board-widget-cell {
   }
 }
 
+/* A lone full-width widget becomes the focused dashboard's page. Keep the
+   regular grid sizing, subtracting only the shell removed from auto heights. */
+:is(.sidebar-region--expanded, .sidebar-region:not(.sidebar-region--open), .board-document__content)
+  openclaw-board-view:has(> .board-view--single-full-width) {
+  padding: 0;
+
+  > .board-view {
+    padding: 0;
+  }
+
+  .board-tabs {
+    padding-left: 16px;
+  }
+
+  .board-widget:not(.board-widget--dragging) {
+    --board-widget-height-trim: 2px;
+    background: transparent;
+    border: 0;
+    border-radius: 0;
+    box-shadow: none;
+
+    &.board-widget--card {
+      --board-widget-height-trim: calc(2px + var(--widget-frame-inset) * 2);
+    }
+
+    &:focus-visible {
+      outline: 2px solid var(--accent);
+      outline-offset: -2px;
+    }
+
+    .board-widget__body {
+      border-radius: 0;
+      padding: 0;
+    }
+  }
+}
+
 .board-widget__grant,
 .board-widget__error {
   align-content: center;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users focusing a dashboard with one full-width widget still see a rounded card, borders, and padding around the content.

## Why This Change Was Made

The active tab identifies its single full-width widget. Expanded dashboards, dashboards with the side panel closed, and standalone dashboard documents remove the outer gutters, card border, shadow, corners, and inner inset. Automatic height subtracts the removed shell so viewport-sized content stays stable. Split views and multi-widget boards retain normal framing; existing widget controls stay available.

## User Impact

A single fullscreen widget presents an uninterrupted canvas. Expanding or restoring the split preserves the loaded iframe and unsaved input. Adding another widget restores normal card separation.

## Evidence

- Board sizing and browser layout: 31 tests passed, including all three presentations and repeated focus/restore cycles. The three new focused cases fail on the original border.
- Dashboard E2E: all nine scenarios verified, including nested scrolling and focus/restore with retained input and a newly added second widget. The original focused layout fails with 29px horizontal and 25px top insets; the fixed layout has zero insets.
- Real Chrome synthetic fixture: zero focused insets and border/radius, normal split framing, and the same iframe after restoring focus.
- Changed-file checks passed: formatting, lint, core-test and UI typechecks, i18n, dead-export scans, and repository guards.
- Independent review: no actionable findings through P2; ClawSweeper also reported no findings.

Before:

![Single focused widget with surrounding card](https://github.com/user-attachments/assets/ae63c0fb-f1ea-4143-87f0-297af8d9d180)

After:

![Single focused widget flush with the dashboard](https://github.com/user-attachments/assets/12b96000-b477-4661-a293-682480e5a37c)
