### PR TITLE
fix(tmux): emit real separators in find-sessions.sh session listing

### DIFF
--- a/skills/tmux/scripts/find-sessions.sh
+++ b/skills/tmux/scripts/find-sessions.sh
@@ -52,7 +52,7 @@ list_sessions() {
   local label="$1"; shift
   local tmux_cmd=(tmux "$@")
 
-  if ! sessions="$("${tmux_cmd[@]}" list-sessions -F '#{session_name}\t#{session_attached}\t#{session_created_string}' 2>/dev/null)"; then
+  if ! sessions="$("${tmux_cmd[@]}" list-sessions -F '#{session_name}|#{session_attached}|#{t:session_created}' 2>/dev/null)"; then
     echo "No tmux server found on $label" >&2
     return 1
   fi
@@ -67,7 +67,7 @@ list_sessions() {
   fi
 
   echo "Sessions on $label:"
-  printf '%s\n' "$sessions" | while IFS=$'\t' read -r name attached created; do
+  printf '%s\n' "$sessions" | while IFS='|' read -r name attached created; do
     attached_label=$([[ "$attached" == "1" ]] && echo "attached" || echo "detached")
     printf '  - %s (%s, started %s)\n' "$name" "$attached_label" "$created"
   done

--- a/skills/tmux/scripts/find-sessions.sh
+++ b/skills/tmux/scripts/find-sessions.sh
@@ -52,7 +52,10 @@ list_sessions() {
   local label="$1"; shift
   local tmux_cmd=(tmux "$@")
 
-  if ! sessions="$("${tmux_cmd[@]}" list-sessions -F '#{session_name}|#{session_attached}|#{t:session_created}' 2>/dev/null)"; then
+  # $'\t' is a real tab byte: tmux emits it verbatim and escapes any tab appearing
+  # in a session name, so the field separator cannot be produced by a session name
+  # (unlike a printable delimiter, which tmux allows in names).
+  if ! sessions="$("${tmux_cmd[@]}" list-sessions -F '#{session_name}'$'\t''#{session_attached}'$'\t''#{t:session_created}' 2>/dev/null)"; then
     echo "No tmux server found on $label" >&2
     return 1
   fi
@@ -67,7 +70,7 @@ list_sessions() {
   fi
 
   echo "Sessions on $label:"
-  printf '%s\n' "$sessions" | while IFS='|' read -r name attached created; do
+  printf '%s\n' "$sessions" | while IFS=$'\t' read -r name attached created; do
     attached_label=$([[ "$attached" == "1" ]] && echo "attached" || echo "detached")
     printf '  - %s (%s, started %s)\n' "$name" "$attached_label" "$created"
   done

--- a/test/scripts/tmux-find-sessions.test.ts
+++ b/test/scripts/tmux-find-sessions.test.ts
@@ -1,14 +1,16 @@
 // Tmux find-sessions tests cover the session-list field parsing contract.
 //
 // The skill script parses `tmux list-sessions -F` output by reading one line per
-// session and splitting it on the delimiter present in the format string. These
-// tests pin that contract in two layers:
+// session and splitting it on the separator present in the format string. These
+// tests pin that contract against the real script source:
 //
-//   1. The separator actually emitted by the format string must be the same
-//      separator the reader splits on. A literal `\t` inside single quotes is
-//      passed to tmux as backslash + t (tmux does not interpret escapes in -F
-//      output), so it never becomes a tab and the whole line lands in the first
-//      field. This is asserted by a real read/split, not by string comparison.
+//   1. The separator emitted by the format string must be one tmux can actually
+//      emit and that cannot occur in a session name. A literal `\t` inside single
+//      quotes reaches tmux as backslash + t (tmux does not interpret escapes in
+//      -F output), so it never becomes a tab: the whole line lands in the first
+//      field, the attachment field stays empty, and every session renders as
+//      "detached". tmux escapes tabs appearing in names, so a real tab byte is
+//      the collision-free choice.
 //   2. The creation-time variable must exist in tmux. `#{session_created_string}`
 //      does not; it expands to the empty string. `#{t:session_created}` is the
 //      supported strftime form.
@@ -21,31 +23,20 @@ const script = readFileSync(SCRIPT_PATH, "utf8");
 
 /** The `-F` format string passed to `tmux list-sessions`. */
 function readFormatString(): string {
-  const match = /list-sessions -F '([^']*)'/.exec(script);
-  const captured = match?.[1];
-  if (captured === undefined) {
-    throw new Error(`no tmux list-sessions -F format string found in ${SCRIPT_PATH}`);
-  }
-  return captured;
+  return readFormatStringFor(script);
 }
 
 /**
  * The `IFS=` delimiter the reader splits each emitted line on.
- * Matches both `IFS='|'` and `IFS=$'\t'` spellings.
+ *
+ * Bash allows two spellings here: a plain single-quoted literal (`IFS='|'`) and
+ * ANSI-C quoting (`IFS=$'\t'`), where `$'...'` interprets backslash escapes. Both
+ * decode to the character the shell would actually use, so a tab written as
+ * `$'\t'` is compared as a real tab byte rather than as the two characters `\`
+ * and `t`.
  */
 function readSplitDelimiter(): string {
-  const match = /while IFS=(\$\?'[^']*'|'[^']*') read -r/.exec(script);
-  const raw = match?.[1];
-  if (raw === undefined) {
-    throw new Error(`no IFS= read -r session reader found in ${SCRIPT_PATH}`);
-  }
-  const quoted = raw.startsWith("$?") ? raw.slice(2) : raw;
-  const literal = quoted.slice(1, -1);
-  if (raw.startsWith("$?")) {
-    // ANSI-C quoting: interpret the one escape form the script is expected to use.
-    return literal.replace(/\\t/g, "\t").replace(/\\n/g, "\n");
-  }
-  return literal;
+  return readSplitDelimiterFor(script);
 }
 
 /** Split one emitted line the way the script's `read -r name attached created` does. */
@@ -60,6 +51,15 @@ function splitEmittedLine(line: string, delimiter: string): string[] {
   return [first, second, rest.join(delimiter)];
 }
 
+/** What bash + tmux actually put on the wire for one session row. */
+function emitRow(name: string, attached: string, created: string, format: string): string {
+  return format
+    .replace("#{session_name}", name)
+    .replace("#{session_attached}", attached)
+    .replace("#{t:session_created}", created)
+    .replace("#{session_created_string}", "");
+}
+
 describe("tmux find-sessions.sh session list fields", () => {
   it("splits an emitted session line into name, attached, and created", () => {
     const delimiter = readSplitDelimiter();
@@ -70,25 +70,45 @@ describe("tmux find-sessions.sh session list fields", () => {
 
   it("does not use a backslash-t escape as the field separator", () => {
     // A single-quoted `\t` reaches tmux as the two characters `\` and `t`, which
-    // tmux does not translate, so the emitted line contains no tab byte at all.
-    // The reader would then split on a real tab and find nothing to split on.
+    // tmux does not translate, so the emitted line carries no tab byte at all and
+    // a reader splitting on a real tab finds nothing to split on.
     const emitted = String.raw`alpha\t1\tSat Sep 12 10:42:07 2026`;
 
     expect(emitted).not.toContain("\t");
     expect(splitEmittedLine(emitted, "\t")).toEqual([emitted]);
-    expect(splitEmittedLine(emitted, "\t")).toHaveLength(1);
   });
 
   it("keeps the format string and the split delimiter in agreement", () => {
     const format = readFormatString();
     const delimiter = readSplitDelimiter();
 
-    // The format string must actually contain the delimiter the reader splits on.
+    // The format must contain the exact character the reader splits on.
     expect(format).toContain(delimiter);
 
-    // And that delimiter must be a real character, not the two-character escape.
-    expect(format).not.toContain("\\t");
-    expect(delimiter).not.toBe("\\t");
+    // And that character must be a real byte, not the two-character escape that
+    // tmux passes through untouched.
+    expect(format).not.toContain(String.raw`\t`);
+    expect(delimiter).not.toBe(String.raw`\t`);
+    expect(delimiter.length).toBe(1);
+  });
+
+  it("uses a separator that cannot occur in a session name", () => {
+    // tmux permits `|` in session names but escapes tabs that appear in names, so
+    // a pipe delimiter would corrupt valid sessions while a tab byte is safe.
+    expect(readSplitDelimiter()).toBe("\t");
+  });
+
+  it("round-trips a session name containing a pipe character", () => {
+    const format = readFormatString();
+    const delimiter = readSplitDelimiter();
+
+    const row = emitRow("alpha|beta", "1", "Sat Sep 12 10:42:07 2026", format);
+
+    expect(splitEmittedLine(row, delimiter)).toEqual([
+      "alpha|beta",
+      "1",
+      "Sat Sep 12 10:42:07 2026",
+    ]);
   });
 
   it("uses a creation-time variable tmux defines", () => {
@@ -111,18 +131,99 @@ describe("tmux find-sessions.sh session list fields", () => {
 
   it("reports attachment state from the attached field", () => {
     const delimiter = readSplitDelimiter();
-    const attachedLabel = (line: string): string => {
-      const [, attached] = splitEmittedLine(line, delimiter);
+    const format = readFormatString();
+    const attachedLabel = (row: string): string => {
+      const [, attached] = splitEmittedLine(row, delimiter);
       return attached === "1" ? "attached" : "detached";
     };
 
     // Before the fix the split never happened, so `attached` was always empty and
     // every session rendered as detached even when tmux reported `1`.
-    expect(attachedLabel(["worker", "1", "Sat Sep 12 10:42:07 2026"].join(delimiter))).toBe(
+    expect(attachedLabel(emitRow("worker", "1", "Sat Sep 12 10:42:07 2026", format))).toBe(
       "attached",
     );
-    expect(attachedLabel(["worker", "0", "Sat Sep 12 10:42:07 2026"].join(delimiter))).toBe(
+    expect(attachedLabel(emitRow("worker", "0", "Sat Sep 12 10:42:07 2026", format))).toBe(
       "detached",
     );
   });
+
+  it("extracts an ANSI-C quoted delimiter as the character bash would use", () => {
+    // Guards the extractor itself: `$'\t'` must decode to a real tab, and the
+    // reader lookup must not silently match some other construct.
+    expect(readSplitDelimiterFor(`while IFS=$'\\t' read -r name; do`)).toBe("\t");
+    expect(readSplitDelimiterFor(`while IFS='|' read -r name; do`)).toBe("|");
+    expect(() => readSplitDelimiterFor("list_sessions() { :; }")).toThrow(/IFS=/);
+  });
 });
+
+/** Same extraction as {@link readFormatString}, against an arbitrary source. */
+function readFormatStringFor(source: string): string {
+  // The -F argument may concatenate quoting forms, e.g.
+  //   -F '#{session_name}'$'\t''#{session_attached}'
+  // which bash joins into a single word. Collect every adjacent segment after -F
+  // up to the end of the argument (first unquoted whitespace) and decode each.
+  const match = /list-sessions\s+-F\s+((?:'[^']*'|\$'(?:[^'\\]|\\.)*'|[^\s'"\\])+)/.exec(source);
+  const word = match?.[1];
+  if (word === undefined) {
+    throw new Error(`no tmux list-sessions -F format string found in ${SCRIPT_PATH}`);
+  }
+  return decodeShellWord(word);
+}
+
+/** Join adjacent bash quoting segments into the single word the shell would pass. */
+function decodeShellWord(word: string): string {
+  let out = "";
+  let i = 0;
+  while (i < word.length) {
+    const rest = word.slice(i);
+    const ansiC = /^\$'((?:[^'\\]|\\.)*)'/.exec(rest);
+    if (ansiC?.[1] !== undefined) {
+      out += decodeAnsiC(ansiC[1]);
+      i += ansiC[0].length;
+      continue;
+    }
+    const single = /^'([^']*)'/.exec(rest);
+    if (single?.[1] !== undefined) {
+      out += single[1];
+      i += single[0].length;
+      continue;
+    }
+    const bare = /^[^\s'"\\]/.exec(rest);
+    if (bare) {
+      out += bare[0];
+      i += 1;
+      continue;
+    }
+    throw new Error(`unparsable -F argument segment: ${JSON.stringify(rest)}`);
+  }
+  return out;
+}
+
+/** Decode the escapes bash interprets inside `$'...'`. */
+function decodeAnsiC(body: string): string {
+  return body.replace(/\\(.)/g, (_all, ch: string) => {
+    switch (ch) {
+      case "t":
+        return "\t";
+      case "n":
+        return "\n";
+      case "r":
+        return "\r";
+      case "\\":
+        return "\\";
+      default:
+        return ch;
+    }
+  });
+}
+
+/** Same extraction as {@link readSplitDelimiter}, against an arbitrary source. */
+function readSplitDelimiterFor(source: string): string {
+  const match = /\bIFS=(\$'((?:[^'\\]|\\.)*)'|'([^']*)')/.exec(source);
+  const ansiC = match?.[2];
+  const literal = match?.[3];
+  if (ansiC === undefined && literal === undefined) {
+    throw new Error(`no IFS= session reader found in ${SCRIPT_PATH}`);
+  }
+  return ansiC !== undefined ? decodeAnsiC(ansiC) : (literal ?? "");
+}

--- a/test/scripts/tmux-find-sessions.test.ts
+++ b/test/scripts/tmux-find-sessions.test.ts
@@ -1,0 +1,128 @@
+// Tmux find-sessions tests cover the session-list field parsing contract.
+//
+// The skill script parses `tmux list-sessions -F` output by reading one line per
+// session and splitting it on the delimiter present in the format string. These
+// tests pin that contract in two layers:
+//
+//   1. The separator actually emitted by the format string must be the same
+//      separator the reader splits on. A literal `\t` inside single quotes is
+//      passed to tmux as backslash + t (tmux does not interpret escapes in -F
+//      output), so it never becomes a tab and the whole line lands in the first
+//      field. This is asserted by a real read/split, not by string comparison.
+//   2. The creation-time variable must exist in tmux. `#{session_created_string}`
+//      does not; it expands to the empty string. `#{t:session_created}` is the
+//      supported strftime form.
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const SCRIPT_PATH = "skills/tmux/scripts/find-sessions.sh";
+
+const script = readFileSync(SCRIPT_PATH, "utf8");
+
+/** The `-F` format string passed to `tmux list-sessions`. */
+function readFormatString(): string {
+  const match = /list-sessions -F '([^']*)'/.exec(script);
+  const captured = match?.[1];
+  if (captured === undefined) {
+    throw new Error(`no tmux list-sessions -F format string found in ${SCRIPT_PATH}`);
+  }
+  return captured;
+}
+
+/**
+ * The `IFS=` delimiter the reader splits each emitted line on.
+ * Matches both `IFS='|'` and `IFS=$'\t'` spellings.
+ */
+function readSplitDelimiter(): string {
+  const match = /while IFS=(\$\?'[^']*'|'[^']*') read -r/.exec(script);
+  const raw = match?.[1];
+  if (raw === undefined) {
+    throw new Error(`no IFS= read -r session reader found in ${SCRIPT_PATH}`);
+  }
+  const quoted = raw.startsWith("$?") ? raw.slice(2) : raw;
+  const literal = quoted.slice(1, -1);
+  if (raw.startsWith("$?")) {
+    // ANSI-C quoting: interpret the one escape form the script is expected to use.
+    return literal.replace(/\\t/g, "\t").replace(/\\n/g, "\n");
+  }
+  return literal;
+}
+
+/** Split one emitted line the way the script's `read -r name attached created` does. */
+function splitEmittedLine(line: string, delimiter: string): string[] {
+  // Mirrors `IFS=<delim> read -r a b c` for a single-character delimiter: at most
+  // three fields, remaining content (including the delimiter) stays in the last.
+  const parts = line.split(delimiter);
+  if (parts.length <= 3) {
+    return parts;
+  }
+  const [first = "", second = "", ...rest] = parts;
+  return [first, second, rest.join(delimiter)];
+}
+
+describe("tmux find-sessions.sh session list fields", () => {
+  it("splits an emitted session line into name, attached, and created", () => {
+    const delimiter = readSplitDelimiter();
+    const line = ["alpha", "1", "Sat Sep 12 10:42:07 2026"].join(delimiter);
+
+    expect(splitEmittedLine(line, delimiter)).toEqual(["alpha", "1", "Sat Sep 12 10:42:07 2026"]);
+  });
+
+  it("does not use a backslash-t escape as the field separator", () => {
+    // A single-quoted `\t` reaches tmux as the two characters `\` and `t`, which
+    // tmux does not translate, so the emitted line contains no tab byte at all.
+    // The reader would then split on a real tab and find nothing to split on.
+    const emitted = String.raw`alpha\t1\tSat Sep 12 10:42:07 2026`;
+
+    expect(emitted).not.toContain("\t");
+    expect(splitEmittedLine(emitted, "\t")).toEqual([emitted]);
+    expect(splitEmittedLine(emitted, "\t")).toHaveLength(1);
+  });
+
+  it("keeps the format string and the split delimiter in agreement", () => {
+    const format = readFormatString();
+    const delimiter = readSplitDelimiter();
+
+    // The format string must actually contain the delimiter the reader splits on.
+    expect(format).toContain(delimiter);
+
+    // And that delimiter must be a real character, not the two-character escape.
+    expect(format).not.toContain("\\t");
+    expect(delimiter).not.toBe("\\t");
+  });
+
+  it("uses a creation-time variable tmux defines", () => {
+    const format = readFormatString();
+
+    expect(format).toContain("#{t:session_created}");
+    expect(format).not.toContain("#{session_created_string}");
+  });
+
+  it("still emits name, attachment state, and creation time in order", () => {
+    const format = readFormatString();
+    const delimiter = readSplitDelimiter();
+
+    expect(format.split(delimiter)).toEqual([
+      "#{session_name}",
+      "#{session_attached}",
+      "#{t:session_created}",
+    ]);
+  });
+
+  it("reports attachment state from the attached field", () => {
+    const delimiter = readSplitDelimiter();
+    const attachedLabel = (line: string): string => {
+      const [, attached] = splitEmittedLine(line, delimiter);
+      return attached === "1" ? "attached" : "detached";
+    };
+
+    // Before the fix the split never happened, so `attached` was always empty and
+    // every session rendered as detached even when tmux reported `1`.
+    expect(attachedLabel(["worker", "1", "Sat Sep 12 10:42:07 2026"].join(delimiter))).toBe(
+      "attached",
+    );
+    expect(attachedLabel(["worker", "0", "Sat Sep 12 10:42:07 2026"].join(delimiter))).toBe(
+      "detached",
+    );
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

`skills/tmux/scripts/find-sessions.sh` lists tmux sessions with all three of its columns wrong. It builds
the `-F` format string with a single-quoted `\t`:

```bash
list-sessions -F '#{session_name}\t#{session_attached}\t#{session_created_string}'
```

Bash passes that to tmux as the two characters `\` and `t`, and **tmux does not interpret escapes in `-F`
output** — so the emitted line contains no tab byte at all. The reader then splits on a real tab
(`IFS=$'\t' read -r name attached created`), finds no separator, and puts the entire line into `name`. Every
session name is corrupted, `attached` is never populated (so the label is unconditionally `detached`, even for
an attached session), and `#{session_created_string}` is not a tmux variable, so the creation date is always
empty.

This is the helper the tmux skill points at for session discovery, and it misreports the state of every
session on the socket.

## Why This Change Was Made

Root cause: the format string never produces the separator the reader splits on.

Three defects share that root:

1. **`\t` is literal, not a tab.** The format must emit a real separator byte. I used `$'\t'` (ANSI-C
   quoting), which bash expands to an actual tab before tmux ever sees it, and matched the reader's existing
   `IFS=$'\t'`.
2. **The separator must be one a session name cannot contain.** tmux's `session_check_name` strips colons,
   periods and control characters but **preserves `|`**, and it escapes tabs that appear in names. So a
   printable delimiter can be produced by a legal name and would split that session incorrectly — a tab byte
   cannot. This is why the delimiter is a tab rather than a printable character.
3. **`#{session_created_string}` does not exist** in tmux (verified absent on 3.5a; it expands to nothing).
   `#{t:session_created}` is the supported form, applying strftime to `session_created`.

The change touches only the format string and the reader's `IFS=`. The surrounding logic, quoting, socket
selection, query filter and exit codes are untouched; `wait-for-text.sh` is unaffected.

## User Impact

The helper now reports what tmux actually knows, including for names that contain printable delimiters:

```
before:  - alpha\t1\t (detached, started )
         - gamma|delta\t1\t (detached, started )

after:   - alpha (attached, started Sat Sep 12 10:42:07 2026)
         - beta (detached, started Sat Sep 12 10:42:08 2026)
         - gamma|delta (attached, started Sat Sep 12 10:42:09 2026)
```

Session names are no longer polluted with the raw format tail, attachment state is read from the field instead
of being hardcoded to `detached`, the creation date is populated, and a name containing `|` survives intact. No
other surface changes: no API, protocol, schema, config, or state is touched.

## Evidence

**Environment:** this host is Windows. It has **real bash** (Git Bash `4.4.23(1)-release`) but **no tmux
binary, no Docker, and no WSL** (all verified absent). So the helper is executed **unmodified through real
bash**, with only the external `tmux` process stubbed — the environment boundary, not the code under test.

### 1. The actual helper, run through real bash (`proof-tmux-find-sessions-fields.mts`)

The stub `tmux` reproduces the two tmux behaviors the helper depends on, both taken from tmux 3.5a source:
`-F` format expansion copies non-`#` characters verbatim (so literal `\t` stays two characters), and
`#{t:session_created}` applies strftime while the non-existent `#{session_created_string}` expands to nothing.

```
=== real bash running the actual helper ===
bash        : 4.4.23(1)-release
helper      : skills/tmux/scripts/find-sessions.sh
sessions    : alpha, beta, gamma|delta  (one contains "|")

--- AFTER (worktree revision) ---
Sessions on default socket:
  - alpha (attached, started Sat Sep 12 10:42:07 2026)
  - beta (detached, started Sat Sep 12 10:42:08 2026)
  - gamma|delta (attached, started Sat Sep 12 10:42:09 2026)

--- BEFORE (upstream/main original) ---
Sessions on default socket:
  - alpha\t1\t (detached, started )
  - beta\t0\t (detached, started )
  - gamma|delta\t1\t (detached, started )

--- checks ---
  PASS  after: three session rows rendered
  PASS  after: plain name + attached correct
  PASS  after: detached reported correctly
  PASS  after: pipe-containing name survives intact
  PASS  before: name corrupted with raw escape tail
  PASS  before: always detached (wrong)
  PASS  before: creation time empty

RESULT: 7/7 checks -> PASS
```

The same run against the pre-fix helper reproduces all three reported symptoms verbatim, and the after-fix run
covers **attached**, **detached**, and **a name containing `|`**.

### 2. Regression tests — entry-point behavior, defect-sensitive

`test/scripts/tmux-find-sessions.test.ts`, 9 cases. The extractor handles bash's two `IFS=` spellings and
decodes `$'...'` ANSI-C quoting properly, so a correct tab-based repair is matched rather than mis-extracted.

Reverting **only** the production file to `upstream/main` and re-running:

```
=== PRE-FIX (production file = upstream/main) ===
 FAIL > keeps the format string and the split delimiter in agreement
      AssertionError: expected '#{session_name}\t#{session_attached}\…' to contain '\t'
 FAIL > round-trips a session name containing a pipe character
      AssertionError: expected [ 'alpha|beta\t1\t' ] to deeply equal [ 'alpha|beta', '1', …(1) ]
 FAIL > uses a creation-time variable tmux defines
      AssertionError: expected '#{session_name}\t#{session_attached}\…' to contain '#{t:session_created}'
 FAIL > still emits name, attachment state, and creation time in order
 FAIL > reports attachment state from the attached field
      AssertionError: expected 'detached' to be 'attached'
 Test Files  1 failed (1)
      Tests  5 failed | 4 passed (9)
```

These are genuine assertion failures about session output, not extraction errors — the extractor correctly
decodes `$'\t'` from the original reader and then the field-parsing assertions fail on the real defect.

With the fix in place:

```
$ node scripts/run-vitest.mjs run test/scripts/tmux-find-sessions.test.ts --reporter=dot
 Test Files  1 passed (1)
      Tests  9 passed (9)
```

### 3. Lint, format, and types

```
$ oxlint -c .oxlintrc.json test/scripts/tmux-find-sessions.test.ts
Found 0 warnings and 0 errors.

$ oxfmt --check test/scripts/tmux-find-sessions.test.ts
All matched files use the correct format.
```

`tsgo:test:root` reports 25 pre-existing errors in this checkout from stale local `node_modules` (e.g.
`@openclaw/fs-safe`, `grammy/types`). I confirmed the identical 25 errors on a clean `upstream/main` with these
changes stashed; **zero** are in `test/scripts/tmux-find-sessions.test.ts`.

---

### Note on a failing lane unrelated to this change

A CI attempt on an intermediate head failed `checks-node-compact-large-14` on
`src/agents/sandbox/browser.create.test.ts` -> *"CDP request was not received"* (a 2-second wall-clock
race on a loopback CDP socket). That file is **not touched by this PR** and is byte-identical to
`upstream/main`. Evidence that it is unrelated:

| Check | Result |
|---|---|
| Files in this diff | only `skills/tmux/scripts/find-sessions.sh` + `test/scripts/tmux-find-sessions.test.ts` |
| `browser.create.test.ts` identical to `upstream/main`? | yes |
| Same shard on the **previous head of this branch** | **success** |
| Same test on a clean `upstream/main` checkout | **fails identically** with this PR's work stashed |

I did not touch that file, raise its timeout, or add a retry: it is outside this PR's concern, and
the repo rules forbid unrelated test edits in a focused fix. Everything this PR is responsible for is
green (lint, format, 9/9 focused tests, 7/7 real-bash proof checks).
