### PR TITLE
fix(gateway): expose missing worker RPC latency diagnostics

### DIFF
--- a/docs/gateway/opentelemetry/model-calls-and-metrics.md
+++ b/docs/gateway/opentelemetry/model-calls-and-metrics.md
@@ -103,7 +103,7 @@ bounds; content remains off by default.
 
 ### Gateway RPC
 
-Authenticated Gateway WebSocket requests emit these metrics while diagnostics
+Authenticated Gateway WebSocket requests, including dedicated worker RPCs, emit these metrics while diagnostics
 and an interested exporter are enabled. They exclude the connection handshake,
 malformed request frames, and HTTP routes.
 
@@ -113,19 +113,29 @@ malformed request frames, and HTTP routes.
 | `openclaw.gateway.rpc.first_response_ms` | histogram | Receipt through the first successfully sent response              |
 | `openclaw.gateway.rpc.handler_ms`        | histogram | Actual handler invocation through return or throw                 |
 | `openclaw.gateway.rpc.admission_ms`      | histogram | Receipt through actual handler invocation                         |
-| `openclaw.gateway.rpc.queue_wait_ms`     | histogram | Wait for operator request start permission, when applicable       |
+| `openclaw.gateway.rpc.queue_wait_ms`     | histogram | Operator start-queue or worker frame-queue wait, when applicable  |
 | `openclaw.gateway.rpc.outcomes`          | counter   | Observations by phase and outcome                                 |
 
 Request and timing metrics have only `openclaw.gateway.rpc.method`: a canonical
-core method name, `other` for plugin methods, or `unknown`. Outcome metrics have
+core or worker method name, `other` for plugin methods, or `unknown`. Outcome metrics have
 only `openclaw.gateway.rpc.phase` and `openclaw.gateway.rpc.outcome`, so errors do
 not multiply every method's series. No request, connection, session, or trace IDs
 appear in metric attributes.
 
-Admission includes authorization, lazy router and handler loading, and operator
-start-queue wait. Queue wait is a subset of admission for handlers that start; it is separate
-from command/session lane `openclaw.queue.wait_ms`. Handler and admission samples
-exist only for invoked handlers. Queue wait is recorded when dispatch settles.
+Operator admission includes authorization, lazy router and handler loading, and
+start-queue wait. Worker admission includes the socket FIFO wait and outer frame
+validation. Worker handler duration includes method validation and service invocation.
+Worker timing starts at the JavaScript socket callback, excluding network delay
+and event-loop delay before that callback. Queue wait is a subset of admission
+for handlers that start, separate from command/session lane `openclaw.queue.wait_ms`.
+Handler and admission samples exist only for invoked handlers. Queue wait is
+recorded when dispatch settles.
+
+Worker inference-start timing measures acceptance and setup, not provider completion.
+Long worker computer and session operations retain their handler timing after
+releasing the socket FIFO. Worker dispatch outcomes describe return or throw.
+Connection closure can suppress a response after successful execution and does
+not by itself prove execution cancellation.
 
 A sent response means the WebSocket sender accepted the frame, not that the
 client received it. Early acknowledgments count as the first response; later

