### PR TITLE
fix(gateway): speed up active chat recovery near history limits

### DIFF
--- a/src/gateway/chat-abort.history-budget.test.ts
+++ b/src/gateway/chat-abort.history-budget.test.ts
@@ -1,0 +1,45 @@
+import { expect, it, vi } from "vitest";
+import { boundInFlightRunSnapshotForChatHistory } from "./chat-abort.js";
+import { updateChatRunProgressSnapshot } from "./server-chat-progress-snapshot.js";
+
+it.each([2, 50])("keeps the newest %i progress events with bounded serialization", (retained) => {
+  let progress: ReturnType<typeof updateChatRunProgressSnapshot>;
+  for (let index = 0; index < 50; index++) {
+    progress = updateChatRunProgressSnapshot(progress, {
+      runId: "run-budget",
+      seq: index + 1,
+      stream: "tool",
+      ts: 1_000 + index,
+      data: {
+        phase: "result",
+        name: "read",
+        toolCallId: `tool-${index}`,
+        result: '漢字\n"\\'.repeat(200),
+      },
+    });
+  }
+  const events = progress?.events ?? [];
+  expect(events).toHaveLength(50);
+  const snapshot = { runId: "run-budget", text: "x".repeat(200_000), startedAt: 1_000, events };
+  const original = JSON.stringify(snapshot);
+  const expected = { ...snapshot, text: "", events: events.slice(-retained) };
+  const maxBytes = 2 + Buffer.byteLength(JSON.stringify(expected));
+  const inputBytes = 2 + Buffer.byteLength(original);
+  const stringify = JSON.stringify;
+  let serializedBytes = 0;
+  const serialization = vi.spyOn(JSON, "stringify").mockImplementation((...args) => {
+    const result = stringify(...args);
+    serializedBytes += typeof result === "string" ? Buffer.byteLength(result) : 0;
+    return result;
+  });
+  let result;
+  try {
+    result = boundInFlightRunSnapshotForChatHistory({ snapshot, messages: [], maxBytes });
+  } finally {
+    serialization.mockRestore();
+  }
+  expect(result).toEqual(expected);
+  expect(2 + Buffer.byteLength(JSON.stringify(result))).toBe(maxBytes);
+  expect(JSON.stringify(snapshot)).toBe(original);
+  expect(serializedBytes).toBeLessThan(inputBytes * 3);
+});

--- a/src/gateway/chat-abort.ts
+++ b/src/gateway/chat-abort.ts
@@ -438,14 +438,20 @@ export function boundInFlightRunSnapshotForChatHistory(params: {
   }
 
   if (params.snapshot.events) {
-    const events = [...params.snapshot.events];
-    while (events.length > 0) {
-      const candidate = { ...bounded, events };
+    const events = params.snapshot.events;
+    let start = 0;
+    let end = events.length;
+    // Try all progress first, then search suffixes instead of serializing each eviction.
+    let middle = 0;
+    while (start < end) {
+      const candidate = { ...bounded, events: events.slice(middle) };
       if (messagesBytes + jsonUtf8Bytes(candidate) <= params.maxBytes) {
         bounded = candidate;
-        break;
+        end = middle;
+      } else {
+        start = middle + 1;
       }
-      events.shift();
+      middle = Math.floor((start + end) / 2);
     }
   }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where reopening an active chat performs excessive synchronous serialization when its saved progress events exceed the history response's remaining byte budget.

## Why This Change Was Made

Find the longest fitting suffix of recent progress events by checking the full progress list first, then using binary search instead of dropping one event and serializing the remaining envelope repeatedly. Each probe still measures the actual JSON envelope with the existing byte-count owner. The producer already bounds progress to 50 events and 128 KiB.

The response retains the same events, timing/progress/plan/text priority, explicit empty projections, and input immutability. No response limits, configuration, persistence, or authorization change.

## User Impact

Active-chat recovery performs less synchronous work near its byte limit while preserving the same visible response.

## Evidence

- A regression built through the real progress producer failed before the fix: it serialized 3,761,762 bytes to return the newest two events. It now passes a bounded-work assertion while preserving the exact UTF-8 byte boundary, escaped and multibyte content, and unchanged input.
- All 83 focused abort/progress tests pass. Four existing `chat.history`/`chat.startup` handler cases pass on the final head, covering plan and tool-event replay.
- 2,000 varied comparisons against the original owner return identical results across budgets, event counts, text, timing, plan, and session-abortable state.
- Synthetic Node 26.8.2 benchmark with 50 producer-owned events (106,731 bytes) and 140,030 bytes of history: with 5,000 bytes left for recovery, median call time fell from 2.48 ms to 0.31 ms and serialization volume from 2,989,524 to 477,159 bytes. Both an already-fitting response and a full progress list that fits after dropping oversized text retain their original serialization volume. The latter case also caught a performance regression in the first draft before publication. These are isolated measurements, not production latency or OOM attribution.
- Complete final changed-file checks pass on `90a3d838f295321fe08a5013539f3e6a4146ed77`; fresh independent P0–P2 review is clean.
- [Exact-head CI run 34679702200](https://github.com/openclaw/openclaw/actions/runs/34679702200) passed, including the required `openclaw/ci-gate`. ClawSweeper finalized the same head with no actionable findings.
