### PR TITLE
feat(signal): distinguish envelope age from local admission time

### DIFF
--- a/docs/channels/signal.md
+++ b/docs/channels/signal.md
@@ -302,6 +302,39 @@ Allowed group messages that do not mention the bot stay silent and are kept only
 - Replies to inbound messages include native Signal quote metadata when the backend accepts the inbound timestamp and author; if quote metadata is missing or rejected, OpenClaw sends the reply as a normal message.
 - Configure native quote use with `channels.signal.replyToMode = off | first | all | batched`, or `channels.signal.replyToModeByChatType.direct/group` for per-chat-type overrides. Account-level values under `channels.signal.accounts.<id>` take precedence.
 
+### Ingress timing
+
+After a new logical Signal envelope completes durable admission and identity-alias
+handling, the Signal plugin emits one informational record:
+
+```json
+{
+  "signalIngressTiming": true,
+  "envelopeAgeAtIngressSeconds": 240,
+  "localAdmissionElapsedMs": 5
+}
+```
+
+`envelopeAgeAtIngressSeconds` is the local ingress observation time minus the
+validated envelope timestamp, truncated toward zero to whole seconds. It compares
+two wall clocks, preserves negative ages, and is not a transport latency or SLA.
+`localAdmissionElapsedMs` uses a monotonic clock, rounded to milliseconds. It
+includes serialized queue waiting, insertion, and identity-alias handling, but
+excludes waiting for agent dispatch. For example, `240s / 5ms` distinguishes an
+already-old envelope from the slow local admission represented by `1s / 239000ms`.
+Neither pair establishes the cause of a delay.
+
+Concrete and identity-alias duplicates recognized within the existing tombstone
+window do not emit another record. Recovered rows, failed admission, and ignored
+transport-only envelopes do not invent new receive timings. The record contains
+only the marker and two durations, not message content, source or destination IDs,
+account or group IDs, event IDs, session keys, attachments, or exact source timestamps.
+No timing fields are added to persistent state. Logging failure cannot fail admission.
+
+These records add log volume and reveal coarse activity patterns, so existing log
+retention and access controls still apply. A record proves admission, not
+authorization, execution, reply delivery, or device receipt.
+
 ## Media + limits
 
 - Outbound text is chunked to `channels.signal.textChunkLimit` (default 4000).

