### PR TITLE
refactor: centralize Google lazy provider loading

### DIFF
--- a/extensions/google/index.ts
+++ b/extensions/google/index.ts
@@ -1,4 +1,5 @@
 import type { ImageGenerationProvider } from "openclaw/plugin-sdk/image-generation";
+import { createLazyRuntimeSurface } from "openclaw/plugin-sdk/lazy-runtime";
 import type { MediaUnderstandingProvider } from "openclaw/plugin-sdk/media-understanding";
 import type { MusicGenerationProvider } from "openclaw/plugin-sdk/music-generation";
 import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
@@ -17,50 +18,29 @@ import { createLazyGoogleRealtimeVoiceProvider } from "./realtime-voice-lazy.js"
 import { buildGoogleSpeechProvider } from "./speech-provider.js";
 import { createGeminiWebSearchProvider } from "./src/gemini-web-search-provider.js";
 
-let googleImageGenerationProviderPromise: Promise<ImageGenerationProvider> | null = null;
-let googleMediaUnderstandingProviderPromise: Promise<MediaUnderstandingProvider> | null = null;
-let googleMusicGenerationProviderPromise: Promise<MusicGenerationProvider> | null = null;
-let googleVideoGenerationProviderPromise: Promise<VideoGenerationProvider> | null = null;
-
 type GoogleMediaUnderstandingProvider = Required<
   Pick<MediaUnderstandingProvider, "transcribeAudio" | "describeVideo">
 >;
 
-async function loadGoogleImageGenerationProvider(): Promise<ImageGenerationProvider> {
-  if (!googleImageGenerationProviderPromise) {
-    googleImageGenerationProviderPromise = import("./image-generation-provider.js").then((mod) =>
-      mod.buildGoogleImageGenerationProvider(),
-    );
-  }
-  return await googleImageGenerationProviderPromise;
-}
+const loadGoogleImageGenerationProvider = createLazyRuntimeSurface(
+  () => import("./image-generation-provider.js"),
+  (mod) => mod.buildGoogleImageGenerationProvider(),
+);
 
-async function loadGoogleMediaUnderstandingProvider(): Promise<MediaUnderstandingProvider> {
-  if (!googleMediaUnderstandingProviderPromise) {
-    googleMediaUnderstandingProviderPromise = import("./media-understanding-provider.js").then(
-      (mod) => mod.googleMediaUnderstandingProvider,
-    );
-  }
-  return await googleMediaUnderstandingProviderPromise;
-}
+const loadGoogleMediaUnderstandingProvider = createLazyRuntimeSurface(
+  () => import("./media-understanding-provider.js"),
+  (mod) => mod.googleMediaUnderstandingProvider,
+);
 
-async function loadGoogleMusicGenerationProvider(): Promise<MusicGenerationProvider> {
-  if (!googleMusicGenerationProviderPromise) {
-    googleMusicGenerationProviderPromise = import("./music-generation-provider.js").then((mod) =>
-      mod.buildGoogleMusicGenerationProvider(),
-    );
-  }
-  return await googleMusicGenerationProviderPromise;
-}
+const loadGoogleMusicGenerationProvider = createLazyRuntimeSurface(
+  () => import("./music-generation-provider.js"),
+  (mod) => mod.buildGoogleMusicGenerationProvider(),
+);
 
