### PR TITLE
improve: reduce cloud worker startup overhead

### DIFF
--- a/src/worker/worker-deploy-highlight-runtime.cjs
+++ b/src/worker/worker-deploy-highlight-runtime.cjs
@@ -1,0 +1,4 @@
+// CommonJS keeps language registration lazy inside the sealed worker bundle.
+module.exports = function loadHighlightJsRuntime() {
+  return require("highlight.js");
+};

--- a/src/worker/worker-deploy-highlight-runtime.d.cts
+++ b/src/worker/worker-deploy-highlight-runtime.d.cts
@@ -1,0 +1,3 @@
+// The dependency's declarations add DOM globals to the core TypeScript program.
+declare function loadHighlightJsRuntime(): unknown;
+export = loadHighlightJsRuntime;

--- a/src/worker/worker-deploy-highlight-runtime.d.mts
+++ b/src/worker/worker-deploy-highlight-runtime.d.mts
@@ -1,2 +1,0 @@
-declare const highlightJsRuntime: unknown;
-export default highlightJsRuntime;

--- a/src/worker/worker-deploy-highlight-runtime.mjs
+++ b/src/worker/worker-deploy-highlight-runtime.mjs
@@ -1,4 +1,0 @@
-// Build-only bridge: keep highlight.js DOM declarations out of the core TypeScript program.
-import highlightJsRuntime from "highlight.js";
-
-export default highlightJsRuntime;

--- a/src/worker/worker-deploy-runtime-registry.ts
+++ b/src/worker/worker-deploy-runtime-registry.ts
@@ -1,9 +1,9 @@
-let highlightJs: unknown;
+let loadHighlightJs: (() => unknown) | undefined;
 
