### PR TITLE
fix(cli): scope channel auth config writes

### DIFF
--- a/src/cli/channel-auth.test.ts
+++ b/src/cli/channel-auth.test.ts
@@ -234,10 +234,7 @@ describe("channel-auth", () => {
 
       await run({ channel: "whatsapp" }, runtime);
 
-      expect(mocks.applyPluginAutoEnable).toHaveBeenCalledWith({
-        config: sourceConfig,
-        env: process.env,
-      });
+      expect(mocks.applyPluginAutoEnable).not.toHaveBeenCalled();
       expect(readFirstCallArg(action).cfg).toBe(runtimeConfig);
       expect(mocks.replaceConfigFile).not.toHaveBeenCalled();
     },
@@ -477,70 +474,72 @@ describe("channel-auth", () => {
     expect(mocks.login).not.toHaveBeenCalled();
   });
 
-  it("auto-picks the single auth-capable channel from the auto-enabled config snapshot", async () => {
+  it("auto-picks from the runtime view without persisting unrelated plugin activation", async () => {
     const sourceConfig: OpenClawConfig = {
+      agents: { defaults: { model: "openai/gpt-5.5" } },
       channels: { whatsapp: {} },
       plugins: { allow: ["whatsapp"] },
     };
     const autoEnabledCfg = {
       ...sourceConfig,
       channels: { whatsapp: { enabled: true } },
+      plugins: {
+        allow: ["whatsapp"],
+        entries: { codex: { enabled: true }, whatsapp: { enabled: true } },
+      },
     };
-    const runtimeConfig = { ...sourceConfig, agents: { defaults: { maxConcurrent: 4 } } };
-    const refreshedRuntimeConfig = {
-      ...autoEnabledCfg,
-      agents: { defaults: { maxConcurrent: 4 } },
+    const runtimeConfig = {
+      ...sourceConfig,
+      agents: { defaults: { model: "openai/gpt-5.5", maxConcurrent: 4 } },
     };
     mocks.readConfigFileSnapshot.mockResolvedValue({ hash: "config-1", valid: true, sourceConfig });
     mocks.loadConfig.mockReturnValue(runtimeConfig);
-    mocks.applyPluginAutoEnable.mockImplementation(({ config }: { config: OpenClawConfig }) =>
-      materializePluginAutoEnableCandidates({
-        config,
-        candidates: [{ pluginId: "whatsapp", kind: "channel-configured", channelId: "whatsapp" }],
-        manifestRegistry: makeRegistry([
-          { id: "whatsapp", channels: ["whatsapp"], origin: "bundled" },
-        ]),
-      }),
-    );
+    mocks.applyPluginAutoEnable.mockReturnValue({
+      config: autoEnabledCfg,
+      changes: ["codex", "whatsapp"],
+    });
     mocks.resolveAccount.mockImplementation((cfg: OpenClawConfig) => ({
       enabled: cfg.channels?.whatsapp?.enabled === true,
     }));
-    mocks.replaceConfigFile.mockImplementation(async () => {
-      mocks.loadConfig.mockReturnValue(refreshedRuntimeConfig);
-    });
 
     await runChannelLogin({}, runtime);
 
+    expect(mocks.applyPluginAutoEnable).toHaveBeenCalledTimes(1);
     expect(mocks.applyPluginAutoEnable).toHaveBeenCalledWith({
-      config: sourceConfig,
+      config: runtimeConfig,
       env: process.env,
     });
     expectFields(readFirstCallArg(mocks.login), {
-      cfg: refreshedRuntimeConfig,
+      cfg: runtimeConfig,
       channelInput: "whatsapp",
     });
-    expect(mocks.replaceConfigFile).toHaveBeenCalledWith({
-      sourceConfig: autoEnabledCfg,
-      baseHash: "config-1",
-    });
-    expect(mocks.resolveAccount.mock.calls[0]?.[0]).toEqual(refreshedRuntimeConfig);
+    expect(mocks.replaceConfigFile).not.toHaveBeenCalled();
+    expect(mocks.resolveAccount.mock.calls[0]?.[0]).toEqual(autoEnabledCfg);
   });
 
-  it("persists auto-enabled config during logout auto-pick too", async () => {
-    const autoEnabledCfg = { channels: { whatsapp: {} }, plugins: { allow: ["whatsapp"] } };
-    mocks.loadConfig.mockReturnValue({});
-    mocks.applyPluginAutoEnable.mockReturnValue({ config: autoEnabledCfg, changes: ["whatsapp"] });
+  it("does not persist auto-enabled config during logout auto-pick", async () => {
+    const sourceConfig = { channels: { whatsapp: {} }, plugins: { allow: ["whatsapp"] } };
+    const autoEnabledCfg = {
+      ...sourceConfig,
+      plugins: {
+        allow: ["whatsapp"],
+        entries: { codex: { enabled: true }, whatsapp: { enabled: true } },
+      },
+    };
+    mocks.readConfigFileSnapshot.mockResolvedValue({ hash: "config-1", valid: true, sourceConfig });
+    mocks.loadConfig.mockReturnValue(sourceConfig);
+    mocks.applyPluginAutoEnable.mockReturnValue({
+      config: autoEnabledCfg,
+      changes: ["codex", "whatsapp"],
+    });
 
     await runChannelLogout({}, runtime);
 
     expectFields(readFirstCallArg(mocks.callGateway), {
-      config: autoEnabledCfg,
+      config: sourceConfig,
       method: "channels.logout",
     });
-    expect(mocks.replaceConfigFile).toHaveBeenCalledWith({
-      sourceConfig: autoEnabledCfg,
-      baseHash: "config-1",
-    });
+    expect(mocks.replaceConfigFile).not.toHaveBeenCalled();
   });
 
   it("ignores configured channels that do not support login when channel is omitted", async () => {

--- a/src/cli/channel-auth.ts
+++ b/src/cli/channel-auth.ts
@@ -109,12 +109,7 @@ async function resolveChannelPluginForMode(
   if (!writeSnapshot) {
     return null;
   }
-  // Runtime defaults are not authored plugin enablement intent.
-  const autoEnabled = applyPluginAutoEnable({
-    config: writeSnapshot.snapshot.sourceConfig,
-    env: process.env,
-  });
-  const cfg = autoEnabled.config;
+  const cfg = writeSnapshot.snapshot.sourceConfig;
   const explicitChannel = opts.channel?.trim();
   const channelInput = explicitChannel || resolveConfiguredAuthChannelInput(mode);
   const normalizedChannelId = normalizeChannelId(channelInput);
@@ -144,7 +139,7 @@ async function resolveChannelPluginForMode(
       }),
     );
   }
-  if (autoEnabled.changes.length > 0 || resolved.configChanged) {
+  if (resolved.configChanged) {
     await commitConfigWithPendingPluginInstalls({
       sourceConfig: resolved.cfg,
       baseHash: writeSnapshot.snapshot.hash,


### PR DESCRIPTION
## What Problem This Solves

`openclaw channels login` and `openclaw channels logout` could persist the entire global plugin auto-enable result while resolving a channel. An unrelated model-derived Codex activation could therefore be written to `openclaw.json` even though the user only requested channel authentication.

Closes #144972.

## Why This Change Was Made

Channel auth now gives plugin resolution the validated authored source config and commits only genuine install-on-demand config changes. Omitted-channel discovery still uses the active runtime's auto-enabled view, but that view is no longer treated as authored config.

## User Impact

Logging a channel in or out no longer enables unrelated bundled plugins or rewrites configuration solely because global auto-enable found a candidate. Channel inference, runtime-resolved account values, and install-on-demand writes continue to work.

## Evidence

- The revised regression failed in four expected assertions on the original production code: explicit auth invoked global auto-enable, omitted-channel auth invoked it twice, and the Codex-bearing view reached the write/runtime path.
- `node scripts/run-vitest.mjs src/cli/channel-auth.test.ts` — 45 passed on the committed head.
- `pnpm test:changed` — 45 passed.
- `node scripts/check-changed.mjs` — passed changed formatting, lint, production/test typechecks, dead-export analysis, and repository guards.
- Fresh Claude autoreview and independent exact-head Claude review found no actionable issue.
- Real built CLI proof used isolated synthetic config with an OpenAI model and configured WhatsApp channel. `openclaw channels logout --channel whatsapp` completed through the Gateway-fallback/local-cleanup path with exit 0; the config's SHA-256 was identical before and after, and no `codex` or `enabled` entry appeared.
- The same 45-test command-owner suite covers fresh catalog-backed channel installation and pending-install-record persistence; no external registry package was installed for this unrelated-write defect.

<details>
<summary>Sanitized CLI transcript</summary>

```text
$ openclaw config validate
Config valid: /private/tmp/openclaw-144972-proof/openclaw.json

$ shasum -a 256 openclaw.json
e0a8d45575031cb2e5577d23a9bf982b5318c8293fdedc5a28b09615967a3fcf

$ openclaw channels logout --channel whatsapp
Local logout will clear auth for whatsapp/default, but the running gateway did not stop it: gateway channels.logout requires credentials before opening a websocket
No WhatsApp Web session found; nothing to delete.
No saved auth was cleared for whatsapp/default. Other credentials may still be active.
exit 0

$ shasum -a 256 openclaw.json
e0a8d45575031cb2e5577d23a9bf982b5318c8293fdedc5a28b09615967a3fcf

$ search openclaw.json for codex or enabled
no matches
```

</details>

AI-assisted implementation and review; the contributor verified the final diff and evidence.
