### PR TITLE
perf(sessions): avoid unused optimistic identity projection

### DIFF
--- a/packages/gateway-client/src/session-projection.ts
+++ b/packages/gateway-client/src/session-projection.ts
@@ -138,11 +138,12 @@ export type SessionProjectionEvent = ScopedSessionProjectionEvent &
 
 /** Local turns have no durable transcript metadata beyond their own optional send key. */
 export function isLocallyOptimisticSessionMessage(message: unknown): boolean {
-  const identity = readSessionMessageIdentity(message);
-  if (!identity || (identity.role !== "user" && identity.role !== "assistant")) {
+  const record = readRecord(message);
+  const role = readNonemptyString(record?.role)?.toLowerCase();
+  if (role !== "user" && role !== "assistant") {
     return false;
   }
-  const metadata = readRecord(readRecord(message)?.["__openclaw"]);
+  const metadata = readRecord(record?.["__openclaw"]);
   return !metadata || Object.keys(metadata).every((key) => key === "idempotencyKey");
 }
 


### PR DESCRIPTION
## What Problem This Solves

Conversation history projection constructs a complete persisted/imported message identity merely to decide whether a row is locally optimistic. Entry creation already constructs the identity it needs, so the classification path repeats work that does not affect its decision.

## Why This Change Was Made

Read the normalized role through the existing record/string helpers and retain the same metadata-key predicate. Authoritative identity construction still belongs to its existing owner. Pending predecessors, durable/imported identity, send rekeying, failure removal, filtering and reset behavior are unchanged.

The one-file change adds one production line. It adds no cache, public surface, configuration, dependency or persistence. It preserves ordinary message-data behavior without promising identical incidental getter/Proxy read counts or inventing a new plain-object requirement.

## User Impact

Less classification work for the measured larger histories. The same messages retain the same pending and authoritative ownership. Small ordinary/empty controls regress, so this is not a uniform speedup or a claim about Gateway latency, browser frames or memory use.

## Evidence

Fresh local validation on macOS/Node 26.8.1 passed **all 101 tests across both complete files**, with zero unselected, skipped or pending cases:

```sh
node scripts/run-vitest.mjs packages/gateway-client/src/session-projection.test.ts packages/gateway-client/src/session-projection-conformance.test.ts
```

The run used task-owned HOME/config/state and a separate Vitest cache. The existing native supervisor bounded each command to 300 seconds, 6 GiB RSS and 64 observed processes. All six children closed with their monitors joined and no supervisor problems. The test command completed in 2.03 seconds with an observed process-tree peak of about 843 MiB. Its complete JSON report and native evidence are retained.

Normal frozen installation, the matching formatter, changed-check dry-run discovery and `git diff --check` passed. The dry-run selected core/coreTests; its broader typecheck, lint and guard commands did not run locally and remain required from exact-head CI. A fresh managed Codex review through P2 completed scoped-clean. No new tests were added, and the separate terminal-snapshot candidate's 267-test proof is not used here.

The author base is `92b9264cef16e92adcbf58401c529a92bce060ee`, which includes the shared lint repair from #145632. All 27 measured source/tool/consumer pins and all 54 prepared validation pins match that base. The exact candidate remains unchanged after formatting. These source comparisons do not relabel the historical timings as measurements of the new host or base.

[Historical Linux measurement](https://github.com/openclaw/openclaw/actions/runs/34674144561) used four fresh processes in B1/C1/C2/B2 order at `b4c35afcc53430eaf46fc079c8461dbd2727b142`. There were nine fixed cases and 4,140 total invocations including initial, warmup and measured work. Hydration timings include `createSessionProjection` plus one snapshot reducer call; the already-live control measures only its event.

Complete state/reference/undefined/sparse/property-descriptor graphs and a separate 13-event lifecycle matched across all arms, with independent pending, predicate and ordering oracles. The original observations, raw graphs and every adverse sample remain preserved. No sample filtering, retries or performance rerun occurred.

Warm wall medians below are microseconds; parentheses show candidate change.

| Case | B1 → C1 | B2 → C2 |
| --- | ---: | ---: |
| Empty | 0.852 → 1.117 (+31.10%) | 0.832 → 0.852 (+2.40%) |
| Ordinary user/assistant | 1.563 → 2.034 (+30.13%) | 1.487 → 2.039 (+37.08%) |
| 32 persisted rows | 14.538 → 10.906 (−24.98%) | 15.014 → 9.568 (−36.27%) |
| 1,024 persisted rows | 289.656 → 214.478 (−25.95%) | 270.399 → 170.254 (−37.04%) |
| 256 imported rows | 208.567 → 135.448 (−35.06%) | 195.026 → 122.097 (−37.39%) |
| 256 optimistic-chain rows | 125.925 → 53.872 (−57.22%) | 95.486 → 62.714 (−34.32%) |
| Role/metadata controls | 10.450 → 6.948 (−33.51%) | 10.199 → 7.134 (−30.06%) |
| Sparse/null/missing | 2.995 → 2.765 (−7.68%) | 2.605 → 2.755 (+5.76%) |
| Already-live control | 1.278 → 1.152 (−9.86%) | 1.112 → 1.202 (+8.09%) |

Larger persisted/imported/optimistic cases have lower wall and CPU medians in both orders, with approximately 25–57% wall reductions. The ordinary two-row case instead costs another **0.471/0.552 microseconds**. Empty, sparse and already-live controls prevent a uniform-win claim.

Whole-process wall changed −2.14%/−4.32%, while system CPU rose +73.62%/+33.15% and peak RSS rose about 0.5–0.6%. Those native totals include imports and untimed setup/assertions; no memory benefit is established.

All ten original measurement children closed, source was restored, the owned worktree was normally removed, and the dedicated Testbox was explicitly stopped and verified completed. Archive SHA256: `81dcc2ab0c347a6eff3c8c52f22bec6194fe079a05c370f315fdf5ce2f980678`. The final-removal receipt is retained separately from the pre-removal archive; no raw final-removal stdio/lineage archive is claimed.


Current-head qualification: refreshed onto main `3d7d21166f0962f05937376db16f3861a9b5bc85`, preserving the authored patch and full production-file bytes. This carries #145657, which initializes context readers during fixture setup without changing the 5-second launch-observation budget. The old run `34676629986` failed three launch-observation checks; its logs and attribution remain preserved, and the changed projection predicate is outside the inspected pre-launch path. Current main also includes the separately reviewed terminal-matching context cleanup (#145618) and mail dependency updates; the predicate and entry-identity contract are unchanged. The 101-test author proof and benchmark retain their original source labels; they are not new combined-main results. Existing Codex P2 remains applicable to the unchanged patch. Fresh exact-head CI is required before landing; no old-base rerun, duplicate repair, or performance rerun is claimed.
