### PR TITLE
perf(discord): encode complete PCM frames without staging copies

### DIFF
--- a/extensions/discord/src/voice/audio.lifecycle.test.ts
+++ b/extensions/discord/src/voice/audio.lifecycle.test.ts
@@ -12,6 +12,83 @@ import { createDiscordOpusEncodeStream } from "./audio.js";
 
 beforeEach(() => createEncoderMock.mockReset());
 
+it.each([false, true])(
+  "preserves PCM frames across arbitrary splits and caller reuse (partial flush: %s)",
+  async (flushBetween) => {
+    const frameBytes = 960 * 2 * 2;
+    const pcm = Buffer.alloc(frameBytes * 5 + 336);
+    for (let index = 0; index < pcm.length; index += 1) {
+      pcm[index] = (index * 37 + 11) % 251;
+    }
+    const parts = [pcm.subarray(0, frameBytes * 4 + 317), pcm.subarray(frameBytes * 4 + 317)];
+    const codec = await vi.importActual<typeof import("libopus-wasm")>("libopus-wasm");
+    const encoder = await codec.createEncoder({
+      application: codec.Application.Audio,
+      channels: 2,
+      sampleRate: 48_000,
+    });
+    const encode = encoder.encode.bind(encoder);
+    const frames: Buffer[] = [];
+    vi.spyOn(encoder, "encode").mockImplementation((input, options) => {
+      frames.push(Buffer.from(new Uint8Array(input.buffer, input.byteOffset, input.byteLength)));
+      return encode(input, options);
+    });
+    createEncoderMock.mockResolvedValueOnce(encoder);
+    const stream = createDiscordOpusEncodeStream();
+    const consumedBytes: number[] = [];
+    const consume = async () => {
+      for await (const packet of stream) {
+        consumedBytes.push(stream.takePcmBytes(packet));
+      }
+    };
+    const write = async () => {
+      for (const [partIndex, part] of parts.entries()) {
+        let offset = 0;
+        for (const size of [1, frameBytes - 2, 1, frameBytes + 1, part.length]) {
+          if (offset >= part.length) {
+            break;
+          }
+          const chunk = Buffer.from(part.subarray(offset, offset + size));
+          offset += chunk.length;
+          await new Promise<void>((resolve, reject) => {
+            stream.write(chunk, (error) => {
+              chunk.fill(0x7f);
+              if (error) {
+                reject(error);
+              } else {
+                resolve();
+              }
+            });
+          });
+        }
+        if (flushBetween && partIndex === 0) {
+          expect(stream.flushPartialFrame()).toBe(true);
+          expect(stream.flushPartialFrame()).toBe(false);
+        }
+      }
+      stream.end();
+    };
+    try {
+      await Promise.all([consume(), write()]);
+      const expectedFrames: Buffer[] = [];
+      const expectedBytes: number[] = [];
+      for (const part of flushBetween ? parts : [pcm]) {
+        for (let offset = 0; offset < part.length; offset += frameBytes) {
+          const frame = Buffer.alloc(frameBytes);
+          expectedBytes.push(part.copy(frame, 0, offset, offset + frameBytes));
+          expectedFrames.push(frame);
+        }
+      }
+      expect(frames).toEqual(expectedFrames);
+      expect(consumedBytes).toEqual(expectedBytes);
+    } finally {
+      stream.destroy();
+      encoder.free();
+      vi.restoreAllMocks();
+    }
+  },
+);
+
 it("releases an encoder acquired after playback was destroyed without encoding queued audio", async () => {
   const codec = await vi.importActual<typeof import("libopus-wasm")>("libopus-wasm");
   const encoder = await codec.createEncoder({ channels: 2, sampleRate: 48_000 });

--- a/extensions/discord/src/voice/audio.ts
+++ b/extensions/discord/src/voice/audio.ts
@@ -141,7 +141,8 @@ export function createDiscordOpusPlaybackStream(input: Readable | string): Reada
 }
 
 class DiscordOpusEncodeStream extends Transform {
-  #buffer = Buffer.alloc(0);
+  #buffer: Buffer = Buffer.alloc(0);
+  #partialFrame = Buffer.alloc(DISCORD_OPUS_FRAME_BYTES);
   #encoder!: LibopusEncoder;
   readonly #packetPcmBytes = new WeakMap<Buffer, number>();
 
@@ -167,12 +168,35 @@ class DiscordOpusEncodeStream extends Transform {
 
   override _transform(chunk: Buffer, _encoding: BufferEncoding, done: TransformCallback): void {
     try {
-      this.#buffer =
-        this.#buffer.length > 0 ? Buffer.concat([this.#buffer, chunk]) : Buffer.from(chunk);
+      if (this.#buffer.length > 0) {
+        const bufferedBytes = this.#buffer.length;
+        const copiedBytes = chunk.copy(
+          this.#partialFrame,
+          bufferedBytes,
+          0,
+          DISCORD_OPUS_FRAME_BYTES - bufferedBytes,
+        );
+        if (bufferedBytes + copiedBytes < DISCORD_OPUS_FRAME_BYTES) {
+          this.#buffer = this.#partialFrame.subarray(0, bufferedBytes + copiedBytes);
+          done();
+          return;
+        }
+        this.#buffer = chunk.subarray(copiedBytes);
+        this.#encodeFrame(this.#partialFrame);
+      } else {
+        this.#buffer = chunk;
+      }
       while (this.#buffer.length >= DISCORD_OPUS_FRAME_BYTES) {
         const frame = this.#buffer.subarray(0, DISCORD_OPUS_FRAME_BYTES);
         this.#buffer = this.#buffer.subarray(DISCORD_OPUS_FRAME_BYTES);
         this.#encodeFrame(frame);
+      }
+      // Complete frames are consumed synchronously; own the tail before the write callback.
+      if (this.#buffer.length > 0) {
+        this.#buffer.copy(this.#partialFrame);
+        this.#buffer = this.#partialFrame.subarray(0, this.#buffer.length);
+      } else {
+        this.#buffer = Buffer.alloc(0);
       }
       done();
     } catch (err) {
@@ -210,6 +234,7 @@ class DiscordOpusEncodeStream extends Transform {
   override _destroy(err: Error | null, done: (error?: Error | null) => void): void {
     this.#encoder?.free();
     this.#buffer = Buffer.alloc(0);
+    this.#partialFrame = Buffer.alloc(0);
     done(err);
   }
 


### PR DESCRIPTION
Closes #145892

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Discord voice playback copies each incoming PCM chunk into another buffer before encoding, including complete frames that the codec can consume immediately. This adds staging work to every streaming write.

## Why This Change Was Made

The existing encoder now passes complete frames directly to the pinned codec, which copies them synchronously. It owns only an incomplete tail between write callbacks in one 3,840-byte partial-frame buffer. Frame position advances before packet emission, preserving reentrant flush and lifecycle behavior.

## User Impact

Encoded packet bytes and order, consumed PCM-byte accounting, zero-padding and resumed input after a partial flush stay unchanged. This removes whole-input staging copies without changing queued writes, resampling, output ownership or Discord transport behavior. The change adds 25 net production lines and 77 test lines.

## Evidence

The same 57 tests across four files passed before and after. The added real-codec cases exercise arbitrary chunk boundaries, caller mutation after write callbacks, exact frame bytes, consumed-byte order, partial flush and resumed input. The full selected gate against baseline 0cccc6d68e58ccd5030cd09931c1753bca924c7b passed, and the source-bound P2 review found no actionable issues.

Three actual encoder-stream comparisons produced identical complete serialized outputs, including Opus packets and consumed PCM bytes:

| Input case | Whole-input copy operations, before → after | Bytes in those copies, before → after |
| --- | ---: | ---: |
| Aligned provider chunks | 3 → 0 | 230,400 → 0 |
| Arbitrary splits with caller reuse | 10 → 0 | 31,139 → 0 |
| Partial flush, resume and caller reuse | 14 → 0 | 27,225 → 0 |

These counts cover only encoder-owned Buffer.from/Buffer.concat operations containing the current input chunk. They exclude partial-tail copies, packet allocations and allocator overhead. One 3,840-byte buffer is allocated per encoder; this is not a zero-allocation, timing, RSS or retained-memory claim.

The first operation harness attempt failed while resolving an import-only dependency, before tests ran. Its path resolution and generated-WASM hash binding were corrected before the successful comparison. The first three selected-gate attempts were capacity denials and started no command; the fourth completed successfully after the shared admission pause ended. Those records remain retained. No live Discord call or full-repository build is claimed.
