### PR TITLE
fix: stop merge verification when drift evidence is unavailable

### DIFF
--- a/scripts/pr-lib/merge.sh
+++ b/scripts/pr-lib/merge.sh
@@ -13,16 +13,17 @@ print_file_list_with_limit() {
   local file_path="$2"
   local limit="${3:-12}"
 
-  if [ ! -s "$file_path" ]; then
+  local count
+  count=$(wc -l < "$file_path" | tr -d ' ') || return 1
+  [[ "$count" =~ ^[0-9]+$ ]] || return 1
+  if [ "$count" -eq 0 ]; then
     return 0
   fi
 
-  local count
-  count=$(wc -l < "$file_path" | tr -d ' ')
-  echo "$label ($count):"
-  sed -n "1,${limit}p" "$file_path" | sed 's/^/  - /'
+  echo "$label ($count):" || return 1
+  sed -n "1,${limit}p" "$file_path" | sed 's/^/  - /' || return 1
   if [ "$count" -gt "$limit" ]; then
-    echo "  ... +$((count - limit)) more"
+    echo "  ... +$((count - limit)) more" || return 1
   fi
 }
 
@@ -122,69 +123,72 @@ require_clawsweeper_review() {
   validate_clawsweeper_review_comments "$pr" "$head_sha"
 }
 
-mainline_drift_requires_sync() {
+# Return 0 for relevant drift, 1 for unrelated drift, and 2 for failed evaluation.
+# The caller uses a conditional, so every fallible evidence operation is checked.
+mainline_drift_requires_sync() (
+  set -o pipefail
   local mainline_base="$1"
   local prepared_head_sha="$2"
 
   if ! GIT_NO_LAZY_FETCH=1 git cat-file -e "${mainline_base}^{commit}" 2>/dev/null; then
-    echo "Mainline drift relevance: mainline base $mainline_base is missing locally; require sync."
-    return 0
+    echo "Mainline drift relevance: unable to read mainline base $mainline_base locally." >&2
+    return 2
   fi
   if ! GIT_NO_LAZY_FETCH=1 git cat-file -e "${prepared_head_sha}^{commit}" 2>/dev/null; then
-    echo "Mainline drift relevance: prepared head $prepared_head_sha is missing locally; require sync."
-    return 0
+    echo "Mainline drift relevance: unable to read prepared head $prepared_head_sha locally." >&2
+    return 2
   fi
 
-  local delta_file
-  local prepared_files_file
-  local overlap_file
-  local critical_file
-  delta_file=$(mktemp)
-  prepared_files_file=$(mktemp)
-  overlap_file=$(mktemp)
-  critical_file=$(mktemp)
+  local scratch
+  scratch=$(mktemp -d "${TMPDIR:-/tmp}/openclaw-pr-drift.XXXXXX") || return 2
+  trap 'rm -rf -- "$scratch" || exit 2' EXIT
+  local delta_file="$scratch/mainline"
+  local prepared_files_file="$scratch/prepared"
+  local overlap_file="$scratch/overlap"
+  local critical_file="$scratch/critical"
 
   # Compare only mainline commits since the prepared lineage base. The remote
   # GraphQL commit has a different parent but its verified tree shares this
   # lineage, so its PR files must not look like incoming mainline drift.
-  git diff --name-only "${mainline_base}..${PR_MAIN_SHA}" | sed '/^$/d' | sort -u > "$delta_file"
-  git diff --name-only "${mainline_base}..${prepared_head_sha}" | sed '/^$/d' | sort -u > "$prepared_files_file"
-  comm -12 "$delta_file" "$prepared_files_file" > "$overlap_file" || true
+  git diff --name-only "${mainline_base}..${PR_MAIN_SHA}" | sed '/^$/d' | sort -u > "$delta_file" || return 2
+  git diff --name-only "${mainline_base}..${prepared_head_sha}" | sed '/^$/d' | sort -u > "$prepared_files_file" || return 2
+  comm -12 "$delta_file" "$prepared_files_file" > "$overlap_file" || return 2
+  : > "$critical_file" || return 2
 
-  local path
+  local path read_count=0
   while IFS= read -r path; do
+    read_count=$((read_count + 1))
     [ -n "$path" ] || continue
     if is_mainline_drift_critical_path_for_merge "$path"; then
-      printf '%s\n' "$path" >> "$critical_file"
+      printf '%s\n' "$path" >> "$critical_file" || return 2
     fi
-  done < "$delta_file"
+  done < "$delta_file" || return 2
 
   local delta_count
   local overlap_count
   local critical_count
-  delta_count=$(wc -l < "$delta_file" | tr -d ' ')
-  overlap_count=$(wc -l < "$overlap_file" | tr -d ' ')
-  critical_count=$(wc -l < "$critical_file" | tr -d ' ')
+  delta_count=$(wc -l < "$delta_file" | tr -d ' ') || return 2
+  overlap_count=$(wc -l < "$overlap_file" | tr -d ' ') || return 2
+  critical_count=$(wc -l < "$critical_file" | tr -d ' ') || return 2
+  [[ "$delta_count" =~ ^[0-9]+$ && "$overlap_count" =~ ^[0-9]+$ && "$critical_count" =~ ^[0-9]+$ ]] || return 2
+  [ "$read_count" -eq "$delta_count" ] || return 2
 
   if [ "$delta_count" -eq 0 ]; then
-    echo "Mainline drift relevance: no mainline changes since the prepared base."
-    rm -f "$delta_file" "$prepared_files_file" "$overlap_file" "$critical_file"
+    echo "Mainline drift relevance: no mainline changes since the prepared base." || return 2
     return 1
   fi
 
   if [ "$overlap_count" -gt 0 ] || [ "$critical_count" -gt 0 ]; then
-    echo "Mainline drift relevance: sync required before merge."
-    print_file_list_with_limit "Mainline files overlapping prepared files" "$overlap_file"
-    print_file_list_with_limit "Mainline files touching merge-critical infrastructure" "$critical_file"
-    rm -f "$delta_file" "$prepared_files_file" "$overlap_file" "$critical_file"
+    print_file_list_with_limit "Mainline files overlapping prepared files" "$overlap_file" || return 2
+    print_file_list_with_limit "Mainline files touching merge-critical infrastructure" "$critical_file" || return 2
+    echo "Mainline drift relevance: sync required before merge." || return 2
     return 0
   fi
 
-  echo "Mainline drift relevance: no overlap with prepared files and no critical infra drift."
-  print_file_list_with_limit "Mainline-only drift files" "$delta_file"
-  rm -f "$delta_file" "$prepared_files_file" "$overlap_file" "$critical_file"
+  print_file_list_with_limit "Mainline-only drift files" "$delta_file" || return 2
+  echo "Mainline drift relevance: no overlap with prepared files and no critical infra drift." || return 2
   return 1
-}
+)
 
 merge_verify() {
   local pr="$1" replacement_head="${2:-}"
@@ -329,6 +333,11 @@ merge_verify() {
       fi
       echo "Merge verify: WARNING — mainline drift is relevant to this PR; proceeding (OPENCLAW_PR_STRICT_DRIFT=1 restores the hard gate)."
     else
+      local drift_status=$?
+      if [ "$drift_status" -ne 1 ]; then
+        echo "Merge verify failed: unable to evaluate mainline drift; no merge was attempted." >&2
+        return 1
+      fi
       echo "Merge verify: continuing without prep-head sync because behind-main drift is unrelated."
     fi
   fi

--- a/test/scripts/pr-main-refresh.test.ts
+++ b/test/scripts/pr-main-refresh.test.ts
@@ -741,6 +741,102 @@ read -r release < "$OPENCLAW_TEST_FETCH_HOLD"
     },
   );
 
