### PR TITLE
chore: exercise sustained multi-session Gateway load

### DIFF
--- a/docs/reference/test/performance.md
+++ b/docs/reference/test/performance.md
@@ -107,7 +107,18 @@ first; no provider key is required.
 
 ```bash
 pnpm test:gateway:concurrency -- --concurrency 16 --tool-events --workspace-fanout --session-count 100 --history-messages 20 --history-clients 4 --subscribers 4 --visible-observer --control-plane --heap-prof-dir .artifacts/gateway-heap --output .artifacts/gateway-concurrency.json
+pnpm test:gateway:concurrency -- --concurrency 64 --turns-per-session 8 --tool-events --timeout-ms 600000 --heap-prof-dir .artifacts/gateway-sustained-heap --output .artifacts/gateway-sustained.json
 ```
+
+`--concurrency` controls parallel sessions; `--turns-per-session` controls serial
+turns in each session (default 1, maximum 100). The second example completes 512
+turns across 64 sessions. Each session starts its next turn as soon as its
+previous turn completes, retaining its conversation history and workspace;
+there is no barrier between rounds. The fresh-connection probe runs once after
+every session has started its first turn. `--tool-events` requests a tool call
+on every turn, including follow-ups. The per-run timeout still bounds the whole
+workload. Health/control sampling is capped at 2,048 samples, while heap
+sampling continues until the full workload finishes.
 
 `--heap-prof-dir` samples allocations in the Gateway's main V8 isolate, starting
 after startup, session seeding, and probe warmup. Sampling ends after the load
@@ -121,6 +132,9 @@ allocation stacks; open the raw file in the Chrome DevTools Memory panel.
 The summary includes sampled allocation bytes per run and per completed turn.
 The per-turn figure also includes concurrent probes and session mutations;
 compare identical workload settings and Node versions across multiple runs.
+Initial and follow-up turns overlap across sessions, so the allocation profile
+covers their combined workload rather than attributing separate cold and warm
+allocations. Compare matched one-turn and sustained runs to study reuse.
 Sampling is statistical and adds overhead. Use unprofiled runs for latency
 comparisons. Existing heap/RSS measurements are taken before exporting the
 profile. `--cpu-prof-dir` remains available separately and includes startup;

