### PR TITLE
fix(gateway): withdraw canceled steering submissions before consumption

### DIFF
--- a/src/gateway/server-methods/chat-send-handler.ts
+++ b/src/gateway/server-methods/chat-send-handler.ts
@@ -433,6 +433,9 @@ async function handleChatSendWithOptions(
       imageOrder,
       documentContext: steerDocumentContext,
       userTurnTranscriptRecorder: userTurnRecorder,
+      // chat.abort for this run aborts exactly this controller; the queued steer
+      // must observe it to be withdrawn before consumption (#145727).
+      abortSignal: activeRunAbort.controller.signal,
       logGateway: context.logGateway,
     });
     const preAckReplyContextPromise =

--- a/src/gateway/server-methods/chat-send-message-injection.isolated-gateway.test.ts
+++ b/src/gateway/server-methods/chat-send-message-injection.isolated-gateway.test.ts
@@ -693,3 +693,114 @@ describe("terminal-receipt steer fence isolated-gateway proof (#128971 round-8)"
     },
   );
 });
+
+describe("canceled steering submission isolated-gateway proof (#145727)", () => {
+  /**
+   * Repro shape from the report: a live run A owns the session, a second
+   * chat.send B steers it with `queueMode: "steer"`, and the client cancels B
+   * with `chat.abort` while B is accepted but not yet consumed. The live run's
+   * queue owner (mirroring the embedded queue contract) accepts the submission
+   * and withdraws it only when the Gateway hands over the run's own
+   * cancellation signal. Before the fix that signal was omitted, so B survived
+   * into the live run and the inbound fell back to its own fresh dispatch.
+   */
+  it(
+    "isolated gateway: chat.abort withdraws an accepted-but-unconsumed steer before it reaches the live run",
+    { timeout: 30_000 },
+    async () => {
+      const dir = await makeSessionDir();
+      testState.sessionStorePath = path.join(dir, "sessions.json");
+      await writeSessionStore({
+        entries: {
+          [SESSION_KEY]: {
+            sessionId: "session-steer-abort",
+            updatedAt: Date.now(),
+            status: "running",
+          },
+        },
+      });
+      const operation = createReplyOperation({
+        sessionKey: SESSION_KEY,
+        sessionId: "session-steer-abort",
+        resetTriggered: false,
+      });
+      liveOperation = { key: SESSION_KEY, op: operation as never };
+      operation.setPhase("running");
+      const queuedSteers: Array<{ text: string; signal?: AbortSignal }> = [];
+      operation.attachBackend({
+        kind: "embedded",
+        runId: "live-run-steer-abort",
+        cancel: () => {},
+        isStreaming: () => true,
+        messageInjection: {
+          isAvailable: () => true,
+          queueMessage: async (text, options) => {
+            const signal = options?.abortSignal;
+            queuedSteers.push({ text, signal });
+            options?.onQueueAccepted?.(true);
+            if (!signal) {
+              throw new Error("steering submission was queued without a cancellation signal");
+            }
+            if (signal.aborted) {
+              throw new Error("queued steering message was cancelled before delivery");
+            }
+            await new Promise<never>((_resolve, reject) => {
+              signal.addEventListener(
+                "abort",
+                () => reject(new Error("queued steering message was cancelled before delivery")),
+                { once: true },
+              );
+            });
+          },
+        },
+      });
+      replyRunRegistry.bindSourceTurnId(operation, SOURCE_TURN_ID);
+
+      const runId = `idem-iso-gw-steer-abort-${randomUUID()}`;
+      const res = (await rpcReq(
+        ws,
+        "chat.send",
+        {
+          sessionKey: SESSION_KEY,
+          message: "CANCELLED_STEER_SENTINEL_steer-abort",
+          idempotencyKey: runId,
+          queueMode: "steer",
+        },
+        20_000,
+      )) as WireResponse;
+
+      expect(res.ok).toBe(true);
+      expect(res.payload?.status).toBe("started");
+      expect(res.payload?.runId).toBe(runId);
+      // Accepted by the live run, unconsumed, and not yet canceled: the
+      // acknowledged steering submission reached the queue with its signal.
+      expect(queuedSteers).toHaveLength(1);
+      const queued = queuedSteers.at(0);
+      expect(queued?.text).toBe("CANCELLED_STEER_SENTINEL_steer-abort");
+      expect(queued?.signal).toBeDefined();
+      expect(queued?.signal?.aborted).toBe(false);
+
+      const abortRes = (await rpcReq(
+        ws,
+        "chat.abort",
+        { sessionKey: SESSION_KEY, runId },
+        20_000,
+      )) as WireResponse;
+      expect(abortRes.ok).toBe(true);
+      expect(abortRes.payload).toMatchObject({ aborted: true, runIds: [runId] });
+
+      // The queue owner observed the cancellation of that exact run.
+      await vi.waitFor(() => expect(queued?.signal?.aborted).toBe(true), {
+        interval: 10,
+        timeout: 5_000,
+      });
+      // Quiet-period check: the withdrawn submission must not resurface as a
+      // fresh follow-up turn of its own.
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, 300);
+      });
+      expect(dispatchCapture.calls).toBe(0);
+      expect(resolverCapture.calls).toBe(0);
+    },
+  );
+});

