### PR TITLE
refactor(tests): reuse state database fixture opens

### DIFF
--- a/src/state/openclaw-state-db.test.ts
+++ b/src/state/openclaw-state-db.test.ts
@@ -842,8 +842,8 @@ function downgradeWorkerPlacementsToV7(db: DatabaseSync): void {
   }
 }
 
-function openMaterializedCurrentStateDatabase(): DatabaseSync {
-  const databasePath = materializeCurrentStateDatabase(createTempStateDir());
+function openMaterializedCurrentStateDatabase(stateDir = createTempStateDir()): DatabaseSync {
+  const databasePath = materializeCurrentStateDatabase(stateDir);
   const { DatabaseSync } = requireNodeSqlite();
   return new DatabaseSync(databasePath);
 }
@@ -1581,9 +1581,7 @@ describe("openclaw state database", () => {
   it("migrates v15 Skill Workshop ownership through v16 and prepared workers to v17 without losing rows", () => {
     const stateDir = createTempStateDir();
     const options = { env: { OPENCLAW_STATE_DIR: stateDir } };
-    const databasePath = materializeCurrentStateDatabase(stateDir);
-    const { DatabaseSync } = requireNodeSqlite();
-    const legacy = new DatabaseSync(databasePath);
+    const legacy = openMaterializedCurrentStateDatabase(stateDir);
     removePreparedWorkerOwnershipColumns(legacy);
     const record = {
       schema: "openclaw.skill-workshop.proposal.v1",
@@ -1856,10 +1854,7 @@ describe("openclaw state database", () => {
   it("upgrades a v15 store without Workshop tables through v16 and prepared workers to v17", () => {
     const stateDir = createTempStateDir();
     const options = { env: { OPENCLAW_STATE_DIR: stateDir } };
-    const databasePath = materializeCurrentStateDatabase(stateDir);
-
-    const { DatabaseSync } = requireNodeSqlite();
-    const legacy = new DatabaseSync(databasePath);
+    const legacy = openMaterializedCurrentStateDatabase(stateDir);
     removePreparedWorkerOwnershipColumns(legacy);
     legacy.exec(`
       PRAGMA foreign_keys = OFF;
@@ -2898,9 +2893,7 @@ describe("openclaw state database", () => {
     (migrationPath) => {
       const stateDir = createTempStateDir();
       const options = { env: { OPENCLAW_STATE_DIR: stateDir } };
-      const databasePath = materializeCurrentStateDatabase(stateDir);
-      const { DatabaseSync } = requireNodeSqlite();
-      const legacy = new DatabaseSync(databasePath);
+      const legacy = openMaterializedCurrentStateDatabase(stateDir);
       legacy.exec(STATE_SCHEMA_13_TO_12_DOWNGRADE_SQL);
       const storeKey = path.join(stateDir, "cron", "jobs.json");
       const cases: Array<{ enabled: boolean; delivery?: { mode: "none" } }> = [
@@ -2960,9 +2953,7 @@ describe("openclaw state database", () => {
     (migrationPath) => {
       const stateDir = createTempStateDir();
       const options = { env: { OPENCLAW_STATE_DIR: stateDir } };
-      const databasePath = materializeCurrentStateDatabase(stateDir);
-      const { DatabaseSync } = requireNodeSqlite();
-      const legacy = new DatabaseSync(databasePath);
+      const legacy = openMaterializedCurrentStateDatabase(stateDir);
       legacy.exec(STATE_SCHEMA_13_TO_12_DOWNGRADE_SQL);
       const insert = legacy.prepare(
         `INSERT INTO cron_jobs (
@@ -3029,9 +3020,7 @@ describe("openclaw state database", () => {
     (migrationPath, column, value) => {
       const stateDir = createTempStateDir();
       const options = { env: { OPENCLAW_STATE_DIR: stateDir } };
-      const databasePath = materializeCurrentStateDatabase(stateDir);
-      const { DatabaseSync } = requireNodeSqlite();
-      const legacy = new DatabaseSync(databasePath);
+      const legacy = openMaterializedCurrentStateDatabase(stateDir);
       legacy.exec(STATE_SCHEMA_13_TO_12_DOWNGRADE_SQL);
       const values = {
         install_records_json: "{}",
@@ -3385,9 +3374,7 @@ describe("openclaw state database", () => {
   it("keeps a pre-existing authProfiles.store KV value over the v13 auth import", () => {
     const stateDir = createTempStateDir();
     const options = { env: { OPENCLAW_STATE_DIR: stateDir } };
-    const databasePath = materializeCurrentStateDatabase(stateDir);
-    const { DatabaseSync } = requireNodeSqlite();
-    const legacy = new DatabaseSync(databasePath);
+    const legacy = openMaterializedCurrentStateDatabase(stateDir);
     legacy.exec(STATE_SCHEMA_13_TO_12_DOWNGRADE_SQL);
     legacy
       .prepare(
@@ -4163,9 +4150,7 @@ describe("openclaw state database", () => {
   it("keeps unrelated schema identifiers named commitments usable", () => {
     const stateDir = createTempStateDir();
     const options = { env: { OPENCLAW_STATE_DIR: stateDir } };
-    const databasePath = materializeCurrentStateDatabase(stateDir);
-    const { DatabaseSync } = requireNodeSqlite();
-    const unrelated = new DatabaseSync(databasePath);
+    const unrelated = openMaterializedCurrentStateDatabase(stateDir);
     seedV6CommitmentSchema(unrelated);
     unrelated.exec("CREATE VIEW commitment_metrics AS SELECT 1 AS commitments;");
     unrelated.close();
@@ -4353,10 +4338,7 @@ INSERT INTO macos_port_guardian_records VALUES (4242, 18789, '/usr/bin/ssh', 're
   it("doctor migrates existing APNs tombstone tables to STRICT without losing rows", () => {
     const stateDir = createTempStateDir();
     const options = { env: { OPENCLAW_STATE_DIR: stateDir } };
-    const databasePath = materializeCurrentStateDatabase(stateDir);
-
-    const { DatabaseSync } = requireNodeSqlite();
-    const legacyDb = new DatabaseSync(databasePath);
+    const legacyDb = openMaterializedCurrentStateDatabase(stateDir);
     legacyDb.exec(`
       ALTER TABLE apns_registration_tombstones RENAME TO apns_registration_tombstones_strict;
       CREATE TABLE apns_registration_tombstones (
@@ -4999,9 +4981,7 @@ INSERT INTO macos_port_guardian_records VALUES (4242, 18789, '/usr/bin/ssh', 're
     (repairPath) => {
       const stateDir = createTempStateDir();
       const options = { env: { OPENCLAW_STATE_DIR: stateDir } };
-      const databasePath = materializeCurrentStateDatabase(stateDir);
-      const { DatabaseSync } = requireNodeSqlite();
-      const legacy = new DatabaseSync(databasePath);
+      const legacy = openMaterializedCurrentStateDatabase(stateDir);
       const entriesSql =
         "SELECT * FROM plugin_state_entries ORDER BY plugin_id, namespace, entry_key";
       const metadataSql =
@@ -5060,10 +5040,7 @@ INSERT INTO macos_port_guardian_records VALUES (4242, 18789, '/usr/bin/ssh', 're
   it("repairs same-version Claw bootstrap columns before runtime schema validation", () => {
     const stateDir = createTempStateDir();
     const env = { OPENCLAW_STATE_DIR: stateDir };
-    const databasePath = materializeCurrentStateDatabase(stateDir);
-
-    const { DatabaseSync } = requireNodeSqlite();
-    const shippedSchema = new DatabaseSync(databasePath);
+    const shippedSchema = openMaterializedCurrentStateDatabase(stateDir);
     try {
       shippedSchema.exec(`
         ALTER TABLE claw_installs DROP COLUMN bootstrap_source_path;
@@ -5171,10 +5148,7 @@ INSERT INTO macos_port_guardian_records VALUES (4242, 18789, '/usr/bin/ssh', 're
   it("installs same-version worker session tool tables before runtime schema validation", () => {
     const stateDir = createTempStateDir();
     const env = { OPENCLAW_STATE_DIR: stateDir };
-    const databasePath = materializeCurrentStateDatabase(stateDir);
-
-    const { DatabaseSync } = requireNodeSqlite();
-    const shippedSchema = new DatabaseSync(databasePath);
+    const shippedSchema = openMaterializedCurrentStateDatabase(stateDir);
     try {
       shippedSchema.exec(`
         DROP TABLE worker_session_tool_operations;
@@ -5453,10 +5427,7 @@ INSERT INTO macos_port_guardian_records VALUES (4242, 18789, '/usr/bin/ssh', 're
   it("upgrades v5 databases that predate startup worker tool tables", () => {
     const stateDir = createTempStateDir();
     const options = { env: { OPENCLAW_STATE_DIR: stateDir } };
-    const databasePath = materializeCurrentStateDatabase(stateDir);
-
-    const { DatabaseSync } = requireNodeSqlite();
-    const legacy = new DatabaseSync(databasePath);
+    const legacy = openMaterializedCurrentStateDatabase(stateDir);
     legacy.exec(`
       DROP TABLE worker_session_tool_operations;
       DROP TABLE worker_turn_tool_authorities;
@@ -5527,10 +5498,7 @@ INSERT INTO macos_port_guardian_records VALUES (4242, 18789, '/usr/bin/ssh', 're
   it("rejects primary-key collation drift in a current-schema table", () => {
     const stateDir = createTempStateDir();
     const options = { env: { OPENCLAW_STATE_DIR: stateDir } };
-    const databasePath = materializeCurrentStateDatabase(stateDir);
-
-    const { DatabaseSync } = requireNodeSqlite();
-    const drifted = new DatabaseSync(databasePath);
+    const drifted = openMaterializedCurrentStateDatabase(stateDir);
     drifted.exec(`
       DROP TABLE apns_registration_tombstones;
       CREATE TABLE apns_registration_tombstones (
@@ -5588,10 +5556,7 @@ INSERT INTO macos_port_guardian_records VALUES (4242, 18789, '/usr/bin/ssh', 're
   it("keeps an unrecognized agent registry schema fail-closed and nonrepairable", () => {
     const stateDir = createTempStateDir();
     const options = { env: { OPENCLAW_STATE_DIR: stateDir } };
-    const databasePath = materializeCurrentStateDatabase(stateDir);
-
-    const { DatabaseSync } = requireNodeSqlite();
-    const malformed = new DatabaseSync(databasePath);
+    const malformed = openMaterializedCurrentStateDatabase(stateDir);
     malformed.exec(`
       DROP TABLE agent_databases;
       CREATE TABLE agent_databases (
@@ -6715,10 +6680,7 @@ INSERT INTO macos_port_guardian_records VALUES (4242, 18789, '/usr/bin/ssh', 're
 
   it("adds gateway boot lifecycle startup markers to existing state databases", () => {
     const stateDir = createTempStateDir();
-    const databasePath = materializeCurrentStateDatabase(stateDir);
-
-    const { DatabaseSync } = requireNodeSqlite();
-    const legacyDb = new DatabaseSync(databasePath);
+    const legacyDb = openMaterializedCurrentStateDatabase(stateDir);
     legacyDb.exec("ALTER TABLE gateway_boot_lifecycle DROP COLUMN startup_reason");
     markStateDatabaseVersion(legacyDb, 5);
     legacyDb.close();
@@ -6735,9 +6697,7 @@ INSERT INTO macos_port_guardian_records VALUES (4242, 18789, '/usr/bin/ssh', 're
 
   it("adds and backfills Claw package update timestamps in existing state databases", () => {
     const stateDir = createTempStateDir();
-    const databasePath = materializeCurrentStateDatabase(stateDir);
-    const { DatabaseSync } = requireNodeSqlite();
-    const legacyDb = new DatabaseSync(databasePath);
+    const legacyDb = openMaterializedCurrentStateDatabase(stateDir);
     legacyDb
       .prepare(
         "INSERT INTO claw_package_refs (" +
@@ -6810,10 +6770,7 @@ INSERT INTO macos_port_guardian_records VALUES (4242, 18789, '/usr/bin/ssh', 're
 
   it("adds worker bootstrap lifecycle columns to existing state databases", () => {
     const stateDir = createTempStateDir();
-    const databasePath = materializeCurrentStateDatabase(stateDir);
-
-    const { DatabaseSync } = requireNodeSqlite();
-    const legacyDb = new DatabaseSync(databasePath);
+    const legacyDb = openMaterializedCurrentStateDatabase(stateDir);
     legacyDb.exec(`
       DROP TABLE worker_environment_credentials;
       ALTER TABLE worker_environments DROP COLUMN bootstrap_bundle_hash;
@@ -6855,10 +6812,7 @@ INSERT INTO macos_port_guardian_records VALUES (4242, 18789, '/usr/bin/ssh', 're
 
   it("repairs additive placement terminal columns in canonical physical order", () => {
     const stateDir = createTempStateDir();
-    const databasePath = materializeCurrentStateDatabase(stateDir);
-
-    const { DatabaseSync } = requireNodeSqlite();
-    const legacyDb = new DatabaseSync(databasePath);
+    const legacyDb = openMaterializedCurrentStateDatabase(stateDir);
     legacyDb.exec(`
       ALTER TABLE worker_session_placements DROP COLUMN terminal_at_ms;
       ALTER TABLE worker_session_placements DROP COLUMN terminal_reason;
@@ -6922,10 +6876,7 @@ INSERT INTO macos_port_guardian_records VALUES (4242, 18789, '/usr/bin/ssh', 're
   it("adds staged worker-result refs during the v5 state migration", () => {
     const stateDir = createTempStateDir();
     const options = { env: { OPENCLAW_STATE_DIR: stateDir } };
-    const databasePath = materializeCurrentStateDatabase(stateDir);
-
-    const { DatabaseSync } = requireNodeSqlite();
-    const legacyDb = new DatabaseSync(databasePath);
+    const legacyDb = openMaterializedCurrentStateDatabase(stateDir);
     legacyDb.exec(`
       ALTER TABLE worker_workspace_pending_results DROP COLUMN staged_result_ref;
       PRAGMA user_version = 4;
@@ -6948,10 +6899,7 @@ INSERT INTO macos_port_guardian_records VALUES (4242, 18789, '/usr/bin/ssh', 're
 
   it("adds worker transcript commit tables to existing state databases", () => {
     const stateDir = createTempStateDir();
-    const databasePath = materializeCurrentStateDatabase(stateDir);
-
-    const { DatabaseSync } = requireNodeSqlite();
-    const legacyDb = new DatabaseSync(databasePath);
+    const legacyDb = openMaterializedCurrentStateDatabase(stateDir);
     legacyDb.exec(`
       DROP TABLE worker_transcript_commits;
       DROP TABLE worker_transcript_commit_heads;
@@ -7079,10 +7027,7 @@ INSERT INTO macos_port_guardian_records VALUES (4242, 18789, '/usr/bin/ssh', 're
   it("does not recursively recommend doctor when operator approval repair refuses a shape", () => {
     const stateDir = createTempStateDir();
     const options = { env: { OPENCLAW_STATE_DIR: stateDir } };
-    const databasePath = materializeCurrentStateDatabase(stateDir);
-
-    const { DatabaseSync } = requireNodeSqlite();
-    const customizedDb = new DatabaseSync(databasePath);
+    const customizedDb = openMaterializedCurrentStateDatabase(stateDir);
     const currentSql = (
       customizedDb
         .prepare(
@@ -7113,10 +7058,7 @@ INSERT INTO macos_port_guardian_records VALUES (4242, 18789, '/usr/bin/ssh', 're
     ({ migrationPath, withRow }) => {
       const stateDir = createTempStateDir();
       const options = { env: { OPENCLAW_STATE_DIR: stateDir } };
-      const databasePath = materializeCurrentStateDatabase(stateDir);
-
-      const { DatabaseSync } = requireNodeSqlite();
-      const legacyDb = new DatabaseSync(databasePath);
+      const legacyDb = openMaterializedCurrentStateDatabase(stateDir);
       replaceManagedImageRecordsWithLegacyTable(legacyDb, { withRow });
       legacyDb.close();
 
@@ -7178,10 +7120,7 @@ INSERT INTO macos_port_guardian_records VALUES (4242, 18789, '/usr/bin/ssh', 're
   it("backfills diagnostic event sequences in legacy creation order", () => {
     const stateDir = createTempStateDir();
     const options = { env: { OPENCLAW_STATE_DIR: stateDir } };
-    const databasePath = materializeCurrentStateDatabase(stateDir);
-
-    const { DatabaseSync } = requireNodeSqlite();
-    const legacyDb = new DatabaseSync(databasePath);
+    const legacyDb = openMaterializedCurrentStateDatabase(stateDir);
     legacyDb.exec(`
       DROP INDEX idx_diagnostic_events_scope_sequence;
       ALTER TABLE diagnostic_events DROP COLUMN sequence;
@@ -7228,10 +7167,7 @@ INSERT INTO macos_port_guardian_records VALUES (4242, 18789, '/usr/bin/ssh', 're
   it("adds relay origins to existing APNs registration tables", () => {
     const stateDir = createTempStateDir();
     const options = { env: { OPENCLAW_STATE_DIR: stateDir } };
-    const databasePath = materializeCurrentStateDatabase(stateDir);
-
-    const { DatabaseSync } = requireNodeSqlite();
-    const legacyDb = new DatabaseSync(databasePath);
+    const legacyDb = openMaterializedCurrentStateDatabase(stateDir);
     legacyDb.exec("ALTER TABLE apns_registrations DROP COLUMN relay_origin");
     markStateDatabaseVersion(legacyDb, 5);
     legacyDb.close();
@@ -7302,10 +7238,7 @@ INSERT INTO macos_port_guardian_records VALUES (4242, 18789, '/usr/bin/ssh', 're
 
   it("migrates requester and executor attribution for existing cross-agent tasks", () => {
     const stateDir = createTempStateDir();
-    const databasePath = materializeCurrentStateDatabase(stateDir);
-
-    const { DatabaseSync } = requireNodeSqlite();
-    const legacyDb = new DatabaseSync(databasePath);
+    const legacyDb = openMaterializedCurrentStateDatabase(stateDir);
     legacyDb.exec("ALTER TABLE task_runs DROP COLUMN requester_agent_id");
     legacyDb
       .prepare(
@@ -7466,9 +7399,7 @@ INSERT INTO macos_port_guardian_records VALUES (4242, 18789, '/usr/bin/ssh', 're
     await withOpenClawTestState(
       { layout: "state-only", prefix: "openclaw-state-task-delivery-status-" },
       async ({ stateDir }) => {
-        const databasePath = materializeCurrentStateDatabase(stateDir);
-        const { DatabaseSync } = requireNodeSqlite();
-        const database = new DatabaseSync(databasePath);
+        const database = openMaterializedCurrentStateDatabase(stateDir);
         const insert = database.prepare(
           `INSERT INTO task_runs (
             task_id, runtime, requester_session_key, owner_key, scope_kind, task, status,
@@ -7527,10 +7458,7 @@ INSERT INTO macos_port_guardian_records VALUES (4242, 18789, '/usr/bin/ssh', 're
 
   it("adds hosted catalog snapshot trust columns to existing state databases", () => {
     const stateDir = createTempStateDir();
-    const databasePath = materializeCurrentStateDatabase(stateDir);
-
-    const { DatabaseSync } = requireNodeSqlite();
-    const legacyDb = new DatabaseSync(databasePath);
+    const legacyDb = openMaterializedCurrentStateDatabase(stateDir);
     legacyDb.exec(`
       ALTER TABLE official_external_plugin_catalog_snapshots DROP COLUMN trust_mode;
       ALTER TABLE official_external_plugin_catalog_snapshots DROP COLUMN trust_key_id;
@@ -7562,10 +7490,7 @@ INSERT INTO macos_port_guardian_records VALUES (4242, 18789, '/usr/bin/ssh', 're
 
   it("adds task detail storage to an existing state database", () => {
     const stateDir = createTempStateDir();
-    const databasePath = materializeCurrentStateDatabase(stateDir);
-
-    const { DatabaseSync } = requireNodeSqlite();
-    const legacyDb = new DatabaseSync(databasePath);
+    const legacyDb = openMaterializedCurrentStateDatabase(stateDir);
     legacyDb.exec("ALTER TABLE task_runs DROP COLUMN detail_json");
     markStateDatabaseVersion(legacyDb, 5);
     legacyDb.close();


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

State database migration tests repeatedly materialized a fixture, loaded SQLite and opened the same single-argument connection even though the file already has an owner for that setup.

## Why This Change Was Made

Let the existing open helper accept the caller's state directory and reuse it at 28 sites. Its six no-argument callers retain their original directory allocation and construction order. This removes 75 test lines while keeping SQL, row fixtures, assertions, close/repair/reopen operations and fresh-initialization tests unchanged.

## User Impact

No production, schema, migration or cache behavior changes. The tests retain their existing storage and lifecycle coverage with less duplicated setup.

## Evidence

- Full owner before and after: 232 passed, one unchanged Linux-only skip; all 233 names, order and results match.
- Owner plus database-open, additive-schema and cache-cleanup siblings: 254 passed, the same skip.
- Exact inverse reconstructs the complete baseline source; 33 controls preserve supplied-directory construction, default allocation and failure order.
- Mapped changed checks, deslop and fresh P2 review passed.

No overall runtime or coverage-percentage improvement is claimed.
