### PR TITLE
fix: keep artifact reads working during transcript archival

### DIFF
--- a/src/config/sessions/session-accessor.sqlite-cold-read.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-cold-read.test.ts
@@ -1,5 +1,6 @@
 import { DatabaseSync } from "node:sqlite";
 import { afterEach, expect, it, vi } from "vitest";
+import { visitSessionMessagesAsync } from "../../gateway/session-transcript-readers.js";
 import {
   clearNodeSqliteKyselyCacheForDatabase,
   executeSqliteQuerySync,
@@ -257,6 +258,36 @@ it("restores once more when a peer archives between async preparation and the at
       expect(result).toMatchObject({ type: "session", id: race.scope.sessionId });
       expect(reads).toBe(2);
     } finally {
+      race.writer.close();
+    }
+  });
+});
+
+it("retries Gateway visitation when a peer archives after async restoration", async () => {
+  await withOpenClawTestState({ label: "cold-gateway-visitor-race" }, async (state) => {
+    const race = await prepareRace(state);
+    try {
+      const visited: Array<{ message: unknown; seq: number }> = [];
+      race.commitAfterMarkerRead();
+      const count = await visitSessionMessagesAsync(
+        { ...race.scope, storePath: race.database.path },
+        (message, seq) => {
+          expect(race.database.db.isTransaction).toBe(true);
+          visited.push({ message, seq });
+        },
+      );
+      expect(race.committed()).toBe(true);
+      expect(count).toBe(2);
+      expect(visited).toEqual([
+        { message: { role: "user", content: "Original question" }, seq: 1 },
+        { message: { role: "assistant", content: "Original answer" }, seq: 2 },
+      ]);
+      expect(race.database.db.isTransaction).toBe(false);
+      expect(race.database.db.prepare("PRAGMA wal_checkpoint(TRUNCATE)").get()).toMatchObject({
+        busy: 0,
+      });
+    } finally {
+      vi.restoreAllMocks();
       race.writer.close();
     }
   });

--- a/src/gateway/session-transcript-readers.ts
+++ b/src/gateway/session-transcript-readers.ts
@@ -308,19 +308,18 @@ export async function visitSessionMessagesAsync(
   scope: SessionTranscriptReadScope,
   visit: (message: unknown, seq: number) => void,
 ): Promise<number> {
-  const target = resolveTranscriptReadTarget(scope);
-  const { restoreSessionColdTranscript } =
-    await import("../config/sessions/session-cold-storage.js");
-  await restoreSessionColdTranscript(toTranscriptReadScope(target));
-  let count = 0;
-  visitSessionTranscriptMessageEvents(toTranscriptReadScope(target), (entry) => {
-    const message = asOptionalRecord(entry.event)?.message;
-    if (message !== undefined) {
-      visit(message, entry.seq);
-      count += 1;
-    }
+  const transcriptScope = toTranscriptReadScope(resolveTranscriptReadTarget(scope));
+  return readRestoredSessionTranscript(transcriptScope, () => {
+    let count = 0;
+    visitSessionTranscriptMessageEvents(transcriptScope, (entry) => {
+      const message = asOptionalRecord(entry.event)?.message;
+      if (message !== undefined) {
+        visit(message, entry.seq);
+        count += 1;
+      }
+    });
+    return count;
   });
-  return count;
 }
 
 /** Counts display messages asynchronously through the reader seam. */


### PR DESCRIPTION
Closes #145623

<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled.

</details>

## What Problem This Solves

Fixes an issue where users listing or downloading transcript artifacts, or reopening an MCP app, could receive a transient failure when another process archived that session between restoration and its message read.

## Why This Change Was Made

The Gateway visitor now uses the existing transcript restore/read owner and its single retry for the same session. The cold-state check precedes all callbacks, and the actual visitation remains within one SQLite snapshot, so the archive race is retried before any message is delivered. Streaming, callback errors and cursor cleanup retain their existing behavior.

## User Impact

Artifact collection and MCP app reconstruction can finish through this archival race. The shared visitor also serves restart replay-safety scanning. This completes the existing read-owner cutover without changing archival policy, persistence or retry limits.

## Evidence

- The new regression uses an actual transcript archive and a second SQLite connection to rearchive after the restore lookup, then calls the real Gateway visitor. Original production failed with `SessionTranscriptColdError` (`TRANSCRIPT_COLD`) from the pre-callback guard; the other 32 tests passed.
- After the fix, all 33 focused tests passed. The regression verifies exact messages and sequence values once/in order, callback execution inside the transaction, transaction closure and a nonbusy WAL checkpoint. Existing incremental visitation, exact callback-error identity, parse-failure and projection-unavailable tests remain unchanged and pass.
- `node scripts/run-vitest.mjs src/config/sessions/session-accessor.sqlite-cold-read.test.ts src/gateway/session-transcript-readers.test.ts` passed. Native JSON/blob reports retain both runs and joined process outcomes; no test retry was needed.
- The full `node scripts/check-changed.mjs --base 7c0dfa5150809b92a9bbc0d32cdc7366b17ac388 -- src/gateway/session-transcript-readers.ts src/config/sessions/session-accessor.sqlite-cold-read.test.ts` gate passed, including core/test typechecks, lint and repository guards. Formatting, final diff checks and fresh independent P2 review passed.
- This correctness repair removes one production code line and adds 30 test code lines: **+29 maintained code lines**, or +30 physical lines. No reduction savings are claimed.

Execution proof belongs to the accepted candidate based on `7c0dfa5150809b92a9bbc0d32cdc7366b17ac388`. Its patch-identical rebase onto `a53c601cd4075a6839bac3f75f2280eda182b4b8` includes the unrelated `thinking.test.ts` lint repair from #145632. Exact changed-file hashes match the expected integration and the inspected restoration/snapshot owners and consumers remain unchanged. Current-head CI success and a live artifact RPC or MCP service roundtrip are not claimed by these local results.
