### PR TITLE
test: use installed ws for worker fault injection

### DIFF
--- a/src/worker/worker-fault-injection.test-support.ts
+++ b/src/worker/worker-fault-injection.test-support.ts
@@ -4,7 +4,8 @@ import { createServer, type Server } from "node:http";
 import path from "node:path";
 import { rawDataToString } from "@openclaw/gateway-client/websocket-data";
 import { expectDefined } from "@openclaw/normalization-core";
-import { WebSocket, WebSocketServer, type RawData } from "ws";
+import { WebSocket, type RawData } from "ws";
+import { WebSocketServer } from "../../packages/gateway-client/src/websocket.test-support.js";
 import {
   type WorkerLiveEventParams,
   WORKER_PROTOCOL_FEATURES,

--- a/src/worker/worker.fault-injection.test.ts
+++ b/src/worker/worker.fault-injection.test.ts
@@ -100,7 +100,7 @@ describe("cloud worker milestone 2 fault injection", () => {
     ["success", "standalone", "credential", "completed", "stop"],
     ["success", "managed", "credential", "completed", "stop"],
   ] as const)(
-    "settles %s through the %s command with real EACCES deleting %s files",
+    "settles %s through the %s command with real permission failures deleting %s files",
     async (outcome, mode, deniedOwner, expectedStatus, stopReason) => {
       const skillDir = path.join(harness.root, "skills", "cleanup");
       await fs.mkdir(skillDir, { recursive: true });
@@ -221,7 +221,12 @@ describe("cloud worker milestone 2 fault injection", () => {
         );
         finishingGate.release.resolve();
         if (deniedOwner === "credential") {
-          await expect.soft(command).rejects.toMatchObject({ code: "EACCES" });
+          // Bun reports the containing directory's ENOTEMPTY until oven-sh/bun#42446 lands.
+          await expect.soft(command).rejects.toMatchObject({
+            code: process.versions.bun
+              ? expect.stringMatching(/^(?:EACCES|ENOTEMPTY)$/u)
+              : "EACCES",
+          });
         } else {
           await expect.soft(command).resolves.toBeUndefined();
         }
@@ -267,7 +272,7 @@ describe("cloud worker milestone 2 fault injection", () => {
           await expect.soft(fs.stat(hostsPath)).rejects.toMatchObject({ code: "ENOENT" });
           expect.soft(warning).toContain("Materialized skill cleanup failed");
           expect.soft(warning).toContain(turnDirectory);
-          expect.soft(warning).toContain("EACCES");
+          expect.soft(warning).toMatch(process.versions.bun ? /EACCES|ENOTEMPTY/u : /EACCES/u);
         } else {
           expect(await fs.readFile(hostsPath, "utf8")).toContain(
             descriptor.assignment.github.token,


### PR DESCRIPTION
## Problem

The direct-Bun source-unit lane stalled six worker fault-injection cases at connection admission. Bun substitutes its built-in `ws` server, whose sockets do not expose the installed `ws` receiver or its mutable payload limit. The harness therefore rejected its own connection through OpenClaw's fail-closed post-auth payload-limit guard.

The product Gateway already forces the installed `ws` implementation for this reason; the fault-injection harness had bypassed that adapter. Shipping Bun also reports `ENOTEMPTY` rather than Node's `EACCES` for the real recursive permission failures used by the matrix.

## Solution

Use the existing installed-`ws` test transport in the worker harness so it exercises the same mutable receiver contract as the Gateway. Keep Node's exact `EACCES` assertion and accept Bun's current `EACCES`/`ENOTEMPTY` variants until [oven-sh/bun#42446](https://github.com/oven-sh/bun/pull/42446) lands.

## Impact

This changes test infrastructure only. Product dependencies, installation behavior, and Gateway runtime behavior are unchanged.

## Evidence

- Before: direct custom Bun timed out at 120 seconds per worker fault-injection case after admission rejected the receiver.
- Shipping Bun 1.4.2: worker fault-injection matrix 15/15 after the adapter and temporary errno compatibility assertion.
- Patched custom Bun: worker fault-injection matrix 15/15.
- Node: worker fault-injection matrix 15/15.
- `node scripts/check-changed.mjs`
- P0-P2 autoreview: clean.
