### PR TITLE
fix: keep attachment code controls after refresh

### DIFF
--- a/docs/web/control-ui/chat.md
+++ b/docs/web/control-ui/chat.md
@@ -226,11 +226,14 @@ an explanation in chat.
 ### Source previews and copying code
 
 Select **Open** on a text attachment to read it directly in the **Files** side
-panel. Same-origin text attachments, including pasted `.txt` files, Markdown,
-CSV, and JSON, display as selectable, read-only text with line breaks and
-indentation preserved. HTML and other markup remain literal text, never an
-embedded page. Previews require UTF-8 content no larger than 256 KiB; unsupported,
-external, oversized, or unavailable files keep their **Download** action.
+panel. Plain-text attachments, including pasted `.txt` files, CSV, and JSON,
+preserve line breaks and indentation. Markdown attachments render as documents
+with interactive code blocks. When an open attachment refreshes with unchanged
+text, its code blocks keep your expansion and wrapping choices after loading.
+A different attachment or changed text starts with fresh controls. HTML and
+other markup remain literal text, never an embedded page. Same-origin previews
+require UTF-8 content no larger than 256 KiB; unsupported, external, oversized,
+or unavailable files keep their **Download** action.
 
 **View Raw Text** keeps Markdown notation literal, including nested code fences.
 Decoded text artifacts use the same literal preview. **Copy code** preserves the

