### PR TITLE
fix(plugins): take a fresh lifecycle lease when a channel starts so provider login can apply settings

### DIFF
--- a/src/gateway/server-channels.ts
+++ b/src/gateway/server-channels.ts
@@ -54,6 +54,7 @@ import {
   type PluginHttpRouteHandoff,
 } from "../plugins/http-registry.js";
 import { runPluginCleanup } from "../plugins/plugin-instance-scope.js";
+import { runOutsidePluginLifecycleLease } from "../plugins/plugin-lifecycle-lease.js";
 import type { PluginRegistry } from "../plugins/registry.js";
 import { withPluginRuntimeRegistryScope } from "../plugins/runtime/gateway-request-scope.js";
 import { runOutsidePluginRuntimeGenerationScope } from "../plugins/runtime/generation-scope.js";
@@ -217,43 +218,9 @@ type ChannelManagerOptions = {
   getPluginRegistry: () => PluginRegistry;
   channelLogs: Partial<Record<ChannelId, SubsystemLogger>>;
   channelRuntimeEnvs: Partial<Record<ChannelId, RuntimeEnv>>;
-  /**
-   * Optional channel runtime helpers for channel plugins.
-   *
-   * When provided, this value is passed to all channel plugins via the
-   * `channelRuntime` field in `ChannelGatewayContext`, enabling external
-   * plugins to access Plugin SDK channel features (AI dispatch, routing,
-   * session management, startup runtime contexts, text processing, etc.).
-   *
-   * This field is optional - omitting it maintains backward compatibility
-   * with existing channels. When provided, it must be a real
-   * `createPluginRuntime().channel` surface; partial stubs are not supported.
-   *
-   * @example
-   * ```typescript
-   * import { createPluginRuntime } from "../plugins/runtime/index.js";
-   *
-   * const channelManager = createChannelManager({
-   *   getRuntimeConfig,
-   *   getPluginRegistry,
-   *   channelLogs,
-   *   channelRuntimeEnvs,
-   *   channelRuntime: createPluginRuntime().channel,
-   * });
-   * ```
-   *
-   * @since Plugin SDK 2026.2.19
-   * @see {@link ChannelGatewayContext.channelRuntime}
-   */
+  /** Supply the complete createPluginRuntime().channel surface; partial stubs are unsupported. */
   channelRuntime?: PluginRuntimeChannel;
-  /**
-   * Lazily resolves optional channel runtime helpers for channel plugins.
-   *
-   * Use this when the caller wants to avoid instantiating the full plugin channel
-   * runtime during gateway startup. The manager only needs the runtime surface once
-   * a channel account actually starts. The resolved value must be a real
-   * `createPluginRuntime().channel` surface.
-   */
+  /** Resolve the same complete surface only when a channel account starts. */
   resolveChannelRuntime?: () => PluginRuntimeChannel | Promise<PluginRuntimeChannel>;
   startupTrace?: GatewayStartupTrace;
   deferStartupAccountStartsUntil?: Promise<void>;
@@ -1230,11 +1197,13 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
     return startOutcomes;
   };
 
-  // Detach stale request generations before selecting this Gateway's registry.
+  // Channel tasks outlive the reload lease and request generation that started them.
   const startChannelInternal: ChannelManager["startChannel"] = (...args) =>
