### PR TITLE
improve(memory): reduce CPU spent constructing chunk overlap

### DIFF
--- a/packages/memory-host-sdk/src/host/internal.test.ts
+++ b/packages/memory-host-sdk/src/host/internal.test.ts
@@ -550,11 +550,25 @@ describe("memory host SDK package internals", () => {
     }
   });
 
-  it("measures the carried tail in weighted units for CJK content", () => {
-    const content = ["中".repeat(300), "x".repeat(1499)].join("\n");
+  it.each([
+    { label: "common CJK", character: "中", count: 60, retained: 24 },
+    { label: "rare BMP CJK", character: "\u3400", count: 60, retained: 8 },
+    { label: "supplementary CJK", character: "\u{20000}", count: 60, retained: 6 },
+    { label: "emoji", character: "🌸", count: 60, retained: 49 },
+    { label: "lone high surrogates", character: "\ud800", count: 120, retained: 99 },
+    { label: "lone low surrogates", character: "\udc00", count: 120, retained: 99 },
+  ])("preserves the weighted overlap tail for $label", ({ character, count, retained }) => {
+    const firstLine = `${"a".repeat(600)}${character.repeat(count)}`;
+    const nextLine = "x".repeat(1499);
+    const content = [firstLine, nextLine].join("\n");
 
     const chunks = chunkMarkdown(content, { tokens: 400, overlap: 80 });
 
+    // The 100-unit overlap window reserves one unit for its separator.
+    expect(chunks.map((chunk) => chunk.text)).toEqual([
+      firstLine,
+      `${character.repeat(retained)}\n${nextLine}`,
+    ]);
     for (const chunk of chunks) {
       expect(estimateStringChars(chunk.text)).toBeLessThanOrEqual(1600);
     }

--- a/packages/memory-host-sdk/src/host/internal.ts
+++ b/packages/memory-host-sdk/src/host/internal.ts
@@ -554,19 +554,11 @@ function takeTailByEstimatedChars(text: string, budget: number): string {
   let acc = 0;
   let start = text.length;
   while (start > 0) {
-    let previous = start - 1;
-    const last = text.charCodeAt(previous);
-    if (last >= 0xdc00 && last <= 0xdfff && previous > 0) {
-      const first = text.charCodeAt(previous - 1);
-      if (first >= 0xd800 && first <= 0xdbff) {
-        previous -= 1;
-      }
-    }
-    const chars = estimateStringChars(text.slice(previous, start));
-    if (!(acc + chars <= budget)) {
+    const previous = start - ((text.codePointAt(start - 2) ?? 0) > 0xffff ? 2 : 1);
+    acc += estimateStringChars(text.slice(previous, start));
+    if (!(acc <= budget)) {
       break;
     }
-    acc += chars;
     start = previous;
   }
   return text.slice(start);
@@ -590,9 +582,6 @@ export function chunkMarkdown(
     : undefined;
 
   const flush = () => {
-    if (current.length === 0) {
-      return;
-    }
     const firstEntry = current[0];
     const lastEntry = current[current.length - 1];
     if (!firstEntry || !lastEntry) {

--- a/packages/memory-host-sdk/src/host/internal.ts
+++ b/packages/memory-host-sdk/src/host/internal.ts
@@ -551,14 +551,25 @@ export function splitCuratedMarkdownEntries(content: string): CuratedMarkdownEnt
 
 /** Takes the trailing slice of text within the weighted char budget, without splitting surrogate pairs. */
 function takeTailByEstimatedChars(text: string, budget: number): string {
-  const chars = Array.from(text);
   let acc = 0;
-  let start = chars.length;
-  while (start > 0 && acc + estimateStringChars(chars[start - 1] ?? "") <= budget) {
-    acc += estimateStringChars(chars[start - 1] ?? "");
-    start -= 1;
+  let start = text.length;
+  while (start > 0) {
+    let previous = start - 1;
+    const last = text.charCodeAt(previous);
+    if (last >= 0xdc00 && last <= 0xdfff && previous > 0) {
+      const first = text.charCodeAt(previous - 1);
+      if (first >= 0xd800 && first <= 0xdbff) {
+        previous -= 1;
+      }
+    }
+    const chars = estimateStringChars(text.slice(previous, start));
+    if (!(acc + chars <= budget)) {
+      break;
+    }
+    acc += chars;
+    start = previous;
   }
-  return chars.slice(start).join("");
+  return text.slice(start);
 }
 
 export function chunkMarkdown(


### PR DESCRIPTION
## What Problem This Solves

Indexing memory notes and session transcripts with long paragraphs spends avoidable CPU rebuilding overlap text at chunk boundaries.

## Why This Change Was Made

The existing chunking owner now walks backward through UTF-16 code points to select the overlap tail. This removes the whole-line character array and duplicate estimates for retained characters. Valid surrogate pairs, lone surrogates, weighted budgets, chunk text, hashes, and chunking version 4 retain their existing behavior. The redundant empty-array flush guard is removed; the existing first/last-entry guard handles that case.

The temporary tail is joined with the incoming segment before a chunk escapes. Existing indexes stay compatible; no index rebuild, migration, configuration change, or update behavior change is introduced.

## User Impact

Memory indexing spends less CPU constructing overlapping chunks when notes or transcripts contain long lines. Embedding provider latency is unaffected. The measured benefit is specific to overlap construction; small no-overlap inputs can have a modest cost, recorded below.

## Evidence

Final production head: `ff8f49857753b5994036e6c595262325584f6b48`; baseline: `8b5fa242a2fa2f3c689f3125304a8000807d1ef0`. The harness imports the edited `chunkMarkdown` directly and compares it with the captured pre-edit owner using the same dependency files. Candidate source SHA-256: `1501d4fb9c2f2656153039cec89a69bed4250911bb38dd9f4b59dae40ca97014`; captured baseline SHA-256: `c2f68169a340b5dbeb6c8bcbc636e1920830c7dce7594f0a624d10a5878cc069`.

The synthetic matrix covers seven document shapes at overlap 0 and 80, with 400-token chunks, 30 warmups and nine alternating batches of 100 calls per variant. These are median milliseconds per actual `chunkMarkdown` call on Windows:

| Long-line document, overlap 80 | Node 24.19.0 before → after | Speedup | Node 26.8.2 before → after | Speedup |
| --- | ---: | ---: | ---: | ---: |
| ASCII | 3.066 → 1.460 | 2.10x | 6.417 → 3.253 | 1.97x |
| Common CJK | 1.850 → 1.292 | 1.43x | 3.792 → 2.667 | 1.42x |
| Rare BMP CJK | 2.836 → 1.999 | 1.42x | 5.764 → 4.031 | 1.43x |
| Supplementary CJK | 2.542 → 1.770 | 1.44x | 5.441 → 3.434 | 1.58x |
| Emoji and ASCII | 4.074 → 2.692 | 1.51x | 9.658 → 6.317 | 1.53x |

V8 versions were `13.6.233.17-node.51` and `14.6.202.34-node.28`. Each runtime compares its own baseline and candidate; absolute times across runtimes are not a version comparison. The first Node 24 process terminated with Windows exit `-1073740791` before producing a full result. After confirming it had exited, one fresh rerun completed with exit 0 and the full matrix; the partial run is excluded from this table.

Control fluctuations prompted a bounded fresh-process ABBA check, with two processes per variant, 100 warmups and eight 250-call samples per process. On Node 26, ASCII no-overlap remained modestly slower: **0.326 → 0.352 ms (+0.026 ms, +7.9%)**, with before samples 0.314–0.386 ms and after samples 0.336–0.402 ms. Rare-CJK no-overlap was +3.7%, emoji no-overlap +1.0%, and the unbroken-line overlap control -0.9%. This records a small measured tradeoff rather than claiming universal improvement. Node 24's corresponding controls ranged from -0.6% to +2.3%; its initially slower paragraph-overlap, supplementary no-overlap and unbroken no-overlap controls resolved to +0.5%, -1.7% and -0.3% in the same fresh-process protocol. All raw distributions are retained in the task evidence. No full indexing-service or provider-network speedup is claimed.

- Full chunk-object parity passed 180 combinations on both runtimes, including ASCII, CJK, supplementary characters, emoji, lone surrogates, chunk sizes and overlap budgets. This checks text, hashes, embedding inputs and source positions.
- The final-source retained-heap probe kept 100 final overlap chunks from 213,814-character inputs after dropping the inputs. Candidate retained 114–127 KB, baseline 103–126 KB, while the raw-slice positive control retained 21.39 MB. This demonstrates that final chunks do not retain the large source strings in this probe; it does not claim lower overall RSS. The result agrees with the [pinned V8 join implementation](https://github.com/nodejs/node/blob/v26.8.2/deps/v8/src/builtins/array-join.tq#L297-L325).
- Focused `internal.test.ts` and `chunk-budget.test.ts`: 36 passed; three existing Windows skips cover case-sensitive and symlink behavior. The existing weighted-overlap test asserts exact CJK, emoji and lone-surrogate tails.
- Final type-aware lint, formatting and `git diff --check` passed. Fresh independent P2 autoreview was scoped-clean. The prior file-length lint failure was corrected in the final head without a limit exception.
- Production core typechecking and selected lightweight changed-scope guards passed. Local core-test typechecking stopped with a tsgo `cannot allocate memory` resource failure, not a TypeScript diagnostic. Local dead-code scanning passed the production scan but reported unchanged script/full-tree exports `canonicalProviderName` and `listPackagedStaticExtensionAssetOutputs`; the final full changed-check wrapper did not complete. These local limitations are retained rather than represented as successful full checks. The final head's hosted required gate, including test types, passed: [CI run](https://github.com/openclaw/openclaw/actions/runs/34680099591).
