### PR TITLE
fix(test): preserve failures when redirecting native reports

### DIFF
--- a/scripts/lib/vitest-report-owner.mts
+++ b/scripts/lib/vitest-report-owner.mts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import type { JsonTestResults } from "vitest/node";
+import { vitestOptionConsumesNextArg } from "./vitest-cli-mode.mts";
 import { parseVitestExecutionArgs } from "./vitest-cli.mts";
 import type { VitestReportCapture } from "./vitest-report-capture.mts";
 
@@ -35,9 +36,7 @@ function withoutOutputArgs(args: string[]) {
       return [...result, ...args.slice(index)];
     }
     if (/^--(?:output(?:File|-file)(?:\.[^=]+)?|coverage\.reportsDirectory)(?:=|$)/u.test(arg)) {
-      if (!arg.includes("=")) {
-        index++;
-      }
+      index += vitestOptionConsumesNextArg(arg, args[index + 1]) ? 1 : 0;
     } else {
       result.push(arg);
     }

--- a/test/scripts/vitest-report-owner.test.ts
+++ b/test/scripts/vitest-report-owner.test.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
+import { parseCLI, type JsonTestResults } from "vitest/node";
 import type { VitestReportCapture } from "../../scripts/lib/vitest-report-capture.mts";
 import { isPidDefinitelyDead } from "../../src/shared/pid-alive.ts";
 import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
@@ -259,6 +260,119 @@ describe.skipIf(process.platform === "win32")("native multi-invocation report ow
       expect(fs.readFileSync(path.join(root, "home/canary"), "utf8")).toBe(
         "synthetic caller home\n",
       );
+    },
+  );
+
+  it.each([
+    {
+      name: "scalar empty-inline output",
+      option: "--outputFile=",
+      mode: "failure",
+      entry: undefined,
+      betaOnly: false,
+    },
+    {
+      name: "dotted empty-inline output",
+      option: "--outputFile.json=",
+      mode: "failure",
+      entry: undefined,
+      betaOnly: false,
+    },
+    {
+      name: "nonempty output ending in equals",
+      option: "attached",
+      mode: "failure",
+      entry: "projects",
+      betaOnly: true,
+    },
+    {
+      name: "batch empty-inline output",
+      option: "--outputFile=",
+      mode: "batch-failure",
+      entry: undefined,
+      betaOnly: false,
+    },
+  ] as const)(
+    "preserves real failed tests with $name",
+    { timeout: 60000 },
+    async ({ option, mode, entry, betaOnly }) => {
+      const root = dirs.make("oc-report-output-operand-");
+      const output = path.join(root, "reports", betaOnly ? "result.json=" : "result.json");
+      const outputArgs =
+        option === "attached" ? [`--outputFile=${output}`, "beta.test.ts"] : [option, output];
+      const nativeArgs = [
+        "--reporter=verbose",
+        "--reporter=json",
+        ...outputArgs,
+        "--passWithNoTests",
+      ];
+      const parsed = parseCLI(["vitest", "run", ...nativeArgs]);
+      const requested = parsed.options.outputFile;
+      expect(typeof requested === "string" ? requested : requested?.json).toBe(output);
+      expect(parsed.filter).toEqual(betaOnly ? ["beta.test.ts"] : []);
+      const result = await createVitestReportFixture(root)(mode, {
+        entry,
+        report: false,
+        nativeArgs,
+      });
+      const report: JsonTestResults = json(output);
+      const cases = (betaOnly ? expected.slice(2) : expected).map(([name, status]) => [
+        name,
+        name === "beta/one" ? "failed" : status,
+      ]);
+
+      expect(inventory(report), result.stderr).toEqual(cases);
+      const failed = report.testResults
+        .flatMap((file) => file.assertionResults)
+        .find((test) => test.fullName.trim() === "beta/one");
+      expect(failed?.failureMessages).toEqual(
+        expect.arrayContaining([expect.stringContaining("expected 1 to be 2")]),
+      );
+      expect(result.code, result.stderr).toBe(1);
+      expect(result.signal).toBeNull();
+      const index = json(path.join(result.reportSet!, "index.json"));
+      expect(index.complete).toBe(true);
+      expect(index.requested).toBe(output);
+      expect(index.aggregate).toBe(output);
+      expect(index.merge).toMatchObject({ code: 1, signal: null });
+    },
+  );
+
+  it.each(["--outputFile.blob", "--outputFile.blob="])(
+    "preserves native no-tests refusal after %s",
+    { timeout: 60000 },
+    async (option) => {
+      const root = dirs.make("oc-report-following-option-");
+      const output = path.join(root, "reports", "result.json");
+      const nativeArgs = [
+        "--reporter=json",
+        `--outputFile.json=${output}`,
+        option,
+        "--passWithNoTests=false",
+      ];
+      const parsed = parseCLI(["vitest", "run", ...nativeArgs]);
+      expect(parsed.options.outputFile).toEqual({ json: output, blob: true });
+      expect(parsed.options.passWithNoTests).toBe(false);
+      expect(parsed.filter).toEqual([]);
+
+      const result = await createVitestReportFixture(root)("empty", {
+        entry: "projects",
+        report: false,
+        nativeArgs,
+      });
+      const index = json(path.join(result.reportSet!, "index.json"));
+      const attempt = index.entries[0].attempts[0];
+      const capture: VitestReportCapture = json(`${attempt.json}.capture.json`);
+      expect(capture.passWithNoTests, result.stderr).toBe(false);
+      expect(capture.command).toContain("--passWithNoTests=false");
+      expect(capture.modules).toEqual([]);
+      expect(capture.ended?.reason).toBe("failed");
+      expect(attempt.outcome).toMatchObject({ code: 1, signal: null });
+      expect(result.code, result.stderr).toBe(1);
+      expect(result.signal).toBeNull();
+      expect(index.complete).toBe(false);
+      expect(index.entries[1].attempts).toEqual([]);
+      expect(fs.existsSync(output)).toBe(false);
     },
   );
 


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

