### PR TITLE
feat(sessions): add time-range filters to sessions_search

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -16956,17 +16956,23 @@ public struct SessionsSearchParams: Codable, Sendable {
     public let sessionkeys: [String]?
     public let query: String
     public let limit: Int?
+    public let mintimestampms: Int?
+    public let beforetimestampms: Int?
 
     public init(
         agentid: String? = nil,
         sessionkeys: [String]? = nil,
         query: String,
-        limit: Int? = nil)
+        limit: Int? = nil,
+        mintimestampms: Int? = nil,
+        beforetimestampms: Int? = nil)
     {
         self.agentid = agentid
         self.sessionkeys = sessionkeys
         self.query = query
         self.limit = limit
+        self.mintimestampms = mintimestampms
+        self.beforetimestampms = beforetimestampms
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -16974,6 +16980,8 @@ public struct SessionsSearchParams: Codable, Sendable {
         case sessionkeys = "sessionKeys"
         case query
         case limit
+        case mintimestampms = "minTimestampMs"
+        case beforetimestampms = "beforeTimestampMs"
     }
 }
 

--- a/docs/concepts/session-search.md
+++ b/docs/concepts/session-search.md
@@ -23,6 +23,35 @@ For SQLite transcript history, a missing or off-path message returns empty histo
 the newest tail; a `sessionId` that does not belong to the selected session key is rejected.
 These rules also apply in local embedded mode, without a running Gateway.
 
+## Time-bounded search
+
+Use `minTimestampMs` (inclusive) and `beforeTimestampMs` (exclusive) to search
+message timestamps within a period. Both are optional non-negative safe integers
+in Unix epoch milliseconds. With both present, `minTimestampMs` must be less than
+`beforeTimestampMs`. A bound of zero is an explicit boundary, not an omitted value.
+
+For example, search for deployment decisions recorded on September 1, 2026 in UTC:
+
+```json
+{
+  "query": "deployment decision",
+  "minTimestampMs": 1788220800000,
+  "beforeTimestampMs": 1788307200000,
+  "limit": 10
+}
+```
+
+Convert dates using the user's intended timezone before supplying milliseconds.
+The search does not parse natural-language dates. The same parameters are accepted
+by Gateway `sessions.search` and local embedded mode.
+
+Filtering happens in SQLite before relevance ordering and the result limit, so
+out-of-window matches cannot fill the returned page first. Ordering within the
+window, visibility checks, redaction, indexing warnings, and output limits stay
+unchanged. These fields constrain message timestamps, not session update times.
+Omitting both preserves the unbounded-in-time search. A non-empty text query is
+still required; this is not a time-only transcript listing or a pagination API.
+
 ## Visibility and output
 
 Search uses the same configured session visibility rules as `sessions_history`. The default

--- a/packages/gateway-protocol/src/schema/sessions.ts
+++ b/packages/gateway-protocol/src/schema/sessions.ts
@@ -414,6 +414,8 @@ export const SessionsSearchParamsSchema = closedObject({
   sessionKeys: Type.Optional(Type.Array(NonEmptyString, { minItems: 1, maxItems: 200 })),
   query: Type.String({ minLength: 1, maxLength: 4096 }),
   limit: Type.Optional(Type.Integer({ minimum: 1, maximum: 25 })),
+  minTimestampMs: Type.Optional(Type.Integer({ minimum: 0, maximum: Number.MAX_SAFE_INTEGER })),
+  beforeTimestampMs: Type.Optional(Type.Integer({ minimum: 0, maximum: Number.MAX_SAFE_INTEGER })),
 });
 
 /** One full-text session transcript match with follow-up provenance. */

--- a/src/agents/tools/embedded-gateway-stub.test.ts
+++ b/src/agents/tools/embedded-gateway-stub.test.ts
@@ -72,6 +72,35 @@ describe("embedded gateway stub", () => {
     runtime.listSessionsFromStoreAsync.mockClear();
   });
 
