### PR TITLE
improve(sessions): reduce ordering time for large result windows

### DIFF
--- a/src/shared/sort-and-limit.test.ts
+++ b/src/shared/sort-and-limit.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { sortAndLimitBy } from "./sort-and-limit.js";
+
+describe("sortAndLimitBy", () => {
+  it.each([1, 5, 50, 200, 201, undefined])(
+    "matches stable full ordering without mutating input for limit %s",
+    (limit) => {
+      const entries = Array.from({ length: 500 }, (_, id) => ({ id, rank: (id * 37) % 23 }));
+      const compare = (a: (typeof entries)[number], b: (typeof entries)[number]) => a.rank - b.rank;
+      for (const input of [entries, entries.toReversed(), entries.toSorted(compare), []]) {
+        const original = [...input];
+        const sorted = input.toSorted(compare);
+        const expected = limit === undefined ? sorted : sorted.slice(0, limit);
+        expect(sortAndLimitBy(input, limit, compare)).toEqual(expected);
+        expect(input).toEqual(original);
+      }
+    },
+  );
+
+  it("bounds comparison work when selecting a large result window", () => {
+    const entries = Array.from({ length: 1_000 }, (_, id) => ({ id, rank: (id * 617) % 1_009 }));
+    let comparisons = 0;
+    const selected = sortAndLimitBy(entries, 200, (a, b) => {
+      comparisons += 1;
+      return a.rank - b.rank;
+    });
+    expect(selected).toEqual(entries.toSorted((a, b) => a.rank - b.rank).slice(0, 200));
+    // Two endpoint comparisons plus at most eight comparisons within a 200-row window.
+    expect(comparisons).toBeLessThanOrEqual(entries.length * 10);
+  });
+});

--- a/src/shared/sort-and-limit.ts
+++ b/src/shared/sort-and-limit.ts
@@ -15,9 +15,21 @@ export function sortAndLimitBy<T extends object>(
       if (!beforeFirst && worst && compare(entry, worst) >= 0) {
         continue;
       }
-      const insertAt = beforeFirst
-        ? 0
-        : selected.findIndex((candidate, index) => index > 0 && compare(entry, candidate) < 0);
+      let insertAt = 0;
+      if (!beforeFirst) {
+        let low = 1;
+        let high = selected.length;
+        // Insert after equal entries to preserve the input order for ties.
+        while (low < high) {
+          const middle = (low + high) >>> 1;
+          if (compare(entry, selected[middle]!) < 0) {
+            high = middle;
+          } else {
+            low = middle + 1;
+          }
+        }
+        insertAt = low < selected.length ? low : -1;
+      }
       if (insertAt >= 0) {
         selected.splice(insertAt, 0, entry);
         if (selected.length > limit) {


### PR DESCRIPTION
## What Problem This Solves

Session lists with large result windows spend unnecessary CPU ordering rows. This affects Gateway session lists, `openclaw sessions`, and status summaries, which share bounded selection.

## Why This Change Was Made

Use stable binary insertion within the existing bounded-ordering owner, preserving its first/worst fast paths and full-sort fallback. Equal entries retain input order; pin, timestamp, and key policies remain with callers. This reduces comparator calls without introducing another cache or changing list contents.

## User Impact

Less CPU and event-loop time when ordering larger session windows. Small limits have little benefit; these results measure ordering, not end-to-end RPC latency. No configuration, storage, or output changes.

## Evidence

Paired measurements of the actual `sortAndLimitSessionEntries` entrypoint, bundled with the repository's esbuild from the before/after source. Synthetic session entries include timestamp/key ties and 5% pinned roots. Nine interleaved trials after warmup; fixture construction is outside timing. Both sort modes matched stable full sorting for every measured case.

| Runtime / workload | Before | After | Speedup |
| --- | ---: | ---: | ---: |
| Node 24.19, 1,000 randomized sessions, limit 50 | 1.34 ms | 0.62 ms | 2.15× |
| Node 24.19, 1,000 randomized sessions, limit 200 | 3.67 ms | 0.69 ms | 5.31× |
| Node 24.19, 10,000 randomized sessions, limit 200 | 33.06 ms | 9.09 ms | 3.64× |
| Node 26.8, 1,000 randomized sessions, limit 200 | 3.48 ms | 0.62 ms | 5.62× |

The deterministic 1,000-row comparison regression falls from 43,679 calls to 5,488 (budget 10,000). Additional parity coverage checks ties, input preservation, empty input, and limits on both sides of the bounded/full-sort boundary. Existing CLI and Gateway tests cover list limits, pin ordering, and offset pagination.

Research: [V8's sorting analysis](https://v8.dev/blog/array-sort) explains why reducing JavaScript comparator calls can matter more than reducing memory moves. The change was selected from measurements, not a general replacement of native sorting or spread operations.

- **298 focused Linux tests passed:** shared selection (7), Gateway session utilities (256), CLI sessions (27), and readonly status (8).
- Independent P2 review was scoped-clean; ClawSweeper reported no actionable findings.
- Formatting, targeted lint, production core types, and earlier changed guards passed. Required hosted `openclaw/ci-gate` is green at `516dfdfddcf1faccfd04ca5f58a16d8beb7d3bd6`.
- Windows runs exposed an unchanged workspace-path assertion, fixture cleanup errors, and a percent-encoded path restriction in the check wrapper. The corresponding Linux tests all passed. A duplicate Linux changed check was stopped during core-test types after required hosted CI passed; hosted CI supplies the remaining gate evidence. No guards or baselines were weakened.
