### PR TITLE
fix: reuse beta qualification for canonical changelog files

### DIFF
--- a/docs/reference/RELEASING.md
+++ b/docs/reference/RELEASING.md
@@ -84,6 +84,10 @@ under `split-changelog-release-v1` only when the complete delta:
   root `CHANGELOG.md` index.
 - Contains no other paths, other releases, renames or deletions.
 
+Beta package versions select the stable-base entry and matching record. For
+example, `2026.9.5-beta.1` uses `CHANGELOG/2026.9.5.md` and
+`CHANGELOG/records/2026.9.5.md`, as release-note generation does.
+
 Docs-source changes do not qualify for this narrow reuse policy. Historical
 root-only receipts retain `changelog-only-release-v1` and its original exact
 `CHANGELOG.md` delta; they are not relabeled as split-layout evidence. Either

--- a/scripts/full-release-validation-policy.mjs
+++ b/scripts/full-release-validation-policy.mjs
@@ -36,12 +36,19 @@ export function isSplitChangelogEvidenceDelta(paths, version) {
     return false;
   }
   try {
+    const targetVersion = version.replace(/^v/u, "");
+    const parsedVersion = parseReleaseVersion(targetVersion);
+    // Beta release notes and contribution records use the stable base section.
+    const sectionVersion =
+      parsedVersion?.channel === "beta" && parsedVersion.version === targetVersion
+        ? parsedVersion.baseVersion
+        : version;
     return (
       Array.isArray(paths) &&
       paths.length > 0 &&
       new Set(paths).size === paths.length &&
-      paths.includes(changelogEntryPath(version)) &&
-      paths.every((name) => isReleaseChangelogPath(name, { version }))
+      paths.includes(changelogEntryPath(sectionVersion)) &&
+      paths.every((name) => isReleaseChangelogPath(name, { version: sectionVersion }))
     );
   } catch {
     return false;

--- a/test/scripts/find-reusable-release-validation.test.ts
+++ b/test/scripts/find-reusable-release-validation.test.ts
@@ -158,7 +158,10 @@ function plistFor(shortVersion: string, buildVersion: string): string {
   ].join("\n");
 }
 
