### PR TITLE
fix(cli): keep cached-only provider catalogs in isolated agent exec

### DIFF
--- a/src/agents/plugin-model-catalog-handoff.ts
+++ b/src/agents/plugin-model-catalog-handoff.ts
@@ -1,0 +1,136 @@
+/**
+ * Request-owned, metadata-only handoff for provider-owned generated catalogs.
+ *
+ * The per-agent SQLite cache holds the catalogs provider discovery validated for
+ * the agent that owns it. A run that redirects state to a fresh directory cannot
+ * rebuild them, so it carries the inventory metadata rather than the source
+ * store: no credentials, request headers, request parameters, or database.
+ */
+import { AsyncLocalStorage } from "node:async_hooks";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { resolveGlobalSingleton } from "../shared/global-singleton.js";
+import {
+  isGeneratedPluginModelCatalog,
+  PLUGIN_MODEL_CATALOG_GENERATED_BY,
+} from "./plugin-model-catalog-repair.js";
+import type { PersistedPluginModelCatalog } from "./plugin-model-catalog.js";
+
+/**
+ * Provider route plus model inventory are the only fields a generated catalog
+ * contributes to model resolution; credentials, request headers, request
+ * parameters, and local-service environment stay in their owner's cache.
+ */
+const HANDOFF_PROVIDER_FIELDS = ["api", "baseUrl", "compat"] as const;
+const HANDOFF_MODEL_FIELDS = [
+  "id",
+  "name",
+  "api",
+  "baseUrl",
+  "compat",
+  "reasoning",
+  "input",
+  "cost",
+  "contextWindow",
+  "contextTokens",
+  "maxTokens",
+  "thinkingLevelMap",
+  "mediaInput",
+  "metadataSource",
+  "agentRuntime",
+] as const;
+
+const PLUGIN_MODEL_CATALOG_HANDOFF_KEY = Symbol.for("openclaw.pluginModelCatalogHandoff");
+
+const handoffStore = resolveGlobalSingleton<
+  AsyncLocalStorage<readonly PersistedPluginModelCatalog[]>
+>(PLUGIN_MODEL_CATALOG_HANDOFF_KEY, () => new AsyncLocalStorage());
+
+function pickHandoffFields(
+  value: Record<string, unknown>,
+  fields: readonly string[],
+): Record<string, unknown> {
+  const picked: Record<string, unknown> = {};
+  for (const field of fields) {
+    if (value[field] !== undefined) {
+      picked[field] = value[field];
+    }
+  }
+  return picked;
+}
+
+/** Projects one generated catalog onto the metadata a run may carry with it. */
+function projectPluginModelCatalogMetadata(
+  catalog: PersistedPluginModelCatalog,
+): PersistedPluginModelCatalog | undefined {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(catalog.contents) as unknown;
+  } catch {
+    return undefined;
+  }
+  if (!isGeneratedPluginModelCatalog(parsed) || !isRecord(parsed.providers)) {
+    return undefined;
+  }
+  const providers: Record<string, unknown> = {};
+  for (const [providerId, provider] of Object.entries(parsed.providers)) {
+    if (!isRecord(provider)) {
+      continue;
+    }
+    providers[providerId] = {
+      ...pickHandoffFields(provider, HANDOFF_PROVIDER_FIELDS),
+      models: (Array.isArray(provider.models) ? provider.models : [])
+        .filter(isRecord)
+        .map((model) => pickHandoffFields(model, HANDOFF_MODEL_FIELDS)),
+    };
+  }
+  if (Object.keys(providers).length === 0) {
+    return undefined;
+  }
+  return {
+    pluginId: catalog.pluginId,
+    contents: JSON.stringify({ generatedBy: PLUGIN_MODEL_CATALOG_GENERATED_BY, providers }),
+  };
+}
+
+/**
+ * Captures operator-owned catalog metadata before a run redirects state. The
+ * projection is metadata-only by construction: it never carries the source
+ * database, credentials, request headers, or request parameters.
+ *
+ * The catalog owner is imported lazily so this module holds no static edge back
+ * into it. Call this outside the run's own handoff scope.
+ */
+export async function capturePluginModelCatalogHandoff(
+  agentDir: string,
+): Promise<readonly PersistedPluginModelCatalog[]> {
+  const { readPersistedPluginModelCatalogs } = await import("./plugin-model-catalog.js");
+  return readPersistedPluginModelCatalogs(agentDir).flatMap((catalog) => {
+    const metadata = projectPluginModelCatalogMetadata(catalog);
+    return metadata ? [metadata] : [];
+  });
+}
+
+/** Runs one bounded operation with operator-owned catalog metadata in scope. */
+export function withPluginModelCatalogHandoff<T>(
+  catalogs: readonly PersistedPluginModelCatalog[],
+  run: () => T,
+): T {
+  return catalogs.length === 0 ? run() : handoffStore.run(catalogs, run);
+}
+
+/**
+ * Keeps retained local catalogs authoritative and only fills plugin ids the
+ * local store does not retain at all, so an isolated run cannot shadow its own
+ * state with handed-off metadata.
+ */
+export function withHandedOffPluginModelCatalogs(
+  catalogs: readonly PersistedPluginModelCatalog[],
+): PersistedPluginModelCatalog[] {
+  const handoff = handoffStore.getStore();
+  if (!handoff?.length) {
+    return [...catalogs];
+  }
+  const retained = new Set(catalogs.map((catalog) => catalog.pluginId));
+  const missing = handoff.filter((catalog) => !retained.has(catalog.pluginId));
+  return missing.length === 0 ? [...catalogs] : [...catalogs, ...missing];
+}

