### PR TITLE
fix(sessions): reduce allocation spikes during disk cleanup

### DIFF
--- a/src/config/sessions/session-history-admission-protection.test.ts
+++ b/src/config/sessions/session-history-admission-protection.test.ts
@@ -1,0 +1,82 @@
+import { DatabaseSync } from "node:sqlite";
+import { expect, it, onTestFinished } from "vitest";
+import { beginSessionWorkAdmission } from "../../sessions/session-lifecycle-admission.js";
+import { collectAdmissionProtectedSessionIds } from "./session-history-eviction.js";
+
+it("reads only admitted entry payloads while protecting normalized keys and every generation", async () => {
+  const db = new DatabaseSync(":memory:");
+  onTestFinished(() => db.close());
+  let payloadReads = 0;
+  db.function("read_payload", (value) => {
+    payloadReads++;
+    return value;
+  });
+  db.exec(`
+    CREATE TABLE stored_nodes (session_key TEXT PRIMARY KEY, current_session_id TEXT, entry_json TEXT);
+    CREATE VIEW session_nodes AS SELECT session_key, current_session_id, read_payload(entry_json) AS entry_json FROM stored_nodes;
+    CREATE TABLE session_windows (session_id TEXT PRIMARY KEY, session_key TEXT);
+  `);
+  const insert = db.prepare("INSERT INTO stored_nodes VALUES (?, ?, ?)");
+  const addWindow = db.prepare("INSERT INTO session_windows VALUES (?, ?)");
+  const entries = [
+    { key: "agent:main:dashboard:tracked", identity: "AGENT:MAIN:DASHBOARD:TRACKED" },
+    { key: "agent:main:dashboard:İtem", identity: "agent:main:dashboard:i\u0307tem" },
+    { key: "agent:main:dashboard:zero\0tail", identity: "agent:main:dashboard:zero\0tail" },
+    { key: "agent:main:signal:group:AbC=", identity: "agent:main:signal:group:AbC=" },
+    {
+      key: "agent:main:dashboard:invalid",
+      identity: "agent:main:dashboard:invalid",
+      invalid: true,
+    },
+  ];
+  const identities = [...entries.map((entry) => entry.identity), "by-id", "orphan-owner"];
+  const expected = new Set(identities);
+  for (const [index, entry] of entries.entries()) {
+    const sessionId = `current-${index}`;
+    const previousSessionId = `previous-${index}`;
+    insert.run(
+      entry.key,
+      sessionId,
+      entry.invalid ? "{" : JSON.stringify({ sessionId, previousSessionId, updatedAt: 1 }),
+    );
+    addWindow.run(`historical-${index}`, entry.key);
+    expected.add(sessionId);
+    expected.add(`historical-${index}`);
+    if (!entry.invalid) {
+      expected.add(previousSessionId);
+    }
+  }
+  addWindow.run("orphan-generation", "orphan-owner");
+  expected.add("orphan-generation");
+  // The lowercase Signal peer is a different conversation, not an alias.
+  insert.run(
+    "agent:main:signal:group:abc=",
+    "different-peer",
+    JSON.stringify({ sessionId: "different-peer", updatedAt: 1 }),
+  );
+  for (let index = 0; index < 100; index++) {
+    const sessionId = `unrelated-${index}`;
+    insert.run(
+      `agent:main:dashboard:${sessionId}`,
+      sessionId,
+      JSON.stringify({
+        sessionId,
+        updatedAt: 1,
+        skillsSnapshot: { prompt: "x".repeat(32_768), skills: [] },
+      }),
+    );
+  }
+  const storePath = "synthetic-admission-protection";
+  const admission = await beginSessionWorkAdmission({
+    scope: storePath,
+    identities,
+    assertAllowed: () => {},
+  });
+  onTestFinished(() => admission.release());
+  expect(collectAdmissionProtectedSessionIds({ database: { db }, storePath })).toEqual(expected);
+  expect(payloadReads).toBe(entries.length);
+  admission.release();
+  payloadReads = 0;
+  expect(collectAdmissionProtectedSessionIds({ database: { db }, storePath })).toEqual(new Set());
+  expect(payloadReads).toBe(0);
+});

