### PR TITLE
refactor: share tool-call promotion test fixtures

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt-tool-call-text-promotion-adjacent.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-tool-call-text-promotion-adjacent.test.ts
@@ -3,38 +3,11 @@
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { describe, expect, it, vi } from "vitest";
 import { wrapStreamFnPromoteStandaloneTextToolCalls } from "./attempt-tool-call-text-promotion.js";
-
-type FakeWrappedStream = {
-  result: () => Promise<unknown>;
-  [Symbol.asyncIterator]: () => AsyncIterator<unknown>;
-};
-
-function createFakeStream(params: {
-  events: unknown[];
-  resultMessage: unknown;
-}): FakeWrappedStream {
-  return {
-    async result() {
-      return params.resultMessage;
-    },
-    [Symbol.asyncIterator]() {
-      return (async function* () {
-        for (const event of params.events) {
-          yield event;
-        }
-      })();
-    },
-  };
-}
-
-async function collectStreamEvents(stream: AsyncIterable<unknown>): Promise<unknown[]> {
-  // Drain streams to inspect generated tool-call events after wrapper mutation.
-  const events: unknown[] = [];
-  for await (const event of stream) {
-    events.push(event);
-  }
-  return events;
-}
+import {
+  collectStreamEvents,
+  createFakeStream,
+  type FakeWrappedStream,
+} from "./attempt-tool-call-text-promotion.test-helpers.js";
 
 const requireRecord = createRequireRecord("object", "expected-label");
 

--- a/src/agents/embedded-agent-runner/run/attempt-tool-call-text-promotion-buffering.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-tool-call-text-promotion-buffering.test.ts
@@ -3,38 +3,11 @@
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { describe, expect, it, vi } from "vitest";
 import { wrapStreamFnPromoteStandaloneTextToolCalls } from "./attempt-tool-call-text-promotion.js";
-
-type FakeWrappedStream = {
-  result: () => Promise<unknown>;
-  [Symbol.asyncIterator]: () => AsyncIterator<unknown>;
-};
-
-function createFakeStream(params: {
-  events: unknown[];
-  resultMessage: unknown;
-}): FakeWrappedStream {
-  return {
-    async result() {
-      return params.resultMessage;
-    },
-    [Symbol.asyncIterator]() {
-      return (async function* () {
-        for (const event of params.events) {
-          yield event;
-        }
-      })();
-    },
-  };
-}
-
-async function collectStreamEvents(stream: AsyncIterable<unknown>): Promise<unknown[]> {
-  // Drain streams to inspect generated tool-call events after wrapper mutation.
-  const events: unknown[] = [];
-  for await (const event of stream) {
-    events.push(event);
-  }
-  return events;
-}
+import {
+  collectStreamEvents,
+  createFakeStream,
+  type FakeWrappedStream,
+} from "./attempt-tool-call-text-promotion.test-helpers.js";
 
 const requireRecord = createRequireRecord("object", "expected-label");
 

--- a/src/agents/embedded-agent-runner/run/attempt-tool-call-text-promotion-sanitization.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-tool-call-text-promotion-sanitization.test.ts
@@ -3,38 +3,11 @@
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { describe, expect, it, vi } from "vitest";
 import { wrapStreamFnPromoteStandaloneTextToolCalls } from "./attempt-tool-call-text-promotion.js";
-
-type FakeWrappedStream = {
-  result: () => Promise<unknown>;
-  [Symbol.asyncIterator]: () => AsyncIterator<unknown>;
-};
-
-function createFakeStream(params: {
-  events: unknown[];
-  resultMessage: unknown;
-}): FakeWrappedStream {
-  return {
-    async result() {
-      return params.resultMessage;
-    },
-    [Symbol.asyncIterator]() {
-      return (async function* () {
-        for (const event of params.events) {
-          yield event;
-        }
-      })();
-    },
-  };
-}
-
-async function collectStreamEvents(stream: AsyncIterable<unknown>): Promise<unknown[]> {
-  // Drain streams to inspect generated tool-call events after wrapper mutation.
-  const events: unknown[] = [];
-  for await (const event of stream) {
-    events.push(event);
-  }
-  return events;
-}
+import {
+  collectStreamEvents,
+  createFakeStream,
+  type FakeWrappedStream,
+} from "./attempt-tool-call-text-promotion.test-helpers.js";
 
 const requireRecord = createRequireRecord("object", "expected-label");
 

