### PR TITLE
test: make Bun-hosted runtime checks portable

### DIFF
--- a/src/dockerfile.test.ts
+++ b/src/dockerfile.test.ts
@@ -6,6 +6,7 @@ import { basename, dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { BUNDLED_PLUGIN_ROOT_DIR } from "openclaw/plugin-sdk/test-fixtures";
 import { describe, expect, it } from "vitest";
+import { resolveTestNodeExecPath } from "./test-utils/node-process.js";
 
 const repoRoot = resolve(fileURLToPath(new URL(".", import.meta.url)), "..");
 const dockerfilePath = join(repoRoot, "Dockerfile");
@@ -347,7 +348,7 @@ describe("Dockerfile", () => {
           expect
             .soft(
               () =>
-                execFileSync(process.execPath, [scriptPath], {
+                execFileSync(resolveTestNodeExecPath(), [scriptPath], {
                   cwd: fixture,
                   env: {
                     HOME: home,

--- a/src/flows/doctor-core-checks.runtime.test.ts
+++ b/src/flows/doctor-core-checks.runtime.test.ts
@@ -1543,7 +1543,7 @@ describe("doctor provider catalog projection checks", () => {
         path: "plugins.entries.mockplugin",
         target: "mockplugin",
         message: "Provider catalog mockplugin failed during doctor validation.",
-        requirement: "Cannot perform 'get' on a proxy that has been revoked",
+        requirement: expect.stringMatching(/proxy.*revoked/iu),
       }),
     );
   });

--- a/src/meeting-bot/node-host.test.ts
+++ b/src/meeting-bot/node-host.test.ts
@@ -33,21 +33,25 @@ describe("MeetingNodeAudioPullWaiters", () => {
     expect(vi.getTimerCount()).toBe(0);
   });
 
-  it("releases its real timeout resource when audio wakes the waiter early", async () => {
-    const activeTimeouts = () =>
-      process.getActiveResourcesInfo().filter((resource) => resource === "Timeout").length;
-    const baselineTimeouts = activeTimeouts();
-    const waiters = new MeetingNodeAudioPullWaiters();
-    const waiting = waiters.wait(2_000);
+  // Bun does not expose Timeout entries through process.getActiveResourcesInfo().
+  it.skipIf(Boolean(process.versions.bun))(
+    "releases its real timeout resource when audio wakes the waiter early",
+    async () => {
+      const activeTimeouts = () =>
+        process.getActiveResourcesInfo().filter((resource) => resource === "Timeout").length;
+      const baselineTimeouts = activeTimeouts();
+      const waiters = new MeetingNodeAudioPullWaiters();
+      const waiting = waiters.wait(2_000);
 
-    expect(waiters.size).toBe(1);
-    expect(activeTimeouts()).toBe(baselineTimeouts + 1);
-    waiters.wake();
-    await waiting;
+      expect(waiters.size).toBe(1);
+      expect(activeTimeouts()).toBe(baselineTimeouts + 1);
+      waiters.wake();
+      await waiting;
 
-    expect(waiters.size).toBe(0);
-    expect(activeTimeouts()).toBe(baselineTimeouts);
-  });
+      expect(waiters.size).toBe(0);
+      expect(activeTimeouts()).toBe(baselineTimeouts);
+    },
+  );
 
   it("cancels every pull timeout when a wake releases concurrent waiters", async () => {
     vi.useFakeTimers();

--- a/src/node-host/invoke.ts
+++ b/src/node-host/invoke.ts
@@ -318,7 +318,7 @@ function clarifyNodeExecCwdSpawnError(
   cwd: string | undefined,
 ): string {
   const message = error.message;
-  if (!cwd || (error.code !== "ENOENT" && error.code !== "ENOTDIR")) {
+  if (!cwd || (error.code && error.code !== "ENOENT" && error.code !== "ENOTDIR")) {
     return message;
   }
   let reason: "does not exist" | "is not a directory";

--- a/src/node-host/node-worker-bundle-installer.test.ts
+++ b/src/node-host/node-worker-bundle-installer.test.ts
@@ -1,6 +1,4 @@
-import type { ChildProcess } from "node:child_process";
 import { createHash } from "node:crypto";
-import { channel } from "node:diagnostics_channel";
 import fs from "node:fs/promises";
 import http from "node:http";
 import os from "node:os";
@@ -748,10 +746,13 @@ describe("node worker bundle installer", () => {
   it("cancels prewarming and releases the namespace queue for the next install", async ({
     signal,
   }) => {
+    const slowMarker = path.join(root, "slow-prewarm-started");
     const slow = await bundleFixture({
       fixtureName: "slow",
       bundlePrewarm: 1,
-      workerSource: 'process.stdout.write("started");\nprocess.stdin.resume();\n',
+      workerSource: `import fs from "node:fs";\nfs.writeFileSync(${JSON.stringify(
+        slowMarker,
+      )}, String(process.pid));\nprocess.stdin.resume();\n`,
     });
     const fastMarker = path.join(root, "fast-prewarm-finished");
     const fast = await bundleFixture({
@@ -783,53 +784,39 @@ describe("node worker bundle installer", () => {
     const controller = new AbortController();
     const cleanupController = new AbortController();
     const testSignal = AbortSignal.any([signal, cleanupController.signal]);
-    const started = createDeferredCore<ChildProcess>();
-    const children = new Map<ChildProcess, Promise<void>>();
-    const entries = [slow, fast].map((fixture) =>
-      path.join(
-        root,
-        fixture.input.gatewayNamespace,
-        "bundles",
-        fixture.input.build.bundleHash,
-        "worker.mjs",
-      ),
-    );
-    const childProcesses = channel("child_process");
-    const trackPrewarm = (message: unknown) => {
-      const child = (message as { process: ChildProcess }).process;
-      child.once("spawn", () => {
-        if (!entries.includes(child.spawnargs[1] ?? "")) {
-          return;
-        }
-        const closed = createDeferredCore();
-        child.once("close", () => closed.resolve());
-        children.set(child, closed.promise);
-        if (child.spawnargs[1] === entries[0]) {
-          child.stdout!.once("data", () => started.resolve(child));
-        }
-      });
-    };
-    childProcesses.subscribe(trackPrewarm);
     const first = installer.ensure({
       input: slow.input,
       gatewayUrl,
       signal: AbortSignal.any([controller.signal, testSignal]),
     });
     const installs = [first];
+    let slowPid: number | undefined;
     cleanupPrewarming = async () => {
       cleanupController.abort();
-      for (const child of children.keys()) {
-        if (child.exitCode === null && child.signalCode === null) {
-          child.kill("SIGKILL");
+      if (!slowPid) {
+        const rawPid = await fs.readFile(slowMarker, "utf8").catch(() => undefined);
+        slowPid = rawPid ? Number(rawPid) : undefined;
+      }
+      if (slowPid) {
+        try {
+          process.kill(slowPid, "SIGKILL");
+        } catch {
+          // The cancellation path already reaped the process.
         }
       }
-      await Promise.allSettled([...installs, ...children.values()]);
-      childProcesses.unsubscribe(trackPrewarm);
+      await Promise.allSettled(installs);
     };
     // Startup time is not the cancellation contract: hold the real child until
-    // abort, and join its close event even when readiness or assertions fail.
-    const slowChild = await Promise.race([
-      started.promise,
+    // abort, and retain its PID so cleanup can terminate it after assertion failure.
+    await Promise.race([
+      vi.waitFor(
+        async () => {
+          const value = await fs.readFile(slowMarker, "utf8");
+          expect(value).toMatch(/^\d+$/u);
+          slowPid = Number(value);
+        },
+        { timeout: 10_000 },
+      ),
       first.then(() => {
         throw new Error("prewarm finished before cancellation");
       }),
@@ -846,8 +833,9 @@ describe("node worker bundle installer", () => {
       expect(first).rejects.toThrow("launch fenced"),
     ]);
     await expect(second).resolves.toEqual(fast.input.build);
-    await children.get(slowChild);
-    expect(slowChild.killed).toBe(true);
+    await vi.waitFor(() => {
+      expect(() => process.kill(slowPid!, 0)).toThrow();
+    });
     await expect(fs.readFile(fastMarker, "utf8")).resolves.toBe("ready");
   });
 });

--- a/src/node-host/node-worker-supervisor.test.ts
+++ b/src/node-host/node-worker-supervisor.test.ts
@@ -525,15 +525,22 @@ describe("node worker supervisor", () => {
         expect(workerEnv).not.toHaveProperty("HTTPS_PROXY");
         expect(workerEnv).not.toHaveProperty("SUPPLIED_SECRET");
         expect(JSON.stringify(workerEnv)).not.toContain(TEST_WORKER_CREDENTIAL);
-        const platformInjectedKeys =
-          process.platform === "darwin" ? ["__CF_USER_TEXT_ENCODING"] : [];
-        expect(Object.keys(workerEnv).toSorted()).toEqual(
-          [...Object.keys(expectedWorkerEnv), ...platformInjectedKeys]
-            .filter(
-              (key) => expectedWorkerEnv[key] !== undefined || platformInjectedKeys.includes(key),
-            )
+        const platformInjectedKeys = new Set(
+          process.platform === "darwin" ? ["__CF_USER_TEXT_ENCODING"] : [],
+        );
+        expect(
+          Object.keys(workerEnv)
+            .filter((key) => !platformInjectedKeys.has(key))
+            .toSorted(),
+        ).toEqual(
+          Object.keys(expectedWorkerEnv)
+            .filter((key) => expectedWorkerEnv[key] !== undefined)
             .toSorted(),
         );
+        if (workerEnv["__CF_USER_TEXT_ENCODING"] !== undefined) {
+          expect(process.platform).toBe("darwin");
+          expect(workerEnv["__CF_USER_TEXT_ENCODING"]).toBeTypeOf("string");
+        }
         await supervisor.close();
       },
     );

--- a/src/node-host/node-worker-workspace.test.ts
+++ b/src/node-host/node-worker-workspace.test.ts
@@ -71,7 +71,7 @@ describe("node worker workspace seeds", () => {
     const result = await execSeed({ action: "apply", key });
 
     expect(result).toMatchObject({ workspaceDir: workspace, code: 0, stdout: "applied\n" });
-    expect(await fsp.readdir(workspace)).toEqual([".git", "link.txt", "tracked.txt"]);
+    expect((await fsp.readdir(workspace)).toSorted()).toEqual([".git", "link.txt", "tracked.txt"]);
     expect(await fsp.readFile(path.join(workspace, "tracked.txt"), "utf8")).toBe("original");
     expect(await fsp.readlink(path.join(workspace, "link.txt"))).toBe("tracked.txt");
     // Apply leaves the store-freshness clock untouched so a used seed still refreshes.

--- a/src/plugins/loader.test-fixtures.ts
+++ b/src/plugins/loader.test-fixtures.ts
@@ -32,7 +32,7 @@ export function mkdirSafe(dir: string) {
   chmodSafeDir(dir);
 }
 
-const fixtureRoot = mkdtempSafe(path.join(os.tmpdir(), "openclaw-plugin-"));
+const fixtureRoot = fs.realpathSync(mkdtempSafe(path.join(os.tmpdir(), "openclaw-plugin-")));
 let tempDirIndex = 0;
 const prevBundledDir = process.env.OPENCLAW_BUNDLED_PLUGINS_DIR;
 const prevDisableBundledPlugins = process.env.OPENCLAW_DISABLE_BUNDLED_PLUGINS;

--- a/src/skills/loading/workspace-skill-loader.test.ts
+++ b/src/skills/loading/workspace-skill-loader.test.ts
@@ -265,7 +265,7 @@ describe("loadWorkspaceSkills", () => {
     expect(mergedControlUi?.skill.source).toBe("openclaw-workspace");
     expect(bundledControlUi?.skill.source).toBe("openclaw-bundled");
     expect(bundledControlUi?.skill.filePath).toBe(
-      path.join(bundledSkillsDir, "control-ui", "SKILL.md"),
+      await fs.realpath(path.join(bundledSkillsDir, "control-ui", "SKILL.md")),
     );
   });
 

--- a/src/skills/runtime/refresh.missing-root.integration.test.ts
+++ b/src/skills/runtime/refresh.missing-root.integration.test.ts
@@ -150,10 +150,13 @@ it("refreshes skills created beneath an initially missing project skills root", 
     const existingSkill = path.join(workspaceDir, "skills", "existing", "SKILL.md");
     // This control covers writes after registration; the cases above cover
     // cached discovery while the initial scan is still pending.
-    await vi.waitFor(() => {
-      expect(registeredPaths.has(workspaceDir)).toBe(true);
-      expect(registeredPaths.has(path.dirname(existingSkill))).toBe(true);
-    });
+    // Bun does not project spy replacements onto already-bound node:fs named exports.
+    if (!process.versions.bun) {
+      await vi.waitFor(() => {
+        expect(registeredPaths.has(workspaceDir)).toBe(true);
+        expect(registeredPaths.has(path.dirname(existingSkill))).toBe(true);
+      });
+    }
     await fs.writeFile(existingSkill, "existing skill");
     await vi.waitFor(() => expect(changes).toContain(existingSkill), { timeout: 3_000 });
     const newSkill = path.join(workspaceDir, ".agents", "skills", "new", "SKILL.md");
@@ -167,9 +170,11 @@ it("refreshes skills created beneath an initially missing project skills root", 
       },
       { timeout: 3_000 },
     );
-    expect(inheritedContexts.length).toBeGreaterThan(0);
-    for (const context of inheritedContexts) {
-      expect(context).toEqual({ turn: undefined, pendingInput: undefined });
+    if (!process.versions.bun) {
+      expect(inheritedContexts.length).toBeGreaterThan(0);
+      for (const context of inheritedContexts) {
+        expect(context).toEqual({ turn: undefined, pendingInput: undefined });
+      }
     }
   } finally {
     unregister();

--- a/src/skills/runtime/refresh.test.ts
+++ b/src/skills/runtime/refresh.test.ts
@@ -55,7 +55,9 @@ describe("ensureSkillsWatcher", () => {
     createdWatchers.length = 0;
     pluginSkillsMocks.resolvePluginSkillRoots.mockClear();
     pluginSkillsMocks.resolvePluginSkillRootsFromMetadata.mockClear();
-    fixtureRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-watch-fixture-"));
+    fixtureRoot = await fs.realpath(
+      await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-watch-fixture-")),
+    );
     fixtureWorkspaceDir = await createFixtureDirectory("workspace");
     await createFixtureDirectory("workspace/skills");
   });

--- a/src/test-utils/ports.test.ts
+++ b/src/test-utils/ports.test.ts
@@ -1,6 +1,7 @@
 import { createServer as createRealServer } from "node:net";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { withEnvAsync } from "./env.js";
+import { spawnNodeEvalSync } from "./node-process.js";
 
 const host = vi.hoisted(() => ({
   platform: vi.fn(() => "linux"),
@@ -140,9 +141,12 @@ describe("deterministic test port blocks", () => {
       );
       const { getDeterministicFreePortBlock, isPortFree } = await import("./ports.js");
       await expect(isPortFree(last)).resolves.toBe(true);
-      await expect(fetch(`http://127.0.0.1:${last}/`)).rejects.toMatchObject({
-        cause: { message: "bad port" },
-      });
+      const blocked = spawnNodeEvalSync(
+        `try { await fetch("http://127.0.0.1:${last}/"); process.exitCode = 1; } catch (error) { process.stdout.write(JSON.stringify({ cause: error.cause?.message })); }`,
+      );
+      expect(blocked.error, blocked.stderr).toBeUndefined();
+      expect(blocked.status, blocked.stderr).toBe(0);
+      expect(JSON.parse(blocked.stdout)).toEqual({ cause: "bad port" });
       const port = await getDeterministicFreePortBlock({ offsets });
       for (const offset of offsets) {
         expect(port + offset).toBeGreaterThanOrEqual(1800);

--- a/src/worker/worker.runtime.test.ts
+++ b/src/worker/worker.runtime.test.ts
@@ -1071,6 +1071,7 @@ describe("worker runtime", () => {
 
   it.each([false, true])("uses only prepared prompt inputs (Gateway extra: %s)", async (extra) => {
     const { gateway, workspaceDir, launch } = await setup();
+    const canonicalWorkspaceDir = await realpath(workspaceDir);
     const promptDir = path.join(workspaceDir, ".openclaw");
     const literalPrompt = path.join(workspaceDir, "not-a-prompt-file.md");
     await mkdir(promptDir);
@@ -1091,8 +1092,8 @@ describe("worker runtime", () => {
       expect(
         openedFiles.mock.calls
           .map(([params]) => params.absolutePath)
-          .filter((filePath) => path.dirname(filePath) === workspaceDir),
-      ).toEqual([path.join(workspaceDir, "AGENTS.md")]);
+          .filter((filePath) => path.dirname(filePath) === canonicalWorkspaceDir),
+      ).toEqual([path.join(canonicalWorkspaceDir, "AGENTS.md")]);
     } finally {
       openedFiles.mockRestore();
     }


### PR DESCRIPTION
## Problem

Direct Bun execution exposed tests that treated Node or filesystem implementation details as cross-runtime contracts: lifecycle scripts inherited the Bun host, blocked-port proof relied on Bun fetch behavior, `readdir` order and macOS `/var` aliases were compared literally, a Node-only timeout resource inventory was asserted under Bun, macOS process-injected environment keys were treated as mandatory, and revoked-Proxy wording was exact. Several shared plugin, worker, and watcher fixtures also mixed logical and canonical macOS temp paths. Bun reports a code-less spawn error when the requested cwd is a file, so the node-host diagnostic blamed the runtime instead of the invalid cwd.

## Solution

Use the existing real-Node resolver for Node-specific lifecycle and Fetch-blocklist proof. Keep filesystem checks semantic by sorting directory entries and comparing canonical paths. Canonicalize shared fixture roots before plugin loading and path-ownership assertions. Preserve exact Node assertions while allowing only documented Bun differences, and skip only the Node resource-inventory probe under Bun while fake-timer ownership tests continue to cover timeout cleanup. The real watcher integration remains active under Bun; only instrumentation that Bun cannot project onto an already-bound `node:fs` named export is omitted.

For node-host execution, inspect the cwd after a failed spawn when Bun provides no error code. Conflicting errors such as `EACCES` remain untouched, and the command still fails closed with the original cwd.

## Impact

No install dependencies or public configuration change. Bun-hosted tests exercise the same product behavior without inheriting Node-only observation details, and Bun users receive the same useful invalid-cwd diagnostic as Node users.

## Evidence

- Custom Bun: 301 passed, 1 documented capability skip across the 12 affected files.
- Node: 302/302 passed across the same files.
- Focused cwd diagnostics: 12/12 under custom Bun and 12/12 under Node.
- `node scripts/check-changed.mjs` passed after correcting the one local lint finding on direct access to `__CF_USER_TEXT_ENCODING`.
- P0-P2 autoreview against the pinned merge base: clean.
