### PR TITLE
feat: drain plugin work before removing Claw packages

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewayProtocol.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewayProtocol.kt
@@ -940,6 +940,7 @@ enum class GatewayMethod(
   SessionsStorageStatus("sessions.storage.status"),
   SessionsStorageRun("sessions.storage.run"),
   PluginsReload("plugins.reload"),
+  ClawsPackagesRemove("claws.packages.remove"),
 }
 
 enum class GatewayEvent(

--- a/docs/cli/claws.md
+++ b/docs/cli/claws.md
@@ -427,7 +427,7 @@ imported heartbeat tasks, uncorroborated monitors, and jobs in another scheduler
 remain blockers.
 Modified files and resources with another current owner are retained or
 blocked. Cleanup choices are part of the plan digest; `--yes` never broadens
-them. Globally installed plugins are retained while this Claw's reference is
+them. By default, globally installed plugins are retained while this Claw's reference is
 released. Removal reports which retained requirements Claw add introduced; use
 the ordinary plugin lifecycle separately when you intend to uninstall a
 process-wide plugin.
@@ -457,7 +457,8 @@ its cleanup record. Correct the reported error, preview removal again, and retry
 to finish cleanup before recreating the agent.
 
 To remove unchanged Claw-introduced references that have no other current
-owner, include `--remove-unused` in both preview and apply. To select exact
+owner, include `--remove-unused` in both preview and apply. Global plugins are
+excluded from this generic cleanup mode. To select exact
 referenced resources instead, repeat `--remove-referenced`:
 
 ```bash
@@ -469,6 +470,22 @@ openclaw claws remove incident-triage \
 Use `--force-referenced` only after reviewing the displayed dependents,
 independent owners, and pre-existing origin. It allows selected cleanup despite
 those conflicts; it does not skip plan-integrity consent.
+
+For a selected plugin, the serving Gateway withdraws its runtime capabilities
+and attempts cleanup before deleting its installed files. The command waits for
+runtime application and reports the resulting Gateway generation without
+restarting the Gateway. Ownership and artifact changes after preview require a
+fresh plan. Cleanup is best effort: warnings appear in the result's `warnings`
+list and in human-readable output, without turning a completed removal into a
+failed result.
+
+If package cleanup fails, removal reports `partial` with `package_cleanup_failed`
+and retains its cleanup record. Earlier removal steps are not rolled back.
+A Gateway runtime replacement failure stops the remaining package phase and
+reports unattempted packages as retained, alongside earlier outcomes and warnings.
+Ordinary package errors continue best-effort cleanup of the other selections.
+Resolve the reported failure, preview again, and retry; a lost connection never
+causes an automatic local uninstall.
 
 ## Export an installed agent
 

--- a/src/claws/lifecycle-config-removal.ts
+++ b/src/claws/lifecycle-config-removal.ts
@@ -146,6 +146,7 @@ async function commitClawAgentConfigRemoval(
 }
 
 type CommittedClawAgentRemoval = ClawAgentConfigRemovalResult & {
+  operationId: string;
   assertCurrent: (database?: OpenClawStateDatabase) => void;
   drainMonitors: () => Promise<void>;
   completeDeletion: (database: OpenClawStateDatabase) => void;
@@ -237,6 +238,7 @@ export async function withClawAgentConfigRemoval<T>(
           assertCurrent();
           return {
             ...result,
+            operationId: deletion.entry.operationId,
             assertCurrent,
             drainMonitors: async () => {
               assertCurrent();

--- a/src/claws/lifecycle-remove-contract.ts
+++ b/src/claws/lifecycle-remove-contract.ts
@@ -1,3 +1,4 @@
+import type { PluginRuntimeApplication } from "../../packages/gateway-protocol/src/schema/plugins.js";
 import type { unsetConfiguredMcpServer } from "../agents/mcp-config-mutation.js";
 import type { listConfiguredMcpServers } from "../config/mcp-config.js";
 import type { purgeAgentSessionStoreEntries } from "../config/sessions/cleanup-service.js";
@@ -6,6 +7,7 @@ import type { OpenClawStateDatabaseOptions } from "../state/openclaw-state-db.js
 import type { ClawCronGateway } from "./cron.js";
 import type { ClawTrashPath, RemovedWorkspaceFile } from "./lifecycle-delete-support.js";
 import type { ClawMonitorCleanupGateway } from "./monitor-cleanup-contract.js";
+import type { ClawPackageRemovalGateway } from "./package-remove-contract.js";
 import type {
   ClawPackageRemovalResult,
   ClawReferencedCleanup,
@@ -74,6 +76,7 @@ export type ClawRemovePlanOptions = OpenClawStateDatabaseOptions & {
 };
 
 export type ClawRemoveApplyOptions = ClawRemovePlanOptions & {
+  packageGateway?: ClawPackageRemovalGateway;
   purgeSessions?: (
     ...args: Parameters<typeof purgeAgentSessionStoreEntries>
   ) => Promise<boolean | void>;
@@ -97,5 +100,7 @@ export type ClawRemoveResult = {
   mcpServers: RemovedMcpServer[];
   cronJobs: RemovedCronJob[];
   packageRefsReleased: number;
+  pluginRuntime?: PluginRuntimeApplication;
+  warnings?: string[];
   error?: { code: string; message: string };
 };

--- a/src/claws/lifecycle-remove-ownership.test.ts
+++ b/src/claws/lifecycle-remove-ownership.test.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../test/helpers/promise.js";
 import { readSourceConfigBestEffort, resetConfigRuntimeState } from "../config/config.js";
 import { executeSqliteQuerySync, getNodeSqliteKysely } from "../infra/kysely-sync.js";
@@ -20,7 +20,7 @@ import {
   quiescentClawMonitorGateway,
 } from "./lifecycle-remove.test-support.js";
 import { applyClawRemovePlan, buildClawRemovePlan } from "./lifecycle-state.js";
-import { readClawInstallRecord } from "./provenance.js";
+import { readClawInstallRecord, persistClawPackageRef, readClawPackageRefs } from "./provenance.js";
 import { readClawWorkspaceFiles } from "./workspace.js";
 
 const cleanups: Array<() => Promise<void>> = [];
@@ -47,16 +47,16 @@ async function fixture(withFile = false) {
         },
       }),
     ).toMatchObject({ status: "complete" });
-    return added.plan.agent.workspace;
+    return { workspace: added.plan.agent.workspace, plan: added.plan };
   };
-  const workspace = await install("initial");
+  const { workspace, plan: initialPlan } = await install("initial");
   const trashPath: NonNullable<ClawRemoveApplyOptions["trashPath"]> = async (pathname) => {
     await fs.rm(pathname, { recursive: true, force: true });
     return true;
   };
   const remove = async (overrides: Partial<ClawRemoveApplyOptions> = {}) => {
     const config = await readSourceConfigBestEffort();
-    const plan = await buildClawRemovePlan("worker", { config });
+    const plan = await buildClawRemovePlan("worker", { config, ...overrides });
     expect(plan.blockers).toEqual([]);
     return await applyClawRemovePlan(plan, {
       config,
@@ -66,7 +66,7 @@ async function fixture(withFile = false) {
       ...overrides,
     });
   };
-  return { state, workspace, install, remove, trashPath };
+  return { state, workspace, plan: initialPlan, install, remove, trashPath };
 }
 
 function expireDeletionLease(): void {
@@ -84,6 +84,75 @@ function expireDeletionLease(): void {
 }
 
 describe("Claw removal operation ownership", () => {
+  it.each(["transport", "runtime"])(
+    "keeps partial state after package %s failure without local fallback",
+    async (failure) => {
+      const current = await fixture(true);
+      persistClawPackageRef(current.plan, {
+        kind: "plugin",
+        source: "clawhub",
+        ref: "audit",
+        version: "1.0.0",
+        integrity: "sha256:audit",
+      });
+      const application = { operationId: "runtime-final", generation: 3, pluginIds: ["audit"] };
+      const message =
+        failure === "transport"
+          ? "package connection lost"
+          : "Plugin activation failed. Gateway generation 3: replacement applied.";
+      const warnings = ["Package dependency pruning failed."];
+      const packages = [
+        {
+          kind: "plugin" as const,
+          ref: "audit",
+          version: "1.0.0",
+          action: "error" as const,
+          reason: message,
+        },
+      ];
+      const packageGateway = vi.fn(async () => {
+        if (failure === "transport") {
+          throw new Error(message);
+        }
+        return { packages, warnings, application };
+      });
+      const uninstallPlugin = vi.fn();
+      const result = await current.remove({
+        referencedCleanup: { mode: "remove-selected", selected: ["plugin:audit@1.0.0"] },
+        packageGateway,
+        packageDeps: {
+          uninstallPlugin,
+          resolvePlugin: async () => ({
+            status: "found",
+            pluginId: "audit",
+            installedVersion: "1.0.0",
+            record: {
+              source: "clawhub",
+              integrity: "sha256:audit",
+              installedAt: "1970-01-01T00:00:00.001Z",
+            },
+          }),
+        },
+      });
+      expect(result).toMatchObject({
+        status: "partial",
+        agentRemoved: true,
+        error: { code: "package_cleanup_failed", message },
+      });
+      expect(result.packages).toEqual(failure === "runtime" ? packages : []);
+      expect(result.pluginRuntime).toEqual(failure === "runtime" ? application : undefined);
+      expect(result.warnings).toEqual(failure === "runtime" ? warnings : undefined);
+      expect(packageGateway).toHaveBeenCalledOnce();
+      expect(uninstallPlugin).not.toHaveBeenCalled();
+      expect(readAgentDeletionJournal("worker")?.cleanupCompleted).toBe(false);
+      expect(readClawInstallRecord("worker")?.status).toBe("partial");
+      expect(readClawPackageRefs({ agentId: "worker" })[0]?.status).toBe("complete");
+      await expect(fs.readFile(path.join(current.workspace, "SOUL.md"), "utf8")).resolves.toBe(
+        "managed\n",
+      );
+    },
+  );
+
   it.each([
     { successor: "removing", reject: false },
     { successor: "removing", reject: true },

--- a/src/claws/lifecycle-state.ts
+++ b/src/claws/lifecycle-state.ts
@@ -1,6 +1,5 @@
-import { createHash } from "node:crypto";
 import { isDeepStrictEqual } from "node:util";
-import { coerceErrorMessage, stableStringify } from "@openclaw/normalization-core";
+import { coerceErrorMessage } from "@openclaw/normalization-core";
 import {
   AgentSharedStoreOwnerError,
   assertAgentSessionStoreDeletionSafe,
@@ -42,8 +41,13 @@ import {
 import { readClawStatus } from "./lifecycle-status.js";
 import { clawMcpRemovalSelector, planClawMcpServerRemoval } from "./mcp.js";
 import { clawMonitorSnapshotSchema } from "./monitor-cleanup-contract.js";
-import { filterReferencedCleanup, projectClawPackageRemovePlan } from "./package-remove-plan.js";
-import { applyClawPackageRemovals, planClawPackageRemovals } from "./package-remove.js";
+import { applyClawPackageRemovalPhase } from "./package-remove-phase.js";
+import {
+  filterReferencedCleanup,
+  projectClawPackageRemovePlan,
+  digestClawRemovalState,
+} from "./package-remove-plan.js";
+import { planClawPackageRemovals } from "./package-remove.js";
 import { CLAW_OUTPUT_STABILITY } from "./types.js";
 
 export { ClawRemoveError } from "./lifecycle-delete-support.js";
@@ -408,9 +412,7 @@ export async function buildClawRemovePlan(
     stability: CLAW_OUTPUT_STABILITY,
     dryRun: true,
     mutationAllowed: false,
-    planIntegrity: `sha256:${createHash("sha256")
-      .update(stableStringify(planIdentity))
-      .digest("hex")}`,
+    planIntegrity: digestClawRemovalState(planIdentity),
     target,
     ...(record ? { agentId: record.install.agentId } : {}),
     actions,
@@ -617,18 +619,19 @@ export async function applyClawRemovePlan(
           "Session cleanup failed; correct the reported error and retry Claw removal.",
         );
       }
-      result.packages = await applyClawPackageRemovals(
-        packageDecisions.toSorted(
-          (left, right) =>
-            Number(left.packageRef.relationship === "referenced") -
-            Number(right.packageRef.relationship === "referenced"),
-        ),
-        {
+      try {
+        const removed = await applyClawPackageRemovalPhase(packageDecisions, {
           ...options,
-          deps: options.packageDeps,
+          agentId,
+          operationId: configRemoval.operationId,
           assertCurrent,
-        },
-      );
+        });
+        result.packages = removed.packages;
+        result.pluginRuntime = removed.application;
+        result.warnings = removed.warnings;
+      } catch (error) {
+        return partial("package_cleanup_failed", coerceErrorMessage(error));
+      }
       assertCurrent();
       const packageErrors = result.packages.filter((pkg) => pkg.action === "error");
       if (packageErrors.length > 0) {

--- a/src/claws/package-remove-contract.ts
+++ b/src/claws/package-remove-contract.ts
@@ -1,0 +1,59 @@
+import { Value } from "typebox/value";
+import { z } from "zod";
+import {
+  PluginRuntimeApplicationSchema,
+  type PluginRuntimeApplication,
+} from "../../packages/gateway-protocol/src/schema/plugins.js";
+import { clawMonitorCleanupBindingSchema } from "./monitor-cleanup-contract.js";
+import { MAX_CLAW_MANIFEST_BYTES } from "./source-limits.js";
+
+const text = z.string().min(1).max(4096);
+const digest = z.string().regex(/^sha256:[a-f0-9]{64}$/u);
+
+export const clawPackageRemovalRequestSchema = z
+  .object({
+    agentId: text,
+    operationId: text,
+    binding: clawMonitorCleanupBindingSchema,
+    expectedInstallDigest: digest,
+    expectedPackagePlanDigest: digest,
+    cleanup: z
+      .object({
+        mode: z.enum(["retain", "remove-if-unused", "remove-selected"]),
+        selected: z.array(text).optional(),
+        allowConflicts: z.boolean().optional(),
+      })
+      .strict(),
+  })
+  .strict()
+  .refine(
+    (request) => Buffer.byteLength(JSON.stringify(request)) <= MAX_CLAW_MANIFEST_BYTES,
+    "Package cleanup request exceeds the Claw manifest byte limit.",
+  );
+
+export const clawPackageRemovalResultSchema = z
+  .object({
+    packages: z.array(
+      z
+        .object({
+          kind: z.enum(["plugin", "skill"]),
+          ref: text,
+          version: text,
+          action: z.enum(["uninstalled", "retained", "error"]),
+          reason: z.string().optional(),
+        })
+        .strict(),
+    ),
+    warnings: z.array(z.string()).optional(),
+    application: z
+      .custom<PluginRuntimeApplication>((value) =>
+        Value.Check(PluginRuntimeApplicationSchema, value),
+      )
+      .optional(),
+  })
+  .strict();
+
+export type ClawPackageRemovalPhaseResult = z.infer<typeof clawPackageRemovalResultSchema>;
+export type ClawPackageRemovalGateway = (
+  request: Omit<z.infer<typeof clawPackageRemovalRequestSchema>, "binding">,
+) => Promise<ClawPackageRemovalPhaseResult>;

--- a/src/claws/package-remove-phase.test.ts
+++ b/src/claws/package-remove-phase.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it, vi } from "vitest";
+import { clawPackageRemovalRequestSchema } from "./package-remove-contract.js";
+import { applyClawPackageRemovalPhase } from "./package-remove-phase.js";
+import { digestClawPackageRemovalPlan } from "./package-remove-plan.js";
+import {
+  planClawPackageRemovals,
+  type ClawPackageRemovalDecision,
+  type ClawReferencedCleanup,
+} from "./package-remove.js";
+import type { PersistedClawPackageRef } from "./provenance.js";
+
+const mocks = vi.hoisted(() => ({ local: vi.fn() }));
+vi.mock("./package-remove.js", async (original) => ({
+  ...(await original<typeof import("./package-remove.js")>()),
+  applyClawPackageRemovals: (...args: unknown[]) => mocks.local(...args),
+}));
+vi.mock("./provenance.js", async (original) => ({
+  ...(await original<typeof import("./provenance.js")>()),
+  readClawInstallRecord: () => undefined,
+}));
+
+function reference(relationship: "managed" | "referenced"): PersistedClawPackageRef {
+  return {
+    schemaVersion: "openclaw.clawPackageRef.v1",
+    agentId: "worker",
+    clawName: "worker",
+    kind: "plugin",
+    source: "clawhub",
+    ref: "audit",
+    version: "1.0.0",
+    integrity: "sha256:audit",
+    status: "complete",
+    relationship,
+    origin: "claw-introduced",
+    independentOwner: false,
+    installedAtMs: 1,
+    updatedAtMs: 1,
+  };
+}
+const application = { operationId: "runtime-removal", generation: 2, pluginIds: ["audit"] };
+const uninstalled = {
+  kind: "plugin" as const,
+  ref: "audit",
+  version: "1.0.0",
+  action: "uninstalled" as const,
+};
+const options = {
+  agentId: "worker",
+  operationId: "deletion-operation",
+  assertCurrent: () => undefined,
+};
+
+async function decisions(relationship: "managed" | "referenced", cleanup: ClawReferencedCleanup) {
+  const ref = reference(relationship);
+  return await planClawPackageRemovals({ workspace: "/synthetic-workspace" }, [ref], {
+    referencedCleanup: cleanup,
+    deps: {
+      readPackageRefs: () => [ref],
+      resolvePlugin: async () => ({
+        status: "found",
+        pluginId: "audit",
+        installedVersion: "1.0.0",
+        record: {
+          source: "clawhub",
+          integrity: ref.integrity,
+          installedAt: "1970-01-01T00:00:00.001Z",
+        },
+      }),
+    },
+  });
+}
+
+describe("Claw package phase handoff", () => {
+  it.each(["retain", "remove-if-unused"] as const)(
+    "keeps referenced plugins retained under %s",
+    async (mode) => {
+      const cleanup = { mode };
+      const planned = await decisions("referenced", cleanup);
+      expect(planned[0]?.action).toBe("retain");
+      const packageGateway = vi.fn();
+      mocks.local.mockResolvedValue({ packages: [{ ...uninstalled, action: "retained" }] });
+      await applyClawPackageRemovalPhase(planned, {
+        ...options,
+        referencedCleanup: cleanup,
+        packageGateway,
+      });
+      expect(packageGateway).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(["managed", "referenced"] as const)(
+    "hands off the canonical %s plugin removal decision without local mutation",
+    async (relationship) => {
+      mocks.local.mockClear();
+      const cleanup: ClawReferencedCleanup =
+        relationship === "managed"
+          ? { mode: "retain" }
+          : { mode: "remove-selected", selected: ["plugin:audit@1.0.0"] };
+      const planned = await decisions(relationship, cleanup);
+      expect(planned[0]?.action).toBe("uninstall");
+      const packageGateway = vi.fn(async (request) => {
+        const wireRequest = JSON.stringify(request);
+        const received = clawPackageRemovalRequestSchema.parse({
+          ...JSON.parse(wireRequest),
+          binding: {
+            configPath: "/synthetic-config",
+            statePath: "/synthetic-state",
+            cronStorePath: "/synthetic-cron",
+          },
+        });
+        expect(received.expectedPackagePlanDigest).toBe(
+          digestClawPackageRemovalPlan(planned, received.cleanup),
+        );
+        return { packages: [uninstalled], application };
+      });
+      expect(
+        await applyClawPackageRemovalPhase(planned, {
+          ...options,
+          referencedCleanup: cleanup,
+          packageGateway,
+        }),
+      ).toEqual({ packages: [uninstalled], application });
+      expect(packageGateway).toHaveBeenCalledOnce();
+      expect(mocks.local).not.toHaveBeenCalled();
+    },
+  );
+
+  it("preserves managed-before-referenced ordering for a mixed phase", async () => {
+    mocks.local.mockClear();
+    const cleanup = { mode: "remove-selected" as const, selected: ["plugin:audit@1.0.0"] };
+    const planned = await decisions("referenced", cleanup);
+    const skill: ClawPackageRemovalDecision = {
+      ...planned[0]!,
+      packageRef: { ...reference("managed"), kind: "skill", ref: "triage" },
+    };
+    const packages = [{ ...uninstalled, kind: "skill" as const, ref: "triage" }, uninstalled];
+    const packageGateway = vi.fn(async () => ({ packages, application }));
+    expect(
+      (
+        await applyClawPackageRemovalPhase([...planned, skill], {
+          ...options,
+          referencedCleanup: cleanup,
+          packageGateway,
+        })
+      ).packages,
+    ).toEqual(packages);
+    expect(mocks.local).not.toHaveBeenCalled();
+  });
+
+  it.each(["transport", "missing outcome", "wrong owner", "missing application"])(
+    "rejects %s without retry or local fallback",
+    async (failure) => {
+      mocks.local.mockClear();
+      const cleanup = { mode: "remove-selected" as const, selected: ["plugin:audit@1.0.0"] };
+      const planned = await decisions("referenced", cleanup);
+      const packageGateway = vi.fn(async () => {
+        if (failure === "transport") {
+          throw new Error("connection lost");
+        }
+        return {
+          packages:
+            failure === "missing outcome"
+              ? []
+              : [{ ...uninstalled, ref: failure === "wrong owner" ? "other" : "audit" }],
+          ...(failure === "missing application" ? {} : { application }),
+        };
+      });
+      await expect(
+        applyClawPackageRemovalPhase(planned, {
+          ...options,
+          referencedCleanup: cleanup,
+          packageGateway,
+        }),
+      ).rejects.toThrow();
+      expect(packageGateway).toHaveBeenCalledOnce();
+      expect(mocks.local).not.toHaveBeenCalled();
+    },
+  );
+});

--- a/src/claws/package-remove-phase.ts
+++ b/src/claws/package-remove-phase.ts
@@ -1,0 +1,62 @@
+import { isDeepStrictEqual } from "node:util";
+import type { ClawRemoveApplyOptions } from "./lifecycle-remove-contract.js";
+import type { ClawPackageRemovalPhaseResult } from "./package-remove-contract.js";
+import {
+  filterReferencedCleanup,
+  digestClawPackageRemovalPlan,
+  digestClawRemovalInstall,
+  orderClawPackageRemovals,
+  normalizeClawPackageCleanup,
+} from "./package-remove-plan.js";
+import { applyClawPackageRemovals, type ClawPackageRemovalDecision } from "./package-remove.js";
+import { readClawInstallRecord } from "./provenance.js";
+
+export async function applyClawPackageRemovalPhase(
+  decisions: ClawPackageRemovalDecision[],
+  options: ClawRemoveApplyOptions & {
+    agentId: string;
+    operationId: string;
+    assertCurrent: () => void;
+  },
+): Promise<ClawPackageRemovalPhaseResult> {
+  const ordered = orderClawPackageRemovals(decisions);
+  options.assertCurrent();
+  const cleanup = normalizeClawPackageCleanup(
+    filterReferencedCleanup(options.referencedCleanup, "package"),
+  );
+  if (
+    !ordered.some(
+      (decision) => decision.packageRef.kind === "plugin" && decision.action === "uninstall",
+    )
+  ) {
+    return await applyClawPackageRemovals(ordered, { ...options, deps: options.packageDeps });
+  }
+  if (!options.packageGateway) {
+    throw new Error("Plugin cleanup requires the serving Gateway package owner.");
+  }
+  // Hand off before taking either cross-process package mutation lease.
+  const removed = await options.packageGateway({
+    agentId: options.agentId,
+    operationId: options.operationId,
+    expectedInstallDigest: digestClawRemovalInstall(
+      readClawInstallRecord(options.agentId, options),
+    ),
+    expectedPackagePlanDigest: digestClawPackageRemovalPlan(ordered, cleanup),
+    cleanup,
+  });
+  options.assertCurrent();
+  const expected = ordered.map(({ packageRef }) => [
+    packageRef.kind,
+    packageRef.ref,
+    packageRef.version,
+  ]);
+  const actual = removed.packages.map((pkg) => [pkg.kind, pkg.ref, pkg.version]);
+  if (
+    !isDeepStrictEqual(expected, actual) ||
+    (removed.packages.some((pkg) => pkg.kind === "plugin" && pkg.action === "uninstalled") &&
+      !removed.application)
+  ) {
+    throw new Error("Gateway package cleanup returned incomplete removal outcomes.");
+  }
+  return removed;
+}

--- a/src/claws/package-remove-plan.ts
+++ b/src/claws/package-remove-plan.ts
@@ -1,9 +1,48 @@
+import { createHash } from "node:crypto";
+import { stableStringify } from "@openclaw/normalization-core";
 import {
   clawPackageRemovalSelector,
   type ClawPackageInspection,
   type ClawPackageRemovalDecision,
   type ClawReferencedCleanup,
 } from "./package-remove.js";
+import type { PersistedClawInstall } from "./provenance.js";
+
+export function orderClawPackageRemovals(decisions: ClawPackageRemovalDecision[]) {
+  return decisions.toSorted(
+    (left, right) =>
+      Number(left.packageRef.relationship === "referenced") -
+      Number(right.packageRef.relationship === "referenced"),
+  );
+}
+
+/** Comparison facts only; removers must still validate their current journal and leases. */
+export function digestClawRemovalState(value: unknown): string {
+  return `sha256:${createHash("sha256").update(stableStringify(value)).digest("hex")}`;
+}
+
+/** Omitted cleanup options and their defaults must have the same identity across JSON RPC. */
+export function normalizeClawPackageCleanup(cleanup?: ClawReferencedCleanup) {
+  return {
+    mode: cleanup?.mode ?? "retain",
+    selected: [...(cleanup?.selected ?? [])],
+    allowConflicts: cleanup?.allowConflicts === true,
+  };
+}
+
+export function digestClawPackageRemovalPlan(
+  decisions: ClawPackageRemovalDecision[],
+  cleanup: ClawReferencedCleanup,
+): string {
+  return digestClawRemovalState({
+    decisions: orderClawPackageRemovals(decisions),
+    cleanup: normalizeClawPackageCleanup(cleanup),
+  });
+}
+
+export function digestClawRemovalInstall(install: PersistedClawInstall | undefined): string {
+  return digestClawRemovalState(install ?? null);
+}
 
 type PackageRemoveAction = {
   kind: "packageRef";

--- a/src/claws/package-remove.test.ts
+++ b/src/claws/package-remove.test.ts
@@ -1,11 +1,18 @@
 import { createHash } from "node:crypto";
-import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { mkdir, readFile, writeFile, rename } from "node:fs/promises";
 import { join } from "node:path";
+import { ok } from "@openclaw/normalization-core/result";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../test/helpers/promise.js";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { PluginRuntimeApplicationError } from "../plugins/lifecycle.js";
+import { applyClawHubSkillUninstall } from "../skills/lifecycle/clawhub-uninstall.js";
 import { digestClawHubSkillTree } from "../skills/lifecycle/skill-tree-digest.js";
-import { applyClawPackageRemovals, planClawPackageRemovals } from "./package-remove.js";
+import {
+  applyClawPackageRemovals,
+  planClawPackageRemovals,
+  type PackageRemovalDeps,
+} from "./package-remove.js";
 import type { PersistedClawInstall, PersistedClawPackageRef } from "./provenance.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
@@ -104,6 +111,167 @@ async function trackedQualifiedSkillFixture() {
 }
 
 describe("Claw package removal", () => {
+  it.each(["lease lost during resolution", "uninstall failed"])(
+    "keeps mutation and compensation with their current package owner: %s",
+    async (failure) => {
+      const ref = packageRef();
+      const store = packageRefStore(ref);
+      let leaseLost = false;
+      const uninstallPlugin = vi.fn<NonNullable<PackageRemovalDeps["uninstallPlugin"]>>(
+        async () => {
+          if (failure === "uninstall failed") {
+            throw new Error(failure);
+          }
+          return ok({
+            pluginId: "audit",
+            requestedPluginId: "audit",
+            pluginIds: ["audit"],
+            removed: [],
+            warnings: [],
+          });
+        },
+      );
+      const heartbeat = () => {
+        if (leaseLost) {
+          throw new Error(failure);
+        }
+      };
+      await expect(
+        applyClawPackageRemovals(
+          [
+            {
+              packageRef: ref,
+              workspace: install.workspace,
+              action: "uninstall",
+              affectedClawAgentIds: [],
+              pluginId: "audit",
+            },
+          ],
+          {
+            deps: {
+              ...store,
+              acquirePackageLease: vi.fn(() => ({ heartbeat, release: vi.fn() })),
+              uninstallPlugin,
+              resolvePlugin: vi.fn(async () => {
+                leaseLost = failure === "lease lost during resolution";
+                return {
+                  status: "found" as const,
+                  pluginId: "audit",
+                  record: {
+                    source: "clawhub" as const,
+                    integrity: "sha256:audit",
+                    installedAt: "1970-01-01T00:00:00.001Z",
+                  },
+                  installedVersion: "1.0.0",
+                };
+              }),
+            },
+          },
+        ),
+      ).resolves.toMatchObject({ packages: [{ action: "error", reason: failure }] });
+      if (leaseLost) {
+        expect(uninstallPlugin).not.toHaveBeenCalled();
+        expect(store.readPackageRefs()[0]?.status).toBe("pending");
+      } else {
+        expect(uninstallPlugin).toHaveBeenCalledOnce();
+        expect(store.readPackageRefs()[0]?.status).toBe("failed");
+      }
+    },
+  );
+
+  it.each([false, true])(
+    "preserves partial package effects and stops only runtime failures (runtime=%s)",
+    async (runtime) => {
+      const refs = ["first", "failed", "last"].map((ref) =>
+        packageRef({ ref, integrity: `sha256:${ref}` }),
+      );
+      const store = packageRefStore(...refs);
+      const failure = runtime
+        ? new PluginRuntimeApplicationError("Plugin activation failed.", {
+            operationId: "replacement",
+            generation: 3,
+            pluginIds: ["failed"],
+            phase: "activate",
+            committed: true,
+          })
+        : new Error("Package removal failed.");
+      const uninstallPlugin = vi.fn<NonNullable<PackageRemovalDeps["uninstallPlugin"]>>(
+        async (input) => {
+          input.onWarning?.(`${input.pluginId} cleanup warning`);
+          if (input.pluginId === "failed") {
+            throw failure;
+          }
+          return ok({
+            pluginId: input.pluginId,
+            requestedPluginId: input.pluginId,
+            pluginIds: [input.pluginId],
+            removed: ["directory"],
+            warnings: [`${input.pluginId} cleanup warning`],
+          });
+        },
+      );
+      const result = await applyClawPackageRemovals(
+        refs.map((ref) => ({
+          packageRef: ref,
+          workspace: install.workspace,
+          action: "uninstall" as const,
+          affectedClawAgentIds: [],
+          pluginId: ref.ref,
+        })),
+        {
+          deps: {
+            ...store,
+            uninstallPlugin,
+            resolvePlugin: async ({ clawhubPackage }) => ({
+              status: "found",
+              pluginId: clawhubPackage,
+              installedVersion: "1.0.0",
+              record: {
+                source: "clawhub",
+                integrity: `sha256:${clawhubPackage}`,
+                installedAt: "1970-01-01T00:00:00.001Z",
+              },
+            }),
+          },
+        },
+      );
+      expect(result.packages).toEqual([
+        { kind: "plugin", ref: "first", version: "1.0.0", action: "uninstalled" },
+        {
+          kind: "plugin",
+          ref: "failed",
+          version: "1.0.0",
+          action: "error",
+          reason: failure.message,
+        },
+        {
+          kind: "plugin",
+          ref: "last",
+          version: "1.0.0",
+          action: runtime ? "retained" : "uninstalled",
+          ...(runtime
+            ? { reason: "Package cleanup stopped after a Gateway runtime replacement failed." }
+            : {}),
+        },
+      ]);
+      expect(result.runtimeFailure).toBe(runtime ? failure : undefined);
+      expect(result.warnings).toEqual(
+        runtime
+          ? ["first cleanup warning", "failed cleanup warning"]
+          : ["first cleanup warning", "failed cleanup warning", "last cleanup warning"],
+      );
+      expect(uninstallPlugin.mock.calls.map(([input]) => input.pluginId)).toEqual(
+        runtime ? ["first", "failed"] : ["first", "failed", "last"],
+      );
+      expect(store.readPackageRefs().map((ref) => ref.status)).toEqual([
+        "complete",
+        "failed",
+        "complete",
+      ]);
+      expect(store.claimPackageRef.mock.calls.some(([ref]) => ref.ref === "last")).toBe(!runtime);
+    },
+  );
+
   it("retains referenced plugins by default while releasing the Claw reference", async () => {
     const ref = packageRef();
     const decisions = await planClawPackageRemovals(install, [ref], {
@@ -125,7 +293,15 @@ describe("Claw package removal", () => {
   it("requires separate selection before invoking the canonical plugin lifecycle", async () => {
     const ref = packageRef();
     const store = packageRefStore(ref);
-    const uninstallPlugin = vi.fn().mockResolvedValue(undefined);
+    const uninstallPlugin = vi.fn().mockResolvedValue(
+      ok({
+        pluginId: "audit",
+        requestedPluginId: "audit",
+        pluginIds: ["audit"],
+        removed: [],
+        warnings: [],
+      }),
+    );
     const decisions = await planClawPackageRemovals(install, [ref], {
       deps: {
         ...store,
@@ -156,11 +332,15 @@ describe("Claw package removal", () => {
           }),
         },
       }),
-    ).resolves.toMatchObject([{ action: "uninstalled" }]);
-    expect(uninstallPlugin).toHaveBeenCalledWith("audit", {
-      force: true,
+    ).resolves.toMatchObject({ packages: [{ action: "uninstalled" }] });
+    expect(uninstallPlugin).toHaveBeenCalledWith({
+      pluginId: "audit",
+      caller: "cli",
       invalidateRuntimeCache: false,
       clawManaged: true,
+      applyRuntime: undefined,
+      beforePersistentApply: expect.any(Function),
+      onWarning: expect.any(Function),
     });
   });
 
@@ -215,12 +395,14 @@ describe("Claw package removal", () => {
           },
         },
       ),
-    ).resolves.toMatchObject([
-      {
-        action: "error",
-        reason: "Plugin audit@1.0.0 changed after removal planning.",
-      },
-    ]);
+    ).resolves.toMatchObject({
+      packages: [
+        {
+          action: "error",
+          reason: "Plugin audit@1.0.0 changed after removal planning.",
+        },
+      ],
+    });
 
     expect(uninstallPlugin).not.toHaveBeenCalled();
     expect(store.claimPackageRef).toHaveBeenLastCalledWith(
@@ -263,14 +445,21 @@ describe("Claw package removal", () => {
               installedVersion: "1.0.0",
             };
           }),
-          uninstallPlugin: vi.fn(
-            async (_id: string, apply?: { beforePersistentApply?: () => void }) => {
+          uninstallPlugin: vi.fn<NonNullable<PackageRemovalDeps["uninstallPlugin"]>>(
+            async (apply) => {
               if (stage === "uninstall") {
                 started.resolve();
                 await resume.promise;
               }
               apply?.beforePersistentApply?.();
               uninstall();
+              return ok({
+                pluginId: "audit",
+                requestedPluginId: "audit",
+                pluginIds: ["audit"],
+                removed: [],
+                warnings: [],
+              });
             },
           ),
         },
@@ -294,54 +483,13 @@ describe("Claw package removal", () => {
         resume.resolve();
       }
 
-      await expect(removing).resolves.toMatchObject([
-        { action: "error", reason: "Parent deletion ended." },
-      ]);
+      await expect(removing).resolves.toMatchObject({
+        packages: [{ action: "error", reason: "Parent deletion ended." }],
+      });
       expect(uninstall).not.toHaveBeenCalled();
       expect(store.readPackageRefs()).toEqual([{ ...ref, status: "pending" }]);
     },
   );
-
-  it("leaves failed provenance when an error occurs after uninstall starts", async () => {
-    const ref = packageRef();
-    const store = packageRefStore(ref);
-    const heartbeat = vi.fn(() => {
-      throw new Error("lease lost");
-    });
-
-    await expect(
-      applyClawPackageRemovals(
-        [
-          {
-            packageRef: ref,
-            workspace: install.workspace,
-            action: "uninstall",
-            affectedClawAgentIds: [],
-            pluginId: "audit",
-          },
-        ],
-        {
-          deps: {
-            ...store,
-            acquirePackageLease: vi.fn(() => ({ heartbeat, release: vi.fn() })),
-            uninstallPlugin: vi.fn().mockResolvedValue(undefined),
-            resolvePlugin: vi.fn().mockResolvedValue({
-              status: "found",
-              pluginId: "audit",
-              record: { source: "clawhub", integrity: "sha256:audit", installedAt: 1 },
-              installedVersion: "1.0.0",
-            }),
-          },
-        },
-      ),
-    ).resolves.toMatchObject([{ action: "error", reason: "lease lost" }]);
-
-    expect(store.claimPackageRef).toHaveBeenLastCalledWith(
-      expect.objectContaining({ ref: "audit" }),
-      "failed",
-      expect.anything(),
-    );
-  });
 
   it("requires an explicit override to remove a selected shared reference", async () => {
     const ref = packageRef();
@@ -395,7 +543,7 @@ describe("Claw package removal", () => {
   });
 
   it("retains a same-version plugin whose installed integrity drifted", async () => {
-    const ref = packageRef();
+    const ref = packageRef({ relationship: "managed" });
     const decisions = await planClawPackageRemovals(install, [ref], {
       deps: {
         readPackageRefs: vi.fn().mockReturnValue([ref]),
@@ -410,14 +558,13 @@ describe("Claw package removal", () => {
     expect(decisions).toMatchObject([
       {
         action: "retain",
-        reason:
-          "Claw add introduced this shared requirement; removal releases its dependency edge and retains the artifact. Use its canonical owner separately to uninstall it.",
+        reason: "Installed plugin changed after the Claw was added.",
       },
     ]);
   });
 
   it("retains a plugin reinstalled directly after Claw provenance", async () => {
-    const ref = packageRef({ updatedAtMs: 10 });
+    const ref = packageRef({ relationship: "managed", updatedAtMs: 10 });
     const decisions = await planClawPackageRemovals(install, [ref], {
       deps: {
         readPackageRefs: vi.fn().mockReturnValue([ref]),
@@ -437,8 +584,7 @@ describe("Claw package removal", () => {
     expect(decisions).toMatchObject([
       {
         action: "retain",
-        reason:
-          "Claw add introduced this shared requirement; removal releases its dependency edge and retains the artifact. Use its canonical owner separately to uninstall it.",
+        reason: "Package has a current non-Claw owner or pre-existing origin.",
       },
     ]);
   });
@@ -467,15 +613,76 @@ describe("Claw package removal", () => {
         },
       },
     ]);
-    await expect(applyClawPackageRemovals(decisions, { deps: store })).resolves.toMatchObject([
-      { action: "uninstalled" },
-    ]);
+    await expect(applyClawPackageRemovals(decisions, { deps: store })).resolves.toMatchObject({
+      packages: [{ action: "uninstalled" }],
+    });
     await expect(readFile(join(current.skillDir, "SKILL.md"), "utf8")).rejects.toThrow();
     const lock = JSON.parse(await readFile(current.lockPath, "utf8")) as {
       skills: Record<string, unknown>;
     };
     expect(lock.skills).toEqual({});
   });
+
+  it.each(["preparation", "staged validation", "successor lease"])(
+    "fences skill effects after ownership loss during %s",
+    async (phase) => {
+      const current = await trackedQualifiedSkillFixture();
+      const currentInstall = { ...install, workspace: current.workspaceDir };
+      const ref = packageRef({ kind: "skill", ref: "@owner/triage", relationship: "managed" });
+      const store = packageRefStore(ref);
+      const decisions = await planClawPackageRemovals(currentInstall, [ref], { deps: store });
+      let owned = true;
+      let retainedDir = current.skillDir;
+      let packageOwned = true;
+      const results = await applyClawPackageRemovals(decisions, {
+        assertCurrent: () => {
+          if (!owned) {
+            throw new Error("removal superseded");
+          }
+        },
+        deps: {
+          ...store,
+          acquirePackageLease: () => ({
+            heartbeat() {
+              if (!packageOwned) {
+                throw new Error("Package lease superseded.");
+              }
+            },
+            release() {},
+          }),
+          uninstallSkill: async (plan, options) => {
+            const pending = applyClawHubSkillUninstall(plan, {
+              ...options,
+              rename: async (from, to) => {
+                await rename(from, to);
+                retainedDir = String(to);
+                if (phase === "staged validation" || phase === "successor lease") {
+                  owned = false;
+                  if (phase === "successor lease") {
+                    packageOwned = false;
+                  }
+                }
+              },
+            });
+            if (phase === "preparation") {
+              owned = false;
+            }
+            return await pending;
+          },
+        },
+      });
+      expect(results).toMatchObject({
+        packages: [{ action: "error", reason: expect.stringContaining("removal superseded") }],
+      });
+      const expectedDir = phase === "successor lease" ? retainedDir : current.skillDir;
+      await expect(readFile(join(expectedDir, "SKILL.md"), "utf8")).resolves.toContain(
+        "name: triage",
+      );
+      const lock = JSON.parse(await readFile(current.lockPath, "utf8"));
+      expect(lock.skills.triage).toBeDefined();
+      expect(store.readPackageRefs()[0]?.status).toBe("pending");
+    },
+  );
 
   it("treats equal skill refs in separate agent workspaces as separate artifacts", async () => {
     const ref = packageRef({ kind: "skill", ref: "triage", relationship: "managed" });
@@ -575,7 +782,7 @@ describe("Claw package removal", () => {
           claimPackageRef,
         },
       }),
-    ).resolves.toMatchObject([{ action: "retained" }]);
+    ).resolves.toMatchObject({ packages: [{ action: "retained" }] });
   });
 
   it("releases a reference whose independent ownership was derived from install time", async () => {
@@ -596,6 +803,6 @@ describe("Claw package removal", () => {
         ],
         { deps: store },
       ),
-    ).resolves.toMatchObject([{ action: "retained" }]);
+    ).resolves.toMatchObject({ packages: [{ action: "retained" }] });
   });
 });

--- a/src/claws/package-remove.ts
+++ b/src/claws/package-remove.ts
@@ -1,6 +1,10 @@
 import { coerceErrorMessage } from "@openclaw/normalization-core/error-coercion";
-import { runPluginUninstallCommand } from "../cli/plugins-uninstall-command.js";
 import { normalizeClawHubSha256Integrity } from "../infra/clawhub-integrity.js";
+import {
+  PluginRuntimeApplicationError,
+  type PluginLifecycleRuntimeApply,
+} from "../plugins/lifecycle.js";
+import type { uninstallPluginWithPolicy } from "../plugins/management-uninstall.js";
 import { resolveInstalledClawHubPlugin } from "../plugins/plugin-install-preflight.js";
 import { withPluginLifecycleLease } from "../plugins/plugin-lifecycle-lease.js";
 import {
@@ -14,6 +18,7 @@ import {
   type MaintainedClawPackageLifecycleLease,
 } from "../state/claw-package-lifecycle-lease.js";
 import type { OpenClawStateDatabaseOptions } from "../state/openclaw-state-db.js";
+import type { ClawPackageRemovalPhaseResult } from "./package-remove-contract.js";
 import {
   readClawPackageRefs,
   readClawInstallRecords,
@@ -42,12 +47,10 @@ export type ClawPackageRemovalDecision = {
   skillPlan?: ClawHubSkillUninstallPlan;
 };
 
-export type ClawPackageRemovalResult = {
-  kind: PersistedClawPackageRef["kind"];
-  ref: string;
-  version: string;
-  action: "uninstalled" | "retained" | "error";
-  reason?: string;
+export type ClawPackageRemovalResult = ClawPackageRemovalPhaseResult["packages"][number];
+
+type ClawPackageRemovalOutcome = ClawPackageRemovalPhaseResult & {
+  runtimeFailure?: PluginRuntimeApplicationError;
 };
 
 export type PackageRemovalDeps = {
@@ -57,7 +60,7 @@ export type PackageRemovalDeps = {
   resolvePlugin?: typeof resolveInstalledClawHubPlugin;
   planSkill?: typeof planClawHubSkillUninstall;
   uninstallSkill?: typeof applyClawHubSkillUninstall;
-  uninstallPlugin?: typeof runPluginUninstallCommand;
+  uninstallPlugin?: typeof uninstallPluginWithPolicy;
   acquirePackageLease?: typeof acquireClawPackageLifecycleLease;
 };
 
@@ -150,7 +153,7 @@ function pluginIntegrityMatches(actual: string | undefined, expected: string): b
 }
 
 export async function inspectClawPackage(
-  install: PersistedClawInstall,
+  install: Pick<PersistedClawInstall, "workspace">,
   packageRef: PersistedClawPackageRef,
   deps: PackageRemovalDeps = {},
 ): Promise<ClawPackageInspection> {
@@ -212,7 +215,7 @@ export async function inspectClawPackage(
 }
 
 export async function planClawPackageRemovals(
-  install: PersistedClawInstall,
+  install: Pick<PersistedClawInstall, "workspace">,
   packages: PersistedClawPackageRef[],
   options: OpenClawStateDatabaseOptions & {
     deps?: PackageRemovalDeps;
@@ -377,6 +380,7 @@ export async function planClawPackageRemovals(
 }
 
 type ApplyClawPackageRemovalOptions = OpenClawStateDatabaseOptions & {
+  applyRuntime?: PluginLifecycleRuntimeApply;
   deps?: PackageRemovalDeps;
   assertCurrent?: () => void;
 };
@@ -384,7 +388,7 @@ type ApplyClawPackageRemovalOptions = OpenClawStateDatabaseOptions & {
 export async function applyClawPackageRemovals(
   decisions: ClawPackageRemovalDecision[],
   options: ApplyClawPackageRemovalOptions = {},
-): Promise<ClawPackageRemovalResult[]> {
+): Promise<ClawPackageRemovalOutcome> {
   if (!decisions.some((decision) => decision.packageRef.kind === "plugin")) {
     return await applyClawPackageRemovalsUnlocked(decisions, options);
   }
@@ -401,7 +405,7 @@ export async function applyClawPackageRemovals(
 async function applyClawPackageRemovalsUnlocked(
   decisions: ClawPackageRemovalDecision[],
   options: ApplyClawPackageRemovalOptions,
-): Promise<ClawPackageRemovalResult[]> {
+): Promise<ClawPackageRemovalOutcome> {
   const deps = options.deps ?? {};
   const claimPackageRef = (
     ref: PersistedClawPackageRef,
@@ -411,17 +415,31 @@ async function applyClawPackageRemovalsUnlocked(
     return (deps.claimPackageRef ?? updateClawPackageRefStatus)(ref, status, options);
   };
   const results: ClawPackageRemovalResult[] = [];
+  const warnings = new Set<string>();
+  let runtimeFailure: PluginRuntimeApplicationError | undefined;
   for (const decision of decisions) {
     const base = {
       kind: decision.packageRef.kind,
       ref: decision.packageRef.ref,
       version: decision.packageRef.version,
     };
+    if (runtimeFailure) {
+      results.push({
+        ...base,
+        action: "retained",
+        reason: "Package cleanup stopped after a Gateway runtime replacement failed.",
+      });
+      continue;
+    }
     let packageLease: MaintainedClawPackageLifecycleLease | null = null;
     let claimed = false;
     let externalMutationStarted = false;
-    try {
+    const assertCurrent = () => {
       options.assertCurrent?.();
+      packageLease?.assertCurrent();
+    };
+    try {
+      assertCurrent();
       const leaseArtifact =
         decision.packageRef.kind === "skill"
           ? {
@@ -558,34 +576,59 @@ async function applyClawPackageRemovalsUnlocked(
             `Plugin ${decision.packageRef.ref}@${decision.packageRef.version} changed after removal planning.`,
           );
         }
-        options.assertCurrent?.();
+        assertCurrent();
+        const uninstallPlugin =
+          deps.uninstallPlugin ??
+          (await import("../plugins/management-uninstall.js")).uninstallPluginWithPolicy;
+        assertCurrent();
         externalMutationStarted = true;
-        await (deps.uninstallPlugin ?? runPluginUninstallCommand)(decision.pluginId, {
-          force: true,
+        const removed = await uninstallPlugin({
+          pluginId: decision.pluginId,
+          caller: "cli",
           invalidateRuntimeCache: false,
           clawManaged: true,
-          ...(options.assertCurrent ? { beforePersistentApply: options.assertCurrent } : {}),
+          applyRuntime: options.applyRuntime,
+          beforePersistentApply: assertCurrent,
+          onWarning: (warning) => {
+            warnings.add(warning);
+          },
         });
+        if (!removed.ok) {
+          throw new Error(removed.error);
+        }
+        for (const warning of removed.value.warnings) {
+          warnings.add(warning);
+        }
       } else {
         if (!decision.skillPlan) {
           throw new Error("Skill removal plan is missing canonical uninstall state.");
         }
-        options.assertCurrent?.();
+        assertCurrent();
         externalMutationStarted = true;
+        const cleanupOwner = packageLease;
         const removed = await (deps.uninstallSkill ?? applyClawHubSkillUninstall)(
           decision.skillPlan,
-          { beforePersistentApply: options.assertCurrent },
+          {
+            beforePersistentApply: assertCurrent,
+            beforeRollback: () => cleanupOwner.assertCurrent(),
+          },
         );
         if (!removed.ok) {
           throw new Error(removed.error);
         }
       }
-      packageLease.assertCurrent();
+      assertCurrent();
       claimPackageRef(decision.packageRef, "complete");
       results.push({ ...base, action: "uninstalled" });
     } catch (error) {
+      // Runtime replacement failure ends this phase, but earlier effects and
+      // emitted warnings must survive alongside its exact publication facts.
+      if (error instanceof PluginRuntimeApplicationError) {
+        runtimeFailure = error;
+      }
       if (claimed) {
         try {
+          assertCurrent();
           claimPackageRef(decision.packageRef, externalMutationStarted ? "failed" : "complete");
         } catch {
           // Preserve the original cleanup failure as the actionable result.
@@ -604,5 +647,9 @@ async function applyClawPackageRemovalsUnlocked(
       }
     }
   }
-  return results;
+  return {
+    packages: results,
+    ...(warnings.size ? { warnings: [...warnings] } : {}),
+    ...(runtimeFailure ? { runtimeFailure } : {}),
+  };
 }

--- a/src/cli/claws-cli.package-removal.ts
+++ b/src/cli/claws-cli.package-removal.ts
@@ -1,0 +1,22 @@
+import { resolveClawMonitorCleanupBinding } from "../claws/monitor-cleanup-binding.js";
+import {
+  clawPackageRemovalResultSchema,
+  type ClawPackageRemovalGateway,
+} from "../claws/package-remove-contract.js";
+import { getRuntimeConfig } from "../config/config.js";
+import { resolveCronJobsStorePathFromConfig } from "../cron/store.js";
+import { callGatewayFromCli } from "./gateway-rpc.js";
+
+export const clawPackageRemovalGateway: ClawPackageRemovalGateway = async (request) =>
+  clawPackageRemovalResultSchema.parse(
+    await callGatewayFromCli(
+      "claws.packages.remove",
+      { timeout: "600000" },
+      {
+        ...request,
+        binding: resolveClawMonitorCleanupBinding(
+          resolveCronJobsStorePathFromConfig(getRuntimeConfig()),
+        ),
+      },
+    ),
+  );

--- a/src/cli/claws-cli.runtime.ts
+++ b/src/cli/claws-cli.runtime.ts
@@ -72,6 +72,7 @@ import type {
   ClawsStatusOptions,
 } from "./claws-cli.js";
 import { clawMonitorCleanupGateway } from "./claws-cli.monitor-cleanup.js";
+import { clawPackageRemovalGateway } from "./claws-cli.package-removal.js";
 import { listCronJobsFromGateway } from "./cron-cli/list-jobs.js";
 import { callGatewayFromCli } from "./gateway-rpc.js";
 
@@ -594,6 +595,7 @@ export async function runClawsRemoveCommand(
   try {
     const result = await applyClawRemovePlan(plan, {
       monitorGateway: clawMonitorCleanupGateway,
+      packageGateway: clawPackageRemovalGateway,
       consentPlanIntegrity: opts.planIntegrity,
       referencedCleanup,
       cronGateway: {
@@ -605,7 +607,7 @@ export async function runClawsRemoveCommand(
       writeRuntimeJson(runtime, result);
     } else {
       logClawExperimentalWarning(runtime);
-      runtime.log(`Removed agent: ${result.agentId}`);
+      runtime.log(`${result.agentRemoved ? "Removed agent" : "Agent"}: ${result.agentId}`);
       runtime.log(`Status: ${result.status}`);
       for (const pkg of result.packages) {
         runtime.log(
@@ -613,6 +615,17 @@ export async function runClawsRemoveCommand(
         );
       }
       runtime.log(`Package references released: ${result.packageRefsReleased}`);
+      if (result.error) {
+        runtime.error(result.error.message);
+      }
+      for (const warning of result.warnings ?? []) {
+        runtime.log(`Warning: ${warning}`);
+      }
+      if (result.pluginRuntime) {
+        runtime.log(
+          `Plugin runtime changed in Gateway generation ${result.pluginRuntime.generation}.`,
+        );
+      }
     }
     if (result.status !== "complete") {
       runtime.exit(1);

--- a/src/cli/claws-cli.test-helpers.ts
+++ b/src/cli/claws-cli.test-helpers.ts
@@ -1,5 +1,6 @@
 import { mkdir, realpath, writeFile } from "node:fs/promises";
 import { basename, dirname, join } from "node:path";
+import type { ClawRemovePlan, ClawRemoveResult } from "../claws/lifecycle-remove-contract.js";
 
 export const minimalManifest = {
   schemaVersion: 1,
@@ -68,4 +69,41 @@ export async function writePackageFixture(tempDirs: {
     "utf8",
   );
   return { root, workspace: join(root, "target-workspace") };
+}
+
+export function createClawRemoveFixtures(): { plan: ClawRemovePlan; result: ClawRemoveResult } {
+  return {
+    plan: {
+      schemaVersion: "openclaw.clawRemovePlan.v1",
+      stability: "experimental",
+      dryRun: true,
+      mutationAllowed: false,
+      planIntegrity: "sha256:remove-plan",
+      target: "demo-agent",
+      agentId: "demo-agent",
+      actions: [
+        {
+          kind: "agent",
+          id: "demo-agent",
+          action: "remove",
+          target: 'agents.entries["demo-agent"]',
+          blocked: false,
+        },
+      ],
+      blockers: [],
+    },
+    result: {
+      schemaVersion: "openclaw.clawRemoveResult.v1",
+      stability: "experimental",
+      dryRun: false,
+      status: "complete",
+      agentId: "demo-agent",
+      agentRemoved: true,
+      workspaceFiles: [],
+      packages: [],
+      mcpServers: [],
+      cronJobs: [],
+      packageRefsReleased: 1,
+    },
+  };
 }

--- a/src/cli/claws-cli.test.ts
+++ b/src/cli/claws-cli.test.ts
@@ -197,37 +197,10 @@ describe("claws cli", () => {
       summary: { claws: 0, partial: 0, missingAgents: 0, driftedFiles: 0, packageRefs: 0 },
     });
     mocks.buildClawRemovePlan.mockReset();
-    mocks.buildClawRemovePlan.mockResolvedValue({
-      schemaVersion: "openclaw.clawRemovePlan.v1",
-      dryRun: true,
-      mutationAllowed: false,
-      planIntegrity: "sha256:remove-plan",
-      target: "demo-agent",
-      agentId: "demo-agent",
-      actions: [
-        {
-          kind: "agent",
-          id: "demo-agent",
-          action: "remove",
-          target: 'agents.entries["demo-agent"]',
-          blocked: false,
-        },
-      ],
-      blockers: [],
-    });
+    const removal = cliTestHelpers.createClawRemoveFixtures();
+    mocks.buildClawRemovePlan.mockResolvedValue(removal.plan);
     mocks.applyClawRemovePlan.mockReset();
-    mocks.applyClawRemovePlan.mockResolvedValue({
-      schemaVersion: "openclaw.clawRemoveResult.v1",
-      dryRun: false,
-      status: "complete",
-      agentId: "demo-agent",
-      agentRemoved: true,
-      workspaceFiles: [],
-      packages: [],
-      mcpServers: [],
-      cronJobs: [],
-      packageRefsReleased: 1,
-    });
+    mocks.applyClawRemovePlan.mockResolvedValue(removal.result);
     mocks.buildClawUpdatePlan.mockReset();
     mocks.buildClawUpdatePlan.mockResolvedValue({
       schemaVersion: "openclaw.clawUpdatePlan.v1",
@@ -1001,7 +974,23 @@ describe("claws cli", () => {
     expect(mocks.runtime.exit).toHaveBeenCalledWith(1);
   });
 
-  it("applies remove only after explicit consent", async () => {
+  it.each(
+    [true, false].flatMap((json) => ["complete", "partial"].map((status) => ({ json, status }))),
+  )("reports consented removal outcomes (json=$json, status=$status)", async ({ json, status }) => {
+    const warnings = ["Plugin cleanup is still finishing."];
+    const pluginRuntime = { operationId: "runtime-final", generation: 3, pluginIds: ["audit"] };
+    const error = {
+      code: "package_cleanup_failed",
+      message: "Plugin activation failed. Gateway generation 3: replacement applied.",
+    };
+    mocks.applyClawRemovePlan.mockResolvedValue({
+      ...cliTestHelpers.createClawRemoveFixtures().result,
+      pluginRuntime,
+      warnings,
+      status,
+      agentRemoved: status === "complete",
+      ...(status === "partial" ? { error } : {}),
+    });
     await runCli([
       "claws",
       "remove",
@@ -1009,7 +998,7 @@ describe("claws cli", () => {
       "--yes",
       "--plan-integrity",
       "sha256:remove-plan",
-      "--json",
+      ...(json ? ["--json"] : []),
     ]);
 
     expect(mocks.applyClawRemovePlan).toHaveBeenCalledWith(
@@ -1019,11 +1008,26 @@ describe("claws cli", () => {
         referencedCleanup: { mode: "retain" },
       }),
     );
-    expect(JSON.parse(mocks.logs[0] ?? "{}")).toMatchObject({
-      schemaVersion: "openclaw.clawRemoveResult.v1",
-      status: "complete",
-      agentId: "demo-agent",
-    });
+    if (json) {
+      expect(JSON.parse(mocks.logs[0] ?? "{}")).toMatchObject({
+        schemaVersion: "openclaw.clawRemoveResult.v1",
+        status,
+        agentId: "demo-agent",
+        pluginRuntime,
+        warnings,
+        ...(status === "partial" ? { error } : {}),
+      });
+    } else {
+      expect(mocks.logs.filter((line) => line === `Warning: ${warnings[0]}`)).toHaveLength(1);
+      expect(mocks.logs).toContain("Plugin runtime changed in Gateway generation 3.");
+      if (status === "partial") {
+        expect(mocks.errors).toContain(error.message);
+        expect(mocks.logs).not.toContain("Removed agent: demo-agent");
+      }
+    }
+    if (status === "partial") {
+      expect(mocks.runtime.exit).toHaveBeenCalledWith(1);
+    }
   });
 
   it("requires the exact dry-run identity with remove consent", async () => {

--- a/src/gateway/methods/core-descriptors.ts
+++ b/src/gateway/methods/core-descriptors.ts
@@ -672,6 +672,7 @@ const CORE_GATEWAY_METHOD_SPECS = [
   ["sessions.storage.status", "sessions-read", "operator.admin", "2026.9"],
   ["sessions.storage.run", "sessions-read", "operator.admin", "2026.9"],
   ["plugins.reload", "plugins-mutations", "operator.admin", "2026.9", CONTROL_PLANE_WRITE],
+  ["claws.packages.remove", "claws-packages", "operator.admin", "2026.9", CONTROL_PLANE_WRITE],
 ] as const satisfies readonly CoreGatewayMethodSpecRow[];
 
 export type CoreGatewayHandlerFamily = Exclude<(typeof CORE_GATEWAY_METHOD_SPECS)[number][1], null>;

--- a/src/gateway/server-claws-packages.test.ts
+++ b/src/gateway/server-claws-packages.test.ts
@@ -1,0 +1,342 @@
+import { randomUUID } from "node:crypto";
+import { ok } from "@openclaw/normalization-core/result";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { z } from "zod";
+import { createDeferred } from "../../test/helpers/promise.js";
+import { buildClawRemovalFixture } from "../claws/lifecycle-remove.test-support.js";
+import { resolveClawMonitorCleanupBinding } from "../claws/monitor-cleanup-binding.js";
+import {
+  type clawPackageRemovalRequestSchema,
+  clawPackageRemovalResultSchema,
+} from "../claws/package-remove-contract.js";
+import {
+  digestClawPackageRemovalPlan,
+  digestClawRemovalInstall,
+} from "../claws/package-remove-plan.js";
+import { planClawPackageRemovals } from "../claws/package-remove.js";
+import {
+  persistClawInstallRecord,
+  persistClawPackageRef,
+  readClawInstallRecord,
+  readClawPackageRefs,
+  updateClawInstallRecordStatus,
+} from "../claws/provenance.js";
+import {
+  PluginRuntimeApplicationError,
+  type PluginLifecycleRuntimeApply,
+} from "../plugins/lifecycle.js";
+import type { uninstallPluginWithPolicy } from "../plugins/management-uninstall.js";
+import { withPluginLifecycleLease } from "../plugins/plugin-lifecycle-lease.js";
+import {
+  beginAgentDeletionJournal,
+  readAgentDeletionJournal,
+} from "../state/agent-deletion-journal.js";
+import { createOpenClawTestState } from "../test-utils/openclaw-test-state.js";
+import { authorizeOperatorScopesForMethod } from "./method-scopes.js";
+import { clawsPackageHandlers } from "./server-methods/claws-packages.js";
+import type { RespondFn } from "./server-methods/types.js";
+
+type ClawPackageRemovalRequest = z.infer<typeof clawPackageRemovalRequestSchema>;
+
+const mocks = vi.hoisted(() => ({ status: vi.fn(), resolve: vi.fn(), uninstall: vi.fn() }));
+vi.mock("../claws/lifecycle-status.js", () => ({
+  readClawStatus: (...args: unknown[]) => mocks.status(...args),
+}));
+vi.mock("../plugins/plugin-install-preflight.js", async (original) => ({
+  ...(await original<typeof import("../plugins/plugin-install-preflight.js")>()),
+  resolveInstalledClawHubPlugin: (...args: unknown[]) => mocks.resolve(...args),
+}));
+vi.mock("../plugins/management-uninstall.js", () => ({
+  uninstallPluginWithPolicy: (...args: unknown[]) => mocks.uninstall(...args),
+}));
+
+const cleanups: Array<() => Promise<void>> = [];
+afterEach(async () => {
+  for (const cleanup of cleanups.splice(0).toReversed()) {
+    await cleanup();
+  }
+});
+
+async function fixture(uninstallWarnings: string[] = []) {
+  vi.clearAllMocks();
+  const state = await createOpenClawTestState({ prefix: "claw-package-owner-" });
+  cleanups.push(() => state.cleanup());
+  const { plan } = await buildClawRemovalFixture(state.root);
+  const install = persistClawInstallRecord(plan);
+  const pkg = {
+    kind: "plugin" as const,
+    source: "clawhub" as const,
+    ref: "audit",
+    version: "1.0.0",
+    integrity: "sha256:audit",
+  };
+  persistClawPackageRef(plan, pkg);
+  const claim = () =>
+    beginAgentDeletionJournal({
+      operationId: randomUUID(),
+      agentId: "worker",
+      workspaceDir: plan.agent.workspace,
+      agentDir: state.agentDir("worker"),
+      sessionsDir: state.sessionsDir("worker"),
+      deleteFiles: false,
+    });
+  const journal = claim();
+  const application = { operationId: "runtime-removal", generation: 2, pluginIds: ["audit"] };
+  mocks.status.mockImplementation(async () => ({
+    records: [
+      {
+        install: readClawInstallRecord("worker"),
+        packages: readClawPackageRefs({ agentId: "worker" }),
+      },
+    ],
+  }));
+  mocks.resolve.mockResolvedValue({
+    status: "found",
+    pluginId: "audit",
+    installedVersion: "1.0.0",
+    record: {
+      source: "clawhub",
+      integrity: pkg.integrity,
+      installedAt: "1970-01-01T00:00:00.001Z",
+    },
+  });
+  mocks.uninstall.mockImplementation(
+    async (input: Parameters<typeof uninstallPluginWithPolicy>[0]) => {
+      input.beforePersistentApply?.();
+      const change = {
+        config: {},
+        pluginIds: ["audit"],
+        reason: "uninstall" as const,
+        assertInvokerOwned: input.beforePersistentApply,
+      };
+      await input.applyRuntime?.(change);
+      input.beforePersistentApply?.();
+      for (const warning of uninstallWarnings) {
+        input.onWarning?.(warning);
+      }
+      const applied = await input.applyRuntime?.(change);
+      input.beforePersistentApply?.();
+      return ok({
+        pluginId: "audit",
+        requestedPluginId: "audit",
+        pluginIds: ["audit"],
+        removed: ["directory"],
+        warnings: [...uninstallWarnings, ...(applied?.warnings ?? [])],
+        application: applied,
+      });
+    },
+  );
+  const cleanup = { mode: "remove-selected" as const, selected: ["plugin:audit@1.0.0"] };
+  const decisions = await planClawPackageRemovals(
+    install,
+    readClawPackageRefs({ agentId: "worker" }),
+    { referencedCleanup: cleanup },
+  );
+  const storePath = state.statePath("cron", "jobs.json");
+  const input: ClawPackageRemovalRequest = {
+    agentId: "worker",
+    operationId: journal.operationId,
+    binding: resolveClawMonitorCleanupBinding(storePath),
+    expectedInstallDigest: digestClawRemovalInstall(install),
+    expectedPackagePlanDigest: digestClawPackageRemovalPlan(decisions, cleanup),
+    cleanup,
+  };
+  const controller = new AbortController();
+  const applyRuntime = vi.fn<PluginLifecycleRuntimeApply>(async (change) => {
+    change.assertInvokerOwned?.();
+    return application;
+  });
+  const invoke = async (overrides: Partial<ClawPackageRemovalRequest> = {}) => {
+    let response: unknown;
+    let failure: string | undefined;
+    const respond: RespondFn = (success, payload, error) => {
+      if (success) {
+        response = payload;
+      } else {
+        failure = error?.message;
+      }
+    };
+    await clawsPackageHandlers["claws.packages.remove"]({
+      params: { ...input, ...overrides },
+      context: {
+        cronStorePath: storePath,
+        getRuntimeConfig: () => ({}),
+        applyPluginLifecycleChange: applyRuntime,
+      },
+      respond,
+      signal: controller.signal,
+    });
+    if (failure) {
+      throw new Error(failure);
+    }
+    return clawPackageRemovalResultSchema.parse(response);
+  };
+  return {
+    state,
+    plan,
+    pkg,
+    decisions,
+    input,
+    application,
+    invoke,
+    claim,
+    applyRuntime,
+    controller,
+  };
+}
+
+describe("Gateway Claw package cleanup owner", () => {
+  it("requires administrative scope", () => {
+    expect(
+      authorizeOperatorScopesForMethod("claws.packages.remove", ["operator.read"]),
+    ).toMatchObject({ allowed: false });
+    expect(
+      authorizeOperatorScopesForMethod("claws.packages.remove", ["operator.admin"]),
+    ).toMatchObject({ allowed: true });
+  });
+
+  it.each([
+    { runtimeWarnings: [], uninstallWarnings: [] },
+    { runtimeWarnings: ["Runtime cleanup is still finishing."], uninstallWarnings: [] },
+    { runtimeWarnings: [], uninstallWarnings: ["Package dependency pruning failed."] },
+    {
+      runtimeWarnings: ["Runtime cleanup is still finishing."],
+      uninstallWarnings: [
+        "Package dependency pruning failed.",
+        "Runtime cleanup is still finishing.",
+      ],
+    },
+  ])("returns actual removal application and all cleanup warnings %j", async (warnings) => {
+    const f = await fixture(warnings.uninstallWarnings);
+    f.applyRuntime.mockResolvedValue({ ...f.application, warnings: warnings.runtimeWarnings });
+    const result = await f.invoke();
+    const expectedWarnings = [
+      ...new Set([...warnings.uninstallWarnings, ...warnings.runtimeWarnings]),
+    ];
+    expect(result).toEqual({
+      packages: [{ kind: "plugin", ref: "audit", version: "1.0.0", action: "uninstalled" }],
+      application: f.application,
+      ...(expectedWarnings.length ? { warnings: expectedWarnings } : {}),
+    });
+    expect(readClawPackageRefs({ agentId: "worker" })[0]?.status).toBe("complete");
+    expect(mocks.uninstall).toHaveBeenCalledOnce();
+  });
+
+  it.each([true, false])(
+    "reports current runtime facts after replacement failure (committed=%s)",
+    async (committed) => {
+      const policyWarnings = ["Package dependency pruning failed."];
+      const runtimeWarnings = ["Earlier runtime cleanup is still finishing."];
+      const f = await fixture(policyWarnings);
+      const failure = new PluginRuntimeApplicationError(
+        "Plugin operation failed during activate.",
+        {
+          ...f.application,
+          operationId: "runtime-final",
+          generation: committed ? 3 : 2,
+          phase: "activate",
+          committed,
+        },
+      );
+      f.applyRuntime
+        .mockResolvedValueOnce({ ...f.application, warnings: runtimeWarnings })
+        .mockRejectedValueOnce(failure);
+      await expect(f.invoke()).resolves.toEqual({
+        packages: [
+          {
+            kind: "plugin",
+            ref: "audit",
+            version: "1.0.0",
+            action: "error",
+            reason: failure.message,
+          },
+        ],
+        application: committed
+          ? { ...f.application, operationId: "runtime-final", generation: 3 }
+          : f.application,
+        warnings: [...policyWarnings, ...runtimeWarnings],
+      });
+      expect(f.applyRuntime).toHaveBeenCalledTimes(2);
+      expect(readClawPackageRefs({ agentId: "worker" })[0]?.status).toBe("failed");
+    },
+  );
+
+  it.each(["journal", "install", "selection", "unknown selection", "binding"])(
+    "rejects changed %s before mutation",
+    async (change) => {
+      const f = await fixture();
+      if (change === "journal") {
+        f.claim();
+      }
+      if (change === "install") {
+        updateClawInstallRecordStatus("worker", "partial");
+      }
+      const overrides: Partial<ClawPackageRemovalRequest> = {};
+      if (change === "selection") {
+        overrides.cleanup = { ...f.input.cleanup, allowConflicts: true };
+      }
+      if (change === "unknown selection") {
+        overrides.cleanup = {
+          ...f.input.cleanup,
+          selected: ["plugin:audit@1.0.0", "plugin:unowned@1.0.0"],
+        };
+        // A matching comparison digest cannot waive the canonical planner's blocker.
+        overrides.expectedPackagePlanDigest = digestClawPackageRemovalPlan(
+          f.decisions,
+          overrides.cleanup,
+        );
+      }
+      if (change === "binding") {
+        overrides.binding = { ...f.input.binding, statePath: "/different-state" };
+      }
+      await expect(f.invoke(overrides)).rejects.toThrow();
+      expect(mocks.uninstall).not.toHaveBeenCalled();
+      expect(readClawPackageRefs({ agentId: "worker" })[0]?.status).toBe("complete");
+    },
+  );
+
+  it("replans after acquiring the plugin lease when another Claw adds a dependency", async () => {
+    const f = await fixture();
+    const entered = createDeferred();
+    const release = createDeferred();
+    const holder = withPluginLifecycleLease({}, async () => {
+      entered.resolve();
+      await release.promise;
+      persistClawPackageRef({ ...f.plan, agent: { ...f.plan.agent, finalId: "other" } }, f.pkg);
+    });
+    await entered.promise;
+    const pending = f.invoke();
+    release.resolve();
+    await holder;
+    await expect(pending).rejects.toThrow("ownership changed");
+    expect(mocks.uninstall).not.toHaveBeenCalled();
+  });
+
+  it.each(["journal", "request"])(
+    "does not mutate or compensate after %s ownership is lost during drain",
+    async (change) => {
+      const f = await fixture();
+      const entered = createDeferred();
+      const release = createDeferred();
+      f.applyRuntime.mockImplementation(async (input) => {
+        entered.resolve();
+        await release.promise;
+        input.assertInvokerOwned?.();
+        return f.application;
+      });
+      const pending = f.invoke();
+      await entered.promise;
+      if (change === "journal") {
+        f.claim();
+      } else {
+        f.controller.abort(new Error("request ended"));
+      }
+      const journal = readAgentDeletionJournal("worker");
+      const refs = readClawPackageRefs({ agentId: "worker" });
+      release.resolve();
+      await expect(pending).rejects.toThrow();
+      expect(readAgentDeletionJournal("worker")).toEqual(journal);
+      expect(readClawPackageRefs({ agentId: "worker" })).toEqual(refs);
+    },
+  );
+});

--- a/src/gateway/server-methods-list.test.ts
+++ b/src/gateway/server-methods-list.test.ts
@@ -204,6 +204,7 @@ describe("listGatewayMethods", () => {
       "sessions.storage.status",
       "sessions.storage.run",
       "plugins.reload",
+      "claws.packages.remove",
     ];
     expect(listGatewayMethods().slice(-expectedSuffix.length)).toEqual(expectedSuffix);
     const methods = listGatewayMethods();
@@ -235,6 +236,7 @@ describe("listGatewayMethods", () => {
       "sessions.storage.status",
       "sessions.storage.run",
       "plugins.reload",
+      "claws.packages.remove",
     ]);
   });
 
@@ -393,6 +395,7 @@ describe("listGatewayMethods", () => {
       "sessions.storage.status",
       "sessions.storage.run",
       "plugins.reload",
+      "claws.packages.remove",
     ];
     expect(coreMethods.slice(-expectedCoreSuffix.length)).toEqual(expectedCoreSuffix);
     expect(methods.indexOf("approval.get")).toBeGreaterThan(methods.indexOf("tts.speak"));

--- a/src/gateway/server-methods/claws-packages.ts
+++ b/src/gateway/server-methods/claws-packages.ts
@@ -1,0 +1,161 @@
+import { isDeepStrictEqual } from "node:util";
+import { ErrorCodes, errorShape } from "../../../packages/gateway-protocol/src/index.js";
+import { listAgentEntries } from "../../agents/agent-scope.js";
+import { readClawStatus } from "../../claws/lifecycle-status.js";
+import { resolveClawMonitorCleanupBinding } from "../../claws/monitor-cleanup-binding.js";
+import { clawPackageRemovalRequestSchema } from "../../claws/package-remove-contract.js";
+import {
+  digestClawPackageRemovalPlan,
+  digestClawRemovalInstall,
+  orderClawPackageRemovals,
+  projectClawPackageRemovePlan,
+} from "../../claws/package-remove-plan.js";
+import { applyClawPackageRemovals, planClawPackageRemovals } from "../../claws/package-remove.js";
+import { readClawInstallRecord } from "../../claws/provenance.js";
+import {
+  capturePluginRuntimeApplications,
+  projectPluginRuntimeFailure,
+} from "../../plugins/lifecycle.js";
+import { withPluginLifecycleLease } from "../../plugins/plugin-lifecycle-lease.js";
+import { readAgentDeletionJournal } from "../../state/agent-deletion-journal.js";
+import { pluginLifecycleError } from "./plugins-lifecycle-error.js";
+import type {
+  GatewayRequestContext,
+  GatewayRequestHandlerOptions,
+  GatewayRequestHandlers,
+} from "./types.js";
+
+type PackageRemovalRequestOptions = Pick<
+  GatewayRequestHandlerOptions,
+  "params" | "respond" | "signal" | "sessionMutationCommitGuard"
+> & {
+  context: Pick<
+    GatewayRequestContext,
+    "cronStorePath" | "applyPluginLifecycleChange" | "getRuntimeConfig"
+  >;
+};
+
+export const clawsPackageHandlers = {
+  "claws.packages.remove": async ({
+    params,
+    respond,
+    context,
+    signal,
+    sessionMutationCommitGuard,
+  }: PackageRemovalRequestOptions) => {
+    const parsed = clawPackageRemovalRequestSchema.safeParse(params);
+    if (!parsed.success) {
+      respond(
+        false,
+        undefined,
+        errorShape(ErrorCodes.INVALID_REQUEST, "Invalid Claw package cleanup parameters."),
+      );
+      return;
+    }
+    const input = parsed.data;
+    let captured: ReturnType<typeof capturePluginRuntimeApplications> | undefined;
+    try {
+      const applyRuntime = context.applyPluginLifecycleChange;
+      if (!applyRuntime) {
+        throw new Error("Claw plugin cleanup requires a running plugin lifecycle owner.");
+      }
+      const assertCurrent = () => {
+        signal?.throwIfAborted();
+        sessionMutationCommitGuard?.();
+        const journal = readAgentDeletionJournal(input.agentId);
+        if (
+          !isDeepStrictEqual(
+            input.binding,
+            resolveClawMonitorCleanupBinding(context.cronStorePath),
+          ) ||
+          journal?.operationId !== input.operationId ||
+          journal.cleanupCompleted ||
+          listAgentEntries(context.getRuntimeConfig()).some(
+            (agent) => agent.id === input.agentId,
+          ) ||
+          digestClawRemovalInstall(readClawInstallRecord(input.agentId)) !==
+            input.expectedInstallDigest
+        ) {
+          throw new Error("Claw package cleanup no longer owns the current removal state.");
+        }
+      };
+      assertCurrent();
+      captured = capturePluginRuntimeApplications((change) => {
+        assertCurrent();
+        return applyRuntime({
+          ...change,
+          assertInvokerOwned: () => {
+            assertCurrent();
+            change.assertInvokerOwned?.();
+          },
+        });
+      });
+      const applyOwnedRuntime = captured.applyRuntime;
+      const { runtimeFailure, ...removed } = await withPluginLifecycleLease(
+        { signal },
+        async (lease) => {
+          const beforePersistentApply = () => {
+            assertCurrent();
+            lease.assertOwned();
+          };
+          beforePersistentApply();
+          const status = await readClawStatus(input.agentId);
+          beforePersistentApply();
+          const record = status.records[0];
+          if (!record || status.records.length !== 1) {
+            throw new Error("Claw package cleanup has no unique current owner.");
+          }
+          const decisions = await planClawPackageRemovals(record.install, record.packages, {
+            referencedCleanup: input.cleanup,
+          });
+          beforePersistentApply();
+          if (
+            digestClawPackageRemovalPlan(decisions, input.cleanup) !==
+            input.expectedPackagePlanDigest
+          ) {
+            throw new Error(
+              "Claw package ownership changed after removal planning; preview removal again.",
+            );
+          }
+          const projection = projectClawPackageRemovePlan({
+            decisions,
+            inspections: record.packages,
+            cleanup: input.cleanup,
+          });
+          if (projection.blockers.length > 0) {
+            throw new Error(projection.blockers.map((blocker) => blocker.message).join("; "));
+          }
+          return await applyClawPackageRemovals(orderClawPackageRemovals(decisions), {
+            applyRuntime: applyOwnedRuntime,
+            assertCurrent: beforePersistentApply,
+          });
+        },
+      );
+      assertCurrent();
+      const { warnings: runtimeWarnings, ...currentApplication } = captured.application ?? {};
+      let application = captured.application ? currentApplication : undefined;
+      if (runtimeFailure) {
+        const runtime = projectPluginRuntimeFailure(runtimeFailure, captured.application).runtime;
+        application = runtime?.committed
+          ? {
+              operationId: runtime.operationId,
+              generation: runtime.generation,
+              pluginIds: runtime.pluginIds,
+            }
+          : undefined;
+      }
+      const warnings = [...new Set([...(removed.warnings ?? []), ...(runtimeWarnings ?? [])])];
+      respond(
+        true,
+        {
+          ...removed,
+          ...(application ? { application } : {}),
+          ...(warnings.length ? { warnings } : {}),
+        },
+        undefined,
+      );
+    } catch (error) {
+      respond(false, undefined, pluginLifecycleError(error, captured?.application));
+    }
+  },
+} satisfies GatewayRequestHandlers;

--- a/src/gateway/server-methods/core-handlers.ts
+++ b/src/gateway/server-methods/core-handlers.ts
@@ -16,6 +16,8 @@ const CORE_GATEWAY_HANDLER_MODULES = {
   agents: () => import("./agents.js").then((module) => module.agentsHandlers),
   "claws-monitors": () =>
     import("./claws-monitors.js").then((module) => module.clawsMonitorHandlers),
+  "claws-packages": () =>
+    import("./claws-packages.js").then((module) => module.clawsPackageHandlers),
   "agents-workspace": () =>
     import("./agents-workspace.js").then((module) => module.agentsWorkspaceHandlers),
   artifacts: () => import("./artifacts.js").then((module) => module.artifactsHandlers),

--- a/src/skills/lifecycle/clawhub-store.ts
+++ b/src/skills/lifecycle/clawhub-store.ts
@@ -17,6 +17,7 @@ import {
   tryReadJson,
   writeJson,
 } from "../../infra/json-files.js";
+import { replaceFileAtomicSync } from "../../infra/replace-file.js";
 import { normalizeTrackedSkillSlug, validateRequestedSkillSlug } from "./archive-install.js";
 
 export { normalizeOptionalStringValue };
@@ -424,6 +425,7 @@ export async function untrackClawHubSkill(
   workspaceDir: string,
   slug: string,
   beforePersistentApply?: () => void,
+  beforeRollback = beforePersistentApply,
 ): Promise<() => Promise<void>> {
   const trackedSlug = normalizeTrackedSkillSlug(slug);
   const lock = await readClawHubSkillsLockfile(workspaceDir);
@@ -431,15 +433,29 @@ export async function untrackClawHubSkill(
   if (!previous) {
     return async () => undefined;
   }
+  // Keep the authority check and atomic publication in one synchronous commit section.
+  // The async atomic writer awaits identity checks after its pre-rename callback.
+  const writeLock = (value: ClawHubSkillsLockfile, assertCurrent = beforePersistentApply) => {
+    assertCurrent?.();
+    return replaceFileAtomicSync({
+      filePath: path.join(workspaceDir, DOT_DIR, "lock.json"),
+      content: `${JSON.stringify(value, null, 2)}\n`,
+      mode: 0o600,
+      dirMode: 0o777 & ~process.umask(),
+      copyFallbackOnPermissionError: true,
+      syncTempFile: true,
+      syncParentDir: true,
+      beforeRename: assertCurrent,
+    });
+  };
   delete lock.skills[trackedSlug];
-  beforePersistentApply?.();
-  await writeClawHubSkillsLockfile(workspaceDir, lock);
+  writeLock(lock);
   return async () => {
     const current = await readClawHubSkillsLockfile(workspaceDir);
     if (current.skills[trackedSlug]) {
       throw new Error(`Skill ${JSON.stringify(trackedSlug)} was retracked during rollback.`);
     }
     current.skills[trackedSlug] = previous;
-    await writeClawHubSkillsLockfile(workspaceDir, current);
+    writeLock(current, beforeRollback);
   };
 }

--- a/src/skills/lifecycle/clawhub-uninstall.test.ts
+++ b/src/skills/lifecycle/clawhub-uninstall.test.ts
@@ -8,6 +8,7 @@ import {
   resetGlobalHookRunner,
 } from "../../plugins/hook-runner-global.js";
 import { createMockPluginRegistry } from "../../plugins/hooks.test-fixtures.js";
+import { untrackClawHubSkill } from "./clawhub-store.js";
 import { applyClawHubSkillUninstall, planClawHubSkillUninstall } from "./clawhub-uninstall.js";
 import { digestClawHubSkillTree } from "./skill-tree-digest.js";
 
@@ -83,6 +84,27 @@ async function replaceTrackedOwner(
 }
 
 describe("ClawHub skill uninstall lifecycle", () => {
+  it.each(["untrack", "rollback"])("fences %s after its awaited lock read", async (phase) => {
+    const current = await fixture();
+    let owned = true;
+    const guard = () => {
+      if (!owned) {
+        throw new Error("removal superseded");
+      }
+    };
+    const restore =
+      phase === "rollback"
+        ? await untrackClawHubSkill(current.workspaceDir, current.slug, guard)
+        : undefined;
+    const before = await readFile(current.lockPath, "utf8");
+    const pending = restore
+      ? restore()
+      : untrackClawHubSkill(current.workspaceDir, current.slug, guard);
+    owned = false;
+    await expect(pending).rejects.toThrow("removal superseded");
+    await expect(readFile(current.lockPath, "utf8")).resolves.toBe(before);
+  });
+
   it("plans and removes an unchanged tracked skill", async () => {
     const current = await fixture();
     const handler = vi.fn();
@@ -248,6 +270,47 @@ describe("ClawHub skill uninstall lifecycle", () => {
     );
     await expect(readFile(current.lockPath, "utf8")).resolves.toBe(beforeLock);
   });
+
+  it.each(["staging", "destination"])(
+    "does not restore over a changed %s owner",
+    async (changed) => {
+      const current = await fixture();
+      const planned = await planClawHubSkillUninstall({
+        workspaceDir: current.workspaceDir,
+        slug: current.slug,
+        expectedVersion: "1.0.0",
+      });
+      if (!planned.ok) {
+        throw new Error(planned.error);
+      }
+      let active = true;
+      let replacement = "";
+      const result = await applyClawHubSkillUninstall(planned.plan, {
+        beforePersistentApply: () => {
+          if (!active) {
+            throw new Error("Parent deletion ended.");
+          }
+        },
+        rename: async (from, to) => {
+          await rename(from, to);
+          active = false;
+          replacement = changed === "staging" ? String(to) : current.skillDir;
+          if (changed === "staging") {
+            await rename(to, `${String(to)}.original`);
+          }
+          await mkdir(replacement);
+          await writeFile(join(replacement, "SKILL.md"), "successor skill");
+        },
+      });
+      expect(result).toMatchObject({
+        ok: false,
+        error: expect.stringContaining("staging or destination changed"),
+      });
+      await expect(readFile(join(replacement, "SKILL.md"), "utf8")).resolves.toBe(
+        "successor skill",
+      );
+    },
+  );
 
   it("restores the staged skill when lockfile untracking fails", async () => {
     const current = await fixture();

--- a/src/skills/lifecycle/clawhub-uninstall.ts
+++ b/src/skills/lifecycle/clawhub-uninstall.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import { lstatSync } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { sha256Hex } from "../../infra/crypto-digest.js";
@@ -191,6 +192,8 @@ export async function applyClawHubSkillUninstall(
     rename?: typeof fs.rename;
     untrack?: typeof untrackClawHubSkill;
     beforePersistentApply?: () => void;
+    /** Compensation keeps the exact package lease, independently of canceled parent execution. */
+    beforeRollback?: () => void;
   } = {},
 ): Promise<{ ok: true } | { ok: false; error: string }> {
   const current = await planClawHubSkillUninstall({
@@ -212,8 +215,31 @@ export async function applyClawHubSkillUninstall(
     : undefined;
   const stagedDir = `${plan.targetDir}.openclaw-skill-remove-${randomUUID()}`;
   let staged = false;
+  let removed = false;
   let restoreTracking: (() => Promise<void>) | undefined;
   const rename = deps.rename ?? fs.rename;
+  const sourceIdentity = await fs.lstat(plan.targetDir, { bigint: true });
+  const assertRollbackCurrent = () => {
+    // Only this operation's unchanged staging may return to an unclaimed destination.
+    const stagedIdentity = lstatSync(stagedDir, { bigint: true });
+    if (
+      sourceIdentity.dev === 0n ||
+      sourceIdentity.ino === 0n ||
+      stagedIdentity.dev !== sourceIdentity.dev ||
+      stagedIdentity.ino !== sourceIdentity.ino ||
+      lstatSync(plan.targetDir, { throwIfNoEntry: false }) !== undefined
+    ) {
+      throw new Error(
+        `Skill ${JSON.stringify(plan.slug)} staging or destination changed during rollback.`,
+      );
+    }
+    deps.beforeRollback?.();
+  };
+  const restoreStaged = async () => {
+    assertRollbackCurrent();
+    await rename(stagedDir, plan.targetDir);
+    staged = false;
+  };
   try {
     deps.beforePersistentApply?.();
     await rename(plan.targetDir, stagedDir);
@@ -224,7 +250,7 @@ export async function applyClawHubSkillUninstall(
       deps.readFile ?? fs.readFile,
     );
     if (!stagedPlan.ok) {
-      await rename(stagedDir, plan.targetDir);
+      await restoreStaged();
       return { ok: false, error: `Skill ${JSON.stringify(plan.slug)} changed during removal.` };
     }
     deps.beforePersistentApply?.();
@@ -232,10 +258,13 @@ export async function applyClawHubSkillUninstall(
       plan.workspaceDir,
       plan.slug,
       deps.beforePersistentApply,
+      assertRollbackCurrent,
     );
     deps.beforePersistentApply?.();
     await (deps.removeDir ?? fs.rm)(stagedDir, { recursive: true, force: false });
+    removed = true;
     if (shouldDispatchChange) {
+      deps.beforePersistentApply?.();
       await dispatchCommittedSkillChangeBestEffort({
         action: "removed",
         source: "clawhub",
@@ -246,16 +275,23 @@ export async function applyClawHubSkillUninstall(
     return { ok: true };
   } catch (error) {
     const rollbackErrors: string[] = [];
-    try {
-      await restoreTracking?.();
-    } catch (rollbackError) {
-      rollbackErrors.push(`could not restore lockfile: ${String(rollbackError)}`);
-    }
-    if (staged) {
-      try {
-        await rename(stagedDir, plan.targetDir);
-      } catch (rollbackError) {
-        rollbackErrors.push(`could not restore skill directory: ${String(rollbackError)}`);
+    if (!removed) {
+      if (restoreTracking) {
+        try {
+          assertRollbackCurrent();
+          await restoreTracking();
+        } catch (rollbackError) {
+          rollbackErrors.push(`could not restore lockfile: ${String(rollbackError)}`);
+        }
+      }
+      if (staged) {
+        try {
+          await restoreStaged();
+        } catch (rollbackError) {
+          rollbackErrors.push(
+            `could not restore skill directory from ${stagedDir}: ${String(rollbackError)}`,
+          );
+        }
       }
     }
     return {

--- a/src/state/claw-package-adoption.test.ts
+++ b/src/state/claw-package-adoption.test.ts
@@ -195,7 +195,7 @@ describe("Claw package independent adoption", () => {
 
     const results = await applyClawPackageRemovals(decisions, { env });
 
-    expect(results).toMatchObject([{ action: "retained" }]);
+    expect(results).toMatchObject({ packages: [{ action: "retained" }] });
     const directLease = acquireClawPackageLifecycleLease(
       { kind: "plugin", source: "clawhub", ref: "@acme/audit" },
       { env, required: true },


### PR DESCRIPTION
Builds on landed #145484. Related: #135599

<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled.

</details>

## What Problem This Solves

Fixes Claw removal with explicitly selected plugin cleanup deleting managed package files without first draining the serving Gateway's plugin work. Cleanup must keep unrelated plugins and the Gateway running, and preserve recoverable state when it cannot finish.

## Why This Change Was Made

The CLI hands the package phase to the serving Gateway before taking package mutation leases. The Gateway revalidates the current deletion journal, install record, cleanup selection and config/state/scheduler binding, then uses the canonical leased uninstall owner. Skill compensation restores only its own staging and tracking while its package lease remains current.

The package owner returns one outcome containing package effects and warnings, retaining typed runtime failure facts for the existing runtime projector. This prevents a later committed failure from being reported with an earlier generation and preserves canonical uninstall warnings, including those emitted before failure. The shared cleanup normalizer gives omitted options the same identity after JSON transport; it leaves the general stable serializer unchanged. Partial CLI results now display their recorded error and do not claim an agent was removed when it was not.

## User Impact

Explicitly selected plugin removal withdraws new calls, drains admitted work, and then removes owned files and records without restarting the Gateway. Default global-plugin retention and explicit conflict consent remain supported. A failed handoff reports partial removal and preserves the deletion fence and recovery record; earlier completed effects are not rolled back, and the CLI does not fall back to a second local uninstall. A runtime replacement failure stops the remaining package phase and reports unattempted packages as retained; ordinary package errors continue best-effort cleanup. Earlier outcomes, warnings, and the actual committed runtime generation stay visible in partial results.

## Evidence

On the initial real G parent `3cf609616b604e0fbe304114f01370c386a24486`, 150 tests across eight full owner/entrypoint files passed; the nine-case JSON wire table was rerun after a test-only clarification. The skill rollback regressions failed on the original G owners, the JSON-roundtrip handoff cases failed before cleanup normalization, and the partial human-output case failed before the renderer correction. Existing tests cover stale journals/bindings/plans, request loss during drain, conflicting owners, real CLI parsing, and owned staging recovery. Two planner fixtures now exercise their intended drift checks, and typed removal fixtures share the existing test helper without raising line limits.

[Linux Testbox run 34641392785](https://github.com/openclaw/openclaw/actions/runs/34641392785) passed a normal build and the original W14/C3/U2 scenarios on assembled product tree `18b3d63c20bd444aab64980c03ecf1c6132e4517`, based on F commit `518125d1e6d31132d46be7db61bb996f8a4c671a`. Both U variants proved files retained until held work finished, withdrawn admission, actual selected removal, same Gateway/connection/sibling, and exactly one start/stop/dispose/held-completion callback. The warning variant emitted its warning once. Default retention was previewed only. This is qualified combined-source evidence, not a new execution of the eventual U head; the omitted-option and failure-rendering corrections have the local regressions above.

Current candidate delta: production +521/-53 (net +468), tests/support +1018/-113, docs +19/-2. Growth implements serving-Gateway ownership and safe cleanup. No config option, SQLite schema or protocol-version change is introduced.

Targeted lint, formatting and diff checks passed. The initial full P2 review found the two outcome bugs above; their source-qualified REDs and corrections are retained. The fresh full corrected P2 review passed all three passes with no accepted/actionable P0–P2 findings against the exact candidate over published G3cf. The reviewed U commit was mechanically rebased onto Gateway feature commit `b53160a3574c6bb1ce5247e71beb169ab814dd4d`. All 22 unaffected U files are byte-identical; the two method-list files match the native three-way merge, preserving the new session-storage methods. The canonical changed gate passed on rebased U commit `39d890f15115f240859da02fe56e5eb09ea090c6`, including production and test typing, unused-export checks, lint and guards. The 59 focused overlap tests passed: method listing, Claw removal ownership and deletion-journal fencing. The original P2 review remains qualified to its original G3cf capture; this is mechanical source-conformance and new-parent gate evidence, not a restamped review. A new local full build was not run for the mechanical rebase; exact-head CI/build and publication remain pending.

The Gateway foundation landed in [#145484](https://github.com/openclaw/openclaw/pull/145484) as `b5134de70af88e342accaba665590c7cb6b79f0b`. U commit `d551ba216ff11c7c72d899b2ec003f81a55c94a4` is based directly on that landed commit and keeps exactly the same 24-file patch and payload bytes as validated `39d890f15115f240859da02fe56e5eb09ea090c6`. Its whole-tree changes are precisely the inherited parent changes. None of the U-owned files or its 26 direct critical owners changed. The connected-owner audit verified that incoming allocation refactors preserve live registry and captured-source membership and leave plugin admission, drainage, and disposal unchanged; session cleanup only drops an unused query field. The 59 overlap tests and 552-second changed gate remain qualified to the earlier validated source; they were not rerun for this mechanically identical U payload. Exact-head CI and landing remain required.

Final head `b8d012c716d1ad58e625f459ec9558e3068f56e9` passes all 134 jobs in [CI run 34679494998](https://github.com/openclaw/openclaw/actions/runs/34679494998). The only post-rebase correction regenerates the Android method catalog for `claws.packages.remove`; canonical protocol generation failed before that single generated entry and passes afterward, with a clean independent P2 review. Production implementation is unchanged. Earlier unrelated subagent fixture failures passed this run without weakening their assertions. Historical Linux behavior evidence above remains qualified to its recorded source.
