### PR TITLE
fix(cli): refuse another agent's credentials after restore

### DIFF
--- a/src/agents/auth-profiles/sqlite.ts
+++ b/src/agents/auth-profiles/sqlite.ts
@@ -21,6 +21,11 @@ import { isPathInside } from "../../infra/path-guards.js";
 import { resolveSqliteDatabaseFilePaths } from "../../infra/sqlite-files.js";
 import { readSqliteUserVersion } from "../../infra/sqlite-user-version.js";
 import { registerSqliteCacheExitClose } from "../../infra/sqlite-wal.js";
+import { normalizeAgentId } from "../../routing/session-key.js";
+import {
+  assertExistingAgentSchemaOwner,
+  readExistingAgentSchemaMeta,
+} from "../../state/openclaw-agent-db-schema-helpers.js";
 import type { DB as OpenClawAgentKyselyDatabase } from "../../state/openclaw-agent-db.generated.js";
 import {
   deferOpenClawAgentPostCommitPublication,
@@ -416,6 +421,23 @@ function acquireAuthProfileReadDatabase(
   authProfileReadDatabases.set(resolvedPath, db);
   unregisterReadHandleExitClose ??= registerSqliteCacheExitClose(closeAuthProfileReadPool);
   return { status: "readable", db };
+}
+
+/** Validate selected-agent ownership without requiring a current session schema. */
+export function assertAuthProfileStoreAgentOwner(agentDir: string, agentId: string): void {
+  const pathname = resolveAuthProfileDatabasePath(agentDir);
+  const acquired = acquireAuthProfileReadDatabase(pathname);
+  if (acquired.status === "missing") {
+    return;
+  }
+  if (acquired.status === "unreadable") {
+    throw new Error(`Unable to read agent auth database ${pathname}.`);
+  }
+  assertExistingAgentSchemaOwner(
+    readExistingAgentSchemaMeta(acquired.db),
+    normalizeAgentId(agentId),
+    pathname,
+  );
 }
 
 export function inspectAuthProfileJsonCellReadOnly(

--- a/src/cli/capability-cli/local-account-secrets.test.ts
+++ b/src/cli/capability-cli/local-account-secrets.test.ts
@@ -15,6 +15,10 @@ vi.mock("../../agents/agent-scope.js", () => ({
   resolveAgentDir: mocks.resolveAgentDir,
 }));
 
+vi.mock("../../agents/auth-profiles/sqlite.js", () => ({
+  assertAuthProfileStoreAgentOwner: vi.fn(),
+}));
+
 vi.mock("../../config/config.js", () => ({
   getRuntimeConfigSourceSnapshot: mocks.getRuntimeConfigSourceSnapshot,
 }));
@@ -53,20 +57,5 @@ describe("prepareLocalCapabilityAccountSecrets", () => {
       allowUnavailableSecretOwners: true,
     });
     expect(mocks.activateSecretsRuntimeSnapshot).toHaveBeenCalledWith({ marker: "snapshot" });
-  });
-
-  it("does not replace an already active secrets runtime snapshot", async () => {
-    const cfg: OpenClawConfig = {};
-    mocks.getActiveSecretsRuntimeConfigSnapshot.mockReturnValue({
-      config: cfg,
-      sourceConfig: cfg,
-      configRefsPrepared: true,
-    });
-
-    await prepareLocalCapabilityAccountSecrets({ cfg, agentId: "main" });
-
-    expect(mocks.resolveAgentDir).not.toHaveBeenCalled();
-    expect(mocks.prepareSecretsRuntimeSnapshot).not.toHaveBeenCalled();
-    expect(mocks.activateSecretsRuntimeSnapshot).not.toHaveBeenCalled();
   });
 });

--- a/src/cli/capability-cli/local-account-secrets.ts
+++ b/src/cli/capability-cli/local-account-secrets.ts
@@ -1,4 +1,5 @@
 import { resolveAgentDir } from "../../agents/agent-scope.js";
+import { assertAuthProfileStoreAgentOwner } from "../../agents/auth-profiles/sqlite.js";
 import { getRuntimeConfigSourceSnapshot } from "../../config/config.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { getActiveSecretsRuntimeConfigSnapshot } from "../../secrets/runtime-state.js";
