### PR TITLE
test(plugins): remove unused typed runtime fixtures

### DIFF
--- a/src/plugin-sdk/plugin-test-runtime.ts
+++ b/src/plugin-sdk/plugin-test-runtime.ts
@@ -118,12 +118,7 @@ export {
   requireRegisteredProvider,
   type RegisteredProviderCollections,
 } from "../test-utils/plugin-registration.js";
-export {
-  createNonExitingRuntimeEnv,
-  createNonExitingTypedRuntimeEnv,
-  createRuntimeEnv,
-  createTypedRuntimeEnv,
-} from "../test-utils/plugin-runtime-env.js";
+export { createNonExitingRuntimeEnv, createRuntimeEnv } from "../test-utils/plugin-runtime-env.js";
 export {
   createPluginSetupWizardAdapter,
   createPluginSetupWizardConfigure,

--- a/src/test-utils/plugin-runtime-env.ts
+++ b/src/test-utils/plugin-runtime-env.ts
@@ -1,5 +1,5 @@
 // Builds plugin runtime environment fixtures for plugin tests.
-import type { OutputRuntimeEnv, RuntimeEnv } from "openclaw/plugin-sdk/runtime";
+import type { OutputRuntimeEnv } from "openclaw/plugin-sdk/runtime";
 import { vi } from "vitest";
 
 type RuntimeEnvOptions = {
@@ -22,19 +22,6 @@ export function createRuntimeEnv(options?: RuntimeEnvOptions): OutputRuntimeEnv 
   };
 }
 
-export function createTypedRuntimeEnv<TRuntime extends RuntimeEnv = OutputRuntimeEnv>(
-  options?: RuntimeEnvOptions,
-  _runtimeShape?: (runtime: TRuntime) => void,
-): TRuntime {
-  return createRuntimeEnv(options) as unknown as TRuntime;
-}
-
 export function createNonExitingRuntimeEnv(): OutputRuntimeEnv {
   return createRuntimeEnv({ throwOnExit: false });
-}
-
-export function createNonExitingTypedRuntimeEnv<TRuntime extends RuntimeEnv = OutputRuntimeEnv>(
-  runtimeShape?: (runtime: TRuntime) => void,
-): TRuntime {
-  return createTypedRuntimeEnv<TRuntime>({ throwOnExit: false }, runtimeShape);
 }


### PR DESCRIPTION
Closes #145843

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

The repository's plugin-test support surface includes two runtime factory helpers that have no consumers. Their presence adds unused choices beside the fixtures tests actually use.

## Why This Change Was Made

Remove `createTypedRuntimeEnv` and `createNonExitingTypedRuntimeEnv` and their repository-only barrel exports. Keep the used `createRuntimeEnv` and `createNonExitingRuntimeEnv` implementations byte-for-byte, along with required type exports and the independent Matrix-local helper.

## User Impact

There is no intended user-visible behavior change. This removes 18 net test-support lines without adding, changing or deleting tests, changing production behavior, or altering published package exports. No runtime speed, allocation or memory savings are claimed.

## Evidence

All eight existing ClickClack setup-verification boundary tests pass through the retained runtime fixture. The full selected gate against `0cccc6d68e58ccd5030cd09931c1753bca924c7b` passes all 33 checks, including extension coverage and all three dead-export scans. Independent P2 review found no actionable findings.

A current tracked-tree reference check confirms that the removed shared factories have no consumers; the similarly named Matrix helper is locally defined and remains in use. Both removal owners still match the accepted beforeimages at that checked revision.
