### PR TITLE
feat: apply Claw plugin requirements in one live batch

### DIFF
--- a/docs/cli/claws.md
+++ b/docs/cli/claws.md
@@ -375,6 +375,21 @@ instructions, writes declared workspace assets, realizes workspace skills, and
 records package, MCP, and cron provenance. Existing files are not overwritten,
 and retries fail closed when owned content drifted.
 
+With a local Gateway running, Claw add and update apply their plugin requirements
+before continuing to the agent, workspace, MCP, and cron phases. One bounded
+handoff reloads the affected packages after the package leases have been released;
+it does not restart the Gateway or reload unrelated plugins. A live requirement
+batch supports at most 64 plugin packages. Normal package, capability, and trust
+confirmation still apply.
+
+If installation was saved but runtime activation was not confirmed, the command
+reports that distinction and stops before later phases. Inspect the reported
+error and preview again before retrying. An exact retry reuses the saved package
+and retries activation. Successfully realized shared requirements remain installed
+if a later Claw phase fails. Disabled or metadata-only entries remain unevaluated;
+their source has not been verified by runtime execution. With no local Gateway,
+installation retains the existing restart requirement.
+
 ## Inspect installed state
 
 ```bash

--- a/src/claws/add.ts
+++ b/src/claws/add.ts
@@ -10,6 +10,7 @@ import type { AgentConfig } from "../config/types.agents.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resolvePathViaExistingAncestorSync } from "../infra/boundary-path.js";
 import { normalizeWindowsPathForComparison } from "../infra/path-guards.js";
+import type { PluginInstallBatchReload } from "../plugins/install-runtime-batch.js";
 import { DEFAULT_AGENT_ID, normalizeAgentId } from "../routing/session-key.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { recordAgentProvenance } from "../state/agent-provenance.js";
@@ -54,6 +55,7 @@ export const CLAW_ADD_RESULT_SCHEMA_VERSION = "openclaw.clawAddResult.v1" as con
 
 type ConfigCommit = (transform: (config: OpenClawConfig) => OpenClawConfig) => Promise<void>;
 type ClawAddApplyOptions = OpenClawStateDatabaseOptions & {
+  reloadPlugins?: PluginInstallBatchReload;
   consentPlanIntegrity?: string;
   resumeRecord?: PersistedClawInstall;
   resumePlan?: ClawAddPlan;

--- a/src/claws/package-resume.ts
+++ b/src/claws/package-resume.ts
@@ -12,12 +12,16 @@ import {
 } from "./provenance.js";
 import type { ClawPackage, ClawPackagePreflightResult } from "./types.js";
 
-function ownerInstallIsNewerThanRef(
+export function ownerInstallIsNewerThanRefs(
   installedAt: string | undefined,
-  ref: PersistedClawPackageRef,
+  refs: readonly PersistedClawPackageRef[],
 ): boolean {
   const timestamp = Date.parse(installedAt ?? "");
-  return Number.isFinite(timestamp) && timestamp > ref.updatedAtMs;
+  return (
+    Number.isFinite(timestamp) &&
+    refs.length > 0 &&
+    refs.every((ref) => timestamp > ref.updatedAtMs)
+  );
 }
 
 function persistedExtensionMatchesPreflight(
@@ -79,7 +83,7 @@ export function findResumableIntroducedPluginRequirement(params: {
       !candidate.independentOwner &&
       persistedExtensionMatchesPreflight(candidate, params.preflight),
   );
-  return ref && !ownerInstallIsNewerThanRef(params.preflight.installedAt, ref) ? ref : undefined;
+  return ref && !ownerInstallIsNewerThanRefs(params.preflight.installedAt, [ref]) ? ref : undefined;
 }
 
 export async function readClawResumeStateReadOnly(

--- a/src/claws/package-update.test.ts
+++ b/src/claws/package-update.test.ts
@@ -1,4 +1,14 @@
-import { describe, expect, it, vi } from "vitest";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { ensureInstallTargetAvailable } from "../infra/install-target.js";
+import { commitPluginInstallRecordsWithConfig } from "../plugins/install-record-commit.js";
+import type { installManagedPlugin } from "../plugins/management-mutations.js";
+import { preflightPluginInstall } from "../plugins/plugin-install-preflight.js";
+import { hasPluginLifecycleLease } from "../plugins/plugin-lifecycle-lease.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { withEnvAsync } from "../test-utils/env.js";
 import { digestClawPackageRef } from "./package-update-provenance.js";
 import { applyClawPackageUpdate } from "./package-update.js";
 import { installClawPackages } from "./packages.js";
@@ -10,6 +20,9 @@ import {
   type ResolvedClawPackage,
 } from "./types.js";
 import { CLAW_UPDATE_PLAN_SCHEMA_VERSION, type ClawUpdatePlan } from "./update-plan.js";
+
+const dirs = useAutoCleanupTempDirTracker(afterEach);
+afterEach(closeOpenClawStateDatabaseForTest);
 
 function ref(kind: "skill" | "plugin", name: string, version: string): PersistedClawPackageRef {
   return {
@@ -424,51 +437,170 @@ describe("applyClawPackageUpdate", () => {
     expect(replaceExpected).not.toHaveBeenCalled();
   });
 
-  it("allows only the expected prior version conflict for an owned plugin upgrade", async () => {
-    const previous = ref("plugin", "audit", "0.9.0");
-    const preflightPlugin = vi.fn(async () => ({
-      ok: false as const,
-      code: "plugin_version_conflict" as const,
-      request: {} as never,
-      installedVersion: "0.9.0",
-      expectedVersion: "1.0.0",
-    }));
-    const installPackages = vi.fn(
-      async (_plan: ClawAddPlan, options: Parameters<typeof installClawPackages>[1]) => {
-        expect(options).toBeDefined();
-        const preflight = await options!.deps?.preflightPlugin?.({
+  it.each([false, true])(
+    "retains an owned upgrade through late provenance failure=%s",
+    async (lateFailure) => {
+      const root = dirs.make("claw-owned-upgrade-");
+      const targetDir = path.join(root, "plugins", "audit");
+      await fs.mkdir(targetDir, { recursive: true });
+      const env = {
+        OPENCLAW_STATE_DIR: root,
+        OPENCLAW_CONFIG_PATH: path.join(root, "openclaw.json"),
+      };
+      await fs.writeFile(env.OPENCLAW_CONFIG_PATH, "{}");
+      const integrity = `sha256:${"a".repeat(64)}`;
+      const previous = { ...ref("plugin", "audit", "0.9.0"), integrity };
+      const targetPlan = {
+        ...addPlan,
+        actions: addPlan.actions
+          .filter((action) => action.id === "plugin:audit")
+          .map((action) =>
+            Object.assign({}, action, {
+              details: Object.assign({}, action.details, { integrity }),
+            }),
+          ),
+      };
+      const failure = new Error("late provenance failure");
+      let committed = false;
+      const priorRecords = {
+        audit: {
+          source: "clawhub" as const,
           clawhubPackage: "audit",
-          rawSpec: "clawhub:audit@1.0.0",
-          expectedVersion: "1.0.0",
-        });
-        expect(preflight).toMatchObject({ ok: true, action: "install" });
-        return [ref("plugin", "audit", "1.0.0")];
-      },
-    );
-
-    await expect(
-      applyClawPackageUpdate(
-        plan([
-          {
-            kind: "package",
-            id: "plugin:audit",
-            action: "change",
-            target: "clawhub:audit@1.0.0",
-            blocked: false,
-            reason: "owned upgrade",
-          },
-        ]),
-        manifest,
-        addPlan,
-        {
-          installPackages,
-          readRefs: () => [previous],
-          replaceExpected: vi.fn(),
-          packageDeps: { preflightPlugin },
+          installPath: targetDir,
+          version: "0.9.0",
+          integrity,
         },
-      ),
-    ).resolves.toMatchObject({ appliedIds: ["plugin:audit"] });
-  });
+      };
+      const currentRecords = { audit: { ...priorRecords.audit, version: "1.0.0" } };
+      const uninstallPlugin = vi.fn(async () => {});
+      const reloadPlugins = vi.fn(async () => {
+        expect(hasPluginLifecycleLease()).toBe(false);
+        return { operationId: "upgrade", generation: 4, pluginIds: ["audit"] };
+      });
+      const installPlugin = vi.fn(async (params: Parameters<typeof installManagedPlugin>[0]) => {
+        if (params.request.source !== "clawhub") {
+          throw new Error("expected ClawHub request");
+        }
+        const result = await ensureInstallTargetAvailable({
+          targetDir,
+          mode: params.request.mode ?? "install",
+          alreadyExistsError: "plugin already exists",
+        });
+        if (!result.ok) {
+          throw new Error(result.error);
+        }
+        const write = await commitPluginInstallRecordsWithConfig({
+          previousInstallRecords: priorRecords,
+          nextInstallRecords: currentRecords,
+          nextConfig: {},
+          writeOptions: { afterWrite: { mode: "none", reason: "owned upgrade fixture" } },
+        });
+        params.deferRuntime?.record({
+          operation: "install",
+          pluginId: "audit",
+          sourceDigests: {},
+          write,
+        });
+        committed = true;
+      });
+      await withEnvAsync(env, async () => {
+        await commitPluginInstallRecordsWithConfig({
+          previousInstallRecords: {},
+          nextInstallRecords: priorRecords,
+          nextConfig: {},
+          writeOptions: { afterWrite: { mode: "none", reason: "prior owner fixture" } },
+        });
+        const pending = applyClawPackageUpdate(
+          plan([
+            {
+              kind: "package",
+              id: "plugin:audit",
+              action: "change",
+              target: "clawhub:audit@1.0.0",
+              blocked: false,
+              reason: "owned upgrade",
+            },
+          ]),
+          manifest,
+          targetPlan,
+          {
+            env,
+            reloadPlugins,
+            readRefs: () => [previous],
+            replaceExpected: () => {
+              if (lateFailure && committed) {
+                throw failure;
+              }
+            },
+            runtime: {
+              log: () => {},
+              error: () => {},
+              exit: () => {
+                throw new Error("unexpected exit");
+              },
+            },
+            packageDeps: {
+              installPlugin,
+              uninstallPlugin,
+              readPackageRefs: () => [{ ...previous, version: "1.0.0" }],
+              resolvePlugin: async () => ({
+                status: "found",
+                pluginId: "audit",
+                installedVersion: "1.0.0",
+                record: currentRecords.audit,
+              }),
+              acquirePackageLease: () => ({ heartbeat: () => {}, release: () => {} }),
+              preflightPlugin: (params) =>
+                preflightPluginInstall({
+                  ...params,
+                  loadInstallRecords: async () => ({
+                    audit: { source: "clawhub", clawhubPackage: "audit", version: "0.9.0" },
+                  }),
+                }),
+              probePlugin: async (params) => {
+                const probeTarget = path.join(
+                  params.extensionsDir ?? path.dirname(targetDir),
+                  "audit",
+                );
+                const available = await ensureInstallTargetAvailable({
+                  targetDir: probeTarget,
+                  mode: params.mode ?? "install",
+                  alreadyExistsError: "plugin already exists",
+                });
+                if (!available.ok) {
+                  return available;
+                }
+                return {
+                  ok: true,
+                  pluginId: "audit",
+                  packageName: "audit",
+                  targetDir: probeTarget,
+                  extensions: [],
+                  clawhub: {
+                    source: "clawhub",
+                    clawhubFamily: "code-plugin",
+                    clawhubUrl: "https://clawhub.ai",
+                    clawhubPackage: "audit",
+                    integrity,
+                  },
+                };
+              },
+            },
+          },
+        );
+        if (lateFailure) {
+          const error = await pending.catch((reason: unknown) => reason);
+          expect(uninstallPlugin).not.toHaveBeenCalled();
+          expect(error).toMatchObject({ partial: true, cause: { cause: failure } });
+        } else {
+          await expect(pending).resolves.toMatchObject({ appliedIds: ["plugin:audit"] });
+        }
+        expect(installPlugin).toHaveBeenCalledOnce();
+        expect(uninstallPlugin).not.toHaveBeenCalled();
+        expect(reloadPlugins).toHaveBeenCalledOnce();
+      });
+    },
+  );
 
   it("rejects an owned plugin upgrade when another owner appears before install", async () => {
     const previous = ref("plugin", "audit", "0.9.0");

--- a/src/claws/package-update.ts
+++ b/src/claws/package-update.ts
@@ -1,13 +1,12 @@
 import { createHash } from "node:crypto";
 import { coerceErrorMessage, stableStringify } from "@openclaw/normalization-core";
 import { preflightPluginInstall } from "../plugins/plugin-install-preflight.js";
-import type { RuntimeEnv } from "../runtime.js";
-import type { OpenClawStateDatabaseOptions } from "../state/openclaw-state-db.js";
 import {
   digestClawPackageRef,
   replaceClawPackageRefExpected,
 } from "./package-update-provenance.js";
 import { installClawPackages } from "./packages.js";
+import type { ClawPluginRuntimeOptions } from "./plugin-runtime.js";
 import {
   CLAW_PACKAGE_REF_SCHEMA_VERSION,
   readClawPackageRefs,
@@ -30,8 +29,9 @@ export class ClawPackageUpdateError extends Error {
   constructor(
     message: string,
     readonly partial: boolean,
+    options?: ErrorOptions,
   ) {
-    super(message);
+    super(message, options);
     this.name = "ClawPackageUpdateError";
   }
 }
@@ -48,12 +48,11 @@ export async function applyClawPackageUpdate(
   updatePlan: ClawUpdatePlan,
   _targetManifest: ClawManifest,
   targetAddPlan: ClawAddPlan,
-  options: OpenClawStateDatabaseOptions & {
+  options: ClawPluginRuntimeOptions & {
     installPackages?: typeof installClawPackages;
     readRefs?: typeof readClawPackageRefs;
     replaceExpected?: typeof replaceClawPackageRefExpected;
     packageDeps?: PackageInstallerDeps;
-    runtime?: RuntimeEnv;
     nowMs?: number;
   },
 ): Promise<ClawPackageUpdateExecution> {
@@ -194,6 +193,7 @@ export async function applyClawPackageUpdate(
         { ...targetAddPlan, actions: [targetAction] },
         {
           ...options,
+          pluginInstallMode: action.action === "change" ? "update" : "install",
           deps: {
             ...options.packageDeps,
             preflightPlugin: async (params) => {
@@ -269,6 +269,7 @@ export async function applyClawPackageUpdate(
       throw new ClawPackageUpdateError(
         `${coerceErrorMessage(error)}; package artifact outcome requires reconciliation`,
         true,
+        { cause: error },
       );
     }
     try {
@@ -277,11 +278,13 @@ export async function applyClawPackageUpdate(
       throw new ClawPackageUpdateError(
         `${coerceErrorMessage(error)}; rollback incomplete: ${coerceErrorMessage(rollbackError)}`,
         externalMutations.length > 0,
+        { cause: new AggregateError([error, rollbackError]) },
       );
     }
     throw new ClawPackageUpdateError(
       coerceErrorMessage(error),
       error instanceof ClawPackageUpdateError ? error.partial : false,
+      { cause: error },
     );
   }
   return { appliedIds, rollback };

--- a/src/claws/packages.runtime.test.ts
+++ b/src/claws/packages.runtime.test.ts
@@ -1,0 +1,282 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import type { PluginInstallRecord } from "../config/types.plugins.js";
+import { commitPluginInstallRecordsWithConfig } from "../plugins/install-record-commit.js";
+import type { PluginInstallBatchReload } from "../plugins/install-runtime-batch.js";
+import { preflightPluginInstall } from "../plugins/plugin-install-preflight.js";
+import { hasPluginLifecycleLease } from "../plugins/plugin-lifecycle-lease.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { withEnvAsync } from "../test-utils/env.js";
+import { installClawPackages } from "./packages.js";
+import { packageInstallPlan } from "./packages.test-support.js";
+
+const installOwner = vi.hoisted(() => ({
+  install: vi.fn(),
+  failure: new Error("artifact owner rejected the installation"),
+}));
+vi.mock("../plugins/management-mutations.js", () => ({
+  installManagedPlugin: installOwner.install,
+}));
+
+const dirs = useAutoCleanupTempDirTracker(afterEach);
+afterEach(() => closeOpenClawStateDatabaseForTest());
+const integrity = `sha256:${"a".repeat(64)}`;
+
+describe("Claw committed plugin requirement handoff", () => {
+  it("preserves the install owner's failure instead of a nested CLI exit", async () => {
+    const root = dirs.make("openclaw-claw-install-error-");
+    const env = {
+      OPENCLAW_STATE_DIR: root,
+      OPENCLAW_CONFIG_PATH: path.join(root, "openclaw.json"),
+    };
+    await fs.writeFile(env.OPENCLAW_CONFIG_PATH, "{}");
+    installOwner.install.mockReset().mockRejectedValue(installOwner.failure);
+    await withEnvAsync(env, async () => {
+      const result = await installClawPackages(
+        packageInstallPlan([
+          { kind: "plugin", source: "clawhub", ref: "@owner/demo", version: "1.0.0", integrity },
+        ]),
+        {
+          env,
+          runtime: {
+            log: () => {},
+            error: () => {},
+            exit: () => {
+              throw new Error("unexpected outer exit");
+            },
+          },
+          deps: {
+            acquirePackageLease: () => ({ heartbeat: () => {}, release: () => {} }),
+            preflightPlugin: (params) =>
+              preflightPluginInstall({ ...params, loadInstallRecords: async () => ({}) }),
+            probePlugin: async () => ({
+              ok: true,
+              pluginId: "demo",
+              packageName: "@owner/demo",
+              targetDir: root,
+              extensions: [],
+              clawhub: {
+                source: "clawhub",
+                clawhubFamily: "code-plugin",
+                clawhubUrl: "https://clawhub.ai",
+                clawhubPackage: "@owner/demo",
+                integrity,
+              },
+            }),
+            persistPackageRef: () => ({
+              schemaVersion: "openclaw.clawPackageRef.v1",
+              agentId: "incident-2",
+              clawName: "incident-claw",
+              kind: "plugin",
+              source: "clawhub",
+              ref: "@owner/demo",
+              version: "1.0.0",
+              integrity,
+              status: "pending",
+              relationship: "referenced",
+              origin: "claw-introduced",
+              independentOwner: false,
+              installedAtMs: 1,
+              updatedAtMs: 1,
+            }),
+            completePackageRef: (ref, status) => ({ ...ref, status }),
+          },
+        },
+      ).catch((error: unknown) => error);
+      expect(installOwner.install).toHaveBeenCalledOnce();
+      expect(result).toMatchObject({
+        code: "package_install_failed",
+        message: installOwner.failure.message,
+        cause: installOwner.failure,
+      });
+    });
+  });
+  it.each([false, true])(
+    "applies retained writes once after lease release (late failure=%s)",
+    async (lateFailure) => {
+      const root = dirs.make("openclaw-claw-runtime-");
+      const env = {
+        OPENCLAW_STATE_DIR: root,
+        OPENCLAW_CONFIG_PATH: path.join(root, "openclaw.json"),
+        OPENCLAW_BUNDLED_PLUGINS_DIR: path.join(root, "bundled"),
+      };
+      await fs.writeFile(env.OPENCLAW_CONFIG_PATH, "{}");
+      await withEnvAsync(env, async () => {
+        let records: Record<string, PluginInstallRecord> = {};
+        let heldPackages = 0;
+        const cleanup = vi.fn();
+        const log = vi.fn();
+        const reloadPlugins = vi.fn<PluginInstallBatchReload>(async (targets) => {
+          expect(hasPluginLifecycleLease()).toBe(false);
+          expect(heldPackages).toBe(0);
+          expect(cleanup).not.toHaveBeenCalled();
+          expect(targets.map((target: { pluginId: string }) => target.pluginId)).toEqual(
+            lateFailure ? ["first"] : ["first", "second"],
+          );
+          return {
+            operationId: "batch",
+            generation: 2,
+            pluginIds: targets.map((target: { pluginId: string }) => target.pluginId),
+            warnings: ["Previous plugin cleanup did not finish."],
+          };
+        });
+        const options: NonNullable<Parameters<typeof installClawPackages>[1]> = {
+          env,
+          runtime: {
+            log,
+            error: () => {},
+            exit: () => {
+              throw new Error("unexpected exit");
+            },
+          },
+          reloadPlugins,
+          deps: {
+            acquirePackageLease: () => {
+              heldPackages++;
+              return {
+                heartbeat: () => true,
+                release: () => {
+                  heldPackages--;
+                },
+              };
+            },
+            preflightPlugin: (params) =>
+              preflightPluginInstall({ ...params, loadInstallRecords: async () => records }),
+            probePlugin: async ({ spec }) => ({
+              ok: true,
+              packageName: spec,
+              pluginId: spec.includes("first") ? "first" : "second",
+              targetDir: root,
+              extensions: [],
+              clawhub: {
+                source: "clawhub",
+                clawhubFamily: "code-plugin",
+                clawhubUrl: "https://clawhub.ai",
+                clawhubPackage: spec,
+                integrity,
+              },
+            }),
+            persistPackageRef: (plan, pkg, persistOptions) => ({
+              schemaVersion: "openclaw.clawPackageRef.v1",
+              agentId: plan.agent.finalId,
+              clawName: plan.claw.name,
+              kind: pkg.kind,
+              source: pkg.source,
+              ref: pkg.ref,
+              version: pkg.version!,
+              integrity: pkg.integrity!,
+              status: persistOptions?.status ?? "pending",
+              relationship: "referenced",
+              origin: "claw-introduced",
+              independentOwner: false,
+              installedAtMs: 1,
+              updatedAtMs: 1,
+            }),
+            completePackageRef: (ref, status) => ({ ...ref, status }),
+            installPlugin: async (params) => {
+              if (params.request.source !== "clawhub" || !params.request.expectedPluginId) {
+                throw new Error("Expected a pinned ClawHub plugin request");
+              }
+              const pluginId = params.request.expectedPluginId;
+              const next = {
+                ...records,
+                [pluginId]: {
+                  source: "clawhub" as const,
+                  clawhubPackage: `@owner/${pluginId}`,
+                  version: "1.0.0",
+                  integrity,
+                  installPath: path.join(root, "plugins", pluginId),
+                },
+              };
+              const write = await commitPluginInstallRecordsWithConfig({
+                previousInstallRecords: records,
+                nextInstallRecords: next,
+                nextConfig: {},
+                writeOptions: { afterWrite: { mode: "none", reason: "batch fixture" } },
+              });
+              records = next;
+              params.deferRuntime?.record({
+                operation: "install",
+                pluginId,
+                sourceDigests: {},
+                write,
+              });
+              params.deferRuntime?.deferCleanup(
+                async (assertOwned, warn) => {
+                  assertOwned();
+                  cleanup(pluginId);
+                  warn(`Source cleanup warning for ${pluginId}`);
+                },
+                path.join(root, "retired", pluginId),
+              );
+              if (lateFailure) {
+                throw new Error("postcommit metadata failure");
+              }
+            },
+          },
+        };
+        const pending = installClawPackages(
+          packageInstallPlan(
+            ["first", "second"].map((id) => ({
+              kind: "plugin",
+              source: "clawhub",
+              ref: `@owner/${id}`,
+              version: "1.0.0",
+              integrity,
+            })),
+          ),
+          options,
+        );
+        let completed: Awaited<typeof pending> | undefined;
+        if (lateFailure) {
+          await expect(pending).rejects.toMatchObject({
+            code: "package_install_failed",
+            message: "postcommit metadata failure",
+          });
+        } else {
+          completed = await pending;
+          expect(completed).toHaveLength(2);
+        }
+        expect(reloadPlugins).toHaveBeenCalledOnce();
+        expect(log).toHaveBeenCalledWith("Previous plugin cleanup did not finish.");
+        expect(cleanup).toHaveBeenCalledTimes(lateFailure ? 1 : 2);
+        expect(log).toHaveBeenCalledWith("Source cleanup warning for first");
+        if (completed) {
+          const installedRefs = completed;
+          cleanup.mockClear();
+          const installPlugin = vi.fn(async () => {
+            throw new Error("resumed requirement was reinstalled");
+          });
+          const resumedOptions = {
+            ...options,
+            deps: {
+              ...options.deps,
+              installPlugin,
+              readPackageRefs: () => installedRefs,
+            },
+          };
+          const resumedPlan = packageInstallPlan(
+            ["first", "second"].map((id) => ({
+              kind: "plugin",
+              source: "clawhub",
+              ref: `@owner/${id}`,
+              version: "1.0.0",
+              integrity,
+            })),
+          );
+          reloadPlugins.mockRejectedValueOnce(new Error("runtime reply lost"));
+          await expect(installClawPackages(resumedPlan, resumedOptions)).rejects.toMatchObject({
+            code: "package_runtime_failed",
+            message: expect.stringContaining("Runtime activation was not confirmed"),
+          });
+          await expect(installClawPackages(resumedPlan, resumedOptions)).resolves.toHaveLength(2);
+          expect(installPlugin).not.toHaveBeenCalled();
+          expect(cleanup).not.toHaveBeenCalled();
+          expect(reloadPlugins).toHaveBeenCalledTimes(3);
+        }
+      });
+    },
+  );
+});

--- a/src/claws/packages.test-support.ts
+++ b/src/claws/packages.test-support.ts
@@ -1,0 +1,57 @@
+import type { ClawAddPlan, ResolvedClawPackage } from "./types.js";
+
+export function packageInstallPlan(
+  packages: ResolvedClawPackage[],
+  ownerAction: "install" | "reuse" = "install",
+): ClawAddPlan {
+  return {
+    schemaVersion: "openclaw.clawAddPlan.v1",
+    manifestSchemaVersion: 1,
+    stability: "experimental",
+    dryRun: true,
+    mutationAllowed: false,
+    planIntegrity: "sha256:plan",
+    claw: {
+      kind: "package",
+      name: "incident-claw",
+      version: "1.0.0",
+      packageRoot: "/tmp/claw",
+      manifestPath: "/tmp/claw/claw.json",
+      integrityKind: "artifact",
+      integrity: "sha256:claw",
+      byteLength: 123,
+    },
+    agent: {
+      requestedId: "incident",
+      finalId: "incident-2",
+      workspace: "/tmp/incident-2",
+      config: { id: "incident-2", workspace: "/tmp/incident-2" },
+    },
+    summary: {
+      totalActions: packages.length,
+      agentActions: 0,
+      workspaceActions: 0,
+      packageActions: packages.length,
+      mcpServerActions: 0,
+      cronJobActions: 0,
+      blockedActions: 0,
+      capabilityEscalations: 0,
+    },
+    capabilityChanges: [],
+    actions: packages.map((pkg) => ({
+      kind: "package",
+      id: `${pkg.kind}:${pkg.ref}`,
+      action: "install",
+      target: `${pkg.source}:${pkg.ref}@${pkg.version}`,
+      details: {
+        ...pkg,
+        ownerAction,
+        ...(pkg.kind === "plugin" ? { installId: pkg.ref.split("/").at(-1) } : {}),
+      },
+      blocked: false,
+    })),
+    readiness: { ready: true, requirements: [] },
+    blockers: [],
+    diagnostics: [],
+  };
+}

--- a/src/claws/packages.test.ts
+++ b/src/claws/packages.test.ts
@@ -4,64 +4,8 @@ import { join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import { PLUGIN_ARTIFACT_ADAPTER_IDENTITY } from "../plugins/install-artifact-inspection.js";
 import { installClawPackages, preflightClawPackage } from "./packages.js";
+import { packageInstallPlan as plan } from "./packages.test-support.js";
 import type { PersistedClawPackageRef } from "./provenance.js";
-import type { ClawAddPlan, ResolvedClawPackage } from "./types.js";
-
-function plan(
-  packages: ResolvedClawPackage[],
-  ownerAction: "install" | "reuse" = "install",
-): ClawAddPlan {
-  return {
-    schemaVersion: "openclaw.clawAddPlan.v1",
-    manifestSchemaVersion: 1,
-    stability: "experimental",
-    dryRun: true,
-    mutationAllowed: false,
-    planIntegrity: "sha256:plan",
-    claw: {
-      kind: "package",
-      name: "incident-claw",
-      version: "1.0.0",
-      packageRoot: "/tmp/claw",
-      manifestPath: "/tmp/claw/claw.json",
-      integrityKind: "artifact",
-      integrity: "sha256:claw",
-      byteLength: 123,
-    },
-    agent: {
-      requestedId: "incident",
-      finalId: "incident-2",
-      workspace: "/tmp/incident-2",
-      config: { id: "incident-2", workspace: "/tmp/incident-2" },
-    },
-    summary: {
-      totalActions: packages.length,
-      agentActions: 0,
-      workspaceActions: 0,
-      packageActions: packages.length,
-      mcpServerActions: 0,
-      cronJobActions: 0,
-      blockedActions: 0,
-      capabilityEscalations: 0,
-    },
-    capabilityChanges: [],
-    actions: packages.map((pkg) => ({
-      kind: "package",
-      id: `${pkg.kind}:${pkg.ref}`,
-      action: "install",
-      target: `${pkg.source}:${pkg.ref}@${pkg.version}`,
-      details: {
-        ...pkg,
-        ownerAction,
-        ...(pkg.kind === "plugin" ? { installId: pkg.ref.split("/").at(-1) } : {}),
-      },
-      blocked: false,
-    })),
-    readiness: { ready: true, requirements: [] },
-    blockers: [],
-    diagnostics: [],
-  };
-}
 
 const integrity = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
 const pluginPackage = {
@@ -522,9 +466,11 @@ describe("installClawPackages", () => {
 
     expect(installPlugin).toHaveBeenCalledWith(
       expect.objectContaining({
-        raw: "clawhub:@owner/audit@2.0.1",
-        allowInstallPolicyWarningPrompt: false,
-        opts: {
+        request: {
+          source: "clawhub",
+          packageName: "@owner/audit",
+          version: "2.0.1",
+          mode: "install",
           expectedIntegrity:
             "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
           expectedPluginId: "audit",
@@ -532,9 +478,6 @@ describe("installClawPackages", () => {
         invalidateRuntimeCache: false,
         clawManaged: true,
       }),
-    );
-    expect(probePlugin).toHaveBeenCalledWith(
-      expect.not.objectContaining({ extensionsDir: expect.anything() }),
     );
     expect(persistPackageRef).toHaveBeenCalledWith(
       expect.anything(),
@@ -875,9 +818,12 @@ describe("installClawPackages", () => {
     ).rejects.toMatchObject({ code: "package_install_failed", message: "second install failed" });
 
     expect(uninstallPlugin).toHaveBeenCalledWith(
-      "first",
-      { force: true, invalidateRuntimeCache: false, clawManaged: true },
-      expect.anything(),
+      expect.objectContaining({
+        pluginId: "first",
+        caller: "cli",
+        invalidateRuntimeCache: false,
+        clawManaged: true,
+      }),
     );
     expect(completePackageRef).toHaveBeenCalledWith(
       expect.objectContaining({ ref: "@owner/first" }),

--- a/src/claws/packages.ts
+++ b/src/claws/packages.ts
@@ -2,26 +2,31 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { coerceErrorMessage, stableStringify } from "@openclaw/normalization-core";
-import { runPluginInstallCommand } from "../cli/plugins-install-command.js";
-import { runPluginUninstallCommand } from "../cli/plugins-uninstall-command.js";
+import { resolveClawHubInstallConfirmation } from "../cli/clawhub-install-confirmation.js";
+import { resolvePluginCapabilityConsentCliOptions } from "../cli/plugin-capability-consent.js";
+import { createPluginInstallLogger } from "../cli/plugins-command-helpers.js";
 import { normalizeClawHubSha256Integrity } from "../infra/clawhub-integrity.js";
 import { installPluginFromClawHub } from "../plugins/clawhub.js";
 import { PLUGIN_ARTIFACT_ADAPTER_IDENTITY } from "../plugins/install-artifact-inspection.js";
+import { installManagedPlugin } from "../plugins/management-mutations.js";
+import { uninstallPluginWithPolicy } from "../plugins/management-uninstall.js";
 import {
   preflightPluginInstall,
   resolveInstalledClawHubPlugin,
 } from "../plugins/plugin-install-preflight.js";
-import { withPluginLifecycleLease } from "../plugins/plugin-lifecycle-lease.js";
-import { defaultRuntime, type RuntimeEnv } from "../runtime.js";
+import { defaultRuntime } from "../runtime.js";
 import { installSkillFromClawHub, preflightSkillFromClawHub } from "../skills/lifecycle/clawhub.js";
 import {
   acquireClawPackageLifecycleLease,
   maintainClawPackageLifecycleLease,
   type MaintainedClawPackageLifecycleLease,
 } from "../state/claw-package-lifecycle-lease.js";
-import type { OpenClawStateDatabaseOptions } from "../state/openclaw-state-db.js";
-import { findResumableIntroducedPluginRequirement } from "./package-resume.js";
+import {
+  findResumableIntroducedPluginRequirement,
+  ownerInstallIsNewerThanRefs,
+} from "./package-resume.js";
 import { resolveClawPluginSetupRequirements } from "./package-setup-requirements.js";
+import { runClawPluginBatch, type ClawPluginRuntimeOptions } from "./plugin-runtime.js";
 import {
   persistClawPackageRef,
   readClawPackageRefs,
@@ -41,15 +46,16 @@ export class ClawPackageInstallError extends Error {
     readonly code: string,
     message: string,
     readonly installedPackages: PersistedClawPackageRef[],
+    options?: ErrorOptions,
   ) {
-    super(message);
+    super(message, options);
     this.name = "ClawPackageInstallError";
   }
 }
 
 type PackageInstallerDeps = {
-  installPlugin?: typeof runPluginInstallCommand;
-  uninstallPlugin?: typeof runPluginUninstallCommand;
+  installPlugin?: (params: Parameters<typeof installManagedPlugin>[0]) => Promise<void>;
+  uninstallPlugin?: (params: Parameters<typeof uninstallPluginWithPolicy>[0]) => Promise<void>;
   probePlugin?: typeof installPluginFromClawHub;
   installSkill?: typeof installSkillFromClawHub;
   preflightPlugin?: typeof preflightPluginInstall;
@@ -107,28 +113,6 @@ function packageFromAction(action: ClawAddPlanAction): PlannedClawPackage {
   };
 }
 
-function installerRuntime(runtime: RuntimeEnv): RuntimeEnv {
-  return {
-    log: (value) => runtime.log(value),
-    error: (value) => runtime.error(value),
-    exit: (code) => {
-      throw new Error(`Plugin installer exited with code ${code}.`);
-    },
-  };
-}
-
-function ownerInstallIsNewerThanRefs(
-  installedAt: string | undefined,
-  refs: PersistedClawPackageRef[],
-): boolean {
-  const timestamp = Date.parse(installedAt ?? "");
-  return (
-    Number.isFinite(timestamp) &&
-    refs.length > 0 &&
-    refs.every((candidate) => timestamp > candidate.updatedAtMs)
-  );
-}
-
 type ClawPluginProbeDeps = {
   probePlugin?: typeof installPluginFromClawHub;
   createProbeExtensionsDir?: () => Promise<string>;
@@ -148,18 +132,14 @@ async function probeClawPluginArtifact(
   if (!isolateFromLiveExtensions) {
     return await probePlugin(request);
   }
-  const probeExtensionsDir = await (
-    deps.createProbeExtensionsDir ??
-    (async () => await mkdtemp(join(tmpdir(), "openclaw-claw-plugin-probe-")))
-  )();
+  const probeExtensionsDir = await (deps.createProbeExtensionsDir?.() ??
+    mkdtemp(join(tmpdir(), "openclaw-claw-plugin-probe-")));
   try {
     return await probePlugin({ ...request, extensionsDir: probeExtensionsDir });
   } finally {
     try {
-      await (
-        deps.removeProbeExtensionsDir ??
-        (async (path: string) => await rm(path, { recursive: true, force: true }))
-      )(probeExtensionsDir);
+      await (deps.removeProbeExtensionsDir?.(probeExtensionsDir) ??
+        rm(probeExtensionsDir, { recursive: true, force: true }));
     } catch {
       // Temporary probe cleanup must not replace the canonical preflight result.
     }
@@ -277,9 +257,9 @@ export async function preflightClawPackage(
   };
 }
 
-type InstallClawPackagesOptions = OpenClawStateDatabaseOptions & {
+type InstallClawPackagesOptions = ClawPluginRuntimeOptions & {
   deps?: PackageInstallerDeps;
-  runtime?: RuntimeEnv;
+  pluginInstallMode?: "install" | "update";
   nowMs?: number;
   onExternalMutation?: (pkg: ClawPackage) => void;
 };
@@ -288,19 +268,28 @@ export async function installClawPackages(
   plan: ClawAddPlan,
   options: InstallClawPackagesOptions = {},
 ): Promise<PersistedClawPackageRef[]> {
-  const includesPlugin = plan.actions.some(
+  const pluginCount = plan.actions.filter(
     (action) => action.kind === "package" && action.details?.kind === "plugin",
-  );
-  if (!includesPlugin) {
+  ).length;
+  if (!pluginCount) {
     return await installClawPackagesUnlocked(plan, options);
   }
-  return await withPluginLifecycleLease(
-    {
-      ...(options.env ? { env: options.env } : {}),
-      ...(options.path ? { path: options.path } : {}),
-      ...(options.database ? { database: options.database } : {}),
+  return await runClawPluginBatch(
+    options,
+    pluginCount,
+    (runtimeBatch) => installClawPackagesUnlocked(plan, { ...options, runtimeBatch }),
+    (failure, operation) => {
+      const original =
+        !operation.ok && operation.error instanceof ClawPackageInstallError
+          ? operation.error
+          : undefined;
+      return new ClawPackageInstallError(
+        original?.code ?? "package_runtime_failed",
+        [original?.message, coerceErrorMessage(failure)].filter(Boolean).join("\n"),
+        original?.installedPackages ?? (operation.ok ? operation.value : []),
+        { cause: !operation.ok ? new AggregateError([operation.error, failure]) : failure },
+      );
     },
-    async () => await installClawPackagesUnlocked(plan, options),
   );
 }
 
@@ -309,9 +298,28 @@ async function installClawPackagesUnlocked(
   options: InstallClawPackagesOptions,
 ): Promise<PersistedClawPackageRef[]> {
   const deps = options.deps ?? {};
-  const installPlugin = deps.installPlugin ?? runPluginInstallCommand;
-  const uninstallPlugin = deps.uninstallPlugin ?? runPluginUninstallCommand;
-  const probePlugin = deps.probePlugin ?? installPluginFromClawHub;
+  const runtime = options.runtime ?? defaultRuntime;
+  const installPlugin =
+    deps.installPlugin ??
+    (async (params) => {
+      const result = await installManagedPlugin(params);
+      for (const warning of result.warnings ?? []) {
+        runtime.log(warning);
+      }
+      runtime.log(`Installed plugin requirement: ${result.plugin.id}`);
+      if (!params.deferRuntime && !params.applyRuntime) {
+        runtime.log("Restart the gateway to load plugins.");
+      }
+    });
+  const uninstallPlugin =
+    deps.uninstallPlugin ??
+    (async (params) => {
+      const result = await uninstallPluginWithPolicy(params);
+      if (!result.ok) {
+        throw new Error(result.error);
+      }
+      runtime.log(`Rolled back plugin requirement: ${result.value.pluginId}`);
+    });
   const installSkill = deps.installSkill ?? installSkillFromClawHub;
   const preflightPlugin = deps.preflightPlugin ?? preflightPluginInstall;
   const preflightSkill = deps.preflightSkill ?? preflightSkillFromClawHub;
@@ -320,7 +328,6 @@ async function installClawPackagesUnlocked(
   const readPackageRefs = deps.readPackageRefs ?? readClawPackageRefs;
   const acquirePackageLease = deps.acquirePackageLease ?? acquireClawPackageLifecycleLease;
   const resolvePlugin = deps.resolvePlugin ?? resolveInstalledClawHubPlugin;
-  const runtime = options.runtime ?? defaultRuntime;
   const installedPackages: PersistedClawPackageRef[] = [];
   const installedPlugins: Array<{ installId: string; packageIndex: number }> = [];
 
@@ -445,8 +452,8 @@ async function installClawPackagesUnlocked(
           installedPackages,
         );
       }
-      const probe = await probeClawPluginArtifact(pkg, preflight.action === "reuse", {
-        probePlugin,
+      const probe = await probeClawPluginArtifact(pkg, true, {
+        probePlugin: deps.probePlugin,
       });
       packageLease.assertCurrent();
       if (!probe.ok) {
@@ -485,13 +492,6 @@ async function installClawPackagesUnlocked(
           installedPackages,
         );
       }
-      if (!pkg.installId) {
-        throw new ClawPackageInstallError(
-          "plugin_identity_unresolved",
-          `Plugin ${pkg.ref}@${pkg.version} has no resolved install identity.`,
-          installedPackages,
-        );
-      }
       if (preflight.action === "reuse") {
         if (
           preflight.installedId !== pkg.installId ||
@@ -506,6 +506,7 @@ async function installClawPackagesUnlocked(
           );
         }
         if (resumableRequirement) {
+          options.runtimeBatch?.retain(probe.pluginId);
           installedPackages.push(
             persistPackageRef(plan, pkg, {
               ...options,
@@ -555,20 +556,30 @@ async function installClawPackagesUnlocked(
       // after an on-disk change is treated as uncertain instead of falsely reported as rolled back.
       options.onExternalMutation?.(pkg);
       await installPlugin({
-        raw: `clawhub:${pkg.ref}@${pkg.version}`,
-        allowInstallPolicyWarningPrompt: false,
-        opts: {
+        request: {
+          source: "clawhub",
+          packageName: pkg.ref,
+          version: pkg.version,
+          mode: options.pluginInstallMode ?? "install",
           expectedIntegrity: pkg.integrity,
-          expectedPluginId: pkg.installId,
+          expectedPluginId: probe.pluginId,
         },
+        env: options.env,
+        beforePersistentApply: packageLease.assertCurrent,
+        logger: createPluginInstallLogger(runtime),
+        confirmInstall: resolveClawHubInstallConfirmation(),
+        ...resolvePluginCapabilityConsentCliOptions({ action: "install", runtime }),
         invalidateRuntimeCache: false,
         clawManaged: true,
-        runtime: installerRuntime(runtime),
+        deferRuntime: options.runtimeBatch?.install(),
       });
-      installedPlugins.push({
-        installId: pkg.installId,
-        packageIndex: installedPackages.length - 1,
-      });
+      // A committed upgrade cannot restore its previous payload; retain it for reconciliation.
+      if (options.pluginInstallMode !== "update") {
+        installedPlugins.push({
+          installId: probe.pluginId,
+          packageIndex: installedPackages.length - 1,
+        });
+      }
       packageLease.assertCurrent();
       packageRef = completePackageRef(packageRef, "complete", options);
       installedPackages[installedPackages.length - 1] = packageRef;
@@ -657,11 +668,15 @@ async function installClawPackagesUnlocked(
             );
             continue;
           }
-          await uninstallPlugin(
-            installedPlugin.installId,
-            { force: true, invalidateRuntimeCache: false, clawManaged: true },
-            installerRuntime(runtime),
-          );
+          await uninstallPlugin({
+            pluginId: installedPlugin.installId,
+            caller: "cli",
+            invalidateRuntimeCache: false,
+            clawManaged: true,
+            beforePersistentApply: rollbackLease.assertCurrent,
+            onWarning: (warning) => runtime.log(warning),
+            deferRuntime: options.runtimeBatch?.install(),
+          });
           rollbackLease.assertCurrent();
           installedPackages[installedPlugin.packageIndex] = completePackageRef(
             installedPackages[installedPlugin.packageIndex] ?? packageRef,
@@ -687,12 +702,15 @@ async function installClawPackagesUnlocked(
           "package_rollback_failed",
           `${message} Rollback incomplete: ${rollbackErrors.join("; ")}.`,
           installedPackages,
+          { cause: error },
         );
       }
-      if (error instanceof ClawPackageInstallError) {
-        throw new ClawPackageInstallError(error.code, error.message, installedPackages);
-      }
-      throw new ClawPackageInstallError("package_install_failed", message, installedPackages);
+      throw new ClawPackageInstallError(
+        error instanceof ClawPackageInstallError ? error.code : "package_install_failed",
+        message,
+        installedPackages,
+        { cause: error },
+      );
     } finally {
       try {
         packageLease?.release();

--- a/src/claws/plugin-runtime.ts
+++ b/src/claws/plugin-runtime.ts
@@ -1,0 +1,67 @@
+import { err, ok, type Result } from "@openclaw/normalization-core/result";
+import { MAX_PLUGIN_RELOAD_TARGETS } from "../../packages/gateway-protocol/src/schema/plugins.js";
+import {
+  PluginInstallRuntimeBatch,
+  type PluginInstallBatchReload,
+} from "../plugins/install-runtime-batch.js";
+import { withPluginLifecycleLease } from "../plugins/plugin-lifecycle-lease.js";
+import { defaultRuntime, type RuntimeEnv } from "../runtime.js";
+import type { OpenClawStateDatabaseOptions } from "../state/openclaw-state-db.js";
+
+export type ClawPluginRuntimeOptions = OpenClawStateDatabaseOptions & {
+  reloadPlugins?: PluginInstallBatchReload;
+  /** The enclosing requirement phase owns nested package installs and compensation. */
+  runtimeBatch?: PluginInstallRuntimeBatch;
+  runtime?: RuntimeEnv;
+};
+
+export async function runClawPluginBatch<T>(
+  options: ClawPluginRuntimeOptions,
+  pluginCount: number,
+  run: (batch: PluginInstallRuntimeBatch | undefined) => Promise<T>,
+  runtimeFailure: (failure: unknown, operation: Result<T, unknown>) => Error,
+): Promise<T> {
+  if (!options.reloadPlugins || options.runtimeBatch) {
+    return await withPluginLifecycleLease(options, () => run(options.runtimeBatch));
+  }
+  if (pluginCount > MAX_PLUGIN_RELOAD_TARGETS) {
+    throw new Error(
+      `A live Claw requirement batch supports at most ${MAX_PLUGIN_RELOAD_TARGETS} plugin packages. Split the requirement batch before installing.`,
+    );
+  }
+  const batch = new PluginInstallRuntimeBatch(options, options.reloadPlugins);
+  let completed: Result<T, unknown> | undefined;
+  const operation = await withPluginLifecycleLease(options, async (lease) => {
+    let result: Result<T, unknown>;
+    try {
+      result = ok(await run(batch));
+    } catch (error) {
+      result = err(error);
+    }
+    completed = result;
+    // The callback has already completed its compensation. Capture final retained owners
+    // before releasing the lease; the Gateway validates those facts again after the gap.
+    batch.prepare(lease);
+    return result;
+  }).catch((error: unknown) => {
+    const committed = batch.hasCommitted;
+    batch.close();
+    if (!committed && !completed) {
+      throw error;
+    }
+    throw runtimeFailure(error, completed ?? err(error));
+  });
+  try {
+    const runtime = options.runtime ?? defaultRuntime;
+    const application = await batch.finish((message) => runtime.log(message));
+    if (application) {
+      runtime.log(`Plugin requirements applied in Gateway generation ${application.generation}.`);
+    }
+  } catch (error) {
+    throw runtimeFailure(error, operation);
+  }
+  if (!operation.ok) {
+    throw operation.error;
+  }
+  return operation.value;
+}

--- a/src/claws/update-apply.requirements.test.ts
+++ b/src/claws/update-apply.requirements.test.ts
@@ -1,0 +1,114 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { commitPluginInstallRecordsWithConfig } from "../plugins/install-record-commit.js";
+import { hasPluginLifecycleLease } from "../plugins/plugin-lifecycle-lease.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { withEnvAsync } from "../test-utils/env.js";
+import { applyClawUpdatePlan } from "./update-apply.js";
+import { addPlan, consent, install, manifest, plan, source } from "./update-apply.test-helpers.js";
+
+const dirs = useAutoCleanupTempDirTracker(afterEach);
+afterEach(closeOpenClawStateDatabaseForTest);
+
+it.each(["complete", "partial", "rejected"] as const)(
+  "settles unchanged requirements before later update phases: %s",
+  async (outcome) => {
+    const root = dirs.make("claw-update-resume-");
+    const env = {
+      OPENCLAW_STATE_DIR: root,
+      OPENCLAW_CONFIG_PATH: path.join(root, "openclaw.json"),
+    };
+    await fs.writeFile(env.OPENCLAW_CONFIG_PATH, "{}");
+    await withEnvAsync(env, async () => {
+      await commitPluginInstallRecordsWithConfig({
+        previousInstallRecords: {},
+        nextInstallRecords: {
+          fixture: { source: "clawhub", clawhubPackage: "fixture", version: "1" },
+        },
+        nextConfig: {},
+        writeOptions: { afterWrite: { mode: "none", reason: "resume fixture" } },
+      });
+      const pkg = {
+        kind: "plugin" as const,
+        source: "clawhub" as const,
+        ref: "fixture",
+        version: "1",
+      };
+      const updatePlan = plan([
+        {
+          kind: "package",
+          id: "plugin:fixture",
+          action: "unchanged",
+          target: "clawhub:fixture@1",
+          blocked: false,
+          reason: "same requirement",
+        },
+      ]);
+      const applyWorkspace = vi.fn(async () => ({ appliedPaths: [], rollback: async () => {} }));
+      const applyPackage = vi.fn();
+      const reloadPlugins = vi.fn(async (targets: readonly { pluginId: string }[]) => {
+        expect(hasPluginLifecycleLease()).toBe(false);
+        expect(applyWorkspace).not.toHaveBeenCalled();
+        expect(targets.map((target) => target.pluginId)).toEqual(["fixture"]);
+        if (outcome === "rejected") {
+          throw new Error("Gateway unavailable");
+        }
+        return { operationId: "resume", generation: 3, pluginIds: ["fixture"] };
+      });
+      const pending = applyClawUpdatePlan(
+        updatePlan,
+        { targetManifest: { ...manifest, packages: [pkg] }, targetSource: source },
+        {
+          env,
+          config: {},
+          ...consent(updatePlan),
+          reloadPlugins,
+          runtime: {
+            log: () => {},
+            error: () => {},
+            exit: () => {
+              throw new Error("unexpected exit");
+            },
+          },
+          rebuildPlan: async () => updatePlan,
+          readInstall: () => ({
+            ...install,
+            status: outcome === "complete" ? "complete" : "partial",
+          }),
+          buildAddPlan: async () => ({
+            ...addPlan,
+            actions: [
+              {
+                kind: "package",
+                id: "plugin:fixture",
+                action: "install",
+                target: "clawhub:fixture@1",
+                blocked: false,
+                details: { ...pkg, installId: "fixture", ownerAction: "reuse" },
+              },
+            ],
+          }),
+          applyWorkspace,
+          applyPackage,
+          applyMcp: async () => ({ appliedNames: [], rollback: async () => {} }),
+          applyCron: async () => ({ appliedIds: [], rollback: async () => {} }),
+          persistInstall: () => ({ ...install, status: "complete" }),
+        },
+      );
+      if (outcome === "rejected") {
+        await expect(pending).rejects.toMatchObject({
+          code: "update_partial",
+          message: expect.stringContaining("Runtime activation was not confirmed"),
+        });
+        expect(applyWorkspace).not.toHaveBeenCalled();
+      } else {
+        await expect(pending).resolves.toMatchObject({ status: "complete" });
+        expect(applyWorkspace).toHaveBeenCalledOnce();
+      }
+      expect(reloadPlugins).toHaveBeenCalledTimes(outcome === "complete" ? 0 : 1);
+      expect(applyPackage).not.toHaveBeenCalled();
+    });
+  },
+);

--- a/src/claws/update-apply.ts
+++ b/src/claws/update-apply.ts
@@ -4,6 +4,7 @@ import { listAgentEntries } from "../agents/agent-scope.js";
 import { transformConfigFileWithRetry } from "../config/config.js";
 import type { AgentConfig } from "../config/types.agents.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { PluginInstallBatchReload } from "../plugins/install-runtime-batch.js";
 import type { RuntimeEnv } from "../runtime.js";
 import type { OpenClawStateDatabaseOptions } from "../state/openclaw-state-db.js";
 import { clawTargetPackages } from "./application-provenance.js";
@@ -24,6 +25,7 @@ import {
   ClawPackageUpdateError,
   type ClawPackageUpdateExecution,
 } from "./package-update.js";
+import { runClawPluginBatch, type ClawPluginRuntimeOptions } from "./plugin-runtime.js";
 import {
   readClawInstallRecord,
   updateClawInstallRecord,
@@ -56,8 +58,9 @@ export class ClawUpdateMutationError extends Error {
   constructor(
     readonly code: string,
     message: string,
+    options?: ErrorOptions,
   ) {
-    super(message);
+    super(message, options);
     this.name = "ClawUpdateMutationError";
   }
 }
@@ -117,6 +120,7 @@ export async function applyClawUpdatePlan(
     consentPlanIntegrity: string | undefined;
     packagePreflight?: ClawAddPlanContext["packagePreflight"];
     runtime?: RuntimeEnv;
+    reloadPlugins?: PluginInstallBatchReload;
     commitConfig?: ConfigCommit;
     rebuildPlan?: typeof buildClawUpdatePlan;
     buildAddPlan?: typeof buildClawAddPlan;
@@ -189,13 +193,16 @@ export async function applyClawUpdatePlan(
   if (!currentInstall) {
     throw new ClawUpdateMutationError("update_changed", "The Claw install record disappeared.");
   }
-  const partialMutation = (message: string): ClawUpdateMutationError => {
+  const partialMutation = (
+    message: string,
+    errorOptions?: ErrorOptions,
+  ): ClawUpdateMutationError => {
     try {
       updateClawInstallRecordStatus(fresh.agentId, "partial", options);
     } catch {
       // Preserve the owner failure; doctor can still reconcile subordinate pending records.
     }
-    return new ClawUpdateMutationError("update_partial", message);
+    return new ClawUpdateMutationError("update_partial", message, errorOptions);
   };
   const targetAddPlan = await buildAddPlan({
     manifest: params.targetManifest,
@@ -313,21 +320,71 @@ export async function applyClawUpdatePlan(
   );
   const applyPackageActions = async (
     actions: ClawUpdateAction[],
+    runtimeBatch?: ClawPluginRuntimeOptions["runtimeBatch"],
   ): Promise<ClawPackageUpdateExecution> => {
     if (actions.length === 0) {
       return { appliedIds: [], rollback: async () => undefined };
     }
-    return await applyPackage({ ...fresh, actions }, params.targetManifest, targetAddPlan, options);
+    return await applyPackage({ ...fresh, actions }, params.targetManifest, targetAddPlan, {
+      ...options,
+      runtimeBatch,
+    });
   };
+  const resumedRequirements =
+    currentInstall.status === "complete"
+      ? []
+      : fresh.actions
+          .filter(
+            (action) =>
+              action.kind === "package" &&
+              action.action === "unchanged" &&
+              targetPackages.get(action.id)?.kind === "plugin",
+          )
+          .map((action) => {
+            const installId = targetAddPlan.actions.find((entry) => entry.id === action.id)?.details
+              ?.installId;
+            if (typeof installId !== "string" || !installId) {
+              throw new ClawUpdateMutationError(
+                "update_changed",
+                `Plugin requirement ${action.id} lost its installed identity; build a new dry-run plan.`,
+              );
+            }
+            return installId;
+          });
 
   let requirementExecution: ClawPackageUpdateExecution;
   try {
-    requirementExecution = await applyPackageActions(requirementActions);
+    requirementExecution =
+      requirementActions.length || resumedRequirements.length
+        ? await runClawPluginBatch(
+            options,
+            requirementActions.length + resumedRequirements.length,
+            (batch) => {
+              for (const id of resumedRequirements) {
+                batch?.retain(id);
+              }
+              return applyPackageActions(requirementActions, batch);
+            },
+            (failure, operation) =>
+              new ClawPackageUpdateError(
+                [
+                  !operation.ok ? coerceErrorMessage(operation.error) : undefined,
+                  coerceErrorMessage(failure),
+                ]
+                  .filter(Boolean)
+                  .join("\n"),
+                true,
+                { cause: !operation.ok ? new AggregateError([operation.error, failure]) : failure },
+              ),
+          )
+        : await applyPackageActions(requirementActions);
   } catch (error) {
     if (error instanceof ClawPackageUpdateError && error.partial) {
-      throw partialMutation(error.message);
+      throw partialMutation(error.message, { cause: error });
     }
-    throw new ClawUpdateMutationError("package_update_failed", coerceErrorMessage(error));
+    throw new ClawUpdateMutationError("package_update_failed", coerceErrorMessage(error), {
+      cause: error,
+    });
   }
   const retainedRequirementMutation = requirementExecution.appliedIds.length > 0;
 

--- a/src/cli/claws-cli.runtime.ts
+++ b/src/cli/claws-cli.runtime.ts
@@ -76,6 +76,7 @@ import { clawMonitorCleanupGateway } from "./claws-cli.monitor-cleanup.js";
 import { clawPackageRemovalGateway } from "./claws-cli.package-removal.js";
 import { listCronJobsFromGateway } from "./cron-cli/list-jobs.js";
 import { callGatewayFromCli } from "./gateway-rpc.js";
+import { resolvePluginBatchReload } from "./plugins-lifecycle-client.js";
 
 function logClawAddPlanSummary(plan: ClawAddPlan, runtime: RuntimeEnv): void {
   runtime.log(`Agent: ${plan.agent.finalId}`);
@@ -473,6 +474,7 @@ export async function runClawsAddCommand(
   }
   try {
     addResult = await applyClawAddPlan(plan, {
+      reloadPlugins: await resolvePluginBatchReload(),
       consentPlanIntegrity: opts.planIntegrity,
       resumeRecord: resumableInstallRecord,
       resumePlan: legacyResumePlan,
@@ -502,6 +504,9 @@ export async function runClawsAddCommand(
     runtime.log(`Added agent: ${addResult.agent.finalId}`);
     runtime.log(`Workspace: ${addResult.agent.workspace}`);
     runtime.log(`Status: ${addResult.status}`);
+    if (addResult.error) {
+      runtime.error(addResult.error.message);
+    }
   }
   if (addResult.status !== "complete") {
     runtime.exit(1);

--- a/src/cli/claws-update-cli.runtime.ts
+++ b/src/cli/claws-update-cli.runtime.ts
@@ -21,6 +21,7 @@ import {
 import { waitUntilGatewayAgentAvailable } from "./claws-cli.gateway-readiness.js";
 import type { ClawsUpdateOptions } from "./claws-cli.js";
 import { callGatewayFromCli } from "./gateway-rpc.js";
+import { resolvePluginBatchReload } from "./plugins-lifecycle-client.js";
 
 export async function runClawsUpdateCommand(
   target: string,
@@ -178,6 +179,7 @@ export async function runClawsUpdateCommand(
       },
       {
         config,
+        reloadPlugins: await resolvePluginBatchReload(),
         sourceMcpServers: listedMcpServers.mcpServers,
         consentPlanIntegrity: opts.planIntegrity,
         packagePreflight: preflightClawPackage,

--- a/src/cli/plugins-install-command.ts
+++ b/src/cli/plugins-install-command.ts
@@ -61,8 +61,8 @@ export async function runPluginInstallCommand(params: RunPluginInstallCommandPar
       }
       throw error;
     });
-    // A Claw batch owns a lease across multiple packages; a guarded in-process
-    // operation owns a callback that cannot be serialized into another process.
+    // An enclosing lifecycle lease or in-process authority guard cannot cross
+    // the Gateway RPC boundary.
     const gateway =
       params.applyRuntime || params.beforePersistentApply || hasPluginLifecycleLease()
         ? null
@@ -77,17 +77,9 @@ export async function runPluginInstallCommand(params: RunPluginInstallCommandPar
       runtime.log(theme.warn(sourcePlan.warning));
     }
     result = await installPluginWithHookFallback({
-      request:
-        request.source === "clawhub"
-          ? {
-              ...request,
-              ...(opts.expectedPluginId ? { expectedPluginId: opts.expectedPluginId } : {}),
-              ...(opts.expectedIntegrity ? { expectedIntegrity: opts.expectedIntegrity } : {}),
-            }
-          : request,
+      request,
       snapshot,
       runtime,
-      clawManaged: params.clawManaged,
       applyRuntime: params.applyRuntime,
       beforePersistentApply: params.beforePersistentApply,
       invalidateRuntimeCache: params.invalidateRuntimeCache ?? true,

--- a/src/cli/plugins-install-preflight.ts
+++ b/src/cli/plugins-install-preflight.ts
@@ -20,15 +20,12 @@ export type RunPluginInstallCommandParams = {
     acceptCapabilities?: boolean;
     acknowledgeInstallPolicyWarning?: boolean;
     dangerouslyForceUnsafeInstall?: boolean;
-    expectedIntegrity?: string;
-    expectedPluginId?: string;
     force?: boolean;
     link?: boolean;
     pin?: boolean;
     marketplace?: string;
   };
   invalidateRuntimeCache?: boolean;
-  clawManaged?: boolean;
   runtime?: RuntimeEnv;
   /** Synchronous authority guard at the final plugin/config mutation. */
   beforePersistentApply?: () => void;

--- a/src/cli/plugins-lifecycle-client.test.ts
+++ b/src/cli/plugins-lifecycle-client.test.ts
@@ -5,7 +5,8 @@ const mocks = vi.hoisted(() => ({ lock: vi.fn(), call: vi.fn(), config: vi.fn() 
 vi.mock("../infra/gateway-lock.js", () => ({ readActiveGatewayLockIdentity: mocks.lock }));
 vi.mock("../gateway/call.js", () => ({ callGateway: mocks.call }));
 vi.mock("../config/config.js", () => ({ getRuntimeConfig: mocks.config }));
-const { resolvePluginLifecycleGateway } = await import("./plugins-lifecycle-client.js");
+const { resolvePluginLifecycleGateway, resolvePluginBatchReload } =
+  await import("./plugins-lifecycle-client.js");
 
 describe("plugin lifecycle CLI transport", () => {
   beforeEach(() => {
@@ -50,6 +51,26 @@ describe("plugin lifecycle CLI transport", () => {
     expect(await resolvePluginLifecycleGateway()).toBeNull();
     expect(mocks.call).not.toHaveBeenCalled();
   });
+
+  it.each([true, false])(
+    "requires an actual batch application receipt (present=%s)",
+    async (present) => {
+      const runtime = { operationId: "batch", generation: 2, pluginIds: ["demo"] };
+      const targets = [{ pluginId: "demo", installHash: "a".repeat(64) }];
+      const warnings = ["Previous plugin cleanup did not finish."];
+      mocks.call.mockResolvedValue(present ? { runtime, warnings } : {});
+      const reload = await resolvePluginBatchReload();
+      expect(reload).toBeDefined();
+      if (present) {
+        await expect(reload!(targets)).resolves.toEqual({ ...runtime, warnings });
+      } else {
+        await expect(reload!(targets)).rejects.toThrow("did not confirm");
+      }
+      expect(mocks.call).toHaveBeenCalledExactlyOnceWith(
+        expect.objectContaining({ method: "plugins.reload", params: { plugins: targets } }),
+      );
+    },
+  );
 
   it("propagates a lost reply without retrying a possibly committed mutation", async () => {
     const failure = new Error("connection lost");

--- a/src/cli/plugins-lifecycle-client.ts
+++ b/src/cli/plugins-lifecycle-client.ts
@@ -3,10 +3,34 @@ import {
   GATEWAY_CLIENT_MODES,
   GATEWAY_CLIENT_NAMES,
 } from "../../packages/gateway-protocol/src/client-info.js";
-import type { PluginsInspectResult } from "../../packages/gateway-protocol/src/schema/plugins.js";
+import type {
+  PluginsInspectResult,
+  PluginsReloadResult,
+} from "../../packages/gateway-protocol/src/schema/plugins.js";
 import { callGateway } from "../gateway/call.js";
 import { readActiveGatewayLockIdentity } from "../infra/gateway-lock.js";
 import type { PluginCapabilityConsentHandler } from "../plugins/capability-consent.js";
+import type { PluginInstallBatchReload } from "../plugins/install-runtime-batch.js";
+
+/** Capture the local client before a Claw batch takes any package or plugin lease. */
+export async function resolvePluginBatchReload(): Promise<PluginInstallBatchReload | undefined> {
+  const gateway = await resolvePluginLifecycleGateway();
+  return gateway
+    ? async (plugins) => {
+        const result = await gateway<PluginsReloadResult>("plugins.reload", {
+          plugins,
+        });
+        if (!result.runtime) {
+          throw new Error(
+            "Gateway did not confirm the plugin batch runtime generation. Inspect plugin status before retrying.",
+          );
+        }
+        return result.warnings?.length
+          ? { ...result.runtime, warnings: result.warnings }
+          : result.runtime;
+      }
+    : undefined;
+}
 
 export type PluginLifecycleGateway = <T>(
   method: string,

--- a/src/gateway/config-reload.ts
+++ b/src/gateway/config-reload.ts
@@ -681,8 +681,8 @@ export function startGatewayConfigReloader(opts: {
       if (entries.length === Object.keys(expected).length) {
         // A completed watcher application can settle this exact committed install.
         // Manual reloads carry no install hashes and always create a replacement.
-        const { capturePluginGenerationArtifact } =
-          await import("../plugins/plugin-generation-artifact.js");
+        const { inspectPluginGenerationSources } =
+          await import("../plugins/plugin-generation-source-inspection.js");
         await checkpoint();
         assertCurrent();
         const covered = pluginLifecycle.pluginIds.every((id) => {
@@ -705,27 +705,19 @@ export function startGatewayConfigReloader(opts: {
           registry === getActivePluginRegistry() &&
           metadata === getProcessGatewayPluginMetadataSnapshot()
         ) {
-          const sources = new Map<string, ReturnType<typeof capturePluginGenerationArtifact>>();
+          const source = inspectPluginGenerationSources(
+            entries.map((entry) => ({
+              pluginId: entry.pluginId,
+              rootDir: entry.rootDir,
+              entryFile: entry.source === entry.manifestPath ? entry.source : undefined,
+            })),
+          );
           for (const [id, digest] of Object.entries(expected)) {
-            const entry = entries.find((indexedEntry) => indexedEntry.pluginId === id);
-            if (!entry) {
-              throw new Error(`Plugin ${id} captured source changed after installation`);
-            }
-            const entryFile = entry.source === entry.manifestPath ? entry.source : undefined;
-            const key = `${entry.rootDir}\0${entryFile ?? ""}`;
-            let source = sources.get(key);
-            if (!source) {
-              source = capturePluginGenerationArtifact(entry.rootDir, entryFile);
-              source.dispose();
-              sources.set(key, source);
-            }
-            if (source.sourceDigest !== digest) {
+            if (source.sourceDigests[id] !== digest) {
               throw new Error(`Plugin ${id} captured source changed after installation`);
             }
           }
-          for (const source of sources.values()) {
-            source.assertSourceCurrent();
-          }
+          source.assertSourceCurrent();
           assertCurrent();
           application?.settle("applied");
           return completeApplication(completed.runtime);

--- a/src/plugins/install-persistence.test.ts
+++ b/src/plugins/install-persistence.test.ts
@@ -2,7 +2,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   buildPluginSnapshotReportMock,
   clearPluginRegistryLoadCacheMock,
@@ -49,6 +49,54 @@ describe("persistPluginInstall", () => {
     clearPluginMetadataLifecycleCaches();
     resetPluginsCliTestState();
   });
+
+  it.each([false, true])(
+    "hands durable batch facts to the coordinator before later output failure=%s",
+    async (outputFails) => {
+      const { persistPluginInstall } = await import("./install-persistence.js");
+      const record = vi.fn();
+      const deferRuntime = { record, deferCleanup: vi.fn() };
+      const commit = vi.fn(async () => undefined);
+      const rollback = vi.fn(async () => undefined);
+      const failure = new Error("terminal output unavailable");
+      const options = {
+        snapshot: { config: {}, baseHash: "config-1", writeOptions: installWriteOptions },
+        pluginId: "alpha",
+        install: { source: "archive" as const, installPath: "/tmp/alpha" },
+        enable: false,
+        deferRuntime,
+        transaction: { commit, rollback },
+        runtime: {
+          log: () => {
+            if (outputFails) {
+              throw failure;
+            }
+          },
+        },
+      };
+      const pending = persistPluginInstall(options);
+      if (outputFails) {
+        await expect(pending).rejects.toMatchObject({ pluginId: "alpha", cause: failure });
+      } else {
+        await pending;
+      }
+      expect(record).toHaveBeenCalledOnce();
+      expect(record.mock.calls[0]?.[0]).toMatchObject({
+        pluginId: "alpha",
+        operation: "install",
+        sourceDigests: {},
+      });
+      expect(replaceConfigFileMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          writeOptions: expect.objectContaining({
+            afterWrite: expect.objectContaining({ mode: "none" }),
+          }),
+        }),
+      );
+      expect(commit).toHaveBeenCalledOnce();
+      expect(rollback).not.toHaveBeenCalled();
+    },
+  );
 
   it.each(["before index", "at config publication"])(
     "rejects an expired owner %s and restores tentative state",

--- a/src/plugins/install-persistence.ts
+++ b/src/plugins/install-persistence.ts
@@ -14,6 +14,7 @@ import { discoverOpenClawPlugins } from "./discovery.js";
 import { enablePluginInConfig, prepareConfigForDisabledInstall } from "./enable.js";
 import type { ConfigSnapshotForInstallPersist } from "./install-config-mutation.js";
 import { commitPluginInstallRecordsWithConfig } from "./install-record-commit.js";
+import type { PluginInstallRuntimeDeferral } from "./install-runtime-batch.js";
 import type { PluginInstallTransaction } from "./install-transaction.js";
 import type { PluginInstallLogger } from "./install-types.js";
 import {
@@ -34,6 +35,7 @@ import { loadPluginManifestRegistryCore } from "./manifest-registry.js";
 import { safeRealpathSync } from "./path-safety.js";
 import { createPluginCache, withPluginCache } from "./plugin-cache.js";
 import { resolvePluginConfigEnablement } from "./plugin-config-enablement.js";
+import { inspectPluginGenerationSources } from "./plugin-generation-source-inspection.js";
 import { tracePluginLifecyclePhaseAsync } from "./plugin-lifecycle-trace.js";
 import { loadPluginMetadataSnapshot } from "./plugin-metadata-snapshot.js";
 import { refreshPluginRegistryAfterConfigMutation } from "./registry-refresh.js";
@@ -201,6 +203,7 @@ export async function persistPluginInstall(params: {
   persistenceLogger?: PluginInstallLogger;
   transaction?: PluginInstallTransaction;
   applyRuntime?: PluginLifecycleRuntimeApply;
+  deferRuntime?: PluginInstallRuntimeDeferral;
   beforePersistentApply?: () => void;
   beforePersistentEffect?: () => void | Promise<void>;
 }): Promise<OpenClawConfig> {
@@ -354,6 +357,18 @@ export async function persistPluginInstall(params: {
         slotWarnings.push(...slotResult.warnings);
       }
       next = withoutPluginInstallRecords(next);
+      const enabled = new Set(enabledPluginIds);
+      const source = params.deferRuntime
+        ? inspectPluginGenerationSources(
+            manifests
+              .filter((manifest) => enabled.has(manifest.id) && manifest.origin !== "bundled")
+              .map((manifest) => ({
+                pluginId: manifest.id,
+                rootDir: manifest.rootDir,
+                entryFile: manifest.manifestPath === manifest.source ? manifest.source : undefined,
+              })),
+          )
+        : undefined;
       const receipt = await tracePluginLifecyclePhaseAsync(
         "config mutation",
         () =>
@@ -365,9 +380,10 @@ export async function persistPluginInstall(params: {
             beforePersistentEffect: params.beforePersistentEffect,
             writeOptions: {
               ...params.snapshot.writeOptions,
-              afterWrite: params.applyRuntime
-                ? { mode: "none", reason: "plugin lifecycle applies runtime" }
-                : { mode: "restart", reason: "plugin source changed" },
+              afterWrite:
+                params.applyRuntime || params.deferRuntime
+                  ? { mode: "none", reason: "plugin lifecycle applies runtime" }
+                  : { mode: "restart", reason: "plugin source changed" },
               ...(params.beforePersistentApply
                 ? {
                     assertConfigPathForWrite: () => {
@@ -382,6 +398,15 @@ export async function persistPluginInstall(params: {
       );
       // Publish the durable install before activation can fail; keep running metadata unchanged.
       committed = true;
+      params.deferRuntime?.record(
+        {
+          operation: "install",
+          pluginId: params.pluginId,
+          sourceDigests: source?.sourceDigests ?? {},
+          write: receipt,
+        },
+        source?.assertSourceCurrent,
+      );
       refreshManagedPluginMetadata({ config: next });
       // Publish and drain the previous generation before removing its source files.
       await params.applyRuntime?.({
@@ -392,27 +417,34 @@ export async function persistPluginInstall(params: {
         assertInvokerOwned: params.beforePersistentApply,
       });
       if (replacedInstallRemoval) {
-        const removalResult = await tracePluginLifecyclePhaseAsync(
-          "replaced install cleanup",
-          () =>
-            applyPluginUninstallDirectoryRemoval(
-              replacedInstallRemoval,
-              params.beforePersistentApply,
+        const cleanup = async (
+          assertOwned?: () => void,
+          reportWarning = (message: string) =>
+            warn(
+              message,
+              "A previous plugin installation could not be fully cleaned up. Run `openclaw plugins doctor`.",
             ),
-          { command: "install", pluginId: params.pluginId },
-        );
-        for (const warning of removalResult.warnings) {
-          warn(
-            warning,
-            "A previous plugin installation could not be fully cleaned up. Run `openclaw plugins doctor`.",
+        ) => {
+          const removalResult = await tracePluginLifecyclePhaseAsync(
+            "replaced install cleanup",
+            () => applyPluginUninstallDirectoryRemoval(replacedInstallRemoval, assertOwned),
+            { command: "install", pluginId: params.pluginId },
           );
-        }
-        if (removalResult.directoryRemoved) {
-          runtime.log(
-            theme.muted(
-              `Removed previous plugin install directory: ${shortenHomePath(replacedInstallRemoval.target)}`,
-            ),
-          );
+          for (const warning of removalResult.warnings) {
+            reportWarning(warning);
+          }
+          if (removalResult.directoryRemoved) {
+            runtime.log(
+              theme.muted(
+                `Removed previous plugin install directory: ${shortenHomePath(replacedInstallRemoval.target)}`,
+              ),
+            );
+          }
+        };
+        if (params.deferRuntime) {
+          params.deferRuntime.deferCleanup(cleanup, replacedInstallRemoval.target);
+        } else {
+          await cleanup(params.beforePersistentApply);
         }
       }
       await refreshPluginRegistryAfterConfigMutation({
@@ -460,7 +492,7 @@ export async function persistPluginInstall(params: {
         install: params.install,
         warn,
       });
-      if (!params.applyRuntime) {
+      if (!params.applyRuntime && !params.deferRuntime) {
         runtime.log(
           "Plugin source changes take effect on the next Gateway start. Installs performed by the running Gateway request an automatic restart when config reload is enabled; installs from a separate shell, or with config reload off, require a manual Gateway restart. Configuration reload can restart connected channels before that Gateway restart.",
         );

--- a/src/plugins/install-persistence.warning-sink.test.ts
+++ b/src/plugins/install-persistence.warning-sink.test.ts
@@ -11,6 +11,7 @@ import {
   pluginsCliRuntimeLogs,
   setInstalledPluginIndexInstallRecords,
 } from "../cli/plugins-cli-test-helpers.js";
+import type { PluginInstallRuntimeDeferral } from "./install-runtime-batch.js";
 import { recordPluginManifestInstallOwner } from "./manifest-install-owner.js";
 
 const snapshot = {
@@ -28,6 +29,40 @@ const install = {
 describe("plugin install persistence warning audiences", () => {
   beforeEach(() => {
     resetPluginsCliTestState();
+  });
+
+  it("delivers deferred source cleanup warnings to the live batch consumer", async () => {
+    const { persistPluginInstall } = await import("./install-persistence.js");
+    const cleanups: Parameters<PluginInstallRuntimeDeferral["deferCleanup"]>[0][] = [];
+    const lateWarning = vi.fn();
+    const warning = "Previous plugin source could not be removed";
+    setInstalledPluginIndexInstallRecords({
+      workboard: { source: "clawhub", installPath: "/private/previous-source/workboard" },
+    });
+    planPluginUninstallMock.mockReturnValueOnce({
+      ok: true,
+      config: {},
+      pluginId: "workboard",
+      actions: {},
+      directoryRemoval: { target: "/private/previous-source/workboard" },
+    });
+    applyPluginUninstallDirectoryRemovalMock.mockResolvedValueOnce({
+      directoryRemoved: false,
+      warnings: [warning],
+    });
+    await persistPluginInstall({
+      snapshot,
+      pluginId: "workboard",
+      install,
+      enable: false,
+      runtime: { log: () => {} },
+      persistenceLogger: { warn: () => {} },
+      deferRuntime: { record: () => {}, deferCleanup: (cleanup) => cleanups.push(cleanup) },
+    });
+    expect(applyPluginUninstallDirectoryRemovalMock).not.toHaveBeenCalled();
+    expect(cleanups).toHaveLength(1);
+    await cleanups[0]!(() => {}, lateWarning);
+    expect(lateWarning).toHaveBeenCalledExactlyOnceWith(warning);
   });
 
   it("reports missing required configuration without forwarding informational logs", async () => {

--- a/src/plugins/install-runtime-batch.test.ts
+++ b/src/plugins/install-runtime-batch.test.ts
@@ -1,0 +1,109 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { withEnvAsync } from "../test-utils/env.js";
+import { commitPluginInstallRecordsWithConfig } from "./install-record-commit.js";
+import { PluginInstallRuntimeBatch } from "./install-runtime-batch.js";
+import { inspectPluginGenerationSources } from "./plugin-generation-source-inspection.js";
+import { hasPluginLifecycleLease, withPluginLifecycleLease } from "./plugin-lifecycle-lease.js";
+
+const dirs = useAutoCleanupTempDirTracker(afterEach);
+afterEach(closeOpenClawStateDatabaseForTest);
+
+it.each(["runtime", "source", "record", "closed", "adopted", "loadpath", "rebound"])(
+  "retains replaced source when the post-lease handoff loses %s ownership",
+  async (failure) => {
+    const root = dirs.make("plugin-batch-gap-");
+    const source = path.join(root, "current");
+    const previousSource = path.join(root, "previous");
+    await fs.mkdir(source);
+    await fs.mkdir(previousSource);
+    await fs.writeFile(path.join(source, "index.ts"), "export const value = 1;");
+    await fs.writeFile(path.join(source, "package.json"), "{}");
+    const env = {
+      OPENCLAW_STATE_DIR: root,
+      OPENCLAW_CONFIG_PATH: path.join(root, "openclaw.json"),
+    };
+    await fs.writeFile(env.OPENCLAW_CONFIG_PATH, "{}");
+    await withEnvAsync(env, async () => {
+      const records = { fixture: { source: "path" as const, installPath: source, version: "1" } };
+      const cleanup = vi.fn(async (assertOwned: () => void) => {
+        assertOwned();
+        await fs.rm(previousSource, { recursive: true });
+      });
+      const reload = vi.fn(async () => {
+        expect(hasPluginLifecycleLease()).toBe(false);
+        if (failure === "runtime") {
+          throw new Error("runtime reply lost");
+        }
+        if (failure === "source") {
+          await fs.writeFile(path.join(source, "index.ts"), "export const value = 2;");
+        } else if (failure === "record" || failure === "adopted") {
+          await withPluginLifecycleLease({ env }, () =>
+            commitPluginInstallRecordsWithConfig({
+              previousInstallRecords: records,
+              nextInstallRecords:
+                failure === "record"
+                  ? { fixture: { ...records.fixture, version: "2" } }
+                  : {
+                      ...records,
+                      adopter: {
+                        source: "path",
+                        sourcePath: previousSource,
+                        installPath: previousSource,
+                      },
+                    },
+              nextConfig: {},
+              writeOptions: { afterWrite: { mode: "none", reason: "replacement fixture" } },
+            }),
+          );
+        } else if (failure === "loadpath") {
+          await fs.writeFile(
+            env.OPENCLAW_CONFIG_PATH,
+            JSON.stringify({ plugins: { load: { paths: [previousSource] } } }),
+          );
+        } else if (failure === "rebound") {
+          await fs.rename(previousSource, path.join(root, "retired-original"));
+          await fs.mkdir(previousSource);
+        } else if (failure === "closed") {
+          batch.close();
+        }
+        return { operationId: "handoff", generation: 2, pluginIds: ["fixture"] };
+      });
+      const batch = new PluginInstallRuntimeBatch({ env }, reload);
+      const deferred = batch.install();
+      await withPluginLifecycleLease({ env }, async (lease) => {
+        const captured = inspectPluginGenerationSources([{ pluginId: "fixture", rootDir: source }]);
+        const write = await commitPluginInstallRecordsWithConfig({
+          previousInstallRecords: {},
+          nextInstallRecords: records,
+          nextConfig: {},
+          writeOptions: { afterWrite: { mode: "none", reason: "batch fixture" } },
+        });
+        deferred.record(
+          {
+            operation: "install",
+            pluginId: "fixture",
+            sourceDigests: captured.sourceDigests,
+            write,
+          },
+          captured.assertSourceCurrent,
+        );
+        deferred.deferCleanup(cleanup, previousSource);
+        batch.prepare(lease);
+      });
+      await expect(batch.finish(() => {})).rejects.toThrow(
+        failure === "runtime" ? "Runtime activation was not confirmed" : "source cleanup failed",
+      );
+      expect(reload).toHaveBeenCalledOnce();
+      expect(cleanup).not.toHaveBeenCalled();
+      await expect(fs.stat(previousSource)).resolves.toBeDefined();
+      expect(() => deferred.deferCleanup(cleanup, previousSource)).toThrow(
+        "no longer accepts mutations",
+      );
+      await expect(batch.finish(() => {})).rejects.toThrow("handoff already started");
+    });
+  },
+);

--- a/src/plugins/install-runtime-batch.ts
+++ b/src/plugins/install-runtime-batch.ts
@@ -1,0 +1,304 @@
+import fs from "node:fs";
+import { safeParseJson } from "@openclaw/normalization-core/json-coercion";
+import { asRecord } from "@openclaw/normalization-core/record-coerce";
+import { readCurrentConfigForPolicyCheck } from "../config/io.runtime.js";
+import type { ConfigReplaceResult } from "../config/mutate.js";
+import { formatErrorMessage } from "../infra/errors.js";
+import type { OpenClawStateDatabaseOptions } from "../state/openclaw-state-db.js";
+import { hashStableJson } from "./installed-plugin-index-hash.js";
+import { resolveInstalledPluginIndexInstallOwner } from "./installed-plugin-index-install-owner.js";
+import { readPersistedInstalledPluginIndexRowSync } from "./installed-plugin-index-row.js";
+import type { InstalledPluginIndexWriteReceipt } from "./installed-plugin-index-store-write.js";
+import { parseInstalledPluginIndex } from "./installed-plugin-index-store.js";
+import { createInstalledPluginOwnershipResolver } from "./installed-plugin-package-ownership.js";
+import type { PluginRuntimeApplication } from "./lifecycle.js";
+import { inspectPluginGenerationSources } from "./plugin-generation-source-inspection.js";
+import {
+  hasPluginLifecycleLease,
+  withPluginLifecycleLease,
+  type PluginLifecycleLeaseContext,
+} from "./plugin-lifecycle-lease.js";
+
+export type PluginInstallRuntimeCommit = {
+  pluginId: string;
+  write: InstalledPluginIndexWriteReceipt & { configWrite: ConfigReplaceResult };
+} & ({ operation: "install"; sourceDigests: Record<string, string> } | { operation: "uninstall" });
+
+export type PluginInstallRuntimeDeferral = {
+  record(commit: PluginInstallRuntimeCommit, assertSourceCurrent?: () => void): void;
+  deferCleanup(cleanup: PluginSourceCleanup, sourcePath: string): void;
+};
+
+type PluginSourceCleanup = (
+  assertOwned: () => void,
+  warn: (message: string) => void,
+) => Promise<void>;
+
+export type PluginInstallBatchTarget = {
+  pluginId: string;
+  installHash: string;
+  sourceDigests?: Record<string, string>;
+};
+export type PluginInstallBatchReload = (
+  plugins: readonly PluginInstallBatchTarget[],
+) => Promise<PluginRuntimeApplication>;
+
+function indexFromRow(value: string | undefined) {
+  if (value === undefined) {
+    return undefined;
+  }
+  const index = parseInstalledPluginIndex(asRecord(safeParseJson(value))?.index);
+  if (!index) {
+    throw new Error("Plugin batch has an invalid installed-index receipt");
+  }
+  return index;
+}
+
+/** Owns ephemeral committed facts and cleanup across the CLI-to-Gateway lease gap. */
+export class PluginInstallRuntimeBatch {
+  private readonly installs: Array<{
+    commit?: PluginInstallRuntimeCommit;
+    cleanups: PluginSourceCleanup[];
+  }> = [];
+  private targets: PluginInstallBatchTarget[] = [];
+  private readonly retained = new Set<string>();
+  private readonly sourceChecks = new Map<string, () => void>();
+  private databasePath?: string;
+  private phase: "collecting" | "prepared" | "applying" | "closed" = "collecting";
+
+  constructor(
+    private readonly options: Pick<OpenClawStateDatabaseOptions, "env" | "path" | "database">,
+    private readonly reload: PluginInstallBatchReload,
+  ) {}
+
+  get hasCommitted(): boolean {
+    return this.installs.some((entry) => entry.commit !== undefined);
+  }
+
+  close(): void {
+    this.phase = "closed";
+    for (const entry of this.installs.splice(0)) {
+      entry.commit = undefined;
+      entry.cleanups.length = 0;
+    }
+    this.targets = [];
+    this.retained.clear();
+    this.sourceChecks.clear();
+  }
+
+  private assertOpen() {
+    if (this.phase === "closed") {
+      throw new Error("Plugin installation batch is closed");
+    }
+  }
+
+  private assertCollecting() {
+    if (this.phase !== "collecting") {
+      throw new Error("Plugin installation batch no longer accepts mutations");
+    }
+  }
+
+  install(): PluginInstallRuntimeDeferral {
+    this.assertCollecting();
+    const entry: (typeof this.installs)[number] = { cleanups: [] };
+    this.installs.push(entry);
+    return {
+      record: (commit, assertSourceCurrent) => {
+        this.assertCollecting();
+        if (entry.commit) {
+          throw new Error("Plugin install already committed in this batch");
+        }
+        entry.commit = commit;
+        if (assertSourceCurrent) {
+          this.sourceChecks.set(commit.pluginId, assertSourceCurrent);
+        } else {
+          this.sourceChecks.delete(commit.pluginId);
+        }
+      },
+      deferCleanup: (cleanup, sourcePath) => {
+        this.assertCollecting();
+        if (!entry.commit) {
+          throw new Error("Cannot transfer cleanup before plugin installation commits");
+        }
+        const configPath = entry.commit.write.configWrite.path;
+        const original = fs.lstatSync(sourcePath, { bigint: true, throwIfNoEntry: false });
+        entry.cleanups.push(async (assertOwned, warn) => {
+          const assertUnclaimed = () => {
+            assertOwned();
+            const current = fs.lstatSync(sourcePath, { bigint: true, throwIfNoEntry: false });
+            // Cleanup can mutate or remove its own tree, but never adopt a replacement inode.
+            if (
+              current &&
+              (!original || current.dev !== original.dev || current.ino !== original.ino)
+            ) {
+              throw new Error(`Retired plugin source changed before cleanup: ${sourcePath}`);
+            }
+            const index = indexFromRow(
+              readPersistedInstalledPluginIndexRowSync({ filePath: this.databasePath })?.value_json,
+            );
+            if (!index) {
+              throw new Error("Plugin index disappeared before source cleanup");
+            }
+            const config = readCurrentConfigForPolicyCheck({
+              configPath,
+              env: this.options.env ?? process.env,
+            });
+            if (
+              createInstalledPluginOwnershipResolver(index, this.options.env).isSourceInUse(
+                sourcePath,
+                config.plugins?.load?.paths ?? [],
+              )
+            ) {
+              throw new Error(`Retired plugin source acquired a current owner: ${sourcePath}`);
+            }
+            assertOwned();
+          };
+          assertUnclaimed();
+          await cleanup(assertUnclaimed, warn);
+        });
+      },
+    };
+  }
+
+  retain(pluginId: string): void {
+    this.assertCollecting();
+    this.retained.add(pluginId);
+  }
+
+  /** Called before the original batch lease exits, after its compensation has settled. */
+  prepare(lease: PluginLifecycleLeaseContext): void {
+    this.assertCollecting();
+    lease.assertOwned();
+    this.databasePath = lease.databasePath;
+    if (!this.hasCommitted && this.retained.size === 0) {
+      this.phase = "prepared";
+      return;
+    }
+    const index = indexFromRow(
+      readPersistedInstalledPluginIndexRowSync({ filePath: lease.databasePath })?.value_json,
+    );
+    const current = index?.installRecords ?? {};
+    const targets = new Map<string, PluginInstallBatchTarget>();
+    for (const pluginId of this.retained) {
+      if (!current[pluginId]) {
+        throw new Error(`Resumable plugin ${pluginId} is no longer installed`);
+      }
+      const source = inspectPluginGenerationSources(
+        (index?.plugins ?? [])
+          .filter(
+            (entry) =>
+              resolveInstalledPluginIndexInstallOwner(entry) === pluginId &&
+              entry.enabled &&
+              entry.origin !== "bundled",
+          )
+          .map((entry) => ({
+            pluginId: entry.pluginId,
+            rootDir: entry.rootDir,
+            entryFile: entry.source === entry.manifestPath ? entry.source : undefined,
+          })),
+      );
+      this.sourceChecks.set(pluginId, source.assertSourceCurrent);
+      targets.set(pluginId, {
+        pluginId,
+        installHash: hashStableJson(current[pluginId]),
+        sourceDigests: source.sourceDigests,
+      });
+    }
+    const finalCommits = new Map<string, PluginInstallRuntimeCommit>();
+    for (const { commit } of this.installs) {
+      if (!commit) {
+        continue;
+      }
+      finalCommits.set(commit.pluginId, commit);
+    }
+    for (const commit of finalCommits.values()) {
+      const { pluginId, write } = commit;
+      if (write.mutation.databasePath !== lease.databasePath) {
+        throw new Error("Plugin batch commit belongs to a different state database");
+      }
+      const installed = indexFromRow(write.mutation.after.value_json)?.installRecords[pluginId];
+      if (commit.operation === "uninstall") {
+        if (installed || current[pluginId]) {
+          throw new Error(`Plugin ${pluginId} compensation did not remove its installed record`);
+        }
+        targets.delete(pluginId);
+        continue;
+      }
+      if (!installed) {
+        throw new Error(`Plugin ${pluginId} is missing from its committed index receipt`);
+      }
+      const installHash = hashStableJson(installed);
+      if (!current[pluginId] || hashStableJson(current[pluginId]) !== installHash) {
+        throw new Error(`Plugin ${pluginId} changed during batch settlement`);
+      }
+      targets.set(pluginId, { pluginId, installHash, sourceDigests: commit.sourceDigests });
+    }
+    this.targets = [...targets.values()].toSorted((a, b) => a.pluginId.localeCompare(b.pluginId));
+    this.phase = "prepared";
+  }
+
+  /** The caller must leave every batch lease before invoking the captured runtime client. */
+  async finish(warn: (message: string) => void): Promise<PluginRuntimeApplication | undefined> {
+    if (this.phase !== "prepared" || !this.databasePath || hasPluginLifecycleLease()) {
+      throw new Error("Plugin batch was not prepared or its handoff already started");
+    }
+    this.phase = "applying";
+    const targets = this.targets;
+    let application: PluginRuntimeApplication | undefined;
+    try {
+      if (targets.length === 0) {
+        return undefined;
+      }
+      application = await this.reload(targets);
+      this.assertOpen();
+      for (const warning of application.warnings ?? []) {
+        warn(warning);
+      }
+      await withPluginLifecycleLease(this.options, async (lease) => {
+        const assertCurrent = () => {
+          this.assertOpen();
+          lease.assertOwned();
+          if (lease.databasePath !== this.databasePath) {
+            throw new Error("Plugin cleanup belongs to a different state database");
+          }
+          const records =
+            indexFromRow(
+              readPersistedInstalledPluginIndexRowSync({ filePath: lease.databasePath })
+                ?.value_json,
+            )?.installRecords ?? {};
+          for (const target of targets) {
+            this.sourceChecks.get(target.pluginId)?.();
+            if (
+              !records[target.pluginId] ||
+              hashStableJson(records[target.pluginId]) !== target.installHash
+            ) {
+              throw new Error(`Plugin ${target.pluginId} changed before committed source cleanup`);
+            }
+          }
+        };
+        for (const { commit, cleanups } of this.installs) {
+          if (!commit || !targets.some((target) => target.pluginId === commit.pluginId)) {
+            continue;
+          }
+          for (const cleanup of cleanups) {
+            assertCurrent();
+            await cleanup(assertCurrent, warn);
+            assertCurrent();
+          }
+        }
+      });
+      return application;
+    } catch (error) {
+      throw new Error(
+        `Plugin installations are saved: ${targets.map((target) => target.pluginId).join(", ")}. ` +
+          (application
+            ? `Gateway generation ${application.generation} was applied, but source cleanup failed. `
+            : "Runtime activation was not confirmed. ") +
+          `Fix the reported issue, then run openclaw plugins reload <plugin-id> for each affected plugin. ${formatErrorMessage(error)}`,
+        { cause: error },
+      );
+    } finally {
+      this.close();
+    }
+  }
+}

--- a/src/plugins/installed-plugin-package-ownership.ts
+++ b/src/plugins/installed-plugin-package-ownership.ts
@@ -195,7 +195,26 @@ export function createInstalledPluginOwnershipResolver(
     }
     return resolveLifecycle(pluginId);
   }
-  return { resolvePackage, resolveLifecycle, resolveReload };
+  function isSourceInUse(sourcePath: string, loadPaths: readonly string[]): boolean {
+    const target = safeRealpathSync(sourcePath, realpathCache) ?? path.resolve(sourcePath);
+    const paths = [
+      ...loadPaths,
+      ...Object.values(index.installRecords).flatMap((record) => [
+        record.installPath,
+        record.sourcePath,
+      ]),
+      ...index.plugins.flatMap((entry) => [entry.rootDir, entry.source, entry.manifestPath]),
+    ];
+    return paths.some((candidate) => {
+      if (!candidate?.trim()) {
+        return false;
+      }
+      const resolved = path.resolve(resolveUserPath(candidate, env));
+      const current = safeRealpathSync(resolved, realpathCache) ?? resolved;
+      return isPathInside(target, current) || isPathInside(current, target);
+    });
+  }
+  return { resolvePackage, resolveLifecycle, resolveReload, isSourceInUse };
 }
 
 function installRecordPathMatchesPluginRoot(

--- a/src/plugins/management-install.ts
+++ b/src/plugins/management-install.ts
@@ -32,6 +32,7 @@ import {
 import type { ConfigSnapshotForInstallPersist } from "./install-config-mutation.js";
 import { resolveDefaultPluginExtensionsDir } from "./install-paths.js";
 import { persistPluginInstall } from "./install-persistence.js";
+import type { PluginInstallRuntimeDeferral } from "./install-runtime-batch.js";
 import type { InstallSafetyOverrides } from "./install-security-scan.js";
 import type { InstallPolicyWarningDetails } from "./install-security-scan.types.js";
 import {
@@ -231,6 +232,7 @@ type ManagedPluginSourceInstallParams = {
   acknowledgeCapabilities?: PluginCapabilityConsentAcknowledgment;
   onCapabilityConsent?: PluginCapabilityConsentHandler;
   applyRuntime?: PluginLifecycleRuntimeApply;
+  deferRuntime?: PluginInstallRuntimeDeferral;
   beforePersistentApply?: () => void;
   /** Revalidate the initiating owner after artifact review and before durable activation. */
   beforePersistentEffect?: () => void | Promise<void>;

--- a/src/plugins/management-mutations.ts
+++ b/src/plugins/management-mutations.ts
@@ -180,6 +180,7 @@ export async function installManagedPlugin(
         : undefined;
       const installed = await installManagedPluginSource({
         applyRuntime: captured?.applyRuntime,
+        deferRuntime: params.deferRuntime,
         beforePersistentApply,
         request,
         snapshot,

--- a/src/plugins/management-uninstall.ts
+++ b/src/plugins/management-uninstall.ts
@@ -16,6 +16,7 @@ import {
 } from "./install-config-mutation.js";
 import { resolveDefaultPluginExtensionsDir } from "./install-paths.js";
 import { commitPluginInstallRecordsWithConfig } from "./install-record-commit.js";
+import type { PluginInstallRuntimeDeferral } from "./install-runtime-batch.js";
 import {
   loadInstalledPluginIndexInstallRecords,
   removePluginInstallRecordFromRecords,
@@ -232,6 +233,7 @@ export async function uninstallPluginWithPolicy(
     beforePersistentApply?: () => void;
     signal?: AbortSignal;
     applyRuntime?: PluginLifecycleRuntimeApply;
+    deferRuntime?: PluginInstallRuntimeDeferral;
     onPreview?: (preview: PreparedPluginUninstall) => void;
     onWarning?: (warning: string) => void;
     onComplete?: (result: PluginUninstallOutcome) => void;
@@ -296,9 +298,10 @@ export async function uninstallPluginWithPolicy(
               baseHash: snapshot.baseHash,
               writeOptions: {
                 ...guardedWriteOptions(snapshot.writeOptions),
-                afterWrite: params.applyRuntime
-                  ? { mode: "none", reason: "plugin lifecycle applies runtime" }
-                  : { mode: "auto" },
+                afterWrite:
+                  params.applyRuntime || params.deferRuntime
+                    ? { mode: "none", reason: "plugin lifecycle applies runtime" }
+                    : { mode: "auto" },
               },
             }),
           );
@@ -345,7 +348,7 @@ export async function uninstallPluginWithPolicy(
             writeOptions: {
               ...guardedWriteOptions(snapshot.writeOptions),
               ...(cli || params.applyRuntime ? { allowConfigSizeDrop: true } : {}),
-              ...(params.applyRuntime
+              ...(params.applyRuntime || params.deferRuntime
                 ? {
                     afterWrite: {
                       mode: "none" as const,
@@ -358,6 +361,7 @@ export async function uninstallPluginWithPolicy(
             },
           }),
         );
+        params.deferRuntime?.record({ operation: "uninstall", pluginId, write: committed });
         const warnings = [
           ...(!cli
             ? collectClawPluginUninstallWarnings({

--- a/src/plugins/plugin-generation-source-inspection.ts
+++ b/src/plugins/plugin-generation-source-inspection.ts
@@ -1,0 +1,36 @@
+import { capturePluginGenerationArtifact } from "./plugin-generation-artifact.js";
+
+/** Inspect the same source graph the module owner will capture, without evaluating it. */
+export function inspectPluginGenerationSources(
+  entries: readonly { pluginId: string; rootDir: string; entryFile?: string }[],
+) {
+  const bySource = new Map<string, string>();
+  const digests = new Map<string, string>();
+  const checks: Array<() => void> = [];
+  for (const entry of entries) {
+    if (digests.has(entry.pluginId)) {
+      continue;
+    }
+    const key = `${entry.rootDir}\0${entry.entryFile ?? ""}`;
+    let digest = bySource.get(key);
+    if (digest === undefined) {
+      const artifact = capturePluginGenerationArtifact(entry.rootDir, entry.entryFile);
+      try {
+        digest = artifact.sourceDigest;
+        bySource.set(key, digest);
+        checks.push(artifact.assertSourceCurrent);
+      } finally {
+        artifact.dispose();
+      }
+    }
+    digests.set(entry.pluginId, digest);
+  }
+  return {
+    sourceDigests: Object.fromEntries(digests),
+    assertSourceCurrent: () => {
+      for (const check of checks) {
+        check();
+      }
+    },
+  };
+}


### PR DESCRIPTION
Builds on landed #145710. Builds on landed #145484. Related: #135599

<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled.

</details>

## What Problem This Solves

Claw add/update can install several plugin requirements. Applying each immediately exposes an incomplete set; later failures must finish compensation before surviving requirements become active.

## Why This Change Was Made

One batch owner collects committed install/source facts, completes compensation under the existing leases, then releases those leases before a bounded Gateway reload. It revalidates ownership before cleaning retired source files. Replace per-install runtime application and duplicated source inspection with this shared flow.

## User Impact

Claw requirements apply together without restarting the Gateway. Retries reuse saved requirements. An unconfirmed runtime handoff reports recovery guidance and stops before later agent/workspace/MCP/cron changes. Offline behavior remains supported.

## Evidence

[Linux Testbox run 34641392785](https://github.com/openclaw/openclaw/actions/runs/34641392785) passed a normal production build and the original W14/C3/U2 live scenarios on assembled product tree `18b3d63c20bd444aab64980c03ecf1c6132e4517`, based on real F commit `518125d1e6d31132d46be7db61bb996f8a4c671a`. The independent artifact audit passed; four Gateways exited 0, all 34 recorded PIDs were absent, ports closed, and the lease completed. This is combined-source live evidence with synthetic package services; the unit cohort was not rerun in this lane.

C's three scenarios cover two-package add, update, and partial-failure compensation through real CLI/PTY consent and a compiled Gateway, preserving the connection and unrelated resident plugin.

Child delta: production **+720/−159 (net +561)**; tests/support +854/−110; docs +15. The added owner retains committed facts, source checks, deferred cleanup, and compensation across the CLI-to-Gateway lease gap.

Rebased onto real W commit `0377a4282bccb941d7c33b5a5d51372b5ac89c87` as `0b9f04a6f652cd94e847e7ab9579b763bc57827c`, inheriting landed Gateway management change `b5134de70af88e342accaba665590c7cb6b79f0b`. The complete binary diff across all 29 child files is byte-identical to the prior reviewed C revisions. None of the 297 incoming parent paths overlaps C; adjacent RPC/reload contracts remain compatible. Twenty overlap cases and the canonical changed gate passed on C revision `7f1f91e3b4eb6f8cc70c947b0c33309d68edd194`, including core/core-test types, dead-export scans, typed lint, and required guards. These results retain their original source binding; this mechanical sync used source conformance without repeating the gate. The earlier source-qualified C review has no accepted actionable findings.

The live result above remains bound to its assembled product; it is not relabeled as a new live run. Parent W completed its remaining canonical checks, including 1,147 macOS tests; that evidence retains its recorded source binding. Exact-head hosted checks remain part of landing these smaller PRs.


The install-source parent landed as `6e259355b89e390f18a7183249ba964774da60e4`. This PR now targets main at `0a8c766698ba48d12d5b14698540c877ff813dc1`. Its 29-file child patch is preserved through the rebase; the two CLI/docs overlaps are exact three-way merges retaining both batch application and the landed Claw removal path. All other inherited files match the landed parent. The previous `e623221ebe7a17c74c9b2dd6835dd2d2c689a0e6` head passed all 130 CI jobs in run 34683442335; fresh exact-head CI remains required. Historical runtime evidence retains its stated source qualification.