-    runOutsideGatewayRootWorkAdmission(() =>
-      runOutsidePluginRuntimeGenerationScope(() =>
-        withRegistry((registry) => startChannelProcessOwned(registry, ...args)),
+    runOutsidePluginLifecycleLease(() =>
+      runOutsideGatewayRootWorkAdmission(() =>
+        runOutsidePluginRuntimeGenerationScope(() =>
+          withRegistry((registry) => startChannelProcessOwned(registry, ...args)),
+        ),
       ),
     );
 

--- a/src/gateway/server-reload-channel-restart.test.ts
+++ b/src/gateway/server-reload-channel-restart.test.ts
@@ -1,6 +1,10 @@
+import assert from "node:assert/strict";
 import { afterEach, expect, it, vi } from "vitest";
-import { createDeferred } from "../../test/helpers/promise.js";
+import { createDeferred, withTestTimeout } from "../../test/helpers/promise.js";
 import type { ChannelPlugin } from "../channels/plugins/types.js";
+import { readConfigFileSnapshot } from "../config/config.js";
+import { withPluginLifecycleLease } from "../plugins/plugin-lifecycle-lease.js";
+import { writeProviderAuthConfig } from "../plugins/provider-auth-config.js";
 import {
   createPluginRegistryOwner,
   requireActivePluginChannelRegistry,
@@ -9,7 +13,9 @@ import {
 } from "../plugins/runtime.js";
 import { resetGatewayWorkAdmission } from "../process/gateway-work-admission.js";
 import { createChannelTestPluginBase, createTestRegistry } from "../test-utils/channel-plugins.js";
+import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import type { ChannelKind } from "./config-reload-plan.js";
+import { startGatewayConfigReloader } from "./config-reload.js";
 import { createChannelManager, type ChannelManager } from "./server-channels.js";
 import { restartGatewayChannels } from "./server-reload-channel-restart.js";
 
@@ -48,6 +54,138 @@ afterEach(async () => {
   manager = undefined;
   resetPluginRuntimeStateForTest();
   resetGatewayWorkAdmission();
+});
+
+it("the config watcher restarts a channel that can save provider settings after reload closes", async () => {
+  await withOpenClawTestState({ label: "channel-reload-login" }, async (state) => {
+    const initialConfig = {
+      gateway: { reload: { mode: "hybrid" as const } },
+      commands: { ownerAllowFrom: ["telegram:1"] },
+    };
+    await state.writeConfig(initialConfig);
+    const initial = await readConfigFileSnapshot();
+    expect(initial.valid, JSON.stringify(initial.issues)).toBe(true);
+    const login = createDeferred();
+    const restarted = createDeferred();
+    const saved = createDeferred();
+    const savedResult = saved.promise.then(
+      () => undefined,
+      (error: unknown) => error,
+    );
+    const watcherReady = createDeferred();
+    let starts = 0;
+    const plugin: ChannelPlugin = {
+      ...createChannelTestPluginBase({ id: "telegram" }),
+      gateway: {
+        startAccount: async ({ abortSignal }) => {
+          const stopped = new Promise<void>((resolve) => {
+            abortSignal.addEventListener("abort", () => resolve(), { once: true });
+          });
+          if (++starts === 2) {
+            restarted.resolve();
+            await login.promise;
+            try {
+              const snapshot = await readConfigFileSnapshot();
+              await writeProviderAuthConfig({
+                config: snapshot.config,
+                configSnapshot: snapshot,
+                configPatch: {
+                  models: {
+                    providers: {
+                      "lease-fixture": {
+                        baseUrl: "https://fixture.invalid/v1",
+                        api: "openai-completions",
+                        models: [{ id: "account-model", name: "Account model" }],
+                      },
+                    },
+                  },
+                },
+                credentialsSaved: true,
+              });
+              saved.resolve();
+            } catch (error) {
+              saved.reject(error);
+            }
+          }
+          await stopped;
+        },
+      },
+    };
+    setActivePluginRegistry(createTestRegistry([{ pluginId: "telegram", plugin, source: "test" }]));
+    const owner = createChannelManager({
+      getRuntimeConfig: () => initialConfig,
+      getPluginRegistry: requireActivePluginChannelRegistry,
+      channelLogs: {},
+      channelRuntimeEnvs: {},
+    });
+    await owner.startChannel("telegram");
+    const log = {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn((message: string) => restarted.reject(new Error(message))),
+    };
+    let assertReloadOwned: (() => void) | undefined;
+    const reloader = startGatewayConfigReloader({
+      initialConfig,
+      initialSnapshotRawHash: initial.hash,
+      initialAuthoredConfig: initial.parsed,
+      initialSnapshotValid: initial.valid,
+      initialSnapshotIssues: initial.issues,
+      watchPath: state.configPath,
+      readSnapshot: () => readConfigFileSnapshot(),
+      onWatcherReady: watcherReady.resolve,
+      onNoopConfigCommit: async () => {},
+      onHotReload: async (plan, next, ownership) => {
+        await withPluginLifecycleLease({}, async (lease) => {
+          assertReloadOwned = () => lease.assertOwned();
+        });
+        await reloadChannels(
+          owner,
+          requireActivePluginChannelRegistry,
+          plan.restartChannels,
+          log,
+          (surface) => {
+            throw new Error(`unexpected restart recovery: ${surface}`);
+          },
+        );
+        ownership.markRuntimeCommitted(next, plan);
+        return { status: "applied" };
+      },
+      onRestart: () => {
+        throw new Error("unexpected Gateway restart");
+      },
+      log,
+    });
+    try {
+      await withTestTimeout(watcherReady.promise, 10_000, "config watcher did not start");
+      await reloader.ready;
+      await state.writeConfig({ ...initialConfig, commands: { ownerAllowFrom: ["telegram:2"] } });
+      await withTestTimeout(
+        restarted.promise,
+        10_000,
+        "config watcher did not restart the channel",
+      );
+      await expect.poll(() => reloader.isReloading()).toBe(false);
+      assert(assertReloadOwned);
+      expect(assertReloadOwned).toThrow(
+        "plugin lifecycle lease core:plugin-lifecycle/global was lost",
+      );
+      login.resolve();
+      await expect(
+        withTestTimeout(savedResult, 10_000, "provider settings write did not settle"),
+      ).resolves.toBeUndefined();
+      const persisted = await readConfigFileSnapshot();
+      expect(persisted.config.models?.providers?.["lease-fixture"]).toMatchObject({
+        baseUrl: "https://fixture.invalid/v1",
+        models: [{ id: "account-model", name: "Account model" }],
+      });
+      expect(log.error).not.toHaveBeenCalled();
+    } finally {
+      login.resolve();
+      await reloader.stop();
+      await owner.stopChannel("telegram");
+    }
+  });
 });
 
 it("retries failed teardown before admitting a replacement", async () => {

--- a/src/gateway/server-reload-channel-restart.test.ts
+++ b/src/gateway/server-reload-channel-restart.test.ts
@@ -65,6 +65,7 @@ it("the config watcher restarts a channel that can save provider settings after 
     await state.writeConfig(initialConfig);
     const initial = await readConfigFileSnapshot();
     expect(initial.valid, JSON.stringify(initial.issues)).toBe(true);
+    assert(initial.hash);
     const login = createDeferred();
     const restarted = createDeferred();
     const saved = createDeferred();
@@ -149,7 +150,7 @@ it("the config watcher restarts a channel that can save provider settings after 
           },
         );
         ownership.markRuntimeCommitted(next, plan);
-        return { status: "applied" };
+        return "applied";
       },
       onRestart: () => {
         throw new Error("unexpected Gateway restart");


### PR DESCRIPTION
Related: #145484. @steipete: this repairs its channel-lifetime handoff while preserving live plugin reload.

## What Problem This Solves

After plugin reload, chat sign-in could save credentials but fail to apply connection settings, leaving the account partly configured.

## Why This Change Was Made

The channel manager clears inherited plugin lifecycle ownership when starting a channel. Later settings writes acquire current ownership instead of reusing the completed reload's closed lease. Startup, reload, and automatic restart share this boundary; a truly closed lease still rejects reuse.

## User Impact

Sign-in completes, account models appear, and the first turn works after reload. No configuration or migration change is required.

## Evidence

The registered config-watcher/channel-restart regression failed before the fix. All 176 channel tests passed afterward. Telegram login → /models → model selection → first turn passed with recorded provider responses. Browser sign-in and picker capture passed; opening the populated picker made no request. Concurrent login/reload checks preserved responsiveness. All 16 valid startup fixtures passed, with the invalid legacy fixture rejected as expected. Previous-release state retained saved credentials and transcript history through supported repair and sign-in. Continuous integration passed. Live provider entitlement was not tested.
