### PR TITLE
test(docker): normalize harness artifact permissions

### DIFF
--- a/scripts/e2e/Dockerfile
+++ b/scripts/e2e/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update \
 RUN corepack enable
 RUN npm install -g tsx@4.23.12 --no-fund --no-audit
 
-COPY scripts/prepublish-plugin-registry-artifact.mjs /opt/openclaw-e2e/scripts/
+COPY --chmod=0644 scripts/prepublish-plugin-registry-artifact.mjs /opt/openclaw-e2e/scripts/
 COPY --chmod=0755 scripts/e2e/lib/prepublish-plugin-registry.sh /opt/openclaw-e2e/scripts/e2e/lib/
 COPY scripts/e2e/lib/plugins/npm-registry-server.mjs /opt/openclaw-e2e/scripts/e2e/lib/plugins/
 COPY scripts/lib/bounded-response.mjs /opt/openclaw-e2e/scripts/lib/

--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -6570,6 +6570,13 @@ source "$ROOT_DIR/scripts/lib/docker-e2e-logs.sh"
     expect(dockerfile).toContain("procps");
   });
 
+  it("normalizes shared Docker E2E harness file permissions", () => {
+    const dockerfile = readFileSync("scripts/e2e/Dockerfile", "utf8");
+    expect(dockerfile).toContain(
+      "COPY --chmod=0644 scripts/prepublish-plugin-registry-artifact.mjs /opt/openclaw-e2e/scripts/",
+    );
+  });
+
   it("copies the pnpm lockfile into the runtime image before normalizing its permissions", () => {
     const dockerfile = readFileSync("Dockerfile", "utf8");
     const copy = "COPY --from=runtime-assets --chown=node:node /app/pnpm-lock.yaml .";


### PR DESCRIPTION
## Summary

- normalize the copied prepublish registry artifact to mode `0644` in the shared Docker E2E image
- add a source contract test so restrictive checkout umasks cannot silently reintroduce a root-only harness file

## Why

The shared E2E runner switches to the non-root `appuser`, but this `COPY` previously inherited its source mode. In a checkout created under umask `077`, the image contained `/opt/openclaw-e2e/scripts/prepublish-plugin-registry-artifact.mjs` as `0600 root:root`; published-upgrade survivor lanes then failed with `EACCES` before exercising the candidate.

This was discovered while producing the published-updater compatibility proof for #145789. It is independent of that production fix and is separated here to keep both changes reviewable.

## Validation

- `pnpm vitest run --config test/vitest/vitest.tooling-docker.config.ts test/scripts/docker-build-helper.test.ts -t 'normalizes shared Docker E2E harness file permissions'`
- `node scripts/check-changed.mjs`
