### PR TITLE
fix(gateway): reduce memory churn when listing sessions

### DIFF
--- a/src/gateway/session-utils-core.ts
+++ b/src/gateway/session-utils-core.ts
@@ -256,9 +256,15 @@ export function resolveSessionChildOwners(params: {
     ? normalizeOptionalString(latest.controllerSessionKey) ||
       normalizeOptionalString(latest.requesterSessionKey)
     : normalizeOptionalString(entry.spawnedBy);
-  return [...new Set([controller, normalizeOptionalString(entry.parentSessionKey)])].filter(
-    (owner): owner is string => Boolean(owner) && owner !== key,
-  );
+  const parent = normalizeOptionalString(entry.parentSessionKey);
+  const owners: string[] = [];
+  if (controller && controller !== key) {
+    owners.push(controller);
+  }
+  if (parent && parent !== key && parent !== controller) {
+    owners.push(parent);
+  }
+  return owners;
 }
 
 /** Index only canonical children; retained run results cannot create session links. */
@@ -275,11 +281,17 @@ export function buildStoreChildSessionIndex(params: {
   }
   const parents = new Set(params.keys);
   // One store pass discovers both persisted navigation and runtime-only controller links.
-  for (const [key, entry] of Object.entries(params.store)) {
+  for (const key of Object.keys(params.store)) {
+    const entry = params.store[key];
     if (!entry || params.excludedChildKeys?.has(key)) {
       continue;
     }
-    for (const owner of resolveSessionChildOwners({ ...params, key, entry })) {
+    for (const owner of resolveSessionChildOwners({
+      key,
+      entry,
+      now: params.now,
+      subagentRuns: params.subagentRuns,
+    })) {
       if (parents.has(owner)) {
         const siblings = children.get(owner) ?? [];
         siblings.push(key);

--- a/src/gateway/session-utils-list.ts
+++ b/src/gateway/session-utils-list.ts
@@ -278,7 +278,8 @@ function filterSessionEntries(params: {
       })
     : undefined;
 
-  for (const [key, entry] of candidateEntries) {
+  for (const pair of candidateEntries) {
+    const [key, entry] = pair;
     if (matchesSearch && !matchesSearch(key, entry)) {
       continue;
     }
@@ -329,9 +330,9 @@ function filterSessionEntries(params: {
       effectiveOwner?.identity?.type === "profile" &&
       effectiveOwner.identity.id === ownerFirstActorId
     ) {
-      ownerEntries.push([key, entry]);
+      ownerEntries.push(pair);
     }
-    entries.push([key, entry]);
+    entries.push(pair);
   }
 
   const { people: visiblePeople, overflow } = projectSessionPeopleFacet(
@@ -355,11 +356,10 @@ function filterSessionEntries(params: {
 }
 
 function isPhantomAgentStoreListEntry(key: string, entry: SessionEntry | undefined): boolean {
-  const parsed = parseAgentSessionKey(key);
   return (
-    parsed?.rest === "sessions" &&
+    entry?.updatedAt == null &&
     !normalizeOptionalString(entry?.sessionId) &&
-    entry?.updatedAt == null
+    parseAgentSessionKey(key)?.rest === "sessions"
   );
 }
 


### PR DESCRIPTION
Related: #145608

## What Problem This Solves

Fixes an issue where users refreshing large session inventories cause excessive temporary memory allocation in the Gateway, including while the Control UI refreshes session rows during other activity.

## Why This Change Was Made

Reuse the existing session entry pairs through filtering and owner-first selection, avoid creating entry tuples and copying unrelated options during child indexing, and collect the two possible navigation owners directly. Established session rows now skip phantom-key parsing. Controller order, parent deduplication, current liveness, filtering, and paging remain unchanged.

## User Impact

Large session inventories create less garbage during each refresh. No configuration or storage migration is required.

## Evidence

- Three matched samples of the actual asynchronous listing entry point: 10,000 sessions, 20% child links, 100-row page, 50 measured calls per sample after warmup. Median V8 sampled allocations fell from 28.226 MB to 17.097 MB per list (39.4%). Sampling includes objects collected by both minor and major GC.
- Full projected rows have an identical SHA-256 before and after. This measures allocation churn; retained-memory and RSS changes are not claimed.
- 58 focused tests passed across subagent navigation, ownership, row-cache, and phantom-placeholder coverage.
- Independent P0-P2 review completed with no findings.
- Production and core-test typechecks, formatting, changed-file lint, and all remaining selected state/import guards passed. The broad local changed gate failed on `canonicalProviderName` and `listPackagedStaticExtensionAssetOutputs`; exact scans reproduced both on unchanged baseline `7275b4b`. No ignores or skip flags were added.
- Paired live OpenAI proof on one isolated Linux Testbox, with this patch plus #145672: 1,000 sessions, eight concurrent model turns, 1,200 history reads, 100 session updates, 100 list/control samples, and subscription probes. All streamed/final replies, RPC history, independent persisted SQLite rows, and probes passed in both arms. Complete source verification matched the three reviewed production files; both arms used the same harness and runtime.
- That single live pair measured load allocations of 4.016 GB → 3.975 GB (-1.0%), and seed plus load of 9.531 GB → 9.501 GB (-0.3%). Session-list inclusive allocations fell 6.1%. These sampled estimates exclude native/worker allocations and do not establish statistical significance. Post-GC heap was effectively flat (327.399 → 327.734 MB), as was sampled workload RSS (818.79 → 822.43 MiB); no retained-memory reduction is claimed.
