### PR TITLE
fix(plugins): revoke stale capability host access after reload

### DIFF
--- a/src/plugins/capability-catalog.ts
+++ b/src/plugins/capability-catalog.ts
@@ -3,6 +3,7 @@ import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import type { PluginCapabilityCatalogContext } from "./capability-catalog-context.types.js";
 import type { PluginCapabilityCatalog } from "./capability-catalog.types.js";
 import { unwrapDefaultModuleExport } from "./module-export.js";
+import { wrapCurrentPluginInstance } from "./plugin-instance-scope.js";
 
 export const capabilityCatalogFamilies = [
   "speechProviders",
@@ -23,7 +24,7 @@ export function resolveCapabilityProviderRegistration<T extends { id: string }>(
       "Capability provider factories require host context; supply resolveCapabilityCatalogContext when creating the registry.",
     );
   }
-  const provider = entry(resolveContext());
+  const provider = entry(wrapCurrentPluginInstance(resolveContext()));
   if (isPromiseLike(provider)) {
     void Promise.resolve(provider).catch(() => {});
     throw new Error("capability provider factories must be synchronous");

--- a/src/plugins/captured-registration.test.ts
+++ b/src/plugins/captured-registration.test.ts
@@ -35,7 +35,7 @@ describe("captured plugin registration", () => {
         throw new Error("not provider execution");
       };
       const factory = vi.fn((context: PluginCapabilityCatalogContext) => {
-        expect(context).toBe(resolvePluginCapabilityCatalogContext());
+        expect(context.formatErrorMessage(new Error("context-ready"))).toBe("context-ready");
         const provider = {
           id: "factory-provider",
           label: "Factory provider",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a reloaded or disabled plugin could retain its capability-factory host context and continue calling host services after its registry generation was retired.

## Why This Change Was Made

Capability factories now receive the current plugin instance's stable context view. Provider descriptors keep their exact identity, while the view applies the same admission and revocation boundary as the rest of that plugin generation.

## User Impact

Plugin reloads and disable operations reliably fence capability providers from an earlier generation instead of leaving stale host access callable.

## Evidence

- Reproduced the two failing CJS and TypeScript registry-partition cases on current main under Node and Bun.
- `node scripts/run-vitest.mjs src/plugins/loader.capability-factory.test.ts src/plugins/captured-registration.test.ts` — 34 passed.
- Direct custom Bun: `scripts/run-vitest-child.mts` with the same two files — 34 passed.
- `node scripts/check-changed.mjs` — passed.
- Independent P2 review — no actionable findings.
