### PR TITLE
perf(config): skip unchanged branches when collecting paths

### DIFF
--- a/src/config/config-change-paths.ts
+++ b/src/config/config-change-paths.ts
@@ -8,6 +8,9 @@ export function collectChangedPaths(
   path: string,
   output: Set<string>,
 ): void {
+  if (Object.is(base, target)) {
+    return;
+  }
   if (Array.isArray(base) && Array.isArray(target)) {
     const max = Math.max(base.length, target.length);
     for (let index = 0; index < max; index += 1) {


### PR DESCRIPTION
Closes #145882

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Plugin enablement changes can make config change detection traverse a large unchanged model and agent configuration, allocating temporary keys and path strings for branches shared by both snapshots.

## Why This Change Was Made

The existing changed-path collector now returns immediately when `Object.is(base, target)` is true. This adds three production lines and preserves the existing traversal for distinct values, path ordering, own-key checks and output-set contents. The writer continues to append explicit authored set/unset paths; no cache or mutation-policy change is introduced.

## User Impact

Config operations that retain unchanged branches avoid redundant collection work. Reported changed paths and persistence behavior stay the same, including environment-reference preservation and audit metadata. There is no configuration, schema, migration, plugin-loading or service-lifecycle change.

## Evidence

Seven selected existing writer and plugin-management tests passed across three files and two shards. The complete selected checks against `0cccc6d68e58ccd5030cd09931c1753bca924c7b` passed, including core/coreTests typechecking, lint and formatting. Source-bound P2 review reported no actionable findings.

Six interleaved synthetic baseline/candidate runs each performed 80 measured `setPluginEnabledInConfig` → `collectChangedPaths` operations after five warmups, with two providers containing 256 models each and 64 agents. Median whole-operation sampled allocation was **152,039,456 → 957,048 bytes**. All input/output hashes and checksums matched. The probe also checked signed zero, NaN, missing versus own undefined keys, array paths, pre-existing output entries and shared-branch/input identity.

The allocation figure covers the sampled in-memory operation and does not establish whole-Gateway memory, retained heap, latency or full persistence cost. Timing and RSS are diagnostic only. Eight earlier install/focused requests were refused before execution; successful runs retained nonfatal setup/import-analysis warnings. No earlier executed test failure was recorded.
