### PR TITLE
fix(ui): align the selected agent badge and check

### DIFF
--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -3896,6 +3896,7 @@ td.data-table-key-col {
 }
 
 .agent-select__avatar--icon svg,
+.agent-select__option-check svg,
 .agent-select__footer-icon svg {
   width: 14px;
   height: 14px;
@@ -3941,6 +3942,18 @@ td.data-table-key-col {
   flex: 1;
   min-width: 0;
   gap: 1px;
+}
+
+.agent-select__option-state {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  flex: 0 0 auto;
+}
+
+.agent-select__option-check {
+  display: inline-flex;
+  flex: 0 0 auto;
 }
 
 .agent-select__option-label {


### PR DESCRIPTION
Closes #145568

## What Problem This Solves

Fixes an issue where users opening the agent selector in Settings → Agents saw the selected agent as an oversized row, with the DEFAULT badge stacked above a large checkmark.

## Why This Change Was Made

The trailing state slot now aligns its badge and check in one row. The check shares the existing footer icon's 14px size and stroke styling. The change adds 13 lines of CSS and preserves selection, keyboard handling, avatars, descriptions, and the New agent action.

The affected markup originated in #124301 by @vyctorbrzezowski.

## User Impact

The selected agent appears as a compact row with its avatar, name, DEFAULT badge, and check aligned. Other uses of the shared agent picker receive the same check sizing.

## Evidence

Settings → Agents, open dropdown, 1440×900, identical synthetic two-agent data and default selection. Before uses the parent commit's `components.css`; after uses this commit. Both themes were visually inspected.

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://github.com/user-attachments/assets/84db30ea-030a-4c82-8dd1-6144f930d381" alt="Agents, dark — before" width="600"><br><a href="https://github.com/user-attachments/assets/84db30ea-030a-4c82-8dd1-6144f930d381">Agents, dark — before</a></td>
<td><img src="https://github.com/user-attachments/assets/3a524f0f-3849-4ab3-9814-895c4a4e60f9" alt="Agents, dark — after" width="600"><br><a href="https://github.com/user-attachments/assets/3a524f0f-3849-4ab3-9814-895c4a4e60f9">Agents, dark — after</a></td>
</tr>
<tr>
<td><img src="https://github.com/user-attachments/assets/2a1bb1e6-1c50-40e6-9e9f-b242a5505649" alt="Agents, light — before" width="600"><br><a href="https://github.com/user-attachments/assets/2a1bb1e6-1c50-40e6-9e9f-b242a5505649">Agents, light — before</a></td>
<td><img src="https://github.com/user-attachments/assets/50195cba-b27e-4b30-82bd-23042497ff81" alt="Agents, light — after" width="600"><br><a href="https://github.com/user-attachments/assets/50195cba-b27e-4b30-82bd-23042497ff81">Agents, light — after</a></td>
</tr>
</table>

The selected row measures 99.4px before and 36px after; the check measures 63.25px before and 14px after in both themes.

New session and sidebar, dark theme, under the same before/after conditions. The sidebar tile rectangles are identical.

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://github.com/user-attachments/assets/32bf1244-884e-47b4-b544-915f9732e384" alt="New session, dark — before" width="600"><br><a href="https://github.com/user-attachments/assets/32bf1244-884e-47b4-b544-915f9732e384">New session, dark — before</a></td>
<td><img src="https://github.com/user-attachments/assets/6e1a0fa1-ac44-4c6c-8965-e2684aafda5c" alt="New session, dark — after" width="600"><br><a href="https://github.com/user-attachments/assets/6e1a0fa1-ac44-4c6c-8965-e2684aafda5c">New session, dark — after</a></td>
</tr>
<tr>
<td><img src="https://github.com/user-attachments/assets/a13997a7-cb46-426e-9b8e-0fd2912f0688" alt="Sidebar agent menu, dark — before" width="600"><br><a href="https://github.com/user-attachments/assets/a13997a7-cb46-426e-9b8e-0fd2912f0688">Sidebar agent menu, dark — before</a></td>
<td><img src="https://github.com/user-attachments/assets/ecd7fa29-7efe-4381-8694-e95fb9c471d6" alt="Sidebar agent menu, dark — after" width="600"><br><a href="https://github.com/user-attachments/assets/ecd7fa29-7efe-4381-8694-e95fb9c471d6">Sidebar agent menu, dark — after</a></td>
</tr>
</table>

### Risk and coverage

The shared selectors could affect badge-only, check-only, and combined states wherever the picker is used. Browser checks cover Agents and New session, including switching agents, the default badge, the selected check, and the New agent footer. The sidebar reuses the option/copy classes but does not render either new class; its menu was checked separately.

Every production consumer was traced:

| Consumer | Coverage and result |
| --- | --- |
| Settings → Agents | Browser: dark/light open menu; aligned 14px check, compact selected row, default badge and New agent footer. Selection updates the route; selecting the current agent closes the menu and restores focus. |
| New session | Browser: selected check and agent selection work. |
| Sidebar agent-chip menu | Browser and source: tiles remain visible and selectable; new selectors do not match this menu. |
| Settings → Skills | Source: shared picker, no local override of the new selectors. |
| Memory import | Source: shared picker, no local override of the new selectors. |
| Memory hub (overview, memories, dreams) | Source: shared picker, no local override of the new selectors. |
| Settings → Devices execution-approval scope | Source: shared picker; default badge and selected-check states use the same owner. |
| Sessions | Source: shared agent-scope control. |
| Usage | Source: shared agent-scope control. |
| Automations | Source: shared agent-scope control. |
| Tasks | Source: shared agent-scope control. |
| Settings → Models | Source: shared agent-scope control. |
| Skill workshop | Source: shared agent-scope control. |
| Workboard page scope | Source: host component adapter mounts the shared picker. |
| Workboard toolbar agent filter | Source: host component adapter mounts the shared picker. |
| Workboard create/edit-card assignment | Source: host component adapter mounts the shared picker; descriptions retain their existing layout. |

The remaining consumer routes were not individually exercised in a browser. Mobile, very long localized labels, and third-party plugin picker configurations are not covered by these captures.

Local validation:

| Command | Result |
| --- | --- |
| `node_modules/.bin/oxfmt --write ui/src/styles/components.css` | Passed |
| `node_modules/.bin/stylelint --config config/stylelint.config.mjs ui/src/styles/components.css` | Passed |
| `node scripts/check-changed.mjs -- ui/src/styles/components.css` | Passed |
| `node scripts/run-vitest.mjs ui/src/components/agent-select.test.ts ui/src/pages/agents/view.agent-selector.test.ts` | Passed: 31 tests in 2 files |
| `git diff --check` | Passed |

Review completed with no actionable findings. Hosted CI has not been evaluated.
