### PR TITLE
fix(doctor): make the Workshop tool-policy diagnostic honor the sandbox construction gate and name it in the runtime error

### DIFF
--- a/docs/tools/skill-workshop/troubleshooting.md
+++ b/docs/tools/skill-workshop/troubleshooting.md
@@ -56,8 +56,19 @@ and [Downgrade recovery](/reference/database-schemas#downgrade-recovery).
 ### Tool-policy diagnostic
 
 In `propose` and `auto` modes, `openclaw doctor` runs the
-`core/doctor/skill-workshop-tool-policy` check for the default agent. If policy
-hides `skill_workshop`, the warning names the first excluding config layer and
-the exact `allow` or `alsoAllow` change to make. Older runbooks may still use
+`core/doctor/skill-workshop-tool-policy` check for each configured agent. Doctor
+checks the sandbox construction gate before tool policy: sandboxed runs without
+host-granted library-authoring authority do not construct `skill_workshop`, even
+when `alsoAllow` lists it. The warning names the effective sandbox setting and
+recommends a non-sandboxed session, a human turn with library-authoring authority,
+or the `openclaw skills workshop` CLI. For `non-main` mode, this restriction applies
+to non-main sessions. Library authority is granted by the host for an authenticated
+human turn; it is not an allowlist entry or a permission autonomous reviews can
+grant themselves. See [Personal library authoring](/tools/skill-workshop/personal-library).
+
+When the tool can be constructed but policy hides it, the warning names the first
+excluding config layer and the exact `allow` or `alsoAllow` change to make. A run
+whose explicit allowlist leaves no callable tools also names the sandbox gate
+when it excludes the requested Workshop tool. Older runbooks may still use
 `openclaw plugins inspect skill-workshop`; that command now explains that Skill
 Workshop is built in and prints the same policy hint when applicable.

--- a/src/agents/embedded-agent-runner/run/attempt-tool-catalog.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-tool-catalog.ts
@@ -209,6 +209,10 @@ export function prepareEmbeddedAttemptToolCatalog(input: {
           toolsEnabled,
           disableTools: attempt.disableTools,
           toolsAllowExplicitlyEmpty: preparedToolBase.effectiveToolsAllow?.length === 0,
+          skillWorkshop: {
+            sandboxed: input.setup.sandbox?.enabled,
+            libraryAuthoring: attempt.skillLibraryAuthoring,
+          },
         });
     logAgentRuntimeToolDiagnostics({
       runtimePlan: attempt.runtimePlan,

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -7,6 +7,7 @@ import { isEmbeddedMode } from "../infra/embedded-mode.js";
 import { getActiveSecretsRuntimeConfigSnapshot } from "../secrets/runtime-state.js";
 import { getActiveRuntimeWebToolsMetadataFromState } from "../secrets/runtime-web-tools-state.js";
 import { isCronRunSessionKey } from "../sessions/session-key-utils.js";
+import { resolveSkillWorkshopToolConstructionBlock } from "../skills/workshop/tool-availability.js";
 import { resolveAgentWorkspaceDir, resolveSessionAgentIds } from "./agent-scope.js";
 import { finalizeAgentToolAvailability } from "./agent-tool-availability.js";
 import { bindAssembledAgentToolActionDescriptor } from "./agent-tool-metadata.js";
@@ -482,7 +483,10 @@ export function createOpenClawTools(options?: OpenClawToolsOptions): AnyAgentToo
       sessionAgentId,
       config: resolvedConfig,
     }),
-    ...((options?.sandboxed && !options.skillWorkshop?.libraryAuthoring) || !resolvedConfig
+    ...(resolveSkillWorkshopToolConstructionBlock({
+      sandboxed: options?.sandboxed,
+      libraryAuthoring: options?.skillWorkshop?.libraryAuthoring,
+    }) || !resolvedConfig
       ? []
       : [
           createConfiguredSkillWorkshopTool({

--- a/src/agents/tool-allowlist-guard.test.ts
+++ b/src/agents/tool-allowlist-guard.test.ts
@@ -7,6 +7,51 @@ import {
 } from "./tool-allowlist-guard.js";
 
 describe("tool allowlist guard", () => {
+  it.each([
+    {
+      entries: ["skill_workshop"],
+      toolsEnabled: true,
+      disableTools: false,
+      expected: "sandboxed run without library-authoring authority",
+    },
+    {
+      entries: ["skill_*"],
+      toolsEnabled: true,
+      disableTools: false,
+      expected: "sandboxed run without library-authoring authority",
+    },
+    {
+      entries: ["query_db"],
+      toolsEnabled: true,
+      disableTools: false,
+      expected: "no registered tools matched",
+    },
+    {
+      entries: ["skill_workshop"],
+      toolsEnabled: false,
+      disableTools: false,
+      expected: "selected model does not support tools",
+    },
+    {
+      entries: ["skill_workshop"],
+      toolsEnabled: true,
+      disableTools: true,
+      expected: "tools are disabled for this run",
+    },
+  ])(
+    "reports the relevant gate for $entries (enabled=$toolsEnabled, disabled=$disableTools)",
+    ({ entries, toolsEnabled, disableTools, expected }) => {
+      const input = {
+        sources: [{ label: "runtime toolsAllow", entries, enforceWhenToolsDisabled: true }],
+        hasCallableTools: false,
+        toolsEnabled,
+        disableTools,
+        skillWorkshop: { sandboxed: true },
+      };
+      expect(buildEmptyExplicitToolAllowlistError(input)?.message).toContain(expected);
+    },
+  );
+
   it("fails closed when explicit allowlists resolve to no callable tools", () => {
     const error = buildEmptyExplicitToolAllowlistError({
       sources: [{ label: "tools.allow", entries: [" query_db "] }],

--- a/src/agents/tool-allowlist-guard.ts
+++ b/src/agents/tool-allowlist-guard.ts
@@ -4,6 +4,11 @@
  * Collects operator/user allowlist sources and explains when no callable tools remain.
  */
 import { normalizeStringEntries } from "@openclaw/normalization-core/string-normalization";
+import {
+  resolveSkillWorkshopToolConstructionBlock,
+  type SkillWorkshopToolConstructionContext,
+} from "../skills/workshop/tool-availability.js";
+import { isToolAllowedByPolicyName } from "./tool-policy-match.js";
 import { normalizeToolPolicyName } from "./tool-policy.js";
 
 type ExplicitToolAllowlistSource = {
@@ -38,6 +43,7 @@ export function buildEmptyExplicitToolAllowlistError(params: {
   toolsEnabled: boolean;
   disableTools?: boolean;
   toolsAllowExplicitlyEmpty?: boolean;
+  skillWorkshop?: SkillWorkshopToolConstructionContext;
 }): Error | null {
   const toolsIntentionallyDisabled =
     params.disableTools === true || params.toolsAllowExplicitlyEmpty === true;
@@ -50,6 +56,18 @@ export function buildEmptyExplicitToolAllowlistError(params: {
   const requested = sources
     .map((source) => `${source.label}: ${source.entries.map(normalizeToolPolicyName).join(", ")}`)
     .join("; ");
+  const workshopBlock =
+    params.skillWorkshop &&
+    sources.every((source) =>
+      isToolAllowedByPolicyName("skill_workshop", { allow: source.entries }),
+    )
+      ? resolveSkillWorkshopToolConstructionBlock(params.skillWorkshop)
+      : undefined;
+  if (params.toolsEnabled && !toolsIntentionallyDisabled && workshopBlock) {
+    return new Error(
+      `No callable tools remain after resolving explicit tool allowlist (${requested}); ${workshopBlock.detail} ${workshopBlock.fix}`,
+    );
+  }
   const reason =
     params.disableTools === true
       ? "tools are disabled for this run"

--- a/src/agents/tools/skill-workshop-tool.availability.test.ts
+++ b/src/agents/tools/skill-workshop-tool.availability.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it, onTestFinished, vi } from "vitest";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import type { SkillLibraryAuthoringCapability } from "../../skills/library/authoring.js";
+import { createOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
+import { createOpenClawCodingTools } from "../agent-tools.js";
+import {
+  applyEmbeddedAttemptToolsAllow,
+  resolveEmbeddedAttemptToolConstructionPlan,
+} from "../embedded-agent-runner/run/attempt-tool-construction-plan.js";
+import { createAgentToolsSandboxContext } from "../test-helpers/agent-tools-sandbox-context.js";
+import { buildEmptyExplicitToolAllowlistError } from "../tool-allowlist-guard.js";
+
+vi.mock("../openclaw-plugin-tools.js", () => ({
+  resolveOpenClawPluginToolsForOptions: () => [],
+}));
+
+describe("Workshop construction and runtime allowlist", () => {
+  it.each([
+    { label: "host", sandboxed: false, authorizedLibrary: false },
+    { label: "sandbox", sandboxed: true, authorizedLibrary: false },
+    { label: "authorized library", sandboxed: true, authorizedLibrary: true },
+  ])("resolves a minimal-profile $label turn", async ({ sandboxed, authorizedLibrary }) => {
+    const state = await createOpenClawTestState({
+      prefix: "openclaw-workshop-availability-",
+      applyEnv: true,
+    });
+    onTestFinished(async () => await state.cleanup());
+    const config: OpenClawConfig = {
+      agents: {
+        entries: {
+          main: {
+            default: true,
+            workspace: state.workspaceDir,
+            sandbox: { mode: sandboxed ? "all" : "off" },
+            tools: { profile: "minimal", alsoAllow: ["skill_workshop"] },
+          },
+        },
+      },
+    };
+    const libraryAuthoring: SkillLibraryAuthoringCapability | undefined = authorizedLibrary
+      ? {
+          target: "personal",
+          defaultTarget: "personal",
+          multipleProfiles: true,
+          bind: () => {},
+          invoke: async () => {
+            throw new Error("This test only constructs the library tool");
+          },
+        }
+      : undefined;
+    const constructionPlan = resolveEmbeddedAttemptToolConstructionPlan({
+      toolsEnabled: true,
+      toolsAllow: ["skill_workshop"],
+    });
+    const tools = applyEmbeddedAttemptToolsAllow(
+      createOpenClawCodingTools({
+        config,
+        agentId: "main",
+        sessionKey: "agent:main:cron:workshop-review",
+        workspaceDir: state.workspaceDir,
+        agentDir: state.agentDir(),
+        runtimeToolAllowlist: ["skill_workshop"],
+        toolConstructionPlan: constructionPlan.codingToolConstructionPlan,
+        wrapBeforeToolCallHook: false,
+        skillWorkshop: { libraryAuthoring },
+        ...(sandboxed
+          ? { sandbox: createAgentToolsSandboxContext({ workspaceDir: state.workspaceDir }) }
+          : {}),
+      }),
+      ["skill_workshop"],
+    );
+    const guardInput = {
+      sources: [{ label: "runtime toolsAllow", entries: ["skill_workshop"] }],
+      hasCallableTools: tools.length > 0,
+      toolsEnabled: true,
+      skillWorkshop: { sandboxed, libraryAuthoring },
+    };
+    const error = buildEmptyExplicitToolAllowlistError(guardInput);
+
+    if (sandboxed && !authorizedLibrary) {
+      expect(tools).toEqual([]);
+      expect(error?.message).toContain("sandboxed run without library-authoring authority");
+      expect(error?.message).toContain("non-sandboxed session");
+      expect(error?.message).not.toContain("no registered tools matched");
+      expect(error?.message).not.toContain("enable the plugin");
+      return;
+    }
+    expect(error).toBeNull();
+    expect(tools.map((tool) => tool.name)).toEqual(["skill_workshop"]);
+    if (!authorizedLibrary) {
+      expect(
+        (await tools[0]?.execute("list-proposals", { action: "list" }))?.details,
+      ).toMatchObject({ proposals: [] });
+    }
+  });
+});

--- a/src/skills/workshop/tool-availability.ts
+++ b/src/skills/workshop/tool-availability.ts
@@ -1,0 +1,20 @@
+import type { SkillLibraryAuthoringCapability } from "../library/authoring.js";
+
+export type SkillWorkshopToolConstructionContext = {
+  sandboxed?: boolean;
+  libraryAuthoring?: SkillLibraryAuthoringCapability;
+};
+
+/** Host-side Workshop access requires an unsandboxed run or a host-issued library capability. */
+export function resolveSkillWorkshopToolConstructionBlock(
+  context: SkillWorkshopToolConstructionContext,
+): { detail: string; fix: string } | undefined {
+  if (context.sandboxed && !context.libraryAuthoring) {
+    return {
+      detail:
+        '"skill_workshop" is unavailable in a sandboxed run without library-authoring authority.',
+      fix: "Use a non-sandboxed session for this agent, or a human turn with host-granted library-authoring authority. The openclaw skills workshop CLI is also available.",
+    };
+  }
+  return undefined;
+}

--- a/src/skills/workshop/tool-policy-diagnostic.test.ts
+++ b/src/skills/workshop/tool-policy-diagnostic.test.ts
@@ -15,6 +15,60 @@ function detect(config: OpenClawConfig, workshopEnabled = true) {
 }
 
 describe("detectSkillWorkshopToolPolicyDiagnostic", () => {
+  it.each([false, true])(
+    "reports the sandbox construction gate before profile advice (alsoAllow=%s)",
+    (alsoAllow) => {
+      const diagnostic = detect({
+        agents: {
+          entries: {
+            main: {
+              sandbox: { mode: "all" },
+              tools: {
+                profile: "minimal",
+                ...(alsoAllow ? { alsoAllow: ["skill_workshop"] } : {}),
+              },
+            },
+          },
+        },
+      });
+
+      expect(diagnostic).toMatchObject({ source: "agents.entries.main.sandbox.mode" });
+      expect(diagnostic?.detail).toContain("sandboxed run without library-authoring authority");
+      expect(diagnostic?.fix).toContain("non-sandboxed session");
+      expect(diagnostic?.fix).toContain("host-granted library-authoring authority");
+      expect(diagnostic?.fix).not.toContain("alsoAllow");
+    },
+  );
+
+  it("identifies inherited sandbox mode and limits non-main advice to those sessions", () => {
+    const diagnostic = detect({
+      agents: {
+        defaults: { sandbox: { mode: "non-main" } },
+        entries: { main: { tools: { profile: "minimal", alsoAllow: ["skill_workshop"] } } },
+      },
+    });
+
+    expect(diagnostic).toMatchObject({ source: "agents.defaults.sandbox.mode" });
+    expect(diagnostic?.detail).toContain("In non-main sessions");
+    expect(diagnostic?.fix).not.toContain("alsoAllow");
+  });
+
+  it("honors an agent's unsandboxed override of the inherited mode", () => {
+    expect(
+      detect({
+        agents: {
+          defaults: { sandbox: { mode: "all" } },
+          entries: {
+            main: {
+              sandbox: { mode: "off" },
+              tools: { profile: "minimal", alsoAllow: ["skill_workshop"] },
+            },
+          },
+        },
+      }),
+    ).toBeNull();
+  });
+
   it("names the profile and exact additive grant when policy excludes the tool", () => {
     expect(detect({ tools: { profile: "messaging" } })).toMatchObject({
       source: "tools.profile",

--- a/src/skills/workshop/tool-policy-diagnostic.ts
+++ b/src/skills/workshop/tool-policy-diagnostic.ts
@@ -7,12 +7,14 @@ import {
 import { applyFinalEffectiveToolPolicy } from "../../agents/embedded-agent-runner/effective-tool-policy.js";
 import { resolveDefaultModelForAgent } from "../../agents/model-selection.js";
 import { resolveProviderToolPolicyEntry } from "../../agents/provider-tool-policy.js";
+import { resolveSandboxConfigForAgent } from "../../agents/sandbox/config.js";
 import { isToolAllowedByPolicyName } from "../../agents/tool-policy-match.js";
 import type { ToolPolicyFilterEvent } from "../../agents/tool-policy-pipeline.js";
 import type { AnyAgentTool } from "../../agents/tools/common.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { AgentToolsConfig } from "../../config/types.tools.js";
 import { normalizeAgentId } from "../../routing/session-key.js";
+import { resolveSkillWorkshopToolConstructionBlock } from "./tool-availability.js";
 
 const SKILL_WORKSHOP_TOOL_NAME = "skill_workshop";
 
@@ -29,11 +31,11 @@ type AgentToolsLocation = {
   tools: AgentToolsConfig;
 };
 
-function findAgentTools(config: OpenClawConfig, agentId: string): AgentToolsLocation | undefined {
+function findAgent(config: OpenClawConfig, agentId: string) {
   const listed = listAgentEntriesWithSource(config).find(
     ({ entry }) => normalizeAgentId(entry.id) === normalizeAgentId(agentId),
   );
-  if (!listed?.entry.tools) {
+  if (!listed) {
     return undefined;
   }
   // Report the canonical entries path; an id-less legacy list row (which
@@ -41,11 +43,11 @@ function findAgentTools(config: OpenClawConfig, agentId: string): AgentToolsLoca
   // remediation never points at agents.entries.undefined.
   const path =
     listed.source.kind === "entries"
-      ? `agents.entries.${listed.source.key}.tools`
+      ? `agents.entries.${listed.source.key}`
       : typeof listed.entry.id === "string" && listed.entry.id.length > 0
-        ? `agents.entries.${listed.entry.id}.tools`
-        : `agents.list[${listed.source.index}].tools`;
-  return { path, tools: listed.entry.tools };
+        ? `agents.entries.${listed.entry.id}`
+        : `agents.list[${listed.source.index}]`;
+  return { path, entry: listed.entry };
 }
 
 function providerPolicyPath(params: {
@@ -108,7 +110,10 @@ function describeExclusion(params: {
   event: ToolPolicyFilterEvent;
 }): Pick<SkillWorkshopToolPolicyDiagnostic, "source" | "detail" | "fix"> {
   const label = params.event.step.label;
-  const agent = findAgentTools(params.config, params.agentId);
+  const listed = findAgent(params.config, params.agentId);
+  const agent = listed?.entry.tools
+    ? { path: `${listed.path}.tools`, tools: listed.entry.tools }
+    : undefined;
   const globalProvider = providerPolicyPath({
     tools: params.config.tools,
     basePath: "tools",
@@ -231,6 +236,25 @@ export function detectSkillWorkshopToolPolicyDiagnostic(params: {
     return null;
   }
   const agentId = normalizeAgentId(params.agentId ?? resolveDefaultAgentId(params.config));
+  const prefix = `Skill Workshop is active, but ${JSON.stringify(SKILL_WORKSHOP_TOOL_NAME)} is hidden for agent ${JSON.stringify(agentId)}:`;
+  const sandbox = resolveSandboxConfigForAgent(params.config, agentId);
+  const constructionBlock = resolveSkillWorkshopToolConstructionBlock({
+    sandboxed: sandbox.mode !== "off",
+  });
+  if (constructionBlock) {
+    const agent = findAgent(params.config, agentId);
+    const source = agent?.entry.sandbox?.mode
+      ? `${agent.path}.sandbox.mode`
+      : "agents.defaults.sandbox.mode";
+    const detail = `${source}: ${JSON.stringify(sandbox.mode)}. ${sandbox.mode === "non-main" ? "In non-main sessions, " : ""}${constructionBlock.detail}`;
+    return {
+      agentId,
+      source,
+      detail,
+      fix: constructionBlock.fix,
+      message: `${prefix} ${detail} ${constructionBlock.fix}`,
+    };
+  }
   const model = resolveDefaultModelForAgent({ cfg: params.config, agentId });
   const capabilityProfile = resolveConversationCapabilityProfile({
     config: params.config,
@@ -251,7 +275,6 @@ export function detectSkillWorkshopToolPolicyDiagnostic(params: {
     capabilityProfile,
     event: availability.exclusion,
   });
-  const prefix = `Skill Workshop is active, but ${JSON.stringify(SKILL_WORKSHOP_TOOL_NAME)} is hidden for agent ${JSON.stringify(agentId)}:`;
   return {
     agentId,
     ...explanation,


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where operators following Doctor's Workshop advice could add `skill_workshop` to `alsoAllow`, receive no further diagnostic, and still get an empty-tool failure because the agent was sandboxed without library-authoring authority. The runtime error incorrectly suggested that no registered tools matched or that a plugin needed enabling.

Refs #145503 #144971. Thanks to @DeltaEcho3 for reporting the contradictory Doctor and runtime guidance.

## Why This Change Was Made

The existing sandbox construction gate now has one shared implementation used by the real tool factory, Doctor, and the runtime allowlist error. The sandbox restriction and its host-issued library-authoring exception retain their existing behavior. Doctor checks construction before recommending policy changes, names the effective sandbox setting, and scopes `non-main` advice to non-main sessions.

The runtime catalog supplies the actual sandbox and library-authoring context to the empty-allowlist guard. Its error names the Workshop construction gate only when the requested allowlists can include that tool; disabled-tool and unsupported-model errors retain precedence.

## User Impact

Operators see the actual prerequisite: use a non-sandboxed session, a human turn with host-granted library-authoring authority, or the Workshop CLI. Unsandboxed `minimal` agents still obtain and call the tool through `alsoAllow`. This does not grant new authority or alter profiles, configuration schemas, dependencies, migrations, or stored state.

Update behavior: the installed updater still runs first. These diagnostics take effect in the candidate's Doctor and runtime; there is no installed-driver patch or state migration.

## Evidence

- 108 tests passed across Workshop policy diagnostics, the allowlist guard, real tool construction, OpenClaw tool registration, Workshop tool behavior, and the Doctor health check.
- With only the production repair hunks removed, the Doctor/guard suites reported five expected regression failures: incorrect policy advice or no diagnostic, and the generic runtime error.
- The real-factory sandbox regression separately failed before the fix with `no registered tools matched`, then passed with `sandboxed run without library-authoring authority`. The unsandboxed control executed the real Workshop `list` action against isolated synthetic state; the existing library-authoring construction exception also passed.
- `node scripts/check-changed.mjs` passed, including production/test typechecks, lint, formatting, import-cycle checks, and the remaining guards. The initial new-test-root limit failure was resolved by placing the factory cases with the existing Workshop tool tests, without changing any limit.
- Landing verification: [CI run 34671468082](https://github.com/openclaw/openclaw/actions/runs/34671468082) completed successfully on the unchanged head. Its [check-test-types job](https://github.com/openclaw/openclaw/actions/runs/34671468082/job/103493747799) passed; the log records checkout `5bc76e4c76d486fb370fff7cb40c80f9f811da37`, and an ancestry check confirms that merge commit contains main fix `41861b8055af6088eac51ba82f1a9494b01bf8dd`. Two earlier attempts used stale merge `db45c17d20c7a5000515eeed24eaee1bfcd1837f` and encountered the unrelated UI `retainedMachine` TS2304 error. The lead refreshed CI; no source fixup or branch-head change was needed.
- Fresh independent P1 autoreview completed. Its final pass raised one finding about model-capability precedence in Doctor; rejected after verifying that the existing Doctor checker never evaluates model tool support. The runtime guard owns that precedence, and its unsupported-model/disabled-tools tests pass. No accepted actionable finding remains.

The new factory proof uses the real core construction plan, tool factory, layered policy, runtime allowlist filter, and error guard; only unrelated plugin discovery is stubbed. It is boundary proof, not a full provider turn.

The reporter [confirmed](https://github.com/openclaw/openclaw/issues/145503#issuecomment-5642879126) that their agent was not sandboxed and that Doctor recreated the obsolete collection-review job successfully. That separate stale-job incident is resolved. This PR addresses the remaining sandbox diagnostic gap and does not claim to fix the whole incident.


## ClawSweeper review

The completed revision-5 review of `bc7aacfa900433baa9e5d4e31673c53c939facf3` found no actionable defects and listed no Rank-up moves or before-merge items. No code fixups or skips were needed. The reporter-context clarification above incorporates its evidence; no re-review request is needed because the code is unchanged.
