### PR TITLE
refactor(tests): reuse Discord REST runtime spies

### DIFF
--- a/extensions/discord/src/monitor/provider.rest-proxy.test.ts
+++ b/extensions/discord/src/monitor/provider.rest-proxy.test.ts
@@ -1,8 +1,8 @@
-// Discord tests cover provider.rest proxy plugin behavior.
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { createRuntimeSpies } from "../../../test-support/runtime-spies.js";
 
 const {
   undiciFetchMock,
@@ -121,10 +121,6 @@ function dispatchRequest(dispatcher: unknown, origin: string): void {
     throw new Error("expected attached dispatcher.dispatch");
   }
   target.dispatch({ origin, path: "/", method: "GET" }, {});
-}
-
-function createRuntimeSpies() {
-  return { log: vi.fn(), error: vi.fn(), exit: vi.fn() } as const;
 }
 
 function installUndiciRuntimeDeps(): void {


### PR DESCRIPTION
## What Problem This Solves

The Discord REST tests retain a local three-spy runtime factory that duplicates the shared test helper introduced later.

## Why This Change Was Made

Use the existing `createRuntimeSpies` helper at the same eleven call sites and remove the redundant factory and opening narration comment. Each case still creates fresh log, error, and exit mocks. The distinct throwing-exit fixture remains unchanged.

## User Impact

No production change. Tests are +1/-5 (net -4), with no cases or assertions removed. Existing proxy selection, logging, abort, and cleanup checks remain intact.

## Evidence

The complete REST, request-client, and logging suites pass 19/19 both before and after, with identical ordered case names and results. All 19 normal changed-file checks passed, including extension test types, lint, boundaries, and all three dead-export scans. Independent Codex review found no actionable findings through P2. The signed commit preserves the tested bytes.

This is a test-fixture refactor; the retained checks do not establish broader live Discord or network behavior.
