### PR TITLE
fix(claude-cli): honor CLAUDE_CONFIG_DIR for transcripts

### DIFF
--- a/docs/gateway/cli-backends.md
+++ b/docs/gateway/cli-backends.md
@@ -267,7 +267,7 @@ Serialization: `serialize: true` keeps same-lane runs ordered (most CLIs seriali
 
 ## Fallback prelude from claude-cli sessions
 
-A `claude-cli` attempt can fail over to a non-CLI candidate in [`agents.defaults.model.fallbacks`](/concepts/model-failover). OpenClaw then seeds the next attempt with a context prelude harvested from Claude Code's local JSONL transcript. That transcript lives under `~/.claude/projects/`, keyed per workspace. This supplies CLI-owned context that may not be present in OpenClaw's SQLite session transcript.
+A `claude-cli` attempt can fail over to a non-CLI candidate in [`agents.defaults.model.fallbacks`](/concepts/model-failover). OpenClaw then seeds the next attempt with a context prelude harvested from Claude Code's local JSONL transcript. That transcript lives under `$CLAUDE_CONFIG_DIR/projects/` when `CLAUDE_CONFIG_DIR` is set, or `~/.claude/projects/` otherwise, keyed per workspace. This supplies CLI-owned context that may not be present in OpenClaw's SQLite session transcript.
 
 - The prelude prefers the latest `/compact` summary or `compact_boundary` marker, then appends the most recent post-boundary turns up to a char budget. Pre-boundary turns are dropped because the summary already represents them.
 - Tool blocks are coalesced to compact `(tool call: name)` and `(tool result: …)` hints to keep the prompt budget honest. An oversized summary is truncated and labeled `(truncated)`.
@@ -468,6 +468,22 @@ For `claude-cli`, the installed Claude Code process uses its current native
 login. OpenClaw uses a non-secret route marker and never reads, persists,
 refreshes, selects, or forwards the native tokens.
 Set `CLAUDE_CONFIG_DIR` on the Gateway process to use a separate Claude configuration directory.
+Transcript checks, Doctor diagnostics, fallback context, and imported chat history
+use that same selected directory. They do not search the default `~/.claude`
+directory when another directory is selected.
+
+Prefer an absolute path. Claude Code resolves relative values against its own
+working directory, which can differ from the Gateway's working directory.
+Empty values and spaces are preserved: an empty value selects the working
+directory, and spaces are part of the path. Unset the variable to restore the
+`~/.claude` default.
+
+After a successful Claude CLI turn, OpenClaw retains that turn's working directory
+with the native session binding so fallback and chat history can resolve relative
+paths after a restart. Existing bindings without this directory use the available
+session or agent configuration; an earlier ad-hoc directory cannot be recovered
+from its stored hash. A subsequent successful turn records the directory.
+
 Explicit OpenClaw-managed API-key and token profiles continue to use the
 protected, per-invocation credential-forwarding CLI path.
 

--- a/src/agents/agent-scope-config.ts
+++ b/src/agents/agent-scope-config.ts
@@ -508,11 +508,15 @@ export function resolveAgentWorkspaceDir(
 }
 
 /** Resolves the configured task directory without changing the agent workspace. */
-export function resolveAgentRunCwd(cfg: OpenClawConfig, agentId: string): string | undefined {
+export function resolveAgentRunCwd(
+  cfg: OpenClawConfig,
+  agentId: string,
+  env: NodeJS.ProcessEnv = process.env,
+): string | undefined {
   const cwd =
     normalizeOptionalString(resolveAgentEntry(cfg, agentId)?.cwd) ??
     normalizeOptionalString(cfg.agents?.defaults?.cwd);
-  return cwd ? stripNullBytes(resolveUserPath(cwd)) : undefined;
+  return cwd ? stripNullBytes(resolveUserPath(cwd, env)) : undefined;
 }
 
 /** How a resolved agent workspace should be provisioned by the lifecycle owner. */

--- a/src/agents/cli-runner/cli-run-settlement.ts
+++ b/src/agents/cli-runner/cli-run-settlement.ts
@@ -641,6 +641,9 @@ export function buildCliRunResult(params: {
                 ...(context.promptToolNamesHash
                   ? { promptToolNamesHash: context.promptToolNamesHash }
                   : {}),
+                ...(isClaudeCliBackend(runParams.provider) && context.cwd
+                  ? { cwd: context.cwd }
+                  : {}),
                 ...(context.cwdHash ? { cwdHash: context.cwdHash } : {}),
                 ...(context.preparedBackend.mcpConfigHash
                   ? { mcpConfigHash: context.preparedBackend.mcpConfigHash }

--- a/src/agents/cli-runner/prepare.test.ts
+++ b/src/agents/cli-runner/prepare.test.ts
@@ -683,6 +683,7 @@ describe("prepareCliRunContext", () => {
   });
 
   beforeEach(() => {
+    vi.stubEnv("CLAUDE_CONFIG_DIR", undefined);
     // Install narrow test doubles for external runtime seams so preparation
     // remains about data flow, not bundled plugin or loopback startup cost.
     defaultTestCliBackend = buildDefaultTestCliBackend();
@@ -6314,6 +6315,51 @@ describe("prepareCliRunContext", () => {
     expect(transcriptCheck).not.toHaveBeenCalled();
     expect(orphanCheck).not.toHaveBeenCalled();
   });
+
+  it.each([false, true])(
+    "resumes a configured-root transcript without requiring a live generation (warm=%s)",
+    async (warm) => {
+      const taskDir = path.join(fixture.session.dir, "task");
+      fs.mkdirSync(taskDir);
+      const canonicalCwd = fs.realpathSync.native(taskDir);
+      const configDir = path.join(fixture.session.dir, "selected Claude");
+      const projectDir = path.join(
+        configDir,
+        "projects",
+        canonicalCwd.replace(/[^a-zA-Z0-9]/g, "-"),
+      );
+      fs.mkdirSync(projectDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(projectDir, "configured-session.jsonl"),
+        `${JSON.stringify({
+          type: "assistant",
+          message: { role: "assistant", content: [{ type: "text", text: "prior answer" }] },
+        })}\n`,
+      );
+      vi.stubEnv("CLAUDE_CONFIG_DIR", configDir);
+      setCliBackendForPrepareTest({ liveSession: true });
+      setCliRunnerPrepareTestDeps({
+        getCliLiveSessionGeneration: () => (warm ? "existing-generation" : undefined),
+      });
+
+      // Keep both transcript probes real: a false miss either invalidates the
+      // cold binding or unnecessarily pins the warm process generation.
+      const context = await fixture.prepare({
+        cwd: taskDir,
+        provider: "claude-cli",
+        model: "opus",
+        cliSessionBinding: {
+          sessionId: "configured-session",
+          cwdHash: hashCliSessionText(taskDir),
+        },
+      });
+      expect(context.reusableCliSession).toEqual({
+        mode: "reuse",
+        sessionId: "configured-session",
+      });
+      expect(context.requiredClaudeLiveSessionGeneration).toBeUndefined();
+    },
+  );
 
   it("checks claude-cli transcript content under the resolved cwd", async () => {
     const { dir } = fixture.session;

--- a/src/agents/cli-session.test.ts
+++ b/src/agents/cli-session.test.ts
@@ -38,6 +38,7 @@ describe("cli-session helpers", () => {
       extraSystemPromptHash: "prompt-hash",
       messageToolPolicyHash: "message-policy-hash",
       promptToolNamesHash: "prompt-tools-hash",
+      cwd: "/workspace/ child ",
       cwdHash: "cwd-hash",
       mcpConfigHash: "mcp-hash",
       mcpResumeHash: "mcp-resume-hash",
@@ -60,6 +61,7 @@ describe("cli-session helpers", () => {
       extraSystemPromptHash: "prompt-hash",
       messageToolPolicyHash: "message-policy-hash",
       promptToolNamesHash: "prompt-tools-hash",
+      cwd: "/workspace/ child ",
       cwdHash: "cwd-hash",
       mcpConfigHash: "mcp-hash",
       mcpResumeHash: "mcp-resume-hash",
@@ -174,12 +176,18 @@ describe("cli-session helpers", () => {
     setCliSessionBinding(entry, "claude-cli", {
       sessionId: "cli-session-1",
       reseedReceipt: receipt,
+      cwd: "/workspace/first",
     });
-    setCliSessionBinding(entry, "claude-cli", { sessionId: "cli-session-1" });
+    setCliSessionBinding(entry, "claude-cli", {
+      sessionId: "cli-session-1",
+      cwd: "/workspace/second ",
+    });
+    expect(getCliSessionBinding(entry, "claude-cli")?.cwd).toBe("/workspace/second ");
     expect(getCliSessionBinding(entry, "claude-cli")?.reseedReceipt).toEqual(receipt);
 
     setCliSessionBinding(entry, "claude-cli", { sessionId: "cli-session-2" });
     expect(getCliSessionBinding(entry, "claude-cli")?.reseedReceipt).toBeUndefined();
+    expect(getCliSessionBinding(entry, "claude-cli")?.cwd).toBeUndefined();
   });
 
   it("force-reuses explicitly attached CLI sessions despite metadata drift", () => {
@@ -618,7 +626,10 @@ describe("cli-session helpers", () => {
       sessionId: "openclaw-session",
       updatedAt: Date.now(),
     };
-    setCliSessionBinding(entry, "claude-cli", { sessionId: "claude-session" });
+    setCliSessionBinding(entry, "claude-cli", {
+      sessionId: "claude-session",
+      cwd: "/workspace/child",
+    });
     setCliSessionBinding(entry, "codex-cli", { sessionId: "codex-session" });
 
     clearCliSession(entry, "codex-cli");

--- a/src/agents/cli-session.ts
+++ b/src/agents/cli-session.ts
@@ -111,6 +111,7 @@ export function setCliSessionBinding(
       ...(normalizeOptionalString(binding.promptToolNamesHash)
         ? { promptToolNamesHash: normalizeOptionalString(binding.promptToolNamesHash) }
         : {}),
+      ...(typeof binding.cwd === "string" && binding.cwd ? { cwd: binding.cwd } : {}),
       ...(normalizeOptionalString(binding.cwdHash)
         ? { cwdHash: normalizeOptionalString(binding.cwdHash) }
         : {}),

--- a/src/agents/command/attempt-execution.cli.test.ts
+++ b/src/agents/command/attempt-execution.cli.test.ts
@@ -604,6 +604,8 @@ describe("CLI attempt execution", () => {
     body?: string;
     transcriptBody?: string;
     providerOverride?: string;
+    originalProvider?: string;
+    cwd?: string;
     modelOverride?: string;
     isFallbackRetry?: boolean;
     fallbackRuntimeState?: RunAgentAttemptParams["fallbackRuntimeState"];
@@ -645,7 +647,7 @@ describe("CLI attempt execution", () => {
 
     await runAgentAttempt({
       providerOverride,
-      originalProvider: "openai",
+      originalProvider: overrides?.originalProvider ?? "openai",
       modelOverride: overrides?.modelOverride ?? "gpt-5.4",
       configuredAuthProfileId: overrides?.configuredAuthProfileId,
       cfg: overrides?.config ?? ({ session: { store: storePath } } as OpenClawConfig),
@@ -653,6 +655,7 @@ describe("CLI attempt execution", () => {
       sessionKey,
       sessionFile: path.join(tmpDir, `${runId}.jsonl`),
       workspaceDir: tmpDir,
+      cwd: overrides?.cwd,
       body: overrides?.body ?? "stream gate",
       transcriptBody: overrides?.transcriptBody,
       isFallbackRetry: overrides?.isFallbackRetry ?? false,
@@ -3535,6 +3538,55 @@ describe("CLI attempt execution", () => {
       model: "claude-sonnet-4-6",
     });
   });
+
+  it.each(["absolute", "relative", "bound"] as const)(
+    "seeds the actual fallback prompt from the %s Claude config directory",
+    async (kind) => {
+      const homeDir = path.join(tmpDir, "fallback-home");
+      const childCwd = path.join(tmpDir, "task-subdirectory");
+      await fs.mkdir(childCwd, { recursive: true });
+      const configDir =
+        kind === "absolute" ? path.join(tmpDir, "alternate Claude") : "alternate Claude";
+      vi.stubEnv("HOME", homeDir);
+      vi.stubEnv("CLAUDE_CONFIG_DIR", configDir);
+      const cliSessionId = "configured-fallback-session";
+      const projectKey = (await fs.realpath(childCwd)).replace(/[^a-zA-Z0-9]/g, "-");
+      for (const [root, text] of [
+        [path.resolve(childCwd, configDir), "Native configured history"],
+        [path.join(homeDir, ".claude"), "Wrong default history"],
+      ] as const) {
+        const projectDir = path.join(root, "projects", projectKey);
+        await fs.mkdir(projectDir, { recursive: true });
+        await fs.writeFile(
+          path.join(projectDir, `${cliSessionId}.jsonl`),
+          JSON.stringify({
+            type: "assistant",
+            message: { role: "assistant", content: text },
+          }) + "\n",
+        );
+      }
+      const attempt = await runOpenClawEmbeddedAttemptForTest({
+        originalProvider: "claude-cli",
+        isFallbackRetry: true,
+        cwd: kind === "bound" ? tmpDir : childCwd,
+        body: "Continue this task",
+        sessionEntry: {
+          cliSessionBindings: {
+            "claude-cli": {
+              sessionId: cliSessionId,
+              ...(kind === "bound" ? { cwd: childCwd } : {}),
+            },
+          },
+        },
+      });
+      if (typeof attempt.prompt !== "string") {
+        throw new Error("Expected the fallback model to receive a text prompt");
+      }
+      expect(attempt.prompt).toContain("Native configured history");
+      expect(attempt.prompt).not.toContain("Wrong default history");
+      expect(attempt.prompt.match(/Continue this task/g)).toHaveLength(1);
+    },
+  );
 
   it("routes canonical Anthropic models through the configured Claude CLI runtime", async () => {
     const sessionKey = "agent:main:direct:canonical-claude-cli";

--- a/src/agents/command/attempt-execution.helpers.ts
+++ b/src/agents/command/attempt-execution.helpers.ts
@@ -455,13 +455,18 @@ function formatClaudeCliFallbackPrelude(
 export function buildClaudeCliFallbackContextPrelude(params: {
   cliSessionId: string | undefined;
   homeDir?: string;
+  cwd?: string;
   charBudget?: number;
 }): string {
   const sessionId = params.cliSessionId?.trim();
   if (!sessionId) {
     return "";
   }
-  const seed = readClaudeCliFallbackSeed({ cliSessionId: sessionId, homeDir: params.homeDir });
+  const seed = readClaudeCliFallbackSeed({
+    cliSessionId: sessionId,
+    homeDir: params.homeDir,
+    cwd: params.cwd,
+  });
   if (!seed) {
     return "";
   }

--- a/src/agents/command/attempt-execution.test.ts
+++ b/src/agents/command/attempt-execution.test.ts
@@ -38,6 +38,8 @@ import {
 } from "./attempt-execution.helpers.test-support.js";
 import { resolveClaudeCliProjectDirForWorkspace } from "./claude-cli-project-dir.js";
 
+beforeEach(() => vi.stubEnv("CLAUDE_CONFIG_DIR", undefined));
+
 describe("resolveFallbackRetryPrompt", () => {
   const originalBody = "Summarize the quarterly earnings report and highlight key trends.";
 
@@ -485,6 +487,33 @@ describe("claudeCliSessionTranscriptHasContent", () => {
   }
 
   const GRACE_MS = 250;
+
+  it("probes only the configured Claude root for content and orphaned tools", async () => {
+    const workspaceDir = await fs.realpath(await makeWorkspace());
+    const configDir = path.join(tmpDir, "selected Claude");
+    const projectKey = workspaceDir.replace(/[^a-zA-Z0-9]/g, "-");
+    const sessionId = "configured-session";
+    const selectedFile = path.join(configDir, "projects", projectKey, `${sessionId}.jsonl`);
+    const defaultFile = path.join(tmpDir, ".claude", "projects", projectKey, `${sessionId}.jsonl`);
+    for (const [file, content] of [
+      [selectedFile, [{ type: "tool_use", id: "unanswered", name: "Read", input: {} }]],
+      [defaultFile, [{ type: "text", text: "default-root decoy" }]],
+    ] as const) {
+      await fs.mkdir(path.dirname(file), { recursive: true });
+      await fs.writeFile(file, `${JSON.stringify({ message: { role: "assistant", content } })}\n`);
+    }
+    vi.stubEnv("CLAUDE_CONFIG_DIR", configDir);
+    try {
+      const target = { sessionId, workspaceDir, homeDir: tmpDir };
+      expect(await claudeCliSessionTranscriptHasContent(target)).toBe(true);
+      expect(await claudeCliSessionTranscriptHasOrphanedToolUse(target)).toBe(true);
+      await fs.unlink(selectedFile);
+      expect(await claudeCliSessionTranscriptHasContent(target)).toBe(false);
+      expect(await claudeCliSessionTranscriptHasOrphanedToolUse(target)).toBe(false);
+    } finally {
+      vi.mocked(cliBackendLog.warn).mockClear();
+    }
+  });
 
   it("returns true when the Claude project transcript has an assistant message", async () => {
     const workspaceDir = await makeWorkspace();

--- a/src/agents/command/attempt-execution.ts
+++ b/src/agents/command/attempt-execution.ts
@@ -725,13 +725,17 @@ export function runAgentAttempt(params: {
     completionToolPolicies !== undefined &&
     isToolAllowedByPolicies("message", Object.values(completionToolPolicies)) &&
     isRuntimeToolAllowed("message", params.opts.toolsAllow);
+  const claudeCliBinding = getCliSessionBinding(params.sessionEntry, "claude-cli");
   const claudeCliFallbackPrelude =
     !isRawModelRun &&
     params.isFallbackRetry &&
     isClaudeCliProvider(params.originalProvider) &&
     !isClaudeCliProvider(params.providerOverride)
       ? buildClaudeCliFallbackContextPrelude({
-          cliSessionId: getCliSessionBinding(params.sessionEntry, "claude-cli")?.sessionId,
+          cliSessionId: claudeCliBinding?.sessionId,
+          cwd:
+            claudeCliBinding?.cwd ??
+            (params.cwd ? resolveUserPath(params.cwd) : params.workspaceDir),
         })
       : "";
   const resolvedPrompt = resolveFallbackRetryPrompt({

--- a/src/agents/command/claude-cli-project-dir.test.ts
+++ b/src/agents/command/claude-cli-project-dir.test.ts
@@ -1,0 +1,64 @@
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import { resolveClaudeCliProjectDirForWorkspace } from "./claude-cli-project-dir.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+describe("resolveClaudeCliProjectDirForWorkspace", () => {
+  let homeDir: string;
+  let workspaceDir: string;
+  let projectKey: string;
+
+  beforeEach(() => {
+    const root = fs.realpathSync.native(tempDirs.make("oc-claude-project-dir-"));
+    homeDir = path.join(root, "home");
+    workspaceDir = path.join(root, "workspace");
+    fs.mkdirSync(workspaceDir);
+    projectKey = workspaceDir.replace(/[^a-zA-Z0-9]/g, "-");
+  });
+
+  it.each([
+    { name: "unset", value: undefined, relativeRoot: undefined },
+    { name: "empty", value: "", relativeRoot: "" },
+    { name: "spaces only", value: "  ", relativeRoot: "  " },
+    { name: "relative", value: "claude config", relativeRoot: "claude config" },
+    { name: "trailing space", value: "claude config ", relativeRoot: "claude config " },
+    { name: "decomposed Unicode", value: "cafe\u0301", relativeRoot: "caf\u00e9" },
+  ])("matches Claude Code's $name config root", ({ value, relativeRoot }) => {
+    const expectedRoot =
+      relativeRoot === undefined
+        ? path.join(homeDir, ".claude")
+        : path.join(workspaceDir, relativeRoot);
+    expect(
+      resolveClaudeCliProjectDirForWorkspace({
+        workspaceDir,
+        env: { HOME: homeDir, CLAUDE_CONFIG_DIR: value },
+      }),
+    ).toBe(path.join(expectedRoot, "projects", projectKey));
+  });
+
+  it("uses an absolute config root and isolates an explicitly injected environment", () => {
+    const alternate = path.join(homeDir, "selected Claude");
+    vi.stubEnv("CLAUDE_CONFIG_DIR", alternate);
+    expect(resolveClaudeCliProjectDirForWorkspace({ workspaceDir, homeDir })).toBe(
+      path.join(alternate, "projects", projectKey),
+    );
+    expect(resolveClaudeCliProjectDirForWorkspace({ workspaceDir, homeDir, env: {} })).toBe(
+      path.join(homeDir, ".claude", "projects", projectKey),
+    );
+  });
+
+  it("resolves a relative config root and project key through a symlinked workspace", () => {
+    const link = path.join(path.dirname(workspaceDir), "workspace-link");
+    fs.symlinkSync(workspaceDir, link, process.platform === "win32" ? "junction" : "dir");
+    expect(
+      resolveClaudeCliProjectDirForWorkspace({
+        workspaceDir: link,
+        homeDir,
+        env: { CLAUDE_CONFIG_DIR: "claude" },
+      }),
+    ).toBe(path.join(workspaceDir, "claude", "projects", projectKey));
+  });
+});

--- a/src/agents/command/claude-cli-project-dir.ts
+++ b/src/agents/command/claude-cli-project-dir.ts
@@ -6,7 +6,6 @@ import os from "node:os";
 import path from "node:path";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 
-const CLAUDE_PROJECTS_DIRNAME = path.join(".claude", "projects");
 const MAX_SANITIZED_PROJECT_LENGTH = 200;
 
 // Claude CLI stores project state under a sanitized workspace key. Add a stable
@@ -38,16 +37,66 @@ function canonicalizeWorkspaceDir(workspaceDir: string): string {
   }
 }
 
+type ClaudeCliProjectsRootParams = {
+  homeDir?: string;
+  env?: NodeJS.ProcessEnv;
+  cwd?: string;
+};
+
+function resolveClaudeCliProjectsDir(params: ClaudeCliProjectsRootParams): string {
+  const env = params.env ?? process.env;
+  const homeDir = normalizeOptionalString(params.homeDir) || env.HOME || os.homedir();
+  // Native Claude uses nullish selection and NFC; empty values and spaces are paths.
+  const configDir = (env.CLAUDE_CONFIG_DIR ?? path.join(homeDir, ".claude")).normalize("NFC");
+  return path.join(configDir, "projects");
+}
+
+function isFullyQualifiedProjectsDir(projectsDir: string): boolean {
+  // Windows \profile is absolute to a drive, but still needs the child's drive.
+  return path.isAbsolute(projectsDir) && path.parse(projectsDir).root !== "\\";
+}
+
 /** Resolves Claude CLI's per-workspace project directory. */
 export function resolveClaudeCliProjectDirForWorkspace(params: {
   workspaceDir: string;
   homeDir?: string;
+  env?: NodeJS.ProcessEnv;
 }): string {
-  const homeDir = normalizeOptionalString(params.homeDir) || process.env.HOME || os.homedir();
   const canonicalWorkspaceDir = canonicalizeWorkspaceDir(params.workspaceDir);
-  return path.join(
-    homeDir,
-    CLAUDE_PROJECTS_DIRNAME,
+  return path.resolve(
+    canonicalWorkspaceDir,
+    resolveClaudeCliProjectsDir(params),
     sanitizeClaudeCliProjectKey(canonicalWorkspaceDir),
   );
+}
+
+/** Relative native roots require the child cwd, never an inferred Gateway cwd. */
+export function resolveClaudeCliProjectsRoot(
+  params: ClaudeCliProjectsRootParams,
+): string | undefined {
+  const projectsDir = resolveClaudeCliProjectsDir(params);
+  if (isFullyQualifiedProjectsDir(projectsDir)) {
+    return projectsDir;
+  }
+  return params.cwd ? path.resolve(canonicalizeWorkspaceDir(params.cwd), projectsDir) : undefined;
+}
+
+/** Keep native history discovery asynchronous, including symlinked child cwds. */
+export async function resolveClaudeCliProjectsRootAsync(
+  params: ClaudeCliProjectsRootParams,
+): Promise<string | undefined> {
+  const projectsDir = resolveClaudeCliProjectsDir(params);
+  if (isFullyQualifiedProjectsDir(projectsDir)) {
+    return projectsDir;
+  }
+  if (!params.cwd) {
+    return undefined;
+  }
+  let cwd = path.resolve(params.cwd).normalize("NFC");
+  try {
+    cwd = (await fs.promises.realpath(cwd)).normalize("NFC");
+  } catch {
+    // Match the synchronous workspace resolver when the original directory is gone.
+  }
+  return path.resolve(cwd, projectsDir);
 }

--- a/src/agents/command/claude-cli-project-dir.windows.test.ts
+++ b/src/agents/command/claude-cli-project-dir.windows.test.ts
@@ -1,0 +1,36 @@
+// Exercise Windows path semantics on every host with Node's real win32 implementation.
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("node:path", async () => {
+  const actual = await vi.importActual<typeof import("node:path")>("node:path");
+  return { ...actual, default: actual.win32 };
+});
+
+import {
+  resolveClaudeCliProjectDirForWorkspace,
+  resolveClaudeCliProjectsRoot,
+  resolveClaudeCliProjectsRootAsync,
+} from "./claude-cli-project-dir.js";
+
+const cwd = "Z:\\openclaw-config-dir-test\\workspace";
+
+describe("Windows Claude transcript roots", () => {
+  it.each([
+    ["\\profile", "Z:\\profile\\projects"],
+    ["D:\\profile", "D:\\profile\\projects"],
+    ["\\\\server\\share\\profile", "\\\\server\\share\\profile\\projects"],
+  ])("resolves %s consistently for runtime and history", async (configDir, expected) => {
+    const params = { cwd, env: { CLAUDE_CONFIG_DIR: configDir } };
+    expect(resolveClaudeCliProjectsRoot(params)).toBe(expected);
+    expect(await resolveClaudeCliProjectsRootAsync(params)).toBe(expected);
+    expect(resolveClaudeCliProjectDirForWorkspace({ ...params, workspaceDir: cwd })).toBe(
+      `${expected}\\Z--openclaw-config-dir-test-workspace`,
+    );
+  });
+
+  it("requires the child drive for a root-relative profile", async () => {
+    const params = { env: { CLAUDE_CONFIG_DIR: "\\profile" } };
+    expect(resolveClaudeCliProjectsRoot(params)).toBeUndefined();
+    expect(await resolveClaudeCliProjectsRootAsync(params)).toBeUndefined();
+  });
+});

--- a/src/commands/doctor-claude-cli.test.ts
+++ b/src/commands/doctor-claude-cli.test.ts
@@ -3,7 +3,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core/expect";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { resolveClaudeCliProjectDirForWorkspace } from "../agents/command/claude-cli-project-dir.js";
 import { noteClaudeCliHealth } from "./doctor-claude-cli.js";
 
@@ -52,6 +52,7 @@ function noteTitle(noteFn: ReturnType<typeof vi.fn>): string {
 }
 
 describe("noteClaudeCliHealth", () => {
+  beforeEach(() => vi.stubEnv("CLAUDE_CONFIG_DIR", undefined));
   afterEach(() => {
     resolveCliBackendConfigMock.mockReset();
     resolveModelAgentRuntimeMetadataMock
@@ -126,6 +127,68 @@ describe("noteClaudeCliHealth", () => {
       expect(noteFn).not.toHaveBeenCalled();
     });
   });
+
+  it.each([false, true, "home-relative"] as const)(
+    "checks the configured Claude root with a distinct run cwd=%s",
+    async (configuredCwd) => {
+      await withTempHome(({ homeDir, workspaceDir }) => {
+        const runCwd = configuredCwd
+          ? path.join(configuredCwd === "home-relative" ? homeDir : workspaceDir, "task")
+          : workspaceDir;
+        if (configuredCwd === "home-relative") {
+          vi.stubEnv("HOME", path.join(path.dirname(homeDir), "process-home"));
+          vi.stubEnv("OPENCLAW_HOME", path.join(path.dirname(homeDir), "process-home"));
+        }
+        fs.mkdirSync(runCwd, { recursive: true });
+        const configDir = configuredCwd ? "selected Claude" : path.join(homeDir, "selected Claude");
+        const projectKey = fs.realpathSync
+          .native(runCwd)
+          .normalize("NFC")
+          .replace(/[^a-zA-Z0-9]/g, "-");
+        const selectedDir = path.resolve(
+          fs.realpathSync.native(runCwd),
+          configDir,
+          "projects",
+          projectKey,
+        );
+        const defaultDir = path.join(homeDir, ".claude", "projects", projectKey);
+        fs.mkdirSync(selectedDir, { recursive: true });
+        fs.mkdirSync(path.dirname(defaultDir), { recursive: true });
+        fs.writeFileSync(defaultDir, "default-root decoy");
+        const cfg = {
+          agents: {
+            defaults: { model: "claude-cli/claude-sonnet-4-6" },
+            entries: {
+              main: {
+                default: true,
+                ...(configuredCwd
+                  ? { cwd: configuredCwd === "home-relative" ? "~/task" : runCwd }
+                  : {}),
+              },
+            },
+          },
+        };
+        const noteFn = vi.fn();
+        const deps = {
+          homeDir,
+          workspaceDir,
+          env: { HOME: homeDir, CLAUDE_CONFIG_DIR: configDir },
+          noteFn,
+          isAuthenticated: () => true,
+          resolveCommandPath: () => "/usr/bin/claude",
+        };
+        noteClaudeCliHealth(cfg, deps);
+        expect(noteFn).not.toHaveBeenCalled();
+
+        fs.rmdirSync(selectedDir);
+        fs.writeFileSync(selectedDir, "selected-root problem");
+        noteClaudeCliHealth(cfg, deps);
+        expect(noteFn).toHaveBeenCalledTimes(1);
+        expect(noteBody(noteFn)).toContain(`${selectedDir} exists but is not a directory.`);
+        expect(noteBody(noteFn)).not.toContain(defaultDir);
+      });
+    },
+  );
 
   it("probes auth with the same cleared environment as Claude execution", async () => {
     await withTempHome(({ homeDir, workspaceDir }) => {

--- a/src/commands/doctor-claude-cli.ts
+++ b/src/commands/doctor-claude-cli.ts
@@ -10,6 +10,7 @@ import { note } from "../../packages/terminal-core/src/note.js";
 import { resolveModelAgentRuntimeMetadata } from "../agents/agent-runtime-metadata.js";
 import {
   listAgentIds,
+  resolveAgentRunCwd,
   resolveAgentWorkspaceDir,
   tryResolveDefaultAgentId,
 } from "../agents/agent-scope-config.js";
@@ -139,8 +140,9 @@ function resolveClaudeCliWorkspaceTargets(params: {
           ? params.workspaceDir
           : resolveAgentWorkspaceDir(params.cfg, agentId, params.env);
       const projectDir = resolveClaudeCliProjectDirForWorkspace({
-        workspaceDir,
+        workspaceDir: resolveAgentRunCwd(params.cfg, agentId, params.env) ?? workspaceDir,
         homeDir: params.homeDir,
+        env: params.env,
       });
       return {
         agentId,

--- a/src/config/sessions/cli-session-binding.ts
+++ b/src/config/sessions/cli-session-binding.ts
@@ -84,6 +84,9 @@ export function getCliSessionBinding(
       extraSystemPromptHash: normalizeOptionalString(fromBindings?.extraSystemPromptHash),
       messageToolPolicyHash: normalizeOptionalString(fromBindings?.messageToolPolicyHash),
       promptToolNamesHash: normalizeOptionalString(fromBindings?.promptToolNamesHash),
+      ...(typeof fromBindings?.cwd === "string" && fromBindings.cwd
+        ? { cwd: fromBindings.cwd }
+        : {}),
       cwdHash: normalizeOptionalString(fromBindings?.cwdHash),
       mcpConfigHash: normalizeOptionalString(fromBindings?.mcpConfigHash),
       mcpResumeHash: normalizeOptionalString(fromBindings?.mcpResumeHash),

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -141,6 +141,8 @@ export type CliSessionBinding = {
   extraSystemPromptHash?: string;
   messageToolPolicyHash?: string;
   promptToolNamesHash?: string;
+  /** Native working directory for locating relative external transcript roots after restart. */
+  cwd?: string;
   cwdHash?: string;
   mcpConfigHash?: string;
   mcpResumeHash?: string;

--- a/src/gateway/cli-session-history.claude-config-dir.test.ts
+++ b/src/gateway/cli-session-history.claude-config-dir.test.ts
@@ -1,0 +1,123 @@
+// Native transcript locations are independent fixtures, including wrong-root decoys.
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { readClaudeCliSessionMessagesAsync } from "./cli-session-history.claude-snapshot.js";
+import {
+  readClaudeCliFallbackSeed,
+  readClaudeCliSessionMessages,
+} from "./cli-session-history.claude.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+const sessionId = "native-history-session";
+
+async function writeTranscript(root: string, text: string) {
+  // Native resume can find a session after its project folder has moved.
+  const projectDir = path.join(root, "projects", "moved-project");
+  await fs.mkdir(projectDir, { recursive: true });
+  await fs.writeFile(
+    path.join(projectDir, `${sessionId}.jsonl`),
+    JSON.stringify({
+      type: "assistant",
+      uuid: "native-assistant",
+      timestamp: "2026-09-01T10:00:00.000Z",
+      message: { role: "assistant", content: [{ type: "text", text }] },
+    }) + "\n",
+  );
+}
+
+async function fixture() {
+  const root = await fs.realpath(tempDirs.make("openclaw-claude-history-root-"));
+  const homeDir = path.join(root, "home");
+  const cwd = path.join(root, "child cwd");
+  await fs.mkdir(cwd, { recursive: true });
+  vi.stubEnv("HOME", path.join(root, "different-home"));
+  return { root, homeDir, cwd, cliSessionId: sessionId };
+}
+
+describe("Claude configured transcript roots", () => {
+  it.each(["unset", "absolute", "relative", "empty", "unicode"] as const)(
+    "reads the selected %s root consistently for sync, async, and fallback history",
+    async (kind) => {
+      const params = await fixture();
+      const defaultRoot = path.join(params.homeDir, ".claude");
+      const selectedRoot =
+        kind === "unset"
+          ? defaultRoot
+          : kind === "empty"
+            ? params.cwd
+            : kind === "relative"
+              ? path.join(params.cwd, "relative profile")
+              : kind === "unicode"
+                ? path.join(params.root, "café")
+                : path.join(params.root, "selected profile");
+      const configDir =
+        kind === "unset"
+          ? undefined
+          : kind === "empty"
+            ? ""
+            : kind === "relative"
+              ? "relative profile"
+              : kind === "unicode"
+                ? path.join(params.root, "cafe\u0301")
+                : selectedRoot;
+      vi.stubEnv("CLAUDE_CONFIG_DIR", configDir);
+      if (selectedRoot !== defaultRoot) {
+        await writeTranscript(defaultRoot, "Wrong default history");
+      }
+      await writeTranscript(selectedRoot, "Selected native history");
+      for (const result of [
+        readClaudeCliSessionMessages(params),
+        await readClaudeCliSessionMessagesAsync(params),
+        readClaudeCliFallbackSeed(params),
+      ]) {
+        expect(JSON.stringify(result)).toContain("Selected native history");
+        expect(JSON.stringify(result)).not.toContain("Wrong default history");
+      }
+    },
+  );
+
+  it("does not guess a relative root when the child cwd is unknown", async () => {
+    const { homeDir } = await fixture();
+    vi.stubEnv("CLAUDE_CONFIG_DIR", "relative profile");
+    await writeTranscript(path.join(homeDir, ".claude"), "Wrong default history");
+    const params = { cliSessionId: sessionId, homeDir };
+    expect(readClaudeCliSessionMessages(params)).toEqual([]);
+    expect(await readClaudeCliSessionMessagesAsync(params)).toEqual([]);
+    expect(readClaudeCliFallbackSeed(params)).toBeUndefined();
+  });
+
+  it("resolves a symlinked child cwd before the relative parent path", async () => {
+    const params = await fixture();
+    const physicalCwd = path.join(params.root, "physical", "child");
+    const logicalCwd = path.join(params.root, "logical");
+    await fs.mkdir(physicalCwd, { recursive: true });
+    await fs.symlink(physicalCwd, logicalCwd, process.platform === "win32" ? "junction" : "dir");
+    vi.stubEnv("CLAUDE_CONFIG_DIR", "../profile");
+    await writeTranscript(path.join(params.root, "profile"), "Wrong lexical parent");
+    await writeTranscript(path.join(params.root, "physical", "profile"), "Physical native history");
+    const lookup = { ...params, cwd: logicalCwd };
+    for (const messages of [
+      readClaudeCliSessionMessages(lookup),
+      await readClaudeCliSessionMessagesAsync(lookup),
+    ]) {
+      expect(JSON.stringify(messages)).toContain("Physical native history");
+      expect(JSON.stringify(messages)).not.toContain("Wrong lexical parent");
+    }
+  });
+
+  it("invalidates the imported snapshot when the selected profile changes", async () => {
+    const params = await fixture();
+    const firstRoot = path.join(params.root, "first-profile");
+    const secondRoot = path.join(params.root, "second-profile");
+    await writeTranscript(firstRoot, "History from profile A");
+    await writeTranscript(secondRoot, "History from profile B");
+    vi.stubEnv("CLAUDE_CONFIG_DIR", firstRoot);
+    expect(JSON.stringify(await readClaudeCliSessionMessagesAsync(params))).toContain("profile A");
+    vi.stubEnv("CLAUDE_CONFIG_DIR", secondRoot);
+    const messages = await readClaudeCliSessionMessagesAsync(params);
+    expect(JSON.stringify(messages)).toContain("profile B");
+    expect(JSON.stringify(messages)).not.toContain("profile A");
+  });
+});

--- a/src/gateway/cli-session-history.claude-snapshot.ts
+++ b/src/gateway/cli-session-history.claude-snapshot.ts
@@ -62,6 +62,7 @@ type Message = Record<string, unknown>;
 type HistoryParams = {
   cliSessionId: string;
   homeDir?: string;
+  cwd?: string;
   localSessionId?: string;
   reseedReceipt?: CliSessionReseedReceipt;
 };

--- a/src/gateway/cli-session-history.claude.ts
+++ b/src/gateway/cli-session-history.claude.ts
@@ -1,7 +1,6 @@
 // Claude CLI session history importer.
 // Converts Claude project JSONL into OpenClaw transcript-compatible messages.
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
 import {
   asFiniteNumber,
@@ -13,6 +12,10 @@ import {
   stripCliImageTurnContext,
 } from "../agents/cli-image-turn-correlation.js";
 import { hashCliReseedPrompt, parseCliReseedPrompt } from "../agents/cli-runner/reseed-envelope.js";
+import {
+  resolveClaudeCliProjectsRoot,
+  resolveClaudeCliProjectsRootAsync,
+} from "../agents/command/claude-cli-project-dir.js";
 import type { AgentMessage } from "../agents/runtime/index.js";
 import { redactTranscriptMessage } from "../agents/transcript-redact.js";
 import {
@@ -29,7 +32,6 @@ import {
 import { attachOpenClawTranscriptMeta } from "./session-transcript-readers.js";
 
 export const CLAUDE_CLI_PROVIDER = "claude-cli";
-const CLAUDE_PROJECTS_RELATIVE_DIR = path.join(".claude", "projects");
 
 export type ClaudeCliProjectEntry = {
   type?: unknown;
@@ -74,13 +76,11 @@ export function redactClaudeCliHistoryMessage(
   ) as unknown as TranscriptLikeMessage;
 }
 
-function resolveHistoryHomeDir(homeDir?: string): string {
-  return normalizeOptionalString(homeDir) || process.env.HOME || os.homedir();
-}
-
-function resolveClaudeProjectsDir(homeDir?: string): string {
-  return path.join(resolveHistoryHomeDir(homeDir), CLAUDE_PROJECTS_RELATIVE_DIR);
-}
+type ClaudeCliHistoryLookupParams = {
+  cliSessionId: string;
+  homeDir?: string;
+  cwd?: string;
+};
 
 function normalizeClaudeCliSessionId(value: string): string | undefined {
   const sessionId = value.trim();
@@ -452,15 +452,15 @@ export function parseClaudeCliHistoryEntry(
   ) as TranscriptLikeMessage;
 }
 
-function resolveClaudeCliSessionFilePath(params: {
-  cliSessionId: string;
-  homeDir?: string;
-}): string | undefined {
+function resolveClaudeCliSessionFilePath(params: ClaudeCliHistoryLookupParams): string | undefined {
   const sessionId = normalizeClaudeCliSessionId(params.cliSessionId);
   if (!sessionId) {
     return undefined;
   }
-  const projectsDir = resolveClaudeProjectsDir(params.homeDir);
+  const projectsDir = resolveClaudeCliProjectsRoot(params);
+  if (!projectsDir) {
+    return undefined;
+  }
   let projectEntries: fs.Dirent[];
   try {
     projectEntries = fs.readdirSync(projectsDir, { withFileTypes: true });
@@ -481,15 +481,17 @@ function resolveClaudeCliSessionFilePath(params: {
   return undefined;
 }
 
-export async function resolveClaudeCliSessionFilePathAsync(params: {
-  cliSessionId: string;
-  homeDir?: string;
-}): Promise<string | undefined> {
+export async function resolveClaudeCliSessionFilePathAsync(
+  params: ClaudeCliHistoryLookupParams,
+): Promise<string | undefined> {
   const sessionId = normalizeClaudeCliSessionId(params.cliSessionId);
   if (!sessionId) {
     return undefined;
   }
-  const projectsDir = resolveClaudeProjectsDir(params.homeDir);
+  const projectsDir = await resolveClaudeCliProjectsRootAsync(params);
+  if (!projectsDir) {
+    return undefined;
+  }
   let projectEntries: fs.Dirent[];
   try {
     projectEntries = await fs.promises.readdir(projectsDir, { withFileTypes: true });
@@ -529,12 +531,12 @@ export async function resolveClaudeCliSessionFilePathAsync(params: {
 }
 
 /** Reads visible messages for a bound Claude CLI session. */
-export function readClaudeCliSessionMessages(params: {
-  cliSessionId: string;
-  homeDir?: string;
-  localSessionId?: string;
-  reseedReceipt?: CliSessionReseedReceipt;
-}): TranscriptLikeMessage[] {
+export function readClaudeCliSessionMessages(
+  params: ClaudeCliHistoryLookupParams & {
+    localSessionId?: string;
+    reseedReceipt?: CliSessionReseedReceipt;
+  },
+): TranscriptLikeMessage[] {
   const filePath = resolveClaudeCliSessionFilePath(params);
   if (!filePath) {
     return [];
@@ -625,10 +627,9 @@ function extractSummaryText(entry: ClaudeCliProjectEntry): string | undefined {
   return typeof summary === "string" && summary.trim() ? summary.trim() : undefined;
 }
 
-export function readClaudeCliFallbackSeed(params: {
-  cliSessionId: string;
-  homeDir?: string;
-}): ClaudeCliFallbackSeed | undefined {
+export function readClaudeCliFallbackSeed(
+  params: ClaudeCliHistoryLookupParams,
+): ClaudeCliFallbackSeed | undefined {
   const filePath = resolveClaudeCliSessionFilePath(params);
   if (!filePath) {
     return undefined;

--- a/src/gateway/cli-session-history.ts
+++ b/src/gateway/cli-session-history.ts
@@ -23,6 +23,7 @@ type CliSessionHistoryParams = {
   provider?: string;
   localMessages: unknown[];
   homeDir?: string;
+  cwd?: string;
   preparedImportedMessages?: unknown[];
 };
 
@@ -52,6 +53,7 @@ export function resolveChatHistoryWithCliSessionImports(params: CliSessionHistor
     readClaudeCliSessionMessages({
       cliSessionId: binding.sessionId,
       homeDir: params.homeDir,
+      cwd: binding.cwd ?? params.cwd,
       localSessionId: params.entry?.sessionId,
       reseedReceipt: binding.reseedReceipt,
     });
@@ -80,6 +82,7 @@ export async function readChatHistoryCliSessionImportSnapshot(
     ? await readClaudeCliSessionMessagesAsync({
         cliSessionId: binding.sessionId,
         homeDir: params.homeDir,
+        cwd: binding.cwd ?? params.cwd,
         localSessionId: params.entry?.sessionId,
         reseedReceipt: binding.reseedReceipt,
       })

--- a/src/gateway/server-methods/chat-history-handler.cli-import.test.ts
+++ b/src/gateway/server-methods/chat-history-handler.cli-import.test.ts
@@ -4,11 +4,15 @@ import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
 import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
 import { describe, expect, it, vi } from "vitest";
+import { buildPreparedCliRunContext } from "../../agents/cli-runner.test-helpers.js";
+import { buildCliRunResult } from "../../agents/cli-runner/cli-run-settlement.js";
+import { applyCliSessionBindingResult } from "../../agents/cli-session.js";
 import { composeTranscriptDisplay } from "../../chat/transcript-display-position.js";
 import {
   appendTranscriptMessage,
   upsertSessionEntryCore,
 } from "../../config/sessions/session-accessor.js";
+import { closeOpenClawAgentDatabasesForTest } from "../../state/openclaw-agent-db.js";
 import { withOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
 import {
   augmentChatHistoryWithCanvasBlocks,
@@ -44,6 +48,7 @@ async function withImportedHistory(
     read: (params: HistoryRequest) => Promise<HistoryPage>;
     importedIds: string[];
   }) => Promise<void>,
+  configKind: "default" | "absolute" | "relative" | "bound" = "default",
 ) {
   await withOpenClawTestState({ scenario: "minimal" }, async (state) => {
     const scope = {
@@ -52,12 +57,20 @@ async function withImportedHistory(
       sessionId: randomUUID(),
     };
     const cliSessionId = randomUUID();
+    const childCwd = path.join(state.root, "configured child cwd");
+    if (configKind === "relative" || configKind === "bound") {
+      await fs.mkdir(childCwd, { recursive: true });
+      await state.writeConfig({
+        agents: { defaults: { cwd: configKind === "bound" ? state.workspaceDir : childCwd } },
+      });
+    }
     const timestamp = Date.parse("2026-09-01T10:00:00Z");
     await upsertSessionEntryCore(scope, {
       sessionId: scope.sessionId,
       updatedAt: timestamp,
       providerOverride: "claude-cli",
       modelOverride: "claude-sonnet-4-6",
+      spawnedWorkspaceDir: state.workspaceDir,
       cliSessionBindings: { "claude-cli": { sessionId: cliSessionId } },
     });
     await appendTranscriptMessage(scope, {
@@ -66,8 +79,39 @@ async function withImportedHistory(
     await appendTranscriptMessage(scope, {
       message: { role: "assistant", content: "Local answer", timestamp: timestamp + 1 },
     });
+    if (configKind === "bound") {
+      // The original local transcript and current config do not own the later native cwd.
+      const context = buildPreparedCliRunContext({ provider: "claude-cli", ...scope });
+      context.cwd = childCwd;
+      const result = buildCliRunResult({
+        context,
+        output: { text: "Native turn completed" },
+        effectiveCliSessionId: cliSessionId,
+        bindingFlushOk: true,
+        usedHistoryPrompt: false,
+        userTurnHandled: true,
+        sessionBindingDisabled: false,
+        preparedContextAgentMeta: {},
+      });
+      const entry = { sessionId: scope.sessionId, updatedAt: timestamp + 2 };
+      applyCliSessionBindingResult(entry, "claude-cli", result.meta.agentMeta);
+      await upsertSessionEntryCore(scope, entry);
+      closeOpenClawAgentDatabasesForTest(state.stateDir);
+    }
     const importedIds = Array.from({ length: importedCount }, () => randomUUID());
-    const projectDir = path.join(state.home, ".claude", "projects", "synthetic-history");
+    const configDir = path.join(
+      configKind === "relative" || configKind === "bound" ? childCwd : state.home,
+      configKind === "default" ? ".claude" : "alternate-claude",
+    );
+    vi.stubEnv(
+      "CLAUDE_CONFIG_DIR",
+      configKind === "relative" || configKind === "bound"
+        ? "alternate-claude"
+        : configKind === "absolute"
+          ? configDir
+          : undefined,
+    );
+    const projectDir = path.join(configDir, "projects", "synthetic-history");
     await fs.mkdir(projectDir, { recursive: true });
     await fs.writeFile(
       path.join(projectDir, `${cliSessionId}.jsonl`),
@@ -192,6 +236,28 @@ function projectImportedSnapshot(messages: Record<string, unknown>[]) {
 }
 
 describe("CLI-imported history anchors", () => {
+  it.each([
+    ["chat.history", "absolute"],
+    ["chat.startup", "absolute"],
+    ["chat.history", "relative"],
+    ["chat.startup", "relative"],
+    ["chat.history", "bound"],
+    ["chat.startup", "bound"],
+  ] as const)("%s returns native history from %s CLAUDE_CONFIG_DIR", async (method, configKind) => {
+    await withImportedHistory(
+      method,
+      2,
+      "Configured Claude history",
+      async ({ read, importedIds }) => {
+        const page = await read({ limit: 20 });
+        expect(page.messages.map(readChatHistoryMessageId)).toEqual(
+          expect.arrayContaining(importedIds),
+        );
+        expect(JSON.stringify(page.messages)).toContain("Configured Claude history");
+      },
+      configKind,
+    );
+  });
   it.each(["chat.history", "chat.startup"] as const)(
     "%s keeps conversation and structured outcomes before trimming terminal tool history",
     async (method) => {

--- a/src/gateway/server-methods/chat-history-handler.ts
+++ b/src/gateway/server-methods/chat-history-handler.ts
@@ -7,7 +7,11 @@ import {
   validateChatStartupParams,
 } from "../../../packages/gateway-protocol/src/index.js";
 import { CHAT_HISTORY_MAX_ENTRIES } from "../../../packages/gateway-protocol/src/schema/chat-history-constants.js";
-import { resolveAgentConfig } from "../../agents/agent-scope.js";
+import {
+  resolveAgentConfig,
+  resolveAgentRunCwd,
+  resolveAgentWorkspaceDir,
+} from "../../agents/agent-scope.js";
 import { findModelCatalogEntry } from "../../agents/model-catalog.js";
 import { resolveConfiguredThinkingDefault } from "../../agents/model-thinking-default.js";
 import { composeTranscriptDisplay } from "../../chat/transcript-display-position.js";
@@ -301,6 +305,13 @@ async function handleChatHistoryRequest({
               effectiveMaxChars,
               offset,
               messageId,
+              // Match CLI preparation: task cwd takes precedence over workspace.
+              cwd: resolveClaudeCliBindingSessionId(historyEntry)
+                ? (historyEntry?.spawnedCwd ??
+                  resolveAgentRunCwd(cfg, sessionAgentId) ??
+                  historyEntry?.spawnedWorkspaceDir ??
+                  resolveAgentWorkspaceDir(cfg, sessionAgentId))
+                : undefined,
             }),
           {
             config: cfg,

--- a/src/gateway/server-methods/chat-history-pages.ts
+++ b/src/gateway/server-methods/chat-history-pages.ts
@@ -273,6 +273,7 @@ export async function readChatHistoryPage(params: {
   offset: number | undefined;
   messageId: string | undefined;
   ignoreCliSessionImports?: boolean;
+  cwd?: string;
 }): Promise<ChatHistoryPage> {
   const {
     entry,
@@ -443,6 +444,7 @@ export async function readChatHistoryPage(params: {
         entry,
         provider,
         localMessages: localMessagesWithBoundaryFilter,
+        cwd: params.cwd,
       });
   const cliHistory = params.ignoreCliSessionImports
     ? { messages: localMessagesWithBoundaryFilter, imported: false, expanded: false }
@@ -451,6 +453,7 @@ export async function readChatHistoryPage(params: {
         provider,
         localMessages: localMessagesWithBoundaryFilter,
         preparedImportedMessages: importedMessages,
+        cwd: params.cwd,
       });
   if ((offset !== undefined || messageId) && !cliHistory.imported) {
     return readChatHistoryPage({ ...params, ignoreCliSessionImports: true });
@@ -471,6 +474,7 @@ export async function readChatHistoryPage(params: {
       provider,
       localMessages: completeLocalMessages,
       preparedImportedMessages: importedMessages,
+      cwd: params.cwd,
     });
     if (!completeCliHistory.imported) {
       return readChatHistoryPage({ ...params, ignoreCliSessionImports: true });


### PR DESCRIPTION
Closes #145309

## What Problem This Solves

Users running Claude Code with `CLAUDE_CONFIG_DIR` could have an existing
conversation treated as missing, trigger a session reset or
`cli_live_session_changed`, and lose native history during fallback. The same
hardcoded default directory prevented imported Claude messages from appearing in
chat history.

This change makes transcript probes, Doctor, fallback context, and synchronous
and asynchronous history discovery use the same Claude project-directory owner.
It matches Claude's config-directory selection: nullish fallback, NFC
normalization, and relative paths resolved against the Claude child working
directory. A selected custom directory never falls through to the default
profile's transcript.

## Architecture and Scope

Doctor uses the configured CLI working directory when it differs from the agent
workspace. Successful Claude session settlement retains an optional `cwd` in the
existing native binding so later fallback and history reads can locate a relative
root after the session store is reopened. The existing header records the first
local cwd, while the binding's cwd hash can compare paths but cannot reconstruct
a later ad-hoc cwd.

This adds one optional path string to the existing binding JSON. It does not add
a SQLite schema version, migration, backfill, index, transaction, retention,
authentication, session-generation, fallback-policy, transcript-format, config,
or environment surface. Binding replacement and clearing already own the field's
lifecycle. Existing bindings without it use available session and agent cwd
hints; an arbitrary historical cwd that was never stored cannot be recovered.

### Maintainer decision required

Upstream maintainer acceptance of the retained-cwd contract is still pending.
Contributor authorization is not presented as satisfying the persistent-store
review checkpoint.

The exact-parent compatibility run established this behavior:

1. Candidate head writes `cwd` into a real schema-20 session row.
2. Exact parent `b9d14895e282` opens the same schema-20 database. Its normalized
   view ignores the unknown field, while the raw row retains it.
3. An unrelated parent entry update preserves the raw field.
4. A successful parent Claude binding replacement reconstructs the older known
   field set and drops `cwd`.
5. Candidate head reopens that row, keeps the native session ID, and selects the
   current configured cwd hint because the retained cwd is absent.
6. The next successful candidate binding write records the current child cwd
   again, and another reopen exposes it normally.

The concrete downgrade limit is therefore bounded to an older binary rewriting
the Claude binding. If the original relative-root cwd is no longer the current
configured cwd, history at that original location can remain undiscoverable after
re-upgrade until a current binary completes a turn and records its child cwd.
There is no automatic reconstruction promise.

Both the candidate and exact parent use agent database schema 20. Stable
`v2026.9.4` uses schema 19; the intervening bump came from unrelated #145172.
The exact parent is therefore the executable same-schema pre-feature comparator.
This PR does not claim a stable-release database round trip.

Requested decision: accept this optional retained-cwd contract and its
demonstrated downgrade limit, or defer persistence and accept the narrower
current-hints behavior.

### Named follow-ups

- **Backend/node environment ownership:** per-backend `env` or prepared-env
  overrides and node-host forwarding can still select a different native root.
- **Relative auth-probe cwd:** exact-head instrumentation showed the conversation
  `claude` process running in the agent cwd, while the separate
  `claude auth status --json` probe runs in the Gateway cwd. With relative
  `CLAUDE_CONFIG_DIR`, that probe can create native `.claude.json` metadata below
  a different process-relative root. Transcript selection in this PR is correct;
  provider-discovery auth-probe cwd ownership needs a separate repair.
- **Plugin session catalog:** catalog listing retains its existing blank and
  relative config-dir semantics; sharing the native contract needs the proper
  plugin or SDK boundary.
- **Manual compaction cwd:** the compaction caller's configured-cwd selection is
  a separate existing inconsistency. The new binding field records the cwd the
  child actually used.

## User Impact

Custom Claude profiles retain transcript lookup, fallback context, and imported
chat history. Users without `CLAUDE_CONFIG_DIR` keep the default
`~/.claude/projects` behavior. Existing session-ID path validation, canonical
workspace keys, moved-project scanning, redaction, and history cache and paging
behavior remain in place. No credentials are read or persisted by this change,
and no operator migration or updater action is required.

## Evidence

### Exact-Head Runtime Proof

The proof ran the built Gateway at
`384c93bd6fd1bff0fc3f0a30cbc6ed686aadd1e6`, its real RPC and SQLite paths, and
the official Claude Code 2.1.269 binary on Linux. Only Claude's upstream model
HTTP endpoint was replaced by a deterministic loopback mock, so the run used no
account or personal transcript state.

Sanitized absolute custom-root trace:

```text
turn 1: exit 0; native session S; Claude child P1
turn 2: exit 0; same session S; same warm child P1
selected custom root: one transcript for S
default root: conflicting decoy unchanged
Gateway stop: no Claude child remains
Gateway restart + turn 3: exit 0; new child P2; --resume S
Gateway logs: cli_live_session_changed=false; reset-like lines=0
chat.history: seeded user and assistant history present
direct native `claude --resume S` while Gateway stopped: marker + assistant reply appended
Gateway restart + chat.history: exact native marker and reply imported
cleanup: no Claude child remains
```

Controls also passed:

- unset `CLAUDE_CONFIG_DIR`: default `~/.claude` transcript, Gateway restart and
  resume, direct-native history import, no reset signal, and clean process exit;
- relative `CLAUDE_CONFIG_DIR`: transcript only below
  `<agent-cwd>/rel-claude/projects`, zero transcripts below the isolated HOME
  default, stable resume after Gateway restart, and clean process exit.

The relative run also produced the auth-probe follow-up described above. Its
instrumentation recorded only cwd, mode, option names, argument count, session
ID, and command hashes; prompts and credentials were not captured.

### Regression and Native-Contract Evidence

Synthetic fixtures place assistant JSONL only under
`<selected-config>/projects/<workspace-key>/<session-id>.jsonl`, with a
conflicting default-profile transcript where relevant.

- Baseline runtime resolution selects `<home>/.claude/projects` and misses the
  configured-only transcript; candidate resolution finds it. The default-root
  control still works.
- Baseline native-history matrix: **7 failed, 1 default control passed**.
  Candidate passes all eight tests across synchronous, asynchronous, and fallback
  readers; empty and relative roots; NFC; symlinks; and profile cache changes.
- Baseline fallback prompt uses the default-profile decoy. Candidate fallback
  uses configured native history and includes the current request once.
- Registered `chat.history` and `chat.startup` regressions fail before the repair
  and pass for absolute and relative roots afterward.
- Settlement through binding projection, SQLite serialization, close/reopen, and
  registered history handlers fails without recorded cwd and passes with it when
  the current configured cwd differs.
- Doctor's configured-cwd regression fails before the repair and passes afterward,
  including `~/task` resolved against its injected environment.
- Windows root-relative paths use the child drive; drive-qualified and UNC paths
  retain their roots. Four tests use Node's real `path.win32` implementation on
  every host; two failed before the correction.
- Official Claude Code 2.1.269 `project purge --dry-run` verifies unset, empty,
  spaces, relative, absolute, trailing-space, and physical symlink-parent
  selection. The installed official Agent SDK selector independently corroborates
  nullish selection and NFC.

```sh
node scripts/run-vitest.mjs run \
  src/agents/command/attempt-execution.test.ts \
  src/agents/command/attempt-execution.cli.test.ts \
  src/agents/cli-runner/prepare.test.ts \
  src/commands/doctor-claude-cli.test.ts \
  src/agents/command/claude-cli-project-dir.test.ts \
  src/agents/command/claude-cli-project-dir.windows.test.ts \
  src/gateway/cli-session-history.test.ts \
  src/gateway/cli-session-history.claude-config-dir.test.ts \
  src/gateway/server-methods/chat-history-handler.cli-import.test.ts \
  src/agents/cli-session.test.ts \
  src/agents/cli-runner/cli-run-settlement.test.ts \
  src/agents/agent-scope-config.test.ts \
  src/agents/agent-scope.test.ts
```

**721 tests passed in 13 files, 66.38 s**, against parent
`b9d14895e28249ffb3108be6ba229f4c62c93e34`.

Final validation on that parent:

- `node scripts/changed-lanes.mjs --base b9d14895e28249ffb3108be6ba229f4c62c93e34 --json` selected core, coreTests, and docs.
- `node scripts/check-changed.mjs --base b9d14895e28249ffb3108be6ba229f4c62c93e34` passed in 387.85 s, including formatting, lint, types, dead exports, schema/storage guards, and other applicable checks.
- `git diff --check` passed.
- Exact-head GitHub required CI is green.

Independent adversarial source review completed two passes with no unresolved
blocker or important finding inside this scope. Native Windows and macOS runs
remain unperformed; Windows path behavior is covered by `path.win32` tests. A
pre-existing Doctor-test path-display assumption when a temporary directory is
below effective HOME remains a separate test-portability follow-up.

Diff accounting: production +133/−40 (net +93), tests +495/−5, docs +17/−1.
Production growth carries the actual child cwd through existing settlement and
reader boundaries and provides one native-root owner to synchronous and
asynchronous consumers; it removes the prior duplicate HOME-only history
selector. A probe-only patch would leave the observed fallback and imported
history failures unresolved.

PR #145650 by @xiaoguomeiyitian is useful partial overlap for the absolute-root
case. This PR retains the broader owner-boundary repair because relative roots,
restart-visible cwd, Doctor, fallback, and imported history require the connected
scope above.
