### PR TITLE
refactor(tests): share CLI runtime capture construction

### DIFF
--- a/src/cli/test-runtime-capture.ts
+++ b/src/cli/test-runtime-capture.ts
@@ -2,6 +2,7 @@
 import { vi } from "vitest";
 import type { OutputRuntimeEnv } from "../runtime.js";
 import type { MockFn } from "../test-utils/vitest-mock-fn.js";
+import { createCliRuntimeMock } from "./test-runtime-mock.js";
 
 export type CliMockOutputRuntime = OutputRuntimeEnv & {
   log: MockFn<OutputRuntimeEnv["log"]>;
@@ -30,36 +31,8 @@ type MockCalls = {
   };
 };
 
-function normalizeRuntimeStdout(value: string): string {
-  return value.endsWith("\n") ? value.slice(0, -1) : value;
-}
-
-function stringifyRuntimeJson(value: unknown, space = 2): string {
-  return JSON.stringify(value, null, space > 0 ? space : undefined);
-}
-
 export function createCliRuntimeCapture(): CliRuntimeCapture {
-  // Capture output in arrays while preserving vi mock call inspection.
-  const runtimeLogs: string[] = [];
-  const runtimeErrors: string[] = [];
-  const stringifyArgs = (args: unknown[]) => args.map((value) => String(value)).join(" ");
-  const defaultRuntime: CliMockOutputRuntime = {
-    log: vi.fn((...args: unknown[]) => {
-      runtimeLogs.push(stringifyArgs(args));
-    }),
-    error: vi.fn((...args: unknown[]) => {
-      runtimeErrors.push(stringifyArgs(args));
-    }),
-    writeStdout: vi.fn((value: string) => {
-      defaultRuntime.log(normalizeRuntimeStdout(value));
-    }),
-    writeJson: vi.fn((value: unknown, space = 2) => {
-      defaultRuntime.log(stringifyRuntimeJson(value, space));
-    }),
-    exit: vi.fn((code: number) => {
-      throw new Error(`__exit__:${code}`);
-    }),
-  };
+  const { runtimeLogs, runtimeErrors, defaultRuntime } = createCliRuntimeMock(vi);
   return {
     runtimeLogs,
     runtimeErrors,


### PR DESCRIPTION
## What Problem This Solves

The CLI capture helper duplicates the runtime factory that other CLI tests already use, including output formatting and mock construction.

## Why This Change Was Made

Construct the capture through the existing `createCliRuntimeMock` owner. Preserve its named types, returned runtime and arrays, array-only reset, writer calls through the original log mock, and caller-owned exit overrides and mock-history resets.

## User Impact

No production change. Test support is +2/-29 (net -27); no cases or assertions are removed, and no new helper options or compatibility layer are added.

## Evidence

On refreshed base `67e1a8b0`, 63 selected cases passed: QR (30), browser extension (22), Update initialization failures (2), and plugin-install enablement (9). The Update run intentionally filtered 491 other cases. All 28 normal changed-file checks passed through the configured Testbox route, including core and test types, lint, import and boundary guards, and all three dead-export scans. The remote runs verified the exact candidate tree and completed lease cleanup. Fresh independent Codex source review found no actionable findings through P2.

The earlier CI failure exposed incomplete plugin manifest fixtures. The canonical repair landed separately in #145794 (`67e1a8b0`); the refreshed nine-case enablement run passed, including the previously failing required-configuration case. This PR retains only the original capture-helper consolidation.

Historical proof on base `cb63df0`: all 27 complete selected consumer and sibling suites passed before and after, with 1,445 cases per phase and identical native case order and results. Helper declaration emission produced 8,460 identical declaration paths and bytes in both phases. Those full-suite and declaration comparisons were not rerun on the refreshed base; they are not packaged SDK build proof.
