### PR TITLE
refactor(voice-call): share call-history encoding and provider policy

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -1289,7 +1289,6 @@ extensions/voice-call/src/media-stream.ts	1
 extensions/voice-call/src/providers/mock.ts	7
 extensions/voice-call/src/providers/shared/guarded-json-api.ts	2
 extensions/voice-call/src/providers/shared/response-body.ts	1
-extensions/voice-call/src/providers/twilio.ts	2
 extensions/voice-call/src/providers/twilio/api.ts	3
 extensions/voice-call/src/realtime-agent-context.ts	1
 extensions/voice-call/src/response-generator.ts	3

--- a/docs/plugins/voice-call/troubleshooting.md
+++ b/docs/plugins/voice-call/troubleshooting.md
@@ -25,6 +25,9 @@ Token-bound realtime streams wait for pending call updates before matching the c
 Failed event writes remain retryable, and shutdown drains admitted call work after
 closing webhook and stream producers.
 
+If another realtime stream becomes active during admission, a failure to create
+the new bridge leaves that active call connected.
+
 ### Setup fails webhook exposure
 
 Run setup from the same environment that runs the Gateway:

--- a/extensions/voice-call/doctor-contract-api.test.ts
+++ b/extensions/voice-call/doctor-contract-api.test.ts
@@ -7,46 +7,49 @@ import { expectDefined } from "@openclaw/normalization-core";
 import {
   createPluginStateKeyedStoreForTests,
   resetPluginStateStoreForTests,
+  openOpenClawStateDatabase,
 } from "openclaw/plugin-sdk/plugin-state-test-runtime";
 import type {
   OpenKeyedStoreOptions,
   PluginDoctorStateMigrationContext,
 } from "openclaw/plugin-sdk/runtime-doctor-migrations";
-import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { resolveSessionStoreAgentIds, stateMigrations } from "./doctor-contract-api.js";
 import {
   createTestStorePath,
+  installVoiceCallStateRuntimeForTests,
   makePersistedCall,
   writeLegacyCallsJsonl,
 } from "./src/manager.test-harness.js";
-import { getCallHistoryFromStore, loadActiveCallsFromStore } from "./src/manager/store.js";
-import { setVoiceCallStateRuntime } from "./src/runtime-state.js";
+import {
+  CALL_RECORD_EVENT_CHUNKS_NAMESPACE,
+  getCallHistoryFromStore,
+  loadActiveCallsFromStore,
+} from "./src/manager/store.js";
 
