### PR TITLE
feat(gateway): profile allocations during concurrent workloads

### DIFF
--- a/docs/reference/test/performance.md
+++ b/docs/reference/test/performance.md
@@ -98,6 +98,36 @@ Use JSON output or `--output` when comparing changes. Use `--cpu-prof-dir` only 
 
 </Accordion>
 
+<Accordion title="Gateway concurrency (scripts/bench-gateway-concurrency.ts)">
+
+Runs synthetic streaming agent turns in parallel sessions on one isolated
+Gateway. Add tool calls, session history, observers, and control-plane probes to
+reproduce allocation pressure from a busy Gateway. Build with `pnpm build`
+first; no provider key is required.
+
+```bash
+pnpm test:gateway:concurrency -- --concurrency 16 --tool-events --workspace-fanout --session-count 100 --history-messages 20 --history-clients 4 --subscribers 4 --visible-observer --control-plane --heap-prof-dir .artifacts/gateway-heap --output .artifacts/gateway-concurrency.json
+```
+
+`--heap-prof-dir` samples allocations in the Gateway's main V8 isolate, starting
+after startup, session seeding, and probe warmup. Sampling ends after the load
+and its final memory probe, before profile serialization and teardown. It uses
+a 32 KiB sampling interval and includes objects collected by both minor and
+major GC, so `sampledAllocatedBytes` estimates gross allocations rather than
+retained heap. Native allocations and separate worker isolates are outside this
+profile. Each run records its `.heapprofile` path and the twenty largest
+allocation stacks; open the raw file in the Chrome DevTools Memory panel.
+
+The summary includes sampled allocation bytes per run and per completed turn.
+The per-turn figure also includes concurrent probes and session mutations;
+compare identical workload settings and Node versions across multiple runs.
+Sampling is statistical and adds overhead. Use unprofiled runs for latency
+comparisons. Existing heap/RSS measurements are taken before exporting the
+profile. `--cpu-prof-dir` remains available separately and includes startup;
+the recorded `loadWindow` identifies the measured interval in that CPU profile.
+
+</Accordion>
+
 <Accordion title="Gateway restart (scripts/bench-gateway-restart.ts)">
 
 macOS and Linux only (uses SIGUSR1 for in-process restarts; fails immediately on Windows). Same built-entry default and `--entry scripts/run-node.mjs` override as gateway startup above.

