### PR TITLE
fix(agents): run tool code child with Node under Bun

### DIFF
--- a/src/agents/tool-search-code-mode.ts
+++ b/src/agents/tool-search-code-mode.ts
@@ -3,6 +3,7 @@ import { spawn } from "node:child_process";
 import os from "node:os";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { sliceUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
+import { resolveNodeRuntimeExecutable } from "../infra/node-runtime-executable.js";
 import type { AgentToolUpdateCallback } from "./runtime/index.js";
 import { appendBoundedTextTail, SESSION_TOOL_STDERR_TAIL_BYTES } from "./sessions/tools/limits.js";
 import { TOOL_SEARCH_CODE_MODE_CHILD_SOURCE } from "./tool-search-code-mode-child.js";
@@ -47,11 +48,17 @@ export async function runCodeMode(params: {
   };
 }
 
-function buildCodeModeChildArgs(): string[] {
-  if (!process.allowedNodeEnvironmentFlags.has("--permission")) {
-    throw new ToolInputError("tool_search_code requires a Node runtime with --permission support.");
+function resolveCodeModeChildCommand(): { executable: string; args: string[] } {
+  const executable = resolveNodeRuntimeExecutable({ requiredFlag: "--permission" });
+  if (!executable) {
+    throw new ToolInputError(
+      "tool_search_code requires an installed Node runtime with --permission support.",
+    );
   }
-  return ["--permission", "--input-type=module", "--eval", TOOL_SEARCH_CODE_MODE_CHILD_SOURCE];
+  return {
+    executable,
+    args: ["--permission", "--input-type=module", "--eval", TOOL_SEARCH_CODE_MODE_CHILD_SOURCE],
+  };
 }
 
 function isCodeModeBridgeMethod(value: unknown): value is CodeModeBridgeMethod {
@@ -111,7 +118,8 @@ export function runCodeModeChild(params: {
   onUpdate?: AgentToolUpdateCallback;
 }): Promise<unknown> {
   return new Promise((resolve, reject) => {
-    const child = spawn(process.execPath, buildCodeModeChildArgs(), {
+    const command = resolveCodeModeChildCommand();
+    const child = spawn(command.executable, command.args, {
       cwd: os.tmpdir(),
       env: {},
       // The worker returns logs/results over IPC and never writes stdout.

--- a/src/agents/tool-search-config.ts
+++ b/src/agents/tool-search-config.ts
@@ -1,5 +1,6 @@
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { resolveNodeRuntimeExecutable } from "../infra/node-runtime-executable.js";
 import {
   MAX_TOOL_SEARCH_RESULTS,
   type ToolSearchConfig,
@@ -41,7 +42,7 @@ export function isToolSearchCodeModeSupported(): boolean {
   // so the isolated code child cannot be launched as a plain Node process.
   return (
     typeof process.versions.electron !== "string" &&
-    process.allowedNodeEnvironmentFlags.has("--permission")
+    resolveNodeRuntimeExecutable({ requiredFlag: "--permission" }) !== undefined
   );
 }
 

--- a/src/infra/node-runtime-executable.ts
+++ b/src/infra/node-runtime-executable.ts
@@ -1,0 +1,102 @@
+import { execFileSync } from "node:child_process";
+import path from "node:path";
+
+const NODE_RUNTIME_PROBE_TIMEOUT_MS = 5_000;
+const NODE_RUNTIME_CACHE_MAX_ENTRIES = 16;
+
+const resolvedNodeRuntimeExecutables = new Map<string, string | null>();
+
+function buildProbeEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  const probeEnv: NodeJS.ProcessEnv = {};
+  for (const key of ["SystemRoot", "SYSTEMROOT", "WINDIR", "TEMP", "TMP", "TMPDIR"]) {
+    const value = env[key];
+    if (value) {
+      probeEnv[key] = value;
+    }
+  }
+  return probeEnv;
+}
+
+function buildNodeExecutableCandidates(env: NodeJS.ProcessEnv): string[] {
+  const names =
+    process.platform === "win32"
+      ? (env.PATHEXT ?? ".EXE;.CMD;.BAT;.COM")
+          .split(";")
+          .filter(Boolean)
+          .map((extension) => `node${extension.toLowerCase()}`)
+      : ["node"];
+  const candidates = (env.PATH ?? "")
+    .split(path.delimiter)
+    .filter(Boolean)
+    .flatMap((directory) => names.map((name) => path.join(directory, name)));
+  if (process.platform === "darwin") {
+    candidates.push(
+      "/opt/homebrew/bin/node",
+      "/opt/homebrew/opt/node/bin/node",
+      "/usr/local/bin/node",
+      "/usr/local/opt/node/bin/node",
+      "/usr/bin/node",
+    );
+  } else if (process.platform === "linux") {
+    candidates.push("/usr/local/bin/node", "/usr/bin/node");
+  }
+  return [...new Set(candidates)];
+}
+
+/** Resolves a real Node executable, skipping Bun's optional `node` shim. */
+export function resolveNodeRuntimeExecutable(options?: {
+  env?: NodeJS.ProcessEnv;
+  requiredFlag?: string;
+}): string | undefined {
+  const env = options?.env ?? process.env;
+  const requiredFlag = options?.requiredFlag;
+  if (
+    !process.versions.bun &&
+    (!requiredFlag || process.allowedNodeEnvironmentFlags.has(requiredFlag))
+  ) {
+    return process.execPath;
+  }
+
+  const cacheKey = [
+    process.platform,
+    process.versions.bun ?? process.versions.node,
+    requiredFlag ?? "",
+    env.PATH ?? "",
+    env.PATHEXT ?? "",
+  ].join("\0");
+  const cached = resolvedNodeRuntimeExecutables.get(cacheKey);
+  if (cached !== undefined) {
+    return cached ?? undefined;
+  }
+
+  const probeSource = `const requiredFlag=${JSON.stringify(
+    requiredFlag,
+  )};process.stdout.write(!process.versions.bun&&(!requiredFlag||process.allowedNodeEnvironmentFlags.has(requiredFlag))?process.execPath:"")`;
+  let resolved: string | undefined;
+  for (const candidate of buildNodeExecutableCandidates(env)) {
+    try {
+      const nodePath = execFileSync(candidate, ["--eval", probeSource], {
+        encoding: "utf8",
+        env: buildProbeEnv(env),
+        stdio: ["ignore", "pipe", "ignore"],
+        timeout: NODE_RUNTIME_PROBE_TIMEOUT_MS,
+      }).trim();
+      if (nodePath) {
+        resolved = nodePath;
+        break;
+      }
+    } catch {
+      // Missing, non-executable, incompatible, and Bun shim candidates are skipped.
+    }
+  }
+
+  resolvedNodeRuntimeExecutables.set(cacheKey, resolved ?? null);
+  while (resolvedNodeRuntimeExecutables.size > NODE_RUNTIME_CACHE_MAX_ENTRIES) {
+    const oldest = resolvedNodeRuntimeExecutables.keys().next().value;
+    if (oldest === undefined) {
+      break;
+    }
+    resolvedNodeRuntimeExecutables.delete(oldest);
+  }
+  return resolved;
+}

--- a/src/test-utils/node-process.ts
+++ b/src/test-utils/node-process.ts
@@ -1,6 +1,6 @@
 // Test helpers for spawning Node processes and asserting their output.
 import { execFileSync, spawnSync, type SpawnSyncReturns } from "node:child_process";
-import path from "node:path";
+import { resolveNodeRuntimeExecutable } from "../infra/node-runtime-executable.js";
 
 type NodeEvalArgsOptions = {
   evalFlag?: "--eval" | "-e";
@@ -18,43 +18,10 @@ type SpawnNodeEvalOptions = Omit<NonNullable<Parameters<typeof spawnSync>[2]>, "
   };
 
 export function resolveTestNodeExecPath(): string {
-  if (!process.versions.bun) {
-    return process.execPath;
+  const nodePath = resolveNodeRuntimeExecutable();
+  if (nodePath) {
+    return nodePath;
   }
-
-  // Bun's --bun mode prepends a node shim that points back to Bun. Walk every
-  // PATH candidate and accept only a process that identifies itself as Node.
-  const executableNames =
-    process.platform === "win32"
-      ? (process.env.PATHEXT ?? ".EXE;.CMD;.BAT;.COM")
-          .split(";")
-          .filter(Boolean)
-          .map((extension) => `node${extension.toLowerCase()}`)
-      : ["node"];
-  const candidates = (process.env.PATH ?? "")
-    .split(path.delimiter)
-    .filter(Boolean)
-    .flatMap((directory) => executableNames.map((name) => path.join(directory, name)));
-
-  for (const candidate of new Set(candidates)) {
-    try {
-      const nodePath = execFileSync(
-        candidate,
-        ["-p", "process.versions.bun ? '' : process.execPath"],
-        {
-          encoding: "utf8",
-          stdio: ["ignore", "pipe", "ignore"],
-          timeout: 5_000,
-        },
-      ).trim();
-      if (nodePath) {
-        return nodePath;
-      }
-    } catch {
-      // Missing, non-executable, and broken PATH entries are not Node candidates.
-    }
-  }
-
   throw new Error("Unable to locate a Node executable while running tests under Bun");
 }
 


### PR DESCRIPTION
## What Problem This Solves

Bun cannot run `tool_search_code` because the sandboxed code child requires Node's `--permission` flag. The runtime checked Bun's own flags and launched `process.execPath`, so a direct-Bun MCP recovery test failed before the code child started.

## Why This Change Was Made

OpenClaw now resolves a real Node executable for runtime-specific sidecars. The resolver walks `PATH` plus stable system locations, skips Bun's optional `node` shim, verifies the requested Node flag in a sterile probe process, and caches the result by runtime and executable-search inputs. Tool Search uses that verified Node for its isolated child and advertises code mode under Bun only when a compatible Node is available. The existing test Node resolver now shares the same owner.

## User Impact

Bun-hosted OpenClaw can use the full sandboxed Tool Search code mode while Node behavior stays unchanged. This adds no dependency and does not alter Node installation or package-manager behavior; it only locates an already-installed compatible Node for the child process. Electron keeps its existing structured-tool fallback.

## Evidence

- Direct custom Bun: Tool Search MCP recovery 8/8 passed; before the fix the code-mode case failed with the Node `--permission` runtime error.
- Direct custom Bun: full focused Tool Search and child lifecycle set 204/204 passed, plus the Node resolver regression 1/1.
- Node: the same focused matrix passed 213/213.
- Bun config smoke resolves code mode in about 47 ms on the first probe and 0.02 ms from cache.
- `node scripts/check-changed.mjs`: passed.
- Test-audit: the existing shim regression protects runtime identity, the credible regression is a Bun shim being selected as Node, and the refactor adds no test-only production seam or duplicate test.
- Independent P0-P2 autoreview: scoped clean at 0.89 confidence.
