### PR TITLE
improve: stop SQLite first-row reads after one result

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt-transcript-helpers.presence.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-transcript-helpers.presence.test.ts
@@ -72,19 +72,31 @@ it("keeps one presence snapshot while another connection classifies a message", 
       ) {
         return statement;
       }
+      const classify = () => {
+        // Commit classification after the index probe finishes, while the
+        // physical message remains present throughout both connections.
+        writer
+          .prepare(
+            "UPDATE transcript_event_identities SET event_type = 'message' WHERE session_id = ?",
+          )
+          .run(sessionTarget.sessionId);
+        classified = true;
+      };
       return new Proxy(statement, {
         get(target, property) {
+          if (property === "get") {
+            return new Proxy(target.get.bind(target), {
+              apply(get, _receiver, params) {
+                const row = get(...params);
+                classify();
+                return row;
+              },
+            });
+          }
           if (property === "iterate") {
             return (...params: Parameters<typeof target.iterate>) => {
               const rows = [...target.iterate(...params)];
-              // Commit classification after the index probe finishes, while the
-              // physical message remains present throughout both connections.
-              writer
-                .prepare(
-                  "UPDATE transcript_event_identities SET event_type = 'message' WHERE session_id = ?",
-                )
-                .run(sessionTarget.sessionId);
-              classified = true;
+              classify();
               return rows.values();
             };
           }

--- a/src/agents/sessions/session-manager-model-context.test.ts
+++ b/src/agents/sessions/session-manager-model-context.test.ts
@@ -44,7 +44,8 @@ it("acquires a long sparse context with bounded queries and preserved message or
     ]);
     const database = openOpenClawAgentDatabase({ agentId: "main", path: scope.storePath });
     const prototype = Object.getPrototypeOf(database.db.prepare("SELECT 1")) as StatementSync;
-    const spy = vi.spyOn(prototype, "iterate");
+    const iterate = vi.spyOn(prototype, "iterate");
+    const get = vi.spyOn(prototype, "get");
     try {
       const context = SessionManager.openModelContext(scope).buildSessionContext();
       expect(context.messages.map((message) => "content" in message && message.content)).toEqual(
@@ -53,12 +54,13 @@ it("acquires a long sparse context with bounded queries and preserved message or
           .map((entry) => entry.message.content),
       );
       // Protect acquisition cost independently of the exact chunk size or query implementation.
-      expect(spy.mock.calls.length).toBeLessThan(20);
+      expect(iterate.mock.calls.length + get.mock.calls.length).toBeLessThan(20);
       expect((await SessionManager.openModelContextAsync(scope)).buildSessionContext()).toEqual(
         context,
       );
     } finally {
-      spy.mockRestore();
+      iterate.mockRestore();
+      get.mockRestore();
     }
   });
 });

