### PR TITLE
fix: recover the correct cron run when timestamps collide

### DIFF
--- a/docs/reference/database-schemas/versioning.md
+++ b/docs/reference/database-schemas/versioning.md
@@ -46,8 +46,16 @@ creates a retirement row in the same transaction as the job edit. This includes
 an exact receipt already closed by an agent-owner edit but still awaiting run
 reconciliation. Normal completion and restart recovery preserve the replacement's
 state while retaining the old run's history. The first eligible edit creates the
-table; queued edits do not retire a future evaluation. Existing receipt pruning
-also deletes its retirement row.
+table; queued edits do not retire a future evaluation. The job's private runtime
+state retains the exact running receipt ID until scheduler reconciliation, including
+when an agent-owner edit closes the receipt first. Recovery and later state edits
+use that association even when run timestamps collide. Receipt pruning preserves
+that pending receipt; ordinary history retains its existing 64-receipt bound and
+deletes retirement rows with their receipts.
+
+Rows written before this association was recorded retain their legacy recovery
+fallback. The association adds no SQL table, column, or schema version and is
+omitted from public job state and the public state-patch schema.
 
 A missing table or row means no recorded retirement; earlier edits cannot be
 reconstructed from the final job definition. Older compatible readers ignore the

--- a/docs/reference/database-schemas/versioning.md
+++ b/docs/reference/database-schemas/versioning.md
@@ -54,13 +54,15 @@ that pending receipt; ordinary history retains its existing 64-receipt bound and
 deletes retirement rows with their receipts.
 
 Rows written before this association was recorded retain their legacy recovery
-fallback. The association adds no SQL table, column, or schema version and is
-omitted from public job state and the public state-patch schema.
+fallback. The association adds no SQL table, column, or schema version. Current
+builds omit it from public job state and the public state-patch schema.
 
 A missing table or row means no recorded retirement; earlier edits cannot be
 reconstructed from the final job definition. Older compatible readers ignore the
-companion but do not enforce this protection. Finish active runs before downgrading
-if their edited watcher state must be preserved.
+companion but do not enforce this protection. To preserve edited watcher state,
+complete active runs and pending scheduler reconciliation on the current build
+before downgrading. A terminal task or receipt can still leave job state
+unreconciled.
 
 Worker preparation uses the same-version rule for the bare nullable
 `worker_environments.preparation_purpose TEXT` column in the shared state

