### PR TITLE
fix(auth): recover accounts after subscription quota resets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2836,6 +2836,7 @@ jobs:
             ui/src/e2e/control-ui-auth-transports.e2e.test.ts \
             ui/src/e2e/usage-sessions-owner-attribution.e2e.test.ts \
             ui/src/e2e/profile-page.real-gateway.e2e.test.ts \
+            ui/src/e2e/quota-reset-status.real-gateway.e2e.test.ts \
             ui/src/e2e/logs-lifecycle.e2e.test.ts \
             ui/src/e2e/agent-file-lifecycle.real-gateway.e2e.test.ts \
             ui/src/e2e/chat-composer-websearch-kill-switch.real-gateway.e2e.test.ts \

--- a/src/agents/auth-profiles/profiles.ts
+++ b/src/agents/auth-profiles/profiles.ts
@@ -80,18 +80,6 @@ function replaceProviderAuthState<T>(
   return Object.keys(next).length > 0 ? next : undefined;
 }
 
-function updateSuccessfulUsageStatsEntry(
-  store: AuthProfileStore,
-  profileId: string,
-  lastUsed?: number,
-): void {
-  store.usageStats = store.usageStats ?? {};
-  store.usageStats[profileId] = resetAuthProfileFailureState(
-    store.usageStats[profileId] ?? {},
-    lastUsed === undefined ? undefined : { lastUsed },
-  );
-}
-
 /** Sets or clears explicit auth profile order for a provider. */
 export async function setAuthProfileOrder(params: {
   agentDir?: string;
@@ -520,7 +508,11 @@ export async function markAuthProfileSuccess(params: {
       if (updatesSelection) {
         freshStore.lastGood = replaceProviderAuthState(freshStore.lastGood, providerKey, profileId);
       }
-      updateSuccessfulUsageStatsEntry(freshStore, profileId, inherited ? undefined : lastUsed);
+      freshStore.usageStats ??= {};
+      freshStore.usageStats[profileId] = resetAuthProfileFailureState(
+        freshStore.usageStats[profileId] ?? {},
+        { lastProbeAt: Date.now(), ...(inherited ? {} : { lastUsed }) },
+      );
       applied = true;
       return true;
     },

--- a/src/agents/auth-profiles/types.ts
+++ b/src/agents/auth-profiles/types.ts
@@ -124,6 +124,7 @@ export type ProfileUsageStats = {
   errorCount?: number;
   failureCounts?: Partial<Record<AuthProfileFailureReason, number>>;
   lastFailureAt?: number;
+  /** Most recent quota probe or successful provider use. */
   lastProbeAt?: number;
 };
 

--- a/src/agents/auth-profiles/usage-state.ts
+++ b/src/agents/auth-profiles/usage-state.ts
@@ -92,7 +92,7 @@ export function isActiveUnusableWindow(until: number | undefined, now: number): 
   return timestamp !== undefined && timestamp > 0 && now < timestamp;
 }
 
-function isBlockedWindowActiveForModel(
+export function isBlockedWindowActiveForModel(
   stats: Pick<ProfileUsageStats, "blockedUntil" | "blockedModel" | "blockedScope">,
   now: number,
   forModel?: string | null,
@@ -117,26 +117,27 @@ function isBlockScopedToDifferentModel(
   );
 }
 
-function shouldBypassModelScopedCooldown(
-  stats: Pick<
-    ProfileUsageStats,
-    | "blockedUntil"
-    | "blockedModel"
-    | "blockedScope"
-    | "cooldownReason"
-    | "cooldownModel"
-    | "disabledUntil"
-  >,
-  now: number,
+export function isCooldownScopedToDifferentModel(
+  stats: Pick<ProfileUsageStats, "cooldownReason" | "cooldownModel">,
   forModel?: string | null,
 ): boolean {
   return Boolean(
     (forModel === null || forModel) &&
     isModelScopedCooldownReason(stats.cooldownReason) &&
     stats.cooldownModel &&
-    (forModel === null || stats.cooldownModel !== forModel) &&
+    (forModel === null || stats.cooldownModel !== forModel),
+  );
+}
+
+function shouldBypassModelScopedCooldown(
+  stats: ProfileUsageStats,
+  now: number,
+  forModel?: string | null,
+): boolean {
+  return (
+    isCooldownScopedToDifferentModel(stats, forModel) &&
     !isBlockedWindowActiveForModel(stats, now, forModel) &&
-    !isActiveUnusableWindow(stats.disabledUntil, now),
+    !isActiveUnusableWindow(stats.disabledUntil, now)
   );
 }
 

--- a/src/agents/auth-profiles/usage.test.ts
+++ b/src/agents/auth-profiles/usage.test.ts
@@ -23,14 +23,12 @@ import {
 } from "./usage.js";
 import { testing as authProfileUsageTesting } from "./usage.test-support.js";
 
-// Mirrors the module-local WHAM half-open reprobe interval contract (45 minutes).
-const WHAM_HALF_OPEN_REPROBE_INTERVAL_MS = 45 * 60 * 1000;
-
 const storeMocks = vi.hoisted(() => ({
   resolvePersistedAuthProfileOwnerAgentDir: vi.fn(
     (params: { agentDir?: string }) => params.agentDir,
   ),
   saveAuthProfileStore: vi.fn(),
+  loadAuthProfileStoreWithoutExternalProfiles: vi.fn(),
   updateAuthProfileStoreWithLock: vi.fn().mockResolvedValue(null),
 }));
 const fetchMock = vi.hoisted(() => vi.fn());
@@ -40,6 +38,8 @@ vi.mock("./store.js", async (importOriginal) => ({
   resolvePersistedAuthProfileOwnerAgentDir: storeMocks.resolvePersistedAuthProfileOwnerAgentDir,
 }));
 vi.mock("./store-runtime.js", () => ({
+  loadAuthProfileStoreWithoutExternalProfiles:
+    storeMocks.loadAuthProfileStoreWithoutExternalProfiles,
   updateAuthProfileStoreWithLock: storeMocks.updateAuthProfileStoreWithLock,
   saveAuthProfileStore: storeMocks.saveAuthProfileStore,
 }));
@@ -50,6 +50,7 @@ beforeEach(() => {
     (params: { agentDir?: string }) => params.agentDir,
   );
   storeMocks.saveAuthProfileStore.mockReset();
+  storeMocks.loadAuthProfileStoreWithoutExternalProfiles.mockReset();
   storeMocks.updateAuthProfileStoreWithLock.mockReset();
   fetchMock.mockReset();
   vi.stubGlobal("fetch", fetchMock);
@@ -88,6 +89,7 @@ function makeStore(usageStats: AuthProfileStore["usageStats"]): AuthProfileStore
 }
 
 function mockLockedUpdateForStore(store: AuthProfileStore): void {
+  storeMocks.loadAuthProfileStoreWithoutExternalProfiles.mockImplementation(() => store);
   storeMocks.updateAuthProfileStoreWithLock.mockImplementationOnce(
     async (lockParams: { updater: (store: AuthProfileStore) => boolean }) => {
       const freshStore = structuredClone(store);
@@ -98,6 +100,7 @@ function mockLockedUpdateForStore(store: AuthProfileStore): void {
 }
 
 function mockLockedUpdatesForStore(store: AuthProfileStore): void {
+  storeMocks.loadAuthProfileStoreWithoutExternalProfiles.mockImplementation(() => store);
   storeMocks.updateAuthProfileStoreWithLock.mockImplementation(
     async (lockParams: { updater: (store: AuthProfileStore) => boolean }) => {
       const freshStore = structuredClone(store);
@@ -1300,6 +1303,7 @@ describe("markAuthProfileFailure — WHAM-aware Codex cooldowns", () => {
     mockLock?: boolean;
   }): Promise<void> {
     const dateNowSpy = vi.spyOn(Date, "now").mockReturnValue(params.now);
+    storeMocks.loadAuthProfileStoreWithoutExternalProfiles.mockReturnValue(params.store);
     if (params.mockLock !== false) {
       mockLockedUpdateForStore(params.store);
     }
@@ -1344,47 +1348,6 @@ describe("markAuthProfileFailure — WHAM-aware Codex cooldowns", () => {
     });
     expect(store.usageStats?.["openai:default"]?.lastProbeAt).toBe(now);
     expect(storeMocks.updateAuthProfileStoreWithLock).toHaveBeenCalledTimes(2);
-  });
-
-  it("leaves non-WHAM blocks outside the half-open probe path", () => {
-    const now = 1_700_000_000_000;
-    const store = makeStore({
-      "openai:default": {
-        blockedUntil: now + 6 * 24 * 60 * 60 * 1000,
-        blockedReason: "subscription_limit",
-        blockedSource: "codex_rate_limits",
-      },
-    });
-
-    maybeReprobeWhamBlockedProfiles({
-      store,
-      profileIds: ["openai:default"],
-      now,
-    });
-
-    expect(fetchMock).not.toHaveBeenCalled();
-    expect(storeMocks.updateAuthProfileStoreWithLock).not.toHaveBeenCalled();
-  });
-
-  it("does not re-probe a WHAM block inside the half-open interval", () => {
-    const now = 1_700_000_000_000;
-    const store = makeStore({
-      "openai:default": {
-        blockedUntil: now + 6 * 24 * 60 * 60 * 1000,
-        blockedReason: "subscription_limit",
-        blockedSource: "wham",
-        lastProbeAt: now - WHAM_HALF_OPEN_REPROBE_INTERVAL_MS + 1,
-      },
-    });
-
-    maybeReprobeWhamBlockedProfiles({
-      store,
-      profileIds: ["openai:default"],
-      now,
-    });
-
-    expect(fetchMock).not.toHaveBeenCalled();
-    expect(storeMocks.updateAuthProfileStoreWithLock).not.toHaveBeenCalled();
   });
 
   it("re-arms a stale WHAM block from the latest blocked snapshot", async () => {

--- a/src/agents/auth-profiles/usage.test.ts
+++ b/src/agents/auth-profiles/usage.test.ts
@@ -1331,17 +1331,18 @@ describe("markAuthProfileFailure — WHAM-aware Codex cooldowns", () => {
     mockWhamResponse(200, { rate_limit: { limit_reached: false } });
     mockLockedUpdatesForStore(store);
 
-    maybeReprobeWhamBlockedProfiles({
+    const firstProbe = maybeReprobeWhamBlockedProfiles({
       store,
       profileIds: ["openai:default"],
       now,
     });
-    maybeReprobeWhamBlockedProfiles({
+    const secondProbe = maybeReprobeWhamBlockedProfiles({
       store,
       profileIds: ["openai:default"],
       now,
     });
 
+    await Promise.all([firstProbe, secondProbe]);
     await vi.waitFor(() => {
       expect(fetchMock).toHaveBeenCalledOnce();
       expect(store.usageStats?.["openai:default"]?.blockedUntil).toBeUndefined();
@@ -1371,7 +1372,7 @@ describe("markAuthProfileFailure — WHAM-aware Codex cooldowns", () => {
     const dateNowSpy = vi.spyOn(Date, "now").mockReturnValue(now);
 
     try {
-      maybeReprobeWhamBlockedProfiles({
+      await maybeReprobeWhamBlockedProfiles({
         store,
         profileIds: ["openai:default"],
         forModel: "gpt-5.5",
@@ -1408,7 +1409,7 @@ describe("markAuthProfileFailure — WHAM-aware Codex cooldowns", () => {
     );
     mockLockedUpdatesForStore(store);
 
-    maybeReprobeWhamBlockedProfiles({
+    const probe = maybeReprobeWhamBlockedProfiles({
       store,
       profileIds: ["openai:default"],
       now,
@@ -1422,6 +1423,7 @@ describe("markAuthProfileFailure — WHAM-aware Codex cooldowns", () => {
     stats.lastFailureAt = now + 1;
     releaseResponse(Response.json({ rate_limit: { limit_reached: false } }));
 
+    await probe;
     await vi.waitFor(() => {
       expect(storeMocks.updateAuthProfileStoreWithLock).toHaveBeenCalledTimes(2);
     });

--- a/src/agents/auth-profiles/usage.ts
+++ b/src/agents/auth-profiles/usage.ts
@@ -11,13 +11,20 @@ import {
   resolveExpiresAtMsFromDurationMs,
   resolveExpiresAtMsFromEpochSeconds,
 } from "@openclaw/normalization-core/number-coercion";
+import { z } from "zod";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { cancelUnreadResponseBody } from "../../infra/http-body.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { readProviderJsonResponse } from "../provider-http-errors.js";
 import { resolveProviderRequestHeaders } from "../provider-request-config.js";
+import { resolveAuthProfileOrder } from "./order.js";
+import { resolveSharedAuthStorePath } from "./path-resolve.js";
+import { resolveAuthProfileDatabasePath } from "./sqlite.js";
 import { logAuthProfileFailureStateChange } from "./state-observation.js";
-import { updateAuthProfileStoreWithLock } from "./store-runtime.js";
+import {
+  loadAuthProfileStoreWithoutExternalProfiles,
+  updateAuthProfileStoreWithLock,
+} from "./store-runtime.js";
 import { resolvePersistedAuthProfileOwnerAgentDir } from "./store.js";
 import type {
   AuthProfileBlockedSource,
@@ -25,11 +32,14 @@ import type {
   AuthProfileCredential,
   AuthProfileFailureReason,
   AuthProfileStore,
+  OAuthCredential,
   ProfileUsageStats,
 } from "./types.js";
 import {
   isActiveUnusableWindow,
   isAuthCooldownBypassedForProvider,
+  isBlockedWindowActiveForModel,
+  isCooldownScopedToDifferentModel,
   isModelScopedCooldownReason,
   resolveInlineProviderApiKeyUsageId,
   resolveProfileUnusableUntil,
@@ -118,9 +128,6 @@ const FAILURE_REASON_PRIORITY: AuthProfileFailureReason[] = [
   "unknown",
 ];
 const FAILURE_REASON_SET = new Set<AuthProfileFailureReason>(FAILURE_REASON_PRIORITY);
-const FAILURE_REASON_ORDER = new Map<AuthProfileFailureReason, number>(
-  FAILURE_REASON_PRIORITY.map((reason, index) => [reason, index]),
-);
 
 const WHAM_USAGE_URL = "https://chatgpt.com/backend-api/wham/usage";
 const WHAM_TIMEOUT_MS = 3_000;
@@ -129,56 +136,58 @@ const WHAM_PROBE_FAILURE_COOLDOWN_MS = 30_000;
 const WHAM_HTTP_ERROR_COOLDOWN_MS = 5 * 60 * 1000;
 const WHAM_TOKEN_EXPIRED_COOLDOWN_MS = 12 * 60 * 60 * 1000;
 const WHAM_DEAD_ACCOUNT_COOLDOWN_MS = 24 * 60 * 60 * 1000;
-const WHAM_HALF_OPEN_REPROBE_INTERVAL_MS = 45 * 60 * 1000;
+const WHAM_HALF_OPEN_REPROBE_INTERVAL_MS = 5 * 60 * 1000;
 const whamReprobesInFlight = new Map<string, Promise<void>>();
 
-type WhamUsageWindow = {
-  limit_window_seconds?: number;
-  used_percent?: number;
-  reset_at?: number;
-  reset_after_seconds?: number;
-};
-
-type WhamUsageResponse = {
-  rate_limit?: {
-    limit_reached?: boolean;
-    primary_window?: WhamUsageWindow;
-    secondary_window?: WhamUsageWindow;
-  };
-};
+const whamUsageWindowSchema = z.object({
+  used_percent: z.number().optional(),
+  reset_at: z.number().optional(),
+  reset_after_seconds: z.number().optional(),
+});
+type WhamUsageWindow = z.infer<typeof whamUsageWindowSchema>;
+const whamRateLimitSchema = z.object({
+  limit_reached: z.boolean().optional(),
+  primary_window: whamUsageWindowSchema.nullish(),
+  secondary_window: whamUsageWindowSchema.nullish(),
+});
+const whamUsageSchema = z.object({
+  rate_limit: whamRateLimitSchema,
+  additional_rate_limits: z
+    .array(z.object({ rate_limit: whamRateLimitSchema.nullish() }))
+    .nullish(),
+  spend_control: z.object({ reached: z.boolean() }).nullish(),
+  rate_limit_reached_type: z
+    .object({
+      type: z.enum([
+        "rate_limit_reached",
+        "workspace_owner_credits_depleted",
+        "workspace_member_credits_depleted",
+        "workspace_owner_usage_limit_reached",
+        "workspace_member_usage_limit_reached",
+        "unknown",
+      ]),
+    })
+    .nullish(),
+});
 
 type WhamCooldownProbeResult = {
   available?: true;
   cooldownMs: number;
-  reason: string;
+  cooldownClassification?: AuthProfileCooldownClassification;
   blockedUntil?: number;
-  blockedSource?: AuthProfileBlockedSource;
 };
-
-function resolveWhamCooldownClassification(
-  reason: string,
-): AuthProfileCooldownClassification | undefined {
-  return reason === "wham_token_expired" || reason === "wham_account_dead" ? reason : undefined;
-}
-
-function resolveWhamCanonicalCooldownReason(
-  classification: AuthProfileCooldownClassification,
-): Extract<AuthProfileFailureReason, "auth" | "auth_permanent"> {
-  return classification === "wham_token_expired" ? "auth" : "auth_permanent";
-}
 
 function shouldProbeWhamForFailure(
   profile: AuthProfileCredential | undefined,
   reason: AuthProfileFailureReason,
-): boolean {
-  const normalizedProvider = normalizeProviderId(profile?.provider ?? "");
+): profile is OAuthCredential {
   return (
     profile?.type === "oauth" &&
     Boolean(profile.access) &&
     // Expired access tokens are routine and refreshable; probing with one
     // guarantees a 401 that looks like a 12h token-family outage.
     isFutureDateTimestampMs(profile.expires) &&
-    normalizedProvider === "openai" &&
+    normalizeProviderId(profile.provider) === "openai" &&
     (reason === "rate_limit" ||
       reason === "empty_response" ||
       reason === "no_error_details" ||
@@ -214,35 +223,21 @@ function resolveUsageWindowUntil(now: number, durationMs: number): number {
   );
 }
 
-function resolveWhamResetMs(window: WhamUsageWindow | undefined, now: number): number | null {
-  if (!window) {
-    return null;
-  }
-  if (
-    typeof window.reset_after_seconds === "number" &&
-    Number.isFinite(window.reset_after_seconds) &&
-    window.reset_after_seconds > 0
-  ) {
+function resolveWhamResetMs(window: WhamUsageWindow, now: number): number | null {
+  if (window.reset_after_seconds !== undefined && window.reset_after_seconds > 0) {
     return positiveSecondsToSafeMilliseconds(window.reset_after_seconds) ?? null;
   }
-  if (
-    typeof window.reset_at === "number" &&
-    Number.isFinite(window.reset_at) &&
-    window.reset_at > 0
-  ) {
+  if (window.reset_at !== undefined && window.reset_at > 0) {
     const resetAtMs = resolveExpiresAtMsFromEpochSeconds(window.reset_at);
     return resetAtMs === undefined ? null : Math.max(0, resetAtMs - now);
   }
   return null;
 }
 
-function isWhamWindowExhausted(window: WhamUsageWindow | undefined): boolean {
-  return Boolean(
-    window &&
-    typeof window.used_percent === "number" &&
-    Number.isFinite(window.used_percent) &&
-    window.used_percent >= 100,
-  );
+function isWhamWindowExhausted(
+  window: WhamUsageWindow | null | undefined,
+): window is WhamUsageWindow {
+  return window?.used_percent !== undefined && window.used_percent >= 100;
 }
 
 function applyWhamCooldownResult(params: {
@@ -251,27 +246,21 @@ function applyWhamCooldownResult(params: {
   now: number;
   whamResult: WhamCooldownProbeResult;
 }): ProfileUsageStats {
-  const existingCooldownUntil = params.existing.cooldownUntil;
-  const existingBlockedUntil = params.existing.blockedUntil;
-  const existingActiveCooldownUntil =
-    typeof existingCooldownUntil === "number" &&
-    Number.isFinite(existingCooldownUntil) &&
-    existingCooldownUntil > params.now
-      ? existingCooldownUntil
-      : 0;
-  const existingActiveBlockedUntil =
-    typeof existingBlockedUntil === "number" &&
-    Number.isFinite(existingBlockedUntil) &&
-    existingBlockedUntil > params.now
-      ? existingBlockedUntil
-      : 0;
+  const existingActiveCooldownUntil = resolveActiveWindowUntil(
+    params.existing.cooldownUntil,
+    params.now,
+  );
+  const existingActiveBlockedUntil = resolveActiveWindowUntil(
+    params.existing.blockedUntil,
+    params.now,
+  );
   if (params.whamResult.blockedUntil) {
     return {
       ...params.computed,
       lastProbeAt: params.now,
       blockedUntil: Math.max(existingActiveBlockedUntil, params.whamResult.blockedUntil),
       blockedReason: "subscription_limit",
-      blockedSource: params.whamResult.blockedSource ?? "wham",
+      blockedSource: "wham",
       blockedModel: undefined,
       blockedScope: undefined,
       cooldownUntil: undefined,
@@ -280,11 +269,13 @@ function applyWhamCooldownResult(params: {
       cooldownModel: undefined,
     };
   }
-  const cooldownClassification = resolveWhamCooldownClassification(params.whamResult.reason);
+  const { cooldownClassification } = params.whamResult;
   if (
     !cooldownClassification &&
     !params.whamResult.available &&
-    params.computed.cooldownReason === "rate_limit"
+    (params.computed.cooldownReason === "rate_limit" ||
+      (params.computed.blockedReason === "subscription_limit" &&
+        isBlockedWindowActiveForModel(params.computed, params.now)))
   ) {
     // A failed or incomplete probe supplied no authoritative retry deadline.
     // Keep the persisted local backoff instead of replacing it with a fixed delay.
@@ -301,7 +292,9 @@ function applyWhamCooldownResult(params: {
       resolveUsageWindowUntil(params.now, params.whamResult.cooldownMs),
     ),
     cooldownReason: cooldownClassification
-      ? resolveWhamCanonicalCooldownReason(cooldownClassification)
+      ? cooldownClassification === "wham_token_expired"
+        ? "auth"
+        : "auth_permanent"
       : params.computed.cooldownReason,
     cooldownClassification,
     cooldownModel: cooldownClassification ? undefined : params.computed.cooldownModel,
@@ -309,16 +302,9 @@ function applyWhamCooldownResult(params: {
 }
 
 async function probeWhamForCooldown(
-  store: AuthProfileStore,
+  profile: OAuthCredential,
   profileId: string,
-): Promise<WhamCooldownProbeResult | null> {
-  const profile = store.profiles[profileId];
-  if (profile?.type !== "oauth" || !profile.access) {
-    return null;
-  }
-
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), WHAM_TIMEOUT_MS);
+): Promise<WhamCooldownProbeResult> {
   try {
     const version = process.env.OPENCLAW_VERSION?.trim();
     const defaultHeaders: Record<string, string> = {
@@ -343,7 +329,7 @@ async function probeWhamForCooldown(
     const res = await fetch(WHAM_USAGE_URL, {
       method: "GET",
       headers,
-      signal: controller.signal,
+      signal: AbortSignal.timeout(WHAM_TIMEOUT_MS),
     });
 
     if (!res.ok) {
@@ -353,83 +339,72 @@ async function probeWhamForCooldown(
           res.status === 401
             ? {
                 cooldownMs: WHAM_TOKEN_EXPIRED_COOLDOWN_MS,
-                reason: "wham_token_expired" as const,
+                cooldownClassification: "wham_token_expired" as const,
               }
             : {
                 cooldownMs: WHAM_DEAD_ACCOUNT_COOLDOWN_MS,
-                reason: "wham_account_dead" as const,
+                cooldownClassification: "wham_account_dead" as const,
               };
         authProfileUsageLog.warn("WHAM probe classified auth profile unavailable", {
           event: "auth_profile_wham_auth_classification",
           profileId,
           status: res.status,
-          cooldownClassification: result.reason,
+          cooldownClassification: result.cooldownClassification,
           cooldownMs: result.cooldownMs,
           tags: ["auth_profiles", "provider_probe"],
         });
         return result;
       }
-      return { cooldownMs: WHAM_HTTP_ERROR_COOLDOWN_MS, reason: "wham_http_error" };
+      return { cooldownMs: WHAM_HTTP_ERROR_COOLDOWN_MS };
     }
 
-    const data = await readProviderJsonResponse<WhamUsageResponse>(res, "WHAM usage probe");
-    if (!data.rate_limit) {
-      return { cooldownMs: WHAM_PROBE_FAILURE_COOLDOWN_MS, reason: "wham_probe_failed" };
+    const parsed = whamUsageSchema.safeParse(
+      await readProviderJsonResponse<unknown>(res, "WHAM usage probe"),
+    );
+    const failedProbe = { cooldownMs: WHAM_PROBE_FAILURE_COOLDOWN_MS };
+    if (!parsed.success || parsed.data.spend_control?.reached) {
+      return failedProbe;
     }
-
-    if (data.rate_limit.limit_reached === false) {
-      return {
-        available: true,
-        cooldownMs: WHAM_BURST_COOLDOWN_MS,
-        reason: "wham_burst_contention",
-      };
-    }
-
+    const limits = [
+      parsed.data.rate_limit,
+      ...(parsed.data.additional_rate_limits ?? []).flatMap((entry) =>
+        entry.rate_limit ? [entry.rate_limit] : [],
+      ),
+    ];
     const now = Date.now();
-    const primaryResetMs = resolveWhamResetMs(data.rate_limit.primary_window, now);
-    const secondaryResetMs = resolveWhamResetMs(data.rate_limit.secondary_window, now);
-
-    if (!data.rate_limit.secondary_window) {
-      if (primaryResetMs === null) {
-        return { cooldownMs: WHAM_PROBE_FAILURE_COOLDOWN_MS, reason: "wham_probe_failed" };
+    let resetMs = 0;
+    for (const limit of limits) {
+      const windows = [limit.primary_window, limit.secondary_window].filter(isWhamWindowExhausted);
+      if (limit.limit_reached === false && windows.length === 0) {
+        continue;
       }
-      return {
-        cooldownMs: WHAM_BURST_COOLDOWN_MS,
-        blockedUntil: resolveUsageWindowUntil(now, primaryResetMs),
-        blockedSource: "wham",
-        reason: "wham_personal_rolling",
-      };
-    }
-
-    if (isWhamWindowExhausted(data.rate_limit.secondary_window)) {
-      if (secondaryResetMs === null) {
-        return { cooldownMs: WHAM_PROBE_FAILURE_COOLDOWN_MS, reason: "wham_probe_failed" };
+      // Older personal usage responses identify the reached limit without a percentage.
+      if (windows.length === 0 && limit.primary_window && !limit.secondary_window) {
+        windows.push(limit.primary_window);
       }
-      return {
-        cooldownMs: WHAM_BURST_COOLDOWN_MS,
-        blockedUntil: resolveUsageWindowUntil(now, secondaryResetMs),
-        blockedSource: "wham",
-        reason: "wham_team_weekly",
-      };
-    }
-
-    if (isWhamWindowExhausted(data.rate_limit.primary_window)) {
-      if (primaryResetMs === null) {
-        return { cooldownMs: WHAM_PROBE_FAILURE_COOLDOWN_MS, reason: "wham_probe_failed" };
+      if (windows.length === 0) {
+        return failedProbe;
       }
-      return {
-        cooldownMs: WHAM_BURST_COOLDOWN_MS,
-        blockedUntil: resolveUsageWindowUntil(now, primaryResetMs),
-        blockedSource: "wham",
-        reason: "wham_team_rolling",
-      };
+      for (const window of windows) {
+        const remainingMs = resolveWhamResetMs(window, now);
+        if (remainingMs === null || remainingMs <= 0) {
+          return failedProbe;
+        }
+        resetMs = Math.max(resetMs, remainingMs);
+      }
     }
-
-    return { cooldownMs: WHAM_PROBE_FAILURE_COOLDOWN_MS, reason: "wham_probe_failed" };
+    const reachedType = parsed.data.rate_limit_reached_type?.type;
+    if (resetMs === 0 && reachedType && reachedType !== "unknown") {
+      return failedProbe;
+    }
+    return resetMs > 0
+      ? {
+          cooldownMs: WHAM_BURST_COOLDOWN_MS,
+          blockedUntil: resolveUsageWindowUntil(now, resetMs),
+        }
+      : { available: true, cooldownMs: WHAM_BURST_COOLDOWN_MS };
   } catch {
-    return { cooldownMs: WHAM_PROBE_FAILURE_COOLDOWN_MS, reason: "wham_probe_failed" };
-  } finally {
-    clearTimeout(timeout);
+    return { cooldownMs: WHAM_PROBE_FAILURE_COOLDOWN_MS };
   }
 }
 
@@ -443,59 +418,73 @@ function shouldHalfOpenProbeWhamBlock(params: {
   const stats = params.store.usageStats?.[params.profileId];
   if (
     !stats ||
-    stats.blockedSource !== "wham" ||
     stats.blockedReason !== "subscription_limit" ||
-    !isActiveUnusableWindow(stats.blockedUntil, params.now) ||
-    isActiveUnusableWindow(stats.cooldownUntil, params.now) ||
+    !isBlockedWindowActiveForModel(stats, params.now, params.forModel) ||
+    (isActiveUnusableWindow(stats.cooldownUntil, params.now) &&
+      !isCooldownScopedToDifferentModel(stats, params.forModel) &&
+      !(
+        stats.cooldownReason === "rate_limit" &&
+        isBlockedWindowActiveForModel(stats, params.now, stats.cooldownModel ?? null)
+      )) ||
     isActiveUnusableWindow(stats.disabledUntil, params.now) ||
     !shouldProbeWhamForFailure(profile, "rate_limit")
   ) {
     return false;
   }
-  if (
-    params.forModel &&
-    stats.blockedScope === "model" &&
-    stats.blockedModel &&
-    stats.blockedModel !== params.forModel
-  ) {
-    return false;
-  }
-  const remainingMs = (stats.blockedUntil ?? 0) - params.now;
   const sinceLastProbeMs = params.now - (stats.lastProbeAt ?? 0);
-  return (
-    remainingMs > WHAM_HALF_OPEN_REPROBE_INTERVAL_MS &&
-    sinceLastProbeMs >= WHAM_HALF_OPEN_REPROBE_INTERVAL_MS
-  );
+  return sinceLastProbeMs >= WHAM_HALF_OPEN_REPROBE_INTERVAL_MS;
 }
-
-type WhamBlockGeneration = Pick<
-  ProfileUsageStats,
-  "blockedUntil" | "blockedModel" | "blockedScope" | "lastFailureAt"
-> & { rateLimitFailureCount?: number };
 
 function matchesWhamBlockGeneration(
-  stats: ProfileUsageStats,
-  generation: WhamBlockGeneration,
+  stats: ProfileUsageStats | undefined,
+  generation: ProfileUsageStats | undefined,
 ): boolean {
   return (
-    stats.blockedUntil === generation.blockedUntil &&
-    stats.blockedModel === generation.blockedModel &&
-    stats.blockedScope === generation.blockedScope &&
-    stats.lastFailureAt === generation.lastFailureAt &&
-    stats.failureCounts?.rate_limit === generation.rateLimitFailureCount
+    stats?.blockedUntil === generation?.blockedUntil &&
+    stats?.blockedReason === generation?.blockedReason &&
+    stats?.blockedSource === generation?.blockedSource &&
+    stats?.blockedModel === generation?.blockedModel &&
+    stats?.blockedScope === generation?.blockedScope &&
+    stats?.lastProbeAt === generation?.lastProbeAt &&
+    stats?.lastFailureAt === generation?.lastFailureAt &&
+    stats?.failureCounts?.rate_limit === generation?.failureCounts?.rate_limit
   );
 }
 
-async function claimWhamHalfOpenReprobe(params: {
+function reconcileWhamBlock(
+  stats: ProfileUsageStats,
+  result: WhamCooldownProbeResult,
+  now: number,
+): ProfileUsageStats {
+  return {
+    ...stats,
+    blockedUntil: result.blockedUntil,
+    blockedReason: result.available ? undefined : "subscription_limit",
+    blockedSource: result.available ? undefined : "wham",
+    blockedModel: result.available ? undefined : stats.blockedModel,
+    blockedScope: result.available ? undefined : stats.blockedScope,
+    ...(stats.cooldownReason === "rate_limit" &&
+    isBlockedWindowActiveForModel(stats, now, stats.cooldownModel ?? null)
+      ? {
+          cooldownUntil: undefined,
+          cooldownReason: undefined,
+          cooldownClassification: undefined,
+          cooldownModel: undefined,
+        }
+      : {}),
+  };
+}
+
+async function runWhamHalfOpenReprobe(params: {
   store: AuthProfileStore;
   profileId: string;
   agentDir?: string;
   forModel?: string;
-  expectedProfile: AuthProfileCredential;
+  expectedProfile: OAuthCredential;
   startedAt: number;
-}): Promise<WhamBlockGeneration | null> {
-  let generation: WhamBlockGeneration | undefined;
-  const updated = await updateOwnedAuthProfileUsage(params.store, params.profileId, {
+}): Promise<void> {
+  let didClaim = false;
+  const claimed = await updateOwnedAuthProfileUsage(params.store, params.profileId, {
     agentDir: params.agentDir,
     updater: (freshStore) => {
       const currentProfile = freshStore.profiles[params.profileId];
@@ -514,43 +503,21 @@ async function claimWhamHalfOpenReprobe(params: {
       if (!currentStats) {
         return false;
       }
-      generation = {
-        blockedUntil: currentStats.blockedUntil,
-        blockedModel: currentStats.blockedModel,
-        blockedScope: currentStats.blockedScope,
-        lastFailureAt: currentStats.lastFailureAt,
-        rateLimitFailureCount: currentStats.failureCounts?.rate_limit,
-      };
-      updateUsageStatsEntry(freshStore, params.profileId, (existing) => ({
-        ...existing,
-        lastProbeAt: params.startedAt,
-      }));
+      currentStats.lastProbeAt = params.startedAt;
+      didClaim = true;
       return true;
     },
   });
-  if (updated && generation) {
-    return generation;
-  }
-  if (updated === null) {
+  if (claimed === null) {
     logDroppedAuthProfileBookkeeping("wham_half_open_claim", params.profileId);
   }
-  return null;
-}
-
-async function runWhamHalfOpenReprobe(params: {
-  store: AuthProfileStore;
-  profileId: string;
-  agentDir?: string;
-  forModel?: string;
-  expectedProfile: AuthProfileCredential;
-  startedAt: number;
-}): Promise<void> {
-  const generation = await claimWhamHalfOpenReprobe(params);
-  if (!generation) {
+  const claimedStats = claimed?.usageStats?.[params.profileId];
+  if (!didClaim || !claimedStats) {
     return;
   }
-  const result = await probeWhamForCooldown(params.store, params.profileId);
-  if (!result || (!result.available && !result.blockedUntil)) {
+  const blockGeneration = structuredClone(claimedStats);
+  const result = await probeWhamForCooldown(params.expectedProfile, params.profileId);
+  if (!result.available && !result.blockedUntil) {
     return;
   }
   const updated = await updateOwnedAuthProfileUsage(params.store, params.profileId, {
@@ -560,37 +527,13 @@ async function runWhamHalfOpenReprobe(params: {
       const currentStats = freshStore.usageStats?.[params.profileId];
       if (
         !currentStats ||
-        currentStats.blockedSource !== "wham" ||
         currentStats.blockedReason !== "subscription_limit" ||
-        currentStats.lastProbeAt !== params.startedAt ||
-        !matchesWhamBlockGeneration(currentStats, generation) ||
+        !matchesWhamBlockGeneration(currentStats, blockGeneration) ||
         !isSameWhamCredential(params.expectedProfile, currentProfile)
       ) {
         return false;
       }
-      updateUsageStatsEntry(freshStore, params.profileId, (existing) => {
-        if (result.available) {
-          return {
-            ...existing,
-            blockedUntil: undefined,
-            blockedReason: undefined,
-            blockedSource: undefined,
-            blockedModel: undefined,
-            blockedScope: undefined,
-          };
-        }
-        if (result.blockedUntil) {
-          return {
-            ...existing,
-            blockedUntil: result.blockedUntil,
-            blockedReason: "subscription_limit",
-            blockedSource: "wham",
-            blockedModel: generation.blockedModel,
-            blockedScope: generation.blockedScope,
-          };
-        }
-        return existing ?? {};
-      });
+      Object.assign(currentStats, reconcileWhamBlock(currentStats, result, params.startedAt));
       return true;
     },
   });
@@ -599,49 +542,100 @@ async function runWhamHalfOpenReprobe(params: {
   }
 }
 
-/** Starts bounded background refreshes for long WHAM-only profile blocks. */
-export function maybeReprobeWhamBlockedProfiles(params: {
+/** Reconciles subscription blocks before the caller decides whether to admit a turn. */
+export async function maybeReprobeWhamBlockedProfiles(params: {
   store: AuthProfileStore;
   profileIds: string[];
   agentDir?: string;
   forModel?: string;
   now?: number;
-}): void {
+}): Promise<void> {
   const now = params.now ?? Date.now();
-  for (const profileId of params.profileIds) {
-    if (!shouldHalfOpenProbeWhamBlock({ ...params, profileId, now })) {
-      continue;
-    }
-    const profile = params.store.profiles[profileId];
-    if (!profile) {
-      continue;
-    }
-    const probeKey = `${params.agentDir ?? "default"}\u0000${profileId}`;
-    if (whamReprobesInFlight.has(probeKey)) {
-      continue;
-    }
-    // Keep the current synchronous fallback decision: this attempt still
-    // skips. A deduped refresh updates durable state for the next decision.
-    const task = runWhamHalfOpenReprobe({
-      store: params.store,
-      profileId,
-      agentDir: params.agentDir,
-      forModel: params.forModel,
-      expectedProfile: structuredClone(profile),
-      startedAt: now,
-    })
-      .catch((error: unknown) => {
-        authProfileUsageLog.warn("WHAM half-open reprobe failed", {
-          event: "auth_profile_wham_reprobe_error",
-          profileId,
-          error: error instanceof Error ? error.message : String(error),
-        });
-      })
-      .finally(() => {
-        whamReprobesInFlight.delete(probeKey);
+  await Promise.all(
+    params.profileIds.map(async (profileId) => {
+      const shouldProbe = shouldHalfOpenProbeWhamBlock({ ...params, profileId, now });
+      if (!shouldProbe && whamReprobesInFlight.size === 0) {
+        return;
+      }
+      const profile = params.store.profiles[profileId];
+      if (!shouldProbeWhamForFailure(profile, "rate_limit")) {
+        return;
+      }
+      const ownerAgentDir = resolvePersistedAuthProfileOwnerAgentDir({
+        agentDir: params.agentDir,
+        profileId,
       });
-    whamReprobesInFlight.set(probeKey, task);
+      const ownerPath = ownerAgentDir
+        ? resolveAuthProfileDatabasePath(ownerAgentDir)
+        : resolveSharedAuthStorePath();
+      const probeKey = `${ownerPath}\u0000${profileId}`;
+      let task = whamReprobesInFlight.get(probeKey);
+      if (!task) {
+        if (!shouldProbe) {
+          return;
+        }
+        task = runWhamHalfOpenReprobe({
+          ...params,
+          profileId,
+          expectedProfile: structuredClone(profile),
+          startedAt: now,
+        }).finally(() => {
+          whamReprobesInFlight.delete(probeKey);
+        });
+        whamReprobesInFlight.set(probeKey, task);
+      }
+      await task;
+      // Refresh can rotate a token, and a child can gain its own credential while waiting.
+      const settled = loadAuthProfileStoreWithoutExternalProfiles(params.agentDir, { profileId });
+      const credential = settled.profiles[profileId];
+      if (credential) {
+        params.store.profiles[profileId] = credential;
+      } else {
+        delete params.store.profiles[profileId];
+      }
+      const usage = settled.usageStats?.[profileId];
+      if (usage) {
+        params.store.usageStats = { ...params.store.usageStats, [profileId]: usage };
+      } else {
+        delete params.store.usageStats?.[profileId];
+      }
+    }),
+  );
+}
+
+/** Refreshes the selected provider's quota facts before direct runtime admission. */
+export async function reconcileAuthProfileQuotaBlocks(params: {
+  authProfileStore?: AuthProfileStore;
+  provider: string;
+  config?: OpenClawConfig;
+  agentDir?: string;
+  modelId: string;
+  sessionAuthProfileId?: string;
+  sessionAuthProfileSource?: "auto" | "user" | "user-link";
+}): Promise<void> {
+  const store = params.authProfileStore;
+  if (!store || normalizeProviderId(params.provider) !== "openai") {
+    return;
   }
+  const lockedProfileId =
+    params.sessionAuthProfileSource === "user" || params.sessionAuthProfileSource === "user-link"
+      ? params.sessionAuthProfileId
+      : undefined;
+  await maybeReprobeWhamBlockedProfiles({
+    store,
+    agentDir: params.agentDir,
+    forModel: params.modelId,
+    profileIds: lockedProfileId
+      ? [lockedProfileId]
+      : resolveAuthProfileOrder({
+          store,
+          cfg: params.config,
+          provider: params.provider,
+          preferredProfile: params.sessionAuthProfileId,
+          forModel: params.modelId,
+          includePendingOAuthRefresh: true,
+        }),
+  });
 }
 
 /**
@@ -711,23 +705,13 @@ export function resolveProfilesUnavailableReason(params: {
     }
   }
 
-  if (scores.size === 0) {
-    return null;
-  }
-
   let best: AuthProfileFailureReason | null = null;
   let bestScore = -1;
-  let bestPriority = Number.MAX_SAFE_INTEGER;
   for (const reason of FAILURE_REASON_PRIORITY) {
     const score = scores.get(reason);
-    if (typeof score !== "number") {
-      continue;
-    }
-    const priority = FAILURE_REASON_ORDER.get(reason) ?? Number.MAX_SAFE_INTEGER;
-    if (score > bestScore || (score === bestScore && priority < bestPriority)) {
+    if (score !== undefined && score > bestScore) {
       best = reason;
       bestScore = score;
-      bestPriority = priority;
     }
   }
   return best;
@@ -761,40 +745,32 @@ type ResolvedAuthCooldownConfig = {
 type DisabledFailureReason = Extract<AuthProfileFailureReason, "billing" | "auth_permanent">;
 
 type DisabledFailureBackoffPolicy = {
-  baseMs: (cfg: ResolvedAuthCooldownConfig) => number;
-  maxMs: (cfg: ResolvedAuthCooldownConfig) => number;
+  baseMs: number;
+  maxMs: number;
+};
+
+// Keep the initial billing disable short so inline API keys can retry soon
+// after recharge, even though they cannot probe during an active window.
+const AUTH_COOLDOWN_CONFIG: ResolvedAuthCooldownConfig = {
+  billingBackoffMs: 10 * 60 * 1000,
+  billingMaxMs: 24 * 60 * 60 * 1000,
+  authPermanentBackoffMs: 10 * 60 * 1000,
+  authPermanentMaxMs: 60 * 60 * 1000,
+  failureWindowMs: 24 * 60 * 60 * 1000,
 };
 
 const DISABLED_FAILURE_BACKOFF_POLICIES = {
   billing: {
-    baseMs: (cfg) => cfg.billingBackoffMs,
-    maxMs: (cfg) => cfg.billingMaxMs,
+    baseMs: AUTH_COOLDOWN_CONFIG.billingBackoffMs,
+    maxMs: AUTH_COOLDOWN_CONFIG.billingMaxMs,
   },
   auth_permanent: {
     // Recover quickly because some providers surface auth-looking payloads
     // transiently during incidents.
-    baseMs: (cfg) => cfg.authPermanentBackoffMs,
-    maxMs: (cfg) => cfg.authPermanentMaxMs,
+    baseMs: AUTH_COOLDOWN_CONFIG.authPermanentBackoffMs,
+    maxMs: AUTH_COOLDOWN_CONFIG.authPermanentMaxMs,
   },
 } as const satisfies Record<DisabledFailureReason, DisabledFailureBackoffPolicy>;
-
-// Keep the initial billing disable short so inline API keys can retry soon
-// after recharge, even though they cannot probe during an active window.
-const DEFAULT_BILLING_BACKOFF_MINUTES = 10;
-const DEFAULT_BILLING_MAX_HOURS = 24;
-const DEFAULT_AUTH_PERMANENT_BACKOFF_MINUTES = 10;
-const DEFAULT_AUTH_PERMANENT_MAX_MINUTES = 60;
-const DEFAULT_FAILURE_WINDOW_HOURS = 24;
-
-function resolveAuthCooldownConfig(): ResolvedAuthCooldownConfig {
-  return {
-    billingBackoffMs: DEFAULT_BILLING_BACKOFF_MINUTES * 60 * 1000,
-    billingMaxMs: DEFAULT_BILLING_MAX_HOURS * 60 * 60 * 1000,
-    authPermanentBackoffMs: DEFAULT_AUTH_PERMANENT_BACKOFF_MINUTES * 60 * 1000,
-    authPermanentMaxMs: DEFAULT_AUTH_PERMANENT_MAX_MINUTES * 60 * 1000,
-    failureWindowMs: DEFAULT_FAILURE_WINDOW_HOURS * 60 * 60 * 1000,
-  };
-}
 
 function calculateCappedExponentialBackoffMs(params: {
   errorCount: number;
@@ -813,13 +789,10 @@ function calculateCappedExponentialBackoffMs(params: {
 function resolveDisabledFailureBackoffMs(params: {
   reason: DisabledFailureReason;
   errorCount: number;
-  cfgResolved: ResolvedAuthCooldownConfig;
 }): number {
-  const policy = DISABLED_FAILURE_BACKOFF_POLICIES[params.reason];
   return calculateCappedExponentialBackoffMs({
     errorCount: params.errorCount,
-    baseMs: policy.baseMs(params.cfgResolved),
-    maxMs: policy.maxMs(params.cfgResolved),
+    ...DISABLED_FAILURE_BACKOFF_POLICIES[params.reason],
   });
 }
 
@@ -862,10 +835,17 @@ function computeNextProfileUsageStats(params: {
   existing: ProfileUsageStats;
   now: number;
   reason: AuthProfileFailureReason;
-  cfgResolved: ResolvedAuthCooldownConfig;
   modelId?: string;
 }): ProfileUsageStats {
-  const windowMs = params.cfgResolved.failureWindowMs;
+  // The provider quota writer already recorded this failure and its retry deadline.
+  if (
+    params.reason === "rate_limit" &&
+    params.existing.blockedReason === "subscription_limit" &&
+    isBlockedWindowActiveForModel(params.existing, params.now, params.modelId ?? null)
+  ) {
+    return params.existing;
+  }
+  const windowMs = AUTH_COOLDOWN_CONFIG.failureWindowMs;
   const windowExpired =
     typeof params.existing.lastFailureAt === "number" &&
     params.existing.lastFailureAt > 0 &&
@@ -912,7 +892,6 @@ function computeNextProfileUsageStats(params: {
     const backoffMs = resolveDisabledFailureBackoffMs({
       reason: disabledFailureReason,
       errorCount: disableCount,
-      cfgResolved: params.cfgResolved,
     });
     // Keep active disable windows immutable so retries within the window cannot
     // extend recovery time indefinitely.
@@ -998,7 +977,7 @@ export async function markAuthProfileFailure(params: {
   modelId?: string;
 }): Promise<void> {
   const { store, profileId, reason, agentDir, runId, modelId } = params;
-  const profile = store.profiles[profileId];
+  const profile = structuredClone(store.profiles[profileId]);
   if (
     !profile ||
     profile.setup?.replacement ||
@@ -1014,7 +993,11 @@ export async function markAuthProfileFailure(params: {
     return;
   }
 
-  const whamResult = shouldProbeWham ? await probeWhamForCooldown(store, profileId) : null;
+  const observedStore = shouldProbeWham
+    ? loadAuthProfileStoreWithoutExternalProfiles(agentDir, { profileId })
+    : undefined;
+  const blockGeneration = structuredClone(observedStore?.usageStats?.[profileId]);
+  const whamResult = shouldProbeWham ? await probeWhamForCooldown(profile, profileId) : null;
 
   let nextStats: ProfileUsageStats | undefined;
   let previousStats: ProfileUsageStats | undefined;
@@ -1030,10 +1013,15 @@ export async function markAuthProfileFailure(params: {
       ) {
         return false;
       }
+      previousStats = freshStore.usageStats?.[profileId];
       const currentWhamResult =
         whamResult &&
         shouldProbeWhamForFailure(profileValue, reason) &&
-        isSameWhamCredential(profile, profileValue)
+        isSameWhamCredential(profile, profileValue) &&
+        ((!whamResult.available && !whamResult.blockedUntil) ||
+          (observedStore &&
+            isSameWhamCredential(profile, observedStore.profiles[profileId]) &&
+            matchesWhamBlockGeneration(previousStats, blockGeneration)))
           ? whamResult
           : null;
       // The WHAM response belongs to the credential snapshot used for the
@@ -1042,20 +1030,21 @@ export async function markAuthProfileFailure(params: {
         return false;
       }
       const now = Date.now();
-      const cfgResolved = resolveAuthCooldownConfig();
 
-      previousStats = freshStore.usageStats?.[profileId];
       updateTime = now;
+      const existing =
+        currentWhamResult?.available && previousStats?.blockedReason === "subscription_limit"
+          ? reconcileWhamBlock(previousStats, currentWhamResult, now)
+          : (previousStats ?? {});
       const computed = computeNextProfileUsageStats({
-        existing: previousStats ?? {},
+        existing,
         now,
         reason,
-        cfgResolved,
         modelId,
       });
       nextStats = currentWhamResult
         ? applyWhamCooldownResult({
-            existing: previousStats ?? {},
+            existing,
             computed,
             now,
             whamResult: currentWhamResult,
@@ -1208,7 +1197,6 @@ export async function markInlineProviderApiKeyFailure(params: {
   }
 
   const usageId = resolveInlineProviderApiKeyUsageId(provider);
-  const cfgResolved = resolveAuthCooldownConfig();
 
   let nextStats: ProfileUsageStats | undefined;
   let previousStats: ProfileUsageStats | undefined;
@@ -1223,7 +1211,6 @@ export async function markInlineProviderApiKeyFailure(params: {
         existing: previousStats ?? {},
         now,
         reason,
-        cfgResolved,
         modelId,
       });
       updateUsageStatsEntry(freshStore, usageId, () => nextStats as ProfileUsageStats);

--- a/src/agents/auth-profiles/usage.ts
+++ b/src/agents/auth-profiles/usage.ts
@@ -14,6 +14,7 @@ import {
 import { z } from "zod";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { cancelUnreadResponseBody } from "../../infra/http-body.js";
+import { sqlitePrimaryResultCode } from "../../infra/sqlite-error-diagnostics.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { readProviderJsonResponse } from "../provider-http-errors.js";
 import { resolveProviderRequestHeaders } from "../provider-request-config.js";
@@ -488,7 +489,9 @@ async function runWhamHalfOpenReprobe(params: {
     agentDir: params.agentDir,
     updater: (freshStore) => {
       const currentProfile = freshStore.profiles[params.profileId];
+      const currentStats = freshStore.usageStats?.[params.profileId];
       if (
+        !currentStats ||
         !isSameWhamCredential(params.expectedProfile, currentProfile) ||
         !shouldHalfOpenProbeWhamBlock({
           store: freshStore,
@@ -497,10 +500,6 @@ async function runWhamHalfOpenReprobe(params: {
           now: params.startedAt,
         })
       ) {
-        return false;
-      }
-      const currentStats = freshStore.usageStats?.[params.profileId];
-      if (!currentStats) {
         return false;
       }
       currentStats.lastProbeAt = params.startedAt;
@@ -579,9 +578,16 @@ export async function maybeReprobeWhamBlockedProfiles(params: {
           profileId,
           expectedProfile: structuredClone(profile),
           startedAt: now,
-        }).finally(() => {
-          whamReprobesInFlight.delete(probeKey);
-        });
+        })
+          .catch((error: unknown) => {
+            const code = sqlitePrimaryResultCode(error);
+            if (code !== 8 && code !== 10 && code !== 13) {
+              throw error;
+            }
+          })
+          .finally(() => {
+            whamReprobesInFlight.delete(probeKey);
+          });
         whamReprobesInFlight.set(probeKey, task);
       }
       await task;

--- a/src/agents/btw.ts
+++ b/src/agents/btw.ts
@@ -33,6 +33,7 @@ import { resolveAgentWorkspaceDir } from "./agent-scope.js";
 import { resolveExternalCliAuthOverlayScopeFromSelection } from "./auth-profiles/external-cli-auth-selection.js";
 import { resolveSessionAuthSelection } from "./auth-profiles/session-override.js";
 import type { AuthProfileStore } from "./auth-profiles/types.js";
+import { reconcileAuthProfileQuotaBlocks } from "./auth-profiles/usage.js";
 import { readBtwTranscriptMessages, resolveBtwSessionTranscriptPath } from "./btw-transcript.js";
 import { executePreparedCliRun } from "./cli-runner/execute.runtime.js";
 import { prepareCliRunContext } from "./cli-runner/prepare.runtime.js";
@@ -554,13 +555,14 @@ async function resolveRuntimeModel(params: {
     authProfileStoreSelection.ignoreAutoPreferredProfile && authProfileIdSource !== "user"
       ? undefined
       : authProfileId;
-  const runtimeAuthPreparation = prepareAgentRuntimeAuth({
+  const authParams = {
     provider: runtimeProvider,
     modelId: runtimeModelId,
     modelApi: model.api,
     modelBaseUrl: model.baseUrl,
     config: cfg,
     agentId: params.agentId,
+    agentDir,
     env: process.env,
     workspaceDir,
     authProfileStore: authProfileStoreSelection.store,
@@ -569,7 +571,9 @@ async function resolveRuntimeModel(params: {
     harnessId: params.harnessId,
     harnessRuntime: params.harnessId,
     harnessAuthBootstrap: params.harnessAuthBootstrap,
-  });
+  } satisfies Parameters<typeof prepareAgentRuntimeAuth>[0];
+  await reconcileAuthProfileQuotaBlocks(authParams);
+  const runtimeAuthPreparation = prepareAgentRuntimeAuth(authParams);
   model = await materializeBtwRuntimeModel({
     provider: runtimeProvider,
     modelId: runtimeModelId,
@@ -947,28 +951,32 @@ export async function runBtwSideQuestion(
               authProfileId: runtime.authProfileId,
               authProfileIdSource: runtime.authProfileIdSource,
             });
-      const runtimeAuthPreparation = authProfileStoreSelection
-        ? prepareAgentRuntimeAuth({
-            provider: runtime.model.provider,
-            modelId: runtime.model.id,
-            modelApi: runtime.model.api,
-            modelBaseUrl: runtime.model.baseUrl,
-            config: params.cfg,
-            agentId: sessionAgentId,
-            env: process.env,
-            workspaceDir,
-            authProfileStore: authProfileStoreSelection.store,
-            sessionAuthProfileId:
-              authProfileStoreSelection.ignoreAutoPreferredProfile &&
-              runtime.authProfileIdSource !== "user"
-                ? undefined
-                : runtime.authProfileId,
-            sessionAuthProfileSource: runtime.authProfileIdSource,
-            harnessId: selectedHarness.id,
-            harnessRuntime: selectedHarness.id,
-            harnessAuthBootstrap: selectedHarness.authBootstrap,
-          })
-        : runtime.runtimeAuthPreparation;
+      let runtimeAuthPreparation = runtime.runtimeAuthPreparation;
+      if (authProfileStoreSelection) {
+        const authParams = {
+          provider: runtime.model.provider,
+          modelId: runtime.model.id,
+          modelApi: runtime.model.api,
+          modelBaseUrl: runtime.model.baseUrl,
+          config: params.cfg,
+          agentId: sessionAgentId,
+          agentDir: params.agentDir,
+          env: process.env,
+          workspaceDir,
+          authProfileStore: authProfileStoreSelection.store,
+          sessionAuthProfileId:
+            authProfileStoreSelection.ignoreAutoPreferredProfile &&
+            runtime.authProfileIdSource !== "user"
+              ? undefined
+              : runtime.authProfileId,
+          sessionAuthProfileSource: runtime.authProfileIdSource,
+          harnessId: selectedHarness.id,
+          harnessRuntime: selectedHarness.id,
+          harnessAuthBootstrap: selectedHarness.authBootstrap,
+        } satisfies Parameters<typeof prepareAgentRuntimeAuth>[0];
+        await reconcileAuthProfileQuotaBlocks(authParams);
+        runtimeAuthPreparation = prepareAgentRuntimeAuth(authParams);
+      }
       const selectedAuthProfileStore = authProfileStoreSelection?.store ?? runtime.authProfileStore;
       const implicitHarnessAuthPlan =
         selectedHarness.authBootstrap === "harness" &&

--- a/src/agents/harness/isolated-completion.native-auth.test.ts
+++ b/src/agents/harness/isolated-completion.native-auth.test.ts
@@ -111,6 +111,7 @@ describe("runIsolatedCompletion native authorization", () => {
         );
         expect(mocks.prepareSimpleCompletionModel).toHaveBeenCalledWith(
           expect.objectContaining({ profileId: "openai:key" }),
+          expect.any(Function),
         );
       } else {
         await expect(pending).rejects.toMatchObject({
@@ -441,6 +442,7 @@ describe("runIsolatedCompletion native authorization", () => {
     expect(mocks.prepareSimpleCompletionModel).toHaveBeenCalledOnce();
     expect(mocks.prepareSimpleCompletionModel).toHaveBeenCalledWith(
       expect.objectContaining({ preparedModelRuntime, workspaceDir: "/tmp/workspace" }),
+      expect.any(Function),
     );
     expect(mocks.acquireAgentRunPreparedModelRuntime).toHaveBeenCalledOnce();
     expect(releaseRuntimeLease).toHaveBeenCalledOnce();

--- a/src/agents/isolated-completion.test.ts
+++ b/src/agents/isolated-completion.test.ts
@@ -204,6 +204,7 @@ describe("runIsolatedCompletion", () => {
           await expect(completion).resolves.toMatchObject({ text: "done" });
           expect(mocks.prepareSimpleCompletionModel).toHaveBeenCalledWith(
             expect.objectContaining({ modelId: "gpt-test", profileId: "openai:original" }),
+            expect.any(Function),
           );
           expect(dispatch).toHaveBeenCalledOnce();
           expect(dispatch).toHaveBeenCalledWith(
@@ -261,6 +262,7 @@ describe("runIsolatedCompletion", () => {
             provider: "openai",
             modelId: "gpt-test",
           }),
+          expect.any(Function),
         );
       }
       expect(releaseRuntimeLease).toHaveBeenCalledOnce();
@@ -289,6 +291,7 @@ describe("runIsolatedCompletion", () => {
         preparedModelRuntime,
         workspaceDir: "/tmp/workspace",
       }),
+      expect.any(Function),
     );
     expect(mocks.acquireAgentRunPreparedModelRuntime).toHaveBeenCalledOnce();
     expect(releaseRuntimeLease).toHaveBeenCalledOnce();

--- a/src/agents/isolated-completion.ts
+++ b/src/agents/isolated-completion.ts
@@ -16,6 +16,7 @@ import { withPluginRuntimeGenerationScope } from "../plugins/runtime/generation-
 import { runWithAsyncWorkResources } from "../shared/async-work-resources.js";
 import { prepareSystemAgentRunAdmission } from "./admitted-run-context.js";
 import { resolveAgentDir, resolveAgentWorkspaceDir, resolveDefaultAgentId } from "./agent-scope.js";
+import { reconcileAuthProfileQuotaBlocks } from "./auth-profiles/usage.js";
 import { resolveCliBackendConfig, resolveCliRuntimeCanonicalProvider } from "./cli-backends.js";
 import { normalizeCliModel } from "./cli-runner/helpers.js";
 import { resolveEmbeddedCliBackendDispatchEligibility } from "./embedded-agent-runner/cli-backend-dispatch-eligibility.js";
@@ -560,7 +561,7 @@ async function runIsolatedCompletionOwned(
             allowKeychainPrompt: false,
             config,
           });
-          const authAttempts = prepareAgentRuntimeAuth({
+          const authParams = {
             provider: runtimeModel.provider,
             modelId: runtimeModel.id,
             modelApi: runtimeModel.api,
@@ -573,14 +574,15 @@ async function runIsolatedCompletionOwned(
             harnessId: harness.id,
             harnessRuntime: harness.id,
             harnessAuthBootstrap: harness.authBootstrap,
-          }).attempts;
+          } satisfies Parameters<typeof prepareAgentRuntimeAuth>[0];
+          await reconcileAuthProfileQuotaBlocks(authParams);
+          assertCurrent();
+          const authAttempts = prepareAgentRuntimeAuth(authParams).attempts;
           harnessAuth = { model: runtimeModel, store: authProfileStore, attempts: authAttempts };
         }
         let firstError: unknown;
         let priorProfileAttempted = false;
-        for (const preparedAttempt of harnessAuth?.attempts.length
-          ? harnessAuth.attempts
-          : [undefined]) {
+        for (const preparedAttempt of harnessAuth?.attempts ?? [undefined]) {
           assertCurrent();
           const attempt: PreparedAgentRuntimeAuthAttempt | undefined =
             preparedAttempt?.kind === "profile"

--- a/src/agents/isolated-completion.ts
+++ b/src/agents/isolated-completion.ts
@@ -34,10 +34,7 @@ import {
   isCliRuntimeAliasForProvider,
   resolveCliRuntimeExecutionProvider,
 } from "./model-runtime-aliases.js";
-import {
-  acquireAgentRunPreparedModelRuntime,
-  type PreparedModelRuntimeSnapshot,
-} from "./prepared-model-runtime.js";
+import { acquireAgentRunPreparedModelRuntime } from "./prepared-model-runtime.js";
 import {
   unwrapModelHeaderSentinelsForProviderEgress,
   unwrapSecretSentinelsForProviderEgress,
@@ -359,43 +356,6 @@ function prepareIsolatedHostAuthorization<
   };
 }
 
-async function prepareHostAuthorization(params: {
-  config: OpenClawConfig;
-  agentId: string;
-  agentDir: string;
-  provider: string;
-  modelId: string;
-  authProfileId?: string;
-  workspaceDir: string;
-  preparedModelRuntime: PreparedModelRuntimeSnapshot;
-}): Promise<Extract<AgentHarnessIsolatedCompletionAuthorization, { owner: "host" }>> {
-  const prepared = await prepareSimpleCompletionModel({
-    cfg: params.config,
-    agentId: params.agentId,
-    provider: params.provider,
-    modelId: params.modelId,
-    agentDir: params.agentDir,
-    profileId: params.authProfileId,
-    allowMissingApiKeyModes: ["aws-sdk"],
-    allowBundledStaticCatalogFallback: true,
-    skipAgentDiscovery: true,
-    bindAuthOwner: true,
-    workspaceDir: params.workspaceDir,
-    preparedModelRuntime: params.preparedModelRuntime,
-  });
-  if ("error" in prepared) {
-    throw new Error(`Isolated completion preparation failed: ${prepared.error}`);
-  }
-  return {
-    owner: "host",
-    model: prepared.model,
-    auth: prepared.auth,
-    ...(prepared.sourceAuthFingerprint
-      ? { sourceAuthFingerprint: prepared.sourceAuthFingerprint }
-      : {}),
-  };
-}
-
 /** Run one fresh, zero-tool completion through its selected runtime. */
 export async function runIsolatedCompletion(
   params: RunIsolatedCompletionParams,
@@ -527,6 +487,33 @@ async function runIsolatedCompletionOwned(
         thinkLevel: request.thinkLevel,
         outputTextPolicy: request.outputTextPolicy,
       };
+      const prepareHostAuthorization = async (
+        authProfileId: string | undefined,
+      ): Promise<Extract<AgentHarnessIsolatedCompletionAuthorization, { owner: "host" }>> => {
+        const prepared = await prepareSimpleCompletionModel(
+          {
+            cfg: config,
+            agentId,
+            provider,
+            modelId: request.model,
+            agentDir,
+            profileId: authProfileId,
+            allowMissingApiKeyModes: ["aws-sdk"],
+            allowBundledStaticCatalogFallback: true,
+            skipAgentDiscovery: true,
+            bindAuthOwner: true,
+            workspaceDir,
+            preparedModelRuntime: lease.snapshot,
+            signal: request.abortSignal,
+          },
+          assertCurrent,
+        );
+        assertCurrent();
+        if ("error" in prepared) {
+          throw new Error(`Isolated completion preparation failed: ${prepared.error}`);
+        }
+        return { owner: "host", ...prepared };
+      };
       let result: AgentHarnessIsolatedCompletionResult | undefined;
       if (harness.runIsolatedCompletionV2) {
         let modelMaxTokens: number | undefined;
@@ -648,14 +635,9 @@ async function runIsolatedCompletionOwned(
                 authProfileStore: scopeAuthProfileStoreToPreparedPlan(authProfileStore, plan),
               };
             } else {
-              authorization = await prepareHostAuthorization({
-                ...context,
-                provider,
-                modelId: request.model,
-                authProfileId:
-                  attempt?.kind === "profile" ? attempt.profileId : request.authProfileId,
-                preparedModelRuntime: lease.snapshot,
-              });
+              authorization = await prepareHostAuthorization(
+                attempt?.kind === "profile" ? attempt.profileId : request.authProfileId,
+              );
               modelMaxTokens = authorization.model.maxTokens;
             }
             if (
@@ -694,13 +676,7 @@ async function runIsolatedCompletionOwned(
           throw new Error("No prepared auth attempt succeeded.", { cause: firstError });
         }
       } else {
-        const authorization = await prepareHostAuthorization({
-          ...context,
-          provider,
-          modelId: request.model,
-          authProfileId: request.authProfileId,
-          preparedModelRuntime: lease.snapshot,
-        });
+        const authorization = await prepareHostAuthorization(request.authProfileId);
         const harnessParams: AgentHarnessIsolatedCompletionParams = {
           ...commonParams,
           streamParams: clampIsolatedStreamParams(

--- a/src/agents/model-fallback-runner.ts
+++ b/src/agents/model-fallback-runner.ts
@@ -317,25 +317,25 @@ async function runWithModelFallbackInternal<T>(
           profileId: userLockedAuthProfileId,
           includePendingOAuthRefresh: true,
         }).eligible;
+      let profileIds = authRuntime.resolveAuthProfileOrder({
+        cfg: params.cfg,
+        store: authStore,
+        provider: candidate.provider,
+        forModel: candidate.model,
+        includePendingOAuthRefresh: true,
+      });
+      if (userLockedAuthProfileEligible && userLockedAuthProfileId) {
+        profileIds = [...new Set([userLockedAuthProfileId, ...profileIds])];
+      }
+      await authRuntime.maybeReprobeWhamBlockedProfiles({
+        store: authStore,
+        profileIds,
+        agentDir: params.agentDir,
+        forModel: candidate.model,
+      });
       if (!candidateHarnessAuth.skipsProviderAuthCooldown) {
-        candidateAuthProfileIds = authRuntime.resolveAuthProfileOrder({
-          cfg: params.cfg,
-          store: authStore,
-          provider: candidate.provider,
-          forModel: candidate.model,
-          includePendingOAuthRefresh: true,
-        });
-        if (userLockedAuthProfileEligible && userLockedAuthProfileId) {
-          candidateAuthProfileIds.unshift(userLockedAuthProfileId);
-          candidateAuthProfileIds = [...new Set(candidateAuthProfileIds)];
-        }
+        candidateAuthProfileIds = profileIds;
         profileIdsByCandidate.set(candidate, candidateAuthProfileIds);
-        authRuntime.maybeReprobeWhamBlockedProfiles({
-          store: authStore,
-          profileIds: candidateAuthProfileIds,
-          agentDir: params.agentDir,
-          forModel: candidate.model,
-        });
       }
     }
     const candidateAuthScope = resolveFallbackAuthScope({

--- a/src/agents/simple-completion-runtime.test.ts
+++ b/src/agents/simple-completion-runtime.test.ts
@@ -69,6 +69,10 @@ vi.mock("./auth-profiles/store-runtime.js", () => ({
   ensureAuthProfileStore: hoisted.ensureAuthProfileStoreMock,
 }));
 
+vi.mock("./auth-profiles/usage.js", () => ({
+  reconcileAuthProfileQuotaBlocks: vi.fn(async () => {}),
+}));
+
 vi.mock("../plugins/current-plugin-metadata-snapshot.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../plugins/current-plugin-metadata-snapshot.js")>()),
   getCurrentPluginMetadataSnapshot: hoisted.getCurrentPluginMetadataSnapshotMock,

--- a/src/agents/simple-completion-runtime.ts
+++ b/src/agents/simple-completion-runtime.ts
@@ -26,6 +26,7 @@ import {
 } from "./agent-scope.js";
 import { ensureAuthProfileStore } from "./auth-profiles/store-runtime.js";
 import type { AuthProfileStore } from "./auth-profiles/types.js";
+import { reconcileAuthProfileQuotaBlocks } from "./auth-profiles/usage.js";
 import { DEFAULT_PROVIDER } from "./defaults.js";
 import {
   fingerprintAuthProfileCredential,
@@ -189,6 +190,7 @@ export async function prepareSimpleCompletionModel(
   params: PrepareSimpleCompletionModelParams & {
     preparedModelRuntime: PreparedModelRuntimeSnapshot;
   },
+  assertCurrent?: () => void,
 ): Promise<PreparedSimpleCompletionModel> {
   params.signal?.throwIfAborted();
   const config = params.cfg ?? {};
@@ -206,6 +208,7 @@ export async function prepareSimpleCompletionModel(
     prepareSimpleCompletionModelCore(
       { ...params, agentDir: preparedModelRuntime.agentDir },
       context,
+      assertCurrent,
     ),
   );
   params.signal?.throwIfAborted();
@@ -215,6 +218,7 @@ export async function prepareSimpleCompletionModel(
 async function prepareSimpleCompletionModelCore(
   params: PrepareSimpleCompletionModelParams,
   context: PreparedSimpleCompletionResolverContext,
+  assertCurrent?: () => void,
 ): Promise<PreparedSimpleCompletionModel> {
   const { modelResolver, workspaceDir } = context;
   const resolved = await modelResolver(
@@ -238,6 +242,8 @@ async function prepareSimpleCompletionModelCore(
       error: resolved.error ?? `Unknown model: ${params.provider}/${params.modelId}`,
     };
   }
+  assertCurrent?.();
+  params.signal?.throwIfAborted();
   const initialModel = resolved.model;
   let resolvedModel = initialModel;
   let authStore: AuthProfileStore | undefined;
@@ -252,6 +258,25 @@ async function prepareSimpleCompletionModelCore(
             profileId: params.profileId,
           })
         : undefined;
+
+    const authParams = {
+      provider: initialModel.provider,
+      modelId: initialModel.id,
+      modelApi: initialModel.api,
+      modelBaseUrl: initialModel.baseUrl,
+      config: params.cfg,
+      agentId: params.agentId,
+      agentDir: params.agentDir,
+      workspaceDir,
+      authProfileStore: authStore,
+      metadataSnapshot: context.preparedModelRuntime.metadataSnapshot,
+      sessionAuthProfileId: params.profileId ?? params.preferredProfile,
+      sessionAuthProfileSource: params.profileId ? "user" : "auto",
+      ...(params.bindAuthOwner && params.profileId ? { allowAuthProfileFallback: false } : {}),
+    } satisfies Parameters<typeof prepareAgentRuntimeAuth>[0];
+    await reconcileAuthProfileQuotaBlocks(authParams);
+    assertCurrent?.();
+    params.signal?.throwIfAborted();
 
     const primaryModel = params.cfg
       ? resolveDefaultModelForAgent({
@@ -288,24 +313,7 @@ async function prepareSimpleCompletionModelCore(
     });
     const preparedAuth =
       routeResolution?.kind === "routes"
-        ? prepareAgentRuntimeAuth({
-            provider: initialModel.provider,
-            modelId: initialModel.id,
-            modelApi: initialModel.api,
-            modelBaseUrl: initialModel.baseUrl,
-            config: params.cfg,
-            agentId: params.agentId,
-            routeIntent,
-            agentDir: params.agentDir,
-            workspaceDir,
-            authProfileStore: authStore,
-            metadataSnapshot: context.preparedModelRuntime.metadataSnapshot,
-            sessionAuthProfileId: params.profileId ?? params.preferredProfile,
-            sessionAuthProfileSource: params.profileId ? "user" : "auto",
-            ...(params.bindAuthOwner && params.profileId
-              ? { allowAuthProfileFallback: false }
-              : {}),
-          })
+        ? prepareAgentRuntimeAuth({ ...authParams, routeIntent })
         : undefined;
     const materializeModel = async ({
       plan,
@@ -645,6 +653,7 @@ export async function acquireSimpleCompletionModelWithSelection(
             : {}),
           skipAgentDiscovery: params.skipAgentDiscovery,
           bindAuthOwner: params.bindAuthOwner,
+          signal: params.signal,
         },
         context,
       ),

--- a/test/e2e/qa-lab/runtime/quota-reset-preload.mjs
+++ b/test/e2e/qa-lab/runtime/quota-reset-preload.mjs
@@ -1,0 +1,40 @@
+import { readFileSync } from "node:fs";
+
+// Test-only transport routing; provider responses and auth-state mutation remain real.
+const options = new URL(import.meta.url).searchParams;
+const fixture = new URL(options.get("fixture"));
+const clockFile = options.get("clock");
+if (fixture.protocol !== "http:" || fixture.hostname !== "127.0.0.1" || !clockFile) {
+  throw new Error("Quota fixture requires a loopback HTTP origin and a clock file");
+}
+
+const realNow = Date.now.bind(Date);
+Date.now = () => {
+  const offset = Number(readFileSync(clockFile, "utf8"));
+  if (!Number.isSafeInteger(offset) || offset < 0) {
+    throw new Error("Quota clock offset must be a nonnegative integer");
+  }
+  return realNow() + offset;
+};
+
+const originalFetch = globalThis.fetch;
+globalThis.fetch = (input, init) => {
+  const url = input instanceof Request ? input.url : String(input);
+  const route =
+    url === "https://chatgpt.com/backend-api/wham/usage"
+      ? "/core-wham/usage"
+      : url === "https://chatgpt.com/backend-api/codex/responses"
+        ? "/direct/responses"
+        : url === "https://auth.openai.com/oauth/token"
+          ? "/oauth/token"
+          : undefined;
+  if (!route) {
+    return originalFetch(input, init);
+  }
+  const target = new URL(route, fixture);
+  const fixtureInit = { ...init };
+  delete fixtureInit.dispatcher;
+  return originalFetch(input instanceof Request ? new Request(target, input) : target, fixtureInit);
+};
+// The existing hermetic transport contract also routes guarded OAuth refresh.
+globalThis.fetch.mock = {};

--- a/test/e2e/qa-lab/runtime/quota-reset-preload.mjs
+++ b/test/e2e/qa-lab/runtime/quota-reset-preload.mjs
@@ -1,9 +1,63 @@
 import { readFileSync } from "node:fs";
+import { DatabaseSync } from "node:sqlite";
 
 // Test-only transport routing; provider responses and auth-state mutation remain real.
 const options = new URL(import.meta.url).searchParams;
 const fixture = new URL(options.get("fixture"));
 const clockFile = options.get("clock");
+const storageFaultFile = options.get("storageFault");
+if (storageFaultFile) {
+  // CLI respawns reset inherited signal handling; let SQLite receive EFBIG.
+  process.on("SIGXFSZ", () => undefined);
+  const prepare = DatabaseSync.prototype.prepare;
+  DatabaseSync.prototype.prepare = function (sql) {
+    const statement = prepare.call(this, sql);
+    if (!/^insert into "config_machine_state"/i.test(sql)) {
+      return statement;
+    }
+    const run = statement.run.bind(statement);
+    statement.run = (...args) => {
+      this.exec("DROP TRIGGER IF EXISTS temp.quota_reset_write_fault");
+      const fault = JSON.parse(readFileSync(storageFaultFile, "utf8"));
+      if (fault) {
+        const profile = '$.usageStats."openai:quota"';
+        const condition =
+          fault.write === "claim"
+            ? `json_extract(NEW.value_json, '${profile}.lastProbeAt')
+                 IS NOT json_extract(OLD.value_json, '${profile}.lastProbeAt')
+               AND json_extract(NEW.value_json, '${profile}.blockedUntil') IS NOT NULL`
+            : `json_extract(NEW.value_json, '${profile}.blockedUntil') IS NULL`;
+        const action =
+          fault.failure === "constraint"
+            ? "SELECT RAISE(ABORT, 'quota test constraint invariant');"
+            : `INSERT INTO config_machine_state (state_key, value_json, updated_at_ms)
+               VALUES ('quota-reset-test.scratch', json_quote(hex(zeroblob(96 * 1024 * 1024))), 0);`;
+        // TEMP keeps the production schema intact. The oversized write reaches
+        // the Gateway's real file-size limit; no I/O exception is fabricated.
+        this.exec(`
+          CREATE TEMP TRIGGER quota_reset_write_fault
+          BEFORE UPDATE ON main.config_machine_state
+          WHEN NEW.state_key = 'authProfiles.state'
+            AND json_extract(OLD.value_json, '${profile}.blockedUntil') IS NOT NULL
+            AND ${condition}
+          BEGIN ${action} END;
+        `);
+      }
+      try {
+        return run(...args);
+      } catch (error) {
+        console.error("Quota fixture native storage error", {
+          fault,
+          code: error.code,
+          errcode: error.errcode,
+          message: error.message,
+        });
+        throw error;
+      }
+    };
+    return statement;
+  };
+}
 if (fixture.protocol !== "http:" || fixture.hostname !== "127.0.0.1" || !clockFile) {
   throw new Error("Quota fixture requires a loopback HTTP origin and a clock file");
 }

--- a/test/e2e/qa-lab/runtime/quota-reset-preload.mjs
+++ b/test/e2e/qa-lab/runtime/quota-reset-preload.mjs
@@ -1,10 +1,26 @@
 import { readFileSync } from "node:fs";
+import { createRequire, syncBuiltinESMExports } from "node:module";
 import { DatabaseSync } from "node:sqlite";
 
 // Test-only transport routing; provider responses and auth-state mutation remain real.
 const options = new URL(import.meta.url).searchParams;
 const fixture = new URL(options.get("fixture"));
 const clockFile = options.get("clock");
+if (options.has("catalog")) {
+  const workers = createRequire(import.meta.url)("node:worker_threads");
+  const Worker = workers.Worker;
+  // Production workers intentionally clear execArgv. Carry this fixture's
+  // network boundary into the real worker without replacing its catalog logic.
+  workers.Worker = class extends Worker {
+    constructor(url, workerOptions) {
+      super(url, {
+        ...workerOptions,
+        execArgv: [...(workerOptions?.execArgv ?? process.execArgv), "--import", import.meta.url],
+      });
+    }
+  };
+  syncBuiltinESMExports();
+}
 const storageFaultFile = options.get("storageFault");
 if (storageFaultFile) {
   // CLI respawns reset inherited signal handling; let SQLite receive EFBIG.
@@ -75,13 +91,15 @@ const originalFetch = globalThis.fetch;
 globalThis.fetch = (input, init) => {
   const url = input instanceof Request ? input.url : String(input);
   const route =
-    url === "https://chatgpt.com/backend-api/wham/usage"
-      ? "/core-wham/usage"
-      : url === "https://chatgpt.com/backend-api/codex/responses"
-        ? "/direct/responses"
-        : url === "https://auth.openai.com/oauth/token"
-          ? "/oauth/token"
-          : undefined;
+    options.has("catalog") && url.startsWith("https://chatgpt.com/backend-api/codex/models?")
+      ? "/catalog/models"
+      : url === "https://chatgpt.com/backend-api/wham/usage"
+        ? "/core-wham/usage"
+        : url === "https://chatgpt.com/backend-api/codex/responses"
+          ? "/direct/responses"
+          : url === "https://auth.openai.com/oauth/token"
+            ? "/oauth/token"
+            : undefined;
   if (!route) {
     return originalFetch(input, init);
   }

--- a/test/e2e/qa-lab/runtime/quota-reset.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/quota-reset.e2e.test.ts
@@ -1,0 +1,950 @@
+import { randomUUID } from "node:crypto";
+import fs from "node:fs/promises";
+import { createServer, type IncomingMessage } from "node:http";
+import { createRequire } from "node:module";
+import os from "node:os";
+import path from "node:path";
+import { zstdDecompressSync } from "node:zlib";
+import { describe, expect, it } from "vitest";
+import { WebSocketServer } from "ws";
+import { readPersistedSharedAuthProfileStateRaw } from "../../../../src/agents/auth-profiles/sqlite.js";
+import { coerceAuthProfileState } from "../../../../src/agents/auth-profiles/state.js";
+import { connectGatewayClient } from "../../../../src/gateway/test-helpers.e2e.js";
+import { createDeferredCore, type Deferred } from "../../../../src/shared/deferred.js";
+import { createOpenClawTestInstance } from "../../../helpers/openclaw-test-instance.js";
+
+const MODEL = "openai/gpt-5.5";
+const UTILITY_MODEL_ID = "quota-test-utility";
+const PROFILE_ID = "openai:quota";
+const ACCOUNT_ID = "quota-test-account";
+const MARKER = "QUOTA_TURN_OK";
+const RECHECK_ADVANCE_MS = 300_100;
+type BlockSource = "wham" | "codex_rate_limits";
+type Phase =
+  | "healthy"
+  | "initial-exhaustion"
+  | "ordinary-rate-limit"
+  | "ordinary-rate-limit-with-capacity"
+  | "ordinary-rate-limit-with-exhausted-usage"
+  | "exhausted"
+  | "additional-exhaustion"
+  | "workspace-exhaustion"
+  | "spending-exhaustion"
+  | "malformed-usage"
+  | "restored"
+  | "revoked";
+type RequestRecord = {
+  phase: Phase;
+  transport: "http" | "websocket";
+  path: string;
+  method: string | undefined;
+  headers: IncomingMessage["headers"];
+  rawHeaders: string[];
+  body: string | undefined;
+  bodyBase64?: string;
+  authorization: string | undefined;
+  accountId: string | string[] | undefined;
+};
+type ChatHistory = {
+  messages: Array<{
+    role: string;
+    content?: string | Array<{ type: string; text?: string }>;
+  }>;
+};
+type HeldUsageResponse = {
+  phase: Phase;
+  path: string;
+  status: number;
+  body: string;
+  capturedAt: number;
+  releasedAt?: number;
+  releaseReason?: "explicit" | "deadline" | "aborted";
+};
+
+function syntheticAccessToken(expires = Date.UTC(2036, 0, 1)) {
+  return [
+    { alg: "none" },
+    {
+      "https://api.openai.com/auth": {
+        chatgpt_account_id: ACCOUNT_ID,
+        chatgpt_user_id: "quota-test-user",
+        chatgpt_plan_type: "pro",
+      },
+      exp: Math.floor(expires / 1000),
+      email: "quota@example.invalid",
+    },
+  ]
+    .map((value) => Buffer.from(JSON.stringify(value)).toString("base64url"))
+    .concat("synthetic")
+    .join(".");
+}
+
+function assistantTexts(history: ChatHistory): string[] {
+  return history.messages
+    .filter((message) => message.role === "assistant")
+    .map((message) =>
+      typeof message.content === "string"
+        ? message.content
+        : (message.content ?? [])
+            .filter((part) => part.type === "text")
+            .map((part) => part.text ?? "")
+            .join("\n"),
+    );
+}
+
+async function startQuotaProvider(source: BlockSource) {
+  let phase: Phase = "healthy";
+  let nextSuccessObserver: (() => void) | undefined;
+  let nextUsageHold: { arrived: Deferred<HeldUsageResponse>; released: Deferred<void> } | undefined;
+  const heldUsageResponses: HeldUsageResponse[] = [];
+  const resetAt = Math.floor(Date.now() / 1000) + 5 * 86_400;
+  const requests: RequestRecord[] = [];
+  const responses: Array<{
+    phase: Phase;
+    path: string;
+    value: unknown;
+    headers?: Record<string, string>;
+  }> = [];
+  const errors: string[] = [];
+  const primaryExhausted = () => phase === "initial-exhaustion" || phase === "exhausted";
+  const exhausted = () => phase !== "healthy" && phase !== "restored" && phase !== "revoked";
+  const recordRequest = (
+    request: IncomingMessage,
+    body: string | undefined,
+    transport: RequestRecord["transport"],
+    bodyBytes?: Buffer,
+  ) => {
+    requests.push({
+      phase,
+      transport,
+      path: request.url ?? "",
+      method: request.method,
+      headers: request.headers,
+      rawHeaders: request.rawHeaders,
+      body,
+      bodyBase64: bodyBytes?.toString("base64"),
+      authorization: request.headers.authorization,
+      accountId: request.headers["chatgpt-account-id"],
+    });
+  };
+  const usage = () => {
+    const usageExhausted =
+      primaryExhausted() || phase === "ordinary-rate-limit-with-exhausted-usage";
+    const window = (seconds: number, usedPercent = usageExhausted ? 100 : 2) => ({
+      used_percent: usedPercent,
+      limit_window_seconds: seconds,
+      reset_at: resetAt,
+      reset_after_seconds: resetAt - Math.floor(Date.now() / 1000),
+    });
+    return {
+      plan_type: "pro",
+      rate_limit: {
+        allowed: !usageExhausted,
+        limit_reached: usageExhausted,
+        primary_window: window(18_000),
+        secondary_window: window(604_800),
+      },
+      credits: { has_credits: false, unlimited: false, balance: "0" },
+      additional_rate_limits:
+        phase === "additional-exhaustion"
+          ? [
+              {
+                limit_name: "Additional Codex capacity",
+                metered_feature: "codex_other",
+                rate_limit: {
+                  allowed: false,
+                  limit_reached: true,
+                  primary_window: window(18_000, 100),
+                  secondary_window: null,
+                },
+              },
+            ]
+          : [],
+      spend_control:
+        phase === "malformed-usage"
+          ? { reached: "invalid" }
+          : phase === "spending-exhaustion"
+            ? { reached: true }
+            : null,
+      rate_limit_reached_type:
+        phase === "workspace-exhaustion" ? { type: "workspace_owner_credits_depleted" } : null,
+    };
+  };
+  const failure = () => {
+    const headers: Record<string, string> =
+      primaryExhausted() && source === "codex_rate_limits"
+        ? {
+            "x-codex-primary-used-percent": "100",
+            "x-codex-primary-window-minutes": "300",
+            "x-codex-primary-reset-at": String(resetAt),
+            "x-codex-secondary-used-percent": "100",
+            "x-codex-secondary-window-minutes": "10080",
+            "x-codex-secondary-reset-at": String(resetAt),
+          }
+        : {};
+    return {
+      type: "error",
+      status: phase === "revoked" ? 401 : 429,
+      error:
+        phase === "revoked"
+          ? {
+              type: "invalid_request_error",
+              code: "invalid_api_key",
+              message: "Invalid authentication token",
+            }
+          : phase === "ordinary-rate-limit" ||
+              phase === "ordinary-rate-limit-with-capacity" ||
+              phase === "ordinary-rate-limit-with-exhausted-usage"
+            ? {
+                type: "rate_limit_error",
+                code: "rate_limit_exceeded",
+                message: "Too many requests",
+              }
+            : {
+                type: "usage_limit_reached",
+                message: "The usage limit has been reached",
+                plan_type: "pro",
+                ...(source === "codex_rate_limits" ? { resets_at: resetAt } : {}),
+              },
+      headers,
+    };
+  };
+  const successEvents = () => {
+    const observe = nextSuccessObserver;
+    nextSuccessObserver = undefined;
+    observe?.();
+    const id = randomUUID().replaceAll("-", "");
+    const item = {
+      type: "message",
+      id: `msg${id}`,
+      role: "assistant",
+      status: "completed",
+      content: [{ type: "output_text", text: MARKER, annotations: [] }],
+    };
+    const response = {
+      id: `resp${id}`,
+      status: "completed",
+      output: [item],
+      usage: {
+        input_tokens: 11,
+        output_tokens: 7,
+        total_tokens: 18,
+        input_tokens_details: { cached_tokens: 0 },
+      },
+    };
+    return [
+      { type: "response.created", response: { ...response, status: "in_progress", output: [] } },
+      {
+        type: "response.output_item.added",
+        output_index: 0,
+        item: { ...item, status: "in_progress", content: [] },
+      },
+      {
+        type: "response.output_text.delta",
+        item_id: item.id,
+        output_index: 0,
+        content_index: 0,
+        delta: MARKER,
+      },
+      { type: "response.output_item.done", output_index: 0, item },
+      { type: "response.completed", response },
+    ];
+  };
+  const server = createServer((request, response) => {
+    void (async () => {
+      const chunks: Buffer[] = [];
+      for await (const chunk of request) {
+        chunks.push(Buffer.from(chunk));
+      }
+      const bodyBytes = Buffer.concat(chunks);
+      const encoding = request.headers["content-encoding"];
+      const decoded =
+        encoding === undefined
+          ? bodyBytes
+          : encoding === "zstd"
+            ? zstdDecompressSync(bodyBytes)
+            : undefined;
+      recordRequest(request, decoded?.toString(), "http", bodyBytes);
+      const requestPath = new URL(request.url ?? "/", "http://127.0.0.1").pathname;
+      const json = (
+        status: number,
+        value: unknown,
+        headers: Record<string, string> = {},
+        responsePhase = phase,
+      ) => {
+        responses.push({ phase: responsePhase, path: requestPath, value, headers });
+        response.writeHead(status, { "content-type": "application/json", ...headers });
+        response.end(JSON.stringify(value));
+      };
+      if (requestPath === "/core-wham/usage" || requestPath === "/backend-api/wham/usage") {
+        // Preserve the native block source only on the original quota failure.
+        if (
+          requestPath === "/core-wham/usage" &&
+          ((source === "codex_rate_limits" && phase === "initial-exhaustion") ||
+            phase === "ordinary-rate-limit")
+        ) {
+          json(503, { error: { message: "Usage view temporarily unavailable" } });
+        } else if (phase === "revoked") {
+          json(403, { error: { message: "Account deactivated" } });
+        } else {
+          const value = usage();
+          const hold = requestPath === "/core-wham/usage" ? nextUsageHold : undefined;
+          if (hold) {
+            nextUsageHold = undefined;
+            const captured: HeldUsageResponse = {
+              phase,
+              path: requestPath,
+              status: 200,
+              body: JSON.stringify(value),
+              capturedAt: Date.now(),
+            };
+            heldUsageResponses.push(captured);
+            hold.arrived.resolve(captured);
+            const interrupted = createDeferredCore<"deadline" | "aborted">();
+            const timer = setTimeout(() => interrupted.resolve("deadline"), 2800);
+            const onClose = () => interrupted.resolve("aborted");
+            response.once("close", onClose);
+            try {
+              captured.releaseReason = await Promise.race([
+                hold.released.promise.then(() => "explicit" as const),
+                interrupted.promise,
+              ]);
+              captured.releasedAt = Date.now();
+              if (captured.releaseReason !== "aborted") {
+                json(captured.status, value, {}, captured.phase);
+              }
+            } finally {
+              clearTimeout(timer);
+              response.off("close", onClose);
+            }
+          } else {
+            json(200, value);
+          }
+        }
+      } else if (requestPath === "/oauth/token") {
+        if (phase === "revoked") {
+          json(400, { error: "invalid_grant", error_description: "Refresh token revoked" });
+        } else {
+          json(200, {
+            access_token: syntheticAccessToken(),
+            refresh_token: "synthetic-rotated-refresh",
+            expires_in: 3600,
+          });
+        }
+      } else if (requestPath.endsWith("/models")) {
+        json(200, { models: [] });
+      } else if (requestPath.endsWith("/responses")) {
+        if (exhausted() || phase === "revoked") {
+          const event = failure();
+          json(event.status, { error: event.error }, event.headers);
+        } else {
+          const events = successEvents();
+          responses.push({ phase, path: requestPath, value: events });
+          response.writeHead(200, { "content-type": "text/event-stream" });
+          for (const event of events) {
+            response.write(`data: ${JSON.stringify(event)}\n\n`);
+          }
+          response.end();
+        }
+      } else {
+        json(404, { error: { message: "No synthetic fixture for this route" } });
+      }
+    })().catch((error: unknown) => {
+      errors.push(String(error));
+      if (!response.headersSent) {
+        response.writeHead(500);
+      }
+      response.end();
+    });
+  });
+  const sockets = new WebSocketServer({ noServer: true });
+  server.on("upgrade", (request, socket, head) => {
+    sockets.handleUpgrade(request, socket, head, (websocket) => {
+      websocket.on("error", (error) => errors.push(String(error)));
+      websocket.on("message", (raw) => {
+        recordRequest(request, raw.toString(), "websocket");
+        const events = exhausted() || phase === "revoked" ? [failure()] : successEvents();
+        for (const event of events) {
+          responses.push({ phase, path: request.url ?? "", value: event });
+          websocket.send(JSON.stringify(event));
+        }
+      });
+    });
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("Provider did not bind loopback");
+  }
+  return {
+    baseUrl: `http://127.0.0.1:${address.port}`,
+    requests,
+    responses,
+    heldUsageResponses,
+    errors,
+    setPhase(next: Phase) {
+      phase = next;
+    },
+    observeNextSuccess(observer: () => void) {
+      nextSuccessObserver = observer;
+    },
+    holdNextUsage() {
+      if (nextUsageHold) {
+        throw new Error("A usage response hold is already armed");
+      }
+      const hold = {
+        arrived: createDeferredCore<HeldUsageResponse>(),
+        released: createDeferredCore<void>(),
+      };
+      nextUsageHold = hold;
+      return { arrived: hold.arrived.promise, release: () => hold.released.resolve() };
+    },
+    async stop() {
+      for (const socket of sockets.clients) {
+        socket.terminate();
+      }
+      await new Promise<void>((resolve, reject) => {
+        sockets.close((error) => (error ? reject(error) : resolve()));
+      });
+      server.closeAllConnections();
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    },
+  };
+}
+
+describe.each([
+  {
+    source: "wham",
+    expiresDuringBlock: false,
+    scopedCooldown: false,
+    availableProbeCooldown: false,
+    staleUsageAfterSuccess: false,
+  },
+  {
+    source: "codex_rate_limits",
+    expiresDuringBlock: false,
+    scopedCooldown: false,
+    availableProbeCooldown: false,
+    staleUsageAfterSuccess: false,
+  },
+  {
+    source: "wham",
+    expiresDuringBlock: true,
+    scopedCooldown: false,
+    availableProbeCooldown: false,
+    staleUsageAfterSuccess: false,
+  },
+  {
+    source: "codex_rate_limits",
+    expiresDuringBlock: false,
+    scopedCooldown: true,
+    availableProbeCooldown: false,
+    staleUsageAfterSuccess: false,
+  },
+  {
+    source: "codex_rate_limits",
+    expiresDuringBlock: false,
+    scopedCooldown: true,
+    availableProbeCooldown: true,
+    staleUsageAfterSuccess: false,
+  },
+  {
+    source: "codex_rate_limits",
+    expiresDuringBlock: false,
+    scopedCooldown: true,
+    availableProbeCooldown: false,
+    staleUsageAfterSuccess: true,
+  },
+] as const)(
+  "Gateway quota reset ($source, expired=$expiresDuringBlock, scoped=$scopedCooldown, available=$availableProbeCooldown, stale-success=$staleUsageAfterSuccess)",
+  ({
+    source,
+    expiresDuringBlock,
+    scopedCooldown,
+    availableProbeCooldown,
+    staleUsageAfterSuccess,
+  }) => {
+    it(
+      "recovers the next chat after upstream capacity returns without admitting exhausted or revoked auth",
+      { timeout: 600_000 },
+      async (context) => {
+        const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-quota-reset-"));
+        context.onTestFinished(() => fs.rm(root, { recursive: true, force: true }));
+        const provider = await startQuotaProvider(source);
+        context.onTestFinished(() => provider.stop());
+        const clockFile = path.join(root, "clock-offset");
+        await fs.writeFile(clockFile, "0");
+        let offset = 0;
+        const advanceClock = async (
+          advanceMs = expiresDuringBlock ? 2 * 86_400_000 + RECHECK_ADVANCE_MS : RECHECK_ADVANCE_MS,
+        ) => {
+          offset += advanceMs;
+          await fs.writeFile(`${clockFile}.next`, String(offset));
+          await fs.rename(`${clockFile}.next`, clockFile);
+        };
+        const preload = new URL("./quota-reset-preload.mjs", import.meta.url);
+        preload.searchParams.set("fixture", provider.baseUrl);
+        preload.searchParams.set("clock", clockFile);
+        const requireCodex = createRequire(
+          new URL("../../../../extensions/codex/package.json", import.meta.url),
+        );
+        const launcher = path.join(
+          path.dirname(requireCodex.resolve("@openai/codex/package.json")),
+          "bin/codex.js",
+        );
+        const gateway = await createOpenClawTestInstance({
+          name: `quota-reset-${source}`,
+          gatewayCommandPrefix: [process.execPath, "--import", preload.href],
+          startTimeoutMs: 120_000,
+          env: {
+            OPENCLAW_TEST_MINIMAL_GATEWAY: "0",
+            OPENCLAW_SKIP_PROVIDERS: undefined,
+            OPENCLAW_AGENT_HARNESS_FALLBACK: "none",
+          },
+          config: {
+            gateway: { controlUi: { enabled: false } },
+            ...(scopedCooldown
+              ? {
+                  models: {
+                    providers: {
+                      openai: {
+                        baseUrl: "https://chatgpt.com/backend-api/codex",
+                        api: "openai-chatgpt-responses" as const,
+                        auth: "oauth" as const,
+                        models: ["gpt-5.5", UTILITY_MODEL_ID].map((id) => ({
+                          id,
+                          name: id,
+                          reasoning: false,
+                          input: ["text" as const],
+                          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                          contextWindow: 128_000,
+                          maxTokens: 4096,
+                        })),
+                      },
+                    },
+                  },
+                }
+              : {}),
+            plugins: {
+              enabled: true,
+              allow: ["codex", "openai"],
+              entries: {
+                codex: {
+                  enabled: true,
+                  config: {
+                    appServer: {
+                      mode: "yolo",
+                      command: process.execPath,
+                      args: [
+                        launcher,
+                        "app-server",
+                        "-c",
+                        `chatgpt_base_url="${provider.baseUrl}/backend-api"`,
+                        "-c",
+                        `openai_base_url="${provider.baseUrl}/v1"`,
+                      ],
+                      requestTimeoutMs: 60_000,
+                    },
+                  },
+                },
+              },
+            },
+            agents: {
+              defaults: {
+                model: { primary: MODEL, fallbacks: [] },
+                models: { [MODEL]: { agentRuntime: { id: "codex" } } },
+                ...(scopedCooldown ? { utilityModel: `openai/${UTILITY_MODEL_ID}` } : {}),
+                workspace: "~/workspace",
+                skipBootstrap: true,
+                timeoutSeconds: 90,
+                sandbox: { mode: "off" },
+              },
+            },
+          },
+        });
+        context.onTestFinished(() => gateway.cleanup());
+        // Doctor imports without refreshing a credential outside its one-day warning window.
+        const expires = expiresDuringBlock ? Date.now() + 2 * 86_400_000 : Date.UTC(2036, 0, 1);
+        const access = syntheticAccessToken(expires);
+        await gateway.state.writeText(
+          "agents/main/agent/auth-profiles.json",
+          JSON.stringify({
+            version: 1,
+            profiles: {
+              [PROFILE_ID]: {
+                type: "oauth",
+                provider: "openai",
+                access,
+                refresh: "synthetic-refresh",
+                expires,
+                accountId: ACCOUNT_ID,
+              },
+            },
+            order: { openai: [PROFILE_ID] },
+          }),
+        );
+        const doctor = await gateway.cli(["doctor", "--fix", "--yes", "--non-interactive"], {
+          timeoutMs: 120_000,
+        });
+        expect(doctor.code, doctor.stderr).toBe(0);
+        await gateway.startGateway();
+        const client = await connectGatewayClient({
+          url: `ws://127.0.0.1:${gateway.port}`,
+          token: gateway.gatewayToken,
+          clientName: "cli",
+          mode: "cli",
+          role: "operator",
+          scopes: ["operator.admin", "operator.read", "operator.write"],
+        });
+        context.onTestFinished(() => client.stopAndWait());
+        const sessionKey = `agent:main:quota-${randomUUID()}`;
+        const turns: unknown[] = [];
+        const stats = () =>
+          coerceAuthProfileState(readPersistedSharedAuthProfileStateRaw(gateway.env)).usageStats?.[
+            PROFILE_ID
+          ];
+        const evidence = () =>
+          JSON.stringify(
+            {
+              requests: provider.requests,
+              responses: provider.responses,
+              heldUsageResponses: provider.heldUsageResponses,
+              errors: provider.errors,
+              turns,
+              stats: stats(),
+              gateway: gateway.logs(),
+            },
+            null,
+            2,
+          );
+        const turn = async (key = sessionKey) => {
+          const before = assistantTexts(
+            await client.request<ChatHistory>("chat.history", { sessionKey: key, limit: 100 }),
+          );
+          const started = await client.request<{ runId: string; status: string }>("chat.send", {
+            sessionKey: key,
+            message: `Return ${MARKER}.`,
+            deliver: false,
+            idempotencyKey: randomUUID(),
+          });
+          expect(started.status, evidence()).toBe("started");
+          const terminal = await client.request<{ status: string; error?: unknown }>(
+            "agent.wait",
+            { runId: started.runId, timeoutMs: 100_000 },
+            { timeoutMs: 105_000 },
+          );
+          const history = await client.request<ChatHistory>("chat.history", {
+            sessionKey: key,
+            limit: 100,
+          });
+          turns.push({ started, terminal, history });
+          const after = assistantTexts(history);
+          expect(["ok", "error"], JSON.stringify({ terminal, evidence: evidence() })).toContain(
+            terminal.status,
+          );
+          return { status: terminal.status, output: after.slice(before.length) };
+        };
+        expect(await turn(), evidence()).toEqual({ status: "ok", output: [MARKER] });
+        if (staleUsageAfterSuccess) {
+          const companionSessionKey = `agent:main:quota-companion-${randomUUID()}`;
+          expect(await turn(companionSessionKey), evidence()).toEqual({
+            status: "ok",
+            output: [MARKER],
+          });
+          const warmCompanion = await client.request<{ answer: string }>(
+            "sessions.companion.ask",
+            { sessionKey: companionSessionKey, question: `Return ${MARKER}.` },
+            { timeoutMs: 100_000 },
+          );
+          turns.push({ warmCompanion });
+          expect(warmCompanion.answer, evidence()).toBe(MARKER);
+          const beforeOverlap = stats();
+          turns.push({ beforeOverlap });
+          expect(beforeOverlap?.blockedUntil, evidence()).toBeUndefined();
+          expect(beforeOverlap?.blockedReason, evidence()).toBeUndefined();
+
+          provider.setPhase("ordinary-rate-limit-with-exhausted-usage");
+          const hold = provider.holdNextUsage();
+          const olderCompanion = client
+            .request(
+              "sessions.companion.ask",
+              { sessionKey: companionSessionKey, question: "Return the older request's answer." },
+              { timeoutMs: 100_000 },
+            )
+            .then(
+              (result) => ({ status: "ok", result }),
+              (error: unknown) => ({ status: "error", error: String(error) }),
+            );
+          try {
+            await expect
+              .poll(() => provider.heldUsageResponses.length, { timeout: 2800, interval: 10 })
+              .toBe(1);
+            const captured = await hold.arrived;
+            expect(captured.status, evidence()).toBe(200);
+            expect(JSON.parse(captured.body), evidence()).toMatchObject({
+              rate_limit: {
+                allowed: false,
+                limit_reached: true,
+                primary_window: { used_percent: 100 },
+                secondary_window: { used_percent: 100 },
+              },
+            });
+            provider.setPhase("healthy");
+            expect(await turn(), evidence()).toEqual({ status: "ok", output: [MARKER] });
+            const newerSuccessCompletedAt = Date.now();
+            const beforeRelease = stats();
+            turns.push({ newerSuccessCompletedAt, beforeRelease });
+            expect(captured.releaseReason, evidence()).toBeUndefined();
+            expect(beforeRelease?.blockedUntil, evidence()).toBeUndefined();
+            expect(newerSuccessCompletedAt, evidence()).toBeGreaterThanOrEqual(captured.capturedAt);
+            hold.release();
+            const olderResult = await olderCompanion;
+            const afterRelease = stats();
+            turns.push({ olderResult, afterRelease });
+            expect(olderResult.status, evidence()).toBe("error");
+            expect(captured.releaseReason, evidence()).toBe("explicit");
+            expect(captured.releasedAt, evidence()).toBeGreaterThanOrEqual(newerSuccessCompletedAt);
+            expect(await turn(), evidence()).toEqual({ status: "ok", output: [MARKER] });
+            expect(afterRelease?.blockedUntil, evidence()).toBeUndefined();
+            expect(afterRelease?.blockedReason, evidence()).toBeUndefined();
+            for (const request of provider.requests.filter(
+              (entry) => entry.path.endsWith("/responses") || entry.path === "/core-wham/usage",
+            )) {
+              expect(request.authorization, evidence()).toBe(`Bearer ${access}`);
+            }
+            expect(provider.errors, evidence()).toEqual([]);
+          } finally {
+            hold.release();
+            await olderCompanion;
+          }
+          return;
+        }
+        const quotaSessions =
+          source === "codex_rate_limits"
+            ? [sessionKey, `agent:main:quota-${randomUUID()}`, `agent:main:quota-${randomUUID()}`]
+            : [sessionKey];
+        for (const key of quotaSessions.slice(1)) {
+          expect(await turn(key), evidence()).toEqual({ status: "ok", output: [MARKER] });
+        }
+        provider.setPhase("initial-exhaustion");
+        for (const blocked of await Promise.all(quotaSessions.map((key) => turn(key)))) {
+          expect(blocked.status, evidence()).toBe("error");
+          expect(blocked.output, evidence()).not.toContain(MARKER);
+        }
+        expect(stats(), evidence()).toMatchObject({
+          blockedSource: source,
+          blockedReason: "subscription_limit",
+        });
+        expect(stats()?.blockedUntil, evidence()).toBeGreaterThan(Date.now() + 86_400_000);
+
+        if (availableProbeCooldown) {
+          expect(stats(), evidence()).toMatchObject({
+            blockedModel: "gpt-5.5",
+            blockedScope: "model",
+          });
+          await advanceClock();
+          provider.setPhase("ordinary-rate-limit-with-capacity");
+          await expect(
+            client.request(
+              "sessions.companion.ask",
+              { sessionKey, question: `Return ${MARKER}.` },
+              { timeoutMs: 100_000 },
+            ),
+            evidence(),
+          ).rejects.toThrow();
+          const afterUtilityFailure = stats();
+          turns.push({ afterUtilityFailure });
+          expect(afterUtilityFailure, evidence()).toMatchObject({
+            cooldownModel: UTILITY_MODEL_ID,
+            cooldownReason: "rate_limit",
+          });
+          const ordinaryCooldown = afterUtilityFailure?.cooldownUntil;
+          expect(ordinaryCooldown, evidence()).toBeGreaterThan(Date.now() + offset);
+          expect(provider.responses, evidence()).toContainEqual({
+            phase: "ordinary-rate-limit-with-capacity",
+            path: "/core-wham/usage",
+            value: expect.objectContaining({
+              rate_limit: expect.objectContaining({
+                allowed: true,
+                limit_reached: false,
+                primary_window: expect.objectContaining({ used_percent: 2 }),
+                secondary_window: expect.objectContaining({ used_percent: 2 }),
+              }),
+            }),
+            headers: {},
+          });
+          let beforeRecoveryReply: ReturnType<typeof stats>;
+          provider.observeNextSuccess(() => {
+            beforeRecoveryReply = stats();
+            turns.push({ beforeRecoveryReply });
+          });
+          provider.setPhase("restored");
+          expect(await turn(), evidence()).toEqual({ status: "ok", output: [MARKER] });
+          expect(beforeRecoveryReply?.blockedUntil, evidence()).toBeUndefined();
+          expect(beforeRecoveryReply, evidence()).toMatchObject({
+            cooldownModel: UTILITY_MODEL_ID,
+            cooldownReason: "rate_limit",
+            cooldownUntil: ordinaryCooldown,
+          });
+          expect(provider.errors, evidence()).toEqual([]);
+          return;
+        }
+
+        if (scopedCooldown) {
+          provider.setPhase("ordinary-rate-limit");
+          for (let attempt = 0; attempt < 4; attempt++) {
+            await expect(
+              client.request(
+                "sessions.companion.ask",
+                {
+                  sessionKey,
+                  question: `Return ${MARKER}.`,
+                },
+                { timeoutMs: 100_000 },
+              ),
+              evidence(),
+            ).rejects.toThrow();
+            expect(stats(), evidence()).toMatchObject({
+              blockedModel: "gpt-5.5",
+              blockedScope: "model",
+              cooldownModel: UTILITY_MODEL_ID,
+              cooldownReason: "rate_limit",
+            });
+            if (attempt < 3) {
+              const cooldownUntil = stats()?.cooldownUntil;
+              expect(cooldownUntil, evidence()).toEqual(expect.any(Number));
+              if (cooldownUntil === undefined) {
+                throw new Error("Companion failure did not persist its retry deadline");
+              }
+              await advanceClock(Math.max(1, cooldownUntil - Date.now() - offset + 1));
+            }
+          }
+          provider.setPhase("restored");
+          await advanceClock();
+          expect(stats()?.cooldownUntil, evidence()).toBeGreaterThan(Date.now() + offset);
+          expect(await turn(), evidence()).toEqual({ status: "ok", output: [MARKER] });
+          expect(stats()?.blockedUntil, evidence()).toBeUndefined();
+          expect(provider.errors, evidence()).toEqual([]);
+          return;
+        }
+
+        if (source === "codex_rate_limits") {
+          const originalGeneration = stats();
+          expect(originalGeneration?.lastFailureAt, evidence()).toEqual(expect.any(Number));
+          expect(originalGeneration?.failureCounts?.rate_limit, evidence()).toBeGreaterThan(0);
+          for (const phase of [
+            "additional-exhaustion",
+            "workspace-exhaustion",
+            "spending-exhaustion",
+            "malformed-usage",
+          ] as const) {
+            provider.setPhase(phase);
+            await advanceClock();
+            const additionalLimitTurn = await turn();
+            expect(additionalLimitTurn.status, evidence()).toBe("error");
+            expect(additionalLimitTurn.output, evidence()).not.toContain(MARKER);
+            const retained = stats();
+            expect(retained?.blockedReason, evidence()).toBe("subscription_limit");
+            expect(retained?.blockedUntil, evidence()).toBeGreaterThan(Date.now() + offset);
+            expect(retained?.lastFailureAt, evidence()).toBe(originalGeneration?.lastFailureAt);
+            expect(retained?.failureCounts, evidence()).toEqual(originalGeneration?.failureCounts);
+            const additionalLimitRequests = provider.requests.filter(
+              (request) => request.phase === phase,
+            );
+            expect(
+              additionalLimitRequests.filter((request) => request.path === "/core-wham/usage"),
+              evidence(),
+            ).not.toHaveLength(0);
+            // A fresh exhausted bucket must not become another failed inference attempt.
+            expect(
+              additionalLimitRequests.filter(
+                (request) =>
+                  request.transport === "websocket" || request.path.endsWith("/responses"),
+              ),
+              evidence(),
+            ).toEqual([]);
+          }
+        }
+
+        provider.setPhase("exhausted");
+        if (!expiresDuringBlock) {
+          await advanceClock();
+        }
+        const exhaustedTurn = await turn();
+        expect(exhaustedTurn.status, evidence()).toBe("error");
+        expect(exhaustedTurn.output, evidence()).not.toContain(MARKER);
+        expect(stats()?.blockedUntil, evidence()).toBeGreaterThan(Date.now() + offset);
+
+        provider.setPhase("restored");
+        const earlyRetry = await turn();
+        expect(earlyRetry.status, evidence()).toBe("error");
+        expect(earlyRetry.output, evidence()).not.toContain(MARKER);
+        expect(
+          provider.requests.filter(
+            (request) => request.phase === "restored" && request.path === "/core-wham/usage",
+          ),
+          evidence(),
+        ).toEqual([]);
+        await advanceClock();
+        expect(await turn(), evidence()).toEqual({ status: "ok", output: [MARKER] });
+        expect(stats()?.blockedUntil, evidence()).toBeUndefined();
+        if (expiresDuringBlock) {
+          const refreshRequests = provider.requests.filter(
+            (request) => request.path === "/oauth/token",
+          );
+          expect(refreshRequests, evidence()).toHaveLength(1);
+          expect(refreshRequests[0]?.body, evidence()).toContain("synthetic-refresh");
+        }
+        expect(
+          provider.requests.filter(
+            (request) => request.phase === "restored" && request.path === "/core-wham/usage",
+          ),
+          evidence(),
+        ).not.toHaveLength(0);
+        expect(
+          provider.requests.filter(
+            (request) => request.phase === "restored" && request.path.endsWith("/responses"),
+          ),
+          evidence(),
+        ).not.toHaveLength(0);
+
+        provider.setPhase("revoked");
+        const revoked = await turn();
+        expect(revoked.status, evidence()).toBe("error");
+        expect(revoked.output, evidence()).not.toContain(MARKER);
+        await advanceClock();
+        const revokedAgain = await turn();
+        expect(revokedAgain.status, evidence()).toBe("error");
+        expect(revokedAgain.output, evidence()).not.toContain(MARKER);
+        for (const request of provider.requests.filter(
+          (entry) => entry.path.endsWith("/responses") || entry.path === "/core-wham/usage",
+        )) {
+          const refreshed =
+            expiresDuringBlock && (request.phase === "restored" || request.phase === "revoked");
+          // The native process retains its real clock and may reuse the bound session's token.
+          if (refreshed && request.path.endsWith("/responses")) {
+            expect([`Bearer ${access}`, `Bearer ${syntheticAccessToken()}`], evidence()).toContain(
+              request.authorization,
+            );
+            expect(request.accountId, evidence()).toBe(ACCOUNT_ID);
+          } else {
+            expect(request.authorization, evidence()).toBe(
+              `Bearer ${refreshed ? syntheticAccessToken() : access}`,
+            );
+          }
+        }
+        for (const request of provider.requests.filter(
+          (entry) => entry.path === "/core-wham/usage",
+        )) {
+          expect(request.accountId, evidence()).toBe(ACCOUNT_ID);
+        }
+        expect(provider.errors, evidence()).toEqual([]);
+      },
+    );
+  },
+);

--- a/test/e2e/qa-lab/runtime/quota-reset.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/quota-reset.e2e.test.ts
@@ -1,421 +1,17 @@
 import { randomUUID } from "node:crypto";
-import fs from "node:fs/promises";
-import { createServer, type IncomingMessage } from "node:http";
-import { createRequire } from "node:module";
-import os from "node:os";
-import path from "node:path";
-import { zstdDecompressSync } from "node:zlib";
 import { describe, expect, it } from "vitest";
-import { WebSocketServer } from "ws";
-import { readPersistedSharedAuthProfileStateRaw } from "../../../../src/agents/auth-profiles/sqlite.js";
-import { coerceAuthProfileState } from "../../../../src/agents/auth-profiles/state.js";
-import { connectGatewayClient } from "../../../../src/gateway/test-helpers.e2e.js";
-import { createDeferredCore, type Deferred } from "../../../../src/shared/deferred.js";
-import { createOpenClawTestInstance } from "../../../helpers/openclaw-test-instance.js";
-
-const MODEL = "openai/gpt-5.5";
-const UTILITY_MODEL_ID = "quota-test-utility";
-const PROFILE_ID = "openai:quota";
-const ACCOUNT_ID = "quota-test-account";
-const MARKER = "QUOTA_TURN_OK";
-const RECHECK_ADVANCE_MS = 300_100;
-type BlockSource = "wham" | "codex_rate_limits";
-type Phase =
-  | "healthy"
-  | "initial-exhaustion"
-  | "ordinary-rate-limit"
-  | "ordinary-rate-limit-with-capacity"
-  | "ordinary-rate-limit-with-exhausted-usage"
-  | "exhausted"
-  | "additional-exhaustion"
-  | "workspace-exhaustion"
-  | "spending-exhaustion"
-  | "malformed-usage"
-  | "restored"
-  | "revoked";
-type RequestRecord = {
-  phase: Phase;
-  transport: "http" | "websocket";
-  path: string;
-  method: string | undefined;
-  headers: IncomingMessage["headers"];
-  rawHeaders: string[];
-  body: string | undefined;
-  bodyBase64?: string;
-  authorization: string | undefined;
-  accountId: string | string[] | undefined;
-};
-type ChatHistory = {
-  messages: Array<{
-    role: string;
-    content?: string | Array<{ type: string; text?: string }>;
-  }>;
-};
-type HeldUsageResponse = {
-  phase: Phase;
-  path: string;
-  status: number;
-  body: string;
-  capturedAt: number;
-  releasedAt?: number;
-  releaseReason?: "explicit" | "deadline" | "aborted";
-};
-
-function syntheticAccessToken(expires = Date.UTC(2036, 0, 1)) {
-  return [
-    { alg: "none" },
-    {
-      "https://api.openai.com/auth": {
-        chatgpt_account_id: ACCOUNT_ID,
-        chatgpt_user_id: "quota-test-user",
-        chatgpt_plan_type: "pro",
-      },
-      exp: Math.floor(expires / 1000),
-      email: "quota@example.invalid",
-    },
-  ]
-    .map((value) => Buffer.from(JSON.stringify(value)).toString("base64url"))
-    .concat("synthetic")
-    .join(".");
-}
-
-function assistantTexts(history: ChatHistory): string[] {
-  return history.messages
-    .filter((message) => message.role === "assistant")
-    .map((message) =>
-      typeof message.content === "string"
-        ? message.content
-        : (message.content ?? [])
-            .filter((part) => part.type === "text")
-            .map((part) => part.text ?? "")
-            .join("\n"),
-    );
-}
-
-async function startQuotaProvider(source: BlockSource) {
-  let phase: Phase = "healthy";
-  let nextSuccessObserver: (() => void) | undefined;
-  let nextUsageHold: { arrived: Deferred<HeldUsageResponse>; released: Deferred<void> } | undefined;
-  const heldUsageResponses: HeldUsageResponse[] = [];
-  const resetAt = Math.floor(Date.now() / 1000) + 5 * 86_400;
-  const requests: RequestRecord[] = [];
-  const responses: Array<{
-    phase: Phase;
-    path: string;
-    value: unknown;
-    headers?: Record<string, string>;
-  }> = [];
-  const errors: string[] = [];
-  const primaryExhausted = () => phase === "initial-exhaustion" || phase === "exhausted";
-  const exhausted = () => phase !== "healthy" && phase !== "restored" && phase !== "revoked";
-  const recordRequest = (
-    request: IncomingMessage,
-    body: string | undefined,
-    transport: RequestRecord["transport"],
-    bodyBytes?: Buffer,
-  ) => {
-    requests.push({
-      phase,
-      transport,
-      path: request.url ?? "",
-      method: request.method,
-      headers: request.headers,
-      rawHeaders: request.rawHeaders,
-      body,
-      bodyBase64: bodyBytes?.toString("base64"),
-      authorization: request.headers.authorization,
-      accountId: request.headers["chatgpt-account-id"],
-    });
-  };
-  const usage = () => {
-    const usageExhausted =
-      primaryExhausted() || phase === "ordinary-rate-limit-with-exhausted-usage";
-    const window = (seconds: number, usedPercent = usageExhausted ? 100 : 2) => ({
-      used_percent: usedPercent,
-      limit_window_seconds: seconds,
-      reset_at: resetAt,
-      reset_after_seconds: resetAt - Math.floor(Date.now() / 1000),
-    });
-    return {
-      plan_type: "pro",
-      rate_limit: {
-        allowed: !usageExhausted,
-        limit_reached: usageExhausted,
-        primary_window: window(18_000),
-        secondary_window: window(604_800),
-      },
-      credits: { has_credits: false, unlimited: false, balance: "0" },
-      additional_rate_limits:
-        phase === "additional-exhaustion"
-          ? [
-              {
-                limit_name: "Additional Codex capacity",
-                metered_feature: "codex_other",
-                rate_limit: {
-                  allowed: false,
-                  limit_reached: true,
-                  primary_window: window(18_000, 100),
-                  secondary_window: null,
-                },
-              },
-            ]
-          : [],
-      spend_control:
-        phase === "malformed-usage"
-          ? { reached: "invalid" }
-          : phase === "spending-exhaustion"
-            ? { reached: true }
-            : null,
-      rate_limit_reached_type:
-        phase === "workspace-exhaustion" ? { type: "workspace_owner_credits_depleted" } : null,
-    };
-  };
-  const failure = () => {
-    const headers: Record<string, string> =
-      primaryExhausted() && source === "codex_rate_limits"
-        ? {
-            "x-codex-primary-used-percent": "100",
-            "x-codex-primary-window-minutes": "300",
-            "x-codex-primary-reset-at": String(resetAt),
-            "x-codex-secondary-used-percent": "100",
-            "x-codex-secondary-window-minutes": "10080",
-            "x-codex-secondary-reset-at": String(resetAt),
-          }
-        : {};
-    return {
-      type: "error",
-      status: phase === "revoked" ? 401 : 429,
-      error:
-        phase === "revoked"
-          ? {
-              type: "invalid_request_error",
-              code: "invalid_api_key",
-              message: "Invalid authentication token",
-            }
-          : phase === "ordinary-rate-limit" ||
-              phase === "ordinary-rate-limit-with-capacity" ||
-              phase === "ordinary-rate-limit-with-exhausted-usage"
-            ? {
-                type: "rate_limit_error",
-                code: "rate_limit_exceeded",
-                message: "Too many requests",
-              }
-            : {
-                type: "usage_limit_reached",
-                message: "The usage limit has been reached",
-                plan_type: "pro",
-                ...(source === "codex_rate_limits" ? { resets_at: resetAt } : {}),
-              },
-      headers,
-    };
-  };
-  const successEvents = () => {
-    const observe = nextSuccessObserver;
-    nextSuccessObserver = undefined;
-    observe?.();
-    const id = randomUUID().replaceAll("-", "");
-    const item = {
-      type: "message",
-      id: `msg${id}`,
-      role: "assistant",
-      status: "completed",
-      content: [{ type: "output_text", text: MARKER, annotations: [] }],
-    };
-    const response = {
-      id: `resp${id}`,
-      status: "completed",
-      output: [item],
-      usage: {
-        input_tokens: 11,
-        output_tokens: 7,
-        total_tokens: 18,
-        input_tokens_details: { cached_tokens: 0 },
-      },
-    };
-    return [
-      { type: "response.created", response: { ...response, status: "in_progress", output: [] } },
-      {
-        type: "response.output_item.added",
-        output_index: 0,
-        item: { ...item, status: "in_progress", content: [] },
-      },
-      {
-        type: "response.output_text.delta",
-        item_id: item.id,
-        output_index: 0,
-        content_index: 0,
-        delta: MARKER,
-      },
-      { type: "response.output_item.done", output_index: 0, item },
-      { type: "response.completed", response },
-    ];
-  };
-  const server = createServer((request, response) => {
-    void (async () => {
-      const chunks: Buffer[] = [];
-      for await (const chunk of request) {
-        chunks.push(Buffer.from(chunk));
-      }
-      const bodyBytes = Buffer.concat(chunks);
-      const encoding = request.headers["content-encoding"];
-      const decoded =
-        encoding === undefined
-          ? bodyBytes
-          : encoding === "zstd"
-            ? zstdDecompressSync(bodyBytes)
-            : undefined;
-      recordRequest(request, decoded?.toString(), "http", bodyBytes);
-      const requestPath = new URL(request.url ?? "/", "http://127.0.0.1").pathname;
-      const json = (
-        status: number,
-        value: unknown,
-        headers: Record<string, string> = {},
-        responsePhase = phase,
-      ) => {
-        responses.push({ phase: responsePhase, path: requestPath, value, headers });
-        response.writeHead(status, { "content-type": "application/json", ...headers });
-        response.end(JSON.stringify(value));
-      };
-      if (requestPath === "/core-wham/usage" || requestPath === "/backend-api/wham/usage") {
-        // Preserve the native block source only on the original quota failure.
-        if (
-          requestPath === "/core-wham/usage" &&
-          ((source === "codex_rate_limits" && phase === "initial-exhaustion") ||
-            phase === "ordinary-rate-limit")
-        ) {
-          json(503, { error: { message: "Usage view temporarily unavailable" } });
-        } else if (phase === "revoked") {
-          json(403, { error: { message: "Account deactivated" } });
-        } else {
-          const value = usage();
-          const hold = requestPath === "/core-wham/usage" ? nextUsageHold : undefined;
-          if (hold) {
-            nextUsageHold = undefined;
-            const captured: HeldUsageResponse = {
-              phase,
-              path: requestPath,
-              status: 200,
-              body: JSON.stringify(value),
-              capturedAt: Date.now(),
-            };
-            heldUsageResponses.push(captured);
-            hold.arrived.resolve(captured);
-            const interrupted = createDeferredCore<"deadline" | "aborted">();
-            const timer = setTimeout(() => interrupted.resolve("deadline"), 2800);
-            const onClose = () => interrupted.resolve("aborted");
-            response.once("close", onClose);
-            try {
-              captured.releaseReason = await Promise.race([
-                hold.released.promise.then(() => "explicit" as const),
-                interrupted.promise,
-              ]);
-              captured.releasedAt = Date.now();
-              if (captured.releaseReason !== "aborted") {
-                json(captured.status, value, {}, captured.phase);
-              }
-            } finally {
-              clearTimeout(timer);
-              response.off("close", onClose);
-            }
-          } else {
-            json(200, value);
-          }
-        }
-      } else if (requestPath === "/oauth/token") {
-        if (phase === "revoked") {
-          json(400, { error: "invalid_grant", error_description: "Refresh token revoked" });
-        } else {
-          json(200, {
-            access_token: syntheticAccessToken(),
-            refresh_token: "synthetic-rotated-refresh",
-            expires_in: 3600,
-          });
-        }
-      } else if (requestPath.endsWith("/models")) {
-        json(200, { models: [] });
-      } else if (requestPath.endsWith("/responses")) {
-        if (exhausted() || phase === "revoked") {
-          const event = failure();
-          json(event.status, { error: event.error }, event.headers);
-        } else {
-          const events = successEvents();
-          responses.push({ phase, path: requestPath, value: events });
-          response.writeHead(200, { "content-type": "text/event-stream" });
-          for (const event of events) {
-            response.write(`data: ${JSON.stringify(event)}\n\n`);
-          }
-          response.end();
-        }
-      } else {
-        json(404, { error: { message: "No synthetic fixture for this route" } });
-      }
-    })().catch((error: unknown) => {
-      errors.push(String(error));
-      if (!response.headersSent) {
-        response.writeHead(500);
-      }
-      response.end();
-    });
-  });
-  const sockets = new WebSocketServer({ noServer: true });
-  server.on("upgrade", (request, socket, head) => {
-    sockets.handleUpgrade(request, socket, head, (websocket) => {
-      websocket.on("error", (error) => errors.push(String(error)));
-      websocket.on("message", (raw) => {
-        recordRequest(request, raw.toString(), "websocket");
-        const events = exhausted() || phase === "revoked" ? [failure()] : successEvents();
-        for (const event of events) {
-          responses.push({ phase, path: request.url ?? "", value: event });
-          websocket.send(JSON.stringify(event));
-        }
-      });
-    });
-  });
-  await new Promise<void>((resolve, reject) => {
-    server.once("error", reject);
-    server.listen(0, "127.0.0.1", resolve);
-  });
-  const address = server.address();
-  if (!address || typeof address === "string") {
-    throw new Error("Provider did not bind loopback");
-  }
-  return {
-    baseUrl: `http://127.0.0.1:${address.port}`,
-    requests,
-    responses,
-    heldUsageResponses,
-    errors,
-    setPhase(next: Phase) {
-      phase = next;
-    },
-    observeNextSuccess(observer: () => void) {
-      nextSuccessObserver = observer;
-    },
-    holdNextUsage() {
-      if (nextUsageHold) {
-        throw new Error("A usage response hold is already armed");
-      }
-      const hold = {
-        arrived: createDeferredCore<HeldUsageResponse>(),
-        released: createDeferredCore<void>(),
-      };
-      nextUsageHold = hold;
-      return { arrived: hold.arrived.promise, release: () => hold.released.resolve() };
-    },
-    async stop() {
-      for (const socket of sockets.clients) {
-        socket.terminate();
-      }
-      await new Promise<void>((resolve, reject) => {
-        sockets.close((error) => (error ? reject(error) : resolve()));
-      });
-      server.closeAllConnections();
-      await new Promise<void>((resolve, reject) => {
-        server.close((error) => (error ? reject(error) : resolve()));
-      });
-    },
-  };
-}
+import {
+  ACCOUNT_ID,
+  BACKUP_API_KEY,
+  BACKUP_MARKER,
+  BACKUP_MODEL,
+  BACKUP_RESPONSES_PATH,
+  MARKER,
+  UTILITY_MODEL_ID,
+  createQuotaResetFixture,
+  installQuotaStateWriteFault,
+  syntheticAccessToken,
+} from "./quota-reset.test-support.js";
 
 describe.each([
   {
@@ -473,182 +69,22 @@ describe.each([
       "recovers the next chat after upstream capacity returns without admitting exhausted or revoked auth",
       { timeout: 600_000 },
       async (context) => {
-        const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-quota-reset-"));
-        context.onTestFinished(() => fs.rm(root, { recursive: true, force: true }));
-        const provider = await startQuotaProvider(source);
-        context.onTestFinished(() => provider.stop());
-        const clockFile = path.join(root, "clock-offset");
-        await fs.writeFile(clockFile, "0");
-        let offset = 0;
-        const advanceClock = async (
-          advanceMs = expiresDuringBlock ? 2 * 86_400_000 + RECHECK_ADVANCE_MS : RECHECK_ADVANCE_MS,
-        ) => {
-          offset += advanceMs;
-          await fs.writeFile(`${clockFile}.next`, String(offset));
-          await fs.rename(`${clockFile}.next`, clockFile);
-        };
-        const preload = new URL("./quota-reset-preload.mjs", import.meta.url);
-        preload.searchParams.set("fixture", provider.baseUrl);
-        preload.searchParams.set("clock", clockFile);
-        const requireCodex = createRequire(
-          new URL("../../../../extensions/codex/package.json", import.meta.url),
-        );
-        const launcher = path.join(
-          path.dirname(requireCodex.resolve("@openai/codex/package.json")),
-          "bin/codex.js",
-        );
-        const gateway = await createOpenClawTestInstance({
-          name: `quota-reset-${source}`,
-          gatewayCommandPrefix: [process.execPath, "--import", preload.href],
-          startTimeoutMs: 120_000,
-          env: {
-            OPENCLAW_TEST_MINIMAL_GATEWAY: "0",
-            OPENCLAW_SKIP_PROVIDERS: undefined,
-            OPENCLAW_AGENT_HARNESS_FALLBACK: "none",
-          },
-          config: {
-            gateway: { controlUi: { enabled: false } },
-            ...(scopedCooldown
-              ? {
-                  models: {
-                    providers: {
-                      openai: {
-                        baseUrl: "https://chatgpt.com/backend-api/codex",
-                        api: "openai-chatgpt-responses" as const,
-                        auth: "oauth" as const,
-                        models: ["gpt-5.5", UTILITY_MODEL_ID].map((id) => ({
-                          id,
-                          name: id,
-                          reasoning: false,
-                          input: ["text" as const],
-                          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-                          contextWindow: 128_000,
-                          maxTokens: 4096,
-                        })),
-                      },
-                    },
-                  },
-                }
-              : {}),
-            plugins: {
-              enabled: true,
-              allow: ["codex", "openai"],
-              entries: {
-                codex: {
-                  enabled: true,
-                  config: {
-                    appServer: {
-                      mode: "yolo",
-                      command: process.execPath,
-                      args: [
-                        launcher,
-                        "app-server",
-                        "-c",
-                        `chatgpt_base_url="${provider.baseUrl}/backend-api"`,
-                        "-c",
-                        `openai_base_url="${provider.baseUrl}/v1"`,
-                      ],
-                      requestTimeoutMs: 60_000,
-                    },
-                  },
-                },
-              },
-            },
-            agents: {
-              defaults: {
-                model: { primary: MODEL, fallbacks: [] },
-                models: { [MODEL]: { agentRuntime: { id: "codex" } } },
-                ...(scopedCooldown ? { utilityModel: `openai/${UTILITY_MODEL_ID}` } : {}),
-                workspace: "~/workspace",
-                skipBootstrap: true,
-                timeoutSeconds: 90,
-                sandbox: { mode: "off" },
-              },
-            },
-          },
+        const {
+          client,
+          provider,
+          sessionKey,
+          access,
+          advanceClock,
+          clock,
+          stats,
+          evidence,
+          turn,
+          turns,
+        } = await createQuotaResetFixture(context, {
+          source,
+          expiresDuringBlock,
+          scopedCooldown,
         });
-        context.onTestFinished(() => gateway.cleanup());
-        // Doctor imports without refreshing a credential outside its one-day warning window.
-        const expires = expiresDuringBlock ? Date.now() + 2 * 86_400_000 : Date.UTC(2036, 0, 1);
-        const access = syntheticAccessToken(expires);
-        await gateway.state.writeText(
-          "agents/main/agent/auth-profiles.json",
-          JSON.stringify({
-            version: 1,
-            profiles: {
-              [PROFILE_ID]: {
-                type: "oauth",
-                provider: "openai",
-                access,
-                refresh: "synthetic-refresh",
-                expires,
-                accountId: ACCOUNT_ID,
-              },
-            },
-            order: { openai: [PROFILE_ID] },
-          }),
-        );
-        const doctor = await gateway.cli(["doctor", "--fix", "--yes", "--non-interactive"], {
-          timeoutMs: 120_000,
-        });
-        expect(doctor.code, doctor.stderr).toBe(0);
-        await gateway.startGateway();
-        const client = await connectGatewayClient({
-          url: `ws://127.0.0.1:${gateway.port}`,
-          token: gateway.gatewayToken,
-          clientName: "cli",
-          mode: "cli",
-          role: "operator",
-          scopes: ["operator.admin", "operator.read", "operator.write"],
-        });
-        context.onTestFinished(() => client.stopAndWait());
-        const sessionKey = `agent:main:quota-${randomUUID()}`;
-        const turns: unknown[] = [];
-        const stats = () =>
-          coerceAuthProfileState(readPersistedSharedAuthProfileStateRaw(gateway.env)).usageStats?.[
-            PROFILE_ID
-          ];
-        const evidence = () =>
-          JSON.stringify(
-            {
-              requests: provider.requests,
-              responses: provider.responses,
-              heldUsageResponses: provider.heldUsageResponses,
-              errors: provider.errors,
-              turns,
-              stats: stats(),
-              gateway: gateway.logs(),
-            },
-            null,
-            2,
-          );
-        const turn = async (key = sessionKey) => {
-          const before = assistantTexts(
-            await client.request<ChatHistory>("chat.history", { sessionKey: key, limit: 100 }),
-          );
-          const started = await client.request<{ runId: string; status: string }>("chat.send", {
-            sessionKey: key,
-            message: `Return ${MARKER}.`,
-            deliver: false,
-            idempotencyKey: randomUUID(),
-          });
-          expect(started.status, evidence()).toBe("started");
-          const terminal = await client.request<{ status: string; error?: unknown }>(
-            "agent.wait",
-            { runId: started.runId, timeoutMs: 100_000 },
-            { timeoutMs: 105_000 },
-          );
-          const history = await client.request<ChatHistory>("chat.history", {
-            sessionKey: key,
-            limit: 100,
-          });
-          turns.push({ started, terminal, history });
-          const after = assistantTexts(history);
-          expect(["ok", "error"], JSON.stringify({ terminal, evidence: evidence() })).toContain(
-            terminal.status,
-          );
-          return { status: terminal.status, output: after.slice(before.length) };
-        };
         expect(await turn(), evidence()).toEqual({ status: "ok", output: [MARKER] });
         if (staleUsageAfterSuccess) {
           const companionSessionKey = `agent:main:quota-companion-${randomUUID()}`;
@@ -764,7 +200,7 @@ describe.each([
             cooldownReason: "rate_limit",
           });
           const ordinaryCooldown = afterUtilityFailure?.cooldownUntil;
-          expect(ordinaryCooldown, evidence()).toBeGreaterThan(Date.now() + offset);
+          expect(ordinaryCooldown, evidence()).toBeGreaterThan(Date.now() + clock.offset);
           expect(provider.responses, evidence()).toContainEqual({
             phase: "ordinary-rate-limit-with-capacity",
             path: "/core-wham/usage",
@@ -821,12 +257,12 @@ describe.each([
               if (cooldownUntil === undefined) {
                 throw new Error("Companion failure did not persist its retry deadline");
               }
-              await advanceClock(Math.max(1, cooldownUntil - Date.now() - offset + 1));
+              await advanceClock(Math.max(1, cooldownUntil - Date.now() - clock.offset + 1));
             }
           }
           provider.setPhase("restored");
           await advanceClock();
-          expect(stats()?.cooldownUntil, evidence()).toBeGreaterThan(Date.now() + offset);
+          expect(stats()?.cooldownUntil, evidence()).toBeGreaterThan(Date.now() + clock.offset);
           expect(await turn(), evidence()).toEqual({ status: "ok", output: [MARKER] });
           expect(stats()?.blockedUntil, evidence()).toBeUndefined();
           expect(provider.errors, evidence()).toEqual([]);
@@ -850,7 +286,7 @@ describe.each([
             expect(additionalLimitTurn.output, evidence()).not.toContain(MARKER);
             const retained = stats();
             expect(retained?.blockedReason, evidence()).toBe("subscription_limit");
-            expect(retained?.blockedUntil, evidence()).toBeGreaterThan(Date.now() + offset);
+            expect(retained?.blockedUntil, evidence()).toBeGreaterThan(Date.now() + clock.offset);
             expect(retained?.lastFailureAt, evidence()).toBe(originalGeneration?.lastFailureAt);
             expect(retained?.failureCounts, evidence()).toEqual(originalGeneration?.failureCounts);
             const additionalLimitRequests = provider.requests.filter(
@@ -878,7 +314,7 @@ describe.each([
         const exhaustedTurn = await turn();
         expect(exhaustedTurn.status, evidence()).toBe("error");
         expect(exhaustedTurn.output, evidence()).not.toContain(MARKER);
-        expect(stats()?.blockedUntil, evidence()).toBeGreaterThan(Date.now() + offset);
+        expect(stats()?.blockedUntil, evidence()).toBeGreaterThan(Date.now() + clock.offset);
 
         provider.setPhase("restored");
         const earlyRetry = await turn();
@@ -948,3 +384,110 @@ describe.each([
     );
   },
 );
+
+describe.each([
+  { write: "claim", failure: "io" },
+  { write: "result", failure: "io" },
+  { write: "claim", failure: "constraint" },
+] as const)("Quota $write write $failure failure", ({ write, failure }) => {
+  it.skipIf(process.platform === "win32")(
+    "preserves healthy fallback for operational writes and refuses constraint failures through chat.send",
+    { timeout: 600_000 },
+    async (context) => {
+      const { client, provider, gateway, turn, stats, evidence, advanceClock, storageFaultFile } =
+        await createQuotaResetFixture(context, {
+          source: "codex_rate_limits",
+          includeBackup: true,
+          limitGatewayFileSize: true,
+        });
+      expect(await turn(), evidence()).toEqual({ status: "ok", output: [MARKER] });
+
+      const directBackupSession = `agent:main:quota-backup-${randomUUID()}`;
+      await client.request("sessions.patch", { key: directBackupSession, model: BACKUP_MODEL });
+      expect(await turn(directBackupSession), evidence()).toEqual({
+        status: "ok",
+        output: [BACKUP_MARKER],
+      });
+
+      provider.setPhase("initial-exhaustion");
+      const initialFallback = await turn(`agent:main:quota-initial-fallback-${randomUUID()}`);
+      expect(initialFallback.status, evidence()).toBe("ok");
+      expect(initialFallback.output, evidence()).toContain(BACKUP_MARKER);
+      expect(stats(), evidence()).toMatchObject({
+        blockedSource: "codex_rate_limits",
+        blockedReason: "subscription_limit",
+      });
+      const blockedUntil = stats()?.blockedUntil;
+      expect(blockedUntil, evidence()).toBeGreaterThan(Date.now() + 86_400_000);
+
+      provider.setPhase("restored");
+      await advanceClock();
+      const fault = await installQuotaStateWriteFault(gateway, storageFaultFile, write, failure);
+      try {
+        expect(
+          await turn(directBackupSession, `Direct backup before ${write} I/O failure.`),
+          evidence(),
+        ).toEqual({ status: "ok", output: [BACKUP_MARKER] });
+        const beforeFault = provider.requests.length;
+        const prompt = `Ordinary chat during the quota ${write} write ${failure} failure.`;
+        // A new ordinary session uses configured primary/fallback order instead
+        // of a previous turn's automatic model preference.
+        const fallback = await turn(`agent:main:quota-storage-fallback-${randomUUID()}`, prompt);
+        const backupAfterFault = await turn(
+          directBackupSession,
+          `Direct backup after ${write} I/O failure.`,
+        );
+
+        expect(gateway.logs(), evidence()).toContain(
+          failure === "io" ? "disk I/O error" : "quota test constraint invariant",
+        );
+        expect(gateway.logs(), evidence()).toContain(`errcode: ${failure === "io" ? 778 : 1811}`);
+        expect(fault.scratchCommitted(), evidence()).toBe(false);
+        expect(backupAfterFault, evidence()).toEqual({ status: "ok", output: [BACKUP_MARKER] });
+        expect(fallback.status, evidence()).toBe(failure === "io" ? "ok" : "error");
+        if (failure === "io") {
+          expect(fallback.output, evidence()).toContain(BACKUP_MARKER);
+        } else {
+          expect(fallback.output, evidence()).not.toContain(BACKUP_MARKER);
+        }
+        const faultRequests = provider.requests.slice(beforeFault);
+        expect(
+          faultRequests.filter(
+            (request) =>
+              request.path !== BACKUP_RESPONSES_PATH &&
+              (request.transport === "websocket" || request.path.endsWith("/responses")),
+          ),
+          evidence(),
+        ).toEqual([]);
+        expect(
+          faultRequests.filter((request) => request.path === "/core-wham/usage"),
+          evidence(),
+        ).toHaveLength(write === "claim" ? 0 : 1);
+        const fallbackRequests = faultRequests.filter((request) => request.body?.includes(prompt));
+        if (failure === "io") {
+          expect(fallbackRequests, evidence()).toContainEqual(
+            expect.objectContaining({
+              path: BACKUP_RESPONSES_PATH,
+              authorization: `Bearer ${BACKUP_API_KEY}`,
+            }),
+          );
+        } else {
+          expect(fallbackRequests, evidence()).toEqual([]);
+        }
+        expect(stats(), evidence()).toMatchObject({
+          blockedReason: "subscription_limit",
+          blockedUntil,
+        });
+        expect(provider.errors, evidence()).toEqual([]);
+      } finally {
+        await fault.remove();
+      }
+      await advanceClock();
+      expect(await turn(`agent:main:quota-after-fault-${randomUUID()}`), evidence()).toEqual({
+        status: "ok",
+        output: [MARKER],
+      });
+      expect(stats()?.blockedUntil, evidence()).toBeUndefined();
+    },
+  );
+});

--- a/test/e2e/qa-lab/runtime/quota-reset.isolated.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/quota-reset.isolated.e2e.test.ts
@@ -1,0 +1,244 @@
+import { randomUUID } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import type { ToolsInvokeResult } from "../../../../packages/gateway-protocol/src/schema/agents-models-skills.js";
+import { readPersistedSharedAuthProfileStoreRaw } from "../../../../src/agents/auth-profiles/sqlite.js";
+import type { ModelAuthLogoutResult } from "../../../../src/gateway/server-methods/models-auth-status.types.js";
+import { createQuotaResetFixture } from "./quota-reset.test-support.js";
+
+const ISOLATED_TEXT = '{"result":"QUOTA_ISOLATED_OK"}';
+type QuotaFixture = Awaited<ReturnType<typeof createQuotaResetFixture>>;
+
+async function invokeIsolated(fixture: QuotaFixture, profileId = fixture.profileId) {
+  const result = await fixture.client.request<ToolsInvokeResult>(
+    "tools.invoke",
+    {
+      name: "llm-task",
+      sessionKey: fixture.sessionKey,
+      idempotencyKey: randomUUID(),
+      args: {
+        prompt: `Return ${ISOLATED_TEXT}.`,
+        authProfileId: profileId,
+        schema: {
+          type: "object",
+          properties: { result: { const: "QUOTA_ISOLATED_OK" } },
+          required: ["result"],
+          additionalProperties: false,
+        },
+        timeoutMs: 30_000,
+      },
+    },
+    { timeoutMs: 40_000 },
+  );
+  fixture.turns.push({ isolated: result, profileId });
+  return result;
+}
+
+function expectIsolatedSuccess(result: ToolsInvokeResult, evidence: string) {
+  expect(result, evidence).toMatchObject({
+    ok: true,
+    toolName: "llm-task",
+    source: "plugin",
+    output: {
+      content: [{ type: "text", text: expect.stringContaining('"QUOTA_ISOLATED_OK"') }],
+      details: { json: { result: "QUOTA_ISOLATED_OK" } },
+    },
+  });
+}
+
+describe("Gateway isolated task quota recovery", () => {
+  it(
+    "recovers a registered isolated task after quota resets while rejecting exhausted capacity",
+    { timeout: 600_000 },
+    async (context) => {
+      const fixture = await createQuotaResetFixture(context, {
+        source: "wham",
+        runtime: "openclaw",
+        enableIsolatedTool: true,
+        responseText: ISOLATED_TEXT,
+      });
+      const { provider, turn, stats, advanceClock, clock, evidence, access } = fixture;
+      expect(await turn(), evidence()).toEqual({ status: "ok", output: [ISOLATED_TEXT] });
+      expectIsolatedSuccess(await invokeIsolated(fixture), evidence());
+
+      provider.setPhase("initial-exhaustion");
+      expect((await turn()).status, evidence()).toBe("error");
+      expect(stats(), evidence()).toMatchObject({
+        blockedSource: "wham",
+        blockedReason: "subscription_limit",
+      });
+      expect(stats()?.blockedUntil, evidence()).toBeGreaterThan(Date.now() + 86_400_000);
+
+      provider.setPhase("restored");
+      const beforeEarly = provider.requests.length;
+      expect(await invokeIsolated(fixture), evidence()).toMatchObject({ ok: false });
+      expect(
+        provider.requests
+          .slice(beforeEarly)
+          .filter(
+            (request) => request.path === "/core-wham/usage" || request.path.endsWith("/responses"),
+          ),
+        evidence(),
+      ).toEqual([]);
+      expect(stats()?.blockedReason, evidence()).toBe("subscription_limit");
+
+      await advanceClock();
+      const beforeRecovery = provider.requests.length;
+      // The isolated caller must recover the block without an intervening ordinary turn.
+      expectIsolatedSuccess(await invokeIsolated(fixture), evidence());
+      const recoveryRequests = provider.requests.slice(beforeRecovery);
+      expect(
+        recoveryRequests
+          .filter(
+            (request) => request.path === "/core-wham/usage" || request.path.endsWith("/responses"),
+          )
+          .map((request) => request.path),
+        evidence(),
+      ).toEqual(["/core-wham/usage", "/direct/responses"]);
+      expect(stats()?.blockedUntil, evidence()).toBeUndefined();
+      expect(stats()?.blockedReason, evidence()).toBeUndefined();
+      expect(stats()?.cooldownUntil, evidence()).toBeUndefined();
+      for (const request of recoveryRequests.filter(
+        (entry) => entry.path === "/core-wham/usage" || entry.path.endsWith("/responses"),
+      )) {
+        expect(request.authorization, evidence()).toBe(`Bearer ${access}`);
+      }
+
+      provider.setPhase("initial-exhaustion");
+      expect((await turn()).status, evidence()).toBe("error");
+      expect(stats(), evidence()).toMatchObject({
+        blockedSource: "wham",
+        blockedReason: "subscription_limit",
+      });
+      provider.setPhase("exhausted");
+      await advanceClock();
+      const beforeExhausted = provider.requests.length;
+      expect(await invokeIsolated(fixture), evidence()).toMatchObject({ ok: false });
+      const exhaustedRequests = provider.requests.slice(beforeExhausted);
+      expect(
+        exhaustedRequests.filter((request) => request.path === "/core-wham/usage"),
+        evidence(),
+      ).toHaveLength(1);
+      expect(
+        exhaustedRequests.filter((request) => request.path.endsWith("/responses")),
+        evidence(),
+      ).toEqual([]);
+      expect(stats()?.blockedReason, evidence()).toBe("subscription_limit");
+      expect(stats()?.blockedUntil, evidence()).toBeGreaterThan(Date.now() + clock.offset);
+      expect(
+        provider.requests.filter((request) => request.path === "/oauth/token"),
+        evidence(),
+      ).toEqual([]);
+      expect(provider.errors, evidence()).toEqual([]);
+    },
+  );
+
+  it(
+    "rejects a pending isolated task after its pinned credential is removed",
+    { timeout: 600_000 },
+    async (context) => {
+      const fixture = await createQuotaResetFixture(context, {
+        source: "wham",
+        runtime: "openclaw",
+        enableIsolatedTool: true,
+        responseText: ISOLATED_TEXT,
+        includeAlternateProfile: true,
+      });
+      const {
+        gateway,
+        client,
+        provider,
+        turn,
+        stats,
+        advanceClock,
+        evidence,
+        profileId,
+        alternateProfileId,
+        alternateAccess,
+        access,
+      } = fixture;
+      expect(await turn(), evidence()).toEqual({ status: "ok", output: [ISOLATED_TEXT] });
+      expectIsolatedSuccess(await invokeIsolated(fixture), evidence());
+      expectIsolatedSuccess(await invokeIsolated(fixture, alternateProfileId), evidence());
+
+      provider.setPhase("initial-exhaustion");
+      expect((await turn()).status, evidence()).toBe("error");
+      expect(stats(), evidence()).toMatchObject({
+        blockedSource: "wham",
+        blockedReason: "subscription_limit",
+      });
+      expect(stats()?.blockedUntil, evidence()).toBeGreaterThan(Date.now() + 86_400_000);
+
+      provider.setPhase("restored");
+      await advanceClock();
+      const beforePending = provider.requests.length;
+      const hold = provider.holdNextUsage();
+      const pending = invokeIsolated(fixture);
+      try {
+        const first = await Promise.race([
+          hold.arrived.then((captured) => ({ kind: "usage" as const, captured })),
+          pending.then((result) => ({ kind: "result" as const, result })),
+        ]);
+        expect(first.kind, evidence()).toBe("usage");
+        if (first.kind !== "usage") {
+          throw new Error("Isolated task finished before its due quota request");
+        }
+        const { captured } = first;
+        expect(JSON.parse(captured.body), evidence()).toMatchObject({
+          rate_limit: { allowed: true, limit_reached: false },
+        });
+        expect(
+          provider.requests.slice(beforePending).map((request) => request.authorization),
+          evidence(),
+        ).toEqual([`Bearer ${access}`]);
+
+        const logout = await client.request<ModelAuthLogoutResult>("models.authLogout", {
+          provider: "openai",
+          agentId: "main",
+          profileIds: [profileId],
+        });
+        fixture.turns.push({ logout });
+        expect(logout.removedProfiles, evidence()).toEqual([profileId]);
+        expect(logout.abortedRunIds, evidence()).toEqual([]);
+        const credentials = readPersistedSharedAuthProfileStoreRaw(gateway.env);
+        expect(credentials, evidence()).not.toHaveProperty(["profiles", profileId]);
+        expect(credentials, evidence()).toHaveProperty(["profiles", alternateProfileId]);
+        expect(captured.releaseReason, evidence()).toBeUndefined();
+        hold.release();
+
+        expect(await pending, evidence()).toMatchObject({ ok: false });
+        expect(captured.releaseReason, evidence()).toBe("explicit");
+        expect(
+          provider.requests
+            .slice(beforePending)
+            .filter((request) => request.path.endsWith("/responses")),
+          evidence(),
+        ).toEqual([]);
+        expect(await invokeIsolated(fixture), evidence()).toMatchObject({ ok: false });
+        expect(
+          provider.requests
+            .slice(beforePending)
+            .filter((request) => request.path.endsWith("/responses")),
+          evidence(),
+        ).toEqual([]);
+
+        const beforeAlternate = provider.requests.length;
+        expectIsolatedSuccess(await invokeIsolated(fixture, alternateProfileId), evidence());
+        expect(
+          provider.requests
+            .slice(beforeAlternate)
+            .filter((request) => request.path.endsWith("/responses"))
+            .map((request) => ({ path: request.path, authorization: request.authorization })),
+          evidence(),
+        ).toEqual([{ path: "/direct/responses", authorization: `Bearer ${alternateAccess}` }]);
+        expect(readPersistedSharedAuthProfileStoreRaw(gateway.env), evidence()).not.toHaveProperty([
+          "profiles",
+          profileId,
+        ]);
+        expect(provider.errors, evidence()).toEqual([]);
+      } finally {
+        hold.release();
+        await pending;
+      }
+    },
+  );
+});

--- a/test/e2e/qa-lab/runtime/quota-reset.saved-clear.test-support.mjs
+++ b/test/e2e/qa-lab/runtime/quota-reset.saved-clear.test-support.mjs
@@ -1,0 +1,47 @@
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { DatabaseSync } from "node:sqlite";
+
+const [databasePath, profileId, configPath, busyTimeout] = process.argv.slice(2);
+const digest = (value) => createHash("sha256").update(value).digest("hex");
+const database = new DatabaseSync(databasePath, { timeout: Number(busyTimeout) });
+try {
+  database.exec("BEGIN IMMEDIATE");
+  const readCell = database.prepare(
+    "SELECT value_json FROM config_machine_state WHERE state_key = ?",
+  );
+  const before = JSON.parse(readCell.get("authProfiles.state").value_json);
+  const credentialsBefore = digest(readCell.get("authProfiles.store").value_json);
+  const configBefore = digest(readFileSync(configPath));
+  const after = structuredClone(before);
+  const usage = after.usageStats[profileId];
+  if (usage.blockedReason !== "subscription_limit" || !usage.blockedUntil) {
+    throw new Error("Saved-only repair requires an existing provider-created quota block.");
+  }
+  delete usage.blockedUntil;
+  delete usage.blockedReason;
+  delete usage.blockedSource;
+  delete usage.blockedModel;
+  delete usage.blockedScope;
+  // sqlite-allow-raw -- Reproduce an external manual repair of this test-owned saved row.
+  database
+    .prepare("UPDATE config_machine_state SET value_json = ? WHERE state_key = ?")
+    .run(JSON.stringify(after), "authProfiles.state");
+  database.exec("COMMIT");
+  console.log(
+    JSON.stringify({
+      pid: process.pid,
+      before,
+      after: JSON.parse(readCell.get("authProfiles.state").value_json),
+      credentialsBefore,
+      credentialsAfter: digest(readCell.get("authProfiles.store").value_json),
+      configBefore,
+      configAfter: digest(readFileSync(configPath)),
+    }),
+  );
+} finally {
+  if (database.isTransaction) {
+    database.exec("ROLLBACK");
+  }
+  database.close();
+}

--- a/test/e2e/qa-lab/runtime/quota-reset.test-support.ts
+++ b/test/e2e/qa-lab/runtime/quota-reset.test-support.ts
@@ -71,12 +71,12 @@ type HeldUsageResponse = {
   releaseReason?: "explicit" | "deadline" | "aborted";
 };
 
-export function syntheticAccessToken(expires = Date.UTC(2036, 0, 1)) {
+export function syntheticAccessToken(expires = Date.UTC(2036, 0, 1), accountId = ACCOUNT_ID) {
   return [
     { alg: "none" },
     {
       "https://api.openai.com/auth": {
-        chatgpt_account_id: ACCOUNT_ID,
+        chatgpt_account_id: accountId,
         chatgpt_user_id: "quota-test-user",
         chatgpt_plan_type: "pro",
       },
@@ -102,7 +102,7 @@ function assistantTexts(history: ChatHistory): string[] {
     );
 }
 
-async function startQuotaProvider(source: BlockSource) {
+async function startQuotaProvider(source: BlockSource, responseText: string) {
   let phase: Phase = "healthy";
   let nextSuccessObserver: (() => void) | undefined;
   let nextUsageHold: { arrived: Deferred<HeldUsageResponse>; released: Deferred<void> } | undefined;
@@ -219,7 +219,7 @@ async function startQuotaProvider(source: BlockSource) {
       headers,
     };
   };
-  const successEvents = (marker = MARKER) => {
+  const successEvents = (marker = responseText) => {
     const observe = nextSuccessObserver;
     nextSuccessObserver = undefined;
     observe?.();
@@ -341,6 +341,19 @@ async function startQuotaProvider(source: BlockSource) {
             expires_in: 3600,
           });
         }
+      } else if (requestPath === "/catalog/models") {
+        json(200, {
+          models: [
+            {
+              slug: "gpt-5.5",
+              display_name: "Quota fixture model",
+              visibility: "list",
+              show_in_picker: true,
+              context_window: 128_000,
+              max_output_tokens: 4096,
+            },
+          ],
+        });
       } else if (requestPath.endsWith("/models")) {
         json(200, { models: [] });
       } else if (requestPath.endsWith("/responses")) {
@@ -349,7 +362,7 @@ async function startQuotaProvider(source: BlockSource) {
           const event = failure();
           json(event.status, { error: event.error }, event.headers);
         } else {
-          const events = successEvents(backup ? BACKUP_MARKER : MARKER);
+          const events = successEvents(backup ? BACKUP_MARKER : responseText);
           responses.push({ phase, path: requestPath, value: events });
           response.writeHead(200, { "content-type": "text/event-stream" });
           for (const event of events) {
@@ -436,17 +449,27 @@ export async function createQuotaResetFixture(
     scopedCooldown = false,
     includeBackup = false,
     limitGatewayFileSize = false,
+    runtime = "codex",
+    enableIsolatedTool = false,
+    includeAlternateProfile = false,
+    responseText = MARKER,
+    controlUi = false,
   }: {
     source: BlockSource;
     expiresDuringBlock?: boolean;
     scopedCooldown?: boolean;
     includeBackup?: boolean;
     limitGatewayFileSize?: boolean;
+    runtime?: "openclaw" | "codex";
+    enableIsolatedTool?: boolean;
+    includeAlternateProfile?: boolean;
+    responseText?: string;
+    controlUi?: boolean;
   },
 ) {
   const tempDirs = useAutoCleanupTempDirTracker((cleanup) => context.onTestFinished(cleanup));
   const root = tempDirs.make("openclaw-quota-reset-");
-  const provider = await startQuotaProvider(source);
+  const provider = await startQuotaProvider(source, responseText);
   context.onTestFinished(() => provider.stop());
   const clockFile = path.join(root, "clock-offset");
   await fs.writeFile(clockFile, "0");
@@ -463,6 +486,9 @@ export async function createQuotaResetFixture(
   const preload = new URL("./quota-reset-preload.mjs", import.meta.url);
   preload.searchParams.set("fixture", provider.baseUrl);
   preload.searchParams.set("clock", clockFile);
+  if (controlUi) {
+    preload.searchParams.set("catalog", "1");
+  }
   if (limitGatewayFileSize) {
     preload.searchParams.set("storageFault", storageFaultFile);
   }
@@ -493,7 +519,8 @@ export async function createQuotaResetFixture(
       OPENCLAW_AGENT_HARNESS_FALLBACK: "none",
     },
     config: {
-      gateway: { controlUi: { enabled: false } },
+      gateway: { controlUi: { enabled: controlUi } },
+      ...(enableIsolatedTool ? { tools: { alsoAllow: ["llm-task"] } } : {}),
       ...(scopedCooldown || includeBackup
         ? {
             models: {
@@ -543,8 +570,11 @@ export async function createQuotaResetFixture(
         : {}),
       plugins: {
         enabled: true,
-        allow: ["codex", "openai"],
+        allow: ["codex", "openai", ...(enableIsolatedTool ? ["llm-task"] : [])],
         entries: {
+          ...(enableIsolatedTool
+            ? { "llm-task": { enabled: true, llm: { allowAuthProfileOverride: true } } }
+            : {}),
           codex: {
             enabled: true,
             config: {
@@ -569,7 +599,7 @@ export async function createQuotaResetFixture(
         defaults: {
           model: { primary: MODEL, fallbacks: includeBackup ? [BACKUP_MODEL] : [] },
           models: {
-            [MODEL]: { agentRuntime: { id: "codex" } },
+            [MODEL]: { agentRuntime: { id: runtime } },
             ...(includeBackup ? { [BACKUP_MODEL]: { agentRuntime: { id: "openclaw" } } } : {}),
           },
           ...(scopedCooldown ? { utilityModel: `openai/${UTILITY_MODEL_ID}` } : {}),
@@ -586,11 +616,25 @@ export async function createQuotaResetFixture(
   // Doctor imports without refreshing a credential outside its one-day warning window.
   const expires = expiresDuringBlock ? Date.now() + 2 * 86_400_000 : Date.UTC(2036, 0, 1);
   const access = syntheticAccessToken(expires);
+  const alternateProfileId = "openai:quota-alternate";
+  const alternateAccess = syntheticAccessToken(expires, "quota-alternate-account");
   await gateway.state.writeText(
     "agents/main/agent/auth-profiles.json",
     JSON.stringify({
       version: 1,
       profiles: {
+        ...(includeAlternateProfile
+          ? {
+              [alternateProfileId]: {
+                type: "oauth",
+                provider: "openai",
+                access: alternateAccess,
+                refresh: "synthetic-alternate-refresh",
+                expires,
+                accountId: "quota-alternate-account",
+              },
+            }
+          : {}),
         [PROFILE_ID]: {
           type: "oauth",
           provider: "openai",
@@ -673,6 +717,9 @@ export async function createQuotaResetFixture(
     provider,
     sessionKey,
     access,
+    profileId: PROFILE_ID,
+    alternateProfileId,
+    alternateAccess,
     advanceClock,
     clock: {
       get offset() {

--- a/test/e2e/qa-lab/runtime/quota-reset.test-support.ts
+++ b/test/e2e/qa-lab/runtime/quota-reset.test-support.ts
@@ -1,0 +1,722 @@
+import { randomUUID } from "node:crypto";
+import fs from "node:fs/promises";
+import { createServer, type IncomingMessage } from "node:http";
+import { createRequire } from "node:module";
+import path from "node:path";
+import { zstdDecompressSync } from "node:zlib";
+import { expect, type TestContext } from "vitest";
+import { WebSocketServer } from "ws";
+import { readPersistedSharedAuthProfileStateRaw } from "../../../../src/agents/auth-profiles/sqlite.js";
+import { coerceAuthProfileState } from "../../../../src/agents/auth-profiles/state.js";
+import { connectGatewayClient } from "../../../../src/gateway/test-helpers.e2e.js";
+import { openNodeSqliteDatabase } from "../../../../src/infra/node-sqlite.js";
+import { createDeferredCore, type Deferred } from "../../../../src/shared/deferred.js";
+import { resolveOpenClawStateSqlitePath } from "../../../../src/state/openclaw-state-db.paths.js";
+import {
+  createOpenClawTestInstance,
+  type OpenClawTestInstance,
+} from "../../../helpers/openclaw-test-instance.js";
+import { useAutoCleanupTempDirTracker } from "../../../helpers/temp-dir.js";
+
+export const BACKUP_MODEL = "quota-backup/echo";
+export const BACKUP_MARKER = "QUOTA_BACKUP_OK";
+export const BACKUP_API_KEY = "synthetic-quota-backup-key";
+export const BACKUP_RESPONSES_PATH = "/quota-backup/responses";
+
+const MODEL = "openai/gpt-5.5";
+export const UTILITY_MODEL_ID = "quota-test-utility";
+const PROFILE_ID = "openai:quota";
+export const ACCOUNT_ID = "quota-test-account";
+export const MARKER = "QUOTA_TURN_OK";
+const RECHECK_ADVANCE_MS = 300_100;
+type BlockSource = "wham" | "codex_rate_limits";
+type Phase =
+  | "healthy"
+  | "initial-exhaustion"
+  | "ordinary-rate-limit"
+  | "ordinary-rate-limit-with-capacity"
+  | "ordinary-rate-limit-with-exhausted-usage"
+  | "exhausted"
+  | "additional-exhaustion"
+  | "workspace-exhaustion"
+  | "spending-exhaustion"
+  | "malformed-usage"
+  | "restored"
+  | "revoked";
+type RequestRecord = {
+  phase: Phase;
+  transport: "http" | "websocket";
+  path: string;
+  method: string | undefined;
+  headers: IncomingMessage["headers"];
+  rawHeaders: string[];
+  body: string | undefined;
+  bodyBase64?: string;
+  authorization: string | undefined;
+  accountId: string | string[] | undefined;
+};
+type ChatHistory = {
+  messages: Array<{
+    role: string;
+    content?: string | Array<{ type: string; text?: string }>;
+  }>;
+};
+type HeldUsageResponse = {
+  phase: Phase;
+  path: string;
+  status: number;
+  body: string;
+  capturedAt: number;
+  releasedAt?: number;
+  releaseReason?: "explicit" | "deadline" | "aborted";
+};
+
+export function syntheticAccessToken(expires = Date.UTC(2036, 0, 1)) {
+  return [
+    { alg: "none" },
+    {
+      "https://api.openai.com/auth": {
+        chatgpt_account_id: ACCOUNT_ID,
+        chatgpt_user_id: "quota-test-user",
+        chatgpt_plan_type: "pro",
+      },
+      exp: Math.floor(expires / 1000),
+      email: "quota@example.invalid",
+    },
+  ]
+    .map((value) => Buffer.from(JSON.stringify(value)).toString("base64url"))
+    .concat("synthetic")
+    .join(".");
+}
+
+function assistantTexts(history: ChatHistory): string[] {
+  return history.messages
+    .filter((message) => message.role === "assistant")
+    .map((message) =>
+      typeof message.content === "string"
+        ? message.content
+        : (message.content ?? [])
+            .filter((part) => part.type === "text")
+            .map((part) => part.text ?? "")
+            .join("\n"),
+    );
+}
+
+async function startQuotaProvider(source: BlockSource) {
+  let phase: Phase = "healthy";
+  let nextSuccessObserver: (() => void) | undefined;
+  let nextUsageHold: { arrived: Deferred<HeldUsageResponse>; released: Deferred<void> } | undefined;
+  const heldUsageResponses: HeldUsageResponse[] = [];
+  const resetAt = Math.floor(Date.now() / 1000) + 5 * 86_400;
+  const requests: RequestRecord[] = [];
+  const responses: Array<{
+    phase: Phase;
+    path: string;
+    value: unknown;
+    headers?: Record<string, string>;
+  }> = [];
+  const errors: string[] = [];
+  const primaryExhausted = () => phase === "initial-exhaustion" || phase === "exhausted";
+  const exhausted = () => phase !== "healthy" && phase !== "restored" && phase !== "revoked";
+  const recordRequest = (
+    request: IncomingMessage,
+    body: string | undefined,
+    transport: RequestRecord["transport"],
+    bodyBytes?: Buffer,
+  ) => {
+    requests.push({
+      phase,
+      transport,
+      path: request.url ?? "",
+      method: request.method,
+      headers: request.headers,
+      rawHeaders: request.rawHeaders,
+      body,
+      bodyBase64: bodyBytes?.toString("base64"),
+      authorization: request.headers.authorization,
+      accountId: request.headers["chatgpt-account-id"],
+    });
+  };
+  const usage = () => {
+    const usageExhausted =
+      primaryExhausted() || phase === "ordinary-rate-limit-with-exhausted-usage";
+    const window = (seconds: number, usedPercent = usageExhausted ? 100 : 2) => ({
+      used_percent: usedPercent,
+      limit_window_seconds: seconds,
+      reset_at: resetAt,
+      reset_after_seconds: resetAt - Math.floor(Date.now() / 1000),
+    });
+    return {
+      plan_type: "pro",
+      rate_limit: {
+        allowed: !usageExhausted,
+        limit_reached: usageExhausted,
+        primary_window: window(18_000),
+        secondary_window: window(604_800),
+      },
+      credits: { has_credits: false, unlimited: false, balance: "0" },
+      additional_rate_limits:
+        phase === "additional-exhaustion"
+          ? [
+              {
+                limit_name: "Additional Codex capacity",
+                metered_feature: "codex_other",
+                rate_limit: {
+                  allowed: false,
+                  limit_reached: true,
+                  primary_window: window(18_000, 100),
+                  secondary_window: null,
+                },
+              },
+            ]
+          : [],
+      spend_control:
+        phase === "malformed-usage"
+          ? { reached: "invalid" }
+          : phase === "spending-exhaustion"
+            ? { reached: true }
+            : null,
+      rate_limit_reached_type:
+        phase === "workspace-exhaustion" ? { type: "workspace_owner_credits_depleted" } : null,
+    };
+  };
+  const failure = () => {
+    const headers: Record<string, string> =
+      primaryExhausted() && source === "codex_rate_limits"
+        ? {
+            "x-codex-primary-used-percent": "100",
+            "x-codex-primary-window-minutes": "300",
+            "x-codex-primary-reset-at": String(resetAt),
+            "x-codex-secondary-used-percent": "100",
+            "x-codex-secondary-window-minutes": "10080",
+            "x-codex-secondary-reset-at": String(resetAt),
+          }
+        : {};
+    return {
+      type: "error",
+      status: phase === "revoked" ? 401 : 429,
+      error:
+        phase === "revoked"
+          ? {
+              type: "invalid_request_error",
+              code: "invalid_api_key",
+              message: "Invalid authentication token",
+            }
+          : phase === "ordinary-rate-limit" ||
+              phase === "ordinary-rate-limit-with-capacity" ||
+              phase === "ordinary-rate-limit-with-exhausted-usage"
+            ? {
+                type: "rate_limit_error",
+                code: "rate_limit_exceeded",
+                message: "Too many requests",
+              }
+            : {
+                type: "usage_limit_reached",
+                message: "The usage limit has been reached",
+                plan_type: "pro",
+                ...(source === "codex_rate_limits" ? { resets_at: resetAt } : {}),
+              },
+      headers,
+    };
+  };
+  const successEvents = (marker = MARKER) => {
+    const observe = nextSuccessObserver;
+    nextSuccessObserver = undefined;
+    observe?.();
+    const id = randomUUID().replaceAll("-", "");
+    const item = {
+      type: "message",
+      id: `msg${id}`,
+      role: "assistant",
+      status: "completed",
+      content: [{ type: "output_text", text: marker, annotations: [] }],
+    };
+    const response = {
+      id: `resp${id}`,
+      status: "completed",
+      output: [item],
+      usage: {
+        input_tokens: 11,
+        output_tokens: 7,
+        total_tokens: 18,
+        input_tokens_details: { cached_tokens: 0 },
+      },
+    };
+    return [
+      { type: "response.created", response: { ...response, status: "in_progress", output: [] } },
+      {
+        type: "response.output_item.added",
+        output_index: 0,
+        item: { ...item, status: "in_progress", content: [] },
+      },
+      {
+        type: "response.output_text.delta",
+        item_id: item.id,
+        output_index: 0,
+        content_index: 0,
+        delta: marker,
+      },
+      { type: "response.output_item.done", output_index: 0, item },
+      { type: "response.completed", response },
+    ];
+  };
+  const server = createServer((request, response) => {
+    void (async () => {
+      const chunks: Buffer[] = [];
+      for await (const chunk of request) {
+        chunks.push(Buffer.from(chunk));
+      }
+      const bodyBytes = Buffer.concat(chunks);
+      const encoding = request.headers["content-encoding"];
+      const decoded =
+        encoding === undefined
+          ? bodyBytes
+          : encoding === "zstd"
+            ? zstdDecompressSync(bodyBytes)
+            : undefined;
+      recordRequest(request, decoded?.toString(), "http", bodyBytes);
+      const requestPath = new URL(request.url ?? "/", "http://127.0.0.1").pathname;
+      const json = (
+        status: number,
+        value: unknown,
+        headers: Record<string, string> = {},
+        responsePhase = phase,
+      ) => {
+        responses.push({ phase: responsePhase, path: requestPath, value, headers });
+        response.writeHead(status, { "content-type": "application/json", ...headers });
+        response.end(JSON.stringify(value));
+      };
+      if (requestPath === "/core-wham/usage" || requestPath === "/backend-api/wham/usage") {
+        // Preserve the native block source only on the original quota failure.
+        if (
+          requestPath === "/core-wham/usage" &&
+          ((source === "codex_rate_limits" && phase === "initial-exhaustion") ||
+            phase === "ordinary-rate-limit")
+        ) {
+          json(503, { error: { message: "Usage view temporarily unavailable" } });
+        } else if (phase === "revoked") {
+          json(403, { error: { message: "Account deactivated" } });
+        } else {
+          const value = usage();
+          const hold = requestPath === "/core-wham/usage" ? nextUsageHold : undefined;
+          if (hold) {
+            nextUsageHold = undefined;
+            const captured: HeldUsageResponse = {
+              phase,
+              path: requestPath,
+              status: 200,
+              body: JSON.stringify(value),
+              capturedAt: Date.now(),
+            };
+            heldUsageResponses.push(captured);
+            hold.arrived.resolve(captured);
+            const interrupted = createDeferredCore<"deadline" | "aborted">();
+            const timer = setTimeout(() => interrupted.resolve("deadline"), 2800);
+            const onClose = () => interrupted.resolve("aborted");
+            response.once("close", onClose);
+            try {
+              captured.releaseReason = await Promise.race([
+                hold.released.promise.then(() => "explicit" as const),
+                interrupted.promise,
+              ]);
+              captured.releasedAt = Date.now();
+              if (captured.releaseReason !== "aborted") {
+                json(captured.status, value, {}, captured.phase);
+              }
+            } finally {
+              clearTimeout(timer);
+              response.off("close", onClose);
+            }
+          } else {
+            json(200, value);
+          }
+        }
+      } else if (requestPath === "/oauth/token") {
+        if (phase === "revoked") {
+          json(400, { error: "invalid_grant", error_description: "Refresh token revoked" });
+        } else {
+          json(200, {
+            access_token: syntheticAccessToken(),
+            refresh_token: "synthetic-rotated-refresh",
+            expires_in: 3600,
+          });
+        }
+      } else if (requestPath.endsWith("/models")) {
+        json(200, { models: [] });
+      } else if (requestPath.endsWith("/responses")) {
+        const backup = requestPath === BACKUP_RESPONSES_PATH;
+        if (!backup && (exhausted() || phase === "revoked")) {
+          const event = failure();
+          json(event.status, { error: event.error }, event.headers);
+        } else {
+          const events = successEvents(backup ? BACKUP_MARKER : MARKER);
+          responses.push({ phase, path: requestPath, value: events });
+          response.writeHead(200, { "content-type": "text/event-stream" });
+          for (const event of events) {
+            response.write(`data: ${JSON.stringify(event)}\n\n`);
+          }
+          response.end();
+        }
+      } else {
+        json(404, { error: { message: "No synthetic fixture for this route" } });
+      }
+    })().catch((error: unknown) => {
+      errors.push(String(error));
+      if (!response.headersSent) {
+        response.writeHead(500);
+      }
+      response.end();
+    });
+  });
+  const sockets = new WebSocketServer({ noServer: true });
+  server.on("upgrade", (request, socket, head) => {
+    sockets.handleUpgrade(request, socket, head, (websocket) => {
+      websocket.on("error", (error) => errors.push(String(error)));
+      websocket.on("message", (raw) => {
+        recordRequest(request, raw.toString(), "websocket");
+        const events = exhausted() || phase === "revoked" ? [failure()] : successEvents();
+        for (const event of events) {
+          responses.push({ phase, path: request.url ?? "", value: event });
+          websocket.send(JSON.stringify(event));
+        }
+      });
+    });
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("Provider did not bind loopback");
+  }
+  return {
+    baseUrl: `http://127.0.0.1:${address.port}`,
+    requests,
+    responses,
+    heldUsageResponses,
+    errors,
+    setPhase(next: Phase) {
+      phase = next;
+    },
+    observeNextSuccess(observer: () => void) {
+      nextSuccessObserver = observer;
+    },
+    holdNextUsage() {
+      if (nextUsageHold) {
+        throw new Error("A usage response hold is already armed");
+      }
+      const hold = {
+        arrived: createDeferredCore<HeldUsageResponse>(),
+        released: createDeferredCore<void>(),
+      };
+      nextUsageHold = hold;
+      return { arrived: hold.arrived.promise, release: () => hold.released.resolve() };
+    },
+    async stop() {
+      for (const socket of sockets.clients) {
+        socket.terminate();
+      }
+      await new Promise<void>((resolve, reject) => {
+        sockets.close((error) => (error ? reject(error) : resolve()));
+      });
+      server.closeAllConnections();
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    },
+  };
+}
+
+export async function createQuotaResetFixture(
+  context: TestContext,
+  {
+    source,
+    expiresDuringBlock = false,
+    scopedCooldown = false,
+    includeBackup = false,
+    limitGatewayFileSize = false,
+  }: {
+    source: BlockSource;
+    expiresDuringBlock?: boolean;
+    scopedCooldown?: boolean;
+    includeBackup?: boolean;
+    limitGatewayFileSize?: boolean;
+  },
+) {
+  const tempDirs = useAutoCleanupTempDirTracker((cleanup) => context.onTestFinished(cleanup));
+  const root = tempDirs.make("openclaw-quota-reset-");
+  const provider = await startQuotaProvider(source);
+  context.onTestFinished(() => provider.stop());
+  const clockFile = path.join(root, "clock-offset");
+  await fs.writeFile(clockFile, "0");
+  const storageFaultFile = path.join(root, "storage-fault");
+  await fs.writeFile(storageFaultFile, "null");
+  let offset = 0;
+  const advanceClock = async (
+    advanceMs = expiresDuringBlock ? 2 * 86_400_000 + RECHECK_ADVANCE_MS : RECHECK_ADVANCE_MS,
+  ) => {
+    offset += advanceMs;
+    await fs.writeFile(`${clockFile}.next`, String(offset));
+    await fs.rename(`${clockFile}.next`, clockFile);
+  };
+  const preload = new URL("./quota-reset-preload.mjs", import.meta.url);
+  preload.searchParams.set("fixture", provider.baseUrl);
+  preload.searchParams.set("clock", clockFile);
+  if (limitGatewayFileSize) {
+    preload.searchParams.set("storageFault", storageFaultFile);
+  }
+  const requireCodex = createRequire(
+    new URL("../../../../extensions/codex/package.json", import.meta.url),
+  );
+  const launcher = path.join(
+    path.dirname(requireCodex.resolve("@openai/codex/package.json")),
+    "bin/codex.js",
+  );
+  const gateway = await createOpenClawTestInstance({
+    name: `quota-reset-${source}`,
+    gatewayCommandPrefix: limitGatewayFileSize
+      ? [
+          "/bin/sh",
+          "-c",
+          `ulimit -f 65536; exec "$@"`,
+          "quota-storage-fault",
+          process.execPath,
+          "--import",
+          preload.href,
+        ]
+      : [process.execPath, "--import", preload.href],
+    startTimeoutMs: 120_000,
+    env: {
+      OPENCLAW_TEST_MINIMAL_GATEWAY: "0",
+      OPENCLAW_SKIP_PROVIDERS: undefined,
+      OPENCLAW_AGENT_HARNESS_FALLBACK: "none",
+    },
+    config: {
+      gateway: { controlUi: { enabled: false } },
+      ...(scopedCooldown || includeBackup
+        ? {
+            models: {
+              providers: {
+                ...(scopedCooldown
+                  ? {
+                      openai: {
+                        baseUrl: "https://chatgpt.com/backend-api/codex",
+                        api: "openai-chatgpt-responses" as const,
+                        auth: "oauth" as const,
+                        models: ["gpt-5.5", UTILITY_MODEL_ID].map((id) => ({
+                          id,
+                          name: id,
+                          reasoning: false,
+                          input: ["text" as const],
+                          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                          contextWindow: 128_000,
+                          maxTokens: 4096,
+                        })),
+                      },
+                    }
+                  : {}),
+                ...(includeBackup
+                  ? {
+                      "quota-backup": {
+                        baseUrl: `${provider.baseUrl}/quota-backup`,
+                        api: "openai-responses" as const,
+                        apiKey: BACKUP_API_KEY,
+                        request: { allowPrivateNetwork: true },
+                        models: [
+                          {
+                            id: "echo",
+                            name: "Quota backup echo",
+                            reasoning: false,
+                            input: ["text" as const],
+                            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                            contextWindow: 128_000,
+                            maxTokens: 256,
+                          },
+                        ],
+                      },
+                    }
+                  : {}),
+              },
+            },
+          }
+        : {}),
+      plugins: {
+        enabled: true,
+        allow: ["codex", "openai"],
+        entries: {
+          codex: {
+            enabled: true,
+            config: {
+              appServer: {
+                mode: "yolo",
+                command: process.execPath,
+                args: [
+                  launcher,
+                  "app-server",
+                  "-c",
+                  `chatgpt_base_url="${provider.baseUrl}/backend-api"`,
+                  "-c",
+                  `openai_base_url="${provider.baseUrl}/v1"`,
+                ],
+                requestTimeoutMs: 60_000,
+              },
+            },
+          },
+        },
+      },
+      agents: {
+        defaults: {
+          model: { primary: MODEL, fallbacks: includeBackup ? [BACKUP_MODEL] : [] },
+          models: {
+            [MODEL]: { agentRuntime: { id: "codex" } },
+            ...(includeBackup ? { [BACKUP_MODEL]: { agentRuntime: { id: "openclaw" } } } : {}),
+          },
+          ...(scopedCooldown ? { utilityModel: `openai/${UTILITY_MODEL_ID}` } : {}),
+          workspace: "~/workspace",
+          skipBootstrap: true,
+          timeoutSeconds: 90,
+          sandbox: { mode: "off" },
+        },
+      },
+    },
+  });
+  context.onTestFinished(() => gateway.cleanup());
+  context.onTestFailed(() => console.error(gateway.logs()));
+  // Doctor imports without refreshing a credential outside its one-day warning window.
+  const expires = expiresDuringBlock ? Date.now() + 2 * 86_400_000 : Date.UTC(2036, 0, 1);
+  const access = syntheticAccessToken(expires);
+  await gateway.state.writeText(
+    "agents/main/agent/auth-profiles.json",
+    JSON.stringify({
+      version: 1,
+      profiles: {
+        [PROFILE_ID]: {
+          type: "oauth",
+          provider: "openai",
+          access,
+          refresh: "synthetic-refresh",
+          expires,
+          accountId: ACCOUNT_ID,
+        },
+      },
+      order: { openai: [PROFILE_ID] },
+    }),
+  );
+  const doctor = await gateway.cli(["doctor", "--fix", "--yes", "--non-interactive"], {
+    timeoutMs: 120_000,
+  });
+  expect(doctor.code, doctor.stderr).toBe(0);
+  await gateway.startGateway();
+  gateway.child?.once("exit", (code, signal) =>
+    console.error("Quota fixture Gateway exit", { code, signal }),
+  );
+  const client = await connectGatewayClient({
+    url: `ws://127.0.0.1:${gateway.port}`,
+    token: gateway.gatewayToken,
+    clientName: "cli",
+    mode: "cli",
+    role: "operator",
+    scopes: ["operator.admin", "operator.read", "operator.write"],
+  });
+  context.onTestFinished(() => client.stopAndWait());
+  const sessionKey = `agent:main:quota-${randomUUID()}`;
+  const turns: unknown[] = [];
+  const stats = () =>
+    coerceAuthProfileState(readPersistedSharedAuthProfileStateRaw(gateway.env)).usageStats?.[
+      PROFILE_ID
+    ];
+  const evidence = () =>
+    JSON.stringify(
+      {
+        requests: provider.requests,
+        responses: provider.responses,
+        heldUsageResponses: provider.heldUsageResponses,
+        errors: provider.errors,
+        turns,
+        stats: stats(),
+        gateway: gateway.logs(),
+      },
+      null,
+      2,
+    );
+  const turn = async (key = sessionKey, message = `Return ${MARKER}.`) => {
+    const before = assistantTexts(
+      await client.request<ChatHistory>("chat.history", { sessionKey: key, limit: 100 }),
+    );
+    const started = await client.request<{ runId: string; status: string }>("chat.send", {
+      sessionKey: key,
+      message,
+      deliver: false,
+      idempotencyKey: randomUUID(),
+    });
+    expect(started.status, evidence()).toBe("started");
+    const terminal = await client.request<{ status: string; error?: unknown }>(
+      "agent.wait",
+      { runId: started.runId, timeoutMs: 100_000 },
+      { timeoutMs: 105_000 },
+    );
+    const history = await client.request<ChatHistory>("chat.history", {
+      sessionKey: key,
+      limit: 100,
+    });
+    turns.push({ started, terminal, history });
+    const after = assistantTexts(history);
+    expect(["ok", "error"], JSON.stringify({ terminal, evidence: evidence() })).toContain(
+      terminal.status,
+    );
+    return { status: terminal.status, output: after.slice(before.length) };
+  };
+  return {
+    gateway,
+    client,
+    provider,
+    sessionKey,
+    access,
+    advanceClock,
+    clock: {
+      get offset() {
+        return offset;
+      },
+    },
+    stats,
+    evidence,
+    turn,
+    turns,
+    storageFaultFile,
+  };
+}
+
+export async function installQuotaStateWriteFault(
+  gateway: OpenClawTestInstance,
+  storageFaultFile: string,
+  write: "claim" | "result",
+  failure: "io" | "constraint",
+) {
+  const databasePath = resolveOpenClawStateSqlitePath(gateway.env);
+  await fs.writeFile(`${storageFaultFile}.next`, JSON.stringify({ write, failure }));
+  await fs.rename(`${storageFaultFile}.next`, storageFaultFile);
+  return {
+    scratchCommitted() {
+      const reader = openNodeSqliteDatabase(databasePath, { readOnly: true });
+      try {
+        expect(
+          reader
+            .prepare("SELECT name FROM main.sqlite_schema WHERE name = 'quota_reset_write_fault'")
+            .all(),
+        ).toEqual([]);
+        return (
+          reader
+            .prepare("SELECT 1 FROM config_machine_state WHERE state_key = ?")
+            .get("quota-reset-test.scratch") !== undefined
+        );
+      } finally {
+        reader.close();
+      }
+    },
+    async remove() {
+      await fs.writeFile(`${storageFaultFile}.next`, "null");
+      await fs.rename(`${storageFaultFile}.next`, storageFaultFile);
+    },
+  };
+}

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -13460,8 +13460,9 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
             }
           }
           if (
-            node.expression.text === "createSessionManagementE2eSuite" &&
-            node.arguments[0]?.kind === ts.SyntaxKind.TrueKeyword
+            node.expression.text === "createQuotaResetFixture" ||
+            (node.expression.text === "createSessionManagementE2eSuite" &&
+              node.arguments[0]?.kind === ts.SyntaxKind.TrueKeyword)
           ) {
             ownsPrivateServer = true;
             return;
@@ -13510,6 +13511,7 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
       "ui/src/e2e/model-catalog-partial-refresh.real-gateway.e2e.test.ts",
       "ui/src/e2e/model-picker-search.real-gateway.e2e.test.ts",
       "ui/src/e2e/new-session-page.cloud-startup.runtime-load.e2e.test.ts",
+      "ui/src/e2e/quota-reset-status.real-gateway.e2e.test.ts",
       "ui/src/e2e/session-management.delete.e2e.test.ts",
       "ui/src/e2e/sidebar-account-footer.e2e.test.ts",
     ]);

--- a/test/vitest-ui-e2e-config.test.ts
+++ b/test/vitest-ui-e2e-config.test.ts
@@ -128,6 +128,7 @@ const realGatewayFiles = [
   "model-catalog-partial-refresh.real-gateway",
   "model-picker-search.real-gateway",
   "profile-page.real-gateway",
+  "quota-reset-status.real-gateway",
   "session-progress-hovercard.real-gateway",
   "usage-sessions-owner-attribution",
   "worker-initial-setup.real-gateway",
@@ -615,6 +616,13 @@ describe("Control UI E2E resource ownership", () => {
         {
           file: "ui/src/e2e/profile-page.real-gateway.e2e.test.ts",
           project: "ui-e2e-serial",
+          phase: 1,
+          workers: 1,
+          fileParallelism: false,
+        },
+        {
+          file: "ui/src/e2e/quota-reset-status.real-gateway.e2e.test.ts",
+          project: "ui-e2e-serial-standalone",
           phase: 1,
           workers: 1,
           fileParallelism: false,

--- a/test/vitest/vitest.ui-e2e.config.ts
+++ b/test/vitest/vitest.ui-e2e.config.ts
@@ -25,6 +25,7 @@ const uiE2eIncludePatterns = [
   automationManagementRealGatewayTest,
 ];
 export const uiE2eRealGatewayTestFiles = [
+  "ui/src/e2e/quota-reset-status.real-gateway.e2e.test.ts",
   "ui/src/e2e/model-api-keys.real-gateway.e2e.test.ts",
   "ui/src/e2e/model-catalog-partial-refresh.real-gateway.e2e.test.ts",
   "ui/src/e2e/worker-initial-setup.real-gateway.e2e.test.ts",
@@ -57,6 +58,7 @@ export const uiE2eRealGatewayTestFiles = [
 // These files own their server instead of leasing the global production bundle.
 // Keep any shared source-module optimizer cache under one worker.
 export const uiE2ePrivateServerTestFiles = [
+  "ui/src/e2e/quota-reset-status.real-gateway.e2e.test.ts",
   "ui/src/e2e/agent-file-lifecycle.real-gateway.e2e.test.ts",
   "ui/src/e2e/approval-bootstrap.e2e.test.ts",
   "ui/src/e2e/build-info-unicode.e2e.test.ts",

--- a/test/vitest/vitest.ui-e2e.config.ts
+++ b/test/vitest/vitest.ui-e2e.config.ts
@@ -58,7 +58,6 @@ export const uiE2eRealGatewayTestFiles = [
 // These files own their server instead of leasing the global production bundle.
 // Keep any shared source-module optimizer cache under one worker.
 export const uiE2ePrivateServerTestFiles = [
-  "ui/src/e2e/quota-reset-status.real-gateway.e2e.test.ts",
   "ui/src/e2e/agent-file-lifecycle.real-gateway.e2e.test.ts",
   "ui/src/e2e/approval-bootstrap.e2e.test.ts",
   "ui/src/e2e/build-info-unicode.e2e.test.ts",
@@ -93,6 +92,7 @@ export const uiE2ePrivateServerTestFiles = [
   "ui/src/e2e/mount-recovery.e2e.test.ts",
   "ui/src/e2e/native-notifications-loading.e2e.test.ts",
   "ui/src/e2e/new-session-page.cloud-startup.runtime-load.e2e.test.ts",
+  "ui/src/e2e/quota-reset-status.real-gateway.e2e.test.ts",
   "ui/src/e2e/session-management.delete.e2e.test.ts",
   "ui/src/e2e/settings-loading-skeletons.e2e.test.ts",
   "ui/src/e2e/sidebar-account-footer.e2e.test.ts",

--- a/ui/src/e2e/quota-reset-status.real-gateway.e2e.test.ts
+++ b/ui/src/e2e/quota-reset-status.real-gateway.e2e.test.ts
@@ -62,8 +62,12 @@ function clearSavedBlock(fixture: QuotaFixture): SavedClearReceipt {
   expect(receipt.pid).not.toBe(fixture.gateway.child?.pid);
   expect(receipt.credentialsAfter).toBe(receipt.credentialsBefore);
   expect(receipt.configAfter).toBe(receipt.configBefore);
+  const beforeUsage = receipt.before.usageStats[fixture.profileId];
+  if (!beforeUsage) {
+    throw new Error("Saved-block repair did not capture the selected profile usage.");
+  }
   const retainedUsage = Object.fromEntries(
-    Object.entries(receipt.before.usageStats[fixture.profileId]).filter(
+    Object.entries(beforeUsage).filter(
       ([key]) =>
         ![
           "blockedUntil",

--- a/ui/src/e2e/quota-reset-status.real-gateway.e2e.test.ts
+++ b/ui/src/e2e/quota-reset-status.real-gateway.e2e.test.ts
@@ -1,0 +1,258 @@
+import { spawnSync } from "node:child_process";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { chromium } from "playwright";
+import { describe, expect, it } from "vitest";
+import type { AuthHealthSummary } from "../../../src/agents/auth-health.js";
+import type { ProfileUsageStats } from "../../../src/agents/auth-profiles/types.js";
+import type { ModelAuthStatusResult } from "../../../src/gateway/server-methods/models-auth-status.types.js";
+import { OPENCLAW_SQLITE_BUSY_TIMEOUT_MS } from "../../../src/state/openclaw-state-db-contract.js";
+import { resolveOpenClawStateSqlitePath } from "../../../src/state/openclaw-state-db.paths.js";
+import {
+  ACCOUNT_ID,
+  MARKER,
+  createQuotaResetFixture,
+} from "../../../test/e2e/qa-lab/runtime/quota-reset.test-support.js";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.js";
+import { waitForControlUiGatewayReady } from "../test-helpers/control-ui-e2e-readiness.js";
+
+type QuotaFixture = Awaited<ReturnType<typeof createQuotaResetFixture>>;
+type SavedState = {
+  usageStats: Record<string, ProfileUsageStats>;
+  [key: string]: unknown;
+};
+type SavedClearReceipt = {
+  pid: number;
+  before: SavedState;
+  after: SavedState;
+  credentialsBefore: string;
+  credentialsAfter: string;
+  configBefore: string;
+  configAfter: string;
+};
+type ModelsStatus = {
+  auth: {
+    unusableProfiles: Array<{ profileId: string }>;
+    oauth: Pick<AuthHealthSummary, "profiles">;
+  };
+};
+
+function clearSavedBlock(fixture: QuotaFixture): SavedClearReceipt {
+  const script = fileURLToPath(
+    new URL(
+      "../../../test/e2e/qa-lab/runtime/quota-reset.saved-clear.test-support.mjs",
+      import.meta.url,
+    ),
+  );
+  const result = spawnSync(
+    process.execPath,
+    [
+      script,
+      resolveOpenClawStateSqlitePath(fixture.gateway.env),
+      fixture.profileId,
+      fixture.gateway.configPath,
+      String(OPENCLAW_SQLITE_BUSY_TIMEOUT_MS),
+    ],
+    { env: fixture.gateway.env, encoding: "utf8", timeout: 30_000 },
+  );
+  expect(result.status, result.stderr).toBe(0);
+  const receipt: SavedClearReceipt = JSON.parse(result.stdout);
+  expect(receipt.pid).not.toBe(process.pid);
+  expect(receipt.pid).not.toBe(fixture.gateway.child?.pid);
+  expect(receipt.credentialsAfter).toBe(receipt.credentialsBefore);
+  expect(receipt.configAfter).toBe(receipt.configBefore);
+  const retainedUsage = Object.fromEntries(
+    Object.entries(receipt.before.usageStats[fixture.profileId]).filter(
+      ([key]) =>
+        ![
+          "blockedUntil",
+          "blockedReason",
+          "blockedSource",
+          "blockedModel",
+          "blockedScope",
+        ].includes(key),
+    ),
+  );
+  expect(receipt.after).toEqual({
+    ...receipt.before,
+    usageStats: { ...receipt.before.usageStats, [fixture.profileId]: retainedUsage },
+  });
+  return receipt;
+}
+
+async function captureFinalStatus(
+  fixture: QuotaFixture,
+  artifactDir: string,
+  observations: unknown[],
+) {
+  const cli = await fixture.gateway.cli(["models", "status", "--json"]);
+  observations.push({ action: "models-status", ...cli });
+  expect(cli.code, cli.stderr).toBe(0);
+  const status: ModelsStatus = JSON.parse(cli.stdout);
+  expect
+    .soft(status.auth.unusableProfiles)
+    .not.toContainEqual(expect.objectContaining({ profileId: fixture.profileId }));
+  expect
+    .soft(status.auth.oauth.profiles)
+    .toContainEqual(
+      expect.objectContaining({ profileId: fixture.profileId, type: "oauth", status: "ok" }),
+    );
+
+  const dashboard = await fixture.gateway.cli(["dashboard", "--json"]);
+  expect(dashboard.code, dashboard.stderr).toBe(0);
+  const { browserUrl }: { browserUrl: string } = JSON.parse(dashboard.stdout);
+  const url = new URL("settings/model-providers", browserUrl);
+  url.hash = new URL(browserUrl).hash;
+  const browser = await chromium.launch({ headless: true });
+  try {
+    const context = await browser.newContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { width: 1280, height: 900 },
+    });
+    const page = await context.newPage();
+    page.setDefaultTimeout(60_000);
+    page.on("websocket", (socket) => {
+      const methods = new Map<string, string>();
+      socket.on("framesent", ({ payload }) => {
+        const frame = JSON.parse(String(payload));
+        if (frame.type === "req") {
+          methods.set(frame.id, frame.method);
+        }
+      });
+      socket.on("framereceived", ({ payload }) => {
+        const frame = JSON.parse(String(payload));
+        const method = methods.get(frame.id);
+        if (method?.startsWith("models.")) {
+          observations.push({ action: "browser-rpc", method, frame });
+        }
+      });
+    });
+    page.on("pageerror", (error) =>
+      observations.push({ action: "browser-error", message: error.message }),
+    );
+    await page.addInitScript(() => {
+      localStorage.setItem(
+        "openclaw:control-ui:community-invite",
+        JSON.stringify({ dismissedAtMs: 1770000000000 }),
+      );
+    });
+    try {
+      await page.goto(url.href);
+      await waitForControlUiGatewayReady(page);
+      const card = page.locator('[data-provider-id="openai"]');
+      await card.waitFor({ state: "visible" });
+      const badge = card.locator(".model-providers__head .settings-status");
+      await expect
+        .poll(async () => (await badge.textContent())?.trim(), { timeout: 60_000 })
+        .toBe("Ready");
+      observations.push({
+        action: "control-ui-provider-status",
+        status: (await badge.textContent())?.trim(),
+        text: await card.textContent(),
+      });
+      expect(await page.locator(".community-invite-card").count()).toBe(0);
+      await page.screenshot({
+        path: path.join(artifactDir, "provider-status.png"),
+        animations: "disabled",
+      });
+    } finally {
+      await fs.writeFile(
+        path.join(artifactDir, "rendered-page.json"),
+        JSON.stringify({ text: await page.locator("body").textContent() }, null, 2),
+      );
+      if ((await page.locator(".community-invite-card").count()) === 0) {
+        await page.screenshot({
+          path: path.join(artifactDir, "final-page.png"),
+          animations: "disabled",
+        });
+      }
+    }
+    await context.close();
+  } finally {
+    await browser.close();
+  }
+}
+
+describe.each(["automatic", "saved-clear"] as const)(
+  "Running Gateway quota status: %s",
+  (recovery) => {
+    it(
+      "serves the same account and shows ready status after recovery without restarting",
+      { timeout: 600_000 },
+      async (context) => {
+        const artifactDir = createControlUiE2eArtifactDir(`quota-refresh-${recovery}`);
+        const observations: unknown[] = [];
+        const fixture = await createQuotaResetFixture(context, {
+          source: "codex_rate_limits",
+          controlUi: true,
+        });
+        const { gateway, client, provider, turn, stats, advanceClock, clock, evidence } = fixture;
+        const gatewayProcess = gateway.child;
+        expect(gatewayProcess?.pid).toEqual(expect.any(Number));
+        try {
+          expect(await turn(), evidence()).toEqual({ status: "ok", output: [MARKER] });
+          await expect.poll(() => stats()?.lastProbeAt).toEqual(expect.any(Number));
+          provider.setPhase("initial-exhaustion");
+          expect((await turn()).status, evidence()).toBe("error");
+          const blocked = stats();
+          observations.push({ action: "provider-created-block", state: blocked });
+          expect(blocked, evidence()).toMatchObject({
+            blockedReason: "subscription_limit",
+            blockedSource: "codex_rate_limits",
+          });
+          expect(blocked?.blockedUntil, evidence()).toBeGreaterThan(Date.now() + 86_400_000);
+          provider.setPhase("restored");
+
+          if (recovery === "automatic") {
+            await advanceClock();
+          } else {
+            const lastProbeAt = blocked?.lastProbeAt;
+            expect(lastProbeAt).toEqual(expect.any(Number));
+            if (lastProbeAt === undefined) {
+              throw new Error("Recent saved-block proof requires the previous health observation.");
+            }
+            expect(Date.now() + clock.offset - lastProbeAt).toBeLessThan(300_000);
+            const cleared = clearSavedBlock(fixture);
+            observations.push({ action: "saved-only-external-clear", receipt: cleared });
+            expect(stats()?.blockedUntil).toBeUndefined();
+            const refreshed = await client.request<ModelAuthStatusResult>("models.authStatus", {
+              agentId: "main",
+              refresh: true,
+            });
+            observations.push({ action: "models-auth-status-refresh", result: refreshed });
+            expect(refreshed.unavailable).toBeUndefined();
+            expect(clock.offset).toBe(0);
+            expect(Date.now() - lastProbeAt).toBeLessThan(300_000);
+          }
+
+          // Observe the next turn before CLI or browser reads can affect runtime preparation.
+          const beforeRecovery = provider.requests.length;
+          const nextTurn = await turn();
+          const inference = provider.requests
+            .slice(beforeRecovery)
+            .filter((request) => request.path.endsWith("/responses"));
+          observations.push({ action: "next-ordinary-turn", result: nextTurn, state: stats() });
+          expect.soft(nextTurn, evidence()).toEqual({ status: "ok", output: [MARKER] });
+          expect(inference, evidence()).toHaveLength(1);
+          expect(inference[0], evidence()).toMatchObject({
+            authorization: `Bearer ${fixture.access}`,
+            accountId: ACCOUNT_ID,
+          });
+          expect.soft(stats()?.blockedUntil, evidence()).toBeUndefined();
+          expect(gateway.child).toBe(gatewayProcess);
+          expect(gatewayProcess?.exitCode).toBeNull();
+          await captureFinalStatus(fixture, artifactDir, observations);
+          expect(provider.errors, evidence()).toEqual([]);
+        } finally {
+          await fs.writeFile(
+            path.join(artifactDir, "observations.json"),
+            JSON.stringify(observations, null, 2),
+          );
+          await fs.writeFile(path.join(artifactDir, "gateway-evidence.json"), evidence());
+        }
+      },
+    );
+  },
+);

--- a/ui/src/e2e/quota-reset-status.real-gateway.e2e.test.ts
+++ b/ui/src/e2e/quota-reset-status.real-gateway.e2e.test.ts
@@ -3,7 +3,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { chromium } from "playwright";
-import { describe, expect, it } from "vitest";
+import { describe, expect, inject, it } from "vitest";
 import type { AuthHealthSummary } from "../../../src/agents/auth-health.js";
 import type { ProfileUsageStats } from "../../../src/agents/auth-profiles/types.js";
 import type { ModelAuthStatusResult } from "../../../src/gateway/server-methods/models-auth-status.types.js";
@@ -108,7 +108,10 @@ async function captureFinalStatus(
   const { browserUrl }: { browserUrl: string } = JSON.parse(dashboard.stdout);
   const url = new URL("settings/model-providers", browserUrl);
   url.hash = new URL(browserUrl).hash;
-  const browser = await chromium.launch({ headless: true });
+  const browser = await chromium.launch({
+    headless: true,
+    executablePath: inject("controlUiE2eChromium").executablePath,
+  });
   try {
     const context = await browser.newContext({
       locale: "en-US",


### PR DESCRIPTION
Related: #123009.

## What Problem This Solves

Fixes an issue where a subscription stayed blocked for days after capacity returned, preventing ordinary chat, scheduled runs and inherited-agent turns.

## Why This Change Was Made

The existing account-usage owner checks fresh capacity on demand after five minutes and reconciles stored blocks before authentication planning. Concurrent requests share the check; current credentials and newer failures or successful use prevent stale results from overwriting account health.

## User Impact

Restored accounts work without restart or another login. Operational storage errors retain the block and permit a healthy configured fallback. No configuration or schema change. This replaces the background-only recovery choice in #108683; @steipete, for awareness.

Consumers: chat, scheduled and inherited turns, side questions and shared isolated completion wait for quota reconciliation.

## Evidence

Registered chat, isolated-task and storage-failure checks passed, including delayed observations and credential removal. Eleven Gateway cases and two real-browser status cases passed. Telegram chat and side-question recovery were observed after real five-minute waits; the final archive for that run was unavailable.
