### PR TITLE
test(infra): avoid real wait for update notice deadline

### DIFF
--- a/src/infra/update-managed-service-handoff-boundary.test-support.ts
+++ b/src/infra/update-managed-service-handoff-boundary.test-support.ts
@@ -29,11 +29,13 @@ import {
 import { createManagedServiceBoundaryCleanup } from "./update-managed-service-handoff-process.test-support.js";
 import {
   managedRepairUpdaterScript,
-  prepareManagedRepairSpawnEnv,
   readManagedRepairEffects,
   releaseManagedRepairInference,
 } from "./update-managed-service-handoff-repair.test-support.js";
-import { prepareManagedServiceRuntimeFixture } from "./update-managed-service-handoff-runtime.test-support.js";
+import {
+  prepareManagedServiceRuntimeFixture,
+  prepareManagedServiceSpawn,
+} from "./update-managed-service-handoff-runtime.test-support.js";
 import {
   managedServiceStateUpdateScript,
   readRestartSentinelPayload,
@@ -353,9 +355,8 @@ export function createManagedServiceManagerBoundary({
           outputPath: String(generated.triageContextPath),
         });
       }
-      let helperEnv = options?.repair
-        ? await prepareManagedRepairSpawnEnv(root, childEnv)
-        : childEnv;
+      const spawnFixture = await prepareManagedServiceSpawn(root, scriptPath, childEnv, options);
+      let helperEnv = spawnFixture.env;
       const triageDeadlinePath = path.join(root, "triage-deadline.json");
       if (options?.triageHang) {
         helperEnv = await prepareManagedServiceTriageClockPreload(
@@ -524,6 +525,8 @@ export function createManagedServiceManagerBoundary({
                 runningHelper.stdin?.write(
                   options.beforeParkNotice === "rejected" ? "notice-failed\n" : "noticed\n",
                 );
+              } else {
+                await spawnFixture.releaseNoticeDeadline(parent.signalCode);
               }
             }
             if (options.cancelAtActivation) {

--- a/src/infra/update-managed-service-handoff-runtime.test-support.ts
+++ b/src/infra/update-managed-service-handoff-runtime.test-support.ts
@@ -2,8 +2,15 @@ import fs from "node:fs/promises";
 import { createRequire } from "node:module";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
-import type { ManagedRepairBoundary } from "./update-managed-service-handoff-boundary-contract.test-support.js";
-import { managedRepairConfig } from "./update-managed-service-handoff-repair.test-support.js";
+import { expect } from "vitest";
+import type {
+  ManagedRepairBoundary,
+  ManagedServiceBoundaryOptions,
+} from "./update-managed-service-handoff-boundary-contract.test-support.js";
+import {
+  managedRepairConfig,
+  prepareManagedRepairSpawnEnv,
+} from "./update-managed-service-handoff-repair.test-support.js";
 import { managedServiceStateUpdateScript } from "./update-managed-service-handoff-state.test-support.js";
 
 export async function prepareManagedServiceRuntimeFixture(params: {
@@ -87,4 +94,58 @@ export async function prepareManagedServiceRuntimeFixture(params: {
     );
   }
   return { sourceRuntimeImport, ledgerRuntimeImport };
+}
+
+export async function prepareManagedServiceSpawn(
+  root: string,
+  scriptPath: string,
+  childEnv: NodeJS.ProcessEnv,
+  options?: Pick<ManagedServiceBoundaryOptions, "repair" | "beforeParkNotice">,
+) {
+  let env = options?.repair ? await prepareManagedRepairSpawnEnv(root, childEnv) : childEnv;
+  const deadlinePath = path.join(root, "notice-deadline.json");
+  const releasePath = path.join(root, "notice-deadline-release");
+  if (options?.beforeParkNotice === "stalled") {
+    const preloadPath = path.join(root, "notice-clock-preload.cjs");
+    // Keep other processes and deadlines native; release only after the parent observes the notice.
+    const source = `if (process.argv[1] === ${JSON.stringify(scriptPath)}) {
+      const fs = require("node:fs");
+      const setTimeout = global.setTimeout;
+      const clearTimeout = global.clearTimeout;
+      const polls = new Map();
+      let captured = false;
+      global.clearTimeout = (timer) => {
+        clearInterval(polls.get(timer));
+        polls.delete(timer);
+        return clearTimeout(timer);
+      };
+      global.setTimeout = (callback, delay, ...args) => {
+        const timer = setTimeout(callback, delay, ...args);
+        if (delay !== 10_000) return timer;
+        if (captured) throw new Error("duplicate pre-park notice deadline");
+        captured = true;
+        fs.writeFileSync(${JSON.stringify(deadlinePath)}, JSON.stringify({ requestedMs: delay }));
+        const poll = setInterval(() => {
+          if (!fs.existsSync(${JSON.stringify(releasePath)})) return;
+          global.clearTimeout(timer);
+          callback.apply(timer, args);
+        }, 5);
+        polls.set(timer, poll);
+        return timer;
+      };
+    }`;
+    await fs.writeFile(preloadPath, source);
+    env = { ...env, NODE_OPTIONS: `${env.NODE_OPTIONS ?? ""} --require ${preloadPath}`.trim() };
+  }
+  return {
+    env,
+    releaseNoticeDeadline: async (parentSignal: NodeJS.Signals | null) => {
+      expect(parentSignal).toBeNull();
+      await expect(
+        fs.readFile(deadlinePath, "utf8").then((value) => JSON.parse(value)),
+        "expected one captured 10,000ms pre-park deadline",
+      ).resolves.toEqual({ requestedMs: 10_000 });
+      await fs.writeFile(releasePath, "release");
+    },
+  };
 }


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

The stalled managed-update notice test spends ten real seconds waiting for a timeout, even though its contract is the requested deadline and the order of notice, ownership checks, and service stop.

## Why This Change Was Made

Keep the real generated helper and native timer, but release that exact 10,000ms callback after the parent observes the notice, confirms that no service command ran, and checks that its process is still live. The clock fixture lives with the existing generated-runtime setup. Other timers and child processes remain native, and production code is unchanged.

## User Impact

No user-facing behavior change. In one matched local cohort, the stalled case decreased from 10.707s to 0.614s. This is a scoped test result, not an overall suite-speed claim. The change adds 64 test-support lines.

## Evidence

- All three notice cases and all 21 single-flight sibling cases passed, with identical names/statuses to baseline. The other 174 cases were intentionally filtered, not reported as passing.
- Controlled wrong-deadline, real early-stop, and missing-callback regressions each fail at the intended boundary; direct inner stacks and exact source restoration were verified.
- Source-derived checks preserve non-stalled environment references and repair-environment routing; only the stalled notice enables the scoped preload.
- Independent P2 review is clean. Existing deadline values, assertions, cancellation, child ownership, and cleanup remain intact.
- Revised mapped gate passed, including core-test typechecking, all three dead-export scans, formatting, guards, and targeted lint.
