### PR TITLE
fix(update): keep the rehearsal Doctor from retiring workspace files outside the rehearsal root

### DIFF
--- a/docs/cli/doctor/state-migrations.md
+++ b/docs/cli/doctor/state-migrations.md
@@ -25,6 +25,13 @@ milestones normally. A successful repair removes the runtime blocker; the next
 run has no workspace setup migration to repeat. Invalid files and workspace
 identity/version conflicts remain blocked for inspection.
 
+Update rehearsals write only inside their copied state directory. Workspace
+files are not copied by the rehearsal, so absolute paths retained in proposal,
+rollback, and backup records remain read-only inventory. Doctor reports how many
+legacy workspace files it left untouched; it does not retire their files or
+proposal history. After the candidate is installed, the real Doctor runs the
+normal import, archival, and relocation against the operator's state.
+
 Doctor reports interrupted auth-profile archive recovery even when no new migration remains or you decline another migration. If recovery cannot finish, its warning includes the failure cause and leaves the pending source for recovery; do not delete it to silence the warning.
 
 `doctor --fix` also repairs an inconsistent completed auth migration only when its old receipt has no credential fingerprints, none of the migrated credentials remain in the current canonical store, and the preserved archive still matches the recorded source hash. Doctor reimports through the normal verified migration flow. Completed receipts with fingerprints, surviving migrated credentials, or no archive remain untouched, so removing credentials after a verified migration does not restore them from backup.

--- a/src/commands/doctor-skill-workshop-collection-backups.ts
+++ b/src/commands/doctor-skill-workshop-collection-backups.ts
@@ -11,6 +11,7 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { pathExists } from "../infra/fs-safe.js";
 import { executeSqliteQuerySync } from "../infra/kysely-sync.js";
 import { isPathStrictlyInside } from "../infra/path-guards.js";
+import { isUpdateRehearsalReadOnlyPath } from "../infra/update-rehearsal-paths.js";
 import { resolveSkillManifestMetadata } from "../skills/loading/frontmatter.js";
 import { readSkillFrontmatterSafe } from "../skills/loading/local-loader.js";
 import { resolveSkillDiscoveryLimits } from "../skills/loading/skill-root-discovery.js";
