### PR TITLE
fix(team-reports): bound API response bodies

### DIFF
--- a/extensions/team-reports/src/sources/discord/client.ts
+++ b/extensions/team-reports/src/sources/discord/client.ts
@@ -1,11 +1,20 @@
 import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 import { z } from "zod";
 import type { DiscordSourceConfig, SourceRuntime, SourceStatus } from "../../types.js";
-import { checkAbort, parseApiBase, wait } from "../http.js";
+import {
+  checkAbort,
+  parseApiBase,
+  readSourceResponseText,
+  SourceResponseTooLargeError,
+  wait,
+} from "../http.js";
 
 const retrySchema = z.object({ retry_after: z.number().finite().nonnegative() });
 const timeoutMs = 30_000;
 export const ABORT_LABEL = "Discord collection aborted.";
+
+const exhaustedRequestError = () =>
+  new Error("Discord request failed after retries; check connectivity and API access.");
 
 export class DiscordHttpError extends Error {
   constructor(readonly status: number) {
@@ -51,7 +60,7 @@ export function createClient(
         response = result.response;
         release = result.release;
       }
-      const body = await response.text();
+      const body = await readSourceResponseText(response, "Discord", signal);
       checkAbort(runtime.signal, ABORT_LABEL);
       let data: unknown;
       try {
@@ -78,12 +87,13 @@ export function createClient(
         let result: Awaited<ReturnType<typeof request>>;
         try {
           result = await request(url.toString());
-        } catch {
+        } catch (error) {
           checkAbort(runtime.signal, ABORT_LABEL);
+          if (error instanceof SourceResponseTooLargeError) {
+            throw error;
+          }
           if (retries >= 2) {
-            throw new Error(
-              "Discord request failed after retries; check connectivity and API access.",
-            );
+            throw exhaustedRequestError();
           }
           await wait(1000 * 2 ** retries++, runtime.signal, ABORT_LABEL);
           continue;

--- a/extensions/team-reports/src/sources/discord/transport.test.ts
+++ b/extensions/team-reports/src/sources/discord/transport.test.ts
@@ -1,0 +1,30 @@
+import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
+import { beforeEach, expect, it, vi } from "vitest";
+import type { SourceStatus } from "../../types.js";
+import { oversizedResponse } from "../oversized-response.test-support.js";
+import { createClient } from "./client.js";
+import { config } from "./discord.fixtures.js";
+
+vi.mock("openclaw/plugin-sdk/ssrf-runtime", () => ({ fetchWithSsrFGuard: vi.fn() }));
+beforeEach(() => vi.clearAllMocks());
+
+it("cancels and releases an oversized API response with an actionable error", async () => {
+  const { response, cancellations } = oversizedResponse();
+  const release = vi.fn(async () => {
+    expect(response.bodyUsed).toBe(true);
+  });
+  vi.mocked(fetchWithSsrFGuard).mockResolvedValue({
+    response,
+    finalUrl: config.apiBaseUrl,
+    release,
+  });
+  const status: SourceStatus = { ok: true, warnings: [], stats: {} };
+  const client = createClient(config, { logger: { info() {}, warn() {}, error() {} } }, status);
+
+  await expect(client.get("/guilds/10/channels")).rejects.toThrow(
+    /response exceeded the 16 MiB safety limit.*compatibility.*retry/i,
+  );
+  await vi.waitFor(() => expect(cancellations()).toBe(1));
+  expect(release).toHaveBeenCalledOnce();
+  expect(fetchWithSsrFGuard).toHaveBeenCalledOnce();
+});

--- a/extensions/team-reports/src/sources/github/client.ts
+++ b/extensions/team-reports/src/sources/github/client.ts
@@ -2,7 +2,14 @@ import { parseRetryAfterHeaderSeconds } from "openclaw/plugin-sdk/retry-runtime"
 import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 import { z } from "zod";
 import type { GithubSourceConfig, SourceRuntime, SourceStatus } from "../../types.js";
-import { checkAbort, createResponseParser, parseApiBase, wait } from "../http.js";
+import {
+  checkAbort,
+  createResponseParser,
+  parseApiBase,
+  readSourceResponseText,
+  SourceResponseTooLargeError,
+  wait,
+} from "../http.js";
 
 export const ABORT_LABEL = "GitHub collection aborted";
 
@@ -116,7 +123,7 @@ export class GithubClient {
           response = result.response;
         }
         // Error payloads can echo credentials; neither parse errors nor API bodies escape this client.
-        const body = await response.text();
+        const body = await readSourceResponseText(response, "GitHub", signal);
         checkAbort(this.runtime.signal, ABORT_LABEL);
         if (response.ok) {
           try {
@@ -135,6 +142,9 @@ export class GithubClient {
         checkAbort(this.runtime.signal, ABORT_LABEL);
         if (error instanceof GithubSourceError) {
           throw error;
+        }
+        if (error instanceof SourceResponseTooLargeError) {
+          throw new GithubSourceError(error.message);
         }
         throw new GithubSourceError(
           controller.signal.aborted

--- a/extensions/team-reports/src/sources/github/transport.test.ts
+++ b/extensions/team-reports/src/sources/github/transport.test.ts
@@ -1,5 +1,6 @@
 import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 import { beforeEach, expect, it, vi } from "vitest";
+import { oversizedResponse } from "../oversized-response.test-support.js";
 import { createGithubSource } from "./index.js";
 import { config, logger } from "./responses.fixtures.js";
 
@@ -34,3 +35,24 @@ it.each([true, false])(
     expect(new Headers(options?.init?.headers).get("Authorization")).toBe(`Bearer ${config.token}`);
   },
 );
+
+it("cancels and releases an oversized API response with actionable status", async () => {
+  const { response, cancellations } = oversizedResponse();
+  const release = vi.fn(async () => {
+    expect(response.bodyUsed).toBe(true);
+  });
+  vi.mocked(fetchWithSsrFGuard).mockResolvedValue({
+    response,
+    finalUrl: config.apiBaseUrl,
+    release,
+  });
+
+  const result = await createGithubSource({ logger }).loadRoster(config);
+
+  expect(result.status.ok).toBe(false);
+  expect(result.status.warnings).toEqual([
+    expect.stringMatching(/response exceeded the 16 MiB safety limit.*compatibility.*retry/i),
+  ]);
+  await vi.waitFor(() => expect(cancellations()).toBe(1));
+  expect(release).toHaveBeenCalledOnce();
+});

--- a/extensions/team-reports/src/sources/http.ts
+++ b/extensions/team-reports/src/sources/http.ts
@@ -1,4 +1,22 @@
+import { readProviderTextResponse } from "openclaw/plugin-sdk/provider-http";
 import type { z } from "zod";
+
+export class SourceResponseTooLargeError extends Error {}
+
+export function readSourceResponseText(
+  response: Response,
+  source: string,
+  signal: AbortSignal,
+): Promise<string> {
+  // The SDK reader owns the byte/idle bounds and cancels overflow before guarded release.
+  return readProviderTextResponse(response, `Team Reports ${source} API`, {
+    signal,
+    onOverflow: ({ maxBytes }) =>
+      new SourceResponseTooLargeError(
+        `${source} API response exceeded the ${maxBytes / 1024 / 1024} MiB safety limit; check API compatibility and retry.`,
+      ),
+  });
+}
 
 export function createResponseParser(createError: () => Error) {
   return <T>(schema: z.ZodType<T>, data: unknown): T => {

--- a/extensions/team-reports/src/sources/oversized-response.test-support.ts
+++ b/extensions/team-reports/src/sources/oversized-response.test-support.ts
@@ -1,0 +1,25 @@
+const chunk = new Uint8Array(1024 * 1024).fill(0x20);
+
+export function oversizedResponse(): {
+  response: Response;
+  cancellations: () => number;
+} {
+  let chunks = 0;
+  let cancelCount = 0;
+  const body = new ReadableStream<Uint8Array>({
+    pull(controller) {
+      if (chunks++ < 18) {
+        controller.enqueue(chunk);
+      } else {
+        controller.close();
+      }
+    },
+    cancel() {
+      cancelCount += 1;
+    },
+  });
+  return {
+    response: new Response(body, { headers: { "content-type": "application/json" } }),
+    cancellations: () => cancelCount,
+  };
+}


### PR DESCRIPTION
## What Problem This Solves

Team Reports used `Response.text()` for GitHub and Discord collection. Timeouts bounded how long a request could run, but not how much response data it could buffer, so an incompatible or unexpectedly large API response could cause a memory spike.

## Why This Change Was Made

Both source clients now use the existing plugin SDK bounded provider-response reader through one Team Reports owner helper. Responses are capped at 16 MiB, overflow cancels the stream before guarded release, GitHub keeps its actionable status warning, and Discord does not retry a deterministic oversized response. Ordinary transient retries remain unchanged.

Production delta: +46/-8 lines (net +38); tests add +77 lines. The production growth is the shared source boundary plus source-specific error projection. No config, schema, protocol, or pagination behavior changes.

## User Impact

Oversized GitHub or Discord responses fail with a bounded, actionable compatibility warning instead of being fully buffered. Normal API pages and rate-limit behavior remain unchanged.

## Evidence

- Before the fix, a streamed 18 MiB response was fully consumed by `Response.text()` and was not cancelled.
- After the fix, true streamed overflow tests prove cancellation, guarded release, actionable GitHub status, and a single Discord request with no futile retries.
- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs run extensions/team-reports/src/sources/github/index.test.ts extensions/team-reports/src/sources/github/transport.test.ts extensions/team-reports/src/sources/discord/index.test.ts extensions/team-reports/src/sources/discord/transport.test.ts` — 66/66 passed on Vitest 5.
- The production reader was exercised against live public endpoints: GitHub returned HTTP 200 / 6,249 bytes and Discord returned HTTP 200 / 35 bytes, both parsed as objects. GitHub documents pagination limits of up to 100 items per page; Discord documents up to 100 messages per request and `Retry-After` handling.
- Focused `oxfmt`, `oxlint`, and `git diff --check` passed. Authenticated full-source collection was not run locally; exact-head CI owns the remaining suite.

- Real TLS transport negative control and after-fix proof (no mocked `Response` or mocked fetch): a localhost HTTPS peer streamed 18 MiB through the actual `GithubClient` and Discord `createClient`, with `globalThis.fetch` as the injected transport. On exact parent `27e810cf26256a27ef30743bb82823d7c1ded83e`, both clients read all 18,874,368 bytes before rejecting invalid JSON. On exact head `594dd2e8f0ce3adc6f291405c6aed87db9a96ef5`, both closed the peer after 16,908,288 bytes and returned the source-specific 16 MiB compatibility error. The peer observed one request for each overflow case; Discord did not retry. Normal `[]` controls resolved through both clients on both revisions. Command: `NODE_EXTRA_CA_CERTS=<ephemeral-ca> node scripts/run-vitest.mjs extensions/team-reports/src/sources/real-transport.proof.test.ts --reporter=verbose`; the temporary proof file and one-day certificate were outside the committed patch and the proof file was removed after both runs.