### PR TITLE
refactor(buzz): share directory query and limit policy

### DIFF
--- a/extensions/buzz/src/directory-config.ts
+++ b/extensions/buzz/src/directory-config.ts
@@ -2,32 +2,9 @@ import type {
   ChannelDirectoryEntry,
   DirectoryConfigParams,
 } from "openclaw/plugin-sdk/directory-runtime";
+import { applyBuzzDirectoryQueryAndLimit } from "./directory-query.js";
 import { buildBuzzTarget, parseBuzzTarget } from "./target.js";
 import { resolveBuzzAccount } from "./types.js";
-
-function applyQueryAndLimit(
-  entries: ChannelDirectoryEntry[],
-  params: DirectoryConfigParams,
-): ChannelDirectoryEntry[] {
-  const query = params.query?.trim().toLowerCase() ?? "";
-  const limit =
-    typeof params.limit === "number" && params.limit > 0 ? Math.floor(params.limit) : undefined;
-  const results: ChannelDirectoryEntry[] = [];
-  for (const entry of entries) {
-    if (
-      query &&
-      !entry.id.toLowerCase().includes(query) &&
-      !entry.name?.toLowerCase().includes(query)
-    ) {
-      continue;
-    }
-    results.push(entry);
-    if (limit !== undefined && results.length >= limit) {
-      break;
-    }
-  }
-  return results;
-}
 
 export async function listBuzzDirectoryPeersFromConfig(
   _params: DirectoryConfigParams,
@@ -51,5 +28,5 @@ export async function listBuzzDirectoryGroupsFromConfig(
       } satisfies ChannelDirectoryEntry;
     })
     .toSorted((a, b) => a.id.localeCompare(b.id));
-  return applyQueryAndLimit(entries, params);
+  return applyBuzzDirectoryQueryAndLimit(entries, params);
 }

--- a/extensions/buzz/src/directory-contract.test.ts
+++ b/extensions/buzz/src/directory-contract.test.ts
@@ -1,13 +1,12 @@
 // Buzz tests cover the lightweight config-backed directory contract.
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { describe, expect, it } from "vitest";
-import {
-  listBuzzDirectoryGroupsFromConfig,
-  listBuzzDirectoryPeersFromConfig,
-} from "../directory-contract-api.js";
+import { buzzDirectoryContractPlugin } from "../directory-contract-api.js";
 
 const ROOM_A = "7c4a6d2a-2ed9-4b4e-a5e2-4d705ee9b34c";
 const ROOM_B = "940d0c32-4eb7-46d7-9d5b-d975aaef87f7";
