### PR TITLE
fix(ci): report ClawSweeper dispatch API failures truthfully

### DIFF
--- a/.github/workflows/clawsweeper-dispatch.yml
+++ b/.github/workflows/clawsweeper-dispatch.yml
@@ -62,8 +62,9 @@ jobs:
               if output="$(gh api "$@" 2>&1)"; then
                 printf '%s\n' "$output"
                 return 0
+              else
+                status=$?
               fi
-              status=$?
               lower_output="${output,,}"
               if [[ "$lower_output" != *"rate limit"* && "$output" != *"HTTP 429"* ]]; then
                 printf '%s\n' "$output" >&2

--- a/docs/ci/scheduled-workflows.md
+++ b/docs/ci/scheduled-workflows.md
@@ -282,6 +282,8 @@ for the weekly burst separately from PR and main admission.
 
 `.github/workflows/clawsweeper-dispatch.yml` is the target-side bridge from OpenClaw repository activity into ClawSweeper. It does not check out or execute untrusted pull request code. The workflow creates a GitHub App token from `CLAWSWEEPER_APP_PRIVATE_KEY`, then dispatches compact `repository_dispatch` payloads to `openclaw/clawsweeper`.
 
+Dispatch API calls retry rate-limit failures for up to five attempts with quadratic backoff. Other API errors stop immediately, and exhausted retries preserve the final API exit code. Dispatch callers warn and continue on failure rather than reporting a successful dispatch.
+
 The workflow has three lanes:
 
 - `clawsweeper_item` for exact issue and pull request review requests;

