### PR TITLE
fix(system-agent): avoid onboarding advice for failed requests

### DIFF
--- a/src/system-agent/agent-turn.terminal.test.ts
+++ b/src/system-agent/agent-turn.terminal.test.ts
@@ -154,7 +154,7 @@ describe("system-agent terminal failure cleanup", () => {
       ),
     ).rejects.toMatchObject({
       code: "SYSTEM_AGENT_INFERENCE_UNAVAILABLE",
-      message: expect.not.stringContaining("openclaw onboard"),
+      message: expect.stringContaining("OpenClaw could not complete this request. Try again."),
     });
     expect(session.proposalRef.current).toBeUndefined();
     expect(session.proposalRef.operation).toBeUndefined();

--- a/src/system-agent/agent-turn.terminal.test.ts
+++ b/src/system-agent/agent-turn.terminal.test.ts
@@ -3,7 +3,6 @@ import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import type { OpenClawConfig } from "../config/types.js";
 import { createSystemAgentSession } from "./agent-turn.js";
 import { runSystemAgentTurnWithDeps as runSystemAgentTurnWithDepsImpl } from "./agent-turn.test-support.js";
-import { SystemAgentInferenceUnavailableError } from "./inference-error.js";
 import {
   createSystemAgentVerifiedInferenceTestFixture as createSystemAgentVerifiedInferenceTestFixtureImpl,
   createSystemAgentPluginMetadataTestSnapshot,
@@ -37,6 +36,12 @@ describe("system-agent terminal failure cleanup", () => {
       name: "runner rejection",
       runEmbeddedAgent: async () => {
         throw new Error("provider unavailable");
+      },
+    },
+    {
+      name: "runner rejection without error text",
+      runEmbeddedAgent: async () => {
+        throw new Error("   ");
       },
     },
     {
@@ -147,7 +152,10 @@ describe("system-agent terminal failure cleanup", () => {
           })) as never,
         },
       ),
-    ).rejects.toBeInstanceOf(SystemAgentInferenceUnavailableError);
+    ).rejects.toMatchObject({
+      code: "SYSTEM_AGENT_INFERENCE_UNAVAILABLE",
+      message: expect.not.stringContaining("openclaw onboard"),
+    });
     expect(session.proposalRef.current).toBeUndefined();
     expect(session.proposalRef.operation).toBeUndefined();
     expect(session.cliSession).toBeUndefined();

--- a/src/system-agent/agent-turn.test.ts
+++ b/src/system-agent/agent-turn.test.ts
@@ -355,65 +355,78 @@ describe("runSystemAgentTurn", () => {
     );
   });
 
