### PR TITLE
perf: reduce repository checkpoint latency

### DIFF
--- a/src/gateway/worker-environments/session-repository-checkpoints.test.ts
+++ b/src/gateway/worker-environments/session-repository-checkpoints.test.ts
@@ -20,6 +20,7 @@ import { readActualWorkspaceManifest } from "./workspace-reconcile-core.js";
 import { requireWorkspaceResultGit } from "./workspace-result-git.js";
 import {
   hasWorkerWorkspaceResultRef,
+  readStagedWorkerWorkspaceResult,
   workerWorkspaceResultRef,
 } from "./workspace-result-staging.js";
 
@@ -80,6 +81,26 @@ async function fixture() {
     });
   };
   return { root, remote, database, store, workspace, stage };
+}
+
+async function publicationFixture(root: string, content = "working tree\n") {
+  const normalized = Buffer.from(content);
+  const sha = createHash("sha1")
+    .update(`blob ${normalized.length}\0`)
+    .update(normalized)
+    .digest("hex");
+  const publicationStagingRoot = path.join(root, "publication");
+  await fs.mkdir(path.join(publicationStagingRoot, "blobs"), { recursive: true });
+  await fs.writeFile(path.join(publicationStagingRoot, "blobs", sha), normalized);
+  const metadata = JSON.stringify({
+    version: 1,
+    baseCommit,
+    baseTree: "b".repeat(40),
+    workspaceTree: "c".repeat(40),
+    entries: [{ path: "edit.txt", mode: "100644", sha }],
+  });
+  await fs.writeFile(path.join(publicationStagingRoot, "snapshot.json"), metadata);
+  return { sha, input: { publicationStagingRoot, publicationDigest: hash(metadata) } };
 }
 
 it("retains cumulative multi-turn files, deletions and executable modes in a bare artifact repo", async () => {
@@ -225,26 +246,8 @@ it.each([false, true])(
   async (corrupt) => {
     const { root, remote, store, workspace, stage } = await fixture();
     await fs.writeFile(path.join(remote, "edit.txt"), "working tree\r\n");
-    const normalized = Buffer.from("working tree\n");
-    const sha = createHash("sha1")
-      .update(`blob ${normalized.length}\0`)
-      .update(normalized)
-      .digest("hex");
-    const publicationStagingRoot = path.join(root, "publication");
-    await fs.mkdir(path.join(publicationStagingRoot, "blobs"), { recursive: true });
-    await fs.writeFile(path.join(publicationStagingRoot, "blobs", sha), normalized);
-    const metadata = JSON.stringify({
-      version: 1,
-      baseCommit,
-      baseTree: "b".repeat(40),
-      workspaceTree: "c".repeat(40),
-      entries: [{ path: "edit.txt", mode: "100644", sha }],
-    });
-    await fs.writeFile(path.join(publicationStagingRoot, "snapshot.json"), metadata);
-    const prepared = await stage("turn-publication", {
-      publicationStagingRoot,
-      publicationDigest: hash(metadata),
-    });
+    const { sha, input } = await publicationFixture(root);
+    const prepared = await stage("turn-publication", input);
     const sourceArtifact = store.artifactPath(workspace.workspaceId);
     const candidates = (
       await requireWorkspaceResultGit(sourceArtifact, [
@@ -297,7 +300,7 @@ it.each([false, true])(
           expect(snapshot.publicationStagingRoot).toBeUndefined();
           expect(snapshot.publicationDigest).toBeUndefined();
         } else {
-          expect(snapshot.publicationDigest).toBe(hash(metadata));
+          expect(snapshot.publicationDigest).toBe(input.publicationDigest);
           expect(
             await fs.readFile(path.join(snapshot.publicationStagingRoot!, "blobs", sha), "utf8"),
           ).toBe("working tree\n");
@@ -317,6 +320,74 @@ it.each([false, true])(
     expect(reads).toBe(2);
   },
 );
+
+it.each(["recovery", "publication"])(
+  "verifies the peeled %s candidate and rejects its replacement or removal",
+  async (target) => {
+    const { root, remote, store, workspace, stage } = await fixture();
+    await fs.writeFile(path.join(remote, "edit.txt"), "working tree\r\n");
+    const { input } = await publicationFixture(root);
+    const prepared = await stage("turn-verify", input);
+    const artifact = store.artifactPath(workspace.workspaceId);
+    const refs = (
+      await requireWorkspaceResultGit(artifact, [
+        "for-each-ref",
+        "--format=%(refname)",
+        "refs/openclaw/worker-result-candidates/",
+      ])
+    ).split("\n");
+    const candidates = await Promise.all(
+      refs.map(async (ref) => ({
+        ref,
+        objectId: await requireWorkspaceResultGit(artifact, ["rev-parse", `${ref}^{commit}`]),
+        snapshot: await readStagedWorkerWorkspaceResult(artifact, ref),
+      })),
+    );
+    expect(candidates).toHaveLength(2);
+    const candidate = candidates.find(
+      (value) => (value.snapshot.base.baseCommit === baseCommit) === (target === "recovery"),
+    )!;
+    const other = candidates.find((value) => value !== candidate)!;
+    const tag = await requireWorkspaceResultGit(artifact, ["mktag"], {
+      input: Buffer.from(
+        `object ${candidate.objectId}\ntype commit\ntag checkpoint-peel\ntagger Checkpoint Test <checkpoint@example.invalid> 0 +0000\n\nsame candidate\n`,
+      ),
+    });
+    await requireWorkspaceResultGit(artifact, ["update-ref", candidate.ref, tag]);
+    await prepared.verify();
+    await requireWorkspaceResultGit(artifact, ["update-ref", candidate.ref, other.objectId]);
+    await expect(prepared.verify()).rejects.toThrow(
+      target === "recovery"
+        ? "Repository checkpoint preparation changed"
+        : "Repository publication preparation changed",
+    );
+    await requireWorkspaceResultGit(artifact, ["update-ref", "-d", candidate.ref]);
+    await expect(prepared.verify()).rejects.toThrow();
+    expect(store.get(workspace.workspaceId)?.checkpointRef).toBeNull();
+    await prepared.discard();
+  },
+);
+
+it("cannot replace an immutable publication companion when recovery bytes are unchanged", async () => {
+  const { root, remote, store, workspace, stage } = await fixture();
+  await fs.writeFile(path.join(remote, "edit.txt"), "working tree\r\n");
+  const original = await publicationFixture(root);
+  const initial = await stage("turn-immutable-publication", original.input);
+  await initial.publish();
+  const replacement = await publicationFixture(root, "different publication\n");
+  const collision = await stage("turn-immutable-publication", replacement.input);
+  await expect(collision.publish()).rejects.toThrow("different result");
+  await collision.discard();
+  await withSessionRepositoryCheckpoint(
+    { store, workspaceId: workspace.workspaceId, includePublication: true },
+    async (snapshot) => {
+      expect(snapshot.publicationDigest).toBe(original.input.publicationDigest);
+      expect(await fs.readFile(path.join(snapshot.stagingRoot, "edit.txt"), "utf8")).toBe(
+        "working tree\r\n",
+      );
+    },
+  );
+});
 
 it("accepts raw recovery files when a publication blob fails validation", async () => {
   const { root, remote, store, workspace, stage } = await fixture();

--- a/src/gateway/worker-environments/session-repository-checkpoints.test.ts
+++ b/src/gateway/worker-environments/session-repository-checkpoints.test.ts
@@ -85,10 +85,9 @@ async function fixture() {
 
 async function publicationFixture(root: string, content = "working tree\n") {
   const normalized = Buffer.from(content);
-  const sha = createHash("sha1")
-    .update(`blob ${normalized.length}\0`)
-    .update(normalized)
-    .digest("hex");
+  const sha = await requireWorkspaceResultGit(root, ["hash-object", "--stdin"], {
+    input: normalized,
+  });
   const publicationStagingRoot = path.join(root, "publication");
   await fs.mkdir(path.join(publicationStagingRoot, "blobs"), { recursive: true });
   await fs.writeFile(path.join(publicationStagingRoot, "blobs", sha), normalized);

--- a/src/gateway/worker-environments/session-repository-checkpoints.ts
+++ b/src/gateway/worker-environments/session-repository-checkpoints.ts
@@ -79,20 +79,25 @@ function assertBase(
   return workspace.baseCommit;
 }
 
-async function refObject(
+async function refObjects(
   root: string,
-  ref: string,
+  refs: readonly string[],
   baseEnv?: NodeJS.ProcessEnv,
-): Promise<string | undefined> {
+): Promise<Map<string, string>> {
   const output = await requireWorkspaceResultGit(
     root,
-    ["for-each-ref", "--format=%(refname) %(objectname)", ref],
+    ["for-each-ref", "--format=%(refname) %(objectname)", ...refs],
     { baseEnv },
   );
-  return output
-    .split("\n")
-    .find((line) => line.startsWith(`${ref} `))
-    ?.slice(ref.length + 1);
+  const objects = new Map<string, string>();
+  for (const line of output.split("\n")) {
+    const separator = line.indexOf(" ");
+    const ref = line.slice(0, separator);
+    if (refs.includes(ref)) {
+      objects.set(ref, line.slice(separator + 1));
+    }
+  }
+  return objects;
 }
 
 export async function readSessionRepositoryCheckpoint(params: CheckpointSource) {
@@ -140,7 +145,7 @@ export async function withSessionRepositoryCheckpoint<T>(
     let useStarted = false;
     try {
       const companion = publicationRef(ref);
-      if (!(await refObject(root, companion))) {
+      if (!(await refObjects(root, [companion])).get(companion)) {
         useStarted = true;
         return await use(snapshot);
       }
@@ -224,7 +229,7 @@ async function stagePublication(params: {
     });
     const current = await readActualWorkspaceManifest({ root: stagingRoot, baseCommit: null });
     const currentManifestRaw = serializeWorkerWorkspaceManifest(current.manifest);
-    await workerWorkspaceResultStaging.stageWorkerWorkspaceResult({
+    return await workerWorkspaceResultStaging.stageWorkerWorkspaceResult({
       root: params.root,
       stagingRoot,
       stagedResultRef: params.candidateRef,
@@ -326,7 +331,7 @@ export async function stageSessionRepositoryCheckpoint(
     return discardPromise;
   };
   try {
-    await workerWorkspaceResultStaging.stageWorkerWorkspaceResult({
+    const objectId = await workerWorkspaceResultStaging.stageWorkerWorkspaceResult({
       ...params,
       root,
       stagedResultRef: candidateRef,
@@ -337,7 +342,7 @@ export async function stageSessionRepositoryCheckpoint(
         if (!params.publicationStagingRoot || !params.publicationDigest) {
           throw new Error("Repository publication checkpoint is incomplete");
         }
-        await stagePublication({
+        companionId = await stagePublication({
           root,
           candidateRef: companionCandidate,
           publicationStagingRoot: params.publicationStagingRoot,
@@ -345,10 +350,6 @@ export async function stageSessionRepositoryCheckpoint(
           currentManifestRef: params.currentManifestRef,
           baseCommit,
         });
-        companionId = await requireWorkspaceResultGit(root, [
-          "rev-parse",
-          `${companionCandidate}^{commit}`,
-        ]);
       } catch (error) {
         // A rejected publication payload cannot discard independently validated
         // recovery bytes. Remove only its candidate, then recheck live authority.
@@ -359,22 +360,18 @@ export async function stageSessionRepositoryCheckpoint(
         );
       }
     }
-    const objectId = await requireWorkspaceResultGit(root, [
-      "rev-parse",
-      `${candidateRef}^{commit}`,
-    ]);
     const verify = async () => {
-      if (
-        (await requireWorkspaceResultGit(root, ["rev-parse", `${candidateRef}^{commit}`])) !==
-        objectId
-      ) {
+      const objects = (
+        await requireWorkspaceResultGit(root, [
+          "rev-parse",
+          `${candidateRef}^{commit}`,
+          ...(companionId ? [`${companionCandidate}^{commit}`] : []),
+        ])
+      ).split("\n");
+      if (objects[0] !== objectId) {
         throw new Error("Repository checkpoint preparation changed");
       }
-      if (
-        companionId &&
-        (await requireWorkspaceResultGit(root, ["rev-parse", `${companionCandidate}^{commit}`])) !==
-          companionId
-      ) {
+      if (companionId && objects[1] !== companionId) {
         throw new Error("Repository publication preparation changed");
       }
       assertRevision();
@@ -387,11 +384,17 @@ export async function stageSessionRepositoryCheckpoint(
       publish: async () => {
         await withWorkspaceResultRefMutation(root, async (baseEnv) => {
           const updates: string[] = [];
-          for (const [target, expected] of [
+          const targets = [
             [ref, objectId],
             [publicationRef(ref), companionId],
-          ] as const) {
-            const existing = await refObject(root, target, baseEnv);
+          ] as const;
+          const existingObjects = await refObjects(
+            root,
+            targets.map(([target]) => target),
+            baseEnv,
+          );
+          for (const [target, expected] of targets) {
+            const existing = existingObjects.get(target);
             if (existing !== undefined && existing !== expected) {
               throw new Error("Repository checkpoint identity already contains a different result");
             }

--- a/src/gateway/worker-environments/workspace-result-staging.ts
+++ b/src/gateway/worker-environments/workspace-result-staging.ts
@@ -265,7 +265,7 @@ async function stageWorkerWorkspaceResult(params: {
   currentManifestRef: string;
   baseManifestRaw: string;
   currentManifestRaw: string;
-}): Promise<void> {
+}): Promise<string> {
   const root = await ensureWorkerWorkspaceResultRepository(params.root);
   const stagedResultRef = requireWorkerResultStorageRef(params.stagedResultRef);
   const base = parseWorkerWorkspaceManifest(params.baseManifestRaw, params.baseManifestRef);
@@ -329,7 +329,7 @@ async function stageWorkerWorkspaceResult(params: {
   if (imported.termination !== "exit" || imported.code !== 0) {
     throw new Error(imported.stderr.toString("utf8").trim() || "git fast-import failed");
   }
-  await requireGit(root, ["rev-parse", `${stagedResultRef}^{commit}`]);
+  return await requireGit(root, ["rev-parse", `${stagedResultRef}^{commit}`]);
 }
 
 type LoadedStagedWorkerWorkspace = {


### PR DESCRIPTION
Related: #138724, #145480

## What Problem This Solves

Repository-backed cloud sessions wait for redundant local Git reads while creating their durable checkpoint. This adds latency to workspace preparation and completed-turn reconciliation.

## Why This Change Was Made

Reuse the commit ID that staging already resolves, resolve both candidate commits in one Git call at each existing verification point, and read both immutable publication destinations together under the existing mutation lock. Commit peeling, exact ref matching, live ownership checks, atomic Git publication before SQLite acceptance, and retryable cleanup retain their existing semantics.

## User Impact

Checkpoint creation uses two fewer Git subprocesses without a publication snapshot and five fewer with one. The persisted checkpoint format and recovery behavior stay compatible.

## Evidence

- 31 focused checkpoint, concurrent staging, and repository-startup tests passed, including annotated-tag peeling, candidate replacement/removal, immutable publication collisions, cumulative edits/deletions, interrupted acceptance, and cleanup retry.
- Selected `check:changed` passed, including core and test type checks, scoped lint, and static guards. Independent review through P2 found no actionable findings. The initial OpenGrep run flagged manual SHA-1 hashing in the Git-blob fixture; the fixture now calls Git `hash-object` directly. Its 10 checkpoint tests, selected checks, and fresh P2 review passed after that test-only correction.
- Real-Git benchmark with five alternating-order baseline/candidate pairs per mode: publication used 23 → 18 calls, with medians 494.14 → 404.34 ms and median paired saving 84.15 ms (candidate faster in all five pairs). Without publication, calls fell 16 → 14; medians were 612.90 → 506.14 ms, but only three of five pairs were faster because of host timing noise. Every sample verified durable acceptance, deletion preservation, and recovery/publication bytes. These measure stage → verify → publish locally, with readback afterward.
- Both frozen packages passed all nine qualification phases, real installed Gateway/worker execution, and launcher start/restart/cleanup checks. Runtime proof uses baseline `bca261d5583d` and candidate `d19ecdc880401`; final head `8accc3536fa5` changes only the non-shipped test fixture and preserves both production files byte-for-byte.
- Both Daytona/Crabbox 0.56 live campaigns passed prepared-worker dispatch, session isolation, deletion checkpoint restoration, Gateway restart, natural expiry, and cleanup. All eight machines and both captured images were independently confirmed absent. With synthetic inference, prepared fresh-session dispatch to first output was 10.434 → 8.047 s; restoration was 7.928 → 7.075 s. These are one sample per lifecycle and version, so provider/network/process variation prevents attributing the full difference to this patch. The local paired benchmark is the stronger evidence for the checkpoint-specific gain.
- [CI run 34671195559](https://github.com/openclaw/openclaw/actions/runs/34671195559) passed on final head in attempt 2. One unrelated profiler subprocess test timed out initially; its unchanged job rerun and dependent required gate passed. No timeout or assertion was weakened.
