### PR TITLE
improve: keep terminal output responsive during heavy logging

### DIFF
--- a/src/gateway/terminal/output-ring.ts
+++ b/src/gateway/terminal/output-ring.ts
@@ -19,6 +19,7 @@ export class TerminalOutputRing extends BoundedBuffer<string> {
   }
 
   snapshot(): string {
+    // Evicted slots are cleared, so joining with no separator skips that prefix without a copy.
     return this.values.join("");
   }
 }

--- a/src/gateway/terminal/session-manager.output-ring.test.ts
+++ b/src/gateway/terminal/session-manager.output-ring.test.ts
@@ -20,6 +20,14 @@ describe("TerminalSessionManager output ring", () => {
     fake.emitData("ijkl");
     // Cap exceeded: the oldest whole chunk goes; boundaries stay intact.
     expect(manager.snapshot(outcome.sessionId)).toBe("efghijkl");
+
+    for (let value = 0; value < 5_000; value += 1) {
+      fake.emitData(String(value).padStart(4, "0"));
+    }
+    expect(manager.snapshot(outcome.sessionId)).toBe("49984999");
+    expect(manager.attach("conn-2", outcome.sessionId)?.buffer).toBe("49984999");
+    fake.emitData("tail");
+    expect(manager.snapshot(outcome.sessionId)).toBe("4999tail");
   });
 
   it("keeps only the tail of a single oversized chunk", async () => {

--- a/src/shared/bounded-buffer.test.ts
+++ b/src/shared/bounded-buffer.test.ts
@@ -52,4 +52,18 @@ describe("BoundedBuffer", () => {
     expect(buffer.drain()).toEqual(drained);
     expect(onOverflow).toHaveBeenCalledTimes(overflowCalls);
   });
+
+  it("drains the retained FIFO after sustained overflow and can then be reused", () => {
+    const buffer = new BoundedBuffer<number | undefined>(3, { mode: "drop-oldest" });
+    for (let value = 0; value < 5_000; value += 1) {
+      buffer.push(value);
+    }
+    buffer.push(undefined);
+
+    expect(buffer.drain()).toEqual([4_998, 4_999, undefined]);
+    expect(buffer.drain()).toEqual([]);
+    buffer.push(1);
+    buffer.push(2);
+    expect(buffer.drain()).toEqual([1, 2]);
+  });
 });

--- a/src/shared/bounded-buffer.ts
+++ b/src/shared/bounded-buffer.ts
@@ -4,7 +4,8 @@ type BoundedBufferOverflow<T> =
   | { mode: "fail-closed"; onOverflow: () => void };
 
 export class BoundedBuffer<T> {
-  protected values: T[] = [];
+  protected values: (T | undefined)[] = [];
+  private head = 0;
   private size = 0;
   private closed = false;
 
@@ -34,28 +35,33 @@ export class BoundedBuffer<T> {
     }
     this.values.push(value);
     this.size += valueSize;
-    let dropped = 0;
     // Leave the newest value for fitting; preserve the > comparison for NaN capacities.
-    for (const oldest of this.values) {
-      if (!(this.size > this.capacity) || dropped === this.values.length - 1) {
-        break;
-      }
+    while (this.size > this.capacity && this.head < this.values.length - 1) {
+      // SAFETY: head points to a pushed T; only slots before head have been cleared.
+      const oldest = this.values[this.head] as T;
       this.size -= this.measure(oldest);
-      dropped += 1;
+      this.values[this.head] = undefined;
+      this.head += 1;
     }
-    this.values.splice(0, dropped);
     if (this.size > this.capacity) {
       const fitted = this.overflow.fit?.(value, this.capacity);
       this.values = fitted === undefined ? [] : [fitted];
+      this.head = 0;
       this.size = fitted === undefined ? 0 : this.measure(fitted);
+    } else if (this.head * 2 >= this.values.length) {
+      // Amortize compaction across evictions instead of shifting every retained value per push.
+      this.values = this.values.slice(this.head);
+      this.head = 0;
     }
     return true;
   }
 
   drain(): T[] {
-    const values = this.values;
+    const values = this.head === 0 ? this.values : this.values.slice(this.head);
     this.values = [];
+    this.head = 0;
     this.size = 0;
-    return values;
+    // SAFETY: the captured suffix excludes cleared slots and preserves every pushed T, including undefined.
+    return values as T[];
   }
 }


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where sustained terminal output made of small writes spends increasing CPU time maintaining scrollback after the buffer fills.

## Why This Change Was Made

The shared bounded buffer advances a head index and clears evicted references instead of shifting every retained element after each append. It compacts when the cleared prefix reaches half the array, keeping eviction work amortized and retained storage bounded. Terminal snapshots consume the same buffer without allocating an intermediate array.

## User Impact

Busy terminal streams spend less time maintaining scrollback. Whole-write eviction, Unicode-safe fitting, replay offsets, FIFO order, actual undefined values, and latch/fail-closed behavior remain unchanged.

## Evidence

- Windows x64, Node 26.8.2; actual terminal output controller and ring, eight synthetic streams with 2 MiB per stream and snapshots every 32 KiB. Ten samples per variant in baseline/candidate/candidate/baseline order, with identical source transformation outside timing and recorded source hashes. For 32-character writes, median time excluding assertion time fell from 4,181 to 675 ms (6.20x); process CPU fell from 3,875 to 703 ms. For 128-character writes, median time fell from 486 to 270 ms (1.80x).
- Replay contents, end offsets, and emitted frame order matched. All 16 existing/extended bounded-buffer, session-manager output-ring, and node-relay tests passed on the final source. Targeted lint and production core typecheck passed. Independent review found no actionable issues.
- Larger-write measurements limit the claim: ordered 4 KiB cases regressed; fresh-process warmed 4 KiB comparisons had similar wall/snapshot costs (47.85 vs 45.21 ms wall). CPU granularity and shared-host activity limit small differences. No general large-write or native PTY speedup is claimed; a separate Windows native PTY attempt stalled during startup and produced no usable timing evidence.
- Benchmarks are local task artifacts, not timing-sensitive CI tests. Required hosted CI remains a merge gate.
