### PR TITLE
improve(test): shorten updater signal tests

### DIFF
--- a/src/cli/update-cli/update-command-executor-native-runtime.test-support.ts
+++ b/src/cli/update-cli/update-command-executor-native-runtime.test-support.ts
@@ -2,6 +2,16 @@
 const currentModuleUrl = import.meta.url;
 
 export const updateExecutorNativeEntrypoints = {
+  commandRun: {
+    currentModuleUrl,
+    sourceWorkerName: "update-command-run",
+    distWorkerPath: "cli/update-cli/update-command-run.js",
+  },
+  retainedRecovery: {
+    currentModuleUrl,
+    sourceWorkerName: "../../infra/update-retained-recovery.test-support",
+    distWorkerPath: "infra/update-retained-recovery.test-support.js",
+  },
   executor: {
     currentModuleUrl,
     sourceWorkerName: "update-command-executor",

--- a/src/cli/update-cli/update-command-executor.test.ts
+++ b/src/cli/update-cli/update-command-executor.test.ts
@@ -276,7 +276,7 @@ describe("live update executor", () => {
 
   it("preserves an unreadable existing coordination database without repairing it", async () => {
     const database = path.join(temporary, "managed-update-handoffs.sqlite");
-    fs.writeFileSync(database, "unreadable native owner");
+    fs.writeFileSync(database, "unreadable native owner", { mode: 0o600 });
     const before = fs.readFileSync(database);
     await expect(
       withUpdateCommandExecutor(randomUUID(), async (executor) => executor.enter(root)),

--- a/src/cli/update-cli/update-command-mutable-signals.test.ts
+++ b/src/cli/update-cli/update-command-mutable-signals.test.ts
@@ -4,8 +4,18 @@ import fs from "node:fs";
 import path from "node:path";
 import { afterEach, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import { cronOwnerHardeningEntrypoints } from "../../cron/owner-hardening-runtime.test-support.js";
+import { resolveRuntimeWorkerUrl } from "../../infra/runtime-worker-url.js";
+import { triageTestRuntimeEntrypoints } from "../../infra/triage-runtime.test-support.js";
 import { getUpdateRun, type createUpdateRun } from "../../infra/update-run-ledger.js";
 import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
+import { updateExecutorNativeEntrypoints } from "./update-command-executor-native-runtime.test-support.js";
+
+const sourceImportArgs = resolveRuntimeWorkerUrl(
+  updateExecutorNativeEntrypoints.executor,
+).pathname.endsWith(".ts")
+  ? ["--import", path.resolve("scripts/tsx.mjs")]
+  : [];
 
 const dirs = useAutoCleanupTempDirTracker((cleanup) =>
   afterEach(() => {
@@ -33,11 +43,11 @@ it.skipIf(process.platform === "win32").each([
       script,
       `
     import fs from 'node:fs';
-    import { createUpdateRun, finishUpdateRun, getUpdateRun, recordUpdateRunPhase } from ${JSON.stringify(new URL("../../infra/update-run-ledger.ts", import.meta.url).href)};
-    import { createRetainedUpdateRecovery } from ${JSON.stringify(new URL("../../infra/update-retained-recovery.test-support.ts", import.meta.url).href)};
-    import { closeOpenClawStateDatabaseForTest } from ${JSON.stringify(new URL("../../state/openclaw-state-db.ts", import.meta.url).href)};
-    import { admitUpdateCommandRun, withUpdatePreviewSignals } from ${JSON.stringify(new URL("./update-command-run.ts", import.meta.url).href)};
-    import { withUpdateCommandExecutor } from ${JSON.stringify(new URL("./update-command-executor.ts", import.meta.url).href)};
+    import { createUpdateRun, finishUpdateRun, getUpdateRun, recordUpdateRunPhase } from ${JSON.stringify(resolveRuntimeWorkerUrl(triageTestRuntimeEntrypoints.updateRunLedger).href)};
+    import { createRetainedUpdateRecovery } from ${JSON.stringify(resolveRuntimeWorkerUrl(updateExecutorNativeEntrypoints.retainedRecovery).href)};
+    import { closeOpenClawStateDatabaseForTest } from ${JSON.stringify(resolveRuntimeWorkerUrl(cronOwnerHardeningEntrypoints.stateDatabase).href)};
+    import { admitUpdateCommandRun, withUpdatePreviewSignals } from ${JSON.stringify(resolveRuntimeWorkerUrl(updateExecutorNativeEntrypoints.commandRun).href)};
+    import { withUpdateCommandExecutor } from ${JSON.stringify(resolveRuntimeWorkerUrl(updateExecutorNativeEntrypoints.executor).href)};
     const root = ${JSON.stringify(root)};
     const mode = ${JSON.stringify(mode)};
     const opts = {};
@@ -74,7 +84,7 @@ it.skipIf(process.platform === "win32").each([
     });
   `,
     );
-    const child = spawn(process.execPath, ["--import", "./scripts/tsx.mjs", script], {
+    const child = spawn(process.execPath, [...sourceImportArgs, script], {
       cwd: process.cwd(),
       env: {
         ...process.env,


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Maintainers can edit this same-repository branch using their repository permissions. GitHub's **Allow edits from maintainers** toggle applies to cross-repository PRs.

</details>

## What Problem This Solves

The updater's ten real-signal tests repeatedly start the TypeScript loader in fresh child processes, adding avoidable work to the slow CLI test group. A separate corruption fixture also failed on machines with a group-writable default file mask, including Testbox.

## Why This Change Was Made

Each signal child now uses the existing invocation-scoped compiled runtime. Two test-only entry descriptors expose the admission and retained-recovery fixture; the ledger, database and executor descriptors are reused. All five imports resolve into the same compiled graph, preserving shared admission and database ownership. Source/watch execution retains its source loader.

The corruption fixture explicitly creates a private file, so it reaches the intended corrupt-content refusal instead of the separate unsafe-permissions recovery path.

## User Impact

No product runtime behavior, schema, configuration, shard count, test deadline or assertion changes. Every signal case still starts a fresh process, receives a real OS signal, joins cleanup and checks persisted run/sibling state. Production LOC is unchanged; the three test/support files add 27 lines and remove seven.

## Evidence

On the same source and dependencies, all ten signal cases passed before and after. Test/hook time fell from **56.633s to 16.677s**; total command time fell from **84.58s to 32.04s**. User plus system CPU fell from **125.30s to 43.74s**. Host load also fell from 53 to 31, so the full wall-time difference cannot be attributed solely to the patch; no memory saving is claimed.

The paired compiler preparations took 10.571s and 8.168s, with one additional source input and a net three additional outputs. A separate diagnostic preparation took 15.480s and verified the five concrete JavaScript entry URLs and all 4,579 output hashes before canonical disposal. Preparation varies with host load; the aggregate effect across CI's repeated preparations is not measured. The new fixture input is 5,059 bytes, and the two new stable output facades total 5,088 bytes; bundler hash propagation is not counted as thousands of independent new files.

The original corruption case failed under `umask 0002`: its default `0664` file correctly triggered unsafe-file quarantine. With explicit `0600` creation, the same rejection and byte-preservation assertions pass under `0002` and normal `0022`. Neighboring native executor, admission/schema, handoff database/recovery and URL-resolver checks passed **118 tests**, with one existing skip. This includes the current requester-revocation-before-Doctor case.

All selected changed-file checks passed, including core test types, scoped lint/format, ratchets, dependency guards and dead exports. Independent P2 review returned no findings on the final diff. [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34680677217) passed. In its [targeted Node job](https://github.com/openclaw/openclaw/actions/runs/34680677217/job/103518746561), all ten signal cases passed with rounded case times totaling **6.42 seconds**. This is targeted PR CI, not a paired main-run or whole-job timing comparison.
