### PR TITLE
fix(doctor): avoid stalls with large recovery inventories

### DIFF
--- a/src/commands/doctor-session-sqlite-recovery-inventory.test.ts
+++ b/src/commands/doctor-session-sqlite-recovery-inventory.test.ts
@@ -1,0 +1,96 @@
+import { performance } from "node:perf_hooks";
+import { describe, expect, it } from "vitest";
+import type { MigrationArtifact } from "./doctor-session-sqlite-artifact.js";
+import type {
+  ActiveSessionSqliteMigrationRun,
+  SessionSqliteMigrationTargetManifest,
+} from "./doctor-session-sqlite-migration-run.js";
+import {
+  protectRecoveryDependencies,
+  type RecoveryArtifactReference,
+  type RecoveryCleanupReport,
+} from "./doctor-session-sqlite-recovery-inventory.js";
+
+function recoveryGraph(transcripts: number) {
+  const target: SessionSqliteMigrationTargetManifest = {
+    agentId: "main",
+    storePath: "/synthetic/sessions/sessions.json",
+    sqlitePath: "/synthetic/agent/openclaw-agent.sqlite",
+    issues: [],
+    validationBeforeArchive: "passed",
+    completedMoves: [],
+    plannedMoves: Array.from({ length: transcripts + 1 }, (_, i) => ({
+      kind: i === 0 ? "legacy-store" : "transcript",
+      sourcePath: `/synthetic/sessions/${i === 0 ? "sessions.json" : `${i}.jsonl`}`,
+      archivePath: `/synthetic/archive/${i}.original`,
+    })),
+  };
+  target.completedMoves = [...target.plannedMoves];
+  const run: ActiveSessionSqliteMigrationRun = {
+    manifestPath: "/synthetic/run.json",
+    manifest: {
+      manifestVersion: 2,
+      openClawVersion: "test",
+      runId: "test",
+      startedAt: "2030-01-01",
+      completedAt: "2030-01-01",
+      targets: [target],
+    },
+  };
+  const refs = new Map<string, RecoveryArtifactReference[]>(
+    target.plannedMoves.map((move) => [
+      move.archivePath,
+      [{ run, target, move, trusted: true, consumedByRestore: false }],
+    ]),
+  );
+  const artifacts: RecoveryCleanupReport["artifacts"] = target.plannedMoves.map((move) => ({
+    path: move.archivePath,
+    runs: ["test"],
+    bytes: 1,
+    outcome: "verification-required",
+    reason: "historical-manifest-without-import-proof",
+  }));
+  artifacts[artifacts.length - 1]!.outcome = "blocked";
+  return { target, refs, artifacts };
+}
+
+describe("recovery dependency inventory", () => {
+  it("protects a large historical index and all siblings within the inventory budget", () => {
+    const { refs, artifacts } = recoveryGraph(10_000);
+    const start = performance.now();
+    protectRecoveryDependencies(artifacts, refs);
+    const elapsed = performance.now() - start;
+    expect(artifacts.filter((item) => item.outcome === "protected")).toHaveLength(10_000);
+    expect(artifacts.at(-1)?.outcome).toBe("blocked");
+    // Ten thousand originals previously took seconds of quadratic graph rebuilding;
+    // this allowance remains orders of magnitude above the linear traversal.
+    expect(elapsed).toBeLessThan(5_000);
+  });
+
+  it.each(["recorded", "adopted"] as const)(
+    "honors an explicitly empty %s dependency list",
+    (evidence) => {
+      const { target, refs, artifacts } = recoveryGraph(2);
+      const artifact: MigrationArtifact = {
+        identity: { dev: "1", ino: "1", mtimeNs: "1", size: 1, sha256: "0".repeat(64) },
+        classification: "imported",
+        reason: "verified-historical-import",
+        dependencies: [],
+        disposal: { state: "retained" },
+      };
+      const indexRef = refs.get(target.plannedMoves[0]!.archivePath)![0]!;
+      const adoptions = new Map<RecoveryArtifactReference, MigrationArtifact>();
+      if (evidence === "recorded") {
+        indexRef.move.artifact = artifact;
+      } else {
+        adoptions.set(indexRef, artifact);
+      }
+      protectRecoveryDependencies(artifacts, refs, adoptions);
+      expect(artifacts.map((item) => item.outcome)).toEqual([
+        "verification-required",
+        "verification-required",
+        "blocked",
+      ]);
+    },
+  );
+});

