### PR TITLE
fix(cron): migrate persisted job ownership so existing automations stay updatable after 2026.9.4

### DIFF
--- a/docs/automation/cron-jobs/managing-jobs.md
+++ b/docs/automation/cron-jobs/managing-jobs.md
@@ -82,6 +82,15 @@ Each admin management request records its method, run, operational instance, and
 
 ### CLI management
 
+For older automations missing creator account metadata, run `openclaw doctor --fix`.
+Doctor reconciles the account only when the stored creator identity proves it,
+and reports the repair. The matching creator session can then update an agent
+prompt without supplying a new tool cap. Existing tool permissions and creator
+attribution stay intact; capless jobs retain their legacy execution policy.
+An explicit permission edit still requires matching owner authority. Jobs whose
+stored identity cannot prove an account need authenticated administrator recovery;
+Doctor does not infer ownership from delivery settings or the current caller.
+
 ```bash
 # List enabled jobs
 openclaw automations list

--- a/src/commands/doctor/cron/legacy-repair.ts
+++ b/src/commands/doctor/cron/legacy-repair.ts
@@ -417,6 +417,11 @@ export async function applyLegacyCronStoreRepair(params: {
   }
 
   changes.push(...retirementChanges);
+  if (normalized.issues.reconciledOwnerAccount) {
+    changes.push(
+      `Reconciled ${pluralize(normalized.issues.reconciledOwnerAccount, "cron job owner account")} from persisted creator identity; existing tool permissions were preserved.`,
+    );
+  }
   if (quarantineRecovery.recoveredJobs.length > 0) {
     changes.push(
       `Recovered ${pluralize(quarantineRecovery.recoveredJobs.length, "quarantined automation")} after current schedule validation passed.`,

--- a/src/commands/doctor/cron/repair-plan.ts
+++ b/src/commands/doctor/cron/repair-plan.ts
@@ -62,7 +62,7 @@ export function formatScheduledToolPolicyAdvisory(params: {
   const lines: string[] = [];
   if (params.legacyJobs.length > 0) {
     lines.push(
-      `${pluralize(params.legacyJobs.length, "tool-bearing cron job")} ${params.legacyJobs.length === 1 ? "keeps" : "keep"} legacy sender-policy resolution because stored account authority is not provable${formatJobNameList(params.legacyJobs)}.`,
+      `${pluralize(params.legacyJobs.length, "tool-bearing cron job")} ${params.legacyJobs.length === 1 ? "keeps" : "keep"} legacy sender-policy resolution because an explicit tool cap or provable stored account identity is missing${formatJobNameList(params.legacyJobs)}.`,
     );
   }
   if (params.invalidJobs.length > 0) {
@@ -175,6 +175,11 @@ export function formatLegacyIssuePreview(issues: CronLegacyIssueCounts): string[
   if (issues.migratedScheduledToolPolicy) {
     lines.push(
       `- ${pluralize(issues.migratedScheduledToolPolicy, "job")} can recover scheduled account authority from persisted owner identity`,
+    );
+  }
+  if (issues.reconciledOwnerAccount) {
+    lines.push(
+      `- ${pluralize(issues.reconciledOwnerAccount, "job")} can reconcile its owner account from persisted creator identity without changing tool permissions`,
     );
   }
   if (issues.invalidSchedule) {

--- a/src/commands/doctor/cron/scheduled-tool-policy-migration.test.ts
+++ b/src/commands/doctor/cron/scheduled-tool-policy-migration.test.ts
@@ -84,6 +84,23 @@ describe("migrateScheduledToolPolicy", () => {
     expect(result.legacyScheduledToolPolicyJobs).toEqual(["Legacy"]);
   });
 
+  it("recovers a capless creator account without changing execution permissions", () => {
+    const raw = job({
+      owner: { agentId: "main", sessionKey: "agent:main:discord:work:direct:user-1" },
+      payload: { kind: "agentTurn", message: "run" },
+    });
+    const result = normalizeStoredCronJobs([raw]);
+    expect(raw.owner).toEqual({
+      agentId: "main",
+      sessionKey: "agent:main:discord:work:direct:user-1",
+      accountId: "work",
+    });
+    expect(raw.payload).toEqual({ kind: "agentTurn", message: "run" });
+    expect(raw.scheduledToolPolicy).toBeUndefined();
+    expect(result.issues).toMatchObject({ reconciledOwnerAccount: 1 });
+    expect(normalizeStoredCronJobs([raw]).issues).not.toHaveProperty("reconciledOwnerAccount");
+  });
+
   it("rejects malformed and owner-inconsistent provenance", () => {
     const malformed = job({ scheduledToolPolicy: { version: 2, mode: "trusted" } });
     expect(normalizeStoredCronJobs([malformed]).invalidScheduledToolPolicyJobs).toEqual(["Legacy"]);

--- a/src/commands/doctor/cron/scheduled-tool-policy-migration.ts
+++ b/src/commands/doctor/cron/scheduled-tool-policy-migration.ts
@@ -11,6 +11,7 @@ import { parseAgentSessionKey } from "../../../sessions/session-key-utils.js";
 
 type ScheduledToolPolicyMigrationResult = {
   mutated: boolean;
+  ownerReconciled?: boolean;
   status: "current" | "migrated" | "legacy" | "invalid" | "not-applicable";
 };
 
@@ -21,11 +22,14 @@ export function createScheduledToolPolicyMigrationCollector() {
   return {
     legacyJobs,
     invalidJobs,
-    migrate(raw: Record<string, unknown>, onMigrated: () => void) {
+    migrate(raw: Record<string, unknown>, onMigrated: (kind: "owner" | "policy") => void) {
       const result = migrateScheduledToolPolicy(raw);
       const jobName = normalizeOptionalString(raw.name) ?? normalizeOptionalString(raw.id);
       if (result.status === "migrated") {
-        onMigrated();
+        onMigrated("policy");
+      }
+      if (result.ownerReconciled) {
+        onMigrated("owner");
       }
       if (result.status === "legacy" && jobName) {
         legacyJobs.push(jobName);
@@ -86,9 +90,7 @@ function migrateScheduledToolPolicy(
     return { mutated, status: "current" };
   }
 
-  // Capless historical jobs have no bounded authority to recover. They remain
-  // on legacy sender-policy resolution until an operator explicitly edits tools.
-  if (!toolsAllow || !ownerSessionKey) {
+  if (!ownerSessionKey) {
     return { mutated: false, status: "legacy" };
   }
   const parsedSession = parseAgentSessionKey(ownerSessionKey);
@@ -116,12 +118,19 @@ function migrateScheduledToolPolicy(
   if (!scheduledToolPolicy) {
     return { mutated: false, status: "legacy" };
   }
-  raw.owner = {
+  const reconciledOwner = {
     ...owner,
     ...(ownerAgentId ? { agentId: normalizeAgentId(ownerAgentId) } : {}),
     sessionKey: ownerSessionKey,
     accountId: recoveredAccountId,
   };
+  const ownerReconciled = JSON.stringify(raw.owner) !== JSON.stringify(reconciledOwner);
+  raw.owner = reconciledOwner;
+  // Creator identity is recoverable independently of a tool cap. Capless jobs
+  // retain legacy execution policy until an explicit permission edit.
+  if (!toolsAllow) {
+    return { mutated: ownerReconciled, ownerReconciled, status: "legacy" };
+  }
   raw.scheduledToolPolicy = scheduledToolPolicy;
-  return { mutated: true, status: "migrated" };
+  return { mutated: true, ownerReconciled, status: "migrated" };
 }

--- a/src/commands/doctor/cron/store-migration.ts
+++ b/src/commands/doctor/cron/store-migration.ts
@@ -57,6 +57,7 @@ type CronStoreIssueKey =
   | "legacyTopLevelDeliveryFields"
   | "legacyDeliveryMode"
   | "migratedScheduledToolPolicy"
+  | "reconciledOwnerAccount"
   | "invalidSchedule"
   | "invalidPayload";
 
@@ -632,8 +633,8 @@ export function normalizeStoredCronJobs(
       mutated = true;
     }
 
-    const scheduledPolicyMutated = scheduledToolPolicyMigrations.migrate(raw, () =>
-      trackIssue("migratedScheduledToolPolicy"),
+    const scheduledPolicyMutated = scheduledToolPolicyMigrations.migrate(raw, (kind) =>
+      trackIssue(kind === "owner" ? "reconciledOwnerAccount" : "migratedScheduledToolPolicy"),
     );
     mutated ||= scheduledPolicyMutated;
 

--- a/src/gateway/server-methods/cron.ts
+++ b/src/gateway/server-methods/cron.ts
@@ -355,6 +355,26 @@ function cronPatchTouchesToolRuntime(patch: CronJobPatch): boolean {
   return patch.payload !== undefined || Object.hasOwn(patch, "trigger");
 }
 
+function isLegacyCreatorPromptUpdate(
+  job: CronJob,
+  patch: CronJobPatch,
+  callerScope: CronCallerScope | undefined,
+): boolean {
+  // A prompt edit keeps the legacy execution policy; it cannot establish new
+  // authority or transfer management to another session/account.
+  return (
+    callerScope?.sessionKey !== undefined &&
+    job.owner?.sessionKey === callerScope.sessionKey &&
+    job.owner?.accountId === callerScope.accountId &&
+    job.scheduledToolPolicy === undefined &&
+    job.payload.kind === "agentTurn" &&
+    patch.payload !== undefined &&
+    (patch.payload.kind === undefined || patch.payload.kind === "agentTurn") &&
+    Object.keys(patch).every((key) => key === "payload") &&
+    Object.keys(patch.payload).every((key) => key === "kind" || key === "message")
+  );
+}
+
 function assertCronDoesNotTargetAgentHarness(input: {
   agentId?: string | null;
   sessionTarget?: string | null;
@@ -1146,7 +1166,8 @@ export const cronHandlers: GatewayRequestHandlers = {
       });
       if (
         touchesToolRuntime &&
-        requiresExplicitAgentRuntimeToolsAllow({ job: nextJob, callerScope })
+        requiresExplicitAgentRuntimeToolsAllow({ job: nextJob, callerScope }) &&
+        !isLegacyCreatorPromptUpdate(jobToUpdate, patch, callerScope)
       ) {
         throw new TypeError("agent-runtime tool jobs require an explicit payload.toolsAllow cap");
       }

--- a/src/gateway/server-methods/cron.validation.test.ts
+++ b/src/gateway/server-methods/cron.validation.test.ts
@@ -7,12 +7,18 @@ import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../../test/helpers/promise.js";
 import { createOperationalRunInstanceRef } from "../../agents/admitted-run-context.js";
+import { updateCronJobFromAgentTool } from "../../agents/tools/cron-tool-write.js";
 import type { ChannelPlugin } from "../../channels/plugins/types.public.js";
+import {
+  applyLegacyCronStoreRepair,
+  loadLegacyCronRepairState,
+} from "../../commands/doctor/cron/legacy-repair.js";
 import type { SessionCreatedActor } from "../../config/sessions/session-entry-provenance.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { CronRuntimeAuthority } from "../../cron/runtime-authority.js";
 import { CronService } from "../../cron/service.js";
 import { createCronStoreHarness, createNoopLogger } from "../../cron/service.test-harness.js";
+import { loadCronStore, saveCronStore } from "../../cron/store.js";
 import type { CronDelivery, CronJob } from "../../cron/types.js";
 import {
   claimAgentRunDelegatedAuthority,
@@ -2909,24 +2915,113 @@ describe("cron method validation", () => {
     expectCronSuccess(respond);
   });
 
-  it("rejects agent-runtime edits that leave a tool-runtime job capless", async () => {
-    const { context, respond } = await invokeCronUpdate(
-      {
-        id: "cron-1",
-        patch: { payload: { kind: "agentTurn", message: "updated" } },
-      },
-      createCronJob({
-        agentId: "ops",
-        payload: { kind: "agentTurn", message: "legacy" },
-      }),
-      { client: callerClient("ops") },
-    );
+  it.each([undefined, { agentId: "ops", sessionKey: "agent:ops:discord:group:ops" }])(
+    "rejects capless prompt edits without a proven owner account: %j",
+    async (owner) => {
+      const { context, respond } = await invokeCronUpdate(
+        {
+          id: "cron-1",
+          patch: { payload: { kind: "agentTurn", message: "updated" } },
+        },
+        createCronJob({
+          agentId: "ops",
+          owner,
+          payload: { kind: "agentTurn", message: "legacy" },
+        }),
+        { client: callerClient("ops", undefined, owner?.sessionKey) },
+      );
 
-    expect(context.cron.update).not.toHaveBeenCalled();
-    expectResponseError(respond, {
-      code: "INVALID_REQUEST",
-      messageIncludes: "explicit payload.toolsAllow cap",
+      expect(context.cron.update).not.toHaveBeenCalled();
+      expectResponseError(respond, {
+        code: "INVALID_REQUEST",
+        messageIncludes: "explicit payload.toolsAllow cap",
+      });
+    },
+  );
+
+  it("updates a legacy creator's prompt through the tool after Doctor without adopting permissions", async () => {
+    const { storePath } = await makeStorePath();
+    const sessionKey = "agent:ops:discord:work:direct:user-1";
+    const legacy = createCronJob({
+      enabled: false,
+      agentId: "ops",
+      owner: { agentId: "ops", sessionKey },
+      payload: { kind: "agentTurn", message: "legacy" },
     });
+    await saveCronStore(storePath, { version: 1, jobs: [legacy] });
+    const cfg: OpenClawConfig = { agents: { entries: { ops: {} } } };
+    const state = expectDefined(
+      await loadLegacyCronRepairState({ cfg, storePath }),
+      "legacy cron repair state",
+    );
+    const repair = await applyLegacyCronStoreRepair({ cfg, state });
+    const cron = new CronService({
+      storePath,
+      cronEnabled: false,
+      defaultAgentId: "ops",
+      log: cronLogger,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeat: vi.fn(),
+      runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const })),
+    });
+    const context = createCronContext();
+    context.cron.readJob.mockImplementation((id) => cron.readJob(id));
+    context.cron.updateWithPrecondition.mockImplementation((...args) =>
+      cron.updateWithPrecondition(...args),
+    );
+    let client = callerClient("ops", "work", sessionKey);
+    const edit = async (payload: Record<string, unknown>) =>
+      await updateCronJobFromAgentTool({
+        id: legacy.id,
+        patch: { payload },
+        creatorToolAllowlist: [{ name: "read" }],
+        gatewayOpts: {},
+        callGateway: async (method, _opts, params) => {
+          if (method !== "cron.get" && method !== "cron.update") {
+            throw new Error(`unexpected method: ${method}`);
+          }
+          const { respond } = await invokeCron(method, requireRecord(params, "cron params"), {
+            context,
+            client,
+          });
+          const [ok, result, error] = expectDefined(respond.mock.calls[0], "cron response");
+          if (!ok) {
+            throw new Error(error.message);
+          }
+          return result;
+        },
+      });
+    try {
+      await expect(edit({ message: "updated" })).resolves.toMatchObject({
+        owner: { ...legacy.owner, accountId: "work" },
+        payload: { kind: "agentTurn", message: "updated" },
+      });
+      const updated = expectDefined((await loadCronStore(storePath)).jobs[0], "updated cron job");
+      expect(updated.payload).toEqual({ kind: "agentTurn", message: "updated" });
+      expect(updated.scheduledToolPolicy).toBeUndefined();
+      expect(repair.changes).toContain(
+        "Reconciled 1 cron job owner account from persisted creator identity; existing tool permissions were preserved.",
+      );
+      client = callerClient("ops", "personal", sessionKey);
+      await expect(edit({ message: "foreign" })).rejects.toThrow("cron job not found: cron-1");
+      expect((await loadCronStore(storePath)).jobs[0]?.payload).toEqual(updated.payload);
+      client = callerClient("ops", "work", "agent:ops:discord:work:direct:user-2");
+      await expect(edit({ message: "another session" })).rejects.toThrow(
+        "explicit payload.toolsAllow cap",
+      );
+      expect((await loadCronStore(storePath)).jobs[0]?.payload).toEqual(updated.payload);
+      client = callerClient("ops", "work", sessionKey);
+      await expect(edit({ kind: "agentTurn", toolsAllow: ["read"] })).resolves.toMatchObject({
+        scheduledToolPolicy: {
+          version: 1,
+          mode: "account",
+          ownerSessionKey: sessionKey,
+          ownerAccountId: "work",
+        },
+      });
+    } finally {
+      cron.stop();
+    }
   });
 
   it("allows agent-runtime non-policy edits to legacy capless jobs", async () => {


### PR DESCRIPTION
Fixes #145689
Refs #139619 #140765 #144814

<details>
<summary>Additional instructions</summary>

This branch is in `openclaw/openclaw`; maintainers with repository write access can edit it.

</details>

## What Problem This Solves

Fixes an issue where users editing an older automation's prompt through chat would be asked for a new tool-permission cap, then encounter `scheduled account policy must match the persisted job owner` when supplying it. Jobs created before account attribution could carry a creator session without a separate owner account, and Doctor skipped account recovery for every capless job.

## Why This Change Was Made

Doctor now reconciles provable creator account metadata independently of tool-cap migration and reports the repair. Capless jobs retain their existing execution policy. Gateway mutation admission permits a prompt-only edit by the exact persisted creator session/account without requiring a new cap; explicit tool edits still use the existing owner validation. Accountless or conflicting legacy identities are not assigned to the current caller.

This follows the approved migration policy in https://github.com/openclaw/openclaw/issues/145689#issuecomment-5644221587. The existing Doctor store writer, transaction, concurrency checks, and upgrade lifecycle remain the owners. No schema, config, dependency, retention, or rollback changes.

## User Impact

After `openclaw doctor --fix`, a legitimate creator can edit a recoverable older automation's prompt while preserving its permissions and attribution. Later explicit cap changes no longer fail merely because the old row omitted a recoverable account ID. Different accounts remain unable to update the job. Cross-session management policy is unchanged.

Thanks to @joncursi for reporting the two-stage failure and its isolation requirements.

## Evidence

- Replacement head `27e4041d221f7574498bcc9197249238a7b19b7f` corrects commit-message attribution only: @joncursi is credited as the reporter in prose. Its tree is identical to reviewed head `12f98a31b418f095df4d09c142c5076027c46f5c` (empty commit-to-commit diff; tree `31bffeb19d0f4cbd0c1750aaeae8752943a26e0a`). The existing scoped-clean Codex autoreview and ClawSweeper review are adopted for this unchanged tree under the maintainer’s explicit ruling; no new review was requested.

- Before the fix, the new Doctor regression failed because `owner.accountId` remained absent. The new tool → Gateway handler → SQLite cron-service regression failed with `agent-runtime tool jobs require an explicit payload.toolsAllow cap` (235 existing Gateway tests passed).
- After the fix, the migration regression and all 237 Gateway validation tests passed. The boundary proof covers prompt editing without a cap, unchanged durable execution policy, rejected foreign-account and foreign-session edits, Doctor's reconciliation report, and a successful later explicit permission edit.
- Selected cron service, Doctor, scheduled-policy, caller-scope, and creator-cap suites: 1,031 tests passed across 63 files.
- `node scripts/check-changed.mjs`: passed, including production/test typechecks, lint, formatting, and static guards.
- Fresh independent Codex P1 autoreview: scoped-clean, no accepted/actionable findings. The accountless-caller concern was checked against the concrete caller normalization contract and the added ambiguous-group negative case.

Known gaps: the reporter's sanitized persisted row is unavailable. The regression uses the historically supported account-scoped direct-session shape; accountless group-session records remain ambiguous and require authenticated operator recovery. This is an isolated mock transport proof using real Doctor and cron persistence, not a live Discord or published-updater run.

## ClawSweeper review

The completed review of `12f98a31b418f095df4d09c142c5076027c46f5c` found no actionable code or security defect. No code fixups were needed. Published-driver upgrade/recovery proof and the reporter's exact sanitized legacy row remain unavailable; these requests are deferred under the maintainer's explicit decision to land this bounded repair. Existing Doctor → tool → Gateway → SQLite regression coverage proves recovered ownership, preserved permissions, creator prompt edits, and rejection of foreign accounts/sessions for the supported fixture. The data-model compatibility request is covered at that persistence boundary; a published-updater run remains a known validation gap.
