### PR TITLE
refactor(plugins): unify Gateway startup planning

### DIFF
--- a/src/plugins/bundled-plugin-metadata.test.ts
+++ b/src/plugins/bundled-plugin-metadata.test.ts
@@ -12,7 +12,7 @@ import { resolveBundledPluginGeneratedPath } from "./bundled-plugin-scan.js";
 import { isPluginEnabledByDefaultForPlatform } from "./default-enablement.js";
 
 type BundledPluginMetadata = ReturnType<typeof listBundledPluginMetadata>[number];
-import { resolveGatewayStartupPluginIdsFromRegistry } from "./gateway-startup-plugin-ids.js";
+import { resolveGatewayStartupPluginPlanFromRegistry } from "./gateway-startup-plugin-ids.js";
 import {
   createGeneratedPluginTempRoot,
   installGeneratedPluginTempRootCleanup,
@@ -592,13 +592,13 @@ describe("bundled plugin metadata", () => {
     ].toSorted((left, right) => left.localeCompare(right));
 
     expect(
-      resolveGatewayStartupPluginIdsFromRegistry({
+      resolveGatewayStartupPluginPlanFromRegistry({
         config: {},
         env: {},
         index,
         manifestRegistry,
         platform: "linux",
-      }),
+      }).pluginIds,
     ).toEqual(expectedPluginIds);
   });
 
@@ -607,13 +607,13 @@ describe("bundled plugin metadata", () => {
     const index = createInstalledPluginIndexForManifests(manifestRegistry);
 
     expect(
-      resolveGatewayStartupPluginIdsFromRegistry({
+      resolveGatewayStartupPluginPlanFromRegistry({
         config: {},
         env: process.env,
         index,
         manifestRegistry,
         platform: "darwin",
-      }),
+      }).pluginIds,
     ).toContain("bonjour");
   });
 
@@ -635,12 +635,12 @@ describe("bundled plugin metadata", () => {
     const manifestRegistry = createRepoBundledManifestRegistry();
 
     expect(
-      resolveGatewayStartupPluginIdsFromRegistry({
+      resolveGatewayStartupPluginPlanFromRegistry({
         config,
         env: {},
         index: createInstalledPluginIndexForManifests(manifestRegistry),
         manifestRegistry,
-      }),
+      }).pluginIds,
     ).toContain("openai");
   });
 
@@ -649,13 +649,13 @@ describe("bundled plugin metadata", () => {
     const index = createInstalledPluginIndexForManifests(manifestRegistry);
 
     expect(
-      resolveGatewayStartupPluginIdsFromRegistry({
+      resolveGatewayStartupPluginPlanFromRegistry({
         config: { plugins: { entries: { bonjour: { enabled: true } } } },
         env: process.env,
         index,
         manifestRegistry,
         platform: "linux",
-      }),
+      }).pluginIds,
     ).toContain("bonjour");
   });
 

--- a/src/plugins/channel-plugin-ids.test.ts
+++ b/src/plugins/channel-plugin-ids.test.ts
@@ -84,7 +84,6 @@ import {
   createGatewayStartupMetadataPluginIdScope,
   loadGatewayStartupPluginPlanWithMetadata,
   resolveGatewayStartupMetadataPluginIds,
-  resolveGatewayStartupPluginIdsFromRegistry,
   resolveGatewayStartupPluginPlanFromRegistry,
 } from "./channel-plugin-ids.js";
 
