### PR TITLE
refactor(voice): reduce GPT-Live support duplication

### DIFF
--- a/extensions/google/realtime-voice-lazy.ts
+++ b/extensions/google/realtime-voice-lazy.ts
@@ -97,10 +97,7 @@ function createLazyGoogleRealtimeVoiceBridge(
     };
   // Loading and connecting finish on separate async boundaries. Keep close ownership
   // here so either late completion closes the provider bridge exactly once.
-  const closeBridge = (loadedBridge = bridge): void | Promise<void> => {
-    if (!loadedBridge) {
-      return;
-    }
+  const closeBridge = (loadedBridge: RealtimeVoiceBridge): void | Promise<void> => {
     if (closedBridges.has(loadedBridge)) {
       return closedBridges.get(loadedBridge);
     }

--- a/extensions/openai/realtime-live-api.test.ts
+++ b/extensions/openai/realtime-live-api.test.ts
@@ -1,3 +1,4 @@
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import type { RealtimeVoiceGatewayControl } from "openclaw/plugin-sdk/realtime-voice";
 import { describe, expect, it, vi } from "vitest";
 import {
@@ -320,12 +321,9 @@ describe("public GPT-Live WebRTC broker", () => {
   );
 
   it("hangs up a session allocated after cancellation without attaching its sideband", async () => {
-    let finishCreation!: (response: Response) => void;
-    const creation = new Promise<Response>((resolve) => {
-      finishCreation = resolve;
-    });
+    const creation = createDeferred<Response>();
     const fetchImpl = vi.fn<typeof fetch>(async (url) =>
-      url === HANGUP_URL ? new Response(null, { status: 204 }) : creation,
+      url === HANGUP_URL ? new Response(null, { status: 204 }) : creation.promise,
     );
     const fixture = createBroker({ fetchImpl });
     try {
@@ -338,7 +336,7 @@ describe("public GPT-Live WebRTC broker", () => {
       await vi.waitFor(() => expect(fetchImpl).toHaveBeenCalledOnce());
       const canceling = fixture.realtime.broker.cancelBrowserSession(reservation);
       expect(fetchImpl.mock.calls[0]?.[1]?.signal?.aborted).toBe(true);
-      finishCreation(liveResponse());
+      creation.resolve(liveResponse());
       await Promise.all([handling, canceling]);
 
       expect(response.res.statusCode).toBe(502);
@@ -354,7 +352,7 @@ describe("public GPT-Live WebRTC broker", () => {
         reservations: 0,
       });
     } finally {
-      finishCreation(liveResponse());
+      creation.resolve(liveResponse());
       await fixture.realtime.cleanup();
     }
   });

--- a/extensions/openai/realtime-quicksilver-bridge.test-support.ts
+++ b/extensions/openai/realtime-quicksilver-bridge.test-support.ts
@@ -82,18 +82,12 @@ export function createHarness(params?: {
   const socket = new FakeSocket(params?.autoStart, params?.afterOpen);
   socket.deferClose = params?.deferClose ?? false;
   const connections: Array<{ url: string; options: ClientOptions }> = [];
-  const webSocketFactory: OpenAIQuicksilverSocketFactory = (url, options) => {
+  const webSocketFactory: OpenAIQuicksilverSocketFactory = function (url, options) {
     connections.push({ url, options });
     queueMicrotask(() => socket.open());
     return socket;
   };
-  if (params?.mockDefaultSocket) {
-    params.mockDefaultSocket.mockImplementation(function (url: string, options: ClientOptions) {
-      connections.push({ url, options });
-      queueMicrotask(() => socket.open());
-      return socket;
-    });
-  }
+  params?.mockDefaultSocket?.mockImplementation(webSocketFactory);
   const onAudio: Mock<RealtimeVoiceBridgeCallbacks["onAudio"]> = vi.fn();
   const onClearAudio: Mock<RealtimeVoiceBridgeCallbacks["onClearAudio"]> = vi.fn();
   const onTranscript: Mock<NonNullable<RealtimeVoiceBridgeCallbacks["onTranscript"]>> = vi.fn();

--- a/extensions/openai/realtime-quicksilver-bridge.test.ts
+++ b/extensions/openai/realtime-quicksilver-bridge.test.ts
@@ -22,7 +22,6 @@ import {
   FakeSocket,
   sentEvents,
 } from "./realtime-quicksilver-bridge.test-support.js";
-import type { OpenAIQuicksilverSocket } from "./realtime-quicksilver-sideband.js";
 
 describe("OpenAIQuicksilverVoiceBridge", () => {
   it("connects directly to /v1/live and completes the Frameless Bidi handshake", async () => {
@@ -525,7 +524,7 @@ describe("OpenAIQuicksilverVoiceBridge", () => {
           const socket = new FakeSocket(false);
           sockets.push(socket);
           queueMicrotask(() => socket.open());
-          return socket as unknown as OpenAIQuicksilverSocket;
+          return socket;
         },
         onAudio: vi.fn(),
         onClearAudio: vi.fn(),

--- a/extensions/openai/realtime-quicksilver-bridge.ts
+++ b/extensions/openai/realtime-quicksilver-bridge.ts
@@ -132,10 +132,9 @@ export class OpenAIQuicksilverVoiceBridge implements RealtimeVoiceBridge {
         dispatch: (id, input) => this.startDelegation(id, input, connection),
         onExpired: (id) =>
           this.sendContext(
-            "delegation.context.append",
-            id,
             "Ask the user to repeat their request; no user transcript was received.",
             "speakable",
+            id,
           ),
         onError: (error) => this.fail(connection, error),
       });
@@ -324,16 +323,11 @@ export class OpenAIQuicksilverVoiceBridge implements RealtimeVoiceBridge {
 
   sendUserMessage(text: string): void {
     const channel = isOpenAIGptLiveApiModel(this.config.model) ? "speakable" : undefined;
-    this.sendContext("session.context.append", undefined, text, channel);
+    this.sendContext(text, channel);
   }
 
   triggerGreeting(instructions?: string): void {
-    this.sendContext(
-      "session.context.append",
-      undefined,
-      instructions ?? "Greet the user briefly.",
-      "speakable",
-    );
+    this.sendContext(instructions ?? "Greet the user briefly.", "speakable");
   }
 
   submitToolResult(
@@ -343,13 +337,11 @@ export class OpenAIQuicksilverVoiceBridge implements RealtimeVoiceBridge {
   ): void {
     const channel = options?.suppressResponse || options?.willContinue ? "commentary" : "speakable";
     const isDelegation = this.activeDelegations.has(callId);
-    const type = isDelegation ? "delegation.context.append" : "session.context.append";
     const text = openAIQuicksilverToolResultText(result);
     this.sendContext(
-      type,
-      isDelegation ? callId : undefined,
       isDelegation ? boundOpenAIQuicksilverDelegationResult(text) : text,
       channel,
+      isDelegation ? callId : undefined,
     );
     if (!options?.willContinue) {
       this.activeDelegations.delete(callId);
@@ -579,8 +571,7 @@ export class OpenAIQuicksilverVoiceBridge implements RealtimeVoiceBridge {
       activeDelegations: this.activeDelegations,
       isActive: () => this.lifecycle.acceptsEvents(connection),
       isCurrent: () => this.lifecycle.isCurrent(connection),
-      sendReply: (message) =>
-        this.sendContext("delegation.context.append", id, message, "speakable"),
+      sendReply: (message) => this.sendContext(message, "speakable", id),
       onError: (error) => this.fail(connection, error),
     });
   }
@@ -597,10 +588,9 @@ export class OpenAIQuicksilverVoiceBridge implements RealtimeVoiceBridge {
   }
 
   private sendContext(
-    type: "delegation.context.append" | "session.context.append",
-    delegationItemId: string | undefined,
     text: string,
     channel?: "speakable" | "commentary",
+    delegationId?: string,
   ): void {
     if (this.lifecycle.phase() === "terminal") {
       return;
@@ -611,7 +601,7 @@ export class OpenAIQuicksilverVoiceBridge implements RealtimeVoiceBridge {
           model: this.config.model,
           text: chunk,
           channel,
-          delegationId: type === "delegation.context.append" ? delegationItemId : undefined,
+          delegationId,
         }),
       );
     }

--- a/extensions/openai/realtime-quicksilver-delegation-controller.ts
+++ b/extensions/openai/realtime-quicksilver-delegation-controller.ts
@@ -136,9 +136,9 @@ export class OpenAIQuicksilverDelegationController {
         dispatch: (id, input) => this.startDelegation(id, input),
         onExpired: (id) => {
           this.sendAppend(
-            { type: "delegation.context.append", delegation_item_id: id },
             "Ask the user to repeat their request; no user transcript was received.",
             "speakable",
+            id,
           );
         },
         onError: (error) => this.fail(error),
@@ -252,9 +252,9 @@ export class OpenAIQuicksilverDelegationController {
       const input = event.prompt ?? this.transcript.latestUserInput();
       if (event.prompt === undefined && !input.trim()) {
         this.sendAppend(
-          { type: "delegation.context.append", delegation_item_id: event.id },
           "Ask the user to repeat their request; no user transcript was received.",
           "speakable",
+          event.id,
         );
         return;
       }
@@ -266,7 +266,7 @@ export class OpenAIQuicksilverDelegationController {
     const content = text.trim();
     if (content) {
       // Standalone speech must not become the result of whichever delegation is active.
-      this.sendAppend({ type: "session.context.append" }, content, channel);
+      this.sendAppend(content, channel);
     }
   }
 
@@ -334,12 +334,7 @@ export class OpenAIQuicksilverDelegationController {
           return;
         }
         try {
-          this.sendAppend(
-            { type: "delegation.context.append", delegation_item_id: id },
-            message,
-            "speakable",
-            socket,
-          );
+          this.sendAppend(message, "speakable", id, socket);
         } catch (error) {
           this.fail(toErrorObject(error, "OpenAI GPT-Live control response failed"));
         }
@@ -554,13 +549,7 @@ export class OpenAIQuicksilverDelegationController {
       this.revokeRequesterFinal();
       return;
     }
-    if (
-      !this.sendAppend(
-        { type: "delegation.context.append", delegation_item_id: delegationId },
-        text,
-        "speakable",
-      )
-    ) {
+    if (!this.sendAppend(text, "speakable", delegationId)) {
       this.revokeRequesterFinal();
     }
   }
@@ -572,9 +561,9 @@ export class OpenAIQuicksilverDelegationController {
     }
     this.requesterFinalOwner = undefined;
     return this.sendAppend(
-      { type: "delegation.context.append", delegation_item_id: owner.delegationId },
       boundOpenAIQuicksilverDelegationResult(text),
       "speakable",
+      owner.delegationId,
     );
   }
 
@@ -584,11 +573,9 @@ export class OpenAIQuicksilverDelegationController {
   }
 
   private sendAppend(
-    target:
-      | { type: "session.context.append" }
-      | { type: "delegation.context.append"; delegation_item_id: string },
     text: string,
     channel: "speakable" | "commentary",
+    delegationId?: string,
     socket = this.options.getSocket(),
   ): boolean {
     for (const chunk of chunkOpenAIQuicksilverAppendText(text)) {
@@ -609,8 +596,7 @@ export class OpenAIQuicksilverDelegationController {
             model: this.options.model,
             text: chunk,
             channel,
-            delegationId:
-              target.type === "delegation.context.append" ? target.delegation_item_id : undefined,
+            delegationId,
           }),
         ),
       );

--- a/extensions/openai/realtime-quicksilver-session-retirement.test.ts
+++ b/extensions/openai/realtime-quicksilver-session-retirement.test.ts
@@ -124,15 +124,7 @@ describe("GA Realtime call retirement", () => {
   it.each(["cancel", "cleanup"] as const)(
     "retains a failed GA hangup for a later %s without reviving the client grant",
     async (action) => {
-      const bridge = {
-        connect: vi.fn(async () => undefined),
-        close: vi.fn(),
-        sendAudio: vi.fn(),
-        setMediaTimestamp: vi.fn(),
-        submitToolResult: vi.fn(),
-        acknowledgeMark: vi.fn(),
-        isConnected: vi.fn(() => true),
-      } satisfies RealtimeVoiceBridge;
+      const bridge = retirementBridge();
       const hangupTargets: string[] = [];
       const fetchMock = vi.fn(async (url: string | URL | Request) => {
         const target = requestTarget(url);
@@ -147,20 +139,7 @@ describe("GA Realtime call retirement", () => {
       });
       const { realtime } = createBroker({ fetchImpl: fetchMock as typeof fetch });
       try {
-        const reservation = await realtime.broker.createBrowserSession(
-          {
-            providerConfig: {},
-            model: "gpt-realtime-2.1",
-            gaSession: { type: "realtime", model: "gpt-realtime-2.1" },
-            gaSideband: { createBridge: () => bridge },
-            clientControl: { owner: "gateway" },
-            gatewayControl: { bindBridge: vi.fn() },
-          },
-          { type: "api-key", token: "platform-key" },
-        );
-        if (reservation.transport !== "webrtc") {
-          throw new Error("Expected WebRTC reservation");
-        }
+        const reservation = await reserveRetirementSession(realtime, () => bridge);
         const response = createResponseHarness();
         await realtime.handler(
           createRequest({ token: reservation.clientSecret, body: AUDIO_ONLY_SDP }),
@@ -218,25 +197,19 @@ describe("GA Realtime call retirement", () => {
     let creations = 0;
     let hangups = 0;
     let failHangup = true;
-    let releaseCreation!: () => void;
-    const creation = new Promise<void>((resolve) => {
-      releaseCreation = resolve;
-    });
-    let releaseFirstHangup!: () => void;
-    const firstHangup = new Promise<void>((resolve) => {
-      releaseFirstHangup = resolve;
-    });
+    const creation = createDeferred<void>();
+    const firstHangup = createDeferred<void>();
     let cancelSettled = false;
     const fetchImpl = vi.fn(async (url: string | URL | Request) => {
       if (requestTarget(url).endsWith("/hangup")) {
         hangups += 1;
         if (failure === "cancel during creation" && hangups === 1) {
-          await firstHangup;
+          await firstHangup.promise;
         }
         return new Response(null, { status: failHangup && hangups < 3 ? 503 : 204 });
       }
       creations += 1;
-      await creation;
+      await creation.promise;
       const answer =
         failure === "answer stream failure"
           ? new ReadableStream({
@@ -306,11 +279,11 @@ describe("GA Realtime call retirement", () => {
                 },
               )
             : undefined;
-      releaseCreation();
+      creation.resolve();
       if (failure === "cancel during creation") {
         await vi.waitFor(() => expect(hangups).toBe(1));
         expect.soft(cancelSettled).toBe(false);
-        releaseFirstHangup();
+        firstHangup.resolve();
       }
       const handlingError = await handling.then(
         () => undefined,
@@ -364,8 +337,8 @@ describe("GA Realtime call retirement", () => {
       expect(hangups).toBe(3);
     } finally {
       failHangup = false;
-      releaseCreation();
-      releaseFirstHangup();
+      creation.resolve();
+      firstHangup.resolve();
       await realtime.cleanup();
     }
   });
@@ -377,10 +350,7 @@ describe("GA Realtime call retirement", () => {
       const bridge = retirementBridge();
       let hangups = 0;
       let failHangup = true;
-      let answerStarted!: () => void;
-      const delivering = new Promise<void>((resolve) => {
-        answerStarted = resolve;
-      });
+      const delivering = createDeferred<void>();
       const fetchImpl = vi.fn(async (url: string | URL | Request) => {
         if (requestTarget(url).endsWith("/hangup")) {
           hangups += 1;
@@ -396,7 +366,7 @@ describe("GA Realtime call retirement", () => {
       const response = new ServerResponse(request);
       const end = vi.spyOn(response, "end").mockImplementationOnce(() => {
         response.writeHead(response.statusCode);
-        answerStarted();
+        delivering.resolve();
         return response;
       });
       let handling: Promise<boolean> | undefined;
@@ -404,7 +374,7 @@ describe("GA Realtime call retirement", () => {
         const reservation = await reserveRetirementSession(realtime, () => bridge);
         request.headers.authorization = `Bearer ${reservation.clientSecret}`;
         handling = realtime.handler(request, response);
-        await delivering;
+        await delivering.promise;
         expect(response.headersSent).toBe(true);
         await expect(realtime.broker.cancelBrowserSession(reservation)).rejects.toThrow(
           "OpenAI Realtime call hangup failed (503)",
@@ -483,15 +453,12 @@ describe("GA Realtime call retirement", () => {
   it.each([204, 404])("coalesces reentrant retirement and settles HTTP %s once", async (status) => {
     vi.useFakeTimers();
     const bridge = retirementBridge();
-    let finishHangup!: () => void;
-    const hungUp = new Promise<void>((resolve) => {
-      finishHangup = resolve;
-    });
+    const hungUp = createDeferred<void>();
     let hangups = 0;
     const fetchImpl = vi.fn(async (url: string | URL | Request) => {
       if (requestTarget(url).endsWith("/hangup")) {
         hangups += 1;
-        await hungUp;
+        await hungUp.promise;
         return new Response(null, { status });
       }
       return new Response("v=answer\r\n", {
@@ -517,13 +484,13 @@ describe("GA Realtime call retirement", () => {
       const concurrent = realtime.cleanup();
       expect(hangups).toBe(1);
       expect(bridge.close).toHaveBeenCalledOnce();
-      finishHangup();
+      hungUp.resolve();
       await Promise.all([first, concurrent, reentered]);
       await vi.advanceTimersByTimeAsync(30 * 60_000);
       await realtime.cleanup();
       expect(hangups).toBe(1);
     } finally {
-      finishHangup();
+      hungUp.resolve();
       await realtime.cleanup();
     }
   });

--- a/extensions/voice-call/src/webhook/realtime-handler.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.ts
@@ -1352,12 +1352,11 @@ export class RealtimeCallHandler {
       sessionClosed = true;
       this.cancelConsultSession(callId, session);
       audioPacer.close();
-      const finishClose = () => {
+      sessionClosePromise = drainProviderClose(closeSession).finally(() => {
         this.clearActiveBridgeMappings(callId, callSid, session);
         this.clearUserTranscriptState(callId, userTranscriptOwner);
         harness.close();
-      };
-      sessionClosePromise = drainProviderClose(closeSession).finally(finishClose);
+      });
       return sessionClosePromise;
     };
 
@@ -1380,11 +1379,6 @@ export class RealtimeCallHandler {
       bindingClosed = true;
       clearLivenessTimer();
       const ownsCall = this.activeTelephonyBindingsByCallId.get(callId) === binding;
-      const reportCloseError = (error: unknown) => {
-        console.warn(
-          `[voice-call] Failed to close realtime bridge ${callSid}: ${formatErrorMessage(error)}`,
-        );
-      };
       const finishClose = () => {
         const stillOwnsCall = this.activeTelephonyBindingsByCallId.get(callId) === binding;
         this.clearActiveTelephonyBinding(callId, binding);
@@ -1409,7 +1403,9 @@ export class RealtimeCallHandler {
         );
       }
       bindingClosePromise = pending.then(finishClose, async (error: unknown) => {
-        reportCloseError(error);
+        console.warn(
+          `[voice-call] Failed to close realtime bridge ${callSid}: ${formatErrorMessage(error)}`,
+        );
         try {
           await finishClose();
         } catch (terminationError) {

--- a/extensions/xai/realtime-voice-lazy.ts
+++ b/extensions/xai/realtime-voice-lazy.ts
@@ -2,6 +2,7 @@ import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 import { createRealtimeVoiceAudioQueue } from "openclaw/plugin-sdk/realtime-voice-audio-queue";
 import {
   RealtimeVoiceSessionLifecycle,
+  toStringifiedError,
   type RealtimeVoiceBridge,
   type RealtimeVoiceBridgeCreateRequest,
   type RealtimeVoiceSessionConnection,
@@ -92,12 +93,7 @@ export function createLazyXaiRealtimeVoiceBridge(
     clearPendingInput();
     req.onClose?.(terminalOutcome);
   };
-  const closeBridge = (
-    loadedBridge: RealtimeVoiceBridge | undefined = bridge,
-  ): void | Promise<void> => {
-    if (!loadedBridge) {
-      return;
-    }
+  const closeBridge = (loadedBridge: RealtimeVoiceBridge): void | Promise<void> => {
     if (closedBridges.has(loadedBridge)) {
       return closedBridges.get(loadedBridge);
     }
@@ -127,9 +123,7 @@ export function createLazyXaiRealtimeVoiceBridge(
         closeOwner = undefined;
         if (outcome === "error") {
           try {
-            req.onError?.(
-              primaryError instanceof Error ? primaryError : new Error(String(primaryError)),
-            );
+            req.onError?.(toStringifiedError(primaryError));
           } catch {
             // Error observers cannot replace the disposal outcome or skip its terminal notification.
           }

--- a/ui/src/pages/chat/realtime-talk-conversation.ts
+++ b/ui/src/pages/chat/realtime-talk-conversation.ts
@@ -75,7 +75,6 @@ export function updateRealtimeTalkConversation(
       update.role === "user" ? state.userEntryId : state.assistantEntryId,
       text,
       update.final,
-      nowMs,
       update.textMode,
     );
   }
@@ -87,7 +86,6 @@ export function updateRealtimeTalkConversation(
       preparedState.assistantEntryId,
       text,
       update.final,
-      nowMs,
     );
   }
   const entryId = state.userEntryId;
@@ -112,7 +110,6 @@ export function updateRealtimeTalkConversation(
     shouldStartNewUserEntry ? null : entryId,
     text,
     update.final,
-    nowMs,
   );
 }
 
@@ -136,7 +133,6 @@ function upsertRealtimeConversationEntry(
   entryId: string | null,
   text: string,
   isFinal: boolean,
-  nowMs: number,
   textMode?: RealtimeTalkTranscript["textMode"],
 ): RealtimeTalkConversationState {
   if (entryId === null) {
@@ -155,17 +151,13 @@ function upsertRealtimeConversationEntry(
       role,
       id,
       isFinal,
-      nowMs,
     );
   }
 
   const targetIndex = state.entries.findIndex((entry) => entry.id === entryId);
-  if (targetIndex === -1) {
-    return upsertRealtimeConversationEntry(state, role, null, text, isFinal, nowMs, textMode);
-  }
   const entry = state.entries[targetIndex];
   if (!entry) {
-    return upsertRealtimeConversationEntry(state, role, null, text, isFinal, nowMs, textMode);
+    return upsertRealtimeConversationEntry(state, role, null, text, isFinal, textMode);
   }
   const mergedText =
     textMode === "verbatim"
@@ -182,7 +174,7 @@ function upsertRealtimeConversationEntry(
             ? { ...candidate, text: updatedText, isStreaming: !isFinal }
             : candidate,
         );
-  return rememberRealtimeConversationEntry({ ...state, entries }, role, entryId, isFinal, nowMs);
+  return rememberRealtimeConversationEntry({ ...state, entries }, role, entryId, isFinal);
 }
 
 function rememberRealtimeConversationEntry(
@@ -190,7 +182,6 @@ function rememberRealtimeConversationEntry(
   role: RealtimeTalkConversationRole,
   entryId: string,
   isFinal: boolean,
-  _nowMs: number,
 ): RealtimeTalkConversationState {
   if (role === "user") {
     return {


### PR DESCRIPTION
Related: #145382, #145071, #145614, #145657

## What Problem This Solves

The GPT-Live paths carried redundant wire-target descriptors, unused helper arguments, and repeated test fixtures. These extra branches and forwarding steps made transport and shutdown behavior harder to review.

## Why This Change Was Made

Keep protocol selection in the existing wire builder, reuse established error-coercion and fixture helpers, and remove redundant private-call plumbing and fixture setup. The cleanup removes 88 lines across ten files: 46 production and 42 test/helper lines.

The Google loader follows the shared `createLazyRuntimeSurface` owner introduced by #145614. This PR retains only the separate private close-helper simplification in that file.

## User Impact

No user-visible behavior changes. Account-aware Talk defaults, public/subscription wire formats, caption output, lifecycle ownership, shutdown ordering, and primary-error precedence retain their existing contracts. Every test case and assertion remains, including distinct socket-close timing and portable mock declaration types.

## Evidence

- 278 focused voice tests passed, along with the full selected changed-file checks without skips, `pnpm build`, and the Google entrypoint profiler (211.2 MiB peak memory; no performance improvement is claimed).
- Fresh independent review through P2 is scoped-clean for the retained cleanup. Conflict resolution removes superseded changes and introduces no new cleanup logic.
- All 49 focused Google entrypoint, realtime-lazy, and media-video tests pass with Node 24.20.0 after retaining #145614's shared loader. All ten final voice files match that tested head exactly.
- Linux [CI 34676563045](https://github.com/openclaw/openclaw/actions/runs/34676563045) passed on the preceding head: 93 successful jobs, 13 skipped, zero failures, including all eight worker-context cases and the unchanged 50-turn retention case.
- Earlier CI exposed source-reader startup inside a five-second functional turn window. The two-line readiness fix landed independently in #145657; this PR drops its duplicate commit and keeps main's fixture verbatim. The five-second turn, 60-second reader, and 180-second setup budgets remain unchanged. No test retry loops, skipped cases, weaker assertions, or production test seams were added.
- Final exact-head [CI 34678099243](https://github.com/openclaw/openclaw/actions/runs/34678099243) passed on `e8967fffaf00`: 93 successful jobs, 13 skipped, zero failures, including the Gateway shard and real-Gateway UI E2E. The fresh current-head ClawSweeper review has no findings or before-merge items.
