### PR TITLE
refactor(paths): centralize home directory resolution

### DIFF
--- a/packages/normalization-core/package.json
+++ b/packages/normalization-core/package.json
@@ -49,6 +49,11 @@
       "import": "./dist/expect.mjs",
       "default": "./dist/expect.mjs"
     },
+    "./home-dir": {
+      "types": "./dist/home-dir.d.mts",
+      "import": "./dist/home-dir.mjs",
+      "default": "./dist/home-dir.mjs"
+    },
     "./json-coercion": {
       "types": "./dist/json-coercion.d.mts",
       "import": "./dist/json-coercion.mjs",
@@ -126,7 +131,7 @@
     }
   },
   "scripts": {
-    "build": "tsdown src/index.ts src/agent-id.ts src/agent-run-terminal-outcome.ts src/boolean-coercion.ts src/cjk-chars.ts src/code-points.ts src/error-coercion.ts src/expect.ts src/json-coercion.ts src/json-schema.ts src/markdown-plain-text.ts src/mountinfo-path.ts src/node-crypto.ts src/number-coercion.ts src/phone-presentation.ts src/promise-like.ts src/record-coerce.ts src/result.ts src/stable-node-path.ts src/stable-stringify.ts src/string-coerce.ts src/string-normalization.ts src/utf16-slice.ts --no-config --platform node --format esm --dts --out-dir dist --clean"
+    "build": "tsdown src/index.ts src/agent-id.ts src/agent-run-terminal-outcome.ts src/boolean-coercion.ts src/cjk-chars.ts src/code-points.ts src/error-coercion.ts src/expect.ts src/home-dir.ts src/json-coercion.ts src/json-schema.ts src/markdown-plain-text.ts src/mountinfo-path.ts src/node-crypto.ts src/number-coercion.ts src/phone-presentation.ts src/promise-like.ts src/record-coerce.ts src/result.ts src/stable-node-path.ts src/stable-stringify.ts src/string-coerce.ts src/string-normalization.ts src/utf16-slice.ts --no-config --platform node --format esm --dts --out-dir dist --clean"
   },
   "dependencies": {
     "libphonenumber-js": "1.13.12",

--- a/packages/normalization-core/src/home-dir.test.ts
+++ b/packages/normalization-core/src/home-dir.test.ts
@@ -3,6 +3,15 @@ import { describe, expect, it } from "vitest";
 import { resolveEffectiveHomeDir } from "./home-dir.js";
 
 describe("resolveEffectiveHomeDir", () => {
+  it("preserves raw fallback separators until after tilde substitution", () => {
+    const env = {
+      HOME: "/home/alice/",
+      OPENCLAW_HOME: "~\\svc",
+    } as NodeJS.ProcessEnv;
+
+    expect(resolveEffectiveHomeDir(env, () => "/fallback")).toBe(path.resolve("/home/alice/\\svc"));
+  });
+
   it("preserves terminal display fallback for unresolved tilde homes", () => {
     const env = { OPENCLAW_HOME: "~" } as NodeJS.ProcessEnv;
     const unavailableHome = () => {

--- a/packages/normalization-core/src/home-dir.test.ts
+++ b/packages/normalization-core/src/home-dir.test.ts
@@ -1,0 +1,17 @@
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { resolveEffectiveHomeDir } from "./home-dir.js";
+
+describe("resolveEffectiveHomeDir", () => {
+  it("preserves terminal display fallback for unresolved tilde homes", () => {
+    const env = { OPENCLAW_HOME: "~" } as NodeJS.ProcessEnv;
+    const unavailableHome = () => {
+      throw new Error("missing home");
+    };
+
+    expect(resolveEffectiveHomeDir(env, unavailableHome)).toBeUndefined();
+    expect(resolveEffectiveHomeDir(env, unavailableHome, { preserveUnresolvedTilde: true })).toBe(
+      path.resolve("~"),
+    );
+  });
+});

--- a/packages/normalization-core/src/home-dir.ts
+++ b/packages/normalization-core/src/home-dir.ts
@@ -52,7 +52,7 @@ export function resolveEffectiveHomeDir(
     return resolveOsHomeDir(env, homedir);
   }
   if (explicitHome === "~" || explicitHome.startsWith("~/") || explicitHome.startsWith("~\\")) {
-    const osHome = resolveOsHomeDir(env, homedir);
+    const osHome = resolveRawOsHomeDir(env, homedir);
     if (!osHome) {
       return options?.preserveUnresolvedTilde ? path.resolve(explicitHome) : undefined;
     }

--- a/packages/normalization-core/src/home-dir.ts
+++ b/packages/normalization-core/src/home-dir.ts
@@ -1,0 +1,62 @@
+import os from "node:os";
+import path from "node:path";
+
+export function normalizeHomeDirValue(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed && trimmed !== "undefined" && trimmed !== "null" ? trimmed : undefined;
+}
+
+function normalizeSafe(homedir: () => string): string | undefined {
+  try {
+    return normalizeHomeDirValue(homedir());
+  } catch {
+    return undefined;
+  }
+}
+
+function resolveTermuxHome(env: NodeJS.ProcessEnv): string | undefined {
+  const prefix = normalizeHomeDirValue(env.PREFIX);
+  if (!prefix || !normalizeHomeDirValue(env.ANDROID_DATA)) {
+    return undefined;
+  }
+  if (!/(?:^|\/)com\.termux\/files\/usr\/?$/u.test(prefix.replace(/\\/gu, "/"))) {
+    return undefined;
+  }
+  return path.resolve(prefix, "..", "home");
+}
+
+function resolveRawOsHomeDir(env: NodeJS.ProcessEnv, homedir: () => string): string | undefined {
+  return (
+    normalizeHomeDirValue(env.HOME) ??
+    normalizeHomeDirValue(env.USERPROFILE) ??
+    resolveTermuxHome(env) ??
+    normalizeSafe(homedir)
+  );
+}
+
+export function resolveOsHomeDir(
+  env: NodeJS.ProcessEnv = process.env,
+  homedir: () => string = os.homedir,
+): string | undefined {
+  const raw = resolveRawOsHomeDir(env, homedir);
+  return raw ? path.resolve(raw) : undefined;
+}
+
+export function resolveEffectiveHomeDir(
+  env: NodeJS.ProcessEnv = process.env,
+  homedir: () => string = os.homedir,
+  options?: { preserveUnresolvedTilde?: boolean },
+): string | undefined {
+  const explicitHome = normalizeHomeDirValue(env.OPENCLAW_HOME);
+  if (!explicitHome) {
+    return resolveOsHomeDir(env, homedir);
+  }
+  if (explicitHome === "~" || explicitHome.startsWith("~/") || explicitHome.startsWith("~\\")) {
+    const osHome = resolveOsHomeDir(env, homedir);
+    if (!osHome) {
+      return options?.preserveUnresolvedTilde ? path.resolve(explicitHome) : undefined;
+    }
+    return path.resolve(explicitHome.replace(/^~(?=$|[\\/])/, () => osHome));
+  }
+  return path.resolve(explicitHome);
+}

--- a/packages/normalization-core/src/index.ts
+++ b/packages/normalization-core/src/index.ts
@@ -7,6 +7,7 @@ export * from "./code-points.js";
 export * from "./error-coercion.js";
 export * from "./expect.js";
 export * from "./format.js";
+export * from "./home-dir.js";
 export * from "./json-coercion.js";
 export * from "./number-coercion.js";
 export * from "./record-coerce.js";

--- a/packages/normalization-core/src/index.ts
+++ b/packages/normalization-core/src/index.ts
@@ -7,7 +7,6 @@ export * from "./code-points.js";
 export * from "./error-coercion.js";
 export * from "./expect.js";
 export * from "./format.js";
-export * from "./home-dir.js";
 export * from "./json-coercion.js";
 export * from "./number-coercion.js";
 export * from "./record-coerce.js";

--- a/packages/terminal-core/src/display-string.ts
+++ b/packages/terminal-core/src/display-string.ts
@@ -1,8 +1,6 @@
 import os from "node:os";
-import {
-  lowercasePreservingWhitespace,
-  resolveEffectiveHomeDir,
-} from "@openclaw/normalization-core";
+import { lowercasePreservingWhitespace } from "@openclaw/normalization-core";
+import { resolveEffectiveHomeDir } from "@openclaw/normalization-core/home-dir";
 
 // Display-safe string helpers for shortening user home paths.
 

--- a/packages/terminal-core/src/display-string.ts
+++ b/packages/terminal-core/src/display-string.ts
@@ -1,71 +1,16 @@
 import os from "node:os";
-import path from "node:path";
-import { lowercasePreservingWhitespace } from "@openclaw/normalization-core/string-coerce";
+import {
+  lowercasePreservingWhitespace,
+  resolveEffectiveHomeDir,
+} from "@openclaw/normalization-core";
 
 // Display-safe string helpers for shortening user home paths.
 
-/** Normalize env/home values and reject shell placeholder strings. */
-function normalize(value: string | undefined): string | undefined {
-  const trimmed = value?.trim();
-  return trimmed && trimmed !== "undefined" && trimmed !== "null" ? trimmed : undefined;
-}
-
-/** Run a home resolver defensively because some runtimes throw for missing passwd data. */
-function normalizeSafe(fn: () => string | undefined): string | undefined {
-  try {
-    return normalize(fn());
-  } catch {
-    return undefined;
-  }
-}
-
-/** Resolve Termux home from its Android prefix layout. */
-function resolveTermuxHome(env: NodeJS.ProcessEnv): string | undefined {
-  const prefix = normalize(env.PREFIX);
-  if (!prefix || !normalize(env.ANDROID_DATA)) {
-    return undefined;
-  }
-  if (!/(?:^|\/)com\.termux\/files\/usr\/?$/u.test(prefix.replace(/\\/gu, "/"))) {
-    return undefined;
-  }
-  return path.resolve(prefix, "..", "home");
-}
-
-/** Resolve the underlying OS home before applying OpenClaw overrides. */
-function resolveRawOsHomeDir(env: NodeJS.ProcessEnv, homedir: () => string): string | undefined {
-  return (
-    normalize(env.HOME) ??
-    normalize(env.USERPROFILE) ??
-    resolveTermuxHome(env) ??
-    normalizeSafe(homedir)
-  );
-}
-
-/** Resolve raw home with OPENCLAW_HOME tilde expansion. */
-function resolveRawHomeDir(
-  env: NodeJS.ProcessEnv = process.env,
-  homedir: () => string = os.homedir,
-): string | undefined {
-  const explicitHome = normalize(env.OPENCLAW_HOME);
-  if (explicitHome) {
-    const fallbackHome = resolveRawOsHomeDir(env, homedir);
-    return fallbackHome ? explicitHome.replace(/^~(?=$|[\\/])/, () => fallbackHome) : explicitHome;
-  }
-  return resolveRawOsHomeDir(env, homedir);
-}
-
-/** Resolve the effective absolute home directory for display replacement. */
-function resolveEffectiveHomeDir(
-  env: NodeJS.ProcessEnv = process.env,
-  homedir: () => string = os.homedir,
-): string | undefined {
-  const raw = resolveRawHomeDir(env, homedir);
-  return raw ? path.resolve(raw) : undefined;
-}
-
 /** Resolve the display prefix that should replace the effective home path. */
 function resolveHomeDisplayPrefix(): { home: string; prefix: string } | undefined {
-  const home = resolveEffectiveHomeDir();
+  const home = resolveEffectiveHomeDir(process.env, os.homedir, {
+    preserveUnresolvedTilde: true,
+  });
   if (!home) {
     return undefined;
   }

--- a/src/infra/home-dir.ts
+++ b/src/infra/home-dir.ts
@@ -1,75 +1,14 @@
 // Resolves OpenClaw home and platform-specific config directories.
 import os from "node:os";
 import path from "node:path";
+import {
+  normalizeHomeDirValue,
+  resolveEffectiveHomeDir,
+  resolveOsHomeDir,
+} from "@openclaw/normalization-core";
 import { tryProcessCwd } from "./safe-cwd.js";
 
-function normalize(value: string | undefined): string | undefined {
-  const trimmed = value?.trim();
-  if (!trimmed || trimmed === "undefined" || trimmed === "null") {
-    return undefined;
-  }
-  return trimmed;
-}
-
-function normalizeSafe(homedir: () => string): string | undefined {
-  try {
-    return normalize(homedir());
-  } catch {
-    return undefined;
-  }
-}
-
-function resolveTermuxHome(env: NodeJS.ProcessEnv): string | undefined {
-  const prefix = normalize(env.PREFIX);
-  if (!prefix || !normalize(env.ANDROID_DATA)) {
-    return undefined;
-  }
-  // Termux exposes PREFIX under the app sandbox; other Android/chroot prefixes
-  // should not be treated as user-home evidence.
-  if (!/(?:^|\/)com\.termux\/files\/usr\/?$/u.test(prefix.replace(/\\/gu, "/"))) {
-    return undefined;
-  }
-  return path.resolve(prefix, "..", "home");
-}
-
-function resolveRawOsHomeDir(env: NodeJS.ProcessEnv, homedir: () => string): string | undefined {
-  return (
-    normalize(env.HOME) ??
-    normalize(env.USERPROFILE) ??
-    resolveTermuxHome(env) ??
-    normalizeSafe(homedir)
-  );
-}
-
-function resolveRawHomeDir(env: NodeJS.ProcessEnv, homedir: () => string): string | undefined {
-  const explicitHome = normalize(env.OPENCLAW_HOME);
-  if (!explicitHome) {
-    return resolveRawOsHomeDir(env, homedir);
-  }
-  if (explicitHome === "~" || explicitHome.startsWith("~/") || explicitHome.startsWith("~\\")) {
-    const fallbackHome = resolveRawOsHomeDir(env, homedir);
-    return fallbackHome ? explicitHome.replace(/^~(?=$|[\\/])/, () => fallbackHome) : undefined;
-  }
-  return explicitHome;
-}
-
-/** Resolves OpenClaw's effective home, honoring OPENCLAW_HOME before OS homes. */
-export function resolveEffectiveHomeDir(
-  env: NodeJS.ProcessEnv = process.env,
-  homedir: () => string = os.homedir,
-): string | undefined {
-  const raw = resolveRawHomeDir(env, homedir);
-  return raw ? path.resolve(raw) : undefined;
-}
-
-/** Resolves the underlying OS user home, ignoring OPENCLAW_HOME overrides. */
-export function resolveOsHomeDir(
-  env: NodeJS.ProcessEnv = process.env,
-  homedir: () => string = os.homedir,
-): string | undefined {
-  const raw = resolveRawOsHomeDir(env, homedir);
-  return raw ? path.resolve(raw) : undefined;
-}
+export { resolveEffectiveHomeDir, resolveOsHomeDir };
 
 /** Resolves the effective home or falls back to cwd when no home source exists. */
 export function resolveRequiredHomeDir(
@@ -112,7 +51,7 @@ export function expandHomePrefix(
     return input;
   }
   const home =
-    normalize(opts?.home) ??
+    normalizeHomeDirValue(opts?.home) ??
     resolveEffectiveHomeDir(opts?.env ?? process.env, opts?.homedir ?? os.homedir);
   if (!home) {
     return input;

--- a/src/infra/home-dir.ts
+++ b/src/infra/home-dir.ts
@@ -5,7 +5,7 @@ import {
   normalizeHomeDirValue,
   resolveEffectiveHomeDir,
   resolveOsHomeDir,
-} from "@openclaw/normalization-core";
+} from "@openclaw/normalization-core/home-dir";
 import { tryProcessCwd } from "./safe-cwd.js";
 
 export { resolveEffectiveHomeDir, resolveOsHomeDir };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -222,6 +222,9 @@
       "@openclaw/normalization-core/utf16-slice": [
         "./packages/normalization-core/src/utf16-slice.ts"
       ],
+      "@openclaw/normalization-core/home-dir": [
+        "./packages/normalization-core/src/home-dir.ts"
+      ],
       "@openclaw/normalization-core/*": ["./packages/normalization-core/src/*"],
       "@openclaw/retry": ["./packages/retry/src/index.ts"],
       "@openclaw/mermaid-renderer": ["./packages/mermaid-renderer/src/renderer.ts"],


### PR DESCRIPTION
## Summary

- make `@openclaw/normalization-core/home-dir` the Node-only owner of normalized OS/OpenClaw home selection
- reuse that owner from app infrastructure and terminal display normalization without exposing it from the browser-safe root barrel
- retain path-expansion and token-aware display policy with their existing consumers

This removes 56 net production lines.

## Compatibility

- preserves environment precedence, Termux handling, raw-fallback tilde expansion order, and display replacement
- app path resolution remains fail-closed
- required-home, cwd, path-expansion, and token-aware display behavior stay with their current owners

## Validation

- 40 focused home precedence, Termux, tilde, display, and browser-import cases
- normalization-core build and declarations
- production and all test-type shards
- `pnpm check:architecture`
- `pnpm check:changed`
- all Knip, lint, database, sidecar, webhook, pairing, and import-cycle guards