-  it("rejects an always-on CLI backend before launching OpenClaw", async () => {
-    useTempStateDir();
-    cliBackendsTesting.setDepsForTest({
-      resolveRuntimeCliBackends: () => [
-        {
-          id: "google-gemini-cli",
-          pluginId: "google",
-          modelProvider: "google",
-          config: { command: "gemini" },
-          nativeToolMode: "always-on",
+  it.each(["always-on", "selectable"] as const)(
+    "rejects a %s CLI backend without tool enforcement before launching OpenClaw",
+    async (nativeToolMode) => {
+      useTempStateDir();
+      cliBackendsTesting.setDepsForTest({
+        resolveRuntimeCliBackends: () => [
+          {
+            id: "google-gemini-cli",
+            pluginId: "google",
+            modelProvider: "google",
+            config: { command: "gemini" },
+            nativeToolMode,
+          },
+        ],
+      });
+      const config = {
+        agents: {
+          defaults: {
+            model: "google-gemini-cli/gemini-3.1-pro-preview",
+          },
         },
-      ],
-    });
-    const config = {
-      agents: {
-        defaults: {
-          model: "google-gemini-cli/gemini-3.1-pro-preview",
-        },
-      },
-    } as OpenClawConfig;
-    const runCliAgent = vi.fn();
-    const runEmbeddedAgent = vi.fn();
-    const { session, deps } = await createVerifiedSession(config);
-    let failure: unknown;
+      } as OpenClawConfig;
+      const runCliAgent = vi.fn();
+      const runEmbeddedAgent = vi.fn();
+      const { session, deps } = await createVerifiedSession(config);
+      session.proposalRef.current = "partial-proposal";
+      session.proposalRef.operation = { kind: "setup" };
+      session.cliSession = {
+        routeKey: "stale-route",
+        binding: { sessionId: "uncertain-cli-session" },
+      };
+      let failure: unknown;
 
-    try {
-      await runSystemAgentTurnWithDeps(
-        {
-          input: "set up my workspace",
-          overview: { defaultModel: "google-gemini-cli/gemini-3.1-pro-preview" } as never,
-          surface: "gateway",
-          approvalArmed: false,
-          session,
-        },
-        {
-          ...deps,
-          runCliAgent: runCliAgent as never,
-          runEmbeddedAgent: runEmbeddedAgent as never,
-          readConfigFileSnapshot: vi.fn(async () => configSnapshot(config)) as never,
-        },
-      );
-    } catch (error) {
-      failure = error;
-    }
+      try {
+        await runSystemAgentTurnWithDeps(
+          {
+            input: "set up my workspace",
+            overview: { defaultModel: "google-gemini-cli/gemini-3.1-pro-preview" } as never,
+            surface: "gateway",
+            approvalArmed: false,
+            session,
+          },
+          {
+            ...deps,
+            runCliAgent: runCliAgent as never,
+            runEmbeddedAgent: runEmbeddedAgent as never,
+            readConfigFileSnapshot: vi.fn(async () => configSnapshot(config)) as never,
+          },
+        );
+      } catch (error) {
+        failure = error;
+      }
 
-    expect(failure).toBeInstanceOf(SystemAgentInferenceUnavailableError);
-    const unavailable = failure as SystemAgentInferenceUnavailableError;
-    expect(unavailable.failures).toEqual([
-      expect.objectContaining({
-        message: expect.stringContaining(
-          "CLI backend google-gemini-cli cannot enforce OpenClaw's exact tool availability",
-        ),
-      }),
-    ]);
-    expect(unavailable.message).not.toContain("openclaw onboard");
-    expect(unavailable.cause).toBe(unavailable.failures[0]);
-    expect(runCliAgent).not.toHaveBeenCalled();
-    expect(runEmbeddedAgent).not.toHaveBeenCalled();
-  });
+      expect(failure).toBeInstanceOf(SystemAgentInferenceUnavailableError);
+      const unavailable = failure as SystemAgentInferenceUnavailableError;
+      expect(unavailable.failures).toEqual([
+        expect.objectContaining({
+          message: expect.stringContaining(
+            "CLI backend google-gemini-cli cannot enforce OpenClaw's exact tool availability",
+          ),
+        }),
+      ]);
+      expect(unavailable.message).toContain("Choose a compatible model or CLI backend");
+      expect(unavailable.message).not.toContain("Try again");
+      expect(unavailable.message).not.toContain("openclaw onboard");
+      expect(unavailable.cause).toBe(unavailable.failures[0]);
+      expect(session.proposalRef).toEqual({});
+      expect(session.cliSession).toBeUndefined();
+      expect(runCliAgent).not.toHaveBeenCalled();
+      expect(runEmbeddedAgent).not.toHaveBeenCalled();
+    },
+  );
 
   it.each(["timeout", "aborted"] as const)(
     "resumes Claude's native transcript and clears continuity after a partial %s",

--- a/src/system-agent/agent-turn.test.ts
+++ b/src/system-agent/agent-turn.test.ts
@@ -401,13 +401,16 @@ describe("runSystemAgentTurn", () => {
     }
 
     expect(failure).toBeInstanceOf(SystemAgentInferenceUnavailableError);
-    expect((failure as SystemAgentInferenceUnavailableError).failures).toEqual([
+    const unavailable = failure as SystemAgentInferenceUnavailableError;
+    expect(unavailable.failures).toEqual([
       expect.objectContaining({
         message: expect.stringContaining(
           "CLI backend google-gemini-cli cannot enforce OpenClaw's exact tool availability",
         ),
       }),
     ]);
+    expect(unavailable.message).not.toContain("openclaw onboard");
+    expect(unavailable.cause).toBe(unavailable.failures[0]);
     expect(runCliAgent).not.toHaveBeenCalled();
     expect(runEmbeddedAgent).not.toHaveBeenCalled();
   });
@@ -955,7 +958,11 @@ describe("runSystemAgentTurn", () => {
           readConfigFileSnapshot: readConfigFileSnapshot as never,
         },
       ),
-    ).rejects.toBeInstanceOf(SystemAgentInferenceUnavailableError);
+    ).rejects.toMatchObject({
+      code: "SYSTEM_AGENT_INFERENCE_UNAVAILABLE",
+      message: expect.stringContaining("openclaw onboard"),
+      failures: [],
+    });
     expect(readConfigFileSnapshot).not.toHaveBeenCalled();
     expect(runCliAgent).not.toHaveBeenCalled();
     expect(runEmbeddedAgent).not.toHaveBeenCalled();

--- a/src/system-agent/agent-turn.ts
+++ b/src/system-agent/agent-turn.ts
@@ -16,7 +16,10 @@ import type { CliSessionBinding } from "../config/sessions.js";
 import { buildAgentMainSessionKey, toAgentStoreSessionKey } from "../routing/session-key.js";
 import { SYSTEM_AGENT_ID } from "./agent-id.js";
 import { SYSTEM_AGENT_SYSTEM_PROMPT } from "./assistant-prompts.js";
-import { SystemAgentInferenceUnavailableError } from "./inference-error.js";
+import {
+  SystemAgentInferenceRouteError,
+  SystemAgentInferenceUnavailableError,
+} from "./inference-error.js";
 import type { SystemAgentConfiguredRoute } from "./inference-route.js";
 import type { SystemAgentProposalRef } from "./operator-approval.js";
 import type { SystemAgentOverview } from "./overview.js";
@@ -212,7 +215,9 @@ function resolveSystemAgentCliToolAvailability(
     return { native: [], openClaw: [SYSTEM_AGENT_TOOL_NAME] };
   }
   const backendId = backend?.id ?? "unknown";
-  throw new Error(`CLI backend ${backendId} cannot enforce OpenClaw's exact tool availability`);
+  throw new SystemAgentInferenceRouteError(
+    `CLI backend ${backendId} cannot enforce OpenClaw's exact tool availability`,
+  );
 }
 
 /**

--- a/src/system-agent/agent-turn.ts
+++ b/src/system-agent/agent-turn.ts
@@ -430,17 +430,17 @@ async function runSystemAgentTurnWithDeps(
       throw new Error(terminalError);
     }
     if (params.session.verifiedInference !== binding) {
-      throw new SystemAgentInferenceUnavailableError("agent-turn");
+      throw new Error("The verified inference route changed during the OpenClaw turn.");
     }
     // A completed model turn is still untrusted until the exact route owner is
     // revalidated. This also rejects directives produced while config changed.
     const currentRoute = await resolveSystemAgentVerifiedInferenceRoute(binding, deps);
     if (!currentRoute) {
-      throw new SystemAgentInferenceUnavailableError("agent-turn");
+      throw new Error("The verified inference route changed during the OpenClaw turn.");
     }
     const text = extractAgentRunText(result)?.trim();
     if (!text) {
-      throw new SystemAgentInferenceUnavailableError("agent-turn");
+      throw new Error("The OpenClaw inference turn completed without a visible reply.");
     }
     return {
       text,

--- a/src/system-agent/inference-error.ts
+++ b/src/system-agent/inference-error.ts
@@ -5,18 +5,22 @@ type SystemAgentInferenceStage = "agent-turn" | "planner" | "conversation";
 
 const INFERENCE_UNAVAILABLE_MESSAGE =
   "OpenClaw could not reach working inference. Run `openclaw onboard` on the machine running OpenClaw to reconnect — it live-tests the route before saving it. Then try again.";
+const REQUEST_FAILED_MESSAGE = "OpenClaw could not complete this request. Try again.";
 const INFERENCE_FAILURE_SUMMARY_MAX_CHARS = 300;
 
 function inferenceUnavailableMessage(failures: readonly unknown[]): string {
-  const detail = failures.length > 0 ? formatErrorMessage(failures[0]).trim() : "";
-  if (!detail) {
+  if (failures.length === 0) {
     return INFERENCE_UNAVAILABLE_MESSAGE;
+  }
+  const detail = formatErrorMessage(failures[0]).trim();
+  if (!detail) {
+    return REQUEST_FAILED_MESSAGE;
   }
   const summary =
     detail.length > INFERENCE_FAILURE_SUMMARY_MAX_CHARS
       ? `${truncateUtf16Safe(detail, INFERENCE_FAILURE_SUMMARY_MAX_CHARS - 1)}…`
       : detail;
-  return `${INFERENCE_UNAVAILABLE_MESSAGE} Cause: ${summary}`;
+  return `${REQUEST_FAILED_MESSAGE} Cause: ${summary}`;
 }
 
 /** Safe public error for an OpenClaw turn that could not complete with intelligence. */
