### PR TITLE
test(auto-reply): split response usage coverage

### DIFF
--- a/src/auto-reply/thinking.response-usage.test.ts
+++ b/src/auto-reply/thinking.response-usage.test.ts
@@ -1,0 +1,46 @@
+/** Tests response-usage configuration precedence independently from thinking profiles. */
+import { describe, expect, it } from "vitest";
+import { resolveEffectiveResponseUsage } from "./thinking.js";
+
+describe("resolveEffectiveResponseUsage", () => {
+  it("returns off when session is unset and no config is provided", () => {
+    expect(resolveEffectiveResponseUsage(undefined, undefined)).toBe("off");
+    expect(resolveEffectiveResponseUsage(null, undefined)).toBe("off");
+  });
+
+  it("applies config default when session is unset", () => {
+    expect(resolveEffectiveResponseUsage(undefined, "tokens")).toBe("tokens");
+    expect(resolveEffectiveResponseUsage(undefined, "full")).toBe("full");
+  });
+
+  it("applies per-channel config entry when session is unset", () => {
+    const cfg = { default: "off", discord: "full", telegram: "tokens" } as const;
+    expect(resolveEffectiveResponseUsage(undefined, cfg, "discord")).toBe("full");
+    expect(resolveEffectiveResponseUsage(undefined, cfg, "telegram")).toBe("tokens");
+    // Unknown channel falls back to config default
+    expect(resolveEffectiveResponseUsage(undefined, cfg, "whatsapp")).toBe("off");
+  });
+
+  it("session explicit off overrides any config default", () => {
+    // Explicit "off" is stored and wins — non-off config default cannot re-enable it.
+    expect(resolveEffectiveResponseUsage("off", "tokens")).toBe("off");
+    expect(resolveEffectiveResponseUsage("off", "full")).toBe("off");
+    expect(
+      resolveEffectiveResponseUsage("off", { default: "full", discord: "full" }, "discord"),
+    ).toBe("off");
+  });
+
+  it("session explicit on value overrides config default", () => {
+    expect(resolveEffectiveResponseUsage("tokens", "full")).toBe("tokens");
+    expect(resolveEffectiveResponseUsage("full", "off")).toBe("full");
+  });
+
+  it("unset (undefined/null) falls through to config; explicit off does not", () => {
+    // These two are distinct states:
+    // - undefined = unset/inherit → gets config default
+    // - "off"     = explicit off  → stays off
+    const cfg = "tokens" as const;
+    expect(resolveEffectiveResponseUsage(undefined, cfg)).toBe("tokens"); // inherits
+    expect(resolveEffectiveResponseUsage("off", cfg)).toBe("off"); // explicit off persists
+  });
+});

--- a/src/auto-reply/thinking.test.ts
+++ b/src/auto-reply/thinking.test.ts
@@ -21,7 +21,6 @@ const {
   formatThinkingLevels,
   resolveSupportedThinkingLevel,
   resolveThinkingDefaultForModel,
-  resolveEffectiveResponseUsage,
 } = await import("./thinking.js");
 
 beforeEach(() => {
@@ -1103,48 +1102,5 @@ describe("normalizeReasoningLevel", () => {
   it("accepts stream", () => {
     expect(normalizeReasoningLevel("stream")).toBe("stream");
     expect(normalizeReasoningLevel("streaming")).toBe("stream");
-  });
-});
-
-describe("resolveEffectiveResponseUsage", () => {
-  it("returns off when session is unset and no config is provided", () => {
-    expect(resolveEffectiveResponseUsage(undefined, undefined)).toBe("off");
-    expect(resolveEffectiveResponseUsage(null, undefined)).toBe("off");
-  });
-
-  it("applies config default when session is unset", () => {
-    expect(resolveEffectiveResponseUsage(undefined, "tokens")).toBe("tokens");
-    expect(resolveEffectiveResponseUsage(undefined, "full")).toBe("full");
-  });
-
-  it("applies per-channel config entry when session is unset", () => {
-    const cfg = { default: "off", discord: "full", telegram: "tokens" } as const;
-    expect(resolveEffectiveResponseUsage(undefined, cfg, "discord")).toBe("full");
-    expect(resolveEffectiveResponseUsage(undefined, cfg, "telegram")).toBe("tokens");
-    // Unknown channel falls back to config default
-    expect(resolveEffectiveResponseUsage(undefined, cfg, "whatsapp")).toBe("off");
-  });
-
-  it("session explicit off overrides any config default", () => {
-    // Explicit "off" is stored and wins — non-off config default cannot re-enable it.
-    expect(resolveEffectiveResponseUsage("off", "tokens")).toBe("off");
-    expect(resolveEffectiveResponseUsage("off", "full")).toBe("off");
-    expect(
-      resolveEffectiveResponseUsage("off", { default: "full", discord: "full" }, "discord"),
-    ).toBe("off");
-  });
-
-  it("session explicit on value overrides config default", () => {
-    expect(resolveEffectiveResponseUsage("tokens", "full")).toBe("tokens");
-    expect(resolveEffectiveResponseUsage("full", "off")).toBe("full");
-  });
-
-  it("unset (undefined/null) falls through to config; explicit off does not", () => {
-    // These two are distinct states:
-    // - undefined = unset/inherit → gets config default
-    // - "off"     = explicit off  → stays off
-    const cfg = "tokens" as const;
-    expect(resolveEffectiveResponseUsage(undefined, cfg)).toBe("tokens"); // inherits
-    expect(resolveEffectiveResponseUsage("off", cfg)).toBe("off"); // explicit off persists
   });
 });


### PR DESCRIPTION
## Summary

- move response-usage precedence coverage into a focused test file
- bring `src/auto-reply/thinking.test.ts` back below the enforced max-lines budget
- preserve all existing assertions and production behavior

## Why

Current `main` fails `check-lint-core-2` because recently merged thinking-profile tests combine to exceed the file budget. That base failure blocks unrelated PR CI, including #123058.

## Verification

- `pnpm exec vitest run src/auto-reply/thinking.test.ts src/auto-reply/thinking.response-usage.test.ts` — 83 passed
- `pnpm check:changed` — passed