--- a/src/config/sessions/session-accessor.sqlite-cold-read.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-cold-read.test.ts
@@ -132,6 +132,16 @@ async function prepareRace(state: OpenClawTestState) {
       if (!matches(query)) {
         return statement;
       }
+      const nativeGet = statement.get.bind(statement);
+      vi.spyOn(statement, "get").mockImplementation(
+        new Proxy(nativeGet, {
+          apply(get, _receiver, args) {
+            const row = get(...args);
+            commitArchive();
+            return row;
+          },
+        }),
+      );
       const iterate = statement.iterate.bind(statement);
       vi.spyOn(statement, "iterate").mockImplementation(function* (...args) {
         yield* iterate(...args);

--- a/src/infra/kysely-sync.test.ts
+++ b/src/infra/kysely-sync.test.ts
@@ -65,6 +65,28 @@ describe("kysely sync helpers", () => {
     ]);
   });
 
+  it("stops first-row selects without evaluating later rows and releases the reader", () => {
+    database = new DatabaseSync(":memory:");
+    database.exec("create table items (id integer primary key, name text not null)");
+    database.exec("insert into items values (1, 'Ada'), (2, 'Grace'), (3, 'Lin')");
+    enableNodeSqliteKyselyStatementCache(database);
+    const db = getNodeSqliteKysely<SyncHelperTestDatabase>(database);
+    const visited: number[] = [];
+    database.function("visit", (id) => {
+      visited.push(Number(id));
+      return id;
+    });
+    const select = db.selectFrom("items").select(db.fn<number>("visit", ["id"]).as("id"));
+    for (let attempt = 0; attempt < 3; attempt++) {
+      visited.length = 0;
+      expect(executeSqliteQueryTakeFirstSync(database, select)).toEqual({ id: 1 });
+      expect(visited).toEqual([1]);
+    }
+    database.exec("drop table items");
+    database.exec("create table items (id integer primary key, name text not null)");
+    expect(executeSqliteQueryTakeFirstSync(database, select)).toBeUndefined();
+  });
+
   it("preserves raw readers and distinguishes writes with and without returned rows", () => {
     database = new DatabaseSync(":memory:");
     database.exec("create table items (id integer primary key, name text not null)");
@@ -453,33 +475,38 @@ describe("kysely sync helpers", () => {
     expect(prepares.calls()).toBe(3);
   });
 
-  it.each(["eager", "lazy"])("reads current columns without allocating metadata (%s)", (mode) => {
-    database = new DatabaseSync(":memory:");
-    database.exec("create table items (id integer primary key, name text not null)");
-    database.exec("insert into items (id, name) values (1, 'Ada')");
-    const db = getNodeSqliteKysely<SyncHelperTestDatabase>(database);
-    const select = db.selectFrom("items").selectAll();
-    const prepares = countPrepares(database);
-    const columns = vi.spyOn(StatementSync.prototype, "columns");
-    const read = () =>
-      mode === "eager"
-        ? executeSqliteQuerySync(database!, select).rows
-        : [...iterateSqliteQuerySync(database!, select)];
-    try {
-      for (let attempt = 0; attempt < 3; attempt++) {
-        expect(read()).toEqual([{ id: 1, name: "Ada" }]);
+  it.each(["eager", "lazy", "first"])(
+    "reads current columns without allocating metadata (%s)",
+    (mode) => {
+      database = new DatabaseSync(":memory:");
+      database.exec("create table items (id integer primary key, name text not null)");
+      database.exec("insert into items (id, name) values (1, 'Ada')");
+      const db = getNodeSqliteKysely<SyncHelperTestDatabase>(database);
+      const select = db.selectFrom("items").selectAll();
+      const prepares = countPrepares(database);
+      const columns = vi.spyOn(StatementSync.prototype, "columns");
+      const read = () =>
+        mode === "eager"
+          ? executeSqliteQuerySync(database!, select).rows
+          : mode === "first"
+            ? [executeSqliteQueryTakeFirstSync(database!, select)]
+            : [...iterateSqliteQuerySync(database!, select)];
+      try {
+        for (let attempt = 0; attempt < 3; attempt++) {
+          expect(read()).toEqual([{ id: 1, name: "Ada" }]);
+        }
+        expect(prepares.calls()).toBe(mode === "lazy" ? 3 : 2);
+
+        database.exec("alter table items add column note text not null default 'new'");
+
+        expect(read()).toEqual([{ id: 1, name: "Ada", note: "new" }]);
+        expect(prepares.calls()).toBe(mode === "lazy" ? 4 : 2);
+        expect(columns).not.toHaveBeenCalled();
+      } finally {
+        columns.mockRestore();
       }
-      expect(prepares.calls()).toBe(mode === "eager" ? 2 : 3);
-
-      database.exec("alter table items add column note text not null default 'new'");
-
-      expect(read()).toEqual([{ id: 1, name: "Ada", note: "new" }]);
-      expect(prepares.calls()).toBe(mode === "eager" ? 2 : 4);
-      expect(columns).not.toHaveBeenCalled();
-    } finally {
-      columns.mockRestore();
-    }
-  });
+    },
+  );
 
   it("resets a cached row statement after a step-time error", () => {
     database = new DatabaseSync(":memory:");

--- a/src/infra/kysely-sync.ts
+++ b/src/infra/kysely-sync.ts
@@ -68,12 +68,20 @@ function reportNodeSqliteKyselyQueryError(db: DatabaseSync, error: unknown): voi
 function executeCompiledSqliteQuerySync<Row>(
   db: DatabaseSync,
   compiledQuery: CompiledQuery<Row>,
+  firstRowOnly = false,
 ): QueryResult<Row> {
   const parameters = compiledQuery.parameters as SQLInputValue[];
   try {
     const sql = compiledQuery.sql;
     installStatementInvalidation(db);
     return executeWithCachedStatement(db, sql, parameters, (statement) => {
+      if (firstRowOnly && SelectQueryNode.is(compiledQuery.query)) {
+        // get() reads columns after step/reprepare and resets the reader before returning.
+        // Raw SQL and writes still run to completion through the general executor.
+        // SAFETY: the compiled Kysely selection defines the native result row shape.
+        const row = statement.get(...parameters) as Row | undefined;
+        return { rows: row === undefined ? [] : [row] };
+      }
       // SELECT already guarantees a reader; avoid allocating native column metadata
       // just to classify it. Raw SQL and other roots still need native classification.
       if (SelectQueryNode.is(compiledQuery.query) || statement.columns().length > 0) {
@@ -194,5 +202,5 @@ export function executeSqliteQueryTakeFirstSync<Row>(
   db: DatabaseSync,
   query: Compilable<Row>,
 ): Row | undefined {
-  return executeSqliteQuerySync<Row>(db, query).rows[0];
+  return executeCompiledSqliteQuerySync(db, query.compile(), true).rows[0];
 }

--- a/src/infra/update-managed-service-handoff-retarget.test.ts
+++ b/src/infra/update-managed-service-handoff-retarget.test.ts
@@ -315,15 +315,20 @@ unix("leaves source and destination unchanged when destination inspection is unr
     db.prepare = (sql) => {
       const statement = prepare(sql);
       if (sql.startsWith('select "owner"')) {
-        const iterate = statement.iterate.bind(statement);
-        statement.iterate = (root) => {
+        const requireReadableRoot = (root: unknown) => {
           if (typeof root !== "string") {
             throw new Error("expected one positional installation root");
           }
           if (root === to) {
             throw new Error("destination unreadable");
           }
-          return iterate(root);
+          return root;
+        };
+        const get = statement.get.bind(statement);
+        statement.get = (root) => get(requireReadableRoot(root));
+        const iterate = statement.iterate.bind(statement);
+        statement.iterate = (root) => {
+          return iterate(requireReadableRoot(root));
         };
       }
       return statement;

--- a/src/plugins/installed-plugin-index-store.install-record-map.test.ts
+++ b/src/plugins/installed-plugin-index-store.install-record-map.test.ts
@@ -93,6 +93,7 @@ describe("installed plugin index install-record persistence", () => {
           }
           const { StatementSync } = requireNodeSqlite();
           const iterate = vi.spyOn(StatementSync.prototype, "iterate");
+          const get = vi.spyOn(StatementSync.prototype, "get");
           const readRecords = () =>
             expect(readPersistedInstalledPluginIndexInstallRecords({ stateDir })).toEqual(records);
           const readIndex = () => {
@@ -111,16 +112,18 @@ describe("installed plugin index install-record persistence", () => {
           }
 
           expect(
-            iterate.mock.calls.filter((params, index) => {
-              const statement = iterate.mock.contexts[index];
-              return (
-                statement instanceof StatementSync &&
-                params.includes("plugins.installedIndex") &&
-                /SELECT\s+"?value_json"?\s+FROM\s+"?config_machine_state"?\s+WHERE\s+"?state_key"?\s*=/i.test(
-                  statement.sourceSQL,
-                )
-              );
-            }),
+            [iterate, get].flatMap((spy) =>
+              spy.mock.calls.filter((params, index) => {
+                const statement = spy.mock.contexts[index];
+                return (
+                  statement instanceof StatementSync &&
+                  params.includes("plugins.installedIndex") &&
+                  /SELECT\s+"?value_json"?\s+FROM\s+"?config_machine_state"?\s+WHERE\s+"?state_key"?\s*=/i.test(
+                    statement.sourceSQL,
+                  )
+                );
+              }),
+            ),
           ).toHaveLength(1);
         },
       );

--- a/src/skills/lifecycle/upload-store.test.ts
+++ b/src/skills/lifecycle/upload-store.test.ts
@@ -339,23 +339,38 @@ describe("skill upload store", () => {
     const archiveReads: Array<{ bytes: number; inTransaction: boolean }> = [];
     const nativeBlobs = new WeakSet<Uint8Array>();
     const bufferFrom = vi.spyOn(Buffer, "from");
+    const observeRow = (row: Record<string, unknown>) => {
+      for (const bytes of [row.chunk_blob, row.archive_blob]) {
+        if (bytes instanceof Uint8Array) {
+          nativeBlobs.add(bytes);
+        }
+      }
+      if (row.archive_blob instanceof Uint8Array) {
+        archiveReads.push({
+          bytes: row.archive_blob.byteLength,
+          inTransaction: db.isTransaction,
+        });
+      }
+    };
     const nativePrepare = db.prepare.bind(db);
     vi.spyOn(db, "prepare").mockImplementation((sql) => {
       const statement = nativePrepare(sql);
+      const nativeGet = statement.get.bind(statement);
+      vi.spyOn(statement, "get").mockImplementation(
+        new Proxy(nativeGet, {
+          apply(get, _receiver, bindings) {
+            const row = get(...bindings);
+            if (row) {
+              observeRow(row);
+            }
+            return row;
+          },
+        }),
+      );
       const iterate = statement.iterate.bind(statement);
       vi.spyOn(statement, "iterate").mockImplementation(function* (...bindings) {
         for (const row of iterate(...bindings)) {
-          for (const bytes of [row.chunk_blob, row.archive_blob]) {
-            if (bytes instanceof Uint8Array) {
-              nativeBlobs.add(bytes);
-            }
-          }
-          if (row.archive_blob instanceof Uint8Array) {
-            archiveReads.push({
-              bytes: row.archive_blob.byteLength,
-              inTransaction: db.isTransaction,
-            });
-          }
+          observeRow(row);
           yield row;
         }
         return undefined;

--- a/src/transcripts/library.test.ts
+++ b/src/transcripts/library.test.ts
@@ -63,6 +63,31 @@ function observeArchiveReads(database: DatabaseSync) {
     }
     const record = { sql, rows: 0, bytes: 0, maxRowBytes: 0, closed: false };
     queries.push(record);
+    const observeRow = (row: Record<string, unknown>) => {
+      const bytes = Object.values(row).reduce<number>(
+        (total, value) => total + (typeof value === "string" ? Buffer.byteLength(value) : 0),
+        0,
+      );
+      record.rows++;
+      record.bytes += bytes;
+      record.maxRowBytes = Math.max(record.maxRowBytes, bytes);
+    };
+    const nativeGet = statement.get.bind(statement);
+    vi.spyOn(statement, "get").mockImplementation(
+      new Proxy(nativeGet, {
+        apply(get, _receiver, parameters) {
+          try {
+            const row = get(...parameters);
+            if (row) {
+              observeRow(row);
+            }
+            return row;
+          } finally {
+            record.closed = true;
+          }
+        },
+      }),
+    );
     const iterate = statement.iterate.bind(statement);
     vi.spyOn(statement, "iterate").mockImplementation((...parameters) => {
       const iterator = iterate(...parameters);
@@ -72,13 +97,7 @@ function observeArchiveReads(database: DatabaseSync) {
         if (result.done) {
           record.closed = true;
         } else {
-          const bytes = Object.values(result.value).reduce<number>(
-            (total, value) => total + (typeof value === "string" ? Buffer.byteLength(value) : 0),
-            0,
-          );
-          record.rows++;
-          record.bytes += bytes;
-          record.maxRowBytes = Math.max(record.maxRowBytes, bytes);
+          observeRow(result.value);
         }
         return result;
       });

--- a/test/helpers/sqlite-statement-execution-counter.ts
+++ b/test/helpers/sqlite-statement-execution-counter.ts
@@ -5,7 +5,7 @@ import { clearNodeSqliteKyselyCacheForDatabase } from "../../src/infra/kysely-sy
 /**
  * Count SQLite query executions per caller-defined bucket. Prepared-statement
  * caching (src/infra/kysely-sync.ts) reuses statements across calls, so
- * counting `prepare` invocations undercounts; this wraps `iterate` and `run` on matching
+ * counting `prepare` invocations undercounts; this wraps `get`, `iterate`, and `run` on matching
  * statements and clears the statement cache at attach so statements cached
  * before the spy cannot bypass it.
  */
@@ -23,6 +23,14 @@ export function trackSqliteStatementExecutions<Key extends string>(
   const counts = Object.fromEntries(keys.map((key) => [key, 0])) as Record<Key, number>;
   const rowCounts = Object.fromEntries(keys.map((key) => [key, 0])) as Record<Key, number>;
   const textBytes = Object.fromEntries(keys.map((key) => [key, 0])) as Record<Key, number>;
+  const observeRow = (key: Key, row: Record<string, unknown>) => {
+    rowCounts[key] += 1;
+    for (const value of Object.values(row)) {
+      if (typeof value === "string") {
+        textBytes[key] += Buffer.byteLength(value);
+      }
+    }
+  };
   const originalPrepare = db.prepare.bind(db);
   const prepareSpy = vi.spyOn(db, "prepare").mockImplementation((sqlText: string) => {
     const statement = originalPrepare(sqlText);
@@ -35,6 +43,16 @@ export function trackSqliteStatementExecutions<Key extends string>(
           return Reflect.apply(run, receiver, args);
         },
       });
+      statement.get = new Proxy(statement.get.bind(statement), {
+        apply(get, _receiver, args) {
+          counts[key] += 1;
+          const row = get(...args);
+          if (row) {
+            observeRow(key, row);
+          }
+          return row;
+        },
+      });
       const originalIterate = statement.iterate.bind(statement) as (
         ...args: unknown[]
       ) => ReturnType<StatementSync["iterate"]>;
@@ -44,12 +62,7 @@ export function trackSqliteStatementExecutions<Key extends string>(
         const rows = originalIterate(...args);
         return (function* () {
           for (const row of rows) {
-            rowCounts[key] += 1;
-            for (const value of Object.values(row)) {
-              if (typeof value === "string") {
-                textBytes[key] += Buffer.byteLength(value);
-              }
-            }
+            observeRow(key, row);
             yield row;
           }
         })();


### PR DESCRIPTION
## What Problem This Solves

SQLite callers requesting one result currently allocate and iterate every selected row before returning the first, adding work to frequent state lookups.

## Why This Change Was Made

Use node:sqlite's `get()` for compiled SELECT roots in the first-row helper. The existing statement cache still owns reuse, invalidation, and reentry. Raw SQL and writes, including RETURNING statements, retain completion semantics. Node's `get()` reads column metadata after SQLite can reprepare and resets the reader before returning.

## User Impact

Faster state lookups and no evaluation of unnecessary later SELECT rows.

## Evidence

- 31 focused runtime and type tests passed on Node 26.8.2. The new regression fails on the original executor by evaluating all three fixture rows. Coverage includes schema changes, empty results, released readers, cache reentry, authorizer invalidation, and write completion.
- Same-process alternating baseline/candidate measurements, seven rounds of 20,000 calls: fixed-query first-row execution 5.175 → 3.404 µs; rebuilt-query execution 7.531 → 4.980 µs on Node 26.8.2 / SQLite 3.53.4, about 34% lower elapsed time. Node 24.19.0 also improved by 24–25%.
- Production typecheck, formatting, and repository guards passed. The local full core-test typecheck wrapper refuses the Windows checkout's percent-encoded space; hosted CI must complete that gate.
- Integration observers now count native `get()` as well as iteration, preserving archive-race and exact 8 MiB transactional materialization assertions. Upload-store (23 tests), plugin retention (10), and 15 of 16 cold-read cases passed locally. The remaining canonical-copy timeout and sibling Windows cleanup/rename/executable-bit failures were reproduced on the unchanged executor; assertions, timeouts, and skips were not weakened. Exact-head Linux CI supplies full integration proof.
- Independent P0–P2 reviews of the executor and subsequent observer repair completed clean. Scoped type-aware lint and diff checks passed.

- Final observer audit also covers unreadable update destinations, archive read budgets, a real WAL peer-writer race, model-context acquisition counts, and installed-plugin record caching. All 85 affected portable tests pass; the Unix-only destination fault injection fails before the observer correction and passes on Linux afterward. Fresh P0–P2 review, scoped type-aware lint, formatting, and selected repository guards pass. Production behavior is unchanged by these test repairs.
