### PR TITLE
fix(auth): complete credential removal from legacy shared stores

### DIFF
--- a/src/agents/auth-profiles/profiles.test.ts
+++ b/src/agents/auth-profiles/profiles.test.ts
@@ -1699,6 +1699,70 @@ describe("promoteAuthProfileInOrder", () => {
     });
   });
 
+  it.each(
+    (["profile", "provider"] as const).flatMap((scope) =>
+      [false, true].map((replaceDuringCleanup) => ({ scope, replaceDuringCleanup })),
+    ),
+  )(
+    "removes a legacy-main $scope once after config cleanup (replacement=$replaceDuringCleanup)",
+    async ({ scope, replaceDuringCleanup }) => {
+      await withAuthProfileTestState("openclaw-auth-remove-shared-alias-", async ({ agentDir }) => {
+        const profileId = "openai:default";
+        const original = {
+          type: "token" as const,
+          provider: "openai",
+          token: "synthetic-original",
+        };
+        const replacement = { ...original, token: "synthetic-replacement" };
+        const unrelated = createApiKeyCredential("other", "synthetic-other");
+        saveAuthProfileStore(
+          {
+            version: AUTH_STORE_VERSION,
+            profiles: { [profileId]: original, "other:default": unrelated },
+          },
+          agentDir,
+        );
+        expect(reloadSharedAuthStoreOwnership().location).toBe("legacy-main");
+        const beforeRemove = vi.fn(async () => {
+          expect(loadPersistedAuthProfileStore()?.profiles[profileId]).toEqual(original);
+          if (replaceDuringCleanup) {
+            saveAuthProfileStore(
+              {
+                version: AUTH_STORE_VERSION,
+                profiles: { [profileId]: replacement, "other:default": unrelated },
+              },
+              agentDir,
+            );
+          }
+        });
+        const onIncomplete = vi.fn(async () => {});
+
+        const removed = await removeAuthProfilesAcrossOwnerStores({
+          agentDir,
+          profileIds: [profileId],
+          ...(scope === "provider" ? { provider: "openai" } : {}),
+          beforeRemove,
+          onIncomplete,
+        });
+
+        expect(removed).toBe(!replaceDuringCleanup);
+        expect(beforeRemove).toHaveBeenCalledExactlyOnceWith([profileId]);
+        for (const owner of [agentDir, undefined]) {
+          const persisted = loadPersistedAuthProfileStore(owner);
+          expect(persisted?.profiles[profileId]).toEqual(
+            replaceDuringCleanup ? replacement : undefined,
+          );
+          expect(persisted?.profiles["other:default"]).toEqual(unrelated);
+        }
+        if (replaceDuringCleanup) {
+          expect(onIncomplete).toHaveBeenCalledExactlyOnceWith(new Map([[profileId, replacement]]));
+        } else {
+          expect(onIncomplete).not.toHaveBeenCalled();
+        }
+      });
+    },
+  );
+
   it("removes an inherited profile from the owning main store too", async () => {
     await withAuthProfileTestState("openclaw-auth-remove-owner-", async ({ agentDirFor }) => {
       const mainAgentDir = agentDirFor("main");

--- a/src/agents/auth-profiles/profiles.ts
+++ b/src/agents/auth-profiles/profiles.ts
@@ -418,7 +418,14 @@ export async function removeAuthProfilesAcrossOwnerStores(params: {
   for (let attempt = 0; attempt < OAUTH_REMOVAL_MAX_ATTEMPTS; attempt += 1) {
     const owners =
       params.provider === undefined ? [params.agentDir] : providerAuthStoreOwners(params.agentDir);
-    const profilesByOwner = new Map(owners.map((owner) => [owner, new Set(profileIds)]));
+    // An explicit main dir and the implicit shared owner can name one legacy database.
+    // Capture it once, or the first removal makes its duplicate target look stale.
+    const profilesByOwner = new Map(
+      owners.map((owner) => [
+        isSharedMainAuthProfileAgentDir(owner) ? undefined : owner,
+        new Set(profileIds),
+      ]),
+    );
     for (const profileId of profileIds) {
       const ownerAgentDir = resolvePersistedAuthProfileOwnerAgentDir({
         agentDir: params.agentDir,

--- a/test/e2e/qa-lab/runtime/codex-auth-product-proof.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/codex-auth-product-proof.e2e.test.ts
@@ -475,12 +475,13 @@ describe("Codex auth product proof", () => {
         // A metadata patch alone does not prove the selected profile reaches native execution.
         await runConfiguredTurn("qa-codex-profile-binding-pinned");
 
-        const logoutResult = await client.request("models.authLogout", {
-          provider: "openai",
-          agentId: "main",
-          profileIds: [MISSING_PROFILE_ID],
-        });
-        expect(logoutResult, testInstance.logs()).toEqual({
+        await expect(
+          client.request("models.authLogout", {
+            provider: "openai",
+            agentId: "main",
+            profileIds: [MISSING_PROFILE_ID],
+          }),
+        ).resolves.toEqual({
           provider: "openai",
           removedProfiles: [MISSING_PROFILE_ID],
           abortedRunIds: [],

--- a/test/e2e/qa-lab/runtime/codex-auth-product-proof.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/codex-auth-product-proof.e2e.test.ts
@@ -375,6 +375,8 @@ describe("Codex auth product proof", () => {
           OPENCLAW_AGENT_HARNESS_FALLBACK: "none",
           OPENCLAW_QA_CODEX_APP_SERVER_VERSION: CODEX_APP_SERVER_VERSION,
           OPENCLAW_SKIP_PROVIDERS: undefined,
+          // Auth refresh consumes the configured owner published by full Gateway startup.
+          OPENCLAW_TEST_MINIMAL_GATEWAY: undefined,
         },
         config: {
           plugins: {
@@ -473,13 +475,12 @@ describe("Codex auth product proof", () => {
         // A metadata patch alone does not prove the selected profile reaches native execution.
         await runConfiguredTurn("qa-codex-profile-binding-pinned");
 
-        await expect(
-          client.request("models.authLogout", {
-            provider: "openai",
-            agentId: "main",
-            profileIds: [MISSING_PROFILE_ID],
-          }),
-        ).resolves.toEqual({
+        const logoutResult = await client.request("models.authLogout", {
+          provider: "openai",
+          agentId: "main",
+          profileIds: [MISSING_PROFILE_ID],
+        });
+        expect(logoutResult, testInstance.logs()).toEqual({
           provider: "openai",
           removedProfiles: [MISSING_PROFILE_ID],
           abortedRunIds: [],


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/pull/144316

## What Problem This Solves

Fixes an issue where users removing saved credentials receive “Saved credentials could not be removed” even though the credential was deleted, when shared auth still uses the supported main-agent SQLite location before Doctor relocation. The same failure reaches `models.authLogout` as `UNAVAILABLE`.

## Why This Change Was Made

Normalize removal targets through the existing shared-store owner predicate before capturing credentials. An explicit main-agent directory and the implicit shared owner can identify the same database; removing both captured targets makes the second appear stale. Capture and remove that owner once, preserving config cleanup, captured-credential comparisons, OAuth generation fences, personal-account boundaries, and distinct stores after relocation.

The Gateway fixture uses full startup so the configured model-runtime owner exists when logout refreshes auth. This adjustment follows [@fuller-stack-dev’s existing handoff](https://github.com/openclaw/openclaw/pull/144316#issuecomment-5640775954). The runtime repair was independently implemented; the broader contributor packet is not included.

Provenance: the alias-prone owner capture began in [#141477](https://github.com/openclaw/openclaw/pull/141477), authored and merged by @vincentkoc. Config-first removal in [#144420](https://github.com/openclaw/openclaw/pull/144420), authored and merged by @obviyus, made that collision surface without retry. Both existing safety contracts remain intact.

## User Impact

An unchanged credential can be removed successfully from the legacy shared store. A credential replaced during config cleanup stays protected, and unrelated credentials remain intact. No schema, config, provider, or external logout contract changes.

## Evidence

Results below are bound to their named source SHAs. The historical build of `931ff739c2aaf790c7c098ecbaac596777b88927` ran locally on Darwin arm64; the earlier behavior proof used native Testbox child phases. That build does not qualify the current head `42f489dff840a58b4ce14d03f65697bd877b2857`; CI and review for that head have not been verified here. Linked workflows are lease carriers, not exact-source CI results.

- **Historical build, September 13, 2026:** `931ff739c2aaf790c7c098ecbaac596777b88927` passed `OPENCLAW_BUILD_PRIVATE_QA=1 pnpm build` in **323.144 seconds**, using Node 26.7.0 and pnpm 12.3.4. Its isolated capsule first passed `pnpm install --frozen-lockfile --no-ignore-scripts` with normal dependency-install hooks. `OPENCLAW_RUN_NODE_SKIP_DTS_BUILD` and `OPENCLAW_UPDATE_IN_PROGRESS` were unset for the build. Full runtime and plugin-SDK declarations, QA Lab and qa-channel artifacts, all 153 public SDK subpaths, CLI bootstrap/runtime checks, and the Control UI completed. Install and build exited 0; their child processes settled, and the final guard verified all 41,197 tracked source files unchanged. No focused tests, E2E, or live-provider proof was rerun. The recorded source-commit hook exception for `931ff739` remains unchanged.
- **Retained build identities:** source tree `2f94ecde179b400e8b4a8fc80f1d7d0199bb4137`; build receipt SHA-256 `ac00a84bed7af143af4692dd20811c277a1cb25eb9aa61b97479c981372c7f7f`; generated-output manifest SHA-256 `8427747061b9fa7d69d1a27af452a31be690f5847b60a2bc73f10e3f5cb70883` covers 13,310 entries / 286,246,290 bytes. These identify retained local proof, not hosted CI.
- **Build advisory:** Control UI startup JavaScript gzip measured 354,509 bytes against the 354,270-byte limit (239 bytes over); the build returned 0. No baseline comparison was run, so this advisory is not attributed to the auth change.

This build evidence preserves the alias-only scope. The separate selected-profile recovery and SecretRef work remain in the [existing coordination](https://github.com/openclaw/openclaw/pull/145585#issuecomment-5651713547); their additional qualification is not claimed here.

- **Regression RED:** original production source at `ee641013ec25853f96e8894ce5a094a93440835d` plus the new test fails exactly the two ordinary-removal cells; both concurrent-replacement controls pass.
- **82 focused tests pass** at `0f6cb3bfc787c7a17379c5fb282b95580daf4bf9`: four real-SQLite regression cells, profile removal, OAuth peer settlement, inherited owners, personal-account refusal, and CLI logout. Selected changed gates and a full private-QA build also pass. [Blacksmith Testbox run](https://github.com/openclaw/openclaw/actions/runs/34659518916).
- **Full-startup Gateway proof** at `389d9674fff79efff5b523d192d460afadc746c5`: strict `models.authLogout` response passes with the expected removed profile and no refresh warning. E2E changed gates and a fresh full private-QA build pass. [Blacksmith Testbox run](https://github.com/openclaw/openclaw/actions/runs/34670757711). Production and regression-test bytes match `0f6cb3`; the final test-only cleanup restores the original strict assertion syntax and removes diagnostic context.
- **Source and artifact checks:** before/after manifests match across all 41,197 tracked files. Diagnostic replay also preserves all 12,898 built-dist files and removes its exclusively created test driver. Proof used Node 24.19.0 and source-pinned dependencies.
- **Full recovery E2E remains red:** after successful logout, the next turn rejects before native execution with a generic configured-profile error. The existing test expects a native lifecycle event, and chat/`agent.wait` expose the profile ID instead of the canonical recovery message. No app-server methods ran for that rejected turn. This is the separate **selected-profile admission recovery and session-event fixture** follow-up already proposed in [@fuller-stack-dev’s handoff](https://github.com/openclaw/openclaw/pull/144316#issuecomment-5640775954); this PR does not claim that flow is fixed. Original failed runs are retained.

Production LOC: +8/-1 (net +7), justified by canonical store-owner identity. Tests: +66/-0. Dependency inspection covered Codex `414782450952a196bbb64b1605a458c2531c47b6`, [account logout](https://github.com/openai/codex/blob/414782450952a196bbb64b1605a458c2531c47b6/codex-rs/app-server/src/request_processors/account_processor.rs#L705) and [turn admission](https://github.com/openai/codex/blob/414782450952a196bbb64b1605a458c2531c47b6/codex-rs/app-server/src/request_processors/turn_processor.rs#L444). The Gateway proof uses a local app-server fixture; live provider revocation is untested.