--- a/test/scripts/clawsweeper-dispatch.test.ts
+++ b/test/scripts/clawsweeper-dispatch.test.ts
@@ -1,0 +1,157 @@
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { beforeAll, describe, expect, it } from "vitest";
+import { parse } from "yaml";
+
+const workflow = parse(readFileSync(".github/workflows/clawsweeper-dispatch.yml", "utf8")) as {
+  jobs: { dispatch: { steps: { name: string; run?: string }[] } };
+};
+const install = workflow.jobs.dispatch.steps.find(
+  (step) => step.name === "Install GitHub API backoff helper",
+)?.run;
+const helper = install?.split("<<'BASH'\n")[1]?.split("\nBASH")[0];
+
+const cases = [
+  {
+    name: "returns successful output without retrying",
+    response: `printf '{"accepted":true}\\n'`,
+    code: 0,
+    output: '{"accepted":true}\n',
+    error: "",
+    attempts: 1,
+    sleeps: [],
+  },
+  {
+    name: "preserves a non-retryable failure instead of reporting success",
+    response: `printf 'permission denied\\n' >&2; return 42`,
+    code: 42,
+    output: "",
+    error: "permission denied\n",
+    attempts: 1,
+    sleeps: [],
+  },
+  {
+    name: "retries case-insensitive rate limits and returns recovered output",
+    response: `
+      if ((call < 3)); then
+        printf 'API RaTe LiMiT exceeded\\n' >&2
+        return 41
+      fi
+      printf 'recovered\\n'`,
+    code: 0,
+    output: "recovered\n",
+    error: "",
+    attempts: 3,
+    sleeps: [5, 20],
+  },
+  {
+    name: "returns the last HTTP 429 failure after five attempts",
+    response: `printf 'HTTP 429: throttled on call %s\\n' "$call" >&2; return "$((40 + call))"`,
+    code: 45,
+    output: "",
+    error: "HTTP 429: throttled on call 5\n",
+    attempts: 5,
+    sleeps: [5, 20, 45, 80, 125],
+  },
+  {
+    name: "stops immediately when a retry becomes non-retryable",
+    response: `
+      if ((call == 1)); then
+        printf 'rate limit exceeded\\n' >&2
+        return 41
+      fi
+      printf 'HTTP 403: forbidden\\n' >&2
+      return 42`,
+    code: 42,
+    output: "",
+    error: "HTTP 403: forbidden\n",
+    attempts: 2,
+    sleeps: [5],
+  },
+];
+
+describe.skipIf(process.platform === "win32")("ClawSweeper GitHub API backoff", () => {
+  let bash: string;
+
+  beforeAll(() => {
+    expect(helper).toContain("gh_api_with_retry()");
+    const candidates =
+      process.platform === "darwin"
+        ? ["/opt/homebrew/bin/bash", "/usr/local/bin/bash", "/bin/bash"]
+        : ["/bin/bash"];
+    const compatible = candidates.find(
+      (binary) =>
+        spawnSync(binary, ["--noprofile", "--norc", "-c", "((BASH_VERSINFO[0] >= 4))"], {
+          env: { PATH: process.env.PATH },
+          timeout: 5_000,
+        }).status === 0,
+    );
+    if (!compatible) {
+      throw new Error("ClawSweeper backoff tests require Bash 4+ (on macOS: brew install bash).");
+    }
+    bash = compatible;
+  });
+
+  it.each(cases)("$name", ({ response, code, output, error, attempts, sleeps }) => {
+    const root = mkdtempSync(join(tmpdir(), "clawsweeper-backoff-"));
+    const args = ["synthetic/dispatches", "--method", "POST", "-f", "message=two words"];
+    try {
+      writeFileSync(join(root, "attempt"), "0\n");
+      writeFileSync(join(root, "sleeps"), "");
+      const result = spawnSync(
+        bash,
+        [
+          "--noprofile",
+          "--norc",
+          "-c",
+          `set -euo pipefail
+${helper}
+gh() {
+  local call
+  read -r call < "$RUNNER_TEMP/attempt"
+  call=$((call + 1))
+  printf '%s\\n' "$call" > "$RUNNER_TEMP/attempt"
+  printf '%s\\n' "$@" > "$RUNNER_TEMP/args-$call"
+  ${response}
+}
+sleep() { printf '%s\\n' "$1" >> "$RUNNER_TEMP/sleeps"; }
+if gh_api_with_retry "$@"; then
+  exit 0
+else
+  exit "$?"
+fi`,
+          "backoff-test",
+          ...args,
+        ],
+        {
+          encoding: "utf8",
+          timeout: 5_000,
+          // No inherited credentials, startup hooks, or external commands: gh and sleep are stubs.
+          env: { PATH: "", RUNNER_TEMP: root },
+        },
+      );
+      expect(result.error).toBeUndefined();
+      expect(result.status).toBe(code);
+      expect(result.stdout).toBe(output);
+      const stderrLines = result.stderr.split("\n").filter(Boolean);
+      const warnings = stderrLines.filter((line) => line.startsWith("::warning::"));
+      expect(warnings).toHaveLength(sleeps.length);
+      expect(stderrLines.filter((line) => !line.startsWith("::warning::")).join("\n")).toBe(
+        error.trimEnd(),
+      );
+      expect(readFileSync(join(root, "attempt"), "utf8")).toBe(`${attempts}\n`);
+      expect(readFileSync(join(root, "sleeps"), "utf8")).toBe(
+        sleeps.map((seconds) => `${seconds}\n`).join(""),
+      );
+      for (let call = 1; call <= attempts; call++) {
+        expect(readFileSync(join(root, `args-${call}`), "utf8")).toBe(
+          ["api", ...args, ""].join("\n"),
+        );
+      }
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/scripts/test-projects.test.ts
+++ b/test/scripts/test-projects.test.ts
@@ -1386,7 +1386,6 @@ describe("scripts/test-projects changed-target routing", () => {
   it("keeps PR automation workflow edits on workflow guard tests", () => {
     for (const workflowPath of [
       ".github/workflows/auto-response.yml",
-      ".github/workflows/clawsweeper-dispatch.yml",
       ".github/workflows/labeler.yml",
       ".github/workflows/real-behavior-proof.yml",
       ".github/workflows/stale.yml",
@@ -1402,6 +1401,10 @@ describe("scripts/test-projects changed-target routing", () => {
           : ["test/scripts/ci-workflow-guards.test.ts"],
       );
     }
+    expectChangedTargets(
+      [".github/workflows/clawsweeper-dispatch.yml"],
+      ["test/scripts/ci-workflow-guards.test.ts", "test/scripts/clawsweeper-dispatch.test.ts"],
+    );
   });
 
   it("keeps security-sensitive guard workflow edits on guard workflow tests", () => {


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where ClawSweeper Dispatch reported successful API dispatches after GitHub rejected a request or rate-limit retries were exhausted. The false success also prevented acknowledgement callers from taking their existing error-handling branches.

## Why This Change Was Made

Capture the failed `gh api` exit status inside the `else` branch, before Bash replaces it with the completed `if` compound's successful status. Preserve the existing five-attempt quadratic backoff, rate-limit matching, output handling, and callers' warning-and-continue behavior. Document that boundary and cover the actual workflow helper with offline behavior tests.

This is a separate, narrowly scoped workflow repair. It changes no secrets, permissions, deployment configuration, event routing, or pricing behavior.

## User Impact

Operators now receive the existing failure warnings instead of misleading dispatch-success messages when GitHub API calls fail. Successful requests and bounded rate-limit recovery behave as before.

## Evidence

- Reproduced using the exact extracted helper on Bash 5.3.15 and a synthetic `gh` returning 42: before the fix, the wrapper exited 0.
- Five offline behavior cases cover immediate success, non-retryable failure, case-insensitive rate-limit recovery, HTTP 429 exhaustion with the final failure code, and a retry becoming non-retryable. Before the fix, three failed with exit 0 instead of 42 or 45; after the fix, all five passed.
- Coverage also verifies output streams, argument forwarding, attempt counts, and quadratic backoff delays. The harness uses stubbed `gh` and `sleep`, no inherited credentials, and an empty command search path; it cannot execute real GitHub writes.
- Passed `node scripts/run-vitest.mjs test/scripts/clawsweeper-dispatch.test.ts test/scripts/test-projects.test.ts -- --reporter=dot`: 484 tests before the base refresh; 531 tests on the rebased head with current-main coverage. CI exposed the existing workflow target-selection test's outdated singleton expectation; it now requires both the existing workflow guard and the new dispatch behavior suite.
- Passed `node --import ./scripts/tsx.mjs scripts/check-workflows.mts`.
- Passed scoped `node scripts/check-changed.mjs` checks, including typechecking, lint, formatting, and repository guards; `git diff --check` passed.
- Independent Codex autoreview found no actionable P0–P2 findings.

Local proof used modern macOS Bash; the tests require Bash 4+ and skip Windows. No live dispatch was used as proof. Exact-head hosted checks are required before landing.

Initial hosted CI exposed two failures outside this PR's changed files: [core lint](https://github.com/openclaw/openclaw/actions/runs/34674754976/job/103502565030) reports `src/auto-reply/thinking.test.ts` at 1006 counted lines, and [Gateway tests](https://github.com/openclaw/openclaw/actions/runs/34674754976/job/103502565295) timed out waiting 5000ms for worker launch in `worker-turn-detached-context.test.ts`. Neither unrelated file is changed here.

On the corrected head `03847099107432aed0382b53c5e3722395d884fb`, [the second CI run](https://github.com/openclaw/openclaw/actions/runs/34675357307) completed with only `check-lint-core-2` and its aggregate `openclaw/ci-gate` failing; the routing and Gateway test failures did not recur. The main lint failure was repaired separately in [PR #145632](https://github.com/openclaw/openclaw/pull/145632), merged as `9ab6ba866c9b`. This branch was rebased onto main containing that repair; `git range-diff` confirms both scoped commits remain patch-identical. [CI run 34676295153](https://github.com/openclaw/openclaw/actions/runs/34676295153) then passed on exact head `95977cd113e3e8f11be8a262e090b6b2ce66e3fc`; the native watcher finished GREEN with zero pending checks. ClawSweeper's latest exact-head review reports no actionable correctness or security findings.