--- a/src/config/sessions/session-history-admission-protection.test.ts
+++ b/src/config/sessions/session-history-admission-protection.test.ts
@@ -80,3 +80,48 @@ it("reads only admitted entry payloads while protecting normalized keys and ever
   expect(collectAdmissionProtectedSessionIds({ database: { db }, storePath })).toEqual(new Set());
   expect(payloadReads).toBe(0);
 });
+
+it.each(["UTF-8", "UTF-16le", "UTF-16be"] as const)(
+  "preserves admission protection through raw %s key decoding",
+  async (encoding) => {
+    const db = new DatabaseSync(":memory:");
+    onTestFinished(() => db.close());
+    db.exec(`
+      PRAGMA encoding='${encoding}';
+      CREATE TABLE session_nodes (session_key TEXT PRIMARY KEY, current_session_id TEXT, entry_json TEXT);
+      CREATE TABLE session_windows (session_id TEXT PRIMARY KEY, session_key TEXT);
+    `);
+    const insert = db.prepare("INSERT INTO session_nodes VALUES (CAST(? AS TEXT), ?, ?)");
+    const addWindow = db.prepare("INSERT INTO session_windows VALUES (?, CAST(? AS TEXT))");
+    const expected = new Set<string>();
+    for (const [index, suffix] of ["\uFFFE", "\uFFFF", "\uD800", "\uDC00", "\0tail"].entries()) {
+      const key = `agent:main:dashboard:raw-${index}-${suffix}`;
+      // Bind a BLOB so SQLite retains the original encoding before Node decodes the key.
+      const bytes = Buffer.from(key, encoding === "UTF-8" ? "utf8" : "utf16le");
+      if (encoding === "UTF-16be") {
+        bytes.swap16();
+      }
+      const sessionId = `current-${index}`;
+      const previousSessionId = `previous-${index}`;
+      insert.run(bytes, sessionId, JSON.stringify({ sessionId, previousSessionId, updatedAt: 1 }));
+      addWindow.run(`historical-${index}`, bytes);
+      expected.add(sessionId).add(previousSessionId).add(`historical-${index}`);
+    }
+    const identities = db
+      .prepare("SELECT session_key FROM session_nodes")
+      .all()
+      .map((row) => String(row.session_key));
+    for (const identity of identities) {
+      expected.add(identity);
+    }
+    const storePath = `synthetic-raw-admission-${encoding}`;
+    const admission = await beginSessionWorkAdmission({
+      scope: storePath,
+      identities,
+      assertAllowed: () => {},
+    });
+    onTestFinished(() => admission.release());
+
+    expect(collectAdmissionProtectedSessionIds({ database: { db }, storePath })).toEqual(expected);
+  },
+);

--- a/src/config/sessions/session-history-eviction.test.ts
+++ b/src/config/sessions/session-history-eviction.test.ts
@@ -49,7 +49,7 @@ import {
   replaceSessionEntrySync,
   resetSessionEntryLifecycle,
 } from "./session-accessor.js";
-import { readReferencedSessionIds } from "./session-accessor.sqlite-lifecycle-state.js";
+import * as sessionLifecycleState from "./session-accessor.sqlite-lifecycle-state.js";
 import { getSessionKysely } from "./session-accessor.sqlite-scope.js";
 import {
   enforceSqliteSessionHistoryDiskBudget,
@@ -261,9 +261,9 @@ describe("SQLite historical session disk budget", () => {
             archiveReason: "active-session-cap",
           },
         );
-        expect(readReferencedSessionIds(database(), undefined, ["oldest-history"])).toEqual(
-          new Set(["oldest-history"]),
-        );
+        expect(
+          sessionLifecycleState.readReferencedSessionIds(database(), undefined, ["oldest-history"]),
+        ).toEqual(new Set(["oldest-history"]));
       }
       setSessionUpdatedAt("newer-history", 20);
       settlePhysicalUsage();
