### PR TITLE
fix(plugins): fail runtime builds for missing package manifests

### DIFF
--- a/scripts/lib/plugin-npm-package-manifest.mts
+++ b/scripts/lib/plugin-npm-package-manifest.mts
@@ -1112,8 +1112,10 @@ export function resolveAugmentedPluginNpmManifest(params: PluginPackageParams) {
   const pluginId =
     typeof manifest.id === "string" && manifest.id ? manifest.id : path.basename(packageDir);
   const generatedChannelConfigs = readGeneratedBundledChannelConfigs(repoRoot).get(pluginId);
+  // Manifest-only overlays have no package runtime to rewrite.
   const runtimePlan =
-    manifest.providerCatalogEntry || manifest.capabilityCatalogEntry
+    (manifest.providerCatalogEntry || manifest.capabilityCatalogEntry) &&
+    fs.existsSync(resolvePackageJsonPath(packageDir))
       ? resolvePluginNpmRuntimeBuildPlan({ repoRoot, packageDir })
       : null;
   const augmentedManifest = mergeGeneratedChannelConfigs(

--- a/scripts/lib/plugin-npm-runtime-build.mjs
+++ b/scripts/lib/plugin-npm-runtime-build.mjs
@@ -1,5 +1,6 @@
 import { runTsxCliShim } from "./tsx-cli-shim.mjs";
 
 await runTsxCliShim(import.meta.url, {
+  failureTool: "plugin-npm-runtime-build",
   implementation: "./plugin-npm-runtime-build.mts",
 });

--- a/scripts/lib/plugin-npm-runtime-build.mts
+++ b/scripts/lib/plugin-npm-runtime-build.mts
@@ -309,9 +309,6 @@ export function resolvePluginNpmRuntimeBuildPlan(params: PluginNpmRuntimeBuildPa
   const repoRoot = path.resolve(params.repoRoot ?? ".");
   const packageDir = resolvePackageDir(repoRoot, params.packageDir);
   const packageJsonPath = path.join(packageDir, "package.json");
-  if (!fs.existsSync(packageJsonPath)) {
-    return null;
-  }
   const packageJson = readJsonFile(packageJsonPath);
   const rootPackageJsonPath = path.join(repoRoot, "package.json");
   const rootPackageJson = fs.existsSync(rootPackageJsonPath)

--- a/test/plugin-npm-package-manifest.test.ts
+++ b/test/plugin-npm-package-manifest.test.ts
@@ -586,59 +586,67 @@ describe("plugin npm package manifest staging", () => {
     expect(generateCalls).toBe(1);
   });
 
-  it("overlays generated channel configs while packing and restores source manifest", () => {
-    const repoDir = makeTempRepoRoot(tempDirs, "openclaw-plugin-npm-package-manifest-");
-    const packageDir = join(repoDir, "extensions", "twitch");
-    mkdirSync(packageDir, { recursive: true });
-    const sourceManifest = {
-      id: "twitch",
-      channels: ["twitch"],
-      configSchema: {
-        type: "object",
-        additionalProperties: false,
-        properties: {},
-      },
-    };
-    writeJsonFile(join(packageDir, "openclaw.plugin.json"), sourceManifest);
-    writeGeneratedChannelMetadata(repoDir);
+  it.each([undefined, "providerCatalogEntry", "capabilityCatalogEntry"] as const)(
+    "overlays manifest-only channel configs and restores catalog metadata (%s)",
+    (catalogField) => {
+      const repoDir = makeTempRepoRoot(tempDirs, "openclaw-plugin-npm-package-manifest-");
+      const packageDir = join(repoDir, "extensions", "twitch");
+      mkdirSync(packageDir, { recursive: true });
+      const sourceManifest = {
+        id: "twitch",
+        ...(catalogField ? { [catalogField]: "./catalog.ts" } : {}),
+        channels: ["twitch"],
+        configSchema: {
+          type: "object",
+          additionalProperties: false,
+          properties: {},
+        },
+      };
+      writeJsonFile(join(packageDir, "openclaw.plugin.json"), sourceManifest);
+      writeGeneratedChannelMetadata(repoDir);
 
-    const resolved = resolveAugmentedPluginNpmManifest({
-      repoRoot: repoDir,
-      packageDir,
-    });
-    expect(resolved.changed).toBe(true);
-    expect(resolved.manifest).toEqual({
-      id: "twitch",
-      channels: ["twitch"],
-      configSchema: {
-        type: "object",
-        additionalProperties: false,
-        properties: {},
-      },
-      channelConfigs: {
-        twitch: {
-          description: "Twitch chat integration",
-          label: "Twitch",
-          schema: {
-            type: "object",
-            required: ["channelName"],
-            properties: {
-              channelName: { type: "string" },
+      const resolved = resolveAugmentedPluginNpmManifest({
+        repoRoot: repoDir,
+        packageDir,
+      });
+      expect(resolved.changed).toBe(true);
+      expect(resolved.manifest).toEqual({
+        ...sourceManifest,
+        channelConfigs: {
+          twitch: {
+            description: "Twitch chat integration",
+            label: "Twitch",
+            schema: {
+              type: "object",
+              required: ["channelName"],
+              properties: {
+                channelName: { type: "string" },
+              },
             },
           },
         },
-      },
-    });
+      });
 
-    const originalText = readFileSync(join(packageDir, "openclaw.plugin.json"), "utf8");
-    withAugmentedPluginNpmManifestForPackage({ repoRoot: repoDir, packageDir }, () => {
-      const stagedManifest = JSON.parse(
-        readFileSync(join(packageDir, "openclaw.plugin.json"), "utf8"),
+      const originalText = readFileSync(join(packageDir, "openclaw.plugin.json"), "utf8");
+      const result = withAugmentedPluginNpmManifestForPackage(
+        { repoRoot: repoDir, packageDir },
+        (context) => {
+          const stagedManifest = JSON.parse(
+            readFileSync(join(packageDir, "openclaw.plugin.json"), "utf8"),
+          );
+          expect(stagedManifest.channelConfigs.twitch.description).toBe("Twitch chat integration");
+          expect(context.packageJsonApplied).toBe(false);
+          if (catalogField) {
+            expect(stagedManifest[catalogField]).toBe("./catalog.ts");
+          }
+          return "overlay-ran";
+        },
       );
-      expect(stagedManifest.channelConfigs.twitch.description).toBe("Twitch chat integration");
-    });
-    expect(readFileSync(join(packageDir, "openclaw.plugin.json"), "utf8")).toBe(originalText);
-  });
+      expect(result).toBe("overlay-ran");
+      expect(existsSync(join(packageDir, "package.json"))).toBe(false);
+      expect(readFileSync(join(packageDir, "openclaw.plugin.json"), "utf8")).toBe(originalText);
+    },
+  );
 
   it("overlays package-local runtime metadata while packing and restores source package json", () => {
     const repoDir = makeTempRepoRoot(tempDirs, "openclaw-plugin-npm-package-runtime-");

--- a/test/plugin-npm-runtime-build.test.ts
+++ b/test/plugin-npm-runtime-build.test.ts
@@ -3,6 +3,7 @@ import {
   existsSync,
   mkdirSync,
   readFileSync,
+  readdirSync,
   readlinkSync,
   symlinkSync,
   writeFileSync,
@@ -41,6 +42,50 @@ function expectPluginNpmRuntimeBuildPlan(
 }
 
 describe("plugin npm runtime build planning", () => {
+  it.each([
+    "missing-directory",
+    "missing-manifest",
+    "malformed-manifest",
+    "no-extensions",
+    "javascript-only",
+  ])("reports selected package input without touching output (%s)", async (scenario) => {
+    const packageDir = path.join(tempDirs.make("openclaw-plugin-runtime-input-"), "selected");
+    const manifestPath = path.join(packageDir, "package.json");
+    const outDir = path.join(packageDir, "dist");
+    if (scenario !== "missing-directory") {
+      mkdirSync(outDir, { recursive: true });
+      writeFileSync(path.join(outDir, "sentinel.js"), "keep\n");
+    }
+    if (scenario === "malformed-manifest") {
+      writeFileSync(manifestPath, "{");
+    } else if (scenario === "no-extensions" || scenario === "javascript-only") {
+      writeFileSync(
+        manifestPath,
+        JSON.stringify({
+          name: "input-fixture",
+          version: "1.0.0",
+          ...(scenario === "javascript-only" ? { openclaw: { extensions: ["./index.js"] } } : {}),
+        }),
+      );
+      writeFileSync(path.join(packageDir, "index.js"), "export default {};\n");
+    }
+
+    const result = buildPluginNpmRuntime({ repoRoot, packageDir, logLevel: "silent" });
+    if (scenario === "missing-directory" || scenario === "missing-manifest") {
+      await expect(result).rejects.toMatchObject({ code: "ENOENT", path: manifestPath });
+    } else if (scenario === "malformed-manifest") {
+      await expect(result).rejects.toBeInstanceOf(SyntaxError);
+    } else {
+      await expect(result).resolves.toBeNull();
+    }
+    if (scenario === "missing-directory") {
+      expect(existsSync(packageDir)).toBe(false);
+    } else {
+      expect(readdirSync(outDir)).toEqual(["sentinel.js"]);
+      expect(readFileSync(path.join(outDir, "sentinel.js"), "utf8")).toBe("keep\n");
+    }
+  });
+
   it("builds a private worker without registering it as a plugin entry", async () => {
     const packageDir = tempDirs.make("openclaw-plugin-runtime-worker-");
     mkdirSync(path.join(packageDir, "src"));

--- a/test/scripts/check-plugin-npm-runtime-builds.test.ts
+++ b/test/scripts/check-plugin-npm-runtime-builds.test.ts
@@ -76,7 +76,10 @@ describe("plugin npm runtime build checks", () => {
         repoRoot,
         packageDirs: ["extensions/missing"],
       }),
-    ).rejects.toThrow("did not produce a package-local runtime build plan");
+    ).rejects.toMatchObject({
+      code: "ENOENT",
+      path: join(repoRoot, "extensions", "missing", "package.json"),
+    });
   });
 
   it("builds a ClawHub-only TypeScript package runtime", async () => {


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

This same-repository branch is editable by maintainers.

</details>

## What Problem This Solves

Fixes an issue where developers explicitly building a plugin runtime would get exit 0 and no output when the selected directory or its `package.json` did not exist. The requested build silently did nothing, while malformed manifests already failed.

## Why This Change Was Made

The runtime planner now reads its required package manifest through the existing native reader. Missing input fails before loading the compiler or deleting output. The optional manifest-overlay caller retains its existing no-package contract at its own boundary, alongside the existing optional package-overlay guard. The public JavaScript entrypoint uses the shim's existing failure footer.

This removes the misplaced absence branch without adding a second error handler or a fallback. Production/tooling is **+4/−4, net 0**; existing tests are **+104/−48, net +56**. The same invariant accounts for all three production changes.

## User Impact

A missing selected manifest produces a failing exit and an error naming the actual path. Valid packages with no TypeScript runtime continue to need no build; ordinary TypeScript builds and manifest-only catalog overlays retain their behavior. Package selection, dependency installation, publication policy, runtime format, configuration and storage are unchanged.

## Evidence

Tests and public-command proof were recorded on base `0eea7170b3f529d4d63af03e590e63c8c5ca18ef` plus the patch. The complete tested patch is byte-identical after moving onto `817b871416730fd7ad05cf0a98e029818e83bb1e`. Independent comparison found all 329 files in the local static import tree unchanged, along with the relevant package/lock/config inputs. One separately inspected generated-metadata change updates unrelated Discord help text; the proof fixtures have no matching generated row.

- Baseline: **3 intended failures and 9 passing controls** across missing input, optional metadata overlays and executable compiler/worker cases.
- Candidate: **77/77 tests passed**, covering runtime planning, native compilation, package checking and manifest staging.
- Full changed checks passed. Full `pnpm build` passed in **5m33s**.
- Fresh independent managed review on the final base found no actionable P0–P2 findings. Separate source/current-main/duplicate and raw before/after audits passed.

```sh
node scripts/run-vitest.mjs test/plugin-npm-runtime-build.test.ts test/plugin-npm-package-manifest.test.ts test/scripts/check-plugin-npm-runtime-builds.test.ts
node scripts/check-changed.mjs -- scripts/lib/plugin-npm-runtime-build.mts scripts/lib/plugin-npm-package-manifest.mts scripts/lib/plugin-npm-runtime-build.mjs test/plugin-npm-runtime-build.test.ts test/plugin-npm-package-manifest.test.ts test/scripts/check-plugin-npm-runtime-builds.test.ts
pnpm build
```

Nine public command/import cases ran in each phase using the real `.mjs` entrypoints, a genuine terminal stdin, separate stdout/stderr pipes, private synthetic fixtures and the checkout's own frozen dependencies:

| Case | Before | After |
|---|---|---|
| Missing directory | Exit 0, empty output | Exit 1, selected `package.json` ENOENT and final failure footer |
| Missing manifest | Exit 0, empty output | Same explicit failure; existing output preserved |
| Malformed manifest | Native JSON error, exit 1 | Same error and exit, plus final failure footer |
| No extensions / JavaScript-only | Exit 0, existing files preserved | Preserved |
| Tiny TypeScript runtime | Real generated output | Same executable output |
| Native generated import | Prints `42`, exit 0 | Preserved |
| Provider / capability manifest-only overlays | Original catalog metadata, no package manifest | Preserved |

Each phase also checked the actual Node executable and terminal stdin. All ten launched commands completed naturally with complete streams, absent owned groups, no observed escapes and no forced cleanup. Phases took approximately 8.3s and 7.7s. Independently rehashed raw controls compare fully after exact phase-path substitutions, measured compiler-duration digits and the one intentional malformed-error footer. Generated code differs only in its phase-path comment and imports successfully in both phases.

The public overlay controls establish the unchanged no-package catalog path. Actual generated-channel write/restoration is covered separately by the existing unit fixture, extended for both catalog fields. Tests initially triggered the repository wrapper's required 35.8s cold runtime preparation; that is recorded separately from the later full candidate build.

These are macOS/Node 24.20.0 terminal-input observations through the actual source-tooling entrypoint. They do not claim the non-TTY detached branch, other operating systems, a package installation, provider/Gateway behavior, or a fully hermetic loaded dependency closure. Named source/dependency identities, complete fixture inventories and observed native exits are retained; refreshed-base review and hosted CI are separate from original-base runtime/build evidence.
