### PR TITLE
fix(config): preserve literal keys in validation diagnostics

### DIFF
--- a/docs/cli/config.md
+++ b/docs/cli/config.md
@@ -153,6 +153,8 @@ machine-output spelling and keeps stdout reserved for the schema document.
 
 ### `config validate`
 
+Human validation diagnostics quote literal record keys, such as `agents.defaults.models["provider/model.v1"].alias`, instead of displaying the dot inside a key as nested traversal. Numeric array positions use brackets, such as `agents.entries.main.skills[0]`. The `issues[].path` field in `config validate --json` keeps its existing dot-joined representation.
+
 Validates the current config against the active schema without starting the gateway. It also checks provider/source compatibility for every registry-declared SecretRef, including disabled plugin or channel configuration. This strict command can report an inactive mismatch that does not block normal Gateway startup, where SecretRef resolution remains limited to effectively active surfaces.
 
 After schema validation, it checks every configured manual exec provider's command path using the same non-executing trust checks as startup: file presence, symlinks, trusted directories, permissions, ownership, and Windows ACL availability. `config set`, `config patch`, and `config unset` apply these checks only to providers changed or referenced by the operation, including during dry runs. Replacing the `secrets` or `secrets.providers` collection checks every remaining provider. An unrelated inactive provider does not block targeted repairs or removal of that provider.

