### PR TITLE
fix(cron): keep a committed cadence edit on startup run replay

### DIFF
--- a/src/cron/service/run-recovery.test.ts
+++ b/src/cron/service/run-recovery.test.ts
@@ -17,6 +17,7 @@ import {
 } from "../store/run-receipt-store.js";
 import type { CronJob } from "../types.js";
 import { start, stop } from "./ops-lifecycle.js";
+import { update } from "./ops-mutations.js";
 import {
   proposeCronRunRecovery,
   recomputeUnownedCronSchedules,
@@ -303,6 +304,69 @@ describe("atomic cron run recovery", () => {
         enabled: true,
         state: { nextRunAtMs: historyRetryAtMs },
       });
+    } finally {
+      stop(recovered);
+    }
+  });
+
+  it("lets a committed cadence edit outrank the run history startup replays", async () => {
+    const { storePath } = await makeStorePath();
+    const startedAtMs = Date.parse("2026-09-12T13:00:00.000Z");
+    const endedAtMs = startedAtMs + 1_000;
+    const editedAtMs = endedAtMs + 1_000;
+    const editedNextRunAtMs = editedAtMs + 60_000;
+    const hourly = (id: string) => {
+      const job = makeJob(id, startedAtMs);
+      job.schedule = { kind: "every", everyMs: 3_600_000, anchorMs: startedAtMs };
+      job.state.nextRunAtMs = startedAtMs;
+      return job;
+    };
+    const jobs = [hourly("cadence-edit-during-run"), hourly("cadence-unchanged")];
+    await writeCronStoreSnapshot({ storePath, jobs });
+    const execution = makeState(storePath, endedAtMs);
+    for (const job of jobs) {
+      const taskRunId = tryCreateCronTaskRun({ state: execution, job, startedAt: startedAtMs });
+      expect(taskRunId).toBeDefined();
+      // Terminal history commits with the next hourly slot while the separate
+      // job-row write fails, leaving the running marker behind.
+      tryFinishCronTaskRun(execution, {
+        taskRunId,
+        job,
+        event: {
+          jobId: job.id,
+          action: "finished",
+          job,
+          status: "ok",
+          runAtMs: startedAtMs,
+          durationMs: endedAtMs - startedAtMs,
+          nextRunAtMs: startedAtMs + 3_600_000,
+        },
+      });
+    }
+    const editor = makeState(storePath, editedAtMs);
+    const edited = await update(editor, jobs[0]!.id, {
+      schedule: { kind: "every", everyMs: 60_000, anchorMs: editedAtMs },
+    });
+    expect(edited.schedule).toMatchObject({ kind: "every", everyMs: 60_000 });
+    expect(edited.state.nextRunAtMs).toBe(editedNextRunAtMs);
+    expect(edited.state.runningAtMs).toBe(startedAtMs);
+
+    const recovered = makeState(storePath, editedAtMs);
+    try {
+      await start(recovered);
+      const persisted = new Map(
+        (await loadCronStore(storePath)).jobs.map((job) => [job.id, job] as const),
+      );
+      const editedJob = persisted.get("cadence-edit-during-run");
+      expect(editedJob?.schedule).toMatchObject({ kind: "every", everyMs: 60_000 });
+      expect(editedJob?.enabled).toBe(true);
+      expect(editedJob?.state.nextRunAtMs).toBe(editedNextRunAtMs);
+      expect(editedJob?.state.runningAtMs).toBeUndefined();
+      expect(editedJob?.state.lastRunStatus).toBe("ok");
+      const untouched = persisted.get("cadence-unchanged");
+      expect(untouched?.state.nextRunAtMs).toBe(startedAtMs + 3_600_000);
+      expect(untouched?.state.runningAtMs).toBeUndefined();
+      expect(untouched?.state.lastRunStatus).toBe("ok");
     } finally {
       stop(recovered);
     }

--- a/src/cron/service/startup-run-repair.ts
+++ b/src/cron/service/startup-run-repair.ts
@@ -125,6 +125,15 @@ export function markInterruptedStartupRun(params: {
   };
 }
 
+/** True when the persisted row was re-authored after the replayed run was admitted. */
+function scheduleEditedAfterRun(job: CronJob, startedAt: number): boolean {
+  // `scheduleActivatedAtMs` is the durable stamp of a committed scheduling edit
+  // (schedule, enablement, pacing, trigger), so a newer one owns the cadence and
+  // next slot even when the run's own terminal row write was lost.
+  const activatedAtMs = asDateTimestampMs(job.state.scheduleActivatedAtMs);
+  return activatedAtMs !== undefined && activatedAtMs > startedAt;
+}
+
 export function restoreFinalizedStartupRun(params: {
   state: CronServiceState;
   job: CronJob;
@@ -151,8 +160,9 @@ export function restoreFinalizedStartupRun(params: {
   // Finalization writes history first, so a later one-shot slot or disable in
   // the job row owns lifecycle state when startup replays that older history.
   const scheduleOwnership =
-    job.schedule.kind === "at" &&
-    (!job.enabled || (persistedNextRunAtMs !== undefined && persistedNextRunAtMs > startedAt))
+    scheduleEditedAfterRun(job, startedAt) ||
+    (job.schedule.kind === "at" &&
+      (!job.enabled || (persistedNextRunAtMs !== undefined && persistedNextRunAtMs > startedAt)))
       ? "stale"
       : "current";
   // A once result can record no next run before a later edit retires its


### PR DESCRIPTION
## What Problem This Solves

A cron run can save its task history and still lose its scheduler-row write (for example: the payload succeeds, the terminal task/history commit lands, then the separate `cron_jobs` row update fails). The row keeps the pre-run schedule plus the `runningAtMs` marker.

Startup recovery then replays that finalized history over the row. For recurring schedules (`every` / `cron`) `restoreFinalizedStartupRun` treated the row as belonging to the run unconditionally, so it wrote the completed run's **old** next-run timestamp back (`replaySchedule: { nextRunAtMs: entry.nextRunAtMs }`, applied in `applyJobResult`). A schedule edit committed *after* the run — already acknowledged to the operator — was silently overwritten: the job kept the new cadence but resumed on the retired slot.

Reproduction from the report (hourly `every` job, run at 13:00:00, completion write aborted, `cron.update` to a one-minute cadence at 13:00:02):

| Observation | After acknowledged edit | After recovery (before the fix) |
| --- | --- | --- |
| `schedule.everyMs` | `60000` | `60000` |
| `enabled` | `true` | `true` |
| Next check, UTC | 13:01:02 (`1789218062000`) | 14:00:00 (`1789221600000`) |

**Root cause.** Recovery had no way to tell "this row is the run's own state" from "this row is a newer operator edit", so it defaulted to replaying history for every non-`at` schedule. The live finalization path makes that decision by comparing the admitted snapshot with the current row; recovery has no admitted snapshot, but the row carries the durable stamp that a committed scheduling edit writes.

**Fix** (`src/cron/service/startup-run-repair.ts`): the persisted row owns enablement, cadence, and the next slot when its `scheduleActivatedAtMs` stamp is newer than the replayed run's start — the same ownership rule used at runtime. Recovery still restores the run's history, clears the running marker, and settles the receipt; unchanged schedules keep recovering their recorded slot (the pre-existing `at` replacement check is untouched and now composes with the new one).

```ts
/** True when the persisted row was re-authored after the replayed run was admitted. */
function scheduleEditedAfterRun(job: CronJob, startedAt: number): boolean {
  // `scheduleActivatedAtMs` is the durable stamp of a committed scheduling edit
  // (schedule, enablement, pacing, trigger), so a newer one owns the cadence and
  // next slot even when the run's own terminal row write was lost.
  const activatedAtMs = asDateTimestampMs(job.state.scheduleActivatedAtMs);
  return activatedAtMs !== undefined && activatedAtMs > startedAt;
}
```

## Evidence

Regression test: `src/cron/service/run-recovery.test.ts` → "lets a committed cadence edit outrank the run history startup replays". It drives the real `CronService` path (store snapshot, task-ledger terminal commit, `cron.update`, `start()` recovery) against native SQLite, with two hourly `every` jobs: one edited to a one-minute cadence after its completed run, one left untouched.

Command:

```
node node_modules/vitest/vitest.mjs run src/cron/service/run-recovery.test.ts \
  --config test/vitest/vitest.cron.config.ts --maxWorkers=1 --no-file-parallelism -t "cadence"
```

Before the fix (red — reproduces the reported timestamps exactly):

```
FAIL  |cron| src/cron/service/run-recovery.test.ts > atomic cron run recovery > lets a committed cadence edit outrank the run history startup replays
AssertionError: expected 1789221600000 to be 1789218062000 // Object.is equality

- Expected
+ Received

- 1789218062000
+ 1789221600000

 ❯ src/cron/service/run-recovery.test.ts:363:44
    363|       expect(editedJob?.state.nextRunAtMs).toBe(editedNextRunAtMs);

 Test Files  1 failed (1)
      Tests  1 failed | 27 skipped (28)
```

After the fix (green):

```
 Test Files  1 passed (1)
      Tests  1 passed | 27 skipped (28)
```

The same run also asserts the unchanged job still recovers history's slot (`nextRunAtMs` = the completed run's next hourly slot), the running marker is cleared, and `lastRunStatus` is `ok` — history and receipt settlement are preserved, and no payload is executed during recovery.

Closes #145722

### Independent verification (parent)

Re-run in the same worktree with the source change reverted in the working tree only (the branch
still holds it), then restored:

```
# without the fix
FAIL  |cron| src/cron/service/run-recovery.test.ts > atomic cron run recovery > lets a committed cadence edit outrank the run history startup replays
AssertionError: expected 1789221600000 to be 1789218062000 // Object.is equality
 Test Files  1 failed (1)
      Tests  1 failed | 27 passed (28)

# with the fix
 Test Files  1 passed (1)
      Tests  28 passed (28)
```

Closes #145722
