### PR TITLE
refactor(cli): remove retired container runtime envelopes

### DIFF
--- a/src/cli/container-target.ts
+++ b/src/cli/container-target.ts
@@ -24,11 +24,8 @@ type ContainerTargetDeps = {
   stdoutIsTTY: boolean;
 };
 
-type ContainerRuntimeExec = {
-  runtime: "podman" | "docker";
-  command: string;
-  argsPrefix: string[];
-};
+const CONTAINER_RUNTIMES = ["podman", "docker"] as const;
+type ContainerRuntime = (typeof CONTAINER_RUNTIMES)[number];
 
 const CONTAINER_ALLOW_LOOPBACK_PROXY_URL_ENV = "OPENCLAW_CONTAINER_ALLOW_LOOPBACK_PROXY_URL";
 const CONTAINER_RUNTIME_PROBE_TIMEOUT_MS = 10_000;
@@ -68,70 +65,43 @@ export function resolveCliContainerTarget(
 }
 
 function isContainerRunning(params: {
-  exec: ContainerRuntimeExec;
+  runtime: ContainerRuntime;
   containerName: string;
   deps: Pick<ContainerTargetDeps, "spawnSync">;
 }): boolean {
   const result = params.deps.spawnSync(
-    params.exec.command,
-    [...params.exec.argsPrefix, "inspect", "--format", "{{.State.Running}}", params.containerName],
-    params.exec.command === "sudo"
-      ? {
-          encoding: "utf8",
-          killSignal: "SIGKILL",
-          stdio: ["inherit", "pipe", "inherit"],
-          timeout: CONTAINER_RUNTIME_PROBE_TIMEOUT_MS,
-        }
-      : {
-          encoding: "utf8",
-          killSignal: "SIGKILL",
-          timeout: CONTAINER_RUNTIME_PROBE_TIMEOUT_MS,
-        },
+    params.runtime,
+    ["inspect", "--format", "{{.State.Running}}", params.containerName],
+    {
+      encoding: "utf8",
+      killSignal: "SIGKILL",
+      timeout: CONTAINER_RUNTIME_PROBE_TIMEOUT_MS,
+    },
   );
   return result.status === 0 && result.stdout.trim() === "true";
 }
 
-function candidateContainerRuntimes(): ContainerRuntimeExec[] {
-  return [
-    {
-      runtime: "podman",
-      command: "podman",
-      argsPrefix: [],
-    },
-    {
-      runtime: "docker",
-      command: "docker",
-      argsPrefix: [],
-    },
-  ];
-}
-
 function resolveRunningContainer(params: {
   containerName: string;
-  env: NodeJS.ProcessEnv;
   deps: Pick<ContainerTargetDeps, "spawnSync">;
-}): (ContainerRuntimeExec & { containerName: string }) | null {
-  const matches: Array<ContainerRuntimeExec & { containerName: string }> = [];
-  const candidates = candidateContainerRuntimes();
-  for (const exec of candidates) {
+}): ContainerRuntime | null {
+  const matches: ContainerRuntime[] = [];
+  for (const runtime of CONTAINER_RUNTIMES) {
     if (
       isContainerRunning({
-        exec,
+        runtime,
         containerName: params.containerName,
         deps: params.deps,
       })
     ) {
-      matches.push({ ...exec, containerName: params.containerName });
-      if (exec.runtime === "docker") {
-        break;
-      }
+      matches.push(runtime);
     }
   }
   if (matches.length === 0) {
     return null;
   }
   if (matches.length > 1) {
-    const runtimes = matches.map((match) => match.runtime).join(", ");
+    const runtimes = matches.join(", ");
     throw new Error(
       `Container "${params.containerName}" is running under multiple runtimes (${runtimes}); use a unique container name.`,
     );
@@ -140,7 +110,7 @@ function resolveRunningContainer(params: {
 }
 
 function buildContainerExecArgs(params: {
-  exec: ContainerRuntimeExec;
+  runtime: ContainerRuntime;
   containerName: string;
   argv: string[];
   env: NodeJS.ProcessEnv;
@@ -148,7 +118,7 @@ function buildContainerExecArgs(params: {
   stdoutIsTTY: boolean;
 }): string[] {
   // Preserve proxy env only after loopback validation; localhost would point inside the container.
-  const envFlag = params.exec.runtime === "docker" ? "-e" : "--env";
+  const envFlag = params.runtime === "docker" ? "-e" : "--env";
   const proxyUrl = normalizeOptionalString(params.env.OPENCLAW_PROXY_URL);
   if (proxyUrl) {
     assertContainerProxyUrlIsReachable(proxyUrl, params.env);
@@ -156,7 +126,6 @@ function buildContainerExecArgs(params: {
   const proxyEnvArgs = proxyUrl ? [envFlag, `OPENCLAW_PROXY_URL=${proxyUrl}`] : [];
   const interactiveFlags = ["-i", ...(params.stdinIsTTY && params.stdoutIsTTY ? ["-t"] : [])];
   return [
-    ...params.exec.argsPrefix,
     "exec",
     ...interactiveFlags,
     envFlag,
@@ -298,7 +267,6 @@ export function maybeRunCliInContainer(
 
   const runningContainer = resolveRunningContainer({
     containerName,
-    env: resolvedDeps.env,
     deps: resolvedDeps,
   });
   if (!runningContainer) {
@@ -306,10 +274,10 @@ export function maybeRunCliInContainer(
   }
 
   const result = resolvedDeps.spawnSync(
-    runningContainer.command,
+    runningContainer,
     buildContainerExecArgs({
-      exec: runningContainer,
-      containerName: runningContainer.containerName,
+      runtime: runningContainer,
+      containerName,
       argv: parsed.argv.slice(2),
       env: resolvedDeps.env,
       stdinIsTTY: resolvedDeps.stdinIsTTY,


### PR DESCRIPTION
Closes #145813

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Maintaining container-targeted CLI execution requires following runtime state that the CLI no longer produces. This cleanup simplifies that path without changing which container runtime is selected or how commands execute.

## Why This Change Was Made

After retirement of the sudo/service-user producer, the private runtime choice is always Podman or Docker. Carry that value directly through both existing bounded inspect probes and command construction, removing redundant command/prefix and result wrappers.

Podman-before-Docker ordering, ambiguity rejection, missing-container errors, probe timeouts, terminal flags, runtime-specific environment flags, proxy validation/redaction, environment scrubbing and exit/signal handling are preserved. Existing container update-command rejection and root-option behavior are unchanged.

## User Impact

Container selection and execution behave as before. The change removes 32 net production lines and leaves tests unchanged, with no public API, configuration, schema, dependency or persistence change. Subprocess counts are unchanged; no timing, allocation-byte or memory improvement is claimed.

## Evidence

Against baseline `0cccc6d68e58ccd5030cd09931c1753bca924c7b`, the same 37 container-target tests pass on the original and candidate versions. Eleven synthetic native cases per version produce identical recorded semantics, including command arguments and error/exit behavior. Each version records 25 invocations and 24 native subprocess starts.

The full selected changed gate and independent P2 review pass. No standalone build was selected. The native fixture was removed and all owned proof processes finished. This proof uses synthetic executables; no real container inventory or live container execution is claimed.

Related: [#139290](https://github.com/openclaw/openclaw/pull/139290) reuses a shared assertion helper in the unchanged test file. It is complementary to this production-only cleanup; its independent test change should be preserved if it lands.
