### PR TITLE
fix(feishu): close acquired media streams after failed saves

### DIFF
--- a/extensions/feishu/src/media-chunk-idle.ts
+++ b/extensions/feishu/src/media-chunk-idle.ts
@@ -23,6 +23,7 @@ function destroySource(source: unknown) {
 function withChunkIdleTimeout<T>(
   source: AsyncIterable<T>,
   chunkTimeoutMs: number,
+  teardownSource: () => void,
 ): AsyncIterable<T> {
   return {
     async *[Symbol.asyncIterator]() {
@@ -35,11 +36,7 @@ function withChunkIdleTimeout<T>(
           const timeoutPromise = new Promise<never>((_, reject) => {
             timeoutHandle = setTimeout(() => {
               reject(new FeishuInboundMediaTimeoutError(chunkTimeoutMs));
-              try {
-                destroySource(source);
-              } catch {
-                // Teardown is best-effort; the timeout must remain authoritative.
-              }
+              teardownSource();
             }, chunkTimeoutMs);
           });
           let result: IteratorResult<T>;
@@ -67,18 +64,35 @@ function withChunkIdleTimeout<T>(
   };
 }
 
-export function saveMediaStreamWithIdleTimeout(
+export async function saveMediaStreamWithIdleTimeout(
   stream: AsyncIterable<unknown>,
   contentType: string | undefined,
   maxBytes: number,
   fileName: string | undefined,
   chunkTimeoutMs: number,
 ): Promise<SavedMedia> {
-  return saveMediaStream(
-    withChunkIdleTimeout(stream, chunkTimeoutMs),
-    contentType,
-    "inbound",
-    maxBytes,
-    fileName,
-  );
+  let teardownAttempted = false;
+  const teardownSource = () => {
+    if (teardownAttempted) {
+      return;
+    }
+    teardownAttempted = true;
+    try {
+      destroySource(stream);
+    } catch {
+      // Teardown must not replace the storage or timeout error.
+    }
+  };
+  try {
+    return await saveMediaStream(
+      withChunkIdleTimeout(stream, chunkTimeoutMs, teardownSource),
+      contentType,
+      "inbound",
+      maxBytes,
+      fileName,
+    );
+  } catch (error) {
+    teardownSource();
+    throw error;
+  }
 }

--- a/extensions/feishu/src/media-download.test.ts
+++ b/extensions/feishu/src/media-download.test.ts
@@ -1,0 +1,94 @@
+import fs from "node:fs/promises";
+import http from "node:http";
+import { withEnvAsync, withServer, withTempDir } from "openclaw/plugin-sdk/test-env";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import type { ClawdbotConfig } from "../runtime-api.js";
+
+const messageResourceGet = vi.hoisted(() => vi.fn());
+vi.mock("./client.js", () => ({
+  createFeishuClient: () => ({ im: { messageResource: { get: messageResourceGet } } }),
+}));
+
+const cfg: ClawdbotConfig = {
+  channels: { feishu: { appId: "synthetic-app-id", appSecret: "synthetic-app-secret" } },
+};
+let saveMessageResourceFeishu: typeof import("./media.js").saveMessageResourceFeishu;
+
+beforeAll(async () => {
+  ({ saveMessageResourceFeishu } = await import("./media.js"));
+});
+
+afterAll(() => {
+  vi.doUnmock("./client.js");
+  vi.resetModules();
+});
+
+describe("saveMessageResourceFeishu stream ownership", () => {
+  it.each([false, true])(
+    "closes an acquired stream on terminal storage failure (teardown throws: %s)",
+    async (teardownThrows) => {
+      await withTempDir("openclaw-feishu-download-", (stateDir) =>
+        withEnvAsync({ OPENCLAW_STATE_DIR: stateDir }, async () => {
+          let serverSawClose = false;
+          await withServer(
+            (_request, response) => {
+              response.once("close", () => {
+                serverSawClose = true;
+              });
+              response.writeHead(200, {
+                "content-type": "image/jpeg",
+                "content-length": "1024",
+              });
+              response.flushHeaders();
+            },
+            async (baseUrl) => {
+              const stream = await new Promise<http.IncomingMessage>((resolve, reject) => {
+                http.get(`${baseUrl}/media`, resolve).once("error", reject);
+              });
+              messageResourceGet.mockResolvedValueOnce({
+                getReadableStream: () => stream,
+                headers: { "content-type": "image/jpeg" },
+              });
+              const storageError = Object.assign(new Error("media directory unavailable"), {
+                code: "EACCES",
+              });
+              const mkdir = vi.spyOn(fs, "mkdir").mockRejectedValueOnce(storageError);
+              const iterate = vi.spyOn(stream, Symbol.asyncIterator);
+              const destroySource = stream.destroy.bind(stream);
+              const destroy = vi.spyOn(stream, "destroy").mockImplementationOnce((error) => {
+                const result = destroySource(error);
+                if (teardownThrows) {
+                  throw new Error("source teardown failed");
+                }
+                return result;
+              });
+              const download = saveMessageResourceFeishu({
+                cfg,
+                messageId: "om_storage_failure",
+                fileKey: "img_key_storage_failure",
+                type: "image",
+                maxBytes: 1024,
+              });
+              const settled = download.then(
+                () => undefined,
+                () => undefined,
+              );
+              try {
+                await expect(download).rejects.toBe(storageError);
+                expect(iterate).not.toHaveBeenCalled();
+                expect(stream.destroyed).toBe(true);
+                await vi.waitFor(() => expect(serverSawClose).toBe(true));
+              } finally {
+                mkdir.mockRestore();
+                iterate.mockRestore();
+                destroy.mockRestore();
+                stream.destroy();
+                await settled;
+              }
+            },
+          );
+        }),
+      );
+    },
+  );
+});


### PR DESCRIPTION
Closes #145890

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where Feishu media downloads leave an acquired response stream open when saving fails before iteration, such as a failure to create the media directory or open its temporary file.

## Why This Change Was Made

The existing Feishu save wrapper owns one best-effort explicit teardown operation. Timeout rejection invokes it immediately; terminal save rejection invokes it after the shared store exhausts its existing pre-consumption retries. Recording the attempt before calling `destroy` preserves the original error even when teardown throws. Detached `iterator.return` and reject-before-destroy timeout ordering remain intact.

## User Impact

Failed saves attempt to close acquired destroyable streams while callers retain the exact storage or timeout error. Successful bytes, metadata, limits, HTTP fallback and non-destroyable iterator behavior remain unchanged. The guard bounds the wrapper's explicit attempts; it does not claim exactly-once destruction across Node's internal cleanup.

## Evidence

The original source passes 51 existing tests and fails the two new cases as expected. After moving those cases into the focused file, both original-source failures were reproduced again. The final candidate passes 53 tests across four files, the selected gate and source-bound local P2.

The regression uses the actual `saveMessageResourceFeishu` entry point, real synthetic-config account resolution, shared media storage and a real loopback HTTP response. SDK acquisition is mocked and only `fs.mkdir` EACCES is injected. It verifies unchanged error identity, no iteration, destroyed source and server-side close, including a teardown that throws after native cleanup.

Three failed attempts remain retained:

- An always-throwing spy was reentered by Node cleanup: all 53 tests passed, but Vitest exited 1 for an unhandled error. A one-shot spy corrected the fixture without changing production code or assertions.
- The first test placement exceeded `media.test.ts`'s length gate. That file was restored to B0 and the two cases moved into new `media-download.test.ts`; no exception or baseline was changed.
- Host ENOSPC prevented temporary-directory creation before the cases reached the flow. After joined cleanup and observed disk recovery, the bounded retry passed.

The final patch is exactly two files: +14 net production lines and +94 test lines. The new test file is included in the saved patch; existing `media.test.ts` and `media-chunk-idle.test.ts` remain B0. No live Feishu service or operator data was used, and no timing, allocation, RSS or retained-memory improvement is claimed.
