### PR TITLE
fix(voice-call): dispatch each distinct realtime agent consult with its own question

### DIFF
--- a/extensions/voice-call/src/webhook/realtime-handler.lifecycle.test.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.lifecycle.test.ts
@@ -840,6 +840,130 @@ describe("RealtimeCallHandler lifecycle", () => {
     },
   );
 
+  it("dispatches each distinct concurrent native consult with its own question", async () => {
+    let onToolCall:
+      | ((event: { itemId: string; callId: string; name: string; args: unknown }) => void)
+      | undefined;
+    const submitToolResult = vi.fn();
+    const createBridgeForCall = vi.fn(
+      (request: {
+        onToolCall?: (event: {
+          itemId: string;
+          callId: string;
+          name: string;
+          args: unknown;
+        }) => void;
+      }) => {
+        onToolCall = request.onToolCall;
+        return createBridge(vi.fn(), {
+          supportsToolResultContinuation: true,
+          submitToolResult,
+        });
+      },
+    );
+    const call: CallRecord = {
+      callId: "call-concurrent-consult",
+      providerCallId: "CA-concurrent-consult",
+      provider: "twilio",
+      direction: "inbound",
+      state: "ringing",
+      from: "+15550001111",
+      to: "+15550002222",
+      startedAt: Date.now(),
+      transcript: [],
+      processedEventIds: [],
+    };
+    const handler = new RealtimeCallHandler(
+      createRealtimeConfig(),
+      {
+        processEvent: vi.fn<CallManager["processEvent"]>(async () => ({ kind: "processed" })),
+        updateCallMetadata,
+        endCall: vi.fn(async () => ({ success: true })),
+        getCallByProviderCallId: vi.fn(() => call),
+      } as unknown as CallManager,
+      makeCallRegistrationResolver(makeRealtimeProvider(createBridgeForCall)),
+      "/voice/webhook",
+      noOpStreamDisconnectLifecycle,
+    );
+    const questions = [
+      "Return 2025 sales for Dataset A.",
+      "Correction: return all-time sales for Dataset B instead.",
+      "Also list the required fields for a new customer record.",
+    ];
+    const dispatched: string[] = [];
+    let releaseConsults = () => {};
+    const consultGate = new Promise<void>((resolve) => {
+      releaseConsults = resolve;
+    });
+    handler.registerToolHandler("openclaw_agent_consult", async (args) => {
+      const question = String((args as { question?: string }).question);
+      dispatched.push(question);
+      await consultGate;
+      return { text: `ANSWER FOR: ${question}` };
+    });
+    const { streamUrl } = handler.issueStreamSession();
+    const server = await startUpgradeWsServer({
+      urlPath: new URL(streamUrl).pathname,
+      onUpgrade: (request, socket, head) => {
+        handler.handleWebSocketUpgrade(request, socket, head);
+      },
+    });
+    const ws = await connectWs(server.url);
+
+    try {
+      ws.send(
+        JSON.stringify({
+          event: "start",
+          start: { streamSid: "MZ-concurrent-consult", callSid: "CA-concurrent-consult" },
+        }),
+      );
+      await vi.waitFor(() => {
+        expect(createBridgeForCall).toHaveBeenCalledTimes(1);
+      });
+
+      onToolCall?.({
+        itemId: "item-consult-1",
+        callId: "tool-consult-1",
+        name: "openclaw_agent_consult",
+        args: { question: questions[0] },
+      });
+      await vi.waitFor(() => {
+        expect(dispatched).toEqual([questions[0]]);
+      });
+      onToolCall?.({
+        itemId: "item-consult-2",
+        callId: "tool-consult-2",
+        name: "openclaw_agent_consult",
+        args: { question: questions[1] },
+      });
+      onToolCall?.({
+        itemId: "item-consult-3",
+        callId: "tool-consult-3",
+        name: "openclaw_agent_consult",
+        args: { question: questions[2] },
+      });
+      releaseConsults();
+
+      const finalResults = () =>
+        submitToolResult.mock.calls.filter(
+          (entry) => !(entry[2] as { willContinue?: boolean } | undefined)?.willContinue,
+        );
+      await vi.waitFor(() => {
+        expect(dispatched).toEqual(questions);
+        expect(finalResults()).toHaveLength(questions.length);
+      });
+      expect(finalResults().map((entry) => (entry[1] as { text?: string }).text)).toEqual(
+        questions.map((question) => `ANSWER FOR: ${question}`),
+      );
+    } finally {
+      if (ws.readyState !== WebSocket.CLOSED) {
+        ws.terminate();
+      }
+      await handler.close();
+      await server.close();
+    }
+  });
+
   it("does not start a native consult after teardown during transcript settling", async () => {
     let onToolCall:
       | ((event: { itemId: string; callId: string; name: string; args: unknown }) => void)

--- a/extensions/voice-call/src/webhook/realtime-handler.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.ts
@@ -292,6 +292,7 @@ type RealtimeConsultSession = {
 
 type NativeConsultState = {
   owner: ActiveRealtimeVoiceBridge;
+  bridgeCallId: string;
   startedAt: number;
   promise: Promise<unknown>;
   cancellation: Promise<void>;
@@ -388,6 +389,9 @@ export class RealtimeCallHandler {
   private readonly forcedConsultsByCallId = new Map<string, ForcedConsultState>();
   private readonly consultSessionsByCallId = new Map<string, RealtimeConsultSession>();
   private readonly nativeConsultsInFlightByCallId = new Map<string, NativeConsultState>();
+  // Serialization tail for distinct native consults on one call: each queued
+  // invocation waits for the previous turn so it dispatches with its own args.
+  private readonly nativeConsultQueueTailByCallId = new Map<string, Promise<void>>();
   private readonly terminationAttempts = new Set<Promise<void>>();
   private readonly admissions = new Set<Promise<void>>();
   private closePromise: Promise<void> | null = null;
@@ -1632,6 +1636,7 @@ export class RealtimeCallHandler {
       }
       this.activeBridgesByCallId.delete(key);
     }
+    this.nativeConsultQueueTailByCallId.delete(callId);
   }
 
   private clearActiveTelephonyBinding(callId: string, binding: RealtimeTelephonyBinding): void {
@@ -2060,7 +2065,7 @@ export class RealtimeCallHandler {
       }
 
       const existingNativeConsult = this.nativeConsultsInFlightByCallId.get(callId);
-      if (existingNativeConsult) {
+      if (existingNativeConsult && existingNativeConsult.bridgeCallId === bridgeCallId) {
         console.log(
           `[voice-call] realtime tool call sharing in-flight agent consult callId=${callId} ageMs=${Date.now() - existingNativeConsult.startedAt}`,
         );
@@ -2073,82 +2078,108 @@ export class RealtimeCallHandler {
         return;
       }
 
-      const abortController = new AbortController();
-      let releaseCancellation = () => {};
-      const cancellation = new Promise<void>((resolve) => {
-        releaseCancellation = resolve;
+      // Distinct consult invocations never inherit the in-flight result: they
+      // serialize behind the current consult and dispatch with their own args.
+      // One in-flight consult per call stays the owner of cancellation and
+      // user-transcript consumption.
+      let releaseConsultTurn = () => {};
+      const consultTurn = new Promise<void>((resolve) => {
+        releaseConsultTurn = resolve;
       });
-      let completeConsult = (_result: unknown) => {};
-      const consult = new Promise<unknown>((resolve) => {
-        completeConsult = resolve;
-      });
-      const state: NativeConsultState = {
-        owner: bridge,
-        startedAt,
-        promise: consult,
-        cancellation,
-        cancelled: false,
-        // Provider continuity owns the consult lifetime, not only its eventual result.
-        cancel: () => {
-          abortController.abort(new Error("Realtime native consult owner was cancelled."));
-          releaseCancellation();
-        },
-      };
-      this.nativeConsultsInFlightByCallId.set(callId, state);
-      void (async () => {
-        try {
-          await submitWorkingResponse();
-          if (state.cancelled) {
-            return undefined;
-          }
-          await Promise.race([
-            this.waitForConsultTranscriptSettle(callId, userTranscriptOwner, startedAt),
-            state.cancellation,
-          ]);
-          if (state.cancelled) {
-            return undefined;
-          }
-          const context = {
-            partialUserTranscript: this.resolveUserTranscriptContext(callId, userTranscriptOwner),
-            abortSignal: abortController.signal,
-          };
-          state.partialUserTranscript = context.partialUserTranscript;
-          const handlerArgs = withFallbackConsultQuestion(args, context.partialUserTranscript);
-          console.log(
-            `[voice-call] realtime tool call executing callId=${callId} tool=${name} hasHandler=${Boolean(handler)}`,
-          );
-          return !handler
-            ? { error: `Tool "${name}" not available` }
-            : await handler(handlerArgs, callId, context);
-        } catch (error) {
-          return buildRealtimeVoiceAgentErrorProviderResult(error);
-        }
-      })().then(completeConsult);
-      try {
-        const outcome = await waitForNativeConsult(state);
-        if (outcome.kind === "cancelled") {
+      const previousConsultTurn = this.nativeConsultQueueTailByCallId.get(callId);
+      this.nativeConsultQueueTailByCallId.set(callId, consultTurn);
+      if (existingNativeConsult && previousConsultTurn) {
+        console.log(
+          `[voice-call] realtime tool call queueing behind in-flight agent consult callId=${callId} ageMs=${Date.now() - existingNativeConsult.startedAt}`,
+        );
+        await submitWorkingResponse();
+        await previousConsultTurn;
+        if (this.activeBridgesByCallId.get(callId) !== bridge) {
           return;
         }
-        const result = outcome.result;
-        const failed = hasResultError(result);
-        const error = failed ? formatErrorMessage(result.error ?? "unknown") : undefined;
-        console.log(
-          `[voice-call] realtime tool call completed callId=${callId} tool=${name} status=${failed ? "error" : "ok"} elapsedMs=${Date.now() - startedAt}${error ? ` error=${error}` : ""}`,
-        );
-        await submitFinalToolResult(result);
-        if (!failed) {
-          this.consumePartialUserTranscript(
-            callId,
-            userTranscriptOwner,
-            state.partialUserTranscript,
-          );
-        }
-      } finally {
-        if (this.nativeConsultsInFlightByCallId.get(callId) === state) {
-          this.nativeConsultsInFlightByCallId.delete(callId);
-        }
       }
-      return;
+
+      try {
+        const abortController = new AbortController();
+        let releaseCancellation = () => {};
+        const cancellation = new Promise<void>((resolve) => {
+          releaseCancellation = resolve;
+        });
+        let completeConsult = (_result: unknown) => {};
+        const consult = new Promise<unknown>((resolve) => {
+          completeConsult = resolve;
+        });
+        const state: NativeConsultState = {
+          owner: bridge,
+          bridgeCallId,
+          startedAt,
+          promise: consult,
+          cancellation,
+          cancelled: false,
+          // Provider continuity owns the consult lifetime, not only its eventual result.
+          cancel: () => {
+            abortController.abort(new Error("Realtime native consult owner was cancelled."));
+            releaseCancellation();
+          },
+        };
+        this.nativeConsultsInFlightByCallId.set(callId, state);
+        void (async () => {
+          try {
+            await submitWorkingResponse();
+            if (state.cancelled) {
+              return undefined;
+            }
+            await Promise.race([
+              this.waitForConsultTranscriptSettle(callId, userTranscriptOwner, startedAt),
+              state.cancellation,
+            ]);
+            if (state.cancelled) {
+              return undefined;
+            }
+            const context = {
+              partialUserTranscript: this.resolveUserTranscriptContext(callId, userTranscriptOwner),
+              abortSignal: abortController.signal,
+            };
+            state.partialUserTranscript = context.partialUserTranscript;
+            const handlerArgs = withFallbackConsultQuestion(args, context.partialUserTranscript);
+            console.log(
+              `[voice-call] realtime tool call executing callId=${callId} tool=${name} hasHandler=${Boolean(handler)}`,
+            );
+            return !handler
+              ? { error: `Tool "${name}" not available` }
+              : await handler(handlerArgs, callId, context);
+          } catch (error) {
+            return buildRealtimeVoiceAgentErrorProviderResult(error);
+          }
+        })().then(completeConsult);
+        try {
+          const outcome = await waitForNativeConsult(state);
+          if (outcome.kind === "cancelled") {
+            return;
+          }
+          const result = outcome.result;
+          const failed = hasResultError(result);
+          const error = failed ? formatErrorMessage(result.error ?? "unknown") : undefined;
+          console.log(
+            `[voice-call] realtime tool call completed callId=${callId} tool=${name} status=${failed ? "error" : "ok"} elapsedMs=${Date.now() - startedAt}${error ? ` error=${error}` : ""}`,
+          );
+          await submitFinalToolResult(result);
+          if (!failed) {
+            this.consumePartialUserTranscript(
+              callId,
+              userTranscriptOwner,
+              state.partialUserTranscript,
+            );
+          }
+        } finally {
+          if (this.nativeConsultsInFlightByCallId.get(callId) === state) {
+            this.nativeConsultsInFlightByCallId.delete(callId);
+          }
+        }
+        return;
+      } finally {
+        releaseConsultTurn();
+      }
     }
     console.log(
       `[voice-call] realtime tool call executing callId=${callId} tool=${name} hasHandler=${Boolean(handler)}`,


### PR DESCRIPTION
## What Problem This Solves

When one native Voice Call `openclaw_agent_consult` is still pending, later distinct consult invocations on the same call are keyed only by `callId`: they join the first pending promise and receive the first request's result. The later questions are never dispatched to the backing agent at all — every concurrent consult on a call silently answers with the first question's answer. Reported in #145445 with a deterministic handler-level reproduction.

## Solution

The realtime model re-sending the same tool call (same tool-call id) still shares the in-flight result. A **distinct** invocation (different tool-call id) now queues behind the current consult on a per-call serialization tail and dispatches with its own args once it owns the call's single consult slot. The one-in-flight consult per call stays the owner of cancellation (`cancelNativeConsult`) and user-transcript consumption, so the cancellation and transcript contracts are unchanged.

## Impact

Every distinct `openclaw_agent_consult` invocation is evaluated with its own supplied question and returns a result for that question, matching the sequential dispatch behavior that already worked.

## Evidence

New regression test `dispatches each distinct concurrent native consult with its own question` (`realtime-handler.lifecycle.test.ts`) drives the real WebSocket entry point (`issueStreamSession` → upgrade → `onToolCall`) with three concurrent consults on one call, the first held pending on a gate:

- **Pre-fix** (production change stashed, test present): the backend records only the first question (`dispatched` = 1 entry) and, after release, all three tool results carry the first question's answer — the exact reported symptom.
- **Post-fix**: all three questions dispatch and each final tool result matches its own question (`ANSWER FOR: <own question>`); the full `realtime-handler.lifecycle.test.ts` passes 23/23, including the existing `blocks SDK SSO...`-adjacent consult lifecycle tests (`does not start a native consult after teardown during transcript settling`, `aborts a hung native consult during stream teardown`), confirming the cancellation and transcript-settle contracts are untouched.

Closes #145445

🤖 Generated with [Claude Code](https://claude.com/claude-code)
