### PR TITLE
perf(sessions): avoid repeated terminal snapshot scans

### DIFF
--- a/packages/gateway-client/src/session-projection-final-identity.ts
+++ b/packages/gateway-client/src/session-projection-final-identity.ts
@@ -104,29 +104,6 @@ function hasTerminalStopReason(message: unknown): boolean {
   );
 }
 
-function hasCompletedRunSnapshotContext(
-  entry: TerminalProjectionEntry,
-  snapshot: readonly TerminalProjectionEntry[],
-  runId: string | null,
-): boolean {
-  if (!runId || entry.identity?.runId !== runId) {
-    return false;
-  }
-  const entryIndex = snapshot.indexOf(entry);
-  if (entryIndex < 0) {
-    return false;
-  }
-  const hasEarlierUser = snapshot
-    .slice(0, entryIndex)
-    .some((candidate) => candidate.identity?.role === "user" && candidate.identity.runId === runId);
-  const hasLaterAssistant = snapshot
-    .slice(entryIndex + 1)
-    .some(
-      (candidate) => candidate.identity?.role === "assistant" && candidate.identity.runId === runId,
-    );
-  return hasEarlierUser && !hasLaterAssistant;
-}
-
 /** Read stable persisted identity first, falling back to canonical display content. */
 export function readSessionProjectionFinalMessageIdentity(message: unknown): string | null {
   if (!hasDisplayableSessionMessage(message)) {
@@ -176,7 +153,8 @@ export function findUniqueSnapshotTerminalMatch(
     current.identity.id ||
     current.identity.sequence !== null ||
     !run ||
-    run.status === "streaming"
+    run.status === "streaming" ||
+    matches.length === 0
   ) {
     return null;
   }
@@ -184,13 +162,46 @@ export function findUniqueSnapshotTerminalMatch(
   if (!terminalContent || readFinalContentIdentity(run.message) !== terminalContent) {
     return null;
   }
+  let snapshotIndexes: Map<TerminalProjectionEntry, number> | undefined;
+  let firstUserIndex = -1;
+  let lastAssistantIndex = -1;
+  const hasCompletedRunSnapshotContext = (entry: TerminalProjectionEntry): boolean => {
+    const runId = current.identity?.runId;
+    if (!runId || entry.identity?.runId !== runId) {
+      return false;
+    }
+    if (!snapshotIndexes) {
+      const indexes = new Map<TerminalProjectionEntry, number>();
+      snapshot.forEach((candidate, index) => {
+        if (candidate.identity?.runId === runId) {
+          // Keep indexOf's first-occurrence identity when a snapshot repeats an entry.
+          if (!indexes.has(candidate)) {
+            indexes.set(candidate, index);
+          }
+          if (candidate.identity.role === "user" && firstUserIndex < 0) {
+            firstUserIndex = index;
+          } else if (candidate.identity.role === "assistant") {
+            lastAssistantIndex = index;
+          }
+        }
+      });
+      snapshotIndexes = indexes;
+    }
+    const entryIndex = snapshotIndexes.get(entry);
+    return (
+      entryIndex !== undefined &&
+      firstUserIndex >= 0 &&
+      firstUserIndex < entryIndex &&
+      lastAssistantIndex <= entryIndex
+    );
+  };
   const durableTerminalMatches = matches.filter((entry) => {
     const metadata = readRecord(readRecord(entry.message)?.["__openclaw"]);
     return (
       (metadata?.runTerminal === true ||
         (entry.identity?.runId === current.identity?.runId &&
           hasTerminalStopReason(entry.message)) ||
-        hasCompletedRunSnapshotContext(entry, snapshot, current.identity?.runId ?? null)) &&
+        hasCompletedRunSnapshotContext(entry)) &&
       readFinalContentIdentity(entry.message) === terminalContent
     );
   });


### PR DESCRIPTION
## What Problem This Solves

Reloading a long conversation can repeat work while matching a live final reply to durable history. Many unmarked same-run assistant candidates cause repeated scans and temporary array copies during terminal reconciliation.

## Why This Change Was Made

Prepare first-occurrence indexes only for the target run, together with its first user and last assistant positions, once per matcher invocation. Return immediately when there are no matches. This avoids repeated context scans and unnecessary indexing of foreign-run rows without adding a persistent or reconciliation-wide cache.

The one-file change adds 11 net production lines. First-occurrence object identity, nonmember rejection, explicit terminal markers, recognized stop reasons, content checks, ambiguity rejection, inferred recovery, filtering, and reset behavior remain unchanged. Later tool-boundary history still restores an inferred live final; authoritative removal, filtering, and confirmation retire recovery. The empty-match shortcut applies to normal client-produced message data; it does not promise to evaluate arbitrary throwing JavaScript getters or Proxies. No public API, protocol, storage, update, or authorization change is intended.

## User Impact

The intended benefit is less reconciliation work for long histories with many unmarked same-run candidates. Message content and order remain unchanged. **Actual UI responsiveness is unproven:** these measurements cover complete reducer event sequences, not browser rendering or transport latency. R2 was selected for reducing unnecessary structural work, not because it consistently fixed every control timing.

## Evidence

[The R2 Linux comparison](https://github.com/openclaw/openclaw/actions/runs/34672800113) completed the fixed B1/C1/C2/B2 order, all 11 cases, 7,100 full event sequences / 78,248 reducer transitions, and four separate qualification runs without retrying or changing limits. The full qualification bytes matched across phases and also matched R1. Complete input/state graphs matched across all R2 arms, including reference relationships. Native children closed, source restoration passed, the owned worktree was removed, and the dedicated lease was stopped and verified absent.

Each sequence includes live terminal publication, gap/reconnect, partial and repeated history, a later tool boundary, authoritative final history, filtering, reset, and stale-history rejection. Actual reducer transitions and context preparation are inside timing; fixture setup and full-state assertions are outside. Two warmup batches precede seven measured batches. Every batch checks its complete last sequence; intermediate repetitions are not individually serialized. The insertion control proves observation of inserted rows, not cache invalidation. All raw samples, distributions, graphs, and adverse cases are retained.

R2 wall medians below are milliseconds per complete 11-event sequence, or 12 events for insertion observation. Negative changes mean less time. Row counts are additional assistant rows beyond the final candidate.

| R2 case | B1 → C1 wall ms | Wall change | B2 → C2 wall ms | Wall change | CPU change B1/C1; B2/C2 |
| --- | ---: | ---: | ---: | ---: | ---: |
| Empty history | 0.0120 → 0.0066 | −44.87% | 0.0133 → 0.0075 | −43.47% | +44.16%; +44.57% |
| Single unmarked | 0.0298 → 0.0299 | +0.24% | 0.0304 → 0.0296 | −2.48% | −43.66%; −28.44% |
| 32 unmarked | 0.1531 → 0.1171 | −23.57% | 0.1227 → 0.1261 | +2.74% | −2.32%; +60.41% |
| 256 unmarked | 0.9219 → 0.7189 | −22.02% | 0.8883 → 0.7352 | −17.23% | −28.05%; −19.79% |
| 1,024 unmarked | 5.1296 → 2.8998 | −43.47% | 5.3274 → 2.8618 | −46.28% | −45.11%; −48.61% |
| 256 all-marked | 0.5369 → 0.5296 | −1.36% | 0.5396 → 0.8992 | +66.63% | −5.27%; +70.91% |
| 256 stop-only | 0.5311 → 0.5316 | +0.10% | 0.6047 → 0.8156 | +34.87% | −1.16%; +39.32% |
| 256 foreign rows, no target user | 0.5788 → 0.6020 | +4.00% | 0.6034 → 0.7570 | +25.45% | +10.92%; +36.12% |
| Single candidate amid 256 foreign rows, valid user | 0.6518 → 0.6519 | +0.007% | 0.6866 → 0.9369 | +36.45% | +0.019%; +38.14% |
| 256 rows with ambiguous terminals | 0.7464 → 0.6372 | −14.63% | 0.7932 → 0.8133 | +2.55% | −14.60%; +2.49% |
| 256 rows with live insertion | 0.9905 → 0.8603 | −13.14% | 1.0347 → 0.9112 | −11.94% | −13.17%; −11.91% |

The 1,024-row unmarked workload improved **43.5–46.3% in wall time** in both R2 orders. R2 did not consistently improve the controls: empty CPU rose, reverse marked/stop/foreign cases regressed, and several smaller cases were mixed. Marked/stop-only controls bypass context preparation while a live matcher remains eligible, so their changes cannot be attributed to eliminating context scans. Whole-child wall time changed −9.18%/+3.79%, user CPU −7.78%/+5.00%, and system CPU −44.06%/−26.27%. Kernel peak RSS changed −4.82%/−0.55%; sampled process-tree peak RSS −4.20%/−0.68%. Native totals include imports, qualification, setup, and parity. No population confidence or universal gain is claimed.

[Historical R1](https://github.com/openclaw/openclaw/actions/runs/34667167320) was a different source revision, before target-run-only indexing and the empty guard. It measured a 68.3% wall reduction at 1,024 rows in both orders. That is **not R2's result**, and the two datasets are not pooled or ranked by their best percentages. R1's retained adverse medians include reverse empty +45.85% wall/+53.28% CPU, reverse single +22.92%/+40.26%, reverse 32-row CPU +14.04%, forward foreign-without-user +9.19%/+33.81%, and forward single-amid-foreign +6.33%/+9.33%. Its forward kernel/tree RSS increased +0.49%/+0.008%. Both independent datasets and the original source artifacts remain preserved.

Both measurements remain pinned to `b6073553b799d81cb4805cc6111e73545d9b5d24`. The validation packet uses `c944cb12c08100e5b441edebc038dea116449f43`; this PR is authored on `f35d894ba5351278ce88a328d8753e6f9057a446`. All 58 pinned source, caller, test, package and toolchain files match between the validation packet and the author base. The exact candidate is unchanged. Relative to the older measured base, dependency inputs include typebox 1.3.26 and newer UI history cancellation/metadata-cache ownership, so those timings remain historical rather than measurements of the newer base.

**Focused validation: 267 unique cases passed.** [Validation R1](https://github.com/openclaw/openclaw/actions/runs/34673682159) passed all 101 projection/conformance tests and all 47 terminal reconciliation/bookkeeping tests, plus formatting and the changed-check dry-run plan. Its filtered UI run passed five cases but correctly failed the eleven-title acceptance check: Vitest 5 truncates interpolated test-name strings to 40 characters, so six full-name selectors did not match their generated display titles. The source cases were present; this was a selection/proof failure, not a failed product assertion. That failure and its exact evidence remain preserved.

[Corrective validation R2](https://github.com/openclaw/openclaw/actions/runs/34674107654) ran the complete pinned UI state test file without a title filter: all 119 cases passed, with zero failed, skipped, pending or todo cases. The five earlier UI passes overlap and are not counted twice. This is the normal jsdom state/history/publication boundary, not browser appearance, frame timing or live Gateway proof. The full changed gate was not run; exact-head hosted checks remain required before landing.

All native validation children closed with their monitors joined. R1 retained its worktree after the acceptance failure until verified VM shutdown; R2 restored source and removed its worktree normally, and its dedicated Testbox was independently confirmed completed. Limits were unchanged. R2's recovered archive SHA256 is `27946807973ca8d0a20805b32af80fc3b4ea68e650e752fcae344165c0c3b78a`.

The matching oxfmt 0.66.0 tool, using the current author configuration, made no source-byte changes. A fresh managed Codex review through P2 completed scoped-clean with no actionable findings. No benchmark was rerun for authoring, and no universal UI, Gateway, CPU or memory improvement is claimed.

**Current-head qualification:** Head `0987790b0ae9` preserves the authored patch on main `785266d3af19`, including the shared lint repair in #145632. Stable patch ID, complete changed-file bytes, and all 58 supporting source/test/toolchain pins match the previously reviewed candidate, so the recorded P2 review and validation remain applicable within their original scope. Historical benchmarks retain their original source labels. Prior CI failures remain recorded; no test or benchmark was rerun for this rebase, and fresh exact-head CI is required before landing.
