### PR TITLE
fix(scripts): reject extra empty target arguments

### DIFF
--- a/scripts/check-package-dist-imports.mjs
+++ b/scripts/check-package-dist-imports.mjs
@@ -23,7 +23,7 @@ function parseArgs(argv) {
     throw new Error(`Unknown package dist import check option: ${packageRootArg}`);
   }
   const extraArg = args[1]?.trim();
-  if (extraArg) {
+  if (args.length > 1) {
     throw new Error(`Unexpected package dist import check argument: ${extraArg}`);
   }
   return {

--- a/scripts/lib/plugin-npm-runtime-build.mts
+++ b/scripts/lib/plugin-npm-runtime-build.mts
@@ -532,7 +532,7 @@ function readPackageDirArg(argv: string[]) {
     throw new Error(usage());
   }
   const extraArg = args[1];
-  if (extraArg) {
+  if (args.length > 1) {
     throw new Error(`unexpected plugin npm runtime build argument: ${extraArg}`);
   }
   return prepareIndex === -1 ? { packageDir } : { packageDir, prepareNativeImport: true };

--- a/scripts/openclaw-npm-postpublish-verify.ts
+++ b/scripts/openclaw-npm-postpublish-verify.ts
@@ -156,7 +156,7 @@ export function parseOpenClawNpmPostpublishVerifyArgs(
     throw new Error(`Unknown openclaw npm postpublish verifier option: ${version}`);
   }
   const extraArg = args[1]?.trim();
-  if (extraArg) {
+  if (args.length > 1) {
     throw new Error(`Unexpected openclaw npm postpublish verifier argument: ${extraArg}`);
   }
   return { help: false, version };

--- a/test/openclaw-npm-postpublish-verify.test.ts
+++ b/test/openclaw-npm-postpublish-verify.test.ts
@@ -70,15 +70,31 @@ describe("parseOpenClawNpmPostpublishVerifyArgs", () => {
     });
   });
 
-  it("rejects missing, option-like, and extra arguments before verification", () => {
+  it.each([
+    { argv: ["2026.3.23", "extra"] },
+    { argv: ["2026.3.23", ""] },
+    { argv: ["2026.3.23", " \t "] },
+    { argv: ["2026.3.23", "", "--unexpected"] },
+    { argv: ["--", "2026.3.23", ""] },
+  ])("rejects excess postpublish argv $argv before verification", ({ argv }) => {
+    expect(() => parseOpenClawNpmPostpublishVerifyArgs(argv)).toThrow(
+      "Unexpected openclaw npm postpublish verifier argument",
+    );
+  });
+
+  it("keeps help ahead of unused operands", () => {
+    expect(parseOpenClawNpmPostpublishVerifyArgs(["--", "--help", ""])).toEqual({
+      help: true,
+      version: "",
+    });
+  });
+
+  it("rejects missing and option-like arguments before verification", () => {
     expect(() => parseOpenClawNpmPostpublishVerifyArgs([])).toThrow(
       openClawNpmPostpublishVerifyUsage(),
     );
     expect(() => parseOpenClawNpmPostpublishVerifyArgs(["--tag"])).toThrow(
       "Unknown openclaw npm postpublish verifier option: --tag",
-    );
-    expect(() => parseOpenClawNpmPostpublishVerifyArgs(["2026.3.23", "extra"])).toThrow(
-      "Unexpected openclaw npm postpublish verifier argument: extra",
     );
   });
 });

--- a/test/scripts/check-package-dist-imports.test.ts
+++ b/test/scripts/check-package-dist-imports.test.ts
@@ -59,16 +59,35 @@ describe("check-package-dist-imports", () => {
     expect(extra.stderr).not.toContain("missing dist directory");
   });
 
-  it("accepts a minimal package dist root", () => {
-    const root = makeTempDir(tempDirs, "openclaw-package-dist-imports-");
-    mkdirSync(join(root, "dist"), { recursive: true });
-    writeFileSync(join(root, "dist", "index.js"), "export {};\n", "utf8");
+  it.each([
+    { leading: [], tail: [], accepted: true },
+    { leading: ["--"], tail: [], accepted: true },
+    { leading: [], tail: [""], accepted: false },
+    { leading: [], tail: [" \t "], accepted: false },
+    { leading: [], tail: ["", "extra"], accepted: false },
+    { leading: [], tail: ["", "--unexpected"], accepted: false },
+    { leading: ["--"], tail: [""], accepted: false },
+  ])(
+    "enforces one dist root with leading $leading and tail $tail",
+    ({ leading, tail, accepted }) => {
+      const root = makeTempDir(tempDirs, "openclaw-package-dist-imports-");
+      mkdirSync(join(root, "dist"), { recursive: true });
+      writeFileSync(join(root, "dist", "index.js"), "export {};\n", "utf8");
 
-    const result = spawnSync("node", [CHECK_SCRIPT, root], { encoding: "utf8" });
+      const result = spawnSync(process.execPath, [CHECK_SCRIPT, ...leading, root, ...tail], {
+        encoding: "utf8",
+      });
 
-    expect(result.status, result.stderr).toBe(0);
-    expect(result.stdout).toContain("OpenClaw package dist import closure passed.");
-  });
+      expect(result.error, result.stderr).toBeUndefined();
+      expect(result.status, result.stderr).toBe(accepted ? 0 : 1);
+      if (accepted) {
+        expect(result.stdout).toContain("OpenClaw package dist import closure passed.");
+      } else {
+        expect(result.stderr).toContain("Unexpected package dist import check argument");
+        expect(result.stdout).not.toContain("OpenClaw package dist import closure passed.");
+      }
+    },
+  );
 
   it("rejects missing chunks across ESM import, re-export, and CommonJS forms", () => {
     const root = makeTempDir(tempDirs, "openclaw-package-dist-imports-");

--- a/test/scripts/plugin-npm-package-manifest-args.test.ts
+++ b/test/scripts/plugin-npm-package-manifest-args.test.ts
@@ -52,6 +52,18 @@ describe("plugin-npm-package-manifest run args", () => {
     expect(() => parseRunArgs(["--run", "--bad", "--", "npm", "pack"])).toThrow(usage);
   });
 
+  it("preserves empty callback arguments after the command separator", () => {
+    const forwarded = ["", "--literal", " \t ", ""];
+    expect(parseRunArgs(["--run", "extensions/slack", "--", "node", ...forwarded])).toEqual({
+      packageDir: "extensions/slack",
+      command: "node",
+      args: forwarded,
+    });
+    expect(() => parseRunArgs(["--run", "extensions/slack", "", "--", "node"])).toThrow(
+      "unexpected plugin npm package manifest run argument",
+    );
+  });
+
   it("rejects unexpected args before the command separator", () => {
     expect(() => parseRunArgs(["--run", "extensions/slack", "extra", "--", "npm"])).toThrow(
       "unexpected plugin npm package manifest run argument: extra",

--- a/test/scripts/plugin-npm-runtime-build-args.test.ts
+++ b/test/scripts/plugin-npm-runtime-build-args.test.ts
@@ -46,6 +46,40 @@ describe("plugin npm runtime build args", () => {
     ).toThrow(/unexpected/u);
   });
 
+  it.each([
+    { argv: ["extensions/slack", ""] },
+    { argv: ["extensions/slack", " \t "] },
+    { argv: ["extensions/slack", "", "extra"] },
+    { argv: ["extensions/slack", "", "--unexpected"] },
+    { argv: ["--", "extensions/slack", ""] },
+    { argv: ["--prepare-native-import", "extensions/slack", ""] },
+    { argv: ["extensions/slack", "", "--prepare-native-import"] },
+    { argv: ["extensions/slack", "--prepare-native-import", "", "--unexpected"] },
+    { argv: ["--", "--prepare-native-import", "extensions/slack", ""] },
+    { argv: ["--prepare-native-import", "extensions/slack", "", "--prepare-native-import"] },
+  ])("rejects excess runtime build argv $argv after extracting its mode", ({ argv }) => {
+    expect(() => parseSingleBuildArgs(argv)).toThrow(
+      "unexpected plugin npm runtime build argument",
+    );
+  });
+
+  it("preserves help, literal targets, and the bulk builder's separate grammar", () => {
+    expect(parseSingleBuildArgs(["--", "--help", ""])).toEqual({ help: true, packageDir: "" });
+    expect(parseSingleBuildArgs(["--prepare-native-import", "--help"])).toEqual({
+      help: true,
+      packageDir: "",
+    });
+    expect(parseSingleBuildArgs([" extensions/slack "])).toEqual({
+      packageDir: " extensions/slack ",
+    });
+    expect(parseSingleBuildArgs(["--", "extensions/slack", "--prepare-native-import"])).toEqual({
+      packageDir: "extensions/slack",
+      prepareNativeImport: true,
+    });
+    expect(() => parseBulkBuildArgs(["--package", "extensions/slack", ""])).toThrow(/usage:/u);
+    expect(() => parseBulkBuildArgs(["--package", ""])).toThrow("missing value for --package");
+  });
+
   it("rejects missing or option-looking package targets", () => {
     expect(() => parseBulkBuildArgs(["--package"])).toThrow("missing value for --package");
     expect(() => parseBulkBuildArgs(["--package", "--package", "extensions/slack"])).toThrow(

--- a/test/scripts/plugin-npm-runtime-native-import.test.ts
+++ b/test/scripts/plugin-npm-runtime-native-import.test.ts
@@ -125,6 +125,53 @@ function snapshot(root: string, directories: string[]) {
 
 describe("explicit source native-import preparation", () => {
   it.each([
+    { argv: ["--prepare-native-import", "extensions/demo", ""] },
+    { argv: ["extensions/demo", "", "--prepare-native-import"] },
+    { argv: ["extensions/demo", "", "--prepare-native-import", "--unexpected"] },
+  ])("rejects excess preparation argv $argv before changing the host link", ({ argv }) => {
+    const { root, packageDir } = fixture();
+    const before = snapshot(root, ["."]);
+    const result = runCli(root, argv);
+
+    expect(result.error, result.stderr).toBeUndefined();
+    expect(result.status, result.stderr).toBe(1);
+    expect(result.stderr).toContain("unexpected plugin npm runtime build argument");
+    expect(fs.existsSync(path.join(packageDir, "node_modules"))).toBe(false);
+    expect(fs.existsSync(path.join(root, "executed"))).toBe(false);
+    expect(snapshot(root, ["."])).toEqual(before);
+  });
+
+  it("rejects excess build argv through the public shim without compiling", () => {
+    const { root } = fixture();
+    const packageDir = path.join(root, "javascript-only");
+    writeFile(
+      packageDir,
+      "package.json",
+      JSON.stringify({
+        name: "@openclaw/arity-js-fixture",
+        version: "1.0.0",
+        type: "module",
+        openclaw: { extensions: ["./index.js"] },
+      }),
+    );
+    writeFile(packageDir, "index.js", 'throw new Error("JS-only argv proof must not execute");\n');
+    writeFile(packageDir, "dist/sentinel.js", "keep\n");
+    const before = snapshot(root, ["."]);
+    const valid = runCli(root, [packageDir]);
+
+    expect(valid.error, valid.stderr).toBeUndefined();
+    expect(valid.status, valid.stderr).toBe(0);
+    expect(snapshot(root, ["."])).toEqual(before);
+
+    const result = runCli(root, [packageDir, "", "--unexpected"]);
+
+    expect(result.error, result.stderr).toBeUndefined();
+    expect(result.status, result.stderr).toBe(1);
+    expect(result.stderr).toContain("unexpected plugin npm runtime build argument");
+    expect(snapshot(root, ["."])).toEqual(before);
+  });
+
+  it.each([
     ["esm", "peerDependencies"],
     ["cjs", "peerDependencies"],
     ["esm", "dependencies"],


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where passing an extra empty argument to the single-plugin runtime builder, package dist checker, or npm postpublish verifier bypassed argument validation. A later argument could also be hidden behind the empty operand. Malformed native-import preparation could still create a host link, and the dist checker could incorrectly report success.

## Why This Change Was Made

Each parser now checks the number of remaining operands after its existing separator and mode handling. This replaces three truthiness checks in their existing owners: **production +3/−3, net 0**. The scripts retain their different target grammars, help behavior and diagnostics. The manifest callback wrapper continues forwarding legitimate empty arguments after its command separator.

## User Impact

Malformed invocations stop with their existing unexpected-argument error before target work. Valid single-target invocations, native-import preparation, help, and callback argument forwarding retain their behavior. No package publication or install policy changes.

## Evidence

- Tests-first coverage reproduced the failures. All 227 tests across five complete owner suites now pass, including real native preparation/build/import controls. Full changed checks passed; formatting uses the repository formatter. Tests add 142 lines and remove 14.
- Paired public CLI proof: 22 cases per phase, using actual scripts/shims with a real terminal input and isolated synthetic files. All 14 intended behavior changes passed; eight controls retained byte-identical output and exits. Rejected preparation calls no longer create host links; all original fixture files remained unchanged. All processes exited naturally.
- Four postpublish cases deliberately use the existing HTTP-registry rejection before any request. Their status stays 1 while the diagnostic changes from the downstream registry guard to argument rejection. This proves admission behavior, not registry publication or installation.
- Managed independent review found no actionable P0–P2 findings. Source, raw outputs, process cleanup and test/check receipts were independently audited.

The tests and CLI proof were run on `1a8620efbb196ccab29f6e12270c102e0ce17cc7` plus this patch. Source compatibility with current main `0325f01ac8e1b35c1d8af69f7b0c0da0d8d60f92` was checked separately. The valid JavaScript-only witness preserves the required-manifest repair in #145823; its newer failure footer remains intact when these three focused hunks land. This is distinct from #145468, which repairs the application CLI's root argument scanner.