-export function setWorkerDeployHighlightJs(next: unknown): void {
-  highlightJs = next;
+export function setWorkerDeployHighlightJsLoader(next: () => unknown): void {
+  loadHighlightJs = next;
 }
 
 export function getWorkerDeployHighlightJs(): unknown {
-  return highlightJs;
+  return loadHighlightJs?.();
 }

--- a/src/worker/worker-deploy-runtime.ts
+++ b/src/worker/worker-deploy-runtime.ts
@@ -1,10 +1,10 @@
 import "../infra/sealed-runtime-bootstrap.js";
 import { registerSealedRuntimeProcessEntrypoint } from "../infra/runtime-process-url.js";
-import highlightJsRuntime from "./worker-deploy-highlight-runtime.mjs";
-import { setWorkerDeployHighlightJs } from "./worker-deploy-runtime-registry.js";
+import loadHighlightJsRuntime from "./worker-deploy-highlight-runtime.cjs";
+import { setWorkerDeployHighlightJsLoader } from "./worker-deploy-runtime-registry.js";
 
 registerSealedRuntimeProcessEntrypoint(
   "githubExec",
   new URL("./github-exec-launcher.mjs", import.meta.url),
 );
-setWorkerDeployHighlightJs(highlightJsRuntime);
+setWorkerDeployHighlightJsLoader(loadHighlightJsRuntime);

--- a/test/scripts/worker-deploy-build-plugin.test.ts
+++ b/test/scripts/worker-deploy-build-plugin.test.ts
@@ -36,7 +36,7 @@ describe("worker deploy build plugin", () => {
     },
   );
 
-  it("keeps the complete deploy graph inside its single staged worker file", async () => {
+  it("keeps worker bootstrap portable and defers syntax highlighting until rendering", async () => {
     const { build } = await import("tsdown");
     const { default: configs } = await import("../../tsdown.config.ts");
     const config = configs.find(
@@ -49,12 +49,29 @@ describe("worker deploy build plugin", () => {
       throw new Error("Worker deploy build config is missing");
     }
     const root = tempDirs.make("openclaw-worker-complete-graph-");
+    const entrySource = path.resolve("src/worker/worker-deploy-entry.ts");
+    const highlightSource = fs.realpathSync(path.resolve("node_modules/highlight.js/lib/index.js"));
     const bundles = await build({
       ...config,
       config: false,
       outDir: path.join(root, "dist"),
       dts: false,
       logLevel: "silent",
+      plugins: [
+        config.plugins,
+        {
+          name: "test:worker-highlight-initialization",
+          transform(code, id) {
+            if (id === entrySource) {
+              return `${code}\nexport { highlight, supportsLanguage } from "../agents/utils/syntax-highlight.js";`;
+            }
+            if (id === highlightSource) {
+              return `globalThis[Symbol.for("worker-highlight-initializations")] = (globalThis[Symbol.for("worker-highlight-initializations")] ?? 0) + 1;\n${code}`;
+            }
+            return null;
+          },
+        },
+      ],
     });
     try {
       // A dynamic import cycle can leave an unstaged root facade even with code splitting off.
@@ -69,6 +86,48 @@ describe("worker deploy build plugin", () => {
           workerDeployEntrypoints: ["dist/worker/worker.mjs"],
         }),
       ).toEqual([]);
+      const result = await promisify(execFile)(
+        process.execPath,
+        [
+          ...(process.versions.bun ? ["--no-install"] : []),
+          "--input-type=module",
+          "--eval",
+          `
+import assert from "node:assert/strict";
+import { createRequire } from "node:module";
+import { pathToFileURL } from "node:url";
+const entry = process.argv[1];
+assert.throws(() => createRequire(pathToFileURL(entry)).resolve("highlight.js"), { code: "MODULE_NOT_FOUND" });
+process.argv = [process.execPath, entry, "--internal-worker-prewarm"];
+const { highlight, supportsLanguage } = await import(pathToFileURL(entry).href);
+const initializations = () => globalThis[Symbol.for("worker-highlight-initializations")] ?? 0;
+assert.equal(initializations(), 0, "headless worker bootstrap must not initialize syntax highlighting");
+assert.equal(supportsLanguage("abnf"), true);
+assert.equal(supportsLanguage("javascript"), true);
+assert.match(highlight("const answer = 42;", {
+  language: "javascript", theme: { keyword: text => "[" + text + "]" },
+}), /\\[const\\]/);
+assert.equal(initializations(), 1, "rendering must initialize the bundled highlighter only once");
+console.log("portable worker syntax highlighting passed");
+`,
+          path.join(root, "dist/worker/worker.mjs"),
+        ],
+        {
+          cwd: root,
+          timeout: 30_000,
+          env: {
+            PATH: process.env.PATH,
+            SystemRoot: process.env.SystemRoot,
+            WINDIR: process.env.WINDIR,
+            HOME: root,
+            USERPROFILE: root,
+            TMPDIR: root,
+            TMP: root,
+            TEMP: root,
+          },
+        },
+      );
+      expect(result.stdout.trim()).toBe("portable worker syntax highlighting passed");
     } finally {
       for (const bundle of bundles) {
         await bundle[Symbol.asyncDispose]();


### PR DESCRIPTION
## What Problem This Solves

Cloud worker turns initialize every syntax-highlighting language before starting headless work. That adds avoidable CPU work before the first tool runs.

## Why This Change Was Made

Register a synchronous loader during worker bootstrap. A CommonJS bridge lets the sealed bundle defer language registration until the existing renderer needs it; that renderer continues to validate and cache the runtime. All languages remain bundled, and the worker archive layout is unchanged.

## User Impact

Headless workers avoid language-registration work. On one 2-CPU/4-GiB Daytona Linux machine with Node 24.20.0, ten fresh processes per version measured these medians:

| Measurement | Baseline | Candidate |
| --- | ---: | ---: |
| Spawn to Gateway connection | 486 ms | 460 ms |
| Spawn to first tool | 717 ms | 707 ms |
| Whole-process CPU | 1,331 ms | 1,303 ms |

The first-tool difference is within observed variation. This is a small reduction in startup work; the experiment does not establish a substantial total-turn speedup. The first actual syntax render still pays initialization cost. Provisioning, remote Gateway round trips, and real inference latency are outside this measurement.

## Evidence

- The extended real-worker build test fails on the original eager initialization and passes with the fix. It also checks package-free execution, language support, themed rendering, and one-time initialization.
- All 24 selected tests passed on the current head, including 16 build/runtime and 8 worker-context cases. Core, core-test and root-test typechecks passed.
- Full `pnpm build` passed on `04fa48550410`. Independent review through P2 found no actionable issues; the rebase preserved the reviewed patch exactly.
- Linux baseline `a0946936c485` and candidate `04fa48550410` used the same machine, opposite block order, fresh compile caches with installer-style prewarm, synthetic inference, and real exec/transcript/live-ACK flows. All turns passed. Diagnostic profile runs were excluded from the medians.
- The test lease was released and independently confirmed absent through the provider API; temporary credentials were removed.
- Current-head CI [34679562475](https://github.com/openclaw/openclaw/actions/runs/34679562475) passed. Earlier unrelated fixture/timeout failures were investigated; the upstream context fixture fix #145657 is included, and no assertions or deadlines were weakened.
