### PR TITLE
fix(net): propagate Bun response aborts through Undici

### DIFF
--- a/src/infra/net/fetch-guard.release.test.ts
+++ b/src/infra/net/fetch-guard.release.test.ts
@@ -44,7 +44,7 @@ describe("guarded request release", () => {
         captures.set(new URL(url).pathname, captured);
         const response = await fetchWithRuntimeDispatcher(input, init);
         captureHttpExchange(
-          { url, method: "GET", response },
+          { url, method: "GET", response, signal: init?.signal ?? undefined },
           {
             enabled: true,
             required: false,
@@ -186,9 +186,18 @@ describe("guarded request release", () => {
             const completed = await get("/complete");
             expect(completed.dispatcherReused).toBe(true);
             expect(dispatchers[2]).toBe(dispatchers[0]);
-            expect((await readResponseWithLimit(completed.response, 32)).toString("utf8")).toBe(
-              "complete",
-            );
+            const completedClone = completed.response.clone();
+            expect(completedClone.url).toBe(completed.response.url);
+            expect(completedClone.redirected).toBe(completed.response.redirected);
+            expect(completedClone.type).toBe(completed.response.type);
+            expect(() => completed.response.headers.set("x-openclaw-test", "1")).toThrow();
+            expect(() => completedClone.headers.set("x-openclaw-test", "1")).toThrow();
+            const [completedBody, completedCloneBody] = await Promise.all([
+              readResponseWithLimit(completed.response, 32),
+              readResponseWithLimit(completedClone, 32),
+            ]);
+            expect(completedBody.toString("utf8")).toBe("complete");
+            expect(completedCloneBody.toString("utf8")).toBe("complete");
             await completed.release();
             expect(await withinDeadline(captures.get("/complete")!.promise)).toMatchObject({
               kind: "response",

--- a/src/infra/net/fetch-guard.ts
+++ b/src/infra/net/fetch-guard.ts
@@ -660,7 +660,7 @@ async function fetchWithSsrFGuardInternal(
       const captureParams = {
         url: parsedUrl.toString(),
         method: currentInit?.method ?? "GET",
-        signal: init.signal ?? undefined,
+        signal: process.versions.bun ? (init.signal ?? undefined) : undefined,
         requestHeaders: currentInit?.headers as Headers | Record<string, string> | undefined,
         requestBody:
           (currentInit as (RequestInit & { body?: BodyInit | null }) | undefined)?.body ?? null,

--- a/src/infra/net/fetch-guard.ts
+++ b/src/infra/net/fetch-guard.ts
@@ -14,6 +14,7 @@ import {
   shouldResolveConfiguredLocalOriginManagedProxyBypass,
   type ConfiguredLocalOriginManagedProxyBypass,
 } from "./configured-local-origin-bypass.js";
+import { responseWithAbortSignal } from "./guarded-body-stream.js";
 import { PinnedDispatcherPool, type PinnedDispatcherLease } from "./pinned-dispatcher-pool.js";
 import { shouldUseEnvHttpProxyForUrl } from "./proxy-env.js";
 import { retainSafeHeadersForCrossOriginRedirect as retainSafeRedirectHeaders } from "./redirect-headers.js";
@@ -659,6 +660,7 @@ async function fetchWithSsrFGuardInternal(
       const captureParams = {
         url: parsedUrl.toString(),
         method: currentInit?.method ?? "GET",
+        signal: init.signal ?? undefined,
         requestHeaders: currentInit?.headers as Headers | Record<string, string> | undefined,
         requestBody:
           (currentInit as (RequestInit & { body?: BodyInit | null }) | undefined)?.body ?? null,
@@ -722,8 +724,15 @@ async function fetchWithSsrFGuardInternal(
         continue;
       }
 
+      // oxlint-disable-next-line no-warning-comments -- removal awaits an upstream Bun runtime fix.
+      // TODO: Remove this wrapper once Bun propagates post-header aborts through
+      // installed Undici response and clone body streams.
+      const returnedResponse =
+        process.versions.bun && !(response instanceof Response)
+          ? responseWithAbortSignal(response, init.signal ?? undefined)
+          : response;
       return {
-        response,
+        response: returnedResponse,
         finalUrl: currentUrl,
         release: async () => finishRequest(releaseDispatcher),
         refreshTimeout: refresh,

--- a/src/infra/net/guarded-body-stream.test.ts
+++ b/src/infra/net/guarded-body-stream.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { createDeferredCore } from "../../shared/deferred.js";
+import { readResponseWithLimit } from "../http-body.js";
 import { responseWithAbortSignal, wrapGuardedBodyStream } from "./guarded-body-stream.js";
 
 describe("wrapGuardedBodyStream", () => {
@@ -138,7 +139,7 @@ describe("responseWithAbortSignal", () => {
     expect(clone.url).toBe("https://example.test/final");
     expect(clone.redirected).toBe(true);
     expect(clone.type).toBe("cors");
-    expect(await clone.text()).toBe("payload");
+    expect((await readResponseWithLimit(clone, 32)).toString("utf8")).toBe("payload");
     await wrapped.body?.cancel();
   });
 

--- a/src/infra/net/guarded-body-stream.test.ts
+++ b/src/infra/net/guarded-body-stream.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { createDeferredCore } from "../../shared/deferred.js";
-import { wrapGuardedBodyStream } from "./guarded-body-stream.js";
+import { responseWithAbortSignal, wrapGuardedBodyStream } from "./guarded-body-stream.js";
 
 describe("wrapGuardedBodyStream", () => {
   it("releases the source reader lock after downstream cancellation", async () => {
@@ -121,5 +121,44 @@ describe("wrapGuardedBodyStream", () => {
 
     expect(cleanup).toHaveBeenCalledOnce();
     expect(source.locked).toBe(false);
+  });
+});
+
+describe("responseWithAbortSignal", () => {
+  it("preserves response metadata across clones", async () => {
+    const source = new Response("payload");
+    Object.defineProperties(source, {
+      url: { value: "https://example.test/final" },
+      redirected: { value: true },
+      type: { value: "cors" },
+    });
+    const wrapped = responseWithAbortSignal(source, new AbortController().signal);
+    const clone = wrapped.clone();
+
+    expect(clone.url).toBe("https://example.test/final");
+    expect(clone.redirected).toBe(true);
+    expect(clone.type).toBe("cors");
+    expect(await clone.text()).toBe("payload");
+    await wrapped.body?.cancel();
+  });
+
+  it("attaches the abort listener only when body consumption starts", async () => {
+    const controller = new AbortController();
+    const addEventListener = vi.spyOn(controller.signal, "addEventListener");
+    const wrapped = responseWithAbortSignal(
+      new Response(new ReadableStream<Uint8Array>()),
+      controller.signal,
+    );
+
+    expect(addEventListener).not.toHaveBeenCalled();
+    const reader = wrapped.body!.getReader();
+    const read = reader.read();
+    await vi.waitFor(() =>
+      expect(addEventListener).toHaveBeenCalledWith("abort", expect.any(Function), { once: true }),
+    );
+    const reason = new Error("caller stopped");
+    controller.abort(reason);
+    await expect(read).rejects.toBe(reason);
+    reader.releaseLock();
   });
 });

--- a/src/infra/net/guarded-body-stream.ts
+++ b/src/infra/net/guarded-body-stream.ts
@@ -11,10 +11,17 @@ const guardedBodyCleanupRegistry = new FinalizationRegistry<{ finalize: () => Pr
   },
 );
 
+type BodyAbortOwner = { abort: () => void };
+
+// A live body owns its abort callback. The signal listener keeps only a weak
+// reference so a partially read, abandoned body can still reach finalization.
+const guardedBodyAbortOwners = new WeakMap<ReadableStream<Uint8Array>, BodyAbortOwner>();
+
 type BodyStreamOptions = {
   body: ReadableStream<Uint8Array>;
   cleanup: () => Promise<void> | void;
   refreshTimeout?: () => void;
+  signal?: AbortSignal;
 };
 
 function wrapBodyStream(
@@ -23,6 +30,8 @@ function wrapBodyStream(
 ): ReadableStream<Uint8Array> {
   let reader: ReadableStreamDefaultReader<Uint8Array> | undefined;
   let finalized = false;
+  let abortAttached = false;
+  let detachAbort = () => {};
   const cleanupRegistrationToken = {};
   const finalize = async (
     cancelReader: () => Promise<void> = async () => {
@@ -33,6 +42,7 @@ function wrapBodyStream(
       return;
     }
     finalized = true;
+    detachAbort();
     guardedBodyCleanupRegistry.unregister(cleanupRegistrationToken);
     // Start cancellation before cleanup so its reason reaches the reader, but
     // let request cleanup abort a retained capture tee before awaiting settlement.
@@ -51,34 +61,68 @@ function wrapBodyStream(
       throw cancellation.reason;
     }
   };
-  const wrappedBody = new ReadableStream<Uint8Array>({
-    start() {
-      reader = params.body.getReader();
-    },
-    async pull(controller) {
-      try {
-        const chunk = await reader?.read();
-        if (!chunk || chunk.done) {
-          controller.close();
-          await finalize();
+  const wrappedBody = new ReadableStream<Uint8Array>(
+    {
+      start() {
+        reader = params.body.getReader();
+      },
+      async pull(controller) {
+        const signal = params.signal;
+        if (signal && !abortAttached) {
+          abortAttached = true;
+          const owner: BodyAbortOwner = {
+            abort: () => {
+              if (finalized) {
+                return;
+              }
+              const reason =
+                signal.reason ?? new DOMException("This operation was aborted", "AbortError");
+              const cleanup = finalize(async () => await reader?.cancel(reason));
+              controller.error(reason);
+              void cleanup.catch(() => undefined);
+            },
+          };
+          guardedBodyAbortOwners.set(wrappedBody, owner);
+          const ownerRef = new WeakRef(owner);
+          const abort = () => ownerRef.deref()?.abort();
+          if (signal.aborted) {
+            abort();
+          } else {
+            signal.addEventListener("abort", abort, { once: true });
+            detachAbort = () => signal.removeEventListener("abort", abort);
+          }
+        }
+        if (finalized) {
           return;
         }
-        params.refreshTimeout?.();
-        controller.enqueue(chunk.value);
-      } catch (error) {
-        // The SDK response contract exposes release failures; guarded streams
-        // report the source failure immediately and release resources best-effort.
-        if (errorSource === "release") {
+        try {
+          const chunk = await reader?.read();
+          if (!chunk || chunk.done) {
+            controller.close();
+            await finalize();
+            return;
+          }
+          params.refreshTimeout?.();
+          controller.enqueue(chunk.value);
+        } catch (error) {
+          if (finalized) {
+            return;
+          }
+          // The SDK response contract exposes release failures; guarded streams
+          // report the source failure immediately and release resources best-effort.
+          if (errorSource === "release") {
+            await finalize();
+          }
+          controller.error(error);
           await finalize();
         }
-        controller.error(error);
-        await finalize();
-      }
+      },
+      async cancel(reason) {
+        await finalize(async () => await reader?.cancel(reason));
+      },
     },
-    async cancel(reason) {
-      await finalize(async () => await reader?.cancel(reason));
-    },
-  });
+    params.signal ? { highWaterMark: 0 } : undefined,
+  );
   guardedBodyCleanupRegistry.register(wrappedBody, { finalize }, cleanupRegistrationToken);
   return wrappedBody;
 }
@@ -86,6 +130,36 @@ function wrapBodyStream(
 /** Wraps a guarded body with best-effort cleanup and explicit cancellation errors. */
 export function wrapGuardedBodyStream(params: BodyStreamOptions): ReadableStream<Uint8Array> {
   return wrapBodyStream(params, "cancellation");
+}
+
+/** Preserves post-header request cancellation around runtime fetch body streams. */
+export function responseWithAbortSignal(response: Response, signal?: AbortSignal): Response {
+  if (!response.body || !signal) {
+    return response;
+  }
+  const wrapped = new Response(
+    wrapBodyStream({ body: response.body, cleanup: () => {}, signal }, "cancellation"),
+    {
+      status: response.status,
+      statusText: response.statusText,
+      headers: response.headers,
+    },
+  );
+  const applyMetadata = (target: Response): Response => {
+    Object.defineProperties(target, {
+      headers: { value: response.headers },
+      url: { value: response.url },
+      redirected: { value: response.redirected },
+      type: { value: response.type },
+      clone: {
+        configurable: true,
+        value: (): Response => applyMetadata(Response.prototype.clone.call(target)),
+        writable: true,
+      },
+    });
+    return target;
+  };
+  return applyMetadata(wrapped);
 }
 
 const NULL_BODY_STATUSES = new Set([101, 103, 204, 205, 304]);

--- a/src/proxy-capture/runtime.ts
+++ b/src/proxy-capture/runtime.ts
@@ -79,12 +79,14 @@ function readCapturedResponseBodyBounded(
   maxBytes: number,
   owner: CaptureOwner,
   record: (result: CapturedResponseBodyResult) => void,
+  signal?: AbortSignal,
 ): void {
   let reader: ReadableStreamDefaultReader<Uint8Array> | undefined;
   let chunks: Buffer[] = [];
   let total = 0;
   let finished = false;
   let canceled = false;
+  let detachAbort = () => {};
   const cancel = (reason?: unknown) => {
     if (!reader || canceled) {
       return;
@@ -109,6 +111,7 @@ function readCapturedResponseBodyBounded(
       return;
     }
     finished = true;
+    detachAbort();
     owner.pending.delete(finalize);
     try {
       if (owner.store.isClosed) {
@@ -126,6 +129,32 @@ function readCapturedResponseBodyBounded(
   };
   const finalize = () => finish({ status: "finalized", buffer: Buffer.concat(chunks, total) });
   owner.pending.add(finalize);
+  if (signal) {
+    const onAbort = () => {
+      queueMicrotask(() => {
+        if (finished) {
+          return;
+        }
+        finish({
+          status: "failed",
+          buffer: Buffer.concat(chunks, total),
+          error:
+            signal.reason instanceof Error
+              ? signal.reason
+              : new Error("Response capture aborted", { cause: signal.reason }),
+        });
+      });
+    };
+    if (signal.aborted) {
+      onAbort();
+    } else {
+      signal.addEventListener("abort", onAbort, { once: true });
+      detachAbort = () => signal.removeEventListener("abort", onAbort);
+    }
+  }
+  if (finished) {
+    return;
+  }
   void (async () => {
     try {
       const clone = response.clone();
@@ -462,6 +491,7 @@ type HttpCaptureParams = {
   requestHeaders?: HeadersLike | Record<string, string> | undefined;
   requestBody?: BodyInit | Buffer | string | null;
   response: Response;
+  signal?: AbortSignal;
   transport?: "http" | "sse";
   flowId?: string;
   meta?: Record<string, unknown>;
@@ -658,6 +688,7 @@ function captureOwnedHttpExchange(params: HttpCaptureParams, owner: CaptureOwner
     MAX_CAPTURED_RESPONSE_BODY_BYTES,
     owner,
     recordTerminal,
+    params.signal,
   );
 }
 

--- a/src/proxy-capture/runtime.ts
+++ b/src/proxy-capture/runtime.ts
@@ -131,7 +131,9 @@ function readCapturedResponseBodyBounded(
   owner.pending.add(finalize);
   if (signal) {
     const onAbort = () => {
-      queueMicrotask(() => {
+      // Bun can deliver the caller's abort in the same turn as a clean body
+      // EOF. Give the pending stream read one poll turn to record that EOF.
+      setTimeout(() => {
         if (finished) {
           return;
         }
@@ -143,7 +145,7 @@ function readCapturedResponseBodyBounded(
               ? signal.reason
               : new Error("Response capture aborted", { cause: signal.reason }),
         });
-      });
+      }, 0);
     };
     if (signal.aborted) {
       onAbort();

--- a/test/scripts/lint-suppressions.test.ts
+++ b/test/scripts/lint-suppressions.test.ts
@@ -232,6 +232,7 @@ describe("production lint suppressions", () => {
         "src/infra/device-pairing-store.ts|typescript/no-unnecessary-type-parameters|1",
         "src/infra/exec-approvals-effective.ts|typescript/no-unnecessary-type-parameters|1",
         "src/infra/json-file.ts|typescript-eslint/no-unnecessary-type-parameters|1",
+        "src/infra/net/fetch-guard.ts|no-warning-comments|1",
         // Undici invokes its method-shaped clientFactory callback without an options receiver.
         "src/infra/net/undici-dispatcher-options.ts|typescript/unbound-method|1",
         // NUL delimiters identify protected code spans without colliding with escaped user text.


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Bun-hosted guarded requests using the installed Undici runtime could hang after response headers: aborting the request closed the socket, but the caller body and diagnostic `Response.clone()` branch did not receive the abort. This retained capture ownership and made guarded release tests time out.

## Why This Change Was Made

Guarded fetches now wrap only foreign installed-Undici responses under Bun with an abort-aware body stream, while preserving URL, redirect/type metadata, clone behavior, and immutable network headers. Under Bun, the diagnostic capture shares the owning request signal and waits one poll turn before treating an abort as failure so an already-buffered clean EOF can win. Weak abort ownership lets partially read abandoned bodies reach finalization, and the TODO records removal once Bun propagates these aborts natively.

The related Bun stream-state defect that prevented installed Undici from surfacing forced socket errors is fixed separately in oven-sh/bun#42416 and is present in the custom runtime used for the Bun proof.

## User Impact

Bun-hosted provider and guarded HTTP streams now settle promptly on cancellation without changing Node behavior, leaking capture readers, mutating fetch headers, or breaking cloned-response metadata.

## Evidence

- Before the fix, the unread guarded-release case timed out after 120 seconds under direct Bun; parent-signal cases also failed to settle.
- Direct custom-Bun and Node guarded release suites: 10/10 each.
- Direct custom-Bun and Node capture ownership/lifecycle suites: 34/34 each.
- Direct custom-Bun and Node guarded body stream regressions: 7/7 each.
- Direct custom-Bun and Node provider capture lifecycle modes: 6/6 each, including clean partial EOF and forced transport failure.
- The full direct-Bun unit-fast shard reaches completion with 20,067 tests passing; its remaining failures are tracked in separate HTTP, PTY, retention, MCP, context-engine, and WebSocket clusters.
- `pnpm check:changed`: passed.
- Independent P0-P2 autoreview: scoped clean at 0.90 confidence after resolving the Node EOF and Bun poll-turn races.
