### PR TITLE
refactor(gateway): skip ineligible voicewake routing reads

### DIFF
--- a/src/gateway/agent-turn/agent-content-phase.ts
+++ b/src/gateway/agent-turn/agent-content-phase.ts
@@ -168,28 +168,29 @@ export async function prepareAgentContentPhase(params: {
   const to = params.sessionKeyFromTo
     ? ""
     : (params.explicitRecipientSession?.to ?? params.requestedToRaw ?? "");
-  const explicitVoiceWakeSessionTarget = params.requestedSessionKeyRaw
-    ? (() => {
-        const { cfg, canonicalKey } = loadSessionEntry(params.requestedSessionKeyRaw!, {
-          ...(agentId ? { agentId } : {}),
-          clone: false,
-          projection: "list",
-        });
-        const routedAgentId = resolveAgentIdFromSessionKey(canonicalKey, agentId);
-        const compatibilityOwner = tryResolveSessionCompatibilityOwnerAgentId(cfg, canonicalKey);
-        if (!compatibilityOwner || routedAgentId !== compatibilityOwner) {
-          return true;
-        }
-        return canonicalKey !== resolveAgentMainSessionKey({ cfg, agentId: routedAgentId });
-      })()
-    : false;
   const canAutoRouteVoiceWake =
+    Object.hasOwn(params.request, "voiceWakeTrigger") &&
     !normalizeOptionalString(params.request.agentId) &&
-    !explicitVoiceWakeSessionTarget &&
     !params.requestedSessionId &&
     !replyTo &&
     !to;
-  if (Object.hasOwn(params.request, "voiceWakeTrigger") && canAutoRouteVoiceWake) {
+  const explicitVoiceWakeSessionTarget =
+    canAutoRouteVoiceWake && params.requestedSessionKeyRaw
+      ? (() => {
+          const { cfg, canonicalKey } = loadSessionEntry(params.requestedSessionKeyRaw!, {
+            ...(agentId ? { agentId } : {}),
+            clone: false,
+            projection: "list",
+          });
+          const routedAgentId = resolveAgentIdFromSessionKey(canonicalKey, agentId);
+          const compatibilityOwner = tryResolveSessionCompatibilityOwnerAgentId(cfg, canonicalKey);
+          if (!compatibilityOwner || routedAgentId !== compatibilityOwner) {
+            return true;
+          }
+          return canonicalKey !== resolveAgentMainSessionKey({ cfg, agentId: routedAgentId });
+        })()
+      : false;
+  if (canAutoRouteVoiceWake && !explicitVoiceWakeSessionTarget) {
     try {
       const route = resolveVoiceWakeRouteByTrigger({
         trigger: voiceWakeTrigger || undefined,


### PR DESCRIPTION
## What Problem This Solves

Agent turns resolve voicewake session ownership even when explicit agent, session, or delivery settings already make automatic voicewake routing ineligible, or no voicewake trigger is present. That repeats a session lookup whose routing result cannot be used.

## Why This Change Was Made

Evaluate the existing cheap eligibility checks first, then resolve explicit session ownership only when automatic routing can use it. Eligible routing still uses the same owner and target checks; attachment model selection and the independent routed-target lookup are unchanged.

## User Impact

No intended user-visible behavior change. This is a small unused-read cleanup, not a general latency improvement. Explicit routing preferences, trigger fallback, and existing admission and persistence owners remain authoritative.

## Evidence

- Historical focused validation at `f35d894ba5351278ce88a328d8753e6f9057a446`: 13 selected tests passed (two global-image ownership cases and eleven registered-handler cases); 315 were unselected. Formatting and changed-check plan discovery passed. [Validation run](https://github.com/openclaw/openclaw/actions/runs/34675674874). Full changed gates remain for exact-head CI.
- Current author base `c0c0324155503f0b8437289e3b1bd4b99da30a3d`: the production owner and selected tests match the validated source. Three supporting files changed on main. Source review traced the preserved raw key and fresh requested-agent admission check after awaited attachment preparation. The skipped clone:false read was a read-only routing lookup, not a writable-admission refusal gate. This does not claim a new universal database check immediately before run registration.
- Historical R4 measurement at `b6073553b799d81cb4805cc6111e73545d9b5d24` preserved complete registered-handler output/completion parity and demonstrated the skipped reads in separate untimed controls. Timings were mixed: explicit-agent wall time improved about 1.0%/2.5%, while a to-session-key control regressed 3.5%/4.5%; absent-trigger wall time regressed 1.3%/23.0%. Native wall time changed -2.7%/+13.7%, and tree RSS increased about 0.95%/1.78%. All adverse results and earlier failed attempts are retained. This synthetic completion environment is not a real prepared-runtime lease or live end-to-end speedup claim.
- Fresh independent Codex P2 review completed with no actionable findings. Normal commit hooks, own frozen dependency installation, and matching formatting passed with unchanged candidate bytes. No new tests or benchmark rerun are credited here.

Same-repository task branch; maintainers can update it. Release-note context: internal voicewake routing avoids an unused session ownership read without changing routing policy.
