### PR TITLE
fix(ui): recover saved messages after browser storage closes

### DIFF
--- a/docs/web/control-ui/offline-and-reconnect.md
+++ b/docs/web/control-ui/offline-and-reconnect.md
@@ -133,6 +133,12 @@ If the destination changes, a newer draft appears, or storage fails, recovery ke
 available rather than overwriting newer input. Do not clear browser site data
 while you still have saved messages or attachment drafts to recover.
 
+If the browser closes its draft database connection, the next storage operation
+opens a fresh connection automatically. A recovery error without any loaded entries
+appears as **Saved messages could not be loaded**; it does not mean that messages
+have lost their destinations or that browser storage is full. Reload to retry if
+the error persists, keeping site data intact.
+
 First opens and reloads without usable warm state show a small animated OpenClaw mark while the Gateway resolves the initial
 connection, including when authentication comes from a trusted proxy or Tailscale instead of a
 browser-stored credential. The login gate appears only after the initial connection fails or the

--- a/ui/src/e2e/composer-draft-store.e2e.test.ts
+++ b/ui/src/e2e/composer-draft-store.e2e.test.ts
@@ -64,64 +64,6 @@ async function rawDraftRecords(page: Page, scopes: readonly TestDraftScope[], ex
 }
 
 suite.define(() => {
-  it("reopens composer storage after the browser forcibly closes its database", async () => {
-    await suite.withPage({ serviceWorkers: "block" }, async ({ context, page }) => {
-      await page.route("**/composer-storage-reopen", (route) =>
-        route.fulfill({ contentType: "text/html", body: "Composer storage recovery" }),
-      );
-      await page.goto(`${suite.server.baseUrl}composer-storage-reopen`);
-      const draftStore = await page.evaluateHandle<
-        typeof import("../lib/chat/composer-draft-store.runtime.ts")
-      >('import("/src/lib/chat/composer-draft-store.runtime.ts")');
-      const scope = {
-        gatewayOwner: "reopen-gateway",
-        recoveryScope: "reopen-owner",
-        scopeKey: "chat:v3:agent:main:reopen\u0000agent:main",
-      };
-      expect(
-        await draftStore.evaluate(
-          (store, destination) => store.prepareDurableComposerRecovery(destination),
-          scope,
-        ),
-      ).toEqual({ status: "ready", entries: [] });
-      const database = await page.evaluateHandle<
-        typeof import("../lib/chat/control-ui-database.runtime.ts")
-      >('import("/src/lib/chat/control-ui-database.runtime.ts")');
-      const lifecycle = await database.evaluateHandle(async (store) => {
-        const connection = await store.openControlUiDatabase();
-        return {
-          closed: new Promise<void>((resolve) =>
-            connection.addEventListener("close", () => resolve(), { once: true }),
-          ),
-        };
-      });
-      const protocol = await context.newCDPSession(page);
-      try {
-        await protocol.send("Storage.clearDataForOrigin", {
-          origin: new URL(suite.server.baseUrl).origin,
-          storageTypes: "indexeddb",
-        });
-        await lifecycle.evaluate((state) => state.closed);
-      } finally {
-        await protocol.detach();
-      }
-      const result = await draftStore.evaluate(async (store, destination) => {
-        const recovered = await store.prepareDurableComposerRecovery(destination);
-        const written = await store.writeDurableComposerDraft(
-          destination,
-          { revision: 1, text: "Draft after browser storage recovery", attachments: [] },
-          { expectedRevision: 0, writeId: "after-reopen" },
-        );
-        return { recovered, written, read: await store.readDurableComposerDraft(destination) };
-      }, scope);
-      expect(result).toMatchObject({
-        recovered: { status: "ready", entries: [] },
-        written: { status: "persisted" },
-        read: { status: "found", draft: { text: "Draft after browser storage recovery" } },
-      });
-    });
-  });
-
   it("does not reuse a cached composer owner while reconnect authentication is unresolved", async () => {
     await suite.withPage({ locale: "en-US", serviceWorkers: "block" }, async ({ page }) => {
       await installMockGateway(page);

--- a/ui/src/e2e/composer-draft-store.e2e.test.ts
+++ b/ui/src/e2e/composer-draft-store.e2e.test.ts
@@ -64,6 +64,64 @@ async function rawDraftRecords(page: Page, scopes: readonly TestDraftScope[], ex
 }
 
 suite.define(() => {
+  it("reopens composer storage after the browser forcibly closes its database", async () => {
+    await suite.withPage({ serviceWorkers: "block" }, async ({ context, page }) => {
+      await page.route("**/composer-storage-reopen", (route) =>
+        route.fulfill({ contentType: "text/html", body: "Composer storage recovery" }),
+      );
+      await page.goto(`${suite.server.baseUrl}composer-storage-reopen`);
+      const draftStore = await page.evaluateHandle<
+        typeof import("../lib/chat/composer-draft-store.runtime.ts")
+      >('import("/src/lib/chat/composer-draft-store.runtime.ts")');
+      const scope = {
+        gatewayOwner: "reopen-gateway",
+        recoveryScope: "reopen-owner",
+        scopeKey: "chat:v3:agent:main:reopen\u0000agent:main",
+      };
+      expect(
+        await draftStore.evaluate(
+          (store, destination) => store.prepareDurableComposerRecovery(destination),
+          scope,
+        ),
+      ).toEqual({ status: "ready", entries: [] });
+      const database = await page.evaluateHandle<
+        typeof import("../lib/chat/control-ui-database.runtime.ts")
+      >('import("/src/lib/chat/control-ui-database.runtime.ts")');
+      const lifecycle = await database.evaluateHandle(async (store) => {
+        const connection = await store.openControlUiDatabase();
+        return {
+          closed: new Promise<void>((resolve) =>
+            connection.addEventListener("close", () => resolve(), { once: true }),
+          ),
+        };
+      });
+      const protocol = await context.newCDPSession(page);
+      try {
+        await protocol.send("Storage.clearDataForOrigin", {
+          origin: new URL(suite.server.baseUrl).origin,
+          storageTypes: "indexeddb",
+        });
+        await lifecycle.evaluate((state) => state.closed);
+      } finally {
+        await protocol.detach();
+      }
+      const result = await draftStore.evaluate(async (store, destination) => {
+        const recovered = await store.prepareDurableComposerRecovery(destination);
+        const written = await store.writeDurableComposerDraft(
+          destination,
+          { revision: 1, text: "Draft after browser storage recovery", attachments: [] },
+          { expectedRevision: 0, writeId: "after-reopen" },
+        );
+        return { recovered, written, read: await store.readDurableComposerDraft(destination) };
+      }, scope);
+      expect(result).toMatchObject({
+        recovered: { status: "ready", entries: [] },
+        written: { status: "persisted" },
+        read: { status: "found", draft: { text: "Draft after browser storage recovery" } },
+      });
+    });
+  });
+
   it("does not reuse a cached composer owner while reconnect authentication is unresolved", async () => {
     await suite.withPage({ locale: "en-US", serviceWorkers: "block" }, async ({ page }) => {
       await installMockGateway(page);

--- a/ui/src/e2e/composer-recovery-fences.e2e.test.ts
+++ b/ui/src/e2e/composer-recovery-fences.e2e.test.ts
@@ -1,5 +1,6 @@
 import { expect, it } from "vitest";
 import type { ChatQueueItem } from "../lib/chat/chat-types.ts";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import {
   waitForControlUiGatewayReady,
   waitForControlUiGatewayReconnecting,
@@ -17,6 +18,57 @@ const suite = createControlUiE2eSuite({
 });
 
 suite.define(() => {
+  it("shows a storage failure without claiming there are messages missing destinations", async () => {
+    await suite.withPage(
+      { locale: "en-US", serviceWorkers: "block", viewport: { width: 1000, height: 700 } },
+      async ({ page }) => {
+        await installMockGateway(page);
+        await page.goto(`${suite.server.baseUrl}settings`);
+        await page.evaluate(() => {
+          IDBFactory.prototype.open = () => {
+            throw new DOMException("Storage unavailable", "UnknownError");
+          };
+        });
+        await page.evaluate('import("/src/pages/chat/chat-outbox-recovery.ts")');
+        await page.evaluate(() => {
+          const component = Object.assign(document.createElement("openclaw-chat-outbox-recovery"), {
+            host: {
+              settings: { gatewayUrl: "ws://recovery-error.test" },
+              connected: true,
+              client: { recoveryScopeReady: true, recoveryScope: "owner" },
+              sessionKey: "agent:main:main",
+              chatMessage: "",
+              chatAttachments: [],
+              chatQueue: [],
+            },
+            identity: "storage-error",
+          });
+          const stage = document.createElement("main");
+          stage.style.cssText = "position:fixed;inset:0;z-index:100;background:var(--bg)";
+          stage.append(component);
+          document.body.append(stage);
+        });
+        const notice = page.locator(".chat-outbox-recovery");
+        await notice.locator("summary").click();
+        await notice.getByRole("alert").waitFor();
+        if (process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim()) {
+          const artifacts = createControlUiE2eArtifactDir("recovery-error");
+          await page.screenshot({ path: `${artifacts}/expanded.png`, animations: "disabled" });
+          await page.setViewportSize({ width: 390, height: 700 });
+          await page.screenshot({ path: `${artifacts}/mobile.png`, animations: "disabled" });
+        }
+        expect((await notice.locator("summary").textContent())?.trim()).toBe(
+          "Saved messages could not be loaded",
+        );
+        expect(await notice.textContent()).not.toContain("older browser");
+        expect(await notice.textContent()).not.toContain("Free browser storage");
+        expect(await notice.getByRole("button", { name: "Restore here for review" }).count()).toBe(
+          0,
+        );
+      },
+    );
+  });
+
   it("commits an independent offline split-pane draft after submit, remove and reorder", async () => {
     await suite.withPage(
       { locale: "en-US", serviceWorkers: "block", viewport: { width: 1440, height: 1000 } },

--- a/ui/src/e2e/composer-recovery-fences.e2e.test.ts
+++ b/ui/src/e2e/composer-recovery-fences.e2e.test.ts
@@ -18,6 +18,64 @@ const suite = createControlUiE2eSuite({
 });
 
 suite.define(() => {
+  it("reopens composer storage after the browser forcibly closes its database", async () => {
+    await suite.withPage({ serviceWorkers: "block" }, async ({ context, page }) => {
+      await page.route("**/composer-storage-reopen", (route) =>
+        route.fulfill({ contentType: "text/html", body: "Composer storage recovery" }),
+      );
+      await page.goto(`${suite.server.baseUrl}composer-storage-reopen`);
+      const draftStore = await page.evaluateHandle<
+        typeof import("../lib/chat/composer-draft-store.runtime.ts")
+      >('import("/src/lib/chat/composer-draft-store.runtime.ts")');
+      const scope = {
+        gatewayOwner: "reopen-gateway",
+        recoveryScope: "reopen-owner",
+        scopeKey: "chat:v3:agent:main:reopen\u0000agent:main",
+      };
+      expect(
+        await draftStore.evaluate(
+          (store, destination) => store.prepareDurableComposerRecovery(destination),
+          scope,
+        ),
+      ).toEqual({ status: "ready", entries: [] });
+      const database = await page.evaluateHandle<
+        typeof import("../lib/chat/control-ui-database.runtime.ts")
+      >('import("/src/lib/chat/control-ui-database.runtime.ts")');
+      const lifecycle = await database.evaluateHandle(async (store) => {
+        const connection = await store.openControlUiDatabase();
+        return {
+          closed: new Promise<void>((resolve) => {
+            connection.addEventListener("close", () => resolve(), { once: true });
+          }),
+        };
+      });
+      const protocol = await context.newCDPSession(page);
+      try {
+        await protocol.send("Storage.clearDataForOrigin", {
+          origin: new URL(suite.server.baseUrl).origin,
+          storageTypes: "indexeddb",
+        });
+        await lifecycle.evaluate((state) => state.closed);
+      } finally {
+        await protocol.detach();
+      }
+      const result = await draftStore.evaluate(async (store, destination) => {
+        const recovered = await store.prepareDurableComposerRecovery(destination);
+        const written = await store.writeDurableComposerDraft(
+          destination,
+          { revision: 1, text: "Draft after browser storage recovery", attachments: [] },
+          { expectedRevision: 0, writeId: "after-reopen" },
+        );
+        return { recovered, written, read: await store.readDurableComposerDraft(destination) };
+      }, scope);
+      expect(result).toMatchObject({
+        recovered: { status: "ready", entries: [] },
+        written: { status: "persisted" },
+        read: { status: "found", draft: { text: "Draft after browser storage recovery" } },
+      });
+    });
+  });
+
   it("shows a storage failure without claiming there are messages missing destinations", async () => {
     await suite.withPage(
       { locale: "en-US", serviceWorkers: "block", viewport: { width: 1000, height: 700 } },

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -5161,15 +5161,16 @@ export const en: TranslationMap & {
       description: "The earlier conversation was cleared.",
     },
     outboxRecoveryTitle: "Saved messages need a destination",
+    outboxRecoveryFailedTitle: "Saved messages could not be loaded",
     outboxRecoveryDescription:
-      "An older browser version did not preserve every destination. These drafts and queued messages have not been sent by recovery. Open an empty non-Incognito conversation, then restore an entry here for review. Attachment drafts may appear separately.",
+      "These saved drafts and queued messages need a conversation. Open an empty non-Incognito conversation, then restore an entry for review. Nothing is sent automatically. Attachment drafts may appear separately.",
     outboxRecoveryConfirm:
       "Confirm this destination for the saved entry. Queued messages will remain paused for review and Retry. If delivery was uncertain, check the conversation before retrying.",
     outboxRecoveryRestore: "Restore here for review",
     outboxRecoveryConflict:
       "This destination has a newer draft or queue, or changed during confirmation. Open an empty conversation and try again. The saved entry is still available.",
     outboxRecoveryStorageFailed:
-      "Browser storage could not complete recovery. The original saved data has been retained. Free browser storage and reload to try again.",
+      "Your saved data has been kept. Reload to try again. If the problem continues, check that browser storage is available. Do not clear site data while you have messages to recover.",
     outboxRecoveryFull:
       "Recovery is full. Restore saved entries to make room; remaining legacy data is still retained in this browser.",
     outboxRecoveryMessages: "Queued messages: {count}",

--- a/ui/src/lib/chat/control-ui-database.runtime.ts
+++ b/ui/src/lib/chat/control-ui-database.runtime.ts
@@ -39,7 +39,12 @@ export function openControlUiDatabase(): Promise<IDBDatabase> {
   if (databasePromise) {
     return databasePromise;
   }
-  databasePromise = new Promise((resolve, reject) => {
+  const opening = new Promise<IDBDatabase>((resolve, reject) => {
+    const release = () => {
+      if (databasePromise === opening) {
+        databasePromise = null;
+      }
+    };
     if (typeof indexedDB === "undefined") {
       reject(new Error("IndexedDB is unavailable"));
       return;
@@ -68,12 +73,14 @@ export function openControlUiDatabase(): Promise<IDBDatabase> {
         const database = request.result;
         if (blocked) {
           database.close();
-          databasePromise = null;
+          release();
           return;
         }
+        // Browser-forced closure does not emit versionchange; never reuse its dead handle.
+        database.addEventListener("close", release, { once: true });
         database.addEventListener("versionchange", () => {
           database.close();
-          databasePromise = null;
+          release();
         });
         resolve(database);
       },
@@ -82,7 +89,7 @@ export function openControlUiDatabase(): Promise<IDBDatabase> {
     request.addEventListener(
       "error",
       () => {
-        databasePromise = null;
+        release();
         reject(indexedDbError(request.error, "IndexedDB open failed"));
       },
       { once: true },
@@ -98,5 +105,6 @@ export function openControlUiDatabase(): Promise<IDBDatabase> {
       { once: true },
     );
   });
-  return databasePromise;
+  databasePromise = opening;
+  return opening;
 }

--- a/ui/src/pages/chat/chat-outbox-recovery.ts
+++ b/ui/src/pages/chat/chat-outbox-recovery.ts
@@ -1,5 +1,6 @@
 import { html, LitElement, nothing, type PropertyValues } from "lit";
 import { showConfirmDialog } from "../../components/confirm-dialog.ts";
+import "../../styles/chat/outbox-recovery.css";
 import { t } from "../../i18n/index.ts";
 import type { DurableComposerRecoveryEntry } from "../../lib/chat/composer-draft-store.runtime.ts";
 import {
@@ -183,43 +184,48 @@ class ChatOutboxRecovery extends LitElement {
       return nothing;
     }
     const rows = [...this.entries, ...this.drafts];
-    return html`<details
-      class="callout warn chat-outbox-recovery"
-      style="max-height: 40vh; overflow: auto"
-    >
-      <summary>${t("chat.outboxRecoveryTitle")} (${rows.length})</summary>
-      <p>${t("chat.outboxRecoveryDescription")}</p>
-      ${this.error ? html`<p role="alert">${this.error}</p>` : nothing}
-      ${rows.map(
-        (entry) => html`<div class="chat-outbox-recovery-row">
-          <p>
-            ${
-              "id" in entry
-                ? [entry.session.draft, ...(entry.session.queue ?? []).map((item) => item.text)]
-                    .filter(Boolean)
-                    .join(" · ")
-                    .slice(0, 240)
-                : entry.text.slice(0, 240)
-            }
-          </p>
-          <p>
-            ${
-              "id" in entry
-                ? t("chat.outboxRecoveryMessages", {
-                    count: String(entry.session.queue?.length ?? 0),
-                  })
-                : entry.attachmentNames.join(", ").slice(0, 240)
-            }
-          </p>
-          <button
-            class="btn"
-            ?disabled=${this.busy || !this.owner()}
-            @click=${() => void this.recover(entry)}
-          >
-            ${t("chat.outboxRecoveryRestore")}
-          </button>
-        </div>`,
-      )}
+    return html`<details class="chat-outbox-recovery">
+      <summary>
+        ${rows.length ? t("chat.outboxRecoveryTitle") : t("chat.outboxRecoveryFailedTitle")}${
+          rows.length
+            ? html` <span class="chat-outbox-recovery__count">${rows.length}</span>`
+            : nothing
+        }
+      </summary>
+      <div class="chat-outbox-recovery__content">
+        ${rows.length ? html`<p>${t("chat.outboxRecoveryDescription")}</p>` : nothing}
+        ${this.error ? html`<p class="chat-outbox-recovery__error" role="alert">${this.error}</p>` : nothing}
+        ${rows.map(
+          (entry) => html`<div class="chat-outbox-recovery-row">
+            <p>
+              ${
+                "id" in entry
+                  ? [entry.session.draft, ...(entry.session.queue ?? []).map((item) => item.text)]
+                      .filter(Boolean)
+                      .join(" · ")
+                      .slice(0, 240)
+                  : entry.text.slice(0, 240)
+              }
+            </p>
+            <p>
+              ${
+                "id" in entry
+                  ? t("chat.outboxRecoveryMessages", {
+                      count: String(entry.session.queue?.length ?? 0),
+                    })
+                  : entry.attachmentNames.join(", ").slice(0, 240)
+              }
+            </p>
+            <button
+              class="btn"
+              ?disabled=${this.busy || !this.owner()}
+              @click=${() => void this.recover(entry)}
+            >
+              ${t("chat.outboxRecoveryRestore")}
+            </button>
+          </div>`,
+        )}
+      </div>
     </details>`;
   }
 }

--- a/ui/src/styles/chat/outbox-recovery.css
+++ b/ui/src/styles/chat/outbox-recovery.css
@@ -1,0 +1,62 @@
+.chat-outbox-recovery {
+  margin: 12px 16px;
+  max-height: 40vh;
+  overflow: auto;
+  border: 1px solid color-mix(in srgb, var(--warn) 28%, var(--border));
+  border-radius: var(--radius-md);
+  background: color-mix(in srgb, var(--warn) 6%, var(--bg-elevated));
+  color: var(--text);
+  font-size: 13px;
+  line-height: 1.5;
+  overflow-wrap: anywhere;
+}
+
+.chat-outbox-recovery > summary {
+  padding: 12px 16px;
+  color: var(--text-strong);
+  font-weight: 600;
+}
+
+.chat-outbox-recovery > summary::marker {
+  color: var(--warn);
+}
+
+.chat-outbox-recovery__count {
+  display: inline-block;
+  margin-inline-start: 6px;
+  padding: 1px 7px;
+  border-radius: var(--radius-sm);
+  background: color-mix(in srgb, var(--warn) 12%, transparent);
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+}
+
+.chat-outbox-recovery__content {
+  display: grid;
+  gap: 12px;
+  padding: 0 16px 16px;
+  user-select: text;
+}
+
+.chat-outbox-recovery__content p {
+  margin: 0;
+}
+
+.chat-outbox-recovery__error {
+  color: var(--muted);
+}
+
+.chat-outbox-recovery-row {
+  display: grid;
+  justify-items: start;
+  gap: 8px;
+  min-width: 0;
+  padding-top: 12px;
+  border-top: 1px solid var(--border);
+}
+
+.chat-outbox-recovery-row .btn {
+  max-width: 100%;
+  white-space: normal;
+  text-align: start;
+}


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users returning to an open Control UI could get a persistent saved-message recovery error after the browser closed its IndexedDB connection. The banner incorrectly suggested an older browser had lost message destinations and that storage was full, even when it displayed zero recovery entries. It also ran into the pane edges with no outer spacing.

## Why This Change Was Made

The shared draft/outbox database owner now releases its cached connection on the browser's native `close` event. Later operations reopen storage; callbacks from an older connection cannot invalidate a replacement. The database schema, stored records, and recovery/send rules are unchanged.

The recovery notice now distinguishes a load failure from actual entries needing a destination. It has an inset card, padded disclosure and content, separated entries, wrapping buttons, and a count only when entries exist. Error guidance asks for a reload without claiming storage capacity is the cause.

## User Impact

Draft recovery, draft saving, and attachment storage can resume after a browser-forced connection closure without staying stuck on a dead handle. Real recovery entries remain available for explicit review and are never sent automatically by recovery.

## Evidence

- Live Chrome diagnosis: valid current-format metadata, zero recovery entries, and a cached database whose read-only transaction throws `InvalidStateError: The database connection is closing.` The browser action that originally closed the connection was not identified.
- A real Chromium regression forces a native database closure in an isolated, empty test origin. Recovery, write, and read all fail before the fix and succeed afterward.
- 78 focused tests passed: 69 storage/outbox tests, 8 recovery UI/ownership E2E tests, and the existing blocked-upgrade attachment-retention E2E.
- Production Control UI build, typechecks, i18n verification, unused-export scans, lint and styles passed. Independent review found no actionable P0–P2 issues; diff-scoped deslop is complete. A test-file size violation was resolved by keeping the new regression in the focused recovery suite.
- Initial merge-ref CI encountered the unrelated `retainedMachine` type error already fixed by #145540. Rebased onto current main with both recovery commits verified unchanged by `git range-diff`.
- Exact-head required PR CI passed: [run 34669975881](https://github.com/openclaw/openclaw/actions/runs/34669975881).
- A [broader hosted fallback](https://github.com/openclaw/openclaw/actions/runs/34670927841) was started while 34 Blacksmith jobs were unassigned. It exposed an unchanged Android diagnostic test timing race (missing `probe.pid` after its one-second deadline); the normal required PR run passed. The redundant fallback was canceled once that required run succeeded. No repository-wide runner settings were changed.
- Synthetic visual proof inspected at desktop and 390px mobile widths.

Before:

![Before: misleading zero-entry recovery warning touching the pane edges](https://github.com/user-attachments/assets/f2f89968-1a40-4f20-810c-9c35c8a978b2)

After:

![After: padded recovery error with accurate guidance](https://github.com/user-attachments/assets/a57499dd-de2b-4f91-9e27-cd31d23d92f5)

Mobile:

![Mobile: recovery error with readable wrapping and padding](https://github.com/user-attachments/assets/799fa913-9a80-4003-b26e-ef233fe9c769)
