### PR TITLE
fix(update): honor local override replay from fresh profiles

### DIFF
--- a/src/cli/update-cli/update-command-fresh-overrides.test.ts
+++ b/src/cli/update-cli/update-command-fresh-overrides.test.ts
@@ -1,0 +1,143 @@
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { assert, expect, it, vi } from "vitest";
+import { writePackageDistInventory } from "../../../scripts/lib/package-dist-inventory.js";
+import type { PackageUpdateTransaction } from "../../infra/package-update-steps.js";
+import {
+  createNpmTarget,
+  writePackageRoot,
+} from "../../infra/package-update-steps.test-support.js";
+import * as updateGlobal from "../../infra/update-global.js";
+import { finishUpdateRun } from "../../infra/update-run-ledger.js";
+import * as shared from "./shared.js";
+import * as execution from "./update-command-execution.js";
+import { installFreshUpdateFixture } from "./update-command-fresh.test-support.js";
+import * as packageUpdate from "./update-command-package.js";
+import * as commandRun from "./update-command-run.js";
+import * as servicePlan from "./update-command-service-plan.js";
+import { updateCommand } from "./update-command.js";
+
+const { fixture, dirs } = installFreshUpdateFixture();
+
+it.each([false, true])(
+  "preserves local files through real fresh-profile staging (replay=%s)",
+  async (reapplyLocalOverrides) => {
+    const base = dirs.make("fresh-artifact-overrides-");
+    const target = createNpmTarget(path.join(base, "prefix", "lib", "node_modules"));
+    const npmVersion = execFileSync("npm", ["--version"], { encoding: "utf8" }).trim();
+    const [major = 0, minor = 0] = npmVersion.split(".").map(Number);
+    target.npmOwner = {
+      version: npmVersion,
+      lifecyclePolicy:
+        major >= 12
+          ? "allow-scripts"
+          : major === 11 && minor >= 16
+            ? "allow-scripts-advisory"
+            : "unflagged",
+    };
+    fixture.root = target.packageRoot!;
+    await writePackageRoot(fixture.root, "2026.9.3");
+    const relativeFile = "dist/local-reapply-probe.txt";
+    const marker = "operator-owned override\n";
+    fs.writeFileSync(path.join(fixture.root, relativeFile), marker, { mode: 0o600 });
+    const candidate = path.join(base, "package");
+    await writePackageRoot(candidate, "2026.9.4");
+    fs.writeFileSync(
+      path.join(candidate, "package.json"),
+      JSON.stringify({
+        name: "openclaw",
+        version: "2026.9.4",
+        type: "module",
+        openclaw: { schemaVersions: { state: 17, agent: 20 } },
+      }),
+    );
+    await writePackageDistInventory(candidate);
+    const artifact = path.join(base, "candidate.tgz");
+    execFileSync("tar", ["-czf", artifact, "-C", base, "package"], {
+      env: { ...process.env, COPYFILE_DISABLE: "1" },
+    });
+    vi.mocked(shared.resolveTargetVersion).mockResolvedValue(null);
+    vi.mocked(updateGlobal.resolveGlobalInstallTarget).mockResolvedValue(target);
+    vi.mocked(updateGlobal.createGlobalInstallEnv).mockResolvedValue({
+      ...process.env,
+      npm_config_userconfig: path.join(base, "empty.npmrc"),
+      npm_config_globalconfig: path.join(base, "empty-global.npmrc"),
+      npm_config_cache: path.join(base, "npm-cache"),
+    });
+    vi.mocked(packageUpdate.stagePackageInstallUpdate).mockRestore();
+    const prepare = vi.mocked(commandRun.prepareUpdateCommand).getMockImplementation()!;
+    vi.mocked(commandRun.prepareUpdateCommand).mockImplementation(async (opts) => ({
+      ...(await prepare(opts)),
+      timeoutMs: 30_000,
+    }));
+    vi.spyOn(servicePlan, "resolvePackageRuntimePreflight").mockResolvedValue({
+      ok: true,
+      value: { nodeRunner: process.execPath },
+    });
+    vi.spyOn(execution, "executeMutableUpdate").mockImplementation(async (params) => {
+      // Keep real admission, staging, npm, replay and backup ownership; this synthetic
+      // package has no Gateway lifecycle or post-core plugin convergence to finalize.
+      assert(params.stagedPackage);
+      const run = params.opts.run;
+      assert(run);
+      const assertCurrent = () => run.executorFence!.assertCurrent();
+      let transaction: PackageUpdateTransaction | undefined;
+      const result = await params.stagedPackage.run({
+        root: fixture.root,
+        installKind: "package",
+        tag: artifact,
+        timeoutMs: 30_000,
+        startedAt: params.startedAt,
+        jsonMode: true,
+        progress: params.progress,
+        nodeRunner: process.execPath,
+        managedServiceEnv: run.env,
+        reapplyLocalOverrides: params.opts.reapplyLocalOverrides,
+        validateCandidate: async () => [],
+        beforeActivate: async () => assertCurrent(),
+        onTransaction: (value) => {
+          transaction = value;
+        },
+      });
+      expect(result.status).toBe("ok");
+      assert(transaction);
+      await transaction.complete({ activationVerified: true }, assertCurrent);
+      expect(fs.existsSync(path.join(fixture.root, relativeFile))).toBe(reapplyLocalOverrides);
+      if (reapplyLocalOverrides) {
+        expect(fs.readFileSync(path.join(fixture.root, relativeFile), "utf8")).toBe(marker);
+        expect(result.localOverrides?.warnings).toEqual([]);
+      } else {
+        expect(result.localOverrides?.warnings).toEqual([
+          expect.stringContaining("were not reapplied"),
+        ]);
+      }
+      expect(result.localOverrides).toMatchObject({
+        status: reapplyLocalOverrides ? "applied" : "preserved",
+        added: 1,
+        applied: reapplyLocalOverrides ? 1 : 0,
+        conflicts: [],
+      });
+      const recoveryDir = result.localOverrides!.recoveryDir!;
+      expect(fs.readFileSync(path.join(recoveryDir, "files", relativeFile), "utf8")).toBe(marker);
+      expect(
+        result.steps.some(
+          (step) =>
+            step.name === "local package overrides" && step.advisory?.message.includes(recoveryDir),
+        ),
+      ).toBe(true);
+      finishUpdateRun(run.runId, { status: "succeeded" }, { env: run.env });
+      return null;
+    });
+
+    expect(fs.existsSync(fixture.databasePath)).toBe(false);
+    await updateCommand({
+      tag: `file:${artifact}`,
+      yes: true,
+      json: true,
+      restart: false,
+      reapplyLocalOverrides,
+    });
+  },
+  60_000,
+);

