### PR TITLE
fix(ui): release reply previews when connections retire

### DIFF
--- a/ui/src/pages/chat/chat-pane-context.ts
+++ b/ui/src/pages/chat/chat-pane-context.ts
@@ -336,6 +336,7 @@ export abstract class ChatPaneContext extends ChatPaneLifecycle {
       // A reconnect can retain the browser client. Keep async ownership tied
       // to the logical connection, not only the transport object identity.
       this.connectionGeneration += 1;
+      this.retireReplyMessages();
       this.retireHeaderSessionMutations();
       invalidateChatAvatarCache(state);
       state.assistantIdentityRequestVersion += 1;

--- a/ui/src/pages/chat/chat-pane-history-reply.test.ts
+++ b/ui/src/pages/chat/chat-pane-history-reply.test.ts
@@ -99,6 +99,7 @@ describe("chat pane reply-source history navigation", () => {
 
     pane.requestReplyMessage("source-message");
     await Promise.resolve();
+    pane.resetOlderMessagesViewport();
     pane.requestReplyMessage("source-message");
     expect(request).toHaveBeenCalledOnce();
     pane.connectionGeneration += 1;

--- a/ui/src/pages/chat/chat-pane-lifecycle.ts
+++ b/ui/src/pages/chat/chat-pane-lifecycle.ts
@@ -655,6 +655,7 @@ export abstract class ChatPaneLifecycle extends ChatPaneSessionCreation {
     this.paneResizeObserver?.disconnect();
     this.paneResizeObserver = null;
     this.connectionGeneration += 1;
+    this.retireReplyMessages();
     this.retireHeaderSessionMutations();
     this.retireDeferredSessionHydration();
     this.sessionDiscussionPanels.clear();

--- a/ui/src/pages/chat/chat-pane-reply-navigation.ts
+++ b/ui/src/pages/chat/chat-pane-reply-navigation.ts
@@ -118,6 +118,10 @@ export abstract class ChatPaneReplyNavigation extends ChatPaneSession {
     };
   }
 
+  protected retireReplyMessages(): void {
+    this.replyMessages.clear();
+  }
+
   protected resetReplyNavigation(): void {
     this.activeReplyNavigation = null;
     this.replyNavigationSessionKey = null;

--- a/ui/src/pages/chat/chat-pane-retained-presentation.test.ts
+++ b/ui/src/pages/chat/chat-pane-retained-presentation.test.ts
@@ -1,6 +1,7 @@
 /* @vitest-environment jsdom */
 /* @vitest-environment-options {"url":"http://chat-pane-retained.test/"} */
 
+import { queryObjects } from "node:v8";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../../../test/helpers/promise.js";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
@@ -8,6 +9,7 @@ import type { SessionWorkspaceGetResult } from "../../api/types.ts";
 import { chatInputOwnerForContext } from "../../app/chat-input-owner.ts";
 import { loadSettings, patchSettings } from "../../app/settings.ts";
 import type { SessionCapability } from "../../lib/sessions/index.ts";
+import { collectGarbageForTest } from "../../test-helpers/garbage-collection.ts";
 import { createStorageMock } from "../../test-helpers/storage.ts";
 import {
   getChatAttachmentDataUrl,
@@ -52,6 +54,57 @@ describe("chat pane retained presentation lifecycle", () => {
     resetChatComposerState();
     vi.unstubAllGlobals();
   });
+
+  it.each(["connection", "pane"] as const)(
+    "releases reply preview objects at the %s retirement boundary",
+    async (boundary) => {
+      class ReplyPreviewMessage {
+        role = "assistant";
+        content = "Previous connection's answer";
+      }
+      let preview: WeakRef<ReplyPreviewMessage> | undefined;
+      let requests = 0;
+      const client = createGatewayBrowserClientFixture({
+        request: async (method) => {
+          if (method !== "chat.message.get") {
+            return {};
+          }
+          requests += 1;
+          const message = new ReplyPreviewMessage();
+          preview = new WeakRef(message);
+          return { ok: true, message };
+        },
+      });
+      const { pane } = createTestChatPane({ client });
+      pane.requestReplyMessage("source-message");
+      await vi.waitFor(() => expect(pane.readReplyMessage("source-message")).toBeDefined());
+
+      pane.resetOlderMessagesViewport();
+      pane.presented = false;
+      pane.presented = true;
+      const retainedControl = new WeakRef({ unowned: true });
+      await collectGarbageForTest(() => {
+        queryObjects(ReplyPreviewMessage);
+      });
+      expect(retainedControl.deref()).toBeUndefined();
+      expect(preview!.deref()).toBeDefined();
+      pane.requestReplyMessage("source-message");
+      expect(requests).toBe(1);
+
+      if (boundary === "connection") {
+        pane.applyGatewaySnapshot({ ...pane.context.gateway.snapshot, phase: "stopped" });
+      } else {
+        pane.disconnectedCallback();
+      }
+      const retiredControl = new WeakRef({ unowned: true });
+      await collectGarbageForTest(() => {
+        queryObjects(ReplyPreviewMessage);
+      });
+      expect(retiredControl.deref()).toBeUndefined();
+      expect(preview!.deref()).toBeUndefined();
+      expect(pane.readReplyMessage("source-message")).toBeUndefined();
+    },
+  );
 
   it.each([false, true])(
     "restores dormant sidebar tabs for compact=%s without replacing saved task preferences",

--- a/ui/src/pages/chat/chat-pane.test-support.ts
+++ b/ui/src/pages/chat/chat-pane.test-support.ts
@@ -141,6 +141,9 @@ export type TestChatPane = HTMLElement & {
   prependUniqueNativeMessages: (messages: unknown[], current: unknown[]) => unknown[];
   prependUniqueCatalogMessages: (messages: unknown[]) => unknown[];
   loadOlderMessages: () => Promise<void>;
+  resetOlderMessagesViewport: () => void;
+  requestReplyMessage: (messageId: string) => void;
+  readReplyMessage: (messageId: string) => unknown;
   hasOlderMessages: () => boolean;
   loadingOlder: boolean;
   catalogCursor: string | undefined;


### PR DESCRIPTION
Closes #145906

## What Problem This Solves

Control UI panes retained fetched reply-preview payloads after their Gateway connection retired or the pane disconnected, even though those payloads could no longer be used.

## User Impact

Obsolete preview objects can be collected as soon as their connection or pane lifetime ends. Reply navigation, unavailable-message feedback, and reconnect recovery keep their existing behavior. This fixes object retention; it does not claim a measured allocation, RSS, or timing improvement.

## Why This Change Was Made

Clear the existing reply-preview owner's map at both connection-generation retirement boundaries. Keep successful responses and failed attempts cached across viewport resets and hide/show changes, with the existing 256-entry bound and stale-response guards.

## Evidence

The two reachability regressions fail on the original source through the actual connection-retirement and pane-disconnection callbacks. They verify that an unowned control can be collected while the obsolete cached payload remains reachable; the fix releases that payload before any refetch.

Final head `6dad1726711b248d23900ca5859b6caf49a9b17d` integrates main at `2ef09f01deba518303f6f92ec32f0fb148d10753`:

- All 40 focused unit cases passed: 22 retained-presentation, nine history/reply-navigation, and nine transcript/reply cases.
- All five existing bundled mocked-Gateway browser recovery cases passed. These checks cover the UI boundary; they are not live-provider proof.
- All mapped checks passed, including core and UI typechecks, formatting, three unused-export scans, and lint.
- Fresh independent review through P2 found no actionable findings. The later main integration preserved the exact six-file patch and every supplied review-context source.

The first mapped run encountered the pre-existing duplicate declaration fixed by #151417. Incorporating that existing main repair made the full check pass; this PR adds no separate fix for it. Hosted CI and the required hosted review are refreshed for this final head before landing.

## Before and after

These historical synthetic captures of the unavailable-source case are byte-identical: the same feedback and usable draft remain visible. They demonstrate unchanged presentation, while the lifecycle tests establish object release. Both images were inspected and verified rendering in the originating task and this PR.

| Before | After |
| --- | --- |
| ![Before: unavailable reply source](https://github.com/user-attachments/assets/193bf6a1-7a31-4959-9d80-348fd41f8dda) | ![After: unavailable reply source](https://github.com/user-attachments/assets/193bf6a1-7a31-4959-9d80-348fd41f8dda) |