+const ROOM_C = "a11f29e0-21bc-43d9-b1b5-2b8bb3abc4ef";
+const ROOM_D = "cb710159-4fe8-4d82-a664-cd02e2994c91";
 
 describe("Buzz directory contract", () => {
   it("lists enabled configured rooms with query and limit filtering", async () => {
@@ -15,30 +14,41 @@ describe("Buzz directory contract", () => {
       channels: {
         buzz: {
           groups: {
+            [ROOM_D]: {},
             [ROOM_B]: { enabled: false },
+            [ROOM_C]: {},
             [ROOM_A]: {},
           },
         },
       },
     } as unknown as OpenClawConfig;
 
+    const all = [ROOM_A, ROOM_C, ROOM_D];
+    for (const [query, limit, rooms] of [
+      [ROOM_A.slice(0, 8).toUpperCase(), 1, [ROOM_A]],
+      ["  BUZZ:  ", 2, [ROOM_A, ROOM_C]],
+      ["  ", 1, [ROOM_A]],
+      [null, null, all],
+      ["missing", 1, []],
+    ] as const) {
+      await expect(
+        buzzDirectoryContractPlugin.directory.listGroups({
+          cfg,
+          accountId: "default",
+          query,
+          limit,
+        }),
+      ).resolves.toEqual(
+        rooms.map((roomId) => ({
+          kind: "group",
+          id: `buzz:${roomId}`,
+          name: roomId,
+          raw: { roomId },
+        })),
+      );
+    }
     await expect(
-      listBuzzDirectoryGroupsFromConfig({
-        cfg,
-        accountId: "default",
-        query: ROOM_A.slice(0, 8),
-        limit: 1,
-      }),
-    ).resolves.toEqual([
-      {
-        kind: "group",
-        id: `buzz:${ROOM_A}`,
-        name: ROOM_A,
-        raw: { roomId: ROOM_A },
-      },
-    ]);
-    await expect(
-      listBuzzDirectoryPeersFromConfig({
+      buzzDirectoryContractPlugin.directory.listPeers({
         cfg,
         accountId: "default",
         query: null,

--- a/extensions/buzz/src/directory-query.ts
+++ b/extensions/buzz/src/directory-query.ts
@@ -1,0 +1,28 @@
+import type { ChannelDirectoryEntry } from "openclaw/plugin-sdk/directory-runtime";
+
+function matchesDirectoryQuery(entry: ChannelDirectoryEntry, query: string): boolean {
+  if (!query) {
+    return true;
+  }
+  return [entry.id, entry.name, entry.handle].some((value) => value?.toLowerCase().includes(query));
+}
+
+export function applyBuzzDirectoryQueryAndLimit(
+  entries: ChannelDirectoryEntry[],
+  params: { query?: string | null; limit?: number | null },
+): ChannelDirectoryEntry[] {
+  const query = params.query?.trim().toLowerCase() ?? "";
+  const limit =
+    typeof params.limit === "number" && params.limit > 0 ? Math.floor(params.limit) : undefined;
+  const result: ChannelDirectoryEntry[] = [];
+  for (const entry of entries) {
+    if (!matchesDirectoryQuery(entry, query)) {
+      continue;
+    }
+    result.push(entry);
+    if (limit !== undefined && result.length >= limit) {
+      break;
+    }
+  }
+  return result;
+}

--- a/extensions/buzz/src/directory-state.test.ts
+++ b/extensions/buzz/src/directory-state.test.ts
@@ -174,7 +174,9 @@ describe("Buzz directory state", () => {
         name: "Engineering",
       }),
     ]);
-    expect(state.listGroupMembers({ groupId: `buzz:${ROOM_ID}`, limit: 2 })).toHaveLength(2);
+    expect(
+      state.listGroupMembers({ groupId: `buzz:${ROOM_ID}`, limit: 2 }).map((entry) => entry.id),
+    ).toEqual([ALICE_PUBLIC_KEY, BOB_PUBLIC_KEY]);
   });
 
   it("excludes rooms whose latest relay metadata marks them archived", () => {

--- a/extensions/buzz/src/directory-state.ts
+++ b/extensions/buzz/src/directory-state.ts
@@ -1,6 +1,7 @@
 import type { Event } from "nostr-tools";
 import type { ChannelDirectoryEntry } from "openclaw/plugin-sdk/directory-runtime";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
+import { applyBuzzDirectoryQueryAndLimit } from "./directory-query.js";
 import { isNewerBuzzRevision } from "./event-order.js";
 import type { BuzzMentionMember } from "./mentions.js";
 import type { BuzzRoomMembership } from "./room-membership.js";
@@ -60,33 +61,6 @@ function readPreferredString(params: {
 
 function fallbackPublicKeyLabel(publicKey: string): string {
   return `${publicKey.slice(0, 8)}...${publicKey.slice(-6)}`;
-}
-
-function matchesDirectoryQuery(entry: ChannelDirectoryEntry, query: string): boolean {
-  if (!query) {
-    return true;
-  }
-  return [entry.id, entry.name, entry.handle].some((value) => value?.toLowerCase().includes(query));
-}
-
-function applyQueryAndLimit(
-  entries: ChannelDirectoryEntry[],
-  params: { query?: string | null; limit?: number | null },
-): ChannelDirectoryEntry[] {
-  const query = params.query?.trim().toLowerCase() ?? "";
-  const limit =
-    typeof params.limit === "number" && params.limit > 0 ? Math.floor(params.limit) : undefined;
-  const result: ChannelDirectoryEntry[] = [];
-  for (const entry of entries) {
-    if (!matchesDirectoryQuery(entry, query)) {
-      continue;
-    }
-    result.push(entry);
-    if (limit !== undefined && result.length >= limit) {
-      break;
-    }
-  }
-  return result;
 }
 
 function parseBuzzDirectoryProfileEvent(event: Event): BuzzDirectoryProfile | undefined {
@@ -298,14 +272,14 @@ export class BuzzDirectoryState {
     const entries = [...peers]
       .map((publicKey) => this.#buildUserEntry(publicKey))
       .toSorted(compareDirectoryEntries);
-    return applyQueryAndLimit(entries, params);
+    return applyBuzzDirectoryQueryAndLimit(entries, params);
   }
 
   listGroups(params: { query?: string | null; limit?: number | null }): ChannelDirectoryEntry[] {
     const entries = this.activeRoomIds()
       .map((roomId) => this.#buildRoomEntry(roomId))
       .toSorted(compareDirectoryEntries);
-    return applyQueryAndLimit(entries, params);
+    return applyBuzzDirectoryQueryAndLimit(entries, params);
   }
 
   listGroupMembers(params: { groupId: string; limit?: number | null }): ChannelDirectoryEntry[] {
@@ -333,7 +307,7 @@ export class BuzzDirectoryState {
         return entry;
       })
       .toSorted(compareDirectoryEntries);
-    return applyQueryAndLimit(entries, { limit: params.limit });
+    return applyBuzzDirectoryQueryAndLimit(entries, { limit: params.limit });
   }
 
   mentionMembers(roomId: string): BuzzMentionMember[] | undefined {

--- a/extensions/buzz/src/directory.test.ts
+++ b/extensions/buzz/src/directory.test.ts
@@ -135,6 +135,7 @@ describe("Buzz live directory", () => {
               content: JSON.stringify({
                 display_name: "Alice",
                 picture: "https://example.com/alice.png",
+                nip05: "alice@example.com",
               }),
             }),
           );
@@ -195,6 +196,13 @@ describe("Buzz live directory", () => {
     ]);
     expect(relayMocks.auth).toHaveBeenCalledOnce();
     expect(relayMocks.close).toHaveBeenCalledOnce();
+    const peers = await listBuzzDirectoryPeersLive({
+      cfg,
+      accountId: "default",
+      query: "  @EXAMPLE.COM  ",
+      limit: 1,
+    });
+    expect(peers.map((entry) => entry.id)).toEqual([MEMBER_PUBLIC_KEY]);
   });
 
   it.each([


### PR DESCRIPTION
Closes #145762

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Maintainer-requested cleanup of duplicate Buzz directory filtering: configured groups and live/state directory listings maintain separate query/limit loops that can drift.

## Why This Change Was Made

Move the existing policy to one plugin-owned helper and migrate every caller. Config and state keep identity, membership, sorting, and lifecycle ownership; the helper preserves prepared entry objects and order, trimmed case-insensitive ID/name/handle matching, and existing limit behavior.

## User Impact

No intended behavior change, new SDK surface, schema, configuration option, or dependency. Existing directory results and limits remain intact.

## Evidence

All 34 original owner/sibling cases pass, including registered lightweight config listing, stable member order, and a padded uppercase handle query through the live-listing adapter. Final formatting, extension-test types, targeted lint, and whitespace checks pass. The full changed gate's unchanged production/import proof is retained from before the final test-only refinement; the final independent P2 review is clean.

The full build passes, including declarations and Doctor closures. Isolated Buzz entry import and a native Node probe of the built directory contract pass. Relay behavior uses the existing isolated mock-relay harness; no real relay, account credential, Gateway, or live state was exercised. Historical initial test expansions and proof remain separately identified.

Evidence is bound to `6678f617` plus the accepted patch (SHA-256 `84688e5c9feb563a5a29143929a66695e8e2bef2969b92e36729c572accdbca9`). Source-only preflight through `354943cc` finds Buzz unchanged. No newer runtime/CI execution is claimed. Production decreases by 20 code lines and tests grow by 20, so maintained code is unchanged; this is one policy owner with zero booked savings.
