### PR TITLE
fix(test): preserve sibling writes during home acquisition failure

### DIFF
--- a/src/plugin-sdk/test-helpers/temp-home.ts
+++ b/src/plugin-sdk/test-helpers/temp-home.ts
@@ -94,7 +94,7 @@ export async function withTempHomeCore<T>(
     initialized = true;
     return await fn(base);
   } finally {
-    if (!opts.skipSessionCleanup) {
+    if (initialized && !opts.skipSessionCleanup) {
       await cleanupSessionStateForTest({ stateDir: path.join(base, ".openclaw") }).catch(
         () => undefined,
       );

--- a/src/test-utils/temp-home.test.ts
+++ b/src/test-utils/temp-home.test.ts
@@ -3,6 +3,9 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
+import { runExclusiveSessionStoreWrite } from "../config/sessions/store-writer.js";
+import { resolveEffectiveHomeDir } from "../infra/home-dir.js";
 import { withTempHomeCore } from "../plugin-sdk/test-helpers/temp-home.js";
 import { captureEnv, captureFullEnv, withEnvAsync } from "./env.js";
 import { createTempHomeEnv } from "./temp-home.js";
@@ -75,25 +78,35 @@ describe("createTempHomeEnv", () => {
     },
   );
 
-  it("sets home env vars and restores them on cleanup", async () => {
-    const previousHome = process.env.HOME;
-    const previousUserProfile = process.env.USERPROFILE;
-    const previousStateDir = process.env.OPENCLAW_STATE_DIR;
-
-    const tempHome = await createTempHomeEnv("openclaw-temp-home-");
-    expect(process.env.HOME).toBe(tempHome.home);
-    expect(process.env.USERPROFILE).toBe(tempHome.home);
-    expect(process.env.OPENCLAW_STATE_DIR).toBe(path.join(tempHome.home, ".openclaw"));
-    const homeStat = await fs.stat(tempHome.home);
-    expect(homeStat.isDirectory()).toBe(true);
-
-    await tempHome.restore();
-
-    expect(process.env.HOME).toBe(previousHome);
-    expect(process.env.USERPROFILE).toBe(previousUserProfile);
-    expect(process.env.OPENCLAW_STATE_DIR).toBe(previousStateDir);
-    await expectPathMissing(tempHome.home);
-  });
+  it.each([false, true])(
+    "sets home env vars and restores them on cleanup (inherited home override=%s)",
+    async (inheritedOverride) => {
+      const callerHome = inheritedOverride ? path.join(os.tmpdir(), "caller-home") : undefined;
+      await withEnvAsync({ OPENCLAW_HOME: callerHome }, async () => {
+        const previousHome = process.env.HOME;
+        const previousUserProfile = process.env.USERPROFILE;
+        const previousStateDir = process.env.OPENCLAW_STATE_DIR;
+        const previousEffectiveHome = resolveEffectiveHomeDir();
+        const tempHome = await createTempHomeEnv("openclaw-temp-home-");
+        try {
+          expect(process.env.HOME).toBe(tempHome.home);
+          expect(process.env.USERPROFILE).toBe(tempHome.home);
+          expect(process.env.OPENCLAW_STATE_DIR).toBe(path.join(tempHome.home, ".openclaw"));
+          expect(resolveEffectiveHomeDir()).toBe(tempHome.home);
+          const homeStat = await fs.stat(tempHome.home);
+          expect(homeStat.isDirectory()).toBe(true);
+        } finally {
+          await tempHome.restore();
+        }
+        expect(process.env.HOME).toBe(previousHome);
+        expect(process.env.USERPROFILE).toBe(previousUserProfile);
+        expect(process.env.OPENCLAW_STATE_DIR).toBe(previousStateDir);
+        expect(process.env.OPENCLAW_HOME).toBe(callerHome);
+        expect(resolveEffectiveHomeDir()).toBe(previousEffectiveHome);
+        await expectPathMissing(tempHome.home);
+      });
+    },
+  );
 });
 
 describe("withTempHome acquisition", () => {
@@ -145,7 +158,22 @@ describe("withTempHome acquisition", () => {
           const failure = new Error("env acquisition failed");
           const body = vi.fn(async () => undefined);
           let failedHome = "";
-          await expect(
+          const started = createDeferred();
+          const release = createDeferred();
+          const envReached = createDeferred();
+          const writes: string[] = [];
+          const storePath = path.join(callerHome, "sessions.json");
+          const active = runExclusiveSessionStoreWrite(storePath, async () => {
+            started.resolve();
+            await release.promise;
+            writes.push("active");
+          });
+          await started.promise;
+          const pending = runExclusiveSessionStoreWrite(storePath, async () => {
+            writes.push("pending");
+          });
+          const writers = Promise.allSettled([active, pending]);
+          const acquisition = expect(
             withTempHomeCore(body, {
               prefix,
               skipHomeCleanup,
@@ -155,11 +183,24 @@ describe("withTempHome acquisition", () => {
                 ACQUISITION_DELETED: undefined,
                 ACQUISITION_THROW: (home) => {
                   failedHome = home;
+                  envReached.resolve();
                   throw failure;
                 },
               },
             }),
           ).rejects.toBe(failure);
+          try {
+            await Promise.race([envReached.promise, acquisition]);
+          } finally {
+            release.resolve();
+            await writers;
+            await acquisition;
+          }
+          expect(await writers).toEqual([
+            { status: "fulfilled", value: undefined },
+            { status: "fulfilled", value: undefined },
+          ]);
+          expect(writes).toEqual(["active", "pending"]);
           expect(body).not.toHaveBeenCalled();
           const changedKeys = [
             ...new Set([...Object.keys(callerEnv), ...Object.keys(process.env)]),

--- a/src/test-utils/temp-home.ts
+++ b/src/test-utils/temp-home.ts
@@ -3,7 +3,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
-import { captureEnv, setTestEnvValue } from "./env.js";
+import { captureEnv, deleteTestEnvValue, setTestEnvValue } from "./env.js";
 import { cleanupSessionStateForTest } from "./session-state-cleanup.js";
 
 const HOME_ENV_KEYS = [
@@ -11,6 +11,7 @@ const HOME_ENV_KEYS = [
   "USERPROFILE",
   "HOMEDRIVE",
   "HOMEPATH",
+  "OPENCLAW_HOME",
   "OPENCLAW_STATE_DIR",
 ] as const;
 
@@ -56,6 +57,7 @@ export async function createTempHomeEnv(prefix: string): Promise<TempHomeEnv> {
     await fs.mkdir(stateDir, { recursive: true });
     setTestEnvValue("HOME", home);
     setTestEnvValue("USERPROFILE", home);
+    deleteTestEnvValue("OPENCLAW_HOME");
     setTestEnvValue("OPENCLAW_STATE_DIR", stateDir);
 
     if (process.platform === "win32") {


### PR DESCRIPTION
Closes #145875

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where temporary-home tests can cancel a sibling's pending session-store write when environment setup fails before the test body starts. It also fixes manual temporary-home setup leaving the effective-home resolver pointed at an inherited `OPENCLAW_HOME` instead of the isolated home.

## Why This Change Was Made

`withTempHomeCore` now drains session state only after successful acquisition. Failed acquisition still restores the environment, removes its partial home, and preserves the original error. `createTempHomeEnv` captures, clears, and exactly restores `OPENCLAW_HOME` through its existing environment snapshot.

The callback and manual helpers keep their distinct lifetimes, prefix roots, and cleanup/error semantics. Successful session-store and SQLite writer drains, cleanup options, and body-failure retention remain intact.

## User Impact

Developers get reliable home isolation and acquisition rollback without interrupting sibling queued writes. Existing APIs and Windows environment routing stay unchanged. The change adds two net test-support lines and 41 net test lines; there is no product-runtime change or performance claim.

## Evidence

The final regression test failed against the original B0 helpers in three expected cases: inherited `OPENCLAW_HOME` and a throwing environment callback with either `skipHomeCleanup` setting. After repair, the same test passed, with 17 tests passing across three files. The queue regression uses the real session-store writer queue and verifies active and pending work both finish in order, while environment restoration, sibling files, error identity, and subsequent helper reuse remain correct.

All 34 selected checks against `0cccc6d68e58ccd5030cd09931c1753bca924c7b` passed, along with the diff check. Source-bound P2 review was scoped-clean with no actionable findings. These are retained local results using B0 dependencies. No observed CI incident or live Windows validation is claimed.


Hosted CI passed on unchanged head after one failed-job retry of run34687761900. The first attempt stopped during Matrix crypto dependency installation: its binary download hit ECONNRESET, then the existing postinstall error handler threw before source-contract checks ran. Attempt2 passed that check and the dependent CI aggregate. No source, dependency, assertion or timeout was changed for the retry.
