### PR TITLE
fix(radius): Claude requests fail with thinking disabled

### DIFF
--- a/extensions/radius/stream.test.ts
+++ b/extensions/radius/stream.test.ts
@@ -75,6 +75,20 @@ beforeEach(() => {
 });
 
 describe("Radius native message transport", () => {
+  it("omits disabled reasoning from Pi requests without changing the output cap", async () => {
+    fetchMock.mockResolvedValue(response([{ type: "done", reason: "stop", usage }]));
+    await createRadiusStreamFn()(model, context, {
+      ...options,
+      reasoning: "off",
+      maxTokens: 1024,
+    }).result();
+    expect(await new Response(fetchMock.mock.calls[0]![1]?.body).json()).toEqual({
+      model: model.id,
+      context,
+      options: { maxTokens: 1024 },
+    });
+  });
+
   it("bounds large-tool preview work while emitting every delta and the final arguments", async () => {
     const toolArguments = { content: "a".repeat(100_000) };
     const json = JSON.stringify(toolArguments);

--- a/extensions/radius/stream.ts
+++ b/extensions/radius/stream.ts
@@ -283,7 +283,8 @@ export function createRadiusStreamFn(): StreamFunction<string, RadiusStreamOptio
           options: {
             temperature: options.temperature,
             maxTokens: options.maxTokens,
-            reasoning: options.reasoning,
+            // Pi represents disabled reasoning by omitting the option.
+            reasoning: options.reasoning === "off" ? undefined : options.reasoning,
             cacheRetention: options.cacheRetention,
             sessionId: options.sessionId,
             toolChoice: options.toolChoice,


### PR DESCRIPTION
Related: #145377

## What Problem This Solves

Fixes an issue where users running Radius Claude models with thinking disabled receive an upstream `max_tokens: Input should be a valid integer` error instead of a reply. A live sweep of Radius's 28 advertised entries reproduced this for Haiku 4.5, Opus 4.1/4.5, and Sonnet 4/4.5.

## Why This Change Was Made

Radius's native Pi protocol represents disabled reasoning by omitting the option. OpenClaw's adapter forwarded its explicit `off` value instead. Pi's older Anthropic budget path has no budget for that value and produces a non-finite output limit.

Normalize only `off` to an omitted field at the Radius transport boundary, matching [Pi's agent contract](https://github.com/earendil-works/pi/blob/main/packages/agent/src/agent.ts). Explicit enabled reasoning, numeric output caps, authentication, and all other request options remain unchanged.

## User Impact

Radius requests with thinking disabled no longer fail because of malformed thinking/output budgets. The correction stays inside the Radius plugin; shared reasoning semantics and other providers are unchanged.

## Evidence

- Baseline live sweep: 23 of 28 entries completed a streamed model-to-read-tool-to-model round trip; five older Claude entries failed with the same integer-schema error.
- New wire-contract regression fails before the fix because the JSON payload contains `reasoning: "off"`; after the fix it is omitted and `maxTokens: 1024` remains numeric. The existing signed-stream case preserves coverage for explicit `high` reasoning and other native options.
- All 41 Radius tests passed. The selected changed-file checks passed, including extension/test typechecks, lint, formatting, plugin boundaries, dead exports, and import cycles.
- Independent P0-P2 review is clean.
- The corrected live run already proves Haiku 4.5, Opus 4.5, and Sonnet 4.5 complete their tool round trips. Opus 4.1 and Sonnet 4 now reach a distinct upstream model-not-found response despite being advertised by Radius; the plugin preserves those service-owned catalog entries and surfaces their error.
- Completed corrected live sweep: **26/28 passed**, each with native streaming, a real read-tool round trip, exact synthetic file output, and no fallback. The only remaining failures are the two upstream model-not-found responses above. Test conditions stayed the same: thinking off, a 1,024-token output cap, and isolated state. Corrected sweep reported usage was $0.32388551. [Required exact-head CI passed](https://github.com/openclaw/openclaw/actions/runs/34670505166).

