### PR TITLE
perf(gateway): reuse ordinary history delta projections

### DIFF
--- a/src/gateway/chat-display-projection.core.ts
+++ b/src/gateway/chat-display-projection.core.ts
@@ -117,6 +117,7 @@ type ChatDisplayProjectionResult = {
   turnBoundaryPending: boolean;
   assistantErrorPending: boolean;
   assistantErrorRecoveryObserved: boolean;
+  commentaryFallbacksObserved?: true;
 };
 
 const GATEWAY_ASSISTANT_CONTEXT_OVERFLOW_FALLBACK_TEXT =
@@ -460,21 +461,25 @@ export function projectChatDisplayMessagesWithState(
     options?.assistantErrorPending,
   );
   const projectedErrors = projectEmptyAssistantErrorMessages(recoveredErrors.messages);
+  const sanitizedMessages = toProjectedMessages(
+    sanitizeChatHistoryMessages(projectedErrors, Number.MAX_SAFE_INTEGER, {
+      includeCommentaryFallbacks: options?.includeCommentaryFallbacks,
+    }),
+  );
+  const commentaryFallbacksObserved =
+    options?.includeCommentaryFallbacks === true &&
+    sanitizedMessages.some(
+      (message) => asOptionalRecord(message.openclawStreamFallback)?.source === "segment",
+    );
   const filtered = filterVisibleProjectedHistoryMessages(
-    projectSessionsSendInterSessionMessages(
-      toProjectedMessages(
-        sanitizeChatHistoryMessages(projectedErrors, Number.MAX_SAFE_INTEGER, {
-          includeCommentaryFallbacks: options?.includeCommentaryFallbacks,
-        }),
-      ),
-    ),
+    projectSessionsSendInterSessionMessages(sanitizedMessages),
     options?.turnBoundaryPending,
   );
   const displayMessages = sanitizeChatHistoryMessages(
     mergeTtsSupplementMessages(filtered.messages),
     options?.maxChars ?? DEFAULT_CHAT_HISTORY_TEXT_MAX_CHARS,
   ) as Array<Record<string, unknown>>;
