### PR TITLE
refactor: streamline updater test setup and coverage

### DIFF
--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -6803,24 +6803,6 @@ describe("update-cli", () => {
     );
   });
 
-  it("parses update status --json as the subcommand option", async () => {
-    const program = new Command();
-    program.name("openclaw");
-    program.enablePositionalOptions();
-    let seenJson = false;
-    const update = program.command("update").option("--json", "", false);
-    update
-      .command("status")
-      .option("--json", "", false)
-      .action((opts) => {
-        seenJson = Boolean(opts.json);
-      });
-
-    await program.parseAsync(["node", "openclaw", "update", "status", "--json"]);
-
-    expect(seenJson).toBe(true);
-  });
-
   it.each([
     {
       name: "defaults to dev channel for git installs when unset",
@@ -12852,15 +12834,6 @@ describe("update-cli", () => {
       name: "uses the installed Git CLI when service env refresh cannot complete",
       run: async () => {
         await runRestartFallbackScenario({ daemonInstall: "fail" });
-      },
-      assert: () => {
-        expectNoSideEffects(runDaemonInstall, runDaemonRestart);
-      },
-    },
-    {
-      name: "uses the installed Git CLI after service env refresh succeeds",
-      run: async () => {
-        await runRestartFallbackScenario({ daemonInstall: "ok" });
       },
       assert: () => {
         expectNoSideEffects(runDaemonInstall, runDaemonRestart);

--- a/src/cli/update-cli/update-command-legacy-finalize.test.ts
+++ b/src/cli/update-cli/update-command-legacy-finalize.test.ts
@@ -4,11 +4,13 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { afterEach, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import { resolveRuntimeWorkerUrl } from "../../infra/runtime-worker-url.js";
 import { resolvePreferredOpenClawTmpDir } from "../../infra/tmp-openclaw-dir.js";
 import { createManagedHandoffLeaseStore } from "../../infra/update-managed-service-handoff-lease.js";
 import { createUpdateRun, getUpdateRun } from "../../infra/update-run-ledger.js";
 import { runUtf8CommandWithTimeout } from "../../process/exec.js";
 import { closeOpenClawStateDatabase } from "../../state/openclaw-state-db.js";
+import { updateExecutorNativeEntrypoints } from "./update-command-executor-native-runtime.test-support.js";
 
 const dirs = useAutoCleanupTempDirTracker(afterEach);
 afterEach(() => closeOpenClawStateDatabase());
@@ -100,15 +102,16 @@ it.each([
     };
     const entry = path.join(scratch, "native-entry.mjs");
     const loader = path.resolve("scripts/tsx.mjs");
-    const owner = new URL("../daemon-cli/update-executor.ts", import.meta.url).href;
-    const exec = new URL("../../daemon/exec-file.ts", import.meta.url).href;
+    // Both receiver imports share the same graph and service-authority scope.
+    const owner = resolveRuntimeWorkerUrl(updateExecutorNativeEntrypoints.nativeExecutor);
+    const exec = resolveRuntimeWorkerUrl(updateExecutorNativeEntrypoints.nativeExec).href;
     fs.writeFileSync(
       entry,
       `
-      await import(${JSON.stringify(loader)});
+      ${owner.pathname.endsWith(".ts") ? `await import(${JSON.stringify(loader)});` : ""}
       const fs=await import("node:fs");
       const {DatabaseSync}=await import("node:sqlite");
-      const {runGatewayServiceUpdateCommand}=await import(${JSON.stringify(owner)});
+      const {runGatewayServiceUpdateCommand}=await import(${JSON.stringify(owner.href)});
       const {execFileUtf8}=await import(${JSON.stringify(exec)});
       const mode=process.argv[process.argv.indexOf("--update-executor")+1];
       await runGatewayServiceUpdateCommand(mode,"restart",async()=>{


### PR DESCRIPTION
## What Problem This Solves

Updater tests repeated an installed-service refresh scenario already covered by stronger assertions, and a local Commander self-test bypassed the real OpenClaw registration. Legacy finalization also loaded source TypeScript in fresh native receiver processes despite existing prepared runtime entries.

## Why This Change Was Made

Reuse the existing native receiver and native execution descriptors from the same prepared graph, preserving their shared service-authority scope. Standalone/watch retains the original source loader; the finalizer's source loader and fixture hook remain unchanged.

Delete the weaker duplicate service-refresh row and the toy parser case. The stronger installed-service assertions and real registered `update status --json` forwarding coverage remain, along with the distinct failure, no-restart, and no-success cases.

## User Impact

No production behavior changes. This removes redundant test work and reuses the existing receiver runtime without changing compiler inventory, authority checks, mocks, state isolation, or deadlines. Production LOC delta: 0; tests: 7 added / 31 removed (net −24).

## Evidence

- All ten original legacy-finalization scenarios passed before and after the receiver change in their original order, with matching inventory/status digests and joined process cleanup.
- All four retained service-refresh rows and the complete 73-case real-registration option-collision suite passed in one targeted run.
- Source-mode resolution produces the original receiver/exec module URLs and retains the original bootstrap.
- Final combined scoped checks passed; independent P2 review completed both passes with no actionable findings.

The receiver-only local pair measured 140.194s → 133.082s wrapper time and 127.386s → 122.869s summed case time. Some receiver cases improved, but unchanged incumbent controls also slowed substantially, so this is a modest observation rather than a stable speedup claim. The two deleted cells accounted for 1.731s of summed case time in the retained main CI log; that is not an end-to-end saving measurement. No whole-shard or eight-minute CI claim is made.