--- a/src/cli/update-cli/update-command-fresh-preview.test.ts
+++ b/src/cli/update-cli/update-command-fresh-preview.test.ts
@@ -2,18 +2,15 @@ import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
-import { afterEach, assert, beforeEach, describe, expect, it, vi } from "vitest";
-import { createTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import { assert, describe, expect, it, vi } from "vitest";
 import { withTriageTerminal } from "../../commands/triage.test-support.js";
 import * as tempRoot from "../../infra/tmp-openclaw-dir.js";
 import * as packageMetadata from "../../infra/update-check-package-target.js";
 import * as updateCheck from "../../infra/update-check.js";
-import * as updateGlobal from "../../infra/update-global.js";
 import { createManagedHandoffLeaseStore } from "../../infra/update-managed-service-handoff-lease.js";
 import { finishUpdateRun, getUpdateRun } from "../../infra/update-run-ledger.js";
 import type { UpdateRecoveryFence } from "../../infra/update-run-recovery.js";
 import { defaultRuntime } from "../../runtime.js";
-import * as processIdentity from "../../shared/pid-alive.js";
 import {
   closeOpenClawStateDatabaseForTest,
   openOpenClawStateDatabase,
@@ -21,11 +18,10 @@ import {
 import { resolveOpenClawStateSqlitePath } from "../../state/openclaw-state-db.paths.js";
 import { removePreparedWorkerOwnershipColumns } from "../../state/openclaw-state-schema-v17.test-support.js";
 import * as oneShotExit from "../one-shot-exit.js";
-import { captureTargetDatabaseSchemaContext } from "./schema-preflight.js";
 import * as shared from "./shared.js";
-import * as databaseContext from "./update-command-database-context.js";
 import * as execution from "./update-command-execution.js";
 import * as executorOwner from "./update-command-executor.js";
+import { installFreshUpdateFixture, targetMetadata } from "./update-command-fresh.test-support.js";
 import * as initialization from "./update-command-initialization.js";
 import * as packageUpdate from "./update-command-package.js";
 import * as commandRun from "./update-command-run.js";
@@ -44,106 +40,24 @@ vi.mock("@clack/prompts", async (original) => ({
   confirm: promptConfirm,
 }));
 
-const dirs = createTempDirTracker();
-let root: string;
-let databasePath: string;
-let managedServiceNodeRunner: string | undefined;
+const { fixture, dirs } = installFreshUpdateFixture();
 const inheritedRunIds = [
   undefined,
   "f9ccab65-df92-4ba2-84b9-d15c9c37c9a0",
   "  1c5a25f3-f46a-408b-a87f-a0f0d1f80ee7  ",
   " \t ",
 ] as const;
-const targetMetadata = {
-  target: "2026.9.2",
-  version: "2026.9.2",
-  nodeEngine: null,
-  schemaVersions: { state: 16, agent: 19 },
-};
-
-beforeEach(() => {
-  managedServiceNodeRunner = undefined;
-  const home = dirs.make("openclaw-update-fresh-preview-");
-  root = path.join(home, "installation");
-  fs.mkdirSync(root);
-  fs.writeFileSync(
-    path.join(root, "package.json"),
-    JSON.stringify({ name: "openclaw", version: "2026.9.3" }),
-  );
-  vi.stubEnv("HOME", home);
-  vi.stubEnv("OPENCLAW_STATE_DIR", path.join(home, "profile"));
-  vi.stubEnv("OPENCLAW_CONFIG_PATH", path.join(home, "profile", "openclaw.json"));
-  vi.stubEnv("OPENCLAW_UPDATE_RUN_ID", undefined);
-  vi.stubEnv("OPENCLAW_UPDATE_RUN_HANDOFF", undefined);
-  vi.stubEnv("OPENCLAW_UPDATE_POST_CORE", undefined);
-  databasePath = resolveOpenClawStateSqlitePath(process.env);
-  const executorRoot = path.join(home, "executor");
-  fs.mkdirSync(executorRoot);
-  vi.spyOn(tempRoot, "resolvePreferredOpenClawTmpDir").mockReturnValue(executorRoot);
-  // The macOS test sandbox denies /bin/ps. Keep real lease ownership and liveness,
-  // supplying only the stable self identity that the OS probe cannot read here.
-  vi.spyOn(processIdentity, "getFileLockProcessStartTime").mockImplementation((pid) =>
-    pid === process.pid ? 1_700_000_000 : null,
-  );
-  vi.spyOn(defaultRuntime, "writeJson").mockImplementation(() => undefined);
-  vi.spyOn(defaultRuntime, "error").mockImplementation(() => undefined);
-  vi.spyOn(commandRun, "prepareUpdateCommand").mockImplementation(async (opts) => ({
-    startedAt: Date.now(),
-    postCoreUpdateResume: false,
-    postCoreUpdateChannel: undefined,
-    timeoutMs: 5_000,
-    shouldRestart: opts.restart !== false,
-    requestedChannel: opts.channel === "stable" ? "stable" : null,
-    devTarget: undefined,
-    controlPlaneUpdateSentinelMeta: null,
-    discoveredRoot: root,
-    installKind: "package",
-    servicePlan: { rootRedirect: null, nodeRunner: managedServiceNodeRunner },
-  }));
-  vi.spyOn(servicePlan, "isGatewayServiceManagementAllowedForUpdate").mockReturnValue(false);
-  vi.spyOn(databaseContext, "inspectUpdateDatabaseContexts").mockImplementation(async () => ({
-    service: undefined,
-    services: new Map(),
-    contexts: [await captureTargetDatabaseSchemaContext(process.env)],
-    managedEnv: undefined,
-  }));
-  vi.spyOn(shared, "resolveGlobalManager").mockResolvedValue("npm");
-  vi.spyOn(shared, "resolveTargetVersion").mockResolvedValue("2026.9.2");
-  vi.spyOn(updateGlobal, "createGlobalInstallEnv").mockResolvedValue({ ...process.env });
-  vi.spyOn(updateGlobal, "resolveGlobalInstallTarget").mockResolvedValue({
-    manager: "npm",
-    command: "npm",
-    globalRoot: path.dirname(root),
-    packageRoot: root,
-    npmOwner: { version: "11.10.0", lifecyclePolicy: "unflagged" },
-  });
-  vi.spyOn(updateCheck, "resolveNpmChannelTag").mockResolvedValue({
-    tag: "latest",
-    version: "2026.9.2",
-  });
-  vi.spyOn(packageMetadata, "fetchNpmPackageTargetStatus").mockResolvedValue(targetMetadata);
-  vi.spyOn(packageUpdate, "stagePackageInstallUpdate").mockRejectedValue(
-    new Error("Read-only update admission must not stage a package"),
-  );
-});
-
-afterEach(() => {
-  closeOpenClawStateDatabaseForTest();
-  vi.restoreAllMocks();
-  vi.unstubAllEnvs();
-  dirs.cleanup();
-});
 
 function expectFreshStatePreserved() {
-  expect(fs.existsSync(databasePath)).toBe(false);
+  expect(fs.existsSync(fixture.databasePath)).toBe(false);
   expect(packageUpdate.stagePackageInstallUpdate).not.toHaveBeenCalled();
-  expect(fs.readdirSync(root)).toEqual(["package.json"]);
+  expect(fs.readdirSync(fixture.root)).toEqual(["package.json"]);
 }
 
 function createSelectedTargetStateDatabase() {
   openOpenClawStateDatabase();
   closeOpenClawStateDatabaseForTest();
-  const db = new DatabaseSync(databasePath);
+  const db = new DatabaseSync(fixture.databasePath);
   try {
     removePreparedWorkerOwnershipColumns(db);
     db.exec(
@@ -170,7 +84,7 @@ describe("update command admission with fresh state", () => {
     expect(defaultRuntime.writeJson).toHaveBeenCalledWith(
       expect.objectContaining({ status: "skipped", reason: "downgrade-confirmation-required" }),
     );
-    expect(createManagedHandoffLeaseStore().read(root).kind).toBe("absent");
+    expect(createManagedHandoffLeaseStore().read(fixture.root).kind).toBe("absent");
     expectFreshStatePreserved();
   });
 
@@ -180,7 +94,7 @@ describe("update command admission with fresh state", () => {
     const exitAfterOutput = oneShotExit.exitCliAfterOutput;
     const leases: string[] = [];
     vi.spyOn(oneShotExit, "exitCliAfterOutput").mockImplementation((...args) => {
-      leases.push(createManagedHandoffLeaseStore().read(root).kind);
+      leases.push(createManagedHandoffLeaseStore().read(fixture.root).kind);
       return exitAfterOutput(...args);
     });
     await withTriageTerminal(true, async () => {
@@ -237,7 +151,7 @@ describe("update command admission with fresh state", () => {
     };
     const observations: { closed: boolean; lease: string }[] = [];
     const staged = {
-      root,
+      root: fixture.root,
       run: vi.fn(),
       close: vi.fn().mockImplementation(async () => {
         if (cleanup === "release") {
@@ -253,14 +167,14 @@ describe("update command admission with fresh state", () => {
     });
     if (cleanup.includes("coordinator")) {
       vi.spyOn(initialization, "acquireLegacyUpdateInitializationFence").mockReturnValue({
-        path: path.join(root, "fixture-coordinator"),
+        path: path.join(fixture.root, "fixture-coordinator"),
         release: legacyRelease,
       });
     }
     vi.mocked(defaultRuntime.writeJson).mockImplementation(() => {
       observations.push({
         closed: staged.close.mock.calls.length === 1,
-        lease: createManagedHandoffLeaseStore().read(root).kind,
+        lease: createManagedHandoffLeaseStore().read(fixture.root).kind,
       });
     });
     if (source === "metadata") {
@@ -307,7 +221,7 @@ describe("update command admission with fresh state", () => {
         }),
       );
     }
-    expect(fs.existsSync(databasePath)).toBe(false);
+    expect(fs.existsSync(fixture.databasePath)).toBe(false);
     expect(staged.run).not.toHaveBeenCalled();
     expect(legacyRelease).toHaveBeenCalledTimes(cleanup.includes("coordinator") ? 1 : 0);
   });
@@ -317,7 +231,11 @@ describe("update command admission with fresh state", () => {
       ok: true,
       value: {},
     });
-    const staged = { root, run: vi.fn(), close: vi.fn().mockResolvedValue(undefined) };
+    const staged = {
+      root: fixture.root,
+      run: vi.fn(),
+      close: vi.fn().mockResolvedValue(undefined),
+    };
     vi.mocked(packageUpdate.stagePackageInstallUpdate).mockResolvedValue(staged);
     vi.spyOn(initialization, "initializeUpdateStateFromTarget").mockImplementation(async () => {
       createSelectedTargetStateDatabase();
@@ -327,7 +245,7 @@ describe("update command admission with fresh state", () => {
       throw releaseError;
     });
     vi.spyOn(initialization, "acquireLegacyUpdateInitializationFence").mockReturnValue({
-      path: path.join(root, "fixture-coordinator"),
+      path: path.join(fixture.root, "fixture-coordinator"),
       release,
     });
     await expect(updateCommand({ yes: true, json: true, restart: false })).rejects.toBe(
@@ -336,7 +254,7 @@ describe("update command admission with fresh state", () => {
     expect(staged.close).toHaveBeenCalledOnce();
     expect(release).toHaveBeenCalledOnce();
     expect(staged.run).not.toHaveBeenCalled();
-    expect(createManagedHandoffLeaseStore().read(root).kind).toBe("absent");
+    expect(createManagedHandoffLeaseStore().read(fixture.root).kind).toBe("absent");
     expect(defaultRuntime.writeJson).not.toHaveBeenCalled();
   });
 
@@ -345,18 +263,22 @@ describe("update command admission with fresh state", () => {
       ok: true,
       value: {},
     });
-    const staged = { root, run: vi.fn(), close: vi.fn().mockResolvedValue(undefined) };
+    const staged = {
+      root: fixture.root,
+      run: vi.fn(),
+      close: vi.fn().mockResolvedValue(undefined),
+    };
     vi.mocked(packageUpdate.stagePackageInstallUpdate).mockResolvedValue(staged);
     vi.spyOn(initialization, "initializeUpdateStateFromTarget").mockImplementation(async () => {
       createSelectedTargetStateDatabase();
-      vi.stubEnv("OPENCLAW_STATE_DIR", path.join(path.dirname(root), "changed-profile"));
+      vi.stubEnv("OPENCLAW_STATE_DIR", path.join(path.dirname(fixture.root), "changed-profile"));
     });
     const observations: { boundary: string; closed: boolean; lease: string }[] = [];
     const observe = (boundary: string) => {
       observations.push({
         boundary,
         closed: staged.close.mock.calls.length === 1,
-        lease: createManagedHandoffLeaseStore().read(root).kind,
+        lease: createManagedHandoffLeaseStore().read(fixture.root).kind,
       });
     };
     vi.mocked(defaultRuntime.writeJson).mockImplementation(() => observe("report"));
@@ -416,12 +338,12 @@ describe("update command admission with fresh state", () => {
       );
       let leaseAtPublication: string | undefined;
       vi.mocked(defaultRuntime.writeJson).mockImplementation(() => {
-        leaseAtPublication = createManagedHandoffLeaseStore().read(root).kind;
+        leaseAtPublication = createManagedHandoffLeaseStore().read(fixture.root).kind;
       });
       let outputAtCleanup = -1;
       let historyAtCleanup: string | undefined;
       const staged = {
-        root,
+        root: fixture.root,
         run: vi.fn(),
         close: vi.fn().mockImplementation(async () => {
           outputAtCleanup = vi.mocked(defaultRuntime.writeJson).mock.calls.length;
@@ -448,7 +370,7 @@ describe("update command admission with fresh state", () => {
       };
       vi.mocked(packageUpdate.stagePackageInstallUpdate).mockResolvedValue(staged);
       vi.spyOn(initialization, "initializeUpdateStateFromTarget").mockImplementation(async () => {
-        expect(fs.existsSync(databasePath)).toBe(false);
+        expect(fs.existsSync(fixture.databasePath)).toBe(false);
         createSelectedTargetStateDatabase();
       });
       vi.spyOn(execution, "executeMutableUpdate").mockImplementation(async (params) => {
@@ -459,13 +381,13 @@ describe("update command admission with fresh state", () => {
         const result = {
           status: "ok" as const,
           mode: "npm" as const,
-          root,
+          root: fixture.root,
           steps: [],
           durationMs: 1,
         };
         const publish = async (failure?: unknown) => {
           const settled = await resolveSettledUpdateCommandResult(
-            { opts: params.opts, root },
+            { opts: params.opts, root: fixture.root },
             result,
             failure,
           );
@@ -580,7 +502,7 @@ describe("update command admission with fresh state", () => {
   ])(
     "limits fresh-state Node fallback to the service it will refresh (owned=$owned, restart=$restart)",
     async ({ owned, restart, expectedFallback }) => {
-      managedServiceNodeRunner = "/service/node";
+      fixture.managedServiceNodeRunner = "/service/node";
       vi.spyOn(shared, "resolveNodeRunner").mockReturnValue("/current/node");
       vi.spyOn(servicePlan, "gatewayServiceCommandUsesRoot").mockResolvedValue(owned);
       const runtimePreflight = vi
@@ -686,7 +608,11 @@ describe("update command admission with fresh state", () => {
       ok: true,
       value: {},
     });
-    const staged = { root, run: vi.fn(), close: vi.fn().mockResolvedValue(undefined) };
+    const staged = {
+      root: fixture.root,
+      run: vi.fn(),
+      close: vi.fn().mockResolvedValue(undefined),
+    };
     vi.mocked(packageUpdate.stagePackageInstallUpdate).mockImplementationOnce(async () => {
       writeStoredChannel("beta");
       return staged;
@@ -708,7 +634,7 @@ describe("update command admission with fresh state", () => {
     expect(JSON.parse(fs.readFileSync(configPath, "utf8"))).toEqual({
       update: { channel: "beta" },
     });
-    expect(fs.existsSync(databasePath)).toBe(false);
+    expect(fs.existsSync(fixture.databasePath)).toBe(false);
   });
 
   it("accepts target Doctor config changes that preserve the selected stored channel", async () => {
@@ -717,7 +643,11 @@ describe("update command admission with fresh state", () => {
       ok: true,
       value: {},
     });
-    const staged = { root, run: vi.fn(), close: vi.fn().mockResolvedValue(undefined) };
+    const staged = {
+      root: fixture.root,
+      run: vi.fn(),
+      close: vi.fn().mockResolvedValue(undefined),
+    };
     vi.mocked(packageUpdate.stagePackageInstallUpdate).mockResolvedValue(staged);
     const migrated = {
       update: { channel: "stable" },
@@ -741,7 +671,7 @@ describe("update command admission with fresh state", () => {
     expect(JSON.parse(fs.readFileSync(configPath, "utf8"))).toEqual(migrated);
     expect(staged.close).toHaveBeenCalledOnce();
     expect(staged.run).not.toHaveBeenCalled();
-    expect(fs.existsSync(databasePath)).toBe(false);
+    expect(fs.existsSync(fixture.databasePath)).toBe(false);
   });
 
   it("keeps fresh staging releasable for a supervised handoff before package activation", async () => {
@@ -762,7 +692,7 @@ describe("update command admission with fresh state", () => {
       value: {},
     });
     const staged = {
-      root,
+      root: fixture.root,
       run: vi.fn().mockRejectedValue(new Error("Unexpected package activation")),
       close: vi.fn().mockResolvedValue(undefined),
     };
@@ -780,8 +710,8 @@ describe("update command admission with fresh state", () => {
 
     expect(staged.close).toHaveBeenCalledOnce();
     expect(staged.run).not.toHaveBeenCalled();
-    expect(fs.existsSync(databasePath)).toBe(false);
-    expect(fs.readdirSync(root)).toEqual(["package.json"]);
+    expect(fs.existsSync(fixture.databasePath)).toBe(false);
+    expect(fs.readdirSync(fixture.root)).toEqual(["package.json"]);
   });
 });
 
@@ -813,7 +743,7 @@ it("fresh local artifact reaches compatible target staging without creating pare
     () => "completed",
     (error: unknown) => (error instanceof Error ? error.message : "unknown"),
   );
-  expect(fs.existsSync(databasePath)).toBe(false);
+  expect(fs.existsSync(fixture.databasePath)).toBe(false);
   expect(outcome).toBe("artifact-staged");
 });
 
@@ -840,7 +770,7 @@ it.each([16, undefined] as const)(
       expect(privateState).not.toBe(process.env.OPENCLAW_STATE_DIR);
       expect(params.installEnv?.HOME).toBe(process.env.HOME);
       expect(params.managedServiceEnv?.OPENCLAW_STATE_DIR).toBe(process.env.OPENCLAW_STATE_DIR);
-      expect(fs.existsSync(databasePath)).toBe(false);
+      expect(fs.existsSync(fixture.databasePath)).toBe(false);
       return staged;
     });
     const runtime = vi
@@ -851,7 +781,7 @@ it.each([16, undefined] as const)(
       .mockImplementation(async (params) => {
         expect(params.root).toBe(candidate);
         expect(params.env.OPENCLAW_STATE_DIR).toBe(process.env.OPENCLAW_STATE_DIR);
-        expect(fs.existsSync(databasePath)).toBe(false);
+        expect(fs.existsSync(fixture.databasePath)).toBe(false);
         if (schema === 16) {
           createSelectedTargetStateDatabase();
         } else {
@@ -877,7 +807,7 @@ it.each([16, undefined] as const)(
     if (schema === undefined) {
       expect(doctor).not.toHaveBeenCalled();
       expect(admission).not.toHaveBeenCalled();
-      expect(fs.existsSync(databasePath)).toBe(false);
+      expect(fs.existsSync(fixture.databasePath)).toBe(false);
       expect(defaultRuntime.writeJson).toHaveBeenCalledWith(
         expect.objectContaining({ reason: "target-metadata-preflight" }),
       );
@@ -888,7 +818,7 @@ it.each([16, undefined] as const)(
         expect.objectContaining({ target: { version: "2026.9.2", nodeEngine: ">=22" } }),
       );
       expect(admission).toHaveBeenCalledOnce();
-      const db = new DatabaseSync(databasePath, { readOnly: true });
+      const db = new DatabaseSync(fixture.databasePath, { readOnly: true });
       try {
         expect(db.prepare("PRAGMA user_version").get()).toEqual({ user_version: schema });
       } finally {
@@ -918,7 +848,7 @@ it.each(["node", "concurrent-state"] as const)(
       if (fault === "concurrent-state") {
         openOpenClawStateDatabase();
         closeOpenClawStateDatabaseForTest();
-        previous = fs.readFileSync(databasePath);
+        previous = fs.readFileSync(fixture.databasePath);
       }
       return stage;
     });
@@ -944,9 +874,9 @@ it.each(["node", "concurrent-state"] as const)(
     expect(stage.run).not.toHaveBeenCalled();
     expect(stage.close).toHaveBeenCalledOnce();
     if (previous) {
-      expect(fs.readFileSync(databasePath)).toEqual(previous);
+      expect(fs.readFileSync(fixture.databasePath)).toEqual(previous);
     } else {
-      expect(fs.existsSync(databasePath)).toBe(false);
+      expect(fs.existsSync(fixture.databasePath)).toBe(false);
     }
   },
 );
@@ -981,7 +911,7 @@ it("requires confirmation for an inspected older artifact without a TTY", async 
   expect(doctor).not.toHaveBeenCalled();
   expect(admission).not.toHaveBeenCalled();
   expect(stage.close).toHaveBeenCalledOnce();
-  expect(fs.existsSync(databasePath)).toBe(false);
+  expect(fs.existsSync(fixture.databasePath)).toBe(false);
 });
 
 it.each([17, 18])(
@@ -1009,7 +939,7 @@ it.each([17, 18])(
       .mockImplementation(async () => {
         openOpenClawStateDatabase();
         closeOpenClawStateDatabaseForTest();
-        const db = new DatabaseSync(databasePath);
+        const db = new DatabaseSync(fixture.databasePath);
         try {
           db.exec(`PRAGMA user_version=${schema}; UPDATE schema_meta SET schema_version=${schema}`);
         } finally {
@@ -1021,7 +951,7 @@ it.each([17, 18])(
       .mockImplementation(async (params) => {
         const run = params.opts.run;
         assert(run);
-        const db = new DatabaseSync(databasePath, { readOnly: true });
+        const db = new DatabaseSync(fixture.databasePath, { readOnly: true });
         try {
           expect(db.prepare("PRAGMA user_version").get()).toEqual({ user_version: 17 });
         } finally {

--- a/src/cli/update-cli/update-command-fresh.test-support.ts
+++ b/src/cli/update-cli/update-command-fresh.test-support.ts
@@ -1,0 +1,107 @@
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, beforeEach, vi } from "vitest";
+import { createTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import * as tempRoot from "../../infra/tmp-openclaw-dir.js";
+import * as packageMetadata from "../../infra/update-check-package-target.js";
+import * as updateCheck from "../../infra/update-check.js";
+import * as updateGlobal from "../../infra/update-global.js";
+import { defaultRuntime } from "../../runtime.js";
+import * as processIdentity from "../../shared/pid-alive.js";
+import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
+import { resolveOpenClawStateSqlitePath } from "../../state/openclaw-state-db.paths.js";
+import { captureTargetDatabaseSchemaContext } from "./schema-preflight.js";
+import * as shared from "./shared.js";
+import * as databaseContext from "./update-command-database-context.js";
+import * as packageUpdate from "./update-command-package.js";
+import * as commandRun from "./update-command-run.js";
+import * as servicePlan from "./update-command-service-plan.js";
+
+export const targetMetadata = {
+  target: "2026.9.2",
+  version: "2026.9.2",
+  nodeEngine: null,
+  schemaVersions: { state: 16, agent: 19 },
+};
+
+export function installFreshUpdateFixture() {
+  const dirs = createTempDirTracker();
+  const fixture: { root: string; databasePath: string; managedServiceNodeRunner?: string } = {
+    root: "",
+    databasePath: "",
+  };
+  beforeEach(() => {
+    fixture.managedServiceNodeRunner = undefined;
+    const home = dirs.make("openclaw-update-fresh-preview-");
+    fixture.root = path.join(home, "installation");
+    fs.mkdirSync(fixture.root);
+    fs.writeFileSync(
+      path.join(fixture.root, "package.json"),
+      JSON.stringify({ name: "openclaw", version: "2026.9.3" }),
+    );
+    vi.stubEnv("HOME", home);
+    vi.stubEnv("OPENCLAW_STATE_DIR", path.join(home, "profile"));
+    vi.stubEnv("OPENCLAW_CONFIG_PATH", path.join(home, "profile", "openclaw.json"));
+    vi.stubEnv("OPENCLAW_UPDATE_RUN_ID", undefined);
+    vi.stubEnv("OPENCLAW_UPDATE_RUN_HANDOFF", undefined);
+    vi.stubEnv("OPENCLAW_UPDATE_POST_CORE", undefined);
+    fixture.databasePath = resolveOpenClawStateSqlitePath(process.env);
+    const executorRoot = path.join(home, "executor");
+    fs.mkdirSync(executorRoot);
+    vi.spyOn(tempRoot, "resolvePreferredOpenClawTmpDir").mockReturnValue(executorRoot);
+    // The macOS test sandbox denies /bin/ps. Keep real lease ownership and liveness,
+    // supplying only the stable self identity that the OS probe cannot read here.
+    vi.spyOn(processIdentity, "getFileLockProcessStartTime").mockImplementation((pid) =>
+      pid === process.pid ? 1_700_000_000 : null,
+    );
+    vi.spyOn(defaultRuntime, "writeJson").mockImplementation(() => undefined);
+    vi.spyOn(defaultRuntime, "error").mockImplementation(() => undefined);
+    vi.spyOn(commandRun, "prepareUpdateCommand").mockImplementation(async (opts) => ({
+      startedAt: Date.now(),
+      postCoreUpdateResume: false,
+      postCoreUpdateChannel: undefined,
+      timeoutMs: 5_000,
+      shouldRestart: opts.restart !== false,
+      requestedChannel: opts.channel === "stable" ? "stable" : null,
+      devTarget: undefined,
+      controlPlaneUpdateSentinelMeta: null,
+      discoveredRoot: fixture.root,
+      installKind: "package",
+      servicePlan: { rootRedirect: null, nodeRunner: fixture.managedServiceNodeRunner },
+    }));
+    vi.spyOn(servicePlan, "isGatewayServiceManagementAllowedForUpdate").mockReturnValue(false);
+    vi.spyOn(databaseContext, "inspectUpdateDatabaseContexts").mockImplementation(async () => ({
+      service: undefined,
+      services: new Map(),
+      contexts: [await captureTargetDatabaseSchemaContext(process.env)],
+      managedEnv: undefined,
+    }));
+    vi.spyOn(shared, "resolveGlobalManager").mockResolvedValue("npm");
+    vi.spyOn(shared, "resolveTargetVersion").mockResolvedValue("2026.9.2");
+    vi.spyOn(updateGlobal, "createGlobalInstallEnv").mockResolvedValue({ ...process.env });
+    vi.spyOn(updateGlobal, "resolveGlobalInstallTarget").mockResolvedValue({
+      manager: "npm",
+      command: "npm",
+      globalRoot: path.dirname(fixture.root),
+      packageRoot: fixture.root,
+      npmOwner: { version: "11.10.0", lifecyclePolicy: "unflagged" },
+    });
+    vi.spyOn(updateCheck, "resolveNpmChannelTag").mockResolvedValue({
+      tag: "latest",
+      version: "2026.9.2",
+    });
+    vi.spyOn(packageMetadata, "fetchNpmPackageTargetStatus").mockResolvedValue(targetMetadata);
+    vi.spyOn(packageUpdate, "stagePackageInstallUpdate").mockRejectedValue(
+      new Error("Read-only update admission must not stage a package"),
+    );
+  });
+
+  afterEach(() => {
+    closeOpenClawStateDatabaseForTest();
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+    dirs.cleanup();
+  });
+
+  return { fixture, dirs };
+}

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -1,4 +1,3 @@
-// Main update orchestration for source checkouts and package installs.
 import { randomUUID } from "node:crypto";
 import { theme } from "../../../packages/terminal-core/src/theme.js";
 import { resolveConfigPath } from "../../config/paths.js";
@@ -226,6 +225,7 @@ async function initializeAndRunUpdate(
             target.updateInstallKind === "package" &&
             !canResolveRegistryVersionForPackageTarget(target.packageInstallSpec ?? target.tag);
           const stageParams = (progress: ReturnType<typeof createUpdateProgress>["progress"]) => ({
+            reapplyLocalOverrides: opts.reapplyLocalOverrides,
             root: target.root,
             installKind: prepared.installKind,
             tag: target.tag,
@@ -671,7 +671,6 @@ async function updateCommandInternal(
   recoveryState.triageTarget.failureResult = result;
   recoveryState.triageTarget.env =
     recoveryEnv ?? ownedManagedUpdateContext?.env ?? recoveryState.triageTarget.env;
-  const finalizationConfigSnapshot = ownedManagedUpdateContext?.configSnapshot ?? configSnapshot;
   stop();
   const finalization = {
     ...executionState,
@@ -679,7 +678,7 @@ async function updateCommandInternal(
     root,
     previousInstallRoot: discoveredRoot,
     installKindChanged: switchToGit || switchToPackage,
-    configSnapshot: finalizationConfigSnapshot,
+    configSnapshot: ownedManagedUpdateContext?.configSnapshot ?? configSnapshot,
     requestedChannel,
     storedChannel,
     channel,
@@ -703,7 +702,7 @@ async function updateCommandInternal(
         packageUpdateNodeRunner,
         schemaVersions: execution.schemaVersions,
         candidateSchemaVersions: execution.candidateSchemaVersions,
-        config: finalizationConfigSnapshot.config,
+        config: finalization.configSnapshot.config,
         env: ownedManagedUpdateContext?.env ?? run.env,
       });
   run.executorFence?.assertCurrent();

--- a/src/infra/package-local-overrides-preflight.ts
+++ b/src/infra/package-local-overrides-preflight.ts
@@ -11,7 +11,6 @@ import {
   resolveSafePackagePath,
   type LocalPackageOverridesPlan,
   type LocalPackageOverridesResult,
-  type LocalPackageOverrideTargetProbe,
 } from "./package-local-overrides-shared.js";
 
 function buildCurrentInventoryMap(entries: PackageDistContentInventoryEntry[] | null) {
@@ -32,12 +31,10 @@ export async function preflightLocalOverrides(params: {
     symlinks: "reject",
   });
   const conflicts: LocalPackageOverridesResult["conflicts"] = [];
-  const targetProbes = new Map<string, LocalPackageOverrideTargetProbe>();
   for (const change of params.plan.changes) {
     const targetPath = resolveSafePackagePath(params.packageRoot, change.path);
     const nextEntry = nextInventory.get(change.path);
     const targetProbe = await probeLocalOverrideTarget(targetPath);
-    targetProbes.set(change.path, targetProbe);
     if (targetProbe.status === "error") {
       conflicts.push({ path: change.path, reason: "target-inspection-failed" });
       continue;

--- a/src/infra/package-local-overrides.ts
+++ b/src/infra/package-local-overrides.ts
@@ -23,6 +23,7 @@ import {
   probeLocalOverrideTarget,
   readLocalOverridePackageRootIdentity,
   resolveSafePackagePath,
+  writeFileWithMode,
   type LocalOverridePackageRoot,
   type LocalPackageOverrideChange,
   type LocalPackageOverrideConflictReason,
@@ -154,28 +155,6 @@ function createLocalOverrideMutationPath(relativePath: string, label: string): s
   );
 }
 
-async function moveLocalOverrideTargetNoReplace(params: {
-  packageFs: LocalOverridePackageRoot;
-  runtimeUrls: readonly string[];
-  sourcePath: string;
-  relativePath: string;
-  onMoved?: () => void;
-}): Promise<void> {
-  await runRequiredFsSafeMove(params);
-}
-
-async function writeRollbackBackup(params: {
-  backupPath: string;
-  content: Buffer;
-  mode: number;
-}): Promise<void> {
-  await fs.mkdir(path.dirname(params.backupPath), { recursive: true });
-  await fs.writeFile(params.backupPath, params.content);
-  if (process.platform !== "win32") {
-    await fs.chmod(params.backupPath, params.mode);
-  }
-}
-
 async function publishLocalOverrideTarget(params: {
   packageFs: LocalOverridePackageRoot;
   runtimeUrls: readonly string[];
@@ -193,7 +172,7 @@ async function publishLocalOverrideTarget(params: {
     realPackageRoot: params.packageFs.rootReal,
     relativePath: params.relativePath,
   });
-  await moveLocalOverrideTargetNoReplace({ ...params, onMoved: params.onPublished });
+  await runRequiredFsSafeMove({ ...params, onMoved: params.onPublished });
   await assertLocalOverrideMutationTopology({
     packageRoot: params.packageFs.rootDir,
     realPackageRoot: params.packageFs.rootReal,
@@ -265,7 +244,7 @@ async function moveExpectedLocalOverrideTarget(params: {
   const movedPath = createLocalOverrideMutationPath(params.relativePath, "previous");
   let targetMoved = false;
   try {
-    await moveLocalOverrideTargetNoReplace({
+    await runRequiredFsSafeMove({
       packageFs: params.packageFs,
       runtimeUrls: params.runtimeUrls,
       sourcePath: params.relativePath,
@@ -341,11 +320,7 @@ async function replaceLocalOverrideTarget(params: {
       if (replacementMode !== undefined) {
         replacementMode = mergeLocalOverrideFileMode(moved.mode, replacementMode);
       }
-      await writeRollbackBackup({
-        backupPath: params.backupPath,
-        content: moved.content,
-        mode: moved.mode,
-      });
+      await writeFileWithMode(moved.content, params.backupPath, moved.mode);
       backupWritten = true;
     }
     if (replacementMode !== undefined && process.platform !== "win32") {
@@ -405,11 +380,7 @@ async function deleteLocalOverrideTarget(params: {
   });
   let backupWritten = false;
   try {
-    await writeRollbackBackup({
-      backupPath: params.backupPath,
-      content: moved.content,
-      mode: moved.mode,
-    });
+    await writeFileWithMode(moved.content, params.backupPath, moved.mode);
     backupWritten = true;
     await params.packageFs.remove(moved.movedPath);
     await assertLocalOverrideMutationTopology({


### PR DESCRIPTION
Closes #145752

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where fresh-profile updates with `--reapply-local-overrides` succeeded but left local edits only in the recovery bundle instead of replaying them into the installation.

## Why This Change Was Made

Forward the existing option when staging starts, where the package runner captures replay policy. Keep replay and recovery with the existing transaction owner; remove redundant forwarding/write helpers and an unused probe map, and share the fresh-profile test fixture.

## User Impact

Explicit replay now restores trusted local edits and retains the recovery bundle. Without the flag, preservation-only behavior and its manual-recovery warning remain unchanged. Existing conflict and rollback handling stays intact.

## Evidence

- The real-npm fresh-profile regression fails before the fix only for replay. At `6678f617` plus this exact patch, all 176 selected tests across 13 files and the full pinned changed-source gate pass. The canonical runtime build passes; both native test process groups joined. Coverage includes package Doctor, config provenance, delegated Doctor requester revocation, and built-canary startup/cleanup.
- [Installed Linux Testbox proof](https://github.com/openclaw/openclaw/actions/runs/34670972157), pinned to `57674ef82592b712a17507539b6f89609d8547c2` plus the patch: published `openclaw@2026.9.4` bootstraps the candidate, then the installed candidate exercises the later replay flag. Flag off reports `preserved`, zero applied, installed file absent, recovery bytes/mode `0600` retained, and the expected warning. Flag on reports `applied`, one applied, correct installed bytes/mode `0600`, recovery retained, and no conflict/warning.
- Both installed cases start without a profile database and record eight fresh-artifact child events. All five product processes exit 0 with joined process trees, and all three updates report successful plugin maintenance. The task-owned Testbox is stopped. Verified wrapper assertions establish success; the later Actions status after cleanup is not the product result.
- The original proof also includes 92 focused tests, nine package-update end-to-end cases, the public package build and tarball/import checks, and final independent scoped review. Earlier failed transport/observer attempts and an incomplete review are preserved separately and excluded from passing proof. The current-candidate fixture was corrected to schema 20; the historical fixture remains schema 19.

Patch SHA-256: `0ff7c9a8fe7e3c5cc90a5a010bf34cd90540f4d3eabd863248e1146aad899102`. Installed candidate archive SHA-256: `3c5b33a762f90280c41e7ce38f1dad0798f9b1b51d7bb4a28befbbfcc67f0a6b`.

Installed proof uses isolated synthetic profiles, an inert added file, and `--no-restart`; replacement/deletion/conflict/rollback have existing suite coverage. No operator Gateway, service restart, live channel, or provider request was exercised. Source-only preflight through `354943cc` finds the six patch preimages unchanged; newer Doctor retirement/rehearsal behavior is not claimed as executed by the older proof. Native PR/current-head CI remains a landing gate.

Production code decreases by 30 lines; test/support grows by 173, for 143 additional maintained lines. This is a correctness repair, not booked code-reduction savings.
