### PR TITLE
refactor(gateway): share assistant display text extraction

### DIFF
--- a/src/gateway/server-methods/chat-assistant-content.ts
+++ b/src/gateway/server-methods/chat-assistant-content.ts
@@ -104,22 +104,19 @@ export function sanitizeAssistantDisplayText(
     : undefined;
 }
 
-export function extractAssistantDisplayTextFromContent(
+export function extractAssistantDisplayText(
   content?: readonly AssistantDisplayContentBlock[] | null,
 ): string | undefined {
   if (!Array.isArray(content) || content.length === 0) {
     return undefined;
   }
-  const parts = content
-    .map((block) => {
-      if (block?.type !== "text" || typeof block.text !== "string") {
-        return "";
-      }
-      return block.text;
-    })
-    .filter(Boolean);
-  const text = combineNonStreamingReplyParts(parts);
-  return text || undefined;
+  const parts: string[] = [];
+  for (const block of content) {
+    if (block?.type === "text" && typeof block.text === "string" && block.text) {
+      parts.push(block.text);
+    }
+  }
+  return combineNonStreamingReplyParts(parts) || undefined;
 }
 
 export async function buildAssistantReplyContent(params: {
@@ -284,20 +281,6 @@ export function stripManagedOutgoingAssistantContentBlocks(
     );
   });
   return filtered.length > 0 ? filtered : undefined;
-}
-
-export function extractAssistantDisplayText(
-  content: readonly AssistantDisplayContentBlock[] | undefined,
-): string | undefined {
-  if (!content || content.length === 0) {
-    return undefined;
-  }
-  const text = combineNonStreamingReplyParts(
-    content.map((block) =>
-      block?.type === "text" && typeof block.text === "string" ? block.text : "",
-    ),
-  );
-  return text || undefined;
 }
 
 export function hasAssistantDisplayMediaContent(

--- a/src/gateway/server-methods/chat-send-reply-dispatch.ts
+++ b/src/gateway/server-methods/chat-send-reply-dispatch.ts
@@ -33,7 +33,7 @@ import { formatForLog } from "../ws-log.js";
 import {
   buildAssistantReplyContent,
   combineNonStreamingReplyParts,
-  extractAssistantDisplayTextFromContent,
+  extractAssistantDisplayText,
   hasAssistantDisplayMediaContent,
   isMediaBearingPayload,
   sanitizeAssistantDisplayText,
@@ -257,7 +257,7 @@ export function createChatSendReplyDispatch(params: {
     }
     const transcriptReply =
       mediaMessage?.transcriptText ??
-      extractAssistantDisplayTextFromContent(assistantContent) ??
+      extractAssistantDisplayText(assistantContent) ??
       buildTranscriptReplyText([transcriptPayload]);
     const payloadMetadata = getReplyPayloadMetadata(payload);
     const sourceMediaUrls = Array.from(

--- a/src/gateway/server-methods/chat-send-reply-finalization.ts
+++ b/src/gateway/server-methods/chat-send-reply-finalization.ts
@@ -13,7 +13,6 @@ import {
   buildAssistantReplyContent,
   combineNonStreamingReplyParts,
   extractAssistantDisplayText,
-  extractAssistantDisplayTextFromContent,
   hasAssistantDisplayMediaContent,
   hasVisibleAssistantFinalMessage,
   stripManagedOutgoingAssistantContentBlocks,
@@ -297,8 +296,7 @@ export async function finalizeChatSendDispatchedReplies(params: {
       ? mediaMessage?.content
       : assistantContent;
   const displayReply =
-    extractAssistantDisplayTextFromContent(assistantContent) ??
-    buildTranscriptReplyText(finalPayloads);
+    extractAssistantDisplayText(assistantContent) ?? buildTranscriptReplyText(finalPayloads);
   const transcriptDisplayReply = displayReply?.trim() ?? "";
   const transcriptReply =
     mediaMessage?.transcriptText ||

--- a/src/gateway/server-methods/chat-send-source-finalization.ts
+++ b/src/gateway/server-methods/chat-send-source-finalization.ts
@@ -15,7 +15,7 @@ import { loadSessionEntry } from "../session-utils.js";
 import { formatForLog } from "../ws-log.js";
 import {
   buildAssistantReplyContent,
-  extractAssistantDisplayTextFromContent,
+  extractAssistantDisplayText,
   hasAssistantDisplayMediaContent,
   hasManagedOutgoingAssistantContent,
   hasVisibleAssistantFinalMessage,
@@ -295,7 +295,7 @@ async function finalizeChatSendAgentReplyPayloads(
   }
 
   const displayReply =
-    extractAssistantDisplayTextFromContent(sourceReplyBroadcastContent) ??
+    extractAssistantDisplayText(sourceReplyBroadcastContent) ??
     buildTranscriptReplyText(finalPayloads);
   if (!sourceReplyBroadcastContent.length && !displayReply) {
     return { kind: "dropped", reason: "no-visible-content" };
@@ -408,7 +408,7 @@ async function finalizeChatSendAgentReplyPayloads(
       return state.broadcastContent;
     })
     .filter((block): block is AssistantDisplayContentBlock => Boolean(block));
-  const sourceReplyTextFromContent = extractAssistantDisplayTextFromContent(sourceReplyContent);
+  const sourceReplyTextFromContent = extractAssistantDisplayText(sourceReplyContent);
   const sourceReplyText =
     sourceReplyTextFromContent ?? (sourceReplyContent.length === 0 ? displayReply : undefined);
   const message = {

--- a/src/gateway/server-methods/chat-tts-markers.ts
+++ b/src/gateway/server-methods/chat-tts-markers.ts
@@ -7,7 +7,7 @@ import {
 import type { ReplyPayload } from "../../auto-reply/reply-payload.js";
 import { projectChatDisplayMessage } from "../chat-display-projection.js";
 import {
-  extractAssistantDisplayTextFromContent,
+  extractAssistantDisplayText,
   type AssistantDisplayContentBlock,
 } from "./chat-assistant-content.js";
 import type { GatewayInjectedTtsSupplementMarker } from "./chat-transcript-inject.js";
@@ -29,7 +29,7 @@ function resolveTtsSupplementMarkerText(text: string): string {
     ? (projected.content as AssistantDisplayContentBlock[])
     : undefined;
   return (
-    extractAssistantDisplayTextFromContent(projectedContent) ??
+    extractAssistantDisplayText(projectedContent) ??
     (typeof projected?.text === "string" ? projected.text.trim() : undefined) ??
     trimmed
   );


### PR DESCRIPTION
## What Problem This Solves

Gateway reply handling has two nearly identical implementations for extracting display text from assistant content. Final replies, source replies, and TTS supplement matching can therefore drift apart, and one path allocates separate map/filter arrays before recombining the text.

## Why This Change Was Made

Keep one existing extraction owner, migrate every internal caller, and collect nonempty text blocks in one pass before the unchanged Markdown-preserving combiner. Text order, meaningful indentation, blank/non-text handling, media fallback precedence, and TTS marker identity remain unchanged. No cache, public API, storage, authorization, or delivery-policy change is introduced.

The accepted cleanup removes 18 production lines. The required formatter removes one additional layout line, for **19 fewer lines across five files**. That formatting correction changes only a newline and indentation between unchanged nullish-coalescing operands.

## User Impact

No intended change to replies, transcript text, or TTS supplement matching. **This is a code cleanup, not a general performance improvement.** Historical measurements are mixed and include adverse CPU and memory results; they do not establish faster Gateway turns, speech synthesis, or UI rendering.

## Evidence

[Focused validation R2](https://github.com/openclaw/openclaw/actions/runs/34674469623) passed **47 tests**: all 32 chat-display projection tests, all 11 reply-dispatch tests, and four exact selected TTS supplement tests. The other **215 tests were unselected**, not counted as passing. The TTS cases cover delayed supplements, forwarded replies, pre-truncation matching, and visible-final separation.

Formatting passed on all five files. The changed-check dry-run plan passed and selected core/coreTests, but none of its listed full gates ran; exact-head hosted CI remains required. The earlier validation R1 stopped on formatting before tests or PLAN ran. That failure is preserved. R2 applied the exact one-newline formatter correction without changing expressions, tests, assertions, or limits.

The R2 archive was recovered and verified (SHA256 `ccd07857ae25fdc1124b70e29a73de1369d3ac3a2db8236522588d856c293990`). Every observed native child closed and its monitor joined. Baseline restoration and normal worktree removal succeeded; the post-export removal receipt summary is retained separately, not claimed as an archived raw family. The dedicated Testbox was stopped and independently confirmed completed.

The PR is authored on `bf630269dbf8c0821885a46c0a58ca33aba1d1a0`. All 34 validation source, caller, test, toolchain, and formatter-config pins match the validated `b4c35afcc53430eaf46fc079c8461dbd2727b142` packet. The exact formatted candidate is unchanged. Its own frozen dependency install passed; matching oxfmt 0.66.0 made no further source changes.

Fresh managed Codex review through P2 completed scoped-clean across both evidence batches, with no actionable findings. No product tests or benchmarks were rerun during authoring.

[Historical source-R2 measurement](https://github.com/openclaw/openclaw/actions/runs/34654768256) used four fresh Linux processes in B1/C1/C2/B2 order at `8d61c22a019994e18dfcbe3608087ce1972ea76c`, with two warmup and seven measured batches. Each phase made 95,777 calls over 17 cases. Complete case outputs matched across all phases, and the native processes, worktree and lease were closed. These are extractor and TTS-marker measurements, not full chat delivery or real TTS-provider tests. The five affected baseline owners match the later validation base; the formatted finalization file differs from the measured candidate only by the mechanical newline correction. Timings retain their original source label, and no benchmark was rerun for this PR.

Percentage changes below are candidate versus baseline; negative means less time. Tiny controls have very small absolute costs, so percentages should not be generalized.

| Historical case | B1/C1 wall | B2/C2 wall | B1/C1 CPU | B2/C2 CPU |
| --- | ---: | ---: | ---: | ---: |
| absent-content | +9.45% | +10.25% | -4.76% | +20.00% |
| null-content | +10.97% | +2.31% | +10.00% | +0.00% |
| empty-content | -6.64% | -0.98% | -5.26% | +0.00% |
| mixed-caption-blocks | -4.88% | -22.84% | -4.78% | -24.55% |
| paragraph-and-indent | -12.89% | -15.07% | -13.19% | -16.07% |
| crlf-fenced-reply | +0.41% | +12.52% | +1.05% | +13.13% |
| sparse-null-blocks | -22.15% | -7.44% | -22.70% | -6.96% |
| only-nonvisible-blocks | -26.50% | -5.45% | -26.13% | -7.27% |
| many-display-blocks | -30.89% | +6.82% | -31.07% | +97.68% |
| legacy-dense-captions | -16.35% | -7.65% | -15.92% | -8.28% |
| legacy-empty-content | +12.73% | +16.40% | +12.73% | +15.87% |
| tts-no-supplement | +19.74% | +12.26% | +33.33% | +0.00% |
| tts-no-media | +51.07% | +4.41% | +50.00% | +0.00% |
| tts-spoken-only | -12.81% | -7.16% | -46.35% | +101.33% |
| tts-visible-markdown-priority | -5.73% | -17.92% | -7.56% | -9.16% |
| tts-crlf-code | -3.64% | -25.84% | -3.81% | -25.77% |
| tts-long-visible-text | -6.99% | -14.05% | -7.14% | -14.29% |

The many-block case changed from 0.04284 to 0.02961 ms in one order, but from 0.03561 to 0.03803 ms in the reverse order, where CPU increased 97.68%. Spoken-only TTS-marker wall time improved in both orders while reverse CPU increased 101.33%. Absent/null input, the existing extractor's empty case, and no-supplement/no-media TTS controls also retain adverse observations.

Whole-child wall changed −25.52%/−0.65%, user CPU −21.09%/−1.98%, and system CPU −32.90%/+7.22%. Kernel peak RSS changed −0.27%/+6.80%; sampled process-tree RSS +0.17%/+6.48%. Those totals include imports, setup and untimed checks. No universal benefit or population-confidence claim is made. Earlier source-R1 measurements and validation failures remain preserved; the cleanup decision does not relabel them as successes.

**Current-head qualification:** Head `96662747816e` preserves the authored patch on main `785266d3af19`, including the shared lint repair in #145632. Stable patch ID, complete changed-file bytes, and all 34 supporting source/test/toolchain pins match the previously reviewed candidate, so the recorded P2 review and validation remain applicable within their original scope. Historical benchmarks retain their original source labels. Prior CI failures remain recorded; no test or benchmark was rerun for this rebase, and fresh exact-head CI is required before landing.
