### PR TITLE
perf(plugins): reuse model matches before prefix fallback

### DIFF
--- a/src/plugins/providers.test.ts
+++ b/src/plugins/providers.test.ts
@@ -1767,13 +1767,21 @@ describe("resolvePluginProviders", () => {
   });
 
   it("preserves LM Studio @iq* quant suffixes when resolving model-owned provider plugins", () => {
-    setManifestPlugin({
-      id: "lmstudio",
-      providerIds: ["lmstudio"],
-      modelSupport: {
-        modelPatterns: ["^qwen3\\.6-27b@iq3_xxs$"],
-      },
-    });
+    setManifestPlugins([
+      createManifestProviderPlugin({
+        id: "lmstudio",
+        providerIds: ["lmstudio"],
+        modelSupport: {
+          modelPatterns: ["^qwen3\\.6-27b@iq3_xxs$"],
+        },
+      }),
+      createManifestProviderPlugin({
+        id: "workspace-prefix",
+        providerIds: ["workspace-prefix"],
+        origin: "workspace",
+        modelSupport: { modelPrefixes: ["qwen3.6-27b@"] },
+      }),
+    ]);
     const provider: ProviderPlugin = {
       id: "lmstudio",
       label: "LM Studio",
@@ -1805,14 +1813,23 @@ describe("resolvePluginProviders", () => {
     });
   });
 
-  it("auto-loads a model-owned provider plugin from shorthand model refs", () => {
-    setManifestPlugin({
-      id: "openai",
-      providerIds: ["openai", "openai"],
-      modelSupport: {
-        modelPrefixes: ["gpt-", "o1", "o3", "o4"],
-      },
-    });
+  it("auto-loads a same-id prefix record after ambiguous pattern matches", () => {
+    setManifestPlugins([
+      createManifestProviderPlugin({
+        id: "openai",
+        providerIds: ["openai", "openai"],
+        modelSupport: {
+          modelPrefixes: ["gpt-", "o1", "o3", "o4"],
+        },
+      }),
+      ...["openai", "second-pattern"].map((id) =>
+        createManifestProviderPlugin({
+          id,
+          providerIds: [id],
+          modelSupport: { modelPatterns: ["^gpt-"], modelPrefixes: ["gpt-"] },
+        }),
+      ),
+    ]);
     const provider: ProviderPlugin = {
       id: "openai",
       label: "OpenAI",

--- a/src/plugins/providers.ts
+++ b/src/plugins/providers.ts
@@ -403,8 +403,6 @@ export function resolveActivatableProviderOwnerPluginIds(params: {
       }),
   });
 }
-type ModelSupportMatchKind = "pattern" | "prefix";
-
 function resolveManifestRegistry(params: {
   config?: PluginLoadOptions["config"];
   workspaceDir?: string;
@@ -463,10 +461,7 @@ function splitExplicitModelRef(rawModel: string): { provider?: string; modelId: 
   return { provider, modelId };
 }
 
-function resolveModelSupportMatchKind(
-  plugin: PluginManifestRecord,
-  modelId: string,
-): ModelSupportMatchKind | undefined {
+function matchesModelPattern(plugin: PluginManifestRecord, modelId: string): boolean {
   const patterns = plugin.modelSupport?.modelPatterns ?? [];
   for (const patternSource of patterns) {
     // compileSafeRegex rejects patterns with nested repetition (ReDoS risk)
@@ -474,16 +469,10 @@ function resolveModelSupportMatchKind(
     // will not match via that pattern but other patterns/prefixes still apply.
     const regex = compileSafeRegex(patternSource, "u");
     if (regex?.test(modelId)) {
-      return "pattern";
+      return true;
     }
   }
-  const prefixes = plugin.modelSupport?.modelPrefixes ?? [];
-  for (const prefix of prefixes) {
-    if (modelId.startsWith(prefix)) {
-      return "prefix";
-    }
-  }
-  return undefined;
+  return false;
 }
 
 function classifyProviderRefOwnership(pluginIds: string[] | undefined): ProviderRefOwnership {
@@ -700,20 +689,30 @@ export function resolveOwningPluginIdsForModelRef(params: {
     ...params,
     includeDisabled: true,
   });
-  const matchedByPattern = manifestRegistry.plugins
-    .filter((plugin) => resolveModelSupportMatchKind(plugin, parsed.modelId) === "pattern")
-    .map((plugin) => plugin.id);
+  const matchedByPattern = manifestRegistry.plugins.filter((plugin) =>
+    matchesModelPattern(plugin, parsed.modelId),
+  );
   const preferredPatternPluginIds = resolvePreferredManifestPluginIds(
     manifestRegistry,
-    matchedByPattern,
+    matchedByPattern.map((plugin) => plugin.id),
   );
   if (preferredPatternPluginIds) {
     return preferredPatternPluginIds;
   }
 
-  const matchedByPrefix = manifestRegistry.plugins
-    .filter((plugin) => resolveModelSupportMatchKind(plugin, parsed.modelId) === "prefix")
-    .map((plugin) => plugin.id);
+  const patternMatches = matchedByPattern.length > 0 ? new Set(matchedByPattern) : undefined;
+  const matchedByPrefix: string[] = [];
+  for (const plugin of manifestRegistry.plugins) {
+    if (patternMatches?.has(plugin)) {
+      continue;
+    }
+    for (const prefix of plugin.modelSupport?.modelPrefixes ?? []) {
+      if (parsed.modelId.startsWith(prefix)) {
+        matchedByPrefix.push(plugin.id);
+        break;
+      }
+    }
+  }
   return resolvePreferredManifestPluginIds(manifestRegistry, matchedByPrefix);
 }
 


### PR DESCRIPTION
Closes #145913

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Plugin ownership lookup repeats model-pattern matching during prefix fallback and prepares prefix results that are unused when a preferred pattern owner wins.

## Why This Change Was Made

Match patterns once and preserve the existing preferred-pattern early return. Only fallback evaluates prefixes, excluding exact pattern-matched record identities so a distinct prefix record with the same plugin ID can still qualify.

## User Impact

Owner selection, ambiguity handling, sorted/deduplicated results, model-reference parsing and activation scope remain unchanged. No global cache, public API, configuration, schema or dependency is added. The two-file change removes one net production line and adds 17 net test lines.

## Evidence

The final candidate passed 64 resolver tests, the full selected gate against `0cccc6d68e58ccd5030cd09931c1753bca924c7b`, a normal build and source-bound P2 review. The single keyless built OpenAI entrypoint profile passed; this is an import-boundary check, not live-provider or comparative startup/RSS proof.

Four fresh keyless processes exercised the exported `resolveOwningPluginIdsForModelRefs` caller: one baseline/candidate pair per unchanged synthetic workload, 50 warmup batches and 1,000 measured batches of 16 references with a warmed regex cache. Collected-object sampling counted each unique profile node once at a 1,024-byte sampling interval; inputs and outputs matched within each pair.

| Workload | Sampled bytes before → after | Observed reduction |
| --- | ---: | ---: |
| Prefix fallback, 42 plugins | 171,756,624 → 137,594,928 | 19.89% |
| Pattern winner, 41 plugins | 57,350,824 → 48,504,600 | 15.42% |

These are single-pair observations, not medians or statistical conclusions. Workloads are not weighted or added together, and no Gateway-wide allocation, timing or RSS improvement is claimed.

The earlier variant eagerly collected both match classes and increased pattern-winner sampled allocation by 13.19% across its three-repetition comparison. That result and source remain retained separately; long validation was not run on that superseded design. The final implementation preserves the early return and defers prefix bookkeeping until fallback.
