### PR TITLE
fix: model catalog scan starves the gateway event loop on large catalogs

### DIFF
--- a/src/agents/model-auth-provider-config.ts
+++ b/src/agents/model-auth-provider-config.ts
@@ -1,6 +1,7 @@
 /**
  * Provider-entry configuration and stored-profile binding for model auth.
  */
+import { isDeepStrictEqual } from "node:util";
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import { resolveMergedModelProviderEntry } from "../config/model-provider-config.js";
 import {
@@ -640,9 +641,14 @@ export function providerConfigMatchesRuntimeSnapshot(params: {
   });
   // Shared provider objects need no catalog traversal; distinct mutable inputs
   // still compare their current bytes before reusing runtime SecretRef provenance.
+  // A deep-equal pass is cheap next to hashing a large provider model catalog
+  // (400+ entries) and catches the common case -- structurally identical but
+  // not object-identical provider configs -- without the cost of two full
+  // structural hashes (openclaw/openclaw#138139).
   return inputProvider && runtimeProvider
     ? params.inputConfig === params.runtimeConfig ||
         inputProvider === runtimeProvider ||
+        isDeepStrictEqual(inputProvider, runtimeProvider) ||
         hashRuntimeConfigValue(toComparableConfig(inputProvider)) ===
           hashRuntimeConfigValue(toComparableConfig(runtimeProvider))
     : false;

--- a/src/agents/model-catalog-decisions.test.ts
+++ b/src/agents/model-catalog-decisions.test.ts
@@ -277,6 +277,35 @@ describe("captured model decisions", () => {
     });
   });
 
