### PR TITLE
test(ci): bound hosted tooling growth inventory

### DIFF
--- a/docs/help/testing/writing-tests.md
+++ b/docs/help/testing/writing-tests.md
@@ -64,6 +64,12 @@ Future evals should stay deterministic first:
 
 ## Adding regressions (guidance)
 
+For inventory-growth and capacity regressions, pass bounded synthetic inventories
+and fixed timing data through the real planner. Put the fixture at the capacity
+boundary and preserve coverage, ownership, and execution-budget assertions. Keep
+real-checkout inventory coverage in its integration tests instead of rebuilding
+the growing repository plan for every synthetic variation.
+
 When you fix a provider/model issue discovered in live:
 
 - Add a CI-safe regression if possible (mock/stub provider, or capture the exact request-shape transformation)

--- a/test/scripts/ci-node-test-plan.test.ts
+++ b/test/scripts/ci-node-test-plan.test.ts
@@ -2418,11 +2418,39 @@ describe("scripts/lib/ci-node-test-plan.mts", () => {
   });
 
   it("keeps hosted tooling within the GitHub job cap when its inventory grows", async () => {
-    // The checkout is fixed; keep real discovery caches while rebuilding each planner snapshot.
     const unitFastPaths = await vi.importActual<
       typeof import("../vitest/vitest.unit-fast-paths.mjs")
     >("../vitest/vitest.unit-fast-paths.mjs");
-    const trackedTestFiles = new Map<string, readonly string[]>();
+    // Fifty-six full-budget anchors leave 24 of the 80 jobs for tooling.
+    const anchors = Array.from({ length: 56 }, (_, index) => ({
+      config: `test/vitest/vitest.capacity-anchor-${index}.config.ts`,
+      name: `capacity-anchor-${index}`,
+      projects: [`test/vitest/vitest.capacity-anchor-${index}.config.ts`],
+    }));
+    const fixtureShards = [
+      ...anchors,
+      {
+        config: "test/vitest/vitest.full-core-tooling.config.ts",
+        name: "core-tooling",
+        projects: ["test/vitest/vitest.tooling.config.ts"],
+      },
+    ];
+    // Ten files per tooling family exercise full stripes and packable tails; the compiler
+    // fixture puts a stronger runner in a tail that can absorb smaller families.
+    const fixtureFiles = [
+      ...Array.from(
+        { length: 160 },
+        (_, index) => `test/scripts/fixture-${String(index).padStart(3, "0")}.test.ts`,
+      ),
+      "test/scripts/write-unified-entry-dts.test.ts",
+    ];
+    const fixtureTimings = Object.fromEntries([
+      ...anchors.map(({ name }): [string, number] => [name, 210]),
+      ...Array.from({ length: 16 }, (_, index): [string, number] => [
+        `core-tooling-${index + 1}`,
+        200,
+      ]),
+    ]);
     const options = {
       compactMode: "pull-request" as const,
       runnerBackend: "github",
@@ -2440,7 +2468,6 @@ describe("scripts/lib/ci-node-test-plan.mts", () => {
         "test/scripts/install-smoke-ref-admission.test.ts",
       ],
     ];
-    const growthFiles = new Set([inventoryGrowthFile, ...extraInventories.flat()]);
     const isHostedToolingGroup = (group: { shard_name: string }) =>
       /^core-tooling-\d+-hosted-\d+$/u.test(group.shard_name);
     const runnerRanks = new Map([
@@ -2453,38 +2480,40 @@ describe("scripts/lib/ci-node-test-plan.mts", () => {
       extraFiles: string[] = [],
     ) => {
       vi.resetModules();
-      vi.doMock("../vitest/vitest.unit-fast-paths.mjs", () => unitFastPaths);
-      vi.doMock("../../scripts/lib/list-test-files.mts", async (importOriginal) => {
-        const actual =
-          await importOriginal<typeof import("../../scripts/lib/list-test-files.mts")>();
-        return {
-          ...actual,
-          listTrackedTestFiles(rootDir: string, suffix = ".test.ts") {
-            const key = JSON.stringify([rootDir, suffix]);
-            let rawFiles = trackedTestFiles.get(key);
-            if (rawFiles === undefined) {
-              rawFiles = actual.listTrackedTestFiles(rootDir, suffix);
-              trackedTestFiles.set(key, rawFiles);
-            }
-            const files = rawFiles.filter((file) => !growthFiles.has(file));
-            return rootDir === "test" && (includeGrowthFile || extraFiles.length > 0)
-              ? [
-                  ...new Set([
-                    ...files,
-                    ...extraFiles,
-                    ...(includeGrowthFile ? [inventoryGrowthFile] : []),
-                  ]),
-                ].toSorted()
-              : files;
-          },
-        };
-      });
+      vi.doMock("../vitest/vitest.unit-fast-paths.mjs", () => ({
+        ...unitFastPaths,
+        getUnitFastTestFiles: () => [],
+        getUnitFastIsolatedTestFiles: () => [],
+        getUnitFastTimerTestFiles: () => [],
+        getUnitFastTestFilesForIncludePatterns: () => [],
+      }));
+      vi.doMock("../vitest/vitest.test-shards.mjs", async (importOriginal) => ({
+        ...(await importOriginal<typeof import("../vitest/vitest.test-shards.mjs")>()),
+        fullSuiteVitestShards: fixtureShards,
+      }));
+      vi.doMock("../../scripts/lib/ci-test-timings.mts", () => ({
+        ...testTimings,
+        readCompactGroupTimings: () => fixtureTimings,
+      }));
+      vi.doMock("../../scripts/lib/list-test-files.mts", () => ({
+        listTrackedTestFiles(rootDir: string) {
+          return rootDir === "test"
+            ? [
+                ...fixtureFiles,
+                ...extraFiles,
+                ...(includeGrowthFile ? [inventoryGrowthFile] : []),
+              ].toSorted()
+            : [];
+        },
+      }));
       try {
         const { createNodeTestShardBundles: createPlan } =
           await import("../../scripts/lib/ci-node-test-plan.mts");
         return createPlan(options);
       } finally {
         vi.doUnmock("../../scripts/lib/list-test-files.mts");
+        vi.doUnmock("../../scripts/lib/ci-test-timings.mts");
+        vi.doUnmock("../vitest/vitest.test-shards.mjs");
         vi.doUnmock("../vitest/vitest.unit-fast-paths.mjs");
         vi.resetModules();
       }
@@ -2494,6 +2523,8 @@ describe("scripts/lib/ci-node-test-plan.mts", () => {
       .flatMap((job) => job.groups)
       .filter(isNumberedToolingGroup)
       .flatMap((group) => group.includePatterns ?? []);
+    expect(baseline).toHaveLength(80);
+    expect(baselineToolingFiles.toSorted()).toEqual(fixtureFiles.toSorted());
     const grown = await createPlanWithInventory(true);
     const toolingGroups = grown.flatMap((job) => job.groups).filter(isNumberedToolingGroup);
     const toolingFiles = toolingGroups.flatMap((group) => group.includePatterns ?? []);


### PR DESCRIPTION
## What Problem This Solves

`test/scripts/ci-node-test-plan.test.ts > keeps hosted tooling within the GitHub job cap when its inventory grows` planned over the real, growing repository inventory twelve times per run and timed out at 120 s on a hosted runner this week (shard core-tooling-15-hosted-3, run 34142285775) on a PR that never touched it.

## Why This Change Was Made

The cap contract does not need the real inventory: the test now drives the twelve planning passes with bounded synthetic inventories that exercise the same growth shape, keeping every original assertion. Case time drops from 8.9 s to 0.6 s locally, and the test no longer gets slower as the repository grows. Production code is unchanged; the testing docs note the bounded-inventory convention.

## User Impact

None at runtime. Fewer spurious red shards for contributors.

## Evidence

- All 61 owner tests in the file pass; the changed case runs in 0.575 s versus 8.858 s before.
- `node scripts/check-changed.mjs` and `pnpm check:architecture` pass; independent review clean.
- Line delta: production 0, tests +60/−29, docs +6.

## Known Gaps

Two other hosted-CI flakes seen this week were investigated and not changed, because neither yielded an owner-side defect: the `update-dry-run-state.process` CLI spawn stall happened on an already-built, warmed CLI, and the native Mermaid browser failures in CI were permanent engine failures rather than a premature "delivered" signal. Both remain tracked separately.
