### PR TITLE
improve: reduce Gateway overhead during frequent state writes

### DIFF
--- a/extensions/whatsapp/src/monitor-inbox.socket-lifecycle.test.ts
+++ b/extensions/whatsapp/src/monitor-inbox.socket-lifecycle.test.ts
@@ -588,7 +588,7 @@ describe("web monitor inbox socket lifecycle", () => {
         );
         expect(loggedTimeoutFailure).toBe(true);
       });
-      expect(vi.getTimerCount()).toBe(0);
+      expect(sock.readMessages).toHaveBeenCalledTimes(1);
     } finally {
       vi.useRealTimers();
       await listener.close();

--- a/src/cron/service.every-jobs-fire.test.ts
+++ b/src/cron/service.every-jobs-fire.test.ts
@@ -34,9 +34,11 @@ describe("CronService interval/cron jobs fire on time", () => {
     jobId: string;
     firstDueAt: number;
   }) => {
-    vi.setSystemTime(new Date(firstDueAt + 5));
+    const untilDueMs = firstDueAt - Date.now();
+    // Move wall time five milliseconds ahead without consuming the timer's remaining delay.
+    vi.setSystemTime(new Date(Date.now() + 5));
     const finishedRun = finished.waitForOk(jobId);
-    await vi.runOnlyPendingTimersAsync();
+    await vi.advanceTimersByTimeAsync(untilDueMs);
     await finishedRun;
     const jobs = await cron.list({ includeDisabled: true });
     return jobs.find((current) => current.id === jobId);
@@ -128,7 +130,7 @@ describe("CronService interval/cron jobs fire on time", () => {
 
     const finishedRun = finished.waitForOk(job.id);
     cron.resumeScheduling();
-    await vi.runOnlyPendingTimersAsync();
+    await vi.advanceTimersByTimeAsync(2_000);
     await finishedRun;
     expectMainSystemEvent(enqueueSystemEvent, "resumed-tick");
 
@@ -162,12 +164,22 @@ describe("CronService interval/cron jobs fire on time", () => {
       throw new Error("arm failed");
     });
 
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+    const clearTimeoutSpy = vi.spyOn(globalThis, "clearTimeout");
     expect(() => cron.resumeScheduling()).toThrow("arm failed");
-    expect(vi.getTimerCount()).toBe(0);
+    expect(setTimeoutSpy).toHaveBeenCalledExactlyOnceWith(expect.any(Function), 10_000);
+    expect(clearTimeoutSpy).toHaveBeenCalledWith(setTimeoutSpy.mock.results[0]?.value);
+    setTimeoutSpy.mockClear();
+    clearTimeoutSpy.mockClear();
+
     expect(() => cron.resumeScheduling()).not.toThrow();
-    expect(vi.getTimerCount()).toBe(1);
+    expect(setTimeoutSpy).toHaveBeenCalledExactlyOnceWith(expect.any(Function), 10_000);
+    expect(clearTimeoutSpy).not.toHaveBeenCalled();
 
     cron.stop();
+    expect(clearTimeoutSpy).toHaveBeenCalledWith(setTimeoutSpy.mock.results[0]?.value);
+    setTimeoutSpy.mockRestore();
+    clearTimeoutSpy.mockRestore();
     await store.cleanup();
   });
 

--- a/src/cron/service.persists-delivered-status.test.ts
+++ b/src/cron/service.persists-delivered-status.test.ts
@@ -177,8 +177,7 @@ async function runSingleJobAndReadState(params: {
 }) {
   const job = await params.cron.add(params.job);
   const finishedPromise = params.waitForFinished?.(job.id) ?? params.finished.waitForOk(job.id);
-  vi.setSystemTime(new Date(job.state.nextRunAtMs! + 5));
-  await vi.runOnlyPendingTimersAsync();
+  await vi.advanceTimersByTimeAsync(job.state.nextRunAtMs! + 5 - Date.now());
   await finishedPromise;
 
   const jobs = await params.cron.list({ includeDisabled: true });

--- a/src/cron/service.runs-one-shot-main-job-disables-it.test.ts
+++ b/src/cron/service.runs-one-shot-main-job-disables-it.test.ts
@@ -162,8 +162,7 @@ async function runIsolatedAnnounceJobAndWait(params: {
   status: "ok" | "error";
 }) {
   const { job, runAt } = await addDefaultIsolatedAnnounceJob(params.cron, params.name);
-  vi.setSystemTime(runAt);
-  await vi.runOnlyPendingTimersAsync();
+  await vi.advanceTimersByTimeAsync(runAt.getTime() - Date.now());
   await params.events.waitFor(
     (evt) => evt.jobId === job.id && evt.action === "finished" && evt.status === params.status,
   );
@@ -301,8 +300,7 @@ describe("CronService", () => {
 
     expect(job.state.nextRunAtMs).toBe(atMs);
 
-    vi.setSystemTime(new Date("2025-12-13T00:00:02.000Z"));
-    await vi.runOnlyPendingTimersAsync();
+    await vi.advanceTimersByTimeAsync(Date.parse("2025-12-13T00:00:02.000Z") - Date.now());
     await events.waitFor((evt) => evt.jobId === job.id && evt.action === "finished");
 
     const jobs = await cron.list({ includeDisabled: true });
@@ -321,8 +319,7 @@ describe("CronService", () => {
         name: "one-shot delete",
       });
 
-    vi.setSystemTime(new Date("2025-12-13T00:00:02.000Z"));
-    await vi.runOnlyPendingTimersAsync();
+    await vi.advanceTimersByTimeAsync(Date.parse("2025-12-13T00:00:02.000Z") - Date.now());
     await events.waitFor((evt) => evt.jobId === job.id && evt.action === "removed");
 
     const jobs = await cron.list({ includeDisabled: true });
@@ -384,8 +381,7 @@ describe("CronService", () => {
       delivery: { mode: "announce", bestEffort: testCase.bestEffort },
     });
 
-    vi.setSystemTime(runAt);
-    await vi.runOnlyPendingTimersAsync();
+    await vi.advanceTimersByTimeAsync(runAt.getTime() - Date.now());
     const event = await events.waitFor(
       (candidate) => candidate.jobId === job.id && candidate.action === "finished",
     );
@@ -451,8 +447,7 @@ describe("CronService", () => {
     });
 
     const firstAt = job.state.nextRunAtMs!;
-    vi.setSystemTime(firstAt);
-    await vi.runOnlyPendingTimersAsync();
+    await vi.advanceTimersByTimeAsync(firstAt - Date.now());
     await events.waitFor(
       (candidate) => candidate.jobId === job.id && candidate.action === "finished",
     );
@@ -460,8 +455,7 @@ describe("CronService", () => {
     expect(secondAt).toBeTypeOf("number");
     expect(cron.getJob(job.id)?.state.consecutiveErrors).toBe(0);
 
-    vi.setSystemTime(secondAt!);
-    await vi.runOnlyPendingTimersAsync();
+    await vi.advanceTimersByTimeAsync(secondAt! - Date.now());
     await vi.waitFor(() => expect(runIsolatedAgentJob).toHaveBeenCalledTimes(2));
     const updated = cron.getJob(job.id);
     expect(updated).toMatchObject({
@@ -494,8 +488,7 @@ describe("CronService", () => {
     });
     expect(updated.deleteAfterRun).toBe(true);
 
-    vi.setSystemTime(atMs);
-    await vi.runOnlyPendingTimersAsync();
+    await vi.advanceTimersByTimeAsync(atMs - Date.now());
     await events.waitFor((evt) => evt.jobId === job.id && evt.action === "removed");
 
     const jobs = await cron.list({ includeDisabled: true });
@@ -521,8 +514,7 @@ describe("CronService", () => {
     });
     expect(updated.deleteAfterRun).toBe(false);
 
-    vi.setSystemTime(atMs);
-    await vi.runOnlyPendingTimersAsync();
+    await vi.advanceTimersByTimeAsync(atMs - Date.now());
     await events.waitFor((evt) => evt.jobId === job.id && evt.action === "finished");
 
     const jobs = await cron.list({ includeDisabled: true });

--- a/src/gateway/exec-approval-manager.test.ts
+++ b/src/gateway/exec-approval-manager.test.ts
@@ -22,15 +22,11 @@ import type { ExecApprovalManagerOptions } from "./exec-approval-manager.types.j
 import { getOperatorApprovalDetailed, resolveOperatorApproval } from "./operator-approval-store.js";
 
 type TimeoutCallback = Parameters<typeof setTimeout>[0];
-type GetOperatorApprovalParams = Parameters<typeof getOperatorApprovalDetailed>[0];
 
-function getOperatorApproval(params: GetOperatorApprovalParams) {
+function getOperatorApproval(params: Parameters<typeof getOperatorApprovalDetailed>[0]) {
   const result = getOperatorApprovalDetailed(params);
   return result.outcome === "found" ? result.record : null;
 }
-type MockTimerHandle = ReturnType<typeof setTimeout> & {
-  unref: ReturnType<typeof vi.fn>;
-};
 
 describe("ExecApprovalManager", () => {
   const tempDirs: string[] = [];
@@ -71,20 +67,24 @@ describe("ExecApprovalManager", () => {
     const timers: Array<{
       callback: TimeoutCallback;
       delay: number | undefined;
-      handle: MockTimerHandle;
+      handle: { unref: ReturnType<typeof vi.fn> };
     }> = [];
 
-    vi.spyOn(globalThis, "setTimeout").mockImplementation(((
-      callback: TimeoutCallback,
-      delay?: number,
-    ) => {
-      const handle = { unref: vi.fn() } as unknown as MockTimerHandle;
+    vi.spyOn(globalThis, "setTimeout").mockImplementation((callback, delay) => {
+      const handle = { unref: vi.fn() };
       timers.push({ callback, delay, handle });
-      return handle;
-    }) as unknown as typeof setTimeout);
+      return handle as unknown as ReturnType<typeof setTimeout>;
+    });
     vi.spyOn(globalThis, "clearTimeout").mockImplementation(() => undefined);
 
     return timers;
+  }
+
+  function deadlineTimers(timers: ReturnType<typeof installTimerMocks>, delays: number[]) {
+    // Pending deadlines keep their waiter alive; cleanup and maintenance do not.
+    const deadlines = timers.filter(({ handle }) => handle.unref.mock.calls.length === 0);
+    expect(deadlines.map(({ delay }) => delay)).toEqual(delays);
+    return deadlines;
   }
 
   function runTimer(timer: { callback: TimeoutCallback } | undefined): void {
@@ -255,7 +255,7 @@ describe("ExecApprovalManager", () => {
     void manager.register(record, MAX_TIMER_TIMEOUT_MS + 1);
 
     expect(record.expiresAtMs).toBe(1_000 + MAX_TIMER_TIMEOUT_MS);
-    expect(timers[0]?.delay).toBe(MAX_TIMER_TIMEOUT_MS);
+    deadlineTimers(timers, [MAX_TIMER_TIMEOUT_MS]);
   });
 
   it("schedules registration from the record's remaining lifetime", (testContext) => {
@@ -267,7 +267,7 @@ describe("ExecApprovalManager", () => {
     void manager.register(record, 60_000);
 
     expect(record.expiresAtMs).toBe(61_000);
-    expect(timers[0]?.delay).toBe(59_750);
+    deadlineTimers(timers, [59_750]);
   });
 
   it("reschedules a deadline timer when the wall clock rolls backward", async () => {
@@ -278,15 +278,14 @@ describe("ExecApprovalManager", () => {
     const decisionPromise = manager.register(record, 60_000);
     vi.mocked(Date.now).mockReturnValue(500);
 
-    runTimer(timers[0]);
+    runTimer(deadlineTimers(timers, [60_000])[0]);
 
     expect(getOperatorApproval({ id: record.id, databaseOptions })).toMatchObject({
       status: "pending",
     });
-    expect(timers[1]?.delay).toBe(60_500);
-
+    const rescheduled = deadlineTimers(timers, [60_000, 60_500]);
     vi.mocked(Date.now).mockReturnValue(record.expiresAtMs);
-    runTimer(timers[1]);
+    runTimer(rescheduled[1]);
     await expect(decisionPromise).resolves.toBeNull();
     expect(getOperatorApproval({ id: record.id, databaseOptions })).toMatchObject({
       status: "expired",
@@ -462,7 +461,7 @@ describe("ExecApprovalManager", () => {
     const decisionPromise = manager.register(record, 60_000);
     vi.mocked(Date.now).mockReturnValue(record.expiresAtMs);
 
-    runTimer(timers[0]);
+    runTimer(deadlineTimers(timers, [60_000])[0]);
 
     await expect(decisionPromise).resolves.toBeNull();
     expect(lifecycleEvents.map((event) => event.phase)).toEqual(["pending", "terminal"]);
@@ -787,6 +786,7 @@ describe("ExecApprovalManager", () => {
 
   it("reports persistence failures from the timeout callback without throwing", async () => {
     const timers = installTimerMocks();
+    vi.spyOn(Date, "now").mockReturnValue(1_000);
     const onError = vi.fn();
     const { manager, databaseOptions, dir } = createPersistentManager({ onError });
     const record = manager.create({ command: "echo ok" }, 60_000, "approval-timer-error");
@@ -795,7 +795,8 @@ describe("ExecApprovalManager", () => {
     fs.writeFileSync(blocker, "blocked");
     databaseOptions.path = path.join(blocker, "state.sqlite");
 
-    expect(() => runTimer(timers[0])).not.toThrow();
+    const deadline = deadlineTimers(timers, [60_000])[0];
+    expect(() => runTimer(deadline)).not.toThrow();
     await expect(decisionPromise).resolves.toBe("deny");
     expect(onError).toHaveBeenCalledWith(
       expect.any(Error),

--- a/src/gateway/worker-environments/service-lifetime.test.ts
+++ b/src/gateway/worker-environments/service-lifetime.test.ts
@@ -58,6 +58,8 @@ describe("worker environment service", () => {
 
   it("maintains configured providers on the existing timer with no environments", async () => {
     vi.useFakeTimers();
+    const setIntervalSpy = vi.spyOn(globalThis, "setInterval");
+    const clearIntervalSpy = vi.spyOn(globalThis, "clearInterval");
     const maintain = vi.fn(async () => {});
     const workerService = support.createService(support.createProvider(), {
       maintainProviders: maintain,
@@ -69,9 +71,11 @@ describe("worker environment service", () => {
     expect(maintain).toHaveBeenCalledOnce();
     await vi.advanceTimersByTimeAsync(25);
     expect(maintain).toHaveBeenCalledTimes(2);
-    expect(vi.getTimerCount()).toBe(1);
+    expect(setIntervalSpy).toHaveBeenCalledExactlyOnceWith(expect.any(Function), 25);
     await workerService.stop();
-    expect(vi.getTimerCount()).toBe(0);
+    expect(clearIntervalSpy).toHaveBeenCalledWith(setIntervalSpy.mock.results[0]?.value);
+    await vi.advanceTimersByTimeAsync(25);
+    expect(maintain).toHaveBeenCalledTimes(2);
   });
 
   it("keeps maintenance off reconciliation and allocation while shutdown aborts and drains it", async () => {
@@ -271,6 +275,8 @@ describe("worker environment service", () => {
 
   it("owns and clears one periodic reconciliation timer", async () => {
     vi.useFakeTimers();
+    const setIntervalSpy = vi.spyOn(globalThis, "setInterval");
+    const clearIntervalSpy = vi.spyOn(globalThis, "clearInterval");
     const environmentId = "worker-guarded-reconcile";
     support.seedReady(environmentId);
     const inspect = vi.fn(async () => ({ status: "active" as const }));
@@ -306,7 +312,7 @@ describe("worker environment service", () => {
     workerService.start();
     await vi.advanceTimersByTimeAsync(0);
     expect(liveEvents.start).toHaveBeenCalledOnce();
-    expect(vi.getTimerCount()).toBe(1);
+    expect(setIntervalSpy).toHaveBeenCalledExactlyOnceWith(expect.any(Function), 25);
     await vi.advanceTimersByTimeAsync(25);
     expect(guardedEnvironmentIds).toEqual([environmentId, environmentId, environmentId]);
     expect(inspect).toHaveBeenCalledTimes(3);
@@ -318,7 +324,9 @@ describe("worker environment service", () => {
 
     expect(liveEvents.clear).toHaveBeenCalledTimes(2);
     expect(unsubscribeTurnClaimClosed).toHaveBeenCalledOnce();
-    expect(vi.getTimerCount()).toBe(0);
+    expect(clearIntervalSpy).toHaveBeenCalledWith(setIntervalSpy.mock.results[0]?.value);
+    await vi.advanceTimersByTimeAsync(25);
+    expect(inspect).toHaveBeenCalledTimes(4);
   });
 
   it("closes new guarded reconciliation and drains the admitted operation on uninstall", async () => {

--- a/src/infra/sqlite-coordinator.idle.test.ts
+++ b/src/infra/sqlite-coordinator.idle.test.ts
@@ -1,0 +1,337 @@
+import { execFileSync, spawn } from "node:child_process";
+import { once } from "node:events";
+import fs from "node:fs";
+import path from "node:path";
+import type { DatabaseSync } from "node:sqlite";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { stopChildProcess } from "../../test/helpers/stop-child-process.js";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { requireNodeSqlite } from "./node-sqlite.js";
+import {
+  tryAcquireExclusiveSqliteCoordinator,
+  tryAcquireSharedSqliteCoordinator,
+} from "./sqlite-coordinator.js";
+import {
+  acquireStateDatabaseCoordinator,
+  acquireStateDatabaseHandleExclusion,
+} from "./state-database-coordinator.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+const loader = new URL("../../scripts/tsx.mjs", import.meta.url).href;
+const ownerUrl = new URL("./state-database-coordinator.ts", import.meta.url).href;
+
+function observeConnections() {
+  const databases = new Set<DatabaseSync>();
+  const prototype = requireNodeSqlite().DatabaseSync.prototype;
+  const exec = prototype.exec;
+  vi.spyOn(prototype, "exec").mockImplementation(function (this: DatabaseSync, sql) {
+    databases.add(this);
+    return exec.call(this, sql);
+  });
+  return databases;
+}
+
+function fixture() {
+  const directory = tempDirs.make("openclaw-coordinator-idle-");
+  const location = path.join(directory, "coordinator.sqlite");
+  fs.writeFileSync(location, "");
+  return { directory, location };
+}
+
+async function holdPeer(location: string) {
+  const peer = spawn(
+    process.execPath,
+    [
+      "--input-type=module",
+      "--eval",
+      `
+    import { DatabaseSync } from "node:sqlite";
+    const db = new DatabaseSync(process.argv[1]);
+    db.exec("PRAGMA journal_mode=MEMORY; BEGIN EXCLUSIVE");
+    process.send("ready");
+    process.once("message", () => { db.exec("ROLLBACK"); db.close(); process.disconnect(); });
+  `,
+      location,
+    ],
+    { stdio: ["ignore", "ignore", "pipe", "ipc"] },
+  );
+  try {
+    const [message] = await once(peer, "message", { signal: AbortSignal.timeout(5_000) });
+    expect(message).toBe("ready");
+  } catch (error) {
+    await stopChildProcess(peer, 5_000);
+    throw error;
+  }
+  return async () => {
+    const exited = once(peer, "exit");
+    peer.send("release");
+    await exited;
+  };
+}
+
+describe("idle SQLite coordinator connections", () => {
+  beforeEach(() => vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] }));
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
+  });
+
+  it("reuses the default state owner connection while releasing each lock and resetting timeout", async () => {
+    const { directory } = fixture();
+    const params = { databasePath: path.join(directory, "state.sqlite") };
+    const first = acquireStateDatabaseCoordinator(params);
+    const location = first.path;
+    first.release();
+    const databases = observeConnections();
+    const warm = acquireStateDatabaseCoordinator({ ...params, busyTimeoutMs: 25 });
+    warm.release();
+    const [database] = databases;
+    expect(database.isOpen).toBe(true);
+    expect(database.isTransaction).toBe(false);
+    const releasePeer = await holdPeer(location);
+    await releasePeer();
+    const next = acquireStateDatabaseCoordinator(params);
+    expect(databases.size).toBe(1);
+    expect(database.prepare("PRAGMA busy_timeout").get()).toEqual({ timeout: 0 });
+    expect(database.isTransaction).toBe(true);
+    next.release();
+    vi.advanceTimersByTime(60_000);
+    expect(database.isOpen).toBe(false);
+    fs.unlinkSync(location);
+  });
+
+  it("does not let an old expiry close a checked-out or newly idle owner", () => {
+    const { location } = fixture();
+    const databases = observeConnections();
+    const timer = vi.spyOn(globalThis, "setTimeout");
+    tryAcquireExclusiveSqliteCoordinator(location, { keepAlive: true })?.release();
+    const oldExpiry = timer.mock.calls.at(-1)?.[0];
+    const active = tryAcquireExclusiveSqliteCoordinator(location, { keepAlive: true });
+    const [database] = databases;
+    if (typeof oldExpiry !== "function") {
+      throw new Error("idle expiry was not scheduled");
+    }
+    oldExpiry();
+    expect(database.isOpen).toBe(true);
+    expect(database.isTransaction).toBe(true);
+    active?.release();
+    oldExpiry();
+    expect(database.isOpen).toBe(true);
+    vi.advanceTimersByTime(60_000);
+    expect(database.isOpen).toBe(false);
+  });
+
+  it.skipIf(process.platform === "win32").each(["replace", "delete"])(
+    "locks the current file after idle pathname %s",
+    async (change) => {
+      const { directory, location } = fixture();
+      tryAcquireExclusiveSqliteCoordinator(location, { keepAlive: true })?.release();
+      if (change === "replace") {
+        fs.renameSync(location, path.join(directory, "previous.sqlite"));
+      } else {
+        fs.unlinkSync(location);
+      }
+      fs.writeFileSync(location, "");
+      const release = await holdPeer(location);
+      try {
+        expect(tryAcquireExclusiveSqliteCoordinator(location, { keepAlive: true })).toBeNull();
+      } finally {
+        await release();
+      }
+      const acquired = tryAcquireExclusiveSqliteCoordinator(location, { keepAlive: true });
+      expect(acquired).not.toBeNull();
+      acquired?.release();
+    },
+  );
+
+  it("bounds idle connections and never evicts a borrowed lock", () => {
+    const databases = observeConnections();
+    const { location } = fixture();
+    const held = tryAcquireExclusiveSqliteCoordinator(location, { keepAlive: true });
+    const [activeDatabase] = databases;
+    for (let index = 0; index < 20; index++) {
+      tryAcquireExclusiveSqliteCoordinator(fixture().location, { keepAlive: true })?.release();
+    }
+    expect([...databases].filter((database) => database.isOpen)).toHaveLength(17);
+    expect(activeDatabase.isTransaction).toBe(true);
+    held?.release();
+    expect([...databases].filter((database) => database.isOpen)).toHaveLength(16);
+    vi.advanceTimersByTime(60_000);
+    expect([...databases].some((database) => database.isOpen)).toBe(false);
+  });
+
+  it.each([tryAcquireExclusiveSqliteCoordinator, tryAcquireSharedSqliteCoordinator])(
+    "keeps unpooled acquisitions immediately removable",
+    (acquire) => {
+      const { location } = fixture();
+      const databases = observeConnections();
+      acquire(location)?.release();
+      expect([...databases].every((database) => !database.isOpen)).toBe(true);
+      fs.unlinkSync(location);
+    },
+  );
+
+  it.each(["runtimeDirectory", "coordinatorPath"])(
+    "does not retain caller-owned %s",
+    (override) => {
+      const { directory, location } = fixture();
+      const databases = observeConnections();
+      const params = {
+        databasePath: path.join(directory, "state.sqlite"),
+        ...(override === "runtimeDirectory"
+          ? { runtimeDirectory: directory }
+          : { coordinatorPath: location }),
+      };
+      const coordinator = acquireStateDatabaseCoordinator(params);
+      coordinator.release();
+      expect([...databases].every((database) => !database.isOpen)).toBe(true);
+      fs.unlinkSync(coordinator.path);
+    },
+  );
+
+  it("rechecks idle eligibility after an authority callback changes the runtime location", () => {
+    const { directory } = fixture();
+    const params: { databasePath: string; runtimeDirectory?: string } = {
+      databasePath: path.join(directory, "state.sqlite"),
+    };
+    const exclusion = acquireStateDatabaseHandleExclusion(params);
+    let changeRuntime = false;
+    let coordinatorPath: string | undefined;
+    try {
+      exclusion.runWithCanonicalWrites(
+        () => {
+          if (changeRuntime) {
+            params.runtimeDirectory = directory;
+          }
+        },
+        () => {
+          changeRuntime = true;
+          const databases = observeConnections();
+          const coordinator = acquireStateDatabaseCoordinator(params);
+          coordinatorPath = coordinator.path;
+          coordinator.release();
+          expect([...databases].every((database) => !database.isOpen)).toBe(true);
+        },
+      );
+    } finally {
+      exclusion.release();
+    }
+    expect(coordinatorPath).toBeDefined();
+    if (coordinatorPath) {
+      fs.unlinkSync(coordinatorPath);
+    }
+  });
+
+  it.skipIf(process.platform === "win32")(
+    "reopens an idle file after its access mode changes",
+    () => {
+      const { location } = fixture();
+      const databases = observeConnections();
+      fs.chmodSync(location, 0o600);
+      tryAcquireExclusiveSqliteCoordinator(location, { keepAlive: true })?.release();
+      const [previous] = databases;
+      fs.chmodSync(location, 0o640);
+      tryAcquireExclusiveSqliteCoordinator(location, { keepAlive: true })?.release();
+      expect(previous.isOpen).toBe(false);
+      expect(databases.size).toBe(2);
+    },
+  );
+
+  it("falls back to a fresh connection when filesystem identity is unknown", () => {
+    const { location } = fixture();
+    const databases = observeConnections();
+    const unknown = Object.assign(fs.lstatSync(location, { bigint: true }), { dev: 0n, ino: 0n });
+    vi.spyOn(fs, "lstatSync").mockReturnValue(unknown);
+    for (let attempt = 0; attempt < 2; attempt++) {
+      tryAcquireExclusiveSqliteCoordinator(location, { keepAlive: true })?.release();
+    }
+    expect(databases.size).toBe(2);
+    expect([...databases].every((database) => !database.isOpen)).toBe(true);
+  });
+
+  it.each(["throws", "remains open"])("discards a transaction when rollback %s", (failure) => {
+    const { location } = fixture();
+    const databases = observeConnections();
+    const lease = tryAcquireExclusiveSqliteCoordinator(location, { keepAlive: true });
+    const [database] = databases;
+    const exec = database.exec.bind(database);
+    const rollback = vi.spyOn(database, "exec").mockImplementation((sql) => {
+      if (sql === "ROLLBACK") {
+        if (failure === "throws") {
+          throw new Error("rollback failed");
+        }
+        return;
+      }
+      exec(sql);
+    });
+    expect(() => lease?.release()).toThrow(/rollback/);
+    rollback.mockRestore();
+    expect(database.isOpen).toBe(false);
+    const replacements = observeConnections();
+    const next = tryAcquireExclusiveSqliteCoordinator(location, { keepAlive: true });
+    const [replacement] = replacements;
+    expect(replacement === database).toBe(false);
+    expect(replacement.isTransaction).toBe(true);
+    next?.release();
+  });
+
+  it("warns on idle close failure, refuses reuse, and retains cleanup for process exit", () => {
+    const { location } = fixture();
+    const existingExitListeners = new Set(process.listeners("exit"));
+    const databases = observeConnections();
+    tryAcquireExclusiveSqliteCoordinator(location, { keepAlive: true })?.release();
+    const [database] = databases;
+    const exitClose = process
+      .listeners("exit")
+      .find((listener) => !existingExitListeners.has(listener));
+    expect(exitClose).toBeDefined();
+    const close = vi.spyOn(database, "close").mockImplementationOnce(() => {
+      throw new Error("native close failed");
+    });
+    const warning = vi.spyOn(process, "emitWarning").mockImplementation(() => {});
+    vi.advanceTimersByTime(60_000);
+    expect(warning).toHaveBeenCalledWith(
+      expect.objectContaining({ message: "Idle SQLite coordinator close failed" }),
+    );
+    expect(database.isOpen).toBe(true);
+    tryAcquireExclusiveSqliteCoordinator(location, { keepAlive: true })?.release();
+    expect(databases.size).toBe(2);
+    close.mockRestore();
+    exitClose?.(0);
+    expect([...databases].every((connection) => !connection.isOpen)).toBe(true);
+    expect(process.listeners("exit")).not.toContain(exitClose);
+  });
+
+  it("does not keep an idle expiry attached to a request or keep the process alive", () => {
+    const { directory } = fixture();
+    const result = execFileSync(
+      process.execPath,
+      [
+        "--import",
+        loader,
+        "--input-type=module",
+        "--eval",
+        `
+      import { AsyncLocalStorage, createHook } from "node:async_hooks";
+      import { acquireStateDatabaseCoordinator } from ${JSON.stringify(ownerUrl)};
+      const params = { databasePath: process.argv[1] };
+      acquireStateDatabaseCoordinator(params).release();
+      const request = new AsyncLocalStorage();
+      const observed = [];
+      const hook = createHook({ init(id, type, trigger, resource) {
+        if (type === "Timeout") observed.push({ resource, context: request.getStore() });
+      }}).enable();
+      request.run("request", () => acquireStateDatabaseCoordinator(params).release());
+      hook.disable();
+      process.stdout.write(JSON.stringify(observed.map(({ resource, context }) => ({
+        context: context ?? null, referenced: resource.hasRef()
+      }))));
+    `,
+        path.join(directory, "state.sqlite"),
+      ],
+      { encoding: "utf8", timeout: 15_000 },
+    );
+    expect(JSON.parse(result)).toEqual([{ context: null, referenced: false }]);
+  });
+});

--- a/src/infra/sqlite-coordinator.idle.test.ts
+++ b/src/infra/sqlite-coordinator.idle.test.ts
@@ -31,6 +31,14 @@ function observeConnections() {
   return databases;
 }
 
+function firstConnection(databases: ReadonlySet<DatabaseSync>) {
+  const database = databases.values().next().value;
+  if (!database) {
+    throw new Error("Coordinator did not open a connection");
+  }
+  return database;
+}
+
 function fixture() {
   const directory = tempDirs.make("openclaw-coordinator-idle-");
   const location = path.join(directory, "coordinator.sqlite");
@@ -86,7 +94,7 @@ describe("idle SQLite coordinator connections", () => {
     const databases = observeConnections();
     const warm = acquireStateDatabaseCoordinator({ ...params, busyTimeoutMs: 25 });
     warm.release();
-    const [database] = databases;
+    const database = firstConnection(databases);
     expect(database.isOpen).toBe(true);
     expect(database.isTransaction).toBe(false);
     const releasePeer = await holdPeer(location);
@@ -108,7 +116,7 @@ describe("idle SQLite coordinator connections", () => {
     tryAcquireExclusiveSqliteCoordinator(location, { keepAlive: true })?.release();
     const oldExpiry = timer.mock.calls.at(-1)?.[0];
     const active = tryAcquireExclusiveSqliteCoordinator(location, { keepAlive: true });
-    const [database] = databases;
+    const database = firstConnection(databases);
     if (typeof oldExpiry !== "function") {
       throw new Error("idle expiry was not scheduled");
     }
@@ -149,7 +157,7 @@ describe("idle SQLite coordinator connections", () => {
     const databases = observeConnections();
     const { location } = fixture();
     const held = tryAcquireExclusiveSqliteCoordinator(location, { keepAlive: true });
-    const [activeDatabase] = databases;
+    const activeDatabase = firstConnection(databases);
     for (let index = 0; index < 20; index++) {
       tryAcquireExclusiveSqliteCoordinator(fixture().location, { keepAlive: true })?.release();
     }
@@ -230,7 +238,7 @@ describe("idle SQLite coordinator connections", () => {
       const databases = observeConnections();
       fs.chmodSync(location, 0o600);
       tryAcquireExclusiveSqliteCoordinator(location, { keepAlive: true })?.release();
-      const [previous] = databases;
+      const previous = firstConnection(databases);
       fs.chmodSync(location, 0o640);
       tryAcquireExclusiveSqliteCoordinator(location, { keepAlive: true })?.release();
       expect(previous.isOpen).toBe(false);
@@ -254,7 +262,7 @@ describe("idle SQLite coordinator connections", () => {
     const { location } = fixture();
     const databases = observeConnections();
     const lease = tryAcquireExclusiveSqliteCoordinator(location, { keepAlive: true });
-    const [database] = databases;
+    const database = firstConnection(databases);
     const exec = database.exec.bind(database);
     const rollback = vi.spyOn(database, "exec").mockImplementation((sql) => {
       if (sql === "ROLLBACK") {
@@ -270,7 +278,7 @@ describe("idle SQLite coordinator connections", () => {
     expect(database.isOpen).toBe(false);
     const replacements = observeConnections();
     const next = tryAcquireExclusiveSqliteCoordinator(location, { keepAlive: true });
-    const [replacement] = replacements;
+    const replacement = firstConnection(replacements);
     expect(replacement === database).toBe(false);
     expect(replacement.isTransaction).toBe(true);
     next?.release();
@@ -281,7 +289,7 @@ describe("idle SQLite coordinator connections", () => {
     const existingExitListeners = new Set(process.listeners("exit"));
     const databases = observeConnections();
     tryAcquireExclusiveSqliteCoordinator(location, { keepAlive: true })?.release();
-    const [database] = databases;
+    const database = firstConnection(databases);
     const exitClose = process
       .listeners("exit")
       .find((listener) => !existingExitListeners.has(listener));

--- a/src/infra/sqlite-coordinator.idle.test.ts
+++ b/src/infra/sqlite-coordinator.idle.test.ts
@@ -104,7 +104,9 @@ describe("idle SQLite coordinator connections", () => {
     expect(database.prepare("PRAGMA busy_timeout").get()).toEqual({ timeout: 0 });
     expect(database.isTransaction).toBe(true);
     next.release();
-    vi.advanceTimersByTime(60_000);
+    vi.advanceTimersByTime(30 * 60_000 - 1);
+    expect(database.isOpen).toBe(true);
+    vi.advanceTimersByTime(1);
     expect(database.isOpen).toBe(false);
     fs.unlinkSync(location);
   });
@@ -126,7 +128,7 @@ describe("idle SQLite coordinator connections", () => {
     active?.release();
     oldExpiry();
     expect(database.isOpen).toBe(true);
-    vi.advanceTimersByTime(60_000);
+    vi.advanceTimersByTime(30 * 60_000);
     expect(database.isOpen).toBe(false);
   });
 
@@ -165,7 +167,7 @@ describe("idle SQLite coordinator connections", () => {
     expect(activeDatabase.isTransaction).toBe(true);
     held?.release();
     expect([...databases].filter((database) => database.isOpen)).toHaveLength(16);
-    vi.advanceTimersByTime(60_000);
+    vi.advanceTimersByTime(30 * 60_000);
     expect([...databases].some((database) => database.isOpen)).toBe(false);
   });
 
@@ -298,7 +300,7 @@ describe("idle SQLite coordinator connections", () => {
       throw new Error("native close failed");
     });
     const warning = vi.spyOn(process, "emitWarning").mockImplementation(() => {});
-    vi.advanceTimersByTime(60_000);
+    vi.advanceTimersByTime(30 * 60_000);
     expect(warning).toHaveBeenCalledWith(
       expect.objectContaining({ message: "Idle SQLite coordinator close failed" }),
     );

--- a/src/infra/sqlite-coordinator.idle.test.ts
+++ b/src/infra/sqlite-coordinator.idle.test.ts
@@ -21,14 +21,9 @@ const loader = new URL("../../scripts/tsx.mjs", import.meta.url).href;
 const ownerUrl = new URL("./state-database-coordinator.ts", import.meta.url).href;
 
 function observeConnections() {
-  const databases = new Set<DatabaseSync>();
-  const prototype = requireNodeSqlite().DatabaseSync.prototype;
-  const exec = prototype.exec;
-  vi.spyOn(prototype, "exec").mockImplementation(function (this: DatabaseSync, sql) {
-    databases.add(this);
-    return exec.call(this, sql);
-  });
-  return databases;
+  const { DatabaseSync } = requireNodeSqlite();
+  const exec = vi.spyOn(DatabaseSync.prototype, "exec");
+  return () => new Set(exec.mock.contexts.filter((context) => context instanceof DatabaseSync));
 }
 
 function firstConnection(databases: ReadonlySet<DatabaseSync>) {
@@ -94,13 +89,13 @@ describe("idle SQLite coordinator connections", () => {
     const databases = observeConnections();
     const warm = acquireStateDatabaseCoordinator({ ...params, busyTimeoutMs: 25 });
     warm.release();
-    const database = firstConnection(databases);
+    const database = firstConnection(databases());
     expect(database.isOpen).toBe(true);
     expect(database.isTransaction).toBe(false);
     const releasePeer = await holdPeer(location);
     await releasePeer();
     const next = acquireStateDatabaseCoordinator(params);
-    expect(databases.size).toBe(1);
+    expect(databases().size).toBe(1);
     expect(database.prepare("PRAGMA busy_timeout").get()).toEqual({ timeout: 0 });
     expect(database.isTransaction).toBe(true);
     next.release();
@@ -118,7 +113,7 @@ describe("idle SQLite coordinator connections", () => {
     tryAcquireExclusiveSqliteCoordinator(location, { keepAlive: true })?.release();
     const oldExpiry = timer.mock.calls.at(-1)?.[0];
     const active = tryAcquireExclusiveSqliteCoordinator(location, { keepAlive: true });
-    const database = firstConnection(databases);
+    const database = firstConnection(databases());
     if (typeof oldExpiry !== "function") {
       throw new Error("idle expiry was not scheduled");
     }
@@ -159,16 +154,16 @@ describe("idle SQLite coordinator connections", () => {
     const databases = observeConnections();
     const { location } = fixture();
     const held = tryAcquireExclusiveSqliteCoordinator(location, { keepAlive: true });
-    const activeDatabase = firstConnection(databases);
+    const activeDatabase = firstConnection(databases());
     for (let index = 0; index < 20; index++) {
       tryAcquireExclusiveSqliteCoordinator(fixture().location, { keepAlive: true })?.release();
     }
-    expect([...databases].filter((database) => database.isOpen)).toHaveLength(17);
+    expect([...databases()].filter((database) => database.isOpen)).toHaveLength(17);
     expect(activeDatabase.isTransaction).toBe(true);
     held?.release();
-    expect([...databases].filter((database) => database.isOpen)).toHaveLength(16);
+    expect([...databases()].filter((database) => database.isOpen)).toHaveLength(16);
     vi.advanceTimersByTime(30 * 60_000);
-    expect([...databases].some((database) => database.isOpen)).toBe(false);
+    expect([...databases()].some((database) => database.isOpen)).toBe(false);
   });
 
   it.each([tryAcquireExclusiveSqliteCoordinator, tryAcquireSharedSqliteCoordinator])(
@@ -177,7 +172,7 @@ describe("idle SQLite coordinator connections", () => {
       const { location } = fixture();
       const databases = observeConnections();
       acquire(location)?.release();
-      expect([...databases].every((database) => !database.isOpen)).toBe(true);
+      expect([...databases()].every((database) => !database.isOpen)).toBe(true);
       fs.unlinkSync(location);
     },
   );
@@ -195,7 +190,7 @@ describe("idle SQLite coordinator connections", () => {
       };
       const coordinator = acquireStateDatabaseCoordinator(params);
       coordinator.release();
-      expect([...databases].every((database) => !database.isOpen)).toBe(true);
+      expect([...databases()].every((database) => !database.isOpen)).toBe(true);
       fs.unlinkSync(coordinator.path);
     },
   );
@@ -221,7 +216,7 @@ describe("idle SQLite coordinator connections", () => {
           const coordinator = acquireStateDatabaseCoordinator(params);
           coordinatorPath = coordinator.path;
           coordinator.release();
-          expect([...databases].every((database) => !database.isOpen)).toBe(true);
+          expect([...databases()].every((database) => !database.isOpen)).toBe(true);
         },
       );
     } finally {
@@ -240,11 +235,11 @@ describe("idle SQLite coordinator connections", () => {
       const databases = observeConnections();
       fs.chmodSync(location, 0o600);
       tryAcquireExclusiveSqliteCoordinator(location, { keepAlive: true })?.release();
-      const previous = firstConnection(databases);
+      const previous = firstConnection(databases());
       fs.chmodSync(location, 0o640);
       tryAcquireExclusiveSqliteCoordinator(location, { keepAlive: true })?.release();
       expect(previous.isOpen).toBe(false);
-      expect(databases.size).toBe(2);
+      expect(databases().size).toBe(2);
     },
   );
 
@@ -256,15 +251,15 @@ describe("idle SQLite coordinator connections", () => {
     for (let attempt = 0; attempt < 2; attempt++) {
       tryAcquireExclusiveSqliteCoordinator(location, { keepAlive: true })?.release();
     }
-    expect(databases.size).toBe(2);
-    expect([...databases].every((database) => !database.isOpen)).toBe(true);
+    expect(databases().size).toBe(2);
+    expect([...databases()].every((database) => !database.isOpen)).toBe(true);
   });
 
   it.each(["throws", "remains open"])("discards a transaction when rollback %s", (failure) => {
     const { location } = fixture();
     const databases = observeConnections();
     const lease = tryAcquireExclusiveSqliteCoordinator(location, { keepAlive: true });
-    const database = firstConnection(databases);
+    const database = firstConnection(databases());
     const exec = database.exec.bind(database);
     const rollback = vi.spyOn(database, "exec").mockImplementation((sql) => {
       if (sql === "ROLLBACK") {
@@ -280,7 +275,7 @@ describe("idle SQLite coordinator connections", () => {
     expect(database.isOpen).toBe(false);
     const replacements = observeConnections();
     const next = tryAcquireExclusiveSqliteCoordinator(location, { keepAlive: true });
-    const replacement = firstConnection(replacements);
+    const replacement = firstConnection(replacements());
     expect(replacement === database).toBe(false);
     expect(replacement.isTransaction).toBe(true);
     next?.release();
@@ -291,7 +286,7 @@ describe("idle SQLite coordinator connections", () => {
     const existingExitListeners = new Set(process.listeners("exit"));
     const databases = observeConnections();
     tryAcquireExclusiveSqliteCoordinator(location, { keepAlive: true })?.release();
-    const database = firstConnection(databases);
+    const database = firstConnection(databases());
     const exitClose = process
       .listeners("exit")
       .find((listener) => !existingExitListeners.has(listener));
@@ -306,10 +301,10 @@ describe("idle SQLite coordinator connections", () => {
     );
     expect(database.isOpen).toBe(true);
     tryAcquireExclusiveSqliteCoordinator(location, { keepAlive: true })?.release();
-    expect(databases.size).toBe(2);
+    expect(databases().size).toBe(2);
     close.mockRestore();
     exitClose?.(0);
-    expect([...databases].every((connection) => !connection.isOpen)).toBe(true);
+    expect([...databases()].every((connection) => !connection.isOpen)).toBe(true);
     expect(process.listeners("exit")).not.toContain(exitClose);
   });
 

--- a/src/infra/sqlite-coordinator.ts
+++ b/src/infra/sqlite-coordinator.ts
@@ -95,7 +95,7 @@ export function ensurePrivateSqliteCoordinatorDirectory(
   }
 }
 
-const IDLE_COORDINATOR_TIMEOUT_MS = 60_000;
+const IDLE_COORDINATOR_TIMEOUT_MS = 30 * 60_000;
 const MAX_IDLE_COORDINATORS = 16;
 // Bootstrap imports this owner before turns. Idle timers must not retain the
 // request context that released a coordinator.

--- a/src/infra/sqlite-coordinator.ts
+++ b/src/infra/sqlite-coordinator.ts
@@ -1,4 +1,8 @@
+import { AsyncLocalStorage } from "node:async_hooks";
 import fs from "node:fs";
+import path from "node:path";
+import type { DatabaseSync } from "node:sqlite";
+import { sameFileIdentity } from "./fs-safe-advanced.js";
 import { openNodeSqliteDatabase } from "./node-sqlite.js";
 import { applyPrivateModeSync } from "./private-mode.js";
 import { isSqliteLockError } from "./sqlite-error-diagnostics.js";
@@ -91,13 +95,152 @@ export function ensurePrivateSqliteCoordinatorDirectory(
   }
 }
 
+const IDLE_COORDINATOR_TIMEOUT_MS = 60_000;
+const MAX_IDLE_COORDINATORS = 16;
+// Bootstrap imports this owner before turns. Idle timers must not retain the
+// request context that released a coordinator.
+const runInCoordinatorPoolContext = AsyncLocalStorage.snapshot();
+type IdleCoordinator = {
+  database: DatabaseSync;
+  identity: fs.BigIntStats;
+  timer: ReturnType<typeof setTimeout>;
+};
+const idleCoordinators = new Map<string, IdleCoordinator>();
+const failedIdleCloses = new Set<DatabaseSync>();
+let exitCloseRegistered = false;
+
+function updateCoordinatorExitClose() {
+  const needed = idleCoordinators.size > 0 || failedIdleCloses.size > 0;
+  if (needed && !exitCloseRegistered) {
+    process.once("exit", closeIdleCoordinatorsOnExit);
+  } else if (!needed && exitCloseRegistered) {
+    process.removeListener("exit", closeIdleCoordinatorsOnExit);
+  }
+  exitCloseRegistered = needed;
+}
+
+function takeIdleCoordinator(location: string) {
+  const idle = idleCoordinators.get(location);
+  if (idle) {
+    idleCoordinators.delete(location);
+    clearTimeout(idle.timer);
+    updateCoordinatorExitClose();
+  }
+  return idle;
+}
+
+function closeIdleCoordinatorDatabase(database: DatabaseSync) {
+  try {
+    if (database.isOpen) {
+      database.close();
+    }
+  } finally {
+    if (database.isOpen) {
+      failedIdleCloses.add(database);
+    } else {
+      failedIdleCloses.delete(database);
+    }
+    updateCoordinatorExitClose();
+  }
+}
+
+function closeIdleCoordinatorsOnExit() {
+  const databases = new Set(failedIdleCloses);
+  for (const [location] of idleCoordinators) {
+    const idle = takeIdleCoordinator(location);
+    if (idle) {
+      databases.add(idle.database);
+    }
+  }
+  for (const database of databases) {
+    try {
+      closeIdleCoordinatorDatabase(database);
+    } catch {
+      // Process exit is the last cleanup opportunity for a failed native close.
+    }
+  }
+}
+
+function readCoordinatorIdentity(location: string): fs.BigIntStats | undefined {
+  try {
+    const identity = fs.lstatSync(location, { bigint: true });
+    return identity.isFile() && identity.dev !== 0n && identity.ino !== 0n ? identity : undefined;
+  } catch {
+    // Reuse is optional; a fresh SQLite open owns normal path errors/creation.
+    return undefined;
+  }
+}
+
+function matchesCoordinatorIdentity(left: fs.BigIntStats, right: fs.BigIntStats | undefined) {
+  return (
+    right !== undefined &&
+    sameFileIdentity(left, right) &&
+    left.birthtimeNs === right.birthtimeNs &&
+    left.mode === right.mode &&
+    left.uid === right.uid &&
+    left.gid === right.gid
+  );
+}
+
+function retainIdleCoordinator(location: string, database: DatabaseSync, identity: fs.BigIntStats) {
+  const previous = takeIdleCoordinator(location);
+  if (previous) {
+    closeIdleCoordinatorDatabase(previous.database);
+  }
+  if (idleCoordinators.size + failedIdleCloses.size >= MAX_IDLE_COORDINATORS) {
+    const oldest = idleCoordinators.keys().next().value;
+    if (oldest !== undefined) {
+      const evicted = takeIdleCoordinator(oldest);
+      if (evicted) {
+        closeIdleCoordinatorDatabase(evicted.database);
+      }
+    }
+  }
+  if (idleCoordinators.size + failedIdleCloses.size >= MAX_IDLE_COORDINATORS) {
+    return false;
+  }
+  const timer = runInCoordinatorPoolContext(() =>
+    setTimeout(() => {
+      if (idleCoordinators.get(location)?.timer !== timer) {
+        return;
+      }
+      const idle = takeIdleCoordinator(location);
+      if (!idle) {
+        return;
+      }
+      try {
+        closeIdleCoordinatorDatabase(idle.database);
+      } catch (error) {
+        process.emitWarning(
+          new SqliteCoordinatorError("Idle SQLite coordinator close failed", error),
+        );
+      }
+    }, IDLE_COORDINATOR_TIMEOUT_MS),
+  );
+  timer.unref();
+  idleCoordinators.set(location, { database, identity, timer });
+  updateCoordinatorExitClose();
+  return true;
+}
+
 function tryAcquireSqliteCoordinator(
   location: string,
   mode: "shared" | "exclusive",
-  options: { busyTimeoutMs?: number },
+  options: { busyTimeoutMs?: number; keepAlive?: boolean },
 ): { release: () => void } | null {
   const busyTimeoutMs = Math.max(0, Math.trunc(options.busyTimeoutMs ?? 0));
-  const database = openNodeSqliteDatabase(location);
+  const poolLocation =
+    options.keepAlive && location !== "" && location !== ":memory:" && !location.startsWith("file:")
+      ? path.resolve(location)
+      : undefined;
+  const before = poolLocation ? readCoordinatorIdentity(poolLocation) : undefined;
+  const idle = poolLocation ? takeIdleCoordinator(poolLocation) : undefined;
+  const reused = idle && matchesCoordinatorIdentity(idle.identity, before) ? idle : undefined;
+  if (idle && !reused) {
+    closeIdleCoordinatorDatabase(idle.database);
+  }
+  const database = reused?.database ?? openNodeSqliteDatabase(location);
+  let identity: fs.BigIntStats | undefined;
   try {
     // Kysely transaction callbacks cannot own a lock beyond their synchronous commit section.
     // This handle never writes or commits data. Keep the empty database's initial
@@ -109,8 +252,20 @@ function tryAcquireSqliteCoordinator(
           : "BEGIN; SELECT rootpage FROM sqlite_schema LIMIT 1;"
       }`,
     );
+    if (poolLocation && before) {
+      const current = readCoordinatorIdentity(poolLocation);
+      if (matchesCoordinatorIdentity(before, current)) {
+        identity = before;
+      } else if (reused) {
+        throw new SqliteCoordinatorError("SQLite coordinator changed during acquisition");
+      }
+    }
   } catch (error) {
-    database.close();
+    if (poolLocation) {
+      closeIdleCoordinatorDatabase(database);
+    } else {
+      database.close();
+    }
     if (isSqliteLockError(error)) {
       return null;
     }
@@ -126,13 +281,30 @@ function tryAcquireSqliteCoordinator(
       const errors: unknown[] = [];
       try {
         database.exec("ROLLBACK");
+        if (poolLocation && database.isTransaction) {
+          throw new SqliteCoordinatorError("SQLite coordinator rollback left its transaction open");
+        }
       } catch (error) {
         errors.push(error);
       }
-      try {
-        database.close();
-      } catch (error) {
-        errors.push(error);
+      let retained = false;
+      if (errors.length === 0 && poolLocation && identity) {
+        try {
+          retained = retainIdleCoordinator(poolLocation, database, identity);
+        } catch (error) {
+          errors.push(error);
+        }
+      }
+      if (!retained) {
+        try {
+          if (poolLocation) {
+            closeIdleCoordinatorDatabase(database);
+          } else {
+            database.close();
+          }
+        } catch (error) {
+          errors.push(error);
+        }
       }
       if (errors.length === 1) {
         throw errors[0];
@@ -147,7 +319,7 @@ function tryAcquireSqliteCoordinator(
 /** Hold a raw exclusive transaction until release for cross-process coordination. */
 export function tryAcquireExclusiveSqliteCoordinator(
   location: string,
-  options: { busyTimeoutMs?: number } = {},
+  options: { busyTimeoutMs?: number; keepAlive?: boolean } = {},
 ): { release: () => void } | null {
   return tryAcquireSqliteCoordinator(location, "exclusive", options);
 }

--- a/src/infra/state-database-coordinator.ts
+++ b/src/infra/state-database-coordinator.ts
@@ -103,6 +103,7 @@ export function resolveStateDatabaseCoordinatorPath(params: {
 function acquireLifecycleCoordinator(
   family: CoordinatorFamily,
   params: CoordinatorOptions,
+  keepAlive = false,
 ): { path: string; release: () => void } {
   const coordinatorPath =
     params.coordinatorPath ??
@@ -118,6 +119,7 @@ function acquireLifecycleCoordinator(
     ensurePrivateSqliteCoordinatorDirectory(path.dirname(coordinatorPath), `${family} coordinator`);
     const coordinator = tryAcquireExclusiveSqliteCoordinator(coordinatorPath, {
       busyTimeoutMs: params.busyTimeoutMs,
+      keepAlive,
     });
     if (!coordinator) {
       throw new StateDatabaseCoordinatorContentionError(family);
@@ -169,6 +171,9 @@ export function retainHeldStateDatabaseCoordinator(databasePath: string) {
 }
 
 export function acquireStateDatabaseCoordinator(params: CoordinatorOptions) {
+  // Caller-owned locations must remain removable immediately after release,
+  // including on Windows where an idle SQLite handle blocks unlink.
+  const keepAlive = params.coordinatorPath === undefined && params.runtimeDirectory === undefined;
   // Lifecycle ownership is reentrant for nested transactions. File publication
   // is not: even this process must refuse before ownership probes touch SQLite.
   const base = resolveLifecycleCoordinatorBase({
@@ -184,15 +189,23 @@ export function acquireStateDatabaseCoordinator(params: CoordinatorOptions) {
     }
     writeScope.assertCurrent();
     // Authority callbacks can change paths; resolve again after their checks.
-    return acquireLifecycleCoordinator("state-lifecycle", params);
+    return acquireLifecycleCoordinator(
+      "state-lifecycle",
+      params,
+      params.coordinatorPath === undefined && params.runtimeDirectory === undefined,
+    );
   } else if (heldCoordinators.has(handlesPath)) {
     throw new StateDatabaseCoordinatorContentionError("state-handles");
   }
-  return acquireLifecycleCoordinator("state-lifecycle", {
-    ...params,
-    coordinatorPath:
-      params.coordinatorPath ?? buildLifecycleCoordinatorPath("state-lifecycle", base),
-  });
+  return acquireLifecycleCoordinator(
+    "state-lifecycle",
+    {
+      ...params,
+      coordinatorPath:
+        params.coordinatorPath ?? buildLifecycleCoordinatorPath("state-lifecycle", base),
+    },
+    keepAlive,
+  );
 }
 
 /** Fence schema mutation against another process's live Gateway owner. */

--- a/src/state/openclaw-state-db-open.test.ts
+++ b/src/state/openclaw-state-db-open.test.ts
@@ -30,14 +30,27 @@ describe("unpublished state database acquisition", () => {
         }
       }
       databases.clear();
+      // Expire idle coordinator handles before discarding the fake clock.
+      vi.runOnlyPendingTimers();
       vi.clearAllTimers();
       vi.useRealTimers();
       cleanup();
     });
   });
 
+  function observeMaintenanceTimers() {
+    const scheduled = vi.spyOn(globalThis, "setInterval");
+    const cleared = vi.spyOn(globalThis, "clearInterval");
+    return () =>
+      scheduled.mock.results.filter(
+        (result) =>
+          result.type === "return" && !cleared.mock.calls.some(([timer]) => timer === result.value),
+      ).length;
+  }
+
   function acquisitionFixture() {
     vi.useFakeTimers();
+    const maintenanceTimerCount = observeMaintenanceTimers();
     const pathname = path.join(tempDirs.make("openclaw-state-acquisition-"), "state.sqlite");
     const params = {
       pathname,
@@ -65,22 +78,23 @@ describe("unpublished state database acquisition", () => {
       }
       return db;
     });
-    return { params, open, openNative, opened };
+    return { params, open, openNative, opened, maintenanceTimerCount };
   }
 
   function expectSuccessfulReopen(params: Parameters<typeof openUnpublishedStateDatabase>[0]) {
+    const maintenanceTimerCount = observeMaintenanceTimers();
     const reopened = openUnpublishedStateDatabase(params);
     try {
       expect(reopened.db.prepare("SELECT value FROM payload").all()).toEqual([
         { value: "committed" },
       ]);
       expect(reopened.db.isOpen).toBe(true);
-      expect(vi.getTimerCount()).toBe(1);
+      expect(maintenanceTimerCount()).toBe(1);
     } finally {
       reopened.walMaintenance.close();
       closeTrackedStateDatabase(reopened.db);
     }
-    expect(vi.getTimerCount()).toBe(0);
+    expect(maintenanceTimerCount()).toBe(0);
   }
 
   it.each([
@@ -91,7 +105,7 @@ describe("unpublished state database acquisition", () => {
     "schema",
     "hardening",
   ])("releases every acquisition after failed %s and preserves committed state", (phase) => {
-    const { params, open, openNative, opened } = acquisitionFixture();
+    const { params, open, openNative, opened, maintenanceTimerCount } = acquisitionFixture();
     const failure = new Error(`${phase} failed`);
     if (phase === "statement cache") {
       vi.spyOn(kyselySync, "enableNodeSqliteKyselyStatementCache").mockImplementation(() => {
@@ -150,7 +164,7 @@ describe("unpublished state database acquisition", () => {
       const db = expectDefined(opened.at(-1), "failed acquisition");
       expect(db.isOpen).toBe(false);
       expect(kyselyCache.kyselyByDatabase.has(db)).toBe(false);
-      expect(vi.getTimerCount()).toBe(0);
+      expect(maintenanceTimerCount()).toBe(0);
     }
     expect(params.recordOpenFailure).not.toHaveBeenCalled();
     vi.restoreAllMocks();
@@ -169,7 +183,7 @@ describe("unpublished state database acquisition", () => {
   )(
     "preserves the $phase error and $cleanupFailure cleanup failures with a disposal-only owner",
     ({ phase, cleanupFailure }) => {
-      const { params, opened } = acquisitionFixture();
+      const { params, opened, maintenanceTimerCount } = acquisitionFixture();
       const failure = new Error(`${phase} failed`);
       const maintenanceFailure = new Error("maintenance close failed");
       const nativeFailure = new Error("native close failed");
@@ -226,7 +240,7 @@ describe("unpublished state database acquisition", () => {
       });
       expect(db.isOpen).toBe(nativeFails);
       expect(kyselyCache.kyselyByDatabase.has(db)).toBe(false);
-      expect(vi.getTimerCount()).toBe(0);
+      expect(maintenanceTimerCount()).toBe(0);
       expect(
         openClawStateDatabaseCache.getOpenClawStateDatabaseIfOpenAtPath(params.pathname),
       ).toBeUndefined();
@@ -270,7 +284,7 @@ describe("unpublished state database acquisition", () => {
   )(
     "latches the real $terminal failure without retrying retained native cleanup (cache failure: $cacheFails)",
     ({ terminal, cacheFails }) => {
-      const { params, open, openNative, opened } = acquisitionFixture();
+      const { params, open, openNative, opened, maintenanceTimerCount } = acquisitionFixture();
       const seed = openNative(params.pathname);
       try {
         if (terminal === "schema") {
@@ -344,7 +358,7 @@ describe("unpublished state database acquisition", () => {
       expect(() =>
         acquireStateDatabaseHandleExclusion({ databasePath: params.pathname, busyTimeoutMs: 0 }),
       ).toThrow(/state-handles/);
-      expect(vi.getTimerCount()).toBe(0);
+      expect(maintenanceTimerCount()).toBe(0);
       vi.restoreAllMocks();
       expect(openClawStateDatabaseCache.closeOpenClawStateDatabaseByPath(params.pathname)).toBe(
         true,


### PR DESCRIPTION
Closes #145607

<details>
<summary>Additional instructions</summary>

This PR uses a same-repository maintainer branch, which repository maintainers can edit. GitHub only exposes fork collaboration for cross-repository PRs.

</details>

## What Problem This Solves

Resolves a problem where busy Gateways spend time repeatedly opening and closing coordinator databases while processing frequent state writes, including ordinary memory indexing.

## Why This Change Was Made

The existing SQLite coordinator owner now keeps successfully rolled-back default state-lifecycle connections available for 30 minutes. Each acquisition still starts a fresh transaction and each release immediately drops its lock. The pool admits at most 16 ordinary idle connections and uses unref timers outside request context.

Reuse verifies known file identity and access metadata around acquisition. File replacement, failed admission, and failed rollback discard reuse. Explicit caller-owned coordinator paths and runtime directories remain immediately closable, including after an authority callback changes the path. This preserves Windows cleanup behavior. Exceptional native close failures remain unavailable for reuse and retain cleanup custody for process exit.

The shared state data connection was already cached. This change preserves its owner and existing memory workspace lock boundaries. It adds no config, schema, data migration, or retained-data changes; updating or rolling back requires no conversion.

## User Impact

Frequent state operations avoid repeated native connection setup while other processes can still acquire the coordinator between operations. Dreaming is disabled in both load-test arms; ordinary indexing remains enabled.

## Evidence

- Linux coordinator benchmark: seven rounds of 2,000 default-owner acquire/release operations improved from 190.69 ms to 119.01 ms median (37.6%); native closes fell from 2,000 to zero per round. Three alternating memory-index pairs improved from 174.07 ms to 165.30 ms median (5.0%), preserving all 30 indexed files, chunks, and search results. These short runs exercised the same pool with its earlier 60-second constant; neither reached idle expiry.
- Windows mechanism proof: 500 warm default-owner acquisitions reused one connection with zero new native handles or closes. The final 30-minute sourcePerformance build passed. Timed-close tests passed on Linux and Windows; Windows skips cover existing platform-specific filesystem cases.
- The default-owner reuse regression fails on the original owner because its connection is already closed after release. The latest Linux selection passed all 16 idle-lifecycle and 16 state-database acquisition cases, including committed-data preservation and cleanup failures. Existing cross-process coordinator and source-exclusion sibling tests also passed.
- Timer integration fixes make existing approval, worker, cron, and state-database tests observe their own deadlines and cleanup handles. All 115 approval/worker/cron cases passed; the final approval-helper revision passed its 62 cases again. The original failures were reproduced before repair. All selected core checks passed: production and full test type graphs, typed lint with zero warnings/errors, and the remaining architecture/storage guards resumed after an interrupted run. [Final-head CI passed](https://github.com/openclaw/openclaw/actions/runs/34679623719) on `c53c68e57e981e4c5e3f590ea4d6959a47dccc79`.
- All 31 WhatsApp socket-lifecycle and timing-owner cases and targeted type-aware lint passed. The inbound read-receipt test verifies exactly one native attempt while retaining delivery, request arguments, and timeout logging assertions; the timing-owner tests retain cleanup proof after timeout and early completion. Its original process-global timer assertion failure was reproduced, and the one-line repair received a separate scoped-clean review through P2.
- The cron delivery-status helper now advances only to its job deadline. Its original assertion failure also reproduces on the immutable pre-pool baseline: the existing WAL maintenance timer already made a global drain execute repeated jobs. All 24 delivery cases passed on the current PR base, including real HTTP timeout/cancellation siblings; targeted type-aware lint passed and all delivery assertions remain intact.
- Fresh independent autoreview of the complete pool/timer change is scoped clean through P2; subsequent test-only repairs also passed scoped supplemental review. ClawSweeper completed the final-head review with no findings or before-merge blockers. The refresh onto current main includes the previously landed unrelated thinking-test line-cap repair; all changed files and supplied review-context owners are byte-identical across that base refresh.
- Full Gateway latency evidence is inconclusive. Original visible-observer runs generated unequal background inference. A subsequent observer-excluded 1,000-session pair retained eight turns, 100 patches, indexing, and disabled dreaming, but external compiler activity coincided with broad filesystem timing inflation. All turns and patches completed; the baseline had one failed probe and the candidate four. Both Windows runs required forced teardown, followed by verified process and fixture cleanup. No overall Gateway latency improvement is claimed from these runs.
- [Isolated live OpenAI proof](https://github.com/openclaw/openclaw/actions/runs/34675003706): eight of eight responses matched streaming, final events, RPC history and independently read post-shutdown SQLite transcripts, with 1,000 synthetic sessions, 100 patches, 327 history samples and no RPC/HTTP probe failures. Dreaming was verified disabled; ordinary indexing remained enabled. Gateway exited 0, isolated state was removed, and the Testbox lease was verified stopped. Main-isolate instrumentation recorded eight Responses requests, nine embedding requests and one transport error event without a captured cause; all eight user turns completed. This is functional live evidence, not a paired latency comparison.

The live Gateway ran for approximately 18.6 seconds, so the earlier 60-second idle deadline never fired. That live flow evidence is reused for the final 30-minute constant together with its timed-close tests; it is not a 30-minute live soak.
