### PR TITLE
refactor(qa): share live transport CLI registration

### DIFF
--- a/extensions/qa-lab/src/cli-scenario-selection.test.ts
+++ b/extensions/qa-lab/src/cli-scenario-selection.test.ts
@@ -6,7 +6,8 @@ const { runQaProfileCommand, runQaSuiteCommand } = vi.hoisted(() => ({
   runQaSuiteCommand: vi.fn(),
 }));
 
-vi.mock("openclaw/plugin-sdk/qa-runner-runtime", () => ({
+vi.mock("openclaw/plugin-sdk/qa-runner-runtime", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("openclaw/plugin-sdk/qa-runner-runtime")>()),
   listQaRunnerCliContributions: () => [],
 }));
 

--- a/extensions/qa-lab/src/cli.test.ts
+++ b/extensions/qa-lab/src/cli.test.ts
@@ -100,7 +100,8 @@ function requireQaSuiteOptions() {
   return options;
 }
 
-vi.mock("openclaw/plugin-sdk/qa-runner-runtime", () => ({
+vi.mock("openclaw/plugin-sdk/qa-runner-runtime", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("openclaw/plugin-sdk/qa-runner-runtime")>()),
   listQaRunnerCliContributions,
 }));
 

--- a/extensions/qa-lab/src/coverage-report.commands.test.ts
+++ b/extensions/qa-lab/src/coverage-report.commands.test.ts
@@ -11,7 +11,8 @@ import type { QaScorecardChannelDriver } from "./scorecard-taxonomy.js";
 import { selectQaFlowSuiteScenarios } from "./suite-planning.js";
 import { makeQaSuiteTestScenario } from "./suite-test-helpers.js";
 
-vi.mock("openclaw/plugin-sdk/qa-runner-runtime", () => ({
+vi.mock("openclaw/plugin-sdk/qa-runner-runtime", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("openclaw/plugin-sdk/qa-runner-runtime")>()),
   listQaRunnerCliContributions: () => [],
 }));
 

--- a/extensions/qa-lab/src/live-transports/cli.test.ts
+++ b/extensions/qa-lab/src/live-transports/cli.test.ts
@@ -23,7 +23,10 @@ const {
   suiteRuntimeLoads: { count: 0 },
 }));
 
