### PR TITLE
fix(codex): honor limited profiles for native execution

### DIFF
--- a/docs/plugins/codex-harness.md
+++ b/docs/plugins/codex-harness.md
@@ -59,6 +59,17 @@ The sandbox exec-server option does not bypass those tool restrictions. Node-bac
 `remote-exec` on a paired device or cloud worker instead uses its
 placement-owned environment without that experimental flag. A dedicated cloud worker with a completed project preparation keeps the bound workspace and `HOME` paths, so native commands can reuse setup caches. The node exec-server still uses a separate temporary `CODEX_HOME` for each connection. Ending the connection removes that Codex state and preserves the prepared project home.
 
+Some placements require native execution. Node-backed `remote-exec` turns reject
+a limited profile when they cannot run without native tools. A native-owned
+attached Codex thread can also reject a restricted turn when applying the policy
+would require replacing that externally owned thread. This can interrupt an
+existing conversation after an upgrade. To retain a limited profile, use a
+Gateway-managed conversation or runtime with a compatible execution environment.
+If native shell and filesystem access is intended, the operator can choose
+`coding` or `full`. Other explicit tool and sandbox restrictions still apply;
+an explicit finite tool allowlist still blocks native execution. OpenClaw does
+not broaden tool access or replace externally owned threads automatically.
+
 Eligible native-shell turns also retain `gateway_exec` and `gateway_process`
 as a distinct OpenClaw execution path. Use `gateway_exec` only when a command
 needs OpenClaw-managed Gateway environment access, including Secret Store

--- a/docs/plugins/codex-harness.md
+++ b/docs/plugins/codex-harness.md
@@ -51,7 +51,11 @@ with Codex native code mode enabled (code-mode-only stays off by default), so
 native workspace/code capabilities remain available alongside OpenClaw
 dynamic tools routed through the app-server `item/tool/call` bridge. An
 ordinary OpenClaw sandbox or restricted tool policy disables native code mode
-unless you opt into the experimental sandbox exec-server path. Node-backed
+unless you opt into the experimental sandbox exec-server path. The effective
+tool profile must allow all native shell and filesystem capabilities: `coding`
+and `full` do, while `messaging` and `minimal` disable the native surface. Agent
+and provider profile overrides and explicit tool restrictions still apply.
+The sandbox exec-server option does not bypass those tool restrictions. Node-backed
 `remote-exec` on a paired device or cloud worker instead uses its
 placement-owned environment without that experimental flag. A dedicated cloud worker with a completed project preparation keeps the bound workspace and `HOME` paths, so native commands can reuse setup caches. The node exec-server still uses a separate temporary `CODEX_HOME` for each connection. Ending the connection removes that Codex state and preserves the prepared project home.
 

--- a/docs/plugins/sdk-agent-harness/core-ownership.md
+++ b/docs/plugins/sdk-agent-harness/core-ownership.md
@@ -36,8 +36,17 @@ Set `conversationToolPolicySupport: "exact"` only when `runAttempt` enforces eve
 explicit OpenClaw tool-policy layer across native and built-in tools, OpenClaw
 tools, requester and configured MCP servers, apps, delegation, and resumed
 threads. Core passes `params.pluginHarnessToolPolicyRestricted` as the prepared
-decision that the native surface must be isolated. Default tool-profile narrowing
-does not set this flag.
+decision that the native surface must be isolated.
+
+If the native surface exposes several capabilities together, declare their
+canonical OpenClaw tool names in `conversationToolPolicyNativeTools`. Core checks
+every requirement against the effective tool profile and provider profile,
+including agent overrides and `alsoAllow`. A missing capability sets the same
+restriction flag. For example, Codex declares its shell and filesystem tools, so
+`messaging` and `minimal` profiles disable native code mode while `coding` and
+`full` keep it available. This declaration does not relax explicit allowlists,
+denylists, sandbox policy, or runtime caps. Omitting it preserves existing
+profile handling for harnesses that enforce native availability independently.
 
 Harnesses with an independently managed native surface can also declare
 `conversationToolPolicySafeDenyTools` using canonical OpenClaw tool names. Core