--- a/src/agents/embedded-agent-runner/run/attempt-tool-call-text-promotion.test-helpers.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-tool-call-text-promotion.test-helpers.ts
@@ -1,0 +1,31 @@
+export type FakeWrappedStream = {
+  result: () => Promise<unknown>;
+  [Symbol.asyncIterator]: () => AsyncIterator<unknown>;
+};
+
+export function createFakeStream(params: {
+  events: unknown[];
+  resultMessage: unknown;
+}): FakeWrappedStream {
+  return {
+    async result() {
+      return params.resultMessage;
+    },
+    [Symbol.asyncIterator]() {
+      return (async function* () {
+        for (const event of params.events) {
+          yield event;
+        }
+      })();
+    },
+  };
+}
+
+export async function collectStreamEvents(stream: AsyncIterable<unknown>): Promise<unknown[]> {
+  // Drain streams to inspect generated tool-call events after wrapper mutation.
+  const events: unknown[] = [];
+  for await (const event of stream) {
+    events.push(event);
+  }
+  return events;
+}

--- a/src/agents/embedded-agent-runner/run/attempt-tool-call-text-promotion.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-tool-call-text-promotion.test.ts
@@ -4,38 +4,11 @@ import { expectDefined } from "@openclaw/normalization-core";
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { describe, expect, it, vi } from "vitest";
 import { wrapStreamFnPromoteStandaloneTextToolCalls } from "./attempt-tool-call-text-promotion.js";
-
-type FakeWrappedStream = {
-  result: () => Promise<unknown>;
-  [Symbol.asyncIterator]: () => AsyncIterator<unknown>;
-};
-
-function createFakeStream(params: {
-  events: unknown[];
-  resultMessage: unknown;
-}): FakeWrappedStream {
-  return {
-    async result() {
-      return params.resultMessage;
-    },
-    [Symbol.asyncIterator]() {
-      return (async function* () {
-        for (const event of params.events) {
-          yield event;
-        }
-      })();
-    },
-  };
-}
-
-async function collectStreamEvents(stream: AsyncIterable<unknown>): Promise<unknown[]> {
-  // Drain streams to inspect generated tool-call events after wrapper mutation.
-  const events: unknown[] = [];
-  for await (const event of stream) {
-    events.push(event);
-  }
-  return events;
-}
+import {
+  collectStreamEvents,
+  createFakeStream,
+  type FakeWrappedStream,
+} from "./attempt-tool-call-text-promotion.test-helpers.js";
 
 const requireRecord = createRequireRecord("object", "expected-label");
 


### PR DESCRIPTION
## What Problem This Solves

Four tool-call text-promotion suites repeat the same fake stream type, factory, and event collector. Keeping these copies synchronized adds maintenance work to the same owner’s regression coverage.

## Why This Change Was Made

Move the identical fixture declarations into one sibling test-support module. Preserve caller-owned event and result references, lazy property reads, fresh pull-driven iterators, async result behavior, and early termination. All case bodies and the buffering suite’s custom instrumented iterator remain unchanged.

## User Impact

No user-visible or production behavior changes. Removes 77 net lines across tests and test support while retaining all existing regression cases.

## Evidence

- All four suites pass before and after: 31 tests in each run. Reported labels, order, and status match; one reporter label is abbreviated, so whole-source inversion separately proves that every original case body and full description is unchanged.
- Byte-exact inverse reconstruction of all four original files; the shared declarations match the original implementations.
- Fourteen semantic controls pass for each original implementation and the shared helper, including reference identity, pull timing, malformed events, property-access failures, and early return.
- The mapped core-test gate passed, including typechecks, lint, formatting, and static guards. Its first attempt stopped on an ENOSPC cache write; the unchanged command passed after disk recovery.
- Fresh P2 review found no actionable findings; the diff-scoped cleanup pass required no changes.

Local focused timings are not evidence of a runtime improvement; this change reduces duplicated fixture maintenance.
