### PR TITLE
improve: format long list-heavy reports faster

### DIFF
--- a/packages/markdown-core/src/ir.ts
+++ b/packages/markdown-core/src/ir.ts
@@ -684,8 +684,7 @@ function appendParagraphSeparator(
 }
 
 function appendTopLevelListSeparator(state: RenderState) {
-  const trailingNewlines = state.text.match(/\n*$/)?.[0].length ?? 0;
-  if (trailingNewlines < 2) {
+  if (!state.text.endsWith("\n\n")) {
     state.text += "\n";
   }
 }


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where long reports with many separate lists take progressively longer to format for messaging channels.

## Why This Change Was Made

The shared Markdown renderer only needs to know whether its output ends with two newlines. Check that suffix directly instead of searching the entire accumulated output after every top-level list. This preserves the existing separator behavior and removes repeated prefix scans.

## User Impact

Large list-heavy responses spend less time in Markdown parsing. Formatting, Unicode offsets, and parser metadata remain unchanged.

## Evidence

- Windows x64, Node 26.8.2; actual `markdownToIR` source entry, ten warmups and thirty samples per fixed synthetic report. The 512-section / 225,575 UTF-16-unit workload improved from 323.50 ms to 136.90 ms median (2.36x). Smaller cases were noisy and do not establish a speedup.
- Descriptor-inclusive output digests match at 32, 128, and 512 sections, including non-enumerable list and block metadata. Benchmark generation, hashing, and I/O were outside the timed interval.
- Existing Markdown IR and nested-list suites: 54 tests passed. An additional exhaustive check of 19,531 suffix cases, including CR/LF and Unicode line separators, found identical separator decisions.
- Source-performance build passed. Independent review found no actionable issues. Formatting, targeted lint, production core typecheck, and all core test typecheck shards passed. The original local changed-file check flagged `canonicalProviderName` in `scripts/crabbox-wrapper-providers.mts` despite existing external consumers; that export, its consumers, and Knip configuration were unchanged between original baseline7275b4baa025 and the tested patch.
- Refreshed onto main after #145708 repaired the reproduced cold-worker CI failure. `git range-diff` confirms the Markdown patch is identical, and the measured candidate source hash remains unchanged. Fresh exact-head [CI run34679693312](https://github.com/openclaw/openclaw/actions/runs/34679693312) passed, including the originally failing shard.
- Both Markdown suites passed again on refreshed commit `d0068253c7866c20e0bc32c5205dad07db891f0d`: 54 tests, Node 26.8.2, after repairing missing task-local dependency payloads. The checkout remains clean.
- An independent isolated Gateway stress run (8 turns, 1,000 sessions, 100 updates, 540 history reads) exposed a session-list timeout. It does not establish an end-to-end speedup and is being investigated separately.

The benchmark artifact is local task evidence, not a new timing-sensitive CI assertion.


