### PR TITLE
fix(mcp): accept already-ended session cleanup

### DIFF
--- a/src/agents/mcp-http-transport.test.ts
+++ b/src/agents/mcp-http-transport.test.ts
@@ -556,7 +556,9 @@ describe("OpenClaw MCP HTTP lifecycle adapters", () => {
       }
       response.writeHead(405).end();
     });
-    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", resolve);
+    });
     try {
       const address = server.address();
       if (!address || typeof address === "string") {

--- a/src/agents/mcp-http-transport.test.ts
+++ b/src/agents/mcp-http-transport.test.ts
@@ -521,6 +521,67 @@ describe("OpenClaw MCP HTTP lifecycle adapters", () => {
     },
   );
 
+  it("treats a server-already-terminated DELETE 404 as successful cleanup", async () => {
+    let deleteCount = 0;
+    const server = createServer((request, response) => {
+      if (request.method === "POST") {
+        let body = "";
+        request.setEncoding("utf8");
+        request.on("data", (chunk: string) => (body += chunk));
+        request.on("end", () => {
+          const message = JSON.parse(body) as { id?: number };
+          response.writeHead(200, {
+            "content-type": "application/json",
+            "mcp-session-id": "already-terminated",
+          });
+          response.end(
+            JSON.stringify({
+              jsonrpc: "2.0",
+              id: message.id,
+              result: {
+                protocolVersion: "2025-06-18",
+                capabilities: {},
+                serverInfo: { name: "fixture", version: "1" },
+              },
+            }),
+          );
+        });
+        return;
+      }
+      if (request.method === "DELETE") {
+        deleteCount += 1;
+        response.writeHead(404, { "content-type": "text/plain" });
+        response.end("session already gone");
+        return;
+      }
+      response.writeHead(405).end();
+    });
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    try {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        throw new Error("expected loopback TCP address");
+      }
+      const transport = new OpenClawStreamableHTTPClientTransport(
+        new URL(`http://127.0.0.1:${address.port}/mcp`),
+      );
+      const client = new Client({ name: "test", version: "1" });
+      await client.connect(transport);
+
+      await expect(transport.terminateSession()).resolves.toBeUndefined();
+      await transport.terminateSession();
+      expect(deleteCount).toBe(1);
+      await expect(
+        disposeMcpClient({ client, transport, transportType: "streamable-http" }),
+      ).resolves.toBe("closed");
+    } finally {
+      await new Promise<void>((resolve) => {
+        server.close(() => resolve());
+        server.closeAllConnections();
+      });
+    }
+  });
+
   it("accepts unsupported session DELETE without sending it again", async () => {
     const onDelete = vi.fn(() => new Response(null, { status: 405 }));
     const fetchMock = initializedFetch({

--- a/src/agents/mcp-http-transport.ts
+++ b/src/agents/mcp-http-transport.ts
@@ -377,7 +377,9 @@ export class OpenClawStreamableHTTPClientTransport extends OpenClawMcpHttpTransp
       signal: AbortSignal.timeout(SESSION_TERMINATION_TIMEOUT_MS),
     });
     void response.body?.cancel().catch(() => undefined);
-    if (!response.ok && response.status !== 405) {
+    // A terminated session is no longer addressable; MCP servers report 404
+    // for that id, which is already the desired outcome of cleanup.
+    if (!response.ok && response.status !== 404 && response.status !== 405) {
       throw new StreamableHTTPError(
         response.status,
         `Failed to terminate session: ${response.statusText}`,


### PR DESCRIPTION
## What Problem This Solves

MCP Streamable HTTP cleanup reports an error when `DELETE` receives `404 Not Found` for a session that the server has already terminated. That turns idempotent cleanup into an uncertain lifecycle result and can surface false cleanup failures during client disposal.

## Why This Change Was Made

The MCP session-management contract permits a server to report `404` when a request carries a session ID that no longer exists. `terminateSession()` already treats `405 Method Not Allowed` as a completed cleanup when explicit termination is unsupported; it now applies the same completed-cleanup semantics to `404`, while retaining failures for other statuses.

## User Impact

Already-ended MCP sessions no longer produce false cleanup failures. Authentication, server, and other unexpected DELETE errors remain visible.

## Evidence

- Issue: https://github.com/openclaw/openclaw/issues/144860
- Dependency source inspected: `node_modules/@modelcontextprotocol/sdk/dist/esm/client/streamableHttp.js` (`terminateSession()` handles 405 only; OpenClaw owns the additional 404 lifecycle policy).
- MCP session-management specification: https://modelcontextprotocol.io/specification/2025-06-18/basic/transports#session-management
- Pre-fix regression: a real loopback HTTP server returned 404 to DELETE and `terminateSession()` rejected with `Failed to terminate session: Not Found`.
- Exact-head regression: the same loopback server now completes termination, does not send a second DELETE, and client disposal returns `closed`.

```text
$ node scripts/run-vitest.mjs src/agents/mcp-http-transport.test.ts
Test Files  1 passed (1)
Tests       19 passed (19)

$ git diff --check origin/main...HEAD
exit=0
```

The changed production surface is one status predicate (+3 lines including the invariant comment); test coverage adds one real loopback transport regression.

---

## Maintainer validation

## What Problem This Solves

`openclaw doctor --lint` reports failed cleanup when an MCP server returns DELETE 404 for a session it has already ended. The user receives advice to inspect child processes even though the connection is HTTP.

## Why This Change Was Made

The existing HTTP transport accepts DELETE 404 as completed cleanup and records the session as terminated. Repeated sequential cleanup sends no second DELETE. The [MCP session-management contract](https://modelcontextprotocol.io/specification/2025-06-18/basic/transports#session-management) requires servers to return 404 for requests carrying an ended session's ID.

## User Impact

- Already-ended sessions no longer cause false cleanup failures.
- Existing 2xx and 405 behavior stays intact. Explicit DELETE 401/403, server errors, and local-close failures still produce uncertain cleanup.
- A server or proxy that disguises an authorization or routing failure as DELETE 404 is indistinguishable from an ended session here. Local disposal still closes the client; the server may retain the remote session until expiry.
- No config or state migration is needed.

## Evidence

- The registered command `pnpm openclaw doctor --lint --json --only core/doctor/runtime-tool-schemas` failed on main and passed on contributor head `851f2e83d4116281ae865b5ba7d75906bb592174` against a real loopback HTTP server.
- DELETE 404 changed from exit 1 with a cleanup finding to exit 0 with no findings. The 405 control stayed clean; 401 and 500 still failed.
- Fresh direct disposal and repeated sequential termination followed by disposal each returned `closed` after one DELETE for 404. Controls retained 204/405 success and 401/403/500 uncertainty.
- A fresh local merge with main passed 125 transport, cleanup, node-recovery, and Doctor tests; 785 routing tests; and the test-root partition check. Changed-file lint and formatting passed.
- The existing CI gate is green on the exact contributor head. That CI result is separate from the local merge checks; the full fallback suite was not repeated on the local merge.
- The added loopback test covers the real adapter. The separate retained Doctor and fresh-disposal recordings cover the complete product flow.

## Consumers

Doctor, Gateway-managed MCP runtimes, plugin-supplied MCP servers, node-host cleanup, and MCP CLI probes share the same transport owner. Session retirement drops local authority before cleanup. Active-request and notification-stream 404 errors retain their existing fresh-session recovery paths without replaying failed tool calls.

The wrapper sends DELETE itself and does not call the dependency's `terminateSession()`. A future change limited to that dependency method will not add a second DELETE path.

Validation CI: [run 34799773048](https://github.com/openclaw/openclaw/actions/runs/34799773048), attempt 2, is green on the unchanged contributor head.
