### PR TITLE
feat(approvals): record verified reviewers in approval history

### DIFF
--- a/docs/tools/exec-approvals.md
+++ b/docs/tools/exec-approvals.md
@@ -63,6 +63,25 @@ for matching, prompting, and binding restrictions.
 - The **node host service** forwards `system.run` to the **macOS app** over local IPC.
 - The **macOS app** enforces approvals and executes the command in UI context.
 
+## Decision history
+
+The Control UI Approvals page and authorized terminal approval RPC responses retain
+the winning reviewer's opaque profile ID and, when already verified at sign-in,
+their GitHub handle. The handle is a historical snapshot, not a link to the current
+account. Profile merges, handle changes, retries, and later reviewers do not rewrite
+the recorded decision.
+
+Shared gateway credentials, internal agents, automatic reviewers, channel-only
+reviewers, and historical records without a verified person remain unattributed.
+Device and runtime resolver labels remain separate from human identity. The source
+agent and session identify where the request arose, not a human originator; session
+ownership does not establish who requested an action.
+
+Attribution uses the existing approval readers and rolling 30-day history retention.
+It is not included in ordinary session events and does not store names, emails,
+credentials, or GitHub tokens. No audit setting or schema-version change is needed.
+See the [accepted attribution scope](https://github.com/openclaw/openclaw/issues/115902#issuecomment-5641921911).
+
 ## Inspecting the effective policy
 
 | Command                                                          | What it shows                                                                              |

--- a/packages/gateway-protocol/src/approvals-validators.test.ts
+++ b/packages/gateway-protocol/src/approvals-validators.test.ts
@@ -325,6 +325,30 @@ describe("unified approval protocol validators", () => {
     expect(validateApprovalHistoryParams({ kind: "tool" })).toBe(false);
 
     expect(validateApprovalHistoryResult({ items: [terminal], nextCursor: "next" })).toBe(true);
+    for (const decisionActor of [
+      { profileId: "person-a" },
+      { profileId: "person-a", githubLogin: "reviewer-a" },
+    ]) {
+      expect(validateApprovalHistoryResult({ items: [{ ...terminal, decisionActor }] })).toBe(true);
+      expect(
+        validateApprovalResolveParams({
+          id: terminal.id,
+          kind: "plugin",
+          decision: "deny",
+          decisionActor,
+        }),
+      ).toBe(false);
+    }
+    for (const decisionActor of [
+      { profileId: "" },
+      { profileId: "x".repeat(257) },
+      { profileId: "person-a", githubLogin: "not a login" },
+      { profileId: "person-a", email: "reviewer@example.test" },
+    ]) {
+      expect(validateApprovalHistoryResult({ items: [{ ...terminal, decisionActor }] })).toBe(
+        false,
+      );
+    }
     expect(validateApprovalHistoryResult({ items: [{ ...execRecord, status: "pending" }] })).toBe(
       false,
     );

--- a/packages/gateway-protocol/src/schema/approvals.ts
+++ b/packages/gateway-protocol/src/schema/approvals.ts
@@ -226,6 +226,17 @@ const ApprovalResolutionFields = {
   resolvedAtMs: Type.Integer({ minimum: 0 }),
   source: Type.Optional(ApprovalHistorySourceAttributionSchema),
   resolver: Type.Optional(ApprovalHistoryResolverAttributionSchema),
+  decisionActor: Type.Optional(
+    closedObject({
+      profileId: Type.String({ minLength: 1, maxLength: 256 }),
+      githubLogin: Type.Optional(
+        Type.String({
+          maxLength: 39,
+          pattern: "^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$",
+        }),
+      ),
+    }),
+  ),
 };
 
 /** Approval that has not yet accepted a reviewer decision. */

--- a/src/gateway/exec-approval-manager.ts
+++ b/src/gateway/exec-approval-manager.ts
@@ -25,6 +25,7 @@ import {
   insertOperatorApproval,
   resolveOperatorApproval,
   type ForceDenyOperatorApprovalResult,
+  type OperatorApprovalDecisionActor,
   type OperatorApprovalKind,
   type OperatorApprovalRecord,
   type OperatorApprovalResolver,
@@ -259,6 +260,7 @@ export class ExecApprovalManager<
     options: {
       /** Explicit grant expiry override; undefined defers to the configured default. */
       grantExpiresAtMs?: number | null;
+      decisionActor?: OperatorApprovalDecisionActor;
     } = {},
   ): ExecApprovalResolveResult<TPayload> {
     if (this.retired) {
@@ -332,6 +334,7 @@ export class ExecApprovalManager<
         decision,
         resolver,
         expectedKind: this.approvalKind,
+        decisionActor: localResolutionSource === "operator" ? options.decisionActor : undefined,
         runtimeEpoch: persistence.runtimeEpoch,
         databaseOptions: persistence.databaseOptions,
         ...(standingGrant?.kind === "cron" ? { standingGrant } : {}),
@@ -578,7 +581,10 @@ export class ExecApprovalManager<
     recordId: string,
     decision: ExecApprovalDecision,
     resolvedBy?: string | null,
-    options: { grantExpiresAtMs?: number | null } = {},
+    options: {
+      grantExpiresAtMs?: number | null;
+      decisionActor?: OperatorApprovalDecisionActor;
+    } = {},
   ): boolean {
     return (
       this.resolveDetailed(

--- a/src/gateway/github-user-identity.cache.test.ts
+++ b/src/gateway/github-user-identity.cache.test.ts
@@ -109,8 +109,12 @@ describe("GitHub public identity metadata cache", () => {
         );
       stubIdentityFetch(metadata);
       const first = await createAccessSync()();
+      expect(first.githubIdentity).toMatchObject({ accountId: 101, login: "ada" });
       clock.mockReturnValue(1_800_000_000_000 + CACHE_TTL_MS - 1);
-      await expect(createAccessSync()()).resolves.toMatchObject({ profileId: first.profileId });
+      await expect(createAccessSync()()).resolves.toMatchObject({
+        profileId: first.profileId,
+        githubIdentity: { accountId: 101, login: "ada" },
+      });
       expect(metadata).toHaveBeenCalledOnce();
       clock.mockReturnValue(1_800_000_000_000 + CACHE_TTL_MS);
       await expect(createAccessSync()()).resolves.toMatchObject({
@@ -123,7 +127,10 @@ describe("GitHub public identity metadata cache", () => {
       await createAccessSync()();
       expect(metadata).toHaveBeenCalledTimes(2);
       clock.mockReturnValue(1_800_000_000_000 + 2 * CACHE_TTL_MS);
-      await createAccessSync()();
+      await expect(createAccessSync()()).resolves.toMatchObject({
+        profileId: first.profileId,
+        githubIdentity: { accountId: 101, login: "ada-renamed" },
+      });
       expect(getUserProfileListItem(first.profileId).githubIdentity?.login).toBe("ada-renamed");
     });
   });
@@ -320,8 +327,14 @@ describe("GitHub public identity metadata cache", () => {
       stubIdentityFetch(metadata, access);
       const first = await createAccessSync()();
       clock.mockReturnValue(1_800_000_000_000 + CACHE_TTL_MS);
-      await expect(createAccessSync()()).resolves.toMatchObject({ profileId: first.profileId });
-      await expect(createAccessSync()()).resolves.toMatchObject({ profileId: first.profileId });
+      await expect(createAccessSync()()).resolves.toMatchObject({
+        profileId: first.profileId,
+        githubIdentity: { accountId: 101, login: "ada" },
+      });
+      await expect(createAccessSync()()).resolves.toMatchObject({
+        profileId: first.profileId,
+        githubIdentity: { accountId: 101, login: "ada" },
+      });
       access.email = "new-principal@example.test";
       await expect(createAccessSync(access.email)()).rejects.toMatchObject({ statusCode: 429 });
       expect(metadata).toHaveBeenCalledTimes(2);
@@ -348,6 +361,8 @@ describe("GitHub public identity metadata cache", () => {
       };
       const first = await sync();
       const second = await sync();
+      expect(first.githubIdentity).toMatchObject({ accountId: 101, login: "ada" });
+      expect(second.githubIdentity).toMatchObject({ accountId: 102, login: "ada" });
       expect(second.profileId).not.toBe(first.profileId);
       expect(transport).toHaveBeenCalledTimes(2);
     });

--- a/src/gateway/github-user-identity.ts
+++ b/src/gateway/github-user-identity.ts
@@ -44,7 +44,12 @@ type GitHubIdentityMetadataCache = {
   pending: Map<string, Promise<ResolvedGitHubUserIdentity>>;
 };
 const identityMetadataCaches = new WeakMap<typeof fetch, GitHubIdentityMetadataCache>();
-type AuthenticatedGitHubIdentitySyncResult = { profileId: string; updatedAt: number };
+export type AuthenticatedGitHubIdentity = { profileId: string; accountId: number; login: string };
+type AuthenticatedGitHubIdentitySyncResult = {
+  profileId: string;
+  updatedAt: number;
+  githubIdentity: { accountId: number; login: string };
+};
 export type AuthenticatedGitHubIdentitySync = () => Promise<AuthenticatedGitHubIdentitySyncResult>;
 
 function headerValue(value: string | string[] | undefined): string | undefined {
@@ -277,7 +282,7 @@ export function createAuthenticatedGitHubIdentitySync(params: {
         authenticationAlias: { kind: "github-login", login: tailscaleLogin.subject },
         initialDisplayName: params.authResult.tailscaleIdentity?.name,
       });
-      return { profileId: profile.id, updatedAt: profile.updatedAt };
+      return { profileId: profile.id, updatedAt: profile.updatedAt, githubIdentity: identity };
     });
   }
 
@@ -323,6 +328,6 @@ export function createAuthenticatedGitHubIdentitySync(params: {
       authenticationAlias: { kind: "email", email: access.principal },
       initialDisplayName: accessIdentity.initialDisplayName,
     });
-    return { profileId: profile.id, updatedAt: profile.updatedAt };
+    return { profileId: profile.id, updatedAt: profile.updatedAt, githubIdentity: lookup.identity };
   });
 }

--- a/src/gateway/http-utils.authorize-request.test.ts
+++ b/src/gateway/http-utils.authorize-request.test.ts
@@ -253,7 +253,11 @@ describe("authorizeGatewayHttpRequestOrReply", () => {
   );
 
   it("uses the verified GitHub profile before dispatching a request without roles", async () => {
-    const sync = vi.fn().mockResolvedValue({ profileId: "profile-github", updatedAt: 3 });
+    const sync = vi.fn().mockResolvedValue({
+      profileId: "profile-github",
+      updatedAt: 3,
+      githubIdentity: { accountId: 101, login: "reviewer" },
+    });
     vi.mocked(githubIdentity.createAuthenticatedGitHubIdentitySync).mockReturnValue(sync);
     vi.mocked(profileStore.getUserProfileDisplay).mockReturnValue({
       id: "profile-github-canonical",

--- a/src/gateway/operator-approval-decision-actor.ts
+++ b/src/gateway/operator-approval-decision-actor.ts
@@ -1,0 +1,33 @@
+import { GATEWAY_OWNER_PROFILE_ID } from "../../packages/gateway-protocol/src/schema/users.js";
+import {
+  normalizeOperatorApprovalDecisionActor,
+  type OperatorApprovalDecisionActor,
+} from "./operator-approval-store.js";
+import type { GatewayClient } from "./server-methods/client-types.js";
+import { isSyntheticGatewayCaller } from "./server-methods/gateway-personal-caller.js";
+
+export function resolveOperatorApprovalDecisionActor(
+  client: GatewayClient | null,
+): OperatorApprovalDecisionActor | undefined {
+  if (
+    !client?.authenticatedUserId ||
+    (client.connect.role !== undefined && client.connect.role !== "operator") ||
+    isSyntheticGatewayCaller(client) ||
+    client.internal?.approvalRuntime ||
+    client.internal?.operatorRoleActor?.kind === "system"
+  ) {
+    return undefined;
+  }
+  const github = client.authenticatedGitHubIdentity;
+  const profileId = github?.profileId ?? client.authenticatedUserProfile?.profileId;
+  // Shared gateway credentials get an owner profile, not an authenticated person.
+  if (profileId === GATEWAY_OWNER_PROFILE_ID) {
+    return undefined;
+  }
+  return normalizeOperatorApprovalDecisionActor(
+    profileId,
+    github && Number.isSafeInteger(github.accountId) && github.accountId > 0
+      ? github.login
+      : undefined,
+  );
+}

--- a/src/gateway/operator-approval-store.ts
+++ b/src/gateway/operator-approval-store.ts
@@ -24,7 +24,7 @@ import {
 } from "../infra/kysely-sync.js";
 import { normalizeSqliteNumber } from "../infra/sqlite-number.js";
 import { withExistingOpenClawStateDatabaseReadOnly } from "../state/openclaw-state-db-readonly.js";
-import { tableExists } from "../state/openclaw-state-db-schema-helpers.js";
+import { ensureColumn, tableExists } from "../state/openclaw-state-db-schema-helpers.js";
 import type {
   DB as OpenClawStateKyselyDatabase,
   OperatorApprovals,
@@ -34,6 +34,7 @@ import {
   runOpenClawStateWriteTransaction,
   type OpenClawStateDatabaseOptions,
 } from "../state/openclaw-state-db.js";
+import { normalizeGitHubLogin } from "../utils/github-login.js";
 import {
   mintCronStandingGrantLocked,
   type CronStandingGrantMintSpec,
@@ -80,6 +81,37 @@ export type OperatorApprovalResolver = {
   id: string | null;
 };
 
+export type OperatorApprovalDecisionActor = {
+  profileId: string;
+  githubLogin?: string;
+};
+
+export function normalizeOperatorApprovalDecisionActor(
+  profileId: unknown,
+  githubLogin?: unknown,
+): OperatorApprovalDecisionActor | undefined {
+  if (typeof profileId !== "string" || !profileId.trim() || profileId.length > 256) {
+    return undefined;
+  }
+  const login = typeof githubLogin === "string" ? normalizeGitHubLogin(githubLogin) : undefined;
+  return { profileId, ...(login ? { githubLogin: login } : {}) };
+}
+
+const decisionActorSchemaDatabases = new WeakSet<DatabaseSync>();
+
+function ensureDecisionActorSchema(options: OpenClawStateDatabaseOptions = {}): void {
+  const database = openOpenClawStateDatabase(options);
+  if (decisionActorSchemaDatabases.has(database.db)) {
+    return;
+  }
+  runOpenClawStateWriteTransaction(({ db }) => {
+    ensureColumn(db, "operator_approvals", "resolver_profile_id TEXT");
+    ensureColumn(db, "operator_approvals", "resolver_github_login TEXT");
+  }, options);
+  // Cache only committed DDL; a rolled-back ensure must remain retryable.
+  decisionActorSchemaDatabases.add(database.db);
+}
+
 export type OperatorApprovalRecord = {
   id: string;
   resolutionRef: string;
@@ -98,9 +130,21 @@ export type OperatorApprovalRecord = {
   terminalReason: OperatorApprovalTerminalReason | null;
   resolvedAtMs: number | null;
   resolver: OperatorApprovalResolver | null;
+  decisionActor?: OperatorApprovalDecisionActor;
   consumedAtMs: number | null;
   consumedBy: string | null;
 };
+
+export function projectOperatorApprovalDecisionActor(
+  record: OperatorApprovalRecord,
+  nowMs = Date.now(),
+): OperatorApprovalDecisionActor | undefined {
+  // Known-ID lookups can outlive opportunistic parent pruning; actor disclosure cannot.
+  return record.resolvedAtMs !== null &&
+    record.resolvedAtMs > nowMs - OPERATOR_APPROVAL_TERMINAL_RETENTION_MS
+    ? record.decisionActor
+    : undefined;
+}
 
 type NewOperatorApproval = {
   id: string;
@@ -433,6 +477,11 @@ function decodeOperatorApprovalRow(row: OperatorApprovalRow): OperatorApprovalRe
   const decision = row.decision as OperatorApprovalDecision | null;
   const terminalReason = row.terminal_reason as OperatorApprovalTerminalReason | null;
   const resolverKind = row.resolver_kind as OperatorApprovalResolverKind | null;
+  // Audit metadata never participates in lifecycle validation or execution authority.
+  const decisionActor =
+    row.terminal_reason === "user" && (resolverKind === "device" || resolverKind === "runtime")
+      ? normalizeOperatorApprovalDecisionActor(row.resolver_profile_id, row.resolver_github_login)
+      : undefined;
   if (
     !presentation ||
     !isWellFormedApprovalId(row.approval_id) ||
@@ -511,6 +560,7 @@ function decodeOperatorApprovalRow(row: OperatorApprovalRow): OperatorApprovalRe
           },
     consumedAtMs: row.consumed_at_ms,
     consumedBy: row.consumed_by,
+    ...(decisionActor ? { decisionActor } : {}),
   };
 }
 
@@ -1679,6 +1729,7 @@ export function resolveOperatorApproval(params: {
   id: string;
   decision: OperatorApprovalDecision;
   resolver: OperatorApprovalResolver;
+  decisionActor?: OperatorApprovalDecisionActor;
   expectedKind?: OperatorApprovalKind;
   runtimeEpoch?: string;
   nowMs?: number;
@@ -1691,6 +1742,16 @@ export function resolveOperatorApproval(params: {
 }): ResolveOperatorApprovalResult {
   const id = requireApprovalId(params.id);
   const resolverId = normalizeNullableString(params.resolver.id);
+  const decisionActor =
+    params.resolver.kind === "device" || params.resolver.kind === "runtime"
+      ? normalizeOperatorApprovalDecisionActor(
+          params.decisionActor?.profileId,
+          params.decisionActor?.githubLogin,
+        )
+      : undefined;
+  if (decisionActor) {
+    ensureDecisionActorSchema(params.databaseOptions);
+  }
   const runtimeEpoch =
     params.runtimeEpoch === undefined
       ? undefined
@@ -1739,6 +1800,12 @@ export function resolveOperatorApproval(params: {
         resolved_at_ms: auditTimestampMs,
         resolver_kind: params.resolver.kind,
         resolver_id: resolverId,
+        ...("resolver_profile_id" in row
+          ? {
+              resolver_profile_id: decisionActor?.profileId ?? null,
+              resolver_github_login: decisionActor?.githubLogin ?? null,
+            }
+          : {}),
         updated_at_ms: auditTimestampMs,
       })
       .where("approval_id", "=", id)

--- a/src/gateway/server-broadcast.serialization.test.ts
+++ b/src/gateway/server-broadcast.serialization.test.ts
@@ -508,6 +508,7 @@ describe("presence recipient projection", () => {
       pending.authenticatedGitHubIdentitySync = async () => ({
         profileId: "creator",
         updatedAt: 1,
+        githubIdentity: { accountId: 101, login: "creator" },
       });
       const node = makeClient("node").client;
       node.connect.role = "node";

--- a/src/gateway/server-methods.profile-authorization.test.ts
+++ b/src/gateway/server-methods.profile-authorization.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import { createDeferredCore } from "../shared/deferred.js";
 import { ensureProfileForEmail, getUserProfileListItem } from "../state/user-profiles.js";
 import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
+import type { AuthenticatedGitHubIdentitySync } from "./github-user-identity.js";
 import { createGatewayMethodRegistry } from "./methods/registry.js";
 import { handleGatewayRequest } from "./server-methods.js";
 import type { GatewayRequestHandler } from "./server-methods/types.js";
@@ -55,7 +56,7 @@ describe("Gateway pending-profile authorization", () => {
   it.each(["chat.send", "models.list"])(
     "waits for immutable profile attachment before %s dispatch",
     async (method) => {
-      const deferred = createDeferredCore<{ profileId: string; updatedAt: number }>();
+      const deferred = createDeferredCore<Awaited<ReturnType<AuthenticatedGitHubIdentitySync>>>();
       const client = createPendingProfileClient();
       client.authenticatedGitHubIdentitySync = vi.fn(async () => await deferred.promise);
       const handler = vi.fn<GatewayRequestHandler>(({ respond }) => respond(true, { ok: true }));
@@ -78,7 +79,11 @@ describe("Gateway pending-profile authorization", () => {
         hasAvatar: false,
         updatedAt: 1,
       };
-      deferred.resolve({ profileId: "profile-canonical", updatedAt: 1 });
+      deferred.resolve({
+        profileId: "profile-canonical",
+        updatedAt: 1,
+        githubIdentity: { accountId: 101, login: "canonical" },
+      });
 
       await expect(request).resolves.toHaveBeenCalledWith(true, { ok: true });
       expect(handler).toHaveBeenCalledOnce();
@@ -88,7 +93,7 @@ describe("Gateway pending-profile authorization", () => {
   it("returns retryable unavailability without dispatch and retries on the next request", async () => {
     const client = createPendingProfileClient();
     client.authenticatedGitHubIdentitySync = vi
-      .fn()
+      .fn<AuthenticatedGitHubIdentitySync>()
       .mockRejectedValueOnce(new Error("private provider detail"))
       .mockImplementationOnce(async () => {
         client.authenticatedUserProfile = {
@@ -97,7 +102,11 @@ describe("Gateway pending-profile authorization", () => {
           hasAvatar: false,
           updatedAt: 2,
         };
-        return { profileId: "profile-retried", updatedAt: 2 };
+        return {
+          profileId: "profile-retried",
+          updatedAt: 2,
+          githubIdentity: { accountId: 101, login: "retried" },
+        };
       });
     const handler = vi.fn<GatewayRequestHandler>(({ respond }) => respond(true, { ok: true }));
 
@@ -252,7 +261,7 @@ describe("Gateway pending-profile authorization", () => {
     for (const method of ["users.self", "status"]) {
       const client = createPendingProfileClient();
       client.authenticatedGitHubIdentitySync = vi.fn(
-        () => new Promise<{ profileId: string; updatedAt: number }>(() => {}),
+        () => new Promise<Awaited<ReturnType<AuthenticatedGitHubIdentitySync>>>(() => {}),
       );
       const handler = vi.fn<GatewayRequestHandler>(({ respond }) => respond(true, { ok: true }));
       const methodRegistry = createGatewayMethodRegistry([

--- a/src/gateway/server-methods/approval-shared.ts
+++ b/src/gateway/server-methods/approval-shared.ts
@@ -17,6 +17,8 @@ import type { PluginApprovalRequestPayload } from "../../infra/plugin-approvals.
 import { createDeferredCore } from "../../shared/deferred.js";
 import { prepareApprovalChannelCustody } from "../approval-channel-custody.js";
 import type { ExecApprovalManager, ExecApprovalRecord } from "../exec-approval-manager.js";
+import { resolveOperatorApprovalDecisionActor } from "../operator-approval-decision-actor.js";
+import type { OperatorApprovalDecisionActor } from "../operator-approval-store.js";
 import {
   type ApprovalRecordLookupResult,
   isApprovalRecordVisibleToClient,
@@ -488,6 +490,7 @@ export async function handleApprovalResolve<
     resolvedBy: string | null;
     snapshot: ExecApprovalRecord<TPayload>;
     resolver?: { kind: "channel"; id: string };
+    decisionActor?: OperatorApprovalDecisionActor;
   }) => boolean;
   forwardResolved?: (event: ResolvedApprovalEvent<TPayload>) => Promise<void> | void;
   forwardResolvedErrorLabel?: string;
@@ -562,6 +565,7 @@ export async function handleApprovalResolve<
   const resolvedBy =
     params.client?.connect?.client?.displayName ?? params.client?.connect?.client?.id ?? null;
   const resolver = custody ? ({ kind: "channel", id: custody.resolverId } as const) : undefined;
+  const decisionActor = custody ? undefined : resolveOperatorApprovalDecisionActor(params.client);
   let ok: boolean;
   try {
     ok = params.resolveRecord
@@ -571,11 +575,14 @@ export async function handleApprovalResolve<
           resolvedBy,
           snapshot: resolved.snapshot,
           resolver,
+          decisionActor,
         })
       : resolver
         ? params.manager.resolveDetailed(resolved.approvalId, params.decision, resolver, resolvedBy)
             .outcome === "resolved"
-        : params.manager.resolve(resolved.approvalId, params.decision, resolvedBy);
+        : params.manager.resolve(resolved.approvalId, params.decision, resolvedBy, {
+            decisionActor,
+          });
   } catch (err) {
     respondApprovalStorageUnavailable({ ...params, operation: "resolve", error: err });
     return;

--- a/src/gateway/server-methods/approval.test.ts
+++ b/src/gateway/server-methods/approval.test.ts
@@ -37,6 +37,7 @@ import { withEnvAsync } from "../../test-utils/env.js";
 import { ExecApprovalManager } from "../exec-approval-manager.js";
 import { createTestApprovalManager } from "../exec-approval-manager.test-support.js";
 import type { ExecApprovalManagerOptions } from "../exec-approval-manager.types.js";
+import { projectOperatorApprovalSnapshot } from "../operator-approval-snapshot.js";
 import { getOperatorApprovalDetailed, insertOperatorApproval } from "../operator-approval-store.js";
 
 function getOperatorApproval(params: Parameters<typeof getOperatorApprovalDetailed>[0]) {
@@ -49,6 +50,8 @@ import {
   cancelWorkerTurnClaimBoundApprovals,
 } from "./approval-run-cancellation.js";
 import { createApprovalHandlers } from "./approval.js";
+import { createExecApprovalHandlers } from "./exec-approval.js";
+import { createPluginApprovalHandlers } from "./plugin-approval.js";
 import type { GatewayRequestHandlerOptions } from "./types.js";
 
 const prepareApprovalChannelCustodyMock = vi.hoisted(() => vi.fn());
@@ -255,7 +258,12 @@ function createContext(
 
 async function invoke(params: {
   handlers: ReturnType<typeof createApprovalHandlers>;
-  method: "approval.get" | "approval.history" | "approval.resolve";
+  method:
+    | "approval.get"
+    | "approval.history"
+    | "approval.resolve"
+    | "exec.approval.resolve"
+    | "plugin.approval.resolve";
   body: Record<string, unknown>;
   client: GatewayRequestHandlerOptions["client"];
   context?: GatewayRequestHandlerOptions["context"];
@@ -288,6 +296,157 @@ function approvalFromResult(result: unknown) {
 }
 
 describe("unified approval handlers", () => {
+  it.each(["exec", "plugin", "system-agent"] as const)(
+    "captures the winning human for %s without disclosing it in session events",
+    async (kind) => {
+      const databaseOptions = createDatabaseOptions();
+      const managers = createManagers(databaseOptions);
+      const pending =
+        kind === "exec"
+          ? registerExec(managers.exec, { id: "actor" })
+          : kind === "plugin"
+            ? registerPlugin(managers.plugin, { id: "actor" })
+            : registerSystemAgent(managers.systemAgent, "actor");
+      const handlers = createApprovalHandlers({
+        execApprovalManager: managers.exec,
+        pluginApprovalManager: managers.plugin,
+        systemAgentApprovalManager: managers.systemAgent,
+        databaseOptions,
+      });
+      const first = createClient({ deviceId: "reviewer" })!;
+      first.authenticatedUserId = "first@example.test";
+      first.authenticatedUserProfile = {
+        profileId: "person-a",
+        displayName: "Not persisted",
+        hasAvatar: false,
+        updatedAt: 1,
+      };
+      first.authenticatedGitHubIdentity = {
+        profileId: "person-a",
+        accountId: 101,
+        login: "reviewer-a",
+      };
+      const second = {
+        ...first,
+        authenticatedUserId: "second@example.test",
+        authenticatedGitHubIdentity: { profileId: "person-b", accountId: 102, login: "reviewer-b" },
+      };
+      const body = { id: "actor", kind, decision: "allow-once" };
+      const response = await invoke({ handlers, method: "approval.resolve", body, client: first });
+      const decisionActor = { profileId: "person-a", githubLogin: "reviewer-a" };
+      expect(response.result).toMatchObject({
+        applied: true,
+        approval: { decisionActor, source: { agentId: "main", sessionKey: "agent:main:child" } },
+      });
+      expect(validateApprovalResolveResult(response.result)).toBe(true);
+      for (const decision of ["allow-once", "deny"]) {
+        const replay = await invoke({
+          handlers,
+          method: "approval.resolve",
+          body: { ...body, decision },
+          client: second,
+        });
+        expect(replay.result).toMatchObject({ applied: false, approval: { decisionActor } });
+      }
+      await expect(pending.decision).resolves.toBe("allow-once");
+      const stored = getOperatorApproval({ id: "actor", databaseOptions })!;
+      expect(projectOperatorApprovalSnapshot(stored, "")).not.toHaveProperty("decisionActor");
+      const history = await invoke({
+        handlers,
+        method: "approval.history",
+        body: {},
+        client: first,
+      });
+      expect(history.result).toMatchObject({ items: [{ decisionActor }] });
+      expect(JSON.stringify(vi.mocked(response.context.broadcast).mock.calls)).not.toContain(
+        "reviewer-a",
+      );
+      vi.spyOn(Date, "now").mockReturnValue(stored.resolvedAtMs! + 30 * 24 * 60 * 60_000);
+      const expiredGet = await invoke({
+        handlers,
+        method: "approval.get",
+        body: { id: "actor" },
+        client: first,
+      });
+      const expiredReplay = await invoke({
+        handlers,
+        method: "approval.resolve",
+        body,
+        client: first,
+      });
+      for (const expired of [expiredGet, expiredReplay]) {
+        expect(approvalFromResult(expired.result)).not.toHaveProperty("decisionActor");
+        expect(approvalFromResult(expired.result)).toMatchObject({
+          status: "allowed",
+          resolver: { kind: "device", id: "reviewer" },
+        });
+      }
+    },
+  );
+
+  it.each(["exec", "plugin"] as const)(
+    "retains verified attribution through the legacy %s adapter",
+    async (kind) => {
+      const databaseOptions = createDatabaseOptions();
+      const managers = createManagers(databaseOptions);
+      const pending =
+        kind === "exec"
+          ? registerExec(managers.exec, { id: "legacy-actor" })
+          : registerPlugin(managers.plugin, { id: "legacy-actor" });
+      const handlers =
+        kind === "exec"
+          ? createExecApprovalHandlers(managers.exec)
+          : createPluginApprovalHandlers(managers.plugin);
+      const client = createClient({ deviceId: "reviewer" })!;
+      client.authenticatedUserId = "reviewer@example.test";
+      client.authenticatedUserProfile = {
+        profileId: "person-a",
+        displayName: null,
+        hasAvatar: false,
+        updatedAt: 1,
+      };
+      const response = await invoke({
+        handlers,
+        method: kind === "exec" ? "exec.approval.resolve" : "plugin.approval.resolve",
+        body: { id: "legacy-actor", decision: "allow-once" },
+        client,
+      });
+      expect(response.ok).toBe(true);
+      await expect(pending.decision).resolves.toBe("allow-once");
+      expect(getOperatorApproval({ id: "legacy-actor", databaseOptions })).toMatchObject({
+        decisionActor: { profileId: "person-a" },
+      });
+    },
+  );
+
+  it("rejects forged actor fields without persisting human attribution", async () => {
+    const databaseOptions = createDatabaseOptions();
+    const managers = createManagers(databaseOptions);
+    const pending = registerExec(managers.exec, { id: "forged-actor" });
+    const handlers = createApprovalHandlers({
+      execApprovalManager: managers.exec,
+      pluginApprovalManager: managers.plugin,
+      databaseOptions,
+    });
+    const response = await invoke({
+      handlers,
+      method: "approval.resolve",
+      body: {
+        id: "forged-actor",
+        kind: "exec",
+        decision: "allow-once",
+        decisionActor: { profileId: "forged", githubLogin: "forged" },
+      },
+      client: createClient({ deviceId: "reviewer" }),
+    });
+    expect(approvalFromResult(response.result)).toMatchObject({
+      status: "denied",
+      reason: "malformed-verdict",
+    });
+    expect(approvalFromResult(response.result)).not.toHaveProperty("decisionActor");
+    await expect(pending.decision).resolves.toBe("deny");
+  });
+
   afterEach(() => {
     vi.restoreAllMocks();
     for (const manager of managersForCleanup.splice(0)) {

--- a/src/gateway/server-methods/approval.ts
+++ b/src/gateway/server-methods/approval.ts
@@ -31,11 +31,14 @@ import {
   canResolveOperatorApproval,
   canReviewOperatorApproval,
 } from "../operator-approval-authorization.js";
+import { resolveOperatorApprovalDecisionActor } from "../operator-approval-decision-actor.js";
 import { projectOperatorApprovalSnapshot } from "../operator-approval-snapshot.js";
 import {
   getOperatorApprovalDetailed,
   listTerminalOperatorApprovals,
   OperatorApprovalHistoryCursorError,
+  projectOperatorApprovalDecisionActor,
+  type OperatorApprovalDecisionActor,
   type OperatorApprovalRecord,
   type OperatorApprovalResolver,
 } from "../operator-approval-store.js";
@@ -67,12 +70,14 @@ function buildApprovalSnapshot(
     return snapshot;
   }
   // Terminal attribution belongs to RPC readers; session events omit it.
+  const decisionActor = projectOperatorApprovalDecisionActor(record);
   return {
     ...snapshot,
     source: {
       ...(record.source.agentId ? { agentId: record.source.agentId } : {}),
       ...(record.source.sessionKey ? { sessionKey: record.source.sessionKey } : {}),
     },
+    ...(decisionActor ? { decisionActor } : {}),
     ...(record.resolver
       ? {
           resolver: {
@@ -241,6 +246,7 @@ function applyApprovalDecision<TPayload>(params: {
   forceMalformedDeny: boolean;
   resolver: OperatorApprovalResolver;
   localResolvedBy: string | null;
+  decisionActor?: OperatorApprovalDecisionActor;
   grantExpiresAtMs?: number;
 }): ApplyApprovalDecisionResult<TPayload> {
   const result = params.forceMalformedDeny
@@ -259,7 +265,7 @@ function applyApprovalDecision<TPayload>(params: {
         params.resolver,
         params.localResolvedBy,
         "operator",
-        params.grantExpiresAtMs !== undefined ? { grantExpiresAtMs: params.grantExpiresAtMs } : {},
+        { grantExpiresAtMs: params.grantExpiresAtMs, decisionActor: params.decisionActor },
       );
   if (result.outcome === "decision-not-allowed") {
     return applyApprovalDecision({ ...params, forceMalformedDeny: true });
@@ -441,6 +447,7 @@ export function createApprovalHandlers(
         ? ({ kind: "channel", id: custody.resolverId } as const)
         : resolveApprovalResolver(client);
       const localResolvedBy = resolveLegacyApprovalLabel(client);
+      const decisionActor = custody ? undefined : resolveOperatorApprovalDecisionActor(client);
       const requestedDecision = resolveParams?.decision ?? null;
       const decisionAllowed =
         requestedDecision === "deny" ||
@@ -464,6 +471,7 @@ export function createApprovalHandlers(
                 forceMalformedDeny,
                 resolver,
                 localResolvedBy,
+                decisionActor,
                 // Grant terms freeze at resolve; an explicit per-resolve
                 // override (custom operator UIs, CLI) beats the config default.
                 ...(requestedDecision === "allow-always" &&
@@ -482,6 +490,7 @@ export function createApprovalHandlers(
                   forceMalformedDeny,
                   resolver,
                   localResolvedBy,
+                  decisionActor,
                 })
               : applyApprovalDecision({
                   manager: params.systemAgentApprovalManager!,
@@ -490,6 +499,7 @@ export function createApprovalHandlers(
                   forceMalformedDeny,
                   resolver,
                   localResolvedBy,
+                  decisionActor,
                 });
       } catch (error) {
         respondApprovalStorageUnavailable({ context, respond, operation: "resolve", error });

--- a/src/gateway/server-methods/client-types.ts
+++ b/src/gateway/server-methods/client-types.ts
@@ -4,7 +4,10 @@ import type { TranscriptSenderIdentity } from "../../chat/sender-identity.js";
 import type { PluginSubagentRequesterContext } from "../../plugins/runtime/subagent-requester-context.js";
 import type { RuntimePluginToolGrant } from "../../plugins/runtime/tool-grant.js";
 import type { AgentRuntimeIdentity } from "../agent-runtime-identity-token.js";
-import type { AuthenticatedGitHubIdentitySync } from "../github-user-identity.js";
+import type {
+  AuthenticatedGitHubIdentity,
+  AuthenticatedGitHubIdentitySync,
+} from "../github-user-identity.js";
 import type { GatewayOperatorRoleActor } from "../operator-role-actor.js";
 import type { PluginNodeCapabilitySurface } from "../plugin-node-capability.js";
 import type { GatewayWsBrowserOrigin } from "../server/ws-types.js";
@@ -47,6 +50,8 @@ export type GatewayClient = {
   /** Verified Tailscale provider identity; generic proxy identities must not infer this. */
   authenticatedUserIsTailscaleProvider?: boolean;
   authenticatedGitHubIdentitySync?: AuthenticatedGitHubIdentitySync;
+  /** Verified account binding captured at authentication, never accepted from wire params. */
+  authenticatedGitHubIdentity?: AuthenticatedGitHubIdentity;
   authenticatedUserProfile?: {
     profileId: string;
     displayName: string | null;

--- a/src/gateway/server-methods/exec-approval.ts
+++ b/src/gateway/server-methods/exec-approval.ts
@@ -655,11 +655,17 @@ export function createExecApprovalHandlers(
                 details: APPROVAL_ALLOW_ALWAYS_UNAVAILABLE_DETAILS,
               };
         },
-        resolveRecord: ({ approvalId, decision: decisionLocal, resolvedBy, resolver }) => {
+        resolveRecord: ({
+          approvalId,
+          decision: decisionLocal,
+          resolvedBy,
+          resolver,
+          decisionActor,
+        }) => {
           if (autoReviewResolution) {
             return manager.resolveAutoReview(approvalId, resolvedBy);
           }
-          const grantOptions = grantExpiresAtMs !== undefined ? { grantExpiresAtMs } : {};
+          const grantOptions = { grantExpiresAtMs, decisionActor };
           return resolver
             ? manager.resolveDetailed(
                 approvalId,

--- a/src/gateway/server-methods/gateway-client-identity.test.ts
+++ b/src/gateway/server-methods/gateway-client-identity.test.ts
@@ -67,7 +67,11 @@ describe("gateway client identity", () => {
   it("keeps a GitHub-backed mutable alias unattributed until immutable sync completes", () => {
     const client = {
       authenticatedUserId: "released-login@github",
-      authenticatedGitHubIdentitySync: async () => ({ profileId: "owner", updatedAt: 1 }),
+      authenticatedGitHubIdentitySync: async () => ({
+        profileId: "owner",
+        updatedAt: 1,
+        githubIdentity: { accountId: 101, login: "released-login" },
+      }),
     } as GatewayClient;
 
     expect(gatewayClientSenderFields(client)).toEqual({});

--- a/src/gateway/server-methods/operator-approval-decision-actor.test.ts
+++ b/src/gateway/server-methods/operator-approval-decision-actor.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it, vi } from "vitest";
+import { GATEWAY_OWNER_PROFILE_ID } from "../../../packages/gateway-protocol/src/schema/users.js";
+import { withGatewayToolCallerIdentity } from "../../agents/tools/gateway-caller-context.js";
+import { resolveOperatorApprovalDecisionActor } from "../operator-approval-decision-actor.js";
+import type { GatewayClient } from "./client-types.js";
+
+function client(): GatewayClient {
+  return {
+    connect: {
+      minProtocol: 1,
+      maxProtocol: 1,
+      client: {
+        id: "openclaw-control-ui",
+        displayName: "Not an identity",
+        version: "test",
+        platform: "test",
+        mode: "webchat",
+      },
+      role: "operator",
+    },
+    authenticatedUserId: "reviewer@example.test",
+    authenticatedUserProfile: {
+      profileId: "person-a",
+      displayName: "Not an identity",
+      hasAvatar: false,
+      updatedAt: 1,
+    },
+  };
+}
+
+describe("authenticated approval decision actor", () => {
+  it("distinguishes people using the same client without copying names or emails", () => {
+    const first = client();
+    const second = client();
+    second.authenticatedUserProfile!.profileId = "person-b";
+    expect(resolveOperatorApprovalDecisionActor(first)).toEqual({ profileId: "person-a" });
+    expect(resolveOperatorApprovalDecisionActor(second)).toEqual({ profileId: "person-b" });
+  });
+
+  it("keeps a prepared GitHub binding together across profile refresh, without awaiting sync", () => {
+    const reviewer = client();
+    reviewer.authenticatedUserIsTailscaleProvider = true;
+    reviewer.authenticatedGitHubIdentity = {
+      profileId: "person-a",
+      accountId: 101,
+      login: "reviewer-a",
+    };
+    reviewer.authenticatedGitHubIdentitySync = vi.fn();
+    reviewer.authenticatedUserProfile!.profileId = "person-b";
+    expect(resolveOperatorApprovalDecisionActor(reviewer)).toEqual({
+      profileId: "person-a",
+      githubLogin: "reviewer-a",
+    });
+    expect(reviewer.authenticatedGitHubIdentitySync).not.toHaveBeenCalled();
+  });
+
+  it.each<Partial<GatewayClient>>([
+    { authenticatedUserId: undefined },
+    { authenticatedUserProfile: undefined },
+    { internal: { syntheticClient: true } },
+    { internal: { agentToolCaller: { agentId: "main", sessionKey: "agent:main:test" } } },
+    { internal: { approvalRuntime: true } },
+    { internal: { operatorRoleActor: { kind: "system" } } },
+    {
+      authenticatedUserProfile: {
+        profileId: GATEWAY_OWNER_PROFILE_ID,
+        displayName: null,
+        hasAvatar: false,
+        updatedAt: 1,
+      },
+    },
+  ])("does not turn shared or internal clients into people: %j", (overrides) => {
+    expect(resolveOperatorApprovalDecisionActor({ ...client(), ...overrides })).toBeUndefined();
+  });
+
+  it("ignores request-supplied actor fields and invalid optional account metadata", () => {
+    const reviewer = client();
+    Object.assign(reviewer.connect, {
+      decisionActor: { profileId: "forged", githubLogin: "forged" },
+    });
+    reviewer.authenticatedGitHubIdentity = {
+      profileId: "person-a",
+      accountId: -1,
+      login: "forged",
+    };
+    expect(resolveOperatorApprovalDecisionActor(reviewer)).toEqual({ profileId: "person-a" });
+  });
+
+  it("does not attribute ambient agent-tool dispatch to its retained human client", async () => {
+    await withGatewayToolCallerIdentity({ agentId: "main", sessionKey: "agent:main:test" }, () => {
+      expect(resolveOperatorApprovalDecisionActor(client())).toBeUndefined();
+    });
+  });
+});

--- a/src/gateway/server-methods/operator-approval-store-attribution.test.ts
+++ b/src/gateway/server-methods/operator-approval-store-attribution.test.ts
@@ -1,0 +1,299 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  executeSqliteQuerySync,
+  executeSqliteQueryTakeFirstSync,
+  getNodeSqliteKysely,
+} from "../../infra/kysely-sync.js";
+import { assertSqliteSchemaContains } from "../../infra/sqlite-schema-contract.js";
+import type { DB as OpenClawStateKyselyDatabase } from "../../state/openclaw-state-db.generated.js";
+import {
+  closeOpenClawStateDatabaseForTest,
+  openOpenClawStateDatabase,
+  type OpenClawStateDatabaseOptions,
+} from "../../state/openclaw-state-db.js";
+import {
+  getOpenClawStateRuntimeSchema,
+  STATE_PERSISTENT_SCHEMA_COMPATIBILITY,
+} from "../../state/openclaw-state-schema-compatibility.js";
+import { ensureProfileForEmail, syncGitHubIdentity } from "../../state/user-profiles.js";
+import {
+  consumeOperatorApprovalAllowOnce,
+  getOperatorApprovalDetailed,
+  insertOperatorApproval,
+  pruneTerminalOperatorApprovals,
+  projectOperatorApprovalDecisionActor,
+  resolveOperatorApproval,
+} from "../operator-approval-store.js";
+
+type OperatorApprovalDatabase = Pick<OpenClawStateKyselyDatabase, "operator_approvals">;
+type NewOperatorApproval = Parameters<typeof insertOperatorApproval>[0]["approval"];
+const OPERATOR_APPROVAL_TERMINAL_RETENTION_MS = 30 * 24 * 60 * 60_000;
+const tempDirs: string[] = [];
+
+function createDatabaseOptions(): OpenClawStateDatabaseOptions {
+  const stateDir = fs.realpathSync(
+    fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-approval-attribution-")),
+  );
+  tempDirs.push(stateDir);
+  return { env: { ...process.env, OPENCLAW_STATE_DIR: stateDir } };
+}
+
+function approval(id: string): NewOperatorApproval {
+  return {
+    id,
+    kind: "exec",
+    presentation: {
+      kind: "exec",
+      commandText: `echo ${id}`,
+      commandPreview: `echo ${id}`,
+      warningText: null,
+      host: "gateway",
+      nodeId: null,
+      agentId: "main",
+      allowedDecisions: ["allow-once", "allow-always", "deny"],
+    },
+    requester: { deviceId: "request-device", clientId: "request-client", deviceTokenAuth: true },
+    reviewerDeviceIds: ["reviewer"],
+    source: {
+      agentId: "main",
+      sessionKey: "agent:main:child",
+      sessionId: "session-1",
+      runId: "run-1",
+      toolCallId: "tool-call-1",
+      toolName: "exec",
+    },
+    audienceSessionKeys: ["agent:main:child"],
+    runtimeEpoch: "runtime-a",
+    createdAtMs: 1_000,
+    expiresAtMs: 10_000,
+  };
+}
+
+function getOperatorApproval(params: Parameters<typeof getOperatorApprovalDetailed>[0]) {
+  const result = getOperatorApprovalDetailed(params);
+  return result.outcome === "found" ? result.record : null;
+}
+
+function rawApprovalRow(options: OpenClawStateDatabaseOptions, id: string) {
+  const database = openOpenClawStateDatabase(options);
+  const stateDb = getNodeSqliteKysely<OperatorApprovalDatabase>(database.db);
+  return executeSqliteQueryTakeFirstSync(
+    database.db,
+    stateDb.selectFrom("operator_approvals").selectAll().where("approval_id", "=", id),
+  );
+}
+
+describe("operator approval decision attribution storage", () => {
+  afterEach(() => {
+    closeOpenClawStateDatabaseForTest();
+    for (const dir of tempDirs.splice(0)) {
+      fs.rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  it("freezes the winning actor through replay, profile merge, rename, reopen, and retention", () => {
+    const databaseOptions = createDatabaseOptions();
+    const identity = { accountId: 101, login: "reviewer-a" };
+    const person = ensureProfileForEmail("reviewer@example.test", databaseOptions);
+    const decisionActor = { profileId: person.id, githubLogin: identity.login };
+    insertOperatorApproval({ approval: approval("actor-winner"), databaseOptions });
+    const decision = {
+      id: "actor-winner",
+      decision: "allow-once" as const,
+      resolver: { kind: "device" as const, id: "shared-client" },
+      nowMs: 2_000,
+      databaseOptions,
+    };
+    expect(resolveOperatorApproval({ ...decision, decisionActor })).toMatchObject({
+      outcome: "resolved",
+      record: { decisionActor },
+    });
+    for (const verdict of ["allow-once", "deny"] as const) {
+      expect(
+        resolveOperatorApproval({
+          ...decision,
+          decision: verdict,
+          decisionActor: { profileId: "loser" },
+        }),
+      ).toMatchObject({ outcome: "already-resolved", record: { decisionActor } });
+    }
+
+    const canonical = syncGitHubIdentity(
+      { identity, authenticationAlias: { kind: "email", email: "canonical@example.test" } },
+      databaseOptions,
+    );
+    const merged = syncGitHubIdentity(
+      {
+        identity: { ...identity, login: "renamed-reviewer" },
+        authenticationAlias: { kind: "email", email: "reviewer@example.test" },
+      },
+      databaseOptions,
+    );
+    expect(merged.id).toBe(canonical.id);
+    expect(merged.id).not.toBe(person.id);
+    closeOpenClawStateDatabaseForTest();
+    const retained = getOperatorApproval({ id: decision.id, nowMs: 3_000, databaseOptions })!;
+    expect(
+      projectOperatorApprovalDecisionActor(
+        retained,
+        1_999 + OPERATOR_APPROVAL_TERMINAL_RETENTION_MS,
+      ),
+    ).toEqual(decisionActor);
+    expect(
+      projectOperatorApprovalDecisionActor(
+        retained,
+        2_000 + OPERATOR_APPROVAL_TERMINAL_RETENTION_MS,
+      ),
+    ).toBeUndefined();
+    expect(getOperatorApproval({ id: decision.id, nowMs: 3_000, databaseOptions })).toMatchObject({
+      status: "allowed",
+      decisionActor,
+    });
+    expect(
+      consumeOperatorApprovalAllowOnce({
+        id: decision.id,
+        consumerId: "requester",
+        nowMs: 3_000,
+        databaseOptions,
+      }),
+    ).toMatchObject({ outcome: "consumed", record: { decisionActor } });
+    pruneTerminalOperatorApprovals({
+      nowMs: 2_001 + OPERATOR_APPROVAL_TERMINAL_RETENTION_MS,
+      databaseOptions,
+    });
+    expect(rawApprovalRow(databaseOptions, decision.id)).toBeUndefined();
+  });
+
+  it("keeps absent and malformed audit metadata out of lifecycle authority", () => {
+    const databaseOptions = createDatabaseOptions();
+    for (const [id, kind] of [
+      ["historical", "runtime"],
+      ["channel", "channel"],
+      ["corrupt-actor", "device"],
+    ] as const) {
+      insertOperatorApproval({ approval: approval(id), databaseOptions });
+      resolveOperatorApproval({
+        id,
+        decision: "allow-once",
+        resolver: { kind, id: "resolver" },
+        ...(id !== "historical"
+          ? { decisionActor: { profileId: "person-a", githubLogin: "reviewer-a" } }
+          : {}),
+        nowMs: 2_000,
+        databaseOptions,
+      });
+    }
+    expect(
+      getOperatorApproval({ id: "historical", nowMs: 3_000, databaseOptions }),
+    ).not.toHaveProperty("decisionActor");
+    expect(
+      getOperatorApproval({ id: "channel", nowMs: 3_000, databaseOptions }),
+    ).not.toHaveProperty("decisionActor");
+    const { db } = openOpenClawStateDatabase(databaseOptions);
+    const stateDb = getNodeSqliteKysely<OperatorApprovalDatabase>(db);
+    executeSqliteQuerySync(
+      db,
+      stateDb
+        .updateTable("operator_approvals")
+        .set({ resolver_profile_id: "x".repeat(257), resolver_github_login: "not a login" })
+        .where("approval_id", "=", "corrupt-actor"),
+    );
+    expect(
+      getOperatorApproval({ id: "corrupt-actor", nowMs: 3_000, databaseOptions }),
+    ).not.toHaveProperty("decisionActor");
+    expect(
+      consumeOperatorApprovalAllowOnce({
+        id: "corrupt-actor",
+        consumerId: "requester",
+        nowMs: 3_000,
+        databaseOptions,
+      }),
+    ).toMatchObject({ outcome: "consumed" });
+  });
+
+  it("adds nullable actor columns on first use and preserves the previous reader/writer contract", () => {
+    const databaseOptions = createDatabaseOptions();
+    const initial = openOpenClawStateDatabase(databaseOptions).db;
+    const version = initial.prepare("PRAGMA user_version").get();
+    initial.exec(
+      "ALTER TABLE operator_approvals DROP COLUMN resolver_profile_id; ALTER TABLE operator_approvals DROP COLUMN resolver_github_login;",
+    );
+    closeOpenClawStateDatabaseForTest();
+    const { db } = openOpenClawStateDatabase(databaseOptions);
+    const actorColumns = () =>
+      db
+        .prepare("PRAGMA table_info(operator_approvals)")
+        .all()
+        .filter(
+          (column) =>
+            column.name === "resolver_profile_id" || column.name === "resolver_github_login",
+        );
+    expect(actorColumns()).toEqual([]);
+    insertOperatorApproval({ approval: approval("first-actor"), databaseOptions });
+    expect(actorColumns()).toEqual([]);
+    const decisionActor = { profileId: "person-a", githubLogin: "reviewer-a" };
+    const decision = {
+      id: "first-actor",
+      decision: "allow-once" as const,
+      resolver: { kind: "device" as const, id: "device" },
+      decisionActor,
+      nowMs: 2_000,
+      databaseOptions,
+    };
+    expect(resolveOperatorApproval(decision)).toMatchObject({ outcome: "resolved" });
+    expect(resolveOperatorApproval(decision)).toMatchObject({ outcome: "already-resolved" });
+    expect(
+      actorColumns().map(({ name, type, notnull, dflt_value }) => ({
+        name,
+        type,
+        notnull,
+        dflt_value,
+      })),
+    ).toEqual([
+      { name: "resolver_profile_id", type: "TEXT", notnull: 0, dflt_value: null },
+      { name: "resolver_github_login", type: "TEXT", notnull: 0, dflt_value: null },
+    ]);
+    expect(db.prepare("PRAGMA user_version").get()).toEqual(version);
+    const previousSchema = getOpenClawStateRuntimeSchema({
+      includeVersionLazyAdditiveTables: false,
+    })
+      .replace("  resolver_profile_id TEXT,\n", "")
+      .replace("  resolver_github_login TEXT,\n", "");
+    expect(() =>
+      assertSqliteSchemaContains(
+        db,
+        "pre-attribution state database",
+        previousSchema,
+        STATE_PERSISTENT_SCHEMA_COMPATIBILITY,
+      ),
+    ).not.toThrow();
+    expect(
+      db
+        .prepare(
+          "SELECT status, decision, resolver_kind, resolver_id FROM operator_approvals WHERE approval_id = ?",
+        )
+        .get(decision.id),
+    ).toEqual({
+      status: "allowed",
+      decision: "allow-once",
+      resolver_kind: "device",
+      resolver_id: "device",
+    });
+    db.prepare(
+      "UPDATE operator_approvals SET consumed_at_ms = ?, consumed_by = ?, updated_at_ms = ? WHERE approval_id = ? AND consumed_at_ms IS NULL",
+    ).run(3_000, "previous-reader", 3_000, decision.id);
+    insertOperatorApproval({ approval: approval("older-insert"), databaseOptions });
+    resolveOperatorApproval({ ...decision, id: "older-insert", decisionActor: undefined });
+    closeOpenClawStateDatabaseForTest();
+    expect(getOperatorApproval({ id: decision.id, nowMs: 4_000, databaseOptions })).toMatchObject({
+      decisionActor,
+      consumedBy: "previous-reader",
+    });
+    expect(
+      getOperatorApproval({ id: "older-insert", nowMs: 4_000, databaseOptions }),
+    ).not.toHaveProperty("decisionActor");
+  });
+});

--- a/src/gateway/server-methods/system-agent-session-ownership.test.ts
+++ b/src/gateway/server-methods/system-agent-session-ownership.test.ts
@@ -127,7 +127,11 @@ function makeClient(params: {
       : {}),
     ...(params.githubSyncPending
       ? {
-          authenticatedGitHubIdentitySync: async () => ({ profileId: "pending", updatedAt: 1 }),
+          authenticatedGitHubIdentitySync: async () => ({
+            profileId: "pending",
+            updatedAt: 1,
+            githubIdentity: { accountId: 101, login: "pending" },
+          }),
         }
       : {}),
   } as GatewayClient;

--- a/src/gateway/server-methods/users.test.ts
+++ b/src/gateway/server-methods/users.test.ts
@@ -8,6 +8,7 @@ import {
   validateUsersSetRoleResult,
 } from "../../../packages/gateway-protocol/src/index.js";
 import { UserProfileOwnerError } from "../../state/user-profiles-schema.js";
+import type { AuthenticatedGitHubIdentitySync } from "../github-user-identity.js";
 import { usersHandlers } from "./users.js";
 
 const linkEmail = vi.hoisted(() => vi.fn());
@@ -212,9 +213,9 @@ describe("users gateway methods", () => {
       authenticatedUserIsTailscaleProvider: true,
       connect: { scopes: ["operator.write"] },
     };
-    const authenticatedGitHubIdentitySync = vi.fn(
+    const authenticatedGitHubIdentitySync = vi.fn<AuthenticatedGitHubIdentitySync>(
       async () =>
-        await new Promise<{ profileId: string; updatedAt: number }>((resolve) => {
+        await new Promise<Awaited<ReturnType<AuthenticatedGitHubIdentitySync>>>((resolve) => {
           finishSync = () => {
             providerClient.authenticatedUserProfile = {
               profileId: profile.id,
@@ -222,7 +223,11 @@ describe("users gateway methods", () => {
               hasAvatar: false,
               updatedAt: 1,
             };
-            resolve({ profileId: profile.id, updatedAt: profile.updatedAt });
+            resolve({
+              profileId: profile.id,
+              updatedAt: profile.updatedAt,
+              githubIdentity: { accountId: 101, login: "ada" },
+            });
           };
         }),
     );
@@ -247,7 +252,7 @@ describe("users gateway methods", () => {
       connect: { scopes: ["operator.write"] },
     };
     const authenticatedGitHubIdentitySync = vi
-      .fn()
+      .fn<AuthenticatedGitHubIdentitySync>()
       .mockRejectedValueOnce(new Error("network unavailable"))
       .mockImplementationOnce(async () => {
         providerClient.authenticatedUserProfile = {
@@ -256,7 +261,11 @@ describe("users gateway methods", () => {
           hasAvatar: false,
           updatedAt: 1,
         };
-        return { profileId: profile.id, updatedAt: profile.updatedAt };
+        return {
+          profileId: profile.id,
+          updatedAt: profile.updatedAt,
+          githubIdentity: { accountId: 101, login: "ada" },
+        };
       });
     providerClient.authenticatedGitHubIdentitySync = authenticatedGitHubIdentitySync;
     resolveUserProfileId.mockReturnValue(profile.id);

--- a/src/gateway/server-plugin-subagent-runtime.test.ts
+++ b/src/gateway/server-plugin-subagent-runtime.test.ts
@@ -361,7 +361,11 @@ describe("plugin background completions", () => {
         entered.resolve();
         await verification.promise;
         client.authenticatedUserProfile = operatorProfile;
-        return { profileId: operatorProfile.profileId, updatedAt: Date.now() };
+        return {
+          profileId: operatorProfile.profileId,
+          updatedAt: Date.now(),
+          githubIdentity: { accountId: 101, login: "operator" },
+        };
       };
       const result = completeScoped(client, { agentId: "main" });
       const rejected = expect(result).rejects.toThrow(/retired|current gateway instance binding/u);

--- a/src/gateway/server-request-entry.test.ts
+++ b/src/gateway/server-request-entry.test.ts
@@ -139,7 +139,11 @@ describe("Gateway request entry lifetime", { concurrent: false }, () => {
             hasAvatar: false,
             updatedAt: 1,
           };
-          return { profileId: "entry-profile", updatedAt: 1 };
+          return {
+            profileId: "entry-profile",
+            updatedAt: 1,
+            githubIdentity: { accountId: 101, login: "entry" },
+          };
         };
       }
       const harness = createDispatchTestHarness({
@@ -415,7 +419,11 @@ describe("Gateway request entry lifetime", { concurrent: false }, () => {
         hasAvatar: false,
         updatedAt: 1,
       };
-      return { profileId: "typed-profile", updatedAt: 1 };
+      return {
+        profileId: "typed-profile",
+        updatedAt: 1,
+        githubIdentity: { accountId: 101, login: "typed" },
+      };
     };
     const facade = createInternalAgentTurnFacade({
       client,

--- a/src/gateway/server/client-presence.test.ts
+++ b/src/gateway/server/client-presence.test.ts
@@ -328,6 +328,7 @@ describe("live person presence timing", () => {
     delayed.client.authenticatedGitHubIdentitySync = async () => ({
       profileId: "delayed-person",
       updatedAt: 1,
+      githubIdentity: { accountId: 101, login: "delayed-person" },
     });
     const started = Date.now();
     delayed.handler.setClient(delayed.client);

--- a/src/gateway/server/ws-connection/authenticated-request-dispatch.lifetime.test.ts
+++ b/src/gateway/server/ws-connection/authenticated-request-dispatch.lifetime.test.ts
@@ -77,7 +77,11 @@ describe("authenticated request completion", { concurrent: false }, () => {
             hasAvatar: false,
             updatedAt: 1,
           };
-          return { profileId: "lifetime-profile", updatedAt: 1 };
+          return {
+            profileId: "lifetime-profile",
+            updatedAt: 1,
+            githubIdentity: { accountId: 101, login: "lifetime" },
+          };
         };
       }
       const dispatch = harness.dispatcher

--- a/src/gateway/server/ws-connection/connect-session.ts
+++ b/src/gateway/server/ws-connection/connect-session.ts
@@ -25,7 +25,6 @@ import { resolveRuntimeServiceBuildId, resolveRuntimeServiceVersion } from "../.
 import { verifyAgentRuntimeIdentityToken } from "../../agent-runtime-identity-token.js";
 import { buildAuthenticatedPresenceUser } from "../../authenticated-presence-user.js";
 import { shouldUseGatewayOwnerProfile } from "../../gateway-owner-profile.js";
-import { createAuthenticatedGitHubIdentitySync } from "../../github-user-identity.js";
 import {
   attachGatewayLocalUserIngress,
   prepareGatewayLocalUserIngress,
@@ -55,6 +54,7 @@ import {
 import { sendGatewayHello } from "./connect-hello.js";
 import { prepareGatewayNodeConnect } from "./connect-node-session.js";
 import {
+  prepareGatewayConnectGitHubIdentity,
   resolveAuthenticatedProfile,
   resolveGatewayConnectUserProfile,
 } from "./connect-user-profile.js";
@@ -188,11 +188,12 @@ export async function attachAuthenticatedGatewayConnect(
     ? classifyTailscaleLogin(authResult.tailscaleIdentity.login)
     : undefined;
   const authenticatedUserIsTailscaleProvider = tailscaleLogin?.kind === "provider";
-  const resolveAuthenticatedGitHubIdentity = createAuthenticatedGitHubIdentitySync({
+  const gitHubIdentity = prepareGatewayConnectGitHubIdentity({
     authResult,
     authConfig: context.configSnapshot.gateway?.auth,
     requestHeaders: context.handler.upgradeReq.headers,
   });
+  const resolveAuthenticatedGitHubIdentity = gitHubIdentity.resolve;
   const rolesConfigured = Boolean(context.configSnapshot.gateway?.roles);
   const sharedSecretOperatorOwner =
     role === "operator" && (authMethod === "token" || authMethod === "password");
@@ -426,6 +427,7 @@ export async function attachAuthenticatedGatewayConnect(
     ...(authenticatedUserId ? { authenticatedUserId } : {}),
     ...(authenticatedUserIsTailscaleProvider ? { authenticatedUserIsTailscaleProvider: true } : {}),
     ...(authenticatedUserProfile ? { authenticatedUserProfile } : {}),
+    ...(gitHubIdentity.identity ? { authenticatedGitHubIdentity: gitHubIdentity.identity } : {}),
     clientIp: reportedClientIp,
     ...(context.browserOrigin ? { browserOrigin: context.browserOrigin } : {}),
     ...(Object.keys(internal).length > 0 ? { internal } : {}),
@@ -461,6 +463,7 @@ export async function attachAuthenticatedGatewayConnect(
     nextClient.authenticatedGitHubIdentitySync = async () => {
       const result = await resolveAuthenticatedGitHubIdentity();
       attachAuthenticatedProfile(result.profileId, result.updatedAt);
+      nextClient.authenticatedGitHubIdentity = gitHubIdentity.identity;
       return result;
     };
   }

--- a/src/gateway/server/ws-connection/connect-user-profile.ts
+++ b/src/gateway/server/ws-connection/connect-user-profile.ts
@@ -6,7 +6,34 @@ import {
   getUserProfileDisplay,
 } from "../../../state/user-profiles.js";
 import type { GatewayAuthResult } from "../../auth.js";
-import type { createAuthenticatedGitHubIdentitySync } from "../../github-user-identity.js";
+import {
+  createAuthenticatedGitHubIdentitySync,
+  type AuthenticatedGitHubIdentity,
+  type AuthenticatedGitHubIdentitySync,
+} from "../../github-user-identity.js";
+
+export function prepareGatewayConnectGitHubIdentity(
+  params: Parameters<typeof createAuthenticatedGitHubIdentitySync>[0],
+) {
+  const prepared: {
+    resolve: AuthenticatedGitHubIdentitySync | undefined;
+    identity?: AuthenticatedGitHubIdentity;
+  } = { resolve: undefined };
+  const sync = createAuthenticatedGitHubIdentitySync(params);
+  if (sync) {
+    prepared.resolve = async () => {
+      const result = await sync();
+      // Keep the verified binding together even if profile display refresh follows a merge.
+      prepared.identity = {
+        profileId: result.profileId,
+        accountId: result.githubIdentity.accountId,
+        login: result.githubIdentity.login,
+      };
+      return result;
+    };
+  }
+  return prepared;
+}
 
 export function resolveAuthenticatedProfile(profileId: string, updatedAt: number) {
   const { id, displayName, avatarRevision, hasAvatar } = getUserProfileDisplay(profileId);

--- a/src/gateway/server/ws-connection/message-handler.post-connect-health.test.ts
+++ b/src/gateway/server/ws-connection/message-handler.post-connect-health.test.ts
@@ -641,7 +641,11 @@ describe("attachGatewayWsMessageHandler post-connect health refresh", () => {
           const profile = params.authResult.tailscaleIdentity
             ? ensureProfileForTailscaleIdentity(params.authResult.tailscaleIdentity)
             : ensureProfileForEmailMock("authenticated@example.test");
-          return { profileId: profile.id, updatedAt: profile.updatedAt };
+          return {
+            profileId: profile.id,
+            updatedAt: profile.updatedAt,
+            githubIdentity: { accountId: 101, login: "ada" },
+          };
         });
       },
     );
@@ -1300,11 +1304,19 @@ describe("attachGatewayWsMessageHandler post-connect health refresh", () => {
     async (closedBeforeSync) => {
       await withGatewayTestState({ label: "gateway-github-profile-deferred" }, async () => {
         const canonical = ensureProfileForEmail("canonical@example.test");
-        const syncCompletion = createGatewayHarnessGate<{ profileId: string; updatedAt: number }>();
+        const syncCompletion = createGatewayHarnessGate<{
+          profileId: string;
+          updatedAt: number;
+          githubIdentity: { accountId: number; login: string };
+        }>();
         let finishSync: (() => void) | undefined;
         const sync = vi.fn(async () => {
           finishSync = () =>
-            syncCompletion.resolve({ profileId: canonical.id, updatedAt: canonical.updatedAt });
+            syncCompletion.resolve({
+              profileId: canonical.id,
+              updatedAt: canonical.updatedAt,
+              githubIdentity: { accountId: 101, login: "ada" },
+            });
           return await syncCompletion.promise;
         });
         createAuthenticatedGitHubIdentitySyncMock.mockReturnValueOnce(sync);
@@ -1377,6 +1389,7 @@ describe("attachGatewayWsMessageHandler post-connect health refresh", () => {
         await waitForFast(() => {
           expect(harness.client).toMatchObject({
             authenticatedUserProfile: { profileId: canonical.id },
+            authenticatedGitHubIdentity: { profileId: canonical.id, accountId: 101, login: "ada" },
           });
           expect(localUserIngressFor(harness.client)).toMatchObject({
             facts: {
@@ -1399,6 +1412,7 @@ describe("attachGatewayWsMessageHandler post-connect health refresh", () => {
         const sync = vi.fn(async () => ({
           profileId: canonical.id,
           updatedAt: canonical.updatedAt,
+          githubIdentity: { accountId: 101, login: "ada" },
         }));
         createAuthenticatedGitHubIdentitySyncMock.mockReturnValueOnce(sync);
         resolveConnectAuthStateMock.mockResolvedValueOnce({
@@ -1455,7 +1469,11 @@ describe("attachGatewayWsMessageHandler post-connect health refresh", () => {
   it("resolves a GitHub-backed role before registering the connection or sending hello", async () => {
     await withGatewayTestState({ label: "gateway-github-role-before-hello" }, async () => {
       const canonical = ensureProfileForEmail("canonical@example.test");
-      const syncCompletion = createGatewayHarnessGate<{ profileId: string; updatedAt: number }>();
+      const syncCompletion = createGatewayHarnessGate<{
+        profileId: string;
+        updatedAt: number;
+        githubIdentity: { accountId: number; login: string };
+      }>();
       const sync = vi.fn(async () => await syncCompletion.promise);
       createAuthenticatedGitHubIdentitySyncMock.mockReturnValueOnce(sync);
       loadConfigMock.mockImplementationOnce(() => ({
@@ -1504,12 +1522,17 @@ describe("attachGatewayWsMessageHandler post-connect health refresh", () => {
       await waitForFast(() => expect(sync).toHaveBeenCalledOnce());
       expect(harness.client).toBeNull();
       expect(harness.socketSend).not.toHaveBeenCalled();
-      syncCompletion.resolve({ profileId: canonical.id, updatedAt: canonical.updatedAt });
+      syncCompletion.resolve({
+        profileId: canonical.id,
+        updatedAt: canonical.updatedAt,
+        githubIdentity: { accountId: 101, login: "ada" },
+      });
 
       await waitForFast(() => {
         expect(harness.client).toMatchObject({
           connect: { scopes: ["operator.read"] },
           authenticatedUserProfile: { profileId: canonical.id },
+          authenticatedGitHubIdentity: { profileId: canonical.id, accountId: 101, login: "ada" },
         });
         expect(harness.socketSend).toHaveBeenCalled();
       });

--- a/src/gateway/server/ws-types.ts
+++ b/src/gateway/server/ws-types.ts
@@ -2,7 +2,10 @@
 import type { WebSocket } from "ws";
 import type { ConnectParams } from "../../../packages/gateway-protocol/src/schema/frames.js";
 import type { AgentRuntimeIdentity } from "../agent-runtime-identity-token.js";
-import type { AuthenticatedGitHubIdentitySync } from "../github-user-identity.js";
+import type {
+  AuthenticatedGitHubIdentity,
+  AuthenticatedGitHubIdentitySync,
+} from "../github-user-identity.js";
 import type { GatewayOperatorRoleActor } from "../operator-role-actor.js";
 import type { PluginNodeCapabilityClient } from "../plugin-node-capability.js";
 import type { WorkerConnectionIdentity } from "../worker-environments/connection-identity.js";
@@ -48,6 +51,8 @@ export type GatewayWsClient = PluginNodeCapabilityClient & {
   /** Verified Tailscale provider identity; generic proxy identities must not infer this. */
   authenticatedUserIsTailscaleProvider?: boolean;
   authenticatedGitHubIdentitySync?: AuthenticatedGitHubIdentitySync;
+  /** Verified account binding captured at authentication, never accepted from wire params. */
+  authenticatedGitHubIdentity?: AuthenticatedGitHubIdentity;
   authenticatedUserProfile?: {
     profileId: string;
     displayName: string | null;

--- a/src/gateway/session-sharing.test-utils.ts
+++ b/src/gateway/session-sharing.test-utils.ts
@@ -47,7 +47,11 @@ export function sharingPolicyClient(params: {
       : {}),
     ...(params.githubSyncPending
       ? {
-          authenticatedGitHubIdentitySync: async () => ({ profileId: "pending", updatedAt: 1 }),
+          authenticatedGitHubIdentitySync: async () => ({
+            profileId: "pending",
+            updatedAt: 1,
+            githubIdentity: { accountId: 101, login: "pending-reviewer" },
+          }),
         }
       : {}),
   };

--- a/src/gateway/session-viewer-presence.test.ts
+++ b/src/gateway/session-viewer-presence.test.ts
@@ -174,6 +174,7 @@ describe("presence projection store admission", () => {
       pending.authenticatedGitHubIdentitySync = async () => ({
         profileId: "pending",
         updatedAt: 1,
+        githubIdentity: { accountId: 101, login: "pending" },
       });
       const node = recipient();
       node.connect.role = "node";

--- a/src/state/openclaw-state-db-additive-columns.ts
+++ b/src/state/openclaw-state-db-additive-columns.ts
@@ -8,6 +8,8 @@ type LazyColumn = readonly [
 
 // Added after v6 shipped; first-use-only columns stay absent until their feature writes.
 const lazyColumns = [
+  ["operator_approvals", "resolver_profile_id", "TEXT", true],
+  ["operator_approvals", "resolver_github_login", "TEXT", true],
   ["claw_installs", "bootstrap_content_digest", "TEXT"],
   ["claw_installs", "bootstrap_source_path", "TEXT"],
   ["worker_environments", "desktop_json", "TEXT"],

--- a/src/state/openclaw-state-db.generated.d.ts
+++ b/src/state/openclaw-state-db.generated.d.ts
@@ -1039,8 +1039,10 @@ export interface OperatorApprovals {
   requested_by_device_token_auth: Generated<number>;
   resolution_ref: string;
   resolved_at_ms: number | null;
+  resolver_github_login: string | null;
   resolver_id: string | null;
   resolver_kind: string | null;
+  resolver_profile_id: string | null;
   reviewer_device_ids_json: string;
   runtime_epoch: string;
   source_agent_id: string | null;

--- a/src/state/openclaw-state-schema.sql
+++ b/src/state/openclaw-state-schema.sql
@@ -451,6 +451,8 @@ CREATE TABLE IF NOT EXISTS operator_approvals (
   resolved_at_ms INTEGER,
   resolver_kind TEXT CHECK (resolver_kind IN ('device', 'channel', 'runtime', 'system')),
   resolver_id TEXT,
+  resolver_profile_id TEXT,
+  resolver_github_login TEXT,
   consumed_at_ms INTEGER,
   consumed_by TEXT,
   CHECK (expires_at_ms >= created_at_ms),

--- a/src/state/user-profile-github-identity.ts
+++ b/src/state/user-profile-github-identity.ts
@@ -67,7 +67,7 @@ function selectStoredGitHubIdentities(
 export function resolveCachedGitHubIdentity(
   params: { accountId: number; email: string },
   options: OpenClawStateDatabaseOptions = {},
-): { profileId: string; updatedAt: number } | undefined {
+): { profileId: string; updatedAt: number; githubIdentity: StoredGitHubIdentity } | undefined {
   const email = params.email.trim().toLowerCase();
   if (!email || !Number.isSafeInteger(params.accountId) || params.accountId <= 0) {
     return undefined;
@@ -88,7 +88,7 @@ export function resolveCachedGitHubIdentity(
   }
   const identity = selectStoredGitHubIdentities(db, [profile.id]).get(profile.id);
   return identity?.accountId === params.accountId
-    ? { profileId: profile.id, updatedAt: profile.updated_at }
+    ? { profileId: profile.id, updatedAt: profile.updated_at, githubIdentity: identity }
     : undefined;
 }
 

--- a/ui/src/pages/approvals/approvals-page.test.ts
+++ b/ui/src/pages/approvals/approvals-page.test.ts
@@ -1,6 +1,7 @@
 /* @vitest-environment jsdom */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { validateApprovalHistoryResult } from "../../../../packages/gateway-protocol/src/approval-result-validators.js";
 import type { ApprovalHistoryResult } from "../../../../packages/gateway-protocol/src/schema/approvals.js";
 import type { GatewayBrowserClient, GatewayEventFrame } from "../../api/gateway.ts";
 import type { ApplicationContext, ApplicationGatewaySnapshot } from "../../app/context.ts";
@@ -110,6 +111,40 @@ function stubGrants(
 }
 
 describe("ApprovalsPage", () => {
+  it("renders historical people as plain text while retaining transport attribution", async () => {
+    const history: ApprovalHistoryResult = {
+      items: [
+        {
+          ...terminal("known", 3_000),
+          decisionActor: { profileId: "person-a", githubLogin: "historical-reviewer" },
+        },
+        { ...terminal("profile-only", 2_000), decisionActor: { profileId: "person-b" } },
+        terminal("unknown", 1_000),
+      ],
+    };
+    expect(validateApprovalHistoryResult(history)).toBe(true);
+    const request = vi.fn().mockResolvedValue(history);
+    const { page } = createPage(stubGrants(request));
+    await settle(page);
+    const rows = page.querySelectorAll(".approval-history-table tbody tr");
+    expect(rows[0]?.textContent).toContain("@historical-reviewer");
+    expect(rows[0]?.textContent).toContain("person-a");
+    expect(rows[0]?.textContent).toContain("reviewer-device");
+    expect(rows[1]?.textContent).toContain("person-b");
+    expect(rows[2]?.textContent).not.toContain("person-");
+    for (const [index, profileId] of [
+      [0, "person-a"],
+      [1, "person-b"],
+    ] as const) {
+      const resolverCell = rows[index]?.lastElementChild;
+      expect(resolverCell?.childElementCount).toBe(1);
+      expect(resolverCell?.firstElementChild?.textContent).toContain(profileId);
+      expect(resolverCell?.firstElementChild?.textContent).toContain("reviewer-device");
+    }
+    expect(rows[2]?.lastElementChild?.childElementCount).toBe(0);
+    expect(page.querySelector('a[href^="https://github.com/"]')).toBeNull();
+    expect(request).toHaveBeenCalledOnce();
+  });
   it("loads and renders terminal history, then paginates", async () => {
     const request = vi
       .fn()

--- a/ui/src/pages/approvals/approvals-page.ts
+++ b/ui/src/pages/approvals/approvals-page.ts
@@ -500,7 +500,20 @@ class ApprovalsPage extends OpenClawLightDomElement {
                           ${sourceLabel(item)}
                         </td>
                         <td class="mono" data-label=${t("approvalHistory.columns.resolver")}>
-                          ${resolverLabel(item)}
+                          ${
+                            item.decisionActor
+                              ? html`<div>
+                                  <div>
+                                    ${
+                                      item.decisionActor.githubLogin
+                                        ? `@${item.decisionActor.githubLogin} · `
+                                        : nothing
+                                    }${item.decisionActor.profileId}
+                                  </div>
+                                  ${resolverLabel(item)}
+                                </div>`
+                              : resolverLabel(item)
+                          }
                         </td>
                       </tr>
                     `,


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/issues/115902

## What Problem This Solves

Approval history identifies the device/runtime that resolved a request, but not the authenticated person who made the decision. Shared clients make that insufficient for reviewing release-process approvals.

## Why This Change Was Made

Capture the winning reviewer's opaque profile ID and an already-verified GitHub handle in the existing approval transaction. Identity comes from the authenticated connection, not request fields, display names, session ownership, or a new GitHub lookup. The handle is a historical snapshot rather than a link to the current account.

This follows the [accepted attribution scope](https://github.com/openclaw/openclaw/issues/115902#issuecomment-5641921911): two nullable TEXT columns, the existing additive-schema path, and no schema-version bump. Authorization, resolver labels, lifecycle decisions, ordinary session/project events, and `audit.run.inspect` remain unchanged.

## User Impact

- Authorized terminal approval RPCs and the Control UI Approvals history can show who approved or denied a request.
- Retries, competing reviewers, profile merges, and later handle changes cannot rewrite the winning attribution.
- Shared credentials, internal/system callers, automatic review, channel-only review, and old records stay unattributed rather than inventing a person.
- Source agent/session metadata remains separate. This does not infer or add a human originator.
- Attribution stores no names, email addresses, credentials, assertions, or tokens. Actor disclosure stops at the existing 30-day history boundary; physical row deletion remains the existing opportunistic parent pruning.

No production permissions, service configuration, or deployments are changed. This is the bounded approval-history part of the related issue, not completion of its broader authorization/API work.

## Evidence

- Final affected Gateway rerun: **323 tests passed across 15 files** on Linux/Node 24.19.0 using the [Blacksmith Testbox environment](https://github.com/openclaw/openclaw/actions/runs/34671583200).
- Also passed: protocol validation (8 tests), UI (15 tests), and additive-state migration (15 tests), plus the earlier approval/authentication sibling suites.
- Full core and core-test typechecks, UI typecheck, scoped lint, formatting, shard-boundary and import-cycle checks, and the packaged `pnpm build` passed. The build verified all 153 public plugin SDK subpaths and the Control UI performance budget.
- Final source and lockfile hashes matched the frozen input before and after remote validation. No dependency or runner-allocation changes.

- Exact-base old approval-store source successfully reads, consumes, and resolves rows with the new nullable columns; reopening with the candidate preserves old decisions and the winning actor. This exercises the old store module in the candidate checkout, not a full old-binary downgrade.
- Playwright against the source UI and mock Gateway: desktop 1440x1000 and mobile 390x844, real response validation, 39-character handles, 36-character profile IDs, attributed/profile-only/legacy rows, no overflow, no GitHub account links, and no browser errors. Mobile transport alignment is asserted.
- Independent source review and P2 autoreview: no outstanding findings. New attribution tests use the existing methods shard; runner counts and shard limits are unchanged.

### Desktop

Before:
![Approval history before human attribution](https://github.com/user-attachments/assets/f74ba321-6d89-45b9-9085-c6bd411d4456)

After:
![Approval history after human attribution](https://github.com/user-attachments/assets/d8482a8d-e2fe-4d4c-a988-bcaff2091a63)

### Mobile

Before:
![Mobile approval history before human attribution](https://github.com/user-attachments/assets/655af838-a767-417c-be67-eadd94f8df00)

After:
![Mobile approval history after human attribution](https://github.com/user-attachments/assets/f6943092-2b85-4c17-b4db-227383e3da45)

All captures use synthetic identities. Live production sign-in and release execution were not exercised.
