### PR TITLE
fix(sessions): reduce repeated store checks when listing sessions

### DIFF
--- a/src/config/sessions/session-accessor.readonly.test.ts
+++ b/src/config/sessions/session-accessor.readonly.test.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import path from "node:path";
 import { DatabaseSync, type StatementSync } from "node:sqlite";
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -38,6 +39,7 @@ import {
   upsertSessionEntryCore,
 } from "./session-accessor.js";
 import { ensureTranscriptSessionRoot } from "./session-accessor.sqlite-transcript-state.js";
+import * as sqliteTargets from "./session-sqlite-target.js";
 
 const tempDirs: string[] = [];
 const autoTempDirs = useAutoCleanupTempDirTracker(afterEach);
@@ -60,6 +62,52 @@ afterEach(() => {
 });
 
 describe("session accessor readonly listing", () => {
+  it("resolves a registered exact store once per batch and observes its next owner", () => {
+    const env = { OPENCLAW_STATE_DIR: autoTempDirs.make("openclaw-exact-read-target-") };
+    const storePath = path.join(env.OPENCLAW_STATE_DIR, "registered.sqlite");
+    const scope = { agentId: "worker-1", env, storePath, projection: "list" as const };
+    const keys = [
+      "agent:worker-1:first",
+      "agent:worker-1:second",
+      "agent:worker-1:missing",
+    ] as const;
+    openOpenClawAgentDatabase({ agentId: scope.agentId, env, path: storePath });
+    for (const sessionKey of keys.slice(0, 2)) {
+      replaceSessionEntrySync({ ...scope, sessionKey }, { sessionId: sessionKey, updatedAt: 1 });
+    }
+    const resolve = vi.spyOn(sqliteTargets, "resolveSqliteTargetFromSessionStorePath");
+    const read = () =>
+      loadExactSessionEntryCandidatesReadOnlyBatch(
+        keys.map((sessionKey) => ({ ...scope, sessionKeys: [sessionKey] })),
+      );
+    try {
+      expect(read()).toMatchObject([
+        { ok: true, value: [{ sessionKey: keys[0], entry: { sessionId: keys[0] } }] },
+        { ok: true, value: [{ sessionKey: keys[1], entry: { sessionId: keys[1] } }] },
+        { ok: true, value: [] },
+      ]);
+      expect(resolve).toHaveBeenCalledOnce();
+
+      closeOpenClawAgentDatabasesForTest();
+      clearRegisteredAgentDatabases(env);
+      fs.renameSync(storePath, `${storePath}.previous`);
+      openOpenClawAgentDatabase({ agentId: "worker-2", env, path: storePath });
+      replaceSessionEntrySync(
+        { ...scope, sessionKey: keys[0] },
+        { sessionId: "replacement-first", updatedAt: 2 },
+      );
+      resolve.mockClear();
+      expect(read()).toMatchObject([
+        { ok: true, value: [{ sessionKey: keys[0], entry: { sessionId: "replacement-first" } }] },
+        { ok: true, value: [] },
+        { ok: true, value: [] },
+      ]);
+      expect(resolve).toHaveBeenCalledOnce();
+    } finally {
+      resolve.mockRestore();
+    }
+  });
+
   it("returns the same entries as the writable listing for a populated agent database", async () => {
     const stateDir = makeTempDir(tempDirs, "openclaw-session-readonly-populated-");
     const env = { OPENCLAW_STATE_DIR: stateDir };
@@ -222,7 +270,13 @@ describe("session accessor readonly listing", () => {
           ["agent:main:tie-a", "agent:main:bad-timestamp"],
           ["agent:main:tie-a"],
           [retainedScope.sessionKey, "agent:main:missing"],
-        ].map((sessionKeys) => ({ agentId: scope.agentId, env, sessionKeys, projection })),
+        ].map((sessionKeys) => ({
+          agentId: scope.agentId,
+          env,
+          storePath: database.path,
+          sessionKeys,
+          projection,
+        })),
       );
       expect(grouped).toMatchObject([
         {

--- a/src/config/sessions/session-accessor.sqlite-exact-read.ts
+++ b/src/config/sessions/session-accessor.sqlite-exact-read.ts
@@ -8,7 +8,11 @@ import {
 } from "../../state/openclaw-agent-db.js";
 import type { ExactSessionEntry } from "./session-accessor.sqlite-contract.js";
 import { readExactSessionEntryRowValidated } from "./session-accessor.sqlite-entry-store.js";
-import { resolveSqliteScope, toDatabaseOptions } from "./session-accessor.sqlite-scope.js";
+import {
+  resolveSqliteScope,
+  toDatabaseOptions,
+  type SessionSqliteTargetResolutionCache,
+} from "./session-accessor.sqlite-scope.js";
 import type { SessionEntryReadScope } from "./session-accessor.types.js";
 import { assertCanonicalSqliteSessionKeysCurrent } from "./session-canonical-key.js";
 
@@ -83,6 +87,7 @@ export function loadExactSessionEntryCandidatesReadOnlyBatch(
   })[],
 ): Array<Result<ExactSessionEntry[], unknown>> {
   const results: Array<Result<ExactSessionEntry[], unknown>> = scopes.map(() => ok([]));
+  const targetCache: SessionSqliteTargetResolutionCache = new Map();
   const groups = new Map<
     string,
     {
@@ -98,7 +103,7 @@ export function loadExactSessionEntryCandidatesReadOnlyBatch(
       continue;
     }
     try {
-      const options = toDatabaseOptions(resolveSqliteScope({ ...scope, sessionKey }));
+      const options = toDatabaseOptions(resolveSqliteScope({ ...scope, sessionKey }, targetCache));
       const groupKey = [
         options.agentId,
         resolveOpenClawAgentSqlitePath(options),

--- a/src/config/sessions/session-accessor.sqlite-scope.ts
+++ b/src/config/sessions/session-accessor.sqlite-scope.ts
@@ -292,6 +292,7 @@ export function resolveSqliteScope(
     SessionAccessScope,
     "agentId" | "defaultAgentId" | "env" | "sessionKey" | "storePath"
   >,
+  targetCache?: SessionSqliteTargetResolutionCache,
 ): ResolvedSqliteScope {
   const parsedAgentId = parseAgentSessionKey(scope.sessionKey)?.agentId;
   const scopedAgentId = scope.agentId ? normalizeAgentId(scope.agentId) : parsedAgentId;
@@ -303,11 +304,15 @@ export function resolveSqliteScope(
     : scope.storePath;
   const effectiveAgentId = incognitoAgentId ?? scopedAgentId;
   const storeTarget = effectiveStorePath
-    ? resolveSqliteTargetFromSessionStorePath(effectiveStorePath, {
-        agentId: effectiveAgentId,
-        defaultAgentId: scope.defaultAgentId,
-        ...(scope.env ? { env: scope.env } : {}),
-      })
+    ? resolveCachedSqliteStoreTarget(
+        {
+          agentId: effectiveAgentId,
+          defaultAgentId: scope.defaultAgentId,
+          env: scope.env,
+          storePath: effectiveStorePath,
+        },
+        targetCache,
+      )
     : undefined;
   const agentId = resolveSqliteAgentId({
     scopedAgentId: effectiveAgentId,


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled.

</details>

## What Problem This Solves

Fixes an issue where users loading the Sessions list pay repeated filesystem ownership checks for every returned row when many sessions share one SQLite store.

## Why This Change Was Made

The sharing refresh already groups exact session reads by physical store, but resolving each row's store repeated the same ownership and realpath work before grouping. Reuse the existing synchronous batch target-resolution cache during that planning step. Each new batch resolves current ownership again; incognito routing, logical session ownership, read-only admission, and per-row failure handling remain with their existing owners.

## User Impact

Sessions list requests perform less synchronous work when many returned rows share a store. This does not change session visibility or stored data.

## Evidence

A synthetic benchmark exercised the registered `sessions.list` handler with real SQLite stores, 2 configured agents, 3,000 sessions, and a 100-row page. Across 15 unprofiled repetitions:

| Measurement | Before | After |
| --- | ---: | ---: |
| Median request duration | 36.97 ms | 34.17 ms |
| Median sharing refresh duration | 9.94 ms | 5.63 ms |
| Store target resolutions per sharing batch | 100 | 1 |
| Realpath calls per sharing batch | 200 | 2 |

These are local synthetic measurements, not a production speedup claim. The disposable benchmark is excluded from the product change.

The regression failed before the fix with three ownership resolutions instead of one. It also replaces the physical database owner between batches and verifies that the next batch reads the replacement store. Existing corrupt-row coverage now uses an explicit store locator to exercise cached resolution while retaining partial-result errors.

Validation: all 248 selected permanent tests passed across the read-only accessor, target resolution, combined-store, incognito transcript, Sessions list ownership, and session creation suites. The full changed-file gate passed, including production/test typechecking, lint, formatting, export scans, and boundary guards. Independent P2 review found no actionable issues. [Hosted CI](https://github.com/openclaw/openclaw/actions/runs/34680365048) passed on exact head `4a50daaffc4fbb9adfa064c94a6005878d9d098e`, including the required `openclaw/ci-gate`. ClawSweeper reviewed that same head with no actionable findings.
