### PR TITLE
feat(linux): add Omarchy agents panel with desktop handoff

### DIFF
--- a/.github/workflows/linux-app.yml
+++ b/.github/workflows/linux-app.yml
@@ -97,6 +97,11 @@ jobs:
         working-directory: apps/linux/src-tauri
         run: cargo +stable fmt --check
 
+      - name: Test Omarchy desktop handoff
+        run: |
+          PYTHONDONTWRITEBYTECODE=1 /usr/bin/python3 -m unittest discover \
+            -s apps/linux/omarchy -p 'test_*.py'
+
       - name: Run Rust tests
         working-directory: apps/linux/src-tauri
         run: cargo +stable test --locked --all-targets

--- a/apps/linux/README.md
+++ b/apps/linux/README.md
@@ -12,6 +12,13 @@ Debian 12 meet that ABI floor. RHEL 9 and Rocky Linux 9 ship glibc 2.34, so
 they cannot run the published AppImage. Extraction does not bypass this
 requirement.
 
+## Omarchy
+
+The optional Omarchy 4 bar plugin provides agents, sessions, and quick prompts.
+With the matching desktop app running, it uses the app’s selected Gateway and
+keeps a single visible OpenClaw icon. See [Omarchy support](https://docs.openclaw.ai/platforms/omarchy)
+for installation, app handoff, shortcuts, and troubleshooting.
+
 ## Linux prerequisites
 
 Debian and Ubuntu development packages:

--- a/apps/linux/omarchy/CritterIcon.qml
+++ b/apps/linux/omarchy/CritterIcon.qml
@@ -1,0 +1,102 @@
+import QtQuick
+
+// Geometry adapted from OpenClaw's macOS CritterIconRenderer (18-point template).
+// Eyes are transparent cutouts so the icon also works on a transparent bar.
+Canvas {
+  id: root
+  property color foreground: "white"
+  property bool animated: true
+  property bool working: false
+  property real blink: 0
+  property real legs: 0
+  property real antenna: 0
+  implicitWidth: 18
+  implicitHeight: 18
+  onForegroundChanged: requestPaint()
+  onBlinkChanged: requestPaint()
+  onLegsChanged: requestPaint()
+  onAntennaChanged: requestPaint()
+  onWidthChanged: requestPaint()
+  onHeightChanged: requestPaint()
+
+  onPaint: {
+    var c = getContext("2d")
+    c.reset()
+    c.clearRect(0, 0, width, height)
+    c.save()
+    c.scale(width / 18, height / 18)
+    c.translate(0, 18)
+    c.scale(1, -1)
+    c.fillStyle = foreground
+    c.strokeStyle = foreground
+    c.lineWidth = 2.07
+    c.lineCap = "round"
+    for (var side of [-1, 1]) {
+      c.beginPath()
+      c.moveTo(9 + side * 2.0736, 13.437)
+      c.quadraticCurveTo(9 + side * 2.8512, 16.65,
+                        9 + side * 5.184 + side * antenna * 0.28,
+                        16.38 + antenna * 0.2 * side)
+      c.stroke()
+    }
+    function ellipse(x, y, w, h) {
+      c.beginPath()
+      c.ellipse(x, y, w, h)
+      c.fill()
+    }
+    for (var side of [-1, 1]) {
+      var lift = side * 1.134 * legs
+      c.beginPath()
+      c.roundedRect(9 + side * 2.34 - 1.26, 1.8 + lift, 2.52, 3.24, 1.26, 1.26)
+      c.fill()
+    }
+    ellipse(0.9, 6.6096, 3.6, 3.6)
+    ellipse(13.5, 6.6096, 3.6, 3.6)
+    ellipse(2.52, 3.42, 12.96, 11.88)
+    var eyeH = 3.0888 * Math.max(0.22, 1 - blink)
+    c.globalCompositeOperation = "destination-out"
+    for (var side of [-1, 1]) {
+      ellipse(9 + side * 2.8512 - 1.4256, 10.3104 - eyeH / 2, 2.8512, eyeH)
+    }
+    c.globalCompositeOperation = "source-over"
+    if (blink < 0.3) {
+      for (var side of [-1, 1]) {
+        ellipse(9 + side * 2.8512 - 1.3686, 10.1251, 1.4826, 1.4826)
+      }
+    }
+    c.restore()
+  }
+
+  Timer {
+    interval: 5500
+    running: root.animated && root.visible
+    repeat: true
+    onTriggered: blinkMotion.restart()
+  }
+  Timer {
+    interval: root.working ? 1600 : 9700
+    running: root.animated && root.visible
+    repeat: true
+    onTriggered: wiggleMotion.restart()
+  }
+  SequentialAnimation {
+    id: blinkMotion
+    NumberAnimation { target: root; property: "blink"; to: 1; duration: 80; easing.type: Easing.InOutQuad }
+    PauseAnimation { duration: 80 }
+    NumberAnimation { target: root; property: "blink"; to: 0; duration: 120; easing.type: Easing.OutQuad }
+  }
+  SequentialAnimation {
+    id: wiggleMotion
+    ParallelAnimation {
+      NumberAnimation { target: root; property: "rotation"; to: -4; duration: 180; easing.type: Easing.InOutQuad }
+      NumberAnimation { target: root; property: "legs"; to: 0.7; duration: 140; easing.type: Easing.InOutQuad }
+      NumberAnimation { target: root; property: "antenna"; to: 1.2; duration: 180; easing.type: Easing.InOutQuad }
+    }
+    PauseAnimation { duration: 180 }
+    ParallelAnimation {
+      NumberAnimation { target: root; property: "rotation"; to: 0; duration: 240; easing.type: Easing.OutBack }
+      NumberAnimation { target: root; property: "legs"; to: 0; duration: 180; easing.type: Easing.OutQuad }
+      NumberAnimation { target: root; property: "antenna"; to: 0; duration: 240; easing.type: Easing.OutBack }
+    }
+  }
+}

--- a/apps/linux/omarchy/Panel.qml
+++ b/apps/linux/omarchy/Panel.qml
@@ -1,0 +1,384 @@
+import QtQuick
+import QtQuick.Controls as Controls
+import Quickshell
+import Quickshell.Io
+import qs.Commons
+import qs.Ui
+
+Panel {
+  id: root
+  moduleName: "openclaw.desktop"
+  ipcTarget: "openclaw.desktop"
+
+  readonly property var service: bar && bar.shell ? bar.shell.serviceFor("openclaw.desktop") : null
+  property var registeredService: null
+  property bool mounted: false
+  readonly property var agents: service ? service.snapshot.agents || [] : []
+  readonly property var sessions: service ? service.snapshot.sessions || [] : []
+  readonly property string defaultAgent: service ? service.snapshot.defaultAgent || "" : ""
+  readonly property bool selectionRequired: !service || service.snapshot.selectionRequired !== false
+  property string agentFilter: ""
+  property string stateFilter: "all"
+  property string selectedId: ""
+  readonly property string connectionError: service ? service.error : "Connecting to OpenClaw…"
+  readonly property bool connected: !!service && service.ready && service.snapshot.ok === true
+  property bool hidePreviews: false
+  readonly property bool hasMore: !!service && service.snapshot.hasMore === true
+  readonly property double checkedAt: service ? service.snapshot.checkedAt || 0 : 0
+  readonly property string routeId: service ? service.routeId : ""
+  property string acceptedRoute: ""
+  property bool routeChanged: false
+  property string sendNotice: ""
+  property bool uncertain: false
+  property string sendId: ""
+  property string activationId: ""
+  property var sendRequest: ({})
+  readonly property bool sending: sendId !== ""
+  readonly property bool yielded: !!service && service.yielded
+  readonly property var selectedSession: sessions.find(function(s) { return s.id === root.selectedId }) || null
+  readonly property string targetAgent: selectedId ? (selectedSession ? selectedSession.agentId : "") : (agentFilter || (selectionRequired ? "" : defaultAgent))
+  readonly property bool canSend: connected && !routeChanged && !sending && !uncertain && targetAgent !== "" && prompt.text.trim() !== "" && prompt.text.length <= 8000
+    && (!selectedId || selectedSession !== null)
+  readonly property int busyCount: sessions.filter(function(s) { return s.status === "running" || s.status === "queued" }).length
+  readonly property int attentionCount: sessions.filter(function(s) { return s.attention }).length
+  readonly property var agentOptions: [{value: "", label: "All agents (" + agents.length + ")"}].concat(agents.map(function(a) {
+    var count = root.sessions.filter(function(s) { return s.agentId === a.id }).length
+    return {value: a.id, label: a.name + " · " + count + " sessions"}
+  }))
+  readonly property var visibleSessions: sessions.filter(function(s) {
+    var matchesAgent = !root.agentFilter || s.agentId === root.agentFilter
+    var matchesState = root.stateFilter === "all" || (root.stateFilter === "busy" ? ["running", "queued"].indexOf(s.status) >= 0 : s.attention)
+    var query = search.text.toLowerCase()
+    return matchesAgent && matchesState && (!query || (s.title + " " + s.agentId + " " + s.model).toLowerCase().indexOf(query) >= 0)
+  })
+  readonly property string destination: selectedId
+    ? (selectedSession ? (hidePreviews ? "Selected session" : selectedSession.title) : "Selected session unavailable — select it again")
+    : "New session · " + agentName(targetAgent)
+
+  visible: !yielded
+  implicitWidth: yielded ? 0 : button.implicitWidth
+  implicitHeight: yielded ? 0 : button.implicitHeight
+
+  component Copy: Text {
+    textFormat: Text.PlainText
+    color: Color.foreground
+    font.family: Style.font.family
+    font.pixelSize: Style.font.body
+    wrapMode: Text.WordWrap
+  }
+
+  function agentName(id) {
+    var agent = agents.find(function(a) { return a.id === id })
+    return agent ? agent.name : (id || "choose an agent")
+  }
+  function age(timestamp) {
+    if (!timestamp) return ""
+    var minutes = Math.max(0, Math.floor((Date.now() - timestamp) / 60000))
+    if (minutes < 1) return "just now"
+    if (minutes < 60) return minutes + "m ago"
+    if (minutes < 1440) return Math.floor(minutes / 60) + "h ago"
+    return Math.floor(minutes / 1440) + "d ago"
+  }
+  function bindService() {
+    if (!mounted || registeredService === service) return
+    if (registeredService) registeredService.unregisterWidget(root)
+    registeredService = service
+    if (registeredService) registeredService.registerWidget(root)
+  }
+  onServiceChanged: bindService()
+  Component.onCompleted: { mounted = true; bindService() }
+  Component.onDestruction: if (registeredService) registeredService.unregisterWidget(root)
+  onRouteIdChanged: {
+    if (routeId === acceptedRoute) return
+    selectedId = ""
+    agentFilter = ""
+    // A draft belongs to the route the user saw; a new owner cannot inherit it.
+    if (prompt.text !== "" || sending) routeChanged = true
+    else { acceptedRoute = routeId; routeChanged = false }
+  }
+  onYieldedChanged: if (yielded) close()
+  function refresh() { if (service) service.refresh() }
+  function open() { if (!yielded) { refresh(); controller.show() } }
+  function activate(action) {
+    if (!service || routeChanged || activationId) return
+    activationId = service.request({op: "activate", routeId: routeId, action: action,
+      sessionKey: selectedSession ? selectedSession.key : "", agentId: targetAgent})
+  }
+  function openSelected() { if (selectedSession) activate("session") }
+  function sendPrompt() {
+    if (!canSend) return
+    sendRequest = {op: "send", routeId: routeId, agentId: targetAgent, sessionKey: selectedSession ? selectedSession.key : "", message: prompt.text}
+    sendId = service.request(sendRequest)
+    if (sendId) sendNotice = "Sending to " + destination + "…"
+  }
+  Connections {
+    target: root.service
+    function onResult(result) {
+      if (result.op === "activate") {
+        if (result.id !== root.activationId) return
+        root.activationId = ""
+        if (result.ok) root.close()
+        else root.sendNotice = result.error || "Could not open OpenClaw."
+        return
+      }
+      if (result.id !== root.sendId || result.op !== "send") return
+      root.sendId = ""
+      root.uncertain = result.uncertain === true
+      if (result.routeId === root.routeId && result.sessionKey) root.selectedId = JSON.stringify([root.sendRequest.agentId, result.sessionKey])
+      if (result.ok) {
+        root.sendNotice = "Prompt accepted. The session list will show its progress and latest reply."
+        if (prompt.text === root.sendRequest.message && result.routeId === root.routeId) prompt.text = ""
+      } else root.sendNotice = result.error || "Prompt was not accepted."
+      root.sendRequest = ({})
+      root.refresh()
+    }
+  }
+
+  BarIconButton {
+    id: button
+    anchors.fill: parent
+    bar: root.bar
+    iconComponent: Component {
+      CritterIcon {
+        foreground: root.barForeground
+        working: root.connected && root.busyCount > 0
+      }
+    }
+    tooltipText: "OpenClaw · " + (root.connected
+      ? root.agents.length + " agents · " + root.busyCount + " active · " + root.attentionCount + " need attention"
+      : root.connectionError)
+    onPressed: function(code) {
+      if (code === Qt.MiddleButton) root.refresh()
+      else root.toggle()
+    }
+    Text {
+      visible: root.connected && root.attentionCount > 0
+      anchors.right: parent.right
+      anchors.bottom: parent.bottom
+      text: root.attentionCount > 9 ? "+" : root.attentionCount
+      textFormat: Text.PlainText
+      color: root.barForeground
+      font.family: Style.font.family
+      font.pixelSize: Style.space(9)
+      font.bold: true
+    }
+  }
+
+  KeyboardPanel {
+    id: popup
+    anchorItem: button
+    owner: root
+    bar: root.bar
+    open: root.opened
+    focusTarget: content
+    contentWidth: popup.fittedContentWidth(Style.space(480))
+    contentHeight: popup.fittedContentHeight(content.implicitHeight, Style.space(760))
+
+    Flickable {
+      anchors.fill: parent
+      contentWidth: width
+      contentHeight: content.implicitHeight
+      clip: true
+      boundsBehavior: Flickable.StopAtBounds
+      Controls.ScrollBar.vertical: Controls.ScrollBar {}
+      Column {
+        id: content
+        width: parent.width
+        spacing: Style.space(10)
+        focus: true
+        Keys.onEscapePressed: root.close()
+        Keys.onPressed: function(event) {
+          if ((event.modifiers & Qt.ControlModifier) && event.key === Qt.Key_L) {
+            prompt.forceActiveFocus()
+            event.accepted = true
+          } else if ((event.modifiers & Qt.ControlModifier) && (event.key === Qt.Key_Return || event.key === Qt.Key_Enter)) {
+            root.sendPrompt()
+            event.accepted = true
+          }
+        }
+        Row {
+          width: parent.width
+          spacing: Style.space(12)
+          CritterIcon {
+            width: Style.space(25); height: width
+            foreground: Color.foreground
+            animated: false
+          }
+          Copy { text: "OpenClaw"; font.pixelSize: Style.font.title; font.bold: true }
+          Button { text: root.hidePreviews ? "Show previews" : "Hide previews"; focusable: true; onClicked: root.hidePreviews = !root.hidePreviews }
+        }
+        Copy {
+          width: parent.width
+          text: root.connected ? root.agents.length + " agents · " + root.sessions.length + " sessions · " + root.busyCount + " active · " + root.attentionCount + " attention" : root.connectionError
+        }
+        Copy {
+          visible: !root.connected && root.checkedAt > 0
+          width: parent.width
+          text: "Showing cached data from " + root.age(root.checkedAt) + ". Sending is disabled."
+          opacity: 0.65
+        }
+        Copy {
+          width: parent.width
+          text: service && service.desktop ? "Using the desktop app’s selected Gateway" : "Using the local CLI’s Gateway"
+          opacity: 0.65
+        }
+        Copy {
+          width: parent.width
+          visible: root.routeChanged
+          text: "The Gateway changed. Your draft is saved. Choose whether to use this Gateway before sending."
+        }
+        Button {
+          visible: root.routeChanged
+          text: "Use this Gateway"
+          enabled: root.routeId !== "" && !root.sending
+          focusable: true
+          onClicked: { root.acceptedRoute = root.routeId; root.routeChanged = false; root.refresh() }
+        }
+        Flow {
+          width: parent.width
+          spacing: Style.space(6)
+          Button { text: "Dashboard"; enabled: !root.routeChanged; focusable: true; onClicked: root.activate("dashboard") }
+          Button { text: "Quick Chat"; visible: !!root.service && root.service.desktop; enabled: !root.routeChanged; focusable: true; onClicked: root.activate("quickchat") }
+          Button { text: "Updates"; visible: !!root.service && root.service.desktop; enabled: !root.routeChanged; focusable: true; onClicked: root.activate("updates") }
+          Button { text: "Quit app"; visible: !!root.service && root.service.desktop; enabled: !root.routeChanged; focusable: true; onClicked: root.activate("quit") }
+          Button { text: "Diagnostics"; visible: !root.service || !root.service.desktop; enabled: !root.routeChanged; focusable: true; onClicked: root.activate("diagnostics") }
+          Button { text: service && service.refreshing ? "Refreshing…" : "Refresh"; enabled: !!service && !service.refreshing; focusable: true; onClicked: root.refresh() }
+        }
+        Dropdown {
+          id: agentPicker
+          width: parent.width
+          options: root.agentOptions
+          value: root.agentFilter
+          showLabel: false
+          enabled: !root.sending
+          onChanged: function(value) { root.agentFilter = value; root.selectedId = "" }
+        }
+        Row {
+          spacing: Style.space(6)
+          Repeater {
+            model: [{id: "all", name: "All"}, {id: "busy", name: "Active"}, {id: "attention", name: "Attention"}]
+            Button {
+              required property var modelData
+              text: modelData.name
+              selected: root.stateFilter === modelData.id
+              focusable: true
+              onClicked: root.stateFilter = modelData.id
+            }
+          }
+          Button { text: "New session"; enabled: !root.sending; focusable: true; onClicked: root.selectedId = "" }
+        }
+        TextField {
+          id: search
+          width: parent.width
+          placeholderText: "Find a session, agent, or model…"
+          maximumLength: 200
+        }
+        ListView {
+          id: sessionList
+          width: parent.width
+          height: Style.space(220)
+          clip: true
+          spacing: Style.space(6)
+          model: root.visibleSessions
+          boundsBehavior: Flickable.StopAtBounds
+          Controls.ScrollBar.vertical: Controls.ScrollBar {}
+          delegate: Rectangle {
+            id: card
+            required property var modelData
+            width: sessionList.width
+            height: summary.implicitHeight + Style.space(18)
+            color: root.selectedId === modelData.id ? Qt.rgba(Color.foreground.r, Color.foreground.g, Color.foreground.b, 0.10) : "transparent"
+            border.color: Qt.rgba(Color.foreground.r, Color.foreground.g, Color.foreground.b, root.selectedId === modelData.id ? 0.65 : 0.15)
+            radius: Style.cornerRadius
+            activeFocusOnTab: true
+            Keys.onReturnPressed: if (!root.sending) root.selectedId = modelData.id
+            Column {
+              id: summary
+              anchors.left: parent.left
+              anchors.right: parent.right
+              anchors.top: parent.top
+              anchors.margins: Style.space(9)
+              spacing: Style.space(3)
+              Copy {
+                width: parent.width
+                text: (card.modelData.unread ? "● " : "") + (root.hidePreviews ? "Session" : card.modelData.title)
+                font.bold: true
+                maximumLineCount: 1
+                elide: Text.ElideRight
+              }
+              Copy {
+                width: parent.width
+                text: root.agentName(card.modelData.agentId) + " · " + (card.modelData.waiting ? "waiting for you" : card.modelData.status) + " · " + root.age(card.modelData.updatedAt)
+                opacity: 0.7
+                maximumLineCount: 1
+                elide: Text.ElideRight
+              }
+              Copy {
+                width: parent.width
+                visible: !root.hidePreviews && text !== ""
+                text: card.modelData.activity || card.modelData.preview
+                maximumLineCount: 2
+                elide: Text.ElideRight
+                opacity: 0.8
+              }
+              Copy {
+                width: parent.width
+                visible: text !== ""
+                text: [card.modelData.model, card.modelData.channel, card.modelData.totalTokens ? Math.round(card.modelData.totalTokens / 1000) + "k tokens" : ""].filter(Boolean).join(" · ")
+                font.pixelSize: Style.font.caption
+                maximumLineCount: 1
+                elide: Text.ElideRight
+                opacity: 0.55
+              }
+            }
+            MouseArea {
+              anchors.fill: parent
+              enabled: !root.sending
+              cursorShape: Qt.PointingHandCursor
+              onClicked: { root.selectedId = card.modelData.id; card.forceActiveFocus() }
+              onDoubleClicked: { root.selectedId = card.modelData.id; root.openSelected() }
+            }
+          }
+          Copy {
+            anchors.centerIn: parent
+            width: parent.width - Style.space(16)
+            horizontalAlignment: Text.AlignHCenter
+            visible: root.visibleSessions.length === 0
+            text: root.connected ? "No matching sessions. Start one below." : "Connect OpenClaw to see your agents and sessions."
+            opacity: 0.6
+          }
+        }
+        Copy {
+          visible: root.hasMore
+          text: "Showing recent and active sessions. Open the dashboard for the full history."
+          width: parent.width
+          font.pixelSize: Style.font.caption
+          opacity: 0.6
+        }
+        Copy { text: "QUICK PROMPT"; font.pixelSize: Style.font.caption; font.bold: true }
+        Copy { width: parent.width; text: "To: " + root.destination; maximumLineCount: 2; elide: Text.ElideRight }
+        Controls.TextArea {
+          id: prompt
+          width: parent.width
+          height: Style.space(80)
+          placeholderText: "What should your agent do?"
+          color: Color.foreground
+          placeholderTextColor: Qt.darker(Color.foreground, 1.5)
+          font.family: Style.font.family
+          font.pixelSize: Style.font.body
+          wrapMode: TextEdit.Wrap
+          selectByMouse: true
+          textFormat: TextEdit.PlainText
+          background: Rectangle { color: "transparent"; border.color: Qt.rgba(Color.foreground.r, Color.foreground.g, Color.foreground.b, 0.4); radius: Style.cornerRadius }
+        }
+        Row {
+          spacing: Style.space(6)
+          Button { text: root.sending ? "Sending…" : "Send · Ctrl+Enter"; enabled: root.canSend && prompt.text.length <= 8000; focusable: true; onClicked: root.sendPrompt() }
+          Button { text: "Open session"; enabled: !!root.selectedSession && !root.routeChanged; focusable: true; onClicked: root.openSelected() }
+        }
+        Copy { width: parent.width; visible: root.sendNotice !== ""; text: root.sendNotice; opacity: 0.8 }
+        Button { visible: root.uncertain; text: "I checked the session — allow sending"; focusable: true; onClicked: { root.uncertain = false; root.sendNotice = "" } }
+      }
+    }
+  }
+}

--- a/apps/linux/omarchy/Panel.qml
+++ b/apps/linux/omarchy/Panel.qml
@@ -124,7 +124,7 @@ Panel {
       if (result.id !== root.sendId || result.op !== "send") return
       root.sendId = ""
       root.uncertain = result.uncertain === true
-      if (result.routeId === root.routeId && result.sessionKey) root.selectedId = JSON.stringify([root.sendRequest.agentId, result.sessionKey])
+      if (result.routeId === root.routeId && result.sessionId) root.selectedId = result.sessionId
       if (result.ok) {
         root.sendNotice = "Prompt accepted. The session list will show its progress and latest reply."
         if (prompt.text === root.sendRequest.message && result.routeId === root.routeId) prompt.text = ""

--- a/apps/linux/omarchy/README.md
+++ b/apps/linux/omarchy/README.md
@@ -1,0 +1,76 @@
+# OpenClaw for the Omarchy bar
+
+This optional Omarchy 4 plugin shows OpenClaw agents, recent and active sessions,
+attention indicators, and a quick prompt. Its animated mascot uses the bar’s
+foreground color, so it follows your theme without adding colors.
+
+## Install
+
+From this directory in an OpenClaw checkout:
+
+```bash
+./install.sh
+```
+
+The installer requires an existing Omarchy installation, Python 3, and the
+Python GObject bindings (`python-gobject` on Arch Linux). It validates the plugin
+against the installed Omarchy manifest schema before writing files. It copies
+this plugin to `${XDG_CONFIG_HOME:-~/.config}/omarchy/plugins/openclaw.desktop`
+and enables it through Omarchy. It installs no dependencies and does not start,
+restart, or reconfigure a Gateway. Run it again to update the installed files;
+existing placement is preserved. Before replacing plugin files or enabling the
+plugin, it backs up the affected existing files under Omarchy’s `backups`
+directory and prints the location.
+
+Other user plugins, including earlier private OpenClaw widgets, are left alone.
+If you previously installed one, disable its separate bar entry yourself to
+avoid showing both widgets.
+
+To disable this plugin:
+
+```bash
+omarchy plugin disable openclaw.desktop
+```
+
+## Use
+
+Click the mascot to see agents and sessions. Filter by agent, active work, or
+attention; search by session title, agent, or model. Select a session to continue
+it, or choose **New session**. When your Gateway requires agent selection, pick
+an agent before sending. **Hide previews** conceals session titles and messages.
+
+Use **Ctrl+L** to focus the prompt and **Ctrl+Enter** to send. **Open session**
+opens the selected conversation. A prompt is cleared only after confirmed
+acceptance. If acceptance is unknown, inspect the destination before explicitly
+allowing another send; the widget never retries prompts automatically.
+
+With a matching Linux desktop app running, the widget uses that app’s selected
+Gateway and exposes **Quick Chat**, **Dashboard**, **Updates**, and **Quit app**.
+The desktop app and widget coordinate their icons so there is one entry point.
+An older desktop app retains its tray icon and the widget hides until it exits.
+Without the app, the widget uses the installed OpenClaw CLI and its Gateway.
+
+When the Gateway route changes, the widget clears the old session selection,
+keeps your draft, and asks you to choose **Use this Gateway** before sending if
+a draft or pending prompt belongs to the previous route. With no draft or pending
+prompt, it switches automatically.
+Prompts remain bound to the route shown when they were submitted.
+
+## Connection and lifecycle
+
+`Service.qml` owns one Python worker shared across monitors. Bar instances
+register with that service through Omarchy’s `bar.shell.serviceFor` API. The
+worker remains alive while any instance is registered, including while yielding
+to an older desktop app. Removing the final instance closes its input so the
+worker can release its desktop claim and exit.
+
+The worker exchanges JSON lines over standard input and output. It uses public
+Gateway methods for agents, session projections, and prompt acceptance; the QML
+layer does not read Gateway credentials or session storage. Refreshes run every
+10 seconds while a popup is open and every minute otherwise. Desktop presence
+and claim renewal are handled independently by the worker.
+
+Disconnected data is marked as cached and sending is disabled. Use **Refresh**
+to check again, the desktop app’s connection status when using the app, or
+**Diagnostics** when using the standalone CLI. Agent and session counts describe
+the bounded recent/active projection; open the dashboard for full history.

--- a/apps/linux/omarchy/Service.qml
+++ b/apps/linux/omarchy/Service.qml
@@ -1,0 +1,126 @@
+import QtQuick
+import Quickshell.Io
+
+Item {
+  id: root
+  property var shell: null
+  property var widgets: []
+  property var snapshot: ({})
+  property string routeId: ""
+  property bool ready: false
+  property bool desktop: false
+  property bool yielded: false
+  property string error: "Connecting to OpenClaw…"
+  property var pending: ({})
+  property int serial: 0
+  property string refreshId: ""
+  property bool stopping: false
+  readonly property bool refreshing: refreshId !== ""
+  readonly property string bridgePath: Qt.resolvedUrl("bridge.py").toString().replace(/^file:\/\//, "")
+  signal result(var response)
+
+  // One service spans every monitor. Yielding an icon keeps its registration so
+  // the worker can notice the legacy app exit and restore the widget.
+  function registerWidget(widget) {
+    if (widgets.indexOf(widget) >= 0) return
+    widgets = widgets.concat([widget])
+    startWorker()
+  }
+  function unregisterWidget(widget) {
+    widgets = widgets.filter(function(item) { return item !== widget })
+    if (widgets.length === 0 && worker.running) {
+      stopping = true
+      worker.stdinEnabled = false
+    }
+  }
+  function startWorker() {
+    if (!widgets.length || worker.running || stopping) return
+    worker.stdinEnabled = true
+    worker.running = true
+  }
+  function request(message) {
+    if (!worker.running || stopping) {
+      error = "OpenClaw bridge is reconnecting. Try again when connected."
+      return ""
+    }
+    var id = String(++serial)
+    var request = Object.assign({}, message, {id: id})
+    var next = Object.assign({}, pending)
+    next[id] = {op: request.op, routeId: request.routeId}
+    pending = next
+    worker.write(JSON.stringify(request) + "\n")
+    return id
+  }
+  function refresh() {
+    if (!refreshId && routeId && !yielded) refreshId = request({op: "snapshot", routeId: routeId})
+  }
+  function receive(response) {
+    if (response.op === "state") {
+      var changed = routeId !== response.routeId
+      if (changed) snapshot = ({})
+      routeId = response.routeId || ""
+      ready = response.ready === true
+      desktop = response.desktop === true
+      yielded = response.yield === true
+      error = response.error || (ready ? "" : "Connecting to OpenClaw…")
+      if (ready && (changed || !snapshot.ok)) refresh()
+      return
+    }
+    var request = pending[response.id]
+    if (!request) return
+    var next = Object.assign({}, pending)
+    delete next[response.id]
+    pending = next
+    if (response.id === refreshId) refreshId = ""
+    if (response.op === "snapshot") {
+      if (response.routeId !== routeId) { refresh(); return }
+      if (response.ok) {
+        snapshot = response
+        error = ""
+      } else {
+        snapshot = Object.assign({}, snapshot, {ok: false})
+        error = response.error || "Gateway unavailable. Open diagnostics."
+      }
+    }
+    result(response)
+  }
+  Timer {
+    interval: root.widgets.some(function(widget) { return widget.opened }) ? 10000 : 60000
+    running: root.widgets.length > 0
+    repeat: true
+    onTriggered: root.refresh()
+  }
+  Timer {
+    id: reconnect
+    interval: 3000
+    onTriggered: root.startWorker()
+  }
+  Process {
+    id: worker
+    command: ["python3", "-u", root.bridgePath, "--serve"]
+    stdinEnabled: true
+    stdout: SplitParser {
+      onRead: function(line) {
+        try { root.receive(JSON.parse(line)) }
+        catch (e) { root.error = "Could not read OpenClaw bridge data. Open diagnostics." }
+      }
+    }
+    onExited: function(code) {
+      root.ready = false
+      root.stopping = false
+      root.error = "OpenClaw bridge disconnected. Reconnecting…"
+      var pending = root.pending
+      root.pending = ({})
+      root.refreshId = ""
+      // A terminated worker might have already sent the prompt. Never replay it.
+      Object.keys(pending).forEach(function(id) {
+        root.result({id: id, op: pending[id].op, routeId: pending[id].routeId,
+          ok: false, uncertain: pending[id].op === "send",
+          error: pending[id].op === "send"
+            ? "Acceptance unknown. Check the session before sending again."
+            : "OpenClaw bridge disconnected. Try again when connected."})
+      })
+      if (root.widgets.length) reconnect.restart()
+    }
+  }
+}

--- a/apps/linux/omarchy/bridge.py
+++ b/apps/linux/omarchy/bridge.py
@@ -57,6 +57,10 @@ def text(value, limit=240):
     return value[:limit] if isinstance(value, str) else ""
 
 
+def session_id(agent_id, key):
+    return json.dumps([agent_id, key], separators=(",", ":"))
+
+
 def session(row):
     if not isinstance(row, dict) or not isinstance(row.get("key"), str):
         return None
@@ -76,7 +80,7 @@ def session(row):
                  or (isinstance(digest, dict) and digest.get("health") in ("waiting-on-user", "stuck", "failed"))
                  or (isinstance(agent_status, dict) and bool(agent_status.get("attention"))))
     return {
-        "id": json.dumps([agent_id, row["key"]], separators=(",", ":")),
+        "id": session_id(agent_id, row["key"]),
         "key": row["key"], "agentId": agent_id,
         "title": text(row.get("label") or row.get("displayName") or row.get("derivedTitle") or row["key"]),
         "preview": text(row.get("lastMessagePreview"), 360),
@@ -322,6 +326,8 @@ class Worker:
                 self.target(request)
             elif operation == "send":
                 result = send(request, lambda method, params: self.dispatch(state, method, params))
+                if result.get("sessionKey"):
+                    result["sessionId"] = session_id(request["agentId"], result["sessionKey"])
             elif operation == "activate":
                 result = self.activate(state, request)
             else:

--- a/apps/linux/omarchy/bridge.py
+++ b/apps/linux/omarchy/bridge.py
@@ -1,0 +1,367 @@
+#!/usr/bin/env python3
+"""Omarchy presentation adapter for OpenClaw's public Gateway CLI."""
+import hashlib
+import json
+import os
+import queue
+from pathlib import Path
+import threading
+import shutil
+import subprocess
+import sys
+import time
+import uuid
+
+
+class GatewayError(Exception):
+    pass
+
+
+def cli_path():
+    override = os.environ.get("OPENCLAW_DESKTOP_CLI")
+    if override:
+        return override
+    managed = Path.home() / ".openclaw/bin/openclaw"
+    return str(managed) if managed.is_file() else shutil.which("openclaw")
+
+
+def cli_json(cli, arguments):
+    if not cli:
+        raise GatewayError("OpenClaw is not on PATH. Install it from Omarchy Menu → Install → AI → OpenClaw.")
+    try:
+        result = subprocess.run(
+            [cli, *arguments],
+            capture_output=True, text=True, timeout=25, check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired) as error:
+        raise GatewayError("Gateway did not respond. Open diagnostics to check the connection.") from error
+    if result.returncode:
+        # CLI stderr may include connection details; keep it in the diagnostics terminal.
+        raise GatewayError("Gateway request failed. Update the CLI and check its connection in diagnostics.")
+    try:
+        value = json.loads(result.stdout)
+        if not isinstance(value, dict):
+            raise ValueError("Expected object")
+        return value
+    except (ValueError, TypeError) as error:
+        raise GatewayError("Unrecognized Gateway response. Check the installed OpenClaw version.") from error
+
+
+
+def rpc(method, params, cli, expected_url):
+    return cli_json(cli, ["gateway", "call", method, "--json", "--timeout", "15000",
+                          "--expect-url", expected_url, "--params", json.dumps(params)])
+
+
+def text(value, limit=240):
+    return value[:limit] if isinstance(value, str) else ""
+
+
+def session(row):
+    if not isinstance(row, dict) or not isinstance(row.get("key"), str):
+        return None
+    status = row.get("status", "idle")
+    if row.get("hasActiveRun") is True:
+        status = "running"
+    if status not in ("queued", "running", "done", "failed", "killed", "timeout"):
+        status = "idle"
+    agent_id = text(row.get("agentId"), 128)
+    # Older supported rows encode the owner in the canonical agent session key.
+    if not agent_id and row["key"].startswith("agent:"):
+        agent_id = row["key"].split(":", 2)[1]
+    digest = row.get("observerDigest") or {}
+    agent_status = row.get("agentStatus") or {}
+    waiting = isinstance(digest, dict) and digest.get("health") == "waiting-on-user"
+    attention = (row.get("unread") is True or status in ("failed", "timeout")
+                 or (isinstance(digest, dict) and digest.get("health") in ("waiting-on-user", "stuck", "failed"))
+                 or (isinstance(agent_status, dict) and bool(agent_status.get("attention"))))
+    return {
+        "id": json.dumps([agent_id, row["key"]], separators=(",", ":")),
+        "key": row["key"], "agentId": agent_id,
+        "title": text(row.get("label") or row.get("displayName") or row.get("derivedTitle") or row["key"]),
+        "preview": text(row.get("lastMessagePreview"), 360),
+        "activity": text(digest.get("headline")) if isinstance(digest, dict) else "",
+        "status": status, "unread": row.get("unread") is True,
+        "attention": attention, "waiting": waiting,
+        "model": text(row.get("model"), 120),
+        "channel": text(row.get("channel"), 80),
+        "updatedAt": row.get("updatedAt") if isinstance(row.get("updatedAt"), (float, int)) else 0,
+        "totalTokens": row.get("totalTokens") if isinstance(row.get("totalTokens"), (float, int)) else 0,
+    }
+
+
+def snapshot_data(cli, expected_url):
+    params = {"limit": 40, "includeDerivedTitles": True, "includeLastMessage": True, "includeGlobal": True}
+    roster = rpc("agents.list", {}, cli, expected_url)
+    recent = rpc("sessions.list", params, cli, expected_url)
+    active = rpc("sessions.list", {**params, "activeOnly": True}, cli, expected_url)
+    return project(roster, recent, active)
+
+
+def project(roster, recent, active):
+    agents = []
+    for row in roster.get("agents", [])[:100]:
+        if not isinstance(row, dict) or not row.get("id"):
+            continue
+        identity = row.get("identity") or {}
+        model = row.get("model") or {}
+        agents.append({
+            "id": text(row["id"], 128),
+            "name": text(row.get("name") or identity.get("name") or row["id"], 100),
+            "model": text(model.get("primary"), 120) if isinstance(model, dict) else text(model, 120),
+        })
+    rows = {}
+    for row in recent.get("sessions", []) + active.get("sessions", []):
+        item = session(row)
+        if item:
+            rows[item["id"]] = item
+    sessions = sorted(rows.values(), key=lambda s: (
+        not s["attention"],
+        s["status"] not in ("running", "queued"), -s["updatedAt"],
+    ))
+    return {"ok": True, "agents": agents, "sessions": sessions,
+            "defaultAgent": text(roster.get("defaultId"), 128),
+            "selectionRequired": roster.get("selectionRequired") is True,
+            "hasMore": bool(recent.get("hasMore") or active.get("hasMore")),
+            "checkedAt": int(time.time() * 1000)}
+
+
+def send(request, dispatch):
+    agent_id = request.get("agentId")
+    message = request.get("message")
+    key = request.get("sessionKey", "")
+    if not isinstance(agent_id, str) or not agent_id or not isinstance(key, str):
+        return {"ok": False, "uncertain": False, "error": "Select an agent and a destination first."}
+    if not isinstance(message, str) or not message.strip() or len(message) > 8000:
+        return {"ok": False, "uncertain": False, "error": "Enter a prompt of 1–8,000 characters."}
+    request_id = str(uuid.uuid4())
+    try:
+        if key:
+            reply = dispatch("chat.send", {"agentId": agent_id, "sessionKey": key,
+                        "message": message, "deliver": False, "idempotencyKey": request_id})
+        else:
+            reply = dispatch("sessions.create", {"agentId": agent_id, "message": message,
+                        "idempotencyKey": request_id})
+            key = text(reply.get("key"), 2048)
+            if reply.get("runError") or reply.get("runStarted") is not True:
+                return {"ok": False, "uncertain": True, "sessionKey": key,
+                        "requestId": request_id,
+                        "error": "Session created, but prompt acceptance was not confirmed. Open the session before sending again."}
+        if not reply.get("runId") or reply.get("status") not in ("started", "accepted", "queued", "ok"):
+            return {"ok": False, "uncertain": True, "sessionKey": key,
+                    "requestId": request_id, "error": "Acceptance was not confirmed. Check the session before sending again."}
+        return {"ok": True, "sessionKey": key, "runId": reply["runId"], "requestId": request_id}
+    except (GatewayError, ValueError, TypeError, KeyError, AttributeError) as error:
+        # A timeout can follow an accepted write. Never retry or switch targets.
+        return {"ok": False, "uncertain": True, "sessionKey": key, "requestId": request_id,
+                "error": (str(error) if isinstance(error, GatewayError) else "The response was not recognized.") + " Acceptance is unknown; check the session before sending again."}
+
+
+
+class Desktop:
+    """Use the app's live bus owner and route, never copy its credentials."""
+
+    def __init__(self):
+        from gi.repository import Gio, GLib
+        self.Gio, self.GLib = Gio, GLib
+        try:
+            self.bus = Gio.bus_get_sync(Gio.BusType.SESSION, None)
+        except GLib.Error as error:
+            raise GatewayError("Session bus unavailable. Check the desktop session.") from error
+
+    def owner(self, name):
+        try:
+            result = self.bus.call_sync(
+                "org.freedesktop.DBus", "/org/freedesktop/DBus", "org.freedesktop.DBus",
+                "GetNameOwner", self.GLib.Variant("(s)", (name,)), None,
+                self.Gio.DBusCallFlags.NONE, 2000, None)
+            return result.unpack()[0]
+        except self.GLib.Error as error:
+            if self.Gio.DBusError.get_remote_error(error) == "org.freedesktop.DBus.Error.NameHasNoOwner":
+                return ""
+            raise GatewayError("Session bus unavailable. Check the desktop app.") from error
+
+    def call(self, owner, method, signature="()", args=()):
+        try:
+            reply = self.bus.call_sync(
+                owner, "/ai/openclaw/Desktop", "ai.openclaw.Desktop1", method,
+                self.GLib.Variant(signature, args), None,
+                self.Gio.DBusCallFlags.NONE, 65000, None).unpack()
+            return json.loads(reply[0]) if reply else None
+        except self.GLib.Error as error:
+            # Remote errors can contain Gateway URLs or provider diagnostics.
+            raise GatewayError("Desktop request failed. Open the app to check its connection.") from error
+
+
+class Worker:
+    def __init__(self):
+        self.desktop = Desktop()
+        self.state = {}
+        self.state_lock = threading.Lock()
+        self.output_lock = threading.Lock()
+        self.stopped = threading.Event()
+        self.cli_state = None
+        self.cli_lock = threading.Lock()
+
+    def emit(self, value):
+        with self.output_lock:
+            print(json.dumps(value), flush=True)
+
+    def probe(self, refresh_cli=False):
+        owner = self.desktop.owner("ai.openclaw.Desktop")
+        if owner:
+            state = self.desktop.call(owner, "GetState")
+            if state.get("version") != 1:
+                raise GatewayError("Update the Omarchy plugin to match the desktop app.")
+            return {"routeId": owner + "/" + state["routeId"], "desktop": True,
+                    "ready": state["ready"], "yield": False, "owner": owner,
+                    "nativeRoute": state["routeId"]}
+        legacy = self.desktop.owner("ai.openclaw.linux.SingleInstance")
+        if legacy:
+            return {"routeId": legacy, "desktop": True, "ready": False, "yield": True,
+                    "error": "This desktop app uses its own tray. Update it to enable the Omarchy panel."}
+        cli = cli_path()
+        with self.cli_lock:
+            if refresh_cli or self.cli_state is None or self.cli_state.get("cli") != cli:
+                state = {"desktop": False, "yield": False, "cli": cli, "ready": False,
+                         "routeId": "cli:unavailable:" + hashlib.sha256((cli or "").encode()).hexdigest(),
+                         "error": "Install OpenClaw from Omarchy Menu → Install → AI → OpenClaw."}
+                if cli:
+                    try:
+                        status = cli_json(cli, ["status", "--json", "--timeout", "1000"])
+                        url = status.get("gateway", {}).get("url")
+                        if not isinstance(url, str) or not url.startswith(("ws://", "wss://")):
+                            raise GatewayError("Could not identify the CLI Gateway. Update OpenClaw and open diagnostics.")
+                        route = hashlib.sha256(json.dumps([cli, url]).encode()).hexdigest()
+                        state.update(routeId="cli:" + route, cliUrl=url, ready=True, error="")
+                    except (GatewayError, AttributeError, TypeError) as error:
+                        state["error"] = str(error) if isinstance(error, GatewayError) else "Could not identify the CLI Gateway. Open diagnostics."
+                self.cli_state = state
+            return dict(self.cli_state)
+
+    def heartbeat(self):
+        while not self.stopped.is_set():
+            try:
+                state = self.probe()
+                if state.get("owner"):
+                    self.desktop.call(state["owner"], "ClaimPresenter", "(s)", (state["nativeRoute"],))
+            except (GatewayError, ValueError, KeyError, TypeError) as error:
+                state = {"routeId": "", "desktop": True, "ready": False, "yield": True,
+                         "error": str(error) if isinstance(error, GatewayError) else "Desktop response was not recognized."}
+            with self.state_lock:
+                changed = state != self.state
+                self.state = state
+            if changed:
+                self.emit({"op": "state", **self.public_state(state)})
+            self.stopped.wait(3)
+
+    @staticmethod
+    def public_state(state):
+        return {key: value for key, value in state.items() if key not in ("owner", "nativeRoute", "cli", "cliUrl")}
+
+    def target(self, request, refresh_cli=False):
+        state = self.probe(refresh_cli=refresh_cli)
+        if not request.get("routeId") or request["routeId"] != state["routeId"] or state["yield"]:
+            raise GatewayError("Gateway changed. Review the destination before trying again.")
+        return state
+
+    def dispatch(self, state, method, params):
+        # Fence once more immediately before writes; never retry over another transport.
+        current = self.probe()
+        if current["routeId"] != state["routeId"] or current["yield"]:
+            raise GatewayError("Gateway changed. Check the session before sending again.")
+        if state.get("owner"):
+            return self.desktop.call(state["owner"], "SendPrompt", "(sssss)", (
+                state["nativeRoute"], params["agentId"], params.get("sessionKey", ""),
+                params["message"], params["idempotencyKey"]))
+        if method == "chat.send" and params.get("sessionKey") != "global":
+            params = {key: value for key, value in params.items() if key != "agentId"}
+        return rpc(method, params, state["cli"], state["cliUrl"])
+
+    def activate(self, state, request):
+        action = request.get("action")
+        key = request.get("sessionKey", "")
+        if state.get("owner"):
+            if action == "diagnostics":
+                raise GatewayError("Open the desktop app to inspect its selected Gateway connection.")
+            self.desktop.call(state["owner"], "Activate", "(ssss)",
+                              (state["nativeRoute"], action, key, request.get("agentId", "")))
+        else:
+            cli = cli_path()
+            if not cli:
+                raise GatewayError("Install OpenClaw first.")
+            if action == "dashboard":
+                command = ["omarchy-launch-terminal", cli, "dashboard"]
+            elif action == "session" and isinstance(key, str) and key:
+                agent_id = request.get("agentId", "")
+                if key == "global":
+                    if not isinstance(agent_id, str) or not agent_id or ":" in agent_id:
+                        raise GatewayError("Select the session’s agent first.")
+                    key = "agent:" + agent_id + ":global"
+                command = ["omarchy-launch-terminal", cli, "tui", "--session", key]
+            elif action == "diagnostics":
+                command = ["omarchy-launch-terminal", cli, "gateway", "status"]
+            else:
+                raise GatewayError("This action needs the OpenClaw desktop app.")
+            subprocess.Popen(command, stdin=subprocess.DEVNULL, stdout=subprocess.DEVNULL,
+                             stderr=subprocess.DEVNULL, start_new_session=True)
+        return {"ok": True}
+
+    def handle(self, request):
+        operation = request.get("op")
+        try:
+            state = self.target(request, refresh_cli=True)
+            if not state["desktop"] and not state["ready"] and operation != "activate":
+                raise GatewayError(state["error"])
+            if operation == "snapshot":
+                if state.get("owner"):
+                    raw = self.desktop.call(state["owner"], "Snapshot", "(s)", (state["nativeRoute"],))
+                    result = project(raw["agents"], raw["recent"], raw["active"])
+                else:
+                    result = snapshot_data(state["cli"], state["cliUrl"])
+                self.target(request)
+            elif operation == "send":
+                result = send(request, lambda method, params: self.dispatch(state, method, params))
+            elif operation == "activate":
+                result = self.activate(state, request)
+            else:
+                raise GatewayError("Unknown widget action.")
+        except (GatewayError, ValueError, TypeError, KeyError, AttributeError, OSError) as error:
+            result = {"ok": False, "uncertain": False,
+                      "error": str(error) if isinstance(error, GatewayError) else "Could not read OpenClaw data. Open the app to check its connection."}
+        self.emit({**result, "id": request.get("id"), "op": operation, "routeId": request.get("routeId", "")})
+
+    def serve(self):
+        requests = queue.Queue()
+
+        def consume():
+            while not self.stopped.is_set():
+                request = requests.get()
+                self.handle(request)
+
+        threading.Thread(target=self.heartbeat, daemon=True).start()
+        threading.Thread(target=consume, daemon=True).start()
+        try:
+            for line in sys.stdin:
+                try:
+                    request = json.loads(line)
+                    if not isinstance(request, dict):
+                        raise ValueError("Expected object")
+                    requests.put(request)
+                except ValueError:
+                    self.emit({"ok": False, "error": "Invalid widget request."})
+        finally:
+            self.stopped.set()
+
+
+def main():
+    try:
+        Worker().serve()
+    except (ImportError, GatewayError) as error:
+        print(json.dumps({"op": "state", "ready": False, "yield": False, "routeId": "",
+                          "error": "The widget needs Python 3, PyGObject, and a working desktop session bus."}), flush=True)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/linux/omarchy/fixture_bridge.py
+++ b/apps/linux/omarchy/fixture_bridge.py
@@ -1,0 +1,160 @@
+"""Synthetic CLI and desktop peers for the real widget worker protocol tests."""
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import threading
+import time
+
+
+def record(transport, method, params):
+    with open(Path(os.environ['FIXTURE_DIR']) / (transport + '.jsonl'), 'a') as stream:
+        stream.write(json.dumps({'method': method, 'params': params}) + '\n')
+
+
+def response(method, params):
+    if method == 'agents.list':
+        return {'defaultId': 'research', 'selectionRequired': True, 'agents': [
+            {'id': 'research', 'name': 'Research', 'model': {'primary': 'example/model'}},
+            {'id': 'builder', 'name': 'Builder'}]}
+    if method == 'sessions.list':
+        now = int(time.time() * 1000)
+        rows = [
+            {'key': 'agent:research:report', 'agentId': 'research', 'label': 'Release research',
+             'hasActiveRun': True, 'updatedAt': now - 60000,
+             'observerDigest': {'health': 'on-track', 'headline': 'Comparing release notes'},
+             'lastMessagePreview': 'Summarize changes.', 'model': 'example/model', 'totalTokens': 12500},
+            {'key': 'agent:builder:review', 'agentId': 'builder', 'label': 'Review the widget',
+             'status': 'done', 'unread': False, 'updatedAt': now - 180000,
+             'observerDigest': {'health': 'waiting-on-user', 'headline': 'Choose a layout'}},
+            {'key': 'agent:research:notes', 'agentId': 'research', 'status': 'done',
+             'unread': True, 'updatedAt': now - 3600000},
+            {'key': 'agent:builder:choice', 'agentId': 'builder', 'status': 'done',
+             'agentStatus': {'attention': 'needs-user'}, 'updatedAt': now - 4000000}]
+        if params.get('activeOnly'):
+            rows = rows[:1]
+        if params.get('includeGlobal'):
+            rows.extend([
+                {'key': 'global', 'agentId': 'research', 'label': 'Research global',
+                 'hasActiveRun': True, 'updatedAt': now, 'totalTokens': 700},
+                {'key': 'global', 'agentId': 'builder', 'label': 'Builder global',
+                 'hasActiveRun': True, 'updatedAt': now, 'totalTokens': 1300}])
+        return {'sessions': rows,
+                'hasMore': False, 'path': 'private state path not for presentation'}
+    if method == 'chat.send':
+        return {'status': 'started', 'runId': 'run-fixture'}
+    if method == 'sessions.create':
+        return {'key': 'agent:' + params['agentId'] + ':new-fixture',
+                'runStarted': True, 'status': 'started', 'runId': 'run-fixture'}
+    raise ValueError(method)
+
+
+def cli():
+    args = sys.argv[2:]
+    config = Path(os.environ['FIXTURE_DIR']) / 'desktop.json'
+    state = json.loads(config.read_text())
+    url = state['cliUrl']
+    if args[0] == 'status':
+        record('status', 'status', args[1:])
+        if state.get('changeAfterStatus'):
+            state['cliUrl'] = state.pop('changeAfterStatus')
+            temporary = config.with_suffix('.status.tmp')
+            temporary.write_text(json.dumps(state))
+            temporary.replace(config)
+        print(json.dumps({'gateway': {'url': url}}))
+        return
+    method = args[2]
+    expected = args[args.index('--expect-url') + 1] if '--expect-url' in args else None
+    if expected != url:
+        record('guard', method, {'expected': expected, 'actual': url})
+        print('Gateway destination changed', file=sys.stderr)
+        sys.exit(1)
+    params = json.loads(args[args.index('--params') + 1])
+    record('cli', method, params)
+    if os.environ.get('FIXTURE_SLOW') and method == 'agents.list':
+        (Path(os.environ['FIXTURE_DIR']) / 'snapshot-entered').touch()
+        time.sleep(5)
+    if os.environ.get('FIXTURE_FAIL') and method in ('chat.send', 'sessions.create'):
+        print('private connection detail must not reach UI', file=sys.stderr)
+        sys.exit(1)
+    print(json.dumps(response(method, params)))
+
+
+XML = '''<node><interface name="ai.openclaw.Desktop1">
+<method name="GetState"><arg type="s" direction="out"/></method>
+<method name="ClaimPresenter"><arg type="s" direction="in"/></method>
+<method name="Snapshot"><arg type="s" direction="in"/><arg type="s" direction="out"/></method>
+<method name="SendPrompt">
+<arg type="s" direction="in"/><arg type="s" direction="in"/><arg type="s" direction="in"/>
+<arg type="s" direction="in"/><arg type="s" direction="in"/><arg type="s" direction="out"/>
+</method>
+<method name="Activate"><arg type="s" direction="in"/><arg type="s" direction="in"/>
+<arg type="s" direction="in"/><arg type="s" direction="in"/></method>
+</interface></node>'''
+
+
+def desktop(mode):
+    from gi.repository import Gio, GLib
+    bus = Gio.bus_get_sync(Gio.BusType.SESSION, None)
+    config = Path(os.environ['FIXTURE_DIR']) / 'desktop.json'
+
+    def handle(connection, sender, path, interface, method, arguments, invocation):
+        args = arguments.unpack()
+        record('desktop', method, args)
+        state = json.loads(config.read_text())
+        if method == 'GetState':
+            result = {'version': 1, 'routeId': state['route'], 'ready': state['ready']}
+        elif args[0] != state['route']:
+            invocation.return_dbus_error('org.freedesktop.DBus.Error.Failed', 'Gateway changed')
+            return
+        elif method in ('ClaimPresenter', 'Activate'):
+            invocation.return_value(GLib.Variant('()', ()))
+            return
+        elif not state['ready'] or (state.get('fail') and method == 'SendPrompt'):
+            invocation.return_dbus_error('org.freedesktop.DBus.Error.Failed',
+                                         'private connection detail must not reach UI')
+            return
+        elif method == 'Snapshot':
+            result = {'agents': response('agents.list', {}),
+                      'recent': response('sessions.list', {'includeGlobal': True}),
+                      'active': response('sessions.list', {'activeOnly': True, 'includeGlobal': True})}
+        elif method == 'SendPrompt':
+            params = {'agentId': args[1], 'sessionKey': args[2],
+                      'message': args[3], 'idempotencyKey': args[4]}
+            result = response('chat.send' if args[2] else 'sessions.create', params)
+        else:
+            raise ValueError(method)
+        invocation.return_value(GLib.Variant('(s)', (json.dumps(result),)))
+
+    if mode != 'legacy':
+        interface = Gio.DBusNodeInfo.new_for_xml(XML).interfaces[0]
+        bus.register_object('/ai/openclaw/Desktop', interface, handle, None, None)
+    name = 'ai.openclaw.linux.SingleInstance' if mode == 'legacy' else 'ai.openclaw.Desktop'
+    bus.call_sync('org.freedesktop.DBus', '/org/freedesktop/DBus', 'org.freedesktop.DBus',
+                  'RequestName', GLib.Variant('(su)', (name, 0)), None,
+                  Gio.DBusCallFlags.NONE, 2000, None)
+    loop = GLib.MainLoop()
+    threading.Thread(target=loop.run, daemon=True).start()
+    return bus, loop
+
+
+def launch():
+    # This process and the worker inherit only the private dbus-run-session bus.
+    # Keeping the fixture alive retains its bus name until the worker exits.
+    peer = desktop(sys.argv[2]) if sys.argv[2] != 'cli' else None
+    worker = subprocess.Popen([sys.executable, str(Path(__file__).with_name('bridge.py'))])
+    try:
+        sys.exit(worker.wait())
+    finally:
+        if peer:
+            peer[1].quit()
+
+
+if __name__ == '__main__':
+    if sys.argv[1] == 'cli':
+        cli()
+    elif sys.argv[1] == 'terminal':
+        record('terminal', 'launch', sys.argv[2:])
+    else:
+        launch()

--- a/apps/linux/omarchy/fixture_bridge.py
+++ b/apps/linux/omarchy/fixture_bridge.py
@@ -25,7 +25,7 @@ def response(method, params):
              'hasActiveRun': True, 'updatedAt': now - 60000,
              'observerDigest': {'health': 'on-track', 'headline': 'Comparing release notes'},
              'lastMessagePreview': 'Summarize changes.', 'model': 'example/model', 'totalTokens': 12500},
-            {'key': 'agent:builder:review', 'agentId': 'builder', 'label': 'Review the widget',
+            {'key': os.environ.get('FIXTURE_SESSION_KEY', 'agent:builder:review'), 'agentId': 'builder', 'label': 'Review the widget',
              'status': 'done', 'unread': False, 'updatedAt': now - 180000,
              'observerDigest': {'health': 'waiting-on-user', 'headline': 'Choose a layout'}},
             {'key': 'agent:research:notes', 'agentId': 'research', 'status': 'done',

--- a/apps/linux/omarchy/install.sh
+++ b/apps/linux/omarchy/install.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+plugin_id=openclaw.desktop
+source_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+config_dir=${XDG_CONFIG_HOME:-"$HOME/.config"}/omarchy
+plugin_dir=$config_dir/plugins/$plugin_id
+
+for command in python3 omarchy omarchy-shell; do
+  command -v "$command" >/dev/null || { echo "Missing $command. Install Omarchy 4 and Python 3 first." >&2; exit 1; }
+done
+python3 -c 'from gi.repository import Gio, GLib' 2>/dev/null || {
+  echo "Missing Python GObject bindings. Install python-gobject, then run this installer again." >&2
+  exit 1
+}
+omarchy plugin validate "$source_dir"
+
+# Backups cover only this install's destination and the shell layout it enables.
+# Keep other user plugins and their placements under their existing ownership.
+backup_dir=""
+backup() {
+  if [[ -z $backup_dir ]]; then
+    mkdir -p "$config_dir/backups"
+    backup_dir=$(mktemp -d "$config_dir/backups/openclaw-desktop.XXXXXXXX")
+  fi
+  cp -a -- "$1" "$backup_dir/$2"
+}
+files=(manifest.json Panel.qml Service.qml CritterIcon.qml bridge.py README.md)
+for file in "${files[@]}"; do
+  [[ -f $source_dir/$file ]] || { echo "Missing plugin source: $source_dir/$file" >&2; exit 1; }
+done
+changed=false
+for file in "${files[@]}"; do
+  if ! cmp -s "$source_dir/$file" "$plugin_dir/$file"; then changed=true; break; fi
+done
+if $changed; then
+  [[ ! -d $plugin_dir ]] || backup "$plugin_dir" plugin
+  mkdir -p "$plugin_dir"
+  for file in "${files[@]}"; do
+    install -m 644 "$source_dir/$file" "$plugin_dir/$file"
+  done
+fi
+[[ ! -f $config_dir/shell.json ]] || backup "$config_dir/shell.json" shell.json
+omarchy-shell shell rescanPlugins >/dev/null
+omarchy plugin enable "$plugin_id"
+echo "Enabled OpenClaw. Open its monochrome icon in the Omarchy bar."
+[[ -z $backup_dir ]] || echo "Previous files: $backup_dir"

--- a/apps/linux/omarchy/manifest.json
+++ b/apps/linux/omarchy/manifest.json
@@ -1,0 +1,22 @@
+{
+  "schemaVersion": 1,
+  "id": "openclaw.desktop",
+  "name": "OpenClaw",
+  "version": "1.0.0",
+  "author": "OpenClaw",
+  "description": "OpenClaw agents, sessions, activity, attention indicators, and quick prompts",
+  "kinds": [
+    "service",
+    "bar-widget"
+  ],
+  "entryPoints": {
+    "service": "Service.qml",
+    "barWidget": "Panel.qml"
+  },
+  "barWidget": {
+    "displayName": "OpenClaw",
+    "category": "AI",
+    "allowMultiple": false,
+    "defaultSection": "right"
+  }
+}

--- a/apps/linux/omarchy/test_bridge.py
+++ b/apps/linux/omarchy/test_bridge.py
@@ -1,0 +1,296 @@
+"""Exercise widget stdin/stdout against isolated CLI and real D-Bus peers."""
+import json
+import os
+from pathlib import Path
+import queue
+import signal
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+import unittest
+
+FIXTURE = Path(__file__).with_name('fixture_bridge.py').resolve()
+
+
+class BridgeContract(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory(prefix='openclaw-omarchy-test-')
+        self.addCleanup(self.temp.cleanup)
+        self.folder = Path(self.temp.name)
+        self.config = self.folder / 'desktop.json'
+        self.configure_desktop()
+        cli = self.folder / 'openclaw'
+        for name, mode in (('openclaw', 'cli'), ('omarchy-launch-terminal', 'terminal')):
+            executable = self.folder / name
+            executable.write_text('#!' + sys.executable + '\nimport os, sys\nos.execv(' +
+                                  repr(sys.executable) + ', [' + repr(sys.executable) + ', ' +
+                                  repr(str(FIXTURE)) + ', ' + repr(mode) + ', *sys.argv[1:]])\n')
+            executable.chmod(0o700)
+        # Avoid inheriting real CLI/Gateway credentials or the user's desktop bus.
+        self.env = {'PATH': str(self.folder) + ':/usr/bin:/bin', 'HOME': str(self.folder),
+                    'XDG_CONFIG_HOME': str(self.folder / 'config'),
+                    'OPENCLAW_DESKTOP_CLI': str(cli), 'FIXTURE_DIR': str(self.folder),
+                    'PYTHONUNBUFFERED': '1'}
+        self.messages = queue.Queue()
+        self.serial = 0
+
+    def configure_desktop(self, route='remote-fixture/1', ready=True, fail=False,
+                          cli_url='ws://127.0.0.1:18789', change_after_status=None):
+        # Atomic replacement also lets a test switch the live fixture's route.
+        temporary = self.config.with_suffix('.tmp')
+        temporary.write_text(json.dumps({'route': route, 'ready': ready, 'fail': fail,
+                                         'cliUrl': cli_url, 'changeAfterStatus': change_after_status}))
+        temporary.replace(self.config)
+
+    def start(self, mode='cli'):
+        self.worker = subprocess.Popen(
+            ['dbus-run-session', '--', sys.executable, str(FIXTURE), 'launch', mode],
+            stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+            text=True, env=self.env, start_new_session=True)
+        self.addCleanup(self.stop)
+        threading.Thread(target=self.read_output, daemon=True).start()
+        self.state = self.receive(lambda item: item.get('op') == 'state')
+        return self.state
+
+    def read_output(self):
+        for line in self.worker.stdout:
+            try:
+                self.messages.put(json.loads(line))
+            except ValueError:
+                self.messages.put({'invalidOutput': line})
+        self.messages.put({'eof': True})
+
+    def stop(self):
+        self.worker.stdin.close()
+        try:
+            self.worker.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            os.killpg(self.worker.pid, signal.SIGKILL)
+            self.worker.wait(timeout=5)
+        # A terminated worker may leave a detached fixture CLI running.
+        # This private process group contains only this test's fixture tree.
+        try:
+            os.killpg(self.worker.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+        self.worker.stdout.close()
+        self.worker.stderr.close()
+
+    def receive(self, predicate):
+        deadline = time.monotonic() + 10
+        while time.monotonic() < deadline:
+            try:
+                item = self.messages.get(timeout=max(0.01, deadline - time.monotonic()))
+            except queue.Empty:
+                break
+            self.assertNotIn('invalidOutput', item)
+            if item.get('eof'):
+                self.fail('Worker exited: ' + self.worker.stderr.read())
+            if predicate(item):
+                return item
+        self.fail('Timed out waiting for worker protocol response')
+
+    def request(self, operation, **params):
+        self.serial += 1
+        request = {'id': self.serial, 'op': operation, 'routeId': self.state['routeId'], **params}
+        self.worker.stdin.write(json.dumps(request) + '\n')
+        self.worker.stdin.flush()
+        return self.receive(lambda item: item.get('id') == self.serial)
+
+    def calls(self, transport='cli', method=None):
+        path = self.folder / (transport + '.jsonl')
+        rows = [json.loads(line) for line in path.read_text().splitlines()] if path.exists() else []
+        return [row for row in rows if method is None or row['method'] == method]
+
+    def prompt(self, **params):
+        return self.request('send', **{'agentId': 'builder', 'sessionKey': 'agent:builder:review',
+                                      'message': 'Draft a checklist', **params})
+
+    def assert_global_sessions(self, snapshot):
+        rows = [row for row in snapshot['sessions'] if row['key'] == 'global']
+        self.assertEqual(len(rows), 2)
+        self.assertEqual({row['agentId']: row['totalTokens'] for row in rows},
+                         {'research': 700, 'builder': 1300})
+        self.assertEqual(len({row['id'] for row in snapshot['sessions']}), 6)
+
+    def test_cli_snapshot_preserves_selection_attention_and_deduplicates_pages(self):
+        self.assertFalse(self.start()['desktop'])
+        result = self.request('snapshot')
+        self.assertTrue(result['ok'])
+        self.assertTrue(result['selectionRequired'])
+        self.assertEqual(len(result['sessions']), 6)
+        self.assert_global_sessions(result)
+        rows = {row['key']: row for row in result['sessions']}
+        self.assertTrue(rows['agent:builder:review']['waiting'])
+        for key in ('agent:builder:review', 'agent:builder:choice', 'agent:research:notes'):
+            self.assertTrue(rows[key]['attention'])
+        self.assertEqual(rows['agent:research:report']['status'], 'running')
+        self.assertNotIn('private state path', json.dumps(result))
+        self.assertEqual({row['method'] for row in self.calls()}, {'agents.list', 'sessions.list'})
+
+    def test_cli_prompt_preserves_literal_content_and_new_session_destination(self):
+        self.start()
+        marker = self.folder / 'must-not-exist'
+        prompt = 'Explain $(touch ' + str(marker) + ') and `literal`\n"quoted" 🦞'
+        self.assertTrue(self.prompt(message=prompt)['ok'])
+        params = self.calls()[0]['params']
+        self.assertEqual(params['message'], prompt)
+        self.assertEqual(params['sessionKey'], 'agent:builder:review')
+        self.assertFalse(params['deliver'])
+        self.assertTrue(params['idempotencyKey'])
+        self.assertFalse(marker.exists())
+        result = self.prompt(sessionKey='')
+        self.assertTrue(result['ok'])
+        self.assertEqual(result['sessionKey'], 'agent:builder:new-fixture')
+        self.assertEqual(self.calls()[1]['method'], 'sessions.create')
+        self.assertEqual(self.calls()[1]['params']['agentId'], 'builder')
+        self.assertTrue(self.prompt(sessionKey='global')['ok'])
+        self.assertEqual(self.calls()[2]['params']['agentId'], 'builder')
+        self.assertEqual(self.calls()[2]['params']['sessionKey'], 'global')
+
+    def test_cli_session_activation_preserves_global_agent_owner(self):
+        self.start()
+        for index, (key, expected) in enumerate((('agent:builder:review', 'agent:builder:review'),
+                                                  ('global', 'agent:builder:global')), 1):
+            self.assertTrue(self.request('activate', action='session', sessionKey=key,
+                                         agentId='builder')['ok'])
+            # Terminal launch is detached; wait for its observable argument record.
+            deadline = time.monotonic() + 3
+            while len(self.calls('terminal')) < index and time.monotonic() < deadline:
+                time.sleep(0.01)
+            calls = self.calls('terminal')
+            self.assertEqual(len(calls), index)
+            self.assertEqual(calls[-1]['params'],
+                             [self.env['OPENCLAW_DESKTOP_CLI'], 'tui', '--session', expected])
+        self.assertEqual(self.calls(), [])
+
+    def test_cli_route_change_rejects_prompt_from_previous_snapshot(self):
+        self.start()
+        self.assertTrue(self.request('snapshot')['ok'])
+        self.configure_desktop(cli_url='wss://other-gateway.example')
+        result = self.prompt()
+        self.assertFalse(result['ok'])
+        self.assertFalse(result['uncertain'])
+        self.assertEqual(self.calls(method='chat.send'), [])
+        self.assertEqual(self.calls(method='sessions.create'), [])
+
+    def test_cli_expect_url_blocks_route_change_after_status_resolution(self):
+        self.start()
+        self.assertTrue(self.request('snapshot')['ok'])
+        self.configure_desktop(change_after_status='wss://other-gateway.example')
+        result = self.prompt()
+        self.assertFalse(result['ok'])
+        self.assertTrue(result['uncertain'])
+        self.assertEqual(self.calls('guard'), [{'method': 'chat.send', 'params': {
+            'expected': 'ws://127.0.0.1:18789', 'actual': 'wss://other-gateway.example'}}])
+        self.assertEqual(self.calls(method='chat.send'), [])
+        self.assertEqual(self.calls(method='sessions.create'), [])
+
+    def test_cli_unknown_send_is_never_retried_and_redacts_diagnostics(self):
+        self.env['FIXTURE_FAIL'] = '1'
+        self.start()
+        result = self.prompt()
+        self.assertFalse(result['ok'])
+        self.assertTrue(result['uncertain'])
+        self.assertEqual(result['sessionKey'], 'agent:builder:review')
+        self.assertNotIn('private connection detail', json.dumps(result))
+        # A follow-up read is a protocol barrier after the failed send.
+        self.assertTrue(self.request('snapshot')['ok'])
+        self.assertEqual(len(self.calls(method='chat.send')), 1)
+
+    def test_stdin_eof_exits_while_cli_snapshot_is_in_flight(self):
+        self.env['FIXTURE_SLOW'] = '1'
+        self.start()
+        self.worker.stdin.write(json.dumps({'id': 1, 'op': 'snapshot',
+                                             'routeId': self.state['routeId']}) + '\n')
+        self.worker.stdin.flush()
+        entered = self.folder / 'snapshot-entered'
+        deadline = time.monotonic() + 3
+        while not entered.exists() and time.monotonic() < deadline:
+            time.sleep(0.01)
+        self.assertTrue(entered.exists(), 'Snapshot must reach the slow CLI before closing stdin')
+        self.worker.stdin.close()
+        self.assertEqual(self.worker.wait(timeout=2), 0)
+        self.assertEqual(self.calls(method='chat.send'), [])
+        self.assertEqual(self.calls(method='sessions.create'), [])
+
+    def test_invalid_prompt_never_reaches_gateway(self):
+        self.start()
+        for message in (' ', 'x' * 8001):
+            with self.subTest(length=len(message)):
+                result = self.prompt(message=message)
+                self.assertFalse(result['ok'])
+                self.assertFalse(result['uncertain'])
+        self.assertEqual(self.calls(), [])
+
+    def test_desktop_owns_snapshot_send_and_session_activation_without_cli(self):
+        state = self.start('desktop')
+        self.assertTrue(state['desktop'])
+        self.assertFalse(state['yield'])
+        self.assertTrue(state['ready'])
+        snapshot = self.request('snapshot')
+        self.assertTrue(snapshot['selectionRequired'])
+        self.assert_global_sessions(snapshot)
+        self.assertTrue(self.prompt()['ok'])
+        self.assertTrue(self.prompt(sessionKey='')['ok'])
+        for key in ('agent:builder:review', 'global'):
+            self.assertTrue(self.request('activate', action='session',
+                                         sessionKey=key, agentId='builder')['ok'])
+        self.assertEqual([row['params'] for row in self.calls('desktop', 'Activate')], [
+            ['remote-fixture/1', 'session', 'agent:builder:review', 'builder'],
+            ['remote-fixture/1', 'session', 'global', 'builder']])
+        calls = self.calls('desktop')
+        self.assertTrue(any(row['method'] == 'ClaimPresenter' for row in calls))
+        sends = self.calls('desktop', 'SendPrompt')
+        self.assertEqual(len(sends), 2)
+        self.assertEqual(sends[0]['params'][:4],
+                         ['remote-fixture/1', 'builder', 'agent:builder:review', 'Draft a checklist'])
+        self.assertEqual(sends[1]['params'][2], '')
+        self.assertTrue(sends[0]['params'][4])
+        self.assertEqual(self.calls(), [])
+        self.assertEqual(self.calls('status'), [])
+
+    def test_disconnected_desktop_never_falls_back_to_cli(self):
+        self.configure_desktop(ready=False)
+        self.assertFalse(self.start('desktop')['ready'])
+        self.assertFalse(self.request('snapshot')['ok'])
+        self.assertFalse(self.prompt()['ok'])
+        self.assertEqual(self.calls(), [])
+        self.assertEqual(self.calls('status'), [])
+
+    def test_changed_desktop_route_rejects_stale_prompt_before_dispatch(self):
+        self.start('desktop')
+        self.configure_desktop(route='another-gateway/2')
+        result = self.prompt()
+        self.assertFalse(result['ok'])
+        self.assertFalse(result['uncertain'])
+        self.assertEqual(self.calls('desktop', 'SendPrompt'), [])
+        self.assertEqual(self.calls(), [])
+        self.assertEqual(self.calls('status'), [])
+
+    def test_unknown_desktop_send_never_retries_or_switches_to_cli(self):
+        self.configure_desktop(fail=True)
+        self.start('desktop')
+        result = self.prompt()
+        self.assertFalse(result['ok'])
+        self.assertTrue(result['uncertain'])
+        self.assertNotIn('private connection detail', json.dumps(result))
+        self.assertTrue(self.request('snapshot')['ok'])
+        self.assertEqual(len(self.calls('desktop', 'SendPrompt')), 1)
+        self.assertEqual(self.calls(), [])
+        self.assertEqual(self.calls('status'), [])
+
+    def test_legacy_desktop_keeps_its_entry_and_blocks_cli_requests(self):
+        state = self.start('legacy')
+        self.assertTrue(state['desktop'])
+        self.assertTrue(state['yield'])
+        self.assertFalse(self.request('snapshot')['ok'])
+        self.assertFalse(self.prompt()['ok'])
+        self.assertEqual(self.calls(), [])
+        self.assertEqual(self.calls('status'), [])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/apps/linux/omarchy/test_bridge.py
+++ b/apps/linux/omarchy/test_bridge.py
@@ -150,6 +150,20 @@ class BridgeContract(unittest.TestCase):
         self.assertEqual(self.calls()[2]['params']['agentId'], 'builder')
         self.assertEqual(self.calls()[2]['params']['sessionKey'], 'global')
 
+    def test_unicode_session_identity_survives_prompt_and_refresh(self):
+        key = 'agent:builder:café-🦞'
+        self.env['FIXTURE_SESSION_KEY'] = key
+        self.start()
+        before = next(row for row in self.request('snapshot')['sessions'] if row['key'] == key)
+        result = self.prompt(sessionKey=key)
+        self.assertTrue(result['ok'])
+        self.assertEqual(result['sessionId'], before['id'])
+        after = next(row for row in self.request('snapshot')['sessions'] if row['id'] == result['sessionId'])
+        self.assertEqual((after['agentId'], after['key']), ('builder', key))
+        self.assertTrue(self.prompt(sessionKey=after['key'])['ok'])
+        created = self.prompt(sessionKey='')
+        self.assertEqual(json.loads(created['sessionId']), ['builder', created['sessionKey']])
+
     def test_cli_session_activation_preserves_global_agent_owner(self):
         self.start()
         for index, (key, expected) in enumerate((('agent:builder:review', 'agent:builder:review'),

--- a/apps/linux/src-tauri/src/desktop_bridge.rs
+++ b/apps/linux/src-tauri/src/desktop_bridge.rs
@@ -1,0 +1,372 @@
+//! Same-user session-bus integration for a desktop panel. Gateway credentials stay
+//! with GatewayClient; every operation is fenced by its selected route generation.
+use crate::gateway_ws::{DesktopMethod, GatewayClient};
+use crate::{quickchat, tray, DesktopState};
+use serde_json::json;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+use tauri::{AppHandle, Manager};
+use zbus::{fdo, message::Header};
+
+const LEASE: Duration = Duration::from_secs(10);
+
+struct Presenter {
+    sender: String,
+    generation: u64,
+    renewed: Instant,
+}
+
+impl Presenter {
+    fn is_current(&self, generation: u64, now: Instant) -> bool {
+        self.generation == generation && now.duration_since(self.renewed) < LEASE
+    }
+}
+
+struct Bridge {
+    app: AppHandle,
+    instance: String,
+    presenter: Arc<Mutex<Option<Presenter>>>,
+    last_read: Arc<Mutex<Option<Instant>>>,
+}
+
+impl Bridge {
+    fn gateway(&self) -> tauri::State<'_, GatewayClient> {
+        self.app.state::<GatewayClient>()
+    }
+
+    fn route_id(&self, generation: u64) -> String {
+        format!("{}:{generation}", self.instance)
+    }
+
+    fn generation(&self, route_id: &str) -> fdo::Result<u64> {
+        let (generation, _) = self.gateway().desktop_state();
+        if route_id != self.route_id(generation) {
+            return Err(fdo::Error::Failed(
+                "Desktop Gateway changed; refresh before trying again.".into(),
+            ));
+        }
+        Ok(generation)
+    }
+}
+
+fn failed(message: String) -> fdo::Error {
+    fdo::Error::Failed(message)
+}
+
+#[zbus::interface(name = "ai.openclaw.Desktop1")]
+impl Bridge {
+    fn get_state(&self) -> String {
+        *self
+            .last_read
+            .lock()
+            .expect("desktop demand mutex poisoned") = Some(Instant::now());
+        self.gateway().set_desktop_demand(true);
+        self.gateway().activate(self.app.clone());
+        let (generation, ready) = self.gateway().desktop_state();
+        json!({"version": 1, "routeId": self.route_id(generation), "ready": ready}).to_string()
+    }
+
+    async fn snapshot(&self, route_id: &str) -> fdo::Result<String> {
+        let generation = self.generation(route_id)?;
+        let gateway = self.gateway();
+        let agents = gateway
+            .desktop_request(generation, DesktopMethod::Agents, json!({}))
+            .await
+            .map_err(failed)?;
+        let params = json!({"limit":40,"includeDerivedTitles":true,"includeLastMessage":true,"includeGlobal":true});
+        let recent = gateway
+            .desktop_request(generation, DesktopMethod::Sessions, params.clone())
+            .await
+            .map_err(failed)?;
+        let mut active_params = params;
+        active_params["activeOnly"] = json!(true);
+        let active = gateway
+            .desktop_request(generation, DesktopMethod::Sessions, active_params)
+            .await
+            .map_err(failed)?;
+        self.generation(route_id)?;
+        Ok(json!({"agents":agents,"recent":recent,"active":active}).to_string())
+    }
+
+    async fn send_prompt(
+        &self,
+        route_id: &str,
+        agent_id: &str,
+        session_key: &str,
+        message: &str,
+        idempotency_key: &str,
+    ) -> fdo::Result<String> {
+        let generation = self.generation(route_id)?;
+        if message.trim().is_empty()
+            || message.len() > 32_000
+            || agent_id.is_empty()
+            || agent_id.len() > 256
+            || session_key.len() > 2048
+            || idempotency_key.is_empty()
+            || idempotency_key.len() > 256
+        {
+            return Err(fdo::Error::InvalidArgs(
+                "Choose an agent and enter a prompt (up to 32,000 bytes).".into(),
+            ));
+        }
+        let mut params =
+            json!({"agentId":agent_id,"message":message,"idempotencyKey":idempotency_key});
+        let method = if session_key.is_empty() {
+            DesktopMethod::Create
+        } else {
+            // Canonical agent keys carry ownership; the raw global key needs
+            // its separate agent owner.
+            if session_key != "global" {
+                params
+                    .as_object_mut()
+                    .expect("prompt params object")
+                    .remove("agentId");
+            }
+            params["sessionKey"] = json!(session_key);
+            params["deliver"] = json!(false);
+            DesktopMethod::Send
+        };
+        let result = self
+            .gateway()
+            .desktop_request(generation, method, params)
+            .await
+            .map_err(failed)?;
+        Ok(result.to_string())
+    }
+
+    fn claim_presenter(
+        &self,
+        route_id: &str,
+        #[zbus(header)] header: Header<'_>,
+    ) -> fdo::Result<()> {
+        let generation = self.generation(route_id)?;
+        let sender = header
+            .sender()
+            .ok_or_else(|| fdo::Error::AccessDenied("A session-bus sender is required.".into()))?
+            .to_string();
+        let mut presenter = self
+            .presenter
+            .lock()
+            .expect("desktop presenter mutex poisoned");
+        if presenter.as_ref().is_some_and(|current| {
+            current.sender != sender && current.is_current(generation, Instant::now())
+        }) {
+            return Err(fdo::Error::Failed(
+                "Another panel is presenting OpenClaw.".into(),
+            ));
+        }
+        *presenter = Some(Presenter {
+            sender,
+            generation,
+            renewed: Instant::now(),
+        });
+        Ok(())
+    }
+
+    async fn activate(
+        &self,
+        route_id: &str,
+        action: &str,
+        session_key: &str,
+        agent_id: &str,
+    ) -> fdo::Result<()> {
+        let generation = self.generation(route_id)?;
+        if !matches!(
+            action,
+            "dashboard" | "quickchat" | "session" | "updates" | "quit"
+        ) || session_key.len() > 2048
+            || agent_id.len() > 256
+            || (action == "session"
+                && (session_key.is_empty()
+                    || (session_key == "global" && agent_id.trim().is_empty())))
+        {
+            return Err(fdo::Error::InvalidArgs(
+                "Unknown desktop action or invalid session.".into(),
+            ));
+        }
+        let app = self.app.clone();
+        let action = action.to_string();
+        let session_key = session_key.to_string();
+        let agent_id = agent_id.to_string();
+        let (reply, result) = tokio::sync::oneshot::channel();
+        self.app
+            .run_on_main_thread(move || {
+                let gateway = app.state::<GatewayClient>();
+                let outcome = gateway.with_desktop_route(generation, |ws_url| {
+                    match action.as_str() {
+                        "session" => {
+                            let ws_url =
+                                ws_url.ok_or("Select a Gateway in the desktop app first.")?;
+                            let url = session_url(ws_url, &session_key, &agent_id)?;
+                            crate::main_window(&app)?
+                                .navigate(url)
+                                .map_err(|e| e.to_string())?;
+                            tray::show_window(&app);
+                        }
+                        "dashboard" => tray::show_window(&app),
+                        "quickchat" => quickchat::toggle_quickchat(&app),
+                        "updates" => {
+                            tray::show_window(&app);
+                            crate::updater::spawn_check(app.clone());
+                        }
+                        "quit" => {
+                            app.state::<DesktopState>().quit();
+                            app.exit(0);
+                        }
+                        _ => unreachable!(),
+                    }
+                    Ok(())
+                });
+                let _ = reply.send(outcome);
+            })
+            .map_err(|e| failed(e.to_string()))?;
+        result
+            .await
+            .map_err(|_| failed("Desktop action interrupted.".into()))?
+            .map_err(failed)
+    }
+}
+
+fn session_url(ws_url: &str, session_key: &str, agent_id: &str) -> Result<tauri::Url, String> {
+    let mut url = crate::remote_gateway::dashboard_url(
+        &tauri::Url::parse(ws_url).map_err(|error| error.to_string())?,
+    )?;
+    url.set_query(None);
+    url.set_fragment(None);
+    {
+        let mut path = url
+            .path_segments_mut()
+            .map_err(|_| "Gateway URL has no path")?;
+        path.pop_if_empty().push("chat");
+        if session_key == "global" {
+            if agent_id.trim().is_empty() || matches!(agent_id, "." | "..") {
+                return Err("Choose the global session's agent.".into());
+            }
+            // The shared URL contract maps raw global to the selected agent's
+            // home route; agent:<id>:global is a distinct literal session.
+            path.push(agent_id);
+        }
+    }
+    if session_key != "global" {
+        // Control UI bootstrap normalizes this shipped query contract.
+        url.query_pairs_mut().append_pair("session", session_key);
+    }
+    Ok(url)
+}
+
+pub(crate) fn start(app: AppHandle) {
+    tauri::async_runtime::spawn(async move {
+        if let Err(error) = run(app.clone()).await {
+            eprintln!("Desktop panel bridge unavailable: {error}");
+        }
+        app.state::<GatewayClient>().set_desktop_demand(false);
+        app.state::<DesktopState>()
+            .with_tray(|tray| tray.set_visible(true));
+    });
+}
+
+async fn run(app: AppHandle) -> zbus::Result<()> {
+    let presenter = Arc::new(Mutex::new(None::<Presenter>));
+    let last_read = Arc::new(Mutex::new(None::<Instant>));
+    let bridge = Bridge {
+        app: app.clone(),
+        instance: uuid::Uuid::new_v4().to_string(),
+        presenter: presenter.clone(),
+        last_read: last_read.clone(),
+    };
+    let connection = zbus::connection::Builder::session()?
+        .name("ai.openclaw.Desktop")?
+        .serve_at("/ai/openclaw/Desktop", bridge)?
+        .build()
+        .await?;
+    let bus = fdo::DBusProxy::new(&connection).await?;
+    loop {
+        tokio::time::sleep(Duration::from_secs(1)).await;
+        let sender = presenter
+            .lock()
+            .expect("desktop presenter mutex poisoned")
+            .as_ref()
+            .map(|claim| claim.sender.clone());
+        let owner_alive = match sender.as_deref() {
+            Some(sender) => bus.name_has_owner(sender.try_into()?).await?,
+            None => true,
+        };
+        let active = last_read
+            .lock()
+            .expect("desktop demand mutex poisoned")
+            .is_some_and(|read| read.elapsed() < LEASE);
+        app.state::<GatewayClient>().set_desktop_demand(active);
+        let current_app = app.clone();
+        let presenter = presenter.clone();
+        app.run_on_main_thread(move || {
+            let gateway = current_app.state::<GatewayClient>();
+            let (generation, _) = gateway.desktop_state();
+            // The bus lookup can overlap a new claim; do not apply an old sender's
+            // liveness result to its replacement. The next tick checks the new owner.
+            let mut claim = presenter.lock().expect("desktop presenter mutex poisoned");
+            if claim.as_ref().map(|claim| claim.sender.as_str()) != sender.as_deref() {
+                return;
+            }
+            let _ = gateway.with_desktop_route(generation, |_| {
+                let hide = claim.as_ref().is_some_and(|claim| {
+                    owner_alive && claim.is_current(generation, Instant::now())
+                });
+                if !hide {
+                    *claim = None;
+                }
+                current_app
+                    .state::<DesktopState>()
+                    .with_tray(|tray| tray.set_visible(!hide));
+                Ok(())
+            });
+        })
+        .map_err(|error| zbus::Error::Failure(error.to_string()))?;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn session_navigation_preserves_global_owner_and_qualified_literal_keys() {
+        for (key, agent, expected) in [
+            (
+                "global",
+                "builder",
+                "https://gateway.example/control/chat/builder",
+            ),
+            (
+                "agent:builder:global",
+                "builder",
+                "https://gateway.example/control/chat?session=agent%3Abuilder%3Aglobal",
+            ),
+            (
+                "global",
+                "builder/other",
+                "https://gateway.example/control/chat/builder%2Fother",
+            ),
+        ] {
+            assert_eq!(
+                session_url("wss://gateway.example/control/", key, agent)
+                    .unwrap()
+                    .as_str(),
+                expected
+            );
+        }
+        assert!(session_url("ws://127.0.0.1/", "global", "").is_err());
+    }
+
+    #[test]
+    fn presenter_lease_cannot_hide_a_replaced_route_or_outlive_its_deadline() {
+        let now = Instant::now();
+        let presenter = Presenter {
+            sender: ":1.23".into(),
+            generation: 4,
+            renewed: now,
+        };
+        assert!(presenter.is_current(4, now + Duration::from_secs(9)));
+        assert!(!presenter.is_current(5, now));
+        assert!(!presenter.is_current(4, now + LEASE));
+    }
+}

--- a/apps/linux/src-tauri/src/gateway_ws.rs
+++ b/apps/linux/src-tauri/src/gateway_ws.rs
@@ -296,6 +296,12 @@ struct SuspendResumeResponse {
 
 enum GatewayRequest {
     AgentsList,
+    #[cfg(target_os = "linux")]
+    Desktop {
+        generation: u64,
+        method: DesktopMethod,
+        params: Value,
+    },
     ChatSend(ChatSendParams),
     RefreshCanvasSurface {
         observed_url: Option<String>,
@@ -312,7 +318,29 @@ enum GatewayRequest {
     },
 }
 
+#[cfg(target_os = "linux")]
+pub(crate) enum DesktopMethod {
+    Agents,
+    Sessions,
+    Send,
+    Create,
+}
+
+#[cfg(target_os = "linux")]
+impl DesktopMethod {
+    fn name(&self) -> &'static str {
+        match self {
+            Self::Agents => "agents.list",
+            Self::Sessions => "sessions.list",
+            Self::Send => "chat.send",
+            Self::Create => "sessions.create",
+        }
+    }
+}
+
 enum GatewayResponse {
+    #[cfg(target_os = "linux")]
+    Desktop(Value),
     AgentsList(AgentsListResult),
     ChatSend(ChatSendAck),
     CanvasSurface(Option<String>),
@@ -449,6 +477,7 @@ struct GatewayClientInner {
     reconnect_paused: AtomicBool,
     sleep_cycle_depth: AtomicU64,
     running: AtomicBool,
+    desktop_demand: AtomicBool,
 }
 
 #[derive(Clone)]
@@ -461,6 +490,72 @@ impl GatewayClient {
         Self {
             inner: Arc::default(),
         }
+    }
+
+    #[cfg(target_os = "linux")]
+    pub(crate) fn desktop_state(&self) -> (u64, bool) {
+        let _config = self
+            .inner
+            .config
+            .lock()
+            .expect("gateway config mutex poisoned");
+        (
+            self.inner.config_generation.load(Ordering::SeqCst),
+            self.is_connected(),
+        )
+    }
+
+    #[cfg(target_os = "linux")]
+    pub(crate) fn set_desktop_demand(&self, active: bool) {
+        self.inner.desktop_demand.store(active, Ordering::SeqCst);
+    }
+
+    #[cfg(target_os = "linux")]
+    pub(crate) fn with_desktop_route<T>(
+        &self,
+        generation: u64,
+        action: impl FnOnce(Option<&str>) -> Result<T, String>,
+    ) -> Result<T, String> {
+        let config = self
+            .inner
+            .config
+            .lock()
+            .map_err(|_| "Gateway route unavailable")?;
+        if self.inner.config_generation.load(Ordering::SeqCst) != generation {
+            return Err("Desktop Gateway changed; refresh before trying again.".into());
+        }
+        action(config.as_ref().map(|config| config.ws_url.as_str()))
+    }
+
+    #[cfg(target_os = "linux")]
+    pub(crate) async fn desktop_request(
+        &self,
+        generation: u64,
+        method: DesktopMethod,
+        params: Value,
+    ) -> Result<Value, String> {
+        self.with_desktop_route(generation, |url| {
+            url.map(|_| ())
+                .ok_or_else(|| "Select a Gateway in the desktop app first.".into())
+        })?;
+        let is_send = matches!(method, DesktopMethod::Send);
+        let response = self
+            .request(GatewayRequest::Desktop {
+                generation,
+                method,
+                params,
+            })
+            .await?;
+        self.with_desktop_route(generation, |_| Ok(()))?;
+        let GatewayResponse::Desktop(value) = response else {
+            return Err("Unexpected desktop response".into());
+        };
+        if is_send {
+            let ack: ChatSendAck = serde_json::from_value(value.clone())
+                .map_err(|error| format!("Invalid chat.send response: {error}"))?;
+            classify_chat_ack(&ack)?;
+        }
+        Ok(value)
     }
 
     pub fn configure(&self, app: &AppHandle, config: GatewayWsConfig) {
@@ -774,7 +869,8 @@ impl GatewayClient {
         let mut reconnect_attempt = 0_u32;
         loop {
             if !driver_should_run(
-                app.get_window(QUICKCHAT_LABEL).is_some(),
+                app.get_window(QUICKCHAT_LABEL).is_some()
+                    || self.inner.desktop_demand.load(Ordering::SeqCst),
                 self.inner.sleep_cycle_depth.load(Ordering::SeqCst) > 0,
             ) {
                 self.inner.reconnect_paused.store(false, Ordering::SeqCst);
@@ -855,7 +951,8 @@ impl GatewayClient {
                 reconnect_attempt = 1;
             }
             if !driver_should_run(
-                app.get_window(QUICKCHAT_LABEL).is_some(),
+                app.get_window(QUICKCHAT_LABEL).is_some()
+                    || self.inner.desktop_demand.load(Ordering::SeqCst),
                 self.inner.sleep_cycle_depth.load(Ordering::SeqCst) > 0,
             ) {
                 continue;
@@ -950,7 +1047,8 @@ impl GatewayClient {
         loop {
             if self.inner.config_generation.load(Ordering::SeqCst) != generation
                 || !driver_should_run(
-                    app.get_window(QUICKCHAT_LABEL).is_some(),
+                    app.get_window(QUICKCHAT_LABEL).is_some()
+                        || self.inner.desktop_demand.load(Ordering::SeqCst),
                     self.inner.sleep_cycle_depth.load(Ordering::SeqCst) > 0,
                 )
             {
@@ -1221,8 +1319,8 @@ fn reject_disconnected_command(command: DriverCommand) {
 }
 
 fn driver_should_run(window_exists: bool, sleep_active: bool) -> bool {
-    // Sleep cycles temporarily activate the driver; the companion-wide connection lifetime
-    // remains owned by Quick Chat outside that narrow window.
+    // Quick Chat and the desktop panel provide window demand; sleep cycles
+    // temporarily keep the same connection owner alive without either surface.
     window_exists || sleep_active
 }
 
@@ -1408,9 +1506,10 @@ async fn wait_for_connect_challenge(
 }
 
 #[cfg(target_os = "linux")]
-struct SleepDispatch<'a> {
+struct RouteDispatch<'a> {
     client: &'a GatewayClient,
-    route: &'a GatewaySleepRoute,
+    route: Option<&'a GatewaySleepRoute>,
+    generation: u64,
     connection_generation: u64,
 }
 
@@ -1420,7 +1519,7 @@ async fn request_on_socket<T, F>(
     params: Value,
     budget: Duration,
     dispatch: &F,
-    #[cfg(target_os = "linux")] sleep: Option<SleepDispatch<'_>>,
+    #[cfg(target_os = "linux")] authority: Option<RouteDispatch<'_>>,
 ) -> Result<T, RequestFailure>
 where
     T: DeserializeOwned,
@@ -1437,8 +1536,8 @@ where
         // Read current authority after transport readiness, and hold it through enqueue.
         // The socket generation also fences commands queued for a replaced connection.
         #[cfg(target_os = "linux")]
-        let current = sleep.as_ref().map(|sleep| {
-            sleep
+        let current = authority.as_ref().map(|authority| {
+            authority
                 .client
                 .inner
                 .config
@@ -1446,22 +1545,28 @@ where
                 .expect("gateway config mutex poisoned")
         });
         #[cfg(target_os = "linux")]
-        if let Some(sleep) = sleep.as_ref() {
+        if let Some(authority) = authority.as_ref() {
             let owned = current
                 .as_ref()
                 .and_then(|current| current.as_ref())
                 .is_some_and(|config| {
-                    config.ownership == GatewayOwnership::Local
-                        && config.ws_url == sleep.route.ws_url
-                        && is_loopback_ws_url(&config.ws_url)
+                    authority.route.is_none_or(|route| {
+                        config.ownership == GatewayOwnership::Local
+                            && config.ws_url == route.ws_url
+                            && is_loopback_ws_url(&config.ws_url)
+                    })
                 });
             if !owned
-                || sleep.route.generation != sleep.connection_generation
-                || sleep.client.inner.config_generation.load(Ordering::SeqCst)
-                    != sleep.route.generation
+                || authority.generation != authority.connection_generation
+                || authority
+                    .client
+                    .inner
+                    .config_generation
+                    .load(Ordering::SeqCst)
+                    != authority.generation
             {
                 return Err(RequestFailure::method_with_details(
-                    "Gateway sleep route changed; lease will self-expire.",
+                    "Gateway route changed before dispatch; refresh before trying again.",
                     None,
                 ));
             }
@@ -1524,6 +1629,26 @@ where
     let _ = (client, connection_generation);
     let budget = budget.unwrap_or(REQUEST_TIMEOUT);
     match request {
+        #[cfg(target_os = "linux")]
+        GatewayRequest::Desktop {
+            generation,
+            method,
+            params,
+        } => request_on_socket(
+            socket,
+            method.name(),
+            params,
+            budget,
+            dispatch,
+            Some(RouteDispatch {
+                client,
+                route: None,
+                generation,
+                connection_generation,
+            }),
+        )
+        .await
+        .map(GatewayResponse::Desktop),
         GatewayRequest::AgentsList => request_agents_list(socket, budget, dispatch)
             .await
             .map(GatewayResponse::AgentsList),
@@ -1572,9 +1697,10 @@ where
             json!({ "requestId": request_id }),
             budget,
             dispatch,
-            Some(SleepDispatch {
+            Some(RouteDispatch {
                 client,
-                route: &route,
+                route: Some(&route),
+                generation: route.generation,
                 connection_generation,
             }),
         )
@@ -1590,9 +1716,10 @@ where
             json!({ "suspensionId": suspension_id }),
             budget,
             dispatch,
-            Some(SleepDispatch {
+            Some(RouteDispatch {
                 client,
-                route: &route,
+                route: Some(&route),
+                generation: route.generation,
                 connection_generation,
             }),
         )
@@ -2092,6 +2219,86 @@ esac
         // An unbalanced extra end saturates at zero instead of wrapping.
         client.end_sleep_cycle();
         assert!(!driver_should_run(false, sleep_active(&client)));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn desktop_requests_never_retarget_across_gateway_generations() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let mut socket = tokio_tungstenite::accept_async(stream).await.unwrap();
+            // Only the final request may cross the transport. A stale queued prompt
+            // would become this first frame and fail the independent wire assertion.
+            let frame: Value =
+                serde_json::from_str(socket.next().await.unwrap().unwrap().to_text().unwrap())
+                    .unwrap();
+            assert_eq!(frame["method"], "chat.send");
+            assert_eq!(frame["params"]["message"], "current route");
+            assert_eq!(frame["params"]["deliver"], false);
+            socket.send(Message::Text(json!({"type":"res","id":frame["id"],"ok":true,"payload":{"status":"started","runId":"fixture-run"}}).to_string().into())).await.unwrap();
+        });
+        let (mut socket, _) = connect_async(format!("ws://{address}")).await.unwrap();
+        let client = GatewayClient::new();
+        let config = |ownership| {
+            GatewayWsConfig::new(format!("ws://{address}"), None, None, None, ownership)
+        };
+        let old = client.replace_configuration(Some(config(GatewayOwnership::Local)));
+        let current = client.replace_configuration(Some(config(GatewayOwnership::Remote)));
+        for (token, connection) in [(old, current), (current, old)] {
+            let result = perform_request(
+                &client,
+                connection,
+                &mut socket,
+                GatewayRequest::Desktop {
+                    generation: token,
+                    method: DesktopMethod::Send,
+                    params: json!({"message":"stale route"}),
+                },
+                None,
+                &|_| {},
+            )
+            .await;
+            let error = result.err().expect("stale route must fail before enqueue");
+            assert!(!error.disconnect);
+            assert!(error.message.contains("route changed"));
+        }
+        client.replace_configuration(None);
+        assert!(perform_request(
+            &client,
+            current,
+            &mut socket,
+            GatewayRequest::Desktop {
+                generation: current,
+                method: DesktopMethod::Send,
+                params: json!({"message":"cleared route"}),
+            },
+            None,
+            &|_| {}
+        )
+        .await
+        .is_err());
+        let current = client.replace_configuration(Some(config(GatewayOwnership::Remote)));
+        let response = perform_request(
+            &client,
+            current,
+            &mut socket,
+            GatewayRequest::Desktop {
+                generation: current,
+                method: DesktopMethod::Send,
+                params: json!({"message":"current route","deliver":false}),
+            },
+            None,
+            &|_| {},
+        )
+        .await
+        .unwrap_or_else(|error| panic!("{}", error.message));
+        let GatewayResponse::Desktop(value) = response else {
+            panic!("desktop response expected");
+        };
+        assert_eq!(value["runId"], "fixture-run");
+        server.await.unwrap();
     }
 
     #[tokio::test]

--- a/apps/linux/src-tauri/src/main.rs
+++ b/apps/linux/src-tauri/src/main.rs
@@ -1,4 +1,6 @@
 mod cli;
+#[cfg(target_os = "linux")]
+mod desktop_bridge;
 mod discovery;
 mod gateway;
 mod gateway_device_identity;
@@ -1354,6 +1356,8 @@ fn main() {
         app.manage(quickchat_state.clone());
         app.manage(updater::UpdaterState::default());
         state.set_tray(tray::build(app, state.clone(), global_shortcuts_supported)?);
+        #[cfg(target_os = "linux")]
+        desktop_bridge::start(app.handle().clone());
         Ok(())
     });
     let builder = builder.invoke_handler(tauri::generate_handler![

--- a/apps/linux/src-tauri/src/tray.rs
+++ b/apps/linux/src-tauri/src/tray.rs
@@ -29,6 +29,8 @@ const QUIT_ID: &str = "quit";
 
 pub struct TrayHandles {
     _tray: TrayIcon<tauri::Wry>,
+    #[cfg(target_os = "linux")]
+    visible: Mutex<bool>,
     status: MenuItem<tauri::Wry>,
     status_line: Mutex<StatusLine>,
     update_action: MenuItem<tauri::Wry>,
@@ -82,6 +84,18 @@ impl StatusLine {
 }
 
 impl TrayHandles {
+    #[cfg(target_os = "linux")]
+    pub(crate) fn set_visible(&self, visible: bool) {
+        let mut current = self.visible.lock().expect("tray visibility mutex poisoned");
+        if *current == visible {
+            return;
+        }
+        match self._tray.set_visible(visible) {
+            Ok(()) => *current = visible,
+            Err(error) => eprintln!("Could not change desktop tray visibility: {error}"),
+        }
+    }
+
     pub fn update(&self, snapshot: &GatewaySnapshot) {
         let mut status_line = self.status_line.lock().expect("tray status mutex poisoned");
         status_line.gateway.clone_from(&snapshot.status);
@@ -294,6 +308,8 @@ pub fn build(
 
     Ok(TrayHandles {
         _tray: tray,
+        #[cfg(target_os = "linux")]
+        visible: Mutex::new(true),
         status,
         status_line: Mutex::new(StatusLine {
             gateway: "Checking…".to_string(),

--- a/docs/.i18n/glossary.zh-CN.json
+++ b/docs/.i18n/glossary.zh-CN.json
@@ -12,6 +12,10 @@
     "target": "radius"
   },
   {
+    "source": "Omarchy",
+    "target": "Omarchy"
+  },
+  {
     "source": "OpenClaw",
     "target": "OpenClaw"
   },

--- a/docs/cli/gateway/query.md
+++ b/docs/cli/gateway/query.md
@@ -308,6 +308,12 @@ Config defaults (optional): `gateway.remote.sshTarget`, `gateway.remote.sshIdent
 
 Low-level RPC helper.
 
+Use `--expect-url <url>` to bind a call to a previously observed Gateway endpoint
+without changing URL selection or authentication. The CLI compares the exact
+resolved URL before connecting and fails if the destination changed. Automation
+can obtain the endpoint from `gateway.url` in `openclaw status --json`; a redacted
+URL cannot serve as an exact endpoint assertion.
+
 ```bash
 openclaw gateway call status
 openclaw gateway call health --port 18999

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -2336,6 +2336,7 @@
                   "platforms/index",
                   "platforms/macos",
                   "platforms/linux",
+                  "platforms/omarchy",
                   "platforms/windows",
                   "platforms/android",
                   "platforms/chromeos",

--- a/docs/platforms/index.md
+++ b/docs/platforms/index.md
@@ -11,9 +11,8 @@ recommended runtime**. Bun 1.4+ builds with WAL-reset-safe `node:sqlite` can run
 the CLI, Gateway, and managed node host as an explicit opt-in; see
 [Bun](/install/bun).
 
-Companion apps exist for Windows Hub, macOS (menu bar app), and mobile nodes
-(iOS/Android). Linux companion apps are planned, but the Gateway is fully
-supported today. On Windows, choose Windows Hub for the desktop app, native
+Companion apps exist for Linux, Windows Hub, macOS (menu bar app), and mobile
+nodes (iOS/Android). On Windows, choose Windows Hub for the desktop app, native
 PowerShell install for terminal-first use, or WSL2 for the most
 Linux-compatible Gateway runtime.
 
@@ -24,6 +23,7 @@ Linux-compatible Gateway runtime.
 - iOS: [iOS](/platforms/ios)
 - Linux: [Linux](/platforms/linux)
 - macOS: [macOS](/platforms/macos)
+- Omarchy: [Omarchy](/platforms/omarchy)
 - Windows: [Windows](/platforms/windows)
 
 ## VPS and hosting

--- a/docs/platforms/omarchy.md
+++ b/docs/platforms/omarchy.md
@@ -1,0 +1,143 @@
+---
+summary: "OpenClaw on Omarchy: bar plugin, desktop app handoff, and support"
+read_when:
+  - Installing the OpenClaw bar plugin on Omarchy
+  - Using agents, sessions, and quick prompts from the Omarchy bar
+  - Troubleshooting duplicate OpenClaw icons or desktop connection handoff
+title: "Omarchy"
+---
+
+# OpenClaw on Omarchy
+
+The OpenClaw Omarchy plugin puts agents, recent sessions, and a quick prompt in
+your desktop bar. Its monochrome mascot follows the shell theme, blinks, and
+animates with reported agent activity. With the Linux desktop app running, the
+plugin becomes the single bar entry and uses the app's selected Gateway.
+
+This page covers the plugin in the OpenClaw source tree. Install it separately;
+do not assume an older desktop release includes the matching integration.
+For Gateway installation and the desktop app itself, see [Linux](/platforms/linux).
+
+## Requirements
+
+- Omarchy 4 with its Quickshell bar and plugin support. Earlier Waybar-based
+  Omarchy versions do not provide this plugin host.
+- Python 3 and PyGObject for the desktop session's D-Bus connection.
+- Either a connected OpenClaw Linux desktop app with Omarchy integration, or
+  an `openclaw` CLI with a configured, reachable Gateway and support for
+  `openclaw gateway call --expect-url`. Use a CLI build containing this
+  integration; older builds may not support that option.
+
+The desktop app is optional. The plugin resolves the CLI from
+`OPENCLAW_DESKTOP_CLI`, then `~/.openclaw/bin/openclaw`, then the graphical
+session's `PATH`. It does not install or start a Gateway in the background.
+Use your existing OpenClaw installation and authentication. In standalone
+mode, the plugin identifies the selected Gateway through
+`openclaw status --json` and checks that destination before each request. If status redacts the
+endpoint URL, standalone mode cannot establish the destination and disables
+requests. Use the desktop app for that connection.
+
+## Install the bar plugin
+
+From an OpenClaw source checkout containing `apps/linux/omarchy`, run:
+
+```bash
+bash apps/linux/omarchy/install.sh
+```
+
+The installer places the plugin in your user configuration. Check it with:
+
+```bash
+omarchy plugin validate ~/.config/omarchy/plugins/openclaw.desktop
+omarchy plugin enable openclaw.desktop
+```
+
+Click the OpenClaw mascot. Confirm that the panel shows the expected agents
+and sessions before sending a prompt. When using the desktop app, connect it
+to your intended Gateway first.
+
+## Use agents, sessions, and quick prompts
+
+Select an agent, search sessions, or use the **All**, **Active**, and
+**Attention** filters. Session cards show recent messages or activity,
+status, and available model and token details. Search and counts cover the
+loaded sessions; open the dashboard for full history.
+
+Click a session to target it, then use **Open session** to continue in the
+desktop app. Without the app, the plugin opens the session in the TUI.
+Choose **New session** to start a separate conversation with the selected agent.
+
+- **Ctrl+L** focuses **Quick prompt**.
+- **Ctrl+Enter** sends. **Enter** inserts a newline.
+- **Esc** closes the panel.
+- Middle-click the mascot to refresh.
+
+The prompt limit is 8,000 characters. An accepted send means the Gateway
+accepted the work; watch the session for the result. If a send's outcome is
+unknown, check the session before sending again. The plugin does not retry
+uncertain sends automatically. Drafts live in memory and do not survive a
+shell restart.
+
+**Hide previews** hides session titles, activity, and message previews. Agent
+names, models, and channels remain visible. The attention badge summarizes
+reported session activity; it is not an approval inbox. Open the dashboard to
+review approvals.
+
+## One icon with the desktop app
+
+| Running                         | Bar behavior                                                             |
+| ------------------------------- | ------------------------------------------------------------------------ |
+| Plugin only                     | The plugin shows sessions through the configured CLI.                    |
+| Desktop app only                | The desktop app shows its normal tray icon.                              |
+| Both, with matching integration | The plugin stays visible and the app hides its duplicate tray icon.      |
+| Older app without integration   | The plugin yields when it recognizes the app's session-bus registration. |
+
+While both are connected, session actions and quick prompts use the desktop
+app's selected Gateway, including remote connections. Opening a session focuses
+the existing app. If that app disconnects, the plugin shows the connection
+problem and disables sending instead of switching to a different CLI Gateway.
+
+If the Gateway changes, the plugin clears the previous session selection and
+keeps your draft. Choose **Use this Gateway** to confirm the new destination
+before sending. A prompt already submitted stays bound to its original route.
+
+Disable the plugin to restore the app's tray icon:
+
+```bash
+omarchy plugin disable openclaw.desktop
+```
+
+The app also restores its icon after the plugin stops responding. This may
+take a short interval while it detects that the plugin is gone.
+
+## Updates
+
+Update each component through the installation that owns it: the Omarchy
+updater for the shell, the desktop app's supported update flow for the app,
+and your existing OpenClaw updater for the CLI and Gateway. After updating
+the source checkout, rerun the plugin installer to update its installed copy.
+See [Updating](/install/updating) for Gateway update guidance.
+
+## Troubleshooting and support
+
+| Symptom                                    | Check                                                                                                                                                |
+| ------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| No plugin icon                             | Validate and enable the plugin using the commands above. An older running desktop app may own the visible icon.                                      |
+| Two OpenClaw icons                         | Update both the plugin and desktop app to versions with the integration. They must run in the same desktop user session.                             |
+| CLI not found                              | Check `OPENCLAW_DESKTOP_CLI`, `~/.openclaw/bin/openclaw`, or the graphical session's `PATH`. Install through your normal OpenClaw installation path. |
+| Desktop connection unavailable             | Open the desktop app and reconnect to its selected Gateway. Resolve authentication or pairing there.                                                 |
+| Sessions look stale or sending is disabled | Refresh the panel and check the connection error. The plugin retains cached results after a failed refresh.                                          |
+| A prompt may have been sent                | Open the target session and inspect its latest messages before resubmitting.                                                                         |
+
+The integration targets Omarchy 4's Quickshell environment. Other bars, older
+Omarchy releases, and other desktop sessions require their own integration;
+a passing mock-Gateway test does not establish compatibility with those hosts.
+The plugin samples Gateway activity rather than streaming every event.
+Desktop app limitations, including Wayland global shortcuts, are documented
+in the [Linux guide](/platforms/linux#quick-chat).
+
+For setup help, use [OpenClaw support](/help). For a reproducible plugin or
+handoff defect, file an [OpenClaw bug report](https://github.com/openclaw/openclaw/issues/new?template=bug_report.yml)
+with Omarchy, plugin/source, desktop app, and Gateway versions; whether the
+Gateway is local or remote; and the steps to reproduce. Remove credentials
+and private session content from logs or screenshots before sharing them.

--- a/src/cli/gateway-cli/register.option-collisions.test.ts
+++ b/src/cli/gateway-cli/register.option-collisions.test.ts
@@ -198,6 +198,17 @@ describe("gateway register option collisions", () => {
 
   it.each([
     {
+      name: "forwards the expected endpoint without overriding configured routing",
+      argv: ["gateway", "call", "chat.send", "--expect-url", "wss://gateway.example/ws", "--json"],
+      assert: () => {
+        expect(callGatewayCli).toHaveBeenCalledTimes(1);
+        const [method, opts] = firstGatewayCall();
+        expect(method).toBe("chat.send");
+        expect(opts).toMatchObject({ expectUrl: "wss://gateway.example/ws" });
+        expect(opts).not.toHaveProperty("url");
+      },
+    },
+    {
       name: "forwards --token to gateway call when parent and child option names collide",
       argv: ["gateway", "call", "health", "--token", "tok_call", "--json"],
       assert: () => {

--- a/src/cli/gateway-cli/register.ts
+++ b/src/cli/gateway-cli/register.ts
@@ -490,6 +490,10 @@ export function registerGatewayCli(program: Command, deps: GatewayCliDependencie
       .command("call")
       .description("Call a Gateway method")
       .argument("<method>", "Method name (health/status/system-presence/cron.*)")
+      .option(
+        "--expect-url <url>",
+        "Fail if the resolved Gateway URL differs; preserves configured authentication",
+      )
       .option("--params <json>", "JSON object string for params", "{}")
       .action(async (method, opts, command) => {
         await runGatewayCommand(

--- a/src/cli/gateway-rpc.runtime.test.ts
+++ b/src/cli/gateway-rpc.runtime.test.ts
@@ -84,7 +84,7 @@ describe("callGatewayFromCliRuntime", () => {
     const config = { gateway: { mode: "local" as const } };
     await callGatewayFromCliRuntime(
       "node.list",
-      { config, localPortOverride: 19_083 },
+      { config, localPortOverride: 19_083, expectUrl: "ws://127.0.0.1:19083" },
       {},
       {
         timeoutMs: null,
@@ -99,6 +99,7 @@ describe("callGatewayFromCliRuntime", () => {
       expect.objectContaining({
         config,
         localPortOverride: 19_083,
+        expectUrl: "ws://127.0.0.1:19083",
         timeoutMs: null,
         scopes: ["operator.read", "operator.pairing"],
         useStoredDeviceAuth: true,

--- a/src/cli/gateway-rpc.runtime.ts
+++ b/src/cli/gateway-rpc.runtime.ts
@@ -76,6 +76,7 @@ export async function callGatewayFromCliRuntime<T = Record<string, unknown>>(
       await callGateway<T>({
         config: opts.config,
         url: opts.url,
+        expectUrl: opts.expectUrl,
         token: opts.token,
         password: opts.password,
         method,

--- a/src/cli/gateway-rpc.types.ts
+++ b/src/cli/gateway-rpc.types.ts
@@ -2,6 +2,7 @@
 /** Common gateway RPC flags accepted by direct gateway command helpers. */
 export type GatewayRpcOpts = {
   url?: string;
+  expectUrl?: string;
   port?: string;
   token?: string;
   password?: string;

--- a/src/gateway/call.test.ts
+++ b/src/gateway/call.test.ts
@@ -421,6 +421,77 @@ describe("callGateway url resolution", () => {
     resetGatewayCallMocks();
   });
 
+  it.each(["local config", "remote config", "environment"])(
+    "binds an observed %s endpoint without replacing its authentication",
+    async (source) => {
+      setGatewayNetworkDefaults();
+      const expected =
+        source === "local config" ? "ws://127.0.0.1:18789" : "wss://gateway.example/ws";
+      if (source === "local config") {
+        setGatewayConfig({ mode: "local", auth: { token: "fixture-local-token" } });
+      } else {
+        setGatewayConfig({
+          mode: "remote",
+          remote: { url: expected, token: "fixture-remote-token" },
+        });
+      }
+      if (source === "environment") {
+        process.env.OPENCLAW_GATEWAY_URL = expected;
+        process.env.OPENCLAW_GATEWAY_TOKEN = "fixture-env-token";
+      }
+      await callGateway({
+        method: "chat.send",
+        params: { message: "observed destination" },
+        expectUrl: expected,
+      });
+      expect(lastClientOptions?.url).toBe(expected);
+      expect(lastClientOptions?.token).toBe(
+        source === "local config"
+          ? "fixture-local-token"
+          : source === "environment"
+            ? "fixture-env-token"
+            : "fixture-remote-token",
+      );
+
+      // The user's snapshot names the first endpoint; a later CLI invocation
+      // reloads configuration before sending its selected-session prompt.
+      if (source === "environment") {
+        process.env.OPENCLAW_GATEWAY_URL = "wss://replacement.example/ws";
+      } else {
+        setGatewayConfig({
+          mode: "remote",
+          remote: { url: "wss://replacement.example/ws", token: "fixture-replacement-token" },
+        });
+      }
+      startCalls = 0;
+      lastClientOptions = null;
+      lastRequestOptions = null;
+      await expect(
+        callGateway({
+          method: "chat.send",
+          mode: GATEWAY_CLIENT_MODES.CLI,
+          params: { message: "must not retarget" },
+          expectUrl: expected,
+        }),
+      ).rejects.toThrow("Gateway destination changed");
+      expect(startCalls).toBe(0);
+      expect(lastClientOptions).toBeNull();
+      expect(lastRequestOptions).toBeNull();
+    },
+  );
+
+  it.each(["", " "])(
+    "does not disable an explicitly empty expected endpoint (%j)",
+    async (expectUrl) => {
+      setLocalLoopbackGatewayConfig();
+      await expect(callGateway({ method: "chat.send", expectUrl })).rejects.toThrow(
+        "Gateway destination changed",
+      );
+      expect(startCalls).toBe(0);
+      expect(lastRequestOptions).toBeNull();
+    },
+  );
+
   it("classifies only the implicit configured local Gateway as local", async () => {
     setLocalLoopbackGatewayConfig();
     await expect(isImplicitLocalGatewayTarget({})).resolves.toBe(true);

--- a/src/gateway/call.ts
+++ b/src/gateway/call.ts
@@ -115,6 +115,8 @@ export type GatewayRequestFunction = <T = Record<string, unknown>>(
 
 type CallGatewayBaseOptions = {
   url?: string;
+  /** Require this resolved endpoint without overriding target selection or authentication. */
+  expectUrl?: string;
   token?: string;
   password?: string;
   tlsFingerprint?: string;
@@ -1160,6 +1162,9 @@ async function callGatewayWithScopes<T = Record<string, unknown>>(
   });
   const connectionDetails = bootstrap.connectionDetails;
   const url = bootstrap.url;
+  if (opts.expectUrl !== undefined && url !== opts.expectUrl) {
+    throw new Error("Gateway destination changed. Refresh the selected Gateway before retrying.");
+  }
   const deviceAuthScope = bootstrap.deviceAuthScope;
   const token = useStoredDeviceAuth ? undefined : bootstrap.auth.token;
   const password = useStoredDeviceAuth ? undefined : bootstrap.auth.password;


### PR DESCRIPTION
Closes #145567

## What Problem This Solves

Omarchy users need agents, sessions, and a quick prompt in their desktop bar. A separate widget and the Linux desktop app otherwise expose duplicate icons and can target different Gateways.

## Why This Change Was Made

Adds an optional Omarchy 4 plugin with a monochrome animated mascot, session activity and attention, agent filtering, and quick prompts. When the desktop app runs, its existing Gateway connection owns all requests and a short presenter lease lets the widget replace the app's tray icon. The tray returns when the widget disconnects or stops renewing. Older apps keep their tray; standalone use resolves the configured CLI.

Gateway changes preserve drafts and require destination confirmation before sending. Session identity includes its owning agent, including shared `global` keys. Uncertain sends are never retried automatically. The CLI adds `gateway call --expect-url` to reject changed destinations without overriding its configured authentication. No Gateway protocol, dependencies, or persistent state are added.

## User Impact

Users can inspect agents and recent/active sessions, continue a conversation or start one, open the existing desktop app or Quick Chat, and access updates from one bar entry. The dedicated Omarchy support page (`docs/platforms/omarchy.md`) explains installation, compatibility, updates, and troubleshooting. The plugin is installed separately from this source checkout and needs a matching desktop app for full handoff.

## Evidence

- Focused Gateway call and CLI parser/runtime tests: 221 passed. Destination-change regression fails before the endpoint assertion and passes after it.
- Real supported CLI wrapper against synthetic endpoints: matching endpoint retains configured authentication; changing configuration makes the expected-URL assertion fail before any replacement connection.
- Native build and `cargo test --locked --all-targets`: 161 passed; one existing logind live test ignored.
- Fourteen Python worker tests on private D-Bus sessions: standalone/native routing, shared global identities, stale routes, unknown sends, legacy apps, and session activation. Added to the existing Linux app CI job.
- Real compiled Tauri app with isolated HOME/private D-Bus and a synthetic Gateway: snapshots, new/existing/global prompts, correct HTTP session navigation, Quick Chat, and tray Active → Passive → Active on claim/disconnect/expiry. Actual Python worker EOF restored the native tray.
- Actual Omarchy 4 QML: inspected synthetic-data captures, keyboard prompt accepted with the correct global agent, route change retained the draft and blocked sending, and two bar instances shared one worker until the last was removed. A two-panel regression confirms only the initiating popup closes when opening the app.
- Unicode session regression: actual QML fails before the fix and passes after it; selection survives acceptance and refresh, and the follow-up prompt targets the same agent/key. The worker now supplies one opaque session identity to QML.
- Independent review: no actionable P0–P2 findings after resolving CLI route binding and EOF shutdown findings.
- `node scripts/check-changed.mjs` passed, including core/test type checks, lint, and repository guards.
- Installed plugin through its real installer; manifest and docs checks pass. Authenticated production Gateway/model execution and other desktop environments were not exercised.

The captures use synthetic agents and sessions.

![global-session](https://github.com/user-attachments/assets/1e2b024c-2f5b-41f9-b68b-6425213fd105)

![route-draft](https://github.com/user-attachments/assets/7b07e0a3-ab70-4e60-a4eb-709c455fbb2b)