+  it("forwards an embedded search window after canonicalizing its session keys", async () => {
+    await createEmbeddedCallGateway()({
+      method: "sessions.search",
+      params: { query: "needle", sessionKeys: ["main"], minTimestampMs: 0, beforeTimestampMs: 200 },
+    });
+    expect(runtime.searchSessionTranscripts).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionKeys: ["agent:main:main"],
+        minTimestampMs: 0,
+        beforeTimestampMs: 200,
+      }),
+    );
+  });
+
+  it.each([
+    { minTimestampMs: 200, beforeTimestampMs: 100 },
+    { minTimestampMs: 100, beforeTimestampMs: 100 },
+    { minTimestampMs: "100" },
+    { beforeTimestampMs: null },
+  ])("rejects an invalid embedded window instead of silently ignoring it: %j", async (bounds) => {
+    await expect(
+      createEmbeddedCallGateway()({
+        method: "sessions.search",
+        params: { query: "needle", ...bounds },
+      }),
+    ).rejects.toThrow(/TimestampMs/);
+    expect(runtime.searchSessionTranscripts).not.toHaveBeenCalled();
+  });
+
   it("scopes embedded session lists to the requested agent", async () => {
     const callGateway = createEmbeddedCallGateway();
     await callGateway({

--- a/src/agents/tools/embedded-gateway-stub.ts
+++ b/src/agents/tools/embedded-gateway-stub.ts
@@ -11,6 +11,7 @@ import type {
 import type { CallGatewayOptions } from "../../gateway/call.js";
 import { jsonUtf8Bytes } from "../../infra/json-utf8-bytes.js";
 import { parseAgentSessionKey, scopeLegacySessionKeyToAgent } from "../../routing/session-key.js";
+import { parseSessionSearchTimeRange } from "../../shared/session-search-time-range.js";
 import {
   readNonNegativeIntegerParam,
   readPositiveIntegerParam,
@@ -88,6 +89,10 @@ async function handleSessionsSearch(params: Record<string, unknown>) {
   if (query.length > SESSIONS_SEARCH_MAX_QUERY_CHARS) {
     throw new Error(`query must not exceed ${SESSIONS_SEARCH_MAX_QUERY_CHARS} characters`);
   }
+  const timeRange = parseSessionSearchTimeRange(params);
+  if (!timeRange.ok) {
+    throw new Error(timeRange.error);
+  }
   if (params.agentId !== undefined && params.sessionKeys === undefined) {
     throw new Error("agentId requires sessionKeys");
   }
@@ -131,6 +136,7 @@ async function handleSessionsSearch(params: Record<string, unknown>) {
     agentId,
     storePath: rt.resolveSessionStorePathCore(cfg.session?.store, { agentId }),
     query,
+    ...timeRange.value,
     limit: readPositiveIntegerParam(params, "limit"),
     sessionKeys,
   });

--- a/src/agents/tools/sessions-search-tool.test.ts
+++ b/src/agents/tools/sessions-search-tool.test.ts
@@ -107,6 +107,55 @@ function createTool(params: {
 describe("sessions_search tool", () => {
   const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
+  it("forwards time bounds to the search owner without changing visible session targeting", async () => {
+    const requests: CallGatewayRequest[] = [];
+    const plainRequests: CallGatewayRequest[] = [];
+    await createTool({ requests: plainRequests, results: [hit()] }).execute("plain-search", {
+      query: "text",
+    });
+    const tool = createTool({ requests, results: [hit()] });
+    await tool.execute("time-search", { query: "text", minTimestampMs: 0, beforeTimestampMs: 200 });
+    const searches = requests.filter((request) => request.method === "sessions.search");
+    const plainSearches = plainRequests.filter((request) => request.method === "sessions.search");
+    expect(searches).not.toHaveLength(0);
+    expect(searches).toHaveLength(plainSearches.length);
+    for (const [index, request] of searches.entries()) {
+      const plainParams = plainSearches[index]?.params;
+      if (typeof plainParams !== "object" || plainParams === null) {
+        throw new Error("expected the unbounded control search request");
+      }
+      expect(request.params).toEqual({ ...plainParams, minTimestampMs: 0, beforeTimestampMs: 200 });
+    }
+  });
+
+  it("describes and validates optional numeric time bounds in the tool schema", () => {
+    const schema = createTool({}).parameters;
+    expect(Value.Check(schema, { query: "text", minTimestampMs: 0, beforeTimestampMs: 200 })).toBe(
+      true,
+    );
+    expect(Value.Check(schema, { query: "text", minTimestampMs: "100" })).toBe(false);
+    expect(Value.Check(schema, { query: "text", beforeTimestampMs: null })).toBe(false);
+    expect(
+      Value.Check(schema, { query: "text", beforeTimestampMs: Number.MAX_SAFE_INTEGER + 1 }),
+    ).toBe(false);
+  });
+
+  it.each([
+    { minTimestampMs: "100" },
+    { minTimestampMs: null },
+    { minTimestampMs: -1 },
+    { beforeTimestampMs: 1.5 },
+    { minTimestampMs: 200, beforeTimestampMs: 100 },
+    { minTimestampMs: 100, beforeTimestampMs: 100 },
+  ])("rejects invalid windows before any Gateway call: %j", async (bounds) => {
+    const requests: CallGatewayRequest[] = [];
+    const tool = createTool({ requests });
+    await expect(tool.execute("invalid-window", { query: "text", ...bounds })).rejects.toThrow(
+      /TimestampMs/,
+    );
+    expect(requests).toEqual([]);
+  });
+
   it("rejects a literal global target owned by another fixed-store agent when agent-to-agent is disabled", async () => {
     const requests: CallGatewayRequest[] = [];
     const tool = createTool({

--- a/src/agents/tools/sessions-search-tool.ts
+++ b/src/agents/tools/sessions-search-tool.ts
@@ -8,6 +8,7 @@ import {
   isIncognitoSessionKey,
   parseAgentSessionKey,
 } from "../../routing/session-key.js";
+import { parseSessionSearchTimeRange } from "../../shared/session-search-time-range.js";
 import { truncateUtf16Safe } from "../../utils.js";
 import { resolveSessionAgentId } from "../agent-scope.js";
 import { optionalPositiveIntegerSchema } from "../schema/typebox.js";
@@ -55,6 +56,20 @@ const SessionsSearchToolSchema = Type.Object({
   query: Type.String({ maxLength: SESSIONS_SEARCH_MAX_QUERY_CHARS }),
   sessionKey: Type.Optional(Type.String()),
   limit: optionalPositiveIntegerSchema({ maximum: SESSIONS_SEARCH_MAX_LIMIT }),
+  minTimestampMs: Type.Optional(
+    Type.Integer({
+      minimum: 0,
+      maximum: Number.MAX_SAFE_INTEGER,
+      description: "Inclusive lower bound on message timestamps in Unix epoch milliseconds.",
+    }),
+  ),
+  beforeTimestampMs: Type.Optional(
+    Type.Integer({
+      minimum: 0,
+      maximum: Number.MAX_SAFE_INTEGER,
+      description: "Exclusive upper bound on message timestamps in Unix epoch milliseconds.",
+    }),
+  ),
 });
 
 const SessionsSearchHitSchema = Type.Object(
@@ -369,6 +384,10 @@ export function createSessionsSearchTool(opts?: {
         readPositiveIntegerParam(params, "limit", {
           max: SESSIONS_SEARCH_MAX_LIMIT,
         }) ?? SESSIONS_SEARCH_DEFAULT_LIMIT;
+      const timeRange = parseSessionSearchTimeRange(params);
+      if (!timeRange.ok) {
+        throw new ToolInputError(timeRange.error);
+      }
       const requestedSessionKey = readToolStringParam(params, "sessionKey");
       const {
         cfg,
@@ -552,6 +571,7 @@ export function createSessionsSearchTool(opts?: {
               params: {
                 agentId,
                 query,
+                ...timeRange.value,
                 limit: SESSIONS_SEARCH_MAX_LIMIT,
                 sessionKeys: chunk.map((candidate) => candidate.key),
               },

--- a/src/config/sessions/session-transcript-search.test.ts
+++ b/src/config/sessions/session-transcript-search.test.ts
@@ -115,6 +115,112 @@ function agentKysely() {
 }
 
 describe("searchSessionTranscripts", () => {
+  it("applies inclusive and exclusive timestamp bounds inside SQLite", async () => {
+    for (const now of [1_000, 2_000, 3_000, 4_000]) {
+      await appendTranscriptMessage(transcriptScope("time-session", "agent:main:time"), {
+        now,
+        message: { role: "user", content: [{ type: "text", text: "window needle" }] },
+      });
+    }
+    const base = { agentId: "main", env: env(), query: "needle" };
+    const timestamps = (options: { minTimestampMs?: number; beforeTimestampMs?: number }) =>
+      searchSessionTranscripts({ ...base, ...options }).hits.map((hit) => hit.timestamp);
+    expect(timestamps({ minTimestampMs: 2_000, beforeTimestampMs: 4_000 })).toEqual([3_000, 2_000]);
+    expect(timestamps({ minTimestampMs: 3_000 })).toEqual([4_000, 3_000]);
+    expect(timestamps({ beforeTimestampMs: 2_000 })).toEqual([1_000]);
+    expect(timestamps({ minTimestampMs: 0 })).toEqual([4_000, 3_000, 2_000, 1_000]);
+    expect(timestamps({ beforeTimestampMs: 0 })).toEqual([]);
+    expect(timestamps({})).toEqual([4_000, 3_000, 2_000, 1_000]);
+  });
+
+  it("finds an in-window result behind more than 25 out-of-window matches", async () => {
+    for (let index = 0; index < 30; index += 1) {
+      await appendTranscriptMessage(transcriptScope("outside-window", "agent:main:outside"), {
+        now: 10_000 + index,
+        message: { role: "user", content: [{ type: "text", text: "window needle" }] },
+      });
+    }
+    await appendTranscriptMessage(transcriptScope("inside-window", "agent:main:inside"), {
+      now: 2_000,
+      message: { role: "user", content: [{ type: "text", text: "window needle" }] },
+    });
+    const params = {
+      agentId: "main",
+      env: env(),
+      query: "needle",
+      limit: 1,
+      minTimestampMs: 1_000,
+      beforeTimestampMs: 3_000,
+    };
+    expect(searchSessionTranscripts(params)).toEqual({
+      hits: [expect.objectContaining({ sessionId: "inside-window", timestamp: 2_000 })],
+      indexing: false,
+      truncated: false,
+    });
+    expect(
+      searchSessionTranscripts({ ...params, sessionKeys: ["agent:main:outside"] }).hits,
+    ).toEqual([]);
+  });
+
+  it("reports truncation only for remaining in-window hits", async () => {
+    for (const now of [1_000, 2_000, 3_000, 10_000]) {
+      await appendTranscriptMessage(transcriptScope("time-page", "agent:main:time-page"), {
+        now,
+        message: { role: "user", content: [{ type: "text", text: "window needle" }] },
+      });
+    }
+    const params = { agentId: "main", env: env(), query: "needle", beforeTimestampMs: 4_000 };
+    expect(searchSessionTranscripts({ ...params, limit: 2 }).truncated).toBe(true);
+    expect(searchSessionTranscripts({ ...params, limit: 3 }).truncated).toBe(false);
+  });
+
+  it("compares numeric-string FTS timestamps numerically", async () => {
+    const appended = await appendTranscriptMessage(
+      transcriptScope("text-time", "agent:main:text-time"),
+      {
+        now: 2_000,
+        message: { role: "user", content: [{ type: "text", text: "window needle" }] },
+      },
+    );
+    if (!appended) {
+      throw new Error("expected a committed fixture message");
+    }
+    const { db, kysely } = agentKysely();
+    executeSqliteQuerySync(
+      db,
+      kysely
+        .updateTable("session_transcript_fts")
+        .set({ timestamp: "2000" })
+        .where("message_id", "=", appended.messageId),
+    );
+    const params = {
+      agentId: "main",
+      env: env(),
+      query: "needle",
+      minTimestampMs: 1_000,
+      beforeTimestampMs: 3_000,
+    };
+    expect(searchSessionTranscripts(params).hits).toEqual([
+      expect.objectContaining({ timestamp: 2_000, messageId: appended.messageId }),
+    ]);
+  });
+
+  it.each([
+    { minTimestampMs: -1 },
+    { minTimestampMs: 1.5 },
+    { beforeTimestampMs: Number.NaN },
+    { beforeTimestampMs: Number.POSITIVE_INFINITY },
+    { minTimestampMs: Number.MAX_SAFE_INTEGER + 1 },
+    { minTimestampMs: 2_000, beforeTimestampMs: 2_000 },
+    { minTimestampMs: 3_000, beforeTimestampMs: 2_000 },
+  ])("rejects invalid timestamp windows before opening storage: %j", (bounds) => {
+    const databasePath = resolveOpenClawAgentSqlitePath({ agentId: "main", env: env() });
+    expect(() =>
+      searchSessionTranscripts({ agentId: "main", env: env(), query: "needle", ...bounds }),
+    ).toThrow(/TimestampMs/);
+    expect(fs.existsSync(databasePath)).toBe(false);
+  });
+
   it.each([false, true])(
     "searches a populated closed database without reopening a writer (shared: %s)",
     async (shared) => {

--- a/src/config/sessions/session-transcript-search.ts
+++ b/src/config/sessions/session-transcript-search.ts
@@ -6,6 +6,7 @@ import { sql } from "kysely";
 import { executeSqliteQueryTakeFirstSync, getNodeSqliteKysely } from "../../infra/kysely-sync.js";
 import { runSqliteDeferredTransactionSync } from "../../infra/sqlite-transaction.js";
 import { toAgentStoreSessionKey } from "../../routing/session-key.js";
+import { parseSessionSearchTimeRange } from "../../shared/session-search-time-range.js";
 import { withOpenClawAgentDatabaseReadOnly } from "../../state/openclaw-agent-db-readonly.js";
 import type { DB } from "../../state/openclaw-agent-db.generated.js";
 import { truncateUtf16Safe } from "../../utils.js";
@@ -53,6 +54,8 @@ export function searchSessionTranscripts(params: {
   query: string;
   sessionKeys?: string[];
   storePath?: string;
+  minTimestampMs?: number;
+  beforeTimestampMs?: number;
 }): SessionTranscriptSearchResult {
   const query = params.query.trim();
   if (!query) {
@@ -61,6 +64,11 @@ export function searchSessionTranscripts(params: {
   if (query.length > SEARCH_QUERY_MAX_CHARS) {
     throw new Error(`query must not exceed ${SEARCH_QUERY_MAX_CHARS} characters`);
   }
+  const timeRange = parseSessionSearchTimeRange(params);
+  if (!timeRange.ok) {
+    throw new Error(timeRange.error);
+  }
+  const { minTimestampMs, beforeTimestampMs } = timeRange.value;
   const scope = resolveSqliteReadScope(params);
   const databaseOptions = toDatabaseOptions(scope);
   const result = withOpenClawAgentDatabaseReadOnly(
@@ -86,6 +94,17 @@ export function searchSessionTranscripts(params: {
               : sessionFilterValues.length > 0
                 ? ` AND session_windows.session_key IN (${sessionFilterValues.map(() => "?").join(", ")})`
                 : "";
+          // FTS columns have no numeric affinity; keep numeric-string timestamps comparable too.
+          let whereTime = "";
+          const timeValues: number[] = [];
+          if (minTimestampMs !== undefined) {
+            whereTime += " AND CAST(session_transcript_fts.timestamp AS NUMERIC) >= ?";
+            timeValues.push(minTimestampMs);
+          }
+          if (beforeTimestampMs !== undefined) {
+            whereTime += " AND CAST(session_transcript_fts.timestamp AS NUMERIC) < ?";
+            timeValues.push(beforeTimestampMs);
+          }
           const archivedTranscriptsExcluded =
             executeSqliteQueryTakeFirstSync(
               database.db,
@@ -122,14 +141,14 @@ export function searchSessionTranscripts(params: {
       bm25(session_transcript_fts) AS rank
     FROM session_transcript_fts
     JOIN session_windows ON session_windows.session_id = session_transcript_fts.session_id
-    WHERE session_transcript_fts MATCH ?${whereSession}
+    WHERE session_transcript_fts MATCH ?${whereSession}${whereTime}
       AND session_transcript_fts.session_id NOT IN (
         SELECT session_id FROM session_transcript_index_state WHERE needs_rebuild != 0
       )
     ORDER BY rank ASC, timestamp DESC, message_id ASC
     LIMIT ?
     `);
-          const values = [toFtsQuery(query), ...sessionFilterValues, limit + 1];
+          const values = [toFtsQuery(query), ...sessionFilterValues, ...timeValues, limit + 1];
           const rows = statement.all(...values) as Array<{
             message_id: unknown;
             rank: unknown;

--- a/src/gateway/server-methods/sessions-read.ts
+++ b/src/gateway/server-methods/sessions-read.ts
@@ -35,6 +35,7 @@ import {
   normalizeAgentId,
   parseAgentSessionKey,
 } from "../../routing/session-key.js";
+import { parseSessionSearchTimeRange } from "../../shared/session-search-time-range.js";
 import { hasOperatorBoundary } from "../operator-role-policy.js";
 import {
   resolveRequestedSessionAgentId as resolveRequestedGlobalAgentId,
@@ -83,6 +84,11 @@ export const sessionReadHandlers: GatewayRequestHandlers = {
     const query = params.query.trim();
     if (!query) {
       respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "query must not be empty"));
+      return;
+    }
+    const timeRange = parseSessionSearchTimeRange(params);
+    if (!timeRange.ok) {
+      respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, timeRange.error));
       return;
     }
     const cfg = context.getRuntimeConfig();
@@ -159,6 +165,7 @@ export const sessionReadHandlers: GatewayRequestHandlers = {
           searchSessionTranscripts({
             ...target,
             query,
+            ...timeRange.value,
             // Over-fetch retired multi-store searches so deduplication can still fill the caller's
             // requested page when the same transcript was copied during a store migration.
             limit: configured ? params.limit : 25,

--- a/src/gateway/server-methods/sessions-search.test.ts
+++ b/src/gateway/server-methods/sessions-search.test.ts
@@ -73,6 +73,46 @@ describe("sessions.search gateway method", () => {
     resolveExistingAgentSessionStoreTargetsSyncMock.mockReturnValue([]);
   });
 
+  it.each([
+    { minTimestampMs: 0 },
+    { beforeTimestampMs: 200 },
+    { minTimestampMs: 100, beforeTimestampMs: 200 },
+  ])("forwards a valid time window to the scoped query: %j", async (bounds) => {
+    const respond = await callSearch({
+      query: "needle",
+      sessionKeys: ["agent:main:main"],
+      ...bounds,
+    });
+    expect(searchSessionTranscriptsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentId: "main",
+        sessionKeys: ["agent:main:main"],
+        ...bounds,
+      }),
+    );
+    expect(respond).toHaveBeenCalledWith(true, { results: [] });
+  });
+
+  it.each([
+    { minTimestampMs: 200, beforeTimestampMs: 100 },
+    { minTimestampMs: 100, beforeTimestampMs: 100 },
+    { minTimestampMs: "100" },
+    { beforeTimestampMs: null },
+    { beforeTimestampMs: Number.MAX_SAFE_INTEGER + 1 },
+  ])("rejects invalid windows without searching any store: %j", async (bounds) => {
+    const respond = await callSearch({
+      query: "needle",
+      sessionKeys: ["agent:main:main"],
+      ...bounds,
+    });
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({ code: "INVALID_REQUEST" }),
+    );
+    expect(searchSessionTranscriptsMock).not.toHaveBeenCalled();
+  });
+
   it("validates params and rejects whitespace-only queries", async () => {
     const invalidLimit = await callSearch({ query: "needle", limit: 26 });
     expect(invalidLimit).toHaveBeenCalledWith(

--- a/src/shared/session-search-time-range.ts
+++ b/src/shared/session-search-time-range.ts
@@ -1,0 +1,32 @@
+import type { Result } from "@openclaw/normalization-core/result";
+
+/** Timestamp window shared by tool, Gateway, embedded, and transcript-search inputs. */
+type SessionSearchTimeRange = {
+  minTimestampMs?: number;
+  beforeTimestampMs?: number;
+};
+
+export function parseSessionSearchTimeRange(input: {
+  minTimestampMs?: unknown;
+  beforeTimestampMs?: unknown;
+}): Result<SessionSearchTimeRange, string> {
+  const range: SessionSearchTimeRange = {};
+  for (const key of ["minTimestampMs", "beforeTimestampMs"] as const) {
+    const value = input[key];
+    if (value === undefined) {
+      continue;
+    }
+    if (typeof value !== "number" || !Number.isSafeInteger(value) || value < 0) {
+      return { ok: false, error: `${key} must be a non-negative safe integer in milliseconds` };
+    }
+    range[key] = value;
+  }
+  if (
+    range.minTimestampMs !== undefined &&
+    range.beforeTimestampMs !== undefined &&
+    range.minTimestampMs >= range.beforeTimestampMs
+  ) {
+    return { ok: false, error: "minTimestampMs must be less than beforeTimestampMs" };
+  }
+  return { ok: true, value: range };
+}

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
@@ -1176,9 +1176,21 @@
         "description": "Search visible past sessions for matching user and assistant text. Follow up with sessions_history using a returned sessionKey, sessionId, and messageId for neighboring context.",
         "inputSchema": {
           "properties": {
+            "beforeTimestampMs": {
+              "description": "Exclusive upper bound on message timestamps in Unix epoch milliseconds.",
+              "maximum": 9007199254740991,
+              "minimum": 0,
+              "type": "integer"
+            },
             "limit": {
               "maximum": 25,
               "minimum": 1,
+              "type": "integer"
+            },
+            "minTimestampMs": {
+              "description": "Inclusive lower bound on message timestamps in Unix epoch milliseconds.",
+              "maximum": 9007199254740991,
+              "minimum": 0,
               "type": "integer"
             },
             "query": {

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md.diff
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md.diff
@@ -1,5 +1,5 @@
---- telegram-direct-codex-message-tool.md	sha256=2475be00b6677cc61504cd75ba4d13b047048e8f5fec0fb684d53f542ef80179
-+++ discord-group-codex-message-tool.md	sha256=17a9e3b5986e800bf68ffe2c4ec52a1c1f76d9a5117e6d73e720087aec6269e1
+--- telegram-direct-codex-message-tool.md	sha256=3b73ee382e660080b1388ceb3dd4bc6cfd9d1c8bfdb35ae5424ff7ca78f7eb18
++++ discord-group-codex-message-tool.md	sha256=6f18eeed1b1de6e2192847e60c23f8ae9c9822752b4f724f295e8764fe03e88d
 @@ -1,1 +1,1 @@
 -# Telegram Direct Codex Message Tool Turn
 +# Discord Group Codex Message Tool Turn
@@ -32,10 +32,10 @@
 -    "chars": 882,
 +    "chars": 881,
 @@ -257,2 +257,2 @@
--    "chars": 58613,
--    "roughTokens": 14654
-+    "chars": 59169,
-+    "roughTokens": 14793
+-    "chars": 59124,
+-    "roughTokens": 14781
++    "chars": 59680,
++    "roughTokens": 14920
 @@ -261,2 +261,2 @@
 -    "chars": 2629,
 -    "roughTokens": 658
@@ -47,10 +47,10 @@
 +    "chars": 27781,
 +    "roughTokens": 6946
 @@ -273,2 +273,2 @@
--    "chars": 85078,
--    "roughTokens": 21270
-+    "chars": 86952,
-+    "roughTokens": 21738
+-    "chars": 85589,
+-    "roughTokens": 21398
++    "chars": 87463,
++    "roughTokens": 21866
 @@ -277,2 +277,2 @@
 -    "chars": 793,
 -    "roughTokens": 199

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
@@ -254,8 +254,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 58613,
-    "roughTokens": 14654
+    "chars": 59124,
+    "roughTokens": 14781
   },
   "openClawDeveloperInstructions": {
     "chars": 2629,
@@ -270,8 +270,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6616
   },
   "totalWithDynamicToolsJson": {
-    "chars": 85078,
-    "roughTokens": 21270
+    "chars": 85589,
+    "roughTokens": 21398
   },
   "userInputText": {
     "chars": 793,

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md.diff
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md.diff
@@ -1,5 +1,5 @@
---- telegram-direct-codex-message-tool.md	sha256=2475be00b6677cc61504cd75ba4d13b047048e8f5fec0fb684d53f542ef80179
-+++ telegram-heartbeat-codex-tool.md	sha256=004dd538094b6838132330854911d9b4c10df4de6230396440700ac4d43acaa6
+--- telegram-direct-codex-message-tool.md	sha256=3b73ee382e660080b1388ceb3dd4bc6cfd9d1c8bfdb35ae5424ff7ca78f7eb18
++++ telegram-heartbeat-codex-tool.md	sha256=a39a0935e1706916ee7d023684073b87d13c1244d6cf7ccbdcc3b2fa93625130
 @@ -1,1 +1,1 @@
 -# Telegram Direct Codex Message Tool Turn
 +# Telegram Direct Codex Heartbeat Tool Turn
@@ -37,20 +37,20 @@
 +    "chars": 752,
 +    "roughTokens": 188
 @@ -257,2 +254,2 @@
--    "chars": 58613,
--    "roughTokens": 14654
-+    "chars": 60106,
-+    "roughTokens": 15027
+-    "chars": 59124,
+-    "roughTokens": 14781
++    "chars": 60617,
++    "roughTokens": 15155
 @@ -269,2 +266,2 @@
 -    "chars": 26463,
 -    "roughTokens": 6616
 +    "chars": 26675,
 +    "roughTokens": 6669
 @@ -273,2 +270,2 @@
--    "chars": 85078,
--    "roughTokens": 21270
-+    "chars": 86783,
-+    "roughTokens": 21696
+-    "chars": 85589,
+-    "roughTokens": 21398
++    "chars": 87294,
++    "roughTokens": 21824
 @@ -277,2 +274,2 @@
 -    "chars": 793,
 -    "roughTokens": 199


### PR DESCRIPTION
## What Problem This Solves

Session search cannot restrict matches to a message-time window. Filtering its capped results afterwards can miss relevant messages when higher-ranked matches outside the desired period fill the page.

Closes #135247.

## Why This Change Was Made

Add optional `minTimestampMs` (inclusive) and `beforeTimestampMs` (exclusive) to `sessions_search`, Gateway `sessions.search`, and embedded search. One shared validator rejects invalid bounds before empty-result shortcuts; the SQLite search owner applies numeric timestamp predicates before ranking and limiting.

## User Impact

Agents can search a specific period using non-negative safe integers in Unix epoch milliseconds. Omitting both fields preserves current behavior. Existing visibility, incognito exclusion, redaction, retired-store deduplication, archive exclusions, and result limits remain in force. This adds no database schema/version or configuration changes. Documentation, generated Swift parameters, and model-facing schema snapshots are updated.

## Evidence

### Prepared snapshot integration publication

Head: `018cdc0058f2068d31d8b7730b554dcb1dad20f4`. This reviewed merge retains previous PR head `98e20ece74c9f4f0e1b25ace7d0a7fb947438513` and integration base `89fc81e0dc29180ae4fde0bc506c3df6b87915af` without force-pushing. Prompt conflicts were regenerated through the canonical generator; its recorded result and the independent P0–P2 source review passed.

No new full build or broad runtime suite is claimed for this mechanical integration. Earlier four-file test receipts remain attributed to their original revision: 26 + 22 + 30 + 27 assertions passed, while their report aggregation failed separately. This publication does not relabel that aggregate as a successful runner exit. Exact new-head hosted CI and current-main mergeability must be read independently.


### September 14 integration refresh

Current head: `e36ed881308a23d3315aaf8a4b278c971fb6e50f`. Original branch head `e0ae58ecac3177b11d255df20a09d041890840e1` and pinned main `8b917bc499607eb94bb77358ddd69f6494d26c65` are both preserved as parents; no force-push. Retain main's database-identity cache version, deferred read transaction, generation/role predicates, recent ordering and archive exclusion. Apply the PR time predicates before ORDER BY/LIMIT with matching SQL parameter order. Add a combined generation/role/time/order/limit regression. Regenerate prompt snapshots and the Swift model from their canonical generators, without hand-editing generated output.

Validation on Linux / Node 26.1.0 with frozen-lockfile dependencies: 30/30 tests passed. The native staged-content/format guard, main-relative diff check, and one fresh independent P0-P2 source review passed. No full build or full type-aware check was rerun locally; new-head CI is tracked separately. Earlier runtime proof below retains its recorded SHA; it is not relabeled as a new execution.


- Baseline proof: real SQLite search returned 25 outside-window matches; an authenticated Gateway rejected the new fields with `INVALID_REQUEST`.
- Real candidate proof: seven cases passed through the canonical transcript writer, SQLite FTS, authenticated Gateway, actual tool, and embedded reader. All four search surfaces returned timestamps `[1720000000500, 1720000000000]`, including the lower boundary and excluding the upper boundary. Empty ranges returned `INVALID_REQUEST`; omitted bounds still returned 25 results with `truncated: true`. Corpus rows and the three search-owner schema definitions were unchanged; Gateway/database cleanup completed.
- Native focused tests: 171 passed across six files and five shards, including non-admin/incognito filtering, agent/store ownership, retired-store deduplication, archive exclusions, active-branch reconciliation, invalid inputs, and protocol validation. Command: `node scripts/run-vitest.mjs src/config/sessions/session-transcript-search.test.ts src/agents/tools/sessions-search-tool.test.ts src/agents/tools/embedded-gateway-stub.test.ts src/gateway/server-methods/sessions-search.test.ts src/gateway/server-methods/sessions-read-visibility.test.ts packages/gateway-protocol/src/index.test.ts`.
- Official protocol generators and prompt snapshot check passed; native outputs were byte-idempotent. Swift/Kotlin compilation was not run on Linux.
- Supported `gatewayWatch` runtime build, focused formatting, and syntax lint passed. No full typecheck, packaged build, UI, or cross-platform claim.
- Post-commit `pnpm protocol:check` passed. Independent autoreview: `gpt-6-astra`, medium reasoning, P2 threshold; no actionable findings.

Proof ran on the staged candidate at base `2c167efab94cff1527772938a5732f7efed819de`, then those bytes were committed unchanged as `e0ae58ecac3177b11d255df20a09d041890840e1`. All 17 proof-covered file hashes match the commit (aggregate SHA-256 `a3dbd3e348091a159ce52ef6b2a398c51e54481c867ec78e69b7916eaccbffe6`). The proof's 11,119-file runtime inventory remained stable (SHA-256 `cbb9ca6f405619f58e50fb1213d32b77dc59ff84966fc6f7d3db8893779c02a9`). The isolated one-agent corpus exercises real runtime boundaries; multi-user and multi-store controls are covered by the native sibling tests.

The proof command was `node --import "$WORK/scripts/tsx.mjs" "$EVIDENCE/session-search-cli-current.mjs"` (Node 24.21.0, supported `gatewayWatch` runtime build). The driver writes the isolated corpus through the canonical transcript writer, starts a real Gateway, invokes built `openclaw.mjs gateway call sessions.search --json --params '<request>'`, and calls the actual tool and embedded reader. Gateway URL and credentials come from the isolated configuration. Request bounds were `minTimestampMs: 1720000000000` and `beforeTimestampMs: 1720000001000`; both baseline and candidate used the same corpus and entry points.

The final receipt recorded:

```json
{"sqlite":{"timestamps":[1720000000500,1720000000000],"truncated":false},"gatewayExit":0,"toolAndEmbeddedTimestamps":[1720000000500,1720000000000],"emptyRange":{"exit":1,"code":"INVALID_REQUEST"},"omittedBounds":{"count":25,"truncated":true},"rowsUnchanged":true,"searchSchemaUnchanged":true,"gatewayProcessJoined":true,"databaseHandlesClosed":true}
```

The proof's raw stdout SHA-256 was `3380807d3e42d35c10a0e1f144985d8db55f03c0399334aa55551ac9a6b94c44`. Isolated scratch was removed. An initial run generated missing Control UI assets and failed the build-integrity envelope despite passing every behavior assertion; the reported repeat passed with assets present and an unchanged runtime inventory.

Production growth: +86 core TypeScript lines and +8 generated Swift lines; the added capability requires shared validation and four existing search entry/owner paths. Tests add 224 lines, generated prompt fixtures add 12 net lines, docs add 29. No alternate search or storage path was introduced.

Existing-solutions preflight: this extends the existing SQLite/FTS and session-search owners. Caller-side filtering cannot recover matches already excluded by the result cap; no additional storage, search service, or plugin dependency is needed. There are no changes to authentication, authorization, config/defaults, stored data, or schema versions; the Gateway inputs are optional additions and omitted-field behavior is covered above.

AI-assisted implementation and verification using Codex; source and evidence reviewed before publication.
