### PR TITLE
fix(models): capture startup auth facts for scoped catalogs

### DIFF
--- a/src/agents/prepared-model-catalog-worker.scope.integration.test.ts
+++ b/src/agents/prepared-model-catalog-worker.scope.integration.test.ts
@@ -18,17 +18,22 @@ import {
   REF_ONLY_TOKEN_ENV,
   UNRELATED_PLUGIN_ID,
   UNRELATED_PLUGIN_WORKER_MARKER_ENV,
+  UNRELATED_SYNTHETIC_AUTH_ID,
   writeFixturePlugin,
   writeUnrelatedFixturePlugin,
 } from "./prepared-model-catalog-worker.test-support.js";
 import { getPreparedModelRuntimeAuthStore } from "./prepared-model-runtime-auth.js";
 import { startSerializedSnapshotBuildBatch } from "./prepared-model-runtime.build.js";
+import { retainPreparedPluginGeneration } from "./prepared-model-runtime.plugin-lifetime.js";
 import { usePreparedCatalogWorkerFixtures } from "./test-helpers/prepared-model-catalog-worker-fixture.js";
 
 const { makeTempDir, retireAfterTest } = usePreparedCatalogWorkerFixtures();
 
 describe("prepared model catalog worker plugin scope", () => {
-  it("keeps catalog contributors on the models.list route without importing unrelated plugins", async () => {
+  it.each([
+    { first: "full", asyncSyntheticAuth: false, syntheticAuthAvailable: true },
+    { first: "scoped", asyncSyntheticAuth: true, syntheticAuthAvailable: false },
+  ])("keeps models.list scoped with $first catalog discovery first", async (selection) => {
     const root = makeTempDir("openclaw-model-catalog-scope-worker-");
     const stateDir = path.join(root, "state");
     const agentDir = path.join(stateDir, "agents", "main", "agent");
@@ -38,7 +43,7 @@ describe("prepared model catalog worker plugin scope", () => {
     fs.mkdirSync(agentDir, { recursive: true });
     fs.mkdirSync(workspaceDir, { recursive: true });
 
-    const pluginFile = writeFixturePlugin({ root, spinMs: 0 });
+    const pluginFile = writeFixturePlugin({ root, spinMs: 0, ...selection });
     const unrelatedPluginFile = writeUnrelatedFixturePlugin(root);
     const config = {
       agents: {
@@ -100,6 +105,31 @@ describe("prepared model catalog worker plugin scope", () => {
     )[0];
     if (!prepared) {
       throw new Error("prepared runtime produced no snapshot");
+    }
+    await using _ = {
+      [Symbol.asyncDispose]: retainPreparedPluginGeneration(prepared.pluginGeneration),
+    };
+    if (selection.first === "scoped") {
+      expect(prepared.snapshot.authModes[HARNESS_ID]).toBeUndefined();
+      const probePath = path.join(root, "synthetic-auth-probes.txt");
+      const ownerPath = path.join(root, "synthetic-auth-owner.txt");
+      fs.writeFileSync(probePath, "");
+      fs.writeFileSync(ownerPath, "");
+      // Do not warm the worker: reconstruction needs the unavailable native sibling's fact.
+      const catalog = await prepared.snapshot.loadFullModelCatalog!({
+        providerIds: [PROVIDER_ID],
+        refresh: true,
+      });
+      expect(catalog.entries).toContainEqual(
+        expect.objectContaining({ provider: PROVIDER_ID, id: "plugin-generation-v1" }),
+      );
+      const probes = fs.readFileSync(probePath, "utf8").trim().split("\n");
+      expect(probes).toContain(HARNESS_ID);
+      expect(probes).not.toContain(UNRELATED_SYNTHETIC_AUTH_ID);
+      expect(new Set(fs.readFileSync(ownerPath, "utf8").trim().split("\n"))).toEqual(
+        new Set(["parent"]),
+      );
+      expect(fs.existsSync(unrelatedMarker)).toBe(false);
     }
     const authStore = getPreparedModelRuntimeAuthStore(prepared.snapshot);
     if (!authStore) {

--- a/src/agents/prepared-model-catalog-worker.scope.integration.test.ts
+++ b/src/agents/prepared-model-catalog-worker.scope.integration.test.ts
@@ -7,9 +7,9 @@ import { modelsHandlers } from "../gateway/server-methods/models.js";
 import type { GatewayRequestContext, RespondFn } from "../gateway/server-methods/types.js";
 import { registerGatewayModelCatalogPrivateAccess } from "../gateway/server-model-catalog-auth.js";
 import type { PreparedGatewayModelCatalogSnapshot } from "../gateway/server-model-catalog-auth.js";
+import { drainGlobalSingletonLifecycleState } from "../shared/global-singleton.js";
 import { unregisterResolvedAgentDir } from "./agent-dir-registry.js";
 import { replaceRuntimeAuthProfileStoreSnapshots } from "./auth-profiles/runtime-snapshots.js";
-import { preparePublishedModelCatalogOwnerIdentity } from "./prepared-model-catalog-owner.js";
 import {
   HARNESS_ID,
   PLUGIN_ID,
@@ -23,16 +23,20 @@ import {
   writeUnrelatedFixturePlugin,
 } from "./prepared-model-catalog-worker.test-support.js";
 import { getPreparedModelRuntimeAuthStore } from "./prepared-model-runtime-auth.js";
-import { startSerializedSnapshotBuildBatch } from "./prepared-model-runtime.build.js";
-import { retainPreparedPluginGeneration } from "./prepared-model-runtime.plugin-lifetime.js";
+import {
+  getPreparedModelRuntimeSnapshot,
+  publishPreparedModelRuntimeSnapshot,
+} from "./prepared-model-runtime.js";
 import { usePreparedCatalogWorkerFixtures } from "./test-helpers/prepared-model-catalog-worker-fixture.js";
 
-const { makeTempDir, retireAfterTest } = usePreparedCatalogWorkerFixtures();
+const { makeTempDir, retireAfterTest, waitForMarker, waitForWorkers } =
+  usePreparedCatalogWorkerFixtures();
 
 describe("prepared model catalog worker plugin scope", () => {
   it.each([
     { first: "full", asyncSyntheticAuth: false, syntheticAuthAvailable: true },
     { first: "scoped", asyncSyntheticAuth: true, syntheticAuthAvailable: false },
+    { first: "held", asyncSyntheticAuth: true, syntheticAuthAvailable: false },
   ])("keeps models.list scoped with $first catalog discovery first", async (selection) => {
     const root = makeTempDir("openclaw-model-catalog-scope-worker-");
     const stateDir = path.join(root, "state");
@@ -51,9 +55,29 @@ describe("prepared model catalog worker plugin scope", () => {
           model: `${PROVIDER_ID}/sqlite-model`,
           models: {
             [`${PROVIDER_ID}/sqlite-model`]: { agentRuntime: { id: HARNESS_ID } },
+            "published-fixture/published-model": { agentRuntime: { id: "openclaw" } },
           },
         },
         list: [{ id: "main", default: true, agentDir, workspace: workspaceDir }],
+      },
+      models: {
+        providers: {
+          "published-fixture": {
+            api: "openai-completions",
+            baseUrl: "https://published-fixture.invalid/v1",
+            apiKey: "published-fixture-key-not-real",
+            models: [
+              {
+                id: "published-model",
+                name: "Published model",
+                reasoning: false,
+                input: ["text"],
+                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                maxTokens: 1_024,
+              },
+            ],
+          },
+        },
       },
       plugins: {
         allow: [PLUGIN_ID, UNRELATED_PLUGIN_ID],
@@ -83,75 +107,38 @@ describe("prepared model catalog worker plugin scope", () => {
       config,
       env,
     };
-    let current = true;
     retireAfterTest(() => {
-      current = false;
       unregisterResolvedAgentDir({ agentId: "main", agentDir, env });
     });
-    const prepared = (
-      await startSerializedSnapshotBuildBatch(
-        [
-          {
-            input,
-            catalogOwner: preparePublishedModelCatalogOwnerIdentity(input),
-            isGenerationCurrent: () => current,
-            isBuildCurrent: () => current,
-          },
-        ],
-        new Map(),
-        30_000,
-        "static",
-      ).pending
-    )[0];
-    if (!prepared) {
-      throw new Error("prepared runtime produced no snapshot");
-    }
-    await using _ = {
-      [Symbol.asyncDispose]: retainPreparedPluginGeneration(prepared.pluginGeneration),
-    };
-    if (selection.first === "scoped") {
-      expect(prepared.snapshot.authModes[HARNESS_ID]).toBeUndefined();
-      const probePath = path.join(root, "synthetic-auth-probes.txt");
-      const ownerPath = path.join(root, "synthetic-auth-owner.txt");
-      fs.writeFileSync(probePath, "");
-      fs.writeFileSync(ownerPath, "");
-      // Do not warm the worker: reconstruction needs the unavailable native sibling's fact.
-      const catalog = await prepared.snapshot.loadFullModelCatalog!({
-        providerIds: [PROVIDER_ID],
-        refresh: true,
-      });
-      expect(catalog.entries).toContainEqual(
-        expect.objectContaining({ provider: PROVIDER_ID, id: "plugin-generation-v1" }),
-      );
-      const probes = fs.readFileSync(probePath, "utf8").trim().split("\n");
-      expect(probes).toContain(HARNESS_ID);
-      expect(probes).not.toContain(UNRELATED_SYNTHETIC_AUTH_ID);
-      expect(new Set(fs.readFileSync(ownerPath, "utf8").trim().split("\n"))).toEqual(
-        new Set(["parent"]),
-      );
-      expect(fs.existsSync(unrelatedMarker)).toBe(false);
-    }
-    const authStore = getPreparedModelRuntimeAuthStore(prepared.snapshot);
+    const snapshot = await publishPreparedModelRuntimeSnapshot(input, {
+      provenance: "configured",
+      catalogMode: "static",
+    });
+    const authStore = getPreparedModelRuntimeAuthStore(snapshot);
     if (!authStore) {
       throw new Error("prepared runtime produced no auth store");
     }
-    const projectSnapshot = async (full: boolean): Promise<PreparedGatewayModelCatalogSnapshot> => {
+    const projectSnapshot = async (
+      full: boolean,
+      providerIds?: readonly string[],
+      refresh?: boolean,
+    ): Promise<PreparedGatewayModelCatalogSnapshot> => {
       const modelCatalog = full
-        ? await prepared.snapshot.loadFullModelCatalog!()
-        : prepared.snapshot.modelCatalog;
+        ? await snapshot.loadFullModelCatalog!({ providerIds, refresh })
+        : snapshot.modelCatalog;
       return {
         ...modelCatalog,
         agentId: "main",
         agentDir,
         workspaceDir,
         config,
-        observationConfig: prepared.snapshot.observationConfig,
-        isCurrent: prepared.snapshot.isCurrent,
-        pluginRegistry: prepared.snapshot.pluginRegistry,
+        observationConfig: snapshot.observationConfig,
+        isCurrent: snapshot.isCurrent,
+        pluginRegistry: snapshot.pluginRegistry,
         catalogComplete: full,
-        authModes: prepared.snapshot.authModes,
+        authModes: snapshot.authModes,
         authStore,
-        metadataSnapshot: prepared.snapshot.metadataSnapshot,
+        metadataSnapshot: snapshot.metadataSnapshot,
         authMaterializations: [],
       };
     };
@@ -165,14 +152,18 @@ describe("prepared model catalog worker plugin scope", () => {
           observationConfig: _observationConfig,
           isCurrent: _isCurrent,
           pluginRegistry: _pluginRegistry,
-          ...snapshot
+          ...publicSnapshot
         } = await projectSnapshot(params?.readOnly === false);
-        return snapshot;
+        return publicSnapshot;
       };
     let published = await projectSnapshot(false);
     registerGatewayModelCatalogPrivateAccess(loadGatewayModelCatalogSnapshot, {
       loadDeferred: async (params) =>
-        (published = await projectSnapshot(params?.readOnly === false)),
+        (published = await projectSnapshot(
+          params?.readOnly === false,
+          params?.providerDiscoveryProviderIds,
+          params?.refreshFullCatalog === true,
+        )),
       readPrepared: async () => published,
     });
     const respond = vi.fn();
@@ -181,6 +172,135 @@ describe("prepared model catalog worker plugin scope", () => {
       loadGatewayModelCatalogSnapshot,
       logGateway: { debug: vi.fn(), warn: vi.fn() },
     });
+    if (selection.first !== "full") {
+      expect(snapshot.authModes[HARNESS_ID]).toBeUndefined();
+      const probePath = path.join(root, "synthetic-auth-probes.txt");
+      const ownerPath = path.join(root, "synthetic-auth-owner.txt");
+      fs.writeFileSync(probePath, "");
+      fs.writeFileSync(ownerPath, "");
+      const hold = path.join(root, "synthetic-auth-hold");
+      if (selection.first === "held") {
+        fs.writeFileSync(hold, "");
+      }
+      // The first worker operation must enter through the registered scoped refresh.
+      const params = { view: "all", provider: PROVIDER_ID, refresh: true };
+      const refresh = Promise.resolve(
+        expectDefined(
+          modelsHandlers["models.list"],
+          "models.list test invariant",
+        )({
+          req: { type: "req", id: "models-list-cold-scoped", method: "models.list", params },
+          params,
+          respond: respond as RespondFn,
+          client: null,
+          isWebchatConnect: () => false,
+          context,
+        }),
+      );
+      if (selection.first === "held") {
+        let settled = false;
+        const observedRefresh = refresh.finally(() => {
+          settled = true;
+        });
+        void observedRefresh.catch(() => {});
+        try {
+          await vi.waitFor(() => expect(fs.readFileSync(ownerPath, "utf8")).toContain("parent\n"));
+          // The entered probe stays pending until abort; later publication probes may proceed.
+          fs.rmSync(hold);
+          const readStarted = performance.now();
+          const readRespond = vi.fn();
+          await expectDefined(
+            modelsHandlers["models.list"],
+            "models.list test invariant",
+          )({
+            req: { type: "req", id: "models-list-during-refresh", method: "models.list" },
+            params: { view: "all" },
+            respond: readRespond as RespondFn,
+            client: null,
+            isWebchatConnect: () => false,
+            context,
+          });
+          const readMs = performance.now() - readStarted;
+          expect(settled).toBe(false);
+          const publicationStarted = performance.now();
+          const replacementInput = {
+            ...input,
+            config: {
+              ...config,
+              agents: {
+                ...config.agents,
+                list: [
+                  {
+                    id: "main",
+                    default: true,
+                    agentDir,
+                    workspace: workspaceDir,
+                    name: "Updated agent",
+                  },
+                ],
+              },
+            },
+          };
+          const publishedReplacement = await publishPreparedModelRuntimeSnapshot(replacementInput, {
+            force: true,
+            provenance: "configured",
+            catalogMode: "static",
+          }).then((replacement) => ({
+            snapshot: replacement,
+            elapsedMs: performance.now() - publicationStarted,
+          }));
+          expect(readMs).toBeLessThan(5_000);
+          expect(publishedReplacement.elapsedMs).toBeLessThan(5_000);
+          expect(readRespond).toHaveBeenCalledWith(
+            true,
+            expect.objectContaining({
+              models: expect.arrayContaining([
+                expect.objectContaining({ provider: "published-fixture", id: "published-model" }),
+              ]),
+            }),
+            undefined,
+          );
+          expect(getPreparedModelRuntimeSnapshot(replacementInput)).toBe(
+            publishedReplacement.snapshot,
+          );
+          expect(snapshot.isCurrent()).toBe(false);
+          console.info("held models.list responsiveness", {
+            readMs,
+            publicationMs: publishedReplacement.elapsedMs,
+            responseBoundMs: 5_000,
+          });
+          const cancelled = path.join(root, "synthetic-auth-cancel.txt");
+          await waitForMarker(cancelled);
+          await expect(observedRefresh).rejects.toThrow("superseded");
+          expect(settled).toBe(true);
+          expect(fs.readFileSync(cancelled, "utf8")).toBe("abort\njoined\n");
+          await waitForWorkers();
+        } finally {
+          fs.rmSync(hold, { force: true });
+          await drainGlobalSingletonLifecycleState("close");
+          await Promise.allSettled([observedRefresh]);
+        }
+        return;
+      }
+      await refresh;
+      expect(respond).toHaveBeenCalledWith(
+        true,
+        expect.objectContaining({
+          models: expect.arrayContaining([
+            expect.objectContaining({ provider: PROVIDER_ID, id: "plugin-generation-v1" }),
+          ]),
+        }),
+        undefined,
+      );
+      const probes = fs.readFileSync(probePath, "utf8").trim().split("\n");
+      expect(probes).toContain(HARNESS_ID);
+      expect(probes).not.toContain(UNRELATED_SYNTHETIC_AUTH_ID);
+      expect(new Set(fs.readFileSync(ownerPath, "utf8").trim().split("\n"))).toEqual(
+        new Set(["parent"]),
+      );
+      expect(fs.existsSync(unrelatedMarker)).toBe(false);
+      respond.mockClear();
+    }
     await expectDefined(
       modelsHandlers["models.list"],
       'modelsHandlers["models.list"] test invariant',

--- a/src/agents/prepared-model-catalog-worker.test-support.ts
+++ b/src/agents/prepared-model-catalog-worker.test-support.ts
@@ -43,7 +43,7 @@ export const PROVIDER_ID = "worker-catalog-fixture";
 export const HARNESS_ID = "worker-catalog-fixture-harness";
 export const DISCOVERED_HARNESS_ID = `${PROVIDER_ID}-discovered-harness`;
 export const MISSING_AUTH_HARNESS_ID = `${PROVIDER_ID}-missing-auth-harness`;
-const UNRELATED_SYNTHETIC_AUTH_ID = `${PROVIDER_ID}-unrelated-harness`;
+export const UNRELATED_SYNTHETIC_AUTH_ID = `${PROVIDER_ID}-unrelated-harness`;
 export const SHARED_AUTH_PROVIDER_ID = `${PROVIDER_ID}-shared-auth`;
 export const PLUGIN_ID = "worker-catalog-fixture";
 export const PROFILE_ID = `${SHARED_AUTH_PROVIDER_ID}:named`;
@@ -117,6 +117,7 @@ export function writeFixturePlugin(params: {
   builtPluginVersion?: string;
   nativeCatalog?: boolean;
   asyncSyntheticAuth?: boolean;
+  syntheticAuthAvailable?: boolean;
 }): string {
   const pluginDir = path.join(params.root, "plugin");
   fs.mkdirSync(pluginDir, { recursive: true });
@@ -135,6 +136,7 @@ export function writeFixturePlugin(params: {
     unrelatedId: UNRELATED_SYNTHETIC_AUTH_ID,
     pluginVersion: params.pluginVersion ?? "v1",
     asyncSyntheticAuth: params.asyncSyntheticAuth,
+    syntheticAuthAvailable: params.syntheticAuthAvailable,
   });
   fs.writeFileSync(
     pluginFile,
@@ -286,6 +288,7 @@ module.exports = {
       spinMs: params.spinMs,
       pluginVersion: params.builtPluginVersion,
       asyncSyntheticAuth: params.asyncSyntheticAuth,
+      syntheticAuthAvailable: params.syntheticAuthAvailable,
     });
     const distDir = path.join(pluginDir, "dist");
     fs.mkdirSync(distDir);

--- a/src/agents/prepared-model-catalog-worker.ts
+++ b/src/agents/prepared-model-catalog-worker.ts
@@ -303,10 +303,8 @@ export function createPreparedModelCatalogWorker(
       }, PREPARED_MODEL_CATALOG_WORKER_GENERATION_POLL_MS);
       generationPoll.unref();
       const { input } = workerInput;
-      const providerScope =
-        command.kind === "catalog" && command.providerIds
-          ? command.providerIds
-          : [...workerInput.providerIds, ...(command.providerIds ?? [])];
+      // Worker reconstruction consumes startup auth facts even for a scoped catalog request.
+      const providerScope = [...workerInput.providerIds, ...(command.providerIds ?? [])];
       const capture = withPluginRuntimeGenerationScope(
         { metadataSnapshot, pluginRegistry: params.pluginRegistry },
         () =>

--- a/src/agents/test-helpers/prepared-model-catalog-worker-fixture.ts
+++ b/src/agents/test-helpers/prepared-model-catalog-worker-fixture.ts
@@ -72,6 +72,7 @@ export function writeSyntheticAuthDiscoveryFixture(params: {
   unrelatedId: string;
   pluginVersion: string;
   asyncSyntheticAuth?: boolean;
+  syntheticAuthAvailable?: boolean;
 }): void {
   const probePath = path.join(params.root, "synthetic-auth-probes.txt");
   fs.writeFileSync(
@@ -109,7 +110,7 @@ module.exports = {
         : ""
     }
     fs.appendFileSync(${JSON.stringify(probePath)}, provider + "\\n");
-    return provider === ${JSON.stringify(params.harnessId)}
+    return ${params.syntheticAuthAvailable !== false} && provider === ${JSON.stringify(params.harnessId)}
       ? { apiKey: "native-login-not-real", source: "fixture native login", mode: "oauth" }
       : undefined;
   },


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a cold, provider-scoped model-list refresh failed because startup authentication facts for another unavailable account had not been captured.

## Why This Change Was Made

The existing catalog preparation operation captures startup prerequisites together with requested providers. Live discovery still uses the requested provider scope, and unavailable authentication remains an explicit result.

## User Impact

Scoped model listing can return configured rows and a failed-refresh warning while unavailable accounts retain sign-in guidance. No configuration or public contract change.

Consumers: cold model-list refresh and automatic scoped catalog refresh receive complete startup facts.

## Evidence

The registered models.list regression failed before the fix and passed afterward; 19 targeted tests passed. A held prerequisite did not block a published catalog read or configuration publication, and cancellation settled. Three real-configuration startup checks returned usable rows. Telegram model-list replies delivered rows and warnings; remote discovery and inference were not claimed.
