### PR TITLE
refactor: share model ID prefix normalization

### DIFF
--- a/packages/model-catalog-core/src/provider-model-id-normalization.ts
+++ b/packages/model-catalog-core/src/provider-model-id-normalization.ts
@@ -120,9 +120,9 @@ export function normalizeBuiltInProviderModelId(provider: string, model: string)
   ) {
     return normalizeGooglePreviewModelId(model);
   }
-  if (normalizedProvider === "openrouter") {
+  if (normalizedProvider === "openrouter" || normalizedProvider === "nvidia") {
     const trimmed = model.trim();
-    return trimmed && !trimmed.includes("/") ? `openrouter/${trimmed}` : model;
+    return trimmed && !trimmed.includes("/") ? `${normalizedProvider}/${trimmed}` : model;
   }
   if (normalizedProvider === "anthropic") {
     // Mirror the Anthropic manifest aliases for callers that skip manifest normalization.
@@ -142,11 +142,7 @@ export function normalizeBuiltInProviderModelId(provider: string, model: string)
       sonnet: "claude-sonnet-5",
       "sonnet-4.6": "claude-sonnet-4-6",
     };
-    const anthropicPrefix = "anthropic/";
-    const normalizedModel = normalizeLowercaseStringOrEmpty(model);
-    const providerModel = normalizedModel.startsWith(anthropicPrefix)
-      ? model.trim().slice(anthropicPrefix.length)
-      : model;
+    const providerModel = stripSelfProviderModelPrefix(normalizedProvider, model);
     return anthropicAliases[normalizeLowercaseStringOrEmpty(providerModel)] ?? providerModel;
   }
   if (normalizedProvider === "vercel-ai-gateway") {
@@ -167,10 +163,6 @@ export function normalizeBuiltInProviderModelId(provider: string, model: string)
       ? model.slice(prefix.length)
       : model;
   }
-  if (normalizedProvider === "nvidia") {
-    const trimmed = model.trim();
-    return trimmed && !trimmed.includes("/") ? `nvidia/${trimmed}` : model;
-  }
   if (normalizedProvider === "xai") {
     const xaiAliases: Record<string, string> = {
       "grok-4.3-latest": "grok-4.3",
@@ -180,9 +172,6 @@ export function normalizeBuiltInProviderModelId(provider: string, model: string)
       "grok-4-1-fast-reasoning": "grok-4-1-fast",
     };
     return xaiAliases[normalizeLowercaseStringOrEmpty(model)] ?? model;
-  }
-  if (normalizedProvider === "openai") {
-    return model;
   }
   if (normalizedProvider === "together") {
     return normalizeTogetherModelId(model);


### PR DESCRIPTION
## What Problem This Solves

Built-in model ID normalization repeated the same bare-ID qualification rule for two providers and duplicated an existing self-prefix helper. It also carried an explicit branch that returned the same value as the default path.

## Why This Change Was Made

Share OpenRouter/Nvidia qualification, reuse the same-file prefix helper for Anthropic, and remove the no-op return. This keeps the normalization policy in its existing owner and removes 11 production lines.

## User Impact

No intended behavior change. Model aliases, case and whitespace handling, already-qualified IDs, manifest ordering, exports, and function signatures remain unchanged. Other provider-specific rules retain their existing behavior.

## Evidence

The same 34 existing package and core-caller tests pass before and after the refactor. No tests or dependencies were added. Targeted lint, formatting, and diff checks pass. This is behavior-preservation evidence, not a red-to-green bug claim.

Canonical core and test checks passed. Independent review found no actionable P0–P2 findings.
