### PR TITLE
improve(prometheus): reduce logging overhead on busy gateways

### DIFF
--- a/extensions/diagnostics-prometheus/src/service.subscription.test.ts
+++ b/extensions/diagnostics-prometheus/src/service.subscription.test.ts
@@ -1,0 +1,73 @@
+import {
+  emitDiagnosticEvent,
+  emitTrustedDiagnosticEventWithPrivateData,
+  waitForDiagnosticEventsDrained,
+} from "openclaw/plugin-sdk/diagnostic-runtime";
+import { onTrustedInternalDiagnosticEvent } from "openclaw/plugin-sdk/plugin-test-runtime";
+import { expect, it, vi } from "vitest";
+import { createDiagnosticsPrometheusExporter } from "./service.js";
+
+it("records terminal metrics without reading logs or private diagnostic content", async () => {
+  const exporter = createDiagnosticsPrometheusExporter();
+  const readPrivateContent = vi.fn(() => ({ toolInput: { text: "private tool input" } }));
+  const readLogAttribute = vi.fn(() => "synthetic log attribute");
+  const emitLog = () =>
+    emitDiagnosticEvent({
+      type: "log.record",
+      level: "INFO",
+      message: "synthetic log",
+      attributes: {
+        get detail() {
+          return readLogAttribute();
+        },
+      },
+    });
+  exporter.service.start({
+    config: {},
+    stateDir: "/tmp/openclaw-prometheus-test",
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+    internalDiagnostics: {
+      emit() {},
+      onEvent: onTrustedInternalDiagnosticEvent,
+    },
+  });
+  try {
+    emitLog();
+    emitTrustedDiagnosticEventWithPrivateData(
+      {
+        type: "tool.execution.completed",
+        runId: "run-1",
+        toolCallId: "call-1",
+        toolName: "synthetic",
+        toolSource: "core",
+        durationMs: 3,
+      },
+      {
+        get toolContent() {
+          return readPrivateContent();
+        },
+      },
+    );
+    await waitForDiagnosticEventsDrained();
+    expect(exporter.render()).toContain(
+      'openclaw_tool_execution_total{error_category="none",outcome="completed",params_kind="unknown",tool="synthetic",tool_owner="none",tool_source="core"} 1',
+    );
+    expect(readPrivateContent).not.toHaveBeenCalled();
+    expect(readLogAttribute).not.toHaveBeenCalled();
+    const logs = vi.fn();
+    const stopLogs = onTrustedInternalDiagnosticEvent(logs, { include: ["log.record"] });
+    try {
+      emitLog();
+      await waitForDiagnosticEventsDrained();
+      expect(logs).toHaveBeenCalledOnce();
+      expect(logs.mock.calls[0]?.[0].attributes).toEqual({ detail: "synthetic log attribute" });
+      expect(readLogAttribute).toHaveBeenCalledOnce();
+    } finally {
+      stopLogs();
+    }
+  } finally {
+    exporter.service.stop?.();
+    await waitForDiagnosticEventsDrained();
+  }
+  expect(exporter.render()).toBe("");
+});

--- a/extensions/diagnostics-prometheus/src/service.test.ts
+++ b/extensions/diagnostics-prometheus/src/service.test.ts
@@ -1,13 +1,6 @@
 import { createServer } from "node:http";
 import { expectDefined } from "@openclaw/normalization-core";
-// Diagnostics Prometheus tests cover service plugin behavior.
-import {
-  emitTrustedDiagnosticEventWithPrivateData,
-  waitForDiagnosticEventsDrained,
-  type DiagnosticEventPrivateData,
-} from "openclaw/plugin-sdk/diagnostic-runtime";
-import { onTrustedInternalDiagnosticEvent } from "openclaw/plugin-sdk/plugin-test-runtime";
-// Diagnostics Prometheus tests cover service plugin behavior.
+import type { DiagnosticEventPrivateData } from "openclaw/plugin-sdk/diagnostic-runtime";
 import { describe, expect, it, vi } from "vitest";
 import type { DiagnosticEventMetadata, DiagnosticEventPayload } from "../api.js";
 import { createDiagnosticsPrometheusExporter } from "./service.js";
