### PR TITLE
test: preload TypeScript for Node workers under Bun

### DIFF
--- a/src/agents/code-mode-retention.test.ts
+++ b/src/agents/code-mode-retention.test.ts
@@ -2,6 +2,7 @@ import { fileURLToPath } from "node:url";
 import { expect, it } from "vitest";
 import { runNodeScript } from "../../test/helpers/run-node-script.js";
 import { resolveRuntimeWorkerArgv, resolveRuntimeWorkerUrl } from "../infra/runtime-worker-url.js";
+import { resolveTestNodeExecPath } from "../test-utils/node-process.js";
 import {
   codeModeDescriptionRetentionEntrypoint,
   codeModeRetentionEntrypoint,
@@ -20,7 +21,10 @@ it.for([
   },
 ])("$name", { timeout: 30_000 }, async ({ entrypoint, expected }, { signal }) => {
   const result = await runNodeScript(
-    ["--expose-gc", ...resolveRuntimeWorkerArgv(resolveRuntimeWorkerUrl(entrypoint))],
+    [
+      "--expose-gc",
+      ...resolveRuntimeWorkerArgv(resolveRuntimeWorkerUrl(entrypoint), resolveTestNodeExecPath()),
+    ],
     { ...process.env, NODE_OPTIONS: "", TSX_DISABLE_CACHE: "1" },
     15_000,
     {


### PR DESCRIPTION
## Problem

When Vitest runs under Bun, the code-mode heap-retention test correctly delegates its child to real Node, but it derived the worker argv from the Bun host executable. The TypeScript preload was therefore omitted, and the Node child could not resolve workspace package exports or source `.js` specifiers back to TypeScript.

## Solution

Resolve the worker argv against the same real Node executable selected by the child-process helper. Node-hosted tests retain their existing behavior, while Bun-hosted tests now attach the required TypeScript preload to the Node child.

## Impact

This is a test-harness compatibility fix only. It does not change OpenClaw runtime behavior or installation dependencies.

## Evidence

- Before: the full direct-Bun core lane reported exactly these 2 failures after 20,150 passes and 44 expected platform skips.
- After: `src/agents/code-mode-retention.test.ts` passes 2/2 under the custom Bun host.
- Node regression: the same file passes 2/2 under Node.
- `node scripts/check-changed.mjs`
- P0-P2 autoreview: clean.