--- a/scripts/bench-gateway-concurrency.ts
+++ b/scripts/bench-gateway-concurrency.ts
@@ -1361,7 +1361,7 @@ async function runGatewaySample(options: {
       const timelineFrom = Date.now();
       const loadStartMonotonicMicros = Number(process.hrtime.bigint() / 1_000n);
       const turns = Promise.all(
-        Array.from({ length: options.concurrency }, (_, index) =>
+        turnSessionKeys.map((sessionKey, index) =>
           runSessionTurns(rpc, index, loadDeadlineAt, {
             onStarted: () => {
               startedTurnCount += 1;
@@ -1369,7 +1369,7 @@ async function runGatewaySample(options: {
                 resolveAllTurnsStarted();
               }
             },
-            sessionKey: turnSessionKeys[index],
+            sessionKey,
             toolEvents: options.toolEvents,
             turnsPerSession: options.turnsPerSession,
           }),

--- a/scripts/bench-gateway-concurrency.ts
+++ b/scripts/bench-gateway-concurrency.ts
@@ -165,6 +165,7 @@ type CliOptions = {
   subscribers: number;
   timeoutMs: number;
   toolEvents: boolean;
+  turnsPerSession: number;
   visibleObserver: boolean;
   warmup: number;
   workspaceFanout: boolean;
@@ -178,6 +179,7 @@ const DEFAULT_TIMEOUT_MS = 120_000;
 const DEFAULT_WARMUP = 0;
 const MOCK_RESPONSE_CHUNK_DELAY_MS = 1_000;
 const MAX_CONCURRENCY = 64;
+const MAX_TURNS_PER_SESSION = 100;
 const MAX_PLUGIN_COUNT = 100;
 const MAX_SESSION_COUNT = 10_000;
 const MAX_SESSION_UPDATES = 100_000;
@@ -223,6 +225,7 @@ const VALUE_FLAGS = new Set([
   "--stream-chunk-delay-ms",
   "--subscribers",
   "--timeout-ms",
+  "--turns-per-session",
   "--warmup",
 ]);
 
@@ -358,6 +361,12 @@ function parseOptions(argv: string[] = process.argv.slice(2)): CliOptions {
       10 * 60_000,
     ),
     toolEvents: hasFlag(argv, "--tool-events"),
+    turnsPerSession: parseBoundedPositiveInt(
+      parseFlagValue(argv, "--turns-per-session"),
+      1,
+      "--turns-per-session",
+      MAX_TURNS_PER_SESSION,
+    ),
     visibleObserver: hasFlag(argv, "--visible-observer"),
     warmup: parseBoundedNonNegativeInt(
       parseFlagValue(argv, "--warmup"),
@@ -386,7 +395,8 @@ Usage:
   node scripts/bench-gateway-concurrency.ts [options]
 
 Options:
-  --concurrency <n>  Concurrent synthetic streaming turns (default: ${DEFAULT_CONCURRENCY})
+  --concurrency <n>  Concurrent synthetic sessions (default: ${DEFAULT_CONCURRENCY})
+  --turns-per-session <n> Serial turns per session (default: 1, max: ${MAX_TURNS_PER_SESSION})
   --control-plane   Also probe tasks.list, cron.list, and cron.status during load
   --history-messages <n> Inject up to 500 synthetic messages per seeded session
   --history-message-chars <n> Synthetic message size (default: 1024, max: 65536)
@@ -408,7 +418,7 @@ Options:
   --no-diagnostics-timeline Disable diagnostics timeline file writes
   --plugin-count <n> Configure synthetic plugins through plugins.load.paths (default: 0)
   --tool-events      Make every synthetic turn execute a tool before replying
-  --workspace-fanout Bind each turn to a distinct workspace
+  --workspace-fanout Bind each session to a distinct workspace
   --max-control-ms   Fail when any load-phase health/control probe exceeds this bound
   --max-handshake-ms Fail when a fresh authenticated connection exceeds this bound
   --output <path>    Write machine-readable JSON to a file
@@ -898,6 +908,27 @@ async function runTurn(
   }
 }
 
+async function runSessionTurns(
+  rpc: GatewayRpc,
+  index: number,
+  deadlineAt: number,
+  options: {
+    onStarted?: () => void;
+    sessionKey: string;
+    toolEvents: boolean;
+    turnsPerSession: number;
+  },
+): Promise<number> {
+  for (let turn = 0; turn < options.turnsPerSession; turn += 1) {
+    requireRemainingMs(deadlineAt, `starting session ${index + 1} turn ${turn + 1}`);
+    await runTurn(rpc, index * options.turnsPerSession + turn, deadlineAt, options.toolEvents, {
+      sessionKey: options.sessionKey,
+      onStarted: turn === 0 ? options.onStarted : undefined,
+    });
+  }
+  return options.turnsPerSession;
+}
+
 async function sampleGateway(params: {
   deadlineAt: number;
   port: number;
@@ -1053,6 +1084,7 @@ async function runGatewaySample(options: {
   subscribers: number;
   timeoutMs: number;
   toolEvents: boolean;
+  turnsPerSession: number;
   visibleObserver: boolean;
   workspaceFanout: boolean;
 }): Promise<BenchmarkRun> {
@@ -1330,14 +1362,16 @@ async function runGatewaySample(options: {
       const loadStartMonotonicMicros = Number(process.hrtime.bigint() / 1_000n);
       const turns = Promise.all(
         Array.from({ length: options.concurrency }, (_, index) =>
-          runTurn(rpc, index, loadDeadlineAt, options.toolEvents, {
+          runSessionTurns(rpc, index, loadDeadlineAt, {
             onStarted: () => {
               startedTurnCount += 1;
               if (startedTurnCount === options.concurrency) {
                 resolveAllTurnsStarted();
               }
             },
-            ...(turnSessionKeys[index] ? { sessionKey: turnSessionKeys[index] } : {}),
+            sessionKey: turnSessionKeys[index],
+            toolEvents: options.toolEvents,
+            turnsPerSession: options.turnsPerSession,
           }),
         ),
       ).finally(() => {
@@ -1460,7 +1494,7 @@ async function runGatewaySample(options: {
       ).finally(() => {
         updatesDone = true;
       });
-      const [freshConnectionResult] = await Promise.all([
+      const [freshConnectionResult, sessionTurnCounts] = await Promise.all([
         freshConnection,
         turns,
         sampler,
@@ -1507,7 +1541,7 @@ async function runGatewaySample(options: {
         sessionsList,
         sessionUpdates,
         setupDurationMs,
-        turnCount: options.concurrency,
+        turnCount: sessionTurnCounts.reduce((sum, count) => sum + count, 0),
         turnsDurationMs,
       };
     } catch (error) {
@@ -1696,6 +1730,7 @@ function summarizeRuns(
     sessionUpdateLatencyMs: summarizeNumbers(sessionUpdates.map((sample) => sample.latencyMs)),
     sessionUpdateSampleCount: sessionUpdates.length,
     setupDurationMs: summarizeNumbers(runs.map((run) => run.setupDurationMs)),
+    turnCount: runs.reduce((sum, run) => sum + run.turnCount, 0),
     turnsDurationMs: summarizeNumbers(runs.map((run) => run.turnsDurationMs)),
   };
 }
@@ -1758,6 +1793,7 @@ async function main(): Promise<void> {
     subscribers: options.subscribers,
     summary: summarizeRuns(runs, options),
     toolEvents: options.toolEvents,
+    turnsPerSession: options.turnsPerSession,
     visibleObserver: options.visibleObserver,
     workspaceFanout: options.workspaceFanout,
   };
@@ -1779,6 +1815,7 @@ export const testing = {
   formatRunFailure,
   requestHttp,
   runBenchmarkSamples,
+  runSessionTurns,
   runTurn,
   sampleGateway,
   readDiagnosticsTimelineSpans,

--- a/scripts/e2e/mock-openai-server.mjs
+++ b/scripts/e2e/mock-openai-server.mjs
@@ -496,13 +496,26 @@ function preambleThenToolCallEvents(preamble, name, args) {
   ];
 }
 
-/** Two-turn draft scenario: preamble + shell call, then a final answer. */
+function hasCurrentTurnToolOutput(messages) {
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index];
+    if (message?.role === "user") {
+      return false;
+    }
+    if (message?.role === "tool" || message?.type === "function_call_output") {
+      return true;
+    }
+  }
+  return false;
+}
+
+/** Draft scenario: preamble + shell call, then a final answer for each user turn. */
 function progressDraftEvents(body, bodyText) {
   const allText = collectText(body).join("\n");
   if (!allText.includes("OPENCLAW_E2E_DRAFTPROOF")) {
     return null;
   }
-  if (!collectFunctionCallOutputText(body)) {
+  if (!hasCurrentTurnToolOutput(Array.isArray(body.input) ? body.input : [])) {
     if (!hasDeclaredTool(bodyText, "exec")) {
       return null;
     }
@@ -924,7 +937,7 @@ const server = http.createServer((req, res) => {
       // commentary, which channels render as the draft status headline.
       if (!responseControl && bodyText.includes("OPENCLAW_E2E_DRAFTPROOF")) {
         const messages = Array.isArray(body.messages) ? body.messages : [];
-        const toolTurnDone = messages.some((message) => message?.role === "tool");
+        const toolTurnDone = hasCurrentTurnToolOutput(messages);
         if (!toolTurnDone) {
           writeChatCompletionPreambleToolCall(
             res,

--- a/test/scripts/bench-gateway-concurrency.test.ts
+++ b/test/scripts/bench-gateway-concurrency.test.ts
@@ -12,6 +12,7 @@ import {
   readGatewayHeapProfile,
 } from "../../scripts/lib/gateway-bench-heap.ts";
 import { withTempDir } from "../../src/test-utils/temp-dir.js";
+import { createDeferred } from "../helpers/promise.js";
 
 type BenchmarkRun = Parameters<typeof testing.summarizeRuns>[0][number];
 
@@ -440,8 +441,11 @@ describe("gateway concurrency benchmark script", () => {
   it("advances parallel sessions independently while serializing their own turns", async () => {
     const starts: Array<{ sessionKey: string; idempotencyKey: string; message: string }> = [];
     const startedSessions: string[] = [];
-    const issued = Array.from({ length: 4 }, () => Promise.withResolvers<void>());
-    const completions = Array.from({ length: 4 }, () => Promise.withResolvers<void>());
+    const createTurn = () => ({
+      issued: createDeferred<void>(),
+      completed: createDeferred<void>(),
+    });
+    const turns = [createTurn(), createTurn(), createTurn(), createTurn()] as const;
     const rpc = async <T>(method: string, params: unknown): Promise<T> => {
       if (method === "agent") {
         const request = params as (typeof starts)[number];
@@ -450,8 +454,12 @@ describe("gateway concurrency benchmark script", () => {
       }
       const { runId } = params as { runId: string };
       const index = starts.findIndex((request) => request.idempotencyKey === runId);
-      issued[index].resolve();
-      await completions[index].promise;
+      const turn = turns[index];
+      if (!turn) {
+        throw new Error(`Unexpected agent wait: ${runId}`);
+      }
+      turn.issued.resolve();
+      await turn.completed.promise;
       return { status: "ok" } as T;
     };
     const [fastSession, slowSession] = ["fast", "slow"].map((sessionKey, index) =>
@@ -462,19 +470,19 @@ describe("gateway concurrency benchmark script", () => {
         turnsPerSession: 2,
       }),
     );
-    await Promise.all([issued[0].promise, issued[1].promise]);
+    await Promise.all([turns[0].issued.promise, turns[1].issued.promise]);
     expect(starts.map((request) => request.sessionKey)).toEqual(["fast", "slow"]);
 
-    completions[0].resolve();
-    await issued[2].promise;
+    turns[0].completed.resolve();
+    await turns[2].issued.promise;
     expect(starts.map((request) => request.sessionKey)).toEqual(["fast", "slow", "fast"]);
-    completions[2].resolve();
+    turns[2].completed.resolve();
     expect(await fastSession).toBe(2);
     expect(startedSessions).toEqual(["fast", "slow"]);
 
-    completions[1].resolve();
-    await issued[3].promise;
-    completions[3].resolve();
+    turns[1].completed.resolve();
+    await turns[3].issued.promise;
+    turns[3].completed.resolve();
     expect(await slowSession).toBe(2);
     expect(starts.map((request) => request.sessionKey)).toEqual(["fast", "slow", "fast", "slow"]);
     expect(startedSessions).toEqual(["fast", "slow"]);

--- a/test/scripts/bench-gateway-concurrency.test.ts
+++ b/test/scripts/bench-gateway-concurrency.test.ts
@@ -108,6 +108,8 @@ describe("gateway concurrency benchmark script", () => {
       testing.parseOptions([
         "--concurrency",
         "12",
+        "--turns-per-session",
+        "8",
         "--runs",
         "2",
         "--warmup",
@@ -177,12 +179,18 @@ describe("gateway concurrency benchmark script", () => {
       subscribers: 4,
       timeoutMs: 90_000,
       toolEvents: true,
+      turnsPerSession: 8,
       visibleObserver: true,
       warmup: 0,
       workspaceFanout: true,
     });
     expect(() => testing.parseOptions(["--concurrency", "65"])).toThrow(
       "--concurrency must be at most 64",
+    );
+    expect(testing.parseOptions([]).turnsPerSession).toBe(1);
+    expect(() => testing.parseOptions(["--turns-per-session", "0"])).toThrow("--turns-per-session");
+    expect(() => testing.parseOptions(["--turns-per-session", "101"])).toThrow(
+      "--turns-per-session must be at most 100",
     );
     expect(() => testing.parseOptions(["--runs", "2", "--runs", "3"])).toThrow(
       "--runs was provided more than once",
@@ -428,6 +436,51 @@ describe("gateway concurrency benchmark script", () => {
       expect(wait?.timeoutMs).toBeLessThanOrEqual(budgetMs);
     },
   );
+
+  it("advances parallel sessions independently while serializing their own turns", async () => {
+    const starts: Array<{ sessionKey: string; idempotencyKey: string; message: string }> = [];
+    const startedSessions: string[] = [];
+    const issued = Array.from({ length: 4 }, () => Promise.withResolvers<void>());
+    const completions = Array.from({ length: 4 }, () => Promise.withResolvers<void>());
+    const rpc = async <T>(method: string, params: unknown): Promise<T> => {
+      if (method === "agent") {
+        const request = params as (typeof starts)[number];
+        starts.push(request);
+        return { runId: request.idempotencyKey, status: "accepted" } as T;
+      }
+      const { runId } = params as { runId: string };
+      const index = starts.findIndex((request) => request.idempotencyKey === runId);
+      issued[index].resolve();
+      await completions[index].promise;
+      return { status: "ok" } as T;
+    };
+    const [fastSession, slowSession] = ["fast", "slow"].map((sessionKey, index) =>
+      testing.runSessionTurns(rpc, index, performance.now() + 60_000, {
+        onStarted: () => startedSessions.push(sessionKey),
+        sessionKey,
+        toolEvents: true,
+        turnsPerSession: 2,
+      }),
+    );
+    await Promise.all([issued[0].promise, issued[1].promise]);
+    expect(starts.map((request) => request.sessionKey)).toEqual(["fast", "slow"]);
+
+    completions[0].resolve();
+    await issued[2].promise;
+    expect(starts.map((request) => request.sessionKey)).toEqual(["fast", "slow", "fast"]);
+    completions[2].resolve();
+    expect(await fastSession).toBe(2);
+    expect(startedSessions).toEqual(["fast", "slow"]);
+
+    completions[1].resolve();
+    await issued[3].promise;
+    completions[3].resolve();
+    expect(await slowSession).toBe(2);
+    expect(starts.map((request) => request.sessionKey)).toEqual(["fast", "slow", "fast", "slow"]);
+    expect(startedSessions).toEqual(["fast", "slow"]);
+    expect(new Set(starts.map((request) => request.idempotencyKey)).size).toBe(4);
+    expect(new Set(starts.map((request) => request.message)).size).toBe(4);
+  });
 
   it("gives every gateway sample a fresh pre-warmup timeout budget", async () => {
     const deadlines: number[] = [];

--- a/test/scripts/bench-gateway-concurrency.test.ts
+++ b/test/scripts/bench-gateway-concurrency.test.ts
@@ -442,8 +442,8 @@ describe("gateway concurrency benchmark script", () => {
     const starts: Array<{ sessionKey: string; idempotencyKey: string; message: string }> = [];
     const startedSessions: string[] = [];
     const createTurn = () => ({
-      issued: createDeferred<void>(),
-      completed: createDeferred<void>(),
+      issued: createDeferred(),
+      completed: createDeferred(),
     });
     const turns = [createTurn(), createTurn(), createTurn(), createTurn()] as const;
     const rpc = async <T>(method: string, params: unknown): Promise<T> => {

--- a/test/scripts/e2e-mock-config-limits.test.ts
+++ b/test/scripts/e2e-mock-config-limits.test.ts
@@ -300,13 +300,14 @@ describe("mock OpenAI response markers", () => {
           }
 
           const finalStartedAt = performance.now();
-          const final = await request([
+          const completedTurn = [
             user,
             ...assistant,
             api === "responses"
               ? { type: "function_call_output", call_id: call.call_id, output: toolOutput }
               : { role: "tool", tool_call_id: call.call_id, content: toolOutput },
-          ]);
+          ];
+          const final = await request(completedTurn);
           if (api === "responses") {
             const response = stream
               ? final.find((event) => event.type === "response.completed").response
@@ -323,6 +324,32 @@ describe("mock OpenAI response markers", () => {
                 .join(""),
             ).toBe("OPENCLAW_E2E_DRAFTPROOF");
             taskExpect(performance.now() - finalStartedAt).toBeGreaterThanOrEqual(60);
+          }
+
+          const followup = await request([
+            ...completedTurn,
+            { role: "assistant", content: "OPENCLAW_E2E_DRAFTPROOF" },
+            { role: "user", content: "repeat OPENCLAW_E2E_DRAFTPROOF for this next turn" },
+          ]);
+          if (api === "responses") {
+            const items = stream
+              ? followup
+                  .filter((event) => event.type === "response.output_item.done")
+                  .map((event) => event.item)
+              : followup[0].output;
+            taskExpect(items).toContainEqual(
+              taskExpect.objectContaining({ type: "function_call", name: "exec" }),
+            );
+          } else {
+            const calls = followup.flatMap((chunk) => {
+              const message = stream ? chunk.choices[0].delta : chunk.choices[0].message;
+              return message.tool_calls ?? [];
+            });
+            taskExpect(calls).toContainEqual(
+              taskExpect.objectContaining({
+                function: taskExpect.objectContaining({ name: "exec" }),
+              }),
+            );
           }
         },
       );


### PR DESCRIPTION
Related: #145686

## What Problem This Solves

Gateway concurrency benchmarks previously exercised one turn per session. They could not reproduce the accumulated tool, task, and observer work of a busy Gateway serving ongoing conversations. The mock provider also treated a tool result anywhere in history as completion of the current turn, silently skipping tool calls on later turns.

## Why This Change Was Made

Add `--turns-per-session` (default 1, maximum 100). Sessions advance concurrently while each session waits for its own turn to finish. The initial handshake barrier remains tied to the first turn; prompts and idempotency keys stay distinct. Report completed turn totals and normalize sampled allocations by that total. The existing child-only heap profiler continues covering the entire joined load window.

The mock provider now recognizes tool outputs only after the latest user message, for Responses and chat-completions. Document the sustained command and the existing bounded probe retention.

## User Impact

Developers can reproduce sustained multi-session load, including repeated tool execution, history reads, session updates, and visible observers. The default benchmark remains a single turn per session.

## Evidence

- 57 benchmark and mock-provider tests passed, including independent session advancement, ordered turns, failure propagation, and follow-up tools in streaming and nonstreaming Responses/chat-completions. The four follow-up tool regressions fail against the original mock provider.
- A built Gateway completed 512 turns across 64 sessions (8 turns each), with 512 seeded sessions, 32 observers, 4 history clients, and 1,024 session updates.
- That sustained baseline exposed a session-list timeout and unstable Tasks-list reads; the benchmark records those failures rather than hiding them. Runtime fixes are tracked separately in #145686.

```sh
node scripts/bench-gateway-concurrency.ts --concurrency 64 --turns-per-session 8 \
  --session-count 512 --tool-events --subscribers 32 --visible-observer \
  --history-clients 4 --history-messages 8 --control-plane --session-updates 1024 \
  --timeout-ms 600000 --heap-prof-dir .artifacts/gateway-load-profiles \
  --output .artifacts/gateway-load.json
```
