### PR TITLE
docs(skills): clarify gog auth assumptions in SKILL.md

### DIFF
--- a/skills/gog/SKILL.md
+++ b/skills/gog/SKILL.md
@@ -26,6 +26,8 @@ metadata:
 
 Use `gog` for Gmail/Calendar/Drive/Contacts/Sheets/Docs. Requires OAuth setup.
 
+Accounts are commonly already authenticated on this host. Run the command you need directly with `exec` — do not ask the user for credentials, do not use the `secrets` tool, and do not assume setup is required. Only fall back to the setup steps below if the command itself fails with an auth error (check with `gog auth list` to confirm).
+
 Setup (once)
 
 - `gog auth credentials /path/to/client_secret.json`


### PR DESCRIPTION
## What Problem This Solves
The `gog` skill's SKILL.md wording implied auth setup was required before every use, which could mislead a model into assuming credentials aren't configured and asking the user for them instead of just running the command.

## Why This Change Was Made
Clarify that existing auth should be assumed unless a command actually fails, so agents don't unnecessarily prompt users for re-authorization.

## User Impact
Docs-only change to `skills/gog/SKILL.md`. No runtime behavior change.

## Evidence
Docs-only diff; `git diff --check` clean.