### PR TITLE
improve(doctor): reduce repeated state copies during update checks

### DIFF
--- a/src/commands/doctor-lint.test.ts
+++ b/src/commands/doctor-lint.test.ts
@@ -793,6 +793,9 @@ describe("runDoctorLintCli", () => {
           },
         ],
       });
+      expect(
+        mocks.prepareSqliteReadOnlyLocationSync.mock.calls.map(([pathname]) => pathname),
+      ).toEqual([databasePath]);
       expect(sourceOpenStacks).toEqual([]);
       expect(snapshotDoctorLintSqliteFamily(databasePath)).toEqual(before);
     } finally {

--- a/src/commands/doctor-lint.ts
+++ b/src/commands/doctor-lint.ts
@@ -34,7 +34,10 @@ import {
 } from "../plugins/install-root-context.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { closeOpenClawStateDatabaseByPathAsync } from "../state/openclaw-state-db-cache.js";
-import { withArtifactPreservingStateReads } from "../state/openclaw-state-db-readonly.js";
+import {
+  withArtifactPreservingStateReads,
+  withDisposableOpenClawStateReads,
+} from "../state/openclaw-state-db-readonly.js";
 import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
 import { isPostCoreConvergencePass, isUpdateDoctorLintPass } from "./doctor/shared/update-phase.js";
 
@@ -355,12 +358,11 @@ async function withReadOnlyPluginStateSnapshot<T>(
       // Global readers and OAuth refresh/challenge writers share the private state view.
       outcome = {
         ok: true,
-        value: await withPluginInstallRoots(
-          { ...installRoots, stateDir: privateStateDir },
-          async () => {
+        value: await withDisposableOpenClawStateReads(privateDatabasePath, () =>
+          withPluginInstallRoots({ ...installRoots, stateDir: privateStateDir }, async () => {
             runStarted = true;
             return await run(privateEnv);
-          },
+          }),
         ),
       };
     } catch (error) {

--- a/src/state/openclaw-state-db-readonly.test.ts
+++ b/src/state/openclaw-state-db-readonly.test.ts
@@ -27,6 +27,7 @@ import {
   withExistingOpenClawStateDatabaseArtifactPreservingReadOnlyAsync,
   withExistingOpenClawStateDatabaseReadOnly,
   withArtifactPreservingStateReads,
+  withDisposableOpenClawStateReads,
 } from "./openclaw-state-db-readonly.js";
 import {
   closeOpenClawStateDatabaseForTest,
@@ -241,6 +242,47 @@ describe.each(["admission", "explicit", "async"] as const)("%s read-only state r
       : mode === "admission"
         ? admittedRead
         : withExistingOpenClawStateDatabaseArtifactPreservingReadOnly;
+  it("reads only active disposable scopes directly and revokes inherited async access", async () => {
+    await withTempDir("openclaw-state-disposable-", async (root) => {
+      const outer = createOptions(path.join(root, "outer"));
+      const inner = createOptions(path.join(root, "inner"));
+      const source = createOptions(path.join(root, "source"));
+      const paths = [outer, inner, source];
+      for (const options of paths) {
+        fs.mkdirSync(path.dirname(options.path), { recursive: true });
+        const db = new DatabaseSync(options.path);
+        db.exec(
+          "PRAGMA journal_mode = WAL; CREATE TABLE held(value TEXT); INSERT INTO held VALUES ('committed')",
+        );
+        db.close();
+      }
+      const read = (options: ReturnType<typeof createOptions>) =>
+        readState(({ db }) => {
+          expect(db.prepare("SELECT value FROM held").get()).toEqual({ value: "committed" });
+          expect(() => db.exec("INSERT INTO held VALUES ('unexpected')")).toThrow(/readonly/);
+          return db.location();
+        }, options);
+      const sourceBefore = fs.readFileSync(source.path);
+      const released = createDeferredCore();
+      let descendant: Promise<unknown> | undefined;
+      await withDisposableOpenClawStateReads(outer.path, async () => {
+        expect(await read(outer)).toBe(outer.path);
+        await withDisposableOpenClawStateReads(inner.path, async () => {
+          expect(await read(outer)).toBe(outer.path);
+          expect(await read(inner)).toBe(inner.path);
+          expect(await read(source)).not.toBe(source.path);
+          descendant = released.promise.then(() => read(inner));
+        });
+        expect(await read(inner)).not.toBe(inner.path);
+        expect(await read(outer)).toBe(outer.path);
+        released.resolve();
+        expect(await descendant).not.toBe(inner.path);
+      });
+      expect(await read(outer)).not.toBe(outer.path);
+      expect(fs.readFileSync(source.path)).toEqual(sourceBefore);
+      expect(fs.readdirSync(path.dirname(source.path))).toEqual(["openclaw.sqlite"]);
+    });
+  });
   it("reads a consolidated WAL database without creating source sidecars", async () => {
     await withTempDir("openclaw-state-readonly-sidecars-", async (stateDir) => {
       const options = createOptions(stateDir);

--- a/src/state/openclaw-state-db-readonly.ts
+++ b/src/state/openclaw-state-db-readonly.ts
@@ -25,6 +25,35 @@ const artifactPreservingReads = resolveGlobalSingleton(
   () => new AsyncLocalStorage<boolean>(),
 );
 
+const disposableStateReads = resolveGlobalSingleton(
+  Symbol.for("openclaw.disposableStateReads"),
+  () => new AsyncLocalStorage<{ path: string; active: boolean }[]>(),
+);
+
+/** The caller owns this private database and removes its files after the scope closes. */
+export async function withDisposableOpenClawStateReads<T>(
+  pathname: string,
+  operation: () => Promise<T>,
+): Promise<T> {
+  const scope = { path: path.resolve(pathname), active: true };
+  try {
+    return await disposableStateReads.run(
+      [...(disposableStateReads.getStore() ?? []), scope],
+      operation,
+    );
+  } finally {
+    // Async descendants can retain the context after its owner starts cleanup.
+    scope.active = false;
+  }
+}
+
+function requiresArtifactPreservingSnapshot(pathname: string): boolean {
+  return (
+    isArtifactPreservingStateRead() &&
+    !disposableStateReads.getStore()?.some((scope) => scope.active && scope.path === pathname)
+  );
+}
+
 /** Admission scopes every nested reader without changing normal live-read semantics. */
 export function withArtifactPreservingStateReads<T>(operation: () => T): T {
   return artifactPreservingReads.run(true, operation);
@@ -103,7 +132,7 @@ function withFreshOpenClawStateDatabaseReadOnly<T>(
   openClawStateDatabaseCache.assertOpenClawStateDatabaseFreshOpenAllowedAtPath(pathname, env);
   // Even read-only SQLite opens can create a missing WAL. The existing worker
   // snapshots committed WAL pages without touching source sidecars or caller-held locks.
-  const prepared = isArtifactPreservingStateRead()
+  const prepared = requiresArtifactPreservingSnapshot(pathname)
     ? prepareSqliteReadOnlyLocationSync(pathname)
     : undefined;
   return withOpenClawStateReadOnlyLocation(operation, pathname, prepared ?? pathname);
@@ -253,6 +282,9 @@ export function withExistingOpenClawStateDatabaseArtifactPreservingReadOnlyAsync
     }
     const env = options.env ?? process.env;
     openClawStateDatabaseCache.assertOpenClawStateDatabaseFreshOpenAllowedAtPath(pathname, env);
+    if (!requiresArtifactPreservingSnapshot(pathname)) {
+      return withOpenClawStateReadOnlyLocation(operation, pathname, pathname);
+    }
     const prepared = await prepareSqliteReadOnlyLocation(pathname, {
       preserveSourceArtifacts: true,
     });


### PR DESCRIPTION
## Summary

### High Level TLDR

Doctor's post-plugin readiness check makes a private copy of shared state, then unnecessarily copies that private database again for subsequent reads. This change keeps those reads on the disposable database already owned by the check.

## What Problem This Solves

Fixes an issue where update finalization performs redundant full shared-state copies during Doctor lint. The existing real-SQLite readiness scenario produces three snapshots: the original operator-state snapshot and two copies of that temporary database.

### Root Cause

Doctor correctly wraps lint in artifact-preserving reads and creates a private plugin-state view. The shared read owner inherits the artifact-preserving context even after reads have been redirected to that disposable view, so fresh reads snapshot it again.

## Why This Change Was Made

The shared read owner now recognizes an explicitly scoped disposable path. Doctor activates that scope only around its own private database. Native read-only handles, schema checks, and tracked handle cleanup remain with their existing owners. Other paths retain artifact-preserving reads, nested scopes remain independent, and inherited asynchronous contexts lose the exemption when their owner finishes.

No persistent schema, data representation, migration, configuration option, or cross-run cache changes. Installed update drivers remain unchanged; the optimization runs inside the candidate's existing Doctor lint path. Rollback needs no data conversion.

## User Impact

A synthetic 206,671,872-byte shared database produces one full snapshot instead of three, avoiding 413,343,744 bytes of redundant copied output and two snapshot workers per exercised readiness pass. This is a bounded I/O optimization, not a claim to resolve all update latency.

## Verification

### Real behavior proof

The existing registered post-plugin readiness scenario runs real SQLite readers and snapshot workers. Its new assertion fails on the original code because two extra private paths are copied, and passes with this patch. It still reports the required missing local-embedding setup error, preserves the operator database family byte-for-byte, and never opens the operator database in the parent.

- 70 focused tests passed, including nested path scopes, read-only writes being rejected, unrelated source protection, and revocation of inherited async contexts.
- Targeted lint, formatting, and `git diff --check` passed.
- Independent Astra high autoreview: scoped-clean at P0–P2.
- Full `pnpm build` and the complete four-file `check:changed` gate passed, including core/core-test typechecks, dead-export scans, scoped lint, and storage/import guards.
- Published `openclaw@2026.9.4` updater × exact candidate `9cdebdc907a1f629174bab85cfc0a3d4c43de329`: **passed** using the repository's isolated Docker `sqlite-volume` scenario. The actual installed updater performed the npm update; the scenario preserved 4,800 sessions, 23,890 events, and 2,200 cron jobs, verified eight conversations across two agents before and after Gateway restart, and passed repeat Doctor idempotence in 18 seconds.

Focused tests:

```sh
node scripts/run-vitest.mjs src/state/openclaw-state-db-readonly.test.ts
node scripts/run-vitest.mjs src/commands/doctor-lint.test.ts src/commands/doctor-lint.state-isolation.test.ts
```

Published-driver cell (Node 24.19.0/Linux; candidate built and packaged with the canonical package helper):

```sh
OPENCLAW_CURRENT_PACKAGE_TGZ=/tmp/doctor-lint-package/openclaw-current.tgz \
OPENCLAW_DOCKER_E2E_SELECTED_SHA=9cdebdc907a1f629174bab85cfc0a3d4c43de329 \
OPENCLAW_UPGRADE_SURVIVOR_PUBLISHED_BASELINE=1 \
OPENCLAW_UPGRADE_SURVIVOR_BASELINE_SPEC=openclaw@2026.9.4 \
OPENCLAW_UPGRADE_SURVIVOR_SCENARIO=sqlite-volume \
bash scripts/e2e/upgrade-survivor-docker.sh
```

Copied output:

```text
sqlite-volume sessions=4800 events=23890 cronJobs=2200
sqlite-volume Gateway RPC verified 8 conversations across 2 agents
SQLite volume idempotence doctor completed in 18s (budget 60s).
Upgrade survivor Docker E2E passed baseline=openclaw@2026.9.4 scenario=sqlite-volume candidate=2026.9.4 updateRestartMode=manual idempotence=18s startup=24s updateRestart=manuals healthz=1s readyz=1s status=1s.
```

Update receipt: `status=ok`, `mode=npm`; published build `2026.9.4-release-3a9d69db306c-2026-09-10T22-53-16.719Z` → candidate build `2026.9.4-9cdebdc907a1-2026-09-12T03-42-19.063Z`. Local Docker was used because hosted Package Acceptance accepts upstream-reachable refs, while this candidate is on the author fork. Its source-trust gate was preserved.

### Performance limits

One warm run showed a large timing difference, but the repeated comparison measured essentially identical warm medians: 0.970 s baseline and 0.977 s candidate. Disk/cache variability prevents a reliable percentage latency claim. Snapshot counts consistently fell from three to one; findings and operator-state bytes remained unchanged.

### What was not tested

No production update, restart, or operator-state mutation was performed. No claim is made about total update duration or Windows/macOS performance.

Related: #143802 and #145541 avoid agent-database copies during schema/header inspection. This PR addresses repeated shared-state copies inside Doctor's already-isolated lint view.

The first ClawSweeper review found no actionable correctness/security defects and requested the published-updater evidence now recorded above.
