### PR TITLE
refactor(setup): share inference option projection

### DIFF
--- a/src/system-agent/setup-inference-auth-options.test.ts
+++ b/src/system-agent/setup-inference-auth-options.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, it } from "vitest";
 import type { ProviderInstallCatalogEntry } from "../plugins/provider-install-catalog.js";
 import {
   listSetupInferenceAuthOptions,
+  listSetupInferenceEnableOptions,
   listSetupInferenceInstallOptions,
+  listSetupInferenceManualProviders,
+  listSetupInferencePrepareOptions,
 } from "./setup-inference-auth-options.js";
 import { resolveCandidatePresentation } from "./setup-inference-core.js";
 
@@ -64,5 +67,60 @@ describe("setup inference install options", () => {
         ],
       ),
     ).toEqual([]);
+  });
+
+  it("preserves the shared presentation fields across guided setup surfaces", () => {
+    const choice = {
+      ...metaEntry,
+      icon: "sparkles",
+      website: "https://meta.example",
+      appGuidedAuth: "oauth" as const,
+      appGuidedSecret: true,
+      appGuidedDiscovery: true,
+      appGuidedActionLabel: "Connect Meta",
+    };
+
+    expect(listSetupInferenceAuthOptions([choice])).toEqual([
+      {
+        id: "meta-api-key",
+        brandId: "meta",
+        label: "Meta API key",
+        hint: "Meta Responses API",
+        icon: "sparkles",
+        website: "https://meta.example",
+        groupLabel: "Meta",
+        kind: "oauth",
+        featured: false,
+      },
+    ]);
+    expect(listSetupInferenceEnableOptions([choice])[0]).toMatchObject({
+      id: "meta-api-key",
+      brandId: "meta",
+      label: "Meta API key",
+      hint: "Meta Responses API",
+      icon: "sparkles",
+      website: "https://meta.example",
+      groupLabel: "Meta",
+    });
+    expect(listSetupInferenceManualProviders([choice])[0]).toMatchObject({
+      id: "meta-api-key",
+      brandId: "meta",
+      label: "Meta API key",
+      hint: "Meta Responses API",
+      icon: "sparkles",
+      website: "https://meta.example",
+      groupLabel: "Meta",
+    });
+    expect(listSetupInferencePrepareOptions([choice])).toEqual([
+      {
+        id: "meta-api-key",
+        brandId: "meta",
+        label: "Meta API key",
+        hint: "Meta Responses API",
+        icon: "sparkles",
+        website: "https://meta.example",
+        actionLabel: "Connect Meta",
+      },
+    ]);
   });
 });

--- a/src/system-agent/setup-inference-auth-options.ts
+++ b/src/system-agent/setup-inference-auth-options.ts
@@ -4,32 +4,102 @@ import { compareProviderAuthChoiceGroups } from "../plugins/provider-auth-choice
 import type { ProviderAuthChoiceMetadata } from "../plugins/provider-auth-choices.js";
 import type { ProviderInstallCatalogEntry } from "../plugins/provider-install-catalog.js";
 
