### PR TITLE
test: make runtime-neutral async assertions

### DIFF
--- a/src/context-engine/context-engine.test.ts
+++ b/src/context-engine/context-engine.test.ts
@@ -22,6 +22,7 @@ import {
   withPluginRegistrationContext,
 } from "../plugins/runtime.js";
 import type { UserTurnTranscriptAdmissionReceipt } from "../sessions/user-turn-transcript.types.js";
+import { escapeRegExp } from "../shared/regexp.js";
 // ---------------------------------------------------------------------------
 // We dynamically import the registry so we can get a fresh module per test
 // group when needed.  For most groups we use the shared singleton directly.
@@ -1503,7 +1504,9 @@ describe("Invalid engine fallback", () => {
           registerTestContextEngine(engineId, () => 42n as unknown as ContextEngine);
         },
         expectedError: (engineId: string) =>
-          `[context-engine] Context engine "${engineId}" owner=test:${engineId} failed during contract-validation: Do not know how to serialize a BigInt; quarantining it for this process and falling back to default engine "legacy".`,
+          new RegExp(
+            `^\\[context-engine\\] Context engine "${escapeRegExp(engineId)}" owner=test:${escapeRegExp(engineId)} failed during contract-validation: .*BigInt.*; quarantining it for this process and falling back to default engine "legacy"\\.$`,
+          ),
       },
     ] as const;
 
@@ -1514,8 +1517,9 @@ describe("Invalid engine fallback", () => {
       const engine = await resolveContextEngine(configWithSlot(testCase.engineId));
 
       expect(engine.info.id, testCase.name).toBe("legacy");
+      const expectedError = testCase.expectedError(testCase.engineId);
       expect(console.error, testCase.name).toHaveBeenCalledWith(
-        testCase.expectedError(testCase.engineId),
+        typeof expectedError === "string" ? expectedError : expect.stringMatching(expectedError),
       );
       expect(
         listContextEngineQuarantines().some((entry) => entry.engineId === testCase.engineId),

--- a/src/realtime-transcription/websocket-session.test.ts
+++ b/src/realtime-transcription/websocket-session.test.ts
@@ -536,7 +536,7 @@ describe("createRealtimeTranscriptionWebSocketSession", () => {
     session.close();
 
     await withTestTimeout(closed.promise, 1_000, "Graceful provider close not received");
-    expect(transcripts).toEqual(["final provider transcript"]);
+    await vi.waitFor(() => expect(transcripts).toEqual(["final provider transcript"]));
     expect(finalizedFrames).toEqual([{ type: "finalize" }]);
   });
 


### PR DESCRIPTION
## What Problem This Solves

Two direct-Bun unit cases asserted runtime scheduling or engine wording rather than the behavior they intended to protect. Bun formats the native BigInt serialization error differently from V8, and a provider-side WebSocket close can be observed before the client message callback runs.

## Why This Change Was Made

The context-engine case still matches the complete quarantine log structure but accepts the JavaScript engine's text in the serialization slot while requiring it to identify BigInt. The realtime transcription case now waits for the client-visible final transcript after the provider closes instead of treating server-side close ordering as proof that the client callback already ran.

## User Impact

This changes tests only. It keeps the same fallback, quarantine, final-transcript, and single-finalize contracts while making their synchronization and native-error assertions valid under Node and Bun.

## Evidence

- Direct custom Bun and Node context-engine suite: 78/78 passed each.
- Direct custom Bun and Node realtime WebSocket suite: 29/29 passed each.
- Before the change, Bun failed the exact V8 BigInt phrase and observed an empty transcript immediately after provider close.
- `node scripts/check-changed.mjs`: passed.
- Test-audit: both edits remove implementation coupling; they retain exact observable outcomes, add no production seam, and do not duplicate stronger coverage.
- Independent P0-P2 autoreview: scoped clean at 0.94 confidence.
