### PR TITLE
fix(gateway): reduce allocation and keep busy control requests responsive

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -3118,7 +3118,7 @@ src/mcp/channel-bridge.ts	6
 src/mcp/channel-shared.ts	3
 src/mcp/codex-supervision-tools-serve.ts	6
 src/mcp/openclaw-tools-serve-config.ts	1
-src/mcp/plugin-tools-handlers.ts	3
+src/mcp/plugin-tools-handlers.ts	2
 src/media-generation/provider-registry.ts	1
 src/media-understanding/attachments.select.ts	1
 src/media-understanding/entry-capabilities.ts	1

--- a/docs/gateway/protocol/transport.md
+++ b/docs/gateway/protocol/transport.md
@@ -44,8 +44,10 @@ that supervise the Gateway as a child process, see
   sizes, limits, and a safe reason code, never message bodies, attachment
   contents, raw frame bytes, tokens, cookies, or secrets.
 - The Gateway offers `permessage-deflate`. Peers that negotiate it (browsers, `ws`
-  clients) receive frames of 4 KiB and up compressed; smaller frames such as
-  streaming deltas stay raw. Context takeover is disabled in both directions, so
+  clients) receive frames of 32 KiB and up compressed. Smaller session/tool updates
+  and ordinary agent results stay raw so serial compression callbacks do not delay
+  queued RPC replies. Large histories and rosters still compress. Context takeover
+  is disabled in both directions, so
   each frame compresses independently. Peers that do not offer the extension are
   unaffected. Payload limits apply to the inflated size.
 

--- a/src/agents/agent-tools.before-tool-call.wrapper.ts
+++ b/src/agents/agent-tools.before-tool-call.wrapper.ts
@@ -68,14 +68,11 @@ import {
   validateToolExecutionParams,
 } from "./agent-tools.execution-validation.js";
 import {
-  BEFORE_TOOL_CALL_DIAGNOSTIC_OPTIONS,
-  BEFORE_TOOL_CALL_HOOK_CONTEXT,
-  BEFORE_TOOL_CALL_SOURCE_TOOL,
-  BEFORE_TOOL_CALL_WRAPPED,
   clearBeforeToolCallWrappedMarker,
   getBeforeToolCallDiagnosticOptions,
   getBeforeToolCallHookContext,
   getBeforeToolCallSourceTool,
+  setBeforeToolCallMetadata,
   type BeforeToolCallDiagnosticOptions,
 } from "./before-tool-call-metadata.js";
 import { getChannelAgentToolMeta } from "./channel-tool-metadata.js";
@@ -690,11 +687,9 @@ export function wrapToolWithBeforeToolCallHook(
     }
   };
   copyBeforeToolCallWrapperMetadata(tool, wrappedTool);
