### PR TITLE
fix(amazon-bedrock): model discovery no longer hangs on repeated page tokens

### DIFF
--- a/extensions/amazon-bedrock/discovery.test.ts
+++ b/extensions/amazon-bedrock/discovery.test.ts
@@ -542,6 +542,59 @@ describe("bedrock discovery", () => {
     expect(models.find((m) => m.id === "ap.anthropic.claude-sonnet-4-6")).toBeUndefined();
   });
 
+  it("rejects inference profile pagination that repeats a token", async () => {
+    const firstProfile = buildBedrockProfile("us.amazon.nova-micro-v1:0", "US Nova", [
+      "amazon.nova-micro-v1:0",
+    ]);
+    const secondProfile = buildBedrockProfile("eu.amazon.nova-micro-v1:0", "EU Nova", [
+      "amazon.nova-micro-v1:0",
+    ]);
+    sendMock
+      .mockResolvedValueOnce({ modelSummaries: [baseActiveAnthropicSummary] })
+      .mockResolvedValueOnce({
+        inferenceProfileSummaries: [firstProfile],
+        nextToken: "repeated-page",
+      })
+      .mockResolvedValueOnce({
+        inferenceProfileSummaries: [secondProfile],
+        nextToken: "repeated-page",
+      });
+
+    await expect(
+      discoverFreshBedrockModels({ region: "repeated-profile-page", clientFactory }),
+    ).rejects.toThrow("Bedrock ListInferenceProfiles repeated a pagination token");
+    expect(sendMock).toHaveBeenCalledTimes(3);
+    expect(destroyMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("collects inference profile pages with advancing tokens", async () => {
+    const firstProfile = buildBedrockProfile("us.amazon.nova-micro-v1:0", "US Nova", [
+      "amazon.nova-micro-v1:0",
+    ]);
+    const secondProfile = buildBedrockProfile("eu.amazon.nova-micro-v1:0", "EU Nova", [
+      "amazon.nova-micro-v1:0",
+    ]);
+    sendMock
+      .mockResolvedValueOnce({ modelSummaries: [] })
+      .mockResolvedValueOnce({
+        inferenceProfileSummaries: [firstProfile],
+        nextToken: "second-page",
+      })
+      .mockResolvedValueOnce({ inferenceProfileSummaries: [secondProfile] });
+
+    const models = await discoverFreshBedrockModels({
+      region: "advancing-profile-pages",
+      clientFactory,
+    });
+
+    expect(models.map((model) => model.id)).toEqual([
+      secondProfile.inferenceProfileId,
+      firstProfile.inferenceProfileId,
+    ]);
+    expect(sendMock).toHaveBeenCalledTimes(3);
+    expect(destroyMock).toHaveBeenCalledTimes(1);
+  });
+
   it.each(["foundation", "profiles", "profile-page"])(
     "rejects failed %s acquisition and retries the complete catalog",
     async (surface) => {

--- a/extensions/amazon-bedrock/discovery.ts
+++ b/extensions/amazon-bedrock/discovery.ts
@@ -384,6 +384,9 @@ async function fetchInferenceProfileSummaries(
   createListInferenceProfilesCommand: BedrockControlPlaneSdk["createListInferenceProfilesCommand"],
 ): Promise<InferenceProfileSummary[]> {
   const profiles: InferenceProfileSummary[] = [];
+  // A repeated service token makes no pagination progress and would otherwise
+  // block strict catalog acquisition forever instead of reporting a failed refresh.
+  const seenTokens = new Set<string>();
   let nextToken: string | undefined;
   do {
     const command = createListInferenceProfilesCommand({ nextToken });
@@ -395,6 +398,12 @@ async function fetchInferenceProfileSummaries(
       profiles.push(summary);
     }
     nextToken = response.nextToken;
+    if (nextToken) {
+      if (seenTokens.has(nextToken)) {
+        throw new Error("Bedrock ListInferenceProfiles repeated a pagination token");
+      }
+      seenTokens.add(nextToken);
+    }
   } while (nextToken);
   return profiles;
 }


### PR DESCRIPTION
No linked issue: found during a proactive source audit of provider discovery pagination.

## What Problem This Solves

Fixes an issue where users relying on automatic Amazon Bedrock model discovery could have the discovery request run indefinitely when `ListInferenceProfiles` returned a previously seen pagination token.

## Why This Change Was Made

Inference-profile discovery now tracks returned pagination tokens and fails the refresh explicitly when a token repeats, preserving the plugin's strict all-or-nothing discovery contract. Normal pagination with advancing tokens is unchanged.

## User Impact

Bedrock discovery now reports a failed refresh instead of silently looping forever on a non-advancing or cyclic service response. Successful multi-page profile discovery continues to return every page.

## Evidence

- Red-before: the new repeated-token test failed against the previous implementation after it issued a fourth request, with `Cannot read properties of undefined (reading 'inferenceProfileSummaries')`, proving the loop continued past the repeated second-page token.
- Green-after: `ESBUILD_BINARY_PATH=/tmp/openclaw-esbuild-0282/package/bin/esbuild node scripts/run-vitest.mjs extensions/amazon-bedrock/discovery.test.ts` — 1 file passed, 40 tests passed.
- Production-path proof: both new cases exercise `discoverBedrockModels` through the existing injected Bedrock control-plane client boundary, covering repeated-token failure and advancing-token accumulation.
- `pnpm format extensions/amazon-bedrock/discovery.ts extensions/amazon-bedrock/discovery.test.ts` — passed.
- `git diff --check` — passed.
- `node scripts/check-changed.mjs -- extensions/amazon-bedrock/discovery.ts extensions/amazon-bedrock/discovery.test.ts` — relevant conflict-marker and max-lines checks passed; the aggregate stopped on pre-existing assertion-ratchet increases in three unrelated `src/` files.
- Live GitHub duplicate search found no open or closed issue/PR for repeated Bedrock inference-profile pagination tokens; the only symbol match was the merged inference-profile discovery feature PR #61299.

AI-assisted: yes. Codex was used for source review, implementation, and test authoring; all listed evidence was run and inspected directly.

- Real AWS SDK transport before/after proof (no mocked `client.send`): a real `@aws-sdk/client-bedrock` `BedrockClient` used its normal command serializer, SigV4 signing, HTTP transport, and response deserializer against a controlled localhost Bedrock peer. Every captured request carried an AWS4 signature. A healthy two-page control made exactly two `ListInferenceProfiles` requests and completed on both revisions. With both pages returning `nextToken: "stuck-page"`, an exact-parent overlay of `27e810cf26256a27ef30743bb82823d7c1ded83e` issued a third identical signed request and reached the peer HTTP-409 sentinel. Exact head `c2f1c562000754490c9a22bd3017885aa92a1294` stopped after two signed requests with `Bedrock ListInferenceProfiles repeated a pagination token`. Command: `ESBUILD_BINARY_PATH=/tmp/openclaw-esbuild-0282/package/bin/esbuild node scripts/run-vitest.mjs extensions/amazon-bedrock/real-transport.proof.test.ts --reporter=verbose`. The temporary proof test and parent source overlay were removed; `git status` and `git diff --check` were clean afterward. This proves the production AWS SDK transport and paginator against a controlled peer, not a live AWS account occurrence.