-async function loadGoogleVideoGenerationProvider(): Promise<VideoGenerationProvider> {
-  if (!googleVideoGenerationProviderPromise) {
-    googleVideoGenerationProviderPromise = import("./video-generation-provider.js").then((mod) =>
-      mod.buildGoogleVideoGenerationProvider(),
-    );
-  }
-  return await googleVideoGenerationProviderPromise;
-}
+const loadGoogleVideoGenerationProvider = createLazyRuntimeSurface(
+  () => import("./video-generation-provider.js"),
+  (mod) => mod.buildGoogleVideoGenerationProvider(),
+);
 
 async function loadGoogleRequiredMediaUnderstandingProvider(): Promise<GoogleMediaUnderstandingProvider> {
   const provider = await loadGoogleMediaUnderstandingProvider();

--- a/extensions/google/media-understanding-provider.ts
+++ b/extensions/google/media-understanding-provider.ts
@@ -16,7 +16,6 @@ import {
   GOOGLE_MEDIA_UNDERSTANDING_DEFAULT_MODELS,
 } from "./generation-provider-metadata.js";
 import {
-  DEFAULT_GOOGLE_API_BASE_URL,
   normalizeGoogleModelId,
   resolveGoogleGenerativeAiHttpRequestConfig,
 } from "./runtime-api.js";
@@ -36,7 +35,6 @@ async function generateGeminiInlineDataText(params: {
   timeoutMs: number;
   signal?: AbortSignal;
   fetchFn?: typeof fetch;
-  defaultBaseUrl: string;
   defaultModel: string;
   defaultPrompt: string;
   defaultMime: string;
@@ -60,8 +58,7 @@ async function generateGeminiInlineDataText(params: {
       capability: params.defaultMime.startsWith("audio/") ? "audio" : "video",
       transport: "media-understanding",
     });
-  const resolvedBaseUrl = baseUrl ?? params.defaultBaseUrl;
-  const url = `${resolvedBaseUrl}/models/${model}:generateContent`;
+  const url = `${baseUrl}/models/${model}:generateContent`;
 
   const prompt = (() => {
     const trimmed = params.prompt?.trim();
@@ -123,7 +120,6 @@ export async function transcribeGeminiAudio(
 ): Promise<AudioTranscriptionResult> {
   const { text, model } = await generateGeminiInlineDataText({
     ...params,
-    defaultBaseUrl: DEFAULT_GOOGLE_API_BASE_URL,
     defaultModel: GOOGLE_MEDIA_UNDERSTANDING_DEFAULT_MODELS.audio,
     defaultPrompt: DEFAULT_GOOGLE_AUDIO_PROMPT,
     defaultMime: "audio/wav",
@@ -138,7 +134,6 @@ export async function describeGeminiVideo(
 ): Promise<VideoDescriptionResult> {
   const { text, model } = await generateGeminiInlineDataText({
     ...params,
-    defaultBaseUrl: DEFAULT_GOOGLE_API_BASE_URL,
     defaultModel: GOOGLE_MEDIA_UNDERSTANDING_DEFAULT_MODELS.video,
     defaultPrompt: DEFAULT_GOOGLE_VIDEO_PROMPT,
     defaultMime: "video/mp4",

--- a/extensions/google/media-understanding-provider.video.test.ts
+++ b/extensions/google/media-understanding-provider.video.test.ts
@@ -1,11 +1,13 @@
 // Google tests cover media understanding provider.video plugin behavior.
 import { createServer, type Server } from "node:http";
+import { createCapturedPluginRegistration } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { withFetchPreconnect } from "openclaw/plugin-sdk/test-env";
 import {
   createRequestCaptureJsonFetch,
   installPinnedHostnameTestHooks,
 } from "openclaw/plugin-sdk/test-media-understanding";
 import { describe, expect, it } from "vitest";
+import googlePlugin from "./index.js";
 import { describeGeminiVideo, transcribeGeminiAudio } from "./media-understanding-provider.js";
 import { resolveGoogleGenerativeAiHttpRequestConfig } from "./runtime-api.js";
 
@@ -158,47 +160,41 @@ describe("describeGeminiVideo", () => {
     );
   });
 
-  it("uses the canonical endpoint for an empty configured base URL", async () => {
-    const { fetchFn, getRequest } = createRequestCaptureJsonFetch({
-      candidates: [{ content: { parts: [{ text: "video ok" }] } }],
-    });
+  it.each([
+    { method: "describeVideo", baseUrl: "", fileName: "clip.mp4" },
+    { method: "transcribeAudio", baseUrl: "   ", fileName: "clip.wav" },
+  ] as const)(
+    "uses the canonical endpoint for blank $method base URLs through registration",
+    async ({ method, baseUrl, fileName }) => {
+      const captured = createCapturedPluginRegistration({ id: "google" });
+      googlePlugin.register(captured.api);
+      const handler = captured.mediaUnderstandingProviders.find(
+        (provider) => provider.id === "google",
+      )?.[method];
+      if (!handler) {
+        throw new Error(`Expected registered Google ${method}`);
+      }
+      const { fetchFn, getRequest } = createRequestCaptureJsonFetch({
+        candidates: [{ content: { parts: [{ text: "media ok" }] } }],
+      });
 
-    await describeGeminiVideo({
-      buffer: Buffer.from("video-bytes"),
-      fileName: "clip.mp4",
-      apiKey: "test-key",
-      baseUrl: "",
-      timeoutMs: 1500,
-      fetchFn,
-    });
+      const result = await handler({
+        buffer: Buffer.from("media-bytes"),
+        fileName,
+        apiKey: "test-key",
+        baseUrl,
+        timeoutMs: 1500,
+        fetchFn,
+      });
 
-    const { url, init } = getRequest();
-    expect(url).toBe(
-      "https://generativelanguage.googleapis.com/v1beta/models/gemini-3-flash-preview:generateContent",
-    );
-    expect(new Headers(init?.headers).get("x-goog-api-client")).toMatch(/^openclaw\//u);
-  });
-
-  it("uses the canonical endpoint for blank audio base URLs", async () => {
-    const { fetchFn, getRequest } = createRequestCaptureJsonFetch({
-      candidates: [{ content: { parts: [{ text: "audio ok" }] } }],
-    });
-
-    await transcribeGeminiAudio({
-      buffer: Buffer.from("audio-bytes"),
-      fileName: "clip.wav",
-      apiKey: "test-key",
-      baseUrl: "   ",
-      timeoutMs: 1500,
-      fetchFn,
-    });
-
-    const { url, init } = getRequest();
-    expect(url).toBe(
-      "https://generativelanguage.googleapis.com/v1beta/models/gemini-3-flash-preview:generateContent",
-    );
-    expect(new Headers(init?.headers).get("x-goog-api-client")).toMatch(/^openclaw\//u);
-  });
+      const { url, init } = getRequest();
+      expect(result.text).toBe("media ok");
+      expect(url).toBe(
+        "https://generativelanguage.googleapis.com/v1beta/models/gemini-3-flash-preview:generateContent",
+      );
+      expect(new Headers(init?.headers).get("x-goog-api-client")).toMatch(/^openclaw\//u);
+    },
+  );
 
   it("bounds oversized video JSON responses and closes the stream early", async () => {
     const { server, closed } = createOversizedJsonServer();

--- a/extensions/google/realtime-voice-lazy.ts
+++ b/extensions/google/realtime-voice-lazy.ts
@@ -1,3 +1,4 @@
+import { createLazyRuntimeSurface } from "openclaw/plugin-sdk/lazy-runtime";
 import type {
   RealtimeVoiceBridge,
   RealtimeVoiceBridgeCreateRequest,
@@ -10,16 +11,11 @@ import {
   asOptionalRecord,
   normalizeOptionalString,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
-let googleRealtimeVoiceProviderPromise: Promise<RealtimeVoiceProviderPlugin> | null = null;
 
-async function loadGoogleRealtimeVoiceProvider(): Promise<RealtimeVoiceProviderPlugin> {
-  if (!googleRealtimeVoiceProviderPromise) {
-    googleRealtimeVoiceProviderPromise = import("./realtime-voice-provider.js").then((mod) =>
-      mod.buildGoogleRealtimeVoiceProvider(),
-    );
-  }
-  return await googleRealtimeVoiceProviderPromise;
-}
+const loadGoogleRealtimeVoiceProvider = createLazyRuntimeSurface(
+  () => import("./realtime-voice-provider.js"),
+  (mod) => mod.buildGoogleRealtimeVoiceProvider(),
+);
 
 function resolveGoogleRealtimeProviderConfig(
   rawConfig: RealtimeVoiceProviderConfig,


### PR DESCRIPTION
Closes #145609

## What Problem This Solves

Google's image, media, music, video and realtime providers independently maintain the same lazy-loading cache behavior. Keeping those copies aligned makes provider maintenance harder. Media understanding also repeats a default endpoint that its request-config owner already resolves.

## Why This Change Was Made

Use the existing lazy-runtime owner for all five module-level provider caches, preserving concurrent-load coalescing and cached failures. Keep realtime bridge generations and reconnect state with the bridge owner. Media understanding now consumes the resolved endpoint directly, and the existing empty/blank URL tests exercise registered provider callbacks.

## User Impact

No intended user-visible behavior change. Provider loading remains lazy, Google endpoint behavior is preserved, and realtime lifecycle handling remains unchanged.

## Evidence

- Original baseline and candidate each pass 69 focused tests across shared lazy-runtime/promise and Google registration, realtime lifecycle, API and media-understanding coverage. The candidate retains the existing endpoint/header checks and adds returned-text verification through registration.
- Full `pnpm build` passes, including all 153 public SDK subpath checks.
- A standalone probe against the built Google entry passes registered audio/video callbacks with explicit injected responses, plus image auth validation, music/video input validation and realtime lazy-construction validation. The isolated built-entry import profile also passes. This is not a successful live Google API test.
- Fresh independent P2 review found no actionable defects. Selected typechecks, lint, Doctor contract tests, storage/loader guards and import-cycle checks pass.

The complete changed-check command stops on inherited unused exports in `ui/src/pages/new-session/cloud-target.ts`: `renderCloudConfiguration` and `renderConnectMachineMenuItem` in the production scan, and the latter in the full-tree scan. The exact same findings reproduce on the pristine base `619ef3f53b2791e46ca37b40975e9b9739de8356`. Remaining selected commands pass separately; no ignore or allowance was added.

The initial standalone probe replaced global fetch, which selected native transport and produced an API rejection for a synthetic credential. The corrected probe uses explicit injected media responses and pre-request validation for the other providers. Production code did not change during this correction.

Local validation above is retained at source base `619ef3f53b2791e46ca37b40975e9b9739de8356`. The branch is now rebased onto main `92b9264cef16e92adcbf58401c529a92bce060ee`, which includes the upstream thinking-test line-cap repair #145632. Range-diff confirms the Google patch is unchanged, and all newer realtime configuration and bridge implementation bytes below its loader are preserved. Earlier CI run `34674600510` failed on that inherited thinking-test cap; new exact-head CI will validate the refreshed integration.
