### PR TITLE
refactor(heartbeat): select response and scratch source together

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt-result.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-result.test.ts
@@ -1,8 +1,7 @@
+import { expectDefined } from "@openclaw/normalization-core";
 import { describe, expect, it, vi } from "vitest";
-import {
-  resolveHeartbeatScratchProposalFromReplyResult,
-  resolveHeartbeatToolResponseFromReplyResult,
-} from "../../../auto-reply/heartbeat-tool-response.js";
+import { selectHeartbeatToolResponse } from "../../../auto-reply/heartbeat-tool-response.js";
+import { getReplyPayloadMetadata } from "../../../auto-reply/reply-payload.js";
 import { HEARTBEAT_TOKEN } from "../../../auto-reply/tokens.js";
 import { createHookRunner } from "../../../plugins/hooks.js";
 import { makeAssistantMessageFixture } from "../../test-helpers/assistant-message-fixtures.js";
@@ -589,8 +588,12 @@ describe("attempt result projection", () => {
 
       expect(payloads).toHaveLength(1);
       expect(payloads[0]?.text).toBe(expectedText);
-      expect(resolveHeartbeatToolResponseFromReplyResult(payloads)).toEqual(publicResponse);
-      expect(resolveHeartbeatScratchProposalFromReplyResult(payloads)).toBe(scratch);
+      const selected = expectDefined(
+        selectHeartbeatToolResponse(payloads),
+        "expected the carried heartbeat response",
+      );
+      expect(selected.response).toEqual(publicResponse);
+      expect(getReplyPayloadMetadata(selected.payload)?.heartbeatScratchProposal).toBe(scratch);
       expect(JSON.stringify(payloads)).not.toContain(scratch);
       expect(JSON.stringify(payloads)).not.toContain("Internal retry fallback.");
     },
@@ -620,8 +623,11 @@ describe("attempt result projection", () => {
 
     expect(payloads).toHaveLength(1);
     expect(payloads[0]?.text).toBe("The new task is still running.");
-    expect(resolveHeartbeatToolResponseFromReplyResult(payloads)).toBeUndefined();
-    expect(resolveHeartbeatScratchProposalFromReplyResult(payloads)).toBeUndefined();
+    expect(selectHeartbeatToolResponse(payloads)).toBeUndefined();
+    expect(
+      getReplyPayloadMetadata(expectDefined(payloads[0], "expected the fresh-run payload"))
+        ?.heartbeatScratchProposal,
+    ).toBeUndefined();
   });
 
   it("keeps completed client tool calls in reserved source order", () => {

--- a/src/agents/embedded-agent-runner/run/payloads.test.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.test.ts
@@ -3,7 +3,7 @@
 import type { AssistantMessage } from "openclaw/plugin-sdk/llm";
 import { describe, expect, it } from "vitest";
 import { resolveHeartbeatReplyPayload } from "../../../auto-reply/heartbeat-reply-payload.js";
-import { resolveHeartbeatToolResponseFromReplyResult } from "../../../auto-reply/heartbeat-tool-response.js";
+import { selectHeartbeatToolResponse } from "../../../auto-reply/heartbeat-tool-response.js";
 import { getReplyPayloadMetadata } from "../../../auto-reply/reply-payload.js";
 import type { InteractiveReply, MessagePresentation } from "../../../interactive/payload.js";
 import {
@@ -663,7 +663,7 @@ describe("buildEmbeddedRunPayloads tool-error warnings", () => {
       isError: true,
       text: expect.stringContaining("Message failed"),
     });
-    expect(resolveHeartbeatToolResponseFromReplyResult(payloads)).toEqual({
+    expect(selectHeartbeatToolResponse(payloads)?.response).toEqual({
       outcome: "no_change",
       notify: false,
       summary: "Nothing needs attention.",

--- a/src/auto-reply/heartbeat-tool-response.test.ts
+++ b/src/auto-reply/heartbeat-tool-response.test.ts
@@ -1,8 +1,10 @@
+import { expectDefined } from "@openclaw/normalization-core";
 import { describe, expect, it } from "vitest";
 import {
   createHeartbeatToolResponsePayload,
-  resolveHeartbeatScratchProposalFromReplyResult,
+  selectHeartbeatToolResponse,
 } from "./heartbeat-tool-response.js";
+import { getReplyPayloadMetadata } from "./reply-payload.js";
 
 describe("heartbeat scratch proposal resolution", () => {
   it("lets a later heartbeat response clear an earlier scratch proposal", () => {
@@ -18,6 +20,11 @@ describe("heartbeat scratch proposal resolution", () => {
       summary: "corrected",
     });
 
-    expect(resolveHeartbeatScratchProposalFromReplyResult([first, corrected])).toBeUndefined();
+    const selected = expectDefined(
+      selectHeartbeatToolResponse([first, corrected]),
+      "expected the corrected heartbeat response",
+    );
+    expect(selected.response.summary).toBe("corrected");
+    expect(getReplyPayloadMetadata(selected.payload)?.heartbeatScratchProposal).toBeUndefined();
   });
 });

--- a/src/auto-reply/heartbeat-tool-response.ts
+++ b/src/auto-reply/heartbeat-tool-response.ts
@@ -3,11 +3,7 @@ import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeOptionalString as readString } from "@openclaw/normalization-core/string-coerce";
 import { assertCronJobScratchContent } from "../cron/scratch-contract.js";
 import { readTrimmedStringAlias } from "../utils/string-readers.js";
-import {
-  getReplyPayloadMetadata,
-  setReplyPayloadMetadata,
-  type ReplyPayload,
-} from "./reply-payload.js";
+import { setReplyPayloadMetadata, type ReplyPayload } from "./reply-payload.js";
 import { HEARTBEAT_TOKEN } from "./tokens.js";
 
 /** Tool name used by heartbeat runs to report visible or silent progress. */
@@ -102,51 +98,22 @@ export function createHeartbeatToolResponsePayload(response: HeartbeatToolRespon
   return payload;
 }
 
-function getHeartbeatToolResponseFromPayload(
-  payload: ReplyPayload | undefined,
-): HeartbeatToolResponse | undefined {
-  return normalizeHeartbeatToolResponse(
-    payload?.channelData?.[HEARTBEAT_RESPONSE_CHANNEL_DATA_KEY],
-  );
-}
-
-/** Find the last heartbeat tool response embedded in a reply result. */
-export function resolveHeartbeatToolResponseFromReplyResult(
+/** Select the newest valid response and retain its private metadata carrier. */
+export function selectHeartbeatToolResponse(
   replyResult: ReplyPayload | ReplyPayload[] | undefined,
-): HeartbeatToolResponse | undefined {
-  if (!replyResult) {
-    return undefined;
-  }
-  const payloads = Array.isArray(replyResult) ? replyResult : [replyResult];
-  for (let idx = payloads.length - 1; idx >= 0; idx -= 1) {
-    const response = getHeartbeatToolResponseFromPayload(payloads[idx]);
-    if (response) {
-      return response;
-    }
-  }
-  return undefined;
-}
-
-/** Reads the private scratch proposal captured for the heartbeat turn. */
-export function resolveHeartbeatScratchProposalFromReplyResult(
-  replyResult: ReplyPayload | ReplyPayload[] | undefined,
-): string | undefined {
+): { response: HeartbeatToolResponse; payload: ReplyPayload } | undefined {
   if (!replyResult) {
     return undefined;
   }
   const payloads = Array.isArray(replyResult) ? replyResult : [replyResult];
   for (let idx = payloads.length - 1; idx >= 0; idx -= 1) {
     const payload = payloads[idx];
-    if (!payload) {
-      continue;
+    const response = normalizeHeartbeatToolResponse(
+      payload?.channelData?.[HEARTBEAT_RESPONSE_CHANNEL_DATA_KEY],
+    );
+    if (response && payload) {
+      return { response, payload };
     }
-    // Anchor to the newest heartbeat-response payload: a later corrected
-    // response without scratch must supersede an earlier scratch proposal,
-    // so the scan stops at the first response payload either way.
-    if (!getHeartbeatToolResponseFromPayload(payload)) {
-      continue;
-    }
-    return getReplyPayloadMetadata(payload)?.heartbeatScratchProposal;
   }
   return undefined;
 }

--- a/src/auto-reply/reply/agent-runner-payloads.test.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.test.ts
@@ -13,10 +13,7 @@ import {
   createChannelTestPluginBase,
   createTestRegistry,
 } from "../../test-utils/channel-plugins.js";
-import {
-  resolveHeartbeatScratchProposalFromReplyResult,
-  resolveHeartbeatToolResponseFromReplyResult,
-} from "../heartbeat-tool-response.js";
+import { selectHeartbeatToolResponse } from "../heartbeat-tool-response.js";
 import {
   getReplyPayloadMetadata,
   markReplyPayloadForSourceSuppressionDelivery,
@@ -93,12 +90,20 @@ describe("heartbeat reply scratch", () => {
         }),
       );
       const expected = proposals.at(-1);
-      expect(resolveHeartbeatScratchProposalFromReplyResult(payloads)).toBe(expected);
+      const embedded = expectDefined(
+        selectHeartbeatToolResponse(payloads),
+        "expected the embedded heartbeat response",
+      );
+      expect(getReplyPayloadMetadata(embedded.payload)?.heartbeatScratchProposal).toBe(expected);
       const { replyPayloads } = await buildTestReplyPayloads({ isHeartbeat: true, payloads });
 
       expect(replyPayloads).toHaveLength(proposals.length);
-      expect(resolveHeartbeatScratchProposalFromReplyResult(replyPayloads)).toBe(expected);
-      expect(resolveHeartbeatToolResponseFromReplyResult(replyPayloads)).toEqual({
+      const selected = expectDefined(
+        selectHeartbeatToolResponse(replyPayloads),
+        "expected the final heartbeat response",
+      );
+      expect(getReplyPayloadMetadata(selected.payload)?.heartbeatScratchProposal).toBe(expected);
+      expect(selected.response).toEqual({
         outcome: "done",
         notify,
         summary: `Monitor checked ${proposals.length}.`,

--- a/src/infra/heartbeat-dispatch.ts
+++ b/src/infra/heartbeat-dispatch.ts
@@ -5,13 +5,13 @@ import {
   resolveHeartbeatTerminalToolFailure,
 } from "../auto-reply/heartbeat-reply-payload.js";
 import {
-  resolveHeartbeatScratchProposalFromReplyResult,
-  resolveHeartbeatToolResponseFromReplyResult,
+  selectHeartbeatToolResponse,
   type HeartbeatToolResponse,
 } from "../auto-reply/heartbeat-tool-response.js";
 import { DEFAULT_HEARTBEAT_ACK_MAX_CHARS } from "../auto-reply/heartbeat.js";
 import {
   copyReplyPayloadMetadata,
+  getReplyPayloadMetadata,
   markReplyPayloadForSourceSuppressionDelivery,
   setReplyPayloadMetadata,
   type ReplyPayload,
@@ -170,7 +170,8 @@ async function prepareHeartbeatDispatchReply(
   const replies = replyResult ? (Array.isArray(replyResult) ? replyResult : [replyResult]) : [];
   const selected = resolveHeartbeatReplyPayload(replyResult);
   const execution = resolveReplyOperationAgentTurn(runState);
-  const response = resolveHeartbeatToolResponseFromReplyResult(replyResult);
+  const heartbeatResponse = selectHeartbeatToolResponse(replyResult);
+  const response = heartbeatResponse?.response;
   // Admission can lose to foreground work after preflight. An empty rejected
   // turn must leave its events queued, unlike a completed quiet turn.
   const admissionBusy =
@@ -220,9 +221,9 @@ async function prepareHeartbeatDispatchReply(
     ackMaxChars: DEFAULT_HEARTBEAT_ACK_MAX_CHARS,
   });
   const scratch =
-    outcome.kind === "failure"
+    outcome.kind === "failure" || !heartbeatResponse
       ? undefined
-      : resolveHeartbeatScratchProposalFromReplyResult(replyResult);
+      : getReplyPayloadMetadata(heartbeatResponse.payload)?.heartbeatScratchProposal;
   if (scratch !== undefined && response) {
     if (!preflight.scratchJobId) {
       log.warn("heartbeat: scratch update ignored because no monitor job exists");


### PR DESCRIPTION
## What Problem This Solves

Heartbeat dispatch independently selects and normalizes the newest structured response twice: first for delivery policy, then again to locate its private scratch proposal.

## Why This Change Was Made

Select the newest valid response once and carry its original payload as the metadata source. Scratch is still read after classification and suppressed on failure; a newer valid response without scratch still supersedes an earlier proposal. Remove both duplicate internal selectors and their single-use wrapper, and migrate all four existing test consumers. The normalizer, scratch/CAS owner and public SDK surface remain unchanged.

This maintainer-requested cleanup removes 32 production lines after formatting, with 18 lines added to preserve and clarify existing test assertions. It is **not a general speedup or memory-saving claim**.

## User Impact

No intended routing, notification, or scratch behavior change. Private scratch remains outside public replies. Empty replacement, later omission, failure/cancellation and concurrent-revision handling retain their existing semantics.

## Evidence

- Independent Codex P2 review: scoped-clean, no actionable findings; final source remained unchanged afterward.
- All **215 tests across five files passed**, with no failures or skips: heartbeat-tool-response (1), agent-runner-payloads (87), embedded run/payloads (51), run/attempt-result (40), heartbeat-runner.tool-response (36). Upstream direct-block-delivery test changes remain intact.
- Own frozen dependency install, pinned Node 26.8.1/pnpm 12.3.4, matching Oxfmt 0.66.0 check, changed-plan inspection and whitespace diff check passed. The test child closed in 81.19 seconds with 2.97 GB observed peak tree RSS, within its 6 GiB limit.
- One historical native Linux comparison at `b4c35afcc53430eaf46fc079c8461dbd2727b142` completed **15 scenarios / 540 actual runHeartbeatOnce calls / 405 full graph comparisons**. Response, dispatch, session/scratch/outcome, private metadata, privacy and CAS checks passed. The runner and SQLite owners were real; completion and notification transport were synthetic, not a live provider test. All native processes closed, source restoration/worktree removal passed, and both task leases were closed.

**Local changed gates are not claimed green.** The 25 smaller guards listed below were **unrun** because their phase refused the unchanged 3 GiB disk admission floor before spawning any child. Removing only completed task-private transform/Node caches did not restore that floor; dependencies, shared caches and every raw report/receipt were preserved. Three additional broad lanes—`pnpm tsgo:core`, `pnpm tsgo:core:test`, and type-aware core lint for the six changed files—remain **hosted pending**, without repeating known host-limit failures. Full hosted CI must cover these outstanding gates before landing.

<details>
<summary>25 smaller changed guards still unrun locally</summary>

- `pnpm check:no-conflict-markers`
- `pnpm check:max-lines-ratchet --base e6a3bdf79ea05649f755663b68bf0ce2b6aa2b19`
- `pnpm check:assertion-safety --base e6a3bdf79ea05649f755663b68bf0ce2b6aa2b19`
- `pnpm check:changelog-attributions`
- `pnpm check:doctor-deprecation-registry`
- `pnpm lint:extensions:no-guarded-wildcard-reexports`
- `pnpm lint:extensions:no-plugin-sdk-wildcard-reexports`
- `pnpm dup:check:coverage`
- `pnpm deps:pins:check`
- `pnpm plugins:boundary-report:ci`
- `pnpm check:wrapper-shadowing`
- `pnpm deps:patches:check`
- `node scripts/report-test-temp-creations.mjs --base e6a3bdf79ea05649f755663b68bf0ce2b6aa2b19 --head HEAD`
- `pnpm lint:tmp:tsgo-core-boundary`
- `pnpm check:coercion-helpers`
- `pnpm check:deprecated-api-usage`
- `node --import tsx scripts/check-deadcode-exports.mts`
- `node scripts/check-native-state-schema-version.mjs`
- `pnpm check:database-first-legacy-stores`
- `pnpm check:media-download-helpers`
- `pnpm check:runtime-sidecar-loaders`
- `pnpm check:import-cycles`
- `pnpm lint:webhook:no-low-level-body-read`
- `pnpm lint:auth:no-pairing-store-group`
- `pnpm lint:auth:pairing-account-scope`

</details>

Historical timings remain mixed: **6/15 forward and 9/15 reverse wall medians were adverse**. Scratch-limit wall regressed in both orders (**+9.52% / +6.11%**), as did supersession (**+2.42% / +2.72%**). Later-omission reverse wall was **+74.65%**, with **+85.94% CPU**. Kernel peak RSS increased **+1.29% / +2.17%**; process-tree peak RSS increased **+1.32% / +2.39%**. No retiming or favorable-case filtering followed cleanup acceptance.

<details>
<summary>All historical median timing changes</summary>

Candidate change relative to its contemporaneous baseline; positive is adverse. The two orders are B1→C1 and B2→C2.

| Case | Wall forward / reverse | CPU forward / reverse |
|---|---:|---:|
| quiet | -1.63% / +1.66% | -7.07% / +0.93% |
| notify | -53.91% / +3.12% | -54.64% / -1.46% |
| empty | -47.09% / -5.03% | -46.56% / -5.15% |
| ordinary | +6.03% / -3.27% | +4.04% / -1.47% |
| invalid-tail-32 | +3.24% / -0.85% | +2.23% / +3.16% |
| later-omission | -2.25% / +74.65% | +2.67% / +85.94% |
| empty-scratch | -2.25% / +3.70% | +3.59% / +4.94% |
| unicode | -4.17% / +2.68% | -2.26% / -0.70% |
| scratch-limit | +9.52% / +6.11% | +5.03% / +5.30% |
| scratch-overlimit | -4.38% / +10.47% | -3.42% / +10.80% |
| failed | +6.22% / -2.12% | +3.84% / -14.25% |
| cancelled | +3.89% / -6.50% | +4.37% / -21.09% |
| superseded | +2.42% / +2.72% | +2.37% / -2.50% |
| missing-monitor | -0.11% / +3.48% | -1.96% / +1.08% |
| revision-conflict | -4.36% / -0.96% | -3.77% / -10.74% |

Whole-process forward/reverse wall changed −5.84% / +0.89%, user CPU −4.08% / −0.18%, and system CPU −11.30% / +7.48%. Those process totals include imports, fixture setup, post-timing readback and shutdown. Full raw samples and all adverse values remain retained.

</details>

The original argument-limit staging failure, oversized-XZ preflight and reconciled SSH transport failure remain preserved. Exact tar/member verification preceded the single actual experiment; these failures were not relabeled as passing measurements. The earlier Vitest packet remained unexecuted after its known compiled-worker prerequisite was identified. The Darwin author tests are validation, not a new timing comparison with the historical Linux run.
