### PR TITLE
fix(sessions): avoid redundant entry data reads during cleanup

### DIFF
--- a/src/config/sessions/session-accessor.sqlite-lifecycle-artifacts.ts
+++ b/src/config/sessions/session-accessor.sqlite-lifecycle-artifacts.ts
@@ -217,7 +217,7 @@ export function planSessionLifecycleArtifactCleanup(
       database.db,
       db
         .selectFrom("session_nodes")
-        .select(["entry_json", "session_key", "current_session_id", "updated_at"])
+        .select(["session_key", "current_session_id", "updated_at"])
         .orderBy("session_key", "asc"),
     ).rows;
 


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where lifecycle cleanup performed avoidable allocations across large session stores, including cleanup runs with nothing eligible for removal.

## Why This Change Was Made

The initial inventory now selects only the session key, current session ID, and timestamp it consumes. The existing full-store projection continues to supply the authoritative entries for ownership, reference, and retention decisions. The row population and ordering are preserved.

## User Impact

Memory-plugin lifecycle cleanup avoids materializing one unused copy of the stored entry JSON. Eligibility, ownership, archival, and deletion behavior are unchanged.

## Evidence

- A private real-SQLite before/after probe used eight retained entries with 2 MiB synthetic inline skill prompts each. Large returned entry JSON fell from **33,558,104 to 16,779,052 bytes**. The complete fixture hash, survivors, inventory order, cleanup result, and all other native operations matched; the 1,492 bytes of reference-metadata JSON were unchanged. This measures returned payload volume and does not attribute a production OOM.
- **35 existing tests passed** across lifecycle cleanup, cleanup races, and reclamation admission races. Changed-scope formatting, typechecks, lint, and repository guards passed. Independent code review found no actionable findings through P2.
- The [Blacksmith Testbox public SDK cleanup flow](https://github.com/openclaw/openclaw/actions/runs/34675480540) passed on Linux/Node 24.19.0 with the same real-SQLite fixture and one-copy result. The delegated command exited 0, its fixture was removed, and its lease completed. The earlier transport-only attempt failed before the SDK ran; the unchanged proof passed after correcting command framing.

Related: #112423. This change covers the initial entry inventory; it does not change transcript archive encoding or final reclamation.