-  Object.defineProperties(wrappedTool, {
-    [BEFORE_TOOL_CALL_WRAPPED]: { value: true, enumerable: true },
-    [BEFORE_TOOL_CALL_DIAGNOSTIC_OPTIONS]: { value: hookOptions, enumerable: false },
-    [BEFORE_TOOL_CALL_SOURCE_TOOL]: { value: tool, enumerable: false },
-    [BEFORE_TOOL_CALL_HOOK_CONTEXT]: { value: ctx, enumerable: false },
+  setBeforeToolCallMetadata(wrappedTool, tool, {
+    diagnosticOptions: hookOptions,
+    hookContext: ctx,
   });
   return wrappedTool;
 }

--- a/src/agents/agent-tools.schema.test.ts
+++ b/src/agents/agent-tools.schema.test.ts
@@ -25,15 +25,10 @@ import type { AnyAgentTool } from "./agent-tools.types.js";
 import { createProcessTool } from "./bash-tools.process.js";
 import { execSchema, processSchema } from "./bash-tools.schemas.js";
 import {
-  BEFORE_TOOL_CALL_HOOK_CONTEXT,
-  BEFORE_TOOL_CALL_SOURCE_TOOL,
+  getBeforeToolCallHookContext,
+  getBeforeToolCallSourceTool,
 } from "./before-tool-call-metadata.js";
 import { createZeroUsageFixture } from "./test-helpers/usage-fixtures.js";
-
-const beforeToolCallTesting = {
-  BEFORE_TOOL_CALL_HOOK_CONTEXT,
-  BEFORE_TOOL_CALL_SOURCE_TOOL,
-};
 
 const TEST_USAGE = createZeroUsageFixture();
 
@@ -1041,11 +1036,9 @@ describe("normalizeToolParameters", () => {
     const wrapped = wrapToolWithBeforeToolCallHook(source, hookContext);
 
     const normalized = normalizeToolParameters(wrapped);
-    const tagged = normalized as unknown as Record<symbol, unknown>;
-
     expect(isToolWrappedWithBeforeToolCallHook(normalized)).toBe(true);
-    expect(tagged[beforeToolCallTesting.BEFORE_TOOL_CALL_SOURCE_TOOL]).toBe(source);
-    expect(tagged[beforeToolCallTesting.BEFORE_TOOL_CALL_HOOK_CONTEXT]).toBe(hookContext);
+    expect(getBeforeToolCallSourceTool(normalized)).toBe(source);
+    expect(getBeforeToolCallHookContext(normalized)).toBe(hookContext);
   });
 
   it("normalizes truly empty schemas to type:object with properties:{} (MCP parameter-free tools)", () => {

--- a/src/agents/before-tool-call-metadata.test.ts
+++ b/src/agents/before-tool-call-metadata.test.ts
@@ -1,0 +1,114 @@
+import { Type } from "typebox";
+import { describe, expect, it, vi } from "vitest";
+import { PluginInstance } from "../plugins/plugin-instance.js";
+import { copyAgentToolMetadata } from "./agent-tool-metadata.js";
+import {
+  prepareBeforeToolCallExecutionParams,
+  rewrapToolWithBeforeToolCallHook,
+  wrapToolWithBeforeToolCallHook,
+} from "./agent-tools.before-tool-call.wrapper.js";
+import {
+  getBeforeToolCallDiagnosticOptions,
+  getBeforeToolCallHookContext,
+  isToolWrappedWithBeforeToolCallHook,
+  setBeforeToolCallDiagnosticsEnabled,
+} from "./before-tool-call-metadata.js";
+import { getInternalToolExecutionPreparer } from "./runtime/internal-hooks.js";
+import type { AnyAgentTool } from "./tools/common.js";
+
+function createTool(): AnyAgentTool {
+  return {
+    name: "metadata_fixture",
+    label: "Metadata fixture",
+    description: "Exercise host tool metadata",
+    parameters: Type.Object({}),
+    execute: vi.fn(async () => ({ content: [], details: {} })),
+  };
+}
+
+describe("before-tool-call metadata across plugin views", () => {
+  it("preserves host context and mutable diagnostic identity through nested views and copies", async () => {
+    const inner = new PluginInstance("inner-metadata");
+    const outer = new PluginInstance("outer-metadata");
+    const context = { runId: "metadata-run", onToolOutcome: vi.fn() };
+    const wrapped = wrapToolWithBeforeToolCallHook(createTool(), context);
+    const options = getBeforeToolCallDiagnosticOptions(wrapped);
+    try {
+      const view = outer.wrap(inner.wrap(wrapped));
+      const copied = copyAgentToolMetadata(view, { ...view });
+      expect(isToolWrappedWithBeforeToolCallHook(copied)).toBe(true);
+      expect(getBeforeToolCallHookContext(view) === context).toBe(true);
+      expect(getBeforeToolCallHookContext(copied) === context).toBe(true);
+      expect(getBeforeToolCallDiagnosticOptions(copied) === options).toBe(true);
+      setBeforeToolCallDiagnosticsEnabled(copied, false);
+      expect(options?.emitDiagnostics).toBe(false);
+      expect(context.onToolOutcome).not.toHaveBeenCalled();
+    } finally {
+      await Promise.all([inner.dispose(), outer.dispose()]);
+    }
+  });
+
+  it.each(
+    (["inner", "outer"] as const).flatMap((owner) =>
+      (["execute", "prepare"] as const).map((phase) => ({ owner, phase })),
+    ),
+  )(
+    "retains $owner admission for $phase after rewrapping with a new context",
+    async ({ owner, phase }) => {
+      const inner = new PluginInstance("inner-retirement");
+      const outer = new PluginInstance("outer-retirement");
+      const source = createTool();
+      const prepare = vi.fn((params: unknown) => params);
+      if (phase === "prepare") {
+        source.prepareBeforeToolCallParams = prepare;
+      }
+      const context = { runId: "replacement-context", onToolOutcome: vi.fn() };
+      const wrapped = wrapToolWithBeforeToolCallHook(
+        source,
+        { runId: "original-context" },
+        {
+          emitDiagnostics: false,
+        },
+      );
+      try {
+        const view = outer.wrap(inner.wrap(wrapped));
+        const rewrapped = rewrapToolWithBeforeToolCallHook(view, context);
+        expect(getBeforeToolCallHookContext(rewrapped)).toBe(context);
+        await expect(rewrapped.execute("active-execute", {})).resolves.toMatchObject({
+          content: [],
+        });
+        expect(source.execute).toHaveBeenCalledOnce();
+        vi.mocked(source.execute).mockClear();
+        prepare.mockClear();
+        await (owner === "inner" ? inner : outer).dispose();
+
+        await expect(rewrapped.execute("retired-execute", {})).rejects.toThrow(
+          "reloaded or disabled",
+        );
+        if (phase === "prepare") {
+          await expect(
+            prepareBeforeToolCallExecutionParams({ tool: rewrapped, params: {} }),
+          ).rejects.toThrow("reloaded or disabled");
+        } else {
+          const preparer = getInternalToolExecutionPreparer(rewrapped)!;
+          const prepared = await preparer({ toolCallId: "retired-prepared-execute", args: {} });
+          try {
+            expect(prepared.kind).toBe("ready");
+            if (prepared.kind === "ready") {
+              await expect(prepared.execute()).rejects.toThrow("reloaded or disabled");
+            }
+          } finally {
+            prepared.dispose();
+          }
+        }
+        expect(source.execute).not.toHaveBeenCalled();
+        expect(prepare).not.toHaveBeenCalled();
+        const rewrapAfterRetirement = async () =>
+          rewrapToolWithBeforeToolCallHook(view, context).execute("retired-rewrap", {});
+        await expect(rewrapAfterRetirement()).rejects.toThrow("reloaded or disabled");
+      } finally {
+        await Promise.all([inner.dispose(), outer.dispose()]);
+      }
+    },
+  );
+});

--- a/src/agents/before-tool-call-metadata.ts
+++ b/src/agents/before-tool-call-metadata.ts
@@ -7,20 +7,43 @@ export type BeforeToolCallDiagnosticOptions = {
   approvalMode?: "request" | "report" | "deny";
 };
 
-export const BEFORE_TOOL_CALL_WRAPPED = Symbol("beforeToolCallWrapped");
-export const BEFORE_TOOL_CALL_DIAGNOSTIC_OPTIONS = Symbol("beforeToolCallDiagnosticOptions");
-export const BEFORE_TOOL_CALL_SOURCE_TOOL = Symbol("beforeToolCallSourceTool");
-export const BEFORE_TOOL_CALL_HOOK_CONTEXT = Symbol("beforeToolCallHookContext");
+const BEFORE_TOOL_CALL_WRAPPED = Symbol("beforeToolCallWrapped");
+const BEFORE_TOOL_CALL_SOURCE_TOOL = Symbol("beforeToolCallSourceTool");
+
+type BeforeToolCallMetadata = {
+  diagnosticOptions: BeforeToolCallDiagnosticOptions;
+  hookContext?: HookContext;
+};
+
+const metadataByMarker = new WeakMap<object, BeforeToolCallMetadata>();
 
 type BeforeToolCallMetadataTool = AnyAgentTool & {
-  [BEFORE_TOOL_CALL_WRAPPED]?: true;
-  [BEFORE_TOOL_CALL_DIAGNOSTIC_OPTIONS]?: BeforeToolCallDiagnosticOptions;
+  [BEFORE_TOOL_CALL_WRAPPED]?: object;
   [BEFORE_TOOL_CALL_SOURCE_TOOL]?: AnyAgentTool;
-  [BEFORE_TOOL_CALL_HOOK_CONTEXT]?: HookContext;
 };
 
 function withBeforeToolCallMetadata(tool: AnyAgentTool): BeforeToolCallMetadataTool {
   return tool;
+}
+
+function getBeforeToolCallMetadata(tool: AnyAgentTool): BeforeToolCallMetadata | undefined {
+  const marker = withBeforeToolCallMetadata(tool)[BEFORE_TOOL_CALL_WRAPPED];
+  return marker ? metadataByMarker.get(marker) : undefined;
+}
+
+export function setBeforeToolCallMetadata(
+  tool: AnyAgentTool,
+  sourceTool: AnyAgentTool,
+  metadata: BeforeToolCallMetadata,
+): void {
+  // Empty frozen keys survive spreads and plugin views without projecting host context.
+  const marker = Object.freeze({});
+  metadataByMarker.set(marker, metadata);
+  Object.defineProperties(tool, {
+    [BEFORE_TOOL_CALL_WRAPPED]: { value: marker, enumerable: true },
+    // Source execution must retain any outer plugin view's live admission.
+    [BEFORE_TOOL_CALL_SOURCE_TOOL]: { value: sourceTool, enumerable: false },
+  });
 }
 
 export function getBeforeToolCallSourceTool(tool: AnyAgentTool): AnyAgentTool | undefined {
@@ -28,7 +51,7 @@ export function getBeforeToolCallSourceTool(tool: AnyAgentTool): AnyAgentTool | 
 }
 
 export function getBeforeToolCallHookContext(tool: AnyAgentTool): HookContext | undefined {
-  return withBeforeToolCallMetadata(tool)[BEFORE_TOOL_CALL_HOOK_CONTEXT];
+  return getBeforeToolCallMetadata(tool)?.hookContext;
 }
 
 export function clearBeforeToolCallWrappedMarker(tool: AnyAgentTool): void {
@@ -37,12 +60,12 @@ export function clearBeforeToolCallWrappedMarker(tool: AnyAgentTool): void {
 
 /** Return true when a tool already carries the before_tool_call wrapper marker. */
 export function isToolWrappedWithBeforeToolCallHook(tool: AnyAgentTool): boolean {
-  return withBeforeToolCallMetadata(tool)[BEFORE_TOOL_CALL_WRAPPED] === true;
+  return getBeforeToolCallMetadata(tool) !== undefined;
 }
 
 /** Toggle diagnostic event emission on an existing before_tool_call wrapper. */
 export function setBeforeToolCallDiagnosticsEnabled(tool: AnyAgentTool, enabled: boolean): void {
-  const options = withBeforeToolCallMetadata(tool)[BEFORE_TOOL_CALL_DIAGNOSTIC_OPTIONS];
+  const options = getBeforeToolCallMetadata(tool)?.diagnosticOptions;
   if (options) {
     options.emitDiagnostics = enabled;
   }
@@ -51,25 +74,19 @@ export function setBeforeToolCallDiagnosticsEnabled(tool: AnyAgentTool, enabled:
 export function getBeforeToolCallDiagnosticOptions(
   tool: AnyAgentTool,
 ): BeforeToolCallDiagnosticOptions | undefined {
-  return withBeforeToolCallMetadata(tool)[BEFORE_TOOL_CALL_DIAGNOSTIC_OPTIONS];
+  return getBeforeToolCallMetadata(tool)?.diagnosticOptions;
 }
 
 /** Copy before_tool_call marker metadata when another wrapper replaces a tool. */
 export function copyBeforeToolCallHookMarker(source: AnyAgentTool, target: AnyAgentTool): void {
-  if (!isToolWrappedWithBeforeToolCallHook(source)) {
+  const marker = withBeforeToolCallMetadata(source)[BEFORE_TOOL_CALL_WRAPPED];
+  if (!marker || !metadataByMarker.has(marker)) {
     return;
   }
   Object.defineProperty(target, BEFORE_TOOL_CALL_WRAPPED, {
-    value: true,
+    value: marker,
     enumerable: true,
   });
-  const diagnosticOptions = withBeforeToolCallMetadata(source)[BEFORE_TOOL_CALL_DIAGNOSTIC_OPTIONS];
-  if (diagnosticOptions) {
-    Object.defineProperty(target, BEFORE_TOOL_CALL_DIAGNOSTIC_OPTIONS, {
-      value: diagnosticOptions,
-      enumerable: false,
-    });
-  }
   const sourceTool = getBeforeToolCallSourceTool(source);
   if (sourceTool) {
     Object.defineProperty(target, BEFORE_TOOL_CALL_SOURCE_TOOL, {
@@ -77,9 +94,4 @@ export function copyBeforeToolCallHookMarker(source: AnyAgentTool, target: AnyAg
       enumerable: false,
     });
   }
-  const hookContext = getBeforeToolCallHookContext(source);
-  Object.defineProperty(target, BEFORE_TOOL_CALL_HOOK_CONTEXT, {
-    value: hookContext,
-    enumerable: false,
-  });
 }

--- a/src/agents/embedded-agent-runner/run/tool-activity-heartbeat.test.ts
+++ b/src/agents/embedded-agent-runner/run/tool-activity-heartbeat.test.ts
@@ -2,9 +2,9 @@ import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { getPluginToolMeta, setPluginToolMeta } from "../../../plugins/tool-metadata.js";
 import {
-  BEFORE_TOOL_CALL_SOURCE_TOOL,
-  BEFORE_TOOL_CALL_WRAPPED,
+  getBeforeToolCallSourceTool,
   isToolWrappedWithBeforeToolCallHook,
+  setBeforeToolCallMetadata,
 } from "../../before-tool-call-metadata.js";
 import { getChannelAgentToolMeta, setChannelAgentToolMeta } from "../../channel-tool-metadata.js";
 import { isCodeModeControlTool, markCodeModeControlTool } from "../../code-mode-control-tools.js";
@@ -137,20 +137,15 @@ describe("heartbeat wrapper metadata preservation", () => {
 
   it("preserves before-tool-call marker on heartbeat-wrapped tools", () => {
     const source: Record<string, unknown> = { name: "test-tool", execute: vi.fn() as never };
-    Object.defineProperty(source, BEFORE_TOOL_CALL_WRAPPED, {
-      value: true,
-      enumerable: true,
-    });
     const sourceTool = { name: "inner-tool" };
-    Object.defineProperty(source, BEFORE_TOOL_CALL_SOURCE_TOOL, {
-      value: sourceTool,
-      enumerable: false,
+    setBeforeToolCallMetadata(source as never, sourceTool as never, {
+      diagnosticOptions: { emitDiagnostics: false },
     });
 
     const wrapped = wrapEmbeddedAttemptToolWithActivity(source as never, RUN) as typeof source;
 
     expect(isToolWrappedWithBeforeToolCallHook(wrapped as never)).toBe(true);
-    expect((wrapped as Record<symbol, unknown>)[BEFORE_TOOL_CALL_SOURCE_TOOL]).toBe(sourceTool);
+    expect(getBeforeToolCallSourceTool(wrapped as never)).toBe(sourceTool);
   });
 
   it("preserves terminal presentation metadata on heartbeat-wrapped tools", () => {

--- a/src/agents/model-selection-shared.ts
+++ b/src/agents/model-selection-shared.ts
@@ -35,7 +35,7 @@ import {
   normalizeProviderId,
 } from "./model-ref-shared.js";
 import { findNormalizedProviderValue, parseModelRef } from "./model-selection-normalize.js";
-import { resolveModelCatalogIdentityKey } from "./openai-model-routes.js";
+import { createModelCatalogIdentityKeyResolver } from "./openai-model-routes.js";
 
 export { resolvePrimaryStringValue as normalizeModelSelection } from "@openclaw/normalization-core/string-coerce";
 
@@ -1047,6 +1047,7 @@ function buildAllowedModelSetFromPrepared(
   }
 
   const allowedKeys = new Set<string>();
+  const resolveModelCatalogIdentityKey = createModelCatalogIdentityKeyResolver();
   const catalogIdentities = new Set(catalog.map(resolveModelCatalogIdentityKey));
   const allowedCatalogIdentities = new Set<string>();
   const exactAllowedIdentities = new Set<string>();
@@ -1319,6 +1320,7 @@ export function buildConfiguredModelCatalog(params: {
 
   const manifestPlugins = resolveConfiguredModelManifestPlugins(params);
   const normalizeModelId = createConfiguredProviderCatalogModelIdNormalizer({ manifestPlugins });
+  const resolveModelCatalogIdentityKey = createModelCatalogIdentityKeyResolver();
   const capturedByIdentity = params.catalog?.length
     ? indexFirstByKey(params.catalog, resolveModelCatalogIdentityKey)
     : undefined;
@@ -1613,6 +1615,7 @@ export function createModelVisibilityPolicyWithFallbacks(
   const { visibility, policyAliasIndex, selectionAliasIndex, configuredCatalog } = prepared;
   const wildcardModelKeys = visibility.wildcardModelKeys;
   const allowed = buildAllowedModelSetFromPrepared(params, prepared);
+  const resolveModelCatalogIdentityKey = createModelCatalogIdentityKeyResolver();
   const configuredKeys = new Set(configuredCatalog.map(resolveModelCatalogIdentityKey));
   const retainedKeys = new Set<string>();
   const addConfiguredRef = (

--- a/src/agents/model-selection.catalog-policy.test.ts
+++ b/src/agents/model-selection.catalog-policy.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import * as providerPolicy from "../plugins/provider-policy-surface.js";
+import type { ModelCatalogEntry } from "./model-catalog.types.js";
+import {
+  buildAllowedModelSet,
+  buildConfiguredModelCatalog,
+  createModelVisibilityPolicyWithFallbacks,
+} from "./model-selection-shared.js";
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("model selection catalog policy lifetime", () => {
+  it.each(["configured", "allowed", "visibility"] as const)(
+    "%s preparation reuses provider policies across rows and refreshes them next time",
+    (kind) => {
+      const loadPolicy = vi.spyOn(providerPolicy, "resolveDirectBundledProviderPolicySurface");
+      const select = (rowCount: number, scope: string) => {
+        loadPolicy.mockClear().mockReturnValue({
+          normalizeModelCatalogId: ({ modelId }) => modelId.replace(/^legacy-/, `${scope}-`),
+        });
+        const ids = Array.from({ length: rowCount }, (_, index) => `legacy-${index}`);
+        const catalog: ModelCatalogEntry[] = ["first", "second"].flatMap((owner) =>
+          ids.map((_, index) => ({
+            provider: "fixture",
+            id: `${owner}-${index}`,
+            name: `${owner}-${index}`,
+            api: "openai-responses" as const,
+            baseUrl: `https://${owner}.example/v1`,
+          })),
+        );
+        const cfg: OpenClawConfig = {
+          agents: {
+            defaults: { modelPolicy: { allow: ids.map((id) => `fixture/${id}`) } },
+          },
+        };
+        if (kind === "configured") {
+          cfg.models = {
+            providers: {
+              fixture: {
+                baseUrl: "https://configured.example/v1",
+                models: ids.map((id) => ({
+                  id,
+                  name: id,
+                  reasoning: false,
+                  input: ["text"],
+                  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                  maxTokens: 1024,
+                })),
+              },
+            },
+          };
+        }
+        const params = { cfg, catalog, defaultProvider: "fixture", manifestPlugins: [] };
+        const selected =
+          kind === "configured"
+            ? buildConfiguredModelCatalog(params)
+            : kind === "allowed"
+              ? buildAllowedModelSet(params).allowedCatalog
+              : createModelVisibilityPolicyWithFallbacks({
+                  ...params,
+                  fallbackModels: [],
+                  allowManifestNormalization: false,
+                  allowPluginNormalization: false,
+                }).allowedCatalog;
+        expect(selected.map((entry) => entry.baseUrl)).toEqual(
+          Array.from({ length: rowCount }, () => `https://${scope}.example/v1`),
+        );
+        return loadPolicy.mock.calls.length;
+      };
+
+      const singleRowLoads = select(1, "first");
+      expect(singleRowLoads).toBeGreaterThan(0);
+      expect(select(32, "first")).toBe(singleRowLoads);
+      expect(select(32, "second")).toBe(singleRowLoads);
+    },
+  );
+});

--- a/src/cron/trigger-script.test.ts
+++ b/src/cron/trigger-script.test.ts
@@ -5,7 +5,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../test/helpers/promise.js";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { wrapToolWithBeforeToolCallHook } from "../agents/agent-tools.before-tool-call.js";
-import { BEFORE_TOOL_CALL_HOOK_CONTEXT } from "../agents/before-tool-call-metadata.js";
+import { getBeforeToolCallHookContext } from "../agents/before-tool-call-metadata.js";
 import { runCodeModeScriptHeadless, type CodeModeHeadlessResult } from "../agents/code-mode.js";
 import { clearToolSearchCatalog } from "../agents/tool-search.js";
 import { jsonResult, type AnyAgentTool } from "../agents/tools/common.js";
@@ -16,7 +16,6 @@ type EvaluatorDeps = Parameters<typeof createCronScriptRuntime>[0];
 type HeadlessParams = Parameters<NonNullable<EvaluatorDeps["runHeadless"]>>[0];
 type PrepareParams = Parameters<NonNullable<EvaluatorDeps["prepareRuntime"]>>[0];
 
-const beforeToolCallTesting = { BEFORE_TOOL_CALL_HOOK_CONTEXT };
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 function completed(params: { value: unknown; output?: unknown[] }): CodeModeHeadlessResult {
@@ -322,11 +321,11 @@ describe("cron trigger script evaluator", () => {
   });
 
   it("uses a fresh hook run scope for each evaluation", async () => {
-    const contexts: Array<Record<symbol, unknown>> = [];
+    const runIds: Array<string | undefined> = [];
     const { evaluate, prepareRuntime } = createEvaluator(
       vi.fn(async (params) => {
         const wrapped = params.ctx.catalogRef?.current?.entries[0]?.tool;
-        contexts.push((wrapped ?? {}) as Record<symbol, unknown>);
+        runIds.push(wrapped ? getBeforeToolCallHookContext(wrapped)?.runId : undefined);
         return completed({ value: { fire: false } });
       }),
     );
@@ -335,10 +334,6 @@ describe("cron trigger script evaluator", () => {
     await evaluate({ jobId: "job-loop-scope", script: "return result", state: null });
 
     expect(prepareRuntime).toHaveBeenCalledOnce();
-    const runIds = contexts.map((tool) => {
-      const context = tool[beforeToolCallTesting.BEFORE_TOOL_CALL_HOOK_CONTEXT];
-      return (context as { runId?: string } | undefined)?.runId;
-    });
     expect(runIds[0]).toMatch(/^cron-trigger:job-loop-scope:/);
     expect(runIds[1]).toMatch(/^cron-trigger:job-loop-scope:/);
     expect(runIds[1]).not.toBe(runIds[0]);

--- a/src/gateway/server-constants.ts
+++ b/src/gateway/server-constants.ts
@@ -3,10 +3,10 @@
 export const MAX_PAYLOAD_BYTES = 25 * 1024 * 1024;
 export const MAX_BUFFERED_BYTES = 50 * 1024 * 1024; // per-connection send buffer limit (2x max payload)
 export const MAX_PREAUTH_PAYLOAD_BYTES = 64 * 1024;
-// permessage-deflate applies from this frame size up. Streaming deltas and acks stay
-// raw (zlib round trips cost more than they save); transcript and roster payloads
-// compress 5-8x, which is what keeps chat.startup off the cold-load critical path.
-export const WS_COMPRESSION_THRESHOLD_BYTES = 4 * 1024;
+// Keep session/tool events and ordinary agent completions out of serial zlib
+// queues. Large transcript and roster responses still compress to keep cold
+// chat loads efficient.
+export const WS_COMPRESSION_THRESHOLD_BYTES = 32 * 1024;
 export const WEBSOCKET_OPEN_READY_STATE = 1;
 export const WEBSOCKET_CLOSE_GRACE_MS = 1_000;
 

--- a/src/gateway/server-methods/tasks.access.test.ts
+++ b/src/gateway/server-methods/tasks.access.test.ts
@@ -15,6 +15,7 @@ import { createOpenClawTestState } from "../../test-utils/openclaw-test-state.js
 import { seedTaskRegistryRowsForTests } from "../../test-utils/task-registry-sqlite.js";
 import { readGatewayAccessRevision } from "../gateway-access-revision.js";
 import { rolePolicyConfig } from "../session-sharing.test-utils.js";
+import * as taskSessionAccess from "../task-session-access.js";
 import { sessionSharingHandlers } from "./sessions-sharing.js";
 import {
   captureRespond,
@@ -29,9 +30,22 @@ beforeEach(async () => {
   resetTaskRegistryForTests({ persist: false });
 });
 afterEach(async () => {
+  vi.restoreAllMocks();
   resetTaskRegistryForTests({ persist: false });
   await state.cleanup();
 });
+
+function simulateExpensiveAccessSlices() {
+  let workMs = performance.now();
+  const prepareAccess = taskSessionAccess.prepareTaskSessionReadFilter;
+  vi.spyOn(performance, "now").mockImplementation(() => workMs);
+  vi.spyOn(taskSessionAccess, "prepareTaskSessionReadFilter").mockImplementation((...args) => {
+    const filter = prepareAccess(...args);
+    // Cross the elapsed-work yield boundary while retaining real access checks.
+    workMs += 20;
+    return filter;
+  });
+}
 
 describe("task page access snapshots", () => {
   it.each(["canonical", "main alias", "distinct requesters", "warm"] as const)(
@@ -107,6 +121,7 @@ describe("task page access snapshots", () => {
         }
         return parse(value, reviver);
       });
+      simulateExpensiveAccessSlices();
       const yielded = new Promise<{ parses: number; handles: number }>((resolve) => {
         setImmediate(() =>
           resolve({
@@ -186,6 +201,7 @@ describe("task page access snapshots", () => {
       broadcast: () => {},
       getSessionEventSubscriberConnIds: () => new Set<string>(),
     };
+    simulateExpensiveAccessSlices();
     const accessRevision = readGatewayAccessRevision();
     // Exercise both an already-selected requester and one not yet visited when the scan yields.
     const mutation = new Promise<void>((resolve, reject) => {

--- a/src/gateway/server.tasks-list-performance.test.ts
+++ b/src/gateway/server.tasks-list-performance.test.ts
@@ -24,6 +24,7 @@ import {
   TASK_COUNT,
   withAuthenticatedTaskGateway,
 } from "./server.tasks-list.test-helpers.js";
+import * as taskSessionAccess from "./task-session-access.js";
 
 installGatewayTestHooks({ scope: "suite" });
 
@@ -58,6 +59,18 @@ describe("tasks.list Gateway performance", () => {
       });
     };
     await withAuthenticatedTaskGateway(initializeTasks, async ({ admin, viewer }) => {
+      // Keep real authorization and RPCs, but make each prepared access slice
+      // consume a deterministic work budget regardless of host speed.
+      let workMs = performance.now();
+      const workClock = vi.spyOn(performance, "now").mockImplementation(() => workMs);
+      const prepareAccess = taskSessionAccess.prepareTaskSessionReadFilter;
+      const accessWork = vi
+        .spyOn(taskSessionAccess, "prepareTaskSessionReadFilter")
+        .mockImplementation((...args) => {
+          const filter = prepareAccess(...args);
+          workMs += 20;
+          return filter;
+        });
       const sortedInputLengths: number[] = [];
       const originalToSorted = Array.prototype.toSorted;
       const sortSpy = vi.spyOn(Array.prototype, "toSorted").mockImplementation(function <T>(
@@ -404,6 +417,8 @@ describe("tasks.list Gateway performance", () => {
         });
       } finally {
         sortSpy.mockRestore();
+        accessWork.mockRestore();
+        workClock.mockRestore();
       }
     });
   }, 60_000);

--- a/src/gateway/server/ws-connection/request-start.server.test.ts
+++ b/src/gateway/server/ws-connection/request-start.server.test.ts
@@ -384,7 +384,7 @@ describe("authenticated operator request starts", () => {
     },
   );
 
-  it("compresses large frames for peers that offer permessage-deflate and accepts compressed post-auth frames above the preauth cap", async () => {
+  it("keeps small frames raw, compresses large frames, and accepts compressed post-auth frames above the preauth cap", async () => {
     // Regression: the deflate extension keeps its own copy of the preauth maxPayload,
     // so without the extension-aware handoff an authenticated compressed request above
     // 64 KiB closed the socket with 1009 even though the receiver limit was raised.
@@ -395,6 +395,7 @@ describe("authenticated operator request starts", () => {
     setTestPluginRegistry(registry);
     const token = "gateway-compression-test-token";
     const port = await getGatewayTestPort();
+    const capture = captureGatewayConnection(port);
     let server: Awaited<ReturnType<typeof startTestGatewayServer>> | undefined;
     let ws: WebSocket | undefined;
     try {
@@ -405,6 +406,27 @@ describe("authenticated operator request starts", () => {
       });
       ws = await openOperatorSocket(port, token);
       expect(ws.extensions).toContain("permessage-deflate");
+      const { stream } = capture.get();
+      // Cover both live session/tool events and ordinary final agent results.
+      for (const sizeKiB of [6, 20]) {
+        const id = `small-${sizeKiB}`;
+        const smallText = "x".repeat(sizeKiB * 1024);
+        const smallResponse = onceMessage<{
+          type: "res";
+          id: string;
+          ok: boolean;
+          payload: { echoed: string };
+        }>(ws, (value) => value.type === "res" && value.id === id);
+        const beforeSmall = stream.bytesWritten;
+        ws.send(
+          JSON.stringify({ type: "req", id, method: "test.echo", params: { text: smallText } }),
+        );
+        await expect(smallResponse).resolves.toMatchObject({
+          ok: true,
+          payload: { echoed: smallText },
+        });
+        expect(stream.bytesWritten - beforeSmall).toBeGreaterThan(smallText.length);
+      }
       const text = "x".repeat(MAX_PREAUTH_PAYLOAD_BYTES * 2);
       const response = onceMessage<{
         type: "res";
@@ -412,13 +434,16 @@ describe("authenticated operator request starts", () => {
         ok: boolean;
         payload: { echoed: string };
       }>(ws, (value) => value.type === "res" && value.id === "big");
+      const beforeBig = stream.bytesWritten;
       ws.send(JSON.stringify({ type: "req", id: "big", method: "test.echo", params: { text } }));
       await expect(response).resolves.toMatchObject({ ok: true, payload: { echoed: text } });
+      expect(stream.bytesWritten - beforeBig).toBeLessThan(text.length / 4);
     } finally {
       ws?.terminate();
       try {
         await server?.close();
       } finally {
+        capture.restore();
         resetTestPluginRegistry();
       }
     }

--- a/src/mcp/plugin-tools-handlers.ts
+++ b/src/mcp/plugin-tools-handlers.ts
@@ -7,7 +7,7 @@ import {
   rewrapToolWithBeforeToolCallHook,
   wrapToolWithBeforeToolCallHook,
 } from "../agents/agent-tools.before-tool-call.js";
-import { BEFORE_TOOL_CALL_HOOK_CONTEXT } from "../agents/before-tool-call-metadata.js";
+import { getBeforeToolCallHookContext } from "../agents/before-tool-call-metadata.js";
 import { isToolResultError } from "../agents/tool-result-error.js";
 import { isAutomationsToolName } from "../agents/tools/automations-tool-name.js";
 import type { AnyAgentTool } from "../agents/tools/common.js";
@@ -17,10 +17,6 @@ import { coerceChatContentText } from "../shared/chat-content.js";
 type CallPluginToolParams = {
   name: string;
   arguments?: unknown;
-};
-
-type ToolWithBeforeToolCallHookContext = AnyAgentTool & {
-  [BEFORE_TOOL_CALL_HOOK_CONTEXT]?: unknown;
 };
 
 function toMcpContentBlock(block: unknown): unknown {
@@ -61,8 +57,7 @@ function resolveJsonSchemaForTool(tool: AnyAgentTool): Record<string, unknown> {
 }
 
 function resolveBeforeToolCallRunId(tool: AnyAgentTool): string | undefined {
-  const context = (tool as ToolWithBeforeToolCallHookContext)[BEFORE_TOOL_CALL_HOOK_CONTEXT];
-  return isRecord(context) && typeof context.runId === "string" ? context.runId : undefined;
+  return getBeforeToolCallHookContext(tool)?.runId;
 }
 
 export function createPluginToolsMcpHandlers(tools: AnyAgentTool[]) {

--- a/src/plugins/plugin-instance.ts
+++ b/src/plugins/plugin-instance.ts
@@ -17,10 +17,7 @@ import type {
 } from "./plugin-instance.types.js";
 import { resolvePluginReturnPromise } from "./plugin-return-value.js";
 import type { PluginRecord, PluginRegistry } from "./registry-types.js";
-import {
-  withPluginRuntimePluginScope,
-  withPluginRuntimeRegistryScope,
-} from "./runtime/gateway-request-scope.js";
+import { withPluginRuntimePluginScope } from "./runtime/gateway-request-scope.js";
 import { getPluginRuntimeGenerationRegistry } from "./runtime/generation-scope.js";
 
 const { values: valueInstances } = pluginInstanceState;
@@ -249,7 +246,13 @@ export class PluginInstance {
   }
 
   private enter<T>(token: object, run: () => T): T {
-    const invoke = () => invocation.run({ instance: this, token }, run);
+    const current = invocation.getStore();
+    // Node can reuse an identical store instead of copying the entire async context map.
+    const invoke = () =>
+      invocation.run(
+        current?.instance === this && current.token === token ? current : { instance: this, token },
+        run,
+      );
     if (!this.owner) {
       return invoke();
     }
@@ -261,16 +264,15 @@ export class PluginInstance {
       this.consumers.get(token)?.registry ??
       this.calls.get(token) ??
       (generation?.plugins.includes(record) ? generation : this.owner.registry);
-    return withPluginRuntimeRegistryScope(registry, () =>
-      withPluginRuntimePluginScope(
-        {
-          pluginId: record.id,
-          pluginSource: record.source,
-          pluginOrigin: record.origin,
-          pluginTrustedOfficialInstall: record.trustedOfficialInstall,
-        },
-        invoke,
-      ),
+    return withPluginRuntimePluginScope(
+      {
+        pluginId: record.id,
+        pluginSource: record.source,
+        pluginOrigin: record.origin,
+        pluginTrustedOfficialInstall: record.trustedOfficialInstall,
+      },
+      invoke,
+      registry,
     );
   }
 

--- a/src/plugins/runtime/gateway-request-scope.test.ts
+++ b/src/plugins/runtime/gateway-request-scope.test.ts
@@ -144,4 +144,43 @@ describe("gateway request scope", () => {
       );
     });
   });
+
+  it("isolates combined plugin identities across concurrent registry scopes", async () => {
+    const runtimeScope = await importGatewayRequestScopeModule();
+    const parent = {
+      ...TEST_SCOPE,
+      pluginId: "parent",
+      pluginSource: "parent-source",
+      pluginOrigin: "bundled" as const,
+      pluginTrustedOfficialInstall: true,
+    };
+    const registries = [createEmptyPluginRegistry(), createEmptyPluginRegistry()];
+    await runtimeScope.withPluginRuntimeGatewayRequestScope(parent, async () => {
+      await Promise.all(
+        registries.map((registry, index) =>
+          runtimeScope.withPluginRuntimePluginScope(
+            { pluginId: `child-${index}` },
+            async () => {
+              await Promise.resolve();
+              const scoped = runtimeScope.getPluginRuntimeGatewayRequestScope()!;
+              expect(scoped).toEqual({
+                ...TEST_SCOPE,
+                pluginId: `child-${index}`,
+                pluginRegistry: registry,
+                declaredProviderOwners: undefined,
+              });
+              expect(Object.hasOwn(scoped, "pluginSource")).toBe(false);
+              expect(Object.hasOwn(scoped, "pluginOrigin")).toBe(false);
+              expect(Object.hasOwn(scoped, "pluginTrustedOfficialInstall")).toBe(false);
+              scoped.pluginSource = "child-only";
+              expect(parent.pluginSource).toBe("parent-source");
+              expect(requireActivePluginRegistry()).toBe(registry);
+            },
+            registry,
+          ),
+        ),
+      );
+      expectGatewayScope(runtimeScope, parent);
+    });
+  });
 });

--- a/src/plugins/runtime/gateway-request-scope.ts
+++ b/src/plugins/runtime/gateway-request-scope.ts
@@ -227,31 +227,33 @@ export function withPluginRuntimeRegistryScope<T>(
   }
   const current = pluginRuntimeGatewayRequestScope.getStore();
   return pluginRuntimeGatewayRequestScope.run(
-    {
-      isWebchatConnect: () => false,
-      ...current,
-      pluginRegistry: registry,
-      declaredProviderOwners:
-        declaredProviderOwners ??
-        // Nested calls keep this prepared registry's facts, never a different registry's index.
-        (current?.pluginRegistry === registry ? current.declaredProviderOwners : undefined) ??
-        getPluginRuntimeLoadContextState(registry)?.declaredProviderOwners,
-    },
+    createRegistryScope(registry, current, declaredProviderOwners),
     run,
   );
 }
 
-/**
- * Runs work under the current gateway request scope while attaching plugin identity.
- */
-export function withPluginRuntimePluginScope<T>(scope: PluginRuntimePluginScope, run: () => T): T {
-  const current = pluginRuntimeGatewayRequestScope.getStore();
-  const scoped: PluginRuntimeGatewayRequestScope = current
-    ? { ...current, pluginId: scope.pluginId }
-    : {
-        pluginId: scope.pluginId,
-        isWebchatConnect: () => false,
-      };
+function createRegistryScope(
+  registry: PluginRegistry,
+  current: PluginRuntimeGatewayRequestScope | undefined,
+  declaredProviderOwners?: DeclaredProviderOwnerIndex,
+): PluginRuntimeGatewayRequestScope {
+  return {
+    isWebchatConnect: () => false,
+    ...current,
+    pluginRegistry: registry,
+    declaredProviderOwners:
+      declaredProviderOwners ??
+      // Nested calls keep this prepared registry's facts, never a different registry's index.
+      (current?.pluginRegistry === registry ? current.declaredProviderOwners : undefined) ??
+      getPluginRuntimeLoadContextState(registry)?.declaredProviderOwners,
+  };
+}
+
+function applyPluginScope(
+  scoped: PluginRuntimeGatewayRequestScope,
+  scope: PluginRuntimePluginScope,
+): void {
+  scoped.pluginId = scope.pluginId;
   if (scope.pluginSource !== undefined) {
     scoped.pluginSource = scope.pluginSource;
   } else {
@@ -267,6 +269,24 @@ export function withPluginRuntimePluginScope<T>(scope: PluginRuntimePluginScope,
   } else {
     delete scoped.pluginTrustedOfficialInstall;
   }
+}
+
+/**
+ * Runs work under the current gateway request scope while attaching plugin identity.
+ */
+export function withPluginRuntimePluginScope<T>(
+  scope: PluginRuntimePluginScope,
+  run: () => T,
+  registry?: PluginRegistry,
+): T {
+  const current = pluginRuntimeGatewayRequestScope.getStore();
+  // Instance calls combine registry and identity without adding a second async frame.
+  const scoped: PluginRuntimeGatewayRequestScope = registry
+    ? createRegistryScope(registry, current)
+    : current
+      ? { ...current }
+      : { isWebchatConnect: () => false };
+  applyPluginScope(scoped, scope);
   return pluginRuntimeGatewayRequestScope.run(scoped, run);
 }
 

--- a/src/tasks/task-registry-query.test.ts
+++ b/src/tasks/task-registry-query.test.ts
@@ -11,6 +11,7 @@ import { configureTaskRegistryRuntime } from "./task-registry.store.js";
 import type { TaskRecord } from "./task-registry.types.js";
 
 afterEach(() => {
+  vi.restoreAllMocks();
   resetTaskRegistryForTests();
 });
 
@@ -38,6 +39,8 @@ describe("listTaskRecordPage", () => {
     { scope: "sparse", matching: 1 },
     { scope: "dense", matching: 65 },
   ])("keeps $scope session pages independent of unrelated task activity", async ({ matching }) => {
+    let workMs = 0;
+    vi.spyOn(performance, "now").mockImplementation(() => workMs);
     configureTaskSnapshot(
       Array.from({ length: 65 }, (_, index): TaskRecord => ({
         taskId: `task-${index}`,
@@ -66,6 +69,10 @@ describe("listTaskRecordPage", () => {
         offset: 0,
         limit: 1,
         sessionKey: "agent:main:requested",
+        prepareFilter: () => {
+          workMs += 20;
+          return () => true;
+        },
       });
       if (matching === 1) {
         expect(page.ok).toBe(true);
@@ -83,15 +90,15 @@ describe("listTaskRecordPage", () => {
   });
 
   it.each([
-    { count: 32, mutationTurn: 1, completes: true },
-    { count: 64, mutationTurn: 2, completes: true },
-    { count: 33, mutationTurn: 1, completes: false },
-    { count: 65, mutationTurn: 2, completes: false },
+    { cost: "cheap", workPerSliceMs: 0 },
+    { cost: "expensive", workPerSliceMs: 20 },
   ])(
-    "finishes complete batches but yields unfinished work ($count tasks)",
-    async ({ count, mutationTurn, completes }) => {
+    "keeps $cost task scans responsive and consistent under continuing activity",
+    async ({ workPerSliceMs }) => {
+      let workMs = 0;
+      vi.spyOn(performance, "now").mockImplementation(() => workMs);
       configureTaskSnapshot(
-        Array.from({ length: count }, (_, index): TaskRecord => ({
+        Array.from({ length: 512 }, (_, index): TaskRecord => ({
           taskId: `task-${index}`,
           runtime: "cli",
           requesterSessionKey: "agent:main:main",
@@ -105,26 +112,35 @@ describe("listTaskRecordPage", () => {
           lastEventAt: 1,
         })),
       );
-      let turn = 0;
       let mutations = 0;
       const update = () => {
-        turn += 1;
-        if (turn >= mutationTurn) {
-          mutations += 1;
-          markTaskTerminalById({
-            taskId: "task-0",
-            status: "succeeded",
-            endedAt: mutations + 1,
-          });
-        }
+        mutations += 1;
+        markTaskTerminalById({
+          taskId: "task-0",
+          status: "succeeded",
+          endedAt: mutations + 1,
+        });
         pending = setImmediate(update);
       };
-      let pending = setImmediate(update);
+      let pending: ReturnType<typeof setImmediate> | undefined;
+      update();
       try {
-        const page = await listTaskRecordPage({ offset: 0, limit: count });
-        if (completes) {
+        const page = await listTaskRecordPage({
+          offset: 0,
+          limit: 25,
+          prepareFilter: () => {
+            workMs += workPerSliceMs;
+            return () => true;
+          },
+        });
+        if (workPerSliceMs === 0) {
           expect(page.ok).toBe(true);
-          expect(mutations).toBe(0);
+          expect(mutations).toBe(1);
+          if (page.ok) {
+            expect(page.value.tasks).toHaveLength(25);
+            expect(page.value.tasks[0]).toMatchObject({ taskId: "task-0", endedAt: 2 });
+            expect(page.value.hasMore).toBe(true);
+          }
         } else {
           expect(page).toEqual({ ok: false, error: "registry_changed" });
           expect(mutations).toBeGreaterThanOrEqual(3);
@@ -151,6 +167,8 @@ describe("listTaskRecordPage", () => {
       failLater: true,
     },
   ])("handles yielded task pages with $name", async ({ continuation, mutate, failLater }) => {
+    let workMs = 0;
+    vi.spyOn(performance, "now").mockImplementation(() => workMs);
     const tasks = Array.from({ length: 1_024 }, (_, index): TaskRecord => ({
       taskId: `task-${String(index).padStart(5, "0")}`,
       runtime: "cli",
@@ -175,7 +193,7 @@ describe("listTaskRecordPage", () => {
       tasks.slice(25, 50).map((task) => task.taskId),
     );
 
-    let examined = 0;
+    let preparedSlices = 0;
     let scheduled = false;
     let mutation: TaskRecord | null | undefined;
     const accessFailure = new Error("canonical-store collision in a later slice");
@@ -183,14 +201,15 @@ describe("listTaskRecordPage", () => {
       offset: continuation ? 25 : 0,
       limit: 25,
       ...(continuation ? { expectedRevision: first.revision } : {}),
-      prepareFilter: (batch) => {
-        examined += batch.length;
-        if (failLater && examined > 32) {
+      prepareFilter: () => {
+        preparedSlices += 1;
+        workMs += 20;
+        if (failLater && preparedSlices > 1) {
           throw accessFailure;
         }
         if (mutate && !scheduled) {
           scheduled = true;
-          // The ordinary completion runs only when this scan reaches its existing yield.
+          // The ordinary completion runs when this expensive slice yields.
           queueMicrotask(() => {
             mutation = markTaskTerminalById({
               taskId: "task-01023",
@@ -210,7 +229,7 @@ describe("listTaskRecordPage", () => {
     expect(mutation).toMatchObject({ taskId: "task-01023", status: "succeeded" });
     if (continuation) {
       expect(page).toEqual({ ok: false, error: "cursor_stale" });
-      expect(examined).toBe(32);
+      expect(preparedSlices).toBe(1);
     } else {
       expect(page.ok).toBe(true);
       if (page.ok) {
@@ -224,6 +243,8 @@ describe("listTaskRecordPage", () => {
   });
 
   it("keeps large page scans responsive and sorts only the selected window", async () => {
+    let workMs = 0;
+    vi.spyOn(performance, "now").mockImplementation(() => workMs);
     const total = 10_000;
     const offset = 13;
     const limit = 7;
@@ -274,7 +295,14 @@ describe("listTaskRecordPage", () => {
       setImmediate(() => {
         eventLoopTurnRan = true;
       });
-      const page = await readTaskPage({ offset, limit });
+      const page = await readTaskPage({
+        offset,
+        limit,
+        prepareFilter: () => {
+          workMs += 20;
+          return () => true;
+        },
+      });
 
       expect(page.tasks.map((task) => task.taskId)).toEqual(expectedTaskIds);
       expect(page.hasMore).toBe(true);

--- a/src/tasks/task-registry-query.ts
+++ b/src/tasks/task-registry-query.ts
@@ -153,6 +153,7 @@ function heapifyWorstTaskFirst(
 }
 
 const TASK_PAGE_MAX_ATTEMPTS = 3;
+const TASK_PAGE_YIELD_INTERVAL_MS = 12;
 
 export async function listTaskRecordPage(params: {
   offset: number;
@@ -182,6 +183,7 @@ export async function listTaskRecordPage(params: {
   // Filtering and ordering stay registry-owned so authoritative records never
   // cross the boundary; only the bounded selected page is defensively cloned.
   const windowSize = params.offset + params.limit;
+  let workStartedAt = performance.now();
   for (let attempt = 0; attempt < TASK_PAGE_MAX_ATTEMPTS; attempt += 1) {
     const revision = readTaskRegistryRevision();
     if (params.expectedRevision !== undefined && params.expectedRevision !== revision) {
@@ -197,9 +199,11 @@ export async function listTaskRecordPage(params: {
     const iterator = source?.keys() ?? [].values();
     let current = iterator.next();
     while (!current.done && scannedCount < scanLimit) {
-      // Yield only when another batch exists; completed pages keep their revision.
-      if (scannedCount > 0) {
+      // Cheap pages finish atomically even while other sessions are busy. Expensive
+      // scans share the event loop without charging time queued behind other work.
+      if (scannedCount > 0 && performance.now() - workStartedAt >= TASK_PAGE_YIELD_INTERVAL_MS) {
         await yieldToEventLoop();
+        workStartedAt = performance.now();
         // A carried revision cannot recover; skip unrelated reads once it is stale.
         // Cursorless scans still finish their attempt before retrying.
         if (params.expectedRevision !== undefined && revision !== readTaskRegistryRevision()) {


### PR DESCRIPTION
Closes #145686
Benchmark: #145751

## What Problem This Solves

Fixes an issue where opening Sessions or Tasks on a busy Gateway could stall for seconds while agents ran tools in parallel. Repeated policy loading, plugin context copying, and host-metadata projection created substantial transient allocation. Task scans repeatedly yielded into fresh mutations, while small event and agent-result frames queued RPC replies behind serial compression callbacks.

## Why This Change Was Made

Reuse catalog identity policies within each synchronous selection operation, keep host hook context and diagnostic options behind an opaque tool metadata marker, and combine plugin/registry context entry. Source-tool views retain live plugin admission; scope mutations remain isolated and policy preparation refreshes on the next operation.

Cheap task pages now finish within the existing-style 12 ms work budget. Expensive scans still yield, with revision, cursor, and authorization checks preserved. Raise the existing outbound compression threshold to 32 KiB so ordinary events and agent completions avoid serial zlib queues; large responses still compress, with unchanged negotiation, ordering, payload limits, and backpressure handling.

## User Impact

Busy Gateways allocate less temporary memory and serve control requests more promptly. The sustained candidate completed every turn and all health, history, subscription, session-update, and control probes without errors.

This trades additional wire traffic for responsiveness. In the transport-only comparison, actual server output increased 24.4%, including additional control queries served by the faster run. Peak sampled RSS also increased in the combined workload; this is an allocation and responsiveness improvement, not a demonstrated reduction in resident memory.

## Evidence

Same configured workload: 64 concurrent sessions × 8 serial turns, 512 seeded sessions with 8 history messages, 32 visible observers, 4 history clients, and 1,024 session updates. The baseline includes upstream #145659; its argument-restoration work is not part of this diff.

| Heap-profiled sustained run | Baseline | Candidate |
| --- | ---: | ---: |
| Completed agent turns | 512 | 512 |
| Sampled allocated bytes | 105,808,366,000 | 89,464,959,080 (-15.45%) |
| Session-list p95 | 9,317 ms | 915 ms |
| Session-list timeouts | 1 | 0 |
| Tasks-list errors | 7 | 0 |
| Control sample rounds | 101 | 501 |
| Joined load duration | 198.45 s | 163.87 s |
| Sampled peak RSS | 2,091 MiB | 2,853 MiB |

These are closed-loop probes: the faster candidate served almost five times as many rounds, so totals do not represent identical amounts of control work. Allocation sampling includes collected objects and is distinct from retained heap. Endpoint heap use also increased (1,069 → 1,284 MiB). A candidate-only repeat on the published head completed another 512 turns and 499 control rounds without errors. After profile export, a two-second idle, and diagnostic-only GC, V8 heap use was 394 MiB and RSS was 2,098 MiB. Export itself allocates memory, and there is no matched baseline GC sample: this shows collectability but does not establish a smaller resident footprint.

Transport instrumentation correlated client send, server arrival, handler completion, send-queue flush, and client receipt. At 4 KiB, a session-list response spent roughly 19 ms in application work and 16.9 seconds in the send queue. At 32 KiB, session-list p95 was 445 ms and all 285 list responses entered an empty sender queue. An 8 KiB trial still stalled behind 61 compressed agent results around 20 KiB each, which justified the final threshold. No turn-throughput improvement is attributed to that isolated transport experiment.

- 582 focused runtime/benchmark cases plus 95 transport cases passed. Metadata identity, cheap task scans under churn, and 6/20 KiB wire behavior were demonstrated failing against their original owners or intermediate threshold. Large compressed post-auth frames, retirement, ordered delivery, and failed-connection cleanup remain covered.
- Selected changed-check guards, script/core/test typechecks, targeted lint, and the full build passed. Independent P0–P2 review is clean. The move onto current main is patch-identical.
- Nine access-snapshot cases also passed with explicit elapsed-work interleaving. They call the real authorization owner and retain all grant, revocation, returned-task, and resource-bound assertions.
- 128 live OpenAI tasks passed over 32 sessions and 4 waves, with fresh CSV input per wave, verified computed output files, 512 tool events, and no probe failures.

```sh
node scripts/bench-gateway-concurrency.ts --concurrency 64 --turns-per-session 8 \
  --session-count 512 --tool-events --subscribers 32 --visible-observer \
  --history-clients 4 --history-messages 8 --control-plane --session-updates 1024 \
  --timeout-ms 600000 --heap-prof-dir .artifacts/gateway-load-profiles \
  --output .artifacts/gateway-load.json
```
