### PR TITLE
fix(chat): render Claude task-notification as system notice, not operator bubble

### DIFF
--- a/src/gateway/cli-session-history.claude.ts
+++ b/src/gateway/cli-session-history.claude.ts
@@ -39,6 +39,7 @@ export type ClaudeCliProjectEntry = {
   isMeta?: unknown;
   isCompactSummary?: unknown;
   isVisibleInTranscriptOnly?: unknown;
+  origin?: unknown;
   message?: {
     role?: unknown;
     content?: unknown;
@@ -285,7 +286,22 @@ function isClaudeCliVisibleHarnessContext(entry: ClaudeCliProjectEntry): boolean
   return entry.isCompactSummary === true || entry.isVisibleInTranscriptOnly === true;
 }
 
-function isClaudeCliTaskNotification(content: string | unknown[]): boolean {
+function isClaudeCliTaskNotificationOrigin(entry: ClaudeCliProjectEntry): boolean {
+  if (entry === null || typeof entry !== "object") return false;
+  const origin = (entry as { origin?: unknown }).origin;
+  if (origin === null || typeof origin !== "object") return false;
+  return (origin as { kind?: unknown }).kind === "task-notification";
+}
+
+function isClaudeCliTaskNotification(
+  entry: ClaudeCliProjectEntry,
+  content: string | unknown[],
+): boolean {
+  // Native origin is the authorship signal: all 13 genuine harness
+  // notifications carry origin {kind:"task-notification"} while 295 sampled
+  // operator turns have no origin. Envelope text alone is insufficient —
+  // an operator can paste the same XML into the session.
+  if (!isClaudeCliTaskNotificationOrigin(entry)) return false;
   return (
     typeof content === "string" &&
     content.startsWith("<task-notification>") &&
@@ -427,7 +443,7 @@ export function parseClaudeCliHistoryEntry(
     }
     // Record provenance here, where the native row shape is known, so downstream
     // display never has to infer operator authorship from message text.
-    const sourceTool = isClaudeCliTaskNotification(content)
+    const sourceTool = isClaudeCliTaskNotification(entry, content)
       ? "claude_cli_task_notification"
       : isClaudeCliVisibleHarnessContext(entry)
         ? "cli_harness_context"

--- a/src/gateway/cli-session-history.claude.ts
+++ b/src/gateway/cli-session-history.claude.ts
@@ -7,6 +7,7 @@ import {
   asFiniteNumber,
   parseDateStringTimestampMs,
 } from "@openclaw/normalization-core/number-coercion";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import {
   readCliImageTurnContext,
@@ -286,23 +287,14 @@ function isClaudeCliVisibleHarnessContext(entry: ClaudeCliProjectEntry): boolean
   return entry.isCompactSummary === true || entry.isVisibleInTranscriptOnly === true;
 }
 
-function isClaudeCliTaskNotificationOrigin(entry: ClaudeCliProjectEntry): boolean {
-  if (entry === null || typeof entry !== "object") return false;
-  const origin = (entry as { origin?: unknown }).origin;
-  if (origin === null || typeof origin !== "object") return false;
-  return (origin as { kind?: unknown }).kind === "task-notification";
-}
-
 function isClaudeCliTaskNotification(
   entry: ClaudeCliProjectEntry,
   content: string | unknown[],
 ): boolean {
-  // Native origin is the authorship signal: all 13 genuine harness
-  // notifications carry origin {kind:"task-notification"} while 295 sampled
-  // operator turns have no origin. Envelope text alone is insufficient —
-  // an operator can paste the same XML into the session.
-  if (!isClaudeCliTaskNotificationOrigin(entry)) return false;
+  // Native origin establishes authorship; operator-pasted XML must stay a user turn.
   return (
+    isRecord(entry.origin) &&
+    entry.origin.kind === "task-notification" &&
     typeof content === "string" &&
     content.startsWith("<task-notification>") &&
     content.endsWith("</task-notification>")

--- a/src/gateway/cli-session-history.claude.ts
+++ b/src/gateway/cli-session-history.claude.ts
@@ -285,6 +285,14 @@ function isClaudeCliVisibleHarnessContext(entry: ClaudeCliProjectEntry): boolean
   return entry.isCompactSummary === true || entry.isVisibleInTranscriptOnly === true;
 }
 
+function isClaudeCliTaskNotification(content: string | unknown[]): boolean {
+  return (
+    typeof content === "string" &&
+    content.startsWith("<task-notification>") &&
+    content.endsWith("</task-notification>")
+  );
+}
+
 export function resolveClaudeCliPromptTextCandidates(
   entry: ClaudeCliProjectEntry,
   content: string | unknown[],
@@ -417,16 +425,18 @@ export function parseClaudeCliHistoryEntry(
     if (cliImageTurnKey && typeof content === "string") {
       content = stripCliImageTurnContext(content, cliImageTurnKey);
     }
-    // Record provenance here, where the native flags are known, so downstream
+    // Record provenance here, where the native row shape is known, so downstream
     // display never has to infer operator authorship from message text.
-    const harnessInjected = isClaudeCliVisibleHarnessContext(entry);
+    const sourceTool = isClaudeCliTaskNotification(content)
+      ? "claude_cli_task_notification"
+      : isClaudeCliVisibleHarnessContext(entry)
+        ? "cli_harness_context"
+        : undefined;
     return attachOpenClawTranscriptMeta(
       {
         role: "user",
         content,
-        ...(harnessInjected
-          ? { provenance: { kind: "internal_system", sourceTool: "cli_harness_context" } }
-          : {}),
+        ...(sourceTool ? { provenance: { kind: "internal_system", sourceTool } } : {}),
         ...(timestamp !== undefined ? { timestamp } : {}),
       },
       { ...baseMeta, ...(cliImageTurnKey ? { cliImageTurnKey } : {}) },

--- a/src/gateway/cli-session-history.test.ts
+++ b/src/gateway/cli-session-history.test.ts
@@ -420,7 +420,7 @@ describe("cli session history", () => {
     });
   });
 
-  it("omits isMeta rows and records visible harness context provenance", async () => {
+  it("omits isMeta rows and records internal Claude context provenance", async () => {
     await withClaudeProjectsDir(async ({ homeDir, sessionId, filePath }) => {
       await fs.writeFile(
         filePath,
@@ -467,6 +467,21 @@ describe("cli session history", () => {
               content: "Transcript-only synthetic context row.",
             },
           },
+          {
+            type: "user",
+            uuid: "task-notification-1",
+            timestamp: "2026-03-26T16:29:58.000Z",
+            message: {
+              role: "user",
+              content: [
+                "<task-notification>",
+                "<task-id>task-1</task-id>",
+                "<status>completed</status>",
+                "<summary>Background review finished.</summary>",
+                "</task-notification>",
+              ].join("\n"),
+            },
+          },
         ]
           .map((line) => JSON.stringify(line))
           .join("\n"),
@@ -475,7 +490,7 @@ describe("cli session history", () => {
 
       const messages = readClaudeCliSessionMessages({ cliSessionId: sessionId, homeDir });
 
-      expect(messages).toHaveLength(3);
+      expect(messages).toHaveLength(4);
       expect(JSON.stringify(messages)).not.toContain("Base directory for this skill");
       // The operator-authored turn stays free of injected provenance.
       expectFields(messages[0], { role: "user" });
@@ -488,6 +503,10 @@ describe("cli session history", () => {
       expectFields(readRecord(messages[2]).provenance, {
         kind: "internal_system",
         sourceTool: "cli_harness_context",
+      });
+      expectFields(readRecord(messages[3]).provenance, {
+        kind: "internal_system",
+        sourceTool: "claude_cli_task_notification",
       });
     });
   });

--- a/src/gateway/cli-session-history.test.ts
+++ b/src/gateway/cli-session-history.test.ts
@@ -471,6 +471,22 @@ describe("cli session history", () => {
             type: "user",
             uuid: "task-notification-1",
             timestamp: "2026-03-26T16:29:58.000Z",
+            origin: { kind: "task-notification" },
+            message: {
+              role: "user",
+              content: [
+                "<task-notification>",
+                "<task-id>task-1</task-id>",
+                "<status>completed</status>",
+                "<summary>Background review finished.</summary>",
+                "</task-notification>",
+              ].join("\n"),
+            },
+          },
+          {
+            type: "user",
+            uuid: "operator-pasted-xml-1",
+            timestamp: "2026-03-26T16:29:59.000Z",
             message: {
               role: "user",
               content: [
@@ -490,7 +506,7 @@ describe("cli session history", () => {
 
       const messages = readClaudeCliSessionMessages({ cliSessionId: sessionId, homeDir });
 
-      expect(messages).toHaveLength(4);
+      expect(messages).toHaveLength(5);
       expect(JSON.stringify(messages)).not.toContain("Base directory for this skill");
       // The operator-authored turn stays free of injected provenance.
       expectFields(messages[0], { role: "user" });
@@ -508,6 +524,9 @@ describe("cli session history", () => {
         kind: "internal_system",
         sourceTool: "claude_cli_task_notification",
       });
+      // Identical envelope text without the native origin stays operator-authored.
+      expectFields(messages[4], { role: "user" });
+      expect(readRecord(messages[4]).provenance).toBeUndefined();
     });
   });
 

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -5179,6 +5179,9 @@ export const en: TranslationMap & {
       cliHarnessContext: {
         label: "System · injected context",
       },
+      claudeCliTaskNotification: {
+        label: "System · background task",
+      },
       showContent: "Show content",
     },
     progressLabels: {

--- a/ui/src/pages/chat/chat-thread.test.ts
+++ b/ui/src/pages/chat/chat-thread.test.ts
@@ -2271,7 +2271,7 @@ describe("buildCachedChatItems", () => {
     expect(filtered.some((item) => item.kind === "notice")).toBe(false);
   });
 
-  it("renders CLI harness-injected user turns as collapsed context, not operator bubbles", () => {
+  it("renders Claude CLI internal user turns as notices, not operator bubbles", () => {
     const items = buildCachedChatItems(
       createProps({
         messages: [
@@ -2289,14 +2289,24 @@ describe("buildCachedChatItems", () => {
               },
             },
           ),
-          assistantMessage("review finished", 1002),
+          userMessage(
+            "<task-notification>\n<status>completed</status>\n</task-notification>",
+            1002,
+            {
+              provenance: {
+                kind: "internal_system",
+                sourceTool: "claude_cli_task_notification",
+              },
+            },
+          ),
+          assistantMessage("review finished", 1003),
         ],
       }),
     );
 
     // The operator turn keeps its bubble; the injected turn becomes a
     // collapsed system notice that does not start a new operator turn.
-    expect(items.map((item) => item.kind)).toEqual(["group", "notice", "group"]);
+    expect(items.map((item) => item.kind)).toEqual(["group", "notice", "notice", "group"]);
     expect(items[0]).toMatchObject({ kind: "group", role: "user" });
     expect(items[1]).toMatchObject({
       kind: "notice",
@@ -2307,7 +2317,16 @@ describe("buildCachedChatItems", () => {
       timestamp: 1001,
     });
     expect((items[1] as { startsTurn?: true }).startsTurn).toBeUndefined();
-    expect(items[2]).toMatchObject({ kind: "group", role: "assistant" });
+    expect(items[2]).toMatchObject({
+      kind: "notice",
+      icon: "cpu",
+      label: "System · background task",
+      collapsedBody: true,
+      text: "<task-notification>\n<status>completed</status>\n</task-notification>",
+      timestamp: 1002,
+    });
+    expect((items[2] as { startsTurn?: true }).startsTurn).toBeUndefined();
+    expect(items[3]).toMatchObject({ kind: "group", role: "assistant" });
   });
 
   it("attributes assistant groups to the latest user in multi-sender threads", () => {

--- a/ui/src/pages/chat/system-notice-kinds.test.ts
+++ b/ui/src/pages/chat/system-notice-kinds.test.ts
@@ -15,6 +15,15 @@ describe("resolveSystemNoticeKind", () => {
     );
   });
 
+  it("resolves Claude CLI task notifications as collapsed mid-run notices", () => {
+    expect(resolveSystemNoticeKind("claude_cli_task_notification")).toEqual({
+      icon: "cpu",
+      labelKey: "chat.systemNotice.claudeCliTaskNotification.label",
+      collapsedBody: true,
+      startsTurn: false,
+    });
+  });
+
   it.each([
     undefined,
     "heartbeat",

--- a/ui/src/pages/chat/system-notice-kinds.ts
+++ b/ui/src/pages/chat/system-notice-kinds.ts
@@ -32,6 +32,12 @@ const systemNoticeKinds: Readonly<Record<string, SystemNoticeKind>> = {
     collapsedBody: true,
     startsTurn: false,
   },
+  claude_cli_task_notification: {
+    icon: "cpu",
+    labelKey: "chat.systemNotice.claudeCliTaskNotification.label",
+    collapsedBody: true,
+    startsTurn: false,
+  },
 };
 
 export function resolveSystemNoticeKind(


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users viewing native-runtime-backed chat history would see background-task notifications attributed to them as raw XML chat bubbles.

## Why This Change Was Made

Classify notifications at the native transcript import boundary using `origin.kind === "task-notification"`, then reuse the existing collapsed system-notice renderer. Envelope text alone is not enough: identical XML pasted by an operator must remain an operator message.

The origin-based correction was pushed in `c02a8d9505312ee9da039c5c374c0163835a1115`.

AI-assisted

## User Impact

Genuine background-task notifications appear as collapsed “System · background task” notices without starting an operator turn. Operator-pasted XML retains its authorship and normal message presentation. Transcript content is preserved.

## Evidence

### Before: actual reported incident

The reporter supplied this original Control UI screenshot and authorized its publication. It shows the native task-notification XML attributed to the operator. The following “Compiled…” message is the assistant's reply, not an operator reply (correcting the earlier description).

The original image is omitted here because it contains private paths or model text. Sanitized before/after captures were inspected during maintainer validation.

### After: real importer output in the served Control UI

The original image is omitted here because it contains private paths or model text. Sanitized before/after captures were inspected during maintainer validation.

**Method and scope:** the actual native history importer read synthetic native JSONL containing a genuine-origin task notification and an identical operator-authored XML row without origin. Its returned messages were supplied through the repository's mocked Gateway RPC transport to the actual served Control UI. Provenance was not hand-assigned. All sidebar/tasks are synthetic harness fixtures, not production user data. This is importer-to-renderer integration proof, not a full live Gateway or native-runtime background-task run.

In the browser, verified the native notification starts collapsed as “System · background task”; expanded it to inspect the original XML, then collapsed it again. The identical operator XML remains a normal user bubble. Also loaded the same fixture through the exact baseline importer `fac7e2a90ad`: both XML rows appeared as user bubbles. The current UI renderer was used in both cases, isolating the importer change. The original incident screenshot described above is the production before-capture.

**Loaded source:** `d5f1284039b17aaa062c5e6985fb6f9d73028c23`; importer SHA-256 `1d425f3c5a37c7146966ab58a1bc40c5b635df0b6cca45c829b6ccd0d405c021`. Scratch checkout and loopback servers only; no live gateway rebuild/restart.

### Contributor validation before the maintainer refresh

- Importer: **87 tests passed**.
- Chat-thread and notice-registry UI suites: **269 tests passed** on this checkout.
- Targeted lint, formatting, type-assertion safety ratchet and `git diff --check`: passed.
- Fresh independent review of the CI repair: no actionable production finding. The repair reuses `isRecord`, removes unsafe casts and fixes missing-brace violations; it does not alter the intended native-origin rule.
- Remote CI currently fails in `resolve-auth.test.ts` (1-second timeout) and the headless Code Mode deadline test (`internal_error` versus `timeout`). Both suites were re-run unchanged on this exact head: **78/78 passed** (61 Code Mode + 17 auth). The relevant source/test files have no diff from the PR base. No assertions or timeouts were weakened. These remote failures remain visible; the aggregate CI gate is not claimed green. A maintainer may need to rerun them.


---

## Maintainer landing validation

## What Problem This Solves

Background task XML looked like a message the operator wrote.

## Why This Change Was Made

The native history importer records task origin through existing system provenance. This state has one writer. The UI uses its existing collapsed notice renderer.

## User Impact

Background task notices start collapsed, without starting an operator turn. “Show content” reveals the original XML. Identical XML pasted by the operator remains their message.

## Evidence

The real Gateway and served Control UI reproduced the defect on main. The unchanged contributor head and a fresh merge passed the same history flow. Both `chat.history` and `chat.startup` preserved the text and authorship distinction.

Sanitized before, after, and expanded-notice captures were independently inspected and retained with the maintainer proof.

## Consumers

History import, startup, cached chat items, notice rendering, and turn grouping consume the recorded origin. Native transcript bytes stay unchanged. History refresh rebuilds the display; existing activity and fallback behavior stays unchanged. Native mobile and desktop clients use their existing generic system-notice path; no native-device rendering test is claimed. Oversized-row handling and local-copy deduplication remain outside this ordinary string-envelope fix.

## Tests

The fresh merge passed 759 history/chat tests, 58 test-routing assertions, changed-file lint, formatting, and translation checks. The two previously failing suites passed 78 tests on both plain main and the fresh merge. The older failures were not reproduced locally. Current CI run [34784786145](https://github.com/openclaw/openclaw/actions/runs/34784786145) is fully green at the unchanged contributor head.