--- a/src/cli/config-cli.integration.test.ts
+++ b/src/cli/config-cli.integration.test.ts
@@ -11,11 +11,17 @@ import {
 // Register the harness metadata mock before loading the real config and command modules.
 const configRuntime = await import("../config/config.js");
 const { clearConfigCache } = configRuntime;
+const { formatConfigIssueLines } = await import("../config/issue-format.js");
 const { REDACTED_SENTINEL } = await import("../config/redact-snapshot.js");
 const runtimeSchema = await import("../config/runtime-schema.js");
 const { runConfigGet, runConfigPatch, runConfigSet, runConfigUnset } =
   await import("./config-cli.js");
-const { withConfigFileHarness } = useConfigCliIntegrationHarness();
+const {
+  registeredRuntimeLogs,
+  registeredRuntimeErrors,
+  runRegisteredConfigCommand,
+  withConfigFileHarness,
+} = useConfigCliIntegrationHarness();
 
 function installRuntimeSchemaReadHook(hook: () => void | Promise<void>): void {
   const readSchema = runtimeSchema.readBestEffortRuntimeConfigSchema;
@@ -27,6 +33,79 @@ function installRuntimeSchemaReadHook(hook: () => void | Promise<void>): void {
 }
 
 describe("config cli integration", () => {
+  it("renders actionable paths for real dotted model-key validation failures", async () => {
+    const configForAlias = (alias: string | number) => ({
+      agents: {
+        entries: { main: {} },
+        defaults: { models: { "fixture/model.v1": { alias } } },
+      },
+    });
+    const raw = `${JSON.stringify(configForAlias(42), null, 2)}\n`;
+    const displayPath = 'agents.defaults.models["fixture/model.v1"].alias';
+    const issuePath = "agents.defaults.models.fixture/model.v1.alias";
+
+    await withConfigFileHarness(
+      "openclaw-config-cli-dotted-diagnostic-",
+      raw,
+      async ({ configPath }) => {
+        const snapshot = await configRuntime.readConfigFileSnapshot({ observe: false });
+        expect(snapshot.valid).toBe(false);
+        expect(snapshot.issues).toHaveLength(1);
+        expect(snapshot.issues[0]).toMatchObject({
+          path: issuePath,
+          pathSegments: ["agents", "defaults", "models", "fixture/model.v1", "alias"],
+          message: expect.stringContaining("expected string"),
+        });
+
+        for (const args of [
+          ["config", "validate"],
+          ["config", "get", displayPath],
+        ]) {
+          registeredRuntimeErrors.length = 0;
+          await expect(runRegisteredConfigCommand(args)).rejects.toMatchObject({
+            name: "ExitError",
+            code: 1,
+          });
+          const diagnostic = registeredRuntimeErrors.join("\n");
+          expect(diagnostic).toContain(`openclaw.json:9 — ${displayPath}:`);
+          expect(diagnostic).toContain("expected string");
+          expect(diagnostic).not.toContain(`${issuePath}:`);
+          expect(registeredRuntimeLogs).toEqual([]);
+        }
+
+        registeredRuntimeErrors.length = 0;
+        await expect(
+          runRegisteredConfigCommand(["config", "validate", "--json"]),
+        ).rejects.toMatchObject({ name: "ExitError", code: 1 });
+        expect(registeredRuntimeErrors).toEqual([]);
+        expect(registeredRuntimeLogs).toHaveLength(1);
+        expect(JSON.parse(registeredRuntimeLogs[0] ?? "")).toMatchObject({
+          valid: false,
+          path: configPath,
+          issues: [{ path: issuePath, message: expect.stringContaining("expected string") }],
+        });
+        expect(registeredRuntimeLogs[0]).not.toContain("pathSegments");
+        expect(formatConfigIssueLines(snapshot.issues, "")).toEqual([
+          expect.stringContaining(`${displayPath}:`),
+        ]);
+        expect(fs.readFileSync(configPath, "utf8")).toBe(raw);
+      },
+    );
+
+    registeredRuntimeLogs.length = 0;
+    const validRaw = `${JSON.stringify(configForAlias("qa"), null, 2)}\n`;
+    await withConfigFileHarness(
+      "openclaw-config-cli-dotted-lookup-",
+      validRaw,
+      async ({ configPath }) => {
+        await runRegisteredConfigCommand(["config", "get", displayPath, "--json"]);
+        expect(registeredRuntimeLogs).toEqual(['"qa"']);
+        expect(registeredRuntimeErrors).toEqual([]);
+        expect(fs.readFileSync(configPath, "utf8")).toBe(validRaw);
+      },
+    );
+  });
+
   it("redacts SecretRef ids and plugin-only sensitive fields in JSON/text order", async () => {
     const secretRefId = "CONFIG_GET_TEST_TOKEN";
     const schemaOnlySecrets = ["first-private-route", "second-private-route"];

--- a/src/config/issue-format.test.ts
+++ b/src/config/issue-format.test.ts
@@ -12,7 +12,8 @@ describe("config issue format", () => {
     expect(
       formatConfigIssueLine(
         {
-          path: "agents.list[3].tools.profile",
+          path: "agents.list.3.tools.profile",
+          pathSegments: ["agents", "list", 3, "tools", "profile"],
           message: 'Invalid input, got: "none"',
           line: 247,
           sourceFile: "openclaw.json",
@@ -36,11 +37,18 @@ describe("config issue format", () => {
         [
           { path: "", message: "first" },
           { path: "channels.signal.dmPolicy", message: "second" },
+          { path: "foo.bar", pathSegments: ["foo.bar"], message: "literal" },
+          { path: "foo.bar", pathSegments: ["foo", "bar"], message: "nested" },
         ],
         "×",
         { normalizeRoot: true },
       ),
-    ).toEqual(["× <root>: first", "× channels.signal.dmPolicy: second"]);
+    ).toEqual([
+      "× <root>: first",
+      "× channels.signal.dmPolicy: second",
+      '× ["foo.bar"]: literal',
+      "× foo.bar: nested",
+    ]);
   });
 
   it("sanitizes control characters and ANSI sequences in formatted lines", () => {
@@ -72,16 +80,16 @@ describe("config issue format", () => {
   it("normalizes issue collections for machine output", () => {
     const issues = normalizeConfigIssues([
       {
-        path: "update.channel",
-        pathSegments: ["update", "channel"],
+        path: "models.fixture/model.v1.alias",
+        pathSegments: ["models", "fixture/model.v1", "alias"],
         message: "invalid",
         allowedValues: [],
         allowedValuesHiddenCount: 2,
       },
     ]);
 
-    expect(issues).toEqual([{ path: "update.channel", message: "invalid" }]);
-    expect(issues[0]?.pathSegments).toEqual(["update", "channel"]);
+    expect(issues).toEqual([{ path: "models.fixture/model.v1.alias", message: "invalid" }]);
+    expect(issues[0]?.pathSegments).toEqual(["models", "fixture/model.v1", "alias"]);
     expect(JSON.stringify(issues)).not.toContain("pathSegments");
   });
 });

--- a/src/config/issue-format.ts
+++ b/src/config/issue-format.ts
@@ -1,9 +1,11 @@
 // Formats config validation issues for CLI and diagnostics.
 import { sanitizeTerminalText } from "../../packages/terminal-core/src/safe-text.js";
+import { formatConcreteConfigPath } from "../shared/dot-path.js";
 import type { ConfigValidationIssue } from "./types.js";
 
 type ConfigIssueLineInput = {
   path?: string | null;
+  pathSegments?: readonly (string | number)[];
   message: string;
   line?: number;
   sourceFile?: string;
@@ -93,7 +95,10 @@ export function formatConfigIssueLine(
 ): string {
   const prefix = marker ? `${marker} ` : "";
   const locationPrefix = resolveIssueLocationPrefix(issue, opts);
-  const path = sanitizeTerminalText(resolveIssuePathForLine(issue.path, opts));
+  const issuePath = issue.pathSegments?.length
+    ? formatConcreteConfigPath(issue.pathSegments)
+    : issue.path;
+  const path = sanitizeTerminalText(resolveIssuePathForLine(issuePath, opts));
   const message = sanitizeTerminalText(issue.message);
   return `${prefix}${locationPrefix}${path}: ${message}`;
 }

--- a/src/config/issue-location.test.ts
+++ b/src/config/issue-location.test.ts
@@ -373,7 +373,7 @@ describe("renderConfigValidationIssueLines", () => {
         parsed: config,
         effective: config,
       }),
-    ).toBe('openclaw.json:1 — foo.bar: Invalid input, got: "literal"');
+    ).toBe('openclaw.json:1 — ["foo.bar"]: Invalid input, got: "literal"');
     expect(
       renderIssue({
         issue: issue(["foo", "bar"], "Invalid input"),
@@ -395,7 +395,10 @@ describe("renderConfigValidationIssueLines", () => {
     ).toBe("openclaw.json:1 — gateway.bind: Invalid input");
   });
 
-  it.each(["custom", "vendor.plugin"])("omits plugin-owned values for %s", (pluginId) => {
+  it.each([
+    ["custom", "plugins.entries.custom.config.accessCode"],
+    ["vendor.plugin", 'plugins.entries["vendor.plugin"].config.accessCode'],
+  ])("omits plugin-owned values for %s", (pluginId, displayPath) => {
     const config = {
       plugins: { entries: { [pluginId]: { config: { accessCode: "private" } } } },
     };
@@ -406,6 +409,6 @@ describe("renderConfigValidationIssueLines", () => {
         parsed: config,
         effective: config,
       }),
-    ).toBe(`openclaw.json:1 — plugins.entries.${pluginId}.config.accessCode: Invalid input`);
+    ).toBe(`openclaw.json:1 — ${displayPath}: Invalid input`);
   });
 });

--- a/src/config/issue-location.ts
+++ b/src/config/issue-location.ts
@@ -214,18 +214,6 @@ function lineAtOffset(raw: string, offset: number): number {
   return line;
 }
 
-function formatConfigIssuePath(segments: readonly ConfigIssuePathSegment[]): string {
-  return segments.reduce<string>(
-    (result, segment) =>
-      typeof segment === "number"
-        ? `${result}[${segment}]`
-        : result
-          ? `${result}.${segment}`
-          : segment,
-    "",
-  );
-}
-
 function resolveConfigValueAtPath(
   root: unknown,
   segments: readonly ConfigIssuePathSegment[],
@@ -330,7 +318,6 @@ type AttachConfigIssueDiagnosticsParams = {
   parsed: unknown;
   effective: unknown;
   configPath?: string | null;
-  formatPathForDisplay?: boolean;
   includeReceivedValueHint?: boolean;
 };
 
@@ -365,7 +352,8 @@ function attachConfigIssueDiagnostics(
         : issue.message;
     return {
       ...issue,
-      path: params.formatPathForDisplay ? formatConfigIssuePath(segments) : issue.path,
+      // Validation path metadata is non-enumerable; preserve it through this display copy.
+      pathSegments: segments,
       message,
       ...(line === undefined ? {} : { line, sourceFile }),
     };
@@ -382,7 +370,6 @@ export function renderConfigValidationIssueLines(
     parsed: snapshot.parsed,
     effective: snapshot.sourceConfig,
     configPath: snapshot.path,
-    formatPathForDisplay: true,
     includeReceivedValueHint: true,
   });
   const lines = formatConfigIssueLines(issues, marker, { normalizeRoot: true });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where config validation diagnostics displayed a literal key containing a dot as nested traversal. An invalid alias under `"fixture/model.v1"` was reported as `agents.defaults.models.fixture/model.v1.alias`, which points readers toward the wrong key structure.

## Why This Change Was Made

Validation already records typed path segments. The shared human formatter now sends those segments through the existing concrete-config-path formatter, and the private location-aware rendering copy preserves them. The duplicate path formatter and its display-only switch are removed.

Formatted production is **8 lines added / 16 removed, net −8**. Tests are +100/−10; documentation is +2. Config acceptance, raw structured issue paths, received-value suppression and terminal sanitization remain in their existing owners.

## User Impact

Human diagnostics display `agents.defaults.models["fixture/model.v1"].alias`, preserving the literal key and allowing the existing quoted getter syntax to reach it. Source locations and numeric array indices remain intact. The structured `issues[].path` field keeps its existing dot-joined representation; human-formatted message strings improve wherever the shared formatter is used.

## Evidence

- Tests-first baseline: **5 intended failures and 83 passing controls** across the formatter, location, path parser and registered CLI. The real-schema CLI test confirmed correct typed path metadata before failing on ambiguous human output. All **88 tests** pass after the repair.
- Eight ordinary built-CLI cases per phase, without schema/metadata mocks or import hooks: only the two human literal-key path spellings change. Raw JSON issue fields, actual string/numeric getter values, ordinary nested paths, array indices, source lines and command-owned hints remain unchanged.
- Every private config retains its exact bytes, mode, inode and modification time. All nine processes per phase exit naturally with complete stdout/stderr and no remaining owned groups or supervisor signals. Independent audits inspected the raw captures and actual compiled formatters/callers.
- Full changed-file checks and a fresh `pnpm build ciArtifacts` pass; candidate build took 109.8 seconds. Fresh managed P0–P2 review and independent source/current-main reviews found no actionable defect.

The CLI proof uses the supported Node 24.20.0 final runtime on macOS, with the launcher's existing experimental-warning flag and disabled compile cache. It binds all generated outputs and named source/Zod/Commander/JSON5 files with qualified frozen-install evidence. It does not claim a fully hermetic native/transitive dependency closure, startup respawn coverage, provider execution or Gateway serving behavior. Both phase reports and their eight-case pairing are retained.

Current reviewed head: `4a1182173d47414c1fa67e1762993db8a9150539`. Its full-index committed patch is identical to the tested and reviewed precommit source. Independent raw/compiled candidate pairing found no blocking discrepancy; hosted CI remains required before native landing.
