### PR TITLE
test: share task command runtime fixtures

### DIFF
--- a/src/commands/tasks-json.test.ts
+++ b/src/commands/tasks-json.test.ts
@@ -24,14 +24,7 @@ import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import { createInMemoryTaskFlowRegistryStore } from "../test-utils/task-registry-store.js";
 import { tasksAuditJsonCommand, tasksListJsonCommand } from "./tasks-json.js";
 import { tasksListCommand, tasksShowCommand } from "./tasks.js";
-
-function createRuntime(): RuntimeEnv {
-  return {
-    log: vi.fn(),
-    error: vi.fn(),
-    exit: vi.fn(),
-  };
-}
+import { createTestRuntime } from "./test-runtime-config-helpers.js";
 
 function createTaskRecord(params: Parameters<typeof createTaskRecordOrNull>[0]): TaskRecord {
   const task = createTaskRecordOrNull(params);
@@ -113,7 +106,7 @@ describe("tasks JSON commands", () => {
         task: "Refresh schedule",
       });
 
-      const runtime = createRuntime();
+      const runtime = createTestRuntime();
       await tasksListJsonCommand({ json: true, runtime: "cli", status: "running" }, runtime);
 
       expect(readJsonLog(runtime)).toStrictEqual({
@@ -123,7 +116,7 @@ describe("tasks JSON commands", () => {
         tasks: [jsonRoundTrip(cliTask)],
       });
 
-      const emptyRuntime = createRuntime();
+      const emptyRuntime = createTestRuntime();
       await tasksListJsonCommand({ json: true, runtime: "subagent" }, emptyRuntime);
       expect(readJsonLog(emptyRuntime)).toStrictEqual({
         count: 0,
@@ -166,19 +159,19 @@ describe("tasks JSON commands", () => {
         endedAt: Date.now(),
       });
 
-      const listRuntime = createRuntime();
+      const listRuntime = createTestRuntime();
       await tasksListCommand({ status: "succeeded" }, listRuntime);
       const listOutput = vi.mocked(listRuntime.log).mock.calls.flat().join("\n");
       expect(listOutput).toContain("Task pressure: 0 queued · 0 running · 1 issues");
       expect(listOutput).toMatch(/\bblocked\s+pending\b/);
 
-      const blockedRuntime = createRuntime();
+      const blockedRuntime = createTestRuntime();
       await tasksListCommand({ status: "blocked" }, blockedRuntime);
       const blockedOutput = vi.mocked(blockedRuntime.log).mock.calls.flat().join("\n");
       expect(blockedOutput).toContain(task.taskId.slice(0, 9));
       expect(blockedOutput).not.toContain(completed.taskId.slice(0, 9));
 
-      const blockedJsonRuntime = createRuntime();
+      const blockedJsonRuntime = createTestRuntime();
       await tasksListJsonCommand({ json: true, status: "blocked" }, blockedJsonRuntime);
       expect(readJsonLog(blockedJsonRuntime)).toMatchObject({
         count: 1,
@@ -187,7 +180,7 @@ describe("tasks JSON commands", () => {
         tasks: [{ taskId: task.taskId, status: "succeeded", terminalOutcome: "blocked" }],
       });
 
-      const succeededJsonRuntime = createRuntime();
+      const succeededJsonRuntime = createTestRuntime();
       await tasksListJsonCommand({ json: true, status: "succeeded" }, succeededJsonRuntime);
       expect(readJsonLog(succeededJsonRuntime)).toMatchObject({
         count: 2,
@@ -198,11 +191,11 @@ describe("tasks JSON commands", () => {
         ]),
       });
 
-      const showRuntime = createRuntime();
+      const showRuntime = createTestRuntime();
       await tasksShowCommand({ lookup: task.taskId }, showRuntime);
       expect(vi.mocked(showRuntime.log).mock.calls.flat().join("\n")).toContain("status: blocked");
 
-      const jsonRuntime = createRuntime();
+      const jsonRuntime = createTestRuntime();
       await tasksShowCommand({ lookup: task.taskId, json: true }, jsonRuntime);
       expect(readJsonLog(jsonRuntime)).toMatchObject({
         status: "succeeded",
@@ -222,7 +215,7 @@ describe("tasks JSON commands", () => {
         task: "Inspect issue backlog",
       });
 
-      const runtime = createRuntime();
+      const runtime = createTestRuntime();
       await tasksListJsonCommand({ json: true, runtime: "   ", status: "\t" }, runtime);
 
       expect(readJsonLog(runtime)).toStrictEqual({
@@ -265,7 +258,7 @@ describe("tasks JSON commands", () => {
         updatedAt: now - 40 * 60_000,
       });
 
-      const runtime = createRuntime();
+      const runtime = createTestRuntime();
       await tasksAuditJsonCommand({ json: true, limit: 1 }, runtime);
 
       expect(readJsonLog(runtime)).toStrictEqual({
@@ -324,7 +317,7 @@ describe("tasks JSON commands", () => {
 
   it("reports blank audit filters as absent in JSON output", async () => {
     await withTaskJsonStateDir(async () => {
-      const runtime = createRuntime();
+      const runtime = createTestRuntime();
       await tasksAuditJsonCommand({ json: true, severity: "  ", code: "\t" }, runtime);
 
       expect(readJsonLog(runtime)).toMatchObject({
@@ -365,7 +358,7 @@ describe("tasks JSON commands", () => {
     const query = vi.spyOn(taskRuntime, "listTaskRecords").mockImplementation(() => {
       throw new Error("task JSON query performed");
     });
-    const runtime = createRuntime();
+    const runtime = createTestRuntime();
 
     try {
       await runCommandWithRuntime(runtime, () => run(runtime));
@@ -390,7 +383,7 @@ describe("tasks JSON commands", () => {
           loadSnapshot,
         },
       });
-      const runtime = createRuntime();
+      const runtime = createTestRuntime();
 
       await tasksAuditJsonCommand({ json: true }, runtime);
 

--- a/src/commands/tasks.read.test.ts
+++ b/src/commands/tasks.read.test.ts
@@ -2,7 +2,6 @@
 import { stripVTControlCharacters } from "node:util";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { runCommandWithRuntime } from "../cli/cli-utils.js";
-import type { RuntimeEnv } from "../runtime.js";
 import * as taskRegistryMaintenance from "../tasks/task-registry.maintenance.js";
 import * as taskRegistryReconcile from "../tasks/task-registry.reconcile.js";
 import type { TaskRecord } from "../tasks/task-registry.types.js";
@@ -11,6 +10,7 @@ import type {
   TaskSystemAuditSeverity,
 } from "../tasks/task-system-audit.types.js";
 import { tasksAuditCommand, tasksListCommand } from "./tasks.js";
+import { createTestRuntime } from "./test-runtime-config-helpers.js";
 
 const mocks = vi.hoisted(() => ({
   callGateway: vi.fn(),
@@ -19,14 +19,6 @@ const mocks = vi.hoisted(() => ({
 vi.mock("../gateway/call.js", () => ({
   callGateway: mocks.callGateway,
 }));
-
-function createRuntime(): RuntimeEnv {
-  return {
-    log: vi.fn(),
-    error: vi.fn(),
-    exit: vi.fn(),
-  };
-}
 
 describe("tasks command filter validation", () => {
   it("keeps valid matching and empty filters successful", async () => {
@@ -45,8 +37,8 @@ describe("tasks command filter validation", () => {
     const query = vi
       .spyOn(taskRegistryReconcile, "reconcileInspectableTasks")
       .mockReturnValue([task]);
-    const matchingRuntime = createRuntime();
-    const emptyRuntime = createRuntime();
+    const matchingRuntime = createTestRuntime();
+    const emptyRuntime = createTestRuntime();
 
     try {
       await tasksListCommand({ json: true, status: "running" }, matchingRuntime);
@@ -90,7 +82,7 @@ describe("tasks command filter validation", () => {
       .mockImplementation(() => {
         throw new Error("task query performed");
       });
-    const runtime = createRuntime();
+    const runtime = createTestRuntime();
 
     try {
       await runCommandWithRuntime(runtime, () => tasksListCommand(options, runtime));
@@ -119,7 +111,7 @@ describe("tasks command filter validation", () => {
       .mockImplementation(() => {
         throw new Error("task audit query performed");
       });
-    const runtime = createRuntime();
+    const runtime = createTestRuntime();
 
     try {
       await runCommandWithRuntime(runtime, () => tasksAuditCommand(options, runtime));
@@ -225,7 +217,7 @@ describe("tasks list output", () => {
       const query = vi
         .spyOn(taskRegistryReconcile, "reconcileInspectableTasks")
         .mockReturnValue([task]);
-      const runtime = createRuntime();
+      const runtime = createTestRuntime();
       try {
         await tasksListCommand({}, runtime);
         const lines = vi

--- a/src/commands/tasks.test.ts
+++ b/src/commands/tasks.test.ts
@@ -39,6 +39,7 @@ import {
   tasksMaintenanceCommand,
   tasksShowCommand,
 } from "./tasks.js";
+import { createTestRuntime } from "./test-runtime-config-helpers.js";
 
 const mocks = vi.hoisted(() => ({
   callGateway: vi.fn(),
@@ -47,14 +48,6 @@ const mocks = vi.hoisted(() => ({
 vi.mock("../gateway/call.js", () => ({
   callGateway: mocks.callGateway,
 }));
-
-function createRuntime(): RuntimeEnv {
-  return {
-    log: vi.fn(),
-    error: vi.fn(),
-    exit: vi.fn(),
-  } as unknown as RuntimeEnv;
-}
 
 function createTaskRecord(params: Parameters<typeof createTaskRecordOrNull>[0]): TaskRecord {
   const task = createTaskRecordOrNull(params);
@@ -184,7 +177,7 @@ describe("tasks commands", () => {
         updatedAt: now - 40 * 60_000,
       });
 
-      const runtime = createRuntime();
+      const runtime = createTestRuntime();
       await tasksAuditCommand({ json: true }, runtime);
 
       const payload = readFirstJsonLog(runtime) as {
@@ -212,7 +205,7 @@ describe("tasks commands", () => {
         updatedAt: now - 45 * 60_000,
       });
 
-      const limitedRuntime = createRuntime();
+      const limitedRuntime = createTestRuntime();
       const auditStartedAt = Date.now();
       await tasksAuditCommand({ json: true, limit: 1 }, limitedRuntime);
       const auditFinishedAt = Date.now();
@@ -247,7 +240,7 @@ describe("tasks commands", () => {
         },
       });
 
-      const jsonRuntime = createRuntime();
+      const jsonRuntime = createTestRuntime();
       await tasksAuditCommand({ json: true }, jsonRuntime);
       expect(readFirstJsonLog(jsonRuntime)).toMatchObject({
         count: 1,
@@ -271,7 +264,7 @@ describe("tasks commands", () => {
         ],
       });
 
-      const textRuntime = createRuntime();
+      const textRuntime = createTestRuntime();
       await tasksAuditCommand({ json: false }, textRuntime);
       const output = vi
         .mocked(textRuntime.log)
@@ -295,7 +288,7 @@ describe("tasks commands", () => {
         task: "Inspect issue backlog",
       });
 
-      const runtime = createRuntime();
+      const runtime = createTestRuntime();
       await tasksListCommand({ json: true, runtime: "   ", status: "\t" }, runtime);
 
       expect(readFirstJsonLog(runtime)).toStrictEqual({
@@ -309,7 +302,7 @@ describe("tasks commands", () => {
 
   it("reports blank audit filters as absent in command JSON output", async () => {
     await withTaskCommandStateDir(async () => {
-      const runtime = createRuntime();
+      const runtime = createTestRuntime();
       await tasksAuditCommand(
         {
           json: true,
@@ -383,7 +376,7 @@ describe("tasks commands", () => {
           runId: task.runId,
         },
       });
-      const runtime = createRuntime();
+      const runtime = createTestRuntime();
 
       await tasksCancelCommand({ lookup: task.taskId }, runtime);
 
@@ -420,7 +413,7 @@ describe("tasks commands", () => {
           runId: task.runId,
         },
       });
-      const runtime = createRuntime();
+      const runtime = createTestRuntime();
       await tasksCancelCommand({ lookup: task.taskId }, runtime);
       expect(runtime.log).toHaveBeenCalledWith(expect.stringContaining(`Cancelled ${task.taskId}`));
       expectSafeTaskOutput(runtime);
@@ -429,7 +422,7 @@ describe("tasks commands", () => {
         cancelled: false,
         reason: `gateway refused${unsafe}`,
       });
-      const failureRuntime = createRuntime();
+      const failureRuntime = createTestRuntime();
       await tasksCancelCommand({ lookup: task.taskId }, failureRuntime);
       expectSafeTaskOutput(failureRuntime, "error");
     });
@@ -464,7 +457,7 @@ describe("tasks commands", () => {
           notifyPolicy: "silent",
         });
         mocks.callGateway.mockRejectedValueOnce(new Error("gateway unavailable"));
-        const runtime = createRuntime();
+        const runtime = createTestRuntime();
 
         await tasksCancelCommand({ lookup: task.taskId }, runtime);
 
@@ -508,7 +501,7 @@ describe("tasks commands", () => {
         },
       });
 
-      const runtime = createRuntime();
+      const runtime = createTestRuntime();
       await tasksMaintenanceCommand({ json: true, apply: false }, runtime);
 
       const payload = readFirstJsonLog(runtime) as {
@@ -561,7 +554,7 @@ describe("tasks commands", () => {
         },
       });
 
-      const runtime = createRuntime();
+      const runtime = createTestRuntime();
       await tasksMaintenanceCommand({ json: true, apply: true }, runtime);
 
       const payload = readFirstJsonLog(runtime) as {
@@ -634,7 +627,7 @@ describe("tasks commands", () => {
         [retiredKey]: { sessionId: "retired-run", updatedAt: old },
       });
 
-      const runtime = createRuntime();
+      const runtime = createTestRuntime();
       await tasksMaintenanceCommand({ json: true, apply: true }, runtime);
 
       const payload = readFirstJsonLog(runtime) as {
@@ -688,7 +681,7 @@ describe("tasks commands", () => {
         },
       });
 
-      const runtime = createRuntime();
+      const runtime = createTestRuntime();
       await tasksMaintenanceCommand({ json: true, apply: true }, runtime);
 
       expect(
@@ -709,7 +702,7 @@ describe("tasks commands", () => {
         taskRegistryMaintenance,
         "getTaskRegistryMaintenanceDiagnostics",
       );
-      const runtime = createRuntime();
+      const runtime = createTestRuntime();
 
       await tasksMaintenanceCommand({ json: false, apply: false }, runtime);
 
@@ -729,7 +722,7 @@ describe("tasks commands", () => {
         startedAt: 8_700_000_000_000_000,
       });
 
-      const runtime = createRuntime();
+      const runtime = createTestRuntime();
       await tasksShowCommand({ json: false, lookup: task.taskId }, runtime);
 
       const joined = vi
@@ -756,9 +749,9 @@ describe("tasks commands", () => {
         terminalSummary: `summary${unsafe}`,
       });
       markTaskLostById({ taskId: task.taskId, endedAt: Date.now(), error: `error${unsafe}` });
-      const showRuntime = createRuntime();
-      const listRuntime = createRuntime();
-      const auditRuntime = createRuntime();
+      const showRuntime = createTestRuntime();
+      const listRuntime = createTestRuntime();
+      const auditRuntime = createTestRuntime();
       await tasksShowCommand({ lookup: task.taskId }, showRuntime);
       await tasksListCommand({}, listRuntime);
       await tasksAuditCommand({}, auditRuntime);
@@ -785,18 +778,18 @@ describe("tasks commands", () => {
       }
       expect(vi.mocked(listRuntime.log).mock.calls.flat().join("|")).toContain("error");
       expect(vi.mocked(auditRuntime.log).mock.calls.flat().join("|")).toContain("error");
-      const jsonRuntime = createRuntime();
+      const jsonRuntime = createTestRuntime();
       await tasksShowCommand({ lookup: task.taskId, json: true }, jsonRuntime);
       expect(readFirstJsonLog(jsonRuntime)).toEqual(jsonRoundTrip(getTaskById(task.taskId)));
       expect(getTaskById(task.taskId)).toMatchObject({
         runId: `run${unsafe}`,
         error: `error${unsafe}`,
       });
-      const lookupRuntime = createRuntime();
+      const lookupRuntime = createTestRuntime();
       await tasksShowCommand({ lookup: `missing${unsafe}` }, lookupRuntime);
       expectSafeTaskOutput(lookupRuntime, "error");
 
-      const jsonLookupRuntime = createRuntime();
+      const jsonLookupRuntime = createTestRuntime();
       await tasksShowCommand({ lookup: `missing${unsafe}`, json: true }, jsonLookupRuntime);
       expect(readFirstJsonLog(jsonLookupRuntime)).toMatchObject({
         ok: false,
@@ -830,7 +823,7 @@ describe("tasks commands", () => {
             terminalSummary: "Generic terminal summary",
           });
         }
-        const runtime = createRuntime();
+        const runtime = createTestRuntime();
         await tasksListCommand({}, runtime);
         const output = vi.mocked(runtime.log).mock.calls.flat().join("|");
         expect(output).toContain(error);
@@ -853,7 +846,7 @@ describe("tasks commands", () => {
       });
       createInspectableTask({ progressSummary: "Fetching provider credentials" });
       createInspectableTask({ status: "succeeded", label: "Human-readable task title" });
-      const runtime = createRuntime();
+      const runtime = createTestRuntime();
 
       await tasksListCommand({}, runtime);
 
@@ -881,7 +874,7 @@ describe("tasks commands", () => {
         cleanupAfter,
       });
 
-      const runtime = createRuntime();
+      const runtime = createTestRuntime();
       await tasksMaintenanceCommand({ json: false, apply: true }, runtime);
 
       const joined = vi
@@ -907,7 +900,7 @@ describe("tasks commands", () => {
         endedAt: now - 8 * 24 * 60 * 60_000,
       });
 
-      const runtime = createRuntime();
+      const runtime = createTestRuntime();
       await tasksMaintenanceCommand({ json: true, apply: false }, runtime);
 
       const payload = readFirstJsonLog(runtime) as {
@@ -970,7 +963,7 @@ describe("tasks commands", () => {
             deleteFlow,
           },
         });
-        const runtime = createRuntime();
+        const runtime = createTestRuntime();
 
         await expect(tasksMaintenanceCommand({ json: true, apply }, runtime)).rejects.toThrow(
           "Task-flow registry restore failed: SQLITE_CORRUPT: task-flow maintenance restore failed. Refusing task maintenance.",
@@ -1044,7 +1037,7 @@ describe("tasks commands", () => {
           },
         ],
       });
-      const runtime = createRuntime();
+      const runtime = createTestRuntime();
       await tasksMaintenanceCommand({ json: true, apply: true }, runtime);
 
       const payload = readFirstJsonLog(runtime) as {


### PR DESCRIPTION
## What Problem This Solves

The three task command test suites each maintain the same local log/error/exit runtime factory, including a redundant double cast in one suite.

## Why This Change Was Made

Use the existing typed `createTestRuntime` helper at every original call site. Preserve fresh mocks, the JSON log fallback, nonthrowing exit behavior, both recorded exit arguments, and each suite's existing state and timer cleanup.

## User Impact

No production behavior changes. Test support is +49/-71 lines (net -22); all 52 cases and assertions remain. The 46 retained call sites are a static source count, not a measured allocation count.

## Evidence

All three complete suites passed before and after: 52/52 cases in each run, with identical native inventory, results, and execution order. Targeted formatting and type-aware lint passed with zero warnings or errors. The normal changed-file gate passed through the configured Testbox route, including commands test typechecking, repository guards, all three dead-export scans, and targeted lint.

The [Testbox gate](https://github.com/openclaw/openclaw/actions/runs/34682964000) returned delegated exit code 0 and stopped its lease after completion; the backing Actions lease step may appear cancelled during cleanup. Independent applied review found no actionable findings through P2. The signed commit's tree exactly matches the tested remote candidate, and source, dependency, and cleanup checks passed.
