### PR TITLE
fix(scripts): preserve npm signals in package checks

### DIFF
--- a/scripts/lib/npm-pack-inventory.mts
+++ b/scripts/lib/npm-pack-inventory.mts
@@ -115,21 +115,21 @@ function describeSpawnFailure(
   result: ReturnType<typeof spawnSync>,
   timeoutMs: number,
 ): string {
-  const error = result.error as NodeJS.ErrnoException | undefined;
-  const knownFailure = error?.code
-    ? (
-        {
-          ENOBUFS: "exceeded its output limit",
-          ENOENT: "executable was not found",
-          ETIMEDOUT: `timed out after ${timeoutMs}ms`,
-        } as Record<string, string>
-      )[error.code]
-    : undefined;
-  if (knownFailure) {
-    return `${label} ${knownFailure}`;
+  // Output-limit and timeout errors can also carry the signal used to stop the child.
+  switch ((result.error as NodeJS.ErrnoException | undefined)?.code) {
+    case "ENOBUFS":
+      return `${label} exceeded its output limit`;
+    case "ENOENT":
+      return `${label} executable was not found`;
+    case "ETIMEDOUT":
+      return `${label} timed out after ${timeoutMs}ms`;
+    default: {
+      const stderr = typeof result.stderr === "string" ? result.stderr.trim().slice(0, 2_000) : "";
+      const reason = result.signal ? `signal ${result.signal}` : `status ${String(result.status)}`;
+      const detail = stderr ? `: ${stderr}` : "";
+      return `${label} failed${result.signal || !stderr ? ` with ${reason}` : ""}${detail}`;
+    }
   }
-  const stderr = typeof result.stderr === "string" ? result.stderr.trim().slice(0, 2_000) : "";
-  return `${label} failed${stderr ? `: ${stderr}` : ` with status ${String(result.status)}`}`;
 }
 
 function withoutPackageScripts<T>(packageRoot: string, run: () => T): T {

--- a/test/scripts/npm-pack-inventory.test.ts
+++ b/test/scripts/npm-pack-inventory.test.ts
@@ -1,4 +1,4 @@
-import { chmodSync, mkdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
 import { delimiter, join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
@@ -154,11 +154,78 @@ describe("npm pack inventory", () => {
   });
 
   it.each([
-    { name: "successful pack", exitCode: 0 },
-    { name: "failed pack", exitCode: 23 },
+    {
+      name: "successful pack",
+      phase: "pack",
+      exitCode: 0,
+      signal: null,
+      stderr: "",
+      expectedError: null,
+    },
+    {
+      name: "failed pack",
+      phase: "pack",
+      exitCode: 23,
+      signal: null,
+      stderr: "simulated npm 10 failure\n",
+      expectedError: "npm pack inventory failed: simulated npm 10 failure",
+    },
+    {
+      name: "silent failed pack",
+      phase: "pack",
+      exitCode: 23,
+      signal: null,
+      stderr: "",
+      expectedError: "npm pack inventory failed with status 23",
+    },
+    ...(process.platform === "win32"
+      ? []
+      : [
+          {
+            name: "version output limit",
+            phase: "version",
+            exitCode: 23,
+            signal: null,
+            stderr: "x".repeat(128 * 1024),
+            expectedError: "npm --version exceeded its output limit",
+          },
+          {
+            name: "SIGTERM pack",
+            phase: "pack",
+            exitCode: null,
+            signal: "SIGTERM",
+            stderr: "",
+            expectedError: "npm pack inventory failed with signal SIGTERM",
+          },
+          {
+            name: "SIGKILL pack with stderr",
+            phase: "pack",
+            exitCode: null,
+            signal: "SIGKILL",
+            stderr: "simulated npm 10 failure\n",
+            expectedError:
+              "npm pack inventory failed with signal SIGKILL: simulated npm 10 failure",
+          },
+          {
+            name: "SIGTERM version with stderr",
+            phase: "version",
+            exitCode: null,
+            signal: "SIGTERM",
+            stderr: "simulated npm 10 failure\n",
+            expectedError: "npm --version failed with signal SIGTERM: simulated npm 10 failure",
+          },
+          {
+            name: "SIGKILL version",
+            phase: "version",
+            exitCode: null,
+            signal: "SIGKILL",
+            stderr: "",
+            expectedError: "npm --version failed with signal SIGKILL",
+          },
+        ]),
   ])(
-    "suppresses npm 10 lifecycle scripts and restores package.json after $name",
-    ({ exitCode }) => {
+    "preserves npm probe outcomes and package.json after $name",
+    ({ phase, exitCode, signal, stderr, expectedError }) => {
       const { packageRoot, root } = createPackageFixture();
       const packageJsonPath = join(packageRoot, "package.json");
       const capturePath = join(root, "scripts-capture.json");
@@ -168,35 +235,48 @@ describe("npm pack inventory", () => {
       writeFileSync(packageJsonPath, originalBytes);
       chmodSync(packageJsonPath, 0o444);
       const originalMode = statSync(packageJsonPath).mode;
+      const failureBody = [
+        // Write before native termination so the fixture cannot discard its own stderr.
+        stderr ? `fs.writeSync(2, ${JSON.stringify(stderr)});` : "",
+        signal
+          ? `process.kill(process.pid, ${JSON.stringify(signal)});`
+          : `process.exit(${exitCode});`,
+      ].join("\n");
+      const versionBody =
+        phase === "version" ? failureBody : "process.stdout.write('10.9.4\\n'); process.exit(0);";
       const npm = fakeNpmEnvironment(
         root,
         [
           "import fs from 'node:fs';",
           "import path from 'node:path';",
-          "if (process.argv.includes('--version')) { process.stdout.write('10.9.4\\n'); process.exit(0); }",
+          `if (process.argv.includes('--version')) { ${versionBody} }`,
           "const packIndex = process.argv.indexOf('pack');",
           "const packageRoot = process.argv[packIndex + 1];",
           "const packageJson = JSON.parse(fs.readFileSync(path.join(packageRoot, 'package.json'), 'utf8'));",
           "fs.writeFileSync(process.env.OPENCLAW_TEST_CAPTURE, JSON.stringify({ hasScripts: Object.hasOwn(packageJson, 'scripts') }));",
           exitCode === 0
             ? "process.stdout.write(JSON.stringify([{ files: [{ path: 'package.json' }] }]));"
-            : `process.stderr.write('simulated npm 10 failure\\n'); process.exit(${exitCode});`,
+            : failureBody,
         ].join("\n"),
       );
       npm.sourceEnv.OPENCLAW_TEST_CAPTURE = capturePath;
 
-      if (exitCode === 0) {
+      if (expectedError === null) {
         expect(collectNpmPackInventory(packageRoot, { ...npm, timeoutMs: 2_000 })).toMatchObject({
           files: ["package.json"],
           npmVersion: "10.9.4",
         });
       } else {
         expect(() => collectNpmPackInventory(packageRoot, { ...npm, timeoutMs: 2_000 })).toThrow(
-          "npm pack inventory failed: simulated npm 10 failure",
+          expectedError,
         );
       }
 
-      expect(JSON.parse(readFileSync(capturePath, "utf8"))).toEqual({ hasScripts: false });
+      if (phase === "pack") {
+        expect(JSON.parse(readFileSync(capturePath, "utf8"))).toEqual({ hasScripts: false });
+      } else {
+        expect(existsSync(capturePath)).toBe(false);
+      }
       expect(readFileSync(packageJsonPath)).toEqual(originalBytes);
       expect(statSync(packageJsonPath).mode).toBe(originalMode);
     },


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where package validation loses the reason npm was terminated. A signal-only failure is reported as `with status null`; when npm writes stderr first, the checker omits the signal entirely.

## Why This Change Was Made

Keep the existing npm inventory diagnostic owner and replace its temporary error-message lookup with an exhaustive switch. Recognized output-limit, missing-executable and timeout errors retain priority; the default branch assembles the native signal or exit status and bounded stderr once.

Production is **14 lines added / 14 removed, net 0**. Tests are +90/-10. No extra parser, configuration, dependency or compatibility path is introduced. npm selection, timeouts, output bounds, package.json restoration and the checker's acceptance rules remain unchanged.

## User Impact

The public tarball checker now reports `SIGTERM` or `SIGKILL` for an interrupted npm inventory probe, retaining any bounded stderr. This improves package-validation diagnostics; it does not change installed update, Doctor, Gateway, service or plugin-loading behavior, and a SIGKILL diagnostic does not assert an out-of-memory cause.

## Evidence

- Native baseline tests reproduced four missing-signal failures and passed 13 controls. The final repair passes **26 focused tests**: 17 inventory cases and nine npm-runner cases. Controls cover ordinary exits, output limits, missing npm, timeouts, script suppression and exact package.json bytes/mode restoration.
- Full changed-file checks pass. The first switch proposal failed the exhaustiveness lint rule; the final fallback owns the default branch and passes that original check. Fresh independent review of the final diff found no actionable P0–P2 findings.
- The ordinary `scripts/check-openclaw-package-tarball.mjs` entry was exercised through its normal loader with terminal stdin and separate output pipes. Each phase used the same modern synthetic archive, byte-identical Node/libnode copies, genuine npm 11.19.0 for healthy/version calls, and identical controlled npm fixture sources for the faults.
- Both healthy controls accepted the archive with exit 0. Before repair, native SIGTERM produced `status null`, and SIGKILL plus stderr lost the signal. After repair, both named the correct signal and retained the same 2,000-character stderr bound, with natural checker exit 1. All six paired runs verified process identities, group/pipe cleanup and unchanged sealed inputs. The baseline was repeated under the final candidate's source binding after lint refinement.

This is synthetic terminal-input package-checker proof, not an install/update or release qualification. Seals cover the named Node/libnode/npm and checkout inputs, not the complete operating-system native-library image set. Local evidence is bound to the reviewed precommit source; commit identity is verified separately. Required hosted CI remains a landing gate.