-export type SetupInferenceManualProvider = {
-  /** Provider-auth choice id sent back to `openclaw.setup.activate`. */
+type SetupInferenceOptionPresentation = {
+  /** Provider-auth choice id sent back to the selected setup operation. */
   id: string;
   /** Canonical provider identity for clients with bundled brand artwork. */
   brandId?: string;
-  /** Provider family shown above the specific credential method. */
-  groupLabel?: string;
   label: string;
   hint?: string;
   icon?: string;
   website?: string;
 };
 
-export type SetupInferenceAuthOption = {
-  /** Provider-auth choice id sent to `openclaw.setup.auth.start`. */
-  id: string;
-  /** Canonical provider identity for clients with bundled brand artwork. */
-  brandId?: string;
-  label: string;
-  hint?: string;
+export type SetupInferenceManualProvider = SetupInferenceOptionPresentation & {
+  /** Provider family shown above the specific credential method. */
   groupLabel?: string;
-  icon?: string;
-  website?: string;
+};
+
+export type SetupInferenceAuthOption = SetupInferenceOptionPresentation & {
   kind: "oauth" | "device-code" | "install" | "custom";
   featured: boolean;
+  groupLabel?: string;
 };
+
+type ChoicePresentationSource = Pick<
+  ProviderAuthChoiceMetadata,
+  "choiceId" | "providerId" | "choiceLabel" | "choiceHint" | "icon" | "website"
+>;
+
+function projectChoicePresentation(
+  choice: ChoicePresentationSource,
+  id = choice.choiceId.trim(),
+): SetupInferenceOptionPresentation {
+  return {
+    id,
+    brandId: choice.providerId,
+    label: choice.choiceLabel,
+    ...(choice.choiceHint?.trim() ? { hint: choice.choiceHint.trim() } : {}),
+    ...(choice.icon ? { icon: choice.icon } : {}),
+    ...(choice.website ? { website: choice.website } : {}),
+  };
+}
+
+function compareSetupInferenceOptions(
+  a: SetupInferenceOptionPresentation & { featured?: boolean; groupLabel?: string },
+  b: SetupInferenceOptionPresentation & { featured?: boolean; groupLabel?: string },
+): number {
+  return (
+    Number(b.featured) - Number(a.featured) ||
+    compareProviderAuthChoiceGroups(
+      { id: a.brandId ?? a.id, label: a.groupLabel ?? a.label },
+      { id: b.brandId ?? b.id, label: b.groupLabel ?? b.label },
+    ) ||
+    a.label.localeCompare(b.label, "en") ||
+    a.id.localeCompare(b.id, "en")
+  );
+}
+
+function listSetupInferenceGuidedOptions<
+  TOption extends SetupInferenceOptionPresentation & { featured?: boolean },
+>(params: {
+  choices: readonly ProviderAuthChoiceMetadata[];
+  include: (choice: ProviderAuthChoiceMetadata) => boolean;
+  project: (choice: ProviderAuthChoiceMetadata, id: string) => TOption;
+}): TOption[] {
+  const options = new Map<string, { metadata: ProviderAuthChoiceMetadata; option: TOption }>();
+  for (const choice of params.choices) {
+    const id = choice.choiceId.trim();
+    if (
+      !id ||
+      options.has(id) ||
+      !supportsSetupTextInference(choice.onboardingScopes) ||
+      !params.include(choice)
+    ) {
+      continue;
+    }
+    options.set(id, { metadata: choice, option: params.project(choice, id) });
+  }
+  return [...options.values()]
+    .toSorted(
+      (a, b) =>
+        Number(b.option.featured) - Number(a.option.featured) ||
+        compareProviderAuthChoiceGroups(
+          {
+            id: a.metadata.groupId ?? a.metadata.providerId,
+            label: a.metadata.groupLabel ?? a.metadata.choiceLabel,
+          },
+          {
+            id: b.metadata.groupId ?? b.metadata.providerId,
+            label: b.metadata.groupLabel ?? b.metadata.choiceLabel,
+          },
+        ) ||
+        (a.metadata.assistantPriority ?? 0) - (b.metadata.assistantPriority ?? 0) ||
+        a.option.label.localeCompare(b.option.label, "en") ||
+        a.option.id.localeCompare(b.option.id, "en"),
+    )
+    .map(({ option }) => option);
+}
 
 export function listSetupInferenceInstallOptions(
   entries: readonly ProviderInstallCatalogEntry[],
@@ -46,37 +116,22 @@ export function listSetupInferenceInstallOptions(
       continue;
     }
     options.set(entry.choiceId, {
-      id: entry.choiceId,
-      brandId: entry.providerId,
-      label: entry.choiceLabel,
-      ...(entry.choiceHint?.trim() ? { hint: entry.choiceHint.trim() } : {}),
+      ...projectChoicePresentation({
+        choiceId: entry.choiceId,
+        providerId: entry.providerId,
+        choiceLabel: entry.choiceLabel,
+        choiceHint: entry.choiceHint,
+      }),
       ...(entry.groupLabel?.trim() ? { groupLabel: entry.groupLabel.trim() } : {}),
       kind: "install",
       featured: false,
     });
   }
-  return [...options.values()].toSorted(
-    (a, b) =>
-      Number(b.featured) - Number(a.featured) ||
-      compareProviderAuthChoiceGroups(
-        { id: a.brandId ?? a.id, label: a.groupLabel ?? a.label },
-        { id: b.brandId ?? b.id, label: b.groupLabel ?? b.label },
-      ) ||
-      a.label.localeCompare(b.label, "en") ||
-      a.id.localeCompare(b.id, "en"),
-  );
+  return [...options.values()].toSorted(compareSetupInferenceOptions);
 }
 
-export type SetupInferencePrepareOption = {
-  /** Provider-auth choice id sent to `openclaw.setup.prepare.start`. */
-  id: string;
-  /** Canonical provider identity for clients with bundled brand artwork. */
-  brandId?: string;
-  label: string;
-  hint?: string;
+export type SetupInferencePrepareOption = SetupInferenceOptionPresentation & {
   actionLabel?: string;
-  icon?: string;
-  website?: string;
 };
 
 export function supportsSetupTextInference(
@@ -99,78 +154,28 @@ export function listSetupInferenceManualProviders(
       continue;
     }
     choices.set(id, {
-      id,
-      brandId: choice.providerId,
+      ...projectChoicePresentation(choice, id),
       ...(choice.groupLabel?.trim() ? { groupLabel: choice.groupLabel.trim() } : {}),
-      label: choice.choiceLabel,
-      ...(choice.choiceHint?.trim() ? { hint: choice.choiceHint.trim() } : {}),
-      ...(choice.icon ? { icon: choice.icon } : {}),
-      ...(choice.website ? { website: choice.website } : {}),
     });
   }
-  return [...choices.values()].toSorted(
-    (a, b) =>
-      compareProviderAuthChoiceGroups(
-        { id: a.brandId ?? a.id, label: a.groupLabel ?? a.label },
-        { id: b.brandId ?? b.id, label: b.groupLabel ?? b.label },
-      ) ||
-      a.label.localeCompare(b.label, "en") ||
-      a.id.localeCompare(b.id, "en"),
-  );
+  return [...choices.values()].toSorted(compareSetupInferenceOptions);
 }
 
 export function listSetupInferenceAuthOptions(
   authChoices: readonly ProviderAuthChoiceMetadata[],
 ): SetupInferenceAuthOption[] {
-  const choices = new Map<
-    string,
-    { metadata: ProviderAuthChoiceMetadata; option: SetupInferenceAuthOption }
-  >();
-  for (const choice of authChoices) {
-    const id = choice.choiceId.trim();
-    if (
-      !id ||
-      choices.has(id) ||
-      !supportsSetupTextInference(choice.onboardingScopes) ||
-      (!choice.appGuidedAuth &&
-        (choice.appGuidedSecret === true || choice.appGuidedDiscovery === true))
-    ) {
-      continue;
-    }
-    choices.set(id, {
-      metadata: choice,
-      option: {
-        id,
-        brandId: choice.providerId,
-        label: choice.choiceLabel,
-        ...(choice.choiceHint?.trim() ? { hint: choice.choiceHint.trim() } : {}),
-        ...(choice.groupLabel?.trim() ? { groupLabel: choice.groupLabel.trim() } : {}),
-        ...(choice.icon ? { icon: choice.icon } : {}),
-        ...(choice.website ? { website: choice.website } : {}),
-        kind: choice.appGuidedAuth ?? "install",
-        featured: choice.onboardingFeatured === true,
-      },
-    });
-  }
-  return [...choices.values()]
-    .toSorted(
-      (a, b) =>
-        Number(b.option.featured) - Number(a.option.featured) ||
-        compareProviderAuthChoiceGroups(
-          {
-            id: a.metadata.groupId ?? a.metadata.providerId,
-            label: a.metadata.groupLabel ?? a.metadata.choiceLabel,
-          },
-          {
-            id: b.metadata.groupId ?? b.metadata.providerId,
-            label: b.metadata.groupLabel ?? b.metadata.choiceLabel,
-          },
-        ) ||
-        (a.metadata.assistantPriority ?? 0) - (b.metadata.assistantPriority ?? 0) ||
-        a.option.label.localeCompare(b.option.label, "en") ||
-        a.option.id.localeCompare(b.option.id, "en"),
-    )
-    .map(({ option }) => option);
+  return listSetupInferenceGuidedOptions({
+    choices: authChoices,
+    include: (choice) =>
+      Boolean(choice.appGuidedAuth) ||
+      (choice.appGuidedSecret !== true && choice.appGuidedDiscovery !== true),
+    project: (choice, id) => ({
+      ...projectChoicePresentation(choice, id),
+      ...(choice.groupLabel?.trim() ? { groupLabel: choice.groupLabel.trim() } : {}),
+      kind: choice.appGuidedAuth ?? "install",
+      featured: choice.onboardingFeatured === true,
+    }),
+  });
 }
 
 export function listSetupInferenceEnableOptions(
@@ -179,91 +184,35 @@ export function listSetupInferenceEnableOptions(
   return choices
     .filter((choice) => supportsSetupTextInference(choice.onboardingScopes))
     .map((choice) => {
-      const option: SetupInferenceAuthOption = {
-        id: choice.choiceId,
-        brandId: choice.providerId,
-        label: choice.choiceLabel,
-        kind: "install",
-        featured: choice.onboardingFeatured === true,
-      };
-      const hint = choice.choiceHint?.trim();
+      const option: SetupInferenceAuthOption = Object.assign(
+        projectChoicePresentation(choice, choice.choiceId),
+        {
+          kind: "install",
+          featured: choice.onboardingFeatured === true,
+        } as const,
+      );
       const groupLabel = choice.groupLabel?.trim();
-      if (hint) {
-        option.hint = hint;
-      }
       if (groupLabel) {
         option.groupLabel = groupLabel;
       }
-      if (choice.icon) {
-        option.icon = choice.icon;
-      }
-      if (choice.website) {
-        option.website = choice.website;
-      }
       return option;
     })
-    .toSorted(
-      (a, b) =>
-        Number(b.featured) - Number(a.featured) ||
-        compareProviderAuthChoiceGroups(
-          { id: a.brandId ?? a.id, label: a.groupLabel ?? a.label },
-          { id: b.brandId ?? b.id, label: b.groupLabel ?? b.label },
-        ) ||
-        a.label.localeCompare(b.label, "en") ||
-        a.id.localeCompare(b.id, "en"),
-    );
+    .toSorted(compareSetupInferenceOptions);
 }
 
 export function listSetupInferencePrepareOptions(
   authChoices: readonly ProviderAuthChoiceMetadata[],
 ): SetupInferencePrepareOption[] {
-  const choices = new Map<
-    string,
-    { metadata: ProviderAuthChoiceMetadata; option: SetupInferencePrepareOption }
-  >();
-  for (const choice of authChoices) {
-    const id = choice.choiceId.trim();
-    if (
-      !id ||
-      choices.has(id) ||
-      !supportsSetupTextInference(choice.onboardingScopes) ||
-      choice.appGuidedDiscovery !== true
-    ) {
-      continue;
-    }
-    choices.set(id, {
-      metadata: choice,
-      option: {
-        id,
-        brandId: choice.providerId,
-        label: choice.choiceLabel,
-        ...(choice.choiceHint?.trim() ? { hint: choice.choiceHint.trim() } : {}),
-        ...(choice.appGuidedActionLabel?.trim()
-          ? { actionLabel: choice.appGuidedActionLabel.trim() }
-          : {}),
-        ...(choice.icon ? { icon: choice.icon } : {}),
-        ...(choice.website ? { website: choice.website } : {}),
-      },
-    });
-  }
-  return [...choices.values()]
-    .toSorted(
-      (a, b) =>
-        compareProviderAuthChoiceGroups(
-          {
-            id: a.metadata.groupId ?? a.metadata.providerId,
-            label: a.metadata.groupLabel ?? a.metadata.choiceLabel,
-          },
-          {
-            id: b.metadata.groupId ?? b.metadata.providerId,
-            label: b.metadata.groupLabel ?? b.metadata.choiceLabel,
-          },
-        ) ||
-        (a.metadata.assistantPriority ?? 0) - (b.metadata.assistantPriority ?? 0) ||
-        a.option.label.localeCompare(b.option.label, "en") ||
-        a.option.id.localeCompare(b.option.id, "en"),
-    )
-    .map(({ option }) => option);
+  return listSetupInferenceGuidedOptions({
+    choices: authChoices,
+    include: (choice) => choice.appGuidedDiscovery === true,
+    project: (choice, id) => ({
+      ...projectChoicePresentation(choice, id),
+      ...(choice.appGuidedActionLabel?.trim()
+        ? { actionLabel: choice.appGuidedActionLabel.trim() }
+        : {}),
+    }),
+  });
 }
 
 export function choiceMatchesCredential(


### PR DESCRIPTION
## Summary

- centralize repeated inference-option presentation mapping
- share the guided-option collector and option comparator
- keep provider-specific option construction and filtering local

This removes 51 net production lines and adds direct presentation compatibility coverage.

## Compatibility

- preserves option kinds and filtering
- preserves featured, group, and priority ordering
- preserves every released optional presentation field

## Validation

- all 47 setup-inference tests plus 7 direct presentation cases
- production and all test-type shards
- strict Plugin SDK 153-subpath smoke
- `pnpm check:architecture`
- `pnpm check:changed`
- all Knip, lint, database, integrity, and import-cycle guards

