### PR TITLE
fix(docs): reject malformed search result collections

### DIFF
--- a/docs/cli/docs.md
+++ b/docs/cli/docs.md
@@ -46,6 +46,8 @@ openclaw docs gateway token secretref
 
 In a rich (TTY) terminal, results render as a heading followed by a bullet list: page title, linked docs URL, and a short snippet on the next line. Empty results print "No results.".
 
+A response without a results array is malformed and fails the command; it is not treated as a successful search with no matches.
+
 In non-rich output (piped, `--no-color`, scripts), the same data renders as Markdown:
 
 ```markdown
@@ -59,6 +61,9 @@ With `--json`, stdout contains one object with the normalized query and result
 list. With no query, `query` is `null`, `url` is the docs entrypoint, and
 `results` is empty. Styling and headings are suppressed; request diagnostics
 stay on stderr so stdout can be piped directly to a JSON parser.
+
+On failure, `--json` emits the [CLI JSON failure envelope](/cli#json-failures) on stdout
+while retaining the error message on stderr.
 
 ## Exit codes
 

--- a/src/commands/docs.test.ts
+++ b/src/commands/docs.test.ts
@@ -167,6 +167,35 @@ describe("docsSearchCommand", () => {
     );
   });
 
+  it.each([
+    { name: "missing results", payload: {} },
+    { name: "null results", payload: { results: null } },
+    { name: "object results", payload: { results: {} } },
+    { name: "string results", payload: { results: "unavailable" } },
+  ])("rejects $name instead of reporting a successful empty search", async ({ payload }) => {
+    fetchMock.mockResolvedValueOnce(new Response(JSON.stringify(payload)));
+    const runtime = makeRuntime();
+
+    await expect(docsSearchCommand(["gateway"], runtime, { json: true })).rejects.toThrow(
+      "Docs search failed: Docs search response is malformed: expected results array",
+    );
+
+    expect(runtime.log).not.toHaveBeenCalled();
+  });
+
+  it("keeps a successful empty search distinct from a malformed response", async () => {
+    fetchMock.mockResolvedValueOnce(new Response(JSON.stringify({ results: [] })));
+    const runtime = makeRuntime();
+
+    await docsSearchCommand(["no-matches"], runtime, { json: true });
+
+    expect(runtime.log).toHaveBeenCalledOnce();
+    expect(JSON.parse(String(runtime.log.mock.calls[0]?.[0]))).toEqual({
+      query: "no-matches",
+      results: [],
+    });
+  });
+
   it("reports docs search responses with invalid UTF-8 bytes as malformed", async () => {
     const body = new Uint8Array([
       ...new TextEncoder().encode('{"results":[{"title":"Plugin allow'),

--- a/src/commands/docs.ts
+++ b/src/commands/docs.ts
@@ -97,7 +97,7 @@ async function fetchDocsSearch(query: string): Promise<DocResult[]> {
 
 function parseDocsSearchResults(raw: unknown): DocResult[] {
   if (!Array.isArray(raw)) {
-    return [];
+    throw new Error("Docs search response is malformed: expected results array");
   }
   const results: DocResult[] = [];
   for (const item of raw) {


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where users searching with `openclaw docs` would receive a successful empty result when the search API returned JSON with a missing, null, object or string `results` collection. Text output said “No results,” and `--json` returned an empty result list, both with exit code 0.

## Why This Change Was Made

The existing response normalizer now rejects a non-array collection through the established docs-search error path. This replaces one statement with one statement: production **+1/−1, net 0**. Valid empty arrays, tolerant item filtering, filtering before `--limit`, and the existing request/body bounds remain intact.

## User Impact

Malformed search responses produce a visible error and exit 1. JSON mode uses the existing CLI failure envelope on stdout with human diagnostics on stderr; the docs now clarify that behavior. Successful searches, including genuine no-match results, retain their output.

## Evidence

- Focused suite: `node scripts/run-vitest.mjs src/commands/docs.test.ts` showed **4 intended failures / 10 passes** before the repair and **14 passes** afterward. The earlier baseline unit run predates the refresh to `31848a15205`; immutable comparisons confirmed unchanged command, test, registrar and body-reader sources across that refresh.
- Paired registered CLI proof at sealed `31848a15205`: all four malformed collections reproduced false-empty success in text and JSON modes on baseline; all eight repaired cells now exit 1 with the correct text error or standard JSON failure envelope. Eight queryless/valid-empty/mixed/limit controls retain byte-identical successful stdout. Each queried injected case recorded one exact docs GET and finite native Response body hash; both phases closed every process/stdio stream naturally without supervisor signals or remaining owned groups.
- Separate public controls on 2026-09-12, repeated for both phases: canonical HTTPS GETs returned HTTP 200 with 12 results for `gateway` and an empty array for the same opaque query. Both queries also passed through the real CLI in text and JSON modes **without a preload**. These successful live controls are separate from malformed-response injection; no hosted malformed-response incident is claimed.
- Fresh managed review found no actionable P0–P2 defects; separate source and proof audits found no blocking discrepancy.
- Changed-file checks passed for the core/coreTests/docs lanes, including formatting, core/test typechecks, changed lint and selected static guards. Candidate `pnpm build ciArtifacts` passed in 89.2 seconds. The repaired compiled docs module and its registrar reference were inspected, and all 13,975 candidate sealed files matched on independent readback.

CLI observations use the same supported Node runtime with the launcher-equivalent `--disable-warning=ExperimentalWarning` flag and disabled compile cache, without TLS/CA overrides. They exercise the ordinary final runtime, not startup respawn behavior. Seals cover generated outputs and named source/Commander 15.0.0 files; they are not a complete installed-dependency provenance claim. The independent HTTP captures and live CLI calls are separate requests, so exact rankings and CLI-consumed response bytes are not assumed identical.

The same false-empty branch is present in the latest stable release, `v2026.9.4`. Earlier malformed-JSON context repair #108364 addresses syntax errors; this repair handles valid JSON with an invalid result collection.

Current reviewed head: `f0089a2bd48f5d1c2823b02e2cbcea00e1165107`, mechanically rebased onto `aa7bd5936bf11c0e12e0678bfafbbcb45aaaa2ff`. Both rebases preserve the patch by `git range-diff`; all three touched blobs and the fourteen declared CLI/reader/output/startup source contracts match the original proof. The frozen install was aligned with current main, all 14 focused tests passed again, and fresh managed P0–P2 review found no actionable defects. Original build and CLI observations remain attributed to their original source tree.

CI recovery: [run 34674485960](https://github.com/openclaw/openclaw/actions/runs/34674485960) failed an untouched thinking-test line limit; upstream #145632 fixed it. [Run 34676214000](https://github.com/openclaw/openclaw/actions/runs/34676214000) then hit an untouched worker-fixture launch observation timeout. Upstream #145657 initializes the existing context reader before that observation while retaining the five-second bound and assertions. Both upstream fixes are verified merged and contained in the current base. No unrelated repair was added to this PR. Fresh hosted CI remains required before native landing.
