### PR TITLE
fix: preserve code expansion and wrapping as replies stream

### DIFF
--- a/docs/web/control-ui/chat.md
+++ b/docs/web/control-ui/chat.md
@@ -238,6 +238,10 @@ code's leading whitespace and final newline when present. Indented Markdown code
 blocks also work at the start of a message and remain literal while streaming,
 including blank lines within the block.
 
+Completed top-level code blocks keep your expansion and wrapping choices while
+later paragraphs stream into the same assistant reply. Replacing the message or
+correcting earlier content starts a fresh view.
+
 **Copy URL** in browser tab cards also works on plain HTTP connections where the
 browser does not provide its Clipboard API.
 

--- a/ui/src/pages/chat/components/chat-message-markdown.test.ts
+++ b/ui/src/pages/chat/components/chat-message-markdown.test.ts
@@ -2,8 +2,9 @@
 // Contract for full-message eligibility: the Gateway marks every display-
 // capped projection; pending inputs share assistant expansion without gaining
 // transcript mutation actions.
-import { render } from "lit";
+import { html, nothing, render } from "lit";
 import { describe, expect, it, vi } from "vitest";
+import { markdownBlocks } from "../../../components/markdown-blocks.ts";
 import { handleMarkdownCodeBlockClick } from "../../../components/markdown-code-blocks.ts";
 import { extractText } from "../../../lib/chat/message-extract.ts";
 import { normalizeMessage } from "../../../lib/chat/message-normalizer.ts";
