### PR TITLE
fix(qa-lab): keep log previews when labels mention GIF

### DIFF
--- a/docs/concepts/qa-e2e-automation/qa-reporting.md
+++ b/docs/concepts/qa-e2e-automation/qa-reporting.md
@@ -41,6 +41,11 @@ producer `qa-evidence.json`. When `qa suite` is reached through `qa run
 --qa-profile`, the same `qa-evidence.json` also includes the profile
 scorecard summary for the selected taxonomy categories.
 
+The QA Lab evidence gallery uses recognized file suffixes to select image,
+video, JSON, or text previews. A `.log` file remains text even when its free-form
+artifact kind contains a media hint such as `gif`. Kind hints still classify
+extensionless files and unknown suffixes; the complete kind label is preserved.
+
 `qa confidence-report` keeps `productImpact` and `qaImpact` annotations in their
 own Markdown table cells, collapsing whitespace for display. The JSON summary
 preserves the annotation values, including internal line breaks.

--- a/extensions/qa-lab/src/evidence-gallery.test.ts
+++ b/extensions/qa-lab/src/evidence-gallery.test.ts
@@ -16,8 +16,8 @@ import {
   type QaEvidenceSummaryJson,
 } from "./evidence-summary.js";
 
-async function createTempRepo() {
-  return fs.mkdtemp(path.join(os.tmpdir(), "qa-evidence-gallery-"));
+async function createTempRepo(prefix = "qa-evidence-gallery-") {
+  return fs.mkdtemp(path.join(os.tmpdir(), prefix));
 }
 
 async function writeJson(filePath: string, value: unknown) {
@@ -168,6 +168,106 @@ describe("evidence gallery", () => {
     });
   });
 
