### PR TITLE
improve: start cloud worker turns sooner over remote connections

### DIFF
--- a/src/worker/worker-connection-admission.ts
+++ b/src/worker/worker-connection-admission.ts
@@ -153,6 +153,14 @@ export function connectWorkerConnectionAttempt(
             new WorkerConnectionInterruptedError(`admission send failed: ${error.message}`),
           );
           socket.terminate();
+          return;
+        }
+        if (isActive() && admission === "pending") {
+          try {
+            connectionOptions.onAdmissionRequestSent?.();
+          } catch {
+            // Optional preparation observers do not control admission or retry policy.
+          }
         }
       });
     });

--- a/src/worker/worker-connection-contract.ts
+++ b/src/worker/worker-connection-contract.ts
@@ -50,6 +50,8 @@ export type WorkerConnectionOptions = {
   requestTimeoutMs?: number;
   createSocket?: (url: string, options: ClientOptions) => WebSocket;
   heartbeatStatus?: () => WorkerHeartbeatParams["status"];
+  /** The connect frame was written; this does not establish admission. */
+  onAdmissionRequestSent?: () => void;
   onConnectionFailure?: (error: Error | undefined) => void;
 };
 

--- a/src/worker/worker-connection.test.ts
+++ b/src/worker/worker-connection.test.ts
@@ -2,6 +2,7 @@ import { EventEmitter, once } from "node:events";
 import { createServer as createHttpsServer } from "node:https";
 import net from "node:net";
 import { rawDataToString } from "@openclaw/gateway-client/websocket-data";
+import { Value } from "typebox/value";
 import { describe, expect, it, vi } from "vitest";
 import { WebSocket, WebSocketServer } from "ws";
 import {
@@ -10,6 +11,7 @@ import {
 } from "../../packages/gateway-protocol/src/client-info.js";
 import {
   type WorkerConnectParams,
+  WorkerConnectRequestFrameSchema,
   WORKER_PROTOCOL_FEATURES,
   WORKER_RPC_SET_VERSION,
   WORKER_PUBLIC_INGRESS_PATH,
@@ -18,6 +20,7 @@ import type {
   WorkerInferenceEventFrame,
   WorkerInferenceTerminalFrame,
 } from "../../packages/gateway-protocol/src/schema/worker-inference.js";
+import { createDeferred } from "../../test/helpers/promise.js";
 import { TEST_TLS_CERT_PEM, TEST_TLS_KEY_PEM } from "../../test/helpers/tls-fixture.js";
 import {
   toWorkerConnectionError,
@@ -92,6 +95,202 @@ function sendWorkerHello(
     }),
   );
 }
