### PR TITLE
fix(ui): preserve Debug payload selection during live updates

### DIFF
--- a/ui/src/pages/debug/event-log.browser.test.ts
+++ b/ui/src/pages/debug/event-log.browser.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, assert, describe, expect, it, vi } from "vitest";
+import type { EventLogEntry } from "../../api/event-log.ts";
+import type { ApplicationContext } from "../../app/context.ts";
+import { createGatewayEventLog } from "../../app/gateway-observers.ts";
+import { i18n } from "../../i18n/index.ts";
+import "./debug-page.ts";
+
+afterEach(() => {
+  document.body.replaceChildren();
+  vi.restoreAllMocks();
+});
+
+describe.runIf("__vitest_browser__" in globalThis)("Debug event log", () => {
+  it("preserves selected payload text when live events prepend and evict rows", async () => {
+    await i18n.setLocale("en");
+    vi.spyOn(Date, "now").mockReturnValue(1);
+    const log = createGatewayEventLog();
+    const listeners = new Set<(events: readonly EventLogEntry[]) => void>();
+    for (let index = 0; index < 250; index++) {
+      log.record({ type: "event", event: "agent", payload: { message: `event ${index}` } });
+    }
+    const request = vi.fn(async (method: string) => {
+      switch (method) {
+        case "diagnostics.lanes":
+          return { ts: 1, lanes: [], dynamic: null };
+        case "models.list":
+          return { models: [] };
+        default:
+          return {};
+      }
+    });
+    const page = document.createElement("openclaw-debug-page") as HTMLElement & {
+      context: ApplicationContext;
+      updateComplete: Promise<boolean>;
+    };
+    page.context = {
+      basePath: "",
+      gateway: {
+        snapshot: { phase: "connected", client: { request } },
+        get eventLog() {
+          return log.entries;
+        },
+        subscribe: () => () => {},
+        subscribeEventLog(listener: (events: readonly EventLogEntry[]) => void) {
+          listeners.add(listener);
+          return () => listeners.delete(listener);
+        },
+      },
+      agentSelection: { state: { selectedId: "main" }, subscribe: () => () => {} },
+    } as unknown as ApplicationContext;
+    document.body.append(page);
+    await page.updateComplete;
+
+    const eventSection = page.querySelector(".settings-section:last-child");
+    assert(eventSection);
+    const payloads = Array.from(eventSection.querySelectorAll("pre"));
+    expect(payloads).toHaveLength(250);
+    assert(payloads[100]);
+    const selected = payloads[100].querySelector(".hljs-string");
+    assert(selected);
+    const range = document.createRange();
+    range.selectNodeContents(selected);
+    const selection = window.getSelection();
+    assert(selection);
+    selection.removeAllRanges();
+    selection.addRange(range);
+    const selectedText = selection.toString();
+    expect(selectedText).not.toBe("");
+
+    log.record({ type: "event", event: "agent", payload: { message: "newest" } });
+    for (const listener of listeners) {
+      listener(log.entries);
+    }
+    await page.updateComplete;
+
+    const nextPayloads = Array.from(eventSection.querySelectorAll("pre"));
+    expect(nextPayloads).toHaveLength(250);
+    assert(nextPayloads[0] && nextPayloads[101]);
+    expect(nextPayloads[0].textContent).toContain("newest");
+    expect(nextPayloads[101]).toBe(payloads[100]);
+    expect(nextPayloads[101].querySelector(".hljs-string")).toBe(selected);
+    expect(selection.toString()).toBe(selectedText);
+    expect(eventSection.textContent).not.toContain('"event 0"');
+
+    log.resetConnection();
+    for (const listener of listeners) {
+      listener(log.entries);
+    }
+    await page.updateComplete;
+    expect(eventSection.querySelector("pre")).toBeNull();
+    page.remove();
+    expect(listeners.size).toBe(0);
+  });
+});

--- a/ui/src/pages/debug/view.test.ts
+++ b/ui/src/pages/debug/view.test.ts
@@ -1,6 +1,7 @@
 // Control UI tests cover debug behavior.