+  it("yields to the event loop instead of monopolizing it across a large catalog scan", async () => {
+    // Each call reports a fresh, steadily increasing timestamp so the batch
+    // threshold is always exceeded, regardless of how many other
+    // performance.now() calls land in between (auth resolution, route
+    // matching, etc.).
+    let clockMs = 0;
+    vi.spyOn(performance, "now").mockImplementation(() => (clockMs += 100));
+    const immediateSpy = vi.spyOn(global, "setImmediate");
+    const entries: ModelCatalogEntry[] = Array.from({ length: 5 }, (_, index) => ({
+      provider: "openai",
+      id: `gpt-5.4-${index}`,
+      name: "GPT",
+    }));
+    const owner = createModelCatalogDecisions({
+      cfg: {},
+      agentId: "main",
+      workspaceDir: "/tmp/catalog-workspace",
+      snapshot: { entries, routeVariants: entries },
+      metadataSnapshot: metadata,
+      preparedAuthStore: { version: 1, profiles: {} },
+      routeResolverFactory: routeResolverFactory(dualRoutes),
+    });
+    const results = await Promise.all(entries.map((candidate) => owner.evaluateEntry(candidate)));
+    expect(results).toHaveLength(entries.length);
+    // A scan this size must yield at least once; it must not run every entry
+    // in one uninterrupted microtask batch that starves the event loop.
+    expect(immediateSpy).toHaveBeenCalled();
+  });
+
   it("retains native provenance and mode without blessing a same-name bearer credential", () => {
     expect(
       resolveUsableAgentCredentialModes({

--- a/src/agents/model-catalog-decisions.ts
+++ b/src/agents/model-catalog-decisions.ts
@@ -120,7 +120,9 @@ function createModelsListEntryEvaluator(params: {
     }
     const next = evaluationTail.then(async (): Promise<ModelAuthAvailabilityEvaluation> => {
       if (performance.now() - batchStartedAt >= 8) {
-        await new Promise((resolve) => setImmediate(resolve));
+        await new Promise<void>((resolve) => {
+          setImmediate(resolve);
+        });
         batchStartedAt = performance.now();
       }
       const defaultProfileId = params.preferredProfilesByProvider?.get(

--- a/src/agents/model-catalog-decisions.ts
+++ b/src/agents/model-catalog-decisions.ts
@@ -98,6 +98,12 @@ function createModelsListEntryEvaluator(params: {
   runtimeId?: string,
 ) => Promise<ModelAuthAvailabilityEvaluation> {
   const pending = new Map<string, Promise<ModelAuthAvailabilityEvaluation>>();
+  // A large configured model list evaluates every entry in the same microtask
+  // batch, starving the event loop for the whole scan (#observed on 2026.9.4).
+  // Yielding back to the loop every ~8ms keeps concurrent I/O responsive
+  // without changing any evaluation result, only when it becomes available.
+  let evaluationTail: Promise<unknown> = Promise.resolve();
+  let batchStartedAt = performance.now();
   return (entry, routeVariants, runtimeId) => {
     const identity = openAIModelCatalogRoutePolicy.resolveIdentity(entry);
     const observedRoutes = (routeVariants ?? [entry]).map(({ api, baseUrl }) => ({ api, baseUrl }));
@@ -112,7 +118,11 @@ function createModelsListEntryEvaluator(params: {
     if (cached) {
       return cached;
     }
-    const next = Promise.resolve().then((): ModelAuthAvailabilityEvaluation => {
+    const next = evaluationTail.then(async (): Promise<ModelAuthAvailabilityEvaluation> => {
+      if (performance.now() - batchStartedAt >= 8) {
+        await new Promise((resolve) => setImmediate(resolve));
+        batchStartedAt = performance.now();
+      }
       const defaultProfileId = params.preferredProfilesByProvider?.get(
         normalizeProviderId(entry.provider),
       );
@@ -158,6 +168,10 @@ function createModelsListEntryEvaluator(params: {
           }
         : resolved;
     });
+    evaluationTail = next.then(
+      () => undefined,
+      () => undefined,
+    );
     pending.set(cacheKey, next);
     return next;
   };


### PR DESCRIPTION
Closes #145675
Related: #138139

## What Problem This Solves

Fixes an issue where users with a large configured model catalog (hundreds of provider entries) would experience the Gateway becoming fully unresponsive to all concurrent traffic -- dashboard, chat channels, RPC -- for the duration of a catalog evaluation pass. Concurrent requests, including a plain HTTP request to `/healthz`, get no response at all until the scan finishes; from the outside this looks like the Gateway went offline.

## Why This Change Was Made

`createModelsListEntryEvaluator` scheduled every catalog entry as an independent `Promise.resolve().then(...)`, so a large catalog ran as one uninterrupted microtask batch with no point where control returned to the event loop between entries. The fix chains entries through a single tail promise and yields back to the event loop (via `setImmediate`) roughly every 8ms of wall-clock time spent evaluating, instead of letting every entry run in the same batch. No evaluation result, cache key, or ordering guarantee changes -- only *when* each result becomes available.

Separately, this also adds a smaller, always-correct improvement to `providerConfigMatchesRuntimeSnapshot` (called from within each entry's evaluation): a deep-equal shortcut before the two `hashRuntimeConfigValue` calls, for the common case of structurally-identical-but-not-reference-identical provider configs. This is related to #138139 but does not fully close it -- that issue's suggested identity-keyed memoization breaks an existing test that models in-place runtime-config mutation (`keeps distinct configurations current after runtime mutation and replacement`); details in [my comment on that issue](https://github.com/openclaw/openclaw/issues/138139#issuecomment-5644065185). This PR takes the safe subset (a fresh-every-call shortcut, never stale) rather than the full memoization. (Note: #138351 has since merged a separate, narrower shared-object shortcut for that same function; this PR's `isDeepStrictEqual` addition targets the different, still-uncovered case of distinct-but-equal objects.)

## User Impact

The Gateway keeps answering concurrent requests while a large model-catalog scan runs, instead of appearing to hang or go offline until the scan completes.

## Evidence

### Real production reproduction (2026.9.4, before the fix existed)

This defect was found by diagnosing a live incident, not by reading the source in the abstract. On the affected install, while a catalog scan was in flight:

```text
$ top -bn1 -H -p <gateway-pid>
  PID USER  PR  NI  VIRT   RES   SHR S  %CPU %MEM  TIME+  COMMAND
 <pid> ...  20   0  27.6g  1.0g  ...  R  93.9  1.6  7:42.90 MainThread

$ curl -s -m 5 -o /dev/null -w "HTTP %{http_code} in %{time_total}s\n" http://127.0.0.1:18789/healthz
HTTP 000 in 5.002484s

$ openclaw gateway health
gateway timeout after 10000ms
```

After applying this fix and restarting:

```text
$ openclaw gateway health
Gateway Health
OK (79ms)
Telegram: configured

$ openclaw gateway call health
{ "ok": true, "eventLoop": { "degraded": false, "reasons": [] }, ... }
```

### Controlled before/after measurement (isolated repro, this checkout)

To get a clean, repeatable A/B measurement (not just the live incident above), I wrote a small standalone script (not part of this diff) that:
- builds the same `createModelCatalogDecisions` owner used by the real Gateway, with a synthetic 500-entry catalog across two providers,
- starts a real local HTTP server sharing the process's event loop (the closest same-process analog to the Gateway's own `/healthz` handler),
- fires real concurrent HTTP requests against it every 5ms while `Promise.all(entries.map(owner.evaluateEntry))` runs,
- measures actual request latency, success/timeout counts, total scan time, and process RSS.

Ran 3 times each on `main` (unpatched) and on this branch (patched), Node v24.19.0:

| | Unpatched (`main`) | Patched (this PR) |
|---|---|---|
| Concurrent requests attempted per run | ~18 | ~18 |
| Concurrent requests that **succeeded** | **1** (all 3 runs) | **17-18** (all 3 runs) |
| Concurrent requests that timed out | 0 (rest just never got a chance to run before the scan ended) | 0 |
| Median successful-request latency | 1653-1772ms (i.e. the one request that got through waited almost the entire scan) | 10ms |
| Scan wall time (500 entries) | 1627-1742ms | 1747-2519ms* |
| Process RSS delta during scan | +10MB | +10-21MB |

\* Slightly higher on the patched side -- expected, since the scan now periodically yields to the event loop instead of running flat-out; this is the traded-off cost of staying responsive, not a regression in per-entry work.

Raw output, patched run 1:
```json
{"entries":500,"scanElapsedMs":2519,"concurrentRequestsDuringScan":17,"concurrentRequestsSucceeded":17,"concurrentRequestsTimedOut":0,"maxRequestLatencyMs":2210,"medianRequestLatencyMs":10,"rssBeforeMb":627,"rssAfterMb":648}
```
Raw output, unpatched run 1:
```json
{"entries":500,"scanElapsedMs":1627,"concurrentRequestsDuringScan":1,"concurrentRequestsSucceeded":1,"concurrentRequestsTimedOut":0,"maxRequestLatencyMs":1653,"medianRequestLatencyMs":1653,"rssBeforeMb":630,"rssAfterMb":640}
```

Honest caveat: in every patched run, the very first concurrent request (only) landed before the first yield point and took longer than the steady-state 10ms median (up to ~2.2s) -- consistent with it racing the initial synchronous batch of promise-chain construction before any yield has occurred yet. Every subsequent request in every patched run was fast and none timed out; in the unpatched baseline, only that first request *ever* got serviced at all, and only once the whole scan had nearly finished.

### Test coverage

- Added a regression test (`yields to the event loop instead of monopolizing it across a large catalog scan`) that mocks `performance.now()` to force the yield threshold and asserts `setImmediate` is invoked. Verified it fails without the fix and passes with it (confirmed via `git stash`/`git checkout main --` before finalizing).
- Existing coverage for the deep-equal shortcut: `provider config structural comparison > matches a equivalent clone` in `model-auth.test.ts` already exercises the structurally-identical/different-reference case this shortcut targets, and still passes.
- Full targeted lane: `node scripts/run-vitest.mjs run --config test/vitest/vitest.agents.config.ts src/agents/model-auth.test.ts src/agents/model-catalog-decisions.test.ts` -- 110/110 passing.
- `pnpm tsgo` (core typecheck) clean; `oxfmt --check` clean on all three changed files.
