### PR TITLE
fix(browser): profile status starts Chrome debugger while idle

### DIFF
--- a/extensions/browser/src/browser/extension-relay/relay-tab-count.test.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-tab-count.test.ts
@@ -32,10 +32,14 @@ async function authServer(
   let connections = 0;
   let fields: BrowserRelayProofFields;
   let entered!: () => void;
-  const received = new Promise<void>((resolve) => (entered = resolve));
+  const received = new Promise<void>((resolve) => {
+    entered = resolve;
+  });
   let socketClosed!: () => void;
-  const closed = new Promise<void>((resolve) => (socketClosed = resolve));
-  const server = http.createServer(async (req, res) => {
+  const closed = new Promise<void>((resolve) => {
+    socketClosed = resolve;
+  });
+  const handleRequest = async (req: http.IncomingMessage, res: http.ServerResponse) => {
     paths.push(req.url ?? "");
     entered();
     if (options.hang) {
@@ -85,6 +89,11 @@ async function authServer(
         }),
       );
     }
+  };
+  const server = http.createServer((req, res) => {
+    void handleRequest(req, res).catch((error: unknown) => {
+      res.destroy(error instanceof Error ? error : new Error(String(error)));
+    });
   });
   server.on("connection", (socket) => {
     connections += 1;
@@ -94,7 +103,9 @@ async function authServer(
   await once(server, "listening");
   onTestFinished(async () => {
     server.closeAllConnections();
-    await new Promise<void>((resolve) => server.close(() => resolve()));
+    await new Promise<void>((resolve) => {
+      server.close(() => resolve());
+    });
   });
   const address = server.address();
   if (address === null || typeof address === "string") {

--- a/extensions/browser/src/browser/extension-relay/relay-tab-count.test.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-tab-count.test.ts
@@ -1,0 +1,197 @@
+import { once } from "node:events";
+import http from "node:http";
+import { describe, expect, it, onTestFinished, vi } from "vitest";
+import { relayTestKey } from "../../../chrome-extension/relay-key.test-support.js";
+import {
+  createRelayProof,
+  randomRelayId,
+  randomRelayNonce,
+  type BrowserRelayProofFields,
+} from "./auth-v2-crypto.js";
+import {
+  BROWSER_RELAY_AUTH_CHALLENGE_PATH,
+  BROWSER_RELAY_AUTH_COMPLETE_PATH,
+  BROWSER_RELAY_CHALLENGE_TTL_MS,
+  invalidateBrowserRelayAuthV2Authority,
+} from "./auth-v2.js";
+import * as relayAuth from "./relay-auth.js";
+import { startExtensionRelayServer } from "./relay-server.js";
+import { countExtensionRelayTabs } from "./relay-tab-count.js";
+
+const token = relayTestKey(12);
+
+async function authServer(
+  options: {
+    changeChallenge?: (challenge: Record<string, unknown>) => void;
+    invalidAcceptance?: boolean;
+    closeChallenge?: boolean;
+    hang?: boolean;
+  } = {},
+) {
+  const paths: string[] = [];
+  let connections = 0;
+  let fields: BrowserRelayProofFields;
+  let entered!: () => void;
+  const received = new Promise<void>((resolve) => (entered = resolve));
+  let socketClosed!: () => void;
+  const closed = new Promise<void>((resolve) => (socketClosed = resolve));
+  const server = http.createServer(async (req, res) => {
+    paths.push(req.url ?? "");
+    entered();
+    if (options.hang) {
+      return;
+    }
+    const chunks: Buffer[] = [];
+    for await (const chunk of req) {
+      chunks.push(Buffer.from(chunk));
+    }
+    const body = JSON.parse(Buffer.concat(chunks).toString());
+    if (req.url === BROWSER_RELAY_AUTH_CHALLENGE_PATH) {
+      fields = {
+        keyId: body.keyId,
+        clientNonce: body.clientNonce,
+        instanceId: randomRelayId(),
+        sessionId: randomRelayId(),
+        serverNonce: randomRelayNonce(),
+        issuedAtMs: Date.now(),
+        expiresAtMs: Date.now() + BROWSER_RELAY_CHALLENGE_TTL_MS,
+        role: "cdp",
+        transport: "connection",
+        method: "GET",
+        resource: "/json/list",
+        flow: "json-list",
+      };
+      fields.expiresAtMs = fields.issuedAtMs + BROWSER_RELAY_CHALLENGE_TTL_MS;
+      const challenge = {
+        ...fields,
+        type: "auth.challenge",
+        v: 2,
+        serverProof: createRelayProof(token, "server", fields),
+      };
+      options.changeChallenge?.(challenge);
+      if (options.closeChallenge) {
+        res.setHeader("Connection", "close");
+      }
+      res.end(JSON.stringify(challenge));
+    } else {
+      res.end(
+        JSON.stringify({
+          type: "auth.ok",
+          v: 2,
+          sessionId: fields.sessionId,
+          acceptProof: options.invalidAcceptance
+            ? randomRelayNonce()
+            : createRelayProof(token, "accept", fields, body.clientProof),
+        }),
+      );
+    }
+  });
+  server.on("connection", (socket) => {
+    connections += 1;
+    socket.once("close", socketClosed);
+  });
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  onTestFinished(async () => {
+    server.closeAllConnections();
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  });
+  const address = server.address();
+  if (address === null || typeof address === "string") {
+    throw new Error("Expected test listener");
+  }
+  return { port: address.port, paths, received, closed, connections: () => connections };
+}
+
+describe("passive extension relay tab count", () => {
+  it("counts granted pages through auth-v2 without CDP clients or debugger attachment", async () => {
+    vi.spyOn(relayAuth, "readExtensionRelayToken").mockReturnValue(token);
+    invalidateBrowserRelayAuthV2Authority();
+    onTestFinished(() => {
+      vi.restoreAllMocks();
+      invalidateBrowserRelayAuthV2Authority();
+    });
+    const relay = await startExtensionRelayServer({ port: 0, token, allowLegacyAuth: false });
+    onTestFinished(() => relay.close());
+    const send = vi.fn();
+    const extension = relay.bridge.attachExtensionSocket({ send, close: vi.fn() });
+    extension.onMessage(
+      JSON.stringify({
+        type: "hello",
+        browserVersion: "Chrome/test",
+        userAgent: "tab-count-test",
+        extensionVersion: "2",
+        tabs: [
+          { tabId: 1, title: "First", url: "https://first.example", active: true },
+          { tabId: 2, title: "Second", url: "https://second.example", active: false },
+        ],
+      }),
+    );
+    send.mockClear();
+    for (let index = 0; index < 3; index += 1) {
+      await expect(
+        countExtensionRelayTabs({ port: relay.port, token, signal: new AbortController().signal }),
+      ).resolves.toBe(2);
+    }
+    expect(relay.bridge.cdpClientCount).toBe(0);
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["resource", "wrong-resource"],
+    ["clientNonce", randomRelayNonce()],
+    ["serverProof", randomRelayNonce()],
+    ["expiresAtMs", 1],
+  ])("rejects a malformed %s before sending the client proof", async (key, value) => {
+    const fixture = await authServer({ changeChallenge: (challenge) => (challenge[key] = value) });
+    await expect(
+      countExtensionRelayTabs({ ...fixture, token, signal: new AbortController().signal }),
+    ).rejects.toThrow(/binding mismatch|did not prove/);
+    expect(fixture.paths).toEqual([BROWSER_RELAY_AUTH_CHALLENGE_PATH]);
+  });
+
+  it("rejects an invalid acceptance proof before requesting inventory", async () => {
+    const fixture = await authServer({ invalidAcceptance: true });
+    await expect(
+      countExtensionRelayTabs({ ...fixture, token, signal: new AbortController().signal }),
+    ).rejects.toThrow("acceptance proof failed");
+    expect(fixture.paths).toEqual([
+      BROWSER_RELAY_AUTH_CHALLENGE_PATH,
+      BROWSER_RELAY_AUTH_COMPLETE_PATH,
+    ]);
+  });
+
+  it("never reconnects to continue an interrupted authentication sequence", async () => {
+    const fixture = await authServer({ closeChallenge: true });
+    await expect(
+      countExtensionRelayTabs({ ...fixture, token, signal: new AbortController().signal }),
+    ).rejects.toThrow(/connection closed|socket hang up/);
+    expect(fixture.connections()).toBe(1);
+    expect(fixture.paths).toEqual([BROWSER_RELAY_AUTH_CHALLENGE_PATH]);
+  });
+
+  it("closes a pending HTTP connection when the caller cancels", async () => {
+    const fixture = await authServer({ hang: true });
+    const controller = new AbortController();
+    const result = countExtensionRelayTabs({ ...fixture, token, signal: controller.signal });
+    const rejected = expect(result).rejects.toThrow();
+    await fixture.received;
+    controller.abort();
+    await rejected;
+    await fixture.closed;
+    expect(fixture.connections()).toBe(1);
+  });
+
+  it("bounds a stalled HTTP response by the caller's timeout", async () => {
+    const fixture = await authServer({ hang: true });
+    await expect(
+      countExtensionRelayTabs({
+        ...fixture,
+        token,
+        signal: new AbortController().signal,
+        timeoutMs: 50,
+      }),
+    ).rejects.toThrow();
+    await fixture.closed;
+  });
+});

--- a/extensions/browser/src/browser/extension-relay/relay-tab-count.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-tab-count.ts
@@ -1,0 +1,177 @@
+import http from "node:http";
+import net from "node:net";
+import {
+  createRelayProof,
+  isCanonicalBase64UrlBytes,
+  randomRelayNonce,
+  relayKeyIdFromHex,
+  verifyRelayProof,
+  type BrowserRelayProofFields,
+} from "./auth-v2-crypto.js";
+import {
+  BROWSER_RELAY_AUTH_CHALLENGE_PATH,
+  BROWSER_RELAY_AUTH_COMPLETE_PATH,
+  BROWSER_RELAY_CHALLENGE_TTL_MS,
+  parseStrictJsonObject,
+} from "./auth-v2.js";
+
+/** Count granted tabs without opening CDP or attaching the Chrome debugger. */
+export async function countExtensionRelayTabs(params: {
+  port: number;
+  token: string;
+  signal: AbortSignal;
+  timeoutMs?: number;
+}): Promise<number> {
+  if (!Number.isInteger(params.port) || params.port < 1 || params.port > 65535) {
+    throw new Error("Invalid extension relay port");
+  }
+  const deadline = new AbortController();
+  const signal = AbortSignal.any([params.signal, deadline.signal]);
+  signal.throwIfAborted();
+  const timer = setTimeout(
+    () => deadline.abort(new Error("Extension relay tab count timed out")),
+    params.timeoutMs ?? BROWSER_RELAY_CHALLENGE_TTL_MS,
+  );
+  timer.unref();
+  const agent = new http.Agent({ keepAlive: true, maxSockets: 1 });
+  let connected = false;
+  // The proof authenticates a socket, not a pool. Never replay any handshake
+  // step on a replacement connection, even if the listener closes keep-alive.
+  agent.createConnection = (_options, callback) => {
+    if (connected) {
+      const closed = new net.Socket();
+      queueMicrotask(() =>
+        callback?.(new Error("Extension relay authentication connection closed"), closed),
+      );
+      return undefined;
+    }
+    connected = true;
+    return net.createConnection({ host: "127.0.0.1", port: params.port, signal });
+  };
+  const abort = () => agent.destroy();
+  signal.addEventListener("abort", abort, { once: true });
+  const request = (path: string, body?: object): Promise<string> =>
+    new Promise((resolve, reject) => {
+      signal.throwIfAborted();
+      const content = body === undefined ? "" : JSON.stringify(body);
+      const req = http.request(
+        {
+          hostname: "127.0.0.1",
+          port: params.port,
+          path,
+          method: body === undefined ? "GET" : "POST",
+          agent,
+          signal,
+          headers: {
+            "Content-Type": "application/json",
+            "Content-Length": Buffer.byteLength(content),
+          },
+        },
+        (res) => {
+          const chunks: Buffer[] = [];
+          let bytes = 0;
+          res.on("error", reject);
+          res.on("data", (chunk: Buffer) => {
+            bytes += chunk.length;
+            if (bytes > 4 * 1024 * 1024) {
+              res.destroy(new Error("Extension relay response is too large"));
+            } else {
+              chunks.push(chunk);
+            }
+          });
+          res.on("end", () => {
+            if (res.statusCode !== 200) {
+              reject(new Error(`Extension relay HTTP ${res.statusCode}`));
+              return;
+            }
+            resolve(Buffer.concat(chunks).toString("utf8"));
+          });
+        },
+      );
+      req.on("error", reject);
+      req.end(content);
+    });
+  try {
+    const keyId = relayKeyIdFromHex(params.token);
+    const clientNonce = randomRelayNonce();
+    const binding = {
+      role: "cdp",
+      transport: "connection",
+      method: "GET",
+      resource: "/json/list",
+      flow: "json-list",
+    } as const;
+    const challenge = parseStrictJsonObject(
+      await request(BROWSER_RELAY_AUTH_CHALLENGE_PATH, {
+        v: 2,
+        keyId,
+        clientNonce,
+        ...binding,
+      }),
+    );
+    const now = Date.now();
+    if (
+      !challenge ||
+      Object.keys(challenge).length !== 15 ||
+      challenge.type !== "auth.challenge" ||
+      challenge.v !== 2 ||
+      challenge.keyId !== keyId ||
+      challenge.clientNonce !== clientNonce ||
+      Object.entries(binding).some(([key, value]) => challenge[key] !== value) ||
+      !isCanonicalBase64UrlBytes(challenge.instanceId, 16) ||
+      !isCanonicalBase64UrlBytes(challenge.sessionId, 16) ||
+      !isCanonicalBase64UrlBytes(challenge.serverNonce, 32) ||
+      typeof challenge.issuedAtMs !== "number" ||
+      !Number.isSafeInteger(challenge.issuedAtMs) ||
+      typeof challenge.expiresAtMs !== "number" ||
+      !Number.isSafeInteger(challenge.expiresAtMs) ||
+      challenge.expiresAtMs <= now ||
+      challenge.issuedAtMs > now + 30_000 ||
+      challenge.expiresAtMs - challenge.issuedAtMs !== BROWSER_RELAY_CHALLENGE_TTL_MS
+    ) {
+      throw new Error("Extension relay tab count authentication binding mismatch");
+    }
+    const fields: BrowserRelayProofFields = {
+      keyId,
+      clientNonce,
+      ...binding,
+      instanceId: challenge.instanceId,
+      sessionId: challenge.sessionId,
+      serverNonce: challenge.serverNonce,
+      issuedAtMs: challenge.issuedAtMs,
+      expiresAtMs: challenge.expiresAtMs,
+    };
+    if (!verifyRelayProof(params.token, "server", fields, challenge.serverProof)) {
+      throw new Error("Extension relay did not prove the configured key");
+    }
+    const clientProof = createRelayProof(params.token, "client", fields);
+    const accepted = parseStrictJsonObject(
+      await request(BROWSER_RELAY_AUTH_COMPLETE_PATH, {
+        v: 2,
+        sessionId: fields.sessionId,
+        clientProof,
+      }),
+    );
+    if (
+      !accepted ||
+      Object.keys(accepted).length !== 4 ||
+      accepted.type !== "auth.ok" ||
+      accepted.v !== 2 ||
+      accepted.sessionId !== fields.sessionId ||
+      !verifyRelayProof(params.token, "accept", fields, accepted.acceptProof, clientProof)
+    ) {
+      throw new Error("Extension relay acceptance proof failed");
+    }
+    const tabs: unknown = JSON.parse(await request("/json/list"));
+    if (!Array.isArray(tabs)) {
+      throw new Error("Invalid extension relay tab inventory");
+    }
+    signal.throwIfAborted();
+    return tabs.filter((tab) => tab !== null && typeof tab === "object" && tab.type === "page")
+      .length;
+  } finally {
+    clearTimeout(timer);
+    signal.removeEventListener("abort", abort);
+    agent.destroy();
+  }
+}

--- a/extensions/browser/src/browser/server-context.availability.ts
+++ b/extensions/browser/src/browser/server-context.availability.ts
@@ -276,6 +276,44 @@ export function createProfileAvailability({
     signal,
     pageProbe,
   ) => {
+    if (capabilities.mode === "local-extension" && pageProbe) {
+      // Profile status must consume discovery metadata, never CDP target
+      // enumeration: the latter attaches Chrome's debugger even while idle.
+      const relay = await ensureExtensionRelay(signal);
+      if (!relay || state().extensionRelays?.get(profile.name) !== relay) {
+        return false;
+      }
+      if (relay.ownership === "owned") {
+        const ready = relay.bridge.extensionConnected;
+        pageProbe.onResult(ready ? relay.bridge.accessibleTabs().length : 0);
+        return ready;
+      }
+      const probeSignal = AbortSignal.any([
+        ...(signal ? [signal] : []),
+        AbortSignal.timeout(resolveTimeouts(timeoutMs).httpTimeoutMs),
+      ]);
+      const ready = await waitForProfileOperation(relay.client.status(), probeSignal);
+      if (state().extensionRelays?.get(profile.name) !== relay) {
+        return false;
+      }
+      let tabCount = 0;
+      if (ready.ready) {
+        const { countExtensionRelayTabs } = await import("./extension-relay/relay-tab-count.js");
+        relay.client.assertCurrent();
+        tabCount = await countExtensionRelayTabs({
+          port: relay.port,
+          token: relay.token,
+          signal: probeSignal,
+        });
+      }
+      probeSignal.throwIfAborted();
+      relay.client.assertCurrent();
+      if (state().extensionRelays?.get(profile.name) !== relay) {
+        return false;
+      }
+      pageProbe.onResult(tabCount);
+      return ready.ready;
+    }
     if (capabilities.usesChromeMcp) {
       assertChromeMcpCdpTransportAllowed(profile, getCdpReachabilityPolicy());
       const { ensureChromeMcpAvailable } = await getChromeMcpModule();

--- a/extensions/browser/src/browser/server-context.extension-status.test.ts
+++ b/extensions/browser/src/browser/server-context.extension-status.test.ts
@@ -24,7 +24,7 @@ vi.mock("./pw-ai-module.js", () => ({
 
 const cleanups: Array<() => Promise<void>> = [];
 afterEach(async () => {
-  for (const cleanup of cleanups.splice(0).reverse()) {
+  for (const cleanup of cleanups.splice(0).toReversed()) {
     await cleanup();
   }
   vi.restoreAllMocks();

--- a/extensions/browser/src/browser/server-context.extension-status.test.ts
+++ b/extensions/browser/src/browser/server-context.extension-status.test.ts
@@ -1,0 +1,200 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import "./server-context.chrome-test-harness.js";
+import { relayTestKey } from "../../chrome-extension/relay-key.test-support.js";
+import { RelayOwnerClient } from "./extension-relay/owner-client.js";
+import type { ExtensionRelayResource } from "./extension-relay/relay-access.js";
+import { startExtensionRelayServer } from "./extension-relay/relay-server.js";
+import { registerBrowserBasicRoutes } from "./routes/basic.js";
+import { createBrowserRouteApp, createBrowserRouteResponse } from "./routes/test-helpers.js";
+import { createBrowserRouteContext } from "./server-context.js";
+import { makeBrowserProfile, makeBrowserServerState } from "./server-context.test-harness.js";
+
+const mocks = vi.hoisted(() => ({ ensure: vi.fn(), listPages: vi.fn(), readToken: vi.fn() }));
+vi.mock("./extension-relay/relay-auth.js", () => ({
+  readExtensionRelayToken: mocks.readToken,
+}));
+vi.mock("./extension-relay.runtime.js", () => ({
+  getExtensionRelayModule: async () => ({
+    ensureExtensionRelayForProfile: mocks.ensure,
+  }),
+}));
+vi.mock("./pw-ai-module.js", () => ({
+  getPwAiModule: async () => ({ listPagesViaPlaywright: mocks.listPages }),
+}));
+
+const cleanups: Array<() => Promise<void>> = [];
+afterEach(async () => {
+  for (const cleanup of cleanups.splice(0).reverse()) {
+    await cleanup();
+  }
+  vi.restoreAllMocks();
+  vi.clearAllMocks();
+});
+
+async function createFixture(ownership: "owned" | "borrowed", connected = true) {
+  mocks.readToken.mockReturnValue(relayTestKey(11));
+  const owned = await startExtensionRelayServer({
+    port: 0,
+    profileName: "chrome",
+    token: relayTestKey(11),
+    allowLegacyAuth: false,
+  });
+  cleanups.push(() => owned.close());
+  const socket = { send: vi.fn(), close: vi.fn() };
+  const extension = owned.bridge.attachExtensionSocket(socket);
+  if (connected) {
+    extension.onMessage(
+      JSON.stringify({
+        type: "hello",
+        userAgent: "status-test",
+        browserVersion: "Chrome/test",
+        extensionVersion: "2",
+        tabs: [
+          { tabId: 1, url: "https://one.example/", title: "One", active: true },
+          { tabId: 2, url: "https://two.example/", title: "Two", active: false },
+        ],
+      }),
+    );
+  }
+  let relay: ExtensionRelayResource = owned;
+  if (ownership === "borrowed") {
+    const client = await RelayOwnerClient.connect({
+      port: owned.port,
+      profile: "chrome",
+      token: owned.token,
+      signal: AbortSignal.timeout(5_000),
+    });
+    relay = {
+      ownership,
+      port: owned.port,
+      token: owned.token,
+      allowLegacyAuth: false,
+      client,
+      close: () => client.close(),
+    };
+    cleanups.push(() => client.close());
+  }
+  const profile = makeBrowserProfile({
+    name: "chrome",
+    driver: "extension",
+    attachOnly: true,
+    cdpPort: owned.port,
+    cdpUrl: `http://127.0.0.1:${owned.port}`,
+  });
+  const state = makeBrowserServerState({
+    profile,
+    resolvedOverrides: {
+      extensionRelayPorts: { chrome: owned.port },
+      extensionRelay: { allowLegacyAuth: false },
+    },
+  });
+  state.extensionRelays = new Map([["chrome", relay]]);
+  mocks.ensure.mockResolvedValue(relay);
+  mocks.listPages.mockResolvedValue([
+    { targetId: "target-1", type: "page", url: "https://one.example/", title: "One" },
+    { targetId: "target-2", type: "page", url: "https://two.example/", title: "Two" },
+  ]);
+  const ctx = createBrowserRouteContext({ getState: () => state });
+  const profileCtx = ctx.forProfile("chrome");
+  const runtime = state.profiles.get("chrome")!;
+  runtime.lastTargetId = "selected-target";
+  runtime.tabAliases = {
+    nextTabNumber: 2,
+    byTargetId: {
+      "selected-target": { tabId: "tab-1", label: "Selected" },
+    },
+  };
+  const { app, getHandlers } = createBrowserRouteApp();
+  registerBrowserBasicRoutes(app, ctx);
+  const status = async () => {
+    const response = createBrowserRouteResponse();
+    await getHandlers.get("/profiles")!({ params: {}, query: {} }, response.res);
+    expect(response.statusCode).toBe(200);
+    return response.body;
+  };
+  return { owned, relay, state, runtime, socket, status, profileCtx, extension };
+}
+
+describe("extension profile status", () => {
+  it.each(["owned", "borrowed"] as const)(
+    "counts tabs through GET /profiles without attaching or changing selection (%s relay)",
+    async (ownership) => {
+      const fixture = await createFixture(ownership);
+      const aliases = structuredClone(fixture.runtime.tabAliases);
+      for (let attempt = 0; attempt < 3; attempt += 1) {
+        expect(await fixture.status()).toMatchObject({
+          profiles: [{ name: "chrome", running: true, tabCount: 2 }],
+        });
+        expect(mocks.listPages).not.toHaveBeenCalled();
+        expect(fixture.owned.bridge.cdpClientCount).toBe(0);
+        expect(fixture.socket.send).not.toHaveBeenCalled();
+        expect(fixture.runtime.lastTargetId).toBe("selected-target");
+        expect(fixture.runtime.tabAliases).toEqual(aliases);
+      }
+      fixture.extension.onMessage(JSON.stringify({ type: "tabs", tabs: [] }));
+      expect(await fixture.status()).toMatchObject({ profiles: [{ running: true, tabCount: 0 }] });
+    },
+  );
+
+  it.each(["owned", "borrowed"] as const)("reports a disconnected %s relay", async (ownership) => {
+    const fixture = await createFixture(ownership, false);
+    expect(await fixture.status()).toMatchObject({ profiles: [{ running: false, tabCount: 0 }] });
+    expect(mocks.listPages).not.toHaveBeenCalled();
+    expect(fixture.socket.send).not.toHaveBeenCalled();
+  });
+
+  it("keeps explicit tab enumeration on Playwright with authoritative target IDs", async () => {
+    const fixture = await createFixture("owned");
+    const tabs = await fixture.profileCtx.listTabs();
+    expect(mocks.listPages).toHaveBeenCalledOnce();
+    expect(tabs.map((tab) => tab.targetId)).toEqual(["target-1", "target-2"]);
+  });
+
+  it("does not publish status from a replaced borrowed relay", async () => {
+    const fixture = await createFixture("borrowed");
+    if (fixture.relay.ownership !== "borrowed") {
+      throw new Error("expected borrowed relay");
+    }
+    const status = fixture.relay.client.status.bind(fixture.relay.client);
+    vi.spyOn(fixture.relay.client, "status").mockImplementation(async () => {
+      const ready = await status();
+      fixture.state.extensionRelays?.delete("chrome");
+      return ready;
+    });
+    const onResult = vi.fn();
+    await expect(
+      fixture.profileCtx.isTransportAvailable(1_000, undefined, { onResult }),
+    ).resolves.toBe(false);
+    expect(onResult).not.toHaveBeenCalled();
+    expect(fixture.socket.send).not.toHaveBeenCalled();
+  });
+
+  it("cancels a borrowed status wait without publishing an observation", async () => {
+    const fixture = await createFixture("borrowed");
+    if (fixture.relay.ownership !== "borrowed") {
+      throw new Error("expected borrowed relay");
+    }
+    let entered!: () => void;
+    const waiting = new Promise<void>((resolve) => {
+      entered = resolve;
+    });
+    const originalStatus = fixture.relay.client.status.bind(fixture.relay.client);
+    let finish!: (value: Awaited<ReturnType<typeof originalStatus>>) => void;
+    vi.spyOn(fixture.relay.client, "status").mockImplementation(() => {
+      entered();
+      return new Promise((resolve) => {
+        finish = resolve;
+      });
+    });
+    const controller = new AbortController();
+    const onResult = vi.fn();
+    const result = fixture.profileCtx.isTransportAvailable(1_000, controller.signal, { onResult });
+    const rejected = expect(result).rejects.toThrow("status cancelled");
+    await waiting;
+    controller.abort(new Error("status cancelled"));
+    await rejected;
+    finish(await originalStatus());
+    expect(onResult).not.toHaveBeenCalled();
+    expect(fixture.socket.send).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/browser/src/browser/server-context.ts
+++ b/extensions/browser/src/browser/server-context.ts
@@ -277,11 +277,15 @@ export function createBrowserRouteContext(opts: ContextOptions): BrowserRouteCon
               let activeRunning: boolean;
               let activeTabCount = 0;
 
-              if (capabilities.usesChromeMcp) {
+              if (capabilities.usesChromeMcp || capabilities.mode === "local-extension") {
                 try {
-                  activeRunning = await profileCtx.isTransportAvailable(300, signal, {
-                    onResult: (observedTabCount) => (activeTabCount = observedTabCount ?? 0),
-                  });
+                  activeRunning = await profileCtx.isTransportAvailable(
+                    capabilities.usesChromeMcp ? 300 : current.resolved.remoteCdpTimeoutMs,
+                    signal,
+                    {
+                      onResult: (observedTabCount) => (activeTabCount = observedTabCount ?? 0),
+                    },
+                  );
                 } catch {
                   activeRunning = false;
                 }
@@ -301,14 +305,11 @@ export function createBrowserRouteContext(opts: ContextOptions): BrowserRouteCon
                   })
                     ? 200
                     : current.resolved.remoteCdpTimeoutMs;
-                  activeRunning =
-                    capabilities.mode === "local-extension"
-                      ? await profileCtx.isTransportAvailable(probeTimeoutMs, signal)
-                      : await isChromeReachable(
-                          activeProfile.cdpUrl,
-                          probeTimeoutMs,
-                          resolveCdpReachabilityPolicy(activeProfile, current.resolved.ssrfPolicy),
-                        );
+                  activeRunning = await isChromeReachable(
+                    activeProfile.cdpUrl,
+                    probeTimeoutMs,
+                    resolveCdpReachabilityPolicy(activeProfile, current.resolved.ssrfPolicy),
+                  );
                   if (activeRunning) {
                     const tabs = await profileCtx.listTabs({ signal }).catch(() => []);
                     activeTabCount = tabs.filter((tab) => tab.type === "page").length;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users checking browser profile status would see Chrome report that OpenClaw was debugging the browser even when no browser task was running. Repeated `openclaw browser profiles --json` calls could establish a persistent debugger connection just to count tabs.

## Why This Change Was Made

Extension profile status now reads passive tab metadata instead of running Playwright target enumeration. For a relay owned by another OpenClaw process, it uses the existing connection-bound auth-v2 `/json/list` flow, preserving the shipped strict owner protocol. Explicit tab operations still use authoritative CDP target IDs.

## User Impact

Users can inspect profile status and tab counts without attaching the Chrome debugger or changing tab aliases and sticky selection. Both locally owned and shared relays are covered.

## Evidence

### Real Chrome verification using the submitted source

Verified on macOS with the existing Chrome 152 connection and OpenClaw extension 2.3.0, with `allowLegacyAuth: false`. This runs the actual production TypeScript from commit `8a92810e6bdc367d430fb08c0fdb77ef63de41a7`, with no module mocks, no replacement status/count functions, and no installed-code hotfix standing in for the PR implementation.

A temporary loopback HTTP server registered the production `registerBrowserBasicRoutes` with `createBrowserRouteContext` and production config resolution. HTTP `GET /profiles` therefore executed the submitted `listProfiles` / `isTransportAvailable` path and, for borrowed relays, the new `countExtensionRelayTabs` HTTP client. The diagnostic server was scoped to the existing extension profile so unrelated browser profiles were not probed.

| Live topology | Repeated HTTP polls | Result on every poll |
| --- | ---: | --- |
| PR-source client borrowing the installed 2026.9.4 Gateway relay | 5 | running=true, 6 tabs, legacy auth=false, selection unchanged |
| PR-source process owning the relay, connected to the real Chrome extension | 5 | running=true, 6 tabs, legacy auth=false, selection unchanged, **0 CDP clients, 0 attached targets** |
| Second PR-source process borrowing that PR-source owner's relay | 5 | running=true, 6 tabs, legacy auth=false, selection unchanged |

For the owned run, the source process briefly took over the same local relay port; the installed Gateway was restarted and forwarded the existing extension connection through the authenticated owner channel. After verification the source processes closed their leases/listener and the installed Gateway regained relay ownership. Browser tabs and pairing were preserved.

Chrome's debugger banner was absent when inspected through native macOS accessibility before verification and after the PR-source owned/borrowed runs. This inspection did not create a CDP connection. The owned relay's diagnostics above independently confirm that polling created no CDP clients or attached targets. Private tab addresses, titles, and credentials are omitted from the evidence.

<details>
<summary>Captured runtime output and source identity</summary>

```jsonl
{"topology": "borrowed_shipped_owner"}
{"event": "GET /profiles", "poll": 1, "ownership": "borrowed", "running": true, "tabCount": 6, "legacyAuth": false, "selectionUnchanged": true}
{"event": "GET /profiles", "poll": 2, "ownership": "borrowed", "running": true, "tabCount": 6, "legacyAuth": false, "selectionUnchanged": true}
{"event": "GET /profiles", "poll": 3, "ownership": "borrowed", "running": true, "tabCount": 6, "legacyAuth": false, "selectionUnchanged": true}
{"event": "GET /profiles", "poll": 4, "ownership": "borrowed", "running": true, "tabCount": 6, "legacyAuth": false, "selectionUnchanged": true}
{"event": "GET /profiles", "poll": 5, "ownership": "borrowed", "running": true, "tabCount": 6, "legacyAuth": false, "selectionUnchanged": true}
{"topology": "owned_pr_source"}
{"event": "GET /profiles", "poll": 1, "ownership": "owned", "running": true, "tabCount": 6, "legacyAuth": false, "selectionUnchanged": true, "cdpClients": 0, "attachedTargets": 0}
{"event": "GET /profiles", "poll": 2, "ownership": "owned", "running": true, "tabCount": 6, "legacyAuth": false, "selectionUnchanged": true, "cdpClients": 0, "attachedTargets": 0}
{"event": "GET /profiles", "poll": 3, "ownership": "owned", "running": true, "tabCount": 6, "legacyAuth": false, "selectionUnchanged": true, "cdpClients": 0, "attachedTargets": 0}
{"event": "GET /profiles", "poll": 4, "ownership": "owned", "running": true, "tabCount": 6, "legacyAuth": false, "selectionUnchanged": true, "cdpClients": 0, "attachedTargets": 0}
{"event": "GET /profiles", "poll": 5, "ownership": "owned", "running": true, "tabCount": 6, "legacyAuth": false, "selectionUnchanged": true, "cdpClients": 0, "attachedTargets": 0}
{"topology": "borrowed_pr_source_owner"}
{"event": "GET /profiles", "poll": 1, "ownership": "borrowed", "running": true, "tabCount": 6, "legacyAuth": false, "selectionUnchanged": true}
{"event": "GET /profiles", "poll": 2, "ownership": "borrowed", "running": true, "tabCount": 6, "legacyAuth": false, "selectionUnchanged": true}
{"event": "GET /profiles", "poll": 3, "ownership": "borrowed", "running": true, "tabCount": 6, "legacyAuth": false, "selectionUnchanged": true}
{"event": "GET /profiles", "poll": 4, "ownership": "borrowed", "running": true, "tabCount": 6, "legacyAuth": false, "selectionUnchanged": true}
{"event": "GET /profiles", "poll": 5, "ownership": "borrowed", "running": true, "tabCount": 6, "legacyAuth": false, "selectionUnchanged": true}
```

The 3 production files loaded by these runs were byte-compared with the submitted commit. SHA-256:

```text
0ffb24672ba5a1219a8708f2b1073101545bc1e13be143e93b8330d30fa6d267  server-context.ts
9f4ab594586296324d03f9e896179dc4ef781924779b5eb25184710665e49fea  server-context.availability.ts
10daebc57cc04cf3266faeef4247397cc1fe79efa19dd90ff5749bec328840ac  extension-relay/relay-tab-count.ts
```

</details>

<details>
<summary>Temporary live verification driver (not committed, no mocks)</summary>

Run from the source checkout using `node --import ./scripts/tsx.mjs /path/to/browser-live-proof.mts`. Normal invocation borrows the live relay. `PROOF_OWNERSHIP=owned PROOF_WAIT_FOR_PORT=1 PROOF_HOLD=1` prepares the owner process before the controlled service restart, waits for the real extension, and holds ownership for the second borrowing process. The driver reads the existing host-local relay credential through production code and never prints it.

```typescript
import assert from 'node:assert/strict';
import crypto from 'node:crypto';
import fs from 'node:fs';
import { createRequire } from 'node:module';
import path from 'node:path';
import net from 'node:net';
import { pathToFileURL } from 'node:url';
import { setTimeout as delay } from 'node:timers/promises';

const root = process.cwd();
const source = (name: string) => import(pathToFileURL(path.join(root, 'extensions/browser/src/browser', name)).href);
const [{ resolveBrowserConfig }, { createBrowserRouteContext }, { registerBrowserBasicRoutes }, { stopExtensionRelays }] = await Promise.all([
  source('config.ts'), source('server-context.ts'), source('routes/basic.ts'), source('extension-relay/relay-lifecycle.ts'),
]);
const require = createRequire(path.join(root, 'extensions/browser/package.json'));
const express = require('express');
const cfg = { enabled: true, defaultProfile: 'chrome', extensionRelay: { allowLegacyAuth: false }, profiles: { chrome: { driver: 'extension', color: '#FF4500', cdpPort: Number(process.env.PROOF_RELAY_PORT ?? 18799) } } };
const resolved = resolveBrowserConfig(cfg);
// Scope this diagnostic server to the paired extension; never probe other browser profiles.
resolved.profiles = { chrome: resolved.profiles.chrome };
const state = { resolved, profiles: new Map(), port: 0, server: null };
const context = createBrowserRouteContext({ getState: () => state });
const app = express();
registerBrowserBasicRoutes(app, context);
const server = app.listen(0, '127.0.0.1');
await new Promise<void>((resolve) => server.once('listening', resolve));
const url = `http://127.0.0.1:${server.address().port}/profiles`;
const sources = ['server-context.ts', 'server-context.availability.ts', 'extension-relay/relay-tab-count.ts'];
console.log(JSON.stringify({ event: 'source', files: Object.fromEntries(sources.map(name => [name, crypto.createHash('sha256').update(fs.readFileSync(path.join(root, 'extensions/browser/src/browser', name))).digest('hex')])) }));
try {
  if (process.env.PROOF_WAIT_FOR_PORT === '1') {
    console.log(JSON.stringify({ event: 'ready_for_gateway_stop' }));
    const deadline = Date.now() + 120000;
    while (Date.now() < deadline) {
      const occupied = await new Promise<boolean>(resolve => {
        const socket = net.connect({host:'127.0.0.1',port:cfg.profiles.chrome.cdpPort});
        socket.once('connect', () => { socket.destroy(); resolve(true); });
        socket.once('error', () => { socket.destroy(); resolve(false); });
      });
      if (!occupied) break;
      await delay(25);
    }
  }
  const profile = context.forProfile('chrome');
  await profile.isTransportAvailable(1500, AbortSignal.timeout(10000));
  const relay = state.extensionRelays.get('chrome');
  assert.equal(relay.ownership, process.env.PROOF_OWNERSHIP ?? 'borrowed');
  if (relay.ownership === 'owned') {
    console.log(JSON.stringify({ event: 'waiting_for_extension', port: relay.port }));
    assert.equal(await relay.bridge.waitForExtensionConnection(AbortSignal.timeout(180000), 180000), true);
  }
  const runtime = state.profiles.get('chrome');
  const before = JSON.stringify({ aliases: runtime.tabAliases, target: runtime.lastTargetId });
  for (let poll = 1; poll <= 5; poll++) {
    const response = await fetch(url);
    assert.equal(response.status, 200);
    const { profiles } = await response.json();
    assert.equal(profiles.length, 1);
    const status = profiles[0];
    assert.equal(status.running, true);
    assert.ok(status.tabCount > 0);
    assert.equal(JSON.stringify({ aliases: runtime.tabAliases, target: runtime.lastTargetId }), before);
    const ownerStatus = relay.ownership === 'borrowed' ? await relay.client.status() : null;
    console.log(JSON.stringify({ event: 'GET /profiles', poll, ownership: relay.ownership, running: status.running, tabCount: status.tabCount, legacyAuth: ownerStatus?.allowLegacyAuth ?? relay.allowLegacyAuth, selectionUnchanged: true, ...(relay.ownership === 'owned' ? { cdpClients: relay.bridge.cdpClientCount, attachedTargets: relay.bridge.devtoolsTargetDescriptors().filter(t => !t.id.startsWith('tab-')).length } : {}) }));
    await delay(1000);
  }
  console.log(JSON.stringify({ event: 'polls_complete' }));
  if (process.env.PROOF_HOLD === '1') {
    await new Promise<void>(resolve => { process.once('SIGTERM', resolve); process.once('SIGINT', resolve); });
  }
} finally {
  await stopExtensionRelays(state);
  await new Promise<void>(resolve => server.close(() => resolve()));
  console.log(JSON.stringify({ event: 'closed', relaysRemaining: state.extensionRelays?.size ?? 0 }));
}
```

</details>

### Regression tests and checks

- The registered `GET /profiles` regression failed on the original implementation for both owned and borrowed relays because status called Playwright. With the patch it preserves counts, aliases, and selection without active enumeration. Explicit tab enumeration is separately covered.
- `pnpm test:extension browser`: **4,046 passed, 41 skipped** (243 test files passed, 7 skipped).
- Follow-up: **16/16 targeted tests passed** after fixing all 5 test lint findings reported by CI. The repository oxlint wrapper with the extension tsconfig now passes on both changed test files; no lint rules were suppressed.
- Extension production/test typechecks, formatting, dependency/boundary guards, and dead-export scans passed locally. The earlier local declaration-artifact preparation failure is recorded in the initial submission; the follow-up targeted lint run completed successfully.
- Independent P0–P2 reviews of the production patch and the test follow-up found no actionable defects.
- [Current-head CI passed](https://github.com/openclaw/openclaw/actions/runs/34687433834) at `8a92810e6bdc367d430fb08c0fdb77ef63de41a7`, including build-artifacts, lint/typechecks, baseline ratchets, and `openclaw/ci-gate`. A rebuilt Mac app was not needed for the source-level live verification above.
