### PR TITLE
improve: avoid copying discarded memory search payloads

### DIFF
--- a/extensions/memory-core/src/memory/manager-search-orchestration.test.ts
+++ b/extensions/memory-core/src/memory/manager-search-orchestration.test.ts
@@ -250,47 +250,21 @@ describe("memory index", () => {
       );
     }
 
-    const originalPrepare = fields.db.prepare.bind(fields.db);
-    let scannedBatches = 0;
-    const prepareSpy = vi.spyOn(fields.db, "prepare").mockImplementation((sql: string) => {
-      const statement = originalPrepare(sql);
-      if (!sql.includes("SELECT rowid, id, path")) {
-        return statement;
-      }
-      return {
-        all: (...args: Parameters<typeof statement.all>) => {
-          scannedBatches += 1;
-          return statement.all(...args);
-        },
-      } as unknown as typeof statement;
-    });
+    const caller = new AbortController();
+    const abortReason = new Error("caller stopped hybrid memory search");
+    const pending = manager.search("alpha", { signal: caller.signal });
+    setImmediate(() => caller.abort(abortReason));
 
-    try {
-      const caller = new AbortController();
-      const abortReason = new Error("caller stopped hybrid memory search");
-      const pending = manager.search("alpha", { signal: caller.signal });
-      setImmediate(() => caller.abort(abortReason));
+    await expect(pending).rejects.toBe(abortReason);
 
-      await expect(pending).rejects.toBe(abortReason);
-      await new Promise<void>((resolve) => {
-        setImmediate(resolve);
-      });
-      await new Promise<void>((resolve) => {
-        setImmediate(resolve);
-      });
-      expect(scannedBatches).toBe(1);
+    const healthyResults = await manager.search("alpha");
+    expect(healthyResults.some((result) => result.path === "memory/2026-01-12.md")).toBe(true);
 
-      const healthyResults = await manager.search("alpha");
-      expect(healthyResults.some((result) => result.path === "memory/2026-01-12.md")).toBe(true);
-
-      fields.ensureVectorReady = async () => {
-        throw new Error("vector store unavailable");
-      };
-      const degradedResults = await manager.search("alpha");
-      expect(degradedResults.some((result) => result.path === "memory/2026-01-12.md")).toBe(true);
-    } finally {
-      prepareSpy.mockRestore();
-    }
+    fields.ensureVectorReady = async () => {
+      throw new Error("vector store unavailable");
+    };
+    const degradedResults = await manager.search("alpha");
+    expect(degradedResults.some((result) => result.path === "memory/2026-01-12.md")).toBe(true);
   });
 
   it("supplements thin strict FTS results for conversational queries", async () => {

--- a/extensions/memory-core/src/memory/manager-search.test.ts
+++ b/extensions/memory-core/src/memory/manager-search.test.ts
@@ -1,4 +1,4 @@
-import path from "node:path";
+import nodePath from "node:path";
 // Memory Core tests cover manager search plugin behavior.
 import type { DatabaseSync } from "node:sqlite";
 import { expectDefined } from "@openclaw/normalization-core";
@@ -1406,7 +1406,7 @@ describe("searchVector sqlite-vec KNN", () => {
   });
 
   it("reads contender payloads from the scored batch snapshot during external writes", async () => {
-    const filename = path.join(tempDirs.make("memory-search-snapshot-"), "memory.sqlite");
+    const filename = nodePath.join(tempDirs.make("memory-search-snapshot-"), "memory.sqlite");
     const db = new DatabaseSync(filename);
     const writer = new DatabaseSync(filename);
     try {

--- a/extensions/memory-core/src/memory/manager-search.test.ts
+++ b/extensions/memory-core/src/memory/manager-search.test.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 // Memory Core tests cover manager search plugin behavior.
 import type { DatabaseSync } from "node:sqlite";
 import { expectDefined } from "@openclaw/normalization-core";
@@ -6,7 +7,8 @@ import {
   loadSqliteVecExtension,
   requireNodeSqlite,
 } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
-import { describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "openclaw/plugin-sdk/test-env";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { bm25RankToScore, buildFtsQuery } from "./hybrid.js";
 import { runVectorKnnQuery } from "./manager-search-knn.js";
 import { searchKeyword, searchPathKeyword, searchVector } from "./manager-search.js";
@@ -1007,6 +1009,7 @@ describe("searchKeyword cross-model FTS visibility (issue #48300)", () => {
 
 describe("searchVector sqlite-vec KNN", () => {
   const { DatabaseSync } = requireNodeSqlite();
+  const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
   it("yields to the event loop during large fallback scans (issue #81172)", async () => {
     // Real Nextcloud-scale corpus where the vec0 fast path is unavailable
@@ -1084,38 +1087,38 @@ describe("searchVector sqlite-vec KNN", () => {
         });
       }
 
-      let scannedBatches = 0;
-      const countedDb = {
-        prepare: (sql: string) => {
-          const statement = db.prepare(sql);
-          if (!sql.includes("SELECT rowid, id, path")) {
-            return statement;
-          }
-          return {
-            all: (...args: Parameters<typeof statement.all>) => {
-              scannedBatches += 1;
-              return statement.all(...args);
-            },
-          };
-        },
-      } as unknown as DatabaseSync;
+      let scannedRows = 0;
+      db.function("observe_embedding", (embedding) => {
+        scannedRows += 1;
+        return embedding;
+      });
+      db.exec(`
+        ALTER TABLE memory_index_chunks RENAME TO observed_chunks;
+        CREATE VIEW memory_index_chunks AS
+          SELECT rowid, id, path, source, start_line, end_line, model, text,
+                 observe_embedding(embedding) AS embedding
+          FROM observed_chunks;
+      `);
       const caller = new AbortController();
       const abortReason = new Error("caller stopped memory search");
       const pending = runMemorySearchWithDeadline({
         timeoutMs: 5_000,
         parentSignal: caller.signal,
-        run: async (signal) => await searchVectorFixture(countedDb, { signal }),
+        run: async (signal) => await searchVectorFixture(db, { signal }),
       });
       setImmediate(() => caller.abort(abortReason));
 
       await expect(pending).rejects.toBe(abortReason);
+      const rowsAtAbort = scannedRows;
+      expect(rowsAtAbort).toBeGreaterThan(0);
+      expect(rowsAtAbort).toBeLessThan(4096);
       await new Promise<void>((resolve) => {
         setImmediate(resolve);
       });
       await new Promise<void>((resolve) => {
         setImmediate(resolve);
       });
-      expect(scannedBatches).toBe(1);
+      expect(scannedRows).toBe(rowsAtAbort);
 
       const healthyResults = await searchVectorFixture(db, { limit: 1 });
       expect(healthyResults.map((result) => result.id)).toEqual(["chunk-4095"]);
@@ -1346,6 +1349,96 @@ describe("searchVector sqlite-vec KNN", () => {
       expect(inserted).toBe(true);
       expect(results.map((r) => r.id)).toEqual(["winner-A", "winner-B"]);
     } finally {
+      db.close();
+    }
+  });
+
+  it("keeps scored payloads and equal-score ordering when chunks change between batches", async () => {
+    const db = createFallbackDb();
+    try {
+      for (let index = 0; index < 257; index += 1) {
+        insertFallbackChunk(db, {
+          id: `chunk-${index}`,
+          model: "target-model",
+          vector: index < 2 || index === 256 ? [1, 0] : [0, 1],
+        });
+      }
+      db.prepare("UPDATE memory_index_chunks SET text = ? WHERE id = ?").run(
+        "old 😀 text",
+        "chunk-0",
+      );
+      const changed = new Promise<void>((resolve) => {
+        setImmediate(() => {
+          db.prepare("UPDATE memory_index_chunks SET text = ?, embedding = ? WHERE id = ?").run(
+            "replacement",
+            "[0,1]",
+            "chunk-0",
+          );
+          resolve();
+        });
+      });
+
+      const results = await searchVectorFixture(db, { limit: 2, snippetMaxChars: 5 });
+      await changed;
+      expect(results).toEqual([
+        {
+          id: "chunk-0",
+          path: "memory/chunk-0.md",
+          startLine: 1,
+          endLine: 1,
+          score: 1,
+          snippet: "old ",
+          source: "memory",
+        },
+        {
+          id: "chunk-1",
+          path: "memory/chunk-1.md",
+          startLine: 1,
+          endLine: 1,
+          score: 1,
+          snippet: "chunk",
+          source: "memory",
+        },
+      ]);
+    } finally {
+      db.close();
+    }
+  });
+
+  it("reads contender payloads from the scored batch snapshot during external writes", async () => {
+    const filename = path.join(tempDirs.make("memory-search-snapshot-"), "memory.sqlite");
+    const db = new DatabaseSync(filename);
+    const writer = new DatabaseSync(filename);
+    try {
+      db.exec("PRAGMA journal_mode = WAL");
+      ensureMemoryIndexSchema({ db, cacheEnabled: false, ftsEnabled: false });
+      insertFallbackChunk(db, { id: "winner", model: "target-model", vector: [1, 0] });
+      db.exec(`
+        ALTER TABLE memory_index_chunks RENAME TO observed_chunks;
+        CREATE VIEW memory_index_chunks AS
+          SELECT rowid, id, path, source, start_line, end_line, model, text,
+                 observe_embedding(embedding) AS embedding
+          FROM observed_chunks;
+      `);
+      let replaced = false;
+      db.function("observe_embedding", (embedding) => {
+        if (!replaced) {
+          writer
+            .prepare("UPDATE observed_chunks SET text = ?, embedding = ? WHERE id = ?")
+            .run("replacement payload", "[0,1]", "winner");
+          replaced = true;
+        }
+        return embedding;
+      });
+
+      const results = await searchVectorFixture(db, { limit: 1 });
+      expect(replaced).toBe(true);
+      expect(results[0]).toMatchObject({ id: "winner", score: 1, snippet: "chunk winner" });
+      expect(writer.prepare("SELECT text FROM observed_chunks").get()?.text).toBe(
+        "replacement payload",
+      );
+    } finally {
+      writer.close();
       db.close();
     }
   });

--- a/extensions/memory-core/src/memory/manager-search.ts
+++ b/extensions/memory-core/src/memory/manager-search.ts
@@ -422,7 +422,7 @@ async function searchChunksByEmbedding(params: {
   // table, and do not hold a sqlite iterator open across the setImmediate yield
   // below. The rowid cursor keeps memory bounded without OFFSET rescans.
   const stmt = params.db.prepare(
-    `SELECT rowid, id, path, start_line, end_line, text, embedding, source\n` +
+    `SELECT rowid, embedding\n` +
       `  FROM memory_index_chunks\n` +
       ` WHERE ${modelFilter} AND rowid > ?${params.sourceFilter.sql}\n` +
       ` ORDER BY rowid ASC\n` +
@@ -430,38 +430,51 @@ async function searchChunksByEmbedding(params: {
   );
   type ChunkEmbeddingRow = {
     rowid: number | bigint;
+    embedding: string;
+  };
+  const payloadStmt = params.db.prepare(
+    `SELECT id, path, start_line, end_line, text, source FROM memory_index_chunks WHERE rowid = ?`,
+  );
+  type ChunkPayload = {
     id: string;
     path: string;
     start_line: number;
     end_line: number;
     text: string;
-    embedding: string;
     source: SearchSource;
   };
 
   const topResults: SearchRowResult[] = [];
   let lastRowid = 0;
   while (true) {
-    const batch = stmt.all(
+    const batch = stmt.iterate(
       ...providerModels,
       lastRowid,
       ...params.sourceFilter.params,
       FALLBACK_VECTOR_BATCH_SIZE,
-    ) as ChunkEmbeddingRow[];
-    if (batch.length === 0) {
-      break;
-    }
+    ) as IterableIterator<ChunkEmbeddingRow>;
+    let batchSize = 0;
     for (const row of batch) {
+      batchSize += 1;
+      lastRowid = typeof row.rowid === "bigint" ? Number(row.rowid) : row.rowid;
       const score = cosineSimilarity(params.queryVec, parseEmbedding(row.embedding));
-      if (Number.isFinite(score)) {
+      const lowest = topResults.at(-1);
+      if (
+        Number.isFinite(score) &&
+        (topResults.length < params.limit || (lowest && score > lowest.score))
+      ) {
+        // Hydrate contenders before yielding so an old score cannot acquire a
+        // replacement chunk's payload.
+        // SAFETY: these schema-defined columns belong to this rowid in the active read snapshot.
+        const payload = payloadStmt.get(row.rowid) as ChunkPayload;
         const result: SearchRowResult = {
-          id: row.id,
-          path: row.path,
-          startLine: row.start_line,
-          endLine: row.end_line,
+          id: payload.id,
+          path: payload.path,
+          startLine: payload.start_line,
+          endLine: payload.end_line,
           score,
-          snippet: truncateUtf16Safe(row.text, params.snippetMaxChars),
-          source: row.source,
+          snippet: truncateUtf16Safe(payload.text, params.snippetMaxChars),
+          source: payload.source,
         };
         if (topResults.length < params.limit) {
           topResults.push(result);
@@ -469,17 +482,12 @@ async function searchChunksByEmbedding(params: {
             topResults.sort((a, b) => b.score - a.score);
           }
         } else {
-          const lowest = topResults.at(-1);
-          if (lowest && result.score > lowest.score) {
-            topResults[topResults.length - 1] = result;
-            topResults.sort((a, b) => b.score - a.score);
-          }
+          topResults[topResults.length - 1] = result;
+          topResults.sort((a, b) => b.score - a.score);
         }
       }
     }
-    const nextRowid = batch.at(-1)?.rowid;
-    lastRowid = typeof nextRowid === "bigint" ? Number(nextRowid) : (nextRowid ?? lastRowid);
-    if (batch.length < FALLBACK_VECTOR_BATCH_SIZE) {
+    if (batchSize < FALLBACK_VECTOR_BATCH_SIZE) {
       break;
     }
     await yieldToEventLoop();


### PR DESCRIPTION
## What Problem This Solves

Memory searches that fall back from the vector extension copy every matching chunk's text into JavaScript, even though only a few chunks become results. This wastes time and allocations for large documents.

## Why This Change Was Made

Scan embeddings in the existing bounded batches and hydrate payloads only when their scores enter the best-result set. Hydration runs while the batch iterator holds the same SQLite read snapshot. The iterator closes before yielding to the event loop, preserving cancellation, equal-score order, and the association between a score and its original text.

## User Impact

Faster fallback memory searches, especially when indexed chunks contain substantial text. Native vector search and the public search contract stay the same.

## Evidence

- 50 memory-search tests passed. All 26 orchestration cases also passed across the sibling run and a focused rerun of the updated cancellation case.
- Real WAL connections verify that an external writer cannot pair a scored embedding with a replacement payload. Coverage also checks inter-batch changes, ties, UTF-16 truncation, yielding, and cancellation recovery.
- Paired actual search measurements on Node 26.8.2 / SQLite 3.53.4, with identical results: 12,000 rows, 768 dimensions, 8 KiB text, top eight: median 504.93 → 441.57 ms (12.5% lower). At 1,000 rows/64 dimensions, 10.64 → 7.23 ms. Small payloads showed a smaller, noisy gain.
- Production extension typecheck and initial repository guards passed. Local extension-test typechecking exhausted host memory; hosted CI must complete that gate. Independent P0–P2 review completed clean.

## Existing Database Compatibility

This changes fallback SELECT projection and result materialization only: no schema, indexes, versions, writers, or embedding format changes. At head `37f1424b`, the original reader from `3f0b8a1` and the updated reader returned identical results in eight cases against the same existing canonical memory-index disk database (1,025 synthetic chunks, 64 dimensions, cache and FTS enabled). Both connections were read-only. All 19 tables' schema/data digests, stored revision, user/schema versions, and the database SHA-256 remained unchanged; both connections recorded zero writes. This separate check establishes reader compatibility; the timing benchmark's minimal schema is not migration proof.
