### PR TITLE
fix(gateway): avoid loading inactive worker history

### DIFF
--- a/src/gateway/worker-environments/worker-turn-detached-context.test.ts
+++ b/src/gateway/worker-environments/worker-turn-detached-context.test.ts
@@ -1,0 +1,381 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { SessionPlacementTurnParams } from "../../agents/session-placement-admission.js";
+import { SessionManager } from "../../agents/sessions/session-manager.js";
+import {
+  makeAgentAssistantMessage,
+  makeAgentUserMessage,
+} from "../../agents/test-helpers/agent-message-fixtures.js";
+import { upsertSessionEntryCore } from "../../config/sessions/session-accessor.js";
+import { withTimeout } from "../../infra/fs-safe.js";
+import { WorkerTaskPool } from "../../infra/worker-task-pool.js";
+import { createUserTurnTranscriptRecorder } from "../../sessions/user-turn-transcript.js";
+import { projectWorkerSessionTurnClaim } from "./placement-record.js";
+import { WorkerRunnerUnavailableError, type WorkerTurnTunnelHandle } from "./tunnel-contract.js";
+import { releaseClaimIfOwned } from "./worker-turn-admission.js";
+import {
+  ENVIRONMENT_ID,
+  OWNER_EPOCH,
+  SESSION_ID,
+  SESSION_KEY,
+  attachedEnvironment,
+  cleanupWorkerTurnLauncherTest,
+  createWorkerSessionTurnPlacementProvider,
+  credential,
+  measureLaunchTurn,
+  placements,
+  root as fixtureRoot,
+  seedActivePlacement,
+  sessionTarget,
+  setupWorkerTurnLauncherTest,
+  turn,
+  unusedEnvironments,
+  type WorkerTurnEnvironmentService,
+} from "./worker-turn-launcher.test-support.js";
+
+function visible(messages: readonly unknown[]) {
+  return messages.map((message) => {
+    if (!message || typeof message !== "object") {
+      throw new Error("invalid synthetic history");
+    }
+    const item = message as { role?: string; content?: unknown };
+    const text =
+      typeof item.content === "string"
+        ? item.content
+        : Array.isArray(item.content)
+          ? item.content
+              .map((part: unknown) =>
+                part && typeof part === "object" && "text" in part && typeof part.text === "string"
+                  ? part.text
+                  : "",
+              )
+              .join("")
+          : "";
+    return { role: item.role, text };
+  });
+}
+
+function seedPrevious() {
+  const manager = SessionManager.open(sessionTarget);
+  manager.appendMessage(makeAgentUserMessage({ content: "previous request", timestamp: 1 }));
+  const previousLeafId = manager.appendMessage(
+    makeAgentAssistantMessage({
+      content: [{ type: "text", text: "previous answer" }],
+      timestamp: 2,
+    }),
+  );
+  return { manager, previousLeafId };
+}
+
+const prior = [
+  { role: "user", text: "previous request" },
+  { role: "assistant", text: "previous answer" },
+];
+
+function recorder() {
+  return createUserTurnTranscriptRecorder({
+    target: { ...sessionTarget, sessionEntry: undefined },
+    input: {
+      text: "current request",
+      idempotencyKey: "synthetic-current-user",
+    },
+  });
+}
+
+let hasUnjoinedOwner = false;
+
+function request(runId: string): SessionPlacementTurnParams {
+  return { ...turn(runId), prompt: "current request", transcriptPrompt: "current request" };
+}
+
+async function launchProbe(input: SessionPlacementTurnParams, assertRunCurrent?: () => void) {
+  seedActivePlacement();
+  const deliberateStop = new WorkerRunnerUnavailableError();
+  let credentialCalls = 0;
+  let tunnelCalls = 0;
+  let launch: { baseLeafId: string | null; history: ReturnType<typeof visible> } | undefined;
+  const unexpected = async (): Promise<never> => {
+    throw new Error("unexpected virtual transport operation");
+  };
+  const tunnel: WorkerTurnTunnelHandle = {
+    environmentId: ENVIRONMENT_ID,
+    ownerEpoch: OWNER_EPOCH,
+    runWorkspaceCommand: unexpected,
+    syncWorkspace: unexpected,
+    quiesceWorkspace: unexpected,
+    reconcileWorkspace: unexpected,
+    stop: async () => {},
+    measureLaunchTurn,
+    launchTurn: async ({ plan }) => {
+      launch = {
+        baseLeafId: plan.assignment.transcript.baseLeafId,
+        history: visible(plan.assignment.initialMessages),
+      };
+      // Never call onDispatchReady: no remote turn or credential delivery occurs.
+      throw deliberateStop;
+    },
+  };
+  const environments: WorkerTurnEnvironmentService = {
+    ...unusedEnvironments(),
+    get: () => attachedEnvironment(),
+    acquireTurnCredential: async () => {
+      credentialCalls++;
+      return credential();
+    },
+    acknowledgeCredentialDelivery: () => {
+      throw new Error("fixture must not dispatch");
+    },
+    startTunnel: async () => {
+      tunnelCalls++;
+      return tunnel;
+    },
+    stopTunnel: async () => {},
+    destroy: unexpected,
+  };
+  const provider = createWorkerSessionTurnPlacementProvider({ environments, placements });
+  const fixtureAbort = new AbortController();
+  const pending = provider
+    .executeTurn(
+      { sessionId: SESSION_ID, sessionKey: SESSION_KEY, agentId: "main", runId: input.runId },
+      {
+        ...input,
+        abortSignal: input.abortSignal
+          ? AbortSignal.any([input.abortSignal, fixtureAbort.signal])
+          : fixtureAbort.signal,
+      },
+      unexpected,
+      undefined,
+      assertRunCurrent,
+    )
+    .then(
+      () => ({ kind: "resolved" as const }),
+      (error: unknown) => ({ kind: "rejected" as const, error }),
+    );
+  let outcome: Awaited<typeof pending> | undefined;
+  const failures: unknown[] = [];
+  try {
+    outcome = await withTimeout(pending, input.timeoutMs, "worker functional launch observation");
+  } catch (error) {
+    failures.push(error);
+    fixtureAbort.abort(error);
+    try {
+      outcome = await withTimeout(pending, input.timeoutMs, "worker functional owner join");
+    } catch (joinError) {
+      failures.push(joinError);
+      hasUnjoinedOwner = true;
+    }
+  } finally {
+    input.preparedRunAdmission?.close();
+  }
+  if (failures.length > 0 || !outcome) {
+    throw new AggregateError(
+      failures,
+      `Worker functional proof did not settle in its budget; fixture state: ${fixtureRoot}`,
+    );
+  }
+  expect(placements.get(SESSION_ID)?.turnClaim).toBeNull();
+  expect(placements.listPendingWorkspaceResults()).toHaveLength(0);
+  if (launch) {
+    expect(outcome.kind).toBe("rejected");
+    if (outcome.kind === "rejected") {
+      expect(outcome.error).toBe(deliberateStop);
+    }
+  }
+  return { launch, credentialCalls, tunnelCalls, outcome, deliberateStop };
+}
+
+async function withAsyncReadHook<T>(
+  hooks: { before?: () => Promise<void>; after?: () => Promise<void> },
+  run: () => Promise<T>,
+) {
+  const original = SessionManager.openModelContextAsync.bind(SessionManager);
+  const descriptor = Object.getOwnPropertyDescriptor(SessionManager, "openModelContextAsync")!;
+  let calls = 0;
+  Object.defineProperty(SessionManager, "openModelContextAsync", {
+    ...descriptor,
+    value: async (...args: Parameters<typeof original>) => {
+      calls++;
+      await hooks.before?.();
+      const result = await original(...args);
+      await hooks.after?.();
+      return result;
+    },
+  });
+  try {
+    return { result: await run(), calls };
+  } finally {
+    Object.defineProperty(SessionManager, "openModelContextAsync", descriptor);
+  }
+}
+
+describe("worker detached model-context branch parity", () => {
+  beforeEach(async () => {
+    if (hasUnjoinedOwner) {
+      throw new Error("prior worker fixture remains unjoined; retained state must not be replaced");
+    }
+    await setupWorkerTurnLauncherTest();
+  });
+  afterEach(async () => {
+    if (!hasUnjoinedOwner) {
+      await cleanupWorkerTurnLauncherTest();
+    }
+  });
+
+  it("keeps a pre-persisted current user out of replay and uses its exact base leaf", async () => {
+    const { manager } = seedPrevious();
+    const currentId = manager.appendMessage(
+      makeAgentUserMessage({
+        content: "current request",
+        timestamp: 3,
+      }),
+    );
+    const result = await launchProbe({
+      ...request("persisted-current"),
+      suppressNextUserMessagePersistence: true,
+    });
+    expect(result.launch).toEqual({ baseLeafId: currentId, history: prior });
+    expect(result.outcome).toEqual({ kind: "rejected", error: result.deliberateStop });
+  });
+
+  it("joins recorder persistence already in flight during preparation", async () => {
+    seedPrevious();
+    const inputRecorder = recorder();
+    expect(inputRecorder.hasPersisted()).toBe(false);
+    const pendingPersistence = inputRecorder.persistApproved();
+    const result = await launchProbe({
+      ...request("recorder-read-race"),
+      userTurnTranscriptRecorder: inputRecorder,
+    });
+    await pendingPersistence;
+    expect(result.launch).toEqual({
+      baseLeafId: inputRecorder.getAdmissionReceipt()?.entryId,
+      history: prior,
+    });
+  });
+
+  it("joins recorder persistence begun after taking the context snapshot", async () => {
+    seedPrevious();
+    const inputRecorder = recorder();
+    let snapshotRead = false;
+    let pendingPersistence: ReturnType<typeof inputRecorder.persistApproved> | undefined;
+    const persistInput = () => {
+      snapshotRead = true;
+      pendingPersistence ??= inputRecorder.persistApproved();
+      return pendingPersistence;
+    };
+    const workerRead = vi
+      .spyOn(WorkerTaskPool.prototype, "run")
+      .mockImplementationOnce(async function (this: WorkerTaskPool<unknown, unknown>, ...args) {
+        workerRead.mockRestore();
+        const snapshot = await this.run(...args);
+        await persistInput();
+        return snapshot;
+      });
+    const synchronousRead = vi
+      .spyOn(SessionManager.prototype, "buildSessionContext")
+      .mockImplementationOnce(function (this: SessionManager) {
+        synchronousRead.mockRestore();
+        const snapshot = this.buildSessionContext();
+        void persistInput();
+        return snapshot;
+      });
+    try {
+      const result = await launchProbe({
+        ...request("recorder-snapshot-overlap"),
+        userTurnTranscriptRecorder: inputRecorder,
+      });
+      expect(snapshotRead).toBe(true);
+      expect(result.outcome).toEqual({ kind: "rejected", error: result.deliberateStop });
+      expect(result.launch).toEqual({
+        baseLeafId: inputRecorder.getAdmissionReceipt()?.entryId,
+        history: prior,
+      });
+      expect(visible(SessionManager.open(sessionTarget).buildSessionContext().messages)).toEqual([
+        ...prior,
+        { role: "user", text: "current request" },
+      ]);
+    } finally {
+      workerRead.mockRestore();
+      synchronousRead.mockRestore();
+      await pendingPersistence;
+    }
+  });
+
+  it("preserves logical base leaf when durable side-append placement differs", async () => {
+    const { manager, previousLeafId } = seedPrevious();
+    const currentId = manager.appendMessage(
+      makeAgentUserMessage({
+        content: "current request",
+        timestamp: 3,
+      }),
+    );
+    manager.branch(previousLeafId);
+    const sideId = manager.appendMessage(
+      makeAgentUserMessage({
+        content: "inactive side input",
+        timestamp: 4,
+      }),
+    );
+    manager.appendLeafControl({ targetId: currentId, appendParentId: sideId, appendMode: "side" });
+    expect(manager.getLeafId()).toBe(currentId);
+    expect(manager.getAppendParentId()).toBe(sideId);
+    const result = await launchProbe({
+      ...request("split-leaf"),
+      suppressNextUserMessagePersistence: true,
+    });
+    expect(result.launch).toEqual({ baseLeafId: currentId, history: prior });
+    const after = SessionManager.open(sessionTarget);
+    expect(after.getLeafId()).toBe(currentId);
+    expect(after.getAppendParentId()).toBe(sideId);
+  });
+
+  it.each(["cancel", "claim", "caller", "session"] as const)(
+    "refuses new effects after %s changes during the asynchronous context read",
+    async (change) => {
+      const { manager } = seedPrevious();
+      manager.appendMessage(makeAgentUserMessage({ content: "current request", timestamp: 3 }));
+      const abort = new AbortController();
+      let callerCurrent = true;
+      const observed = await withAsyncReadHook(
+        {
+          after: async () => {
+            if (change === "cancel") {
+              abort.abort(new Error("synthetic context-read cancellation"));
+            } else if (change === "claim") {
+              const placement = placements.get(SESSION_ID);
+              const claim = placement && projectWorkerSessionTurnClaim(placement);
+              if (!claim) {
+                throw new Error("fixture turn claim was not admitted");
+              }
+              await releaseClaimIfOwned(placements, claim);
+            } else if (change === "caller") {
+              callerCurrent = false;
+            } else {
+              await upsertSessionEntryCore(sessionTarget, {
+                sessionId: "replacement-session",
+                updatedAt: Date.now(),
+              });
+            }
+          },
+        },
+        () =>
+          launchProbe(
+            {
+              ...request("after-read-" + change),
+              suppressNextUserMessagePersistence: true,
+              abortSignal: abort.signal,
+            },
+            () => {
+              if (!callerCurrent) {
+                throw new Error("synthetic caller owner closed");
+              }
+            },
+          ),
+      );
+      expect(observed.calls).toBe(1);
+      expect(observed.result.credentialCalls).toBe(0);
+      expect(observed.result.tunnelCalls).toBe(0);
+      expect(observed.result.launch).toBeUndefined();
+      expect(observed.result.outcome.kind).toBe("rejected");
+    },
+  );
+});

