### PR TITLE
fix(slack): preserve diagnostics for cyclic error causes

### DIFF
--- a/extensions/slack/src/errors.causes.test.ts
+++ b/extensions/slack/src/errors.causes.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import { formatSlackError } from "./errors.js";
+
+describe("Slack error cause traversal", () => {
+  it("terminates a self-referencing Error cause", () => {
+    const error = new Error("request failed");
+    error.cause = error;
+    expect(formatSlackError(error)).toBe("request failed; cause: [Circular]");
+  });
+
+  it("terminates a multi-error cycle without losing outer metadata", () => {
+    const outer = Object.assign(new Error("request failed"), { code: "transport_error" });
+    const inner = new Error("socket failed", { cause: outer });
+    outer.cause = inner;
+    expect(formatSlackError(outer)).toBe(
+      "request failed; cause: socket failed; cause: [Circular]; code: transport_error",
+    );
+  });
+
+  it("bounds a deeply nested acyclic cause chain", () => {
+    let error = new Error("leaf");
+    for (let index = 0; index < 10_000; index += 1) {
+      error = new Error("wrapper", { cause: error });
+    }
+    const formatted = formatSlackError(error);
+    expect(formatted).toContain("[Cause chain truncated]");
+    expect(formatted.match(/wrapper/gu)).toHaveLength(32);
+    expect(formatted).not.toContain("leaf");
+  });
+
+  it("preserves a short acyclic chain and structured metadata ordering", () => {
+    const inner = Object.assign(new Error("upstream"), { statusCode: 503 });
+    const outer = Object.assign(new Error("request", { cause: inner }), { code: "http_error" });
+    expect(formatSlackError(outer)).toBe(
+      "request; cause: upstream; statusCode: 503; code: http_error",
+    );
+  });
+
+  it("does not retain visited errors between independent formatting calls", () => {
+    const shared = new Error("shared cause");
+    const first = new Error("first", { cause: shared });
+    const second = new Error("second", { cause: shared });
+    expect(formatSlackError(first)).toBe("first; cause: shared cause");
+    expect(formatSlackError(second)).toBe("second; cause: shared cause");
+    expect(formatSlackError(first)).toBe("first; cause: shared cause");
+  });
+
+  it("preserves circular plain-object serialization at a cause leaf", () => {
+    const cause: Record<string, unknown> = {};
+    cause.self = cause;
+    expect(formatSlackError(new Error("outer", { cause }))).toBe(
+      'outer; cause: {"self":"[Circular]"}',
+    );
+  });
+
+  it("preserves primitive causes and empty fallback behavior", () => {
+    expect(formatSlackError(new Error("outer", { cause: 0 }))).toBe("outer; cause: 0");
+    expect(formatSlackError(new Error("outer", { cause: "" }))).toBe("outer");
+    expect(formatSlackError(undefined, "fallback")).toBe("fallback");
+  });
+
+  it("still redacts sensitive strings inside a cyclic cause chain", () => {
+    const token = ["xoxb", "1234567890abcdef"].join("-");
+    const outer = new Error("request failed");
+    const inner = new Error(`Authorization: Bearer ${token}`, { cause: outer });
+    outer.cause = inner;
+    const formatted = formatSlackError(outer);
+    expect(formatted).not.toContain(token);
+    expect(formatted).toContain("xoxb-1…cdef");
+    expect(formatted).toContain("[Circular]");
+  });
+});

--- a/extensions/slack/src/errors.ts
+++ b/extensions/slack/src/errors.ts
@@ -3,6 +3,7 @@ import { redactSensitiveText } from "openclaw/plugin-sdk/logging-core";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 
 const NO_ERROR_DETAIL = "no error detail";
+const MAX_ERROR_CAUSE_DEPTH = 32;
 
 function redact(value: string): string {
   return redactSensitiveText(value);
@@ -113,7 +114,7 @@ function addRecordDetails(details: string[], value: Record<string, unknown>) {
   }
 }
 
