### PR TITLE
perf(cli): stop overlay freshness scans at missing outputs

### DIFF
--- a/scripts/run-node.mts
+++ b/scripts/run-node.mts
@@ -476,20 +476,6 @@ const listBuiltBundledPluginEntries = (deps: RunNodeRequirementDeps) => {
     .toSorted((left, right) => left.id.localeCompare(right.id));
 };
 
-const listBuiltBundledPluginRuntimeOverlayDirs = (deps: RunNodeRequirementDeps) => {
-  const distExtensionsRoot = path.join(deps.distRoot, "extensions");
-  let entries;
-  try {
-    entries = deps.fs.readdirSync(distExtensionsRoot, { withFileTypes: true });
-  } catch {
-    return [];
-  }
-  return entries
-    .filter((entry) => entry.isDirectory() && entry.name !== "node_modules")
-    .map((entry) => entry.name)
-    .toSorted((left, right) => left.localeCompare(right));
-};
-
 const listRequiredBundledPluginMetadataOutputs = (
   pluginEntries: BundledPluginBuildEntry[],
   deps: RunNodeRequirementDeps,
@@ -506,9 +492,10 @@ const listRequiredBundledPluginMetadataOutputs = (
     return requiredPaths;
   });
 
-const listRuntimeOverlaySourcePaths = (sourceDir: string, deps: RunNodeRequirementDeps) => {
-  const paths: string[] = [];
-  const queue = [sourceDir];
+const hasMissingBundledPluginRuntimeOverlayOutput = (deps: RunNodeRequirementDeps) => {
+  const distExtensionsRoot = path.join(deps.distRoot, "extensions");
+  const runtimeExtensionsRoot = path.join(deps.cwd, "dist-runtime", "extensions");
+  const queue = [distExtensionsRoot];
   while (queue.length > 0) {
     const current = queue.pop();
     if (!current) {
@@ -529,26 +516,18 @@ const listRuntimeOverlaySourcePaths = (sourceDir: string, deps: RunNodeRequireme
         queue.push(entryPath);
         continue;
       }
-      if (entry.isFile() || entry.isSymbolicLink()) {
-        paths.push(entryPath);
+      if (current !== distExtensionsRoot && (entry.isFile() || entry.isSymbolicLink())) {
+        const runtimePath = path.join(
+          runtimeExtensionsRoot,
+          path.relative(distExtensionsRoot, entryPath),
+        );
+        if (statMtime(runtimePath, deps.fs) == null) {
+          return true;
+        }
       }
     }
   }
-  return paths.toSorted((left, right) => left.localeCompare(right));
-};
-
-const listRequiredBundledPluginRuntimeOverlayOutputs = (deps: RunNodeRequirementDeps) => {
-  const distRoot = deps.distRoot;
-  const runtimeRoot = path.join(deps.cwd, "dist-runtime");
-  const runtimePaths: string[] = [];
-  for (const pluginId of listBuiltBundledPluginRuntimeOverlayDirs(deps)) {
-    const distPluginDir = path.join(distRoot, "extensions", pluginId);
-    const runtimePluginDir = path.join(runtimeRoot, "extensions", pluginId);
-    for (const sourcePath of listRuntimeOverlaySourcePaths(distPluginDir, deps)) {
-      runtimePaths.push(path.join(runtimePluginDir, path.relative(distPluginDir, sourcePath)));
-    }
-  }
-  return [...new Set(runtimePaths)].toSorted((left, right) => left.localeCompare(right));
+  return false;
 };
 
 const isSafePluginSdkSubpathSegment = (subpath: string) =>
@@ -632,22 +611,21 @@ const listRequiredCoreRuntimePostBuildOutputs = (deps: RunNodeRequirementDeps) =
     path.join(deps.cwd, normalizePath(relativePath)),
   );
 
-/** Lists runtime postbuild outputs that must exist before the dev CLI starts. */
-const listRequiredRuntimePostBuildOutputs = (deps: RunNodeRequirementDeps) => {
+const hasMissingRequiredRuntimePostBuildOutput = (deps: RunNodeRequirementDeps) => {
   const builtPluginEntries = listBuiltBundledPluginEntries(deps);
-  return [
-    ...listRequiredCoreRuntimePostBuildOutputs(deps),
-    ...listRequiredOpenClawExtensionAliasOutputs(deps),
-    ...listRequiredStaticExtensionAssetOutputs(deps),
-    ...listRequiredBundledPluginMetadataOutputs(builtPluginEntries, deps),
-    ...listRequiredBundledPluginRuntimeOverlayOutputs(deps),
+  // Keep discovery failures ahead of missing-output checks.
+  const requiredOutputGroups = [
+    listRequiredCoreRuntimePostBuildOutputs(deps),
+    listRequiredOpenClawExtensionAliasOutputs(deps),
+    listRequiredStaticExtensionAssetOutputs(deps),
+    listRequiredBundledPluginMetadataOutputs(builtPluginEntries, deps),
   ];
-};
-
-const hasMissingRequiredRuntimePostBuildOutput = (deps: RunNodeRequirementDeps) =>
-  listRequiredRuntimePostBuildOutputs(deps).some(
-    (filePath) => statMtime(filePath, deps.fs) == null,
+  return (
+    requiredOutputGroups.some((outputs) =>
+      outputs.some((filePath) => statMtime(filePath, deps.fs) == null),
+    ) || hasMissingBundledPluginRuntimeOverlayOutput(deps)
   );
+};
 
 /** Decides whether source changes require a new dev build. */
 export const resolveBuildRequirement = (deps: RunNodeRequirementDeps): BuildRequirement => {

--- a/src/infra/run-node.test.ts
+++ b/src/infra/run-node.test.ts
@@ -1238,59 +1238,71 @@ describe("run-node script", () => {
     expect(runRuntimePostBuild).toHaveBeenCalledOnce();
   });
 
-  it("serializes runtime postbuild restaging across concurrent clean launchers", async ({
-    tmp,
-  }) => {
-    await setupStampedProject(tmp, { oldPaths: [ROOT_SRC, ROOT_TSCONFIG, ROOT_PACKAGE] });
+  it.for(["stamp", "overlay"])(
+    "serializes concurrent runtime restaging with a missing %s",
+    async (missing, { tmp }) => {
+      await setupStampedProject(tmp, {
+        files:
+          missing === "overlay"
+            ? {
+                [DIST_EXTENSION_INDEX]: "export default {};\n",
+                [RUNTIME_POSTBUILD_STAMP]: '{"head":"abc123"}\n',
+              }
+            : {},
+        oldPaths: [ROOT_SRC, ROOT_TSCONFIG, ROOT_PACKAGE],
+      });
 
-    let activePostbuilds = 0;
-    let maxActivePostbuilds = 0;
-    let markPostbuildStarted!: () => void;
-    let releasePostbuild!: () => void;
-    const postbuildStarted = new Promise<void>((resolve) => {
-      markPostbuildStarted = resolve;
-    });
-    const postbuildRelease = new Promise<void>((resolve) => {
-      releasePostbuild = resolve;
-    });
-    const runRuntimePostBuild = vi.fn(async () => {
-      activePostbuilds += 1;
-      maxActivePostbuilds = Math.max(maxActivePostbuilds, activePostbuilds);
-      markPostbuildStarted();
-      await postbuildRelease;
-      activePostbuilds -= 1;
-    });
-    const { spawn, spawnSync } = createCurrentGitSpawnRecorder();
+      let markPostbuildStarted!: () => void;
+      let releasePostbuild!: () => void;
+      const postbuildStarted = new Promise<void>((resolve) => {
+        markPostbuildStarted = resolve;
+      });
+      const postbuildRelease = new Promise<void>((resolve) => {
+        releasePostbuild = resolve;
+      });
+      let markWaiting!: () => void;
+      const waitingForLock = new Promise<void>((resolve) => {
+        markWaiting = resolve;
+      });
+      const runRuntimePostBuild = vi.fn(async () => {
+        markPostbuildStarted();
+        await postbuildRelease;
+        if (missing === "overlay") {
+          const runtimePath = resolvePath(tmp, DIST_RUNTIME_EXTENSION_INDEX);
+          await fs.mkdir(path.dirname(runtimePath), { recursive: true });
+          await fs.copyFile(resolvePath(tmp, DIST_EXTENSION_INDEX), runtimePath);
+        }
+      });
+      const { spawn, spawnSync } = createCurrentGitSpawnRecorder();
 
-    const runs = Promise.all([
-      runStatusCommand({
-        tmp,
+      const options = {
         spawn,
         spawnSync,
         env: {
+          OPENCLAW_RUNNER_LOG: "1",
           OPENCLAW_RUN_NODE_BUILD_LOCK_POLL_MS: "1",
         },
-        runRuntimePostBuild,
-      }),
-      runStatusCommand({
-        tmp,
-        spawn,
-        spawnSync,
-        env: {
-          OPENCLAW_RUN_NODE_BUILD_LOCK_POLL_MS: "1",
+        stderr: {
+          write: (chunk: string | Uint8Array) => {
+            if (String(chunk).includes("Waiting for TypeScript/runtime artifact lock")) {
+              markWaiting();
+            }
+            return true;
+          },
         },
         runRuntimePostBuild,
-      }),
-    ]);
+      };
+      const runs = Promise.all([runNodeCommand(tmp, options), runNodeCommand(tmp, options)]);
 
-    await postbuildStarted;
-    releasePostbuild();
-    await expect(runs).resolves.toEqual([0, 0]);
+      await postbuildStarted;
+      await waitingForLock;
+      releasePostbuild();
+      await expect(runs).resolves.toEqual([0, 0]);
 
-    expect(runRuntimePostBuild).toHaveBeenCalledTimes(1);
-    expect(maxActivePostbuilds).toBe(1);
-    expect(fsSync.existsSync(path.join(tmp, ".artifacts", "run-node-build.lock"))).toBe(false);
-  });
+      expect(runRuntimePostBuild).toHaveBeenCalledTimes(1);
+      expect(fsSync.existsSync(path.join(tmp, ".artifacts", "run-node-build.lock"))).toBe(false);
+    },
+  );
 
   it("returns the canonical build failure without starting the CLI", async ({ tmp }) => {
     const spawn = vi.fn((cmd: string, args: string[] = []) => {
@@ -1955,7 +1967,7 @@ describe("run-node script", () => {
     });
   });
 
-  it("reports missing runtime overlay outputs from restored dist without plugin sources", async ({
+  it("restages missing runtime overlays from restored dist without plugin sources", async ({
     tmp,
   }) => {
     await setupStampedProject(tmp, {
@@ -1972,12 +1984,21 @@ describe("run-node script", () => {
     await fs.rm(resolvePath(tmp, "extensions"), { recursive: true, force: true });
     await fs.rm(resolvePath(tmp, DIST_RUNTIME_EXTENSION_INDEX));
 
-    const requirement = resolveRuntimePostBuildRequirement(createBuildRequirementDeps(tmp));
-
-    expect(requirement).toEqual({
-      shouldSync: true,
-      reason: "missing_runtime_postbuild_output",
+    const { spawnCalls, spawn, spawnSync } = createCurrentGitSpawnRecorder();
+    const runRuntimePostBuild = vi.fn(async () => {
+      await fs.copyFile(
+        resolvePath(tmp, DIST_EXTENSION_INDEX),
+        resolvePath(tmp, DIST_RUNTIME_EXTENSION_INDEX),
+      );
     });
+    const exitCode = await runStatusCommand({ tmp, spawn, spawnSync, runRuntimePostBuild });
+
+    expect(exitCode).toBe(0);
+    expect(spawnCalls).toEqual([statusCommandSpawn()]);
+    expect(runRuntimePostBuild).toHaveBeenCalledOnce();
+    await expect(fs.readFile(resolvePath(tmp, DIST_RUNTIME_EXTENSION_INDEX), "utf8")).resolves.toBe(
+      "export default {};\n",
+    );
   });
 
   it("does not require OpenClaw SDK alias outputs when dist extensions are absent", async ({


### PR DESCRIPTION
Closes #145897

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Development CLI startup inventories and sorts every runtime-overlay output even when an early missing output has already established that restaging is required.

## Why This Change Was Made

Replace the private overlay inventories with a fresh boolean traversal that stops at a missing output. Other output producers stay eager and ordered, preserving discovery-error priority and the existing locked freshness checks.

## User Impact

The launcher keeps the same restage and launch behavior, including restored dist trees without plugin sources, directory/symlink eligibility, node_modules exclusions, native paths and valid zero modification times. The change removes 22 net production lines and adds 21 net test lines without a new test file, production seam or cache.

## Evidence

Against baseline `0cccc6d68e58ccd5030cd09931c1753bca924c7b`, the same strengthened suite passed 114 tests per version. Fourteen synthetic outcomes through the actual `runNodeMain` launcher matched. Early-missing source-directory reads fell 36→4 while destination stats stayed at two per version; all-present reads and stats stayed unchanged and fresh. The existing restoration and concurrency cases verify repaired output, a lock waiter and exactly one restage.

The full selected gate and source-bound P2 review passed. An initial check-only formatting failure occurred before tests or source swaps; the installed formatter corrected only assertion wrapping, and the failed record and pre-format snapshots remain retained. No standalone build or repeated test run was selected by the gate.

These are source-materialization and filesystem-operation observations on synthetic fixtures, with no timing, allocation-byte, RSS, real Gateway, container or Git-inventory claim.

Related: [#145664](https://github.com/openclaw/openclaw/pull/145664) changes the same artifact flow by adding shared ownership and a freshness recheck under that lock. It does not implement this traversal change. Preserve its ownership and static-asset policy changes if the work is composed; the B0 proof here does not establish results for that future combination.
