### PR TITLE
perf(ui): avoid cloning read-only config baselines

### DIFF
--- a/ui/src/lib/config/config-draft-model.ts
+++ b/ui/src/lib/config/config-draft-model.ts
@@ -357,9 +357,8 @@ export function adoptConfigSetAck(
 }
 
 function syncConfigDraft(state: RuntimeConfigState, nextForm: Record<string, unknown>) {
-  const original = cloneConfigObject(
-    state.configFormOriginal ?? resolveEditableSnapshotConfig(state.configSnapshot) ?? {},
-  );
+  const original =
+    state.configFormOriginal ?? resolveEditableSnapshotConfig(state.configSnapshot) ?? {};
   const nextRaw = serializeConfigForm(nextForm);
   const originalRaw = serializeConfigForm(original);
   state.configForm = nextForm;


### PR DESCRIPTION
Closes #145845

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Control UI configuration form edits copy the complete comparison baseline even though that baseline is only read to determine whether the draft is dirty.

## Why This Change Was Made

Draft synchronization now serializes the existing baseline directly. The mutable draft copy and the ingestion, acknowledgement, rebase and reset isolation boundaries remain unchanged.

## User Impact

Configuration editing, dirty-state tracking and saving retain the same behavior while avoiding one unnecessary baseline clone per form edit. The change removes one net production line from a single file and changes no tests.

## Evidence

Against baseline `0cccc6d68e58ccd5030cd09931c1753bca924c7b`, 136 existing tests across six files passed, along with the full selected gate and a source-bound P2 review.

A 609,893-byte synthetic configuration fixture exercised 128 edits through `createRuntimeConfigCapability(...).patchForm`. Full configuration clones fell 256→128: baseline clones 128→0, while the 128 mutable-draft clones remained. Complete serialized edited output matched, with unchanged baselines, snapshots and prior drafts, detached edited drafts, and correct dirty-to-clean revert behavior.

Separate edit/save captures against a synthetic mocked Gateway retained identical submitted values and byte-identical before/after images. They are source-Vite UI evidence, not a live Gateway run. The clone counts do not establish timing, allocation-byte, RSS or retained-memory gains.

## After-change behavior verification — passed

The applicable UI edit/save flow was exercised in Chromium with the actual Control UI source at this PR's unchanged head, using the repository's source UI server and a synthetic Gateway protocol fixture:

1. Open Settings → Advanced → Laboratory and verify the Endpoint field starts at `before-save`.
2. Edit Endpoint to `after-save`. The UI emits its real `config.set` client request with base hash `synthetic-config-1` and the complete submitted value `{"laboratory":{"endpoint":"after-save","retryBudget":2}}`.
3. Acknowledge that request with `synthetic-config-2` and verify the UI displays **Saved**. The inspected after-change screenshot below records this completed state.

Both source-bound before/after runs completed those assertions and produced identical submitted values and screenshots. This covers the changed UI draft synchronization and client save boundary; the backend is a synthetic protocol fixture. The separate 128-edit public `patchForm` experiment above also passed its baseline/snapshot/prior-draft immutability, detached-draft, dirty/revert, and exact serialized-output assertions. The improvement claimed is fewer clone operations, without a timing or memory measurement.

## Visual verification

Before and after the same synthetic edit/save flow are byte-identical; both views use the same uploaded asset.

| Before | After |
| --- | --- |
| ![Before: synthetic configuration edit and save](https://github.com/user-attachments/assets/aa0bdf44-a2f4-4ed0-ab47-476cf4064cf9) | ![After: identical synthetic configuration edit and save](https://github.com/user-attachments/assets/aa0bdf44-a2f4-4ed0-ab47-476cf4064cf9) |
