### PR TITLE
refactor(tests): reuse Buzz runtime spies

### DIFF
--- a/extensions/buzz/src/setup-surface.test.ts
+++ b/extensions/buzz/src/setup-surface.test.ts
@@ -6,6 +6,7 @@ import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import type { SecretInput, WizardPrompter } from "openclaw/plugin-sdk/setup";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { createRuntimeSpies } from "../../test-support/runtime-spies.js";
 import { createBuzzSetupWizard } from "./setup-surface.js";
 
 const ROOM_A = "7c4a6d2a-2ed9-4b4e-a5e2-4d705ee9b34c";
@@ -103,14 +104,6 @@ function createPrompter(): WizardPrompter {
   };
 }
 
-function createRuntime(): RuntimeEnv {
-  return {
-    log: vi.fn(),
-    error: vi.fn(),
-    exit: vi.fn() as RuntimeEnv["exit"],
-  };
-}
-
 describe("Buzz guided setup", () => {
   afterEach(async () => {
     vi.unstubAllEnvs();
@@ -129,7 +122,7 @@ describe("Buzz guided setup", () => {
       verifyAfterWrite,
     });
     const prompter = createPrompter();
-    const runtime = createRuntime();
+    const runtime = createRuntimeSpies();
     const hooks: Array<{
       run: (ctx: { cfg: OpenClawConfig; runtime: RuntimeEnv }) => void | Promise<void>;
     }> = [];
@@ -199,7 +192,7 @@ describe("Buzz guided setup", () => {
     const configure = (accountId: string) =>
       wizard.configure({
         cfg,
-        runtime: createRuntime(),
+        runtime: createRuntimeSpies(),
         prompter,
         accountOverrides: { buzz: accountId },
         shouldPromptAccountIds: false,
@@ -240,7 +233,7 @@ describe("Buzz guided setup", () => {
       .mockResolvedValueOnce("wss://ada.example.com");
     const result = await wizard.configure({
       cfg: { channels: { buzz: root } } as OpenClawConfig,
-      runtime: createRuntime(),
+      runtime: createRuntimeSpies(),
       prompter,
       accountOverrides: {},
       shouldPromptAccountIds: true,
@@ -287,7 +280,7 @@ describe("Buzz guided setup", () => {
 
     const result = await wizard.configure({
       cfg: {} as OpenClawConfig,
-      runtime: createRuntime(),
+      runtime: createRuntimeSpies(),
       prompter,
       options: { secretInputMode: "ref" },
       accountOverrides: {},
@@ -325,7 +318,7 @@ describe("Buzz guided setup", () => {
           },
         },
       } as OpenClawConfig,
-      runtime: createRuntime(),
+      runtime: createRuntimeSpies(),
       prompter,
       accountOverrides: {},
       shouldPromptAccountIds: false,
@@ -368,7 +361,7 @@ describe("Buzz guided setup", () => {
       vi.mocked(prompter.multiselect).mockResolvedValueOnce([]).mockResolvedValueOnce([ROOM_A]);
       const result = await createBuzzSetupWizard({ discoverRooms }).configure({
         cfg,
-        runtime: createRuntime(),
+        runtime: createRuntimeSpies(),
         prompter,
         accountOverrides: { buzz: accountId },
         shouldPromptAccountIds: false,
@@ -430,7 +423,7 @@ describe("Buzz guided setup", () => {
       cfg: {
         channels: { buzz: { relayUrl: "ws://127.attacker.example" } },
       } as OpenClawConfig,
-      runtime: createRuntime(),
+      runtime: createRuntimeSpies(),
       prompter,
       accountOverrides: {},
       shouldPromptAccountIds: false,
@@ -470,7 +463,7 @@ describe("Buzz guided setup", () => {
           },
         },
       } as OpenClawConfig,
-      runtime: createRuntime(),
+      runtime: createRuntimeSpies(),
       prompter,
       accountOverrides: {},
       shouldPromptAccountIds: false,
@@ -522,7 +515,7 @@ describe("Buzz guided setup", () => {
 
       const result = await wizard.configure({
         cfg,
-        runtime: createRuntime(),
+        runtime: createRuntimeSpies(),
         prompter,
         accountOverrides: { buzz: accountId },
         shouldPromptAccountIds: false,
@@ -590,7 +583,7 @@ describe("Buzz guided setup", () => {
       await expect(
         wizard.configure({
           cfg,
-          runtime: createRuntime(),
+          runtime: createRuntimeSpies(),
           prompter: createPrompter(),
           options: { onPostWriteHook },
           accountOverrides: { buzz: accountId },
@@ -627,7 +620,7 @@ describe("Buzz guided setup", () => {
           },
         },
       } as OpenClawConfig,
-      runtime: createRuntime(),
+      runtime: createRuntimeSpies(),
       prompter,
       options: { secretInputMode: "ref" },
       accountOverrides: {},
@@ -659,7 +652,7 @@ describe("Buzz guided setup", () => {
 
     const result = await wizard.configure({
       cfg: {} as OpenClawConfig,
-      runtime: createRuntime(),
+      runtime: createRuntimeSpies(),
       prompter,
       accountOverrides: {},
       shouldPromptAccountIds: false,

--- a/extensions/buzz/src/setup-verify.test.ts
+++ b/extensions/buzz/src/setup-verify.test.ts
@@ -1,19 +1,11 @@
-import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createRuntimeSpies } from "../../test-support/runtime-spies.js";
 
 const mocks = vi.hoisted(() => ({ callGatewayFromCli: vi.fn() }));
 
 vi.mock("openclaw/plugin-sdk/gateway-runtime", () => ({
   callGatewayFromCli: mocks.callGatewayFromCli,
 }));
-
-function createRuntime(): RuntimeEnv {
-  return {
-    log: vi.fn(),
-    error: vi.fn(),
-    exit: vi.fn() as RuntimeEnv["exit"],
-  };
-}
 
 describe("verifyBuzzAfterSetup", () => {
   beforeEach(() => {
@@ -39,7 +31,7 @@ describe("verifyBuzzAfterSetup", () => {
           ],
         },
       });
-    const runtime = createRuntime();
+    const runtime = createRuntimeSpies();
     const { verifyBuzzAfterSetup } = await import("./setup-verify.js");
 
     await verifyBuzzAfterSetup({
@@ -73,7 +65,7 @@ describe("verifyBuzzAfterSetup", () => {
       .mockResolvedValueOnce({
         channelAccounts: { buzz: [{ accountId: "default" }] },
       });
-    const runtime = createRuntime();
+    const runtime = createRuntimeSpies();
     const { verifyBuzzAfterSetup } = await import("./setup-verify.js");
 
     await verifyBuzzAfterSetup({
@@ -96,7 +88,7 @@ describe("verifyBuzzAfterSetup", () => {
         code: 1006,
       }),
     );
-    const runtime = createRuntime();
+    const runtime = createRuntimeSpies();
     const { verifyBuzzAfterSetup } = await import("./setup-verify.js");
 
     await verifyBuzzAfterSetup({
@@ -118,7 +110,7 @@ describe("verifyBuzzAfterSetup", () => {
         code: 1006,
       }),
     );
-    const runtime = createRuntime();
+    const runtime = createRuntimeSpies();
     const { verifyBuzzAfterSetup } = await import("./setup-verify.js");
 
     await verifyBuzzAfterSetup({


### PR DESCRIPTION
## What Problem This Solves

Buzz setup tests duplicate the same log, error, and exit spy factory in two files.

## Why This Change Was Made

Use the existing shared runtime-spies helper and remove both local factories and the obsolete exit casts. Keep the message-sensitive setup prompter, post-write runtime forwarding, synthetic credential fixtures, and cleanup unchanged.

## User Impact

No production change. Tests are +18/-33 (net -15); no test cases are added or removed.

## Evidence

Fresh proof on the refreshed main base passes all three complete suites before and after: 38 cases (21 setup-surface, 4 setup verification, 13 setup-core), with identical observed case order and results. Existing identity, account, credential-reference, retry, and error assertions remain intact. This is fixture proof, not a live Buzz service claim.

All 19 normal changed-file checks passed through the configured Testbox route, including extension test types, lint, boundaries, and all three dead-export scans. The receiver verified the exact candidate source and the owned lease and capsule were cleaned up. Fresh independent Codex review found no actionable findings. The signed refresh preserves the original two-file patch.

The earlier PR CI failed an unchanged main thinking-test line limit. This refresh includes the canonical fix from #145632. It also adopts main's TypeBox update, so the fresh pair and gate above replace reliance on the older dependency proof; they do not claim general TypeBox compatibility. Exact-head PR CI remains a separate landing gate.
