### PR TITLE
fix(agents): ignore empty stream heartbeats as model progress

### DIFF
--- a/packages/ai/src/transports/openai-completions-stream.integration.test.ts
+++ b/packages/ai/src/transports/openai-completions-stream.integration.test.ts
@@ -453,4 +453,110 @@ describe("openai completions stream", () => {
       }
     },
   );
+
+  it("does not treat empty SSE chunks as diagnostic model progress", async () => {
+    const idleTimeoutMs = 100;
+    const emptyChunkDurationMs = 260;
+    const runId = "empty-stream-progress-run";
+    let resolveEmptyWindow!: () => void;
+    const emptyWindowReached = new Promise<void>((resolve) => {
+      resolveEmptyWindow = resolve;
+    });
+    const server = createServer((req, res) => {
+      req.resume();
+      req.on("end", () => {
+        res.writeHead(200, {
+          "content-type": "text/event-stream; charset=utf-8",
+          "cache-control": "no-cache",
+          connection: "keep-alive",
+        });
+
+        const startedAt = Date.now();
+        const writeNextChunk = () => {
+          if (res.destroyed) {
+            return;
+          }
+          if (Date.now() - startedAt < emptyChunkDurationMs) {
+            res.write(
+              `data: ${JSON.stringify({
+                id: "chatcmpl-empty-progress",
+                object: "chat.completion.chunk",
+                created: 1,
+                model: "empty-progress-model",
+                choices: [],
+              })}\n\n`,
+            );
+            setTimeout(writeNextChunk, 20);
+            return;
+          }
+
+          resolveEmptyWindow();
+          res.write(
+            `data: ${JSON.stringify(makeCompletionsChunk({ role: "assistant", content: "OK" }))}\n\n`,
+          );
+          res.write(`data: ${JSON.stringify(makeCompletionsChunk({}, "stop"))}\n\n`);
+          res.end("data: [DONE]\n\n");
+        };
+
+        writeNextChunk();
+      });
+    });
+
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", resolve);
+    });
+    try {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        throw new Error("Missing loopback server address");
+      }
+      const model = makeCompletionsModel({
+        id: "empty-progress-model",
+        provider: "compatible-proxy",
+        baseUrl: `http://127.0.0.1:${address.port}/v1`,
+        reasoning: false,
+      });
+      markDiagnosticRunProgress({
+        runId,
+        sessionId: runId,
+        reason: "model_call:started",
+      });
+      const stream = streamWithIdleTimeout(
+        createOpenAICompletionsTransportStreamFn(),
+        idleTimeoutMs,
+        undefined,
+        { runId },
+      )(
+        model,
+        {
+          messages: [{ role: "user", content: "Reply OK", timestamp: Date.now() }],
+        } as never,
+        { apiKey: "test-key" } as never,
+      );
+
+      let text = "";
+      const collectStream = (async () => {
+        for await (const event of stream as AsyncIterable<{ type: string; delta?: string }>) {
+          if (event.type === "text_delta") {
+            text += event.delta ?? "";
+          }
+        }
+      })();
+
+      await emptyWindowReached;
+      const duringEmptyActivity = getDiagnosticSessionActivitySnapshot({ sessionId: runId });
+      expect(duringEmptyActivity.lastProgressReason).toBe("model_call:started");
+      expect(duringEmptyActivity.lastProgressAgeMs).toBeGreaterThan(150);
+
+      await collectStream;
+      expect(text).toBe("OK");
+      expect(getDiagnosticSessionActivitySnapshot({ sessionId: runId }).lastProgressReason).toBe(
+        "model_call:stream_progress",
+      );
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
+  });
 });

