### PR TITLE
feat(plugins): offer asynchronous task and flow reads

### DIFF
--- a/docs/plugins/sdk-runtime/background-work.md
+++ b/docs/plugins/sdk-runtime/background-work.md
@@ -143,6 +143,39 @@ Start agent work in the background: hook-dispatched turns for external content, 
 
   </Accordion>
   <Accordion title="api.runtime.tasks">
+    Prefer `api.runtime.tasks.async` for reads. It has `runs`, `flows`, and
+    `managedFlows` namespaces with the same synchronous `bindSession(...)` and
+    `fromToolContext(...)` factories. Await `get`, `list`, `findLatest`, and
+    `resolve`; both flow namespaces also provide awaited `getTaskSummary`.
+
+    ```typescript
+    const flows = api.runtime.tasks.async.managedFlows.fromToolContext(ctx);
+    const current = await flows.get(flowId);
+    ```
+
+    Results preserve the corresponding synchronous payloads and owner scope.
+    Reads query persisted SQLite records in the shared database worker, without
+    overwriting the process registry. The first cold call still performs the
+    existing schema admission and registry restore on the main thread. Access
+    checks for bare owner keys without a persisted requester agent can also
+    require existing runtime-configuration preparation on the main thread.
+    Warmed task and flow SQL queries run in the worker. A result describes its
+    query snapshot and may be superseded by a later mutation.
+
+    Lists sort newest first. Equal task timestamps sort by task ID descending;
+    equal flow timestamps sort by flow ID ascending. Run-ID lookup retains its
+    runtime preference and oldest-first selection, then uses task ID ascending
+    for ties. Legacy synchronous methods
+    keep their existing insertion-order tie behavior.
+
+    The 14 synchronous read methods remain supported but are deprecated in
+    favor of this opt-in surface. Their removal requires a supported external
+    plugin migration and an explicitly approved Plugin SDK major release.
+    Mutations and cancellation continue through the existing namespaces; the
+    async namespace does not expose replacement write methods yet. An awaited
+    read does not authorize a later write: retain revision checks and the
+    synchronous final backing-task read/link sequence described below.
+
     Bind Task Flow and Task Run state to a trusted, existing OpenClaw owner session.
 
     - `managedFlows` creates and mutates managed flow records. Bind with `fromToolContext(ctx)` or `bindSession({ sessionKey, requesterOrigin })` using host-resolved context, never raw user input.

