### PR TITLE
perf(heartbeat): reuse active-hours timezone formatters

### DIFF
--- a/src/infra/heartbeat-active-hours.ts
+++ b/src/infra/heartbeat-active-hours.ts
@@ -9,21 +9,28 @@ type HeartbeatConfig = AgentDefaultsConfig["heartbeat"];
 
 const ACTIVE_HOURS_TIME_PATTERN = /^(?:([01]\d|2[0-3]):([0-5]\d)|24:00)$/;
 
-/** Resolve the timezone used to evaluate heartbeat active hours. */
-function resolveActiveHoursTimezone(cfg: OpenClawConfig, raw?: string): string {
-  const trimmed = raw?.trim();
-  if (!trimmed || trimmed === "user") {
-    return resolveUserTimezone(cfg.agents?.defaults?.userTimezone);
-  }
-  if (trimmed === "local") {
+/** Resolve the formatter used to evaluate heartbeat active hours. */
+function resolveActiveHoursFormatter(
+  cfg: OpenClawConfig,
+  raw?: string,
+): Intl.DateTimeFormat | null {
+  let timeZone = raw?.trim();
+  const isExplicit = timeZone && timeZone !== "user" && timeZone !== "local";
+  if (!timeZone || timeZone === "user") {
+    timeZone = resolveUserTimezone(cfg.agents?.defaults?.userTimezone);
+  } else if (timeZone === "local") {
     const host = Intl.DateTimeFormat().resolvedOptions().timeZone;
-    return host?.trim() || "UTC";
+    timeZone = host?.trim() || "UTC";
   }
   try {
-    new Intl.DateTimeFormat("en-US", { timeZone: trimmed }).format(new Date());
-    return trimmed;
+    return new Intl.DateTimeFormat("en-US", {
+      timeZone,
+      hour: "2-digit",
+      minute: "2-digit",
+      hourCycle: "h23",
+    });
   } catch {
-    return resolveUserTimezone(cfg.agents?.defaults?.userTimezone);
+    return isExplicit ? resolveActiveHoursFormatter(cfg) : null;
   }
 }
 
@@ -86,16 +93,8 @@ export function isWithinActiveHours(
     return false;
   }
 
-  const timeZone = resolveActiveHoursTimezone(cfg, active.timezone);
-  let formatter: Intl.DateTimeFormat;
-  try {
-    formatter = new Intl.DateTimeFormat("en-US", {
-      timeZone,
-      hour: "2-digit",
-      minute: "2-digit",
-      hourCycle: "h23",
-    });
-  } catch {
+  const formatter = resolveActiveHoursFormatter(cfg, active.timezone);
+  if (!formatter) {
     return true;
   }
 


### PR DESCRIPTION
Closes #145899

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Heartbeat active-hours checks repeat timezone setup when an explicit timezone is configured. The check can validate that timezone and read its local time with the same formatter.

## Why This Change Was Made

The existing private resolver now returns the hour/minute formatter used by the active-hours predicate. Invalid explicit timezones retain the user-timezone fallback, local timezone reads remain fresh, and final formatter failures retain the existing permissive result.

Window comparisons, quiet-hours events, cron and targeted-wake handling, scheduling ownership and the shared date-time cache remain unchanged. No global cache or public API is added.

## User Impact

Active-hours behavior stays the same while a valid explicit-zone check constructs one formatter instead of two. The change removes one net production line and leaves maintained tests unchanged. This is a small cleanup, with no measured timing, allocation-byte, RSS or retained-memory improvement claimed.

## Evidence

Against baseline `0cccc6d68e58ccd5030cd09931c1753bca924c7b`, the same ten selected tests pass on both revisions: seven owner cases and three heartbeat-runner cases. The explicit name filter leaves 86 unrelated cases skipped per revision; no maintained tests were added or removed.

Thirty synthetic cases through `runHeartbeatOnce` produce identical result, event and queue records. Across the twelve explicit-zone cases, native-delegating instrumentation records 24 formatter constructions before and 12 after. These are construction counts only, not timing or memory measurements.

The boundary stops at quiet-hours or busy-queue outcomes before session, model or delivery work. Its isolated state stays empty, and the fixture and instrumentation are restored afterward. Proof ran on macOS with Node 26.8.2; no native Windows/Linux or live-provider coverage is claimed.

All 28 selected checks and the independent P2 review pass. Hosted CI and the completed PR review remain pending.
