### PR TITLE
fix: preserve streamed Markdown disclosure contents

### DIFF
--- a/ui/src/components/markdown-details.test.ts
+++ b/ui/src/components/markdown-details.test.ts
@@ -5,6 +5,12 @@ function htmlFragment(html: string): DocumentFragment {
   return document.createRange().createContextualFragment(html);
 }
 
+const rawHtmlStreamingContexts = [
+  ["comment", "<!--\n</details>\n-->"],
+  ["pre", "<pre>\n</details>\n</pre>"],
+  ["lowercase declaration", "<!doctype\n</details>\n>"],
+] as const;
+
 describe("model-authored details blocks", () => {
   it("renders block-level details with nested markdown", () => {
     const html = toSanitizedMarkdownHtml(
@@ -155,6 +161,7 @@ describe("model-authored details blocks", () => {
 
   it.each([
     ["<details>\n<summary>Still arriving", ["Still arriving"], null],
+    ["<details>\n<summary>Literal\n", [], "<summary>Literal"],
     ["<details><summary>Outer</summary>\n<details><summary>Inner", ["Outer", "Inner"], null],
     ["<summary>Orphan", [], "<summary>Orphan"],
     ["<details><summary>First</summary>\n<summary>Second", ["First"], "<summary>Second"],
@@ -329,14 +336,13 @@ describe("multi-token details shapes", () => {
   });
 
   it.each([
-    ["comment", "<!--\n</details>\n-->"],
-    ["pre", "<pre>\n</details>\n</pre>"],
+    ...rawHtmlStreamingContexts,
     ["script", "<script>\n</details>\n</script>"],
     ["style", "<style>\n</details>\n</style>"],
     ["processing instruction", "<?pi\n</details>\n?>"],
     ["declaration", "<!DOCTYPE\n</details>\n>"],
     ["CDATA", "<![CDATA[\n</details>\n]]>"],
-  ])("keeps closer-shaped text inside an embedded raw HTML %s literal", (_name, raw) => {
+  ] as const)("keeps closer-shaped text inside an embedded raw HTML %s literal", (_name, raw) => {
     const html = toSanitizedMarkdownHtml(
       `<details>\n<summary>X</summary>\n\n<div>\n${raw}\n</div>\n</details>\n\nFollowing`,
     );
@@ -347,6 +353,114 @@ describe("multi-token details shapes", () => {
     expect(details?.textContent).not.toContain("Following");
     expect(fragment.lastElementChild?.textContent).toBe("Following");
   });
+
+  it.each(rawHtmlStreamingContexts)(
+    "keeps body after a raw %s inside streaming details",
+    (_name, raw) => {
+      const pending = `<details>\n<summary>X</summary>\n\n<div>\n${raw}\n</div>\n\nStill inside`;
+      const completed = `${pending}\n</details>\n\nFollowing`;
+      for (const source of [pending, completed]) {
+        for (const html of [
+          toSanitizedMarkdownHtml(source),
+          toStreamingMarkdownParts(source).join(""),
+        ]) {
+          const fragment = htmlFragment(html);
+          const details = fragment.querySelector("details");
+          expect(details?.textContent).toContain("</details>");
+          expect(details?.textContent).toContain("Still inside");
+          expect(details?.textContent).not.toContain("Following");
+          if (source === completed) {
+            expect(fragment.lastElementChild?.textContent).toBe("Following");
+          }
+        }
+      }
+    },
+  );
+
+  it.each(
+    ["<!--", "<pre>"].flatMap((opener) =>
+      [
+        ["blockquote", `> ${opener}\n> **literal`],
+        ["list continuation", `- item\n\n  ${opener}\n  **literal`],
+      ].flatMap(([container, raw]) =>
+        [
+          { suffix: "**outside", selector: "strong", text: "outside" },
+          {
+            suffix: "<details>\n<summary>Next",
+            selector: "details:last-child summary",
+            text: "Next",
+          },
+        ].map(({ suffix, selector, text }) => ({ opener, container, raw, suffix, selector, text })),
+      ),
+    ),
+  )(
+    "resumes $text after an unfinished $opener leaves its $container",
+    ({ raw, suffix, selector, text }) => {
+      const source = `<details>\n<summary>X</summary>\n\n${raw}\n\n</details>\n\n${suffix}`;
+      const fragment = htmlFragment(toStreamingMarkdownParts(source).join(""));
+      expect(fragment.querySelector("details")?.textContent).toContain("**literal");
+      expect(fragment.querySelector("details")?.textContent).not.toContain(text);
+      expect(fragment.querySelector(selector)?.textContent).toBe(text);
+    },
+  );
+
+  it.each(rawHtmlStreamingContexts)(
+    "keeps a raw %s code sample from owning a later summary",
+    (_name, raw) => {
+      const opener = raw.slice(0, raw.indexOf("\n"));
+      const source = `    ${opener}\n\n<details>\n<summary>Actual`;
+      const fragment = htmlFragment(toStreamingMarkdownParts(source).join(""));
+      expect(fragment.querySelector("code")?.textContent).toBe(`${opener}\n`);
+      expect(fragment.querySelector("details summary")?.textContent).toBe("Actual");
+    },
+  );
+
+  it.each(
+    rawHtmlStreamingContexts.flatMap(([context, raw]) =>
+      [
+        { syntax: "emphasis", delimiter: "**", tag: "strong" },
+        { syntax: "inline code", delimiter: "`", tag: "code" },
+      ].flatMap(({ syntax, delimiter, tag }) =>
+        [false, true].map((closed) => ({ context, raw, syntax, delimiter, tag, closed })),
+      ),
+    ),
+  )(
+    "keeps $syntax literal in a $context block (closed=$closed)",
+    ({ raw, delimiter, tag, closed }) => {
+      const rawBlock = raw.replace("</details>", `${delimiter}literal`);
+      const literal = closed ? rawBlock : rawBlock.slice(0, rawBlock.lastIndexOf("\n"));
+      const source = `<details>\n<summary>X</summary>\n\n${literal}${closed ? `\n${delimiter}outside` : ""}`;
+      const details = htmlFragment(toStreamingMarkdownParts(source).join("")).querySelector(
+        "details",
+      );
+      expect(details?.textContent).toContain(literal);
+      if (closed) {
+        expect(details?.querySelector(tag)?.textContent).toBe("outside");
+      } else {
+        const staticDetails = htmlFragment(toSanitizedMarkdownHtml(source)).querySelector(
+          "details",
+        );
+        expect(details?.textContent).toBe(staticDetails?.textContent);
+      }
+    },
+  );
+
+  it.each(rawHtmlStreamingContexts)(
+    "keeps unfinished summaries in a raw %s literal while streaming",
+    (_name, raw) => {
+      const opener = raw.slice(0, raw.indexOf("\n"));
+      const source = `<details>\n${opener}\n<summary>literal`;
+      for (const html of [
+        toSanitizedMarkdownHtml(source),
+        toStreamingMarkdownParts(source).join(""),
+      ]) {
+        const details = htmlFragment(html).querySelector("details");
+        expect(details?.querySelector("summary")).toBeNull();
+        expect(details?.textContent).toContain("<summary>literal");
+        expect(details?.textContent).not.toContain("</summary>");
+      }
+    },
+  );
 
   it("renders details when body text starts without a summary", () => {
     const html = toSanitizedMarkdownHtml("<details>\nfirst line\n\nsecond paragraph\n</details>");

--- a/ui/src/components/markdown-details.ts
+++ b/ui/src/components/markdown-details.ts
@@ -22,6 +22,8 @@ type MarkdownRawHtmlContext =
   | "cdata"
   | { element: string };
 
+type MarkdownRawHtmlState = { context: MarkdownRawHtmlContext | null };
+
 type MarkdownDisclosureTag = {
   end: number;
   raw: string;
@@ -237,7 +239,7 @@ function openingRawHtmlContext(line: string): MarkdownRawHtmlContext | null {
   if (trimmed.startsWith("<![CDATA[")) {
     return "cdata";
   }
-  if (/^<![A-Z]/.test(trimmed)) {
+  if (/^<![A-Za-z]/.test(trimmed)) {
     return "declaration";
   }
   const element = /^<(pre|script|style|textarea)(?=[\s>]|$)/i.exec(trimmed)?.[1];
@@ -258,6 +260,59 @@ function closesRawHtmlContext(context: MarkdownRawHtmlContext, line: string): bo
     return line.includes(">");
   }
   return line.includes("]]>");
+}
+
+export function consumeMarkdownRawHtmlLine(
+  line: string,
+  state: MarkdownRawHtmlState,
+  codeSpans: ReadonlyArray<readonly [number, number]> = [],
+  lineOffset = 0,
+): boolean {
+  const context = state.context ?? openingRawHtmlContext(line);
+  if (!context) {
+    return false;
+  }
+  const start = line.length - line.trimStart().length;
+  if (!state.context && isInsideMarkdownCode(lineOffset + start, codeSpans)) {
+    return false;
+  }
+  state.context = closesRawHtmlContext(context, line) ? null : context;
+  return true;
+}
+
+/** Raw ownership ends at the native HTML token, including its enclosing container. */
+export function findMarkdownRawHtmlRanges(
+  markdown: string,
+  markdownParser: MarkdownIt,
+): Array<[number, number]> {
+  const tokens: DetailsToken[] = [];
+  markdownParser.block.parse(markdown, markdownParser, {}, tokens);
+  const lineOffsets = [0];
+  for (const match of markdown.matchAll(/\n/g)) {
+    lineOffsets.push(match.index + 1);
+  }
+  const ranges: Array<[number, number]> = [];
+  for (const token of tokens) {
+    if (token.type !== "html_block" || !token.map) {
+      continue;
+    }
+    const rawHtml: MarkdownRawHtmlState = { context: null };
+    const lines = token.content.split("\n");
+    for (let line = token.map[0]; line < token.map[1]; line += 1) {
+      if (!consumeMarkdownRawHtmlLine(lines[line - token.map[0]] ?? "", rawHtml)) {
+        continue;
+      }
+      const start = lineOffsets[line] ?? markdown.length;
+      const end = lineOffsets[line + 1] ?? markdown.length;
+      const previous = ranges.at(-1);
+      if (previous?.[1] === start) {
+        previous[1] = end;
+      } else {
+        ranges.push([start, end]);
+      }
+    }
+  }
+  return ranges;
 }
 
 export function installMarkdownDetails(markdownParser: MarkdownIt): void {
@@ -315,7 +370,7 @@ export function installMarkdownDetails(markdownParser: MarkdownIt): void {
       };
       const lines = token.content.split("\n");
       let pendingHtml = "";
-      let rawHtmlContext: MarkdownRawHtmlContext | null = null;
+      const rawHtml: MarkdownRawHtmlState = { context: null };
       const flushHtml = () => {
         if (!pendingHtml) {
           return;
@@ -327,19 +382,8 @@ export function installMarkdownDetails(markdownParser: MarkdownIt): void {
       };
       for (const [lineOffset, line] of lines.entries()) {
         const hasLineBreak = lineOffset < lines.length - 1;
-        if (rawHtmlContext) {
+        if (consumeMarkdownRawHtmlLine(line, rawHtml)) {
           pendingHtml += line + (hasLineBreak ? "\n" : "");
-          if (closesRawHtmlContext(rawHtmlContext, line)) {
-            rawHtmlContext = null;
-          }
-          continue;
-        }
-        const openingContext = openingRawHtmlContext(line);
-        if (openingContext) {
-          pendingHtml += line + (hasLineBreak ? "\n" : "");
-          if (!closesRawHtmlContext(openingContext, line)) {
-            rawHtmlContext = openingContext;
-          }
           continue;
         }
         if (!scanMarkdownDisclosureLine(line)) {

--- a/ui/src/components/markdown-streaming.test.ts
+++ b/ui/src/components/markdown-streaming.test.ts
@@ -31,11 +31,28 @@ describe("toStreamingMarkdownParts", () => {
     }
   });
 
+  it("does not reparse a literal container line on each append", () => {
+    const prefixes = Array.from(
+      { length: 48 },
+      (_, index) => `<details>\n> <!--\n> ${"literal ".repeat((index + 1) * 30)}`,
+    );
+    const findRawRanges = vi.spyOn(markdownDetails, "findMarkdownRawHtmlRanges");
+    try {
+      const fullHtml = prefixes.map((value) => toStreamingMarkdownParts(value).join(""));
+      expect(findRawRanges).toHaveBeenCalledTimes(prefixes.length);
+      findRawRanges.mockClear();
+
+      const incrementalHtml = prefixes.map((value) =>
+        toStreamingMarkdownParts(value, {}, "literal-line-scan-regression").join(""),
+      );
+      expect(incrementalHtml).toEqual(fullHtml);
+      expect(findRawRanges).toHaveBeenCalledTimes(1);
+    } finally {
+      findRawRanges.mockRestore();
+    }
+  });
+
   it("keeps chunked-prefix splits identical to full splits", () => {
-    const splitIncrementally = splitStableStreamingMarkdown as (
-      markdown: string,
-      streamKey: string,
-    ) => ReturnType<typeof splitStableStreamingMarkdown>;
     const cases = [
       [
         "## Result",
@@ -57,13 +74,36 @@ describe("toStreamingMarkdownParts", () => {
       "`` multiline\n<details> remains code\n``\n\n<details>\n<summary>Real</summary>",
       "- item\n\n    <details>\n    <summary>Logs</summary>\n\n    still inside",
       "1. item\n\n    <details>\n    <summary>Logs</summary>\n\n    still inside",
+      ...[
+        "> <!--\n> **literal",
+        "- item\n\n  <pre>\n  **literal\n\n  **still literal",
+        "> - item\n>\n>   <!--\n>   **literal",
+        "10. item\n\n    <pre>\n    **literal",
+        "-\t<pre>\n\t**literal",
+      ].map(
+        (raw) =>
+          `<details>\n<summary>X</summary>\n\n${raw}\n\n</details>\n\n**outside\n\n<details>\n<summary>Next`,
+      ),
+      "<details>\r\n> <!--\r\n> **literal\r\n\r\n</details>\r\n\r\n**outside",
+      ...["<!--\n</details>\n-->", "<pre>\n</details>\n</pre>", "<!doctype\n</details>\n>"].flatMap(
+        (raw) =>
+          [
+            `<details>\n<summary>X</summary>\n\n<div>\n${raw}\n</div>\n\nStill inside\n</details>\n\nFollowing`,
+            `${raw.replace("</details>", "<details>")}\n\n<details><summary>Next</summary>body`,
+          ].concat(
+            ["**", "`"].map(
+              (delimiter) =>
+                `<details>\n<summary>X</summary>\n\n${raw.replace("</details>", `${delimiter}literal`)}\n${delimiter}outside`,
+            ),
+          ),
+      ),
     ];
     for (const [caseIndex, markdown] of cases.entries()) {
       for (const chunkSize of [1, 7, 64]) {
         for (let end = chunkSize; end <= markdown.length + chunkSize; end += chunkSize) {
           const prefix = markdown.slice(0, Math.min(end, markdown.length));
           const key = `${caseIndex}-${chunkSize}`;
-          expect(splitIncrementally(prefix, `split-parity-${key}`)).toEqual(
+          expect(splitStableStreamingMarkdown(prefix, `split-parity-${key}`)).toEqual(
             splitStableStreamingMarkdown(prefix),
           );
           expect(toStreamingMarkdownParts(prefix, {}, `html-parity-${key}`).join("")).toBe(
@@ -78,18 +118,15 @@ describe("toStreamingMarkdownParts", () => {
   });
 
   it("resets replaced streams and keeps interleaved streams independent", () => {
-    const splitIncrementally = splitStableStreamingMarkdown as (
-      markdown: string,
-      streamKey: string,
-    ) => ReturnType<typeof splitStableStreamingMarkdown>;
     const streams = new Map([
       ["a", "First stream\n\n```ts\nconst a = 1;"],
       ["b", "Second stream\n\n<details>\n<summary>B</summary>"],
+      ["raw", "<details>\n> <pre>\n> literal"],
     ]);
     for (const end of [8, 16, 32, 64]) {
       for (const [key, markdown] of streams) {
         const prefix = markdown.slice(0, end);
-        expect(splitIncrementally(prefix, `interleaved-${key}`)).toEqual(
+        expect(splitStableStreamingMarkdown(prefix, `interleaved-${key}`)).toEqual(
           splitStableStreamingMarkdown(prefix),
         );
       }
@@ -99,9 +136,11 @@ describe("toStreamingMarkdownParts", () => {
       "Replacement\n\n- starts a different list",
       "A much longer replacement\n\n```ts\nconst changed = true;",
     ]) {
-      expect(splitIncrementally(replacement, "interleaved-a")).toEqual(
-        splitStableStreamingMarkdown(replacement),
-      );
+      for (const key of ["a", "raw"]) {
+        expect(splitStableStreamingMarkdown(replacement, `interleaved-${key}`)).toEqual(
+          splitStableStreamingMarkdown(replacement),
+        );
+      }
     }
   });
 

--- a/ui/src/components/markdown-streaming.ts
+++ b/ui/src/components/markdown-streaming.ts
@@ -4,10 +4,13 @@ import {
   findMarkdownCodeRegions,
 } from "../../../packages/markdown-core/src/reasoning-tags.js";
 import {
+  consumeMarkdownRawHtmlLine,
+  findMarkdownRawHtmlRanges,
   walkMarkdownDisclosureTags,
   type MarkdownDetailsFrame,
   scanMarkdownDisclosureLine,
 } from "./markdown-details.ts";
+import { createMarkdownParser } from "./markdown-parser.ts";
 
 const FENCE_OPEN_RE = /^[ \t]{0,3}(`{3,}|~{3,})/;
 const FENCE_CONTAINER_PREFIX_RE = /^[ \t]{0,3}(?:(?:>\s?)|(?:(?:[-+*]|\d{1,9}[.)])[ \t]+))/;
@@ -80,7 +83,7 @@ type StreamingMarkdownCursor = {
   firstListOffset: number | null;
   hasLinkReferenceDefinition: boolean;
   index: number;
-  lastFenceOffset: number;
+  lastLiteralOffset: number;
   lineMode: "fence" | "plain" | null;
   openFence: FenceMarker | null;
 };
@@ -88,6 +91,8 @@ type StreamingMarkdownCursor = {
 type StreamingMarkdownCacheEntry = {
   cursor: StreamingMarkdownCursor;
   markdown: string;
+  rawTail: boolean;
+  result: StreamingMarkdownSplit;
 };
 
 // A reused row key does not imply append-only text: rollovers, snapshots, and
@@ -101,6 +106,41 @@ function findStreamingCodeSpans(markdown: string, start: number): Array<[number,
   ]);
 }
 
+let rawHtmlParser: ReturnType<typeof createMarkdownParser> | undefined;
+
+function createStreamingRawHtmlScanner(
+  markdown: string,
+  start: number,
+  getCodeSpans: () => ReadonlyArray<readonly [number, number]>,
+) {
+  let ranges: Array<[number, number]> | undefined;
+  let current = 0;
+  return (line: string, index: number) => {
+    const stripped = stripMarkdownContainerPrefixes(line);
+    if (
+      !ranges &&
+      stripped.content.trimStart().startsWith("<") &&
+      consumeMarkdownRawHtmlLine(
+        stripped.content,
+        { context: null },
+        getCodeSpans(),
+        index + stripped.offset,
+      )
+    ) {
+      ranges = findMarkdownRawHtmlRanges(
+        markdown.slice(start),
+        (rawHtmlParser ??= createMarkdownParser()),
+      ).map(([from, to]) => [from + start, to + start]);
+    }
+    let range = ranges?.[current];
+    while (range && range[1] <= index) {
+      current += 1;
+      range = ranges?.[current];
+    }
+    return range && range[0] <= index && index < range[1] ? range : undefined;
+  };
+}
+
 function scanStableStreamingMarkdown(
   markdownLocal: string,
   cursor: StreamingMarkdownCursor = {
@@ -108,20 +148,20 @@ function scanStableStreamingMarkdown(
     firstListOffset: null,
     hasLinkReferenceDefinition: false,
     index: 0,
-    lastFenceOffset: 0,
+    lastLiteralOffset: 0,
     lineMode: null,
     openFence: null,
   },
-): { cursor: StreamingMarkdownCursor; result: StreamingMarkdownSplit } {
-  let { boundary, firstListOffset, hasLinkReferenceDefinition, index, lastFenceOffset } = cursor;
+): { cursor: StreamingMarkdownCursor; rawTail: boolean; result: StreamingMarkdownSplit } {
+  let { boundary, firstListOffset, hasLinkReferenceDefinition, index, lastLiteralOffset } = cursor;
   let lineMode = cursor.lineMode;
   let openFence = cursor.openFence;
   const detailsStack: MarkdownDetailsFrame[] = [];
-  // Completed fences cannot gain indentation ownership from later prose. Keep
+  // Completed literal blocks cannot gain indentation ownership from later prose. Keep
   // list containers and unfinished fences intact when parsing the retained suffix.
   const codeStart = cursor.openFence
     ? 0
-    : Math.min(cursor.lastFenceOffset, cursor.firstListOffset ?? cursor.lastFenceOffset);
+    : Math.min(cursor.lastLiteralOffset, cursor.firstListOffset ?? cursor.lastLiteralOffset);
   const codeInput = markdownLocal.slice(codeStart);
   const codeRegions = / {4}|\t/u.test(codeInput)
     ? findMarkdownCodeRegions(codeInput).map((region) => ({
@@ -133,7 +173,13 @@ function scanStableStreamingMarkdown(
   let codeSpans: ReturnType<typeof findMarkdownCodeSpans> | undefined = codeRegions.length
     ? codeRegions.map(({ start, end }) => [start, end])
     : undefined;
+  const findRawHtmlRange = createStreamingRawHtmlScanner(
+    markdownLocal,
+    Math.min(cursor.boundary, cursor.firstListOffset ?? cursor.boundary),
+    () => (codeSpans ??= findStreamingCodeSpans(markdownLocal, firstListOffset ?? boundary)),
+  );
   let resumeCursor = cursor;
+  let rawTail = false;
 
   while (index < markdownLocal.length) {
     const nextLineBreak = markdownLocal.indexOf("\n", index);
@@ -146,7 +192,7 @@ function scanStableStreamingMarkdown(
         firstListOffset,
         hasLinkReferenceDefinition,
         index,
-        lastFenceOffset,
+        lastLiteralOffset,
         lineMode,
         openFence,
       };
@@ -154,48 +200,63 @@ function scanStableStreamingMarkdown(
     }
     const line = markdownLocal.slice(index, nextLineBreak === -1 ? lineEnd : nextLineBreak);
     const lineFence = openFence;
+    let rawHtmlLine = false;
 
     if (openFence) {
       if (isFenceClose(line, openFence)) {
         openFence = null;
-        lastFenceOffset = lineEnd;
+        lastLiteralOffset = lineEnd;
         if (detailsStack.length === 0) {
           boundary = lineEnd;
         }
       }
     } else {
-      if (firstListOffset === null && LIST_ITEM_OPEN_RE.test(line)) {
-        firstListOffset = index;
+      const strippedLine = stripMarkdownContainerPrefixes(line);
+      const rawHtmlRange = findRawHtmlRange(line, index);
+      rawHtmlLine = rawHtmlRange !== undefined;
+      if (
+        firstListOffset === null &&
+        LIST_ITEM_OPEN_RE.test(line) &&
+        (!rawHtmlRange || rawHtmlRange[0] === index)
+      ) {
+        // A list also retains the disclosure that contains it.
+        firstListOffset = detailsStack.length > 0 ? boundary : index;
       }
-
-      const openingFence = getFenceMarker(line);
-      if (openingFence) {
-        openFence = openingFence;
-        lastFenceOffset = lineEnd;
+      if (rawHtmlLine) {
+        lastLiteralOffset = lineEnd;
+        const content = strippedLine.content.trimStart();
+        rawTail = nextLineBreak === -1 && content.length > 0 && !content.startsWith("<");
       } else {
-        const strippedLine = stripMarkdownContainerPrefixes(line).content;
-        if (DISCLOSURE_LINE_CANDIDATE_RE.test(strippedLine)) {
-          updateDetailsStack(
-            line,
-            detailsStack,
-            false,
-            (codeSpans ??= findStreamingCodeSpans(markdownLocal, firstListOffset ?? boundary)),
-            index,
-          );
-        }
-        if (detailsStack.length === 0) {
-          if (LINK_REFERENCE_CANDIDATE_RE.test(strippedLine)) {
-            hasLinkReferenceDefinition = true;
+        const openingFence = getFenceMarker(line);
+        if (openingFence) {
+          openFence = openingFence;
+          lastLiteralOffset = lineEnd;
+        } else {
+          if (DISCLOSURE_LINE_CANDIDATE_RE.test(strippedLine.content)) {
+            updateDetailsStack(
+              line,
+              detailsStack,
+              false,
+              (codeSpans ??= findStreamingCodeSpans(markdownLocal, firstListOffset ?? boundary)),
+              index,
+            );
           }
-          if (line.trim() === "") {
-            boundary = lineEnd;
+          if (detailsStack.length === 0) {
+            if (LINK_REFERENCE_CANDIDATE_RE.test(strippedLine.content)) {
+              hasLinkReferenceDefinition = true;
+            }
+            if (line.trim() === "") {
+              boundary = lineEnd;
+            }
           }
         }
       }
     }
     index = lineEnd;
+    // A raw token at EOF can extend on append; resume only after a later nonliteral line.
     if (
       detailsStack.length === 0 &&
+      !rawHtmlLine &&
       (nextLineBreak !== -1 || canResumeStreamingLine(line, lineFence))
     ) {
       lineMode = nextLineBreak === -1 ? (lineFence ? "fence" : "plain") : null;
@@ -204,7 +265,7 @@ function scanStableStreamingMarkdown(
         firstListOffset,
         hasLinkReferenceDefinition,
         index,
-        lastFenceOffset,
+        lastLiteralOffset,
         lineMode,
         openFence,
       };
@@ -223,7 +284,7 @@ function scanStableStreamingMarkdown(
 
   // Blank lines inside indented code do not retire the block, and prose repair
   // must never complete punctuation in any parser-owned code block.
-  let lastCodeEnd = lastFenceOffset;
+  let lastLiteralEnd = lastLiteralOffset;
   for (const region of codeRegions) {
     if (!region.block) {
       continue;
@@ -231,14 +292,15 @@ function scanStableStreamingMarkdown(
     if (region.start < boundary && boundary < region.end) {
       boundary = region.start;
     }
-    lastCodeEnd = Math.max(lastCodeEnd, region.end);
+    lastLiteralEnd = Math.max(lastLiteralEnd, region.end);
   }
 
   return {
     cursor: resumeCursor,
+    rawTail,
     result: {
       boundary,
-      tailRepairStart: openFence ? null : Math.max(boundary, lastCodeEnd),
+      tailRepairStart: openFence ? null : Math.max(boundary, lastLiteralEnd),
     },
   };
 }
@@ -261,12 +323,19 @@ export function splitStableStreamingMarkdown(
   }
   const stableMarkdown = markdownLocal.slice(0, stablePrefixLength);
   const cached = streamingSplitCache.get(streamKey);
-  const scanned = scanStableStreamingMarkdown(
-    stableMarkdown,
-    cached && stableMarkdown.startsWith(cached.markdown) ? cached.cursor : undefined,
-  );
+  const append = cached && stableMarkdown.startsWith(cached.markdown);
+  // Appending within an established literal line cannot change its container.
+  // A new line or an ambiguous opener goes back through the native block parser.
+  const scanned =
+    append && cached.rawTail && !/[\r\n]/u.test(stableMarkdown.slice(cached.markdown.length))
+      ? {
+          cursor: cached.cursor,
+          rawTail: true,
+          result: { boundary: cached.result.boundary, tailRepairStart: stableMarkdown.length },
+        }
+      : scanStableStreamingMarkdown(stableMarkdown, append ? cached.cursor : undefined);
   streamingSplitCache.delete(streamKey);
-  streamingSplitCache.set(streamKey, { cursor: scanned.cursor, markdown: stableMarkdown });
+  streamingSplitCache.set(streamKey, { ...scanned, markdown: stableMarkdown });
   while (streamingSplitCache.size > STREAMING_SPLIT_CACHE_LIMIT) {
     const oldest = streamingSplitCache.keys().next().value;
     if (oldest === undefined) {
@@ -285,8 +354,11 @@ export function splitStableStreamingMarkdown(
 // completing `$$` would inject visible characters into ordinary prose.
 const streamingRemendOptions = { katex: false, linkMode: "text-only" } satisfies RemendOptions;
 
-// Preserve completed fences verbatim while repairing only the prose after them.
-export function repairStreamingMarkdownTail(tail: string, repairStart = 0): string {
+// repairStart is the splitter-owned literal boundary relative to this tail.
+export function repairStreamingMarkdownTail(tail: string, repairStart: number): string {
+  if (repairStart === tail.length) {
+    return tail;
+  }
   const repaired =
     tail.slice(0, repairStart) + remend(tail.slice(repairStart), streamingRemendOptions);
   if (!repaired.includes("<")) {
@@ -294,6 +366,11 @@ export function repairStreamingMarkdownTail(tail: string, repairStart = 0): stri
   }
   const detailsStack: MarkdownDetailsFrame[] = [];
   const codeSpans = findMarkdownCodeSpans(repaired);
+  const findRawHtmlRange = createStreamingRawHtmlScanner(
+    tail.slice(0, repairStart),
+    0,
+    () => codeSpans,
+  );
   let openFence: FenceMarker | null = null;
   let pendingSummary = false;
   let index = 0;
@@ -305,13 +382,13 @@ export function repairStreamingMarkdownTail(tail: string, repairStart = 0): stri
       if (isFenceClose(line, openFence)) {
         openFence = null;
       }
-    } else {
+    } else if (!findRawHtmlRange(line, index)) {
       openFence = getFenceMarker(line);
       if (!openFence) {
         pendingSummary = updateDetailsStack(
           line,
           detailsStack,
-          lineEnd === repaired.length,
+          nextLineBreak === -1,
           codeSpans,
           index,
         );


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users reading a streamed Chat reply would see text outside a collapsed disclosure when a literal code example contained a closing details tag. Streaming could also add punctuation inside literal HTML examples, or stop completing ordinary Markdown after a quoted or listed example ended.

## Why This Change Was Made

Static rendering and streaming now share raw-block classification, with the existing Markdown parser owning quote/list boundaries. Tail repair preserves literal text and resumes on the following prose. The existing bounded stream cache reuses established literal-line results, and only an unfinished final summary line is eligible for completion.

## User Impact

Disclosures keep their contents inside until expanded. Literal comment, preformatted and declaration examples retain their text, while following emphasis and summaries render normally as the answer streams.

## Evidence

The complete candidate passes 120 selected renderer, scanner and highlighting tests, canonical changed checks, and a fresh Control UI build. Fifteen new assertions fail against the preceding candidate and pass with the container/declaration repair; earlier checks separately established the original containment and raw-punctuation defects. Three existing active-HTML cases were excluded from the local selection.

Chromium exercised the actual Chat composer and streaming reply against a synthetic Gateway. The before captures use the original source; the after captures use this complete candidate. All four full frames were inspected, and the browser, context and source server closed afterward. These images show disclosure containment; public DOM tests cover the additional punctuation and container cases.

| State | Before | After |
| --- | --- | --- |
| Collapsed | ![Before: reply text outside the collapsed disclosure](https://github.com/user-attachments/assets/32c116c0-635f-442f-a3e1-080f6f144079) | ![After: reply text remains inside the collapsed disclosure](https://github.com/user-attachments/assets/5abbc55c-da20-4d02-9014-284d78be7ebf) |
| Expanded | ![Before: example and following text are separated](https://github.com/user-attachments/assets/a812774e-fc4f-4f24-b9e2-f8faa422fb04) | ![After: example and following text share the disclosure](https://github.com/user-attachments/assets/60ed7dc6-47b5-4c6d-9975-8806baf52ab6) |

The cache check compares cached and uncached rendering of the final implementation: 48 appends produce identical HTML while native raw-range parsing runs once instead of 48 times. It does not claim linear work for long containers growing by new lines. No live-provider or operator Gateway execution is claimed.

Independent review covered the complete patch. A separate bounded comparison used 48 ordinary newline updates ending at 1,553 characters: all HTML matched, and added native block parsing took roughly 0.4–1.2 ms per complete sample. Closed-example totals rose about 2.7–4.1 ms across those 48 updates; these small measurements do not establish behavior near the message cap.
