### PR TITLE
perf(slack): skip unused global table and chart scans

### DIFF
--- a/extensions/slack/src/blocks-render.ts
+++ b/extensions/slack/src/blocks-render.ts
@@ -233,15 +233,20 @@ function readSlackOpenClawBlockIndex(blockId: string, prefix: string): number | 
 }
 
 /** Resolve existing Block Kit indexes and native-data budgets before appending portable blocks. */
-export function resolveSlackBlockOffsets(blocks?: readonly SlackBlock[]): SlackBlockRenderOptions {
+export function resolveSlackBlockOffsets(
+  blocks?: readonly SlackBlock[],
+  mode: "all" | "controls" = "all",
+): SlackBlockRenderOptions {
   let buttonIndexOffset = 0;
   const dataTableCellCharacterCountOffset =
-    countSlackDataTableBlocksCellCharacters(blocks) ??
-    SLACK_DATA_TABLE_AGGREGATE_CELL_CHARACTERS_MAX + 1;
+    mode === "all"
+      ? (countSlackDataTableBlocksCellCharacters(blocks) ??
+        SLACK_DATA_TABLE_AGGREGATE_CELL_CHARACTERS_MAX + 1)
+      : 0;
   let dataVisualizationCountOffset = 0;
   let selectIndexOffset = 0;
   for (const block of blocks ?? []) {
-    if (hasSlackDataVisualizationBlock([block])) {
+    if (mode === "all" && hasSlackDataVisualizationBlock([block])) {
       dataVisualizationCountOffset += 1;
     }
     const blockId = readSlackBlockId(block);

--- a/extensions/slack/src/outbound-payload.test.ts
+++ b/extensions/slack/src/outbound-payload.test.ts
@@ -864,27 +864,89 @@ describe("slackOutbound sendPayload", () => {
     expect(result.messageId).toBe("sl-controls");
   });
 
-  it("rolls over authored blocks instead of dropping over-limit content", async () => {
-    const { run, sendMock } = createHarness({
-      payload: {
-        channelData: {
-          slack: { blocks: Array.from({ length: 50 }, () => ({ type: "divider" })) },
+  it.each(["blocks", "table", "chart"] as const)(
+    "rolls over the %s budget while keeping control indexes reply-wide",
+    async (budget) => {
+      const rawData =
+        budget === "blocks"
+          ? Array.from({ length: 48 }, () => ({ type: "divider" }))
+          : budget === "table"
+            ? [
+                {
+                  type: "data_table",
+                  caption: "Existing table",
+                  rows: [
+                    [{ type: "raw_text", text: "N" }],
+                    [{ type: "raw_text", text: "x".repeat(9_999) }],
+                  ],
+                },
+              ]
+            : Array.from({ length: 2 }, () => ({
+                type: "data_visualization",
+                title: "Existing chart",
+                chart: { type: "pie", segments: [{ label: "Open", value: 5 }] },
+              }));
+      const rawBlocks = [
+        ...rawData,
+        { type: "divider", block_id: "openclaw_reply_buttons_7suffix" },
+        { type: "divider", block_id: "openclaw_reply_select_11" },
+      ];
+      const { run, sendMock, to } = createHarness({
+        payload: {
+          channelData: {
+            slack: { blocks: rawBlocks },
+          },
+          presentation: {
+            blocks: [
+              budget === "chart"
+                ? createPipelineChart()
+                : { type: "table", caption: "Accounts", headers: ["Account"], rows: [["Acme"]] },
+              valueButtons("Stage", "stage"),
+              { type: "select", options: [{ label: "Production", value: "production" }] },
+            ],
+          },
+          interactive: {
+            blocks: [
+              valueButtons("Approve", "approve"),
+              { type: "select", options: [{ label: "Recent", value: "recent" }] },
+            ],
+          },
         },
-        presentation: {
-          blocks: [{ type: "table", caption: "Accounts", headers: ["Account"], rows: [["Acme"]] }],
-        },
-        interactive: interactiveButtons("Allow", "pluginbind:approval-123:o"),
-      },
-    });
+        sendResults: [{ messageId: "sl-first" }, { messageId: "sl-second" }],
+      });
 
-    await expect(run()).resolves.toMatchObject({ messageId: "sl-1" });
-    expect(sendMock).toHaveBeenCalledTimes(2);
-    expect(sentSlackMessage(sendMock, 0).options.blocks).toHaveLength(50);
-    expect(sentSlackMessage(sendMock, 1).options.blocks?.map((block) => block.type)).toEqual([
-      "data_table",
-      "actions",
-    ]);
-  });
+      await expect(run()).resolves.toMatchObject({ channel: "slack", messageId: "sl-second" });
+      expect(sendMock).toHaveBeenCalledTimes(2);
+      expect(sentSlackMessage(sendMock, 0)).toMatchObject({ to, options: { blocks: rawBlocks } });
+      const second = sentSlackMessage(sendMock, 1);
+      expect(second.to).toBe(to);
+      expect(second.options.blocks?.map((block) => block.type)).toEqual([
+        budget === "chart" ? "data_visualization" : "data_table",
+        "actions",
+        "actions",
+        "actions",
+        "actions",
+      ]);
+      expect(second.options.blocks?.slice(1)).toMatchObject([
+        {
+          block_id: "openclaw_reply_buttons_8",
+          elements: [{ action_id: "openclaw:reply_button:8:1" }],
+        },
+        {
+          block_id: "openclaw_reply_select_12",
+          elements: [{ action_id: "openclaw:reply_select:12" }],
+        },
+        {
+          block_id: "openclaw_reply_buttons_9",
+          elements: [{ action_id: "openclaw:reply_button:9:1" }],
+        },
+        {
+          block_id: "openclaw_reply_select_13",
+          elements: [{ action_id: "openclaw:reply_select:13" }],
+        },
+      ]);
+    },
+  );
 
   it("offsets presentation controls against native Slack blocks before standalone interactive controls", async () => {
     const { run, sendMock, to } = createHarness({

--- a/extensions/slack/src/reply-blocks.ts
+++ b/extensions/slack/src/reply-blocks.ts
@@ -380,7 +380,7 @@ function resolvePresentationRenderOptions(
   segments: SlackReplyBlockSegment[],
   mode: "current" | "new-message",
 ): SlackBlockRenderOptions {
-  const allOffsets = resolveSlackBlockOffsets(readAllNativeBlocks(segments));
+  const allOffsets = resolveSlackBlockOffsets(readAllNativeBlocks(segments), "controls");
   const messageOffsets =
     mode === "current" ? resolveSlackBlockOffsets(readLastBlockSegment(segments)) : {};
   // Control ids span the logical reply, while chart/table limits reset for
@@ -564,10 +564,12 @@ export function resolveSlackReplyBlockResolution(
   }
   const renderedPresentationBlocks = readAllNativeBlocks(segments).slice(presentationBlockOffset);
 
-  const interactiveBlocks = buildSlackInteractiveBlocks(payload.interactive, {
-    ...resolveSlackBlockOffsets(readAllNativeBlocks(segments)),
-    questionOptionIndices,
-  });
+  const interactiveBlocks = payload.interactive
+    ? buildSlackInteractiveBlocks(payload.interactive, {
+        ...resolveSlackBlockOffsets(readAllNativeBlocks(segments)),
+        questionOptionIndices,
+      })
+    : [];
   // Companions are independent of the presentation's alternative text.
   // Preserve the authored continuation when no native presentation survives.
   if (


### PR DESCRIPTION
Closes #145700

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Slack reply preparation repeats table and chart accounting while assigning reply-wide button and select indexes. It also calculates unused offsets when no legacy interactive companion is present.

## Why This Change Was Made

The existing offset resolver now supports an internal controls-only mode for the reply-wide pass. Current-message and present legacy-companion accounting keep the full mode, and absent companions skip the unused calculation.

## User Impact

Slack output stays unchanged: control indexes span the reply, table/chart budgets reset per message, and existing block-ID parsing, mutable aliases, malformed-table handling, companion mirroring, fallback text and send order are preserved. The change adds seven net production lines and 62 net test lines.

## Evidence

Against baseline `0cccc6d68e58ccd5030cd09931c1753bca924c7b`, the same 129 tests across five files passed before and after. The full selected gate passed, and the source-bound P2 review found no actionable issues.

Seven synthetic cases through the actual outbound adapter retained identical complete serialized outputs and hashes, covering plain text, table/control replies, table and chart rollover with companions, malformed tables, and mutated block IDs. For the table/control case without a companion, table parses fell 26→13, table-budget scans 25→12, and chart checks 219→102. These are function invocation counts only; no timing, allocation-byte, RSS or retained-memory improvement is claimed.

The adapter proof uses injected synthetic senders, supplemented by existing send-path mock-client coverage; it is not a live Slack send. No extra build, profile or update proof was selected: package, public SDK, loading/startup, updater and Doctor contracts are unchanged, and the selected extension type/import/lint and owner checks passed.
