### PR TITLE
refactor: remove unused update-repair test import hook

### DIFF
--- a/src/infra/update-managed-service-handoff-repair.test-support.ts
+++ b/src/infra/update-managed-service-handoff-repair.test-support.ts
@@ -133,31 +133,12 @@ export async function managedRepairUpdaterScript(params: {
   const repairModule = new URL("../cli/update-cli/update-command-repair.ts", import.meta.url).href;
   const admissionModule = new URL("../cli/update-cli/update-command-run.ts", import.meta.url).href;
   const sentinelModule = new URL("./update-control-plane-sentinel.ts", import.meta.url).href;
-  const sourceRuntimePaths = ["js", "ts"].map(
-    (extension) => new URL(`./update-repair-agent.runtime.${extension}`, import.meta.url).pathname,
-  );
-  const builtRuntime = new URL("../../dist/update-repair-agent.runtime.js", import.meta.url).href;
   const installRoot = params.phase === "verifying" ? candidate : params.root;
   return `void (async () => {
     // Source workers resolve the checkout's toolchain from the driver cwd.
     process.chdir(${JSON.stringify(path.resolve("."))});
     ${params.sourceRuntimeImport}
     const fs = require("node:fs");
-    // Match the repair E2E's compiled host execution without replacing source admission or orchestration.
-    const sourceRuntimePaths = new Set(${JSON.stringify(sourceRuntimePaths)});
-    const { registerHooks } = require("node:module");
-    registerHooks({
-      resolve(specifier, context, nextResolve) {
-        if ((specifier.startsWith(".") || specifier.startsWith("file:")) && context.parentURL &&
-            sourceRuntimePaths.has(new URL(specifier, context.parentURL).pathname)) {
-          return { url: ${JSON.stringify(builtRuntime)}, shortCircuit: true };
-        }
-        const resolved = nextResolve(specifier, context);
-        return sourceRuntimePaths.has(new URL(resolved.url).pathname)
-          ? { url: ${JSON.stringify(builtRuntime)}, shortCircuit: true }
-          : resolved;
-      },
-    });
     process.stderr.write("repair-boundary: loading admission\\n");
     const { runUpdateCommandRepair } = await import(${JSON.stringify(repairModule)});
     const { admitUpdateCommandRun } = await import(${JSON.stringify(admissionModule)});


### PR DESCRIPTION
## What Problem This Solves

Update-repair lifecycle tests still intercepted parent-process imports after both repair phases moved into compiled candidate workers. The redirect was unused but ran checks during thousands of module resolutions in each fixture process.

## Why This Change Was Made

Remove the obsolete parent import hook and its two supporting variables. The source updater still performs admission and orchestration, and the candidate worker retains its existing spawn recorder and runtime loading. This follows the worker ownership established in #145044.

## User Impact

No production behavior changes. Test setup loses 19 lines of unused machinery while retaining the same four validating/verifying and current/revoked-requester cases, real effects, authority checks, cleanup, and deadlines. Production LOC delta: 0; test-support delta: −19.

## Evidence

A diagnostic on the original fixture observed 50,184 parent-hook resolutions and zero redirects across all four cases. Separate uninstrumented original and candidate runs both passed the same four cases in their original order, with identical inventory/status digests.

The local case-duration sum was 265.446s before and 145.415s after; wrapper times were 296.704s and 284.126s. These are observations, not a causal CI speed claim: the candidate alone triggered a 113.5s canonical pretest runtime build, which can prime caches, and the host showed timing variability. No cache reset, readiness bypass, retries, or deadline changes were used.

Validation: the four existing lifecycle cases passed on both sources; independent P2 review found no actionable findings. Core-test types, scoped guards, formatting, and targeted lint passed. The initial scoped run stopped at two unrelated unused UI exports on its older base. Current main already contained their exact cleanup; the patch was carried onto `04aac5be` with all 15 relevant repair owners unchanged, and the failed export scan passed there. This is composite validation; the original failed run is retained. Exact-head hosted CI remains the landing gate.