This same-repository branch is editable by maintainers.

</details>

## What Problem This Solves

Fixes an issue where developers requesting a combined JSON test report could receive an empty successful result despite a selected test failing. With multiple invocations, `--outputFile= result.json` and `--outputFile.json= result.json` leaked the destination into native test filters. A bare dotted output option could also swallow a following `--passWithNoTests=false`, turning an intentional empty-selection failure into success.

## Why This Change Was Made

The report owner still selects which destinations to replace, but now uses the existing shared argument-consumption helper to determine whether each option owns its next token. This deletes the duplicate rule that disagreed with native Vitest/MRI parsing. Nonempty inline values ending in `=`, subsequent flags, and the argument separator keep their existing ownership.

Production/tooling changes are **+2/−3, net −1**. Tests are **+114/−0** in the existing native-fixture suite. No unrelated deletions offset the fix.

## User Impact

Multi-invocation reports retain the selected tests and their real failures. An explicit refusal to accept no tests remains effective. Report destinations, admission rules, aggregate format, retry/watchdog behavior, and valid empty-selection handling are unchanged.

## Evidence

Original baseline: `31848a15205a1aab75165e91c994af851962e0e8`. Final candidate base: `1a8620efbb196ccab29f6e12270c102e0ce17cc7`. The corrected complete patch is byte-identical across that refresh, and the relevant production, helper, caller and native-fixture sources are unchanged. The current checkout has its own frozen dependency installation.

- Tests-first selection: **3 intended failures and 15 passing controls**, with 65 cases intentionally filtered out.
- Candidate: **83/83 owner tests passed**, repeated successfully on the final candidate base. The test typecheck initially caught a nullable failure-message assertion; it now requires an actual array containing the native failure message. Four affected rows and the full changed gate passed after that correction on the original base.
- Final-base changed checks passed, including scripts/test-root typechecks, formatting, lint, unused-export scans and selected guards.
- Fresh independent managed review of the final candidate found no actionable P0–P2 findings. Separate raw-evidence review checked all 12 retained phase runs, 21 native attempts and nine merges.

Commands used:

```sh
node scripts/run-vitest.mjs test/scripts/vitest-report-owner.test.ts
node scripts/check-changed.mjs -- scripts/lib/vitest-report-owner.mts test/scripts/vitest-report-owner.test.ts
```

Six retained native scenarios ran before and after the repair through the real repository test wrappers and installed Vitest 5.0.0, using synthetic test projects with genuine assertions:

| Scenario | Before | After |
|---|---|---|
| Empty-inline scalar output | Empty aggregate, exit 0 | Five cases including the real beta failure, exit 1 |
| Empty-inline dotted output | Empty aggregate, exit 0 | Same five-case inventory and failure, exit 1 |
| Inline filename ending in `=` | Three beta cases, exit 1 | Preserved |
| Batch caller with explicit targets | Five cases, exit 1 | Preserved; leaked destination removed |
| Bare dotted output followed by explicit false flag | Empty success, exit 0 | Native no-tests refusal, exit 1; no aggregate |
| Empty-inline dotted output followed by that flag | Native refusal, exit 1; no aggregate | Preserved |

Each outer proof process exited successfully only after checking its expected phase contract; the inner failures above are intentional. Original reports, blobs, captures, aggregate inventories, assertion text and process outcomes were independently compared. These scenarios completed in approximately 1.1–2.3 seconds under the unchanged 45-second fixture deadline. All outer receipts record joined processes/groups and null signals. Batch groups in this proof run serially.

Runtime observations belong to the original precommit source, then bind to the unchanged production patch. Final-base tests and review are separate evidence. Selected source and native dependency hashes were checked, not a fully hermetic transitive/runtime closure. No provider, Gateway, other OS or packaged-install behavior is claimed. A full OpenClaw build is unnecessary for this source-tooling-only change: the helper was already loaded transitively, and no published package/build entrypoint or module boundary changes.
