### PR TITLE
fix(test): restore environment snapshots using own keys

### DIFF
--- a/src/test-utils/env.test.ts
+++ b/src/test-utils/env.test.ts
@@ -36,17 +36,28 @@ describe("env test utils", () => {
     expect(process.env[keyB]).toBe(prevB);
   });
 
-  it("captureFullEnv restores added keys and baseline values", () => {
-    const key = "OPENCLAW_ENV_TEST_ADDED";
-    const prevHome = process.env.HOME;
-    const snapshot = captureFullEnv();
-    setTestEnvValue(key, "1");
-    deleteTestEnvValue("HOME");
+  it.each([
+    ["OPENCLAW_ENV_TEST_ADDED", "HOME"],
+    ["constructor", "toString"],
+    ["toString", "constructor"],
+  ])("captureFullEnv removes added %s and restores baseline %s", (addedKey, baselineKey) => {
+    const original = captureFullEnv();
+    try {
+      deleteTestEnvValue(addedKey);
+      setTestEnvValue(baselineKey, "baseline");
+      const snapshot = captureFullEnv();
+      setTestEnvValue(addedKey, "added");
+      deleteTestEnvValue(baselineKey);
 
-    snapshot.restore();
+      snapshot.restore();
 
-    expect(process.env[key]).toBeUndefined();
-    expect(process.env.HOME).toBe(prevHome);
+      expect(Object.hasOwn(process.env, addedKey)).toBe(false);
+      expect(process.env[baselineKey]).toBe("baseline");
+    } finally {
+      deleteTestEnvValue(addedKey);
+      deleteTestEnvValue(baselineKey);
+      original.restore();
+    }
   });
 
   it("withEnv applies values only inside callback", () => {

--- a/src/test-utils/env.ts
+++ b/src/test-utils/env.ts
@@ -112,7 +112,7 @@ export function captureFullEnv() {
   return {
     restore() {
       for (const key of Object.keys(process.env)) {
-        if (!(key in snapshot)) {
+        if (!Object.hasOwn(snapshot, key)) {
           deleteTestEnvValue(key);
         }
       }

--- a/test/test-env.test.ts
+++ b/test/test-env.test.ts
@@ -26,25 +26,10 @@ import {
 import { cleanupTempDirs, makeTempDir } from "./helpers/temp-dir.js";
 import { installTestEnv } from "./test-env.js";
 
-const ORIGINAL_ENV = { ...process.env };
+const originalEnv = captureFullEnv();
 
 const tempDirs = new Set<string>();
 const cleanupFns: Array<() => void> = [];
-
-function restoreProcessEnv(): void {
-  for (const key of Object.keys(process.env)) {
-    if (!(key in ORIGINAL_ENV)) {
-      deleteTestEnvValue(key);
-    }
-  }
-  for (const [key, value] of Object.entries(ORIGINAL_ENV)) {
-    if (value === undefined) {
-      deleteTestEnvValue(key);
-    } else {
-      setTestEnvValue(key, value);
-    }
-  }
-}
 
 // Compare every key without printing ambient credentials in assertion failures.
 function changedEnvKeys(expected: NodeJS.ProcessEnv): string[] {
@@ -92,7 +77,7 @@ afterEach(() => {
   while (cleanupFns.length > 0) {
     cleanupFns.pop()?.();
   }
-  restoreProcessEnv();
+  originalEnv.restore();
   vi.restoreAllMocks();
   vi.doUnmock("node:child_process");
   cleanupTempDirs(tempDirs);


### PR DESCRIPTION
Closes #145878

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where test environment restoration leaves newly added `constructor` or `toString` keys behind, allowing those values to leak into later tests.

## Why This Change Was Made

The shared restorer now checks the captured object's own keys with `Object.hasOwn`. Installer tests use that same owner instead of a duplicate loop, keeping their snapshot at module load and restoration in the existing `afterEach` position.

## User Impact

Tests remove newly added keys even when their names match inherited object properties, while restoring values that were actually captured. Successful installer cleanup still retains profile additions; failed staging still restores its full snapshot. Production behavior is unchanged, and no performance improvement is claimed. The change removes four net test/support lines.

## Evidence

The original helper failed only the two intended prototype-name rows; ten other helper tests passed. The repaired helper and installer suites then passed all 37 tests, and the 32-check selected gate passed against `0cccc6d68e58ccd5030cd09931c1753bca924c7b`.

The ordinary test baseline key was subsequently changed to `HOME`, with a synthetic value. Final verification passed all 12 helper tests, formatting, diff check, and scoped P2 review. The helper implementation, installer caller, prototype rows, assertions, and line counts were unchanged by that one-literal correction. Root accepted reuse of the earlier installer-suite and 32-check evidence; those checks were not rerun on the final literal.
