### PR TITLE
fix(models): make discovered models available to new turns

### DIFF
--- a/docs/plugins/sdk-overview/host-hooks.md
+++ b/docs/plugins/sdk-overview/host-hooks.md
@@ -271,6 +271,16 @@ separately when distinct identities share a combined reference. Human-name
 matching, alias/date version selection, and case-insensitive glob scopes remain
 available.
 
+`ModelRegistry.fork(authStorage, publishedModels?)` creates an isolated registry.
+`authStorage` supplies that caller's credentials. The optional `publishedModels`
+is a read-only map from provider ID to complete validated runtime model rows;
+an empty array withdraws that provider's rows. Omitted providers keep the captured
+catalog. Forks retain the current source's authored request settings and runtime
+registrations, and later `refresh()` calls retain the captured model publication.
+Published model metadata does not supply credentials or authorize an account.
+The optional argument requires a host release containing executable catalog
+publication; the v2026.9.4 host supports only `fork(authStorage)`.
+
 Session extension SDK and supported TypeBox imports share the host's modules.
 
 The contracts intentionally split authority:

--- a/docs/plugins/sdk-overview/host-hooks.md
+++ b/docs/plugins/sdk-overview/host-hooks.md
@@ -280,6 +280,8 @@ registrations, and later `refresh()` calls retain the captured model publication
 Published model metadata does not supply credentials or authorize an account.
 The optional argument requires a host release containing executable catalog
 publication; the v2026.9.4 host supports only `fork(authStorage)`.
+This session-extension subpath is runtime-only and does not publish TypeScript
+declarations.
 
 Session extension SDK and supported TypeBox imports share the host's modules.
 

--- a/src/agents/prepared-model-catalog-worker.ts
+++ b/src/agents/prepared-model-catalog-worker.ts
@@ -7,6 +7,7 @@ import { projectConfigOntoRuntimeSourceSnapshot } from "../config/runtime-source
 import { runtimeProcessEntrypoints } from "../infra/runtime-process-entrypoints.js";
 import { resolveRuntimeWorkerUrl } from "../infra/runtime-worker-url.js";
 import { WorkerTaskError, WorkerTaskPool } from "../infra/worker-task-pool.js";
+import type { Model } from "../llm/types.js";
 import { resolveInstalledManifestRegistryIndexFingerprint } from "../plugins/manifest-registry-installed.js";
 import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.types.js";
 import { captureProviderSyntheticAuthFacts } from "../plugins/provider-runtime.js";
@@ -66,6 +67,7 @@ export type PreparedModelWorkerResult =
       kind: "catalog";
       generationFingerprint: string;
       snapshot: ModelCatalogSnapshot;
+      runtimeModels: Map<string, Model[]>;
       configuredRuntimeModels: PreparedModelRuntimeCatalogFacts["configuredRuntimeModels"];
       credentials: Readonly<AuthStorageData>;
       providerAuthLabels: ModelCatalogAuthLabels;
@@ -204,9 +206,11 @@ type PreparedModelCatalogWorker = Readonly<{
   loadAuth: (
     scope: PreparedModelRuntimeAuthScope,
   ) => Promise<PreparedModelRuntimeAuth & { credentials: Readonly<AuthStorageData> }>;
-  loadCatalog: (
-    providerIds?: readonly string[],
-  ) => Promise<Pick<PreparedModelRuntimeCatalogFacts, "modelCatalog" | "configuredRuntimeModels">>;
+  loadCatalog: (providerIds?: readonly string[]) => Promise<
+    Pick<PreparedModelRuntimeCatalogFacts, "modelCatalog" | "configuredRuntimeModels"> & {
+      runtimeModels: Map<string, Model[]>;
+    }
+  >;
 }>;
 
 export function createPreparedModelCatalogWorker(
@@ -389,7 +393,11 @@ export function createPreparedModelCatalogWorker(
         credentials: message.credentials,
         providerAuthLabels: message.providerAuthLabels,
       });
