### PR TITLE
refactor: share Telegram media test fixtures

### DIFF
--- a/extensions/telegram/src/bot/delivery.resolve-media-local.test.ts
+++ b/extensions/telegram/src/bot/delivery.resolve-media-local.test.ts
@@ -1,11 +1,16 @@
 import { GrammyError } from "grammy";
-import type { Message } from "grammy/types";
 import { coerceErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { sleepWithAbort } from "openclaw/plugin-sdk/runtime-env";
 // Telegram tests cover delivery.resolve media retry plugin behavior.
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { resolveMedia } from "./delivery.resolve-media.js";
+import {
+  expectMediaFetchError,
+  expectRecordFields,
+  expectResolvedMediaFields,
+  makeCtx,
+} from "./delivery.resolve-media.test-helpers.js";
 import type { TelegramContext } from "./types.js";
 
 const saveMediaBuffer = vi.fn();
@@ -80,85 +85,6 @@ vi.mock("../sticker-cache.js", () => ({
 
 const MAX_MEDIA_BYTES = 10_000_000;
 const FIXTURE = "fixture-token";
-
-function makeCtx(
-  mediaField: "voice" | "audio" | "photo" | "video" | "document" | "animation" | "sticker",
-  getFile: TelegramContext["getFile"],
-  opts?: { file_name?: string; mime_type?: string },
-): TelegramContext {
-  const msg: Record<string, unknown> = {
-    message_id: 1,
-    date: 0,
-    chat: { id: 1, type: "private" },
-  };
-  if (mediaField === "voice") {
-    msg.voice = {
-      file_id: "v1",
-      duration: 5,
-      file_unique_id: "u1",
-      ...(opts?.mime_type && { mime_type: opts.mime_type }),
-    };
-  }
-  if (mediaField === "audio") {
-    msg.audio = {
-      file_id: "a1",
-      duration: 5,
-      file_unique_id: "u2",
-      ...(opts?.file_name && { file_name: opts.file_name }),
-      ...(opts?.mime_type && { mime_type: opts.mime_type }),
-    };
-  }
-  if (mediaField === "photo") {
-    msg.photo = [{ file_id: "p1", width: 100, height: 100 }];
-  }
-  if (mediaField === "video") {
-    msg.video = {
-      file_id: "vid1",
-      duration: 10,
-      file_unique_id: "u3",
-      ...(opts?.file_name && { file_name: opts.file_name }),
-    };
-  }
-  if (mediaField === "document") {
-    msg.document = {
-      file_id: "d1",
-      file_unique_id: "u4",
-      ...(opts?.file_name && { file_name: opts.file_name }),
-      ...(opts?.mime_type && { mime_type: opts.mime_type }),
-    };
-  }
-  if (mediaField === "animation") {
-    msg.animation = {
-      file_id: "an1",
-      duration: 3,
-      file_unique_id: "u5",
-      width: 200,
-      height: 200,
-      ...(opts?.file_name && { file_name: opts.file_name }),
-    };
-  }
-  if (mediaField === "sticker") {
-    msg.sticker = {
-      file_id: "stk1",
-      file_unique_id: "ustk1",
-      type: "regular",
-      width: 512,
-      height: 512,
-      is_animated: false,
-      is_video: false,
-    };
-  }
-  return {
-    message: msg as unknown as Message,
-    me: {
-      id: 1,
-      is_bot: true,
-      first_name: "bot",
-      username: "bot",
-    } as unknown as TelegramContext["me"],
-    getFile,
-  };
-}
 
 function setupTransientGetFileRetry() {
   const getFile = vi
@@ -235,23 +161,7 @@ function resolveMediaWithDefaults(
   });
 }
 
-function requireResolvedMedia(
-  result: Awaited<ReturnType<typeof resolveMediaWithDefaults>>,
-  label: string,
-) {
-  if (!result) {
-    throw new Error(`expected ${label} media result`);
-  }
-  return result;
-}
-
 const requireRecord = createRequireRecord("record", "expected-label-record");
-
-function expectRecordFields(record: Record<string, unknown>, fields: Record<string, unknown>) {
-  for (const [key, value] of Object.entries(fields)) {
-    expect(record[key]).toEqual(value);
-  }
-}
 
 function requireReadRemoteMediaBufferParams(callIndex = 0): Record<string, unknown> {
   const call = (readRemoteMediaBuffer.mock.calls as unknown[][])[callIndex];
@@ -268,33 +178,6 @@ function expectReadRemoteMediaBufferFields(fields: Record<string, unknown>, call
 function expectFetchSsrfPolicyFields(fields: Record<string, unknown>, callIndex = 0) {
   const params = requireReadRemoteMediaBufferParams(callIndex);
   expectRecordFields(requireRecord(params.ssrfPolicy, "readRemoteMediaBuffer ssrfPolicy"), fields);
-}
-
-function expectResolvedMediaFields(
-  result: Awaited<ReturnType<typeof resolveMediaWithDefaults>>,
-  label: string,
-  fields: Record<string, unknown>,
-) {
-  expectRecordFields(requireResolvedMedia(result, label), fields);
-}
-
-async function expectMediaFetchError(
-  promise: Promise<unknown>,
-  fields: { code: string; messageIncludes: string; name?: string; status?: number },
-) {
-  try {
-    await promise;
-  } catch (error) {
-    const record = requireRecord(error, "MediaFetchError");
-    expect(record.name).toBe(fields.name ?? "MediaFetchError");
-    expect(record.code).toBe(fields.code);
-    expect(String(record.message)).toContain(fields.messageIncludes);
-    if (fields.status !== undefined) {
-      expect(record.status).toBe(fields.status);
-    }
-    return;
-  }
-  throw new Error("expected MediaFetchError rejection");
 }
 
 async function expectTransientGetFileRetrySuccess() {

--- a/extensions/telegram/src/bot/delivery.resolve-media-retry.test.ts
+++ b/extensions/telegram/src/bot/delivery.resolve-media-retry.test.ts
@@ -1,10 +1,16 @@
-import type { Message } from "grammy/types";
 import { coerceErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { sleepWithAbort } from "openclaw/plugin-sdk/runtime-env";
 // Telegram tests cover delivery.resolve media retry plugin behavior.
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { resolveMedia } from "./delivery.resolve-media.js";
+import {
+  expectMediaFetchError,
+  expectRecordFields,
+  expectResolvedMediaFields,
+  makeCtx,
+  requireResolvedMedia,
+} from "./delivery.resolve-media.test-helpers.js";
 import type { TelegramContext } from "./types.js";
 
 const saveMediaBuffer = vi.fn();
@@ -80,85 +86,6 @@ vi.mock("../sticker-cache.js", () => ({
 const MAX_MEDIA_BYTES = 10_000_000;
 const BOT_TOKEN = "tok123";
 
-function makeCtx(
-  mediaField: "voice" | "audio" | "photo" | "video" | "document" | "animation" | "sticker",
-  getFile: TelegramContext["getFile"],
-  opts?: { file_name?: string; mime_type?: string },
-): TelegramContext {
-  const msg: Record<string, unknown> = {
-    message_id: 1,
-    date: 0,
-    chat: { id: 1, type: "private" },
-  };
-  if (mediaField === "voice") {
-    msg.voice = {
-      file_id: "v1",
-      duration: 5,
-      file_unique_id: "u1",
-      ...(opts?.mime_type && { mime_type: opts.mime_type }),
-    };
-  }
-  if (mediaField === "audio") {
-    msg.audio = {
-      file_id: "a1",
-      duration: 5,
-      file_unique_id: "u2",
-      ...(opts?.file_name && { file_name: opts.file_name }),
-      ...(opts?.mime_type && { mime_type: opts.mime_type }),
-    };
-  }
-  if (mediaField === "photo") {
-    msg.photo = [{ file_id: "p1", width: 100, height: 100 }];
-  }
-  if (mediaField === "video") {
-    msg.video = {
-      file_id: "vid1",
-      duration: 10,
-      file_unique_id: "u3",
-      ...(opts?.file_name && { file_name: opts.file_name }),
-    };
-  }
-  if (mediaField === "document") {
-    msg.document = {
-      file_id: "d1",
-      file_unique_id: "u4",
-      ...(opts?.file_name && { file_name: opts.file_name }),
-      ...(opts?.mime_type && { mime_type: opts.mime_type }),
-    };
-  }
-  if (mediaField === "animation") {
-    msg.animation = {
-      file_id: "an1",
-      duration: 3,
-      file_unique_id: "u5",
-      width: 200,
-      height: 200,
-      ...(opts?.file_name && { file_name: opts.file_name }),
-    };
-  }
-  if (mediaField === "sticker") {
-    msg.sticker = {
-      file_id: "stk1",
-      file_unique_id: "ustk1",
-      type: "regular",
-      width: 512,
-      height: 512,
-      is_animated: false,
-      is_video: false,
-    };
-  }
-  return {
-    message: msg as unknown as Message,
-    me: {
-      id: 1,
-      is_bot: true,
-      first_name: "bot",
-      username: "bot",
-    } as unknown as TelegramContext["me"],
-    getFile,
-  };
-}
-
 function mockPdfFetchAndSave(fileName: string | undefined) {
   readRemoteMediaBuffer.mockResolvedValueOnce({
     buffer: Buffer.from("pdf-data"),
@@ -187,23 +114,7 @@ function resolveMediaWithDefaults(
   });
 }
 
-function requireResolvedMedia(
-  result: Awaited<ReturnType<typeof resolveMediaWithDefaults>>,
-  label: string,
-) {
-  if (!result) {
-    throw new Error(`expected ${label} media result`);
-  }
-  return result;
-}
-
 const requireRecord = createRequireRecord("record", "expected-label-record");
-
-function expectRecordFields(record: Record<string, unknown>, fields: Record<string, unknown>) {
-  for (const [key, value] of Object.entries(fields)) {
-    expect(record[key]).toEqual(value);
-  }
-}
 
 function requireReadRemoteMediaBufferParams(callIndex = 0): Record<string, unknown> {
   const call = (readRemoteMediaBuffer.mock.calls as unknown[][])[callIndex];
@@ -220,33 +131,6 @@ function expectReadRemoteMediaBufferFields(fields: Record<string, unknown>, call
 function expectFetchSsrfPolicyFields(fields: Record<string, unknown>, callIndex = 0) {
   const params = requireReadRemoteMediaBufferParams(callIndex);
   expectRecordFields(requireRecord(params.ssrfPolicy, "readRemoteMediaBuffer ssrfPolicy"), fields);
-}
-
-function expectResolvedMediaFields(
-  result: Awaited<ReturnType<typeof resolveMediaWithDefaults>>,
-  label: string,
-  fields: Record<string, unknown>,
-) {
-  expectRecordFields(requireResolvedMedia(result, label), fields);
-}
-
-async function expectMediaFetchError(
-  promise: Promise<unknown>,
-  fields: { code: string; messageIncludes: string; name?: string; status?: number },
-) {
-  try {
-    await promise;
-  } catch (error) {
-    const record = requireRecord(error, "MediaFetchError");
-    expect(record.name).toBe(fields.name ?? "MediaFetchError");
-    expect(record.code).toBe(fields.code);
-    expect(String(record.message)).toContain(fields.messageIncludes);
-    if (fields.status !== undefined) {
-      expect(record.status).toBe(fields.status);
-    }
-    return;
-  }
-  throw new Error("expected MediaFetchError rejection");
 }
 
 function expectSaveMediaBufferCall(callIndex: number, fields: Record<string, unknown>) {

--- a/extensions/telegram/src/bot/delivery.resolve-media.test-helpers.ts
+++ b/extensions/telegram/src/bot/delivery.resolve-media.test-helpers.ts
@@ -1,0 +1,132 @@
+import type { Message } from "grammy/types";
+import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
+import { expect } from "vitest";
+import type { resolveMedia } from "./delivery.resolve-media.js";
+import type { TelegramContext } from "./types.js";
+
+const requireRecord = createRequireRecord("record", "expected-label-record");
+
+export function makeCtx(
+  mediaField: "voice" | "audio" | "photo" | "video" | "document" | "animation" | "sticker",
+  getFile: TelegramContext["getFile"],
+  opts?: { file_name?: string; mime_type?: string },
+): TelegramContext {
+  const msg: Record<string, unknown> = {
+    message_id: 1,
+    date: 0,
+    chat: { id: 1, type: "private" },
+  };
+  if (mediaField === "voice") {
+    msg.voice = {
+      file_id: "v1",
+      duration: 5,
+      file_unique_id: "u1",
+      ...(opts?.mime_type && { mime_type: opts.mime_type }),
+    };
+  }
+  if (mediaField === "audio") {
+    msg.audio = {
+      file_id: "a1",
+      duration: 5,
+      file_unique_id: "u2",
+      ...(opts?.file_name && { file_name: opts.file_name }),
+      ...(opts?.mime_type && { mime_type: opts.mime_type }),
+    };
+  }
+  if (mediaField === "photo") {
+    msg.photo = [{ file_id: "p1", width: 100, height: 100 }];
+  }
+  if (mediaField === "video") {
+    msg.video = {
+      file_id: "vid1",
+      duration: 10,
+      file_unique_id: "u3",
+      ...(opts?.file_name && { file_name: opts.file_name }),
+    };
+  }
+  if (mediaField === "document") {
+    msg.document = {
+      file_id: "d1",
+      file_unique_id: "u4",
+      ...(opts?.file_name && { file_name: opts.file_name }),
+      ...(opts?.mime_type && { mime_type: opts.mime_type }),
+    };
+  }
+  if (mediaField === "animation") {
+    msg.animation = {
+      file_id: "an1",
+      duration: 3,
+      file_unique_id: "u5",
+      width: 200,
+      height: 200,
+      ...(opts?.file_name && { file_name: opts.file_name }),
+    };
+  }
+  if (mediaField === "sticker") {
+    msg.sticker = {
+      file_id: "stk1",
+      file_unique_id: "ustk1",
+      type: "regular",
+      width: 512,
+      height: 512,
+      is_animated: false,
+      is_video: false,
+    };
+  }
+  return {
+    message: msg as unknown as Message,
+    me: {
+      id: 1,
+      is_bot: true,
+      first_name: "bot",
+      username: "bot",
+    } as unknown as TelegramContext["me"],
+    getFile,
+  };
+}
+
+export function requireResolvedMedia(
+  result: Awaited<ReturnType<typeof resolveMedia>>,
+  label: string,
+) {
+  if (!result) {
+    throw new Error(`expected ${label} media result`);
+  }
+  return result;
+}
+
+export function expectRecordFields(
+  record: Record<string, unknown>,
+  fields: Record<string, unknown>,
+) {
+  for (const [key, value] of Object.entries(fields)) {
+    expect(record[key]).toEqual(value);
+  }
+}
+
+export function expectResolvedMediaFields(
+  result: Awaited<ReturnType<typeof resolveMedia>>,
+  label: string,
+  fields: Record<string, unknown>,
+) {
+  expectRecordFields(requireResolvedMedia(result, label), fields);
+}
+
+export async function expectMediaFetchError(
+  promise: Promise<unknown>,
+  fields: { code: string; messageIncludes: string; name?: string; status?: number },
+) {
+  try {
+    await promise;
+  } catch (error) {
+    const record = requireRecord(error, "MediaFetchError");
+    expect(record.name).toBe(fields.name ?? "MediaFetchError");
+    expect(record.code).toBe(fields.code);
+    expect(String(record.message)).toContain(fields.messageIncludes);
+    if (fields.status !== undefined) {
+      expect(record.status).toBe(fields.status);
+    }
+    return;
+  }
+  throw new Error("expected MediaFetchError rejection");
+}


### PR DESCRIPTION
## What Problem This Solves

The Telegram media resolution suites repeat the same context factory and four assertion helpers. Maintaining two copies adds unnecessary work around the same media owner’s regression coverage.

## Why This Change Was Made

Move those declarations into one sibling test-support module, preserving all seven media branches, fresh objects, option getter behavior, property presence, getFile identity, and literal error assertions. The production return type is referenced through a type-only import. Mock-bound helpers and all case bodies remain local and unchanged.

## User Impact

No user-visible or production behavior changes. Removes 101 net lines across tests and test support while retaining all existing coverage.

## Evidence

- Complete owner suites pass before and after: 54 tests. Their reported labels, order, and status match; whole-source inversion separately proves full case-body preservation.
- Relevant media-error and transport-error sibling cohort: 139 passing tests, including the same 54 owner cases.
- Byte-exact source inverses bind both original suites to the reviewed base. Emitted helper declarations match both originals, and production type imports are erased.
- Sixteen semantic control families agree across both original implementations and the shared helper, covering fresh references, seven media branches, option getters, omitted fields, and success/error assertion behavior.
- Mapped extension-test checks and fresh P2 review pass. The first mapped gate caught an unused import in one suite; it was removed and the corrected gate and final owner suites passed. That removal has identical emitted runtime code.

No overall test-runtime improvement is claimed for this fixture extraction.
