### PR TITLE
test(scripts): retain failed fixture cleanup for retry

### DIFF
--- a/test/scripts/test-helpers.test.ts
+++ b/test/scripts/test-helpers.test.ts
@@ -1,0 +1,44 @@
+import fs from "node:fs";
+import path from "node:path";
+import { expect, it, vi } from "vitest";
+import { createScriptTestHarness } from "./test-helpers.js";
+
+const hooks = vi.hoisted(() => [] as Array<() => void>);
+vi.mock("vitest", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("vitest")>()),
+  afterEach: (cleanup: () => void) => hooks.push(cleanup),
+}));
+
+it("cleans script fixtures in LIFO order and retains failed removals for the next hook", async () => {
+  const harness = createScriptTestHarness();
+  const first = harness.createTempDir("openclaw-script-cleanup-first-");
+  const failed = await harness.createTempDirAsync("openclaw-script-cleanup-failed-");
+  const tracked = harness.trackTempDir(path.join(first, "tracked"));
+  fs.mkdirSync(tracked);
+  const failure = new Error("injected script fixture removal failure");
+  const rmSync = fs.rmSync.bind(fs);
+  const remove = vi.spyOn(fs, "rmSync").mockImplementation((dir, options) => {
+    if (dir === failed) {
+      throw failure;
+    }
+    rmSync(dir, options);
+  });
+  try {
+    const [cleanup] = hooks;
+    if (!cleanup) {
+      throw new Error("Script harness did not register its cleanup hook");
+    }
+    expect(() => cleanup()).toThrow(failure);
+    expect.soft(remove.mock.calls.map(([dir]) => dir)).toEqual([tracked, failed, first]);
+    expect.soft(fs.existsSync(tracked)).toBe(false);
+    expect.soft(fs.existsSync(first)).toBe(false);
+
+    remove.mockRestore();
+    cleanup();
+    expect.soft(fs.existsSync(failed)).toBe(false);
+  } finally {
+    remove.mockRestore();
+    rmSync(first, { recursive: true, force: true });
+    rmSync(failed, { recursive: true, force: true });
+  }
+});

--- a/test/scripts/test-helpers.ts
+++ b/test/scripts/test-helpers.ts
@@ -4,6 +4,7 @@ import fsPromises from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach } from "vitest";
+import { cleanupTempDirs } from "../helpers/temp-dir.js";
 
 export function linkPnpmBootstrapShellTools(binDir: string): void {
   // Omit package managers: absence must not depend on the host's installed tools.
@@ -68,29 +69,18 @@ else if (query.includes("{id: .profileId")) {
 export function createScriptTestHarness() {
   const tempDirs: string[] = [];
 
-  afterEach(() => {
-    while (tempDirs.length > 0) {
-      const dir = tempDirs.pop();
-      if (dir) {
-        fs.rmSync(dir, { recursive: true, force: true });
-      }
-    }
-  });
+  afterEach(() => cleanupTempDirs(tempDirs));
 
   function createTempDir(prefix: string): string {
-    const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
-    tempDirs.push(dir);
-    return dir;
+    return trackTempDir(fs.mkdtempSync(path.join(os.tmpdir(), prefix)));
   }
 
   async function createTempDirAsync(prefix: string): Promise<string> {
-    const dir = await fsPromises.mkdtemp(path.join(os.tmpdir(), prefix));
-    tempDirs.push(dir);
-    return dir;
+    return trackTempDir(await fsPromises.mkdtemp(path.join(os.tmpdir(), prefix)));
   }
 
   function trackTempDir(dir: string): string {
-    tempDirs.push(dir);
+    tempDirs.unshift(dir);
     return dir;
   }
 


### PR DESCRIPTION
Closes #145860

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where script tests leave fixture directories behind when one removal fails: cleanup skips older siblings and cannot retry the failed root on a later hook.

## Why This Change Was Made

The registered hook now uses the existing `cleanupTempDirs` owner, which continues sibling removal, retains failed roots, and reports the errors. All three harness creation/registration APIs use its existing tracker, inserting newest roots first to preserve LIFO cleanup and retry order.

## User Impact

Script-test cleanup attempts every tracked root and can retry failed removals later. Returned APIs, raw temporary-path spelling, asynchronous registration order, and hook scope stay unchanged. There is no production behavior change or performance claim. The change removes ten net support lines and adds a 44-line regression.

## Evidence

The new registered-hook regression failed against the original helper on the expected sibling-skip and forgotten-root assertions, then passed after repair. It exercises synchronous, asynchronous, and explicit registration, removal ordering, failure continuation, and a second cleanup hook.

Focused proof passed 57 tests across five files, with one existing Windows-only path-canonicalization test skipped on macOS. All 16 selected checks against `0cccc6d68e58ccd5030cd09931c1753bca924c7b` passed, including formatting/type/lint checks. Source-bound P2 review reported no actionable findings. The original failing evidence is retained.
