### PR TITLE
fix(cron): report failed runs when scheduled accounts are unavailable

### DIFF
--- a/docs/automation/cron-jobs/troubleshooting.md
+++ b/docs/automation/cron-jobs/troubleshooting.md
@@ -32,6 +32,8 @@ openclaw doctor
     - Confirm the Gateway is running continuously.
     - For `cron` schedules, verify timezone (`--tz`) vs the host timezone.
     - `reason: not-due` in run output means the manual run was checked with `openclaw automations run <jobId> --due` and the job was not due yet.
+    - If the job's execution agent cannot be resolved, automatic and manual attempts record a failed task and a skipped run-history entry with the reason. Select an agent with `openclaw automations edit <jobId> --agent <id>`.
+    - If a capped job's stored named creator account is unavailable, the run fails before model/tool execution. Job details, run history, and warning logs name the account. Re-add it to the channel configuration, or recreate the automation from the intended account; changing the delivery `--account` does not change creator authority. Legacy jobs without account metadata keep their existing execution policy.
 
   </Accordion>
   <Accordion title="Job fired but no delivery">

--- a/src/agents/agent-tools.create-openclaw-coding-tools.test.ts
+++ b/src/agents/agent-tools.create-openclaw-coding-tools.test.ts
@@ -1536,7 +1536,16 @@ describe("createOpenClawCodingTools", () => {
     createOpenClawToolsMock.mockClear();
 
     createOpenClawCodingTools({
-      config: testConfig,
+      config: {
+        ...testConfig,
+        channels: {
+          discord: {
+            accounts: {
+              creator: {},
+            },
+          },
+        },
+      },
       agentAccountId: "delivery",
       scheduledToolPolicy: {
         version: 1,
@@ -1560,9 +1569,19 @@ describe("createOpenClawCodingTools", () => {
     createOpenClawToolsMock.mockClear();
 
     createOpenClawCodingTools({
-      config: testConfig,
+      config: {
+        ...testConfig,
+        channels: {
+          discord: {
+            accounts: {
+              creator: {},
+            },
+          },
+        },
+      },
       agentAccountId: "delivery",
       messageChannel: "discord",
+      messageProvider: "discord",
       scheduledToolPolicy: {
         version: 1,
         mode: "account",

--- a/src/agents/agent-tools.policy.test.ts
+++ b/src/agents/agent-tools.policy.test.ts
@@ -15,6 +15,7 @@ import { createWarnLogCapture } from "../logging/test-helpers/warn-log-capture.j
 import {
   resolveEffectiveToolPolicy,
   resolveGroupToolPolicy,
+  resolveGroupToolPolicyOutcome,
   resolveInheritedToolPolicyForSession,
   resolveSubagentToolPolicyForSession,
   resolveTrustedGroupId,
@@ -218,44 +219,37 @@ describe("resolveGroupToolPolicy group context validation", () => {
     expect(policy).toEqual({ allow: ["read"] });
   });
 
-  it("fails closed when scheduled authority names a removed account", () => {
-    expect(
-      resolveGroupToolPolicy({
+  it.each(["agent:main:whatsapp:group:safe-room", "agent:main:main"])(
+    "reports unavailable scheduled authority for %s before tool construction",
+    (sessionKey) => {
+      const params = {
         config: cfg,
-        sessionKey: "agent:main:whatsapp:group:safe-room",
+        sessionKey,
         accountId: "removed",
         requireConfiguredAccount: true,
+      };
+      expect(resolveGroupToolPolicyOutcome(params)).toMatchObject({
+        kind: "account-unavailable",
+        accountId: "removed",
+        message: expect.stringContaining('Scheduled account "removed" is unavailable'),
+      });
+      expect(() => resolveGroupToolPolicy(params)).toThrow(
+        'Scheduled account "removed" is unavailable',
+      );
+    },
+  );
+
+  it("preserves intentional deny-all policy for a configured scheduled account", () => {
+    expect(
+      resolveGroupToolPolicyOutcome({
+        config: {
+          channels: { whatsapp: { groups: { "safe-room": { tools: { deny: ["*"] } } } } },
+        },
+        sessionKey: "agent:main:whatsapp:group:safe-room",
+        accountId: "default",
+        requireConfiguredAccount: true,
       }),
-    ).toEqual({ allow: [], deny: ["*"] });
-  });
-
-  it("denies every tool when scheduled authority names a removed account", () => {
-    const policy = resolveGroupToolPolicy({
-      config: cfg,
-      sessionKey: "agent:main:whatsapp:group:safe-room",
-      accountId: "removed",
-      requireConfiguredAccount: true,
-    });
-    const tools = [
-      createStubTool("read"),
-      createStubTool("write"),
-      createStubTool("exec"),
-      createStubTool("apply_patch"),
-    ];
-    expect(filterToolsByPolicy(tools, policy)).toStrictEqual([]);
-    expect(isToolAllowedByPolicyName("exec", policy)).toBe(false);
-    expect(isToolAllowedByPolicyName("apply_patch", policy)).toBe(false);
-  });
-
-  it("fails closed when scheduled authority names a removed account without channel context", () => {
-    const policy = resolveGroupToolPolicy({
-      config: cfg,
-      sessionKey: "agent:main:main",
-      accountId: "removed",
-      requireConfiguredAccount: true,
-    });
-    expect(policy).toEqual({ allow: [], deny: ["*"] });
-    expect(isToolAllowedByPolicyName("exec", policy)).toBe(false);
+    ).toMatchObject({ kind: "resolved", policy: { deny: ["*"] } });
   });
 
   it("resolves scheduled group policy for a still-configured named account", () => {

--- a/src/agents/agent-tools.policy.ts
+++ b/src/agents/agent-tools.policy.ts
@@ -486,12 +486,20 @@ export function resolveEffectiveToolPolicy(params: {
   return { ...effectivePolicy, gatewayConfigReadAllowed };
 }
 
-function denyAllToolPolicy(): SandboxToolPolicy {
-  return { allow: [], deny: ["*"] };
+type GroupToolPolicyOutcome =
+  | { kind: "resolved"; policy?: SandboxToolPolicy }
+  | { kind: "account-unavailable"; accountId: string; message: string };
+
+function unavailableScheduledAccount(accountId: string): GroupToolPolicyOutcome {
+  return {
+    kind: "account-unavailable",
+    accountId,
+    message: `Scheduled account "${accountId}" is unavailable. Re-add it to the channel configuration, or recreate this automation from the intended account.`,
+  };
 }
 
-/** Resolve group-scoped tool policy after validating session provenance. */
-export function resolveGroupToolPolicy(params: {
+/** Resolve policy without conflating unavailable scheduled authority with intentional denial. */
+export function resolveGroupToolPolicyOutcome(params: {
   config?: OpenClawConfig;
   sessionKey?: string;
   spawnedBy?: string | null;
@@ -507,9 +515,9 @@ export function resolveGroupToolPolicy(params: {
   senderName?: string | null;
   senderUsername?: string | null;
   senderE164?: string | null;
-}): SandboxToolPolicy | undefined {
+}): GroupToolPolicyOutcome {
   if (!params.config) {
-    return undefined;
+    return { kind: "resolved" };
   }
   const sessionContext = resolveGroupContextFromSessionKey(params.sessionKey);
   const spawnedContext = resolveGroupContextFromSessionKey(params.spawnedBy);
@@ -530,8 +538,8 @@ export function resolveGroupToolPolicy(params: {
   const accountId = normalizeAccountId(params.accountId);
   if (!channel) {
     return params.requireConfiguredAccount && accountId !== DEFAULT_ACCOUNT_ID
-      ? denyAllToolPolicy()
-      : undefined;
+      ? unavailableScheduledAccount(accountId)
+      : { kind: "resolved" };
   }
   let plugin;
   try {
@@ -550,13 +558,11 @@ export function resolveGroupToolPolicy(params: {
       configured = false;
     }
     if (!configured) {
-      // A named creator account is an authority boundary, not a fallback hint.
-      // If it disappears, deny the scheduled surface instead of selecting default config.
-      return denyAllToolPolicy();
+      return unavailableScheduledAccount(accountId);
     }
   }
   if (groupIds.length === 0) {
-    return undefined;
+    return { kind: "resolved" };
   }
   for (const groupId of groupIds) {
     const toolsConfig = plugin?.groups?.resolveToolPolicy?.({
@@ -573,7 +579,7 @@ export function resolveGroupToolPolicy(params: {
     });
     const policy = pickSandboxToolPolicy(toolsConfig);
     if (policy) {
-      return policy;
+      return { kind: "resolved", policy };
     }
   }
   const configTools = resolveChannelGroupToolsPolicy({
@@ -589,5 +595,16 @@ export function resolveGroupToolPolicy(params: {
     senderUsername: params.senderUsername,
     senderE164: params.senderE164,
   });
-  return pickSandboxToolPolicy(configTools);
+  return { kind: "resolved", policy: pickSandboxToolPolicy(configTools) };
+}
+
+/** Tool-building callers must stop before exposing a surface with unavailable authority. */
+export function resolveGroupToolPolicy(
+  params: Parameters<typeof resolveGroupToolPolicyOutcome>[0],
+): SandboxToolPolicy | undefined {
+  const outcome = resolveGroupToolPolicyOutcome(params);
+  if (outcome.kind === "account-unavailable") {
+    throw new Error(outcome.message);
+  }
+  return outcome.policy;
 }

--- a/src/agents/conversation-capability-profile.test.ts
+++ b/src/agents/conversation-capability-profile.test.ts
@@ -12,7 +12,6 @@ import { createTestRegistry } from "../test-utils/channel-plugins.js";
 import { INTERNAL_MESSAGE_CHANNEL } from "../utils/message-channel.js";
 import { resolveConversationCapabilityProfile } from "./conversation-capability-profile.js";
 import { projectConversationToolNames } from "./conversation-tool-policy-pipeline.js";
-import { isToolAllowedByPolicyName } from "./tool-policy-match.js";
 
 describe("resolveConversationCapabilityProfile", () => {
   it("intersects base and provider profile contributions from plugin manifests", () => {
@@ -493,12 +492,7 @@ describe("resolveConversationCapabilityProfile scheduled account authority", () 
     expect(scheduledProfile({ work: {} }).policy.groupPolicy).toEqual({ allow: ["read"] });
   });
 
-  it("denies every tool for a scheduled run after its owner account is removed", () => {
-    const groupPolicy = scheduledProfile({}).policy.groupPolicy;
-
-    expect(groupPolicy).toEqual({ allow: [], deny: ["*"] });
-    for (const toolName of ["read", "write", "exec", "apply_patch"]) {
-      expect(isToolAllowedByPolicyName(toolName, groupPolicy)).toBe(false);
-    }
+  it("rejects a scheduled run after its owner account is removed", () => {
+    expect(() => scheduledProfile({})).toThrow('Scheduled account "work" is unavailable');
   });
 });

--- a/src/cron/isolated-agent/run-executor.ts
+++ b/src/cron/isolated-agent/run-executor.ts
@@ -5,6 +5,7 @@ import {
   createOperationalRunInstanceRef,
   prepareAgentRunAdmission,
 } from "../../agents/admitted-run-context.js";
+import { resolveGroupToolPolicyOutcome } from "../../agents/agent-tools.policy.js";
 import type { BootstrapContextMode } from "../../agents/bootstrap-files.js";
 import { resolveCliBackendConfig } from "../../agents/cli-backends.js";
 import {
@@ -337,6 +338,19 @@ function createCronPromptExecutor(
   const { sourceDelivery } = params;
   const sourceReplyDeliveryMode = sourceDelivery.sourceReplyDeliveryMode;
   const messageChannel = sourceDelivery.target.channel ?? params.resolvedDelivery.channel;
+  if (scheduledToolPolicy?.mode === "account") {
+    const policyOutcome = resolveGroupToolPolicyOutcome({
+      config: params.cfgWithAgentDefaults,
+      sessionKey: scheduledToolPolicy.ownerSessionKey,
+      messageProvider: messageChannel,
+      accountId: scheduledToolPolicy.ownerAccountId,
+      requireConfiguredAccount: true,
+      senderPolicyMode: "never",
+    });
+    if (policyOutcome.kind === "account-unavailable") {
+      throw new Error(policyOutcome.message);
+    }
+  }
   // Cron prompts may intentionally have nothing to report; both runners must agree on silence.
   const allowEmptyAssistantReplyAsSilent = true;
   const finalizePromptForResolvedTools = ({

--- a/src/cron/isolated-agent/run.account-policy.test.ts
+++ b/src/cron/isolated-agent/run.account-policy.test.ts
@@ -1,0 +1,149 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createCronRegressionState,
+  createDueIsolatedJob,
+  noopLogger,
+  setupCronRegressionFixtures,
+} from "../../../test/helpers/cron/service-regression-fixtures.js";
+import "../../agents/test-helpers/fast-coding-tools.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { listTaskRegistryRecordsByRuntimeSourceIdFromSqlite } from "../../tasks/task-registry.store.sqlite.js";
+import { resetTaskRegistryForTests } from "../../tasks/task-runtime.test-helpers.js";
+import { stop } from "../service/ops-lifecycle.js";
+import { list } from "../service/ops-read.js";
+import type { CronEvent } from "../service/state.js";
+import { onTimer } from "../service/timer-scheduler.js";
+import { loadCronStore, saveCronStore } from "../store.js";
+import { cronStoreKey } from "../store/key.js";
+import { readCronTaskRunHistoryPage } from "../task-run-history.js";
+import type { CronJob } from "../types.js";
+import {
+  getChannelPluginMock,
+  loadRunCronIsolatedAgentTurn,
+  mockRunCronFallbackPassthrough,
+  resetRunCronIsolatedAgentTurnHarness,
+  runEmbeddedAgentMock,
+} from "./run.test-harness.js";
+
+const fixtures = setupCronRegressionFixtures({ prefix: "cron-account-outcome-" });
+const runCronIsolatedAgentTurn = await loadRunCronIsolatedAgentTurn();
+
+beforeEach(() => {
+  vi.stubEnv("OPENCLAW_TEST_FAST", "1");
+  resetRunCronIsolatedAgentTurnHarness();
+  mockRunCronFallbackPassthrough();
+  getChannelPluginMock.mockReturnValue({
+    config: {
+      listAccountIds: (cfg: OpenClawConfig) => [
+        "default",
+        ...Object.keys(cfg.channels?.whatsapp?.accounts ?? {}),
+      ],
+    },
+  });
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  resetTaskRegistryForTests({ persist: false });
+});
+
+describe("scheduled account policy outcomes", () => {
+  it.each([
+    { name: "removed named account", accountId: "removed", toolsAllow: ["read"], fails: true },
+    { name: "configured named account", accountId: "work", toolsAllow: ["read"], fails: false },
+    { name: "default account", accountId: "default", toolsAllow: ["read"], fails: false },
+    { name: "legacy accountless cap", accountId: undefined, toolsAllow: ["read"], fails: false },
+    { name: "legacy capless job", accountId: undefined, toolsAllow: undefined, fails: false },
+    { name: "intentional no-tool job", accountId: "work", toolsAllow: [], fails: false },
+  ])(
+    "records $name through scheduler and history",
+    async ({ name, accountId, toolsAllow, fails }) => {
+      const { storePath } = fixtures.makeStorePath();
+      const cfg: OpenClawConfig = { channels: { whatsapp: { accounts: { work: {} } } } };
+      const ownerSessionKey = "agent:main:whatsapp:group:team";
+      const job: CronJob = {
+        ...createDueIsolatedJob({
+          id: name.replaceAll(" ", "-"),
+          nowMs: Date.now(),
+          nextRunAtMs: Date.now(),
+        }),
+        agentId: "main",
+        owner: {
+          agentId: "main",
+          sessionKey: ownerSessionKey,
+          ...(accountId ? { accountId } : {}),
+        },
+        payload: { kind: "agentTurn", message: "Summarize the report", toolsAllow },
+        scheduledToolPolicy: {
+          version: 1,
+          mode: "account",
+          ownerSessionKey,
+          ownerAccountId: accountId ?? "removed",
+        },
+      };
+      await saveCronStore(storePath, { version: 1, jobs: [job] });
+      const events: CronEvent[] = [];
+      const warn = vi.fn();
+      const state = createCronRegressionState({
+        storePath,
+        defaultAgentId: "main",
+        log: { ...noopLogger, warn },
+        onEvent: (event) => events.push(structuredClone(event)),
+        runIsolatedAgentJob: (params) =>
+          runCronIsolatedAgentTurn({
+            ...params,
+            cfg,
+            deps: {},
+            sessionKey: `cron:${params.job.id}`,
+          }),
+      });
+      try {
+        await list(state);
+        await onTimer(state);
+        const persisted = (await loadCronStore(storePath)).jobs[0];
+        const history = readCronTaskRunHistoryPage({
+          storeKey: cronStoreKey(storePath),
+          jobId: job.id,
+        });
+        const tasks = listTaskRegistryRecordsByRuntimeSourceIdFromSqlite({
+          runtime: "cron",
+          sourceId: job.id,
+        });
+        expect(history.entries).toHaveLength(1);
+        expect(tasks).toHaveLength(1);
+        const expectedStatus = fails ? "error" : "ok";
+        expect(persisted?.state.lastRunStatus).toBe(expectedStatus);
+        expect(history.entries[0]).toMatchObject({
+          status: expectedStatus,
+          completionStatus: fails ? "failed" : "succeeded",
+        });
+        expect(tasks[0]?.status).toBe(fails ? "failed" : "succeeded");
+        expect(events.filter((event) => event.action === "finished")).toEqual([
+          expect.objectContaining({ status: expectedStatus }),
+        ]);
+        if (fails) {
+          const reason = persisted?.state.lastError;
+          expect(reason).toContain('Scheduled account "removed" is unavailable');
+          expect(reason).toContain("Re-add");
+          expect(history.entries[0]?.error).toBe(reason);
+          expect(history.entries[0]?.diagnostics?.summary).toContain(reason);
+          expect(persisted?.state.lastDiagnosticSummary).toContain(reason);
+          expect(warn).toHaveBeenCalledWith(
+            expect.objectContaining({ error: reason }),
+            "cron: job run returned error status",
+          );
+          expect(runEmbeddedAgentMock).not.toHaveBeenCalled();
+        } else {
+          expect(persisted?.state.lastError).toBeUndefined();
+          expect(runEmbeddedAgentMock).toHaveBeenCalledTimes(1);
+          expect(runEmbeddedAgentMock.mock.calls[0]?.[0].toolsAllow).toEqual(toolsAllow);
+          if (!accountId) {
+            expect(runEmbeddedAgentMock.mock.calls[0]?.[0].scheduledToolPolicy).toBeUndefined();
+          }
+        }
+      } finally {
+        stop(state);
+      }
+    },
+  );
+});

--- a/src/cron/service/run-admission.ownerless.test.ts
+++ b/src/cron/service/run-admission.ownerless.test.ts
@@ -35,6 +35,7 @@ import { list } from "./ops-read.js";
 import { enqueueRun, run } from "./ops-run.js";
 import { persistQueuedCronRunReservations } from "./run-admission.js";
 import type { CronEvent, CronServiceState } from "./state.js";
+import { onTimer } from "./timer-scheduler.js";
 
 const NOW = Date.parse("2026-09-06T20:24:00.000Z");
 const fixtures = setupCronRegressionFixtures({
@@ -119,7 +120,14 @@ describe("ownerless reservation and manual completion", () => {
       expect(events.filter((event) => event.action === "finished")).toEqual([
         expect.objectContaining({ jobId: ownerless.id, status: "skipped" }),
       ]);
-      expect(history(storePath, ownerless.id)).toEqual([]);
+      expect(history(storePath, ownerless.id)).toEqual([
+        expect.objectContaining({
+          jobId: ownerless.id,
+          status: "skipped",
+          completionStatus: "failed",
+          error: CRON_AGENT_SELECTION_REQUIRED_MESSAGE,
+        }),
+      ]);
       expect(receipts(storePath, ownerless.id)).toEqual([]);
       expect(execute).not.toHaveBeenCalled();
     } finally {
@@ -133,52 +141,68 @@ describe("ownerless reservation and manual completion", () => {
     }
   });
 
-  it("records one durable manual skip without an agent, session, or execution receipt", async () => {
-    const job = commandJob("ownerless-manual-history", NOW + 3_600_000);
-    const { state, storePath, events, execute, finished } = await setupOwnerlessJob(job);
-    const revision = resolveCronJobConfigRevision(job);
-    const ack = await enqueueRun(state, job.id, "force");
-    if (!ack.ok || !("enqueued" in ack) || !ack.enqueued) {
-      throw new Error("Expected an acknowledged manual run");
-    }
-    await finished.promise;
-    await vi.waitFor(() => expect(getTotalQueueSize()).toBe(0));
-    const terminal = {
-      jobId: job.id,
-      runId: ack.runId,
-      status: "skipped",
-      completionStatus: "failed",
-      error: CRON_AGENT_SELECTION_REQUIRED_MESSAGE,
-    };
-    expect(events.filter((event) => event.action === "finished")).toEqual([
-      expect.objectContaining(terminal),
-    ]);
-    expect(history(storePath, job.id, ack.runId)).toEqual([expect.objectContaining(terminal)]);
-    const tasks = listTaskRegistryRecordsByRuntimeSourceIdFromSqlite({
-      runtime: "cron",
-      sourceId: job.id,
-    });
-    expect(tasks).toHaveLength(1);
-    expect(tasks[0]).toMatchObject({
-      scopeKind: "system",
-      ownerKey: "",
-      requesterSessionKey: "",
-      status: "failed",
-      deliveryStatus: "not_applicable",
-      notifyPolicy: "silent",
-    });
-    expect(tasks[0]?.agentId).toBeUndefined();
-    expect(tasks[0]?.requesterAgentId).toBeUndefined();
-    expect(tasks[0]?.childSessionKey).toBeUndefined();
-    expect(receipts(storePath, job.id)).toEqual([]);
-    expect(execute).not.toHaveBeenCalled();
-    const persisted = (await loadCronStore(storePath)).jobs[0]!;
-    expect(persisted.enabled).toBe(true);
-    expect(persisted.schedule).toEqual(job.schedule);
-    expect(persisted.state.nextRunAtMs).toBe(job.state.nextRunAtMs);
-    expect(persisted.payload).toEqual(job.payload);
-    expect(resolveCronJobConfigRevision(persisted)).toBe(revision);
-  });
+  it.each(["automatic", "manual"])(
+    "records one durable %s skip without an agent, session, or execution receipt",
+    async (mode) => {
+      const job = commandJob(
+        `ownerless-${mode}-history`,
+        mode === "manual" ? NOW + 3_600_000 : NOW,
+      );
+      const { state, storePath, events, execute, finished } = await setupOwnerlessJob(job);
+      const revision = resolveCronJobConfigRevision(job);
+      let runId: string | undefined;
+      if (mode === "manual") {
+        const ack = await enqueueRun(state, job.id, "force");
+        if (!ack.ok || !("enqueued" in ack) || !ack.enqueued) {
+          throw new Error("Expected an acknowledged manual run");
+        }
+        runId = ack.runId;
+        await finished.promise;
+        await vi.waitFor(() => expect(getTotalQueueSize()).toBe(0));
+      } else {
+        await onTimer(state);
+      }
+      const terminal = {
+        jobId: job.id,
+        ...(runId ? { runId } : {}),
+        status: "skipped",
+        completionStatus: "failed",
+        error: CRON_AGENT_SELECTION_REQUIRED_MESSAGE,
+      };
+      expect(events.filter((event) => event.action === "finished")).toEqual([
+        expect.objectContaining(terminal),
+      ]);
+      expect(history(storePath, job.id, runId)).toEqual([expect.objectContaining(terminal)]);
+      const tasks = listTaskRegistryRecordsByRuntimeSourceIdFromSqlite({
+        runtime: "cron",
+        sourceId: job.id,
+      });
+      expect(tasks).toHaveLength(1);
+      expect(tasks[0]).toMatchObject({
+        scopeKind: "system",
+        ownerKey: "",
+        requesterSessionKey: "",
+        status: "failed",
+        deliveryStatus: "not_applicable",
+        notifyPolicy: "silent",
+      });
+      expect(tasks[0]?.agentId).toBeUndefined();
+      expect(tasks[0]?.requesterAgentId).toBeUndefined();
+      expect(tasks[0]?.childSessionKey).toBeUndefined();
+      expect(receipts(storePath, job.id)).toEqual([]);
+      expect(execute).not.toHaveBeenCalled();
+      const persisted = (await loadCronStore(storePath)).jobs[0]!;
+      expect(persisted.enabled).toBe(mode === "manual");
+      expect(persisted.schedule).toEqual(job.schedule);
+      expect(persisted.state.nextRunAtMs).toBe(
+        mode === "manual" ? job.state.nextRunAtMs : undefined,
+      );
+      expect(persisted.payload).toEqual(job.payload);
+      if (mode === "manual") {
+        expect(resolveCronJobConfigRevision(persisted)).toBe(revision);
+      }
+    },
+  );
 
   it("preserves the original scheduled slot when an ownerless manual run waits past it", async () => {
     const scheduledAt = NOW + 1_000;

--- a/src/cron/service/run-owner.ts
+++ b/src/cron/service/run-owner.ts
@@ -134,9 +134,7 @@ function emitOwnerlessFinished(
     deliveryStatus: job.state.lastDeliveryStatus,
     deliveryError: job.state.lastDeliveryError,
   };
-  if (manualRun?.runId) {
-    tryFinishCronTaskRun(state, { event, ownerlessManualRun: true });
-  }
+  tryFinishCronTaskRun(state, { event, ownerlessRun: true });
   emit(state, event);
   if (manualRun?.terminalTracker) {
     manualRun.terminalTracker.emitted = true;

--- a/src/cron/service/task-runs.test.ts
+++ b/src/cron/service/task-runs.test.ts
@@ -263,15 +263,15 @@ describe("cron task run terminal records", () => {
   });
 
   it.each([
-    { owner: "assigned", agentId: "finn", ownerlessManualRun: undefined },
-    { owner: "ownerless manual", agentId: undefined, ownerlessManualRun: true as const },
+    { owner: "assigned", agentId: "finn", ownerlessRun: undefined },
+    { owner: "ownerless", agentId: undefined, ownerlessRun: true as const },
   ])("creates terminal history for an $owner skipped-only event", async (testCase) => {
     await withOpenClawTestState(
       { layout: "state-only", prefix: "openclaw-cron-skipped-task-" },
       async () => {
         resetTaskRegistryForTests();
         const startedAt = 1_000;
-        const error = testCase.ownerlessManualRun
+        const error = testCase.ownerlessRun
           ? CRON_AGENT_SELECTION_REQUIRED_MESSAGE
           : "cron: job execution timed out";
         const job: CronJob = {
@@ -301,7 +301,7 @@ describe("cron task run terminal records", () => {
 
         tryFinishCronTaskRun(state, {
           job,
-          ownerlessManualRun: testCase.ownerlessManualRun,
+          ownerlessRun: testCase.ownerlessRun,
           event: {
             jobId: job.id,
             action: "finished",

--- a/src/cron/service/task-runs.ts
+++ b/src/cron/service/task-runs.ts
@@ -301,11 +301,11 @@ function tryCreateCronTaskRunRecord(params: {
   startedAt: number;
   runId: string;
   childSessionKey?: string;
-  ownerlessManualRun?: true;
+  ownerlessRun?: true;
 }): { runId: string; taskId: string; flowId?: string } | undefined {
   try {
     const childSessionKey = params.childSessionKey;
-    const agentId = params.ownerlessManualRun
+    const agentId = params.ownerlessRun
       ? undefined
       : params.job
         ? resolveCronJobEffectiveAgentId(params.job, resolveCurrentDefaultAgentId(params.state))
@@ -418,8 +418,8 @@ export function tryFinishCronTaskRun(
     taskRunId?: string;
     job?: CronJob;
     event: CronEvent & { action: "finished" };
-    /** An acknowledged rejection needs history without claiming an agent executed. */
-    ownerlessManualRun?: true;
+    /** An ownerless attempt needs history without claiming an agent executed. */
+    ownerlessRun?: true;
     errorClassification?: CronRunErrorClassification;
     scriptResult?: { scriptStateChanged?: boolean; scriptState?: unknown };
     triggerEval?: { fired: boolean; stateChanged: boolean; state?: unknown };
@@ -445,7 +445,7 @@ export function tryFinishCronTaskRun(
             startedAt,
             runId: candidateRunId,
             childSessionKey: entry.sessionKey,
-            ownerlessManualRun: result.ownerlessManualRun,
+            ownerlessRun: result.ownerlessRun,
           });
     const taskRunId = existingCandidate?.runtime === "cron" ? candidateRunId : created?.runId;
     if (!taskRunId) {
@@ -521,7 +521,7 @@ export function tryFinishCronTaskRun(
           startedAt,
           runId: taskRunId,
           childSessionKey: entry.sessionKey,
-          ownerlessManualRun: result.ownerlessManualRun,
+          ownerlessRun: result.ownerlessRun,
         });
         if (recreated) {
           updated = finalize(recreated.runId);

--- a/src/gateway/tool-resolution.exclude.test.ts
+++ b/src/gateway/tool-resolution.exclude.test.ts
@@ -274,7 +274,7 @@ describe("resolveGatewayScopedTools excludeToolNames", () => {
     expect(hoisted.createLazyExecToolMock).not.toHaveBeenCalled();
   });
 
-  it("denies loopback tools after the scheduled owner account is removed", () => {
+  it("rejects loopback tool construction after the scheduled owner account is removed", () => {
     const resolveToolPolicy = vi.fn(() => ({ allow: ["read"] }));
     hoisted.getLoadedChannelPluginMock.mockReturnValue({
       config: {
@@ -305,25 +305,29 @@ describe("resolveGatewayScopedTools excludeToolNames", () => {
       surface: "loopback",
       scheduledToolPolicy,
     });
-    const removed = resolveGatewayScopedTools({
-      cfg: {
-        channels: {
-          discord: {
-            accounts: {
-              delivery: {},
+    expect(configured.tools.map((tool) => tool.name)).toEqual(["read"]);
+    hoisted.createOpenClawToolsMock.mockClear();
+    expect(() =>
+      resolveGatewayScopedTools({
+        cfg: {
+          channels: {
+            discord: {
+              accounts: {
+                delivery: {},
+              },
             },
           },
-        },
-      } as OpenClawConfig,
-      sessionKey: "agent:main:cron:run-1",
-      runtimePolicySessionKey: "agent:main:cron:run-1",
-      accountId: "delivery",
-      surface: "loopback",
-      scheduledToolPolicy,
-    });
+        } as OpenClawConfig,
+        sessionKey: "agent:main:cron:run-1",
+        runtimePolicySessionKey: "agent:main:cron:run-1",
+        accountId: "delivery",
+        surface: "loopback",
+        scheduledToolPolicy,
+      }),
+    ).toThrow('Scheduled account "creator" is unavailable');
 
-    expect(configured.tools.map((tool) => tool.name)).toEqual(["read"]);
-    expect(removed.tools).toEqual([]);
+    expect(hoisted.createOpenClawToolsMock).not.toHaveBeenCalled();
+    expect(resolveToolPolicy).toHaveBeenCalledTimes(1);
     expect(resolveToolPolicy).toHaveBeenCalledWith(
       expect.objectContaining({
         accountId: "creator",


### PR DESCRIPTION
Refs #145689

<details>
<summary>Additional instructions</summary>

This branch is in openclaw/openclaw, where maintainers can update it directly.

</details>

## What Problem This Solves

Fixes an issue where users running scheduled automations could see a successful run without the requested work after the job's named creator account was removed. Automatic attempts with no resolvable execution agent also lacked run history despite recording a skipped job.

Reported by @runvouch in #145689: jobs that “quietly stop firing.” This repairs the execution-time visibility gaps; the exact cause of that user's missing export remains unproven. The separate management-path repair is #145730.

## Why This Change Was Made

The configured-account check collapsed unavailable authority into ordinary deny-all tool policy, allowing a model turn to complete successfully with no ordinary tools. The policy owner now returns a closed account-unavailable outcome, and cron rejects that outcome before model execution through its existing error/diagnostic path. Tool-building consumers also fail visibly rather than constructing an empty surface from missing authority.

Automatic ownerless attempts now use the same agentless task/history writer as manual attempts. The former empty-history test assertion protected an oversight, not an intended contract. Production delta: **+29 lines** across the policy outcome, cron execution check, and reuse of the task writer. No schema, configuration, dependency, retention, or recovery changes.

## User Impact

Job details, run history, task status, and warning logs now explain the unavailable account and recovery action. Restore the account in channel configuration or recreate the automation from the intended account. Delivery `--account` does not change creator authority, and execution never substitutes another account.

Legacy jobs missing account metadata keep their ordinary policy path. Configured/default accounts, intentional no-tool jobs, and successful no-fire trigger evaluations retain their behavior.

## Evidence

The scheduler-to-history regression failed on the original account code with `expected 'ok' to be 'error'` (1 failed, 5 compatibility cases passed). The two ownerless regressions failed before their fix with `expected [] to deeply equal [ ObjectContaining{…} ]`; the manual case passed.

- `node scripts/run-vitest.mjs src/cron/isolated-agent/run.account-policy.test.ts src/cron/isolated-agent/run.tools-allow.test.ts src/agents/agent-tools.policy.test.ts` — 71 passed. Checks named error, failed task/history, job diagnostics, warning log, no model call, and preserved legacy/configured/no-tool cases.
- `node scripts/run-vitest.mjs src/cron/service/run-admission.ownerless.test.ts src/cron/service/task-runs.test.ts src/cron/service.unresolved-owner.test.ts src/cron/service.trigger-eval.test.ts` — 82 passed, including manual cadence, transaction guards, startup/timer behavior, and quiet no-fire handling.
- `node scripts/run-vitest.mjs src/agents/conversation-capability-profile.test.ts src/agents/requester-tool-policy.test.ts src/agents/harness/selection.test.ts` — 210 passed (with a separate filesystem module cache while changed checks ran).
- `node scripts/check-changed.mjs --staged` — passed, including production/test typechecks, lint, formatting, export scans, and architecture/storage guards.
- `node scripts/run-vitest.mjs src/agents/agent-tools.create-openclaw-coding-tools.test.ts src/gateway/tool-resolution.exclude.test.ts` — 176 passed. Initial CI found two fixtures missing the required creator account and one Gateway assertion expecting silent denial; the follow-up configures the accounts and proves explicit rejection before construction without changing production behavior.
- [Exact-head CI run](https://github.com/openclaw/openclaw/actions/runs/34682508882) — completed successfully on `a6db63de7eae24bd3bdb3d90b4b31d00b6fccb9b`; the repository watcher returned `GREEN` after accounting for superseded checks.
- Independent Codex reviews at P1: clean, including the committed production change and test-only CI follow-up.

No live Gateway proof was run; the regressions use the real scheduler, policy resolver, isolated-run orchestration, and SQLite history/task writers with a mocked model backend.

## ClawSweeper review

The exact-head review found no actionable code defects. The maintainer accepts the documented compatibility change: jobs whose required named creator account was removed fail before model execution, including tool-free turns. Restore that account or recreate the automation from the intended account. Live operator recovery was not demonstrated; the supplied scheduler-to-SQLite regressions and preserved-account compatibility cases provide the approved proof. No code fixups were needed, and the live-proof request is skipped under this explicit landing decision.