-      return { modelCatalog, configuredRuntimeModels: message.configuredRuntimeModels };
+      return {
+        modelCatalog,
+        configuredRuntimeModels: message.configuredRuntimeModels,
+        runtimeModels: message.runtimeModels,
+      };
     },
     loadAuth: async ({ providerIds, profileIds }) => {
       const normalizedProviderIds = [...new Set(providerIds)].toSorted((left, right) =>

--- a/src/agents/prepared-model-catalog.worker.ts
+++ b/src/agents/prepared-model-catalog.worker.ts
@@ -340,11 +340,21 @@ export async function runPreparedModelCatalogWorkerRequest(
       ),
       ...credentials,
     };
+    const runtimeModels = Map.groupBy(facts.templateModelRegistry.getAll(), (model) =>
+      normalizeProviderId(model.provider),
+    );
+    for (const outcome of facts.modelCatalog.providerOutcomes ?? []) {
+      const provider = normalizeProviderId(outcome.provider);
+      if (!runtimeModels.has(provider)) {
+        runtimeModels.set(provider, []);
+      }
+    }
     return {
       status: "ok",
       kind: "catalog",
       generationFingerprint,
       snapshot: facts.modelCatalog,
+      runtimeModels,
       configuredRuntimeModels: facts.configuredRuntimeModels,
       credentials: catalogCredentials,
       providerAuthLabels: withPluginRuntimeGenerationScope(pluginGenerationScope, () =>

--- a/src/agents/prepared-model-catalog.worker.ts
+++ b/src/agents/prepared-model-catalog.worker.ts
@@ -8,6 +8,7 @@ import {
 } from "../config/resolution-facts.js";
 import { setRuntimeConfigSnapshot } from "../config/runtime-snapshot.js";
 import { serveWorkerTasks } from "../infra/worker-task-pool.js";
+import type { Model } from "../llm/types.js";
 import { listRuntimePluginIdsFromRegistry } from "../plugins/active-runtime-registry.js";
 import { normalizePluginsConfig } from "../plugins/config-state.js";
 import { isManifestPluginAvailableForControlPlane } from "../plugins/manifest-contract-eligibility.js";
@@ -340,9 +341,13 @@ export async function runPreparedModelCatalogWorkerRequest(
       ),
       ...credentials,
     };
-    const runtimeModels = Map.groupBy(facts.templateModelRegistry.getAll(), (model) =>
-      normalizeProviderId(model.provider),
-    );
+    const runtimeModels = new Map<string, Model[]>();
+    for (const model of facts.templateModelRegistry.getAll()) {
+      const provider = normalizeProviderId(model.provider);
+      const models = runtimeModels.get(provider) ?? [];
+      models.push(model);
+      runtimeModels.set(provider, models);
+    }
     for (const outcome of facts.modelCatalog.providerOutcomes ?? []) {
       const provider = normalizeProviderId(outcome.provider);
       if (!runtimeModels.has(provider)) {

--- a/src/agents/prepared-model-runtime-lease.ts
+++ b/src/agents/prepared-model-runtime-lease.ts
@@ -4,6 +4,7 @@ import { withPluginMetadataSnapshotScope } from "../plugins/current-plugin-metad
 import { resolvePluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
 import { isReservedSystemAgentId } from "../system-agent/agent-id.js";
 import { getPreparedModelRuntimeBorrowedSnapshot } from "./prepared-model-runtime-generation-scope.js";
+import { capturePreparedModelRuntimeCatalog } from "./prepared-model-runtime.capture.js";
 import {
   PreparedModelRuntimeOwnerNotPublishedError,
   PreparedModelRuntimePublicationSupersededError,
@@ -311,6 +312,20 @@ export async function acquirePreparedModelRuntimeLeaseFromOwners(
   }
   try {
     assertAdmission();
+    const configuredOwner = resolveConfiguredOwner(context.owners, input);
+    const catalogOwner =
+      configuredOwner &&
+      ownerKey({
+        ...configuredOwner.input,
+        loadRuntimePlugins: false,
+        runtimePluginSelections: undefined,
+      }) === ownerKey({ ...input, loadRuntimePlugins: false, runtimePluginSelections: undefined })
+        ? configuredOwner
+        : owner;
+    snapshot = capturePreparedModelRuntimeCatalog(
+      snapshot,
+      catalogOwner.snapshot?.readPublishedModels?.(),
+    );
     const pluginGeneration = owner.pluginGeneration!;
     if (owner.provenance !== provenance) {
       return {

--- a/src/agents/prepared-model-runtime.capture.ts
+++ b/src/agents/prepared-model-runtime.capture.ts
@@ -1,0 +1,28 @@
+import type { Model } from "../llm/types.js";
+import { copyPreparedModelRuntimeAuthBindings } from "./prepared-model-runtime-auth.js";
+import type { PreparedModelRuntimeSnapshot } from "./prepared-model-runtime.types.js";
+import { AuthStorage } from "./sessions/auth-storage.js";
+
+/** Captures executable discovery for a new lease without changing any open lease. */
+export function capturePreparedModelRuntimeCatalog(
+  snapshot: PreparedModelRuntimeSnapshot,
+  models: ReadonlyMap<string, readonly Model[]> | undefined,
+): PreparedModelRuntimeSnapshot {
+  if (!models) {
+    return snapshot;
+  }
+  const stores = snapshot.createStores();
+  const credentials = stores.authStorage.getAll();
+  const registry = stores.modelRegistry.fork(stores.authStorage, models);
+  const captured: PreparedModelRuntimeSnapshot = Object.freeze({
+    ...snapshot,
+    readPublishedModels: () => models,
+    routeModelResolutionMemo: new Map(),
+    createStores: () => {
+      const authStorage = AuthStorage.inMemory(credentials);
+      return { authStorage, modelRegistry: registry.fork(authStorage) };
+    },
+  });
+  copyPreparedModelRuntimeAuthBindings(snapshot, captured);
+  return captured;
+}

--- a/src/agents/prepared-model-runtime.capture.ts
+++ b/src/agents/prepared-model-runtime.capture.ts
@@ -3,13 +3,26 @@ import { copyPreparedModelRuntimeAuthBindings } from "./prepared-model-runtime-a
 import type { PreparedModelRuntimeSnapshot } from "./prepared-model-runtime.types.js";
 import { AuthStorage } from "./sessions/auth-storage.js";
 
+const catalogRouteMemos = new WeakMap<
+  PreparedModelRuntimeSnapshot,
+  {
+    models: ReadonlyMap<string, readonly Model[]>;
+    memo: Map<string, Promise<Model>>;
+  }
+>();
+
 /** Captures executable discovery for a new lease without changing any open lease. */
 export function capturePreparedModelRuntimeCatalog(
   snapshot: PreparedModelRuntimeSnapshot,
   models: ReadonlyMap<string, readonly Model[]> | undefined,
 ): PreparedModelRuntimeSnapshot {
-  if (!models) {
+  if (!models?.size) {
     return snapshot;
+  }
+  let cached = catalogRouteMemos.get(snapshot);
+  if (!cached || cached.models !== models) {
+    cached = { models, memo: new Map() };
+    catalogRouteMemos.set(snapshot, cached);
   }
   const stores = snapshot.createStores();
   const credentials = stores.authStorage.getAll();
@@ -17,7 +30,7 @@ export function capturePreparedModelRuntimeCatalog(
   const captured: PreparedModelRuntimeSnapshot = Object.freeze({
     ...snapshot,
     readPublishedModels: () => models,
-    routeModelResolutionMemo: new Map(),
+    routeModelResolutionMemo: cached.memo,
     createStores: () => {
       const authStorage = AuthStorage.inMemory(credentials);
       return { authStorage, modelRegistry: registry.fork(authStorage) };

--- a/src/agents/prepared-model-runtime.catalog-access.ts
+++ b/src/agents/prepared-model-runtime.catalog-access.ts
@@ -34,6 +34,8 @@ import {
 } from "./prepared-model-runtime.facts.js";
 import {
   type PreparedModelRuntimeCatalogAccess,
+  filterPreparedProviderCatalog,
+  mergePreparedProviderCatalog,
   isPreparedModelCatalogFull,
   markPreparedModelCatalogFull,
   materializePreparedModelCatalog,
@@ -119,44 +121,6 @@ function preparedProviderCatalogCredentials(
       Object.entries(authStore.order ?? {}).filter(([id]) => normalize(id) === provider),
     ),
   });
-}
-
-function filterPreparedProviderCatalog(
-  catalog: ModelCatalogSnapshot,
-  includesProvider: (provider: string) => boolean,
-): ModelCatalogSnapshot {
-  return {
-    ...catalog,
-    entries: catalog.entries.filter((entry) => includesProvider(entry.provider)),
-    routeVariants: catalog.routeVariants.filter((entry) => includesProvider(entry.provider)),
-    staticEntries: catalog.staticEntries?.filter((entry) => includesProvider(entry.provider)),
-    providerOutcomes: catalog.providerOutcomes?.filter((outcome) =>
-      includesProvider(outcome.provider),
-    ),
-  };
-}
-
-function mergePreparedProviderCatalog(
-  previous: ModelCatalogSnapshot | undefined,
-  discovered: ModelCatalogSnapshot,
-  providers: ReadonlySet<string>,
-  normalize: (provider: string) => string,
-): ModelCatalogSnapshot {
-  const retained =
-    previous &&
-    filterPreparedProviderCatalog(previous, (provider) => !providers.has(normalize(provider)));
-  const scoped = filterPreparedProviderCatalog(discovered, (provider) =>
-    providers.has(normalize(provider)),
-  );
-  const outcomes = [...(retained?.providerOutcomes ?? []), ...(scoped.providerOutcomes ?? [])];
-  return {
-    ...scoped,
-    entries: [...(retained?.entries ?? []), ...scoped.entries],
-    routeVariants: [...(retained?.routeVariants ?? []), ...scoped.routeVariants],
-    staticEntries: [...(retained?.staticEntries ?? []), ...(scoped.staticEntries ?? [])],
-    providerOutcomes: outcomes,
-    authoritative: outcomes.every((outcome) => outcome.status === "ready"),
-  };
 }
 
 export function createFullModelCatalogAccess(params: {

--- a/src/agents/prepared-model-runtime.catalog-access.ts
+++ b/src/agents/prepared-model-runtime.catalog-access.ts
@@ -265,6 +265,11 @@ export function createFullModelCatalogAccess(params: {
           catalog: filterPreparedProviderCatalog(previousInventory.catalog, (provider) =>
             retainedProviders.has(normalizeProvider(provider)),
           ),
+          runtimeModels: new Map(
+            [...previousInventory.runtimeModels].filter(([provider]) =>
+              retainedProviders.has(normalizeProvider(provider)),
+            ),
+          ),
           nativeSource,
           providerSources: new Map(
             [...previousInventory.providerSources].filter(([provider]) =>
@@ -433,8 +438,11 @@ export function createFullModelCatalogAccess(params: {
       for (const providerIds of scopes) {
         await limitFullModelCatalogBuild(async () => {
           assertCurrent();
-          const { modelCatalog: workerCatalog, configuredRuntimeModels } =
-            await worker.loadCatalog(providerIds);
+          const {
+            modelCatalog: workerCatalog,
+            configuredRuntimeModels,
+            runtimeModels,
+          } = await worker.loadCatalog(providerIds);
           assertCurrent();
           const scope = new Set(
             (
@@ -477,11 +485,20 @@ export function createFullModelCatalogAccess(params: {
                   scope.has(normalizeProvider(provider)),
                 )
               : workerCatalog,
+            new Map(
+              [...runtimeModels].filter(([provider]) => scope.has(normalizeProvider(provider))),
+            ),
             inventory,
             auth,
             normalizeProvider,
           );
           if (providerIds) {
+            publication.runtimeModels = new Map([
+              ...[...(inventory?.runtimeModels ?? [])].filter(
+                ([provider]) => !scope.has(normalizeProvider(provider)),
+              ),
+              ...publication.runtimeModels,
+            ]);
             publication.catalog = mergePreparedProviderCatalog(
               inventory?.catalog,
               publication.catalog,
@@ -619,6 +636,7 @@ export function createFullModelCatalogAccess(params: {
           setPreparedModelFullCatalogAuth(rawCatalog, catalogAuth);
           inventory = {
             catalog: mergePreparedNativeCatalog(rawCatalog, rawInventory),
+            runtimeModels: inventory?.runtimeModels ?? new Map(),
             key: inventoryKey,
             pluginFingerprint,
             nativeSource,
@@ -691,6 +709,10 @@ export function createFullModelCatalogAccess(params: {
     readFullModelCatalog: () => {
       assertCurrent();
       return fullCatalog;
+    },
+    readPublishedModels: () => {
+      assertCurrent();
+      return inventory?.runtimeModels;
     },
     loadFullModelCatalog: async (options) => {
       let timer: ReturnType<typeof setTimeout> | undefined;

--- a/src/agents/prepared-model-runtime.full-catalog.ts
+++ b/src/agents/prepared-model-runtime.full-catalog.ts
@@ -155,6 +155,44 @@ export function mergePreparedNativeCatalog(
   };
 }
 
+export function filterPreparedProviderCatalog(
+  catalog: ModelCatalogSnapshot,
+  includesProvider: (provider: string) => boolean,
+): ModelCatalogSnapshot {
+  return {
+    ...catalog,
+    entries: catalog.entries.filter((entry) => includesProvider(entry.provider)),
+    routeVariants: catalog.routeVariants.filter((entry) => includesProvider(entry.provider)),
+    staticEntries: catalog.staticEntries?.filter((entry) => includesProvider(entry.provider)),
+    providerOutcomes: catalog.providerOutcomes?.filter((outcome) =>
+      includesProvider(outcome.provider),
+    ),
+  };
+}
+
+export function mergePreparedProviderCatalog(
+  previous: ModelCatalogSnapshot | undefined,
+  discovered: ModelCatalogSnapshot,
+  providers: ReadonlySet<string>,
+  normalize: (provider: string) => string,
+): ModelCatalogSnapshot {
+  const retained =
+    previous &&
+    filterPreparedProviderCatalog(previous, (provider) => !providers.has(normalize(provider)));
+  const scoped = filterPreparedProviderCatalog(discovered, (provider) =>
+    providers.has(normalize(provider)),
+  );
+  const outcomes = [...(retained?.providerOutcomes ?? []), ...(scoped.providerOutcomes ?? [])];
+  return {
+    ...scoped,
+    entries: [...(retained?.entries ?? []), ...scoped.entries],
+    routeVariants: [...(retained?.routeVariants ?? []), ...scoped.routeVariants],
+    staticEntries: [...(retained?.staticEntries ?? []), ...(scoped.staticEntries ?? [])],
+    providerOutcomes: outcomes,
+    authoritative: outcomes.every((outcome) => outcome.status === "ready"),
+  };
+}
+
 export function prepareModelCatalogPublication(
   discovered: ModelCatalogSnapshot,
   runtimeModels: ReadonlyMap<string, readonly Model[]>,

--- a/src/agents/prepared-model-runtime.full-catalog.ts
+++ b/src/agents/prepared-model-runtime.full-catalog.ts
@@ -157,10 +157,13 @@ export function mergePreparedNativeCatalog(
 
 export function prepareModelCatalogPublication(
   discovered: ModelCatalogSnapshot,
-  inventory: Pick<PreparedModelCatalogInventory, "catalog" | "discoveryOrigins"> | undefined,
+  runtimeModels: ReadonlyMap<string, readonly Model[]>,
+  inventory:
+    | Pick<PreparedModelCatalogInventory, "catalog" | "discoveryOrigins" | "runtimeModels">
+    | undefined,
   auth: PreparedModelCatalogAuth,
   normalizeProvider: (provider: string) => string,
-): Pick<PreparedModelCatalogInventory, "catalog" | "discoveryOrigins"> {
+): Pick<PreparedModelCatalogInventory, "catalog" | "discoveryOrigins" | "runtimeModels"> {
   // Provider discovery publishes provider rows; the inventory owner merges native observations.
   const catalog: ModelCatalogSnapshot = {
     ...discovered,
@@ -176,7 +179,7 @@ export function prepareModelCatalogPublication(
     .filter((outcome) => outcome.status === "ready")
     .map(({ provider, profileId }) => ({ provider: normalizeProvider(provider), profileId }));
   if (failed.length === 0) {
-    return { catalog, discoveryOrigins };
+    return { catalog, discoveryOrigins, runtimeModels };
   }
   const previous = inventory?.catalog;
   const previousAuth = previous && getPreparedModelFullCatalogAuth(previous);
@@ -255,6 +258,14 @@ export function prepareModelCatalogPublication(
   setPreparedModelFullCatalogAuth(published, auth);
   return {
     catalog: published,
+    runtimeModels: new Map([
+      ...[...runtimeModels].filter(
+        ([provider]) => !retainedProviders.has(normalizeProvider(provider)),
+      ),
+      ...[...(inventory?.runtimeModels ?? [])].filter(([provider]) =>
+        retainedProviders.has(normalizeProvider(provider)),
+      ),
+    ]),
     discoveryOrigins: [
       ...discoveryOrigins,
       ...(inventory?.discoveryOrigins ?? []).filter((origin) =>
@@ -333,6 +344,7 @@ export type PreparedModelRuntimeCatalogAccess = Readonly<{
   isCurrent: () => boolean;
   withRefreshStatus: (catalog: ModelCatalogSnapshot) => ModelCatalogSnapshot;
   readFullModelCatalog: () => ModelCatalogSnapshot | undefined;
+  readPublishedModels: () => ReadonlyMap<string, readonly Model[]> | undefined;
   loadFullModelCatalog: (
     options?: PreparedModelCatalogRefreshOptions,
   ) => Promise<ModelCatalogSnapshot>;
@@ -400,6 +412,7 @@ export function createPreparedModelRuntimeSnapshot(
       : {}),
     modelCatalog: catalogAccess.withRefreshStatus(modelCatalog),
     readFullModelCatalog: catalogAccess.readFullModelCatalog,
+    readPublishedModels: catalogAccess.readPublishedModels,
     loadFullModelCatalog: catalogAccess.loadFullModelCatalog,
     configuredRuntimeModels,
     inlineProviderModels,

--- a/src/agents/prepared-model-runtime.published-owner.ts
+++ b/src/agents/prepared-model-runtime.published-owner.ts
@@ -1,3 +1,4 @@
+import { capturePreparedModelRuntimeCatalog } from "./prepared-model-runtime.capture.js";
 import {
   PreparedModelRuntimeOwnerNotPublishedError,
   normalizePreparedModelRuntimeInput,
@@ -22,7 +23,7 @@ export function retainPublishedModelRuntimeOwner(
     throw new Error("Published model runtime has no plugin generation");
   }
   return {
-    snapshot,
+    snapshot: capturePreparedModelRuntimeCatalog(snapshot, snapshot.readPublishedModels?.()),
     pluginGeneration,
     [Symbol.asyncDispose]: retainPreparedPluginGeneration(pluginGeneration),
   };

--- a/src/agents/prepared-model-runtime.sources.test.ts
+++ b/src/agents/prepared-model-runtime.sources.test.ts
@@ -186,6 +186,7 @@ describe("prepared catalog source composition", () => {
           isCurrent: () => true,
           withRefreshStatus: (catalog) => catalog,
           readFullModelCatalog: () => undefined,
+          readPublishedModels: () => undefined,
           loadFullModelCatalog: async () => catalogFacts.modelCatalog,
           loadAuth: async () => ({ authStore: facts.authStore, authModes: {}, credentials: {} }),
         },

--- a/src/agents/prepared-model-runtime.startup-static.test.ts
+++ b/src/agents/prepared-model-runtime.startup-static.test.ts
@@ -146,7 +146,11 @@ vi.mock("./prepared-model-catalog-worker.js", () => ({
         authStore: { version: 1, profiles: {} },
         authModes: {},
       });
-      return { modelCatalog: catalog, configuredRuntimeModels: agentFacts.configuredRuntimeModels };
+      return {
+        modelCatalog: catalog,
+        runtimeModels: new Map(),
+        configuredRuntimeModels: agentFacts.configuredRuntimeModels,
+      };
     },
     loadAuth: async () => ({
       authStore: { version: 1, profiles: {} },

--- a/src/agents/prepared-model-runtime.test-harness.ts
+++ b/src/agents/prepared-model-runtime.test-harness.ts
@@ -137,6 +137,7 @@ vi.mock("./prepared-model-catalog-worker.js", () => ({
         );
         return {
           modelCatalog: catalog,
+          runtimeModels: new Map(),
           configuredRuntimeModels: factoryArgs[0].agentFacts.configuredRuntimeModels,
         };
       },

--- a/src/agents/prepared-model-runtime.types.ts
+++ b/src/agents/prepared-model-runtime.types.ts
@@ -98,6 +98,8 @@ export type PreparedModelRuntimeSnapshot = Readonly<{
   modelCatalog: ModelCatalogSnapshot;
   /** Reads a completed full catalog without starting provider discovery. */
   readFullModelCatalog?: () => ModelCatalogSnapshot | undefined;
+  /** Reads validated executable rows from this owner's accepted provider publication. */
+  readPublishedModels?: () => ReadonlyMap<string, readonly Model[]> | undefined;
   /** Builds this generation's full control-plane catalog without replacing turn facts. */
   loadFullModelCatalog?: (
     options?: PreparedModelCatalogRefreshOptions,
@@ -207,6 +209,7 @@ export type PreparedModelRuntimeBuildStats = Readonly<{
 
 export type PreparedModelCatalogInventory = {
   catalog: ModelCatalogSnapshot;
+  runtimeModels: ReadonlyMap<string, readonly Model[]>;
   key: string;
   pluginFingerprint: string;
   nativeSource: string;

--- a/src/agents/sessions/model-registry.ts
+++ b/src/agents/sessions/model-registry.ts
@@ -380,6 +380,7 @@ export class ModelRegistry {
     authStorage: AuthStorage,
     modelsJsonPath: string | undefined,
     options: ModelRegistryOptions = {},
+    publishedModels?: ReadonlyMap<string, readonly Model[]>,
   ) {
     this.authStorage = authStorage;
     this.config = options.config ?? options.sourceSnapshot?.config;
@@ -387,7 +388,16 @@ export class ModelRegistry {
     initializeModelRegistryRuntime(this);
     if (options.sourceSnapshot) {
       const source = options.sourceSnapshot;
-      const sourceSnapshot = source.baseCatalogSnapshot ?? source.captureCatalogSnapshot();
+      const captured = source.baseCatalogSnapshot ?? source.captureCatalogSnapshot();
+      const sourceSnapshot = publishedModels
+        ? {
+            ...captured,
+            models: [
+              ...captured.models.filter((model) => !publishedModels.has(model.provider)),
+              ...[...publishedModels.values()].flat(),
+            ],
+          }
+        : captured;
       this.sourceSnapshot = sourceSnapshot;
       this.baseCatalogSnapshot = sourceSnapshot;
       this.restoreSourceCatalog(sourceSnapshot);
@@ -459,8 +469,11 @@ export class ModelRegistry {
   }
 
   /** Creates a request-isolated registry from this lifecycle-owned catalog snapshot. */
-  fork(authStorage: AuthStorage): ModelRegistry {
-    return new ModelRegistry(authStorage, undefined, { sourceSnapshot: this });
+  fork(
+    authStorage: AuthStorage,
+    publishedModels?: ReadonlyMap<string, readonly Model[]>,
+  ): ModelRegistry {
+    return new ModelRegistry(authStorage, undefined, { sourceSnapshot: this }, publishedModels);
   }
 
   /**

--- a/src/agents/tools/media-generate-tool.donor-resources.test.ts
+++ b/src/agents/tools/media-generate-tool.donor-resources.test.ts
@@ -235,6 +235,7 @@ module.exports = { id: '${id}', register(api) {
               isCurrent: () => true,
               withRefreshStatus: (value) => value,
               readFullModelCatalog: () => catalog.modelCatalog,
+              readPublishedModels: () => undefined,
               loadFullModelCatalog: async () => catalog.modelCatalog,
               loadAuth: async () => {
                 throw new Error("No model auth in this fixture");

--- a/src/agents/tools/media-generate-tool.resources.test.ts
+++ b/src/agents/tools/media-generate-tool.resources.test.ts
@@ -273,6 +273,7 @@ async function prepareSnapshot(
       isCurrent: () => true,
       withRefreshStatus: (value) => value,
       readFullModelCatalog: () => catalog.modelCatalog,
+      readPublishedModels: () => undefined,
       loadFullModelCatalog: async () => catalog.modelCatalog,
       loadAuth: async () => {
         throw new Error("The synthetic media provider does not request model credentials");

--- a/src/gateway/gateway-route-model-reuse.test.ts
+++ b/src/gateway/gateway-route-model-reuse.test.ts
@@ -256,6 +256,32 @@ describe("Gateway route model reuse", () => {
             },
           );
           const activeClient = client;
+          // Measure reuse after startup publication has settled its runtime facts.
+          await activeClient.request("models.list", {
+            agentId: "main",
+            view: "all",
+            refresh: true,
+          });
+          await expect
+            .poll(
+              async () => {
+                const catalog = await activeClient.request<{
+                  models: Array<{ id: string; provider: string }>;
+                  pendingProviders?: string[];
+                  refreshFailed?: boolean;
+                }>("models.list", { agentId: "main", view: "all" });
+                expect(catalog.refreshFailed).not.toBe(true);
+                expect(catalog.models).toEqual(
+                  expect.arrayContaining([
+                    expect.objectContaining({ provider: PROVIDERS[0], id: "stable" }),
+                    expect.objectContaining({ provider: PROVIDERS[1], id: "stable" }),
+                  ]),
+                );
+                return catalog.pendingProviders;
+              },
+              { timeout: 30_000 },
+            )
+            .toBeUndefined();
           const stats = () =>
             activeClient.request<{ counts: Counts; reloadSettled: boolean }>(
               "routeModelProof.stats",

--- a/src/gateway/server-methods/models-dispatch.catalog.integration.test.ts
+++ b/src/gateway/server-methods/models-dispatch.catalog.integration.test.ts
@@ -39,7 +39,7 @@ it("dispatches a newly discovered model and preserves an admitted turn when disc
   const endpoint = createServer((request, response) => {
     if (request.method === "GET" && request.url === "/v1/models") {
       response.writeHead(200, { "content-type": "application/json" });
-      response.end(JSON.stringify(advertised));
+      response.end(JSON.stringify({ object: "list", data: advertised }));
       return;
     }
     if (request.method !== "POST" || request.url !== "/v1/chat/completions") {
@@ -112,7 +112,7 @@ it("dispatches a newly discovered model and preserves an admitted turn when disc
                   headers: { Authorization: "Bearer " + auth.discoveryApiKey },
                 });
                 if (!response.ok) throw new Error("Fixture discovery failed");
-                const rows = await response.json();
+                const { data: rows } = await response.json();
                 return { provider: {
                   baseUrl: ${JSON.stringify(baseUrl)}, api: "openai-completions",
                   models: rows.map((row) => ({

--- a/src/gateway/server-methods/models-dispatch.catalog.integration.test.ts
+++ b/src/gateway/server-methods/models-dispatch.catalog.integration.test.ts
@@ -1,0 +1,310 @@
+import { once } from "node:events";
+import { createServer } from "node:http";
+import { text as readText } from "node:stream/consumers";
+import { describeImageWithModel } from "openclaw/plugin-sdk/media-understanding";
+import { expect, it } from "vitest";
+import type { ModelsListResult } from "../../../packages/gateway-protocol/src/schema/agents-models-skills.js";
+import { createDeferred, withTestTimeout } from "../../../test/helpers/promise.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { createOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
+import { disconnectGatewayClient, startGatewayWithClient } from "../test-helpers.e2e.js";
+
+it("dispatches a newly discovered model and preserves an admitted turn when discovery withdraws it", async () => {
+  const state = await createOpenClawTestState({
+    label: "models-dispatch-catalog",
+    env: {
+      OPENCLAW_TEST_MINIMAL_GATEWAY: undefined,
+      OPENCLAW_SKIP_CHANNELS: "1",
+      OPENCLAW_SKIP_GMAIL_WATCHER: "1",
+      OPENCLAW_SKIP_CRON: "1",
+      OPENCLAW_SKIP_CANVAS_HOST: "1",
+      OPENCLAW_SKIP_BROWSER_CONTROL_SERVER: "1",
+      OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+    },
+  });
+  const provider = "opencode";
+  const model = "live-only-model";
+  const modelRef = `${provider}/${model}`;
+  const inferenceStarted = createDeferred();
+  const imageStarted = createDeferred();
+  const releaseInference = createDeferred();
+  const requests: Array<{
+    authorization: string | undefined;
+    catalogHeader: string | string[] | undefined;
+    requestHeader: string | string[] | undefined;
+    body: { model: string; max_tokens: number; messages: unknown[] };
+  }> = [];
+  const providerWork: Promise<void>[] = [];
+  let advertised: Array<{ id: string; name: string }> = [];
+  const endpoint = createServer((request, response) => {
+    if (request.method === "GET" && request.url === "/v1/models") {
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end(JSON.stringify(advertised));
+      return;
+    }
+    if (request.method !== "POST" || request.url !== "/v1/chat/completions") {
+      response.writeHead(404).end();
+      return;
+    }
+    const work = (async () => {
+      requests.push({
+        authorization: request.headers.authorization,
+        catalogHeader: request.headers["x-catalog-model"],
+        requestHeader: request.headers["x-dispatch-request"],
+        body: JSON.parse(await readText(request)),
+      });
+      inferenceStarted.resolve();
+      if (requests.length === 2) {
+        imageStarted.resolve();
+      }
+      await releaseInference.promise;
+      response.writeHead(200, { "content-type": "text/event-stream" });
+      response.end(
+        `data: ${JSON.stringify({
+          id: "chatcmpl-discovered-model",
+          object: "chat.completion.chunk",
+          created: 0,
+          model,
+          choices: [
+            {
+              index: 0,
+              delta: { role: "assistant", content: "CATALOG_DISPATCH_REPLY" },
+              finish_reason: "stop",
+            },
+          ],
+          usage: { prompt_tokens: 11, completion_tokens: 7, total_tokens: 18 },
+        })}\n\ndata: [DONE]\n\n`,
+      );
+    })();
+    providerWork.push(work);
+    void work.catch((error: unknown) => {
+      inferenceStarted.reject(error);
+      response.destroy(error instanceof Error ? error : new Error(String(error)));
+    });
+  });
+  try {
+    endpoint.listen(0, "127.0.0.1");
+    await once(endpoint, "listening");
+    const address = endpoint.address();
+    if (!address || typeof address === "string") {
+      throw new Error("Dispatch fixture did not bind a TCP port");
+    }
+    const baseUrl = `http://127.0.0.1:${address.port}/v1`;
+    await state.writeJson("catalog-plugin/openclaw.plugin.json", {
+      id: provider,
+      providers: [provider],
+      modelCatalog: { discovery: { [provider]: "refreshable" } },
+      configSchema: { type: "object", additionalProperties: false },
+    });
+    const pluginPath = await state.writeText(
+      "catalog-plugin/index.cjs",
+      `module.exports = {
+        id: ${JSON.stringify(provider)},
+        register(api) {
+          api.registerProvider({
+            id: ${JSON.stringify(provider)}, label: "Dispatch fixture", auth: [],
+            catalog: {
+              order: "profile",
+              async run(ctx) {
+                const auth = ctx.resolveProviderAuth(${JSON.stringify(provider)});
+                if (!auth.discoveryApiKey) return null;
+                const response = await fetch(${JSON.stringify(`${baseUrl}/models`)}, {
+                  headers: { Authorization: "Bearer " + auth.discoveryApiKey },
+                });
+                if (!response.ok) throw new Error("Fixture discovery failed");
+                const rows = await response.json();
+                return { provider: {
+                  baseUrl: ${JSON.stringify(baseUrl)}, api: "openai-completions",
+                  models: rows.map((row) => ({
+                    ...row, reasoning: false, input: ["text", "image"],
+                    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                    contextWindow: 32768, maxTokens: 1536,
+                    headers: { "X-Catalog-Model": "discovered-generation" },
+                    compat: { maxTokensField: "max_tokens" },
+                  })),
+                } };
+              },
+            },
+          });
+        },
+      };`,
+    );
+    const token = "catalog-dispatch-gateway-token";
+    const cfg = {
+      models: {
+        providers: {
+          [provider]: {
+            request: {
+              allowPrivateNetwork: true,
+              headers: { "X-Dispatch-Request": "configured-transport" },
+            },
+          },
+        },
+      },
+      agents: {
+        defaults: {
+          skipBootstrap: true,
+          heartbeat: { every: "0m" },
+          modelPolicy: { allow: [`${provider}/*`] },
+        },
+        list: [{ id: "main", workspace: state.workspaceDir }],
+      },
+      tools: { profile: "minimal" },
+      plugins: {
+        allow: [provider],
+        load: { paths: [pluginPath] },
+        slots: { memory: "none" },
+      },
+      gateway: { mode: "local", auth: { mode: "token", token } },
+    } satisfies OpenClawConfig;
+    await state.writeConfig(cfg);
+    await state.writeAuthProfiles({
+      version: 1,
+      profiles: {
+        [`${provider}:default`]: { type: "api_key", provider, key: "dispatch-account-key" },
+        [`${provider}:alternate`]: { type: "api_key", provider, key: "image-account-key" },
+      },
+      order: { [provider]: [`${provider}:default`, `${provider}:alternate`] },
+    });
+    const { client, server } = await startGatewayWithClient({
+      cfg,
+      configPath: state.configPath,
+      token,
+      scopes: ["operator.admin"],
+    });
+    try {
+      await server.startupSettled;
+      const refresh = () =>
+        client.request<ModelsListResult>("models.list", {
+          agentId: "main",
+          provider,
+          view: "all",
+          refresh: true,
+        });
+      expect((await refresh()).models.filter((row) => row.provider === provider)).toEqual([]);
+      advertised = [{ id: model, name: "Live-only model" }];
+      const discovered = await refresh();
+      expect(discovered.refreshFailed).not.toBe(true);
+      expect(discovered.models).toEqual(
+        expect.arrayContaining([expect.objectContaining({ provider, id: model, available: true })]),
+      );
+      const session = await client.request<{ ok: boolean; key: string }>("sessions.create", {
+        agentId: "main",
+        key: "agent:main:catalog-dispatch",
+        label: "Catalog dispatch",
+        model: modelRef,
+      });
+      expect(session.ok).toBe(true);
+      const started = await client.request<{ runId: string; status: string }>("chat.send", {
+        sessionKey: session.key,
+        message: "Reply with the catalog dispatch marker.",
+        idempotencyKey: "catalog-dispatch-first-turn",
+      });
+      expect(started.status).toBe("started");
+      await withTestTimeout(
+        inferenceStarted.promise,
+        30_000,
+        "Discovered model did not reach the provider on its first turn",
+      );
+      expect(requests).toHaveLength(1);
+      expect(requests[0]).toMatchObject({
+        authorization: "Bearer dispatch-account-key",
+        catalogHeader: undefined,
+        requestHeader: "configured-transport",
+        body: { model: "live-only-model", max_tokens: 1536 },
+      });
+
+      const image = describeImageWithModel({
+        provider,
+        model,
+        cfg,
+        agentId: "main",
+        agentDir: state.agentDir("main"),
+        workspaceDir: state.workspaceDir,
+        profile: `${provider}:alternate`,
+        buffer: Buffer.from(
+          "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/aX8AAAAASUVORK5CYII=",
+          "base64",
+        ),
+        fileName: "pixel.png",
+        mime: "image/png",
+        prompt: "Describe the pixel.",
+        maxTokens: 321,
+        timeoutMs: 30_000,
+      });
+      await withTestTimeout(
+        Promise.race([imageStarted.promise, image]),
+        30_000,
+        "Image utility did not use the published model",
+      );
+      expect(requests).toHaveLength(2);
+      expect(requests[1]).toMatchObject({
+        authorization: "Bearer image-account-key",
+        catalogHeader: undefined,
+        requestHeader: "configured-transport",
+        body: { model: "live-only-model", max_tokens: 321 },
+      });
+
+      advertised = [];
+      const withdrawn = await refresh();
+      expect(withdrawn.refreshFailed).not.toBe(true);
+      expect(withdrawn.models.filter((row) => row.provider === provider)).toEqual([]);
+      releaseInference.resolve();
+      await expect(image).resolves.toMatchObject({ text: "CATALOG_DISPATCH_REPLY" });
+      const completed = await client.request<{ status: string }>(
+        "agent.wait",
+        { runId: started.runId, timeoutMs: 30_000 },
+        { timeoutMs: 35_000 },
+      );
+      expect(completed).toMatchObject({ status: "ok" });
+      const history = await client.request<{ messages: unknown[] }>("chat.history", {
+        sessionKey: session.key,
+      });
+      expect(history.messages).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            role: "assistant",
+            content: expect.arrayContaining([
+              expect.objectContaining({ type: "text", text: "CATALOG_DISPATCH_REPLY" }),
+            ]),
+          }),
+        ]),
+      );
+
+      const nextSession = await client.request<{ key: string }>("sessions.create", {
+        agentId: "main",
+        key: "agent:main:catalog-after-withdrawal",
+        label: "After withdrawal",
+        model: modelRef,
+      });
+      const nextTurn = await client.request<{ runId: string }>("chat.send", {
+        sessionKey: nextSession.key,
+        message: "Try the withdrawn model.",
+        idempotencyKey: "catalog-dispatch-after-withdrawal",
+      });
+      const unavailable = await client.request<{ status: string; error?: string }>(
+        "agent.wait",
+        { runId: nextTurn.runId, timeoutMs: 30_000 },
+        { timeoutMs: 35_000 },
+      );
+      expect(unavailable).toMatchObject({ status: "error" });
+      expect(unavailable.error).toContain("The configured model is unavailable from the provider");
+      expect(requests).toHaveLength(2);
+    } finally {
+      releaseInference.resolve();
+      await disconnectGatewayClient(client);
+      await server.close();
+    }
+  } finally {
+    releaseInference.resolve();
+    endpoint.closeAllConnections();
+    try {
+      await new Promise<void>((resolve, reject) => {
+        endpoint.close((error) => (error ? reject(error) : resolve()));
+      });
+      await Promise.all(providerWork);
+    } finally {
+      await state.cleanup();
+    }
+  }
+}, 120_000);

--- a/src/gateway/server-methods/models-dispatch.catalog.integration.test.ts
+++ b/src/gateway/server-methods/models-dispatch.catalog.integration.test.ts
@@ -134,6 +134,8 @@ it("dispatches a newly discovered model and preserves an admitted turn when disc
       models: {
         providers: {
           [provider]: {
+            baseUrl: "",
+            models: [],
             request: {
               allowPrivateNetwork: true,
               headers: { "X-Dispatch-Request": "configured-transport" },

--- a/src/gateway/server-methods/models-dispatch.lifecycle.integration.test.ts
+++ b/src/gateway/server-methods/models-dispatch.lifecycle.integration.test.ts
@@ -1,0 +1,446 @@
+import { once } from "node:events";
+import { createServer } from "node:http";
+import { text as readText } from "node:stream/consumers";
+import { expect, it, vi } from "vitest";
+import type { ModelsListResult } from "../../../packages/gateway-protocol/src/schema/agents-models-skills.js";
+import { createDeferred, withTestTimeout } from "../../../test/helpers/promise.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { createOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
+import { disconnectGatewayClient, startGatewayWithClient } from "../test-helpers.e2e.js";
+
+type DispatchRequest = {
+  authorization: string | undefined;
+  requestHeader: string | string[] | undefined;
+  body: { model: string; max_tokens: number; messages: unknown[] };
+};
+
+async function withDispatchLifecycle(
+  run: (fixture: {
+    client: Awaited<ReturnType<typeof startGatewayWithClient>>["client"];
+    requests: DispatchRequest[];
+    advertised: Map<string, string[]>;
+    setDiscoveryAvailable: (available: boolean) => void;
+    holdDiscovery: () => { started: Promise<void>; release: () => void };
+    saveAccount: (key: string) => Promise<void>;
+    restart: () => Promise<void>;
+    list: (refresh?: boolean, view?: "all" | "default") => Promise<ModelsListResult>;
+    send: (model: string, name: string) => Promise<{ status: string; error?: string }>;
+  }) => Promise<void>,
+) {
+  const state = await createOpenClawTestState({
+    label: "models-dispatch-lifecycle",
+    env: {
+      OPENCLAW_TEST_MINIMAL_GATEWAY: undefined,
+      OPENCLAW_SKIP_CHANNELS: "1",
+      OPENCLAW_SKIP_GMAIL_WATCHER: "1",
+      OPENCLAW_SKIP_CRON: "1",
+      OPENCLAW_SKIP_CANVAS_HOST: "1",
+      OPENCLAW_SKIP_BROWSER_CONTROL_SERVER: "1",
+      OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+    },
+  });
+  const requests: DispatchRequest[] = [];
+  const hotReloadRecovery = vi.fn(() => ({ status: "emitted" as const }));
+  const advertised = new Map([
+    ["account-a-key", ["account-a-only"]],
+    ["account-b-key", ["account-b-only", "account-b-sibling"]],
+  ]);
+  let discoveryAvailable = true;
+  let heldDiscovery:
+    | {
+        started: ReturnType<typeof createDeferred<void>>;
+        release: ReturnType<typeof createDeferred<void>>;
+      }
+    | undefined;
+  const pending: Promise<void>[] = [];
+  const endpoint = createServer((request, response) => {
+    const work = (async () => {
+      if (request.method === "GET" && request.url === "/v1/models") {
+        const held = heldDiscovery;
+        if (held) {
+          held.started.resolve();
+          await held.release.promise;
+        }
+        if (!discoveryAvailable) {
+          response.writeHead(503).end();
+          return;
+        }
+        const key = request.headers.authorization?.replace(/^Bearer /, "");
+        const models = key ? advertised.get(key) : undefined;
+        if (!models) {
+          response.writeHead(401).end();
+          return;
+        }
+        response.writeHead(200, { "content-type": "application/json" });
+        response.end(JSON.stringify({ data: models.map((id) => ({ id, object: "model" })) }));
+        return;
+      }
+      if (request.method !== "POST" || request.url !== "/v1/chat/completions") {
+        response.writeHead(404).end();
+        return;
+      }
+      const recorded: DispatchRequest = {
+        authorization: request.headers.authorization,
+        requestHeader: request.headers["x-dispatch-request"],
+        body: JSON.parse(await readText(request)),
+      };
+      requests.push(recorded);
+      response.writeHead(200, { "content-type": "text/event-stream" });
+      response.end(
+        `data: ${JSON.stringify({
+          id: "chatcmpl-lifecycle",
+          object: "chat.completion.chunk",
+          created: 0,
+          model: recorded.body.model,
+          choices: [
+            {
+              index: 0,
+              delta: { role: "assistant", content: "LIFECYCLE_DISPATCH_REPLY" },
+              finish_reason: "stop",
+            },
+          ],
+          usage: { prompt_tokens: 11, completion_tokens: 7, total_tokens: 18 },
+        })}\n\ndata: [DONE]\n\n`,
+      );
+    })();
+    pending.push(work);
+    void work.catch((error: unknown) => {
+      response.destroy(error instanceof Error ? error : new Error(String(error)));
+    });
+  });
+  let gateway: Awaited<ReturnType<typeof startGatewayWithClient>> | undefined;
+  const saveAccount = async (key: string) => {
+    await state.writeAuthProfiles({
+      version: 1,
+      profiles: { "opencode:default": { type: "api_key", provider: "opencode", key } },
+    });
+  };
+  try {
+    endpoint.listen(0, "127.0.0.1");
+    await once(endpoint, "listening");
+    const address = endpoint.address();
+    if (!address || typeof address === "string") {
+      throw new Error("Lifecycle fixture did not bind a TCP port");
+    }
+    const baseUrl = `http://127.0.0.1:${address.port}/v1`;
+    await state.writeJson("catalog-plugin/openclaw.plugin.json", {
+      id: "opencode",
+      providers: ["opencode"],
+      modelCatalog: { discovery: { opencode: "refreshable" } },
+      configSchema: { type: "object", additionalProperties: false },
+    });
+    const pluginPath = await state.writeText(
+      "catalog-plugin/index.cjs",
+      `module.exports = {
+        id: "opencode",
+        register(api) {
+          api.registerProvider({
+            id: "opencode", label: "Dispatch lifecycle fixture", auth: [],
+            catalog: {
+              order: "profile",
+              async run(ctx) {
+                const auth = ctx.resolveProviderAuth("opencode");
+                if (!auth.discoveryApiKey) return null;
+                const response = await fetch(${JSON.stringify(`${baseUrl}/models`)}, {
+                  headers: { Authorization: "Bearer " + auth.discoveryApiKey },
+                });
+                if (!response.ok) return {
+                  providers: {}, outcomes: [{ provider: "opencode", status: "unavailable" }],
+                };
+                const { data } = await response.json();
+                return { provider: {
+                  baseUrl: ${JSON.stringify(baseUrl)}, api: "openai-completions",
+                  models: data.map(({ id }) => ({
+                    id, name: id, reasoning: false, input: ["text"],
+                    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                    contextWindow: 32768, maxTokens: 1536,
+                    compat: { maxTokensField: "max_tokens" },
+                  })),
+                } };
+              },
+            },
+          });
+        },
+      };`,
+    );
+    const token = "dispatch-lifecycle-gateway-token";
+    const cfg = {
+      models: {
+        providers: {
+          opencode: {
+            request: {
+              allowPrivateNetwork: true,
+              headers: { "X-Dispatch-Request": "initial-transport" },
+            },
+          },
+        },
+      },
+      agents: {
+        defaults: {
+          skipBootstrap: true,
+          heartbeat: { every: "0m" },
+          modelPolicy: { allow: ["opencode/*"] },
+        },
+        list: [{ id: "main", workspace: state.workspaceDir }],
+      },
+      tools: { profile: "minimal" },
+      plugins: {
+        allow: ["opencode"],
+        load: { paths: [pluginPath] },
+        slots: { memory: "none" },
+      },
+      gateway: { mode: "local", auth: { mode: "token", token } },
+    } satisfies OpenClawConfig;
+    await state.writeConfig(cfg);
+    await saveAccount("account-a-key");
+    const start = async () => {
+      const started = await startGatewayWithClient({
+        cfg,
+        configPath: state.configPath,
+        token,
+        scopes: ["operator.admin"],
+        hotReloadRecovery,
+      });
+      gateway = started;
+      await started.server.startupSettled;
+      return started;
+    };
+    let active = await start();
+    await run({
+      get client() {
+        return active.client;
+      },
+      requests,
+      advertised,
+      setDiscoveryAvailable: (available) => {
+        discoveryAvailable = available;
+      },
+      holdDiscovery: () => {
+        const held = { started: createDeferred(), release: createDeferred() };
+        heldDiscovery = held;
+        return {
+          started: held.started.promise,
+          release: () => {
+            heldDiscovery = undefined;
+            held.release.resolve();
+          },
+        };
+      },
+      saveAccount,
+      restart: async () => {
+        await disconnectGatewayClient(active.client);
+        await active.server.close();
+        gateway = undefined;
+        active = await start();
+      },
+      list: (refresh = false, view = "all") =>
+        active.client.request<ModelsListResult>("models.list", {
+          agentId: "main",
+          provider: "opencode",
+          view,
+          refresh,
+        }),
+      send: async (model, name) => {
+        const session = await active.client.request<{ key: string }>("sessions.create", {
+          agentId: "main",
+          key: `agent:main:${name}`,
+          label: name,
+          model: `opencode/${model}`,
+        });
+        const started = await active.client.request<{ runId: string; status: string }>(
+          "chat.send",
+          {
+            sessionKey: session.key,
+            message: "Reply with the lifecycle dispatch marker.",
+            idempotencyKey: name,
+          },
+        );
+        expect(started.status).toBe("started");
+        const completed = await active.client.request<{ status: string; error?: string }>(
+          "agent.wait",
+          { runId: started.runId, timeoutMs: 30_000 },
+          { timeoutMs: 35_000 },
+        );
+        if (completed.status === "ok") {
+          const history = await active.client.request<{ messages: unknown[] }>("chat.history", {
+            sessionKey: session.key,
+          });
+          expect(history.messages).toEqual(
+            expect.arrayContaining([
+              expect.objectContaining({
+                role: "assistant",
+                content: expect.arrayContaining([
+                  expect.objectContaining({ type: "text", text: "LIFECYCLE_DISPATCH_REPLY" }),
+                ]),
+              }),
+            ]),
+          );
+        }
+        return completed;
+      },
+    });
+    expect(hotReloadRecovery).not.toHaveBeenCalled();
+  } finally {
+    heldDiscovery?.release.resolve();
+    try {
+      if (gateway) {
+        await disconnectGatewayClient(gateway.client);
+        await gateway.server.close();
+      }
+    } finally {
+      endpoint.closeAllConnections();
+      try {
+        await new Promise<void>((resolve, reject) => {
+          endpoint.close((error) => (error ? reject(error) : resolve()));
+        });
+        await Promise.all(pending);
+      } finally {
+        await state.cleanup();
+      }
+    }
+  }
+}
+
+it("models.list retains executable rows on failed refresh and replaces them after Gateway restart", async () => {
+  await withDispatchLifecycle(async (fixture) => {
+    const discovered = await fixture.list(true);
+    expect(discovered.models).toContainEqual(
+      expect.objectContaining({ provider: "opencode", id: "account-a-only", available: true }),
+    );
+    await expect(fixture.send("account-a-only", "before-failure")).resolves.toMatchObject({
+      status: "ok",
+    });
+    expect(fixture.requests).toHaveLength(1);
+
+    fixture.setDiscoveryAvailable(false);
+    const failed = await fixture.list(true);
+    expect(failed.refreshFailed).toBe(true);
+    expect(failed.models).toContainEqual(
+      expect.objectContaining({ provider: "opencode", id: "account-a-only", available: true }),
+    );
+    await expect(fixture.send("account-a-only", "after-failure")).resolves.toMatchObject({
+      status: "ok",
+    });
+    expect(fixture.requests).toHaveLength(2);
+    expect(fixture.requests[1]).toMatchObject({
+      authorization: "Bearer account-a-key",
+      requestHeader: "initial-transport",
+      body: { model: "account-a-only", max_tokens: 1536 },
+    });
+
+    fixture.advertised.set("account-a-key", ["after-restart"]);
+    fixture.setDiscoveryAvailable(true);
+    await fixture.restart();
+    const restarted = await fixture.list(true);
+    expect(
+      restarted.models.filter((model) => model.provider === "opencode").map((model) => model.id),
+    ).toEqual(["after-restart"]);
+    await expect(fixture.send("after-restart", "first-after-restart")).resolves.toMatchObject({
+      status: "ok",
+    });
+    expect(fixture.requests).toHaveLength(3);
+    expect(fixture.requests[2]).toMatchObject({
+      authorization: "Bearer account-a-key",
+      requestHeader: "initial-transport",
+      body: { model: "after-restart", max_tokens: 1536 },
+    });
+    await expect(fixture.send("account-a-only", "withdrawn-after-restart")).resolves.toMatchObject({
+      status: "error",
+      error: expect.stringContaining("The configured model is unavailable from the provider"),
+    });
+    expect(fixture.requests).toHaveLength(3);
+  });
+}, 180_000);
+
+it("models.authRefresh revokes old executable rows before discovery and config.patch applies current policy and transport", async () => {
+  await withDispatchLifecycle(async (fixture) => {
+    await fixture.list(true);
+    await expect(fixture.send("account-a-only", "before-replacement")).resolves.toMatchObject({
+      status: "ok",
+    });
+    expect(fixture.requests[0]).toMatchObject({ authorization: "Bearer account-a-key" });
+
+    const held = fixture.holdDiscovery();
+    try {
+      await fixture.saveAccount("account-b-key");
+      await fixture.client.request("models.authRefresh", { agentId: "main", operation: "login" });
+      await withTestTimeout(held.started, 30_000, "Replacement account discovery did not start");
+      expect((await fixture.list()).models).not.toContainEqual(
+        expect.objectContaining({ provider: "opencode", id: "account-a-only" }),
+      );
+      await expect(fixture.send("account-a-only", "during-replacement")).resolves.toMatchObject({
+        status: "error",
+        error: expect.stringContaining("The configured model is unavailable from the provider"),
+      });
+      expect(fixture.requests).toHaveLength(1);
+    } finally {
+      held.release();
+    }
+    await expect
+      .poll(
+        async () =>
+          (await fixture.list()).models
+            .filter((model) => model.provider === "opencode")
+            .map((model) => model.id),
+        { timeout: 30_000 },
+      )
+      .toEqual(["account-b-only", "account-b-sibling"]);
+    await expect(fixture.send("account-b-only", "after-replacement")).resolves.toMatchObject({
+      status: "ok",
+    });
+    expect(fixture.requests).toHaveLength(2);
+    expect(fixture.requests[1]).toMatchObject({
+      authorization: "Bearer account-b-key",
+      requestHeader: "initial-transport",
+      body: { model: "account-b-only", max_tokens: 1536 },
+    });
+
+    const config = await fixture.client.request<{ hash: string }>("config.get", {});
+    await fixture.client.request("config.patch", {
+      baseHash: config.hash,
+      replacePaths: ["agents.defaults.modelPolicy.allow"],
+      raw: JSON.stringify({
+        agents: { defaults: { modelPolicy: { allow: ["opencode/account-b-only"] } } },
+        models: {
+          providers: {
+            opencode: { request: { headers: { "X-Dispatch-Request": "reloaded-transport" } } },
+          },
+        },
+      }),
+    });
+    await expect
+      .poll(
+        async () => {
+          const publication = await fixture.list(false, "default");
+          return {
+            pending: publication.pendingProviders ?? [],
+            models: publication.models
+              .filter((model) => model.provider === "opencode")
+              .map(({ id, contextWindow, available }) => ({ id, contextWindow, available })),
+          };
+        },
+        { timeout: 30_000 },
+      )
+      .toEqual({
+        pending: [],
+        models: [{ id: "account-b-only", contextWindow: 32768, available: true }],
+      });
+    await expect(
+      fixture.client.request("sessions.create", {
+        agentId: "main",
+        key: "agent:main:denied-after-reload",
+        model: "opencode/account-b-sibling",
+      }),
+    ).rejects.toThrow("model not allowed");
+    expect(fixture.requests).toHaveLength(2);
+    await expect(fixture.send("account-b-only", "after-config-reload")).resolves.toMatchObject({
+      status: "ok",
+    });
+    expect(fixture.requests).toHaveLength(3);
+    expect(fixture.requests[2]).toMatchObject({
+      authorization: "Bearer account-b-key",
+      requestHeader: "reloaded-transport",
+      body: { model: "account-b-only", max_tokens: 1536 },
+    });
+  });
+}, 180_000);

--- a/src/gateway/server-methods/models-dispatch.lifecycle.integration.test.ts
+++ b/src/gateway/server-methods/models-dispatch.lifecycle.integration.test.ts
@@ -168,6 +168,8 @@ async function withDispatchLifecycle(
       models: {
         providers: {
           opencode: {
+            baseUrl: "",
+            models: [],
             request: {
               allowPrivateNetwork: true,
               headers: { "X-Dispatch-Request": "initial-transport" },

--- a/test/openai-model-discovery-auth-order.test.ts
+++ b/test/openai-model-discovery-auth-order.test.ts
@@ -19,6 +19,7 @@ import { resolveImplicitProviders } from "../src/agents/models-config.providers.
 import { prepareModelCatalogPublication } from "../src/agents/prepared-model-runtime.full-catalog.js";
 import type { ModelProviderConfig } from "../src/config/types.models.js";
 import type { OpenClawConfig } from "../src/config/types.openclaw.js";
+import type { Model } from "../src/llm/types.js";
 import { createTestPluginApi } from "../src/plugin-sdk/plugin-test-api.js";
 import type { ProviderCatalogOutcome } from "../src/plugins/provider-catalog.types.js";
 import * as providerDiscovery from "../src/plugins/provider-discovery.js";
@@ -536,6 +537,16 @@ describe("Provider model discovery auth preparation", () => {
         name: "Prior Account Model",
         provider: providerId,
       };
+      const priorRuntimeModel: Model = {
+        ...priorModel,
+        api: "openai-completions",
+        baseUrl: "https://catalog-retention.example.invalid/v1",
+        reasoning: false,
+        input: ["text"],
+        contextWindow: 32768,
+        maxTokens: 1536,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      };
       const previous = prepareModelCatalogPublication(
         {
           entries: [priorModel],
@@ -544,6 +555,7 @@ describe("Provider model discovery auth preparation", () => {
             { provider: providerId, profileId: previousProfileId, status: "ready" },
           ],
         },
+        new Map([[providerId, [priorRuntimeModel]]]),
         undefined,
         auth,
         (provider) => provider,
@@ -559,12 +571,14 @@ describe("Provider model discovery auth preparation", () => {
           ),
           providerOutcomes: outcomes,
         },
+        new Map(),
         previous,
         auth,
         (provider) => provider,
       );
 
       expect(published.catalog.entries).toContainEqual(priorModel);
+      expect(published.runtimeModels.get(providerId)).toEqual([priorRuntimeModel]);
       expect(published.discoveryOrigins).toEqual(previous.discoveryOrigins);
       expect(outcomes).toEqual(
         profileIds.map((profileId) => ({ provider: providerId, profileId, status: "unavailable" })),

--- a/test/openai-model-discovery-auth-order.test.ts
+++ b/test/openai-model-discovery-auth-order.test.ts
@@ -19,7 +19,6 @@ import { resolveImplicitProviders } from "../src/agents/models-config.providers.
 import { prepareModelCatalogPublication } from "../src/agents/prepared-model-runtime.full-catalog.js";
 import type { ModelProviderConfig } from "../src/config/types.models.js";
 import type { OpenClawConfig } from "../src/config/types.openclaw.js";
-import type { Model } from "../src/llm/types.js";
 import { createTestPluginApi } from "../src/plugin-sdk/plugin-test-api.js";
 import type { ProviderCatalogOutcome } from "../src/plugins/provider-catalog.types.js";
 import * as providerDiscovery from "../src/plugins/provider-discovery.js";
@@ -537,16 +536,6 @@ describe("Provider model discovery auth preparation", () => {
         name: "Prior Account Model",
         provider: providerId,
       };
-      const priorRuntimeModel: Model = {
-        ...priorModel,
-        api: "openai-completions",
-        baseUrl: "https://catalog-retention.example.invalid/v1",
-        reasoning: false,
-        input: ["text"],
-        contextWindow: 32768,
-        maxTokens: 1536,
-        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-      };
       const previous = prepareModelCatalogPublication(
         {
           entries: [priorModel],
@@ -555,7 +544,7 @@ describe("Provider model discovery auth preparation", () => {
             { provider: providerId, profileId: previousProfileId, status: "ready" },
           ],
         },
-        new Map([[providerId, [priorRuntimeModel]]]),
+        new Map(),
         undefined,
         auth,
         (provider) => provider,
@@ -578,7 +567,6 @@ describe("Provider model discovery auth preparation", () => {
       );
 
       expect(published.catalog.entries).toContainEqual(priorModel);
-      expect(published.runtimeModels.get(providerId)).toEqual([priorRuntimeModel]);
       expect(published.discoveryOrigins).toEqual(previous.discoveryOrigins);
       expect(outcomes).toEqual(
         profileIds.map((profileId) => ({ provider: providerId, profileId, status: "unavailable" })),


### PR DESCRIPTION
Related: [#145761](https://github.com/openclaw/openclaw/pull/145761).

## What Problem This Solves

Fixes an issue where a newly discovered model appeared in the picker but the next turn failed as unavailable before reaching the provider.

## Why This Change Was Made

Catalog publication now carries complete validated executable model rows into the existing generation and account state. New execution leases capture those rows through the model registry; existing leases retain their models across refresh. A successful empty refresh withdraws models from new leases.

## User Impact

Newly discovered models can serve their first selected turn and direct image requests use the selected account. No configuration or protocol change. The optional registry-fork argument requires an updated installation; the existing one-argument form remains compatible.

Consumers: turn, utility, image and local catalog leases capture accepted executable rows.

## Evidence

Telegram model selection and reply checks passed. Registered chat/image and lifecycle tests covered withdrawal, failed-refresh retention, account changes and reload. Command-line and embedded model listing passed without a Gateway. Previous-release runtime checks passed; declaration imports failed on both compared packages, so declaration compatibility is not claimed.
