### PR TITLE
fix: avoid repeated scans when opening historical messages

### DIFF
--- a/src/config/sessions/session-accessor.sqlite-history-events.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-history-events.test.ts
@@ -704,6 +704,31 @@ describe("SQLite transcript history events", () => {
       "before-tool",
       "first-reset",
     ]);
+    for (const [messageId, maxMessages, ids, seqs, offset, hasOverreadContext] of [
+      ["before-user", 1, ["before-user"], [1], 3, false],
+      [
+        "before-assistant",
+        2,
+        ["before-user", "before-assistant", "before-tool"],
+        [1, 2, 3],
+        1,
+        true,
+      ],
+      [
+        "before-tool",
+        3,
+        ["before-user", "before-assistant", "before-tool", "first-reset"],
+        [1, 2, 3, 4],
+        0,
+        true,
+      ],
+      ["first-reset", 1, ["before-tool", "first-reset"], [3, 4], 0, true],
+    ] as const) {
+      const page = readSessionTranscriptHistoryAnchorPage(scope, { messageId, maxMessages });
+      expect(page).toMatchObject({ found: true, totalMessages: 4, offset, hasOverreadContext });
+      expect(page.events.map(historyEventId)).toEqual(ids);
+      expect(page.events.map(({ seq }) => seq)).toEqual(seqs);
+    }
     expect(
       readSessionTranscriptHistoryAnchorPage(scope, {
         maxMessages: 10,
@@ -733,6 +758,57 @@ describe("SQLite transcript history events", () => {
       events: [],
       totalMessages: 2,
     });
+  });
+
+  it("keeps historical anchor pages in display order across hidden control rows", async () => {
+    await replaceTranscriptEvents(scope, [
+      { type: "session", version: 3, id: scope.sessionId },
+      { type: "message", id: "first", parentId: null, message: { role: "user", content: "first" } },
+      { type: "custom", id: "control", parentId: "first", customType: "hidden" },
+      {
+        type: "custom_message",
+        id: "hidden",
+        parentId: "control",
+        customType: "notice",
+        display: false,
+        content: "hidden",
+      },
+      {
+        type: "custom_message",
+        id: "notice",
+        parentId: "hidden",
+        customType: "notice",
+        display: true,
+        content: "visible",
+      },
+      {
+        type: "message",
+        id: "last",
+        parentId: "notice",
+        message: { role: "assistant", content: "last" },
+      },
+      { type: "reset", id: "reset", parentId: "last", reason: "new" },
+      {
+        type: "message",
+        id: "fresh",
+        parentId: "reset",
+        message: { role: "user", content: "fresh" },
+      },
+    ]);
+    for (const [messageId, maxMessages, ids, seqs, offset, hasOverreadContext] of [
+      ["first", 2, ["first", "notice"], [1, 2], 2, false],
+      ["notice", 1, ["first", "notice"], [1, 2], 2, true],
+      ["last", 2, ["notice", "last", "reset"], [2, 3, 4], 0, true],
+      ["first", 10, ["first", "notice", "last", "reset"], [1, 2, 3, 4], 0, false],
+    ] as const) {
+      const page = readSessionTranscriptHistoryAnchorPage(scope, { messageId, maxMessages });
+      expect(page).toMatchObject({ found: true, totalMessages: 4, offset, hasOverreadContext });
+      expect(page.events.map(historyEventId)).toEqual(ids);
+      expect(page.events.map(({ seq }) => seq)).toEqual(seqs);
+    }
+    expect(
+      readSessionTranscriptHistoryAnchorPage(scope, { messageId: "hidden", maxMessages: 10 }).found,
+    ).toBe(false);
   });
 
   it.each(["message", "custom_message"])(

--- a/src/config/sessions/session-accessor.sqlite-history-interval.ts
+++ b/src/config/sessions/session-accessor.sqlite-history-interval.ts
@@ -47,10 +47,19 @@ function selectHistoricalDisplayEvents(
 ) {
   return getActiveTranscriptKysely(projection.database)
     .selectFrom("session_transcript_active_events as active")
-    .innerJoin("transcript_event_identities as identity", (join) =>
-      join
-        .onRef("identity.session_id", "=", "active.session_id")
-        .onRef("identity.seq", "=", "active.event_seq"),
+    .innerJoin(
+      // Without statistics, the covering event-type index can scan the session for every row.
+      getActiveTranscriptKysely(projection.database)
+        .selectFrom("transcript_event_identities")
+        .select(["session_id", "seq", "event_type"])
+        .modifyEnd(
+          /* kysely-allow-raw: pin the canonical sequence lookup to avoid quadratic cold-history joins. */ sql`INDEXED BY idx_agent_transcript_event_identity_sequence`,
+        )
+        .as("identity"),
+      (join) =>
+        join
+          .onRef("identity.session_id", "=", "active.session_id")
+          .onRef("identity.seq", "=", "active.event_seq"),
     )
     .innerJoin("transcript_events as event", (join) =>
       join
@@ -115,14 +124,11 @@ function readDisplayableActiveEventById(projection: CurrentTranscriptProjection,
 function countHistoricalDisplayEvents(
   projection: CurrentTranscriptProjection,
   interval: ClosedResetInterval,
-  beforeActivePosition?: number,
+  beforeActivePosition: number,
 ): number {
-  let query = selectHistoricalDisplayEvents(projection, interval).select((eb) =>
-    eb.fn.countAll<number>().as("event_count"),
-  );
-  if (beforeActivePosition !== undefined) {
-    query = query.where("active.active_position", "<", beforeActivePosition);
-  }
+  const query = selectHistoricalDisplayEvents(projection, interval)
+    .select((eb) => eb.fn.countAll<number>().as("event_count"))
+    .where("active.active_position", "<", beforeActivePosition);
   const row = executeSqliteQueryTakeFirstSync(projection.database.db, query);
   return row?.event_count ?? 0;
 }
@@ -133,22 +139,35 @@ function readHistoricalDisplayEventRange(
   interval: ClosedResetInterval,
   start: number,
   count: number,
+  anchor: { activePosition: number; displayPosition: number },
 ): SessionTranscriptMessageEvent[] {
   if (count <= 0) {
     return [];
   }
-  const rows = executeSqliteQuerySync(
+  const query = selectHistoricalDisplayEvents(projection, interval).select([
+    "active.event_seq",
+    "event.event_json",
+  ]);
+  const olderCount = anchor.displayPosition - start;
+  // The anchor already identifies the physical position; visit only its selected neighbors.
+  const older = executeSqliteQuerySync(
     projection.database.db,
-    selectHistoricalDisplayEvents(projection, interval)
-      .select(["active.event_seq", "event.event_json"])
+    query
+      .where("active.active_position", "<", anchor.activePosition)
+      .orderBy("active.active_position", "desc")
+      .limit(olderCount),
+  ).rows;
+  const newer = executeSqliteQuerySync(
+    projection.database.db,
+    query
+      .where("active.active_position", ">=", anchor.activePosition)
       .orderBy("active.active_position", "asc")
-      .offset(start)
-      .limit(count),
+      .limit(count - olderCount),
   ).rows;
   return positionTranscriptDisplayEvents(
     projection,
     displaySource,
-    rows.map((row, index) => ({
+    [...older.reverse(), ...newer].map((row, index) => ({
       event: parseStoredTranscriptEvent(row.event_json),
       eventSeq: row.event_seq,
       seq: start + index + 1,
@@ -201,8 +220,18 @@ export function readHistoricalHistoryAnchorPage(
   if (!interval) {
     return undefined;
   }
-  const total = countHistoricalDisplayEvents(projection, interval);
-  const anchorPosition = countHistoricalDisplayEvents(projection, interval, row.active_position);
+  const counts = executeSqliteQueryTakeFirstSync(
+    projection.database.db,
+    selectHistoricalDisplayEvents(projection, interval).select((eb) => [
+      eb.fn.countAll<number>().as("total"),
+      eb.fn
+        .countAll<number>()
+        .filterWhere("active.active_position", "<", row.active_position)
+        .as("before_anchor"),
+    ]),
+  );
+  const total = counts?.total ?? 0;
+  const anchorPosition = counts?.before_anchor ?? 0;
   const pageSize = Math.max(
     1,
     Math.floor(Number.isFinite(options.maxMessages) ? options.maxMessages : 1),
@@ -220,6 +249,7 @@ export function readHistoricalHistoryAnchorPage(
       interval,
       readStart,
       endExclusive - readStart,
+      { activePosition: row.active_position, displayPosition: anchorPosition },
     ),
     found: true,
     hasOverreadContext: readStart < start,

--- a/src/config/sessions/session-accessor.sqlite-history-interval.ts
+++ b/src/config/sessions/session-accessor.sqlite-history-interval.ts
@@ -167,7 +167,7 @@ function readHistoricalDisplayEventRange(
   return positionTranscriptDisplayEvents(
     projection,
     displaySource,
-    [...older.reverse(), ...newer].map((row, index) => ({
+    [...older.toReversed(), ...newer].map((row, index) => ({
       event: parseStoredTranscriptEvent(row.event_json),
       eventSeq: row.event_seq,
       seq: start + index + 1,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where opening a message before a session reset can stall on a large transcript when SQLite has no planner statistics. A synthetic 20,001-event history took 79 seconds to return an anchor page.

## Why This Change Was Made

Use the existing canonical sequence index for historical event identity lookups, preventing repeated session-wide scans. Compute the total and anchor ordinal together, then fetch bounded neighbors around the known physical anchor instead of rescanning with OFFSET. Display visibility, page boundaries, ordinals, and overread context remain unchanged.

## User Impact

Historical message navigation completes promptly even before planner statistics exist. Existing schemas and persisted transcripts require no migration.

## Evidence

- All 22 history owner tests passed on Node 26.8.2, including hidden controls, reset boundaries, malformed/custom payloads, inactive branches, sparse rows, and short pages.
- Same canonical 20,001-event SQLite database, exact page equality: without statistics, original 79,366 ms (one bounded slow sample) → candidate median 30.13 ms / p95 35.18 ms (15 runs).
- With bounded planner optimization already applied, original median 67.00 ms / p95 70.58 ms → candidate 29.96 ms / p95 31.28 ms (15 runs each), about 55% lower median time. Runtime: Node 26.8.2 / SQLite 3.53.4.
- Formatting and diff checks passed. Independent P0–P2 review completed clean. Hosted CI will cover the remaining broad typechecks and repository gates.
