### PR TITLE
fix(update): keep the candidate capability probe free of state migration so ownership never refuses it

### DIFF
--- a/docs/cli/update/how-updates-run.md
+++ b/docs/cli/update/how-updates-run.md
@@ -75,6 +75,12 @@ Candidate build and rehearsal processes resolve source-linked plugin SDKs from
 the candidate root, even when the serving source launcher passed its own checkout
 root. This keeps candidate assets and validation independent of the old checkout.
 
+The candidate answers the updater's native service capability probe before
+loading configuration or initializing debug capture. Probing capability does not
+open or migrate shared state, so the old Gateway can keep serving while its
+database schema is older than the candidate's. The installed updater runs first;
+this repair takes effect when the candidate it probes contains the fix.
+
 Snapshot preparation budgets time for the SQLite database and journal bytes,
 including copying and verification passes, with a five-minute startup floor.
 It uses the larger of that allowance and the configured per-step timeout.

--- a/src/cli/daemon-cli/update-capability.test.ts
+++ b/src/cli/daemon-cli/update-capability.test.ts
@@ -19,6 +19,7 @@ describe("early service capability routing", () => {
   it.each([
     ["gateway", "install"],
     ["gateway", "install", "--update-executor", "run"],
+    ["gateway", "install", "--update-executor", "--json", "check"],
     ["gateway", "install", "--update-executor", "check", "--update-executor", "run"],
     ["gateway", "install", "--token", "--update-executor", "check"],
     ["gateway", "install", "--", "--update-executor", "check"],

--- a/src/cli/daemon-cli/update-capability.test.ts
+++ b/src/cli/daemon-cli/update-capability.test.ts
@@ -1,0 +1,33 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { tryRunGatewayServiceUpdateCapabilityProbe } from "./update-capability.js";
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("early service capability routing", () => {
+  it.each([
+    ["gateway", "install", "--update-executor", "check", "--json"],
+    ["gateway", "restart", "--json", "--update-executor=check"],
+    ["daemon", "stop", "--update-executor", "check"],
+  ])("answers the machine probe %j", (...args) => {
+    const output = vi.spyOn(process.stdout, "write").mockReturnValue(true);
+    expect(tryRunGatewayServiceUpdateCapabilityProbe(["node", "openclaw", ...args])).toBe(true);
+    expect(output).toHaveBeenCalledExactlyOnceWith(
+      JSON.stringify({ updateExecutor: "root-spawner-v1", targetRootBinding: true }),
+    );
+  });
+
+  it.each([
+    ["gateway", "install"],
+    ["gateway", "install", "--update-executor", "run"],
+    ["gateway", "install", "--update-executor", "check", "--update-executor", "run"],
+    ["gateway", "install", "--token", "--update-executor", "check"],
+    ["gateway", "install", "--", "--update-executor", "check"],
+    ["gateway", "install", "--update-executor", "check", "--unknown"],
+    ["gateway", "status", "--update-executor", "check"],
+    ["plugin", "install", "--update-executor", "check"],
+  ])("leaves non-probes and validation to Commander: %j", (...args) => {
+    const output = vi.spyOn(process.stdout, "write").mockReturnValue(true);
+    expect(tryRunGatewayServiceUpdateCapabilityProbe(["node", "openclaw", ...args])).toBe(false);
+    expect(output).not.toHaveBeenCalled();
+  });
+});

--- a/src/cli/daemon-cli/update-capability.ts
+++ b/src/cli/daemon-cli/update-capability.ts
@@ -15,7 +15,11 @@ export function tryRunGatewayServiceUpdateCapabilityProbe(argv: string[]): boole
   ) {
     return false;
   }
-  const probe = options.filter((option) => option !== "--json");
+  // A JSON flag between the executor option and its mode is an invalid value.
+  const probe = options.slice(
+    options[0] === "--json" ? 1 : 0,
+    options.at(-1) === "--json" ? -1 : undefined,
+  );
   if (
     !(
       (probe.length === 2 && probe[0] === "--update-executor" && probe[1] === "check") ||

--- a/src/cli/daemon-cli/update-capability.ts
+++ b/src/cli/daemon-cli/update-capability.ts
@@ -1,0 +1,29 @@
+import { GATEWAY_UPDATE_EXECUTOR_CONTRACT } from "../../daemon/service-update-authority.js";
+
+export function writeGatewayServiceUpdateCapability(): void {
+  process.stdout.write(
+    JSON.stringify({ updateExecutor: GATEWAY_UPDATE_EXECUTOR_CONTRACT, targetRootBinding: true }),
+  );
+}
+
+/** The updater's machine probe must return before capture or config can open live state. */
+export function tryRunGatewayServiceUpdateCapabilityProbe(argv: string[]): boolean {
+  const [primary, action, ...options] = argv.slice(2);
+  if (
+    (primary !== "gateway" && primary !== "daemon") ||
+    (action !== "install" && action !== "restart" && action !== "stop")
+  ) {
+    return false;
+  }
+  const probe = options.filter((option) => option !== "--json");
+  if (
+    !(
+      (probe.length === 2 && probe[0] === "--update-executor" && probe[1] === "check") ||
+      (probe.length === 1 && probe[0] === "--update-executor=check")
+    )
+  ) {
+    return false;
+  }
+  writeGatewayServiceUpdateCapability();
+  return true;
+}

--- a/src/cli/daemon-cli/update-executor.ts
+++ b/src/cli/daemon-cli/update-executor.ts
@@ -1,14 +1,12 @@
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
-import {
-  GATEWAY_UPDATE_EXECUTOR_CONTRACT,
-  withGatewayServiceUpdateAuthority,
-} from "../../daemon/service-update-authority.js";
+import { withGatewayServiceUpdateAuthority } from "../../daemon/service-update-authority.js";
 import { resolveOpenClawPackageRoot } from "../../infra/openclaw-root.js";
 import { resolveUpdateInstallRoot } from "../../infra/update-install-root.js";
 import {
   withDelegatedUpdateCommandExecutor,
   type UpdateCommandChildGrant,
 } from "../update-cli/update-command-executor.js";
+import { writeGatewayServiceUpdateCapability } from "./update-capability.js";
 
 type NativeUpdateAction = "install" | "restart" | "stop";
 
@@ -24,9 +22,7 @@ export async function runGatewayServiceUpdateCommand(
     return;
   }
   if (mode === "check") {
-    process.stdout.write(
-      JSON.stringify({ updateExecutor: GATEWAY_UPDATE_EXECUTOR_CONTRACT, targetRootBinding: true }),
-    );
+    writeGatewayServiceUpdateCapability();
     return;
   }
   if (mode !== "run") {

--- a/src/cli/gateway-service-capability.process.test.ts
+++ b/src/cli/gateway-service-capability.process.test.ts
@@ -1,0 +1,141 @@
+import fs from "node:fs";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import {
+  createBuiltRuntime,
+  createSourceRuntime,
+  runBuiltRuntime,
+  runSourceRuntime,
+} from "../commands/doctor-config-preflight.process.test-support.js";
+import { resolveRuntimeWorkerUrl } from "../infra/runtime-worker-url.js";
+import {
+  acquireGatewayLifecycleCoordinator,
+  acquireStateDatabaseCoordinator,
+} from "../infra/state-database-coordinator.js";
+import { OPENCLAW_STATE_SCHEMA_VERSION } from "../state/openclaw-state-db-contract.js";
+import {
+  closeOpenClawStateDatabaseForTest,
+  openOpenClawStateDatabase,
+} from "../state/openclaw-state-db.js";
+import { cliRecoveryEntrypoints } from "./cli-entrypoint.test-support.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+function createFixture() {
+  const root = tempDirs.make("openclaw-service-capability-");
+  const stateDir = path.join(root, "state");
+  const configPath = path.join(root, "openclaw.json");
+  fs.writeFileSync(configPath, '{"gateway":{"mode":"local"}}\n');
+  const env = {
+    PATH: process.env.PATH,
+    HOME: root,
+    USERPROFILE: root,
+    OPENCLAW_HOME: root,
+    OPENCLAW_STATE_DIR: stateDir,
+    OPENCLAW_CONFIG_PATH: configPath,
+    OPENCLAW_NO_RESPAWN: "1",
+    NODE_DISABLE_COMPILE_CACHE: "1",
+    OPENCLAW_HIDE_BANNER: "1",
+    OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+    OPENCLAW_DEBUG_PROXY_ENABLED: "1",
+    OPENCLAW_UPDATE_IN_PROGRESS: "1",
+  };
+  const databasePath = openOpenClawStateDatabase({ env }).path;
+  closeOpenClawStateDatabaseForTest();
+  const legacy = new DatabaseSync(databasePath);
+  legacy.exec(`PRAGMA user_version = ${OPENCLAW_STATE_SCHEMA_VERSION - 1};
+    UPDATE schema_meta SET schema_version = ${OPENCLAW_STATE_SCHEMA_VERSION - 1};`);
+  legacy.close();
+  const entry = fileURLToPath(resolveRuntimeWorkerUrl(cliRecoveryEntrypoints.cli));
+  const source = /\.[cm]?ts$/u.test(entry);
+  const runtimeRoot = source
+    ? createSourceRuntime(root)
+    : createBuiltRuntime(root, path.dirname(entry));
+  return {
+    databasePath,
+    stateDir,
+    run: (args: string[]) =>
+      source
+        ? runSourceRuntime(
+            runtimeRoot,
+            env,
+            [path.join(runtimeRoot, "src/entry.ts"), ...args],
+            60_000,
+          )
+        : runBuiltRuntime(runtimeRoot, env, args, 60_000),
+  };
+}
+
+function snapshotState(stateDir: string) {
+  return fs
+    .readdirSync(stateDir, { recursive: true })
+    .toSorted((left, right) => String(left).localeCompare(String(right)))
+    .map((relative) => {
+      const pathname = path.join(stateDir, String(relative));
+      const stat = fs.statSync(pathname);
+      return [
+        relative,
+        stat.mtimeMs,
+        stat.isFile() ? fs.readFileSync(pathname).toString("hex") : null,
+      ];
+    });
+}
+
+describe("candidate service capability startup", () => {
+  it("answers capability and version probes without state writes or locks while a Gateway owns an older schema", () => {
+    const fixture = createFixture();
+    const gateway = acquireGatewayLifecycleCoordinator({ databasePath: fixture.databasePath });
+    const before = snapshotState(fixture.stateDir);
+    try {
+      const result = fixture.run(["gateway", "install", "--update-executor", "check", "--json"]);
+      expect(result.error).toBeUndefined();
+      expect(result.status, `${result.stderr}\n${result.stdout}`).toBe(0);
+      expect(JSON.parse(result.stdout)).toEqual({
+        updateExecutor: "root-spawner-v1",
+        targetRootBinding: true,
+      });
+      const state = acquireStateDatabaseCoordinator({ databasePath: fixture.databasePath });
+      try {
+        const locked = fixture.run(["gateway", "install", "--update-executor=check", "--json"]);
+        expect(locked.status, locked.stderr).toBe(0);
+        expect(JSON.parse(locked.stdout)).toEqual(JSON.parse(result.stdout));
+      } finally {
+        state.release();
+      }
+      const version = fixture.run(["--version"]);
+      expect(version.status, version.stderr).toBe(0);
+      expect(version.stdout).toMatch(/^OpenClaw /u);
+      expect(snapshotState(fixture.stateDir)).toEqual(before);
+      const database = new DatabaseSync(fixture.databasePath, { readOnly: true });
+      try {
+        expect(database.prepare("PRAGMA user_version").get()?.user_version).toBe(
+          OPENCLAW_STATE_SCHEMA_VERSION - 1,
+        );
+      } finally {
+        database.close();
+      }
+    } finally {
+      gateway.release();
+    }
+  });
+
+  it("keeps ordinary service commands behind the live Gateway schema fence", () => {
+    const fixture = createFixture();
+    const gateway = acquireGatewayLifecycleCoordinator({ databasePath: fixture.databasePath });
+    const before = fs.readFileSync(fixture.databasePath);
+    try {
+      const result = fixture.run(["gateway", "install", "--json"]);
+      expect(result.error).toBeUndefined();
+      expect(result.status).toBe(1);
+      expect(`${result.stderr}\n${result.stdout}`).toContain(
+        "because another Gateway owns that state directory",
+      );
+      expect(fs.readFileSync(fixture.databasePath)).toEqual(before);
+    } finally {
+      gateway.release();
+    }
+  });
+});

--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -35,6 +35,7 @@ import {
 } from "./command-registration-policy.js";
 import { resolveCliStartupPolicy as resolveCliStartupPolicyForArgv } from "./command-startup-policy.js";
 import { maybeRunCliInContainer, parseCliContainerArgs } from "./container-target.js";
+import { tryRunGatewayServiceUpdateCapabilityProbe } from "./daemon-cli/update-capability.js";
 import { shouldStartLocalOnboarding } from "./fresh-install-config.js";
 import {
   consumeGatewayFastPathRootOptionToken,
@@ -1122,6 +1123,10 @@ async function runCliWithPreparedOutputMode(
     true,
     options.runtimeRecoveryEnv,
   );
+
+  if (tryRunGatewayServiceUpdateCapabilityProbe(normalizedArgv)) {
+    return;
+  }
 
   if (
     !isHelpOrVersionInvocation &&


### PR DESCRIPTION
Refs #144005

<details>
<summary>Additional instructions</summary>

Maintainer edits are enabled through the repository-owned branch.

</details>

## What Problem This Solves

Fixes an issue where users updating while debug capture is enabled receive `target-native-unsupported` when the candidate needs a newer shared-state schema and the old Gateway is still serving. The native service capability probe tries to initialize capture storage before reaching its capability handler, so the live Gateway's schema-ownership guard correctly refuses that unintended migration.

## Why This Change Was Made

Route the updater's exact machine probe before dotenv, configuration, and capture startup, and share the capability response with the existing service-command handler. Ordinary commands, delegated `run`, invalid options, and other argument shapes retain Commander parsing and their existing migration and ownership checks. The ownership guard is unchanged.

The installed updater runs first and cannot be repaired by the candidate. This fix is candidate-side: a driver that invokes the candidate's capability probe benefits as soon as that candidate contains the fix.

## User Impact

The candidate can advertise native update support while the previous Gateway continues serving an older database schema. Probing does not open or migrate shared state, acquire its lifecycle lock, or write capture records.

Release-note context: keep candidate native service capability discovery independent of live-state migration when debug capture is enabled, avoiding a misleading unsupported-target update failure.

## Evidence

- Regression command: `node scripts/run-vitest.mjs src/cli/gateway-service-capability.process.test.ts`. Before the fix: one failed, one passed; the probe exited 1 with `OpenClaw refused shared state schema mutation ... because another Gateway owns that state directory`. After: both passed. The fixture runs the real CLI, holds the Gateway owner over an older schema, verifies unchanged database/tree bytes and modification times, and separately holds the state lifecycle lock. Version output remains successful; ordinary service installation still refuses migration.
- `node scripts/run-vitest.mjs src/cli/gateway-service-capability.process.test.ts src/cli/daemon-cli/update-capability.test.ts src/cli/daemon-cli/register-service-commands.test.ts src/cli/run-main.exit.test.ts src/entry.version-fast-path.test.ts`: 311 tests passed.
- `pnpm build`: passed, including CLI bootstrap import checks.
- Fresh P1 autoreview of the complete final staged diff: scoped clean; no actionable findings. A final manual check also found and fixed a malformed-mode edge case (`--update-executor --json check`); its regression failed before the correction and passes afterward.
- `node scripts/check-changed.mjs`: passed. An initial test-only sorting lint error was corrected; the final regression rerun passed.
- Linux with a real systemd user manager: published 2026.9.3 Gateway remained healthy at schema 16; candidate capability and version probes exited 0 with debug capture enabled. Database/lock SHA-256, size, and modification-time snapshots were identical, and `strace` recorded no state/schema/Gateway-lock file operations. An ordinary command still exited 1 with the ownership refusal. Candidate package SHA-256: `163b5028516167cd1be15fa2e8f3ed98659d397873177331804e779579224d73`.
- Original current-source-driver cell shape on real systemd-user: update from installed 2026.9.3 to candidate 2026.9.4 exited 0 with `status: ok` in 56.904 seconds. The captured native check returned capability JSON, code 0, normal exit, and normal process-tree cleanup. Post-update version and service status exited 0.
- Actual published 2026.9.3 npm driver on a separate real systemd-user profile: update exited 0 with `status: ok` in 50.974 seconds; shared schema advanced 16 → 17, post-update service status exited 0, and `/healthz` returned `live`. Both task services and the Testbox lease were cleaned up.
- Linux evidence came from Testbox [run 34669556952](https://github.com/openclaw/openclaw/actions/runs/34669556952). The candidate package was built from the matching three production-file SHA-256 values, before the commit was created; its build ID therefore contains the source-sync base SHA. Package identity is recorded above.

Evidence clarification: the original L121 cell used a current-source driver over an installed 2026.9.3 Gateway, with a systemctl shim. The published npm 2026.9.3 updater does not contain this capability probe. This PR does not claim that the probe explains failures originating in that published driver's own code. Separate proof uses a real systemd user manager for the candidate probe and both driver shapes.

No contributor patch was imported. No schema, configuration option, dependency, protocol, or retention/recovery contract changes.

CI note: first-head run [34668973311](https://github.com/openclaw/openclaw/actions/runs/34668973311/job/103486684745) failed `check-test-types` on `ui/src/e2e/new-session-page.cloud-dispatch.e2e.test.ts:438`: TS2304, undefined `retainedMachine`. The failed checkout was synthetic merge `b7687d0a45d1338ba1736dddc005b24ed5207ec4`, based on `af135e06854029f867635665508a0048cad1d07c`. This PR does not change that UI test; main corrected the stale reference in #145540 (`41861b8055af6088eac51ba82f1a9494b01bf8dd`). Final-source Linux proof passed, including malformed argv rejection, both updater variants, and confirmed cleanup. Its three production-file hashes match HEAD `d6f563b7ce3a40da408469fbe96afdbfddc5df3a`. Final-head [CI run 34669786159](https://github.com/openclaw/openclaw/actions/runs/34669786159) is green on `d6f563b7ce3a40da408469fbe96afdbfddc5df3a`. The exact-head watcher completed with `STATUS rollup=green github_rollup=SUCCESS pending=0` and `GREEN`. No test retries or timeout increases were used.

## ClawSweeper review

The latest completed review covers `d6f563b7ce3a40da408469fbe96afdbfddc5df3a` and reports no findings, no before-merge items, and no Rank-up moves. Nothing required applying or skipping; no code changed during landing preparation.
