### PR TITLE
test(ui): restore the retained machine reference in the cloud-dispatch e2e proof

### DIFF
--- a/ui/src/e2e/new-session-page.cloud-dispatch.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.cloud-dispatch.e2e.test.ts
@@ -421,10 +421,9 @@ suite.define(() => {
       const retainedCloudProfile = place.locator('[data-value="cloud:aws"]');
       await expect.poll(() => retainedCloudProfile.isDisabled()).toBe(false);
       await retainedCloudProfile.click();
-      await expect.poll(() => place.locator('[data-value="machine:fast"]').isVisible()).toBe(true);
-      expect(await place.locator('[data-value="machine:fast"]').getAttribute("aria-pressed")).toBe(
-        "true",
-      );
+      const retainedMachine = place.locator('[data-value="machine:fast"]');
+      await expect.poll(() => retainedMachine.isVisible()).toBe(true);
+      expect(await retainedMachine.getAttribute("aria-pressed")).toBe("true");
       if (captureUiProofEnabled) {
         await writeFile(
           path.join(


### PR DESCRIPTION
Superseded by #145540, merged as `41861b8055af6088eac51ba82f1a9494b01bf8dd` while this repair was being validated. That change uses the same Fast-machine locator inline and has successful `check-test-types` and `openclaw/ci-gate` checks. Closing this duplicate; the evidence below remains the independent reproduction and verification.

Refs #145463 #145501

<details>
<summary>Additional instructions</summary>

Maintainers can edit this same-repository branch.

</details>

## What Problem This Solves

Resolves a problem where `check-test-types` fails on main and downstream PRs because the cloud-dispatch E2E proof references an undefined retained machine. The capture-enabled browser flow also fails before it can record the retained cloud configuration.

Reported failure: https://github.com/openclaw/openclaw/actions/runs/34667898213/job/103483522622

## Why This Change Was Made

Restore the existing `machine:fast` locator as `retainedMachine` and reuse it for the visibility assertion, selected-state assertion, and screenshot content. The existing cloud-profile retention and dispatch assertions remain intact.

History shows #145436 inlined the locator, while #145463 added the screenshot reference. The green #145463 head (`21458750915ff32e9c324df99f85055c3e4cd542`) still declared the locator; its type-check log explicitly includes the `ui-e2e` graph. The combined landed tree lost that declaration, so this is an integration regression rather than an omitted typed shard.

## User Impact

Restores the affected CI type gate and screenshot proof. There is no production UI or runtime behavior change. This is the explicitly requested L145 maintainer repair for the known main failure.

## Evidence

- `node scripts/run-tsgo-core-test-shards.mjs --changed-paths-json '["ui/src/e2e/new-session-page.cloud-dispatch.e2e.test.ts"]'`: before, TS2304 at line 438; after, `core test graphs: ui-e2e`, exit 0.
- `OPENCLAW_CAPTURE_UI_PROOF=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/new-session-page.cloud-dispatch.e2e.test.ts`: before, 1 failed / 1 passed with `ReferenceError: retainedMachine is not defined` at line 438; after, 2 passed. Inspected the resulting retention screenshot: the aws profile and selected Fast machine are visible.
- `node scripts/check-changed.mjs`: passed (formatting, guards, ui-e2e types, i18n validation, dead exports, and targeted lint).
- Fresh P1 autoreview: scoped-clean, no accepted/actionable findings.

The existing capture-enabled E2E is the regression proof; no duplicate test or production seam was added. Live cloud provisioning is outside this test-only repair.
