### PR TITLE
fix(context-engine): prevent leaked resources and premature cleanup

### DIFF
--- a/docs/concepts/context-engine.md
+++ b/docs/concepts/context-engine.md
@@ -311,7 +311,13 @@ Optional members:
 | `afterTurn(params)`            | Method | Post-run lifecycle work (persist state, trigger background compaction).                                                                      |
 | `prepareSubagentSpawn(params)` | Method | Set up shared state for a child session before it starts.                                                                                    |
 | `onSubagentEnded(params)`      | Method | Clean up after a subagent ends.                                                                                                              |
-| `dispose()`                    | Method | Release engine-instance resources when the logical turn retires, after any retained turn work finishes.                                      |
+| `dispose()`                    | Method | Release engine-instance resources when the owning operation ends, after any retained work finishes.                                          |
+
+The host also disposes instances resolved for standalone compaction, Doctor
+inspection, and subagent lifecycle hooks. A queued subagent spawn keeps its
+instance until dispatch succeeds or preparation is rolled back; returning a
+queued acceptance does not end that lifetime. Timed-out compaction keeps its
+instance until the underlying plugin work settles.
 
 Foreground engine disposal shares the agent cleanup deadline: 10 seconds by
 default, adjustable with `OPENCLAW_AGENT_CLEANUP_TIMEOUT_MS`. A stalled cleanup

