### PR TITLE
refactor(plugins): share install policy hook sequencing

### DIFF
--- a/src/plugins/install-security-scan.runtime.ts
+++ b/src/plugins/install-security-scan.runtime.ts
@@ -890,6 +890,34 @@ async function runOperatorInstallPolicy(params: {
   };
 }
 
+type InstallPolicyAndHookRequest = Omit<
+  Parameters<typeof runBeforeInstallHook>[0],
+  "installLabel" | "origin"
+> & {
+  config?: OpenClawConfig;
+  hookOrigin: string;
+  installLabel: string;
+  onInstallPolicyWarning?: InstallSafetyOverrides["onInstallPolicyWarning"];
+  policyOrigin: InstallPolicyOrigin;
+  skipHook?: boolean;
+};
+
+async function runInstallPolicyAndHook(
+  params: InstallPolicyAndHookRequest,
+): Promise<InstallSecurityScanResult | undefined> {
+  const policyResult = await runOperatorInstallPolicy({
+    ...params,
+    origin: params.policyOrigin,
+  });
+  if (params.skipHook || policyResult?.blocked) {
+    return policyResult;
+  }
+  return await runBeforeInstallHook({
+    ...params,
+    origin: params.hookOrigin,
+  });
+}
+
 export async function scanBundleInstallSourceRuntime(
   params: InstallSafetyOverrides & {
     config?: OpenClawConfig;
@@ -903,59 +931,38 @@ export async function scanBundleInstallSourceRuntime(
     source?: InstallPolicySource;
   },
 ): Promise<InstallSecurityScanResult | undefined> {
-  const runPolicy = () =>
-    runOperatorInstallPolicy({
-      config: params.config,
-      logger: params.logger,
-      onInstallPolicyWarning: params.onInstallPolicyWarning,
-      origin: { type: "plugin-bundle", ...(params.version ? { version: params.version } : {}) },
-      source:
-        params.source ?? resolvePolicySource({ requestKind: params.requestKind ?? "plugin-dir" }),
-      sourcePath: params.sourceDir,
-      sourcePathKind: "directory",
-      targetName: params.pluginId,
-      targetType: "plugin",
-      requestKind: params.requestKind ?? "plugin-dir",
-      requestMode: params.mode ?? "install",
-      requestedSpecifier: params.requestedSpecifier,
-      plugin: {
-        contentType: "bundle",
-        pluginId: params.pluginId,
-        manifestId: params.pluginId,
-        ...(params.version ? { version: params.version } : {}),
-      },
-    });
+  const requestKind = params.requestKind ?? "plugin-dir";
+  const source = params.source ?? resolvePolicySource({ requestKind });
+  const plugin = {
+    contentType: "bundle" as const,
+    pluginId: params.pluginId,
+    manifestId: params.pluginId,
+    ...(params.version ? { version: params.version } : {}),
+  };
   await validatePackageDependencyBoundaries({
     rootDir: params.sourceDir,
   });
-  if (shouldBypassOpenClawInstallFriction({ source: params.source })) {
-    return await runPolicy();
-  }
-
-  const policyResult = await runPolicy();
-  if (policyResult?.blocked) {
-    return policyResult;
-  }
-
-  const hookResult = await runBeforeInstallHook({
+  return await runInstallPolicyAndHook({
+    config: params.config,
     logger: params.logger,
+    onInstallPolicyWarning: params.onInstallPolicyWarning,
+    policyOrigin: {
+      type: "plugin-bundle",
+      ...(params.version ? { version: params.version } : {}),
+    },
+    hookOrigin: "plugin-bundle",
     installLabel: `Bundle "${params.pluginId}" installation`,
-    origin: "plugin-bundle",
+    source,
     sourcePath: params.sourceDir,
     sourcePathKind: "directory",
     targetName: params.pluginId,
     targetType: "plugin",
-    requestKind: params.requestKind ?? "plugin-dir",
+    requestKind,
     requestMode: params.mode ?? "install",
     requestedSpecifier: params.requestedSpecifier,
-    plugin: {
-      contentType: "bundle",
-      pluginId: params.pluginId,
-      manifestId: params.pluginId,
-      ...(params.version ? { version: params.version } : {}),
-    },
+    plugin,
+    skipHook: shouldBypassOpenClawInstallFriction({ source: params.source }),
   });
-  return hookResult;
 }
 
 export async function scanPackageInstallSourceRuntime(
@@ -975,72 +982,44 @@ export async function scanPackageInstallSourceRuntime(
     trustedSourceLinkedOfficialInstall?: boolean;
   },
 ): Promise<InstallSecurityScanResult | undefined> {
-  const runPolicy = () =>
-    runOperatorInstallPolicy({
-      config: params.config,
-      logger: params.logger,
-      onInstallPolicyWarning: params.onInstallPolicyWarning,
-      origin: {
-        type: "plugin-package",
-        ...(params.packageName ? { packageName: params.packageName } : {}),
-        ...(params.version ? { version: params.version } : {}),
-      },
-      source:
-        params.source ?? resolvePolicySource({ requestKind: params.requestKind ?? "plugin-dir" }),
-      sourcePath: params.packageDir,
-      sourcePathKind: "directory",
-      targetName: params.pluginId,
-      targetType: "plugin",
-      requestKind: params.requestKind ?? "plugin-dir",
-      requestMode: params.mode ?? "install",
-      requestedSpecifier: params.requestedSpecifier,
-      plugin: {
-        contentType: "package",
-        pluginId: params.pluginId,
-        ...(params.packageName ? { packageName: params.packageName } : {}),
-        ...(params.manifestId ? { manifestId: params.manifestId } : {}),
-        ...(params.version ? { version: params.version } : {}),
-        extensions: params.extensions.slice(),
-      },
-    });
+  const requestKind = params.requestKind ?? "plugin-dir";
+  const source = params.source ?? resolvePolicySource({ requestKind });
+  const plugin = {
+    contentType: "package" as const,
+    pluginId: params.pluginId,
+    ...(params.packageName ? { packageName: params.packageName } : {}),
+    ...(params.manifestId ? { manifestId: params.manifestId } : {}),
+    ...(params.version ? { version: params.version } : {}),
+    extensions: params.extensions.slice(),
+  };
   await validatePackageDependencyBoundaries({
     rootDir: params.packageDir,
   });
-  if (
-    shouldBypassOpenClawInstallFriction({
-      source: params.source,
-      trustedSourceLinkedOfficialInstall: params.trustedSourceLinkedOfficialInstall,
-    })
-  ) {
-    return await runPolicy();
-  }
-
-  const policyResult = await runPolicy();
-  if (policyResult?.blocked) {
-    return policyResult;
-  }
-
-  const hookResult = await runBeforeInstallHook({
+  return await runInstallPolicyAndHook({
+    config: params.config,
     logger: params.logger,
+    onInstallPolicyWarning: params.onInstallPolicyWarning,
+    policyOrigin: {
+      type: "plugin-package",
+      ...(params.packageName ? { packageName: params.packageName } : {}),
+      ...(params.version ? { version: params.version } : {}),
+    },
+    hookOrigin: "plugin-package",
     installLabel: `Plugin "${params.pluginId}" installation`,
-    origin: "plugin-package",
+    source,
     sourcePath: params.packageDir,
     sourcePathKind: "directory",
     targetName: params.pluginId,
     targetType: "plugin",
-    requestKind: params.requestKind ?? "plugin-dir",
+    requestKind,
     requestMode: params.mode ?? "install",
     requestedSpecifier: params.requestedSpecifier,
-    plugin: {
-      contentType: "package",
-      pluginId: params.pluginId,
-      ...(params.packageName ? { packageName: params.packageName } : {}),
-      ...(params.manifestId ? { manifestId: params.manifestId } : {}),
-      ...(params.version ? { version: params.version } : {}),
-      extensions: params.extensions.slice(),
-    },
+    plugin,
+    skipHook: shouldBypassOpenClawInstallFriction({
+      source: params.source,
+      trustedSourceLinkedOfficialInstall: params.trustedSourceLinkedOfficialInstall,
+    }),
   });
-  return hookResult;
 }
 
 export async function scanInstalledPackageDependencyTreeRuntime(params: {
@@ -1108,11 +1087,18 @@ export async function scanFileInstallSourceRuntime(
     source?: InstallPolicySource;
   },
 ): Promise<InstallSecurityScanResult | undefined> {
-  const policyResult = await runOperatorInstallPolicy({
+  const plugin = {
+    contentType: "file" as const,
+    pluginId: params.pluginId,
+    extensions: [path.basename(params.filePath)],
+  };
+  return await runInstallPolicyAndHook({
     config: params.config,
     logger: params.logger,
     onInstallPolicyWarning: params.onInstallPolicyWarning,
-    origin: { type: "plugin-file" },
+    policyOrigin: { type: "plugin-file" },
+    hookOrigin: "plugin-file",
+    installLabel: `Plugin file "${params.pluginId}" installation`,
     source: params.source ?? resolvePolicySource({ requestKind: "plugin-file" }),
     sourcePath: params.filePath,
     sourcePathKind: "file",
@@ -1121,34 +1107,8 @@ export async function scanFileInstallSourceRuntime(
     requestKind: "plugin-file",
     requestMode: params.mode ?? "install",
     requestedSpecifier: params.requestedSpecifier,
-    plugin: {
-      contentType: "file",
-      pluginId: params.pluginId,
-      extensions: [path.basename(params.filePath)],
-    },
+    plugin,
   });
-  if (policyResult?.blocked) {
-    return policyResult;
-  }
-
-  const hookResult = await runBeforeInstallHook({
-    logger: params.logger,
-    installLabel: `Plugin file "${params.pluginId}" installation`,
-    origin: "plugin-file",
-    sourcePath: params.filePath,
-    sourcePathKind: "file",
-    targetName: params.pluginId,
-    targetType: "plugin",
-    requestKind: "plugin-file",
-    requestMode: params.mode ?? "install",
-    requestedSpecifier: params.requestedSpecifier,
-    plugin: {
-      contentType: "file",
-      pluginId: params.pluginId,
-      extensions: [path.basename(params.filePath)],
-    },
-  });
-  return hookResult;
 }
 
 export async function preflightPluginNpmInstallPolicyRuntime(params: {
@@ -1228,39 +1188,20 @@ export async function evaluateSkillInstallPolicyRuntime(params: {
   skillName: string;
   sourceDir: string;
 }): Promise<InstallSecurityScanResult | undefined> {
-  const runPolicy = () =>
-    runOperatorInstallPolicy({
-      config: params.config,
-      logger: params.logger,
-      onInstallPolicyWarning: params.onInstallPolicyWarning,
-      origin: params.origin,
-      source:
-        params.source ??
-        resolvePolicySource({ requestKind: "skill-install", origin: params.origin }),
-      sourcePath: params.sourceDir,
-      sourcePathKind: "directory",
-      targetName: params.skillName,
-      targetType: "skill",
-      requestKind: "skill-install",
-      requestMode: params.mode ?? "install",
-      requestedSpecifier: params.requestedSpecifier,
-      skill: {
-        installId: params.installId,
-        ...(params.installSpec ? { installSpec: params.installSpec } : {}),
-      },
-    });
-  if (shouldBypassOpenClawInstallFriction({ source: params.source })) {
-    return await runPolicy();
-  }
-  const policyResult = await runPolicy();
-  if (policyResult?.blocked) {
-    return policyResult;
-  }
-
-  const hookResult = await runBeforeInstallHook({
+  const source =
+    params.source ?? resolvePolicySource({ requestKind: "skill-install", origin: params.origin });
+  const skill = {
+    installId: params.installId,
+    ...(params.installSpec ? { installSpec: params.installSpec } : {}),
+  };
+  return await runInstallPolicyAndHook({
+    config: params.config,
     logger: params.logger,
+    onInstallPolicyWarning: params.onInstallPolicyWarning,
+    policyOrigin: params.origin,
+    hookOrigin: formatInstallPolicyOriginForHook(params.origin),
     installLabel: `Skill "${params.skillName}" installation`,
-    origin: formatInstallPolicyOriginForHook(params.origin),
+    source,
     sourcePath: params.sourceDir,
     sourcePathKind: "directory",
     targetName: params.skillName,
@@ -1268,11 +1209,8 @@ export async function evaluateSkillInstallPolicyRuntime(params: {
     requestKind: "skill-install",
     requestMode: params.mode ?? "install",
     requestedSpecifier: params.requestedSpecifier,
-    skill: {
-      installId: params.installId,
-      ...(params.installSpec ? { installSpec: params.installSpec } : {}),
-    },
+    skill,
+    skipHook: shouldBypassOpenClawInstallFriction({ source: params.source }),
   });
-  return hookResult;
 }
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */


### PR DESCRIPTION
## Summary

- add one private orchestrator for the repeated install policy, terminal-block, and `before_install` hook sequence
- use it for bundle, package, file, and skill installation
- leave target-specific source classification and dependency scanning local

This removes 62 net production lines.

## Compatibility

- preserves policy-before-hook ordering and acknowledgement/re-evaluation behavior
- preserves official-source bypass, dependency-boundary scans, request payloads, and failure codes
- does not change install policy or security decisions

## Validation

- 29 focused install-security tests, including escaping symlinks, terminal blocks, warning acknowledgement, official bypass, and hook ordering
- production and all test-type shards
- `pnpm check:architecture`
- `pnpm check:changed`
- all Knip, lint, database, sidecar, webhook, pairing, and import-cycle guards