@@ -446,8 +446,10 @@ describe("SQLite historical session disk budget", () => {
     const oldArchive = path.join(tempDir, archiveName);
     fs.writeFileSync(oldArchive, Buffer.alloc(256 * 1024));
     const before = await measureSessionPhysicalDiskUsage(storePath);
+    const readReferences = vi.spyOn(sessionLifecycleState, "readReferencedSessionIds");
 
     const result = await enforceSqliteSessionHistoryDiskBudget({
+      env: { OPENCLAW_STATE_DIR: testState.stateDir },
       storePath,
       mode: "enforce",
       maintenance: {
@@ -459,6 +461,7 @@ describe("SQLite historical session disk budget", () => {
     expect(result).toMatchObject({ removedEntries: 0, removedFiles: 1 });
     expect(fs.existsSync(oldArchive)).toBe(false);
     expect(sessionExists("archive-history")).toBe(true);
+    expect(readReferences.mock.calls.length).toBe(0);
   });
 
   it("prunes the canonical archive row and its derived file before searchable history", async () => {

--- a/src/config/sessions/session-history-eviction.ts
+++ b/src/config/sessions/session-history-eviction.ts
@@ -1,4 +1,8 @@
-import { executeSqliteQuerySync } from "../../infra/kysely-sync.js";
+import {
+  executeSqliteQuerySync,
+  iterateSqliteQuerySync,
+  sqliteStringSet,
+} from "../../infra/kysely-sync.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import {
   collectActiveSessionWorkAdmissions,
@@ -229,14 +233,26 @@ export function collectAdmissionProtectedSessionIds(params: {
     [...admissionIdentities].map((identity) => normalizeStoreSessionKey(identity)),
   );
   const db = getSessionKysely(params.database.db);
-  const rows = executeSqliteQuerySync(
+  const admittedKeys: string[] = [];
+  // Normalize lightweight keys before reading payloads; unrelated saved prompts can be large.
+  for (const row of iterateSqliteQuerySync(
     params.database.db,
-    db.selectFrom("session_nodes").select(["entry_json", "current_session_id", "session_key"]),
-  ).rows;
-  for (const row of rows) {
-    if (!normalizedAdmissionKeys.has(normalizeStoreSessionKey(row.session_key))) {
-      continue;
+    db.selectFrom("session_nodes").select("session_key"),
+  )) {
+    if (normalizedAdmissionKeys.has(normalizeStoreSessionKey(row.session_key))) {
+      admittedKeys.push(row.session_key);
     }
+  }
+  const rows = admittedKeys.length
+    ? iterateSqliteQuerySync(
+        params.database.db,
+        db
+          .selectFrom("session_nodes")
+          .select(["entry_json", "current_session_id"])
+          .where("session_key", "in", sqliteStringSet(admittedKeys)),
+      )
+    : [];
+  for (const row of rows) {
     protectedSessionIds.add(row.current_session_id);
     const entry = parseSessionEntryJson(row);
     if (entry) {
@@ -248,10 +264,10 @@ export function collectAdmissionProtectedSessionIds(params: {
   // Key-scoped admissions must survive rollover: an in-flight run admitted by
   // key may still write to a generation the entry no longer references, so
   // every generation of an admitted key stays off-limits.
-  const generationRows = executeSqliteQuerySync(
+  const generationRows = iterateSqliteQuerySync(
     params.database.db,
     db.selectFrom("session_windows").select(["session_id", "session_key"]),
-  ).rows;
+  );
   for (const row of generationRows) {
     if (normalizedAdmissionKeys.has(normalizeStoreSessionKey(row.session_key))) {
       protectedSessionIds.add(row.session_id);
@@ -514,11 +530,14 @@ async function enforceSessionHistoryMaintenanceSerialized(
   };
   let { usage, removedFiles } = await pruneArchives("initial");
   let removedEntries = 0;
-  const candidates = readHistoricalSessionIds({
-    databaseOptions,
-    preserveRecentMs: params.maintenance.preserveRecentMs,
-    storePath: params.storePath,
-  });
+  const candidates =
+    usage.totalBytes > highWaterBytes
+      ? readHistoricalSessionIds({
+          databaseOptions,
+          preserveRecentMs: params.maintenance.preserveRecentMs,
+          storePath: params.storePath,
+        })
+      : [];
 
   for (const sessionId of candidates) {
     if (usage.totalBytes <= highWaterBytes) {

--- a/src/config/sessions/session-history-eviction.ts
+++ b/src/config/sessions/session-history-eviction.ts
@@ -233,23 +233,38 @@ export function collectAdmissionProtectedSessionIds(params: {
     [...admissionIdentities].map((identity) => normalizeStoreSessionKey(identity)),
   );
   const db = getSessionKysely(params.database.db);
-  const admittedKeys: string[] = [];
+  const admittedKeyBytes: string[] = [];
   // Normalize lightweight keys before reading payloads; unrelated saved prompts can be large.
   for (const row of iterateSqliteQuerySync(
     params.database.db,
-    db.selectFrom("session_nodes").select("session_key"),
+    db
+      .selectFrom("session_nodes")
+      .select(["session_key", db.fn<string>("hex", ["session_key"]).as("key_bytes")]),
   )) {
     if (normalizedAdmissionKeys.has(normalizeStoreSessionKey(row.session_key))) {
-      admittedKeys.push(row.session_key);
+      admittedKeyBytes.push(row.key_bytes);
     }
   }
-  const rows = admittedKeys.length
+  const rows = admittedKeyBytes.length
     ? iterateSqliteQuerySync(
         params.database.db,
         db
           .selectFrom("session_nodes")
           .select(["entry_json", "current_session_id"])
-          .where("session_key", "in", sqliteStringSet(admittedKeys)),
+          // Keep stored keys inside SQLite: Node TEXT rebinding can change raw UTF-16 keys.
+          // The key-only subquery scans the existing index before fetching matched payloads.
+          .where(
+            "session_key",
+            "in",
+            db
+              .selectFrom("session_nodes")
+              .select("session_key")
+              .where(
+                db.fn<string>("hex", ["session_key"]),
+                "in",
+                sqliteStringSet(admittedKeyBytes),
+              ),
+          ),
       )
     : [];
   for (const row of rows) {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where disk-pressure cleanup copies every session's metadata into the Gateway heap while protecting only a few active sessions. It also enumerates historical candidates after archive pruning has already cleared disk pressure.

## Why This Change Was Made

The existing protection owner first reads and normalizes lightweight keys, then hydrates full metadata only for matching stored keys. It captures the stored key bytes as hex so raw SQLite text never needs to round-trip through a Node TEXT binding. A SQLite-only key subquery uses the existing covering index before indexed payload reads. Historical-generation protection is streamed through the same owner. Candidate enumeration runs only while physical usage still exceeds the existing high-water target.

Key normalization, full entry parsing, admission and post-archive rechecks, integrity checks, retention, transactions, and worker ownership keep their existing contracts. This changes read projection and planning only; it adds no cache, schema, index, configuration, or worker lifetime.

## User Impact

Cleanup performs less synchronous work and creates far less temporary heap pressure while preserving active sessions and their history.

## Evidence

- The real SQLite/admission regression failed with 106 payload reads for five admitted entries and now passes with five. It covers Unicode folding, opaque Signal peer case, embedded NUL, malformed entries, orphan historical generations, and admission release.
- Raw BLOB-to-TEXT fixtures cover UTF-8 and both UTF-16 byte orders, including U+FFFE, U+FFFF, unmatched surrogates, and NUL. They pass with the original full-scan owner, fail for both UTF-16 encodings with decoded-key rebinding, and pass with the repaired byte-preserving selection. The earlier parameter-insertion probes did not cover this case because text was normalized before storage.
- Existing real archive-first cleanup cases failed with one unnecessary reference scan after pressure cleared and now pass with zero, preserving the same removed archive and searchable history.
- All 67 tests pass across historical eviction, admission, protected cancellation, and budget ownership suites, including real worker and external-connection races.
- Synthetic owner benchmark on Node 26.8.2: 3,000 rows containing 98.6 MB of JSON, one admitted session, two warm-ups and ten measured calls. Mean lookup time changed from 48.45 ms to 4.13 ms; immediate heap growth changed from about 101.8 MB to 2.12 MB. This measures an in-memory SQLite projection, not live request latency, retained heap, or an OOM cure.
- SQLite query-plan inspection confirms a covering scan of the existing primary-key index and indexed payload lookups; no new index is required.

- Complete changed-file checks passed, including core and all test typechecks, formatting, lint, dead-export scans, and storage/runtime/import guards.
- Fresh independent P2 review of the final staged candidate completed with no actionable findings.

The repaired candidate is `d3427763c41e7b5a75b133b3bd75507567a231a6`, based on `9ab6ba866c9bb1ee6cdb74cdc99173833998dac3`. Its local proof includes the raw-encoding correction. Exact-head [CI run 34676752315](https://github.com/openclaw/openclaw/actions/runs/34676752315) completed successfully: 131 jobs finished with success or intentional skip, and the aggregate gate passed. The fresh ClawSweeper review of this head also completed with no findings or pre-merge actions.