--- a/ui/src/pages/chat/components/chat-text-attachment.browser.test.ts
+++ b/ui/src/pages/chat/components/chat-text-attachment.browser.test.ts
@@ -13,59 +13,172 @@ afterEach(() => {
 });
 
 describe.runIf("__vitest_browser__" in globalThis)("Markdown attachment controls", () => {
-  it("initializes overflow and disclosure after a deferred body without a parent render", async () => {
-    const response = createDeferred<Response>();
-    const fetchMock = vi.fn<typeof fetch>().mockReturnValue(response.promise);
-    vi.stubGlobal("fetch", fetchMock);
-    const container = document.createElement("div");
-    container.className = "side-panel__panel";
-    container.style.cssText = "display:flex;width:480px;height:600px;";
-    const panel = document.createElement("openclaw-chat-detail-panel") as HTMLElement & {
-      content: SidebarContent;
-      updateComplete: Promise<unknown>;
-    };
-    panel.className = "chat-sidebar";
-    panel.content = {
-      kind: "attachment",
-      title: "notes.md",
-      mimeType: "text/markdown",
-      src: "/notes.md",
-    };
-    container.append(panel);
-    document.body.append(container);
-    await panel.updateComplete;
-    await expect.poll(() => fetchMock.mock.calls.length).toBe(1);
-    expect(panel.querySelector(".code-block-wrapper")).toBeNull();
+  it.each(["transport", "identity", "contents", "failed refresh", "oversized metadata"] as const)(
+    "initializes deferred controls and refreshes the attachment %s",
+    async (change) => {
+      const observed = new Map<ResizeObserver, Set<Element>>();
+      const NativeResizeObserver = ResizeObserver;
+      vi.stubGlobal(
+        "ResizeObserver",
+        class extends NativeResizeObserver {
+          override observe(target: Element, options?: ResizeObserverOptions) {
+            const targets = observed.get(this) ?? new Set<Element>();
+            targets.add(target);
+            observed.set(this, targets);
+            super.observe(target, options);
+          }
+          override unobserve(target: Element) {
+            observed.get(this)?.delete(target);
+            super.unobserve(target);
+          }
+          override disconnect() {
+            observed.get(this)?.clear();
+            super.disconnect();
+          }
+        },
+      );
+      const isObserved = (target: Element) =>
+        [...observed.values()].some((targets) => targets.has(target));
+      const response = createDeferred<Response>();
+      const refreshed = createDeferred<Response>();
+      const recovered = createDeferred<Response>();
+      const fetchMock = vi
+        .fn<typeof fetch>()
+        .mockReturnValueOnce(response.promise)
+        .mockReturnValueOnce(refreshed.promise)
+        .mockReturnValueOnce(recovered.promise);
+      vi.stubGlobal("fetch", fetchMock);
+      let source = "/notes.md";
+      let requestSourceUpdate: (() => void) | undefined;
+      const container = document.createElement("div");
+      container.className = "side-panel__panel";
+      container.style.cssText = "display:flex;width:480px;height:600px;";
+      const panel = document.createElement("openclaw-chat-detail-panel") as HTMLElement & {
+        content: SidebarContent;
+        updateComplete: Promise<unknown>;
+      };
+      panel.className = "chat-sidebar";
+      panel.content = {
+        kind: "attachment",
+        title: "notes.md",
+        mimeType: "text/markdown",
+        sourceIdentity: "attachment:notes",
+        resolveSource: (requestUpdate) => {
+          requestSourceUpdate = requestUpdate;
+          return { status: "ready", src: source };
+        },
+      };
+      container.append(panel);
+      document.body.append(container);
+      await panel.updateComplete;
+      await expect.poll(() => fetchMock.mock.calls.length).toBe(1);
+      expect(panel.querySelector(".code-block-wrapper")).toBeNull();
 
-    const text = [
-      "```ts",
-      `const longLine = "${"notes ".repeat(80)}";`,
-      ...Array(20).fill("// another line"),
-      "```",
-    ].join("\n");
-    response.resolve(new Response(text));
-    await expect
-      .poll(() => panel.querySelector(".code-block-wrapper.has-horizontal-overflow"))
-      .not.toBeNull();
-    const viewport = expectDefined(
-      panel.querySelector<HTMLElement>(".code-block-viewport"),
-      "Code viewport",
-    );
-    const expand = expectDefined(
-      panel.querySelector<HTMLButtonElement>(".code-block-expand"),
-      "Expand control",
-    );
-    const wrap = expectDefined(
-      panel.querySelector<HTMLButtonElement>(".code-block-wrap"),
-      "Wrap control",
-    );
-    expect(viewport.id).not.toBe("");
-    expect(expand.getAttribute("aria-controls")).toBe(viewport.id);
-    expand.click();
-    expect(expand.getAttribute("aria-expanded")).toBe("true");
-    expect(getComputedStyle(wrap).display).not.toBe("none");
-    wrap.click();
-    expect(wrap.getAttribute("aria-pressed")).toBe("true");
-    expect(panel.querySelector(".code-block-wrapper.is-wrapped")).not.toBeNull();
-  });
+      const text = [
+        "```ts",
+        `const longLine = "${"notes ".repeat(80)}";`,
+        ...Array(20).fill("// another line"),
+        "```",
+      ].join("\n");
+      response.resolve(new Response(text));
+      await expect
+        .poll(() => panel.querySelector(".code-block-wrapper.has-horizontal-overflow"))
+        .not.toBeNull();
+      const viewport = expectDefined(
+        panel.querySelector<HTMLElement>(".code-block-viewport"),
+        "Code viewport",
+      );
+      const expand = expectDefined(
+        panel.querySelector<HTMLButtonElement>(".code-block-expand"),
+        "Expand control",
+      );
+      const wrap = expectDefined(
+        panel.querySelector<HTMLButtonElement>(".code-block-wrap"),
+        "Wrap control",
+      );
+      expect(viewport.id).not.toBe("");
+      expect(expand.getAttribute("aria-controls")).toBe(viewport.id);
+      expand.click();
+      expect(expand.getAttribute("aria-expanded")).toBe("true");
+      expect(getComputedStyle(wrap).display).not.toBe("none");
+      wrap.click();
+      expect(wrap.getAttribute("aria-pressed")).toBe("true");
+      expect(panel.querySelector(".code-block-wrapper.is-wrapped")).not.toBeNull();
+
+      const reader = expectDefined(panel.querySelector("article"), "Loaded reader");
+      let observedViewport = viewport;
+      const nextText = change === "contents" ? text.replace("longLine", "updatedLine") : text;
+      try {
+        if (change === "oversized metadata") {
+          panel.content = { ...panel.content, sizeBytes: 256 * 1024 + 1 };
+          await expect.poll(() => panel.textContent).toContain("Download it to read the full file");
+          expect(fetchMock).toHaveBeenCalledOnce();
+          expect(reader.checkVisibility()).toBe(false);
+          expect(isObserved(viewport)).toBe(false);
+          panel.content = { ...panel.content, sizeBytes: undefined };
+        } else {
+          source = "/refreshed-notes.md";
+          if (change === "identity") {
+            panel.content = { ...panel.content, sourceIdentity: "attachment:other-notes" };
+          }
+          expectDefined(requestSourceUpdate, "Source update callback")();
+        }
+        await expect.poll(() => fetchMock.mock.calls.length).toBe(2);
+        await expect.poll(() => reader.checkVisibility()).toBe(false);
+        expect(isObserved(viewport)).toBe(false);
+        expect(panel.querySelector('[role="status"]')).not.toBeNull();
+
+        if (change === "failed refresh") {
+          refreshed.resolve(new Response("Temporarily unavailable", { status: 503 }));
+          await expect.poll(() => panel.textContent).toContain("Download it to read the full file");
+          expect(reader.checkVisibility()).toBe(false);
+          expect(isObserved(viewport)).toBe(false);
+          source = "/retried-notes.md";
+          expectDefined(requestSourceUpdate, "Source update callback")();
+          await expect.poll(() => fetchMock.mock.calls.length).toBe(3);
+          recovered.resolve(new Response(nextText));
+        } else {
+          refreshed.resolve(new Response(nextText));
+        }
+        await expect.poll(() => panel.querySelector("article")).not.toBeNull();
+        const nextReader = expectDefined(panel.querySelector("article"), "Refreshed reader");
+        const retained = change === "transport";
+        const nextExpand = expectDefined(
+          nextReader.querySelector<HTMLButtonElement>(".code-block-expand"),
+          "Refreshed expand control",
+        );
+        const nextWrap = expectDefined(
+          nextReader.querySelector<HTMLButtonElement>(".code-block-wrap"),
+          "Refreshed wrap control",
+        );
+        expect(nextExpand.getAttribute("aria-expanded")).toBe(String(retained));
+        expect(nextWrap.getAttribute("aria-pressed")).toBe(String(retained));
+        expect(
+          nextReader.querySelector(".code-block-wrapper")?.classList.contains("is-expanded"),
+        ).toBe(retained);
+        expect(
+          nextReader.querySelector(".code-block-wrapper")?.classList.contains("is-wrapped"),
+        ).toBe(retained);
+        const nextViewport = expectDefined(
+          nextReader.querySelector<HTMLElement>(".code-block-viewport"),
+          "Refreshed code viewport",
+        );
+        observedViewport = nextViewport;
+        await expect.poll(() => isObserved(nextViewport)).toBe(true);
+        await expect.poll(() => nextViewport.id).not.toBe("");
+        expect(nextExpand.getAttribute("aria-controls")).toBe(nextViewport.id);
+        expect(nextReader.querySelector("code")?.textContent).toContain(
+          change === "contents" ? "updatedLine" : "longLine",
+        );
+        nextExpand.click();
+        nextWrap.click();
+        expect(nextWrap.getAttribute("aria-pressed")).toBe(String(!retained));
+      } finally {
+        refreshed.resolve(new Response(nextText));
+        recovered.resolve(new Response(nextText));
+        container.remove();
+        expect(isObserved(observedViewport)).toBe(false);
+      }
+    },
+  );
 });