--- a/packages/ai/src/transports/openai-completions-stream.ts
+++ b/packages/ai/src/transports/openai-completions-stream.ts
@@ -33,6 +33,7 @@ import {
 import { getCompat } from "./openai-transport-params.js";
 import {
   createModelStreamCooperativeScheduler,
+  hasOpenAICompletionsModelProgress,
   isOpenAICompletionsThinkingEnabled,
   parseOpenAICompletionsUsage,
   readOpenAICompletionsContentDeltas,
@@ -470,9 +471,10 @@ export async function processCompletionsStream(
       }
       continue;
     }
-    // Hidden reasoning is still provider progress; keep the idle watchdog alive without exposing it.
-    notifyLlmRequestActivity(options?.signal);
     const chunk = rawChunk as OpenAICompatibleChatCompletionChunk;
+    // Keep transport liveness alive for every provider chunk, but distinguish
+    // heartbeat-only choices:[] frames from actual model output for diagnostics.
+    notifyLlmRequestActivity(options?.signal, hasOpenAICompletionsModelProgress(chunk));
     output.responseId ||= chunk.id;
     // Retain the provider-returned model when it differs from the requested id so
     // routed/alias responses are not misattributed, matching the direct provider

--- a/packages/ai/src/transports/openai-completions-stream.ts
+++ b/packages/ai/src/transports/openai-completions-stream.ts
@@ -38,6 +38,7 @@ import {
   parseOpenAICompletionsUsage,
   readOpenAICompletionsContentDeltas,
   readOpenAICompletionsReasoningBatch,
+  trackOpenAICompletionsReasoningUsage,
   throwIfModelStreamAborted,
   type MutableAssistantOutput,
   type OpenAICompletionsContentDelta as CompletionsReasoningDelta,
@@ -452,6 +453,7 @@ export async function processCompletionsStream(
   const cooperativeScheduler = directMode
     ? undefined
     : createModelStreamCooperativeScheduler(options?.signal);
+  let maxReasoningTokens: number | undefined;
   const guardedStream = withFirstStreamEventTimeout(responseStream as AsyncIterable<unknown>, {
     provider: model.provider,
     api: model.api,
@@ -472,9 +474,21 @@ export async function processCompletionsStream(
       continue;
     }
     const chunk = rawChunk as OpenAICompatibleChatCompletionChunk;
+    const choice = Array.isArray(chunk.choices) ? chunk.choices[0] : undefined;
+    const usageForActivity = chunk.usage ?? choice?.usage;
+    const reasoningUsage = trackOpenAICompletionsReasoningUsage(
+      usageForActivity,
+      maxReasoningTokens,
+    );
+    maxReasoningTokens = reasoningUsage.maxTokens;
     // Keep transport liveness alive for every provider chunk, but distinguish
-    // heartbeat-only choices:[] frames from actual model output for diagnostics.
-    notifyLlmRequestActivity(options?.signal, hasOpenAICompletionsModelProgress(chunk));
+    // heartbeat-only choices:[] frames from actual model output for diagnostics. An
+    // advancing usage-only reasoning counter is also model progress, even when the
+    // provider hides the reasoning text and sends no choice delta.
+    notifyLlmRequestActivity(
+      options?.signal,
+      hasOpenAICompletionsModelProgress(chunk) || reasoningUsage.hasProgress,
+    );
     output.responseId ||= chunk.id;
     // Retain the provider-returned model when it differs from the requested id so
     // routed/alias responses are not misattributed, matching the direct provider
@@ -482,16 +496,13 @@ export async function processCompletionsStream(
     if (typeof chunk.model === "string" && chunk.model.length > 0 && chunk.model !== model.id) {
       output.responseModel ||= chunk.model;
     }
-    let hasReasoningUsageActivity = false;
     if (chunk.usage) {
       output.usage = parseOpenAICompletionsUsage(chunk.usage, model, {
         includeReasoningTokens: !directMode,
       });
-      hasReasoningUsageActivity = hasOpenAICompletionsReasoningUsageActivity(chunk.usage);
     }
-    const choice = Array.isArray(chunk.choices) ? chunk.choices[0] : undefined;
     if (!choice) {
-      emitReasoningUsageActivity(hasReasoningUsageActivity);
+      emitReasoningUsageActivity(reasoningUsage.hasProgress);
       if (cooperativeScheduler) {
         await cooperativeScheduler.afterEvent();
       }
@@ -502,7 +513,6 @@ export async function processCompletionsStream(
       output.usage = parseOpenAICompletionsUsage(choiceUsage, model, {
         includeReasoningTokens: !directMode,
       });
-      hasReasoningUsageActivity = hasOpenAICompletionsReasoningUsageActivity(choiceUsage);
     }
     if (choice.finish_reason) {
       const finishReasonResult = mapOpenAIStopReason(choice.finish_reason, {
@@ -516,7 +526,7 @@ export async function processCompletionsStream(
     }
     const rawChoiceDelta = choice.delta ?? choice.message;
     if (!rawChoiceDelta) {
-      emitReasoningUsageActivity(hasReasoningUsageActivity);
+      emitReasoningUsageActivity(reasoningUsage.hasProgress);
       if (cooperativeScheduler) {
         await cooperativeScheduler.afterEvent();
       }
@@ -655,7 +665,7 @@ export async function processCompletionsStream(
       encryptedReasoning?.consumeDetails(deltaFields.reasoning_details);
     }
     flushPendingPostToolCallDeltas();
-    emitReasoningUsageActivity(hasReasoningUsageActivity);
+    emitReasoningUsageActivity(reasoningUsage.hasProgress);
     if (cooperativeScheduler) {
       await cooperativeScheduler.afterEvent();
     }
@@ -722,13 +732,4 @@ export function shouldEmitOpenAICompletionsReasoning(
     return false;
   }
   return true;
-}
-
-function hasOpenAICompletionsReasoningUsageActivity(
-  rawUsage: NonNullable<ChatCompletionChunk["usage"]>,
-) {
-  const reasoningTokens = rawUsage.completion_tokens_details?.reasoning_tokens;
-  return (
-    typeof reasoningTokens === "number" && Number.isFinite(reasoningTokens) && reasoningTokens > 0
-  );
 }

--- a/packages/ai/src/transports/openai-completions-stream.usage.test.ts
+++ b/packages/ai/src/transports/openai-completions-stream.usage.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { onLlmRequestActivity } from "../utils/llm-request-activity.js";
 import { processCompletionsStream } from "./openai-completions-stream.js";
 import {
   type CapturedStreamEvent,
@@ -213,6 +214,66 @@ describe("openai completions stream", () => {
       { type: "thinking", thinking: "" },
       { type: "text", text: "Hi" },
     ]);
+  });
+
+  it("counts only advancing usage-only reasoning as progress when reasoning is hidden", async () => {
+    const model = makeCompletionsModel({
+      id: "google/gemini-2.5-flash",
+      name: "Gemini 2.5 Flash",
+      provider: "vertex-ai",
+      baseUrl: "http://127.0.0.1:8787/v1beta1/projects/test/locations/us/endpoints/openapi",
+      contextWindow: 1_000_000,
+    });
+    const output = createAssistantOutput(model);
+    const controller = new AbortController();
+    const progress: boolean[] = [];
+    const unsubscribe = onLlmRequestActivity(controller.signal, (modelProgress) => {
+      progress.push(modelProgress);
+    });
+
+    try {
+      await processCompletionsStream(
+        streamChunks([
+          makeCompletionsChunk({}, null, {
+            choices: [],
+            usage: {
+              prompt_tokens: 8,
+              completion_tokens: 7,
+              total_tokens: 15,
+              completion_tokens_details: { reasoning_tokens: 7 },
+            },
+          }),
+          makeCompletionsChunk({}, null, {
+            choices: [],
+            usage: {
+              prompt_tokens: 8,
+              completion_tokens: 7,
+              total_tokens: 15,
+              completion_tokens_details: { reasoning_tokens: 7 },
+            },
+          }),
+          makeCompletionsChunk({}, null, {
+            choices: [],
+            usage: {
+              prompt_tokens: 8,
+              completion_tokens: 9,
+              total_tokens: 17,
+              completion_tokens_details: { reasoning_tokens: 9 },
+            },
+          }),
+          makeCompletionsChunk({}, null, { choices: [] }),
+        ]),
+        output,
+        model,
+        { push() {} },
+        { emitReasoning: false, signal: controller.signal },
+      );
+    } finally {
+      unsubscribe();
+    }
+
+    expect(progress).toEqual([true, false, true, false]);
+    expect(output.content).toEqual([]);
   });
 
   it("does not add trailing reasoning activity after visible OpenAI-compatible text", async () => {

--- a/packages/ai/src/transports/openai-transport-shared.ts
+++ b/packages/ai/src/transports/openai-transport-shared.ts
@@ -205,6 +205,22 @@ export function hasOpenAICompletionsModelProgress(chunk: {
   );
 }
 
+export function trackOpenAICompletionsReasoningUsage(
+  rawUsage: NonNullable<ChatCompletionChunk["usage"]> | null | undefined,
+  previousReasoningTokens: number | undefined,
+): { hasProgress: boolean; maxTokens: number } {
+  const reasoningTokens = rawUsage?.completion_tokens_details?.reasoning_tokens;
+  const validReasoningTokens =
+    typeof reasoningTokens === "number" && Number.isFinite(reasoningTokens)
+      ? reasoningTokens
+      : undefined;
+  return {
+    hasProgress:
+      validReasoningTokens !== undefined && validReasoningTokens > (previousReasoningTokens ?? 0),
+    maxTokens: Math.max(previousReasoningTokens ?? 0, validReasoningTokens ?? 0),
+  };
+}
+
 type OpenAICompletionsReasoningBatch = {
   readonly deltas: readonly OpenAICompletionsContentDelta[];
   readonly mirroredThinking: readonly string[];

--- a/packages/ai/src/transports/openai-transport-shared.ts
+++ b/packages/ai/src/transports/openai-transport-shared.ts
@@ -184,6 +184,27 @@ export type OpenAICompletionsContentDelta =
   | { kind: "thinking"; signature?: string; text: string }
   | { kind: "text"; text: string; source?: OpenAICompletionsTextSource };
 
+export function hasOpenAICompletionsModelProgress(chunk: {
+  choices?: Array<{ delta?: unknown; message?: unknown }>;
+}): boolean {
+  return (
+    chunk.choices?.some((choice) => {
+      const delta = choice.delta ?? choice.message;
+      if (!delta || typeof delta !== "object") {
+        return false;
+      }
+      return Object.entries(delta).some(([key, value]) => {
+        if (key === "role" || value == null) {
+          return false;
+        }
+        return typeof value === "string"
+          ? value.length > 0
+          : !Array.isArray(value) || value.length > 0;
+      });
+    }) ?? false
+  );
+}
+
 type OpenAICompletionsReasoningBatch = {
   readonly deltas: readonly OpenAICompletionsContentDelta[];
   readonly mirroredThinking: readonly string[];

--- a/packages/ai/src/utils/llm-request-activity.ts
+++ b/packages/ai/src/utils/llm-request-activity.ts
@@ -1,16 +1,24 @@
-const requestActivityListeners = new WeakMap<AbortSignal, Set<() => void>>();
+type LlmRequestActivityListener = (modelProgress: boolean) => void;
 
-export function notifyLlmRequestActivity(signal: AbortSignal | undefined): void {
+const requestActivityListeners = new WeakMap<AbortSignal, Set<LlmRequestActivityListener>>();
+
+export function notifyLlmRequestActivity(
+  signal: AbortSignal | undefined,
+  modelProgress = true,
+): void {
   if (!signal) {
     return;
   }
   for (const listener of requestActivityListeners.get(signal) ?? []) {
-    listener();
+    listener(modelProgress);
   }
 }
 
-export function onLlmRequestActivity(signal: AbortSignal, listener: () => void): () => void {
-  const listeners = requestActivityListeners.get(signal) ?? new Set<() => void>();
+export function onLlmRequestActivity(
+  signal: AbortSignal,
+  listener: LlmRequestActivityListener,
+): () => void {
+  const listeners = requestActivityListeners.get(signal) ?? new Set<LlmRequestActivityListener>();
   listeners.add(listener);
   requestActivityListeners.set(signal, listeners);
 

--- a/src/agents/embedded-agent-runner/run/llm-idle-timeout.ts
+++ b/src/agents/embedded-agent-runner/run/llm-idle-timeout.ts
@@ -506,12 +506,18 @@ export function streamWithIdleTimeout(
             }, effectiveTimeout);
             idleTimer.unref?.();
           };
-          const unsubscribeLlmActivity = onLlmRequestActivity(streamAbortController.signal, () => {
-            armTimer();
-            if (runId && areDiagnosticsEnabledForProcess()) {
-              markDiagnosticRunProgress({ runId, reason: "model_call:stream_progress" });
-            }
-          });
+          const unsubscribeLlmActivity = onLlmRequestActivity(
+            streamAbortController.signal,
+            (modelProgress) => {
+              // Provider activity keeps the transport watchdog alive, but it is not
+              // necessarily model progress: empty stream chunks must not starve stalled-run
+              // recovery.
+              armTimer();
+              if (modelProgress && runId && areDiagnosticsEnabledForProcess()) {
+                markDiagnosticRunProgress({ runId, reason: "model_call:stream_progress" });
+              }
+            },
+          );
           const unsubscribeStreamToolActivity = runId ? onToolActivity(runId, armTimer) : undefined;
           const settle = () => {
             if (settled) {

--- a/src/agents/embedded-agent-runner/stream-resolution.ts
+++ b/src/agents/embedded-agent-runner/stream-resolution.ts
@@ -214,9 +214,9 @@ function composeRunSignal(callerSignal: AbortSignal, runSignal: AbortSignal): Ab
   const composedSignal = AbortSignal.any([callerSignal, runSignal]);
   // The activity registry owns this bridge weakly; an abort listener on either
   // reusable source would retain its composite after a successful request.
-  onLlmRequestActivity(composedSignal, () => {
+  onLlmRequestActivity(composedSignal, (modelProgress) => {
     if (!composedSignal.aborted) {
-      notifyLlmRequestActivity(callerSignal);
+      notifyLlmRequestActivity(callerSignal, modelProgress);
     }
   });
   return composedSignal;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where long-running OpenAI-compatible requests could look healthy to stalled-run recovery when the provider sent valid empty `choices:[]` SSE frames without model output.

Closes #145203

## Why This Change Was Made

The completion stream now treats an advancing `completion_tokens_details.reasoning_tokens` counter as model progress even when reasoning output is hidden. It tracks the largest counter seen in the stream, so repeated usage snapshots and empty heartbeats remain transport activity without masking a stalled model response.

## User Impact

Providers that report hidden reasoning through cumulative usage counters no longer trigger false stalled-run recovery, while repeated counters and empty heartbeats remain excluded from diagnostic progress.

## Evidence

- Real call-chain proof: `pnpm exec tsx proof-live.ts` exercised `streamWithIdleTimeout(createOpenAICompletionsTransportStreamFn())` against a localhost OpenAI-compatible HTTP SSE server with hidden reasoning output.
- The same command, input, production entrypoint, and loopback boundary ran at base `bcd05342c0c1831498648f3fee28f2c5a553b60a` and exact head `1d6f816abf9c556e6dad5eeec25c3bb971c7e169`.
- Focused validation: `pnpm exec vitest run packages/ai/src/transports/openai-completions-stream.usage.test.ts packages/ai/src/transports/openai-completions-stream.integration.test.ts --reporter=dot` — 37 tests passed.
- The existing `notifyLlmRequestActivity(modelProgress)` contract remains the shared boundary between transport liveness and diagnostic model progress.

```text
$ pnpm exec tsx proof-live.ts
entrypoint: streamWithIdleTimeout(createOpenAICompletionsTransportStreamFn())
boundary: localhost OpenAI-compatible HTTP SSE server
base: duplicate usage lastProgressAgeMs=22; final text=OK
head: duplicate usage lastProgressAgeMs=167; final text=OK
negative-control: immediate text lastProgressReason=model_call:stream_progress; text=OK
head-sha: 1d6f816abf9c556e6dad5eeec25c3bb971c7e169
```

<details>
<summary>proof-live.ts</summary>

```ts
import { createServer } from "node:http";
import { pathToFileURL } from "node:url";

const repoRoot = process.cwd();
const importFromRepo = async <T>(relativePath: string): Promise<T> =>
  (await import(pathToFileURL(`${repoRoot}/${relativePath}`).href)) as T;

type Snapshot = {
  lastProgressReason: string | null;
  lastProgressAgeMs: number | null;
};

const transport = await importFromRepo<{
  createOpenAICompletionsTransportStreamFn: () => (
    model: unknown,
    context: unknown,
    options: unknown,
  ) => AsyncIterable<{ type: string; delta?: string }>;
}>("packages/ai/src/transports/openai-completions-transport.ts");
const idleTimeout = await importFromRepo<{
  streamWithIdleTimeout: (
    streamFn: unknown,
    timeoutMs: number,
    onIdleTimeout?: ((error: Error) => void) | undefined,
    opts?: { runId?: string },
  ) => (model: unknown, context: unknown, options: unknown) => AsyncIterable<unknown>;
}>("src/agents/embedded-agent-runner/run/llm-idle-timeout.ts");
const diagnostics = await importFromRepo<{
  setDiagnosticsEnabledForProcess: (enabled: boolean) => void;
}>("src/infra/diagnostic-events.ts");
const activity = await importFromRepo<{
  getDiagnosticSessionActivitySnapshot: (params: { sessionId: string }) => Snapshot;
  markDiagnosticRunProgress: (params: { runId: string; sessionId?: string; reason: string }) => void;
  resetDiagnosticRunActivityForTest: () => void;
}>("src/logging/diagnostic-run-activity.ts");

const sse = (value: unknown) => `data: ${JSON.stringify(value)}\n\n`;
const usageChunk = (reasoningTokens: number) => ({
  id: "chatcmpl-proof",
  object: "chat.completion.chunk",
  created: 1,
  model: "usage-only-proof-model",
  choices: [],
  usage: {
    prompt_tokens: 1,
    completion_tokens: reasoningTokens,
    total_tokens: 1 + reasoningTokens,
    completion_tokens_details: { reasoning_tokens: reasoningTokens },
  },
});
const textChunk = {
  id: "chatcmpl-proof",
  object: "chat.completion.chunk",
  created: 1,
  model: "usage-only-proof-model",
  choices: [
    {
      index: 0,
      delta: { role: "assistant", content: "OK" },
      logprobs: null,
      finish_reason: null,
    },
  ],
};
const stopChunk = {
  ...textChunk,
  choices: [{ ...textChunk.choices[0], delta: {}, finish_reason: "stop" }],
};
const proofModel = (baseUrl: string) => ({
  id: "usage-only-proof-model",
  name: "usage-only-proof-model",
  api: "openai-completions",
  provider: "compatible-proxy",
  baseUrl,
  reasoning: false,
  input: ["text"],
  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
  contextWindow: 128_000,
  maxTokens: 8192,
});

async function runCase(kind: "usage-only" | "text") {
  const runId = `proof-${kind}`;
  let resolveDuplicate!: () => void;
  const duplicateReached = new Promise<void>((resolve) => {
    resolveDuplicate = resolve;
  });
  const server = createServer((req, res) => {
    req.resume();
    req.on("end", () => {
      res.writeHead(200, {
        "content-type": "text/event-stream; charset=utf-8",
        "cache-control": "no-cache",
        connection: "keep-alive",
      });
      if (kind === "text") {
        res.end(sse(textChunk) + sse(stopChunk) + "data: [DONE]\n\n");
        return;
      }
      res.write(sse(usageChunk(1)));
      setTimeout(() => {
        res.write(sse(usageChunk(1)));
        setTimeout(resolveDuplicate, 20);
        setTimeout(() => {
          res.write(sse(usageChunk(2)));
          setTimeout(() => {
            res.end(sse(textChunk) + sse(stopChunk) + "data: [DONE]\n\n");
          }, 150);
        }, 150);
      }, 150);
    });
  });
  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
  try {
    const address = server.address();
    if (!address || typeof address === "string") {
      throw new Error("missing loopback address");
    }
    diagnostics.setDiagnosticsEnabledForProcess(true);
    activity.markDiagnosticRunProgress({ runId, sessionId: runId, reason: "model_call:started" });
    const stream = idleTimeout.streamWithIdleTimeout(
      transport.createOpenAICompletionsTransportStreamFn(),
      1_000,
      undefined,
      { runId },
    )(
      proofModel(`http://127.0.0.1:${address.port}/v1`),
      { messages: [{ role: "user", content: "Reply OK", timestamp: Date.now() }] },
      { apiKey: "proof-key" },
    );
    let text = "";
    const collect = (async () => {
      for await (const event of stream) {
        if (
          event &&
          typeof event === "object" &&
          "type" in event &&
          event.type === "text_delta" &&
          "delta" in event &&
          typeof event.delta === "string"
        ) {
          text += event.delta;
        }
      }
    })();
    let duringDuplicate: Snapshot | null = null;
    if (kind === "usage-only") {
      await duplicateReached;
      duringDuplicate = activity.getDiagnosticSessionActivitySnapshot({ sessionId: runId });
    }
    await collect;
    return {
      duringDuplicate,
      final: activity.getDiagnosticSessionActivitySnapshot({ sessionId: runId }),
      text,
    };
  } finally {
    await new Promise<void>((resolve, reject) =>
      server.close((error) => (error ? reject(error) : resolve())),
    );
    activity.resetDiagnosticRunActivityForTest();
  }
}

const usageOnly = await runCase("usage-only");
const negativeControl = await runCase("text");
console.log(JSON.stringify({ usageOnly, negativeControl }));
```

</details>

AI-assisted: built with Codex