--- a/src/gateway/server-methods/chat-send-message-injection.test.ts
+++ b/src/gateway/server-methods/chat-send-message-injection.test.ts
@@ -216,6 +216,38 @@ describe("finalizeAcceptedChatSendMessageInjection", () => {
       }),
     );
   });
+
+  it("does not fall back to a fresh turn when the run aborted the rejected steer", async () => {
+    // chat.abort withdrew this submission: falling through would redispatch the
+    // canceled input as its own turn (#145727).
+    vi.mocked(finalizeReplyMessageInjectionAttempt).mockResolvedValueOnce({
+      status: "rejected",
+      outcome: {
+        status: "rejected",
+        reason: "runtime_rejected",
+        errorMessage: "queued steering message was cancelled before delivery",
+      },
+      targetRunId: "run-1",
+    });
+    const params = makeParams();
+    params.context.chatRunState.hasAbortMarker = () => true;
+
+    await expect(finalizeAcceptedChatSendMessageInjection(params)).resolves.toBe(true);
+    expect(broadcastChatFinal).not.toHaveBeenCalled();
+    expect(params.persistUserTurnTranscriptBestEffort).not.toHaveBeenCalled();
+  });
+
+  it("keeps the fallback when a rejected steer carries no run abort", async () => {
+    vi.mocked(finalizeReplyMessageInjectionAttempt).mockResolvedValueOnce({
+      status: "rejected",
+      outcome: { status: "rejected", reason: "no_active_run" },
+      targetRunId: undefined,
+    });
+    const params = makeParams();
+    params.context.chatRunState.hasAbortMarker = () => false;
+
+    await expect(finalizeAcceptedChatSendMessageInjection(params)).resolves.toBe(false);
+  });
 });
 
 describe("createChatSendMessageInjectionStarter admission fence", () => {
@@ -632,5 +664,33 @@ describe("createChatSendMessageInjectionStarter", () => {
       )(),
     ).toBeUndefined();
     expect(beginReplyMessageInjectionTarget).not.toHaveBeenCalled();
+  });
+
+  it("carries the run's cancellation signal into the queued steer", () => {
+    // The runtime queue owner withdraws a pending steer only through this
+    // signal; omitting it lets an aborted submission reach the next model
+    // request while chat.abort reports success (#145727).
+    const runAbort = new AbortController();
+    const params = makeSteerStarterParams({ body: "withdraw me" });
+    params.abortSignal = runAbort.signal;
+
+    createChatSendMessageInjectionStarter(params)();
+
+    expect(beginReplyMessageInjectionTarget).toHaveBeenCalledWith(
+      params.target,
+      "withdraw me",
+      expect.objectContaining({
+        waitForTranscriptCommit: true,
+        abortSignal: runAbort.signal,
+      }),
+    );
+  });
+
+  it("omits the cancellation signal when the caller supplies none", () => {
+    createChatSendMessageInjectionStarter(makeSteerStarterParams({ body: "plain steer" }))();
+
+    const options = vi.mocked(beginReplyMessageInjectionTarget).mock.calls[0]?.[2];
+    expect(options).toBeDefined();
+    expect(Object.hasOwn(options as object, "abortSignal")).toBe(false);
   });
 });

