### PR TITLE
docs(discord): keep API URL override undocumented

### DIFF
--- a/docs/channels/discord.md
+++ b/docs/channels/discord.md
@@ -141,12 +141,6 @@ Set `channels.discord.activities` to let the core `show_widget` tool post self-c
 ## Safety and operations
 
 - Treat bot tokens as secrets (`DISCORD_BOT_TOKEN` preferred in supervised environments).
-- `DISCORD_API_URL` overrides the process-wide, versioned Discord REST base (for example,
-  `https://discord.example.com/api/v10`). OpenClaw also uses that origin for Gateway discovery,
-  WebSocket connections, media, webhooks, OAuth, and command registration; requests do not fall
-  back to public Discord while the override is set. Plain HTTP/WS is accepted only on loopback,
-  and Discord voice transport is unavailable with the override. Set it in the Gateway process
-  environment or global runtime dotenv, not a workspace `.env`.
 - Grant least-privilege Discord permissions.
 - If command deploy/state is stale, restart the gateway and re-check with `openclaw channels status --probe`.
 


### PR DESCRIPTION
## Summary

Removes the public `DISCORD_API_URL` documentation added by #118067.

Runtime behavior remains unchanged. This keeps the override available as an intentionally undocumented operator escape hatch instead of promoting it as a Discord configuration surface.

## Validation

- `pnpm docs:list`
- `git diff --check`
- confirmed no remaining `DISCORD_API_URL` mentions in public docs
