### PR TITLE
refactor(tasks): isolate SQLite connection kernels

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -3558,7 +3558,6 @@ src/tasks/task-registry-query.ts	4
 src/tasks/task-registry-state.ts	3
 src/tasks/task-registry.process-state.ts	1
 src/tasks/task-registry.sqlite.shared.ts	1
-src/tasks/task-registry.store.sqlite.ts	1
 src/tasks/task-registry.ts	1
 src/tasks/task-registry.types.ts	2
 src/tasks/task-status.ts	1

--- a/docs/reference/database-schemas/storage-changes.md
+++ b/docs/reference/database-schemas/storage-changes.md
@@ -31,6 +31,14 @@ on the supplied `node:sqlite` connection. Calling Kysely's asynchronous
 dialect can identify syntax coupling, but does not prove driver behavior,
 isolation, or database compatibility.
 
+Task and flow stores keep row codecs and SQLite operations in connection-bound
+kernels. Their existing facades retain global connection acquisition, cache and
+close behavior, and write transaction admission. Compound subagent and cron
+operations call the kernels on their already-admitted connection. Task status
+classification stays with the pure record types, so decoding does not load
+provider or plugin runtime ownership. These operations and their transaction
+callbacks remain synchronous; this separation does not move SQL to a worker.
+
 Acquire a connection once for an operation and pass that exact connection
 through its transactional helpers. SQLite write callbacks remain synchronous:
 finish asynchronous planning first, then reread authoritative rows after write

--- a/scripts/check-kysely-guardrails.mts
+++ b/scripts/check-kysely-guardrails.mts
@@ -146,7 +146,7 @@ const rawSqliteAllowPathGroups = {
     "src/plugin-state/plugin-state-store.sqlite.ts",
     "src/proxy-capture/store.sqlite.ts",
     "src/tasks/task-flow-registry.store.sqlite.ts",
-    "src/tasks/task-registry.store.sqlite.ts",
+    "src/tasks/task-registry.store.kernel.ts",
   ],
 };
 

--- a/src/agents/embedded-agent-runner/run/attempt-async-tasks.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-async-tasks.ts
@@ -5,8 +5,7 @@ import { createAbortError as createNamedAbortError } from "../../../infra/abort-
 import { isFastTestRuntimeEnv } from "../../../infra/env.js";
 import { toErrorObject } from "../../../infra/errors.js";
 import { isCronRunSessionKey } from "../../../sessions/session-key-utils.js";
-import { isTerminalTaskStatus } from "../../../tasks/task-executor-policy.js";
-import type { TaskRecord } from "../../../tasks/task-registry.types.js";
+import { isTerminalTaskStatus, type TaskRecord } from "../../../tasks/task-registry.types.js";
 import {
   findTaskByRunIdForStatus,
   listTasksForOwnerOrRequesterSessionKeyForStatus,

--- a/src/agents/subagents/completion/subagent-completion-admission.store.ts
+++ b/src/agents/subagents/completion/subagent-completion-admission.store.ts
@@ -24,7 +24,7 @@ import {
   bindTaskRecord,
   readTaskRecord,
   upsertTaskRunRowInDatabase,
-} from "../../../tasks/task-registry.store.sqlite.js";
+} from "../../../tasks/task-registry.store.kernel.js";
 import type { TaskRecord } from "../../../tasks/task-registry.types.js";
 import { ensureDeliveryState } from "../registry/subagent-delivery-state.js";
 import { resolveFinalizedSubagentTaskState } from "../registry/subagent-registry-completion.js";

