### PR TITLE
refactor(desktop): use one native browser title observer

### DIFF
--- a/apps/linux/scripts/test-inline-browser.mjs
+++ b/apps/linux/scripts/test-inline-browser.mjs
@@ -342,10 +342,12 @@ try {
     await tabReady(firstId, `${base}/two`);
     assert.equal(await child.evaluate('window.fixtureName'), 'two');
   });
-  await record('SPA pushState, hash, and history navigation update native state', async () => {
+  await record('title-only changes and SPA history update native state', async () => {
     // Native Chromium Back skips history entries created without user activation.
     // Exercise the user-initiated SPA path, as with the popup interaction below.
-    await child.evaluate('history.pushState({fixture:true}, "", "/spa-pushed"); document.title="Inline fixture SPA"', true);
+    await child.evaluate('document.title="Inline fixture SPA"');
+    await until(async () => (await state()).tabs.find(tab => tab.id === firstId).title === 'Inline fixture SPA', 'title-only publication without navigation');
+    await child.evaluate('history.pushState({fixture:true}, "", "/spa-pushed")', true);
     await until(async () => { const tab = (await state()).tabs.find(tab => tab.id === firstId); return tab.url === `${base}/spa-pushed` && tab.title === 'Inline fixture SPA' && tab.canGoBack; }, 'SPA URL and title publication');
     await child.evaluate('location.hash="fixture-fragment"', true);
     await until(async () => (await state()).tabs.find(tab => tab.id === firstId).url === `${base}/spa-pushed#fixture-fragment`, 'hash URL publication');

--- a/apps/linux/src-tauri/src/native_browser.rs
+++ b/apps/linux/src-tauri/src/native_browser.rs
@@ -323,7 +323,6 @@ impl NativeBrowserState {
             let navigation_label = label.clone();
             let load_owner = self.clone();
             let load_clock = Arc::new(AtomicU64::new(0));
-            let title_owner = self.clone();
             let popup_owner = self.clone();
             let popup_app = app.clone();
             let popup_label = label.clone();
@@ -332,7 +331,6 @@ impl NativeBrowserState {
             let bootstrap = Arc::new(AtomicBool::new(true));
             let navigation_bootstrap = bootstrap.clone();
             let load_bootstrap = bootstrap.clone();
-            let title_bootstrap = bootstrap.clone();
             let navigation_epoch = Arc::new(AtomicU64::new(0));
             let navigation_clock = navigation_epoch.clone();
             let failed_epoch = Arc::new(AtomicU64::new(u64::MAX));
@@ -402,19 +400,6 @@ impl NativeBrowserState {
                         tab.url = view.url().map(|url| url.to_string()).unwrap_or(url);
                         tab.loading = !finished && tab.url != "about:blank";
                         tab.initial_finished |= finished;
-                        host.publish(view.app_handle());
-                    }
-                });
-            })
-            .on_document_title_changed(move |view, title| {
-                if title_bootstrap.load(Ordering::SeqCst) {
-                    return;
-                }
-                let owner = title_owner.clone();
-                tauri::async_runtime::spawn(async move {
-                    let mut host = owner.inner.lock().await;
-                    if let Some(tab) = host.tabs.iter_mut().find(|tab| tab.label == view.label()) {
-                        tab.title = title;
                         host.publish(view.app_handle());
                     }
                 });


### PR DESCRIPTION
Closes #145767

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Maintainer-requested cleanup of duplicate title-update processing in the Tauri companion's inline browser. Tabs currently schedule two updates for the same native title notification.

## Why This Change Was Made

Use the existing native navigation observer, which reads title, URL, and history together and rejects stale observations. Remove the second title callback and its captures. The existing browser scenario now waits for a title-only change before changing history. The complete change removes 15 production lines and adds two proof-script lines.

## User Impact

No intended user-visible change. Initial and dynamic titles, SPA history, dashboard reload, and tab lifecycle behavior remain intact. No new configuration or dependency is introduced.

## Evidence

- [Linux Testbox proof](https://github.com/openclaw/openclaw/actions/runs/34675605350): baseline `6678f617` and this candidate pass the same 18 ordered scenario steps, including independent title publication, SPA history/Back, native input, inspection/snapshots, dashboard reload/replacement, and exact save/cancel behavior. The task-only fixture extension preserves the existing assertions and deadlines.
- Ten focused Rust browser/authority tests pass on each Linux revision; macOS compilation and the same ten focused cases also pass. All 11 selected changed checks, Rustfmt, JavaScript syntax, and independent P2 review pass.
- Source binding: candidate `native_browser.rs` SHA-256 `b718dd488b598fd9375e5a07e26532c168953ab2051f30aafd377be5880c3489`; retained successful proof archive SHA-256 `15d8c550bc2723a3f7ceb1095bf497ffb4c3229534b36418aaee22d51e0c7100`.

These captures show preserved native viewport content. Title behavior is proved by the scenario assertions.

Before:

![Native browser viewport before consolidation](https://github.com/user-attachments/assets/a517a2f8-6be7-4c28-a796-4ccd5e3dafc1)

After:

![Native browser viewport after consolidation](https://github.com/user-attachments/assets/8d98e10a-cb12-47bd-af54-c5fe853f4388)

The first Linux attempt stopped after baseline title publication because xdotool waited for movement to its unchanged coordinates. Moving the pointer away fixed only the fixture, with unchanged assertions and deadlines. A review preflight also required the platform's private temporary directory. Windows script proof is syntax-only; Windows/macOS GUI behavior has source-equivalence evidence, not native execution. Live proof is pinned to `6678f617`; source-only preflight through `354943cc` finds the title owner and both edited files unchanged despite adjacent Omarchy integration. No newer native execution is claimed.