--- a/ui/src/pages/chat/components/chat-text-attachment.test.ts
+++ b/ui/src/pages/chat/components/chat-text-attachment.test.ts
@@ -200,34 +200,38 @@ it("shows a download fallback for an unavailable response", async () => {
   expect(panel.querySelector("pre")).toBeNull();
 });
 
-it("aborts a superseded read and never displays its late contents", async () => {
-  let resolveOld!: (response: Response) => void;
-  const fetchMock = vi
-    .fn<typeof fetch>()
-    .mockImplementationOnce(
-      () =>
-        new Promise((resolve) => {
-          resolveOld = resolve;
-        }),
-    )
-    .mockResolvedValueOnce(new Response("Current file"));
-  vi.stubGlobal("fetch", fetchMock);
-  const panel = await mountAttachment();
-  await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledOnce());
-  const signal = fetchMock.mock.calls[0]?.[1]?.signal;
-  panel.content = {
-    kind: "attachment",
-    title: "next.txt",
-    src: "/next.txt",
-    mimeType: "text/plain",
-  };
-  await vi.waitFor(() => expect(panel.querySelector("pre")?.textContent).toBe("Current file"));
-  expect(signal?.aborted).toBe(true);
-  resolveOld(new Response("Old file"));
-  await vi.waitFor(() => expect(fetchMock.mock.settledResults[0]?.type).toBe("fulfilled"));
-  await panel.querySelector("openclaw-chat-text-attachment")?.updateComplete;
-  expect(panel.querySelector("pre")?.textContent).toBe("Current file");
-});
+it.each(["same", "different"])(
+  "aborts a superseded read for the %s identity and never displays its late contents",
+  async (identity) => {
+    let resolveOld!: (response: Response) => void;
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveOld = resolve;
+          }),
+      )
+      .mockResolvedValueOnce(new Response("Current file"));
+    vi.stubGlobal("fetch", fetchMock);
+    const panel = await mountAttachment({ sourceIdentity: "attachment:notes" });
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledOnce());
+    const signal = fetchMock.mock.calls[0]?.[1]?.signal;
+    panel.content = {
+      kind: "attachment",
+      title: "next.txt",
+      src: "/next.txt",
+      mimeType: "text/plain",
+      sourceIdentity: identity === "same" ? "attachment:notes" : "attachment:next",
+    };
+    await vi.waitFor(() => expect(panel.querySelector("pre")?.textContent).toBe("Current file"));
+    expect(signal?.aborted).toBe(true);
+    resolveOld(new Response("Old file"));
+    await vi.waitFor(() => expect(fetchMock.mock.settledResults[0]?.type).toBe("fulfilled"));
+    await panel.querySelector("openclaw-chat-text-attachment")?.updateComplete;
+    expect(panel.querySelector("pre")?.textContent).toBe("Current file");
+  },
+);
 
 it("aborts a closed preview and reloads it after remount", async () => {
   const fetchMock = vi

--- a/ui/src/pages/chat/components/chat-text-attachment.ts
+++ b/ui/src/pages/chat/components/chat-text-attachment.ts
@@ -1,5 +1,7 @@
 import { html, type PropertyValues } from "lit";
 import { property, state } from "lit/decorators.js";
+import { cache } from "lit/directives/cache.js";
+import { keyed } from "lit/directives/keyed.js";
 import { unsafeHTML } from "lit/directives/unsafe-html.js";
 import { markdownBlocks } from "../../../components/markdown-blocks.ts";
 import { toSanitizedMarkdownHtml } from "../../../components/markdown.ts";
@@ -121,6 +123,39 @@ class ChatTextAttachment extends OpenClawLightDomContentsElement {
       mimeType === "text/markdown" ||
       mimeType === "text/x-markdown" ||
       /\.(?:md|markdown)$/i.test(this.label);
+    // Cache detaches the reader before identity or validated-text changes replace it.
+    const reader =
+      this.text === null
+        ? renderAttachmentPreviewSkeleton()
+        : html`${keyed(
+            this.sourceIdentity || this.loadVersion,
+            html`${keyed(
+              this.text,
+              markdown
+                ? html`<article
+                    class="sidebar-attachment-preview__markdown sidebar-markdown-reader sidebar-markdown"
+                    dir=${detectTextDirection(this.text)}
+                    aria-label=${this.label}
+                    ${markdownBlocks()}
+                  >
+                    ${unsafeHTML(
+                      toSanitizedMarkdownHtml(this.text, {
+                        // The fetch already bounds document size; do not apply chat-message
+                        // truncation or let an attachment load remote tracking images.
+                        mode: "document",
+                        remoteImages: false,
+                        codeBlockInteraction: "interactive",
+                      }),
+                    )}
+                  </article>`
+                : html`<pre
+                    class="sidebar-attachment-preview__text"
+                    tabindex="0"
+                    aria-label=${this.label}
+                  >
+${this.text}</pre>`,
+            )}`,
+          )}`;
     return html`
       ${renderCompactAttachmentCard({
         kind: "document",
@@ -133,31 +168,7 @@ class ChatTextAttachment extends OpenClawLightDomContentsElement {
       ${
         this.failed
           ? html`<p class="muted" role="status">${t("chat.attachments.textPreviewUnavailable")}</p>`
-          : this.text === null
-            ? renderAttachmentPreviewSkeleton()
-            : markdown
-              ? html`<article
-                  class="sidebar-attachment-preview__markdown sidebar-markdown-reader sidebar-markdown"
-                  dir=${detectTextDirection(this.text)}
-                  aria-label=${this.label}
-                  ${markdownBlocks()}
-                >
-                  ${unsafeHTML(
-                    toSanitizedMarkdownHtml(this.text, {
-                      // The fetch already bounds document size; do not apply chat-message
-                      // truncation or let an attachment load remote tracking images.
-                      mode: "document",
-                      remoteImages: false,
-                      codeBlockInteraction: "interactive",
-                    }),
-                  )}
-                </article>`
-              : html`<pre
-                  class="sidebar-attachment-preview__text"
-                  tabindex="0"
-                  aria-label=${this.label}
-                >
-${this.text}</pre>`
+          : cache(reader)
       }
     `;
   }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users reading a Markdown attachment in the Files panel would lose their code-block expansion and wrapping choices when the attachment's download URL refreshed, even if its contents stayed identical.

## Why This Change Was Made

The reader now uses Lit's existing template cache while a refreshed body loads. The attachment identity and validated text determine whether to reuse the reader or replace it. Fetching, cancellation, size limits, and failure handling retain their existing owner; no additional presentation-state store is introduced. The source-preview documentation now reflects Markdown document rendering and the retained controls.

## User Impact

An unchanged attachment returns with the same expanded and wrapped code blocks after loading. A different attachment or changed text starts with fresh controls. Pending and unavailable previews stay hidden, and restored controls reacquire their resize observers.

## Evidence

- The browser regression fails on the original reader because an identical refresh resets Expand.
- 23 focused tests pass: five Chromium cases plus 18 cancellation and Markdown lifecycle cases. They cover transport refresh, identity/content replacement, failed-refresh recovery, metadata rejection, and observer cleanup.
- The complete changed-file checks and a fresh Control UI build pass.
- Independent review completed both passes with no actionable findings through P2.

Synthetic before/after captures use the actual Files detail-panel renderer. The UI bundle was built separately from the source-served browser proof. An initial after-capture module startup failed before reaching the scenario; the later diagnostic capture completed all interaction checks. No live Gateway or provider was used.

| Before: identical refresh resets the reader | After: expansion and wrapping remain |
| --- | --- |
| ![Identical attachment refresh resets expanded and wrapped code](https://github.com/user-attachments/assets/a7f4bbc2-c2e2-40c6-8642-0268f858e85e) | ![Identical attachment refresh preserves expanded and wrapped code](https://github.com/user-attachments/assets/74f09b15-3146-498a-8e2c-a81034b325e6) |
