### PR TITLE
improve(gateway): avoid rescanning streamed assistant text

### DIFF
--- a/src/gateway/agent-event-assistant-text.ts
+++ b/src/gateway/agent-event-assistant-text.ts
@@ -19,6 +19,25 @@ export type AssistantTextSnapshot = {
   };
 };
 
+type AssistantTextMerge = AssistantTextSnapshot & {
+  /** Present only when this merge proves an append to its input snapshot. */
+  appendedText?: string;
+};
+
+/** Append provenance is usable only while the wire still matches the merge base. */
+export function resolveAssistantTextStreamDelta(
+  previous: AssistantTextSnapshot,
+  merged: AssistantTextMerge,
+  streamed: AssistantTextSnapshot,
+): string | undefined {
+  if (previous === streamed && merged.appendedText !== undefined) {
+    return merged.appendedText;
+  }
+  return merged.text.startsWith(streamed.text)
+    ? merged.text.slice(streamed.text.length)
+    : undefined;
+}
+
 /** A text-bearing empty result clears output; a missing text payload does not. */
 export function resolveAssistantResultText(result: unknown): string | undefined {
   const payloads = asOptionalObjectRecord(result)?.payloads;
@@ -88,7 +107,7 @@ export function mergeAssistantText(
   previous: AssistantTextSnapshot,
   input: AssistantTextInput,
   unkeyed: "live" | "append-only",
-): AssistantTextSnapshot {
+): AssistantTextMerge {
   let scope = previous.scope;
   if (!input.itemId) {
     scope = undefined;
@@ -104,6 +123,16 @@ export function mergeAssistantText(
   }
   let text: string;
   if (scope) {
+    // After two provider characters, appends cannot change leading-newline
+    // padding. Avoid slicing and rebuilding the growing item on every delta.
+    if (
+      input.text === undefined &&
+      scope === previous.scope &&
+      previous.text.length - scope.prefix.length - scope.separatorLength >= 2
+    ) {
+      const appendedText = input.delta ?? "";
+      return { text: previous.text + appendedText, scope, appendedText };
+    }
     // Inserted padding is not provider text. Keep it out of later item deltas
     // so a matching cumulative snapshot cannot retract a streamed newline.
     const itemText =
@@ -123,14 +152,19 @@ export function mergeAssistantText(
     scope.separatorLength = itemText ? Math.max(0, scope.boundaryNewlines - leadingNewlines) : 0;
     text = scope.prefix + "\n".repeat(scope.separatorLength) + itemText;
   } else if (input.text === undefined) {
-    text = previous.text + (input.delta ?? "");
+    const appendedText = input.delta ?? "";
+    return { text: previous.text + appendedText, scope, appendedText };
   } else if (unkeyed === "append-only") {
     // Legacy HTTP snapshots recover held prefixes; non-prefix input remains
     // incremental unless its producer explicitly marks a replacement.
-    text =
-      input.replace || input.text.startsWith(previous.text)
-        ? input.text
-        : previous.text + (input.delta ?? input.text);
+    if (input.replace) {
+      return { text: input.text, scope };
+    }
+    if (input.text.startsWith(previous.text)) {
+      return { text: input.text, scope, appendedText: input.text.slice(previous.text.length) };
+    }
+    const appendedText = input.delta ?? input.text;
+    return { text: previous.text + appendedText, scope, appendedText };
   } else if (
     previous.text &&
     input.text.length > previous.text.length &&

--- a/src/gateway/openai-http.test.ts
+++ b/src/gateway/openai-http.test.ts
@@ -2641,7 +2641,9 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
       events: [
         { itemId: "answer-1", text: "First." },
         { itemId: "answer-2", delta: "\n" },
-        { itemId: "answer-2", delta: "\nSecond." },
+        { itemId: "answer-2", delta: "\n" },
+        { itemId: "answer-2", delta: "Se" },
+        { itemId: "answer-2", delta: "cond." },
         { itemId: "answer-2", text: "\n\nSecond." },
       ],
       expected: "First.\n\nSecond.",
@@ -2864,6 +2866,7 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
   it.each([
     { name: "rewritten", replacementText: "final answer" },
     { name: "shortened", replacementText: "dra" },
+    { name: "rewritten then extended by a delta", replacementText: "other answer", tailDelta: "!" },
     { name: "cleared", replacementText: "" },
     {
       name: "replaced by a held provisional item",
@@ -2913,6 +2916,7 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
       resultText,
       noResultText,
       terminalEcho,
+      tailDelta,
     }) => {
       agentCommandMock.mockClear();
       agentCommandMock.mockImplementationOnce((async (opts: unknown) => {
@@ -2948,6 +2952,9 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
         }
         if (terminalEcho) {
           emitAgentEvent({ runId, stream: "assistant", data: { text: replacementText } });
+        }
+        if (tailDelta) {
+          emitAgentEvent({ runId, stream: "assistant", data: { delta: tailDelta } });
         }
         emitAgentEvent({ runId, stream: "lifecycle", data: { phase: "end" } });
         return {

--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -43,6 +43,7 @@ import {
   resolveAssistantResultText,
   resolveAssistantTextCompletion,
   resolveAssistantTextInput,
+  resolveAssistantTextStreamDelta,
   type AssistantTextSnapshot,
 } from "./agent-event-assistant-text.js";
 import {
@@ -1128,8 +1129,8 @@ export async function handleOpenAiHttpRequest(
   setSseHeaders(res);
 
   let wroteStopChunk = false;
-  let streamedAssistantText = "";
   let assistantText: AssistantTextSnapshot = { text: "" };
+  let streamedAssistantText = assistantText;
   let pendingAssistantText: AssistantTextSnapshot | undefined;
   let finalResultText: string | undefined;
   let finalFinishReason: "stop" | "length" = "stop";
@@ -1168,21 +1169,20 @@ export async function handleOpenAiHttpRequest(
         assistantText,
         pending: pendingAssistantText,
         resultText: finalResultText,
-        streamedText: streamedAssistantText,
+        streamedText: streamedAssistantText.text,
         fallbackText: finalToolCalls ? "" : "No response from OpenClaw.",
       });
-      if (!text.startsWith(streamedAssistantText)) {
+      if (!text.startsWith(streamedAssistantText.text)) {
         finishStreamWithError({
           message: "Assistant output cannot be represented as an append-only response stream.",
           type: "api_error",
         });
         return;
       }
-      const content = text.slice(streamedAssistantText.length);
+      const content = text.slice(streamedAssistantText.text.length);
       if (content) {
         writeAssistantContentChunk(res, { ...streamIdentity, content });
       }
-      streamedAssistantText = text;
       if (finalToolCalls) {
         writeAssistantToolCallsIncrementalChunks(res, {
           ...streamIdentity,
@@ -1234,24 +1234,26 @@ export async function handleOpenAiHttpRequest(
         return;
       }
 
-      assistantText = mergeAssistantText(assistantText, input, "append-only");
+      const previous = assistantText;
+      const merged = mergeAssistantText(previous, input, "append-only");
+      assistantText = merged;
       // Hold prose until the run proves the requested client-tool call exists.
       if (toolChoiceConstraint) {
         return;
       }
       // SSE cannot retract bytes already delivered, even for an item correction.
-      if (!assistantText.text.startsWith(streamedAssistantText)) {
+      const content = resolveAssistantTextStreamDelta(previous, merged, streamedAssistantText);
+      if (content === undefined) {
         terminalStreamError ??= {
           message: "Assistant output cannot be represented as an append-only response stream.",
           type: "api_error",
         };
         return;
       }
-      const content = assistantText.text.slice(streamedAssistantText.length);
+      streamedAssistantText = assistantText;
       if (!content) {
         return;
       }
-      streamedAssistantText = assistantText.text;
       writeAssistantContentChunk(res, { ...streamIdentity, content });
       return;
     }

--- a/src/gateway/openresponses-http.test.ts
+++ b/src/gateway/openresponses-http.test.ts
@@ -484,7 +484,9 @@ describe("OpenResponses HTTP API (e2e)", () => {
       events: [
         { itemId: "answer-1", text: "First." },
         { itemId: "answer-2", delta: "\n" },
-        { itemId: "answer-2", delta: "\nSecond." },
+        { itemId: "answer-2", delta: "\n" },
+        { itemId: "answer-2", delta: "Se" },
+        { itemId: "answer-2", delta: "cond." },
         { itemId: "answer-2", text: "\n\nSecond." },
       ],
       expected: "First.\n\nSecond.",
@@ -548,6 +550,7 @@ describe("OpenResponses HTTP API (e2e)", () => {
   it.each([
     { name: "rewritten", replacementText: "final answer" },
     { name: "shortened", replacementText: "dra" },
+    { name: "rewritten then extended by a delta", replacementText: "other answer", tailDelta: "!" },
     { name: "cleared", replacementText: "" },
     {
       name: "replaced by a held provisional item",
@@ -591,6 +594,7 @@ describe("OpenResponses HTTP API (e2e)", () => {
       resultText,
       noResultText,
       terminalEcho,
+      tailDelta,
     }) => {
       agentCommandMock.mockClear();
       agentCommandMock.mockImplementationOnce((async (opts: unknown) => {
@@ -620,6 +624,9 @@ describe("OpenResponses HTTP API (e2e)", () => {
         });
         if (terminalEcho) {
           emitAgentEvent({ runId, stream: "assistant", data: { text: replacementText } });
+        }
+        if (tailDelta) {
+          emitAgentEvent({ runId, stream: "assistant", data: { delta: tailDelta } });
         }
         emitAgentEvent({ runId, stream: "lifecycle", data: { phase: "end" } });
         return {

--- a/src/gateway/openresponses-http.ts
+++ b/src/gateway/openresponses-http.ts
@@ -46,6 +46,7 @@ import {
   resolveAssistantResultText,
   resolveAssistantTextCompletion,
   resolveAssistantTextInput,
+  resolveAssistantTextStreamDelta,
   type AssistantTextSnapshot,
 } from "./agent-event-assistant-text.js";
 import type { AuthRateLimiter } from "./auth-rate-limit.js";
@@ -255,8 +256,7 @@ export const testing = {
 };
 
 function writeSseEvent(res: ServerResponse, event: StreamingEvent) {
-  res.write(`event: ${event.type}\n`);
-  res.write(`data: ${JSON.stringify(event)}\n\n`);
+  res.write(`event: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`);
 }
 
 type ResolvedResponsesLimits = {
@@ -858,7 +858,7 @@ export async function handleOpenResponsesHttpRequest(
   setSseHeaders(res);
 
   let assistantText: AssistantTextSnapshot = { text: "" };
-  let streamedAssistantText = "";
+  let streamedAssistantText = assistantText;
   let pendingAssistantText: AssistantTextSnapshot | undefined;
   let finalResultText: string | undefined;
   let finalToolCalls: PendingToolCall[] | undefined;
@@ -898,14 +898,14 @@ export async function handleOpenResponsesHttpRequest(
         assistantText,
         pending: pendingAssistantText,
         resultText: finalResultText,
-        streamedText: streamedAssistantText,
+        streamedText: streamedAssistantText.text,
         fallbackText: finalToolCalls ? "" : "No response from OpenClaw.",
       });
-      if (!finalText.startsWith(streamedAssistantText)) {
+      if (!finalText.startsWith(streamedAssistantText.text)) {
         finalizeUnrepresentableAssistantReplacement();
         return;
       }
-      const delta = finalText.slice(streamedAssistantText.length);
+      const delta = finalText.slice(streamedAssistantText.text.length);
       if (delta) {
         writeSseEvent(res, {
           type: "response.output_text.delta",
@@ -915,7 +915,6 @@ export async function handleOpenResponsesHttpRequest(
           delta,
         });
       }
-      streamedAssistantText = finalText;
       closed = true;
       unsubscribe();
 
@@ -1093,31 +1092,33 @@ export async function handleOpenResponsesHttpRequest(
           !input.replaceable &&
           input.replace &&
           input.text !== undefined &&
-          pendingAssistantText.text.startsWith(streamedAssistantText)
+          pendingAssistantText.text.startsWith(streamedAssistantText.text)
         ) {
           unrepresentableAssistantReplacement = false;
         }
         return;
       }
 
-      assistantText = mergeAssistantText(assistantText, input, "append-only");
+      const previous = assistantText;
+      const merged = mergeAssistantText(previous, input, "append-only");
+      assistantText = merged;
       // Unconfirmed tool-choice prose may still be corrected before it is sent.
       if (toolChoiceConstraint) {
         return;
       }
       // Keep physical wire progress separate from a corrected item snapshot.
-      if (!assistantText.text.startsWith(streamedAssistantText)) {
+      const content = resolveAssistantTextStreamDelta(previous, merged, streamedAssistantText);
+      if (content === undefined) {
         unrepresentableAssistantReplacement = true;
         return;
       }
       if (input.replace && input.text !== undefined) {
         unrepresentableAssistantReplacement = false;
       }
-      const content = assistantText.text.slice(streamedAssistantText.length);
+      streamedAssistantText = assistantText;
       if (!content) {
         return;
       }
-      streamedAssistantText = assistantText.text;
       writeSseEvent(res, {
         type: "response.output_text.delta",
         item_id: outputItemId,

--- a/src/gateway/sessions-history-http.ts
+++ b/src/gateway/sessions-history-http.ts
@@ -103,8 +103,7 @@ function resolveLimit(req: IncomingMessage): Result<number | undefined, string> 
 }
 
 function sseWrite(res: ServerResponse, event: string, payload: unknown): void {
-  res.write(`event: ${event}\n`);
-  res.write(`data: ${JSON.stringify(payload)}\n\n`);
+  res.write(`event: ${event}\ndata: ${JSON.stringify(payload)}\n\n`);
 }
 
 function resolveSessionHistoryHttpClient(


### PR DESCRIPTION
Related: #145679

## What Problem This Solves

Resolves a problem where long assistant responses spend increasing CPU time processing each streamed text fragment through the OpenAI-compatible HTTP endpoints.

## Why This Change Was Made

The shared text merger records when an event provably appends text. HTTP adapters reuse that fact only when the merge base matches actual wire progress, retaining prefix validation for corrections and withheld output. Responses and session-history SSE frames now use one write per event.

## User Impact

Long delta streams need less CPU while preserving streamed text, correction handling, event order, and SSE bytes. This does not change slow-client buffering policy.

## Evidence

- 160,108 original/candidate merge and wire-output comparisons matched, covering item changes, withheld output, corrections, split Unicode, and scope retirement. Six exact-source SSE framing comparisons also matched.
- Synthetic exact-source 256 KiB response with 64-character deltas and per-event JSON framing: 430.08 -> 2.05 ms median. This measures local text processing, not model latency or whole-Gateway throughput.
- Existing HTTP endpoint tests extended for split leading newlines and incompatible corrections followed by deltas.
- Linux/Node 24.19: all five baseline suites passed (390 tests); all five candidate suites passed (392 tests), including the two added SDK cases. Coverage includes both HTTP adapters, shared stream merging, history SSE, and revocation. Baseline/candidate wall times were 214.21/152.93 seconds; cold/warm transform differences make these validation timings, not an application benchmark.
- Fresh independent review and ClawSweeper review of the exact head found no actionable findings. Formatting, diff checks, and final-head hosted CI passed. Native merge completed as `3f75b33d671017c7ca6cf9ea300279b11e0948c8`.
- After #145696 also landed, all 104 tests in the transcript-path, history HTTP/SSE, and revocation suites passed together on main `354943cc2f7e1516d90ae9d2ee7420a12a74bac9`.