--- a/src/gateway/worker-environments/worker-turn-execution.ts
+++ b/src/gateway/worker-environments/worker-turn-execution.ts
@@ -91,7 +91,24 @@ export async function executeWorkerTurn(
   turn.onExecutionStarted?.({ lifecycleGeneration: turn.lifecycleGeneration });
   turn.onExecutionPhase?.({ phase: "runner_entered", backend: "cloud-worker" });
   const transcriptTarget = resolveWorkerTurnTranscriptTarget(turn);
-  const manager = SessionManager.open(transcriptTarget);
+  // The unrecorded-input fallback retains its writable view and captured append custody.
+  const readAsynchronously =
+    turn.suppressNextUserMessagePersistence === true ||
+    turn.userTurnTranscriptRecorder?.hasPersisted() === true;
+  // Pending recorder writes keep the synchronous read-before-persist ordering.
+  const manager = readAsynchronously
+    ? await SessionManager.openModelContextAsync(transcriptTarget, { signal: turn.abortSignal })
+    : turn.userTurnTranscriptRecorder
+      ? SessionManager.openModelContext(transcriptTarget)
+      : SessionManager.open(transcriptTarget);
+  if (readAsynchronously) {
+    params.assertRunCurrent?.();
+    turn.abortSignal?.throwIfAborted();
+    if (!params.placements.validateTurnClaim(params.turnClaim)) {
+      throw new Error("Worker turn claim changed during context preparation");
+    }
+    resolveWorkerTurnTranscriptTarget(turn);
+  }
   const userMessageAlreadyPersisted =
     turn.suppressNextUserMessagePersistence === true ||
     turn.userTurnTranscriptRecorder?.hasPersisted() === true;

--- a/src/gateway/worker-environments/worker-turn-launcher.ts
+++ b/src/gateway/worker-environments/worker-turn-launcher.ts
@@ -366,7 +366,10 @@ export function createWorkerSessionTurnPlacementProvider(options: WorkerTurnLaun
           };
           return remoteExec
             ? await executeRemoteExecTurn({ ...executionParams, runLocal, assertRunCurrent })
-            : await executeWorkerTurn(executionParams);
+            : await executeWorkerTurn({
+                ...executionParams,
+                assertRunCurrent: assertAdmissionCurrent,
+              });
         } catch (error) {
           if (error instanceof StaleWorkerBuildError) {
             const canRecoverBuild =

--- a/src/gateway/worker-environments/worker-turn-transcript-footprint.test.ts
+++ b/src/gateway/worker-environments/worker-turn-transcript-footprint.test.ts
@@ -1,0 +1,263 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { SessionManager } from "../../agents/sessions/session-manager.js";
+import {
+  makeAgentAssistantMessage,
+  makeAgentUserMessage,
+} from "../../agents/test-helpers/agent-message-fixtures.js";
+import { withTimeout } from "../../infra/fs-safe.js";
+import { createUserTurnTranscriptRecorder } from "../../sessions/user-turn-transcript.js";
+import { createDeferredCore } from "../../shared/deferred.js";
+import { WorkerRunnerUnavailableError } from "./tunnel-contract.js";
+import {
+  SESSION_ID,
+  SESSION_KEY,
+  attachedEnvironment,
+  cleanupWorkerTurnLauncherTest,
+  createWorkerSessionTurnPlacementProvider,
+  placements,
+  root as fixtureRoot,
+  seedActivePlacement,
+  sessionTarget,
+  setupWorkerTurnLauncherTest,
+  turn,
+  unusedEnvironments,
+  type WorkerTurnEnvironmentService,
+} from "./worker-turn-launcher.test-support.js";
+
+const INACTIVE_MARKER = "inactive fixture message ";
+const INPUT_TEXT = "Inspect this workspace";
+
+function textOf(message: unknown): string {
+  if (!message || typeof message !== "object") {
+    return "";
+  }
+  const content = (message as { content?: unknown }).content;
+  if (typeof content === "string") {
+    return content;
+  }
+  return Array.isArray(content)
+    ? content
+        .map((part: unknown) =>
+          part && typeof part === "object" && "text" in part && typeof part.text === "string"
+            ? part.text
+            : "",
+        )
+        .join("")
+    : "";
+}
+
+function seedBranchedHistory(persistCurrentInput: boolean): number {
+  const manager = SessionManager.open(sessionTarget);
+  const anchor = manager.appendMessage(
+    makeAgentUserMessage({ content: "Starting the conversation.", timestamp: 1 }),
+  );
+  for (let index = 0; index < 64; index++) {
+    const text = `${INACTIVE_MARKER}${index}`.padEnd(1024, ".");
+    manager.appendMessage(
+      index % 2 === 0
+        ? makeAgentUserMessage({ content: text, timestamp: index + 2 })
+        : makeAgentAssistantMessage({
+            content: [{ type: "text", text }],
+            timestamp: index + 2,
+          }),
+    );
+  }
+  manager.branch(anchor);
+  manager.appendMessage(
+    makeAgentUserMessage({ content: "Continue on the selected branch.", timestamp: 66 }),
+  );
+  manager.appendMessage(
+    makeAgentAssistantMessage({
+      content: [{ type: "text", text: "Selected branch is ready." }],
+      timestamp: 67,
+    }),
+  );
+  if (persistCurrentInput) {
+    manager.appendMessage(makeAgentUserMessage({ content: INPUT_TEXT, timestamp: 68 }));
+  }
+  return persistCurrentInput ? 4 : 3;
+}
+
+describe("Gateway worker-turn selected transcript preparation", () => {
+  let hasUnjoinedOwner = false;
+  beforeEach(async () => {
+    if (hasUnjoinedOwner) {
+      throw new Error("Prior worker fixture remains unjoined; retained state must not be replaced");
+    }
+    await setupWorkerTurnLauncherTest();
+  });
+  afterEach(async () => {
+    if (!hasUnjoinedOwner) {
+      await cleanupWorkerTurnLauncherTest();
+    }
+  });
+
+  it.each(["already-persisted", "recorder-owned"] as const)(
+    "does not hydrate inactive branches for %s input",
+    async (persistence) => {
+      const expectedMessages = seedBranchedHistory(persistence === "already-persisted");
+      seedActivePlacement();
+      const reachedCredential = createDeferredCore();
+      const releaseCredential = createDeferredCore();
+      const deliberateStop = new WorkerRunnerUnavailableError();
+      const fixtureAbort = new AbortController();
+      const recorder =
+        persistence === "recorder-owned"
+          ? createUserTurnTranscriptRecorder({
+              target: { ...sessionTarget, sessionEntry: undefined },
+              input: { text: INPUT_TEXT },
+            })
+          : undefined;
+      const request = {
+        ...turn(`selected-context-${persistence}`),
+        prompt: INPUT_TEXT,
+        ...(recorder
+          ? { userTurnTranscriptRecorder: recorder }
+          : { suppressNextUserMessagePersistence: true }),
+        abortSignal: fixtureAbort.signal,
+      };
+      let credentialCalls = 0;
+      let tunnelCalls = 0;
+      let localCalls = 0;
+      let destroyCalls = 0;
+      const environments: WorkerTurnEnvironmentService = {
+        ...unusedEnvironments(),
+        get: () => attachedEnvironment(),
+        acquireTurnCredential: async () => {
+          credentialCalls++;
+          reachedCredential.resolve();
+          await releaseCredential.promise;
+          throw deliberateStop;
+        },
+        startTunnel: async () => {
+          tunnelCalls++;
+          throw new Error("Fixture must stop before tunnel creation");
+        },
+        destroy: async () => {
+          destroyCalls++;
+          throw new Error("Pre-launch refusal must preserve the active placement");
+        },
+      };
+      const provider = createWorkerSessionTurnPlacementProvider({ environments, placements });
+      let contextCalls = 0;
+      let observation:
+        | {
+            loadedMessages: number;
+            inactiveLoadedMessages: number;
+            contextMessages: number;
+            inactiveContextMessages: number;
+          }
+        | undefined;
+      // Preserve the implementation to forward each observed manager as its explicit receiver.
+      // oxlint-disable-next-line typescript/unbound-method
+      const originalContext = SessionManager.prototype.buildSessionContext;
+      const ownContextDescriptor = Object.getOwnPropertyDescriptor(
+        SessionManager.prototype,
+        "buildSessionContext",
+      );
+      // Observe loaded entries without retaining manager/results in mock histories.
+      Object.defineProperty(SessionManager.prototype, "buildSessionContext", {
+        configurable: true,
+        writable: true,
+        value(this: SessionManager) {
+          const result = originalContext.call(this);
+          const loaded = this.getEntries().filter((entry) => entry.type === "message");
+          contextCalls++;
+          observation = {
+            loadedMessages: loaded.length,
+            inactiveLoadedMessages: loaded.filter((entry) =>
+              textOf(entry.message).startsWith(INACTIVE_MARKER),
+            ).length,
+            contextMessages: result.messages.length,
+            inactiveContextMessages: result.messages.filter((message) =>
+              textOf(message).startsWith(INACTIVE_MARKER),
+            ).length,
+          };
+          return result;
+        },
+      });
+      const pending = provider
+        .executeTurn(
+          { sessionId: SESSION_ID, sessionKey: SESSION_KEY, agentId: "main", runId: request.runId },
+          request,
+          async () => {
+            localCalls++;
+            throw new Error("Fixture must use Gateway worker-turn orchestration");
+          },
+        )
+        .then(
+          () => ({ kind: "resolved" as const }),
+          (error: unknown) => ({ kind: "rejected" as const, error }),
+        );
+      const failures: unknown[] = [];
+      let outcome: Awaited<typeof pending> | undefined;
+      try {
+        await withTimeout(
+          Promise.race([
+            reachedCredential.promise,
+            pending.then(() => {
+              throw new Error("Turn settled before reaching credential acquisition");
+            }),
+          ]),
+          request.timeoutMs,
+          "worker transcript preparation",
+        );
+        expect(contextCalls).toBe(1);
+        expect(observation?.contextMessages).toBe(expectedMessages);
+        expect(observation?.inactiveContextMessages).toBe(0);
+        expect(credentialCalls).toBe(1);
+        expect(tunnelCalls).toBe(0);
+        expect(localCalls).toBe(0);
+        if (recorder) {
+          expect(recorder.hasPersisted()).toBe(true);
+          expect(recorder.getAdmissionReceipt()?.entryId).toEqual(expect.any(String));
+        }
+        expect(observation?.inactiveLoadedMessages).toBe(0);
+        expect(observation?.loadedMessages).toBe(expectedMessages);
+      } catch (error) {
+        failures.push(error);
+      } finally {
+        releaseCredential.resolve();
+        fixtureAbort.abort(deliberateStop);
+        try {
+          outcome = await withTimeout(pending, request.timeoutMs, "worker preparation owner join");
+        } catch (error) {
+          hasUnjoinedOwner = true;
+          failures.push(
+            new Error(`Unjoined worker fixture retained at ${fixtureRoot}`, { cause: error }),
+          );
+        } finally {
+          try {
+            request.preparedRunAdmission.close();
+          } finally {
+            if (ownContextDescriptor) {
+              Object.defineProperty(
+                SessionManager.prototype,
+                "buildSessionContext",
+                ownContextDescriptor,
+              );
+            } else {
+              delete (SessionManager.prototype as Partial<SessionManager>).buildSessionContext;
+            }
+          }
+        }
+      }
+      try {
+        expect(outcome?.kind).toBe("rejected");
+        if (outcome?.kind === "rejected") {
+          expect(outcome.error).toBe(deliberateStop);
+        }
+        if (outcome) {
+          expect(placements.get(SESSION_ID)).toMatchObject({ state: "active", turnClaim: null });
+          expect(placements.listPendingWorkspaceResults()).toHaveLength(0);
+        }
+        expect(destroyCalls).toBe(0);
+      } catch (error) {
+        failures.push(error);
+      }
+      if (failures.length > 0) {
+        throw new AggregateError(failures, "Worker selected-transcript preparation failed");
+      }
+    },
+  );
+});


### PR DESCRIPTION
## What Problem This Solves

Fixes unnecessary Gateway memory use when cloud-worker turns begin in sessions with inactive transcript branches. Preparing a small active conversation loaded and retained the physical transcript's inactive message payloads while credentials, workspace media, and skills were prepared.

## Why This Change Was Made

Use the existing selected model-context readers for recorder-owned or already-persisted input. A pending recorder keeps the synchronous read-before-persist ordering, so its own append cannot invalidate an asynchronous snapshot. Already-persisted input uses the asynchronous reader and revalidates the caller, cancellation, exact placement claim, and current transcript identity after the read.

Unrecorded input keeps its writable SessionManager, preserving captured append ancestry, conflict handling, and writer custody. The completion reader and recorder-race fallback remain unchanged. No schema, retention, or transcript-commit recovery contract changes.

## User Impact

Worker turns stop retaining inactive message payloads during this preparation phase while keeping the same active history and current-input/base-leaf behavior. This is a bounded allocation repair, not a claim that all Gateway memory pressure or stalls are resolved.

## Evidence

Both permanent 64-row tests fail on the unmodified producer because it hydrates 64 inactive 1 KiB messages, then pass with zero inactive payloads. The active conversation remains four messages for already-persisted input or three before recorder-owned persistence. The earlier 512-row diagnostic measured roughly 614 KB of serialized loaded payload versus under 600 bytes for the selected reader; that is a payload proxy, not a retained-heap or RSS measurement.

All 10 focused tests pass on the current candidate. They cover input/history/base-leaf parity, split logical/append leaves, canonical persistence already in flight or begun after snapshot acquisition, and cancellation, claim loss, caller revocation, and session rebinding during the asynchronous read. Existing launcher/media/handoff and SessionManager owner suites previously passed 124 tests on the integration base.

Independent P0-P2 review is clean. The revised [Blacksmith wire proof](https://github.com/openclaw/openclaw/actions/runs/34672349693) passed two authenticated chat turns, history-prefix/input/base-leaf checks, completed supervisor receipts, and joined cleanup; the owned lease is completed. The native synced proof verified both producer hashes, the harness, tests, and lockfile before its build (Node 24.19.0). Its delegated checkout metadata follows the hydrated main; exact-head CI is tracked separately on this PR.

The campaign wire harness remains private rather than duplicating the maintained service suite. It uses a loopback mock provider and a separate authenticated operator.read/operator.write client; it does not establish real-provider behavior or multi-profile membership semantics. The final native changed checks passed, including typechecking, lint, dead-code and repository guards.

Exact-head CI passed after one qualified rerun of the unchanged QA gallery shard. A temporary path containing `gif` deterministically reproduces its log-as-image classification failure; the original CI failure is retained and the unrelated gallery repair is tracked separately.