@@ -419,7 +418,7 @@ function expectStartupPluginIds(params: {
 }) {
   const manifestRegistry = loadPluginManifestRegistryCore() as PluginManifestRegistry;
   expect(
-    resolveGatewayStartupPluginIdsFromRegistry({
+    resolveGatewayStartupPluginPlanFromRegistry({
       config: params.config,
       ...(params.activationSourceConfig !== undefined
         ? { activationSourceConfig: params.activationSourceConfig }
@@ -430,7 +429,7 @@ function expectStartupPluginIds(params: {
       ...(params.workerProviderIds !== undefined
         ? { workerProviderIds: params.workerProviderIds }
         : {}),
-    }),
+    }).pluginIds,
   ).toEqual(params.expected);
 }
 
@@ -537,7 +536,7 @@ function createStartupConfig(params: {
   return config as OpenClawConfig;
 }
 
-describe("resolveGatewayStartupPluginIdsFromRegistry", () => {
+describe("resolveGatewayStartupPluginPlanFromRegistry", () => {
   beforeEach(() => {
     listPotentialConfiguredChannelIds.mockReset().mockImplementation((config: OpenClawConfig) => {
       if (Object.hasOwn(config, "channels")) {

--- a/src/plugins/channel-plugin-ids.ts
+++ b/src/plugins/channel-plugin-ids.ts
@@ -26,6 +26,5 @@ export {
   loadGatewayStartupPluginPlan,
   loadGatewayStartupPluginPlanWithMetadata,
   resolveGatewayStartupPluginPlanFromRegistry,
-  resolveGatewayStartupPluginIdsFromRegistry,
   type GatewayStartupPluginPlan,
 } from "./gateway-startup-plugin-ids.js";

--- a/src/plugins/gateway-startup-plugin-config.ts
+++ b/src/plugins/gateway-startup-plugin-config.ts
@@ -25,10 +25,7 @@ import {
   resolveSelectedContextEnginePluginIdFromConfig,
 } from "./config-state.js";
 import { isPluginEnabledByDefaultForPlatform } from "./default-enablement.js";
-import type {
-  ManifestRegistryLookup,
-  NormalizedPluginsConfig,
-} from "./gateway-startup-plugin-contracts.js";
+import type { NormalizedPluginsConfig } from "./gateway-startup-plugin-contracts.js";
 import { sortUniquePluginIds } from "./gateway-startup-plugin-contracts.js";
 import {
   collectConfiguredGenerationProviderIds,
@@ -42,7 +39,7 @@ import type {
   InstalledPluginIndexRecord,
   InstalledPluginIndexScopeLookup,
 } from "./installed-plugin-index-types.js";
-import type { PluginManifestRecord, PluginManifestRegistry } from "./manifest-registry.js";
+import type { PluginManifestRecord } from "./manifest-registry.js";
 import { normalizePluginsConfigWithRegistry } from "./plugin-registry-contributions.js";
 
 export function readStartupBundledDiscoveryMode(
@@ -259,36 +256,6 @@ export function shouldConsiderForGatewayStartup(params: {
     return true;
   }
   return params.memorySlotStartupPluginId === params.plugin.pluginId;
-}
-
-export function hasConfiguredStartupChannel(params: {
-  plugin: InstalledPluginIndexRecord;
-  manifestLookup: ManifestRegistryLookup;
-  configuredChannelIds: ReadonlySet<string>;
-}): boolean {
-  return listManifestChannelIds(params.manifestLookup, params.plugin.pluginId).some((channelId) =>
-    params.configuredChannelIds.has(channelId),
-  );
-}
-
-export function createManifestRegistryLookup(
-  manifestRegistry: PluginManifestRegistry,
-): ManifestRegistryLookup {
-  return new Map(manifestRegistry.plugins.map((plugin) => [plugin.id, plugin]));
-}
-
-export function listManifestChannelIds(
-  manifestLookup: ManifestRegistryLookup,
-  pluginId: string,
-): readonly string[] {
-  return manifestLookup.get(pluginId)?.channels ?? [];
-}
-
-export function findManifestPlugin(
-  manifestLookup: ManifestRegistryLookup,
-  pluginId: string,
-): PluginManifestRecord | undefined {
-  return manifestLookup.get(pluginId);
 }
 
 export function hasConfiguredActivationPath(params: {

--- a/src/plugins/gateway-startup-plugin-contracts.ts
+++ b/src/plugins/gateway-startup-plugin-contracts.ts
@@ -1,5 +1,4 @@
 // Shared contracts for Gateway startup plugin collection and planning.
-import type { PluginManifestRecord } from "./manifest-registry.js";
 import { normalizePluginsConfigWithRegistry } from "./plugin-registry-contributions.js";
 
 export type GatewayStartupPluginPlan = {
@@ -21,7 +20,6 @@ export type ConfiguredGenerationProviderIds = Record<
   ReadonlySet<string>
 >;
 export type ConfiguredVoiceProviderIds = Record<VoiceProviderContractKey, ReadonlySet<string>>;
-export type ManifestRegistryLookup = ReadonlyMap<string, PluginManifestRecord>;
 export function sortUniquePluginIds(values: Iterable<string>): string[] {
   return [...new Set([...values].map((value) => value.trim()).filter(Boolean))].toSorted(
     (left, right) => left.localeCompare(right),

--- a/src/plugins/gateway-startup-plugin-ids.ts
+++ b/src/plugins/gateway-startup-plugin-ids.ts
@@ -18,5 +18,4 @@ export {
   loadGatewayStartupPluginPlan,
   loadGatewayStartupPluginPlanWithMetadata,
   resolveChannelPluginIds,
-  resolveGatewayStartupPluginIdsFromRegistry,
 } from "./gateway-startup-plugin-loader.js";

--- a/src/plugins/gateway-startup-plugin-loader.ts
+++ b/src/plugins/gateway-startup-plugin-loader.ts
@@ -4,7 +4,6 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { GatewayStartupPluginPlan } from "./gateway-startup-plugin-contracts.js";
 import { createGatewayStartupMetadataPluginIdScope } from "./gateway-startup-plugin-metadata.js";
 import { resolveGatewayStartupPluginPlanFromRegistry } from "./gateway-startup-plugin-plan.js";
-import type { PluginManifestRegistry } from "./manifest-registry.js";
 import {
   resolvePluginMetadataSnapshot,
   type PluginMetadataSnapshot,
@@ -17,18 +16,6 @@ export function resolveChannelPluginIds(params: {
   env: NodeJS.ProcessEnv;
 }): string[] {
   return [...loadGatewayStartupPluginPlan(params).channelPluginIds];
-}
-
-export function resolveGatewayStartupPluginIdsFromRegistry(params: {
-  config: OpenClawConfig;
-  activationSourceConfig?: OpenClawConfig;
-  env: NodeJS.ProcessEnv;
-  index: PluginRegistrySnapshot;
-  manifestRegistry: PluginManifestRegistry;
-  workerProviderIds?: readonly string[];
-  platform?: NodeJS.Platform;
-}): string[] {
-  return [...resolveGatewayStartupPluginPlanFromRegistry(params).pluginIds];
 }
 
 type GatewayStartupPluginPlanParams = {
@@ -46,6 +33,7 @@ type GatewayStartupPluginPlanParams = {
 export function loadGatewayStartupPluginPlanWithMetadata(params: GatewayStartupPluginPlanParams): {
   plan: GatewayStartupPluginPlan;
   metadataSnapshot: PluginMetadataSnapshot;
+  startupPlanMs: number;
 } {
   const snapshotConfig = params.activationSourceConfig ?? params.config;
   // Activation may change, but a supplied inventory still belongs to its boot.
@@ -70,6 +58,7 @@ export function loadGatewayStartupPluginPlanWithMetadata(params: GatewayStartupP
           : {}),
       }),
     });
+  const startupPlanStartedAt = performance.now();
   const plan = resolveGatewayStartupPluginPlanFromRegistry({
     config: params.config,
     ...(params.activationSourceConfig !== undefined
@@ -84,7 +73,7 @@ export function loadGatewayStartupPluginPlanWithMetadata(params: GatewayStartupP
     platform: params.platform,
     ambientEnvTriggers: params.ambientEnvTriggers,
   });
-  return { plan, metadataSnapshot };
+  return { plan, metadataSnapshot, startupPlanMs: performance.now() - startupPlanStartedAt };
 }
 
 export function loadGatewayStartupPluginPlan(

--- a/src/plugins/gateway-startup-plugin-plan.ts
+++ b/src/plugins/gateway-startup-plugin-plan.ts
@@ -17,14 +17,10 @@ import { isPluginEnabledByDefaultForPlatform } from "./default-enablement.js";
 import type { PluginDiscoveryResult } from "./discovery.js";
 import { canStartGatewayStartupPlugin } from "./gateway-startup-plugin-activation.js";
 import {
-  hasConfiguredStartupChannel,
   resolveAuthorizedGatewayStartupDreamingPluginIds,
   resolveContextEngineSlotStartupPluginId,
   resolveMemorySlotStartupPluginId,
   shouldConsiderForGatewayStartup,
-  createManifestRegistryLookup,
-  findManifestPlugin,
-  listManifestChannelIds,
 } from "./gateway-startup-plugin-config.js";
 import type { GatewayStartupPluginPlan } from "./gateway-startup-plugin-contracts.js";
 import {
@@ -94,7 +90,9 @@ export function resolveGatewayStartupPluginPlanFromRegistry(params: {
     plugins: activationSourcePlugins,
     rootConfig: activationSourceConfig,
   };
-  const manifestLookup = createManifestRegistryLookup(params.manifestRegistry);
+  const manifestLookup = new Map(
+    params.manifestRegistry.plugins.map((plugin) => [plugin.id, plugin]),
+  );
   const explicitlyDisabledChannelIds = new Set(
     listExplicitlyDisabledChannelIdsForConfig(params.config),
   );
@@ -138,7 +136,8 @@ export function resolveGatewayStartupPluginPlanFromRegistry(params: {
   });
   const pluginIds: string[] = [];
   for (const plugin of params.index.plugins) {
-    const manifest = findManifestPlugin(manifestLookup, plugin.pluginId);
+    const manifest = manifestLookup.get(plugin.pluginId);
+    const manifestChannelIds = manifest?.channels ?? [];
     const hasEnabledManifestChannel =
       manifest?.channels?.some((channelId) => {
         const normalizedChannelId = normalizeOptionalLowercaseString(channelId);
@@ -156,20 +155,14 @@ export function resolveGatewayStartupPluginPlanFromRegistry(params: {
       pluginsConfig.entries[plugin.pluginId]?.enabled === true &&
       !pluginsConfig.deny.includes(plugin.pluginId);
     if (
-      hasConfiguredStartupChannel({
-        plugin,
-        manifestLookup,
-        configuredChannelIds,
-      }) ||
+      manifestChannelIds.some((channelId) => configuredChannelIds.has(channelId)) ||
       hasExplicitlyEnabledNonBundledChannel
     ) {
       const canStartConfiguredChannel = canStartConfiguredChannelPlugin({
         id: plugin.pluginId,
         origin: plugin.origin,
         channelIds:
-          plugin.origin === "bundled"
-            ? listManifestChannelIds(manifestLookup, plugin.pluginId)
-            : plugin.contributions?.channels,
+          plugin.origin === "bundled" ? manifestChannelIds : plugin.contributions?.channels,
         config: params.config,
         pluginsConfig,
         activationSource,

--- a/src/plugins/plugin-lookup-table.ts
+++ b/src/plugins/plugin-lookup-table.ts
@@ -1,15 +1,9 @@
 /** Builds plugin lookup tables keyed by manifest ids, channels, providers, and commands. */
 import type { AmbientEnvTriggerPolicy } from "../channels/config-presence.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import {
-  createGatewayStartupMetadataPluginIdScope,
-  resolveGatewayStartupPluginPlanFromRegistry,
-  type GatewayStartupPluginPlan,
-} from "./channel-plugin-ids.js";
-import {
-  resolvePluginMetadataSnapshot,
-  type PluginMetadataSnapshot,
-} from "./plugin-metadata-snapshot.js";
+import type { GatewayStartupPluginPlan } from "./gateway-startup-plugin-contracts.js";
+import { loadGatewayStartupPluginPlanWithMetadata } from "./gateway-startup-plugin-loader.js";
+import type { PluginMetadataSnapshot } from "./plugin-metadata-snapshot.js";
 import type { PluginRegistrySnapshot } from "./plugin-registry-snapshot.js";
 import { normalizeWorkerProviderIds } from "./worker-provider-id.js";
 
@@ -36,44 +30,12 @@ type LoadPluginLookUpTableParams = {
 };
 
 export function loadPluginLookUpTable(params: LoadPluginLookUpTableParams): PluginLookUpTable {
-  const requestedSnapshotConfig = params.activationSourceConfig ?? params.config;
   const workerProviderIds = normalizeWorkerProviderIds(params.workerProviderIds ?? []);
-  const metadataSnapshot =
-    // A caller-prepared inventory is authoritative. Startup activation selects
-    // from it; policy changes never authorize discovering a replacement graph.
-    params.metadataSnapshot ??
-    resolvePluginMetadataSnapshot({
-      config: requestedSnapshotConfig,
-      workspaceDir: params.workspaceDir,
-      env: params.env,
-      allowWorkspaceScopedCurrent: params.workspaceDir === undefined,
-      ...(params.index ? { index: params.index } : {}),
-      pluginIdScope: createGatewayStartupMetadataPluginIdScope({
-        config: params.config,
-        ...(params.activationSourceConfig !== undefined
-          ? { activationSourceConfig: params.activationSourceConfig }
-          : {}),
-        env: params.env,
-        workerProviderIds,
-        ambientEnvTriggers: params.ambientEnvTriggers,
-      }),
-    });
-  const { index, manifestRegistry } = metadataSnapshot;
-  const startupPlanStartedAt = performance.now();
-  const startup = resolveGatewayStartupPluginPlanFromRegistry({
-    config: params.config,
-    ...(params.activationSourceConfig !== undefined
-      ? { activationSourceConfig: params.activationSourceConfig }
-      : {}),
-    env: params.env,
-    index,
-    manifestRegistry,
-    discovery: metadataSnapshot.discovery,
-    normalizePluginId: metadataSnapshot.normalizePluginId,
-    workerProviderIds,
-    ambientEnvTriggers: params.ambientEnvTriggers,
-  });
-  const startupPlanMs = performance.now() - startupPlanStartedAt;
+  const {
+    metadataSnapshot,
+    plan: startup,
+    startupPlanMs,
+  } = loadGatewayStartupPluginPlanWithMetadata({ ...params, workerProviderIds });
 
   return {
     ...metadataSnapshot,


### PR DESCRIPTION
## What Problem This Solves

Gateway startup, plugin reload, and metadata-backed CLI lookups need to select activation from the same prepared plugin inventory. Maintaining duplicate startup-planning paths makes that snapshot and policy contract harder to preserve as reload behavior evolves.

This is a maintainer-requested ownership cleanup, not a claimed startup speedup.

## Why This Change Was Made

Make lookup-table construction consume the existing plan-with-metadata loader, while retaining its own worker-ID normalization, table projection, and metrics. Planning time remains measured after metadata acquisition and is added to the existing metadata total.

Keep manifest lookup in the planner that uses it, remove its obsolete single-caller wrappers, and retire an ID-only adapter used only by tests. Move those existing assertions through the full plan owner without changing expected values, fixtures, timeouts, or platform coverage. The change removes 93 production lines and one test line after formatting.

## User Impact

No intended user-visible behavior change. Supplied snapshots, including empty and scoped inventories, remain authoritative. Raw versus effective configuration, external indexed channel contributions, bundled manifest channels, last-manifest precedence, and live worker IDs retain their existing contracts. Reload publication, authority, disposal, and retirement remain with their current owners. No configuration, persistence, schema, or public SDK changes.

Historical supplied-snapshot measurements had full output parity but mixed performance. Denied lookup regressed 17.9%/24.1% in wall time and 18%/36.2% in CPU; reverse-with-metadata and empty-plan CPU controls also had adverse results. Direct plan-with-metadata callers now pay for the timing reads. This PR is justified by removing duplicate ownership, not by a broad latency or memory claim, and those historical results are not presented as a current-main Gateway benchmark.

## Evidence

- 219 focused tests passed: 215 across the complete startup-policy, bundled-metadata, and lookup-table owner files; three existing startup-caller cases; and one real registry/lookup case that verifies retained declarations and owners after removing its manifest file. The 49 unselected assertions in targeted files are not counted as passes.
- Full `pnpm build` passed, including declarations, SDK export checks, the CLI bootstrap import guard, and UI build. Matching formatting and fresh independent P2 review passed.
- 26 of 29 repository-selected local check commands passed. The cumulative check runner exceeded its fixed 64-process budget, so the remaining existing commands were run separately without increasing per-command limits. Import-cycle checking found zero runtime value cycles.
- **Pending hosted CI:** core typechecking and targeted type-aware lint exceeded the configured 6 GiB process-tree RSS limit, at observed peaks of 6,544,048,128 and 6,474,579,968 bytes respectively. The core-test typecheck attempt stopped before compilation on the artifact lock retained after the terminated core checker. The exact owned process tree was verified closed before recovering that lock; these checks were not retried with larger limits or weaker assertions. All local children and monitors closed, and source hashes remained unchanged.
- The existing 600-second real Gateway reload lifecycle test was not run inside the 300-second local validation envelope. A direct plugin-import profile is not claimed as proof of core startup planning.

Hosted exact-head CI must pass all normal typecheck and lint gates before landing. Local resource failures and historical adverse measurements remain preserved; no benchmark rerun or cap/guard changes were made.