@@ -11,6 +12,8 @@ export async function prepareLocalCapabilityAccountSecrets(params: {
   cfg: OpenClawConfig;
   agentId: string;
 }): Promise<void> {
+  const agentDir = resolveAgentDir(params.cfg, params.agentId);
+  assertAuthProfileStoreAgentOwner(agentDir, params.agentId);
   if (getActiveSecretsRuntimeConfigSnapshot()) {
     return;
   }
@@ -19,7 +22,7 @@ export async function prepareLocalCapabilityAccountSecrets(params: {
   const snapshot = await secretsRuntime.prepareSecretsRuntimeSnapshot({
     config: getRuntimeConfigSourceSnapshot() ?? params.cfg,
     assignmentConfig: params.cfg,
-    agentDirs: [resolveAgentDir(params.cfg, params.agentId)],
+    agentDirs: [agentDir],
     includeConfigRefs: false,
     allowUnavailableSecretOwners: true,
   });

--- a/src/cli/capability-cli/local-runners.account-secrets.test.ts
+++ b/src/cli/capability-cli/local-runners.account-secrets.test.ts
@@ -115,13 +115,13 @@ function buildRawCfg(agentDir: string): OpenClawConfig {
   };
 }
 
-async function runLocalCapability(argv: string[]): Promise<void> {
+async function runLocalCapability(argv: string[], agent = "ops"): Promise<void> {
   const capability = new Command();
   registerImageCapabilityCommands(capability);
   registerEmbeddingCapabilityCommands(capability);
   registerAudioCapabilityCommands(capability);
   registerVideoCapabilityCommands(capability);
-  await capability.parseAsync([...argv, "--agent", "ops", "--json"], { from: "user" });
+  await capability.parseAsync([...argv, "--agent", agent, "--json"], { from: "user" });
 }
 
 describe("local capability runners saved-account SecretRefs", () => {
@@ -163,7 +163,7 @@ describe("local capability runners saved-account SecretRefs", () => {
     ["audio transcribe", ["audio", "transcribe", "--file", "input.wav"]],
     ["video generate", ["video", "generate", "--prompt", "a red square"]],
     ["video describe", ["video", "describe", "--file", "input.mp4"]],
-  ])("%s resolves the saved account credential", async (_name, argv) => {
+  ])("infer %s uses only the durable owner’s saved credential", async (_name, argv) => {
     await runLocalCapability(argv);
 
     expect(hoisted.egressAuth).toHaveLength(1);
@@ -171,5 +171,21 @@ describe("local capability runners saved-account SecretRefs", () => {
       source: "profile:customacct:saved",
       apiKey: ACCOUNT_KEY_VALUE,
     });
+    hoisted.rawCfg = {
+      ...hoisted.rawCfg,
+      agents: {
+        ...hoisted.rawCfg.agents,
+        entries: { restored: { agentDir: state.agentDir("ops") } },
+      },
+    };
+    for (const activeSnapshot of [true, false]) {
+      if (!activeSnapshot) {
+        clearSecretsRuntimeSnapshotState();
+      }
+      await expect(runLocalCapability(argv, "restored")).rejects.toThrow(
+        "belongs to agent ops; requested agent restored",
+      );
+      expect(hoisted.egressAuth).toHaveLength(1);
+    }
   });
 });


### PR DESCRIPTION
Related: #144931, #145188, #145171, #144831.

## What Problem This Solves

Restoring an agent backup under a different agent name could let local capability commands use the original agent's saved credential. Local model inference already rejected this ownership mismatch.

## Why This Change Was Made

Shared local account preparation now passes the selected agent identity to the existing durable credential-owner check before resolving credentials, including when a secrets snapshot is active.

## User Impact

Local inference rejects credentials owned by another agent before making a request. Legitimate accounts continue to work. No schema, migration, configuration, or protocol change is required.

Consumers: embedding, image generation and description, audio transcription, and video generation and description now enforce the same saved-credential ownership rule.

## Evidence

Supported backup restore and agent registration commands reproduced credential use before the fix. All six repaired command families then rejected the restored identity with zero recorded requests. Legitimate and rotated credentials succeeded against a recording endpoint. Registered capability regressions failed before the fix; 255 capability tests and 16 auth database tests passed. Post-rebase command checks passed. Previous-release saved accounts remained usable. A separate multi-agent image-description forwarding issue remains tracked by #145188 and #145171.
