### PR TITLE
docs: correct Anthropic shared auth troubleshooting

### DIFF
--- a/docs/providers/anthropic.md
+++ b/docs/providers/anthropic.md
@@ -808,7 +808,14 @@ OpenClaw supports Anthropic's prompt caching feature for API-key auth.
   </Accordion>
 
   <Accordion title='No API key found for provider "anthropic"'>
-    Anthropic auth is **per agent**; new agents do not inherit the main agent's keys. Re-run onboarding for that agent (or configure an API key on the gateway host), then verify with `openclaw models status`.
+    Agents read shared auth profiles at runtime, with agent-local profiles overriding shared profiles with the same ID. A new agent does not need a separate API key when a usable shared Anthropic profile exists.
+
+    Check the affected agent with `openclaw models status --agent <agentId>`. If no usable credential is available, configure an Anthropic API key on the Gateway host or set up auth for that agent.
+
+    Read-through is separate from copying: non-portable profiles can still be used from the shared store. Explicit copy flows follow the [agent copy portability policy](/auth-credential-semantics#agent-copy-portability).
+
+    Native Claude CLI logins remain owned by Claude Code, not the shared OpenClaw auth store. For that route, use the [Claude CLI setup](/providers/anthropic#getting-started); do not copy native OAuth tokens into OpenClaw.
+
   </Accordion>
 
   <Accordion title='No credentials found for profile "anthropic:default"'>


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users troubleshooting `No API key found for provider "anthropic"` were told that new agents cannot inherit the main agent's credentials and must repeat onboarding. That advice conflicts with the canonical shared-store read-through behavior and can lead to unnecessary duplicate credential setup.

## Why This Change Was Made

Corrects only the Anthropic troubleshooting accordion: agents read shared auth profiles at runtime, and agent-local profiles override matching shared profile IDs. The guidance targets the affected agent with `openclaw models status --agent <agentId>`, distinguishes runtime read-through from explicit copy portability, and preserves Claude Code's exclusive ownership of native Claude CLI login tokens and refresh.

No runtime, configuration, storage, pricing, or model changes. This repair is separate from the unrelated Sonnet pricing work that exposed the documentation conflict. The canonical credential-semantics document remains unchanged.

## User Impact

Operators can troubleshoot the actual agent's effective credentials instead of assuming every new agent needs another API key. Non-portable shared profiles are not confused with unavailable profiles, and native Claude CLI users are directed to the existing CLI setup rather than copying native OAuth tokens into OpenClaw.

## Evidence

- Verified current main still contains the incorrect troubleshooting claim before publication.
- Verified `loadAuthProfileStoreForRuntime` in `src/agents/auth-profiles/store.ts`, matching-ID override precedence in `src/agents/auth-profiles/persisted.ts`, and the separate explicit-copy policy in `src/agents/auth-profiles/portability.ts` against `docs/auth-credential-semantics.md`.
- Verified Claude CLI availability-only probing and non-secret routing in `extensions/anthropic/cli-auth-seam.ts` and `provider-discovery.ts`.
- Passed repository changed-file docs checks: `node scripts/check-changed.mjs -- docs/providers/anthropic.md`.
- Passed focused MDX validation, the changed-doc glossary check, scoped link/anchor validation for the provider page and canonical credential-semantics page, and `git diff --check`.
- The broader anchor audit has three pre-existing unrelated `windows-app-node` failures in generated maturity docs (`docs/maturity/scorecard.md` and `docs/maturity/taxonomy.md`). The touched pages have no broken links or anchors.
- Runtime tests and live credential probes were intentionally not run for this documentation-only correction.