+import hljs from "highlight.js/lib/core";
 import { render, type LitElement } from "lit";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, assert, beforeEach, describe, expect, it, vi } from "vitest";
 import { flattenTranslations } from "../../../../scripts/lib/control-ui-i18n-sync-plan.ts";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { ApplicationContext, ApplicationGatewaySnapshot } from "../../app/context.ts";
@@ -176,6 +177,63 @@ afterEach(async () => {
 });
 
 describe("renderDebug", () => {
+  it("retains event payload DOM and only highlights changed diagnostics", () => {
+    const container = document.createElement("div");
+    const events = Array.from({ length: 250 }, (_, index) => ({
+      ts: 1,
+      event: "agent",
+      payload: { message: `event ${index}` },
+    }));
+    const props = createProps({ eventLog: events, callResult: '{"ok":true}' });
+    const highlight = vi.spyOn(hljs, "highlight");
+    try {
+      render(renderDebug(props), container);
+      const eventSection = container.querySelector(".settings-section:last-child");
+      assert(eventSection);
+      const payloads = Array.from(eventSection.querySelectorAll("pre"));
+      assert(payloads[0]);
+      const firstToken = payloads[0].querySelector("span");
+      assert(firstToken);
+      highlight.mockClear();
+
+      const newest = { ts: 1, event: "agent", payload: { message: "newest" } };
+      const nextProps = { ...props, eventLog: [newest, ...events.slice(0, -1)] };
+      render(renderDebug(nextProps), container);
+
+      const nextPayloads = Array.from(eventSection.querySelectorAll("pre"));
+      expect(nextPayloads).toHaveLength(250);
+      assert(nextPayloads[0] && nextPayloads[1]);
+      expect(nextPayloads[0].textContent).toContain("newest");
+      expect(nextPayloads.slice(1)).toEqual(payloads.slice(0, -1));
+      expect(nextPayloads[1].querySelector("span")).toBe(firstToken);
+      expect(highlight).toHaveBeenCalledTimes(1);
+
+      highlight.mockClear();
+      render(renderDebug({ ...nextProps, callParams: '{"typed":true}' }), container);
+      expect(highlight).not.toHaveBeenCalled();
+
+      render(
+        renderDebug({
+          ...nextProps,
+          status: { version: "updated" },
+          health: { ok: true },
+          heartbeat: { source: "updated" },
+          models: [{ id: "updated" }],
+          callResult: '{"result":"updated"}',
+        }),
+        container,
+      );
+      expect(highlight).toHaveBeenCalledTimes(5);
+      expect(container.textContent).toContain("updated");
+
+      render(renderDebug({ ...props, eventLog: [] }), container);
+      expect(eventSection.querySelector("pre")).toBeNull();
+      expect(eventSection.textContent).not.toContain("event 0");
+    } finally {
+      highlight.mockRestore();
+    }
+  });
+
   it("disables refresh and explains how to recover while disconnected", () => {
     const container = document.createElement("div");
     render(

--- a/ui/src/pages/debug/view.ts
+++ b/ui/src/pages/debug/view.ts
@@ -1,5 +1,7 @@
 // Control UI view renders debug screen content.
 import { html, nothing } from "lit";
+import { guard } from "lit/directives/guard.js";
+import { repeat } from "lit/directives/repeat.js";
 import { unsafeHTML } from "lit/directives/unsafe-html.js";
 import type { EventLogEntry } from "../../api/event-log.ts";
 import { isNativeEmbedHost } from "../../app/native-web-chrome.ts";
@@ -50,7 +52,7 @@ function renderJsonRow(title: unknown, value: unknown) {
     title,
     stacked: true,
     control: html`<pre class="code-block">
-${unsafeHTML(highlightJsonHtml(JSON.stringify(value ?? {}, null, 2)))}</pre>`,
+${guard([value], () => unsafeHTML(highlightJsonHtml(JSON.stringify(value ?? {}, null, 2))))}</pre>`,
   });
 }
 
@@ -122,7 +124,7 @@ function renderEventRow(evt: EventLogEntry) {
     description: formatTimeMs(evt.ts, undefined, ""),
     stacked: true,
     control: html`<pre class="code-block">
-${unsafeHTML(highlightJsonHtml(formatEventPayload(evt.payload)))}</pre>`,
+${guard([evt.payload], () => unsafeHTML(highlightJsonHtml(formatEventPayload(evt.payload))))}</pre>`,
   });
 }
 
@@ -240,7 +242,8 @@ export function renderDebug(props: DebugProps) {
           ? html`
               <div class="settings-row settings-row--stacked">
                 ${renderSettingsStatus({ kind: "ok", label: t("common.ok") })}
-                <pre class="code-block">${unsafeHTML(highlightJsonHtml(props.callResult))}</pre>
+                <pre class="code-block">
+${guard([props.callResult], () => unsafeHTML(highlightJsonHtml(props.callResult!)))}</pre>
               </div>
             `
           : nothing
@@ -253,7 +256,7 @@ export function renderDebug(props: DebugProps) {
     html`
       <div class="settings-row settings-row--stacked">
         <pre class="code-block">
-${unsafeHTML(highlightJsonHtml(JSON.stringify(props.models ?? [], null, 2)))}</pre>
+${guard([props.models], () => unsafeHTML(highlightJsonHtml(JSON.stringify(props.models ?? [], null, 2))))}</pre>
       </div>
     `,
   );
@@ -262,7 +265,9 @@ ${unsafeHTML(highlightJsonHtml(JSON.stringify(props.models ?? [], null, 2)))}</p
     { title: t("debug.eventLogTitle"), description: t("debug.eventLogSubtitle") },
     props.eventLog.length === 0
       ? renderSettingsEmpty(t("debug.noEvents"))
-      : props.eventLog.map((evt) => renderEventRow(evt)),
+      : // Entries retain their identity as the log prepends and evicts. Keep their
+        // highlighted DOM and selection attached to the event, not its list index.
+        repeat(props.eventLog, (evt) => evt, renderEventRow),
   );
 
   return renderSettingsPage(


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/issues/145587

## What Problem This Solves

Fixes an issue where users reading the Debug event log lose selected payload text and repeat expensive rendering work as live events arrive.

## Why This Change Was Made

Key event rows by the entry objects retained by the Gateway log, and guard JSON formatting/highlighting by the payload or diagnostic value. Lit now retains each event's highlighted DOM through prepends and eviction. Guard state retires with its rendered row; full payloads and the existing 250-entry retention remain intact.

Production delta: +5 lines; tests: +152. This reuses Lit's existing directives without adding an application cache or event identifier.

## User Impact

Live Debug updates preserve selected text and avoid serializing/highlighting unchanged payloads and snapshots. This addresses client rendering overhead; no end-to-end cloud-session speedup is claimed.

## Evidence

- The baseline renderer fails the original unit regression's retained-row assertion. Final green runs include strengthened DOM-presence assertions; the identity check is unchanged.
- 19 Debug unit tests pass. The workload checks 250 entries, eviction/reset, one new highlight per prepend, zero highlights for an unchanged rerender, and refreshed diagnostics.
- Real Chromium test passes through the Debug page subscription lifecycle, preserving row/span identity and selected text across live prepend/eviction.
- Selected typechecks, scoped static checks/lint, and UI production build pass, including finalized sidecar verification and bundle budgets.
- Independent source review and exact-commit autoreview: no actionable findings.

Proof used Node 24.19.0 on Blacksmith Testbox, with the complete source tree and frozen dependency lock verified. [Testbox hydration run](https://github.com/openclaw/openclaw/actions/runs/34671571965).

Landing qualification: [exact-head CI passed](https://github.com/openclaw/openclaw/actions/runs/34699309159) at `06661e012352081091bb9ca2e800f790ebed764f` (88 successful jobs, 13 scope-based skips). Native `OPENCLAW_TESTBOX=1 scripts/pr prepare-run 145600` passed without changing the head.
