### PR TITLE
refactor(agents): retire unused manual Bash session layer

### DIFF
--- a/src/agents/sessions/agent-session-base.ts
+++ b/src/agents/sessions/agent-session-base.ts
@@ -43,7 +43,7 @@ import {
   type TurnEndEvent,
   type TurnStartEvent,
 } from "./extensions/index.js";
-import type { BashExecutionMessage, CustomMessage } from "./messages.js";
+import type { CustomMessage } from "./messages.js";
 import { getModelRegistryRuntime } from "./model-registry-runtime.js";
 import type { ModelRegistry } from "./model-registry.js";
 import type { PromptTemplate } from "./prompt-templates.js";
@@ -102,10 +102,6 @@ export abstract class AgentSessionBase {
   // Retry state
   protected retryAbortController: AbortController | undefined = undefined;
   protected retryCount = 0;
-
-  // Bash execution state
-  protected bashAbortController: AbortController | undefined = undefined;
-  protected pendingBashMessages: BashExecutionMessage[] = [];
 
   // Extension system
   protected currentExtensionRunner!: ExtensionRunner;
@@ -612,7 +608,6 @@ export abstract class AgentSessionBase {
       () => this.abortRetry(),
       () => this.abortCompaction(),
       () => this.abortBranchSummary(),
-      () => this.abortBash(),
       () => this.agent.abort(),
     ];
     for (const abortOperation of abortOperations) {
@@ -886,6 +881,4 @@ export abstract class AgentSessionBase {
   abstract abortRetry(): void;
   abstract abortCompaction(): void;
   abstract abortBranchSummary(): void;
-  abstract abortBash(): void;
-  protected abstract flushPendingBashMessages(): void;
 }

--- a/src/agents/sessions/agent-session-execution.ts
+++ b/src/agents/sessions/agent-session-execution.ts
@@ -4,10 +4,6 @@ import { isRetryableAssistantError } from "../../llm/utils/retry.js";
 import { sleep } from "../../utils/sleep.js";
 import { classifyRateLimitWindow } from "../failover/retry-evidence.js";
 import { AgentSessionExtensions } from "./agent-session-extensions.js";
-import { type BashResult, executeBashWithOperations } from "./bash-executor.js";
-import type { BashExecutionMessage } from "./messages.js";
-import type { BashOperations } from "./tools/bash-operations.js";
-import { createLocalBashOperations } from "./tools/bash.js";
 
 export abstract class AgentSessionExecution extends AgentSessionExtensions {
   // =========================================================================
@@ -116,118 +112,5 @@ export abstract class AgentSessionExecution extends AgentSessionExtensions {
    */
   setAutoRetryEnabled(enabled: boolean): void {
     this.settingsManager.setRetryEnabled(enabled);
-  }
-
-  // =========================================================================
-  // Bash Execution
-  // =========================================================================
-
-  /**
-   * Execute a bash command.
-   * Adds result to agent context and session.
-   * @param command The bash command to execute
-   * @param onChunk Optional streaming callback for output
-   * @param options.excludeFromContext If true, command output won't be sent to LLM (!! prefix)
-   * @param options.operations Custom BashOperations for remote execution
-   */
-  async executeBash(
-    command: string,
-    onChunk?: (chunk: string) => void,
-    options?: { excludeFromContext?: boolean; operations?: BashOperations },
-  ): Promise<BashResult> {
-    this.bashAbortController = new AbortController();
-
-    // Apply command prefix if configured (e.g., "shopt -s expand_aliases" for alias support)
-    const prefix = this.settingsManager.getShellCommandPrefix();
-    const shellPath = this.settingsManager.getShellPath();
-    const resolvedCommand = prefix ? `${prefix}\n${command}` : command;
-
-    try {
-      const result = await executeBashWithOperations(
-        resolvedCommand,
-        this.sessionManager.getCwd(),
-        options?.operations ?? createLocalBashOperations({ shellPath }),
-        {
-          onChunk,
-          signal: this.bashAbortController.signal,
-        },
-      );
-
-      this.recordBashResult(command, result, options);
-      return result;
-    } finally {
-      this.bashAbortController = undefined;
-    }
-  }
-
-  /**
-   * Record a bash execution result in session history.
-   * Used by executeBash and by extensions that handle bash execution themselves.
-   */
-  recordBashResult(
-    command: string,
-    result: BashResult,
-    options?: { excludeFromContext?: boolean },
-  ): void {
-    const bashMessage: BashExecutionMessage = {
-      role: "bashExecution",
-      command,
-      output: result.output,
-      exitCode: result.exitCode,
-      cancelled: result.cancelled,
-      truncated: result.truncated,
-      fullOutputPath: result.fullOutputPath,
-      timestamp: Date.now(),
-      excludeFromContext: options?.excludeFromContext,
-    };
-
-    // If agent is streaming, defer adding to avoid breaking tool_use/tool_result ordering
-    if (this.isStreaming) {
-      // Queue for later - will be flushed on agent_end
-      this.pendingBashMessages.push(bashMessage);
-    } else {
-      // Add to agent state immediately
-      this.agent.state.messages.push(bashMessage);
-
-      // Save to session
-      this.sessionManager.appendMessage(bashMessage);
-    }
-  }
-
-  /**
-   * Cancel running bash command.
-   */
-  abortBash(): void {
-    this.bashAbortController?.abort();
-  }
-
-  /** Whether a bash command is currently running */
-  get isBashRunning(): boolean {
-    return this.bashAbortController !== undefined;
-  }
-
-  /** Whether there are pending bash messages waiting to be flushed */
-  get hasPendingBashMessages(): boolean {
-    return this.pendingBashMessages.length > 0;
-  }
-
-  /**
-   * Flush pending bash messages to agent state and session.
-   * Called after agent turn completes to maintain proper message ordering.
-   */
-  protected flushPendingBashMessages(): void {
-    if (this.pendingBashMessages.length === 0) {
-      return;
-    }
-
-    for (const bashMessage of this.pendingBashMessages) {
-      // Add to agent state
-      this.agent.state.messages.push(bashMessage);
-
-      // Save to session
-      this.sessionManager.appendMessage(bashMessage);
-    }
-
-    this.pendingBashMessages = [];
   }
 }

--- a/src/agents/sessions/agent-session-loop-next-turn.test.ts
+++ b/src/agents/sessions/agent-session-loop-next-turn.test.ts
@@ -195,43 +195,6 @@ describe("AgentSession queue and next-turn lifecycle correctness", () => {
     expect(lifecycleEvents).toEqual(["agent_end", "agent_end", "agent_settled"]);
   });
 
-  it("publishes settlement when deferred bash persistence fails", async () => {
-    let finishResponse: (() => void) | undefined;
-    streamMocks.streamSimple.mockImplementation((activeModel: Model) => {
-      const stream = createAssistantMessageEventStream();
-      finishResponse = () => {
-        const message = createAssistant(activeModel, [{ type: "text", text: "finished" }]);
-        stream.push({ type: "done", reason: "stop", message });
-        stream.end();
-      };
-      return stream;
-    });
-    const { session, sessionManager } = await createTestSession();
-    const settled = vi.fn();
-    session.subscribe((event) => {
-      if (event.type === "agent_end") {
-        vi.spyOn(sessionManager, "appendMessage").mockImplementation(() => {
-          throw new Error("deferred bash persistence failed");
-        });
-      } else if (event.type === "agent_settled") {
-        settled();
-      }
-    });
-
-    const prompt = session.prompt("run until the response is released");
-    await vi.waitFor(() => expect(finishResponse).toBeTypeOf("function"));
-    session.recordBashResult("printf done", {
-      output: "done",
-      exitCode: 0,
-      cancelled: false,
-      truncated: false,
-    });
-    finishResponse?.();
-
-    await expect(prompt).rejects.toThrow("deferred bash persistence failed");
-    expect(settled).toHaveBeenCalledOnce();
-  });
-
   it("does not settle an active run when a concurrent prompt loses admission", async () => {
     let releaseFirst!: () => void;
     let releaseSecond!: () => void;
@@ -920,7 +883,6 @@ describe("AgentSession queue and next-turn lifecycle correctness", () => {
     const abortRetry = vi.spyOn(session, "abortRetry");
     const abortCompaction = vi.spyOn(session, "abortCompaction");
     const abortBranchSummary = vi.spyOn(session, "abortBranchSummary");
-    const abortBash = vi.spyOn(session, "abortBash");
     const abortAgent = vi.spyOn(session.agent, "abort");
     abortRetry.mockImplementationOnce(() => {
       throw new Error("retry abort failed");
@@ -935,7 +897,6 @@ describe("AgentSession queue and next-turn lifecycle correctness", () => {
     expect(abortRetry).toHaveBeenCalledOnce();
     expect(abortCompaction).toHaveBeenCalledOnce();
     expect(abortBranchSummary).toHaveBeenCalledOnce();
-    expect(abortBash).toHaveBeenCalledOnce();
     expect(abortAgent).toHaveBeenCalledOnce();
   });
 

--- a/src/agents/sessions/agent-session-prompting.ts
+++ b/src/agents/sessions/agent-session-prompting.ts
@@ -27,12 +27,6 @@ import { setSteeringMessageIdentity } from "./steering-message-identity.js";
 
 type PostAgentRunAction = "continue" | "settled" | "handoff";
 
-function rethrowPromptFinalizationFailure(failed: boolean, error: unknown): void {
-  if (failed) {
-    throw error;
-  }
-}
-
 /** @internal Host preparation runs after SDK prompt hooks and owns its run cancellation. */
 export const agentSessionSetPromptPreparation: unique symbol = Symbol.for(
   "openclaw.agent-session.set-prompt-preparation",
@@ -94,34 +88,17 @@ export abstract class AgentSessionPrompting extends AgentSessionBase {
       }
     } finally {
       this.systemPromptOverride = undefined;
-      let flushFailed = false;
-      let flushError: unknown;
-      try {
-        this.flushPendingBashMessages();
-      } catch (error) {
-        flushFailed = true;
-        flushError = error;
-      }
       this.logicalPromptActive = false;
-      let terminalFailed = false;
-      let terminalError: unknown;
-      try {
-        // Consume handoff state before callbacks can start a nested run and set it again.
-        endedForTurnHandoff ||= this.lastRunEndedForTurnHandoff;
-        this.lastRunEndedForTurnHandoff = false;
-        // Failed or aborted runs can still be idle; only handoff leaves external delivery pending.
-        if (endedForTurnHandoff) {
-          this.emit({ type: "agent_handoff" });
-        } else {
-          this.emit({ type: "agent_settled" });
-          await this.currentExtensionRunner.emit({ type: "agent_settled" });
-        }
-      } catch (error) {
-        terminalFailed = true;
-        terminalError = error;
+      // Consume handoff state before callbacks can start a nested run and set it again.
+      endedForTurnHandoff ||= this.lastRunEndedForTurnHandoff;
+      this.lastRunEndedForTurnHandoff = false;
+      // Failed or aborted runs can still be idle; only handoff leaves external delivery pending.
+      if (endedForTurnHandoff) {
+        this.emit({ type: "agent_handoff" });
+      } else {
+        this.emit({ type: "agent_settled" });
+        await this.currentExtensionRunner.emit({ type: "agent_settled" });
       }
-      rethrowPromptFinalizationFailure(flushFailed, flushError);
-      rethrowPromptFinalizationFailure(terminalFailed, terminalError);
     }
   }
 
@@ -269,9 +246,6 @@ export abstract class AgentSessionPrompting extends AgentSessionBase {
         preflightResult?.(true);
         return;
       }
-
-      // Flush any pending bash messages before the new prompt
-      this.flushPendingBashMessages();
 
       // Validate model
       if (!this.model) {

--- a/src/agents/sessions/bash-executor.ts
+++ b/src/agents/sessions/bash-executor.ts
@@ -1,9 +1,5 @@
 /**
  * Bash command execution with streaming support and cancellation.
- *
- * This module provides a unified bash execution implementation used by:
- * - AgentSession.executeBash() for interactive and RPC modes
- * - Direct calls from modes that need bash execution
  */
 
 import { createStreamingBinaryOutputSanitizer } from "../shell-utils.js";


### PR DESCRIPTION
## What Problem This Solves

Ordinary agent sessions still carry a manual Bash queue and its prompt-finalization plumbing even though no supported caller reaches the producer. That leaves unnecessary state and lifecycle code on every session.

## Why This Change Was Made

Remove the unused producer, queue, abort hook, flush sites, and obsolete flush-failure bookkeeping together. The standalone Bash executor, normal Bash tools, shell settings, and persisted Bash transcript messages remain supported. Retry, steering, handoff, and terminal-listener behavior are preserved.

The class was exposed by an older SDK wildcard, but #108440 already removed that public export. Both the August and September stable SDK barrels omit it. This follows that completed public cutover; it does not remove a currently supported SDK method.

The change removes 154 production lines and 5,047 bytes, plus one obsolete queue-specific test and an obsolete spy in the existing disposal test.

## User Impact

No user-visible behavior change is intended. Existing Bash tools and saved Bash history continue to work. Agent sessions carry less unused state and finalization code.

## Evidence

- One Linux Testbox B1/C1/C2/B2 measurement passed all 24 lifecycle cases in each process, plus full parity for 576 measured lifecycles and 48 warmups. It exercises the real session factories and prompt/settlement/disposal flow with synthetic model transport, including restored Bash history, queued messages, cancellation, handoff, and terminal callback failures.
- Warm complete-prompt medians improved in this measurement: ordinary-session follow-up 0.346423 → 0.320561 ms; embedded ordinary prompt 0.185733 → 0.176483 ms. These are small synthetic lifecycle timings, not provider or end-to-end Gateway latency claims.
- The adverse memory result is retained: mean observed process-tree peak RSS increased from 696.56 to 717.04 MiB (+2.94%). There is no memory-saving claim. All phases stayed within 75 seconds / 2 GiB / 16 observed processes, and all native children and the Testbox lease closed.
- Measurement used `db2666090f196b07ec84867972a6c5f571b1b013`. Focused author validation ran at `584196023eff5537ca5a45042e8257a08f454f00`. The published branch now includes main `bca261d5583d12f73ed67f9f9df73089d68a0aca`; its authored patch and all five changed-file bytes are preserved. All five changed baseline files match the measurement base. The inherited Radius workspace/package metadata change was reviewed separately; other repository code changed too, so the measurement remains historical. No benchmark was rerun.
- Native measurement run: https://github.com/openclaw/openclaw/actions/runs/34667056190. Successful one-shot Testbox cleanup may appear as a cancelled Actions step; the native command exited 0 and the lease finished `completed`.
- Managed Codex P2 source review passed with no accepted/actionable findings. Matching local oxfmt 0.66.0 changed no bytes, and `git diff --check` passed.
- Current-author focused validation passed all 85 tests across all five complete selected files, with no skips or pending tests. Normal frozen installation, formatting, and the changed-check dry-run plan passed. Full typecheck/lint/guards were intentionally deferred because the base had an independently identified capture-test type error; exact-head hosted gates remain required before landing. [Focused validation](https://github.com/openclaw/openclaw/actions/runs/34669343330) retained both evidence frames, all six closed native receipts, normal worktree removal, and independently verified completed lease status.
