### PR TITLE
improve(agents): reduce work ranking Tool Search results

### DIFF
--- a/src/agents/tool-search-ranking.test.ts
+++ b/src/agents/tool-search-ranking.test.ts
@@ -34,11 +34,11 @@ const CATALOG = [
   }),
 ];
 
-function runtime(): ToolSearchRuntime {
+function runtime(catalog = CATALOG): ToolSearchRuntime {
   const ctx = {
     catalogRef: {
       current: {
-        entries: CATALOG,
+        entries: catalog,
         counterScope: "scope-1",
         searchCount: 0,
         describeCount: 0,
@@ -258,6 +258,17 @@ describe("untrusted schemas", () => {
 });
 
 describe("ToolSearchRuntime.search", () => {
+  it("preserves ranked exact-match order when the limit excludes other exact matches", async () => {
+    const search = runtime([
+      entry({ id: "z", name: "harvest", description: "Collect records" }),
+      entry({ id: "a", name: "harvest", description: "Collect records" }),
+      entry({ id: "m", name: "HARVEST", description: "Collect records" }),
+      entry({ name: "records", description: "harvest" }),
+    ]);
+
+    expect((await search.search("harvest", { limit: 2 })).map((hit) => hit.id)).toEqual(["a", "m"]);
+  });
+
   it.each([
     {
       query: "scheduling",

--- a/src/agents/tool-search-runtime.ts
+++ b/src/agents/tool-search-runtime.ts
@@ -1,5 +1,6 @@
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { getPluginToolMeta } from "../plugins/tool-metadata.js";
+import { sortAndLimitBy } from "../shared/sort-and-limit.js";
 import { resolveAgentToolExecutionSchema } from "./agent-tool-availability.js";
 import {
   finalizeToolTerminalPresentation,
@@ -409,19 +410,25 @@ export class ToolSearchRuntime {
       };
       catalogIndexes.set(indexKey, cachedIndex);
     }
-    const ranked = scoreLexical(cachedIndex.index, tokenizeQuery(query))
-      .toSorted(
-        (a, b) =>
-          Number(isExact(b.value)) - Number(isExact(a.value)) ||
-          Number(b.matchedLiteral) - Number(a.matchedLiteral) ||
-          b.score - a.score ||
-          a.value.id.localeCompare(b.value.id),
-      )
-      .map((hit) => hit.value);
+    const hits = scoreLexical(cachedIndex.index, tokenizeQuery(query));
+    const exactMatchSet = new Set(exactMatches);
     // A tool whose name is a stopword ("do") tokenizes to nothing and so never
     // reaches the ranking at all. Naming it exactly is still an unambiguous
     // request for it, which the previous scorer honored.
-    const exactEntries = exactMatches.filter((entry) => !ranked.includes(entry));
+    const exactEntries = exactMatches.filter((entry) => !hits.some((hit) => hit.value === entry));
+    const remaining = limit - exactEntries.length;
+    const ranked =
+      remaining > 0
+        ? sortAndLimitBy(
+            hits,
+            remaining,
+            (a, b) =>
+              Number(exactMatchSet.has(b.value)) - Number(exactMatchSet.has(a.value)) ||
+              Number(b.matchedLiteral) - Number(a.matchedLiteral) ||
+              b.score - a.score ||
+              a.value.id.localeCompare(b.value.id),
+          ).map((hit) => hit.value)
+        : [];
     return [...exactEntries, ...ranked]
       .slice(0, limit)
       .map((entry) => compactToolSearchCatalogEntry(entry));


### PR DESCRIPTION
## What Problem This Solves

Tool Search sorts every lexical hit and repeatedly normalizes exact names inside the comparator, even when a large catalog search requests only a few results.

## Why This Change Was Made

Use the existing stable `sortAndLimitBy` owner for the remaining result budget and compute exact-match membership once. Identify exact entries missing from all lexical hits before limiting, preserving stopword catalog order and the existing exact-name, literal-match, score, and ID tiers. The exact single-result shortcut, visibility filtering, and index invalidation stay with the existing runtime owner.

## User Impact

Broad searches over large tool catalogs perform less sorting work while returning the same compact results. The structured single/batch search tools and code-mode search bridge consume the same runtime change.

## Evidence

- Benchmarked the actual `ToolSearchRuntime.search` owner at base `3f75b33d671` against candidate `658f188fe8e`, using the same checkout dependencies and shared sorter from #145682. Node 26.8.2 / V8 14.6.202.34-node.28; synthetic catalogs of 100/1,000/5,000 entries, cached indexes, nine alternating before/after batches per timing cell. Catalog construction and module startup are outside the timed searches. All 180 base output-parity combinations plus stopwords, ambiguous exact limits, visibility, and catalog/schema mutation cases passed.

| 5,000-entry workload | Limit | Before median | After median |
| --- | ---: | ---: | ---: |
| Shuffled, broad `search records` | 8 | 11.28 ms | 1.70 ms |
| Shuffled, broad `search records` | 50 | 11.69 ms | 1.68 ms |
| Shuffled, narrow `file` | 8 | 2.02 ms | 1.15 ms |
| ID-ordered tied catalog, narrow `file` | 50 | 1.25 ms | 1.38 ms |

- Broad search improved 6.65x in the paired matrix. Fresh-process ABBA controls confirmed the gain: 13.45 ms to 2.63 ms aggregate median (5.12x), with batch ranges 10.57–16.59 ms before and 1.41–5.65 ms after. Exact outputs matched across the fresh processes.
- Tradeoff: five ID-ordered tied workload cells were 4–13% slower in the paired matrix, including narrow `file` queries about 0.12 ms slower at 5,000 entries. Fresh-process controls for the 5,000-entry/limit-50 case were noisy and reversed the result (4.61 ms before, 2.58 ms after, overlapping ranges); no narrow tied-catalog speedup is claimed, and a small slowdown remains possible.
- Whole-process peak RSS in the fresh controls was 544.6–546.8 MiB before versus 526.0–537.5 MiB after for broad searches, and 508.0–517.5 MiB before versus 534.0–536.5 MiB after for tied narrow searches. These include module loading and GC effects; no RSS reduction is claimed.
- 301 tests passed across `tool-search-ranking.test.ts`, `tool-search-runtime.test.ts`, and `tool-search.test.ts`. Added actual-runtime coverage for ambiguous exact matches at a result cutoff; existing tests cover stopword order, visibility, the exact-name shortcut, and cache invalidation.
- Independent P2 review is scoped-clean with no findings. Targeted formatting, oxlint, and `git diff --check` passed. Initial selected static guards and all 11 remaining lightweight guards passed, including the core graph boundary, schema/store guards, and import-cycle check.
- Local gaps: the original changed-gate run was interrupted before core/core-test types completed. The unused-export production scan passed with zero entries; its script scope failed on the unchanged `scripts/crabbox-wrapper-providers.mts:canonicalProviderName` export (identical base/candidate blob), and the full-tree scope produced no usable result. The unused-export gate is not claimed passing. Full required gate evidence is tracked by [CI for candidate 658f188fe8e](https://github.com/openclaw/openclaw/actions/runs/34679080222) and the native merge receipt.
