### PR TITLE
fix(agents): keep the bash process registry process-wide

### DIFF
--- a/src/agents/bash-process-registry.instances.test.ts
+++ b/src/agents/bash-process-registry.instances.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Duplicated registry module instances must observe one process-wide state.
+ *
+ * The bash process registry is reloaded once per bundle that inlines it (the
+ * shared Gateway chunk and the self-contained worker bundle), and the test
+ * support helper documents that "a later module evaluation may replace the
+ * global slot while existing callers still own the original instance".
+ *
+ * A background exec admitted through one module instance has to stay visible to
+ * the readers served by another instance: the runtime "Active exec sessions"
+ * carrier is fed by `listActiveProcessSessionReferences()`, while the `process`
+ * tool reads the registry directly. When the state is per instance rather than
+ * per process those two readers disagree about the same run.
+ *
+ * Registry state is process-wide, so every case resets it explicitly, the same
+ * way the rest of the registry suite isolates its own sessions.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createProcessSessionFixture } from "./bash-process-registry.test-helpers.js";
+import { resetProcessRegistryForTests } from "./bash-process-registry.test-support.js";
+
+const SCOPE_KEY = "agent:main:registry-instance-probe";
+
+describe("bash process registry across module instances", () => {
+  beforeEach(() => {
+    resetProcessRegistryForTests();
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    resetProcessRegistryForTests();
+    vi.resetModules();
+  });
+
+  it("shows a background session admitted by another module instance", async () => {
+    const writer = await import("./bash-process-registry.js");
+    vi.resetModules();
+    const reader = await import("./bash-process-references.js");
+
+    const session = createProcessSessionFixture({ id: "instance-probe", backgrounded: true });
+    session.scopeKey = SCOPE_KEY;
+    writer.addSession(session);
+
+    expect(reader.listActiveProcessSessionReferences({ scopeKey: SCOPE_KEY })).toMatchObject([
+      { sessionId: "instance-probe", status: "running" },
+    ]);
+  });
+
+  it("keeps the carrier reader working for its own instance (control)", async () => {
+    const reader = await import("./bash-process-references.js");
+    const readerRegistry = await import("./bash-process-registry.js");
+
+    const session = createProcessSessionFixture({ id: "own-instance-probe", backgrounded: true });
+    session.scopeKey = SCOPE_KEY;
+    readerRegistry.addSession(session);
+
+    expect(reader.listActiveProcessSessionReferences({ scopeKey: SCOPE_KEY })).toMatchObject([
+      { sessionId: "own-instance-probe", status: "running" },
+    ]);
+  });
+
+  it("keeps the scope filter closed to other scopes (control)", async () => {
+    const writer = await import("./bash-process-registry.js");
+    vi.resetModules();
+    const reader = await import("./bash-process-references.js");
+
+    const session = createProcessSessionFixture({ id: "other-scope-probe", backgrounded: true });
+    session.scopeKey = "agent:other:elsewhere";
+    writer.addSession(session);
+
+    expect(reader.listActiveProcessSessionReferences({ scopeKey: SCOPE_KEY })).toEqual([]);
+  });
+});

--- a/src/agents/bash-process-registry.test.ts
+++ b/src/agents/bash-process-registry.test.ts
@@ -402,7 +402,7 @@ describe("bash process registry", () => {
     expect(getActiveBackgroundExecSessionCount()).toBe(0);
   });
 
