### PR TITLE
fix: accept model JSON before trailing diagnostics

### DIFF
--- a/src/system-agent/setup-app-recommendations.test.ts
+++ b/src/system-agent/setup-app-recommendations.test.ts
@@ -345,6 +345,34 @@ describe("setup app recommendation matcher", () => {
     }
   });
 
+  it("uses the first complete object when prose contains later JSON", async () => {
+    const result = await getSetupAppRecommendations({
+      inventorySource,
+      runtime: defaultRuntime,
+      deps: {
+        ...candidateDeps,
+        complete: async () => ({
+          ok: true,
+          text: `${JSON.stringify({
+            matches: [
+              {
+                appLabel: "Notes",
+                candidateId: "@demo-owner/notes-tools",
+                tier: "recommended",
+                reason: "Connects directly to your notes",
+              },
+            ],
+          })}\nDiagnostics: {"tokens":12}`,
+        }),
+      },
+    });
+
+    expect(result.status).toBe("ok");
+    if (result.status === "ok") {
+      expect(result.matches[0]?.candidateId).toBe("@demo-owner/notes-tools");
+    }
+  });
+
   it("skips garbage model output", async () => {
     await expect(
       getSetupAppRecommendations({

--- a/src/system-agent/setup-app-recommendations.ts
+++ b/src/system-agent/setup-app-recommendations.ts
@@ -1,4 +1,4 @@
-import { safeParseJson } from "@openclaw/normalization-core";
+import { extractBalancedJsonPrefix, safeParseJson } from "@openclaw/normalization-core";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import pLimit from "p-limit";
@@ -286,14 +286,10 @@ async function gatherSetupAppCandidates(params: {
 }
 
 // Models routinely wrap JSON in markdown fences or prose despite "JSON only"
-// instructions; parse the outermost object instead of the raw text.
+// instructions; parse the first complete object instead of the raw text.
 function parseMatcherJson(text: string): unknown {
-  const start = text.indexOf("{");
-  const end = text.lastIndexOf("}");
-  if (start === -1 || end <= start) {
-    return null;
-  }
-  return safeParseJson(text.slice(start, end + 1)) ?? null;
+  const json = extractBalancedJsonPrefix(text, { openers: ["{"] })?.json;
+  return json ? (safeParseJson(json) ?? null) : null;
 }
 
 function buildMatcherPrompt(groups: SetupAppCandidateGroup[]): string {

--- a/src/transcripts/summary-model.test.ts
+++ b/src/transcripts/summary-model.test.ts
@@ -124,6 +124,19 @@ describe("model-backed transcript summaries", () => {
     expect(runIsolatedCompletion).toHaveBeenCalledOnce();
   });
 
+  it("uses the first complete object when prose contains later JSON", async () => {
+    runIsolatedCompletion.mockResolvedValue(
+      completion(`${JSON.stringify(notes)}\nDiagnostics: {"tokens":12}`),
+    );
+
+    expect(await summarizeTranscriptsWithModel(params)).toMatchObject({
+      ...notes,
+      overview: notes.overview.trim(),
+      source: "model",
+    });
+    expect(runIsolatedCompletion).toHaveBeenCalledOnce();
+  });
+
   it("tries the primary once after utility output is invalid", async () => {
     runIsolatedCompletion
       .mockResolvedValueOnce(completion("not JSON"))

--- a/src/transcripts/summary-model.ts
+++ b/src/transcripts/summary-model.ts
@@ -1,4 +1,7 @@
-import { resolvePositiveTimerTimeoutMs } from "@openclaw/normalization-core/number-coercion";
+import {
+  extractBalancedJsonPrefix,
+  resolvePositiveTimerTimeoutMs,
+} from "@openclaw/normalization-core";
 import { sliceUtf16Safe, truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { z } from "zod";
 import { createReasoningTagTextPartitioner } from "../../packages/markdown-core/src/reasoning-tags.js";
@@ -151,7 +154,7 @@ export async function summarizeTranscriptsWithModel(params: {
           .flatMap((delta) => (delta.kind === "text" ? [delta.text] : []))
           .join("");
         // Models may wrap the bounded visible response in fences or explanatory prose.
-        const object = visible.slice(visible.indexOf("{"), visible.lastIndexOf("}") + 1);
+        const object = extractBalancedJsonPrefix(visible, { openers: ["{"] })?.json ?? "";
         const notes = summarySchema.parse(JSON.parse(object));
         return {
           ...base,


### PR DESCRIPTION
## What Problem This Solves

Setup recommendations were discarded, and transcript summaries retried or fell back to heuristics, when a valid model JSON object was followed by diagnostics containing another object.

## User Impact

Both flows now accept the valid result before trailing diagnostics without an unnecessary model retry. Existing validation, candidate filtering, reasoning exclusion, sanitization, and fallback behavior remain unchanged.

## Why This Change Was Made

Reuse the existing balanced-JSON prefix extractor at both callers instead of slicing from the first opening brace through the last closing brace. No prompt, config, schema, provider, or persistence changes.

## Evidence

Retained proof from contributor head `114e0967c9977e22afba6f64181511a09524e817`, validated on a fresh, secretless AWS machine:

- A private deterministic production-flow harness exercised both callers through the real HTTP completion transport to a synthetic loopback peer, without mocked completion results. Plain-JSON transport qualification passed for both flows.
- With only the two original caller files from parent `27e810cf26256a27ef30743bb82823d7c1ded83e` overlaid, exactly the two trailing-diagnostics cases failed at their intended result assertions; eight controls passed. This was an old-caller overlay, not a full historical checkout.
- Restoring the candidate files and verifying their hashes produced 10/10 passing flow cases, with no skips. Positive cases asserted the accepted fields and exactly one completion request. Controls covered malformed and schema-invalid output, unknown candidates, heuristic fallback, and utility-to-primary fallback.
- The existing setup, model-summary, transcript-summary, and balanced-JSON suites passed 43/43 tests with no skips.
- Scoped `check:changed` passed, including formatting, core/core-test typechecks, dead-export scans, lint, and applicable guards. `git diff --check` passed. Fresh scoped review found no actionable P0-P2 issues.
- Its [CI freshness rerun](https://github.com/openclaw/openclaw/actions/runs/34680788998/attempts/2) exposed an unrelated native-hook-relay test publication race: one failure, 3,057 passes, and four skips in the affected shard. The existing main fix is [PR #145771](https://github.com/openclaw/openclaw/pull/145771); it awaits relay readiness without changing production behavior or timeouts. The superseded run ended cancelled.
- The subsequent `9479c110` [CI run](https://github.com/openclaw/openclaw/actions/runs/34827224026) failed on an obsolete Docker fixture assertion and two timeout cases outside this four-file patch. The one-line assertion repair landed separately in [PR #148129](https://github.com/openclaw/openclaw/pull/148129), with all 356 changed-file tests and its exact-head required CI passing. This refresh includes that repair through main ancestry. It does not claim to fix or relax the database-module or Bash child timeouts; their failed records remain distinct from the passing flow proof.

Candidate `5d983bd3449a39c0492f6480d116e03720373405` preserves the original contributor commit through signed main merges, most recently main `6b3e342ddb1e541f56b49b942d912cf8b376e24c` into `9479c1106ca6b0cf435a6b9beaf5f6c68931be63`. All four changed file blobs, the balanced-JSON helper, and its export barrel are identical to the proven head. The complete patch against refreshed main is byte-for-byte identical to the original patch; neither prerequisite repair was copied into this PR's four-file diff.

Historical candidate CI: [run 34837172055, attempt 1](https://github.com/openclaw/openclaw/actions/runs/34837172055/attempts/1) ended with 144 successful jobs, 17 skipped jobs, and failures in the [cron shard](https://github.com/openclaw/openclaw/actions/runs/34837172055/job/103956627956), [cache-retention shard](https://github.com/openclaw/openclaw/actions/runs/34837172055/job/103956628146), [desktop-stream shard](https://github.com/openclaw/openclaw/actions/runs/34837172055/job/103956628067), and [required gate](https://github.com/openclaw/openclaw/actions/runs/34837172055/job/103970405299). These failure records are retained separately from the recovered result below.

Bounded, secretless diagnostics on exact candidate `5d983bd3`, with unchanged assertions and deadlines:

- One isolated full-file cron invocation passed 17/17 tests; the coalesced cron/exec target passed in 5.445 seconds with a complete target trace and test cleanup. After the tests, the diagnostic controller exited 1 on process-enumeration `EACCES`. The trace limit was reached later, outside that target. There was no overlay-restoration receipt for this run; machine teardown completed containment.
- A second fresh isolated run executed only the previously unrun files: cache 1/1 and desktop 12/12 passed, with no failures or skips. Its controller exited 0, process joins and source-overlay restoration were verified, and capture validation passed, including the compiled child source/output binding. Both isolated machines were released.

Both runs used two-CPU availability, two workers, and plan concurrency one. They preserved each file's test order, but did not reproduce attempt 1 CI's multi-file shard order, caches, host contention, or RAM (about 65.97 GB versus attempt 1 CI's 8.22 GB). These results establish neither CI equivalence, a flake classification, nor a root cause. These isolated passes alone do not establish grounds for a CI retry or production change.

After independent review of the failed surfaces, one investigated failed-only retry used the existing GitHub-hosted fork-retry route on unchanged head `5d983bd3449a39c0492f6480d116e03720373405`. [Run 34837172055, attempt 2](https://github.com/openclaw/openclaw/actions/runs/34837172055/attempts/2) completed successfully with 148 passed jobs and 17 skipped jobs. The 144 prior successes retained their original execution evidence, and all 17 intentional skips remained unexecuted. Only the previously failed [cron shard](https://github.com/openclaw/openclaw/actions/runs/34837172055/job/103979983146), [cache-retention shard](https://github.com/openclaw/openclaw/actions/runs/34837172055/job/103979983035), [desktop-stream shard](https://github.com/openclaw/openclaw/actions/runs/34837172055/job/103979983020), and dependent [required gate](https://github.com/openclaw/openclaw/actions/runs/34837172055/job/103984697164) executed again; all passed, and the exact-head required-check readback passed. No source, assertions, timeouts, workflows, or runner settings were changed. This recovered required CI without identifying or fixing the original failure causes.

The retained `114e0967` production-flow proof above is separate from this candidate's CI and diagnostics; the 53 passing cases were not rerun on `5d983bd3`.

This is deterministic production-flow proof, not a live-provider test. The private harness and captures are not part of the patch.
