### PR TITLE
fix(tests): build complete plugin install manifests

### DIFF
--- a/src/plugins/install-persistence.enablement.test.ts
+++ b/src/plugins/install-persistence.enablement.test.ts
@@ -329,18 +329,13 @@ describe("persistPluginInstall enablement", () => {
     } as OpenClawConfig;
     loadPluginManifestRegistryMock.mockReturnValue({
       plugins: [
-        recordPluginManifestInstallOwner(
-          {
-            id: "needs-config",
-            manifestPath: "/tmp/needs-config/openclaw.plugin.json",
-            configSchema: {
-              type: "object",
-              required: ["token"],
-              properties: { token: { type: "string" } },
-            },
+        createManifestRecord("needs-config", {
+          configSchema: {
+            type: "object",
+            required: ["token"],
+            properties: { token: { type: "string" } },
           },
-          "needs-config",
-        ),
+        }),
       ],
       diagnostics: [],
     });
@@ -437,18 +432,13 @@ describe("persistPluginInstall enablement", () => {
     } as OpenClawConfig;
     loadPluginManifestRegistryMock.mockReturnValue({
       plugins: [
-        recordPluginManifestInstallOwner(
-          {
-            id: "needs-config",
-            manifestPath: "/tmp/needs-config/openclaw.plugin.json",
-            configSchema: {
-              type: "object",
-              required: ["token"],
-              properties: { token: { type: "string" } },
-            },
+        createManifestRecord("needs-config", {
+          configSchema: {
+            type: "object",
+            required: ["token"],
+            properties: { token: { type: "string" } },
           },
-          "needs-config",
-        ),
+        }),
       ],
       diagnostics: [],
     });


### PR DESCRIPTION
Related: #145717

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Resolves a problem where plugin install enablement checks crash during metadata refresh instead of verifying required-configuration behavior. The inherited failure surfaced in [CI for CLI capture PR #145717](https://github.com/openclaw/openclaw/actions/runs/34678734317).

## Why This Change Was Made

Two mocked registry records omitted required manifest-record fields, including `rootDir`. Reuse the suite's existing typed `createManifestRecord` builder for both records, preserving their schemas, install ownership, and assertions. Production metadata refresh remains unchanged.

## User Impact

No product behavior change. All nine cases remain: missing configuration leaves the plugin disabled, and invalid authored configuration is rejected before writes. Production delta is zero; tests are +12/-22 (net -10).

## Evidence

- Pristine parent `8b5fa242a2fa2f3c689f3125304a8000807d1ef0` and CI merge `5deca927f6f2d5f4a6b83046281425c8de60e6c9`: each reports 8 passes and the same failure, `The "from" argument must be of type string. Received undefined`, at `installed-plugin-index-record-builder.ts:206`.
- Candidate: all 9 cases pass through `node scripts/run-vitest.mjs src/plugins/install-persistence.enablement.test.ts`, with the same case names and order.
- Independent applied review through P2: no actionable findings.
- All 20 normal changed-file checks passed through configured Testbox, including the affected test typecheck, lint, and all three dead-export scans. The earlier local pnpm formatter-download failure is retained; the repository-installed formatter and the full configured gate subsequently passed.