--- a/extensions/webhooks/index.test.ts
+++ b/extensions/webhooks/index.test.ts
@@ -16,6 +16,11 @@ function createApi(params?: {
     pluginConfig: params?.pluginConfig ?? {},
     runtime: {
       tasks: {
+        async: {
+          managedFlows: {
+            bindSession: vi.fn(({ sessionKey }: { sessionKey: string }) => ({ sessionKey })),
+          },
+        },
         managedFlows: {
           bindSession: vi.fn(({ sessionKey }: { sessionKey: string }) => ({ sessionKey })),
         },

--- a/extensions/webhooks/index.ts
+++ b/extensions/webhooks/index.ts
@@ -27,6 +27,9 @@ function registerWebhookRoutes(api: OpenClawPluginApi): void {
       secretInput: route.secret,
       defaultControllerId: route.controllerId,
       taskFlow,
+      taskFlowReads: api.runtime.tasks.async.managedFlows.bindSession({
+        sessionKey: route.sessionKey,
+      }),
     };
     targetsByPath.set(target.path, [...(targetsByPath.get(target.path) ?? []), target]);
     api.registerHttpRoute({

--- a/extensions/webhooks/src/http.test.ts
+++ b/extensions/webhooks/src/http.test.ts
@@ -29,6 +29,21 @@ type MockIncomingMessage = IncomingMessage & {
 
 let nextSessionId = 0;
 
+// This HTTP fixture models the Promise-valued SDK contract. Real SQLite worker
+// execution is covered through the registered runtime's integration tests.
+function createFlowBindings(sessionKey: string) {
+  const taskFlow = createRuntimeTaskFlow().bindSession({ sessionKey });
+  const taskFlowReads: TaskFlowWebhookTarget["taskFlowReads"] = {
+    sessionKey,
+    get: async (flowId) => taskFlow.get(flowId),
+    list: async () => taskFlow.list(),
+    findLatest: async () => taskFlow.findLatest(),
+    resolve: async (token) => taskFlow.resolve(token),
+    getTaskSummary: async (flowId) => taskFlow.getTaskSummary(flowId),
+  };
+  return { taskFlow, taskFlowReads };
+}
+
 function createJsonRequest(params: {
   path: string;
   secret?: string;
@@ -61,16 +76,13 @@ function createHandler(secret = "shared-secret"): {
   target: TaskFlowWebhookTarget;
   secret: string;
 } {
-  const runtime = createRuntimeTaskFlow();
   nextSessionId += 1;
   const target: TaskFlowWebhookTarget = {
     routeId: "zapier",
     path: "/plugins/webhooks/zapier",
     secretInput: secret,
     defaultControllerId: "webhooks/zapier",
-    taskFlow: runtime.bindSession({
-      sessionKey: `agent:main:webhook-test-${String(nextSessionId)}`,
-    }),
+    ...createFlowBindings(`agent:main:webhook-test-${String(nextSessionId)}`),
   };
   const targetsByPath = new Map<string, TaskFlowWebhookTarget[]>([[target.path, [target]]]);
   return {
@@ -115,6 +127,44 @@ function parseJsonBody(res: { body?: string | Buffer | null }) {
 }
 
 describe("createTaskFlowWebhookRequestHandler", () => {
+  it.each([
+    "get_flow",
+    "list_flows",
+    "find_latest_flow",
+    "resolve_flow",
+    "get_task_summary",
+  ] as const)("awaits the SDK read result for %s", async (action) => {
+    const { handler, target, secret } = createHandler();
+    const created = createManagedFlow(target, {
+      controllerId: "tests/webhook-reads",
+      goal: "Read a synthetic flow",
+    });
+    const response = await dispatchJsonRequest({
+      handler,
+      path: target.path,
+      secret,
+      body: {
+        action,
+        ...(action === "get_flow" || action === "get_task_summary"
+          ? { flowId: created.flowId }
+          : {}),
+        ...(action === "resolve_flow" ? { token: created.flowId } : {}),
+      },
+    });
+    expect(response.statusCode).toBe(200);
+    const expectedFlow = expect.objectContaining({
+      flowId: created.flowId,
+      goal: "Read a synthetic flow",
+    });
+    expect(parseJsonBody(response).result).toMatchObject(
+      action === "get_task_summary"
+        ? { summary: { total: 0, active: 0, terminal: 0 } }
+        : action === "list_flows"
+          ? { flows: [expectedFlow] }
+          : { flow: expectedFlow },
+    );
+  });
+
   it("rejects requests with the wrong secret", async () => {
     const { handler, target } = createHandler();
     const res = await dispatchJsonRequest({
@@ -132,7 +182,6 @@ describe("createTaskFlowWebhookRequestHandler", () => {
   });
 
   it("keeps an unresolved SecretRef-backed route cold", async () => {
-    const runtime = createRuntimeTaskFlow();
     const target: TaskFlowWebhookTarget = {
       routeId: "cached",
       path: "/plugins/webhooks/cached",
@@ -142,9 +191,7 @@ describe("createTaskFlowWebhookRequestHandler", () => {
         id: "OPENCLAW_WEBHOOK_SECRET",
       },
       defaultControllerId: "webhooks/cached",
-      taskFlow: runtime.bindSession({
-        sessionKey: "agent:main:webhook-cached",
-      }),
+      ...createFlowBindings("agent:main:webhook-cached"),
     };
     const handler = createHandlerWithTarget(target);
 

--- a/extensions/webhooks/src/http.ts
+++ b/extensions/webhooks/src/http.ts
@@ -31,6 +31,7 @@ export type TaskFlowWebhookTarget = {
   secretInput: WebhookSecretInput;
   defaultControllerId: string;
   taskFlow: BoundTaskFlowRuntime;
+  taskFlowReads: ReturnType<PluginRuntime["tasks"]["async"]["managedFlows"]["bindSession"]>;
 };
 
 type FlowView = {
@@ -422,21 +423,21 @@ async function executeWebhookAction(params: {
         : { created: false, code: "persist_failed" };
     }
     case "get_flow": {
-      const flow = target.taskFlow.get(action.flowId);
+      const flow = await target.taskFlowReads.get(action.flowId);
       return { flow: flow ? toFlowView(flow) : null };
     }
     case "list_flows":
-      return { flows: target.taskFlow.list().map(toFlowView) };
+      return { flows: (await target.taskFlowReads.list()).map(toFlowView) };
     case "find_latest_flow": {
-      const flow = target.taskFlow.findLatest();
+      const flow = await target.taskFlowReads.findLatest();
       return { flow: flow ? toFlowView(flow) : null };
     }
     case "resolve_flow": {
-      const flow = target.taskFlow.resolve(action.token);
+      const flow = await target.taskFlowReads.resolve(action.token);
       return { flow: flow ? toFlowView(flow) : null };
     }
     case "get_task_summary":
-      return { summary: target.taskFlow.getTaskSummary(action.flowId) ?? null };
+      return { summary: (await target.taskFlowReads.getTaskSummary(action.flowId)) ?? null };
     case "set_waiting": {
       const result = target.taskFlow.setWaiting({
         flowId: action.flowId,

--- a/src/acp/server.startup.test.ts
+++ b/src/acp/server.startup.test.ts
@@ -44,7 +44,7 @@ const mockState = vi.hoisted(() => ({
   routeLogsToStderr: vi.fn(),
   startProxy: vi.fn(async (_configForTest: unknown) => null as unknown),
   stopProxy: vi.fn(async (_handle: unknown) => {}),
-  closeOpenClawStateDatabase: vi.fn(),
+  closeOpenClawStateDatabaseAsync: vi.fn<() => Promise<void>>(async () => {}),
   gatewayStopDeferred: null as {
     resolve: () => void;
     promise: Promise<void>;
@@ -198,7 +198,7 @@ vi.mock("../logging/console.js", async (importOriginal) => {
 });
 
 vi.mock("../state/openclaw-state-db.js", () => ({
-  closeOpenClawStateDatabase: () => mockState.closeOpenClawStateDatabase(),
+  closeOpenClawStateDatabaseAsync: () => mockState.closeOpenClawStateDatabaseAsync(),
 }));
 
 vi.mock("./event-ledger.js", () => ({
@@ -377,7 +377,7 @@ describe("serveAcpGateway startup", () => {
     mockState.routeLogsToStderr.mockReset();
     mockState.startProxy.mockReset();
     mockState.stopProxy.mockReset();
-    mockState.closeOpenClawStateDatabase.mockReset();
+    mockState.closeOpenClawStateDatabaseAsync.mockReset();
     mockState.gatewayStopDeferred = null;
     mockState.startProxy.mockResolvedValue(null);
     mockState.stopProxy.mockResolvedValue(undefined);
@@ -574,7 +574,7 @@ describe("serveAcpGateway startup", () => {
     try {
       await serveAcpGateway({});
       expect(mockState.agentSideConnectionCtor).not.toHaveBeenCalled();
-      expect(mockState.closeOpenClawStateDatabase).toHaveBeenCalledOnce();
+      expect(mockState.closeOpenClawStateDatabaseAsync).toHaveBeenCalledOnce();
     } finally {
       onceSpy.mockRestore();
     }
@@ -685,14 +685,14 @@ describe("serveAcpGateway startup", () => {
 
   it("closes the shared state database on shutdown", async () => {
     const { signalHandlers, onceSpy } = captureProcessSignalHandlers();
-    expect(mockState.closeOpenClawStateDatabase).not.toHaveBeenCalled();
+    expect(mockState.closeOpenClawStateDatabaseAsync).not.toHaveBeenCalled();
 
     try {
       const servePromise = serveAcpGateway({});
       await emitHelloAndWaitForAgentSideConnection();
       await stopServeWithSigint(signalHandlers, servePromise);
       expect(mockState.agentShutdown).toHaveBeenCalledOnce();
-      expect(mockState.closeOpenClawStateDatabase).toHaveBeenCalledOnce();
+      expect(mockState.closeOpenClawStateDatabaseAsync).toHaveBeenCalledOnce();
     } finally {
       onceSpy.mockRestore();
     }
@@ -713,7 +713,7 @@ describe("serveAcpGateway startup", () => {
       await servePromise;
 
       expect(mockState.agentShutdown).toHaveBeenCalledOnce();
-      expect(mockState.closeOpenClawStateDatabase).toHaveBeenCalledOnce();
+      expect(mockState.closeOpenClawStateDatabaseAsync).toHaveBeenCalledOnce();
     } finally {
       onceSpy.mockRestore();
     }
@@ -734,11 +734,11 @@ describe("serveAcpGateway startup", () => {
       await vi.waitFor(() => {
         expect(mockState.agentShutdown).toHaveBeenCalledOnce();
       });
-      expect(mockState.closeOpenClawStateDatabase).not.toHaveBeenCalled();
+      expect(mockState.closeOpenClawStateDatabaseAsync).not.toHaveBeenCalled();
 
       resolveStop();
       await servePromise;
-      expect(mockState.closeOpenClawStateDatabase).toHaveBeenCalledOnce();
+      expect(mockState.closeOpenClawStateDatabaseAsync).toHaveBeenCalledOnce();
     } finally {
       onceSpy.mockRestore();
     }
@@ -747,7 +747,7 @@ describe("serveAcpGateway startup", () => {
   it("closes a real node:sqlite DatabaseSync handle through serveAcpGateway shutdown", async () => {
     // Use the real state-db module to open and verify a DatabaseSync handle —
     // this proves the full serveAcpGateway → shutdown → close path, not just
-    // the closeOpenClawStateDatabase helper in isolation.
+    // the closeOpenClawStateDatabaseAsync helper in isolation.
     const actualStateDb = await vi.importActual<typeof import("../state/openclaw-state-db.js")>(
       "../state/openclaw-state-db.js",
     );
@@ -757,10 +757,10 @@ describe("serveAcpGateway startup", () => {
     expect(actualStateDb.isOpenClawStateDatabaseOpen()).toBe(true);
 
     // Wire the test mock so serveAcpGateway's shutdown handler calls the
-    // real closeOpenClawStateDatabase, which closes the handle we opened above.
-    mockState.closeOpenClawStateDatabase.mockImplementation(() => {
-      actualStateDb.closeOpenClawStateDatabase();
-    });
+    // real closeOpenClawStateDatabaseAsync, which closes the handle we opened above.
+    mockState.closeOpenClawStateDatabaseAsync.mockImplementation(() =>
+      actualStateDb.closeOpenClawStateDatabaseAsync(),
+    );
 
     const { signalHandlers, onceSpy } = captureProcessSignalHandlers();
     try {
@@ -774,7 +774,7 @@ describe("serveAcpGateway startup", () => {
       expect(realDb.db.isOpen).toBe(false);
       expect(actualStateDb.isOpenClawStateDatabaseOpen()).toBe(false);
     } finally {
-      actualStateDb.closeOpenClawStateDatabase();
+      await actualStateDb.closeOpenClawStateDatabaseAsync();
       onceSpy.mockRestore();
     }
   });

--- a/src/acp/server.ts
+++ b/src/acp/server.ts
@@ -24,7 +24,7 @@ import { GatewayClient } from "../gateway/client.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { isMainModule } from "../infra/is-main.js";
 import { routeLogsToStderr } from "../logging/console.js";
-import { closeOpenClawStateDatabase } from "../state/openclaw-state-db.js";
+import { closeOpenClawStateDatabaseAsync } from "../state/openclaw-state-db.js";
 import { createSqliteAcpEventLedger } from "./event-ledger.js";
 import { readSecretFromFile } from "./secret-file.js";
 import { AcpGatewayAgent } from "./translator.js";
@@ -107,9 +107,13 @@ export async function serveAcpGateway(opts: AcpServerOptions = {}): Promise<void
 
   let agent: AcpGatewayAgent | null = null;
   let onClosed!: () => void;
-  const closed = new Promise<void>((resolve) => {
+  let onCloseFailed!: (error: unknown) => void;
+  const closed = new Promise<void>((resolve, reject) => {
     onClosed = resolve;
+    onCloseFailed = reject;
   });
+  // Startup can still be awaiting Gateway readiness when shutdown fails.
+  void closed.catch(() => {});
   const startupAbortController = new AbortController();
   let stopped = false;
   let gatewayConnected = false;
@@ -134,11 +138,12 @@ export async function serveAcpGateway(opts: AcpServerOptions = {}): Promise<void
     gatewayReadySettled = true;
     onGatewayReadyReject(err instanceof Error ? err : new Error(String(err)));
   };
-  const closeStateDatabase = () => {
+  const closeStateDatabase = async () => {
     try {
-      closeOpenClawStateDatabase();
+      await closeOpenClawStateDatabaseAsync();
     } catch (err) {
       console.warn(`acp: state database close failed during shutdown: ${formatErrorMessage(err)}`);
+      throw err;
     }
   };
 
@@ -190,33 +195,47 @@ export async function serveAcpGateway(opts: AcpServerOptions = {}): Promise<void
   const rawInput = Readable.toWeb(process.stdin) as unknown as ReadableStream<Uint8Array>;
   const startupInput = createStartupInputMonitor(rawInput);
 
-  const shutdown = async () => {
-    if (stopped) {
-      return;
+  let shuttingDown: Promise<void> | undefined;
+  let stoppingAgent: AcpGatewayAgent | null = null;
+  const shutdown = () => {
+    if (shuttingDown) {
+      return shuttingDown;
     }
-    stopped = true;
-    startupAbortController.abort();
-    startupInput.dispose();
-    process.stdin.pause();
-    resolveGatewayReady();
-    // Revoke ledger access before transport teardown. ACP requests and Gateway
-    // events can both resume asynchronously, and must not reopen the shared DB.
-    const activeAgent = agent;
-    agent = null;
-    await activeAgent?.shutdown();
-    const gatewayStop = gateway.stopAndWait().catch((err: unknown) => {
-      console.warn(`acp: gateway stop failed during shutdown: ${formatErrorMessage(err)}`);
+    shuttingDown = (async () => {
+      if (!stopped) {
+        stopped = true;
+        startupAbortController.abort();
+        startupInput.dispose();
+        process.stdin.pause();
+        resolveGatewayReady();
+        // Revoke ledger access before transport teardown. Retain its cleanup
+        // owner until shutdown succeeds, including across a failed drain.
+        stoppingAgent = agent;
+        agent = null;
+      }
+      await stoppingAgent?.shutdown();
+      stoppingAgent = null;
+      const gatewayStop = gateway.stopAndWait().catch((err: unknown) => {
+        console.warn(`acp: gateway stop failed during shutdown: ${formatErrorMessage(err)}`);
+      });
+      await gatewayStop;
+      await closeStateDatabase();
+      onClosed();
+    })();
+    void shuttingDown.catch((error: unknown) => {
+      shuttingDown = undefined;
+      onCloseFailed(error);
     });
-    await gatewayStop;
-    closeStateDatabase();
-    onClosed();
+    return shuttingDown;
   };
 
-  void startupInput.ended.then(() => {
-    if (!gatewayConnected) {
-      void shutdown();
-    }
-  }, shutdown);
+  void startupInput.ended
+    .then(() => {
+      if (!gatewayConnected) {
+        void shutdown();
+      }
+    }, shutdown)
+    .catch(onCloseFailed);
 
   process.once("SIGINT", () => {
     void shutdown();
@@ -264,7 +283,7 @@ export async function serveAcpGateway(opts: AcpServerOptions = {}): Promise<void
   );
   // The SDK closes the connection when stdin reaches EOF. Reuse the normal
   // shutdown path so the Gateway and shared database cannot keep the bridge alive.
-  void connection.closed.then(shutdown, shutdown);
+  void connection.closed.then(shutdown, shutdown).catch(onCloseFailed);
 
   return closed;
 }

--- a/src/commands/cleanup-utils.ts
+++ b/src/commands/cleanup-utils.ts
@@ -444,7 +444,9 @@ export async function removeStateAndLinkedPaths(
 
   const lock = await acquireStateCleanupOwnership(cleanup);
   let lockHeld = true;
-  let stateCoordinator: ReturnType<typeof acquireOpenClawStateDatabaseFileExclusion> | undefined;
+  let stateCoordinator:
+    | Awaited<ReturnType<typeof acquireOpenClawStateDatabaseFileExclusion>>
+    | undefined;
   const releaseLock = async () => {
     if (!lockHeld) {
       return;
@@ -470,7 +472,7 @@ export async function removeStateAndLinkedPaths(
       ...process.env,
       OPENCLAW_STATE_DIR: stateDir,
     });
-    stateCoordinator = acquireOpenClawStateDatabaseFileExclusion(databasePath);
+    stateCoordinator = await acquireOpenClawStateDatabaseFileExclusion(databasePath);
     const preservePaths = requestedPreservePaths
       .map((target) =>
         isPathWithin(target, requestedStateDir)

--- a/src/commands/doctor-lint.ts
+++ b/src/commands/doctor-lint.ts
@@ -33,7 +33,7 @@ import {
   withPluginInstallRoots,
 } from "../plugins/install-root-context.js";
 import type { RuntimeEnv } from "../runtime.js";
-import { closeOpenClawStateDatabaseByPath } from "../state/openclaw-state-db-cache.js";
+import { closeOpenClawStateDatabaseByPathAsync } from "../state/openclaw-state-db-cache.js";
 import { withArtifactPreservingStateReads } from "../state/openclaw-state-db-readonly.js";
 import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
 import { isPostCoreConvergencePass, isUpdateDoctorLintPass } from "./doctor/shared/update-phase.js";
@@ -333,52 +333,54 @@ async function withReadOnlyPluginStateSnapshot<T>(
     ...sourceEnv,
     OPENCLAW_STATE_DIR: privateStateDir,
   });
-  let outcome: { ok: true; value: T } | { ok: false; error: unknown };
-  let runStarted = false;
-  try {
-    fs.mkdirSync(path.dirname(privateDatabasePath), { recursive: true, mode: 0o700 });
-    if (prepared) {
-      for (const suffix of ["", "-journal", "-shm", "-wal"]) {
-        const sourcePath = `${prepared.location}${suffix}`;
-        if (fs.existsSync(sourcePath)) {
-          fs.renameSync(sourcePath, `${privateDatabasePath}${suffix}`);
+  const privateEnv = {
+    ...sourceEnv,
+    OPENCLAW_CONFIG_PATH: resolveConfigPath(sourceEnv, resolveStateDir(sourceEnv)),
+    OPENCLAW_STATE_DIR: privateStateDir,
+  };
+  return await withDoctorLintStateEnv(privateEnv, async () => {
+    let outcome: { ok: true; value: T } | { ok: false; error: unknown };
+    let runStarted = false;
+    try {
+      fs.mkdirSync(path.dirname(privateDatabasePath), { recursive: true, mode: 0o700 });
+      if (prepared) {
+        for (const suffix of ["", "-journal", "-shm", "-wal"]) {
+          const sourcePath = `${prepared.location}${suffix}`;
+          if (fs.existsSync(sourcePath)) {
+            fs.renameSync(sourcePath, `${privateDatabasePath}${suffix}`);
+          }
         }
       }
+      const installRoots = resolvePluginInstallRoots(sourceEnv);
+      // Global readers and OAuth refresh/challenge writers share the private state view.
+      outcome = {
+        ok: true,
+        value: await withPluginInstallRoots(
+          { ...installRoots, stateDir: privateStateDir },
+          async () => {
+            runStarted = true;
+            return await run(privateEnv);
+          },
+        ),
+      };
+    } catch (error) {
+      outcome = { ok: false, error };
     }
-    const sourceConfigPath = resolveConfigPath(sourceEnv, resolveStateDir(sourceEnv));
-    const privateEnv = {
-      ...sourceEnv,
-      OPENCLAW_CONFIG_PATH: sourceConfigPath,
-      OPENCLAW_STATE_DIR: privateStateDir,
-    };
-    const installRoots = resolvePluginInstallRoots(sourceEnv);
-    // Global readers and OAuth refresh/challenge writers share the private state view.
-    outcome = {
-      ok: true,
-      value: await withDoctorLintStateEnv(privateEnv, () =>
-        withPluginInstallRoots({ ...installRoots, stateDir: privateStateDir }, async () => {
-          runStarted = true;
-          return await run(privateEnv);
-        }),
-      ),
-    };
-  } catch (error) {
-    outcome = { ok: false, error };
-  }
-  try {
-    // Inspectors can cache private writers. Retire only this snapshot's handle
-    // before deleting its files; a failed retirement must retain those files.
-    closeOpenClawStateDatabaseByPath(privateDatabasePath);
-    if (!cleanup()) {
-      throw new Error("Temporary doctor lint state snapshot cleanup did not complete.");
+    try {
+      // Inspectors can cache private writers. Retire only this snapshot's handle
+      // before restoring the ambient state or deleting files; failed retirement retains files.
+      await closeOpenClawStateDatabaseByPathAsync(privateDatabasePath);
+      if (!cleanup()) {
+        throw new Error("Temporary doctor lint state snapshot cleanup did not complete.");
+      }
+    } catch (error) {
+      throw new DoctorLintStateSnapshotError(error);
     }
-  } catch (error) {
-    throw new DoctorLintStateSnapshotError(error);
-  }
-  if (!outcome.ok) {
-    throw runStarted ? outcome.error : new DoctorLintStateSnapshotError(outcome.error);
-  }
-  return outcome.value;
+    if (!outcome.ok) {
+      throw runStarted ? outcome.error : new DoctorLintStateSnapshotError(outcome.error);
+    }
+    return outcome.value;
+  });
 }
 
 async function withDoctorLintStateEnv<T>(

--- a/src/commands/doctor-maintenance.ts
+++ b/src/commands/doctor-maintenance.ts
@@ -76,29 +76,26 @@ export async function beginDoctorMaintenance(params: {
   const coordinators: Array<{ release(): void }> = [];
   let repairStoresMayBeOpen = false;
   const release = async () => {
+    if (repairStoresMayBeOpen) {
+      const [{ closeOpenClawAgentDatabasesAsync }, { closeOpenClawStateDatabaseByPathAsync }] =
+        await Promise.all([
+          import("../state/openclaw-agent-db.js"),
+          import("../state/openclaw-state-db.js"),
+        ]);
+      // Agent handles release leases through shared state. Keep maintenance
+      // ownership and retry state until both drains succeed.
+      await closeOpenClawAgentDatabasesAsync();
+      await closeOpenClawStateDatabaseByPathAsync(resolveOpenClawStateSqlitePath(env));
+      repairStoresMayBeOpen = false;
+    }
+    for (const coordinator of coordinators.splice(0).toReversed()) {
+      coordinator.release();
+    }
+    const recovery = stopped?.windowsTaskAutoStartRecovery;
     try {
-      if (repairStoresMayBeOpen) {
-        repairStoresMayBeOpen = false;
-        const [{ closeOpenClawAgentDatabasesAsync }, { closeOpenClawStateDatabaseByPath }] =
-          await Promise.all([
-            import("../state/openclaw-agent-db.js"),
-            import("../state/openclaw-state-db.js"),
-          ]);
-        // Agent handles release leases through shared state. Close them before
-        // handing off the coordinators, or the restarted Gateway sees Doctor as a writer.
-        await closeOpenClawAgentDatabasesAsync();
-        closeOpenClawStateDatabaseByPath(resolveOpenClawStateSqlitePath(env));
-      }
+      await serviceMaintenance?.maybeResumeWindowsTaskAutoStartAfterPackageUpdate(stopped);
     } finally {
-      for (const coordinator of coordinators.splice(0).toReversed()) {
-        coordinator.release();
-      }
-      const recovery = stopped?.windowsTaskAutoStartRecovery;
-      try {
-        await serviceMaintenance?.maybeResumeWindowsTaskAutoStartAfterPackageUpdate(stopped);
-      } finally {
-        await recovery?.complete();
-      }
+      await recovery?.complete();
     }
   };
   try {

--- a/src/gateway/server-close.test.ts
+++ b/src/gateway/server-close.test.ts
@@ -66,7 +66,7 @@ const mocks = vi.hoisted(() => ({
   disposeAcpSessionManagerInstance: vi.fn(async () => undefined),
   getAcpSessionManager: vi.fn(() => ({})),
   fenceSessionSuspensionWritesForGatewayShutdown: vi.fn(),
-  closePluginStateDatabase: vi.fn<() => Promise<void>>(async () => undefined),
+  closePluginStateDatabaseAsync: vi.fn<() => Promise<void>>(async () => undefined),
 }));
 const WEBSOCKET_CLOSE_GRACE_MS = 1_000;
 const WEBSOCKET_CLOSE_FORCE_CONTINUE_MS = 250;
@@ -144,7 +144,7 @@ vi.mock("../plugin-state/plugin-state-store.js", async () => ({
   ...(await vi.importActual<typeof import("../plugin-state/plugin-state-store.js")>(
     "../plugin-state/plugin-state-store.js",
   )),
-  closePluginStateDatabase: mocks.closePluginStateDatabase,
+  closePluginStateDatabaseAsync: mocks.closePluginStateDatabaseAsync,
 }));
 
 vi.mock("../logging/subsystem.js", () => ({
@@ -306,7 +306,7 @@ describe("createGatewayCloseHandler", () => {
       expect(() => retainGatewayPluginMetadata()).toThrow(/retir|shut/i);
       modelReleased.resolve();
       await cleanupEntered.promise;
-      expect(mocks.closePluginStateDatabase).not.toHaveBeenCalled();
+      expect(mocks.closePluginStateDatabaseAsync).not.toHaveBeenCalled();
       expect(clearSecretsRuntimeSnapshot).not.toHaveBeenCalled();
       expect(() => retainGatewayPluginMetadata()).toThrow(/retir|shut/i);
       cleanupReleased.resolve();
@@ -361,7 +361,7 @@ describe("createGatewayCloseHandler", () => {
     expect(cleanup).toHaveBeenCalledOnce();
     expect(instance.lifecycle.signal.aborted).toBe(true);
     expect(getActivePluginRegistry()).toBeNull();
-    expect(mocks.closePluginStateDatabase).toHaveBeenCalledOnce();
+    expect(mocks.closePluginStateDatabaseAsync).toHaveBeenCalledOnce();
     expect(clearSecretsRuntimeSnapshot).toHaveBeenCalledOnce();
     const repeated = owner.close();
     expect(owner.close()).toBe(repeated);
@@ -520,7 +520,7 @@ describe("createGatewayCloseHandler", () => {
     await expect(instance.dispose()).resolves.toEqual({ errors: [failure] });
     expect(instance.lifecycle.signal.aborted).toBe(true);
     expect(getActivePluginRegistry()).toBeNull();
-    expect(mocks.closePluginStateDatabase).toHaveBeenCalledOnce();
+    expect(mocks.closePluginStateDatabaseAsync).toHaveBeenCalledOnce();
     expect(clearSecretsRuntimeSnapshot).toHaveBeenCalledOnce();
   });
 
@@ -550,8 +550,8 @@ describe("createGatewayCloseHandler", () => {
     mocks.disposeAcpSessionManagerInstance.mockResolvedValue(undefined);
     mocks.getAcpSessionManager.mockClear();
     mocks.fenceSessionSuspensionWritesForGatewayShutdown.mockReset();
-    mocks.closePluginStateDatabase.mockReset();
-    mocks.closePluginStateDatabase.mockResolvedValue(undefined);
+    mocks.closePluginStateDatabaseAsync.mockReset();
+    mocks.closePluginStateDatabaseAsync.mockResolvedValue(undefined);
   });
 
   afterEach(() => {
@@ -623,7 +623,7 @@ describe("createGatewayCloseHandler", () => {
     async (owner) => {
       const { createOpenClawTestState } = await import("../test-utils/openclaw-test-state.js");
       const { openOpenClawStateDatabase } = await import("../state/openclaw-state-db.js");
-      const { closePluginStateDatabase } = await vi.importActual<
+      const { closePluginStateDatabaseAsync } = await vi.importActual<
         typeof import("../plugin-state/plugin-state-store.js")
       >("../plugin-state/plugin-state-store.js");
       const hooks = await vi.importActual<typeof import("../hooks/internal-hooks.js")>(
@@ -695,7 +695,9 @@ describe("createGatewayCloseHandler", () => {
         hooks.registerInternalHook(eventKey, cleanup);
         mocks.triggerInternalHook.mockImplementation(hooks.triggerInternalHook);
       }
-      mocks.closePluginStateDatabase.mockImplementation(async () => closePluginStateDatabase());
+      mocks.closePluginStateDatabaseAsync.mockImplementation(async () =>
+        closePluginStateDatabaseAsync(),
+      );
       const httpClose = vi.fn((callback: (error?: Error | null) => void) => callback(null));
       const close = createGatewayCloseHandler(
         createGatewayCloseTestDeps({
@@ -727,7 +729,7 @@ describe("createGatewayCloseHandler", () => {
         expect(preparedDatabase.isOpen).toBe(true);
         expect(sdkDisposalReads).toEqual([]);
         expect(closed).toBe(false);
-        expect(mocks.closePluginStateDatabase).not.toHaveBeenCalled();
+        expect(mocks.closePluginStateDatabaseAsync).not.toHaveBeenCalled();
       } finally {
         release.resolve();
         await finished.promise;
@@ -747,7 +749,7 @@ describe("createGatewayCloseHandler", () => {
           }
           hooks.unregisterInternalHook(eventKey, cleanup);
           vi.useRealTimers();
-          closePluginStateDatabase();
+          await closePluginStateDatabaseAsync();
           await state.cleanup();
         }
       }
@@ -755,7 +757,7 @@ describe("createGatewayCloseHandler", () => {
       expect(failures).toEqual([]);
       expect(reads).toEqual([{ value: 1 }]);
       expect(database.db.isOpen).toBe(false);
-      expect(mocks.closePluginStateDatabase).toHaveBeenCalledOnce();
+      expect(mocks.closePluginStateDatabaseAsync).toHaveBeenCalledOnce();
     },
   );
 
@@ -764,7 +766,7 @@ describe("createGatewayCloseHandler", () => {
     async (globalFailure) => {
       const { createOpenClawTestState } = await import("../test-utils/openclaw-test-state.js");
       const { openOpenClawStateDatabase } = await import("../state/openclaw-state-db.js");
-      const { closePluginStateDatabase } = await vi.importActual<
+      const { closePluginStateDatabaseAsync } = await vi.importActual<
         typeof import("../plugin-state/plugin-state-store.js")
       >("../plugin-state/plugin-state-store.js");
       const state = await createOpenClawTestState({ label: "sdk-disposal-failure-tail" });
@@ -795,7 +797,9 @@ describe("createGatewayCloseHandler", () => {
       });
       resolveGlobalSingleton(Symbol("sdk-failure-tail"), () => ({}), reset);
       const clearSecretsRuntimeSnapshot = vi.fn();
-      mocks.closePluginStateDatabase.mockImplementation(async () => closePluginStateDatabase());
+      mocks.closePluginStateDatabaseAsync.mockImplementation(async () =>
+        closePluginStateDatabaseAsync(),
+      );
       let sdkFailure: unknown;
       const close = createGatewayCloseHandler(
         createGatewayCloseTestDeps({
@@ -847,7 +851,7 @@ describe("createGatewayCloseHandler", () => {
         if (sdkDatabase.isOpen) {
           sdkDatabase.close();
         }
-        closePluginStateDatabase();
+        await closePluginStateDatabaseAsync();
         await state.cleanup();
       }
     },
@@ -907,14 +911,14 @@ describe("createGatewayCloseHandler", () => {
         if (failureKind === "admission") {
           await expect(closing).rejects.toThrow(/retir/);
           expect(stop).not.toHaveBeenCalled();
-          expect(mocks.closePluginStateDatabase).not.toHaveBeenCalled();
+          expect(mocks.closePluginStateDatabaseAsync).not.toHaveBeenCalled();
           expect(getActivePluginRegistry()).toBe(registry);
           expect(clearSecretsRuntimeSnapshot).not.toHaveBeenCalled();
         } else {
           const result = await closing;
           expect(result.warnings).toContain("plugin-services");
           expect(stop).toHaveBeenCalledOnce();
-          expect(mocks.closePluginStateDatabase).toHaveBeenCalledOnce();
+          expect(mocks.closePluginStateDatabaseAsync).toHaveBeenCalledOnce();
           expect(getActivePluginRegistry()).toBeNull();
           expect(clearSecretsRuntimeSnapshot).toHaveBeenCalledOnce();
           expect(await pluginServices.stop()).toEqual({ errors: [failure] });
@@ -957,12 +961,12 @@ describe("createGatewayCloseHandler", () => {
       closed = true;
     });
     await vi.waitFor(() => expect(stopMediaCleanup).toHaveBeenCalledTimes(1));
-    expect(mocks.closePluginStateDatabase).not.toHaveBeenCalled();
+    expect(mocks.closePluginStateDatabaseAsync).not.toHaveBeenCalled();
     expect(closed).toBe(false);
 
     releaseMediaCleanup();
     await closing;
-    expect(mocks.closePluginStateDatabase).toHaveBeenCalledTimes(1);
+    expect(mocks.closePluginStateDatabaseAsync).toHaveBeenCalledTimes(1);
     expect(closed).toBe(true);
   });
 
@@ -975,14 +979,14 @@ describe("createGatewayCloseHandler", () => {
     try {
       await vi.waitFor(() => expect(updateCheckStop).toHaveBeenCalledOnce());
       expect(mocks.disposeAllCodeModeRuns).not.toHaveBeenCalled();
-      expect(mocks.closePluginStateDatabase).not.toHaveBeenCalled();
+      expect(mocks.closePluginStateDatabaseAsync).not.toHaveBeenCalled();
     } finally {
       updateCheckStopped.resolve();
       await closing;
     }
 
     expect(mocks.disposeAllCodeModeRuns).toHaveBeenCalledOnce();
-    expect(mocks.closePluginStateDatabase).toHaveBeenCalledOnce();
+    expect(mocks.closePluginStateDatabaseAsync).toHaveBeenCalledOnce();
   });
 
   it("retains shared state when media cleanup times out", async () => {
@@ -994,13 +998,13 @@ describe("createGatewayCloseHandler", () => {
     const closing = close({ reason: "test" });
     try {
       await vi.waitFor(() => expect(stopMediaCleanup).toHaveBeenCalledTimes(1));
-      expect(mocks.closePluginStateDatabase).not.toHaveBeenCalled();
+      expect(mocks.closePluginStateDatabaseAsync).not.toHaveBeenCalled();
     } finally {
       cleanup.resolve();
       await closing;
     }
     const result = await closing;
-    expect(mocks.closePluginStateDatabase).toHaveBeenCalledOnce();
+    expect(mocks.closePluginStateDatabaseAsync).toHaveBeenCalledOnce();
     expect(result.warnings).toContain("media-cleanup");
   });
 
@@ -1526,7 +1530,7 @@ describe("createGatewayCloseHandler", () => {
     try {
       await vi.advanceTimersByTimeAsync(GATEWAY_SHUTDOWN_HOOK_TIMEOUT_MS);
       expect(stopTaskRegistryMaintenance).toHaveBeenCalledTimes(1);
-      expect(mocks.closePluginStateDatabase).not.toHaveBeenCalled();
+      expect(mocks.closePluginStateDatabaseAsync).not.toHaveBeenCalled();
     } finally {
       cleanup.resolve();
       await closePromise;
@@ -1592,14 +1596,14 @@ describe("createGatewayCloseHandler", () => {
       await vi.advanceTimersByTimeAsync(0);
       expect(stopChannel).toHaveBeenCalledWith("discord");
       expect(deps.heartbeatRunner.stop).toHaveBeenCalledOnce();
-      expect(mocks.closePluginStateDatabase).not.toHaveBeenCalled();
+      expect(mocks.closePluginStateDatabaseAsync).not.toHaveBeenCalled();
       expect(closed).toBe(false);
 
       pluginCleanup.resolve();
       const result = await closePromise;
       expect(result.warnings).toContain("plugin-services");
       expect(pluginServices.stop).toHaveBeenCalledOnce();
-      expect(mocks.closePluginStateDatabase).toHaveBeenCalledOnce();
+      expect(mocks.closePluginStateDatabaseAsync).toHaveBeenCalledOnce();
       expect(
         mocks.logWarn.mock.calls.some(([message]) =>
           String(message).includes("plugin-services runtime disposal exceeded 5000ms"),
@@ -1671,7 +1675,7 @@ describe("createGatewayCloseHandler", () => {
           await vi.advanceTimersByTimeAsync(5_000);
           expect(deps.stopChannel).toHaveBeenCalledWith("discord");
           expect(mocks.disposeAllSessionMcpRuntimes).toHaveBeenCalledOnce();
-          expect(mocks.closePluginStateDatabase).not.toHaveBeenCalled();
+          expect(mocks.closePluginStateDatabaseAsync).not.toHaveBeenCalled();
           expect(clearSecretsRuntimeSnapshot).not.toHaveBeenCalled();
           expect(getActivePluginRegistry()).toBe(registry);
           expect(closed).toBe(false);
@@ -1684,7 +1688,7 @@ describe("createGatewayCloseHandler", () => {
         const result = await closing;
         expect(stop).toHaveBeenCalledOnce();
         expect(deps.stopChannel).toHaveBeenCalledWith("discord");
-        expect(mocks.closePluginStateDatabase).toHaveBeenCalledOnce();
+        expect(mocks.closePluginStateDatabaseAsync).toHaveBeenCalledOnce();
         expect(clearSecretsRuntimeSnapshot).toHaveBeenCalledOnce();
         expect(getActivePluginRegistry()).not.toBe(registry);
         if (cleanupOutcome === "stalls") {
@@ -2670,7 +2674,7 @@ describe("createGatewayCloseHandler", () => {
     try {
       await vi.advanceTimersByTimeAsync(GATEWAY_PRE_RESTART_HOOK_TIMEOUT_MS);
       expect(mocks.stopGmailWatcher).toHaveBeenCalledOnce();
-      expect(mocks.closePluginStateDatabase).not.toHaveBeenCalled();
+      expect(mocks.closePluginStateDatabaseAsync).not.toHaveBeenCalled();
     } finally {
       cleanup.resolve();
       await closePromise;
@@ -2820,7 +2824,7 @@ describe("createGatewayCloseHandler", () => {
 
       await vi.advanceTimersByTimeAsync(AGENT_HARNESS_CLOSE_GRACE_MS);
       expect(httpClose).toHaveBeenCalledOnce();
-      expect(mocks.closePluginStateDatabase).not.toHaveBeenCalled();
+      expect(mocks.closePluginStateDatabaseAsync).not.toHaveBeenCalled();
       expect(
         mocks.logWarn.mock.calls.some(([message]) =>
           String(message).includes("agent-harnesses runtime disposal exceeded 5000ms"),
@@ -2881,7 +2885,7 @@ describe("createGatewayCloseHandler", () => {
       try {
         await vi.advanceTimersByTimeAsync(5_000);
         expect(httpClose).toHaveBeenCalledOnce();
-        expect(mocks.closePluginStateDatabase).not.toHaveBeenCalled();
+        expect(mocks.closePluginStateDatabaseAsync).not.toHaveBeenCalled();
       } finally {
         cleanup.resolve();
         await closePromise;

--- a/src/gateway/server-close.ts
+++ b/src/gateway/server-close.ts
@@ -13,7 +13,7 @@ import { createInternalHookEvent, triggerInternalHook } from "../hooks/internal-
 import { formatErrorMessage } from "../infra/errors.js";
 import type { HeartbeatRunner } from "../infra/heartbeat-runner.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
-import { closePluginStateDatabase } from "../plugin-state/plugin-state-store.js";
+import { closePluginStateDatabaseAsync } from "../plugin-state/plugin-state-store.js";
 import type { GatewayPluginMetadataOwner } from "../plugins/plugin-metadata-lifecycle.js";
 import { hasRetainedPluginRuntimeCloseError } from "../plugins/runtime-close-error.js";
 import type { createPluginRegistryOwner } from "../plugins/runtime.js";
@@ -685,7 +685,7 @@ export async function completeGatewayClose(
           await closePreparedModelRuntimeSnapshots();
           await retire();
           if (mediaCleanupStopResult !== undefined) {
-            await shutdownStep("plugin-state-store", () => closePluginStateDatabase(), warnings);
+            await closePluginStateDatabaseAsync();
           }
           try {
             await drainGlobalSingletonLifecycleState(

--- a/src/infra/runtime-process-entrypoints.ts
+++ b/src/infra/runtime-process-entrypoints.ts
@@ -4,6 +4,11 @@ const currentModuleUrl = import.meta.url;
 export const SQLITE_READONLY_CHILD_ARG = "--openclaw-sqlite-readonly-child";
 
 export const runtimeProcessEntrypoints = {
+  sharedStateStore: {
+    currentModuleUrl,
+    sourceWorkerName: "../state/openclaw-state.worker",
+    distWorkerPath: "state/openclaw-state.worker.js",
+  },
   sqliteStore: {
     currentModuleUrl,
     sourceWorkerName: "sqlite-store.worker",

--- a/src/infra/sqlite-worker-identity.test.ts
+++ b/src/infra/sqlite-worker-identity.test.ts
@@ -1,0 +1,22 @@
+import { writeFileSync } from "node:fs";
+import path from "node:path";
+import { afterEach, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import {
+  readDatabasePathIdentity,
+  readDatabasePathIdentitySync,
+} from "./sqlite-worker-identity.js";
+
+const dirs = useAutoCleanupTempDirTracker(afterEach);
+
+it("shares prospective and existing file identities between sync capture and async admission", async () => {
+  const pathname = path.join(dirs.make("openclaw-worker-identity-"), "state.sqlite");
+  const prospective = readDatabasePathIdentitySync(pathname);
+  expect(prospective.key).toBe(`path:${prospective.canonicalPath}`);
+  expect(await readDatabasePathIdentity(pathname)).toEqual(prospective);
+  writeFileSync(pathname, "");
+  const existing = readDatabasePathIdentitySync(pathname);
+  expect(existing.key).toMatch(/^file:/);
+  expect(existing.canonicalPath).toBe(prospective.canonicalPath);
+  expect(await readDatabasePathIdentity(pathname)).toEqual(existing);
+});

--- a/src/infra/sqlite-worker-identity.ts
+++ b/src/infra/sqlite-worker-identity.ts
@@ -22,8 +22,10 @@ function existingIdentity(
   return { key: `file:${file.dev}:${file.ino}`, canonicalPath };
 }
 
-/** Capture identity before yielding; lifecycle owners reuse this fact until retirement. */
-export function readDatabasePathIdentitySync(databasePath: string): DatabasePathIdentity {
+/** Inspect a native-owner path without replacing its diagnostic for a non-file target. */
+export function inspectDatabasePathIdentitySync(
+  databasePath: string,
+): DatabasePathIdentity | undefined {
   const resolvedPath = path.resolve(databasePath);
   let file: BigIntStats | undefined;
   try {
@@ -34,6 +36,9 @@ export function readDatabasePathIdentitySync(databasePath: string): DatabasePath
     }
   }
   if (file) {
+    if (!file.isFile()) {
+      return undefined;
+    }
     const canonicalPath = realpathSync(resolvedPath);
     return existingIdentity(file, statSync(canonicalPath, { bigint: true }), canonicalPath);
   }
@@ -55,6 +60,15 @@ export function readDatabasePathIdentitySync(databasePath: string): DatabasePath
       ancestor = parent;
     }
   }
+}
+
+/** Capture identity before yielding; worker admission requires a regular file or absent path. */
+export function readDatabasePathIdentitySync(databasePath: string): DatabasePathIdentity {
+  const identity = inspectDatabasePathIdentitySync(databasePath);
+  if (!identity) {
+    throw new Error("SQLite worker database path must identify a regular file");
+  }
+  return identity;
 }
 
 export async function readDatabasePathIdentity(

--- a/src/infra/sqlite-worker-identity.ts
+++ b/src/infra/sqlite-worker-identity.ts
@@ -1,12 +1,65 @@
-import { statSync } from "node:fs";
+import { realpathSync, statSync, type BigIntStats } from "node:fs";
 import { realpath, stat } from "node:fs/promises";
 import path from "node:path";
 import { hasErrnoCode } from "./errno.js";
 
-export async function readDatabasePathIdentity(databasePath: string): Promise<{
+export type DatabasePathIdentity = Readonly<{
   key: string;
   canonicalPath: string;
-}> {
+}>;
+
+function existingIdentity(
+  file: BigIntStats,
+  canonicalFile: BigIntStats,
+  canonicalPath: string,
+): DatabasePathIdentity {
+  if (!file.isFile()) {
+    throw new Error("SQLite worker database path must identify a regular file");
+  }
+  if (file.dev !== canonicalFile.dev || file.ino !== canonicalFile.ino) {
+    throw new Error("SQLite database pathname changed during admission");
+  }
+  return { key: `file:${file.dev}:${file.ino}`, canonicalPath };
+}
+
+/** Capture identity before yielding; lifecycle owners reuse this fact until retirement. */
+export function readDatabasePathIdentitySync(databasePath: string): DatabasePathIdentity {
+  const resolvedPath = path.resolve(databasePath);
+  let file: BigIntStats | undefined;
+  try {
+    file = statSync(resolvedPath, { bigint: true });
+  } catch (error) {
+    if (!hasErrnoCode(error, "ENOENT")) {
+      throw error;
+    }
+  }
+  if (file) {
+    const canonicalPath = realpathSync(resolvedPath);
+    return existingIdentity(file, statSync(canonicalPath, { bigint: true }), canonicalPath);
+  }
+  const missing: string[] = [];
+  let ancestor = resolvedPath;
+  while (true) {
+    try {
+      const canonicalPath = path.join(realpathSync(ancestor), ...missing);
+      return { key: `path:${canonicalPath}`, canonicalPath };
+    } catch (error) {
+      if (!hasErrnoCode(error, "ENOENT")) {
+        throw error;
+      }
+      missing.unshift(path.basename(ancestor));
+      const parent = path.dirname(ancestor);
+      if (parent === ancestor) {
+        throw error;
+      }
+      ancestor = parent;
+    }
+  }
+}
+
+export async function readDatabasePathIdentity(
+  databasePath: string,
+): Promise<DatabasePathIdentity> {
   const file = await stat(databasePath, { bigint: true }).catch((error: unknown) => {
     if (hasErrnoCode(error, "ENOENT")) {
       return undefined;
@@ -14,15 +67,9 @@ export async function readDatabasePathIdentity(databasePath: string): Promise<{
     throw error;
   });
   if (file) {
-    if (!file.isFile()) {
-      throw new Error("SQLite worker database path must identify a regular file");
-    }
     const canonicalPath = await realpath(databasePath);
     const canonicalFile = await stat(canonicalPath, { bigint: true });
-    if (file.dev !== canonicalFile.dev || file.ino !== canonicalFile.ino) {
-      throw new Error("SQLite database pathname changed during admission");
-    }
-    return { key: `file:${file.dev}:${file.ino}`, canonicalPath };
+    return existingIdentity(file, canonicalFile, canonicalPath);
   }
   // Resolve the existing ancestor before a first open so directory aliases share admission.
   const missing: string[] = [];

--- a/src/infra/sqlite-worker-task-runtime.test.ts
+++ b/src/infra/sqlite-worker-task-runtime.test.ts
@@ -1,0 +1,305 @@
+import { existsSync } from "node:fs";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { requireNodeSqlite } from "../infra/node-sqlite.js";
+import { createPluginRuntime } from "../plugins/runtime/index.js";
+import { resetRuntimeTaskTestState } from "../plugins/runtime/runtime-task-test-harness.js";
+import { drainGlobalSingletonLifecycleState } from "../shared/global-singleton.js";
+import {
+  acquireOpenClawStateDatabaseFileExclusion,
+  closeOpenClawStateDatabaseAsync,
+} from "../state/openclaw-state-db-cache.js";
+import {
+  closeOpenClawStateDatabase,
+  openOpenClawStateDatabase,
+} from "../state/openclaw-state-db.js";
+import { upsertTaskFlowRegistryRecordToSqlite } from "../tasks/task-flow-registry.store.sqlite.js";
+import type { TaskFlowRecord } from "../tasks/task-flow-registry.types.js";
+import { getTaskById } from "../tasks/task-registry.js";
+import { upsertTaskWithDeliveryStateToSqlite } from "../tasks/task-registry.store.sqlite.js";
+import type { TaskRecord } from "../tasks/task-registry.types.js";
+import {
+  createOpenClawTestState,
+  type OpenClawTestState,
+} from "../test-utils/openclaw-test-state.js";
+
+const ownerKey = "agent:main:async-reader";
+let state: OpenClawTestState;
+
+function task(taskId: string, overrides: Partial<TaskRecord> = {}): TaskRecord {
+  return {
+    taskId,
+    runtime: "acp",
+    requesterSessionKey: ownerKey,
+    ownerKey,
+    scopeKind: "session",
+    task: "Synthetic task",
+    status: "running",
+    deliveryStatus: "not_applicable",
+    notifyPolicy: "silent",
+    createdAt: 100,
+    parentFlowId: "flow-a",
+    runId: "run-a",
+    requesterAgentId: "main",
+    ...overrides,
+  };
+}
+
+function flow(flowId: string, overrides: Partial<TaskFlowRecord> = {}): TaskFlowRecord {
+  return {
+    flowId,
+    syncMode: "managed",
+    controllerId: "tests/async-reads",
+    ownerKey,
+    revision: 1,
+    status: "running",
+    notifyPolicy: "silent",
+    goal: "Synthetic flow",
+    createdAt: 100,
+    updatedAt: 100,
+    ...overrides,
+  };
+}
+
+beforeEach(async () => {
+  state = await createOpenClawTestState({ prefix: "openclaw-task-async-", applyEnv: true });
+});
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  await closeOpenClawStateDatabaseAsync();
+  await resetRuntimeTaskTestState();
+  await state.cleanup();
+});
+
+describe("registered tasks.async runtime", () => {
+  it("refuses a sealed read before cold native admission", async () => {
+    const database = openOpenClawStateDatabase();
+    const runs = createPluginRuntime().tasks.async.runs.bindSession({ sessionKey: ownerKey });
+    const exclusion = await acquireOpenClawStateDatabaseFileExclusion(database.path);
+    const prepare = vi.spyOn(requireNodeSqlite().DatabaseSync.prototype, "prepare");
+    try {
+      await expect(runs.list()).rejects.toThrow(/admission is closed/);
+      expect(prepare).not.toHaveBeenCalled();
+    } finally {
+      prepare.mockRestore();
+      exclusion.release();
+    }
+  });
+
+  it("keeps the selected state across the asynchronous module boundary", async () => {
+    const other = await createOpenClawTestState({
+      prefix: "openclaw-task-other-",
+      applyEnv: false,
+    });
+    try {
+      upsertTaskWithDeliveryStateToSqlite({ task: task("selected", { task: "Selected state" }) });
+      const runs = createPluginRuntime().tasks.async.runs.bindSession({ sessionKey: ownerKey });
+      const pending = runs.get("selected");
+      vi.stubEnv("OPENCLAW_STATE_DIR", other.stateDir);
+      expect((await pending)?.title).toBe("Selected state");
+      expect(existsSync(other.statePath("state", "openclaw.sqlite"))).toBe(false);
+    } finally {
+      vi.unstubAllEnvs();
+      await other.cleanup();
+    }
+  });
+
+  it("opens a fresh worker after the global restart lifecycle drains the broker", async () => {
+    upsertTaskWithDeliveryStateToSqlite({ task: task("retained") });
+    const runs = createPluginRuntime().tasks.async.runs.bindSession({ sessionKey: ownerKey });
+    expect((await runs.get("retained"))?.id).toBe("retained");
+    await drainGlobalSingletonLifecycleState("restart");
+    expect((await runs.get("retained"))?.id).toBe("retained");
+  });
+
+  it("repairs an old additive task shape before querying retained rows", async () => {
+    upsertTaskWithDeliveryStateToSqlite({ task: task("retained") });
+    openOpenClawStateDatabase().db.exec("ALTER TABLE task_runs DROP COLUMN tool_use_count");
+    closeOpenClawStateDatabase();
+    const runs = createPluginRuntime().tasks.async.runs.bindSession({ sessionKey: ownerKey });
+    expect((await runs.get("retained"))?.id).toBe("retained");
+  });
+
+  it("rejects a cold schema failure instead of returning an empty list", async () => {
+    openOpenClawStateDatabase().db.exec("PRAGMA user_version = 9999");
+    closeOpenClawStateDatabase();
+    const runs = createPluginRuntime().tasks.async.runs.bindSession({ sessionKey: ownerKey });
+    await expect(runs.list()).rejects.toThrow(/newer schema version 9999/);
+  });
+
+  it("preserves all 14 read payloads while warmed native queries execute off the main thread", async () => {
+    upsertTaskFlowRegistryRecordToSqlite(flow("flow-a"));
+    upsertTaskWithDeliveryStateToSqlite({
+      task: task("task-a", { progressSummary: "Persisted progress" }),
+    });
+    const runtime = createPluginRuntime();
+    const runs = runtime.tasks.async.runs.bindSession({ sessionKey: ownerKey });
+    const flows = runtime.tasks.async.flows.fromToolContext({ sessionKey: ownerKey });
+    const managed = runtime.tasks.async.managedFlows.bindSession({ sessionKey: ownerKey });
+    const legacyRuns = runtime.tasks.runs.bindSession({ sessionKey: ownerKey });
+    const legacyFlows = runtime.tasks.flows.bindSession({ sessionKey: ownerKey });
+    const legacyManaged = runtime.tasks.managedFlows.bindSession({ sessionKey: ownerKey });
+    const expectedRun = legacyRuns.get("task-a");
+    const expectedFlow = legacyFlows.get("flow-a");
+    const expectedManaged = legacyManaged.get("flow-a");
+    const summary = legacyFlows.getTaskSummary("flow-a");
+    await runs.get("task-a");
+    const native = requireNodeSqlite();
+    // A Promise wrapper around synchronous SQL fails here. The independent
+    // worker uses its own native prototype and reads the real fixture database.
+    vi.spyOn(native.DatabaseSync.prototype, "prepare").mockImplementation(() => {
+      throw new Error("Unexpected warmed main-thread SQLite prepare");
+    });
+    vi.spyOn(native.DatabaseSync.prototype, "exec").mockImplementation(() => {
+      throw new Error("Unexpected warmed main-thread SQLite exec");
+    });
+    for (const method of ["iterate", "get", "all", "run"] as const) {
+      vi.spyOn(native.StatementSync.prototype, method).mockImplementation(() => {
+        throw new Error("Unexpected warmed main-thread SQLite statement execution");
+      });
+    }
+    const results = await Promise.all([
+      runs.get("task-a"),
+      runs.list(),
+      runs.findLatest(),
+      runs.resolve("run-a"),
+      flows.get("flow-a"),
+      flows.list(),
+      flows.findLatest(),
+      flows.resolve(ownerKey),
+      flows.getTaskSummary("flow-a"),
+      managed.get("flow-a"),
+      managed.list(),
+      managed.findLatest(),
+      managed.resolve(ownerKey),
+      managed.getTaskSummary("flow-a"),
+    ]);
+    expect(results).toEqual([
+      expectedRun,
+      [expectedRun],
+      expectedRun,
+      expectedRun,
+      expectedFlow,
+      [legacyFlows.list()[0]],
+      expectedFlow,
+      expectedFlow,
+      summary,
+      expectedManaged,
+      [expectedManaged],
+      expectedManaged,
+      expectedManaged,
+      summary,
+    ]);
+    expect(getTaskById("task-a")?.progressSummary).toBe("Persisted progress");
+  });
+
+  it("keeps scope and lookup precedence with deterministic equal-timestamp ordering", async () => {
+    for (const record of [
+      task("task-a"),
+      task("task-z"),
+      task("foreign", {
+        ownerKey: "agent:other:reader",
+        requesterAgentId: "other",
+        createdAt: 50,
+      }),
+    ]) {
+      upsertTaskWithDeliveryStateToSqlite({ task: record });
+    }
+    upsertTaskFlowRegistryRecordToSqlite(flow("flow-z"));
+    upsertTaskFlowRegistryRecordToSqlite(flow("flow-a", { status: "succeeded", endedAt: 100 }));
+    const runtime = createPluginRuntime();
+    const runs = runtime.tasks.async.runs.bindSession({ sessionKey: ownerKey });
+    const flows = runtime.tasks.async.managedFlows.bindSession({ sessionKey: ownerKey });
+    expect((await runs.list()).map((item) => item.id)).toEqual(["task-z", "task-a"]);
+    expect((await runs.findLatest())?.id).toBe("task-z");
+    expect((await runs.resolve("task-a"))?.id).toBe("task-a");
+    // Run selection is global before owner access: a foreign preferred run
+    // cannot be replaced by a less-preferred visible match.
+    expect(await runs.resolve("run-a")).toBeUndefined();
+    expect(await runs.get("foreign")).toBeUndefined();
+    expect((await flows.list()).map((item) => item.flowId)).toEqual(["flow-a", "flow-z"]);
+    expect((await flows.findLatest())?.flowId).toBe("flow-a");
+    expect((await flows.resolve(ownerKey))?.flowId).toBe("flow-z");
+    expect(await flows.resolve("agent:other:reader")).toBeUndefined();
+  });
+
+  it("preserves managed JSON while DTO lists and summaries expose only their public fields", async () => {
+    const stateJson = { payload: "s".repeat(4096) };
+    const waitJson = { payload: "w".repeat(4096) };
+    upsertTaskFlowRegistryRecordToSqlite(flow("flow-a", { stateJson, waitJson }));
+    for (const record of [
+      task("running"),
+      task("succeeded", { runtime: "subagent", status: "succeeded" }),
+      task("failed", { runtime: "cli", status: "failed" }),
+    ]) {
+      upsertTaskWithDeliveryStateToSqlite({ task: record });
+    }
+    const runtime = createPluginRuntime();
+    const views = runtime.tasks.async.flows.bindSession({ sessionKey: ownerKey });
+    const managed = runtime.tasks.async.managedFlows.bindSession({ sessionKey: ownerKey });
+    expect((await managed.list())[0]).toMatchObject({ stateJson, waitJson });
+    expect(await views.list()).toEqual(
+      runtime.tasks.flows.bindSession({ sessionKey: ownerKey }).list(),
+    );
+    const expected = runtime.tasks.managedFlows
+      .bindSession({ sessionKey: ownerKey })
+      .getTaskSummary("flow-a");
+    expect(expected).toMatchObject({
+      total: 3,
+      active: 1,
+      terminal: 2,
+      failures: 1,
+      byStatus: { running: 1, succeeded: 1, failed: 1 },
+      byRuntime: { acp: 1, cli: 1, subagent: 1, cron: 0 },
+    });
+    expect(await views.getTaskSummary("flow-a")).toEqual(expected);
+    expect(await managed.getTaskSummary("flow-a")).toEqual(expected);
+    expect(
+      await runtime.tasks.async.flows
+        .bindSession({ sessionKey: "agent:other:reader" })
+        .getTaskSummary("flow-a"),
+    ).toBeUndefined();
+  });
+
+  it("preserves owner-visible fallback between ID, run, and related-session lookup tiers", async () => {
+    for (const record of [
+      task("owned-by-run", { runId: "collision" }),
+      task("collision", {
+        ownerKey: "agent:other:reader",
+        requesterAgentId: "other",
+        runId: "foreign-run",
+      }),
+      task("foreign-by-run", {
+        ownerKey: "agent:other:reader",
+        requesterAgentId: "other",
+        runId: ownerKey,
+      }),
+      task("owned-latest", { runId: "latest-run", createdAt: 400 }),
+    ]) {
+      upsertTaskWithDeliveryStateToSqlite({ task: record });
+    }
+    const runtime = createPluginRuntime();
+    const syncRuns = runtime.tasks.runs.bindSession({ sessionKey: ownerKey });
+    const asyncRuns = runtime.tasks.async.runs.bindSession({ sessionKey: ownerKey });
+    expect(syncRuns.resolve("collision")?.id).toBe("owned-by-run");
+    expect((await asyncRuns.resolve("collision"))?.id).toBe("owned-by-run");
+    expect(syncRuns.resolve(ownerKey)?.id).toBe("owned-latest");
+    expect((await asyncRuns.resolve(ownerKey))?.id).toBe("owned-latest");
+  });
+
+  it("retains cold admission and observes later persisted changes without replacing the sync cache", async () => {
+    const native = requireNodeSqlite();
+    const prepare = vi.spyOn(native.DatabaseSync.prototype, "prepare");
+    const runtime = createPluginRuntime();
+    const runs = runtime.tasks.async.runs.bindSession({ sessionKey: ownerKey });
+    expect(await runs.list()).toEqual([]);
+    expect(prepare).toHaveBeenCalled();
+    upsertTaskWithDeliveryStateToSqlite({ task: task("fresh") });
+    expect(getTaskById("fresh")).toBeUndefined();
+    prepare.mockClear();
+    expect((await runs.get("fresh"))?.id).toBe("fresh");
+    expect(prepare).not.toHaveBeenCalled();
+    expect(getTaskById("fresh")).toBeUndefined();
+    expect(openOpenClawStateDatabase().db.isOpen).toBe(true);
+  });
+});

--- a/src/infra/update-migrated-finalize.worker.ts
+++ b/src/infra/update-migrated-finalize.worker.ts
@@ -21,7 +21,7 @@ import { createWindowsTaskAutoStartRecovery } from "../cli/update-cli/update-com
 import { defaultRuntime } from "../runtime.js";
 import { OPENCLAW_AGENT_SCHEMA_VERSION } from "../state/openclaw-agent-db-contract.js";
 import { OPENCLAW_STATE_SCHEMA_VERSION } from "../state/openclaw-state-db-contract.js";
-import { closeOpenClawStateDatabase } from "../state/openclaw-state-db.js";
+import { closeOpenClawStateDatabaseAsync } from "../state/openclaw-state-db.js";
 import { resolveEnvironmentValue } from "./process-env.js";
 import {
   UPDATE_POST_INSTALL_DOCTOR_RESULT_PATH_ENV,
@@ -263,9 +263,13 @@ async function finalizeInput(
   executorFence?.assertCurrent();
 }
 
-void finalizeMigratedUpdate()
-  .catch((error: unknown) => {
-    process.stderr.write(`${formatUpdateFinalizationError(error)}\n`);
-    process.exitCode = 1;
-  })
-  .finally(() => closeOpenClawStateDatabase());
+void (async () => {
+  try {
+    await finalizeMigratedUpdate();
+  } finally {
+    await closeOpenClawStateDatabaseAsync();
+  }
+})().catch((error: unknown) => {
+  process.stderr.write(`${formatUpdateFinalizationError(error)}\n`);
+  process.exitCode = 1;
+});

--- a/src/infra/update-repair.worker.ts
+++ b/src/infra/update-repair.worker.ts
@@ -1,5 +1,5 @@
 import { createDeferredCore } from "../shared/deferred.js";
-import { closeOpenClawStateDatabase } from "../state/openclaw-state-db.js";
+import { closeOpenClawStateDatabaseAsync } from "../state/openclaw-state-db.js";
 import { toErrorObject } from "./errors.js";
 import { runUpdateRepairLoop } from "./update-repair-agent.js";
 import {
@@ -122,8 +122,8 @@ process.on("message", (raw: unknown) => {
           },
         });
       })()
-        .then((result) => {
-          closeOpenClawStateDatabase();
+        .then(async (result) => {
+          await closeOpenClawStateDatabaseAsync();
           send({ type: "result", result }, () => process.exit(0));
         })
         .catch(() => process.exit(1));

--- a/src/infra/update-run-recovery-handoff.test.ts
+++ b/src/infra/update-run-recovery-handoff.test.ts
@@ -73,10 +73,10 @@ function shape(pathname: string) {
     db.close();
   }
 }
-it("refuses existing-state writes while another owner excludes the physical state file", () => {
+it("refuses existing-state writes while another owner excludes the physical state file", async () => {
   const f = source();
   const before = fs.readFileSync(f.pathname);
-  const held = acquireOpenClawStateDatabaseFileExclusion(f.pathname);
+  const held = await acquireOpenClawStateDatabaseFileExclusion(f.pathname);
   try {
     expect(() => probeExistingWriter(f)).toThrow(/state-handles/);
     expect(fs.readFileSync(f.pathname)).toEqual(before);

--- a/src/plugin-sdk/qa-runtime.ts
+++ b/src/plugin-sdk/qa-runtime.ts
@@ -32,7 +32,7 @@ export async function closeQaRuntimeStores(tempRoot: string): Promise<void> {
   // until every scoped handle closes, or exit-time release can recreate the root.
   auth.closeAuthProfileReadPool({ kind: "root", rootPath: tempRoot });
   await agents.closeOpenClawAgentDatabasesAsync(tempRoot);
-  state.closeOpenClawStateDatabaseByPath(
+  await state.closeOpenClawStateDatabaseByPathAsync(
     paths.resolveOpenClawStateSqlitePath({ OPENCLAW_STATE_DIR: path.join(tempRoot, "state") }),
   );
 }

--- a/src/plugin-sdk/test-helpers/plugin-runtime-mock.ts
+++ b/src/plugin-sdk/test-helpers/plugin-runtime-mock.ts
@@ -21,6 +21,7 @@ import {
   implicitMentionKindWhen,
   resolveInboundMentionDecision,
 } from "../channel-mention-gating.js";
+import { createPluginTasksRuntimeMock } from "./plugin-runtime-tasks-mock.js";
 
 type InboundDebounceFlush = ReturnType<InboundDebounceCreateParams<unknown>["onFlush"]>;
 type InboundDebounceFlushFactory = Parameters<InboundDebounceCreateParams<unknown>["onFlush"]>[1];
@@ -60,7 +61,6 @@ type ChannelStructuredContextEntries = NonNullable<
 type ChannelStructuredContextResolution =
   | { kind: "absent" }
   | { kind: "present"; entries: ChannelStructuredContextEntries };
-type BoundTaskFlowRuntime = ReturnType<PluginRuntime["tasks"]["managedFlows"]["bindSession"]>;
 
 type GenericMockProcedure = (...args: never[]) => unknown;
 
@@ -86,26 +86,6 @@ function mergeDeep<T>(base: T, overrides: DeepPartial<T>): T {
     result[key] = overrideValue;
   }
   return result as T;
-}
-
-function createTaskFlowSessionMock(): BoundTaskFlowRuntime {
-  return {
-    sessionKey: "agent:main:main",
-    createManaged: vi.fn<BoundTaskFlowRuntime["createManaged"]>(),
-    tryCreateManaged: vi.fn<BoundTaskFlowRuntime["tryCreateManaged"]>(),
-    get: vi.fn<BoundTaskFlowRuntime["get"]>(),
-    list: vi.fn<BoundTaskFlowRuntime["list"]>(() => []),
-    findLatest: vi.fn<BoundTaskFlowRuntime["findLatest"]>(),
-    resolve: vi.fn<BoundTaskFlowRuntime["resolve"]>(),
-    getTaskSummary: vi.fn<BoundTaskFlowRuntime["getTaskSummary"]>(),
-    setWaiting: vi.fn<BoundTaskFlowRuntime["setWaiting"]>(),
-    resume: vi.fn<BoundTaskFlowRuntime["resume"]>(),
-    finish: vi.fn<BoundTaskFlowRuntime["finish"]>(),
-    fail: vi.fn<BoundTaskFlowRuntime["fail"]>(),
-    requestCancel: vi.fn<BoundTaskFlowRuntime["requestCancel"]>(),
-    cancel: vi.fn<BoundTaskFlowRuntime["cancel"]>(),
-    runTask: vi.fn<BoundTaskFlowRuntime["runTask"]>(),
-  };
 }
 
 function normalizeUntrustedGroupPrompt(value: unknown): string | undefined {
@@ -199,12 +179,6 @@ export function createPluginRuntimeMock(overrides: DeepPartial<PluginRuntime> = 
       payloads: [],
       meta: { durationMs: 0 },
     });
-  const taskFlow = {
-    bindSession:
-      vi.fn<PluginRuntime["tasks"]["managedFlows"]["bindSession"]>(createTaskFlowSessionMock),
-    fromToolContext:
-      vi.fn<PluginRuntime["tasks"]["managedFlows"]["fromToolContext"]>(createTaskFlowSessionMock),
-  };
   const dispatchAssembledChannelTurnMock = vi.fn<
     PluginRuntime["channel"]["inbound"]["dispatchReply"]
   >(async (params) => {
@@ -997,17 +971,7 @@ export function createPluginRuntimeMock(overrides: DeepPartial<PluginRuntime> = 
         },
       ),
     },
-    tasks: {
-      runs: {
-        bindSession: vi.fn(),
-        fromToolContext: vi.fn(),
-      } as PluginRuntime["tasks"]["runs"],
-      flows: {
-        bindSession: vi.fn(),
-        fromToolContext: vi.fn(),
-      } as PluginRuntime["tasks"]["flows"],
-      managedFlows: taskFlow,
-    },
+    tasks: createPluginTasksRuntimeMock(),
     modelConfig: {
       resolveDefaultModelForAgent:
         vi.fn<PluginRuntime["modelConfig"]["resolveDefaultModelForAgent"]>(),

--- a/src/plugin-sdk/test-helpers/plugin-runtime-tasks-mock.ts
+++ b/src/plugin-sdk/test-helpers/plugin-runtime-tasks-mock.ts
@@ -1,0 +1,66 @@
+import { vi } from "vitest";
+import type { PluginRuntime } from "../../plugins/runtime/types.js";
+
+type BoundTaskFlowRuntime = ReturnType<PluginRuntime["tasks"]["managedFlows"]["bindSession"]>;
+
+function createTaskFlowSessionMock(): BoundTaskFlowRuntime {
+  return {
+    sessionKey: "agent:main:main",
+    createManaged: vi.fn<BoundTaskFlowRuntime["createManaged"]>(),
+    tryCreateManaged: vi.fn<BoundTaskFlowRuntime["tryCreateManaged"]>(),
+    get: vi.fn<BoundTaskFlowRuntime["get"]>(),
+    list: vi.fn<BoundTaskFlowRuntime["list"]>(() => []),
+    findLatest: vi.fn<BoundTaskFlowRuntime["findLatest"]>(),
+    resolve: vi.fn<BoundTaskFlowRuntime["resolve"]>(),
+    getTaskSummary: vi.fn<BoundTaskFlowRuntime["getTaskSummary"]>(),
+    setWaiting: vi.fn<BoundTaskFlowRuntime["setWaiting"]>(),
+    resume: vi.fn<BoundTaskFlowRuntime["resume"]>(),
+    finish: vi.fn<BoundTaskFlowRuntime["finish"]>(),
+    fail: vi.fn<BoundTaskFlowRuntime["fail"]>(),
+    requestCancel: vi.fn<BoundTaskFlowRuntime["requestCancel"]>(),
+    cancel: vi.fn<BoundTaskFlowRuntime["cancel"]>(),
+    runTask: vi.fn<BoundTaskFlowRuntime["runTask"]>(),
+  };
+}
+
+function createAsyncReadSession(params: { sessionKey?: string }) {
+  return {
+    sessionKey: params.sessionKey ?? "agent:main:main",
+    get: vi.fn(async () => undefined),
+    list: vi.fn(async () => []),
+    findLatest: vi.fn(async () => undefined),
+    resolve: vi.fn(async () => undefined),
+  };
+}
+
+function createAsyncFlowReadSession(params: { sessionKey?: string }) {
+  return { ...createAsyncReadSession(params), getTaskSummary: vi.fn(async () => undefined) };
+}
+
+function readBinding<Bound>(factory: (params: { sessionKey?: string }) => Bound) {
+  return { bindSession: vi.fn(factory), fromToolContext: vi.fn(factory) };
+}
+
+export function createPluginTasksRuntimeMock(): PluginRuntime["tasks"] {
+  return {
+    async: {
+      runs: readBinding(createAsyncReadSession),
+      flows: readBinding(createAsyncFlowReadSession),
+      managedFlows: readBinding(createAsyncFlowReadSession),
+    },
+    runs: {
+      bindSession: vi.fn<PluginRuntime["tasks"]["runs"]["bindSession"]>(),
+      fromToolContext: vi.fn<PluginRuntime["tasks"]["runs"]["fromToolContext"]>(),
+    },
+    flows: {
+      bindSession: vi.fn<PluginRuntime["tasks"]["flows"]["bindSession"]>(),
+      fromToolContext: vi.fn<PluginRuntime["tasks"]["flows"]["fromToolContext"]>(),
+    },
+    managedFlows: {
+      bindSession:
+        vi.fn<PluginRuntime["tasks"]["managedFlows"]["bindSession"]>(createTaskFlowSessionMock),
+      fromToolContext:
+        vi.fn<PluginRuntime["tasks"]["managedFlows"]["fromToolContext"]>(createTaskFlowSessionMock),
+    },
+  };
+}

--- a/src/plugin-state/plugin-state-store.sqlite.ts
+++ b/src/plugin-state/plugin-state-store.sqlite.ts
@@ -15,6 +15,7 @@ import {
 } from "../state/openclaw-state-db-readonly.js";
 import {
   closeOpenClawStateDatabase,
+  closeOpenClawStateDatabaseAsync,
   isOpenClawStateDatabaseOpen,
   openOpenClawStateDatabase,
   type OpenClawStateDatabaseOptions,
@@ -1202,6 +1203,10 @@ function probePluginStateStore(): PluginStateStoreProbeResult {
 
 export function closePluginStateDatabase(): void {
   closeOpenClawStateDatabase();
+}
+
+export async function closePluginStateDatabaseAsync(): Promise<void> {
+  await closeOpenClawStateDatabaseAsync();
 }
 
 if (process.env.VITEST || process.env.NODE_ENV === "test") {

--- a/src/plugin-state/plugin-state-store.ts
+++ b/src/plugin-state/plugin-state-store.ts
@@ -48,7 +48,7 @@ export type {
 export type { PluginDoctorRawStateEntry } from "./plugin-state-store.sqlite.js";
 
 export {
-  closePluginStateDatabase,
+  closePluginStateDatabaseAsync,
   countPluginStateLiveEntries,
   getPluginStateCapacity,
   MAX_PLUGIN_STATE_BULK_DELETE_ENTRIES,

--- a/src/plugins/compat/registry-records.ts
+++ b/src/plugins/compat/registry-records.ts
@@ -30,7 +30,7 @@ export const PLUGIN_COMPAT_RECORDS = [
     diagnostics: [
       "TypeScript @deprecated annotations and migration documentation; no runtime warnings",
     ],
-    tests: ["src/infra/sqlite-worker-task-runtime.test.ts", "extensions/webhooks/src/http.test.ts"],
+    tests: ["src/infra/sqlite-worker-task-runtime.test.ts", "extensions/webhooks/index.test.ts"],
     releaseNote:
       "Plugins can opt into worker-backed Task Run and Task Flow queries through tasks.async while synchronous reads remain available for external compatibility. Cold registry and configuration preparation remains synchronous.",
   },

--- a/src/plugins/compat/registry-records.ts
+++ b/src/plugins/compat/registry-records.ts
@@ -12,6 +12,29 @@ export const PLUGIN_COMPAT_RECORDS = [
   ...DEPRECATION_MARKING_COMPAT_RECORDS,
   MEDIA_LEGACY_PROJECTION_COMPAT_RECORD,
   {
+    code: "plugin-tasks-sync-reads",
+    status: "deprecated",
+    owner: "sdk",
+    introduced: "2026-09-12",
+    deprecated: "2026-09-12",
+    warningStarts: "2026-09-12",
+    removalGate: "next-plugin-sdk-major",
+    replacement:
+      "Await the 14 read methods on api.runtime.tasks.async.runs, flows, and managedFlows. Retain synchronous reads until supported external-plugin migration and explicit breaking-release approval; mutations and cancellation remain on the existing surface.",
+    docsPath: "/plugins/sdk-runtime/background-work",
+    surfaces: [
+      "api.runtime.tasks.runs get/list/findLatest/resolve",
+      "api.runtime.tasks.flows get/list/findLatest/resolve/getTaskSummary",
+      "api.runtime.tasks.managedFlows get/list/findLatest/resolve/getTaskSummary",
+    ],
+    diagnostics: [
+      "TypeScript @deprecated annotations and migration documentation; no runtime warnings",
+    ],
+    tests: ["src/infra/sqlite-worker-task-runtime.test.ts", "extensions/webhooks/src/http.test.ts"],
+    releaseNote:
+      "Plugins can opt into worker-backed Task Run and Task Flow queries through tasks.async while synchronous reads remain available for external compatibility. Cold registry and configuration preparation remains synchronous.",
+  },
+  {
     code: "plugin-state-sync-keyed-store",
     status: "deprecated",
     owner: "sdk",

--- a/src/plugins/runtime/runtime-taskflow.types.ts
+++ b/src/plugins/runtime/runtime-taskflow.types.ts
@@ -73,10 +73,15 @@ export type BoundTaskFlowRuntime = {
   readonly requesterOrigin?: TaskDeliveryState["requesterOrigin"];
   createManaged: (params: ManagedTaskFlowCreateParams) => ManagedTaskFlowRecord;
   tryCreateManaged: (params: ManagedTaskFlowCreateParams) => ManagedTaskFlowRecord | null;
+  /** @deprecated Use the same method on api.runtime.tasks.async.managedFlows. */
   get: (flowId: string) => TaskFlowRecord | undefined;
+  /** @deprecated Use the same method on api.runtime.tasks.async.managedFlows. */
   list: () => TaskFlowRecord[];
+  /** @deprecated Use the same method on api.runtime.tasks.async.managedFlows. */
   findLatest: () => TaskFlowRecord | undefined;
+  /** @deprecated Use the same method on api.runtime.tasks.async.managedFlows. */
   resolve: (token: string) => TaskFlowRecord | undefined;
+  /** @deprecated Use the same method on api.runtime.tasks.async.managedFlows. */
   getTaskSummary: (flowId: string) => TaskRegistrySummary | undefined;
   setWaiting: (params: {
     flowId: string;

--- a/src/plugins/runtime/runtime-tasks-async.ts
+++ b/src/plugins/runtime/runtime-tasks-async.ts
@@ -1,0 +1,177 @@
+import { captureOpenClawStateDatabaseReadAdmission } from "../../state/openclaw-state-db-cache.js";
+import { resolveOpenClawStateSqlitePath } from "../../state/openclaw-state-db.paths.js";
+import {
+  mapTaskFlowDetail,
+  mapTaskRunAggregateSummary,
+  mapTaskRunDetail,
+  mapTaskRunView,
+} from "../../tasks/task-domain-views.js";
+import { ensureTaskFlowRegistryReady } from "../../tasks/task-flow-registry.js";
+import { canOwnerAccessTask } from "../../tasks/task-owner-access.js";
+import { ensureTaskRegistryReady } from "../../tasks/task-registry-state.js";
+import type { TaskRecord } from "../../tasks/task-registry.types.js";
+import { normalizeDeliveryContext } from "../../utils/delivery-context.shared.js";
+import type {
+  BoundAsyncManagedTaskFlowsRuntime,
+  BoundAsyncTaskFlowsRuntime,
+  BoundAsyncTaskRunsRuntime,
+  PluginRuntimeAsyncTasks,
+} from "./runtime-tasks.types.js";
+
+type Binding = Parameters<PluginRuntimeAsyncTasks["runs"]["bindSession"]>[0];
+
+function bind(params: Binding) {
+  const sessionKey = params.sessionKey?.trim();
+  if (!sessionKey) {
+    throw new Error("Tasks runtime requires a bound sessionKey.");
+  }
+  const requesterOrigin = normalizeDeliveryContext(params.requesterOrigin);
+  return { sessionKey, ...(requesterOrigin ? { requesterOrigin } : {}) };
+}
+
+async function readStore(includeTasks: boolean, includeFlows: boolean) {
+  const databasePath = resolveOpenClawStateSqlitePath();
+  const context = captureOpenClawStateDatabaseReadAdmission(databasePath);
+  // Cold restore retains canonical schema admission and failure semantics. Only
+  // this first admission uses main-thread SQLite; warmed queries run in the worker.
+  if (includeFlows) {
+    context.assertCurrent();
+    ensureTaskFlowRegistryReady();
+  }
+  if (includeTasks) {
+    context.assertCurrent();
+    ensureTaskRegistryReady();
+  }
+  const store = await import("../../state/openclaw-state-worker-store.js");
+  context.assertCurrent();
+  return { store, context };
+}
+
+function bindRuns(params: Binding): BoundAsyncTaskRunsRuntime {
+  const binding = bind(params);
+  const identity = { callerOwnerKey: binding.sessionKey, callerAgentId: params.agentId };
+  const visible = (task: TaskRecord | undefined) =>
+    task && canOwnerAccessTask(task, identity) ? task : undefined;
+  const list = async () => {
+    const { store, context } = await readStore(true, false);
+    const records = await store.executeOpenClawStateWorker(context, {
+      type: "tasks.list",
+      input: { ownerKey: binding.sessionKey },
+    });
+    return records.filter((task) => canOwnerAccessTask(task, identity));
+  };
+  return {
+    ...binding,
+    async get(taskId) {
+      const { store, context } = await readStore(true, false);
+      const task = visible(
+        await store.executeOpenClawStateWorker(context, {
+          type: "tasks.get",
+          input: { taskId: taskId.trim() },
+        }),
+      );
+      return task ? mapTaskRunDetail(task) : undefined;
+    },
+    list: async () => (await list()).map(mapTaskRunView),
+    async findLatest() {
+      const task = (await list())[0];
+      return task ? mapTaskRunDetail(task) : undefined;
+    },
+    async resolve(token) {
+      const { store, context } = await readStore(true, false);
+      const records = await store.executeOpenClawStateWorker(context, {
+        type: "tasks.resolve",
+        input: { ownerKey: binding.sessionKey, token: token.trim() },
+      });
+      const task =
+        visible(records.direct) ?? visible(records.byRun) ?? records.related.find(visible);
+      return task ? mapTaskRunDetail(task) : undefined;
+    },
+  };
+}
+
+async function readFlowTaskSummary(ownerKey: string, flowId: string) {
+  const { store, context } = await readStore(true, true);
+  return store.executeOpenClawStateWorker(context, {
+    type: "flows.summary",
+    input: { ownerKey, flowId },
+  });
+}
+
+function bindFlowReads(params: Binding): BoundAsyncManagedTaskFlowsRuntime {
+  const binding = bind(params);
+  const read = async (lookup: "id" | "latest" | "resolve", token?: string) => {
+    const { store, context } = await readStore(false, true);
+    return store.executeOpenClawStateWorker(context, {
+      type: "flows.read",
+      input: { ownerKey: binding.sessionKey, lookup, token },
+    });
+  };
+  return {
+    ...binding,
+    get: (flowId) => read("id", flowId),
+    async list() {
+      const { store, context } = await readStore(false, true);
+      return store.executeOpenClawStateWorker(context, {
+        type: "flows.list",
+        input: { ownerKey: binding.sessionKey },
+      });
+    },
+    findLatest: () => read("latest"),
+    resolve: (token) => read("resolve", token),
+    getTaskSummary: (flowId) => readFlowTaskSummary(binding.sessionKey, flowId),
+  };
+}
+
+function bindFlows(params: Binding): BoundAsyncTaskFlowsRuntime {
+  const binding = bind(params);
+  const read = async (lookup: "id" | "latest" | "resolve", token?: string) => {
+    const { store, context } = await readStore(true, true);
+    const result = await store.executeOpenClawStateWorker(context, {
+      type: "flows.detail",
+      input: { ownerKey: binding.sessionKey, lookup, token },
+    });
+    return result ? mapTaskFlowDetail(result) : undefined;
+  };
+  return {
+    ...binding,
+    get: (flowId) => read("id", flowId),
+    async list() {
+      const { store, context } = await readStore(false, true);
+      return store.executeOpenClawStateWorker(context, {
+        type: "flows.views",
+        input: { ownerKey: binding.sessionKey },
+      });
+    },
+    findLatest: () => read("latest"),
+    resolve: (token) => read("resolve", token),
+    async getTaskSummary(flowId) {
+      const summary = await readFlowTaskSummary(binding.sessionKey, flowId);
+      return summary ? mapTaskRunAggregateSummary(summary) : undefined;
+    },
+  };
+}
+
+export function createRuntimeAsyncTasks(): PluginRuntimeAsyncTasks {
+  return {
+    runs: {
+      bindSession: bindRuns,
+      fromToolContext: (ctx) =>
+        bindRuns({
+          sessionKey: ctx.sessionKey ?? "",
+          agentId: ctx.agentId,
+          requesterOrigin: ctx.deliveryContext,
+        }),
+    },
+    flows: {
+      bindSession: bindFlows,
+      fromToolContext: (ctx) =>
+        bindFlows({ sessionKey: ctx.sessionKey ?? "", requesterOrigin: ctx.deliveryContext }),
+    },
+    managedFlows: {
+      bindSession: bindFlowReads,
+      fromToolContext: (ctx) =>
+        bindFlowReads({ sessionKey: ctx.sessionKey ?? "", requesterOrigin: ctx.deliveryContext }),
+    },
+  };
+}

--- a/src/plugins/runtime/runtime-tasks-async.ts
+++ b/src/plugins/runtime/runtime-tasks-async.ts
@@ -6,7 +6,7 @@ import {
   mapTaskRunDetail,
   mapTaskRunView,
 } from "../../tasks/task-domain-views.js";
-import { ensureTaskFlowRegistryReady } from "../../tasks/task-flow-registry.js";
+import { ensureTaskFlowRegistryReady } from "../../tasks/task-flow-runtime-internal.js";
 import { canOwnerAccessTask } from "../../tasks/task-owner-access.js";
 import { ensureTaskRegistryReady } from "../../tasks/task-registry-state.js";
 import type { TaskRecord } from "../../tasks/task-registry.types.js";

--- a/src/plugins/runtime/runtime-tasks.ts
+++ b/src/plugins/runtime/runtime-tasks.ts
@@ -22,6 +22,7 @@ import {
 } from "../../tasks/task-owner-access.js";
 import { normalizeDeliveryContext } from "../../utils/delivery-context.shared.js";
 import type { PluginRuntimeTaskFlow } from "./runtime-taskflow.types.js";
+import { createRuntimeAsyncTasks } from "./runtime-tasks-async.js";
 import type {
   BoundTaskFlowsRuntime,
   BoundTaskRunsRuntime,
@@ -220,6 +221,7 @@ export function createRuntimeTasks(params: {
   managedTaskFlow: PluginRuntimeTaskFlow;
 }): PluginRuntimeTasks {
   return {
+    async: createRuntimeAsyncTasks(),
     runs: createRuntimeTaskRuns(),
     flows: createRuntimeTaskFlows(),
     managedFlows: params.managedTaskFlow,

--- a/src/plugins/runtime/runtime-tasks.types.ts
+++ b/src/plugins/runtime/runtime-tasks.types.ts
@@ -1,6 +1,7 @@
 // Runtime task types describe plugin task runtime config and invocation options.
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import type { TaskDeliveryState } from "../../tasks/task-registry.types.js";
+import type { TaskFlowRecord } from "../../tasks/task-flow-registry.types.js";
+import type { TaskDeliveryState, TaskRegistrySummary } from "../../tasks/task-registry.types.js";
 import type { OpenClawPluginToolContext } from "../tool-types.js";
 import type { PluginRuntimeTaskFlow } from "./runtime-taskflow.types.js";
 import type {
@@ -16,9 +17,13 @@ export type { TaskFlowDetail, TaskRunCancelResult } from "./task-domain-types.js
 export type BoundTaskRunsRuntime = {
   readonly sessionKey: string;
   readonly requesterOrigin?: TaskDeliveryState["requesterOrigin"];
+  /** @deprecated Use the same method on api.runtime.tasks.async.runs. */
   get: (taskId: string) => TaskRunDetail | undefined;
+  /** @deprecated Use the same method on api.runtime.tasks.async.runs. */
   list: () => TaskRunView[];
+  /** @deprecated Use the same method on api.runtime.tasks.async.runs. */
   findLatest: () => TaskRunDetail | undefined;
+  /** @deprecated Use the same method on api.runtime.tasks.async.runs. */
   resolve: (token: string) => TaskRunDetail | undefined;
   cancel: (params: { taskId: string; cfg: OpenClawConfig }) => Promise<TaskRunCancelResult>;
 };
@@ -37,10 +42,15 @@ export type PluginRuntimeTaskRuns = {
 export type BoundTaskFlowsRuntime = {
   readonly sessionKey: string;
   readonly requesterOrigin?: TaskDeliveryState["requesterOrigin"];
+  /** @deprecated Use the same method on api.runtime.tasks.async.flows. */
   get: (flowId: string) => TaskFlowDetail | undefined;
+  /** @deprecated Use the same method on api.runtime.tasks.async.flows. */
   list: () => TaskFlowView[];
+  /** @deprecated Use the same method on api.runtime.tasks.async.flows. */
   findLatest: () => TaskFlowDetail | undefined;
+  /** @deprecated Use the same method on api.runtime.tasks.async.flows. */
   resolve: (token: string) => TaskFlowDetail | undefined;
+  /** @deprecated Use the same method on api.runtime.tasks.async.flows. */
   getTaskSummary: (flowId: string) => TaskRunAggregateSummary | undefined;
 };
 
@@ -55,7 +65,47 @@ export type PluginRuntimeTaskFlows = {
 };
 
 export type PluginRuntimeTasks = {
+  async: PluginRuntimeAsyncTasks;
   runs: PluginRuntimeTaskRuns;
   flows: PluginRuntimeTaskFlows;
   managedFlows: PluginRuntimeTaskFlow;
+};
+
+type AsyncTaskReadBinding = {
+  readonly sessionKey: string;
+  readonly requesterOrigin?: TaskDeliveryState["requesterOrigin"];
+};
+
+export type BoundAsyncTaskRunsRuntime = AsyncTaskReadBinding & {
+  get: (taskId: string) => Promise<TaskRunDetail | undefined>;
+  list: () => Promise<TaskRunView[]>;
+  findLatest: () => Promise<TaskRunDetail | undefined>;
+  resolve: (token: string) => Promise<TaskRunDetail | undefined>;
+};
+export type BoundAsyncTaskFlowsRuntime = AsyncTaskReadBinding & {
+  get: (flowId: string) => Promise<TaskFlowDetail | undefined>;
+  list: () => Promise<TaskFlowView[]>;
+  findLatest: () => Promise<TaskFlowDetail | undefined>;
+  resolve: (token: string) => Promise<TaskFlowDetail | undefined>;
+  getTaskSummary: (flowId: string) => Promise<TaskRunAggregateSummary | undefined>;
+};
+export type BoundAsyncManagedTaskFlowsRuntime = AsyncTaskReadBinding & {
+  get: (flowId: string) => Promise<TaskFlowRecord | undefined>;
+  list: () => Promise<TaskFlowRecord[]>;
+  findLatest: () => Promise<TaskFlowRecord | undefined>;
+  resolve: (token: string) => Promise<TaskFlowRecord | undefined>;
+  getTaskSummary: (flowId: string) => Promise<TaskRegistrySummary | undefined>;
+};
+
+type AsyncTaskBinding<Runtime, Bound> = {
+  [Key in keyof Runtime]: Runtime[Key] extends (...args: infer Args) => unknown
+    ? (...args: Args) => Bound
+    : never;
+};
+
+/** Binding is synchronous; reads execute native SQLite queries in the shared worker. */
+export type PluginRuntimeAsyncTasks = {
+  runs: AsyncTaskBinding<PluginRuntimeTaskRuns, BoundAsyncTaskRunsRuntime>;
+  flows: AsyncTaskBinding<PluginRuntimeTaskFlows, BoundAsyncTaskFlowsRuntime>;
+  managedFlows: AsyncTaskBinding<PluginRuntimeTaskFlow, BoundAsyncManagedTaskFlowsRuntime>;
 };

--- a/src/plugins/runtime/types-core.ts
+++ b/src/plugins/runtime/types-core.ts
@@ -6,7 +6,7 @@ import type { SessionPluginJsonValue } from "../../config/sessions/types.js";
 import type { HeartbeatRunResult } from "../../infra/heartbeat-wake.js";
 import type { LogLevel } from "../../logging/levels.js";
 import type { MediaUnderstandingRuntime } from "../../media-understanding/runtime-types.js";
-import type { PluginRuntimeTaskFlows, PluginRuntimeTaskRuns } from "./runtime-tasks.types.js";
+import type { PluginRuntimeTasks } from "./runtime-tasks.types.js";
 
 type TtsRuntimeApi = typeof import("../../tts/runtime-api.js");
 type ListSpeechVoices = TtsRuntimeApi["listSpeechVoices"];
@@ -539,11 +539,7 @@ export type PluginRuntimeCore = {
       },
     ) => import("../../channels/message/ingress-drain.js").ChannelIngressDrain;
   };
-  tasks: {
-    runs: PluginRuntimeTaskRuns;
-    flows: PluginRuntimeTaskFlows;
-    managedFlows: import("./runtime-taskflow.types.js").PluginRuntimeTaskFlow;
-  };
+  tasks: PluginRuntimeTasks;
   llm: {
     complete: (params: LlmCompleteParams) => Promise<LlmCompleteResult>;
     acquireLocalService: (

--- a/src/state/openclaw-database-verify.impl.ts
+++ b/src/state/openclaw-database-verify.impl.ts
@@ -233,11 +233,11 @@ export function collectOpenClawDatabaseVerifyTargets(options: {
 }
 
 /** Reconfirm worker failures on live owners before quarantine and latching. */
-export function applyOpenClawDatabaseVerificationResults(options: {
+export async function applyOpenClawDatabaseVerificationResults(options: {
   env: NodeJS.ProcessEnv;
   results: readonly OpenClawDatabaseVerifyResult[];
   targets: readonly OpenClawDatabaseVerifyTarget[];
-}): void {
+}): Promise<void> {
   const targetByPath = new Map(options.targets.map((target) => [target.path, target]));
 
   for (const result of options.results) {
@@ -264,7 +264,7 @@ export function applyOpenClawDatabaseVerificationResults(options: {
     }
     const confirmation =
       target.kind === "state"
-        ? confirmOpenClawStateDatabaseIntegrity(result.path)
+        ? await confirmOpenClawStateDatabaseIntegrity(result.path)
         : confirmOpenClawAgentDatabaseIntegrity(result.path);
     if (confirmation.status === "healthy") {
       log.info("discarding stale database integrity verification result", {

--- a/src/state/openclaw-database-verify.shutdown.test.ts
+++ b/src/state/openclaw-database-verify.shutdown.test.ts
@@ -1,0 +1,98 @@
+import { ChildProcess } from "node:child_process";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferredCore } from "../shared/deferred.js";
+import type * as VerifierImplementation from "./openclaw-database-verify.impl.js";
+import { startOpenClawDatabaseIntegrityVerifier } from "./openclaw-database-verify.js";
+import type { OpenClawDatabaseVerifyResult } from "./openclaw-database-verify.worker.js";
+
+const mocks = vi.hoisted(() => ({
+  collectOpenClawDatabaseVerifyTargets:
+    vi.fn<typeof VerifierImplementation.collectOpenClawDatabaseVerifyTargets>(),
+  runDatabaseVerifyWorker: vi.fn<typeof VerifierImplementation.runDatabaseVerifyWorker>(),
+  terminateDatabaseVerifyWorker:
+    vi.fn<typeof VerifierImplementation.terminateDatabaseVerifyWorker>(),
+  applyOpenClawDatabaseVerificationResults:
+    vi.fn<typeof VerifierImplementation.applyOpenClawDatabaseVerificationResults>(),
+}));
+
+vi.mock("./openclaw-database-verify.impl.js", () => ({
+  ...mocks,
+  OPENCLAW_DATABASE_VERIFY_INITIAL_DELAY_MS: 1,
+  OPENCLAW_DATABASE_VERIFY_INTERVAL_MS: 100,
+}));
+
+describe("database verifier shutdown", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.resetAllMocks();
+    mocks.collectOpenClawDatabaseVerifyTargets.mockReturnValue([
+      { kind: "state", label: "synthetic state", path: "synthetic.sqlite" },
+    ]);
+    mocks.terminateDatabaseVerifyWorker.mockResolvedValue(undefined);
+    mocks.applyOpenClawDatabaseVerificationResults.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it.each(["fulfilled", "rejected"] as const)(
+    "joins %s result application after the child has exited",
+    async (outcome) => {
+      const application = createDeferredCore();
+      const entered = createDeferredCore();
+      mocks.runDatabaseVerifyWorker.mockResolvedValue([]);
+      mocks.applyOpenClawDatabaseVerificationResults.mockImplementation(() => {
+        entered.resolve();
+        return application.promise;
+      });
+      const verifier = startOpenClawDatabaseIntegrityVerifier({ env: {} });
+      await vi.advanceTimersByTimeAsync(1);
+      await entered.promise;
+      let stopped = false;
+      const stopping = verifier.stop().then(() => {
+        stopped = true;
+      });
+      try {
+        await vi.advanceTimersByTimeAsync(100);
+        expect(stopped).toBe(false);
+        expect(mocks.runDatabaseVerifyWorker).toHaveBeenCalledOnce();
+        expect(mocks.terminateDatabaseVerifyWorker).not.toHaveBeenCalled();
+      } finally {
+        if (outcome === "rejected") {
+          application.reject(new Error("synthetic confirmation failure"));
+        } else {
+          application.resolve();
+        }
+        await stopping;
+      }
+      expect(stopped).toBe(true);
+      expect(vi.getTimerCount()).toBe(0);
+    },
+  );
+
+  it("joins the running turn after termination and skips results received during stop", async () => {
+    const results = createDeferredCore<OpenClawDatabaseVerifyResult[]>();
+    const child = new ChildProcess();
+    mocks.runDatabaseVerifyWorker.mockImplementation((_targets, options) => {
+      options?.onWorker?.(child);
+      return results.promise;
+    });
+    const verifier = startOpenClawDatabaseIntegrityVerifier({ env: {} });
+    await vi.advanceTimersByTimeAsync(1);
+    let stopped = false;
+    const stopping = verifier.stop().then(() => {
+      stopped = true;
+    });
+    try {
+      await vi.advanceTimersByTimeAsync(100);
+      expect(mocks.terminateDatabaseVerifyWorker).toHaveBeenCalledWith(child);
+      expect(stopped).toBe(false);
+    } finally {
+      results.resolve([]);
+      await stopping;
+    }
+    expect(mocks.applyOpenClawDatabaseVerificationResults).not.toHaveBeenCalled();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});

--- a/src/state/openclaw-database-verify.test.ts
+++ b/src/state/openclaw-database-verify.test.ts
@@ -241,7 +241,7 @@ describe("OpenClaw database integrity verifier", () => {
       },
     ]);
 
-    applyOpenClawDatabaseVerificationResults({
+    await applyOpenClawDatabaseVerificationResults({
       env,
       results,
       targets,
@@ -289,7 +289,7 @@ describe("OpenClaw database integrity verifier", () => {
 
     fs.renameSync(agentPath, corruptArchivePath);
     fs.renameSync(healthyReplacementPath, agentPath);
-    applyOpenClawDatabaseVerificationResults({ env, results, targets });
+    await applyOpenClawDatabaseVerificationResults({ env, results, targets });
 
     expect(readOpenClawDatabaseQuarantine(agentPath, { env })).toBeUndefined();
     expect(openOpenClawAgentDatabase({ agentId: "worker-1", env }).db.isOpen).toBe(true);
@@ -312,7 +312,7 @@ describe("OpenClaw database integrity verifier", () => {
 
       fs.renameSync(agent.path, corruptArchivePath);
       fs.renameSync(healthyReplacementPath, agent.path);
-      applyOpenClawDatabaseVerificationResults({ env, results, targets });
+      await applyOpenClawDatabaseVerificationResults({ env, results, targets });
 
       expect(agent.db.isOpen).toBe(false);
       expect(readOpenClawDatabaseQuarantine(agent.path, { env })).toBeUndefined();
@@ -337,7 +337,7 @@ describe("OpenClaw database integrity verifier", () => {
 
       fs.renameSync(state.path, corruptArchivePath);
       fs.renameSync(healthyReplacementPath, state.path);
-      applyOpenClawDatabaseVerificationResults({ env, results, targets });
+      await applyOpenClawDatabaseVerificationResults({ env, results, targets });
 
       expect(state.db.isOpen).toBe(false);
       expect(readOpenClawDatabaseQuarantine(state.path, { env })).toBeUndefined();
@@ -357,7 +357,7 @@ describe("OpenClaw database integrity verifier", () => {
     ];
     const results = preparedVerificationResults(targets);
 
-    applyOpenClawDatabaseVerificationResults({ env, results, targets });
+    await applyOpenClawDatabaseVerificationResults({ env, results, targets });
 
     expect(readOpenClawDatabaseQuarantine(agentPath, { env })?.reason).toMatch(
       /missing from index unsafe_index_records_value/iu,
@@ -383,13 +383,13 @@ describe("OpenClaw database integrity verifier", () => {
     await expect(verifyOpenClawDatabases(targets)).resolves.toEqual([
       expect.objectContaining({ ok: true }),
     ]);
-    applyOpenClawDatabaseVerificationResults({ env, results, targets });
+    await applyOpenClawDatabaseVerificationResults({ env, results, targets });
 
     expect(readOpenClawDatabaseQuarantine(agentPath, { env })).toBeUndefined();
     expect(openOpenClawAgentDatabase({ agentId: "worker-1", env }).db.isOpen).toBe(true);
   });
 
-  it("rejects stale terminal results after draining healthy owners", () => {
+  it("rejects stale terminal results after draining healthy owners", async () => {
     const stateDir = tempDirs.make("openclaw-database-verify-live-stale-");
     const env = { OPENCLAW_STATE_DIR: stateDir };
     const state = openOpenClawStateDatabase({ env });
@@ -399,7 +399,7 @@ describe("OpenClaw database integrity verifier", () => {
       { kind: "agent", label: "OpenClaw agent database worker-1", path: agent.path },
     ];
 
-    applyOpenClawDatabaseVerificationResults({
+    await applyOpenClawDatabaseVerificationResults({
       env,
       results: targets.map((target) => ({
         path: target.path,
@@ -418,7 +418,7 @@ describe("OpenClaw database integrity verifier", () => {
     expect(openOpenClawAgentDatabase({ agentId: "worker-1", env }).db.isOpen).toBe(true);
   });
 
-  it("revalidates agent schema ownership after confirmation drains a pathname", () => {
+  it("revalidates agent schema ownership after confirmation drains a pathname", async () => {
     const stateDir = tempDirs.make("openclaw-database-verify-agent-revalidate-");
     const env = { OPENCLAW_STATE_DIR: stateDir };
     const agent = openOpenClawAgentDatabase({ agentId: "worker-1", env });
@@ -433,7 +433,7 @@ describe("OpenClaw database integrity verifier", () => {
       { kind: "agent", label: "OpenClaw agent database worker-1", path: agent.path },
     ];
 
-    applyOpenClawDatabaseVerificationResults({
+    await applyOpenClawDatabaseVerificationResults({
       env,
       results: [{ path: agent.path, ok: false, error: "stale terminal result", terminal: true }],
       targets,
@@ -709,7 +709,7 @@ describe("OpenClaw database integrity verifier", () => {
     },
   );
 
-  it("does not latch transient verifier errors", () => {
+  it("does not latch transient verifier errors", async () => {
     const stateDir = tempDirs.make("openclaw-database-verify-transient-");
     const env = { OPENCLAW_STATE_DIR: stateDir };
     const agentPath = openOpenClawAgentDatabase({ agentId: "worker-1", env }).path;
@@ -719,7 +719,7 @@ describe("OpenClaw database integrity verifier", () => {
       { kind: "agent", label: "OpenClaw agent database worker-1", path: agentPath },
     ];
 
-    applyOpenClawDatabaseVerificationResults({
+    await applyOpenClawDatabaseVerificationResults({
       env,
       results: [{ path: agentPath, ok: false, error: "Error: database is busy", terminal: false }],
       targets,

--- a/src/state/openclaw-database-verify.ts
+++ b/src/state/openclaw-database-verify.ts
@@ -16,11 +16,14 @@ export function startOpenClawDatabaseIntegrityVerifier(options: { env: NodeJS.Pr
   stop: () => Promise<void>;
 } {
   let activeWorker: ChildProcess | undefined;
+  let activeRun: Promise<void> | undefined;
   let stopped = false;
   let timer: ReturnType<typeof setTimeout> | undefined;
 
   const schedule = (delayMs: number) => {
-    timer = setTimeout(() => void run(), delayMs);
+    timer = setTimeout(() => {
+      activeRun = run();
+    }, delayMs);
     timer.unref?.();
   };
   const run = async () => {
@@ -34,7 +37,7 @@ export function startOpenClawDatabaseIntegrityVerifier(options: { env: NodeJS.Pr
           },
         });
         if (!stopped) {
-          applyOpenClawDatabaseVerificationResults({ ...options, results, targets });
+          await applyOpenClawDatabaseVerificationResults({ ...options, results, targets });
         }
       }
     } catch (error) {
@@ -57,10 +60,14 @@ export function startOpenClawDatabaseIntegrityVerifier(options: { env: NodeJS.Pr
         clearTimeout(timer);
         timer = undefined;
       }
-      if (activeWorker) {
-        await terminateDatabaseVerifyWorker(activeWorker);
+      try {
+        if (activeWorker) {
+          await terminateDatabaseVerifyWorker(activeWorker);
+        }
+      } finally {
+        // Worker exit can precede async confirmation and result application.
+        await activeRun;
       }
-      activeWorker = undefined;
     },
   };
 }

--- a/src/state/openclaw-state-db-async-lifecycle.test.ts
+++ b/src/state/openclaw-state-db-async-lifecycle.test.ts
@@ -1,4 +1,4 @@
-import { linkSync, writeFileSync } from "node:fs";
+import { existsSync, linkSync, mkdirSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
@@ -11,6 +11,7 @@ import {
   acquireOpenClawStateDatabaseFileExclusion,
   captureOpenClawStateDatabaseReadAdmission,
   closeOpenClawStateDatabaseAsync,
+  closeOpenClawStateDatabaseByPath,
   closeOpenClawStateDatabaseByPathAsync,
   registerOpenClawStateDatabaseAsyncResource,
 } from "./openclaw-state-db-cache.js";
@@ -29,6 +30,41 @@ function databasePath(name = "state") {
 }
 
 describe("canonical shared-state resource drainage", () => {
+  it.each(["missing", "directory"] as const)(
+    "keeps unrelated owners while closing a never-admitted %s path",
+    async (kind) => {
+      const pathname = databasePath(kind);
+      if (kind === "directory") {
+        mkdirSync(pathname);
+        expect(() => captureOpenClawStateDatabaseReadAdmission(pathname)).toThrow(/regular file/);
+        expect(() => openOpenClawStateDatabase({ path: pathname })).toThrow(
+          /EISDIR|directory|open database/u,
+        );
+      }
+      const owner = openOpenClawStateDatabase({ path: databasePath("retained") });
+      const admission = captureOpenClawStateDatabaseReadAdmission(owner.path);
+      const unregister = registerOpenClawStateDatabaseAsyncResource({
+        async close(identity) {
+          if (identity === undefined) {
+            throw new Error("Unexpected global resource drain");
+          }
+          if (identity.key === admission.identity.key) {
+            owner.db.close();
+          }
+        },
+      });
+      try {
+        expect(closeOpenClawStateDatabaseByPath(pathname)).toBe(false);
+        expect(await closeOpenClawStateDatabaseByPathAsync(pathname)).toBe(false);
+        expect(owner.db.isOpen).toBe(true);
+        admission.assertCurrent();
+        expect(existsSync(pathname)).toBe(kind === "directory");
+      } finally {
+        unregister();
+      }
+    },
+  );
+
   it("keeps first-creation admission when an alias supplies the physical identity", async () => {
     const lifecycle = createOpenClawStateDatabaseAsyncLifecycle();
     const pathname = databasePath();

--- a/src/state/openclaw-state-db-async-lifecycle.test.ts
+++ b/src/state/openclaw-state-db-async-lifecycle.test.ts
@@ -1,0 +1,236 @@
+import { linkSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import type { DatabasePathIdentity } from "../infra/sqlite-worker-identity.js";
+import * as databaseIdentity from "../infra/sqlite-worker-identity.js";
+import { createDeferredCore } from "../shared/deferred.js";
+import { drainGlobalSingletonLifecycleState } from "../shared/global-singleton.js";
+import { createOpenClawStateDatabaseAsyncLifecycle } from "./openclaw-state-db-async-lifecycle.js";
+import {
+  acquireOpenClawStateDatabaseFileExclusion,
+  captureOpenClawStateDatabaseReadAdmission,
+  closeOpenClawStateDatabaseAsync,
+  closeOpenClawStateDatabaseByPathAsync,
+  registerOpenClawStateDatabaseAsyncResource,
+} from "./openclaw-state-db-cache.js";
+import { openOpenClawStateReadConnection } from "./openclaw-state-db-read-connection.js";
+import { openOpenClawStateDatabase } from "./openclaw-state-db.js";
+
+const dirs = useAutoCleanupTempDirTracker((cleanup) =>
+  afterEach(async () => {
+    await closeOpenClawStateDatabaseAsync();
+    cleanup();
+  }),
+);
+
+function databasePath(name = "state") {
+  return path.join(dirs.make("openclaw-async-drain-"), `${name}.sqlite`);
+}
+
+describe("canonical shared-state resource drainage", () => {
+  it("keeps first-creation admission when an alias supplies the physical identity", async () => {
+    const lifecycle = createOpenClawStateDatabaseAsyncLifecycle();
+    const pathname = databasePath();
+    const alias = path.join(path.dirname(pathname), "created-alias.sqlite");
+    const original = lifecycle.capture(pathname);
+    expect(original.identity.key).toMatch(/^path:/);
+    writeFileSync(pathname, "");
+    linkSync(pathname, alias);
+    const observed = lifecycle.capture(alias);
+    expect(original.identity.key).toBe(observed.identity.key);
+    lifecycle.publish(pathname);
+    original.assertCurrent();
+    observed.assertCurrent();
+    const closing = lifecycle.close(alias, () => false);
+    expect(original.assertCurrent).toThrow(/admission is closed/);
+    await closing;
+    expect(original.assertCurrent).toThrow(/admission changed/);
+    expect(observed.assertCurrent).toThrow(/admission changed/);
+  });
+
+  it("shares recorded admission and closes native owners for one physical database", async () => {
+    const pathname = databasePath();
+    const original = openOpenClawStateDatabase({ path: pathname });
+    const alias = path.join(path.dirname(pathname), "alias.sqlite");
+    linkSync(pathname, alias);
+    const originalAdmission = captureOpenClawStateDatabaseReadAdmission(pathname);
+    const aliasAdmission = captureOpenClawStateDatabaseReadAdmission(alias);
+    expect(aliasAdmission.identity.key).toBe(originalAdmission.identity.key);
+    expect(aliasAdmission.databasePath).toBe(alias);
+    const identityReads = vi.spyOn(databaseIdentity, "readDatabasePathIdentitySync");
+    captureOpenClawStateDatabaseReadAdmission(pathname).assertCurrent();
+    captureOpenClawStateDatabaseReadAdmission(alias).assertCurrent();
+    expect(identityReads).not.toHaveBeenCalled();
+    identityReads.mockRestore();
+    const closed = vi.fn(async (_identity?: DatabasePathIdentity) => {});
+    const unregister = registerOpenClawStateDatabaseAsyncResource({ close: closed });
+    try {
+      const closing = closeOpenClawStateDatabaseByPathAsync(alias);
+      expect(originalAdmission.assertCurrent).toThrow(/admission is closed/);
+      expect(aliasAdmission.assertCurrent).toThrow(/admission is closed/);
+      await closing;
+      expect(closed).toHaveBeenCalledWith(originalAdmission.identity);
+      expect(original.db.isOpen).toBe(false);
+    } finally {
+      unregister();
+    }
+  });
+
+  it.each(["path", "all", "restart"] as const)(
+    "joins the native reader before %s retirement and invalidates old admissions",
+    async (scope) => {
+      const pathname = databasePath();
+      const admitted = captureOpenClawStateDatabaseReadAdmission(pathname);
+      const writer = openOpenClawStateDatabase({ path: pathname });
+      // Successful native admission does not invalidate its own captured generation.
+      admitted.assertCurrent();
+      const reader = openOpenClawStateReadConnection(pathname, pathname);
+      const entered = createDeferredCore();
+      const finish = createDeferredCore();
+      const unregister = registerOpenClawStateDatabaseAsyncResource({
+        async close(target) {
+          if (target !== undefined && target.key !== admitted.identity.key) {
+            return;
+          }
+          entered.resolve();
+          await finish.promise;
+          reader.close();
+        },
+      });
+      const closing =
+        scope === "path"
+          ? closeOpenClawStateDatabaseByPathAsync(pathname)
+          : scope === "all"
+            ? closeOpenClawStateDatabaseAsync()
+            : drainGlobalSingletonLifecycleState("restart");
+      try {
+        expect(admitted.assertCurrent).toThrow(/admission is closed/);
+        await entered.promise;
+        expect(writer.db.isOpen).toBe(true);
+        expect(reader.database.db.isOpen).toBe(true);
+        finish.resolve();
+        await closing;
+        expect(reader.database.db.isOpen).toBe(false);
+        expect(writer.db.isOpen).toBe(false);
+        expect(admitted.assertCurrent).toThrow(/admission changed/);
+        captureOpenClawStateDatabaseReadAdmission(pathname).assertCurrent();
+        const reopened = openOpenClawStateDatabase({ path: pathname });
+        expect(reopened.db.isOpen).toBe(true);
+      } finally {
+        finish.resolve();
+        await closing;
+        unregister();
+      }
+    },
+  );
+
+  it("retains an unregistered multipath resource after failure and retries only requested paths", async () => {
+    const first = openOpenClawStateDatabase({ path: databasePath("first") });
+    const second = openOpenClawStateDatabase({ path: databasePath("second") });
+    const firstReader = openOpenClawStateReadConnection(first.path, first.path);
+    const secondReader = openOpenClawStateReadConnection(second.path, second.path);
+    const firstIdentity = captureOpenClawStateDatabaseReadAdmission(first.path).identity;
+    const secondIdentity = captureOpenClawStateDatabaseReadAdmission(second.path).identity;
+    const failure = new Error("reader close incomplete");
+    let failFirst = true;
+    const close = vi.fn(async (target?: DatabasePathIdentity) => {
+      if (target === undefined || target.key === firstIdentity.key) {
+        if (failFirst) {
+          throw failure;
+        }
+        firstReader.close();
+      }
+      if (target === undefined || target.key === secondIdentity.key) {
+        secondReader.close();
+      }
+    });
+    const unregister = registerOpenClawStateDatabaseAsyncResource({ close });
+    try {
+      await expect(closeOpenClawStateDatabaseByPathAsync(first.path)).rejects.toBe(failure);
+      unregister();
+      expect(first.db.isOpen).toBe(true);
+      expect(firstReader.database.db.isOpen).toBe(true);
+      expect(() => captureOpenClawStateDatabaseReadAdmission(first.path)).toThrow(/closed/);
+      captureOpenClawStateDatabaseReadAdmission(second.path).assertCurrent();
+      await closeOpenClawStateDatabaseByPathAsync(second.path);
+      expect(close).toHaveBeenLastCalledWith(secondIdentity);
+      expect(second.db.isOpen).toBe(false);
+      expect(secondReader.database.db.isOpen).toBe(false);
+      expect(firstReader.database.db.isOpen).toBe(true);
+      failFirst = false;
+      await closeOpenClawStateDatabaseByPathAsync(first.path);
+      expect(firstReader.database.db.isOpen).toBe(false);
+      expect(first.db.isOpen).toBe(false);
+      captureOpenClawStateDatabaseReadAdmission(first.path).assertCurrent();
+    } finally {
+      failFirst = false;
+      await closeOpenClawStateDatabaseAsync();
+      unregister();
+    }
+  });
+
+  it("coalesces pending closes and retains the read seal after a native close failure", async () => {
+    const owner = openOpenClawStateDatabase({ path: databasePath() });
+    const nativeClose = owner.db.close.bind(owner.db);
+    const failure = new Error("native close incomplete");
+    const close = vi.spyOn(owner.db, "close").mockImplementationOnce(() => {
+      throw failure;
+    });
+    try {
+      const first = closeOpenClawStateDatabaseByPathAsync(owner.path);
+      expect(closeOpenClawStateDatabaseByPathAsync(owner.path)).toBe(first);
+      await expect(first).rejects.toBe(failure);
+      expect(owner.db.isOpen).toBe(true);
+      expect(() => captureOpenClawStateDatabaseReadAdmission(owner.path)).toThrow(/closed/);
+      close.mockImplementation(nativeClose);
+      await closeOpenClawStateDatabaseByPathAsync(owner.path);
+      expect(owner.db.isOpen).toBe(false);
+      captureOpenClawStateDatabaseReadAdmission(owner.path).assertCurrent();
+    } finally {
+      close.mockRestore();
+      await closeOpenClawStateDatabaseByPathAsync(owner.path);
+    }
+  });
+
+  it("keeps worker admission sealed through exclusion and native binding until release", async () => {
+    const owner = openOpenClawStateDatabase({ path: databasePath() });
+    const identity = captureOpenClawStateDatabaseReadAdmission(owner.path).identity;
+    const reader = openOpenClawStateReadConnection(owner.path, owner.path);
+    const entered = createDeferredCore();
+    const finish = createDeferredCore();
+    const unregister = registerOpenClawStateDatabaseAsyncResource({
+      async close(target) {
+        if (target === undefined || target.key === identity.key) {
+          entered.resolve();
+          await finish.promise;
+          reader.close();
+        }
+      },
+    });
+    const acquiring = acquireOpenClawStateDatabaseFileExclusion(owner.path);
+    let exclusion: Awaited<typeof acquiring> | undefined;
+    try {
+      expect(() => captureOpenClawStateDatabaseReadAdmission(owner.path)).toThrow(/closed/);
+      await entered.promise;
+      expect(reader.database.db.isOpen).toBe(true);
+      finish.resolve();
+      exclusion = await acquiring;
+      expect(reader.database.db.isOpen).toBe(false);
+      await exclusion.bindCaptured(exclusion.assertCurrent, () => {
+        openOpenClawStateDatabase({ path: owner.path });
+        expect(() => captureOpenClawStateDatabaseReadAdmission(owner.path)).toThrow(/closed/);
+        return undefined;
+      });
+      expect(() => captureOpenClawStateDatabaseReadAdmission(owner.path)).toThrow(/closed/);
+      exclusion.release();
+      exclusion = undefined;
+      captureOpenClawStateDatabaseReadAdmission(owner.path).assertCurrent();
+    } finally {
+      finish.resolve();
+      exclusion ??= await acquiring;
+      exclusion.release();
+      unregister();
+    }
+  });
+});

--- a/src/state/openclaw-state-db-async-lifecycle.ts
+++ b/src/state/openclaw-state-db-async-lifecycle.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import { createSqliteLifecycleAggregateError } from "../infra/sqlite-coordinator.js";
 import {
+  inspectDatabasePathIdentitySync,
   readDatabasePathIdentitySync,
   type DatabasePathIdentity,
 } from "../infra/sqlite-worker-identity.js";
@@ -48,13 +49,13 @@ export function createOpenClawStateDatabaseAsyncLifecycle() {
       throw new Error("OpenClaw state database read admission is closed");
     }
   };
-  const resolve = (pathname: string): IdentityRecord => {
+  const resolve = (pathname: string, preparedIdentity?: DatabasePathIdentity): IdentityRecord => {
     const resolvedPath = path.resolve(pathname);
     const cached = known(resolvedPath);
     if (cached) {
       return cached;
     }
-    const identity = readDatabasePathIdentitySync(resolvedPath);
+    const identity = preparedIdentity ?? readDatabasePathIdentitySync(resolvedPath);
     let record = records.get(identity.key);
     if (!record && identity.key.startsWith("file:")) {
       // A first creation can become visible through an alias before publication.
@@ -86,6 +87,14 @@ export function createOpenClawStateDatabaseAsyncLifecycle() {
     record.paths.add(resolvedPath).add(identity.canonicalPath);
     return record;
   };
+  const resolveForNative = (pathname: string): IdentityRecord | undefined => {
+    const cached = known(pathname);
+    if (cached) {
+      return cached;
+    }
+    const identity = inspectDatabasePathIdentitySync(pathname);
+    return identity ? resolve(pathname, identity) : undefined;
+  };
   const invalidate = (record?: IdentityRecord) => {
     for (const current of record ? [record] : records.values()) {
       current.generation = {};
@@ -104,8 +113,8 @@ export function createOpenClawStateDatabaseAsyncLifecycle() {
   };
 
   return {
-    identity(pathname: string): DatabasePathIdentity {
-      return resolve(pathname).identity;
+    identity(pathname: string): DatabasePathIdentity | undefined {
+      return resolveForNative(pathname)?.identity;
     },
     knownIdentity(pathname: string): DatabasePathIdentity | undefined {
       return known(pathname)?.identity;
@@ -185,7 +194,12 @@ export function createOpenClawStateDatabaseAsyncLifecycle() {
       pathname: string | undefined,
       retireNative: (identity?: DatabasePathIdentity) => boolean,
     ): Promise<boolean> {
-      const record = pathname === undefined ? undefined : resolve(pathname);
+      const record = pathname === undefined ? undefined : resolveForNative(pathname);
+      if (pathname !== undefined && !record) {
+        // No worker could enter a non-file target. Retire only the caller's exact
+        // native path; undefined must not reach resource.close as a global drain.
+        return Promise.resolve(retireNative());
+      }
       let attempt = attempts.get(record);
       if (attempt?.pending) {
         return attempt.pending;

--- a/src/state/openclaw-state-db-async-lifecycle.ts
+++ b/src/state/openclaw-state-db-async-lifecycle.ts
@@ -1,0 +1,259 @@
+import path from "node:path";
+import { createSqliteLifecycleAggregateError } from "../infra/sqlite-coordinator.js";
+import {
+  readDatabasePathIdentitySync,
+  type DatabasePathIdentity,
+} from "../infra/sqlite-worker-identity.js";
+
+export type OpenClawStateDatabaseReadAdmission = {
+  readonly databasePath: string;
+  readonly identity: DatabasePathIdentity;
+  assertCurrent: () => void;
+};
+export type OpenClawStateDatabaseAsyncResource = {
+  close: (identity?: DatabasePathIdentity) => Promise<void>;
+};
+
+type IdentityRecord = {
+  identity: DatabasePathIdentity;
+  paths: Set<string>;
+  generation: object;
+};
+type ReadSeal = { record?: IdentityRecord };
+type CloseAttempt = {
+  seal: ReadSeal;
+  retained: Set<OpenClawStateDatabaseAsyncResource>;
+  pending?: Promise<boolean>;
+};
+
+/** The cache owns physical identity and admission across drainage and file exclusion. */
+export function createOpenClawStateDatabaseAsyncLifecycle() {
+  const resources = new Set<OpenClawStateDatabaseAsyncResource>();
+  const records = new Map<string, IdentityRecord>();
+  const seals = new Set<ReadSeal>();
+  const attempts = new Map<IdentityRecord | undefined, CloseAttempt>();
+  let tail = Promise.resolve();
+
+  const known = (pathname: string) => {
+    const resolvedPath = path.resolve(pathname);
+    return [...records.values()].find((record) => record.paths.has(resolvedPath));
+  };
+  const overlaps = (left: IdentityRecord, right: IdentityRecord) =>
+    left.identity.key === right.identity.key ||
+    [...left.paths].some((pathname) => right.paths.has(pathname));
+  const isSealed = (record: IdentityRecord) =>
+    [...seals].some((held) => held.record === undefined || overlaps(held.record, record));
+  const assertOpen = (record: IdentityRecord) => {
+    if (isSealed(record)) {
+      throw new Error("OpenClaw state database read admission is closed");
+    }
+  };
+  const resolve = (pathname: string): IdentityRecord => {
+    const resolvedPath = path.resolve(pathname);
+    const cached = known(resolvedPath);
+    if (cached) {
+      return cached;
+    }
+    const identity = readDatabasePathIdentitySync(resolvedPath);
+    let record = records.get(identity.key);
+    if (!record && identity.key.startsWith("file:")) {
+      // A first creation can become visible through an alias before publication.
+      // Reconcile unresolved creation facts here, never on warmed captures.
+      record = [...records.values()].find((candidate) => {
+        if (!candidate.identity.key.startsWith("path:")) {
+          return false;
+        }
+        try {
+          return (
+            readDatabasePathIdentitySync(candidate.identity.canonicalPath).key === identity.key
+          );
+        } catch {
+          // Unpublished prospective paths have no admitted worker. Keep their
+          // records without making unrelated identity lookup failures contagious.
+          return false;
+        }
+      });
+      if (record) {
+        records.delete(record.identity.key);
+        record.identity = identity;
+        records.set(identity.key, record);
+      }
+    }
+    if (!record) {
+      record = { identity, paths: new Set(), generation: {} };
+      records.set(identity.key, record);
+    }
+    record.paths.add(resolvedPath).add(identity.canonicalPath);
+    return record;
+  };
+  const invalidate = (record?: IdentityRecord) => {
+    for (const current of record ? [record] : records.values()) {
+      current.generation = {};
+    }
+  };
+  const seal = (record?: IdentityRecord): ReadSeal => {
+    invalidate(record);
+    const held = { record };
+    seals.add(held);
+    return held;
+  };
+  const forget = (record: IdentityRecord) => {
+    if (!isSealed(record) && records.get(record.identity.key) === record) {
+      records.delete(record.identity.key);
+    }
+  };
+
+  return {
+    identity(pathname: string): DatabasePathIdentity {
+      return resolve(pathname).identity;
+    },
+    knownIdentity(pathname: string): DatabasePathIdentity | undefined {
+      return known(pathname)?.identity;
+    },
+    publish(pathname: string): DatabasePathIdentity {
+      const resolvedPath = path.resolve(pathname);
+      const identity = readDatabasePathIdentitySync(resolvedPath);
+      const previous = known(resolvedPath);
+      let record = records.get(identity.key);
+      if (previous && previous.identity.key !== identity.key) {
+        if (previous.identity.key.startsWith("path:") && !record) {
+          // First canonical creation binds the same captured admission to its file.
+          records.delete(previous.identity.key);
+          previous.identity = identity;
+          records.set(identity.key, previous);
+          record = previous;
+        } else {
+          invalidate(previous);
+          forget(previous);
+        }
+      }
+      if (!record) {
+        record = { identity, paths: new Set(), generation: {} };
+        records.set(identity.key, record);
+      }
+      record.paths.add(resolvedPath).add(identity.canonicalPath);
+      return identity;
+    },
+    invalidate(pathname?: string): void {
+      if (pathname === undefined) {
+        invalidate();
+      } else {
+        const record = known(pathname);
+        if (record) {
+          invalidate(record);
+        }
+      }
+    },
+    register(resource: OpenClawStateDatabaseAsyncResource): () => void {
+      resources.add(resource);
+      return () => {
+        resources.delete(resource);
+      };
+    },
+    capture(pathname: string): OpenClawStateDatabaseReadAdmission {
+      const databasePath = path.resolve(pathname);
+      const record = resolve(databasePath);
+      assertOpen(record);
+      const generation = record.generation;
+      return {
+        databasePath,
+        get identity() {
+          return record.identity;
+        },
+        assertCurrent() {
+          assertOpen(record);
+          if (records.get(record.identity.key) !== record || record.generation !== generation) {
+            throw new Error("OpenClaw state database read admission changed");
+          }
+        },
+      };
+    },
+    holdExclusion(pathname: string): () => void {
+      const record = resolve(pathname);
+      const held = seal(record);
+      return () => {
+        seals.delete(held);
+        // Replacement can leave a new physical record sharing this logical path.
+        for (const current of records.values()) {
+          if (overlaps(record, current)) {
+            forget(current);
+          }
+        }
+      };
+    },
+    close(
+      pathname: string | undefined,
+      retireNative: (identity?: DatabasePathIdentity) => boolean,
+    ): Promise<boolean> {
+      const record = pathname === undefined ? undefined : resolve(pathname);
+      let attempt = attempts.get(record);
+      if (attempt?.pending) {
+        return attempt.pending;
+      }
+      if (!attempt) {
+        attempt = { seal: seal(record), retained: new Set() };
+        attempts.set(record, attempt);
+      }
+      const current = attempt;
+      const pending = tail.then(async () => {
+        const closing = new Set([...resources, ...current.retained]);
+        for (const entry of attempts.values()) {
+          for (const resource of entry.retained) {
+            closing.add(resource);
+          }
+        }
+        const errors: unknown[] = [];
+        await Promise.all(
+          [...closing].map(async (resource) => {
+            try {
+              await resource.close(record?.identity);
+              current.retained.delete(resource);
+            } catch (error) {
+              // Unregistration cannot abandon a resource whose close failed.
+              current.retained.add(resource);
+              errors.push(error);
+            }
+          }),
+        );
+        if (errors.length === 1) {
+          throw errors[0];
+        }
+        if (errors.length > 1) {
+          throw createSqliteLifecycleAggregateError(
+            errors,
+            "OpenClaw state resource drainage failed",
+            errors[0],
+          );
+        }
+        const retired = retireNative(record?.identity);
+        attempts.delete(record);
+        seals.delete(current.seal);
+        if (record === undefined) {
+          // A successful whole-cache retry also discharges prior failed path closes.
+          for (const [key, entry] of attempts) {
+            if (!entry.pending) {
+              attempts.delete(key);
+              seals.delete(entry.seal);
+            }
+          }
+          for (const entry of records.values()) {
+            forget(entry);
+          }
+        } else {
+          forget(record);
+        }
+        return retired;
+      });
+      current.pending = pending;
+      tail = pending.then(
+        () => undefined,
+        () => undefined,
+      );
+      void pending.catch(() => {
+        // Keep the seal and failed resource custody, while allowing an explicit retry.
+        current.pending = undefined;
+      });
+      return pending;
+    },
+  };
+}

--- a/src/state/openclaw-state-db-cache.retention.test.ts
+++ b/src/state/openclaw-state-db-cache.retention.test.ts
@@ -7,13 +7,14 @@ const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 it("releases closed shared database wrappers after path and global retirement", () => {
   const stateDir = tempDirs.make("openclaw-state-retention-");
   const moduleUrl = new URL("./openclaw-state-db.ts", import.meta.url).href;
+  const cacheModuleUrl = new URL("./openclaw-state-db-cache.ts", import.meta.url).href;
   const script = `
     import assert from "node:assert/strict";
     import {
       closeOpenClawStateDatabase,
-      closeOpenClawStateDatabaseByPath,
       openOpenClawStateDatabase,
     } from ${JSON.stringify(moduleUrl)};
+    import { closeOpenClawStateDatabaseByPath } from ${JSON.stringify(cacheModuleUrl)};
 
     function retire(byPath) {
       const owner = openOpenClawStateDatabase();

--- a/src/state/openclaw-state-db-cache.ts
+++ b/src/state/openclaw-state-db-cache.ts
@@ -21,14 +21,21 @@ import {
 import { createSqliteTerminalOpenLatch } from "../infra/sqlite-terminal-open-latch.js";
 import { isSqliteSchemaVersionError } from "../infra/sqlite-user-version.js";
 import { registerSqliteCacheExitClose } from "../infra/sqlite-wal.js";
+import type { DatabasePathIdentity } from "../infra/sqlite-worker-identity.js";
 import {
   acquireStateDatabaseCoordinator,
   acquireStateDatabaseHandleExclusion,
 } from "../infra/state-database-coordinator.js";
+import { resolveGlobalSingleton } from "../shared/global-singleton.js";
 import {
   createOpenClawDatabaseVerificationError,
   readOpenClawDatabaseQuarantine,
 } from "./openclaw-quarantine-store.js";
+import {
+  createOpenClawStateDatabaseAsyncLifecycle,
+  type OpenClawStateDatabaseAsyncResource,
+  type OpenClawStateDatabaseReadAdmission,
+} from "./openclaw-state-db-async-lifecycle.js";
 import {
   OPENCLAW_SQLITE_BUSY_TIMEOUT_MS,
   type OpenClawStateDatabase,
@@ -36,7 +43,6 @@ import {
 import { closeTrackedStateDatabase } from "./openclaw-state-db-handle.js";
 import { assertSupportedStateSchemaVersion } from "./openclaw-state-db-schema-version.js";
 
-const cachedDatabases = new Map<string, OpenClawStateDatabase>();
 type StateDatabaseHandle = Pick<OpenClawStateDatabase, "db" | "path"> &
   Partial<Pick<OpenClawStateDatabase, "walMaintenance">> & {
     afterClose?: () => undefined;
@@ -44,26 +50,82 @@ type StateDatabaseHandle = Pick<OpenClawStateDatabase, "db" | "path"> &
 type OpenClawStateDatabaseCloseOptions = NonNullable<
   Parameters<OpenClawStateDatabase["walMaintenance"]["close"]>[0]
 > & { busyTimeoutMs?: number };
-// Failed native closes and dependent cleanup stay disposal-owned, never cache hits.
-const retainedDatabaseHandles = new Map<DatabaseSync, StateDatabaseHandle>();
-let unregisterRetainedExitClose: (() => void) | undefined;
-// Statements retain their native database; key by the plain lifecycle owner so
-// removing that owner releases the statement instead of rooting its own weak key.
-const cachedDataVersionStatements = new WeakMap<
-  OpenClawStateDatabase,
-  ReturnType<DatabaseSync["prepare"]>
->();
-const cachedDataVersions = new WeakMap<DatabaseSync, number>();
 type OpenClawStateDatabaseLifecycleEvent =
-  | { kind: "opened"; database: OpenClawStateDatabase }
-  | { kind: "closed"; path: string }
-  | { kind: "open-error"; path: string; error: unknown };
-const databaseLifecycleListeners = new Set<(event: OpenClawStateDatabaseLifecycleEvent) => void>();
+  | { kind: "opened"; database: OpenClawStateDatabase; identity: DatabasePathIdentity }
+  | { kind: "closed"; path: string; identity: DatabasePathIdentity }
+  | { kind: "open-error"; path: string; identity?: DatabasePathIdentity; error: unknown };
+type StateDatabaseLifecycle = {
+  cachedDatabases: Map<string, OpenClawStateDatabase>;
+  retainedDatabaseHandles: Map<DatabaseSync, StateDatabaseHandle>;
+  unregisterRetainedExitClose?: () => void;
+  cachedDataVersionStatements: WeakMap<OpenClawStateDatabase, ReturnType<DatabaseSync["prepare"]>>;
+  cachedDataVersions: WeakMap<DatabaseSync, number>;
+  databaseIdentities: WeakMap<DatabaseSync, DatabasePathIdentity>;
+  databaseLifecycleListeners: Set<(event: OpenClawStateDatabaseLifecycleEvent) => void>;
+  terminalOpenLatch: ReturnType<typeof createSqliteTerminalOpenLatch>;
+  asyncResources: ReturnType<typeof createOpenClawStateDatabaseAsyncLifecycle>;
+};
+const stateDatabaseLifecycle = resolveGlobalSingleton<StateDatabaseLifecycle>(
+  Symbol.for("openclaw.stateDatabaseLifecycle"),
+  () => ({
+    cachedDatabases: new Map<string, OpenClawStateDatabase>(),
+    retainedDatabaseHandles: new Map<DatabaseSync, StateDatabaseHandle>(),
+    unregisterRetainedExitClose: undefined,
+    // The plain owner key must not retain the statement's own native database.
+    cachedDataVersionStatements: new WeakMap<
+      OpenClawStateDatabase,
+      ReturnType<DatabaseSync["prepare"]>
+    >(),
+    cachedDataVersions: new WeakMap<DatabaseSync, number>(),
+    databaseIdentities: new WeakMap<DatabaseSync, DatabasePathIdentity>(),
+    databaseLifecycleListeners: new Set<(event: OpenClawStateDatabaseLifecycleEvent) => void>(),
+    terminalOpenLatch: createSqliteTerminalOpenLatch({
+      closeByPath: (pathname) => {
+        const cached = cachedDatabases.get(pathname);
+        if (cached) {
+          evictCachedOpenClawStateDatabase(cached);
+        }
+      },
+    }),
+    asyncResources: createOpenClawStateDatabaseAsyncLifecycle(),
+  }),
+  () => closeOpenClawStateDatabaseAsync(),
+);
+const {
+  cachedDatabases,
+  retainedDatabaseHandles,
+  cachedDataVersionStatements,
+  cachedDataVersions,
+  databaseIdentities,
+  databaseLifecycleListeners,
+  terminalOpenLatch,
+  asyncResources,
+} = stateDatabaseLifecycle;
 
 function notifyOpenClawStateDatabaseLifecycle(event: OpenClawStateDatabaseLifecycleEvent): void {
+  const notification =
+    event.kind === "open-error"
+      ? { ...event, identity: event.identity ?? asyncResources.knownIdentity(event.path) }
+      : event;
   for (const listener of databaseLifecycleListeners) {
-    listener(event);
+    listener(notification);
   }
+}
+
+function notifyOpenClawStateDatabaseClosed(database: StateDatabaseHandle): void {
+  notifyOpenClawStateDatabaseLifecycle({
+    kind: "closed",
+    path: database.path,
+    identity: requireOpenClawStateDatabaseIdentity(database),
+  });
+}
+
+function requireOpenClawStateDatabaseIdentity(database: StateDatabaseHandle): DatabasePathIdentity {
+  const identity = databaseIdentities.get(database.db);
+  if (!identity) {
+    throw new Error("Published shared-state owner has no recorded database identity");
+  }
+  return identity;
 }
 
 function readSqliteDataVersion(database: OpenClawStateDatabase): number {
@@ -87,7 +149,11 @@ export function registerOpenClawStateDatabaseLifecycleListener(
   databaseLifecycleListeners.add(listener);
   for (const database of cachedDatabases.values()) {
     if (database.db.isOpen) {
-      listener({ kind: "opened", database });
+      listener({
+        kind: "opened",
+        database,
+        identity: requireOpenClawStateDatabaseIdentity(database),
+      });
     }
   }
   return () => databaseLifecycleListeners.delete(listener);
@@ -125,12 +191,14 @@ function closeOpenClawStateDatabaseHandle(
   }
   if (database.db.isOpen || cleanupPending) {
     retainedDatabaseHandles.set(database.db, database);
-    unregisterRetainedExitClose ??= registerSqliteCacheExitClose(closeOpenClawStateDatabase);
+    stateDatabaseLifecycle.unregisterRetainedExitClose ??= registerSqliteCacheExitClose(
+      closeOpenClawStateDatabase,
+    );
   } else {
     retainedDatabaseHandles.delete(database.db);
     if (retainedDatabaseHandles.size === 0) {
-      unregisterRetainedExitClose?.();
-      unregisterRetainedExitClose = undefined;
+      stateDatabaseLifecycle.unregisterRetainedExitClose?.();
+      stateDatabaseLifecycle.unregisterRetainedExitClose = undefined;
     }
   }
   // A failed native close retains physical custody, never a successful cache hit.
@@ -146,8 +214,9 @@ function evictCachedOpenClawStateDatabase(database: OpenClawStateDatabase): bool
   }
   // Remove ownership before cleanup. A poisoned native handle can reject close,
   // but it must never remain discoverable as the process-wide shared handle.
+  asyncResources.invalidate(database.path);
   cachedDatabases.delete(database.path);
-  notifyOpenClawStateDatabaseLifecycle({ kind: "closed", path: database.path });
+  notifyOpenClawStateDatabaseClosed(database);
   // A poisoned cache owner is not the database lifecycle owner. PASSIVE avoids
   // waiting on readers or resetting recovery frames another connection needs.
   closeOpenClawStateDatabaseHandle(database, { checkpointMode: "PASSIVE" });
@@ -162,21 +231,14 @@ function evictOpenClawStateDatabaseAfterCorruption(
   return isSqliteCorruptionError(error) && evictCachedOpenClawStateDatabase(database);
 }
 
-const terminalOpenLatch = createSqliteTerminalOpenLatch({
-  closeByPath: (pathname) => {
-    const cached = cachedDatabases.get(pathname);
-    if (cached) {
-      evictCachedOpenClawStateDatabase(cached);
-    }
-  },
-});
-
 /** Publish a fully opened handle and bind query corruption to its exact cache owner. */
 function publishOpenClawStateDatabase(database: OpenClawStateDatabase): OpenClawStateDatabase {
   const { db, path: pathname } = database;
+  const identity = asyncResources.publish(pathname);
+  databaseIdentities.set(db, identity);
   cachedDataVersions.set(db, readSqliteDataVersion(database));
   cachedDatabases.set(pathname, database);
-  notifyOpenClawStateDatabaseLifecycle({ kind: "opened", database });
+  notifyOpenClawStateDatabaseLifecycle({ kind: "opened", database, identity });
   registerNodeSqliteKyselyQueryErrorHandler(db, (error) => {
     // Write transactions own rollback and evict at their outer boundary.
     if (!db.isTransaction && isSqliteCorruptionError(error)) {
@@ -244,8 +306,9 @@ function closeStaleCachedOpenClawStateDatabase(database: OpenClawStateDatabase):
   if (cachedDatabases.get(database.path) !== database) {
     return;
   }
+  asyncResources.invalidate(database.path);
   const errors = closeOpenClawStateDatabaseHandle(database);
-  notifyOpenClawStateDatabaseLifecycle({ kind: "closed", path: database.path });
+  notifyOpenClawStateDatabaseClosed(database);
   throwStateDatabaseCleanupErrors(
     errors,
     `Stale OpenClaw state database cleanup failed for ${database.path}.`,
@@ -268,6 +331,7 @@ export function clearOpenClawStateDatabaseOpenFailure(pathname: string): void {
 
 /** Reject shared-state access after a process-local terminal failure. */
 function assertOpenClawStateDatabaseOpenAllowed(pathname: string): void {
+  asyncResources.identity(pathname);
   const terminalFailure = terminalOpenLatch.get(pathname);
   if (terminalFailure) {
     throw terminalFailure;
@@ -318,10 +382,11 @@ function retireOpenClawStateDatabaseHandle(
   runWithSqliteCoordinator(coordinator, "state database retirement", () => {
     // Refused acquisition leaves both cache and physical ownership untouched.
     const wasCached = cachedDatabases.get(database.path)?.db === database.db;
+    asyncResources.invalidate(database.path);
     const errors = closeOpenClawStateDatabaseHandle(database, closeOptions);
     if (wasCached) {
       try {
-        notifyOpenClawStateDatabaseLifecycle({ kind: "closed", path: database.path });
+        notifyOpenClawStateDatabaseClosed(database);
       } catch (error) {
         errors.push(error);
       }
@@ -346,6 +411,7 @@ function throwStateDatabaseCleanupErrors(errors: unknown[], message: string): vo
 function retireOpenClawStateDatabaseHandles(
   pathname?: string,
   options?: OpenClawStateDatabaseCloseOptions,
+  identity?: DatabasePathIdentity,
 ): boolean {
   const databases = new Set<StateDatabaseHandle>([
     ...retainedDatabaseHandles.values(),
@@ -354,7 +420,11 @@ function retireOpenClawStateDatabaseHandles(
   const errors: unknown[] = [];
   let found = false;
   for (const database of databases) {
-    if (pathname !== undefined && database.path !== pathname) {
+    if (
+      pathname !== undefined &&
+      database.path !== pathname &&
+      (identity === undefined || databaseIdentities.get(database.db)?.key !== identity.key)
+    ) {
       continue;
     }
     found = true;
@@ -373,12 +443,50 @@ export function closeOpenClawStateDatabaseByPath(
   pathname: string,
   options?: OpenClawStateDatabaseCloseOptions,
 ): boolean {
-  return retireOpenClawStateDatabaseHandles(path.resolve(pathname), options);
+  return retireOpenClawStateDatabaseHandles(
+    path.resolve(pathname),
+    options,
+    asyncResources.identity(pathname),
+  );
 }
 
 /** Close all cached shared state database handles. */
 export function closeOpenClawStateDatabase(options?: OpenClawStateDatabaseCloseOptions): void {
   retireOpenClawStateDatabaseHandles(undefined, options);
+}
+
+/** Register a resource owner before it can admit any shared-state worker opens. */
+export function registerOpenClawStateDatabaseAsyncResource(
+  resource: OpenClawStateDatabaseAsyncResource,
+): () => void {
+  return asyncResources.register(resource);
+}
+
+/** Capture the canonical read generation before any asynchronous worker admission. */
+export function captureOpenClawStateDatabaseReadAdmission(
+  pathname: string,
+): OpenClawStateDatabaseReadAdmission {
+  return asyncResources.capture(pathname);
+}
+
+/** Drain worker resources before native checkpoint/close at one exact path. */
+export function closeOpenClawStateDatabaseByPathAsync(
+  pathname: string,
+  options?: OpenClawStateDatabaseCloseOptions,
+): Promise<boolean> {
+  const resolvedPath = path.resolve(pathname);
+  return asyncResources.close(resolvedPath, (identity) =>
+    retireOpenClawStateDatabaseHandles(resolvedPath, options, identity),
+  );
+}
+
+/** Orderly lifecycle close; synchronous close remains native/exit cleanup only. */
+export async function closeOpenClawStateDatabaseAsync(
+  options?: OpenClawStateDatabaseCloseOptions,
+): Promise<void> {
+  await asyncResources.close(undefined, () =>
+    retireOpenClawStateDatabaseHandles(undefined, options),
+  );
 }
 
 /** Test whether a cached shared state database handle is still open, optionally at one path. */
@@ -417,15 +525,20 @@ export const openClawStateDatabaseCache = {
 };
 
 /** Drain local cached owners before excluding participating foreign handles for file removal. */
-export function acquireOpenClawStateDatabaseFileExclusion(pathname: string) {
+export async function acquireOpenClawStateDatabaseFileExclusion(pathname: string) {
   const databasePath = path.resolve(pathname);
-  const lifecycle = acquireStateDatabaseCoordinator({ databasePath, busyTimeoutMs: 0 });
+  const releaseAdmission = asyncResources.holdExclusion(databasePath);
+  let lifecycle: ReturnType<typeof acquireStateDatabaseCoordinator> | undefined;
   let handles: ReturnType<typeof acquireStateDatabaseHandleExclusion>;
   try {
-    closeOpenClawStateDatabaseByPath(databasePath);
+    // The admission seal spans drainage and acquisition; no worker can reopen
+    // between native retirement and the physical exclusion becoming current.
+    await closeOpenClawStateDatabaseByPathAsync(databasePath);
+    lifecycle = acquireStateDatabaseCoordinator({ databasePath, busyTimeoutMs: 0 });
     handles = acquireStateDatabaseHandleExclusion({ databasePath, busyTimeoutMs: 0 });
   } catch (error) {
-    lifecycle.release();
+    lifecycle?.release();
+    releaseAdmission();
     throw error;
   }
   return {
@@ -470,7 +583,7 @@ export function acquireOpenClawStateDatabaseFileExclusion(pathname: string) {
           handles.runWithCanonicalWrites(handles.assertCurrent, () => {
             errors.push(...closeOpenClawStateDatabaseHandle(database));
           });
-          notifyOpenClawStateDatabaseLifecycle({ kind: "closed", path: databasePath });
+          notifyOpenClawStateDatabaseClosed(database);
         } catch (error) {
           errors.push(error);
         }
@@ -513,7 +626,7 @@ export function acquireOpenClawStateDatabaseFileExclusion(pathname: string) {
           handles.runWithCanonicalWrites(handles.assertCurrent, () => {
             errors.push(...closeOpenClawStateDatabaseHandle(database));
           });
-          notifyOpenClawStateDatabaseLifecycle({ kind: "closed", path: databasePath });
+          notifyOpenClawStateDatabaseClosed(database);
         } catch (error) {
           errors.push(error);
         }
@@ -546,17 +659,18 @@ export function acquireOpenClawStateDatabaseFileExclusion(pathname: string) {
       try {
         handles.release();
       } finally {
-        lifecycle.release();
+        lifecycle?.release();
+        releaseAdmission();
       }
     },
   };
 }
 
 /** Reconfirm an advisory worker failure on the live owner connection. */
-export function confirmOpenClawStateDatabaseIntegrity(
+export async function confirmOpenClawStateDatabaseIntegrity(
   pathname: string,
-): SqliteIntegrityConfirmation {
+): Promise<SqliteIntegrityConfirmation> {
   const resolvedPath = path.resolve(pathname);
-  closeOpenClawStateDatabaseByPath(resolvedPath);
+  await closeOpenClawStateDatabaseByPathAsync(resolvedPath);
   return confirmSqliteFileIntegrity(resolvedPath, resolvedPath);
 }

--- a/src/state/openclaw-state-db-readonly.exclusion.test.ts
+++ b/src/state/openclaw-state-db-readonly.exclusion.test.ts
@@ -7,6 +7,7 @@ import { stopChildProcess } from "../../test/helpers/stop-child-process.js";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { openNodeSqliteDatabase } from "../infra/node-sqlite.js";
 import { withSqliteSnapshotSource } from "../infra/sqlite-snapshot-source.js";
+import { acquireStateDatabaseHandleExclusion } from "../infra/state-database-coordinator.js";
 import { acquireOpenClawStateDatabaseFileExclusion } from "./openclaw-state-db-cache.js";
 import { withExistingOpenClawStateDatabaseReadOnly } from "./openclaw-state-db-readonly.js";
 import {
@@ -33,14 +34,14 @@ function source() {
   return pathname;
 }
 
-it("keeps a fresh live read inside the physical handle barrier", () => {
+it("keeps a fresh live read inside the physical handle barrier", async () => {
   const pathname = source();
   const rows = withExistingOpenClawStateDatabaseReadOnly(
     ({ db }) => {
       let excluded = false;
-      let exclusion: ReturnType<typeof acquireOpenClawStateDatabaseFileExclusion> | undefined;
+      let exclusion: ReturnType<typeof acquireStateDatabaseHandleExclusion> | undefined;
       try {
-        exclusion = acquireOpenClawStateDatabaseFileExclusion(pathname);
+        exclusion = acquireStateDatabaseHandleExclusion({ databasePath: pathname });
       } catch (error) {
         expect(String(error)).toMatch(/state-handles/);
         excluded = true;
@@ -55,12 +56,12 @@ it("keeps a fresh live read inside the physical handle barrier", () => {
     { path: pathname },
   );
   expect(rows).toEqual([{ event_key: "preserved" }]);
-  acquireOpenClawStateDatabaseFileExclusion(pathname).release();
+  (await acquireOpenClawStateDatabaseFileExclusion(pathname)).release();
 });
 
-it("refuses a new live readonly handle without touching an excluded source", () => {
+it("refuses a new live readonly handle without touching an excluded source", async () => {
   const pathname = source();
-  const exclusion = acquireOpenClawStateDatabaseFileExclusion(pathname);
+  const exclusion = await acquireOpenClawStateDatabaseFileExclusion(pathname);
   const before = fs.statSync(pathname, { bigint: true });
   try {
     expect(() =>
@@ -127,9 +128,11 @@ it("keeps the source-copy child's own handle lease until its actual backup settl
     const [ready] = await once(child, "message", { signal: AbortSignal.timeout(15_000) });
     expect(ready).toEqual({ ready: true });
     let excluded = false;
-    let exclusion: ReturnType<typeof acquireOpenClawStateDatabaseFileExclusion> | undefined;
+    let exclusion:
+      | Awaited<ReturnType<typeof acquireOpenClawStateDatabaseFileExclusion>>
+      | undefined;
     try {
-      exclusion = acquireOpenClawStateDatabaseFileExclusion(pathname);
+      exclusion = await acquireOpenClawStateDatabaseFileExclusion(pathname);
     } catch (error) {
       expect(String(error)).toMatch(/state-handles/);
       excluded = true;
@@ -142,7 +145,7 @@ it("keeps the source-copy child's own handle lease until its actual backup settl
     child.send({ release: true });
     expect((await done)[0]).toEqual({ rows: [{ event_key: "preserved" }] });
     await closed;
-    acquireOpenClawStateDatabaseFileExclusion(pathname).release();
+    (await acquireOpenClawStateDatabaseFileExclusion(pathname)).release();
   } finally {
     await stopChildProcess(child, 5_000);
   }
@@ -174,9 +177,11 @@ it("keeps a live-path snapshot callback excluded until its actual reader closes"
   try {
     await started;
     let excluded = false;
-    let exclusion: ReturnType<typeof acquireOpenClawStateDatabaseFileExclusion> | undefined;
+    let exclusion:
+      | Awaited<ReturnType<typeof acquireOpenClawStateDatabaseFileExclusion>>
+      | undefined;
     try {
-      exclusion = acquireOpenClawStateDatabaseFileExclusion(pathname);
+      exclusion = await acquireOpenClawStateDatabaseFileExclusion(pathname);
     } catch (error) {
       expect(String(error)).toMatch(/state-handles/);
       excluded = true;
@@ -188,5 +193,5 @@ it("keeps a live-path snapshot callback excluded until its actual reader closes"
     resume();
   }
   expect(await copying).toEqual([{ event_key: "preserved" }]);
-  acquireOpenClawStateDatabaseFileExclusion(pathname).release();
+  (await acquireOpenClawStateDatabaseFileExclusion(pathname)).release();
 });

--- a/src/state/openclaw-state-db-readonly.test.ts
+++ b/src/state/openclaw-state-db-readonly.test.ts
@@ -53,7 +53,7 @@ it("keeps fresh synchronous read callbacks from returning asynchronous work", as
     expect(() =>
       withExistingOpenClawStateDatabaseReadOnly(() => Promise.resolve(1), options),
     ).toThrow("SQLite source read must remain synchronous");
-    const exclusion = acquireOpenClawStateDatabaseFileExclusion(options.path);
+    const exclusion = await acquireOpenClawStateDatabaseFileExclusion(options.path);
     exclusion.release();
   });
 });
@@ -128,14 +128,14 @@ it("retains stream handle custody when native close fails until explicit close s
       expect((await rows.next()).value).toBe(1);
       await expect(rows.return()).rejects.toBe(failure);
       expect(reader?.isOpen).toBe(true);
-      expect(() => acquireOpenClawStateDatabaseFileExclusion(source.path)).toThrow(
+      await expect(acquireOpenClawStateDatabaseFileExclusion(source.path)).rejects.toThrow(
         "reader close failed",
       );
       expect(reader?.isOpen).toBe(true);
       refuseClose = false;
       closeOpenClawStateDatabaseForTest();
       expect(reader?.isOpen).toBe(false);
-      const exclusion = acquireOpenClawStateDatabaseFileExclusion(source.path);
+      const exclusion = await acquireOpenClawStateDatabaseFileExclusion(source.path);
       exclusion.release();
     } finally {
       refuseClose = false;
@@ -441,7 +441,7 @@ it("reads under its live mutation owner but refuses an unrelated caller", async 
     const initial = openOpenClawStateDatabase(options);
     initial.db.exec("CREATE TABLE held(value TEXT); INSERT INTO held VALUES ('original')");
     const pathname = initial.path;
-    const owner = acquireOpenClawStateDatabaseFileExclusion(pathname);
+    const owner = await acquireOpenClawStateDatabaseFileExclusion(pathname);
     const entered = createDeferredCore();
     const resume = createDeferredCore();
     const read = () =>

--- a/src/state/openclaw-state-db-source-exclusion.test.ts
+++ b/src/state/openclaw-state-db-source-exclusion.test.ts
@@ -74,7 +74,6 @@ describe("owner-held SQLite source reads", () => {
     },
   );
 
-
   it("reads a private SQLite copy under current physical exclusion", async () => {
     await withOpenClawTestState({ label: "excluded-checkpoint" }, async (state) => {
       const pathname = populate(state.env);

--- a/src/state/openclaw-state-db-source-exclusion.test.ts
+++ b/src/state/openclaw-state-db-source-exclusion.test.ts
@@ -33,7 +33,7 @@ describe("owner-held SQLite source reads", () => {
   it("does not let a second caller borrow another task's physical exclusion", async () => {
     await withOpenClawTestState({ label: "excluded-owner-reentry" }, async (state) => {
       const databasePath = populate(state.env);
-      const current = acquireOpenClawStateDatabaseFileExclusion(databasePath);
+      const current = await acquireOpenClawStateDatabaseFileExclusion(databasePath);
       let competing: ReturnType<typeof acquireStateDatabaseHandleExclusion> | undefined;
       try {
         expect(() => {
@@ -52,7 +52,7 @@ describe("owner-held SQLite source reads", () => {
     async (inspect) => {
       await withOpenClawTestState({ label: "excluded-copy-abort" }, async (state) => {
         const pathname = populate(state.env);
-        const exclusion = acquireOpenClawStateDatabaseFileExclusion(pathname);
+        const exclusion = await acquireOpenClawStateDatabaseFileExclusion(pathname);
         try {
           await exclusion.runWithSourceReads(async (assertCurrent) => {
             const controller = new AbortController();
@@ -74,10 +74,11 @@ describe("owner-held SQLite source reads", () => {
     },
   );
 
+
   it("reads a private SQLite copy under current physical exclusion", async () => {
     await withOpenClawTestState({ label: "excluded-checkpoint" }, async (state) => {
       const pathname = populate(state.env);
-      const exclusion = acquireOpenClawStateDatabaseFileExclusion(pathname);
+      const exclusion = await acquireOpenClawStateDatabaseFileExclusion(pathname);
       try {
         await exclusion.runWithSourceReads(async (assertCurrent) => {
           expect(() => openOpenClawStateDatabase({ env: state.env })).toThrow(/state-handles/);
@@ -105,7 +106,7 @@ describe("owner-held SQLite source reads", () => {
     async (preserveSourceArtifacts) => {
       await withOpenClawTestState({ label: "excluded-private-copy" }, async (state) => {
         const pathname = populate(state.env);
-        const exclusion = acquireOpenClawStateDatabaseFileExclusion(pathname);
+        const exclusion = await acquireOpenClawStateDatabaseFileExclusion(pathname);
         try {
           await exclusion.runWithSourceReads(async (assertCurrent) => {
             const prepared = await prepareSqliteReadOnlyLocation(pathname, {
@@ -129,7 +130,7 @@ describe("owner-held SQLite source reads", () => {
   it("does not admit a concurrent non-owner reader through the local scope", async () => {
     await withOpenClawTestState({ label: "excluded-nonowner-read" }, async (state) => {
       const pathname = populate(state.env);
-      const exclusion = acquireOpenClawStateDatabaseFileExclusion(pathname);
+      const exclusion = await acquireOpenClawStateDatabaseFileExclusion(pathname);
       const entered = createDeferredCore();
       const release = createDeferredCore();
       const running = exclusion.runWithSourceReads(async (assertCurrent) => {
@@ -152,7 +153,7 @@ describe("owner-held SQLite source reads", () => {
   it("retains physical exclusion through admitted reads after early owner release", async () => {
     await withOpenClawTestState({ label: "excluded-read-drain" }, async (state) => {
       const pathname = populate(state.env);
-      const exclusion = acquireOpenClawStateDatabaseFileExclusion(pathname);
+      const exclusion = await acquireOpenClawStateDatabaseFileExclusion(pathname);
       const entered = createDeferredCore();
       const finish = createDeferredCore();
       const running = exclusion.runWithSourceReads(async () =>
@@ -164,17 +165,19 @@ describe("owner-held SQLite source reads", () => {
       );
       await entered.promise;
       exclusion.release();
-      let competing: ReturnType<typeof acquireOpenClawStateDatabaseFileExclusion> | undefined;
+      let competing:
+        | Awaited<ReturnType<typeof acquireOpenClawStateDatabaseFileExclusion>>
+        | undefined;
       try {
-        expect(() => {
-          competing = acquireOpenClawStateDatabaseFileExclusion(pathname);
-        }).toThrow(/state-handles/);
+        await expect(async () => {
+          competing = await acquireOpenClawStateDatabaseFileExclusion(pathname);
+        }).rejects.toThrow(/state-handles/);
       } finally {
         competing?.release();
         finish.resolve();
       }
       await expect(running).rejects.toThrow(/no longer current/);
-      const next = acquireOpenClawStateDatabaseFileExclusion(pathname);
+      const next = await acquireOpenClawStateDatabaseFileExclusion(pathname);
       next.release();
     });
   });
@@ -182,7 +185,7 @@ describe("owner-held SQLite source reads", () => {
   it("expires inherited read scopes and refuses a released owner", async () => {
     await withOpenClawTestState({ label: "excluded-read-expiry" }, async (state) => {
       const pathname = populate(state.env);
-      const exclusion = acquireOpenClawStateDatabaseFileExclusion(pathname);
+      const exclusion = await acquireOpenClawStateDatabaseFileExclusion(pathname);
       const wake = createDeferredCore();
       let delayed: Promise<unknown> | undefined;
       try {

--- a/src/state/openclaw-state-db.ts
+++ b/src/state/openclaw-state-db.ts
@@ -722,8 +722,9 @@ function getOpenClawStateDatabaseIfOpen(
 export {
   recordOpenClawStateDatabaseOpenFailure,
   clearOpenClawStateDatabaseOpenFailure,
-  closeOpenClawStateDatabaseByPath,
+  closeOpenClawStateDatabaseByPathAsync,
   closeOpenClawStateDatabase,
+  closeOpenClawStateDatabaseAsync,
   isOpenClawStateDatabaseOpen,
   closeOpenClawStateDatabaseForTest,
   confirmOpenClawStateDatabaseIntegrity,

--- a/src/state/openclaw-state-lease-exclusion.ts
+++ b/src/state/openclaw-state-lease-exclusion.ts
@@ -59,7 +59,7 @@ async function perform<T>(
   };
   let result: T | undefined;
   let lifecycle: ReturnType<typeof acquireStateDatabaseCoordinator> | undefined;
-  let exclusion: ReturnType<typeof acquireOpenClawStateDatabaseFileExclusion> | undefined;
+  let exclusion: Awaited<ReturnType<typeof acquireOpenClawStateDatabaseFileExclusion>> | undefined;
   let timer: ReturnType<typeof setTimeout> | undefined;
   let generation: SqliteFileGeneration | undefined;
   let active = true;
@@ -73,7 +73,7 @@ async function perform<T>(
     for (const participant of participants) {
       participant.expiresAt = participant.owner.params.readExpiry(databasePath);
     }
-    exclusion = acquireOpenClawStateDatabaseFileExclusion(databasePath);
+    exclusion = await acquireOpenClawStateDatabaseFileExclusion(databasePath);
     generation = readStableSqliteFileGeneration(databasePath);
     const held = exclusion;
     const deadline = Math.min(...participants.map((participant) => participant.expiresAt ?? 0));

--- a/src/state/openclaw-state-lease-heartbeat.test.ts
+++ b/src/state/openclaw-state-lease-heartbeat.test.ts
@@ -2,7 +2,10 @@ import { once } from "node:events";
 import type { Worker } from "node:worker_threads";
 import { afterEach, describe, expect, it } from "vitest";
 import { tryAcquireExclusiveSqliteCoordinator } from "../infra/sqlite-coordinator.js";
-import { acquireStateDatabaseCoordinator } from "../infra/state-database-coordinator.js";
+import {
+  acquireStateDatabaseCoordinator,
+  acquireStateDatabaseHandleExclusion,
+} from "../infra/state-database-coordinator.js";
 import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import {
   acquireOpenClawStateDatabaseFileExclusion,
@@ -131,18 +134,20 @@ describe("maintenance lease heartbeat", () => {
       const databasePath = openOpenClawStateDatabase({ env: state.env }).path;
       await withOpenClawStateLease({ ...options(state.env), leaseMs: 10_000 }, async (lease) => {
         closeOpenClawStateDatabaseByPath(databasePath);
-        let exclusion: ReturnType<typeof acquireOpenClawStateDatabaseFileExclusion> | undefined;
+        let exclusion:
+          | Awaited<ReturnType<typeof acquireOpenClawStateDatabaseFileExclusion>>
+          | undefined;
         try {
-          expect(() => {
-            exclusion = acquireOpenClawStateDatabaseFileExclusion(databasePath);
-          }).toThrow(/state-handles/);
+          await expect(async () => {
+            exclusion = await acquireOpenClawStateDatabaseFileExclusion(databasePath);
+          }).rejects.toThrow(/state-handles/);
         } finally {
           exclusion?.release();
         }
         lease.assertOwned();
       });
       // withOpenClawStateLease joins the real worker, then releases its durable row.
-      const exclusion = acquireOpenClawStateDatabaseFileExclusion(databasePath);
+      const exclusion = await acquireOpenClawStateDatabaseFileExclusion(databasePath);
       exclusion.release();
     });
   });
@@ -207,10 +212,10 @@ describe("maintenance lease heartbeat", () => {
           block(100);
           const databasePath = openOpenClawStateDatabase({ env: state.env }).path;
           closeOpenClawStateDatabaseByPath(databasePath);
-          let exclusion: ReturnType<typeof acquireOpenClawStateDatabaseFileExclusion> | undefined;
+          let exclusion: ReturnType<typeof acquireStateDatabaseHandleExclusion> | undefined;
           try {
             expect(() => {
-              exclusion = acquireOpenClawStateDatabaseFileExclusion(databasePath);
+              exclusion = acquireStateDatabaseHandleExclusion({ databasePath });
             }).toThrow(/state-handles/);
           } finally {
             exclusion?.release();

--- a/src/state/openclaw-state-worker-contract.ts
+++ b/src/state/openclaw-state-worker-contract.ts
@@ -1,0 +1,44 @@
+import type { TaskFlowView } from "../plugins/runtime/task-domain-types.js";
+import type { TaskFlowRecord } from "../tasks/task-flow-registry.types.js";
+import type { TaskRecord, TaskRegistrySummary } from "../tasks/task-registry.types.js";
+
+type TaskLookupRecords = {
+  direct?: TaskRecord;
+  byRun?: TaskRecord;
+  related: TaskRecord[];
+};
+
+type TaskFlowRead = {
+  flow: TaskFlowRecord;
+  tasks: TaskRecord[];
+};
+
+type TaskFlowReadQuery = {
+  ownerKey: string;
+  lookup: "id" | "latest" | "resolve";
+  token?: string;
+};
+
+/** Commands share one physical shared-state actor; bindings belong to commands, not open input. */
+export type OpenClawStateWorkerOperations = {
+  "tasks.get": { input: { taskId: string }; output: TaskRecord | undefined };
+  "tasks.list": { input: { ownerKey: string }; output: TaskRecord[] };
+  "tasks.resolve": {
+    input: { ownerKey: string; token: string };
+    output: TaskLookupRecords;
+  };
+  "flows.list": { input: { ownerKey: string }; output: TaskFlowRecord[] };
+  "flows.views": { input: { ownerKey: string }; output: TaskFlowView[] };
+  "flows.summary": {
+    input: { ownerKey: string; flowId: string };
+    output: TaskRegistrySummary | undefined;
+  };
+  "flows.read": {
+    input: TaskFlowReadQuery;
+    output: TaskFlowRecord | undefined;
+  };
+  "flows.detail": {
+    input: TaskFlowReadQuery;
+    output: TaskFlowRead | undefined;
+  };
+};

--- a/src/state/openclaw-state-worker-store.ts
+++ b/src/state/openclaw-state-worker-store.ts
@@ -1,0 +1,126 @@
+import { runtimeProcessEntrypoints } from "../infra/runtime-process-entrypoints.js";
+import { resolveRuntimeWorkerUrl } from "../infra/runtime-worker-url.js";
+import type { DatabasePathIdentity } from "../infra/sqlite-worker-identity.js";
+import { openSqliteWorkerStore, type SqliteWorkerStore } from "../infra/sqlite-worker-store.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
+import { resolveGlobalSingleton } from "../shared/global-singleton.js";
+import type { OpenClawStateDatabaseReadAdmission } from "./openclaw-state-db-async-lifecycle.js";
+import {
+  registerOpenClawStateDatabaseAsyncResource,
+  registerOpenClawStateDatabaseLifecycleListener,
+} from "./openclaw-state-db-cache.js";
+import { openOpenClawStateDatabase } from "./openclaw-state-db.js";
+import type { OpenClawStateWorkerOperations } from "./openclaw-state-worker-contract.js";
+
+type Store = SqliteWorkerStore<OpenClawStateWorkerOperations>;
+const log = createSubsystemLogger("state/worker");
+
+function createSharedStateWorkerOwner() {
+  const stores = new Map<string, Promise<Store>>();
+  const retiring = new Map<string, Promise<void>>();
+  async function close(identity?: DatabasePathIdentity): Promise<void> {
+    const entries = [...stores].filter(([key]) => identity === undefined || identity.key === key);
+    for (const [key, opening] of entries) {
+      stores.delete(key);
+      const closing = opening.then((store) => store.close());
+      retiring.set(key, closing);
+      void closing
+        .finally(() => {
+          if (retiring.get(key) === closing) {
+            retiring.delete(key);
+          }
+        })
+        .catch(() => {});
+    }
+    // Broker close settles only after native cleanup or joined worker exit.
+    const settled = await Promise.allSettled(
+      [...retiring]
+        .filter(([key]) => identity === undefined || identity.key === key)
+        .map(([, closing]) => closing),
+    );
+    const errors = settled.flatMap((result) =>
+      result.status === "rejected" ? [result.reason] : [],
+    );
+    if (errors.length > 0) {
+      throw new AggregateError(errors, "Failed to close shared-state SQLite workers");
+    }
+  }
+  registerOpenClawStateDatabaseAsyncResource({ close });
+  registerOpenClawStateDatabaseLifecycleListener((event) => {
+    if (event.kind !== "opened" && event.identity) {
+      // Synchronous error eviction cannot await, but actor retirement remains
+      // owned and every subsequent open or canonical drain joins it.
+      void close(event.identity).catch((error: unknown) => {
+        log.warn("Shared-state worker retirement failed", { path: event.path, error });
+      });
+    }
+  });
+  return {
+    close,
+    async open(admission: OpenClawStateDatabaseReadAdmission) {
+      const closing = retiring.get(admission.identity.key);
+      if (closing) {
+        await closing;
+      }
+      admission.assertCurrent();
+      let key = admission.identity.key;
+      let opening = stores.get(key);
+      if (!opening) {
+        // Restore can already be ready after a native close. Reuse canonical
+        // schema admission once when establishing a new worker actor as well.
+        openOpenClawStateDatabase({ path: admission.databasePath });
+        admission.assertCurrent();
+        // Native publication promotes a prospective identity without replacing
+        // its admission. Reuse the physical actor if another alias already opened it.
+        key = admission.identity.key;
+        const promotedClosing = retiring.get(key);
+        if (promotedClosing) {
+          await promotedClosing;
+          admission.assertCurrent();
+        }
+        opening = stores.get(key);
+        if (opening) {
+          return opening;
+        }
+        opening = openSqliteWorkerStore<OpenClawStateWorkerOperations>({
+          moduleUrl: resolveRuntimeWorkerUrl(runtimeProcessEntrypoints.sharedStateStore),
+          databasePath: admission.databasePath,
+          input: undefined,
+          existingOnly: true,
+        }).then((store) => {
+          if (!store) {
+            throw new Error("Admitted shared-state database is missing");
+          }
+          return store;
+        });
+        stores.set(key, opening);
+        const admitted = opening;
+        void opening.catch(() => {
+          if (stores.get(key) === admitted) {
+            stores.delete(key);
+          }
+        });
+      }
+      return opening;
+    },
+  };
+}
+
+function owner() {
+  return resolveGlobalSingleton(
+    Symbol.for("openclaw.sharedStateWorkerOwner"),
+    createSharedStateWorkerOwner,
+    (sharedOwner) => sharedOwner.close(),
+  );
+}
+
+export async function executeOpenClawStateWorker<Key extends keyof OpenClawStateWorkerOperations>(
+  context: OpenClawStateDatabaseReadAdmission,
+  command: { type: Key; input: OpenClawStateWorkerOperations[Key]["input"] },
+): Promise<OpenClawStateWorkerOperations[Key]["output"]> {
+  const store = await owner().open(context);
+  context.assertCurrent();
+  const result = await store.execute(command);
+  context.assertCurrent();
+  return result;
+}

--- a/src/state/openclaw-state.worker.ts
+++ b/src/state/openclaw-state.worker.ts
@@ -1,0 +1,93 @@
+import { runSqliteDeferredTransactionSync } from "../infra/sqlite-transaction.js";
+import type { SqliteWorkerBackend } from "../infra/sqlite-worker-contract.js";
+import { mapTaskFlowView } from "../tasks/task-domain-views.js";
+import { normalizeRestoredFlowRecord } from "../tasks/task-flow-registry.records.js";
+import {
+  listTaskFlowRecordsForOwnerReadInDatabase,
+  readTaskFlowRecord,
+  listTaskFlowViewRecordsForOwnerInDatabase,
+  readTaskFlowViewRecordInDatabase,
+} from "../tasks/task-flow-registry.store.kernel.js";
+import { isTerminalTaskFlow } from "../tasks/task-flow-registry.types.js";
+import {
+  findTaskRecordByRunIdForViewInDatabase,
+  listTaskRecordsForFlowReadInDatabase,
+  listTaskRecordsForOwnerReadInDatabase,
+  readTaskViewRecordInDatabase,
+} from "../tasks/task-registry.store.kernel.js";
+import { summarizeTaskRecords } from "../tasks/task-registry.summary.js";
+import { openOpenClawStateReadConnection } from "./openclaw-state-db-read-connection.js";
+import type { OpenClawStateWorkerOperations } from "./openclaw-state-worker-contract.js";
+
+/** Schema admission remains with the canonical state owner before this existing-only open. */
+export function openExistingSqliteWorkerBackend(
+  _input: undefined,
+  context: { databasePath: string },
+): SqliteWorkerBackend<OpenClawStateWorkerOperations> {
+  const connection = openOpenClawStateReadConnection(context.databasePath, context.databasePath);
+  const { db } = connection.database;
+  const listFlows = (ownerKey: string) =>
+    listTaskFlowRecordsForOwnerReadInDatabase(db, ownerKey).map(normalizeRestoredFlowRecord);
+  const ownedFlow = (flow: ReturnType<typeof readTaskFlowRecord>, ownerKey: string) =>
+    flow?.ownerKey.trim() === ownerKey ? normalizeRestoredFlowRecord(flow) : undefined;
+  return {
+    execute(command) {
+      return runSqliteDeferredTransactionSync(db, () => {
+        switch (command.type) {
+          case "tasks.get":
+            return readTaskViewRecordInDatabase(db, command.input.taskId);
+          case "tasks.list":
+            return listTaskRecordsForOwnerReadInDatabase(db, command.input.ownerKey);
+          case "tasks.resolve": {
+            const { ownerKey, token } = command.input;
+            return {
+              direct: readTaskViewRecordInDatabase(db, token),
+              byRun: findTaskRecordByRunIdForViewInDatabase(db, token),
+              related: listTaskRecordsForOwnerReadInDatabase(db, ownerKey, token),
+            };
+          }
+          case "flows.list":
+            return listFlows(command.input.ownerKey);
+          case "flows.views":
+            return listTaskFlowViewRecordsForOwnerInDatabase(db, command.input.ownerKey)
+              .map(normalizeRestoredFlowRecord)
+              .map(mapTaskFlowView);
+          case "flows.summary": {
+            const { ownerKey, flowId } = command.input;
+            const flow = ownedFlow(readTaskFlowViewRecordInDatabase(db, flowId), ownerKey);
+            return flow
+              ? summarizeTaskRecords(listTaskRecordsForFlowReadInDatabase(db, flow.flowId))
+              : undefined;
+          }
+          case "flows.read":
+          case "flows.detail": {
+            const { ownerKey, lookup, token } = command.input;
+            const direct = token === undefined ? undefined : readTaskFlowRecord(db, token);
+            let flow = ownedFlow(direct, ownerKey);
+            if (
+              !flow &&
+              (lookup === "latest" || (lookup === "resolve" && token?.trim() === ownerKey))
+            ) {
+              const flows = listFlows(ownerKey);
+              flow =
+                lookup === "resolve"
+                  ? (flows.find((candidate) => !isTerminalTaskFlow(candidate)) ?? flows[0])
+                  : flows[0];
+            }
+            if (!flow) {
+              return undefined;
+            }
+            return command.type === "flows.detail"
+              ? { flow, tasks: listTaskRecordsForFlowReadInDatabase(db, flow.flowId) }
+              : flow;
+          }
+          default:
+            throw new Error("Unknown shared-state SQLite command");
+        }
+      });
+    },
+    close() {
+      connection.close();
+    },
+  };
+}

--- a/src/tasks/task-flow-registry.store.kernel.ts
+++ b/src/tasks/task-flow-registry.store.kernel.ts
@@ -136,8 +136,33 @@ function getFlowRegistryKysely(db: DatabaseSync) {
   return getNodeSqliteKysely<FlowRegistryStoreDatabase>(db);
 }
 
+const FLOW_RUN_SELECT_COLUMNS = [
+  "flow_id",
+  "sync_mode",
+  "shape",
+  "owner_key",
+  "requester_origin_json",
+  "controller_id",
+  "revision",
+  "status",
+  "notify_policy",
+  "goal",
+  "current_step",
+  "blocked_task_id",
+  "blocked_summary",
+  "state_json",
+  "wait_json",
+  "cancel_requested_at",
+  "created_at",
+  "updated_at",
+  "ended_at",
+] as const;
+
 type TaskFlowRegistryQueries = {
   point?: ReturnType<typeof prepareSqliteQuerySync<string, FlowRegistryRow>>;
+  owner?: ReturnType<typeof prepareSqliteQuerySync<string, FlowRegistryRow>>;
+  viewOwner?: ReturnType<typeof prepareSqliteQuerySync<string, FlowRegistryRow>>;
+  viewPoint?: ReturnType<typeof prepareSqliteQuerySync<string, FlowRegistryRow>>;
 };
 const taskFlowRegistryQueries = new WeakMap<DatabaseSync, TaskFlowRegistryQueries>();
 
@@ -150,30 +175,30 @@ function getTaskFlowRegistryQueries(db: DatabaseSync): TaskFlowRegistryQueries {
   return queries;
 }
 
+export function listTaskFlowRecordsForOwnerReadInDatabase(
+  db: DatabaseSync,
+  ownerKey: string,
+): TaskFlowRecord[] {
+  const queries = getTaskFlowRegistryQueries(db);
+  const read = (queries.owner ??= prepareSqliteQuerySync<string, FlowRegistryRow>(db, (parameter) =>
+    getFlowRegistryKysely(db)
+      .selectFrom("flow_runs")
+      .selectAll()
+      .where(
+        "owner_key",
+        "=",
+        parameter((value) => value),
+      )
+      .orderBy("created_at", "desc")
+      .orderBy("flow_id", "asc"),
+  ));
+  return read(ownerKey).rows.map(rowToFlowRecord);
+}
+
 export function readTaskFlowRegistrySnapshot(db: DatabaseSync): TaskFlowRegistryStoreSnapshot {
   const query = getFlowRegistryKysely(db)
     .selectFrom("flow_runs")
-    .select([
-      "flow_id",
-      "sync_mode",
-      "shape",
-      "owner_key",
-      "requester_origin_json",
-      "controller_id",
-      "revision",
-      "status",
-      "notify_policy",
-      "goal",
-      "current_step",
-      "blocked_task_id",
-      "blocked_summary",
-      "state_json",
-      "wait_json",
-      "cancel_requested_at",
-      "created_at",
-      "updated_at",
-      "ended_at",
-    ])
+    .select(FLOW_RUN_SELECT_COLUMNS)
     .orderBy("created_at", "asc")
     .orderBy("flow_id", "asc");
   const flows = new Map<string, TaskFlowRecord>();
@@ -182,6 +207,58 @@ export function readTaskFlowRegistrySnapshot(db: DatabaseSync): TaskFlowRegistry
     flows.set(row.flow_id, rowToFlowRecord(row));
   }
   return { flows };
+}
+
+const FLOW_VIEW_SELECT_COLUMNS = FLOW_RUN_SELECT_COLUMNS.filter(
+  (column) => column !== "state_json" && column !== "wait_json",
+);
+
+function flowViewQuery(db: DatabaseSync) {
+  return getFlowRegistryKysely(db)
+    .selectFrom("flow_runs")
+    .select(FLOW_VIEW_SELECT_COLUMNS)
+    .select((expression) => [
+      expression.val(null).as("state_json"),
+      expression.val(null).as("wait_json"),
+    ]);
+}
+
+export function listTaskFlowViewRecordsForOwnerInDatabase(
+  db: DatabaseSync,
+  ownerKey: string,
+): TaskFlowRecord[] {
+  const queries = getTaskFlowRegistryQueries(db);
+  const read = (queries.viewOwner ??= prepareSqliteQuerySync<string, FlowRegistryRow>(
+    db,
+    (parameter) =>
+      flowViewQuery(db)
+        .where(
+          "owner_key",
+          "=",
+          parameter((value) => value),
+        )
+        .orderBy("created_at", "desc")
+        .orderBy("flow_id", "asc"),
+  ));
+  return read(ownerKey).rows.map(rowToFlowRecord);
+}
+
+export function readTaskFlowViewRecordInDatabase(
+  db: DatabaseSync,
+  flowId: string,
+): TaskFlowRecord | undefined {
+  const queries = getTaskFlowRegistryQueries(db);
+  const read = (queries.viewPoint ??= prepareSqliteQuerySync<string, FlowRegistryRow>(
+    db,
+    (parameter) =>
+      flowViewQuery(db).where(
+        "flow_id",
+        "=",
+        parameter((value) => value),
+      ),
+  ));
+  const row = read(flowId).rows[0];
+  return row ? rowToFlowRecord(row) : undefined;
 }
 
 export function upsertTaskFlowRowInDatabase(db: DatabaseSync, row: BoundTaskFlowRecord): void {

--- a/src/tasks/task-owner-access.ts
+++ b/src/tasks/task-owner-access.ts
@@ -21,7 +21,7 @@ type TaskOwnerIdentity = {
   config?: OpenClawConfig;
 };
 
-function canOwnerAccessTask(task: TaskRecord, identity: TaskOwnerIdentity): boolean {
+export function canOwnerAccessTask(task: TaskRecord, identity: TaskOwnerIdentity): boolean {
   if (
     task.scopeKind !== "session" ||
     normalizeOptionalString(task.ownerKey) !== normalizeOptionalString(identity.callerOwnerKey)

--- a/src/tasks/task-registry-records.ts
+++ b/src/tasks/task-registry-records.ts
@@ -1,9 +1,27 @@
 // Clones and normalizes task registry records at persistence boundaries.
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
 import {
   isTerminalTaskStatus,
   type TaskDeliveryState,
   type TaskRecord,
 } from "./task-registry.types.js";
+
+export function getTaskRelatedSessionIndexKeys(
+  task: Pick<TaskRecord, "requesterSessionKey" | "ownerKey" | "childSessionKey">,
+): string[] {
+  return uniqueStrings(
+    [task.requesterSessionKey, task.ownerKey, task.childSessionKey]
+      .map(normalizeOptionalString)
+      .filter((key): key is string => Boolean(key)),
+  );
+}
+
+export function compareTasksForRunIdLookup(left: TaskRecord, right: TaskRecord): number {
+  const leftPriority = left.runtime === "cli" ? 1 : 0;
+  const rightPriority = right.runtime === "cli" ? 1 : 0;
+  return leftPriority - rightPriority || left.createdAt - right.createdAt;
+}
 
 export function cloneTaskRecord(record: TaskRecord): TaskRecord {
   return {

--- a/src/tasks/task-registry-state.ts
+++ b/src/tasks/task-registry-state.ts
@@ -1,11 +1,15 @@
 import { createRequire } from "node:module";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
-import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
 import { formatErrorMessage } from "../infra/errors.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { createLazyPromiseLoader } from "../shared/lazy-runtime.js";
 import type { TaskRegistryControlRuntime } from "./task-registry-control.types.js";
-import { cloneTaskRecord, normalizeTaskTimestamps } from "./task-registry-records.js";
+import {
+  cloneTaskRecord,
+  compareTasksForRunIdLookup,
+  getTaskRelatedSessionIndexKeys,
+  normalizeTaskTimestamps,
+} from "./task-registry-records.js";
 import { getTaskRegistryProcessState } from "./task-registry.process-state.js";
 import {
   getTaskRegistryObservers,
@@ -264,14 +268,6 @@ function deleteIndexedKey(index: Map<string, Set<string>>, key: string, taskId: 
 
 type TaskSessionKeys = Pick<TaskRecord, "requesterSessionKey" | "ownerKey" | "childSessionKey">;
 
-function getTaskRelatedSessionIndexKeys(task: TaskSessionKeys) {
-  return uniqueStrings(
-    [task.requesterSessionKey, task.ownerKey, task.childSessionKey]
-      .map(normalizeOptionalString)
-      .filter((key): key is string => Boolean(key)),
-  );
-}
-
 export function addOwnerKeyIndex(taskId: string, task: Pick<TaskRecord, "ownerKey">) {
   const key = normalizeOptionalString(task.ownerKey);
   if (!key) {
@@ -406,19 +402,8 @@ export function getPeerTasksForDelivery(task: TaskRecord): TaskRecord[] {
   );
 }
 
-function taskLookupPriority(task: TaskRecord): number {
-  const runtimePriority = task.runtime === "cli" ? 1 : 0;
-  return runtimePriority;
-}
-
 export function pickPreferredRunIdTask(matches: TaskRecord[]): TaskRecord | undefined {
-  return [...matches].toSorted((left, right) => {
-    const priorityDiff = taskLookupPriority(left) - taskLookupPriority(right);
-    if (priorityDiff !== 0) {
-      return priorityDiff;
-    }
-    return left.createdAt - right.createdAt;
-  })[0];
+  return [...matches].toSorted(compareTasksForRunIdLookup)[0];
 }
 
 export function compareTasksNewestFirst(

--- a/src/tasks/task-registry.store.kernel.ts
+++ b/src/tasks/task-registry.store.kernel.ts
@@ -18,7 +18,11 @@ import { normalizeSqliteNumber } from "../infra/sqlite-number.js";
 import { runSqliteDeferredTransactionSync } from "../infra/sqlite-transaction.js";
 import { tableExists, tableHasColumns } from "../state/openclaw-state-db-schema-helpers.js";
 import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-db.generated.js";
-import { normalizeTaskTimestamps } from "./task-registry-records.js";
+import {
+  compareTasksForRunIdLookup,
+  getTaskRelatedSessionIndexKeys,
+  normalizeTaskTimestamps,
+} from "./task-registry-records.js";
 import { parseDeliveryContextJson, parseSqliteJsonValue } from "./task-registry.sqlite.shared.js";
 import type { TaskRegistryStoreSnapshot } from "./task-registry.store.types.js";
 import {
@@ -217,6 +221,10 @@ type TaskRegistryQueries = {
   point?: TaskRegistryQuery<string>;
   runtime?: TaskRegistryQuery<TaskRuntime>;
   runtimeSource?: TaskRegistryQuery<{ runtime: TaskRuntime; sourceId: string }>;
+  viewPoint?: TaskRegistryQuery<string>;
+  viewOwner?: TaskRegistryQuery<string>;
+  viewFlow?: TaskRegistryQuery<string>;
+  viewRunId?: TaskRegistryQuery<string>;
 };
 const taskRegistryQueries = new WeakMap<DatabaseSync, TaskRegistryQueries>();
 
@@ -323,6 +331,109 @@ export function readTaskRecord(db: DatabaseSync, taskId: string): TaskRecord | u
   ));
   const row = read(taskId).rows[0];
   return row ? rowToTaskRecord(row) : undefined;
+}
+
+const TASK_VIEW_SELECT_COLUMNS = TASK_RUN_SELECT_COLUMNS.filter(
+  (column) => column !== "detail_json",
+);
+
+function taskViewQuery(db: DatabaseSync) {
+  // Public run views and summaries never expose detail. Keep large private
+  // blobs out of native materialization, decoding, and worker transport.
+  return getTaskRegistryKysely(db)
+    .selectFrom("task_runs")
+    .select(TASK_VIEW_SELECT_COLUMNS)
+    .select((expression) => expression.val(null).as("detail_json"));
+}
+
+function compareTaskViewOrder(left: TaskRecord, right: TaskRecord): number {
+  // Normalize legacy timestamps before sorting; retain SQLite's binary ID order for ties.
+  return right.createdAt - left.createdAt;
+}
+
+export function readTaskViewRecordInDatabase(
+  db: DatabaseSync,
+  taskId: string,
+): TaskRecord | undefined {
+  const queries = getTaskRegistryQueries(db);
+  const read = (queries.viewPoint ??= prepareSqliteQuerySync<string, TaskRegistryRow>(
+    db,
+    (parameter) =>
+      taskViewQuery(db).where(
+        "task_id",
+        "=",
+        parameter((value) => value),
+      ),
+  ));
+  const row = read(taskId).rows[0];
+  return row ? rowToTaskRecord(row) : undefined;
+}
+
+export function listTaskRecordsForOwnerReadInDatabase(
+  db: DatabaseSync,
+  ownerKey: string,
+  relatedSessionKey?: string,
+): TaskRecord[] {
+  const queries = getTaskRegistryQueries(db);
+  const read = (queries.viewOwner ??= prepareSqliteQuerySync<string, TaskRegistryRow>(
+    db,
+    (parameter) =>
+      taskViewQuery(db)
+        .where(
+          "owner_key",
+          "=",
+          parameter((value) => value),
+        )
+        .orderBy("task_id", "desc"),
+  ));
+  const rows = read(ownerKey).rows;
+  const records = rows.map(rowToTaskRecord);
+  const related =
+    relatedSessionKey === undefined
+      ? records
+      : records.filter((record) =>
+          getTaskRelatedSessionIndexKeys(record).includes(relatedSessionKey),
+        );
+  return related.toSorted(compareTaskViewOrder);
+}
+
+export function listTaskRecordsForFlowReadInDatabase(
+  db: DatabaseSync,
+  flowId: string,
+): TaskRecord[] {
+  const queries = getTaskRegistryQueries(db);
+  const read = (queries.viewFlow ??= prepareSqliteQuerySync<string, TaskRegistryRow>(
+    db,
+    (parameter) =>
+      taskViewQuery(db)
+        .where(
+          "parent_flow_id",
+          "=",
+          parameter((value) => value),
+        )
+        .orderBy("task_id", "desc"),
+  ));
+  return read(flowId).rows.map(rowToTaskRecord).toSorted(compareTaskViewOrder);
+}
+
+export function findTaskRecordByRunIdForViewInDatabase(
+  db: DatabaseSync,
+  runId: string,
+): TaskRecord | undefined {
+  const queries = getTaskRegistryQueries(db);
+  const read = (queries.viewRunId ??= prepareSqliteQuerySync<string, TaskRegistryRow>(
+    db,
+    (parameter) =>
+      taskViewQuery(db)
+        .where(
+          "run_id",
+          "=",
+          parameter((value) => value),
+        )
+        .orderBy("task_id", "asc"),
+  ));
+  const records = read(runId).rows.map(rowToTaskRecord);
+  return records.toSorted(compareTasksForRunIdLookup)[0];
 }
 
 function selectTaskDeliveryStateRows(db: DatabaseSync): TaskDeliveryStateRow[] {

--- a/src/test-utils/session-state-cleanup.ts
+++ b/src/test-utils/session-state-cleanup.ts
@@ -10,7 +10,7 @@ import {
   closeOpenClawAgentDatabaseByPath,
   listOpenClawAgentDatabasesForTest,
 } from "../state/openclaw-agent-db.js";
-import { closeOpenClawStateDatabaseByPath } from "../state/openclaw-state-db.js";
+import { closeOpenClawStateDatabaseByPathAsync } from "../state/openclaw-state-db.js";
 import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
 
 export async function cleanupSessionStateForTest(
@@ -35,7 +35,7 @@ export async function cleanupSessionStateForTest(
       closeOpenClawAgentDatabaseByPath(database.path);
     }
   }
-  closeOpenClawStateDatabaseByPath(
+  await closeOpenClawStateDatabaseByPathAsync(
     resolveOpenClawStateSqlitePath({ ...process.env, OPENCLAW_STATE_DIR: options.stateDir }),
   );
 }

--- a/src/transcripts/store.test.ts
+++ b/src/transcripts/store.test.ts
@@ -57,7 +57,7 @@ describe("TranscriptsStore", () => {
       await store.writeSession({ ...session("c"), title: "changed" });
       closeOpenClawStateDatabaseForTest();
       expect(writer.db.isOpen).toBe(false);
-      expect(() => acquireOpenClawStateDatabaseFileExclusion(writer.path)).toThrow(
+      await expect(acquireOpenClawStateDatabaseFileExclusion(writer.path)).rejects.toThrow(
         StateDatabaseCoordinatorContentionError,
       );
       const remaining: string[] = [];
@@ -68,7 +68,7 @@ describe("TranscriptsStore", () => {
     } finally {
       await rows.return(false);
     }
-    const exclusion = acquireOpenClawStateDatabaseFileExclusion(writer.path);
+    const exclusion = await acquireOpenClawStateDatabaseFileExclusion(writer.path);
     exclusion.release();
     expect((await store.readSession("c"))?.title).toBe("changed");
   });
@@ -88,7 +88,7 @@ describe("TranscriptsStore", () => {
       try {
         const first = await rows.next();
         expect(first.done).toBe(false);
-        expect(() => acquireOpenClawStateDatabaseFileExclusion(writer.path)).toThrow(
+        await expect(acquireOpenClawStateDatabaseFileExclusion(writer.path)).rejects.toThrow(
           StateDatabaseCoordinatorContentionError,
         );
         if (finish === "return") {
@@ -107,7 +107,7 @@ describe("TranscriptsStore", () => {
       } finally {
         await rows.return(undefined);
       }
-      const exclusion = acquireOpenClawStateDatabaseFileExclusion(writer.path);
+      const exclusion = await acquireOpenClawStateDatabaseFileExclusion(writer.path);
       exclusion.release();
       expect((await store.readUtterancesForSession(target)).map((row) => row.text)).toEqual([
         "first",

--- a/src/wizard/setup.migration-stage.ts
+++ b/src/wizard/setup.migration-stage.ts
@@ -22,7 +22,7 @@ import {
   disposeOpenClawAgentDatabaseByPath,
   openOpenClawAgentDatabase,
 } from "../state/openclaw-agent-db.js";
-import { closeOpenClawStateDatabaseByPath } from "../state/openclaw-state-db.js";
+import { closeOpenClawStateDatabaseByPathAsync } from "../state/openclaw-state-db.js";
 import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
 import { hashSetupMigrationConfig } from "./setup.migration-canonical.js";
 import {
@@ -315,14 +315,14 @@ export async function createSetupMigrationStage(params: {
   let finalAgentDatabaseRegistered = false;
   let retainForRecovery = false;
 
-  const disposeDatabases = () => {
+  const disposeDatabases = async () => {
     if (databasesDisposed) {
       return;
     }
     clearRuntimeAuthProfileStoreSnapshot(stagedAgentDir);
     const stagedAgentDatabasePath = path.join(stagedAgentDir, "openclaw-agent.sqlite");
     disposeOpenClawAgentDatabaseByPath(stagedAgentDatabasePath, { env: stageEnv });
-    closeOpenClawStateDatabaseByPath(resolveOpenClawStateSqlitePath(stageEnv));
+    await closeOpenClawStateDatabaseByPathAsync(resolveOpenClawStateSqlitePath(stageEnv));
     databasesDisposed = true;
   };
 
@@ -341,7 +341,7 @@ export async function createSetupMigrationStage(params: {
     projectPlanToStage: (plan) => projectPlanTargets(plan, toStage),
     projectResultToFinal: (result) => projectValue(result, toFinal) as MigrationApplyResult,
     async promote({ expectedConfig, continuation, readConfigFile, commitConfigFile }) {
-      disposeDatabases();
+      await disposeDatabases();
       // Bootstrap owns this state-local lock tree; it is not provider output and must not be promoted.
       const gatewayLockDir = resolveGatewayLockDir(stagedStateDir);
       await fs.rm(gatewayLockDir, { recursive: true, force: true });
@@ -492,7 +492,7 @@ export async function createSetupMigrationStage(params: {
       if (retainForRecovery) {
         return;
       }
-      disposeDatabases();
+      await disposeDatabases();
       await Promise.all([
         fs.rm(stagedStateDir, { recursive: true, force: true }),
         fs.rm(stagedWorkspaceDir, { recursive: true, force: true }),

--- a/src/worker/worker.runtime.ts
+++ b/src/worker/worker.runtime.ts
@@ -10,7 +10,7 @@ import type { ComputerContextEpoch } from "../agents/tools/computer-tool.js";
 import { isPathInside } from "../infra/path-guards.js";
 import { registerSecretValueForRedaction } from "../logging/secret-redaction-registry.js";
 import { getProcessSupervisor } from "../process/supervisor/index.js";
-import { closeOpenClawStateDatabaseByPath } from "../state/openclaw-state-db-cache.js";
+import { closeOpenClawStateDatabaseByPathAsync } from "../state/openclaw-state-db-cache.js";
 import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
 import type { WorkerBrowserRuntime } from "./browser-runtime.js";
 import { buildWorkerConnectParams, type WorkerLaunchDescriptor } from "./launch-descriptor.js";
@@ -90,7 +90,7 @@ export async function createWorkerRuntimeEnvironment(sessionId: string) {
           throw failed.reason;
         }
         // Exec finalizers can open state; release its handle before Windows removes the file.
-        closeOpenClawStateDatabaseByPath(
+        await closeOpenClawStateDatabaseByPathAsync(
           resolveOpenClawStateSqlitePath({ OPENCLAW_STATE_DIR: stateDir }),
         );
         // Process completion writes its task outcome into this environment's state.
@@ -106,7 +106,10 @@ export async function createWorkerRuntimeEnvironment(sessionId: string) {
           process.env.OPENCLAW_CONFIG_PATH = previousConfigPath;
         }
         await rm(stateDir, { recursive: true, force: true });
-      })()),
+      })().catch((error: unknown) => {
+        closing = undefined;
+        throw error;
+      })),
   };
 }
 

--- a/test/scripts/run-vitest-state-cleanup.test.ts
+++ b/test/scripts/run-vitest-state-cleanup.test.ts
@@ -39,11 +39,11 @@ const counterfactualFailure = "counterfactual first-file failure after allocatio
 const fixtureTests = [
   [
     "tui-pty-harness.e2e.test.ts",
-    "opens actual fallback SQLite and retains it until the worker finishes",
+    "opens actual fallback SQLite and retains it until file drainage",
   ],
   [
     "tui-pty-local.e2e.test.ts",
-    "keeps the same worker namespace alive across files and module resets",
+    "keeps the worker namespace and stored rows across file drainage and module resets",
   ],
 ] as const;
 
@@ -271,6 +271,7 @@ it(${JSON.stringify(fixtureTests[0][1])}, () => {
   closeOpenClawStateDatabaseForTest();
   expect(first.db.isOpen).toBe(false);
   const reopened = openOpenClawStateDatabase();
+  reopened.db.exec("CREATE TABLE worker_lifetime_sentinel(value TEXT); INSERT INTO worker_lifetime_sentinel VALUES ('retained')");
   const fallback = openOpenClawStateDatabase({ env: {} });
   expect(fallback.path).toBe(fallbackPath);
   const explicit = openOpenClawStateDatabase({ env: { OPENCLAW_STATE_DIR: ${JSON.stringify(path.dirname(path.dirname(explicitPath)))} } });
@@ -294,12 +295,14 @@ const { openOpenClawStateDatabase } = await import(${databaseModule});
 const resources = await allocateResources();
 it(${JSON.stringify(fixtureTests[1][1])}, () => {
   expect(process.pid).toBe(previous.pid);
-  expect(previous.reopened.db.isOpen).toBe(true);
-  expect(previous.explicit.db.isOpen).toBe(true);
-  expect(previous.fallback.db.isOpen).toBe(true);
+  expect(previous.reopened.db.isOpen).toBe(false);
+  expect(previous.explicit.db.isOpen).toBe(false);
+  expect(previous.fallback.db.isOpen).toBe(false);
   expect(assertHomeBoundary()).toBe(previous.fallback.path);
   const current = openOpenClawStateDatabase();
   expect(current.path).toBe(previous.reopened.path);
+  expect(current.db === previous.reopened.db).toBe(false);
+  expect(current.db.prepare("SELECT value FROM worker_lifetime_sentinel").get().value).toBe("retained");
   expect(current.db.prepare("SELECT count(*) AS count FROM sqlite_schema").get().count).toBeGreaterThan(0);
   expect(fs.existsSync(current.path)).toBe(true);
   expect(resources.home).toBe(previous.resources.home);


### PR DESCRIPTION
Related: #144592
Depends on landed #145926.

## What Problem This Solves

Plugin authors have no opt-in asynchronous task and flow read API. They need an awaited way to query persisted state through the runtime SDK while existing synchronous integrations remain supported.

## Why This Change Was Made

Adds 14 reads under `api.runtime.tasks.async`, using the existing session-binding factories, owner checks, lookup precedence, and public payloads. A shared SQLite worker executes scoped queries through canonical task/flow kernels. Compound flow reads use one snapshot, and replies do not overwrite the synchronous registry cache. The landed broker framing preserves complete large managed records and lists; DTO projections omit private task details and unused flow state/wait JSON.

The state cache owns physical database identity, read admission, and drainage. Maintenance, exclusion, and shutdown callers await that owner before retiring native handles. Pending opens, failed-close custody, global restart, and native invalid-path diagnostics retain their existing owners.

## User Impact

Plugins can await task, flow, and managed-flow reads. Bundled Webhooks read actions use this surface. The 14 corresponding synchronous reads remain available with deprecation guidance; removal requires supported external-plugin migration and an approved Plugin SDK major. Mutations, cancellation, revision checks, and final backing-task read/link operations retain their existing owners.

New async lists have documented deterministic ID ordering for equal timestamps. Cold registry/schema admission and bare-owner configuration preparation still perform synchronous work. Warm SQL queries execute in the worker. Authoritative worker reads have greater per-call latency than cached-map reads; cold preparation and worker mutations remain follow-up work.

## Evidence

Final candidate: `17b19079fe19e33182de405f33d4e2ce050af831`, based on landed framing merge `ecfbddbbcc819d0bb9d5ef10adf560117cf67a4a`.

- Full final build, package integrity/import graph checks, changed-file gate, and [exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34692866014) passed. Final composition passed 125 focused cases covering registered reads, owner/lookup collisions, schema admission, identity, drainage, ACP, and Gateway cleanup. Independent reviews found no unresolved actionable findings.
- Source and compiled registered-API checks returned an exact 68,157,905-byte managed result through get/list and flow detail. The projected flow list was 262 bytes. The compiled check observed `dist/state/openclaw-state.worker.js` and completed canonical drainage.
- Pinned Node 24.20.0 measurements at 1,000 and 10,000 task rows, with 100 owner rows, observed zero warmed main-thread SQLite calls. The original benchmark base was `ad7534cc7f35d4ed5fa542a04090936d107e0301`; cold admission still made 2,763 calls. Compiled median get/list/summary latency was 0.152/1.103/0.735 ms versus 0.003/0.226/0.140 ms for cached synchronous reads. These measurements are separate from transport-size and update qualification.
- An isolated published-driver qualification used unchanged `openclaw@2026.9.4` to update to the final candidate. Updater status was `ok`, its ledger was `succeeded`, and plugin convergence was `ok`. The installed build reported `17b19079`; installed runtime, lifecycle, and state-worker hashes matched the pinned candidate tarball. Exact task/flow rows and CLI payloads survived baseline, update, first startup, and restart. Candidate async reads/drain passed; the published backup was verified and restored by the candidate with the exact retained records recovered. Restarted health/readiness returned HTTP 200 and RPC succeeded.

Candidate tarball SHA-256: `f6b180a218e74c3e639e0b6df154b316c293f2647e2c04b044f3fc6c92796f80`.

Qualification limits: startup and restart took about 76 seconds, and a startup sample reported event-loop degradation with roughly 3.1 seconds p99 delay. This does not establish whole-Gateway nonblocking performance or attribute that sample to SQLite. Doctor recorded expected fixture advisories for disabled device pairing, loopback binding, and ambiguous channel ownership. The application cell exited 0; artifact collection subsequently exited 2 on container-owned permissions and was recovered read-only with exit 0, without an application rerun. All owned cloud resources were released.
