### PR TITLE
fix(google-meet): stop artifact fetches from looping on repeated page tokens

### DIFF
--- a/extensions/google-meet/index.test.ts
+++ b/extensions/google-meet/index.test.ts
@@ -1825,6 +1825,95 @@ describe("google-meet plugin", () => {
     );
   });
 
+  it("collects every page of Meet artifact metadata", async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = requestUrl(input);
+      if (url.pathname === "/v2/conferenceRecords/rec-1") {
+        return jsonResponse({ name: "conferenceRecords/rec-1" });
+      }
+      if (url.pathname === "/v2/conferenceRecords/rec-1/participants") {
+        return jsonResponse(
+          url.searchParams.get("pageToken") === "page-2"
+            ? { participants: [{ name: "conferenceRecords/rec-1/participants/p2" }] }
+            : {
+                participants: [{ name: "conferenceRecords/rec-1/participants/p1" }],
+                nextPageToken: "page-2",
+              },
+        );
+      }
+      if (url.pathname.endsWith("/recordings")) {
+        return jsonResponse({ recordings: [] });
+      }
+      if (url.pathname.endsWith("/transcripts")) {
+        return jsonResponse({ transcripts: [] });
+      }
+      if (url.pathname.endsWith("/smartNotes")) {
+        return jsonResponse({ smartNotes: [] });
+      }
+      return new Response(`unexpected ${url.pathname}`, { status: 404 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await fetchGoogleMeetArtifacts({
+      accessToken: "token",
+      conferenceRecord: "rec-1",
+      includeTranscriptEntries: false,
+    });
+
+    expect(result.artifacts[0]?.participants.map((participant) => participant.name)).toEqual([
+      "conferenceRecords/rec-1/participants/p1",
+      "conferenceRecords/rec-1/participants/p2",
+    ]);
+    expect(
+      fetchMock.mock.calls
+        .map(([input]) => requestUrl(input))
+        .filter((url) => url.pathname.endsWith("/participants"))
+        .map((url) => url.searchParams.get("pageToken")),
+    ).toEqual([null, "page-2"]);
+  });
+
+  it("rejects a repeated Meet API nextPageToken", async () => {
+    let participantPageRequests = 0;
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = requestUrl(input);
+      if (url.pathname === "/v2/conferenceRecords/rec-1") {
+        return jsonResponse({ name: "conferenceRecords/rec-1" });
+      }
+      if (url.pathname === "/v2/conferenceRecords/rec-1/participants") {
+        participantPageRequests += 1;
+        if (participantPageRequests > 2) {
+          throw new Error("test guard: pagination did not stop");
+        }
+        return jsonResponse({
+          participants: [
+            { name: `conferenceRecords/rec-1/participants/p${participantPageRequests}` },
+          ],
+          nextPageToken: "stuck-page",
+        });
+      }
+      if (url.pathname.endsWith("/recordings")) {
+        return jsonResponse({ recordings: [] });
+      }
+      if (url.pathname.endsWith("/transcripts")) {
+        return jsonResponse({ transcripts: [] });
+      }
+      if (url.pathname.endsWith("/smartNotes")) {
+        return jsonResponse({ smartNotes: [] });
+      }
+      return new Response(`unexpected ${url.pathname}`, { status: 404 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      fetchGoogleMeetArtifacts({
+        accessToken: "token",
+        conferenceRecord: "rec-1",
+        includeTranscriptEntries: false,
+      }),
+    ).rejects.toThrow("Google Meet conferenceRecords.participants.list repeated nextPageToken");
+    expect(participantPageRequests).toBe(2);
+  });
+
   it("keeps all conference records available when requested", async () => {
     const fetchMock = stubMeetArtifactsApi();
 

--- a/extensions/google-meet/src/meet-api.ts
+++ b/extensions/google-meet/src/meet-api.ts
@@ -321,6 +321,8 @@ async function listGoogleMeetCollection<T extends { name?: string }>(params: {
   errorPrefix: string;
 }): Promise<T[]> {
   const items: T[] = [];
+  // Reusing an opaque cursor cannot make progress, so fail instead of polling forever.
+  const seenPageTokens = new Set<string>();
   let pageToken: string | undefined;
   do {
     const payload = await fetchGoogleMeetJson<Record<string, unknown>>({
@@ -341,7 +343,15 @@ async function listGoogleMeetCollection<T extends { name?: string }>(params: {
     if (typeof params.maxItems === "number" && items.length >= params.maxItems) {
       break;
     }
-    pageToken = typeof payload.nextPageToken === "string" ? payload.nextPageToken : undefined;
+    const nextPageToken =
+      typeof payload.nextPageToken === "string" ? payload.nextPageToken : undefined;
+    if (nextPageToken && seenPageTokens.has(nextPageToken)) {
+      throw new Error(`${params.errorPrefix} repeated nextPageToken`);
+    }
+    if (nextPageToken) {
+      seenPageTokens.add(nextPageToken);
+    }
+    pageToken = nextPageToken;
   } while (pageToken);
   return items;
 }


### PR DESCRIPTION
<!--
Optional linked context:
Add a visible `Closes #<issue-number>` or `Related: #<issue-number>` line
below this comment.

Required PR title:
type: user-facing description
Use a parenthesized scope only when it adds clarity:
fix(auth): login redirect loops when session cookie is expired

Types: feat, fix, improve, refactor, docs, chore.
For fixes, describe the user-visible symptom and trigger:
fix: task list fails to load when user has no environments
Avoid implementation details such as:
fix: add null check to task query
-->

No linked issue: live GitHub searches for Google Meet pagination, `nextPageToken`, and repeated-token fixes found no matching open issue or pull request.

AI-assisted: Codex traced the Google Meet API owner/call paths, implemented the bounded repair, and ran the evidence below; the contributor reviewed the resulting diff.

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where users fetching Google Meet artifacts or attendance could have the request loop forever when a Meet list response repeated its pagination token.

## Why This Change Was Made

The Google Meet plugin now tracks opaque page tokens within each list operation and fails with a contextual error when a token repeats. Normal multi-page collection remains unchanged, and the fix stays inside the Google Meet API owner without adding config or API surface. This matches Google's list contract: `nextPageToken` is returned for a subsequent list call and is unset after the final page.

Google API contract: https://developers.google.com/workspace/meet/api/reference/rest/v2/conferenceRecords.participants/list

## User Impact

Google Meet artifact, attendance, and export requests now terminate with an actionable API error instead of hanging indefinitely if Google returns a stuck pagination cursor. Healthy multi-page responses still return every item.

## Evidence

- Red-before: `node scripts/run-vitest.mjs extensions/google-meet/index.test.ts -t "rejects a repeated Meet API nextPageToken"` failed because the production paginator made a third request and reached `test guard: pagination did not stop`.
- Green-after: `node scripts/run-vitest.mjs extensions/google-meet/index.test.ts -t "(collects every page of Meet artifact metadata|rejects a repeated Meet API nextPageToken)"` passed both focused tests (`2 passed`, `169 skipped`).
- Supplemental production-entry coverage: both tests call exported `fetchGoogleMeetArtifacts` and traverse conference-record resolution plus pagination. The SSRF transport and HTTP responses are mocked, so this is not live Google API proof. The tests assert normal two-page aggregation and two-request termination for a repeated token.
- Live API proof was not run because no Google Meet credentials or disposable conference record were available in this checkout; PR CI covers the repository integration gates.
- `./node_modules/.bin/oxfmt --check extensions/google-meet/src/meet-api.ts extensions/google-meet/index.test.ts`
- `./node_modules/.bin/oxlint extensions/google-meet/src/meet-api.ts extensions/google-meet/index.test.ts`
- `git diff --check`
- Real guarded-transport before/after proof: an isolated Docker network mapped `meet.googleapis.com` to a synthetic TLS peer trusted only for the proof. `fetchGoogleMeetArtifacts` still traversed the production `fetchWithSsrFGuard`, pinned dispatcher, HTTPS, JSON reader, conference-record resolution, and participant paginator; neither fetch nor the SSRF transport was mocked. A healthy two-page control resolved two participants with exactly two participant requests on both revisions. With `nextPageToken: "stuck-page"` on both pages, an exact-parent overlay of `cfa3a6257553d97650d41691feeecff7c89feec1` issued a third identical participant request and reached the peer sentinel. Exact head `466d1f467ec1f0a1c9f6b5e43dcbaaa0c150da98` stopped after two requests with `Google Meet conferenceRecords.participants.list repeated nextPageToken`. The temporary proof test, certificate, source overlay, container, and Docker network were removed; `git status`, `git diff --check`, and the committed source diff were clean afterward. This proves real local transport behavior against a controlled peer, not a live Google account round-trip.