@@ -180,35 +181,118 @@ describe("user message disclosure", () => {
 });
 
 describe("streaming message Markdown", () => {
-  it("retains completed fence controls while the following paragraph streams", () => {
-    const container = document.createElement("div");
-    const prefix = "```ts\nconst answer = 42;\n```\n\n";
-    const renderTail = (tail: string) =>
+  it.each([
+    { stage: "following paragraph", tail: "The answer is ready.", isStreaming: true },
+    {
+      stage: "later paragraph",
+      tail: "The answer is ready.\n\nMore is arriving.",
+      isStreaming: true,
+    },
+    {
+      stage: "completed reply with its message owner retained",
+      tail: "The answer is ready.",
+      isStreaming: false,
+    },
+  ])("retains completed code choices in the $stage", async ({ tail, isStreaming }) => {
+    const container = document.body.appendChild(document.createElement("div"));
+    const code = Array.from({ length: 10 }, (_, index) => `const value${index} = ${index};`).join(
+      "\n",
+    );
+    const prefix = `\`\`\`ts\n${code}\n\`\`\`\n\n`;
+    const renderTail = (text: string, streaming: boolean) =>
       render(
-        renderMessageMarkdown(
-          prefix + tail,
-          "retained-fence",
-          { role: "assistant", isStreaming: true },
-          { codeBlockInteraction: "interactive" },
-        ),
+        html`<section ${markdownBlocks()} @click=${handleMarkdownCodeBlockClick}>
+          ${renderMessageMarkdown(
+            prefix + text,
+            "retained-fence",
+            { role: "assistant", isStreaming: streaming },
+            { codeBlockInteraction: "interactive", linkFavicons: !streaming },
+          )}
+        </section>`,
         container,
       );
-    container.addEventListener("click", handleMarkdownCodeBlockClick);
-    renderTail("The answer");
-    const code = container.querySelector("code");
-    const wrapper = container.querySelector(".code-block-wrapper");
-    expect(code).not.toBeNull();
-    container.querySelector<HTMLButtonElement>(".code-block-wrap")?.click();
-    expect(wrapper?.classList.contains("is-wrapped")).toBe(true);
+    try {
+      renderTail("The answer", true);
+      await Promise.resolve();
+      container.querySelector<HTMLButtonElement>(".code-block-expand")?.click();
+      container.querySelector<HTMLButtonElement>(".code-block-wrap")?.click();
+      expect(container.querySelector(".code-block-expand")?.getAttribute("aria-expanded")).toBe(
+        "true",
+      );
+      expect(container.querySelector(".code-block-wrap")?.getAttribute("aria-pressed")).toBe(
+        "true",
+      );
 
-    renderTail("The answer is ready.");
+      renderTail(tail, isStreaming);
+      await Promise.resolve();
 
-    expect(container.querySelector("code")).toBe(code);
-    expect(container.querySelector(".code-block-wrapper")?.classList.contains("is-wrapped")).toBe(
-      true,
-    );
-    expect(container.querySelector(".chat-text > p")?.textContent).toBe("The answer is ready.");
-    container.removeEventListener("click", handleMarkdownCodeBlockClick);
+      expect(container.querySelector(".code-block-expand")?.getAttribute("aria-expanded")).toBe(
+        "true",
+      );
+      expect(container.querySelector(".code-block-wrap")?.getAttribute("aria-pressed")).toBe(
+        "true",
+      );
+      expect(container.querySelector(".code-block-wrapper.is-expanded.is-wrapped")).not.toBeNull();
+      expect(container.querySelector(".chat-text > p:last-child")?.textContent).toBe(
+        tail.split("\n\n").at(-1),
+      );
+    } finally {
+      render(nothing, container);
+      container.remove();
+    }
+  });
+
+  it.each([
+    "message identity",
+    "source correction",
+    "render options",
+    "reference definition",
+  ] as const)("updates streaming Markdown after a %s change", async (change) => {
+    const container = document.body.appendChild(document.createElement("div"));
+    const source = "```ts\nconst original = 42;\n```\n\nSee [guide][ref]\n\nTail";
+    const show = (markdown: string, key = "message", interactive = true) =>
+      render(
+        html`<section ${markdownBlocks()} @click=${handleMarkdownCodeBlockClick}>
+          ${renderMessageMarkdown(
+            markdown,
+            key,
+            { role: "assistant", isStreaming: true },
+            { codeBlockInteraction: interactive ? "interactive" : "static" },
+          )}
+        </section>`,
+        container,
+      );
+    try {
+      show(source);
+      await Promise.resolve();
+      container.querySelector<HTMLButtonElement>(".code-block-wrap")?.click();
+      expect(container.querySelector(".code-block-wrap")?.getAttribute("aria-pressed")).toBe(
+        "true",
+      );
+
+      if (change === "message identity") {
+        show(source, "other-message");
+        expect(container.querySelector(".code-block-wrap")?.getAttribute("aria-pressed")).toBe(
+          "false",
+        );
+      } else if (change === "source correction") {
+        show(source.replace("const original = 42;", "const corrected = 43;"));
+        expect(container.querySelector("code")?.textContent).toBe("const corrected = 43;\n");
+      } else if (change === "render options") {
+        show(source, "message", false);
+        expect(container.querySelector(".code-block-wrap")).toBeNull();
+        expect(container.querySelector(".code-block-copy")).not.toBeNull();
+      } else {
+        show(`${source}\n\n[ref]: https://example.com/guide`);
+        expect(container.querySelector('a[href="https://example.com/guide"]')?.textContent).toBe(
+          "guide",
+        );
+      }
+      expect(container.querySelectorAll("pre code")).toHaveLength(1);
+    } finally {
+      render(nothing, container);
+      container.remove();
+    }
   });
 
   it.each([
@@ -230,6 +314,22 @@ describe("streaming message Markdown", () => {
 
     expect(container.querySelectorAll(".chat-duplicate-count")).toHaveLength(1);
     expect(container.querySelector(`${owner} > .chat-duplicate-count`)?.textContent).toBe("×3");
+    expect(container.querySelector("code .chat-duplicate-count")).toBeNull();
+
+    render(
+      renderMessageMarkdown(
+        `${markdown}\n\nMore`,
+        "streaming-duplicate",
+        { role: "assistant", isStreaming: true },
+        {},
+        { count: 4, label: "Four identical messages" },
+      ),
+      container,
+    );
+    expect(container.querySelectorAll(".chat-duplicate-count")).toHaveLength(1);
+    expect(
+      container.querySelector(".chat-text > p:last-child > .chat-duplicate-count")?.textContent,
+    ).toBe("×4");
     expect(container.querySelector("code .chat-duplicate-count")).toBeNull();
   });
 });

--- a/ui/src/pages/chat/components/chat-message-text.ts
+++ b/ui/src/pages/chat/components/chat-message-text.ts
@@ -1,5 +1,7 @@
 import { asNullableRecord } from "@openclaw/normalization-core/record-coerce";
 import { html } from "lit";
+import { Directive, directive } from "lit/directive.js";
+import { keyed } from "lit/directives/keyed.js";
 import { ref } from "lit/directives/ref.js";
 import { unsafeHTML } from "lit/directives/unsafe-html.js";
 import { icons } from "../../../components/icons.ts";
@@ -151,6 +153,7 @@ export function renderMessageMarkdown(
   const recovered = recoverFullMessage && disclosure?.expanded;
   const text = renderMarkdownText(
     recovered ? (disclosure.markdown ?? markdown) : markdown,
+    messageKey,
     opts.isStreaming,
     recovered ? { ...markdownRenderOptions, mode: "document" } : markdownRenderOptions,
     duplicateSuffix,
@@ -208,8 +211,43 @@ export type AssistantMessageDisclosure = {
   onRetryFullMessage?: () => void;
 };
 
+class MarkdownPartsDirective extends Directive {
+  private messageKey: string | undefined;
+  private source = "";
+  private stableHtml = "";
+  private fragments: string[] = [];
+  private generation = {};
+
+  render(messageKey: string, source: string, [stableHtml, tailHtml]: readonly [string, string]) {
+    if (
+      this.messageKey !== messageKey ||
+      !source.startsWith(this.source) ||
+      !stableHtml.startsWith(this.stableHtml)
+    ) {
+      this.fragments = [];
+      this.stableHtml = "";
+      this.generation = {};
+    }
+    if (stableHtml.length > this.stableHtml.length) {
+      this.fragments.push(stableHtml.slice(this.stableHtml.length));
+    }
+    this.messageKey = messageKey;
+    this.source = source;
+    this.stableHtml = stableHtml;
+    // Canonical HTML proves continuity; live DOM also contains the reader's
+    // control choices and Markdown enhancements, which must stay on its nodes.
+    return keyed(
+      this.generation,
+      html`${this.fragments.map((fragment) => unsafeHTML(fragment))}${unsafeHTML(tailHtml)}`,
+    );
+  }
+}
+
+const markdownParts = directive(MarkdownPartsDirective);
+
 function renderMarkdownText(
   markdown: string,
+  messageKey: string,
   isStreaming: boolean,
   markdownRenderOptions?: MarkdownRenderOptions,
   duplicateSuffix?: DuplicateSuffix,
@@ -222,9 +260,7 @@ function renderMarkdownText(
     const terminalPart = parts[1].trim() ? 1 : 0;
     parts[terminalPart] = appendDuplicateSuffix(parts[terminalPart], duplicateSuffix);
   }
-  // Separate Lit parts preserve completed code controls and diagrams while the
-  // streaming tail changes; the Markdown splitter still owns container boundaries.
-  const content = parts.map((part) => unsafeHTML(part));
+  const content = markdownParts(messageKey, markdown, parts);
   return html` <div class="chat-text" dir="${detectTextDirection(markdown)}">${content}</div> `;
 }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users expanding or wrapping a completed code block in a streaming assistant reply would lose those choices when a later paragraph finished.

## Why This Change Was Made

The message renderer now keeps unchanged completed HTML sections in place and updates the growing tail separately. Its private rendering directive uses the existing message identity and canonical HTML to decide when to preserve or replace the view. The Markdown parser still owns all content boundaries, and the existing controls and observer lifecycle remain unchanged.

## User Impact

Completed top-level code blocks retain expansion and wrapping as later paragraphs arrive. A replaced message, corrected earlier content, or changed rendered prefix gets a fresh view. Finishing a reply can retain the same controls when its message view stays mounted; this does not restore controls after the transcript replaces the whole row.

## Evidence

- Final regression tests fail on the original renderer for later-paragraph updates, completion within a retained view, and replacement message identity.
- 80 selected tests pass: 64 renderer/parser/cache cases and 16 code-control lifecycle cases, including corrected content, rendering options, late references, and duplicate badges.
- Complete changed-file checks and a fresh Control UI build pass.
- Independent review completed with no actionable findings through P2.

The synthetic browser fixture uses the actual message renderer, Markdown lifecycle, production styles, and click handler. All nine before/after frames were inspected. It deliberately retains the message view for its completion step, and does not claim a full Chat-route or live Gateway run. An initial fixture serialization error was corrected before the clean before/after runs.

| Before: a later paragraph resets code controls | After: expansion and wrapping remain |
| --- | --- |
| ![A later streamed paragraph resets expanded and wrapped code](https://github.com/user-attachments/assets/68252ea2-96eb-426f-ad01-ef513f2c8b0a) | ![A later streamed paragraph preserves expanded and wrapped code](https://github.com/user-attachments/assets/fbd004aa-f99d-415d-be27-f8424f0f84ba) |
