### PR TITLE
fix(update): restore gateway after partial stop failures

### DIFF
--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -3859,6 +3859,36 @@ describe("update-cli", () => {
     );
   });
 
+  it("restarts the managed gateway when stop partially succeeds before failing", async () => {
+    mockPackageInstallStatus(createCaseDir("openclaw-update-partial-stop-failure"));
+    serviceReadCommand.mockResolvedValue({
+      programArguments: ["openclaw", "gateway", "run"],
+      environment: {
+        OPENCLAW_SERVICE_MARKER: "openclaw",
+        OPENCLAW_SERVICE_KIND: "gateway",
+      },
+    });
+    serviceLoaded.mockResolvedValue(true);
+    serviceReadRuntime
+      .mockResolvedValueOnce({ status: "running", pid: 4242, state: "running" })
+      .mockResolvedValueOnce({ status: "unknown", state: "not-loaded" });
+    serviceStop.mockImplementationOnce(async (args: unknown) => {
+      (args as { onMutation?: () => void }).onMutation?.();
+      throw new Error("stop validation failed");
+    });
+
+    await updateCommand({ yes: true });
+
+    expect(serviceStop).toHaveBeenCalledTimes(1);
+    expect(serviceRestart).toHaveBeenCalledWith(
+      expect.objectContaining({
+        env: expect.objectContaining({ OPENCLAW_SERVICE_KIND: "gateway" }),
+      }),
+    );
+    expect(packageInstallCommandCall()).toBeUndefined();
+    expect(defaultRuntime.exit).toHaveBeenCalledWith(1);
+  });
+
   it("preserves both the update and Scheduled Task recovery failures", async () => {
     const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
     mockPackageInstallStatus(createCaseDir("openclaw-update-recovery-failure"));

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -1146,6 +1146,7 @@ async function maybeStopManagedServiceBeforeMutableUpdate(params: {
   root: string;
   shouldRestart: boolean;
   jsonMode: boolean;
+  onStopped?: (state: PreManagedServiceStop) => void;
 }): Promise<PreManagedServiceStop> {
   let service: ReturnType<typeof resolveGatewayService>;
   let serviceState: Awaited<ReturnType<typeof readGatewayServiceState>>;
@@ -1280,6 +1281,26 @@ async function maybeStopManagedServiceBeforeMutableUpdate(params: {
     await service.stop({
       env: serviceState.env,
       stdout: serviceControlStdoutForMode(params.jsonMode),
+      // launchd can unload the job before its port-release validation fails.
+      onMutation: () =>
+        params.onStopped?.({
+          stopped: true,
+          inspected: true,
+          runtimeInspected: true,
+          running: true,
+          ...serviceOwnership,
+          serviceEnv: serviceState.env,
+          ...(windowsTaskAutoStartRecovery ? { windowsTaskAutoStartRecovery } : {}),
+        }),
+    });
+    params.onStopped?.({
+      stopped: true,
+      inspected: true,
+      runtimeInspected: true,
+      running: true,
+      ...serviceOwnership,
+      serviceEnv: serviceState.env,
+      ...(windowsTaskAutoStartRecovery ? { windowsTaskAutoStartRecovery } : {}),
     });
     if (windowsTaskAutoStartRecovery) {
       await abortWindowsTaskUpdateIfInterrupted(windowsTaskAutoStartRecovery);
@@ -1303,6 +1324,17 @@ async function maybeStopManagedServiceBeforeMutableUpdate(params: {
       if (windowsTaskAutoStartRecovery.interrupted()) {
         throw new UpdateCommandAbort();
       }
+    }
+    const runtimeAfterFailure = await service.readRuntime(serviceState.env).catch(() => undefined);
+    if (runtimeAfterFailure?.status === "stopped") {
+      params.onStopped?.({
+        stopped: true,
+        inspected: true,
+        runtimeInspected: true,
+        running: true,
+        ...serviceOwnership,
+        serviceEnv: serviceState.env,
+      });
     }
     throw err;
   }
@@ -4178,6 +4210,9 @@ async function updateCommandInternal(
           root: mutationRoot,
           shouldRestart,
           jsonMode: Boolean(opts.json),
+          onStopped: (state) => {
+            preManagedServiceStop = state;
+          },
         });
         if (preManagedServiceStop.windowsTaskAutoStartRecovery) {
           recoveryState.windowsTaskAutoStartRecovery =
@@ -4195,6 +4230,10 @@ async function updateCommandInternal(
         }
       }
     } catch (err) {
+      await maybeRestartServiceAfterFailedMutableUpdate({
+        preManagedServiceStop,
+        jsonMode: Boolean(opts.json),
+      });
       if (err instanceof UpdateCommandAbort) {
         throw err;
       }

--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -862,6 +862,7 @@ export async function stopLaunchAgent({
   stdout,
   env,
   disable: persistDisable,
+  onMutation,
 }: GatewayServiceControlArgs): Promise<void> {
   const serviceEnv = env ?? (process.env as GatewayServiceEnv);
   const domain = resolveGuiDomain();
@@ -884,6 +885,7 @@ export async function stopLaunchAgent({
     if (bootout.code !== 0 && !isLaunchctlNotLoaded(bootout)) {
       throw new Error(`launchctl bootout failed: ${formatLaunchctlResultDetail(bootout)}`);
     }
+    onMutation?.();
     await assertGatewayPortReleasedAfterStop(serviceEnv);
     stdout.write(`${formatLine("Stopped LaunchAgent", serviceTarget)}\n`);
     return;
@@ -898,6 +900,7 @@ export async function stopLaunchAgent({
       stdout,
       warning: `launchctl disable failed; used bootout fallback and left service unloaded: ${formatLaunchctlResultDetail(disableResult)}`,
     });
+    onMutation?.();
     await assertGatewayPortReleasedAfterStop(serviceEnv);
     stdout.write(`${formatLine("Stopped LaunchAgent (degraded)", serviceTarget)}\n`);
     return;
@@ -911,6 +914,7 @@ export async function stopLaunchAgent({
       stdout,
       warning: `launchctl stop failed; used bootout fallback and left service unloaded: ${formatLaunchctlResultDetail(stop)}`,
     });
+    onMutation?.();
     await assertGatewayPortReleasedAfterStop(serviceEnv);
     stdout.write(`${formatLine("Stopped LaunchAgent (degraded)", serviceTarget)}\n`);
     return;
@@ -923,11 +927,13 @@ export async function stopLaunchAgent({
         ? `launchctl print could not confirm stop; used bootout fallback and left service unloaded: ${stopState.detail ?? "unknown error"}`
         : "launchctl stop did not fully stop the service; used bootout fallback and left service unloaded";
     await bootoutLaunchAgentOrThrow({ serviceTarget, stdout, warning });
+    onMutation?.();
     await assertGatewayPortReleasedAfterStop(serviceEnv);
     stdout.write(`${formatLine("Stopped LaunchAgent (degraded)", serviceTarget)}\n`);
     return;
   }
 
+  onMutation?.();
   await assertGatewayPortReleasedAfterStop(serviceEnv);
   stdout.write(`${formatLine("Stopped LaunchAgent", serviceTarget)}\n`);
 }

--- a/src/daemon/service-types.ts
+++ b/src/daemon/service-types.ts
@@ -31,6 +31,8 @@ export type GatewayServiceControlArgs = {
   env?: GatewayServiceEnv;
   disable?: boolean;
   warn?: (message: string) => void;
+  /** Called after the native supervisor mutation, before post-stop validation. */
+  onMutation?: () => void;
 };
 
 export type GatewayServiceRestartResult = { outcome: "completed" } | { outcome: "scheduled" };


### PR DESCRIPTION
## Summary
- retain the managed-service stop state as soon as the service actually stops
- restart the gateway if stop validation or later update preparation fails
- keep package mutation blocked on the failed preparation

Narrow 7.33 adaptation of #136285 / ad682b4a88.

## Prior finding disposition
The unload-state finding is resolved on the current head: launchd reports accepted bootout before port-release validation, and the updater retains that mutation state even when validation throws. The focused failure regression verifies restart is attempted, package installation remains blocked, and the command exits non-zero.

## Validation
- focused update CLI regressions: 4 passed
- partial-stop/validation-failure recovery regression
- core test typecheck; exact formatting and diff checks
- combined published `openclaw@2026.6.35` → packed `2026.7.33` proof: manual restart and managed automatic restart passed; managed restart returned in 88s with state/config/session survival and Gateway health/readiness/status
