### PR TITLE
improve: avoid model-context worker startup delays in tests

### DIFF
--- a/docs/reference/test/local.md
+++ b/docs/reference/test/local.md
@@ -130,9 +130,10 @@ Isolated Doctor config scripts also share the prepared config-flow, health-write
 and install-index modules. Each case still starts a fresh process with separate
 state; standalone and watch runs resolve the original TypeScript entrypoints.
 
-The prepared model-catalog worker also uses this compiled generation. Separate
-prepared model generations still own separate worker threads, and their choice
-of source or built plugin artifacts stays independent of worker compilation.
+The model-catalog and session model-context workers also use this compiled generation.
+Model-catalog workers still belong to their prepared model generations; context reads
+retain their serial worker pool. Plugin source/built selection remains independent
+of worker compilation.
 Other worker-thread entries and arbitrary source CLI fixtures remain outside
 this declared set.
 

--- a/src/config/sessions/session-model-context-worker-runtime.ts
+++ b/src/config/sessions/session-model-context-worker-runtime.ts
@@ -1,3 +1,4 @@
+import { runtimeProcessEntrypoints } from "../../infra/runtime-process-entrypoints.js";
 import { resolveRuntimeWorkerUrl } from "../../infra/runtime-worker-url.js";
 import { WorkerTaskPool } from "../../infra/worker-task-pool.js";
 import { isIncognitoSessionKey } from "../../routing/session-key.js";
@@ -9,11 +10,7 @@ const modelContextReads = new WorkerTaskPool<
   SessionModelContextWorkerInput,
   ReturnType<typeof readSessionTranscriptModelContext>
 >({
-  workerUrl: resolveRuntimeWorkerUrl({
-    currentModuleUrl: import.meta.url,
-    sourceWorkerName: "session-model-context.worker",
-    distWorkerPath: "config/sessions/session-model-context.worker.js",
-  }),
+  workerUrl: resolveRuntimeWorkerUrl(runtimeProcessEntrypoints.sessionModelContext),
   // Preserve context-read admission order and avoid multiplying large SQLite scans.
   maxWorkers: 1,
 });

--- a/src/infra/runtime-process-entrypoints.ts
+++ b/src/infra/runtime-process-entrypoints.ts
@@ -64,6 +64,11 @@ export const runtimeProcessEntrypoints = {
     sourceWorkerName: "../config/sessions/session-accessor.sqlite-archive.worker",
     distWorkerPath: "config/sessions/session-accessor.sqlite-archive.worker.js",
   },
+  sessionModelContext: {
+    currentModuleUrl,
+    sourceWorkerName: "../config/sessions/session-model-context.worker",
+    distWorkerPath: "config/sessions/session-model-context.worker.js",
+  },
   sessionTranscriptReconcile: {
     currentModuleUrl,
     sourceWorkerName: "../config/sessions/session-transcript-reconcile.worker",

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -419,8 +419,6 @@ function buildCoreDistEntries(): Record<string, string> {
     "agents/tool-images.runtime": "src/agents/tool-images.runtime.ts",
     "agents/code-mode.worker": "src/agents/code-mode.worker.ts",
     "agents/compaction-planning.worker": "src/agents/compaction-planning.worker.ts",
-    "config/sessions/session-model-context.worker":
-      "src/config/sessions/session-model-context.worker.ts",
     "config/sessions/disk-budget.worker": "src/config/sessions/disk-budget.worker.ts",
     ...runtimeProcessBuildEntries,
     ...runtimeProcessDeclarationEntries,


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where source-backed functional tests time out while starting the first model-context worker. This reproduced the cold-worker failure in #145665: six async cases exceeded their existing five-second launch deadline on unchanged main source.

## Why This Change Was Made

Register the model-context worker with the existing runtime process entrypoint owner and consume that descriptor from its launcher. The shared build and test preparation now compile this worker with the other declared workers. Remove the duplicate explicit build entry and document the ownership, following the existing model-catalog worker pattern.

## User Impact

Local and CI tests avoid repeated source-loader startup for model-context reads. The worker keeps its serial pool, cancellation behavior, read contract, and existing packaged output path. Installed Gateways already use compiled workers; this PR does not claim an installed-Gateway latency improvement.

## Evidence

- Linux, Node 26.8.2, fresh module caches, original test order, and identical diagnostic timing wrappers: baseline six async failures/two passes; candidate all eight tests pass. The first model-context read changed from a timeout at 5,003 ms to completion in 869 ms. Existing test deadlines and assertions are unchanged.
- All 81 relevant tests passed: detached context launch (8), transcript footprint (2), model-context/snapshot contracts (39), worker URL resolution (9), and build configuration (23).
- Final four-file formatting, diff checks, scoped type-aware lint, core and scripts typechecks, and the worker sidecar guard passed. Independent review found no actionable issues.
- The runtime package graph emitted the worker at its unchanged installed path, and its syntax check passed. Exact-head [CI run34678254638](https://github.com/openclaw/openclaw/actions/runs/34678254638) passed, including the previously failing shard, runtime build, both canonical SDK declaration groups from cache misses, SDK exports, UI, and built CLI checks.
- Neither local full-build attempt completed uninterrupted: the first stopped on dependency hardlink metadata drift; the retry passed all six core declaration groups and their integrity seal, then exited129 during SDK generation. Hosted SDK generation provides covering proof for the interrupted step. No guards were weakened.
- The subsequent isolated local SDK declaration retry also passed with exit 0, sealed and published normally, and released its task-owned processes. The four reviewed source hashes remained unchanged.

The diagnostic benchmark is a local artifact. No new test mocks, prewarming hooks, retry policy, or timeout exceptions were introduced.
