### PR TITLE
fix(plugins): reject missing JavaScript entries in package verification

### DIFF
--- a/scripts/verify-plugin-npm-published-runtime.mts
+++ b/scripts/verify-plugin-npm-published-runtime.mts
@@ -138,15 +138,11 @@ export function collectPluginNpmPublishedRuntimeErrors(params: {
   }
 
   for (const [index, entry] of extensions.entries()) {
-    const runtimeEntry = runtimeExtensions[index];
+    const runtimeEntry = runtimeExtensions[index] ?? (isTypeScriptPackageEntry(entry) ? "" : entry);
     if (runtimeEntry) {
       if (!hasPackedFile(packageFiles, runtimeEntry)) {
         errors.push(`${packageLabel} runtime extension entry not found: ${runtimeEntry}`);
       }
-      continue;
-    }
-
-    if (!isTypeScriptPackageEntry(entry)) {
       continue;
     }
 

--- a/test/scripts/verify-plugin-npm-published-runtime.test.ts
+++ b/test/scripts/verify-plugin-npm-published-runtime.test.ts
@@ -98,6 +98,71 @@ describe("plugin npm publish verifier command limits", () => {
 });
 
 describe("collectPluginNpmPublishedRuntimeErrors", () => {
+  it.each(
+    [".js", ".mjs", ".cjs"].flatMap((extension) => [
+      { extension, present: false },
+      { extension, present: true },
+    ]),
+  )("checks declared $extension runtime presence (present=$present)", ({ extension, present }) => {
+    const entry = `./lib/index${extension}`;
+    expect(
+      collectPluginNpmPublishedRuntimeErrors({
+        packageJson: {
+          name: "runtime-entry-fixture",
+          openclaw: { extensions: [entry] },
+        },
+        files: ["package.json", "openclaw.plugin.json", ...(present ? [entry.slice(2)] : [])],
+      }),
+    ).toEqual(present ? [] : [`runtime-entry-fixture runtime extension entry not found: ${entry}`]);
+  });
+
+  it("reports a missing later JavaScript entry alongside valid JavaScript and TypeScript entries", () => {
+    expect(
+      collectPluginNpmPublishedRuntimeErrors({
+        packageJson: {
+          name: "runtime-entry-fixture",
+          openclaw: { extensions: ["./first.js", "./second.mjs", "./third.cts"] },
+        },
+        files: ["package.json", "openclaw.plugin.json", "first.js", "dist/third.cjs"],
+      }),
+    ).toEqual(["runtime-entry-fixture runtime extension entry not found: ./second.mjs"]);
+  });
+
+  it.each([
+    {
+      name: "uses a valid override without the declared source",
+      sourcePresent: false,
+      runtimePresent: true,
+    },
+    {
+      name: "rejects a missing override despite the declared source",
+      sourcePresent: true,
+      runtimePresent: false,
+    },
+  ])("$name for JavaScript entries", ({ sourcePresent, runtimePresent }) => {
+    expect(
+      collectPluginNpmPublishedRuntimeErrors({
+        packageJson: {
+          name: "runtime-entry-fixture",
+          openclaw: {
+            extensions: ["./index.js"],
+            runtimeExtensions: ["./dist/runtime.cjs"],
+          },
+        },
+        files: [
+          "package.json",
+          "openclaw.plugin.json",
+          ...(sourcePresent ? ["index.js"] : []),
+          ...(runtimePresent ? ["dist/runtime.cjs"] : []),
+        ],
+      }),
+    ).toEqual(
+      runtimePresent
+        ? []
+        : ["runtime-entry-fixture runtime extension entry not found: ./dist/runtime.cjs"],
+    );
+  });
+
   it.each([".ts", ".tsx", ".mts", ".cts"])(
     "rejects source-only %s runtime and setup entries",
     (extension) => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where plugin package verification reported success when a declared JavaScript entry file was missing. Ordinary `.js`, `.mjs`, and `.cjs` entries were skipped unless a runtime override was configured, even though the installer requires the selected entry to exist.

## Why This Change Was Made

The verifier resolves the effective entry once and reuses its existing packed-file check, removing the unconditional non-TypeScript skip. Explicit runtime overrides remain authoritative; TypeScript compiled-entry inference and setup-entry checks keep their existing behavior. Production is **+1/−5, net −4**; regression coverage adds 65 test lines.

## User Impact

Package verification now reports missing declared JavaScript entry files instead of a misleading OK result. This checks file presence; successful verification alone does not establish plugin importability or runtime readiness.

## Evidence

- Tests-first: four intended failures and 36 passing controls in the complete verifier suite. Candidate: all 40 verifier tests and nine installer/runtime sibling tests pass. Full changed checks and formatting pass.
- Genuine offline local npm pack/view and tar extraction through the public verifier: 12 cases per phase. Four missing-entry cases change from OK/exit 0 to the exact missing-entry error/exit 1. Eight controls preserve byte-identical output and exits, covering present JS variants, runtime overrides, TypeScript compilation requirements and setup entries.
- Fixtures and qualified dependencies remain unchanged; all processes and temporary package-extraction directories close naturally. No fixture module is imported, and no registry publication or installation is claimed.
- Managed independent review found no actionable P0–P2 findings. Source and runtime evidence were independently audited. Execution is pinned to `0325f01ac8e1b35c1d8af69f7b0c0da0d8d60f92` plus the patch; all 26 bound source inputs remain unchanged on `ed0df5bf09b778cf1175aafa770be561527ee02f`.