+
+async function createAdmissionWriteFixture(onAdmissionRequestSent: () => void) {
+  type WriteCallback = NonNullable<Parameters<WebSocket["send"]>[2]>;
+  type WriteOptions = Parameters<WebSocket["send"]>[1];
+  const server = new WebSocketServer({ host: "127.0.0.1", port: 0 });
+  await once(server, "listening");
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("test gateway did not allocate a TCP port");
+  }
+  const slot = () => ({
+    written: createDeferred<WriteCallback>(),
+    received: createDeferred<{ peer: WebSocket; id: string }>(),
+  });
+  let expected: ReturnType<typeof slot> | undefined;
+  const connection = createWorkerConnection({
+    endpoint: {
+      kind: "websocket",
+      url: `ws://127.0.0.1:${address.port}${WORKER_PUBLIC_INGRESS_PATH}`,
+    },
+    connectParams: FRAME_CONNECT_PARAMS,
+    reconnectBackoff: { initialMs: 1, maxMs: 1, factor: 1, jitter: 0 },
+    onAdmissionRequestSent,
+    createSocket: (url, options) => {
+      const attempt = expected;
+      if (!attempt) {
+        throw new Error("unexpected worker connection attempt");
+      }
+      expected = undefined;
+      const socket = new WebSocket(url, options);
+      const send = socket.send.bind(socket);
+      socket.send = (
+        data: Parameters<WebSocket["send"]>[0],
+        optionsOrCallback?: WriteOptions | WriteCallback,
+        callback?: WriteCallback,
+      ) => {
+        const onWritten = typeof optionsOrCallback === "function" ? optionsOrCallback : callback;
+        const holdCompletion: WriteCallback = (error) => {
+          if (error) {
+            onWritten?.(error);
+            attempt.written.reject(error);
+            return;
+          }
+          // Bytes really crossed the socket; admission observes completion only when released.
+          attempt.written.resolve((writeError) => onWritten?.(writeError));
+        };
+        if (typeof optionsOrCallback === "function" || optionsOrCallback === undefined) {
+          send(data, holdCompletion);
+        } else {
+          send(data, optionsOrCallback, holdCompletion);
+        }
+      };
+      return socket;
+    },
+  });
+  const nextAttempt = () => {
+    if (expected) {
+      throw new Error("worker connection attempt is already expected");
+    }
+    const attempt = slot();
+    expected = attempt;
+    server.once("connection", (peer) => {
+      peer.once("message", (data) => {
+        try {
+          const frame: unknown = JSON.parse(rawDataToString(data));
+          if (!Value.Check(WorkerConnectRequestFrameSchema, frame)) {
+            throw new Error("expected the worker admission request");
+          }
+          attempt.received.resolve({ peer, id: frame.id });
+        } catch (error) {
+          attempt.received.reject(error);
+        }
+      });
+    });
+    return Promise.all([attempt.written.promise, attempt.received.promise]).then(
+      ([completeWrite, received]) => ({ completeWrite, ...received }),
+    );
+  };
+  const first = nextAttempt();
+  const starting = connection.start();
+  const settled = starting.catch((error: unknown) => error);
+  return {
+    connection,
+    first,
+    starting,
+    settled,
+    nextAttempt,
+    async close() {
+      await connection.stop();
+      for (const peer of server.clients) {
+        peer.terminate();
+      }
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+      await settled;
+    },
+  };
+}
+
+describe("worker admission write completion", () => {
+  it.each([false, true])(
+    "notifies only after the request write completes, isolating observer failure: %s",
+    async (throws) => {
+      const sent = vi.fn(() => {
+        if (throws) {
+          throw new Error("induced admission observer failure");
+        }
+      });
+      const f = await createAdmissionWriteFixture(sent);
+      try {
+        const attempt = await f.first;
+        expect(sent).not.toHaveBeenCalled();
+        expect(f.connection.state.kind).toBe("admitting");
+        expect(() => attempt.completeWrite()).not.toThrow();
+        expect(sent).toHaveBeenCalledOnce();
+        expect(f.connection.state.kind).toBe("admitting");
+        sendWorkerHello(attempt.peer, attempt.id, FRAME_CONNECT_PARAMS.admission);
+        await f.starting;
+        expect(f.connection.state.kind).toBe("ready");
+        expect(sent).toHaveBeenCalledOnce();
+      } finally {
+        await f.close();
+      }
+    },
+  );
+
+  it.each(["stop", "denied hello", "accepted hello"] as const)(
+    "ignores late request-write completion after %s",
+    async (boundary) => {
+      const sent = vi.fn();
+      const f = await createAdmissionWriteFixture(sent);
+      try {
+        const attempt = await f.first;
+        if (boundary === "stop") {
+          await f.connection.stop();
+          expect(await f.settled).toBeInstanceOf(WorkerConnectionStoppedError);
+        } else if (boundary === "denied hello") {
+          attempt.peer.send(
+            JSON.stringify({
+              type: "res",
+              id: attempt.id,
+              ok: false,
+              error: {
+                code: "INVALID_REQUEST",
+                message: "invalid admission",
+                details: { reason: "invalid-handshake" },
+                retryable: false,
+              },
+            }),
+          );
+          expect(await f.settled).toBeInstanceOf(WorkerAdmissionError);
+        } else {
+          sendWorkerHello(attempt.peer, attempt.id, FRAME_CONNECT_PARAMS.admission);
+          await f.starting;
+          expect(f.connection.state.kind).toBe("ready");
+        }
+        expect(() => attempt.completeWrite()).not.toThrow();
+        expect(sent).not.toHaveBeenCalled();
+      } finally {
+        await f.close();
+      }
+    },
+  );
+
+  it.each(["failed write", "replaced socket"] as const)(
+    "only notifies for the current successful attempt after %s",
+    async (interruption) => {
+      const sent = vi.fn();
+      const f = await createAdmissionWriteFixture(sent);
+      try {
+        const first = await f.first;
+        const replacement = f.nextAttempt();
+        if (interruption === "failed write") {
+          first.completeWrite(new Error("induced admission write failure"));
+        } else {
+          first.peer.close(1012, "gateway-unavailable");
+        }
+        const second = await replacement;
+        expect(second.peer).not.toBe(first.peer);
+        expect(f.connection.state).toEqual({ kind: "admitting", attempt: 1 });
+        if (interruption === "replaced socket") {
+          first.completeWrite();
+        }
+        expect(sent).not.toHaveBeenCalled();
+        second.completeWrite();
+        expect(sent).toHaveBeenCalledOnce();
+        sendWorkerHello(second.peer, second.id, FRAME_CONNECT_PARAMS.admission);
+        await f.starting;
+        expect(f.connection.state.kind).toBe("ready");
+      } finally {
+        await f.close();
+      }
+    },
+  );
+});
 
 function createFrameDispatcher() {
   return new WorkerConnectionFrameDispatcher({

--- a/src/worker/worker.runtime-imports.test-support.mjs
+++ b/src/worker/worker.runtime-imports.test-support.mjs
@@ -1,0 +1,223 @@
+import assert from "node:assert/strict";
+import { once } from "node:events";
+import { stat } from "node:fs/promises";
+import { registerHooks } from "node:module";
+import { setImmediate } from "node:timers/promises";
+import { rawDataToString } from "@openclaw/gateway-client/websocket-data";
+import { WebSocketServer } from "ws";
+import {
+  WORKER_PROTOCOL_FEATURES,
+  WORKER_PUBLIC_INGRESS_PATH,
+  WORKER_RPC_SET_VERSION,
+} from "../../packages/gateway-protocol/src/schema/worker-admission.ts";
+import { parseWorkerLaunchDescriptor } from "./launch-descriptor.ts";
+
+const [mode, workspaceDir] = process.argv.slice(2);
+assert(["rejected", "cancelled", "import-error", "accepted"].includes(mode));
+const previousStateDir = process.env.OPENCLAW_STATE_DIR;
+const previousConfigPath = process.env.OPENCLAW_CONFIG_PATH;
+const names = ["embedded", "inference"];
+const importsStarted = new Map(names.map((name) => [name, Promise.withResolvers()]));
+const importsFinished = new Map(names.map((name) => [name, Promise.withResolvers()]));
+const work = [];
+process.on("worker-import:started", (name) => importsStarted.get(name).resolve());
+process.on("worker-import:finished", (name, stateDir) =>
+  importsFinished.get(name).resolve(stateDir),
+);
+process.on("worker-import:work", (name) => work.push(name));
+
+// Each child has a fresh native ESM cache. Only the two lazy modules are replaced;
+// the runtime, connection, abort controller, and environment cleanup remain real.
+const hooks = registerHooks({
+  resolve(specifier, context, nextResolve) {
+    const name = context.parentURL?.endsWith("/worker.runtime.ts")
+      ? {
+          "./embedded-agent.runtime.js": "embedded",
+          "./inference-stream.runtime.js": "inference",
+        }[specifier]
+      : undefined;
+    if (!name) {
+      return nextResolve(specifier, context);
+    }
+    const exported =
+      name === "embedded" ? "runWorkerEmbeddedTurn" : "createWorkerInferenceStreamAdapter";
+    const source = `
+      import { once } from "node:events";
+      const released = once(process, "worker-import:release:${name}");
+      process.emit("worker-import:started", "${name}");
+      const [reject] = await released;
+      process.emit("worker-import:finished", "${name}", process.env.OPENCLAW_STATE_DIR);
+      if (reject) throw new Error("embedded import failed");
+      export function ${exported}() { process.emit("worker-import:work", "${name}"); }
+    `;
+    return { url: `data:text/javascript,${encodeURIComponent(source)}`, shortCircuit: true };
+  },
+});
+const { runWorkerDescriptor } = await import("./worker.runtime.ts");
+const controller = new AbortController();
+const connected = Promise.withResolvers();
+const disconnected = Promise.withResolvers();
+const gateway = new WebSocketServer({ host: "127.0.0.1", port: 0 });
+gateway.on("connection", (socket) => {
+  socket.once("close", () => disconnected.resolve());
+  socket.on("message", (data) => {
+    const frame = JSON.parse(rawDataToString(data));
+    assert.equal(frame.method, "connect", "No runtime RPC is expected from the controlled turn");
+    connected.resolve({ socket, frame });
+  });
+});
+await once(gateway, "listening");
+const address = gateway.address();
+assert(address && typeof address === "object");
+const descriptor = parseWorkerLaunchDescriptor({
+  version: 4,
+  connectionEndpoint: {
+    kind: "websocket",
+    url: `ws://127.0.0.1:${address.port}${WORKER_PUBLIC_INGRESS_PATH}`,
+  },
+  admission: {
+    environmentId: "import-environment",
+    credential: "synthetic-import-admission",
+    sessionId: "import-session",
+    ownerEpoch: 1,
+    rpcSetVersion: WORKER_RPC_SET_VERSION,
+    handshake: {
+      bundleHash: "a".repeat(64),
+      openclawVersion: "import-test",
+      protocolFeatures: [...WORKER_PROTOCOL_FEATURES],
+    },
+  },
+  assignment: {
+    agentId: "import-agent",
+    runId: "import-run",
+    turnId: "import-turn",
+    operationalRunInstance: { instanceId: "import-instance", runId: "import-run" },
+    agentRuntimeIdentityToken: "synthetic-import-runtime",
+    prompt: "Synthetic turn",
+    workspaceDir,
+    suppressPromptTranscript: false,
+    initialMessages: [],
+    modelRef: { provider: "openai", model: "gpt-5.6-luna" },
+    inferenceOptions: {},
+    transcript: { baseLeafId: null, nextSeq: 1 },
+    liveEvents: { ackedSeq: 0, nextSeq: 1 },
+    toolAuthority: { allowedToolNames: [] },
+  },
+});
+let settled = false;
+const run = (async () => {
+  try {
+    return { result: await runWorkerDescriptor(descriptor, { signal: controller.signal }) };
+  } catch (error) {
+    return { error };
+  } finally {
+    settled = true;
+  }
+})();
+const release = (name, reject = false) => process.emit(`worker-import:release:${name}`, reject);
+try {
+  const { socket, frame } = await connected.promise;
+  await Promise.all([...importsStarted.values()].map(({ promise }) => promise));
+  const runtimeStateDir = process.env.OPENCLAW_STATE_DIR;
+  assert.notEqual(runtimeStateDir, previousStateDir);
+  assert((await stat(runtimeStateDir)).isDirectory());
+  release("embedded", mode !== "accepted");
+  await importsFinished.get("embedded").promise;
+  // Cross an unhandled-rejection checkpoint while hello is still pending.
+  // The child runs with --unhandled-rejections=strict, so an unobserved import is fatal.
+  await setImmediate();
+  assert.equal(settled, false);
+  assert.deepEqual(work, []);
+  if (mode === "accepted") {
+    release("inference");
+    await importsFinished.get("inference").promise;
+    await setImmediate();
+    assert.deepEqual(work, [], "Resolved imports must not execute the turn before hello");
+    assert.equal(settled, false);
+  }
+  if (mode === "rejected") {
+    socket.send(
+      JSON.stringify({
+        type: "res",
+        id: frame.id,
+        ok: false,
+        error: {
+          code: "INVALID_REQUEST",
+          message: "rejected admission",
+          retryable: false,
+          details: { reason: "invalid-credential" },
+        },
+      }),
+    );
+  } else if (mode === "cancelled") {
+    controller.abort(new Error("operator cancelled"));
+  } else {
+    socket.send(
+      JSON.stringify({
+        type: "res",
+        id: frame.id,
+        ok: true,
+        payload: {
+          type: "worker-hello-ok",
+          environmentId: descriptor.admission.environmentId,
+          sessionId: descriptor.admission.sessionId,
+          ownerEpoch: 1,
+          rpcSetVersion: WORKER_RPC_SET_VERSION,
+          protocolFeatures: [...WORKER_PROTOCOL_FEATURES],
+          credentialExpiresAtMs: Date.now() + 60_000,
+          policy: { heartbeatIntervalMs: 60_000, maxPayload: 25 * 1024 * 1024 },
+        },
+      }),
+    );
+  }
+  await disconnected.promise;
+  if (mode !== "accepted") {
+    await setImmediate();
+    assert.equal(settled, false, "Cleanup must join the second import after the first rejects");
+    assert.equal(
+      process.env.OPENCLAW_STATE_DIR,
+      runtimeStateDir,
+      "Cleanup restored process state while an import is pending",
+    );
+    assert((await stat(runtimeStateDir)).isDirectory());
+    release("inference");
+    assert.equal(await importsFinished.get("inference").promise, runtimeStateDir);
+  }
+  const outcome = await run;
+  if (mode === "accepted") {
+    assert.deepEqual(work, ["inference", "embedded"]);
+    assert.deepEqual(outcome.result, {
+      status: "completed",
+      transcriptLeafId: null,
+      transcriptNextSeq: 1,
+    });
+  } else {
+    assert.deepEqual(work, []);
+    assert(outcome.error instanceof Error);
+    assert.equal(
+      outcome.error.message,
+      {
+        rejected: "worker admission rejected: invalid-credential",
+        cancelled: "worker connection stopped",
+        "import-error": "embedded import failed",
+      }[mode],
+    );
+  }
+  assert.equal(process.env.OPENCLAW_STATE_DIR, previousStateDir);
+  assert.equal(process.env.OPENCLAW_CONFIG_PATH, previousConfigPath);
+  await assert.rejects(stat(runtimeStateDir), { code: "ENOENT" });
+  console.log(JSON.stringify({ mode, passed: true }));
+} finally {
+  controller.abort();
+  for (const name of names) {
+    release(name);
+  }
+  await run;
+  for (const socket of gateway.clients) {
+    socket.terminate();
+  }
+  await new Promise((resolve) => {
+    gateway.close(resolve);
+  });
+  hooks.deregister();
+}

--- a/src/worker/worker.runtime-imports.test.ts
+++ b/src/worker/worker.runtime-imports.test.ts
@@ -1,0 +1,49 @@
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+import { runNodeScript } from "../../test/helpers/run-node-script.js";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+const repoRoot = fileURLToPath(new URL("../../", import.meta.url));
+
+describe("worker runtime imports during admission", () => {
+  it.each([
+    ["rejected", "preserves rejected hello and joins both imports after one rejects"],
+    ["cancelled", "preserves cancellation and joins both imports after one rejects"],
+    ["import-error", "surfaces import failure after accepted hello and joins the pending import"],
+    ["accepted", "waits for accepted hello before constructing the stream or running the turn"],
+  ])("%s: %s", async (mode) => {
+    const root = tempDirs.make("worker-runtime-imports-");
+    const workspace = path.join(root, "workspace");
+    await mkdir(workspace);
+    const result = await runNodeScript(
+      [
+        "--unhandled-rejections=strict",
+        "--import",
+        path.join(repoRoot, "scripts/tsx.mjs"),
+        fileURLToPath(new URL("./worker.runtime-imports.test-support.mjs", import.meta.url)),
+        mode,
+        workspace,
+      ],
+      {
+        PATH: process.env.PATH,
+        SystemRoot: process.env.SystemRoot,
+        WINDIR: process.env.WINDIR,
+        HOME: root,
+        USERPROFILE: root,
+        TMPDIR: root,
+        TMP: root,
+        TEMP: root,
+        OPENCLAW_STATE_DIR: path.join(root, "ambient-state"),
+        OPENCLAW_CONFIG_PATH: path.join(root, "ambient-config.json"),
+      },
+      20_000,
+      { cwd: repoRoot, maxBuffer: 1024 * 1024 },
+    );
+    expect(result.error, result.stderr).toBeUndefined();
+    expect(result.status, result.stderr).toBe(0);
+    expect(JSON.parse(result.stdout)).toEqual({ mode, passed: true });
+  });
+});

--- a/src/worker/worker.runtime.ts
+++ b/src/worker/worker.runtime.ts
@@ -149,9 +149,26 @@ export async function runWorkerDescriptor(
   let turnStarted = false;
   let resultFenceAcked = false;
   let forcedStopTimer: NodeJS.Timeout | undefined;
+  function loadRuntimeImports() {
+    const imports = [
+      import("./embedded-agent.runtime.js"),
+      import("./inference-stream.runtime.js"),
+    ] as const;
+    const ready = Promise.all(imports);
+    // Rejected admission does not await ready; still observe errors and join both
+    // imports before restoring the process environment.
+    void ready.catch(() => undefined);
+    return { ready, settled: Promise.allSettled(imports) };
+  }
+  let runtimeImports: ReturnType<typeof loadRuntimeImports> | undefined;
   const connection = createWorkerConnection({
     endpoint: descriptor.connectionEndpoint,
     connectParams: buildWorkerConnectParams(descriptor),
+    onAdmissionRequestSent: () => {
+      if (!abortController.signal.aborted) {
+        runtimeImports ??= loadRuntimeImports();
+      }
+    },
     onConnectionFailure: (error) => {
       options.onConnectionFailure?.(error?.message);
     },
@@ -209,10 +226,8 @@ export async function runWorkerDescriptor(
       }
       throw error;
     }
-    const [{ runWorkerEmbeddedTurn }, { createWorkerInferenceStreamAdapter }] = await Promise.all([
-      import("./embedded-agent.runtime.js"),
-      import("./inference-stream.runtime.js"),
-    ]);
+    const [{ runWorkerEmbeddedTurn }, { createWorkerInferenceStreamAdapter }] =
+      await (runtimeImports ??= loadRuntimeImports()).ready;
     const computerContextEpoch: ComputerContextEpoch = { value: 0 };
     const stream = createWorkerInferenceStreamAdapter({
       client: inference,
@@ -333,6 +348,7 @@ export async function runWorkerDescriptor(
     inference.dispose();
     live.dispose();
     await connection.stop();
+    await runtimeImports?.settled;
     await environment?.close();
   }
 }


### PR DESCRIPTION
## What Problem This Solves

Cloud workers wait for the Gateway to accept their connection before loading the runtime needed to start a turn. On remote connections, those two independent waits unnecessarily add together.

## Why This Change Was Made

Begin the existing runtime imports after the connect frame finishes writing, while admission is pending. Waiting for write completion preserves compressed WebSocket scheduling. Stream construction, workspace preparation, inference and tools still wait for validated hello.

Late callbacks cannot trigger loading after denial, stop or socket replacement. Import errors are observed immediately, and cleanup joins both imports before restoring the worker environment.

## User Impact

On the measured macOS host, runtime initialization took roughly 120 ms. Workers can overlap that work with the admission round trip. A controlled 100 ms response wait hid about 101 ms of that initialization in three diagnostic trials. Local connections offer little overlap. This reduces a specific startup wait; it does not reduce CPU work.

A denied or cancelled startup must finish module initialization before exiting. In 18 final-bundle local probes, this added 122–147 ms to median rejection, fencing and cancellation exit time; every outcome and cleanup check passed, with no inference, tools or workspace writes. This is a measured local tradeoff, not a fleet-wide latency bound.

## Evidence

- Seven real-WebSocket race cases passed with the existing connection tests (31 total). Original admission source fails the two new successful-notification cases.
- Four isolated runtime cases cover denied/cancelled/accepted hello, import failure and environment cleanup. Removing the rejection observer or settlement join makes the tests fail.
- All 108 broader runtime, managed-command, environment and import cases passed; all 35 focused connection/import cases passed on the final rebased head.
- Independent review through P2 found no actionable issues.
- Full `pnpm build` passed on `9e84f89bc213`. Selected formatting, typecheck, lint, dead-export and architecture guards passed.
- All 40 real-network trials passed using macOS workers, an isolated Linux Gateway on Daytona, and an authenticated SSH tunnel. Both ABBA and reversed block orders were retained. Combined median spawn-to-exec was 1,348 ms baseline and 1,262 ms candidate, but batch effects reversed; this does not establish a stable overall speedup. The phase trace below explains the bounded benefit without attributing all network variation to this change.
- The supported tunnel-first setup retained every workspace-owner renewal check throughout the successful campaign. Earlier setup collisions are preserved as failed infrastructure attempts, without timing samples.
- Twelve separate instrumented local diagnostic flows passed: three zero-delay and three fixed-100-ms-response trials per version. Baseline initialization remained after hello; candidate overlapped 100.83–101.69 ms of the fixed wait and left 18.54–30.31 ms after the server wrote hello. These are synthetic phase measurements, separate from the ordinary real-network results.
- Independent review through P2 and ClawSweeper review are clean. [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34682979657) passed. All task-owned cloud leases, processes and temporary credentials were cleaned up.
