### PR TITLE
perf(tasks): reduce repeated SQLite read work

### DIFF
--- a/src/tasks/task-flow-registry.store.kernel.ts
+++ b/src/tasks/task-flow-registry.store.kernel.ts
@@ -10,6 +10,7 @@ import {
   executeSqliteQuerySync,
   executeSqliteQueryTakeFirstSync,
   getNodeSqliteKysely,
+  prepareSqliteQuerySync,
 } from "../infra/kysely-sync.js";
 import { normalizeSqliteNumber } from "../infra/sqlite-number.js";
 import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-db.generated.js";
@@ -130,6 +131,20 @@ function getFlowRegistryKysely(db: DatabaseSync) {
   return getNodeSqliteKysely<FlowRegistryStoreDatabase>(db);
 }
 
+type TaskFlowRegistryQueries = {
+  point?: ReturnType<typeof prepareSqliteQuerySync<string, FlowRegistryRow>>;
+};
+const taskFlowRegistryQueries = new WeakMap<DatabaseSync, TaskFlowRegistryQueries>();
+
+function getTaskFlowRegistryQueries(db: DatabaseSync): TaskFlowRegistryQueries {
+  let queries = taskFlowRegistryQueries.get(db);
+  if (!queries) {
+    queries = {};
+    taskFlowRegistryQueries.set(db, queries);
+  }
+  return queries;
+}
+
 export function readTaskFlowRegistrySnapshot(db: DatabaseSync): TaskFlowRegistryStoreSnapshot {
   const query = getFlowRegistryKysely(db)
     .selectFrom("flow_runs")
@@ -195,10 +210,18 @@ export function upsertTaskFlowRowInDatabase(db: DatabaseSync, row: BoundTaskFlow
 }
 
 export function readTaskFlowRecord(db: DatabaseSync, flowId: string): TaskFlowRecord | undefined {
-  const row = executeSqliteQueryTakeFirstSync(
-    db,
-    getFlowRegistryKysely(db).selectFrom("flow_runs").selectAll().where("flow_id", "=", flowId),
-  );
+  const queries = getTaskFlowRegistryQueries(db);
+  const read = (queries.point ??= prepareSqliteQuerySync<string, FlowRegistryRow>(db, (parameter) =>
+    getFlowRegistryKysely(db)
+      .selectFrom("flow_runs")
+      .selectAll()
+      .where(
+        "flow_id",
+        "=",
+        parameter((value) => value),
+      ),
+  ));
+  const row = read(flowId).rows[0];
   return row ? rowToFlowRecord(row) : undefined;
 }
 

--- a/src/tasks/task-registry.store.kernel.test.ts
+++ b/src/tasks/task-registry.store.kernel.test.ts
@@ -16,13 +16,19 @@ vi.mock("../plugins/loader-runtime-load.js", () => {
 it("isolates supplied connections and rolls back compound task, flow, delivery, and binding writes", async () => {
   // Cold evaluation proves the dependency boundary even if setup previously loaded a store.
   vi.resetModules();
-  const [tasks, flows, { OPENCLAW_STATE_SCHEMA_SQL }, { runSqliteImmediateTransactionSync }] =
-    await Promise.all([
-      import("./task-registry.store.kernel.js"),
-      import("./task-flow-registry.store.kernel.js"),
-      import("../state/openclaw-state-schema.js"),
-      import("../infra/sqlite-transaction.js"),
-    ]);
+  const [
+    tasks,
+    flows,
+    { OPENCLAW_STATE_SCHEMA_SQL },
+    { runSqliteImmediateTransactionSync },
+    { enableNodeSqliteKyselyStatementCache },
+  ] = await Promise.all([
+    import("./task-registry.store.kernel.js"),
+    import("./task-flow-registry.store.kernel.js"),
+    import("../state/openclaw-state-schema.js"),
+    import("../infra/sqlite-transaction.js"),
+    import("../infra/kysely-sync.js"),
+  ]);
   const first = new DatabaseSync(":memory:");
   const second = new DatabaseSync(":memory:");
   const task: TaskRecord = {
@@ -64,6 +70,7 @@ it("isolates supplied connections and rolls back compound task, flow, delivery, 
   });
   try {
     for (const db of [first, second]) {
+      enableNodeSqliteKyselyStatementCache(db);
       db.exec(OPENCLAW_STATE_SCHEMA_SQL);
       runSqliteImmediateTransactionSync(db, () => {
         tasks.upsertTaskWithDeliveryStateInDatabase(
@@ -86,6 +93,44 @@ it("isolates supplied connections and rolls back compound task, flow, delivery, 
     expect(tasks.listTaskRecordsByRuntimeSourceIdInDatabase(first, "cron", "source-a")).toEqual([
       task,
     ]);
+
+    const otherTask: TaskRecord = {
+      ...task,
+      taskId: "task-b",
+      runtime: "subagent",
+      sourceId: "source-b",
+      ownerKey: "owner-b",
+    };
+    const otherFlow: TaskFlowRecord = { ...flow, flowId: "flow-b", ownerKey: "owner-b" };
+    runSqliteImmediateTransactionSync(first, () => {
+      tasks.upsertTaskRunRowInDatabase({ db: first }, tasks.bindTaskRecord(otherTask));
+      flows.upsertTaskFlowRowInDatabase(first, flows.bindTaskFlowRecord(otherFlow));
+    });
+    expect(tasks.readTaskRecord(first, otherTask.taskId)).toEqual(otherTask);
+    expect(tasks.readTaskRecord(first, "missing")).toBeUndefined();
+    expect(tasks.readTaskRecord(first, task.taskId)).toEqual(task);
+    expect(flows.readTaskFlowRecord(first, otherFlow.flowId)).toEqual(otherFlow);
+    expect(flows.readTaskFlowRecord(first, "missing")).toBeUndefined();
+    expect(flows.readTaskFlowRecord(first, flow.flowId)).toEqual(flow);
+    expect(tasks.listTaskRecordsByRuntimeSourceIdInDatabase(first, "cron")).toEqual([task]);
+    expect(tasks.listTaskRecordsByRuntimeSourceIdInDatabase(first, "subagent")).toEqual([
+      otherTask,
+    ]);
+    expect(tasks.listTaskRecordsByRuntimeSourceIdInDatabase(first, "cron", "")).toEqual([]);
+    expect(tasks.listTaskRecordsByRuntimeSourceIdInDatabase(first, "subagent", "source-a")).toEqual(
+      [],
+    );
+    expect(tasks.listTaskRecordsByRuntimeSourceIdInDatabase(first, "cron", "source-b")).toEqual([]);
+    expect(tasks.listTaskRecordsByRuntimeSourceIdInDatabase(first, "subagent", "source-b")).toEqual(
+      [otherTask],
+    );
+    expect(tasks.listTaskRecordsByOwnerKeyInDatabase(first, "owner-b")).toEqual([otherTask]);
+    expect(tasks.listTaskRecordsByOwnerKeyInDatabase(first, "missing")).toEqual([]);
+    expect(tasks.listTaskRecordsByOwnerKeyInDatabase(first, task.ownerKey)).toEqual([task]);
+    runSqliteImmediateTransactionSync(first, () => {
+      tasks.deleteTaskRowsWithDeliveryState(first, otherTask.taskId);
+      flows.deleteTaskFlowRowInDatabase(first, otherFlow.flowId);
+    });
 
     const before = snapshot();
     const replacement = { ...task, task: "Updated task", detail: null };

--- a/src/tasks/task-registry.store.kernel.ts
+++ b/src/tasks/task-registry.store.kernel.ts
@@ -6,10 +6,12 @@ import {
   bindExecutionOwnerLifecycleMetadata,
   deleteExecutionOwnerLifecycleMetadata,
 } from "../audit/execution-owner-lifecycle-binding-store.js";
+import { executeWithCachedStatement } from "../infra/kysely-sync-cache-state.js";
 import {
   executeSqliteQuerySync,
   executeSqliteQueryTakeFirstSync,
   getNodeSqliteKysely,
+  prepareSqliteQuerySync,
 } from "../infra/kysely-sync.js";
 import { assertSqliteTableIntegrity } from "../infra/sqlite-integrity.js";
 import { normalizeSqliteNumber } from "../infra/sqlite-number.js";
@@ -210,6 +212,23 @@ function getTaskRegistryKysely(db: DatabaseSync) {
   return getNodeSqliteKysely<TaskRegistryStoreDatabase>(db);
 }
 
+type TaskRegistryQuery<Params> = ReturnType<typeof prepareSqliteQuerySync<Params, TaskRegistryRow>>;
+type TaskRegistryQueries = {
+  point?: TaskRegistryQuery<string>;
+  runtime?: TaskRegistryQuery<TaskRuntime>;
+  runtimeSource?: TaskRegistryQuery<{ runtime: TaskRuntime; sourceId: string }>;
+};
+const taskRegistryQueries = new WeakMap<DatabaseSync, TaskRegistryQueries>();
+
+function getTaskRegistryQueries(db: DatabaseSync): TaskRegistryQueries {
+  let queries = taskRegistryQueries.get(db);
+  if (!queries) {
+    queries = {};
+    taskRegistryQueries.set(db, queries);
+  }
+  return queries;
+}
+
 function selectTaskRows(db: DatabaseSync): TaskRegistryRow[] {
   const query = getTaskRegistryKysely(db)
     .selectFrom("task_runs")
@@ -223,14 +242,16 @@ function selectTaskRowsByOwnerKey(db: DatabaseSync, ownerKey: string): TaskRegis
   const selectColumns = TASK_RUN_SELECT_COLUMNS.join(", ");
   // This lookup gates duplicate media tasks. A table scan is intentional so a
   // stale secondary index cannot hide an existing task between integrity checks.
-  return db
-    .prepare(
-      `SELECT ${selectColumns}
+  return executeWithCachedStatement(
+    db,
+    `SELECT ${selectColumns}
        FROM task_runs NOT INDEXED
        WHERE owner_key = ?
        ORDER BY created_at ASC, task_id ASC`,
-    )
-    .all(ownerKey) as TaskRegistryRow[]; // SAFETY: The admitted handle has the canonical columns projected above.
+    [ownerKey],
+    // SAFETY: The admitted handle has the canonical columns projected above.
+    (statement) => statement.all(ownerKey) as TaskRegistryRow[],
+  );
 }
 
 function selectTaskRowsByRuntimeSourceId(
@@ -238,15 +259,45 @@ function selectTaskRowsByRuntimeSourceId(
   runtime: TaskRuntime,
   sourceId?: string,
 ): TaskRegistryRow[] {
-  let query = getTaskRegistryKysely(db)
-    .selectFrom("task_runs")
-    .select(TASK_RUN_SELECT_COLUMNS)
-    .where("runtime", "=", runtime);
-  if (sourceId !== undefined) {
-    query = query.where("source_id", "=", sourceId);
+  const queries = getTaskRegistryQueries(db);
+  if (sourceId === undefined) {
+    const read = (queries.runtime ??= prepareSqliteQuerySync<TaskRuntime, TaskRegistryRow>(
+      db,
+      (parameter) =>
+        getTaskRegistryKysely(db)
+          .selectFrom("task_runs")
+          .select(TASK_RUN_SELECT_COLUMNS)
+          .where(
+            "runtime",
+            "=",
+            parameter((value) => value),
+          )
+          .orderBy("created_at", "asc")
+          .orderBy("task_id", "asc"),
+    ));
+    return read(runtime).rows;
   }
-  return executeSqliteQuerySync(db, query.orderBy("created_at", "asc").orderBy("task_id", "asc"))
-    .rows;
+  const read = (queries.runtimeSource ??= prepareSqliteQuerySync<
+    { runtime: TaskRuntime; sourceId: string },
+    TaskRegistryRow
+  >(db, (parameter) =>
+    getTaskRegistryKysely(db)
+      .selectFrom("task_runs")
+      .select(TASK_RUN_SELECT_COLUMNS)
+      .where(
+        "runtime",
+        "=",
+        parameter((params) => params.runtime),
+      )
+      .where(
+        "source_id",
+        "=",
+        parameter((params) => params.sourceId),
+      )
+      .orderBy("created_at", "asc")
+      .orderBy("task_id", "asc"),
+  ));
+  return read({ runtime, sourceId }).rows;
 }
 
 /** Reads task records from the caller's shared-state transaction. */
@@ -259,13 +310,18 @@ export function listTaskRecordsByRuntimeSourceIdInDatabase(
 }
 
 export function readTaskRecord(db: DatabaseSync, taskId: string): TaskRecord | undefined {
-  const row = executeSqliteQueryTakeFirstSync(
-    db,
+  const queries = getTaskRegistryQueries(db);
+  const read = (queries.point ??= prepareSqliteQuerySync<string, TaskRegistryRow>(db, (parameter) =>
     getTaskRegistryKysely(db)
       .selectFrom("task_runs")
       .select(TASK_RUN_SELECT_COLUMNS)
-      .where("task_id", "=", taskId),
-  );
+      .where(
+        "task_id",
+        "=",
+        parameter((value) => value),
+      ),
+  ));
+  const row = read(taskId).rows[0];
   return row ? rowToTaskRecord(row) : undefined;
 }
 


### PR DESCRIPTION
Related: #145652

## What Problem This Solves

Repeated task and flow reads rebuild and compile the same Kysely query trees even when the shared SQLite owner already reuses their native statements. The duplicate-admission owner lookup also prepares identical SQL on every call.

## Why This Change Was Made

Retain lazy prepared-binding closures in one weak query bag per physical connection in each kernel. Existing task point, runtime/source, and flow point reads continue through the normal synchronous executor with fresh parameters. The duplicate-owner lookup uses the existing bounded native statement cache while keeping its exact `NOT INDEXED` SQL, ordering, `.all()` execution, and error behavior.

The existing cache owner retains responsibility for native statements, active-call reentry, invalidation, and close. No schema, index, transaction, public API, dependency, or persistence change is introduced. Public actor/view query additions are a separate change and can extend these same query bags.

## User Impact

Repeated reads spend less time rebuilding query trees. Database values and ordering remain fresh; intentional duplicate-admission table scans are preserved. This does not activate a worker or claim an end-to-end Gateway latency improvement.

## Evidence

Synthetic canonical SQLite datasets used 1,000 and 10,000 tasks, changing IDs/scopes, and seven alternating paired rounds. Exact SQL, parameters, row results, and query plans matched. At 10,000 tasks, median complete kernel-call timings including decoding were:

| Read | Before | After |
| --- | ---: | ---: |
| Task point hit | 17.96 µs | 6.44 µs |
| Task point miss | 12.30 µs | 1.28 µs |
| Runtime/source scope, 10 rows | 68.50 µs | 52.95 µs |
| Runtime scope, 100 rows | 513.87 µs | 500.77 µs |
| Flow point | 7.24 µs | 5.14 µs |

Warm query compilations fell from 100 to zero per 100 kernel calls. Native prepares on those Kysely reads remained two per 100 calls; their gain comes from compilation reuse. The intentional owner scan reduced native prepares from 100 to two, but scanning dominates at larger row counts.

- 53 kernel/store cases pass, including supplied-connection isolation, changing point/runtime/source bindings, missing reads, empty source filters, cache-enabled execution, and compound rollback. The final fixture transaction wrapper also passed its focused case.
- Six existing ordinary helper contracts pass for fresh/reentrant bindings, active statement reuse, step-time failure, original error reporting, and close behavior.
- A synthetic lifetime probe confirms the closed handle is collected with query bags present, and closed task/flow reads retain the normal database-closed error.
- The full changed-file gate passes, including core and core-test typechecks, lint, export scans, schema/storage guards, and import-cycle checks. Final P2 review and root source review are clean.
- Rebased patch-identically onto main containing #145652; the touched kernel files, query helpers, and row normalization implementation are unchanged in the intervening base.

- [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34678798148) passed after one unchanged retry recovered two unrelated CLI startup timeouts. No source, timeout, assertion, or routing changes were made for that retry.
- The cached `.all()` primitive also preserved the original step error, read successfully afterward, and kept outer bindings during nested SQL callback reentry.
