### PR TITLE
fix: show sidebar at the default desktop window size

### DIFF
--- a/ui/src/app/mobile-nav-layout.ts
+++ b/ui/src/app/mobile-nav-layout.ts
@@ -2,7 +2,7 @@ import { isSessionRouteId } from "../app-route-paths.ts";
 import type { RouteId } from "../app-routes.ts";
 import { isNativeWebChromeHost } from "./native-web-chrome.ts";
 
-const MOBILE_NAV_MAX_WIDTH = 1100;
+const MOBILE_NAV_MAX_WIDTH = 900;
 const NATIVE_WEB_CHROME_MOBILE_NAV_MAX_WIDTH = 600;
 const NATIVE_SHELL_CLASSES = [
   "openclaw-native-macos",

--- a/ui/src/app/mobile-nav-layout.ts
+++ b/ui/src/app/mobile-nav-layout.ts
@@ -11,10 +11,10 @@ const NATIVE_SHELL_CLASSES = [
 ] as const;
 
 export function mobileNavLayoutMediaQuery(): string {
-  const maxWidth = isNativeWebChromeHost()
-    ? NATIVE_WEB_CHROME_MOBILE_NAV_MAX_WIDTH
-    : MOBILE_NAV_MAX_WIDTH;
-  return `(max-width: ${maxWidth}px)`;
+  if (isNativeWebChromeHost()) {
+    return `(max-width: ${NATIVE_WEB_CHROME_MOBILE_NAV_MAX_WIDTH}px)`;
+  }
+  return `(max-width: ${MOBILE_NAV_MAX_WIDTH}px), (max-width: 932px) and (max-height: 500px) and (orientation: landscape)`;
 }
 
 export function isMobileNavLayout(): boolean {

--- a/ui/src/e2e/login-gate.e2e.test.ts
+++ b/ui/src/e2e/login-gate.e2e.test.ts
@@ -213,7 +213,7 @@ suite.define(() => {
   });
 
   it.each([
-    { name: "tablet", width: 1024 },
+    { name: "tablet", width: 900 },
     { name: "phone", width: 390 },
   ])("spans the $name settings viewport while reconnecting", async ({ width }) => {
     const context = await suite.browser.newContext({ viewport: { height: 900, width } });

--- a/ui/src/pages/chat/chat-page.test.ts
+++ b/ui/src/pages/chat/chat-page.test.ts
@@ -282,7 +282,9 @@ describe("chat page split layout host", () => {
     const pane = itemAt(page.querySelectorAll<RenderedPane>("openclaw-chat-pane"), 0, "pane");
     expect(pane.mergedChrome).toBe(true);
     expect(matchMedia).toHaveBeenCalledWith("(max-width: 1099px)");
-    expect(matchMedia).toHaveBeenCalledWith("(max-width: 900px)");
+    expect(matchMedia).toHaveBeenCalledWith(
+      "(max-width: 900px), (max-width: 932px) and (max-height: 500px) and (orientation: landscape)",
+    );
   });
 
   it("retains the classic pane element while split view opens and closes", async () => {

--- a/ui/src/pages/chat/chat-page.test.ts
+++ b/ui/src/pages/chat/chat-page.test.ts
@@ -282,7 +282,7 @@ describe("chat page split layout host", () => {
     const pane = itemAt(page.querySelectorAll<RenderedPane>("openclaw-chat-pane"), 0, "pane");
     expect(pane.mergedChrome).toBe(true);
     expect(matchMedia).toHaveBeenCalledWith("(max-width: 1099px)");
-    expect(matchMedia).toHaveBeenCalledWith("(max-width: 1100px)");
+    expect(matchMedia).toHaveBeenCalledWith("(max-width: 900px)");
   });
 
   it("retains the classic pane element while split view opens and closes", async () => {

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -4575,7 +4575,7 @@ html:not(.openclaw-native-macos):not(.openclaw-native-nav):not(.openclaw-native-
    Responsive - Tablet
    =========================================== */
 
-@media (max-width: 900px) {
+@media (max-width: 900px), (max-width: 932px) and (max-height: 500px) and (orientation: landscape) {
   .shell--mobile-nav {
     --shell-pad: 12px;
     --shell-gap: 12px;

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -4575,7 +4575,7 @@ html:not(.openclaw-native-macos):not(.openclaw-native-nav):not(.openclaw-native-
    Responsive - Tablet
    =========================================== */
 
-@media (max-width: 1100px) {
+@media (max-width: 900px) {
   .shell--mobile-nav {
     --shell-pad: 12px;
     --shell-gap: 12px;

--- a/ui/src/styles/layout.mobile.css
+++ b/ui/src/styles/layout.mobile.css
@@ -45,7 +45,7 @@
 
 /* The app host chooses this class from the platform-aware drawer breakpoint.
    Native macOS keeps its rail beside the half-width link browser until 600px;
-   regular browsers retain the 1100px tablet breakpoint. */
+   browsers and Tauri keep the sidebar at the default 1080px window width. */
 .shell--mobile-nav,
 .shell--mobile-nav.shell--nav-collapsed {
   --shell-topbar-height: 58px;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users opening the Tauri desktop app at its default 1080 × 720 content size would see a collapsed navigation drawer instead of the sidebar. The existing 1100px breakpoint was wider than the default window.

## Why This Change Was Made

Move the standard browser/Tauri drawer breakpoint to the existing 900px layout rung and align the tablet shell styling. Preserve the existing landscape-phone drawer exception up to 932 × 500. The native macOS web-chrome breakpoint remains 600px.

## User Impact

The sidebar stays visible at the default desktop size and at slightly smaller widths above 900px. Narrower windows and landscape phones retain the mobile drawer and its controls. Explicit sidebar collapse still works.

## Evidence

- Measured the running Windows Tauri window at 1095 × 751 including the frame; checked the configured content size of 1080 × 720.
- Inspected synthetic before/after captures at 1080px and the updated layout at 1000px. The same mock-Gateway browser flow confirmed a docked 258px sidebar at 1080, 1000, and 901px, with the mobile drawer at 900 and 768px and successful resize handoff.
- All 69 targeted E2E tests passed across the responsive/sidebar, attributed-chat, and login-gate suites using Microsoft Edge on Windows. These cover native macOS chrome, mobile drawer controls, landscape-phone safe areas, and the tablet reconnect notice at the new 900px drawer boundary. The harness built the production UI bundle.
- The running app was inspected for reproduction; the changed UI was verified with the mock-Gateway browser flow, without replacing the running app's build.
- All 28 chat-page unit tests passed after aligning the existing breakpoint expectation with the 900px and landscape-phone media conditions. CI exposed the old unit expectation and landscape-phone drawer assumption; both were corrected and verified locally.
- Independent review confirmed the corrected landscape-phone behavior. Its only finding concerned the old staged version; staging the verified correction resolved it before committing.
- Core-test and UI type checks, formatting, targeted TypeScript/CSS lint, i18n, and preceding changed-file guards passed. The broad check stopped at the dead-export scanner because its pnpm tool cache could not resolve the `formatly` dependency; this is an execution gap, not a passing scan.

![Before: sidebar hidden at the default 1080px width](https://github.com/user-attachments/assets/8d3fea32-d9f0-45d4-a87a-1d96706c2cd0)

![After: sidebar visible at the default 1080px width](https://github.com/user-attachments/assets/f76ad86c-af25-436c-95dd-70bb415980db)