--- a/extensions/signal/src/signal-ingress.timing.test.ts
+++ b/extensions/signal/src/signal-ingress.timing.test.ts
@@ -1,0 +1,330 @@
+// Real ingress monitor and SQLite queue, with clocks and transport delivery controlled.
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { performance } from "node:perf_hooks";
+import {
+  closeOpenClawStateDatabaseForTest,
+  createChannelIngressQueueForTests,
+} from "openclaw/plugin-sdk/channel-ingress-test-runtime";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { SignalSseEvent } from "./client-adapter.js";
+import { startSignalIngressMonitor } from "./signal-ingress.js";
+
+type Queue = NonNullable<Parameters<typeof startSignalIngressMonitor>[0]["queue"]>;
+type Payload = Parameters<Queue["enqueue"]>[1];
+const now = 1_800_000_000_000;
+function event(timestamp = now - 1_000, uuid?: string): SignalSseEvent {
+  return {
+    event: "receive",
+    data: JSON.stringify({
+      envelope: {
+        sourceNumber: "+15550001111",
+        ...(uuid ? { sourceUuid: uuid } : {}),
+        timestamp,
+        dataMessage: { timestamp, message: "synthetic-private-message" },
+      },
+    }),
+  };
+}
+function timingRows(log: ReturnType<typeof vi.fn>): unknown[] {
+  return log.mock.calls.flatMap(([line]) => {
+    if (typeof line !== "string" || !line.startsWith('{"signalIngressTiming":true,')) {
+      return [];
+    }
+    return [JSON.parse(line)];
+  });
+}
+async function withQueue(run: (queue: Queue) => Promise<void>) {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-signal-timing-"));
+  const queue = createChannelIngressQueueForTests<Payload>({
+    channelId: "signal",
+    accountId: "default",
+    stateDir: dir,
+  });
+  try {
+    await run(queue);
+  } finally {
+    closeOpenClawStateDatabaseForTest();
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+}
+async function open(queue: Queue, log = vi.fn()) {
+  const dispatch = vi.fn(async () => undefined);
+  const monitor = await startSignalIngressMonitor({
+    accountId: "default",
+    queue,
+    dispatch,
+    runtime: { log, error: vi.fn() },
+  });
+  return { monitor, log, dispatch };
+}
+afterEach(() => {
+  vi.restoreAllMocks();
+  closeOpenClawStateDatabaseForTest();
+});
+
+describe("Signal admission timing", () => {
+  it("does not invent a fresh admission timing for recovered durable rows", async () => {
+    await withQueue(async (queue) => {
+      const input = event();
+      await queue.enqueue(
+        JSON.stringify(["number:+15550001111", now - 1_000]),
+        { version: 1, receivedAt: now, event: input },
+        { receivedAt: now, laneKey: "direct:number:+15550001111" },
+      );
+      const f = await open(queue);
+      try {
+        await f.monitor.waitForIdle();
+        expect(f.dispatch).toHaveBeenCalledOnce();
+        expect(timingRows(f.log)).toEqual([]);
+      } finally {
+        await f.monitor.stop();
+      }
+    });
+  });
+
+  it.each([
+    { age: 240_000, elapsed: 5, seconds: 240 },
+    { age: 1_000, elapsed: 239_000, seconds: 1 },
+    { age: -2_500, elapsed: 3, seconds: -2 },
+  ])(
+    "distinguishes signed envelope age $age from local admission $elapsed",
+    async ({ age, elapsed, seconds }) => {
+      await withQueue(async (queue) => {
+        let monotonic = 0;
+        vi.spyOn(Date, "now").mockReturnValue(now);
+        vi.spyOn(performance, "now").mockImplementation(() => monotonic);
+        const enqueue = queue.enqueue.bind(queue);
+        vi.spyOn(queue, "enqueue").mockImplementation(async (...args) => {
+          const result = await enqueue(...args);
+          monotonic = elapsed;
+          return result;
+        });
+        const f = await open(queue);
+        try {
+          await f.monitor.receive(event(now - age));
+          expect(timingRows(f.log)).toEqual([
+            {
+              signalIngressTiming: true,
+              envelopeAgeAtIngressSeconds: seconds,
+              localAdmissionElapsedMs: elapsed,
+            },
+          ]);
+          expect(f.dispatch).toHaveBeenCalledOnce();
+        } finally {
+          await f.monitor.stop();
+        }
+      });
+    },
+  );
+
+  it("does not persist timing facts in the durable event payload", async () => {
+    await withQueue(async (queue) => {
+      const enqueue = vi.spyOn(queue, "enqueue");
+      const f = await open(queue);
+      const input = event();
+      try {
+        await f.monitor.receive(input);
+        expect(enqueue.mock.calls[0]?.[1]).toEqual({
+          version: 1,
+          receivedAt: expect.any(Number),
+          event: input,
+        });
+        expect(timingRows(f.log)).toHaveLength(1);
+        expect(Object.keys(timingRows(f.log)[0] as object).toSorted()).toEqual([
+          "envelopeAgeAtIngressSeconds",
+          "localAdmissionElapsedMs",
+          "signalIngressTiming",
+        ]);
+        expect(JSON.stringify(timingRows(f.log))).not.toContain("synthetic-private-message");
+        expect(JSON.stringify(timingRows(f.log))).not.toContain("15550001111");
+      } finally {
+        await f.monitor.stop();
+      }
+    });
+  });
+
+  it("suppresses concrete and identity-alias duplicate timing records", async () => {
+    await withQueue(async (queue) => {
+      const f = await open(queue);
+      try {
+        await f.monitor.receive(event());
+        await f.monitor.receive(event());
+        await f.monitor.receive(event(now - 1_000, "123e4567-e89b-12d3-a456-426614174000"));
+        expect(timingRows(f.log)).toHaveLength(1);
+        expect(f.dispatch).toHaveBeenCalledOnce();
+      } finally {
+        await f.monitor.stop();
+      }
+    });
+  });
+
+  it("includes identity-alias work but excludes dispatch waiting", async () => {
+    await withQueue(async (queue) => {
+      let monotonic = 10;
+      vi.spyOn(performance, "now").mockImplementation(() => monotonic);
+      const complete = queue.complete.bind(queue);
+      vi.spyOn(queue, "complete").mockImplementation(async (...args) => {
+        const result = await complete(...args);
+        monotonic = 30;
+        return result;
+      });
+      const log = vi.fn();
+      const monitor = await startSignalIngressMonitor({
+        accountId: "default",
+        queue,
+        runtime: { log, error: vi.fn() },
+        dispatch: async () => {
+          monotonic = 9_000;
+        },
+      });
+      try {
+        await monitor.receive(event(now - 1_000, "123e4567-e89b-12d3-a456-426614174000"));
+        expect(timingRows(log)).toEqual([expect.objectContaining({ localAdmissionElapsedMs: 20 })]);
+      } finally {
+        await monitor.stop();
+      }
+    });
+  });
+
+  it("keeps local admission duration independent of wall-clock changes", async () => {
+    await withQueue(async (queue) => {
+      let wall = now;
+      let monotonic = 0;
+      vi.spyOn(Date, "now").mockImplementation(() => wall);
+      vi.spyOn(performance, "now").mockImplementation(() => monotonic);
+      const enqueue = queue.enqueue.bind(queue);
+      vi.spyOn(queue, "enqueue").mockImplementation(async (...args) => {
+        const result = await enqueue(...args);
+        wall += 3_600_000;
+        monotonic = 7;
+        return result;
+      });
+      const f = await open(queue);
+      try {
+        await f.monitor.receive(event(now - 1_000));
+        expect(timingRows(f.log)).toEqual([
+          { signalIngressTiming: true, envelopeAgeAtIngressSeconds: 1, localAdmissionElapsedMs: 7 },
+        ]);
+      } finally {
+        await f.monitor.stop();
+      }
+    });
+  });
+
+  it("includes waiting behind another serialized admission", async () => {
+    await withQueue(async (queue) => {
+      const entered = createDeferred<void>();
+      const release = createDeferred<void>();
+      let monotonic = 0;
+      let calls = 0;
+      vi.spyOn(performance, "now").mockImplementation(() => monotonic);
+      const enqueue = queue.enqueue.bind(queue);
+      vi.spyOn(queue, "enqueue").mockImplementation(async (...args) => {
+        calls += 1;
+        if (calls === 1) {
+          entered.resolve();
+          await release.promise;
+        }
+        return await enqueue(...args);
+      });
+      const f = await open(queue);
+      const first = f.monitor.receive(event(now - 2_000));
+      let second: Promise<void> | undefined;
+      try {
+        await entered.promise;
+        monotonic = 10;
+        second = f.monitor.receive(event(now - 1_000));
+        monotonic = 90;
+        release.resolve();
+        await Promise.all([first, second]);
+        expect(timingRows(f.log)).toEqual([
+          expect.objectContaining({ localAdmissionElapsedMs: 90 }),
+          expect.objectContaining({ localAdmissionElapsedMs: 80 }),
+        ]);
+      } finally {
+        release.resolve();
+        await Promise.allSettled([first, ...(second ? [second] : [])]);
+        await f.monitor.stop();
+      }
+    });
+  });
+
+  it("isolates a throwing timing logger from admission and delivery", async () => {
+    await withQueue(async (queue) => {
+      const log = vi.fn((line: string) => {
+        if (line.startsWith('{"signalIngressTiming":true,')) {
+          throw new Error("logger unavailable");
+        }
+      });
+      const f = await open(queue, log);
+      try {
+        await expect(f.monitor.receive(event())).resolves.toBeUndefined();
+        expect(timingRows(f.log)).toHaveLength(1);
+        expect(f.dispatch).toHaveBeenCalledOnce();
+      } finally {
+        await f.monitor.stop();
+      }
+    });
+  });
+
+  it("does not report successful admission when enqueue fails", async () => {
+    await withQueue(async (queue) => {
+      const failure = new Error("storage unavailable");
+      vi.spyOn(queue, "enqueue").mockRejectedValue(failure);
+      const f = await open(queue);
+      try {
+        await expect(f.monitor.receive(event())).rejects.toBe(failure);
+        expect(timingRows(f.log)).toEqual([]);
+        expect(f.dispatch).not.toHaveBeenCalled();
+      } finally {
+        await f.monitor.stop();
+      }
+    });
+  });
+
+  it("does not report successful timing when identity-alias handling fails", async () => {
+    await withQueue(async (queue) => {
+      const failure = new Error("alias storage unavailable");
+      const aliasId = JSON.stringify(["number:+15550001111", now - 1_000]);
+      const complete = queue.complete.bind(queue);
+      vi.spyOn(queue, "complete").mockImplementation(async (...args) => {
+        if (args[0] === aliasId) {
+          throw failure;
+        }
+        return await complete(...args);
+      });
+      const f = await open(queue);
+      try {
+        await expect(
+          f.monitor.receive(event(now - 1_000, "123e4567-e89b-12d3-a456-426614174000")),
+        ).rejects.toBe(failure);
+        expect(timingRows(f.log)).toEqual([]);
+        // The existing monitor owns recovery of an already-durable row after callback failure.
+        // This diagnostic change must not claim that such a row was never admitted or dispatched.
+      } finally {
+        await f.monitor.stop();
+      }
+    });
+  });
+
+  it("does not log timing for ignored transport-only envelopes", async () => {
+    await withQueue(async (queue) => {
+      const f = await open(queue);
+      try {
+        await f.monitor.receive({
+          event: "receive",
+          data: JSON.stringify({
+            envelope: { timestamp: now, sourceNumber: "+15550001111", typingMessage: {} },
+          }),
+        });
+        expect(timingRows(f.log)).toEqual([]);
+        expect(f.dispatch).not.toHaveBeenCalled();
+      } finally {
+        await f.monitor.stop();
+      }
+    });
+  });
+});

--- a/extensions/signal/src/signal-ingress.ts
+++ b/extensions/signal/src/signal-ingress.ts
@@ -1,4 +1,5 @@
 // Signal plugin module owns raw-envelope durable ingress mapping and draining.
+import { performance } from "node:perf_hooks";
 import {
   createChannelIngressError,
   createChannelIngressMonitor,
@@ -32,11 +33,13 @@ type SignalIngressEventFacts = {
   eventId: string;
   laneKey: string;
   numberAliasEventId?: string;
+  timestamp: number;
 };
 
 type SignalPreparedIngressEvent = [
   event: SignalSseEvent,
   parsedPayload: SignalReceivePayload | null | undefined,
+  admissionStartedAt?: number,
 ];
 
 type SignalIngressPayload = {
@@ -139,6 +142,7 @@ function inspectSignalIngressEvent(
     normalizeRawString(dataGroup?.groupId) ?? normalizeRawString(reactionGroup?.groupId);
   return {
     eventId: JSON.stringify([senderKey, timestamp]),
+    timestamp,
     laneKey: groupId ? `group:${groupId}` : `direct:${senderKey}`,
     ...(senderUuid && senderNumber
       ? { numberAliasEventId: JSON.stringify([`number:${senderNumber}`, timestamp]) }
@@ -198,15 +202,29 @@ export async function startSignalIngressMonitor(params: {
     },
     deliver: ([event, parsedPayload], lifecycle) =>
       parsedPayload ? params.dispatch(event, lifecycle, parsedPayload) : undefined,
-    onDurableAdmission: async (_event, { facts, isNew }) => {
-      const { numberAliasEventId } = facts as SignalIngressEventFacts;
-      if (!numberAliasEventId) {
-        return;
-      }
+    onDurableAdmission: async (prepared, { facts, receivedAt, isNew }) => {
+      const admissionStartedAt = prepared[2];
+      const { numberAliasEventId, timestamp } = facts as SignalIngressEventFacts;
       // signal-cli can learn or forget a UUID between redeliveries; bridge both
       // shipped sender IDs before the monitor releases its admission/claim lock.
-      if (!(await ingressQueue.complete(numberAliasEventId)) && isNew) {
+      if (numberAliasEventId && !(await ingressQueue.complete(numberAliasEventId)) && isNew) {
         await ingressQueue.complete(facts.eventId);
+        return;
+      }
+      if (!isNew || admissionStartedAt === undefined) {
+        return;
+      }
+      try {
+        params.runtime.log?.(
+          JSON.stringify({
+            signalIngressTiming: true,
+            // Signed age compares two wall clocks; it is not transport latency.
+            envelopeAgeAtIngressSeconds: Math.trunc((receivedAt - timestamp) / 1_000),
+            localAdmissionElapsedMs: Math.round(performance.now() - admissionStartedAt),
+          }),
+        );
+      } catch {
+        // Admission and alias handling already succeeded; logging cannot undo them.
       }
     },
     pollIntervalMs: SIGNAL_INGRESS_DRAIN_INTERVAL_MS,
@@ -228,7 +246,7 @@ export async function startSignalIngressMonitor(params: {
 
   return {
     receive: async (event) => {
-      await monitor.admit([event, undefined]);
+      await monitor.admit([event, undefined, performance.now()]);
       await monitor.waitForPumpIdle();
     },
     stop: monitor.stop,


### PR DESCRIPTION
Closes #144470.

## What Problem This Solves

Operators investigating delayed Signal messages cannot distinguish an envelope that was already old when OpenClaw received it from slow local durable admission.

## Why This Change Was Made

The Signal plugin records coarse signed envelope age and monotonic local admission elapsed time after insertion and identity-alias handling. The existing queue, deduplication, and dispatch owners remain authoritative. Timing facts stay in memory; the durable payload and SQLite schema do not change.

Production delta: +25/-7 (net +18), justified by the new admission diagnostic. Tests: +330. Documentation: +33. The callback's early return is consolidated into the alias/duplicate guards; no parallel admission path is added.

## User Impact

One informational JSON record per newly admitted logical envelope helps distinguish already-old input from local admission cost. Exact and number/UUID duplicates within the existing tombstone window do not log again. Failed admission, transport-only inputs, and recovered rows do not invent receive timings. The record contains only a marker and two durations, with no message content, identifiers, or exact source timestamp.

These records add normal-level log volume and expose coarse activity patterns. They prove admission, not authorization, model execution, reply delivery, device receipt, or network latency. Logging exceptions cannot turn successful admission into failure.

## Evidence

### September 14 integration refresh

Current head: `e00e1f7cbc924e2872c2e5ec3b0eac9df69caf96`. Original branch head `b7c3a34753eb44b748a1059c96f821b6e545c988` and pinned main `8b917bc499607eb94bb77358ddd69f6494d26c65` are both preserved as parents; no force-push. Refresh the existing accepted patch onto pinned main to remove stale integration inputs and obtain new-head CI. No new feature or unrelated failure workaround is added. The resulting tree exactly matches the conflict-free git merge-tree result; there are no manual source or test edits.

Validation on Linux / Node 26.1.0 with frozen-lockfile dependencies: No new local runtime test is claimed for this mechanical integration; existing proof keeps its original revision and exact-head hosted CI is required.. The native staged-content/format guard, main-relative diff check, and one fresh independent P0-P2 source review passed. No full build or full type-aware check was rerun locally; new-head CI is tracked separately. Earlier runtime proof below retains its recorded SHA; it is not relabeled as a new execution.


AI-assisted implementation, manually inspected at the Signal receive/admission owner and shared queue callback/alias boundary.

**Behavior addressed:** distinguish signed apparent envelope age from monotonic local admission duration while preserving deduplication, recovery, payload privacy, and dispatch semantics.

**Environment:** Node 24.21.0; isolated temporary state; actual TypeScript Signal ingress monitor and canonical SQLite queue, loaded with the repository TS loader. Synthetic raw receive envelopes and a terminal no-model dispatch consumer; no replaced queue/admission modules.

**Verified head:** `b7c3a34753eb44b748a1059c96f821b6e545c988`. Tests, proof, and review ran on frozen staged content; all three committed file hashes match the final proof snapshot exactly.

**Production entry and recorder:** `node --import "$WORK/scripts/tsx.mjs" "$PACKET/proofs/signal-ingress.mjs"` runs synthetic raw receive events through `startSignalIngressMonitor.receive` → canonical durable admission and alias handling → SQLite queue, then reads the actual file-backed runtime log and dispatch counts. The capture command was `python3 "$PACKET/scripts/run.py" proof A01 --repo "$WORK" --base dda647045420956f7900180c5ca32d457dbc4973 --mode candidate --out "$EVIDENCE/proof-final"`. The production file SHA-256 was `637ec6bc2811c94d031fa7fa8084741a21e370d6eb75e2e57123d2b08e1ebe97`, unchanged by the commit.

**Evidence before fix:** the unmodified base `dda647045420956f7900180c5ca32d457dbc4973` admitted and dispatched the 240-second-old envelope, but emitted zero timing records. Exact and number/UUID alias redeliveries kept dispatches at one; transport-only input added no dispatch. A future-clock envelope brought dispatches to two, still with zero timing records. All four baseline observations passed their before-change expectations.

```json
{"dispatches":1,"timings":[]}
{"dispatches":1,"timings":[]}
{"dispatches":1,"timingCount":0}
{"dispatches":2,"timings":[],"errors":[]}
```

**Evidence after fix:** all four final real-clock scenarios passed. The first envelope emitted age `240s` and local admission `44ms`. Exact and number/UUID alias redeliveries kept dispatches and timing records at one. A transport-only envelope added neither. The future-clock envelope emitted signed age `-10s` with `11ms` admission and brought dispatches to two. No error was recorded; the exact timing-record key set and absence of fixture identifiers/message text were checked.

```json
{"signalIngressTiming":true,"envelopeAgeAtIngressSeconds":240,"localAdmissionElapsedMs":44}
{"signalIngressTiming":true,"envelopeAgeAtIngressSeconds":-10,"localAdmissionElapsedMs":11}
```

These are observed values from this run, not performance guarantees.

**Validation:** 42/42 tests passed across the two focused files: 13 timing tests and 29 durable-ingress tests, with no failures or skips. Formatting and staged diff whitespace checks passed. Targeted syntax lint passed: 2 files, 230 rules, zero diagnostics. Independent gpt-6-astra/medium/P2 review passed with no findings and concluded that the patch is correct; its secret scan was clean.

**Hosted CI:** the separate Security Sensitive Guard run `34681900955` failed with `500 Internal Server Error` while executing the GitHub guard. The contributor account's retry was rejected with `Must have admin rights to Repository`; a maintainer rerun is required. This is not presented as a passing security guard or as a product-code failure.

```text
node scripts/run-vitest.mjs extensions/signal/src/signal-ingress.timing.test.ts extensions/signal/src/signal-ingress.test.ts
Test Files  2 passed (2)
     Tests  42 passed (42)
```

**Existing owner and compatibility:** this uses the existing ingress monitor, SQLite queue and runtime logger. The durable serializer remains `{ receivedAt, event }` with payload version 1; timestamp and monotonic timing facts are transient. No config/default key, SQLite schema/version, stored payload, public protocol or dependency is changed. No data migration or backfill is needed.

**Limitations:** no signal-cli SSE networking, Signal service, real device, or model turn was exercised. Recovery, artificial queue contention, wall-clock changes, logger throws, storage/alias failures, and payload privacy are tested separately by repository tests. Broader event-handler lifecycle coverage, full builds, global typecheck/lint and docs checks are left to CI. Only the completed focused runs above are counted as passing validation.

**Cleanup:** both baseline and final proof stopped the monitor, closed database handles, and removed isolated scratch. Source content stayed unchanged during both proof runs.