-vi.mock("openclaw/plugin-sdk/qa-runner-runtime", () => ({ listQaRunnerCliContributions }));
+vi.mock("openclaw/plugin-sdk/qa-runner-runtime", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("openclaw/plugin-sdk/qa-runner-runtime")>()),
+  listQaRunnerCliContributions,
+}));
 vi.mock("./shared/live-transport-suite.runtime.js", () => {
   suiteRuntimeLoads.count += 1;
   return {

--- a/extensions/qa-lab/src/live-transports/shared/live-transport-cli.ts
+++ b/extensions/qa-lab/src/live-transports/shared/live-transport-cli.ts
@@ -1,8 +1,9 @@
 // Qa Lab plugin module implements live transport cli behavior.
-import type { Command } from "commander";
-import type {
-  LiveTransportQaCommandOptions as QaRunnerCommandOptions,
-  QaRunnerCliRegistration,
+import {
+  createLiveTransportQaCliRegistration as createQaRunnerCliRegistration,
+  type LiveTransportQaCommandOptions as QaRunnerCommandOptions,
+  type LiveTransportQaCliRegistrationOptions as QaRunnerCliRegistrationOptions,
+  type QaRunnerCliRegistration,
 } from "openclaw/plugin-sdk/qa-runner-runtime";
 import { parseQaCliPositiveIntegerOption } from "../../cli-options.js";
 import { DEFAULT_QA_LIVE_PROVIDER_MODE, formatQaProviderModeHelp } from "../../providers/index.js";
@@ -12,46 +13,15 @@ export type LiveTransportQaCommandOptions = QaRunnerCommandOptions & {
   concurrency?: number;
 };
 
-type LiveTransportQaCommanderOptions = {
-  concurrency?: number;
-  repoRoot?: string;
-  outputDir?: string;
-  providerMode?: string;
-  model?: string;
-  altModel?: string;
-  scenario?: string[];
-  listScenarios?: boolean;
-  fast?: boolean;
-  allowFailures?: boolean;
-  failFast?: boolean;
-  profile?: string;
-  sutAccount?: string;
-  credentialSource?: string;
-  credentialRole?: string;
-};
-
 export type LiveTransportQaCliRegistration = Omit<QaRunnerCliRegistration, "adapterFactory"> & {
   adapterFactory?: QaTransportAdapterFactory;
 };
 
-type LiveTransportQaCliRegistrationOptions = {
-  commandName: string;
-  credentialOptions?: {
-    sourceDescription?: string;
-    roleDescription?: string;
-  };
-  defaultProviderMode: string;
-  description: string;
-  providerModeHelp: string;
-  listScenariosHelp?: string;
-  outputDirHelp: string;
-  profileHelp?: string;
-  failFastHelp?: string;
-  allowFailuresHelp?: string;
-  scenarioHelp: string;
-  sutAccountHelp: string;
+type LiveTransportQaCliRegistrationOptions = Omit<
+  QaRunnerCliRegistrationOptions,
+  "adapterFactory" | "concurrency"
+> & {
   adapterFactory?: QaTransportAdapterFactory;
-  run: (opts: LiveTransportQaCommandOptions) => Promise<void>;
 };
 
 export function createLazyCliRuntimeLoader<T>(load: () => Promise<T>) {
@@ -59,86 +29,6 @@ export function createLazyCliRuntimeLoader<T>(load: () => Promise<T>) {
   return async () => {
     promise ??= load();
     return await promise;
-  };
-}
-
-function collectStringOption(value: string, previous: string[]) {
-  const trimmed = value.trim();
-  return trimmed ? [...previous, trimmed] : previous;
-}
-
-function mapCommanderOptions(opts: LiveTransportQaCommanderOptions): LiveTransportQaCommandOptions {
-  return {
-    ...(opts.concurrency !== undefined ? { concurrency: opts.concurrency } : {}),
-    repoRoot: opts.repoRoot,
-    outputDir: opts.outputDir,
-    providerMode: opts.providerMode,
-    primaryModel: opts.model,
-    alternateModel: opts.altModel,
-    fastMode: opts.fast,
-    allowFailures: opts.allowFailures,
-    failFast: opts.failFast,
-    profile: opts.profile,
-    scenarioIds: opts.scenario,
-    listScenarios: opts.listScenarios,
-    sutAccountId: opts.sutAccount,
-    credentialSource: opts.credentialSource,
-    credentialRole: opts.credentialRole,
-  };
-}
-
-function createSharedLiveTransportQaCliRegistration(
-  params: LiveTransportQaCliRegistrationOptions,
-): LiveTransportQaCliRegistration {
-  return {
-    commandName: params.commandName,
-    adapterFactory: params.adapterFactory,
-    register(qa: Command) {
-      const command = qa
-        .command(params.commandName)
-        .description(params.description)
-        .option("--repo-root <path>", "Repository root to target when running from a neutral cwd")
-        .option("--output-dir <path>", params.outputDirHelp)
-        .option("--provider-mode <mode>", params.providerModeHelp, params.defaultProviderMode)
-        .option("--model <ref>", "Primary provider/model ref")
-        .option("--alt-model <ref>", "Alternate provider/model ref")
-        .option("--scenario <id>", params.scenarioHelp, collectStringOption, [])
-        .option("--fast", "Enable provider fast mode where supported");
-
-      if (params.adapterFactory?.isolatesInstances === true) {
-        command.option(
-          "--concurrency <count>",
-          "Scenario worker concurrency (bounded by the transport limit)",
-          (value: string) => parseQaCliPositiveIntegerOption(value, "--concurrency"),
-        );
-      }
-      if (params.allowFailuresHelp) {
-        command.option("--allow-failures", params.allowFailuresHelp, false);
-      }
-      command.option("--sut-account <id>", params.sutAccountHelp, "sut");
-      if (params.listScenariosHelp) {
-        command.option("--list-scenarios", params.listScenariosHelp, false);
-      }
-      if (params.profileHelp) {
-        command.option("--profile <profile>", params.profileHelp);
-      }
-      if (params.failFastHelp) {
-        command.option("--fail-fast", params.failFastHelp, false);
-      }
-      if (params.credentialOptions) {
-        command.option(
-          "--credential-source <source>",
-          params.credentialOptions.sourceDescription ??
-            "Credential source for live lanes: env or convex (default: env)",
-        );
-        if (params.credentialOptions.roleDescription) {
-          command.option("--credential-role <role>", params.credentialOptions.roleDescription);
-        }
-      }
-      command.action(async (opts: LiveTransportQaCommanderOptions) => {
-        await params.run(mapCommanderOptions(opts));
-      });
-    },
   };
 }
 
@@ -157,9 +47,16 @@ type QaLabLiveTransportQaCliRegistrationOptions = Omit<
 export function createLiveTransportQaCliRegistration(
   params: QaLabLiveTransportQaCliRegistrationOptions,
 ) {
-  return createSharedLiveTransportQaCliRegistration({
+  return createQaRunnerCliRegistration({
     ...params,
     allowFailuresHelp: "Write artifacts without setting a failing exit code when scenarios fail",
+    concurrency:
+      params.adapterFactory?.isolatesInstances === true
+        ? {
+            help: "Scenario worker concurrency (bounded by the transport limit)",
+            parse: (value: string) => parseQaCliPositiveIntegerOption(value, "--concurrency"),
+          }
+        : undefined,
     defaultProviderMode: params.defaultProviderMode ?? DEFAULT_QA_LIVE_PROVIDER_MODE,
     providerModeHelp: formatQaProviderModeHelp(),
   });

--- a/src/plugin-sdk/qa-runner-runtime.ts
+++ b/src/plugin-sdk/qa-runner-runtime.ts
@@ -209,6 +209,7 @@ export type QaRunnerCliRegistration = {
 
 /** Normalized options passed from live-transport QA CLIs into lane runners. */
 export type LiveTransportQaCommandOptions = {
+  concurrency?: number;
   repoRoot?: string;
   outputDir?: string;
   providerMode?: string;
@@ -242,6 +243,7 @@ export type LiveTransportQaSuiteCommandOptions = {
 };
 
 type LiveTransportQaCommanderOptions = {
+  concurrency?: number;
   repoRoot?: string;
   outputDir?: string;
   providerMode?: string;
@@ -271,6 +273,10 @@ export type LiveTransportQaCredentialCliOptions = {
 /** Declarative command metadata and runner used to install a live-transport QA CLI. */
 export type LiveTransportQaCliRegistrationOptions = {
   commandName: string;
+  concurrency?: {
+    help: string;
+    parse: (value: string) => number;
+  };
   credentialFileHelp?: string;
   credentialOptions?: LiveTransportQaCredentialCliOptions;
   defaultProviderMode: string;
@@ -305,6 +311,7 @@ function mapLiveTransportQaCommanderOptions(
   opts: LiveTransportQaCommanderOptions,
 ): LiveTransportQaCommandOptions {
   return {
+    concurrency: opts.concurrency,
     repoRoot: opts.repoRoot,
     outputDir: opts.outputDir,
     providerMode: opts.providerMode,
@@ -339,6 +346,10 @@ function registerLiveTransportQaCli(
     .option("--alt-model <ref>", "Alternate provider/model ref")
     .option("--scenario <id>", params.scenarioHelp, collectLiveTransportQaStringOption, [])
     .option("--fast", "Enable provider fast mode where supported");
+
+  if (params.concurrency) {
+    command.option("--concurrency <count>", params.concurrency.help, params.concurrency.parse);
+  }
 
   if (params.allowFailuresHelp) {
     command.option("--allow-failures", params.allowFailuresHelp, false);


### PR DESCRIPTION
## Summary

- move shared live-transport Commander registration and option mapping into the published Plugin SDK registrar
- add an optional caller-supplied concurrency option to that registrar
- retain QA Lab's positive-integer parser, transport defaults, and adapter factory extension locally

This removes 92 production lines and leaves one owner for live-transport CLI registration.

## Validation

- `pnpm check:changed`
- 57 focused Plugin SDK and QA Lab tests covering discovery, registration, lazy loading, defaults, errors, and concurrency visibility
- Plugin SDK declaration generation
- core/extension production and all test-type shards
- SDK surface/boundary checks, architecture, all three Knip scans, lint, database, sidecar, webhook, pairing, and cycle guards

## Compatibility

Existing transport flags, defaults, command names, lazy loading, error propagation, and QA Lab concurrency parsing remain unchanged. The new SDK parameter is optional and additive; callers that omit it retain the previous registrar behavior.
