### PR TITLE
fix(cli): preserve native session binding across operator abort

### DIFF
--- a/src/agents/cli-runner/cli-run-settlement.test.ts
+++ b/src/agents/cli-runner/cli-run-settlement.test.ts
@@ -137,6 +137,40 @@ describe("isCliBindingFlushed", () => {
 });
 
 describe("CLI native continuity projection", () => {
+  it.each([
+    { bindingFlushOk: true, expectedSessionId: "interrupted-session" },
+    { bindingFlushOk: false, expectedSessionId: undefined },
+  ])(
+    "uses transcript flush=$bindingFlushOk to settle an interrupted binding",
+    ({ bindingFlushOk, expectedSessionId }) => {
+      const context = buildPreparedCliRunContext({ provider: "claude-cli" });
+      const result = buildCliRunResult({
+        context,
+        output: {
+          text: "partial reply",
+          terminalInterruption: { reason: "aborted" },
+        },
+        effectiveCliSessionId: "interrupted-session",
+        bindingFlushOk,
+        usedHistoryPrompt: false,
+        userTurnHandled: true,
+        sessionBindingDisabled: false,
+        preparedContextAgentMeta: {},
+      });
+      const entry: SessionEntry = {
+        sessionId: context.params.sessionId,
+        updatedAt: 1,
+        cliSessionBindings: { "claude-cli": { sessionId: "interrupted-session" } },
+      };
+
+      applyCliSessionBindingResult(entry, "claude-cli", result.meta.agentMeta);
+
+      expect(result.meta.aborted).toBe(true);
+      expect(result.meta.agentMeta?.clearCliSessionBinding).toBe(bindingFlushOk ? undefined : true);
+      expect(getCliSessionBinding(entry, "claude-cli")?.sessionId).toBe(expectedSessionId);
+    },
+  );
+
   it.each(["blocked", "no-native-id", "native", "stateless"])(
     "projects only explicit native continuity from a %s result",
     (kind) => {

--- a/src/agents/cli-runner/cli-run-settlement.ts
+++ b/src/agents/cli-runner/cli-run-settlement.ts
@@ -502,11 +502,9 @@ export function buildCliRunResult(params: {
       ? effectiveCliSessionId
       : undefined;
   const terminalInterruption = output.terminalInterruption;
-  // An interrupted process cannot preserve its now-invalid native session binding.
-  const cliSessionBindingCleared =
-    terminalInterruption !== undefined ||
-    sessionBindingDisabled ||
-    unflushedCliSessionId !== undefined;
+  // Interruption alone does not invalidate a native transcript. The bounded
+  // flush probe above decides whether the binding is safe to persist.
+  const cliSessionBindingCleared = sessionBindingDisabled || unflushedCliSessionId !== undefined;
   const persistedCliSessionId = cliSessionBindingCleared ? undefined : effectiveCliSessionId;
   const createdReseedReceipt =
     persistedCliSessionId &&

--- a/src/agents/cli-session.test.ts
+++ b/src/agents/cli-session.test.ts
@@ -636,14 +636,21 @@ describe("cli-session helpers", () => {
     expect(hashCliSessionText("")).toBeUndefined();
   });
 
-  it("shares failed reused-session cleanup policy across CLI entry points", () => {
+  it("preserves reusable bindings for aborts and clears only invalid sessions", () => {
     const abort = Object.assign(new Error("aborted"), { name: "AbortError" });
 
     const binding = { sessionId: "reused" };
     const forkBinding = { sessionId: "fork-source", forkNextResume: true as const };
 
-    expect(shouldClearFailedCliSessionBinding({ error: abort, binding })).toBe(true);
+    expect(shouldClearFailedCliSessionBinding({ error: abort, binding })).toBe(false);
     expect(shouldClearFailedCliSessionBinding({ error: abort, binding: forkBinding })).toBe(false);
+    expect(
+      shouldClearFailedCliSessionBinding({
+        error: abort,
+        binding: { sessionId: "replacement" },
+        bindingReplacedDuringRun: true,
+      }),
+    ).toBe(true);
     expect(
       shouldClearFailedCliSessionBinding({
         error: new FailoverError("session expired", {

--- a/src/agents/cli-session.ts
+++ b/src/agents/cli-session.ts
@@ -148,6 +148,7 @@ export function clearCliSession(entry: SessionEntry, provider: string): void {
 export function shouldClearFailedCliSessionBinding(params: {
   error: unknown;
   binding?: CliSessionBinding;
+  bindingReplacedDuringRun?: boolean;
   hasNewGeneratedMediaTask?: boolean;
 }): boolean {
   if (!normalizeOptionalString(params.binding?.sessionId)) {
@@ -160,8 +161,10 @@ export function shouldClearFailedCliSessionBinding(params: {
   if (isFailoverError(params.error)) {
     return isCliSessionInvalidatingFailoverReason(params.error.reason);
   }
-  // A pre-successor fork abort keeps its one-shot marker for the next turn.
-  return params.binding?.forkNextResume !== true && readErrorName(params.error) === "AbortError";
+  // Operator cancellation stops the process; it does not invalidate the
+  // provider transcript that backed the attempted resume. A replacement
+  // installed mid-run is not established until that run settles, though.
+  return params.bindingReplacedDuringRun === true && readErrorName(params.error) === "AbortError";
 }
 
 /** Stable reason used when recording why a failed reused CLI session was cleared. */

--- a/src/agents/command/attempt-execution.cli.test.ts
+++ b/src/agents/command/attempt-execution.cli.test.ts
@@ -1515,7 +1515,7 @@ describe("CLI attempt execution", () => {
     );
   });
 
-  it("clears reused Claude CLI session IDs after AbortError without retrying", async () => {
+  it("preserves and resumes a reused Claude CLI session after AbortError", async () => {
     const sessionKey = "agent:main:direct:cli-abort";
     const cliSessionId = "abort-poisoned-session";
     await writeClaudeCliAssistantTranscript(cliSessionId);
@@ -1537,14 +1537,29 @@ describe("CLI attempt execution", () => {
 
     expect(runCliAgentMock).toHaveBeenCalledTimes(1);
     expect(firstRunCliAgentArg().cliSessionId).toBe(cliSessionId);
-    expect(sessionStore[sessionKey]?.cliSessionBindings?.["claude-cli"]).toBeUndefined();
-    expect(sessionStore[sessionKey]?.cliSessionIds?.["claude-cli"]).toBeUndefined();
-    expect(sessionStore[sessionKey]?.claudeCliSessionId).toBeUndefined();
+    expect(sessionStore[sessionKey]?.cliSessionBindings?.["claude-cli"]?.sessionId).toBe(
+      cliSessionId,
+    );
+    expect(sessionStore[sessionKey]?.cliSessionIds?.["claude-cli"]).toBe(cliSessionId);
+    expect(sessionStore[sessionKey]?.claudeCliSessionId).toBe(cliSessionId);
 
     const persisted = readSessionStore();
-    expect(persisted[sessionKey]?.cliSessionBindings?.["claude-cli"]).toBeUndefined();
-    expect(persisted[sessionKey]?.cliSessionIds?.["claude-cli"]).toBeUndefined();
-    expect(persisted[sessionKey]?.claudeCliSessionId).toBeUndefined();
+    expect(persisted[sessionKey]?.cliSessionBindings?.["claude-cli"]?.sessionId).toBe(cliSessionId);
+    expect(persisted[sessionKey]?.cliSessionIds?.["claude-cli"]).toBe(cliSessionId);
+    expect(persisted[sessionKey]?.claudeCliSessionId).toBe(cliSessionId);
+
+    runCliAgentMock.mockResolvedValueOnce(makeCliResult("continued after abort", cliSessionId));
+
+    await runClaudeCliAttempt({
+      sessionKey,
+      sessionEntry,
+      sessionStore,
+      body: "continue after abort",
+      runId: "run-cli-abort-resume",
+    });
+
+    expect(runCliAgentMock).toHaveBeenCalledTimes(2);
+    expect(firstRunCliAgentArg(1).cliSessionId).toBe(cliSessionId);
   });
 
   it("clears a fork-marked Claude CLI session after terminal failover", async () => {

--- a/src/agents/command/attempt-execution.ts
+++ b/src/agents/command/attempt-execution.ts
@@ -1251,6 +1251,7 @@ export function runAgentAttempt(params: {
             shouldClearFailedCliSessionBinding({
               error: err,
               binding: failedCliSessionBinding,
+              bindingReplacedDuringRun: failedCliSessionId !== activeCliSessionBinding?.sessionId,
               hasNewGeneratedMediaTask: hasNewGeneratedMediaTaskForSessionKey(
                 params.sessionKey,
                 mediaTaskIdsBefore,

--- a/src/auto-reply/reply/agent-runner-execution-cli-sessions.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution-cli-sessions.test.ts
@@ -779,6 +779,48 @@ describe("executeAgentTurn: CLI session routing", () => {
     expect(sessionEntry.claudeCliSessionId).toBe("media-session");
   });
 
+  it("preserves a reused binding after an operator aborts a channel turn", async () => {
+    const sessionKey = "agent:main:direct:aborted-run";
+    state.isCliProviderMock.mockReturnValue(true);
+    state.runWithModelFallbackMock.mockImplementationOnce(async (params: FallbackRunnerParams) => ({
+      result: await params.run(
+        "claude-cli",
+        "claude-opus-4-8",
+        initialFallbackAttemptOptions(params),
+      ),
+      provider: "claude-cli",
+      model: "claude-opus-4-8",
+      attempts: [],
+    }));
+    state.runCliAgentMock.mockRejectedValueOnce(
+      Object.assign(new Error("CLI run aborted"), { name: "AbortError" }),
+    );
+
+    const followupRun = createFollowupRun();
+    followupRun.run.provider = "claude-cli";
+    followupRun.run.model = "claude-opus-4-8";
+    const sessionEntry = {
+      sessionId: "openclaw-session",
+      updatedAt: 1,
+      cliSessionBindings: { "claude-cli": { sessionId: "aborted-session" } },
+      cliSessionIds: { "claude-cli": "aborted-session" },
+      claudeCliSessionId: "aborted-session",
+    } as SessionEntry;
+    const activeSessionStore = { [sessionKey]: sessionEntry };
+    const executeAgentTurn = await getExecuteAgentTurnForTest();
+
+    await executeAgentTurn({
+      ...createMinimalRunAgentTurnParams({ followupRun }),
+      sessionKey,
+      activeSessionStore,
+      getActiveSessionEntry: () => sessionEntry,
+    });
+
+    expect(sessionEntry.cliSessionBindings?.["claude-cli"]?.sessionId).toBe("aborted-session");
+    expect(sessionEntry.cliSessionIds?.["claude-cli"]).toBe("aborted-session");
+    expect(sessionEntry.claudeCliSessionId).toBe("aborted-session");
+  });
+
   it("does not attribute media from an earlier admitted turn to a queued failure", async () => {
     const sessionKey = "agent:main:cron:media-job:run:run-queued";
     state.isCliProviderMock.mockReturnValue(true);


### PR DESCRIPTION
## What Problem This Solves

Cancelling a Claude CLI turn can discard its reusable native conversation binding. If gateway history cannot be admitted across an unknown authentication boundary, the next turn has neither native resume nor replayed history.

## Evidence

### Observed runtime evidence (before fix)

These are real gateway log records, normalized to UTC. Model and identifiers are redacted. `SESSION_A` and `SESSION_B` denote different native resume fingerprints. No prompt content is included.

```text
2026-09-12T02:05:55.516Z cli exec: provider=claude-cli model=[redacted] promptChars=34 trigger=user useResume=true session=present resumeSession=SESSION_A reuse=reusable historyPrompt=none
2026-09-12T02:07:26.025Z cli terminal failure: provider=claude-cli model=[redacted] durationMs=90586 runId=[redacted] error=CLI run aborted
2026-09-12T02:07:26.225Z cli exec: provider=claude-cli model=[redacted] promptChars=23 trigger=user useResume=false session=none resumeSession=none reuse=none historyPrompt=none
2026-09-12T02:27:28.252Z cli terminal failure: provider=claude-cli model=[redacted] durationMs=110592 runId=[redacted] error=CLI run aborted
2026-09-12T02:27:33.767Z cli terminal failure: provider=claude-cli model=[redacted] durationMs=5418 runId=[redacted] error=CLI run aborted
2026-09-12T02:27:39.052Z cli terminal failure: provider=claude-cli model=[redacted] durationMs=5214 runId=[redacted] error=CLI run aborted
2026-09-12T02:27:56.359Z cli session history refused across auth boundary: reason=auth-unknown
2026-09-12T02:27:56.362Z cli exec: provider=claude-cli model=[redacted] promptChars=17 trigger=user useResume=false session=none resumeSession=none reuse=none historyPrompt=none
2026-09-12T02:28:54.858Z cli exec: provider=claude-cli model=[redacted] promptChars=162 trigger=user useResume=true session=present resumeSession=SESSION_B reuse=reusable historyPrompt=none
```

The final record resumes a different native session. It is not proof that the lost context returned. The logs establish the abort-to-no-resume failure; they do not establish which physical UI key generated each cancellation.

## Why This Change Was Made

- Preserve an established native binding on AbortError instead of treating cancellation alone as invalidation.
- Retain cleanup for a binding replaced during the failed run.
- Stop unconditionally clearing a binding on terminal interruption. Preserve existing disabled-binding and failed-flush cleanup.
- Do not bypass authentication/history admission boundaries.

Important scope: managed live sessions skip the native transcript probe. Therefore this PR does **not** claim every retained binding has passed an on-disk transcript check.

## User Impact

Cancellation should retain native conversation continuity without bypassing history authorization or retaining invalid replacement bindings.

### Validation and remaining evidence

The submitted patch has targeted regression coverage for abort handling, replacement cleanup and interrupted settlement. Existing reported unit results are not a real managed-Claude abort/resume recording.

### After: actual patched Gateway and native Claude process

Pinned source/build: `a3d83ddcbf364f7352cfa69031fe619a468b7693`; independently installed dependencies, synthetic workspace, separate SQLite/config, explicit scratch port. This was normal Gateway `chat.send` / `chat.abort`, not mocked CLI execution.

Gateway RPC chat.send seeded synthetic PEBBLE-7429; model acknowledged remembered. A subsequent normal gateway chat.send requested a long lighthouse story. After gateway recorded assistant_output_started, gateway chat.abort returned {"ok":true,"aborted":true,"runIds":["STREAM"]}. The next gateway chat.send asked for the earlier code without repeating it; native result was PEBBLE-7429. Same native session before and after; no history reseed.

```text
2026-09-12T13:58:35.626Z cli exec: provider=claude-cli model=[redacted] promptChars=117 useResume=true session=present resumeSession=SESSION_A reuse=reusable historyPrompt=none
2026-09-12T13:58:51.091Z milestone=assistant_output_started run=STREAM
2026-09-12T13:58:52.643Z stream=lifecycle phase=end aborted=true run=STREAM
2026-09-12T13:58:52.651Z outcome=skipped reason=reply_operation_aborted run=STREAM
2026-09-12T13:58:52.652Z chat.abort success
2026-09-12T13:58:53.700Z cli turn durationMs=18074 outBytes=278
2026-09-12T13:58:55.853Z cli exec: provider=claude-cli model=[redacted] promptChars=82 useResume=true session=present resumeSession=SESSION_A reuse=reusable historyPrompt=none
2026-09-12T13:58:59.487Z cli turn durationMs=3634 outBytes=11
native result: PEBBLE-7429
```

This demonstrates the actual managed gateway partial-output interruption/settlement path and continuation. It does not demonstrate an AbortError before any output, nor prove all provider cancellation modes.


The successful run used explicit port isolation. An earlier scratch startup inherited the production port and was stopped; it is not presented as clean isolation proof. Production was not restarted. A subsequent stricter environment-scrubbed repeat encountered provider refusals and is not counted as a successful repeat.

### CI scope

The current head has CI failures in the native-Bash allowlist test (deny versus allow) and an authentication test (1-second timeout), plus the aggregate gate. Both failing suites were re-run unchanged on the pinned patched checkout: **20/20 tests passed**. GitHub rejected the remote rerun with `Must have admin rights to Repository`; a maintainer rerun is needed. The aggregate CI result is not claimed green. No timeout, assertion, allowlist or baseline was weakened.

Related report: https://github.com/openclaw/openclaw/issues/144392 (review-identified overlap; not independently audited here).