--- a/scripts/bench-gateway-concurrency.ts
+++ b/scripts/bench-gateway-concurrency.ts
@@ -1,4 +1,4 @@
-import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { spawn, type ChildProcess, type ChildProcessWithoutNullStreams } from "node:child_process";
 // Bench Gateway Concurrency script measures gateway probes during synthetic streaming turns.
 import { randomUUID } from "node:crypto";
 import {
@@ -20,6 +20,11 @@ import { isRecord } from "../packages/normalization-core/src/record-coerce.ts";
 import { sliceUtf16Safe } from "../packages/normalization-core/src/utf16-slice.ts";
 import { applyMockOpenAiModelConfig } from "./e2e/lib/fixtures/mock-openai-config.mjs";
 import { delay, stopChild } from "./lib/gateway-bench-child.ts";
+import {
+  controlGatewayHeapProfile,
+  readGatewayHeapProfile,
+  type GatewayHeapProfile,
+} from "./lib/gateway-bench-heap.ts";
 import { getFreePort, readProcessRssMb } from "./lib/gateway-bench-probes.ts";
 import {
   BASE_GATEWAY_BENCH_CONFIG,
@@ -102,6 +107,7 @@ type GatewayChildExit = {
 };
 
 type BenchmarkRun = {
+  heapProfile?: GatewayHeapProfile;
   controlPlane: Array<TimedProbe & { method: string }>;
   controlUi: ControlUiProbe[];
   durationMs: number;
@@ -139,6 +145,7 @@ type CliOptions = {
   concurrency: number;
   controlPlane: boolean;
   cpuProfDir?: string;
+  heapProfDir?: string;
   diagnosticsTimeline: boolean;
   entry: string;
   historyBurst: number;
@@ -199,6 +206,7 @@ const VALUE_FLAGS = new Set([
   "--cadence-ms",
   "--concurrency",
   "--cpu-prof-dir",
+  "--heap-prof-dir",
   "--entry",
   "--history-burst",
   "--history-clients",
@@ -261,6 +269,7 @@ function parseOptions(argv: string[] = process.argv.slice(2)): CliOptions {
     ),
     controlPlane: hasFlag(argv, "--control-plane"),
     cpuProfDir: resolveOutputPath(parseFlagValue(argv, "--cpu-prof-dir")),
+    heapProfDir: resolveOutputPath(parseFlagValue(argv, "--heap-prof-dir")),
     diagnosticsTimeline: !hasFlag(argv, "--no-diagnostics-timeline"),
     entry: resolveEntry(parseFlagValue(argv, "--entry"), DEFAULT_ENTRY),
     historyBurst: parseBoundedPositiveInt(
@@ -382,6 +391,7 @@ Options:
   --history-messages <n> Inject up to 500 synthetic messages per seeded session
   --history-message-chars <n> Synthetic message size (default: 1024, max: 65536)
   --cpu-prof-dir <p> Write Gateway V8 CPU profiles to this directory
+  --heap-prof-dir <p> Sample load-phase allocations, including GC-collected objects
   --runs <n>         Measured gateway runs (default: ${DEFAULT_RUNS})
   --warmup <n>       Warmup gateway runs (default: ${DEFAULT_WARMUP})
   --cadence-ms <ms>  Probe cadence (default: ${DEFAULT_CADENCE_MS})
@@ -584,10 +594,13 @@ function tailLines(output: string, lineCount: number): string {
   return output.trimEnd().split(/\r?\n/u).slice(-lineCount).join("\n");
 }
 
-function captureChildOutput(child: ChildProcessWithoutNullStreams): {
+function captureChildOutput(child: ChildProcess): {
   readOutput: () => string;
   readStderrTail: () => string;
 } {
+  if (!child.stdout || !child.stderr) {
+    throw new Error("Gateway benchmark children require piped stdout and stderr");
+  }
   let output = "";
   let stderr = "";
   const appendOutput = (chunk: Buffer) => {
@@ -1027,6 +1040,7 @@ async function runGatewaySample(options: {
   diagnosticsTimeline: boolean;
   entry: string;
   cpuProfDir?: string;
+  heapProfDir?: string;
   historyBurst: number;
   historyClients: number;
   historyMessages: number;
@@ -1047,8 +1061,11 @@ async function runGatewaySample(options: {
   const runStartedAt = performance.now();
   const timelinePath = path.join(root, "diagnostics-timeline.jsonl");
   const requestLogPath = path.join(root, "mock-provider-requests.jsonl");
+  const heapProfilePath = options.heapProfDir
+    ? path.resolve(options.heapProfDir, `gateway-load-${randomUUID()}.heapprofile`)
+    : undefined;
   const protocolVersion = await readGatewayProtocolVersion(options.entry);
-  let gateway: ChildProcessWithoutNullStreams | undefined;
+  let gateway: ChildProcess | undefined;
   let mockProvider: ChildProcessWithoutNullStreams | undefined;
   let client: Awaited<ReturnType<typeof connectGateway>> | undefined;
   const auxiliaryClients: Array<Awaited<ReturnType<typeof connectGateway>>> = [];
@@ -1089,6 +1106,13 @@ async function runGatewaySample(options: {
         mkdirSync(options.cpuProfDir, { recursive: true });
       }
       const gatewayArgs = buildGatewayBenchChildArgs(options.entry, port);
+      if (heapProfilePath) {
+        mkdirSync(path.dirname(heapProfilePath), { recursive: true });
+        gatewayArgs.unshift(
+          "--import",
+          new URL("./lib/gateway-bench-heap-preload.ts", import.meta.url).href,
+        );
+      }
       gateway = spawn(
         process.execPath,
         options.cpuProfDir
@@ -1097,6 +1121,7 @@ async function runGatewaySample(options: {
         {
           cwd: process.cwd(),
           detached: process.platform !== "win32",
+          stdio: heapProfilePath ? ["pipe", "pipe", "pipe", "ipc"] : ["pipe", "pipe", "pipe"],
           env: {
             ...createGatewayBenchEnv(root, configPath, {
               caseEnv: {
@@ -1270,6 +1295,9 @@ async function runGatewaySample(options: {
         auxiliaryClients.push(subscriptionProbeClient);
       }
       const memoryBefore = await readGatewayMemory(rpc, runStartedAt);
+      if (heapProfilePath) {
+        await controlGatewayHeapProfile(gateway, "start", heapProfilePath);
+      }
       const setupDurationMs = performance.now() - setupStartedAt;
       // Large session fixtures are setup, not benchmarked load. Every measured
       // run therefore gets its complete timeout after all clients are ready.
@@ -1432,22 +1460,33 @@ async function runGatewaySample(options: {
       ).finally(() => {
         updatesDone = true;
       });
-      await Promise.all([turns, sampler, historyLoad, sessionUpdateLoad]);
+      const [freshConnectionResult] = await Promise.all([
+        freshConnection,
+        turns,
+        sampler,
+        historyLoad,
+        sessionUpdateLoad,
+      ]);
       const loadEndMonotonicMicros = Number(process.hrtime.bigint() / 1_000n);
+      const turnsDurationMs = performance.now() - turnsStartedAt;
+      const memoryAfter = await readGatewayMemory(rpc, runStartedAt);
+      timelineWindow = { from: timelineFrom, through: Date.now() };
+      let heapProfile: GatewayHeapProfile | undefined;
+      if (heapProfilePath) {
+        await controlGatewayHeapProfile(gateway, "stop", heapProfilePath);
+        heapProfile = readGatewayHeapProfile(heapProfilePath);
+      }
       if (options.historyClients > 0 && !history.some((sample) => sample.ok)) {
         const failure = history[0]?.error ?? "no requests completed before turns finished";
         throw new Error(`all configured chat.history load probes failed: ${failure}`);
       }
-      const freshConnectionResult = await freshConnection;
-      const turnsDurationMs = performance.now() - turnsStartedAt;
-      const memoryAfter = await readGatewayMemory(rpc, runStartedAt);
       peakRssMb = Math.max(peakRssMb, memoryAfter.rssMb);
       const modelRequestCount = existsSync(requestLogPath)
         ? readFileSync(requestLogPath, "utf8").split(/\r?\n/u).filter(Boolean).length
         : 0;
 
-      timelineWindow = { from: timelineFrom, through: Date.now() };
       result = {
+        ...(heapProfile ? { heapProfile } : {}),
         controlPlane,
         controlUi,
         durationMs: performance.now() - runStartedAt,
@@ -1585,6 +1624,14 @@ function summarizeRuns(
   });
   return {
     budgetViolations,
+    gatewaySampledAllocatedBytes: summarizeNumbers(
+      runs.flatMap((run) => (run.heapProfile ? [run.heapProfile.sampledAllocatedBytes] : [])),
+    ),
+    gatewaySampledAllocatedBytesPerTurn: summarizeNumbers(
+      runs.flatMap((run) =>
+        run.heapProfile ? [run.heapProfile.sampledAllocatedBytes / run.turnCount] : [],
+      ),
+    ),
     controlPlane: Object.fromEntries(
       controlMethodProbes.map(({ method, samples }) => [
         method,

--- a/scripts/lib/gateway-bench-child.ts
+++ b/scripts/lib/gateway-bench-child.ts
@@ -1,5 +1,5 @@
 // Gateway Bench Child script supports OpenClaw repository automation.
-import type { ChildProcessWithoutNullStreams } from "node:child_process";
+import type { ChildProcess } from "node:child_process";
 import {
   inspectManagedProcessGroup,
   terminateManagedChild,
@@ -28,7 +28,7 @@ type StopChildOptions = {
 };
 
 export async function stopChild(
-  child: ChildProcessWithoutNullStreams,
+  child: ChildProcess,
   options: StopChildOptions = {},
 ): Promise<StopChildResult> {
   const teardownGraceMs = options.teardownGraceMs ?? TEARDOWN_GRACE_MS;
@@ -157,9 +157,10 @@ export async function stopChild(
   return { exitCode: null, exitedBeforeTeardown: false, signal: "SIGKILL" };
 }
 
-function releaseUnsettledChild(child: ChildProcessWithoutNullStreams): void {
-  child.stdin.destroy();
-  child.stdout.destroy();
-  child.stderr.destroy();
+function releaseUnsettledChild(child: ChildProcess): void {
+  child.stdin?.destroy();
+  child.stdout?.destroy();
+  child.stderr?.destroy();
+  child.channel?.unref();
   child.unref();
 }

--- a/scripts/lib/gateway-bench-heap-preload.ts
+++ b/scripts/lib/gateway-bench-heap-preload.ts
@@ -1,0 +1,69 @@
+import { writeFileSync } from "node:fs";
+import { Session } from "node:inspector/promises";
+import { isMainThread } from "node:worker_threads";
+import {
+  GATEWAY_HEAP_PROFILE_CHANNEL,
+  GATEWAY_HEAP_SAMPLE_INTERVAL,
+  type GatewayHeapProfileCommand,
+} from "./gateway-bench-heap.ts";
+
+// Only the benchmark child gets this preload and IPC descriptor. No inspector
+// listener or profiler control is exposed through the Gateway protocol.
+if (isMainThread) {
+  if (!process.send) {
+    throw new Error("Gateway heap profiling requires the benchmark IPC channel");
+  }
+  const inspector = new Session();
+  inspector.connect();
+  let active = false;
+  let busy = false;
+  process.on("message", (message: GatewayHeapProfileCommand) => {
+    if (message?.channel !== GATEWAY_HEAP_PROFILE_CHANNEL) {
+      return;
+    }
+    const reply = (error?: string) => {
+      process.send?.({ channel: GATEWAY_HEAP_PROFILE_CHANNEL, action: message.action, error });
+    };
+    if (busy) {
+      reply("Gateway heap profile command already in progress");
+      return;
+    }
+    busy = true;
+    void (async () => {
+      if (message.action === "start") {
+        if (active) {
+          throw new Error("Gateway heap profile already started");
+        }
+        // Include dead allocations as well as survivors: retained heap alone
+        // misses the short-lived objects that cause busy-Gateway GC pressure.
+        const options = {
+          samplingInterval: GATEWAY_HEAP_SAMPLE_INTERVAL,
+          includeObjectsCollectedByMajorGC: true,
+          includeObjectsCollectedByMinorGC: true,
+        };
+        await inspector.post("HeapProfiler.startSampling", options);
+        active = true;
+      } else if (message.action === "stop") {
+        if (!active) {
+          throw new Error("Gateway heap profile has not started");
+        }
+        const { profile } = await inspector.post("HeapProfiler.stopSampling");
+        active = false;
+        writeFileSync(message.profilePath, JSON.stringify(profile), { mode: 0o600 });
+      } else {
+        throw new Error("Unknown Gateway heap profile command");
+      }
+    })().then(
+      () => {
+        busy = false;
+        reply();
+      },
+      (error: unknown) => {
+        busy = false;
+        reply(error instanceof Error ? error.message : String(error));
+      },
+    );
+  });
+  process.once("disconnect", () => inspector.disconnect());
+  process.channel?.unref();
+}

--- a/scripts/lib/gateway-bench-heap.ts
+++ b/scripts/lib/gateway-bench-heap.ts
@@ -1,0 +1,105 @@
+import type { ChildProcess } from "node:child_process";
+import { readFileSync } from "node:fs";
+import type { HeapProfiler } from "node:inspector";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+export const GATEWAY_HEAP_PROFILE_CHANNEL = "openclaw-gateway-bench-heap";
+export const GATEWAY_HEAP_SAMPLE_INTERVAL = 32 * 1024;
+
+export type GatewayHeapProfileCommand = {
+  channel: typeof GATEWAY_HEAP_PROFILE_CHANNEL;
+  action: "start" | "stop";
+  profilePath: string;
+};
+
+type GatewayHeapProfileReply = {
+  channel: typeof GATEWAY_HEAP_PROFILE_CHANNEL;
+  action: "start" | "stop";
+  error?: string;
+};
+
+export type GatewayHeapProfile = {
+  profilePath: string;
+  samplingIntervalBytes: number;
+  includesCollectedObjects: true;
+  sampledAllocatedBytes: number;
+  topAllocationSites: Array<{
+    sampledBytes: number;
+    stack: string[];
+  }>;
+};
+
+export async function controlGatewayHeapProfile(
+  child: ChildProcess,
+  action: GatewayHeapProfileCommand["action"],
+  profilePath: string,
+): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const finish = (error?: Error) => {
+      clearTimeout(timer);
+      child.off("message", onMessage);
+      child.off("exit", onExit);
+      child.off("disconnect", onDisconnect);
+      if (error) {
+        reject(error);
+      } else {
+        resolve();
+      }
+    };
+    const onMessage = (message: GatewayHeapProfileReply) => {
+      if (message?.channel !== GATEWAY_HEAP_PROFILE_CHANNEL || message.action !== action) {
+        return;
+      }
+      finish(message.error ? new Error(message.error) : undefined);
+    };
+    const onExit = () => finish(new Error(`Gateway exited during heap profile ${action}`));
+    const onDisconnect = () =>
+      finish(new Error(`Gateway disconnected during heap profile ${action}`));
+    const timer = setTimeout(
+      () => finish(new Error(`Gateway heap profile ${action} timed out after 30000ms`)),
+      30_000,
+    );
+    child.on("message", onMessage);
+    child.once("exit", onExit);
+    child.once("disconnect", onDisconnect);
+    if (!child.connected) {
+      onDisconnect();
+      return;
+    }
+    child.send({ channel: GATEWAY_HEAP_PROFILE_CHANNEL, action, profilePath }, (error) => {
+      if (error) {
+        finish(error);
+      }
+    });
+  });
+}
+
+export function readGatewayHeapProfile(profilePath: string): GatewayHeapProfile {
+  const profile: HeapProfiler.SamplingHeapProfile = JSON.parse(readFileSync(profilePath, "utf8"));
+  const sites: GatewayHeapProfile["topAllocationSites"] = [];
+  let sampledAllocatedBytes = 0;
+  const formatFrame = (frame: HeapProfiler.SamplingHeapProfileNode["callFrame"]): string => {
+    const filePath = frame.url.startsWith("file://") ? fileURLToPath(frame.url) : frame.url;
+    const url = path.isAbsolute(filePath) ? path.relative(process.cwd(), filePath) : filePath;
+    return `${frame.functionName || "(anonymous)"} (${url}:${frame.lineNumber + 1})`;
+  };
+  const visit = (node: HeapProfiler.SamplingHeapProfileNode, parents: string[]) => {
+    const stack = [...parents, formatFrame(node.callFrame)];
+    sampledAllocatedBytes += node.selfSize;
+    if (node.selfSize > 0) {
+      sites.push({ sampledBytes: node.selfSize, stack: stack.slice(-8) });
+    }
+    for (const child of node.children) {
+      visit(child, stack);
+    }
+  };
+  visit(profile.head, []);
+  return {
+    profilePath,
+    samplingIntervalBytes: GATEWAY_HEAP_SAMPLE_INTERVAL,
+    includesCollectedObjects: true,
+    sampledAllocatedBytes,
+    topAllocationSites: sites.toSorted((a, b) => b.sampledBytes - a.sampledBytes).slice(0, 20),
+  };
+}

--- a/test/scripts/bench-gateway-child-test-support.ts
+++ b/test/scripts/bench-gateway-child-test-support.ts
@@ -68,8 +68,9 @@ export function registerStopChildBehaviorTests<TChild>(params: {
     expect(child.kill).toHaveBeenCalledWith("SIGTERM");
   });
 
-  it("bounds teardown when the child ignores termination signals", async () => {
+  it("bounds teardown and releases IPC when the child ignores termination signals", async () => {
     const child = new EventEmitter() as EventEmitter & {
+      channel: { unref: ReturnType<typeof vi.fn> };
       exitCode: number | null;
       kill: ReturnType<typeof vi.fn>;
       signalCode: NodeJS.Signals | null;
@@ -80,6 +81,7 @@ export function registerStopChildBehaviorTests<TChild>(params: {
     };
     child.exitCode = null;
     child.signalCode = null;
+    child.channel = { unref: vi.fn() };
     child.kill = vi.fn(() => true);
     child.stderr = { destroy: vi.fn() };
     child.stdin = { destroy: vi.fn() };
@@ -101,6 +103,7 @@ export function registerStopChildBehaviorTests<TChild>(params: {
     expect(child.stdin.destroy).toHaveBeenCalledOnce();
     expect(child.stdout.destroy).toHaveBeenCalledOnce();
     expect(child.stderr.destroy).toHaveBeenCalledOnce();
+    expect(child.channel.unref).toHaveBeenCalledOnce();
     expect(child.unref).toHaveBeenCalledOnce();
   });
 

--- a/test/scripts/bench-gateway-concurrency.test.ts
+++ b/test/scripts/bench-gateway-concurrency.test.ts
@@ -1,11 +1,16 @@
 // Gateway concurrency benchmark tests cover CLI controls, probe budgets, and summaries.
-import { spawnSync } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
+import { once } from "node:events";
 import { writeFile } from "node:fs/promises";
 import { createServer as createHttpServer } from "node:http";
 import { createServer as createRawServer, type Socket } from "node:net";
 import { performance } from "node:perf_hooks";
 import { describe, expect, it } from "vitest";
 import { testing } from "../../scripts/bench-gateway-concurrency.ts";
+import {
+  controlGatewayHeapProfile,
+  readGatewayHeapProfile,
+} from "../../scripts/lib/gateway-bench-heap.ts";
 import { withTempDir } from "../../src/test-utils/temp-dir.js";
 
 type BenchmarkRun = Parameters<typeof testing.summarizeRuns>[0][number];
@@ -39,6 +44,65 @@ function createBenchmarkRun(overrides: Partial<BenchmarkRun> = {}): BenchmarkRun
 }
 
 describe("gateway concurrency benchmark script", () => {
+  it("profiles load allocations after collection without charging startup allocations", async () => {
+    await withTempDir("gateway-heap-profile-", async (dir) => {
+      const child = spawn(
+        process.execPath,
+        [
+          "--expose-gc",
+          "--import",
+          new URL("../../scripts/lib/gateway-bench-heap-preload.ts", import.meta.url).href,
+          "--input-type=module",
+          "--eval",
+          `process.stdin.resume();
+        function startupAllocations() {
+          return Array.from({ length: 20000 }, (_, index) => Array(100).fill(index));
+        }
+        globalThis.startup = startupAllocations();
+        globalThis.startup = null;
+        gc();
+        function loadAllocations() {
+          return Array.from({ length: 20000 }, (_, index) => Array(100).fill(index));
+        }
+        process.on("message", (message) => {
+          if (message !== "allocate") return;
+          globalThis.load = loadAllocations();
+          globalThis.load = null;
+          gc();
+          gc();
+          process.send("allocated");
+        });
+        process.send("ready");`,
+        ],
+        { stdio: ["pipe", "pipe", "pipe", "ipc"] },
+      );
+      const exited = once(child, "exit");
+      try {
+        const ready = await Promise.race([
+          once(child, "message"),
+          exited.then(() => {
+            throw new Error("Heap profile fixture exited before ready");
+          }),
+        ]);
+        expect(ready[0]).toBe("ready");
+        const profilePath = `${dir}/load.heapprofile`;
+        await controlGatewayHeapProfile(child, "start", profilePath);
+        const allocated = once(child, "message");
+        child.send("allocate");
+        expect((await allocated)[0]).toBe("allocated");
+        await controlGatewayHeapProfile(child, "stop", profilePath);
+        const profile = readGatewayHeapProfile(profilePath);
+        expect(profile.sampledAllocatedBytes).toBeGreaterThan(1_000_000);
+        const stacks = profile.topAllocationSites.flatMap((site) => site.stack).join("\n");
+        expect(stacks).toContain("loadAllocations");
+        expect(stacks).not.toContain("startupAllocations");
+      } finally {
+        child.kill();
+        await exited;
+      }
+    });
+  });
+
   it("parses benchmark controls without booting a gateway", () => {
     expect(
       testing.parseOptions([
@@ -54,6 +118,8 @@ describe("gateway concurrency benchmark script", () => {
         "90000",
         "--cpu-prof-dir",
         "/tmp/gateway-cpu-profiles",
+        "--heap-prof-dir",
+        "/tmp/gateway-heap-profiles",
         "--plugin-count",
         "50",
         "--session-count",
@@ -91,6 +157,7 @@ describe("gateway concurrency benchmark script", () => {
       cadenceMs: 50,
       concurrency: 12,
       cpuProfDir: "/tmp/gateway-cpu-profiles",
+      heapProfDir: "/tmp/gateway-heap-profiles",
       diagnosticsTimeline: false,
       json: true,
       historyBurst: 5,


### PR DESCRIPTION
Related: #145608

## What Problem This Solves

Busy Gateway benchmarks report retained heap and RSS, which hide short-lived allocations that have already been garbage-collected. Startup allocations also obscure the work performed by concurrent sessions.

## Why This Change Was Made

Add `--heap-prof-dir` to the existing Gateway concurrency benchmark. A private child-process preload starts V8 sampling after fixture setup and stops after every load operation, including the fresh-connection probe. Sampling includes objects collected by minor and major GC. The report retains the raw profile, sampled bytes per run and turn, and the largest allocation stacks.

The instrumentation stays in repository tooling. It exposes no Gateway RPC or inspector listener, skips worker threads, and does not keep the Gateway process alive.

## User Impact

Developers can attribute allocation churn to the actual parallel-session workload and compare fixes using the existing benchmark options. Normal Gateway execution is unchanged.

## Evidence

- Benchmark and sibling lifecycle tests: 91 passed, including a real V8 allocation/GC test that excludes startup allocations and retains collected load objects.
- Three completed 32-session synthetic runs with tool execution, 128 seeded sessions, 16 observers, history clients, session updates, and control-plane probes. All turns and probes completed; profiles consistently identified approximately 10.8 GiB of load allocations in the existing runtime.
- Independent review identified an incomplete handshake barrier and an IPC teardown fallback; both are fixed. The teardown regression fails without IPC release and passes with it.
- Full build, typechecks, and selected lint/ownership/graph checks passed.

## Data compatibility

The new JSON writes produce explicit benchmark artifacts in the operator-selected `--heap-prof-dir`, using a fresh UUID filename for each run. They contain V8's sampling profile and are read only by the benchmark's summary step. Gateway databases, schemas, configuration, saved sessions, and upgrade/migration paths are untouched. Normal runs without the flag do not create these files. There is no stored application-data migration to prove; the existing Node/V8 profile contract and disabled/enabled benchmark tests cover the artifact boundary.

Initial merged-base CI surfaced the unrelated `src/auto-reply/thinking.test.ts` line cap, already being repaired by #145632, plus a timeout in an unchanged isolated `run-vitest-profile` help case. The latter did not execute this benchmark or preload; its precise stalled phase is not available in the CI log.