-function createDoctorContext(env: NodeJS.ProcessEnv): PluginDoctorStateMigrationContext {
+function createDoctorContext(
+  env: NodeJS.ProcessEnv,
+  beforeWrite?: (namespace: string) => void,
+): PluginDoctorStateMigrationContext {
   return {
     openPluginStateKeyedStore<T>(options: OpenKeyedStoreOptions) {
-      return createPluginStateKeyedStoreForTests<T>("voice-call", {
+      const store = createPluginStateKeyedStoreForTests<T>("voice-call", {
         ...options,
         env: options.env ?? env,
       });
+      if (!beforeWrite) {
+        return store;
+      }
+      const register = store.register.bind(store);
+      return {
+        ...store,
+        async register(...args: Parameters<typeof store.register>) {
+          beforeWrite(options.namespace);
+          await register(...args);
+        },
+      };
     },
   };
-}
-
-function installStateRuntime(): void {
-  setVoiceCallStateRuntime({
-    state: {
-      resolveStateDir: () => "",
-      openKeyedStore: (options: OpenKeyedStoreOptions) =>
-        createPluginStateKeyedStoreForTests("voice-call", options),
-      openChannelIngressQueue: (() => {
-        throw new Error("openChannelIngressQueue is not used by voice-call doctor tests");
-      }) as never,
-      openChannelIngressDrain: (() => {
-        throw new Error("openChannelIngressDrain is not used by voice-call doctor tests");
-      }) as never,
-    },
-  });
 }
 
 describe("voice-call doctor state migration", () => {
@@ -71,7 +74,7 @@ describe("voice-call doctor state migration", () => {
       OPENCLAW_STATE_DIR: warmStateDir,
     };
     try {
-      installStateRuntime();
+      installVoiceCallStateRuntimeForTests();
       const calls = Array.from({ length: 1002 }, (_, index) =>
         makePersistedCall({
           callId: `call-${index}`,
@@ -119,7 +122,7 @@ describe("voice-call doctor state migration", () => {
     stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-voice-call-doctor-"));
     storePath = createTestStorePath();
     env = { ...process.env, HOME: stateDir, OPENCLAW_STATE_DIR: stateDir };
-    installStateRuntime();
+    installVoiceCallStateRuntimeForTests();
   });
 
   afterEach(async () => {
@@ -379,6 +382,67 @@ describe("voice-call doctor state migration", () => {
     expect(overCapacityMigration.historyCallIds[0]).toBe("call-2");
     expect(overCapacityMigration.historyCallIds.at(-1)).toBe("call-1001");
   });
+
+  it.each([1, 2])(
+    "retains the source and written prefix after chunk write %s fails",
+    async (failedWrite) => {
+      const call = makePersistedCall({
+        callId: "call-write-failure",
+        transcript: [{ timestamp: 1, speaker: "user", text: "x".repeat(100_000), isFinal: true }],
+      });
+      writeLegacyCallsJsonl(storePath, [call]);
+      const failure = new Error("chunk write failed");
+      let writes = 0;
+      const beforeWrite = vi.fn((_namespace: string) => {
+        if (++writes === failedWrite) {
+          throw failure;
+        }
+      });
+      const params = {
+        config: { plugins: { entries: { "voice-call": { config: { store: storePath } } } } },
+        env,
+        stateDir,
+        oauthDir: path.join(stateDir, "oauth"),
+        context: createDoctorContext(env, beforeWrite),
+      };
+      const migration = expectDefined(stateMigrations[0], "voice-call state migration");
+      const result = await migration.migrateLegacyState(params);
+      expect(result).toEqual({
+        changes: [],
+        warnings: [
+          "Failed migrating Voice Call call-log line 1: Error: chunk write failed",
+          "Left Voice Call call-log source in place because migration was incomplete",
+        ],
+      });
+      expect(beforeWrite.mock.calls).toEqual(
+        Array.from({ length: failedWrite }, () => [CALL_RECORD_EVENT_CHUNKS_NAMESPACE]),
+      );
+      await fs.access(path.join(storePath, "calls.jsonl"));
+      await expect(fs.access(path.join(storePath, "calls.jsonl.migrated"))).rejects.toThrow();
+      const { db } = openOpenClawStateDatabase({ env: { OPENCLAW_STATE_DIR: storePath } });
+      expect(
+        db
+          .prepare(
+            "SELECT namespace, json_extract(value_json, '$.index') AS chunk_index FROM plugin_state_entries WHERE plugin_id = ? ORDER BY entry_key",
+          )
+          .all("voice-call"),
+      ).toEqual(
+        Array.from({ length: failedWrite - 1 }, (_, index) => ({
+          namespace: CALL_RECORD_EVENT_CHUNKS_NAMESPACE,
+          chunk_index: index,
+        })),
+      );
+      resetPluginStateStoreForTests();
+      await expect(getCallHistoryFromStore(storePath)).resolves.toEqual([]);
+      const retried = await migration.migrateLegacyState({
+        ...params,
+        context: createDoctorContext(env),
+      });
+      expect(retried.warnings).toEqual([]);
+      await fs.access(path.join(storePath, "calls.jsonl.migrated"));
+      await expect(getCallHistoryFromStore(storePath)).resolves.toEqual([call]);
+    },
+  );
 
   it("leaves malformed mixed legacy logs in place after importing valid records", async () => {
     const sourcePath = path.join(storePath, "calls.jsonl");

--- a/extensions/voice-call/doctor-contract-api.ts
+++ b/extensions/voice-call/doctor-contract-api.ts
@@ -14,36 +14,22 @@ import {
 } from "openclaw/plugin-sdk/runtime-doctor-migrations";
 import { asOptionalRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import {
+  buildChunkKey,
   buildVoiceCallLegacyJsonlEventKey,
+  encodeCallRecordEvent,
+  type CallRecordEventChunk,
+  type CallRecordEventMeta,
   CALL_RECORD_CHUNK_MAX_ENTRIES,
   CALL_RECORD_EVENT_CHUNKS_NAMESPACE,
   CALL_RECORD_EVENT_META_MAX_ENTRIES,
   CALL_RECORD_EVENTS_NAMESPACE,
   MAX_CALL_RECORD_EVENTS,
-  MAX_CHUNKS_PER_CALL_RECORD_EVENT,
-  prepareVoiceCallRecordForStorage,
   parseVoiceCallRecordLine,
-  RAW_CALL_RECORD_CHUNK_BYTES,
   resolveVoiceCallLegacyCallLogPath,
 } from "./src/manager/store.js";
 import { resolveDefaultVoiceCallStoreDir } from "./src/store-path.js";
-import type { CallRecord } from "./src/types.js";
 
 // Doctor state migration for Voice Call legacy JSONL call logs.
-
-/** Plugin state metadata row for one migrated call record event. */
-type CallRecordEventMeta = {
-  chunkCount: number;
-  byteLength: number;
-  persistedAt?: number;
-  sequence?: number;
-};
-
-/** Plugin state chunk row for one migrated call record event. */
-type CallRecordEventChunk = {
-  index: number;
-  dataBase64: string;
-};
 
 /** Prepared legacy JSONL call record ready for plugin state import. */
 type PreparedLegacyCallRecord = {
@@ -172,41 +158,6 @@ function describeVoiceCallSchemaMigration(migration: OpenClawStateDatabaseSchema
   return migration.kind satisfies never;
 }
 
-/** Build the plugin state key for one migrated event chunk. */
-function buildChunkKey(eventKey: string, index: number): string {
-  return `${eventKey}:chunk:${String(index).padStart(4, "0")}`;
-}
-
-/** Chunk a prepared call record into bounded plugin state rows. */
-function prepareChunks(call: CallRecord): {
-  chunks: CallRecordEventChunk[];
-  meta: CallRecordEventMeta;
-} {
-  const serialized = JSON.stringify(prepareVoiceCallRecordForStorage(call));
-  const buffer = Buffer.from(serialized, "utf8");
-  const chunkCount = Math.max(1, Math.ceil(buffer.byteLength / RAW_CALL_RECORD_CHUNK_BYTES));
-  if (chunkCount > MAX_CHUNKS_PER_CALL_RECORD_EVENT) {
-    throw new Error(
-      `voice-call record exceeds SQLite chunk limit (${chunkCount}/${MAX_CHUNKS_PER_CALL_RECORD_EVENT})`,
-    );
-  }
-  const chunks: CallRecordEventChunk[] = [];
-  for (let index = 0; index < chunkCount; index += 1) {
-    const chunk = buffer.subarray(
-      index * RAW_CALL_RECORD_CHUNK_BYTES,
-      (index + 1) * RAW_CALL_RECORD_CHUNK_BYTES,
-    );
-    chunks.push({ index, dataBase64: chunk.toString("base64") });
-  }
-  return {
-    chunks,
-    meta: {
-      chunkCount,
-      byteLength: buffer.byteLength,
-    },
-  };
-}
-
 /** Read and prepare legacy JSONL call records, collecting line-level warnings. */
 async function readLegacyCallRecords(filePath: string): Promise<{
   entries: PreparedLegacyCallRecord[];
@@ -231,11 +182,14 @@ async function readLegacyCallRecords(filePath: string): Promise<{
       continue;
     }
     try {
-      const prepared = prepareChunks(parsed.call);
+      const prepared = encodeCallRecordEvent(parsed.call);
+      const chunks = Array.from({ length: prepared.meta.chunkCount }, (_, chunkIndex) =>
+        prepared.chunk(chunkIndex),
+      );
       entries.push({
         eventKey: buildVoiceCallLegacyJsonlEventKey(line, index),
         lineNumber: index + 1,
-        chunks: prepared.chunks,
+        chunks,
         meta: {
           ...prepared.meta,
           persistedAt: parsed.persistedAt,

--- a/extensions/voice-call/src/manager.test-harness.ts
+++ b/extensions/voice-call/src/manager.test-harness.ts
@@ -87,7 +87,7 @@ export function createTestStorePath(): string {
   return fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-voice-call-test-"));
 }
 
-function createVoiceCallStateRuntimeForTests(): VoiceCallStateRuntime["state"] {
+export function createVoiceCallStateRuntimeForTests(): VoiceCallStateRuntime["state"] {
   return {
     resolveStateDir: () => "",
     openKeyedStore: <T>(options: OpenKeyedStoreOptions) =>
@@ -101,7 +101,7 @@ function createVoiceCallStateRuntimeForTests(): VoiceCallStateRuntime["state"] {
   };
 }
 
-function installVoiceCallStateRuntimeForTests(): void {
+export function installVoiceCallStateRuntimeForTests(): void {
   setVoiceCallStateRuntime({ state: createVoiceCallStateRuntimeForTests() });
 }
 

--- a/extensions/voice-call/src/manager/store.test.ts
+++ b/extensions/voice-call/src/manager/store.test.ts
@@ -14,6 +14,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { registerVoiceCallLogs } from "../cli-call-log.js";
 import {
   createTestStorePath,
+  createVoiceCallStateRuntimeForTests,
   makePersistedCall,
   writeLegacyCallsJsonl,
 } from "../manager.test-harness.js";
@@ -49,11 +50,12 @@ function installStateRuntime({
     key?: string,
   ) => Promise<void>;
 } = {}): void {
+  const state = createVoiceCallStateRuntimeForTests();
   setVoiceCallStateRuntime({
     state: {
-      resolveStateDir: () => "",
+      ...state,
       openKeyedStore: <T>(options: OpenKeyedStoreOptions) => {
-        const backingStore = createPluginStateKeyedStoreForTests<T>("voice-call", options);
+        const backingStore = state.openKeyedStore<T>(options);
         const store = beforeOperation
           ? {
               ...backingStore,
@@ -73,12 +75,6 @@ function installStateRuntime({
         const { lookupMany: _lookupMany, ...legacy } = store;
         return legacy;
       },
-      openChannelIngressQueue: (() => {
-        throw new Error("openChannelIngressQueue is not used by voice-call store tests");
-      }) as never,
-      openChannelIngressDrain: (() => {
-        throw new Error("openChannelIngressDrain is not used by voice-call store tests");
-      }) as never,
     },
   });
 }
@@ -172,16 +168,10 @@ describe("voice-call call record store", () => {
     writeLegacyCallsJsonl(storePath, [call]);
     setVoiceCallStateRuntime({
       state: {
-        resolveStateDir: () => "",
-        openKeyedStore: (() => {
+        ...createVoiceCallStateRuntimeForTests(),
+        openKeyedStore: () => {
           throw new Error("sqlite unavailable");
-        }) as never,
-        openChannelIngressQueue: (() => {
-          throw new Error("openChannelIngressQueue is not used by voice-call store tests");
-        }) as never,
-        openChannelIngressDrain: (() => {
-          throw new Error("openChannelIngressDrain is not used by voice-call store tests");
-        }) as never,
+        },
       },
     });
 
@@ -242,6 +232,62 @@ describe("voice-call call record store", () => {
       await expect(findCallInStore(storePath, good.callId)).rejects.toThrowError(
         expect.objectContaining({ code: "PLUGIN_STATE_CORRUPT" }),
       );
+    },
+  );
+
+  it.each([1, 2])(
+    "stops at failed chunk write %s without publishing metadata",
+    async (failedWrite) => {
+      const call = CallRecordSchema.parse(
+        makePersistedCall({
+          transcript: [{ timestamp: 1, speaker: "user", text: "x".repeat(100_000), isFinal: true }],
+        }),
+      );
+      const failure = new Error("chunk write failed");
+      let writes = 0;
+      const beforeWrite = vi.fn((_namespace: string) => {
+        if (++writes === failedWrite) {
+          throw failure;
+        }
+      });
+      installStateRuntime({
+        beforeOperation: async (namespace, operation) => {
+          if (operation === "register") {
+            beforeWrite(namespace);
+          }
+        },
+      });
+      const storePath = createTestStorePath();
+      const toString = vi.spyOn(Buffer.prototype, "toString");
+      try {
+        await expect(persistCallRecord(storePath, call)).rejects.toBe(failure);
+        expect(beforeWrite.mock.calls).toEqual(
+          Array.from({ length: failedWrite }, () => [CALL_RECORD_EVENT_CHUNKS_NAMESPACE]),
+        );
+        expect(toString.mock.calls.filter(([encoding]) => encoding === "base64")).toHaveLength(
+          failedWrite,
+        );
+        toString.mockRestore();
+        const { db } = openOpenClawStateDatabase({ env: { OPENCLAW_STATE_DIR: storePath } });
+        expect(
+          db
+            .prepare(
+              "SELECT namespace, json_extract(value_json, '$.index') AS chunk_index FROM plugin_state_entries WHERE plugin_id = ? ORDER BY entry_key",
+            )
+            .all("voice-call"),
+        ).toEqual(
+          Array.from({ length: failedWrite - 1 }, (_, index) => ({
+            namespace: CALL_RECORD_EVENT_CHUNKS_NAMESPACE,
+            chunk_index: index,
+          })),
+        );
+        resetPluginStateStoreForTests();
+        expect((await loadActiveCallsFromStore(storePath)).activeCalls.size).toBe(0);
+      } finally {
+        toString.mockRestore();
+        resetPluginStateStoreForTests();
+        fs.rmSync(storePath, { recursive: true, force: true });
+      }
     },
   );
 

--- a/extensions/voice-call/src/manager/store.ts
+++ b/extensions/voice-call/src/manager/store.ts
@@ -21,15 +21,15 @@ export const MAX_CALL_RECORD_EVENTS = 1000;
 /** Extra metadata entries retained so pruning can safely trim oldest rows. */
 export const CALL_RECORD_EVENT_META_MAX_ENTRIES = MAX_CALL_RECORD_EVENTS + 100;
 /** Maximum chunks allowed for one persisted call record event. */
-export const MAX_CHUNKS_PER_CALL_RECORD_EVENT = 48;
+const MAX_CHUNKS_PER_CALL_RECORD_EVENT = 48;
 export const CALL_RECORD_CHUNK_MAX_ENTRIES =
   MAX_CALL_RECORD_EVENTS * MAX_CHUNKS_PER_CALL_RECORD_EVENT + MAX_CHUNKS_PER_CALL_RECORD_EVENT;
 /** Raw UTF-8 bytes stored per call record chunk before base64 encoding. */
-export const RAW_CALL_RECORD_CHUNK_BYTES = 47 * 1024;
+const RAW_CALL_RECORD_CHUNK_BYTES = 47 * 1024;
 let callRecordEventSequence = 0;
 
 /** Metadata row for a chunked call record event. */
-type CallRecordEventMeta = {
+export type CallRecordEventMeta = {
   chunkCount: number;
   byteLength: number;
   persistedAt?: number;
@@ -37,7 +37,7 @@ type CallRecordEventMeta = {
 };
 
 /** One base64 chunk for a serialized call record event. */
-type CallRecordEventChunk = {
+export type CallRecordEventChunk = {
   index: number;
   dataBase64: string;
 };
@@ -98,7 +98,7 @@ function tryCreateCallRecordStateStores(storePath: string): CallRecordStateStore
 }
 
 /** Build the stable storage key for one chunk of an event. */
-function buildChunkKey(eventKey: string, index: number): string {
+export function buildChunkKey(eventKey: string, index: number): string {
   return `${eventKey}:chunk:${String(index).padStart(4, "0")}`;
 }
 
@@ -173,7 +173,7 @@ function countCallRecordChunks(call: CallRecord): number {
 }
 
 /** Truncate oversized call records to fit the bounded plugin state chunk budget. */
-export function prepareVoiceCallRecordForStorage(call: CallRecord): CallRecord {
+function prepareVoiceCallRecordForStorage(call: CallRecord): CallRecord {
   let boundedCall = call;
   if (call.processedEventIds.length > MAX_CALL_REPLAY_KEYS) {
     boundedCall = {
@@ -219,14 +219,8 @@ export function prepareVoiceCallRecordForStorage(call: CallRecord): CallRecord {
   return boundedCall;
 }
 
-/** Register a serialized call record event and its chunks, then prune old events. */
-async function registerCallRecordEvent(
-  stores: CallRecordStateStores,
-  eventKey: string,
-  call: CallRecord,
-  order: { persistedAt: number; sequence: number },
-): Promise<void> {
-  // Capture the snapshot before chunk writes yield to later call mutations.
+/** Encode one bounded record; chunks are produced only when requested by the writer. */
+export function encodeCallRecordEvent(call: CallRecord) {
   const serialized = JSON.stringify(prepareVoiceCallRecordForStorage(call));
   const buffer = Buffer.from(serialized, "utf8");
   const chunkCount = Math.max(1, Math.ceil(buffer.byteLength / RAW_CALL_RECORD_CHUNK_BYTES));
@@ -235,19 +229,32 @@ async function registerCallRecordEvent(
       `voice-call record exceeds SQLite chunk limit (${chunkCount}/${MAX_CHUNKS_PER_CALL_RECORD_EVENT})`,
     );
   }
-  for (let index = 0; index < chunkCount; index += 1) {
-    const chunk = buffer.subarray(
-      index * RAW_CALL_RECORD_CHUNK_BYTES,
-      (index + 1) * RAW_CALL_RECORD_CHUNK_BYTES,
-    );
-    await stores.chunks.register(buildChunkKey(eventKey, index), {
-      index,
-      dataBase64: chunk.toString("base64"),
-    });
+  return {
+    meta: { chunkCount, byteLength: buffer.byteLength },
+    chunk(index: number): CallRecordEventChunk {
+      const chunk = buffer.subarray(
+        index * RAW_CALL_RECORD_CHUNK_BYTES,
+        (index + 1) * RAW_CALL_RECORD_CHUNK_BYTES,
+      );
+      return { index, dataBase64: chunk.toString("base64") };
+    },
+  };
+}
+
+/** Register a serialized call record event and its chunks, then prune old events. */
+async function registerCallRecordEvent(
+  stores: CallRecordStateStores,
+  eventKey: string,
+  call: CallRecord,
+  order: { persistedAt: number; sequence: number },
+): Promise<void> {
+  // Capture the snapshot before chunk writes yield to later call mutations.
+  const encoded = encodeCallRecordEvent(call);
+  for (let index = 0; index < encoded.meta.chunkCount; index += 1) {
+    await stores.chunks.register(buildChunkKey(eventKey, index), encoded.chunk(index));
   }
   await stores.events.register(eventKey, {
-    chunkCount,
-    byteLength: buffer.byteLength,
+    ...encoded.meta,
     persistedAt: order.persistedAt,
     sequence: order.sequence,
   });

--- a/extensions/voice-call/src/providers/twilio.media-stream.test.ts
+++ b/extensions/voice-call/src/providers/twilio.media-stream.test.ts
@@ -1,0 +1,436 @@
+import { expectDefined } from "openclaw/plugin-sdk/expect-runtime";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
+import { rawDataToString } from "openclaw/plugin-sdk/webhook-ingress";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { guardedJsonApiRequestMock } = vi.hoisted(() => ({
+  guardedJsonApiRequestMock: vi.fn(),
+}));
+
+vi.mock("./shared/guarded-json-api.js", () => ({
+  guardedJsonApiRequest: guardedJsonApiRequestMock,
+}));
+
+import { MediaStreamHandler } from "../media-stream.js";
+import { createTelephonyTtsProvider, type TelephonyTtsRuntime } from "../telephony-tts.js";
+import { connectWs, startUpgradeWsServer, withTimeout } from "../websocket-test-support.js";
+import { WebSocket } from "../websocket.js";
+import { TwilioProvider } from "./twilio.js";
+
+beforeEach(() => {
+  vi.useRealTimers();
+  guardedJsonApiRequestMock.mockReset();
+});
+
+function createStreamSendResult(sent = true): ReturnType<MediaStreamHandler["sendAudio"]> {
+  return { sent, bufferedBeforeBytes: 0, bufferedAfterBytes: 0 };
+}
+
+function createProvider(): TwilioProvider {
+  return new TwilioProvider(
+    { accountSid: "AC123", authToken: "secret" },
+    { publicUrl: "https://example.ngrok.app", streamPath: "/voice/stream" },
+  );
+}
+
+type StreamFrame =
+  | { event: "media"; streamSid: string; media: { payload: string } }
+  | { event: "mark"; streamSid: string; mark: { name: string } }
+  | { event: "clear"; streamSid: string };
+
+async function withStreamingProvider(
+  run: (fixture: {
+    provider: TwilioProvider;
+    messages: StreamFrame[];
+    beforeSend: ReturnType<typeof vi.fn<(frame: StreamFrame) => void>>;
+    synthesize: ReturnType<typeof vi.fn<TelephonyTtsRuntime["textToSpeechTelephony"]>>;
+    result: Awaited<ReturnType<TelephonyTtsRuntime["textToSpeechTelephony"]>>;
+    play: (text: string) => Promise<void>;
+    marks: () => Array<Extract<StreamFrame, { event: "mark" }>>;
+    speech: () => Buffer[];
+    acknowledge: (index: number) => void;
+  }) => Promise<void>,
+): Promise<void> {
+  const provider = createProvider();
+  const connected = createDeferred<void>();
+  const messages: StreamFrame[] = [];
+  const playbacks: Promise<void>[] = [];
+  const beforeSend = vi.fn<(frame: StreamFrame) => void>();
+  const result = {
+    success: true,
+    audioBuffer: Buffer.alloc(1_920, Buffer.from([0xe8, 0x03])),
+    sampleRate: 24_000,
+    outputFormat: "pcm",
+  };
+  const synthesize = vi.fn<TelephonyTtsRuntime["textToSpeechTelephony"]>(async () => result);
+  provider.setTTSProvider(
+    await createTelephonyTtsProvider({
+      coreConfig: {},
+      runtime: {
+        prepareTtsRequest: async ({ cfg, text }) => ({
+          cfg,
+          directives: { cleanedText: text, hasDirective: false, overrides: {}, warnings: [] },
+        }),
+        textToSpeechTelephony: synthesize,
+      },
+    }),
+  );
+  const handler = new MediaStreamHandler({
+    transcriptionProvider: {
+      id: "fixture",
+      label: "Fixture",
+      isConfigured: () => true,
+      createSession: () => ({
+        connect: async () => {},
+        sendAudio: () => {},
+        close: () => {},
+        isConnected: () => true,
+      }),
+    },
+    providerConfig: {},
+    shouldAcceptStream: ({ callId, streamSid }) =>
+      callId === "CA-stream" && streamSid === "MZ-stream",
+    onConnect: (callId, streamSid) => provider.registerCallStream(callId, streamSid),
+    onTranscriptionReady: () => connected.resolve(),
+  });
+  provider.setMediaStreamHandler(handler);
+  guardedJsonApiRequestMock.mockImplementation(() => {
+    throw new Error("Unexpected Twilio REST request during stream playback");
+  });
+  const server = await startUpgradeWsServer({
+    urlPath: "/voice/stream",
+    onUpgrade: (request, socket, head) => handler.handleUpgrade(request, socket, head),
+  });
+  let peer: WebSocket | undefined;
+  try {
+    const client = await connectWs(server.url);
+    peer = client;
+    client.on("message", (data) => {
+      messages.push(JSON.parse(rawDataToString(data)) as StreamFrame);
+    });
+    client.send(
+      JSON.stringify({ event: "start", streamSid: "MZ-stream", start: { callSid: "CA-stream" } }),
+    );
+    await withTimeout(connected.promise);
+    const discovery = vi.spyOn(WebSocket.prototype, "send");
+    let serverSocket: WebSocket;
+    try {
+      expect(handler.sendMark("MZ-stream", "fixture-ready").sent).toBe(true);
+      const receiver = discovery.mock.contexts[0];
+      if (!(receiver instanceof WebSocket)) {
+        throw new Error("Expected the stream's WebSocket receiver");
+      }
+      serverSocket = receiver;
+      await vi.waitFor(() => expect(messages).toHaveLength(1));
+      expect(messages.shift()).toEqual({
+        event: "mark",
+        streamSid: "MZ-stream",
+        mark: { name: "fixture-ready" },
+      });
+    } finally {
+      discovery.mockRestore();
+    }
+    const originalSend = serverSocket.send.bind(serverSocket);
+    const send = vi.spyOn(serverSocket, "send").mockImplementation((...args) => {
+      const data = args[0];
+      if (typeof data !== "string" && !Buffer.isBuffer(data) && !(data instanceof ArrayBuffer)) {
+        throw new Error("Expected a JSON text or byte frame from the media handler");
+      }
+      beforeSend(
+        JSON.parse(typeof data === "string" ? data : rawDataToString(data)) as StreamFrame,
+      );
+      originalSend(...args);
+    });
+    const marks = () => messages.filter((frame) => frame.event === "mark");
+    try {
+      await run({
+        provider,
+        messages,
+        beforeSend,
+        synthesize,
+        result,
+        play: (text) => {
+          const playback = provider.playTts({
+            callId: "call-stream",
+            providerCallId: "CA-stream",
+            text,
+          });
+          playbacks.push(playback);
+          return playback;
+        },
+        marks,
+        speech: () =>
+          messages.flatMap((frame) => {
+            if (frame.event !== "media") {
+              return [];
+            }
+            const audio = Buffer.from(frame.media.payload, "base64");
+            return audio.every((byte) => byte === 0xff) ? [] : [audio];
+          }),
+        acknowledge: (index) =>
+          client.send(JSON.stringify(expectDefined(marks()[index], "playback mark"))),
+      });
+      expect(guardedJsonApiRequestMock).not.toHaveBeenCalled();
+    } finally {
+      send.mockRestore();
+    }
+  } finally {
+    provider.clearTtsQueue("CA-stream", "test cleanup");
+    peer?.terminate();
+    await handler.close();
+    await Promise.allSettled(playbacks);
+    await server.close();
+  }
+}
+
+describe("TwilioProvider", () => {
+  it("times out telephony synthesis in stream mode and does not send completion mark", async () => {
+    vi.useFakeTimers();
+    try {
+      const provider = createProvider();
+      provider.registerCallStream("CA-timeout", "MZ-timeout");
+
+      const sendAudio = vi.fn<MediaStreamHandler["sendAudio"]>(() => createStreamSendResult());
+      const sendMarkAndWait = vi.fn();
+      const mediaStreamHandler = {
+        queueTts: async (
+          _streamSid: string,
+          playFn: (signal: AbortSignal) => Promise<void>,
+        ): Promise<void> => {
+          await playFn(new AbortController().signal);
+        },
+        sendAudio,
+        sendMarkAndWait,
+        clearAudio: vi.fn(),
+      };
+
+      provider.setMediaStreamHandler(mediaStreamHandler as never);
+      provider.setTTSProvider({
+        synthesisTimeoutMs: 5000,
+        synthesizeForTelephony: async () => await new Promise<Buffer>(() => {}),
+      });
+
+      const playExpectation = expect(
+        provider.playTts({
+          callId: "call-timeout",
+          providerCallId: "CA-timeout",
+          text: "Timeout me",
+        }),
+      ).rejects.toThrow("Telephony TTS synthesis timed out after 5000ms");
+      await vi.advanceTimersByTimeAsync(5_100);
+      await playExpectation;
+      expect(sendAudio).toHaveBeenCalled();
+      expect(sendMarkAndWait).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("stops and clears real stream playback on the first failed audio chunk", async () => {
+    await withStreamingProvider(async (f) => {
+      f.synthesize.mockResolvedValueOnce({
+        ...f.result,
+        audioBuffer: Buffer.alloc(2_880, Buffer.from([0xe8, 0x03])),
+      });
+      const order: string[] = [];
+      let speechAttempts = 0;
+      f.beforeSend.mockImplementation((frame) => {
+        if (frame.event === "media" && Buffer.from(frame.media.payload, "base64")[0] === 0xce) {
+          speechAttempts += 1;
+          order.push(`speech-${speechAttempts}`);
+          if (speechAttempts === 2) {
+            throw new Error("synthetic socket send failure");
+          }
+        } else if (frame.event === "clear") {
+          order.push("clear");
+        }
+      });
+      const playback = f.play("Dropped audio").catch((error: unknown) => {
+        order.push("error");
+        throw error;
+      });
+      await expect(withTimeout(playback)).rejects.toThrow("audio chunk 2 not delivered");
+      await vi.waitFor(() => {
+        expect(f.messages.some((frame) => frame.event === "clear")).toBe(true);
+      });
+      expect(order).toEqual(["speech-1", "speech-2", "clear", "error"]);
+      expect(f.speech()).toEqual([Buffer.alloc(160, 0xce)]);
+      expect(f.marks()).toEqual([]);
+      expect(f.beforeSend.mock.calls.some(([frame]) => frame.event === "mark")).toBe(false);
+    });
+  });
+
+  it("fails stream playback when telephony synthesis returns empty audio", async () => {
+    await withStreamingProvider(async (f) => {
+      f.synthesize.mockResolvedValueOnce({ ...f.result, audioBuffer: Buffer.alloc(0) });
+      await expect(withTimeout(f.play("Empty audio"))).rejects.toThrow(
+        "Telephony TTS produced no audio",
+      );
+      expect(f.beforeSend).toHaveBeenCalled();
+      expect(f.beforeSend.mock.calls.some(([frame]) => frame.event === "mark")).toBe(false);
+    });
+  });
+
+  it("exits chunk pacing early when the abort signal fires after the first chunk", async () => {
+    vi.useFakeTimers();
+    try {
+      const provider = createProvider();
+      provider.registerCallStream("CA-abort-chunk", "MZ-abort-chunk");
+
+      const sendMarkAndWait = vi.fn(async () => {});
+      const controller = new AbortController();
+      const sendAudio = vi.fn<MediaStreamHandler["sendAudio"]>(() => {
+        // The first send is the synthesis keepalive; the second is the first real audio chunk.
+        if (sendAudio.mock.calls.length === 2) {
+          controller.abort();
+        }
+        return createStreamSendResult();
+      });
+
+      const mediaStreamHandler = {
+        queueTts: async (
+          _streamSid: string,
+          playFn: (signal: AbortSignal) => Promise<void>,
+        ): Promise<void> => {
+          await playFn(controller.signal);
+        },
+        sendAudio,
+        sendMarkAndWait,
+        clearAudio: vi.fn(),
+      };
+
+      provider.setMediaStreamHandler(mediaStreamHandler as never);
+      provider.setTTSProvider({
+        synthesisTimeoutMs: 5000,
+        synthesizeForTelephony: async () => Buffer.alloc(160 * 10, 0x80),
+      });
+
+      const startedAt = Date.now();
+      await expect(
+        provider.playTts({
+          callId: "call-abort-chunk",
+          providerCallId: "CA-abort-chunk",
+          text: "hello",
+          voice: "default",
+          locale: "en-US",
+        }),
+      ).resolves.toBeUndefined();
+
+      expect(Date.now()).toBe(startedAt);
+      expect(sendAudio).toHaveBeenCalledTimes(2);
+      expect(sendMarkAndWait).not.toHaveBeenCalled();
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("streams exact PCM output and gates the real queue on echoed playback marks", async () => {
+    await withStreamingProvider(async (f) => {
+      const synthesis = createDeferred<void>();
+      f.synthesize.mockImplementationOnce(async () => {
+        await synthesis.promise;
+        return f.result;
+      });
+      let completed = false;
+      const first = f.play("first").then(() => {
+        completed = true;
+      });
+      const second = f.play("second");
+      try {
+        await vi.waitFor(() => expect(f.messages.length).toBeGreaterThanOrEqual(2));
+        for (const frame of f.messages) {
+          expect(frame).toEqual({
+            event: "media",
+            streamSid: "MZ-stream",
+            media: { payload: Buffer.alloc(160, 0xff).toString("base64") },
+          });
+        }
+        synthesis.resolve();
+        await vi.waitFor(() => expect(f.marks()).toHaveLength(1));
+        expect(f.speech()).toEqual([Buffer.alloc(160, 0xce), Buffer.alloc(160, 0xce)]);
+        expect(completed).toBe(false);
+        expect(f.synthesize).toHaveBeenCalledTimes(1);
+        f.acknowledge(0);
+        await withTimeout(first);
+        expect(completed).toBe(true);
+        await vi.waitFor(() => expect(f.marks()).toHaveLength(2));
+        expect(f.marks()[1]?.mark.name).not.toBe(f.marks()[0]?.mark.name);
+        expect(f.synthesize.mock.calls.map(([request]) => request.text)).toEqual([
+          "first",
+          "second",
+        ]);
+        f.acknowledge(1);
+        await withTimeout(second);
+        expect(Buffer.concat(f.speech())).toEqual(Buffer.alloc(640, 0xce));
+      } finally {
+        synthesis.resolve();
+        f.provider.clearTtsQueue("CA-stream", "test cleanup");
+        await Promise.allSettled([first, second]);
+      }
+    });
+  });
+
+  it.each([false, true])(
+    "preserves synthesis outcome after a failed keepalive (rejects=%s)",
+    async (rejects) => {
+      await withStreamingProvider(async (f) => {
+        f.beforeSend.mockImplementationOnce(() => {
+          throw new Error("keepalive socket failure");
+        });
+        const synthesisError = new Error("synthesis failure");
+        if (rejects) {
+          f.synthesize.mockRejectedValueOnce(synthesisError);
+        }
+        const playback = f.play("keepalive");
+        if (rejects) {
+          await expect(withTimeout(playback)).rejects.toBe(synthesisError);
+          expect(f.marks()).toEqual([]);
+        } else {
+          await vi.waitFor(() => expect(f.marks()).toHaveLength(1));
+          expect(Buffer.concat(f.speech())).toEqual(Buffer.alloc(320, 0xce));
+          f.acknowledge(0);
+          await withTimeout(playback);
+        }
+        expect(f.beforeSend.mock.calls[0]?.[0]).toEqual({
+          event: "media",
+          streamSid: "MZ-stream",
+          media: { payload: Buffer.alloc(160, 0xff).toString("base64") },
+        });
+      });
+    },
+  );
+
+  it("cancels active and queued synthesis and recovers through the real stream queue", async () => {
+    await withStreamingProvider(async (f) => {
+      const lateSynthesis = createDeferred<void>();
+      f.synthesize.mockImplementationOnce(async () => {
+        await lateSynthesis.promise;
+        return { ...f.result, audioBuffer: Buffer.alloc(1_920, Buffer.from([0x18, 0xfc])) };
+      });
+      const cancelled = f.play("cancel me");
+      const queued = f.play("discard me");
+      try {
+        await vi.waitFor(() => expect(f.synthesize).toHaveBeenCalledTimes(1));
+        f.provider.clearTtsQueue("CA-stream", "barge-in");
+        await withTimeout(Promise.all([cancelled, queued]));
+        expect(f.speech()).toEqual([]);
+        expect(f.marks()).toEqual([]);
+        const next = f.play("play next");
+        lateSynthesis.resolve();
+        await vi.waitFor(() => expect(f.marks()).toHaveLength(1));
+        expect(f.synthesize.mock.calls.map(([request]) => request.text)).toEqual([
+          "cancel me",
+          "play next",
+        ]);
+        expect(f.speech()).toEqual([Buffer.alloc(160, 0xce), Buffer.alloc(160, 0xce)]);
+        f.acknowledge(0);
+        await withTimeout(next);
+      } finally {
+        lateSynthesis.resolve();
+        f.provider.clearTtsQueue("CA-stream", "test cleanup");
+        await Promise.allSettled([cancelled, queued]);
+      }
+    });
+  });
+});

--- a/extensions/voice-call/src/providers/twilio.test.ts
+++ b/extensions/voice-call/src/providers/twilio.test.ts
@@ -34,7 +34,6 @@ type TwilioPrivateCallState = {
   callStreamMap: Map<string, string>;
   streamAuthTokens: Map<string, string>;
   twimlStorage: Map<string, string>;
-  notifyCalls: Set<string>;
   activeStreamCalls: Set<string>;
 };
 
@@ -55,7 +54,6 @@ function seedTwilioPrivateCallState(params: {
   state.callStreamMap.set(params.providerCallId, "MZ-private-state");
   state.streamAuthTokens.set(params.providerCallId, "stream-token");
   state.twimlStorage.set(params.callId, "<Response><Say>Hello</Say></Response>");
-  state.notifyCalls.add(params.callId);
   state.activeStreamCalls.add(params.providerCallId);
 }
 
@@ -69,7 +67,6 @@ function expectTwilioPrivateCallStateReleased(params: {
   expect(state.callStreamMap.has(params.providerCallId)).toBe(false);
   expect(state.streamAuthTokens.has(params.providerCallId)).toBe(false);
   expect(state.twimlStorage.has(params.callId)).toBe(false);
-  expect(state.notifyCalls.has(params.callId)).toBe(false);
   expect(state.activeStreamCalls.has(params.providerCallId)).toBe(false);
 }
 
@@ -83,7 +80,6 @@ function expectTwilioPrivateCallStatePresent(params: {
   expect(state.callStreamMap.has(params.providerCallId)).toBe(true);
   expect(state.streamAuthTokens.has(params.providerCallId)).toBe(true);
   expect(state.twimlStorage.has(params.callId)).toBe(true);
-  expect(state.notifyCalls.has(params.callId)).toBe(true);
   expect(state.activeStreamCalls.has(params.providerCallId)).toBe(true);
 }
 
@@ -252,6 +248,17 @@ describe("TwilioProvider", () => {
     );
     expect(params.StatusCallbackEvent).toEqual(["initiated", "ringing", "answered", "completed"]);
     expect(params).not.toHaveProperty("Url");
+    expect(
+      provider.consumeInitialTwiML(createContext("CallSid=CA123", { callId: "call-1" })),
+    ).toBeNull();
+    const statusUrl = new URL(String(params.StatusCallback));
+    const statusCallback = createContext(
+      "CallSid=CA123&CallStatus=completed&Direction=outbound-api",
+      Object.fromEntries(statusUrl.searchParams),
+    );
+    expect(provider.parseWebhookEvent(statusCallback).providerResponseBody).toBe(
+      '<?xml version="1.0" encoding="UTF-8"?><Response></Response>',
+    );
   });
 
   it("uses the webhook URL for conversation outbound calls", async () => {
@@ -759,278 +766,5 @@ describe("TwilioProvider", () => {
 
     provider.unregisterCallStream("CA-reconnect", "MZ-new");
     expect(provider.hasRegisteredStream("CA-reconnect")).toBe(false);
-  });
-
-  it("times out telephony synthesis in stream mode and does not send completion mark", async () => {
-    vi.useFakeTimers();
-    try {
-      const provider = createProvider();
-      provider.registerCallStream("CA-timeout", "MZ-timeout");
-
-      const sendAudio = vi.fn();
-      const sendMarkAndWait = vi.fn();
-      const mediaStreamHandler = {
-        queueTts: async (
-          _streamSid: string,
-          playFn: (signal: AbortSignal) => Promise<void>,
-        ): Promise<void> => {
-          await playFn(new AbortController().signal);
-        },
-        sendAudio,
-        sendMarkAndWait,
-        clearAudio: vi.fn(),
-      };
-
-      provider.setMediaStreamHandler(mediaStreamHandler as never);
-      provider.setTTSProvider({
-        synthesisTimeoutMs: 5000,
-        synthesizeForTelephony: async () => await new Promise<Buffer>(() => {}),
-      });
-
-      const playExpectation = expect(
-        provider.playTts({
-          callId: "call-timeout",
-          providerCallId: "CA-timeout",
-          text: "Timeout me",
-        }),
-      ).rejects.toThrow("Telephony TTS synthesis timed out after 5000ms");
-      await vi.advanceTimersByTimeAsync(5_100);
-      await playExpectation;
-      expect(sendAudio).toHaveBeenCalled();
-      expect(sendMarkAndWait).not.toHaveBeenCalled();
-    } finally {
-      vi.useRealTimers();
-    }
-  });
-
-  it("stops and clears playback on the first failed audio chunk", async () => {
-    vi.useFakeTimers();
-    try {
-      const provider = createProvider();
-      provider.registerCallStream("CA-dropped", "MZ-dropped");
-
-      const sendAudio = vi
-        .fn<() => { sent: boolean }>()
-        .mockReturnValueOnce({ sent: true })
-        .mockReturnValueOnce({ sent: true })
-        .mockReturnValue({ sent: false });
-      const sendMarkAndWait = vi.fn();
-      const clearAudio = vi.fn();
-      const mediaStreamHandler = {
-        queueTts: async (
-          _streamSid: string,
-          playFn: (signal: AbortSignal) => Promise<void>,
-        ): Promise<void> => {
-          await playFn(new AbortController().signal);
-        },
-        sendAudio,
-        sendMarkAndWait,
-        clearAudio,
-      };
-
-      provider.setMediaStreamHandler(mediaStreamHandler as never);
-      provider.setTTSProvider({
-        synthesisTimeoutMs: 5000,
-        synthesizeForTelephony: async () => Buffer.alloc(480),
-      });
-
-      const playback = provider.playTts({
-        callId: "call-dropped",
-        providerCallId: "CA-dropped",
-        text: "Dropped audio",
-      });
-      const playExpectation = expect(playback).rejects.toThrow("Telephony stream playback failed");
-      await vi.advanceTimersByTimeAsync(100);
-      await playExpectation;
-      expect(sendAudio).toHaveBeenCalledTimes(3);
-      expect(clearAudio).toHaveBeenCalledWith("MZ-dropped");
-      expect(sendMarkAndWait).not.toHaveBeenCalled();
-    } finally {
-      vi.useRealTimers();
-    }
-  });
-
-  it("fails stream playback when telephony synthesis returns empty audio", async () => {
-    const provider = createProvider();
-    provider.registerCallStream("CA-empty", "MZ-empty");
-
-    const sendAudio = vi.fn();
-    const sendMarkAndWait = vi.fn();
-    const mediaStreamHandler = {
-      queueTts: async (
-        _streamSid: string,
-        playFn: (signal: AbortSignal) => Promise<void>,
-      ): Promise<void> => {
-        await playFn(new AbortController().signal);
-      },
-      sendAudio,
-      sendMarkAndWait,
-      clearAudio: vi.fn(),
-    };
-
-    provider.setMediaStreamHandler(mediaStreamHandler as never);
-    provider.setTTSProvider({
-      synthesisTimeoutMs: 5000,
-      synthesizeForTelephony: async () => Buffer.alloc(0),
-    });
-
-    await expect(
-      provider.playTts({
-        callId: "call-empty",
-        providerCallId: "CA-empty",
-        text: "Empty audio",
-      }),
-    ).rejects.toThrow("Telephony TTS produced no audio");
-    expect(sendAudio).toHaveBeenCalled();
-    expect(sendMarkAndWait).not.toHaveBeenCalled();
-  });
-
-  it("exits chunk pacing early when the abort signal fires after the first chunk", async () => {
-    vi.useFakeTimers();
-    try {
-      const provider = createProvider();
-      provider.registerCallStream("CA-abort-chunk", "MZ-abort-chunk");
-
-      const sendMarkAndWait = vi.fn(async () => {});
-      const controller = new AbortController();
-      const sendAudio = vi.fn(() => {
-        // The first send is the synthesis keepalive; the second is the first real audio chunk.
-        if (sendAudio.mock.calls.length === 2) {
-          controller.abort();
-        }
-        return { sent: true };
-      });
-
-      const mediaStreamHandler = {
-        queueTts: async (
-          _streamSid: string,
-          playFn: (signal: AbortSignal) => Promise<void>,
-        ): Promise<void> => {
-          await playFn(controller.signal);
-        },
-        sendAudio,
-        sendMarkAndWait,
-        clearAudio: vi.fn(),
-      };
-
-      provider.setMediaStreamHandler(mediaStreamHandler as never);
-      provider.setTTSProvider({
-        synthesisTimeoutMs: 5000,
-        synthesizeForTelephony: async () => Buffer.alloc(160 * 10, 0x80),
-      });
-
-      const startedAt = Date.now();
-      await expect(
-        provider.playTts({
-          callId: "call-abort-chunk",
-          providerCallId: "CA-abort-chunk",
-          text: "hello",
-          voice: "default",
-          locale: "en-US",
-        }),
-      ).resolves.toBeUndefined();
-
-      expect(Date.now()).toBe(startedAt);
-      expect(sendAudio).toHaveBeenCalledTimes(2);
-      expect(sendMarkAndWait).not.toHaveBeenCalled();
-      expect(vi.getTimerCount()).toBe(0);
-    } finally {
-      vi.useRealTimers();
-    }
-  });
-
-  it("waits for the provider playback mark before completing stream playback", async () => {
-    vi.useFakeTimers();
-    try {
-      const provider = createProvider();
-      provider.registerCallStream("CA-mark", "MZ-mark");
-      let acknowledgeMark!: () => void;
-      const markAcknowledgement = new Promise<void>((resolve) => {
-        acknowledgeMark = resolve;
-      });
-      const sendMarkAndWait = vi.fn(async () => await markAcknowledgement);
-      provider.setMediaStreamHandler({
-        queueTts: async (_streamSid: string, playFn: (signal: AbortSignal) => Promise<void>) =>
-          await playFn(new AbortController().signal),
-        sendAudio: () => ({ sent: true }),
-        sendMarkAndWait,
-        clearAudio: vi.fn(),
-      } as never);
-      provider.setTTSProvider({
-        synthesisTimeoutMs: 5_000,
-        synthesizeForTelephony: async () => Buffer.alloc(320, 0x80),
-      });
-
-      let completed = false;
-      const playback = provider
-        .playTts({ callId: "call-mark", providerCallId: "CA-mark", text: "hello" })
-        .then(() => {
-          completed = true;
-        });
-      await vi.advanceTimersByTimeAsync(100);
-
-      expect(sendMarkAndWait).toHaveBeenCalledOnce();
-      expect(completed).toBe(false);
-      acknowledgeMark();
-      await playback;
-      expect(completed).toBe(true);
-    } finally {
-      vi.useRealTimers();
-    }
-  });
-
-  it("releases serialized playback immediately when barge-in aborts synthesis", async () => {
-    const provider = createProvider();
-    provider.registerCallStream("CA-synth-abort", "MZ-synth-abort");
-    let activeController: AbortController | undefined;
-    let queueTail = Promise.resolve();
-    const mediaStreamHandler = {
-      queueTts: (_streamSid: string, playFn: (signal: AbortSignal) => Promise<void>) => {
-        const controller = new AbortController();
-        const operation = queueTail.then(async () => {
-          activeController = controller;
-          try {
-            await playFn(controller.signal);
-          } catch (error) {
-            if (!controller.signal.aborted) {
-              throw error;
-            }
-          } finally {
-            if (activeController === controller) {
-              activeController = undefined;
-            }
-          }
-        });
-        queueTail = operation.catch(() => {});
-        return operation;
-      },
-      clearTtsQueue: () => activeController?.abort(),
-      sendAudio: () => ({ sent: true }),
-      sendMarkAndWait: async () => {},
-      clearAudio: vi.fn(),
-    };
-    provider.setMediaStreamHandler(mediaStreamHandler as never);
-    const synthesizeForTelephony = vi
-      .fn<() => Promise<Buffer>>()
-      .mockImplementationOnce(async () => await new Promise<Buffer>(() => {}))
-      .mockResolvedValueOnce(Buffer.alloc(160, 0x80));
-    provider.setTTSProvider({ synthesisTimeoutMs: 30_000, synthesizeForTelephony });
-
-    const cancelled = provider.playTts({
-      callId: "call-synth-abort",
-      providerCallId: "CA-synth-abort",
-      text: "cancel me",
-    });
-    await vi.waitFor(() => expect(synthesizeForTelephony).toHaveBeenCalledTimes(1));
-    provider.clearTtsQueue("CA-synth-abort", "barge-in");
-    const next = provider.playTts({
-      callId: "call-synth-abort",
-      providerCallId: "CA-synth-abort",
-      text: "play next",
-    });
-
-    await expect(cancelled).resolves.toBeUndefined();
-    await expect(next).resolves.toBeUndefined();
-    expect(synthesizeForTelephony).toHaveBeenCalledTimes(2);
   });
 });

--- a/extensions/voice-call/src/providers/twilio.ts
+++ b/extensions/voice-call/src/providers/twilio.ts
@@ -67,10 +67,6 @@ function createTwilioRequestDedupeKey(ctx: WebhookContext, verifiedRequestKey?: 
     .digest("hex")}`;
 }
 
-type StreamSendResult = {
-  sent: boolean;
-};
-
 type TwilioProviderConfig = {
   accountSid?: string;
   authToken?: string;
@@ -101,21 +97,18 @@ export class TwilioProvider implements VoiceCallProvider {
   /** Per-call tokens for media stream authentication */
   private streamAuthTokens = new Map<string, string>();
 
-  /** Storage for TwiML content (for notify mode with URL-based TwiML) */
+  /** Storage for one-use pre-connect TwiML content */
   private readonly twimlStorage = new Map<string, string>();
-  /** Track notify-mode calls to avoid streaming on follow-up callbacks */
-  private readonly notifyCalls = new Set<string>();
   private readonly activeStreamCalls = new Set<string>();
 
   /**
    * Delete stored TwiML for a given `callId`.
    *
    * We keep TwiML in-memory only long enough to satisfy the initial Twilio
-   * webhook request (notify mode). Subsequent webhooks should not reuse it.
+   * webhook request before streaming. Subsequent webhooks should not reuse it.
    */
   private deleteStoredTwiml(callId: string): void {
     this.twimlStorage.delete(callId);
-    this.notifyCalls.delete(callId);
   }
 
   /**
@@ -438,7 +431,6 @@ export class TwilioProvider implements VoiceCallProvider {
     const decision = decideTwimlResponse({
       ...view,
       hasStoredTwiml: Boolean(storedTwiml),
-      isNotifyCall: view.callIdFromQuery ? this.notifyCalls.has(view.callIdFromQuery) : false,
       hasActiveStreams: this.activeStreamCalls.size > 0,
       canStream: Boolean(view.callSid && this.getStreamUrl()),
     });
@@ -471,10 +463,9 @@ export class TwilioProvider implements VoiceCallProvider {
     if (!storedTwiml) {
       return null;
     }
-    const kind = this.notifyCalls.has(view.callIdFromQuery) ? "notify" : "pre-connect";
     this.deleteStoredTwiml(view.callIdFromQuery);
     console.log(
-      `[voice-call] Twilio initial TwiML consumed for call ${view.callIdFromQuery} (kind=${kind}, callSid=${view.callSid ?? "unknown"})`,
+      `[voice-call] Twilio initial TwiML consumed for call ${view.callIdFromQuery} (kind=pre-connect, callSid=${view.callSid ?? "unknown"})`,
     );
     return storedTwiml;
   }
@@ -694,29 +685,9 @@ export class TwilioProvider implements VoiceCallProvider {
     const handler = this.mediaStreamHandler;
     const ttsProvider = this.ttsProvider;
 
-    const normalizeSendResult = (raw: unknown): StreamSendResult => {
-      if (!raw || typeof raw !== "object") {
-        return { sent: true };
-      }
-      const typed = raw as {
-        sent?: unknown;
-      };
-      return {
-        sent: typed.sent === undefined ? true : Boolean(typed.sent),
-      };
-    };
-
-    const sendAudioChunk = (audio: Buffer): StreamSendResult => {
-      const raw = (handler as { sendAudio: (sid: string, chunk: Buffer) => unknown }).sendAudio(
-        streamSid,
-        audio,
-      );
-      return normalizeSendResult(raw);
-    };
-
     await handler.queueTts(streamSid, async (signal) => {
       const sendKeepAlive = () => {
-        sendAudioChunk(SILENCE_CHUNK);
+        handler.sendAudio(streamSid, SILENCE_CHUNK);
       };
       sendKeepAlive();
       const keepAlive = setInterval(() => {
@@ -772,7 +743,7 @@ export class TwilioProvider implements VoiceCallProvider {
           break;
         }
         chunkAttempts += 1;
-        const chunkResult = sendAudioChunk(chunk);
+        const chunkResult = handler.sendAudio(streamSid, chunk);
         if (!chunkResult.sent) {
           handler.clearAudio(streamSid);
           throw new Error(

--- a/extensions/voice-call/src/providers/twilio/twiml-policy.test.ts
+++ b/extensions/voice-call/src/providers/twilio/twiml-policy.test.ts
@@ -14,7 +14,7 @@ function createContext(rawBody: string, query?: WebhookContext["query"]): Webhoo
 }
 
 describe("twiml policy", () => {
-  it("returns stored twiml decision for initial notify callback", () => {
+  it("returns stored twiml decision for an initial pre-connect callback", () => {
     const view = readTwimlRequestView(
       createContext("CallStatus=initiated&Direction=outbound-api&CallSid=CA123", {
         callId: "call-1",
@@ -24,7 +24,6 @@ describe("twiml policy", () => {
     const decision = decideTwimlResponse({
       ...view,
       hasStoredTwiml: true,
-      isNotifyCall: true,
       hasActiveStreams: false,
       canStream: true,
     });
@@ -40,7 +39,6 @@ describe("twiml policy", () => {
     const decision = decideTwimlResponse({
       ...view,
       hasStoredTwiml: false,
-      isNotifyCall: false,
       hasActiveStreams: true,
       canStream: true,
     });
@@ -56,7 +54,6 @@ describe("twiml policy", () => {
     const decision = decideTwimlResponse({
       ...view,
       hasStoredTwiml: false,
-      isNotifyCall: false,
       hasActiveStreams: false,
       canStream: true,
     });
@@ -75,7 +72,6 @@ describe("twiml policy", () => {
     const decision = decideTwimlResponse({
       ...view,
       hasStoredTwiml: false,
-      isNotifyCall: false,
       hasActiveStreams: false,
       canStream: true,
     });

--- a/extensions/voice-call/src/providers/twilio/twiml-policy.ts
+++ b/extensions/voice-call/src/providers/twilio/twiml-policy.ts
@@ -16,7 +16,6 @@ type TwimlRequestView = {
 /** Full TwiML policy input including manager/runtime state. */
 type TwimlPolicyInput = TwimlRequestView & {
   hasStoredTwiml: boolean;
-  isNotifyCall: boolean;
   hasActiveStreams: boolean;
   canStream: boolean;
 };
@@ -65,10 +64,6 @@ export function decideTwimlResponse(input: TwimlPolicyInput): TwimlDecision {
     if (input.hasStoredTwiml) {
       return { kind: "stored", consumeStoredTwimlCallId: input.callIdFromQuery };
     }
-    if (input.isNotifyCall) {
-      return { kind: "empty" };
-    }
-
     if (isOutboundDirection(input.direction)) {
       return input.canStream ? { kind: "stream" } : { kind: "pause" };
     }

--- a/extensions/voice-call/src/webhook-security.test.ts
+++ b/extensions/voice-call/src/webhook-security.test.ts
@@ -27,53 +27,13 @@ function plivoV2Signature(params: {
 
 function plivoV3Signature(params: {
   authToken: string;
-  urlWithQuery: string;
-  postBody: string;
+  canonicalBase: string;
   nonce: string;
 }): string {
-  const u = new URL(params.urlWithQuery);
-  const baseNoQuery = `${u.protocol}//${u.host}${u.pathname}`;
-  const queryPairs: Array<[string, string]> = [];
-  for (const [k, v] of u.searchParams.entries()) {
-    queryPairs.push([k, v]);
-  }
-
-  const queryMap = new Map<string, string[]>();
-  for (const [k, v] of queryPairs) {
-    queryMap.set(k, (queryMap.get(k) ?? []).concat(v));
-  }
-
-  const sortedQuery = Array.from(queryMap.keys())
-    .toSorted()
-    .flatMap((k) => [...(queryMap.get(k) ?? [])].toSorted().map((v) => `${k}=${v}`))
-    .join("&");
-
-  const postParams = new URLSearchParams(params.postBody);
-  const postMap = new Map<string, string[]>();
-  for (const [k, v] of postParams.entries()) {
-    postMap.set(k, (postMap.get(k) ?? []).concat(v));
-  }
-
-  const sortedPost = Array.from(postMap.keys())
-    .toSorted()
-    .flatMap((k) => [...(postMap.get(k) ?? [])].toSorted().map((v) => `${k}${v}`))
-    .join("");
-
-  const hasPost = sortedPost.length > 0;
-  let baseUrl = baseNoQuery;
-  if (sortedQuery.length > 0 || hasPost) {
-    baseUrl = `${baseNoQuery}?${sortedQuery}`;
-  }
-  if (sortedQuery.length > 0 && hasPost) {
-    baseUrl = `${baseUrl}.`;
-  }
-  baseUrl = `${baseUrl}${sortedPost}`;
-
-  const digest = crypto
+  return crypto
     .createHmac("sha256", params.authToken)
-    .update(`${baseUrl}.${params.nonce}`)
+    .update(`${params.canonicalBase}.${params.nonce}`)
     .digest("base64");
-  return canonicalizeBase64(digest);
 }
 
 function twilioSignature(params: { authToken: string; url: string; postBody: string }): string {
@@ -337,6 +297,56 @@ describe("verified webhook replay detection", () => {
 });
 
 describe("verifyPlivoWebhook", () => {
+  it.each([
+    ["POST", "", "", ""],
+    ["POST", "?q=x", "", "?q=x"],
+    ["POST", "", "Foo=", "?Foo"],
+    ["POST", "", "=", "?"],
+    ["GET", "?q=x", "Foo=y", "?q=x."],
+    [
+      "POST",
+      "?flow=answer&callId=abc",
+      "CallUUID=uuid&CallStatus=in-progress&From=%2B15550000000",
+      "?callId=abc&flow=answer.CallStatusin-progressCallUUIDuuidFrom+15550000000",
+    ],
+    [
+      "POST",
+      "?2=x&10=y&b=%2B&a=hello+world&%C3%A4=z",
+      "Tag=z&Tag=a&Tag=a&Raw=%26%3D&Tag=hello+world&Tag=%C3%A4",
+      "?10=y&2=x&a=hello world&b=+&ä=z.Raw&=TagaTagaTaghello worldTagzTagä",
+    ],
+  ] as const)(
+    "accepts valid V3 signature (including multi-signature header): %s %s %s",
+    (method, query, rawBody, suffix) => {
+      const publicUrl = "https://example.com/voice/webhook";
+      const authToken = "test-auth-token";
+      const nonce = `literal-${method}-${query}-${rawBody}`;
+      const canonicalBase = publicUrl + suffix;
+      const signature = plivoV3Signature({ authToken, canonicalBase, nonce });
+      const ctx = {
+        headers: {
+          host: "example.com",
+          "x-forwarded-proto": "https",
+          "x-plivo-signature-v3": `bad, ${signature}`,
+          "x-plivo-signature-v3-nonce": nonce,
+        },
+        rawBody,
+        url: publicUrl + query,
+        method,
+      };
+      const first = verifyPlivoWebhook(ctx, authToken);
+      const second = verifyPlivoWebhook(ctx, authToken);
+
+      expectAcceptedWebhookVersion(first, "v3");
+      expectReplayResultPair(first, second);
+      expect(first).toMatchObject({
+        version: "v3",
+        verifiedRequestKey: `plivo:v3:${crypto.createHash("sha256").update(`${canonicalBase}\n${nonce}`).digest("hex")}`,
+      });
+      first.releaseReplay?.();
+    },
+  );
+
   it("accepts valid V2 signature", () => {
     const authToken = "test-auth-token";
     const nonce = "nonce-123";
@@ -375,8 +385,8 @@ describe("verifyPlivoWebhook", () => {
     const webhookUrl = "https://[2001:db8::1]/voice/webhook?flow=answer&callId=ipv6";
     const signature = plivoV3Signature({
       authToken,
-      urlWithQuery: webhookUrl,
-      postBody,
+      canonicalBase:
+        "https://[2001:db8::1]/voice/webhook?callId=ipv6&flow=answer.CallStatusin-progressCallUUIDipv6-uuid",
       nonce,
     });
 
@@ -404,39 +414,6 @@ describe("verifyPlivoWebhook", () => {
     expect(result.verificationUrl).toBe(webhookUrl);
   });
 
-  it("accepts valid V3 signature (including multi-signature header)", () => {
-    const authToken = "test-auth-token";
-    const nonce = "nonce-456";
-
-    const urlWithQuery = "https://example.com/voice/webhook?flow=answer&callId=abc";
-    const postBody = "CallUUID=uuid&CallStatus=in-progress&From=%2B15550000000";
-
-    const good = plivoV3Signature({
-      authToken,
-      urlWithQuery,
-      postBody,
-      nonce,
-    });
-
-    const result = verifyPlivoWebhook(
-      {
-        headers: {
-          host: "example.com",
-          "x-forwarded-proto": "https",
-          "x-plivo-signature-v3": `bad, ${good}`,
-          "x-plivo-signature-v3-nonce": nonce,
-        },
-        rawBody: postBody,
-        url: urlWithQuery,
-        method: "POST",
-        query: { flow: "answer", callId: "abc" },
-      },
-      authToken,
-    );
-
-    expectAcceptedWebhookVersion(result, "v3");
-  });
-
   it("pins Plivo publicUrl verification to the configured path", () => {
     const authToken = "test-auth-token";
     const nonce = "nonce-public-url-path";
@@ -444,8 +421,8 @@ describe("verifyPlivoWebhook", () => {
     const attackerPathUrl = "https://voice.openclaw.ai/admin?flow=answer&callId=abc";
     const signature = plivoV3Signature({
       authToken,
-      urlWithQuery: attackerPathUrl,
-      postBody,
+      canonicalBase:
+        "https://voice.openclaw.ai/admin?callId=abc&flow=answer.CallStatusin-progressCallUUIDuuidFrom+15550000000",
       nonce,
     });
 
@@ -481,8 +458,8 @@ describe("verifyPlivoWebhook", () => {
 
     const signature = plivoV3Signature({
       authToken,
-      urlWithQuery: webhookUrl,
-      postBody,
+      canonicalBase:
+        "https://proxy.example.com/voice/webhook?callId=abc&flow=answer.CallStatusin-progressCallUUIDuuidFrom+15550000000",
       nonce,
     });
 
@@ -522,37 +499,6 @@ describe("verifyPlivoWebhook", () => {
 
     expect(result.ok).toBe(false);
     expect(result.reason).toMatch(/Missing Plivo signature headers/);
-  });
-
-  it("marks replayed valid V3 requests as replay without failing auth", () => {
-    const authToken = "test-auth-token";
-    const nonce = "nonce-replay-v3";
-    const urlWithQuery = "https://example.com/voice/webhook?flow=answer&callId=abc";
-    const postBody = "CallUUID=uuid&CallStatus=in-progress&From=%2B15550000000";
-    const signature = plivoV3Signature({
-      authToken,
-      urlWithQuery,
-      postBody,
-      nonce,
-    });
-
-    const ctx = {
-      headers: {
-        host: "example.com",
-        "x-forwarded-proto": "https",
-        "x-plivo-signature-v3": signature,
-        "x-plivo-signature-v3-nonce": nonce,
-      },
-      rawBody: postBody,
-      url: urlWithQuery,
-      method: "POST" as const,
-      query: { flow: "answer", callId: "abc" },
-    };
-
-    const first = verifyPlivoWebhook(ctx, authToken);
-    const second = verifyPlivoWebhook(ctx, authToken);
-
-    expectReplayResultPair(first, second);
   });
 
   it("treats query-only V2 variants as the same verified request", () => {
@@ -600,53 +546,6 @@ describe("verifyPlivoWebhook", () => {
     expect(second.ok).toBe(true);
     expect(second.verifiedRequestKey).toBe(first.verifiedRequestKey);
     expect(second.isReplay).toBe(true);
-  });
-
-  it("detects V3 replay when query parameters are reordered", () => {
-    const authToken = "test-auth-token";
-    const nonce = "nonce-v3-reorder";
-    const postBody = "CallUUID=uuid&CallStatus=in-progress";
-
-    const urlA = "https://example.com/voice/webhook?flow=answer&callId=abc";
-    const urlB = "https://example.com/voice/webhook?callId=abc&flow=answer";
-
-    const signatureA = plivoV3Signature({ authToken, urlWithQuery: urlA, postBody, nonce });
-    const signatureB = plivoV3Signature({ authToken, urlWithQuery: urlB, postBody, nonce });
-    expect(signatureA).toBe(signatureB);
-
-    const first = verifyPlivoWebhook(
-      {
-        headers: {
-          host: "example.com",
-          "x-forwarded-proto": "https",
-          "x-plivo-signature-v3": signatureA,
-          "x-plivo-signature-v3-nonce": nonce,
-        },
-        rawBody: postBody,
-        url: urlA,
-        method: "POST",
-        query: { flow: "answer", callId: "abc" },
-      },
-      authToken,
-    );
-
-    const second = verifyPlivoWebhook(
-      {
-        headers: {
-          host: "example.com",
-          "x-forwarded-proto": "https",
-          "x-plivo-signature-v3": signatureB,
-          "x-plivo-signature-v3-nonce": nonce,
-        },
-        rawBody: postBody,
-        url: urlB,
-        method: "POST",
-        query: { callId: "abc", flow: "answer" },
-      },
-      authToken,
-    );
-
-    expectReplayResultPair(first, second);
   });
 });
 

--- a/extensions/voice-call/src/webhook-security.ts
+++ b/extensions/voice-call/src/webhook-security.ts
@@ -673,20 +673,6 @@ function createPlivoV2ReplayKey(url: string, nonce: string): string {
   return `plivo:v2:${sha256Hex(`${getBaseUrlNoQuery(url)}\n${nonce}`)}`;
 }
 
-function createPlivoV3ReplayKey(params: {
-  method: "GET" | "POST";
-  url: string;
-  postParams: PlivoParamMap;
-  nonce: string;
-}): string {
-  const baseUrl = constructPlivoV3BaseUrl({
-    method: params.method,
-    url: params.url,
-    postParams: params.postParams,
-  });
-  return `plivo:v3:${sha256Hex(`${baseUrl}\n${params.nonce}`)}`;
-}
-
 function validatePlivoV2Signature(params: {
   authToken: string;
   signature: string;
@@ -716,7 +702,7 @@ function toParamMapFromSearchParams(sp: URLSearchParams): PlivoParamMap {
   return map;
 }
 
-function sortedQueryString(params: PlivoParamMap): string {
+function sortedPlivoParams(params: PlivoParamMap, format: "query" | "body"): string {
   const parts: string[] = [];
   const entries = Object.entries(params).toSorted(([left], [right]) =>
     left < right ? -1 : left > right ? 1 : 0,
@@ -724,24 +710,10 @@ function sortedQueryString(params: PlivoParamMap): string {
   for (const [key, entryValues] of entries) {
     const values = [...entryValues].toSorted();
     for (const value of values) {
-      parts.push(`${key}=${value}`);
+      parts.push(format === "query" ? `${key}=${value}` : `${key}${value}`);
     }
   }
-  return parts.join("&");
-}
-
-function sortedParamsString(params: PlivoParamMap): string {
-  const parts: string[] = [];
-  const entries = Object.entries(params).toSorted(([left], [right]) =>
-    left < right ? -1 : left > right ? 1 : 0,
-  );
-  for (const [key, entryValues] of entries) {
-    const values = [...entryValues].toSorted();
-    for (const value of values) {
-      parts.push(`${key}${value}`);
-    }
-  }
-  return parts.join("");
+  return parts.join(format === "query" ? "&" : "");
 }
 
 function constructPlivoV3BaseUrl(params: {
@@ -754,7 +726,7 @@ function constructPlivoV3BaseUrl(params: {
   const baseNoQuery = `${u.protocol}//${u.host}${u.pathname}`;
 
   const queryMap = toParamMapFromSearchParams(u.searchParams);
-  const queryString = sortedQueryString(queryMap);
+  const queryString = sortedPlivoParams(queryMap, "query");
 
   // In the Plivo V3 algorithm, the query portion is always sorted, and if we
   // have POST params we add a '.' separator after the query string.
@@ -770,24 +742,16 @@ function constructPlivoV3BaseUrl(params: {
     return baseUrl;
   }
 
-  return baseUrl + sortedParamsString(params.postParams);
+  return baseUrl + sortedPlivoParams(params.postParams, "body");
 }
 
 function validatePlivoV3Signature(params: {
   authToken: string;
   signatureHeader: string;
   nonce: string;
-  method: "GET" | "POST";
-  url: string;
-  postParams: PlivoParamMap;
+  baseUrl: string;
 }): boolean {
-  const baseUrl = constructPlivoV3BaseUrl({
-    method: params.method,
-    url: params.url,
-    postParams: params.postParams,
-  });
-
-  const hmacBase = `${baseUrl}.${params.nonce}`;
+  const hmacBase = `${params.baseUrl}.${params.nonce}`;
   const digest = crypto.createHmac("sha256", params.authToken).update(hmacBase).digest("base64");
   const expected = normalizeSignatureBase64(digest);
 
@@ -886,13 +850,12 @@ export function verifyPlivoWebhook(
     }
 
     const postParams = toParamMapFromSearchParams(new URLSearchParams(ctx.rawBody));
+    const baseUrl = constructPlivoV3BaseUrl({ method, url: verificationUrl, postParams });
     const ok = validatePlivoV3Signature({
       authToken,
       signatureHeader: signatureV3,
       nonce: nonceV3,
-      method,
-      url: verificationUrl,
-      postParams,
+      baseUrl,
     });
     if (!ok) {
       return {
@@ -902,12 +865,7 @@ export function verifyPlivoWebhook(
         reason: "Invalid Plivo V3 signature",
       };
     }
-    const replayKey = createPlivoV3ReplayKey({
-      method,
-      url: verificationUrl,
-      postParams,
-      nonce: nonceV3,
-    });
+    const replayKey = `plivo:v3:${sha256Hex(`${baseUrl}\n${nonceV3}`)}`;
     return {
       ok: true,
       version: "v3",

--- a/extensions/voice-call/src/webhook.test.ts
+++ b/extensions/voice-call/src/webhook.test.ts
@@ -226,14 +226,12 @@ function expectTwilioCallStateReleased(
     callStreamMap: Map<string, string>;
     streamAuthTokens: Map<string, string>;
     twimlStorage: Map<string, string>;
-    notifyCalls: Set<string>;
     activeStreamCalls: Set<string>;
   };
   expect(state.callWebhookUrls.has(params.providerCallId)).toBe(false);
   expect(state.callStreamMap.has(params.providerCallId)).toBe(false);
   expect(state.streamAuthTokens.has(params.providerCallId)).toBe(false);
   expect(state.twimlStorage.has(params.callId)).toBe(false);
-  expect(state.notifyCalls.has(params.callId)).toBe(false);
   expect(state.activeStreamCalls.has(params.providerCallId)).toBe(false);
 }
 
@@ -1289,7 +1287,6 @@ describe("VoiceCallWebhookServer replay handling", () => {
       callStreamMap: Map<string, string>;
       streamAuthTokens: Map<string, string>;
       twimlStorage: Map<string, string>;
-      notifyCalls: Set<string>;
       activeStreamCalls: Set<string>;
     };
     state.callWebhookUrls.set(
@@ -1299,7 +1296,6 @@ describe("VoiceCallWebhookServer replay handling", () => {
     state.callStreamMap.set(providerCallId, "MZ-webhook-terminal");
     state.streamAuthTokens.set(providerCallId, "stream-token");
     state.twimlStorage.set(callId, "<Response><Say>Hello</Say></Response>");
-    state.notifyCalls.add(callId);
     state.activeStreamCalls.add(providerCallId);
 
     const parseWebhookEvent = vi.spyOn(twilioProvider, "parseWebhookEvent");
@@ -1494,21 +1490,26 @@ describe("VoiceCallWebhookServer replay handling", () => {
   });
 
   it("returns Plivo XML for replayed answer callbacks while skipping event side effects", async () => {
+    const authToken = "signed-plivo-replay-token";
+    const nonce = "signed-plivo-replay-nonce";
+    const publicUrl = "https://example.test/voice/webhook";
     const plivoProvider = new PlivoProvider(
       {
         authId: "MA000000000000000000",
-        authToken: "test-token",
+        authToken,
       },
-      { skipVerification: true },
+      { publicUrl },
     );
     const parseWebhookEvent = vi.spyOn(plivoProvider, "parseWebhookEvent");
     const { manager, processEvent } = createManager([]);
     const config = createConfig({
       provider: "plivo",
-      skipSignatureVerification: true,
+      skipSignatureVerification: false,
+      serve: { port: 0, bind: "127.0.0.1", path: "/voice/webhook" },
+      staleCallReaperSeconds: 0,
       plivo: {
         authId: "MA000000000000000000",
-        authToken: "test-token",
+        authToken,
       },
     });
     const server = new VoiceCallWebhookServer(config, manager, plivoProvider);
@@ -1519,34 +1520,77 @@ describe("VoiceCallWebhookServer replay handling", () => {
       requestUrl.searchParams.set("provider", "plivo");
       requestUrl.searchParams.set("flow", "answer");
       requestUrl.searchParams.set("callId", "internal-call-id");
+      requestUrl.searchParams.append("tag", "z");
+      requestUrl.searchParams.append("tag", "a");
       const body =
-        "CallUUID=plivo-replay-answer-callback&CallStatus=in-progress&Direction=outbound&From=%2B15550000000&To=%2B15550000001&Event=StartApp";
+        "CallUUID=plivo-replay-answer-callback&CallStatus=in-progress&Direction=outbound&From=%2B15550000000&To=%2B15550000001&Event=StartApp&Tag=z&Tag=a";
+      const canonicalBaseFor = (tag: string) =>
+        `${publicUrl}?callId=internal-call-id&flow=answer&provider=plivo&tag=a&tag=z.CallStatusin-progressCallUUIDplivo-replay-answer-callbackDirectionoutboundEventStartAppFrom+15550000000Tag${tag}TagzTo+15550000001`;
+      const signatureFor = (tag: string) =>
+        crypto
+          .createHmac("sha256", authToken)
+          .update(`${canonicalBaseFor(tag)}.${nonce}`)
+          .digest("base64");
+      const expectedKeyFor = (tag: string) =>
+        `plivo:v3:${crypto
+          .createHash("sha256")
+          .update(`${canonicalBaseFor(tag)}\n${nonce}`)
+          .digest("hex")}`;
+      const postCallback = (rawBody: string, signature: string) =>
+        fetch(requestUrl, {
+          method: "POST",
+          headers: {
+            "content-type": "application/x-www-form-urlencoded",
+            "x-plivo-signature-v3": signature,
+            "x-plivo-signature-v3-nonce": nonce,
+          },
+          body: rawBody,
+        });
 
-      const first = await fetch(requestUrl.toString(), {
-        method: "POST",
-        headers: { "content-type": "application/x-www-form-urlencoded" },
-        body,
-      });
+      const rejected = await postCallback(body, "invalid");
+      expect(rejected.status).toBe(401);
+      expect(await rejected.text()).toBe("Unauthorized");
+      expect(parseWebhookEvent).not.toHaveBeenCalled();
+      expect(processEvent).not.toHaveBeenCalled();
+
+      const first = await postCallback(body, signatureFor("a"));
       expect(first.status).toBe(200);
       expect(first.headers.get("content-type")).toContain("text/xml");
-      expect(await first.text()).toContain("<Wait");
+      const expectedBody = await first.text();
+      expect(expectedBody).toContain("<Wait");
       expect(parseWebhookEvent).toHaveBeenCalledTimes(1);
       expect(processEvent).toHaveBeenCalledTimes(1);
+      const firstKey = processEvent.mock.calls[0]?.[0].dedupeKey;
+      expect(firstKey).toBe(expectedKeyFor("a"));
+      expect(parseWebhookEvent.mock.calls[0]?.[1]).toEqual({
+        verifiedRequestKey: expectedKeyFor("a"),
+      });
 
       parseWebhookEvent.mockClear();
       processEvent.mockClear();
 
-      const replay = await fetch(requestUrl.toString(), {
-        method: "POST",
-        headers: { "content-type": "application/x-www-form-urlencoded" },
-        body,
-      });
+      requestUrl.search = "?tag=a&callId=internal-call-id&tag=z&flow=answer&provider=plivo";
+      const replay = await postCallback(body.split("&").toReversed().join("&"), signatureFor("a"));
 
       expect(replay.status).toBe(200);
       expect(replay.headers.get("content-type")).toContain("text/xml");
-      expect(await replay.text()).toContain("<Wait");
+      const replayBody = await replay.text();
+      expect(replayBody).toContain("<Wait");
+      expect(replayBody).toBe(expectedBody);
       expect(parseWebhookEvent).not.toHaveBeenCalled();
       expect(processEvent).not.toHaveBeenCalled();
+
+      const changed = await postCallback(body.replace("Tag=a", "Tag=b"), signatureFor("b"));
+      expect(changed.status).toBe(200);
+      expect(await changed.text()).toBe(expectedBody);
+      expect(parseWebhookEvent).toHaveBeenCalledTimes(1);
+      expect(processEvent).toHaveBeenCalledTimes(1);
+      const changedKey = processEvent.mock.calls[0]?.[0].dedupeKey;
+      expect(changedKey).toBe(expectedKeyFor("b"));
+      expect(parseWebhookEvent.mock.calls[0]?.[1]).toEqual({
+        verifiedRequestKey: expectedKeyFor("b"),
+      });
+      expect(changedKey).not.toBe(firstKey);
     } finally {
       parseWebhookEvent.mockRestore();
       await server.stop();
@@ -1955,57 +1999,6 @@ describe("VoiceCallWebhookServer replay handling", () => {
       expect(response.status).toBe(200);
       expect(body).toContain("<Connect><Stream");
       expect(buildTwiMLPayload).toHaveBeenCalledTimes(1);
-    } finally {
-      await server.stop();
-    }
-  });
-
-  it("passes verified request key from verifyWebhook into parseWebhookEvent", async () => {
-    const parseWebhookEvent = vi.fn((_ctx: unknown, options?: { verifiedRequestKey?: string }) => ({
-      events: [
-        {
-          id: "evt-verified",
-          dedupeKey: options?.verifiedRequestKey,
-          type: "call.speech" as const,
-          callId: "call-1",
-          providerCallId: "provider-call-1",
-          timestamp: Date.now(),
-          transcript: "hello",
-          isFinal: true,
-        },
-      ],
-      statusCode: 200,
-    }));
-    const verifiedProvider: VoiceCallProvider = {
-      ...provider,
-      verifyWebhook: () => ({ ok: true, verifiedRequestKey: "verified:req:123" }),
-      parseWebhookEvent,
-    };
-    const { manager, processEvent } = createManager([]);
-    const config = createConfig({ serve: { port: 0, bind: "127.0.0.1", path: "/voice/webhook" } });
-    const server = new VoiceCallWebhookServer(config, manager, verifiedProvider);
-
-    try {
-      const baseUrl = await server.start();
-      const response = await postWebhookForm(server, baseUrl, "CallSid=CA123&SpeechResult=hello");
-
-      expect(response.status).toBe(200);
-      expect(parseWebhookEvent).toHaveBeenCalledTimes(1);
-      const parseOptions = expectDefined(parseWebhookEvent.mock.calls.at(0), "webhook parse")[1];
-      if (!parseOptions) {
-        throw new Error("webhook server did not pass verified parse options");
-      }
-      expect(parseOptions).toEqual({
-        verifiedRequestKey: "verified:req:123",
-      });
-      expect(processEvent).toHaveBeenCalledTimes(1);
-      const firstEvent = expectDefined(processEvent.mock.calls.at(0), "processed event")[0] as
-        | NormalizedEvent
-        | undefined;
-      if (!firstEvent) {
-        throw new Error("webhook server did not forward the parsed event");
-      }
-      expect(firstEvent.dedupeKey).toBe("verified:req:123");
     } finally {
       await server.stop();
     }

--- a/extensions/voice-call/src/webhook/realtime-handler.admission.test.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.admission.test.ts
@@ -1,0 +1,80 @@
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
+import type { RealtimeVoiceProviderPlugin } from "openclaw/plugin-sdk/realtime-voice";
+import { describe, expect, it, vi } from "vitest";
+import { WebSocket } from "ws";
+import type { CallManager } from "../manager.js";
+import { waitForClose } from "../websocket-test-support.js";
+import {
+  connectCarrierStream,
+  createBridge,
+  createCarrierLifecycleHarness,
+} from "./realtime-handler.lifecycle.test-helpers.js";
+
+describe("RealtimeCallHandler lifecycle", () => {
+  it("preserves a concurrently admitted bridge when another creation fails", async () => {
+    const firstPersistence = createDeferred<Awaited<ReturnType<CallManager["processEvent"]>>>();
+    const secondPersistence = createDeferred<Awaited<ReturnType<CallManager["processEvent"]>>>();
+    const greeting = vi.fn();
+    const createBridgeForCall = vi
+      .fn<RealtimeVoiceProviderPlugin["createBridge"]>()
+      .mockImplementationOnce(() => createBridge(vi.fn(), { triggerGreeting: greeting }))
+      .mockImplementationOnce(() => {
+        throw new Error("concurrent realtime bridge creation failed");
+      });
+    const { call, handler, endCall, hangupCall, processEvent } =
+      createCarrierLifecycleHarness(createBridgeForCall);
+    let answered = 0;
+    processEvent.mockImplementation(async (event) => {
+      if (event.type === "call.answered") {
+        return ++answered === 1 ? firstPersistence.promise : secondPersistence.promise;
+      }
+      return { kind: "processed" };
+    });
+    const first = await connectCarrierStream(handler);
+    let second: Awaited<ReturnType<typeof connectCarrierStream>> | undefined;
+
+    try {
+      first.ws.send(
+        JSON.stringify({
+          event: "start",
+          start: { streamSid: "MZ-concurrent-first", callSid: call.providerCallId },
+        }),
+      );
+      await vi.waitFor(() => expect(answered).toBe(1));
+      second = await connectCarrierStream(handler);
+      const secondClosed = waitForClose(second.ws);
+      second.ws.send(
+        JSON.stringify({
+          event: "start",
+          start: { streamSid: "MZ-concurrent-second", callSid: call.providerCallId },
+        }),
+      );
+      await vi.waitFor(() => expect(answered).toBe(2));
+      expect(createBridgeForCall).not.toHaveBeenCalled();
+
+      firstPersistence.resolve({ kind: "processed" });
+      await vi.waitFor(() => expect(createBridgeForCall).toHaveBeenCalledOnce());
+      expect(handler.speak(call.callId, "first bridge is active")).toEqual({ success: true });
+      secondPersistence.resolve({ kind: "processed" });
+      expect(await secondClosed).toEqual({
+        code: 1011,
+        reason: "Failed to create realtime bridge",
+      });
+
+      expect(createBridgeForCall).toHaveBeenCalledTimes(2);
+      expect(endCall).not.toHaveBeenCalled();
+      expect(hangupCall).not.toHaveBeenCalled();
+      expect(first.ws.readyState).toBe(WebSocket.OPEN);
+      expect(handler.speak(call.callId, "first bridge remains active")).toEqual({ success: true });
+      expect(greeting).toHaveBeenLastCalledWith("first bridge remains active");
+    } finally {
+      firstPersistence.resolve({ kind: "processed" });
+      secondPersistence.resolve({ kind: "processed" });
+      first.ws.terminate();
+      second?.ws.terminate();
+      await handler.close();
+      await second?.server.close();
+      await first.server.close();
+    }
+  });
+});


### PR DESCRIPTION
Related: #145047, #145382

## What Problem This Solves

Voice Call's runtime persistence and Doctor migration duplicated call-record serialization and chunk construction. Provider code also repeated Plivo parameter ordering and retained an unwritten Twilio notification set.

## Why This Change Was Made

Runtime and Doctor now share the record encoder, chunk keys, and row types. Snapshot capture still completes before the first await, chunk writes finish before metadata publication, and pruning remains ordered afterward. Doctor materializes every chunk before selecting migration capacity. Plivo uses one parameter-ordering implementation, and Twilio consumes the concrete media-send result.

This preserves #145382's already-landed admission guard, asynchronous provider cleanup, and fixture ownership. The retained regression covers two admissions waiting on persistence before either bridge exists; it uses the existing lifecycle helper. No production race fix or duplicate fixture is added here.

## User Impact

No intended behavior change. Existing call-history bytes, migration ordering, and provider policy remain compatible. Coverage now also protects the concurrent-admission case fixed upstream.

The refreshed patch removes 101 production code lines and adds 264 test/support lines: **+163 maintained code lines overall**. The previously reviewed candidate was +178; its superseded race guard and fixture extraction are excluded from this PR and receive no new credit.

## Evidence

At base `6678f6174b336fb5df22b661ab6e6cba0524bc9a`, 217 tests passed across 11 focused Voice suites, including the current lifecycle and transcript-persistence tests. Formatting and whitespace checks passed. Fresh P2 review passed with no findings. PR-head CI remains pending.

Retained proof for the earlier `9252b591` candidate includes a full build, complete changed-file gate, nine-case/18-operation raw SQLite parity, and an installed update from published `openclaw@2026.9.2` to candidate `2026.9.4`. The installed proof checked all 27 non-dependency package files and separately verified old and candidate Doctor migrations, exact selected module/root/boundary, loader/file hashes, three chunks, 120,390 payload bytes, metadata, and archived input.

That [wrapper run](https://github.com/openclaw/openclaw/actions/runs/34660425307) exited 1 on an obsolete observer cache field after the product steps. Independent immutable-archive reconciliation passed; the original failure remains recorded. Those artifacts retain their original source/package identity and are not presented as a build or installed run of this newer base. The task-owned Testbox was stopped and confirmed completed. No carrier calls or live Gateway execution are claimed.

A bounded source preflight against main `3f0b8a175098c19f1a89d39e8649f8f82d54da1b` found unchanged Voice source, direct persistence/Doctor contracts, and package inputs; the accepted patch still applies. Later plugin-update changes are outside the retained artifact identity.
