### PR TITLE
fix(config): report unavailable runtime values as unset

### DIFF
--- a/docs/cli/config.md
+++ b/docs/cli/config.md
@@ -115,6 +115,9 @@ A schema-valid but unset path explains that the runtime default applies; an unkn
 `openclaw config schema`. With `--json`, both use the standard [CLI JSON failure envelope](/cli#json-failures)
 on stdout and exit with status 1. Without `--json`, diagnostics remain on stderr.
 
+Explicit `null`, `false`, `0`, and empty strings remain readable values in both modes;
+`--json` preserves their types. Optional fields with no runtime value are reported as unset.
+
 ```bash
 openclaw config get browser.executablePath
 openclaw config get agents.defaults.model --json

--- a/src/cli/config-cli.integration.test-harness.ts
+++ b/src/cli/config-cli.integration.test-harness.ts
@@ -58,6 +58,9 @@ export function useConfigCliIntegrationHarness() {
     vi.spyOn(defaultRuntime, "log").mockImplementation((...values: unknown[]) => {
       registeredRuntimeLogs.push(values.map(String).join(" "));
     });
+    vi.spyOn(defaultRuntime, "writeStdout").mockImplementation((value: string) => {
+      registeredRuntimeLogs.push(value);
+    });
     vi.spyOn(defaultRuntime, "writeJson").mockImplementation((value, space = 2) => {
       registeredRuntimeLogs.push(JSON.stringify(value, null, space));
     });

--- a/src/cli/config-cli.integration.test.ts
+++ b/src/cli/config-cli.integration.test.ts
@@ -106,6 +106,154 @@ describe("config cli integration", () => {
     );
   });
 
+  it("classifies real unset model metadata without losing authored values", async () => {
+    const providerId = "qa-config-absence";
+    const providerPath = `models.providers.${providerId}`;
+    const modelPath = `${providerPath}.models[0]`;
+    const syntheticSecret = "qa-config-get-redaction-marker";
+    const raw = `${JSON.stringify(
+      {
+        agents: { entries: { main: {} } },
+        models: {
+          providers: {
+            [providerId]: {
+              baseUrl: "https://provider.example.invalid/v1",
+              api: "openai-completions",
+              apiKey: syntheticSecret,
+              models: [
+                {
+                  id: "qa-model",
+                  name: "QA Model",
+                  params: { qaNull: null, qaFalse: false, qaZero: 0, qaEmpty: "" },
+                },
+                {
+                  id: "qa-sized-model",
+                  name: "QA Sized Model",
+                  contextWindow: 32768,
+                  contextTokens: 16384,
+                },
+              ],
+            },
+          },
+        },
+      },
+      null,
+      2,
+    )}\n`;
+
+    await withConfigFileHarness("openclaw-config-cli-unset-model-", raw, async ({ configPath }) => {
+      const snapshot = await configRuntime.readConfigFileSnapshot({ observe: false });
+      expect(snapshot.valid).toBe(true);
+      expect(snapshot.issues).toEqual([]);
+      const authored = snapshot.sourceConfig.models?.providers?.[providerId]?.models[0];
+      const materialized = snapshot.config.models?.providers?.[providerId]?.models[0];
+      if (!authored || !materialized) {
+        throw new Error("Expected the authored and materialized model fixture");
+      }
+      for (const field of ["contextWindow", "contextTokens"] as const) {
+        expect(Object.hasOwn(authored, field)).toBe(false);
+        expect(materialized[field]).toBeUndefined();
+      }
+      expect(materialized.reasoning).toBe(false);
+
+      const get = (getterPath: string, json: boolean) => {
+        registeredRuntimeLogs.length = 0;
+        registeredRuntimeErrors.length = 0;
+        return runRegisteredConfigCommand([
+          "config",
+          "get",
+          getterPath,
+          ...(json ? ["--json"] : []),
+        ]);
+      };
+      await get(modelPath, true);
+      expect(registeredRuntimeErrors).toEqual([]);
+      expect(registeredRuntimeLogs).toHaveLength(1);
+      const modelJson = JSON.parse(registeredRuntimeLogs[0] ?? "");
+      expect(modelJson).toMatchObject({ id: "qa-model", reasoning: false });
+      expect(modelJson).not.toHaveProperty("contextWindow");
+      expect(modelJson).not.toHaveProperty("contextTokens");
+
+      const failures = [
+        {
+          field: "contextWindow",
+          prefix: "Config path is valid but unset",
+          remedy: "openclaw config set",
+        },
+        {
+          field: "contextTokens",
+          prefix: "Config path is valid but unset",
+          remedy: "openclaw config set",
+        },
+        {
+          field: "notAConfigField",
+          prefix: "Unknown config path",
+          remedy: "openclaw config schema",
+        },
+      ];
+      for (const { field, prefix, remedy } of failures) {
+        const getterPath = `${modelPath}.${field}`;
+        for (const json of [false, true]) {
+          await expect(get(getterPath, json)).rejects.toMatchObject({
+            name: "ExitError",
+            code: 1,
+          });
+          let message: string;
+          if (json) {
+            expect(registeredRuntimeErrors).toEqual([]);
+            expect(registeredRuntimeLogs).toHaveLength(1);
+            const failure = JSON.parse(registeredRuntimeLogs[0] ?? "");
+            expect(failure).toEqual({
+              ok: false,
+              error: { type: "cli_error", message: expect.any(String) },
+            });
+            message = failure.error.message;
+          } else {
+            expect(registeredRuntimeLogs).toEqual([]);
+            expect(registeredRuntimeErrors).toHaveLength(1);
+            message = registeredRuntimeErrors[0] ?? "";
+          }
+          expect(message).toContain(`${prefix}: ${getterPath}.`);
+          expect(message).toContain(remedy);
+          expect(message).not.toContain(syntheticSecret);
+        }
+      }
+
+      const values = [
+        { path: `${modelPath}.params.qaNull`, value: null, text: "null" },
+        { path: `${modelPath}.params.qaFalse`, value: false, text: "false\n" },
+        { path: `${modelPath}.params.qaZero`, value: 0, text: "0\n" },
+        { path: `${modelPath}.params.qaEmpty`, value: "", text: "\n" },
+        { path: `${providerPath}.models[1].contextWindow`, value: 32768, text: "32768\n" },
+        { path: `${providerPath}.models[1].contextTokens`, value: 16384, text: "16384\n" },
+        {
+          path: `${providerPath}.apiKey`,
+          value: REDACTED_SENTINEL,
+          text: `${REDACTED_SENTINEL}\n`,
+        },
+      ];
+      for (const { path: getterPath, value, text } of values) {
+        for (const json of [false, true]) {
+          await get(getterPath, json);
+          expect(registeredRuntimeErrors).toEqual([]);
+          expect(registeredRuntimeLogs).toHaveLength(1);
+          if (json) {
+            expect(JSON.parse(registeredRuntimeLogs[0] ?? "")).toEqual(value);
+          } else {
+            expect(registeredRuntimeLogs).toEqual([text]);
+          }
+          expect(registeredRuntimeLogs.join("\n")).not.toContain(syntheticSecret);
+        }
+      }
+      await get(providerPath, true);
+      expect(JSON.parse(registeredRuntimeLogs[0] ?? "")).toMatchObject({
+        apiKey: REDACTED_SENTINEL,
+      });
+      expect(registeredRuntimeLogs.join("\n")).not.toContain(syntheticSecret);
+      expect(fs.readFileSync(configPath, "utf8")).toBe(raw);
+    });
+  });
+
   it("redacts SecretRef ids and plugin-only sensitive fields in JSON/text order", async () => {
     const secretRefId = "CONFIG_GET_TEST_TOKEN";
     const schemaOnlySecrets = ["first-private-route", "second-private-route"];

--- a/src/cli/config-cli.ts
+++ b/src/cli/config-cli.ts
@@ -139,7 +139,7 @@ export async function runConfigGet(opts: { path: string; json?: boolean; runtime
       snapshot.sourceConfig,
     );
     const res = getAtPath(redactConfigObject(snapshot.config, uiHints), parsedPath);
-    if (!res.found) {
+    if (!res.found || res.value === undefined) {
       const message = isConfigSchemaPath(schema, parsedPath)
         ? `Config path is valid but unset: ${opts.path}. The runtime default applies until you set an authored value with ${formatCliCommand(`openclaw config set ${quoteCliArg(opts.path)} <value>`)}.`
         : `Unknown config path: ${opts.path}. Run ${formatCliCommand("openclaw config schema")} to inspect valid paths.`;
@@ -151,7 +151,7 @@ export async function runConfigGet(opts: { path: string; json?: boolean; runtime
       exitCliAfterOutput(runtime, 1);
     }
     if (opts.json) {
-      writeRuntimeJson(runtime, res.value ?? null);
+      writeRuntimeJson(runtime, res.value);
     } else if (
       typeof res.value === "string" ||
       typeof res.value === "number" ||
@@ -159,7 +159,7 @@ export async function runConfigGet(opts: { path: string; json?: boolean; runtime
     ) {
       writeRuntimeStdout(runtime, `${String(res.value)}\n`);
     } else {
-      writeRuntimeJson(runtime, res.value ?? null);
+      writeRuntimeJson(runtime, res.value);
     }
   } catch (err) {
     if (err instanceof ExitError) {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where reading optional runtime metadata with `openclaw config get` returned `null` and exit status 0 even though no value was configured or known. For example, a custom model without `contextWindow` or `contextTokens` appeared to have an explicit null value.

## Why This Change Was Made

The CLI now classifies `undefined` through its existing unset-path diagnostic and removes the two conversions that invented null. Runtime defaults and the shared structural path walker retain their existing contracts; the getter owns whether a value can be displayed. Formatted production delta is **+3/−3 (net 0)**; tests/support +151 and docs +3.

## User Impact

Missing runtime metadata produces the existing “valid but unset” diagnostic and exit status 1, including the standard JSON failure envelope. Authored null, false, zero, empty strings, defined defaults, redaction and parent-object output remain intact. Configuration validation, writes, storage and defaults are unchanged.

## Evidence

- Tests-first integration reproduced the defect; the candidate passes all 15 integration cases and 19 existing getter controls.
- Full changed checks and a full build passed on `1a8620efbb196ccab29f6e12270c102e0ce17cc7` plus this patch.
- Real built CLI: 26 isolated synthetic-config cases per phase. Four missing context-field reads changed from `null`/exit 0 to the exact unset diagnostic/exit 1. The other 22 cases had byte-identical stdout, stderr and exits, including both parent snapshots. All config files remained unchanged; all processes exited naturally.
- Independent source, compiled-output and raw CLI evidence audits passed. The CLI proof covers the macOS final runtime on Node 24.20.0; it does not exercise provider calls or Gateway behavior.

Release-note context: config getters now report optional fields without a runtime value as unset instead of fabricating successful null values.
