### PR TITLE
improve(gateway): discover Claude history without blocking requests

### DIFF
--- a/src/gateway/cli-session-history.claude-snapshot.ts
+++ b/src/gateway/cli-session-history.claude-snapshot.ts
@@ -12,7 +12,7 @@ import {
   type ClaudeCliProjectEntry,
   parseClaudeCliHistoryEntry,
   redactClaudeCliHistoryMessage,
-  resolveClaudeCliSessionFilePath,
+  resolveClaudeCliSessionFilePathAsync,
 } from "./cli-session-history.claude.js";
 
 const YIELD_BYTES = 256 * 1024;
@@ -132,7 +132,7 @@ function fingerprint(stats: fs.Stats): string {
 async function resolveSource(
   params: HistoryParams,
 ): Promise<readonly [filePath: string, cacheKey: string] | undefined> {
-  const candidate = resolveClaudeCliSessionFilePath(params);
+  const candidate = await resolveClaudeCliSessionFilePathAsync(params);
   if (!candidate) {
     return undefined;
   }

--- a/src/gateway/cli-session-history.claude.ts
+++ b/src/gateway/cli-session-history.claude.ts
@@ -452,7 +452,7 @@ export function parseClaudeCliHistoryEntry(
   ) as TranscriptLikeMessage;
 }
 
-export function resolveClaudeCliSessionFilePath(params: {
+function resolveClaudeCliSessionFilePath(params: {
   cliSessionId: string;
   homeDir?: string;
 }): string | undefined {
@@ -475,6 +475,53 @@ export function resolveClaudeCliSessionFilePath(params: {
     const projectDir = path.join(projectsDir, entry.name);
     const candidate = resolveClaudeSessionCandidate(projectDir, sessionId);
     if (candidate && fs.existsSync(candidate)) {
+      return candidate;
+    }
+  }
+  return undefined;
+}
+
+export async function resolveClaudeCliSessionFilePathAsync(params: {
+  cliSessionId: string;
+  homeDir?: string;
+}): Promise<string | undefined> {
+  const sessionId = normalizeClaudeCliSessionId(params.cliSessionId);
+  if (!sessionId) {
+    return undefined;
+  }
+  const projectsDir = resolveClaudeProjectsDir(params.homeDir);
+  let projectEntries: fs.Dirent[];
+  try {
+    projectEntries = await fs.promises.readdir(projectsDir, { withFileTypes: true });
+  } catch {
+    return undefined;
+  }
+
+  // Bound filesystem work while preserving the first match in directory order.
+  const batchSize = 16;
+  for (let offset = 0; offset < projectEntries.length; offset += batchSize) {
+    const candidates = await Promise.all(
+      projectEntries.slice(offset, offset + batchSize).map(async (entry) => {
+        if (!entry.isDirectory()) {
+          return undefined;
+        }
+        const candidate = resolveClaudeSessionCandidate(
+          path.join(projectsDir, entry.name),
+          sessionId,
+        );
+        if (!candidate) {
+          return undefined;
+        }
+        try {
+          await fs.promises.access(candidate);
+          return candidate;
+        } catch {
+          return undefined;
+        }
+      }),
+    );
+    const candidate = candidates.find((value) => value !== undefined);
+    if (candidate) {
       return candidate;
     }
   }

--- a/src/gateway/cli-session-history.test.ts
+++ b/src/gateway/cli-session-history.test.ts
@@ -5,6 +5,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
 import {
   formatCliImageTurnContext,
   hashCliImageTurnEntryId,
@@ -278,6 +279,8 @@ describe("cli session history", () => {
       const streamSpy = vi.spyOn(rawFs, "createReadStream");
       const transcriptRedact = await import("../agents/transcript-redact.js");
       const redactSpy = vi.spyOn(transcriptRedact, "redactTranscriptMessage");
+      const readdirSyncSpy = vi.spyOn(rawFs, "readdirSync");
+      const existsSyncSpy = vi.spyOn(rawFs, "existsSync");
       const initial = await (async () => {
         try {
           const [first, second] = await Promise.all([
@@ -285,8 +288,12 @@ describe("cli session history", () => {
             readChatHistoryCliSessionImportSnapshot(params),
           ]);
           expect(second).toEqual(first);
+          expect(await readChatHistoryCliSessionImportSnapshot(params)).toEqual(first);
           expect(streamSpy).toHaveBeenCalledTimes(1);
           expect(redactSpy).toHaveBeenCalledTimes(first.length);
+          // Cold and cached requests must both leave filesystem discovery off the event loop.
+          expect(readdirSyncSpy).not.toHaveBeenCalled();
+          expect(existsSyncSpy).not.toHaveBeenCalled();
           return resolveChatHistoryWithCliSessionImports({
             ...params,
             preparedImportedMessages: first,
@@ -294,6 +301,8 @@ describe("cli session history", () => {
         } finally {
           streamSpy.mockRestore();
           redactSpy.mockRestore();
+          readdirSyncSpy.mockRestore();
+          existsSyncSpy.mockRestore();
         }
       })();
       expect(initial.messages).toHaveLength(3);
@@ -324,9 +333,66 @@ describe("cli session history", () => {
         externalId: "replacement-assistant",
       });
 
-      await fs.rm(filePath);
+      const movedProjectDir = path.join(path.dirname(path.dirname(filePath)), "moved-workspace");
+      await fs.mkdir(movedProjectDir);
+      const movedFilePath = path.join(movedProjectDir, path.basename(filePath));
+      await fs.rename(filePath, movedFilePath);
+      expect(await read()).toEqual(replaced);
+
+      await fs.rm(movedFilePath);
       const deleted = await read();
       expect(deleted).toEqual({ messages: [], imported: false, expanded: false });
+    });
+  });
+
+  it("preserves project precedence when a later matching transcript is found first", async () => {
+    await withClaudeProjectsDir(async ({ homeDir, sessionId, filePath }) => {
+      const projectsDir = path.dirname(path.dirname(filePath));
+      const otherProjectDir = path.join(projectsDir, "other-workspace");
+      await fs.mkdir(otherProjectDir);
+      await fs.writeFile(
+        path.join(otherProjectDir, path.basename(filePath)),
+        createClaudeTextHistoryLines([
+          { role: "user", uuid: "other-project-user", content: "other project" },
+        ]),
+      );
+      const [firstPath, secondPath] = (await fs.readdir(projectsDir)).map((project) =>
+        path.join(projectsDir, project, path.basename(filePath)),
+      );
+      const expected = readClaudeCliSessionMessages({ cliSessionId: sessionId, homeDir });
+      const releaseFirst = createDeferred();
+      const foundSecond = createDeferred();
+      const access = fs.access;
+      const accessSpy = vi
+        .spyOn(rawFs.promises, "access")
+        .mockImplementation(async (candidate, mode) => {
+          if (candidate === firstPath) {
+            await releaseFirst.promise;
+          }
+          await access(candidate, mode);
+          if (candidate === secondPath) {
+            foundSecond.resolve();
+          }
+        });
+      const pending = readChatHistoryCliSessionImportSnapshot({
+        entry: {
+          sessionId: "openclaw-session",
+          updatedAt: Date.now(),
+          cliSessionBindings: { "claude-cli": { sessionId } },
+        },
+        provider: "claude-cli",
+        localMessages: [],
+        homeDir,
+      });
+      try {
+        await Promise.race([foundSecond.promise, pending]);
+        releaseFirst.resolve();
+        expect(await pending).toEqual(expected);
+      } finally {
+        releaseFirst.resolve();
+        await pending;
+        accessSpy.mockRestore();
+      }
     });
   });
 
@@ -1788,6 +1854,18 @@ describe("cli session history", () => {
 
       for (const cliSessionId of ["../outside", "nested/session", "nested\\session"]) {
         expect(readClaudeCliSessionMessages({ cliSessionId, homeDir })).toEqual([]);
+        expect(
+          await readChatHistoryCliSessionImportSnapshot({
+            entry: {
+              sessionId: "openclaw-session",
+              updatedAt: Date.now(),
+              cliSessionBindings: { "claude-cli": { sessionId: cliSessionId } },
+            },
+            provider: "claude-cli",
+            localMessages: [],
+            homeDir,
+          }),
+        ).toEqual([]);
       }
     });
   });

--- a/src/gateway/cli-session-history.test.ts
+++ b/src/gateway/cli-session-history.test.ts
@@ -291,9 +291,12 @@ describe("cli session history", () => {
           expect(await readChatHistoryCliSessionImportSnapshot(params)).toEqual(first);
           expect(streamSpy).toHaveBeenCalledTimes(1);
           expect(redactSpy).toHaveBeenCalledTimes(first.length);
-          // Cold and cached requests must both leave filesystem discovery off the event loop.
-          expect(readdirSyncSpy).not.toHaveBeenCalled();
-          expect(existsSyncSpy).not.toHaveBeenCalled();
+          // Scope this to transcript discovery; redaction may load unrelated config.
+          const projectsDir = path.dirname(path.dirname(filePath));
+          expect(
+            readdirSyncSpy.mock.calls.filter(([directory]) => directory === projectsDir),
+          ).toHaveLength(0);
+          expect(existsSyncSpy).not.toHaveBeenCalledWith(filePath);
           return resolveChatHistoryWithCliSessionImports({
             ...params,
             preparedImportedMessages: first,


### PR DESCRIPTION
Related: #145679

## What Problem This Solves

Resolves a problem where opening Claude CLI conversation history blocks other Gateway requests while searching a large project directory.

## Why This Change Was Made

Async history snapshots now discover transcripts using asynchronous directory reads and bounded batches of filesystem probes. Results preserve directory-order precedence. Synchronous readers retain their existing synchronous contract; snapshot freshness and cache ownership stay unchanged.

## User Impact

Other requests remain responsive during transcript discovery, including warm history reads. The selected transcript and imported messages remain unchanged.

## Evidence

- Synthetic NTFS fixture with 1,001 projects, exact-source resolver, Node 24.19, seven-run medians: queued callback delay 46.725 -> 0.116 ms; lookup completion 46.665 -> 47.551 ms. This demonstrates reduced event-loop blocking, not faster overall lookup.
- Existing snapshot coverage extended to guard async discovery for cold/concurrent/warm reads and refresh after relocation. Additional coverage checks directory precedence when probes complete out of order and rejects path-like IDs.
- Linux/Node 24.19: baseline passed all 141 tests across three suites; final candidate passed all 142. The corrected regression test failed on original production with three synchronous reads of the Claude projects directory versus zero expected.
- The initial candidate test overreached into an unrelated synchronous config read during redaction. The final assertion targets transcript discovery while retaining output/cache checks; fresh review and original-failure/candidate-success proof confirm that scope.
- Fresh full-patch and test-correction reviews: no P0-P2 findings. Formatting, diff checks, and final-head CI passed. Native merge completed as `41c45d213063896073a08b98d3a4f22d9ca72950`.
