### PR TITLE
perf(plugins): reuse enablement preparation for CLI descriptors

### DIFF
--- a/src/plugins/cli-root-descriptors.ts
+++ b/src/plugins/cli-root-descriptors.ts
@@ -3,7 +3,7 @@ import { collectUniqueCommandDescriptors } from "../cli/program/command-descript
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { PluginCliLoaderOptions } from "./cli-registry-loader.js";
 import { normalizePluginsConfig, resolveMemorySlotDecision } from "./config-state.js";
-import { isInstalledPluginEnabled } from "./installed-plugin-index.js";
+import { createInstalledPluginEnabledPredicate } from "./installed-plugin-index.js";
 import { validatePluginConfig } from "./loader-shared.js";
 import { normalizePluginPolicyId } from "./plugin-policy-id.js";
 import { buildPluginRuntimeLoadOptions } from "./runtime/load-context.js";
@@ -36,13 +36,18 @@ export async function getPluginCliCommandDescriptors(
     const memorySlot = context.config.plugins?.slots?.memory;
     const normalizedConfig = normalizePluginsConfig(context.config.plugins);
     const sourceConfig = normalizePluginsConfig(context.activationSourceConfig.plugins);
+    const isEnabled = createInstalledPluginEnabledPredicate(
+      snapshot.index.plugins,
+      context.config,
+      context.env,
+    );
 
     for (const plugin of snapshot.plugins) {
       if (seenPluginIds.has(plugin.id)) {
         continue;
       }
       seenPluginIds.add(plugin.id);
-      if (!isInstalledPluginEnabled(snapshot.index, plugin.id, context.config, context.env)) {
+      if (!isEnabled(plugin.id)) {
         continue;
       }
       const pluginConfig = normalizedConfig.entries[normalizePluginPolicyId(plugin.id)]?.config;

--- a/src/plugins/cli.test.ts
+++ b/src/plugins/cli.test.ts
@@ -343,6 +343,8 @@ describe("registerPluginCliCommands", () => {
 
   it("loads root-help descriptors from manifests without entering the plugin module loader", async () => {
     const { rawConfig, autoEnabledConfig } = createAutoEnabledCliFixture();
+    const siblingConfig = { enabled: false };
+    autoEnabledConfig.plugins!.entries!["external-cli"] = siblingConfig;
     mocks.applyPluginAutoEnable.mockReturnValue({
       config: autoEnabledConfig,
       changes: [],
@@ -350,7 +352,30 @@ describe("registerPluginCliCommands", () => {
         demo: ["demo configured"],
       },
     });
-    mocks.resolvePluginMetadataSnapshot.mockReturnValue(createCliMetadataSnapshot());
+    const snapshot = createCliMetadataSnapshot();
+    const sibling = {
+      id: "external-cli",
+      origin: "global",
+      format: "openclaw",
+      cliCommands: [
+        { name: "external-cli", description: "External utilities", hasSubcommands: false },
+      ],
+    };
+    const plugins = [...snapshot.plugins, sibling];
+    mocks.resolvePluginMetadataSnapshot.mockReturnValue({
+      ...snapshot,
+      index: {
+        ...snapshot.index,
+        plugins: [
+          ...snapshot.index.plugins,
+          { pluginId: "matrix", enabled: true, enabledByDefault: false, origin: "bundled" },
+          { pluginId: sibling.id, enabled: true, origin: sibling.origin },
+        ],
+      },
+      manifestRegistry: { plugins, diagnostics: [] },
+      plugins,
+      byPluginId: new Map(plugins.map((plugin) => [plugin.id, plugin])),
+    });
 
     await expect(getPluginCliCommandDescriptors(rawConfig)).resolves.toEqual([
       {
@@ -363,6 +388,11 @@ describe("registerPluginCliCommands", () => {
     const help = await renderRootHelpText({ config: rawConfig });
     expect(help).toContain("matrix *");
     expect(help).toContain("Matrix channel utilities");
+    expect(help).not.toContain("External utilities");
+
+    autoEnabledConfig.plugins!.entries!.matrix = { enabled: false };
+    siblingConfig.enabled = true;
+    await expect(getPluginCliCommandDescriptors(rawConfig)).resolves.toEqual(sibling.cliCommands);
     expect(mocks.loadOpenClawPluginCliRegistry).not.toHaveBeenCalled();
     expect(mocks.applyPluginAutoEnable).toHaveBeenCalledWith(
       expect.objectContaining({ config: rawConfig }),


### PR DESCRIPTION
Closes #145894

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Root CLI help repeats live activation-policy preparation for each installed manifest owner while collecting command descriptors.

## Why This Change Was Made

The descriptor owner now creates the existing installed-plugin enablement predicate once per synchronous operation, passing the same installed records, resolved config and environment. The predicate remains local to each call. Its existing duplicate handling and bundled-provider compatibility rules continue to own eligibility.

The manifest loop retains config/schema validation, memory-slot selection and command ordering. The later legacy external-plugin runtime fallback is unchanged. The existing root-help test now exercises mixed bundled/external owners and changed eligibility on a subsequent invocation.

## User Impact

Root help avoids repeated activation-source preparation while retaining the same command descriptors and per-call config freshness. Manifest-backed help remains independent of plugin runtime loading. Update behavior is unchanged: this metadata preparation change does not alter the updater, Doctor, state, plugin lifecycle or legacy runtime-loading flow.

## Evidence

The saved baseline and candidate suites each passed **62 cases: 61 permanent owner/sibling cases plus one temporary operation observation**. The temporary checkout copy was removed after proof, with its exact source and receipts preserved externally. All **29 selected checks** for the core/coreTests lanes passed. The gate used `origin/main`, observed at `bcc7cc90bb739013a0a2efd471ce6167f511fe9f`; both touched beforeimages match the authored base. Final source-bound P2 review reported no actionable findings.

For eight non-provider manifest owners, recorded `createPluginActivationSource` calls fell **8 → 1**, with identical descriptor output. Empty operations remained at **0** preparations and both arms recorded **0** runtime loads. This does not count all normalization: direct descriptor/schema normalization remains unchanged, and mixed bundled-provider compatibility may retain a separate second activation source.

The initial full-62 baseline run used an earlier runner before inherited-environment metadata reporting was corrected. The later baseline observation and candidate used the identical corrected runner with matching source/runtime/install bindings. The initial full-suite runner identities are not claimed identical.

These are operation counts, not timing, allocation-byte, retained-heap or RSS measurements. No broad optional suite, build or plugin-entrypoint profile was run; import topology and runtime-loading behavior are unchanged.