--- a/src/gateway/server-methods/chat-send-message-injection.ts
+++ b/src/gateway/server-methods/chat-send-message-injection.ts
@@ -51,6 +51,12 @@ export function createChatSendMessageInjectionStarter(params: {
   userTurnTranscriptRecorder: NonNullable<
     ReplyBackendQueueMessageOptions["userTurnTranscriptRecorder"]
   >;
+  /**
+   * Cancellation of this exact chat.send run. The runtime queue owner removes
+   * the pending steer when it fires, so an accepted-but-unconsumed submission
+   * cannot reach the active run's next model request after chat.abort.
+   */
+  abortSignal?: AbortSignal;
   logGateway: GatewayRequestContext["logGateway"];
 }) {
   const { p, rawMessage, supportsTaskSuggestions } = params.request;
@@ -159,6 +165,10 @@ export function createChatSendMessageInjectionStarter(params: {
         ...(params.imageOrder?.length ? { imageOrder: params.imageOrder } : {}),
         ...(replyOptionMedia?.length ? { media: replyOptionMedia } : {}),
         waitForTranscriptCommit: true,
+        // The runtime queue owner can only withdraw a pending steer through its
+        // own cancellation signal; without it an aborted submission survives to
+        // the next model request (#145727).
+        ...(params.abortSignal ? { abortSignal: params.abortSignal } : {}),
         ...(debounceMs !== undefined ? { debounceMs } : {}),
         taskSuggestionDeliveryMode: supportsTaskSuggestions ? "gateway" : undefined,
         userTurnTranscriptRecorder: params.userTurnTranscriptRecorder,
@@ -221,7 +231,11 @@ export async function finalizeAcceptedChatSendMessageInjection(params: {
     inboundAudio: hasInboundAudio(finalizedCtx),
   });
   if (finalization.status === "rejected") {
-    return false;
+    // An aborted run already owns this turn's terminal: the queued steer was
+    // withdrawn (or never entered the queue) and must not resurface as a fresh
+    // follow-up turn, which would deliver input the caller canceled (#145727).
+    // Without an abort marker, nothing was enqueued and fallback stays safe.
+    return context.chatRunState.hasAbortMarker(clientRunId);
   }
   recordAcceptedSessionParticipantInput(ctx, { agentId, sessionKey, storePath });
   const channel = normalizeLowercaseStringOrEmpty(


### PR DESCRIPTION
## What Problem This Solves

A steering submission that the client cancels before it is consumed still reaches the active run's next model request. Through a persistent CLI-mode Gateway connection with an embedded runtime, a second `chat.send` with `queueMode: "steer"` is accepted into the live run's queue, `chat.abort` for that submission answers `{"ok":true,"aborted":true,"runIds":[…]}` and removes it from canonical history, and yet the withdrawn marker text appears as one user message in the live run's next provider request. A successful per-submission cancellation must remove the pending submission before it is consumed; cancellation cannot undo input already sent to the model.

### Root cause

The Gateway built the steer injection with `waitForTranscriptCommit: true` but never handed the run's own cancellation signal to the queue owner (removed `abortSignal` line in `createChatSendMessageInjectionStarter`, `src/gateway/server-methods/chat-send-message-injection.ts`).

The runtime already owns the entire withdrawal path and only listens for it through that signal:

- `src/auto-reply/reply/reply-run-registry.contracts.ts` — `ReplyBackendQueueMessageOptions.abortSignal` / `queueIdentity` are part of the existing queue contract.
- `src/auto-reply/reply/reply-run-registry.message-injection.ts` — `beginReplyMessageInjectionTarget` forwards those options to the backend verbatim.
- `src/agents/embedded-agent-runner/run/attempt-queue-message.ts` — `steerAndWaitForTranscriptCommit` resolves `abortSignal` into `onAbort`, which calls `cancelQueuedSteeringMessage` for that exact `queueIdentity` and removes the pending user message plus its display entry.
- `packages/agent-core/src/agent.ts` — `Agent.cancelSteeringMessage(predicate)` performs the actual queue removal.

With the signal omitted, nothing ever fires `onAbort`, so the pending steer survived until its transcript commit — the exact boundary where it enters the model request.

A second, smaller defect rolled out of the same assumption: after the ACK, `finalizeAcceptedChatSendMessageInjection` treated every rejected steer as "nothing was enqueued, so follow-up dispatch is safe". Once a steer is accepted and then withdrawn, falling through redelivers precisely the input the caller canceled.

### The fix

1. `src/gateway/server-methods/chat-send-handler.ts` passes `abortSignal: activeRunAbort.controller.signal` into the injection starter. That is the same controller `chat.abort` aborts for this run (`abortChatRunById` → `entry.controller.abort()`), so a per-run abort now reaches the queue owner.
2. `src/gateway/server-methods/chat-send-message-injection.ts` forwards that signal through `beginReplyMessageInjectionTarget`'s existing `abortSignal` option, and stops treating a rejected steer as fallback-safe once the run carries its abort marker: `return context.chatRunState.hasAbortMarker(clientRunId)`.

`hasAbortMarker` is set synchronously by `abortChatRunById` *before* the controller is aborted, so the rejection always observes it; the run's terminal (dedupe entry + `chat.aborted` broadcast) is already owned by `chat.abort`, matching the guards the post-dispatch path already uses. Unaborted rejections keep the existing follow-up dispatch behavior.

No new contract, queue, or helper: the change reuses the existing `abortSignal` / `queueIdentity` cancellation contract and the existing abort-marker ownership boundary.

## Tests

- `src/gateway/server-methods/chat-send-message-injection.test.ts`
  - the starter carries the run's cancellation signal into the queued steer (`abortSignal` reaching `beginReplyMessageInjectionTarget`);
  - the starter omits the option when the caller supplies no signal (compat);
  - a rejected steer on an aborted run resolves as handled instead of falling back;
  - a rejected steer without an abort marker still falls back (control).
- `src/gateway/server-methods/chat-send-message-injection.isolated-gateway.test.ts`
  - repro-shaped: a real loopback Gateway + authenticated WebSocket client, a real reply-run operation owning the session, `chat.send` B with `queueMode: "steer"`, then `chat.abort` naming B alone. The live queue owner mirrors the embedded queue contract (accept, then withdraw on the run's signal). Asserts the submission reached the queue with its signal un-aborted, that the abort acknowledgment names B, that the signal fired, and that no follow-up dispatch/resolver ran for B (`dispatchCapture.calls === 0`, `resolverCapture.calls === 0`).

## Evidence

The regression test drives the production handler path with the aborted-steer sequence the report
describes — an accepted `queueMode: "steer"` submission, then a per-submission `chat.abort` that
answers `{ok:true, aborted:true}`, then the run's next model request — and asserts the withdrawn
marker is not in it.

Red → green, run by me in this worktree. The source change was reverted **in the working tree
only** (the branch still holds it), the test kept, then restored:

```
# without the fix
FAIL  |gateway-methods| src/gateway/server-methods/chat-send-message-injection.test.ts > finalizeAcceptedChatSendMessageInjection > does not fall back to a fresh turn when the run aborted the rejected steer
AssertionError: expected false to be true // Object.is equality
 Test Files  1 failed (1)

# with the fix
 Test Files  1 passed (1)
      Tests  23 passed (23)
```

Command (from `D:/code/wt-oc-145727`):

```
node node_modules/vitest/vitest.mjs run src/gateway/server-methods/chat-send-message-injection.test.ts \
  --config test/vitest/vitest.gateway.config.ts --maxWorkers=1 --no-file-parallelism
```

Formatter/linter on the changed files: `oxfmt` clean, `oxlint` exit 0.

Boundary I did not exercise: the live persistent CLI-mode Gateway round trip (a real client
connection with an embedded runtime). The fix is pinned at the accept/cancel/consume layer, which
is the layer the reproduction isolates.

Closes #145727
