### PR TITLE
refactor(tests): table UTF-16 slicing and truncation cases

### DIFF
--- a/packages/normalization-core/src/utf16-slice.test.ts
+++ b/packages/normalization-core/src/utf16-slice.test.ts
@@ -23,80 +23,33 @@ describe("avoidTrailingHighSurrogateBreak", () => {
 });
 
 describe("sliceUtf16Safe", () => {
-  it("slices ASCII string normally", () => {
-    expect(sliceUtf16Safe("hello world", 0, 5)).toBe("hello");
-  });
-
-  it("handles negative start", () => {
-    expect(sliceUtf16Safe("hello world", -5)).toBe("world");
-  });
-
-  it("handles negative end", () => {
-    expect(sliceUtf16Safe("hello world", 0, -6)).toBe("hello");
-  });
-
-  it("handles start beyond length", () => {
-    expect(sliceUtf16Safe("hello", 10)).toBe("");
-  });
-
-  it("handles end beyond length", () => {
-    expect(sliceUtf16Safe("hello", 0, 10)).toBe("hello");
-  });
-
-  it("returns empty when start > end, matching String.prototype.slice", () => {
-    expect(sliceUtf16Safe("hello", 3, 1)).toBe("");
-  });
-
-  it("preserves emoji with surrogate pairs", () => {
-    const emoji = "👨‍👩‍👧‍👦";
-    expect(sliceUtf16Safe(emoji, 0)).toBe(emoji);
-  });
-
-  it("returns empty string when slicing middle of surrogate pair", () => {
-    const input = "👨👩";
-    // Slicing at position 1-3 hits middle of surrogate pairs
-    expect(sliceUtf16Safe(input, 1, 3)).toBe("");
-  });
-
-  it("returns empty string when slicing at start of surrogate pair", () => {
-    const input = "👨👩";
-    // Slicing at position 0-1 would cut surrogate pair, adjust to 0
-    expect(sliceUtf16Safe(input, 0, 1)).toBe("");
-  });
-
-  it("handles empty string", () => {
-    expect(sliceUtf16Safe("", 0)).toBe("");
-  });
-
-  it("handles undefined end", () => {
-    expect(sliceUtf16Safe("hello", 2)).toBe("llo");
+  it.each<[string, Parameters<typeof sliceUtf16Safe>, string]>([
+    ["slices ASCII string normally", ["hello world", 0, 5], "hello"],
+    ["handles negative start", ["hello world", -5], "world"],
+    ["handles negative end", ["hello world", 0, -6], "hello"],
+    ["handles start beyond length", ["hello", 10], ""],
+    ["handles end beyond length", ["hello", 0, 10], "hello"],
+    ["returns empty when start > end, matching String.prototype.slice", ["hello", 3, 1], ""],
+    ["preserves emoji with surrogate pairs", ["👨‍👩‍👧‍👦", 0], "👨‍👩‍👧‍👦"],
+    ["returns empty string when slicing middle of surrogate pair", ["👨👩", 1, 3], ""],
+    ["returns empty string when slicing at start of surrogate pair", ["👨👩", 0, 1], ""],
+    ["handles empty string", ["", 0], ""],
+    ["handles undefined end", ["hello", 2], "llo"],
+  ])("%s", (_name, args, expected) => {
+    expect(sliceUtf16Safe(...args)).toBe(expected);
   });
 });
 
 describe("truncateUtf16Safe", () => {
-  it("returns input when shorter than limit", () => {
-    expect(truncateUtf16Safe("hello", 10)).toBe("hello");
-  });
-
-  it("truncates when longer than limit", () => {
-    expect(truncateUtf16Safe("hello world", 5)).toBe("hello");
-  });
-
-  it("handles zero limit", () => {
-    expect(truncateUtf16Safe("hello", 0)).toBe("");
-  });
-
-  it("handles negative limit", () => {
-    expect(truncateUtf16Safe("hello", -1)).toBe("");
-  });
-
-  it("floors decimal limit", () => {
-    expect(truncateUtf16Safe("hello world", 5.7)).toBe("hello");
-  });
-
-  it("returns empty string when truncating at surrogate pair boundary", () => {
-    const input = "👨👩";
-    expect(truncateUtf16Safe(input, 1)).toBe("");
+  it.each<[string, Parameters<typeof truncateUtf16Safe>, string]>([
+    ["returns input when shorter than limit", ["hello", 10], "hello"],
+    ["truncates when longer than limit", ["hello world", 5], "hello"],
+    ["handles zero limit", ["hello", 0], ""],
+    ["handles negative limit", ["hello", -1], ""],
+    ["floors decimal limit", ["hello world", 5.7], "hello"],
+    ["returns empty string when truncating at surrogate pair boundary", ["👨👩", 1], ""],
+  ])("%s", (_name, args, expected) => {
+    expect(truncateUtf16Safe(...args)).toBe(expected);
   });
 });
 


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

The UTF-16 slicing tests repeat the same call and assertion setup for individual boundary cases, making their inputs harder to compare.

## Why This Change Was Made

Express the 11 slicing and six truncation cases as explicit typed argument tables. Preserve all original descriptions, argument values and arity, literal expected values, and case order. Keep the boundary-adjustment and marker tests unchanged.

## User Impact

No product behavior changes. The test file loses 47 net lines while retaining its full surrogate-pair and truncation coverage.

## Evidence

- Current-main original/final owner tests: 26 passing cases in identical order.
- Owner and text-truncate consumer cohort: 26 plus nine passing cases.
- All 17 affected descriptions, primitive argument arrays and expected values match the original; omitted arguments remain omitted.
- Boundary-adjustment and existing marker sections are byte-identical.
- Renewed changed-file gate and independent P2 review passed. Earlier unrelated baseline gate failures were repaired on main before the renewed proof.

No overall runtime reduction is claimed for this table consolidation.
