### PR TITLE
fix(cron): preserve literal script file paths

### DIFF
--- a/docs/automation/cron-jobs/payloads.md
+++ b/docs/automation/cron-jobs/payloads.md
@@ -125,7 +125,7 @@ openclaw automations create "0 * * * *" \
   --announce
 ```
 
-Use `--script <file|->` to read JavaScript from a file or stdin. The timeout defaults to 300 seconds and is capped at 900; the tool budget defaults to 50 calls and is capped at 200. These payload budgets are separate from the smaller trigger-gate evaluation budgets.
+Use `--script <file|->` to read JavaScript from a file or stdin. The CLI preserves leading and trailing spaces in file paths; quote the path as one shell argument. The timeout defaults to 300 seconds and is capped at 900; the tool budget defaults to 50 calls and is capped at 200. These payload budgets are separate from the smaller trigger-gate evaluation budgets.
 
 The script may return an object with these optional fields:
 

--- a/docs/automation/cron-jobs/schedules.md
+++ b/docs/automation/cron-jobs/schedules.md
@@ -115,7 +115,7 @@ Author watchers around **actionable state**, not only success: a watcher that go
 Condition-trigger scripts and `script` payloads run unattended by default with the owning agent's **full tool policy, including `exec`**. Stream schedules also keep operator-authored commands running unattended. Treat these surfaces as unattended code execution with that agent's permissions. Operators who need a hard stop can set `cron.triggers.enabled: false`; remove it or set it to `true` to re-enable them.
 </Warning>
 
-Create a watcher from a local script file (`-` reads the script from stdin):
+Create a watcher from a local script file (`-` reads the script from stdin). The CLI preserves leading and trailing spaces in file paths; quote the path as one shell argument:
 
 ```bash
 openclaw automations add \

--- a/src/cli/cron-cli/register.cron-add.ts
+++ b/src/cli/cron-cli/register.cron-add.ts
@@ -3,6 +3,7 @@ import { parseStrictPositiveInteger } from "@openclaw/normalization-core/number-
 import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
+  readNonBlankString,
 } from "@openclaw/normalization-core/string-coerce";
 import type { Command } from "commander";
 import { theme } from "../../../packages/terminal-core/src/theme.js";
@@ -135,14 +136,15 @@ export function registerCronAddCommand(cron: Command) {
               );
             }
 
