### PR TITLE
perf(gateway): avoid repeated tool recipient expiry scans

### DIFF
--- a/src/gateway/server-chat-state.test.ts
+++ b/src/gateway/server-chat-state.test.ts
@@ -32,6 +32,52 @@ describe("createChatRunState", () => {
     },
   );
 
+  it("expires idle recipients while activity extends another run's lifetime", () => {
+    let now = 1_000;
+    const clock = vi.spyOn(Date, "now").mockImplementation(() => now);
+    try {
+      const state = createChatRunState();
+      state.toolEventRecipients.add("idle", "conn-idle");
+      state.toolEventRecipients.add("active", "conn-active");
+      now = 301_000;
+      expect(state.toolEventRecipients.get("active")).toEqual(new Set(["conn-active"]));
+      now = 600_999;
+      state.toolEventRecipients.get("active");
+      expect(state.runs.has("idle")).toBe(true);
+      now += 1;
+      state.toolEventRecipients.get("active");
+      expect(state.runs.has("idle")).toBe(false);
+      expect(state.toolEventRecipients.get("active")).toEqual(new Set(["conn-active"]));
+    } finally {
+      clock.mockRestore();
+    }
+  });
+
+  it.each([false, true])(
+    "expires new recipients after clock rollback (clear previous state: %s)",
+    (clear) => {
+      let now = 1_000_000;
+      const clock = vi.spyOn(Date, "now").mockImplementation(() => now);
+      try {
+        const state = createChatRunState();
+        state.toolEventRecipients.add("previous", "conn-previous");
+        if (clear) {
+          state.clear();
+        }
+        now = 1_000;
+        state.toolEventRecipients.add("early", "conn-early");
+        now = 500_000;
+        state.toolEventRecipients.add("active", "conn-active");
+        now = 601_000;
+        expect(state.toolEventRecipients.get("active")).toEqual(new Set(["conn-active"]));
+        expect(state.runs.has("early")).toBe(false);
+        expect(state.runs.has("previous")).toBe(!clear);
+      } finally {
+        clock.mockRestore();
+      }
+    },
+  );
+
   it("clears transient projection state without dropping run ownership or abort tombstones", () => {
     const state = createChatRunState();
     state.registry.add("run-1", { sessionKey: "session-1", clientRunId: "client-1" });

--- a/src/gateway/server-chat-state.ts
+++ b/src/gateway/server-chat-state.ts
@@ -603,11 +603,21 @@ export function createSessionMessageSubscriberRegistry(
 function createToolEventRecipientRegistryForStore(
   store: ChatRunRecordStore,
 ): ToolEventRecipientRegistry {
-  const prune = () => {
-    if (store.runs.size === 0) {
+  let nextPruneAt = Infinity;
+  const prune = (updated: ChatRunToolRecipientState) => {
+    // Refreshes can move expiry later; a conservative lower bound avoids a
+    // full run scan on each tool event while retaining exact expiry cleanup.
+    nextPruneAt = Math.min(
+      nextPruneAt,
+      updated.finalizedAt
+        ? updated.finalizedAt + TOOL_EVENT_RECIPIENT_FINAL_GRACE_MS
+        : updated.updatedAt + TOOL_EVENT_RECIPIENT_TTL_MS,
+    );
+    const now = Date.now();
+    if (now < nextPruneAt) {
       return;
     }
-    const now = Date.now();
+    nextPruneAt = Infinity;
     for (const [runId, record] of store.runs) {
       const entry = record.toolRecipient;
       if (!entry) {
@@ -619,6 +629,8 @@ function createToolEventRecipientRegistryForStore(
       if (now >= cutoff) {
         delete record.toolRecipient;
         store.releaseIfEmpty(runId);
+      } else {
+        nextPruneAt = Math.min(nextPruneAt, cutoff);
       }
     }
   };
@@ -628,25 +640,20 @@ function createToolEventRecipientRegistryForStore(
       return;
     }
     const now = Date.now();
-    const record = store.getOrCreate(runId);
-    const existing = record.toolRecipient;
-    if (existing) {
-      existing.connIds.add(connId);
-      existing.updatedAt = now;
-    } else {
-      record.toolRecipient = {
-        connIds: new Set([connId]),
-        updatedAt: now,
-      };
-    }
-    prune();
+    const entry = (store.getOrCreate(runId).toolRecipient ??= {
+      connIds: new Set<string>(),
+      updatedAt: now,
+    });
+    entry.connIds.add(connId);
+    entry.updatedAt = now;
+    prune(entry);
   };
 
   const get = (runId: string) => {
     const entry = store.runs.get(runId)?.toolRecipient;
     if (entry) {
       entry.updatedAt = Date.now();
-      prune();
+      prune(entry);
     }
     // Pruning may retire this finalized run; never return its former audience.
     return store.runs.get(runId)?.toolRecipient?.connIds;
@@ -658,7 +665,7 @@ function createToolEventRecipientRegistryForStore(
       return;
     }
     entry.finalizedAt = Date.now();
-    prune();
+    prune(entry);
   };
 
   return { add, get, markFinal };


### PR DESCRIPTION
Related: #127158

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

Resolves a problem where delivering live tool progress becomes increasingly expensive as the Gateway tracks more active runs, including runs without tool-event recipients.

## Why This Change Was Made

The recipient registry checks the earliest possible expiry before scanning run state. A due expiry still triggers a full sweep and recomputes that deadline, preserving the existing ten-minute idle lifetime and thirty-second finalized grace period. This reduces repeated work during active tool streams.

Related #127158 addresses pre-existing idle cleanup without subsequent recipient activity; this change addresses repeated scanning during activity and does not add a maintenance hook.

## User Impact

Busy Gateways spend less CPU delivering live tool updates while preserving recipient ordering, refresh behavior, and finalized expiry.

## Evidence

- Synthetic benchmark through the real `createAgentEventHandler`, with 10,000 tracked active runs: median processing time for 10,000 tool events fell from **924.26 ms to 10.10 ms** (91.5×). Each scenario verified all 51,000 deliveries, including 1,000 warmup events and five measured batches. Node v24.19.0 on Windows; baseline `47ce03dbc6994435af783fecf13d5586e7b307f4`. Measurement excludes network and provider latency; due-expiry sweeps remain linear in tracked runs.
- **255 tests passed** with `node scripts/run-vitest.mjs src/gateway/server-chat-state.test.ts src/gateway/server-chat.agent-events.test.ts`. Coverage includes expired run audiences with current session subscribers, idle refresh, clock rollback, state clearing, and live tool-event routing.
- Core production and core-test typechecks, formatting, `git diff --check`, and the preceding changed-file guards passed in an independently installed validation checkout. **The full combined changed gate failed** on Knip findings for `canonicalProviderName` and `listPackagedStaticExtensionAssetOutputs` in unrelated scripts. Their definitions, real script consumers, and scanner configuration match immutable baseline blobs; a fresh clean-baseline Knip run has not been performed. All nine remaining selected lint/state/import guards passed when run separately; the combined gate remains failed.
- Real Gateway HTTP/WebSocket workloads completed with a synthetic provider. The two-fix comparisons were mixed and retained large control-plane stalls; they do not establish an event-routing-specific network speedup.
- Combined-tree live validation on an isolated Linux Testbox passed: 1,000 seeded sessions, eight concurrent real OpenAI turns, 100 session updates, and 303 history probes. All eight responses matched streamed output, final events, RPC history, and independent SQLite reads after verified Gateway shutdown. Zero RPC/readiness failures; Gateway exited 0 and the owned runner lease was stopped and verified completed. Tools were denied, dreaming was disabled, and output was capped at 128 tokens to bound inference. This validates the combined Gateway/provider flow, not tool-call delivery or a paired latency improvement. The run still recorded 19 degraded health samples and a 368 ms maximum event-loop delay. Direct provider request count was not independently observed.
- Fresh autoreview returned one P2 claiming missing recipient lookups previously always pruned. Two independent inspections rejected that attribution: the [immutable baseline already guards pruning with `if (entry)`](https://github.com/openclaw/openclaw/blob/47ce03dbc6994435af783fecf13d5586e7b307f4/src/gateway/server-chat-state.ts#L645-L652), and this patch retains that condition. The raw review remains a finding with a documented rejection.

Related: #145579