--- a/extensions/diagnostics-otel/src/service-metrics.ts
+++ b/extensions/diagnostics-otel/src/service-metrics.ts
@@ -59,7 +59,7 @@ export function createDiagnosticsMetrics(
     }),
     gatewayRpcQueueWaitHistogram: createHistogram("openclaw.gateway.rpc.queue_wait_ms", {
       unit: "ms",
-      description: "Gateway operator request start queue wait",
+      description: "Gateway operator start queue or worker frame queue wait",
       advice: { explicitBucketBoundaries: AGENT_DURATION_MS_BUCKETS },
     }),
     tokensCounter: createCounter("openclaw.tokens", {

--- a/src/gateway/server/ws-connection/message-handler.worker-metrics.test.ts
+++ b/src/gateway/server/ws-connection/message-handler.worker-metrics.test.ts
@@ -1,0 +1,264 @@
+import { performance } from "node:perf_hooks";
+import { afterEach, beforeEach, describe, expect, it, onTestFinished, vi } from "vitest";
+import {
+  onInternalDiagnosticEvent,
+  resetDiagnosticEventsForTest,
+  setDiagnosticsEnabledForProcess,
+  waitForDiagnosticEventsDrained,
+  type DiagnosticEventPayload,
+} from "../../../infra/diagnostic-events.js";
+import { createDeferredCore } from "../../../shared/deferred.js";
+import {
+  admit,
+  attachHarness,
+  ATTACHED_IDENTITY,
+  CREDENTIAL,
+  INFERENCE_EVENT,
+  INFERENCE_START,
+  setupWorkerProtocolTestState,
+  TRANSCRIPT_COMMIT,
+  waitForWorkerProtocol,
+} from "./message-handler.worker.test-support.js";
+import { captureGatewayRpcReceivedAt, createWorkerRpcDiagnostics } from "./request-diagnostics.js";
+
+type RpcEvent = Extract<DiagnosticEventPayload, { type: "gateway.rpc" }>;
+
+function observeRequests() {
+  const events: RpcEvent[] = [];
+  onTestFinished(
+    onInternalDiagnosticEvent(
+      (event) => {
+        if (event.type === "gateway.rpc") {
+          events.push(event);
+        }
+      },
+      { include: ["gateway.rpc"] },
+    ),
+  );
+  return events;
+}
+
+async function settled(events: RpcEvent[], count = 1) {
+  await waitForWorkerProtocol(() =>
+    expect(events.filter((event) => event.phase === "dispatch")).toHaveLength(count),
+  );
+  await waitForDiagnosticEventsDrained();
+}
+
+describe("dedicated worker RPC diagnostics", () => {
+  setupWorkerProtocolTestState();
+  beforeEach(() => resetDiagnosticEventsForTest());
+  afterEach(() => {
+    vi.restoreAllMocks();
+    resetDiagnosticEventsForTest();
+  });
+
+  it("measures FIFO admission separately from inference acceptance without delaying its ACK", async () => {
+    const events = observeRequests();
+    let now = 100;
+    vi.spyOn(performance, "now").mockImplementation(() => now);
+    const harness = attachHarness({
+      identity: ATTACHED_IDENTITY,
+      onInferenceLaunch: (sink) => {
+        expect(harness.responses.at(-1)).toMatchObject({
+          id: "inference-request",
+          ok: true,
+          payload: { status: "accepted" },
+        });
+        now = 210;
+        sink.send(INFERENCE_EVENT);
+      },
+    });
+    await admit(harness);
+    expect(events).toEqual([]);
+    const entered = createDeferredCore();
+    const release = createDeferredCore();
+    const result = await harness.service.commitTranscript();
+    harness.service.commitTranscript.mockImplementationOnce(async () => {
+      entered.resolve();
+      await release.promise;
+      return result;
+    });
+    harness.sendRequest("worker.transcript.commit", TRANSCRIPT_COMMIT, "commit-request");
+    try {
+      await entered.promise;
+      now = 140;
+      harness.sendRequest("worker.inference.start", INFERENCE_START, "inference-request");
+      expect(harness.service.startInference).not.toHaveBeenCalled();
+      now = 180;
+      release.resolve();
+      await settled(events, 2);
+      const inference = events.filter((event) => event.method === "worker.inference.start");
+      expect(inference.map((event) => event.phase)).toEqual([
+        "received",
+        "response",
+        "handler",
+        "dispatch",
+      ]);
+      expect(inference[1]).toMatchObject({ outcome: "ok", durationMs: 40 });
+      expect(inference[2]).toMatchObject({ admissionMs: 40, durationMs: 30, outcome: "returned" });
+      expect(inference[3]).toMatchObject({
+        queueWaitMs: 40,
+        durationMs: 70,
+        outcome: "returned",
+        response: "sent",
+      });
+      expect(harness.responses.at(-1)).toEqual(INFERENCE_EVENT);
+      expect(harness.close).not.toHaveBeenCalled();
+      for (const value of [
+        "inference-request",
+        "commit-request",
+        CREDENTIAL,
+        "session-1",
+        "hello",
+      ]) {
+        expect(JSON.stringify(events)).not.toContain(value);
+      }
+    } finally {
+      release.resolve();
+    }
+  });
+
+  it.each([false, true])(
+    "releases the FIFO while computer timing stays open (closed=%s)",
+    async (closed) => {
+      const events = observeRequests();
+      const harness = attachHarness({ identity: ATTACHED_IDENTITY });
+      await admit(harness);
+      let now = 100;
+      vi.spyOn(performance, "now").mockImplementation(() => now);
+      const entered = createDeferredCore();
+      const release = createDeferredCore();
+      let signal: AbortSignal | undefined;
+      harness.service.executeComputer.mockImplementationOnce(
+        async (_identity, _request, receivedSignal) => {
+          signal = receivedSignal;
+          entered.resolve();
+          await release.promise;
+          return { ok: true, result: { resultJson: "{}" } };
+        },
+      );
+      harness.sendRequest(
+        "worker.computer",
+        { command: "screen.snapshot", paramsJson: "{}" },
+        "computer",
+      );
+      try {
+        await entered.promise;
+        now = 120;
+        harness.sendRequest("worker.inference.start", INFERENCE_START, "inference");
+        await settled(events);
+        expect(
+          events.filter((event) => event.method === "worker.computer").map((event) => event.phase),
+        ).toEqual(["received"]);
+        expect(signal?.aborted).toBe(false);
+        now = 200;
+        if (closed) {
+          harness.close();
+          expect(signal?.aborted).toBe(true);
+        }
+        release.resolve();
+        await settled(events, 2);
+        const computer = events.filter((event) => event.method === "worker.computer");
+        expect(computer.filter((event) => event.phase === "response")).toMatchObject([
+          { outcome: closed ? "suppressed" : "ok", durationMs: 100 },
+        ]);
+        expect(computer.find((event) => event.phase === "handler")).toMatchObject({
+          admissionMs: 0,
+          durationMs: 100,
+        });
+        expect(computer.at(-1)).toMatchObject({
+          phase: "dispatch",
+          outcome: "returned",
+          queueWaitMs: 0,
+        });
+        expect(
+          harness.responses.filter((frame) => (frame as { id?: string }).id === "computer"),
+        ).toHaveLength(closed ? 0 : 1);
+      } finally {
+        release.resolve();
+      }
+    },
+  );
+
+  it("does not turn a completed computer handler into cancellation when its send closes", async () => {
+    const events = observeRequests();
+    const harness = attachHarness({ identity: ATTACHED_IDENTITY });
+    await admit(harness);
+    harness.sendResponse.mockImplementationOnce(() => {
+      harness.close();
+      return { kind: "unavailable" };
+    });
+    harness.sendRequest("worker.computer", { command: "screen.snapshot", paramsJson: "{}" });
+    await settled(events);
+    expect(events.find((event) => event.phase === "handler")).toMatchObject({
+      outcome: "returned",
+    });
+    expect(events.at(-1)).toMatchObject({
+      phase: "dispatch",
+      outcome: "returned",
+      response: "unavailable",
+    });
+  });
+
+  it.each(["unavailable", "serialization"] as const)(
+    "records %s sender failure without a sent response",
+    async (kind) => {
+      const events = observeRequests();
+      const harness = attachHarness({ identity: ATTACHED_IDENTITY });
+      await admit(harness);
+      harness.sendResponse.mockReturnValueOnce(
+        kind === "serialization"
+          ? { kind, error: new Error("synthetic encoding fault") }
+          : { kind },
+      );
+      harness.sendRequest("worker.inference.start", INFERENCE_START);
+      await settled(events);
+      expect(events.filter((event) => event.phase === "response")).toMatchObject([
+        { outcome: "unavailable" },
+      ]);
+      expect(events.at(-1)).toMatchObject({ phase: "dispatch", response: "unavailable" });
+    },
+  );
+
+  it("records a throwing service once and preserves protocol failure", async () => {
+    const events = observeRequests();
+    const harness = attachHarness({ identity: ATTACHED_IDENTITY });
+    await admit(harness);
+    harness.service.commitTranscript.mockRejectedValueOnce(new Error("synthetic service fault"));
+    harness.sendRequest("worker.transcript.commit", TRANSCRIPT_COMMIT);
+    await settled(events);
+    expect(events.map((event) => event.phase)).toEqual(["received", "handler", "dispatch"]);
+    expect(events.slice(1)).toMatchObject([
+      { outcome: "threw" },
+      { outcome: "threw", response: "none" },
+    ]);
+    expect(harness.close).toHaveBeenCalledWith(1011, "gateway-unavailable");
+    expect(JSON.stringify(events)).not.toContain("synthetic service fault");
+  });
+
+  it("buckets arbitrary methods without leaking caller values", async () => {
+    const events = observeRequests();
+    const harness = attachHarness({ identity: ATTACHED_IDENTITY });
+    await admit(harness);
+    harness.sendRequest(
+      "private-method-value",
+      { private: "private-payload-value" },
+      "private-request-value",
+    );
+    await settled(events);
+    expect(new Set(events.map((event) => event.method))).toEqual(new Set(["unknown"]));
+    expect(events.find((event) => event.phase === "response")).toMatchObject({ outcome: "error" });
+    expect(JSON.stringify(events)).not.toContain("private-");
+  });
+
+  it("takes no diagnostic clocks when disabled or uninterested", () => {
+    const clock = vi.spyOn(performance, "now");
+    expect(captureGatewayRpcReceivedAt()).toBeUndefined();
+    expect(createWorkerRpcDiagnostics("worker.computer", undefined)).toBeUndefined();
+    observeRequests();
+    setDiagnosticsEnabledForProcess(false);
+    expect(captureGatewayRpcReceivedAt()).toBeUndefined();
+    expect(clock).not.toHaveBeenCalled();
+  });
+});

--- a/src/gateway/server/ws-connection/message-handler.worker.test-support.ts
+++ b/src/gateway/server/ws-connection/message-handler.worker.test-support.ts
@@ -29,6 +29,7 @@ import { GatewayConnectionWork } from "../../server-connection-work.js";
 import type { WorkerConnectionIdentity } from "../../worker-environments/connection-identity.js";
 import { createGatewayWsTestSocket } from "../ws-connection.test-helpers.js";
 import type { GatewayWsClient } from "../ws-types.js";
+import type { GatewayWsMessageHandlerParams } from "./message-handler-types.js";
 import { attachWorkerWsMessageHandler, type WorkerConnectionService } from "./worker-connection.js";
 
 export const CREDENTIAL = ["worker", "credential", "fixture"].join("-");
@@ -240,6 +241,13 @@ export function attachHarness(
   const setLastFrameMeta = vi.fn();
   const advanceHandshakePhase = vi.fn();
   const connectionWork = new GatewayConnectionWork();
+  const sendResponse = vi.fn<GatewayWsMessageHandlerParams["send"]>((frame) => {
+    responses.push(frame);
+    if (options.closeDuringHello) {
+      close();
+    }
+    return { kind: "sent" };
+  });
   const cleanup = attachWorkerWsMessageHandler({
     socket: socket as unknown as WebSocket,
     connectionWork,
@@ -249,12 +257,7 @@ export function attachHarness(
     publicAdmission: options.omitPublicAdmission
       ? undefined
       : { clientIp: "203.0.113.10", rateLimiter: options.rateLimiter },
-    send: (frame) => {
-      responses.push(frame);
-      if (options.closeDuringHello) {
-        close();
-      }
-    },
+    send: sendResponse,
     close,
     isClosed: () => closed,
     clearHandshakeTimer: vi.fn(),
@@ -281,6 +284,7 @@ export function attachHarness(
     logGateway,
     logWsControl,
     responses,
+    sendResponse,
     service,
     setClient,
     setCloseCause,

--- a/src/gateway/server/ws-connection/request-diagnostics.ts
+++ b/src/gateway/server/ws-connection/request-diagnostics.ts
@@ -1,4 +1,6 @@
 import { performance } from "node:perf_hooks";
+import { WORKER_PROTOCOL_METHODS } from "../../../../packages/gateway-protocol/src/schema/worker-admission.js";
+import { WORKER_INFERENCE_METHODS } from "../../../../packages/gateway-protocol/src/schema/worker-inference.js";
 import { hasInternalDiagnosticEventInterest } from "../../../infra/diagnostic-event-listener-presence.js";
 import {
   areDiagnosticsEnabledForProcess,
@@ -16,9 +18,11 @@ import type { GatewayRequestHandlers } from "../../server-methods/types.js";
 type RpcEvent = Extract<DiagnosticEventInput, { type: "gateway.rpc" }>;
 type ResponseOutcome = Extract<RpcEvent, { phase: "response" }>["outcome"];
 type DispatchOutcome = Extract<RpcEvent, { phase: "dispatch" }>["outcome"];
+const workerMethods = new Set<string>([...WORKER_PROTOCOL_METHODS, ...WORKER_INFERENCE_METHODS]);
+
+export type GatewayRpcQueueTiming = { receivedAt: number; dequeuedAt: number };
 
 class GatewayRpcDiagnostics {
-  private readonly startedAt = performance.now();
   private trace = getActiveDiagnosticTraceContext();
   private queueStartedAt?: number;
   private queueWaitMs?: number;
@@ -27,7 +31,12 @@ class GatewayRpcDiagnostics {
   private dispatchFinished = false;
   private responseState: Extract<RpcEvent, { phase: "dispatch" }>["response"] = "none";
 
-  constructor(private readonly method: string) {
+  constructor(
+    private readonly method: string,
+    private readonly startedAt = performance.now(),
+    queueWaitMs?: number,
+  ) {
+    this.queueWaitMs = queueWaitMs;
     this.emit({ type: "gateway.rpc", method, phase: "received" });
   }
 
@@ -113,6 +122,29 @@ class GatewayRpcDiagnostics {
 }
 
 export type { GatewayRpcDiagnostics };
+
+/** Capture receipt before a socket FIFO, without work when diagnostics are unused. */
+export function captureGatewayRpcReceivedAt(): number | undefined {
+  return areDiagnosticsEnabledForProcess() && hasInternalDiagnosticEventInterest("gateway.rpc")
+    ? performance.now()
+    : undefined;
+}
+
+export function createWorkerRpcDiagnostics(
+  method: string,
+  timing: GatewayRpcQueueTiming | undefined,
+): GatewayRpcDiagnostics | undefined {
+  if (!timing) {
+    return undefined;
+  }
+  // Dedicated worker ingress bypasses the generic registry. Never let a caller's
+  // unknown method become an unbounded metric dimension.
+  return new GatewayRpcDiagnostics(
+    workerMethods.has(method) ? method : "unknown",
+    timing.receivedAt,
+    timing.dequeuedAt - timing.receivedAt,
+  );
+}
 
 export function createGatewayRpcDiagnostics(
   method: string,

--- a/src/gateway/server/ws-connection/worker-connection.ts
+++ b/src/gateway/server/ws-connection/worker-connection.ts
@@ -1,3 +1,4 @@
+import { performance } from "node:perf_hooks";
 import { rawDataToString } from "@openclaw/gateway-client/websocket-data";
 import type { RawData, WebSocket } from "ws";
 import {
@@ -30,6 +31,12 @@ import { MAX_RUNNING_WORKER_SESSION_TOOL_OPERATIONS } from "../../worker-environ
 import { runWorkerTurnAdmissionContinuation } from "../../worker-environments/placement-turn-claim-events.js";
 import type { PublicWorkerIngressContext } from "../public-worker-ingress-context.js";
 import type { GatewayWsClient, WsHandshakePhase } from "../ws-types.js";
+import type { GatewayWsMessageHandlerParams } from "./message-handler-types.js";
+import {
+  captureGatewayRpcReceivedAt,
+  createWorkerRpcDiagnostics,
+  type GatewayRpcQueueTiming,
+} from "./request-diagnostics.js";
 import { raiseGatewayReceiverPayloadLimit } from "./request-start.js";
 import { runWorkerAdmissionBoundary } from "./worker-admission-boundary.js";
 import {
@@ -54,7 +61,7 @@ type WorkerWsMessageHandlerParams = {
   connId: string;
   service?: WorkerConnectionService;
   isStartupPending?: () => boolean;
-  send(frame: unknown): void;
+  send: GatewayWsMessageHandlerParams["send"];
   close(code?: number, reason?: string): void;
   isClosed(): boolean;
   clearHandshakeTimer(): void;
@@ -240,7 +247,11 @@ export function attachWorkerWsMessageHandler(params: WorkerWsMessageHandlerParam
     expiryTimer.unref?.();
   };
 
-  const handleMessage = async (data: RawData, admissionOpen: boolean) => {
+  const handleMessage = async (
+    data: RawData,
+    admissionOpen: boolean,
+    timing: GatewayRpcQueueTiming | undefined,
+  ) => {
     const client = params.getClient();
     if (client?.invalidated) {
       failFrame(1008, "credential-replaced");
@@ -324,32 +335,38 @@ export function attachWorkerWsMessageHandler(params: WorkerWsMessageHandlerParam
       closeWorker(1008, "environment-unavailable");
       return;
     }
+    const diagnostics = createWorkerRpcDiagnostics(parsed.method, timing);
     const respond = (
       ok: boolean,
       payload?: unknown,
       error?: Parameters<Parameters<typeof dispatchWorkerRequest>[0]["respond"]>[2],
     ) => {
       if (disposed || params.isClosed() || params.getClient() !== client || client.invalidated) {
+        diagnostics?.response("suppressed");
         return;
       }
-      params.send(
+      const result = params.send(
         ok
           ? { type: "res", id: parsed.id, ok, payload }
           : { type: "res", id: parsed.id, ok, error },
       );
+      diagnostics?.response(result.kind === "sent" ? (ok ? "ok" : "error") : "unavailable");
     };
-    const dispatch = (signal?: AbortSignal) =>
-      dispatchWorkerRequest({
-        request: parsed,
-        identity: client.worker!,
-        connectionId: params.connId,
-        service: params.service,
-        send: (frame) => params.send(frame),
-        respond,
-        close: closeWorker,
-        warn: (message) => params.logGateway.warn(message),
-        ...(signal ? { signal } : {}),
-      });
+    const dispatch = (signal?: AbortSignal) => {
+      const invoke = () =>
+        dispatchWorkerRequest({
+          request: parsed,
+          identity: client.worker!,
+          connectionId: params.connId,
+          service: params.service,
+          send: (frame) => params.send(frame),
+          respond,
+          close: closeWorker,
+          warn: (message) => params.logGateway.warn(message),
+          ...(signal ? { signal } : {}),
+        });
+      return diagnostics ? diagnostics.runHandler(invoke) : invoke();
+    };
     const isLongSessionOperation =
       parsed.method === "worker.sessions.spawn" ||
       parsed.method === "worker.sessions.send" ||
@@ -358,13 +375,16 @@ export function attachWorkerWsMessageHandler(params: WorkerWsMessageHandlerParam
     if (isLongSessionOperation) {
       if (sessionOperations.has(parsed.id)) {
         failFrame(1008, "invalid-frame");
+        diagnostics?.finish("rejected");
         return;
       }
       if (sessionOperations.size >= MAX_RUNNING_WORKER_SESSION_TOOL_OPERATIONS) {
         respond(false, undefined, workerProtocolError("gateway-unavailable"));
+        diagnostics?.finish("rejected");
         return;
       }
       sessionOperations.add(parsed.id);
+      let outcome: "returned" | "threw" = "returned";
       // Release the frame queue while retaining shutdown admission. Desktop input
       // belongs to this socket; durable session work survives response-transport loss.
       void params.connectionWork.track(() =>
@@ -373,15 +393,27 @@ export function attachWorkerWsMessageHandler(params: WorkerWsMessageHandlerParam
           "worker:dispatch",
         )
           .catch(() => {
+            outcome = "threw";
             respond(false, undefined, workerProtocolError("gateway-unavailable"));
           })
           .finally(() => {
             sessionOperations.delete(parsed.id);
+            // A socket abort can follow successful execution. Record the actual
+            // dispatch settlement separately from suppressed/unavailable delivery.
+            diagnostics?.finish(outcome);
           }),
       );
       return;
     }
-    await dispatch();
+    let outcome: "returned" | "threw" = "returned";
+    try {
+      await dispatch();
+    } catch (error) {
+      outcome = "threw";
+      throw error;
+    } finally {
+      diagnostics?.finish(outcome);
+    }
   };
 
   let queue = Promise.resolve();
@@ -406,10 +438,15 @@ export function attachWorkerWsMessageHandler(params: WorkerWsMessageHandlerParam
     }
     pendingFrames += 1;
     pendingBytes += frameBytes;
+    const receivedAt = captureGatewayRpcReceivedAt();
     const previous = queue;
     queue = params.connectionWork.track(() =>
       previous
         .then(async () => {
+          // Preserve the FIFO wait before parsing/classifying the request. This
+          // starts at the JS socket callback, not at network or event-loop receipt.
+          const timing =
+            receivedAt === undefined ? undefined : { receivedAt, dequeuedAt: performance.now() };
           if (disposed || params.isClosed()) {
             return;
           }
@@ -426,18 +463,18 @@ export function attachWorkerWsMessageHandler(params: WorkerWsMessageHandlerParam
               params.service?.validateWorkerConnection(identity) === null
             ) {
               const continuation = runWorkerTurnAdmissionContinuation(identity, () =>
-                handleMessage(data, true),
+                handleMessage(data, true, timing),
               );
               if (continuation) {
                 await continuation;
                 return;
               }
             }
-            await handleMessage(data, false);
+            await handleMessage(data, false, timing);
             return;
           }
           try {
-            await admission.run(() => handleMessage(data, true));
+            await admission.run(() => handleMessage(data, true, timing));
           } finally {
             admission.release();
           }

--- a/src/gateway/worker-environments/computer-transport.connection.test.ts
+++ b/src/gateway/worker-environments/computer-transport.connection.test.ts
@@ -138,7 +138,9 @@ describe("worker computer connection lifetime", () => {
           send: (frame) => {
             if (socket.readyState === WebSocket.OPEN) {
               socket.send(JSON.stringify(frame));
+              return { kind: "sent" };
             }
+            return { kind: "unavailable" };
           },
           close: (code, reason) => socket.close(code, reason),
           isClosed: () => closed,

--- a/src/worker/worker-fault-injection.test-support.ts
+++ b/src/worker/worker-fault-injection.test-support.ts
@@ -693,7 +693,7 @@ export class ComposedGatewayHarness {
     });
   }
 
-  private send(socket: WebSocket, frame: unknown): void {
+  private send(socket: WebSocket, frame: unknown) {
     const response =
       frame && typeof frame === "object" && !Array.isArray(frame)
         ? (frame as { event?: unknown; id?: unknown; payload?: { seq?: unknown } })
@@ -713,17 +713,18 @@ export class ComposedGatewayHarness {
       } else {
         socket.terminate();
       }
-      return;
+      return { kind: "unavailable" } as const;
     }
     if (socket.readyState !== WebSocket.OPEN) {
-      return;
+      return { kind: "unavailable" } as const;
     }
     const encoded = JSON.stringify(frame);
     if (fault?.kind === "partition-after-inference-event") {
       socket.send(encoded, () => socket.terminate());
-      return;
+    } else {
+      socket.send(encoded);
     }
-    socket.send(encoded);
+    return { kind: "sent" } as const;
   }
 
   private terminateSockets(): void {


### PR DESCRIPTION
Closes https://github.com/openclaw/openclaw/issues/145587

Follows merged https://github.com/openclaw/openclaw/pull/145600. This main-targeted PR contains only worker RPC diagnostic coverage.

## What Problem This Solves

Resolves a problem where operators investigating cloud-worker pauses cannot distinguish Gateway queue wait, request handling, and response delay because dedicated worker ingress bypasses Gateway RPC diagnostics.

## Why This Change Was Made

Reuse the existing `gateway.rpc` lifecycle at the dedicated worker ingress boundary. Capture receipt before its FIFO, preserve the dequeue time through validation, and record handler settlement and the actual sender result. Method dimensions come from the canonical closed worker method tuples; unknown methods use one fixed label.

Existing scheduling, inference acknowledgment ordering, durable transcript commits, and connection ownership stay intact. Production delta: +69 lines to cover the previously unobserved ingress boundary; tests: +271; docs: +10. No new metric names, configuration, protocol fields, or storage are introduced.

## User Impact

Existing Gateway RPC dashboards can distinguish worker FIFO admission, handler work, and response sending. A successful send records acceptance by the WebSocket sender; client receipt is outside this measurement. Timing starts at the JavaScript socket callback. It excludes preceding network/event-loop delay; inference-start measures acceptance/setup rather than provider completion. Socket closure alone does not prove execution cancellation. This enables diagnosis and makes no measured latency-reduction claim.

## Evidence

- 87 worker/Gateway tests pass, including nine new metric cases plus existing admission, transcript, media, duplicate request, shutdown, durable-session, and generic RPC coverage.
- Six diagnostics plugin tests pass with real OpenTelemetry SDK aggregation.
- New cases prove deterministic FIFO/handler timings, ACK-before-launch, detached computer lifetime, failed/suppressed sends, service throws, bounded labels, and the disabled fast path.
- 15 composed worker fault-injection cases pass, covering disconnects, replay, restart fencing, and durable transcript settlement.
- Five computer connection-lifetime cases pass through real WebSockets, including policy/pairing fencing, completed input, and durable work during ordinary close.
- Selected typechecks and scoped static checks/lint pass; the production UI build also passes for the combined stack.
- Independent exact-commit review and autoreview: no actionable findings.

Development proof at the original telemetry head `3b599b2eca3d3e1f450d5ae79ea05bcd97730329` used Node 24.19.0 on Blacksmith Testbox, with all 41,132 source blobs and the frozen dependency lock verified. [Testbox hydration run](https://github.com/openclaw/openclaw/actions/runs/34671571965).

The signed restack `d34c45bf00da3015543d14fa9989c1ef7fb8b5a0` is based on the UI squash merge `ef217a415fea44500c19b9434db2ec40fa288547`. `git range-diff` confirms the telemetry patch is unchanged; current main's WebSocket test import is preserved. [Required hosted CI](https://github.com/openclaw/openclaw/actions/runs/34700304642) passed for this exact head: 115 successful jobs, 16 scope-based skips, and no failures. The [required `openclaw/ci-gate`](https://github.com/openclaw/openclaw/actions/runs/34700304642/job/103572748302) is green. Fresh exact-head ClawSweeper review found no actionable findings or remaining before-merge actions.
