### PR TITLE
refactor(tests): reuse command config runtimes

### DIFF
--- a/src/cli/command-config-resolution.test.ts
+++ b/src/cli/command-config-resolution.test.ts
@@ -1,5 +1,5 @@
-// Command config resolution tests cover config lookup before command execution.
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createTestRuntime } from "../commands/test-runtime-config-helpers.js";
 
 const mocks = vi.hoisted(() => ({
   resolveCommandSecretRefsViaGateway: vi.fn(),
@@ -22,7 +22,7 @@ describe("resolveCommandConfigWithSecrets", () => {
   });
 
   it("emits diagnostics to stderr and preserves resolved config when auto-enable is off", async () => {
-    const runtime = { log: vi.fn(), error: vi.fn(), exit: vi.fn() } as const;
+    const runtime = createTestRuntime();
     const config = { channels: {} };
     const resolvedConfig = { channels: { telegram: {} } };
     const targetIds = new Set(["channels.telegram.token"]);

--- a/src/commands/config-validation.test.ts
+++ b/src/commands/config-validation.test.ts
@@ -1,8 +1,8 @@
-// Config validation tests cover config snapshot validation and command error handling.
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { PluginCompatibilityNotice } from "../plugins/status.js";
 import { createCompatibilityNotice } from "../plugins/status.test-fixtures.js";
 import { requireValidConfig, requireValidConfigForWrite } from "./config-validation.js";
+import { createTestRuntime } from "./test-runtime-config-helpers.js";
 
 const {
   readConfigFileSnapshot,
@@ -44,26 +44,6 @@ describe("requireValidConfig", () => {
     ]);
   }
 
-  function createRuntime() {
-    return {
-      log: vi.fn(),
-      error: vi.fn(),
-      exit: vi.fn(),
-    };
-  }
-
-  function requireFirstLog(runtime: ReturnType<typeof createRuntime>): string {
-    const [call] = runtime.log.mock.calls;
-    if (!call) {
-      throw new Error("expected runtime log message");
-    }
-    const [message] = call;
-    if (message === undefined) {
-      throw new Error("expected runtime log message");
-    }
-    return String(message);
-  }
-
   it("retains native write ownership and the read-time environment after an await", async () => {
     const writeSnapshot = {
       snapshot: {
@@ -80,7 +60,7 @@ describe("requireValidConfig", () => {
       },
     };
     readConfigFileSnapshotForWrite.mockResolvedValue(writeSnapshot);
-    const result = await requireValidConfigForWrite(createRuntime());
+    const result = await requireValidConfigForWrite(createTestRuntime());
     await Promise.resolve();
     expect(result).toBe(writeSnapshot);
     expect(result?.writeOptions.envSnapshotForRestore).toEqual({ CONFIG_READ_TOKEN: "at-read" });
@@ -102,7 +82,7 @@ describe("requireValidConfig", () => {
       },
       writeOptions: { expectedConfigPath: "/tmp/owned.json" },
     });
-    const runtime = createRuntime();
+    const runtime = createTestRuntime();
     expect(await requireValidConfigForWrite(runtime)).toBeNull();
     expect(runtime.exit).toHaveBeenCalledWith(1);
     expect(runtime.error).toHaveBeenCalledWith("Fix: openclaw doctor --fix");
@@ -110,7 +90,7 @@ describe("requireValidConfig", () => {
 
   it("returns config without emitting compatibility advice by default", async () => {
     createValidSnapshot();
-    const runtime = createRuntime();
+    const runtime = createTestRuntime();
 
     const config = await requireValidConfig(runtime);
 
@@ -124,7 +104,7 @@ describe("requireValidConfig", () => {
 
   it("can validate core config without loading plugin schemas", async () => {
     createValidSnapshot();
-    const runtime = createRuntime();
+    const runtime = createTestRuntime();
 
     await expect(requireValidConfig(runtime, { skipPluginValidation: true })).resolves.toEqual({
       plugins: {},
@@ -135,7 +115,7 @@ describe("requireValidConfig", () => {
 
   it("can validate config without observing persistent health state", async () => {
     createValidSnapshot();
-    const runtime = createRuntime();
+    const runtime = createTestRuntime();
 
     await expect(requireValidConfig(runtime, { observe: false })).resolves.toEqual({
       plugins: {},
@@ -146,7 +126,7 @@ describe("requireValidConfig", () => {
 
   it("emits a non-blocking compatibility advisory when explicitly requested", async () => {
     createValidSnapshot();
-    const runtime = createRuntime();
+    const runtime = createTestRuntime();
 
     const config = await requireValidConfig(runtime, {
       includeCompatibilityAdvisory: true,
@@ -156,7 +136,7 @@ describe("requireValidConfig", () => {
     expect(readConfigFileSnapshotForWrite).not.toHaveBeenCalled();
     expect(runtime.error).not.toHaveBeenCalled();
     expect(runtime.exit).not.toHaveBeenCalled();
-    expect(requireFirstLog(runtime)).toBe(
+    expect(runtime.log.mock.calls[0]?.[0]).toBe(
       [
         "Plugin compatibility: 1 notice.",
         "- legacy-plugin is hook-only. This remains a supported compatibility path, but it has not migrated to explicit capability registration yet.",
@@ -176,7 +156,7 @@ describe("requireValidConfig", () => {
       config: {},
       issues: [{ path: "routing.allowFrom", message: "Legacy key" }],
     });
-    const runtime = createRuntime();
+    const runtime = createTestRuntime();
 
     const config = await requireValidConfig(runtime, {
       includeCompatibilityAdvisory: true,
@@ -212,7 +192,7 @@ describe("requireValidConfig", () => {
       ],
       legacyIssues: [],
     });
-    const runtime = createRuntime();
+    const runtime = createTestRuntime();
 
     const config = await requireValidConfig(runtime);
 
@@ -237,7 +217,7 @@ describe("requireValidConfig", () => {
       issues: [{ path: "gateway.mode", message: "Expected 'local' or 'remote'" }],
       legacyIssues: [],
     });
-    const runtime = createRuntime();
+    const runtime = createTestRuntime();
 
     const config = await requireValidConfig(runtime);
 

--- a/src/commands/models/load-config.test.ts
+++ b/src/commands/models/load-config.test.ts
@@ -1,5 +1,5 @@
-// Model load-config tests cover loading config used by model commands.
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createTestRuntime } from "../test-runtime-config-helpers.js";
 
 const mocks = vi.hoisted(() => ({
   getRuntimeConfig: vi.fn(),
@@ -58,7 +58,7 @@ describe("models load-config", () => {
         },
       },
     };
-    const runtime = { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
+    const runtime = createTestRuntime();
 
     mockResolvedConfigFlow({ sourceConfig, diagnostics: ["diag-one", "diag-two"] });
 


### PR DESCRIPTION
## What Problem This Solves

Three configuration-related test suites duplicate runtime mocks instead of using their existing shared helper. A local log extractor also coerces the first captured argument into a string, hiding its actual type.

## Why This Change Was Made

Reuse the canonical configuration-test runtime. Remove the one-use stringification extractor and assert the first logged argument directly against the same expected text. The production owner emits a joined string; the assertion retains first-message scope without adding call-count or arity constraints.

## User Impact

No production change. Tests are +15/-35 (net -20), with all 16 cases retained. Config ownership, read-time environment, error and exit expectations, writers, and cleanup remain covered.

## Evidence

The original paired proof passed 16 cases before and after the runtime-fixture cleanup. The final revision passes all 16 existing cases on the refreshed base, retaining the same inventory. The shared typed mock exposed a no-base-to-string lint error; the direct assertion resolves that error without a cast or suppression.

Exact typed lint and all 20 normal changed-file checks passed, including both selected core test graphs and all three dead-export scans. Independent Codex review found no actionable findings. The signed commit preserves the final tested bytes. Historical proof and the earlier download/lint failures are retained separately.
