### PR TITLE
refactor: simplify abort waits and verify native cleanup

### DIFF
--- a/src/infra/abort-signal.test.ts
+++ b/src/infra/abort-signal.test.ts
@@ -1,4 +1,4 @@
-// Covers abort signal wait helpers.
+import { getEventListeners } from "node:events";
 import { describe, expect, it } from "vitest";
 import {
   createAbortError,
@@ -58,58 +58,21 @@ describe("waitForAbortSignal", () => {
     abort.abort();
     await task;
     expect(resolved).toBe(true);
-  });
-
-  it("registers and removes the abort listener exactly once", async () => {
-    let handler: (() => void) | undefined;
-    const addEventListener = (
-      _type: string,
-      listener: () => void,
-      options?: AddEventListenerOptions,
-    ) => {
-      handler = listener;
-      expect(options).toEqual({ once: true });
-    };
-    const removeEventListener = (_type: string, listener: () => void) => {
-      expect(listener).toBe(handler);
-      removed += 1;
-    };
-    let removed = 0;
-
-    const task = waitForAbortSignal({
-      aborted: false,
-      addEventListener,
-      removeEventListener,
-    } as unknown as AbortSignal);
-
-    expect(handler).toBeTypeOf("function");
-    handler?.();
-    await expect(task).resolves.toBeUndefined();
-    expect(removed).toBe(1);
+    expect(getEventListeners(abort.signal, "abort")).toHaveLength(0);
   });
 });
 
 describe("racePromiseWithAbortSignal", () => {
   it("preserves source settlement and removes the listener", async () => {
-    let handler: (() => void) | undefined;
-    let removed = 0;
-    const signal = {
-      aborted: false,
-      addEventListener: (_type: string, listener: () => void) => {
-        handler = listener;
-      },
-      removeEventListener: (_type: string, listener: () => void) => {
-        expect(listener).toBe(handler);
-        removed += 1;
-      },
-    } as unknown as AbortSignal;
+    const signal = new AbortController().signal;
     const sourceError = new Error("source failed");
 
     await expect(racePromiseWithAbortSignal(Promise.resolve("done"), signal)).resolves.toBe("done");
+    expect(getEventListeners(signal, "abort")).toHaveLength(0);
     await expect(racePromiseWithAbortSignal(Promise.reject(sourceError), signal)).rejects.toBe(
       sourceError,
     );
-    expect(removed).toBe(2);
+    expect(getEventListeners(signal, "abort")).toHaveLength(0);
   });
 
   it("rejects with the abort reason as cause without cancelling the source", async () => {

--- a/src/infra/abort-signal.ts
+++ b/src/infra/abort-signal.ts
@@ -46,12 +46,6 @@ export async function waitForAbortSignal(signal?: AbortSignal): Promise<void> {
     return;
   }
   await new Promise<void>((resolve) => {
-    const onAbort = () => {
-      // Remove explicitly even with `{ once: true }`; tests use foreign
-      // AbortSignal-like objects, and cleanup must stay deterministic there.
-      signal.removeEventListener("abort", onAbort);
-      resolve();
-    };
-    signal.addEventListener("abort", onAbort, { once: true });
+    signal.addEventListener("abort", () => resolve(), { once: true });
   });
 }


### PR DESCRIPTION
## What Problem This Solves

Abort-wait cleanup duplicated the native signal's one-shot listener behavior. Its test used a fake signal that recorded the `once` option without implementing it, coupling the test to an explicit removal call instead of checking listener retention.

## Why This Change Was Made

Use the existing `{ once: true }` subscription in `waitForAbortSignal` and check listener cleanup with real `AbortController` signals. Keep the race helper's explicit cleanup: its source promise can settle before the signal aborts.

## User Impact

No intended behavior or SDK change. Missing and already-aborted signals still resolve immediately, active waits still resolve on abort, and raced operations preserve their settlement and abort reason. This removes 6 production lines and 37 test lines.

## Evidence

The final 15 native-signal tests pass against both original and simplified production code. Two selected LINE lifecycle tests pass, covering waiting for abort and the caller's already-aborted early-stop path. Twenty unrelated LINE cases were unselected. This is preservation proof, not a red-to-green bug claim.

Canonical changed-file checks pass, including core and test types, targeted lint, formatting, and repository guards.

Independent review found no actionable P0–P2 issues.
