### PR TITLE
improve(agents): reduce copying of fragmented LSP responses

### DIFF
--- a/src/agents/agent-bundle-lsp-runtime.test.ts
+++ b/src/agents/agent-bundle-lsp-runtime.test.ts
@@ -406,6 +406,46 @@ describe("bundle LSP runtime", () => {
     await runtime.dispose();
   });
 
+  it.each([1, 4096])(
+    "preserves consecutive multibyte tool responses delivered in %i-byte chunks",
+    async (chunkSize) => {
+      configureSingleLspServer();
+      const child = new MockChildProcess("", new Set(["initialize", "shutdown"]));
+      spawnMock.mockReturnValue(child);
+      const runtime = await createBundleLspToolRuntime({ workspaceDir: "/tmp/workspace" });
+      const tool = runtime.tools.find((candidate) => candidate.name === "lsp_hover_typescript");
+      if (!tool) {
+        throw new Error("expected hover tool");
+      }
+      const results = [{ contents: "té🙂".repeat(2048) }, { contents: "次の結果".repeat(1024) }];
+      const requests = results.map((_, index) =>
+        tool.execute(`call-${index}`, {
+          uri: "file:///tmp/workspace/index.ts",
+          line: index,
+          character: 0,
+        }),
+      );
+      const calls = child.receivedMessages.filter(
+        (message) => message.method === "textDocument/hover",
+      );
+      const bytes = Buffer.from(
+        results
+          .map((result, index) =>
+            encodeLspMessage({ jsonrpc: "2.0", id: calls[index]?.id, result }),
+          )
+          .join(""),
+      );
+      for (let offset = 0; offset < bytes.length; offset += chunkSize) {
+        child.stdout.write(bytes.subarray(offset, offset + chunkSize));
+      }
+
+      expect((await Promise.all(requests)).map((result) => result.content)).toEqual(
+        results.map((result) => [{ type: "text", text: JSON.stringify(result, null, 2) }]),
+      );
+      await runtime.dispose();
+    },
+  );
+
   it("accepts a maximum-size header when its separator is split across chunks", async () => {
     configureSingleLspServer();
     const child = new MockChildProcess("", undefined, (body) => {

--- a/src/agents/agent-bundle-lsp-runtime.ts
+++ b/src/agents/agent-bundle-lsp-runtime.ts
@@ -32,7 +32,7 @@ type LspSession = {
   process: OwnedStdioProcess;
   requestId: number;
   pendingRequests: ReturnType<typeof createPendingRequestRegistry<number, unknown, undefined>>;
-  buffer: Buffer;
+  input: LspInputBuffer;
   initialized: boolean;
   capabilities: LspServerCapabilities;
   disposed: boolean;
@@ -75,7 +75,7 @@ function createLspSession(serverName: string, child: OwnedStdioProcess): LspSess
     process: child,
     requestId: 0,
     pendingRequests: createPendingRequestRegistry<number, unknown, undefined>(),
-    buffer: Buffer.alloc(0),
+    input: { buffer: Buffer.alloc(0), length: 0 },
     initialized: false,
     capabilities: {},
     disposed: false,
@@ -147,8 +147,14 @@ class LspFramingError extends Error {
 }
 
 type LspParseResult =
-  | { readonly ok: true; readonly messages: unknown[]; readonly remaining: Buffer }
+  | { readonly ok: true; readonly messages: unknown[]; readonly consumed: number }
   | { readonly ok: false; readonly messages: unknown[]; readonly error: LspFramingError };
+
+type LspInputBuffer = {
+  buffer: Buffer;
+  length: number;
+  body?: { start: number; end: number };
+};
 
 function framingError(messages: unknown[], detail: string): LspParseResult {
   return {
@@ -190,35 +196,38 @@ function parseContentLength(header: string): number | LspFramingError {
   return length;
 }
 
-function parseLspMessages(buffer: Buffer): LspParseResult {
+function parseLspMessages(input: LspInputBuffer): LspParseResult {
   const messages: unknown[] = [];
-  let remaining = buffer;
+  let consumed = 0;
 
   while (true) {
-    const headerEnd = remaining.indexOf(LSP_HEADER_SEPARATOR);
-    if (headerEnd === -1) {
-      const maxIncompleteHeaderBytes = MAX_LSP_HEADER_BYTES + LSP_HEADER_SEPARATOR.length - 1;
-      return remaining.length > maxIncompleteHeaderBytes
-        ? framingError(messages, `header exceeds ${MAX_LSP_HEADER_BYTES} bytes`)
-        : { ok: true, messages, remaining };
-    }
-    if (headerEnd > MAX_LSP_HEADER_BYTES) {
-      return framingError(messages, `header exceeds ${MAX_LSP_HEADER_BYTES} bytes`);
-    }
+    if (!input.body) {
+      const remaining = input.buffer.subarray(consumed, input.length);
+      const headerEnd = remaining.indexOf(LSP_HEADER_SEPARATOR);
+      if (headerEnd === -1) {
+        const maxIncompleteHeaderBytes = MAX_LSP_HEADER_BYTES + LSP_HEADER_SEPARATOR.length - 1;
+        return remaining.length > maxIncompleteHeaderBytes
+          ? framingError(messages, `header exceeds ${MAX_LSP_HEADER_BYTES} bytes`)
+          : { ok: true, messages, consumed };
+      }
+      if (headerEnd > MAX_LSP_HEADER_BYTES) {
+        return framingError(messages, `header exceeds ${MAX_LSP_HEADER_BYTES} bytes`);
+      }
 
-    const contentLength = parseContentLength(remaining.subarray(0, headerEnd).toString("ascii"));
-    if (contentLength instanceof LspFramingError) {
-      return { ok: false, messages, error: contentLength };
+      const contentLength = parseContentLength(remaining.subarray(0, headerEnd).toString("ascii"));
+      if (contentLength instanceof LspFramingError) {
+        return { ok: false, messages, error: contentLength };
+      }
+      const start = consumed + headerEnd + LSP_HEADER_SEPARATOR.length;
+      input.body = { start, end: start + contentLength };
     }
-    const bodyStart = headerEnd + LSP_HEADER_SEPARATOR.length;
-    const bodyEnd = bodyStart + contentLength;
-    if (remaining.length < bodyEnd) {
-      return { ok: true, messages, remaining };
+    if (input.length < input.body.end) {
+      return { ok: true, messages, consumed };
     }
 
     let body: string;
     try {
-      body = LSP_BODY_DECODER.decode(remaining.subarray(bodyStart, bodyEnd));
+      body = LSP_BODY_DECODER.decode(input.buffer.subarray(input.body.start, input.body.end));
     } catch {
       return framingError(messages, "body is not valid UTF-8");
     }
@@ -230,7 +239,8 @@ function parseLspMessages(buffer: Buffer): LspParseResult {
         `body is not valid JSON: ${error instanceof Error ? error.message : String(error)}`,
       );
     }
-    remaining = remaining.subarray(bodyEnd);
+    consumed = input.body.end;
+    input.body = undefined;
   }
 }
 
@@ -298,16 +308,37 @@ function sendRequest(
 }
 
 function handleIncomingData(session: LspSession, chunk: Buffer | string) {
-  session.buffer = Buffer.concat([
-    session.buffer,
-    typeof chunk === "string" ? Buffer.from(chunk, "utf8") : chunk,
-  ]);
-  const parsed = parseLspMessages(session.buffer);
-  session.buffer = parsed.ok
-    ? parsed.remaining.length === 0
-      ? Buffer.alloc(0)
-      : Buffer.from(parsed.remaining)
-    : Buffer.alloc(0);
+  const bytes = typeof chunk === "string" ? Buffer.from(chunk, "utf8") : chunk;
+  const input = session.input;
+  const length = input.length + bytes.length;
+  if (length > input.buffer.length) {
+    // Grow geometrically while a frame arrives, instead of copying its full
+    // prefix on every stdout chunk. Only input.length bytes are initialized.
+    const capacity = Math.max(
+      length,
+      Math.min(
+        Math.max(4096, input.buffer.length * 2),
+        MAX_LSP_HEADER_BYTES + LSP_HEADER_SEPARATOR.length + MAX_LSP_BODY_BYTES,
+      ),
+    );
+    const buffer = Buffer.allocUnsafe(capacity);
+    input.buffer.copy(buffer, 0, 0, input.length);
+    input.buffer = buffer;
+  }
+  bytes.copy(input.buffer, input.length);
+  input.length = length;
+  const parsed = parseLspMessages(input);
+  if (!parsed.ok || parsed.consumed === input.length) {
+    session.input = { buffer: Buffer.alloc(0), length: 0 };
+  } else if (parsed.consumed > 0) {
+    // Detach the incomplete tail from completed frames and release spare capacity.
+    input.buffer = Buffer.from(input.buffer.subarray(parsed.consumed, input.length));
+    input.length -= parsed.consumed;
+    if (input.body) {
+      input.body.start -= parsed.consumed;
+      input.body.end -= parsed.consumed;
+    }
+  }
 
   for (const msg of parsed.messages) {
     if (typeof msg !== "object" || msg === null) {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users requesting large results from bundled language servers would wait for avoidable CPU work when responses arrived in many stdout chunks. A synthetic 8 MiB references response took 3.34 seconds to ingest and render when delivered in 4 KiB chunks.

## Why This Change Was Made

The LSP runtime now grows its pending buffer geometrically and retains the validated body boundary until the frame completes. This removes repeated copying of the entire response prefix and repeated header parsing. Completed frames release spare capacity, and incomplete tails detach from completed response storage. Framing limits, Unicode decoding, response ordering, and process lifecycle remain unchanged.

## User Impact

Large fragmented LSP responses complete faster, reducing synchronous work on the Gateway event loop. Pending buffers can reserve spare capacity between chunks; this change makes no claim of reduced process RSS.

## Evidence

The benchmark invokes the registered `lsp_references_bench` tool through `createBundleLspToolRuntime` with a synthetic stdio process. Fixture construction is outside the timer; response ingestion, JSON parsing, and tool-result rendering are inside. Every result is checked byte-for-byte against the expected rendered JSON. Measurements used Windows x64, Node 26.8.2 / V8 14.6.202.34-node.28, with one warmup and four measured replies per cell.

| Approximate response size | Stdout chunk | Before median | After median | Speedup |
| --- | --- | ---: | ---: | ---: |
| 64 KiB | 4 KiB | 0.983 ms | 0.874 ms | 1.12× |
| 64 KiB | 64 KiB | 0.828 ms | 0.823 ms | 1.01× |
| 1 MiB | 4 KiB | 97.558 ms | 12.197 ms | 8.00× |
| 1 MiB | 64 KiB | 14.628 ms | 10.907 ms | 1.34× |
| 8 MiB | 4 KiB | 3336.567 ms | 86.537 ms | 38.56× |
| 8 MiB | 64 KiB | 258.098 ms | 84.369 ms | 3.06× |

Fresh-process 8 MiB whole-frame controls ran in baseline/candidate/candidate/baseline order, with eight measured replies after one warmup per process. Across 16 samples per version, the median was **68.124 → 67.877 ms**. Baseline samples ranged from 47.384–88.133 ms and candidate samples from 54.110–86.566 ms; per-process medians in execution order were 60.49, 68.67, 66.46, and 78.38 ms. These controls show comparable whole-frame performance amid host variance; no whole-frame improvement is claimed. Every output matched, and the committed candidate source was restored byte-for-byte after the control swaps. RSS samples were recorded but varied with GC history, so they do not establish a memory reduction.

- Bundled LSP runtime tests: **30/30 passed**, including consecutive multibyte responses fragmented into 1-byte and 4 KiB chunks.
- Independent review through **P2: scoped-clean**, with no actionable findings.
- Changed formatting, targeted oxlint, production core typecheck, all core test typecheck shards, and `git diff --check` passed.
- `check:changed` stopped at existing unused-export findings in `scripts/crabbox-wrapper-providers.mts` (`canonicalProviderName`) and `scripts/lib/static-extension-assets.mts` (`listPackagedStaticExtensionAssetOutputs`). Both files are byte-identical to base `a53c601cd4075a6839bac3f75f2280eda182b4b8`; the production unused-export scan passed with zero entries. Later changed-gate steps remain unrun, except the two-file oxlint check run separately. No guard or baseline was changed.
- Required hosted `openclaw/ci-gate` passed at exact head `51009850eb560cbe603205e7b4d00a5b7ebe9e4c`, covering the remaining gates.
