### PR TITLE
refactor(mac): share child-process deadline observation

### DIFF
--- a/apps/macos/Sources/OpenClaw/BoundedProcess.swift
+++ b/apps/macos/Sources/OpenClaw/BoundedProcess.swift
@@ -14,11 +14,6 @@ struct BoundedProcessResult: Sendable {
 enum BoundedProcess {
     private static let outputLimit = 64 * 1024
 
-    private enum DeadlineOutcome: Sendable {
-        case exited
-        case timedOut
-    }
-
     static func run(
         path: String,
         arguments: [String],
@@ -51,22 +46,7 @@ enum BoundedProcess {
         { execution in
             let exitSignal = ChildProcessExit(
                 processIdentifier: pid_t(execution.processIdentifier.value))
-            let deadline = await withTaskGroup(of: DeadlineOutcome.self) { group in
-                group.addTask {
-                    await exitSignal.wait()
-                    return .exited
-                }
-                group.addTask {
-                    do {
-                        try await Task.sleep(for: .seconds(timeout))
-                        return .timedOut
-                    } catch {
-                        return .exited
-                    }
-                }
-                defer { group.cancelAll() }
-                return await group.next() ?? .exited
-            }
+            let deadline = await exitSignal.wait(timeout: timeout)
             try Task.checkCancellation()
 
             switch deadline {

--- a/apps/macos/Sources/OpenClaw/ChildProcessExit.swift
+++ b/apps/macos/Sources/OpenClaw/ChildProcessExit.swift
@@ -4,6 +4,11 @@ import Foundation
 
 /// Observes one unreaped child until exit or cancellation; it never signals or reaps it.
 final class ChildProcessExit: @unchecked Sendable {
+    enum Outcome: Sendable, Equatable {
+        case exited
+        case timedOut
+    }
+
     private let lock = NSLock()
     private let processIdentifier: pid_t
     private let source: DispatchSourceProcess?
@@ -34,7 +39,26 @@ final class ChildProcessExit: @unchecked Sendable {
         }
     }
 
-    func wait() async {
+    func wait(timeout: TimeInterval) async -> Outcome {
+        await withTaskGroup(of: Outcome.self) { group in
+            group.addTask {
+                await self.wait()
+                return .exited
+            }
+            group.addTask {
+                do {
+                    try await Task.sleep(for: .seconds(timeout))
+                    return .timedOut
+                } catch {
+                    return .exited
+                }
+            }
+            defer { group.cancelAll() }
+            return await group.next() ?? .exited
+        }
+    }
+
+    private func wait() async {
         await withTaskGroup(of: Void.self) { group in
             group.addTask { await self.waitForSignal() }
             group.addTask { await self.pollUntilExit() }

--- a/apps/macos/Sources/OpenClaw/ShellExecutor.swift
+++ b/apps/macos/Sources/OpenClaw/ShellExecutor.swift
@@ -64,11 +64,6 @@ enum ShellExecutor {
         case timedOut
     }
 
-    private enum DeadlineOutcome: Sendable, Equatable {
-        case exited
-        case timedOut
-    }
-
     private enum StreamingTaskResult: Sendable {
         case drained
         case deadline(timedOut: Bool)
@@ -213,22 +208,7 @@ enum ShellExecutor {
             let exitSignal = ChildProcessExit(
                 processIdentifier: processIdentifier,
                 queue: .global(qos: .userInitiated))
-            let deadline = await withTaskGroup(of: DeadlineOutcome.self) { group in
-                group.addTask {
-                    await exitSignal.wait()
-                    return .exited
-                }
-                group.addTask {
-                    do {
-                        try await Task.sleep(for: .seconds(timeout))
-                        return .timedOut
-                    } catch {
-                        return .exited
-                    }
-                }
-                defer { group.cancelAll() }
-                return await group.next() ?? .exited
-            }
+            let deadline = await exitSignal.wait(timeout: timeout)
 
             guard deadline == .timedOut, !exitSignal.hasExited() else { return false }
             try? execution.send(signal: .terminate, toProcessGroup: true)


### PR DESCRIPTION
## What Problem This Solves

Native commands need consistent completion and timeout observation while retaining reliable cancellation and descendant cleanup. This maintainer-requested refactor reduces the risk of future deadline fixes diverging between bounded processes and shell execution.

## Why This Change Was Made

Move the common exit-versus-timeout race and its outcome type into the existing `ChildProcessExit` owner. Both launchers retain their final liveness checks, cancellation handling, process-group signaling, reaping boundaries, and output policies; the internal no-timeout waiter becomes private.

## User Impact

No intended user-visible change. Timeouts, exit statuses, cancellation, inherited-handle cleanup, and streaming output preserve their existing behavior. Managed processes continue using the unchanged non-reaping exit probe.

## Evidence

- App and all native test targets compiled with `swift build --package-path apps/macos --build-system native`, using `--product OpenClaw` and then `--build-tests`. The repository Mermaid resource generator was run for the fresh checkout before compilation.
- Eight `BoundedProcessTests` and six `ShellExecutorTimeoutTests` passed in an OS sandbox, including both streaming modes in the parameterized instant-exit case. The sandbox denied operator files, preferences/Keychain services, network access, desktop helpers, and outside-process signals. The full native suite and app were not launched.
- The retained suites cover concurrent exits, output ordering and limits, cancellation, timeouts, inherited handles, and TERM-ignoring descendants. No tests or assertions changed.
- `node scripts/check-changed.mjs`, `scripts/format-swift.sh macos`, `pnpm native:i18n:verify`, and `git diff --check` passed. P2 review found no actionable findings.
