### PR TITLE
perf(infra): skip route probes for a single LAN address

### DIFF
--- a/src/infra/advertised-lan-host.ts
+++ b/src/infra/advertised-lan-host.ts
@@ -14,12 +14,6 @@ const WINDOWS_DEFAULT_ROUTE_COMMAND =
   "[Console]::OutputEncoding=[Text.UTF8Encoding]::new($false); Get-NetRoute -AddressFamily IPv4 -DestinationPrefix '0.0.0.0/0' | " +
   "Select-Object -Property InterfaceAlias,RouteMetric,InterfaceMetric | ConvertTo-Json -Compress";
 
-type AdvertisedLanHostCandidate = {
-  interfaceName: string;
-  address: string;
-  order: number;
-};
-
 type AdvertisedLanRouteHint = {
   interfaceName: string;
 };
@@ -65,42 +59,6 @@ function normalizeMetric(value: unknown): number {
     return Number.isFinite(parsed) ? parsed : 0;
   }
   return 0;
-}
-
-function listAdvertisedLanHostCandidates(
-  snapshot: NetworkInterfacesSnapshot | undefined,
-): AdvertisedLanHostCandidate[] {
-  return listExternalInterfaceAddresses(snapshot, "IPv4")
-    .filter((entry) => isRfc1918Ipv4Address(entry.address))
-    .map((entry, order) => ({
-      interfaceName: entry.name,
-      address: entry.address,
-      order,
-    }));
-}
-
-function selectAdvertisedLanHost(
-  candidates: AdvertisedLanHostCandidate[],
-  routeHints: AdvertisedLanRouteHint[] = [],
-): string | null {
-  if (candidates.length === 0) {
-    return null;
-  }
-
-  for (const hint of routeHints) {
-    const hintedName = normalizeInterfaceName(hint.interfaceName);
-    if (!hintedName) {
-      continue;
-    }
-    const routed = candidates.find(
-      (candidate) => normalizeInterfaceName(candidate.interfaceName) === hintedName,
-    );
-    if (routed) {
-      return routed.address;
-    }
-  }
-
-  return candidates[0]?.address ?? null;
 }
 
 function parseWindowsDefaultRouteHints(stdout: string): AdvertisedLanRouteHint[] {
@@ -215,11 +173,12 @@ async function resolveDefaultRouteHints(params: {
 export async function resolveAdvertisedLanHostCore(
   options: ResolveAdvertisedLanHostOptions = {},
 ): Promise<string | null> {
-  const candidates = listAdvertisedLanHostCandidates(
+  const candidates = listExternalInterfaceAddresses(
     safeNetworkInterfaces(options.networkInterfaces),
-  );
-  if (candidates.length === 0) {
-    return null;
+    "IPv4",
+  ).filter((entry) => isRfc1918Ipv4Address(entry.address));
+  if (candidates.length <= 1) {
+    return candidates[0]?.address ?? null;
   }
 
   const routeHints = await resolveDefaultRouteHints({
@@ -227,5 +186,18 @@ export async function resolveAdvertisedLanHostCore(
     runCommandWithTimeout: options.runCommandWithTimeout ?? defaultRunCommandWithTimeout,
     timeoutMs: options.timeoutMs ?? DEFAULT_ROUTE_HINT_TIMEOUT_MS,
   });
-  return selectAdvertisedLanHost(candidates, routeHints);
+  for (const hint of routeHints) {
+    const hintedName = normalizeInterfaceName(hint.interfaceName);
+    if (!hintedName) {
+      continue;
+    }
+    const routed = candidates.find(
+      (candidate) => normalizeInterfaceName(candidate.name) === hintedName,
+    );
+    if (routed) {
+      return routed.address;
+    }
+  }
+
+  return candidates[0]?.address ?? null;
 }

--- a/src/pairing/setup-code.test.ts
+++ b/src/pairing/setup-code.test.ts
@@ -740,7 +740,7 @@ describe("pairing setup code", () => {
     });
   });
 
-  it("allows lan bind cleartext setup urls for mobile pairing", async () => {
+  it("allows LAN cleartext pairing without route probing for a single address", async () => {
     const runCommandWithTimeout = createNoRouteRunner();
     await expectResolvedSetupSuccessCase({
       config: {
@@ -760,7 +760,7 @@ describe("pairing setup code", () => {
         ...limitedPlaintextAccess,
       },
       runCommandWithTimeout,
-      expectedRunCommandCalls: 1,
+      expectedRunCommandCalls: 0,
     });
   });
 
@@ -827,7 +827,10 @@ describe("pairing setup code", () => {
         },
       } satisfies ResolveSetupConfig,
       options: {
-        networkInterfaces: () => createIpv4NetworkInterfaces("192.168.139.3"),
+        networkInterfaces: () => ({
+          ...createIpv4NetworkInterfaces("192.168.139.3"),
+          bridge100: createIpv4NetworkInterfaces("10.37.129.4").en0,
+        }),
         runCommandWithTimeout,
       } satisfies ResolveSetupOptions,
       expected: {


### PR DESCRIPTION
Closes #145811

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

LAN pairing starts a platform route probe even when only one eligible private IPv4 address exists and the probe cannot change the selected address.

## Why This Change Was Made

The LAN resolver now returns that sole address directly from the existing normalized interface entries, removing the candidate copy and private selection wrappers. Multiple-address selection retains route hints, metric ties, aliases, Unicode handling and fallbacks.

## User Impact

Single-address lookups avoid unnecessary subprocess work while keeping a fresh interface read on every call. Pairing URL/auth/limited-access payloads, public signatures and SDK behavior remain unchanged. The change removes 28 net production lines and adds three net lines to existing tests.

## Evidence

Against baseline `0cccc6d68e58ccd5030cd09931c1753bca924c7b`, each version passed 64 tests; one existing native Windows-only case remained skipped on Darwin. The updated singleton pairing test failed against the original owner because it performed one unnecessary probe. The source-bound P2 review and full selected changed gate passed.

The actual pairing resolver produced ten identical complete result/code rows using synthetic interface snapshots and bootstrap data. Both versions made 42 fresh interface reads. Native child starts fell 40→4 overall and 32→0 across the 32-call singleton workload. The canonical process runner used real Node children producing synthetic route output, with unchanged platform argv, 3,000 ms timeout and 16,384-byte output bounds checked.

This is operation-count proof on Darwin, not a measurement of latency, allocation bytes or RSS. It used no real interface inventory or platform route command, and native Windows execution remains unrun locally.
