### PR TITLE
fix(gateway): reduce memory churn in active progress histories

### DIFF
--- a/src/gateway/server-chat-progress-snapshot.ts
+++ b/src/gateway/server-chat-progress-snapshot.ts
@@ -103,9 +103,29 @@ export function updateChatRunProgressSnapshot(
     ? next.events.find((candidate) => candidate.stream === "usage")
     : undefined;
 
+  let recounted = false;
   const removeWhere = (predicate: (candidate: AgentEventPayload) => boolean) => {
-    next.events = next.events.filter((candidate) => !predicate(candidate));
-    next.byteLength = next.events.reduce((total, candidate) => total + jsonUtf8Bytes(candidate), 0);
+    let removedBytes = 0;
+    next.events = next.events.filter((candidate) => {
+      if (!predicate(candidate)) {
+        return true;
+      }
+      if (recounted) {
+        removedBytes += jsonUtf8Bytes(candidate);
+      }
+      return false;
+    });
+    if (recounted) {
+      next.byteLength -= removedBytes;
+    } else {
+      // Nested producer payloads can change between updates. Recount once,
+      // then charge only evictions during this synchronous update.
+      next.byteLength = next.events.reduce(
+        (total, candidate) => total + jsonUtf8Bytes(candidate),
+        0,
+      );
+      recounted = true;
+    }
   };
 
   if (

--- a/src/gateway/server-chat-state.test.ts
+++ b/src/gateway/server-chat-state.test.ts
@@ -388,6 +388,45 @@ describe("createChatRunState", () => {
     });
   });
 
+  it.each(["tool", "notice"])(
+    "recounts changed payloads before %s activity evicts multiple reconnect owners",
+    (stream) => {
+      const state = createChatRunState();
+      const args = { text: "x".repeat(1_024) };
+      for (let seq = 1; seq <= 50; seq += 1) {
+        state.recordProgressEvent("run-1", {
+          runId: "run-1",
+          seq,
+          stream: "tool",
+          ts: seq,
+          data: { phase: "start", toolCallId: `tool-${seq}`, args },
+        });
+      }
+      // Tool producers can retain and update nested payload objects between events.
+      args.text = "é".repeat(2_048);
+      state.recordProgressEvent("run-1", {
+        runId: "run-1",
+        seq: 51,
+        stream,
+        ts: 51,
+        data:
+          stream === "tool"
+            ? { phase: "start", toolCallId: "latest" }
+            : { phase: "warning", message: "Still running" },
+      });
+      const snapshot = state.runs.get("run-1")?.progressSnapshot;
+      expect(snapshot?.events.at(-1)?.seq).toBe(51);
+      expect(snapshot?.events.length).toBeLessThan(49);
+      expect(snapshot?.byteLength).toBe(
+        snapshot?.events.reduce(
+          (total, event) => total + Buffer.byteLength(JSON.stringify(event)),
+          0,
+        ),
+      );
+      expect(snapshot?.byteLength).toBeLessThanOrEqual(128 * 1024);
+    },
+  );
+
   it("keeps a review-heavy reconnect bounded, adverse, and attached to its owner", () => {
     const state = createChatRunState();
     const event = (seq: number, data: Record<string, unknown>) =>

--- a/src/gateway/server-chat.agent-events.test.ts
+++ b/src/gateway/server-chat.agent-events.test.ts
@@ -634,6 +634,37 @@ describe("agent event handler", () => {
     );
   });
 
+  it("sizes retained progress once when a live event evicts old reconnect activity", () => {
+    const { chatRunState, handler } = createHarness();
+    registerChatRun(chatRunState, "provider-run", "session-1", "client-run");
+    const emit = (seq: number) =>
+      emitAgentEvent(
+        handler,
+        "provider-run",
+        "item",
+        { kind: "preamble", itemId: `item-${seq}`, progressText: "x".repeat(2_048) },
+        { seq },
+      );
+    for (let seq = 1; seq <= 50; seq += 1) {
+      emit(seq);
+    }
+    const retained = chatRunState.runs.get("client-run")?.progressSnapshot?.events.at(-1);
+    const stringify = vi.spyOn(JSON, "stringify");
+    try {
+      emit(51);
+      expect(
+        stringify.mock.calls.filter(([value]) => value === retained).length,
+      ).toBeLessThanOrEqual(1);
+      const snapshot = chatRunState.runs.get("client-run")?.progressSnapshot;
+      expect(snapshot?.events).toHaveLength(50);
+      expect(snapshot?.events[0]?.seq).toBe(2);
+      expect(snapshot?.events.at(-1)?.seq).toBe(51);
+    } finally {
+      stringify.mockRestore();
+      handler.dispose();
+    }
+  });
+
   it("replays cumulative usage with the same client identity as live delivery", () => {
     const { chatRunState, handler, broadcast } = createHarness();
     registerChatRun(chatRunState, "provider-run", "session-1", "client-run");


### PR DESCRIPTION
Related: #145608

## What Problem This Solves

Fixes an issue where long, active Gateway runs allocate excessive temporary memory when the reconnect progress history reaches its event or byte limit. Updating progress repeatedly serialized retained activity again while evicting old entries.

## Why This Change Was Made

Recount retained payload sizes once per synchronous progress update, then subtract the sizes of later evictions in that update. Nested payloads are still remeasured on the next update; no persistent size cache is introduced. Existing event limits, usage preservation, whole-tool eviction, and reconnect ordering remain intact.

## User Impact

Runs with full progress histories create less garbage while continuing to expose the same bounded reconnect activity. No configuration or storage migration is required.

## Evidence

- Actual agent-event handler benchmark: 100 active run histories, 50 retained events each, and 10,000 measured updates. V8 sampled allocations, including objects collected by minor and major GC, fell from 2.329 GB to 1.245 GB (46.5%). Serialized character volume fell 48.5%.
- All 15,000 seeded and measured deliveries, final event order, and exact byte totals were verified. This establishes allocation-churn reduction; no retained-memory or RSS reduction is claimed.
- 258 focused tests passed. The work-bound regression failed before the fix; mutable payload growth, multiple owner eviction, and notice-first eviction remain covered.
- Independent P0-P2 review passed with no findings. Production/core-test typechecks, formatting, lint, and all remaining selected guards passed. The broad local changed gate failed on `canonicalProviderName` and `listPackagedStaticExtensionAssetOutputs`; exact scans reproduced both on unchanged baseline `7275b4b`. No ignores or skip flags were added.
- Paired live OpenAI correctness proof with #145671 passed on one isolated Linux Testbox: 1,000 sessions, eight concurrent turns, 1,200 history reads, 100 session updates, list/control samples, and subscription probes. Both arms verified streamed/final replies, RPC history, and independent persisted SQLite rows, using the same harness and runtime. The tools-denied live workload does not overflow the progress buffer; the separate actual-handler workload proves that condition. The combined live pair showed about 1% less load allocation, with effectively flat retained heap and sampled RSS; it does not establish this patch's live performance effect.
