### PR TITLE
test(hooks): await duplicate-module relay publication

### DIFF
--- a/src/agents/harness/native-hook-relay.test.ts
+++ b/src/agents/harness/native-hook-relay.test.ts
@@ -1106,13 +1106,14 @@ describe("native hook relay registry", () => {
 
   it("shares relay state across duplicate module instances", async () => {
     const duplicateModule = await importDuplicateNativeHookRelayModuleForTests();
-    const relay = registerNativeHookRelay({
+    const relay = registerOwnedNativeHookRelay({
       provider: "codex",
       relayId: "codex-duplicate-module-session",
       sessionId: "session-1",
       runId: "run-1",
       allowedEvents: ["pre_tool_use", "permission_request"],
     });
+    await relay.ready;
 
     await expect(
       duplicateModule.invokeNativeHookRelay({
@@ -1178,13 +1179,14 @@ describe("native hook relay registry", () => {
     expect(duplicateApprovalRequester).toHaveBeenCalledTimes(1);
     expect(primaryApprovalRequester).not.toHaveBeenCalled();
 
-    const replacement = duplicateModule.registerNativeHookRelay({
+    const replacement = duplicateModule.registerOwnedNativeHookRelay({
       provider: "codex",
       relayId: relay.relayId,
       sessionId: "session-1",
       runId: "run-2",
       allowedEvents: ["post_tool_use"],
     });
+    await replacement.ready;
     expect(testing.getNativeHookRelayRegistrationForTests(relay.relayId)).toMatchObject({
       runId: "run-2",
       allowedEvents: ["post_tool_use"],


### PR DESCRIPTION
Refs #145349

<details>
<summary>Additional instructions</summary>

The branch is in openclaw/openclaw and repository maintainers can push to it.

</details>

## What Problem This Solves

Resolves a problem where unrelated PRs fail the native-hook-relay duplicate-module test in `checks-node-compact-large-15`. CI run 34679294250, job 103514926194, rejected its successor bridge invocation with `native hook relay bridge stale registration`.

## Why This Change Was Made

The fixture invoked the bridge immediately after replacement. Registration switches the shared in-memory owner synchronously, but retires the old SQLite locator and publishes its successor asynchronously. The immediate read can capture the old locator; a delayed HTTP response then arrives after the existing 250 ms stale-locator retry grace.

Await the existing owned-registration publication promise for the initial relay and its replacement. This preserves the duplicate-module, shared-approval, stale-handle teardown, and exact HTTP-response assertions while establishing their actual transport precondition. Production already awaits relay preparation before launching native hooks.

## User Impact

Developers no longer encounter this scheduling-dependent CI failure. There is no production behavior, configuration, storage, or timeout change.

## Evidence

- Source CI failure: https://github.com/openclaw/openclaw/actions/runs/34679294250/job/103514926194
- The unmodified relay file passed all 124 tests in isolation. The unmodified 148-file CI group also passed locally, confirming the failure depends on scheduling.
- A temporary 300 ms worker scheduling pause reproduced the exact rejection in isolation and in the captured CI dispatch order, using real SQLite, real HTTP, three non-isolated workers, and the unchanged 2-second request timeout. Before the fix, the ordered group reported 1 failed / 146 passed / 1 skipped file; the only failure was this test.
- The same controlled pause passes after awaiting publication. The diagnostic pause is not part of this patch.

Validation uses Node 24.20.0 on macOS. Original CI ran Linux x64; one Linux-only test file is skipped locally. The original log does not identify worker assignment, which remains timing-dependent; replay preserves its 148-file membership, original file-size dispatch order, and three-worker non-isolated configuration.

Final-patch focused proof: `node scripts/run-vitest.mjs src/agents/harness/native-hook-relay.test.ts src/agents/harness/native-hook-relay.lifecycle.test.ts` — 138 passed. The final uninstrumented ordered replay passed 147 files / 3,288 tests (one file / 13 tests skipped on macOS). `node scripts/check-changed.mjs` and `git diff --check` passed. Independent Codex review is clean at P0/P1 in both local and committed-branch modes. This is a maintainer-requested repair of the CI failure linked above.

Exact-head CI passed; the repository watcher finished GREEN: https://github.com/openclaw/openclaw/actions/runs/34681115215 (head `add5bcb0fc2ac95b44a97112677f3ac873b5ecc3`).


## ClawSweeper review

The completed review of `add5bcb0fc2ac95b44a97112677f3ac873b5ecc3` found no actionable findings. No fixups or skips are required; the patch is unchanged.