@@ -27,7 +31,10 @@ export class SystemAgentInferenceUnavailableError extends Error {
     readonly stage: SystemAgentInferenceStage,
     readonly failures: readonly unknown[] = [],
   ) {
-    super(inferenceUnavailableMessage(failures));
+    super(
+      inferenceUnavailableMessage(failures),
+      failures[0] === undefined ? undefined : { cause: failures[0] },
+    );
     this.name = "SystemAgentInferenceUnavailableError";
   }
 }

--- a/src/system-agent/inference-error.ts
+++ b/src/system-agent/inference-error.ts
@@ -6,21 +6,35 @@ type SystemAgentInferenceStage = "agent-turn" | "planner" | "conversation";
 const INFERENCE_UNAVAILABLE_MESSAGE =
   "OpenClaw could not reach working inference. Run `openclaw onboard` on the machine running OpenClaw to reconnect — it live-tests the route before saving it. Then try again.";
 const REQUEST_FAILED_MESSAGE = "OpenClaw could not complete this request. Try again.";
+const ROUTE_INCOMPATIBLE_MESSAGE =
+  "OpenClaw cannot use the configured inference route. Choose a compatible model or CLI backend, then start a new conversation.";
 const INFERENCE_FAILURE_SUMMARY_MAX_CHARS = 300;