-            const payload = (() => {
+            const resolvedPayload = await (async () => {
               // Main-session jobs use system events; isolated/current/session jobs use messages.
               const systemEvent = normalizeOptionalString(opts.systemEvent) ?? "";
               const optionMessage = normalizeOptionalString(opts.message);
               const positionalMessage = normalizeOptionalString(messageArg);
               const commandShell = normalizeOptionalString(opts.command);
               const commandArgv = parseCronCommandArgv(opts.commandArgv);
-              const scriptPath = normalizeOptionalString(opts.script);
+              // File arguments identify exact local paths; trimming can select another file.
+              const scriptPath = readNonBlankString(opts.script);
               const toolsAllow = parseCronToolsAllow(opts.tools);
               if (optionMessage && positionalMessage && optionMessage !== positionalMessage) {
                 throw new CronCliError(
@@ -193,10 +195,10 @@ export function registerCronAddCommand(cron: Command) {
                 }
                 return {
                   kind: "script" as const,
-                  scriptPath,
                   timeoutSeconds: scriptTimeoutSeconds,
                   toolBudget: scriptToolBudget,
                   toolsAllow,
+                  script: await readCronPayloadScript(scriptPath),
                 };
               }
               const timeoutSeconds = parseStrictPositiveInteger(opts.timeoutSeconds);
@@ -247,16 +249,6 @@ export function registerCronAddCommand(cron: Command) {
                 timeoutSeconds,
                 lightContext: opts.lightContext === true ? true : undefined,
                 toolsAllow,
-              };
-            })();
-            const resolvedPayload = await (async () => {
-              if (payload.kind !== "script") {
-                return payload;
-              }
-              const { scriptPath, ...scriptPayload } = payload;
-              return {
-                ...scriptPayload,
-                script: await readCronPayloadScript(scriptPath),
               };
             })();
 
@@ -387,7 +379,7 @@ export function registerCronAddCommand(cron: Command) {
             }
 
             const sessionKey = normalizeOptionalString(opts.sessionKey);
-            const triggerScriptPath = normalizeOptionalString(opts.triggerScript);
+            const triggerScriptPath = readNonBlankString(opts.triggerScript);
             if ((opts.triggerOnce || opts.triggerScript !== undefined) && !triggerScriptPath) {
               throw new CronCliError(
                 `--trigger-${opts.triggerOnce ? "once requires --trigger-script" : "script must not be blank"}`,

--- a/src/cli/cron-cli/register.cron-edit-options.ts
+++ b/src/cli/cron-cli/register.cron-edit-options.ts
@@ -1,5 +1,8 @@
 import { parseStrictPositiveInteger } from "@openclaw/normalization-core/number-coercion";
-import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import {
+  normalizeOptionalString,
+  readNonBlankString,
+} from "@openclaw/normalization-core/string-coerce";
 import { isSystemMonitorDeclaration } from "../../cron/system-owned-declaration.js";
 import type { CronJob } from "../../cron/types.js";
 import { isSystemOwnedCronPayloadKind } from "../../cron/types.js";
@@ -32,7 +35,7 @@ export async function resolveCronEditPayloadDeliveryPatch(
 ): Promise<Record<string, unknown>> {
   const patch: Record<string, unknown> = {};
   const hasSystemEventPatch = typeof opts.systemEvent === "string";
-  const scriptPath = normalizeOptionalString(opts.script);
+  const scriptPath = readNonBlankString(opts.script);
   const commandShell = normalizeOptionalString(opts.command);
   const commandArgv = parseCronCommandArgv(opts.commandArgv);
   if (commandShell && commandArgv) {

--- a/src/cli/cron-cli/register.cron-edit.test.ts
+++ b/src/cli/cron-cli/register.cron-edit.test.ts
@@ -136,40 +136,48 @@ describe("cron edit command", () => {
     });
   });
 
-  it("preserves existing trigger.once when only the script body is replaced (#119916)", async () => {
-    const fixtureDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "cron-edit-cli-"));
-    const scriptPath = path.join(fixtureDir, "next.js");
-    await fs.promises.writeFile(scriptPath, "return { fire: true };", "utf8");
-    const configRevision = "trigger-script-revision";
-    callGatewayFromCli.mockImplementation(async (method: string) => {
-      if (method === "cron.get") {
-        return {
-          id: "job-1",
-          configRevision,
-          trigger: { script: "return { fire: false };", once: true },
-        };
-      }
-      return { ok: true };
-    });
-
-    try {
-      await createCronProgram().parseAsync(["edit", "job-1", "--trigger-script", scriptPath], {
-        from: "user",
+  it.each(["next.js", "next.js "])(
+    "preserves trigger.once when reading %j (#119916)",
+    async (fileName) => {
+      const fixtureDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "cron-edit-cli-"));
+      const scriptPath = path.join(fixtureDir, fileName);
+      await fs.promises.writeFile(
+        path.join(fixtureDir, "next.js"),
+        "return { fire: false };",
+        "utf8",
+      );
+      await fs.promises.writeFile(scriptPath, "return { fire: true };", "utf8");
+      const configRevision = "trigger-script-revision";
+      callGatewayFromCli.mockImplementation(async (method: string) => {
+        if (method === "cron.get") {
+          return {
+            id: "job-1",
+            configRevision,
+            trigger: { script: "return { fire: false };", once: true },
+          };
+        }
+        return { ok: true };
       });
-    } finally {
-      await fs.promises.rm(fixtureDir, { recursive: true, force: true });
-    }
 
-    expect(callGatewayFromCli).toHaveBeenCalledWith(
-      "cron.update",
-      expect.anything(),
-      expect.objectContaining({
-        id: "job-1",
-        patch: { trigger: { script: "return { fire: true };", once: true } },
-        expectedConfigRevision: configRevision,
-      }),
-    );
-  });
+      try {
+        await createCronProgram().parseAsync(["edit", "job-1", "--trigger-script", scriptPath], {
+          from: "user",
+        });
+      } finally {
+        await fs.promises.rm(fixtureDir, { recursive: true, force: true });
+      }
+
+      expect(callGatewayFromCli).toHaveBeenCalledWith(
+        "cron.update",
+        expect.anything(),
+        expect.objectContaining({
+          id: "job-1",
+          patch: { trigger: { script: "return { fire: true };", once: true } },
+          expectedConfigRevision: configRevision,
+        }),
+      );
+    },
+  );
 
   it.each([
     ["empty", "", undefined],

--- a/src/cli/cron-cli/register.cron-edit.ts
+++ b/src/cli/cron-cli/register.cron-edit.ts
@@ -3,6 +3,7 @@ import { parseStrictPositiveInteger } from "@openclaw/normalization-core/number-
 import {
   normalizeOptionalLowercaseString,
   normalizeOptionalString,
+  readNonBlankString,
 } from "@openclaw/normalization-core/string-coerce";
 import type { Command } from "commander";
 import type { CronJob } from "../../cron/types.js";
@@ -182,7 +183,7 @@ export function registerCronEditCommand(cron: Command) {
           if (deliveryModeFlagCount > 1) {
             throw new CronCliError("Choose at most one of --announce, --no-deliver, or --webhook.");
           }
-          const triggerScriptPath = normalizeOptionalString(opts.triggerScript);
+          const triggerScriptPath = readNonBlankString(opts.triggerScript);
           if (typeof opts.triggerScript === "string" && !triggerScriptPath) {
             throw new CronCliError("--trigger-script must not be blank");
           }

--- a/src/cli/cron-cli/trigger-options.test.ts
+++ b/src/cli/cron-cli/trigger-options.test.ts
@@ -46,8 +46,9 @@ describe("cron trigger CLI options", () => {
     }
   });
 
-  it("reads --trigger-script client-side and sends trigger metadata on add", async () => {
-    const scriptPath = path.join(fixtureRoot, "watch.js");
+  it.each(["watch.js", "watch.js "])("reads trigger file %j on add", async (fileName) => {
+    const scriptPath = path.join(fixtureRoot, fileName);
+    await fs.writeFile(path.join(fixtureRoot, "watch.js"), "json({ fire: false })", "utf8");
     await fs.writeFile(scriptPath, "  json({ fire: true })  \n", "utf8");
     const program = new Command().exitOverride();
     registerCronAddCommand(program);
@@ -116,8 +117,9 @@ describe("cron trigger CLI options", () => {
     }
   });
 
-  it("reads --script client-side and sends payload budgets on add", async () => {
-    const scriptPath = path.join(fixtureRoot, "job.js");
+  it.each(["job.js", "job.js "])("reads payload file %j and budgets on add", async (fileName) => {
+    const scriptPath = path.join(fixtureRoot, fileName);
+    await fs.writeFile(path.join(fixtureRoot, "job.js"), "return { notify: 'wrong file' }", "utf8");
     await fs.writeFile(scriptPath, "  return { notify: 'done' }  \n", "utf8");
     const program = new Command().exitOverride();
     registerCronAddCommand(program);
@@ -191,8 +193,13 @@ describe("cron trigger CLI options", () => {
     }
   });
 
-  it("reads script payload updates client-side", async () => {
-    const scriptPath = path.join(fixtureRoot, "edit-job.js");
+  it.each(["edit-job.js", "edit-job.js "])("reads payload file %j on edit", async (fileName) => {
+    const scriptPath = path.join(fixtureRoot, fileName);
+    await fs.writeFile(
+      path.join(fixtureRoot, "edit-job.js"),
+      "return { state: { ok: false } }",
+      "utf8",
+    );
     await fs.writeFile(scriptPath, "return { state: { ok: true } }\n", "utf8");
     const program = new Command().exitOverride();
     registerCronEditCommand(program);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where `cron add` and `cron edit` silently read a different script when a quoted filename contains leading or trailing whitespace. For example, passing `"payload.js "` selected `payload.js` if that neighboring file existed, then reported success.

## Why This Change Was Made

All four payload/trigger file-argument producers now use the existing nonblank string reader, which preserves the original filename. The shared stream reader continues to own the exact `-` stdin sentinel, byte limits, content trimming and read errors.

The add path reads the script in its original payload branch, removing its intermediate script-path representation and second conversion step. Formatted production is **13 lines added / 17 removed, net −4**. Tests are +53/−38 and docs +2/−2. No parser, option, compatibility path or execution policy is added.

## User Impact

The CLI sends the contents of the named local file. Payload budgets, trigger `once`, edit revision handling, ordinary filenames, blank-input validation and existing output/exit behavior remain intact. The docs clarify literal file-path handling.

## Evidence

- Tests-first baseline: **4 intended failures and 120 passing controls** across the trigger, edit and scratch suites. Each failing row used two real files with distinct contents; all four trailing-space arguments selected the decoy file. The repaired suites pass **all 124 tests**.
- Paired ordinary built-CLI proof: eight cases per phase, crossing ordinary/trailing filenames with add/edit and payload/trigger. An input-only loopback recorder captured **18 RPCs per phase**. Baseline sent the decoy contents for all four trailing-space cases; the candidate sent the named files’ contents. Four ordinary controls, payload budgets, trigger metadata, revisions and CLI JSON/wire agreement remain correct.
- Both phases completed naturally: all ten processes per phase exited 0, streams drained, owned groups disappeared, the recorder listener closed, and all sixteen source-file identities/bytes per phase stayed unchanged. The four erroneous baseline invocations were silent successes rather than parse failures.
- All changed-file checks passed. A fresh `pnpm build ciArtifacts` passed in 109.8 seconds; the compiled registrar and all four repaired producer sites were inspected. Fresh managed P0–P2 review found no actionable defects.

The CLI proof uses Node 24.20.0 with the existing launcher-equivalent experimental-warning flag and disabled compile cache. It exercises the normal final runtime on macOS. Generated outputs and named source/ws/Commander files are sealed with qualified frozen-install evidence; this is not a fully hermetic external/native dependency claim. The receiver only records input and returns an acknowledgment: Gateway persistence, scheduler/script execution and channel delivery are outside these observations.

Independent source, current-main compatibility and raw/compiled before/after audits found no blocking discrepancy. This is one shared cron argument-producer defect across four call sites. Current reviewed head: `a7df240e7871b0894018c8f73182e1b374ca9892`; its full-index patch is byte-identical to the tested/reviewed precommit source. Hosted CI remains required before native landing.