+  it.each([
+    [
+      "commit read",
+      'git() { if [ "${DRIFT_FAULT_ACTIVE:-}" = 1 ] && [ "$1" = cat-file ]; then return 1; fi; command git "$@"; }',
+    ],
+    [
+      "scratch allocation",
+      'mktemp() { [ "${DRIFT_FAULT_ACTIVE:-}" != 1 ] || return 1; command mktemp "$@"; }',
+    ],
+    [
+      "mainline diff",
+      'git() { if [ "${DRIFT_FAULT_ACTIVE:-}" = 1 ] && [ "$1" = diff ] && [[ "$3" = *"$PR_MAIN_SHA" ]]; then return 1; fi; command git "$@"; }',
+    ],
+    [
+      "prepared diff",
+      'git() { if [ "${DRIFT_FAULT_ACTIVE:-}" = 1 ] && [ "$1" = diff ] && [[ "$3" = *"$PREP_HEAD_SHA" ]]; then return 1; fi; command git "$@"; }',
+    ],
+    [
+      "overlap read",
+      'comm() { [ "${DRIFT_FAULT_ACTIVE:-}" != 1 ] || return 1; command comm "$@"; }',
+    ],
+    [
+      "critical file write",
+      'is_mainline_drift_critical_path_for_merge() { rm -f "$critical_file"; mkdir "$critical_file"; return 0; }',
+    ],
+    ["path read", 'read() { [ "${DRIFT_FAULT_ACTIVE:-}" != 1 ] || return 1; builtin read "$@"; }'],
+    ["count read", 'wc() { [ "${DRIFT_FAULT_ACTIVE:-}" != 1 ] || return 1; command wc "$@"; }'],
+    [
+      "diagnostic read",
+      'sed() { if [ "${DRIFT_FAULT_ACTIVE:-}" = 1 ] && [ "$1" = -n ]; then return 1; fi; command sed "$@"; }',
+    ],
+  ])("rejects drift %s failure before merge intent or dispatch", (_name, fault) => {
+    const f = fixture();
+    expect(f.run("prepare-run").status).toBe(0);
+    f.configure({ moveAtChecks: true });
+    const result = f.shell(`
+eval "$(declare -f mainline_drift_requires_sync | sed '1s/mainline_drift_requires_sync/evaluate_actual_drift/')"
+mainline_drift_requires_sync() {
+  local DRIFT_FAULT_ACTIVE=1
+  evaluate_actual_drift "$@"
+}
+${fault}
+# Stop an unfixed verifier before it could create even a synthetic merge intent.
+prepare_squash_merge_body() { echo UNEXPECTED_AFTER_VERIFY >&2; return 99; }
+merge_run 42 || exit 1
+`);
+    const output = result.stdout + result.stderr;
+    expect(result.status, output).toBe(1);
+    expect(output, output).toContain("unable to evaluate mainline drift");
+    expect(output).not.toContain("UNEXPECTED_AFTER_VERIFY");
+    expect(output).not.toContain("because behind-main drift is unrelated");
+    expect(existsSync(join(f.local, "merge-output.log"))).toBe(false);
+    expect(
+      f.events().some((e) => e.kind === "gh" && e.args?.[0] === "pr" && e.args[1] === "merge"),
+    ).toBe(false);
+    expect(
+      f.git(
+        f.canonical,
+        "for-each-ref",
+        "--format=%(refname)",
+        "refs/openclaw/pr-merge-outcomes/42",
+      ),
+    ).toBe("");
+    expect(f.git(f.origin, "rev-parse", "refs/heads/main")).toBe(f.movedMain);
+    expect(readdirSync(f.root).filter((name) => name.startsWith("openclaw-pr-drift."))).toEqual([]);
+  });
+
+  it.each([false, true])("retains successful unrelated drift results (files=%s)", (hasFiles) => {
+    const f = fixture();
+    const result = f.shell(
+      `PR_MAIN_SHA=${hasFiles ? f.movedMain : f.main}
+if mainline_drift_requires_sync ${f.main} ${f.main}; then
+  exit 99
+else
+  test "$?" -eq 1
+fi`,
+      "/bin/bash",
+    );
+    expect(result.status, result.stdout + result.stderr).toBe(0);
+    expect(result.stdout).toContain(hasFiles ? "no overlap" : "no mainline changes");
+    expect(readdirSync(f.root).filter((name) => name.startsWith("openclaw-pr-drift."))).toEqual([]);
+  });
+
+  it("rejects drift evaluation errors in strict mode", () => {
+    const f = fixture();
+    expect(f.run("prepare-run").status).toBe(0);
+    f.configure({ moveAtChecks: true });
+    f.env.OPENCLAW_PR_STRICT_DRIFT = "1";
+    const result = f.shell(
+      "mainline_drift_requires_sync() { return 2; }\nmerge_verify 42 || exit 1",
+    );
+    expect(result.status, result.stdout + result.stderr).toBe(1);
+    expect(result.stderr).toContain("unable to evaluate mainline drift");
+    expect(result.stdout).not.toContain("because behind-main drift is unrelated");
+  });
+
   it("rejects a moved prepared branch without consuming CI proof", () => {
     const f = fixture();
     expect(f.run("prepare-run").status).toBe(0);


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where native merge verification could report unrelated mainline drift and continue after temporary-file allocation or evidence reads failed. Disk exhaustion exposed this failure path: empty counts fell through to the unrelated-drift result.

## Why This Change Was Made

The evaluator now distinguishes valid relevant drift, valid unrelated drift, and failed evaluation. Every evidence operation is checked, scratch files share one owned temporary directory with cleanup, and the caller rejects evaluation errors in both normal and strict modes. Successful evaluations retain the existing advisory-versus-strict policy.

## User Impact

Maintainers get an explicit verification failure when drift evidence is unavailable. No new option or bypass is added, and completed merge outcomes are untouched.

## Evidence

The original implementation fails eight new fault/strict regressions. The retained allocation reproduction reaches a false unrelated-drift result; a fixture sentinel stops it before any intent or dispatch. All 61 main-refresh tests now pass, retaining all 49 existing cases and adding 12 focused cases for errors, cleanup, and successful results. Tests use isolated file-only Git remotes and synthetic GitHub responses.

Mapped checks pass, including root-test types, all three dead-export scans, script lint, and formatting. Fresh independent P0–P2 review is clean. The diff adds 96 test lines and nine tooling lines.
