### PR TITLE
fix(release): admit frozen parsed session schema

### DIFF
--- a/scripts/lib/frozen-target-compat.sh
+++ b/scripts/lib/frozen-target-compat.sh
@@ -408,6 +408,7 @@ openclaw_resolve_frozen_typed_onboarding_contract() {
 
 openclaw_resolve_frozen_session_cold_storage_contract() {
   local source_root="${1:?missing selected source root}" authorization_status=0 has_current has_cold has_legacy
+  local has_legacy_duration has_legacy_parsed_duration
 
   export OPENCLAW_FROZEN_TARGET_SESSION_COLD_STORAGE_MODE="required"
   openclaw_prepare_frozen_target_context "$source_root" || authorization_status=$?
@@ -422,8 +423,9 @@ openclaw_resolve_frozen_session_cold_storage_contract() {
   [ "$has_cold" = 0 ] || return 0
   has_legacy="$(openclaw_frozen_target_source_flag contains "$source_root" src/config/zod-schema.session.ts 'export const SessionSchema = z')" || return 2
   if [ "$has_legacy" = 1 ]; then
-    has_legacy="$(openclaw_frozen_target_source_flag contains "$source_root" src/config/zod-schema.session.ts 'pruneAfter: PositiveDurationSchema.optional()')" || return 2
-    if [ "$has_legacy" = 1 ]; then
+    has_legacy_duration="$(openclaw_frozen_target_source_flag contains "$source_root" src/config/zod-schema.session.ts 'pruneAfter: PositiveDurationSchema.optional()')" || return 2
+    has_legacy_parsed_duration="$(openclaw_frozen_target_source_flag contains "$source_root" src/config/zod-schema.session.ts 'pruneAfter: z.union([z.string(), z.number()]).optional()')" || return 2
+    if [ "$has_legacy_duration" = 1 ] || [ "$has_legacy_parsed_duration" = 1 ]; then
       export OPENCLAW_FROZEN_TARGET_SESSION_COLD_STORAGE_MODE="unsupported"
       return 0
     fi

--- a/test/scripts/preflight-frozen-target-contracts.test.ts
+++ b/test/scripts/preflight-frozen-target-contracts.test.ts
@@ -720,6 +720,15 @@ describe("frozen admission entry", () => {
     { name: "legacy authorized", files: {}, allow: true, mode: "unsupported" },
     { name: "legacy strict", files: {}, allow: false, mode: "required" },
     {
+      name: "parsed-duration legacy authorized",
+      files: {
+        "src/config/zod-schema.session.ts":
+          "export const SessionSchema = z.object({ maintenance: z.object({ pruneAfter: z.union([z.string(), z.number()]).optional() }) });",
+      },
+      allow: true,
+      mode: "unsupported",
+    },
+    {
       name: "current authorized",
       files: { "src/config/zod-schema.session-config.ts": "coldStorage: z.object({})" },
       allow: true,


### PR DESCRIPTION
## Summary

- recognize the parsed-duration session schema shipped by 2026.7.33 as predating cold storage
- preserve strict admission for unknown schema shapes and require cold-storage coverage for current declarations
- cover the additional frozen schema dialect in the admission contract matrix

## Validation

- exact 2026.7.33 production admission request: both `openai-chat-tools` and `session-runtime-context` resolve cold storage as `unsupported`
- `pnpm exec vitest run test/scripts/preflight-frozen-target-contracts.test.ts` (101/101)
- final-head targeted regression (1/1)
- `pnpm check:test-types`
- `pnpm check:changed`
- `bash -n scripts/lib/frozen-target-compat.sh`
- changed-file formatting and diff checks

Fixes the early admission failure in Full Release Validation run 34672859563.