+
+/** A known route incompatibility that retrying the same request cannot repair. */
+export class SystemAgentInferenceRouteError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "SystemAgentInferenceRouteError";
+  }
+}
 
 function inferenceUnavailableMessage(failures: readonly unknown[]): string {
   if (failures.length === 0) {
     return INFERENCE_UNAVAILABLE_MESSAGE;
   }
+  const message =
+    failures[0] instanceof SystemAgentInferenceRouteError
+      ? ROUTE_INCOMPATIBLE_MESSAGE
+      : REQUEST_FAILED_MESSAGE;
   const detail = formatErrorMessage(failures[0]).trim();
   if (!detail) {
-    return REQUEST_FAILED_MESSAGE;
+    return message;
   }
   const summary =
     detail.length > INFERENCE_FAILURE_SUMMARY_MAX_CHARS
       ? `${truncateUtf16Safe(detail, INFERENCE_FAILURE_SUMMARY_MAX_CHARS - 1)}…`
       : detail;
-  return `${REQUEST_FAILED_MESSAGE} Cause: ${summary}`;
+  return `${message} Cause: ${summary}`;
 }
 
 /** Safe public error for an OpenClaw turn that could not complete with intelligence. */


### PR DESCRIPTION
Related: #139710. Complements #145002; does not replace its runtime-generation fix.