@@ -29,46 +22,6 @@ vi.mock("openclaw/plugin-sdk/plugin-runtime", () => ({
 }));
 
 describe("diagnostics-prometheus service", () => {
-  it("records terminal metrics without reading private diagnostic content", async () => {
-    const exporter = createDiagnosticsPrometheusExporter();
-    const readPrivateContent = vi.fn(() => ({ toolInput: { text: "private tool input" } }));
-    exporter.service.start({
-      config: {},
-      stateDir: "/tmp/openclaw-prometheus-test",
-      logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
-      internalDiagnostics: {
-        emit() {},
-        onEvent: onTrustedInternalDiagnosticEvent,
-      },
-    });
-    try {
-      emitTrustedDiagnosticEventWithPrivateData(
-        {
-          type: "tool.execution.completed",
-          runId: "run-1",
-          toolCallId: "call-1",
-          toolName: "synthetic",
-          toolSource: "core",
-          durationMs: 3,
-        },
-        {
-          get toolContent() {
-            return readPrivateContent();
-          },
-        },
-      );
-      await waitForDiagnosticEventsDrained();
-      expect(exporter.render()).toContain(
-        'openclaw_tool_execution_total{error_category="none",outcome="completed",params_kind="unknown",tool="synthetic",tool_owner="none",tool_source="core"} 1',
-      );
-      expect(readPrivateContent).not.toHaveBeenCalled();
-    } finally {
-      exporter.service.stop?.();
-      await waitForDiagnosticEventsDrained();
-    }
-    expect(exporter.render()).toBe("");
-  });
-
   it("records Gateway RPC timings by method and outcomes without method multiplication", () => {
     const metrics = createMetricsHarness();
     const base = {

--- a/extensions/diagnostics-prometheus/src/service.ts
+++ b/extensions/diagnostics-prometheus/src/service.ts
@@ -1110,7 +1110,8 @@ export function createDiagnosticsPrometheusExporter() {
             );
           }
         },
-        undefined,
+        // Metrics do not consume logs; avoid enabling their diagnostic copy/formatting path.
+        { exclude: ["log.record"] },
         { includePrivateData: false },
       );
       internalDiagnostics = ctx.internalDiagnostics as unknown as TrustedExporterDiagnosticsBridge;


### PR DESCRIPTION
## What Problem This Solves

Resolves unnecessary logging overhead when operators enable Prometheus metrics on a busy Gateway. Each log record activated diagnostic formatting, redaction, queueing, and copying even though Prometheus exports no log records.

## Why This Change Was Made

Exclude `log.record` through the existing diagnostic subscription filter. This lets the logger skip its diagnostic preparation when no log consumer is present, while other subscribers can still request logs. All metric events, trust checks, and the existing private-content exclusion remain unchanged.

The existing bus regression moves into a focused subscription test to stay within the test-file line limit.

## User Impact

Prometheus-enabled Gateways spend less CPU and allocation work on discarded logs. Metric names, values, labels, and scrape behavior stay the same; no configuration or storage migration is needed.

## Evidence

- The extended diagnostic-bus regression failed before the fix because an unused log attribute was read. It now passes, retains terminal metrics without reading private content, and proves an independent log subscriber still receives the same event.
- All 39 focused exporter tests pass, covering subscriptions, RPC metrics, trust, series limits, drop counters, runtime identity, and HTTP scopes. Extension production/test typechecks, targeted lint, and applicable changed-file guards pass. Dependency-link omissions in the isolated checkout were repaired before rerunning the affected checks.
- A synthetic logger → diagnostic bus → exporter benchmark compared the prior broad subscription with the filtered subscription in six alternating rounds. For 4,000 structured log calls with roughly 8 KB of raw synthetic input per call, median CPU time fell from 1,778 ms to 162 ms and median elapsed time from 3,341 ms to 237 ms. Prometheus received 4,000 unused log events before and zero afterward; an emitted health RPC still produced the expected metric. File output was disabled to isolate diagnostic overhead. These figures describe this synthetic logging workload, not whole-Gateway performance or an OOM cure.
- An 8,000-event synthetic `run.progress`/`context.assembled` workload remained unchanged, supporting the narrow log-only exclusion. Fresh independent review found no actionable P0–P2 findings.