--- a/src/commands/doctor-session-sqlite-recovery-inventory.ts
+++ b/src/commands/doctor-session-sqlite-recovery-inventory.ts
@@ -364,11 +364,12 @@ export function protectRecoveryDependencies(
   };
   for (const [archive, references] of refs) {
     for (const ref of references.filter(active)) {
-      const moves = uniqueRestoreMoves(ref.target);
       const dependencies =
         (ref.move.artifact ?? adoptions?.get(ref))?.dependencies ??
         (ref.move.kind === "legacy-store"
-          ? moves.filter((move) => move.kind === "transcript").map((move) => move.sourcePath)
+          ? uniqueRestoreMoves(ref.target)
+              .filter((move) => move.kind === "transcript")
+              .map((move) => move.sourcePath)
           : []);
       for (const source of dependencies) {
         for (const dependency of bySource.get(source) ?? []) {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where updates and Doctor could stall on installations with large retained migration inventories. Recovery dependency inspection rebuilt every target's complete move map for every transcript, including transcripts with no dependencies. A 10,000-transcript reproduction took 36 seconds just to build the retention graph.

## Why This Change Was Made

Resolve the target-wide transcript list only for a legacy index that lacks recorded or adopted dependency evidence. Recorded dependencies, explicitly empty lists, historical fallback, consumed/disposed filtering, and transitive protection retain their existing behavior. This removes eager work at the shared inventory owner used by Doctor and cleanup preview.

## User Impact

Large recovery inventories no longer incur this quadratic dependency-discovery cost during Doctor and update. No schema, retention policy, cleanup eligibility, or timeout changes. Separate quadratic work in cleanup application remains a follow-up; this change fixes read-only inventory construction.

## Evidence

- All 239 existing Doctor SQLite tests passed, including historical adoption, recovery dependencies, interrupted disposal, and confirmation races.
- New 10,000-transcript regression: unmodified main failed at 36,008 ms; the fixed test passed in 25 ms, with the index and all sibling dependencies protected.
- Explicitly empty recorded and adopted dependency lists both remain authoritative.
- Independent 6,000-reference benchmark: 10,087 ms before, 5.89 ms after, byte-identical output digest.
- Independent review through P2 and exact-head ClawSweeper review: no actionable findings. Native prepare passed using the successful hosted gate.
- Local changed checks passed initial guards and formatting. After materializing an independent dependency tree, core typecheck stopped on unrelated dependency drift: the available install has `@openclaw/proxyline` 0.3.11 while the lockfile requires 0.3.12 (`ProxyConnectOptions` is absent). Fresh [hosted CI on the exact head](https://github.com/openclaw/openclaw/actions/runs/34678452243) passed the full gate, including production/test types, runtime tests, and Docker seed E2E. Focused changed-file lint passed.

Production: 3 added / 2 removed lines (one removed eager binding; formatting accounts for the net line). Tests: 96 added lines. No new production API or test seam.

### Review follow-through

The final ClawSweeper review requests published-driver-to-candidate validation with a retained inventory. That full update cell is not claimed here. The maintainer review accepts the bounded read-only algorithm proof for this repair: the skipped operation only builds a temporary local Map, existing dependency/protection semantics are unchanged, all 242 focused tests and exact-head hosted CI pass, and the original performance regression is demonstrated. Full deployment verification is tracked separately. This is an explicit deferral of that requested validation/rank-up, not evidence that a complete published-updater run was performed.
