### PR TITLE
fix: preserve cron cadence edits during startup recovery

### DIFF
--- a/docs/automation/cron-jobs/how-it-works.md
+++ b/docs/automation/cron-jobs/how-it-works.md
@@ -37,6 +37,8 @@ How the Gateway scheduler runs a job, what it keeps between runs, and how a repe
 
     Restart recovery matches finalized results to the run identity, never just a coincident start time. A verified live process keeps its run receipt. If a foreign process exists but its start identity cannot be verified, its receipt becomes recoverable after more than two hours from the queued or running start. Recovery revokes that receipt before admitting another run; it cannot undo external side effects already in flight. On Gateway startup, an enabled one-shot interrupted before a terminal task result recovers through normal missed-job catch-up, regardless of how overdue it is. Reclaiming a dead running owner during normal operation records the interruption without replaying the consumed one-shot; a separately rescheduled occurrence remains eligible. Catch-up limits and delays pace recovery; they do not expire it. Pending recovery survives another restart, including during agent-turn deferral. A terminal result is restored without replaying that run, and `deleteAfterRun` deletes the job only when completion is `succeeded`.
 
+    If a completed run's history was saved but its job update failed, a later acknowledged schedule or pacing edit keeps its next check through recovery. Recovery retains the completed history and settles the old run without executing its payload again. Saving an unchanged schedule does not change how that completed run is recovered.
+
   </Accordion>
 </AccordionGroup>
 

--- a/docs/reference/database-schemas/versioning.md
+++ b/docs/reference/database-schemas/versioning.md
@@ -64,6 +64,19 @@ complete active runs and pending scheduler reconciliation on the current build
 before downgrading. A terminal task or receipt can still leave job state
 unreconciled.
 
+Scheduling edits made while a run awaits reconciliation record a private
+`runningScheduleChangeId` in the existing job runtime state, in the same
+transaction as the edit. The fresh value distinguishes successive committed
+edits even when a passive editor's snapshot spans two runs. Completion and
+recovery preserve the edited scheduling state; a new run and pending-run cleanup
+clear the marker. This adds no table, column, or public job field.
+
+Pending runs without this marker retain their previous recovery behavior.
+Edits acknowledged by older builds cannot be reconstructed reliably from
+timestamps or the final schedule. New edits to those pending jobs record the
+marker normally. Older compatible readers ignore it; finish pending runs before
+downgrading if their edited cadence must be preserved.
+
 Worker preparation uses the same-version rule for the bare nullable
 `worker_environments.preparation_purpose TEXT` column in the shared state
 database. Shared state database startup repair adds it without changing state schema 17.

--- a/src/cron/public-job.test.ts
+++ b/src/cron/public-job.test.ts
@@ -13,6 +13,7 @@ describe("toPublicCronJob", () => {
         startupCatchupAtMs: 2_000,
         pacedNextRunAtMs: 2_000,
         forcePreservedNextRunAtMs: 2_000,
+        runningScheduleChangeId: "pending-run-edit",
       },
     });
 
