### PR TITLE
perf(state): reuse paths during coordinator acquisition

### DIFF
--- a/src/infra/state-database-coordinator.test.ts
+++ b/src/infra/state-database-coordinator.test.ts
@@ -1,16 +1,86 @@
+import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import {
   acquireGatewayLifecycleCoordinator,
   acquireStateDatabaseCoordinator,
+  acquireStateDatabaseHandleExclusion,
+  resolveStateDatabaseCoordinatorPath,
   withStateSchemaFence,
 } from "./state-database-coordinator.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 describe("state database coordinator", () => {
+  it.each([false, true])(
+    "bounds filesystem path probes per acquisition with explicit coordinator path %s",
+    (explicit) => {
+      const root = tempDirs.make("openclaw-state-coordinator-path-work-");
+      const params = {
+        databasePath: path.join(root, "state", "openclaw.sqlite"),
+        runtimeDirectory: root,
+        uid: typeof process.getuid === "function" ? process.getuid() : undefined,
+        coordinatorPath: explicit ? path.join(root, "custom", "coordinator.sqlite") : undefined,
+      };
+      const resolvePath = vi.spyOn(fsSync, "realpathSync");
+      try {
+        for (let attempt = 0; attempt < 2; attempt++) {
+          params.databasePath = path.join(root, `state-${attempt}`, "openclaw.sqlite");
+          const expectedPath =
+            params.coordinatorPath ?? resolveStateDatabaseCoordinatorPath(params);
+          resolvePath.mockClear();
+          const coordinator = acquireStateDatabaseCoordinator(params);
+          try {
+            expect(coordinator.path).toBe(expectedPath);
+            expect(resolvePath).toHaveBeenCalledTimes(2);
+          } finally {
+            coordinator.release();
+          }
+        }
+      } finally {
+        resolvePath.mockRestore();
+      }
+    },
+  );
+
+  it("resolves lifecycle paths after the current write authority callback", () => {
+    const root = tempDirs.make("openclaw-state-coordinator-authority-path-");
+    const params = {
+      databasePath: path.join(root, "state", "openclaw.sqlite"),
+      runtimeDirectory: path.join(root, "initial-runtime"),
+      uid: typeof process.getuid === "function" ? process.getuid() : undefined,
+    };
+    const nextRuntime = path.join(root, "next-runtime");
+    const expectedPath = resolveStateDatabaseCoordinatorPath({
+      ...params,
+      runtimeDirectory: nextRuntime,
+    });
+    const exclusion = acquireStateDatabaseHandleExclusion(params);
+    let changeRuntime = false;
+    try {
+      exclusion.runWithCanonicalWrites(
+        () => {
+          if (changeRuntime) {
+            params.runtimeDirectory = nextRuntime;
+          }
+        },
+        () => {
+          changeRuntime = true;
+          const coordinator = acquireStateDatabaseCoordinator(params);
+          try {
+            expect(coordinator.path).toBe(expectedPath);
+          } finally {
+            coordinator.release();
+          }
+        },
+      );
+    } finally {
+      exclusion.release();
+    }
+  });
+
   it.each([
     ["state", acquireStateDatabaseCoordinator],
     ["Gateway", acquireGatewayLifecycleCoordinator],

--- a/src/infra/state-database-coordinator.ts
+++ b/src/infra/state-database-coordinator.ts
@@ -61,21 +61,35 @@ export function resolveStateLifecycleRuntimeDirectory(): string {
     : "/tmp";
 }
 
-function resolveLifecycleCoordinatorPath(
-  family: CoordinatorFamily,
-  params: { databasePath: string; runtimeDirectory: string; uid: number | undefined },
-): string {
+function resolveLifecycleCoordinatorBase(params: {
+  databasePath: string;
+  runtimeDirectory: string;
+  uid: number | undefined;
+}) {
   const canonicalDatabasePath = resolvePathViaExistingAncestorSync(params.databasePath);
   const canonicalRuntimeDirectory = resolvePathViaExistingAncestorSync(params.runtimeDirectory);
   // The predecessor state-local coordinator shipped only in v2026.8.1-beta.2.
   // Keep one current stable runtime path; beta-only peers are not upgrade-compatible.
   const suffix =
     params.uid === undefined ? "openclaw-state-locks" : `openclaw-state-locks-${params.uid}`;
-  return path.join(
-    canonicalRuntimeDirectory,
-    suffix,
-    `${family}.${sha256HexPrefixCore(canonicalDatabasePath, 8)}.lock.sqlite`,
-  );
+  return {
+    directory: path.join(canonicalRuntimeDirectory, suffix),
+    databaseHash: sha256HexPrefixCore(canonicalDatabasePath, 8),
+  };
+}
+
+function buildLifecycleCoordinatorPath(
+  family: CoordinatorFamily,
+  base: ReturnType<typeof resolveLifecycleCoordinatorBase>,
+): string {
+  return path.join(base.directory, `${family}.${base.databaseHash}.lock.sqlite`);
+}
+
+function resolveLifecycleCoordinatorPath(
+  family: CoordinatorFamily,
+  params: Parameters<typeof resolveLifecycleCoordinatorBase>[0],
+): string {
+  return buildLifecycleCoordinatorPath(family, resolveLifecycleCoordinatorBase(params));
 }
 
 export function resolveStateDatabaseCoordinatorPath(params: {
@@ -157,21 +171,28 @@ export function retainHeldStateDatabaseCoordinator(databasePath: string) {
 export function acquireStateDatabaseCoordinator(params: CoordinatorOptions) {
   // Lifecycle ownership is reentrant for nested transactions. File publication
   // is not: even this process must refuse before ownership probes touch SQLite.
-  const handlesPath = resolveLifecycleCoordinatorPath("state-handles", {
+  const base = resolveLifecycleCoordinatorBase({
     databasePath: params.databasePath,
     runtimeDirectory: params.runtimeDirectory ?? resolveStateLifecycleRuntimeDirectory(),
     uid: params.uid ?? (typeof process.getuid === "function" ? process.getuid() : undefined),
   });
+  const handlesPath = buildLifecycleCoordinatorPath("state-handles", base);
   const writeScope = canonicalWriteScopes.getStore()?.get(handlesPath);
   if (writeScope) {
     if (!writeScope.active) {
       throw new SqliteCoordinatorError("SQLite binding write scope is no longer current");
     }
     writeScope.assertCurrent();
+    // Authority callbacks can change paths; resolve again after their checks.
+    return acquireLifecycleCoordinator("state-lifecycle", params);
   } else if (heldCoordinators.has(handlesPath)) {
     throw new StateDatabaseCoordinatorContentionError("state-handles");
   }
-  return acquireLifecycleCoordinator("state-lifecycle", params);
+  return acquireLifecycleCoordinator("state-lifecycle", {
+    ...params,
+    coordinatorPath:
+      params.coordinatorPath ?? buildLifecycleCoordinatorPath("state-lifecycle", base),
+  });
 }
 
 /** Fence schema mutation against another process's live Gateway owner. */


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled for this PR.

</details>

## What Problem This Solves

Resolves a problem where heavy session activity adds avoidable synchronous work to Gateway state writes, delaying session lists and other control requests.

## Why This Change Was Made

Resolve the database and runtime paths once within each ordinary coordinator acquisition, then derive both existing lock identities from those prepared facts. Explicit coordinator paths retain precedence, and acquisitions with an authority callback still resolve paths again after that callback. Lock identities, lifetimes, permission checks, and transaction boundaries stay unchanged; there is no persistent cache or storage change.

## User Impact

State writes spend less time on repeated filesystem probes. This reduces one measured contributor to Gateway stalls; substantial latency remains under the stress workload below.

## Evidence

Baseline `47ce03dbc6994435af783fecf13d5586e7b307f4`, Windows, Node 24.19.0. A real Gateway profile with 1,000 sessions attributed 19.62 seconds inclusive of a 73.69-second sample to ancestor path resolution, overlapping with 40.97 seconds in shared-state writes. Workspace-memory lock registration and release repeatedly reach this path. These samples include time inside synchronous native calls, not exclusively CPU computation.

Synthetic component benchmark through the actual acquisition entry point, seven alternating passes of 100 operations per arm, with two warmups:

| Acquisition | Median before | Median after |
| --- | ---: | ---: |
| Ordinary acquire/release | 1.576 ms | 1.159 ms |
| Nested acquire/release | 1.138 ms | 0.486 ms |

Ordinary filesystem probes fall from eight to four `existsSync` calls and four to two `realpathSync` calls. Directory creation and permission-check calls remain unchanged.

One isolated before/after pair through real HTTP/WebSocket transport used 1,000 sessions, eight requested turns, 100 patches, and a synthetic provider. Only this production patch changed between runs; both included the same two preceding Gateway fixes:

| Metric | Before | After |
| --- | ---: | ---: |
| Load completion | 40.95 s | 30.96 s |
| Session list p95 | 19.23 s | 10.09 s |
| History p95 | 3.27 s | 2.65 s |
| Patch p95 | 2.63 s | 1.86 s |

Both runs had zero transport probe failures. This is supportive single-pair evidence, not a general speedup guarantee: dynamic background provider requests differed (21 versus 15), and maximum event-loop delay increased from 1.50 to 2.09 seconds. Windows teardown forced Gateway exit 1 after completed load; all owned processes were verified stopped. No real OpenAI call was made.

- The new work-bound regression fails on the original code with four realpath probes instead of two and passes after the change. Preservation cases cover explicit paths, changing database paths between acquisitions, and path changes inside the authority callback.
- Focused checks: 25 tests passed, two existing device-identity contract cases skipped on Windows, and two source-exclusion cases failed. Both failures reproduced identically against the original coordinator with complete dependencies: concurrent non-owner reads and inherited read-scope expiry returned a copy rather than rejecting. No assertions were weakened.
- The first grouped test invocation encountered incomplete package dependencies and an automatic worker-build timeout/retry. Dependency links were restored before the independent baseline comparison, which completed without dependency warnings or retries.
- Core and core-test typechecks passed. The original combined changed gate has two findings in untouched exports; their owners, consumers, and scanner configuration match baseline blobs, but no fresh baseline Knip run was performed. Formatting and diff sanity passed.
- Final targeted lint, formatting, and diff sanity passed after the braces-only test correction. Fresh independent review of the exact patch was scoped-clean through P2. Repeated paired live comparisons have not run.
- Combined-tree live validation on an isolated Linux Testbox passed: 1,000 seeded sessions, eight concurrent real OpenAI turns, 100 session updates, and 303 history probes. All eight responses matched streamed output, final events, RPC history, and independent SQLite reads after verified Gateway shutdown. Zero RPC/readiness failures; Gateway exited 0 and the owned runner lease was stopped and verified completed. Tools were denied, dreaming was disabled, and output was capped at 128 tokens to bound inference. This validates the combined Gateway/provider flow, not tool-call delivery or a paired latency improvement. The run still recorded 19 degraded health samples and a 368 ms maximum event-loop delay. Direct provider request count was not independently observed.

Related: #145579