--- a/src/cron/public-job.test.ts
+++ b/src/cron/public-job.test.ts
@@ -9,6 +9,7 @@ describe("toPublicCronJob", () => {
       state: {
         nextRunAtMs: 2_000,
         queuedAtMs: 1_900,
+        runningReceiptId: "pending-receipt",
         startupCatchupAtMs: 2_000,
         pacedNextRunAtMs: 2_000,
         forcePreservedNextRunAtMs: 2_000,
@@ -18,10 +19,12 @@ describe("toPublicCronJob", () => {
     const publicJob = toPublicCronJob(job);
 
     expect(publicJob.state.queuedAtMs).toBeUndefined();
+    expect(publicJob.state.runningReceiptId).toBeUndefined();
     expect(publicJob.state.startupCatchupAtMs).toBeUndefined();
     expect(publicJob.state.pacedNextRunAtMs).toBeUndefined();
     expect(publicJob.state.forcePreservedNextRunAtMs).toBeUndefined();
     expect(job.state.queuedAtMs).toBe(1_900);
+    expect(job.state.runningReceiptId).toBe("pending-receipt");
     expect(job.state.startupCatchupAtMs).toBe(2_000);
     expect(job.state.pacedNextRunAtMs).toBe(2_000);
     expect(job.state.forcePreservedNextRunAtMs).toBe(2_000);

--- a/src/cron/public-job.ts
+++ b/src/cron/public-job.ts
@@ -14,6 +14,7 @@ export function toPublicCronJob(job: CronStoredJob): CronJob {
   } = job;
   const state = { ...job.state };
   delete state.queuedAtMs;
+  delete state.runningReceiptId;
   delete state.startupCatchupAtMs;
   delete state.pacedNextRunAtMs;
   delete state.forcePreservedNextRunAtMs;

--- a/src/cron/service.cross-tick-admission.test.ts
+++ b/src/cron/service.cross-tick-admission.test.ts
@@ -19,10 +19,10 @@ import { cronStoreKey } from "./store/key.js";
 import {
   claimCronRunReceiptInDatabase,
   finishCronRunReceipt,
-  inspectActiveCronRunReceipt,
   prepareCronRunReceiptClaim,
   type CronRunReceiptHandle,
 } from "./store/run-receipt-store.js";
+import { inspectActiveCronRunReceipt } from "./store/run-receipt-store.test-support.js";
 import type { CronJob } from "./types.js";
 
 const fixtures = setupCronRegressionFixtures({

--- a/src/cron/service.recovery-identity.test.ts
+++ b/src/cron/service.recovery-identity.test.ts
@@ -13,7 +13,7 @@ import { createCronServiceState, type CronServiceDeps } from "./service/state.js
 import { findCronTaskRunRecoveryInDatabase } from "./service/task-runs.js";
 import { loadCronStore } from "./store.js";
 import { cronStoreKey } from "./store/key.js";
-import { inspectActiveCronRunReceipt } from "./store/run-receipt-store.js";
+import { inspectActiveCronRunReceipt } from "./store/run-receipt-store.test-support.js";
 import { readCronTaskRunHistoryPage } from "./task-run-history.js";
 
 const { logger, makeStorePath } = setupCronServiceSuite({ prefix: "cron-recovery-identity-" });

--- a/src/cron/service.recovery-identity.test.ts
+++ b/src/cron/service.recovery-identity.test.ts
@@ -1,0 +1,202 @@
+import crypto from "node:crypto";
+import { describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
+import {
+  openOpenClawStateDatabase,
+  runOpenClawStateWriteTransaction,
+} from "../state/openclaw-state-db.js";
+import { CronService } from "./service.js";
+import { setupCronServiceSuite } from "./service.test-harness.js";
+import { waitForActiveCronTaskRuns } from "./service/active-run-cancellation.js";
+import { proposeCronRunRecovery, recoverCronRunProposal } from "./service/run-recovery.js";
+import { createCronServiceState, type CronServiceDeps } from "./service/state.js";
+import { findCronTaskRunRecoveryInDatabase } from "./service/task-runs.js";
+import { loadCronStore } from "./store.js";
+import { cronStoreKey } from "./store/key.js";
+import { inspectActiveCronRunReceipt } from "./store/run-receipt-store.js";
+import { readCronTaskRunHistoryPage } from "./task-run-history.js";
+
+const { logger, makeStorePath } = setupCronServiceSuite({ prefix: "cron-recovery-identity-" });
+let uuidCounter = 0xffffffffffff;
+
+function pendingPayload() {
+  return {
+    started: createDeferred(),
+    completion: createDeferred<{ status: "ok"; summary: string }>(),
+  };
+}
+
+function rejectSchedulerWrite(jobId: string) {
+  const db = openOpenClawStateDatabase().db;
+  // The terminal task commits independently of the scheduler's outcome write.
+  db.exec(`
+    CREATE TEMP TRIGGER reject_identity_scheduler_write
+    BEFORE UPDATE ON cron_jobs
+    WHEN NEW.job_id = '${jobId.replaceAll("'", "''")}'
+    BEGIN SELECT RAISE(ABORT, 'scheduler write unavailable'); END;
+  `);
+  return () => db.exec("DROP TRIGGER IF EXISTS reject_identity_scheduler_write");
+}
+
+describe("cron recovery run identity", () => {
+  it.each([
+    { name: "retired predecessor", edit: "predecessor", advanceMs: 0, staleProposal: false },
+    { name: "retired pending run", edit: "pending", advanceMs: 0, staleProposal: false },
+    { name: "edit after receipt closure", edit: "late", advanceMs: 0, staleProposal: false },
+    { name: "unedited pending run", edit: "none", advanceMs: 0, staleProposal: false },
+    { name: "advancing clock", edit: "predecessor", advanceMs: 1, staleProposal: false },
+    { name: "stale predecessor proposal", edit: "none", advanceMs: 0, staleProposal: true },
+  ] as const)("recovers the pending run with $name", async ({ edit, advanceMs, staleProposal }) => {
+    // Keep real admission/task producers, but force their UUID tie-break order.
+    const uuids = vi.spyOn(crypto, "randomUUID").mockImplementation(() => {
+      const suffix = (uuidCounter--).toString(16).padStart(12, "0");
+      return `00000000-0000-4000-8000-${suffix}`;
+    });
+    const { storePath } = await makeStorePath();
+    const storeKey = cronStoreKey(storePath);
+    const firstStartedAt = Date.now();
+    let payload = pendingPayload();
+    let evaluationCount = 0;
+    const evaluateCronTrigger = vi.fn(async () => ({
+      kind: "evaluated" as const,
+      fire: true,
+      state: { owner: `evaluation-${++evaluationCount}` },
+    }));
+    const runIsolatedAgentJob = vi.fn(async () => {
+      const pending = payload;
+      pending.started.resolve();
+      return pending.completion.promise;
+    });
+    const deps: CronServiceDeps = {
+      storePath,
+      cronEnabled: true,
+      cronConfig: { triggers: { enabled: true } },
+      defaultAgentId: "alpha",
+      resolveDefaultAgentId: () => "alpha",
+      isAgentAvailable: () => true,
+      log: logger,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeat: vi.fn(),
+      evaluateCronTrigger,
+      runIsolatedAgentJob,
+    };
+    const cron = new CronService(deps);
+    let restarted: CronService | undefined;
+    let run: ReturnType<CronService["run"]> | undefined;
+    let allowWrites: (() => void) | undefined;
+    try {
+      await cron.start();
+      cron.pauseScheduling();
+      const job = await cron.add({
+        name: "receipt identity watcher",
+        agentId: "alpha",
+        enabled: true,
+        schedule: { kind: "every", everyMs: 86_400_000, anchorMs: firstStartedAt },
+        trigger: { script: "return true", once: true },
+        sessionTarget: "isolated",
+        wakeMode: "now",
+        payload: { kind: "agentTurn", message: "watcher payload" },
+        delivery: { mode: "none" },
+        state: { triggerState: { owner: "initial" } },
+      });
+      const readJob = async () => (await loadCronStore(storePath)).jobs[0]!;
+      const readHistory = () => readCronTaskRunHistoryPage({ storeKey, jobId: job.id }).entries;
+      const recoveryState = createCronServiceState(deps);
+
+      await cron.update(job.id, { state: { nextRunAtMs: firstStartedAt } });
+      run = cron.run(job.id, "due");
+      await payload.started.promise;
+      const first = inspectActiveCronRunReceipt({ storePath, jobId: job.id });
+      if (!first) {
+        throw new Error("predecessor was not admitted");
+      }
+      const predecessorProposal = proposeCronRunRecovery(
+        recoveryState,
+        job.id,
+        undefined,
+        firstStartedAt,
+      );
+      if (edit === "predecessor") {
+        await cron.update(job.id, { state: { triggerState: { owner: "predecessor edit" } } });
+      }
+      payload.completion.resolve({ status: "ok", summary: "first completed" });
+      await expect(run).resolves.toEqual({ ok: true, ran: true });
+
+      const pendingStartedAt = firstStartedAt + advanceMs;
+      vi.setSystemTime(pendingStartedAt);
+      if (!cron.getJob(job.id)?.enabled) {
+        await cron.update(job.id, { enabled: true });
+      }
+      await cron.update(job.id, { state: { nextRunAtMs: pendingStartedAt } });
+      payload = pendingPayload();
+      run = cron.run(job.id, "due");
+      await payload.started.promise;
+      const pending = inspectActiveCronRunReceipt({ storePath, jobId: job.id });
+      if (!pending) {
+        throw new Error("pending run was not admitted");
+      }
+      if (edit === "pending") {
+        await cron.update(job.id, { state: { triggerState: { owner: "replacement" } } });
+      }
+      allowWrites = rejectSchedulerWrite(job.id);
+      payload.completion.resolve({ status: "ok", summary: "pending completed" });
+      await expect(run).rejects.toThrow("scheduler write unavailable");
+      allowWrites();
+      allowWrites = undefined;
+      run = undefined;
+      await expect(waitForActiveCronTaskRuns(0)).resolves.toEqual({ drained: true, active: 0 });
+      expect((await readJob()).state.runningAtMs).toBe(pendingStartedAt);
+      const history = readHistory();
+      expect(history).toHaveLength(2);
+      expect(history.every((entry) => entry.status === "ok")).toBe(true);
+
+      cron.stop();
+      await cron.update(job.id, { agentId: "beta" });
+      expect(inspectActiveCronRunReceipt({ storePath, jobId: job.id })).toBeUndefined();
+      if (edit === "late") {
+        await cron.update(job.id, { state: { triggerState: { owner: "replacement" } } });
+      }
+      const fallback = runOpenClawStateWriteTransaction(({ db }) =>
+        findCronTaskRunRecoveryInDatabase({
+          database: db,
+          storeKey,
+          jobId: job.id,
+          startedAt: pendingStartedAt,
+        }),
+      );
+      expect(fallback.receiptId).toBe(advanceMs === 0 ? first.receiptId : pending.receiptId);
+
+      if (staleProposal) {
+        const before = await readJob();
+        expect(recoverCronRunProposal(recoveryState, predecessorProposal, "startup")).toEqual({
+          kind: "superseded",
+        });
+        expect(await readJob()).toEqual(before);
+      }
+      restarted = new CronService(deps);
+      await restarted.start();
+      restarted.pauseScheduling();
+
+      const recovered = await readJob();
+      const pendingRetired = edit === "pending" || edit === "late";
+      expect(recovered.enabled).toBe(pendingRetired);
+      expect(recovered.state.triggerState).toEqual({
+        owner: pendingRetired ? "replacement" : "evaluation-2",
+      });
+      expect(recovered.agentId).toBe("beta");
+      expect(recovered.state.lastRunStatus).toBe("ok");
+      expect(recovered.state.runningAtMs).toBeUndefined();
+      expect(recovered.state.runningReceiptId).toBeUndefined();
+      expect(readHistory()).toEqual(history);
+      expect(evaluateCronTrigger).toHaveBeenCalledTimes(2);
+      expect(runIsolatedAgentJob).toHaveBeenCalledTimes(2);
+    } finally {
+      allowWrites?.();
+      payload.completion.resolve({ status: "ok", summary: "cleanup" });
+      await run?.catch(() => undefined);
+      cron.stop();
+      restarted?.stop();
+      uuids.mockRestore();
+    }
+  });
+});

--- a/src/cron/service.trigger-eval.test.ts
+++ b/src/cron/service.trigger-eval.test.ts
@@ -10,7 +10,7 @@ import { proposeCronRunRecovery, recoverCronRunProposal } from "./service/run-re
 import { createCronServiceState, type CronServiceDeps } from "./service/state.js";
 import { loadCronStore } from "./store.js";
 import { cronStoreKey } from "./store/key.js";
-import { inspectActiveCronRunReceipt } from "./store/run-receipt-store.js";
+import { inspectActiveCronRunReceipt } from "./store/run-receipt-store.test-support.js";
 import { readCronTaskRunHistoryPage } from "./task-run-history.js";
 import type { CronJobCreate } from "./types.js";
 

--- a/src/cron/service/jobs-scheduling.ts
+++ b/src/cron/service/jobs-scheduling.ts
@@ -468,7 +468,7 @@ function normalizeJobTickState(params: { state: CronServiceState; job: CronJob; 
       !ownsCronRunMarker(state, job.id, job.state.runningAtMs, true) &&
       !isCronJobActive(job.id)
     ) {
-      job.state.runningAtMs = undefined;
+      Object.assign(job.state, { runningAtMs: undefined, runningReceiptId: undefined });
       changed = true;
     }
     return { changed, skip: true };
@@ -513,7 +513,7 @@ function normalizeJobTickState(params: { state: CronServiceState; job: CronJob; 
       { jobId: job.id, runningAtMs: runningAt },
       "cron: clearing stuck running marker",
     );
-    job.state.runningAtMs = undefined;
+    Object.assign(job.state, { runningAtMs: undefined, runningReceiptId: undefined });
     changed = true;
     const nextRun = job.state.nextRunAtMs;
     const lastRun = job.state.lastRunAtMs;

--- a/src/cron/service/ops-lifecycle.ts
+++ b/src/cron/service/ops-lifecycle.ts
@@ -94,6 +94,7 @@ async function reconcileForeignRunReceipts(state: CronServiceState): Promise<voi
         jobId: receipt.jobId,
         ...(job?.state.queuedAtMs !== undefined ? { queuedAtMs: job.state.queuedAtMs } : {}),
         ...(job?.state.runningAtMs !== undefined ? { runningAtMs: job.state.runningAtMs } : {}),
+        runningReceiptId: job?.state.runningReceiptId,
         receipt,
       };
       schedulingChanged =

--- a/src/cron/service/ops-mutations.ts
+++ b/src/cron/service/ops-mutations.ts
@@ -93,11 +93,8 @@ export async function quiesceJobs(
 async function resolveConfiguredChannelsForValidation(
   state: CronServiceState,
 ): Promise<readonly string[] | undefined> {
-  if (!state.deps.listConfiguredChannels) {
-    return undefined;
-  }
   try {
-    return await state.deps.listConfiguredChannels();
+    return await state.deps.listConfiguredChannels?.();
   } catch {
     // Channel discovery is advisory at mutation time. Runtime delivery remains
     // authoritative, so discovery failures must not create false rejections.
@@ -214,11 +211,14 @@ function finalizeUpdatedJob(params: {
       // Preserve only genuine execution. Queued reservations must clear so a
       // disabled job can accept a later force run with the same timestamp.
       if (!isCronJobActive(nextJob.id)) {
-        nextJob.state.runningAtMs = undefined;
+        Object.assign(nextJob.state, { runningAtMs: undefined, runningReceiptId: undefined });
       }
     }
   } else if (isJobEnabled(nextJob) && !hasScheduledNextRunAtMs(nextJob.state.nextRunAtMs)) {
     nextJob.state.nextRunAtMs = computeJobNextRunAtMs(nextJob, now);
+  }
+  if (nextJob.state.runningAtMs !== job.state.runningAtMs) {
+    delete nextJob.state.runningReceiptId;
   }
 }
 

--- a/src/cron/service/ops-run-preparation.ts
+++ b/src/cron/service/ops-run-preparation.ts
@@ -551,6 +551,7 @@ async function releasePreparedManualReservation(
       }
       if (runningMatches) {
         delete job.state.runningAtMs;
+        delete job.state.runningReceiptId;
       }
       return { upsertJobIds: [job.id], value: job };
     },

--- a/src/cron/service/ops.run-admission-capacity.test.ts
+++ b/src/cron/service/ops.run-admission-capacity.test.ts
@@ -10,7 +10,7 @@ import { DEFAULT_CRON_MAX_CONCURRENT_RUNS } from "../../config/cron-limits.js";
 import { openOpenClawStateDatabase } from "../../state/openclaw-state-db.js";
 import { saveCronStore } from "../store.js";
 import { cronStoreKey } from "../store/key.js";
-import { inspectActiveCronRunReceipt } from "../store/run-receipt-store.js";
+import { inspectActiveCronRunReceipt } from "../store/run-receipt-store.test-support.js";
 import { stop } from "./ops-lifecycle.js";
 import { update } from "./ops-mutations.js";
 import { run } from "./ops-run.js";

--- a/src/cron/service/ops.run-admission.test.ts
+++ b/src/cron/service/ops.run-admission.test.ts
@@ -18,7 +18,7 @@ import { openOpenClawStateDatabase } from "../../state/openclaw-state-db.js";
 import * as cronStoreModule from "../store.js";
 import { loadCronStore, saveCronStore } from "../store.js";
 import { cronStoreKey } from "../store/key.js";
-import { inspectActiveCronRunReceipt } from "../store/run-receipt-store.js";
+import { inspectActiveCronRunReceipt } from "../store/run-receipt-store.test-support.js";
 import { cronStreamScheduleKey } from "../stream-schedule.js";
 import { recomputeNextRunsForMaintenance } from "./jobs-scheduling.js";
 import { stop } from "./ops-lifecycle.js";

--- a/src/cron/service/ops.test.ts
+++ b/src/cron/service/ops.test.ts
@@ -21,6 +21,7 @@ import * as cronStoreModule from "../store.js";
 import { loadCronJobsStoreWithConfigJobs, loadCronStore } from "../store.js";
 import { cronStoreKey } from "../store/key.js";
 import * as runReceiptStore from "../store/run-receipt-store.js";
+import { inspectActiveCronRunReceipt } from "../store/run-receipt-store.test-support.js";
 import type { CronJob } from "../types.js";
 import { start, stop } from "./ops-lifecycle.js";
 import {
@@ -824,7 +825,7 @@ describe("cron service ops seam coverage", () => {
       ).toEqual({ name: "cron_run_receipts" });
     } finally {
       stop(state);
-      runReceiptStore.inspectActiveCronRunReceipt({ storePath, jobId: job.id });
+      inspectActiveCronRunReceipt({ storePath, jobId: job.id });
     }
   });
 

--- a/src/cron/service/owner-hardening.test.ts
+++ b/src/cron/service/owner-hardening.test.ts
@@ -28,11 +28,11 @@ import { upsertCronJobRow } from "../store/row-codec.js";
 import {
   claimCronRunReceiptInDatabase,
   finishCronRunReceipt,
-  inspectActiveCronRunReceipt,
   isCronRunReceiptOwnerStale,
   prepareCronRunReceiptClaim,
   releaseLocalCronRunReceiptOwnership,
 } from "../store/run-receipt-store.js";
+import { inspectActiveCronRunReceipt } from "../store/run-receipt-store.test-support.js";
 import type { CronJob } from "../types.js";
 import { listForeignReceipts } from "./foreign-receipt-monitor.js";
 import type { CronServiceState } from "./state.js";

--- a/src/cron/service/run-admission.ts
+++ b/src/cron/service/run-admission.ts
@@ -146,6 +146,7 @@ export async function cleanupQueuedCronRunReservations(params: {
             }
             if (runningMatches) {
               delete job.state.runningAtMs;
+              delete job.state.runningReceiptId;
             }
             if (params.recompute && job.enabled && job.state.nextRunAtMs === undefined) {
               recomputeJobNextRunAtMs({
@@ -420,6 +421,7 @@ export async function activateQueuedCronRun(params: {
           ] as const;
           delete current.state.queuedAtMs;
           current.state.runningAtMs = startedAt;
+          current.state.runningReceiptId = runReceipt.receiptId;
           current.state.lastError = undefined;
           return { value, upsertJobIds: [current.id] };
         },
@@ -469,6 +471,7 @@ export async function activateQueuedCronRun(params: {
         }
         current.state.lastError = previousLastError;
         delete current.state.runningAtMs;
+        delete current.state.runningReceiptId;
         return { value: current, upsertJobIds: [current.id] };
       },
     });

--- a/src/cron/service/run-receipts.ts
+++ b/src/cron/service/run-receipts.ts
@@ -144,17 +144,19 @@ function retireServiceCronRunTriggerStateInDatabase(params: {
   const job = loadedCronStoreFromRows(loadCronRows(database, storeKey, new Set([jobId]))).store
     .jobs[0];
   const startedAtMs = job?.state.runningAtMs;
-  if (startedAtMs === undefined) {
+  if (!job || startedAtMs === undefined) {
     return;
   }
-  // An owner edit can terminalize the receipt before its completed task is
-  // reconciled. The selected task's exact receipt still owns those pending facts.
-  const { receiptId } = findCronTaskRunRecoveryInDatabase({
-    database,
-    jobId,
-    storeKey,
-    startedAt: startedAtMs,
-  });
+  // Owner edits close execution authority before scheduler reconciliation.
+  // Only legacy markers without a receipt association need task-history fallback.
+  const receiptId =
+    job.state.runningReceiptId ??
+    findCronTaskRunRecoveryInDatabase({
+      database,
+      jobId,
+      storeKey,
+      startedAt: startedAtMs,
+    }).receiptId;
   if (receiptId) {
     retireCronRunTriggerStateInDatabase({
       database,

--- a/src/cron/service/run-recovery.lifecycle.test.ts
+++ b/src/cron/service/run-recovery.lifecycle.test.ts
@@ -17,10 +17,10 @@ import {
   claimCronRunReceiptInDatabase,
   finishCronRunReceipt,
   finishCronRunReceiptInDatabase,
-  inspectActiveCronRunReceipt,
   prepareCronRunReceiptClaim,
   type CronRunReceiptHandle,
 } from "../store/run-receipt-store.js";
+import { inspectActiveCronRunReceipt } from "../store/run-receipt-store.test-support.js";
 import { readCronTaskRunHistoryPage } from "../task-run-history.js";
 import type { CronJob, CronRunStatus } from "../types.js";
 import { locked } from "./locked.js";

--- a/src/cron/service/run-recovery.test.ts
+++ b/src/cron/service/run-recovery.test.ts
@@ -10,11 +10,11 @@ import {
   claimCronRunReceiptInDatabase,
   finishCronRunReceipt,
   finishCronRunReceiptInDatabase,
-  inspectActiveCronRunReceipt,
   prepareCronRunReceiptClaim,
   releaseLocalCronRunReceiptOwnership,
   type CronRunReceiptHandle,
 } from "../store/run-receipt-store.js";
+import { inspectActiveCronRunReceipt } from "../store/run-receipt-store.test-support.js";
 import type { CronJob } from "../types.js";
 import { start, stop } from "./ops-lifecycle.js";
 import {

--- a/src/cron/service/run-recovery.ts
+++ b/src/cron/service/run-recovery.ts
@@ -13,7 +13,6 @@ import {
 import {
   findActiveCronRunReceiptInDatabase,
   finishCronRunReceiptInDatabase,
-  inspectActiveCronRunReceipt,
   isCronRunReceiptOwnerStale,
   listActiveCronRunReceiptJobIdsInDatabase,
   type CronRunReceiptRecoveryCandidate,
@@ -38,6 +37,7 @@ export type CronRunRecoveryProposal = {
   jobId: string;
   queuedAtMs?: number;
   runningAtMs?: number;
+  runningReceiptId?: string;
   receipt?: CronRunReceiptRecoveryCandidate;
 };
 
@@ -110,6 +110,13 @@ function repairInDatabase(params: {
     }
     return { kind: "superseded" };
   }
+  if (
+    proposal.runningAtMs !== undefined &&
+    job.state.runningAtMs === proposal.runningAtMs &&
+    job.state.runningReceiptId !== proposal.runningReceiptId
+  ) {
+    return { kind: "superseded", ...(currentReceipt ? { receipt: currentReceipt } : {}) };
+  }
   let changed = false;
   if (proposal.queuedAtMs !== undefined && job.state.queuedAtMs === proposal.queuedAtMs) {
     delete job.state.queuedAtMs;
@@ -146,10 +153,10 @@ function repairInDatabase(params: {
       jobId: proposal.jobId,
       startedAt: proposal.runningAtMs,
       storeKey,
-      receiptId: proposal.receipt?.receiptId,
+      receiptId: proposal.runningReceiptId ?? proposal.receipt?.receiptId,
     });
     const finalized = task.finalized;
-    const receiptId = currentReceipt?.receiptId ?? task.receiptId;
+    const receiptId = proposal.runningReceiptId ?? currentReceipt?.receiptId ?? task.receiptId;
     const triggerStateRetired = receiptId
       ? isCronRunTriggerStateRetiredInDatabase({
           database: database.db,
@@ -260,16 +267,34 @@ export function proposeCronRunRecovery(
   queuedAtMs: number | undefined,
   runningAtMs: number | undefined,
 ): CronRunRecoveryProposal {
-  return {
+  const proposal = {
     jobId,
     ...(queuedAtMs !== undefined ? { queuedAtMs } : {}),
-    ...(queuedAtMs !== undefined || runningAtMs !== undefined
-      ? {
-          receipt: inspectActiveCronRunReceipt({ storePath: state.deps.storePath, jobId }),
-        }
-      : {}),
     ...(runningAtMs !== undefined ? { runningAtMs } : {}),
   };
+  if (queuedAtMs === undefined && runningAtMs === undefined) {
+    return proposal;
+  }
+  // Observe the pending marker and execution authority in one transaction.
+  return runOpenClawStateWriteTransaction(
+    ({ db }) => {
+      const storePath = state.deps.storePath;
+      const receipt = findActiveCronRunReceiptInDatabase({ database: db, storePath, jobId });
+      const rows =
+        runningAtMs === undefined
+          ? []
+          : loadCronRows(db, cronStoreKey(storePath), new Set([jobId]));
+      const job = loadedCronStoreFromRows(rows).store.jobs[0];
+      return {
+        ...proposal,
+        receipt,
+        runningReceiptId:
+          job?.state.runningAtMs === runningAtMs ? job?.state.runningReceiptId : undefined,
+      };
+    },
+    {},
+    { operationLabel: "cron.run-recovery.propose" },
+  );
 }
 
 /** Reconciles the bounded durable marker set so live siblings can adopt dead owners. */

--- a/src/cron/service/shared-store-runtime.test.ts
+++ b/src/cron/service/shared-store-runtime.test.ts
@@ -1,9 +1,16 @@
 import { spawnSync } from "node:child_process";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
+import { createDeferred } from "../../../test/helpers/promise.js";
+import {
+  openOpenClawStateDatabase,
+  runOpenClawStateWriteTransaction,
+} from "../../state/openclaw-state-db.js";
 import { CronService } from "../service.js";
 import { createCronStoreHarness } from "../service.test-harness.js";
 import { loadCronStore, saveCronJobsStoreChanges, saveCronStore } from "../store.js";
+import { inspectActiveCronRunReceipt } from "../store/run-receipt-store.js";
+import { isCronRunTriggerStateRetiredInDatabase } from "../store/run-receipt-trigger-state.js";
 import type { CronJob } from "../types.js";
 
 const { makeStorePath } = createCronStoreHarness({ prefix: "cron-shared-runtime-" });
@@ -54,26 +61,70 @@ import path from "node:path";
 import { pathToFileURL } from "node:url";
 const runs = JSON.parse(process.env.OPENCLAW_CRON_SHARED_STORE_RUNS);
 const { CronService } = await import(pathToFileURL(path.join(process.cwd(), "src/cron/service.ts")).href);
+const { openOpenClawStateDatabase } = await import(pathToFileURL(path.join(process.cwd(), "src/state/openclaw-state-db.ts")).href);
 const log = { debug() {}, info() {}, warn() {}, error() {} };
 for (const run of runs) {
   const cron = new CronService({
     cronEnabled: true,
     storePath: run.storePath,
+    nowMs: () => run.startedAtMs ?? Date.now(),
     log,
     enqueueSystemEvent() {},
     requestHeartbeat() {},
     async runIsolatedAgentJob() {
+      if (run.leavePending) {
+        openOpenClawStateDatabase().db.exec(
+          "CREATE TEMP TRIGGER reject_scheduler_completion BEFORE UPDATE ON cron_jobs " +
+          "WHEN json_extract(OLD.state_json, '$.runningAtMs') IS NOT NULL " +
+          "AND json_extract(NEW.state_json, '$.runningAtMs') IS NULL " +
+          "BEGIN SELECT RAISE(ABORT, 'scheduler completion unavailable'); END;",
+        );
+      }
       return { status: "ok", summary: "scheduler child completed" };
     },
   });
-  await cron.start();
-  const result = await cron.run(run.jobId, "force");
-  cron.stop();
-  if (!result.ok || !("ran" in result) || result.ran !== true) {
-    throw new Error("scheduler child did not run " + run.jobId + ": " + JSON.stringify(result));
+  try {
+    await cron.start();
+    const result = await cron.run(run.jobId, "force");
+    if (run.leavePending || !result.ok || !("ran" in result) || result.ran !== true) {
+      throw new Error("scheduler child did not complete the expected run " + run.jobId + ": " + JSON.stringify(result));
+    }
+  } catch (error) {
+    if (!run.leavePending || !String(error).includes("scheduler completion unavailable")) {
+      throw error;
+    }
+  } finally {
+    openOpenClawStateDatabase().db.exec("DROP TRIGGER IF EXISTS reject_scheduler_completion");
+    cron.stop();
   }
 }
 `;
+
+function runSchedulerChild(
+  runs: Array<{ storePath: string; jobId: string; startedAtMs?: number; leavePending?: boolean }>,
+) {
+  const child = spawnSync(
+    process.execPath,
+    [
+      "--import",
+      path.join(process.cwd(), "scripts/tsx.mjs"),
+      "--input-type=module",
+      "--eval",
+      schedulerChildScript,
+    ],
+    {
+      cwd: process.cwd(),
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        OPENCLAW_CRON_SHARED_STORE_RUNS: JSON.stringify(runs),
+      },
+      timeout: 60_000,
+    },
+  );
+  expect(child.stderr).toBe("");
+  expect(child.status).toBe(0);
+}
 
 describe("scheduler-disabled shared-store mutations", () => {
   it("cannot overwrite runtime committed by a scheduler process", async () => {
@@ -90,29 +141,7 @@ describe("scheduler-disabled shared-store mutations", () => {
       }),
     );
 
-    const child = spawnSync(
-      process.execPath,
-      [
-        "--import",
-        path.join(process.cwd(), "scripts/tsx.mjs"),
-        "--input-type=module",
-        "--eval",
-        schedulerChildScript,
-      ],
-      {
-        cwd: process.cwd(),
-        encoding: "utf8",
-        env: {
-          ...process.env,
-          OPENCLAW_CRON_SHARED_STORE_RUNS: JSON.stringify(
-            cases.map(({ canary, storePath }) => ({ jobId: canary.id, storePath })),
-          ),
-        },
-        timeout: 60_000,
-      },
-    );
-    expect(child.stderr).toBe("");
-    expect(child.status).toBe(0);
+    runSchedulerChild(cases.map(({ canary, storePath }) => ({ jobId: canary.id, storePath })));
 
     for (const testCase of cases) {
       const before = (await loadCronStore(testCase.storePath)).jobs.find(
@@ -159,6 +188,116 @@ describe("scheduler-disabled shared-store mutations", () => {
           : before?.state,
       );
       testCase.cron.stop();
+    }
+  }, 90_000);
+
+  it("keeps receipt identity coupled to a marker edited during concurrent admission", async () => {
+    const startedAtMs = Date.now();
+    const cases = await Promise.all(
+      ["same timestamp", "different timestamp", "ordinary edit", "failed replacement"].map(
+        async (operation) => {
+          const { storePath } = await makeStorePath();
+          const cron = createDisabledService(storePath);
+          const job = await addCanary(cron, operation);
+          return { operation, storePath, cron, job, entered: createDeferred() };
+        },
+      ),
+    );
+    const resumeUpdates = createDeferred();
+    const updates = Promise.allSettled(
+      cases.map(({ cron, job, operation, entered }) =>
+        cron.updateWithPrecondition(
+          job.id,
+          {
+            agentId: "beta",
+            state: {
+              ...(operation === "ordinary edit"
+                ? {}
+                : { runningAtMs: startedAtMs + (operation === "same timestamp" ? 0 : 1) }),
+              triggerState: { owner: "saved edit" },
+            },
+          },
+          async (snapshot) => {
+            expect(snapshot.state.runningAtMs).toBeUndefined();
+            entered.resolve();
+            await resumeUpdates.promise;
+          },
+        ),
+      ),
+    );
+    const database = openOpenClawStateDatabase().db;
+    try {
+      await Promise.all(cases.map(({ entered }) => entered.promise));
+      runSchedulerChild(
+        cases.map(({ job, storePath }) => ({
+          jobId: job.id,
+          storePath,
+          startedAtMs,
+          leavePending: true,
+        })),
+      );
+      const admitted = cases.map(({ storePath, job }) => {
+        const receipt = inspectActiveCronRunReceipt({ storePath, jobId: job.id });
+        expect(receipt).toBeDefined();
+        return receipt!;
+      });
+      for (const [index, { operation, storePath }] of cases.entries()) {
+        expect((await loadCronStore(storePath)).jobs[0]?.state, operation).toMatchObject({
+          runningAtMs: startedAtMs,
+          runningReceiptId: admitted[index]!.receiptId,
+        });
+      }
+      const failedJob = cases.find(({ operation }) => operation === "failed replacement")!.job;
+      database.exec(`
+        CREATE TEMP TRIGGER reject_shared_marker_update
+        BEFORE UPDATE ON cron_jobs
+        WHEN NEW.job_id = '${failedJob.id}'
+        BEGIN
+          SELECT RAISE(ABORT, 'marker update unavailable');
+        END;
+      `);
+      resumeUpdates.resolve();
+      const results = await updates;
+      for (const [index, { operation, storePath }] of cases.entries()) {
+        const result = results[index]!;
+        const receipt = admitted[index]!;
+        const failed = operation === "failed replacement";
+        expect(result.status, operation).toBe(failed ? "rejected" : "fulfilled");
+        if (result.status === "rejected") {
+          expect(String(result.reason)).toContain("marker update unavailable");
+        }
+        const persisted = (await loadCronStore(storePath)).jobs[0]!;
+        expect(persisted.state.runningAtMs, operation).toBe(
+          startedAtMs + (operation === "different timestamp" ? 1 : 0),
+        );
+        expect(persisted.state.runningReceiptId, operation).toBe(
+          operation === "different timestamp" ? undefined : receipt.receiptId,
+        );
+        expect(persisted.state.triggerState, operation).toEqual(
+          failed ? undefined : { owner: "saved edit" },
+        );
+        expect(
+          runOpenClawStateWriteTransaction(({ db }) =>
+            isCronRunTriggerStateRetiredInDatabase({ database: db, handle: receipt }),
+          ),
+          operation,
+        ).toBe(!failed);
+        expect(inspectActiveCronRunReceipt({ storePath, jobId: persisted.id }), operation).toEqual(
+          failed ? receipt : undefined,
+        );
+      }
+      const retained = cases.find(({ operation }) => operation === "same timestamp")!;
+      await retained.cron.update(retained.job.id, { state: { runningAtMs: startedAtMs + 2 } });
+      const replaced = (await loadCronStore(retained.storePath)).jobs[0]!;
+      expect(replaced.state.runningAtMs).toBe(startedAtMs + 2);
+      expect(replaced.state.runningReceiptId).toBeUndefined();
+    } finally {
+      database.exec("DROP TRIGGER IF EXISTS reject_shared_marker_update");
+      resumeUpdates.resolve();
+      await updates;
+      for (const { cron } of cases) {
+        cron.stop();
+      }
     }
   }, 90_000);
 

--- a/src/cron/service/shared-store-runtime.test.ts
+++ b/src/cron/service/shared-store-runtime.test.ts
@@ -9,7 +9,7 @@ import {
 import { CronService } from "../service.js";
 import { createCronStoreHarness } from "../service.test-harness.js";
 import { loadCronStore, saveCronJobsStoreChanges, saveCronStore } from "../store.js";
-import { inspectActiveCronRunReceipt } from "../store/run-receipt-store.js";
+import { inspectActiveCronRunReceipt } from "../store/run-receipt-store.test-support.js";
 import { isCronRunTriggerStateRetiredInDatabase } from "../store/run-receipt-trigger-state.js";
 import type { CronJob } from "../types.js";
 

--- a/src/cron/service/startup-run-repair.ts
+++ b/src/cron/service/startup-run-repair.ts
@@ -62,6 +62,7 @@ export function markInterruptedStartupRun(params: {
   );
 
   job.state.runningAtMs = undefined;
+  job.state.runningReceiptId = undefined;
   job.state.lastRunAtMs = runningAtMs;
   job.state.lastRunStatus = "error";
   job.state.lastStatus = "error";

--- a/src/cron/service/timer-catchup.ts
+++ b/src/cron/service/timer-catchup.ts
@@ -171,6 +171,7 @@ function commitStartupCatchupRows(params: {
           }
           if (ownership.markerAtMs === job.state.runningAtMs) {
             delete job.state.runningAtMs;
+            delete job.state.runningReceiptId;
             changed = true;
           }
         }

--- a/src/cron/service/timer-outcome-finalization.receipts.test.ts
+++ b/src/cron/service/timer-outcome-finalization.receipts.test.ts
@@ -15,9 +15,9 @@ import { cronStoreKey } from "../store/key.js";
 import {
   claimCronRunReceiptInDatabase,
   finishCronRunReceipt,
-  inspectActiveCronRunReceipt,
   prepareCronRunReceiptClaim,
 } from "../store/run-receipt-store.js";
+import { inspectActiveCronRunReceipt } from "../store/run-receipt-store.test-support.js";
 import type { CronJob } from "../types.js";
 import { reserveQueuedCronRun } from "./run-admission.js";
 import { createCronServiceState } from "./state.js";

--- a/src/cron/service/timer-outcomes.ts
+++ b/src/cron/service/timer-outcomes.ts
@@ -102,6 +102,7 @@ export function applyJobResult(
   };
   job.state.queuedAtMs = undefined;
   job.state.runningAtMs = undefined;
+  job.state.runningReceiptId = undefined;
   job.state.pacedNextRunAtMs = undefined;
   job.state.forcePreservedNextRunAtMs = undefined;
   job.state.lastRunAtMs = result.startedAt;
@@ -596,6 +597,7 @@ export function applyTriggerNoFireResult(
   const previousForcePreservedNextRunAtMs = job.state.forcePreservedNextRunAtMs;
   job.state.queuedAtMs = undefined;
   job.state.runningAtMs = undefined;
+  job.state.runningReceiptId = undefined;
   job.updatedAtMs = result.endedAt;
   if (!result.triggerEval.busy && opts?.triggerOwnership !== "stale") {
     // A non-firing evaluation is successful scheduler work, not a payload run;

--- a/src/cron/store.ts
+++ b/src/cron/store.ts
@@ -323,6 +323,10 @@ function mergeCronRuntimeChanges(
       Reflect.deleteProperty(merged, key);
     }
   }
+  if (previous.runningAtMs !== next.runningAtMs) {
+    merged.runningReceiptId =
+      next.runningAtMs === current.runningAtMs ? current.runningReceiptId : next.runningReceiptId;
+  }
   return merged;
 }
 

--- a/src/cron/store/run-receipt-retention.test.ts
+++ b/src/cron/store/run-receipt-retention.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../test/helpers/promise.js";
+import {
+  openOpenClawStateDatabase,
+  runOpenClawStateWriteTransaction,
+} from "../../state/openclaw-state-db.js";
+import { CronService } from "../service.js";
+import { setupCronServiceSuite } from "../service.test-harness.js";
+import type { CronServiceDeps } from "../service/state.js";
+import { loadCronStore } from "../store.js";
+import { cronStoreKey } from "./key.js";
+import {
+  claimCronRunReceiptInDatabase,
+  finishCronRunReceipt,
+  inspectActiveCronRunReceipt,
+  prepareCronRunReceiptClaim,
+} from "./run-receipt-store.js";
+
+const { logger, makeStorePath } = setupCronServiceSuite({ prefix: "cron-pending-retention-" });
+
+describe("pending cron receipt retention", () => {
+  it("keeps the pending terminal receipt within 64 rows until reconciliation releases it", async () => {
+    const { storePath } = await makeStorePath();
+    const now = Date.now();
+    const started = createDeferred();
+    const completion = createDeferred<{ status: "ok" }>();
+    const runCommandJob = vi
+      .fn<NonNullable<CronServiceDeps["runCommandJob"]>>()
+      .mockResolvedValue({ status: "ok" })
+      .mockImplementationOnce(async () => {
+        started.resolve();
+        return completion.promise;
+      });
+    const makeService = (cronEnabled = true) =>
+      new CronService({
+        storePath,
+        cronEnabled,
+        log: logger,
+        enqueueSystemEvent() {},
+        requestHeartbeat() {},
+        runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const })),
+        runCommandJob,
+      });
+    const owner = makeService();
+    const editor = makeService(false);
+    const reconciler = makeService();
+    const job = await editor.add({
+      name: "pending receipt retention",
+      agentId: "alpha",
+      enabled: true,
+      schedule: { kind: "every", everyMs: 60_000, anchorMs: now + 60_000 },
+      sessionTarget: "isolated",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "command", argv: ["true"] },
+    });
+    const history: string[] = [];
+    // A clock adjustment can leave all existing terminal rows newer than the
+    // next admitted run. Its pending job association must keep the receipt.
+    for (let index = 0; index < 64; index += 1) {
+      const prepared = prepareCronRunReceiptClaim({
+        storePath,
+        job,
+        agentId: "alpha",
+        startedAtMs: now + 100 + index * 2,
+      });
+      const receipt = runOpenClawStateWriteTransaction(({ db }) =>
+        claimCronRunReceiptInDatabase({
+          database: db,
+          prepared,
+          resolveAgentId: (current) => current.agentId!,
+        }),
+      );
+      history.push(receipt.receiptId);
+      finishCronRunReceipt({
+        handle: receipt,
+        status: "ok",
+        finishedAtMs: now + 101 + index * 2,
+      });
+    }
+    const database = openOpenClawStateDatabase().db;
+    const terminalIds = () =>
+      database
+        .prepare(
+          `SELECT receipt_id AS receiptId FROM cron_run_receipts
+           WHERE store_key = ? AND job_id = ? AND status != 'running'
+           ORDER BY finished_at_ms DESC, started_at_ms DESC, receipt_id DESC`,
+        )
+        .all(cronStoreKey(storePath), job.id)
+        .map((row) => row.receiptId);
+    const running = owner.run(job.id, "force");
+    try {
+      await started.promise;
+      const pending = inspectActiveCronRunReceipt({ storePath, jobId: job.id });
+      expect(pending).toBeDefined();
+      await editor.update(job.id, { state: { triggerState: { owner: "saved edit" } } });
+      const retirement = () =>
+        database
+          .prepare("SELECT receipt_id FROM cron_run_trigger_state_retirements WHERE receipt_id = ?")
+          .get(pending!.receiptId);
+      expect(retirement()).toEqual({ receipt_id: pending!.receiptId });
+
+      database.exec(`
+        CREATE TEMP TRIGGER reject_pending_receipt_completion
+        BEFORE UPDATE ON cron_jobs
+        WHEN NEW.job_id = '${job.id}'
+          AND json_extract(NEW.state_json, '$.runningAtMs') IS NULL
+        BEGIN
+          SELECT RAISE(ABORT, 'pending receipt completion unavailable');
+        END;
+      `);
+      completion.resolve({ status: "ok" });
+      await expect(running).rejects.toThrow("pending receipt completion unavailable");
+      database.exec("DROP TRIGGER reject_pending_receipt_completion");
+      owner.stop();
+      await editor.update(job.id, { agentId: "beta" });
+
+      expect(inspectActiveCronRunReceipt({ storePath, jobId: job.id })).toBeUndefined();
+      // A late settlement still prunes after an owner edit closes its receipt.
+      finishCronRunReceipt({ handle: pending!, status: "ok", finishedAtMs: now });
+      expect(terminalIds()).toEqual([...history.slice(1).toReversed(), pending!.receiptId]);
+      expect(retirement()).toEqual({ receipt_id: pending!.receiptId });
+      expect((await loadCronStore(storePath)).jobs[0]?.state.runningReceiptId).toBe(
+        pending!.receiptId,
+      );
+
+      await reconciler.start();
+      expect(runCommandJob).toHaveBeenCalledOnce();
+      const recovered = (await loadCronStore(storePath)).jobs[0]!;
+      expect(recovered.state.runningAtMs).toBeUndefined();
+      expect(recovered.state.runningReceiptId).toBeUndefined();
+      expect(recovered.state.triggerState).toEqual({ owner: "saved edit" });
+      expect(retirement()).toEqual({ receipt_id: pending!.receiptId });
+
+      vi.setSystemTime(now + 1_000);
+      await expect(reconciler.run(job.id, "force")).resolves.toEqual({ ok: true, ran: true });
+      expect(runCommandJob).toHaveBeenCalledTimes(2);
+      expect(terminalIds()).toHaveLength(64);
+      expect(terminalIds()).not.toContain(pending!.receiptId);
+      // Read the companion directly so a dangling retirement cannot hide
+      // behind its receipt join after ordinary terminal pruning.
+      expect(retirement()).toBeUndefined();
+    } finally {
+      database.exec("DROP TRIGGER IF EXISTS reject_pending_receipt_completion");
+      completion.resolve({ status: "ok" });
+      await running.catch(() => undefined);
+      owner.stop();
+      editor.stop();
+      reconciler.stop();
+    }
+  });
+});

--- a/src/cron/store/run-receipt-retention.test.ts
+++ b/src/cron/store/run-receipt-retention.test.ts
@@ -12,9 +12,9 @@ import { cronStoreKey } from "./key.js";
 import {
   claimCronRunReceiptInDatabase,
   finishCronRunReceipt,
-  inspectActiveCronRunReceipt,
   prepareCronRunReceiptClaim,
 } from "./run-receipt-store.js";
+import { inspectActiveCronRunReceipt } from "./run-receipt-store.test-support.js";
 
 const { logger, makeStorePath } = setupCronServiceSuite({ prefix: "cron-pending-retention-" });
 

--- a/src/cron/store/run-receipt-store.test-support.ts
+++ b/src/cron/store/run-receipt-store.test-support.ts
@@ -1,0 +1,8 @@
+import { runOpenClawStateWriteTransaction } from "../../state/openclaw-state-db.js";
+import { findActiveCronRunReceiptInDatabase } from "./run-receipt-store.js";
+
+export function inspectActiveCronRunReceipt(params: { storePath: string; jobId: string }) {
+  return runOpenClawStateWriteTransaction(({ db }) =>
+    findActiveCronRunReceiptInDatabase({ database: db, ...params }),
+  );
+}

--- a/src/cron/store/run-receipt-store.ts
+++ b/src/cron/store/run-receipt-store.ts
@@ -347,6 +347,9 @@ function receiptHandle(receipt: CronRunReceipt): CronRunReceiptHandle {
 }
 
 function pruneTerminalReceipts(database: DatabaseSync, storeKey: string, jobId: string): void {
+  const job = currentJob(database, storeKey, jobId);
+  const pendingReceiptId =
+    job?.state.runningAtMs === undefined ? undefined : job.state.runningReceiptId;
   const terminalIds = executeSqliteQuerySync(
     database,
     query(database)
@@ -358,7 +361,13 @@ function pruneTerminalReceipts(database: DatabaseSync, storeKey: string, jobId: 
       .orderBy("finished_at_ms", "desc")
       .orderBy("started_at_ms", "desc")
       .orderBy("receipt_id", "desc"),
-  ).rows.slice(CRON_RUN_RECEIPT_TERMINAL_RETENTION);
+  )
+    .rows.toSorted(
+      (left, right) =>
+        Number(right.receipt_id === pendingReceiptId) -
+        Number(left.receipt_id === pendingReceiptId),
+    )
+    .slice(CRON_RUN_RECEIPT_TERMINAL_RETENTION);
   for (let index = 0; index < terminalIds.length; index += CRON_RUN_RECEIPT_DELETE_BATCH_SIZE) {
     const receiptIds = terminalIds
       .slice(index, index + CRON_RUN_RECEIPT_DELETE_BATCH_SIZE)

--- a/src/cron/store/run-receipt-store.ts
+++ b/src/cron/store/run-receipt-store.ts
@@ -346,8 +346,12 @@ function receiptHandle(receipt: CronRunReceipt): CronRunReceiptHandle {
   };
 }
 
-function pruneTerminalReceipts(database: DatabaseSync, storeKey: string, jobId: string): void {
-  const job = currentJob(database, storeKey, jobId);
+function pruneTerminalReceipts(
+  database: DatabaseSync,
+  storeKey: string,
+  jobId: string,
+  job: CronJob | undefined,
+): void {
   const pendingReceiptId =
     job?.state.runningAtMs === undefined ? undefined : job.state.runningReceiptId;
   const terminalIds = executeSqliteQuerySync(
@@ -493,12 +497,12 @@ export function claimCronRunReceiptInDatabase(params: {
     prepared: params.prepared,
     finishedAtMs: handle.startedAtMs,
   });
-  pruneTerminalReceipts(params.database, handle.storeKey, handle.jobId);
-  validateCurrentJob({
+  const job = validateCurrentJob({
     database: params.database,
     handle,
     resolveAgentId: params.resolveAgentId,
   });
+  pruneTerminalReceipts(params.database, handle.storeKey, handle.jobId, job);
   executeSqliteQuerySync(
     params.database,
     query(params.database)
@@ -744,7 +748,12 @@ export function finishCronRunReceiptInDatabase(params: {
       .where("status", "=", "running")
       .where("owner_pid", "=", params.handle.ownerPid),
   );
-  pruneTerminalReceipts(params.database, params.handle.storeKey, params.handle.jobId);
+  pruneTerminalReceipts(
+    params.database,
+    params.handle.storeKey,
+    params.handle.jobId,
+    currentJob(params.database, params.handle.storeKey, params.handle.jobId),
+  );
   const row = executeSqliteQueryTakeFirstSync(
     params.database,
     query(params.database)

--- a/src/cron/store/run-receipt-store.ts
+++ b/src/cron/store/run-receipt-store.ts
@@ -541,23 +541,6 @@ export function listActiveCronRunReceiptJobIdsInDatabase(
   return new Set(activeRow(database, cronStoreKey(storePath)).map((row) => row.job_id));
 }
 
-export function inspectActiveCronRunReceipt(params: {
-  storePath: string;
-  jobId: string;
-  env?: NodeJS.ProcessEnv;
-}): CronRunReceiptRecoveryCandidate | undefined {
-  return withReceiptWrite(
-    "cron.run-receipt.recovery-inspect",
-    params.env ? { env: params.env } : {},
-    (database) =>
-      findActiveCronRunReceiptInDatabase({
-        database,
-        storePath: params.storePath,
-        jobId: params.jobId,
-      }),
-  );
-}
-
 export function isCronRunReceiptOwnerStale(
   candidate: CronRunReceiptRecoveryCandidate,
   nowMs = Date.now(),

--- a/src/cron/store/run-receipt-trigger-state.ts
+++ b/src/cron/store/run-receipt-trigger-state.ts
@@ -67,7 +67,10 @@ export function retireCronRunTriggerStateInDatabase(params: {
   ).store.jobs[0];
   // Queued runs capture current state at activation. Terminal receipts can
   // still own unreconciled facts, so the durable running marker gates retirement.
-  if (job?.state.runningAtMs !== receipt.started_at_ms) {
+  if (
+    job?.state.runningAtMs !== receipt.started_at_ms ||
+    (job.state.runningReceiptId !== undefined && job.state.runningReceiptId !== receipt.receipt_id)
+  ) {
     return;
   }
   ensureRetirementsTable(database);

--- a/src/cron/types.ts
+++ b/src/cron/types.ts
@@ -344,6 +344,8 @@ export type CronJobState = Omit<
   forcePreservedNextRunAtMs?: number;
   /** Durable pre-admission reservation. Cleared on restart without recording a run. */
   queuedAtMs?: number;
+  /** Exact receipt awaiting scheduler reconciliation, even after execution authority closes. */
+  runningReceiptId?: string;
   /** Number of consecutive schedule computation errors. Auto-disables job after threshold. */
   scheduleErrorCount?: number;
   /** @deprecated Use lastRunStatus. */
@@ -433,7 +435,10 @@ export type CronStoreFile = {
 };
 
 type CronJobStateInput = Partial<
-  Omit<CronJobState, "autoDisabled" | "scheduleActivatedAtMs" | "streamSourceIdentity">
+  Omit<
+    CronJobState,
+    "autoDisabled" | "scheduleActivatedAtMs" | "streamSourceIdentity" | "runningReceiptId"
+  >
 >;
 
 /** Create input accepted by cron APIs before id/timestamps/state are assigned. */


### PR DESCRIPTION
## What Problem This Solves

Cron watchers can recover a different completed run when successive runs share a timestamp, the scheduler's completion write fails, and an owner edit closes the pending run's execution receipt. A retired predecessor can prevent a successful once-only watcher from completing, or the wrong run can overwrite replacement trigger state.

## Why This Change Was Made

Pending scheduler state retains its exact receipt identity until reconciliation. Recovery and late state edits use that identity; stale recovery proposals and concurrent marker updates compare it with the running timestamp. Marker cleanup clears both fields, and receipt pruning protects the pending terminal receipt within the existing 64-receipt limit.

The storage scope follows the receipt-owned retirement design in #145375 for #145336: the existing cron owner keeps the same run associated with its pending reconciliation after execution authority closes. The added private `runningReceiptId` lives in `cron_jobs.state_json`; no SQL table, column, schema version, config option, or public state-patch field is added. Current public job projections omit it. Legacy rows without it keep their existing recovery fallback, and ordinary pruning releases the protected receipt and its retirement row after reconciliation.

The documented downgrade boundary requires completing active runs **and pending scheduler reconciliation** on the current build to preserve edited watcher state. A terminal task or receipt alone does not establish that boundary. Older writers do not maintain the new association or its retention protection.

## User Impact

Recovery applies the pending run's result and its own state-edit protection even when another run has identical timestamps. Owner edits still close execution authority immediately.

## Evidence

Proof targets commit `b28b0d22f81bd294885d79e90dbe7f7cd45999f8`, tree `001b1030d843960ed7fe032fd283712deb0bee20`, on one retained [Blacksmith Testbox runner](https://github.com/openclaw/openclaw/actions/runs/34679692212) using Linux, Node 24.19.0, and pnpm 12.3.4.

- All 217 files and 3,099 tests pass across the three maintained cron CI groups, with zero failed or skipped cases and exact coverage of the original native cron input set. The unchanged receipt read-budget assertion passes.
- All 11 focused cases pass across `service.recovery-identity`, `service/shared-store-runtime`, and `store/run-receipt-retention`. Replaying those tests against base `3f75b33d671017c7ca6cf9ea300279b11e0948c8` produces six assertion failures and five passing controls. Coverage includes colliding and advancing timestamps, either run's retirement, edits after receipt closure, stale proposals, cross-process marker updates, and bounded pruning before and after reconciliation.
- Three native `CronService`/SQLite probes pass for retired-pending, retired-predecessor, and unedited runs. Each fails on the base revision at the final recovered enabled/state assertion. Admission, updates, receipts, tasks, history, and restart recovery use their real owners; the wall clock, trigger evaluator, and payload are synthetic.
- All seven cross-version phases pass with v2026.9.4 (`3a9d69db306cd7f081e06254cb89c4bcc14a7107`) and separate frozen dependency installs: released legacy pending state, candidate upgrade recovery, fresh candidate pending state, released read-only preflight, candidate reconciliation, released writable reopen, and candidate reopen. Shared-state schema-17 preflights report `exact`; reconciliation runs no payload; job, task, receipt, and retirement rows remain byte-equal across both reopen phases. Released writable access begins only after the candidate clears the pending marker and ID. This proves the documented cron/shared-state boundary; agent databases, live providers, the full updater, and writable downgrade while reconciliation is pending are outside this proof.
- All 29 selected changed-path gates pass, including full core and core-test types, dead exports, formatting, lint, ratchets, conflict/diff hygiene and storage guards. The dependency deadcode scan passes. The existing public projection test passes. Independent engineering review and autoreview are clean; [ClawSweeper reports Platinum with no findings](https://github.com/openclaw/openclaw/pull/145734#issuecomment-5644348231) for this commit.
- The earlier single-worker monolithic cron run exhausted its unchanged 4 GiB worker limit. An untouched base revision reproduces the same native worker-memory error with the original common file order. The maintained three-group run above preserves the full selected file set, worker limits and assertions; no retry, timeout increase or test exclusion was added.
- [CI attempt 2](https://github.com/openclaw/openclaw/actions/runs/34681280777/attempts/2) passes after one authorized rerun of the failed jobs on the unchanged tested merge. The original seven-file CLI group passes all 275 tests; the rejected-update case passes in 1,236 ms with the expected error and unchanged state-preservation assertions. The original 60-second timeout remains unattributed: the rerun uses Node 24.20.0 on a four-CPU GitHub runner, versus Node 24.19.0 on a two-CPU Blacksmith runner. Separate exact-main and tested-merge replays on Node 24.19.0 also pass all 275 tests. Assertions, timeouts and the two-worker CLI limit are unchanged; no CI exception is used.