-function collectSlackErrorDetails(error: unknown): string[] {
+function collectSlackErrorDetails(error: unknown, seen: Set<Error>): string[] {
   const details: string[] = [];
   if (error === undefined || error === null) {
     return details;
@@ -125,7 +126,7 @@ function collectSlackErrorDetails(error: unknown): string[] {
   if (error instanceof Error) {
     addStringDetail(details, "", error.message || error.name);
     if (error.cause !== undefined) {
-      const cause = formatSlackError(error.cause, "");
+      const cause = formatSlackErrorWithCauses(error.cause, "", seen);
       if (cause) {
         details.push(`cause: ${cause}`);
       }
@@ -141,8 +142,18 @@ function collectSlackErrorDetails(error: unknown): string[] {
   return details;
 }
 
-export function formatSlackError(error: unknown, fallback = NO_ERROR_DETAIL): string {
-  const details = collectSlackErrorDetails(error);
+function formatSlackErrorWithCauses(error: unknown, fallback: string, seen: Set<Error>): string {
+  if (error instanceof Error) {
+    if (seen.has(error)) {
+      return "[Circular]";
+    }
+    // Error.cause can be cyclic or arbitrarily deep; reporting must not overflow the stack.
+    if (seen.size >= MAX_ERROR_CAUSE_DEPTH) {
+      return "[Cause chain truncated]";
+    }
+    seen.add(error);
+  }
+  const details = collectSlackErrorDetails(error, seen);
   if (details.length > 0) {
     return details.join("; ");
   }
@@ -153,4 +164,8 @@ export function formatSlackError(error: unknown, fallback = NO_ERROR_DETAIL): st
     return fallback;
   }
   return safeStringify(error) ?? fallback;
+}
+
+export function formatSlackError(error: unknown, fallback = NO_ERROR_DETAIL): string {
+  return formatSlackErrorWithCauses(error, fallback, new Set<Error>());
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Slack error reporting can itself throw a `RangeError` when an error has a cyclic or sufficiently deep `cause` chain. The original failure details are then lost instead of being returned to the diagnostic caller.

## Why This Change Was Made

Bound recursive cause traversal in the existing Slack error formatter. A per-call visited set detects repeated errors, and a depth limit stops excessively deep chains. Existing message, cause and metadata ordering stays intact, with explicit `[Circular]` and `[Cause chain truncated]` markers for the bounded cases.

The existing safe JSON formatter already handles ordinary object cycles, but does not protect this recursive `Error.cause` path. Repairing its owner avoids caller-specific guards or a new dependency.

## User Impact

Slack diagnostic callers retain usable error text for these inputs instead of failing while reporting an error. Normal error chains, metadata and credential redaction retain their existing behavior. This does not establish a live Slack outage or an SDK exploit.

## Evidence

- Product HEAD: `7bb802be89b4431b0246159387bd4c00d36adbfb`.
- Baseline: `2c167efab94cff1527772938a5732f7efed819de`; Node `v24.21.0` on Linux.
- Production entry/owner: `extensions/slack/src/errors.ts::formatSlackError`. Caller surfaces inspected include `probeSlack`, `formatUnknownError` and reconnect-policy error classification.
- Recorder/readback: actual formatter -> actual repository `redactSensitiveText` -> process stderr and structured receipt. The error objects are synthetic; neither production function is mocked or replaced.
- Same scenarios and repository TS loader were used on the baseline and the committed fix. The self/mutual cycles and a 10,000-error chain throw `RangeError` on the baseline; the repaired formatter returns the bounded observations below.

```text
self cycle:
  before: RangeError on original formatter
  after:  request failed; cause: [Circular]
mutual cycle:
  before: RangeError on original formatter
  after:  request failed; cause: socket failed; cause: [Circular]; code: transport_error
deep chain:
  before: RangeError on original formatter
  after:  32 wrapper messages followed by [Cause chain truncated]
acyclic/metadata control, before and after:
  request; cause: upstream; statusCode: 503; code: http_error
real redactor control, before and after:
  Authorization: Bearer xoxb-1…cdef
  rawSyntheticTokenAbsent=true; independentCallsEqual=true
green receipt: 5/5 cases passed; source_stable=true; isolated_scratch_removed=true
```

Focused test command on the product HEAD:

```sh
node scripts/run-vitest.mjs run extensions/slack/src/errors.causes.test.ts extensions/slack/src/errors.test.ts
```

Result: **13/13 passed**. The original formatter had four targeted test failures with nine passing controls. The actual formatter/redactor process proof above is separate from those unit tests.

Proof command, with `PACKET` pointing to the supplied external validation harness (kept out of the product branch):

```sh
python3 "$PACKET/scripts/run.py" proof B05-01 --repo "$WORK" \
  --base 2c167efab94cff1527772938a5732f7efed819de --mode green --out "$EVIDENCE_DIR"
```

The harness runner used isolated HOME/config/state/tmp directories, selected the baseline/fix expectation explicitly and retained raw stdout/stderr plus the receipt. The useful readback is reproduced inline above; local files alone are not the evidence claim. No production Slack account or other channel was contacted. No persistent fixture resources were created, and the isolated scratch directories were removed.

Additional validation and limits:

- Formatting passed for both changed files; targeted syntax lint checked **2 files / 230 rules**, with no diagnostics. Diff whitespace checks passed.
- Fresh independent autoreview on this exact HEAD: **pass**, no actionable P0/P1/P2 findings.
- Full Slack suite: **2,982 passed / 1 failed** across 158 files. The remaining failure is the existing `provider.auth-test-token.test.ts` org-wide Socket Mode startup case without `app_id` (120-second timeout). It also timed out on the unmodified baseline. No timeout, assertion or startup implementation was changed to hide it.
- Ambient proxy variables initially affected unrelated network fixtures. Running those unchanged fixtures without inherited proxy variables passed **65/65** on the baseline; the subsequent full Slack run left only the startup timeout described above.
- The proof executes source modules through the repository loader. Final-head full application build and complete type-aware lint are deferred to hosted CI; the successful baseline build is not a final-head build claim. Live Slack/SDK caller end-to-end behavior, Bun and other operating systems were not exercised.
- Scope: **2 files; production +19/-4 (net +15), tests +72**. Production growth protects bounded diagnostic traversal; no config/default, protocol/schema, permissions, dependencies, migrations or upgrade steps change. No proof assets or changelog changes are committed.
