### PR TITLE
perf(plugins): pass readonly metadata through provider policy

### DIFF
--- a/src/plugins/provider-model-routes.ts
+++ b/src/plugins/provider-model-routes.ts
@@ -46,11 +46,7 @@ export function resolveProviderModelPolicySurface(
       allowScopedSnapshot: true,
       allowWorkspaceScopedSnapshot: true,
     });
-  return metadata
-    ? resolveProviderPolicySurface(provider, {
-        manifestRegistry: { plugins: [...metadata.plugins] },
-      })
-    : null;
+  return metadata ? resolveProviderPolicySurface(provider, { manifestRegistry: metadata }) : null;
 }
 
 /** Binds one provider's identity facts for an authored-row lookup. */

--- a/src/plugins/provider-public-artifacts.ts
+++ b/src/plugins/provider-public-artifacts.ts
@@ -3,11 +3,7 @@ import path from "node:path";
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import { resolveBundledPluginsDir } from "./bundled-dir.js";
 import { shouldRejectHardlinkedPluginFiles } from "./hardlink-policy.js";
-import {
-  loadPluginManifestRegistryCore,
-  type PluginManifestRecord,
-  type PluginManifestRegistry,
-} from "./manifest-registry.js";
+import { loadPluginManifestRegistryCore, type PluginManifestRecord } from "./manifest-registry.js";
 import { preparePluginModule } from "./plugin-module-loader-cache.js";
 import { getPluginSetupModuleLoader } from "./plugin-setup-module.js";
 import {
@@ -21,15 +17,17 @@ import { loadValidatedPublicSurfaceModule } from "./public-surface-loader.js";
 import { resolvePluginRootPublicSurfacePath } from "./public-surface-runtime.js";
 import { resolvePluginRuntimeRecord } from "./runtime-context.js";
 
+type ProviderPolicyRegistry = { plugins: readonly PluginManifestRecord[] };
+
 type ProviderPolicyMetadata = {
-  manifestRegistry?: Pick<PluginManifestRegistry, "plugins">;
-  loadManifestRegistry?: () => Pick<PluginManifestRegistry, "plugins"> | undefined;
+  manifestRegistry?: ProviderPolicyRegistry;
+  loadManifestRegistry?: () => ProviderPolicyRegistry | undefined;
 };
 
 function resolveBundledProviderPolicyPlugin(
   providerId: string,
   options: ProviderPolicyMetadata = {},
-): PluginManifestRegistry["plugins"][number] | null {
+): PluginManifestRecord | null {
   const normalizedProviderId = normalizeProviderId(providerId);
   if (!normalizedProviderId) {
     return null;
@@ -43,7 +41,7 @@ function resolveBundledProviderPolicyPlugin(
     options.manifestRegistry ??
     options.loadManifestRegistry?.() ??
     loadPluginManifestRegistryCore();
-  let owner: PluginManifestRegistry["plugins"][number] | null = null;
+  let owner: PluginManifestRecord | null = null;
   for (const plugin of registry.plugins) {
     if (plugin.origin !== "bundled" || (owner && owner.id.localeCompare(plugin.id) <= 0)) {
       continue;
@@ -57,7 +55,7 @@ function resolveBundledProviderPolicyPlugin(
 }
 
 function pluginDeclaresProviderPolicyRef(
-  plugin: PluginManifestRegistry["plugins"][number],
+  plugin: PluginManifestRecord,
   normalizedProviderId: string,
 ): boolean {
   const matches = (provider: string) => normalizeProviderId(provider) === normalizedProviderId;
@@ -70,7 +68,7 @@ function pluginDeclaresProviderPolicyRef(
 }
 
 function pluginOwnsProviderPolicyRef(
-  plugin: PluginManifestRegistry["plugins"][number],
+  plugin: PluginManifestRecord,
   normalizedProviderId: string,
 ): boolean {
   if (pluginDeclaresProviderPolicyRef(plugin, normalizedProviderId)) {
@@ -125,7 +123,7 @@ export function resolveBundledProviderPolicySurface(
 /** Resolves provider policy hooks from bundled or trusted official plugin artifacts. */
 export function resolveProviderPolicySurface(
   providerId: string,
-  options: { manifestRegistry?: Pick<PluginManifestRegistry, "plugins"> } = {},
+  options: { manifestRegistry?: ProviderPolicyRegistry } = {},
 ): ProviderPolicySurface | null {
   const bundledSurface = resolveBundledProviderPolicySurface(providerId, options);
   if (bundledSurface) {
@@ -144,7 +142,7 @@ export function resolveProviderPolicySurface(
 
 /** Loads the first usable policy surface from caller-selected trusted owners. */
 export function loadTrustedExternalProviderPolicyArtifacts(
-  owners: PluginManifestRegistry["plugins"],
+  owners: readonly PluginManifestRecord[],
 ) {
   for (const owner of owners) {
     const surface = resolveTrustedExternalProviderPolicySurface(owner);
@@ -159,16 +157,16 @@ export function loadTrustedExternalProviderPolicyArtifacts(
 /** Lists trusted installed plugins that own a provider policy reference. */
 export function listTrustedExternalProviderPolicyOwners(
   providerId: string,
-  manifestRegistry: Pick<PluginManifestRegistry, "plugins">,
+  manifestRegistry: ProviderPolicyRegistry,
 ) {
   const normalizedProviderId = normalizeProviderId(providerId);
-  return manifestRegistry.plugins
-    .filter(
-      (plugin) =>
-        plugin.trustedOfficialInstall === true &&
-        pluginOwnsProviderPolicyRef(plugin, normalizedProviderId),
-    )
-    .toSorted((left, right) => left.id.localeCompare(right.id));
+  const owners = manifestRegistry.plugins.filter(
+    (plugin) =>
+      plugin.trustedOfficialInstall === true &&
+      pluginOwnsProviderPolicyRef(plugin, normalizedProviderId),
+  );
+  owners.sort((left, right) => left.id.localeCompare(right.id));
+  return owners;
 }
 
 /** Loads policy hooks from a host-verified official external plugin install. */


### PR DESCRIPTION
Closes #145918

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Provider policy lookup copies a prepared plugin list that its consumers only read. Trusted external owner selection also copies a fresh filtered array just to sort it.

## Why This Change Was Made

The existing private policy operations now accept readonly plugin-list views, so the model-policy resolver passes prepared metadata directly. Sorting mutates only the newly filtered owner array, preserving the supplied registry and stable tie order.

## User Impact

Policy selection, aliases, trust checks and direct/empty/missing/lazy paths remain unchanged. The two-file change removes six net production lines and changes no tests. No loading/admission decision, runtime import, startup entrypoint or public contract is added.

## Evidence

Against baseline `0cccc6d68e58ccd5030cd09931c1753bca924c7b`, the three existing policy, route and installed-owner suites passed 68 tests per version with no skips. After that paired run, an equivalent local-array sort expression was changed to a separate statement for lint. The final explicit-base selected gate, managed P2 and independent source audit passed on the final form; the paired tests were not rerun for that statement-only adjustment.

The benefit is source-derived removal of the plugin-list copy and wrapper on prepared-metadata fallback, plus the redundant copy of the filtered owner array. No copy-byte, timing, RSS, retained-heap or additional entrypoint-profile result is claimed. No standalone build or profile was selected because loading and startup contracts are unchanged.

Public integration must retain current main's route-intent context in the same routes file. The exact mapping changes only the model-policy resolver's metadata pass-through; all other current routes-file bytes remain intact. The authored B0 change and its proof remain separate from that verified source mapping; hosted CI and actual landed-byte verification are still required.
