### PR TITLE
fix(ui): define retainedMachine in cloud-dispatch e2e

### DIFF
--- a/ui/src/e2e/new-session-page.cloud-dispatch.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.cloud-dispatch.e2e.test.ts
@@ -419,12 +419,11 @@ suite.define(() => {
       await expect.poll(() => startButton.isDisabled()).toBe(false);
       await trigger.click();
       const retainedCloudProfile = place.locator('[data-value="cloud:aws"]');
+      const retainedMachine = place.locator('[data-value="machine:fast"]');
       await expect.poll(() => retainedCloudProfile.isDisabled()).toBe(false);
       await retainedCloudProfile.click();
-      await expect.poll(() => place.locator('[data-value="machine:fast"]').isVisible()).toBe(true);
-      expect(await place.locator('[data-value="machine:fast"]').getAttribute("aria-pressed")).toBe(
-        "true",
-      );
+      await expect.poll(() => retainedMachine.isVisible()).toBe(true);
+      expect(await retainedMachine.getAttribute("aria-pressed")).toBe("true");
       if (captureUiProofEnabled) {
         await writeFile(
           path.join(


### PR DESCRIPTION
## What Problem This Solves

Fixes tip `check-test-types` failing on `ui/src/e2e/new-session-page.cloud-dispatch.e2e.test.ts` with `Cannot find name 'retainedMachine'`. The retention screenshot path referenced `retainedMachine` without declaring it after the simplified environment-picker e2e update.

## Why This Change Was Made

Declare `retainedMachine` as the `machine:fast` locator and reuse it for the visibility/pressed assertions and screenshot markers.

## User Impact

No runtime product change. Restores tip typechecking for the cloud-dispatch new-session e2e.

## Evidence

- Tip error: `error TS2304: Cannot find name 'retainedMachine'` at the screenshot markers array.
- After: `retainedMachine` is declared before use; same locator previously inlined for visibility/pressed checks.