--- a/src/agents/cli-runner.ts
+++ b/src/agents/cli-runner.ts
@@ -255,7 +255,7 @@ async function runPreparedCliAgentOwned(
   context: PreparedCliRunContext,
   diagnosticLifecycle?: ClaudeCliRunDiagnosticLifecycle,
 ): Promise<EmbeddedAgentRunResult> {
-  const { executePreparedCliRun } = await import("./cli-runner/execute.runtime.js");
+  let executePreparedCliRun: typeof import("./cli-runner/execute.runtime.js").executePreparedCliRun;
   const { params } = context;
   const cliFailoverContext = {
     provider: params.provider,
@@ -280,18 +280,8 @@ async function runPreparedCliAgentOwned(
   const hasAgentEndHooks = hookRunner?.hasHooks("agent_end") === true;
   const hasBeforeAgentRunHooks = hookRunner?.hasHooks("before_agent_run") === true;
   const needsHookHistory = hasLlmInputHooks || hasAgentEndHooks || hasBeforeAgentRunHooks;
-  const historyMessages = needsHookHistory ? await loadCliSessionHistoryMessages(params) : [];
+  let historyMessages: unknown[] = [];
   const promptForHooks = context.promptForHooks ?? params.prompt;
-  const llmInputEvent = {
-    runId: params.runId,
-    sessionId: params.sessionId,
-    provider: params.provider,
-    model: context.modelId,
-    systemPrompt: context.systemPrompt,
-    prompt: promptForHooks,
-    historyMessages,
-    imagesCount: params.images?.length ?? 0,
-  } as const;
   const hookContext = {
     runId: params.runId,
     jobId: params.jobId,
@@ -476,6 +466,18 @@ async function runPreparedCliAgentOwned(
   };
 
   const executeRun = async (): Promise<EmbeddedAgentRunResult> => {
+    ({ executePreparedCliRun } = await import("./cli-runner/execute.runtime.js"));
+    historyMessages = needsHookHistory ? await loadCliSessionHistoryMessages(params) : [];
+    const llmInputEvent = {
+      runId: params.runId,
+      sessionId: params.sessionId,
+      provider: params.provider,
+      model: context.modelId,
+      systemPrompt: context.systemPrompt,
+      prompt: promptForHooks,
+      historyMessages,
+      imagesCount: params.images?.length ?? 0,
+    } as const;
     if (isolatedCompletion) {
       const { output, usedHistoryPrompt } = await executeCliAttempt();
       return buildCliRunResult({

--- a/src/agents/cli-runner/cli-run-transcript.ts
+++ b/src/agents/cli-runner/cli-run-transcript.ts
@@ -425,6 +425,7 @@ export async function finalizeCliContextEngineTurn(params: {
       runMaintenance: async (maintenanceParams) =>
         await runHarnessContextEngineMaintenance({
           ...maintenanceParams,
+          onDeferredMaintenance: context.deferContextEngineDisposalUntil,
           withSessionManagerRewriteLock: async (operation) => await operation(),
         }),
       warn: (message) => log.warn(message),

--- a/src/agents/cli-runner/prepare.test.ts
+++ b/src/agents/cli-runner/prepare.test.ts
@@ -4,6 +4,7 @@ import { randomUUID } from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
 import { SYSTEM_PROMPT_CACHE_BOUNDARY } from "@openclaw/ai/internal/shared";
 import { expectDefined } from "@openclaw/normalization-core";
 import { Type } from "typebox";
@@ -27,7 +28,11 @@ import {
   patchSessionEntryCore,
 } from "../../config/sessions/session-accessor.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import { registerContextEngineForOwner } from "../../context-engine/registry.js";
+import { LegacyContextEngine } from "../../context-engine/legacy.js";
+import {
+  registerContextEngineForOwner,
+  registerContextEngineInRegistry,
+} from "../../context-engine/registry.js";
 import type { ContextEngine } from "../../context-engine/types.js";
 import type { resolveMcpLoopbackScopedTools as resolveLoopbackTools } from "../../gateway/mcp-http.runtime.js";
 import {
@@ -41,16 +46,21 @@ import type {
   CliBackendPlugin,
 } from "../../plugins/cli-backend.types.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
-import type { HookRunner } from "../../plugins/hooks.js";
+import { createHookRunner, type HookRunner } from "../../plugins/hooks.js";
 import {
   clearMemoryPluginState,
   registerTestMemoryPromptBuilder,
 } from "../../plugins/memory-state.test-fixtures.js";
+import { createEmptyPluginRegistry } from "../../plugins/registry-empty.js";
+import { PluginRegistryInspectionResources } from "../../plugins/registry-inspection-resources.js";
+import { retireInspectionInstances } from "../../plugins/registry-inspection.test-support.js";
 import { createPluginRegistry } from "../../plugins/registry.js";
 import { setActivePluginRegistry } from "../../plugins/runtime.js";
+import { withPluginRuntimeRegistryScope } from "../../plugins/runtime/gateway-request-scope.js";
 import type { PluginRuntime } from "../../plugins/runtime/types.js";
 import { setActiveDegradedSecretOwners } from "../../secrets/runtime-degraded-state.js";
 import { createUserTurnTranscriptRecorder } from "../../sessions/user-turn-transcript.js";
+import { AsyncWorkScope } from "../../shared/async-work-scope.js";
 import type { SkillLibraryAuthoringCapability } from "../../skills/library/authoring.js";
 import { buildSkillSnapshot } from "../../skills/loading/workspace-skill-prompt.js";
 import type { SkillSnapshot } from "../../skills/types.js";
@@ -107,6 +117,8 @@ import {
   hashCliSessionText,
 } from "../cli-session.js";
 import { resetContextWindowCacheForTest } from "../context.js";
+import { waitForDeferredTurnMaintenanceForSession } from "../embedded-agent-runner/context-engine-maintenance.js";
+import { createContextEngineLogicalTurnLease } from "../harness/context-engine-logical-turn.js";
 import { claimPendingAgentQuestionAnswerFromCaller } from "../harness/gateway-question.js";
 import { withQuestionGateway } from "../harness/gateway-question.test-support.js";
 import {
@@ -116,6 +128,7 @@ import {
 } from "../media-generation-task-status.js";
 import { createAgentCleanupScope } from "../run-cleanup-timeout.js";
 import type { SandboxWorkspaceInfo } from "../sandbox/types.js";
+import { beginForegroundSessionMaintenance } from "../session-maintenance/coordinator.js";
 import { SessionManager } from "../sessions/session-manager.js";
 import {
   captureRoutingDecisionWork,
@@ -125,6 +138,7 @@ import { createZeroUsageFixture } from "../test-helpers/usage-fixtures.js";
 import type { SystemAgentToolOptions } from "../tools/system-agent-tool.js";
 import { prepareCliBundleMcpCaptureAttempt, prepareCliBundleMcpConfig } from "./bundle-mcp.js";
 import { prepareClaudeCliSkillsPlugin } from "./claude-skills-plugin.js";
+import { finalizeCliContextEngineTurn } from "./cli-run-transcript.js";
 import { executePluginOwnedProcess } from "./execute-plugin.js";
 import { prepareCliHistoryBoundary } from "./history-boundary.js";
 import { prepareCliRunContext } from "./prepare.js";
@@ -141,6 +155,37 @@ function registerTestContextEngine(
   return registerContextEngineForOwner(id, factory, `test:${id}`, {
     allowSameOwnerRefresh: true,
   });
+}
+
+function createContextEngineCustodyFixture() {
+  const registry = createEmptyPluginRegistry();
+  const resources = new PluginRegistryInspectionResources(retireInspectionInstances);
+  resources.attach(registry);
+  const database = new DatabaseSync(":memory:");
+  let closed = false;
+  const close = () => {
+    if (!closed) {
+      closed = true;
+      database.close();
+    }
+  };
+  const retirement = createDeferred();
+  const retired = vi.fn(() => {
+    close();
+    retirement.resolve();
+  });
+  resources.register("fixture", { id: "cli-engine-database", dispose: retired });
+  return {
+    registry,
+    resources,
+    retired,
+    retirement: retirement.promise,
+    read: () => database.prepare("SELECT 42 AS value").get()?.value,
+    async cleanup() {
+      await resources.release();
+      close();
+    },
+  };
 }
 
 function installTestPluginRegistry() {
@@ -2676,6 +2721,251 @@ describe("prepareCliRunContext", () => {
     expect(context.systemPrompt).not.toContain("hook exploded");
     expect(hookRunner.runBeforePromptBuild).toHaveBeenCalledOnce();
   });
+
+  it.each([
+    "custom",
+    "legacy",
+    "incompatible",
+    "incompatible-cleanup-failed",
+    "cleanup-failed",
+    "retired",
+  ] as const)("settles directly resolved CLI context-engine custody (%s)", async (scenario) => {
+    const custody = createContextEngineCustodyFixture();
+    const engineId = `cli-custody-${scenario}`;
+    const incompatible = scenario.startsWith("incompatible");
+    const cleanupFailure = new Error("CLI engine cleanup failed");
+    const backendCleanup = vi.fn(async () => {});
+    setRawCliBackendForPrepareTest({
+      ...buildDefaultTestCliBackend(),
+      prepareExecution: async () => ({ cleanup: backendCleanup }),
+    });
+    let current = true;
+    class Engine extends LegacyContextEngine {
+      override readonly info: ContextEngine["info"] = {
+        id: scenario === "legacy" ? "legacy" : engineId,
+        name: "CLI custody fixture",
+        ...(incompatible
+          ? {
+              hostRequirements: {
+                "agent-run": {
+                  requiredCapabilities: ["assemble-before-prompt"],
+                  unsupportedMessage: "CLI engine host unsupported",
+                },
+              },
+            }
+          : {}),
+      };
+      async dispose() {
+        expect(custody.read()).toBe(42);
+        if (scenario.endsWith("cleanup-failed")) {
+          throw cleanupFailure;
+        }
+      }
+    }
+    registerContextEngineInRegistry(
+      custody.registry,
+      engineId,
+      async () => {
+        current = scenario !== "retired";
+        return new Engine();
+      },
+      "plugin:fixture",
+    );
+    try {
+      const preparation = withPluginRuntimeRegistryScope(custody.registry, () =>
+        fixture.prepare({
+          config: { plugins: { slots: { contextEngine: engineId } } },
+          assertCurrent: () => {
+            if (!current) {
+              throw new Error("CLI owner retired after engine acquisition");
+            }
+          },
+        }),
+      );
+      if (incompatible || scenario === "retired") {
+        await expect(preparation).rejects.toThrow(
+          incompatible
+            ? "CLI engine host unsupported"
+            : "CLI owner retired after engine acquisition",
+        );
+        await custody.resources.release();
+      } else {
+        const context = await preparation;
+        expect(context.contextEngine?.info.id).toBe(scenario === "legacy" ? undefined : engineId);
+        await custody.resources.release();
+        expect(custody.retired).not.toHaveBeenCalled();
+        if (scenario === "cleanup-failed") {
+          await expect(context.preparedBackend.cleanup?.()).rejects.toBe(cleanupFailure);
+        } else {
+          await context.preparedBackend.cleanup?.();
+        }
+      }
+      expect(backendCleanup).toHaveBeenCalledOnce();
+      expect(custody.retired).toHaveBeenCalledOnce();
+      expect(() => custody.read()).toThrow();
+    } finally {
+      await custody.cleanup();
+    }
+  });
+
+  it("releases prepared CLI context-engine custody when hook history cannot be read", async () => {
+    const custody = createContextEngineCustodyFixture();
+    const engineId = "cli-custody-history-failure";
+    const historyFailure = new Error("synthetic hook-history read failed");
+    const backendCleanup = vi.fn(async () => {});
+    const execute = vi.fn<CliBackendExecute>(async function* () {
+      yield { type: "result", subtype: "success", result: "unexpected answer" };
+    });
+    setRawCliBackendForPrepareTest({
+      ...buildDefaultTestCliBackend(),
+      prepareExecution: async () => ({ cleanup: backendCleanup, execute }),
+    });
+    let engineAcquired = false;
+    class Engine extends LegacyContextEngine {
+      override readonly info = { id: engineId, name: "CLI failed-history custody fixture" };
+      async dispose() {
+        expect(custody.read()).toBe(42);
+      }
+    }
+    const factory = vi.fn(() => {
+      engineAcquired = true;
+      return new Engine();
+    });
+    registerContextEngineInRegistry(custody.registry, engineId, factory, "plugin:fixture");
+    custody.registry.typedHooks.push({
+      pluginId: "fixture",
+      hookName: "llm_input",
+      handler: () => {},
+      source: "test",
+    });
+    mockGetGlobalHookRunner.mockReturnValue(createHookRunner(custody.registry));
+    const history = await import("./session-history.js");
+    const readHistory = history.loadCliSessionHistoryMessages;
+    const historyRead = vi
+      .spyOn(history, "loadCliSessionHistoryMessages")
+      .mockImplementation(async (params) => {
+        if (engineAcquired) {
+          throw historyFailure;
+        }
+        return await readHistory(params);
+      });
+    try {
+      const { runCliAgent } = await import("../cli-runner.js");
+      const { dir, sessionTarget } = fixture.session;
+      await expect(
+        withPluginRuntimeRegistryScope(custody.registry, () =>
+          wrapRunWithTestPreparedAdmission(runCliAgent)({
+            sessionId: sessionTarget.sessionId,
+            sessionKey: sessionTarget.sessionKey,
+            sessionTarget,
+            sessionFile: sessionTarget.sessionKey,
+            workspaceDir: dir,
+            prompt: "synthetic question",
+            provider: "test-cli",
+            model: "test-model",
+            runId: "cli-custody-history-failure",
+            timeoutMs: 1_000,
+            config: { plugins: { slots: { contextEngine: engineId } } },
+          }),
+        ),
+      ).rejects.toBe(historyFailure);
+      expect(factory).toHaveBeenCalledOnce();
+      expect(execute).not.toHaveBeenCalled();
+      expect(backendCleanup).toHaveBeenCalledOnce();
+      await custody.resources.release();
+      expect(custody.retired).toHaveBeenCalledOnce();
+    } finally {
+      historyRead.mockRestore();
+      await custody.cleanup();
+    }
+  });
+
+  it.each(["direct", "borrowed"] as const)(
+    "retains %s CLI context-engine custody through queued turn maintenance",
+    async (ownership) => {
+      const custody = createContextEngineCustodyFixture();
+      const engineId = `cli-maintenance-custody-${ownership}`;
+      const maintenanceStarted = createDeferred();
+      const maintenanceGate = createDeferred();
+      const work = new AsyncWorkScope();
+      const { sessionTarget } = fixture.session;
+      const sessionKey = sessionTarget.sessionKey;
+      const releaseForeground = await beginForegroundSessionMaintenance(sessionKey);
+      let lease: Awaited<ReturnType<typeof createContextEngineLogicalTurnLease>> | undefined;
+      class Engine extends LegacyContextEngine {
+        override readonly info: ContextEngine["info"] = {
+          id: engineId,
+          name: "CLI maintenance custody fixture",
+          turnMaintenanceMode: "background",
+        };
+        async maintain() {
+          maintenanceStarted.resolve();
+          await maintenanceGate.promise;
+          expect(custody.read()).toBe(42);
+          return { changed: false, bytesFreed: 0, rewrittenEntries: 0 };
+        }
+        async dispose() {
+          expect(custody.read()).toBe(42);
+        }
+      }
+      registerContextEngineInRegistry(
+        custody.registry,
+        engineId,
+        () => new Engine(),
+        "plugin:fixture",
+      );
+      try {
+        const config = { plugins: { slots: { contextEngine: engineId } } };
+        const context = await work.run(() =>
+          withPluginRuntimeRegistryScope(custody.registry, async () => {
+            if (ownership === "borrowed") {
+              lease = await createContextEngineLogicalTurnLease({
+                identity: { runId: "run-test", sessionId: sessionTarget.sessionId },
+                config,
+              });
+            }
+            return await fixture.prepare({
+              config,
+              sessionKey,
+              contextEngineLogicalTurnLease: lease,
+            });
+          }),
+        );
+        await custody.resources.release();
+        await finalizeCliContextEngineTurn({
+          context,
+          historyMessages: [],
+          assistantText: "synthetic answer",
+          output: { text: "synthetic answer" },
+        });
+        await context.preparedBackend.cleanup?.();
+        expect(custody.retired).not.toHaveBeenCalled();
+        await lease?.dispose();
+        expect(custody.retired).not.toHaveBeenCalled();
+        releaseForeground();
+        await maintenanceStarted.promise;
+        expect(custody.read()).toBe(42);
+        maintenanceGate.resolve();
+        await waitForDeferredTurnMaintenanceForSession(sessionKey);
+        if (lease) {
+          await custody.retirement;
+        }
+        await work.drain();
+        expect(custody.retired).toHaveBeenCalledOnce();
+        expect(() => custody.read()).toThrow();
+      } finally {
+        releaseForeground();
+        maintenanceGate.resolve();
+        await waitForDeferredTurnMaintenanceForSession(sessionKey);
+        await lease?.dispose();
+        if (lease) {
+          await custody.retirement;
+        }
+        await work.drain();
+        await custody.cleanup();
+      }
+    },
+  );
 
   it("does not allocate a non-legacy context engine before fallible CLI preparation finishes", async () => {
     const engineId = `cli-prepare-late-engine-${Date.now().toString(36)}`;

--- a/src/agents/cli-runner/prepare.ts
+++ b/src/agents/cli-runner/prepare.ts
@@ -51,6 +51,7 @@ import {
   parseAgentSessionKey,
 } from "../../routing/session-key.js";
 import { annotateInterSessionPromptText } from "../../sessions/input-provenance.js";
+import { captureAsyncWorkTracker } from "../../shared/async-work-scope.js";
 import { resolveSkillsPrompt } from "../../skills/loading/workspace-skill-prompt.js";
 import { resolveEmbeddedRunSkillEntries } from "../../skills/runtime/embedded-run-entries.js";
 import { resolveReusableWorkspaceSkillSnapshot } from "../../skills/runtime/session-snapshot.js";
@@ -2273,6 +2274,8 @@ async function prepareCliRunContextWithinReadFence(
       capabilities: backendResolved.contextEngineHostCapabilities,
     });
     let resolvedContextEngine;
+    let deferContextEngineDisposalUntil: PreparedCliRunContext["deferContextEngineDisposalUntil"] =
+      params.contextEngineLogicalTurnLease?.deferDisposalUntil;
     if (params.contextEngineLogicalTurnLease) {
       selectContextEngineForTranscriptHost({
         lease: params.contextEngineLogicalTurnLease,
@@ -2289,10 +2292,38 @@ async function prepareCliRunContextWithinReadFence(
       });
       resolvedContextEngine = params.contextEngineLogicalTurnLease.begin().engine;
     } else {
-      resolvedContextEngine = await resolveContextEngine(runConfig, {
+      const trackDisposal = captureAsyncWorkTracker();
+      const ownedEngine = await resolveContextEngine(runConfig, {
         agentDir: contextEngineAgentDir,
         workspaceDir,
       });
+      resolvedContextEngine = ownedEngine;
+      const previousCleanup = cleanupPreparedResources;
+      const disposalHolds = new Set<Promise<void>>();
+      deferContextEngineDisposalUntil = (promise: Promise<void>) => {
+        disposalHolds.add(promise);
+        void promise.finally(() => disposalHolds.delete(promise)).catch(() => {});
+      };
+      cleanupPreparedResources = async () => {
+        try {
+          if (disposalHolds.size > 0) {
+            // Queued maintenance may need this foreground turn to release its lane first.
+            void trackDisposal(async () => {
+              await Promise.allSettled(disposalHolds);
+              await runCliCleanup(params, "cli-context-engine-release", async () => {
+                await ownedEngine.dispose?.();
+              });
+            }).catch((error: unknown) => {
+              cliBackendLog.warn(`CLI context engine cleanup failed: ${String(error)}`);
+            });
+          } else {
+            await ownedEngine.dispose?.();
+          }
+        } finally {
+          await previousCleanup?.();
+        }
+      };
+      preparedBackendFinal.cleanup = cleanupPreparedResources;
     }
     const contextEngine =
       resolvedContextEngine.info.id !== "legacy" ? resolvedContextEngine : undefined;
@@ -2372,6 +2403,7 @@ async function prepareCliRunContextWithinReadFence(
       hadSessionFile,
       contextEngineConfig: runConfig,
       contextEngine,
+      deferContextEngineDisposalUntil,
       contextEngineTurnPrompt,
       ...(promptContext ? { promptContext, promptForHooks } : {}),
       modelId,

--- a/src/agents/cli-runner/types.ts
+++ b/src/agents/cli-runner/types.ts
@@ -389,6 +389,7 @@ export type PreparedCliRunContext = {
   hadSessionFile: boolean;
   contextEngineConfig: OpenClawConfig;
   contextEngine?: ContextEngine;
+  deferContextEngineDisposalUntil?: (promise: Promise<void>) => void;
   contextEngineTurnPrompt?: string;
   promptContext?: CliBackendPromptContext;
   /** Logical model input retained for policy/observation hooks when transport context is separate. */

--- a/src/agents/command/cli-compaction.test.ts
+++ b/src/agents/command/cli-compaction.test.ts
@@ -5,11 +5,20 @@ import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
 import { CURRENT_SESSION_VERSION } from "openclaw/plugin-sdk/agent-sessions";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../test/helpers/promise.js";
 import { replaceSessionEntry } from "../../config/sessions/session-accessor.js";
 import { SESSION_TOTAL_TOKENS_VERSION, type SessionEntry } from "../../config/sessions/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import {
+  registerContextEngineInRegistry,
+  resolveContextEngine as resolveContextEngineFromRegistry,
+} from "../../context-engine/registry.js";
 import type { ContextEngine } from "../../context-engine/types.js";
 import { resolveRuntimeWorkerUrl } from "../../infra/runtime-worker-url.js";
+import { createEmptyPluginRegistry } from "../../plugins/registry-empty.js";
+import { PluginRegistryInspectionResources } from "../../plugins/registry-inspection-resources.js";
+import { retireInspectionInstances } from "../../plugins/registry-inspection.test-support.js";
+import { withPluginRuntimeRegistryScope } from "../../plugins/runtime/gateway-request-scope.js";
 import { withEnv } from "../../test-utils/env.js";
 import { resolveCliBackendConfig } from "../cli-backends.js";
 import { createModelGenerationFixture } from "../embedded-agent-runner/model.generation-scope.test-support.js";
@@ -272,6 +281,166 @@ describe("runCliTurnCompactionLifecycle", () => {
     vi.clearAllTimers();
     vi.useRealTimers();
     await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it.each(["context", "native", "fallback", "failure", "stale"] as const)(
+    "retains one resolved engine through compaction and awaits its cleanup (%s)",
+    async (mode) => {
+      const registry = createEmptyPluginRegistry();
+      const resources = new PluginRegistryInspectionResources(retireInspectionInstances);
+      resources.attach(registry);
+      const retire = vi.fn();
+      resources.register("fixture", { id: "resource", dispose: retire });
+      const cleanupStarted = createDeferred();
+      const cleanupGate = createDeferred();
+      const controller = new AbortController();
+      const staleError = new Error("compaction owner retired");
+      const compactCalls: CompactParams[] = [];
+      const raw = {
+        ...buildContextEngine({ compactCalls }),
+        async dispose() {
+          cleanupStarted.resolve();
+          await cleanupGate.promise;
+          if (mode === "failure") {
+            throw new Error("cleanup failed too");
+          }
+        },
+      };
+      registerContextEngineInRegistry(registry, "legacy", () => raw, "core");
+      let engine: ContextEngine | undefined;
+      const scenario = await prepareCompactionScenario({
+        tmpDir,
+        suffix: `owned-${mode}`,
+        provider: "github-copilot",
+        sessionEntry: mode === "native" || mode === "fallback" ? { agentHarnessId: "copilot" } : {},
+        maintenance: async () => {
+          expect(retire).not.toHaveBeenCalled();
+          if (mode === "failure") {
+            throw new Error("maintenance failed");
+          }
+          return { changed: false, bytesFreed: 0, rewrittenEntries: 0 };
+        },
+        deps: {
+          ensureContextEnginesInitialized: vi.fn(),
+          resolveContextEngine: async (cfg) => {
+            engine = await withPluginRuntimeRegistryScope(registry, () =>
+              resolveContextEngineFromRegistry(cfg),
+            );
+            if (mode === "stale") {
+              controller.abort(staleError);
+            }
+            return engine;
+          },
+          maybeCompactAgentHarnessSession: async () => {
+            expect(retire).not.toHaveBeenCalled();
+            return mode === "fallback"
+              ? {
+                  ok: false,
+                  compacted: false,
+                  reason: "unsupported",
+                  failure: { reason: "unsupported_harness_compaction" },
+                }
+              : { ok: true, compacted: true };
+          },
+        },
+      });
+      const result = scenario.run({ abortSignal: controller.signal }).then(
+        () => undefined,
+        (error: unknown) => error,
+      );
+      try {
+        expect(
+          await Promise.race([
+            cleanupStarted.promise.then(() => "cleanup"),
+            result.then(() => "returned"),
+          ]),
+        ).toBe("cleanup");
+        await resources.release();
+        expect(retire).not.toHaveBeenCalled();
+        cleanupGate.resolve();
+        const error = await result;
+        if (mode === "failure") {
+          expect(error).toEqual(new Error("maintenance failed"));
+        } else {
+          expect(error).toBe(mode === "stale" ? staleError : undefined);
+        }
+        expect(compactCalls).toHaveLength(mode === "native" || mode === "stale" ? 0 : 1);
+        expect(retire).toHaveBeenCalledTimes(1);
+      } finally {
+        cleanupGate.resolve();
+        await result;
+        await engine?.dispose?.().catch(() => {});
+        await resources.release();
+      }
+    },
+  );
+
+  it("retains an aborted compaction engine until its raw work and cleanup settle", async () => {
+    const registry = createEmptyPluginRegistry();
+    const resources = new PluginRegistryInspectionResources(retireInspectionInstances);
+    resources.attach(registry);
+    const retired = createDeferred();
+    const retire = vi.fn(() => retired.resolve());
+    resources.register("fixture", { id: "resource", dispose: retire });
+    const compactStarted = createDeferred();
+    const compactGate = createDeferred();
+    const cleanupStarted = createDeferred();
+    const cleanupGate = createDeferred();
+    const dispose = vi.fn(async () => {
+      cleanupStarted.resolve();
+      await cleanupGate.promise;
+    });
+    const engine = {
+      ...buildContextEngine({ compactCalls: [] }),
+      async compact() {
+        compactStarted.resolve();
+        await compactGate.promise;
+        expect(retire).not.toHaveBeenCalled();
+        return { ok: false, compacted: false, reason: "aborted" };
+      },
+      dispose,
+    };
+    registerContextEngineInRegistry(registry, "legacy", () => engine, "core");
+    let owned: ContextEngine | undefined;
+    const scenario = await prepareCompactionScenario({
+      tmpDir,
+      suffix: "owned-abort-tail",
+      deps: {
+        ensureContextEnginesInitialized: vi.fn(),
+        resolveContextEngine: async (cfg) => {
+          owned = await withPluginRuntimeRegistryScope(registry, () =>
+            resolveContextEngineFromRegistry(cfg),
+          );
+          return owned;
+        },
+      },
+    });
+    const controller = new AbortController();
+    const result = scenario
+      .run({ abortSignal: controller.signal })
+      .catch((error: unknown) => error);
+    try {
+      await compactStarted.promise;
+      controller.abort(new Error("compaction cancelled"));
+      expect(await result).toEqual(
+        expect.objectContaining({ message: expect.stringContaining("compaction cancelled") }),
+      );
+      await resources.release();
+      expect(dispose).not.toHaveBeenCalled();
+      expect(retire).not.toHaveBeenCalled();
+      compactGate.resolve();
+      await cleanupStarted.promise;
+      expect(retire).not.toHaveBeenCalled();
+      cleanupGate.resolve();
+      await retired.promise;
+      expect(retire).toHaveBeenCalledTimes(1);
+    } finally {
+      compactGate.resolve();
+      cleanupGate.resolve();
+      await result;
+      await owned?.dispose?.();
+      await resources.release();
+    }
   });
 
   it("ignores an unversioned fresh total on the first upgraded turn", async () => {

--- a/src/agents/command/cli-compaction.ts
+++ b/src/agents/command/cli-compaction.ts
@@ -18,6 +18,7 @@ import { buildContextEngineRuntimeSettings } from "../../context-engine/runtime-
 import type { ContextEngine } from "../../context-engine/types.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { withPluginRuntimeGenerationScope } from "../../plugins/runtime/generation-scope.js";
+import { AsyncWorkScope, captureAsyncWorkTracker } from "../../shared/async-work-scope.js";
 import type { SkillSnapshot } from "../../skills/types.js";
 import { createPreparedEmbeddedAgentSettingsManager as createPreparedEmbeddedAgentSettingsManagerImpl } from "../agent-project-settings.js";
 import { OPENCLAW_AGENT_RUNTIME_ID, normalizeOptionalAgentRuntimeId } from "../agent-runtime-id.js";
@@ -605,15 +606,16 @@ export async function runCliTurnCompactionLifecycle(
   },
   host: QueuedCompactionHostOptions = {},
 ): Promise<SessionEntry | undefined> {
+  const storePath = params.storePath;
   const contextTokenBudget = normalizeSessionTokenCount(params.sessionEntry?.contextTokens);
-  if (!params.storePath || !contextTokenBudget) {
+  if (!storePath || !contextTokenBudget) {
     return params.sessionEntry;
   }
 
   const capturedEntry = loadSessionEntryReadOnly({
     agentId: params.sessionAgentId,
     sessionKey: params.sessionKey,
-    storePath: params.storePath,
+    storePath,
     readConsistency: "latest",
   });
   const expectedEntry = {
@@ -636,7 +638,7 @@ export async function runCliTurnCompactionLifecycle(
     agentId: params.sessionAgentId,
     sessionId: params.sessionId,
     sessionKey: params.sessionKey,
-    storePath: params.storePath,
+    storePath,
   });
   const sessionFile = params.sessionKey;
   const settingsManager = await cliCompactionDeps.createPreparedEmbeddedAgentSettingsManager({
@@ -707,130 +709,164 @@ export async function runCliTurnCompactionLifecycle(
     });
   };
 
-  if (isNativeHarnessCompactionSession(params.sessionEntry, params.provider)) {
-    cliCompactionDeps.ensureContextEnginesInitialized();
-    resolvedContextEngine = await cliCompactionDeps.resolveContextEngine(params.cfg);
-    await applyAutoCompactionGuard(resolvedContextEngine);
-    const nativeOutcome = await compactNativeHarnessCliTranscript({
-      cfg: params.cfg,
-      sessionId: params.sessionId,
-      sessionKey: params.sessionKey,
-      sessionFile,
-      sessionEntry: params.sessionEntry,
-      workspaceDir: params.workspaceDir,
-      cwd: params.cwd,
-      agentDir: params.agentDir,
-      provider: params.provider,
-      model: params.model,
-      contextTokenBudget,
-      currentTokenCount,
-      contextEngine: resolvedContextEngine,
-      skillsSnapshot: params.skillsSnapshot,
-      messageChannel: params.messageChannel,
-      agentAccountId: params.agentAccountId,
-      senderIsOwner: params.senderIsOwner,
-      thinkLevel: params.thinkLevel,
-      extraSystemPrompt: params.extraSystemPrompt,
-      pluginGeneration: params.pluginGeneration,
-      abortSignal: params.abortSignal,
-      assertActive,
-    });
-    if (nativeOutcome.compacted) {
-      compactionKind = "native-harness";
-      nativeCompactionResult = nativeOutcome.result;
-      useContextEngineCompaction = false;
-    } else if (nativeOutcome.fallbackToContextEngine) {
-      // Unlocked sessions may repair or replace a stale native compaction path.
-      nativeFallbackToContextEngine = true;
-      nativeFallbackNeedsBindingClear = nativeOutcome.clearCliSessionBinding === true;
-    } else if (nativeOutcome.failureReason) {
-      throw new Error(
-        `CLI native harness compaction failed for ${params.provider}/${params.model}: ${nativeOutcome.failureReason}`,
-      );
-    } else {
-      useContextEngineCompaction = false;
-    }
-  }
+  const work = new AsyncWorkScope();
+  const trackCleanup = captureAsyncWorkTracker();
+  let result: SessionEntry | undefined;
+  let failure: { error: unknown } | undefined;
+  try {
+    result = await work.run(async () => {
+      if (isNativeHarnessCompactionSession(params.sessionEntry, params.provider)) {
+        cliCompactionDeps.ensureContextEnginesInitialized();
+        resolvedContextEngine = await cliCompactionDeps.resolveContextEngine(params.cfg);
+        await applyAutoCompactionGuard(resolvedContextEngine);
+        const nativeOutcome = await compactNativeHarnessCliTranscript({
+          cfg: params.cfg,
+          sessionId: params.sessionId,
+          sessionKey: params.sessionKey,
+          sessionFile,
+          sessionEntry: params.sessionEntry,
+          workspaceDir: params.workspaceDir,
+          cwd: params.cwd,
+          agentDir: params.agentDir,
+          provider: params.provider,
+          model: params.model,
+          contextTokenBudget,
+          currentTokenCount,
+          contextEngine: resolvedContextEngine,
+          skillsSnapshot: params.skillsSnapshot,
+          messageChannel: params.messageChannel,
+          agentAccountId: params.agentAccountId,
+          senderIsOwner: params.senderIsOwner,
+          thinkLevel: params.thinkLevel,
+          extraSystemPrompt: params.extraSystemPrompt,
+          pluginGeneration: params.pluginGeneration,
+          abortSignal: params.abortSignal,
+          assertActive,
+        });
+        if (nativeOutcome.compacted) {
+          compactionKind = "native-harness";
+          nativeCompactionResult = nativeOutcome.result;
+          useContextEngineCompaction = false;
+        } else if (nativeOutcome.fallbackToContextEngine) {
+          // Unlocked sessions may repair or replace a stale native compaction path.
+          nativeFallbackToContextEngine = true;
+          nativeFallbackNeedsBindingClear = nativeOutcome.clearCliSessionBinding === true;
+        } else if (nativeOutcome.failureReason) {
+          throw new Error(
+            `CLI native harness compaction failed for ${params.provider}/${params.model}: ${nativeOutcome.failureReason}`,
+          );
+        } else {
+          useContextEngineCompaction = false;
+        }
+      }
 
-  if (useContextEngineCompaction) {
-    assertActive();
-    if (!resolvedContextEngine) {
-      cliCompactionDeps.ensureContextEnginesInitialized();
-      resolvedContextEngine = await cliCompactionDeps.resolveContextEngine(params.cfg);
-    }
-    const contextEngine = resolvedContextEngine;
-    await applyAutoCompactionGuard(contextEngine);
+      if (useContextEngineCompaction) {
+        assertActive();
+        if (!resolvedContextEngine) {
+          cliCompactionDeps.ensureContextEnginesInitialized();
+          resolvedContextEngine = await cliCompactionDeps.resolveContextEngine(params.cfg);
+        }
+        const contextEngine = resolvedContextEngine;
+        await applyAutoCompactionGuard(contextEngine);
 
-    const contextOutcome = await compactCliTranscript({
-      agentId: params.sessionAgentId,
-      contextEngine,
-      sessionId: params.sessionId,
-      sessionKey: params.sessionKey,
-      sessionFile,
-      sessionManager,
-      storePath: params.storePath,
-      cfg: params.cfg,
-      workspaceDir: params.workspaceDir,
-      cwd: params.cwd,
-      agentDir: params.agentDir,
-      provider: params.provider,
-      model: params.model,
-      harnessRuntime: params.sessionEntry?.agentHarnessId,
-      modelSelectionLocked: params.sessionEntry?.modelSelectionLocked,
-      contextTokenBudget,
-      currentTokenCount,
-      skillsSnapshot: params.skillsSnapshot,
-      messageChannel: params.messageChannel,
-      agentAccountId: params.agentAccountId,
-      authProfileId,
-      senderIsOwner: params.senderIsOwner,
-      thinkLevel: params.thinkLevel,
-      extraSystemPrompt: params.extraSystemPrompt,
-      bestEffortMaintenance: nativeFallbackToContextEngine,
-      expectedEntry,
-      assertActive,
-      abortSignal: params.abortSignal,
-      onCommitted,
-    });
-    contextCompactionOutcome = contextOutcome;
-    compactionKind = contextOutcome.compacted ? "context-engine" : undefined;
-    if (!compactionKind && contextOutcome.failureReason) {
-      throw new Error(
-        `CLI transcript compaction failed for ${params.provider}/${params.model}: ${contextOutcome.failureReason}`,
-      );
-    }
-  }
+        const contextOutcome = await compactCliTranscript({
+          agentId: params.sessionAgentId,
+          contextEngine,
+          sessionId: params.sessionId,
+          sessionKey: params.sessionKey,
+          sessionFile,
+          sessionManager,
+          storePath,
+          cfg: params.cfg,
+          workspaceDir: params.workspaceDir,
+          cwd: params.cwd,
+          agentDir: params.agentDir,
+          provider: params.provider,
+          model: params.model,
+          harnessRuntime: params.sessionEntry?.agentHarnessId,
+          modelSelectionLocked: params.sessionEntry?.modelSelectionLocked,
+          contextTokenBudget,
+          currentTokenCount,
+          skillsSnapshot: params.skillsSnapshot,
+          messageChannel: params.messageChannel,
+          agentAccountId: params.agentAccountId,
+          authProfileId,
+          senderIsOwner: params.senderIsOwner,
+          thinkLevel: params.thinkLevel,
+          extraSystemPrompt: params.extraSystemPrompt,
+          bestEffortMaintenance: nativeFallbackToContextEngine,
+          expectedEntry,
+          assertActive,
+          abortSignal: params.abortSignal,
+          onCommitted,
+        });
+        contextCompactionOutcome = contextOutcome;
+        compactionKind = contextOutcome.compacted ? "context-engine" : undefined;
+        if (!compactionKind && contextOutcome.failureReason) {
+          throw new Error(
+            `CLI transcript compaction failed for ${params.provider}/${params.model}: ${contextOutcome.failureReason}`,
+          );
+        }
+      }
 
-  if (nativeFallbackNeedsBindingClear && !compactionKind && params.sessionStore) {
-    assertActive();
-    return (
-      (await cliCompactionDeps.clearCliSessionInStore({
-        provider: params.provider,
+      if (nativeFallbackNeedsBindingClear && !compactionKind && params.sessionStore) {
+        assertActive();
+        return (
+          (await cliCompactionDeps.clearCliSessionInStore({
+            provider: params.provider,
+            sessionKey: params.sessionKey,
+            sessionStore: params.sessionStore,
+            storePath,
+            expectedSessionId: params.sessionId,
+            assertCommitAllowed: assertActive,
+          })) ?? params.sessionEntry
+        );
+      }
+
+      if (!compactionKind || !params.sessionStore) {
+        return params.sessionEntry;
+      }
+
+      const recorded = await cliCompactionDeps.recordCliCompactionInStore({
+        compactionKind,
         sessionKey: params.sessionKey,
         sessionStore: params.sessionStore,
-        storePath: params.storePath,
-        expectedSessionId: params.sessionId,
-        assertCommitAllowed: assertActive,
-      })) ?? params.sessionEntry
+        storePath,
+        tokensAfter:
+          nativeCompactionResult?.result?.tokensAfter ?? contextCompactionOutcome?.tokensAfter,
+        expectedSession: contextCompactionOutcome?.accepted?.entry ?? expectedEntry,
+      });
+      if (!recorded) {
+        throw new Error("Session changed before CLI compaction could be recorded");
+      }
+      return recorded;
+    });
+  } catch (error) {
+    failure = { error };
+  }
+  const cleanup = async () => {
+    await AsyncWorkScope.runWhenAllIdle(
+      () => [work],
+      () => work.run(() => work.drain()),
     );
+    await resolvedContextEngine?.dispose?.();
+  };
+  if (work.hasPendingWork) {
+    // A timeout can return before raw compaction settles. Its owner retains
+    // the engine until that work finishes without extending the watchdog.
+    void trackCleanup(cleanup).catch((error: unknown) => {
+      log.warn(`CLI compaction engine cleanup failed: ${String(error)}`);
+    });
+  } else {
+    try {
+      await cleanup();
+    } catch (error) {
+      failure ??= { error };
+    }
   }
-
-  if (!compactionKind || !params.sessionStore) {
-    return params.sessionEntry;
+  if (failure) {
+    throw failure.error;
   }
-
-  const recorded = await cliCompactionDeps.recordCliCompactionInStore({
-    compactionKind,
-    sessionKey: params.sessionKey,
-    sessionStore: params.sessionStore,
-    storePath: params.storePath,
-    tokensAfter:
-      nativeCompactionResult?.result?.tokensAfter ?? contextCompactionOutcome?.tokensAfter,
-    expectedSession: contextCompactionOutcome?.accepted?.entry ?? expectedEntry,
-  });
-  if (!recorded) {
-    throw new Error("Session changed before CLI compaction could be recorded");
-  }
-  return recorded;
+  return result;
 }
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/agents/subagents/registry/subagent-control-kill.ts
+++ b/src/agents/subagents/registry/subagent-control-kill.ts
@@ -227,6 +227,7 @@ async function withSubagentKillScope<T>(
       tree.errors.add(formatErrorMessage(error));
     }
   };
+  let outcome: { ok: true; value: T } | { ok: false; error: unknown };
   try {
     const trees: KillTree[] = [];
     select(params.runs, trees, params.controller, undefined, params.ownsRoot);
@@ -250,11 +251,21 @@ async function withSubagentKillScope<T>(
     };
     scope.refresh();
     const result = await run(scope, trees);
-    return publish ? publish(result, trees) : result;
-  } finally {
-    holds.forEach((reservation) => reservation.release());
-    releaseRetirements.forEach((release) => release());
+    outcome = { ok: true, value: publish ? publish(result, trees) : result };
+  } catch (error) {
+    outcome = { ok: false, error };
   }
+  const released = await Promise.allSettled(holds.map((reservation) => reservation.release()));
+  const retired = await Promise.allSettled(releaseRetirements.map(async (release) => release()));
+  if (!outcome.ok) {
+    throw outcome.error;
+  }
+  for (const result of [...released, ...retired]) {
+    if (result.status === "rejected") {
+      throw result.reason;
+    }
+  }
+  return outcome.value;
 }
 
 async function killLatestSubagentRun(params: {

--- a/src/agents/subagents/registry/subagent-control.concurrency.test.ts
+++ b/src/agents/subagents/registry/subagent-control.concurrency.test.ts
@@ -50,6 +50,8 @@ it.each(["bulk", "admin"] as const)(
       });
     }
     const start = vi.fn(async () => {});
+    const cleanupGate = createDeferred();
+    const removed = vi.fn(async () => await cleanupGate.promise);
     for (const runId of queued) {
       enqueueSwarmRun({
         groupId: "sibling-cancellation",
@@ -58,6 +60,7 @@ it.each(["bulk", "admin"] as const)(
         activeRunIds: running,
         start,
         onStartFailure: () => true,
+        onRemoved: removed,
       });
     }
     const interrupted: string[] = [];
@@ -85,7 +88,8 @@ it.each(["bulk", "admin"] as const)(
       );
     }
     const cfg = getRuntimeConfig();
-    const pending =
+    let settled = false;
+    const pending = (
       boundary === "admin"
         ? killSubagentRunAdmin({ cfg, sessionKey: owner, expectedRunId: "root" })
         : killAllControlledSubagentRuns({
@@ -98,7 +102,10 @@ it.each(["bulk", "admin"] as const)(
               controlScope: "children",
             },
             runs: selected.map((id) => subagentRuns.get(id)!),
-          });
+          })
+    ).finally(() => {
+      settled = true;
+    });
     try {
       await firstInterrupted.promise;
       await vi.waitFor(() => expect(interrupted.toSorted()).toEqual(running));
@@ -107,6 +114,12 @@ it.each(["bulk", "admin"] as const)(
       for (const lease of leases.toReversed()) {
         lease.release();
       }
+      await vi.waitFor(() => expect(removed).toHaveBeenCalledTimes(queued.length));
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
+      expect(settled).toBe(false);
+      cleanupGate.resolve();
       const result = await pending;
       expect(result).toMatchObject(
         boundary === "admin"
@@ -118,6 +131,7 @@ it.each(["bulk", "admin"] as const)(
       }
       expect(start).not.toHaveBeenCalled();
     } finally {
+      cleanupGate.resolve();
       for (const lease of leases) {
         lease.release();
       }

--- a/src/agents/subagents/registry/subagent-registry-context-cleanup.test.ts
+++ b/src/agents/subagents/registry/subagent-registry-context-cleanup.test.ts
@@ -1,4 +1,14 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../../test/helpers/promise.js";
+import { LegacyContextEngine } from "../../../context-engine/legacy.js";
+import {
+  registerContextEngineInRegistry,
+  resolveContextEngine,
+} from "../../../context-engine/registry.js";
+import type { ContextEngine } from "../../../context-engine/types.js";
+import { createEmptyPluginRegistry } from "../../../plugins/registry-empty.js";
+import { PluginRegistryInspectionResources } from "../../../plugins/registry-inspection-resources.js";
+import { retireInspectionInstances } from "../../../plugins/registry-inspection.test-support.js";
 import { createSubagentRunRecord } from "../../subagent-test-fixtures.test-helpers.js";
 import { createSubagentRegistryContextCleanup } from "./subagent-registry-context-cleanup.js";
 import {
@@ -12,6 +22,91 @@ describe("subagent registry context cleanup", () => {
     setSubagentRegistryDepsForTest();
     resetSubagentRegistryRuntimeLoadersForTests();
   });
+
+  it.each(["success", "hook-error", "stale", "absent"] as const)(
+    "retires resolved engine resources after ended-hook work (%s)",
+    async (mode) => {
+      const registry = createEmptyPluginRegistry();
+      const resources = new PluginRegistryInspectionResources(retireInspectionInstances);
+      resources.attach(registry);
+      const retire = vi.fn();
+      resources.register("fixture", { id: "resource", dispose: retire });
+      const resolutionStarted = createDeferred();
+      const resolutionGate = createDeferred();
+      const cleanupStarted = createDeferred();
+      const cleanupGate = createDeferred();
+      const hookError = new Error("ended hook failed");
+      const cleanupError = new Error("engine cleanup failed");
+      const onSubagentEnded = vi.fn(async () => {
+        expect(retire).not.toHaveBeenCalled();
+        if (mode === "hook-error") {
+          throw hookError;
+        }
+      });
+      const raw = Object.assign(new LegacyContextEngine(), {
+        ...(mode === "absent" ? {} : { onSubagentEnded }),
+        async dispose() {
+          cleanupStarted.resolve();
+          await cleanupGate.promise;
+          if (mode === "hook-error") {
+            throw cleanupError;
+          }
+        },
+      });
+      registerContextEngineInRegistry(registry, "legacy", () => raw, "core");
+      let engine: ContextEngine | undefined;
+      let current = true;
+      setSubagentRegistryDepsForTest({
+        getRuntimeConfig: () => ({}),
+        loadAgentRuntimePluginRegistryHandle: () => registry,
+        ensureContextEnginesInitialized: vi.fn(),
+        resolveContextEngine: async (cfg, options) => {
+          engine = await resolveContextEngine(cfg, options);
+          resolutionStarted.resolve();
+          await resolutionGate.promise;
+          return engine;
+        },
+      });
+      const cleanup = createSubagentRegistryContextCleanup({
+        deps: () => subagentRegistryDeps,
+        persist: vi.fn(),
+        warn: vi.fn(),
+      });
+      const pending = cleanup.runContextEngineSubagentEnded(
+        { childSessionKey: "agent:main:subagent:owned", reason: "completed" },
+        { isCurrent: () => current },
+      );
+      const result = pending.then(
+        () => undefined,
+        (error: unknown) => error,
+      );
+      try {
+        await resolutionStarted.promise;
+        current = mode !== "stale";
+        resolutionGate.resolve();
+        expect(
+          await Promise.race([
+            cleanupStarted.promise.then(() => "cleanup"),
+            result.then(() => "returned"),
+          ]),
+        ).toBe("cleanup");
+        await resources.release();
+        expect(retire).not.toHaveBeenCalled();
+        cleanupGate.resolve();
+        expect(await result).toBe(mode === "hook-error" ? hookError : undefined);
+        expect(onSubagentEnded).toHaveBeenCalledTimes(
+          mode === "stale" || mode === "absent" ? 0 : 1,
+        );
+        expect(retire).toHaveBeenCalledTimes(1);
+      } finally {
+        resolutionGate.resolve();
+        cleanupGate.resolve();
+        await result;
+        await engine?.dispose?.().catch(() => {});
+        await resources.release();
+      }
+    },
+  );
 
   it("completes ended-hook cleanup when the plugin runtime loader rejects", async () => {
     const error = new Error("plugin runtime import failed");
@@ -38,46 +133,5 @@ describe("subagent registry context cleanup", () => {
     });
     expect(entry.endedHookEmittedAt).toBeUndefined();
     expect(persist).not.toHaveBeenCalled();
-  });
-
-  it("rechecks lifecycle ownership after resolving the context engine", async () => {
-    let releaseResolution!: () => void;
-    const resolutionGate = new Promise<void>((resolve) => {
-      releaseResolution = resolve;
-    });
-    let resolutionStarted!: () => void;
-    const started = new Promise<void>((resolve) => {
-      resolutionStarted = resolve;
-    });
-    const onSubagentEnded = vi.fn(async () => {});
-    setSubagentRegistryDepsForTest({
-      loadAgentRuntimePluginRegistryHandle: () => undefined,
-      ensureContextEnginesInitialized: vi.fn(),
-      resolveContextEngine: vi.fn(async () => {
-        resolutionStarted();
-        await resolutionGate;
-        return { onSubagentEnded } as never;
-      }),
-    });
-    const cleanup = createSubagentRegistryContextCleanup({
-      deps: () => ({ getRuntimeConfig: () => ({}) }) as never,
-      persist: vi.fn(),
-      warn: vi.fn(),
-    });
-    let current = true;
-
-    const pending = cleanup.notifyContextEngineSubagentEnded(
-      {
-        childSessionKey: "agent:main:subagent:retired",
-        reason: "completed",
-      },
-      { isCurrent: () => current },
-    );
-    await started;
-    current = false;
-    releaseResolution();
-    await pending;
-
-    expect(onSubagentEnded).not.toHaveBeenCalled();
   });
 });

--- a/src/agents/subagents/registry/subagent-registry-context-cleanup.ts
+++ b/src/agents/subagents/registry/subagent-registry-context-cleanup.ts
@@ -44,10 +44,22 @@ export function createSubagentRegistryContextCleanup(config: {
         agentDir: params.agentDir,
         workspaceDir: params.workspaceDir,
       });
-      if (options?.isCurrent?.() === false) {
-        return;
+      let failure: { error: unknown } | undefined;
+      try {
+        if (options?.isCurrent?.() !== false) {
+          await engine.onSubagentEnded?.(params);
+        }
+      } catch (error) {
+        failure = { error };
       }
-      await engine.onSubagentEnded?.(params);
+      try {
+        await engine.dispose?.();
+      } catch (error) {
+        failure ??= { error };
+      }
+      if (failure) {
+        throw failure.error;
+      }
     });
   }
 

--- a/src/agents/subagents/spawn/subagent-spawn-context.ts
+++ b/src/agents/subagents/spawn/subagent-spawn-context.ts
@@ -1,8 +1,9 @@
 import { finiteSecondsToTimerSafeMilliseconds } from "@openclaw/normalization-core/number-coercion";
+import { sanitizeForLog } from "../../../../packages/terminal-core/src/ansi.js";
 import { resolveThreadBindingSpawnPolicy } from "../../../channels/thread-bindings-policy.js";
 import type { SessionEntry } from "../../../config/sessions/types.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
-import type { SubagentSpawnPreparation } from "../../../context-engine/types.js";
+import type { ContextEngine, SubagentSpawnPreparation } from "../../../context-engine/types.js";
 import { summarizeSpawnError } from "../../spawn-pipeline.js";
 import { getSubagentSpawnDeps } from "./subagent-spawn-deps.js";
 import { resolveGatewaySessionStoreTarget } from "./subagent-spawn.runtime.js";
@@ -102,6 +103,10 @@ export async function prepareSubagentSessionContext(params: {
   }
 }
 
+export type PreparedContextEngineSubagentSpawn = SubagentSpawnPreparation & {
+  dispose(): Promise<void>;
+};
+
 export async function prepareContextEngineSubagentSpawn(params: {
   assertActive?: () => void;
   cfg: OpenClawConfig;
@@ -110,12 +115,26 @@ export async function prepareContextEngineSubagentSpawn(params: {
   childSessionKey: string;
   runTimeoutSeconds: number;
 }): Promise<
-  { status: "ok"; preparation?: SubagentSpawnPreparation } | { status: "error"; error: string }
+  | { status: "ok"; preparation: PreparedContextEngineSubagentSpawn }
+  | { status: "error"; error: string }
 > {
+  let engine: ContextEngine | undefined;
+  let disposal: Promise<void> | undefined;
+  const dispose = () =>
+    (disposal ??= (async () => {
+      try {
+        await engine?.dispose?.();
+      } catch (error) {
+        console.warn(
+          `[context-engine] Failed subagent preparation cleanup: ${sanitizeForLog(String(error))}`,
+        );
+        throw error;
+      }
+    })());
   try {
     const deps = getSubagentSpawnDeps();
     deps.ensureContextEnginesInitialized();
-    const engine = await deps.resolveContextEngine(params.cfg);
+    engine = await deps.resolveContextEngine(params.cfg);
     // Resolution may outlive the caller. Returned preparation must still reach
     // the pipeline rollback owner before its next authority check.
     params.assertActive?.();
@@ -132,8 +151,27 @@ export async function prepareContextEngineSubagentSpawn(params: {
         floorSeconds: true,
       }),
     });
-    return { status: "ok", preparation };
+    let rollback: Promise<void> | undefined;
+    return {
+      status: "ok",
+      preparation: {
+        rollback: () =>
+          (rollback ??= (async () => {
+            try {
+              await preparation?.rollback();
+            } finally {
+              await dispose();
+            }
+          })()),
+        async dispose() {
+          // Cancellation may already be rolling back while its caller unwinds.
+          await rollback?.catch(() => {});
+          await dispose().catch(() => {});
+        },
+      },
+    };
   } catch (err) {
+    await dispose().catch(() => {});
     return {
       status: "error",
       error: `Context engine subagent preparation failed: ${summarizeSpawnError(err)}`,

--- a/src/agents/subagents/spawn/subagent-spawn.context-resources.test.ts
+++ b/src/agents/subagents/spawn/subagent-spawn.context-resources.test.ts
@@ -1,0 +1,414 @@
+import { DatabaseSync } from "node:sqlite";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../../test/helpers/promise.js";
+import { LegacyContextEngine } from "../../../context-engine/legacy.js";
+import {
+  registerContextEngineInRegistry,
+  resolveContextEngine,
+} from "../../../context-engine/registry.js";
+import type { ContextEngine } from "../../../context-engine/types.js";
+import { createEmptyPluginRegistry } from "../../../plugins/registry-empty.js";
+import { PluginRegistryInspectionResources } from "../../../plugins/registry-inspection-resources.js";
+import { retireInspectionInstances } from "../../../plugins/registry-inspection.test-support.js";
+import { withPluginRuntimeRegistryScope } from "../../../plugins/runtime/gateway-request-scope.js";
+import { AsyncWorkScope } from "../../../shared/async-work-scope.js";
+import {
+  loadSubagentSpawnModuleForTest,
+  createSubagentSpawnTestConfig,
+} from "./subagent-spawn.test-helpers.js";
+
+function createEngineFixture(
+  prepare?: ContextEngine["prepareSubagentSpawn"],
+  dispose?: () => Promise<void>,
+) {
+  const registry = createEmptyPluginRegistry();
+  const resources = new PluginRegistryInspectionResources(retireInspectionInstances);
+  resources.attach(registry);
+  const database = new DatabaseSync(":memory:");
+  const read = () => expect(database.prepare("SELECT 42 AS value").get()?.value).toBe(42);
+  const retired = vi.fn(() => database.close());
+  resources.register("fixture", { id: "native", dispose: retired });
+  const engineDisposal = vi.fn(async () => {
+    read();
+    await dispose?.();
+  });
+  const raw: ContextEngine = Object.assign(new LegacyContextEngine(), {
+    prepareSubagentSpawn: prepare,
+    dispose: engineDisposal,
+  });
+  registerContextEngineInRegistry(registry, "legacy", () => raw, "core");
+  let engine: ContextEngine | undefined;
+  return {
+    database,
+    read,
+    retired,
+    engineDisposal,
+    async resolve() {
+      engine = await withPluginRuntimeRegistryScope(registry, () => resolveContextEngine());
+      // The spawn now owns the only remaining physical claim.
+      await resources.release();
+      return engine;
+    },
+    async cleanup() {
+      await engine?.dispose?.().catch(() => {});
+      await resources.release();
+    },
+  };
+}
+
+describe("spawn context-engine resource custody", () => {
+  const callGateway = vi.fn();
+  const resolveEngine = vi.fn();
+  const completeLaunchCleanup = vi.fn();
+  const settleLaunchFailure = vi.fn();
+  const registerRun = vi.fn();
+  const config = createSubagentSpawnTestConfig(undefined, {
+    tools: { swarm: { enabled: true, maxConcurrent: 1 } },
+  });
+  let spawn: typeof import("./subagent-spawn.js").spawnSubagentDirect;
+  let scheduler: typeof import("../swarm/swarm-scheduler.js");
+  let resetScheduler: () => void;
+  let GatewayDrainingError: typeof import("../../../process/gateway-work-admission.js").GatewayDrainingError;
+
+  beforeAll(async () => {
+    ({ spawnSubagentDirect: spawn } = await loadSubagentSpawnModuleForTest({
+      callGatewayMock: callGateway,
+      resolveContextEngineMock: resolveEngine,
+      ensureContextEnginesInitializedMock: () => {},
+      completeCollectorLaunchCleanupMock: completeLaunchCleanup,
+      settleFailedQueuedSubagentLaunchMock: settleLaunchFailure,
+      registerSubagentRunMock: registerRun,
+      getRuntimeConfig: () => config,
+    }));
+    scheduler = await import("../swarm/swarm-scheduler.js");
+    ({
+      testing: { reset: resetScheduler },
+    } = await import("../swarm/swarm-scheduler.test-support.js"));
+    ({ GatewayDrainingError } = await import("../../../process/gateway-work-admission.js"));
+  });
+
+  beforeEach(() => {
+    callGateway
+      .mockReset()
+      .mockImplementation(async (request: { method?: string; params?: Record<string, unknown> }) =>
+        request.method === "agent"
+          ? { runId: request.params?.idempotencyKey, status: "accepted" }
+          : { ok: true },
+      );
+    resolveEngine.mockReset();
+    completeLaunchCleanup.mockReset();
+    settleLaunchFailure.mockReset();
+    registerRun.mockReset();
+    resetScheduler();
+    vi.stubEnv("OPENCLAW_TEST_FAST", "1");
+  });
+
+  afterEach(() => {
+    resetScheduler();
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  it.each([
+    "success",
+    "absent-hook",
+    "prepare-failure",
+    "stale-resolution",
+    "dispatch-failure",
+    "rollback-failure",
+  ] as const)("retires the resolved engine after %s", async (mode) => {
+    let current = true;
+    const resolved = createDeferred();
+    const resolutionGate = createDeferred();
+    const rollback = vi.fn(async () => {
+      fixture.read();
+      if (mode === "rollback-failure") {
+        throw new Error("rollback failed");
+      }
+    });
+    const fixture = createEngineFixture(
+      mode === "absent-hook"
+        ? undefined
+        : async () => {
+            fixture.read();
+            if (mode === "prepare-failure") {
+              throw new Error("preparation failed");
+            }
+            return { rollback };
+          },
+    );
+    resolveEngine.mockImplementation(async () => {
+      const engine = await fixture.resolve();
+      resolved.resolve();
+      if (mode === "stale-resolution") {
+        await resolutionGate.promise;
+      }
+      return engine;
+    });
+    callGateway.mockImplementation(async (request: { method?: string }) => {
+      if (request.method === "agent") {
+        fixture.read();
+        if (mode === "dispatch-failure" || mode === "rollback-failure") {
+          throw new Error("launch failed");
+        }
+        return { runId: "child", status: "accepted" };
+      }
+      return { ok: true };
+    });
+    const operation = spawn(
+      { task: "synthetic child" },
+      {
+        agentSessionKey: "main",
+        assertActive() {
+          if (!current) {
+            throw new Error("parent closed");
+          }
+        },
+      },
+    );
+    try {
+      await resolved.promise;
+      if (mode === "stale-resolution") {
+        current = false;
+      }
+      resolutionGate.resolve();
+      const result = await operation;
+      expect(result.status).toBe(
+        mode === "success" || mode === "absent-hook" ? "accepted" : "error",
+      );
+      if (mode === "dispatch-failure" || mode === "rollback-failure") {
+        expect(result.error).toBe("launch failed");
+        expect(rollback).toHaveBeenCalledTimes(1);
+      }
+      expect(fixture.retired).toHaveBeenCalledTimes(1);
+      expect(fixture.engineDisposal).toHaveBeenCalledTimes(1);
+      expect(fixture.database.isOpen).toBe(false);
+    } finally {
+      resolutionGate.resolve();
+      await operation;
+      await fixture.cleanup();
+    }
+  });
+
+  it.each(["success", "failure"] as const)(
+    "awaits asynchronous disposal without replacing %s",
+    async (mode) => {
+      const disposalStarted = createDeferred();
+      const disposalGate = createDeferred();
+      const fixture = createEngineFixture(undefined, async () => {
+        disposalStarted.resolve();
+        await disposalGate.promise;
+        if (mode === "failure") {
+          throw new Error("cleanup failed");
+        }
+      });
+      resolveEngine.mockImplementation(() => fixture.resolve());
+      if (mode === "failure") {
+        callGateway.mockImplementation(async (request: { method?: string }) => {
+          if (request.method === "agent") {
+            throw new Error("launch failed");
+          }
+          return { ok: true };
+        });
+      }
+      vi.spyOn(console, "warn").mockImplementation(() => {});
+      let settled = false;
+      const operation = spawn({ task: "synthetic child" }, { agentSessionKey: "main" }).finally(
+        () => {
+          settled = true;
+        },
+      );
+      try {
+        // A task turn also completes on the original defect, without entering cleanup.
+        await Promise.race([disposalStarted.promise, operation]);
+        expect.soft(settled).toBe(false);
+        expect.soft(fixture.database.isOpen).toBe(true);
+        disposalGate.resolve();
+        const result = await operation;
+        expect(result.status).toBe(mode === "success" ? "accepted" : "error");
+        if (mode === "failure") {
+          expect(result.error).toBe("launch failed");
+        }
+        expect(fixture.retired).toHaveBeenCalledTimes(1);
+      } finally {
+        disposalGate.resolve();
+        await operation;
+        await fixture.cleanup();
+      }
+    },
+  );
+
+  it("rolls back a reservation withdrawn before scheduler activation", async () => {
+    let childPrepared = false;
+    const rollback = vi.fn(async () => {
+      fixture.read();
+      childPrepared = false;
+    });
+    const fixture = createEngineFixture(async () => {
+      childPrepared = true;
+      return { rollback };
+    });
+    resolveEngine.mockImplementation(() => fixture.resolve());
+    registerRun.mockImplementation(({ runId }: { runId: string }) => {
+      expect(scheduler.removeQueuedSwarmRun(runId)).toBe(true);
+    });
+    try {
+      await expect(
+        spawn(
+          { task: "withdrawn child", collect: true, groupId: "withdrawn-group" },
+          { agentSessionKey: "main" },
+        ),
+      ).rejects.toThrow("swarm scheduler reservation missing");
+      expect(childPrepared).toBe(false);
+      expect(rollback).toHaveBeenCalledTimes(1);
+      expect(fixture.engineDisposal).toHaveBeenCalledTimes(1);
+      expect(fixture.retired).toHaveBeenCalledTimes(1);
+    } finally {
+      await fixture.cleanup();
+    }
+  });
+
+  it.each([
+    "success",
+    "failure",
+    "rollback-failure",
+    "disposal-failure",
+    "draining",
+    "retired-draining",
+    "withdrawal",
+  ] as const)("keeps queued preparation alive until %s finishes", async (mode) => {
+    const blockerStarted = createDeferred();
+    const retryStarted = createDeferred();
+    const retryGate = createDeferred();
+    const disposalGate = createDeferred();
+    const disposalStarted = createDeferred();
+    const launchWork = new AsyncWorkScope();
+    const rollback = vi.fn(async () => {
+      fixture.read();
+      if (mode === "rollback-failure") {
+        throw new Error("rollback failed");
+      }
+    });
+    const fixture = createEngineFixture(
+      async () => {
+        fixture.read();
+        return { rollback };
+      },
+      async () => {
+        disposalStarted.resolve();
+        if (mode === "withdrawal") {
+          await disposalGate.promise;
+        }
+        if (mode === "disposal-failure") {
+          throw new Error("engine cleanup failed");
+        }
+      },
+    );
+    resolveEngine.mockImplementation(() => fixture.resolve());
+    let launches = 0;
+    callGateway.mockImplementation(
+      async (request: { method?: string; params?: Record<string, unknown> }) => {
+        if (request.method !== "agent") {
+          return { ok: true };
+        }
+        fixture.read();
+        launches++;
+        if (mode === "failure" || mode === "rollback-failure" || mode === "disposal-failure") {
+          throw new Error("launch failed");
+        }
+        if (mode === "retired-draining") {
+          retryStarted.resolve();
+          await retryGate.promise;
+          fixture.read();
+          throw new GatewayDrainingError();
+        }
+        if (mode === "draining") {
+          if (launches === 1) {
+            throw new GatewayDrainingError();
+          }
+          retryStarted.resolve();
+          await retryGate.promise;
+          fixture.read();
+        }
+        return { runId: request.params?.idempotencyKey, status: "accepted" };
+      },
+    );
+    scheduler.enqueueSwarmRun({
+      groupId: JSON.stringify(["main", "main", "resource-group"]),
+      runId: "blocker",
+      maxConcurrent: 1,
+      activeRunIds: [],
+      start: async () => blockerStarted.resolve(),
+      onStartFailure: () => true,
+    });
+    await blockerStarted.promise;
+    let queuedRunId: string | undefined;
+    try {
+      const result = await spawn(
+        { task: "synthetic queued child", collect: true, groupId: "resource-group" },
+        { agentSessionKey: "main" },
+      );
+      expect(result.status).toBe("accepted");
+      queuedRunId = result.runId;
+      expect(fixture.database.isOpen).toBe(true);
+      expect(launches).toBe(0);
+      if (mode === "withdrawal") {
+        const hold = scheduler.holdQueuedSwarmRun(result.runId!);
+        expect(hold?.withdraw()).toBe(true);
+        let released = false;
+        const release = Promise.resolve(hold?.release()).then(() => {
+          released = true;
+        });
+        await Promise.race([disposalStarted.promise, release]);
+        expect.soft(released).toBe(false);
+        expect(fixture.database.isOpen).toBe(true);
+        disposalGate.resolve();
+        await release;
+      } else {
+        if (mode === "retired-draining") {
+          launchWork.run(() => scheduler.releaseSwarmRun("blocker"));
+        } else {
+          scheduler.releaseSwarmRun("blocker");
+        }
+        if (mode === "draining" || mode === "retired-draining") {
+          await retryStarted.promise;
+          expect(fixture.database.isOpen).toBe(true);
+          expect(rollback).not.toHaveBeenCalled();
+          if (mode === "retired-draining") {
+            await launchWork.drain();
+            expect(scheduler.releaseSwarmRun(result.runId!)).toBe(true);
+            expect(fixture.database.isOpen).toBe(true);
+          }
+          retryGate.resolve();
+        }
+        await vi.waitFor(() => expect(fixture.retired).toHaveBeenCalledTimes(1));
+      }
+      expect(fixture.retired).toHaveBeenCalledTimes(1);
+      expect(fixture.engineDisposal).toHaveBeenCalledTimes(1);
+      if (mode === "failure" || mode === "rollback-failure" || mode === "disposal-failure") {
+        await vi.waitFor(() => expect(settleLaunchFailure).toHaveBeenCalledTimes(1));
+        await new Promise<void>((resolve) => {
+          setImmediate(resolve);
+        });
+        expect(completeLaunchCleanup).toHaveBeenCalledTimes(mode === "failure" ? 1 : 0);
+      }
+      expect(rollback).toHaveBeenCalledTimes(
+        mode === "failure" ||
+          mode === "rollback-failure" ||
+          mode === "disposal-failure" ||
+          mode === "withdrawal" ||
+          mode === "retired-draining"
+          ? 1
+          : 0,
+      );
+    } finally {
+      retryGate.resolve();
+      disposalGate.resolve();
+      if (queuedRunId) {
+        scheduler.removeQueuedSwarmRun(queuedRunId);
+      }
+      await fixture.cleanup();
+      await launchWork.drain();
+    }
+  });
+});

--- a/src/agents/subagents/spawn/subagent-spawn.ts
+++ b/src/agents/subagents/spawn/subagent-spawn.ts
@@ -8,7 +8,6 @@ import { normalizeOptionalString } from "@openclaw/normalization-core/string-coe
 import { isAcpRuntimeSpawnAvailable } from "../../../acp/runtime/availability.js";
 import { isExecutionIdentityCollectionEnabled } from "../../../audit/audit-config.js";
 import { resolveSessionStorePathCore } from "../../../config/sessions/paths.js";
-import type { SubagentSpawnPreparation } from "../../../context-engine/types.js";
 import { listRegisteredPluginAgentPromptGuidance } from "../../../plugins/command-registry-state.js";
 import {
   GatewayDrainingError,
@@ -46,6 +45,7 @@ import {
   prepareContextEngineSubagentSpawn,
   prepareSubagentSessionContext,
   rollbackPreparedContextEngine,
+  type PreparedContextEngineSubagentSpawn,
 } from "./subagent-spawn-context.js";
 import type {
   SpawnSubagentContext,
@@ -131,6 +131,7 @@ export async function spawnSubagentDirect(
   let hasBoundThreadDeliveryOrigin = false;
   let childRunId: string = childIdem;
   let swarmReservationPending = reservationPending;
+  let contextEnginePreparation: PreparedContextEngineSubagentSpawn | undefined;
   try {
     const childPlan = await resolveSubagentChildPlan({
       request: params,
@@ -407,7 +408,7 @@ export async function spawnSubagentDirect(
         ...provisionalSessionIdentity,
         waitForSessionDeletion,
       });
-    type SubagentBackendState = { contextEnginePreparation?: SubagentSpawnPreparation };
+    type SubagentBackendState = { contextEnginePreparation?: PreparedContextEngineSubagentSpawn };
     // Set once the gateway accepts the child run, so a later failure can tell an
     // accepted run apart from one that never started.
     let acceptedChildRunId: string | undefined;
@@ -428,7 +429,8 @@ export async function spawnSubagentDirect(
         if (result.status === "error") {
           throw new Error(result.error);
         }
-        return { contextEnginePreparation: result.preparation };
+        contextEnginePreparation = result.preparation;
+        return { contextEnginePreparation };
       },
       async dispatchTurn() {
         if (params.collect) {
@@ -620,6 +622,7 @@ export async function spawnSubagentDirect(
             }
             await emitSpawnLifecycleHooks(gatewayRunId);
           }, "subagents:spawn");
+          await pipelineResult.state.contextEnginePreparation?.dispose();
         },
         onStartFailure: async (error) => {
           if (error instanceof GatewayDrainingError) {
@@ -654,7 +657,11 @@ export async function spawnSubagentDirect(
           }
           return true;
         },
+        onRemoved: async () => {
+          await rollbackPreparedContextEngine(pipelineResult.state.contextEnginePreparation);
+        },
       });
+      contextEnginePreparation = undefined;
       swarmReservationPending = false;
       collectorSessionKey = childSessionKey;
     } else {
@@ -689,6 +696,11 @@ export async function spawnSubagentDirect(
     admissionReservation?.release();
     if (swarmReservationPending) {
       removeQueuedSwarmRun(childRunId);
+    }
+    if (params.collect && contextEnginePreparation) {
+      await rollbackPreparedContextEngine(contextEnginePreparation);
+    } else {
+      await contextEnginePreparation?.dispose();
     }
   }
 }

--- a/src/agents/subagents/swarm/swarm-scheduler.test.ts
+++ b/src/agents/subagents/swarm/swarm-scheduler.test.ts
@@ -141,7 +141,7 @@ describe("swarm scheduler", () => {
     await vi.waitFor(() => expect(started).toEqual(["one"]));
     const hold = holdQueuedSwarmRun("two");
     expect(isSwarmRunWaitingForCapacity("two", owner)).toBe(false);
-    hold?.release();
+    await hold?.release();
     expect(isSwarmRunWaitingForCapacity("two", owner)).toBe(true);
     expect(removeQueuedSwarmRun("two")).toBe(true);
     expect(waits).toEqual([true, false, true, false]);
@@ -562,11 +562,10 @@ describe("swarm scheduler", () => {
         await flushMicrotasks();
         expect(started).toEqual(["foreign"]);
         expect(isSwarmRunActive("held")).toBe(false);
-        first?.release();
-        first?.release();
+        await Promise.all([first?.release(), first?.release()]);
         await flushMicrotasks();
         expect(started).toEqual(["foreign"]);
-        second?.release();
+        await second?.release();
         await flushMicrotasks();
         expect(started).toEqual(["foreign", "held"]);
         expect(isSwarmRunActive("held")).toBe(true);
@@ -574,8 +573,7 @@ describe("swarm scheduler", () => {
         await flushMicrotasks();
         expect(started).toEqual(["foreign", "held", "next"]);
       } finally {
-        first?.release();
-        second?.release();
+        await Promise.all([first?.release(), second?.release()]);
       }
     },
   );
@@ -606,7 +604,7 @@ describe("swarm scheduler", () => {
         onStartFailure: () => true,
       });
       expect(hold?.withdraw()).toBe(false);
-      hold?.release();
+      await hold?.release();
       await flushMicrotasks();
       expect(oldStart).not.toHaveBeenCalled();
       expect(nextStart).toHaveBeenCalledOnce();

--- a/src/agents/subagents/swarm/swarm-scheduler.ts
+++ b/src/agents/subagents/swarm/swarm-scheduler.ts
@@ -1,9 +1,17 @@
+import { sanitizeForLog } from "../../../../packages/terminal-core/src/ansi.js";
 import { isFastTestRuntimeEnv } from "../../../infra/env.js";
+import {
+  AsyncWorkScope,
+  getAsyncWorkSignal,
+  trackAsyncWork,
+} from "../../../shared/async-work-scope.js";
 
 type SwarmLaunch = {
   start: () => Promise<void>;
   /** True once failure is durable or the row no longer owns queued work. */
   onStartFailure: (error: unknown) => boolean | Promise<boolean>;
+  /** Release preparation only after an abandoned launch can no longer use it. */
+  onRemoved?: () => Promise<void>;
 };
 
 type QueuedSwarmRun = {
@@ -12,6 +20,7 @@ type QueuedSwarmRun = {
   onCapacityChange?: () => void;
   reportedCapacityWait?: boolean;
   launch?: SwarmLaunch;
+  removal?: Promise<void>;
   holds: number;
   retryReady: boolean;
 };
@@ -50,6 +59,30 @@ function publishLaneCapacityChange(lane: SwarmGroupLane, previouslyFull: boolean
   }
 }
 
+function finalizeRemovedRun(item: QueuedSwarmRun): Promise<void> | undefined {
+  const onRemoved = item.launch?.onRemoved;
+  if (onRemoved && !item.removal) {
+    const cleanup = async () => {
+      const work = new AsyncWorkScope();
+      try {
+        await work.track(onRemoved);
+      } finally {
+        await AsyncWorkScope.runWhenAllIdle(
+          () => [work],
+          () => work.run(() => work.drain()),
+        );
+      }
+    };
+    // A retained launch can finish after its triggering request's work scope closes.
+    item.removal = (getAsyncWorkSignal()?.aborted ? cleanup() : trackAsyncWork(cleanup)).catch(
+      (error: unknown) => {
+        console.warn(`[swarm] Failed queued launch cleanup: ${sanitizeForLog(String(error))}`);
+      },
+    );
+  }
+  return item.removal;
+}
+
 async function startQueuedRun(lane: SwarmGroupLane, item: QueuedSwarmRun, launch: SwarmLaunch) {
   lane.active.add(item.runId);
   runLocations.set(item.runId, { lane, state: "active", item });
@@ -67,6 +100,7 @@ async function startQueuedRun(lane: SwarmGroupLane, item: QueuedSwarmRun, launch
     }
     const location = runLocations.get(item.runId);
     if (location?.state !== "active" || location.lane !== lane || location.item !== item) {
+      await finalizeRemovedRun(item);
       return;
     }
     if (failurePersisted) {
@@ -196,30 +230,34 @@ export function isSwarmRunWaitingForCapacity(runId: string, owner: object): bool
 }
 
 /** Attach launch work to an existing FIFO reservation. */
-export function activateSwarmRun(params: {
-  groupId: string;
-  runId: string;
-  start: () => Promise<void>;
-  onStartFailure: (error: unknown) => boolean | Promise<boolean>;
-}): void {
+export function activateSwarmRun(
+  params: SwarmLaunch & {
+    groupId: string;
+    runId: string;
+  },
+): void {
   const location = runLocations.get(params.runId);
   if (!location || location.state !== "queued" || location.lane.groupId !== params.groupId) {
     throw new Error(`swarm scheduler reservation missing for run ${params.runId}`);
   }
   const { lane, item } = location;
-  item.launch = { start: params.start, onStartFailure: params.onStartFailure };
+  item.launch = {
+    start: params.start,
+    onStartFailure: params.onStartFailure,
+    onRemoved: params.onRemoved,
+  };
   publishCapacityChange(item);
   pumpLane(lane);
 }
 
-export function enqueueSwarmRun(params: {
-  groupId: string;
-  runId: string;
-  maxConcurrent: number;
-  activeRunIds: readonly string[];
-  start: () => Promise<void>;
-  onStartFailure: (error: unknown) => boolean | Promise<boolean>;
-}): void {
+export function enqueueSwarmRun(
+  params: SwarmLaunch & {
+    groupId: string;
+    runId: string;
+    maxConcurrent: number;
+    activeRunIds: readonly string[];
+  },
+): void {
   if (!reserveSwarmRun(params)) {
     throw new Error(`swarm scheduler run already exists: ${params.runId}`);
   }
@@ -253,6 +291,7 @@ export function removeQueuedSwarmRun(runId: string): boolean {
   }
   location.lane.queue.splice(index, 1);
   runLocations.delete(runId);
+  void finalizeRemovedRun(location.item);
   publishCapacityChange(location.item);
   pumpLane(location.lane);
   deleteLaneIfIdle(location.lane);
@@ -275,16 +314,16 @@ export function holdQueuedSwarmRun(runId: string) {
   publishCapacityChange(item);
   let released = false;
   return {
-    release() {
-      if (released) {
-        return;
+    async release() {
+      if (!released) {
+        released = true;
+        item.holds -= 1;
+        if (runLocations.get(runId) === location) {
+          publishCapacityChange(item);
+        }
+        pumpLane(lane);
       }
-      released = true;
-      item.holds -= 1;
-      if (runLocations.get(runId) === location) {
-        publishCapacityChange(item);
-      }
-      pumpLane(lane);
+      await item.removal;
     },
     withdraw() {
       // A retained durable kill may withdraw only its never-started reservation.

--- a/src/commands/doctor/shared/context-engine-host-compat.test.ts
+++ b/src/commands/doctor/shared/context-engine-host-compat.test.ts
@@ -1,13 +1,18 @@
 // Context engine host compatibility tests cover doctor warnings for host/context mismatches.
 import { describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../../test/helpers/promise.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
+import { LegacyContextEngine } from "../../../context-engine/legacy.js";
 import {
   getContextEngineRegistration,
+  registerContextEngineInRegistry,
   registerContextEngineForOwner,
 } from "../../../context-engine/registry.js";
 import type { ContextEngine, ContextEngineHostCapability } from "../../../context-engine/types.js";
 import { acquirePluginRegistryForInspection } from "../../../plugins/loader.js";
 import { createEmptyPluginRegistry } from "../../../plugins/registry-empty.js";
+import { PluginRegistryInspectionResources } from "../../../plugins/registry-inspection-resources.js";
+import { retireInspectionInstances } from "../../../plugins/registry-inspection.test-support.js";
 import {
   collectContextEngineHostCompatibilityWarnings,
   maybeRepairContextEngineHostCompatibility,
@@ -99,6 +104,62 @@ function configWithEngine(engineId: string, cfg: OpenClawConfig = {}): OpenClawC
 }
 
 describe("doctor context-engine host compatibility", () => {
+  it.each([false, true])(
+    "settles context engine custody before returning (disposal fails: %s)",
+    async (disposalFails) => {
+      const id = uniqueEngineId();
+      const registry = createEmptyPluginRegistry();
+      const resources = new PluginRegistryInspectionResources(retireInspectionInstances);
+      resources.attach(registry);
+      const retired = vi.fn();
+      resources.register("fixture", { id: "doctor-resource", dispose: retired });
+      const disposalStarted = createDeferred();
+      const disposalGate = createDeferred();
+      class DoctorEngine extends LegacyContextEngine {
+        override readonly info = { id, name: "Doctor custody fixture" };
+        async dispose() {
+          expect(retired).not.toHaveBeenCalled();
+          disposalStarted.resolve();
+          await disposalGate.promise;
+          if (disposalFails) {
+            throw new Error("doctor engine disposal failed");
+          }
+        }
+      }
+      registerContextEngineInRegistry(registry, id, () => new DoctorEngine(), "plugin:fixture");
+      vi.mocked(acquirePluginRegistryForInspection).mockResolvedValue({
+        registry,
+        release: () => resources.release(),
+      });
+      const pending = collectContextEngineHostCompatibilityWarnings({
+        cfg: configWithEngine(id),
+        doctorFixCommand: "openclaw doctor --fix",
+      });
+      try {
+        expect(
+          await Promise.race([
+            disposalStarted.promise.then(() => "disposing"),
+            pending.then(() => "returned"),
+          ]),
+        ).toBe("disposing");
+        expect(retired).not.toHaveBeenCalled();
+        disposalGate.resolve();
+        const warnings = await pending;
+        if (disposalFails) {
+          expect(warnings.join("\n")).toContain("doctor engine disposal failed");
+        } else {
+          expect(warnings).toEqual([]);
+        }
+        expect(retired).toHaveBeenCalledOnce();
+      } finally {
+        disposalGate.resolve();
+        await pending;
+        await resources.release();
+        vi.mocked(acquirePluginRegistryForInspection).mockReset();
+      }
+    },
+  );
+
   it.each([true, false])(
     "reports offline inspection availability without activating or repairing an engine (discovered=%s)",
     async (discovered) => {

--- a/src/commands/doctor/shared/context-engine-host-compat.ts
+++ b/src/commands/doctor/shared/context-engine-host-compat.ts
@@ -24,7 +24,7 @@ import {
   getContextEngineRegistration,
   resolveContextEngine,
 } from "../../../context-engine/registry.js";
-import type { ContextEngineInfo } from "../../../context-engine/types.js";
+import type { ContextEngine, ContextEngineInfo } from "../../../context-engine/types.js";
 import { acquirePluginRegistryForInspection } from "../../../plugins/loader.js";
 import type { PluginRegistry } from "../../../plugins/registry-types.js";
 import { withPluginRuntimeRegistryScope } from "../../../plugins/runtime/gateway-request-scope.js";
@@ -253,41 +253,34 @@ async function resolveSelectedContextEngineInfo(params: {
   ensureContextEnginesInitialized();
   let pluginRegistry: PluginRegistry | undefined;
   let inspection: Awaited<ReturnType<typeof acquirePluginRegistryForInspection>> | undefined;
+  let engine: ContextEngine | undefined;
+  let outcome: { ok: true; result: ContextEngineInfoResult } | { ok: false; error: unknown };
   try {
-    try {
-      if (getContextEngineRegistration(engineId)?.lifecycle !== "runtime") {
-        try {
-          inspection = await acquirePluginRegistryForInspection({
-            config: params.cfg,
-            env: params.env,
-            onlyPluginIds: [engineId],
-          });
-          pluginRegistry = inspection.registry;
-        } catch (error) {
-          const message = error instanceof Error ? error.message : String(error);
-          return {
-            warnings: [
-              `- plugins.slots.contextEngine: could not inspect context engine "${engineId}" host requirements because its plugin failed to load: ${message}`,
-            ],
-          };
-        }
+    let inspectionWarning: string | undefined;
+    if (getContextEngineRegistration(engineId)?.lifecycle !== "runtime") {
+      try {
+        inspection = await acquirePluginRegistryForInspection({
+          config: params.cfg,
+          env: params.env,
+          onlyPluginIds: [engineId],
+        });
+        pluginRegistry = inspection.registry;
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        inspectionWarning = `- plugins.slots.contextEngine: could not inspect context engine "${engineId}" host requirements because its plugin failed to load: ${message}`;
+      }
+      if (pluginRegistry) {
         const registration = pluginRegistry.contextEngines.get(engineId);
         if (registration?.lifecycle === "readOnlyDiscovery") {
-          return {
-            warnings: [
-              `- plugins.slots.contextEngine: context engine "${engineId}" is registered for read-only discovery; offline host compatibility inspection is unavailable. This does not indicate a missing runtime registration in the Gateway.`,
-            ],
-          };
-        }
-        if (registration?.lifecycle !== "runtime") {
-          return {
-            warnings: [
-              `- plugins.slots.contextEngine: could not inspect context engine "${engineId}" host requirements because it is not registered.`,
-            ],
-          };
+          inspectionWarning = `- plugins.slots.contextEngine: context engine "${engineId}" is registered for read-only discovery; offline host compatibility inspection is unavailable. This does not indicate a missing runtime registration in the Gateway.`;
+        } else if (registration?.lifecycle !== "runtime") {
+          inspectionWarning = `- plugins.slots.contextEngine: could not inspect context engine "${engineId}" host requirements because it is not registered.`;
         }
       }
-
+    }
+    if (inspectionWarning) {
+      outcome = { ok: true, result: { warnings: [inspectionWarning] } };
+    } else {
       const agentId = resolveAmbientOwnerAgentId(params.cfg, undefined, {
         surface: "context-engine Doctor checks",
         hint: "Set agents.defaults.systemAgent.agentId before running Doctor.",
@@ -299,12 +292,24 @@ async function resolveSelectedContextEngineInfo(params: {
             ? resolveUserPath(params.cfg.agents.defaults.workspace, params.env)
             : undefined,
         });
-      const engine = await withPluginRuntimeRegistryScope(pluginRegistry, resolve);
-      return { info: engine.info, warnings: [] };
-    } finally {
-      await inspection?.release();
+      engine = await withPluginRuntimeRegistryScope(pluginRegistry, resolve);
+      outcome = { ok: true, result: { info: engine.info, warnings: [] } };
     }
   } catch (error) {
+    outcome = { ok: false, error };
+  }
+  // The engine's final work must finish before its inspection can retire.
+  for (const cleanup of [() => engine?.dispose?.(), () => inspection?.release()]) {
+    try {
+      await cleanup();
+    } catch (error) {
+      if (outcome.ok) {
+        outcome = { ok: false, error };
+      }
+    }
+  }
+  if (!outcome.ok) {
+    const { error } = outcome;
     const message = error instanceof Error ? error.message : String(error);
     return {
       warnings: [
@@ -312,6 +317,7 @@ async function resolveSelectedContextEngineInfo(params: {
       ],
     };
   }
+  return outcome.result;
 }
 
 function collectHostCompatibilityIssues(params: {

--- a/src/gateway/session-utils.queued-collector.test.ts
+++ b/src/gateway/session-utils.queued-collector.test.ts
@@ -295,7 +295,7 @@ describe("queued collector session projection", () => {
       expect(isSubagentRunQueued(entry)).toBe(false);
       expect((await listChildren(context)).sessions[0]?.hasActiveRun).toBe(false);
     } finally {
-      hold.release();
+      await hold.release();
     }
     await Promise.resolve();
     expect(start).not.toHaveBeenCalled();


### PR DESCRIPTION
Closes #145620

<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled.

</details>

## What Problem This Solves

Resolves a problem where context-engine plugin resources remain open after subagent lifecycle work, CLI turns/compaction and Doctor inspection, or are disposed while deferred CLI maintenance still uses them. A queued child canceled before activation can also keep its preparation applied, and a CLI history-read failure can skip already-prepared resource cleanup.

## Why This Change Was Made

Each affected caller now finishes its existing engine ownership after its actual work settles, carrying lifetime through queued dispatch, rollback, timed-out compaction tails and deferred maintenance. Fallible CLI initialization moves inside its existing cleanup boundary; primary operation errors remain intact, and disposal failure cannot certify completed collector cleanup.

## User Impact

Repeated operations release their plugin resources once after final use. Queued cancellation undoes child preparation, and deferred work keeps the resources it needs without extending the compaction watchdog. Public context-engine interfaces, configuration, storage schemas and dependencies stay unchanged.

## Evidence

- Pre-fix regressions exercised the real resolver and inspection ownership, including SQLite retirement, stale authority, failed cleanup, background maintenance, history-read failure and cancellation before scheduler handoff.
- A broader 368-test CLI/runtime run passed. After the final cleanup and handoff fixes, 91 owner/sibling tests passed. These runs overlap.
- `node scripts/check-changed.mjs --base abe0065574d313ecde402a953e6fb3d22dfe3ece` passed for the tested candidate, including production/test typechecks, lint and repository guards; final `git diff --check` passed.
- A follow-up caller cutover joins all eight async reservation-release calls in the existing Gateway/scheduler tests. Original focused lint reproduced eight dropped-Promise errors; the repaired lint and all 67 queued-collector, scheduler and spawn-resource tests passed. Assertions and explicit retained-Promise scheduling proof remain intact.
- The updated full 20-path changed gate passed. Independent P2 review of the original repair and the follow-up caller cutover is scoped clean.
- This is a correctness repair: **+182 production code lines +984 test code lines = +1,166 maintained code lines**. The separate physical-line delta is +1,190; documentation adds 5 code/6 physical lines. Both canonical counting modes agree. **No reduction savings are claimed.**

Proof is from isolated local execution on the accepted candidate before rebasing. The original broader 368 and final 91 runs are retained console execution records; the 67-case follow-up has native JSON/blob reports with joined process outcomes. The existing branch was then mechanically rebased onto `a53c601cd4075a6839bac3f75f2280eda182b4b8`, which contains the unrelated `thinking.test.ts` lint repair from #145632. Range-diff preserves both commits, and every changed-file hash matches the exact current-main-plus-accepted-patch specimen, including the 14 upstream cold-restoration additions from #145172. No new live-provider run or current-head CI success is claimed by the retained local proof.

### Current-head CI and review disposition

Current-head [CI run 34677780164](https://github.com/openclaw/openclaw/actions/runs/34677780164) passed, including the [published-upgrade survivor job](https://github.com/openclaw/openclaw/actions/runs/34677780164/job/103510766038): `openclaw@2026.9.3` → candidate, `legacy-operator-state`, `auto-auth`, passed in 317 seconds.

The hosted checklist's new-disposer timeout premise does not describe the installed Doctor route. The published driver starts Doctor in a fresh subprocess; candidate Doctor skips full plugin activation, and cold context-engine inspection registers discovery-only factories without invoking them. Inspection resource release was already awaited before this patch. The newly awaited engine disposer belongs to an already-runtime-registered caller and retains separate gated success/failure tests. The modified Doctor code adds no schema or store semantics. This upgrade cell is not claimed as a warm custom-engine disposer run.
