### PR TITLE
improve: reduce repeated plugin state registration work

### DIFF
--- a/src/plugin-state/plugin-state-store.kernel.ts
+++ b/src/plugin-state/plugin-state-store.kernel.ts
@@ -298,19 +298,49 @@ export function deleteExpiredPluginStateEntries(
   return Number(result.numAffectedRows ?? 0);
 }
 
+type PluginStateNamespaceCountParams = { pluginId: string; namespace: string; now: number };
+type PluginStateCountRow = { count: number | bigint };
+const pluginStateNamespaceCountQueries = new WeakMap<
+  DatabaseSync,
+  ReturnType<typeof prepareSqliteQuerySync<PluginStateNamespaceCountParams, PluginStateCountRow>>
+>();
+
 function countLivePluginStateNamespaceEntries(
   db: DatabaseSync,
-  params: { pluginId: string; namespace: string; now: number },
+  params: PluginStateNamespaceCountParams,
 ): number {
-  const row = executeSqliteQueryTakeFirstSync(
-    db,
-    getPluginStateKysely(db)
-      .selectFrom("plugin_state_entries")
-      .select((eb) => eb.fn.countAll<number | bigint>().as("count"))
-      .where("plugin_id", "=", params.pluginId)
-      .where("namespace", "=", params.namespace)
-      .where((eb) => eb.or([eb("expires_at", "is", null), eb("expires_at", ">", params.now)])),
-  );
+  let query = pluginStateNamespaceCountQueries.get(db);
+  if (!query) {
+    query = prepareSqliteQuerySync<PluginStateNamespaceCountParams, PluginStateCountRow>(
+      db,
+      (parameter) =>
+        getPluginStateKysely(db)
+          .selectFrom("plugin_state_entries")
+          .select((eb) => eb.fn.countAll<number | bigint>().as("count"))
+          .where(
+            "plugin_id",
+            "=",
+            parameter((value) => value.pluginId),
+          )
+          .where(
+            "namespace",
+            "=",
+            parameter((value) => value.namespace),
+          )
+          .where((eb) =>
+            eb.or([
+              eb("expires_at", "is", null),
+              eb(
+                "expires_at",
+                ">",
+                parameter((value) => value.now),
+              ),
+            ]),
+          ),
+    );
+    pluginStateNamespaceCountQueries.set(db, query);
+  }
+  const row = query(params).rows[0];
   return coerceRequiredSqliteNumber(row?.count ?? 0);
 }
 
@@ -334,18 +364,41 @@ export function allocatePluginStateNamespaceCreatedAt(
   return next;
 }
 
+type PluginStateCountParams = { pluginId: string; now: number };
+const pluginStateCountQueries = new WeakMap<
+  DatabaseSync,
+  ReturnType<typeof prepareSqliteQuerySync<PluginStateCountParams, PluginStateCountRow>>
+>();
+
 export function countLivePluginStateEntries(
   db: DatabaseSync,
-  params: { pluginId: string; now: number },
+  params: PluginStateCountParams,
 ): number {
-  const row = executeSqliteQueryTakeFirstSync(
-    db,
-    getPluginStateKysely(db)
-      .selectFrom("plugin_state_entries")
-      .select((eb) => eb.fn.countAll<number | bigint>().as("count"))
-      .where("plugin_id", "=", params.pluginId)
-      .where((eb) => eb.or([eb("expires_at", "is", null), eb("expires_at", ">", params.now)])),
-  );
+  let query = pluginStateCountQueries.get(db);
+  if (!query) {
+    query = prepareSqliteQuerySync<PluginStateCountParams, PluginStateCountRow>(db, (parameter) =>
+      getPluginStateKysely(db)
+        .selectFrom("plugin_state_entries")
+        .select((eb) => eb.fn.countAll<number | bigint>().as("count"))
+        .where(
+          "plugin_id",
+          "=",
+          parameter((value) => value.pluginId),
+        )
+        .where((eb) =>
+          eb.or([
+            eb("expires_at", "is", null),
+            eb(
+              "expires_at",
+              ">",
+              parameter((value) => value.now),
+            ),
+          ]),
+        ),
+    );
+    pluginStateCountQueries.set(db, query);
+  }
+  const row = query(params).rows[0];
   return coerceRequiredSqliteNumber(row?.count ?? 0);
 }
 
@@ -573,12 +626,17 @@ export function registerPluginStateEntry(
       retention.sweepPending = deleted === PLUGIN_STATE_EXPIRY_BATCH_ROWS;
     }
   }
-  const existing = selectPluginStateEntry(store.db, {
-    pluginId: params.pluginId,
-    namespace: params.namespace,
-    key: params.key,
-    now,
-  });
+  // Ordinary evicting writes enforce quotas after the upsert; they do not need
+  // to load the previous payload. Reject-new and batch counts still need existence.
+  const existing =
+    retention || params.overflowPolicy === "reject-new"
+      ? selectPluginStateEntry(store.db, {
+          pluginId: params.pluginId,
+          namespace: params.namespace,
+          key: params.key,
+          now,
+        })
+      : undefined;
   if (!existing) {
     assertCanInsertPluginStateEntry({
       store,

--- a/src/plugin-state/plugin-state-store.prepared.test.ts
+++ b/src/plugin-state/plugin-state-store.prepared.test.ts
@@ -120,7 +120,7 @@ describe("plugin state prepared queries", () => {
   });
 
   it.each(["register", "registerIfAbsent"] as const)(
-    "reuses %s compilation with fresh write bindings after reopening",
+    "reuses %s write and quota compilation with fresh bindings after reopening",
     (operation) => {
       const options = { namespace: "prepared-writes", maxEntries: 20 };
       const stores = [
@@ -166,6 +166,14 @@ describe("plugin state prepared queries", () => {
               (result) => result.type === "return" && result.value.sql.startsWith("insert"),
             );
             expect(writes).toHaveLength(1);
+            const counts = compile.mock.results.filter(
+              (result) =>
+                result.type === "return" &&
+                result.value.sql.startsWith(
+                  'select count(*) as "count" from "plugin_state_entries"',
+                ),
+            );
+            expect(counts).toHaveLength(2);
           } finally {
             compile.mockRestore();
           }


### PR DESCRIPTION
## What Problem This Solves

Plugin state registrations repeatedly compile the same quota queries and load an existing payload even when the eviction policy does not use it.

## Why This Change Was Made

Reuse compiled namespace and plugin counts for each database connection through the existing prepared-query executor. Ordinary evicting registrations skip the unused payload read; reject-new and migration batch retention preserve their existence checks. Quota, expiry, transaction, and recovery behavior stay the same.

## User Impact

Less SQLite query setup and payload allocation during plugin state writes.

## Evidence

- 121 tests passed across 13 plugin-state files; three existing Windows exclusions remain skipped.
- Paired measurements of the actual registration kernel on Node 26.8.2 / SQLite 3.53.4: 100 rows, 84.99 → 64.64 µs; 3,000 rows, 601.24 → 553.53 µs; 30,000 rows, 5,135.06 → 4,876.11 µs. Seven alternating rounds after warmup.
- Full public registration timings were noisy and do not establish an end-to-end speedup.
- The compilation regression assertion fails on the original code and passes with fresh bindings after reopening. Independent review found no P0–P2 issues.