--- a/src/agents/plugin-model-catalog.handoff.test.ts
+++ b/src/agents/plugin-model-catalog.handoff.test.ts
@@ -1,0 +1,191 @@
+// A one-shot run with fresh state carries operator catalog metadata, not credentials.
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { createPluginMetadataSnapshotFixture } from "../plugins/plugin-metadata.test-support.js";
+import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.js";
+import { discoverModelsFromCapturedSources } from "./agent-model-discovery.js";
+import {
+  capturePluginModelCatalogHandoff,
+  withPluginModelCatalogHandoff,
+} from "./plugin-model-catalog-handoff.js";
+import {
+  encodePluginModelCatalogRelativePath,
+  loadPersistedPluginModelCatalogsReadOnly,
+  PLUGIN_MODEL_CATALOG_GENERATED_BY,
+  replacePersistedPluginModelCatalogs,
+} from "./plugin-model-catalog.js";
+import { AuthStorage } from "./sessions/auth-storage.js";
+
+const CACHED_ONLY_MODEL = "cached-only-model";
+const CATALOG_PLUGIN_ID = "catalog-owner";
+
+const pluginMetadataSnapshot = createPluginMetadataSnapshotFixture({
+  plugins: [{ id: CATALOG_PLUGIN_ID, providers: ["fixture"] }],
+});
+
+const tempDirs: string[] = [];
+
+/** Creates a conventional `<state>/agents/<id>/agent` directory, as a real run does. */
+function createAgentDir(agentId = "fixture-agent"): string {
+  const root = mkdtempSync(join(tmpdir(), "openclaw-plugin-catalog-handoff-"));
+  tempDirs.push(root);
+  const agentDir = join(root, "agents", agentId, "agent");
+  mkdirSync(agentDir, { recursive: true });
+  return agentDir;
+}
+
+/** Seeds one operator-owned generated catalog, credentials included. */
+function seedCatalog(agentDir: string, providers: Record<string, unknown>): string {
+  const contents = JSON.stringify({
+    generatedBy: PLUGIN_MODEL_CATALOG_GENERATED_BY,
+    providers,
+  });
+  replacePersistedPluginModelCatalogs({
+    agentDir,
+    pluginCatalogWrites: { [encodePluginModelCatalogRelativePath(CATALOG_PLUGIN_ID)]: contents },
+  });
+  return contents;
+}
+
+function operatorProviders(): Record<string, unknown> {
+  return {
+    fixture: {
+      api: "openai-completions",
+      baseUrl: "https://fixture.example/v1",
+      apiKey: "operator-api-key",
+      auth: "api-key",
+      headers: { authorization: "Bearer operator-token" },
+      request: { maxRetries: 3 },
+      params: { reasoning: "high" },
+      localService: { command: "serve", env: { SERVICE_TOKEN: "operator-token" } },
+      models: [
+        {
+          id: CACHED_ONLY_MODEL,
+          name: "Cached only",
+          api: "openai-completions",
+          contextWindow: 65536,
+          maxTokens: 4096,
+          reasoning: true,
+          input: ["text"],
+          headers: { "x-model-header": "operator-token" },
+          params: { temperature: 0.2 },
+        },
+      ],
+    },
+  };
+}
+
+/** Reads the prepared-registry source exactly as lifecycle preparation does. */
+function readPreparedCatalogSource(agentDir: string) {
+  return discoverModelsFromCapturedSources(AuthStorage.inMemory(), {
+    // The static manifest declares no provider rows for this model.
+    config: {},
+    modelsJsonContents: null,
+    pluginCatalogs: loadPersistedPluginModelCatalogsReadOnly(agentDir),
+    pluginMetadataSnapshot,
+  });
+}
+
+afterEach(() => {
+  closeOpenClawAgentDatabasesForTest();
+  for (const root of tempDirs.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+describe("request-owned plugin model catalog handoff", () => {
+  it("carries provider and model metadata without credentials or request parameters", async () => {
+    const operatorDir = createAgentDir();
+    seedCatalog(operatorDir, operatorProviders());
+
+    const handoff = await capturePluginModelCatalogHandoff(operatorDir);
+
+    expect(handoff).toHaveLength(1);
+    expect(handoff[0]?.pluginId).toBe(CATALOG_PLUGIN_ID);
+    const carried = JSON.parse(handoff[0]?.contents ?? "{}") as {
+      generatedBy?: string;
+      providers?: Record<string, Record<string, unknown>>;
+    };
+    expect(carried.generatedBy).toBe(PLUGIN_MODEL_CATALOG_GENERATED_BY);
+    expect(carried.providers?.fixture).toEqual({
+      api: "openai-completions",
+      baseUrl: "https://fixture.example/v1",
+      models: [
+        {
+          id: CACHED_ONLY_MODEL,
+          name: "Cached only",
+          api: "openai-completions",
+          contextWindow: 65536,
+          maxTokens: 4096,
+          reasoning: true,
+          input: ["text"],
+        },
+      ],
+    });
+    expect(handoff[0]?.contents).not.toContain("operator-api-key");
+    expect(handoff[0]?.contents).not.toContain("operator-token");
+    expect(handoff[0]?.contents).not.toContain("localService");
+  });
+
+  it("fills only plugin ids the run's own agent directory does not retain", async () => {
+    const operatorDir = createAgentDir();
+    seedCatalog(operatorDir, operatorProviders());
+    const freshRunDir = createAgentDir();
+    expect(loadPersistedPluginModelCatalogsReadOnly(freshRunDir)).toEqual([]);
+
+    const handoff = await capturePluginModelCatalogHandoff(operatorDir);
+    const scoped = withPluginModelCatalogHandoff(handoff, () =>
+      loadPersistedPluginModelCatalogsReadOnly(freshRunDir),
+    );
+
+    expect(scoped.map((catalog) => catalog.pluginId)).toEqual([CATALOG_PLUGIN_ID]);
+    // The scope is request-owned: nothing leaks into the run's own state.
+    expect(loadPersistedPluginModelCatalogsReadOnly(freshRunDir)).toEqual([]);
+  });
+
+  it("keeps a retained local catalog authoritative, including an empty one", async () => {
+    const operatorDir = createAgentDir();
+    seedCatalog(operatorDir, operatorProviders());
+    const runDir = createAgentDir();
+    seedCatalog(runDir, {
+      fixture: {
+        api: "openai-completions",
+        baseUrl: "https://run.example/v1",
+        models: [],
+      },
+    });
+
+    const handoff = await capturePluginModelCatalogHandoff(operatorDir);
+    const scoped = withPluginModelCatalogHandoff(handoff, () =>
+      loadPersistedPluginModelCatalogsReadOnly(runDir),
+    );
+
+    expect(scoped).toHaveLength(1);
+    expect(JSON.parse(scoped[0]?.contents ?? "{}")).toMatchObject({
+      providers: { fixture: { baseUrl: "https://run.example/v1", models: [] } },
+    });
+  });
+
+  it("restores cached-only model resolution for a fresh task state directory", async () => {
+    const operatorDir = createAgentDir();
+    seedCatalog(operatorDir, operatorProviders());
+    const freshRunDir = createAgentDir();
+
+    expect(
+      readPreparedCatalogSource(freshRunDir).find("fixture", CACHED_ONLY_MODEL),
+    ).toBeUndefined();
+
+    const handoff = await capturePluginModelCatalogHandoff(operatorDir);
+    const resolved = withPluginModelCatalogHandoff(handoff, () =>
+      readPreparedCatalogSource(freshRunDir),
+    );
+
+    expect(resolved.getError()).toBeUndefined();
+    expect(resolved.find("fixture", CACHED_ONLY_MODEL)).toMatchObject({
+      name: "Cached only",
+      contextWindow: 65536,
+    });
+  });
+});

--- a/src/agents/plugin-model-catalog.ts
+++ b/src/agents/plugin-model-catalog.ts
@@ -20,6 +20,7 @@ import {
   resolveAuthProfileDatabaseOwnerId,
   resolveAuthProfileDatabasePath,
 } from "./auth-profiles/sqlite.js";
+import { withHandedOffPluginModelCatalogs } from "./plugin-model-catalog-handoff.js";
 import {
   isGeneratedPluginModelCatalog,
   repairPluginModelCatalogTransportMetadata,
@@ -83,13 +84,16 @@ function readPersistedPluginModelCatalogEntries(
   return result.found ? result.value : [];
 }
 
-function readPersistedPluginModelCatalogs(agentDir: string): PersistedPluginModelCatalog[] {
+/** Reads the raw retained catalog rows for one agent directory. */
+export function readPersistedPluginModelCatalogs(agentDir: string): PersistedPluginModelCatalog[] {
   return readPersistedPluginModelCatalogEntries(agentDir, PLUGIN_MODEL_CATALOG_CACHE_SCOPE);
 }
 
 /**
  * Reads an exact plugin-catalog generation without migration or repair writes.
  * Lifecycle preparation uses this for configured providers before atomic publication.
+ * Retained local catalogs stay authoritative; a request-owned handoff only fills
+ * plugin ids this agent directory does not retain at all.
  */
 export function loadPersistedPluginModelCatalogsReadOnly(
   agentDir: string,
@@ -98,12 +102,9 @@ export function loadPersistedPluginModelCatalogsReadOnly(
   if (pluginIds?.length === 0) {
     return [];
   }
-  const catalogs = readPersistedPluginModelCatalogs(agentDir);
-  if (!pluginIds) {
-    return catalogs;
-  }
-  const allowed = new Set(pluginIds);
-  return catalogs.filter(({ pluginId }) => allowed.has(pluginId));
+  const allowed = pluginIds ? new Set(pluginIds) : undefined;
+  const catalogs = withHandedOffPluginModelCatalogs(readPersistedPluginModelCatalogs(agentDir));
+  return allowed ? catalogs.filter(({ pluginId }) => allowed.has(pluginId)) : catalogs;
 }
 
 function repairPersistedPluginModelCatalogs(params: {

--- a/src/commands/agent-exec.plugin-catalog.test.ts
+++ b/src/commands/agent-exec.plugin-catalog.test.ts
@@ -1,0 +1,111 @@
+// `agent exec` keeps cached-only model metadata across an isolated task state.
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  encodePluginModelCatalogRelativePath,
+  loadPersistedPluginModelCatalogsReadOnly,
+  PLUGIN_MODEL_CATALOG_GENERATED_BY,
+  replacePersistedPluginModelCatalogs,
+  type PersistedPluginModelCatalog,
+} from "../agents/plugin-model-catalog.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { RuntimeEnv } from "../runtime.js";
+import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.js";
+import { agentExecCommand } from "./agent-exec.js";
+
+const AGENT_ID = "fixture-agent";
+const tempRoots: string[] = [];
+
+/** Creates a conventional `<state>/agents/<id>/agent` directory, as a real run does. */
+function createAgentDir(): string {
+  const root = mkdtempSync(join(tmpdir(), "openclaw-agent-exec-catalog-"));
+  tempRoots.push(root);
+  const agentDir = join(root, "agents", AGENT_ID, "agent");
+  mkdirSync(agentDir, { recursive: true });
+  return agentDir;
+}
+
+function createRuntime(): RuntimeEnv {
+  return { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
+}
+
+/** One provider-owned generated catalog whose model the static manifest lacks. */
+function seedOperatorCatalog(agentDir: string): void {
+  replacePersistedPluginModelCatalogs({
+    agentDir,
+    pluginCatalogWrites: {
+      [encodePluginModelCatalogRelativePath("catalog-owner")]: JSON.stringify({
+        generatedBy: PLUGIN_MODEL_CATALOG_GENERATED_BY,
+        providers: {
+          fixture: {
+            api: "openai-completions",
+            baseUrl: "https://fixture.example/v1",
+            apiKey: "operator-api-key",
+            models: [{ id: "cached-only-model", name: "Cached only", contextWindow: 65536 }],
+          },
+        },
+      }),
+    },
+  });
+}
+
+function baseConfig(agentDir: string): OpenClawConfig {
+  return { agents: { entries: { [AGENT_ID]: { agentDir } } } };
+}
+
+afterEach(() => {
+  closeOpenClawAgentDatabasesForTest();
+  for (const root of tempRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+describe("agent exec cached-only model metadata", () => {
+  it("preserves validated operator catalog metadata for a fresh task state", async () => {
+    const operatorDir = createAgentDir();
+    seedOperatorCatalog(operatorDir);
+    // A directory this run does not own: only the handoff can fill it.
+    const independentDir = createAgentDir();
+    let observed: readonly PersistedPluginModelCatalog[] = [];
+    const runAgent = vi.fn(async () => {
+      observed = loadPersistedPluginModelCatalogsReadOnly(independentDir);
+      return { payloads: [{ text: "done" }], meta: { durationMs: 1 } };
+    });
+
+    const result = await agentExecCommand("inspect", {}, createRuntime(), {
+      agentId: AGENT_ID,
+      baseConfig: baseConfig(operatorDir),
+      runAgent,
+    });
+
+    expect(result.envelope.error?.message).toBeUndefined();
+    expect(result.exitCode).toBe(0);
+    expect(observed.map((catalog) => catalog.pluginId)).toEqual(["catalog-owner"]);
+    expect(observed[0]?.contents).toContain("cached-only-model");
+    // Credentials stay in the operator's own cache.
+    expect(observed[0]?.contents).not.toContain("operator-api-key");
+  });
+
+  it("carries no operator catalog metadata for environment-only exec", async () => {
+    const operatorDir = createAgentDir();
+    seedOperatorCatalog(operatorDir);
+    const independentDir = createAgentDir();
+    let observed: readonly PersistedPluginModelCatalog[] = [];
+    const runAgent = vi.fn(async () => {
+      observed = loadPersistedPluginModelCatalogsReadOnly(independentDir);
+      return { payloads: [{ text: "done" }], meta: { durationMs: 1 } };
+    });
+
+    const result = await agentExecCommand("inspect", { authEnvOnly: true }, createRuntime(), {
+      agentId: AGENT_ID,
+      baseConfig: baseConfig(operatorDir),
+      runAgent,
+    });
+
+    expect(result.envelope.error?.message).toBeUndefined();
+    expect(result.exitCode).toBe(0);
+    expect(observed).toEqual([]);
+  });
+});

--- a/src/commands/agent-exec.ts
+++ b/src/commands/agent-exec.ts
@@ -352,6 +352,16 @@ export async function agentExecCommand(
     // Auth, session keys, and SQLite ownership must share one resolved owner.
     // Splitting these paths can select an agent's store but emit a `main` key.
     const storedAuthAgentDir = resolveAgentDir(baseConfig, execAgentId);
+    // A one-shot run with a fresh state directory cannot rebuild the selected
+    // agent's provider-owned generated catalogs, so cached-only models they
+    // advertise would resolve as unknown. Carry the operator's validated
+    // metadata into the run -- never its database or credentials -- while any
+    // catalog the run's own state retains still takes precedence.
+    const catalogHandoffModule = inheritInstalledPlugins
+      ? await import("../agents/plugin-model-catalog-handoff.js")
+      : undefined;
+    const catalogHandoff =
+      await catalogHandoffModule?.capturePluginModelCatalogHandoff(storedAuthAgentDir);
     runtimePaths = await import("../config/paths.js");
     const storedAuthStateDir = runtimePaths.resolveStateDir();
     // Capture cleanup before a child can finish or lose its native owner.
@@ -459,13 +469,20 @@ export async function agentExecCommand(
       pluginInstallContext && pluginInstallRoots
         ? pluginInstallContext.withPluginInstallRoots(pluginInstallRoots, invoke)
         : invoke();
+    const runWithCatalogHandoff = () =>
+      catalogHandoffModule && catalogHandoff
+        ? catalogHandoffModule.withPluginModelCatalogHandoff(
+            catalogHandoff,
+            runWithPluginInstallRoots,
+          )
+        : runWithPluginInstallRoots();
     const runWithAuthScope = () =>
       opts.authEnvOnly === true
-        ? withEnvOnlyAuthProfileStore(runWithPluginInstallRoots)
+        ? withEnvOnlyAuthProfileStore(runWithCatalogHandoff)
         : withAuthProfileStoreAgentDir(
             storedAuthAgentDir,
             storedAuthStateDir,
-            runWithPluginInstallRoots,
+            runWithCatalogHandoff,
           );
     const result = await runtimeCleanup.run(() =>
       toolBudget.run(() =>


### PR DESCRIPTION
## What Problem This Solves

`agent exec` runs its turn against a fresh temporary state directory unless
`--state-dir` is passed. Provider-owned generated model catalogs are stored in
the selected agent's per-agent SQLite cache (`agentDir/openclaw-agent.sqlite`,
scope `plugin-model-catalog-v1`), and that cache lives under the state root.

So the one-shot run prepared its model registry against an empty agent
directory: every generated catalog row the selected ambient agent had already
validated was missing, and a model that only that catalog advertises (absent
from the static plugin manifest) resolved as `Unknown model: <provider>/<id>`.

Root cause: state isolation repointed the only readable source of that metadata
without carrying the already-validated metadata with it.

Fix: the command captures the operator agent's retained catalogs before it
repoints `OPENCLAW_STATE_DIR`, projects them onto inventory metadata only, and
hands them to the run through a request-owned `AsyncLocalStorage` scope (the
same shape as the existing run-pinned plugin install roots). The read-only
catalog reader appends handed-off rows **only for plugin ids the run's own
agent directory does not retain**, so:

- a fresh isolated run keeps session state isolated and still sees its
  provider's cached-only models;
- catalogs the run itself retains — including empty ones — stay authoritative,
  so the handoff can never shadow local state;
- the handoff carries **no credentials, request headers, request parameters,
  local-service environment, or source database**: the projection keeps only
  provider route (`api`, `baseUrl`, `compat`) plus model inventory fields. The
  generated-catalog consumer already treats those rows as inventory, never as
  request authority;
- `--isolated` and `--auth-env-only` keep reading no operator state at all
  (same gate as installed-plugin inheritance), so an environment-only run
  carries nothing;
- ownership, suppression, and lifecycle checks are untouched: the rows enter
  through the existing read path and every downstream check still runs.

### Changes

- `src/agents/plugin-model-catalog-handoff.ts` (new): metadata-only projection,
  request-owned handoff scope, and the retained-wins merge.
- `src/agents/plugin-model-catalog.ts`: the read-only reader consults the
  handoff; the raw scope reader is exported for the capture path.
- `src/commands/agent-exec.ts`: capture before the state repoint (gated on the
  existing installed-plugin inheritance flag) and scope the run with it.
- `src/agents/plugin-model-catalog.handoff.test.ts` (new): projection,
  retained-wins, and cached-only model resolution.
- `src/commands/agent-exec.plugin-catalog.test.ts` (new): isolated `agent exec`
  keeps the metadata (and carries none for `--auth-env-only`).

## Evidence

Repro shape: seed a valid provider-owned generated catalog (scope
`plugin-model-catalog-v1`) whose model is absent from the static manifest, then
run `agent exec` with fresh task state and read the run's prepared catalog
source.

Pre-fix (source reverted to the merge base, new tests kept):

```
$ node node_modules/vitest/vitest.mjs run src/commands/agent-exec.plugin-catalog.test.ts \
    --config test/vitest/vitest.commands.config.ts --maxWorkers=1 --no-file-parallelism
 ✓ agent exec cached-only model metadata > carries no operator catalog metadata for environment-only exec
 × agent exec cached-only model metadata > preserves validated operator catalog metadata for a fresh task state
   AssertionError: expected [] to equal [ "catalog-owner" ]
     expect(observed.map((catalog) => catalog.pluginId)).toEqual(["catalog-owner"]);
 Test Files  1 failed (1)
      Tests  1 failed | 1 passed (2)

$ node node_modules/vitest/vitest.mjs run src/agents/plugin-model-catalog.handoff.test.ts \
    --config test/vitest/vitest.agents.config.ts --maxWorkers=1 --no-file-parallelism
 × carries provider and model metadata without credentials or request parameters
 × fills only plugin ids the run's own agent directory does not retain
 × keeps a retained local catalog authoritative, including an empty one
 × restores cached-only model resolution for a fresh task state directory
   TypeError: readPersistedPluginModelCatalogs is not a function
 Test Files  1 failed (1)
      Tests  4 failed (4)
```

Post-fix (committed tree):

```
$ node node_modules/vitest/vitest.mjs run src/commands/agent-exec.plugin-catalog.test.ts \
    --config test/vitest/vitest.commands.config.ts --maxWorkers=1 --no-file-parallelism
 ✓ agent exec cached-only model metadata > preserves validated operator catalog metadata for a fresh task state
 ✓ agent exec cached-only model metadata > carries no operator catalog metadata for environment-only exec
 Test Files  1 passed (1)
      Tests  2 passed (2)

$ node node_modules/vitest/vitest.mjs run src/agents/plugin-model-catalog.handoff.test.ts \
    --config test/vitest/vitest.agents.config.ts --maxWorkers=1 --no-file-parallelism
 ✓ carries provider and model metadata without credentials or request parameters
 ✓ fills only plugin ids the run's own agent directory does not retain
 ✓ keeps a retained local catalog authoritative, including an empty one
 ✓ restores cached-only model resolution for a fresh task state directory
 Test Files  1 passed (1)
      Tests  4 passed (4)
```

The resolution test asserts the real prepared-registry source
(`discoverModelsFromCapturedSources` with the same captured catalog rows) has no
row for the cached-only model from an empty run directory, and resolves it
(`name`, `contextWindow` intact) once the handoff is in scope. The projection
test asserts the carried payload equals provider route plus model metadata and
contains neither the operator API key, the operator header token, nor
`localService`.

Lint/format on every changed file: `npx oxfmt` clean, `npx oxlint` clean
(including the 700 code-line cap on `plugin-model-catalog.ts`: 697).

Scoped regression runs, unchanged by this change:

```
$ node node_modules/vitest/vitest.mjs run src/agents/plugin-model-catalog.test.ts \
    --config test/vitest/vitest.agents.config.ts --maxWorkers=1 --no-file-parallelism
      Tests  5 failed | 27 passed (32)      # identical set before and after (Windows chmod-only tests)

$ node node_modules/vitest/vitest.mjs run src/commands/agent-exec.test.ts \
    --config test/vitest/vitest.commands.config.ts --maxWorkers=1 --no-file-parallelism
      Tests  36 failed | 21 passed (57)     # identical before and after (temp-dir EPERM cleanup on Windows)

$ node node_modules/vitest/vitest.mjs run src/commands/agent-exec.agent-owner.test.ts \
    src/commands/agent-exec.configless.test.ts src/commands/agent-exec.construction.test.ts \
    --config test/vitest/vitest.commands.config.ts --maxWorkers=1 --no-file-parallelism
 Test Files  2 passed (2)
      Tests  3 passed (3)

$ node node_modules/vitest/vitest.mjs run src/agents/models-config.root-authorship.test.ts \
    src/agents/models-config.providers.endpoint.test.ts src/agents/agent-model-discovery.membership.test.ts \
    src/agents/prepared-model-runtime.catalog-owner.test.ts \
    --config test/vitest/vitest.agents.config.ts --maxWorkers=1 --no-file-parallelism
      Tests  4 failed | 26 passed (30)      # 4 = pre-existing catalog-owner failures, identical before and after
```

Not verified here: full-suite runs, CI-only gates that need `pnpm`
(`check-deadcode-exports` / knip unused-export scan could not run in this
environment), and a live inference smoke against a real provider endpoint.

Closes #141355

### Independent verification (parent)

Green and red re-run by me in this worktree (the two production files reverted in the working tree
only; the branch still holds them):

```
# with the fix
 Test Files  1 passed (1)
      Tests  4 passed (4)          # agents-core: plugin-model-catalog.handoff.test.ts
 Test Files  1 passed (1)
      Tests  2 passed (2)          # commands: agent-exec.plugin-catalog.test.ts

# without it
FAIL  |agents-core| … > restores cached-only model resolution for a fresh task state directory
FAIL  |agents-core| … > carries provider and model metadata without credentials or request parameters
 Test Files  1 failed (1)
      Tests  4 failed (4)
FAIL  |commands| … agent exec cached-only model metadata > preserves validated operator catalog metadata for a fresh task state
AssertionError: expected [] to deeply equal [ 'catalog-owner' ]
 Test Files  1 failed (1)
      Tests  1 failed | 1 passed (2)
```

---

# openclaw PR #145839 — after-fix 真实路径行为证据（ocproof-141355）

- 仓库/工作树：`D:/code/wt-oc-141355`，分支 `fix/oc-141355-descr`
- HEAD（修复后）：`43528e5c218e8ea214419d71e0e705b95697e743` — fix(cli): keep cached-only provider catalogs in isolated agent exec
- 对照（修复前）：`git checkout HEAD~1 -- src/agents/plugin-model-catalog.ts src/commands/agent-exec.ts`（只回退这两个生产文件；`git status --porcelain` 显示这两行为 `M`，其余不变）
- 演示脚本：`%LOCALAPPDATA%/Temp/ocproof-141355.mjs`（**不在工作树内、未提交**）
- 原始输出落盘：`%LOCALAPPDATA%/Temp/ocproof-141355/before-fix.out`、`.../after-fix.out`（完整、未改写；下文为逐行截取，仅删去无关行）

## 演示的真实路径

1. **真实本地插件**：`<scratch>/plugin/ocproof-fixture/openclaw.plugin.json` 声明 `providers: ["fixture"]`（provider 归属）与 `setup.providers[].envVars`，不含任何模型行；operator 配置以 `plugins.load.paths` + `plugins.allow` 加载它。
2. **真实 SQLite 生成式目录**：用仓库自身写入函数 `replacePersistedPluginModelCatalogs()` 把一条 `generatedBy` provider 目录写进操作方 agent 的 `<state>/agents/main/agent/openclaw-agent.sqlite` 的 `plugin-model-catalog-v1` scope，其中 `fixture/cached-only-model` **只存在于此缓存**（配置里没有 `models.providers.fixture`，没有任何模型清单）。操作方凭据用仓库 auth store API 写入同一 agentDir（`fixture:manual`）。
3. **真实 CLI**：用源码入口 `src/entry.ts`（与 `dist/entry.js` 同源）跑真实的 `agent exec`，fresh 隔离 state 两种形态都跑：默认（CLI 自建 temp state）与 `--state-dir` 指向一个全新空目录。
4. **真实 provider 请求**：provider baseUrl 指向本机 `scripts/e2e/mock-openai-server.mjs`；它的请求日志用于证明"确实解析成功并走到了 provider"。

## 复现命令

```bash
cd D:/code/wt-oc-141355

# 修复前：只回退两个生产文件
git checkout HEAD~1 -- src/agents/plugin-model-catalog.ts src/commands/agent-exec.ts
node --import "file:///D:/code/wt-oc-141355/scripts/tsx.mjs" "%LOCALAPPDATA%/Temp/ocproof-141355.mjs" \
  --label before-fix --scratch "%LOCALAPPDATA%/Temp/ocproof-141355/before-fix" > "%LOCALAPPDATA%/Temp/ocproof-141355/before-fix.out" 2>&1
git checkout HEAD -- src/agents/plugin-model-catalog.ts src/commands/agent-exec.ts

# 修复后
node --import "file:///D:/code/wt-oc-141355/scripts/tsx.mjs" "%LOCALAPPDATA%/Temp/ocproof-141355.mjs" \
  --label after-fix --scratch "%LOCALAPPDATA%/Temp/ocproof-141355/after-fix" > "%LOCALAPPDATA%/Temp/ocproof-141355/after-fix.out" 2>&1
```

脚本内部对每个 state 形态执行的 CLI 命令（脚本原样打印）：

```text
OPENCLAW_HOME=<scratch>/home OPENCLAW_STATE_DIR=<scratch>/state \
node --import <repo>/scripts/tsx.mjs <repo>/src/entry.ts agent exec [--state-dir <scratch>/fresh-run-state] \
  --config <scratch>/state/openclaw.json --model fixture/cached-only-model --json "Reply with exactly OPENCLAW_E2E_OK"
```

## 修复前（HEAD~1 的两个文件）

seed + read-back（真实 SQLite 行）:

```text
seeded sqlite: C:\Users\Administrator\AppData\Local\Temp\ocproof-141355\before-fix\state\agents\main\agent\openclaw-agent.sqlite
seeded write applied: true
read-back rows: [{"pluginId":"ocproof-fixture","hasModel":true}]
```

**state-mode=temp**

```text
===== command (state-mode=temp) =====
cd D:\code\wt-oc-141355
OPENCLAW_HOME=C:\Users\Administrator\AppData\Local\Temp\ocproof-141355\before-fix\home OPENCLAW_STATE_DIR=C:\Users\Administrator\AppData\Local\Temp\ocproof-141355\before-fix\state \
node --import <repo>/scripts/tsx.mjs <repo>/src/entry.ts agent exec [no --state-dir: CLI-owned fresh temp state] --config <state>/openclaw.json --model fixture/cached-only-model --json "Reply with exactly OPENCLAW_E2E_OK"
```

stdout（JSON envelope，逐字）:

```json
{
  "ok": false,
  "status": "error",
  "final": "",
  "payloads": [],
  "model": null,
  "provider": null,
  "sessionId": "d03f7549-4e7b-4706-b9d3-e17f8bcb4ce5",
  "error": {
    "message": "Unknown model: fixture/cached-only-model",
    "kind": "exception"
  }
}
```

stderr（仅保留与模型解析/provider 相关的行）:

```text
^[[31m[diagnostic]^[[39m ^[[31mlane task error: lane=main durationMs=279 error="Unknown model: fixture/cached-only-model"^[[39m
^[[31m[diagnostic]^[[39m ^[[31mlane task error: lane=session:agent:main:explicit:d03f7549-4e7b-4706-b9d3-e17f8bcb4ce5 durationMs=281 error="Unknown model: fixture/cached-only-model"^[[39m
^[[34m[model-fallback/decision]^[[39m ^[[33mmodel fallback decision: decision=candidate_failed requested=fixture/cached-only-model candidate=fixture/cached-only-model reason=model_not_found next=none detail=Unknown model: fixture/cached-only-model^[[39m
Agent exec cleanup failed: EBUSY: resource busy or locked, unlink 'C:\Users\ADMINI~1\AppData\Local\Temp\openclaw-agent-exec-KuwA6N\state\openclaw.sqlite-shm'
Unknown model: fixture/cached-only-model
```

exit / verdict / provider 请求 / 运行方 state:

```text
OCPROOF(before-fix,temp) exit=1 ok=false model=null provider=null final="" error="Unknown model: fixture/cached-only-model"
mock provider requests seen this run: [] (no request reached the provider endpoint)
```

**state-mode=dir**

```text
===== command (state-mode=dir) =====
cd D:\code\wt-oc-141355
OPENCLAW_HOME=C:\Users\Administrator\AppData\Local\Temp\ocproof-141355\before-fix\home OPENCLAW_STATE_DIR=C:\Users\Administrator\AppData\Local\Temp\ocproof-141355\before-fix\state \
node --import <repo>/scripts/tsx.mjs <repo>/src/entry.ts agent exec --state-dir <scratch>/fresh-run-state --config <state>/openclaw.json --model fixture/cached-only-model --json "Reply with exactly OPENCLAW_E2E_OK"
```

stdout（JSON envelope，逐字）:

```json
{
  "ok": false,
  "status": "error",
  "final": "",
  "payloads": [],
  "model": null,
  "provider": null,
  "sessionId": "e759a824-b2c5-401d-9cd0-d5879ac9c9ee",
  "error": {
    "message": "Unknown model: fixture/cached-only-model",
    "kind": "exception"
  }
}
```

stderr（仅保留与模型解析/provider 相关的行）:

```text
^[[31m[diagnostic]^[[39m ^[[31mlane task error: lane=main durationMs=384 error="Unknown model: fixture/cached-only-model"^[[39m
^[[31m[diagnostic]^[[39m ^[[31mlane task error: lane=session:agent:main:explicit:e759a824-b2c5-401d-9cd0-d5879ac9c9ee durationMs=387 error="Unknown model: fixture/cached-only-model"^[[39m
^[[34m[model-fallback/decision]^[[39m ^[[33mmodel fallback decision: decision=candidate_failed requested=fixture/cached-only-model candidate=fixture/cached-only-model reason=model_not_found next=none detail=Unknown model: fixture/cached-only-model^[[39m
Unknown model: fixture/cached-only-model
```

exit / verdict / provider 请求 / 运行方 state:

```text
OCPROOF(before-fix,dir) exit=1 ok=false model=null provider=null final="" error="Unknown model: fixture/cached-only-model"
mock provider requests seen this run: [] (no request reached the provider endpoint)
run-owned state catalog rows after the run: []
```

## 修复后（HEAD）

seed + read-back（真实 SQLite 行）:

```text
seeded sqlite: C:\Users\Administrator\AppData\Local\Temp\ocproof-141355\after-fix\state\agents\main\agent\openclaw-agent.sqlite
seeded write applied: true
read-back rows: [{"pluginId":"ocproof-fixture","hasModel":true}]
```

**state-mode=temp**

```text
===== command (state-mode=temp) =====
cd D:\code\wt-oc-141355
OPENCLAW_HOME=C:\Users\Administrator\AppData\Local\Temp\ocproof-141355\after-fix\home OPENCLAW_STATE_DIR=C:\Users\Administrator\AppData\Local\Temp\ocproof-141355\after-fix\state \
node --import <repo>/scripts/tsx.mjs <repo>/src/entry.ts agent exec [no --state-dir: CLI-owned fresh temp state] --config <state>/openclaw.json --model fixture/cached-only-model --json "Reply with exactly OPENCLAW_E2E_OK"
```

stdout（JSON envelope，逐字）:

```json
{
  "ok": false,
  "status": "error",
  "final": "",
  "payloads": [],
  "model": null,
  "provider": null,
  "sessionId": "a257e11e-da51-4878-b6bf-4add9a763d2f",
  "error": {
    "message": "Agent exec cleanup failed: EBUSY: resource busy or locked, unlink 'C:\\Users\\ADMINI~1\\AppData\\Local\\Temp\\openclaw-agent-exec-dUYwbB\\state\\openclaw.sqlite-shm'",
    "kind": "exception"
  }
}
```

stderr（仅保留与模型解析/provider 相关的行）:

```text
^[[33m[provider-transport-fetch]^[[39m ^[[36m[model-fetch] start provider=fixture api=openai-completions model=cached-only-model method=POST url=http://127.0.0.1:13067/v1/chat/completions timeoutMs=undefined proxy=none policy=custom^[[39m
^[[33m[provider-transport-fetch]^[[39m ^[[36m[model-fetch] response provider=fixture api=openai-completions model=cached-only-model status=200 elapsedMs=36 dispatcher=new contentType=text/event-stream^[[39m
Agent exec cleanup failed: EBUSY: resource busy or locked, unlink 'C:\Users\ADMINI~1\AppData\Local\Temp\openclaw-agent-exec-dUYwbB\state\openclaw.sqlite-shm'
```

exit / verdict / provider 请求 / 运行方 state:

```text
OCPROOF(after-fix,temp) exit=1 ok=false model=null provider=null final="" error="Agent exec cleanup failed: EBUSY: resource busy or locked, unlink 'C:\\Users\\ADMINI~1\\AppData\\Local\\Temp\\openclaw-agent-exec-dUYwbB\\state\\openclaw.sqlite-shm'"
mock provider requests seen this run: ["/v1/chat/completions"]
```

**state-mode=dir**

```text
===== command (state-mode=dir) =====
cd D:\code\wt-oc-141355
OPENCLAW_HOME=C:\Users\Administrator\AppData\Local\Temp\ocproof-141355\after-fix\home OPENCLAW_STATE_DIR=C:\Users\Administrator\AppData\Local\Temp\ocproof-141355\after-fix\state \
node --import <repo>/scripts/tsx.mjs <repo>/src/entry.ts agent exec --state-dir <scratch>/fresh-run-state --config <state>/openclaw.json --model fixture/cached-only-model --json "Reply with exactly OPENCLAW_E2E_OK"
```

stdout（JSON envelope，逐字）:

```json
{
  "ok": true,
  "status": "ok",
  "final": "OPENCLAW_E2E_OK",
  "payloads": [
    {
      "text": "OPENCLAW_E2E_OK",
      "mediaUrl": null
    }
  ],
  "codeModeEngaged": false,
  "assistantTurns": 1,
  "model": "cached-only-model",
  "provider": "fixture",
  "sessionId": "ebe3f429-f948-475f-a0d3-f1144543950c"
}
```

stderr（仅保留与模型解析/provider 相关的行）:

```text
^[[33m[provider-transport-fetch]^[[39m ^[[36m[model-fetch] start provider=fixture api=openai-completions model=cached-only-model method=POST url=http://127.0.0.1:13067/v1/chat/completions timeoutMs=undefined proxy=none policy=custom^[[39m
^[[33m[provider-transport-fetch]^[[39m ^[[36m[model-fetch] response provider=fixture api=openai-completions model=cached-only-model status=200 elapsedMs=20 dispatcher=new contentType=text/event-stream^[[39m
```

exit / verdict / provider 请求 / 运行方 state:

```text
OCPROOF(after-fix,dir) exit=0 ok=true model="cached-only-model" provider="fixture" final="OPENCLAW_E2E_OK"
mock provider requests seen this run: ["/v1/chat/completions"]
run-owned state catalog rows after the run: []
```

## 结论

隔离 state 的一次性 `agent exec` 在修复前把 provider 自有的生成式目录（`plugin-model-catalog-v1` 缓存）丢在操作方 agentDir 里，导致仅缓存可用的 `fixture/cached-only-model` 解析为 `Unknown model`（exit 1，无 provider 请求）；修复后同一条命令在同样的 fresh 隔离 state 下解析到该模型并真实请求到 provider（`ok=true model="cached-only-model" provider="fixture"`，`/v1/chat/completions` status=200），且请求级 scope 不向运行方 state 泄漏目录行（`run-owned state catalog rows after the run: []`）。

## 备注

- 默认 temp-state 模式的 CLI 退出码 1 仅来自与本次修复无关的 Windows 清理竞态（删除 CLI 自建临时 state 时 `EBUSY: ... unlink ...openclaw.sqlite`）；该轮的 turn 本身同样已解析模型并请求到 provider（见其 stderr 的 `model-fetch ... status=200`）。`--state-dir` 模式不受此影响，因此用于干净地展示 `ok=true`。
- 运行全程未 push、未改 PR；证据跑完后 `git status --porcelain` 为空（工作树 HEAD 不变）。
- 脚本、raw 输出与 scratch 目录（含真实 SQLite 与配置）全部在 `%LOCALAPPDATA%/Temp/ocproof-141355/` 下，可原样重跑。


### Re-ran by the author

Both legs were re-run on this branch by hand; the decisive lines:

```
$ node --import ./scripts/tsx.mjs ocproof-141355.mjs          # worktree at HEAD 43528e5c218
OCPROOF(...,dir) exit=0 ok=true model="cached-only-model" provider="fixture" final="OPENCLAW_E2E_OK"
[provider-transport-fetch] model=cached-only-model status=200
run-owned state catalog rows after the run: []

$ git checkout HEAD~1 -- src/agents/plugin-model-catalog.ts src/commands/agent-exec.ts && node --import ./scripts/tsx.mjs ocproof-141355.mjs
OCPROOF(...,temp) exit=1 ok=false error="Unknown model: fixture/cached-only-model"
OCPROOF(...,dir)  exit=1 ok=false error="Unknown model: fixture/cached-only-model"

$ git checkout HEAD -- src/agents/plugin-model-catalog.ts src/commands/agent-exec.ts && git status --porcelain
(clean)
```

Note on the temp-state leg: with no `--state-dir` the run succeeds but the CLI's own cleanup of the temporary state hits `EBUSY` on Windows and turns the exit code into 1 (`Agent exec cleanup failed: EBUSY ... unlink`). The provider request in that leg is still visible (`status=200`), and the `--state-dir` leg exits 0 cleanly. Both shapes are included above rather than dropping the noisier one.

### Data-model compatibility

No migration or schema change is involved. This branch's diff is 5 files and contains no DDL, no table/index/column change and no migration step — it reads the existing persisted catalog scope (`plugin-model-catalog-v1`) through the repository's own persisted-catalog helpers, the same shape the production writer already produces. An agent state directory written by an older build opens unchanged, and a catalog written through this path is byte-identical in shape to one written by the existing writer; the demo above seeds its database through `replacePersistedPluginModelCatalogs()` and reads it back through the production `agent exec` path.

Upgrade: a state directory written by an older build opens unchanged — this branch adds no tables, columns, indexes, or `schemaVersion` bumps and changes no writer, so there is nothing to migrate and no backfill step. Downgrade: checking out an older build after running this branch is safe — the branch persists zero new bytes (the handoff lives only in a request-owned `AsyncLocalStorage` scope; the trace above shows `run-owned state catalog rows after the run: []`), so older code simply never sees the handoff. Repair path untouched: `repairPersistedPluginModelCatalogs` and the catalog write path are not called by the new code.

```diff
$ git diff origin/main...HEAD --stat
 src/agents/plugin-model-catalog-handoff.ts      | 136 +++++++++
 src/agents/plugin-model-catalog.handoff.test.ts | 191 ++++++++++
 src/agents/plugin-model-catalog.ts              |  15 +-
 src/commands/agent-exec.plugin-catalog.test.ts  | 111 +++++++++
 src/commands/agent-exec.ts                      |  21 +-
 5 files changed, 465 insertions(+), 9 deletions(-)

$ git diff origin/main...HEAD | grep -Ei '^\+.*(CREATE TABLE|ALTER TABLE|CREATE INDEX|migration|schemaVersion)'
(no matches)
```