-function createRepo(options: { plistBuildVersion?: string } = {}, dirs = tempDirs) {
+function createRepo(
+  options: { plistBuildVersion?: string; version?: string } = {},
+  dirs = tempDirs,
+) {
   const origin = dirs.make("evidence-reuse-origin-");
   git(origin, ["init", "-q", "-b", "main"]);
   git(origin, ["config", "user.email", "test-user@example.invalid"]);
@@ -166,7 +169,7 @@ function createRepo(options: { plistBuildVersion?: string } = {}, dirs = tempDir
   git(origin, ["config", "uploadpack.allowReachableSHA1InWant", "true"]);
   writeFileSync(
     join(origin, "package.json"),
-    `${JSON.stringify({ name: "x", version: "2026.7.1" }, null, 2)}\n`,
+    `${JSON.stringify({ name: "x", version: options.version ?? "2026.7.1" }, null, 2)}\n`,
   );
   mkdirSync(join(origin, "apps/macos/Sources/OpenClaw/Resources"), { recursive: true });
   writeFileSync(
@@ -1391,42 +1394,45 @@ describe("scripts/github/find-reusable-release-validation.sh", () => {
     expect(result.stderr).toContain("is not a CHANGELOG.md-only descendant");
   });
 
-  it.each([false, true])(
-    "checks selected split release files in the shell resolver (unrelated=%s)",
-    (unrelated) => {
-      const { origin, priorSha } = createRepo();
-      mkdirSync(join(origin, "CHANGELOG"));
-      const targetSha = commitFile(
-        origin,
-        "CHANGELOG/2026.7.1.md",
-        "## 2026.7.1\n\nReleased.\n",
-        "docs: release entry",
-      );
-      const inputs = { ...DEFAULT_INPUTS, targetVersion: "2026.7.1" };
-      const record = normalizedEvidence({ targetSha: priorSha, validationInputs: inputs });
-      const fixtures = setUpFixtures([{ record, runId: "111" }]);
-      const changedPaths = [
-        "CHANGELOG/2026.7.1.md",
-        ...(unrelated ? ["CHANGELOG/2026.6.8.md"] : []),
-      ];
-      const result = runResolver({
-        ...fixtures,
-        compareBaseSha: priorSha,
-        compareFiles: changedPaths,
-        inputs,
-        repoDir: cloneHead(origin),
-        targetSha,
+  it.each([
+    { version: "2026.7.1", delta: "selected" },
+    { version: "2026.7.1", delta: "unrelated" },
+    { version: "2026.7.1-beta.1", delta: "selected" },
+    { version: "2026.7.1-beta.1", delta: "unrelated" },
+    { version: "2026.7.1-beta.1", delta: "dedicated-beta" },
+  ])("checks $version split release files in the shell resolver ($delta)", ({ version, delta }) => {
+    const { origin, priorSha } = createRepo({ version });
+    const entryVersion = delta === "dedicated-beta" ? version : "2026.7.1";
+    const entryPath = `CHANGELOG/${entryVersion}.md`;
+    const recordPath = `CHANGELOG/records/${entryVersion}.md`;
+    mkdirSync(join(origin, "CHANGELOG/records"), { recursive: true });
+    commitFile(origin, entryPath, `## ${entryVersion}\n\nReleased.\n`, "docs: release entry");
+    const targetSha = commitFile(origin, recordPath, "Contributors.\n", "docs: release record");
+    const inputs = { ...DEFAULT_INPUTS, targetVersion: version };
+    const record = normalizedEvidence({ targetSha: priorSha, validationInputs: inputs });
+    const fixtures = setUpFixtures([{ record, runId: "111" }]);
+    const changedPaths = [
+      entryPath,
+      recordPath,
+      ...(delta === "unrelated" ? ["CHANGELOG/2026.6.8.md"] : []),
+    ];
+    const result = runResolver({
+      ...fixtures,
+      compareBaseSha: priorSha,
+      compareFiles: changedPaths,
+      inputs,
+      repoDir: cloneHead(origin),
+      targetSha,
+    });
+    expect(result.status, result.stderr).toBe(0);
+    expect(parseOutput(result.stdout).reuse).toBe(delta === "selected" ? "true" : "false");
+    if (delta === "selected") {
+      expect(parseOutput(result.stdout)).toMatchObject({
+        changed_paths: JSON.stringify(changedPaths),
+        evidence_policy: "split-changelog-release-v1",
       });
-      expect(result.status, result.stderr).toBe(0);
-      expect(parseOutput(result.stdout).reuse).toBe(unrelated ? "false" : "true");
-      if (!unrelated) {
-        expect(parseOutput(result.stdout)).toMatchObject({
-          changed_paths: JSON.stringify(changedPaths),
-          evidence_policy: "split-changelog-release-v1",
-        });
-      }
-    },
-  );
+    }
+  });
 
   it("rejects a source-file rename to CHANGELOG.md", () => {
     const { origin, priorSha } = createRepo();

--- a/test/scripts/release-ci-summary.test.ts
+++ b/test/scripts/release-ci-summary.test.ts
@@ -3366,64 +3366,92 @@ describe("release CI summary child correlation", () => {
     );
   });
 
-  it("binds split changelog reuse to the selected release entry and matching record", () => {
-    const inputs = { ...rawManifest({}).validationInputs, targetVersion: "2026.9.4" };
-    const root = validateParentManifest(
-      { ...rawManifest({}), validationInputs: inputs },
-      {
-        runAttempt: 2,
-        runId: "29090000000",
-      },
-    );
-    const paths = ["CHANGELOG.md", "CHANGELOG/2026.9.4.md", "CHANGELOG/records/2026.9.4.md"];
-    const makeCurrent = (changedPaths: string[]) =>
-      validateParentManifest(
+  it.each(["2026.7.1", "2026.7.1-beta.1"])(
+    "binds %s split changelog reuse to the selected release entry and matching record",
+    (targetVersion) => {
+      const inputs = { ...rawManifest({}).validationInputs, targetVersion };
+      const root = validateParentManifest(
+        { ...rawManifest({}), validationInputs: inputs },
         {
-          ...rawManifest({
-            evidenceReuse: {
-              changedPaths,
-              evidenceSha: root.targetSha,
-              policy: "split-changelog-release-v1",
-              runId: root.runId,
-              selectedRunId: root.runId,
-            },
-            runId: "29090000001",
-            targetSha: "b".repeat(40),
-          }),
-          validationInputs: inputs,
+          runAttempt: 2,
+          runId: "29090000000",
         },
-        { runAttempt: 2, runId: "29090000001" },
       );
-    const compare = (changedPaths: string[]) => (base: string) => ({
-      files: changedPaths.map((filename) => ({ filename, status: "modified" })),
-      merge_base_commit: { sha: base },
-      status: "ahead",
-    });
-    expect(validateEvidenceReuseChain(makeCurrent(paths), root, root, compare(paths))).toBe(
-      root.targetSha,
-    );
-    for (const unrelated of [
-      "CHANGELOG/2026.8.1.md",
-      "CHANGELOG/records/2026.8.1.md",
-      "src/index.ts",
-    ]) {
-      const changedPaths = [...paths, unrelated];
+      const paths = ["CHANGELOG.md", "CHANGELOG/2026.7.1.md", "CHANGELOG/records/2026.7.1.md"];
+      const makeCurrent = (changedPaths: string[]) =>
+        validateParentManifest(
+          {
+            ...rawManifest({
+              evidenceReuse: {
+                changedPaths,
+                evidenceSha: root.targetSha,
+                policy: "split-changelog-release-v1",
+                runId: root.runId,
+                selectedRunId: root.runId,
+              },
+              runId: "29090000001",
+              targetSha: "b".repeat(40),
+            }),
+            validationInputs: inputs,
+          },
+          { runAttempt: 2, runId: "29090000001" },
+        );
+      const compare = (changedPaths: string[]) => (base: string) => ({
+        files: changedPaths.map((filename) => ({ filename, status: "modified" })),
+        merge_base_commit: { sha: base },
+        status: "ahead",
+      });
+      expect(validateEvidenceReuseChain(makeCurrent(paths), root, root, compare(paths))).toBe(
+        root.targetSha,
+      );
+      for (const unrelated of [
+        "CHANGELOG/2026.8.1.md",
+        "CHANGELOG/records/2026.8.1.md",
+        "src/index.ts",
+      ]) {
+        const changedPaths = [...paths, unrelated];
+        expect(() =>
+          validateEvidenceReuseChain(makeCurrent(changedPaths), root, root, compare(changedPaths)),
+        ).toThrow("invalid target delta");
+        expect(() =>
+          validateEvidenceReuseChain(makeCurrent(paths), root, root, compare(changedPaths)),
+        ).toThrow("failed commit comparison");
+      }
+      for (const filename of paths.slice(1)) {
+        for (const status of ["removed", "renamed"]) {
+          expect(() =>
+            validateEvidenceReuseChain(makeCurrent(paths), root, root, (base: string) => ({
+              ...compare(paths)(base),
+              files: paths.map((path) => ({
+                filename: path,
+                status: path === filename ? status : "modified",
+                previous_filename:
+                  path === filename && status === "renamed" ? "src/index.ts" : undefined,
+              })),
+            })),
+          ).toThrow("failed commit comparison");
+        }
+      }
+      if (targetVersion.endsWith("-beta.1")) {
+        const betaPaths = [
+          "CHANGELOG.md",
+          `CHANGELOG/${targetVersion}.md`,
+          `CHANGELOG/records/${targetVersion}.md`,
+        ];
+        expect(() =>
+          validateEvidenceReuseChain(makeCurrent(betaPaths), root, root, compare(betaPaths)),
+        ).toThrow("invalid target delta");
+      }
       expect(() =>
-        validateEvidenceReuseChain(makeCurrent(changedPaths), root, root, compare(changedPaths)),
+        validateEvidenceReuseChain(
+          makeCurrent(["CHANGELOG.md"]),
+          root,
+          root,
+          compare(["CHANGELOG.md"]),
+        ),
       ).toThrow("invalid target delta");
-      expect(() =>
-        validateEvidenceReuseChain(makeCurrent(paths), root, root, compare(changedPaths)),
-      ).toThrow("failed commit comparison");
-    }
-    expect(() =>
-      validateEvidenceReuseChain(
-        makeCurrent(["CHANGELOG.md"]),
-        root,
-        root,
-        compare(["CHANGELOG.md"]),
-      ),
-    ).toThrow("invalid target delta");
-  });
+    },
+  );
 
   it("rejects exact-target reuse without matching root policy and authorization", () => {
     const root = validateParentManifest(rawManifest({}), {


### PR DESCRIPTION
Related: #145464

## What Problem This Solves

Fixes an issue where release operators could not reuse product qualification for a beta release whose only changes were its canonical changelog entry and contribution record. A beta such as `2026.9.5-beta.1` was matched against beta-suffixed filenames even though release generation and rendering use `2026.9.5`.

## Why This Change Was Made

Select the stable-base entry and matching record for beta versions in the shared evidence-reuse policy. Both the shell finder and receipt validator consume that policy. Historical changelog filenames and stable, alpha, and correction selection remain unchanged.

This addresses the beta-selection review finding on #145464 after its merge and preserves Hannes Rudolph's split changelog design.

## User Impact

Beta release qualification can reuse valid product evidence after canonical notes-only changes. Unrelated releases, source changes, renames, deletions, and dedicated beta entries remain ineligible; final package and image bytes still require their own qualification.

## Evidence

- Reproduced three failures on the original code: the shell finder rejected canonical beta files, accepted dedicated beta files, and the receipt validator rejected a canonical beta receipt.
- All 230 tests pass across the shell finder, receipt validator, and GitHub release-note renderer after the shared policy fix.
- Regression coverage includes matching records, unrelated files, deleted/renamed files, and rejection of beta-suffixed entry/record pairs.
- Changed-file gates passed for formatting, types, script lint, unused exports, and repository guards; the test-fixture lint finding was fixed and its scoped lint and receipt regression tests passed on rerun.
- Independent Codex review found no actionable correctness issues.
- [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34673293589) passed on its first attempt at `6b7580a7b6b25cdce86a97ccaeaf213b2c1d9c32`, including the required gate.
