### PR TITLE
improve(plugins): speed up diagnostic-heavy registry inspection

### DIFF
--- a/src/plugins/plugin-registry-comparison.ts
+++ b/src/plugins/plugin-registry-comparison.ts
@@ -119,6 +119,23 @@ export function diffPluginRegistryRecords(
   // whole registry stale. Reporting a narrower comparison would hide the owning plugin.
   const persistedPlugins = new Map(persisted.plugins.map((plugin) => [plugin.pluginId, plugin]));
   const derivedPlugins = new Map(derived.plugins.map((plugin) => [plugin.pluginId, plugin]));
+  const groupDiagnostics = (index: InstalledPluginIndex) => {
+    const groups = new Map<
+      string | undefined,
+      Array<InstalledPluginIndex["diagnostics"][number]>
+    >();
+    index.diagnostics.forEach((diagnostic) => {
+      const group = groups.get(diagnostic.pluginId);
+      if (group) {
+        group.push(diagnostic);
+      } else {
+        groups.set(diagnostic.pluginId, [diagnostic]);
+      }
+    });
+    return groups;
+  };
+  const persistedDiagnostics = groupDiagnostics(persisted);
+  const derivedDiagnostics = groupDiagnostics(derived);
   const pluginIds = new Set([
     ...persistedPlugins.keys(),
     ...derivedPlugins.keys(),
@@ -152,8 +169,8 @@ export function diffPluginRegistryRecords(
         ["install", persisted.installRecords[pluginId], derived.installRecords[pluginId]],
         [
           "diagnostics",
-          persisted.diagnostics.filter((diagnostic) => diagnostic.pluginId === pluginId),
-          derived.diagnostics.filter((diagnostic) => diagnostic.pluginId === pluginId),
+          persistedDiagnostics.get(pluginId) ?? [],
+          derivedDiagnostics.get(pluginId) ?? [],
         ],
       ];
       const changed = facets


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

This branch is in the main repository.

</details>

## What Problem This Solves

Operators inspecting a stale plugin registry with many diagnostics pay repeated diagnostic-array traversal for every plugin. This makes large diagnostic-heavy inspections slower even though the output only needs each plugin's ordered diagnostic subsequence.

## Why This Change Was Made

Group each side once by exact plugin ID and reuse the original ordered diagnostic objects for attribution. This keeps the existing ID union, exclusions, locale ordering, record/install comparisons, facet order and source reporting. Both complete registry-content comparisons still own freshness. There is no persistent/global cache, schema or activation change. The final production diff is +17 lines, including three formatter-only type-layout lines.

## User Impact

Large ordered diagnostic inventories complete inspection faster in the measured cases, with unchanged diagnostics, ordering, freshness decisions and persisted state. Small-case performance is mixed; this is not a general startup improvement.

## Evidence

### Measured scope and adverse results

One native Linux B1/C1/C2/B2 comparison called actual `inspectPluginRegistry` at base `c8cba01d790d073bdc2b23fa3d4f91ae9c384609`, with Node 24.19.0, controlled synthetic manifests/environment and a SQLite handle opened during fixture preparation. All 40 case-phase outputs and four direct controls per phase agreed. The 36 persisted row envelopes and four absent-row controls were unchanged before/after inspection. Seven measured samples per case/phase and all warmups/adverse samples were retained.

| Case | First pair median wall | Second pair median wall |
| --- | --- | --- |
| 128 plugins, diagnostic-heavy | 23.110 → 21.744 ms (−5.9%) | 22.703 → 19.600 ms (−13.7%) |
| 256 plugins, diagnostic-heavy | 51.261 → 46.587 ms (−9.1%) | 52.959 → 42.183 ms (−20.3%) |
| 16 plugins, diagnostic-heavy | 3.535 → 3.557 ms (+0.6%) | 3.739 → 3.498 ms (−6.4%) |

The small diagnostic case's CPU medians increased 6.0%/3.3%. Fresh-16 CPU increased 12.8%/7.7%, and reverse-128 was effectively neutral on first-pair wall time. Whole-probe maximum RSS increased 0.12%/1.39%. These results support a scoped improvement for large ordered diagnostic arrays, not cold CLI/Gateway startup or a universal speedup.

The comparison owner and selected tests are unchanged at author base `32fc009394c2824515625bc635781adc1a9e62f9`. Snapshot caller, lifecycle/dependency and worker-declaration changes on main mean the historical timings are not current-head performance measurements. Formatting changed only erased type-argument whitespace.

### Current author validation

- Fresh managed Codex P2 review passed both complete-context passes with no actionable findings.
- Darwin/Node 26.8.1, independent frozen pnpm 12.3.4 install: matching formatting and diff checks, ten existing registry inspection assertions and two existing missing-disabled snapshot assertions passed.
- Twenty-four smaller checks selected by the real changed-check plan passed individually under the existing native resource limits; the already completed formatter check was reused.
- Broad `tsgo:core`, `tsgo:core:test` and type-aware lint remain pending hosted exact-head CI under the maintainer's capacity decision. They were not weakened, relabeled as passed or repeatedly run into the known local heap limit.

The initial current-base Testbox validation could not start because the provider's workflow lookup returned HTTP 429. Its original failure and pending recovery record are retained; no payload/test ran and no provider retry occurred. Local Darwin validation above is distinct from the successful historical Linux measurement. All local validation children/monitors closed and the source stayed unchanged.

No new permanent implementation-mirroring test was added. Update markers, persistence/revisions, migration, recovery warnings and rollback behavior remain unchanged. No installed-updater or live Gateway proof is claimed by this inspection change.
