### PR TITLE
fix(tasks): prevent stale flow updates from overwriting current state

### DIFF
--- a/scripts/bench-agent-concurrency-worker.ts
+++ b/scripts/bench-agent-concurrency-worker.ts
@@ -234,13 +234,10 @@ async function configureSpawnRuntime(
         close: () => {},
       },
     });
+    const { createInMemoryTaskFlowRegistryStore } =
+      await import("../src/test-utils/task-registry-store.js");
     flowStore.configureTaskFlowRegistryRuntime({
-      store: {
-        loadSnapshot: () => ({ flows: new Map() }),
-        upsertFlow: () => {},
-        deleteFlow: () => {},
-        close: () => {},
-      },
+      store: createInMemoryTaskFlowRegistryStore(),
     });
     return;
   }

--- a/src/commands/tasks.test.ts
+++ b/src/commands/tasks.test.ts
@@ -964,6 +964,7 @@ describe("tasks commands", () => {
         const deleteFlow = vi.fn();
         configureTaskFlowRegistryRuntime({
           store: {
+            ...createInMemoryTaskFlowRegistryStore(),
             loadSnapshot,
             upsertFlow,
             deleteFlow,

--- a/src/tasks/task-flow-owner-access.test.ts
+++ b/src/tasks/task-flow-owner-access.test.ts
@@ -1,5 +1,6 @@
 // Verifies task-flow owner access checks for parent and child sessions.
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createInMemoryTaskFlowRegistryStore } from "../test-utils/task-registry-store.js";
 import {
   findLatestTaskFlowForOwner,
   getTaskFlowByIdForOwner,
@@ -26,11 +27,7 @@ function createManagedTaskFlow(
 beforeEach(() => {
   resetTaskFlowRegistryForTests({ persist: false });
   configureTaskFlowRegistryRuntime({
-    store: {
-      loadSnapshot: () => ({ flows: new Map() }),
-      upsertFlow: () => {},
-      deleteFlow: () => {},
-    },
+    store: createInMemoryTaskFlowRegistryStore(),
   });
 });
 

--- a/src/tasks/task-flow-registry.concurrency.test.ts
+++ b/src/tasks/task-flow-registry.concurrency.test.ts
@@ -1,0 +1,293 @@
+import { describe, expect, it } from "vitest";
+import { executeSqliteQuerySync, getNodeSqliteKysely } from "../infra/kysely-sync.js";
+import { requireNodeSqlite } from "../infra/node-sqlite.js";
+import type { DB } from "../state/openclaw-state-db.generated.js";
+import {
+  openOpenClawStateDatabase,
+  runOpenClawStateWriteTransaction,
+} from "../state/openclaw-state-db.js";
+import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
+import {
+  createManagedTaskFlow,
+  getTaskFlowById,
+  requestFlowCancel,
+  setFlowWaiting,
+} from "./task-flow-registry.js";
+import type { TaskFlowRegistryObserverEvent } from "./task-flow-registry.store.js";
+import { loadTaskFlowRegistryStateFromSqlite } from "./task-flow-registry.store.sqlite.js";
+import {
+  configureTaskFlowRegistryRuntime,
+  resetTaskFlowRegistryForTests,
+} from "./task-runtime.test-helpers.js";
+
+async function withFlow(run: (flowId: string) => void): Promise<void> {
+  await withOpenClawTestState({ layout: "state-only", prefix: "task-flow-cas-" }, async () => {
+    resetTaskFlowRegistryForTests({ persist: false });
+    try {
+      const flow = createManagedTaskFlow({
+        ownerKey: "agent:main:main",
+        controllerId: "tests/cas",
+        goal: "Canonical flow",
+      });
+      expect(flow).not.toBeNull();
+      if (flow) {
+        run(flow.flowId);
+      }
+    } finally {
+      resetTaskFlowRegistryForTests({ persist: false });
+    }
+  });
+}
+
+describe("task-flow canonical revision updates", () => {
+  it("preserves the existing controller default when updating a restored legacy flow", async () => {
+    await withFlow((flowId) => {
+      const { db } = openOpenClawStateDatabase();
+      executeSqliteQuerySync(
+        db,
+        getNodeSqliteKysely<DB>(db)
+          .updateTable("flow_runs")
+          .set({ controller_id: null })
+          .where("flow_id", "=", flowId),
+      );
+      resetTaskFlowRegistryForTests({ persist: false });
+      expect(getTaskFlowById(flowId)?.controllerId).toBe("core/legacy-restored");
+      expect(setFlowWaiting({ flowId, expectedRevision: 0 })).toMatchObject({
+        applied: true,
+        flow: { revision: 1, controllerId: "core/legacy-restored" },
+      });
+    });
+  });
+
+  it("rejects a stale revision and preserves the latest fields on the next update", async () => {
+    await withFlow((flowId) => {
+      const { DatabaseSync } = requireNodeSqlite();
+      const writer = new DatabaseSync(openOpenClawStateDatabase().path);
+      try {
+        executeSqliteQuerySync(
+          writer,
+          getNodeSqliteKysely<DB>(writer)
+            .updateTable("flow_runs")
+            .set({ revision: 1, goal: "Changed by another connection" })
+            .where("flow_id", "=", flowId),
+        );
+        expect(setFlowWaiting({ flowId, expectedRevision: 0 })).toMatchObject({
+          applied: false,
+          reason: "revision_conflict",
+          current: { revision: 1, goal: "Changed by another connection" },
+        });
+        expect(getTaskFlowById(flowId)).toMatchObject({
+          revision: 1,
+          goal: "Changed by another connection",
+        });
+        expect(setFlowWaiting({ flowId, expectedRevision: 1 })).toMatchObject({
+          applied: true,
+          flow: { revision: 2, status: "waiting", goal: "Changed by another connection" },
+        });
+        expect(loadTaskFlowRegistryStateFromSqlite().flows.get(flowId)).toMatchObject({
+          revision: 2,
+          status: "waiting",
+          goal: "Changed by another connection",
+        });
+      } finally {
+        writer.close();
+      }
+    });
+  });
+
+  it("does not recreate a flow deleted by another connection", async () => {
+    await withFlow((flowId) => {
+      const { DatabaseSync } = requireNodeSqlite();
+      const writer = new DatabaseSync(openOpenClawStateDatabase().path);
+      try {
+        executeSqliteQuerySync(
+          writer,
+          getNodeSqliteKysely<DB>(writer).deleteFrom("flow_runs").where("flow_id", "=", flowId),
+        );
+        expect(setFlowWaiting({ flowId, expectedRevision: 0 })).toEqual({
+          applied: false,
+          reason: "not_found",
+        });
+        expect(getTaskFlowById(flowId)).toBeUndefined();
+        expect(loadTaskFlowRegistryStateFromSqlite().flows.has(flowId)).toBe(false);
+      } finally {
+        writer.close();
+      }
+    });
+  });
+
+  it("does not publish unchanged state when the expected revision is incorrect", async () => {
+    await withFlow((flowId) => {
+      const events: TaskFlowRegistryObserverEvent[] = [];
+      configureTaskFlowRegistryRuntime({ observers: { onEvent: (event) => events.push(event) } });
+      expect(setFlowWaiting({ flowId, expectedRevision: 42 })).toMatchObject({
+        applied: false,
+        reason: "revision_conflict",
+        current: { revision: 0 },
+      });
+      expect(events).toEqual([]);
+    });
+  });
+
+  it.each(["conflict", "missing"] as const)(
+    "rolls back the cached canonical %s observation with its outer transaction",
+    async (observation) => {
+      await withFlow((flowId) => {
+        const before = getTaskFlowById(flowId);
+        const { DatabaseSync } = requireNodeSqlite();
+        const writer = new DatabaseSync(openOpenClawStateDatabase().path);
+        try {
+          const kysely = getNodeSqliteKysely<DB>(writer);
+          if (observation === "conflict") {
+            executeSqliteQuerySync(
+              writer,
+              kysely
+                .updateTable("flow_runs")
+                .set({ revision: 1, goal: "Canonical current state" })
+                .where("flow_id", "=", flowId),
+            );
+          } else {
+            executeSqliteQuerySync(
+              writer,
+              kysely.deleteFrom("flow_runs").where("flow_id", "=", flowId),
+            );
+          }
+          const events: TaskFlowRegistryObserverEvent[] = [];
+          configureTaskFlowRegistryRuntime({
+            observers: { onEvent: (event) => events.push(event) },
+          });
+          const expected = observation === "conflict" ? "revision_conflict" : "not_found";
+          expect(() =>
+            runOpenClawStateWriteTransaction(() => {
+              expect(setFlowWaiting({ flowId, expectedRevision: 0 })).toMatchObject({
+                applied: false,
+                reason: expected,
+              });
+              if (observation === "conflict") {
+                expect(getTaskFlowById(flowId)).toMatchObject({ revision: 1 });
+              } else {
+                expect(getTaskFlowById(flowId)).toBeUndefined();
+              }
+              expect(events).toEqual([]);
+              throw new Error("abort canonical observation");
+            }),
+          ).toThrow("abort canonical observation");
+          expect(getTaskFlowById(flowId)).toEqual(before);
+          expect(events).toEqual([]);
+          expect(setFlowWaiting({ flowId, expectedRevision: 0 })).toMatchObject({
+            applied: false,
+            reason: expected,
+          });
+          expect(events).toHaveLength(1);
+          expect(events[0]?.kind).toBe(observation === "conflict" ? "upserted" : "deleted");
+        } finally {
+          writer.close();
+        }
+      });
+    },
+  );
+
+  it.each(["commit", "rollback", "reentrant observer", "reentrant conflict"] as const)(
+    "preserves staged revisions and observer order for %s",
+    async (outcome) => {
+      await withFlow((flowId) => {
+        const events: TaskFlowRegistryObserverEvent[] = [];
+        let reentrantResult: ReturnType<typeof setFlowWaiting> | undefined;
+        configureTaskFlowRegistryRuntime({
+          observers: {
+            onEvent: (event) => {
+              events.push(event);
+              if (
+                (outcome === "reentrant observer" || outcome === "reentrant conflict") &&
+                event.kind === "upserted" &&
+                event.flow.revision === 1
+              ) {
+                reentrantResult = setFlowWaiting({
+                  flowId,
+                  expectedRevision:
+                    outcome === "reentrant observer"
+                      ? (getTaskFlowById(flowId)?.revision ?? -1)
+                      : 42,
+                  currentStep: "observer update",
+                });
+              }
+            },
+          },
+        });
+        const operation = () =>
+          runOpenClawStateWriteTransaction(() => {
+            expect(setFlowWaiting({ flowId, expectedRevision: 0 })).toMatchObject({
+              applied: true,
+              flow: { revision: 1 },
+            });
+            expect(getTaskFlowById(flowId)?.revision).toBe(1);
+            expect(requestFlowCancel({ flowId, expectedRevision: 1 })).toMatchObject({
+              applied: true,
+              flow: { revision: 2 },
+            });
+            expect(getTaskFlowById(flowId)?.revision).toBe(2);
+            expect(events).toEqual([]);
+            if (outcome === "rollback") {
+              throw new Error("abort outer transaction");
+            }
+          });
+        if (outcome === "rollback") {
+          expect(operation).toThrow("abort outer transaction");
+          expect(events).toEqual([]);
+        } else {
+          operation();
+          expect(events.map((event) => event.kind === "upserted" && event.flow.revision)).toEqual(
+            outcome === "reentrant observer" ? [1, 3] : [1, 2],
+          );
+          if (outcome === "reentrant observer") {
+            expect(reentrantResult).toMatchObject({ applied: true, flow: { revision: 3 } });
+          } else if (outcome === "reentrant conflict") {
+            expect(reentrantResult).toMatchObject({
+              applied: false,
+              reason: "revision_conflict",
+              current: { revision: 2 },
+            });
+          }
+        }
+        const revision = outcome === "rollback" ? 0 : outcome === "reentrant observer" ? 3 : 2;
+        expect(getTaskFlowById(flowId)?.revision).toBe(revision);
+        expect(loadTaskFlowRegistryStateFromSqlite().flows.get(flowId)?.revision).toBe(revision);
+      });
+    },
+  );
+
+  it("discards an inner rollback while allowing the outer transaction to continue", async () => {
+    await withFlow((flowId) => {
+      const events: TaskFlowRegistryObserverEvent[] = [];
+      configureTaskFlowRegistryRuntime({ observers: { onEvent: (event) => events.push(event) } });
+      runOpenClawStateWriteTransaction(() => {
+        expect(setFlowWaiting({ flowId, expectedRevision: 0 })).toMatchObject({ applied: true });
+        expect(() =>
+          runOpenClawStateWriteTransaction(() => {
+            expect(requestFlowCancel({ flowId, expectedRevision: 1 })).toMatchObject({
+              applied: true,
+            });
+            throw new Error("abort savepoint");
+          }),
+        ).toThrow("abort savepoint");
+        expect(getTaskFlowById(flowId)).toMatchObject({ revision: 1, status: "waiting" });
+        expect(getTaskFlowById(flowId)?.cancelRequestedAt).toBeUndefined();
+        expect(
+          setFlowWaiting({ flowId, expectedRevision: 1, currentStep: "continued" }),
+        ).toMatchObject({
+          applied: true,
+          flow: { revision: 2 },
+        });
+        expect(events).toEqual([]);
+      });
+      expect(events.map((event) => event.kind === "upserted" && event.flow.revision)).toEqual([
+        1, 2,
+      ]);
+      expect(loadTaskFlowRegistryStateFromSqlite().flows.get(flowId)).toMatchObject({
+        revision: 2,
+        currentStep: "continued",
+      });
+      expect(getTaskFlowById(flowId)?.cancelRequestedAt).toBeUndefined();
+    });
+  });
+});

--- a/src/tasks/task-flow-registry.store.kernel.ts
+++ b/src/tasks/task-flow-registry.store.kernel.ts
@@ -13,7 +13,12 @@ import {
 } from "../infra/kysely-sync.js";
 import { normalizeSqliteNumber } from "../infra/sqlite-number.js";
 import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-db.generated.js";
-import type { TaskFlowRegistryStoreSnapshot } from "./task-flow-registry.store.types.js";
+import { applyFlowPatch, normalizeRestoredFlowRecord } from "./task-flow-registry.records.js";
+import type {
+  TaskFlowRegistryStoreSnapshot,
+  TaskFlowRegistryUpdate,
+  TaskFlowRegistryUpdateResult,
+} from "./task-flow-registry.store.types.js";
 import {
   parseOptionalTaskFlowSyncMode,
   parseTaskFlowStatus,
@@ -200,6 +205,29 @@ export function readTaskFlowRecord(db: DatabaseSync, flowId: string): TaskFlowRe
     getFlowRegistryKysely(db).selectFrom("flow_runs").selectAll().where("flow_id", "=", flowId),
   );
   return row ? rowToFlowRecord(row) : undefined;
+}
+
+/** The caller holds the SQLite write transaction across the revision check and update. */
+export function updateTaskFlowRecordInDatabase(
+  db: DatabaseSync,
+  params: TaskFlowRegistryUpdate,
+): TaskFlowRegistryUpdateResult {
+  const stored = readTaskFlowRecord(db, params.flowId);
+  if (!stored) {
+    return { applied: false, reason: "not_found" };
+  }
+  const current = normalizeRestoredFlowRecord(stored);
+  if (current.revision !== params.expectedRevision) {
+    return { applied: false, reason: "revision_conflict", current };
+  }
+  let flow: TaskFlowRecord;
+  try {
+    flow = applyFlowPatch(current, params.patch);
+  } catch (error) {
+    return { applied: false, reason: "invalid_patch", error };
+  }
+  upsertTaskFlowRowInDatabase(db, bindTaskFlowRecord(flow));
+  return { applied: true, previous: current, flow };
 }
 
 /** Revalidate the native flow lifecycle before recording its exact execution binding. */

--- a/src/tasks/task-flow-registry.store.sqlite.ts
+++ b/src/tasks/task-flow-registry.store.sqlite.ts
@@ -5,6 +5,10 @@ import {
   executionOwnerBindingFromAdmission,
   type ExecutionOwnerBindingResult,
 } from "../audit/execution-owner-binding.js";
+import {
+  deferSqlitePostCommitPublication,
+  stageSqliteTransactionState,
+} from "../infra/sqlite-post-commit.js";
 import { withExistingOpenClawStateDatabaseReadOnly } from "../state/openclaw-state-db-readonly.js";
 import {
   closeOpenClawStateDatabase,
@@ -17,9 +21,16 @@ import {
   bindTaskFlowRecord,
   deleteTaskFlowRowInDatabase,
   readTaskFlowRegistrySnapshot,
+  updateTaskFlowRecordInDatabase,
   upsertTaskFlowRowInDatabase,
 } from "./task-flow-registry.store.kernel.js";
-import type { TaskFlowRegistryStoreSnapshot } from "./task-flow-registry.store.types.js";
+import type {
+  TaskFlowRegistryObservedUpdate,
+  TaskFlowRegistryStoreSnapshot,
+  TaskFlowRegistryUpdate,
+  TaskFlowRegistryUpdatePublication,
+  TaskFlowRegistryUpdateResult,
+} from "./task-flow-registry.store.types.js";
 import type { TaskFlowRecord } from "./task-flow-registry.types.js";
 
 type FlowRegistryDatabase = {
@@ -68,6 +79,25 @@ export function loadTaskFlowRegistryStateFromSqliteReadOnly(): TaskFlowRegistryS
 export function upsertTaskFlowRegistryRecordToSqlite(flow: TaskFlowRecord) {
   withWriteTransaction(({ db }) => {
     upsertTaskFlowRowInDatabase(db, bindTaskFlowRecord(flow));
+  });
+}
+
+export function updateTaskFlowRegistryRecordInSqlite(
+  params: TaskFlowRegistryUpdate,
+  preparePublication: (update: TaskFlowRegistryObservedUpdate) => TaskFlowRegistryUpdatePublication,
+): TaskFlowRegistryUpdateResult {
+  return runOpenClawStateWriteTransaction(({ db }) => {
+    const result = updateTaskFlowRecordInDatabase(db, params);
+    if (result.applied || result.reason !== "invalid_patch") {
+      const publication = preparePublication(result);
+      stageSqliteTransactionState(db, {
+        stage: publication.stage,
+        rollback: publication.rollback,
+        commit: publication.commit,
+      });
+      deferSqlitePostCommitPublication(db, publication.publish);
+    }
+    return result;
   });
 }
 

--- a/src/tasks/task-flow-registry.store.ts
+++ b/src/tasks/task-flow-registry.store.ts
@@ -3,14 +3,27 @@ import {
   closeTaskFlowRegistryDatabase,
   deleteTaskFlowRegistryRecordFromSqlite,
   loadTaskFlowRegistryStateFromSqlite,
+  updateTaskFlowRegistryRecordInSqlite,
   upsertTaskFlowRegistryRecordToSqlite,
 } from "./task-flow-registry.store.sqlite.js";
-import type { TaskFlowRegistryStoreSnapshot } from "./task-flow-registry.store.types.js";
+import type {
+  TaskFlowRegistryObservedUpdate,
+  TaskFlowRegistryStoreSnapshot,
+  TaskFlowRegistryUpdate,
+  TaskFlowRegistryUpdatePublication,
+  TaskFlowRegistryUpdateResult,
+} from "./task-flow-registry.store.types.js";
 import type { TaskFlowRecord } from "./task-flow-registry.types.js";
 
 type TaskFlowRegistryStore = {
   loadSnapshot: () => TaskFlowRegistryStoreSnapshot;
   upsertFlow: (flow: TaskFlowRecord) => void;
+  updateFlow: (
+    params: TaskFlowRegistryUpdate,
+    preparePublication: (
+      update: TaskFlowRegistryObservedUpdate,
+    ) => TaskFlowRegistryUpdatePublication,
+  ) => TaskFlowRegistryUpdateResult;
   deleteFlow: (flowId: string) => void;
   close?: () => void;
 };
@@ -39,6 +52,7 @@ type TaskFlowRegistryObservers = {
 const defaultFlowRegistryStore: TaskFlowRegistryStore = {
   loadSnapshot: loadTaskFlowRegistryStateFromSqlite,
   upsertFlow: upsertTaskFlowRegistryRecordToSqlite,
+  updateFlow: updateTaskFlowRegistryRecordInSqlite,
   deleteFlow: deleteTaskFlowRegistryRecordFromSqlite,
   close: closeTaskFlowRegistryDatabase,
 };

--- a/src/tasks/task-flow-registry.store.types.ts
+++ b/src/tasks/task-flow-registry.store.types.ts
@@ -1,5 +1,29 @@
 // Defines storage contracts for managed task-flow records.
+import type { FlowRecordPatch } from "./task-flow-registry.records.js";
 import type { TaskFlowRecord } from "./task-flow-registry.types.js";
+
+export type TaskFlowRegistryUpdate = {
+  flowId: string;
+  expectedRevision: number;
+  patch: FlowRecordPatch;
+};
+
+export type TaskFlowRegistryObservedUpdate =
+  | { applied: true; previous: TaskFlowRecord; flow: TaskFlowRecord }
+  | { applied: false; reason: "not_found" }
+  | { applied: false; reason: "revision_conflict"; current: TaskFlowRecord };
+
+export type TaskFlowRegistryUpdateResult =
+  | TaskFlowRegistryObservedUpdate
+  | { applied: false; reason: "invalid_patch"; error: unknown };
+
+/** Stage read-your-writes state separately from committed observer publication. */
+export type TaskFlowRegistryUpdatePublication = {
+  stage: () => void;
+  rollback: () => void;
+  commit: () => void;
+  publish: () => void;
+};
 
 /** Full task-flow registry snapshot used for persistence restore and replacement writes. */
 export type TaskFlowRegistryStoreSnapshot = {

--- a/src/tasks/task-flow-registry.test.ts
+++ b/src/tasks/task-flow-registry.test.ts
@@ -276,6 +276,7 @@ describe("task-flow-registry", () => {
     const deleteFlow = vi.fn();
     configureTaskFlowRegistryRuntime({
       store: {
+        ...createInMemoryTaskFlowRegistryStore(),
         loadSnapshot,
         upsertFlow,
         deleteFlow,
@@ -349,11 +350,8 @@ describe("task-flow-registry", () => {
   });
 
   it("does not throw or mutate memory when flow update persistence fails", () => {
-    let failUpsert = false;
-    const upsertFlow = vi.fn(() => {
-      if (failUpsert) {
-        throw new Error("SQLITE_IOERR: disk I/O error");
-      }
+    const updateFlow = vi.fn(() => {
+      throw new Error("SQLITE_IOERR: disk I/O error");
     });
     configureTaskFlowRegistryRuntime({
       store: {
@@ -361,7 +359,7 @@ describe("task-flow-registry", () => {
         loadSnapshot: () => ({
           flows: new Map(),
         }),
-        upsertFlow,
+        updateFlow,
       },
     });
     const created = createManagedTaskFlow({
@@ -370,7 +368,6 @@ describe("task-flow-registry", () => {
       goal: "Update while persistence fails",
     });
 
-    failUpsert = true;
     const result = setFlowWaiting({
       flowId: created.flowId,
       expectedRevision: created.revision,
@@ -398,6 +395,7 @@ describe("task-flow-registry", () => {
     });
     configureTaskFlowRegistryRuntime({
       store: {
+        ...createInMemoryTaskFlowRegistryStore(),
         loadSnapshot: () => ({
           flows: new Map(),
         }),

--- a/src/tasks/task-flow-registry.ts
+++ b/src/tasks/task-flow-registry.ts
@@ -1,9 +1,9 @@
 // Coordinates managed task-flow creation, updates, ownership, and snapshots.
+import { isDeepStrictEqual } from "node:util";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { formatErrorMessage } from "../infra/errors.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import {
-  applyFlowPatch,
   assertControllerId,
   buildFlowRecord,
   cloneFlowRecord,
@@ -26,6 +26,7 @@ import {
   resetTaskFlowRegistryRuntimeForTests,
   type TaskFlowRegistryObserverEvent,
 } from "./task-flow-registry.store.js";
+import type { TaskFlowRegistryUpdateResult } from "./task-flow-registry.store.types.js";
 import {
   isTerminalTaskFlow,
   type JsonValue,
@@ -247,32 +248,78 @@ export function updateFlowRecordByIdExpectedRevision(params: {
   patch: FlowRecordPatch;
 }): TaskFlowUpdateResult {
   ensureTaskFlowRegistryReady();
-  const current = flows.get(params.flowId);
-  if (!current) {
-    return {
-      applied: false,
-      reason: "not_found",
-    };
-  }
-  if (current.revision !== params.expectedRevision) {
-    return {
-      applied: false,
-      reason: "revision_conflict",
-      current: cloneFlowRecord(current),
-    };
-  }
-  const flow = writeFlowRecord(applyFlowPatch(current, params.patch), current);
-  if (!flow) {
+  const cached = flows.get(params.flowId);
+  let result: TaskFlowRegistryUpdateResult;
+  try {
+    result = getTaskFlowRegistryStore().updateFlow(params, (observed) => {
+      const current = observed.applied
+        ? observed.flow
+        : observed.reason === "revision_conflict"
+          ? observed.current
+          : undefined;
+      const canonical = current ? cloneFlowRecord(current) : undefined;
+      const previous = observed.applied ? observed.previous : cached;
+      const changed =
+        observed.applied ||
+        !isDeepStrictEqual(cached ? normalizeRestoredFlowRecord(cached) : undefined, canonical);
+      const next = changed ? canonical : cached;
+      let committed: TaskFlowRecord | undefined;
+      return {
+        stage: () => {
+          if (next) {
+            flows.set(params.flowId, next);
+          } else {
+            flows.delete(params.flowId);
+          }
+        },
+        rollback: () => {
+          if (cached) {
+            flows.set(params.flowId, cached);
+          } else {
+            flows.delete(params.flowId);
+          }
+        },
+        commit: () => {
+          // Capture the final staged entry before any observer can reenter this owner.
+          committed = flows.get(params.flowId);
+        },
+        publish: () => {
+          if (!changed || flows.get(params.flowId) !== committed) {
+            return;
+          }
+          if (next) {
+            emitFlowRegistryObserverEvent(() => ({
+              kind: "upserted",
+              flow: cloneFlowRecord(next),
+              ...(previous ? { previous: cloneFlowRecord(previous) } : {}),
+            }));
+          } else if (previous) {
+            emitFlowRegistryObserverEvent(() => ({
+              kind: "deleted",
+              flowId: params.flowId,
+              previous: cloneFlowRecord(previous),
+            }));
+          }
+        },
+      };
+    });
+  } catch (error) {
+    log.warn("Failed to persist task-flow registry update", { flowId: params.flowId, error });
     return {
       applied: false,
       reason: "persist_failed",
-      current: cloneFlowRecord(current),
+      ...(cached ? { current: cloneFlowRecord(cached) } : {}),
     };
   }
-  return {
-    applied: true,
-    flow,
-  };
+  if (result.applied) {
+    return { applied: true, flow: cloneFlowRecord(result.flow) };
+  }
+  if (result.reason === "invalid_patch") {
+    throw result.error;
+  }
+  return result.reason === "revision_conflict"
+    ? { ...result, current: cloneFlowRecord(result.current) }
+    : result;
 }
 
 export function setFlowWaiting(params: {

--- a/src/test-utils/task-registry-store.ts
+++ b/src/test-utils/task-registry-store.ts
@@ -1,5 +1,12 @@
+import {
+  applyFlowPatch,
+  normalizeRestoredFlowRecord,
+} from "../tasks/task-flow-registry.records.js";
 import type { getTaskFlowRegistryStore } from "../tasks/task-flow-registry.store.js";
-import type { TaskFlowRegistryStoreSnapshot } from "../tasks/task-flow-registry.store.types.js";
+import type {
+  TaskFlowRegistryObservedUpdate,
+  TaskFlowRegistryStoreSnapshot,
+} from "../tasks/task-flow-registry.store.types.js";
 import type { TaskRegistryStore, TaskRegistryStoreSnapshot } from "../tasks/task-registry.store.js";
 
 type TaskFlowRegistryStore = ReturnType<typeof getTaskFlowRegistryStore>;
@@ -38,6 +45,35 @@ export function createInMemoryTaskFlowRegistryStore(
     loadSnapshot: () => structuredClone(state),
     upsertFlow: (flow) => {
       state.flows.set(flow.flowId, structuredClone(flow));
+    },
+    updateFlow: (params, preparePublication) => {
+      const publish = (result: TaskFlowRegistryObservedUpdate) => {
+        const publication = preparePublication(result);
+        publication.stage();
+        publication.commit();
+        publication.publish();
+        return result;
+      };
+      const stored = state.flows.get(params.flowId);
+      if (!stored) {
+        return publish({ applied: false, reason: "not_found" });
+      }
+      const current = normalizeRestoredFlowRecord(stored);
+      if (current.revision !== params.expectedRevision) {
+        return publish({
+          applied: false,
+          reason: "revision_conflict",
+          current: structuredClone(current),
+        });
+      }
+      let flow;
+      try {
+        flow = applyFlowPatch(current, params.patch);
+      } catch (error) {
+        return { applied: false, reason: "invalid_patch", error };
+      }
+      state.flows.set(flow.flowId, structuredClone(flow));
+      return publish({ applied: true, previous: structuredClone(current), flow });
     },
     deleteFlow: (flowId) => {
       state.flows.delete(flowId);

--- a/test/helpers/acp-manager-task-state.ts
+++ b/test/helpers/acp-manager-task-state.ts
@@ -8,6 +8,7 @@ import {
 import { withTestDir } from "../../src/test-helpers/temp-dir.js";
 import { captureEnv, setTestEnvValue } from "../../src/test-utils/env.js";
 import { installInMemoryTaskRegistryRuntime } from "../../src/test-utils/task-registry-runtime.js";
+import { createInMemoryTaskFlowRegistryStore } from "../../src/test-utils/task-registry-store.js";
 
 // Shared ACP manager task registry setup for tests.
 
@@ -27,14 +28,7 @@ export async function withAcpManagerTaskStateDir(
     resetAcpManagerTaskStateForTests();
     installInMemoryTaskRegistryRuntime();
     configureTaskFlowRegistryRuntime({
-      store: {
-        loadSnapshot: () => ({
-          flows: new Map(),
-        }),
-        upsertFlow: () => {},
-        deleteFlow: () => {},
-        close: () => {},
-      },
+      store: createInMemoryTaskFlowRegistryStore(),
     });
     try {
       await run(root);


### PR DESCRIPTION
Related: #144592
Builds on #145652

## What Problem This Solves

Fixes an issue where task-flow controllers could overwrite newer progress or recreate a deleted flow when their in-memory snapshot lagged behind SQLite. Updates inside a larger transaction could also notify observers even when that transaction later rolled back.

## Why This Change Was Made

The existing revision-based update now rereads the canonical flow, compares its revision, and applies the patch within one SQLite write transaction. Callers receive the actual persisted conflict or updated record, and canonical conflict or missing results also reconcile the cached view. The existing transaction owner stages the flow cache for nested read-your-writes, restores it on rollback, and publishes observer events after the outer commit. Queued notifications stop when synchronous observer reentry replaces that committed state.

This is a focused prerequisite for the accepted SQLite worker migration. It preserves the synchronous API, existing patch-validation errors, legacy flow normalization, and current SQLite schema.

## User Impact

Stale flow updates return a revision conflict with current state, and updates to deleted flows return not found. Rolled-back updates no longer appear as committed progress.

## Evidence

- Real SQLite coverage exercises another connection updating or deleting the flow, consecutive nested updates, outer commit/rollback, inner savepoint rollback, and legacy controller normalization.
- 170 focused flow, executor, maintenance, audit, pure-kernel, ACP manager, owner-access, and task-command tests passed, including 11 real SQLite concurrency/rollback cases.
- Five behavior regressions failed on the original implementation; the legacy compatibility case passed in both versions. The observer-reentry case separately failed before its commit-hook repair.
- The full changed gate and independent P2 review passed on the final source.
- The existing in-memory concurrency benchmark settled both synthetic tasks with zero SQLite rows/files and no remaining runtime work. Test and benchmark store fixtures use the existing in-memory store implementation.