--- a/extensions/codex/harness.ts
+++ b/extensions/codex/harness.ts
@@ -9,6 +9,7 @@ import type {
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { resolvePluginConfigObject } from "openclaw/plugin-sdk/plugin-config-runtime";
 import type { PluginRuntime } from "openclaw/plugin-sdk/plugin-runtime";
+import { CODEX_NATIVE_TOOL_REQUIREMENTS } from "./native-tool-policy.js";
 import { readCodexRuntimeModelId } from "./src/app-server/model-runtime.js";
 import { sessionBindingIdentity } from "./src/app-server/session-binding-record.js";
 import type { CodexAppServerBindingStore } from "./src/app-server/session-binding.js";
@@ -116,6 +117,7 @@ export function createCodexAppServerAgentHarness(
     contextEngineHostCapabilities: CODEX_APP_SERVER_CONTEXT_ENGINE_HOST_CAPABILITIES,
     conversationToolPolicySupport: "exact",
     conversationToolPolicySafeDenyTools: CODEX_TOOL_POLICY_SAFE_DENY_NAMES,
+    conversationToolPolicyNativeTools: CODEX_NATIVE_TOOL_REQUIREMENTS,
     deliveryDefaults: {
       visibleReplies: "message_tool",
     },

--- a/extensions/codex/native-tool-policy.ts
+++ b/extensions/codex/native-tool-policy.ts
@@ -1,0 +1,9 @@
+/** Capabilities exposed together by Codex native code mode. */
+export const CODEX_NATIVE_TOOL_REQUIREMENTS = [
+  "exec",
+  "process",
+  "read",
+  "write",
+  "edit",
+  "apply_patch",
+] as const;

--- a/extensions/codex/src/app-server/dynamic-tool-build.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.ts
@@ -29,6 +29,7 @@ import {
   formatStageTimings,
   type StageTimingSummary,
 } from "openclaw/plugin-sdk/time-runtime";
+import { CODEX_NATIVE_TOOL_REQUIREMENTS } from "../../native-tool-policy.js";
 import {
   isCodexRemoteExecPlacementSandbox,
   readCodexPluginConfig,
@@ -76,14 +77,6 @@ type OpenClawSandboxContext = Awaited<ReturnType<typeof resolveSandboxContext>>;
 type CodexDynamicToolBuildEvent = Parameters<
   NonNullable<EmbeddedRunAttemptParams["onAgentEvent"]>
 >[0];
-const CODEX_NATIVE_SANDBOX_TOOL_REQUIREMENTS = [
-  "exec",
-  "process",
-  "read",
-  "write",
-  "edit",
-  "apply_patch",
-] as const;
 const CODEX_MEMORY_FLUSH_DYNAMIC_TOOL_ALLOW = new Set(["read", "write"]);
 const CODEX_DISABLED_NATIVE_SHELL_DYNAMIC_TOOLS = new Set([
   "exec",
@@ -701,9 +694,7 @@ function canCodexAppServerNativeToolSurfaceHonorSandbox(
 function canSandboxToolPolicyExposeCodexNativeToolSurface(sandbox: {
   tools: Parameters<typeof isToolAllowed>[0];
 }): boolean {
-  return CODEX_NATIVE_SANDBOX_TOOL_REQUIREMENTS.every((toolName) =>
-    isToolAllowed(sandbox.tools, toolName),
-  );
+  return CODEX_NATIVE_TOOL_REQUIREMENTS.every((toolName) => isToolAllowed(sandbox.tools, toolName));
 }
 function isCodexMemoryFlushRun(
   params?: Pick<EmbeddedRunAttemptParams, "trigger" | "memoryFlushWritePath">,

--- a/src/agents/harness/selection.test.ts
+++ b/src/agents/harness/selection.test.ts
@@ -80,6 +80,7 @@ import { resolveAgentHarnessDeliveryDefaults } from "./selection-decision.js";
 import {
   agentHarnessBuildsOpenClawTools,
   agentHarnessExposesOpenClawTools,
+  resolveAgentHarnessNativeToolPolicyRestricted,
   resolveAvailableAgentHarnessPolicy,
   resolvePluginHarnessPolicyToolsAllow,
   runAgentHarnessAttempt,
@@ -1881,23 +1882,29 @@ describe("runAgentHarnessAttempt", () => {
     expect(received[0]?.safeDeniedTools).toEqual(["image_generate"]);
   });
 
-  it("isolates collector runs and explicit restrictive policy layers for plugin harnesses", async () => {
+  it("isolates native capabilities restricted by effective profiles or explicit policy", async () => {
     const received: boolean[] = [];
     const runAttempt = vi.fn<AgentHarness["runAttempt"]>(async (attempt) => {
       received.push(attempt.pluginHarnessToolPolicyRestricted === true);
       return createAttemptResult("codex");
     });
-    registerAgentHarness(
-      {
-        id: "codex",
-        label: "Codex",
-        conversationToolPolicySupport: "exact",
-        supports: (ctx) =>
-          ctx.provider === "codex" ? { supported: true, priority: 100 } : { supported: false },
-        runAttempt,
-      },
-      { ownerPluginId: "codex" },
-    );
+    const harness: AgentHarness = {
+      id: "codex",
+      label: "Codex",
+      conversationToolPolicySupport: "exact",
+      conversationToolPolicyNativeTools: [
+        "exec",
+        "process",
+        "read",
+        "write",
+        "edit",
+        "apply_patch",
+      ],
+      supports: (ctx) =>
+        ctx.provider === "codex" ? { supported: true, priority: 100 } : { supported: false },
+      runAttempt,
+    };
+    registerAgentHarness(harness, { ownerPluginId: "codex" });
 
     const cases: Array<{
       config?: OpenClawConfig;
@@ -1908,6 +1915,38 @@ describe("runAgentHarnessAttempt", () => {
     }> = [
       {},
       { config: { tools: { profile: "coding" } } as OpenClawConfig },
+      { config: { tools: { profile: "full" } } },
+      { config: { tools: { profile: "messaging" } } },
+      { config: { tools: { profile: "minimal" } } },
+      {
+        config: {
+          tools: { profile: "coding" },
+          agents: { entries: { worker: { tools: { profile: "messaging" } } } },
+        },
+        agentId: "worker",
+        sessionKey: "agent:worker:session-1",
+      },
+      {
+        config: {
+          tools: { profile: "messaging" },
+          agents: { entries: { worker: { tools: { profile: "coding" } } } },
+        },
+        agentId: "worker",
+        sessionKey: "agent:worker:session-1",
+      },
+      { config: { tools: { profile: "coding", byProvider: { codex: { profile: "messaging" } } } } },
+      {
+        config: {
+          tools: { profile: "full" },
+          agents: {
+            entries: { worker: { tools: { byProvider: { codex: { profile: "minimal" } } } } },
+          },
+        },
+        agentId: "worker",
+        sessionKey: "agent:worker:session-1",
+      },
+      { config: { tools: { profile: "messaging", alsoAllow: ["group:fs", "group:runtime"] } } },
+      { config: { tools: { profile: "minimal", alsoAllow: ["exec"] } } },
       { conversationToolPolicy: {} },
       { conversationToolPolicy: { allow: ["*"] } },
       { swarmCollector: false },
@@ -1926,18 +1965,42 @@ describe("runAgentHarnessAttempt", () => {
         conversationToolPolicy: {},
       },
     ];
+    const nativeRestrictions: boolean[] = [];
 
     for (const testCase of cases) {
-      await runAgentHarnessAttempt({
+      const params = {
         ...createAttemptParams(testCase.config),
         conversationToolPolicy: testCase.conversationToolPolicy,
         agentId: testCase.agentId,
         sessionKey: testCase.sessionKey,
         swarmCollector: testCase.swarmCollector,
-      });
+      };
+      nativeRestrictions.push(resolveAgentHarnessNativeToolPolicyRestricted(params, harness));
+      await runAgentHarnessAttempt(params);
     }
 
-    expect(received).toEqual([false, false, false, false, false, true, true, true, true, true]);
+    expect(received).toEqual([
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      false,
+      true,
+      true,
+      false,
+      true,
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      true,
+      true,
+    ]);
+    expect(nativeRestrictions).toEqual(received);
   });
 
   it.each([

--- a/src/agents/harness/selection.ts
+++ b/src/agents/harness/selection.ts
@@ -32,6 +32,7 @@ import {
 } from "../provider-secret-egress.js";
 import { resolveSandboxRuntimeStatus } from "../sandbox/runtime-status.js";
 import { isKnownCoreToolId } from "../tool-catalog.js";
+import { isToolAllowedByPolicies } from "../tool-policy-match.js";
 import {
   expandToolGroups,
   mergeAlsoAllowPolicy,
@@ -583,6 +584,7 @@ function preparePluginHarnessParams(
     harness.conversationToolPolicySupport === "exact"
       ? harness.conversationToolPolicySafeDenyTools
       : undefined,
+    harness.conversationToolPolicyNativeTools,
   );
   return applyPluginHarnessDenyAllToolPolicy(
     {
@@ -654,6 +656,7 @@ export function resolveAgentHarnessNativeToolPolicyRestricted(
     harness.conversationToolPolicySupport === "exact"
       ? harness.conversationToolPolicySafeDenyTools
       : undefined,
+    harness.conversationToolPolicyNativeTools,
   ).toolPolicyRestricted;
 }
 
@@ -677,6 +680,7 @@ function resolvePluginHarnessDenyAllToolPolicyPrompt(
 export function resolvePluginHarnessToolPolicies(
   params: PluginHarnessToolPolicyContext,
   safeDenyToolNames?: readonly string[],
+  nativeToolNames?: readonly string[],
 ): ResolvedPluginHarnessToolPolicies {
   const messageProvider = params.messageProvider ?? params.messageChannel;
   const sandboxSessionKey = params.sandboxSessionKey ?? params.sessionKey;
@@ -757,6 +761,10 @@ export function resolvePluginHarnessToolPolicies(
   const safeDenyToolNameSet = safeDenyToolNames
     ? new Set(safeDenyToolNames.map(normalizeToolPolicyName))
     : undefined;
+  const profilePolicies = [
+    mergeAlsoAllowPolicy(policy.profilePolicy, policy.profileAlsoAllow),
+    mergeAlsoAllowPolicy(policy.providerProfilePolicy, policy.providerProfileAlsoAllow),
+  ];
   return {
     senderPolicy: policy.senderPolicy,
     senderScopedGroupPolicy: resolveSenderScopedGroupToolPolicy(
@@ -766,8 +774,7 @@ export function resolvePluginHarnessToolPolicies(
     ),
     groupPolicy: policy.groupPolicy,
     runtimePolicies: [
-      mergeAlsoAllowPolicy(policy.profilePolicy, policy.profileAlsoAllow),
-      mergeAlsoAllowPolicy(policy.providerProfilePolicy, policy.providerProfileAlsoAllow),
+      ...profilePolicies,
       policy.globalPolicy,
       policy.globalProviderPolicy,
       policy.agentPolicy,
@@ -782,6 +789,8 @@ export function resolvePluginHarnessToolPolicies(
     // Keep policy-allowed host replacements, without ambient input or approval surfaces.
     toolPolicyRestricted:
       params.swarmCollector === true ||
+      nativeToolNames?.some((toolName) => !isToolAllowedByPolicies(toolName, profilePolicies)) ===
+        true ||
       explicitPolicies.some((explicitPolicy) =>
         toolPolicyRestrictsHarnessNativeTools(explicitPolicy, safeDenyToolNameSet),
       ),

--- a/src/agents/harness/types.ts
+++ b/src/agents/harness/types.ts
@@ -400,6 +400,8 @@ type AgentHarnessRunCapability<
    * against native equivalents. Every other deny remains fail-closed.
    */
   conversationToolPolicySafeDenyTools?: readonly string[];
+  /** OpenClaw tool capabilities an indivisible native surface requires from effective profiles. */
+  conversationToolPolicyNativeTools?: readonly string[];
   supports(ctx: AgentHarnessSupportContext): AgentHarnessSupport;
   /** Synchronous private ownership read; no discovery, auth loading, or native connection setup. */
   resolveSessionRuntimeOwnership?(params: {


### PR DESCRIPTION
Related: #145573

## What Problem This Solves

Fixes an issue where Codex conversations using a limited OpenClaw tool profile could still execute native shell commands. During live update testing, a messaging-profile guest lacked the owner-only update tool but could invoke the CLI through native shell access.

## Why This Change Was Made

The shared harness policy evaluator now checks a harness's declared native capabilities against the effective global, agent, and provider profiles, including `alsoAllow`. Codex uses one shell/filesystem capability list for this declaration and its existing sandbox check. The result flows through the existing native-tool restriction flag; explicit allow/deny rules and runtime restrictions continue to apply.

## User Impact

Messaging and minimal profiles disable Codex's native code surface. Coding, full, and profiles explicitly granted every required capability keep native execution. The existing update tool, `/update`, and Control UI continue to share the same update backend. No new user configuration or storage migration is required.

Native-only node placements and externally owned attached threads preserve their existing execution/ownership boundaries: a restricted turn can be rejected when it cannot run without native tools or would require replacing an externally owned thread. The operator can use a compatible managed conversation/runtime, or intentionally select a profile permitting native execution. The documentation now describes this upgrade consequence; permissions are not widened automatically.

## Evidence

- The profile regression failed before the change.
- 323 focused tests pass across harness selection, Codex dynamic-tool construction, and Codex harness registration.
- Live reproduction used a real model, Gateway, updater, and systemd service on Blacksmith Testbox with a synthetic QA channel: https://github.com/openclaw/openclaw/actions/runs/34673902773.
- Changed-file repository gates passed, including core/core-test and extension/extension-test type checks, lint, formatting, and boundary guards.
- Independent P0–P2 review is clean. Two additional existing native-only rejection tests passed; they prove visible rejection and preservation of the native-owned binding, not live remote-device behavior.
- Live candidate proof **passed** on Blacksmith Testbox `tbx_01m2a4f1drnqavxy06rs1n4p3n`: https://github.com/openclaw/openclaw/actions/runs/34677929725.
- A real model requested `gateway(update.run)` from the default messaging profile. The existing merged-source driver at `6678f6174b336fb5df22b661ab6e6cba0524bc9a` updated to executable candidate `217ba18bfd6a852cd64e2eed577fa923b04660ca`. Systemd PID changed **20252 → 25822**, the running build identity matched the target, and health/readiness returned HTTP 200.
- The owner tool request and native `/update` both respected `commands.restart=false`. After the upgrade, an admitted messaging guest produced no native shell calls and could not start an update. The original conversation retained its session ID and recalled its pre-update marker.
- The final commit only clarifies documentation; executable code is identical to the live-tested candidate. The synthetic QA channel exercised real models, Gateway, updater, and systemd; this is not live Discord or Telegram traffic. Test service, state, Git daemon, and lease were cleaned up.
