### PR TITLE
fix(test): initialize context readers before worker launch assertions

### DIFF
--- a/src/gateway/worker-environments/worker-turn-detached-context.test.ts
+++ b/src/gateway/worker-environments/worker-turn-detached-context.test.ts
@@ -213,6 +213,8 @@ describe("worker detached model-context branch parity", () => {
       throw new Error("prior worker fixture remains unjoined; retained state must not be replaced");
     }
     await setupWorkerTurnLauncherTest();
+    // Source-worker initialization belongs to setup, outside the launch observation budget.
+    await SessionManager.openModelContextAsync(sessionTarget);
   });
   afterEach(async () => {
     if (!hasUnjoinedOwner) {

--- a/src/gateway/worker-environments/worker-turn-transcript-footprint.test.ts
+++ b/src/gateway/worker-environments/worker-turn-transcript-footprint.test.ts
@@ -85,6 +85,8 @@ describe("Gateway worker-turn selected transcript preparation", () => {
       throw new Error("Prior worker fixture remains unjoined; retained state must not be replaced");
     }
     await setupWorkerTurnLauncherTest();
+    // Source-worker initialization belongs to setup, outside the launch observation budget.
+    await SessionManager.openModelContextAsync(sessionTarget);
   });
   afterEach(async () => {
     if (!hasUnjoinedOwner) {


### PR DESCRIPTION
Related: #145591. Detected in CI for #145612.

## What Problem This Solves

Fixes intermittent worker-history test failures during cold source-worker initialization. The fixtures placed their five-second launch observation timer around initialization of the real model-context worker, which has its own existing 60-second task deadline. On a slow cold start, the observation timer aborted the reader before its module or query handler became ready, then later cases started another cold worker.

## Why This Change Was Made

Initialize the real empty model-context reader in each fixture's existing setup, before seeding the conversation and starting the launch observation. Each test still performs its fresh context read and keeps every history, payload, persistence, authority, and cleanup assertion.

The five-second observation, 60-second worker task, and existing hook deadlines are unchanged. There are no retries, sleeps, new mocks, assertion changes, or production-code changes. Initialization failures still fail setup; real cold loading, cancellation/replacement, and snapshot behavior remain covered by the existing owner suites.

## User Impact

No runtime behavior changes. CI's worker-history assertions no longer depend on cold TypeScript worker startup finishing within their unrelated launch-observation window.

## Evidence

An instrumented local reproduction on CI merge `1657840776c5f9aa95657b1650270c388963fbca` failed six asynchronous cases: each five-second observer aborted and joined its worker before module readiness or SQL handler entry. The two synchronous recorder cases passed.

With real initialization in setup, the same eight-case suite passed. The first worker took about 8.7 seconds from online to module readiness, its first SQL handler took 13 ms, and the first actual launch observation took 48 ms. This diagnoses the fixture boundary; it is not a production-latency or host-contention claim. Historical CI did not retain these stage timestamps.

All 36 uninstrumented tests passed on the current main-based candidate across the two worker fixtures, real WorkerTaskPool/source-loader suites, and SessionManager snapshot suite. Independent P0-P2 review is clean. Native changed checks and exact-head CI passed. The [Linux Testbox proof](https://github.com/openclaw/openclaw/actions/runs/34676849600) also passed all36 tests against the exact source tree, and its owned lease is completed. An initial remote preflight stopped before tests because it compared the capsule carrier commit with the source commit; the corrected check verifies source content-tree identity and tracked bytes under the native source attestation.
