### PR TITLE
fix(channels): keep join intro snapshots valid at the Unicode limit

### DIFF
--- a/src/channels/join-intro/join-intro-prompt.test.ts
+++ b/src/channels/join-intro/join-intro-prompt.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 import { buildChannelJoinIntroPrompt } from "./join-intro-prompt.js";
 
+const UNPAIRED_SURROGATE_RE =
+  /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/;
+
 describe("buildChannelJoinIntroPrompt", () => {
   it("caps the injected snapshot and drops the oldest messages before newer room evidence", () => {
     const prompt = buildChannelJoinIntroPrompt({
@@ -21,6 +24,41 @@ describe("buildChannelJoinIntroPrompt", () => {
     expect(snapshot).toContain("message-99");
     expect(snapshot).not.toContain("message-00");
     expect(snapshot?.indexOf("message-98")).toBeLessThan(snapshot?.indexOf("message-99") ?? -1);
+  });
+
+  it("does not split a surrogate pair when metadata fills the snapshot budget", () => {
+    const roomNamePrefix = "Room name: ";
+    const prompt = buildChannelJoinIntroPrompt({
+      context: {
+        title: `${"x".repeat(12_000 - roomNamePrefix.length - 1)}🙂tail`,
+      },
+    });
+    const snapshot = prompt.split("\n\nRoom context:\n")[1];
+
+    expect(snapshot).toBeDefined();
+    expect(snapshot?.length).toBeLessThanOrEqual(12_000);
+    expect(UNPAIRED_SURROGATE_RE.test(snapshot ?? "")).toBe(false);
+    expect(snapshot?.endsWith("x")).toBe(true);
+  });
+
+  it("does not split a surrogate pair when truncating one oversized recent message", () => {
+    const messageHeader = "\nRecent room messages:\n";
+    const senderPrefix = "Participant: ";
+    const prompt = buildChannelJoinIntroPrompt({
+      context: {
+        recentMessages: [
+          {
+            text: `${"x".repeat(12_000 - messageHeader.length - senderPrefix.length - 1)}🙂tail`,
+          },
+        ],
+      },
+    });
+    const snapshot = prompt.split("\n\nRoom context:\n")[1];
+
+    expect(snapshot).toBeDefined();
+    expect(snapshot?.length).toBeLessThanOrEqual(12_000);
+    expect(UNPAIRED_SURROGATE_RE.test(snapshot ?? "")).toBe(false);
+    expect(snapshot?.endsWith("x")).toBe(true);
   });
 
   it("grounds unreadable room history in visible room facts and asks what the room needs", () => {

--- a/src/channels/join-intro/join-intro-prompt.ts
+++ b/src/channels/join-intro/join-intro-prompt.ts
@@ -1,3 +1,5 @@
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
+
 export type ChannelJoinedRoomContext = {
   /** Human room name, e.g. "#deploys" or "Design Team". */
   title?: string;
@@ -38,7 +40,7 @@ function formatChannelJoinRoomSnapshot(params: {
     roomFacts.push("Earlier room messages cannot be read on this platform.");
   }
 
-  const metadata = roomFacts.join("\n").slice(0, CHANNEL_JOIN_INTRO_MAX_SNAPSHOT_CHARS);
+  const metadata = truncateUtf16Safe(roomFacts.join("\n"), CHANNEL_JOIN_INTRO_MAX_SNAPSHOT_CHARS);
   const messageHeader = "\nRecent room messages:\n";
   let remaining = CHANNEL_JOIN_INTRO_MAX_SNAPSHOT_CHARS - metadata.length - messageHeader.length;
   const recentMessages = (context.recentMessages ?? []).flatMap((message) => {
@@ -52,7 +54,7 @@ function formatChannelJoinRoomSnapshot(params: {
     }
     if (line.length > remaining) {
       if (retained === 0) {
-        return `${metadata}${messageHeader}${line.slice(0, remaining)}`;
+        return `${metadata}${messageHeader}${truncateUtf16Safe(line, remaining)}`;
       }
       break;
     }


### PR DESCRIPTION
<!--
Optional linked context:
Add a visible `Closes #<issue-number>` or `Related: #<issue-number>` line
below this comment.

Required PR title:
type: user-facing description
Use a parenthesized scope only when it adds clarity:
fix(auth): login redirect loops when session cookie is expired

Types: feat, fix, improve, refactor, docs, chore.
For fixes, describe the user-visible symptom and trigger:
fix: task list fails to load when user has no environments
Avoid implementation details such as:
fix: add null check to task query
-->

No linked issue: two live GitHub searches found no open issue or pull request for join-intro UTF-16, surrogate, or truncation handling.

AI-assisted: Codex traced the join-intro prompt owner and caller, reused the canonical normalization helper, and ran the evidence below; the contributor reviewed the resulting diff.

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where a channel join introduction snapshot could contain invalid Unicode when room metadata or one recent message placed an emoji exactly across the 12,000-character boundary.

## Why This Change Was Made

Both bounded cuts now use the existing `truncateUtf16Safe` normalization primitive. The snapshot budget, room metadata ordering, recent-message retention order, prompt contract, and public/config surfaces remain unchanged.

## User Impact

Join introductions keep valid Unicode at the size limit, so downstream model and delivery paths no longer receive an isolated UTF-16 surrogate from a boundary emoji. Snapshots remain capped at 12,000 UTF-16 code units.

## Evidence

- Red-before: the two new boundary tests both failed with `expected true to be false`, proving metadata truncation and single-message truncation each emitted an unpaired surrogate.
- Green-after: `node scripts/run-vitest.mjs src/channels/join-intro/join-intro-prompt.test.ts` passed all 6 tests.
- Boundary proof: each regression case places `🙂` across the exact cut, asserts the extracted snapshot is at most 12,000 code units, rejects lone high/low surrogates, and confirms the safe cut backs off before the emoji.
- `./node_modules/.bin/oxfmt --check src/channels/join-intro/join-intro-prompt.ts src/channels/join-intro/join-intro-prompt.test.ts`
- `./node_modules/.bin/oxlint src/channels/join-intro/join-intro-prompt.ts src/channels/join-intro/join-intro-prompt.test.ts`
- `git diff --check`

### Real Gateway / Telegram join evidence (2026-09-16)

- Exact head: `476c9a9a28483cdf49f22e18c1cb038ce2f94595`.
- Command: `OPENCLAW_E2E_USE_PREBUILT_DIST=1 node scripts/run-vitest.mjs test/e2e/qa-lab/runtime/telegram-join-intro-gateway.e2e.test.ts --reporter=verbose` using a temporary boundary variant of the existing repository E2E; the temporary probe was removed after the run.
- Production path exercised: a real isolated Gateway process loaded the Telegram plugin, consumed an actual `my_chat_member` join update through Telegram long polling, ran the isolated agent turn through the mock OpenAI HTTP peer, and completed one native Telegram `sendMessage` call against the controlled transport peer. This is a controlled-peer E2E, not a live Telegram-account run.
- Boundary input: the room title placed `🙂` across the 12,000-code-unit metadata cut. Head completed with one grounded model response and exactly one delivery (`Boundary room introduction delivered.`); the captured model input contained no unpaired surrogate and excluded the split emoji tail.
- Negative control remains the direct owner-boundary reproduction above: both regression cases fail on exact parent `69467d2ed8a5f8cdab22a17c4dd9ff99274bde49` and pass on head. For transparency, the full Gateway path on the parent still delivered because the later external-untrusted-content wrapper sanitized the malformed code unit before the provider request; that downstream sanitation is not treated as proof that the prompt builder was correct.
- Harness setup initially hit the workstation installed-service state-dir guard and a 5 GiB build heap limit. The successful proof used the repository source-plugin mode and a 6.5 GiB build heap, without stopping or mutating the installed Gateway service.
