### PR TITLE
fix: release completed caller state from idle workers

### DIFF
--- a/src/infra/worker-task-pool.reply-retention.test-support.ts
+++ b/src/infra/worker-task-pool.reply-retention.test-support.ts
@@ -1,28 +1,30 @@
 import assert from "node:assert/strict";
+import { AsyncLocalStorage } from "node:async_hooks";
 import { setImmediate } from "node:timers/promises";
 import { WorkerTaskPool } from "./worker-task-pool.js";
 import type { PoolFixtureInput, PoolFixtureResult } from "./worker-task-pool.test-support.js";
 
 const gc = globalThis.gc;
 assert.ok(gc, "The retention child requires --expose-gc");
+const callerContext = new AsyncLocalStorage<object>();
 const pool = new WorkerTaskPool<PoolFixtureInput, PoolFixtureResult>({
   workerUrl: new URL("./worker-task-pool.test-support.ts", import.meta.url),
   maxWorkers: 1,
-  idleTimeoutMs: 0,
 });
 
 async function receiveFirstReply() {
-  const result = await pool.run(
-    { label: "first reply", buffer: new ArrayBuffer(4) },
-    { timeoutMs: 10_000 },
+  const context = { history: ["synthetic completed caller"] };
+  const contextReference = new WeakRef(context);
+  const result = await callerContext.run(context, () =>
+    pool.run({ label: "first reply", buffer: new ArrayBuffer(4) }, { timeoutMs: 10_000 }),
   );
   assert.equal(result.label, "first reply");
   assert.equal(result.buffer?.byteLength, 4);
-  return { reference: new WeakRef(result), threadId: result.threadId };
+  return { reference: new WeakRef(result), contextReference, threadId: result.threadId };
 }
 
 try {
-  const { reference, threadId } = await receiveFirstReply();
+  const { reference, contextReference, threadId } = await receiveFirstReply();
   const control = new WeakRef({ unowned: true });
   for (let pass = 0; pass < 8; pass += 1) {
     await setImmediate();
@@ -30,6 +32,11 @@ try {
   }
   assert.equal(control.deref(), undefined, "Unowned control must collect");
   assert.equal(reference.deref(), undefined, "Warm worker retained its first completed reply");
+  assert.equal(
+    contextReference.deref(),
+    undefined,
+    "Warm worker retained its completed caller context",
+  );
   const next = await pool.run({ label: "warm worker" }, { timeoutMs: 10_000 });
   assert.equal(next.threadId, threadId, "The worker must remain reusable during collection");
   assert.equal(next.previousBufferBytes, 0, "The same worker must retain its transferred marker");

--- a/src/infra/worker-task-pool.ts
+++ b/src/infra/worker-task-pool.ts
@@ -462,12 +462,14 @@ export class WorkerTaskPool<Input, Output> {
     this.dispatch();
   }
 
-  // A separate scope keeps the idle timer from retaining the completed task/result.
+  // Reply handling restores the caller's context; idle retirement must leave it behind.
   private idle(slot: Slot<Input, Output>): void {
     slot.worker?.unref();
     const idleMs = this.options.idleTimeoutMs ?? 60_000;
     if (idleMs > 0) {
-      slot.idleTimer = this.setTimeoutFn(() => void this.retire(slot), idleMs);
+      slot.idleTimer = runInWorkerPoolContext(() =>
+        this.setTimeoutFn(() => void this.retire(slot), idleMs),
+      );
       slot.idleTimer.unref();
     }
   }


### PR DESCRIPTION
## What Problem This Solves

Fixes extra memory retention after worker tasks finish. An idle worker's retirement timer inherited the completed caller's `AsyncLocalStorage` context, keeping that caller's state alive until reuse or retirement.

## Why This Change Was Made

Create the idle timer in the existing pool-owned async context, matching worker creation. Reply handling deliberately restores each task's caller context, so moving timer creation into a separate method had not separated its async lifetime. The existing retirement delay and caller-bound preparation, host exchanges, completion, and cancellation remain in effect.

The existing real-worker reply-retention regression now uses normal idle retirement and checks collection of the completed caller context as well as the reply.

## User Impact

Workers can remain warm for reuse without their idle timers prolonging completed caller state. This removes avoidable retained heap after bursts of worker tasks.

## Evidence

- The extended regression failed before the fix with `Warm worker retained its completed caller context`; the unowned control and delivered reply collected. After the fix, both caller context and reply collect while the same worker remains reusable.
- All 18 real-worker pool tests pass, covering input/reply collection, per-caller async context, cancellation, queued/reused work, retirement, and headless process exit. The complete selected changed-file gate passes, including core production/test typechecks, lint, and repository guards. Fresh independent P0–P2 review is clean.
- A generic eight-worker synthetic stress run used eight 8 MiB caller histories and forced GC while workers stayed warm. Before: eight contexts retained and approximately 64 MiB additional main-isolate heap. After: zero contexts retained and approximately 0 MiB additional heap. Results match on Node 26.7.0 and 26.8.2 on macOS.
- This measures the generic pool, not any deployment's pool width or the cause of a production OOM. Reuse already released the previous contexts on both tested Node versions, so the fix is limited to idle timer creation. It reuses the existing pool scope; it does not claim to clear every async store or repair a separate lazy-first-import context capture.
