### PR TITLE
perf(sessions): retire unused discovery projections and copies

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -3026,7 +3026,7 @@ src/infra/session-cost-usage-aggregation.ts	5
 src/infra/session-cost-usage-cache.sqlite.ts	1
 src/infra/session-cost-usage-collection.ts	3
 src/infra/session-cost-usage-pricing.ts	6
-src/infra/session-cost-usage-reporting.ts	8
+src/infra/session-cost-usage-reporting.ts	5
 src/infra/session-delivery-queue-storage.ts	6
 src/infra/shell-env.ts	1
 src/infra/sqlite-audit-record-store.ts	1

--- a/src/gateway/server-methods/usage-session-loading.ts
+++ b/src/gateway/server-methods/usage-session-loading.ts
@@ -56,12 +56,13 @@ export async function discoverAllSessionsForUsage(params: {
         agentId,
         startMs: params.startMs,
         endMs: params.endMs,
-        includeFirstUserMessage: false,
       });
       return sessions.map((session) => Object.assign({}, session, { agentId }));
     }),
   );
-  return discovered.flat().toSorted((a, b) => b.mtime - a.mtime);
+  const allSessions = discovered.flat();
+  allSessions.sort((a, b) => b.mtime - a.mtime);
+  return allSessions;
 }
 
 export function mergeUsageCacheStatus(

--- a/src/gateway/server-methods/usage.sessions-usage-owner-attribution.integration.test.ts
+++ b/src/gateway/server-methods/usage.sessions-usage-owner-attribution.integration.test.ts
@@ -265,10 +265,7 @@ it.each([
 
       // Warm the real rollups so the handler assertion tests selection, not refresh timing.
       for (const agentId of ["main", "opus"]) {
-        const discovered = await discoverAllSessions({
-          agentId,
-          includeFirstUserMessage: false,
-        });
+        const discovered = await discoverAllSessions({ agentId });
         if (currentArtifact && agentId === "main") {
           expect(discovered[0]?.sessionId).not.toBe(currentId);
         }

--- a/src/gateway/server-methods/usage.sessions-usage.test.ts
+++ b/src/gateway/server-methods/usage.sessions-usage.test.ts
@@ -51,7 +51,6 @@ vi.mock("../../infra/session-cost-usage.js", async () => {
             sessionId: "s-main",
             sessionFile: "/tmp/agents/main/sessions/s-main.jsonl",
             mtime: 100,
-            firstUserMessage: "hello",
           },
         ];
       }
@@ -61,7 +60,6 @@ vi.mock("../../infra/session-cost-usage.js", async () => {
             sessionId: "s-opus",
             sessionFile: "/tmp/agents/opus/sessions/s-opus.jsonl",
             mtime: 200,
-            firstUserMessage: "hi",
           },
         ];
       }
@@ -71,7 +69,6 @@ vi.mock("../../infra/session-cost-usage.js", async () => {
             sessionId: "s-codex",
             sessionFile: "/tmp/agents/codex/sessions/s-codex.jsonl",
             mtime: 300,
-            firstUserMessage: "disk",
           },
         ];
       }

--- a/src/infra/session-cost-usage-reporting.ts
+++ b/src/infra/session-cost-usage-reporting.ts
@@ -49,7 +49,6 @@ export async function discoverAllSessions(params: {
   agentId: string;
   startMs?: number;
   endMs?: number;
-  includeFirstUserMessage?: boolean;
 }): Promise<DiscoveredSession[]> {
   const files = await listUsageCountedTranscriptStats(params.agentId, {
     minMtimeMs: params.startMs,
@@ -59,49 +58,12 @@ export async function discoverAllSessions(params: {
 
   for (const file of files) {
     // Do not exclude by endMs: a session can have activity in range even if it continued later.
-    const { filePath, sourcePath: sessionFile, sessionId } = file;
+    const { sourcePath: sessionFile, sessionId } = file;
     if (!sessionId) {
       continue;
     }
     const isPrimaryTranscript =
       file.kind === "sqlite" || isPrimarySessionTranscriptFileName(path.basename(sessionFile));
-
-    // Try to read first user message for label extraction
-    let firstUserMessage: string | undefined;
-    if (params.includeFirstUserMessage !== false) {
-      try {
-        for await (const parsed of readTranscriptRecords(filePath)) {
-          try {
-            const message = parsed.message as Record<string, unknown> | undefined;
-            if (message?.role === "user") {
-              const content = message.content;
-              if (typeof content === "string") {
-                firstUserMessage = truncateUtf16Safe(content, 100);
-              } else if (Array.isArray(content)) {
-                for (const block of content) {
-                  if (
-                    typeof block === "object" &&
-                    block &&
-                    (block as Record<string, unknown>).type === "text"
-                  ) {
-                    const text = (block as Record<string, unknown>).text;
-                    if (typeof text === "string") {
-                      firstUserMessage = truncateUtf16Safe(text, 100);
-                    }
-                    break;
-                  }
-                }
-              }
-              break; // Found first user message
-            }
-          } catch {
-            // Skip malformed lines
-          }
-        }
-      } catch {
-        // Ignore read errors
-      }
-    }
 
     const existing = discovered.get(sessionId);
     const existingIsPrimary = existing
@@ -117,19 +79,14 @@ export async function discoverAllSessions(params: {
         sessionId,
         sessionFile,
         mtime: file.mtimeMs,
-        firstUserMessage: firstUserMessage ?? existing?.firstUserMessage,
       });
-      continue;
-    }
-
-    if (!existing.firstUserMessage && firstUserMessage) {
-      existing.firstUserMessage = firstUserMessage;
-      discovered.set(sessionId, existing);
     }
   }
 
   // Sort by mtime descending (most recent first)
-  return Array.from(discovered.values()).toSorted((a, b) => b.mtime - a.mtime);
+  const sessions = Array.from(discovered.values());
+  sessions.sort((a, b) => b.mtime - a.mtime);
+  return sessions;
 }
 
 export async function loadSessionCostSummary(params: {

--- a/src/infra/session-cost-usage.archive-identity.test.ts
+++ b/src/infra/session-cost-usage.archive-identity.test.ts
@@ -272,7 +272,6 @@ describe("usage archive identity", () => {
               sessionId,
               sessionFile,
               mtime: sourceStats.mtimeMs,
-              firstUserMessage: "retained archive prompt",
             },
           ]);
 

--- a/src/infra/session-cost-usage.test.ts
+++ b/src/infra/session-cost-usage.test.ts
@@ -2309,11 +2309,6 @@ describe("session cost usage", () => {
     await withStateDir(root, async () => {
       const sessions = await discoverAllSessions();
       expect(sessions.map((session) => session.sessionId)).toEqual(["sess-deleted", "sess-reset"]);
-      expect(
-        sessions
-          .map((session) => session.firstUserMessage)
-          .toSorted((a, b) => String(a).localeCompare(String(b))),
-      ).toEqual(["deleted transcript", "reset transcript"]);
     });
   });
 
@@ -2357,7 +2352,6 @@ describe("session cost usage", () => {
       expect(sessions).toHaveLength(1);
       expect(sessions[0]?.sessionId).toBe("sess-shared");
       expect(sessions[0]?.sessionFile).toContain(".jsonl.deleted.");
-      expect(sessions[0]?.firstUserMessage).toBe("newer archive");
     });
   });
 
@@ -2398,40 +2392,6 @@ describe("session cost usage", () => {
       expect(sessions).toHaveLength(1);
       expect(sessions[0]?.sessionId).toBe("sess-live");
       expect(sessions[0]?.sessionFile).toBe(activePath);
-      expect(sessions[0]?.firstUserMessage).toBe("active transcript");
-    });
-  });
-
-  it("keeps discovered first-message text on a UTF-16 boundary", async () => {
-    const root = await makeSessionCostRoot("discover-utf16-first-message");
-    const sessionsDir = path.join(root, "agents", "main", "sessions");
-    await fs.mkdir(sessionsDir, { recursive: true });
-    const content = `${"a".repeat(99)}🚀tail`;
-    const fixtures = [
-      { sessionId: "sess-string", content },
-      { sessionId: "sess-block", content: [{ type: "text", text: content }] },
-    ];
-    for (const fixture of fixtures) {
-      await fs.writeFile(
-        path.join(sessionsDir, `${fixture.sessionId}.jsonl`),
-        JSON.stringify({
-          type: "message",
-          timestamp: "2026-02-21T17:47:00.000Z",
-          message: { role: "user", content: fixture.content },
-        }),
-        "utf-8",
-      );
-    }
-
-    await withStateDir(root, async () => {
-      const messages = new Map(
-        (await discoverAllSessions()).map((session) => [
-          session.sessionId,
-          session.firstUserMessage,
-        ]),
-      );
-      expect(messages.get("sess-string")).toBe("a".repeat(99));
-      expect(messages.get("sess-block")).toBe("a".repeat(99));
     });
   });
 

--- a/src/infra/session-cost-usage.types.ts
+++ b/src/infra/session-cost-usage.types.ts
@@ -158,7 +158,6 @@ export type DiscoveredSession = {
   sessionId: string;
   sessionFile: string;
   mtime: number;
-  firstUserMessage?: string;
 };
 
 export type SessionUsageTimePoint = SharedSessionUsageTimePoint;


### PR DESCRIPTION
Closes #145911

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Session discovery carries unused first-user-message extraction code and copies fresh result arrays again before sorting them. Its only production caller already disables snippet extraction, while session labels come from stored session entries.

## Why This Change Was Made

Remove the unused discovery option, result field, and obsolete test expectations. Retain the existing stored-label and transcript-title owners. Sort the newly created per-agent and flattened arrays in place; both sorting stages and stable tie order remain.

## User Impact

Usage responses retain their labels, fields, ordering, archive/SQLite identity and precedence, agent/family attribution, and cache behavior. Filesystem stats, SQLite aggregates, archive materialization, and errors are unchanged. The eight-file change removes 43 net production lines and 47 test lines. Its assertion-ratchet maintenance changes only the reporting owner from 8 to 5.

## Evidence

The original four-file focused suite passed 117 tests. The final candidate passed 116; the removed case tested only the retired discovery snippet. Existing archive, primary/newest precedence, and attribution coverage remains. Targeted lint, the final explicit-base 30-stage selected gate, and the source-bound P2 review passed.

Ten registered usage-handler requests per version returned identical complete normalized response envelopes and asserted success/error arguments. Only task-owned fixture paths were normalized, including paths in SQLite markers; raw responses were retained. Copy-sort operations fell from 30 to zero and copied reference slots from 120 to zero. Directory reads remained equal at one per request per agent. This is isolated registered-handler proof, without socket transport, timing, memory, or I/O savings claims. The only production caller already disabled first-message scans.

The final comparison reuses original-arm evidence with exact source, probe, dependency, lock, and Node bindings, and reruns the final candidate. Earlier attempts remain recorded: a disk-full/SQLite I/O failure before the candidate ran; timestamp and clamped-update fixture assumptions corrected using authoritative stats and persisted priorities; and gate failures resolved by the exact 8-to-5 ratchet reduction and lint-compliant standalone sorts. Assertions were retained through those corrections.

### Hosted CI validation

[CI attempt 1](https://github.com/openclaw/openclaw/actions/runs/34689753646/job/103542914324) failed when the existing rejected-update process test returned `spawnSync ETIMEDOUT` before its next output assertions. The precise cause remains unknown; no source, dependency, assertion or timeout was changed for the retry.

The single authorized [attempt 2](https://github.com/openclaw/openclaw/actions/runs/34689753646/job/103551960977) passed on the same tested checkout `989ceee55bd518c1e4da20e5cf3c8d7cdda2e3e4` and unchanged PR head `d8405bd119c7773b0949317c61bd0773c1a4ddc2`. The original rejected-update test passed, its CLI shard passed all 275 tests across seven files, and the [aggregate gate](https://github.com/openclaw/openclaw/actions/runs/34689753646/job/103553129604) succeeded. This validates the retry; it does not explain or repair the first timeout.