@@ -66,9 +67,15 @@ export async function listPendingLegacyCollectionBackupRoots(
 ): Promise<LegacyCollectionBackupRoot[]> {
   const roots: LegacyCollectionBackupRoot[] = [];
   for (const legacyRoot of await listLegacyCollectionBackupRoots(env)) {
+    if (isUpdateRehearsalReadOnlyPath(legacyRoot, env)) {
+      continue;
+    }
     try {
       const backups = await readLegacyCollectionBackups(legacyRoot);
-      if (backups.length === 0) {
+      if (
+        backups.length === 0 ||
+        backups.some((backup) => isReadOnlyRehearsalBackup(backup, env))
+      ) {
         continue;
       }
       const workspaceDirs = new Set(backups.map((backup) => backup.workspaceDir));
@@ -98,6 +105,9 @@ export async function listPendingLegacyCollectionBackupRoots(
         operation: "doctor",
       });
       const destinationRoot = resolveSkillCollectionBackupRoot(config, ownerAgentId, env);
+      if (isUpdateRehearsalReadOnlyPath(destinationRoot, env)) {
+        continue;
+      }
       const alreadyArchived = await Promise.all(
         backups.map((backup) =>
           isHistoryOnlyBackup(path.join(destinationRoot, backup.manifest.id)),
@@ -125,6 +135,20 @@ type LegacyCollectionBackup = {
   manifest: CollectionBackupManifest;
   sourceDirs: ReadonlyMap<string, string>;
 };
+
+function isReadOnlyRehearsalBackup(
+  backup: LegacyCollectionBackup,
+  env: NodeJS.ProcessEnv,
+): boolean {
+  return [
+    backup.backupDir,
+    backup.workspaceDir,
+    ...[...backup.sourceDirs.values()].flatMap((relativeDir) => [
+      path.join(backup.workspaceDir, relativeDir),
+      path.join(backup.backupDir, "workspace", relativeDir),
+    ]),
+  ].some((filePath) => isUpdateRehearsalReadOnlyPath(filePath, env));
+}
 
 export function inferWorkspaceOwnerAgentId(
   config: OpenClawConfig,
@@ -500,6 +524,14 @@ export async function migrateLegacyCollectionBackups(
       continue;
     }
     const { legacyRoot, backups, ownerAgentId, destinationRoot } = root;
+    if (
+      [legacyRoot, destinationRoot].some((filePath) =>
+        isUpdateRehearsalReadOnlyPath(filePath, env),
+      ) ||
+      backups.some((backup) => isReadOnlyRehearsalBackup(backup, env))
+    ) {
+      continue;
+    }
     try {
       const newerBackupExists = await hasNewerUnrelatedCollectionBackup(destinationRoot, backups);
       const restorable: LegacyCollectionBackup[] = [];
@@ -525,6 +557,9 @@ export async function migrateLegacyCollectionBackups(
         );
       }
       for (const backup of restorable) {
+        if (isReadOnlyRehearsalBackup(backup, env)) {
+          continue;
+        }
         await fs.rm(backup.backupDir, { recursive: true, force: false });
       }
       if ((await fs.readdir(legacyRoot)).length === 0) {

--- a/src/commands/doctor-skill-workshop-rehearsal.test.ts
+++ b/src/commands/doctor-skill-workshop-rehearsal.test.ts
@@ -1,0 +1,347 @@
+import { createHash } from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  readWorkspaceStateSnapshot,
+  replaceWorkspaceAttestation,
+  WORKSPACE_CONTENT_RELOCATION_MIGRATION_KIND,
+} from "../agents/workspace-state-store.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { buildUpdateRehearsalPathEnv } from "../infra/update-rehearsal-paths.js";
+import { resolveSkillCollectionBackupRoot } from "../skills/workshop/collection-paths.js";
+import {
+  renderProposalMarkdown,
+  stripProposalFrontmatterForSkill,
+} from "../skills/workshop/frontmatter.js";
+import { resolveWorkshopSkillsDir } from "../skills/workshop/skills-root.js";
+import { hashSkillProposalContent, importLegacySkillProposal } from "../skills/workshop/store.js";
+import {
+  SKILL_WORKSHOP_ROLLBACK_SCHEMA,
+  type SkillProposalRecord,
+  type SkillProposalRollback,
+} from "../skills/workshop/types.js";
+import { openOpenClawStateDatabase } from "../state/openclaw-state-db.js";
+import {
+  withOpenClawTestState,
+  type OpenClawTestState,
+} from "../test-utils/openclaw-test-state.js";
+import {
+  inspectLegacySkillWorkshopMigration,
+  migrateLegacySkillWorkshopProposals,
+} from "./doctor-skill-workshop-sqlite.js";
+import { createAppliedLegacyProposal } from "./doctor-skill-workshop-sqlite.test-support.js";
+import { prepareWorkshopWorkspaceRelocation } from "./doctor-skill-workshop-workspaces.js";
+
+function rehearsalEnv(state: OpenClawTestState): NodeJS.ProcessEnv {
+  return {
+    ...state.env,
+    ...buildUpdateRehearsalPathEnv(state.stateDir),
+    OPENCLAW_UPDATE_IN_PROGRESS: "1",
+    OPENCLAW_SERVICE_REPAIR_POLICY: "external",
+    OPENCLAW_UPDATE_PARENT_ALLOWS_GATEWAY_SERVICE_REPAIR: "0",
+    OPENCLAW_UPDATE_PARENT_ALLOWS_GATEWAY_ACTIVATION: "0",
+    OPENCLAW_COMPATIBILITY_HOST_VERSION: undefined,
+  };
+}
+
+function configForWorkspace(workspaceDir: string): OpenClawConfig {
+  return { agents: { entries: { main: { workspace: workspaceDir } } } };
+}
+
+async function fileHashes(directory: string): Promise<Record<string, string>> {
+  const entries = await fs.readdir(directory, { recursive: true, withFileTypes: true });
+  return Object.fromEntries(
+    await Promise.all(
+      entries
+        .filter((entry) => entry.isFile())
+        .map(async (entry) => {
+          const filePath = path.join(entry.parentPath, entry.name);
+          return [
+            path.relative(directory, filePath),
+            createHash("sha256")
+              .update(await fs.readFile(filePath))
+              .digest("hex"),
+          ];
+        }),
+    ),
+  );
+}
+
+function legacyProposal(workspaceDir: string) {
+  const name = "rehearsal-procedure";
+  const draft = renderProposalMarkdown({
+    name,
+    description: "Verify the migration result",
+    content: "# Procedure\n\nVerify the saved result.\n",
+    date: "2026-09-01T00:00:00.000Z",
+  });
+  const record: SkillProposalRecord = {
+    ...createAppliedLegacyProposal({
+      id: "rehearsal-procedure-20260901-1234567890",
+      title: "Create rehearsal procedure",
+      description: "Verify the migration result",
+      content: draft,
+      target: { skillKey: name, skillDir: path.join(workspaceDir, "skills", name) },
+    }),
+    origin: { agentId: "main" },
+  };
+  return { record, draft, content: stripProposalFrontmatterForSkill(draft) };
+}
+
+describe("Workshop migration in an update rehearsal", () => {
+  it.each(["partial", "complete"] as const)(
+    "preserves external files and pending rollback state after a %s apply",
+    async (applyState) => {
+      await withOpenClawTestState({ label: "workshop-rehearsal-rollback" }, async (state) => {
+        const env = rehearsalEnv(state);
+        const config = configForWorkspace(state.workspaceDir);
+        const legacy = legacyProposal(state.workspaceDir);
+        const supportPath = "references/verification.md";
+        const supportContent = "Retain the recorded verification steps.\n";
+        const pending: SkillProposalRecord = {
+          ...legacy.record,
+          status: "pending",
+          appliedAt: undefined,
+          supportFiles: [
+            {
+              path: supportPath,
+              sizeBytes: Buffer.byteLength(supportContent),
+              hash: hashSkillProposalContent(supportContent),
+            },
+          ],
+        };
+        const rollback: SkillProposalRollback = {
+          schema: SKILL_WORKSHOP_ROLLBACK_SCHEMA,
+          proposalId: pending.id,
+          writtenAt: pending.createdAt,
+          targetSkillFile: pending.target.skillFile,
+          action: "create",
+          supportFiles: [{ path: supportPath, existed: false }],
+        };
+        const supportFile = path.join(pending.target.skillDir, supportPath);
+        await fs.mkdir(path.dirname(supportFile), { recursive: true });
+        await fs.writeFile(supportFile, supportContent);
+        if (applyState === "complete") {
+          await fs.writeFile(pending.target.skillFile, legacy.content);
+        }
+        await state.writeText(`skill-workshop/proposals/${pending.id}/PROPOSAL.md`, legacy.draft);
+        await state.writeText(
+          `skill-workshop/proposals/${pending.id}/${supportPath}`,
+          supportContent,
+        );
+        importLegacySkillProposal({
+          record: pending,
+          rollback,
+          ownerAgentId: "main",
+          store: { env: state.env },
+        });
+        const db = openOpenClawStateDatabase({ env: state.env }).db;
+        const proposalRows = () =>
+          db
+            .prepare("SELECT * FROM skill_workshop_proposals WHERE proposal_id = ?")
+            .all(pending.id);
+        const rollbackRows = () =>
+          db
+            .prepare("SELECT * FROM skill_workshop_proposal_rollbacks WHERE proposal_id = ?")
+            .all(pending.id);
+        const before = {
+          files: await fileHashes(state.workspaceDir),
+          proposals: proposalRows(),
+          rollbacks: rollbackRows(),
+        };
+        expect(before.rollbacks).toHaveLength(1);
+
+        const result = await migrateLegacySkillWorkshopProposals({
+          config,
+          env,
+          retireMissingDrafts: true,
+        });
+
+        expect(result.warnings).toEqual([]);
+        expect(await fileHashes(state.workspaceDir)).toEqual(before.files);
+        expect(proposalRows()).toEqual(before.proposals);
+        expect(rollbackRows()).toEqual(before.rollbacks);
+        await expect(
+          fs.access(
+            path.join(resolveWorkshopSkillsDir(config, "main", env), pending.target.skillKey),
+          ),
+        ).rejects.toMatchObject({ code: "ENOENT" });
+        await expect(inspectLegacySkillWorkshopMigration({ config, env })).resolves.toMatchObject({
+          externalProposalCount: 0,
+        });
+      });
+    },
+  );
+
+  it.each(["external", "owned"] as const)(
+    "keeps external sidecars as inventory while migrating owned copies: %s",
+    async (location) => {
+      await withOpenClawTestState({ label: "workshop-rehearsal-sidecars" }, async (state) => {
+        const env = rehearsalEnv(state);
+        const workspaceDir =
+          location === "external" ? state.workspaceDir : path.join(state.stateDir, "workspace");
+        const config = configForWorkspace(workspaceDir);
+        const { record, draft, content } = legacyProposal(workspaceDir);
+        await fs.mkdir(record.target.skillDir, { recursive: true });
+        await fs.writeFile(record.target.skillFile, content);
+        const proposalDir = path.join(state.stateDir, "skill-workshop", "proposals", record.id);
+        await state.writeText(`skill-workshop/proposals/${record.id}/PROPOSAL.md`, draft);
+        await state.writeJson(`skill-workshop/proposals/${record.id}/proposal.json`, record);
+        const index = await state.writeJson("skill-workshop/proposals.json", {
+          proposals: [record.id],
+        });
+        const before = {
+          source: await fileHashes(workspaceDir),
+          sidecars: await fileHashes(proposalDir),
+          index: await fs.readFile(index, "utf8"),
+        };
+        const db = openOpenClawStateDatabase({ env: state.env }).db;
+
+        const result = await migrateLegacySkillWorkshopProposals({ config, env });
+
+        expect(result.warnings).toEqual([]);
+        const rows = db
+          .prepare(`
+            SELECT json_extract(record_json, '$.target.source') AS source,
+              json_extract(record_json, '$.target.skillDir') AS skill_dir,
+              json_extract(record_json, '$.target.skillFile') AS skill_file
+            FROM skill_workshop_proposals WHERE proposal_id = ?
+          `)
+          .all(record.id);
+        if (location === "external") {
+          expect(result.migrated).toBe(0);
+          expect(await fileHashes(workspaceDir)).toEqual(before.source);
+          expect(await fileHashes(proposalDir)).toEqual(before.sidecars);
+          expect(await fs.readFile(index, "utf8")).toBe(before.index);
+          expect(rows).toEqual([]);
+        } else {
+          expect(result.migrated).toBe(1);
+          expect(rows).toHaveLength(1);
+          const destination = path.join(
+            resolveWorkshopSkillsDir(config, "main", env),
+            record.target.skillKey,
+          );
+          await expect(fs.readFile(path.join(destination, "SKILL.md"), "utf8")).resolves.toBe(
+            content,
+          );
+          await expect(fs.access(record.target.skillDir)).rejects.toMatchObject({ code: "ENOENT" });
+          await expect(fs.access(path.join(proposalDir, "proposal.json"))).rejects.toMatchObject({
+            code: "ENOENT",
+          });
+          await expect(fs.access(index)).rejects.toMatchObject({ code: "ENOENT" });
+          expect(rows).toEqual([
+            {
+              source: "openclaw-workshop",
+              skill_dir: destination,
+              skill_file: path.join(destination, "SKILL.md"),
+            },
+          ]);
+        }
+      });
+    },
+  );
+
+  it("preserves an external collection backup batch without publishing rewritten archives", async () => {
+    await withOpenClawTestState({ label: "workshop-rehearsal-backups" }, async (state) => {
+      const env = rehearsalEnv(state);
+      const config = configForWorkspace(state.workspaceDir);
+      const relativeSkillDir = path.join("skills", "rehearsal-procedure");
+      const legacyRoot = path.join(
+        state.stateDir,
+        "skill-workshop",
+        "collection-backups",
+        "0000000000000000",
+      );
+      await fs.mkdir(path.join(state.workspaceDir, relativeSkillDir), { recursive: true });
+      await fs.writeFile(
+        path.join(state.workspaceDir, relativeSkillDir, "SKILL.md"),
+        "Current operator skill.\n",
+      );
+      for (const id of ["2026-09-01T00-00-00.000Z-first", "2026-09-02T00-00-00.000Z-second"]) {
+        const backupDir = path.join(legacyRoot, id);
+        await fs.mkdir(path.join(backupDir, "workspace", relativeSkillDir), { recursive: true });
+        await fs.writeFile(
+          path.join(backupDir, "workspace", relativeSkillDir, "SKILL.md"),
+          `Saved skill ${id}.\n`,
+        );
+        await fs.writeFile(
+          path.join(backupDir, "manifest.json"),
+          JSON.stringify({
+            schema: "openclaw.skill-collection-backup.v1",
+            id,
+            createdAt: "2026-09-01T00:00:00.000Z",
+            workspaceDir: state.workspaceDir,
+            skillDirs: [relativeSkillDir],
+            resultSkillDirs: [],
+            resultSkillHashes: {},
+          }),
+        );
+      }
+      const before = {
+        backups: await fileHashes(legacyRoot),
+        source: await fileHashes(state.workspaceDir),
+      };
+
+      const result = await migrateLegacySkillWorkshopProposals({ config, env });
+
+      expect(result.warnings).toEqual([]);
+      expect(await fileHashes(legacyRoot)).toEqual(before.backups);
+      expect(await fileHashes(state.workspaceDir)).toEqual(before.source);
+      await expect(
+        fs.access(resolveSkillCollectionBackupRoot(config, "main", env)),
+      ).rejects.toMatchObject({ code: "ENOENT" });
+      await expect(inspectLegacySkillWorkshopMigration({ config, env })).resolves.toMatchObject({
+        legacyBackupRootCount: 0,
+      });
+    });
+  });
+
+  it("does not replay a prepared relocation receipt for an external workspace", async () => {
+    await withOpenClawTestState({ label: "workshop-rehearsal-receipt" }, async (state) => {
+      const env = rehearsalEnv(state);
+      const config = configForWorkspace(state.workspaceDir);
+      const { record, content } = legacyProposal(state.workspaceDir);
+      await fs.mkdir(record.target.skillDir, { recursive: true });
+      await fs.writeFile(record.target.skillFile, content);
+      await replaceWorkspaceAttestation({
+        workspaceDir: state.workspaceDir,
+        attestedAtMs: Date.now(),
+        generatedHashes: new Map(),
+      });
+      const destination = path.join(
+        resolveWorkshopSkillsDir(config, "main", state.env),
+        record.target.skillKey,
+      );
+      await prepareWorkshopWorkspaceRelocation(
+        state.workspaceDir,
+        [{ source: record.target.skillDir, destination }],
+        state.env,
+      );
+      const db = openOpenClawStateDatabase({ env: state.env }).db;
+      const receipts = () =>
+        db
+          .prepare("SELECT * FROM migration_sources WHERE migration_kind = ?")
+          .all(WORKSPACE_CONTENT_RELOCATION_MIGRATION_KIND);
+      const beforeReceipts = receipts();
+      expect(beforeReceipts).toEqual([expect.objectContaining({ status: "prepared" })]);
+      await fs.mkdir(path.dirname(destination), { recursive: true });
+      await fs.rename(record.target.skillDir, destination);
+      const before = {
+        workspace: await readWorkspaceStateSnapshot(state.workspaceDir, {
+          env: state.env,
+          readOnly: true,
+        }),
+        files: await fileHashes(destination),
+      };
+
+      await migrateLegacySkillWorkshopProposals({ config, env });
+
+      expect(receipts()).toEqual(beforeReceipts);
+      expect(
+        await readWorkspaceStateSnapshot(state.workspaceDir, { env: state.env, readOnly: true }),
+      ).toEqual(before.workspace);
+      expect(await fileHashes(destination)).toEqual(before.files);
+    });
+  });
+});

--- a/src/commands/doctor-skill-workshop-relocation.ts
+++ b/src/commands/doctor-skill-workshop-relocation.ts
@@ -10,6 +10,7 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { isMissingPathError } from "../infra/errors.js";
 import { pathExists } from "../infra/fs-safe.js";
 import { isPathInside } from "../infra/path-guards.js";
+import { isUpdateRehearsalReadOnlyPath } from "../infra/update-rehearsal-paths.js";
 import { normalizeAgentId, parseAgentSessionKey } from "../routing/session-key.js";
 import { readWorkspaceSkillFile } from "../skills/lifecycle/workspace-skill-write.js";
 import { resolveSkillManifestMetadata } from "../skills/loading/frontmatter.js";
@@ -33,6 +34,17 @@ type OwnerAgentInference = {
   ownerAgentId?: string;
   unconfiguredOwnerAgentId?: string;
 };
+
+export function isReadOnlyRehearsalProposal(
+  record: SkillProposalRecord,
+  env: NodeJS.ProcessEnv,
+): boolean {
+  return [
+    record.target.skillDir,
+    record.target.skillFile,
+    ...(record.supportFiles ?? []).map((file) => path.join(record.target.skillDir, file.path)),
+  ].some((filePath) => isUpdateRehearsalReadOnlyPath(filePath, env));
+}
 
 export function resolveLegacyWorkshopWorkspaceDir(
   skillDir: string,
@@ -284,7 +296,7 @@ export async function planWorkshopRelocation(
   recoverableDeferredSources: ReadonlySet<string> = new Set(),
 ) {
   const { candidates, external } = classifyWorkshopRelocation(
-    records,
+    records.filter(({ record }) => !isReadOnlyRehearsalProposal(record, env)),
     config,
     env,
     deferredSources,
@@ -327,6 +339,14 @@ export async function planWorkshopRelocation(
       agentId: plan.ownerAgentId,
       env,
     });
+    if (
+      [target.skillDir, target.skillFile].some((filePath) =>
+        isUpdateRehearsalReadOnlyPath(filePath, env),
+      )
+    ) {
+      plan.deferred = true;
+      continue;
+    }
     const key = [
       plan.ownerAgentId,
       plan.source,

--- a/src/commands/doctor-skill-workshop-sidecars.ts
+++ b/src/commands/doctor-skill-workshop-sidecars.ts
@@ -1,0 +1,381 @@
+import { randomUUID } from "node:crypto";
+import path from "node:path";
+import { resolveStateDir } from "../config/paths.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { hasErrnoCode, isMissingPathError } from "../infra/errors.js";
+import { removePathWithinRoot } from "../infra/fs-safe-remove.js";
+import { pathExists, root, type Root } from "../infra/fs-safe.js";
+import { executeSqliteQueryTakeFirstSync, getNodeSqliteKysely } from "../infra/kysely-sync.js";
+import type { MigrationMessages } from "../infra/state-migrations.types.js";
+import { isUpdateRehearsalReadOnlyPath } from "../infra/update-rehearsal-paths.js";
+import { parseSkillProposalRow } from "../skills/workshop/store-sqlite-record.js";
+import {
+  hashSkillProposalContent,
+  importLegacySkillProposal,
+  readSkillProposal,
+  readSkillProposalRollback,
+  validateSkillProposalRecord,
+  validateSkillProposalRollback,
+} from "../skills/workshop/store.js";
+import type { SkillProposalRecord, SkillProposalRollback } from "../skills/workshop/types.js";
+import { tableExists } from "../state/openclaw-state-db-schema-helpers.js";
+import type { DB as OpenClawStateDatabase } from "../state/openclaw-state-db.generated.js";
+import { openOpenClawStateDatabase } from "../state/openclaw-state-db.js";
+import { listWorkspaceOwnerAgentIds } from "./doctor-skill-workshop-collection-backups.js";
+import {
+  inferOwnerAgentId,
+  isReadOnlyRehearsalProposal,
+  resolveLegacyWorkshopWorkspaceDir,
+} from "./doctor-skill-workshop-relocation.js";
+import {
+  LEGACY_WORKSHOP_PROPOSALS_DIR as PROPOSALS_DIR,
+  LEGACY_WORKSHOP_MAX_RECORD_BYTES as MAX_RECORD_BYTES,
+  LEGACY_WORKSHOP_PROPOSAL_ID_PATTERN as PROPOSAL_ID_PATTERN,
+  readLegacyWorkshopJson as readJson,
+} from "./doctor-skill-workshop-sources.js";
+
+const WORKSHOP_DIR = "skill-workshop";
+const MANIFEST_PATH = `${WORKSHOP_DIR}/proposals.json`;
+// Preserve incomplete proposal artifacts outside active discovery so Doctor
+// does not retry an impossible import on every run.
+const RECOVERY_DIR = `${WORKSHOP_DIR}/recovery`;
+const RECOVERY_PROPOSALS_DIR = `${RECOVERY_DIR}/proposals`;
+// Legacy rollback JSON can expand control characters sixfold across 1 MiB of
+// SKILL.md plus 64 existing 256 KiB support targets.
+const MAX_ROLLBACK_BYTES = 128 * 1024 * 1024;
+
+export type MigrationResult = MigrationMessages & {
+  detected: number;
+  migrated: number;
+};
+
+async function readLegacyRollback(
+  stateRoot: Root,
+  proposalId: string,
+): Promise<SkillProposalRollback | undefined> {
+  try {
+    const rollback = validateSkillProposalRollback(
+      await readJson(stateRoot, `${PROPOSALS_DIR}/${proposalId}/rollback.json`, MAX_ROLLBACK_BYTES),
+    );
+    if (!rollback.ok) {
+      throw new Error(rollback.error.message);
+    }
+    if (rollback.value.proposalId !== proposalId) {
+      throw new Error("invalid rollback metadata");
+    }
+    return rollback.value;
+  } catch (error) {
+    if (isMissingPathError(error)) {
+      return undefined;
+    }
+    throw error;
+  }
+}
+
+async function verifyImportedProposal(
+  config: OpenClawConfig,
+  env: NodeJS.ProcessEnv,
+  record: SkillProposalRecord,
+  rollback?: SkillProposalRollback,
+): Promise<void> {
+  const imported = (
+    await readSkillProposal(record.id, { config, env }, {}, { config, reconcile: false })
+  )?.record;
+  if (
+    !imported ||
+    imported.draftHash !== record.draftHash ||
+    imported.target.skillFile !== record.target.skillFile
+  ) {
+    throw new Error("SQLite verification failed");
+  }
+  if (rollback && !(await readSkillProposalRollback(record.id, { env }))) {
+    throw new Error("SQLite rollback verification failed");
+  }
+}
+
+type PreparedLegacyProposal = {
+  record: SkillProposalRecord;
+  ownerAgentId: string;
+};
+
+async function readLegacyProposalArtifacts(
+  stateRoot: Root,
+  record: SkillProposalRecord,
+  env: NodeJS.ProcessEnv,
+): Promise<SkillProposalRollback | null | undefined> {
+  const rollback = await readLegacyRollback(stateRoot, record.id);
+  if (rollback && isUpdateRehearsalReadOnlyPath(rollback.targetSkillFile, env)) {
+    return null;
+  }
+  const draft = await stateRoot
+    .read(`${PROPOSALS_DIR}/${record.id}/PROPOSAL.md`, {
+      hardlinks: "reject",
+      maxBytes: MAX_RECORD_BYTES,
+      symlinks: "reject",
+    })
+    .catch((error: unknown) => {
+      // Missing drafts must not quarantine a bundle that still owns apply recovery.
+      if (rollback && isMissingPathError(error)) {
+        throw new Error(
+          "Legacy bundle has a missing draft and unfinished apply recovery; restore its draft before retrying Doctor.",
+        );
+      }
+      throw error;
+    });
+  if (hashSkillProposalContent(draft.buffer.toString("utf8")) !== record.draftHash) {
+    throw new Error("proposal draft hash does not match proposal metadata");
+  }
+  return rollback;
+}
+
+async function prepareLegacyProposal(params: {
+  config: OpenClawConfig;
+  env: NodeJS.ProcessEnv;
+  proposalId: string;
+  stateRoot: Root;
+}): Promise<PreparedLegacyProposal | { warning: string } | null> {
+  const proposalDir = `${PROPOSALS_DIR}/${params.proposalId}`;
+  const record = validateSkillProposalRecord(
+    await readJson(params.stateRoot, `${proposalDir}/proposal.json`, MAX_RECORD_BYTES),
+  );
+  if (!record.ok) {
+    throw new Error(record.error.message);
+  }
+  if (record.value.id !== params.proposalId) {
+    throw new Error("invalid proposal metadata");
+  }
+  if (isReadOnlyRehearsalProposal(record.value, params.env)) {
+    return null;
+  }
+  const rollback = await readLegacyProposalArtifacts(params.stateRoot, record.value, params.env);
+  if (rollback === null) {
+    return null;
+  }
+  const workspaceDir = resolveLegacyWorkshopWorkspaceDir(
+    record.value.target.skillDir,
+    params.config,
+    params.env,
+  );
+  const owner = inferOwnerAgentId({
+    config: params.config,
+    env: params.env,
+    record: record.value,
+    workspaceDir,
+  });
+  if (!owner.ownerAgentId) {
+    if (rollback) {
+      throw new Error(
+        `Legacy bundle has unfinished apply recovery at ${path.join(resolveStateDir(params.env), proposalDir, "rollback.json")}; resolve its owning agent and recover the retained apply before retrying Doctor.`,
+      );
+    }
+    const candidates = workspaceDir
+      ? listWorkspaceOwnerAgentIds(params.config, params.env, workspaceDir).toSorted()
+      : [];
+    const reason = owner.unconfiguredOwnerAgentId
+      ? `owning agent "${owner.unconfiguredOwnerAgentId}" is not configured`
+      : "owning agent could not be inferred";
+    return {
+      warning: `Preserved Skill Workshop proposal ${path.join(resolveStateDir(params.env), proposalDir)} for manual review: ${reason}; target ${record.value.target.skillDir} (candidate agents: ${candidates.join(", ") || "none"}). Review the retained metadata and configured workspace ownership before retrying Doctor.`,
+    };
+  }
+  return { record: record.value, ownerAgentId: owner.ownerAgentId };
+}
+
+async function migrateProposal(params: {
+  config: OpenClawConfig;
+  env: NodeJS.ProcessEnv;
+  stateRoot: Root;
+  prepared: PreparedLegacyProposal;
+}): Promise<boolean> {
+  const { record, ownerAgentId } = params.prepared;
+  if (isReadOnlyRehearsalProposal(record, params.env)) {
+    return false;
+  }
+  const proposalDir = `${PROPOSALS_DIR}/${record.id}`;
+  const rollback = await readLegacyProposalArtifacts(params.stateRoot, record, params.env);
+  if (rollback === null) {
+    return false;
+  }
+  importLegacySkillProposal({
+    record,
+    rollback,
+    ownerAgentId,
+    store: { env: params.env },
+  });
+  await verifyImportedProposal(params.config, params.env, record, rollback);
+  if (rollback) {
+    await params.stateRoot.remove(`${proposalDir}/rollback.json`);
+  }
+  await params.stateRoot.remove(`${proposalDir}/proposal.json`);
+  return true;
+}
+
+async function reconcileIncompleteProposal(params: {
+  proposalId: string;
+  proposalDir: string;
+  stateRoot: Root;
+}): Promise<string> {
+  const entries = await params.stateRoot.list(params.proposalDir, { withFileTypes: true });
+  if (entries.length === 0) {
+    await params.stateRoot.remove(params.proposalDir);
+    return `Removed empty legacy Skill Workshop proposal directory ${params.proposalId}.`;
+  }
+  await params.stateRoot.mkdir(RECOVERY_PROPOSALS_DIR);
+  // A unique target preserves earlier recovery artifacts without an unsafe
+  // check-then-replace window. The fs-safe move pins both directory parents.
+  const recoveryPath = `${RECOVERY_PROPOSALS_DIR}/${params.proposalId}-${randomUUID()}`;
+  await params.stateRoot.move(params.proposalDir, recoveryPath, { overwrite: true });
+  return `Quarantined incomplete Skill Workshop proposal ${params.proposalId} to ${recoveryPath} for manual recovery.`;
+}
+
+/** Import verified legacy proposal sidecars, then remove only the imported JSON metadata. */
+export async function importLegacySkillProposalSidecars(params: {
+  config: OpenClawConfig;
+  env?: NodeJS.ProcessEnv;
+}): Promise<MigrationResult> {
+  const env = params.env ?? process.env;
+  const stateDir = resolveStateDir(env);
+  if (!(await pathExists(path.join(stateDir, PROPOSALS_DIR)))) {
+    if (!(await pathExists(path.join(stateDir, MANIFEST_PATH)))) {
+      return {
+        changes: [],
+        warnings: [],
+        detected: 0,
+        migrated: 0,
+      };
+    }
+    await removePathWithinRoot({ rootDir: stateDir, relativePath: MANIFEST_PATH });
+    return {
+      changes: ["Removed the empty legacy Skill Workshop proposal index."],
+      warnings: [],
+      detected: 0,
+      migrated: 0,
+    };
+  }
+  const stateRoot = await root(stateDir);
+  let entries;
+  try {
+    entries = await stateRoot.list(PROPOSALS_DIR, { withFileTypes: true });
+  } catch (error) {
+    if (hasErrnoCode(error, "not-found")) {
+      return { changes: [], warnings: [], detected: 0, migrated: 0 };
+    }
+    return {
+      changes: [],
+      warnings: [`Failed to inspect legacy Skill Workshop proposals: ${String(error)}`],
+      detected: 0,
+      migrated: 0,
+    };
+  }
+
+  const proposalIds = entries
+    .filter((entry) => entry.isDirectory && PROPOSAL_ID_PATTERN.test(entry.name))
+    .map((entry) => entry.name)
+    .toSorted((left, right) => left.localeCompare(right));
+  const warnings: string[] = [];
+  const changes: string[] = [];
+  let recoverableWarningCount = 0;
+  const prepared = new Map<
+    string,
+    PreparedLegacyProposal | { warning: string } | { error: unknown } | null
+  >();
+  // Resolve every sidecar's ownership before the first import or artifact retirement.
+  for (const proposalId of proposalIds) {
+    try {
+      prepared.set(
+        proposalId,
+        await prepareLegacyProposal({ config: params.config, env, proposalId, stateRoot }),
+      );
+    } catch (error) {
+      prepared.set(proposalId, { error });
+    }
+  }
+  const database = openOpenClawStateDatabase({ env });
+  const kysely = getNodeSqliteKysely<Pick<OpenClawStateDatabase, "skill_workshop_proposals">>(
+    database.db,
+  );
+  let migrated = 0;
+  let retainedForRehearsal = false;
+  for (const proposalId of proposalIds) {
+    const proposalDir = `${PROPOSALS_DIR}/${proposalId}`;
+    const proposal = prepared.get(proposalId)!;
+    if (proposal === null) {
+      retainedForRehearsal = true;
+      continue;
+    }
+    if ("warning" in proposal) {
+      warnings.push(proposal.warning);
+      recoverableWarningCount += 1;
+      continue;
+    }
+    try {
+      if ("error" in proposal) {
+        throw proposal.error;
+      }
+      const imported = await migrateProposal({
+        config: params.config,
+        env,
+        prepared: proposal,
+        stateRoot,
+      });
+      if (imported) {
+        migrated += 1;
+      } else {
+        retainedForRehearsal = true;
+      }
+      continue;
+    } catch (error) {
+      if (!isMissingPathError(error)) {
+        warnings.push(`Failed to migrate Skill Workshop proposal ${proposalId}: ${String(error)}`);
+        continue;
+      }
+      // Modern bundles have no legacy sidecar. Recognize their durable record
+      // without entering the feature's schema-writing read facade.
+      const stored = tableExists(database.db, "skill_workshop_proposals")
+        ? executeSqliteQueryTakeFirstSync(
+            database.db,
+            kysely
+              .selectFrom("skill_workshop_proposals")
+              .selectAll()
+              .where("proposal_id", "=", proposalId)
+              .where("owner_agent_id", "is not", null),
+          )
+        : undefined;
+      if (stored && parseSkillProposalRow(stored)) {
+        continue;
+      }
+      try {
+        changes.push(await reconcileIncompleteProposal({ proposalId, proposalDir, stateRoot }));
+      } catch (reconcileError) {
+        warnings.push(
+          `Could not quarantine incomplete Skill Workshop proposal ${proposalId}: ${String(
+            reconcileError,
+          )}. Manually move ${proposalDir} to ${RECOVERY_PROPOSALS_DIR} to recover it.`,
+        );
+      }
+    }
+  }
+  if (!retainedForRehearsal) {
+    await removePathWithinRoot({ rootDir: stateDir, relativePath: MANIFEST_PATH }).catch(
+      (error: unknown) => {
+        if (!isMissingPathError(error)) {
+          warnings.push(`Failed to remove legacy Skill Workshop proposal index: ${String(error)}`);
+        }
+      },
+    );
+  }
+  if (migrated > 0) {
+    changes.unshift(
+      `Migrated ${migrated} Skill Workshop proposal${migrated === 1 ? "" : "s"} into shared SQLite.`,
+    );
+  }
+  return {
+    changes,
+    warnings,
+    ...(warnings.length > 0 && warnings.length === recoverableWarningCount
+      ? { warningDisposition: "recoverable" as const }
+      : {}),
+    detected: proposalIds.length,
+    migrated,
+  };
+}

--- a/src/commands/doctor-skill-workshop-sqlite.ts
+++ b/src/commands/doctor-skill-workshop-sqlite.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { truncateWithMarker } from "@openclaw/normalization-core/utf16-slice";
@@ -7,11 +6,8 @@ import {
   resolveCanonicalWorkspacePath,
   resolveWorkspaceStateIdentity,
 } from "../agents/workspace-state-identity.js";
-import { resolveStateDir } from "../config/paths.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { hasErrnoCode, isMissingPathError } from "../infra/errors.js";
-import { removePathWithinRoot } from "../infra/fs-safe-remove.js";
-import { pathExists, root, type Root } from "../infra/fs-safe.js";
+import { pathExists } from "../infra/fs-safe.js";
 import {
   executeSqliteQuerySync,
   executeSqliteQueryTakeFirstSync,
@@ -20,7 +16,10 @@ import {
 import { isPathInside } from "../infra/path-guards.js";
 import { movePathWithCopyFallback } from "../infra/replace-file.js";
 import { acquireStateDatabaseCoordinator } from "../infra/state-database-coordinator.js";
-import type { MigrationMessages } from "../infra/state-migrations.types.js";
+import {
+  isUpdateRehearsalReadOnlyPath,
+  resolveUpdateRehearsalRoot,
+} from "../infra/update-rehearsal-paths.js";
 import { transitionPendingSkillProposalToStale } from "../skills/workshop/apply-transition.js";
 import { reconcileInterruptedSkillProposalApply } from "../skills/workshop/reconcile-transition.js";
 import { resolveWorkshopSkillsDir } from "../skills/workshop/skills-root.js";
@@ -31,16 +30,10 @@ import {
 } from "../skills/workshop/store-sqlite-record.js";
 import {
   SkillProposalDraftMissingError,
-  hashSkillProposalContent,
-  importLegacySkillProposal,
-  readSkillProposal,
   readSkillProposalBundle,
   readSkillProposalRollback,
   resolveSkillProposalTarget,
-  validateSkillProposalRecord,
-  validateSkillProposalRollback,
 } from "../skills/workshop/store.js";
-import type { SkillProposalRecord, SkillProposalRollback } from "../skills/workshop/types.js";
 import { tableExists } from "../state/openclaw-state-db-schema-helpers.js";
 import type { DB as OpenClawStateDatabase } from "../state/openclaw-state-db.generated.js";
 import {
@@ -54,44 +47,27 @@ import {
 } from "./doctor-skill-workshop-automations.js";
 import {
   listPendingLegacyCollectionBackupRoots,
-  listWorkspaceOwnerAgentIds,
   migrateLegacyCollectionBackups,
   type LegacyCollectionBackupRoot,
 } from "./doctor-skill-workshop-collection-backups.js";
 import {
   classifyWorkshopRelocation,
   inferOwnerAgentId,
+  isReadOnlyRehearsalProposal,
   planWorkshopRelocation,
   readLegacyWorkshopSourceStat,
   resolveLegacyWorkshopWorkspaceDir,
   type WorkshopProposalUpdate,
 } from "./doctor-skill-workshop-relocation.js";
 import {
-  LEGACY_WORKSHOP_PROPOSALS_DIR as PROPOSALS_DIR,
-  LEGACY_WORKSHOP_MAX_RECORD_BYTES as MAX_RECORD_BYTES,
-  LEGACY_WORKSHOP_PROPOSAL_ID_PATTERN as PROPOSAL_ID_PATTERN,
-  readLegacyWorkshopJson as readJson,
-  readWorkshopMigrationRecords,
-} from "./doctor-skill-workshop-sources.js";
+  importLegacySkillProposalSidecars,
+  type MigrationResult,
+} from "./doctor-skill-workshop-sidecars.js";
+import { readWorkshopMigrationRecords } from "./doctor-skill-workshop-sources.js";
 import {
   finishWorkshopWorkspaceRelocations,
   prepareWorkshopWorkspaceRelocation,
 } from "./doctor-skill-workshop-workspaces.js";
-
-const WORKSHOP_DIR = "skill-workshop";
-const MANIFEST_PATH = `${WORKSHOP_DIR}/proposals.json`;
-// Preserve incomplete proposal artifacts outside active discovery so Doctor
-// does not retry an impossible import on every run.
-const RECOVERY_DIR = `${WORKSHOP_DIR}/recovery`;
-const RECOVERY_PROPOSALS_DIR = `${RECOVERY_DIR}/proposals`;
-// Legacy rollback JSON can expand control characters sixfold across 1 MiB of
-// SKILL.md plus 64 existing 256 KiB support targets.
-const MAX_ROLLBACK_BYTES = 128 * 1024 * 1024;
-
-type MigrationResult = MigrationMessages & {
-  detected: number;
-  migrated: number;
-};
 
 type WorkshopRelocationResult = {
   movedSkills: number;
@@ -118,7 +94,11 @@ export async function inspectLegacySkillWorkshopMigration(params: {
   const env = params.env ?? process.env;
   const { records, appliedEvents } = await readWorkshopMigrationRecords(env, true);
   // Lint needs ownership counts, not adoption verification through writable recovery readers.
-  const { external } = classifyWorkshopRelocation(records, params.config, env);
+  const { external } = classifyWorkshopRelocation(
+    records.filter(({ record }) => !isReadOnlyRehearsalProposal(record, env)),
+    params.config,
+    env,
+  );
   const backups = await listPendingLegacyCollectionBackupRoots(params.config, env);
   const automationReferences = await inspectWorkshopAutomationReferences({
     config: params.config,
@@ -185,6 +165,18 @@ async function relocateLegacyWorkshopTargets(
         .where("proposal_id", "=", proposalId),
     ) !== undefined;
   const recoveryWarnings: string[] = [];
+  const readOnlyProposalIds = new Set(
+    resolveUpdateRehearsalRoot(env) && tableExists(database.db, "skill_workshop_proposal_rollbacks")
+      ? executeSqliteQuerySync(
+          database.db,
+          kysely
+            .selectFrom("skill_workshop_proposal_rollbacks")
+            .select(["proposal_id", "target_skill_file"]),
+        )
+          .rows.filter((row) => isUpdateRehearsalReadOnlyPath(row.target_skill_file, env))
+          .map((row) => row.proposal_id)
+      : [],
+  );
   let missingDraftsRetired = 0;
   let recoverableWarningCount = 0;
   // Settle writes while their proposal and rollback still name the same files.
@@ -192,6 +184,12 @@ async function relocateLegacyWorkshopTargets(
   for (const row of readRows()) {
     const record = parseSkillProposalRow(row);
     if (!record || record.status !== "pending") {
+      continue;
+    }
+    if (readOnlyProposalIds.has(record.id) || isReadOnlyRehearsalProposal(record, env)) {
+      const source = resolveCanonicalWorkspacePath(record.target.skillDir);
+      deferredSources.add(source);
+      recoverableDeferredSources.add(source);
       continue;
     }
     const workspaceDir = resolveLegacyWorkshopWorkspaceDir(record.target.skillDir, config, env);
@@ -304,17 +302,23 @@ async function relocateLegacyWorkshopTargets(
   const initialRows = new Map(rows.map((row) => [row.proposal_id, row]));
   const records = rows.flatMap((row) => {
     const record = parseSkillProposalRow(row);
-    return record ? [{ record, ownerAgentId: row.owner_agent_id }] : [];
+    return record && !readOnlyProposalIds.has(record.id)
+      ? [{ record, ownerAgentId: row.owner_agent_id }]
+      : [];
   });
+  const persistedUpdates: WorkshopProposalUpdate[] = [];
   const persistUpdates = (updates: WorkshopProposalUpdate[]): void => {
-    if (updates.length === 0) {
+    if (
+      updates.length === 0 ||
+      updates.some(({ record }) => isReadOnlyRehearsalProposal(record, env))
+    ) {
       return;
     }
     // Every proposal for one moved skill must commit together. Otherwise a
     // retry loses the create row that proves where its pending updates belong.
-    runOpenClawStateWriteTransaction(
+    const committed = runOpenClawStateWriteTransaction(
       ({ db }) => {
-        for (const update of updates) {
+        const currentUpdates = updates.map((update) => {
           const expected = initialRows.get(update.record.id);
           const current = readStoredProposal(update.record.id, { env });
           if (
@@ -324,12 +328,24 @@ async function relocateLegacyWorkshopTargets(
           ) {
             throw new Error(`Skill proposal changed during relocation: ${update.record.id}`);
           }
+          return { update, current };
+        });
+        if (
+          currentUpdates.some(({ current }) => isReadOnlyRehearsalProposal(current.record, env))
+        ) {
+          return false;
+        }
+        for (const { update, current } of currentUpdates) {
           updateProposal(db, current.row, update.record, update.ownerAgentId);
         }
+        return true;
       },
       { env },
       { operationLabel: "skill-workshop.relocation.commit" },
     );
+    if (committed) {
+      persistedUpdates.push(...updates);
+    }
   };
   const plan = await planWorkshopRelocation(
     records,
@@ -353,10 +369,20 @@ async function relocateLegacyWorkshopTargets(
   for (const [workspaceDir, moves] of workspaceMoves) {
     await prepareWorkshopWorkspaceRelocation(workspaceDir, moves, env);
   }
+  let movedSkills = 0;
   for (const move of plan.moves) {
+    if (
+      [move.source, move.destination].some((filePath) =>
+        isUpdateRehearsalReadOnlyPath(filePath, env),
+      ) ||
+      move.updates.some(({ record }) => isReadOnlyRehearsalProposal(record, env))
+    ) {
+      continue;
+    }
     if (move.operation === "move") {
       await fs.mkdir(path.dirname(move.destination), { recursive: true });
       await movePathWithCopyFallback({ from: move.source, to: move.destination });
+      movedSkills += 1;
     } else if (move.operation === "remove-source") {
       await fs.rm(move.source, { recursive: true, force: false });
     }
@@ -365,11 +391,12 @@ async function relocateLegacyWorkshopTargets(
   persistUpdates(plan.updates);
   await finishWorkshopWorkspaceRelocations(env);
   const backupMigration = await migrateLegacyCollectionBackups(config, env, backupRoots);
-  const updates = [...plan.updates, ...plan.moves.flatMap((move) => move.updates)];
-  const staleProposals = updates.filter((update) => update.record.status === "stale").length;
+  const staleProposals = persistedUpdates.filter(
+    (update) => update.record.status === "stale",
+  ).length;
   return {
-    movedSkills: plan.moves.filter((move) => move.operation === "move").length,
-    retargetedProposals: updates.length - staleProposals,
+    movedSkills,
+    retargetedProposals: persistedUpdates.length - staleProposals,
     staleProposals: staleProposals + missingDraftsRetired,
     migratedBackupRoots: backupMigration.migrated,
     warnings: [...recoveryWarnings, ...plan.warnings, ...backupMigration.warnings],
@@ -377,309 +404,6 @@ async function relocateLegacyWorkshopTargets(
       recoverableWarningCount +
       plan.recoverableWarningCount +
       backupMigration.recoverableWarningCount,
-  };
-}
-
-async function readLegacyRollback(
-  stateRoot: Root,
-  proposalId: string,
-): Promise<SkillProposalRollback | undefined> {
-  try {
-    const rollback = validateSkillProposalRollback(
-      await readJson(stateRoot, `${PROPOSALS_DIR}/${proposalId}/rollback.json`, MAX_ROLLBACK_BYTES),
-    );
-    if (!rollback.ok) {
-      throw new Error(rollback.error.message);
-    }
-    if (rollback.value.proposalId !== proposalId) {
-      throw new Error("invalid rollback metadata");
-    }
-    return rollback.value;
-  } catch (error) {
-    if (isMissingPathError(error)) {
-      return undefined;
-    }
-    throw error;
-  }
-}
-
-async function verifyImportedProposal(
-  config: OpenClawConfig,
-  env: NodeJS.ProcessEnv,
-  record: SkillProposalRecord,
-  rollback?: SkillProposalRollback,
-): Promise<void> {
-  const imported = (
-    await readSkillProposal(record.id, { config, env }, {}, { config, reconcile: false })
-  )?.record;
-  if (
-    !imported ||
-    imported.draftHash !== record.draftHash ||
-    imported.target.skillFile !== record.target.skillFile
-  ) {
-    throw new Error("SQLite verification failed");
-  }
-  if (rollback && !(await readSkillProposalRollback(record.id, { env }))) {
-    throw new Error("SQLite rollback verification failed");
-  }
-}
-
-type PreparedLegacyProposal = {
-  record: SkillProposalRecord;
-  ownerAgentId: string;
-};
-
-async function readLegacyProposalArtifacts(
-  stateRoot: Root,
-  record: SkillProposalRecord,
-): Promise<SkillProposalRollback | undefined> {
-  const rollback = await readLegacyRollback(stateRoot, record.id);
-  const draft = await stateRoot
-    .read(`${PROPOSALS_DIR}/${record.id}/PROPOSAL.md`, {
-      hardlinks: "reject",
-      maxBytes: MAX_RECORD_BYTES,
-      symlinks: "reject",
-    })
-    .catch((error: unknown) => {
-      // Missing drafts must not quarantine a bundle that still owns apply recovery.
-      if (rollback && isMissingPathError(error)) {
-        throw new Error(
-          "Legacy bundle has a missing draft and unfinished apply recovery; restore its draft before retrying Doctor.",
-        );
-      }
-      throw error;
-    });
-  if (hashSkillProposalContent(draft.buffer.toString("utf8")) !== record.draftHash) {
-    throw new Error("proposal draft hash does not match proposal metadata");
-  }
-  return rollback;
-}
-
-async function prepareLegacyProposal(params: {
-  config: OpenClawConfig;
-  env: NodeJS.ProcessEnv;
-  proposalId: string;
-  stateRoot: Root;
-}): Promise<PreparedLegacyProposal | { warning: string }> {
-  const proposalDir = `${PROPOSALS_DIR}/${params.proposalId}`;
-  const record = validateSkillProposalRecord(
-    await readJson(params.stateRoot, `${proposalDir}/proposal.json`, MAX_RECORD_BYTES),
-  );
-  if (!record.ok) {
-    throw new Error(record.error.message);
-  }
-  if (record.value.id !== params.proposalId) {
-    throw new Error("invalid proposal metadata");
-  }
-  const rollback = await readLegacyProposalArtifacts(params.stateRoot, record.value);
-  const workspaceDir = resolveLegacyWorkshopWorkspaceDir(
-    record.value.target.skillDir,
-    params.config,
-    params.env,
-  );
-  const owner = inferOwnerAgentId({
-    config: params.config,
-    env: params.env,
-    record: record.value,
-    workspaceDir,
-  });
-  if (!owner.ownerAgentId) {
-    if (rollback) {
-      throw new Error(
-        `Legacy bundle has unfinished apply recovery at ${path.join(resolveStateDir(params.env), proposalDir, "rollback.json")}; resolve its owning agent and recover the retained apply before retrying Doctor.`,
-      );
-    }
-    const candidates = workspaceDir
-      ? listWorkspaceOwnerAgentIds(params.config, params.env, workspaceDir).toSorted()
-      : [];
-    const reason = owner.unconfiguredOwnerAgentId
-      ? `owning agent "${owner.unconfiguredOwnerAgentId}" is not configured`
-      : "owning agent could not be inferred";
-    return {
-      warning: `Preserved Skill Workshop proposal ${path.join(resolveStateDir(params.env), proposalDir)} for manual review: ${reason}; target ${record.value.target.skillDir} (candidate agents: ${candidates.join(", ") || "none"}). Review the retained metadata and configured workspace ownership before retrying Doctor.`,
-    };
-  }
-  return { record: record.value, ownerAgentId: owner.ownerAgentId };
-}
-
-async function migrateProposal(params: {
-  config: OpenClawConfig;
-  env: NodeJS.ProcessEnv;
-  stateRoot: Root;
-  prepared: PreparedLegacyProposal;
-}): Promise<void> {
-  const { record, ownerAgentId } = params.prepared;
-  const proposalDir = `${PROPOSALS_DIR}/${record.id}`;
-  const rollback = await readLegacyProposalArtifacts(params.stateRoot, record);
-  importLegacySkillProposal({
-    record,
-    rollback,
-    ownerAgentId,
-    store: { env: params.env },
-  });
-  await verifyImportedProposal(params.config, params.env, record, rollback);
-  if (rollback) {
-    await params.stateRoot.remove(`${proposalDir}/rollback.json`);
-  }
-  await params.stateRoot.remove(`${proposalDir}/proposal.json`);
-}
-
-async function reconcileIncompleteProposal(params: {
-  proposalId: string;
-  proposalDir: string;
-  stateRoot: Root;
-}): Promise<string> {
-  const entries = await params.stateRoot.list(params.proposalDir, { withFileTypes: true });
-  if (entries.length === 0) {
-    await params.stateRoot.remove(params.proposalDir);
-    return `Removed empty legacy Skill Workshop proposal directory ${params.proposalId}.`;
-  }
-  await params.stateRoot.mkdir(RECOVERY_PROPOSALS_DIR);
-  // A unique target preserves earlier recovery artifacts without an unsafe
-  // check-then-replace window. The fs-safe move pins both directory parents.
-  const recoveryPath = `${RECOVERY_PROPOSALS_DIR}/${params.proposalId}-${randomUUID()}`;
-  await params.stateRoot.move(params.proposalDir, recoveryPath, { overwrite: true });
-  return `Quarantined incomplete Skill Workshop proposal ${params.proposalId} to ${recoveryPath} for manual recovery.`;
-}
-
-/** Import verified legacy proposal sidecars, then remove only the imported JSON metadata. */
-async function importLegacySkillProposalSidecars(params: {
-  config: OpenClawConfig;
-  env?: NodeJS.ProcessEnv;
-}): Promise<MigrationResult> {
-  const env = params.env ?? process.env;
-  const stateDir = resolveStateDir(env);
-  if (!(await pathExists(path.join(stateDir, PROPOSALS_DIR)))) {
-    if (!(await pathExists(path.join(stateDir, MANIFEST_PATH)))) {
-      return {
-        changes: [],
-        warnings: [],
-        detected: 0,
-        migrated: 0,
-      };
-    }
-    await removePathWithinRoot({ rootDir: stateDir, relativePath: MANIFEST_PATH });
-    return {
-      changes: ["Removed the empty legacy Skill Workshop proposal index."],
-      warnings: [],
-      detected: 0,
-      migrated: 0,
-    };
-  }
-  const stateRoot = await root(stateDir);
-  let entries;
-  try {
-    entries = await stateRoot.list(PROPOSALS_DIR, { withFileTypes: true });
-  } catch (error) {
-    if (hasErrnoCode(error, "not-found")) {
-      return { changes: [], warnings: [], detected: 0, migrated: 0 };
-    }
-    return {
-      changes: [],
-      warnings: [`Failed to inspect legacy Skill Workshop proposals: ${String(error)}`],
-      detected: 0,
-      migrated: 0,
-    };
-  }
-
-  const proposalIds = entries
-    .filter((entry) => entry.isDirectory && PROPOSAL_ID_PATTERN.test(entry.name))
-    .map((entry) => entry.name)
-    .toSorted((left, right) => left.localeCompare(right));
-  const warnings: string[] = [];
-  const changes: string[] = [];
-  let recoverableWarningCount = 0;
-  const prepared = new Map<
-    string,
-    PreparedLegacyProposal | { warning: string } | { error: unknown }
-  >();
-  // Resolve every sidecar's ownership before the first import or artifact retirement.
-  for (const proposalId of proposalIds) {
-    try {
-      prepared.set(
-        proposalId,
-        await prepareLegacyProposal({ config: params.config, env, proposalId, stateRoot }),
-      );
-    } catch (error) {
-      prepared.set(proposalId, { error });
-    }
-  }
-  const database = openOpenClawStateDatabase({ env });
-  const kysely = getNodeSqliteKysely<Pick<OpenClawStateDatabase, "skill_workshop_proposals">>(
-    database.db,
-  );
-  let migrated = 0;
-  for (const proposalId of proposalIds) {
-    const proposalDir = `${PROPOSALS_DIR}/${proposalId}`;
-    const proposal = prepared.get(proposalId)!;
-    if ("warning" in proposal) {
-      warnings.push(proposal.warning);
-      recoverableWarningCount += 1;
-      continue;
-    }
-    try {
-      if ("error" in proposal) {
-        throw proposal.error;
-      }
-      await migrateProposal({
-        config: params.config,
-        env,
-        prepared: proposal,
-        stateRoot,
-      });
-      migrated += 1;
-      continue;
-    } catch (error) {
-      if (!isMissingPathError(error)) {
-        warnings.push(`Failed to migrate Skill Workshop proposal ${proposalId}: ${String(error)}`);
-        continue;
-      }
-      // Modern bundles have no legacy sidecar. Recognize their durable record
-      // without entering the feature's schema-writing read facade.
-      const stored = tableExists(database.db, "skill_workshop_proposals")
-        ? executeSqliteQueryTakeFirstSync(
-            database.db,
-            kysely
-              .selectFrom("skill_workshop_proposals")
-              .selectAll()
-              .where("proposal_id", "=", proposalId)
-              .where("owner_agent_id", "is not", null),
-          )
-        : undefined;
-      if (stored && parseSkillProposalRow(stored)) {
-        continue;
-      }
-      try {
-        changes.push(await reconcileIncompleteProposal({ proposalId, proposalDir, stateRoot }));
-      } catch (reconcileError) {
-        warnings.push(
-          `Could not quarantine incomplete Skill Workshop proposal ${proposalId}: ${String(
-            reconcileError,
-          )}. Manually move ${proposalDir} to ${RECOVERY_PROPOSALS_DIR} to recover it.`,
-        );
-      }
-    }
-  }
-  await removePathWithinRoot({ rootDir: stateDir, relativePath: MANIFEST_PATH }).catch(
-    (error: unknown) => {
-      if (!isMissingPathError(error)) {
-        warnings.push(`Failed to remove legacy Skill Workshop proposal index: ${String(error)}`);
-      }
-    },
-  );
-  if (migrated > 0) {
-    changes.unshift(
-      `Migrated ${migrated} Skill Workshop proposal${migrated === 1 ? "" : "s"} into shared SQLite.`,
-    );
-  }
-  return {
-    changes,
-    warnings,
-    ...(warnings.length > 0 && warnings.length === recoverableWarningCount
-      ? { warningDisposition: "recoverable" as const }
-      : {}),
-    detected: proposalIds.length,
-    migrated,
   };
 }
 

--- a/src/commands/doctor-skill-workshop-workspaces.ts
+++ b/src/commands/doctor-skill-workshop-workspaces.ts
@@ -20,6 +20,7 @@ import {
   recordLegacyMigrationSource,
   resolveLegacyMigrationSourceKey,
 } from "../infra/state-migrations.receipts.js";
+import { isUpdateRehearsalReadOnlyPath } from "../infra/update-rehearsal-paths.js";
 import { readSkillProposalTargetTreeSha256 } from "../skills/workshop/proposal-bundle.js";
 import type { DB } from "../state/openclaw-state-db.generated.js";
 import {
@@ -109,6 +110,13 @@ export async function prepareWorkshopWorkspaceRelocation(
   moves: readonly { source: string; destination: string }[],
   env: NodeJS.ProcessEnv,
 ): Promise<void> {
+  if (
+    [workspaceDir, ...moves.flatMap((move) => [move.source, move.destination])].some((filePath) =>
+      isUpdateRehearsalReadOnlyPath(filePath, env),
+    )
+  ) {
+    return;
+  }
   const sourceKey = resolveLegacyMigrationSourceKey(MIGRATION_KIND, workspaceDir);
   const database = openOpenClawStateDatabase({ env });
   const kysely = getNodeSqliteKysely<Pick<DB, "migration_sources">>(database.db);
@@ -209,6 +217,14 @@ export async function finishWorkshopWorkspaceRelocations(env: NodeJS.ProcessEnv)
   ).rows;
   for (const receipt of receipts) {
     const captured = relocationSchema.parse(JSON.parse(receipt.report_json));
+    const retainedPaths = [
+      captured.workspaceDir,
+      captured.workspacePath,
+      ...captured.moves.flatMap((move) => [move.source, move.destination]),
+    ];
+    if (retainedPaths.some((filePath) => isUpdateRehearsalReadOnlyPath(filePath, env))) {
+      continue;
+    }
     const sources = captured.moves.map((move) => move.source);
     let complete = (await directoryIdentity(captured.workspaceDir)) === captured.directoryIdentity;
     if (complete) {
@@ -231,6 +247,9 @@ export async function finishWorkshopWorkspaceRelocations(env: NodeJS.ProcessEnv)
     }
     runOpenClawStateWriteTransaction(
       (writeDatabase) => {
+        if (retainedPaths.some((filePath) => isUpdateRehearsalReadOnlyPath(filePath, env))) {
+          return;
+        }
         const { db } = writeDatabase;
         const current = executeSqliteQueryTakeFirstSync(
           db,

--- a/src/infra/state-migrations.messages.ts
+++ b/src/infra/state-migrations.messages.ts
@@ -81,6 +81,7 @@ export function createLegacyStateMigrationStepReceipt(
       ? { refusedAgentDatabasePaths: result.refusedAgentDatabasePaths }
       : {}),
     ...(result.notices?.length ? { notices: result.notices } : {}),
+    ...(result.rehearsal ? { rehearsal: result.rehearsal } : {}),
     ...(refused
       ? {
           refusal: step.refusal ?? {

--- a/src/infra/state-migrations.types.ts
+++ b/src/infra/state-migrations.types.ts
@@ -179,6 +179,7 @@ export type MigrationMessages = {
   changes: string[];
   warnings: string[];
   notices?: string[];
+  rehearsal?: { outsideRootLegacyFileCount: number };
   /** The owner classified every warning as advisory, including a source-preserving skip. */
   warningDisposition?: "recoverable";
   /** An intentional non-outcome can carry advisory warnings without becoming a refusal. */
@@ -214,6 +215,7 @@ export type LegacyStateMigrationStepReceipt = Omit<LegacyStateMigrationStepPlan,
   warnings: string[];
   notices?: string[];
   refusedAgentDatabasePaths?: readonly string[];
+  rehearsal?: MigrationMessages["rehearsal"];
   refusal?: { code: string; message: string };
 };
 

--- a/src/infra/state-migrations.workspace-setup-files.ts
+++ b/src/infra/state-migrations.workspace-setup-files.ts
@@ -1,0 +1,136 @@
+import { createHash, randomUUID } from "node:crypto";
+import path from "node:path";
+import { TextDecoder } from "node:util";
+import type { Root } from "@openclaw/fs-safe";
+import {
+  LEGACY_WORKSPACE_ATTESTATION_MAX_BYTES,
+  WORKSPACE_DOCTOR_CLAIM_SUFFIX,
+} from "../agents/workspace-legacy-state.js";
+import { formatErrorMessage } from "./errors.js";
+import { LegacyMigrationSourceClaim } from "./state-migrations.source-snapshot.js";
+import type { SourceSnapshot } from "./state-migrations.workspace-setup-store.js";
+import type { LegacyWorkspaceStateSource } from "./state-migrations.workspace-setup.types.js";
+
+const SETUP_MAX_BYTES = 64 * 1024;
+const CLAIM_SUFFIX = WORKSPACE_DOCTOR_CLAIM_SUFFIX;
+const utf8Decoder = new TextDecoder("utf-8", { fatal: true });
+
+async function readBoundedRegularFile(params: {
+  sourceRoot: Root;
+  relativePath: string;
+  sourcePath: string;
+  maxBytes: number;
+}): Promise<SourceSnapshot> {
+  const opened = await params.sourceRoot.open(params.relativePath, {
+    hardlinks: "reject",
+    symlinks: "reject",
+  });
+  try {
+    const before = opened.stat;
+    if (
+      !before.isFile() ||
+      before.nlink !== 1 ||
+      !Number.isSafeInteger(before.size) ||
+      before.size < 0 ||
+      before.size > params.maxBytes
+    ) {
+      throw new Error("legacy workspace source is not a safe regular file");
+    }
+    const buffer = Buffer.alloc(before.size);
+    let offset = 0;
+    while (offset < buffer.length) {
+      const { bytesRead } = await opened.handle.read(
+        buffer,
+        offset,
+        buffer.length - offset,
+        offset,
+      );
+      if (bytesRead === 0) {
+        throw new Error("legacy workspace source ended unexpectedly");
+      }
+      offset += bytesRead;
+    }
+    const after = await opened.handle.stat();
+    if (
+      !after.isFile() ||
+      after.nlink !== 1 ||
+      after.dev !== before.dev ||
+      after.ino !== before.ino ||
+      after.size !== before.size ||
+      after.mtimeMs !== before.mtimeMs ||
+      after.ctimeMs !== before.ctimeMs ||
+      offset !== after.size
+    ) {
+      throw new Error("legacy workspace source changed while reading");
+    }
+    let raw: string;
+    try {
+      raw = utf8Decoder.decode(buffer);
+    } catch {
+      throw new Error("legacy workspace source is not valid UTF-8");
+    }
+    return {
+      sourcePath: params.sourcePath,
+      dev: after.dev,
+      ino: after.ino,
+      mtimeMs: after.mtimeMs,
+      sha256: createHash("sha256").update(buffer).digest("hex"),
+      size: after.size,
+      raw,
+      buffer,
+    };
+  } finally {
+    await opened[Symbol.asyncDispose]();
+  }
+}
+
+export async function archiveWorkspaceSetupSource(
+  sourceRoot: Root,
+  source: LegacyWorkspaceStateSource,
+  snapshot: SourceSnapshot,
+  existingArchivePath?: string,
+): Promise<string> {
+  const archivePath =
+    existingArchivePath ?? `${source.sourcePath}.migrated.${snapshot.sha256}.${randomUUID()}`;
+  const relativePath = path.relative(source.rootDir, archivePath);
+  // The receipt publishes only a verified backup. A crash during creation leaves
+  // an unreferenced artifact, so the next attempt can safely use a fresh name.
+  if (!existingArchivePath) {
+    await sourceRoot.create(relativePath, snapshot.buffer, { mode: 0o600 });
+  }
+  const archived = await readBoundedRegularFile({
+    sourceRoot,
+    relativePath,
+    sourcePath: archivePath,
+    maxBytes: SETUP_MAX_BYTES,
+  });
+  if (archived.sha256 !== snapshot.sha256) {
+    throw new Error(`workspace setup backup differs from the claimed source: ${archivePath}`);
+  }
+  return archivePath;
+}
+
+export function createLegacySourceClaim(
+  sourceRoot: Root,
+  source: LegacyWorkspaceStateSource,
+): LegacyMigrationSourceClaim<SourceSnapshot> {
+  return new LegacyMigrationSourceClaim({
+    stateRoot: sourceRoot,
+    stateDir: source.rootDir,
+    sourcePath: source.sourcePath,
+    label: "workspace",
+    claimSuffix: CLAIM_SUFFIX,
+    formatError: formatErrorMessage,
+    readSnapshot: (sourcePath) =>
+      readBoundedRegularFile({
+        sourceRoot,
+        relativePath:
+          sourcePath === source.sourcePath
+            ? source.relativePath
+            : `${source.relativePath}${CLAIM_SUFFIX}`,
+        sourcePath,
+        maxBytes:
+          source.kind === "setup" ? SETUP_MAX_BYTES : LEGACY_WORKSPACE_ATTESTATION_MAX_BYTES,
+      }),
+  });
+}

--- a/src/infra/state-migrations.workspace-setup.ts
+++ b/src/infra/state-migrations.workspace-setup.ts
@@ -1,13 +1,10 @@
 // Doctor-only import for retired workspace setup and attestation files.
-import { createHash, randomUUID } from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { TextDecoder } from "node:util";
 import { root, type Root } from "@openclaw/fs-safe";
 import {
   LEGACY_WORKSPACE_ATTESTATION_DIRNAME,
-  LEGACY_WORKSPACE_ATTESTATION_MAX_BYTES,
   LEGACY_WORKSPACE_STATE_CURRENT_FILENAME,
   WORKSPACE_DOCTOR_CLAIM_SUFFIX,
   legacyWorkspaceSiblingAttestationMayExist,
@@ -24,11 +21,15 @@ import { resolveUserPath } from "./home-dir.js";
 import { pathMayExistSync } from "./path-existence.js";
 import { withLegacyMigrationStateLock } from "./state-migrations.lock.js";
 import {
-  LegacyMigrationSourceClaim,
+  type LegacyMigrationSourceClaim,
   legacyMigrationSourceOrClaimMayExist as sourceOrClaimMayExist,
   legacyMigrationSourceSnapshotsMatch as snapshotsMatch,
 } from "./state-migrations.source-snapshot.js";
 import type { MigrationMessages } from "./state-migrations.types.js";
+import {
+  archiveWorkspaceSetupSource,
+  createLegacySourceClaim,
+} from "./state-migrations.workspace-setup-files.js";
 import {
   markLegacyMigrationSourceRemoved,
   readReceipt,
@@ -45,130 +46,9 @@ import type {
   LegacyWorkspaceStateSource,
 } from "./state-migrations.workspace-setup.types.js";
 import { formatDoctorStateRepairFailure } from "./state-repair-message.js";
+import { isUpdateRehearsalReadOnlyPath } from "./update-rehearsal-paths.js";
 
-const SETUP_MAX_BYTES = 64 * 1024;
 const CLAIM_SUFFIX = WORKSPACE_DOCTOR_CLAIM_SUFFIX;
-const utf8Decoder = new TextDecoder("utf-8", { fatal: true });
-
-async function readBoundedRegularFile(params: {
-  sourceRoot: Root;
-  relativePath: string;
-  sourcePath: string;
-  maxBytes: number;
-}): Promise<SourceSnapshot> {
-  const opened = await params.sourceRoot.open(params.relativePath, {
-    hardlinks: "reject",
-    symlinks: "reject",
-  });
-  try {
-    const before = opened.stat;
-    if (
-      !before.isFile() ||
-      before.nlink !== 1 ||
-      !Number.isSafeInteger(before.size) ||
-      before.size < 0 ||
-      before.size > params.maxBytes
-    ) {
-      throw new Error("legacy workspace source is not a safe regular file");
-    }
-    const buffer = Buffer.alloc(before.size);
-    let offset = 0;
-    while (offset < buffer.length) {
-      const { bytesRead } = await opened.handle.read(
-        buffer,
-        offset,
-        buffer.length - offset,
-        offset,
-      );
-      if (bytesRead === 0) {
-        throw new Error("legacy workspace source ended unexpectedly");
-      }
-      offset += bytesRead;
-    }
-    const after = await opened.handle.stat();
-    if (
-      !after.isFile() ||
-      after.nlink !== 1 ||
-      after.dev !== before.dev ||
-      after.ino !== before.ino ||
-      after.size !== before.size ||
-      after.mtimeMs !== before.mtimeMs ||
-      after.ctimeMs !== before.ctimeMs ||
-      offset !== after.size
-    ) {
-      throw new Error("legacy workspace source changed while reading");
-    }
-    let raw: string;
-    try {
-      raw = utf8Decoder.decode(buffer);
-    } catch {
-      throw new Error("legacy workspace source is not valid UTF-8");
-    }
-    return {
-      sourcePath: params.sourcePath,
-      dev: after.dev,
-      ino: after.ino,
-      mtimeMs: after.mtimeMs,
-      sha256: createHash("sha256").update(buffer).digest("hex"),
-      size: after.size,
-      raw,
-      buffer,
-    };
-  } finally {
-    await opened[Symbol.asyncDispose]();
-  }
-}
-
-async function archiveWorkspaceSetupSource(
-  sourceRoot: Root,
-  source: LegacyWorkspaceStateSource,
-  snapshot: SourceSnapshot,
-  existingArchivePath?: string,
-): Promise<string> {
-  const archivePath =
-    existingArchivePath ?? `${source.sourcePath}.migrated.${snapshot.sha256}.${randomUUID()}`;
-  const relativePath = path.relative(source.rootDir, archivePath);
-  // The receipt publishes only a verified backup. A crash during creation leaves
-  // an unreferenced artifact, so the next attempt can safely use a fresh name.
-  if (!existingArchivePath) {
-    await sourceRoot.create(relativePath, snapshot.buffer, { mode: 0o600 });
-  }
-  const archived = await readBoundedRegularFile({
-    sourceRoot,
-    relativePath,
-    sourcePath: archivePath,
-    maxBytes: SETUP_MAX_BYTES,
-  });
-  if (archived.sha256 !== snapshot.sha256) {
-    throw new Error(`workspace setup backup differs from the claimed source: ${archivePath}`);
-  }
-  return archivePath;
-}
-
-function createLegacySourceClaim(
-  sourceRoot: Root,
-  source: LegacyWorkspaceStateSource,
-): LegacyMigrationSourceClaim<SourceSnapshot> {
-  return new LegacyMigrationSourceClaim({
-    stateRoot: sourceRoot,
-    stateDir: source.rootDir,
-    sourcePath: source.sourcePath,
-    label: "workspace",
-    claimSuffix: CLAIM_SUFFIX,
-    formatError: formatErrorMessage,
-    readSnapshot: (sourcePath) =>
-      readBoundedRegularFile({
-        sourceRoot,
-        relativePath:
-          sourcePath === source.sourcePath
-            ? source.relativePath
-            : `${source.relativePath}${CLAIM_SUFFIX}`,
-        sourcePath,
-        maxBytes:
-          source.kind === "setup" ? SETUP_MAX_BYTES : LEGACY_WORKSPACE_ATTESTATION_MAX_BYTES,
-      }),
-  });
-}
 
 function createLegacySource(
   params: Omit<LegacyWorkspaceStateSource, "relativePath" | "rootDir"> & { rootDir: string },
@@ -314,7 +194,16 @@ export async function detectLegacyWorkspaceState(params: {
   const env = { ...(params.env ?? process.env), OPENCLAW_STATE_DIR: params.stateDir };
   const homedir = params.homedir ?? os.homedir;
   const byPath = new Map<string, LegacyWorkspaceStateSource>();
+  const rehearsalInventoryPaths = new Set<string>();
   const add = (source: LegacyWorkspaceStateSource) => {
+    if (isUpdateRehearsalReadOnlyPath(source.sourcePath, env)) {
+      for (const sourcePath of [source.sourcePath, `${source.sourcePath}${CLAIM_SUFFIX}`]) {
+        if (pathMayExistSync(sourcePath)) {
+          rehearsalInventoryPaths.add(sourcePath);
+        }
+      }
+      return;
+    }
     const key = `${source.kind}:${path.resolve(source.sourcePath)}`;
     const existing = byPath.get(key);
     const sourceIsConfigured = source.workspaceDir !== undefined;
@@ -348,7 +237,7 @@ export async function detectLegacyWorkspaceState(params: {
   const historicalWorkspaceDirs = [];
   for (const workspaceDir of await listLegacySkillWorkshopWorkspaceDirs(params.cfg, env)) {
     const canonicalPath = resolveWorkspaceStateIdentity(workspaceDir).workspacePath;
-    if (!configuredPaths.has(canonicalPath)) {
+    if (!configuredPaths.has(canonicalPath) && !isUpdateRehearsalReadOnlyPath(workspaceDir, env)) {
       historicalWorkspaceDirs.push(workspaceDir);
     }
     workspaceDirs.add(workspaceDir);
@@ -368,8 +257,12 @@ export async function detectLegacyWorkspaceState(params: {
   );
   return {
     sources,
-    hasLegacy: sources.length > 0 || historicalWorkspaceDirs.length > 0,
+    hasLegacy:
+      sources.length > 0 || historicalWorkspaceDirs.length > 0 || rehearsalInventoryPaths.size > 0,
     ...(historicalWorkspaceDirs.length > 0 ? { historicalWorkspaceDirs } : {}),
+    ...(rehearsalInventoryPaths.size > 0
+      ? { rehearsalInventoryPaths: [...rehearsalInventoryPaths] }
+      : {}),
   };
 }
 
@@ -516,6 +409,9 @@ async function migrateOneSource(params: {
     ...(params.historical ? { warningDisposition: "recoverable" as const } : {}),
   });
   try {
+    if (isUpdateRehearsalReadOnlyPath(params.source.sourcePath, params.env)) {
+      throw new Error("Legacy workspace source is outside the update rehearsal root.");
+    }
     assertConfiguredWorkspaceIdentity(params.source);
     sourceRoot = await root(params.source.rootDir, {
       hardlinks: "reject",
@@ -684,7 +580,13 @@ export async function migrateLegacyWorkspaceState(params: {
     run: async (env) => {
       const changes: string[] = [];
       const warnings: string[] = [];
-      const notices: string[] = [];
+      const outsideRootLegacyFileCount = detected.rehearsalInventoryPaths?.length ?? 0;
+      const notices: string[] =
+        outsideRootLegacyFileCount > 0
+          ? [
+              `rehearsal: ${outsideRootLegacyFileCount} legacy files outside the rehearsal root left untouched`,
+            ]
+          : [];
       const historical = new Map(
         (detected.historicalWorkspaceDirs ?? []).map((directory) => [
           resolveWorkspaceStateIdentity(directory).workspacePath,
@@ -725,6 +627,7 @@ export async function migrateLegacyWorkspaceState(params: {
         changes,
         warnings,
         ...(notices.length > 0 ? { notices } : {}),
+        ...(outsideRootLegacyFileCount > 0 ? { rehearsal: { outsideRootLegacyFileCount } } : {}),
         ...(warnings.length > 0 && blockingWarnings === 0
           ? { warningDisposition: "recoverable" as const }
           : {}),

--- a/src/infra/state-migrations.workspace-setup.types.ts
+++ b/src/infra/state-migrations.workspace-setup.types.ts
@@ -13,4 +13,5 @@ export type LegacyWorkspaceStateDetection = {
   sources: LegacyWorkspaceStateSource[];
   hasLegacy: boolean;
   historicalWorkspaceDirs?: string[];
+  rehearsalInventoryPaths?: string[];
 };

--- a/src/infra/update-candidate-rehearsal.ts
+++ b/src/infra/update-candidate-rehearsal.ts
@@ -20,6 +20,7 @@ import {
   POST_CORE_UPDATE_REQUESTED_CHANNEL_ENV,
   POST_CORE_UPDATE_SOURCE_CONFIG_PATH_ENV,
 } from "./update-post-core-context.js";
+import { buildUpdateRehearsalPathEnv } from "./update-rehearsal-paths.js";
 import { buildUpdateDoctorEnv } from "./update-runner-doctor.js";
 
 export type UpdateCandidateRehearsal = {
@@ -125,8 +126,6 @@ export async function prepareUpdateCandidateRehearsal(params: {
 }): Promise<UpdateCandidateRehearsal> {
   const sourceEnv = params.env ?? process.env;
   const workerEnv = (tempDir: string): NodeJS.ProcessEnv => {
-    const configPath = path.join(tempDir, "openclaw.json");
-    const workspaceDir = path.join(tempDir, "workspace");
     const copiedAgentDir = (directory: string | undefined) =>
       directory?.trim()
         ? resolveUpdateCandidateStatePath(
@@ -137,34 +136,13 @@ export async function prepareUpdateCandidateRehearsal(params: {
         : undefined;
     const env: NodeJS.ProcessEnv = {
       ...sourceEnv,
-      HOME: tempDir,
-      USERPROFILE: tempDir,
-      TMPDIR: tempDir,
-      TMP: tempDir,
-      TEMP: tempDir,
-      XDG_CONFIG_HOME: path.join(tempDir, "config"),
-      XDG_CACHE_HOME: path.join(tempDir, "cache"),
-      XDG_DATA_HOME: path.join(tempDir, "data"),
-      XDG_STATE_HOME: path.join(tempDir, "state"),
-      OPENCLAW_HOME: tempDir,
-      OPENCLAW_STATE_DIR: tempDir,
+      ...buildUpdateRehearsalPathEnv(tempDir),
       // Validation must resolve the candidate SDK, not the source launcher's checkout.
       OPENCLAW_DEV_SOURCE_ROOT: params.candidateRoot,
-      OPENCLAW_CONFIG_PATH: configPath,
-      OPENCLAW_WORKSPACE_DIR: workspaceDir,
       OPENCLAW_AGENT_DIR: copiedAgentDir(sourceEnv.OPENCLAW_AGENT_DIR),
       PI_CODING_AGENT_DIR: copiedAgentDir(sourceEnv.PI_CODING_AGENT_DIR),
       OPENCLAW_BUNDLED_PLUGINS_DIR: undefined,
       OPENCLAW_DISABLE_BUNDLED_PLUGINS: undefined,
-      OPENCLAW_SKIP_CHANNELS: "1",
-      OPENCLAW_SKIP_PROVIDERS: "1",
-      OPENCLAW_SKIP_CRON: "1",
-      OPENCLAW_SKIP_GMAIL_WATCHER: "1",
-      OPENCLAW_SKIP_CANVAS_HOST: "1",
-      OPENCLAW_SKIP_BROWSER_CONTROL_SERVER: "1",
-      OPENCLAW_SKIP_STARTUP_MODEL_PREWARM: "1",
-      OPENCLAW_NO_AUTO_UPDATE: "1",
-      NODE_DISABLE_COMPILE_CACHE: "1",
       OPENCLAW_GATEWAY_SERVICE_PID: undefined,
       OPENCLAW_GATEWAY_PORT: undefined,
       OPENCLAW_COMPATIBILITY_HOST_VERSION: undefined,

--- a/src/infra/update-candidate-workspace-rehearsal.test.ts
+++ b/src/infra/update-candidate-workspace-rehearsal.test.ts
@@ -1,0 +1,185 @@
+import { createHash } from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { assertConfiguredWorkspaceStateReady } from "../agents/workspace-state-dirs.js";
+import {
+  mergeWorkspaceSetupState,
+  readWorkspaceStateSnapshot,
+} from "../agents/workspace-state-store.js";
+import { createAppliedLegacyProposal } from "../commands/doctor-skill-workshop-sqlite.test-support.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { EMPTY_LEGACY_SESSION_SURFACES } from "../plugins/legacy-session-surfaces.types.js";
+import { importLegacySkillProposal } from "../skills/workshop/store.js";
+import {
+  openOpenClawStateDatabase,
+  closeOpenClawStateDatabaseForTest,
+} from "../state/openclaw-state-db.js";
+import {
+  createOpenClawTestState,
+  type OpenClawTestState,
+} from "../test-utils/openclaw-test-state.js";
+import { autoMigrateLegacyState } from "./state-migrations.doctor.js";
+import { throwIfDoctorStateMigrationRefused } from "./state-migrations.messages.js";
+import { prepareUpdateCandidateRehearsal } from "./update-candidate-rehearsal.js";
+
+async function fileHashes(root: string): Promise<Record<string, string>> {
+  const entries = await fs.readdir(root, { recursive: true, withFileTypes: true });
+  return Object.fromEntries(
+    await Promise.all(
+      entries
+        .filter((entry) => entry.isFile())
+        .map(async (entry) => {
+          const file = path.join(entry.parentPath, entry.name);
+          return [
+            path.relative(root, file),
+            createHash("sha256")
+              .update(await fs.readFile(file))
+              .digest("hex"),
+          ];
+        }),
+    ),
+  );
+}
+
+describe("workspace state during an update rehearsal", () => {
+  let state: OpenClawTestState;
+  beforeEach(async () => {
+    state = await createOpenClawTestState({ label: "workspace-rehearsal" });
+  });
+  afterEach(async () => {
+    closeOpenClawStateDatabaseForTest();
+    await state.cleanup();
+  });
+
+  it.each([
+    { name: "older", completed: "2026-04-23T11:31:35.154Z", claim: false },
+    { name: "identical", completed: "2026-08-01T02:32:01.596Z", claim: false },
+    { name: "newer", completed: "2026-09-01T02:32:01.596Z", claim: false },
+    {
+      name: "interrupted claim",
+      completed: "2026-04-23T11:31:35.154Z",
+      claim: true,
+    },
+  ])("preserves live $name files until the real Doctor runs", async ({ completed, claim }) => {
+    const historical = state.path("historical-workspace");
+    const config: OpenClawConfig = {
+      plugins: { enabled: false },
+      agents: { entries: { main: { workspace: state.workspaceDir } } },
+    };
+    await state.writeConfig(config);
+    const canonical = {
+      bootstrapSeededAt: "2026-02-21T23:37:10.373Z",
+      setupCompletedAt: "2026-08-01T02:32:01.596Z",
+    };
+    await fs.mkdir(historical, { recursive: true });
+    await mergeWorkspaceSetupState(historical, canonical, Date.now(), { env: state.env });
+    const setupText = JSON.stringify({ version: 1, ...canonical, setupCompletedAt: completed });
+    const sourcePaths = ["openclaw-workspace-state.json", ".openclaw/workspace-state.json"].map(
+      (relative) => path.join(historical, relative),
+    );
+    for (const source of sourcePaths) {
+      await fs.mkdir(path.dirname(source), { recursive: true });
+      await fs.writeFile(`${source}${claim ? ".doctor-importing" : ""}`, setupText);
+    }
+    const content = "---\nname: procedure\ndescription: Retained procedure\n---\n\n# Procedure\n";
+    const record = {
+      ...createAppliedLegacyProposal({
+        id: "procedure-20260901-1234567890",
+        title: "Procedure",
+        description: "Retained procedure",
+        content,
+        target: { skillKey: "procedure", skillDir: path.join(historical, "skills", "procedure") },
+      }),
+      origin: { agentId: "main" },
+    };
+    await fs.mkdir(record.target.skillDir, { recursive: true });
+    await fs.writeFile(record.target.skillFile, content);
+    importLegacySkillProposal({ record, ownerAgentId: "main", store: { env: state.env } });
+    const before = await fileHashes(historical);
+    const rehearsal = await prepareUpdateCandidateRehearsal({
+      config,
+      stateDir: state.stateDir,
+      candidateRoot: process.cwd(),
+      env: state.env,
+    });
+    try {
+      const env = { ...rehearsal.env };
+      const cfg: OpenClawConfig = JSON.parse(await fs.readFile(rehearsal.configPath, "utf8"));
+      const result = await autoMigrateLegacyState({
+        cfg,
+        env,
+        homedir: () => rehearsal.stateDir,
+        doctorOnlyStateMigrations: true,
+        legacySessionSurfaces: EMPTY_LEGACY_SESSION_SURFACES,
+      });
+      expect(await fileHashes(historical)).toEqual(before);
+      expect(
+        () => throwIfDoctorStateMigrationRefused(result.stepReceipts),
+        result.warnings.join("\n"),
+      ).not.toThrow();
+      expect(
+        result.stepReceipts.find((entry) => entry.id === "workspace-state")?.notices,
+      ).toContain("rehearsal: 2 legacy files outside the rehearsal root left untouched");
+      expect(
+        result.stepReceipts.find((entry) => entry.id === "workspace-state")?.rehearsal,
+      ).toEqual({ outsideRootLegacyFileCount: 2 });
+      expect(
+        openOpenClawStateDatabase({ env })
+          .db.prepare("SELECT status FROM skill_workshop_proposals WHERE proposal_id = ?")
+          .get(record.id),
+      ).toEqual({ status: "applied" });
+    } finally {
+      closeOpenClawStateDatabaseForTest();
+      await rehearsal.cleanup();
+    }
+    expect(await fileHashes(historical)).toEqual(before);
+    const real = await autoMigrateLegacyState({
+      cfg: config,
+      env: {
+        ...state.env,
+        OPENCLAW_UPDATE_IN_PROGRESS: "1",
+        OPENCLAW_COMPATIBILITY_HOST_VERSION: "2026.9.4",
+      },
+      homedir: () => state.home,
+      doctorOnlyStateMigrations: true,
+      legacySessionSurfaces: EMPTY_LEGACY_SESSION_SURFACES,
+    });
+    expect(
+      () => throwIfDoctorStateMigrationRefused(real.stepReceipts),
+      real.warnings.join("\n"),
+    ).not.toThrow();
+    expect((await readWorkspaceStateSnapshot(historical, { env: state.env })).setup).toEqual({
+      version: 1,
+      ...canonical,
+    });
+    const rows = openOpenClawStateDatabase({ env: state.env })
+      .db.prepare(
+        "SELECT status, removed_source, report_json FROM migration_sources WHERE migration_kind = 'legacy-workspace-setup-files'",
+      )
+      .all();
+    expect(rows).toHaveLength(2);
+    for (const row of rows) {
+      expect(row).toMatchObject({ status: "completed", removed_source: 1 });
+    }
+    for (const source of sourcePaths) {
+      await expect(fs.access(source)).rejects.toMatchObject({ code: "ENOENT" });
+      await expect(fs.access(`${source}.doctor-importing`)).rejects.toMatchObject({
+        code: "ENOENT",
+      });
+      const archives = (await fs.readdir(path.dirname(source))).filter((entry) =>
+        entry.startsWith(`${path.basename(source)}.migrated.`),
+      );
+      expect(archives).toHaveLength(1);
+      await expect(
+        fs.readFile(path.join(path.dirname(source), archives[0]!), "utf8"),
+      ).resolves.toBe(setupText);
+    }
+    await expect(
+      fs.readFile(path.join(state.agentDir(), "workshop-skills", "procedure", "SKILL.md"), "utf8"),
+    ).resolves.toBe(content);
+    await expect(
+      assertConfiguredWorkspaceStateReady({ cfg: config, env: state.env }),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/src/infra/update-rehearsal-paths.ts
+++ b/src/infra/update-rehearsal-paths.ts
@@ -1,0 +1,65 @@
+import path from "node:path";
+import { resolveIdentityPathViaExistingAncestorSync } from "./boundary-path.js";
+import { isPathInside } from "./path-guards.js";
+
+/** Declare the private filesystem namespace shared by every rehearsal child. */
+export function buildUpdateRehearsalPathEnv(root: string): NodeJS.ProcessEnv {
+  return {
+    HOME: root,
+    USERPROFILE: root,
+    TMPDIR: root,
+    TMP: root,
+    TEMP: root,
+    XDG_CONFIG_HOME: path.join(root, "config"),
+    XDG_CACHE_HOME: path.join(root, "cache"),
+    XDG_DATA_HOME: path.join(root, "data"),
+    XDG_STATE_HOME: path.join(root, "state"),
+    OPENCLAW_HOME: root,
+    OPENCLAW_STATE_DIR: root,
+    OPENCLAW_CONFIG_PATH: path.join(root, "openclaw.json"),
+    OPENCLAW_WORKSPACE_DIR: path.join(root, "workspace"),
+    OPENCLAW_SKIP_CHANNELS: "1",
+    OPENCLAW_SKIP_PROVIDERS: "1",
+    OPENCLAW_SKIP_CRON: "1",
+    OPENCLAW_SKIP_GMAIL_WATCHER: "1",
+    OPENCLAW_SKIP_CANVAS_HOST: "1",
+    OPENCLAW_SKIP_BROWSER_CONTROL_SERVER: "1",
+    OPENCLAW_SKIP_STARTUP_MODEL_PREWARM: "1",
+    OPENCLAW_NO_AUTO_UPDATE: "1",
+    NODE_DISABLE_COMPILE_CACHE: "1",
+  };
+}
+
+/** Recognize the complete 9.3+ driver contract; update-in-progress alone is also used by live Doctor. */
+export function resolveUpdateRehearsalRoot(env: NodeJS.ProcessEnv): string | undefined {
+  const root = env.OPENCLAW_STATE_DIR;
+  if (
+    !root ||
+    !path.isAbsolute(root) ||
+    !["0", "1"].includes(env.OPENCLAW_UPDATE_IN_PROGRESS ?? "") ||
+    Object.entries(buildUpdateRehearsalPathEnv(root)).some(([key, value]) => env[key] !== value) ||
+    env.OPENCLAW_SERVICE_REPAIR_POLICY !== "external" ||
+    env.OPENCLAW_UPDATE_PARENT_ALLOWS_GATEWAY_SERVICE_REPAIR !== "0" ||
+    env.OPENCLAW_UPDATE_PARENT_ALLOWS_GATEWAY_ACTIVATION !== "0" ||
+    Boolean(env.OPENCLAW_COMPATIBILITY_HOST_VERSION)
+  ) {
+    return undefined;
+  }
+  return path.resolve(root);
+}
+
+/** Uncopied absolute locators remain inventory; they cannot grant writes outside the private root. */
+export function isUpdateRehearsalReadOnlyPath(filePath: string, env: NodeJS.ProcessEnv): boolean {
+  const root = resolveUpdateRehearsalRoot(env);
+  if (!root) {
+    return false;
+  }
+  const resolved = path.resolve(filePath);
+  return (
+    !isPathInside(root, resolved) ||
+    !isPathInside(
+      resolveIdentityPathViaExistingAncestorSync(root),
+      resolveIdentityPathViaExistingAncestorSync(resolved),
+    )
+  );
+}


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users updating from 2026.9.3 could lose active Workshop skill files during candidate rehearsal even though the update reported success. Copied proposal records retained absolute live-workspace paths, so the rehearsal retired the original setup files and moved live skills into its disposable directory.

#145084 already provides the standalone Doctor recovery for the historical-workspace shape in #142585. This PR fixes update-path isolation.

## Why This Change Was Made

The rehearsal owner now shares its existing filesystem namespace contract with Doctor. Persisted paths outside the copied root remain read-only inventory, with both lexical and physical containment checked. This includes setup import, pending rollback recovery, sidecar/index migration, skill relocation, collection backups, and prepared relocation receipts. Paths inside the copied root still migrate normally.

Doctor records a typed count and a notice: `rehearsal: N legacy files outside the rehearsal root left untouched`. The post-swap real Doctor retains the existing import, archival, and relocation behavior.

This is candidate-side: the 9.3/9.4 drivers run the candidate's Doctor, including their pre-plugin phase. Their installed snapshot producer supplies no new marker or workspace map, so the guard recognizes the complete isolation environment they already ship. The current producer uses that same shared contract; no new environment option is introduced.

## User Impact

Update rehearsal preserves the operator's workspace files and recovery history. The real Doctor then records the correct receipts in the real database, preserves archived setup bytes, and keeps Workshop skills available after the update.

## Evidence

- Regression tests fail before the guards: rehearsal changes original file hashes, consumes recovery metadata, rewrites external backups, and replays an external relocation receipt. The owned-path control passes before and after.
- Final targeted run: 50 tests passed, including older, identical, newer, and interrupted-claim setup sources, external rollback/sidecar/backup preservation, and successful migration within the copied root. The broader Workshop suite also passed (54 tests).
- Published 9.3 Docker baseline reproduces the original standalone refusal. Candidate standalone Doctor recovers the same preserved schema-16 fixture with two completed/removed receipts, archived bytes, three relocated skills, and Gateway `/readyz` 200.
- Two independent local Linux arm64 Docker cells recorded 51 rehearsal-child exits each: all five original workspace files remained byte-identical, including after Doctor and the canary Gateway. Both then hit the installed 9.3 driver's separate 30-second baseline-fingerprint timeout before swap (30,001 ms / 30,059 ms; #144758). The old package, schema 16, and original sources remained present. These are retained failures, not successful full-hop claims.
- The complete Linux x64 Docker cell passed on Blacksmith Testbox `tbx_01m29zt3crcg8r1myrdq8sd3sq` ([run](https://github.com/openclaw/openclaw/actions/runs/34674465303)): unchanged published 9.3 updater exit 0 / `status: ok` in 28.903 seconds; swap 5.714 seconds; real Doctor exit 0. All 51 rehearsal observations preserved five original files. Final verification found 2 completed/removed receipts, both archive hashes preserved, 3 applied skills intact, correct separate workspace milestones, and Gateway `/readyz` 200. Source commit `da7f3f22f06ca17eefb78b11b83fdb8f48ed344a` was verified by tree `220c95506a465d7fe7282305a09987af95f05e2c`; the Testbox carrier commit is an intentional wrapper identity. The command exited 0 and the lease completed; Testbox teardown stops its backing workflow. No product assertions or driver timeouts changed.
- `node scripts/check-changed.mjs`, `pnpm build`, and package tarball integrity checks passed. Fresh P1 autoreview on the final helper split: no accepted/actionable findings.

Known limitation: the two local arm64 runs still expose the installed driver's #144758 timeout, which candidate code cannot repair in that running parent. The independent x64 full hop and standalone candidate control pass. No timeout, assertion, schema, dependency, or baseline changes are included in this PR. Previous-head [CI](https://github.com/openclaw/openclaw/actions/runs/34674363265) completed red in [checks-node-compact-large-4](https://github.com/openclaw/openclaw/actions/runs/34674363265/job/103501545384): `src/gateway/worker-environments/worker-turn-detached-context.test.ts` timed out at `worker functional launch observation` after 5,000 ms. That test was added on main by #145591 (`aa7eabb1f6d`) after this branch's base and is absent from the previous PR head; no worker-launch code is changed here. That run's aggregate `openclaw/ci-gate` reflected the failure; other checks passed or skipped. The unrelated test was not altered or manually rerun.

Rebased onto current main to resolve its independent receipt-field addition. Head `d5702e9108db181518df58c9089d0e2cc41c2cb0` preserves the same implementation delta; range-diff shows only adjacent receipt context changed. The 10 rehearsal regressions, `node scripts/check-changed.mjs`, and fresh P1 autoreview all passed after reconciliation. The Docker artifact above remains accurately pinned to its pre-rebase source. Exact-head [CI](https://github.com/openclaw/openclaw/actions/runs/34676086987) is green: `node scripts/watch-pr-ci.mjs 145606 d5702e9108db181518df58c9089d0e2cc41c2cb0` exited 0 with `GREEN`, zero pending checks, and six superseded contexts identified. The previous-head failure above remains historical evidence.

Thanks @xbb19730559 for the evidence and @itilys for the related reproduction details. #142585 is assigned to @RomneyDa; this keeps the repair at the rehearsal and migration owners for review.

Refs #142585. Refs #145084.


## ClawSweeper review

The review of `d5702e9108db181518df58c9089d0e2cc41c2cb0` found no actionable introduced defect. Its remaining compatibility-proof request is addressed by the recorded published-9.3 upgrade cell above and the preservation/control regressions; no code fixup is needed.

| Compatibility risk | Disposition and evidence |
| --- | --- |
| Copied records retain absolute live-workspace paths | Rehearsal never mutates files outside its root. Lexical and physical containment preserve external setup files, skills, backups, and recovery records; 51 recorded rehearsal observations preserved all five live fixture files. |
| Deferring rehearsal migration could prevent real migration | Real Doctor behavior is unchanged. The published-9.3 x64 update completed; post-update Doctor produced two completed/removed receipts, preserved both archives, retained three applied skills, and reached Gateway readiness 200. |
| Older installed drivers cannot supply a new candidate marker | The guard recognizes isolation values already shipped in 9.3/9.4. No new configuration, schema, retention policy, or recovery format is introduced. |
| Historical-workspace recovery overlaps another repair | #145084 already provides standalone recovery. This PR confines candidate rehearsal writes and leaves that real-Doctor repair intact. |

No Rank-up code changes remain. The existing arm64 installed-driver timeout limitation remains recorded above; it does not alter the rehearsal isolation result.
