### PR TITLE
improve(agents): reduce work for large network tool results

### DIFF
--- a/src/agents/tool-search-control-result.ts
+++ b/src/agents/tool-search-control-result.ts
@@ -13,9 +13,12 @@ export function renderToolSearchControlText(text: string, networkContent: boolea
   if (!networkContent) {
     return { text, truncated: false };
   }
-  const bounded = truncateSanitizedExternalContent(text, 20_000);
-  const modelText = bounded.truncated
-    ? `${truncateSanitizedExternalContent(text, 19_988).text}\n[truncated]`
-    : bounded.text;
-  return { text: wrapExternalContent(modelText, { source: "api" }), truncated: bounded.truncated };
+  const bounded =
+    text.length <= 20_000 ? truncateSanitizedExternalContent(text, 20_000) : undefined;
+  const truncated = bounded?.truncated ?? true;
+  const modelText =
+    !bounded || bounded.truncated
+      ? `${truncateSanitizedExternalContent(text, 19_988).text}\n[truncated]`
+      : bounded.text;
+  return { text: wrapExternalContent(modelText, { source: "api" }), truncated };
 }


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

The branch is in the upstream repository; repository maintainers retain normal edit access.

</details>

## What Problem This Solves

Large network-derived Tool Search results and Code Mode outputs spend extra CPU on result delivery and context-budget fitting, especially when the output exceeds the control-text limit.

## Why This Change Was Made

Skip the first preparation only when the original string exceeds 20,000 UTF-16 code units. Its result must report truncation and is discarded by the existing caller. The existing 19,988-unit preparation, suffix, final sanitization, warning, API wrapper, and generated markers remain unchanged. Shorter strings retain the original path, including sanitizer expansion. No new cache or public surface is added.

## User Impact

Less result-processing work for larger network-derived outputs, with identical returned text and structured data. Prompt/history bytes, terminal behavior, execution authority, and error handling are unchanged. Gains are scoped; small and ordinary cases do not uniformly improve.

## Evidence

Current author-base validation (`e6a3bdf79ea05649f755663b68bf0ce2b6aa2b19`):

- 201 assertions passed, none skipped or filtered: Tool Search runtime 73, Code Mode JSON 23, result-budget dispatch 20, external content 85.
- Formatting and all 24 selected smaller guards passed. All 31 native commands and monitors closed; peak tree RSS was 4.33 GiB within the 6 GiB limit.
- Managed Codex review: scoped-clean through P2.
- Pending hosted gates: `tsgo:core`, `tsgo:core:test`, and the selected type-aware oxlint check. These were deliberately not repeated locally under the known capacity limit.

Historical Linux proof on `f35d894ba5351278ce88a328d8753e6f9057a446` used the real `tool_call.execute` entry point and `CodeModeOutputState`, with synthetic target results. Two untimed parity phases preceded B/C/C/B timing: two warmups and seven measured invocations per case, 23 cases plus 13 boundary controls. Full comparison passed for 874 returned entry graphs and 26 boundary graphs; an independent rerun produced byte-identical comparison output. Untimed entropy sequences matched exactly. Timed runs retained raw results and verified generated-marker relationships without global text stripping. All native processes closed, the temporary checkout was removed, and the Testbox was stopped. [Native run](https://github.com/openclaw/openclaw/actions/runs/34681423292).

Larger Unicode tool results improved 11-39% in both orders, above-limit expansion improved 35-37%, and several Code Mode projections improved 7-27%. Adverse evidence is retained: the 128 Ki ASCII tool case changed from -13.8% to +22.1% wall time by order; the small projection used 42 to 55 microseconds of CPU in both orders (+13 microseconds). Measured-phase tree RSS increased 1.24% / 0.77%. Local controls also improved roughly 5-14%, so small-case movement is not attributed to this change.

These are historical bounded result-processing measurements, not a current-head or end-to-end Gateway/model latency claim. The current change differs only in formatting; the later supporting-runtime change affects search ranking, outside the measured call/format path. No retiming occurred. The source-discovered pre-abort fixture correction, pre-lease forwarding failure, and supplemental Python Unicode-offset error remain preserved alongside the successful evidence.

<details>
<summary>All historical paired wall/CPU controls</summary>

Sizes refer to payload UTF-16 code units; serialized UTF-8 sizes were recorded separately. Negative percentages mean lower cost. Both orders and every control are retained.

| Case | Wall forward / reverse | CPU forward / reverse |
|---|---:|---:|
| tool-network-ascii-4k | -9.59% / -6.73% | -11.55% / +1.55% |
| tool-network-ascii-32k | -13.80% / -12.29% | -18.73% / -32.34% |
| tool-network-ascii-128k | -13.83% / +22.08% | -13.72% / +24.74% |
| tool-network-unicode-4k | -7.19% / -9.28% | -8.37% / -9.56% |
| tool-network-unicode-32k | -38.96% / -28.17% | -36.96% / -28.50% |
| tool-network-unicode-128k | -23.72% / -11.05% | -23.73% / -9.95% |
| tool-local-4k | -14.38% / -6.86% | -14.37% / -6.49% |
| tool-local-32k | -8.04% / -3.84% | -7.45% / -3.72% |
| tool-local-128k | -5.17% / -5.47% | -5.10% / -5.52% |
| tool-network-expansion-below | -3.89% / +3.06% | -4.07% / +5.15% |
| tool-network-expansion-above | -36.83% / -35.35% | -36.71% / -35.22% |
| tool-network-terminal | -11.25% / -11.89% | -11.69% / -12.18% |
| tool-network-structured-error | -13.97% / -12.57% | -13.88% / -12.70% |
| tool-abort | -2.75% / -6.81% | -4.55% / -6.67% |
| tool-preflight-rejection | -4.47% / +1.60% | -5.39% / +0.61% |
| tool-closed-catalog | -5.72% / +1.74% | -5.88% / +0.00% |
| projection-network-4k | -1.70% / +15.13% | +30.95% / +30.95% |
| projection-network-32k | -7.54% / -7.10% | -10.11% / -8.29% |
| projection-network-128k | +0.20% / -2.95% | -0.82% / -2.48% |
| projection-local-128k | -4.46% / -0.48% | -4.15% / -0.48% |
| projection-network-expansion | -22.87% / -19.13% | -23.94% / -22.25% |
| projection-network-error | -26.59% / -20.99% | -27.00% / -21.00% |
| projection-unfittable | -1.00% / +0.18% | -2.04% / -3.16% |

Per-sample RSS is a whole-process high-water mark, not allocation per call. Measured native phase tree peaks were B1 666.77, C1 675.07, C2 680.42, and B2 675.24 MiB, below the fixed 2 GiB measurement cap.

</details>
