### PR TITLE
fix(update): bound candidate validation output

### DIFF
--- a/src/infra/update-candidate-canary.test.ts
+++ b/src/infra/update-candidate-canary.test.ts
@@ -557,6 +557,73 @@ describe("update candidate canary", () => {
     await expect(fs.access(childEnv.OPENCLAW_STATE_DIR!)).rejects.toMatchObject({ code: "ENOENT" });
   });
 
+  it("cancels the ready probe body without decoding it", async () => {
+    const readyResponse = Response.json({ ready: true });
+    const decodeReadyBody = vi.spyOn(readyResponse, "json");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string) =>
+        url.endsWith("startupz") ? Response.json({ status: "started" }) : readyResponse,
+      ),
+    );
+
+    const result = await validateUpdateCandidateCanary({
+      root,
+      stateDir: root,
+      config: {},
+      env: {},
+      timeoutMs: 3_000,
+    });
+
+    expect(result).toMatchObject({ status: "ok", phase: "readiness" });
+    expect(decodeReadyBody).not.toHaveBeenCalled();
+    expect(readyResponse.bodyUsed).toBe(true);
+  });
+
+  it("rejects an oversized streamed startup payload before advancing to readiness", async () => {
+    const encoded = new TextEncoder().encode(
+      JSON.stringify({ status: "started", padding: "x".repeat(128 * 1024) }),
+    );
+    let offset = 0;
+    let cancelled = false;
+    const startupResponse = new Response(
+      new ReadableStream<Uint8Array>({
+        pull(controller) {
+          if (offset >= encoded.length) {
+            controller.close();
+            return;
+          }
+          const next = encoded.subarray(offset, offset + 8 * 1024);
+          offset += next.length;
+          controller.enqueue(next);
+        },
+        cancel() {
+          cancelled = true;
+        },
+      }),
+    );
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        const gateway = [...children.values()].at(-1)!;
+        queueMicrotask(() => gateway.emit("close", 1));
+        return startupResponse;
+      }),
+    );
+
+    const result = await validateUpdateCandidateCanary({
+      root,
+      stateDir: root,
+      config: {},
+      env: {},
+      timeoutMs: 3_000,
+    });
+
+    expect(result).toMatchObject({ status: "error", phase: "startup" });
+    expect(cancelled).toBe(true);
+    expect(offset).toBeLessThan(encoded.length);
+  });
+
   it("reuses caller-owned rehearsal changes across validations until the caller disposes them", async () => {
     const config: OpenClawConfig = { logging: { level: "info" } };
     const observed: Array<{ configPath: string; level: string | undefined }> = [];

--- a/src/infra/update-candidate-canary.ts
+++ b/src/infra/update-candidate-canary.ts
@@ -14,6 +14,7 @@ import {
   type OpenClawSchemaVersions,
 } from "../state/openclaw-schema-versions.js";
 import { hasErrnoCode } from "./errors.js";
+import { cancelUnreadResponseBody, readResponseWithLimit } from "./http-body.js";
 import { readPackageVersion } from "./package-json.js";
 import { runtimeProcessEntrypoints } from "./runtime-process-entrypoints.js";
 import {
@@ -59,6 +60,9 @@ type CanaryResult = {
       reason: "doctor-failed" | "runtime-verification-failed";
     }
 );
+
+// Startup is a fixed small object; bound a malformed candidate before JSON decoding.
+const UPDATE_CANDIDATE_STARTUP_MAX_BYTES = 64 * 1024;
 
 async function waitBounded<T>(
   promise: Promise<T>,
@@ -485,16 +489,30 @@ export async function validateUpdateCandidateCanary(params: {
             throw new Error("Candidate gateway exited before readiness");
           }
           try {
+            const probeSignal = AbortSignal.any([
+              AbortSignal.timeout(Math.min(1_000, remaining())),
+              ...(params.signal ? [params.signal] : []),
+            ]);
             const response = await fetch(`http://127.0.0.1:${port}/${endpoint}`, {
-              signal: AbortSignal.any([
-                AbortSignal.timeout(Math.min(1_000, remaining())),
-                ...(params.signal ? [params.signal] : []),
-              ]),
+              signal: probeSignal,
             });
-            const payload: unknown = await response.json();
+            const startupPayload: unknown =
+              endpoint === "startupz"
+                ? JSON.parse(
+                    (
+                      await readResponseWithLimit(response, UPDATE_CANDIDATE_STARTUP_MAX_BYTES, {
+                        signal: probeSignal,
+                      })
+                    ).toString("utf8"),
+                  )
+                : undefined;
+            if (endpoint === "readyz") {
+              await cancelUnreadResponseBody(response);
+            }
             if (
               response.status === 200 &&
-              (endpoint === "readyz" || (isRecord(payload) && payload.status === "started"))
+              (endpoint === "readyz" ||
+                (isRecord(startupPayload) && startupPayload.status === "started"))
             ) {
               capture(
                 `${endpoint}: ${endpoint === "startupz" ? "started" : "ready"} (${Date.now() - started}ms)`,

--- a/src/infra/update-doctor-result.test.ts
+++ b/src/infra/update-doctor-result.test.ts
@@ -241,4 +241,17 @@ describe("post-install doctor result IPC", () => {
     await expect(consumeUpdatePostInstallDoctorResult(resultPath)).resolves.toBeNull();
     await expect(fs.access(resultPath)).rejects.toThrow();
   });
+
+  it("rejects and removes an oversized result without materializing the whole file", async () => {
+    const resultPath = createUpdatePostInstallDoctorResultPath();
+    resultPaths.push(resultPath);
+    await fs.writeFile(
+      resultPath,
+      JSON.stringify({ status: "ok", padding: "x".repeat(1024 * 1024) }),
+      { encoding: "utf8", mode: 0o600, flag: "wx" },
+    );
+
+    await expect(consumeUpdatePostInstallDoctorResult(resultPath)).resolves.toBeNull();
+    await expect(fs.access(resultPath)).rejects.toThrow();
+  });
 });

--- a/src/infra/update-doctor-result.ts
+++ b/src/infra/update-doctor-result.ts
@@ -6,6 +6,7 @@ import { isDeepStrictEqual } from "node:util";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { z } from "zod";
 import { ConfigMutationConflictError } from "../config/mutation-conflict.js";
+import { readRegularFile } from "./regular-file.js";
 import {
   resolvePreferredOpenClawTmpDir,
   type ResolvePreferredOpenClawTmpDirOptions,
@@ -25,6 +26,8 @@ export const UPDATE_POST_INSTALL_DOCTOR_RESULT_PATH_ENV =
 export const UPDATE_POST_INSTALL_DOCTOR_ADVISORY_EXIT_CODE = 86;
 const UPDATE_POST_INSTALL_DOCTOR_RESULT_FILENAME_RE =
   /^openclaw-update-doctor-\d+-[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\.json$/iu;
+// Match the existing candidate JSON ceiling while bounding pre-activation IPC allocation.
+const UPDATE_POST_INSTALL_DOCTOR_RESULT_MAX_BYTES = 1024 * 1024;
 
 export type PackageUpdateStepAdvisory = {
   kind: "package-post-install-doctor";
@@ -282,8 +285,11 @@ export async function consumeUpdatePostInstallDoctorResult(
     return null;
   }
   try {
-    const raw = await fs.readFile(safeResultPath, "utf8");
-    return parseUpdatePostInstallDoctorResult(JSON.parse(raw));
+    const { buffer } = await readRegularFile({
+      filePath: safeResultPath,
+      maxBytes: UPDATE_POST_INSTALL_DOCTOR_RESULT_MAX_BYTES,
+    });
+    return parseUpdatePostInstallDoctorResult(JSON.parse(buffer.toString("utf8")));
   } catch {
     return null;
   } finally {


### PR DESCRIPTION
## What Problem This Solves

Candidate update validation fully buffered gateway probe responses and the post-install Doctor receipt before validating them. A malformed or incompatible candidate could therefore make `openclaw update` allocate an unbounded response or file before failing safely.

## Why This Change Was Made

Read the fixed-shape `startupz` payload through the existing bounded response reader with a 64 KiB ceiling, consume no `readyz` payload, and read the Doctor receipt through the existing regular-file helper with a 1 MiB ceiling. The validation owner now enforces the bounds before JSON decoding while preserving readiness status checks and receipt cleanup.

Production delta: +32/-8 lines (net +24). The growth establishes the two missing allocation boundaries; tests add +80 lines. No config, schema, protocol, or normal candidate behavior changes.

## User Impact

Updates now reject oversized candidate validation output without continuing to read it into memory. Valid candidates and ordinary Doctor receipts behave as before, and rejected Doctor receipts are still removed.

## Evidence

- Before the fix, `response.json()` and `fs.readFile()` materialized their complete inputs. The regression stream could produce all 131,105 bytes, and an oversized receipt was read before rejection.
- After the fix, the streamed startup regression stops after 73,728 bytes, cancels the body, and never reaches readiness; the oversized on-disk receipt returns `null` and is deleted.
- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs run src/infra/update-candidate-canary.test.ts src/infra/update-doctor-result.test.ts` — 49/49 passed on Vitest 5.
- Focused `oxfmt`, `oxlint`, and `git diff --check` passed. Full-suite validation is delegated to exact-head CI.

### Real candidate Gateway validation (2026-09-16)

- Exact head: `9033f2e4f350f11afe25a922c009f1e1fce54835`.
- In a task-owned independent clone with physical dependencies, `NODE_OPTIONS=--max-old-space-size=6500 node scripts/run-vitest.mjs src/infra/update-candidate-canary.integration.test.ts --reporter=verbose` passed (1/1; candidate test 44.3s, shard 106.8s including build).
- This integration starts the built candidate as a real child Gateway with `--update-canary`, retains the occupied sandbox-port setting used by older/published updater handoff, observes successful `startupz: started` and `readyz: ready`, verifies the occupied listener remains intact, reaps the candidate process, and removes the rehearsal state. It exercises the ordinary candidate/Doctor/rehearsal path without touching the installed Gateway.
- This supplements, but does not replace, the bounded rejection tests above. No historical published updater binary was executed, and the open compatibility question for a legitimate Doctor receipt larger than 1 MiB remains unresolved; this run must not be read as proof that such receipts cannot occur.
- The shared PR worktree could not run this lane because its borrowed `node_modules` is intentionally non-reconcilable. The independent exact-head clone was used to satisfy the repository dependency-ownership rule; it remained detached and no source changes were made.
