### PR TITLE
improve(usage): reduce work when scanning large transcripts

### DIFF
--- a/src/infra/session-cost-usage-aggregation.ts
+++ b/src/infra/session-cost-usage-aggregation.ts
@@ -277,27 +277,43 @@ async function scanJsonlRange(params: {
     start: params.startOffset,
     end: params.endOffset - 1,
   });
-  let carry = Buffer.alloc(0);
-  let carryStart = params.startOffset;
+  // Retain fragments until a line is complete; growing a contiguous carry buffer
+  // would repeatedly copy and rescan large transcript records.
+  const lineChunks: Buffer[] = [];
+  let lineBytes = 0;
+  let chunkStart = params.startOffset;
   let processedOffset = params.startOffset;
   try {
     for await (const chunk of stream) {
       const bytes = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
-      const data = carry.length === 0 ? bytes : Buffer.concat([carry, bytes]);
       let lineStart = 0;
-      for (let newline = data.indexOf(10); newline >= 0; newline = data.indexOf(10, lineStart)) {
-        const record = parseJsonlRecord(data.subarray(lineStart, newline));
+      for (let newline = bytes.indexOf(10); newline >= 0; newline = bytes.indexOf(10, lineStart)) {
+        const fragment = bytes.subarray(lineStart, newline);
+        let line = fragment;
+        if (lineChunks.length > 0) {
+          lineChunks.push(fragment);
+          line = Buffer.concat(lineChunks, lineBytes + fragment.length);
+          lineChunks.length = 0;
+          lineBytes = 0;
+        }
+        const record = parseJsonlRecord(line);
         if (record) {
           params.onRecord(record);
         }
-        processedOffset = carryStart + newline + 1;
+        processedOffset = chunkStart + newline + 1;
         lineStart = newline + 1;
       }
-      carry = data.subarray(lineStart);
-      carryStart = processedOffset;
+      if (lineStart < bytes.length) {
+        const fragment = bytes.subarray(lineStart);
+        lineChunks.push(fragment);
+        lineBytes += fragment.length;
+      }
+      chunkStart += bytes.length;
     }
-    if (carry.length > 0) {
-      const record = parseJsonlRecord(carry);
+    if (lineBytes > 0) {
+      const record = parseJsonlRecord(
+        lineChunks.length === 1 ? lineChunks[0] : Buffer.concat(lineChunks, lineBytes),
+      );
       if (record) {
         params.onRecord(record);
         processedOffset = params.endOffset;
@@ -531,7 +547,8 @@ async function scanSqliteUsageRollup(params: {
     ? selectIncrementalSqliteRecords(rawRecords, previousCheckpoint?.visibleLeafId)
     : undefined;
   const appendOnly = Boolean(incremental && params.previous);
-  const allRows = appendOnly ? rows : loadTranscriptEventRowsAfterSeqSync(scope, 0, maxSeq);
+  const allRows =
+    appendOnly || afterSeq === 0 ? rows : loadTranscriptEventRowsAfterSeqSync(scope, 0, maxSeq);
   const allRecords = appendOnly
     ? (incremental?.records ?? [])
     : selectVisibleTranscriptEvents(allRows.map((row) => row.event)).flatMap((event) =>

--- a/src/infra/session-cost-usage-aggregation.ts
+++ b/src/infra/session-cost-usage-aggregation.ts
@@ -310,9 +310,10 @@ async function scanJsonlRange(params: {
       }
       chunkStart += bytes.length;
     }
-    if (lineBytes > 0) {
+    const firstChunk = lineChunks[0];
+    if (firstChunk) {
       const record = parseJsonlRecord(
-        lineChunks.length === 1 ? lineChunks[0] : Buffer.concat(lineChunks, lineBytes),
+        lineChunks.length === 1 ? firstChunk : Buffer.concat(lineChunks, lineBytes),
       );
       if (record) {
         params.onRecord(record);

--- a/src/infra/session-cost-usage.test.ts
+++ b/src/infra/session-cost-usage.test.ts
@@ -1226,7 +1226,7 @@ describe("session cost usage", () => {
     const sessionsDir = path.join(root, "agents", "main", "sessions");
     await fs.mkdir(sessionsDir, { recursive: true });
     const sessionFile = path.join(sessionsDir, "sess-incremental.jsonl");
-    const assistantEntry = (timestamp: string, totalTokens: number) =>
+    const assistantEntry = (timestamp: string, totalTokens: number, content = "") =>
       JSON.stringify({
         type: "message",
         timestamp,
@@ -1234,6 +1234,7 @@ describe("session cost usage", () => {
           role: "assistant",
           provider: "openai",
           model: "gpt-5.5",
+          content,
           usage: {
             input: totalTokens,
             output: 0,
@@ -1245,7 +1246,7 @@ describe("session cost usage", () => {
     await fs.writeFile(
       sessionFile,
       [
-        assistantEntry("2026-02-05T12:00:00.000Z", 10),
+        assistantEntry("2026-02-05T12:00:00.000Z", 10, "🦞".repeat(32 * 1024)),
         assistantEntry("2026-02-05T12:01:00.000Z", 20),
       ].join("\n"),
       "utf-8",


### PR DESCRIPTION
Related: #145679

## What Problem This Solves

Resolves a problem where usage summaries do unnecessary work while scanning large legacy transcript records or rebuilding SQLite transcript totals.

## Why This Change Was Made

Accumulate JSONL fragments and concatenate each completed record once, preserving byte checkpoints and incomplete final records. Reuse SQLite rows when the existing read already starts at sequence zero; failed incremental append detection still reloads the full prefix.

## User Impact

Usage scans perform less copying and fewer database reads. Transcript contents, totals, cache formats, and checkpoint semantics remain unchanged.

## Evidence

- Synthetic exact-source scanner benchmark on Windows/Node 24.19, five-run medians: 1 MiB record 5.86 -> 3.87 ms; 8 MiB 120.43 -> 19.93 ms. This is scanner throughput, not a whole-Gateway speedup.
- 528 original/candidate comparisons matched across chunk boundaries, Unicode, nonzero offsets, malformed lines, and partial final records.
- Existing incremental usage test now includes a 128 KiB Unicode record and still checks append, partial-tail completion, and truncation.
- Fresh independent review through the repository autoreview helper: no P0-P2 findings.
- Clean Linux/Node 24.19 baseline and candidate runs each passed all 67 focused usage and stream-error tests. The candidate includes the enlarged Unicode fixture and SQLite read reuse. Earlier Windows runs had temporary-directory cleanup failures; Linux proof avoids that host limitation.
- Formatting and preliminary changed-file checks pass. Final-head hosted CI, including type and lint gates, passed. Native merge completed as `69cbf9f8bfdd15ac343e495f1e3439d6ca5d0200`.
