### PR TITLE
test: remove duplicate usage precedence case

### DIFF
--- a/src/auto-reply/thinking.response-usage.test.ts
+++ b/src/auto-reply/thinking.response-usage.test.ts
@@ -34,13 +34,4 @@ describe("resolveEffectiveResponseUsage", () => {
     expect(resolveEffectiveResponseUsage("tokens", "full")).toBe("tokens");
     expect(resolveEffectiveResponseUsage("full", "off")).toBe("full");
   });
-
-  it("unset (undefined/null) falls through to config; explicit off does not", () => {
-    // These two are distinct states:
-    // - undefined = unset/inherit → gets config default
-    // - "off"     = explicit off  → stays off
-    const cfg = "tokens" as const;
-    expect(resolveEffectiveResponseUsage(undefined, cfg)).toBe("tokens"); // inherits
-    expect(resolveEffectiveResponseUsage("off", cfg)).toBe("off"); // explicit off persists
-  });
 });


### PR DESCRIPTION
## What Problem This Solves

The response-usage precedence tests repeat two input/output checks in a final case.

## Why This Change Was Made

Remove that redundant case from `thinking.response-usage.test.ts`, preserving the canonical file split from #145633 and all 12 unique checks. The remaining cases, imports, assertions, and comments stay unchanged.

## User Impact

No production change. Tests lose nine lines and one duplicate case.

## Evidence

Fresh proof on the refreshed base passes 91 baseline cases and 90 candidate cases across the response-usage, thinking, thinking-levels, and empty-profile suites. Native inventory differs only by the intended duplicate; every other observed row, order, and result is preserved.

Targeted formatting and all 20 normal changed-file checks passed through the configured Testbox route. The receiver verified the exact candidate tree, and the owned lease and capsule cleanup completed. Independent Codex review found no actionable findings.

The earlier 105/104 proof belongs to the previous test layout and remains historical. This refresh follows the canonical file move that conflicted with the original patch. Exact-head PR CI remains a separate landing gate.
