### PR TITLE
fix(openai): correct spoken-update guidance for public GPT-Live

### DIFF
--- a/docs/providers/openai/voice-and-speech.md
+++ b/docs/providers/openai/voice-and-speech.md
@@ -251,7 +251,12 @@ sidebarTitle: "Voice and speech"
     The public API uses `/v1/live/sessions` for WebRTC creation and primary
     WebSockets. Direct sockets start with `session.start`; browser sessions
     start during the SDP exchange. A Gateway sideband handles delegated work
-    while browser media stays on WebRTC. Public transcript events are fragments,
+    while browser media stays on WebRTC. Public Live instructions describe
+    `session.thinking.append` as quiet context and `session.commentary.append`
+    as spoken updates. Custom instructions should preserve that distinction;
+    the Codex route uses its separate commentary/speakable channel contract.
+
+    Public transcript events are fragments,
     not completed turns. The Gateway owns persistence of bounded received-text
     snapshots; clients display captions without saving another copy. Both live
     captions and saved snapshots can span several exchanges by the same speaker;

--- a/extensions/openai/realtime-quicksilver-instructions.ts
+++ b/extensions/openai/realtime-quicksilver-instructions.ts
@@ -1,7 +1,10 @@
+import { isOpenAIGptLiveApiModel } from "./realtime-quicksilver.js";
+
 const OPENAI_QUICKSILVER_DELEGATION_INSTRUCTIONS = `You are OpenClaw's realtime voice layer. You have no tools of your own.
 Delegate any request that requires real work, reasoning, current information, or actions to the client through a delegation.
-Keep the conversation natural while delegated work runs.
-Context on the commentary channel is silent background. You may use it, but never read it aloud.
+Keep the conversation natural while delegated work runs.`;
+
+const OPENAI_QUICKSILVER_CHANNEL_INSTRUCTIONS = `Context on the commentary channel is silent background. You may use it, but never read it aloud.
 Context on the speakable channel is your answer to deliver naturally in your own words. Never mention the channel or the delegation.`;
 
 export const OPENAI_QUICKSILVER_HOST_CONTROL_INSTRUCTIONS = `Delegate status, cancellation, redirects, and follow-up requests to the client using the caller's request, even while another delegation is active.
@@ -35,11 +38,18 @@ ${records}
   return "";
 }
 
-export function buildOpenAIQuicksilverInstructions(operatorInstructions?: string): string {
+export function buildOpenAIQuicksilverInstructions(
+  model: string,
+  operatorInstructions?: string,
+): string {
+  const channels = isOpenAIGptLiveApiModel(model)
+    ? `Information in session.thinking.append is silent context. Use it when relevant, but do not read it aloud merely because it arrives.
+Information in session.commentary.append is an update to speak aloud naturally. A backend result is not a new user request; do not delegate it.
+Instructions in session.instructions.append direct the live session. Follow those directions without reading them aloud as content. Never mention the channel or the delegation.`
+    : OPENAI_QUICKSILVER_CHANNEL_INSTRUCTIONS;
+  const instructions = `${OPENAI_QUICKSILVER_DELEGATION_INSTRUCTIONS}\n${channels}`;
   const operator = operatorInstructions?.trim();
-  return operator
-    ? `${OPENAI_QUICKSILVER_DELEGATION_INSTRUCTIONS}\n\n${operator}`
-    : OPENAI_QUICKSILVER_DELEGATION_INSTRUCTIONS;
+  return operator ? `${instructions}\n\n${operator}` : instructions;
 }
 
 function escapeXmlText(value: string): string {

--- a/extensions/openai/realtime-voice-provider-factory.ts
+++ b/extensions/openai/realtime-voice-provider-factory.ts
@@ -222,7 +222,7 @@ async function createOpenAIRealtimeBrowserSession(
     const quicksilverRequest = {
       ...req,
       model,
-      instructions: buildOpenAIQuicksilverInstructions(req.instructions),
+      instructions: buildOpenAIQuicksilverInstructions(model, req.instructions),
       voice: req.voice ?? config.voice,
     };
     const auth = await resolveOpenAIQuicksilverBridgeAuth(
@@ -464,7 +464,7 @@ export function buildOpenAIRealtimeVoiceProvider(
               ...req,
               model,
               voice: config.voice,
-              instructions: buildOpenAIQuicksilverInstructions(req.instructions),
+              instructions: buildOpenAIQuicksilverInstructions(model, req.instructions),
               logger: options?.logger ?? { debug: () => undefined, warn: () => undefined },
               resolveAuth: () =>
                 resolveOpenAIQuicksilverBridgeAuth(
@@ -485,7 +485,7 @@ export function buildOpenAIRealtimeVoiceProvider(
             ...req,
             model,
             voice: config.voice,
-            instructions: buildOpenAIQuicksilverInstructions(req.instructions),
+            instructions: buildOpenAIQuicksilverInstructions(model, req.instructions),
             logger: options?.logger ?? { warn: () => undefined },
             resolveAuth: async () => ({
               type: "api-key",

--- a/extensions/openai/realtime-voice-provider-routing.test.ts
+++ b/extensions/openai/realtime-voice-provider-routing.test.ts
@@ -805,45 +805,63 @@ describe("OpenAI realtime voice provider routing", () => {
     expect(createBrowserSession).toHaveBeenCalledTimes(1);
   });
 
-  it("passes configured gpt-live model and voice to the native broker", async () => {
-    const { broker, createBrowserSession } = createQuicksilverBrowserBrokerFixture();
-    const provider = buildOpenAIRealtimeVoiceProvider({
-      quicksilverBrowserSessionBroker: broker,
-    });
+  it.each([
+    { model: "gpt-live-test-canary", voice: "spruce", publicApi: false },
+    { model: "gpt-live-1", voice: "marin", publicApi: true },
+  ])(
+    "passes $model voice and channel instructions to the native broker",
+    async ({ model, voice, publicApi }) => {
+      const { broker, createBrowserSession } = createQuicksilverBrowserBrokerFixture();
+      const provider = buildOpenAIRealtimeVoiceProvider({
+        quicksilverBrowserSessionBroker: broker,
+      });
 
-    await provider.createBrowserSession?.({
-      providerConfig: provider.resolveConfig?.({
-        cfg: {} as never,
-        rawConfig: {
-          apiKey: "test-api-key-platform",
-          model: "gpt-live-test-canary",
-          speakerVoice: "spruce",
-        },
-      }),
-      instructions: "Always address the caller as Captain.",
-      agentId: "voice-agent",
-      workspaceDir: "/tmp/openclaw-agent-workspace",
-      initialItems: [],
-      runAgentConsult: vi.fn(async () => ({ text: "Done" })),
-    } as never);
+      await provider.createBrowserSession?.({
+        providerConfig: provider.resolveConfig?.({
+          cfg: {} as never,
+          rawConfig: {
+            apiKey: "test-api-key-platform",
+            model,
+            speakerVoice: voice,
+          },
+        }),
+        instructions: "Always address the caller as Captain.",
+        agentId: "voice-agent",
+        workspaceDir: "/tmp/openclaw-agent-workspace",
+        initialItems: [],
+        runAgentConsult: vi.fn(async () => ({ text: "Done" })),
+      } as never);
 
-    expect(createBrowserSession).toHaveBeenCalledWith(
-      expect.objectContaining({ model: "gpt-live-test-canary", voice: "spruce" }),
-      { type: "api-key", token: "test-api-key-platform" },
-    );
-    const quicksilverRequest = requireRecord(
-      createBrowserSession.mock.calls[0]?.[0],
-      "quicksilver request",
-    );
-    expect(quicksilverRequest.instructions).toMatch(/^You are OpenClaw's realtime voice layer\./);
-    expect(quicksilverRequest.instructions).toContain(
-      "Context on the commentary channel is silent background",
-    );
-    expect(quicksilverRequest.instructions).toContain(
-      "Context on the speakable channel is your answer",
-    );
-    expect(quicksilverRequest.instructions).toMatch(/Always address the caller as Captain\.$/);
-  });
+      expect(createBrowserSession).toHaveBeenCalledWith(expect.objectContaining({ model, voice }), {
+        type: "api-key",
+        token: "test-api-key-platform",
+      });
+      const quicksilverRequest = requireRecord(
+        createBrowserSession.mock.calls[0]?.[0],
+        "quicksilver request",
+      );
+      expect(quicksilverRequest.instructions).toMatch(/^You are OpenClaw's realtime voice layer\./);
+      if (publicApi) {
+        expect(quicksilverRequest.instructions).toContain(
+          "session.thinking.append is silent context",
+        );
+        expect(quicksilverRequest.instructions).toContain(
+          "session.commentary.append is an update to speak aloud",
+        );
+        expect(quicksilverRequest.instructions).not.toContain(
+          "commentary channel is silent background",
+        );
+      } else {
+        expect(quicksilverRequest.instructions).toContain(
+          "Context on the commentary channel is silent background",
+        );
+        expect(quicksilverRequest.instructions).toContain(
+          "Context on the speakable channel is your answer",
+        );
+      }
+      expect(quicksilverRequest.instructions).toMatch(/Always address the caller as Captain\.$/);
+    },
+  );
 
   it.each([
     { configuredModel: "gpt-live-test-canary", requestedModel: "gpt-realtime-2.1", voice: "marin" },


### PR DESCRIPTION
Related: #145382, #145599

## What Problem This Solves

Resolves a problem where public GPT-Live voice sessions were instructed to keep backend updates silent even when the public API marks those updates for speech. Public Live gives commentary a different meaning from the ChatGPT subscription route.

## Why This Change Was Made

Select the startup instructions from the effective model in browser, Gateway, and direct voice creation. For public Live, thinking updates provide quiet context, commentary updates provide spoken content, and instruction updates direct the session, matching [OpenAI's Live delegation contract](https://developers.openai.com/api/docs/guides/live-delegation#send-the-right-kind-of-update).

The existing subscription prompt bytes, appended operator instructions, and host receipt/control behavior are preserved. The existing browser routing test covers both channel contracts, and the provider documentation explains the distinction for custom instructions.

## User Impact

Public GPT-Live voice sessions receive startup guidance that agrees with the public API's quiet and spoken update channels. The subscription route keeps its existing channel behavior.

Intermittent provider answer omissions remain a separate observation whose cause has not been established.

## Evidence

- The public browser routing regression failed on the old prompt for the intended assertion: 54 cases passed and the new public case failed. After the correction, all 94 routing, public-delegation, and wire tests passed.
- The complete selected changed-file checks passed without skips, including formatting, extension production/test types, declaration-boundary lint, doctor contracts, dead exports, owner guards, and runtime import-cycle checks.
- Managed isolated review through P2 is scoped-clean. The original non-public base prompt remains byte-identical (483 UTF-8 bytes), and all three production instruction-builder callers pass the effective selected model.
- Live relay checks on committed candidate `447501ffbd10`: 19 of 20 cases passed, including all ten public Live cases and the public six-turn conversation. The remaining subscription six-turn case received an incomplete second input transcript; the backend correctly asked for clarification. That diagnostic remains open. No late audio, captions, consultations, or writes were observed in the 20 relay records.
- A real Chromium WebRTC harness passed all four browser transport cases. Independent transcription of voiced output segments confirmed the expected public and subscription answer markers. These harnesses use real provider transports with synthetic backend replies; they do not claim Control UI or full agent-inference coverage.
- Independent audio verification passed 21 of 22 candidate checks, including intentional no-answer checks. The only retained failure is the subscription six-turn case above. Two older preflight checks are excluded from this candidate count.
- Required [CI 34684100007](https://github.com/openclaw/openclaw/actions/runs/34684100007) passed on `447501ffbd10`: 78 successful jobs, 16 skipped, zero failures.
- The initial hosted run failed four plugin model-override assertions outside this diff. The unchanged single file, paired files, and full 34-file child group all passed locally; the single actual hosted repeat passed all eight override cases on the identical merge snapshot. The first failure remains unexplained. GitHub's job-rerun request created no jobs and ended in a startup failure, so the supported close/reopen recovery attached the successful workflow. No source, isolation, assertion, or timeout change was made.
