### PR TITLE
fix(buzz): replies from mid-thread messages preserve ancestry

### DIFF
--- a/extensions/buzz/src/channel.test.ts
+++ b/extensions/buzz/src/channel.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { buzzSetupPlugin } from "../setup-plugin-api.js";
 import { buzzPlugin } from "./channel.js";
+import { buildBuzzMessageTags } from "./message-event.js";
 
 describe("Buzz channel guidance", () => {
   it.each([
@@ -49,6 +50,75 @@ describe("Buzz channel guidance", () => {
       }) ?? original;
     expect(transport).toEqual(expected);
   });
+
+  it("inherits the room thread root for an implicit mid-thread message-tool reply", () => {
+    const threading = buzzPlugin.threading;
+    if (!threading?.buildToolContext || !threading.resolveAutoThreadId) {
+      throw new Error("expected Buzz threading adapter");
+    }
+    const roomId = "64f4debf-e7af-438c-8dcd-d6fbbe77405d";
+    const otherRoomId = "48f551a5-7598-4d6e-a40c-f2219e0aa397";
+    const rootId = "thread-root";
+    const messageId = "child-message";
+    const toolContext = threading.buildToolContext({
+      cfg: {},
+      accountId: "default",
+      context: {
+        Channel: "buzz",
+        To: `buzz:${roomId}`,
+        ChatType: "group",
+        CurrentMessageId: messageId,
+        MessageThreadId: rootId,
+        ReplyToMode: "all",
+      },
+    });
+
+    expect(toolContext).toMatchObject({
+      currentChannelId: `buzz:${roomId}`,
+      currentMessagingTarget: `buzz:${roomId}`,
+      currentMessageId: messageId,
+      currentThreadTs: rootId,
+      replyToMode: "all",
+    });
+    expect(
+      threading.resolveAutoThreadId({
+        cfg: {},
+        accountId: "default",
+        to: roomId.toUpperCase(),
+        toolContext,
+        replyToId: messageId,
+      }),
+    ).toBe(rootId);
+    expect(
+      threading.resolveAutoThreadId({
+        cfg: {},
+        accountId: "default",
+        to: `buzz:${otherRoomId}`,
+        toolContext,
+        replyToId: messageId,
+      }),
+    ).toBeUndefined();
+
+    const transport = threading.resolveReplyTransport?.({
+      cfg: {},
+      accountId: "default",
+      threadId: rootId,
+      replyToId: messageId,
+      replyToIsExplicit: false,
+    });
+    expect(transport).toEqual({ threadId: rootId, replyToId: rootId });
+    expect(
+      buildBuzzMessageTags({
+        channelId: roomId,
+        threadId: String(transport?.threadId),
+        replyToId: transport?.replyToId ?? undefined,
+      }),
+    ).toEqual([
+      ["h", roomId],
+      ["e", rootId, "", "reply"],
+    ]);
+  });
+
   it("advertises directory room targets and native mention syntax", () => {
     const hints = buzzPlugin.agentPrompt?.messageToolHints?.({} as never) ?? [];
 

--- a/extensions/buzz/src/channel.ts
+++ b/extensions/buzz/src/channel.ts
@@ -1,4 +1,5 @@
 import { describeAccountSnapshot } from "openclaw/plugin-sdk/account-helpers";
+import type { ChannelThreadingToolContext } from "openclaw/plugin-sdk/channel-contract";
 import {
   buildChannelOutboundSessionRoute,
   buildThreadAwareOutboundSessionRoute,
@@ -53,6 +54,21 @@ type BuzzProbeResult = {
   rooms: Array<{ id: string; name: string }>;
 };
 
+function matchesBuzzToolContextRoom(
+  target: string,
+  toolContext?: ChannelThreadingToolContext,
+): boolean {
+  const currentTarget = toolContext?.currentMessagingTarget ?? toolContext?.currentChannelId;
+  if (!currentTarget) {
+    return false;
+  }
+  try {
+    return parseBuzzTarget(target) === parseBuzzTarget(currentTarget);
+  } catch {
+    return false;
+  }
+}
+
 export const buzzPlugin = createChatChannelPlugin<ResolvedBuzzAccount, BuzzProbeResult>({
   base: {
     id: "buzz",
@@ -71,6 +87,22 @@ export const buzzPlugin = createChatChannelPlugin<ResolvedBuzzAccount, BuzzProbe
       threads: true,
     },
     threading: {
+      matchesToolContextTarget: ({ target, toolContext }) =>
+        matchesBuzzToolContextRoom(target, toolContext),
+      buildToolContext: ({ context, hasRepliedRef }) => {
+        const currentTarget = context.To?.trim() || undefined;
+        return {
+          currentChannelId: currentTarget,
+          currentMessagingTarget: currentTarget,
+          currentMessageId: context.CurrentMessageId,
+          currentThreadTs:
+            context.MessageThreadId != null ? String(context.MessageThreadId) : undefined,
+          replyToMode: context.ReplyToMode ?? "all",
+          hasRepliedRef,
+        };
+      },
+      resolveAutoThreadId: ({ to, toolContext }) =>
+        matchesBuzzToolContextRoom(to, toolContext) ? toolContext?.currentThreadTs : undefined,
       resolveReplyTransport: ({ replyDelivery, threadId, replyToId, replyToIsExplicit }) => {
         if (replyDelivery?.replyToMode === "off") {
           return { threadId: null, replyToId: null };


### PR DESCRIPTION
Closes #145619

## What Problem This Solves

Fixes an issue where Buzz users replying from a mid-thread message with the message tool would have the relay reject the outgoing message because it named the child reply without the thread root.

## Why This Change Was Made

Buzz now carries the admitted inbound thread root into the shared message-tool context and inherits it only when the outbound target resolves to the same canonical room UUID. The existing transport normalization remains responsible for moving implicit replies to the root, while explicit child replies and shared `topLevel`/thread opt-outs keep their existing behavior. This is an AI-assisted change.

## User Impact

Message-tool sends triggered inside an existing Buzz thread retain valid NIP-10 ancestry and can be accepted by the relay. Sends to another room do not inherit the current room's thread.

## Evidence

- Before-fix negative control: `node scripts/run-vitest.mjs extensions/buzz/src/channel.test.ts` failed the new production-adapter regression with `expected Buzz threading adapter` (1 failed, 8 passed).
- After fix: the same focused command passed all 9 tests.
- Full plugin suite: `node --import ./scripts/tsx.mjs scripts/test-extension.mts buzz` passed 34 files / 333 tests.
- `node scripts/check-changed.mjs --base upstream/main -- extensions/buzz/src/channel.ts extensions/buzz/src/channel.test.ts` passed formatting, dependency, plugin-boundary, and repository guard lanes; the final extensions typecheck was terminated by the local environment with exit 137 after 368 seconds, so CI is the remaining typecheck proof.
- `git diff --check upstream/main..HEAD` passed.
- Not tested live against a Buzz relay because no relay credentials were available; the regression exercises the production Buzz threading adapter and NIP-10 tag builder before network delivery.

- Environment recheck (2026-09-16): no `BUZZ_*`/`NOSTR_*` credential variables, local Buzz relay image, or repository relay E2E fixture are available. The repository tests replace `nostr-tools` relay operations and therefore cannot prove shared dispatch plus relay acceptance. Starting a local Gateway alone would still stop before the required authenticated Buzz publication boundary, so no live-delivery claim is added.