--- a/src/agents/subagents/registry/subagent-registry-replacement-store.ts
+++ b/src/agents/subagents/registry/subagent-registry-replacement-store.ts
@@ -7,7 +7,7 @@ import {
   bindTaskFlowRecord,
   readTaskFlowRecord,
   upsertTaskFlowRowInDatabase,
-} from "../../../tasks/task-flow-registry.store.sqlite.js";
+} from "../../../tasks/task-flow-registry.store.kernel.js";
 import {
   prepareTaskMirroredFlowSync,
   publishTaskFlowAfterAtomicStore,
@@ -16,7 +16,7 @@ import {
   bindTaskRecord,
   readTaskRecord,
   upsertTaskRunRowInDatabase,
-} from "../../../tasks/task-registry.store.sqlite.js";
+} from "../../../tasks/task-registry.store.kernel.js";
 import { subagentRuns } from "./subagent-registry-memory.js";
 import { publishSubagentRunsAfterAtomicStore } from "./subagent-registry-state.js";
 import {

--- a/src/cron/service/task-runs.ts
+++ b/src/cron/service/task-runs.ts
@@ -15,10 +15,8 @@ import {
   recordTaskRunProgressByRunIdCore,
 } from "../../tasks/task-executor.js";
 import { bindTaskFlowExecution } from "../../tasks/task-flow-registry.store.sqlite.js";
-import {
-  bindTaskRunExecution,
-  listTaskRecordsByRuntimeSourceIdInDatabase,
-} from "../../tasks/task-registry.store.sqlite.js";
+import { listTaskRecordsByRuntimeSourceIdInDatabase } from "../../tasks/task-registry.store.kernel.js";
+import { bindTaskRunExecution } from "../../tasks/task-registry.store.sqlite.js";
 import type { JsonValue, TaskRecord, TaskStatus } from "../../tasks/task-registry.types.js";
 import {
   CRON_AGENT_SELECTION_REQUIRED_MESSAGE,

--- a/src/gateway/server-runtime-subscriptions.ts
+++ b/src/gateway/server-runtime-subscriptions.ts
@@ -31,8 +31,8 @@ import { onSessionLifecycleEvent } from "../sessions/session-lifecycle-events.js
 import { onInternalSessionTranscriptUpdate } from "../sessions/transcript-events.js";
 import { createLazyPromise, createLazyPromiseLoader } from "../shared/lazy-runtime.js";
 import { onUserProfilesChanged } from "../state/user-profile-events.js";
-import { isTerminalTaskStatus } from "../tasks/task-executor-policy.js";
 import type { TaskRegistryObserverEvent } from "../tasks/task-registry.store.js";
+import { isTerminalTaskStatus } from "../tasks/task-registry.types.js";
 import { markChatAbortTerminalPersistenceError } from "./chat-abort-lifecycle-internal.js";
 import {
   type ChatAbortControllerEntry,

--- a/src/tasks/task-executor-policy.test.ts
+++ b/src/tasks/task-executor-policy.test.ts
@@ -5,13 +5,16 @@ import {
   formatTaskBlockedFollowupMessage,
   formatTaskStateChangeMessage,
   formatTaskTerminalMessage,
-  isTerminalTaskStatus,
   shouldAutoDeliverTaskStateChange,
   shouldAutoDeliverTaskTerminalUpdate,
   shouldSuppressDuplicateTerminalDelivery,
   shouldUseParentReviewTaskTerminalMessage,
 } from "./task-executor-policy.js";
-import type { TaskEventRecord, TaskRecord } from "./task-registry.types.js";
+import {
+  isTerminalTaskStatus,
+  type TaskEventRecord,
+  type TaskRecord,
+} from "./task-registry.types.js";
 
 function createTask(partial: Partial<TaskRecord>): TaskRecord {
   return {

--- a/src/tasks/task-executor-policy.ts
+++ b/src/tasks/task-executor-policy.ts
@@ -1,18 +1,11 @@
 // Decides task executor delivery, terminal update, and follow-up message policy.
 import { SUBAGENT_KILL_TASK_ERROR } from "./detached-task-runtime-contract.js";
-import type { TaskEventRecord, TaskRecord, TaskStatus } from "./task-registry.types.js";
+import {
+  isTerminalTaskStatus,
+  type TaskEventRecord,
+  type TaskRecord,
+} from "./task-registry.types.js";
 import { formatTaskStatusTitleText, sanitizeTaskStatusText } from "./task-status.js";
-
-/** Returns whether a task status is terminal for delivery and retention policy. */
-export function isTerminalTaskStatus(status: TaskStatus): boolean {
-  return (
-    status === "succeeded" ||
-    status === "failed" ||
-    status === "timed_out" ||
-    status === "cancelled" ||
-    status === "lost"
-  );
-}
 
 function resolveTaskDisplayTitle(task: TaskRecord): string {
   return formatTaskStatusTitleText(

--- a/src/tasks/task-flow-registry.store.kernel.ts
+++ b/src/tasks/task-flow-registry.store.kernel.ts
@@ -1,0 +1,237 @@
+// Connection-bound task-flow row codecs and SQLite operations.
+import type { DatabaseSync } from "node:sqlite";
+import type { Insertable, Selectable } from "kysely";
+import type { ExecutionOwnerBindingResult } from "../audit/execution-owner-binding.js";
+import {
+  bindExecutionOwnerLifecycleMetadata,
+  deleteExecutionOwnerLifecycleMetadata,
+} from "../audit/execution-owner-lifecycle-binding-store.js";
+import {
+  executeSqliteQuerySync,
+  executeSqliteQueryTakeFirstSync,
+  getNodeSqliteKysely,
+} from "../infra/kysely-sync.js";
+import { normalizeSqliteNumber } from "../infra/sqlite-number.js";
+import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-db.generated.js";
+import type { TaskFlowRegistryStoreSnapshot } from "./task-flow-registry.store.types.js";
+import {
+  parseOptionalTaskFlowSyncMode,
+  parseTaskFlowStatus,
+  type JsonValue,
+  type TaskFlowRecord,
+  type TaskFlowSyncMode,
+} from "./task-flow-registry.types.js";
+import { parseDeliveryContextJson, parseSqliteJsonValue } from "./task-registry.sqlite.shared.js";
+import { parseTaskNotifyPolicy } from "./task-registry.types.js";
+
+type FlowRunsTable = OpenClawStateKyselyDatabase["flow_runs"];
+type FlowRegistryStoreDatabase = Pick<OpenClawStateKyselyDatabase, "flow_runs">;
+
+type FlowRegistryRow = Selectable<FlowRunsTable> & {
+  sync_mode: string | null;
+  status: string;
+  notify_policy: string;
+};
+
+function serializeJson(value: unknown): string | null {
+  return value === undefined ? null : JSON.stringify(value);
+}
+
+function resolveFlowSyncMode(row: {
+  sync_mode: string | null;
+  shape: string | null;
+}): TaskFlowSyncMode {
+  // Older single_task rows did not persist sync_mode; preserve their mirrored semantics.
+  const syncMode = parseOptionalTaskFlowSyncMode(row.sync_mode);
+  if (syncMode) {
+    return syncMode;
+  }
+  return row.shape === "single_task" ? "task_mirrored" : "managed";
+}
+
+function rowToSyncMode(row: FlowRegistryRow): TaskFlowSyncMode {
+  return resolveFlowSyncMode(row);
+}
+
+function isFlowExecutionOwnerActive(row: {
+  sync_mode: string | null;
+  shape: string | null;
+  status: string;
+  cancel_requested_at: number | null;
+  ended_at: number | null;
+}): boolean {
+  const syncMode = resolveFlowSyncMode(row);
+  const status = parseTaskFlowStatus(row.status);
+  if (row.cancel_requested_at !== null || row.ended_at !== null) {
+    return false;
+  }
+  // Mirrored `blocked` is derived from a terminal task; managed `blocked`
+  // remains live while its controller waits for the blocking task.
+  return syncMode === "task_mirrored"
+    ? status === "queued" || status === "running"
+    : status === "queued" || status === "running" || status === "waiting" || status === "blocked";
+}
+
+function rowToFlowRecord(row: FlowRegistryRow): TaskFlowRecord {
+  const endedAt = normalizeSqliteNumber(row.ended_at);
+  const cancelRequestedAt = normalizeSqliteNumber(row.cancel_requested_at);
+  const requesterOrigin = parseDeliveryContextJson(row.requester_origin_json);
+  const stateJson = parseSqliteJsonValue<JsonValue>(row.state_json);
+  const waitJson = parseSqliteJsonValue<JsonValue>(row.wait_json);
+  return {
+    flowId: row.flow_id,
+    syncMode: rowToSyncMode(row),
+    ownerKey: row.owner_key,
+    ...(requesterOrigin ? { requesterOrigin } : {}),
+    ...(row.controller_id ? { controllerId: row.controller_id } : {}),
+    revision: normalizeSqliteNumber(row.revision) ?? 0,
+    status: parseTaskFlowStatus(row.status),
+    notifyPolicy: parseTaskNotifyPolicy(row.notify_policy),
+    goal: row.goal,
+    ...(row.current_step ? { currentStep: row.current_step } : {}),
+    ...(row.blocked_task_id ? { blockedTaskId: row.blocked_task_id } : {}),
+    ...(row.blocked_summary ? { blockedSummary: row.blocked_summary } : {}),
+    ...(stateJson !== undefined ? { stateJson } : {}),
+    ...(waitJson !== undefined ? { waitJson } : {}),
+    ...(cancelRequestedAt != null ? { cancelRequestedAt } : {}),
+    createdAt: normalizeSqliteNumber(row.created_at) ?? 0,
+    updatedAt: normalizeSqliteNumber(row.updated_at) ?? 0,
+    ...(endedAt != null ? { endedAt } : {}),
+  };
+}
+
+type BoundTaskFlowRecord = Insertable<FlowRunsTable>;
+
+export function bindTaskFlowRecord(record: TaskFlowRecord): BoundTaskFlowRecord {
+  return {
+    flow_id: record.flowId,
+    sync_mode: record.syncMode,
+    shape: null,
+    owner_key: record.ownerKey,
+    requester_origin_json: serializeJson(record.requesterOrigin),
+    controller_id: record.controllerId ?? null,
+    revision: record.revision,
+    status: record.status,
+    notify_policy: record.notifyPolicy,
+    goal: record.goal,
+    current_step: record.currentStep ?? null,
+    blocked_task_id: record.blockedTaskId ?? null,
+    blocked_summary: record.blockedSummary ?? null,
+    state_json: serializeJson(record.stateJson),
+    wait_json: serializeJson(record.waitJson),
+    cancel_requested_at: record.cancelRequestedAt ?? null,
+    created_at: record.createdAt,
+    updated_at: record.updatedAt,
+    ended_at: record.endedAt ?? null,
+  };
+}
+
+function getFlowRegistryKysely(db: DatabaseSync) {
+  return getNodeSqliteKysely<FlowRegistryStoreDatabase>(db);
+}
+
+export function readTaskFlowRegistrySnapshot(db: DatabaseSync): TaskFlowRegistryStoreSnapshot {
+  const query = getFlowRegistryKysely(db)
+    .selectFrom("flow_runs")
+    .select([
+      "flow_id",
+      "sync_mode",
+      "shape",
+      "owner_key",
+      "requester_origin_json",
+      "controller_id",
+      "revision",
+      "status",
+      "notify_policy",
+      "goal",
+      "current_step",
+      "blocked_task_id",
+      "blocked_summary",
+      "state_json",
+      "wait_json",
+      "cancel_requested_at",
+      "created_at",
+      "updated_at",
+      "ended_at",
+    ])
+    .orderBy("created_at", "asc")
+    .orderBy("flow_id", "asc");
+  const flows = new Map<string, TaskFlowRecord>();
+  // Finish native reads before decoding so SQLite errors retain precedence.
+  for (const row of executeSqliteQuerySync(db, query).rows) {
+    flows.set(row.flow_id, rowToFlowRecord(row));
+  }
+  return { flows };
+}
+
+export function upsertTaskFlowRowInDatabase(db: DatabaseSync, row: BoundTaskFlowRecord): void {
+  executeSqliteQuerySync(
+    db,
+    getFlowRegistryKysely(db)
+      .insertInto("flow_runs")
+      .values(row)
+      .onConflict((conflict) =>
+        conflict.column("flow_id").doUpdateSet({
+          sync_mode: (eb) => eb.ref("excluded.sync_mode"),
+          owner_key: (eb) => eb.ref("excluded.owner_key"),
+          requester_origin_json: (eb) => eb.ref("excluded.requester_origin_json"),
+          controller_id: (eb) => eb.ref("excluded.controller_id"),
+          revision: (eb) => eb.ref("excluded.revision"),
+          status: (eb) => eb.ref("excluded.status"),
+          notify_policy: (eb) => eb.ref("excluded.notify_policy"),
+          goal: (eb) => eb.ref("excluded.goal"),
+          current_step: (eb) => eb.ref("excluded.current_step"),
+          blocked_task_id: (eb) => eb.ref("excluded.blocked_task_id"),
+          blocked_summary: (eb) => eb.ref("excluded.blocked_summary"),
+          state_json: (eb) => eb.ref("excluded.state_json"),
+          wait_json: (eb) => eb.ref("excluded.wait_json"),
+          cancel_requested_at: (eb) => eb.ref("excluded.cancel_requested_at"),
+          created_at: (eb) => eb.ref("excluded.created_at"),
+          updated_at: (eb) => eb.ref("excluded.updated_at"),
+          ended_at: (eb) => eb.ref("excluded.ended_at"),
+        }),
+      ),
+  );
+}
+
+export function readTaskFlowRecord(db: DatabaseSync, flowId: string): TaskFlowRecord | undefined {
+  const row = executeSqliteQueryTakeFirstSync(
+    db,
+    getFlowRegistryKysely(db).selectFrom("flow_runs").selectAll().where("flow_id", "=", flowId),
+  );
+  return row ? rowToFlowRecord(row) : undefined;
+}
+
+/** Revalidate the native flow lifecycle before recording its exact execution binding. */
+export function bindTaskFlowExecutionInDatabase(
+  db: DatabaseSync,
+  flowId: string,
+  binding: Parameters<typeof bindExecutionOwnerLifecycleMetadata>[0]["binding"],
+): Exclude<ExecutionOwnerBindingResult, "disabled"> {
+  const kysely = getFlowRegistryKysely(db);
+  const current = executeSqliteQueryTakeFirstSync(
+    db,
+    kysely
+      .selectFrom("flow_runs")
+      .select(["flow_id", "sync_mode", "shape", "status", "cancel_requested_at", "ended_at"])
+      .where("flow_id", "=", flowId),
+  );
+  if (!current || !isFlowExecutionOwnerActive(current)) {
+    return "missing";
+  }
+  return bindExecutionOwnerLifecycleMetadata({
+    db,
+    ownerKind: "flow",
+    ownerId: current.flow_id,
+    binding,
+  });
+}
+
+/** The caller keeps the flow deletion and native metadata cleanup in one transaction. */
+export function deleteTaskFlowRowInDatabase(db: DatabaseSync, flowId: string): void {
+  executeSqliteQuerySync(
+    db,
+    getFlowRegistryKysely(db).deleteFrom("flow_runs").where("flow_id", "=", flowId),
+  );
+  deleteExecutionOwnerLifecycleMetadata({ db, ownerKind: "flow", ownerIds: [flowId] });
+}

--- a/src/tasks/task-flow-registry.store.sqlite.ts
+++ b/src/tasks/task-flow-registry.store.sqlite.ts
@@ -1,225 +1,33 @@
-// Persists managed task-flow records through the OpenClaw SQLite state database.
+// Persists task-flow records through the global shared-state database owner.
 import type { DatabaseSync } from "node:sqlite";
-import type { Insertable, Selectable } from "kysely";
 import type { AdmittedRunContext } from "../agents/admitted-run-context.js";
 import {
   executionOwnerBindingFromAdmission,
   type ExecutionOwnerBindingResult,
 } from "../audit/execution-owner-binding.js";
-import {
-  bindExecutionOwnerLifecycleMetadata,
-  deleteExecutionOwnerLifecycleMetadata,
-} from "../audit/execution-owner-lifecycle-binding-store.js";
-import {
-  executeSqliteQuerySync,
-  executeSqliteQueryTakeFirstSync,
-  getNodeSqliteKysely,
-} from "../infra/kysely-sync.js";
-import { normalizeSqliteNumber } from "../infra/sqlite-number.js";
 import { withExistingOpenClawStateDatabaseReadOnly } from "../state/openclaw-state-db-readonly.js";
-import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-db.generated.js";
 import {
   closeOpenClawStateDatabase,
   openOpenClawStateDatabase,
   runOpenClawStateWriteTransaction,
   type OpenClawStateDatabaseOptions,
 } from "../state/openclaw-state-db.js";
-import type { TaskFlowRegistryStoreSnapshot } from "./task-flow-registry.store.types.js";
 import {
-  parseOptionalTaskFlowSyncMode,
-  parseTaskFlowStatus,
-  type JsonValue,
-  type TaskFlowRecord,
-  type TaskFlowSyncMode,
-} from "./task-flow-registry.types.js";
-import { parseDeliveryContextJson, parseSqliteJsonValue } from "./task-registry.sqlite.shared.js";
-import { parseTaskNotifyPolicy } from "./task-registry.types.js";
-
-type FlowRunsTable = OpenClawStateKyselyDatabase["flow_runs"];
-type FlowRegistryStoreDatabase = Pick<OpenClawStateKyselyDatabase, "flow_runs">;
-
-type FlowRegistryRow = Selectable<FlowRunsTable> & {
-  sync_mode: string | null;
-  status: string;
-  notify_policy: string;
-};
+  bindTaskFlowExecutionInDatabase,
+  bindTaskFlowRecord,
+  deleteTaskFlowRowInDatabase,
+  readTaskFlowRegistrySnapshot,
+  upsertTaskFlowRowInDatabase,
+} from "./task-flow-registry.store.kernel.js";
+import type { TaskFlowRegistryStoreSnapshot } from "./task-flow-registry.store.types.js";
+import type { TaskFlowRecord } from "./task-flow-registry.types.js";
 
 type FlowRegistryDatabase = {
   db: DatabaseSync;
   path: string;
 };
 
-// SQLite-backed task-flow store mirrors the in-process registry into openclaw-state.db.
 let cachedDatabase: FlowRegistryDatabase | null = null;
-
-function serializeJson(value: unknown): string | null {
-  return value === undefined ? null : JSON.stringify(value);
-}
-
-function resolveFlowSyncMode(row: {
-  sync_mode: string | null;
-  shape: string | null;
-}): TaskFlowSyncMode {
-  // Older single_task rows did not persist sync_mode; preserve their mirrored semantics.
-  const syncMode = parseOptionalTaskFlowSyncMode(row.sync_mode);
-  if (syncMode) {
-    return syncMode;
-  }
-  return row.shape === "single_task" ? "task_mirrored" : "managed";
-}
-
-function rowToSyncMode(row: FlowRegistryRow): TaskFlowSyncMode {
-  return resolveFlowSyncMode(row);
-}
-
-function isFlowExecutionOwnerActive(row: {
-  sync_mode: string | null;
-  shape: string | null;
-  status: string;
-  cancel_requested_at: number | null;
-  ended_at: number | null;
-}): boolean {
-  const syncMode = resolveFlowSyncMode(row);
-  const status = parseTaskFlowStatus(row.status);
-  if (row.cancel_requested_at !== null || row.ended_at !== null) {
-    return false;
-  }
-  // Mirrored `blocked` is derived from a terminal task; managed `blocked`
-  // remains live while its controller waits for the blocking task.
-  return syncMode === "task_mirrored"
-    ? status === "queued" || status === "running"
-    : status === "queued" || status === "running" || status === "waiting" || status === "blocked";
-}
-
-function rowToFlowRecord(row: FlowRegistryRow): TaskFlowRecord {
-  const endedAt = normalizeSqliteNumber(row.ended_at);
-  const cancelRequestedAt = normalizeSqliteNumber(row.cancel_requested_at);
-  const requesterOrigin = parseDeliveryContextJson(row.requester_origin_json);
-  const stateJson = parseSqliteJsonValue<JsonValue>(row.state_json);
-  const waitJson = parseSqliteJsonValue<JsonValue>(row.wait_json);
-  return {
-    flowId: row.flow_id,
-    syncMode: rowToSyncMode(row),
-    ownerKey: row.owner_key,
-    ...(requesterOrigin ? { requesterOrigin } : {}),
-    ...(row.controller_id ? { controllerId: row.controller_id } : {}),
-    revision: normalizeSqliteNumber(row.revision) ?? 0,
-    status: parseTaskFlowStatus(row.status),
-    notifyPolicy: parseTaskNotifyPolicy(row.notify_policy),
-    goal: row.goal,
-    ...(row.current_step ? { currentStep: row.current_step } : {}),
-    ...(row.blocked_task_id ? { blockedTaskId: row.blocked_task_id } : {}),
-    ...(row.blocked_summary ? { blockedSummary: row.blocked_summary } : {}),
-    ...(stateJson !== undefined ? { stateJson } : {}),
-    ...(waitJson !== undefined ? { waitJson } : {}),
-    ...(cancelRequestedAt != null ? { cancelRequestedAt } : {}),
-    createdAt: normalizeSqliteNumber(row.created_at) ?? 0,
-    updatedAt: normalizeSqliteNumber(row.updated_at) ?? 0,
-    ...(endedAt != null ? { endedAt } : {}),
-  };
-}
-
-export type BoundTaskFlowRecord = Insertable<FlowRunsTable>;
-
-export function bindTaskFlowRecord(record: TaskFlowRecord): BoundTaskFlowRecord {
-  return {
-    flow_id: record.flowId,
-    sync_mode: record.syncMode,
-    shape: null,
-    owner_key: record.ownerKey,
-    requester_origin_json: serializeJson(record.requesterOrigin),
-    controller_id: record.controllerId ?? null,
-    revision: record.revision,
-    status: record.status,
-    notify_policy: record.notifyPolicy,
-    goal: record.goal,
-    current_step: record.currentStep ?? null,
-    blocked_task_id: record.blockedTaskId ?? null,
-    blocked_summary: record.blockedSummary ?? null,
-    state_json: serializeJson(record.stateJson),
-    wait_json: serializeJson(record.waitJson),
-    cancel_requested_at: record.cancelRequestedAt ?? null,
-    created_at: record.createdAt,
-    updated_at: record.updatedAt,
-    ended_at: record.endedAt ?? null,
-  };
-}
-
-function getFlowRegistryKysely(db: DatabaseSync) {
-  return getNodeSqliteKysely<FlowRegistryStoreDatabase>(db);
-}
-
-function readTaskFlowRegistrySnapshot(db: DatabaseSync): TaskFlowRegistryStoreSnapshot {
-  const query = getFlowRegistryKysely(db)
-    .selectFrom("flow_runs")
-    .select([
-      "flow_id",
-      "sync_mode",
-      "shape",
-      "owner_key",
-      "requester_origin_json",
-      "controller_id",
-      "revision",
-      "status",
-      "notify_policy",
-      "goal",
-      "current_step",
-      "blocked_task_id",
-      "blocked_summary",
-      "state_json",
-      "wait_json",
-      "cancel_requested_at",
-      "created_at",
-      "updated_at",
-      "ended_at",
-    ])
-    .orderBy("created_at", "asc")
-    .orderBy("flow_id", "asc");
-  const flows = new Map<string, TaskFlowRecord>();
-  // Finish native reads before decoding so SQLite errors retain precedence.
-  for (const row of executeSqliteQuerySync(db, query).rows) {
-    flows.set(row.flow_id, rowToFlowRecord(row));
-  }
-  return { flows };
-}
-
-export function upsertTaskFlowRowInDatabase(db: DatabaseSync, row: BoundTaskFlowRecord): void {
-  executeSqliteQuerySync(
-    db,
-    getFlowRegistryKysely(db)
-      .insertInto("flow_runs")
-      .values(row)
-      .onConflict((conflict) =>
-        conflict.column("flow_id").doUpdateSet({
-          sync_mode: (eb) => eb.ref("excluded.sync_mode"),
-          owner_key: (eb) => eb.ref("excluded.owner_key"),
-          requester_origin_json: (eb) => eb.ref("excluded.requester_origin_json"),
-          controller_id: (eb) => eb.ref("excluded.controller_id"),
-          revision: (eb) => eb.ref("excluded.revision"),
-          status: (eb) => eb.ref("excluded.status"),
-          notify_policy: (eb) => eb.ref("excluded.notify_policy"),
-          goal: (eb) => eb.ref("excluded.goal"),
-          current_step: (eb) => eb.ref("excluded.current_step"),
-          blocked_task_id: (eb) => eb.ref("excluded.blocked_task_id"),
-          blocked_summary: (eb) => eb.ref("excluded.blocked_summary"),
-          state_json: (eb) => eb.ref("excluded.state_json"),
-          wait_json: (eb) => eb.ref("excluded.wait_json"),
-          cancel_requested_at: (eb) => eb.ref("excluded.cancel_requested_at"),
-          created_at: (eb) => eb.ref("excluded.created_at"),
-          updated_at: (eb) => eb.ref("excluded.updated_at"),
-          ended_at: (eb) => eb.ref("excluded.ended_at"),
-        }),
-      ),
-  );
-}
-
-export function readTaskFlowRecord(db: DatabaseSync, flowId: string): TaskFlowRecord | undefined {
-  const row = executeSqliteQueryTakeFirstSync(
-    db,
-    getFlowRegistryKysely(db).selectFrom("flow_runs").selectAll().where("flow_id", "=", flowId),
-  );
-  return row ? rowToFlowRecord(row) : undefined;
-}
 
 function openFlowRegistryDatabase(): FlowRegistryDatabase {
   const database = openOpenClawStateDatabase();
@@ -274,38 +82,14 @@ export function bindTaskFlowExecution(params: {
     return "disabled";
   }
   return runOpenClawStateWriteTransaction(
-    ({ db }) => {
-      const kysely = getFlowRegistryKysely(db);
-      const current = executeSqliteQueryTakeFirstSync(
-        db,
-        kysely
-          .selectFrom("flow_runs")
-          .select(["flow_id", "sync_mode", "shape", "status", "cancel_requested_at", "ended_at"])
-          .where("flow_id", "=", params.flowId),
-      );
-      if (!current || !isFlowExecutionOwnerActive(current)) {
-        return "missing";
-      }
-      return bindExecutionOwnerLifecycleMetadata({
-        db,
-        ownerKind: "flow",
-        ownerId: current.flow_id,
-        binding,
-      });
-    },
+    ({ db }) => bindTaskFlowExecutionInDatabase(db, params.flowId, binding),
     params.options,
     { operationLabel: "task.flow.execution-binding" },
   );
 }
 
 export function deleteTaskFlowRegistryRecordFromSqlite(flowId: string) {
-  withWriteTransaction(({ db }) => {
-    executeSqliteQuerySync(
-      db,
-      getFlowRegistryKysely(db).deleteFrom("flow_runs").where("flow_id", "=", flowId),
-    );
-    deleteExecutionOwnerLifecycleMetadata({ db, ownerKind: "flow", ownerIds: [flowId] });
-  });
+  withWriteTransaction(({ db }) => deleteTaskFlowRowInDatabase(db, flowId));
 }
 
 export function closeTaskFlowRegistryDatabase() {

--- a/src/tasks/task-registry-activity.ts
+++ b/src/tasks/task-registry-activity.ts
@@ -4,7 +4,6 @@ import { sliceUtf16Safe, truncateUtf16Safe } from "@openclaw/normalization-core/
 import { readCompletedFileMutationDelta } from "../agents/file-mutation-args.js";
 import { resolveFileMutationToolName } from "../agents/tool-mutation-names.js";
 import type { AgentEventPayload } from "../infra/agent-events.js";
-import { isTerminalTaskStatus } from "./task-executor-policy.js";
 import { cloneTaskRecordForObserver } from "./task-registry-records.js";
 import {
   emitTaskRegistryObserverEvent,
@@ -12,7 +11,7 @@ import {
   tasks,
 } from "./task-registry-state.js";
 import type { TaskActivityOverlayState } from "./task-registry.process-state.js";
-import type { TaskRecord } from "./task-registry.types.js";
+import { isTerminalTaskStatus, type TaskRecord } from "./task-registry.types.js";
 
 const MAX_ACTIVITY_CHARS = 200;
 const ACTIVITY_LINE_PREFIX = new RegExp(`^(?:\\s*\\S){1,${MAX_ACTIVITY_CHARS + 1}}`);

--- a/src/tasks/task-registry-cancel.ts
+++ b/src/tasks/task-registry-cancel.ts
@@ -10,7 +10,6 @@ import {
   readTaskBackingInstance,
 } from "./task-backing-authority.js";
 import { isProvisionalSubagentKillTask } from "./task-cancellation-state.js";
-import { isTerminalTaskStatus } from "./task-executor-policy.js";
 import { ensureLinkedTaskFlowRegistryReady } from "./task-registry-common.js";
 import { maybeDeliverTaskTerminalUpdate } from "./task-registry-delivery.js";
 import { updateTask } from "./task-registry-mutation.js";
@@ -22,7 +21,7 @@ import {
   loadTaskRegistryControlRuntime,
   tasks,
 } from "./task-registry-state.js";
-import type { TaskRecord } from "./task-registry.types.js";
+import { isTerminalTaskStatus, type TaskRecord } from "./task-registry.types.js";
 import { getTaskRunOwner } from "./task-run-owner.js";
 
 function ensureTaskCancellationReady(task: TaskRecord): void {

--- a/src/tasks/task-registry-common.ts
+++ b/src/tasks/task-registry-common.ts
@@ -4,19 +4,19 @@ import {
   type AgentRunTerminalOutcome,
 } from "../agents/agent-run-terminal-outcome.js";
 import { SUBAGENT_KILL_TASK_ERROR } from "./detached-task-runtime-contract.js";
-import { isTerminalTaskStatus } from "./task-executor-policy.js";
 import { isTerminalTaskFlow, type TaskFlowRecord } from "./task-flow-registry.types.js";
 import { ensureTaskFlowRegistryReady, getTaskFlowById } from "./task-flow-runtime-internal.js";
-import type {
-  TaskDeliveryStatus,
-  TaskEventKind,
-  TaskEventRecord,
-  TaskNotifyPolicy,
-  TaskRecord,
-  TaskRuntime,
-  TaskScopeKind,
-  TaskStatus,
-  TaskTerminalOutcome,
+import {
+  isTerminalTaskStatus,
+  type TaskDeliveryStatus,
+  type TaskEventKind,
+  type TaskEventRecord,
+  type TaskNotifyPolicy,
+  type TaskRecord,
+  type TaskRuntime,
+  type TaskScopeKind,
+  type TaskStatus,
+  type TaskTerminalOutcome,
 } from "./task-registry.types.js";
 
 type ParentFlowLinkErrorCode =

--- a/src/tasks/task-registry-lifecycle.ts
+++ b/src/tasks/task-registry-lifecycle.ts
@@ -2,7 +2,6 @@ import { buildAgentRunTerminalOutcomeFromLifecycleEvent } from "../agents/agent-
 import { subagentRuns } from "../agents/subagents/registry/subagent-registry-memory.js";
 import { onAgentEvent } from "../infra/agent-events.js";
 import { hasAuthoritativeTaskBacking, readTaskBackingInstance } from "./task-backing-authority.js";
-import { isTerminalTaskStatus } from "./task-executor-policy.js";
 import { recordTaskActivityEvent } from "./task-registry-activity.js";
 import {
   appendTaskEvent,
@@ -21,7 +20,7 @@ import {
   setTaskRegistryListenerStarter,
   setTaskRegistryListenerStop,
 } from "./task-registry-state.js";
-import type { TaskRecord } from "./task-registry.types.js";
+import { isTerminalTaskStatus, type TaskRecord } from "./task-registry.types.js";
 import { getTaskRunOwner } from "./task-run-owner.js";
 
 // Keep durable liveness well inside the 30-minute stale-task audit without writing every delta.

--- a/src/tasks/task-registry-mutation.ts
+++ b/src/tasks/task-registry-mutation.ts
@@ -2,7 +2,6 @@ import { normalizeOptionalString } from "@openclaw/normalization-core/string-coe
 import { runWithGatewayIndependentRootWorkAdmission } from "../process/gateway-work-admission.js";
 import { normalizeDeliveryContext } from "../utils/delivery-context.shared.js";
 import { isTaskFlowCancellationPending } from "./task-cancellation-state.js";
-import { isTerminalTaskStatus } from "./task-executor-policy.js";
 import { isTerminalTaskFlow } from "./task-flow-registry.types.js";
 import {
   getTaskFlowById,
@@ -36,7 +35,11 @@ import {
   tryPersistTaskDeliveryStateUpsert,
   tryPersistTaskUpsert,
 } from "./task-registry-state.js";
-import type { TaskDeliveryState, TaskRecord } from "./task-registry.types.js";
+import {
+  isTerminalTaskStatus,
+  type TaskDeliveryState,
+  type TaskRecord,
+} from "./task-registry.types.js";
 import { resolveTaskCleanupAfter } from "./task-retention.js";
 
 function syncManagedFlowCancellationFromTask(task: TaskRecord): void {

--- a/src/tasks/task-registry-publication.ts
+++ b/src/tasks/task-registry-publication.ts
@@ -1,4 +1,3 @@
-import { isTerminalTaskStatus } from "./task-executor-policy.js";
 import { clearTaskActivity, flushTaskActivity } from "./task-registry-activity.js";
 import {
   cloneTaskRecord,
@@ -17,7 +16,7 @@ import {
   rebuildRunIdIndex,
   tasks,
 } from "./task-registry-state.js";
-import type { TaskRecord } from "./task-registry.types.js";
+import { isTerminalTaskStatus, type TaskRecord } from "./task-registry.types.js";
 
 /** Publishes a record already committed by a cross-owner shared-state transaction. */
 export function publishTaskRecordAfterAtomicStore(

--- a/src/tasks/task-registry-record-api.ts
+++ b/src/tasks/task-registry-record-api.ts
@@ -2,7 +2,6 @@ import crypto from "node:crypto";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { normalizeDeliveryContext } from "../utils/delivery-context.shared.js";
 import { hasAuthoritativeTaskBacking } from "./task-backing-authority.js";
-import { isTerminalTaskStatus } from "./task-executor-policy.js";
 import {
   appendTaskEvent,
   assertParentFlowLinkAllowed,
@@ -47,6 +46,7 @@ import {
   tryPersistTaskUpsert,
 } from "./task-registry-state.js";
 import {
+  isTerminalTaskStatus,
   parseTaskNotifyPolicy,
   type JsonValue,
   type TaskDeliveryState,

--- a/src/tasks/task-registry-records.ts
+++ b/src/tasks/task-registry-records.ts
@@ -1,6 +1,9 @@
 // Clones and normalizes task registry records at persistence boundaries.
-import { isTerminalTaskStatus } from "./task-executor-policy.js";
-import type { TaskDeliveryState, TaskRecord } from "./task-registry.types.js";
+import {
+  isTerminalTaskStatus,
+  type TaskDeliveryState,
+  type TaskRecord,
+} from "./task-registry.types.js";
 
 export function cloneTaskRecord(record: TaskRecord): TaskRecord {
   return {

--- a/src/tasks/task-registry.store.kernel.test.ts
+++ b/src/tasks/task-registry.store.kernel.test.ts
@@ -1,0 +1,131 @@
+import { DatabaseSync } from "node:sqlite";
+import { expect, it, vi } from "vitest";
+import type { TaskFlowRecord } from "./task-flow-registry.types.js";
+import type { TaskRecord } from "./task-registry.types.js";
+
+vi.mock("../state/openclaw-state-db.js", () => {
+  throw new Error("A connection-bound kernel imported the global database owner");
+});
+vi.mock("../state/openclaw-state-db-readonly.js", () => {
+  throw new Error("A connection-bound kernel imported global read admission");
+});
+vi.mock("../plugins/loader-runtime-load.js", () => {
+  throw new Error("A connection-bound kernel imported plugin runtime ownership");
+});
+
+it("isolates supplied connections and rolls back compound task, flow, delivery, and binding writes", async () => {
+  // Cold evaluation proves the dependency boundary even if setup previously loaded a store.
+  vi.resetModules();
+  const [tasks, flows, { OPENCLAW_STATE_SCHEMA_SQL }, { runSqliteImmediateTransactionSync }] =
+    await Promise.all([
+      import("./task-registry.store.kernel.js"),
+      import("./task-flow-registry.store.kernel.js"),
+      import("../state/openclaw-state-schema.js"),
+      import("../infra/sqlite-transaction.js"),
+    ]);
+  const first = new DatabaseSync(":memory:");
+  const second = new DatabaseSync(":memory:");
+  const task: TaskRecord = {
+    taskId: "task-a",
+    runtime: "cron",
+    taskKind: "fixture",
+    sourceId: "source-a",
+    requesterSessionKey: "agent:main:fixture",
+    ownerKey: "agent:main:fixture",
+    scopeKind: "session",
+    task: "Original task",
+    status: "running",
+    deliveryStatus: "pending",
+    notifyPolicy: "silent",
+    createdAt: 100,
+    detail: { result: null, values: ["text", 1] },
+  };
+  const flow: TaskFlowRecord = {
+    flowId: "flow-a",
+    syncMode: "managed",
+    ownerKey: task.ownerKey,
+    controllerId: "fixture/controller",
+    revision: 0,
+    status: "running",
+    notifyPolicy: "silent",
+    goal: "Original flow",
+    stateJson: { step: 0 },
+    waitJson: null,
+    createdAt: 100,
+    updatedAt: 100,
+  };
+  const origin = { channel: "test-channel", to: "synthetic-target" };
+  const snapshot = () => ({
+    tasks: tasks.readTaskRegistrySnapshot({ db: first, path: ":memory:" }),
+    flows: flows.readTaskFlowRegistrySnapshot(first),
+    bindings: first
+      .prepare("SELECT * FROM execution_owner_lifecycle_bindings ORDER BY owner_kind, owner_id")
+      .all(),
+  });
+  try {
+    for (const db of [first, second]) {
+      db.exec(OPENCLAW_STATE_SCHEMA_SQL);
+      runSqliteImmediateTransactionSync(db, () => {
+        tasks.upsertTaskWithDeliveryStateInDatabase(
+          { db },
+          {
+            task: { ...task, task: db === first ? task.task : "Other connection" },
+            deliveryState: { taskId: task.taskId, requesterOrigin: origin },
+          },
+        );
+        flows.upsertTaskFlowRowInDatabase(db, flows.bindTaskFlowRecord(flow));
+      });
+    }
+    expect(tasks.readTaskRecord(first, task.taskId)).toEqual(task);
+    expect(tasks.readTaskRecord(second, task.taskId)?.task).toBe("Other connection");
+    expect(flows.readTaskFlowRecord(first, flow.flowId)).toEqual(flow);
+    expect(tasks.readTaskRegistrySnapshotIfReady({ db: first, path: ":memory:" }).state).toBe(
+      "ready",
+    );
+    expect(tasks.listTaskRecordsByOwnerKeyInDatabase(first, task.ownerKey)).toEqual([task]);
+    expect(tasks.listTaskRecordsByRuntimeSourceIdInDatabase(first, "cron", "source-a")).toEqual([
+      task,
+    ]);
+
+    const before = snapshot();
+    const replacement = { ...task, task: "Updated task", detail: null };
+    const nextFlow = { ...flow, revision: 1, stateJson: { step: 1 } };
+    const binding = { contextId: "context-fixture", executionId: "execution-fixture" };
+    const commit = () =>
+      runSqliteImmediateTransactionSync(first, () => {
+        tasks.upsertTaskWithDeliveryStateInDatabase(
+          { db: first },
+          { task: replacement, deliveryState: { taskId: task.taskId, lastNotifiedEventAt: 200 } },
+        );
+        expect(tasks.bindTaskRunExecutionInDatabase(first, task.taskId, binding)).toBe("bound");
+        expect(flows.bindTaskFlowExecutionInDatabase(first, flow.flowId, binding)).toBe("bound");
+        flows.upsertTaskFlowRowInDatabase(first, flows.bindTaskFlowRecord(nextFlow));
+      });
+    first.exec(`
+      CREATE TEMP TRIGGER reject_flow BEFORE INSERT ON flow_runs
+      BEGIN SELECT RAISE(ABORT, 'synthetic compound failure'); END;
+    `);
+    expect(commit).toThrow("synthetic compound failure");
+    expect(snapshot()).toEqual(before);
+    first.exec("DROP TRIGGER reject_flow");
+    commit();
+    expect(tasks.readTaskRecord(first, task.taskId)).toEqual(replacement);
+    expect(flows.readTaskFlowRecord(first, flow.flowId)).toEqual(nextFlow);
+    expect(snapshot().bindings).toHaveLength(2);
+    expect(tasks.readTaskRecord(second, task.taskId)?.task).toBe("Other connection");
+
+    runSqliteImmediateTransactionSync(first, () => {
+      tasks.deleteTaskRowsWithDeliveryState(first, task.taskId);
+      flows.deleteTaskFlowRowInDatabase(first, flow.flowId);
+    });
+    const deleted = snapshot();
+    expect(deleted.tasks.tasks.size).toBe(0);
+    expect(deleted.tasks.deliveryStates.size).toBe(0);
+    expect(deleted.flows.flows.size).toBe(0);
+    expect(deleted.bindings).toEqual([]);
+    expect(tasks.readTaskRecord(second, task.taskId)).toBeDefined();
+  } finally {
+    first.close();
+    second.close();
+  }
+});

--- a/src/tasks/task-registry.store.kernel.ts
+++ b/src/tasks/task-registry.store.kernel.ts
@@ -1,0 +1,417 @@
+// Connection-bound task row codecs and SQLite operations; callers own database lifetime.
+import type { DatabaseSync } from "node:sqlite";
+import type { Insertable, Selectable } from "kysely";
+import type { ExecutionOwnerBindingResult } from "../audit/execution-owner-binding.js";
+import {
+  bindExecutionOwnerLifecycleMetadata,
+  deleteExecutionOwnerLifecycleMetadata,
+} from "../audit/execution-owner-lifecycle-binding-store.js";
+import {
+  executeSqliteQuerySync,
+  executeSqliteQueryTakeFirstSync,
+  getNodeSqliteKysely,
+} from "../infra/kysely-sync.js";
+import { assertSqliteTableIntegrity } from "../infra/sqlite-integrity.js";
+import { normalizeSqliteNumber } from "../infra/sqlite-number.js";
+import { runSqliteDeferredTransactionSync } from "../infra/sqlite-transaction.js";
+import { tableExists, tableHasColumns } from "../state/openclaw-state-db-schema-helpers.js";
+import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-db.generated.js";
+import { normalizeTaskTimestamps } from "./task-registry-records.js";
+import { parseDeliveryContextJson, parseSqliteJsonValue } from "./task-registry.sqlite.shared.js";
+import type { TaskRegistryStoreSnapshot } from "./task-registry.store.types.js";
+import {
+  parseOptionalTaskTerminalOutcome,
+  parseTaskDeliveryStatus,
+  parseTaskNotifyPolicy,
+  parseTaskRuntime,
+  parseTaskScopeKind,
+  parseTaskStatus,
+  type TaskDeliveryState,
+  type JsonValue,
+  type TaskRecord,
+  type TaskRuntime,
+} from "./task-registry.types.js";
+
+type TaskRunsTable = OpenClawStateKyselyDatabase["task_runs"];
+type TaskDeliveryStateTable = OpenClawStateKyselyDatabase["task_delivery_state"];
+type TaskRegistryStoreDatabase = Pick<
+  OpenClawStateKyselyDatabase,
+  "task_delivery_state" | "task_runs"
+>;
+
+type TaskRegistryRow = Selectable<TaskRunsTable> & {
+  runtime: string;
+  scope_kind: string;
+  status: string;
+  delivery_status: string;
+  notify_policy: string;
+  terminal_outcome: string | null;
+};
+
+type TaskDeliveryStateRow = Selectable<TaskDeliveryStateTable>;
+
+export type TaskRegistryDatabase = {
+  db: DatabaseSync;
+  path: string;
+};
+
+const TASK_RUN_SELECT_COLUMNS = [
+  "task_id",
+  "runtime",
+  "task_kind",
+  "source_id",
+  "requester_session_key",
+  "owner_key",
+  "scope_kind",
+  "child_session_key",
+  "parent_flow_id",
+  "parent_task_id",
+  "agent_id",
+  "requester_agent_id",
+  "run_id",
+  "label",
+  "task",
+  "status",
+  "delivery_status",
+  "notify_policy",
+  "created_at",
+  "started_at",
+  "ended_at",
+  "last_event_at",
+  "cleanup_after",
+  "tool_use_count",
+  "last_tool_name",
+  "error",
+  "progress_summary",
+  "terminal_summary",
+  "terminal_outcome",
+  "detail_json",
+] as const;
+
+const TASK_DELIVERY_STATE_SELECT_COLUMNS = [
+  "task_id",
+  "requester_origin_json",
+  "last_notified_event_at",
+] as const;
+
+export type TaskRegistryReadOnlyLoadResult = {
+  state: "ready" | "migration-required";
+  snapshot: TaskRegistryStoreSnapshot;
+};
+
+function serializeJson(value: unknown): string | null {
+  return value === undefined ? null : (JSON.stringify(value) ?? null);
+}
+
+function rowToTaskRecord(row: TaskRegistryRow): TaskRecord {
+  const startedAt = normalizeSqliteNumber(row.started_at);
+  const endedAt = normalizeSqliteNumber(row.ended_at);
+  const lastEventAt = normalizeSqliteNumber(row.last_event_at);
+  const cleanupAfter = normalizeSqliteNumber(row.cleanup_after);
+  const toolUseCount = normalizeSqliteNumber(row.tool_use_count);
+  const scopeKind = parseTaskScopeKind(row.scope_kind);
+  const terminalOutcome = parseOptionalTaskTerminalOutcome(row.terminal_outcome);
+  const detail = parseSqliteJsonValue<JsonValue>(row.detail_json);
+  // System tasks intentionally have no requester session; ownerKey is the lookup anchor.
+  const requesterSessionKey =
+    scopeKind === "system" ? "" : row.requester_session_key?.trim() || row.owner_key;
+  return normalizeTaskTimestamps({
+    taskId: row.task_id,
+    runtime: parseTaskRuntime(row.runtime),
+    ...(row.task_kind ? { taskKind: row.task_kind } : {}),
+    ...(row.source_id ? { sourceId: row.source_id } : {}),
+    requesterSessionKey,
+    ownerKey: row.owner_key,
+    scopeKind,
+    ...(row.child_session_key ? { childSessionKey: row.child_session_key } : {}),
+    ...(row.parent_flow_id ? { parentFlowId: row.parent_flow_id } : {}),
+    ...(row.parent_task_id ? { parentTaskId: row.parent_task_id } : {}),
+    ...(row.agent_id ? { agentId: row.agent_id } : {}),
+    ...(row.requester_agent_id ? { requesterAgentId: row.requester_agent_id } : {}),
+    ...(row.run_id ? { runId: row.run_id } : {}),
+    ...(row.label ? { label: row.label } : {}),
+    task: row.task,
+    status: parseTaskStatus(row.status),
+    deliveryStatus: parseTaskDeliveryStatus(row.delivery_status),
+    notifyPolicy: parseTaskNotifyPolicy(row.notify_policy),
+    createdAt: normalizeSqliteNumber(row.created_at) ?? 0,
+    ...(startedAt != null ? { startedAt } : {}),
+    ...(endedAt != null ? { endedAt } : {}),
+    ...(lastEventAt != null ? { lastEventAt } : {}),
+    ...(cleanupAfter != null ? { cleanupAfter } : {}),
+    ...(toolUseCount != null ? { toolUseCount } : {}),
+    ...(row.last_tool_name ? { lastToolName: row.last_tool_name } : {}),
+    ...(row.error ? { error: row.error } : {}),
+    ...(row.progress_summary ? { progressSummary: row.progress_summary } : {}),
+    ...(row.terminal_summary !== null ? { terminalSummary: row.terminal_summary } : {}),
+    ...(terminalOutcome ? { terminalOutcome } : {}),
+    ...(detail !== undefined ? { detail } : {}),
+  });
+}
+
+function rowToTaskDeliveryState(row: TaskDeliveryStateRow): TaskDeliveryState {
+  const requesterOrigin = parseDeliveryContextJson(row.requester_origin_json);
+  const lastNotifiedEventAt = normalizeSqliteNumber(row.last_notified_event_at);
+  return {
+    taskId: row.task_id,
+    ...(requesterOrigin ? { requesterOrigin } : {}),
+    ...(lastNotifiedEventAt != null ? { lastNotifiedEventAt } : {}),
+  };
+}
+
+type BoundTaskRecord = Insertable<TaskRunsTable>;
+
+/** Canonically serializes a task before an outer transaction acquires the write lock. */
+export function bindTaskRecord(record: TaskRecord): BoundTaskRecord {
+  const normalized = normalizeTaskTimestamps(record);
+  return {
+    task_id: normalized.taskId,
+    runtime: normalized.runtime,
+    task_kind: normalized.taskKind ?? null,
+    source_id: normalized.sourceId ?? null,
+    requester_session_key: normalized.scopeKind === "system" ? "" : normalized.requesterSessionKey,
+    owner_key: normalized.ownerKey,
+    scope_kind: normalized.scopeKind,
+    child_session_key: normalized.childSessionKey ?? null,
+    parent_flow_id: normalized.parentFlowId ?? null,
+    parent_task_id: normalized.parentTaskId ?? null,
+    agent_id: normalized.agentId ?? null,
+    requester_agent_id: normalized.requesterAgentId ?? null,
+    run_id: normalized.runId ?? null,
+    label: normalized.label ?? null,
+    task: normalized.task,
+    status: normalized.status,
+    delivery_status: normalized.deliveryStatus,
+    notify_policy: normalized.notifyPolicy,
+    created_at: normalized.createdAt,
+    started_at: normalized.startedAt ?? null,
+    ended_at: normalized.endedAt ?? null,
+    last_event_at: normalized.lastEventAt ?? null,
+    cleanup_after: normalized.cleanupAfter ?? null,
+    tool_use_count: normalized.toolUseCount ?? null,
+    last_tool_name: normalized.lastToolName ?? null,
+    error: normalized.error ?? null,
+    progress_summary: normalized.progressSummary ?? null,
+    terminal_summary: normalized.terminalSummary ?? null,
+    terminal_outcome: normalized.terminalOutcome ?? null,
+    detail_json: serializeJson(normalized.detail),
+  };
+}
+
+function bindTaskDeliveryState(state: TaskDeliveryState): Insertable<TaskDeliveryStateTable> {
+  return {
+    task_id: state.taskId,
+    requester_origin_json: serializeJson(state.requesterOrigin),
+    last_notified_event_at: state.lastNotifiedEventAt ?? null,
+  };
+}
+
+function getTaskRegistryKysely(db: DatabaseSync) {
+  return getNodeSqliteKysely<TaskRegistryStoreDatabase>(db);
+}
+
+function selectTaskRows(db: DatabaseSync): TaskRegistryRow[] {
+  const query = getTaskRegistryKysely(db)
+    .selectFrom("task_runs")
+    .select(TASK_RUN_SELECT_COLUMNS)
+    .orderBy("created_at", "asc")
+    .orderBy("task_id", "asc");
+  return executeSqliteQuerySync(db, query).rows;
+}
+
+function selectTaskRowsByOwnerKey(db: DatabaseSync, ownerKey: string): TaskRegistryRow[] {
+  const selectColumns = TASK_RUN_SELECT_COLUMNS.join(", ");
+  // This lookup gates duplicate media tasks. A table scan is intentional so a
+  // stale secondary index cannot hide an existing task between integrity checks.
+  return db
+    .prepare(
+      `SELECT ${selectColumns}
+       FROM task_runs NOT INDEXED
+       WHERE owner_key = ?
+       ORDER BY created_at ASC, task_id ASC`,
+    )
+    .all(ownerKey) as TaskRegistryRow[]; // SAFETY: The admitted handle has the canonical columns projected above.
+}
+
+function selectTaskRowsByRuntimeSourceId(
+  db: DatabaseSync,
+  runtime: TaskRuntime,
+  sourceId?: string,
+): TaskRegistryRow[] {
+  let query = getTaskRegistryKysely(db)
+    .selectFrom("task_runs")
+    .select(TASK_RUN_SELECT_COLUMNS)
+    .where("runtime", "=", runtime);
+  if (sourceId !== undefined) {
+    query = query.where("source_id", "=", sourceId);
+  }
+  return executeSqliteQuerySync(db, query.orderBy("created_at", "asc").orderBy("task_id", "asc"))
+    .rows;
+}
+
+/** Reads task records from the caller's shared-state transaction. */
+export function listTaskRecordsByRuntimeSourceIdInDatabase(
+  db: DatabaseSync,
+  runtime: TaskRuntime,
+  sourceId?: string,
+): TaskRecord[] {
+  return selectTaskRowsByRuntimeSourceId(db, runtime, sourceId).map(rowToTaskRecord);
+}
+
+export function readTaskRecord(db: DatabaseSync, taskId: string): TaskRecord | undefined {
+  const row = executeSqliteQueryTakeFirstSync(
+    db,
+    getTaskRegistryKysely(db)
+      .selectFrom("task_runs")
+      .select(TASK_RUN_SELECT_COLUMNS)
+      .where("task_id", "=", taskId),
+  );
+  return row ? rowToTaskRecord(row) : undefined;
+}
+
+function selectTaskDeliveryStateRows(db: DatabaseSync): TaskDeliveryStateRow[] {
+  const query = getTaskRegistryKysely(db)
+    .selectFrom("task_delivery_state")
+    .select(TASK_DELIVERY_STATE_SELECT_COLUMNS)
+    .orderBy("task_id", "asc");
+  return executeSqliteQuerySync(db, query).rows;
+}
+
+/** Upserts a prebound task on the exact supplied shared-state handle. */
+export function upsertTaskRunRowInDatabase(
+  database: Pick<TaskRegistryDatabase, "db">,
+  row: BoundTaskRecord,
+): void {
+  const { db } = database;
+  const updates = { ...row, task_id: undefined };
+  executeSqliteQuerySync(
+    db,
+    getTaskRegistryKysely(db)
+      .insertInto("task_runs")
+      .values(row)
+      .onConflict((conflict) => conflict.column("task_id").doUpdateSet(updates)),
+  );
+}
+
+function replaceTaskDeliveryStateRow(
+  db: DatabaseSync,
+  row: Insertable<TaskDeliveryStateTable>,
+): void {
+  executeSqliteQuerySync(
+    db,
+    getTaskRegistryKysely(db)
+      .insertInto("task_delivery_state")
+      .values(row)
+      .onConflict((conflict) =>
+        conflict.column("task_id").doUpdateSet({
+          requester_origin_json: (eb) => eb.ref("excluded.requester_origin_json"),
+          last_notified_event_at: (eb) => eb.ref("excluded.last_notified_event_at"),
+        }),
+      ),
+  );
+}
+
+export function deleteTaskRowsWithDeliveryState(db: DatabaseSync, taskId: string): void {
+  const kysely = getTaskRegistryKysely(db);
+  executeSqliteQuerySync(
+    db,
+    kysely.deleteFrom("task_delivery_state").where("task_id", "=", taskId),
+  );
+  executeSqliteQuerySync(db, kysely.deleteFrom("task_runs").where("task_id", "=", taskId));
+  deleteExecutionOwnerLifecycleMetadata({ db, ownerKind: "task", ownerIds: [taskId] });
+}
+
+export function readTaskRegistrySnapshot({
+  db,
+  path,
+}: TaskRegistryDatabase): TaskRegistryStoreSnapshot {
+  return runSqliteDeferredTransactionSync(db, () => {
+    assertSqliteTableIntegrity(db, path, "task_runs");
+    assertSqliteTableIntegrity(db, path, "task_delivery_state");
+    const taskRows = selectTaskRows(db);
+    const deliveryRows = selectTaskDeliveryStateRows(db);
+    return {
+      tasks: new Map(taskRows.map((row) => [row.task_id, rowToTaskRecord(row)])),
+      deliveryStates: new Map(
+        deliveryRows.map((row) => [row.task_id, rowToTaskDeliveryState(row)]),
+      ),
+    };
+  });
+}
+
+/** Inspect only the supplied existing connection; never create or repair its schema. */
+export function readTaskRegistrySnapshotIfReady(
+  database: TaskRegistryDatabase,
+): TaskRegistryReadOnlyLoadResult {
+  const { db } = database;
+  const hasReadableSchema =
+    tableExists(db, "task_runs") &&
+    tableExists(db, "task_delivery_state") &&
+    tableHasColumns(db, "task_runs", TASK_RUN_SELECT_COLUMNS) &&
+    tableHasColumns(db, "task_delivery_state", TASK_DELIVERY_STATE_SELECT_COLUMNS);
+  return hasReadableSchema
+    ? { state: "ready", snapshot: readTaskRegistrySnapshot(database) }
+    : {
+        state: "migration-required",
+        snapshot: { tasks: new Map(), deliveryStates: new Map() },
+      };
+}
+
+export function listTaskRecordsByOwnerKeyInDatabase(
+  db: DatabaseSync,
+  ownerKey: string,
+): TaskRecord[] {
+  return selectTaskRowsByOwnerKey(db, ownerKey).map(rowToTaskRecord);
+}
+
+/** Revalidate and bind the exact task row inside its caller's transaction. */
+export function bindTaskRunExecutionInDatabase(
+  db: DatabaseSync,
+  taskId: string,
+  binding: Parameters<typeof bindExecutionOwnerLifecycleMetadata>[0]["binding"],
+): Exclude<ExecutionOwnerBindingResult, "disabled"> {
+  const kysely = getTaskRegistryKysely(db);
+  const current = executeSqliteQueryTakeFirstSync(
+    db,
+    kysely
+      .selectFrom("task_runs")
+      .select(["task_id", "status", "ended_at"])
+      .where("task_id", "=", taskId),
+  );
+  const status = current ? parseTaskStatus(current.status) : undefined;
+  if (!current || (status !== "queued" && status !== "running") || current.ended_at !== null) {
+    return "missing";
+  }
+  return bindExecutionOwnerLifecycleMetadata({
+    db,
+    ownerKind: "task",
+    ownerId: current.task_id,
+    binding,
+  });
+}
+
+/** The caller's transaction covers both the task and delivery-state mutation. */
+export function upsertTaskWithDeliveryStateInDatabase(
+  database: Pick<TaskRegistryDatabase, "db">,
+  params: { task: TaskRecord; deliveryState?: TaskDeliveryState },
+): void {
+  const { db } = database;
+  upsertTaskRunRowInDatabase(database, bindTaskRecord(params.task));
+  if (params.deliveryState) {
+    replaceTaskDeliveryStateRow(db, bindTaskDeliveryState(params.deliveryState));
+  } else {
+    executeSqliteQuerySync(
+      db,
+      getTaskRegistryKysely(db)
+        .deleteFrom("task_delivery_state")
+        .where("task_id", "=", params.task.taskId),
+    );
+  }
+}
+
+export function upsertTaskDeliveryStateInDatabase(
+  db: DatabaseSync,
+  state: TaskDeliveryState,
+): void {
+  replaceTaskDeliveryStateRow(db, bindTaskDeliveryState(state));
+}

--- a/src/tasks/task-registry.store.sqlite.ts
+++ b/src/tasks/task-registry.store.sqlite.ts
@@ -1,26 +1,10 @@
-// Persists task registry records and events through the OpenClaw SQLite state database.
-import type { DatabaseSync } from "node:sqlite";
-import type { Insertable, Selectable } from "kysely";
+// Persists task registry records through the global shared-state database owner.
 import type { AdmittedRunContext } from "../agents/admitted-run-context.js";
 import {
   executionOwnerBindingFromAdmission,
   type ExecutionOwnerBindingResult,
 } from "../audit/execution-owner-binding.js";
-import {
-  bindExecutionOwnerLifecycleMetadata,
-  deleteExecutionOwnerLifecycleMetadata,
-} from "../audit/execution-owner-lifecycle-binding-store.js";
-import {
-  executeSqliteQuerySync,
-  executeSqliteQueryTakeFirstSync,
-  getNodeSqliteKysely,
-} from "../infra/kysely-sync.js";
-import { assertSqliteTableIntegrity } from "../infra/sqlite-integrity.js";
-import { normalizeSqliteNumber } from "../infra/sqlite-number.js";
-import { runSqliteDeferredTransactionSync } from "../infra/sqlite-transaction.js";
 import { withExistingOpenClawStateDatabaseReadOnly } from "../state/openclaw-state-db-readonly.js";
-import { tableExists, tableHasColumns } from "../state/openclaw-state-db-schema-helpers.js";
-import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-db.generated.js";
 import {
   closeOpenClawStateDatabase,
   openOpenClawStateDatabase,
@@ -28,313 +12,22 @@ import {
   type OpenClawStateDatabase,
   type OpenClawStateDatabaseOptions,
 } from "../state/openclaw-state-db.js";
-import { normalizeTaskTimestamps } from "./task-registry-records.js";
-import { parseDeliveryContextJson, parseSqliteJsonValue } from "./task-registry.sqlite.shared.js";
-import type { TaskRegistryStoreSnapshot } from "./task-registry.store.types.js";
 import {
-  parseOptionalTaskTerminalOutcome,
-  parseTaskDeliveryStatus,
-  parseTaskNotifyPolicy,
-  parseTaskRuntime,
-  parseTaskScopeKind,
-  parseTaskStatus,
-  type TaskDeliveryState,
-  type JsonValue,
-  type TaskRecord,
-  type TaskRuntime,
-} from "./task-registry.types.js";
-
-type TaskRunsTable = OpenClawStateKyselyDatabase["task_runs"];
-type TaskDeliveryStateTable = OpenClawStateKyselyDatabase["task_delivery_state"];
-type TaskRegistryStoreDatabase = Pick<
-  OpenClawStateKyselyDatabase,
-  "task_delivery_state" | "task_runs"
->;
-
-type TaskRegistryRow = Selectable<TaskRunsTable> & {
-  runtime: string;
-  scope_kind: string;
-  status: string;
-  delivery_status: string;
-  notify_policy: string;
-  terminal_outcome: string | null;
-};
-
-type TaskDeliveryStateRow = Selectable<TaskDeliveryStateTable>;
-
-type TaskRegistryDatabase = {
-  db: DatabaseSync;
-  path: string;
-};
-
-// SQLite-backed task store mirrors task records and delivery state into openclaw-state.db.
-const TASK_RUN_SELECT_COLUMNS = [
-  "task_id",
-  "runtime",
-  "task_kind",
-  "source_id",
-  "requester_session_key",
-  "owner_key",
-  "scope_kind",
-  "child_session_key",
-  "parent_flow_id",
-  "parent_task_id",
-  "agent_id",
-  "requester_agent_id",
-  "run_id",
-  "label",
-  "task",
-  "status",
-  "delivery_status",
-  "notify_policy",
-  "created_at",
-  "started_at",
-  "ended_at",
-  "last_event_at",
-  "cleanup_after",
-  "tool_use_count",
-  "last_tool_name",
-  "error",
-  "progress_summary",
-  "terminal_summary",
-  "terminal_outcome",
-  "detail_json",
-] as const;
-
-const TASK_DELIVERY_STATE_SELECT_COLUMNS = [
-  "task_id",
-  "requester_origin_json",
-  "last_notified_event_at",
-] as const;
-
-type TaskRegistryReadOnlyLoadResult = {
-  state: "ready" | "migration-required";
-  snapshot: TaskRegistryStoreSnapshot;
-};
+  bindTaskRunExecutionInDatabase,
+  deleteTaskRowsWithDeliveryState,
+  listTaskRecordsByOwnerKeyInDatabase,
+  listTaskRecordsByRuntimeSourceIdInDatabase,
+  readTaskRegistrySnapshot,
+  readTaskRegistrySnapshotIfReady,
+  upsertTaskDeliveryStateInDatabase,
+  upsertTaskWithDeliveryStateInDatabase,
+  type TaskRegistryDatabase,
+  type TaskRegistryReadOnlyLoadResult,
+} from "./task-registry.store.kernel.js";
+import type { TaskRegistryStoreSnapshot } from "./task-registry.store.types.js";
+import type { TaskDeliveryState, TaskRecord, TaskRuntime } from "./task-registry.types.js";
 
 let cachedDatabase: TaskRegistryDatabase | null = null;
-
-function serializeJson(value: unknown): string | null {
-  return value === undefined ? null : (JSON.stringify(value) ?? null);
-}
-
-function rowToTaskRecord(row: TaskRegistryRow): TaskRecord {
-  const startedAt = normalizeSqliteNumber(row.started_at);
-  const endedAt = normalizeSqliteNumber(row.ended_at);
-  const lastEventAt = normalizeSqliteNumber(row.last_event_at);
-  const cleanupAfter = normalizeSqliteNumber(row.cleanup_after);
-  const toolUseCount = normalizeSqliteNumber(row.tool_use_count);
-  const scopeKind = parseTaskScopeKind(row.scope_kind);
-  const terminalOutcome = parseOptionalTaskTerminalOutcome(row.terminal_outcome);
-  const detail = parseSqliteJsonValue<JsonValue>(row.detail_json);
-  // System tasks intentionally have no requester session; ownerKey is the lookup anchor.
-  const requesterSessionKey =
-    scopeKind === "system" ? "" : row.requester_session_key?.trim() || row.owner_key;
-  return normalizeTaskTimestamps({
-    taskId: row.task_id,
-    runtime: parseTaskRuntime(row.runtime),
-    ...(row.task_kind ? { taskKind: row.task_kind } : {}),
-    ...(row.source_id ? { sourceId: row.source_id } : {}),
-    requesterSessionKey,
-    ownerKey: row.owner_key,
-    scopeKind,
-    ...(row.child_session_key ? { childSessionKey: row.child_session_key } : {}),
-    ...(row.parent_flow_id ? { parentFlowId: row.parent_flow_id } : {}),
-    ...(row.parent_task_id ? { parentTaskId: row.parent_task_id } : {}),
-    ...(row.agent_id ? { agentId: row.agent_id } : {}),
-    ...(row.requester_agent_id ? { requesterAgentId: row.requester_agent_id } : {}),
-    ...(row.run_id ? { runId: row.run_id } : {}),
-    ...(row.label ? { label: row.label } : {}),
-    task: row.task,
-    status: parseTaskStatus(row.status),
-    deliveryStatus: parseTaskDeliveryStatus(row.delivery_status),
-    notifyPolicy: parseTaskNotifyPolicy(row.notify_policy),
-    createdAt: normalizeSqliteNumber(row.created_at) ?? 0,
-    ...(startedAt != null ? { startedAt } : {}),
-    ...(endedAt != null ? { endedAt } : {}),
-    ...(lastEventAt != null ? { lastEventAt } : {}),
-    ...(cleanupAfter != null ? { cleanupAfter } : {}),
-    ...(toolUseCount != null ? { toolUseCount } : {}),
-    ...(row.last_tool_name ? { lastToolName: row.last_tool_name } : {}),
-    ...(row.error ? { error: row.error } : {}),
-    ...(row.progress_summary ? { progressSummary: row.progress_summary } : {}),
-    ...(row.terminal_summary !== null ? { terminalSummary: row.terminal_summary } : {}),
-    ...(terminalOutcome ? { terminalOutcome } : {}),
-    ...(detail !== undefined ? { detail } : {}),
-  });
-}
-
-function rowToTaskDeliveryState(row: TaskDeliveryStateRow): TaskDeliveryState {
-  const requesterOrigin = parseDeliveryContextJson(row.requester_origin_json);
-  const lastNotifiedEventAt = normalizeSqliteNumber(row.last_notified_event_at);
-  return {
-    taskId: row.task_id,
-    ...(requesterOrigin ? { requesterOrigin } : {}),
-    ...(lastNotifiedEventAt != null ? { lastNotifiedEventAt } : {}),
-  };
-}
-
-type BoundTaskRecord = Insertable<TaskRunsTable>;
-
-/** Canonically serializes a task before an outer transaction acquires the write lock. */
-export function bindTaskRecord(record: TaskRecord): BoundTaskRecord {
-  const normalized = normalizeTaskTimestamps(record);
-  return {
-    task_id: normalized.taskId,
-    runtime: normalized.runtime,
-    task_kind: normalized.taskKind ?? null,
-    source_id: normalized.sourceId ?? null,
-    requester_session_key: normalized.scopeKind === "system" ? "" : normalized.requesterSessionKey,
-    owner_key: normalized.ownerKey,
-    scope_kind: normalized.scopeKind,
-    child_session_key: normalized.childSessionKey ?? null,
-    parent_flow_id: normalized.parentFlowId ?? null,
-    parent_task_id: normalized.parentTaskId ?? null,
-    agent_id: normalized.agentId ?? null,
-    requester_agent_id: normalized.requesterAgentId ?? null,
-    run_id: normalized.runId ?? null,
-    label: normalized.label ?? null,
-    task: normalized.task,
-    status: normalized.status,
-    delivery_status: normalized.deliveryStatus,
-    notify_policy: normalized.notifyPolicy,
-    created_at: normalized.createdAt,
-    started_at: normalized.startedAt ?? null,
-    ended_at: normalized.endedAt ?? null,
-    last_event_at: normalized.lastEventAt ?? null,
-    cleanup_after: normalized.cleanupAfter ?? null,
-    tool_use_count: normalized.toolUseCount ?? null,
-    last_tool_name: normalized.lastToolName ?? null,
-    error: normalized.error ?? null,
-    progress_summary: normalized.progressSummary ?? null,
-    terminal_summary: normalized.terminalSummary ?? null,
-    terminal_outcome: normalized.terminalOutcome ?? null,
-    detail_json: serializeJson(normalized.detail),
-  };
-}
-
-function bindTaskDeliveryState(state: TaskDeliveryState): Insertable<TaskDeliveryStateTable> {
-  return {
-    task_id: state.taskId,
-    requester_origin_json: serializeJson(state.requesterOrigin),
-    last_notified_event_at: state.lastNotifiedEventAt ?? null,
-  };
-}
-
-function getTaskRegistryKysely(db: DatabaseSync) {
-  return getNodeSqliteKysely<TaskRegistryStoreDatabase>(db);
-}
-
-function selectTaskRows(db: DatabaseSync): TaskRegistryRow[] {
-  const query = getTaskRegistryKysely(db)
-    .selectFrom("task_runs")
-    .select(TASK_RUN_SELECT_COLUMNS)
-    .orderBy("created_at", "asc")
-    .orderBy("task_id", "asc");
-  return executeSqliteQuerySync(db, query).rows;
-}
-
-function selectTaskRowsByOwnerKey(db: DatabaseSync, ownerKey: string): TaskRegistryRow[] {
-  const selectColumns = TASK_RUN_SELECT_COLUMNS.join(", ");
-  // This lookup gates duplicate media tasks. A table scan is intentional so a
-  // stale secondary index cannot hide an existing task between integrity checks.
-  return db
-    .prepare(
-      `SELECT ${selectColumns}
-       FROM task_runs NOT INDEXED
-       WHERE owner_key = ?
-       ORDER BY created_at ASC, task_id ASC`,
-    )
-    .all(ownerKey) as TaskRegistryRow[];
-}
-
-function selectTaskRowsByRuntimeSourceId(
-  db: DatabaseSync,
-  runtime: TaskRuntime,
-  sourceId?: string,
-): TaskRegistryRow[] {
-  let query = getTaskRegistryKysely(db)
-    .selectFrom("task_runs")
-    .select(TASK_RUN_SELECT_COLUMNS)
-    .where("runtime", "=", runtime);
-  if (sourceId !== undefined) {
-    query = query.where("source_id", "=", sourceId);
-  }
-  return executeSqliteQuerySync(db, query.orderBy("created_at", "asc").orderBy("task_id", "asc"))
-    .rows;
-}
-
-/** Reads task records from the caller's shared-state transaction. */
-export function listTaskRecordsByRuntimeSourceIdInDatabase(
-  db: DatabaseSync,
-  runtime: TaskRuntime,
-  sourceId: string,
-): TaskRecord[] {
-  return selectTaskRowsByRuntimeSourceId(db, runtime, sourceId).map(rowToTaskRecord);
-}
-
-export function readTaskRecord(db: DatabaseSync, taskId: string): TaskRecord | undefined {
-  const row = executeSqliteQueryTakeFirstSync(
-    db,
-    getTaskRegistryKysely(db)
-      .selectFrom("task_runs")
-      .select(TASK_RUN_SELECT_COLUMNS)
-      .where("task_id", "=", taskId),
-  );
-  return row ? rowToTaskRecord(row) : undefined;
-}
-
-function selectTaskDeliveryStateRows(db: DatabaseSync): TaskDeliveryStateRow[] {
-  const query = getTaskRegistryKysely(db)
-    .selectFrom("task_delivery_state")
-    .select(TASK_DELIVERY_STATE_SELECT_COLUMNS)
-    .orderBy("task_id", "asc");
-  return executeSqliteQuerySync(db, query).rows;
-}
-
-/** Upserts a prebound task on the exact supplied shared-state handle. */
-export function upsertTaskRunRowInDatabase(
-  database: OpenClawStateDatabase,
-  row: BoundTaskRecord,
-): void {
-  const { db } = database;
-  const updates = { ...row, task_id: undefined };
-  executeSqliteQuerySync(
-    db,
-    getTaskRegistryKysely(db)
-      .insertInto("task_runs")
-      .values(row)
-      .onConflict((conflict) => conflict.column("task_id").doUpdateSet(updates)),
-  );
-}
-
-function replaceTaskDeliveryStateRow(
-  db: DatabaseSync,
-  row: Insertable<TaskDeliveryStateTable>,
-): void {
-  executeSqliteQuerySync(
-    db,
-    getTaskRegistryKysely(db)
-      .insertInto("task_delivery_state")
-      .values(row)
-      .onConflict((conflict) =>
-        conflict.column("task_id").doUpdateSet({
-          requester_origin_json: (eb) => eb.ref("excluded.requester_origin_json"),
-          last_notified_event_at: (eb) => eb.ref("excluded.last_notified_event_at"),
-        }),
-      ),
-  );
-}
-
-function deleteTaskRowsWithDeliveryState(db: DatabaseSync, taskId: string): void {
-  const kysely = getTaskRegistryKysely(db);
-  executeSqliteQuerySync(
-    db,
-    kysely.deleteFrom("task_delivery_state").where("task_id", "=", taskId),
-  );
-  executeSqliteQuerySync(db, kysely.deleteFrom("task_runs").where("task_id", "=", taskId));
-  deleteExecutionOwnerLifecycleMetadata({ db, ownerKind: "task", ownerIds: [taskId] });
-}
 
 function openTaskRegistryDatabase(): TaskRegistryDatabase {
   const database = openOpenClawStateDatabase();
@@ -358,21 +51,6 @@ function withWriteTransaction(write: (database: OpenClawStateDatabase) => void) 
   runOpenClawStateWriteTransaction((database) => write(database));
 }
 
-function readTaskRegistrySnapshot({ db, path }: TaskRegistryDatabase): TaskRegistryStoreSnapshot {
-  return runSqliteDeferredTransactionSync(db, () => {
-    assertSqliteTableIntegrity(db, path, "task_runs");
-    assertSqliteTableIntegrity(db, path, "task_delivery_state");
-    const taskRows = selectTaskRows(db);
-    const deliveryRows = selectTaskDeliveryStateRows(db);
-    return {
-      tasks: new Map(taskRows.map((row) => [row.task_id, rowToTaskRecord(row)])),
-      deliveryStates: new Map(
-        deliveryRows.map((row) => [row.task_id, rowToTaskDeliveryState(row)]),
-      ),
-    };
-  });
-}
-
 export function loadTaskRegistryStateFromSqlite(): TaskRegistryStoreSnapshot {
   return readTaskRegistrySnapshot(openTaskRegistryDatabase());
 }
@@ -385,24 +63,9 @@ export function loadTaskRegistryStateFromSqliteReadOnly(): TaskRegistryStoreSnap
 /** Reads task state only when the existing database already has the canonical task shape. */
 export function loadTaskRegistryStateFromSqliteReadOnlyResult(): TaskRegistryReadOnlyLoadResult {
   return (
-    withExistingOpenClawStateDatabaseReadOnly(({ db, path }) => {
-      const hasReadableSchema =
-        tableExists(db, "task_runs") &&
-        tableExists(db, "task_delivery_state") &&
-        tableHasColumns(db, "task_runs", TASK_RUN_SELECT_COLUMNS) &&
-        tableHasColumns(db, "task_delivery_state", TASK_DELIVERY_STATE_SELECT_COLUMNS);
-      return hasReadableSchema
-        ? { state: "ready" as const, snapshot: readTaskRegistrySnapshot({ db, path }) }
-        : {
-            state: "migration-required" as const,
-            snapshot: { tasks: new Map(), deliveryStates: new Map() },
-          };
-    }) ?? {
+    withExistingOpenClawStateDatabaseReadOnly(readTaskRegistrySnapshotIfReady) ?? {
       state: "ready",
-      snapshot: {
-        tasks: new Map(),
-        deliveryStates: new Map(),
-      },
+      snapshot: { tasks: new Map(), deliveryStates: new Map() },
     }
   );
 }
@@ -415,7 +78,7 @@ export async function listTaskRegistryRecordsByOwnerKeyFromSqlite(
     return [];
   }
   const { db } = openTaskRegistryDatabase();
-  return selectTaskRowsByOwnerKey(db, key).map(rowToTaskRecord);
+  return listTaskRecordsByOwnerKeyInDatabase(db, key);
 }
 
 /** Reads task rows for one runtime/source without restoring the process registry snapshot. */
@@ -429,7 +92,7 @@ export function listTaskRegistryRecordsByRuntimeSourceIdFromSqlite(params: {
   }
   return (
     withExistingOpenClawStateDatabaseReadOnly(({ db }) =>
-      selectTaskRowsByRuntimeSourceId(db, params.runtime, sourceId).map(rowToTaskRecord),
+      listTaskRecordsByRuntimeSourceIdInDatabase(db, params.runtime, sourceId),
     ) ?? []
   );
 }
@@ -445,26 +108,7 @@ export function bindTaskRunExecution(params: {
     return "disabled";
   }
   return runOpenClawStateWriteTransaction(
-    ({ db }) => {
-      const kysely = getTaskRegistryKysely(db);
-      const current = executeSqliteQueryTakeFirstSync(
-        db,
-        kysely
-          .selectFrom("task_runs")
-          .select(["task_id", "status", "ended_at"])
-          .where("task_id", "=", params.taskId),
-      );
-      const status = current ? parseTaskStatus(current.status) : undefined;
-      if (!current || (status !== "queued" && status !== "running") || current.ended_at !== null) {
-        return "missing";
-      }
-      return bindExecutionOwnerLifecycleMetadata({
-        db,
-        ownerKind: "task",
-        ownerId: current.task_id,
-        binding,
-      });
-    },
+    ({ db }) => bindTaskRunExecutionInDatabase(db, params.taskId, binding),
     params.options,
     { operationLabel: "task.run.execution-binding" },
   );
@@ -474,20 +118,7 @@ export function upsertTaskWithDeliveryStateToSqlite(params: {
   task: TaskRecord;
   deliveryState?: TaskDeliveryState;
 }) {
-  withWriteTransaction((database) => {
-    const { db } = database;
-    upsertTaskRunRowInDatabase(database, bindTaskRecord(params.task));
-    if (params.deliveryState) {
-      replaceTaskDeliveryStateRow(db, bindTaskDeliveryState(params.deliveryState));
-    } else {
-      executeSqliteQuerySync(
-        db,
-        getTaskRegistryKysely(db)
-          .deleteFrom("task_delivery_state")
-          .where("task_id", "=", params.task.taskId),
-      );
-    }
-  });
+  withWriteTransaction((database) => upsertTaskWithDeliveryStateInDatabase(database, params));
 }
 
 export function deleteTaskAndDeliveryStateFromSqlite(taskId: string) {
@@ -497,9 +128,7 @@ export function deleteTaskAndDeliveryStateFromSqlite(taskId: string) {
 }
 
 export function upsertTaskDeliveryStateToSqlite(state: TaskDeliveryState) {
-  withWriteTransaction(({ db }) => {
-    replaceTaskDeliveryStateRow(db, bindTaskDeliveryState(state));
-  });
+  withWriteTransaction(({ db }) => upsertTaskDeliveryStateInDatabase(db, state));
 }
 
 export function closeTaskRegistryDatabase() {

--- a/src/tasks/task-registry.store.test.ts
+++ b/src/tasks/task-registry.store.test.ts
@@ -62,8 +62,8 @@ import {
   configureTaskRegistryRuntime,
   type TaskRegistryObserverEvent,
 } from "./task-registry.store.js";
+import { bindTaskRecord } from "./task-registry.store.kernel.js";
 import {
-  bindTaskRecord,
   bindTaskRunExecution,
   loadTaskRegistryStateFromSqlite,
   loadTaskRegistryStateFromSqliteReadOnly,

--- a/src/tasks/task-registry.types.ts
+++ b/src/tasks/task-registry.types.ts
@@ -27,6 +27,17 @@ export type TaskRuntime = (typeof TASK_RUNTIMES)[number];
 export type TaskStatus = (typeof TASK_STATUSES)[number];
 export type TaskStatusFilter = (typeof TASK_STATUS_FILTERS)[number];
 
+/** Returns whether a task status is terminal for delivery and retention policy. */
+export function isTerminalTaskStatus(status: TaskStatus): boolean {
+  return (
+    status === "succeeded" ||
+    status === "failed" ||
+    status === "timed_out" ||
+    status === "cancelled" ||
+    status === "lost"
+  );
+}
+
 export type TaskDeliveryStatus =
   | "pending"
   | "delivered"

--- a/src/tasks/task-status-access.ts
+++ b/src/tasks/task-status-access.ts
@@ -4,7 +4,6 @@ import {
   getLatestGeneratedMediaTaskAdmissionIdForSessionKey,
   listActiveGeneratedMediaTaskIdsForSessionKey,
 } from "./generated-media-task-activity.js";
-import { isTerminalTaskStatus } from "./task-executor-policy.js";
 // Filters task status visibility by requester, owner, and flow scope.
 import {
   findTaskByRunId,
@@ -14,7 +13,7 @@ import {
   listTasksForAgentId,
   listTasksForRelatedSessionKey,
 } from "./task-registry.js";
-import type { TaskRecord } from "./task-registry.types.js";
+import { isTerminalTaskStatus, type TaskRecord } from "./task-registry.types.js";
 
 const GENERATED_MEDIA_TASK_KINDS = new Set([
   "image_generation",


### PR DESCRIPTION
## What Problem This Solves

Task and flow operations that already own a shared-state transaction currently import row codecs and SQL helpers through modules that also acquire, cache, and close the global database. Task timestamp normalization additionally reaches provider/plugin runtime through a terminal-status predicate in a presentation module. These dependencies make it harder to reuse the same storage operations on an explicitly supplied connection.

## Why This Change Was Made

The existing SQL and row codecs now live in task and flow kernels that operate on their caller's connection. The existing facades retain database acquisition, cache/close behavior, write admission, and public return contracts. Subagent completion/replacement and cron recovery import the connection-bound helpers directly. Terminal-status classification moves to the existing pure task-record type module, and all internal callers follow that owner.

## User Impact

Public task/flow behavior is unchanged. This is preparation for a future common worker owner; SQL remains synchronous and no worker backend is activated. Transaction boundaries, row contents, ordering, read-only migration handling, and native execution-binding behavior are preserved. No schema, runtime configuration, or dependency changes are introduced.

## Evidence

- The 135-case baseline and 178-case final focused suites passed, including real task/flow roundtrips, native binding lifecycle behavior, cron recovery, and compound subagent rollback/recovery.
- A new cold-import contract rejects global database/read-admission and plugin-runtime imports, then exercises two real SQLite connections and compound task, delivery, flow, and binding rollback. It failed on the old presentation predicate dependency and passed after the pure-owner cutover.
- Repeated-operation observations are summarized below. Different concurrent host load limits performance conclusions; use these as a regression check.
- The complete changed-file gate, `pnpm build`, and fresh P2 review passed on the final source.
- Hosted architecture CI caught the raw-SQL exception still naming the old facade. Its existing path is moved one-for-one to the canonical kernel; the unchanged `NOT INDEXED` integrity query and exception count are preserved. The actual Kysely guard and fresh P2 review pass.
- The moved raw-row assertion now documents its canonical-schema invariant. The old facade's unused one-assertion allowance is removed as an exact shrink-only ratchet update.

Seven samples of 250 operations used 128 records. Values are milliseconds per operation, median (sample range).

| Operation | Baseline | Final |
| --- | ---: | ---: |
| Compound task/flow write + read | 1.2305 (1.1140–1.4295) | 0.9982 (0.8912–1.2471) |
| Task + delivery upsert | 1.1403 (0.7655–1.3378) | 0.8246 (0.7605–0.9109) |
| Ordered task/flow snapshots | 1.8731 (1.8341–1.9607) | 1.8356 (1.8257–1.9237) |
| Runtime/source lookup | 0.0950 (0.0865–0.1110) | 0.0924 (0.0894–0.0997) |

The one-minute load average declined from 28.2 to 14.8. These measurements do not isolate the extraction's effect on throughput. RSS was 651,904 → 364,544 KiB under the same uncontrolled-load limitation.
