### PR TITLE
ci(linux): validate the Linux companion build on native aarch64

### DIFF
--- a/.github/workflows/linux-app.yml
+++ b/.github/workflows/linux-app.yml
@@ -20,9 +20,19 @@ permissions:
 
 jobs:
   build:
-    name: Build Linux companion
+    name: Build Linux companion (${{ matrix.arch }})
     # Match the release build base for native tests and manually built bundles.
-    runs-on: ubuntu-22.04
+    # GitHub's hosted ubuntu-22.04-arm runner is native aarch64, free for
+    # public repos; no cross-compilation or QEMU involved.
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-22.04
+          - arch: aarch64
+            runner: ubuntu-22.04-arm
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 30
     steps:
       - name: Checkout
@@ -80,9 +90,12 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             apps/linux/src-tauri/target
-          key: linux-app-${{ runner.os }}-${{ hashFiles('apps/linux/src-tauri/Cargo.lock') }}
+          # runner.os is "Linux" for both amd64 and arm64 hosted runners;
+          # include the matrix arch explicitly or the two legs would restore
+          # and poison each other's incompatible target/ directories.
+          key: linux-app-${{ runner.os }}-${{ matrix.arch }}-${{ hashFiles('apps/linux/src-tauri/Cargo.lock') }}
           restore-keys: |
-            linux-app-${{ runner.os }}-
+            linux-app-${{ runner.os }}-${{ matrix.arch }}-
 
       - name: Setup Node environment
         uses: ./.github/actions/setup-node-env
@@ -127,7 +140,7 @@ jobs:
         if: always() && steps.inline-browser.outcome != 'skipped'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: linux-inline-browser
+          name: linux-inline-browser-${{ matrix.arch }}
           retention-days: 14
           if-no-files-found: warn
           path: ${{ runner.temp }}/linux-inline-browser
@@ -187,7 +200,7 @@ jobs:
         if: github.event_name == 'workflow_dispatch' && failure() && steps.first-run.outcome == 'failure'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: linux-first-run-failure
+          name: linux-first-run-failure-${{ matrix.arch }}
           retention-days: 14
           if-no-files-found: error
           path: ${{ runner.temp }}/linux-first-run.log
@@ -203,19 +216,27 @@ jobs:
             echo "Expected one AppImage, found ${#appimages[@]}"
             exit 1
           fi
+          # Official Arch Linux publishes no aarch64 build under this pinned
+          # digest (Arch Linux ARM is a separate project with its own images);
+          # the cross-distro shell-container check only runs on amd64 until an
+          # equivalent pinned aarch64 image is chosen. The FUSE-based
+          # extraction/launch check below still covers both architectures.
+          extra_args=()
+          if [[ "${{ matrix.arch }}" == "amd64" ]]; then
+            extra_args+=(--shell-container "archlinux@sha256:82b1b08faae9d61e3e7e13d562f4d09114d939105b0d59ff34140f3bd418593a")
+          fi
           xvfb-run -a -s '-screen 0 1280x1024x24' dbus-run-session -- \
             /usr/bin/python3 apps/linux/tests/packaged_runtime_smoke.py \
             "${appimages[0]}" \
             --output "${RUNNER_TEMP}/linux-packaged-runtime" \
             --require-fuse \
-            --shell-container \
-              "archlinux@sha256:82b1b08faae9d61e3e7e13d562f4d09114d939105b0d59ff34140f3bd418593a"
+            "${extra_args[@]}"
 
       - name: Upload packaged runtime failure evidence
         if: github.event_name == 'workflow_dispatch' && failure() && steps.packaged-runtime.outcome == 'failure'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: linux-packaged-runtime-failure
+          name: linux-packaged-runtime-failure-${{ matrix.arch }}
           retention-days: 14
           if-no-files-found: warn
           path: ${{ runner.temp }}/linux-packaged-runtime
@@ -224,7 +245,7 @@ jobs:
         if: github.event_name == 'workflow_dispatch'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: openclaw-linux-companion