+  it.each([
+    {
+      kind: "gif-runner-log",
+      file: "artifact.LOG",
+      content: "runner passed\n",
+      mediaKind: "text",
+      preview: "runner passed\n",
+    },
+    {
+      kind: "video-report",
+      file: "artifact.json",
+      content: '{"ok":true}',
+      mediaKind: "json",
+      preview: '{\n  "ok": true\n}',
+    },
+    {
+      kind: "screenshot-validation",
+      file: "artifact.webm",
+      content: "video",
+      mediaKind: "video",
+      preview: null,
+    },
+    {
+      kind: "video-report",
+      file: "artifact.png",
+      content: "image",
+      mediaKind: "image",
+      preview: null,
+    },
+    {
+      kind: "motion-preview-gif",
+      file: "artifact",
+      content: "image",
+      mediaKind: "image",
+      preview: null,
+    },
+    {
+      kind: "video-capture",
+      file: "artifact.capture",
+      content: "video",
+      mediaKind: "video",
+      preview: null,
+    },
+    {
+      kind: "validation-result",
+      file: "artifact.data",
+      content: '{"ok":true}',
+      mediaKind: "json",
+      preview: '{\n  "ok": true\n}',
+    },
+    {
+      kind: "report",
+      file: "artifact.html",
+      content: "<p>report</p>",
+      mediaKind: "text",
+      preview: "<p>report</p>",
+    },
+    {
+      kind: "video-screenshot",
+      file: "artifact.data",
+      content: "image",
+      mediaKind: "image",
+      preview: null,
+    },
+    {
+      kind: "attachment",
+      file: "artifact.data",
+      content: "opaque",
+      mediaKind: "file",
+      preview: null,
+    },
+  ])(
+    "classifies $file with $kind metadata",
+    async ({ kind, file, content, mediaKind, preview }) => {
+      const repoRoot = await createTempRepo();
+      try {
+        const outputDir = path.join(repoRoot, ".artifacts", "qa-e2e", "vitest");
+        await fs.mkdir(outputDir, { recursive: true });
+        await fs.writeFile(path.join(outputDir, file), content, "utf8");
+        await writeJson(
+          path.join(outputDir, QA_EVIDENCE_FILENAME),
+          vitestArtifactEvidence({
+            id: "qa-lab.artifact-classification",
+            title: "Artifact classification",
+            artifact: { kind, path: file },
+          }),
+        );
+        const model = await buildQaEvidenceGalleryModel({ evidencePath: outputDir, repoRoot });
+        expect(model.entries[0]?.artifacts[0]).toMatchObject({
+          exists: true,
+          kind,
+          mediaKind,
+          preview,
+        });
+      } finally {
+        await fs.rm(repoRoot, { recursive: true, force: true });
+      }
+    },
+  );
+
   it("sanitizes local roots from gallery failure reasons", async () => {
     const repoRoot = await createTempRepo();
     const outputDir = path.join(repoRoot, ".artifacts", "qa-e2e", "vitest");
@@ -203,7 +303,7 @@ describe("evidence gallery", () => {
   });
 
   it("normalizes absolute source and declared artifact paths for gallery links", async () => {
-    const repoRoot = await createTempRepo();
+    const repoRoot = await createTempRepo("qa-evidence-gallery-gif-");
     const outputDir = path.join(repoRoot, ".artifacts", "qa-e2e", "vitest");
     const artifactPath = path.join(outputDir, "absolute.log");
     await fs.mkdir(outputDir, { recursive: true });
@@ -268,6 +368,7 @@ describe("evidence gallery", () => {
     expect(artifact).toMatchObject({
       exists: true,
       kind: "<repo-root>/log",
+      mediaKind: "text",
       path: ".artifacts/qa-e2e/vitest/absolute.log",
       preview: "absolute artifact <repo-root>\nfile://<repo-root>/trace.log\n",
       source: "<repo-root>/vitest",

--- a/extensions/qa-lab/src/evidence-gallery.ts
+++ b/extensions/qa-lab/src/evidence-gallery.ts
@@ -364,31 +364,32 @@ async function collectDeclaredQaEvidenceArtifactFiles(params: {
 }
 
 function classifyArtifact(kind: string, filePath: string): QaEvidenceArtifactView["mediaKind"] {
-  const normalizedKind = kind.toLowerCase();
   const ext = path.extname(filePath).toLowerCase();
-  if (
-    normalizedKind.includes("screenshot") ||
-    normalizedKind.includes("gif") ||
-    [".png", ".jpg", ".jpeg", ".gif", ".webp"].includes(ext)
-  ) {
+  if ([".png", ".jpg", ".jpeg", ".gif", ".webp"].includes(ext)) {
     return "image";
   }
-  if (normalizedKind.includes("video") || [".webm", ".mp4", ".mov"].includes(ext)) {
+  if ([".webm", ".mp4", ".mov"].includes(ext)) {
     return "video";
   }
-  if (
-    normalizedKind.includes("validation") ||
-    normalizedKind.includes("json") ||
-    ext === ".json" ||
-    ext === ".jsonl"
-  ) {
+  if (ext === ".json" || ext === ".jsonl") {
     return "json";
   }
-  if (
-    normalizedKind.includes("log") ||
-    normalizedKind.includes("report") ||
-    [".log", ".md", ".txt"].includes(ext)
-  ) {
+  if ([".log", ".md", ".txt"].includes(ext)) {
+    return "text";
+  }
+
+  // Kinds are free-form labels; use their hints only without a known file format.
+  const normalizedKind = kind.toLowerCase();
+  if (normalizedKind.includes("screenshot") || normalizedKind.includes("gif")) {
+    return "image";
+  }
+  if (normalizedKind.includes("video")) {
+    return "video";
+  }
+  if (normalizedKind.includes("validation") || normalizedKind.includes("json")) {
+    return "json";
+  }
+  if (normalizedKind.includes("log") || normalizedKind.includes("report")) {
     return "text";
   }
   return "file";

--- a/extensions/qa-lab/src/lab-server.test.ts
+++ b/extensions/qa-lab/src/lab-server.test.ts
@@ -1197,7 +1197,7 @@ describe("qa-lab server", () => {
                   model: { name: "mock-openai/gpt-5.6-luna", ref: "mock-openai/gpt-5.6-luna" },
                 },
                 packageSource: { kind: "source-checkout" },
-                artifacts: [{ kind: "log", path: "artifact.log", source: "vitest" }],
+                artifacts: [{ kind: "gif-log", path: "artifact.log", source: "vitest" }],
               },
               result: { status: "pass" },
             },
@@ -1227,7 +1227,12 @@ describe("qa-lab server", () => {
         counts: {
           pass: 1,
         },
-        entries: [{ id: "qa-lab.server-artifact" }],
+        entries: [
+          {
+            id: "qa-lab.server-artifact",
+            artifacts: [{ kind: "gif-log", mediaKind: "text", preview: "streamed body\n" }],
+          },
+        ],
       },
     });
 


### PR DESCRIPTION
Related: #145591

## What Problem This Solves

Fixes an issue where QA Lab hides a log artifact's text preview when its free-form kind label contains a media hint such as `gif`. The same precedence error can show JSON as video or a video as an image. It also makes the existing path-redaction test fail when a temporary directory name happens to contain a matching hint.

## Why This Change Was Made

Recognized filename suffixes now determine the gallery media type before kind hints are considered, consistent with the artifact download endpoint. The complete kind remains free-form and preserved; the existing kind fallback and its ordering still apply to unknown suffixes and extensionless artifacts. Format support, path checks and preview byte limits are unchanged.

## User Impact

Log and JSON previews remain readable despite incidental media words in their metadata, and image/video files keep their correct presentation.

## Evidence

- The unchanged source reproduced the reported failure deterministically under a temporary parent containing `gif`. The original CI log does not retain its exact random directory suffix, so this is a matching reproduced failure shape rather than a claim about those missing bytes.
- Four deterministic gallery cases failed before the repair; all 37 gallery/summary tests pass afterward. Coverage retains arbitrary compound kind labels, fallback ordering, extensionless and unknown-suffix artifacts, and uppercase suffixes.
- The existing real HTTP gallery/GET/HEAD test also failed before the repair and passes afterward, including correct text preview, content type and streamed bytes.
- The complete changed gate and independent Codex review through P2 pass.
- Attached before/after captures use synthetic files through the actual gallery model and unchanged renderer/CSS. The baseline defers the `.log` as media; the candidate displays its exact text. Both complete captures were inspected for synthetic-only content.

The original #145591 CI failure and qualified unchanged-head rerun remain separate evidence; the rerun did not repair this classifier.

![Before: the log is treated as deferred media](https://github.com/user-attachments/assets/7c5cc7ac-f732-4444-b9b8-a34ce112e242)

![After: the exact log text is available in the gallery](https://github.com/user-attachments/assets/b3d469e4-5391-4098-b82f-9c34dea9f5dc)