### PR TITLE
fix(http): preserve Bun rejection half-close

### DIFF
--- a/src/infra/http-request-lifecycle.ts
+++ b/src/infra/http-request-lifecycle.ts
@@ -172,10 +172,11 @@ export function selectHttpRequestRejection(req: IncomingMessage): Rejection {
   req.on("readable", pauseCompletedRequest);
   const timer = setTimeout(rejection.destroy, REJECTION_CLOSE_TIMEOUT_MS);
   timer.unref();
+  const detachRequestError = () => req.off("error", rejection.destroy);
+  req.once("close", detachRequestError);
   const onClose = () => {
     rejection.phase = "closed";
     clearTimeout(timer);
-    req.off("error", rejection.destroy);
     req.off("readable", pauseCompletedRequest);
     socket.off("error", rejection.destroy);
     completion.resolve();
@@ -209,7 +210,9 @@ export async function sendHttpRequestRejection(
   }
   const socket = req.socket;
   const onResponseClose = () => {
-    rejection.destroy();
+    if (!res.writableFinished) {
+      rejection.destroy();
+    }
   };
   res.on("error", rejection.destroy);
   res.once("close", onResponseClose);


### PR DESCRIPTION
## What Problem This Solves

Bun-hosted HTTP request rejection produced client `ECONNRESET`s, released webhook and Gateway admission before the hostile-peer deadline, destroyed ordered HEAD transports too early, and left deferred request abort errors unhandled. The rejection response itself was correct, but its intended half-close was immediately converted into a full destroy.

## Why This Change Was Made

Bun must use `ServerResponse.end()` to flush its native HTTP framing. Bun then emits the response's normal `close` after `finish`, and the rejection lifecycle treated every response close as a write failure. It now destroys only when the response closes before `writableFinished`; normal completion keeps the socket half-closed until peer FIN or the existing one-second deadline.

The request error listener also remains attached until the request's own close event. That covers Bun's deferred `ECONNRESET` notification after socket close without retaining the request beyond its lifecycle.

## User Impact

Bun-hosted webhook and guarded HTTP rejections deliver their exact status/body without resetting clients, dispatching pipelined work, releasing admission early, or leaking unhandled abort errors. Node behavior is unchanged.

## Evidence

- Before the fix under custom Bun: 8/32 lifecycle cases failed and Vitest reported 5 unhandled `ECONNRESET` errors.
- After the fix: direct custom-Bun suite passed 32/32 three consecutive times with no unhandled errors.
- Node suite passed 32/32.
- `node scripts/check-changed.mjs`: passed.
- Independent P0-P2 autoreview: scoped clean at 0.90 confidence.
