### PR TITLE
perf(memory): use native FTS rank ordering

### DIFF
--- a/extensions/memory-core/src/memory/manager-search.test.ts
+++ b/extensions/memory-core/src/memory/manager-search.test.ts
@@ -932,6 +932,73 @@ describe("searchPathKeyword", () => {
   });
 });
 
+describe("searchKeyword ranked limits", () => {
+  it.each(["unicode61", "trigram"] as const)(
+    "stops examining scoped candidates after filling the %s result window",
+    async (ftsTokenizer) => {
+      const { db } = createMemorySearchDb({ ftsTokenizer });
+      try {
+        for (let index = 0; index < 64; index++) {
+          insertKeywordFixture(db, {
+            id: `chunk-${index}`,
+            path: `memory/${index}.md`,
+            text: "common keyword",
+            source: index % 2 === 0 ? "memory" : "sessions",
+          });
+        }
+        let examined = 0;
+        db.function("observe_keyword_candidate", () => {
+          examined++;
+          return 1;
+        });
+        const results = await searchKeywordFixture(db, "common", {
+          ftsTokenizer,
+          limit: 3,
+          sourceFilter: {
+            sql: " AND source IN (?) AND observe_keyword_candidate() = 1",
+            params: ["sessions"],
+          },
+        });
+        expect(results.map((row) => row.id)).toEqual(["chunk-1", "chunk-3", "chunk-5"]);
+        expect(examined).toBeLessThanOrEqual(6);
+      } finally {
+        db.close();
+      }
+    },
+  );
+
+  it("preserves default BM25 scores without changing a configured rank mapping", async () => {
+    const { db } = createMemorySearchDb();
+    try {
+      insertKeywordFixture(db, {
+        id: "weak",
+        path: "memory/weak.md",
+        text: "common " + "unrelated ".repeat(20),
+      });
+      insertKeywordFixture(db, {
+        id: "strong",
+        path: "memory/strong.md",
+        text: "common common common",
+      });
+      const expected = await searchKeywordFixture(db, "common");
+      expect(expected.map((row) => row.id)).toEqual(["strong", "weak"]);
+      db.prepare(
+        "INSERT INTO memory_index_chunks_fts(memory_index_chunks_fts, rank) VALUES ('rank', 'bm25(0.0)')",
+      ).run();
+
+      await expect(searchKeywordFixture(db, "common")).resolves.toEqual(expected);
+      expect(
+        db
+          .prepare("SELECT rank FROM memory_index_chunks_fts WHERE memory_index_chunks_fts MATCH ?")
+          .all("common")
+          .map((row) => row.rank),
+      ).toEqual([-0, -0]);
+    } finally {
+      db.close();
+    }
+  });
+});
+
 describe("searchKeyword cross-model FTS visibility (issue #48300)", () => {
   function supportsFts(): boolean {
     const { db, schema } = createMemorySearchDb();

--- a/extensions/memory-core/src/memory/manager-search.ts
+++ b/extensions/memory-core/src/memory/manager-search.ts
@@ -543,12 +543,17 @@ export async function searchKeyword(params: {
     if (terms.length > 0) {
       registerSearchSqlFunctions(params.db, terms);
     }
+    // Hidden rank lets FTS5 supply score order before LIMIT. Pin its mapping per
+    // query so a persisted custom rank cannot change our default BM25 scores.
+    const matchClause = matchQuery
+      ? `${params.ftsTable} MATCH ? AND ${params.ftsTable}.rank MATCH 'bm25()'`
+      : "1=1";
     return params.db
       .prepare(
         `SELECT id, path, source, start_line, end_line, text,\n` +
-          `       ${matchQuery ? `bm25(${params.ftsTable})` : "0"} AS rank\n` +
+          `       ${matchQuery ? `${params.ftsTable}.rank` : "0"} AS rank\n` +
           `  FROM ${params.ftsTable}\n` +
-          ` WHERE ${matchQuery ? `${params.ftsTable} MATCH ?` : "1=1"}${filter.sql}${liveChunkClause}${params.sourceFilter.sql}\n` +
+          ` WHERE ${matchClause}${filter.sql}${liveChunkClause}${params.sourceFilter.sql}\n` +
           (matchQuery ? ` ORDER BY rank ASC\n` : "") +
           ` LIMIT ?`,
       )


### PR DESCRIPTION
## What Problem This Solves

Memory keyword search orders by a BM25 expression alias. SQLite consequently sorts all matching candidates before applying LIMIT, so common queries slow down as the index grows.

## Why This Change Was Made

Use FTS5's hidden rank column so SQLite can produce score order directly. Pin the rank mapping to `bm25()` for each query, preserving current scores even if an existing database has a customized persistent mapping. Substring fallback and path search retain their existing behavior.

## User Impact

Faster keyword searches over large memory indexes, with the same results, source filtering, scores, and stored data.

## Evidence

- 79 memory search and orchestration tests passed. Regressions fail on the original query because it examines 32 matching candidates for a three-result request; candidate work is bounded for both unicode61 and trigram. Coverage preserves source filtering, ties, and customized rank configuration.
- Paired actual search entry point, canonical memory schema, Node 26.8.2 / SQLite 3.53.4, ten alternating measured rounds with full result equality: 30,000 rows, median 66.99 → 42.31 ms; 100,000 rows, 228.64 → 135.13 ms. These synthetic common-term workloads show 37–41% lower latency.
- EXPLAIN QUERY PLAN uses the FTS rank-order path and removes the temporary sort. SQLite documents this optimization for limited result sets: https://www.sqlite.org/fts5.html#sorting_by_auxiliary_function_results
- Production extension types, scoped type-aware lint, formatting and light guards passed. Independent P0–P2 review validated clean. Broad extension-test types remain for hosted CI.
- No schema, index, version, writer, or persistent rank setting changes; query-local ranking preserves default BM25 and leaves existing configuration intact.
