### PR TITLE
refactor(tests): reuse workspace media plugin fixtures

### DIFF
--- a/src/infra/outbound/message-action-params.media-access.test.ts
+++ b/src/infra/outbound/message-action-params.media-access.test.ts
@@ -16,6 +16,7 @@ import {
 } from "../../test-utils/channel-plugins.js";
 import { resolvePreferredOpenClawTmpDir } from "../tmp-openclaw-dir.js";
 import {
+  createWorkspaceMediaTestPlugin,
   resetMessageActionMediaMocks,
   runMessageAction,
   setMessageActionTestPlugin as setTestPlugin,
@@ -100,36 +101,7 @@ async function expectSandboxMediaRewrite(params: {
   );
 }
 
-const workspacePlugin: ChannelPlugin = {
-  ...createChannelTestPluginBase({
-    id: "workspace",
-    label: "Workspace",
-    config: {
-      listAccountIds: () => ["default"],
-      resolveAccount: (cfg) => cfg.channels?.workspace ?? {},
-      isConfigured: async (account) =>
-        typeof (account as { botToken?: unknown }).botToken === "string" &&
-        (account as { botToken?: string }).botToken!.trim() !== "" &&
-        typeof (account as { appToken?: unknown }).appToken === "string" &&
-        (account as { appToken?: string }).appToken!.trim() !== "",
-    },
-  }),
-  outbound: {
-    deliveryMode: "direct",
-    resolveTarget: ({ to }) => {
-      const trimmed = to?.trim() ?? "";
-      if (!trimmed) {
-        return {
-          ok: false,
-          error: new Error("missing target for workspace"),
-        };
-      }
-      return { ok: true, to: trimmed };
-    },
-    sendText: async () => ({ channel: "workspace", messageId: "msg-test" }),
-    sendMedia: async () => ({ channel: "workspace", messageId: "msg-test" }),
-  },
-};
+const workspacePlugin = createWorkspaceMediaTestPlugin();
 
 describe("runMessageAction media behavior", () => {
   beforeEach(async () => {

--- a/src/infra/outbound/message-action-runner.media.test.ts
+++ b/src/infra/outbound/message-action-runner.media.test.ts
@@ -10,6 +10,7 @@ import { createChannelTestPluginBase } from "../../test-utils/channel-plugins.js
 import { withOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
 import {
   messageActionRunnerMocks as channelResolutionMocks,
+  createWorkspaceMediaTestPlugin,
   resetMessageActionMediaMocks,
   runMessageAction,
   setMessageActionTestPlugin as setTestPlugin,
@@ -33,36 +34,7 @@ async function withTempOpenClawStateDir<T>(test: (stateDir: string) => Promise<T
   );
 }
 
-const workspacePlugin: ChannelPlugin = {
-  ...createChannelTestPluginBase({
-    id: "workspace",
-    label: "Workspace",
-    config: {
-      listAccountIds: () => ["default"],
-      resolveAccount: (cfg) => cfg.channels?.workspace ?? {},
-      isConfigured: async (account) =>
-        typeof (account as { botToken?: unknown }).botToken === "string" &&
-        (account as { botToken?: string }).botToken!.trim() !== "" &&
-        typeof (account as { appToken?: unknown }).appToken === "string" &&
-        (account as { appToken?: string }).appToken!.trim() !== "",
-    },
-  }),
-  outbound: {
-    deliveryMode: "direct",
-    resolveTarget: ({ to }) => {
-      const trimmed = to?.trim() ?? "";
-      if (!trimmed) {
-        return {
-          ok: false,
-          error: new Error("missing target for workspace"),
-        };
-      }
-      return { ok: true, to: trimmed };
-    },
-    sendText: async () => ({ channel: "workspace", messageId: "msg-test" }),
-    sendMedia: async () => ({ channel: "workspace", messageId: "msg-test" }),
-  },
-};
+const workspacePlugin = createWorkspaceMediaTestPlugin();
 
 describe("runMessageAction media behavior", () => {
   beforeEach(async () => {

--- a/src/infra/outbound/message-action-runner.test-helpers.ts
+++ b/src/infra/outbound/message-action-runner.test-helpers.ts
@@ -13,7 +13,10 @@ import {
 } from "../../interactive/payload.js";
 import { extractToolPayload } from "../../plugin-sdk/tool-payload.js";
 import { getActivePluginRegistry, setActivePluginRegistry } from "../../plugins/runtime.js";
-import { createTestRegistry } from "../../test-utils/channel-plugins.js";
+import {
+  createChannelTestPluginBase,
+  createTestRegistry,
+} from "../../test-utils/channel-plugins.js";
 
 type ChannelActionHandler = NonNullable<NonNullable<ChannelPlugin["actions"]>["handleAction"]>;
 
@@ -119,6 +122,39 @@ export function setMessageActionTestPlugin(plugin: unknown, pluginId: string, or
   setActivePluginRegistry(
     createTestRegistry([{ pluginId, source: "test", ...(origin ? { origin } : {}), plugin }]),
   );
+}
+
+export function createWorkspaceMediaTestPlugin(): ChannelPlugin {
+  return {
+    ...createChannelTestPluginBase({
+      id: "workspace",
+      label: "Workspace",
+      config: {
+        listAccountIds: () => ["default"],
+        resolveAccount: (cfg) => cfg.channels?.workspace ?? {},
+        isConfigured: async (account) =>
+          typeof (account as { botToken?: unknown }).botToken === "string" &&
+          (account as { botToken?: string }).botToken!.trim() !== "" &&
+          typeof (account as { appToken?: unknown }).appToken === "string" &&
+          (account as { appToken?: string }).appToken!.trim() !== "",
+      },
+    }),
+    outbound: {
+      deliveryMode: "direct",
+      resolveTarget: ({ to }) => {
+        const trimmed = to?.trim() ?? "";
+        if (!trimmed) {
+          return {
+            ok: false,
+            error: new Error("missing target for workspace"),
+          };
+        }
+        return { ok: true, to: trimmed };
+      },
+      sendText: async () => ({ channel: "workspace", messageId: "msg-test" }),
+      sendMedia: async () => ({ channel: "workspace", messageId: "msg-test" }),
+    },
+  };
 }
 
 export function createAlwaysConfiguredPluginConfig(

--- a/src/infra/outbound/message-action-send.media.test.ts
+++ b/src/infra/outbound/message-action-send.media.test.ts
@@ -5,13 +5,12 @@ import path from "node:path";
 // attachments, and channel/plugin media source aliases.
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { beforeEach, describe, expect, it } from "vitest";
-import type { ChannelPlugin } from "../../channels/plugins/types.public.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import { MEDIA_MAX_BYTES } from "../../media/store.js";
-import { createChannelTestPluginBase } from "../../test-utils/channel-plugins.js";
 import { withOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
 import {
   messageActionRunnerMocks as channelResolutionMocks,
+  createWorkspaceMediaTestPlugin,
   resetMessageActionMediaMocks,
   runMessageAction,
   setMessageActionTestPlugin as setTestPlugin,
@@ -71,36 +70,7 @@ const runDrySend = (params: {
 
 const requireRecord = createRequireRecord("record", "expected-non-array-record");
 
-const workspacePlugin: ChannelPlugin = {
-  ...createChannelTestPluginBase({
-    id: "workspace",
-    label: "Workspace",
-    config: {
-      listAccountIds: () => ["default"],
-      resolveAccount: (cfg) => cfg.channels?.workspace ?? {},
-      isConfigured: async (account) =>
-        typeof (account as { botToken?: unknown }).botToken === "string" &&
-        (account as { botToken?: string }).botToken!.trim() !== "" &&
-        typeof (account as { appToken?: unknown }).appToken === "string" &&
-        (account as { appToken?: string }).appToken!.trim() !== "",
-    },
-  }),
-  outbound: {
-    deliveryMode: "direct",
-    resolveTarget: ({ to }) => {
-      const trimmed = to?.trim() ?? "";
-      if (!trimmed) {
-        return {
-          ok: false,
-          error: new Error("missing target for workspace"),
-        };
-      }
-      return { ok: true, to: trimmed };
-    },
-    sendText: async () => ({ channel: "workspace", messageId: "msg-test" }),
-    sendMedia: async () => ({ channel: "workspace", messageId: "msg-test" }),
-  },
-};
+const workspacePlugin = createWorkspaceMediaTestPlugin();
 
 describe("runMessageAction media behavior", () => {
   beforeEach(async () => {


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

Three outbound media test files repeat the same workspace plugin fixture, making its configuration and target behavior harder to maintain consistently.

## Why This Change Was Made

Move the identical fixture into the existing message-action test harness and create one fresh plugin at each original file-level declaration. Preserve its callbacks, token checks, target resolution, send results, and existing module dependencies. Keep the distinct workspace configurations and other plugin fixtures unchanged.

## User Impact

No product behavior changes. This removes 50 net test/support lines while preserving every media and isolation assertion.

## Evidence

- Original and final three-file media cohort: 25 passing cases with identical per-file case order.
- All 12 existing harness consumer files: 167 passing cases.
- Exact source-inverse verification restores all four original files; callback checks confirm independent nested objects/functions, account identity, target outcomes, and fresh send results.
- Full changed-file gate and independent P2 review passed.
- The first local gate used stale dependencies in a retired checkout. A private frozen-lockfile install followed by complete baseline, final, consumer, and gate reruns passed; those refreshed results are the authoritative proof.

- The original CI head inherited an unrelated undefined screenshot-locator reference. This patch-identical refresh includes the landed fix from #145540; fresh exact-head CI is running.

No overall runtime reduction is claimed for this fixture consolidation.
