### PR TITLE
test: keep wizard option selector private

### DIFF
--- a/src/plugin-sdk/plugin-test-runtime.ts
+++ b/src/plugin-sdk/plugin-test-runtime.ts
@@ -137,7 +137,6 @@ export {
   runSetupWizardConfigure,
   runSetupWizardFinalize,
   runSetupWizardPrepare,
-  selectFirstWizardOption,
   type WizardPrompter,
 } from "../test-utils/plugin-setup-wizard.js";
 export { createMockPluginRegistry } from "../plugins/hooks.test-helpers.js";

--- a/src/test-utils/plugin-setup-wizard.ts
+++ b/src/test-utils/plugin-setup-wizard.ts
@@ -22,9 +22,7 @@ type QueuedWizardPrompter = {
   prompter: WizardPrompter;
 };
 
-export async function selectFirstWizardOption<T>(params: {
-  options: Array<{ value: T }>;
-}): Promise<T> {
+async function selectFirstWizardOption<T>(params: { options: Array<{ value: T }> }): Promise<T> {
   const first = params.options[0];
   if (!first) {
     throw new Error("no options");


### PR DESCRIPTION
## What Problem This Solves

The shared wizard test fixture exposes a first-option selector that only its own factory uses.

## Why This Change Was Made

Keep `selectFirstWizardOption` module-local and remove its unused private test-runtime re-export. The function body, empty-options rejection, default callback, and overrides remain unchanged. This API was formerly shipped; its public test-helper surface was canonically retired in v2026.5.27. This change removes only current private source exposure.

## User Impact

No user-visible behavior change. Production code is unchanged; test support is +1/−4 lines, with no cases or assertions removed.

## Evidence

- Complete LINE setup-surface suite: 10/10 passed before and after, with identical native case order and results.
- Local formatting and all 33 normal changed checks passed on the exact formatted source, including SDK export/alias checks, surface budgets, core and plugin types, lint, and dead-export scans.
- The normal lint prerequisite performed SDK boundary declaration emission: 9,197 reported outputs, including build metadata. This is not a production SDK package-build claim.
- Independent applied review found no actionable P0–P2 findings. The earlier formatting failure was corrected and the full gate rerun successfully.
