### PR TITLE
fix(slack): report failed terminal session status updates

### DIFF
--- a/extensions/slack/src/monitor/context.ts
+++ b/extensions/slack/src/monitor/context.ts
@@ -153,13 +153,14 @@ export type SlackMonitorContext = {
   ) => SlackMessageEvent["channel_type"] | undefined;
   resolveUserName: (userId: string, eventScope?: SlackEventScope) => Promise<SlackUserInfo>;
   resolveUserAvatar: (userId: string, eventScope?: SlackEventScope) => string | undefined;
+  /** True means Slack accepted the status write, not that every client rendered it. */
   setSlackSessionStatus: (params: {
     channelId: string;
     threadTs?: string;
     status: "processing" | "active" | "suspended";
     title?: string;
     eventScope?: SlackEventScope;
-  }) => Promise<void>;
+  }) => Promise<boolean>;
   recordSlackSessionTitle: (params: {
     channelId: string;
     threadTs: string;
@@ -431,12 +432,12 @@ export function createSlackMonitorContext(params: {
       runtime: params.runtime,
     });
     if (!updated.ok || p.status !== "processing" || !p.threadTs || p.title === undefined) {
-      return;
+      return updated.ok;
     }
     const title = truncateUtf16Safe(p.title, 200);
     // A user rename received while the status request was in flight wins.
     if (readLruMapEntry(sessionTitles, key) !== previousTitle) {
-      return;
+      return true;
     }
     // setStatus only names newly created sessions. Rename existing sessions once
     // per display-name change; inbound user renames update this same cache.
@@ -455,6 +456,7 @@ export function createSlackMonitorContext(params: {
         recordSlackSessionTitle({ ...p, threadTs: p.threadTs, title });
       }
     }
+    return true;
   };
 
   const setSlackSuggestedPrompts = (input: SlackSuggestedPromptsInput) =>

--- a/extensions/slack/src/monitor/events/agent.test.ts
+++ b/extensions/slack/src/monitor/events/agent.test.ts
@@ -58,7 +58,7 @@ function createSessionEventHarness(channelType: "im" | "channel" | "mpim" = "im"
     ok: true,
     messages: [],
   });
