### PR TITLE
fix(test): prevent worker shard timeouts on loaded hosts

### DIFF
--- a/src/gateway/worker-environments/worker-turn-detached-context.test.ts
+++ b/src/gateway/worker-environments/worker-turn-detached-context.test.ts
@@ -6,7 +6,6 @@ import {
   makeAgentUserMessage,
 } from "../../agents/test-helpers/agent-message-fixtures.js";
 import { upsertSessionEntryCore } from "../../config/sessions/session-accessor.js";
-import { withTimeout } from "../../infra/fs-safe.js";
 import { WorkerTaskPool } from "../../infra/worker-task-pool.js";
 import { createUserTurnTranscriptRecorder } from "../../sessions/user-turn-transcript.js";
 import { projectWorkerSessionTurnClaim } from "./placement-record.js";
@@ -23,7 +22,6 @@ import {
   credential,
   measureLaunchTurn,
   placements,
-  root as fixtureRoot,
   seedActivePlacement,
   sessionTarget,
   setupWorkerTurnLauncherTest,
@@ -132,16 +130,11 @@ async function launchProbe(input: SessionPlacementTurnParams, assertRunCurrent?:
     destroy: unexpected,
   };
   const provider = createWorkerSessionTurnPlacementProvider({ environments, placements });
-  const fixtureAbort = new AbortController();
+  hasUnjoinedOwner = true;
   const pending = provider
     .executeTurn(
       { sessionId: SESSION_ID, sessionKey: SESSION_KEY, agentId: "main", runId: input.runId },
-      {
-        ...input,
-        abortSignal: input.abortSignal
-          ? AbortSignal.any([input.abortSignal, fixtureAbort.signal])
-          : fixtureAbort.signal,
-      },
+      input,
       unexpected,
       undefined,
       assertRunCurrent,
@@ -150,27 +143,12 @@ async function launchProbe(input: SessionPlacementTurnParams, assertRunCurrent?:
       () => ({ kind: "resolved" as const }),
       (error: unknown) => ({ kind: "rejected" as const, error }),
     );
-  let outcome: Awaited<typeof pending> | undefined;
-  const failures: unknown[] = [];
+  let outcome: Awaited<typeof pending>;
   try {
-    outcome = await withTimeout(pending, input.timeoutMs, "worker functional launch observation");
-  } catch (error) {
-    failures.push(error);
-    fixtureAbort.abort(error);
-    try {
-      outcome = await withTimeout(pending, input.timeoutMs, "worker functional owner join");
-    } catch (joinError) {
-      failures.push(joinError);
-      hasUnjoinedOwner = true;
-    }
+    outcome = await pending;
   } finally {
+    hasUnjoinedOwner = false;
     input.preparedRunAdmission?.close();
-  }
-  if (failures.length > 0 || !outcome) {
-    throw new AggregateError(
-      failures,
-      `Worker functional proof did not settle in its budget; fixture state: ${fixtureRoot}`,
-    );
   }
   expect(placements.get(SESSION_ID)?.turnClaim).toBeNull();
   expect(placements.listPendingWorkspaceResults()).toHaveLength(0);
@@ -213,8 +191,6 @@ describe("worker detached model-context branch parity", () => {
       throw new Error("prior worker fixture remains unjoined; retained state must not be replaced");
     }
     await setupWorkerTurnLauncherTest();
-    // Source-worker initialization belongs to setup, outside the launch observation budget.
-    await SessionManager.openModelContextAsync(sessionTarget);
   });
   afterEach(async () => {
     if (!hasUnjoinedOwner) {
@@ -222,7 +198,7 @@ describe("worker detached model-context branch parity", () => {
     }
   });
 
-  it("keeps a pre-persisted current user out of replay and uses its exact base leaf", async () => {
+  it("waits for context readiness and keeps the pre-persisted current user out of replay", async () => {
     const { manager } = seedPrevious();
     const currentId = manager.appendMessage(
       makeAgentUserMessage({
@@ -230,12 +206,26 @@ describe("worker detached model-context branch parity", () => {
         timestamp: 3,
       }),
     );
-    const result = await launchProbe({
-      ...request("persisted-current"),
-      suppressNextUserMessagePersistence: true,
-    });
-    expect(result.launch).toEqual({ baseLeafId: currentId, history: prior });
-    expect(result.outcome).toEqual({ kind: "rejected", error: result.deliberateStop });
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+    try {
+      const { result } = await withAsyncReadHook(
+        {
+          // Readiness may arrive after the former fixture deadline on a loaded host.
+          before: async () => {
+            await vi.advanceTimersByTimeAsync(5_001);
+          },
+        },
+        () =>
+          launchProbe({
+            ...request("persisted-current"),
+            suppressNextUserMessagePersistence: true,
+          }),
+      );
+      expect(result.launch).toEqual({ baseLeafId: currentId, history: prior });
+      expect(result.outcome).toEqual({ kind: "rejected", error: result.deliberateStop });
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("joins recorder persistence already in flight during preparation", async () => {

--- a/src/gateway/worker-environments/worker-turn-transcript-footprint.test.ts
+++ b/src/gateway/worker-environments/worker-turn-transcript-footprint.test.ts
@@ -4,7 +4,6 @@ import {
   makeAgentAssistantMessage,
   makeAgentUserMessage,
 } from "../../agents/test-helpers/agent-message-fixtures.js";
-import { withTimeout } from "../../infra/fs-safe.js";
 import { createUserTurnTranscriptRecorder } from "../../sessions/user-turn-transcript.js";
 import { createDeferredCore } from "../../shared/deferred.js";
 import { WorkerRunnerUnavailableError } from "./tunnel-contract.js";
@@ -15,7 +14,6 @@ import {
   cleanupWorkerTurnLauncherTest,
   createWorkerSessionTurnPlacementProvider,
   placements,
-  root as fixtureRoot,
   seedActivePlacement,
   sessionTarget,
   setupWorkerTurnLauncherTest,
@@ -85,8 +83,6 @@ describe("Gateway worker-turn selected transcript preparation", () => {
       throw new Error("Prior worker fixture remains unjoined; retained state must not be replaced");
     }
     await setupWorkerTurnLauncherTest();
-    // Source-worker initialization belongs to setup, outside the launch observation budget.
-    await SessionManager.openModelContextAsync(sessionTarget);
   });
   afterEach(async () => {
     if (!hasUnjoinedOwner) {
@@ -178,6 +174,7 @@ describe("Gateway worker-turn selected transcript preparation", () => {
           return result;
         },
       });
+      hasUnjoinedOwner = true;
       const pending = provider
         .executeTurn(
           { sessionId: SESSION_ID, sessionKey: SESSION_KEY, agentId: "main", runId: request.runId },
@@ -194,16 +191,12 @@ describe("Gateway worker-turn selected transcript preparation", () => {
       const failures: unknown[] = [];
       let outcome: Awaited<typeof pending> | undefined;
       try {
-        await withTimeout(
-          Promise.race([
-            reachedCredential.promise,
-            pending.then(() => {
-              throw new Error("Turn settled before reaching credential acquisition");
-            }),
-          ]),
-          request.timeoutMs,
-          "worker transcript preparation",
-        );
+        await Promise.race([
+          reachedCredential.promise,
+          pending.then(() => {
+            throw new Error("Turn settled before reaching credential acquisition");
+          }),
+        ]);
         expect(contextCalls).toBe(1);
         expect(observation?.contextMessages).toBe(expectedMessages);
         expect(observation?.inactiveContextMessages).toBe(0);
@@ -222,12 +215,8 @@ describe("Gateway worker-turn selected transcript preparation", () => {
         releaseCredential.resolve();
         fixtureAbort.abort(deliberateStop);
         try {
-          outcome = await withTimeout(pending, request.timeoutMs, "worker preparation owner join");
-        } catch (error) {
-          hasUnjoinedOwner = true;
-          failures.push(
-            new Error(`Unjoined worker fixture retained at ${fixtureRoot}`, { cause: error }),
-          );
+          outcome = await pending;
+          hasUnjoinedOwner = false;
         } finally {
           try {
             request.preparedRunAdmission.close();

--- a/src/gateway/worker-environments/workspace-result-finalize.test.ts
+++ b/src/gateway/worker-environments/workspace-result-finalize.test.ts
@@ -152,7 +152,8 @@ describe("concurrent worker workspace results", () => {
     expect(placements.get(SESSION_ID)?.turnClaim).toBeNull();
   });
 
-  it.each([1, 50])(
+  // Two worktrees cover concurrent publication; the upload barrier orders stale retention.
+  it.each([1, 2])(
     "reconciles %i completed turns when an older retention snapshot arrives after upload",
     async (count) => {
       const repository = path.join(root, "repository");


### PR DESCRIPTION
Refs #145379, #145349. Follow-up to #145657.

<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled.

</details>

## What Problem This Solves

Resolves a problem where the Gateway worker-environment CI shard fails on loaded hosts even after cold context-worker initialization moved into setup. Run [34679294250, job 103514926295](https://github.com/openclaw/openclaw/actions/runs/34679294250/job/103514926295) rejected six detached-context cases with `worker functional launch observation timed out after 5000ms` and timed out the 50-turn reconciliation case at 125,459 ms. These failures blocked the landings of #145379 and #145349.

## Why This Change Was Made

The five-second errors come from test-only observation and owner-join wrappers reusing the synthetic turn's timeout. Await the actual execution-completion and credential-readiness signals, keeping early-settlement failures and the guards that prevent cleanup/replacement of unjoined fixture state. Remove the now-unnecessary context-worker warmup. Extend the existing replay assertion to advance the timer clock by 5,001 ms at the async-read boundary while preserving the exact base-leaf and replay assertions.

The reconcile case protects stale-snapshot retention and concurrent publication, not throughput. Use two concurrent real worktrees instead of 50, retaining the explicit all-uploads-before-retention barrier, real manifests, staging, Git operations, binary result bytes, journals, and claim-release assertions. This reduces that case's real Node manifest checks from 200 to eight. Keep the single-turn case too.

Production LOC delta: **0**. Test LOC delta: **+37 / -57**. This is a maintainer follow-up; no contributor commits were copied.

## User Impact

Developers get worker-shard assertions that do not reject healthy preparation merely because five seconds elapsed, with substantially less integration I/O. No production launch budget, update behavior, configuration, storage, or protocol changes.

## Evidence

- Original three-file suite under 32 CPU hogs, `taskpolicy -c background`, Node 26.8.2, 8 GiB heap and `OPENCLAW_VITEST_MAX_WORKERS=1`: 13 tests passed; the 50-turn case took 70.96 seconds. The CI timeout did not reproduce locally.
- Controlled regression against the original fixture: the modified existing replay case failed with `worker functional launch observation timed out after 5000ms` (1,122 ms real duration). After removing the fixture deadline, it passed (904 ms).
- Historical retention mutation: removing only latest-transferred-manifest reachability made the reduced two-turn case fail with missing-manifest `ENOENT`. The production owner was restored byte-for-byte before final proof.
- Repaired three-file suite under the same contention settings: **13 tests passed**. The two-turn reconcile took 12.02 seconds; delayed context readiness passed at 18.30 seconds. All CPU hogs were joined afterward.
- `node scripts/check-changed.mjs`: passed, including Gateway test types, lint, formatting, and unused-export guards.
- P1 Codex autoreview of both the pinned local candidate and committed branch: clean.

- Full `agentic-gateway-core-2` descriptor via `node --import tsx scripts/ci-run-node-test-shard.mts`, Node 26.8.2, 8 GiB heap, two workers: **255 files / 5,038 tests passed**, exit 0, 611.52 seconds.

Exact-head hosted [CI run 34680987053](https://github.com/openclaw/openclaw/actions/runs/34680987053) is **green** for commit `b3edad90c883960b6dd4b6b2108d6072ef7c851b`; `node scripts/watch-pr-ci.mjs 145770 b3edad90c883960b6dd4b6b2108d6072ef7c851b` completed with `GREEN` and exit 0. The unrelated stale native-hook relay failure in sibling job 103514926194 is outside this diff.


## ClawSweeper review

The completed ClawSweeper review of `b3edad90c883960b6dd4b6b2108d6072ef7c851b` found no actionable correctness or security findings and no before-merge items. No fixups or skips were needed; no code changed during landing preparation.
