### PR TITLE
test: share docs command runtime fixture

### DIFF
--- a/src/commands/docs.test.ts
+++ b/src/commands/docs.test.ts
@@ -1,7 +1,7 @@
 // Docs command tests cover docs lookup, fetch handling, and runtime output.
 import { expectDefined } from "@openclaw/normalization-core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { RuntimeEnv } from "../runtime.js";
+import { createTestRuntime } from "./test-runtime-config-helpers.js";
 
 const fetchMock = vi.fn<typeof fetch>();
 
@@ -25,18 +25,6 @@ vi.mock("../cli/command-format.js", () => ({
 
 const { docsSearchCommand } = await import("./docs.js");
 
-function makeRuntime() {
-  return {
-    log: vi.fn(),
-    error: vi.fn(),
-    exit: vi.fn(),
-  } as unknown as RuntimeEnv & {
-    log: ReturnType<typeof vi.fn>;
-    error: ReturnType<typeof vi.fn>;
-    exit: ReturnType<typeof vi.fn>;
-  };
-}
-
 describe("docsSearchCommand", () => {
   beforeEach(() => {
     fetchMock.mockReset();
@@ -49,7 +37,7 @@ describe("docsSearchCommand", () => {
         headers: { "Content-Type": "application/json" },
       }),
     );
-    const runtime = makeRuntime();
+    const runtime = createTestRuntime();
 
     await docsSearchCommand(["plugin", "allowlist"], runtime);
 
@@ -79,7 +67,7 @@ describe("docsSearchCommand", () => {
         }),
       ),
     );
-    const runtime = makeRuntime();
+    const runtime = createTestRuntime();
 
     await docsSearchCommand(["cli"], runtime, { json: true });
 
@@ -108,7 +96,7 @@ describe("docsSearchCommand", () => {
         }),
       ),
     );
-    const runtime = makeRuntime();
+    const runtime = createTestRuntime();
 
     await docsSearchCommand(["openclaw"], runtime, { json: true, limit: 1 });
 
@@ -119,7 +107,7 @@ describe("docsSearchCommand", () => {
   });
 
   it("emits one JSON object for the docs homepage", async () => {
-    const runtime = makeRuntime();
+    const runtime = createTestRuntime();
 
     await docsSearchCommand([], runtime, { json: true });
 
@@ -145,7 +133,7 @@ describe("docsSearchCommand", () => {
       { status: 503 },
     );
     fetchMock.mockResolvedValueOnce(response);
-    const runtime = makeRuntime();
+    const runtime = createTestRuntime();
 
     await expect(docsSearchCommand(["browser", "existing-session"], runtime)).rejects.toThrow(
       "Docs search failed: HTTP 503",
@@ -160,7 +148,7 @@ describe("docsSearchCommand", () => {
         headers: { "Content-Type": "application/json" },
       }),
     );
-    const runtime = makeRuntime();
+    const runtime = createTestRuntime();
 
     await expect(docsSearchCommand(["bad-json"], runtime)).rejects.toThrow(
       "Docs search failed: Docs search response is malformed JSON",
@@ -174,7 +162,7 @@ describe("docsSearchCommand", () => {
     { name: "string results", payload: { results: "unavailable" } },
   ])("rejects $name instead of reporting a successful empty search", async ({ payload }) => {
     fetchMock.mockResolvedValueOnce(new Response(JSON.stringify(payload)));
-    const runtime = makeRuntime();
+    const runtime = createTestRuntime();
 
     await expect(docsSearchCommand(["gateway"], runtime, { json: true })).rejects.toThrow(
       "Docs search failed: Docs search response is malformed: expected results array",
@@ -185,7 +173,7 @@ describe("docsSearchCommand", () => {
 
   it("keeps a successful empty search distinct from a malformed response", async () => {
     fetchMock.mockResolvedValueOnce(new Response(JSON.stringify({ results: [] })));
-    const runtime = makeRuntime();
+    const runtime = createTestRuntime();
 
     await docsSearchCommand(["no-matches"], runtime, { json: true });
 
@@ -205,7 +193,7 @@ describe("docsSearchCommand", () => {
     fetchMock.mockResolvedValueOnce(
       new Response(body, { headers: { "Content-Type": "application/json" } }),
     );
-    const runtime = makeRuntime();
+    const runtime = createTestRuntime();
 
     await expect(docsSearchCommand(["plugin"], runtime)).rejects.toThrow(
       "Docs search failed: Docs search response is malformed JSON",
@@ -227,7 +215,7 @@ describe("docsSearchCommand", () => {
         { headers: { "Content-Type": "application/json" } },
       ),
     );
-    const runtime = makeRuntime();
+    const runtime = createTestRuntime();
 
     await docsSearchCommand(["plugin", "allowlist"], runtime);
 
@@ -254,7 +242,7 @@ describe("docsSearchCommand", () => {
         headers: { "Content-Type": "application/json" },
       }),
     );
-    const runtime = makeRuntime();
+    const runtime = createTestRuntime();
 
     await expect(docsSearchCommand(["oversized"], runtime)).rejects.toThrow(
       "Docs search failed: Docs search response exceeds 8388608 bytes",


### PR DESCRIPTION
## What Problem This Solves

The Docs command tests duplicate the shared runtime mock factory and use a double cast to expose its mock calls.

## Why This Change Was Made

Reuse `createTestRuntime` at all 11 current call sites. Keep all 14 Docs cases and their assertions unchanged, including the five malformed/empty-results cases added by #145613, JSON output, body cancellation, malformed UTF-8, and response-size limits. This removes 12 net test lines (+12/-24), with no production changes or output writers added.

## User Impact

No user-visible behavior change. The tests retain their existing coverage with less duplicated fixture code.

## Evidence

- Fresh current-base baseline and candidate: all 25 cases passed in the complete Docs and runtime suites (14 + 11), with identical inventory and order.
- Targeted formatting and type-aware lint passed, including all four unchanged String/JSON assertions.
- All 20 normal changed checks passed on [Blacksmith Testbox](https://github.com/openclaw/openclaw/actions/runs/34687604724), with the exact source tree verified, native runner exit 0, and the lease completed. Focused runs used macOS Node 26.5.0; the configured remote gate used Linux Node 24.19.0.
- Independent applied source review found no actionable P0–P2 findings. No live hosted-docs endpoint test or full-build claim.