-  it("resets its own registry after another module instance replaces the global test API", async () => {
+  it("shares one registry with a later module instance and resets it", async () => {
     const testApiKey = Symbol.for("openclaw.bashProcessRegistryTestApi");
     const globalStore = globalThis as Record<PropertyKey, unknown>;
     const originalTestApi = globalStore[testApiKey];
@@ -420,10 +420,17 @@ describe("bash process registry", () => {
         registrySpecifier
       )) as typeof import("./bash-process-registry.js");
       expect(globalStore[testApiKey]).not.toBe(originalTestApi);
-      expect(reloadedRegistry.listRunningSessions()).toEqual([]);
+      // One registry per process: a later module evaluation observes the session the original
+      // instance admitted instead of starting from its own empty Maps. Per-instance state is
+      // what lets the runtime "Active exec sessions" carrier and the `process` tool disagree
+      // about the same run when the two copies are served by different bundles.
+      expect(reloadedRegistry.listRunningSessions().map((entry) => entry.id)).toContain(
+        "original-registry-session",
+      );
 
       resetProcessRegistryForTests();
       expect(listRunningSessions()).toEqual([]);
+      expect(reloadedRegistry.listRunningSessions()).toEqual([]);
     } finally {
       globalStore[testApiKey] = originalTestApi;
       resetProcessRegistryForTests();

--- a/src/agents/bash-process-registry.ts
+++ b/src/agents/bash-process-registry.ts
@@ -12,6 +12,7 @@ import type {
   TerminationReason,
 } from "../process/supervisor/types.js";
 import { createDeferredCore, type Deferred } from "../shared/deferred.js";
+import { resolveGlobalSingleton } from "../shared/global-singleton.js";
 import type { DeliveryContext } from "../utils/delivery-context.types.js";
 import { readEnvInt } from "./bash-tools.shared.js";
 
@@ -113,19 +114,50 @@ export interface ProcessSession {
   cursorKeyMode: "unknown" | "normal" | "application";
 }
 
-const runningSessions = new Map<string, ProcessSession>();
-const finishedSessions = new Map<string, ProcessSession & { endedAt: number; expiresAt: number }>();
-// Display uses start chronology; retained records are evicted in completion order.
-let processSessionStartOrders = new WeakMap<object, number>();
-let nextProcessSessionStartOrder = 0;
-// Promotion stays live when process removal clears its presentation state.
-const activeExecSessions = new Map<
-  string,
-  { session: ProcessSession; promoted: boolean; settled?: Deferred }
->();
-let finishedSessionOutputChars = 0;
+/** One process-wide registry state, shared by every module instance that owns it. */
+type BashProcessRegistryState = {
+  runningSessions: Map<string, ProcessSession>;
+  finishedSessions: Map<string, ProcessSession & { endedAt: number; expiresAt: number }>;
+  // Display uses start chronology; retained records are evicted in completion order.
+  processSessionStartOrders: WeakMap<object, number>;
+  nextProcessSessionStartOrder: number;
+  // Promotion stays live when process removal clears its presentation state.
+  activeExecSessions: Map<
+    string,
+    { session: ProcessSession; promoted: boolean; settled?: Deferred }
+  >;
+  finishedSessionOutputChars: number;
+  sweeper: NodeJS.Timeout | null;
+};
 
-let sweeper: NodeJS.Timeout | null = null;
+// State is per PROCESS, not per module instance: this module is inlined into more than one
+// bundle (the shared Gateway chunk and the self-contained worker bundle), and every evaluation
+// would otherwise start its own Maps. Readers served by different copies then disagree about
+// the same run, and state that must be shared across surfaces belongs behind
+// `resolveGlobalSingleton` -- the runtime "Active exec sessions" carrier and the `process` tool
+// are exactly two such readers, and a session admitted through one copy is invisible to the
+// other. Reverting this to module-level state reintroduces that split: a backgrounded run can
+// be live and pollable through one copy while the carrier that is supposed to surface it reports
+// nothing, and an exit processed by one copy leaves a stale record that the other never reaps.
+const registryState = resolveGlobalSingleton<BashProcessRegistryState>(
+  Symbol.for("openclaw.bashProcessRegistry"),
+  () => ({
+    runningSessions: new Map<string, ProcessSession>(),
+    finishedSessions: new Map<string, ProcessSession & { endedAt: number; expiresAt: number }>(),
+    processSessionStartOrders: new WeakMap<object, number>(),
+    nextProcessSessionStartOrder: 0,
+    activeExecSessions: new Map<
+      string,
+      { session: ProcessSession; promoted: boolean; settled?: Deferred }
+    >(),
+    finishedSessionOutputChars: 0,
+    sweeper: null,
+  }),
+);
+
+const runningSessions = registryState.runningSessions;
+const finishedSessions = registryState.finishedSessions;
+const activeExecSessions = registryState.activeExecSessions;
 
 /** Return whether a process session id is live, retained, or reserved for notification. */
 export function isProcessSessionIdTaken(id: string): boolean {
@@ -134,7 +166,10 @@ export function isProcessSessionIdTaken(id: string): boolean {
 
 /** Adds a running session; retention starts only after background completion. */
 export function addSession(session: ProcessSession) {
-  processSessionStartOrders.set(session, nextProcessSessionStartOrder++);
+  registryState.processSessionStartOrders.set(
+    session,
+    registryState.nextProcessSessionStartOrder++,
+  );
   runningSessions.set(session.id, session);
   activeExecSessions.set(session.id, { session, promoted: session.backgrounded });
 }
@@ -146,7 +181,8 @@ export function compareProcessSessionStartOrder(
 ): number {
   return (
     right.startedAt - left.startedAt ||
-    processSessionStartOrders.get(right)! - processSessionStartOrders.get(left)!
+    registryState.processSessionStartOrders.get(right)! -
+      registryState.processSessionStartOrders.get(left)!
   );
 }
 
@@ -166,7 +202,7 @@ function deleteFinishedSession(id: string): boolean {
     return false;
   }
   finishedSessions.delete(id);
-  finishedSessionOutputChars -= session.aggregated.length;
+  registryState.finishedSessionOutputChars -= session.aggregated.length;
   return true;
 }
 
@@ -409,10 +445,11 @@ function moveToFinished(session: ProcessSession) {
     session.id,
     Object.assign(session, { endedAt, expiresAt: endedAt + session.cleanupMs }),
   );
-  finishedSessionOutputChars += session.aggregated.length;
+  registryState.finishedSessionOutputChars += session.aggregated.length;
   while (
     finishedSessions.size > MAX_FINISHED_SESSION_COUNT ||
-    (finishedSessions.size > 1 && finishedSessionOutputChars > MAX_FINISHED_SESSION_OUTPUT_CHARS)
+    (finishedSessions.size > 1 &&
+      registryState.finishedSessionOutputChars > MAX_FINISHED_SESSION_OUTPUT_CHARS)
   ) {
     const oldestSessionId = finishedSessions.keys().next().value;
     if (oldestSessionId === undefined) {
@@ -479,9 +516,9 @@ export function listFinishedSessions() {
 function resetProcessRegistryForTests() {
   runningSessions.clear();
   finishedSessions.clear();
-  processSessionStartOrders = new WeakMap();
-  nextProcessSessionStartOrder = 0;
-  finishedSessionOutputChars = 0;
+  registryState.processSessionStartOrders = new WeakMap();
+  registryState.nextProcessSessionStartOrder = 0;
+  registryState.finishedSessionOutputChars = 0;
   for (const active of activeExecSessions.values()) {
     active.settled?.resolve();
   }
@@ -508,14 +545,14 @@ function scheduleSweeper() {
   if (!Number.isFinite(nextExpiration)) {
     return;
   }
-  sweeper = setTimeout(scheduleSweeper, nextExpiration - now);
-  sweeper.unref?.();
+  registryState.sweeper = setTimeout(scheduleSweeper, nextExpiration - now);
+  registryState.sweeper.unref?.();
 }
 
 function stopSweeper() {
-  if (!sweeper) {
+  if (!registryState.sweeper) {
     return;
   }
-  clearTimeout(sweeper);
-  sweeper = null;
+  clearTimeout(registryState.sweeper);
+  registryState.sweeper = null;
 }


### PR DESCRIPTION
Fixes #145779.

## What Problem This Solves
The bash process registry keeps its state in module-level declarations, so every evaluation of `src/agents/bash-process-registry.ts` starts its own Maps. The module is inlined into more than one bundle, the shared Gateway chunk and the self-contained worker bundle, and readers reached through different copies then disagree about the same run: a backgrounded exec can stay alive and pollable through the `process` tool while the injected runtime "Active exec sessions" carrier, which reads the same registry through `listActiveProcessSessionReferences()`, reports `none` on every turn. The mirror case is a record whose exit one copy processed and the other never reaped, which is why the carrier can also list a session with a dead pid.

This is the same class as #45994 and the fix in #43683, where a mutable module-scoped registry duplicated across bundled chunks let one process disagree with itself about session state.

## Change
- Move the registry's Maps, counters and sweeper behind `resolveGlobalSingleton(Symbol.for("openclaw.bashProcessRegistry"), ...)`, the pattern #43683 established for chunk duplication and that `agentJobState`, `sessionMaintenance` and the agent event bus already use.
- Keep the existing module-level bindings as aliases of the shared Maps so the rest of the file, and its callers, are unchanged.
- Update `src/agents/bash-process-registry.test.ts` case "resets its own registry after another module instance replaces the global test API": with one process-wide registry, a later module evaluation must observe the original instance's session instead of starting from its own empty Maps, which is the behaviour that split the readers.

## Evidence
Live observation on 2026.9.3, macOS 26.6.2 arm64, Node 26.7.0, 2026-09-11 18:45 to 19:05 PDT: the injected carrier read `Active exec sessions: none` on every turn for twenty minutes, while `process list` in those same turns reported live sessions, up to three at once, for example `tidal-basil running 7m :: for i`, and the run's log grew a line every ten seconds. The reproduction command is in the issue.

Registry instances in one process, on the shipped dist, both bundles loaded into a single Node process: two distinct registry test APIs are published into the shared global slot, and a session admitted through one instance survives `resetProcessRegistryForTests()` on the other. Control: resetting the owning instance does clear it, so the check is sound. Script kept on the fork branch `evidence/bash-process-registry-instance-probe`.

Failing-then-passing test, new `src/agents/bash-process-registry.instances.test.ts`, in the fresh-import style the registry suite already uses for a second module instance. On current main it fails with the production symptom, `expected [] to match object [{ sessionId: "instance-probe", status: "running" }]`, while both controls pass. With this change all three pass, and the suite reports 30 passing across `bash-process-registry.instances.test.ts`, `bash-process-registry.test.ts` and `bash-process-references.test.ts` against 28 passing with the two cross-instance assertions failing on main. `oxlint` reports no warnings or errors and `oxfmt --check` is clean.

Scope filter ruled out, which is what leaves the registry instance as the only remaining variable. Enumerating attempt field states and resolving both keys the way production does (carrier: `attempt.sessionKey`, `attempt.sessionId`, `sessionAgentId`; tools: `runSessionKey = attempt.sessionKey?.trim() || attempt.sessionId`, `sessionId`, `executionAgentId`) shows the two keys agree in every state, including a sandbox key that differs from the session key, a blank session key and no session key at all. The single divergence needs a caller-supplied `exec.scopeKey`, and no production caller sets one. Evidence: `src/agents/bash-process-scope.validation.test.ts` on the same fork branch.

## Not verified here
Which bundle supplies the carrier's own copy inside a live Gateway process. The worker bundle's prewarm runs as a child process and no third copy of the registry exists in the install, so the split is established as the only remaining explanation for the observation above rather than as a directly measured cause. The decisive follow-up is an in-process read of the live gateway registry, which needs an inspector this build does not expose, since `SIGUSR1` is the gateway's own in-process restart signal.
