### PR TITLE
fix(models): default Fable and Astra to medium effort

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -1419,7 +1419,7 @@ packages/ai/src/openai-completions-messages.ts	7
 packages/ai/src/provider-transcript-transform.ts	3
 packages/ai/src/provider-types.ts	1
 packages/ai/src/providers/agent-tools-parameter-schema.ts	23
-packages/ai/src/providers/anthropic-model-contract.ts	2
+packages/ai/src/providers/anthropic-model-contract.ts	1
 packages/ai/src/providers/anthropic-refusal.ts	1
 packages/ai/src/providers/anthropic-server-fallback.ts	3
 packages/ai/src/providers/anthropic-thinking-replay.ts	2

--- a/docs/concepts/model-providers/official-provider-plugins.md
+++ b/docs/concepts/model-providers/official-provider-plugins.md
@@ -69,7 +69,7 @@ Claude CLI reuse (`claude -p`) is a sanctioned OpenClaw integration path. Anthro
 - Auth: OAuth (ChatGPT)
 - Fresh native Codex app-server harness ref: `openai/gpt-5.6-sol`
 - Native Codex app-server harness docs: [Codex harness](/plugins/codex-harness)
-- Astra (`openai/gpt-6-astra`) defaults to `low` reasoning effort to limit routine budget use. The [OpenAI provider default](/providers/openai/models#gpt-6-astra) is shared by model controls and both runtimes; explicit thinking settings take precedence.
+- Astra (`openai/gpt-6-astra`) defaults to `medium` reasoning effort when the account supports it. The [OpenAI provider default](/providers/openai/models#gpt-6-astra) is shared by model controls and both runtimes; explicit thinking settings take precedence.
 - Legacy model refs: `codex/gpt-*`, `openai-codex/gpt-*`
 - Plugin boundary: `openai/*` loads the OpenAI plugin; explicit runtime policy or the provider-owned effective route decides whether the native Codex app-server plugin is selected.
 - CLI: `openclaw onboard --auth-choice openai` or `openclaw models auth login --provider openai`

--- a/docs/plugins/codex-harness/routing.md
+++ b/docs/plugins/codex-harness/routing.md
@@ -12,9 +12,9 @@ Which effective routes select the Codex runtime, and the deployment shapes built
 
 ## Routing and model selection
 
-`openai/gpt-6-astra` defaults to `low` reasoning effort through the shared
-OpenAI provider policy. This limits routine reasoning cost and subscription
-budget use. For OpenClaw-managed turns, the resolved effort is sent in Codex `turn/start` requests,
+`openai/gpt-6-astra` defaults to `medium` reasoning effort through the shared
+OpenAI provider policy when the account supports it. For OpenClaw-managed turns,
+the resolved effort is sent in Codex `turn/start` requests,
 including `collaborationMode.settings.reasoning_effort`, so the native thread
 uses the same default as Control UI. Explicit thinking settings still win;
 an existing session or agent configured for `high` stays at `high`. Threads

--- a/docs/plugins/reference/anthropic-vertex.md
+++ b/docs/plugins/reference/anthropic-vertex.md
@@ -26,8 +26,8 @@ OpenClaw Anthropic Vertex provider plugin for Claude models on Google Vertex AI.
 ## Claude Fable 5
 
 Use `anthropic-vertex/claude-fable-5` where the model is available in your Google Cloud region.
-Fable 5 always uses adaptive thinking and defaults to `high` effort. `/think off` and
-`/think minimal` use `low` effort because the model does not support disabling thinking.
+Fable 5 always uses adaptive thinking; OpenClaw defaults to `medium` effort. Stored `off`
+and `minimal` settings map to `low` because the model does not support disabling thinking.
 
 ## Claude Sonnet 5
 

--- a/docs/providers/anthropic.md
+++ b/docs/providers/anthropic.md
@@ -241,8 +241,8 @@ For Claude CLI authentication, keep that same ref and select the CLI runtime:
 ```
 
 The API and Claude CLI catalogs expose a 1,000,000-token context window and
-128,000-token output limit. Fable 5.1 always uses adaptive thinking, defaults to
-`high`, and supports native `low`, `medium`, `high`, `xhigh`, and `max` effort.
+128,000-token output limit. Fable 5.1 always uses adaptive thinking. OpenClaw defaults to
+`medium`, with native `low`, `medium`, `high`, `xhigh`, and `max` effort available.
 For API-key billing, input and output remain `$10/$50` per million tokens;
 cache reads cost `$0.25` per million tokens, one quarter of Fable 5's rate.
 See Anthropic's [Fable 5.1 specifications](https://platform.claude.com/docs/en/models/fable-5-1/overview).
@@ -458,7 +458,7 @@ per million tokens. Anthropic canceled the previously scheduled September 2026
 increase; see [current model pricing](https://platform.claude.com/docs/en/about-claude/pricing#model-pricing).
 
 `anthropic/claude-fable-5-1` and `anthropic/claude-fable-5` always use adaptive
-thinking and default to `high` effort. Anthropic does not allow thinking to be
+thinking. OpenClaw defaults both versions to `medium` effort. Anthropic does not allow thinking to be
 disabled for these models, so stored `off` and `minimal` settings map to `low`
 effort instead. OpenClaw also omits caller-selected sampling parameters for
 both Fable versions.
@@ -466,7 +466,7 @@ both Fable versions.
 Fable effort controls offer `low`, `medium`, `high`, `xhigh`, and `max`, matching
 [Anthropic's effort levels](https://platform.claude.com/docs/en/build-with-claude/effort).
 Adaptive thinking is always on; it is not a separate effort choice. Existing
-stored `adaptive` selections resolve to the provider's `high` default. Custom
+stored `adaptive` selections resolve to OpenClaw's `medium` default. Custom
 `anthropic-messages` providers use the same profile, including model IDs with
 routing namespaces such as `Claude Gateway/claude-fable-5-1`.
 
@@ -477,8 +477,9 @@ The catalog publishes its 1,000,000-token context window, 128,000-token output
 limit, image input, and `$10/$50` input/output pricing.
 
 For Fable and Mythos, new `/think minimal` and `/think adaptive` directives are
-rejected with the supported choices. Use `/think low` and `/think high`,
-respectively; the remapping above applies to previously stored settings.
+rejected with the supported choices. Use `/think low` in place of `minimal`,
+and `/think default` to use the model's default effort. The remapping above
+applies to previously stored settings.
 
 Claude Opus 4.8 keeps thinking off by default in OpenClaw. When you explicitly
 enable adaptive thinking with `/think high|xhigh|max`, OpenClaw sends

--- a/docs/providers/bedrock.md
+++ b/docs/providers/bedrock.md
@@ -361,7 +361,8 @@ openclaw models list
     Use `amazon-bedrock/anthropic.claude-fable-5` in `us-east-1`, or the
     regional inference ids such as `us.anthropic.claude-fable-5`.
     OpenClaw applies Fable's 1M context window, 128K output limit, always-on
-    adaptive thinking, and supported effort mapping. `/think off` and
+    adaptive thinking, and supported effort mapping. Fable 5 and 5.1 default
+    to `medium` effort; explicit effort settings take precedence. `/think off` and
     `/think minimal` map to `low`; temperature and forced tool choice controls
     are omitted, matching the Opus 4.7/4.8 route. Streaming output is held
     until Bedrock returns a terminal status so mid-stream refusals do not

--- a/docs/providers/openai/models.md
+++ b/docs/providers/openai/models.md
@@ -42,8 +42,8 @@ Astra uses the Responses API for agent tool calls. It supports text and image
 input, a 1,050,000-token context window, and up to 128,000 output tokens.
 OpenClaw retains its ordinary 272,000-token active input budget by default.
 The supported reasoning efforts are `low`, `medium`, `high`, `xhigh`, and `max`.
-OpenClaw defaults Astra to `low` on both the OpenClaw and Codex runtimes to
-limit reasoning cost and subscription-budget consumption on ordinary prompts.
+OpenClaw defaults Astra to `medium` on both the OpenClaw and Codex runtimes
+when the account supports that effort.
 The OpenAI provider owns this default, so model selection, Control UI, and
 Codex turn requests share it. Explicit agent, model, global, and session
 thinking settings still take precedence; switching models does not clear an

--- a/extensions/amazon-bedrock/index.test.ts
+++ b/extensions/amazon-bedrock/index.test.ts
@@ -450,11 +450,19 @@ describe("amazon-bedrock provider plugin", () => {
       defaultLevel: "off",
     },
     {
-      name: "keeps mandatory-adaptive Claude 5 models at high default effort",
+      name: "defaults Fable Bedrock model refs to medium effort",
       modelIds: [
         "anthropic.claude-fable-5",
         "us.anthropic.claude-fable-5",
         "global.anthropic.claude-fable-5",
+        "anthropic.claude-fable-5-1",
+        "us.anthropic.claude-fable-5-1",
+      ],
+      defaultLevel: "medium",
+    },
+    {
+      name: "keeps mandatory-adaptive Mythos 5 models at high default effort",
+      modelIds: [
         "anthropic.claude-mythos-5",
         "us.anthropic.claude-mythos-5",
         "global.anthropic.claude-mythos-5",
@@ -485,7 +493,7 @@ describe("amazon-bedrock provider plugin", () => {
       } as never),
       {
         levelIds: ["off", "minimal", "low", "medium", "high", "xhigh", "adaptive", "max"],
-        defaultLevel: "high",
+        defaultLevel: "medium",
       },
     );
   });

--- a/extensions/amazon-bedrock/provider-policy-api.test.ts
+++ b/extensions/amazon-bedrock/provider-policy-api.test.ts
@@ -105,7 +105,12 @@ describe("amazon-bedrock provider-policy-api", () => {
   it.each([
     {
       canonicalModelId: "claude-fable-5",
-      defaultLevel: "high",
+      defaultLevel: "medium",
+      preservesCatalogOptOut: true,
+    },
+    {
+      canonicalModelId: "claude-fable-5-1",
+      defaultLevel: "medium",
       preservesCatalogOptOut: true,
     },
     {

--- a/extensions/amazon-bedrock/stream.runtime.test.ts
+++ b/extensions/amazon-bedrock/stream.runtime.test.ts
@@ -501,6 +501,43 @@ describe("Bedrock thinking request composition", () => {
   } as never;
 
   it.each([
+    ...[
+      { id: "anthropic.claude-fable-5", name: "Claude Fable 5" },
+      { id: "us.anthropic.claude-fable-5-1", name: "Claude Fable 5.1" },
+      {
+        id: "production-fable-5",
+        name: "Production deployment",
+        params: { canonicalModelId: "claude-fable-5" },
+      },
+      {
+        id: "production-fable-5-1",
+        name: "Production deployment",
+        params: { canonicalModelId: "claude-fable-5-1" },
+      },
+      {
+        id: "arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/abcdefghijk",
+        name: "US Claude Fable 5.1",
+      },
+    ].map((modelOverrides) => ({
+      name: `${modelOverrides.id} default`,
+      model: () =>
+        bedrockModel({ ...modelOverrides, contextWindow: 1_000_000, maxTokens: 128_000 }),
+      reasoning: undefined,
+      expectedMaxTokens: 128_000,
+      expectedEffort: "medium",
+    })),
+    {
+      name: "Fable 5 explicit off",
+      model: () =>
+        bedrockModel({
+          id: "anthropic.claude-fable-5",
+          contextWindow: 1_000_000,
+          maxTokens: 128_000,
+        }),
+      reasoning: "off" as const,
+      expectedMaxTokens: 128_000,
+      expectedEffort: "low",
+    },
     {
       name: "Opus 5 default",
       model: () =>

--- a/extensions/amazon-bedrock/stream.runtime.ts
+++ b/extensions/amazon-bedrock/stream.runtime.ts
@@ -86,7 +86,10 @@ import {
   resolveBedrockPromptCachePolicy,
   type BedrockOptions,
 } from "./bedrock-options.js";
-import { supportsBedrockNativeMaxEffort } from "./thinking-policy.js";
+import {
+  resolveBedrockClaudeThinkingProfile,
+  supportsBedrockNativeMaxEffort,
+} from "./thinking-policy.js";
 
 type Block = (TextContent | ThinkingContent | ToolCall) & {
   index?: number;
@@ -494,16 +497,12 @@ function resolveSimpleBedrockOptions(
     return {
       ...base,
       maxTokens: resolveAdaptiveBedrockMaxTokens(model, base.maxTokens),
-      reasoning: options?.reasoning === "off" ? "low" : (options?.reasoning ?? "high"),
+      reasoning: options?.reasoning,
       thinkingBudgets: options?.thinkingBudgets,
     } satisfies BedrockOptions;
   }
   if (!options?.reasoning) {
-    const reasoning =
-      usesClaudeOpus5BedrockContract(model) ||
-      (isAnthropicClaudeModel(model) && requiresMandatoryAdaptiveThinking(model))
-        ? "high"
-        : undefined;
+    const reasoning = usesClaudeOpus5BedrockContract(model) ? "high" : undefined;
     return {
       ...base,
       ...(reasoning !== undefined || supportsAdaptiveThinking(model)
@@ -831,6 +830,25 @@ function requiresMandatoryAdaptiveThinking(model: Model<"bedrock-converse-stream
     usesClaudeSonnet5BedrockContract(model) ||
     resolveClaudeSonnet5ModelIdentity({ id: profileModelId }) !== undefined
   );
+}
+
+function resolveMandatoryAdaptiveDefault(model: Model<"bedrock-converse-stream">): ThinkingLevel {
+  const defaultLevel =
+    resolveBedrockClaudeThinkingProfile(model.id, model.params).defaultLevel ??
+    resolveBedrockClaudeThinkingProfile(resolveClaudeProfileNameModelId(model.name) ?? "")
+      .defaultLevel;
+  switch (defaultLevel) {
+    case "minimal":
+    case "low":
+    case "medium":
+    case "high":
+    case "xhigh":
+    case "max":
+      return defaultLevel;
+    default:
+      // Adaptive is a picker mode; the Bedrock payload needs a scalar effort.
+      return "high";
+  }
 }
 
 function supportsNativeXhighEffort(model: Model<"bedrock-converse-stream">): boolean {
@@ -1307,14 +1325,15 @@ function buildAdditionalModelRequestFields(
   options: BedrockOptions,
 ): DocumentType | undefined {
   // Mandatory-adaptive Claude routes preserve the public `off` control by
-  // lowering effort instead of silently falling back to the route's high default.
+  // lowering effort instead of silently falling back to the route's default.
   const mandatoryAdaptiveThinking = requiresMandatoryAdaptiveThinking(model);
   const reasoning =
     options.reasoning === "off"
       ? mandatoryAdaptiveThinking
         ? "low"
         : "off"
-      : (options.reasoning ?? (mandatoryAdaptiveThinking ? "high" : undefined));
+      : (options.reasoning ??
+        (mandatoryAdaptiveThinking ? resolveMandatoryAdaptiveDefault(model) : undefined));
   if (reasoning === "off") {
     return undefined;
   }

--- a/extensions/amazon-bedrock/thinking-policy.ts
+++ b/extensions/amazon-bedrock/thinking-policy.ts
@@ -4,6 +4,7 @@ import {
   resolveClaudeMythos5ModelIdentity,
   resolveClaudeOpus5ModelIdentity,
   resolveClaudeSonnet5ModelIdentity,
+  resolveClaudeThinkingProfile,
 } from "openclaw/plugin-sdk/claude-model-runtime";
 /**
  * Thinking-level policy for Claude models on Amazon Bedrock. It maps Bedrock
@@ -122,14 +123,15 @@ export function resolveBedrockClaudeThinkingProfile(
   const trimmed = modelId.trim();
   const canonicalModelId = resolveClaudeModelIdentity({ id: trimmed, params });
   const modelRefs = [trimmed, canonicalModelId];
+  const fableModelId = resolveClaudeFable5ModelIdentity({ id: trimmed, params });
   if (
-    resolveClaudeFable5ModelIdentity({ id: trimmed, params }) ||
+    fableModelId ||
     resolveClaudeMythos5ModelIdentity({ id: trimmed, params }) ||
     resolveClaudeSonnet5ModelIdentity({ id: trimmed, params })
   ) {
     return {
       levels: [...BASE_CLAUDE_THINKING_LEVELS, { id: "xhigh" }, { id: "adaptive" }, { id: "max" }],
-      defaultLevel: "high",
+      defaultLevel: fableModelId ? resolveClaudeThinkingProfile(fableModelId).defaultLevel : "high",
       preserveWhenCatalogReasoningFalse: true,
     };
   }

--- a/extensions/anthropic-vertex/index.test.ts
+++ b/extensions/anthropic-vertex/index.test.ts
@@ -328,7 +328,7 @@ describe("anthropic-vertex provider plugin", () => {
       provider: "anthropic-vertex",
       modelId: "claude-fable-5",
     } as never);
-    expect(fableProfile?.defaultLevel).toBe("high");
+    expect(fableProfile?.defaultLevel).toBe("medium");
     expect(fableProfile?.preserveWhenCatalogReasoningFalse).toBe(true);
 
     const aliasProfile = provider.resolveThinkingProfile?.({
@@ -336,7 +336,7 @@ describe("anthropic-vertex provider plugin", () => {
       modelId: "production-claude",
       params: { canonicalModelId: "claude-fable-5" },
     } as never);
-    expect(aliasProfile?.defaultLevel).toBe("high");
+    expect(aliasProfile?.defaultLevel).toBe("medium");
   });
 
   it("restores Fable metadata for explicit Vertex catalog rows", async () => {

--- a/extensions/anthropic-vertex/stream-runtime.test.ts
+++ b/extensions/anthropic-vertex/stream-runtime.test.ts
@@ -4,7 +4,11 @@ import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { createServer } from "node:http";
 import os from "node:os";
 import path from "node:path";
-import { createAssistantMessageEventStream, type Model } from "openclaw/plugin-sdk/llm";
+import {
+  createAssistantMessageEventStream,
+  stream as streamModel,
+  type Model,
+} from "openclaw/plugin-sdk/llm";
 import {
   notifyProviderStreamOpened,
   withProviderAcceptanceObserver,
@@ -364,19 +368,50 @@ describe("createAnthropicVertexStreamFn", () => {
     expect(streamTransportOptions(streamAnthropicMock).temperature).toBe(0.7);
   });
 
-  it("uses Fable 5's always-adaptive Vertex contract", () => {
-    const { deps, streamAnthropicMock } = createStreamDeps();
-    const streamFn = createAnthropicVertexStreamFn("vertex-project", "us-east5", undefined, deps);
-    const model = makeModel({ id: "claude-fable-5", maxTokens: 128000 });
-
-    void streamFn(model, { messages: [] }, { temperature: 0.7 });
-
-    expect(streamTransportOptions(streamAnthropicMock)).toMatchObject({
-      thinkingEnabled: true,
-      effort: "high",
-      maxTokens: 128000,
+  it.each([
+    { id: "claude-fable-5", effort: "medium" },
+    { id: "claude-fable-5-1", effort: "medium" },
+    {
+      id: "production-fable",
+      params: { canonicalModelId: "claude-fable-5-1" },
+      reasoning: false,
+      effort: "medium",
+    },
+    { id: "claude-mythos-5", effort: "high" },
+  ])("sends the shared Vertex default for $id", async ({ effort, ...modelOptions }) => {
+    const { deps } = createStreamDeps();
+    const streamFn = createAnthropicVertexStreamFn(
+      "vertex-project",
+      "us-east5",
+      undefined,
+      { ...deps, streamAnthropic: streamModel },
+      {},
+    );
+    const onPayload = vi.fn((_payload: unknown) => {
+      throw new Error("stop before network");
     });
-    expect(streamTransportOptions(streamAnthropicMock)).not.toHaveProperty("temperature");
+    const model: Model<"anthropic-messages"> = {
+      ...makeModel({ ...modelOptions, maxTokens: 128000 }),
+      name: modelOptions.id,
+      input: ["text"],
+      contextWindow: 1_000_000,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    };
+    const stream = await streamFn(
+      model,
+      { messages: [{ role: "user", content: "hello", timestamp: 0 }] },
+      { temperature: 0.7, onPayload },
+    );
+    const result = await stream.result();
+
+    expect(onPayload, result.errorMessage).toHaveBeenCalledOnce();
+    const payload = onPayload.mock.calls[0]?.[0];
+    expect(payload).toMatchObject({
+      thinking: { type: "adaptive" },
+      output_config: { effort },
+      max_tokens: 128000,
+    });
+    expect(payload).not.toHaveProperty("temperature");
   });
 
   it.each([
@@ -401,21 +436,6 @@ describe("createAnthropicVertexStreamFn", () => {
       }
     },
   );
-
-  it("uses Mythos 5's mandatory adaptive Vertex contract by default", () => {
-    const { deps, streamAnthropicMock } = createStreamDeps();
-    const streamFn = createAnthropicVertexStreamFn("vertex-project", "us-east5", undefined, deps);
-    const model = makeModel({ id: "claude-mythos-5", maxTokens: 128000 });
-
-    void streamFn(model, { messages: [] }, { temperature: 0.7 });
-
-    expect(streamTransportOptions(streamAnthropicMock)).toMatchObject({
-      thinkingEnabled: true,
-      effort: "high",
-      maxTokens: 128000,
-    });
-    expect(streamTransportOptions(streamAnthropicMock)).not.toHaveProperty("temperature");
-  });
 
   it("uses canonical Claude policy for Vertex deployment aliases", () => {
     const { deps, streamAnthropicMock } = createStreamDeps();

--- a/extensions/anthropic-vertex/stream-runtime.ts
+++ b/extensions/anthropic-vertex/stream-runtime.ts
@@ -206,8 +206,7 @@ export function createAnthropicVertexStreamFn(
     const reasoning =
       requestedReasoning === "off" && mandatoryAdaptiveThinking
         ? "low"
-        : (requestedReasoning ??
-          (mandatoryAdaptiveThinking || adaptiveDefaultClaude5 ? "high" : undefined));
+        : (requestedReasoning ?? (adaptiveDefaultClaude5 ? "high" : undefined));
     const adaptiveThinking =
       mandatoryAdaptiveThinking ||
       Boolean(reasoning && reasoning !== "off" && supportsAdaptiveThinking(contractModelId));
@@ -259,7 +258,6 @@ export function createAnthropicVertexStreamFn(
       }
     } else if (mandatoryAdaptiveThinking) {
       opts.thinkingEnabled = true;
-      opts.effort = "high";
     } else {
       opts.thinkingEnabled = false;
     }

--- a/extensions/anthropic/index.test.ts
+++ b/extensions/anthropic/index.test.ts
@@ -71,6 +71,7 @@ function levelIds(profile: unknown): Array<unknown> {
 }
 
 type Claude5ContractCase = {
+  defaultLevel?: "medium" | "high";
   name: string;
   modelId: string;
   cost: { input: number; output: number; cacheRead: number; cacheWrite: number };
@@ -672,6 +673,7 @@ describe("anthropic provider replay hooks", () => {
     })),
     {
       name: "resolves Claude Fable 5 with its always-adaptive model contract",
+      defaultLevel: "medium",
       modelId: "claude-fable-5",
       cost: { input: 10, output: 50, cacheRead: 1, cacheWrite: 12.5 },
       thinkingLevelMap: { minimal: "low", xhigh: "xhigh", max: "max" },
@@ -680,6 +682,7 @@ describe("anthropic provider replay hooks", () => {
     },
     {
       name: "resolves Claude Fable 5.1 with its always-adaptive model contract",
+      defaultLevel: "medium",
       modelId: "claude-fable-5-1",
       cost: { input: 10, output: 50, cacheRead: 0.25, cacheWrite: 12.5 },
       thinkingLevelMap: { minimal: "low", xhigh: "xhigh", max: "max" },
@@ -700,6 +703,7 @@ describe("anthropic provider replay hooks", () => {
     "$name",
     async ({
       modelId,
+      defaultLevel = "high",
       cost,
       thinkingLevelMap,
       checksMedia,
@@ -738,7 +742,7 @@ describe("anthropic provider replay hooks", () => {
           ? ["low", "medium", "high", "xhigh", "max"]
           : ["off", "minimal", "low", "medium", "high", "xhigh", "adaptive", "max"],
       );
-      expect(requireRecord(profile, `${modelId} thinking profile`).defaultLevel).toBe("high");
+      expect(requireRecord(profile, `${modelId} thinking profile`).defaultLevel).toBe(defaultLevel);
       const normalized = provider.normalizeResolvedModel?.({
         provider: "anthropic",
         modelId,

--- a/extensions/anthropic/provider-policy-api.test.ts
+++ b/extensions/anthropic/provider-policy-api.test.ts
@@ -163,9 +163,13 @@ describe("anthropic provider policy public artifact", () => {
     expect(profile?.defaultLevel).toBe("off");
   });
 
-  it.each(["claude-fable-5", "claude-fable-5-1", "claude-mythos-5"])(
+  it.each([
+    ["claude-fable-5", "medium"],
+    ["claude-fable-5-1", "medium"],
+    ["claude-mythos-5", "high"],
+  ])(
     "exposes only native efforts for the mandatory-adaptive %s thinking profile",
-    (modelId) => {
+    (modelId, defaultLevel) => {
       const profile = resolveThinkingProfile({
         provider: "anthropic",
         modelId,
@@ -173,7 +177,7 @@ describe("anthropic provider policy public artifact", () => {
 
       expect(profile).toEqual({
         levels: [{ id: "low" }, { id: "medium" }, { id: "high" }, { id: "xhigh" }, { id: "max" }],
-        defaultLevel: "high",
+        defaultLevel,
         preserveWhenCatalogReasoningFalse: true,
       });
     },

--- a/extensions/codex/src/app-server/turn-params.test.ts
+++ b/extensions/codex/src/app-server/turn-params.test.ts
@@ -14,7 +14,7 @@ afterEach(() => {
 
 describe("buildTurnStartParams model thinking defaults", () => {
   it.each([
-    { thinking: undefined, thinkingDefault: undefined, expected: "low" },
+    { thinking: undefined, thinkingDefault: undefined, expected: "medium" },
     { thinking: undefined, thinkingDefault: "high" as const, expected: "high" },
     { thinking: "medium", thinkingDefault: "high" as const, expected: "medium" },
   ])("sends $expected for Astra with configured effort $thinking/$thinkingDefault", (testCase) => {

--- a/extensions/microsoft-foundry/index.test.ts
+++ b/extensions/microsoft-foundry/index.test.ts
@@ -1846,7 +1846,7 @@ assert.equal(afterOldest, 130, "the evicted account must refresh through az");
         params: { canonicalModelId: "claude-fable-5" },
       }),
     ).toMatchObject({
-      defaultLevel: "high",
+      defaultLevel: "medium",
       levels: [{ id: "low" }, { id: "medium" }, { id: "high" }, { id: "xhigh" }, { id: "max" }],
     });
     for (const modelName of ["claude-opus-4-6", "claude-sonnet-4-6"]) {

--- a/extensions/openai/provider-policy-api.test.ts
+++ b/extensions/openai/provider-policy-api.test.ts
@@ -121,9 +121,9 @@ describe("OpenAI provider policy artifact", () => {
   });
 
   it.each([
-    ["gpt-6-astra", "codex", "low"],
-    ["gpt-6-astra", "openclaw", "low"],
-    ["gpt-6-astra", "auto", "low"],
+    ["gpt-6-astra", "codex", "medium"],
+    ["gpt-6-astra", "openclaw", "medium"],
+    ["gpt-6-astra", "auto", "medium"],
     ["gpt-5.6-sol", "codex", "medium"],
     ["gpt-5.6-sol", "openclaw", "medium"],
     ["gpt-5.6-terra", "codex", "medium"],

--- a/extensions/openai/thinking-policy.test.ts
+++ b/extensions/openai/thinking-policy.test.ts
@@ -41,6 +41,7 @@ describe("OpenAI thinking route provenance", () => {
     { efforts: [], defaultLevel: undefined },
     { efforts: ["high"], defaultLevel: undefined },
     { efforts: ["low", "high"], defaultLevel: "low" },
+    { efforts: ["medium", "high"], defaultLevel: "medium" },
   ])("retains Astra account efforts $efforts", ({ efforts, defaultLevel }) => {
     const profile = resolveUnifiedOpenAIThinkingProfile("gpt-6-astra", "codex", {
       supportedReasoningEfforts: efforts,

--- a/extensions/openai/thinking-policy.ts
+++ b/extensions/openai/thinking-policy.ts
@@ -104,9 +104,14 @@ function buildOpenAIThinkingProfile(params: {
     // Preserve narrower account capabilities while exposing the supported runtime mode.
     const supportsUltra =
       ["openclaw", "codex", "auto"].includes(agentRuntime) && efforts.includes("max");
+    const defaultLevel = efforts.includes("medium")
+      ? "medium"
+      : efforts.includes("low")
+        ? "low"
+        : undefined;
     return {
       levels: buildCodexLevels(supportsUltra ? [...efforts, "ultra"] : efforts),
-      ...(efforts.includes("low") ? { defaultLevel: "low" as const } : {}),
+      ...(defaultLevel ? { defaultLevel } : {}),
     };
   }
   const resolvedCodexEfforts =

--- a/packages/ai/src/providers/anthropic-model-contract.ts
+++ b/packages/ai/src/providers/anthropic-model-contract.ts
@@ -1,5 +1,6 @@
 // Model-bound thinking cannot be exposed or replayed after a model switch.
 import {
+  CLAUDE_FABLE_5_THINKING_PROFILE,
   requiresClaudeDefaultSampling,
   requiresClaudeMandatoryAdaptiveThinking,
   resolveClaudeFable5ModelIdentity,
@@ -105,7 +106,7 @@ export function requiresClaudeAdaptiveThinking(model: {
   return requiresClaudeMandatoryAdaptiveThinking(model);
 }
 
-/** Return whether omitted thinking should default to adaptive/high. */
+/** Return whether omitted thinking should default to adaptive mode. */
 export function defaultsClaudeAdaptiveThinking(model: {
   id?: string;
   params?: Record<string, unknown>;
@@ -124,6 +125,9 @@ export function resolveAnthropicThinkingEffort(
   model: Model<"anthropic-messages">,
   level: SimpleStreamOptions["reasoning"],
 ): AnthropicEffort {
+  if (level === undefined && resolveClaudeFable5ModelIdentity(model)) {
+    return CLAUDE_FABLE_5_THINKING_PROFILE.defaultLevel;
+  }
   const requestedLevel = level as ModelThinkingLevel | undefined;
   const thinkingLevelMap = resolveClaudeNativeThinkingLevelMap(model);
   const clampModel = {

--- a/packages/ai/src/providers/anthropic-model-contract.ts
+++ b/packages/ai/src/providers/anthropic-model-contract.ts
@@ -125,10 +125,11 @@ export function resolveAnthropicThinkingEffort(
   model: Model<"anthropic-messages">,
   level: SimpleStreamOptions["reasoning"],
 ): AnthropicEffort {
-  if (level === undefined && resolveClaudeFable5ModelIdentity(model)) {
-    return CLAUDE_FABLE_5_THINKING_PROFILE.defaultLevel;
-  }
-  const requestedLevel = level as ModelThinkingLevel | undefined;
+  const requestedLevel: ModelThinkingLevel | undefined =
+    level ??
+    (resolveClaudeFable5ModelIdentity(model)
+      ? CLAUDE_FABLE_5_THINKING_PROFILE.defaultLevel
+      : undefined);
   const thinkingLevelMap = resolveClaudeNativeThinkingLevelMap(model);
   const clampModel = {
     ...model,

--- a/packages/ai/src/providers/anthropic.test.ts
+++ b/packages/ai/src/providers/anthropic.test.ts
@@ -1924,8 +1924,8 @@ describe("Anthropic provider", () => {
     },
   );
 
-  it.each(["low", "medium", "high", "xhigh", "max"] as const)(
-    "preserves pooled Fable %s effort and its routed model id",
+  it.each([undefined, "low", "medium", "high", "xhigh", "max"] as const)(
+    "sends pooled Fable %s effort and preserves its routed model id",
     async (reasoning) => {
       const id = "Claude Gateway/claude-fable-5-1";
       const { payload } = await captureSimpleAnthropicPayload(
@@ -1934,7 +1934,7 @@ describe("Anthropic provider", () => {
       );
       expect(payload.model).toBe(id);
       expect(payload.thinking).toMatchObject({ type: "adaptive" });
-      expect(payload.output_config).toEqual({ effort: reasoning });
+      expect(payload.output_config).toEqual({ effort: reasoning ?? "medium" });
     },
   );
 
@@ -1977,7 +1977,7 @@ describe("Anthropic provider", () => {
       options: { temperature: 0.2 },
       expected: {
         thinking: { type: "adaptive", display: "summarized" },
-        output_config: { effort: "high" },
+        output_config: { effort: "medium" },
       },
       absent: ["temperature"],
     },

--- a/packages/ai/src/providers/anthropic.test.ts
+++ b/packages/ai/src/providers/anthropic.test.ts
@@ -2227,20 +2227,24 @@ describe("Anthropic provider", () => {
     }
   });
 
-  it("honors provider effort restrictions for Claude Fable 5", async () => {
+  it.each([
+    { reasoning: "xhigh", thinkingLevelMap: { xhigh: null, max: null }, effort: "high" },
+    { reasoning: undefined, thinkingLevelMap: { medium: null }, effort: "high" },
+    { reasoning: undefined, thinkingLevelMap: { medium: "low" }, effort: "low" },
+  ] as const)("honors provider effort restrictions for Claude Fable 5: %j", async (testCase) => {
     const { payload } = await captureSimpleAnthropicPayload(
       {
         id: "claude-fable-5",
         name: "Claude Fable 5",
         provider: "github-copilot",
         reasoning: false,
-        thinkingLevelMap: { xhigh: null, max: null },
+        thinkingLevelMap: testCase.thinkingLevelMap,
       },
-      { apiKey: "copilot-token", reasoning: "xhigh" },
+      { apiKey: "copilot-token", reasoning: testCase.reasoning },
     );
     expect(payload).toMatchObject({
       thinking: { type: "adaptive", display: "summarized" },
-      output_config: { effort: "high" },
+      output_config: { effort: testCase.effort },
     });
   });
 

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -366,7 +366,6 @@ export const streamSimpleAnthropic: StreamFunction<
     return streamAnthropic(model, context, {
       ...base,
       thinkingEnabled: mandatoryAdaptiveThinking,
-      ...(mandatoryAdaptiveThinking ? { effort: "high" as const } : {}),
     } satisfies AnthropicCompactionOptions);
   }
 

--- a/packages/ai/src/transports/anthropic-messages.ts
+++ b/packages/ai/src/transports/anthropic-messages.ts
@@ -18,6 +18,7 @@ import type { AnthropicOptions, AnthropicThinkingDisplay } from "../provider-opt
 import {
   bindsClaudeThinkingPrefix,
   requiresClaudeAdaptiveThinking,
+  resolveAnthropicThinkingEffort,
   supportsClaudeAdaptiveThinking,
   supportsClaudeNativeXhighEffort,
 } from "../providers/anthropic-model-contract.js";
@@ -396,7 +397,11 @@ export function buildAnthropicGenerationParams({
       if (supportsClaudeAdaptiveThinking(model)) {
         // Adaptive thinking: Claude decides when and how much to think.
         params.thinking = { type: "adaptive", display };
-        const effort = options?.effort ?? (mandatoryAdaptiveThinking ? "high" : undefined);
+        const effort =
+          options?.effort ??
+          (mandatoryAdaptiveThinking
+            ? resolveAnthropicThinkingEffort(model, undefined)
+            : undefined);
         if (effort) {
           params.output_config = { effort };
         }

--- a/packages/ai/src/transports/anthropic-transport-stream.test.ts
+++ b/packages/ai/src/transports/anthropic-transport-stream.test.ts
@@ -4218,7 +4218,7 @@ describe("anthropic transport stream", () => {
 
     const payload = latestAnthropicRequest().payload;
     expect(payload.thinking).toEqual({ type: "adaptive", display: "summarized" });
-    expect(payload.output_config).toEqual({ effort: "high" });
+    expect(payload.output_config).toEqual({ effort: "medium" });
     expect(payload.tool_choice).toEqual({ type: "auto" });
     expect(payload).not.toHaveProperty("temperature");
     expect(result.responseModel).toBe("claude-fable-5");

--- a/packages/ai/src/transports/anthropic-transport-stream.ts
+++ b/packages/ai/src/transports/anthropic-transport-stream.ts
@@ -687,7 +687,7 @@ function resolveAnthropicTransportOptions(
   if (!reasoning) {
     resolved.thinkingEnabled = defaultsClaudeAdaptiveThinking(model);
     if (resolved.thinkingEnabled) {
-      resolved.effort = "high";
+      resolved.effort = resolveAnthropicThinkingEffort(model, reasoning);
     }
     return resolved;
   }

--- a/packages/llm-core/src/model-contracts/anthropic.ts
+++ b/packages/llm-core/src/model-contracts/anthropic.ts
@@ -17,7 +17,7 @@ function normalizeClaudeModelId(modelId?: string): string {
 
 export const CLAUDE_FABLE_5_THINKING_PROFILE = {
   levels: [{ id: "low" }, { id: "medium" }, { id: "high" }, { id: "xhigh" }, { id: "max" }],
-  defaultLevel: "high",
+  defaultLevel: "medium",
   preserveWhenCatalogReasoningFalse: true,
 } as const;
 

--- a/src/auto-reply/thinking.test.ts
+++ b/src/auto-reply/thinking.test.ts
@@ -395,7 +395,15 @@ describe("listThinkingLevels", () => {
         model: "company-fable",
         catalog,
       }),
-    ).toBe("high");
+    ).toBe("medium");
+    expect(
+      resolveSupportedThinkingLevel({
+        provider: "microsoft-foundry",
+        model: "company-fable",
+        level: "adaptive",
+        catalog,
+      }),
+    ).toBe("medium");
   });
 
   it("exposes Claude Opus xhigh on custom anthropic-messages providers without a plugin profile", () => {

--- a/src/gateway/server-methods/models.test.ts
+++ b/src/gateway/server-methods/models.test.ts
@@ -411,7 +411,7 @@ describe("models.list", () => {
               id: level,
               label: level,
             })),
-            thinkingDefault: "high",
+            thinkingDefault: "medium",
           },
         ],
       });

--- a/src/gateway/session-utils-model.thinking-default.test.ts
+++ b/src/gateway/session-utils-model.thinking-default.test.ts
@@ -81,7 +81,7 @@ describe.each([
   { agentRuntime: "codex", api: "openai-chatgpt-responses" as const },
 ])("Gateway model thinking defaults on $agentRuntime", ({ agentRuntime, api }) => {
   it.each<{ name: string; cfg: OpenClawConfig; expected: string }>([
-    { name: "provider default", cfg: {}, expected: "low" },
+    { name: "provider default", cfg: {}, expected: "medium" },
     {
       name: "global override",
       cfg: { agents: { defaults: { thinkingDefault: "high" } } },

--- a/src/plugin-sdk/provider-model-shared.test.ts
+++ b/src/plugin-sdk/provider-model-shared.test.ts
@@ -454,17 +454,18 @@ describe("resolveClaudeThinkingProfile", () => {
     expectLevelIdsInclude(profile, ["off", "xhigh", "adaptive", "max"]);
   });
 
-  it.each(["claude-fable-5", "claude-mythos-5"])(
-    "exposes %s's mandatory-adaptive profile to Claude providers",
-    (modelId) => {
-      const profile = resolveClaudeThinkingProfile(modelId);
-      expectFields(profile, {
-        defaultLevel: "high",
-        preserveWhenCatalogReasoningFalse: true,
-      });
-      expect(readLevelIds(profile)).toEqual(["low", "medium", "high", "xhigh", "max"]);
-    },
-  );
+  it.each([
+    ["claude-fable-5", "medium"],
+    ["claude-fable-5-1", "medium"],
+    ["claude-mythos-5", "high"],
+  ])("exposes %s's mandatory-adaptive profile to Claude providers", (modelId, defaultLevel) => {
+    const profile = resolveClaudeThinkingProfile(modelId);
+    expectFields(profile, {
+      defaultLevel,
+      preserveWhenCatalogReasoningFalse: true,
+    });
+    expect(readLevelIds(profile)).toEqual(["low", "medium", "high", "xhigh", "max"]);
+  });
 
   it("keeps Mythos Preview mandatory adaptive without claiming the Claude 5 effort ladder", () => {
     const profile = resolveClaudeThinkingProfile("claude-mythos-preview");

--- a/src/plugins/provider-claude-thinking.ts
+++ b/src/plugins/provider-claude-thinking.ts
@@ -42,8 +42,11 @@ export function resolveClaudeThinkingProfile(
 ): ProviderThinkingProfile {
   const ref = { id: modelId, params };
   const canonicalModelId = resolveClaudeModelIdentity(ref);
-  if (resolveClaudeFable5ModelIdentity(ref) || resolveClaudeMythos5ModelIdentity(ref)) {
+  if (resolveClaudeFable5ModelIdentity(ref)) {
     return CLAUDE_FABLE_5_THINKING_PROFILE;
+  }
+  if (resolveClaudeMythos5ModelIdentity(ref)) {
+    return { ...CLAUDE_FABLE_5_THINKING_PROFILE, defaultLevel: "high" };
   }
   // Before the generic xhigh branch: Opus 5 defaults thinking on ("high"),
   // unlike Opus 4.7/4.8 whose omitted-thinking default is off.

--- a/ui/src/e2e/new-session-page.cloud-dispatch.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.cloud-dispatch.e2e.test.ts
@@ -421,10 +421,9 @@ suite.define(() => {
       const retainedCloudProfile = place.locator('[data-value="cloud:aws"]');
       await expect.poll(() => retainedCloudProfile.isDisabled()).toBe(false);
       await retainedCloudProfile.click();
-      await expect.poll(() => place.locator('[data-value="machine:fast"]').isVisible()).toBe(true);
-      expect(await place.locator('[data-value="machine:fast"]').getAttribute("aria-pressed")).toBe(
-        "true",
-      );
+      const retainedMachine = place.locator('[data-value="machine:fast"]');
+      await expect.poll(() => retainedMachine.isVisible()).toBe(true);
+      expect(await retainedMachine.getAttribute("aria-pressed")).toBe("true");
       if (captureUiProofEnabled) {
         await writeFile(
           path.join(

--- a/ui/src/e2e/new-session-page.cloud-dispatch.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.cloud-dispatch.e2e.test.ts
@@ -421,9 +421,10 @@ suite.define(() => {
       const retainedCloudProfile = place.locator('[data-value="cloud:aws"]');
       await expect.poll(() => retainedCloudProfile.isDisabled()).toBe(false);
       await retainedCloudProfile.click();
-      const retainedMachine = place.locator('[data-value="machine:fast"]');
-      await expect.poll(() => retainedMachine.isVisible()).toBe(true);
-      expect(await retainedMachine.getAttribute("aria-pressed")).toBe("true");
+      await expect.poll(() => place.locator('[data-value="machine:fast"]').isVisible()).toBe(true);
+      expect(await place.locator('[data-value="machine:fast"]').getAttribute("aria-pressed")).toBe(
+        "true",
+      );
       if (captureUiProofEnabled) {
         await writeFile(
           path.join(


### PR DESCRIPTION
## What Problem This Solves

Set OpenClaw's default reasoning effort to Medium for Claude Fable 5/5.1 and GPT-6 Astra, following the maintainer's requested preference. Fable previously selected High and Astra selected Low.

## Why This Change Was Made

Fable's shared model profile now owns the Medium default. Anthropic provider calls, managed transports, and Vertex use that same effort resolver for omitted effort, including route-specific restrictions and mappings. Bedrock derives Fable's default through the existing shared Claude contract and resolves omission once when constructing its final request, including regional IDs, canonical aliases, and named inference profiles. Its route-specific choices and mappings remain intact. Mythos and Sonnet retain their High defaults.

Astra's OpenAI provider policy selects Medium across OpenClaw, Codex, and auto runtime policies when the account advertises it. Accounts with narrower effort lists retain a supported fallback. The native Codex client consumes an explicit effort before its catalog default, so this policy belongs in OpenClaw.

## User Impact

OpenClaw-managed turns without an explicit effort use Medium on Fable and Astra. Existing agent, model, global, and session settings keep their precedence, and supported explicit efforts remain intact. Stored Adaptive settings on routes that no longer advertise Adaptive resolve to the model default at the existing logical-policy boundary before scalar request construction. Bedrock retains its explicit Off-to-Low behavior. Use `/think default` to clear a session override and inherit the model default.

## Evidence

- Updated Fable and Astra default assertions failed before implementation. Captured Anthropic requests exposed the independent High fallback and now send Medium when effort is omitted.
- The broader route sweep passed 551 cases across Astra-related unit tests, native Codex requests, Gateway projection, and Bedrock policies/payloads. Earlier Anthropic, Vertex, and saved-setting suites also passed. Explicit overrides and unrelated model defaults remain covered.
- Five new Bedrock omitted-effort cases failed against the old policy/runtime. After restoring the candidate, all 26 request-composition cases passed, covering direct/regional refs, canonical aliases, named profiles, and explicit Off.
- Native Codex turn tests verify both outgoing effort fields; Gateway tests verify the Control UI projection on both runtimes. Their old Low expectations were corrected without weakening override assertions.
- Vertex payload regressions failed on all three old Fable defaults while Mythos stayed High. The full Vertex suite passed 78 cases. The final Anthropic/transport/model-utility/Vertex run passed 286 cases, including two omitted-effort route-map regressions that failed before the fix.
- Independent reviews of the model change, cloud-provider completion, and route-mapping fix are clean through P3. Saved Adaptive normalization stays at its existing logical-policy owner; the scalar request contract was not widened.
- Scoped type, lint, formatting, and guard checks cover the changed paths. Removing an unnecessary type assertion also shrinks its existing allowance by one.
- Current Anthropic, Vertex, Bedrock, OpenAI, and Codex routing guidance reflects OpenClaw's Medium preference. Historical release notes remain historical.
- The rebase absorbed main's independent screenshot-test repair in #145540. The PR contains no UI code or browser-test changes.
- Live provider inference and deployment were not performed.
