### PR TITLE
test: reuse typed heartbeat sender fixtures

### DIFF
--- a/src/infra/heartbeat-runner.returns-default-unset.test.ts
+++ b/src/infra/heartbeat-runner.returns-default-unset.test.ts
@@ -819,6 +819,14 @@ describe("resolveHeartbeatSenderContext", () => {
 });
 
 describe("runHeartbeatOnce", () => {
+  function createWhatsAppSendMock() {
+    return vi
+      .fn<
+        (to: string, text: string, opts?: unknown) => Promise<{ messageId: string; toJid: string }>
+      >()
+      .mockResolvedValue({ messageId: "m1", toJid: "jid" });
+  }
+
   const createHeartbeatDeps = (
     sendWhatsApp: (
       to: string,
@@ -880,11 +888,7 @@ describe("runHeartbeatOnce", () => {
 
     const replySpy = vi.fn();
     replySpy.mockResolvedValue({ text: "Handled internally" });
-    const sendWhatsApp = vi
-      .fn<
-        (to: string, text: string, opts?: unknown) => Promise<{ messageId: string; toJid: string }>
-      >()
-      .mockResolvedValue({ messageId: "m1", toJid: "jid" });
+    const sendWhatsApp = createWhatsAppSendMock();
 
     const res = await runHeartbeatOnce({
       cfg,
@@ -1113,18 +1117,7 @@ describe("runHeartbeatOnce", () => {
       await seedWhatsAppSession(storePath, sessionKey);
 
       replySpy.mockResolvedValue([{ text: "Let me check..." }, { text: "Final alert" }]);
-      const sendWhatsApp = vi
-        .fn<
-          (
-            to: string,
-            text: string,
-            opts?: unknown,
-          ) => Promise<{ messageId: string; toJid: string }>
-        >()
-        .mockResolvedValue({
-          messageId: "m1",
-          toJid: "jid",
-        });
+      const sendWhatsApp = createWhatsAppSendMock();
 
       await runHeartbeatOnce({
         cfg,
@@ -1227,18 +1220,7 @@ describe("runHeartbeatOnce", () => {
 
       await seedWhatsAppSession(storePath, sessionKey);
       replySpy.mockResolvedValue([{ text: "Final alert" }]);
-      const sendWhatsApp = vi
-        .fn<
-          (
-            to: string,
-            text: string,
-            opts?: unknown,
-          ) => Promise<{ messageId: string; toJid: string }>
-        >()
-        .mockResolvedValue({
-          messageId: "m1",
-          toJid: "jid",
-        });
+      const sendWhatsApp = createWhatsAppSendMock();
       await runHeartbeatOnce({
         cfg,
         agentId: "ops",
@@ -1305,18 +1287,7 @@ describe("runHeartbeatOnce", () => {
       await seedWhatsAppSession(storePath, sessionKey, { sessionId, sessionFile });
 
       replySpy.mockResolvedValue([{ text: "Final alert" }]);
-      const sendWhatsApp = vi
-        .fn<
-          (
-            to: string,
-            text: string,
-            opts?: unknown,
-          ) => Promise<{ messageId: string; toJid: string }>
-        >()
-        .mockResolvedValue({
-          messageId: "m1",
-          toJid: "jid",
-        });
+      const sendWhatsApp = createWhatsAppSendMock();
       const result = await runHeartbeatOnce({
         cfg,
         agentId,
@@ -1411,15 +1382,7 @@ describe("runHeartbeatOnce", () => {
 
         replySpy.mockClear();
         replySpy.mockResolvedValue([{ text: message }]);
-        const sendWhatsApp = vi
-          .fn<
-            (
-              to: string,
-              text: string,
-              opts?: unknown,
-            ) => Promise<{ messageId: string; toJid: string }>
-          >()
-          .mockResolvedValue({ messageId: "m1", toJid: "jid" });
+        const sendWhatsApp = createWhatsAppSendMock();
 
         await runHeartbeatOnce({
           cfg,
@@ -1492,15 +1455,7 @@ describe("runHeartbeatOnce", () => {
 
       replySpy.mockClear();
       replySpy.mockResolvedValue([{ text: "Main session heartbeat" }]);
-      const sendWhatsApp = vi
-        .fn<
-          (
-            to: string,
-            text: string,
-            opts?: unknown,
-          ) => Promise<{ messageId: string; toJid: string }>
-        >()
-        .mockResolvedValue({ messageId: "m1", toJid: "jid" });
+      const sendWhatsApp = createWhatsAppSendMock();
 
       await runHeartbeatOnce({
         cfg,
@@ -1544,15 +1499,7 @@ describe("runHeartbeatOnce", () => {
       });
 
       replySpy.mockResolvedValue([{ text: "Final alert" }]);
-      const sendWhatsApp = vi
-        .fn<
-          (
-            to: string,
-            text: string,
-            opts?: unknown,
-          ) => Promise<{ messageId: string; toJid: string }>
-        >()
-        .mockResolvedValue({ messageId: "m1", toJid: "jid" });
+      const sendWhatsApp = createWhatsAppSendMock();
 
       await runHeartbeatOnce({
         cfg,
@@ -1590,15 +1537,7 @@ describe("runHeartbeatOnce", () => {
         lastHeartbeatSentAt: nowMs + 60_000,
       });
       replySpy.mockResolvedValue([{ text: "Final alert" }]);
-      const sendWhatsApp = vi
-        .fn<
-          (
-            to: string,
-            text: string,
-            opts?: unknown,
-          ) => Promise<{ messageId: string; toJid: string }>
-        >()
-        .mockResolvedValue({ messageId: "m1", toJid: "jid" });
+      const sendWhatsApp = createWhatsAppSendMock();
 
       await runHeartbeatOnce({
         cfg,
@@ -1692,15 +1631,7 @@ describe("runHeartbeatOnce", () => {
 
         replySpy.mockClear();
         replySpy.mockResolvedValue(replies);
-        const sendWhatsApp = vi
-          .fn<
-            (
-              to: string,
-              text: string,
-              opts?: unknown,
-            ) => Promise<{ messageId: string; toJid: string }>
-          >()
-          .mockResolvedValue({ messageId: "m1", toJid: "jid" });
+        const sendWhatsApp = createWhatsAppSendMock();
 
         await runHeartbeatOnce({
           cfg,
@@ -1745,15 +1676,7 @@ describe("runHeartbeatOnce", () => {
         { text: "All clear" },
         { text: "Reasoning: because nothing changed" },
       ]);
-      const sendWhatsApp = vi
-        .fn<
-          (
-            to: string,
-            text: string,
-            opts?: unknown,
-          ) => Promise<{ messageId: string; toJid: string }>
-        >()
-        .mockResolvedValue({ messageId: "m1", toJid: "jid" });
+      const sendWhatsApp = createWhatsAppSendMock();
 
       await runHeartbeatOnce({
         cfg,
@@ -1789,18 +1712,7 @@ describe("runHeartbeatOnce", () => {
       await seedWhatsAppSession(storePath, sessionKey);
 
       replySpy.mockResolvedValue({ text: "Hello from heartbeat" });
-      const sendWhatsApp = vi
-        .fn<
-          (
-            to: string,
-            text: string,
-            opts?: unknown,
-          ) => Promise<{ messageId: string; toJid: string }>
-        >()
-        .mockResolvedValue({
-          messageId: "m1",
-          toJid: "jid",
-        });
+      const sendWhatsApp = createWhatsAppSendMock();
 
       await runHeartbeatOnce({
         cfg,
@@ -1888,11 +1800,7 @@ describe("runHeartbeatOnce", () => {
 
     const replySpy = vi.fn();
     replySpy.mockResolvedValue({ text: params.replyText ?? "Checked logs and PRs" });
-    const sendWhatsApp = vi
-      .fn<
-        (to: string, text: string, opts?: unknown) => Promise<{ messageId: string; toJid: string }>
-      >()
-      .mockResolvedValue({ messageId: "m1", toJid: "jid" });
+    const sendWhatsApp = createWhatsAppSendMock();
     const res = await runHeartbeatOnce({
       cfg,
       ...(params.source
@@ -1995,11 +1903,7 @@ Some global directive after tasks.
     };
     await seedWhatsAppSession(storePath, resolveMainSessionKey(cfg));
     const replySpy = vi.fn().mockResolvedValue({ text: "Handled due heartbeat tasks" });
-    const sendWhatsApp = vi
-      .fn<
-        (to: string, text: string, opts?: unknown) => Promise<{ messageId: string; toJid: string }>
-      >()
-      .mockResolvedValue({ messageId: "m1", toJid: "jid" });
+    const sendWhatsApp = createWhatsAppSendMock();
 
     const res = await runHeartbeatOnce({
       cfg,
@@ -2053,11 +1957,7 @@ tasks:
     };
     await seedWhatsAppSession(storePath, resolveMainSessionKey(cfg));
     const replySpy = vi.fn().mockResolvedValue({ text: "Handled due heartbeat tasks" });
-    const sendWhatsApp = vi
-      .fn<
-        (to: string, text: string, opts?: unknown) => Promise<{ messageId: string; toJid: string }>
-      >()
-      .mockResolvedValue({ messageId: "m1", toJid: "jid" });
+    const sendWhatsApp = createWhatsAppSendMock();
 
     const res = await runHeartbeatOnce({
       cfg,
@@ -2274,11 +2174,7 @@ tasks:
 
     const replySpy = vi.fn();
     replySpy.mockResolvedValue({ text: "Handled internally" });
-    const sendWhatsApp = vi
-      .fn<
-        (to: string, text: string, opts?: unknown) => Promise<{ messageId: string; toJid: string }>
-      >()
-      .mockResolvedValue({ messageId: "m1", toJid: "jid" });
+    const sendWhatsApp = createWhatsAppSendMock();
 
     try {
       const res = await runHeartbeatOnce({
@@ -2321,11 +2217,7 @@ tasks:
 
     const replySpy = vi.fn();
     replySpy.mockResolvedValue({ text: "Handled internally" });
-    const sendWhatsApp = vi
-      .fn<
-        (to: string, text: string, opts?: unknown) => Promise<{ messageId: string; toJid: string }>
-      >()
-      .mockResolvedValue({ messageId: "m1", toJid: "jid" });
+    const sendWhatsApp = createWhatsAppSendMock();
 
     try {
       const res = await runHeartbeatOnce({


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

Heartbeat tests repeat the same typed WhatsApp sender setup across sixteen sites, adding fixture maintenance without distinguishing the scenarios.

## Why This Change Was Made

A local factory creates the same fresh mock and resolved result at each original call position. All scenarios, assertions and three untyped mocks remain unchanged; the test file is 108 lines shorter.

## User Impact

No user-visible behavior changes. The heartbeat test fixtures are easier to maintain.

## Evidence

- Full test file: 57 passing cases before and after, with identical ordered case identities.
- Expanding the sixteen calls and removing the helper reconstructs the original file byte-for-byte.
- Actual Vitest mock checks preserve fresh mocks/results across factory calls, stable result identity within each mock, Promise behavior and reset semantics.
- Mapped changed-file gate and independent review passed on Node 24.19.0 with a private frozen dependency install.

No runtime-speed improvement is claimed.
