### PR TITLE
test: run Node fixtures with Node under Bun

### DIFF
--- a/test/helpers/run-node-script.ts
+++ b/test/helpers/run-node-script.ts
@@ -1,4 +1,5 @@
 import { runManagedCommand } from "../../scripts/lib/managed-child-process.mts";
+import { resolveTestNodeExecPath } from "../../src/test-utils/node-process.js";
 import { createBoundedChildOutput } from "./bounded-child-output.js";
 
 export async function runNodeScript(
@@ -27,7 +28,7 @@ export async function runNodeScript(
   let error: unknown;
   try {
     status = await runManagedCommand({
-      bin: process.execPath,
+      bin: resolveTestNodeExecPath(),
       args: typeof scriptPathOrArgs === "string" ? [scriptPathOrArgs] : scriptPathOrArgs,
       cwd,
       env,


### PR DESCRIPTION
## What Problem This Solves

`runNodeScript()` launched `process.execPath`, so when Vitest itself ran under Bun, tests explicitly intended to probe Node instead launched Bun. Node-specific `--expose-gc` retention checks then measured a different garbage collector and produced five false failures.

## Why This Change Was Made

The shared helper now uses the existing `resolveTestNodeExecPath()` boundary. Node-hosted tests keep their current executable; Bun-hosted tests skip Bun's `node` shim and launch a real Node process from `PATH`.

## User Impact

This changes test infrastructure only. It lets the direct-Bun test campaign preserve Node-specific subprocess contracts without weakening their memory assertions or changing production behavior.

## Evidence

- Direct custom Bun: `test/helpers/run-node-script.test.ts` 5/5 passed.
- Direct custom Bun: read and exec-output retention probes 5/5 passed; before the fix all five failed under Bun's GC/runtime semantics.
- Node: the same helper tests 5/5 and retention probes 5/5 passed.
- `node scripts/check-changed.mjs`: passed.
- Test-audit authoring gate: the existing tests protect Node memory-retention behavior, the credible regression is executing them under another runtime, existing coverage did not enforce the child runtime, and the fix adds no test-only production seam.
- Independent P0-P2 autoreview: scoped clean at 0.90 confidence.
