### PR TITLE
improve(gateway): share transcript path checks across history streams

### DIFF
--- a/src/gateway/session-transcript-path.test.ts
+++ b/src/gateway/session-transcript-path.test.ts
@@ -1,0 +1,61 @@
+import path from "node:path";
+import { afterEach, expect, test, vi } from "vitest";
+import * as boundaryPath from "../infra/boundary-path.js";
+import {
+  emitSessionTranscriptUpdate,
+  onInternalSessionTranscriptUpdate,
+} from "../sessions/transcript-events.js";
+import { resolveTranscriptUpdatePathForComparison } from "./session-transcript-path.js";
+
+const unsubscribe: Array<() => void> = [];
+
+afterEach(() => {
+  for (const stop of unsubscribe.splice(0)) {
+    stop();
+  }
+  vi.restoreAllMocks();
+});
+
+test("shares lazy path resolution per event and retries a fallback on the next update", () => {
+  const sessionFile = path.resolve("synthetic-session.jsonl");
+  const resolvedFile = path.resolve("resolved-session.jsonl");
+  const resolvePath = vi
+    .spyOn(boundaryPath, "resolveRealpathOrAbsolute")
+    .mockReturnValueOnce(sessionFile)
+    .mockReturnValueOnce(resolvedFile);
+  const input = { sessionFile };
+
+  emitSessionTranscriptUpdate(input);
+  const stopUnused = onInternalSessionTranscriptUpdate(() => {});
+  emitSessionTranscriptUpdate(input);
+  stopUnused();
+  expect(resolvePath).not.toHaveBeenCalled();
+
+  const first: Array<string | undefined> = [];
+  const second: Array<string | undefined> = [];
+  unsubscribe.push(
+    onInternalSessionTranscriptUpdate((update) => {
+      first.push(resolveTranscriptUpdatePathForComparison(update));
+    }),
+    onInternalSessionTranscriptUpdate((update) => {
+      second.push(resolveTranscriptUpdatePathForComparison(update));
+    }),
+  );
+
+  emitSessionTranscriptUpdate(input);
+  expect(first).toEqual([sessionFile]);
+  expect(second).toEqual(first);
+  expect(resolvePath).toHaveBeenCalledTimes(1);
+
+  emitSessionTranscriptUpdate(input);
+  expect(first).toEqual([sessionFile, resolvedFile]);
+  expect(second).toEqual(first);
+  expect(resolvePath).toHaveBeenCalledTimes(2);
+
+  emitSessionTranscriptUpdate({
+    target: { agentId: "main", sessionId: "synthetic", sessionKey: "agent:main:synthetic" },
+  });
+  expect(first.at(-1)).toBeUndefined();
+  expect(second.at(-1)).toBeUndefined();
+  expect(resolvePath).toHaveBeenCalledTimes(2);
+});

--- a/src/gateway/session-transcript-path.ts
+++ b/src/gateway/session-transcript-path.ts
@@ -2,6 +2,9 @@
 // Normalizes transcript paths for cache, history, and update matching.
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { resolveRealpathOrAbsolute } from "../infra/boundary-path.js";
+import type { InternalSessionTranscriptUpdate } from "../sessions/transcript-events.js";
+
+const transcriptUpdatePaths = new WeakMap<InternalSessionTranscriptUpdate, string | undefined>();
 
 /** Resolve a transcript file path into a stable comparison key. */
 export function resolveTranscriptPathForComparison(value: string | undefined): string | undefined {
@@ -10,4 +13,17 @@ export function resolveTranscriptPathForComparison(value: string | undefined): s
     return undefined;
   }
   return resolveRealpathOrAbsolute(trimmed);
+}
+
+/** Share path resolution across a normalized event's synchronous listener fan-out. */
+export function resolveTranscriptUpdatePathForComparison(
+  update: InternalSessionTranscriptUpdate,
+): string | undefined {
+  if (transcriptUpdatePaths.has(update)) {
+    return transcriptUpdatePaths.get(update);
+  }
+  const resolved = resolveTranscriptPathForComparison(update.sessionFile);
+  // The emitter creates a fresh event per update; later updates retry missing paths.
+  transcriptUpdatePaths.set(update, resolved);
+  return resolved;
 }

--- a/src/gateway/sessions-history-http.test.ts
+++ b/src/gateway/sessions-history-http.test.ts
@@ -13,6 +13,7 @@ import {
   appendAssistantMessageToSessionTranscript,
   appendExactAssistantMessageToSessionTranscript,
 } from "../config/sessions/transcript.js";
+import * as boundaryPath from "../infra/boundary-path.js";
 import { executeSqliteQuerySync, getNodeSqliteKysely } from "../infra/kysely-sync.js";
 import { emitSessionTranscriptUpdate } from "../sessions/transcript-events.js";
 import { persistUserTurnTranscript } from "../sessions/user-turn-transcript.test-support.js";
@@ -1597,20 +1598,42 @@ describe("session history HTTP endpoints", () => {
     },
   );
 
