### PR TITLE
fix(gateway): replace unsupported service Node

### DIFF
--- a/src/cli/daemon-cli/install.test.ts
+++ b/src/cli/daemon-cli/install.test.ts
@@ -1,5 +1,6 @@
 // Daemon install tests cover service install command behavior and plan handling.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { GatewayServiceCommandConfig } from "../../daemon/service.js";
 import type { ResolvedGatewayAuth } from "../../gateway/auth.js";
 import { captureFullEnv } from "../../test-utils/env.js";
 import { createCliRuntimeCapture } from "../test-runtime-capture.js";
@@ -59,6 +60,8 @@ const buildGatewayInstallPlanMock = vi.hoisted(() => vi.fn(createInstallPlanFixt
 const parsePortMock = vi.hoisted(() => vi.fn(() => null));
 const isGatewayDaemonRuntimeMock = vi.hoisted(() => vi.fn(() => true));
 const installDaemonServiceAndEmitMock = vi.hoisted(() => vi.fn(async (_params?: unknown) => {}));
+const resolveNodeRuntimeInfoMock = vi.hoisted(() => vi.fn());
+const resolvePreferredNodePathMock = vi.hoisted(() => vi.fn());
 
 const actionState = vi.hoisted(() => ({
   warnings: [] as string[],
@@ -76,7 +79,7 @@ const service = vi.hoisted(() => ({
   uninstall: vi.fn(async () => {}),
   restart: vi.fn(async () => {}),
   stop: vi.fn(async () => {}),
-  readCommand: vi.fn(async () => null),
+  readCommand: vi.fn<() => Promise<GatewayServiceCommandConfig | null>>(async () => null),
   readRuntime: vi.fn(async () => ({ status: "stopped" as const })),
 }));
 
@@ -167,6 +170,11 @@ vi.mock("../../commands/daemon-runtime.js", () => ({
 
 vi.mock("../../daemon/service.js", () => ({
   resolveGatewayService: () => service,
+}));
+
+vi.mock("../../daemon/runtime-paths.js", () => ({
+  resolveNodeRuntimeInfo: resolveNodeRuntimeInfoMock,
+  resolvePreferredNodePath: resolvePreferredNodePathMock,
 }));
 
 vi.mock("./response.js", () => ({
@@ -273,6 +281,8 @@ describe("runDaemonInstall", () => {
     parsePortMock.mockReset();
     isGatewayDaemonRuntimeMock.mockReset();
     installDaemonServiceAndEmitMock.mockReset();
+    resolveNodeRuntimeInfoMock.mockReset();
+    resolvePreferredNodePathMock.mockReset();
     service.isLoaded.mockReset();
     service.stage.mockReset();
     service.install.mockReset();
@@ -304,6 +314,12 @@ describe("runDaemonInstall", () => {
     parsePortMock.mockReturnValue(null);
     isGatewayDaemonRuntimeMock.mockReturnValue(true);
     installDaemonServiceAndEmitMock.mockResolvedValue(undefined);
+    resolveNodeRuntimeInfoMock.mockResolvedValue({
+      nodeVersion: null,
+      sqliteVersion: null,
+      supported: false,
+    });
+    resolvePreferredNodePathMock.mockResolvedValue("/supported/node");
     service.isLoaded.mockResolvedValue(false);
     service.stage.mockResolvedValue(undefined);
     service.install.mockResolvedValue(undefined);
@@ -554,6 +570,76 @@ describe("runDaemonInstall", () => {
 
     expect(installDaemonServiceAndEmitMock).not.toHaveBeenCalled();
     expectLastEmittedResult("already-installed");
+  });
+
+  it("replaces an unsupported Node recorded in the managed service", async () => {
+    service.isLoaded.mockResolvedValue(true);
+    service.readCommand.mockResolvedValue({
+      programArguments: ["/obsolete/node", "openclaw.mjs", "gateway", "run"],
+      environment: {},
+    });
+    resolveNodeRuntimeInfoMock.mockResolvedValue({
+      nodeVersion: "22.19.0",
+      sqliteVersion: "3.50.0",
+      supported: false,
+    });
+    resolvePreferredNodePathMock.mockResolvedValue("/supported/node");
+
+    await runDaemonInstall({ json: true });
+
+    expect(buildGatewayInstallPlanMock).toHaveBeenCalledWith(
+      expect.objectContaining({ nodePath: "/supported/node" }),
+    );
+    expect(actionState.warnings).toContain(
+      "Replacing unsupported Gateway service Node 22.19.0 (/obsolete/node) with /supported/node; refreshing the install.",
+    );
+    expect(actionState.emitted).toEqual([]);
+  });
+
+  it("replaces an unsupported service Node during forced installation", async () => {
+    service.isLoaded.mockResolvedValue(true);
+    service.readCommand.mockResolvedValue({
+      programArguments: ["/obsolete/node", "openclaw.mjs", "gateway", "run"],
+      environment: { OPENCLAW_SERVICE_MARKER: "preserved" },
+    });
+    resolveNodeRuntimeInfoMock.mockResolvedValue({
+      nodeVersion: "22.19.0",
+      sqliteVersion: "3.50.0",
+      supported: false,
+    });
+    resolvePreferredNodePathMock.mockResolvedValue("/usr/local/bin/node24");
+
+    await runDaemonInstall({ json: true, force: true });
+
+    expect(buildGatewayInstallPlanMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        nodePath: "/usr/local/bin/node24",
+        existingEnvironment: { OPENCLAW_SERVICE_MARKER: "preserved" },
+      }),
+    );
+    expect(actionState.failed).toEqual([]);
+    expect(actionState.emitted).toEqual([]);
+  });
+
+  it("rejects an unsupported service Node before mutating the service when no replacement exists", async () => {
+    service.isLoaded.mockResolvedValue(true);
+    service.readCommand.mockResolvedValue({
+      programArguments: ["/obsolete/node", "openclaw.mjs", "gateway", "run"],
+      environment: { OPENCLAW_SERVICE_MARKER: "preserved" },
+    });
+    resolveNodeRuntimeInfoMock.mockResolvedValue({
+      nodeVersion: "22.19.0",
+      sqliteVersion: "3.50.0",
+      supported: false,
+    });
+    resolvePreferredNodePathMock.mockResolvedValue(undefined);
+
+    await runDaemonInstall({ json: true, force: true });
+
+    expect(actionState.failed[0]?.message).toContain("No supported Node runtime is available");
+    expect(buildGatewayInstallPlanMock).not.toHaveBeenCalled();
+    expect(service.install).not.toHaveBeenCalled();
+    expect(installDaemonServiceAndEmitMock).not.toHaveBeenCalled();
   });
 
   it("reinstalls when the loaded service still embeds OPENCLAW_GATEWAY_TOKEN", async () => {

--- a/src/cli/daemon-cli/install.ts
+++ b/src/cli/daemon-cli/install.ts
@@ -14,6 +14,8 @@ import { replaceConfigFile } from "../../config/mutate.js";
 import { resolveGatewayPort } from "../../config/paths.js";
 import type { OpenClawConfig } from "../../config/types.js";
 import { OPENCLAW_WRAPPER_ENV_KEY, resolveOpenClawWrapperPath } from "../../daemon/program-args.js";
+import { isNodeRuntime } from "../../daemon/runtime-binary.js";
+import { resolveNodeRuntimeInfo, resolvePreferredNodePath } from "../../daemon/runtime-paths.js";
 import { readEmbeddedGatewayToken } from "../../daemon/service-audit.js";
 import { resolveGatewayService } from "../../daemon/service.js";
 import type { GatewayServiceCommandConfig } from "../../daemon/service.js";
@@ -23,6 +25,7 @@ import {
   isDangerousHostEnvVarName,
   normalizeEnvVarKey,
 } from "../../infra/host-env-security.js";
+import { isSupportedNodeVersion } from "../../infra/runtime-guard.js";
 import { defaultRuntime } from "../../runtime.js";
 import { formatCliCommand } from "../command-format.js";
 import { formatInvalidConfigPort, formatInvalidPortOption } from "../error-format.js";
@@ -195,9 +198,31 @@ export async function runDaemonInstall(opts: DaemonInstallOptions) {
       return;
     }
   }
+  let autoRefreshMessage: string | undefined;
+  let replacementNodePath: string | undefined;
+  const recordedNode = existingServiceCommand?.programArguments[0];
+  if (runtimeRaw === "node" && !wrapperPath && recordedNode && isNodeRuntime(recordedNode)) {
+    const recordedRuntime = await resolveNodeRuntimeInfo(recordedNode);
+    if (
+      recordedRuntime.nodeVersion !== null &&
+      !isSupportedNodeVersion(recordedRuntime.nodeVersion)
+    ) {
+      replacementNodePath = await resolvePreferredNodePath({
+        env: installEnv,
+        runtime: "node",
+      }).catch(() => undefined);
+      if (!replacementNodePath) {
+        fail(
+          "No supported Node runtime is available. Install Node 22.22.3+, 24.15.0+, or 25.9.0+, then rerun openclaw gateway install.",
+        );
+        return;
+      }
+      autoRefreshMessage = `Replacing unsupported Gateway service Node ${recordedRuntime.nodeVersion} (${recordedNode}) with ${replacementNodePath}; refreshing the install.`;
+    }
+  }
   if (loaded) {
     if (!opts.force) {
-      const autoRefreshMessage = await getGatewayServiceAutoRefreshMessage({
+      autoRefreshMessage ??= await getGatewayServiceAutoRefreshMessage({
         currentCommand: existingServiceCommand,
         env: process.env,
         installEnv,
@@ -208,13 +233,7 @@ export async function runDaemonInstall(opts: DaemonInstallOptions) {
         existingEnvironmentValueSources: existingServiceCommand?.environmentValueSources,
         config: cfg,
       });
-      if (autoRefreshMessage) {
-        if (json) {
-          warnings.push(autoRefreshMessage);
-        } else {
-          defaultRuntime.log(autoRefreshMessage);
-        }
-      } else {
+      if (!autoRefreshMessage) {
         emit({
           ok: true,
           result: "already-installed",
@@ -229,6 +248,13 @@ export async function runDaemonInstall(opts: DaemonInstallOptions) {
         }
         return;
       }
+    }
+  }
+  if (autoRefreshMessage) {
+    if (json) {
+      warnings.push(autoRefreshMessage);
+    } else {
+      defaultRuntime.log(autoRefreshMessage);
     }
   }
 
@@ -258,6 +284,7 @@ export async function runDaemonInstall(opts: DaemonInstallOptions) {
       env: installEnv,
       port,
       runtime: runtimeRaw,
+      nodePath: replacementNodePath,
       wrapperPath,
       existingEnvironment: existingServiceEnv,
       existingEnvironmentValueSources: existingServiceCommand?.environmentValueSources,

--- a/src/commands/daemon-install-helpers.test.ts
+++ b/src/commands/daemon-install-helpers.test.ts
@@ -294,6 +294,36 @@ describe("buildGatewayInstallPlan", () => {
     expect(serviceEnvRequest?.extraPathDirs).toStrictEqual(["/custom"]);
   });
 
+  it("preserves operator-owned service settings in a replacement-node plan", async () => {
+    mockNodeGatewayPlanFixture({
+      serviceEnvironment: {
+        OPENCLAW_PORT: "3000",
+        OPENCLAW_SERVICE_KIND: "gateway",
+      },
+    });
+
+    const plan = await buildGatewayInstallPlan({
+      env: { HOME: isolatedHome },
+      port: 3000,
+      runtime: "node",
+      nodePath: "/usr/local/bin/node24",
+      existingEnvironment: {
+        BLOGWATCHER_HOME: "/Users/test/.blogwatcher",
+      },
+    });
+
+    expect(mocks.resolveGatewayProgramArguments).toHaveBeenCalledWith(
+      expect.objectContaining({ nodePath: "/usr/local/bin/node24" }),
+    );
+    expect(plan.environment).toEqual(
+      expect.objectContaining({
+        BLOGWATCHER_HOME: "/Users/test/.blogwatcher",
+        OPENCLAW_PORT: "3000",
+        OPENCLAW_SERVICE_KIND: "gateway",
+      }),
+    );
+  });
+
   it("adds the active openclaw command bin directory to the managed service PATH", async () => {
     mockNodeGatewayPlanFixture();
     const originalArgv = process.argv;

--- a/src/daemon/runtime-paths.test.ts
+++ b/src/daemon/runtime-paths.test.ts
@@ -181,6 +181,24 @@ describe("resolvePreferredNodePath", () => {
     expect(execFile).toHaveBeenCalledTimes(2);
   });
 
+  it.each(["/usr/local/bin/nodejs", "/usr/local/bin/node24"])(
+    "accepts supported alternate Node executable %s",
+    async (execPath) => {
+      const execFile = vi.fn().mockResolvedValue(nodeRuntime("24.15.0"));
+
+      const result = await resolvePreferredNodePath({
+        env: {},
+        runtime: "node",
+        platform: "linux",
+        execFile,
+        execPath,
+      });
+
+      expect(result).toBe(execPath);
+      expect(execFile).toHaveBeenCalledTimes(1);
+    },
+  );
+
   it("falls back to system node when execPath version is unsupported", async () => {
     mockNodePathPresent(darwinNode);
 

--- a/src/daemon/runtime-paths.ts
+++ b/src/daemon/runtime-paths.ts
@@ -8,6 +8,7 @@ import { isSupportedNodeVersion } from "../infra/runtime-guard.js";
 import { isSqliteWalResetSafeVersion } from "../infra/sqlite-runtime-version.js";
 import { resolveStableNodePath } from "../infra/stable-node-path.js";
 import { getWindowsProgramFilesRoots } from "../infra/windows-install-roots.js";
+import { isNodeRuntime } from "./runtime-binary.js";
 
 const VERSION_MANAGER_MARKERS = [
   "/.nvm/",
@@ -25,12 +26,6 @@ const VERSION_MANAGER_MARKERS = [
 
 function getPathModule(platform: NodeJS.Platform) {
   return platform === "win32" ? path.win32 : path.posix;
-}
-
-function isNodeExecPath(execPath: string, platform: NodeJS.Platform): boolean {
-  const pathModule = getPathModule(platform);
-  const base = normalizeLowercaseStringOrEmpty(pathModule.basename(execPath));
-  return base === "node" || base === "node.exe";
 }
 
 function normalizeForCompare(input: string, platform: NodeJS.Platform): string {
@@ -95,15 +90,15 @@ try {
 process.stdout.write(JSON.stringify({ nodeVersion: process.versions.node, sqliteVersion }));
 `;
 
-type NodeRuntimeInfo = {
+export type NodeRuntimeInfo = {
   nodeVersion: string | null;
   sqliteVersion: string | null;
   supported: boolean;
 };
 
-async function resolveNodeRuntimeInfo(
+export async function resolveNodeRuntimeInfo(
   nodePath: string,
-  execFileImpl: ExecFileAsync,
+  execFileImpl: ExecFileAsync = execFileAsync,
 ): Promise<NodeRuntimeInfo> {
   try {
     const { stdout } = await execFileImpl(nodePath, ["-e", NODE_RUNTIME_PROBE], {
@@ -255,7 +250,7 @@ export async function resolvePreferredNodePath(params: {
   const platform = params.platform ?? process.platform;
   const currentExecPath = params.execPath ?? process.execPath;
   const execFileImpl = params.execFile ?? execFileAsync;
-  if (currentExecPath && isNodeExecPath(currentExecPath, platform)) {
+  if (currentExecPath && isNodeRuntime(currentExecPath)) {
     const runtime = await resolveNodeRuntimeInfo(currentExecPath, execFileImpl);
     if (runtime.supported) {
       const stableCurrentPath = await resolveStableNodePath(currentExecPath);


### PR DESCRIPTION
## Summary
- probe the Node executable recorded in an existing managed Gateway service
- replace it when that Node version is outside the 7.33 supported ranges
- fail before service mutation with actionable guidance when no supported replacement exists
- reuse the shared Node-runtime classifier so supported `nodejs`, `node24`, and versioned executable names remain eligible

Narrow 7.33 adaptation of the service-Node repair from #143159 / fe79d36c0d. The later updater restructuring is intentionally excluded.

## Prior finding disposition
The alternate-executable finding is resolved on the current head: `resolvePreferredNodePath` now uses the same `isNodeRuntime` classifier as command rendering. Focused tests exercise `nodejs` and `node24`, and forced repair forwards the supported replacement while preserving the existing service environment.

## Validation
- runtime-binary, runtime-path, and daemon-install suites: 65 passed
- automatic unsupported-service repair regression
- forced repair regression with retained service settings
- core/extension test typecheck
- exact formatting and diff checks
- combined published `openclaw@2026.6.35` → packed `2026.7.33` proof: manual restart passed; managed automatic restart returned in 88s; state/config/session survival, plugin cleanup/version parity, and Gateway health/readiness/status passed
