### PR TITLE
perf(boards): reuse compiled SQLite read queries

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2115,7 +2115,7 @@ src/auto-reply/usage-bar/template.ts	1
 src/auto-reply/usage-bar/translator.ts	4
 src/boards/board-store.ts	1
 src/boards/sqlite-board-codec.ts	7
-src/boards/sqlite-board-store.ts	3
+src/boards/sqlite-board-store.ts	1
 src/bootstrap/node-startup-env.ts	1
 src/canvas/documents.ts	1
 src/canvas/serve.runtime.ts	1

--- a/src/boards/sqlite-board-read-queries.ts
+++ b/src/boards/sqlite-board-read-queries.ts
@@ -1,0 +1,62 @@
+import type { DatabaseSync } from "node:sqlite";
+import { getNodeSqliteKysely, prepareSqliteQuerySync } from "../infra/kysely-sync.js";
+import type { DB } from "../state/openclaw-agent-db.generated.js";
+import {
+  BOARD_WIDGET_SNAPSHOT_COLUMNS,
+  type SelectedBoardTabRow,
+  type SelectedBoardWidgetSnapshotRow,
+} from "./sqlite-board-codec.js";
+
+function createBoardReadQueries(database: DatabaseSync) {
+  const db =
+    getNodeSqliteKysely<Pick<DB, "board_tabs" | "board_widgets" | "session_nodes">>(database);
+  return {
+    session: prepareSqliteQuerySync<string, { entry_json: string }>(database, (parameter) =>
+      db
+        .selectFrom("session_nodes")
+        .select("entry_json")
+        .where(
+          "session_key",
+          "=",
+          parameter((key) => key),
+        )
+        .limit(1),
+    ),
+    tabs: prepareSqliteQuerySync<string, SelectedBoardTabRow>(database, (parameter) =>
+      db
+        .selectFrom("board_tabs")
+        .selectAll()
+        .where(
+          "session_key",
+          "=",
+          parameter((key) => key),
+        )
+        .orderBy("position", "asc")
+        .orderBy("tab_id", "asc"),
+    ),
+    widgets: prepareSqliteQuerySync<string, SelectedBoardWidgetSnapshotRow>(database, (parameter) =>
+      db
+        .selectFrom("board_widgets")
+        .select(BOARD_WIDGET_SNAPSHOT_COLUMNS)
+        .where(
+          "session_key",
+          "=",
+          parameter((key) => key),
+        )
+        .orderBy("tab_id", "asc")
+        .orderBy("position", "asc")
+        .orderBy("name", "asc"),
+    ),
+  };
+}
+
+const boardReadQueries = new WeakMap<DatabaseSync, ReturnType<typeof createBoardReadQueries>>();
+
+export function getBoardReadQueries(database: DatabaseSync) {
+  let queries = boardReadQueries.get(database);
+  if (!queries) {
+    queries = createBoardReadQueries(database);
+    boardReadQueries.set(database, queries);
+  }
+  return queries;
+}

--- a/src/boards/sqlite-board-store.ts
+++ b/src/boards/sqlite-board-store.ts
@@ -34,7 +34,6 @@ import {
   type BoardWidgetMcpAppDocument,
 } from "./board-store.js";
 import {
-  BOARD_WIDGET_SNAPSHOT_COLUMNS,
   createBoardWidgetContentFields,
   parseDescriptor,
   parseManifest,
@@ -49,6 +48,7 @@ import {
   type SelectedBoardTabRow,
   type SelectedBoardWidgetSnapshotRow,
 } from "./sqlite-board-codec.js";
+import { getBoardReadQueries } from "./sqlite-board-read-queries.js";
 
 type BoardDatabase = Pick<
   OpenClawAgentKyselyDatabase,
@@ -138,26 +138,9 @@ function readStoredBoard(database: BoardDatabaseHandle, sessionKey: string): Sto
   return runSqliteDeferredTransactionSync(
     database.db,
     () => {
-      const db = getNodeSqliteKysely<BoardDatabase>(database.db);
-      const tabRows = executeSqliteQuerySync(
-        database.db,
-        db
-          .selectFrom("board_tabs")
-          .selectAll()
-          .where("session_key", "=", sessionKey)
-          .orderBy("position", "asc")
-          .orderBy("tab_id", "asc"),
-      ).rows as SelectedBoardTabRow[];
-      const selectedWidgetRows = executeSqliteQuerySync(
-        database.db,
-        db
-          .selectFrom("board_widgets")
-          .select(BOARD_WIDGET_SNAPSHOT_COLUMNS)
-          .where("session_key", "=", sessionKey)
-          .orderBy("tab_id", "asc")
-          .orderBy("position", "asc")
-          .orderBy("name", "asc"),
-      ).rows as SelectedBoardWidgetSnapshotRow[];
+      const queries = getBoardReadQueries(database.db);
+      const tabRows = queries.tabs(sessionKey).rows;
+      const selectedWidgetRows = queries.widgets(sessionKey).rows;
       const parsedWidgetRows = selectedWidgetRows.map((row) => ({
         row,
         manifest: parseManifest(row.manifest),
@@ -322,15 +305,7 @@ function deleteRemovedTabs(
 }
 
 function hasSession(database: BoardDatabaseHandle, sessionKey: string): boolean {
-  const db = getNodeSqliteKysely<BoardDatabase>(database.db);
-  const row = executeSqliteQuerySync(
-    database.db,
-    db
-      .selectFrom("session_nodes")
-      .select("entry_json")
-      .where("session_key", "=", sessionKey)
-      .limit(1),
-  ).rows[0];
+  const row = getBoardReadQueries(database.db).session(sessionKey).rows[0];
   if (!row) {
     return false;
   }


### PR DESCRIPTION
Related: #144592

## What Problem This Solves

Repeated board reads and updates rebuild the same session, tab, and widget queries on every call, adding CPU work before SQLite runs them.

## Why This Change Was Made

Reuse compiled, parameter-bound Kysely queries per database connection. Existing transaction boundaries, native statement-cache ownership, lazy schema checks, and row ordering stay with their current owners. Typed query results also remove two row-array assertions, so their assertion baseline shrinks accordingly.

## User Impact

Warm board operations spend less time preparing reads. This is query preparation work for the continuing database cleanup; board SQLite execution still needs its separate worker migration.

## Evidence

- 49 board-store, codec, parity, and Gateway tests passed, including shared-store and reopen behavior.
- Paired synthetic SQLite query measurements, nine alternating rounds of 2,000 calls on one board with 48 widgets: session lookup 10.90 → 7.08 μs; tab read 14.79 → 10.03 μs; widget read 95.56 → 84.19 μs. These measure query calls, not end-to-end UI latency.
- SQL matched exactly; results matched for two separate session keys and a missing key.
- Full changed checks passed, including core and core-test typechecks, lint, dead-export and import-cycle checks.
- Independent Codex review found no actionable P2-or-higher findings.
