### PR TITLE
fix(codex): drop omitted tool-only context

### DIFF
--- a/extensions/codex/src/app-server/context-engine-projection.test.ts
+++ b/extensions/codex/src/app-server/context-engine-projection.test.ts
@@ -152,7 +152,7 @@ describe("projectContextEngineAssemblyForCodex", () => {
     expect(result.developerInstructionAddition).toBe("memory recall");
   });
 
-  it("preserves role order and falls back to the raw prompt for empty history", async () => {
+  it("preserves retained role order and falls back to the raw prompt for empty history", async () => {
     const empty = await projectContextEngineAssemblyForCodex({
       assembledMessages: [],
       originalHistoryMessages: [],
@@ -169,7 +169,9 @@ describe("projectContextEngineAssemblyForCodex", () => {
       originalHistoryMessages: [textMessage("user", "seed")],
       prompt: "next",
     });
-    expect(ordered.promptText).toContain("[user]\none\n\n[assistant]\ntwo\n\n[toolResult]\nthree");
+    expect(ordered.promptText).toContain("[user]\none\n\n[assistant]\ntwo");
+    expect(ordered.promptText).not.toContain("[toolResult]");
+    expect(ordered.promptText).not.toContain("three");
     expect(ordered.prePromptMessageCount).toBe(1);
   });
 
@@ -234,7 +236,7 @@ describe("projectContextEngineAssemblyForCodex", () => {
     },
   );
 
-  it("frames projected history as reference data and omits tool payloads", async () => {
+  it("drops omitted tool-only events while preserving substantive message text", async () => {
     const result = await projectContextEngineAssemblyForCodex({
       assembledMessages: [
         {
@@ -246,8 +248,19 @@ describe("projectContextEngineAssemblyForCodex", () => {
         } as unknown as AgentMessage,
         {
           role: "toolResult",
-          content: [{ type: "toolResult", toolUseId: "call-1", content: "API_KEY=sk-secret" }],
+          toolCallId: "call-1",
+          toolName: "exec",
+          content: [{ type: "text", text: "API_KEY=sk-secret" }],
+          isError: false,
           timestamp: 2,
+        },
+        {
+          role: "assistant",
+          content: [
+            { type: "text", text: "The operation completed." },
+            { type: "toolCall", name: "read", input: { path: ".env" } },
+          ],
+          timestamp: 3,
         } as unknown as AgentMessage,
       ],
       originalHistoryMessages: [],
@@ -255,10 +268,13 @@ describe("projectContextEngineAssemblyForCodex", () => {
     });
 
     expect(result.promptText).toContain("quoted reference data");
-    expect(result.promptText).toContain("tool call: exec [input omitted]");
-    expect(result.promptText).toContain("tool result: call-1 [content omitted]");
+    expect(result.promptText).toContain("[assistant]\nThe operation completed.");
+    expect(result.promptText).not.toContain("tool call");
+    expect(result.promptText).not.toContain("tool result");
+    expect(result.promptText).not.toContain("call-1");
     expect(result.promptText).not.toContain("sk-secret");
     expect(result.promptText).not.toContain("cat .env");
+    expect(result.promptText).not.toContain('path: ".env"');
   });
 
   it("preserves redacted tool payload context for thread bootstrap projections", async () => {
@@ -281,15 +297,16 @@ describe("projectContextEngineAssemblyForCodex", () => {
         } as unknown as AgentMessage,
         {
           role: "toolResult",
+          toolCallId: "call-1",
+          toolName: "exec",
           content: [
-            {
-              type: "toolResult",
-              toolUseId: "call-1",
-              content: "OPENAI_API_KEY=sk-1234567890abcdef\nstatus ok",
-            },
+            { type: "text", text: "OPENAI_API_KEY=sk-1234567890abcdef\nstatus ok" },
+            { type: "image", data: "private-base64", mimeType: "image/png" },
           ],
-          timestamp: 2,
-        } as unknown as AgentMessage,
+          details: { internal: "private-detail" },
+          isError: false,
+          timestamp: 1_723_456_789,
+        },
       ],
       originalHistoryMessages: [],
       prompt: "continue",
@@ -305,8 +322,12 @@ describe("projectContextEngineAssemblyForCodex", () => {
     expect(result.promptText).toContain('"content"');
     expect(result.promptText).toContain("OPENAI_API_KEY=");
     expect(result.promptText).toContain("status ok");
+    expect(result.promptText).toContain("[image omitted]");
     expect(result.promptText).not.toContain("cat .env");
     expect(result.promptText).not.toContain("sk-1234567890abcdef");
+    expect(result.promptText).not.toContain("private-base64");
+    expect(result.promptText).not.toContain("private-detail");
+    expect(result.promptText).not.toContain("1723456789");
   });
 
   it.each(["assistant", "compaction", "branch_summary"] as const)(

--- a/extensions/codex/src/app-server/context-engine-projection.ts
+++ b/extensions/codex/src/app-server/context-engine-projection.ts
@@ -444,6 +444,15 @@ function renderMessageBody(
   if (message.role === "compactionSummary" || message.role === "branchSummary") {
     return truncateText(message.summary.trim(), options.maxTextPartChars);
   }
+  if (message.role === "toolResult") {
+    if (options.toolPayloadMode === "elide") {
+      return "";
+    }
+    return truncateText(
+      `tool result: ${message.toolCallId}\n${stableJson(renderCanonicalToolResultPayload(message))}`,
+      options.maxTextPartChars,
+    );
+  }
   if (!hasMessageContent(message)) {
     return "";
   }
@@ -489,7 +498,7 @@ function renderMessagePart(
         options.maxTextPartChars,
       );
     }
-    return `${label} [input omitted]`;
+    return "";
   }
   if (type === "toolResult" || type === "tool_result") {
     const label =
@@ -500,7 +509,7 @@ function renderMessagePart(
         options.maxTextPartChars,
       );
     }
-    return `${label} [content omitted]`;
+    return "";
   }
   return `[${type ?? "non-text"} content omitted]`;
 }
@@ -523,6 +532,28 @@ function renderToolResultPayload(record: Record<string, unknown>): Record<string
     payload[key] = redactPreservedToolValue(key, value);
   }
   return payload;
+}
+
+function renderCanonicalToolResultPayload(
+  message: Extract<AgentMessage, { role: "toolResult" }>,
+): Record<string, unknown> {
+  return {
+    toolCallId: redactSensitiveFieldValue("toolCallId", message.toolCallId),
+    toolName: redactSensitiveFieldValue("toolName", message.toolName),
+    isError: message.isError,
+    content: message.content.map((part) => {
+      if (part.type === "text") {
+        return {
+          type: "text",
+          text: redactSensitiveFieldValue("text", redactToolPayloadText(part.text)),
+        };
+      }
+      if (part.type === "image") {
+        return "[image omitted]";
+      }
+      return "[non-text content omitted]";
+    }),
+  };
 }
 
 const TOOL_PAYLOAD_METADATA_KEYS = new Set([

--- a/extensions/codex/src/app-server/run-attempt.context-engine.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.context-engine.test.ts
@@ -166,16 +166,10 @@ function toolResultMessage(payload: unknown, timestamp: number): AgentMessage {
     role: "toolResult",
     toolCallId: `call-${timestamp}`,
     toolName: "bulk_context_probe",
-    content: [
-      {
-        type: "toolResult",
-        toolUseId: `call-${timestamp}`,
-        output: payload,
-      },
-    ],
+    content: [{ type: "text", text: JSON.stringify(payload) ?? "" }],
     isError: false,
     timestamp,
-  } as unknown as AgentMessage;
+  };
 }
 
 function createStartedThreadHarness(


### PR DESCRIPTION
Closes #145561

## What Problem This Solves

Codex continuity projections currently retain a placeholder for every omitted tool call and tool result. Tool-heavy histories therefore spend part of their bounded context window on events that carry no usable content.

## Why This Is The Right Scope

This follows the narrower direction from the earlier closed implementation: default omission mode now drops fully omitted tool-only events instead of replacing them with summary markers. Mixed assistant messages keep their substantive text. Thread-bootstrap preserve mode remains available and now projects canonical tool results through an explicit safe shape: stable identifiers, error state, redacted text, and image omission markers only.

## User Impact

Tool-heavy Codex sessions retain more useful conversation context without changing storage, configuration, transcript ownership, or bootstrap policy. Canonical tool-result details, timestamps, role metadata, and image bytes are not introduced into the projected prompt.

## Evidence

- Added canonical tool-call/tool-result regression coverage for default omission and preserve/bootstrap behavior.
- Updated the run-attempt fixture to use the real `ToolResultMessage` content shape.
- Focused context-engine and run-attempt suites: 88 tests passed.
- `pnpm check:changed` passed with the unrelated repository dead-export scan skipped; the full scan currently reports pre-existing unused exports outside this change.
- Formatting, diff, typecheck, lint, boundary, import-cycle, and preflight checks passed. Preflight only warned about the intentional removal of omission placeholders.
