### PR TITLE
refactor(status): remove retired Tailscale diagnostic state

### DIFF
--- a/src/commands/status-all/diagnosis.test.ts
+++ b/src/commands/status-all/diagnosis.test.ts
@@ -79,12 +79,7 @@ function createBaseParams(
     port: 18789,
     portUsage: { port: 18789, status: "busy", listeners, hints: [] },
     tailscaleMode: "off",
-    tailscale: {
-      backendState: null,
-      dnsName: null,
-      ips: [],
-      error: null,
-    },
+    tailscaleDns: null,
     tailscaleHttpsUrl: null,
     skillStatus: null,
     pluginCompatibility: [],
@@ -259,15 +254,14 @@ describe("status-all diagnosis port checks", () => {
     expect(output).toContain("Pasteable debug report. Auth tokens redacted.");
   });
 
-  it("labels OpenClaw Tailscale exposure separately from daemon state", async () => {
+  it("keeps DNS context while daemon state remains unobserved", async () => {
     const params = createBaseParams([]);
-    params.tailscale.backendState = "Running";
-    params.tailscale.dnsName = "box.tail.ts.net";
+    params.tailscaleDns = "box.tail.ts.net";
 
     await appendStatusAllDiagnosis(params);
 
     const output = params.lines.join("\n");
-    expect(output).toContain("✓ Tailscale exposure: off · daemon Running · box.tail.ts.net");
+    expect(output).toContain("✓ Tailscale exposure: off · daemon unknown · box.tail.ts.net");
     expect(output).not.toContain("Tailscale: off");
   });
 
@@ -583,7 +577,6 @@ describe("status-all diagnosis port checks", () => {
       "Local gateway: not expected on this machine",
       "Remote gateway target: gateway.example.com:19000",
     ].join("\n");
-    params.tailscale.backendState = "Running";
     params.health = undefined;
     params.nodeOnlyGateway = {
       gatewayTarget: "gateway.example.com:19000",

--- a/src/commands/status-all/diagnosis.ts
+++ b/src/commands/status-all/diagnosis.ts
@@ -56,13 +56,6 @@ type ConfigSnapshotLike = {
 
 type PortUsageLike = Pick<PortUsage, "listeners" | "port" | "status" | "hints">;
 
-type TailscaleStatusLike = {
-  backendState: string | null;
-  dnsName: string | null;
-  ips: string[];
-  error: string | null;
-};
-
 type ChannelIssueLike = {
   channel: string;
   accountId: string;
@@ -158,7 +151,7 @@ export async function appendStatusAllDiagnosis(params: {
   port: number;
   portUsage: PortUsageLike | null;
   tailscaleMode: string;
-  tailscale: TailscaleStatusLike;
+  tailscaleDns: string | null;
   tailscaleHttpsUrl: string | null;
   skillStatus: SkillStatusReport | null;
   pluginCompatibility: PluginCompatibilityNotice[];
@@ -291,26 +284,12 @@ export async function appendStatusAllDiagnosis(params: {
     }
   }
 
-  {
-    const backend = params.tailscale.backendState ?? "unknown";
-    const okBackend = backend === "Running";
-    const hasDns = Boolean(params.tailscale.dnsName);
-    const label =
-      params.tailscaleMode === "off"
-        ? `Tailscale exposure: off · daemon ${backend}${params.tailscale.dnsName ? ` · ${params.tailscale.dnsName}` : ""}`
-        : `Tailscale exposure: ${params.tailscaleMode} · daemon ${backend}${params.tailscale.dnsName ? ` · ${params.tailscale.dnsName}` : ""}`;
-    emitCheck(label, params.tailscaleMode === "off" || (okBackend && hasDns) ? "ok" : "warn");
-    if (params.tailscale.error) {
-      lines.push(`  ${muted(`error: ${params.tailscale.error}`)}`);
-    }
-    if (params.tailscale.ips.length > 0) {
-      lines.push(
-        `  ${muted(`ips: ${params.tailscale.ips.slice(0, 3).join(", ")}${params.tailscale.ips.length > 3 ? "…" : ""}`)}`,
-      );
-    }
-    if (params.tailscaleHttpsUrl) {
-      lines.push(`  ${muted(`https: ${params.tailscaleHttpsUrl}`)}`);
-    }
+  emitCheck(
+    `Tailscale exposure: ${params.tailscaleMode} · daemon unknown${params.tailscaleDns ? ` · ${params.tailscaleDns}` : ""}`,
+    params.tailscaleMode === "off" ? "ok" : "warn",
+  );
+  if (params.tailscaleHttpsUrl) {
+    lines.push(`  ${muted(`https: ${params.tailscaleHttpsUrl}`)}`);
   }
 
   if (params.skillStatus) {

--- a/src/commands/status-all/format.test.ts
+++ b/src/commands/status-all/format.test.ts
@@ -140,19 +140,16 @@ describe("status-all format", () => {
         tailscaleMode: "funnel",
         tailscaleDns: null,
         tailscaleHttpsUrl: null,
-        tailscaleBackendState: "Running",
         includeBackendStateWhenOn: true,
       }),
-    ).toBe("funnel · Running · magicdns unknown");
+    ).toBe("funnel · unknown · magicdns unknown");
     expect(
       getStatusOverviewRowValue("Tailscale exposure", {
         tailscaleMode: "off",
-        tailscaleBackendState: "Stopped",
         tailscaleDns: "box.tail.ts.net",
-        includeBackendStateWhenOff: true,
         includeDnsNameWhenOff: true,
       }),
-    ).toBe("off · daemon Stopped · box.tail.ts.net");
+    ).toBe("off · box.tail.ts.net");
   });
 
   it("formats service values across short and detailed runtime surfaces", () => {

--- a/src/commands/status-all/format.ts
+++ b/src/commands/status-all/format.ts
@@ -118,8 +118,6 @@ function formatStatusTailscaleValue(params: {
   tailscaleMode: string;
   dnsName?: string | null;
   httpsUrl?: string | null;
-  backendState?: string | null;
-  includeBackendStateWhenOff?: boolean;
   includeBackendStateWhenOn?: boolean;
   includeDnsNameWhenOff?: boolean;
   decorateOff?: (value: string) => string;
@@ -128,21 +126,14 @@ function formatStatusTailscaleValue(params: {
   const decorateOff = params.decorateOff ?? ((value: string) => value);
   const decorateWarn = params.decorateWarn ?? ((value: string) => value);
   if (params.tailscaleMode === "off") {
-    // Off mode can still show daemon/DNS context when the caller wants diagnostic detail.
-    const suffix = [
-      params.includeBackendStateWhenOff && params.backendState
-        ? `daemon ${params.backendState}`
-        : null,
-      params.includeDnsNameWhenOff && params.dnsName ? params.dnsName : null,
-    ]
-      .filter(Boolean)
-      .join(" · ");
+    // Off mode can still show DNS context when the caller wants diagnostic detail.
+    const suffix = params.includeDnsNameWhenOff ? params.dnsName : null;
     return decorateOff(suffix ? `off · ${suffix}` : "off");
   }
   if (params.dnsName && params.httpsUrl) {
     const parts = [
       params.tailscaleMode,
-      params.includeBackendStateWhenOn ? (params.backendState ?? "unknown") : null,
+      params.includeBackendStateWhenOn ? "unknown" : null,
       params.dnsName,
       params.httpsUrl,
     ].filter(Boolean);
@@ -150,7 +141,7 @@ function formatStatusTailscaleValue(params: {
   }
   const parts = [
     params.tailscaleMode,
-    params.includeBackendStateWhenOn ? (params.backendState ?? "unknown") : null,
+    params.includeBackendStateWhenOn ? "unknown" : null,
     "magicdns unknown",
   ].filter(Boolean);
   return decorateWarn(parts.join(" · "));
@@ -258,8 +249,6 @@ export function buildStatusOverviewSurfaceRows(params: {
   tailscaleDns?: string | null;
   tailscaleHttpsUrl?: string | null;
   advertisedControlUiLinks?: { httpUrl: string; wsUrl: string };
-  tailscaleBackendState?: string | null;
-  includeBackendStateWhenOff?: boolean;
   includeBackendStateWhenOn?: boolean;
   includeDnsNameWhenOff?: boolean;
   decorateTailscaleOff?: (value: string) => string;
@@ -317,8 +306,6 @@ export function buildStatusOverviewSurfaceRows(params: {
       tailscaleMode: params.tailscaleMode,
       dnsName: params.tailscaleDns,
       httpsUrl: params.tailscaleHttpsUrl,
-      backendState: params.tailscaleBackendState,
-      includeBackendStateWhenOff: params.includeBackendStateWhenOff,
       includeBackendStateWhenOn: params.includeBackendStateWhenOn,
       includeDnsNameWhenOff: params.includeDnsNameWhenOff,
       decorateOff: params.decorateTailscaleOff,

--- a/src/commands/status-all/report-data.ts
+++ b/src/commands/status-all/report-data.ts
@@ -71,12 +71,7 @@ async function resolveStatusAllLocalDiagnosis(params: {
     port: number;
     portUsage: Awaited<ReturnType<typeof inspectPortUsage>> | null;
     tailscaleMode: string;
-    tailscale: {
-      backendState: null;
-      dnsName: string | null;
-      ips: string[];
-      error: null;
-    };
+    tailscaleDns: string | null;
     tailscaleHttpsUrl: string | null;
     skillStatus: ReturnType<typeof buildWorkspaceSkillStatus> | null;
     pluginCompatibility: ReturnType<typeof buildPluginCompatibilityNotices>;
@@ -178,12 +173,7 @@ async function resolveStatusAllLocalDiagnosis(params: {
       port,
       portUsage,
       tailscaleMode: overview.tailscaleMode,
-      tailscale: {
-        backendState: null,
-        dnsName: overview.tailscaleDns,
-        ips: [],
-        error: null,
-      },
+      tailscaleDns: overview.tailscaleDns,
       tailscaleHttpsUrl: overview.tailscaleHttpsUrl,
       skillStatus,
       pluginCompatibility,
@@ -237,7 +227,6 @@ export async function buildStatusAllReportData(params: {
     secretDiagnosticsCount: params.overview.secretDiagnostics.length,
     updateRows: buildStatusUpdateRows(diagnosis.sentinel?.payload),
     agentStatus: params.overview.agentStatus,
-    tailscaleBackendState: diagnosis.tailscale.backendState,
   });
 
   return {

--- a/src/commands/status-all/report-lines.test.ts
+++ b/src/commands/status-all/report-lines.test.ts
@@ -101,12 +101,7 @@ describe("buildStatusAllReportLines", () => {
         port: 18789,
         portUsage: null,
         tailscaleMode: "off",
-        tailscale: {
-          backendState: null,
-          dnsName: null,
-          ips: [],
-          error: null,
-        },
+        tailscaleDns: null,
         tailscaleHttpsUrl: null,
         skillStatus: null,
         pluginCompatibility: [],

--- a/src/commands/status-overview-rows.test.ts
+++ b/src/commands/status-overview-rows.test.ts
@@ -281,7 +281,6 @@ describe("status-overview-rows", () => {
         totalSessions: 2,
         agents: [{ id: "main", lastActiveAgeMs: 60_000 }],
       },
-      tailscaleBackendState: "Running",
     });
 
     expect(findRowValue(rows, "Version")).toBe(VERSION);

--- a/src/commands/status-overview-rows.ts
+++ b/src/commands/status-overview-rows.ts
@@ -229,12 +229,9 @@ export function buildStatusAllOverviewRows(params: {
       lastActiveAgeMs?: number | null;
     }>;
   };
-  tailscaleBackendState?: string | null;
 }) {
   return buildStatusOverviewRowsFromSurface({
     surface: params.surface,
-    tailscaleBackendState: params.tailscaleBackendState,
-    includeBackendStateWhenOff: true,
     includeBackendStateWhenOn: true,
     includeDnsNameWhenOff: true,
     prefixRows: [

--- a/src/commands/status-overview-surface.test.ts
+++ b/src/commands/status-overview-surface.test.ts
@@ -74,7 +74,6 @@ describe("status-overview-surface", () => {
         updateValue: "available · custom update",
         gatewayAuthWarningValue: "warn(warn-text)",
         gatewaySelfFallbackValue: "gateway-self",
-        includeBackendStateWhenOff: true,
         includeDnsNameWhenOff: true,
         decorateOk: (value) => `ok(${value})`,
         decorateWarn: (value) => `warn(${value})`,

--- a/src/commands/status-overview-surface.ts
+++ b/src/commands/status-overview-surface.ts
@@ -12,8 +12,6 @@ import type { StatusScanResult } from "./status.scan-result.ts";
 type StatusOverviewRowInput = Parameters<typeof buildStatusOverviewSurfaceRows>[0];
 type StatusOverviewFormatOptions = Pick<
   StatusOverviewRowInput,
-  | "tailscaleBackendState"
-  | "includeBackendStateWhenOff"
   | "includeBackendStateWhenOn"
   | "includeDnsNameWhenOff"
   | "decorateTailscaleOff"


### PR DESCRIPTION
## What Problem This Solves

Maintainer-requested cleanup of `openclaw status --all`: the report still modeled daemon backend, error, and IP diagnostics after its producer stopped collecting them. Those unreachable branches and private test inputs obscured which Tailscale facts the report actually knows.

The producer has supplied `backendState: null`, `ips: []`, and `error: null` since [the original retirement](https://github.com/openclaw/openclaw/commit/72dcf942213845dae33d454cc2762c4980017f45). The enabled-mode hostname probe is still used and remains unchanged.

## Why This Change Was Made

Carry the remaining DNS value directly through the report owner and remove the retired private DTO, unreachable branches, and always-null overview arguments. Keep the existing `daemon unknown` text, off/enabled success-warning distinction, DNS/HTTPS handling, decorator order, and redaction.

This removes **50 production lines and 17 test lines** across five production files and five existing test fixtures. No test case, public JSON field, configuration option, probe, or service behavior is removed. `--json --all` still takes the JSON route, preserving summary spreading and public null/absent-field contracts.

## User Impact

No intended user-visible change. Human reports and machine-readable status retain their existing output. This is a cleanup, **not a claimed runtime or memory improvement**.

## Evidence

- **120 tests passed across all 11 selected files**, with no skipped/unselected assertions. Coverage includes report assembly, real `statusCommand` JSON output, optional/null fields, read-only summaries, and refused-agent presentation.
- **26 selected small guards passed**, each run separately under the same resource limits. Normal commit hooks, formatting, and `git diff --check` passed.
- Fresh managed **Codex P2 review: scoped-clean**, no actionable findings.
- Broad core/core-test typechecking and type-aware lint are **unrun locally and pending exact-head hosted CI**. Their matching owners exceeded the available local capacity in separate work; those failures are not attributed to this candidate.
- The [isolated command comparison](https://github.com/openclaw/openclaw/actions/runs/34675461253) passed **40 executions across 10 fixed cases**, in baseline/candidate/candidate/baseline order, against the historical `beef20565` base. It compared complete human/ANSI output, public JSON, runtime output calls, and ordered external-I/O observations. Network, service-manager, and Tailscale command responses were synthetic; this is not live authentication or daemon proof. Current-author candidate bytes match that comparison; newer unrelated caller changes are not claimed covered by the older run.

The measurements were mixed. Positive values below are adverse; each value compares the two candidate observations with the two baseline observations:

| Case | Command time | Peak process-tree RSS |
| --- | ---: | ---: |
| Full report, off | +5.68% | +0.01% |
| Full report, serve/DNS, rich | +2.45% | −0.62% |
| Full report, funnel/DNS | −6.51% | +1.27% |
| Full report, hostname failure | −2.70% | −0.74% |
| Full report, IP fallback | +7.15% | +6.41% |
| Full report, node-only | +1.70% | −3.48% |
| Ordinary status, off | +7.00% | +0.45% |
| Ordinary status, serve | −6.87% | −2.32% |
| JSON status, off | +0.72% | +2.13% |
| JSON status with all, serve | −11.26% | +2.36% |

Off and IP-fallback command timings were adverse in both pairs. All raw CPU, heap, native timing, and control results were retained; no favorable rerun or performance claim is made. The command proof supports behavior parity.

Two earlier launcher failures—unsupported Testbox environment forwarding and an oversized shell argument—executed zero product cells. The first entered measurement completed with unchanged assertions and caps; its task worktree and lease were closed. The initial review returned no findings but failed to write its report because the output directory was missing; the same frozen inputs subsequently produced the complete managed review result.
