### PR TITLE
docs(openai): document Advanced Account Security OAuth recovery

### DIFF
--- a/docs/providers/openai/setup.md
+++ b/docs/providers/openai/setup.md
@@ -253,6 +253,48 @@ sidebarTitle: "Setup"
     Run `openclaw doctor --fix` to migrate older legacy OpenAI Codex prefix
     profile ids and order entries before relying on profile ordering.
 
+    ### Advanced Account Security enrollment
+
+    OpenAI [Advanced Account Security
+    (AAS)](https://help.openai.com/en/articles/20001221-advanced-account-security)
+    enforces passkey or security-key sign-in. Enrollment signs out every
+    existing session, so OpenClaw-held OAuth credentials are signed out with
+    everything else, and active sessions may be shorter. Do not expect a
+    fixed token lifetime or unattended refresh to keep working indefinitely
+    after enrollment.
+
+    To recover, sign in again through OpenClaw with the enrolled passkey or
+    security key, targeting the same agent and profile the failing route
+    uses:
+
+    ```bash
+    openclaw models auth login --provider openai
+    openclaw models auth login --agent <id> --provider openai
+    openclaw models auth login --provider openai --profile-id openai:ritsuko
+    ```
+
+    A successful standalone `codex login` does not replace an
+    OpenClaw-managed credential. The default agent-scoped mode keeps OAuth
+    material in OpenClaw's auth store and refreshes it from there; letting a
+    native Codex login own the credential is the separate, explicit
+    user-home mode. See [Auth and environment
+    isolation](/plugins/codex-harness-reference/auth#auth-and-environment-isolation).
+
+    Verify with a real request through the intended profile, runtime, and
+    model. A model listing or a completed browser callback is not proof of
+    model access:
+
+    ```bash
+    openclaw models status --probe --probe-provider openai
+    ```
+
+    If a fresh login still fails, note the exact sanitized error and the
+    stage it failed at — browser or security-key interaction, localhost
+    callback, token exchange, token refresh, or the model request — and
+    include both when asking for help. Do not disable AAS, delete credential
+    or thread stores, paste tokens into a report, or switch to API-key
+    billing as a generic workaround.
+
     ### Status indicator
 
     Chat `/status` shows which model runtime is active for the current


### PR DESCRIPTION
<!--
Closes #145438
-->

## What Problem This Solves

Fixes a documentation gap where the OpenAI setup/recovery guide did not explain what to do after enrolling in OpenAI **Advanced Account Security (AAS)**. Users who enabled AAS (passkey/security-key enforcement) were signed out of all existing sessions — including OpenClaw-held OAuth credentials — and the docs offered no recovery path, so an affected user disabled AAS to restore access instead of re-authenticating.

## Why This Change Was Made

Adds an "Advanced Account Security enrollment" subsection to the Codex OAuth recovery section of `docs/providers/openai/setup.md`. It links OpenAI's AAS policy, explains the enrollment-wide sign-out and shorter sessions (without promising a token lifetime), walks through a fresh browser OAuth login through OpenClaw (`openclaw models auth login --provider openai` with agent/profile selectors) using the enrolled key, and clarifies that a standalone `codex login` does not replace an OpenClaw-managed credential — cross-linking the harness auth reference for the separate user-home mode. It also sets verification expectations (a real probe request, not a model listing) and asks for the sanitized error plus failure stage when a fresh login still fails. The wording deliberately avoids recommending disabling AAS, deleting credential stores, pasting tokens, or switching to API-key billing as workarounds, per the constraints in the issue.

## User Impact

Users who enroll in AAS can now follow a documented recovery path: re-login through OpenClaw with their passkey/security key on the same agent/profile the failing route uses, verify with `openclaw models status --probe --probe-provider openai`, and report a precise failure stage (browser/key interaction, localhost callback, token exchange, refresh, or model request) if it still fails — instead of guessing or disabling AAS.

## Evidence

- Changed docs pass the repo docs gates:
  - `node scripts/docs-link-audit.mjs` → `checked_internal_links=13481, broken_links=0`
  - Anchor audit of the new cross-link target `/plugins/codex-harness-reference/auth#auth-and-environment-isolation` — no new fragment failures introduced (remaining anchor failures are pre-existing in unrelated files: `sdk-migration.md`, `cli/gateway.md`, `automation/cron-jobs.md`)
  - `node scripts/check-docs-mdx.mjs docs/providers/openai/setup.md` → "Docs MDX check passed"
  - `format-docs --check` → "Docs formatting clean (1285 files)"
- Docs-only change: no runtime behavior affected.