-  test("streams session history updates over SSE", async () => {
+  test("shares transcript path checks across SSE streams and delivers session updates", async () => {
     const { storePath } = await seedSession({ text: "first message" });
 
-    await withFirstMessageHistoryStream(async (stream) => {
-      const appendedId = await appendVisibleAssistantMessage({
-        sessionKey: "agent:main:main",
-        text: "second message",
-        storePath,
-      });
-      await expectMessageEventMatch(stream, {
-        text: "second message",
-        seq: 2,
-        id: appendedId,
-      });
+    await withGatewayHarness(async (harness) => {
+      const streams: SessionHistorySseStream[] = [];
+      try {
+        for (let index = 0; index < 2; index++) {
+          const stream = await openSessionHistorySse(harness.port, "agent:main:main");
+          streams.push(stream);
+          await expectHistoryEventTexts(stream, ["first message"]);
+        }
+        const unrelatedFile = path.join(path.dirname(storePath), "unrelated-session.jsonl");
+        const resolvePath = vi.spyOn(boundaryPath, "resolveRealpathOrAbsolute");
+        try {
+          const update = { sessionFile: unrelatedFile };
+          emitSessionTranscriptUpdate(update);
+          emitSessionTranscriptUpdate(update);
+          expect(resolvePath.mock.calls.filter(([file]) => file === unrelatedFile)).toHaveLength(2);
+        } finally {
+          resolvePath.mockRestore();
+        }
+        const appendedId = await appendVisibleAssistantMessage({
+          sessionKey: "agent:main:main",
+          text: "second message",
+          storePath,
+        });
+        for (const stream of streams) {
+          await expectMessageEventMatch(stream, {
+            text: "second message",
+            seq: 2,
+            id: appendedId,
+          });
+        }
+      } finally {
+        await Promise.all(streams.map((stream) => stream.reader.cancel()));
+      }
     });
   });
 

--- a/src/gateway/sessions-history-http.ts
+++ b/src/gateway/sessions-history-http.ts
@@ -44,7 +44,10 @@ import {
   SessionHistorySseState,
 } from "./session-history-state.js";
 import { createSessionListEntryFilter, resolveSessionSharingTarget } from "./session-sharing.js";
-import { resolveTranscriptPathForComparison } from "./session-transcript-path.js";
+import {
+  resolveTranscriptPathForComparison,
+  resolveTranscriptUpdatePathForComparison,
+} from "./session-transcript-path.js";
 import {
   resolveCanonicalSessionEntryFromStoreKeys,
   resolveGatewaySessionStoreTargetWithStore,
@@ -461,7 +464,7 @@ export async function handleSessionHistoryHttpRequest(
     const updateMatchesIdentity =
       update.target?.sessionId === historyTarget.sessionId &&
       normalizeAgentId(update.target.agentId) === normalizeAgentId(target.agentId);
-    const updatePath = resolveTranscriptPathForComparison(update.sessionFile);
+    const updatePath = resolveTranscriptUpdatePathForComparison(update);
     if (!updateMatchesIdentity && (!updatePath || !transcriptCandidates.has(updatePath))) {
       return;
     }


### PR DESCRIPTION
Related: #145679

## What Problem This Solves

Resolves a problem where transcript updates repeatedly block the Gateway on the same filesystem path lookup when several session-history streams are open.

## Why This Change Was Made

The existing transcript-path owner lazily reuses the comparison path for each normalized event, and the registered SSE handler consumes that prepared fact. Each new emission resolves afresh; post-authorization path checks still observe current filesystem state.

## User Impact

Multiple history streams need fewer synchronous filesystem calls while receiving the same transcript updates. No path lookup occurs without an interested consumer, and no persistent cache or public event field is added.

## Evidence

- Exact-source Windows/Node 24.19 benchmark with the actual emitter and listeners, ten synthetic file-backed events: 1 stream 1.999 -> 1.976 ms; 10 streams 20.005 -> 2.116 ms; 100 streams 144.796 -> 1.390 ms. This measures event fan-out work, not whole-Gateway throughput.
- Existing SSE delivery test extended to two streams, checking one path resolution per event and subsequent delivery of a persisted message to both. Unit coverage checks lazy resolution, reuse of missing-path fallback, retry on the next event, and identity-only events.
- Linux/Node 24.19: three baseline suites passed 134 tests; four candidate suites passed 135. Coverage includes history delivery, revocation, projection state, and the new event-lifetime path contract. The real-SSE regression fails on original production with four path resolutions instead of two.
- Fresh independent review at P2: no findings. Formatting, diff checks, and final-head hosted CI passed. Native merge completed as `9bebec118fa93eb19b2631c52bbca308a403c24d`.
- Combined with the SSE framing change in #145683, all 104 tests in the transcript-path, history HTTP/SSE, and revocation suites passed on main `354943cc2f7e1516d90ae9d2ee7420a12a74bac9`.
