### PR TITLE
fix(bonjour): stop ENODEV log bursts when transient interfaces disappear

### DIFF
--- a/extensions/bonjour/src/advertiser.test.ts
+++ b/extensions/bonjour/src/advertiser.test.ts
@@ -455,6 +455,37 @@ describe("gateway bonjour advertiser", () => {
     }
   });
 
+  it("suppresses transient ENODEV mDNS socket warnings while advertising", async () => {
+    enableAdvertiserUnitMode();
+
+    const destroy = vi.fn().mockResolvedValue(undefined);
+    const advertise = vi.fn().mockResolvedValue(undefined);
+    mockCiaoService({ advertise, destroy });
+
+    const originalConsoleWarn = console.warn;
+    const baseConsoleWarn = vi.fn();
+    console.warn = baseConsoleWarn as typeof console.warn;
+
+    try {
+      const started = await startAdvertiser({
+        gatewayPort: 18789,
+        sshPort: 2222,
+      });
+
+      console.warn(
+        "Encountered MDNS socket error on socket 'br-deadbeef' : Error: send ENODEV 224.0.0.251:5353\n    at Socket.send (node:dgram:123:45)",
+      );
+      console.warn("ordinary console warning");
+
+      expect(baseConsoleWarn).toHaveBeenCalledTimes(1);
+      expect(baseConsoleWarn).toHaveBeenCalledWith("ordinary console warning");
+
+      await started.stop();
+    } finally {
+      console.warn = originalConsoleWarn;
+    }
+  });
+
   it("does not monkey-patch responder methods during shutdown", async () => {
     enableAdvertiserUnitMode();
 

--- a/extensions/bonjour/src/advertiser.ts
+++ b/extensions/bonjour/src/advertiser.ts
@@ -38,6 +38,8 @@ type BonjourAdvertiserDeps = {
 
 const CIAO_SELF_PROBE_RETRY_FRAGMENT =
   "failed probing with reason: Error: Can't probe for a service which is announced already.";
+const CIAO_MDNS_SOCKET_WARNING_FRAGMENT = "Encountered MDNS socket error on socket";
+const CIAO_TRANSIENT_ENODEV_FRAGMENT = "send ENODEV 224.0.0.251:5353";
 
 const defaultLogger = {
   info: (_msg: string) => {},
@@ -168,18 +170,38 @@ function shouldSuppressCiaoConsoleLog(args: unknown[]): boolean {
   );
 }
 
+function shouldSuppressCiaoConsoleWarn(args: unknown[]): boolean {
+  return args.some(
+    (arg) =>
+      typeof arg === "string" &&
+      arg.includes(CIAO_MDNS_SOCKET_WARNING_FRAGMENT) &&
+      arg.includes(CIAO_TRANSIENT_ENODEV_FRAGMENT),
+  );
+}
+
 function installCiaoConsoleNoiseFilter(): () => void {
   const previousConsoleLog = console.log as ConsoleLogFn;
-  const wrapper = ((...args: unknown[]) => {
+  const previousConsoleWarn = console.warn;
+  const logWrapper = ((...args: unknown[]) => {
     if (shouldSuppressCiaoConsoleLog(args)) {
       return;
     }
     previousConsoleLog(...args);
   }) as ConsoleLogFn;
-  console.log = wrapper;
+  const warnWrapper = (...args: unknown[]) => {
+    if (shouldSuppressCiaoConsoleWarn(args)) {
+      return;
+    }
+    previousConsoleWarn(...args);
+  };
+  console.log = logWrapper;
+  console.warn = warnWrapper;
   return () => {
-    if (console.log === wrapper) {
+    if (console.log === logWrapper) {
       console.log = previousConsoleLog;
+    }
+    if (console.warn === warnWrapper) {
+      console.warn = previousConsoleWarn;
     }
   };
 }


### PR DESCRIPTION
Closes #144796

## What Problem This Solves

Fixes an issue where Linux gateway operators with Bonjour enabled would get bursts of `send ENODEV 224.0.0.251:5353` stack traces when a short-lived network interface, such as a Docker bridge from a self-hosted CI job, disappeared before ciao's network-interface poll retired its socket.

The gateway remains healthy, but each bridge teardown can emit dozens of redundant warnings and add avoidable journal/event-loop noise.

## Why This Change Was Made

Extend the existing ciao console-noise filter to suppress only the transient mDNS socket warning that contains both the ciao socket-error prefix and the IPv4 mDNS `ENODEV` send fingerprint. Other `console.warn` output is still forwarded unchanged, and the filter restores the previous `console.warn` on advertiser shutdown without overwriting a later replacement.

This does not disable Bonjour, change interface selection, alter ciao lifecycle behavior, or hide unrelated socket failures.

## User Impact

Operators can keep LAN Bonjour discovery enabled while transient Docker/network-interface removal no longer floods the gateway journal with known self-healing ENODEV stack traces.

## Evidence

- Regression first failed on current `main`: expected one forwarded warning, observed two because the ENODEV warning was still emitted.
- After the fix, the targeted regression passes and an ordinary warning is still forwarded.
- `pnpm test:extension bonjour`: **34/34 passed**.
- `oxfmt --check extensions/bonjour/src/advertiser.ts extensions/bonjour/src/advertiser.test.ts`: passed.
- `git diff --check`: passed.
- Live reproduction/context: openclaw/openclaw#144796 documents 80–106 warning bursts per transient Docker bridge teardown on a healthy gateway.