@@ -23,11 +24,13 @@ describe("toPublicCronJob", () => {
     expect(publicJob.state.startupCatchupAtMs).toBeUndefined();
     expect(publicJob.state.pacedNextRunAtMs).toBeUndefined();
     expect(publicJob.state.forcePreservedNextRunAtMs).toBeUndefined();
+    expect(publicJob.state).not.toHaveProperty("runningScheduleChangeId");
     expect(job.state.queuedAtMs).toBe(1_900);
     expect(job.state.runningReceiptId).toBe("pending-receipt");
     expect(job.state.startupCatchupAtMs).toBe(2_000);
     expect(job.state.pacedNextRunAtMs).toBe(2_000);
     expect(job.state.forcePreservedNextRunAtMs).toBe(2_000);
+    expect(job.state.runningScheduleChangeId).toBe("pending-run-edit");
   });
 
   it("projects script payload fields without exposing scheduler-only state", () => {

--- a/src/cron/public-job.ts
+++ b/src/cron/public-job.ts
@@ -18,5 +18,6 @@ export function toPublicCronJob(job: CronStoredJob): CronJob {
   delete state.startupCatchupAtMs;
   delete state.pacedNextRunAtMs;
   delete state.forcePreservedNextRunAtMs;
+  delete state.runningScheduleChangeId;
   return { ...publicJob, state };
 }

--- a/src/cron/service.recovery-schedule-ownership.test.ts
+++ b/src/cron/service.recovery-schedule-ownership.test.ts
@@ -1,0 +1,394 @@
+import { describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
+import { openOpenClawStateDatabase } from "../state/openclaw-state-db.js";
+import { listTaskRegistryRecordsByRuntimeSourceIdFromSqlite } from "../tasks/task-registry.store.sqlite.js";
+import { CronService } from "./service.js";
+import { setupCronServiceSuite } from "./service.test-harness.js";
+import type { CronServiceDeps } from "./service/state.js";
+import { loadCronStore } from "./store.js";
+import { cronStoreKey } from "./store/key.js";
+import { inspectActiveCronRunReceipt } from "./store/run-receipt-store.test-support.js";
+import { cronTaskRecordStoreKey, cronTaskRecordToRunLogEntry } from "./task-run-detail.js";
+import { readCronTaskRunHistoryPage } from "./task-run-history.js";
+import type { CronJob, CronJobCreate, CronJobPatch } from "./types.js";
+
+const MINUTE = 60_000;
+const HOUR = 60 * MINUTE;
+const CREATED_AT = Date.parse("2026-09-12T12:00:00.000Z");
+const RUN_AT = CREATED_AT + HOUR;
+const EDIT_AT = RUN_AT + 2_000;
+const HOURLY = { kind: "every", everyMs: HOUR, anchorMs: CREATED_AT } as const;
+const MINUTELY = { kind: "every", everyMs: MINUTE, anchorMs: EDIT_AT } as const;
+const { logger, makeStorePath } = setupCronServiceSuite({
+  prefix: "cron-recovery-schedule-",
+  baseTimeIso: new Date(CREATED_AT).toISOString(),
+});
+
+type RunResult = Awaited<ReturnType<CronServiceDeps["runIsolatedAgentJob"]>>;
+
+async function createHarness(input: Partial<CronJobCreate> = {}) {
+  const { storePath } = await makeStorePath();
+  const evaluateCronTrigger = vi.fn(async () => ({
+    kind: "evaluated" as const,
+    fire: true,
+    state: { observed: "completed evaluation" },
+  }));
+  const runIsolatedAgentJob = vi.fn<CronServiceDeps["runIsolatedAgentJob"]>(async () => ({
+    status: "ok",
+  }));
+  const deps: CronServiceDeps = {
+    storePath,
+    cronEnabled: true,
+    cronConfig: { triggers: { enabled: true } },
+    log: logger,
+    enqueueSystemEvent: vi.fn(),
+    requestHeartbeat: vi.fn(),
+    evaluateCronTrigger,
+    runIsolatedAgentJob,
+  };
+  const cron = new CronService(deps);
+  cron.pauseScheduling();
+  await cron.start();
+  const job = await cron.add({
+    name: "cadence recovery",
+    enabled: true,
+    schedule: HOURLY,
+    trigger: { script: "json({ fire: true })" },
+    sessionTarget: "isolated",
+    wakeMode: "now",
+    payload: { kind: "agentTurn", message: "Check the scheduled condition." },
+    delivery: { mode: "none" },
+    ...input,
+  });
+  return { cron, deps, evaluateCronTrigger, job, runIsolatedAgentJob, storePath };
+}
+
+type Harness = Awaited<ReturnType<typeof createHarness>>;
+
+function readHistory(harness: Harness) {
+  return readCronTaskRunHistoryPage({
+    storeKey: cronStoreKey(harness.storePath),
+    jobId: harness.job.id,
+  }).entries;
+}
+
+function readTasks(harness: Harness) {
+  const storeKey = cronStoreKey(harness.storePath);
+  return listTaskRegistryRecordsByRuntimeSourceIdFromSqlite({
+    runtime: "cron",
+    sourceId: harness.job.id,
+  }).filter((task) => cronTaskRecordStoreKey(task) === storeKey);
+}
+
+function rejectCronRowWrite(jobId: string) {
+  const database = openOpenClawStateDatabase().db;
+  database.exec(`
+    CREATE TEMP TRIGGER reject_cadence_row
+    BEFORE UPDATE ON cron_jobs
+    WHEN NEW.job_id = '${jobId.replaceAll("'", "''")}'
+    BEGIN
+      SELECT RAISE(ABORT, 'cadence row unavailable');
+    END;
+  `);
+  return () => database.exec("DROP TRIGGER IF EXISTS reject_cadence_row");
+}
+
+async function finishWithPendingCronRow(
+  harness: Harness,
+  options: { atMs?: number; endedAtMs?: number; mode?: "due" | "force"; result?: RunResult } = {},
+) {
+  const atMs = options.atMs ?? RUN_AT;
+  const result: RunResult = options.result ?? { status: "ok", summary: "Completed once." };
+  const previousTaskIds = new Set(readTasks(harness).map((task) => task.taskId));
+  const started = createDeferred();
+  const completion = createDeferred<RunResult>();
+  harness.runIsolatedAgentJob.mockImplementationOnce(async () => {
+    started.resolve();
+    return await completion.promise;
+  });
+  vi.setSystemTime(atMs);
+  const job = harness.cron.getJob(harness.job.id);
+  if (!job) {
+    throw new Error("Expected the job to remain available for execution.");
+  }
+  const stream = job.schedule.kind === "stream";
+  const run = harness.cron.run(harness.job.id, options.mode ?? (stream ? "force" : "due"), {
+    evaluateTrigger: true,
+    ...(stream ? { streamBatch: "one synthetic batch", payload: job.payload } : {}),
+  });
+  await Promise.race([
+    started.promise,
+    run.then(() => {
+      throw new Error("The run settled before entering its payload.");
+    }),
+  ]);
+  const receipt = inspectActiveCronRunReceipt({
+    storePath: harness.storePath,
+    jobId: harness.job.id,
+  });
+  if (!receipt) {
+    throw new Error("Expected the admitted run's receipt.");
+  }
+  expect(receipt.startedAtMs).toBe(atMs);
+  const admittedTasks = readTasks(harness).filter((task) => !previousTaskIds.has(task.taskId));
+  expect(admittedTasks).toHaveLength(1);
+  const taskId = admittedTasks[0]?.taskId;
+  if (!taskId) {
+    throw new Error("Expected the admitted run's task.");
+  }
+
+  const allowWrites = rejectCronRowWrite(harness.job.id);
+  try {
+    vi.setSystemTime(options.endedAtMs ?? atMs + 1_000);
+    completion.resolve(result);
+    await expect(run).rejects.toThrow("cadence row unavailable");
+  } finally {
+    allowWrites();
+  }
+
+  const history = readHistory(harness);
+  const finishedTask = readTasks(harness).find((task) => task.taskId === taskId);
+  const entry = finishedTask ? cronTaskRecordToRunLogEntry(finishedTask) : undefined;
+  if (!entry) {
+    throw new Error("Expected the admitted task to retain its completed history entry.");
+  }
+  // The real task commit precedes the failed scheduler row, leaving recovery work.
+  expect(entry).toMatchObject({
+    jobId: harness.job.id,
+    runAtMs: atMs,
+    status: result.status,
+    completionStatus: result.status === "ok" ? "succeeded" : "failed",
+  });
+  expect(finishedTask?.endedAt).toEqual(expect.any(Number));
+  expect(history).toHaveLength(previousTaskIds.size + 1);
+  expect(
+    inspectActiveCronRunReceipt({ storePath: harness.storePath, jobId: harness.job.id })?.receiptId,
+  ).toBe(receipt.receiptId);
+  expect((await loadCronStore(harness.storePath)).jobs[0]?.state.runningAtMs).toBe(atMs);
+  harness.cron.stop();
+  return { entry, history, receipt, taskId, runs: harness.runIsolatedAgentJob.mock.calls.length };
+}
+
+async function restartAndRecover(
+  harness: Harness,
+  pending: Awaited<ReturnType<typeof finishWithPendingCronRow>>,
+) {
+  harness.cron = new CronService(harness.deps);
+  harness.cron.pauseScheduling();
+  await harness.cron.start();
+
+  expect(readHistory(harness)).toEqual(pending.history);
+  expect(harness.evaluateCronTrigger).toHaveBeenCalledTimes(pending.runs);
+  expect(harness.runIsolatedAgentJob).toHaveBeenCalledTimes(pending.runs);
+  expect(
+    inspectActiveCronRunReceipt({ storePath: harness.storePath, jobId: harness.job.id }),
+  ).toBeUndefined();
+  expect(
+    openOpenClawStateDatabase()
+      .db.prepare("SELECT status FROM cron_run_receipts WHERE receipt_id = ?")
+      .get(pending.receipt.receiptId),
+  ).toMatchObject({ status: pending.entry.status });
+  const recovered = (await loadCronStore(harness.storePath)).jobs[0];
+  if (!recovered) {
+    throw new Error("Expected the recurring job to remain stored.");
+  }
+  expect(recovered.state.runningAtMs).toBeUndefined();
+  expect(recovered.state.lastRunAtMs).toBe(pending.receipt.startedAtMs);
+  expect(recovered.state.lastRunStatus).toBe(pending.entry.status);
+  return recovered;
+}
+
+type EditCase = {
+  label: string;
+  input?: Partial<CronJobCreate>;
+  result?: RunResult;
+  endedAtMs?: number;
+  edits: Array<{ atMs: number; patch: CronJobPatch }>;
+  historicalNextRunAtMs: number | undefined;
+  acknowledgedNextRunAtMs: number | undefined;
+};
+
+describe("CronService schedule ownership during finalized-run recovery", () => {
+  it.each<EditCase>([
+    {
+      label: "an hourly-to-minute interval edit",
+      edits: [{ atMs: EDIT_AT, patch: { schedule: MINUTELY } }],
+      historicalNextRunAtMs: RUN_AT + HOUR,
+      acknowledgedNextRunAtMs: EDIT_AT + MINUTE,
+    },
+    {
+      label: "an edit in the admission millisecond",
+      endedAtMs: RUN_AT,
+      edits: [{ atMs: RUN_AT, patch: { schedule: { ...MINUTELY, anchorMs: RUN_AT } } }],
+      historicalNextRunAtMs: RUN_AT + HOUR,
+      acknowledgedNextRunAtMs: RUN_AT + MINUTE,
+    },
+    {
+      label: "an edit after clock rollback",
+      edits: [
+        {
+          atMs: RUN_AT - 2_000,
+          patch: { schedule: { ...MINUTELY, anchorMs: RUN_AT - 2_000 } },
+        },
+      ],
+      historicalNextRunAtMs: RUN_AT + HOUR,
+      acknowledgedNextRunAtMs: RUN_AT - 2_000 + MINUTE,
+    },
+    {
+      label: "an hourly-to-minute cron edit with a valid historical cron slot",
+      input: { schedule: { kind: "cron", expr: "0 * * * *", tz: "UTC", staggerMs: 0 } },
+      edits: [
+        {
+          atMs: EDIT_AT,
+          patch: { schedule: { kind: "cron", expr: "* * * * *", tz: "UTC", staggerMs: 0 } },
+        },
+      ],
+      historicalNextRunAtMs: RUN_AT + HOUR,
+      acknowledgedNextRunAtMs: RUN_AT + MINUTE,
+    },
+    {
+      label: "a timed-to-stream edit with no timer deadline",
+      edits: [{ atMs: EDIT_AT, patch: { schedule: { kind: "stream", command: ["echo"] } } }],
+      historicalNextRunAtMs: RUN_AT + HOUR,
+      acknowledgedNextRunAtMs: undefined,
+    },
+    {
+      label: "a stream-once-to-timed edit that must stay enabled",
+      input: {
+        schedule: { kind: "stream", command: ["echo"] },
+        trigger: { script: "json({ fire: true })", once: true },
+      },
+      edits: [{ atMs: EDIT_AT, patch: { schedule: MINUTELY } }],
+      historicalNextRunAtMs: undefined,
+      acknowledgedNextRunAtMs: EDIT_AT + MINUTE,
+    },
+    {
+      label: "A-to-B-to-A edits restoring an earlier slot after clock rollback",
+      edits: [
+        {
+          atMs: RUN_AT - 2_000,
+          patch: { schedule: { ...MINUTELY, anchorMs: RUN_AT - 2_000 } },
+        },
+        { atMs: RUN_AT - 1_000, patch: { schedule: HOURLY } },
+      ],
+      historicalNextRunAtMs: RUN_AT + HOUR,
+      acknowledgedNextRunAtMs: RUN_AT,
+    },
+    {
+      label: "a pacing edit after the old payload selected a dynamic deadline",
+      input: { pacing: { min: "15m", max: "4h" } },
+      result: { status: "ok", nextCheck: { delayMs: 30 * MINUTE } },
+      edits: [{ atMs: EDIT_AT, patch: { pacing: { min: "15m", max: "2h" } } }],
+      historicalNextRunAtMs: RUN_AT + 1_000 + 30 * MINUTE,
+      acknowledgedNextRunAtMs: RUN_AT + HOUR,
+    },
+    {
+      label: "a cadence edit after an old transient error selected a retry",
+      result: { status: "error", error: "temporary timeout" },
+      edits: [{ atMs: EDIT_AT, patch: { schedule: MINUTELY } }],
+      historicalNextRunAtMs: RUN_AT + 31_000,
+      acknowledgedNextRunAtMs: EDIT_AT + MINUTE,
+    },
+  ])("preserves $label", async (scenario) => {
+    const harness = await createHarness(scenario.input);
+    try {
+      const pending = await finishWithPendingCronRow(harness, scenario);
+      expect(pending.entry.nextRunAtMs).toBe(scenario.historicalNextRunAtMs);
+      let acknowledged: CronJob = harness.job;
+      for (const edit of scenario.edits) {
+        vi.setSystemTime(edit.atMs);
+        acknowledged = await harness.cron.update(harness.job.id, edit.patch);
+      }
+      expect(acknowledged.enabled).toBe(true);
+      expect(acknowledged.state.nextRunAtMs).toBe(scenario.acknowledgedNextRunAtMs);
+      expect(acknowledged.state.nextRunAtMs).not.toBe(pending.entry.nextRunAtMs);
+      expect(readHistory(harness)).toEqual(pending.history);
+
+      const recovered = await restartAndRecover(harness, pending);
+      expect(recovered.enabled).toBe(true);
+      expect(recovered.schedule).toEqual(acknowledged.schedule);
+      expect(recovered.pacing).toEqual(acknowledged.pacing);
+      expect(recovered.state.nextRunAtMs).toBe(acknowledged.state.nextRunAtMs);
+      expect(recovered.state.pacedNextRunAtMs).toBe(acknowledged.state.pacedNextRunAtMs);
+      expect(recovered.state.forcePreservedNextRunAtMs).toBe(
+        acknowledged.state.forcePreservedNextRunAtMs,
+      );
+      expect(recovered.state.lastError).toBe(scenario.result?.error);
+    } finally {
+      harness.cron.stop();
+    }
+  });
+
+  it.each([
+    { edit: "unchanged", error: false },
+    { edit: "name only", error: false },
+    { edit: "idempotent schedule", error: true },
+    { edit: "failed schedule write", error: true },
+  ] as const)("recovers the historical deadline after $edit", async ({ edit, error }) => {
+    const harness = await createHarness();
+    try {
+      const pending = await finishWithPendingCronRow(harness, {
+        result: error ? { status: "error", error: "temporary timeout" } : { status: "ok" },
+      });
+      expect(pending.entry.nextRunAtMs).toBe(RUN_AT + (error ? 31_000 : HOUR));
+      vi.setSystemTime(EDIT_AT);
+      if (edit === "name only") {
+        await harness.cron.update(harness.job.id, { name: "renamed condition" });
+      } else if (edit === "idempotent schedule") {
+        await harness.cron.update(harness.job.id, {
+          schedule: { kind: "every", everyMs: HOUR },
+          enabled: true,
+        });
+      } else if (edit === "failed schedule write") {
+        const allowWrites = rejectCronRowWrite(harness.job.id);
+        try {
+          await expect(harness.cron.update(harness.job.id, { schedule: MINUTELY })).rejects.toThrow(
+            "cadence row unavailable",
+          );
+        } finally {
+          allowWrites();
+        }
+      }
+
+      const recovered = await restartAndRecover(harness, pending);
+      expect(recovered.enabled).toBe(true);
+      expect(recovered.schedule).toEqual(HOURLY);
+      expect(recovered.state.nextRunAtMs).toBe(pending.entry.nextRunAtMs);
+      expect(recovered.state.consecutiveErrors).toBe(error ? 1 : 0);
+      expect(recovered.name).toBe(edit === "name only" ? "renamed condition" : harness.job.name);
+    } finally {
+      harness.cron.stop();
+    }
+  });
+
+  it.each([
+    { clock: "its next due slot", atMs: EDIT_AT + MINUTE, mode: "due" },
+    { clock: "the same admission millisecond", atMs: RUN_AT, mode: "force" },
+    { clock: "a rolled-back clock", atMs: RUN_AT - 1_000, mode: "force" },
+  ] as const)("lets an unchanged successor finish once at $clock", async ({ atMs, mode }) => {
+    const harness = await createHarness({
+      trigger: { script: "json({ fire: true })", once: true },
+    });
+    try {
+      const first = await finishWithPendingCronRow(harness);
+      expect(first.entry.nextRunAtMs).toBeUndefined();
+      vi.setSystemTime(EDIT_AT);
+      const acknowledged = await harness.cron.update(harness.job.id, { schedule: MINUTELY });
+      const replacement = await restartAndRecover(harness, first);
+      expect(replacement.enabled).toBe(true);
+      expect(replacement.state.nextRunAtMs).toBe(acknowledged.state.nextRunAtMs);
+
+      const second = await finishWithPendingCronRow(harness, { atMs, endedAtMs: atMs, mode });
+      expect(second.receipt.receiptId).not.toBe(first.receipt.receiptId);
+      expect(second.taskId).not.toBe(first.taskId);
+      expect(second.entry.nextRunAtMs).toBeUndefined();
+      expect(second.history).toHaveLength(2);
+      const completed = await restartAndRecover(harness, second);
+      expect(completed.enabled).toBe(false);
+      expect(completed.state.nextRunAtMs).toBeUndefined();
+      expect(completed.state.triggerEvalCount).toBe(2);
+    } finally {
+      harness.cron.stop();
+    }
+  });
+});

--- a/src/cron/service/jobs-scheduling.ts
+++ b/src/cron/service/jobs-scheduling.ts
@@ -412,6 +412,7 @@ function normalizeJobTickState(params: { state: CronServiceState; job: CronJob; 
   skip: boolean;
 } {
   const { state, job, nowMs } = params;
+  const { log } = state.deps;
   let changed = false;
 
   if (!job.state) {
@@ -469,6 +470,7 @@ function normalizeJobTickState(params: { state: CronServiceState; job: CronJob; 
       !isCronJobActive(job.id)
     ) {
       Object.assign(job.state, { runningAtMs: undefined, runningReceiptId: undefined });
+      delete job.state.runningScheduleChangeId;
       changed = true;
     }
     return { changed, skip: true };
@@ -495,10 +497,7 @@ function normalizeJobTickState(params: { state: CronServiceState; job: CronJob; 
     Math.abs(nowMs - queuedAt) > CRON_STUCK_RUN_MS &&
     !ownsCronRunMarker(state, job.id, queuedAt)
   ) {
-    state.deps.log.warn(
-      { jobId: job.id, queuedAtMs: queuedAt },
-      "cron: clearing stuck queued marker",
-    );
+    log.warn({ jobId: job.id, queuedAtMs: queuedAt }, "cron: clearing stuck queued marker");
     job.state.queuedAtMs = undefined;
     changed = true;
   }
@@ -509,11 +508,9 @@ function normalizeJobTickState(params: { state: CronServiceState; job: CronJob; 
     Math.abs(nowMs - runningAt) > CRON_STUCK_RUN_MS &&
     !ownsCronRunMarker(state, job.id, runningAt)
   ) {
-    state.deps.log.warn(
-      { jobId: job.id, runningAtMs: runningAt },
-      "cron: clearing stuck running marker",
-    );
+    log.warn({ jobId: job.id, runningAtMs: runningAt }, "cron: clearing stuck running marker");
     Object.assign(job.state, { runningAtMs: undefined, runningReceiptId: undefined });
+    delete job.state.runningScheduleChangeId;
     changed = true;
     const nextRun = job.state.nextRunAtMs;
     const lastRun = job.state.lastRunAtMs;

--- a/src/cron/service/jobs.apply-patch.test.ts
+++ b/src/cron/service/jobs.apply-patch.test.ts
@@ -100,7 +100,10 @@ describe("schedule activation ownership", () => {
       sessionTarget: "main",
       wakeMode: "now",
       payload: { kind: "systemEvent", text: "tick" },
-      state: { scheduleActivatedAtMs: now - 60_000 },
+      state: {
+        scheduleActivatedAtMs: now - 60_000,
+        runningScheduleChangeId: "caller-supplied-edit",
+      },
     } as unknown as CronJobCreate;
 
     const job = createJob(
@@ -114,17 +117,21 @@ describe("schedule activation ownership", () => {
     );
 
     expect(job.state.scheduleActivatedAtMs).toBeUndefined();
+    expect(job.state.runningScheduleChangeId).toBeUndefined();
   });
 
   it("ignores caller-supplied activation state during updates", () => {
-    const job = makeJob({ state: { scheduleActivatedAtMs: 456 } });
+    const job = makeJob({
+      state: { scheduleActivatedAtMs: 456, runningScheduleChangeId: "pending-run-edit" },
+    });
     const patch = {
-      state: { scheduleActivatedAtMs: 123 },
+      state: { scheduleActivatedAtMs: 123, runningScheduleChangeId: null },
     } as unknown as CronJobPatch;
 
     applyJobPatch(job, patch);
 
     expect(job.state.scheduleActivatedAtMs).toBe(456);
+    expect(job.state.runningScheduleChangeId).toBe("pending-run-edit");
   });
 
   it.each(["nextRunAtMs", "startupCatchupAtMs", "pacedNextRunAtMs"] as const)(

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -233,6 +233,7 @@ export function createJob(
   // Schedule activation is stamped only by committed scheduling mutations.
   // Accepting caller state here would let imports spoof restart catch-up ownership.
   delete initialState.scheduleActivatedAtMs;
+  delete initialState.runningScheduleChangeId;
   delete initialState.autoDisabled;
   assertCronJobStateTimestamps(initialState);
   const job: CronStoredJob = {
@@ -424,6 +425,7 @@ export function applyJobPatch(
     // Runtime state patches may report execution progress, but the scheduler
     // alone owns the boundary that decides whether restart catch-up can run.
     delete statePatch.scheduleActivatedAtMs;
+    delete statePatch.runningScheduleChangeId;
     delete statePatch.autoDisabled;
     assertCronJobStateTimestamps(statePatch);
     job.state = { ...job.state, ...statePatch };

--- a/src/cron/service/ops-mutations.ts
+++ b/src/cron/service/ops-mutations.ts
@@ -9,7 +9,6 @@ import {
   type CronActiveJobMarker,
   isCronJobActive,
   noteActiveCronJobRemoval,
-  noteActiveCronJobScheduleMutation,
   noteActiveCronJobTriggerMutation,
   onCronJobInactive,
   requestActiveCronJobCancellation,
@@ -212,6 +211,7 @@ function finalizeUpdatedJob(params: {
       // disabled job can accept a later force run with the same timestamp.
       if (!isCronJobActive(nextJob.id)) {
         Object.assign(nextJob.state, { runningAtMs: undefined, runningReceiptId: undefined });
+        delete nextJob.state.runningScheduleChangeId;
       }
     }
   } else if (isJobEnabled(nextJob) && !hasScheduledNextRunAtMs(nextJob.state.nextRunAtMs)) {
@@ -252,6 +252,7 @@ async function persistUpdatedJob(params: {
     !isDeepStrictEqual(previousJob.state.triggerState, nextJob.state.triggerState) ||
     ((previousJob.payload.kind === "script" || nextJob.payload.kind === "script") &&
       !isDeepStrictEqual(previousJob.payload, nextJob.payload));
+  const scheduleChanged = !cronSchedulingInputsEqual(previousJob, nextJob);
   await persistOrRestore(state, snapshot, {
     suppressScheduledJobId: nextJob.id,
     transactionHooks: cronRunReceiptMutationHooks({
@@ -259,13 +260,9 @@ async function persistUpdatedJob(params: {
       jobId: nextJob.id,
       ownerChanged,
       triggerStateChanged,
+      ...(scheduleChanged ? { scheduleChangedJob: nextJob } : {}),
     }),
   });
-  if (!cronSchedulingInputsEqual(previousJob, nextJob)) {
-    // Mark only committed edits; a failed SQLite write cannot retire the run's
-    // schedule ownership, and idempotent re-saves must not create a new claim.
-    noteActiveCronJobScheduleMutation(nextJob.id);
-  }
   if (isJobEnabled(previousJob) && !isJobEnabled(nextJob)) {
     requestActiveCronJobCancellation(nextJob.id, "Cron job disabled by operator.");
   }

--- a/src/cron/service/ops-run-preparation.ts
+++ b/src/cron/service/ops-run-preparation.ts
@@ -552,6 +552,7 @@ async function releasePreparedManualReservation(
       if (runningMatches) {
         delete job.state.runningAtMs;
         delete job.state.runningReceiptId;
+        delete job.state.runningScheduleChangeId;
       }
       return { upsertJobIds: [job.id], value: job };
     },

--- a/src/cron/service/run-admission.ts
+++ b/src/cron/service/run-admission.ts
@@ -147,6 +147,7 @@ export async function cleanupQueuedCronRunReservations(params: {
             if (runningMatches) {
               delete job.state.runningAtMs;
               delete job.state.runningReceiptId;
+              delete job.state.runningScheduleChangeId;
             }
             if (params.recompute && job.enabled && job.state.nextRunAtMs === undefined) {
               recomputeJobNextRunAtMs({
@@ -422,6 +423,7 @@ export async function activateQueuedCronRun(params: {
           delete current.state.queuedAtMs;
           current.state.runningAtMs = startedAt;
           current.state.runningReceiptId = runReceipt.receiptId;
+          delete current.state.runningScheduleChangeId;
           current.state.lastError = undefined;
           return { value, upsertJobIds: [current.id] };
         },
@@ -472,6 +474,7 @@ export async function activateQueuedCronRun(params: {
         current.state.lastError = previousLastError;
         delete current.state.runningAtMs;
         delete current.state.runningReceiptId;
+        delete current.state.runningScheduleChangeId;
         return { value: current, upsertJobIds: [current.id] };
       },
     });

--- a/src/cron/service/run-receipts.ts
+++ b/src/cron/service/run-receipts.ts
@@ -1,5 +1,10 @@
+import { randomUUID } from "node:crypto";
 import type { DatabaseSync } from "node:sqlite";
-import { isCronSelfRemovalCurrent, type CronActiveJobMarker } from "../active-jobs.js";
+import {
+  isCronSelfRemovalCurrent,
+  noteActiveCronJobScheduleMutation,
+  type CronActiveJobMarker,
+} from "../active-jobs.js";
 import { describeUnavailableCronAgent } from "../agent-availability.js";
 import { resolveCronJobEffectiveAgentId } from "../agent-id.js";
 import { cronStoreKey } from "../store/key.js";
@@ -112,18 +117,42 @@ export function cronRunReceiptMutationHooks(params: {
   jobId: string;
   ownerChanged: boolean;
   triggerStateChanged: boolean;
+  scheduleChangedJob?: CronJob;
 }): CronStoreTransactionHooks | undefined {
   const ownerHooks = params.ownerChanged ? cronRunReceiptOwnerMutationHooks(params) : undefined;
-  if (!ownerHooks && !params.triggerStateChanged) {
+  if (!ownerHooks && !params.triggerStateChanged && !params.scheduleChangedJob) {
     return undefined;
   }
   return {
     ...ownerHooks,
     beforeWrite: (database) => {
+      if (params.scheduleChangedJob) {
+        const current = loadedCronStoreFromRows(
+          loadCronRows(
+            database,
+            cronStoreKey(params.state.deps.storePath),
+            new Set([params.jobId]),
+          ),
+        ).store.jobs[0];
+        if (current?.state.runningAtMs !== undefined) {
+          // A fresh nonce makes every committed edit a distinct state delta,
+          // even if a passive editor observed a retired run that has since ended.
+          params.scheduleChangedJob.state.runningScheduleChangeId = randomUUID();
+        } else {
+          delete params.scheduleChangedJob.state.runningScheduleChangeId;
+        }
+      }
       if (params.triggerStateChanged) {
         retireServiceCronRunTriggerStateInDatabase({ ...params, database });
       }
       ownerHooks?.beforeWrite?.(database);
+    },
+    afterCommit: () => {
+      ownerHooks?.afterCommit?.();
+      if (params.scheduleChangedJob) {
+        // Retire live ownership with the durable edit, never on a failed write.
+        noteActiveCronJobScheduleMutation(params.jobId);
+      }
     },
   };
 }

--- a/src/cron/service/shared-store-runtime.test.ts
+++ b/src/cron/service/shared-store-runtime.test.ts
@@ -1,16 +1,23 @@
-import { spawnSync } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
+import { once } from "node:events";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import { createBoundedChildOutput } from "../../../test/helpers/bounded-child-output.js";
 import { createDeferred } from "../../../test/helpers/promise.js";
+import { stopChildProcess } from "../../../test/helpers/stop-child-process.js";
 import {
   openOpenClawStateDatabase,
   runOpenClawStateWriteTransaction,
 } from "../../state/openclaw-state-db.js";
+import { listTaskRegistryRecordsByRuntimeSourceIdFromSqlite } from "../../tasks/task-registry.store.sqlite.js";
 import { CronService } from "../service.js";
 import { createCronStoreHarness } from "../service.test-harness.js";
 import { loadCronStore, saveCronJobsStoreChanges, saveCronStore } from "../store.js";
+import { cronStoreKey } from "../store/key.js";
 import { inspectActiveCronRunReceipt } from "../store/run-receipt-store.test-support.js";
 import { isCronRunTriggerStateRetiredInDatabase } from "../store/run-receipt-trigger-state.js";
+import { cronTaskRecordStoreKey } from "../task-run-detail.js";
+import { readCronTaskRunHistoryPage } from "../task-run-history.js";
 import type { CronJob } from "../types.js";
 
 const { makeStorePath } = createCronStoreHarness({ prefix: "cron-shared-runtime-" });
@@ -125,6 +132,76 @@ function runSchedulerChild(
   expect(child.stderr).toBe("");
   expect(child.status).toBe(0);
 }
+
+const overlappingRunsChildScript = String.raw`
+import assert from "node:assert/strict";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+const { storePath, jobId, nowMs } = JSON.parse(process.env.OPENCLAW_CRON_SHARED_STORE_RUNS);
+const load = (file) => import(pathToFileURL(path.join(process.cwd(), file)).href);
+const { CronService } = await load("src/cron/service.ts");
+const { loadCronStore } = await load("src/cron/store.ts");
+const { openOpenClawStateDatabase } = await load("src/state/openclaw-state-db.ts");
+const { createDeferred } = await load("test/helpers/promise.ts");
+const started = [createDeferred(), createDeferred()];
+const completions = [createDeferred(), createDeferred()];
+const advance = createDeferred();
+process.once("message", () => advance.resolve());
+let payloads = 0;
+const cron = new CronService({
+  cronEnabled: true,
+  storePath,
+  nowMs: () => nowMs,
+  log: { debug() {}, info() {}, warn() {}, error() {} },
+  enqueueSystemEvent() {},
+  requestHeartbeat() {},
+  async runIsolatedAgentJob() {
+    const index = payloads++;
+    assert.ok(index < 2, "startup must not replay either payload");
+    started[index].resolve();
+    await completions[index].promise;
+    return { status: "ok", summary: "completed payload " + (index + 1) };
+  },
+});
+let database;
+try {
+  cron.pauseScheduling();
+  await cron.start();
+  const first = cron.run(jobId, "force");
+  await Promise.race([
+    started[0].promise,
+    first.then(() => { throw new Error("first run did not enter its payload"); }),
+  ]);
+  await cron.update(jobId, { schedule: { kind: "every", everyMs: 60_000, anchorMs: nowMs } });
+  process.send("ready");
+  await advance.promise;
+  completions[0].resolve();
+  assert.deepEqual(await first, { ok: true, ran: true });
+
+  const second = cron.run(jobId, "force");
+  await Promise.race([
+    started[1].promise,
+    second.then(() => { throw new Error("second run did not enter its payload"); }),
+  ]);
+  const activated = (await loadCronStore(storePath)).jobs.find((job) => job.id === jobId);
+  assert.equal(activated.state.runningAtMs, nowMs);
+  assert.equal(activated.state.runningScheduleChangeId, undefined);
+  database = openOpenClawStateDatabase().db;
+  database.exec(
+    "CREATE TEMP TRIGGER reject_successor_row BEFORE UPDATE ON cron_jobs WHEN NEW.job_id = '" +
+    jobId.replaceAll("'", "''") +
+    "' BEGIN SELECT RAISE(ABORT, 'successor row unavailable'); END;"
+  );
+  completions[1].resolve();
+  await assert.rejects(second, /successor row unavailable/);
+  assert.equal(payloads, 2);
+} finally {
+  database?.exec("DROP TRIGGER IF EXISTS reject_successor_row");
+  for (const completion of completions) completion.resolve();
+  cron.stop();
+  process.disconnect();
+}
+`;
 
 describe("scheduler-disabled shared-store mutations", () => {
   it("cannot overwrite runtime committed by a scheduler process", async () => {
@@ -298,6 +375,139 @@ describe("scheduler-disabled shared-store mutations", () => {
       for (const { cron } of cases) {
         cron.stop();
       }
+    }
+  }, 90_000);
+
+  it("retires a successor when an edit was prepared against an earlier edited run", async () => {
+    const { storePath } = await makeStorePath();
+    const nowMs = Date.parse("2026-09-12T13:00:00.000Z");
+    const runIsolatedAgentJob = vi.fn(async () => ({ status: "ok" as const }));
+    const deps = {
+      storePath,
+      nowMs: () => nowMs,
+      log,
+      enqueueSystemEvent() {},
+      requestHeartbeat() {},
+      runIsolatedAgentJob,
+    };
+    const editor = new CronService({ ...deps, cronEnabled: false });
+    const restarted = new CronService({ ...deps, cronEnabled: true });
+    restarted.pauseScheduling();
+    const job = await editor.add({
+      name: "passive cadence edit",
+      enabled: true,
+      schedule: { kind: "every", everyMs: 3_600_000, anchorMs: nowMs },
+      sessionTarget: "isolated",
+      wakeMode: "now",
+      payload: { kind: "agentTurn", message: "Run the shared-store payload." },
+      delivery: { mode: "none" },
+    });
+    const storeKey = cronStoreKey(storePath);
+    const readTasks = () =>
+      listTaskRegistryRecordsByRuntimeSourceIdFromSqlite({
+        runtime: "cron",
+        sourceId: job.id,
+      }).filter((task) => cronTaskRecordStoreKey(task) === storeKey);
+    const child = spawn(
+      process.execPath,
+      [
+        "--import",
+        path.join(process.cwd(), "scripts/tsx.mjs"),
+        "--input-type=module",
+        "--eval",
+        overlappingRunsChildScript,
+      ],
+      {
+        cwd: process.cwd(),
+        env: {
+          ...process.env,
+          OPENCLAW_CRON_SHARED_STORE_RUNS: JSON.stringify({ storePath, jobId: job.id, nowMs }),
+        },
+        stdio: ["ignore", "ignore", "pipe", "ipc"],
+        timeout: 60_000,
+      },
+    );
+    const stderr = createBoundedChildOutput();
+    child.stderr?.on("data", stderr.append);
+    const closed = once(child, "close");
+    try {
+      const [ready] = await Promise.race([
+        once(child, "message"),
+        closed.then(() => {
+          throw new Error(`Scheduler exited before the edit barrier: ${stderr.text()}`);
+        }),
+      ]);
+      expect(ready).toBe("ready");
+      const before = (await loadCronStore(storePath)).jobs.find((entry) => entry.id === job.id);
+      const firstReceipt = inspectActiveCronRunReceipt({ storePath, jobId: job.id });
+      if (!before || !firstReceipt) {
+        throw new Error("Expected the first edited run to remain active.");
+      }
+      expect(before.state.runningAtMs).toBe(nowMs);
+      const firstTasks = readTasks();
+      expect(firstTasks).toHaveLength(1);
+
+      // A child owns execution so the passive editor can hold its store lock
+      // while both runs advance. Identical clocks cannot identify the new edit.
+      const acknowledged = await editor.updateWithPrecondition(
+        job.id,
+        { schedule: { kind: "every", everyMs: 120_000, anchorMs: nowMs } },
+        async (snapshot) => {
+          expect(snapshot.schedule).toEqual(before.schedule);
+          expect(snapshot.state.runningAtMs).toBe(firstReceipt.startedAtMs);
+          expect(snapshot.state.runningScheduleChangeId).toBe(before.state.runningScheduleChangeId);
+          child.send("advance");
+          await closed;
+          expect(child.exitCode, stderr.text()).toBe(0);
+          expect(child.signalCode).toBeNull();
+        },
+      );
+      expect(acknowledged.state.nextRunAtMs).toBe(nowMs + 120_000);
+      const after = (await loadCronStore(storePath)).jobs.find((entry) => entry.id === job.id);
+      const secondReceipt = inspectActiveCronRunReceipt({ storePath, jobId: job.id });
+      if (!secondReceipt) {
+        throw new Error("Expected the second run to retain its pending receipt.");
+      }
+      expect(secondReceipt.receiptId).not.toBe(firstReceipt.receiptId);
+      expect(secondReceipt.startedAtMs).toBe(nowMs);
+      expect(after?.state.runningAtMs).toBe(nowMs);
+      expect(after?.state.nextRunAtMs).toBe(acknowledged.state.nextRunAtMs);
+      const tasks = readTasks();
+      expect(tasks).toHaveLength(2);
+      expect(tasks.filter((task) => task.taskId !== firstTasks[0]?.taskId)).toHaveLength(1);
+      const readHistory = () => readCronTaskRunHistoryPage({ storeKey, jobId: job.id }).entries;
+      const history = readHistory();
+      expect(history).toHaveLength(2);
+      for (const entry of history) {
+        expect(entry).toMatchObject({
+          runAtMs: nowMs,
+          status: "ok",
+          completionStatus: "succeeded",
+          nextRunAtMs: nowMs + 60_000,
+        });
+      }
+
+      await restarted.start();
+      const recovered = (await loadCronStore(storePath)).jobs.find((entry) => entry.id === job.id);
+      expect(recovered?.enabled).toBe(true);
+      expect(recovered?.schedule).toEqual(acknowledged.schedule);
+      expect(recovered?.state.nextRunAtMs).toBe(acknowledged.state.nextRunAtMs);
+      expect(recovered?.state.runningAtMs).toBeUndefined();
+      expect(readHistory()).toEqual(history);
+      expect(runIsolatedAgentJob).not.toHaveBeenCalled();
+      expect(inspectActiveCronRunReceipt({ storePath, jobId: job.id })).toBeUndefined();
+      expect(
+        openOpenClawStateDatabase()
+          .db.prepare("SELECT status FROM cron_run_receipts WHERE receipt_id = ?")
+          .get(secondReceipt.receiptId),
+      ).toMatchObject({ status: "ok" });
+      expect(before.state.runningScheduleChangeId).toEqual(expect.any(String));
+      expect(after?.state.runningScheduleChangeId).toEqual(expect.any(String));
+      expect(after?.state.runningScheduleChangeId).not.toBe(before.state.runningScheduleChangeId);
+    } finally {
+      editor.stop();
+      restarted.stop();
+      await stopChildProcess(child, 1_000);
     }
   }, 90_000);
 

--- a/src/cron/service/startup-run-repair.ts
+++ b/src/cron/service/startup-run-repair.ts
@@ -63,6 +63,7 @@ export function markInterruptedStartupRun(params: {
 
   job.state.runningAtMs = undefined;
   job.state.runningReceiptId = undefined;
+  delete job.state.runningScheduleChangeId;
   job.state.lastRunAtMs = runningAtMs;
   job.state.lastRunStatus = "error";
   job.state.lastStatus = "error";
@@ -149,11 +150,12 @@ export function restoreFinalizedStartupRun(params: {
   }
   const replacementAtMs = resolveOneShotReplacementAtMs(job, startedAt);
   const persistedNextRunAtMs = asDateTimestampMs(job.state.nextRunAtMs);
-  // Finalization writes history first, so a later one-shot slot or disable in
-  // the job row owns lifecycle state when startup replays that older history.
+  // Committed edits own scheduling even if the clock repeats or moves back.
+  // Keep the existing one-shot protection for older pending runs without a nonce.
   const scheduleOwnership =
-    job.schedule.kind === "at" &&
-    (!job.enabled || (persistedNextRunAtMs !== undefined && persistedNextRunAtMs > startedAt))
+    typeof job.state.runningScheduleChangeId === "string" ||
+    (job.schedule.kind === "at" &&
+      (!job.enabled || (persistedNextRunAtMs !== undefined && persistedNextRunAtMs > startedAt)))
       ? "stale"
       : "current";
   // A once result can record no next run before a later edit retires its

--- a/src/cron/service/timer-catchup.ts
+++ b/src/cron/service/timer-catchup.ts
@@ -172,6 +172,7 @@ function commitStartupCatchupRows(params: {
           if (ownership.markerAtMs === job.state.runningAtMs) {
             delete job.state.runningAtMs;
             delete job.state.runningReceiptId;
+            delete job.state.runningScheduleChangeId;
             changed = true;
           }
         }

--- a/src/cron/service/timer-outcomes.ts
+++ b/src/cron/service/timer-outcomes.ts
@@ -49,7 +49,8 @@ function resolveCronRunScheduleOwnership(params: {
   currentJob: CronJob;
   activeJobMarker?: CronActiveJobMarker;
 }): CronScheduleOwnership {
-  return params.activeJobMarker?.scheduleMutated === true ||
+  return typeof params.currentJob.state.runningScheduleChangeId === "string" ||
+    params.activeJobMarker?.scheduleMutated === true ||
     !cronSchedulingInputsEqual(params.admittedJob, params.currentJob)
     ? "stale"
     : "current";
@@ -103,6 +104,7 @@ export function applyJobResult(
   job.state.queuedAtMs = undefined;
   job.state.runningAtMs = undefined;
   job.state.runningReceiptId = undefined;
+  delete job.state.runningScheduleChangeId;
   job.state.pacedNextRunAtMs = undefined;
   job.state.forcePreservedNextRunAtMs = undefined;
   job.state.lastRunAtMs = result.startedAt;
@@ -598,6 +600,7 @@ export function applyTriggerNoFireResult(
   job.state.queuedAtMs = undefined;
   job.state.runningAtMs = undefined;
   job.state.runningReceiptId = undefined;
+  delete job.state.runningScheduleChangeId;
   job.updatedAtMs = result.endedAt;
   if (!result.triggerEval.busy && opts?.triggerOwnership !== "stale") {
     // A non-firing evaluation is successful scheduler work, not a payload run;

--- a/src/cron/types.ts
+++ b/src/cron/types.ts
@@ -346,6 +346,8 @@ export type CronJobState = Omit<
   queuedAtMs?: number;
   /** Exact receipt awaiting scheduler reconciliation, even after execution authority closes. */
   runningReceiptId?: string;
+  /** Nonce for a committed schedule edit during the pending run. */
+  runningScheduleChangeId?: string;
   /** Number of consecutive schedule computation errors. Auto-disables job after threshold. */
   scheduleErrorCount?: number;
   /** @deprecated Use lastRunStatus. */
@@ -437,7 +439,11 @@ export type CronStoreFile = {
 type CronJobStateInput = Partial<
   Omit<
     CronJobState,
-    "autoDisabled" | "scheduleActivatedAtMs" | "streamSourceIdentity" | "runningReceiptId"
+    | "autoDisabled"
+    | "scheduleActivatedAtMs"
+    | "streamSourceIdentity"
+    | "runningReceiptId"
+    | "runningScheduleChangeId"
   >
 >;
 


### PR DESCRIPTION
Refs #145722

## What Problem This Solves

After a completed run saved its history but failed to update the job row, startup recovery could replace a newly acknowledged cadence with the old run's next-check time. An hourly-to-minute edit reproduced a delay of 58 minutes and 58 seconds.

## Why This Change Was Made

Record each committed scheduling edit with the pending run in the same transaction as the edit. Completion and recovery can then settle that run while preserving the acknowledged scheduling state, including repeated or backward clocks and a passive editor whose snapshot spans successive runs. Starting a new run and cleaning up pending-run state clear the private marker. This builds on the landed run-identity protection in #145734 and adds no schema migration or public API field.

Pending runs edited by older builds retain legacy recovery behavior when no durable edit marker exists. Older builds do not enforce the new protection; complete pending runs and scheduler reconciliation before downgrading when the edited cadence must be preserved. The canonical cron and database compatibility docs describe these boundaries.

## User Impact

Newly acknowledged cadence and pacing edits retain their next check through recovery. Completed history remains available, and recovery does not rerun the completed payload. Unchanged jobs retain their normal completion and retry behavior.

## Evidence

- All 732 selected native tests across 37 files pass on `26c1c100`, after integrating the landed run-identity fix. The run uses real CronService paths and SQLite, including completion-write failure and child-process races.

- Native fault injection covers late edits, repeated and backward clocks, cron overlap, timed/stream transitions, pacing, transient-error deadlines, unchanged/idempotent/failed-edit controls, once-run successors, and a separate-process editor spanning two runs.
- The run-identity and receipt-retention suites also exercise the integrated behavior from #145734. Public projection and patch tests verify that clients cannot read or forge the private marker.
- Released v2026.9.4 compatibility proof uses its own frozen dependencies: it reads the additive pending state without changing the database, writes a separate settled fixture, and the candidate reopens that fixture successfully. Pending downgrade protection is explicitly excluded.
- Local checks passed for formatting, type-aware lint, line and assertion ratchets, conflict hygiene, and unchanged state schema 17. Full remote changed-path validation and required hosted CI are landing gates for the exact PR head.
