### PR TITLE
fix(process): preserve descendant output under Bun stalls

### DIFF
--- a/src/process/child-process.ts
+++ b/src/process/child-process.ts
@@ -13,12 +13,12 @@ const EXIT_STDIO_MAX_DRAIN_MS = 1_000;
  */
 export function releaseChildProcessOutputAfterExit(child: ChildProcess): () => void {
   let idleTimer: NodeJS.Timeout | undefined;
-  let releaseImmediate: NodeJS.Immediate | undefined;
+  let releaseTimer: NodeJS.Timeout | undefined;
   let deadlineTimer: NodeJS.Timeout | undefined;
 
   const cleanup = () => {
     clearTimeout(idleTimer);
-    clearImmediate(releaseImmediate);
+    clearTimeout(releaseTimer);
     clearTimeout(deadlineTimer);
     child.removeListener("exit", onExit);
     child.stdout?.removeListener("data", onData);
@@ -31,14 +31,14 @@ export function releaseChildProcessOutputAfterExit(child: ChildProcess): () => v
   };
   const scheduleRelease = () => {
     // Either timer may run before already-buffered pipe data on a loaded loop.
-    // Share one cancellable release after poll has had a turn to drain it.
-    releaseImmediate ??= setImmediate(release);
-    releaseImmediate.unref();
+    // Defer to the next timers phase so both Node and Bun poll the pipes first.
+    releaseTimer ??= setTimeout(release, 0);
+    releaseTimer.unref();
   };
   const armIdleTimer = () => {
     clearTimeout(idleTimer);
-    clearImmediate(releaseImmediate);
-    releaseImmediate = undefined;
+    clearTimeout(releaseTimer);
+    releaseTimer = undefined;
     idleTimer = setTimeout(scheduleRelease, EXIT_STDIO_GRACE_MS);
     idleTimer.unref();
   };

--- a/src/process/exec.test.ts
+++ b/src/process/exec.test.ts
@@ -703,6 +703,9 @@ describe("runCommandBuffered", () => {
             const closed = once(parent, "close", { signal: AbortSignal.timeout(1_000) });
             await vi.advanceTimersByTimeAsync(timeoutMs - 101);
             await vi.advanceTimersByTimeAsync(100);
+            // Output release runs in the next timers phase so buffered pipe I/O
+            // gets a poll turn on both Node and Bun.
+            await vi.advanceTimersByTimeAsync(1);
             await closed;
             expect(await command).toMatchObject({ code: null, termination: "timeout" });
             expect(isPidAlive(descendantPid)).toBe(true);

--- a/src/process/exec.windows.test.ts
+++ b/src/process/exec.windows.test.ts
@@ -299,6 +299,7 @@ describe("Windows command execution", () => {
 
   it("spawns node plus npm-cli.js instead of npm.cmd when available", async () => {
     vi.spyOn(fs, "existsSync").mockReturnValue(true);
+    vi.spyOn(process, "execPath", "get").mockReturnValue("C:\\Program Files\\nodejs\\node.exe");
     await withMockedWindowsPlatform(async () => {
       void spawnCommand(["npm", "--version"]);
       const [command, args, options] = requireExecaCall(0);

--- a/src/process/terminal-pty-node.test.ts
+++ b/src/process/terminal-pty-node.test.ts
@@ -8,6 +8,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import { runtimeProcessEntrypoints } from "../infra/runtime-process-entrypoints.js";
 import { resolveRuntimeWorkerArgv, resolveRuntimeWorkerUrl } from "../infra/runtime-worker-url.js";
 import { createDeferredCore } from "../shared/deferred.js";
+import { resolveTestNodeExecPath } from "../test-utils/node-process.js";
 import { killPidIfAlive, waitForPidToExit } from "../test-utils/process-tree.js";
 import { spawnNodeTerminalPty } from "./terminal-pty-node.js";
 import type { TerminalPtyEvent } from "./terminal-pty-protocol.js";
@@ -94,7 +95,8 @@ describe.runIf(process.platform !== "win32")("Node-owned terminal PTY", () => {
 
   it("reaps the PTY and its background process when the owning host disconnects", async () => {
     const worker = resolveRuntimeWorkerUrl(runtimeProcessEntrypoints.terminalPty);
-    const child = spawn(process.execPath, resolveRuntimeWorkerArgv(worker), {
+    const node = resolveTestNodeExecPath();
+    const child = spawn(node, resolveRuntimeWorkerArgv(worker, node), {
       stdio: ["ignore", "pipe", "pipe", "ipc"],
       serialization: "json",
     });

--- a/src/process/terminal-pty.test.ts
+++ b/src/process/terminal-pty.test.ts
@@ -21,6 +21,21 @@ const { spawnTerminalPty } = await import("./terminal-pty.js");
 
 const tempDirs: string[] = [];
 
+async function spawnDirectTerminalPty(
+  params: Parameters<typeof spawnTerminalPty>[0],
+): ReturnType<typeof spawnTerminalPty> {
+  const bunDescriptor = Object.getOwnPropertyDescriptor(process.versions, "bun");
+  if (!bunDescriptor) {
+    return await spawnTerminalPty(params);
+  }
+  Object.defineProperty(process.versions, "bun", { ...bunDescriptor, value: undefined });
+  try {
+    return await spawnTerminalPty(params);
+  } finally {
+    Object.defineProperty(process.versions, "bun", bunDescriptor);
+  }
+}
+
 function createWindowsNpmShim(command: string) {
   const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-terminal-pty-shim-"));
   tempDirs.push(binDir);
@@ -55,7 +70,7 @@ function fakePty(pid = 4321) {
 async function spawnFakePty(pid = 4321) {
   const pty = fakePty(pid);
   mocks.spawn.mockReturnValueOnce(pty);
-  const handle = await spawnTerminalPty({
+  const handle = await spawnDirectTerminalPty({
     file: "/bin/sh",
     args: [],
     env: {},
@@ -126,7 +141,7 @@ describe("terminal PTY invocation", () => {
     async (env) => {
       mocks.spawn.mockReturnValueOnce(fakePty());
 
-      await spawnTerminalPty({
+      await spawnDirectTerminalPty({
         file: "/usr/bin/codex",
         args: ["resume", "thread"],
         env,
@@ -148,7 +163,7 @@ describe("terminal PTY invocation", () => {
   it("preserves an interactive TERM", async () => {
     mocks.spawn.mockReturnValueOnce(fakePty());
 
-    await spawnTerminalPty({
+    await spawnDirectTerminalPty({
       file: "/usr/bin/codex",
       args: [],
       env: { TERM: "screen-256color" },
@@ -170,7 +185,7 @@ describe("terminal PTY invocation", () => {
     vi.spyOn(process, "platform", "get").mockReturnValue("win32");
     mocks.spawn.mockReturnValueOnce(fakePty());
 
-    await spawnTerminalPty({
+    await spawnDirectTerminalPty({
       file: "powershell.exe",
       args: [],
       env: { Term: "screen-256color" },
@@ -204,7 +219,7 @@ describe("terminal PTY invocation", () => {
     vi.spyOn(process, "platform", "get").mockReturnValue("win32");
     mocks.spawn.mockReturnValueOnce(fakePty());
 
-    await spawnTerminalPty({
+    await spawnDirectTerminalPty({
       file: `C:\\Program Files\\Codex\\codex${extension}`,
       args: ["resume", "thread title"],
       env,
@@ -225,7 +240,7 @@ describe("terminal PTY invocation", () => {
       const { entrypoint, shimPath } = createWindowsNpmShim("codex");
       mocks.spawn.mockReturnValueOnce(fakePty());
 
-      await spawnTerminalPty({
+      await spawnDirectTerminalPty({
         file: shimPath,
         args: ["exec", "--", "Fix A&B and 100%"],
         env: { PATH: path.dirname(process.execPath), PATHEXT: ".EXE;.CMD" },
@@ -254,7 +269,7 @@ describe("terminal PTY invocation", () => {
       );
       mocks.spawn.mockReturnValueOnce(fakePty());
 
-      await spawnTerminalPty({
+      await spawnDirectTerminalPty({
         file: shimPath,
         args: ["--", "literal"],
         env: { PATH: nodeDir, PATHEXT: ".EXE;.CMD" },
@@ -277,7 +292,7 @@ describe("terminal PTY invocation", () => {
       );
 
       await expect(
-        spawnTerminalPty({
+        spawnDirectTerminalPty({
           file: shimPath,
           args: ["--", "literal"],
           env: { PATH: path.dirname(shimPath), PATHEXT: ".EXE;.CMD" },
@@ -298,7 +313,7 @@ describe("terminal PTY invocation", () => {
       fs.writeFileSync(wrapperPath, "@ECHO off\r\necho custom\r\n", "utf8");
 
       await expect(
-        spawnTerminalPty({
+        spawnDirectTerminalPty({
           file: wrapperPath,
           args: ["Fix A&B and 100%"],
           env: { COMSPEC: "C:\\Windows\\System32\\cmd.exe" },
@@ -319,7 +334,7 @@ describe("terminal PTY invocation", () => {
       fs.copyFileSync(process.execPath, barePath);
       mocks.spawn.mockReturnValueOnce(fakePty());
 
-      await spawnTerminalPty({
+      await spawnDirectTerminalPty({
         file: barePath,
         args: ["--version"],
         env: {},
@@ -338,7 +353,7 @@ describe("terminal PTY invocation", () => {
   it("keeps executables and non-Windows commands direct", async () => {
     const platform = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
     mocks.spawn.mockReturnValueOnce(fakePty());
-    await spawnTerminalPty({
+    await spawnDirectTerminalPty({
       file: "C:\\tools\\codex.exe",
       args: ["resume", "thread"],
       env: {},
@@ -348,7 +363,7 @@ describe("terminal PTY invocation", () => {
 
     platform.mockReturnValue("linux");
     mocks.spawn.mockReturnValueOnce(fakePty());
-    await spawnTerminalPty({
+    await spawnDirectTerminalPty({
       file: "/tmp/codex.cmd",
       args: [],
       env: {},


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where commands running under Bun could lose buffered stdout and stderr from inherited descendant pipes when the event loop was stalled as the direct child exited. It also lets the process and terminal test lanes exercise their intended Node-owned branches when Vitest itself is hosted by Bun.

## Why This Change Was Made

Output cleanup now defers stream destruction to the next timers phase, giving both Node and Bun a poll turn while preserving the existing idle and hard drain bounds. Runtime-specific tests explicitly select a real Node executable or temporarily select the direct PTY branch, matching the ownership boundary each test validates.

## User Impact

Bun-hosted OpenClaw commands retain buffered descendant output across a contended event loop, and the complete process test shard can run directly under Bun without false failures caused by the test host.

## Evidence

- Before the fix, the two event-loop stall regressions lost their TAIL output under direct Bun.
- Direct custom-Bun focused process tests: 58 passed, 5 platform skips.
- Node focused process tests: 58 passed, 5 platform skips.
- Direct custom-Bun full process shard: 41 files passed, 632 tests passed, 64 platform skips.
- pnpm check:changed passed through all diff-owned checks; the initial run reached an unrelated main type failure later fixed by #145540.
- Independent P0-P2 autoreview: scoped clean at 0.91 confidence.