-  const setSlackSessionStatus = vi.fn(async () => {});
+  const setSlackSessionStatus = vi.fn(async () => true);
   const recordSlackSessionTitle = vi.fn();
   const storePath = path.join(tempDir, "sessions.sqlite");
   Object.assign(harness.ctx, {

--- a/extensions/slack/src/monitor/message-handler/dispatch-setup.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch-setup.ts
@@ -125,6 +125,7 @@ export async function createSlackDispatchSetup(prepared: PreparedSlackMessage) {
   const messageTs = message.ts ?? message.event_ts;
   const incomingThreadTs = message.thread_ts;
   let didSetStatus = false;
+  let statusWasSet = false;
   let didAddTypingReaction = false;
   const statusReactionsEnabled =
     prepared.ctxPayload.InboundEventKind !== "room_event" &&
@@ -190,14 +191,15 @@ export async function createSlackDispatchSetup(prepared: PreparedSlackMessage) {
       start: async () => {
         if (!didSetStatus && !threadStatusGate.hasVisibleOutput()) {
           didSetStatus = true;
-          await ctx.setSlackSessionStatus({
-            channelId: message.channel,
-            threadTs: statusThreadTs,
-            status: "processing",
-            // Initialize new sessions with core's derived label; later title changes use rename.
-            title: prepared.sessionDisplayName ?? prepared.ctxPayload.ThreadLabel,
-            eventScope: prepared.eventScope,
-          });
+          statusWasSet =
+            (await ctx.setSlackSessionStatus({
+              channelId: message.channel,
+              threadTs: statusThreadTs,
+              status: "processing",
+              // Initialize new sessions with core's derived label; later title changes use rename.
+              title: prepared.sessionDisplayName ?? prepared.ctxPayload.ThreadLabel,
+              eventScope: prepared.eventScope,
+            })) === true;
         }
         if (typingReaction && message.ts) {
           didAddTypingReaction = true;
@@ -212,12 +214,24 @@ export async function createSlackDispatchSetup(prepared: PreparedSlackMessage) {
       stop: async () => {
         if (didSetStatus) {
           didSetStatus = false;
-          await ctx.setSlackSessionStatus({
+          const reportFailure = statusWasSet;
+          statusWasSet = false;
+          const restored = await ctx.setSlackSessionStatus({
             channelId: message.channel,
             threadTs: statusThreadTs,
             status: "active",
             eventScope: prepared.eventScope,
           });
+          if (reportFailure && restored === false) {
+            try {
+              runtime.error?.(
+                "Slack session status could not return to active after processing. " +
+                  "Status was not retried; enable verbose logging to inspect the Slack API failure.",
+              );
+            } catch {
+              // Diagnostics must not prevent the remaining typing-reaction cleanup.
+            }
+          }
         }
         // Tracked apart from the status write: a suppressed status refresh
         // still adds the reaction, and that reaction must still be removed.

--- a/extensions/slack/src/monitor/message-handler/dispatch-setup.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch-setup.ts
@@ -191,15 +191,14 @@ export async function createSlackDispatchSetup(prepared: PreparedSlackMessage) {
       start: async () => {
         if (!didSetStatus && !threadStatusGate.hasVisibleOutput()) {
           didSetStatus = true;
-          statusWasSet =
-            (await ctx.setSlackSessionStatus({
-              channelId: message.channel,
-              threadTs: statusThreadTs,
-              status: "processing",
-              // Initialize new sessions with core's derived label; later title changes use rename.
-              title: prepared.sessionDisplayName ?? prepared.ctxPayload.ThreadLabel,
-              eventScope: prepared.eventScope,
-            })) === true;
+          statusWasSet = await ctx.setSlackSessionStatus({
+            channelId: message.channel,
+            threadTs: statusThreadTs,
+            status: "processing",
+            // Initialize new sessions with core's derived label; later title changes use rename.
+            title: prepared.sessionDisplayName ?? prepared.ctxPayload.ThreadLabel,
+            eventScope: prepared.eventScope,
+          });
         }
         if (typingReaction && message.ts) {
           didAddTypingReaction = true;
@@ -222,7 +221,7 @@ export async function createSlackDispatchSetup(prepared: PreparedSlackMessage) {
             status: "active",
             eventScope: prepared.eventScope,
           });
-          if (reportFailure && restored === false) {
+          if (reportFailure && !restored) {
             try {
               runtime.error?.(
                 "Slack session status could not return to active after processing. " +

--- a/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
@@ -361,7 +361,7 @@ function createPreparedSlackMessage(params?: {
     threadTs?: string;
     status: string;
     title?: string;
-  }) => Promise<void>;
+  }) => Promise<boolean>;
   sessionDisplayName?: string;
   typingReaction?: string;
   ackReactionMessageTs?: string;
@@ -401,7 +401,7 @@ function createPreparedSlackMessage(params?: {
       channelHistories: new Map(),
       allowFrom: [],
       dispatchReplyFromConfig: params?.dispatchReplyFromConfig,
-      setSlackSessionStatus: params?.setSlackSessionStatus ?? (async () => undefined),
+      setSlackSessionStatus: params?.setSlackSessionStatus ?? (async () => true),
     },
     account: {
       accountId: "default",
@@ -2099,7 +2099,7 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
       const draftStream = createDraftStreamStub();
       draftStream.messageId = () => undefined;
       createSlackDraftStreamMock.mockReturnValueOnce(draftStream);
-      const setSlackSessionStatus = vi.fn(async () => undefined);
+      const setSlackSessionStatus = vi.fn(async () => true);
       mockedReplyOptionEvents = [
         {
           kind: "checkpoint",
@@ -2134,7 +2134,7 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
   );
 
   it("does not restart Slack session status once the turn has visible output", async () => {
-    const setSlackSessionStatus = vi.fn(async () => undefined);
+    const setSlackSessionStatus = vi.fn(async () => true);
 
     await dispatchPreparedSlackMessage(createPreparedSlackMessage({ setSlackSessionStatus }));
 
@@ -2147,7 +2147,7 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
   });
 
   it("keeps Slack typing callbacks when channel replies are message-tool-only", async () => {
-    const setSlackSessionStatus = vi.fn(async () => undefined);
+    const setSlackSessionStatus = vi.fn(async () => true);
 
     await dispatchPreparedSlackMessage(
       createPreparedSlackMessage({

--- a/extensions/slack/src/monitor/message-handler/dispatch.status-diagnostics.test.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.status-diagnostics.test.ts
@@ -1,0 +1,214 @@
+// The registered Slack typing callbacks retain the real context and status API owners.
+import { WebClient, type WebAPICallResult } from "@slack/web-api";
+import {
+  buildChannelInboundEventContext,
+  resolveChannelInboundRouteEnvelope,
+} from "openclaw/plugin-sdk/channel-inbound";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { removeSlackReaction } from "../../actions.js";
+import { createSlackDispatchSetup } from "./dispatch-setup.js";
+import { createInboundSlackTestContext, createSlackTestAccount } from "./prepare.test-helpers.js";
+import type { PreparedSlackMessage } from "./types.js";
+
+type PipelineOptions = Parameters<
+  typeof import("openclaw/plugin-sdk/channel-outbound").createChannelMessageReplyPipeline
+>[0];
+let capturedTyping: PipelineOptions["typing"];
+vi.mock("openclaw/plugin-sdk/channel-outbound", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/channel-outbound")>();
+  return {
+    ...actual,
+    createChannelMessageReplyPipeline: (options: PipelineOptions) => {
+      capturedTyping = options.typing;
+      return { onModelSelected: vi.fn() };
+    },
+  };
+});
+vi.mock("../../actions.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../actions.js")>()),
+  reactSlackMessage: vi.fn(async () => undefined),
+  removeSlackReaction: vi.fn(async () => undefined),
+}));
+
+async function fixture(
+  params: {
+    processing?: WebAPICallResult;
+    active?: WebAPICallResult | Error;
+    typingReaction?: boolean;
+  } = {},
+) {
+  const client = new WebClient();
+  const api = vi.spyOn(client, "apiCall").mockImplementation(async (method, args) => {
+    if (method === "agents.sessions.rename") {
+      return { ok: false };
+    }
+    const response =
+      args?.status === "processing"
+        ? (params.processing ?? { ok: true })
+        : (params.active ?? { ok: true });
+    if (response instanceof Error) {
+      throw response;
+    }
+    return response;
+  });
+  const ctx = createInboundSlackTestContext({ cfg: {}, appClient: client, replyToMode: "all" });
+  const error = vi.fn();
+  ctx.runtime.error = error;
+  ctx.runtime.log = vi.fn();
+  ctx.typingReaction = params.typingReaction ? "hourglass_flowing_sand" : "";
+  const { route } = resolveChannelInboundRouteEnvelope({
+    cfg: {},
+    channel: "slack",
+    accountId: "default",
+    peer: { kind: "group", id: "C1" },
+  });
+  const ctxPayload = buildChannelInboundEventContext({
+    channel: "slack",
+    accountId: "default",
+    messageId: "1.000",
+    from: "slack:channel:C1",
+    sender: { id: "U1" },
+    conversation: { kind: "group", id: "C1", threadId: "1.000" },
+    route: {
+      agentId: route.agentId,
+      dmScope: route.dmScope,
+      accountId: route.accountId,
+      routeSessionKey: route.sessionKey,
+      dispatchSessionKey: route.sessionKey,
+    },
+    reply: { to: "channel:C1", originatingTo: "channel:C1", messageThreadId: "1.000" },
+    message: { body: "hello", bodyForAgent: "hello", rawBody: "hello", commandBody: "hello" },
+  });
+  const prepared: PreparedSlackMessage = {
+    ctx,
+    account: createSlackTestAccount({ streaming: { mode: "off" } }),
+    message: {
+      type: "message",
+      channel: "C1",
+      user: "U1",
+      ts: "1.000",
+      thread_ts: "1.000",
+      text: "hello",
+    },
+    route,
+    channelConfig: null,
+    replyTarget: "channel:C1",
+    ctxPayload,
+    turn: { storePath: "/unused/slack-status-test", record: {} },
+    replyToMode: "all",
+    requireMention: false,
+    isDirectMessage: false,
+    isRoomish: true,
+    historyKey: "status-test",
+    preview: "hello",
+    ackReactionValue: "",
+    ackReactionPromise: null,
+  };
+  await createSlackDispatchSetup(prepared);
+  const typing = capturedTyping;
+  if (!typing?.start || !typing.stop) {
+    throw new Error("registered typing callbacks missing");
+  }
+  return { ctx, api, error, start: typing.start, stop: typing.stop };
+}
+const diagnostic =
+  "Slack session status could not return to active after processing. " +
+  "Status was not retried; enable verbose logging to inspect the Slack API failure.";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  capturedTyping = undefined;
+});
+afterEach(() => vi.restoreAllMocks());
+
+describe("Slack terminal status diagnostics", () => {
+  it("returns the real write outcome through monitor context", async () => {
+    const f = await fixture({ active: { ok: false } });
+    expect(
+      await f.ctx.setSlackSessionStatus({
+        channelId: "C1",
+        threadTs: "1.000",
+        status: "processing",
+      }),
+    ).toBe(true);
+    expect(
+      await f.ctx.setSlackSessionStatus({ channelId: "C1", threadTs: "1.000", status: "active" }),
+    ).toBe(false);
+  });
+
+  it("reports a failed active write once after successful processing", async () => {
+    const f = await fixture({ active: { ok: false } });
+    await f.start();
+    await f.stop();
+    await f.stop();
+    expect(f.error).toHaveBeenCalledExactlyOnceWith(diagnostic);
+    expect(f.api).toHaveBeenCalledTimes(2);
+  });
+
+  it("reports a rejected Slack request without copying private error data to the normal log", async () => {
+    const f = await fixture({ active: new Error("synthetic-private-detail") });
+    await f.start();
+    await f.stop();
+    expect(f.error).toHaveBeenCalledExactlyOnceWith(diagnostic);
+    expect(f.error.mock.calls.flat().join(" ")).not.toContain("synthetic-private-detail");
+    expect(f.api).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps unsupported or failed processing writes quiet at normal level", async () => {
+    const f = await fixture({ processing: { ok: false }, active: { ok: false } });
+    await f.start();
+    await f.stop();
+    expect(f.error).not.toHaveBeenCalled();
+    expect(f.api).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps successful transitions quiet", async () => {
+    const f = await fixture();
+    await f.start();
+    await f.stop();
+    expect(f.error).not.toHaveBeenCalled();
+  });
+
+  it("does not confuse aggregate processing with a failed active write", async () => {
+    const f = await fixture({ active: { ok: true, status: "processing", agent_status: "active" } });
+    await f.start();
+    await f.stop();
+    expect(f.error).not.toHaveBeenCalled();
+  });
+
+  it("does not attempt a status write when cleanup runs before start", async () => {
+    const f = await fixture();
+    await f.stop();
+    expect(f.api).not.toHaveBeenCalled();
+    expect(f.error).not.toHaveBeenCalled();
+  });
+
+  it("returns false without a request when there is no thread", async () => {
+    const f = await fixture();
+    expect(await f.ctx.setSlackSessionStatus({ channelId: "C1", status: "active" })).toBe(false);
+    expect(f.api).not.toHaveBeenCalled();
+  });
+
+  it("continues typing-reaction cleanup if the diagnostic logger throws", async () => {
+    const f = await fixture({ active: { ok: false }, typingReaction: true });
+    f.error.mockImplementation(() => {
+      throw new Error("logger unavailable");
+    });
+    await f.start();
+    await expect(f.stop()).resolves.toBeUndefined();
+    expect(removeSlackReaction).toHaveBeenCalledOnce();
+  });
+
+  it("does not turn a failed rename into a failed accepted processing write", async () => {
+    const f = await fixture();
+    expect(
+      await f.ctx.setSlackSessionStatus({
+        channelId: "C1",
+        threadTs: "1.000",
+        status: "processing",
+        title: "New label",
+      }),
+    ).toBe(true);
+    expect(f.api).toHaveBeenCalledTimes(2);
+  });
+});

--- a/extensions/slack/src/monitor/message-handler/dispatch.status-diagnostics.test.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.status-diagnostics.test.ts
@@ -10,6 +10,12 @@ import { createSlackDispatchSetup } from "./dispatch-setup.js";
 import { createInboundSlackTestContext, createSlackTestAccount } from "./prepare.test-helpers.js";
 import type { PreparedSlackMessage } from "./types.js";
 
+type SlackSessionStatus = "processing" | "active" | "suspended" | "closed";
+type SlackSessionResponse = WebAPICallResult & {
+  status?: SlackSessionStatus;
+  agent_status?: SlackSessionStatus;
+};
+
 type PipelineOptions = Parameters<
   typeof import("openclaw/plugin-sdk/channel-outbound").createChannelMessageReplyPipeline
 >[0];
@@ -32,8 +38,8 @@ vi.mock("../../actions.js", async (importOriginal) => ({
 
 async function fixture(
   params: {
-    processing?: WebAPICallResult;
-    active?: WebAPICallResult | Error;
+    processing?: SlackSessionResponse;
+    active?: SlackSessionResponse | Error;
     typingReaction?: boolean;
   } = {},
 ) {

--- a/extensions/slack/src/monitor/message-handler/prepare.test.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.test.ts
@@ -5104,7 +5104,7 @@ describe("prepareSlackMessage sender prefix", () => {
       isChannelAllowed: () => true,
       resolveChannelName: async () => ({ name: "general", type: "channel" }),
       resolveUserName: async () => ({ name: "Alice" }),
-      setSlackSessionStatus: async () => undefined,
+      setSlackSessionStatus: async () => true,
     } as unknown as SlackMonitorContext;
   }
 

--- a/extensions/slack/src/session-status.ts
+++ b/extensions/slack/src/session-status.ts
@@ -58,10 +58,15 @@ export async function setSlackSessionStatus(params: {
         ),
       );
     }
+    if (!response.ok) {
+      logVerbose(
+        `slack status update returned ok=false for channel ${params.channelId} (${params.status})`,
+      );
+    }
     return response.ok ? { ok: true, title: response.title } : { ok: false };
   } catch (error) {
     logVerbose(
-      `slack status update failed for channel ${params.channelId}: ${formatSlackError(error)}`,
+      `slack status update failed for channel ${params.channelId} (${params.status}): ${formatSlackError(error)}`,
     );
     return { ok: false };
   }


### PR DESCRIPTION
Related: #142772. This fixes terminal API-failure diagnostics, not Slack Desktop's working-indicator behavior.

## What Problem This Solves

Fixes silent Slack session-status cleanup failures when Slack accepts `processing` but rejects the terminal `active` update.

## User Impact

Operators receive one normal-level diagnostic and can enable verbose logging for the underlying Slack API failure. Rejected or unsupported processing writes do not produce this new diagnostic. Status requests, cleanup ordering and retry behavior are unchanged; typing reactions are still removed. No configuration or migration is required.

An accepted status request is not proof that Slack Desktop has refreshed its UI, so the broader issue remains open.

## Why This Change Was Made

Preserve API acceptance through the existing monitor context and consume it in the existing dispatch cleanup owner. A successful write remains successful when another agent keeps Slack's aggregate status at `processing`, or when a subsequent title rename fails. The diagnostic contains no token, channel/thread identifiers, title or raw API error.

The integration preserves current main's inferred context type rather than restoring its retired type file, and updates the existing delivery-trace fixture to the same acceptance contract. Unnecessary helper logging and wording-pinned test assertions were removed.

## Evidence

Actual before/after proof ran on Linux arm64 / Node 24.19.0 through the supported Gateway CLI, the registered **signed Slack HTTP webhook**, real agent dispatch and typing callbacks, and the installed Slack WebClient against a loopback API. Only external Slack/model endpoints were fixtures; the monitor, dispatch, context, SDK response handling and normal file logger were real.

| Scenario | Baseline diagnostics | Candidate diagnostics |
| --- | ---: | ---: |
| Processing accepted, active rejected | **0** | **1** |
| Both writes accepted | 0 | 0 |
| Processing rejected | 0 | 0 |
| Active accepted, aggregate still processing | 0 | 0 |

Every scenario delivered the scripted final reply, wrote `processing` then `active` exactly once, and completed typing-reaction cleanup. Each isolated Gateway was stopped before reading its log. The baseline failed the required diagnostic assertion; the candidate passed the same driver.

Observed normal-level error:

```text
Slack session status could not return to active after processing. Enable verbose logging to inspect the Slack API failure.
```

- Baseline: `7a932d9794421961e45a4715b08d63db74b7fb2d`; the affected owners were unchanged on subsequently checked main `2e053112b61f34964d4b0c360e3562c71f728e99`.
- Candidate: `947b7bd6622af803009bf9ce31b772ec6b2777e1`; committed production hashes match the observed runtime.
- Regression on unmodified baseline: **4 expected failures and 5 passing controls**. The candidate also covers no thread, repeated cleanup, quiet accepted/aggregate-status controls, privacy, failed title rename, and cleanup when the logger throws.
- **501 focused tests passed across seven files**: 471 Slack tests and 30 shared typing lifecycle tests. The nine diagnostic cases and real Gateway flow were rerun after final message-guidance cleanup. Media fixtures used deterministic DNS inside the network-isolated container; no media or network-policy source was changed.
- Targeted type-aware Oxlint, Oxfmt, counted-line growth check and `git diff --check` passed. Full static/matrix validation remains hosted.

```bash
node scripts/run-vitest.mjs \
  extensions/slack/src/monitor/message-handler/dispatch.status-diagnostics.test.ts \
  extensions/slack/src/monitor/context.test.ts \
  extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts \
  extensions/slack/src/monitor/message-handler/prepare.test.ts \
  extensions/slack/src/monitor/events/agent.test.ts \
  extensions/slack/src/delivery-trace.test.ts \
  src/channels/typing.test.ts
```

No live Slack workspace or Desktop rendering was exercised, and no retry, status reordering, dependency, schema or permission change is included.
