### PR TITLE
fix(agents): honor CLAUDE_CONFIG_DIR in claude-cli transcript resolution

### DIFF
--- a/src/agents/command/attempt-execution.test.ts
+++ b/src/agents/command/attempt-execution.test.ts
@@ -8,6 +8,7 @@ import { createDeferred } from "../../../test/helpers/promise.js";
 import { upsertSessionEntryCore } from "../../config/sessions/session-accessor.js";
 import { waitForSessionTranscriptIndexReconcile } from "../../config/sessions/session-transcript-reconcile.js";
 import { closeOpenClawAgentDatabaseByPath } from "../../state/openclaw-agent-db.js";
+import { withEnvAsync } from "../../test-utils/env.js";
 import { SessionManager } from "../sessions/session-manager.js";
 import { buildAssistantMessage, buildUsageWithNoCost } from "../stream-message-shared.js";
 
@@ -507,6 +508,41 @@ describe("claudeCliSessionTranscriptHasContent", () => {
         homeDir: tmpDir,
       }),
     ).toBe(true);
+  });
+
+  it("resolves the transcript under $CLAUDE_CONFIG_DIR/projects when configured", async () => {
+    const workspaceDir = await makeWorkspace();
+    const configDir = path.join(tmpDir, "claude-config");
+    await withEnvAsync({ CLAUDE_CONFIG_DIR: configDir, HOME: tmpDir }, async () => {
+      await writeClaudeProjectFile(
+        workspaceDir,
+        "config-dir-session",
+        `${JSON.stringify({
+          type: "assistant",
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "hello from config dir" }],
+          },
+        })}\n`,
+      );
+      expect(
+        await claudeCliSessionTranscriptHasContent({
+          sessionId: "config-dir-session",
+          workspaceDir,
+          homeDir: tmpDir,
+        }),
+      ).toBe(true);
+    });
+    // Outside the env override the transcript must not resolve under the
+    // default <homeDir>/.claude/projects tree, proving it was written to and
+    // read from $CLAUDE_CONFIG_DIR/projects instead.
+    expect(
+      await claudeCliSessionTranscriptHasContent({
+        sessionId: "config-dir-session",
+        workspaceDir,
+        homeDir: tmpDir,
+      }),
+    ).toBe(false);
   });
 
   it("rejects path-like session ids instead of escaping the Claude projects tree", async () => {

--- a/src/agents/command/attempt-execution.test.ts
+++ b/src/agents/command/attempt-execution.test.ts
@@ -535,14 +535,18 @@ describe("claudeCliSessionTranscriptHasContent", () => {
     });
     // Outside the env override the transcript must not resolve under the
     // default <homeDir>/.claude/projects tree, proving it was written to and
-    // read from $CLAUDE_CONFIG_DIR/projects instead.
-    expect(
-      await claudeCliSessionTranscriptHasContent({
-        sessionId: "config-dir-session",
-        workspaceDir,
-        homeDir: tmpDir,
-      }),
-    ).toBe(false);
+    // read from $CLAUDE_CONFIG_DIR/projects instead. Use a direct path check
+    // to avoid the grace-period wait and warning side-effect of the probe.
+    const defaultProjectDir = resolveClaudeCliProjectDirForWorkspace({
+      workspaceDir,
+      homeDir: tmpDir,
+    });
+    const defaultTranscriptPath = path.join(defaultProjectDir, "config-dir-session.jsonl");
+    const exists = await fs
+      .access(defaultTranscriptPath)
+      .then(() => true)
+      .catch(() => false);
+    expect(exists).toBe(false);
   });
 
   it("rejects path-like session ids instead of escaping the Claude projects tree", async () => {

--- a/src/agents/command/claude-cli-project-dir.test.ts
+++ b/src/agents/command/claude-cli-project-dir.test.ts
@@ -2,7 +2,7 @@
 // default ~/.claude/projects convention.
 import path from "node:path";
 import { describe, expect, it } from "vitest";
-import { withEnvAsync } from "../../test-utils/env.js";
+import { withEnv } from "../../test-utils/env.js";
 import { resolveClaudeCliProjectDirForWorkspace } from "./claude-cli-project-dir.js";
 
 const HOME = path.join(path.sep, "home", "demo-user");
@@ -11,33 +11,33 @@ const WORKSPACE_DIR = path.join(HOME, "work", "demo");
 const SANITIZED_KEY = WORKSPACE_DIR.replace(/[^a-zA-Z0-9]/g, "-");
 
 describe("resolveClaudeCliProjectDirForWorkspace", () => {
-  it("resolves under <homeDir>/.claude/projects by default", async () => {
-    await withEnvAsync({ CLAUDE_CONFIG_DIR: undefined, HOME }, () => {
+  it("resolves under <homeDir>/.claude/projects by default", () => {
+    withEnv({ CLAUDE_CONFIG_DIR: undefined, HOME }, () => {
       expect(
         resolveClaudeCliProjectDirForWorkspace({ workspaceDir: WORKSPACE_DIR, homeDir: HOME }),
       ).toBe(path.join(HOME, ".claude", "projects", SANITIZED_KEY));
     });
   });
 
-  it("resolves under $CLAUDE_CONFIG_DIR/projects when configured", async () => {
+  it("resolves under $CLAUDE_CONFIG_DIR/projects when configured", () => {
     const configDir = path.join(HOME, ".ai-profiles", "claude-personal");
-    await withEnvAsync({ CLAUDE_CONFIG_DIR: configDir, HOME }, () => {
+    withEnv({ CLAUDE_CONFIG_DIR: configDir, HOME }, () => {
       expect(
         resolveClaudeCliProjectDirForWorkspace({ workspaceDir: WORKSPACE_DIR, homeDir: HOME }),
       ).toBe(path.join(configDir, "projects", SANITIZED_KEY));
     });
   });
 
-  it("falls back to <homeDir>/.claude/projects for a blank CLAUDE_CONFIG_DIR", async () => {
-    await withEnvAsync({ CLAUDE_CONFIG_DIR: "   ", HOME }, () => {
+  it("falls back to <homeDir>/.claude/projects for a blank CLAUDE_CONFIG_DIR", () => {
+    withEnv({ CLAUDE_CONFIG_DIR: "   ", HOME }, () => {
       expect(
         resolveClaudeCliProjectDirForWorkspace({ workspaceDir: WORKSPACE_DIR, homeDir: HOME }),
       ).toBe(path.join(HOME, ".claude", "projects", SANITIZED_KEY));
     });
   });
 
-  it("resolves a relative CLAUDE_CONFIG_DIR against the process working directory", async () => {
-    await withEnvAsync({ CLAUDE_CONFIG_DIR: "claude-state", HOME }, () => {
+  it("resolves a relative CLAUDE_CONFIG_DIR against the process working directory", () => {
+    withEnv({ CLAUDE_CONFIG_DIR: "claude-state", HOME }, () => {
       expect(
         resolveClaudeCliProjectDirForWorkspace({ workspaceDir: WORKSPACE_DIR, homeDir: HOME }),
       ).toBe(path.join(path.resolve("claude-state"), "projects", SANITIZED_KEY));

--- a/src/agents/command/claude-cli-project-dir.test.ts
+++ b/src/agents/command/claude-cli-project-dir.test.ts
@@ -1,0 +1,46 @@
+// Resolves Claude CLI project directories honoring CLAUDE_CONFIG_DIR and the
+// default ~/.claude/projects convention.
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { withEnvAsync } from "../../test-utils/env.js";
+import { resolveClaudeCliProjectDirForWorkspace } from "./claude-cli-project-dir.js";
+
+const HOME = path.join(path.sep, "home", "demo-user");
+const WORKSPACE_DIR = path.join(HOME, "work", "demo");
+// sanitizeClaudeCliProjectKey replaces every non-alphanumeric char with "-".
+const SANITIZED_KEY = WORKSPACE_DIR.replace(/[^a-zA-Z0-9]/g, "-");
+
+describe("resolveClaudeCliProjectDirForWorkspace", () => {
+  it("resolves under <homeDir>/.claude/projects by default", async () => {
+    await withEnvAsync({ CLAUDE_CONFIG_DIR: undefined, HOME }, () => {
+      expect(
+        resolveClaudeCliProjectDirForWorkspace({ workspaceDir: WORKSPACE_DIR, homeDir: HOME }),
+      ).toBe(path.join(HOME, ".claude", "projects", SANITIZED_KEY));
+    });
+  });
+
+  it("resolves under $CLAUDE_CONFIG_DIR/projects when configured", async () => {
+    const configDir = path.join(HOME, ".ai-profiles", "claude-personal");
+    await withEnvAsync({ CLAUDE_CONFIG_DIR: configDir, HOME }, () => {
+      expect(
+        resolveClaudeCliProjectDirForWorkspace({ workspaceDir: WORKSPACE_DIR, homeDir: HOME }),
+      ).toBe(path.join(configDir, "projects", SANITIZED_KEY));
+    });
+  });
+
+  it("falls back to <homeDir>/.claude/projects for a blank CLAUDE_CONFIG_DIR", async () => {
+    await withEnvAsync({ CLAUDE_CONFIG_DIR: "   ", HOME }, () => {
+      expect(
+        resolveClaudeCliProjectDirForWorkspace({ workspaceDir: WORKSPACE_DIR, homeDir: HOME }),
+      ).toBe(path.join(HOME, ".claude", "projects", SANITIZED_KEY));
+    });
+  });
+
+  it("resolves a relative CLAUDE_CONFIG_DIR against the process working directory", async () => {
+    await withEnvAsync({ CLAUDE_CONFIG_DIR: "claude-state", HOME }, () => {
+      expect(
+        resolveClaudeCliProjectDirForWorkspace({ workspaceDir: WORKSPACE_DIR, homeDir: HOME }),
+      ).toBe(path.join(path.resolve("claude-state"), "projects", SANITIZED_KEY));
+    });
+  });
+});

--- a/src/agents/command/claude-cli-project-dir.ts
+++ b/src/agents/command/claude-cli-project-dir.ts
@@ -6,7 +6,8 @@ import os from "node:os";
 import path from "node:path";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 
-const CLAUDE_PROJECTS_DIRNAME = path.join(".claude", "projects");
+const CLAUDE_HOME_DIRNAME = ".claude";
+const CLAUDE_PROJECTS_DIRNAME = "projects";
 const MAX_SANITIZED_PROJECT_LENGTH = 200;
 
 // Claude CLI stores project state under a sanitized workspace key. Add a stable
@@ -38,6 +39,17 @@ function canonicalizeWorkspaceDir(workspaceDir: string): string {
   }
 }
 
+// Claude Code stores project transcripts under $CLAUDE_CONFIG_DIR/projects
+// when CLAUDE_CONFIG_DIR is set (the upstream "Respect CLAUDE_CONFIG_DIR
+// everywhere" convention) and otherwise under ~/.claude/projects. This matches
+// the session catalog's configuredClaudeConfigDir resolution.
+function resolveClaudeCliProjectsDir(homeDir: string): string {
+  const configuredDir = process.env.CLAUDE_CONFIG_DIR?.trim();
+  return configuredDir
+    ? path.join(path.resolve(configuredDir), CLAUDE_PROJECTS_DIRNAME)
+    : path.join(homeDir, CLAUDE_HOME_DIRNAME, CLAUDE_PROJECTS_DIRNAME);
+}
+
 /** Resolves Claude CLI's per-workspace project directory. */
 export function resolveClaudeCliProjectDirForWorkspace(params: {
   workspaceDir: string;
@@ -46,8 +58,7 @@ export function resolveClaudeCliProjectDirForWorkspace(params: {
   const homeDir = normalizeOptionalString(params.homeDir) || process.env.HOME || os.homedir();
   const canonicalWorkspaceDir = canonicalizeWorkspaceDir(params.workspaceDir);
   return path.join(
-    homeDir,
-    CLAUDE_PROJECTS_DIRNAME,
+    resolveClaudeCliProjectsDir(homeDir),
     sanitizeClaudeCliProjectKey(canonicalWorkspaceDir),
   );
 }

--- a/src/gateway/cli-session-history.claude.ts
+++ b/src/gateway/cli-session-history.claude.ts
@@ -29,7 +29,8 @@ import {
 import { attachOpenClawTranscriptMeta } from "./session-transcript-readers.js";
 
 export const CLAUDE_CLI_PROVIDER = "claude-cli";
-const CLAUDE_PROJECTS_RELATIVE_DIR = path.join(".claude", "projects");
+const CLAUDE_HOME_DIRNAME = ".claude";
+const CLAUDE_PROJECTS_DIRNAME = "projects";
 
 export type ClaudeCliProjectEntry = {
   type?: unknown;
@@ -78,8 +79,15 @@ function resolveHistoryHomeDir(homeDir?: string): string {
   return normalizeOptionalString(homeDir) || process.env.HOME || os.homedir();
 }
 
+// Claude Code stores project transcripts under $CLAUDE_CONFIG_DIR/projects
+// when CLAUDE_CONFIG_DIR is set (the upstream "Respect CLAUDE_CONFIG_DIR
+// everywhere" convention) and otherwise under ~/.claude/projects. This matches
+// the session catalog's configuredClaudeConfigDir resolution.
 function resolveClaudeProjectsDir(homeDir?: string): string {
-  return path.join(resolveHistoryHomeDir(homeDir), CLAUDE_PROJECTS_RELATIVE_DIR);
+  const configuredDir = process.env.CLAUDE_CONFIG_DIR?.trim();
+  return configuredDir
+    ? path.join(path.resolve(configuredDir), CLAUDE_PROJECTS_DIRNAME)
+    : path.join(resolveHistoryHomeDir(homeDir), CLAUDE_HOME_DIRNAME, CLAUDE_PROJECTS_DIRNAME);
 }
 
 function normalizeClaudeCliSessionId(value: string): string | undefined {

--- a/src/gateway/cli-session-history.test.ts
+++ b/src/gateway/cli-session-history.test.ts
@@ -13,7 +13,7 @@ import { hashCliReseedPrompt } from "../agents/cli-runner/reseed-envelope.js";
 import type { AgentMessage } from "../agents/runtime/index.js";
 import { redactTranscriptMessage } from "../agents/transcript-redact.js";
 import type { SessionEntry } from "../config/sessions.js";
-import { withEnvAsync } from "../test-utils/env.js";
+import { withEnv, withEnvAsync } from "../test-utils/env.js";
 import { readClaudeCliSessionMessages } from "./cli-session-history.claude.js";
 import {
   readClaudeCliFallbackSeed,
@@ -3097,7 +3097,7 @@ describe("readClaudeCliFallbackSeed", () => {
     );
 
     // With CLAUDE_CONFIG_DIR set, the seed must be found under configDir.
-    const seed = await withEnvAsync({ CLAUDE_CONFIG_DIR: configDir, HOME: homeDir }, () =>
+    const seed = withEnv({ CLAUDE_CONFIG_DIR: configDir, HOME: homeDir }, () =>
       readClaudeCliFallbackSeed({ cliSessionId: SESSION_ID, homeDir }),
     );
     const fallbackSeed = requireFallbackSeed(seed, "config-dir session");
@@ -3107,9 +3107,8 @@ describe("readClaudeCliFallbackSeed", () => {
 
     // Without CLAUDE_CONFIG_DIR, the same session must NOT resolve under
     // <homeDir>/.claude/projects — proving the file lives only under configDir.
-    const seedWithoutConfig = await withEnvAsync(
-      { CLAUDE_CONFIG_DIR: undefined, HOME: homeDir },
-      () => readClaudeCliFallbackSeed({ cliSessionId: SESSION_ID, homeDir }),
+    const seedWithoutConfig = withEnv({ CLAUDE_CONFIG_DIR: undefined, HOME: homeDir }, () =>
+      readClaudeCliFallbackSeed({ cliSessionId: SESSION_ID, homeDir }),
     );
     expect(seedWithoutConfig).toBeUndefined();
   });

--- a/src/gateway/cli-session-history.test.ts
+++ b/src/gateway/cli-session-history.test.ts
@@ -3073,6 +3073,47 @@ describe("readClaudeCliFallbackSeed", () => {
     expectFields(fallbackSeed.recentTurns[2], { role: "user" });
   });
 
+  it("resolves transcripts under $CLAUDE_CONFIG_DIR/projects when configured", async () => {
+    const configDir = path.join(tmpRoot, "claude-config");
+    const configProjectsDir = path.join(configDir, "projects", "demo-workspace");
+    await fs.mkdir(configProjectsDir, { recursive: true });
+    const file = path.join(configProjectsDir, `${SESSION_ID}.jsonl`);
+    await fs.writeFile(
+      file,
+      `${JSON.stringify({
+        type: "user",
+        uuid: "u-cfg",
+        message: { role: "user", content: "config-dir prompt" },
+      })}\n${JSON.stringify({
+        type: "assistant",
+        uuid: "a-cfg",
+        message: {
+          role: "assistant",
+          model: "claude-sonnet-4-6",
+          content: [{ type: "text", text: "config-dir reply" }],
+        },
+      })}\n`,
+      "utf-8",
+    );
+
+    // With CLAUDE_CONFIG_DIR set, the seed must be found under configDir.
+    const seed = await withEnvAsync({ CLAUDE_CONFIG_DIR: configDir, HOME: homeDir }, () =>
+      readClaudeCliFallbackSeed({ cliSessionId: SESSION_ID, homeDir }),
+    );
+    const fallbackSeed = requireFallbackSeed(seed, "config-dir session");
+    expect(fallbackSeed.recentTurns).toHaveLength(2);
+    expectFields(fallbackSeed.recentTurns[0], { role: "user" });
+    expectFields(fallbackSeed.recentTurns[1], { role: "assistant" });
+
+    // Without CLAUDE_CONFIG_DIR, the same session must NOT resolve under
+    // <homeDir>/.claude/projects — proving the file lives only under configDir.
+    const seedWithoutConfig = await withEnvAsync(
+      { CLAUDE_CONFIG_DIR: undefined, HOME: homeDir },
+      () => readClaudeCliFallbackSeed({ cliSessionId: SESSION_ID, homeDir }),
+    );
+    expect(seedWithoutConfig).toBeUndefined();
+  });
+
   it("preserves reseed envelopes in fallback model context", async () => {
     const reseedPrompt = buildLegacyReseedPrompt();
     await writeJsonl([


### PR DESCRIPTION
<!--
Closes #145309
-->

## What Problem This Solves

Fixes an issue where users running the `claude-cli` backend with `CLAUDE_CONFIG_DIR` set (e.g. a second Claude login on the same host) would lose session continuity on every cold turn and silently fall back to the next model with no history after any config hot-reload. The bundled `claude-cli` transcript resolver looked for project JSONL files under `$HOME/.claude/projects/…` and ignored `CLAUDE_CONFIG_DIR`, so every transcript check missed — even though the session catalog scanner, provider-auth resolver, and Claude Code itself all honor `CLAUDE_CONFIG_DIR` as the projects tree root.

## Why This Change Was Made

Two resolvers were hardcoding `~/.claude/projects` instead of honoring `CLAUDE_CONFIG_DIR`:

1. **`resolveClaudeCliProjectDirForWorkspace`** (`src/agents/command/claude-cli-project-dir.ts`) — used by the transcript probe (`claudeCliSessionTranscriptHasContent`) and the doctor health check. A miss here triggers `reason=missing-transcript` session resets on every cold turn.

2. **`resolveClaudeProjectsDir`** (`src/gateway/cli-session-history.claude.ts`) — used by `resolveClaudeCliSessionFilePath` and `readClaudeCliFallbackSeed`. A miss here means the fallback prelude has no harvested context, so a fallback-model re-run starts with zero conversation history.

Both now follow the same pattern as the existing `resolveClaudeCliConfigDir` in `src/plugin-sdk/provider-auth-claude-compat.ts` and `configuredClaudeConfigDir` in `extensions/anthropic/session-catalog-scan.ts`: when `CLAUDE_CONFIG_DIR` is set and non-blank, resolve project transcripts under `<resolved config dir>/projects`; otherwise fall back to `<homeDir>/.claude/projects` as before.

## User Impact

Users who set `CLAUDE_CONFIG_DIR` (for a second Claude login, a dedicated profile, or a Docker-mounted config directory) will no longer experience:
- Cold-turn session resets (`reason=missing-transcript`) that discard the stored Claude session id.
- Warm-turn silent fallback to a different model with no conversation history after a config hot-reload.
- The cascading failure where the fallback process occupies the same live-session owner key, blocking the primary model from reusing the slot.

The existing workaround (symlinking `$HOME/.claude/projects/<key>` → `$CLAUDE_CONFIG_DIR/projects/<key>`) is no longer needed.

## Evidence

### Production-path behavior proof

Exercises the **production exported functions the Gateway actually runs** — `claudeCliSessionTranscriptHasContent` (the session-continuity probe used on cold turns) and `readClaudeCliFallbackSeed` (the fallback-history recovery reader) — against a real `CLAUDE_CONFIG_DIR` tree containing a Claude Code session JSONL (one user/assistant exchange):

```
[setup] CLAUDE_CONFIG_DIR = /tmp/oc-proof-prod-swqXxG/claude-config
[setup] transcript written to /tmp/oc-proof-prod-swqXxG/claude-config/projects/-tmp-oc-proof-prod-swqXxG-workspace-demo/prod-proof-session.jsonl

[1] production transcript probe (transcript under $CLAUDE_CONFIG_DIR):
    claudeCliSessionTranscriptHasContent() = true
    -> session stays LIVE, no missing-transcript reset: true

[2] production fallback history reader (readClaudeCliFallbackSeed):
    recentTurns = 2
    turn[0].role = user
    turn[1].role = assistant
    -> fallback re-run recovers the conversation from $CLAUDE_CONFIG_DIR/projects

[3] negative control (CLAUDE_CONFIG_DIR unset):
    probe = false (expected, no reset-triggering miss leak)
    seed = undefined (expected)

Result: production probe + production history reader both honor CLAUDE_CONFIG_DIR.
```

What this demonstrates:
- The **production transcript probe** finds the existing Claude session under `$CLAUDE_CONFIG_DIR/projects/…` and returns `true` — the stored session id stays live across a cold turn instead of being reset with `reason=missing-transcript`.
- The **production fallback history reader** recovers the full recent-turn history (user + assistant roles) from `$CLAUDE_CONFIG_DIR/projects/…` — a fallback-model re-run starts with the actual conversation instead of no context.
- The **negative control** (env var unset) shows the same session id resolves to `false`/`undefined` under the default `<homeDir>/.claude/projects` tree — the fix is selective, not a lookup leak.

(The one `v4 miss` warn line in the trace is the negative-control run emitting its expected structured miss for the default-tree path — the same warn Gateway operators would see before this fix on every turn.)

### CI

All 169 jobs green on head `d3d5304a5c` (run 34682440091, `openclaw/ci-gate` SUCCESS). Earlier runs hit two unrelated infra flakes — a `resolve-auth.test.ts` 1000ms timeout and a runner-preempted `checks-fast-bundled-protocol` job (0 steps executed) — both cleared on rerun; no test failure was ever traced to this patch.

### Resolver unit tests (4/4 passed)

```
✓ resolves under <homeDir>/.claude/projects by default
✓ resolves under $CLAUDE_CONFIG_DIR/projects when configured
✓ falls back to <homeDir>/.claude/projects for a blank CLAUDE_CONFIG_DIR
✓ resolves a relative CLAUDE_CONFIG_DIR against the process working directory
```

### Test-suite coverage (189/189 passed locally)

- **Transcript probe test** (`attempt-execution.test.ts`, 21 tests in the probe suite): writes a transcript under `$CLAUDE_CONFIG_DIR/projects/…`, verifies `claudeCliSessionTranscriptHasContent` returns `true` inside the env override and the file is absent from the default tree outside it (direct path check, no probe side-effects).
- **Fallback seed test** (`cli-session-history.test.ts`, 168 tests): writes a session JSONL under `configDir/projects/demo-workspace/`, verifies `readClaudeCliFallbackSeed` finds it with `CLAUDE_CONFIG_DIR` set (2 turns, correct roles) and returns `undefined` without it.

### Patch history

- `6d11eda` — initial fix + tests
- `7c3d4f` — switch 6 synchronous `withEnvAsync` callbacks to `withEnv` (typecheck)
- `9205926` — avoid probe grace-period side-effects in the new test's negative assertion
- `4ee3802` / `5fce660` / `d3d5304` — empty CI-rerun commits for unrelated infra flakes