## What Problem This Solves

Fixes an issue where users invoking the OpenClaw system agent were told to rerun `openclaw onboard` after unrelated request failures, such as a turn timeout, internal error, or empty reply. Following that advice can change a working inference route without addressing the failed request.

The public reproduction in https://github.com/openclaw/openclaw/issues/139710#issuecomment-5592441331 reports healthy ordinary inference alongside system-agent failures and misleading onboarding advice. This PR addresses the error-reporting portion only; it does not claim to resolve that production outage.

## Why This Change Was Made

Keep the existing missing-route message when no underlying failure is supplied. For request-specific failures, use request-failure guidance instead, retain the bounded cause summary, and preserve the first underlying failure as `Error.cause`. Blank error text also avoids the onboarding fallback. Known CLI tool-availability incompatibilities are now classified at their producer and recommend choosing a compatible model or CLI backend before starting a new conversation, rather than retrying an unchanged route.

Give empty output and a route that changes during an admitted turn explicit causes before wrapping them. Existing error code, failure list, admission checks, and cleanup of proposals and CLI continuity remain intact.

## User Impact

Timeouts, internal errors, and empty responses no longer incorrectly instruct operators to run onboarding. Missing-route failures retain the existing setup guidance. Deterministically incompatible CLI routes receive route-selection guidance without weakening tool enforcement, and callers can inspect the underlying cause.

## Evidence

Review fix: `f38f02cd450c15dd24ba21ea64e929d02d2f0090`.

- Final focused run after review fixes: **29/29 tests passed** in `agent-turn.test.ts` and `agent-turn.terminal.test.ts`.
- The deterministic-route regression failed against the previous published head: expected compatible-route guidance, received `OpenClaw could not complete this request. Try again. Cause: CLI backend google-gemini-cli cannot enforce OpenClaw's exact tool availability`.
- After the fix, both always-on and selectable-without-enforcement CLI backends receive `OpenClaw cannot use the configured inference route. Choose a compatible model or CLI backend, then start a new conversation.` with the original bounded cause. Tests verify neither runner launches, the cause object is preserved, and stale proposal/CLI-session state is cleared.
- Sibling tests retain request-retry guidance for runtime/empty-output failures and onboarding guidance for an absent verified route.
- Final targeted Oxlint: **0 warnings / 0 errors** across all four files; formatting and `git diff --check` passed.
- Full `check:changed` gate for the four touched paths passed, including core and all core-test type checks, dead-export checks, targeted lint/formatting, and selected guards. This is not a full repository test-suite or packaged-build claim.
- Fresh independent P0-P2 autoreview validated the working-tree candidate. Its sole finding was **index-only**: the index still contained the old retry-only code. That finding was resolved by staging the identical tested/reviewed files and verifying the index matches the working tree. The raw overall report was not `scoped-clean`.

## Scope and Limitations

PR #145002 already covers the cross-agent generation boundary with live canary evidence. The original generation-scope change was therefore removed from this patch to avoid duplication. Merged PR #140392 preserves setup-verification causes but does not change this request-error formatter.

Tests use synthetic runner dependencies. ClawSweeper's request for after-fix real CLI/Gateway evidence remains outstanding; the output above is regression-test evidence, not a live deployment or setup replay. No production Gateway was modified to obtain proof. No live provider outage or MCP hot-reload race was replayed, and no complete repository test-suite or packaged-build pass is claimed. The original runtime failure remains the responsibility of the complementary fix.

## Worked on by
- @explainanalyze
