### PR TITLE
fix(cloud): prevent tool-authority mismatch on worker turns

### DIFF
--- a/src/gateway/worker-environments/worker-turn-run-owner.test.ts
+++ b/src/gateway/worker-environments/worker-turn-run-owner.test.ts
@@ -1,10 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../../test/helpers/promise.js";
+import type { EmbeddedRunToolAuthorityBinding } from "../../agents/embedded-agent-runner/run-state.js";
 import {
   isEmbeddedAgentRunHandleActive,
   queueEmbeddedAgentMessageWithOutcomeAsync,
   resolveActiveEmbeddedRunOwner,
 } from "../../agents/embedded-agent-runner/runs.js";
+import { withGatewayToolCallerIdentity } from "../../agents/tools/gateway-caller-context.js";
 import {
   createReplyOperation,
   isReplyRunEvidenceStale,
@@ -48,6 +50,63 @@ import {
 describe("cloud worker run ownership", () => {
   beforeEach(setupWorkerTurnLauncherTest);
   afterEach(cleanupWorkerTurnLauncherTest);
+
+  it("registers the worker turn with its prepared tool authority fingerprint", async () => {
+    const { createWorkerTurnRunOwner } = await import("./worker-turn-run-owner.js");
+    seedActivePlacement();
+    const runId = "worker-tool-authority";
+    const claim = placements.claimTurn({
+      sessionId: SESSION_ID,
+      sessionKey: SESSION_KEY,
+      agentId: "main",
+      runId,
+      claimId: "worker-tool-authority-claim",
+      owner: { kind: "worker", environmentId: ENVIRONMENT_ID, ownerEpoch: OWNER_EPOCH },
+    });
+    const toolAuthorityFingerprint = "prepared-worker-tool-authority";
+    const bindToolAuthority = vi.fn<EmbeddedRunToolAuthorityBinding>(({ handle }) => {
+      if (handle.toolAuthorityFingerprint !== toolAuthorityFingerprint) {
+        throw new Error("embedded tool authority registration does not match its attempt");
+      }
+      return {
+        source: "attempt" as const,
+        assertActive: () => {},
+        project: () => toolAuthorityFingerprint,
+      };
+    });
+    let active: ReturnType<typeof createWorkerTurnRunOwner> | undefined;
+
+    try {
+      await expect(
+        withGatewayToolCallerIdentity(
+          {
+            agentId: "main",
+            sessionKey: SESSION_KEY,
+            embeddedRunToolAuthorityBinding: bindToolAuthority,
+          },
+          async () => {
+            active = createWorkerTurnRunOwner({
+              placements,
+              claim,
+              turn: { ...turn(runId), toolAuthorityFingerprint },
+              sessionKey: SESSION_KEY,
+            });
+          },
+        ),
+      ).resolves.toBeUndefined();
+      expect(bindToolAuthority).toHaveBeenCalledOnce();
+      expect(bindToolAuthority).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sessionId: SESSION_ID,
+          sessionKey: SESSION_KEY,
+          agentId: "main",
+          handle: expect.objectContaining({ runId, toolAuthorityFingerprint }),
+        }),
+      );
+    } finally {
+      active?.dispose();
+    }
+  });
 
   it.each([
     { cancellation: "user", firstToolDelayMs: 0 },

--- a/src/gateway/worker-environments/worker-turn-run-owner.ts
+++ b/src/gateway/worker-environments/worker-turn-run-owner.ts
@@ -104,6 +104,7 @@ export function createWorkerTurnRunOwner(params: {
   const handle = {
     kind: "embedded",
     runId: claim.runId,
+    toolAuthorityFingerprint: turn.toolAuthorityFingerprint,
     startedAtMs,
     diagnosticOwner,
     closeDiagnostics: () => {


### PR DESCRIPTION
Related: #144223

## What Problem This Solves

Fixes an issue where users sending a turn to an active `worker-turn` cloud placement would receive `embedded tool authority registration does not match its attempt` before the model or any worker command could run.

## Why This Change Was Made

The worker-turn owner now carries the exact already-prepared tool-authority fingerprint onto the embedded run handle before registering it. The existing fail-closed binding and fingerprint comparisons remain unchanged.

The regression drives the real Gateway caller-context registration seam. It verifies that the binding is invoked exactly once and receives the expected session, run, and fingerprint.

## User Impact

Cloud worker turns can register their prepared tool authority instead of being rejected immediately. Missing or altered fingerprints are still rejected by the existing guard.

## Evidence

- Reproduced before the fix with the focused test failing on the production error: `embedded tool authority registration does not match its attempt`.
- `pnpm test src/gateway/worker-environments/worker-turn-run-owner.test.ts` — 7/7 passed after the fix.
- `node scripts/check-changed.mjs -- src/gateway/worker-environments/worker-turn-run-owner.ts src/gateway/worker-environments/worker-turn-run-owner.test.ts` — passed all derived core/core-test checks, including formatting, lint, core typecheck, test typecheck, dead-code scans, import cycles, and persistence guardrails.
- Repository `autoreview` identified that the first test could pass without proving the binding was called; the test now asserts one exact binding invocation.

Live post-patch cloud execution was not run because this PR does not update the installed Gateway. The original production failure was observed before model execution, and the focused regression exercises that registration boundary directly.
