### PR TITLE
fix(gateway): paired-node Claude continuations retain Gateway context

### DIFF
--- a/src/gateway/node-agent-cli-runtime.test.ts
+++ b/src/gateway/node-agent-cli-runtime.test.ts
@@ -9,11 +9,9 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock("../plugins/runtime/gateway-request-scope.js", () => ({
-  getPluginRuntimeGatewayRequestScope: () => ({
-    context: {
-      getRuntimeConfig: mocks.getRuntimeConfig,
-      nodeRegistry: { get: mocks.get, invoke: mocks.invoke },
-    },
+  getPluginRuntimeGatewayRequestContext: () => ({
+    getRuntimeConfig: mocks.getRuntimeConfig,
+    nodeRegistry: { get: mocks.get, invoke: mocks.invoke },
   }),
 }));
 

--- a/src/gateway/node-agent-cli-runtime.ts
+++ b/src/gateway/node-agent-cli-runtime.ts
@@ -2,7 +2,7 @@
 import { randomUUID } from "node:crypto";
 import type { SystemRunApprovalPlan } from "../infra/exec-approvals.js";
 import { NODE_AGENT_CLI_CLAUDE_RUN_COMMAND } from "../infra/node-commands.js";
-import { getPluginRuntimeGatewayRequestScope } from "../plugins/runtime/gateway-request-scope.js";
+import { getPluginRuntimeGatewayRequestContext } from "../plugins/runtime/gateway-request-scope.js";
 import {
   invokeNodeClaudeSkillRuntime,
   type NodeClaudeSkillRuntime,
@@ -29,7 +29,7 @@ export async function invokeNodeClaudeCliRun(params: {
   signal?: AbortSignal;
   skillRuntime?: NodeClaudeSkillRuntime;
 }): Promise<NodeInvokeResult> {
-  const context = getPluginRuntimeGatewayRequestScope()?.context;
+  const context = getPluginRuntimeGatewayRequestContext();
   if (!context) {
     return {
       ok: false,

--- a/src/gateway/node-claude-skill-runtime.test.ts
+++ b/src/gateway/node-claude-skill-runtime.test.ts
@@ -15,7 +15,7 @@ import { resolveNodeHostGatewayPlatformIdentity } from "../node-host/gateway-pla
 import { decodeClaudeCliNodeRunParams } from "../node-host/invoke-agent-cli-claude-params.js";
 import { runClaudeCliNodeCommand } from "../node-host/invoke-agent-cli-claude.js";
 import type { NodeInvokeRequestPayload } from "../node-host/invoke-types.js";
-import { withPluginRuntimeGatewayRequestScope } from "../plugins/runtime/gateway-request-scope.js";
+import { withPluginRuntimeGatewayContextResolver } from "../plugins/runtime/gateway-request-scope.js";
 import type { OpenClawPluginNodeHostCommandIo } from "../plugins/types.js";
 import { createDeferredCore } from "../shared/deferred.js";
 import {
@@ -272,30 +272,31 @@ async function fixture(
     { pairingIdentity: "node-1", pairingGeneration: "generation-1" },
   );
   let output = "";
+  const run = (stdin: string) =>
+    executeNodeClaudeRun({
+      context,
+      nodePlacement: { nodeId: "node-1", cwd: workspace },
+      executionArgs: ["-p"],
+      stdinPayload: stdin,
+      noOutputTimeoutMs: 5_000,
+      consumeStdout: (text) => {
+        output += text;
+      },
+      consumeStderr: () => {},
+      deps: {
+        invokeNodeClaudeCliRun,
+        registerExecApprovalRequestForHostOrThrow: async () => {
+          throw new Error("unexpected approval");
+        },
+        resolveRegisteredExecApprovalDecision: async () => {
+          throw new Error("unexpected approval");
+        },
+      },
+    });
   const execute = (stdin = "hello") =>
-    withPluginRuntimeGatewayRequestScope(
-      { context: gateway, client: owner.client, isWebchatConnect: () => true },
-      () =>
-        executeNodeClaudeRun({
-          context,
-          nodePlacement: { nodeId: "node-1", cwd: workspace },
-          executionArgs: ["-p"],
-          stdinPayload: stdin,
-          noOutputTimeoutMs: 5_000,
-          consumeStdout: (text) => {
-            output += text;
-          },
-          consumeStderr: () => {},
-          deps: {
-            invokeNodeClaudeCliRun,
-            registerExecApprovalRequestForHostOrThrow: async () => {
-              throw new Error("unexpected approval");
-            },
-            resolveRegisteredExecApprovalDecision: async () => {
-              throw new Error("unexpected approval");
-            },
-          },
-        }),
+    withPluginRuntimeGatewayContextResolver(
+      () => gateway,
+      () => run(stdin),
     );
   return {
     saved,

--- a/src/gateway/node-claude-skill-runtime.ts
+++ b/src/gateway/node-claude-skill-runtime.ts
@@ -25,7 +25,7 @@ import {
 import { NODE_AGENT_CLI_CLAUDE_RUN_COMMAND } from "../infra/node-commands.js";
 import { createNodeDuplexEndpoint } from "../infra/node-duplex-framing.js";
 import { createPluginToolsMcpHandlers } from "../mcp/plugin-tools-handlers.js";
-import { getPluginRuntimeGatewayRequestScope } from "../plugins/runtime/gateway-request-scope.js";
+import { getPluginRuntimeGatewayRequestContext } from "../plugins/runtime/gateway-request-scope.js";
 import { prepareSkillResourceDelivery } from "../skills/runtime/resources.js";
 import { buildMcpToolSchema } from "./mcp-http.schema.js";
 import { isNodeCommandAllowed, resolveNodeCommandAllowlist } from "./node-command-policy.js";
@@ -57,7 +57,7 @@ export async function prepareNodeClaudeSkillRuntime(
   ) {
     return undefined;
   }
-  const gateway = getPluginRuntimeGatewayRequestScope()?.context;
+  const gateway = getPluginRuntimeGatewayRequestContext();
   const target = context.executionTarget;
   const node =
     target.kind === "node" ? gateway?.nodeRegistry.get(target.placement.nodeId) : undefined;

--- a/src/gateway/server-plugin-in-process-dispatch.ts
+++ b/src/gateway/server-plugin-in-process-dispatch.ts
@@ -3,6 +3,7 @@ import type { AgentWaitParams } from "../../packages/gateway-protocol/src/index.
 import type { SubagentCompletionToolHandoffRegistration } from "../agents/subagents/announce/subagent-announce-handoff.js";
 import { getActivePluginRegistry } from "../plugins/runtime.js";
 import {
+  getPluginRuntimeGatewayRequestContext,
   getPluginRuntimeGatewayRequestScope,
   withPluginRuntimeGatewayRequestScope,
 } from "../plugins/runtime/gateway-request-scope.js";
@@ -418,8 +419,7 @@ export function getInProcessGatewayRequestContext(
   if (resolveGatewayContext) {
     return resolveGatewayContext();
   }
-  const scope = getPluginRuntimeGatewayRequestScope();
-  return scope?.resolveGatewayContext ? scope.resolveGatewayContext() : scope?.context;
+  return getPluginRuntimeGatewayRequestContext();
 }
 
 export async function dispatchGatewayMethodInProcess<T>(

--- a/src/plugins/runtime/gateway-request-scope.test.ts
+++ b/src/plugins/runtime/gateway-request-scope.test.ts
@@ -100,6 +100,22 @@ describe("gateway request scope", () => {
     expect(first.getGatewayContextResolver(owner)).toBeUndefined();
   });
 
+  it("resolves detached Gateway context without reviving a retired request context", async () => {
+    await withTestGatewayScope(async (runtimeScope) => {
+      const detachedContext = {} as NonNullable<PluginRuntimeGatewayRequestScope["context"]>;
+      let current: PluginRuntimeGatewayRequestScope["context"] = detachedContext;
+      await runtimeScope.withPluginRuntimeGatewayContextResolver(
+        () => current,
+        async () => {
+          expect(runtimeScope.getPluginRuntimeGatewayRequestContext()).toBe(detachedContext);
+          current = undefined;
+          expect(runtimeScope.getPluginRuntimeGatewayRequestContext()).toBeUndefined();
+        },
+      );
+      expect(runtimeScope.getPluginRuntimeGatewayRequestContext()).toBe(TEST_SCOPE.context);
+    });
+  });
+
   it("attaches plugin id to the active scope", async () => {
     await expectPluginIdScopedGatewayScope("voice-call");
   });

--- a/src/plugins/runtime/gateway-request-scope.ts
+++ b/src/plugins/runtime/gateway-request-scope.ts
@@ -195,6 +195,12 @@ export function withPluginRuntimeGatewayRequestScope<T>(
   return pluginRuntimeGatewayRequestScope.run(scope, run);
 }
 
+/** Resolves the live Gateway context retained by the current request or detached owner. */
+export function getPluginRuntimeGatewayRequestContext(): GatewayRequestContext | undefined {
+  const scope = pluginRuntimeGatewayRequestScope.getStore();
+  return scope?.resolveGatewayContext ? scope.resolveGatewayContext() : scope?.context;
+}
+
 /** Runs detached work with its captured Gateway binding, including an explicitly unbound owner. */
 export function withPluginRuntimeGatewayContextResolver<T>(
   resolveGatewayContext: GatewayContextResolver | undefined,


### PR DESCRIPTION
Closes #145636

## What Problem This Solves

Fixes an issue where users continuing a native Claude CLI session on a paired node could receive a node-runtime availability or capability error after the originating Gateway request had ended, even though the node remained connected.

## Why This Change Was Made

Gateway request scope now owns one canonical live-context lookup: it prefers the durable resolver whenever one exists and otherwise uses the direct request context. Both paired-node runtime paths use that lookup, and the existing in-process dispatcher delegates to it, so detached continuations no longer bypass their retained resolver. A resolver that reports its owner retired still returns no context; there is deliberately no fallback to stale request state.

This does not change configuration, protocol, storage, or non-node execution behavior.

## User Impact

Adopted Claude sessions can continue through a healthy paired node after the request that created them has completed. If the detached owner has actually retired, the operation continues to fail closed rather than reviving expired state.

## Evidence

AI-assisted implementation and validation.

### Exact-head Gateway/node production-boundary proof

Run against `4d47d0faa9fd4c5338c8107099e7c8ecb215a2db`:

```shell
node scripts/run-vitest.mjs src/gateway/pr145741-production-boundary.proof.test.ts --config test/vitest/vitest.gateway.config.ts
```

The temporary proof fixture:

1. Started the actual Gateway server with isolated config/state.
2. Loaded a startup plugin through the normal plugin loader and captured its real `GatewayRequestContext` during an authenticated RPC.
3. Connected a separately signed WebSocket node identity, then completed normal device pairing and node-command approval.
4. Entered `withPluginRuntimeGatewayContextResolver` after the capture RPC had completed, verified direct `scope.context` was absent, and called the production `invokeNodeClaudeCliRun` implementation changed by this PR.
5. Repeated the call with a resolver that returned `undefined` while deliberately leaving stale direct context present, to prove a retired owner cannot fall back and dispatch.

Observed output:

```text
PR145741_PROOF:{"head":"4d47d0faa9fd4c5338c8107099e7c8ecb215a2db","resolverOnly":{"directContext":false,"connectedNode":true,"dispatched":1,"ok":true},"retiredOwner":{"staleDirectContextPresent":true,"resolverReturnedContext":false,"additionalDispatches":0,"result":{"ok":false,"error":{"code":"UNAVAILABLE","message":"Gateway node runtime unavailable"}}}}

Test Files  1 passed (1)
Tests       1 passed (1)
```

This exercises the real Gateway startup/plugin-loading boundary, device and node pairing, `NodeRegistry`, WebSocket transport, node command policy, and this PR's production resolver lookup. The node protocol peer returned a synthetic successful Claude-command payload; this proves dispatch and retirement behavior, not live Claude model inference or a full terminal-close/Web-composer UI walkthrough.

### Supporting checks

- Scope-level probe inside a real resolver-only scope: legacy direct context was `null`; the new lookup returned `{ "marker": "live-context" }`; after owner retirement it returned `null`.
- `node scripts/run-vitest.mjs src/plugins/runtime/gateway-request-scope.test.ts --config test/vitest/vitest.plugins.config.ts`: 1 file, 7 tests passed, including resolver-only and retired-owner coverage.
- The paired-node fixture exercises its existing continuation scenarios under the same resolver-only detached scope used by production.
- `git diff --check`: passed.
- `node scripts/check-changed.mjs -- <changed files>`: conflict-marker gate passed; the local max-lines ratchet did not complete after 9m49s and was interrupted. Full repository checks remain delegated to PR CI.
- Claude CLI `2.1.268` is installed, but live model inference was not required for this lookup repair and was not claimed.