-  return {
+  const result: ChatDisplayProjectionResult = {
     messages: projectCurrentUserProfileAvatars(
       displayMessages,
       options?.resolveCurrentUserProfileDisplay,
@@ -483,6 +488,10 @@ export function projectChatDisplayMessagesWithState(
     assistantErrorPending: recoveredErrors.pending,
     assistantErrorRecoveryObserved: recoveredErrors.recoveryObserved,
   };
+  if (commentaryFallbacksObserved) {
+    result.commentaryFallbacksObserved = true;
+  }
+  return result;
 }
 
 export function projectChatDisplayMessages(

--- a/src/gateway/server-methods/chat-history-delta.ts
+++ b/src/gateway/server-methods/chat-history-delta.ts
@@ -7,10 +7,7 @@ import {
 } from "../../config/sessions/session-accessor.sqlite-history-events.js";
 import { jsonUtf8BytesOrInfinity } from "../../infra/json-utf8-bytes.js";
 import { isOpenClawDeliveryMirrorAssistantMessage } from "../../shared/transcript-only-openclaw-assistant.js";
-import {
-  createCurrentUserProfileMessageProjector,
-  projectChatDisplayMessagesWithState,
-} from "../chat-display-projection.js";
+import { createCurrentUserProfileMessageProjector } from "../chat-display-projection.js";
 import { resolveCurrentUserProfileDisplay } from "../current-user-profile-display.js";
 import {
   projectSessionMessagePayload,
@@ -92,21 +89,9 @@ export function readChatHistoryDelta(params: {
       return { kind: "reset" };
     }
     const messageId = asOptionalRecord(row.event)?.id;
-    const historyProjection = projectChatDisplayMessagesWithState([entryMessage], {
-      ...projectionState,
-      includeCommentaryFallbacks: true,
-    });
-    if (
-      historyProjection.messages.some(
-        (message) => asOptionalRecord(message.openclawStreamFallback)?.source === "segment",
-      )
-    ) {
-      // One transcript entry can own both commentary and a tool call. The single-message
-      // envelope cannot carry that split; let the full history owner reconcile both rows.
-      return { kind: "reset" };
-    }
     const projected = projectSessionMessagePayload({
       agentId: params.agentId,
+      historyDelta: true,
       message: entryMessage,
       ...(typeof messageId === "string" && messageId ? { messageId } : {}),
       messageSeq: row.messageSeq,
@@ -116,6 +101,9 @@ export function readChatHistoryDelta(params: {
       sessionKey: params.sessionKey,
       sessionSnapshot: params.sessionSnapshot,
     });
+    if (projected.requiresHistoryReset) {
+      return { kind: "reset" };
+    }
     projectionState = projected.projectionState;
     // Recovery can remove this row from history, which an append-only delta cannot express.
     // Keep the last accepted cursor before the error and let a full tail own reconciliation.

--- a/src/gateway/server.chat-history-cursor.test.ts
+++ b/src/gateway/server.chat-history-cursor.test.ts
@@ -597,6 +597,80 @@ describe("chat.history cursor catch-up", () => {
   });
 
   test.each([
+    { name: "no sibling", sibling: [] },
+    {
+      name: "a tool sibling",
+      sibling: [{ type: "toolCall", id: "call-1", name: "read", arguments: {} }],
+    },
+    {
+      name: "a final-answer sibling",
+      sibling: [
+        {
+          type: "text",
+          text: "final answer",
+          textSignature: JSON.stringify({ v: 1, id: "final", phase: "final_answer" }),
+        },
+      ],
+    },
+  ])("keeps heartbeat boundaries after filtered commentary with $name", async ({ sibling }) => {
+    const { context, storePath } = await createCursorSession();
+    const cached = await callChat<{ deltaCursor: string }>(context, "chat.history");
+    expect(cached.ok).toBe(true);
+    expect(cached.payload?.deltaCursor).toEqual(expect.any(String));
+    const scope = currentScope(storePath);
+    await appendTranscriptMessage(scope, {
+      eventId: "heartbeat",
+      parentId: "cached",
+      message: { role: "user", content: HEARTBEAT_PROMPT, timestamp: 2 },
+    });
+    await appendTranscriptMessage(scope, {
+      eventId: "commentary",
+      parentId: "heartbeat",
+      message: {
+        role: "assistant",
+        content: [
+          {
+            type: "text",
+            text: "ANNOUNCE_SKIP REPLY_SKIP",
+            textSignature: JSON.stringify({ v: 1, id: "commentary", phase: "commentary" }),
+          },
+          ...sibling,
+        ],
+        timestamp: 3,
+      },
+    });
+    await appendTranscriptMessage(scope, {
+      eventId: "after-commentary",
+      parentId: "commentary",
+      message: { role: "assistant", content: "visible after commentary", timestamp: 4 },
+    });
+
+    const delta = await callChat<{
+      kind: string;
+      messages: Array<{ messageId: string; message: Record<string, unknown> }>;
+    }>(context, "chat.history", { cursor: cached.payload?.deltaCursor });
+    expect(delta).toMatchObject({ ok: true, payload: { kind: "delta" } });
+    // Full history currently consumes this boundary on the subsequently dropped fallback.
+    // The cursor contract preserves it on the first surviving message instead.
+    expect(
+      delta.payload?.messages.map(({ messageId, message }) => ({
+        messageId,
+        content: message.content,
+        turnBoundary: asOptionalRecord(message["__openclaw"])?.turnBoundary === true,
+      })),
+    ).toEqual([
+      ...(sibling.length > 0
+        ? [{ messageId: "commentary", content: sibling, turnBoundary: true }]
+        : []),
+      {
+        messageId: "after-commentary",
+        content: "visible after commentary",
+        turnBoundary: sibling.length === 0,
+      },
+    ]);
+  });
+
+  test.each([
     {
       name: "plain messages",
       append: async (storePath: string) => {

--- a/src/gateway/session-transcript-message.ts
+++ b/src/gateway/session-transcript-message.ts
@@ -54,6 +54,7 @@ function readTranscriptMessageSenderIsOwner(message: unknown): boolean | undefin
 /** Project one transcript message into the exact payload emitted as session.message. */
 export function projectSessionMessagePayload(params: {
   agentId?: string;
+  historyDelta?: boolean;
   message: unknown;
   messageId?: string;
   messageSeq?: number;
@@ -63,7 +64,11 @@ export function projectSessionMessagePayload(params: {
   runId?: string;
   sessionKey: string;
   sessionSnapshot?: Record<string, unknown>;
-}): { payload?: Record<string, unknown>; projectionState: SessionMessageProjectionState } {
+}): {
+  payload?: Record<string, unknown>;
+  projectionState: SessionMessageProjectionState;
+  requiresHistoryReset?: true;
+} {
   const idempotencyKey = readTranscriptMessageIdempotencyKey(params.message);
   const senderIsOwner = readTranscriptMessageSenderIsOwner(params.message);
   const rawMessage = attachOpenClawTranscriptMeta(params.message, {
@@ -73,16 +78,42 @@ export function projectSessionMessagePayload(params: {
     ...(idempotencyKey ? { idempotencyKey } : {}),
     ...(params.messageSeq !== undefined ? { seq: params.messageSeq } : {}),
   });
-  const projected = params.projectionState
+  const historyProjection = params.historyDelta
     ? projectChatDisplayMessagesWithState([rawMessage], {
-        assistantErrorPending: params.projectionState.assistantErrorPending,
-        turnBoundaryPending: params.projectionState.turnBoundaryPending,
+        ...params.projectionState,
+        includeCommentaryFallbacks: true,
       })
-    : {
-        messages: [projectChatDisplayMessage(rawMessage)],
-        assistantErrorPending: false,
-        turnBoundaryPending: false,
-      };
+    : undefined;
+  if (
+    historyProjection?.messages.some(
+      (message) => asOptionalRecord(message.openclawStreamFallback)?.source === "segment",
+    )
+  ) {
+    // A single-message envelope cannot carry a commentary/tool split; let full history
+    // reconcile both rows.
+    return {
+      projectionState: {
+        assistantErrorPending: historyProjection.assistantErrorPending,
+        turnBoundaryPending: historyProjection.turnBoundaryPending,
+      },
+      requiresHistoryReset: true,
+    };
+  }
+  // A fallback can consume a pending turn boundary before final sanitation removes it.
+  // Reproject those rows from the incoming state, even when no segment remains visible.
+  const projected =
+    historyProjection && !historyProjection.commentaryFallbacksObserved
+      ? historyProjection
+      : params.projectionState
+        ? projectChatDisplayMessagesWithState([rawMessage], {
+            assistantErrorPending: params.projectionState.assistantErrorPending,
+            turnBoundaryPending: params.projectionState.turnBoundaryPending,
+          })
+        : {
+            messages: [projectChatDisplayMessage(rawMessage)],
+            assistantErrorPending: false,
+            turnBoundaryPending: false,
+          };
   const projectionState = {
     assistantErrorPending: projected.assistantErrorPending,
     turnBoundaryPending: projected.turnBoundaryPending,


### PR DESCRIPTION
Closes #145884

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Incremental chat-history reads prepare each ordinary message for display twice while catching up from a cursor, duplicating the complete projection pipeline.

## Why This Change Was Made

The existing session-payload owner now combines commentary-split detection with envelope construction and reuses the first projection for ordinary rows. Surviving commentary segments still request a reset. A fallback observed before visibility filtering or final sanitation retains the second normal projection from incoming state, preserving pending turn boundaries and assistant-error state even if that fallback disappears.

## User Impact

Cursor history returns the same message fields, content, boundaries, and reset decisions with fewer projection passes for ordinary rows. Stored transcript bytes, selection/authority, UTF-8 limits, cursor advancement, and normal live-message projection remain unchanged. The internal fallback fact and reset result account for the net 28 production lines added; tests add 74 lines.

## Evidence

Paired proof passed 91 tests on each implementation, including three registered cursor cases with no sibling, a tool sibling, or a final-answer sibling after filtered commentary. The explicit-base selected gate and source-bound P2 review passed.

Eight instrumented registered cursor cases observed two complete projections becoming one per ordinary row. Filtered-fallback rows intentionally retain two; their three-row cases drop from six to four through the ordinary surrounding rows. Empty deltas remain at zero. Instrumentation forwarded the original functions and retained scalar counts only.

The commentary-aware full-history path gains one scan of its sanitized array to record the fallback fact; that cost was not timed separately. The existing full-history boundary divergence for filtered fallbacks is outside this change. These are operation counts and isolated handler fixtures, not allocation-byte, RSS, timing, live-provider, or browser/WebSocket proof. No full-repository test suite or additional build was run because lazy-loading and bundled-artifact contracts are unchanged.