+          name: openclaw-linux-companion-${{ matrix.arch }}
           retention-days: 14
           if-no-files-found: error
           path: |

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -18105,7 +18105,7 @@ describe("Linux App validation routing", () => {
           linux
             .filter((step) => step.uses?.startsWith("actions/upload-artifact@"))
             .map((step) => step.with?.name),
-        ).toEqual(["linux-inline-browser"]);
+        ).toEqual(["linux-inline-browser-${{ matrix.arch }}"]);
       }
     },
   );
@@ -18898,8 +18898,14 @@ it("pins simple release admission owners before selected checkout and preserves 
   expect(appImageTools).toMatch(/continuous[\s\S]*digest-pinned/u);
 
   const prLinux = parse(readFileSync(".github/workflows/linux-app.yml", "utf8"));
-  expect(prLinux.jobs.build["runs-on"]).toBe("ubuntu-22.04");
-  expect(prLinux.jobs.build.strategy).toBeUndefined();
+  expect(prLinux.jobs.build["runs-on"]).toContain("matrix.runner");
+  // amd64 keeps the release build base (ubuntu-22.04); aarch64 uses GitHub's
+  // free native hosted ubuntu-22.04-arm runner, same Ubuntu version to match
+  // the amd64 leg's documented glibc floor.
+  expect(prLinux.jobs.build.strategy.matrix.include).toEqual([
+    { arch: "amd64", runner: "ubuntu-22.04" },
+    { arch: "aarch64", runner: "ubuntu-22.04-arm" },
+  ]);
   expect(prLinux.on.workflow_dispatch?.inputs).toBeUndefined();
   const abiScannerTest = expectDefined(
     (prLinux.jobs.build.steps as WorkflowStep[]).find(


### PR DESCRIPTION
Related: #138279

## What Problem This Solves

OpenClaw's Linux companion CI only ever validates the amd64 build. The aarch64 packaging path (added in #139729 — an architecture-portable tool manifest and dynamic AppImage runtime-path lookup) has never actually run in CI on real arm64 hardware; the only validation so far has been one contributor's own Raspberry Pi 5, entirely outside this project's CI, as reported in #138279.

## Why This Change Was Made

Adds an `aarch64` leg to the `linux-app.yml` build matrix using GitHub's free native `ubuntu-22.04-arm` hosted runner — no cross-compilation or QEMU. This is scoped to **CI validation only**, matching #138279's own stated non-goal for a first PR ("official arm64 packages build and start," not full release publication); extending the signed release pipeline (`linux-app-release.yml`) to actually publish aarch64 release assets is a separate, larger, secrets-touching change that should follow once this validation exists.

Three things beyond the runner label needed to change for the matrix to work correctly:
- **Cache key collision**: `runner.os` is `"Linux"` for both amd64 and arm64 hosted runners, so the arch was added to the cache key to stop the two legs from poisoning each other's `target/` directories.
- **Artifact name collisions**: the four `upload-artifact` steps used fixed names; both legs would otherwise overwrite each other's uploads. Names are now arch-suffixed.
- **No official aarch64 Arch Linux container image**: the packaged-runtime smoke test's optional cross-distro check pins an Arch Linux container by digest that only publishes an `amd64` platform (confirmed via `docker manifest inspect`; Arch Linux ARM is a separate project). That one optional check now only runs on the amd64 leg — the FUSE-based extraction/launch check it supplements still runs on both architectures.

## User Impact

No user-visible change. Contributors and maintainers get real CI coverage of the aarch64 Linux build path, closing a gap where that path could silently break with no CI signal.

## Evidence

Dispatched this exact workflow on a fork and let it run to completion: https://github.com/kip-claw/openclaw/actions/runs/34689108136

All jobs passed, including `Build Linux companion (aarch64)` running natively on `ubuntu-22.04-arm` end to end: Rust compile, test suite, Tauri bundle build (deb + AppImage), AppImage finalization, and the packaged-runtime smoke test (with the Arch container check correctly skipped for aarch64).

Test plan:
- [x] Live dispatch on a fork, both architectures, full pipeline — see run linked above.
- [ ] Confirm the same on `openclaw/openclaw` once merged (a maintainer would need to dispatch it, or it runs automatically on the next relevant PR).