### PR TITLE
perf(sessions): batch FTS suffix removal in one scan

### DIFF
--- a/src/config/sessions/session-accessor.sqlite-transcript-suffix.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-transcript-suffix.test.ts
@@ -851,20 +851,57 @@ describe("SQLite exact transcript suffix replacement", () => {
     }, events);
   });
 
-  it("rotates generation while updating raw, identity, active, and FTS rows", async () => {
-    await withRewriteFixture(({ db, snapshot, scope }) => {
-      const before = snapshot();
-      replaceTranscriptSuffixForTest(scope, rewriteEvents, rewriteEvents.slice(0, 2));
+  it.each([1, 405])(
+    "removes %i searchable suffix rows in one scan while preserving other sessions",
+    async (count) => {
+      const specialIds = ["suffix-\0-end", "suffix-\\u0000-end", "suffix-🦀", 'suffix-"quote'];
+      const ids = Array.from(
+        { length: count },
+        (_, index) => specialIds[index] ?? `suffix-${index}`,
+      );
+      const events = [
+        ...rewriteEvents.slice(0, 2),
+        ...ids.map((id, index) => ({
+          type: "message",
+          id,
+          parentId: index === 0 ? "user" : ids[index - 1],
+          message: { role: "assistant", content: `removed ${index}` },
+        })),
+      ];
+      await withRewriteFixture(({ db, snapshot, scope }) => {
+        const sibling = { ...scope, sessionId: "sibling", sessionKey: "agent:main:sibling" };
+        runOpenClawAgentWriteTransaction((database) => {
+          appendTranscriptEventsInTransaction(database, sibling, events);
+        }, scope);
+        const readSiblingSearch = () =>
+          db
+            .prepare(
+              "SELECT * FROM session_transcript_fts WHERE session_id = ? ORDER BY message_id",
+            )
+            .all(sibling.sessionId);
+        const siblingSearch = readSiblingSearch();
+        const before = snapshot();
+        const work = trackSqliteStatementExecutions(db, ["ftsDeletes"], (sql) =>
+          /^delete from "session_transcript_fts"/i.test(sql) ? "ftsDeletes" : null,
+        );
+        try {
+          replaceTranscriptSuffixForTest(scope, events, events.slice(0, 2), 2);
+        } finally {
+          work.restore();
+        }
 
-      const after = snapshot();
-      expect(after.generation).not.toBe(before.generation);
-      expect(after.raw).toHaveLength(2);
-      expect(after.identities).toHaveLength(2);
-      expect(after.active).toHaveLength(2);
-      expect(after.search).toMatchObject([{ message_id: "user", text: "question" }]);
-      expect(sessionTranscriptIndexNeedsReconcile(db, scope.sessionId)).toBe(false);
-    });
-  });
+        const after = snapshot();
+        expect(after.generation).not.toBe(before.generation);
+        expect(after.raw).toHaveLength(2);
+        expect(after.identities).toHaveLength(2);
+        expect(after.active).toHaveLength(2);
+        expect(after.search).toMatchObject([{ message_id: "user", text: "question" }]);
+        expect(readSiblingSearch()).toEqual(siblingSearch);
+        expect(work.counts.ftsDeletes).toBe(1);
+        expect(sessionTranscriptIndexNeedsReconcile(db, scope.sessionId)).toBe(false);
+      }, events);
+    },
+  );
 
   it("rotates generation when an already-dirty projection needs reconciliation", async () => {
     await withRewriteFixture(async ({ db, snapshot, scope }) => {

--- a/src/config/sessions/session-transcript-index.ts
+++ b/src/config/sessions/session-transcript-index.ts
@@ -13,6 +13,7 @@ import {
   executeSqliteQueryTakeFirstSync,
   getNodeSqliteKysely,
   prepareSqliteQuerySync,
+  sqliteStringSet,
 } from "../../infra/kysely-sync.js";
 import type { DB as OpenClawAgentKyselyDatabase } from "../../state/openclaw-agent-db.generated.js";
 import {
@@ -465,13 +466,18 @@ export function replaceSessionTranscriptIndexSuffixInTransaction(
             .flatMap((row) => (row.ftsEntry ? [row.ftsEntry.messageId] : [])),
         ),
       ];
-  for (let offset = 0; offset < removedMessageIds.length; offset += 400) {
+  if (removedMessageIds.length > 0) {
+    // FTS metadata is unindexed; bind larger sets once instead of rescanning every 400 IDs.
     executeSqliteQuerySync(
       db,
       kysely
         .deleteFrom("session_transcript_fts")
         .where("session_id", "=", sessionId)
-        .where("message_id", "in", removedMessageIds.slice(offset, offset + 400)),
+        .where(
+          "message_id",
+          "in",
+          removedMessageIds.length <= 400 ? removedMessageIds : sqliteStringSet(removedMessageIds),
+        ),
     );
   }
   executeSqliteQuerySync(


### PR DESCRIPTION
## What Problem This Solves

Replacing a long transcript suffix deletes FTS rows in 400-ID chunks. FTS metadata is unindexed, so each chunk scans the entire agent search table, including unrelated sessions.

## Why This Change Was Made

Bind larger ID sets once through the existing SQLite string-set helper. Small sets retain their direct bound-array path. The existing suffix owner still performs the same session-scoped deletion and projection update in the same transaction.

## User Impact

Faster transcript rewrites when a substantial searchable suffix is removed from an agent with a large search index. Stored formats, retention and transaction boundaries are unchanged.

## Evidence

- All 40 suffix/search owner tests passed. The expanded existing regression fails on the original two-scan behavior at 405 removed rows and verifies generation rotation, raw/identity/active/FTS consistency, sibling sessions with identical IDs, embedded NULs, literal escapes, Unicode, and quotes.
- Paired actual projection owner on the same rollback-restored canonical synthetic schema, seven alternating rounds, Node 26.8.2 / SQLite 3.53.4: 4,000 removed rows with 30,000 unrelated rows, median 92.16 → 18.15 ms; with 100,000 unrelated rows, 238.76 → 32.83 ms. Deleted and retained rows match in every round. These measure the projection update, not complete transcript rewrite latency.
- Core production types, scoped lint and 25 light repository guards passed. Independent P0–P2 review validated clean. Broad test types remain for exact-head hosted CI.
- No schema, index, version, configuration, retention, or transaction-boundary changes.
- The first hosted run timed out after 120 seconds in the unrelated `run-vitest-profile` case "rejects main --pool before evaluating config" (job 103517159157). Its test, owner and configuration are unchanged. The focused candidate passed on Windows in 680 ms and the unchanged baseline passed in WSL in 1,071 ms. Only that failed job was rerun once; exact-head run 34680088058 then completed successfully.


