### PR TITLE
fix(sqlite): return complete large worker results

### DIFF
--- a/docs/plugins/sdk-overview/infrastructure.md
+++ b/docs/plugins/sdk-overview/infrastructure.md
@@ -137,8 +137,11 @@ while the worker is drained.
 The process-wide host starts lazily and permits at most four workers, 64 opening
 or live store clients (including clients sharing a database), 128 outstanding
 operations, and 64 MiB of queued input. Each input message is limited to 32 MiB
-and each result to 64 MiB; capacity exhaustion rejects with
-`code: "overloaded"`. Operations for one database share its connection owner
+and capacity exhaustion rejects with `code: "overloaded"`. Results up to 64 MiB
+use an inline reply; larger results transfer their complete serialized value
+in bounded 8 MiB chunks. Callers still materialize the complete result in memory,
+and the original operation remains owned through transfer validation and cleanup.
+Operations for one database share its connection owner
 and execute in order. There are no reader replicas or worker-pool configuration
 options.
 

--- a/docs/reference/database-schemas/storage-changes.md
+++ b/docs/reference/database-schemas/storage-changes.md
@@ -39,6 +39,14 @@ classification stays with the pure record types, so decoding does not load
 provider or plugin runtime ownership. These operations and their transaction
 callbacks remain synchronous; this separation does not move SQL to a worker.
 
+SQLite worker transport preserves complete result values. Results within the
+64 MiB inline reply budget keep their existing reply path; larger results are
+serialized once and transferred in 8 MiB frames. The original operation retains
+its worker until the complete result and cleanup are acknowledged, including
+during shutdown. Framing does not paginate or repeat the database query, truncate
+results, or change request and queue budgets. Callers still materialize their
+complete result in memory.
+
 Acquire a connection once for an operation and pass that exact connection
 through its transactional helpers. SQLite write callbacks remain synchronous:
 finish asynchronous planning first, then reread authoritative rows after write

--- a/src/infra/sqlite-store.worker.ts
+++ b/src/infra/sqlite-store.worker.ts
@@ -10,21 +10,41 @@ import {
   type SqliteWorkerRequest,
 } from "./sqlite-worker-contract.js";
 import { assertExistingDatabaseIdentity } from "./sqlite-worker-identity.js";
+import { createSqliteWorkerTransferOwner } from "./sqlite-worker-transfer.js";
 
 const port = parentPort;
 if (!port) {
   throw new Error("SQLite store worker requires its host port");
 }
 const actors = new Map<number, SqliteWorkerBackend<SqliteWorkerOperations>>();
+const transfers = createSqliteWorkerTransferOwner();
+let pendingResult: { requestId: number; actor: number; transferId: number } | undefined;
 let sourceLoaderRegistered = false;
 
 async function receive(request: SqliteWorkerRequest): Promise<void> {
   let reply: SqliteWorkerReply;
-  let executed = false;
+  let executed = pendingResult !== undefined;
   let retire = false;
   try {
     let value: unknown;
-    if (request.type === "open") {
+    if (request.type === "result-next") {
+      if (
+        pendingResult?.requestId !== request.id ||
+        pendingResult.actor !== request.actor ||
+        pendingResult.transferId !== request.transferId
+      ) {
+        throw new Error("SQLite worker result transfer is no longer current");
+      }
+      executed = true;
+      const frame = transfers.next(request.transferId);
+      if (frame.done) {
+        transfers.end(request.transferId);
+        pendingResult = undefined;
+      }
+      value = frame;
+    } else if (pendingResult) {
+      throw new Error("SQLite worker result transfer has not finished");
+    } else if (request.type === "open") {
       if (actors.has(request.actor)) {
         throw new Error("SQLite worker actor is already open");
       }
@@ -85,10 +105,25 @@ async function receive(request: SqliteWorkerRequest): Promise<void> {
     }
     const serialized = serialize(value);
     if (serialized.byteLength > SQLITE_WORKER_MAX_RESULT_BYTES) {
-      throw new Error("SQLite worker result exceeds the transport byte limit");
+      if (request.type !== "execute") {
+        throw new Error("SQLite worker frame exceeds the transport byte limit");
+      }
+      const handle = transfers.start([{ kind: "result", serialized }].values(), {
+        kinds: ["result"],
+      });
+      pendingResult = { requestId: request.id, actor: request.actor, transferId: handle.id };
+      reply = { id: request.id, ok: true, value: serialize(handle), transfer: "start" };
+    } else {
+      reply = {
+        id: request.id,
+        ok: true,
+        value: serialized,
+        ...(request.type === "result-next" ? { transfer: "frame" } : {}),
+      };
     }
-    reply = { id: request.id, ok: true, value: serialized };
   } catch (error) {
+    transfers.cancel();
+    pendingResult = undefined;
     const failure = error instanceof Error ? error : new Error(String(error));
     const code = executed ? "outcome-unknown" : "code" in failure ? failure.code : undefined;
     reply = {

--- a/src/infra/sqlite-worker-broker.types.ts
+++ b/src/infra/sqlite-worker-broker.types.ts
@@ -1,0 +1,46 @@
+import type { Worker } from "node:worker_threads";
+import type { SqliteWorkerRequest } from "./sqlite-worker-contract.js";
+import type { createSqliteWorkerTransferReceiver } from "./sqlite-worker-transfer.js";
+
+export type RequestBody = SqliteWorkerRequest extends infer Request
+  ? Request extends SqliteWorkerRequest
+    ? Omit<Request, "id">
+    : never
+  : never;
+export type DispatchState = { dispatched: boolean };
+export type Job = {
+  transfer?: {
+    id: number;
+    receiver: ReturnType<typeof createSqliteWorkerTransferReceiver>;
+    value: unknown;
+  };
+  dispatchState?: DispatchState;
+  request: SqliteWorkerRequest;
+  bytes: number;
+  resolve(value: unknown): void;
+  reject(error: unknown): void;
+  detach(): void;
+};
+export type Slot = {
+  worker: Worker;
+  actors: Set<Actor>;
+  queue: Job[];
+  current?: Job;
+  failed?: Error;
+  retiring?: Promise<void>;
+  exit: Promise<void>;
+  pendingOpens: number;
+};
+export type Actor = {
+  id: number;
+  key: string;
+  pathReferences: Map<string, number>;
+  moduleUrl: string;
+  inputHash: string;
+  slot: Slot;
+  references: number;
+  opened: Promise<unknown>;
+  openDispatch: DispatchState;
+  initialized: boolean;
+  closing?: Promise<void>;
+};

--- a/src/infra/sqlite-worker-contract.ts
+++ b/src/infra/sqlite-worker-contract.ts
@@ -29,16 +29,18 @@ export type SqliteWorkerRequest = {
       input: Uint8Array;
     }
   | { type: "execute"; input: Uint8Array }
+  | { type: "result-next"; transferId: number }
   | { type: "close" }
 );
 
 export type SqliteWorkerReply = {
   id: number;
 } & (
-  | { ok: true; value: Uint8Array }
+  | { ok: true; value: Uint8Array; transfer?: "start" | "frame" }
   | { ok: false; retire?: true; error: { name: string; message: string; code?: string | number } }
 );
 
 export const SQLITE_WORKER_MAX_MESSAGE_BYTES = 32 * 1024 * 1024;
-// Complete multi-record reads can exceed a single admitted write payload.
+// Larger complete results use bounded frames; this remains the inline reply budget.
 export const SQLITE_WORKER_MAX_RESULT_BYTES = 64 * 1024 * 1024;
+export const SQLITE_WORKER_TRANSFER_FRAME_BYTES = 8 * 1024 * 1024;

--- a/src/infra/sqlite-worker-store.test.ts
+++ b/src/infra/sqlite-worker-store.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import {
   link,
   mkdir,
@@ -13,8 +14,13 @@ import { Worker } from "node:worker_threads";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { createDeferredCore } from "../shared/deferred.js";
+import { drainGlobalSingletonLifecycleState } from "../shared/global-singleton.js";
 import { resolveIncognitoOpenClawAgentSqlitePath } from "../state/openclaw-agent-db.paths.js";
-import type { SqliteWorkerReply } from "./sqlite-worker-contract.js";
+import {
+  SQLITE_WORKER_MAX_RESULT_BYTES,
+  SQLITE_WORKER_TRANSFER_FRAME_BYTES,
+  type SqliteWorkerReply,
+} from "./sqlite-worker-contract.js";
 import { openSqliteWorkerStore, type SqliteWorkerStore } from "./sqlite-worker-store.js";
 import type { FixtureOpenInput, FixtureOperations } from "./sqlite-worker-store.test-support.js";
 
@@ -71,6 +77,109 @@ function read(store: SqliteWorkerStore<FixtureOperations>) {
 const nodeIt = process.versions.bun ? it.skip : it;
 
 describe("SQLite worker store", () => {
+  it.each(["read", "client close", "global close", "abort", "failed frame"] as const)(
+    "preserves a complete large result through %s",
+    async (action) => {
+      const file = databasePath();
+      const store = await open(file);
+      const values = Array.from(
+        { length: 3 },
+        (_, index) => `${"x".repeat(24 * 1024 * 1024)}é-${index}`,
+      );
+      const digest = (value: string) => createHash("sha256").update(value).digest("hex");
+      const inlineReplies: string[][] = [];
+      const frames: Array<{ bytes: number; backingBytes: number }> = [];
+      const aborted = new AbortController();
+      let closing: Promise<void> | undefined;
+      // oxlint-disable-next-line typescript/unbound-method -- Reflect.apply preserves the emitting worker below.
+      const originalEmit = Worker.prototype.emit;
+      const messages = vi.spyOn(Worker.prototype, "emit").mockImplementation(function (
+        this: Worker,
+        event: string | symbol,
+        reply: SqliteWorkerReply,
+      ) {
+        if (event === "message" && reply.ok) {
+          if (!reply.transfer) {
+            inlineReplies.push(Object.keys(reply).toSorted());
+          } else if (reply.transfer === "frame") {
+            frames.push({
+              bytes: reply.value.byteLength,
+              backingBytes: reply.value.buffer.byteLength,
+            });
+            if (frames.length === 1) {
+              if (action === "client close") {
+                closing = store.close();
+              }
+              if (action === "global close") {
+                closing = drainGlobalSingletonLifecycleState("restart");
+              }
+              if (action === "abort") {
+                aborted.abort(new Error("Canceled after read dispatch"));
+              }
+              if (action === "failed frame") {
+                return Reflect.apply(originalEmit, this, [
+                  event,
+                  { ...reply, value: new Uint8Array([0]) },
+                ]);
+              }
+            }
+          }
+        }
+        return Reflect.apply(originalEmit, this, [event, reply]);
+      });
+      const requests = vi.spyOn(Worker.prototype, "postMessage");
+      try {
+        for (const value of values) {
+          await append(store, value);
+        }
+        expect(inlineReplies).toEqual(values.map(() => ["id", "ok", "value"]));
+        requests.mockClear();
+        const reading = store.execute(
+          { type: "read", input: undefined },
+          { signal: aborted.signal },
+        );
+        if (action === "failed frame") {
+          const queued = append(store, "must not be dispatched");
+          expect(await Promise.allSettled([reading, queued])).toEqual([
+            { status: "rejected", reason: expect.objectContaining({ code: "outcome-unknown" }) },
+            { status: "rejected", reason: expect.objectContaining({ code: "unavailable" }) },
+          ]);
+        } else {
+          const result = await reading;
+          expect(result).toHaveLength(values.length);
+          expect(result.map(digest)).toEqual(values.map(digest));
+          expect(frames.length).toBeGreaterThan(8);
+          if (action.endsWith("close")) {
+            expect(closing).toBeDefined();
+          }
+          if (action === "abort") {
+            expect(aborted.signal.aborted).toBe(true);
+          }
+          await closing;
+        }
+        expect(requests.mock.calls.filter(([request]) => request.type === "execute")).toHaveLength(
+          1,
+        );
+        expect(
+          frames.every((frame) => frame.bytes <= SQLITE_WORKER_TRANSFER_FRAME_BYTES + 1024),
+        ).toBe(true);
+        expect(frames.every((frame) => frame.backingBytes <= SQLITE_WORKER_MAX_RESULT_BYTES)).toBe(
+          true,
+        );
+      } finally {
+        messages.mockRestore();
+        requests.mockRestore();
+        await Promise.allSettled([closing, store.close()]);
+        stores.delete(store);
+      }
+      if (action === "failed frame") {
+        const recovered = await open(file);
+        expect((await read(recovered)).map(digest)).toEqual(values.map(digest));
+        expect(await append(recovered, "after recovery")).toMatchObject({ writes: 1 });
+      }
+    },
+  );
+
   it.each(["memory", "absolute memory", "memory URI", "incognito", "empty"] as const)(
     "rejects a %s locator before creating a file or dispatching a worker request",
     async (kind) => {

--- a/src/infra/sqlite-worker-store.ts
+++ b/src/infra/sqlite-worker-store.ts
@@ -12,6 +12,7 @@ import { INCOGNITO_AGENT_SQLITE_BASENAME } from "../state/openclaw-agent-db.path
 import { ensureSqliteLibrarySelected } from "./bun-sqlite-library.js";
 import { runtimeProcessEntrypoints } from "./runtime-process-entrypoints.js";
 import { resolveRuntimeWorkerUrl } from "./runtime-worker-url.js";
+import type { Actor, DispatchState, Job, RequestBody, Slot } from "./sqlite-worker-broker.types.js";
 import {
   SQLITE_WORKER_MAX_MESSAGE_BYTES,
   type SqliteWorkerOperations,
@@ -20,6 +21,11 @@ import {
   type SqliteWorkerStore,
 } from "./sqlite-worker-contract.js";
 import { readDatabasePathIdentity } from "./sqlite-worker-identity.js";
+import {
+  createSqliteWorkerTransferReceiver,
+  type SqliteWorkerTransferFrame,
+  type SqliteWorkerTransferHandle,
+} from "./sqlite-worker-transfer.js";
 
 export type {
   SqliteWorkerBackend,
@@ -39,44 +45,6 @@ type SqliteWorkerStoreOptions = {
   databasePath: string;
   input: unknown;
   existingOnly?: boolean;
-};
-
-type RequestBody = SqliteWorkerRequest extends infer Request
-  ? Request extends SqliteWorkerRequest
-    ? Omit<Request, "id">
-    : never
-  : never;
-type DispatchState = { dispatched: boolean };
-type Job = {
-  dispatchState?: DispatchState;
-  request: SqliteWorkerRequest;
-  bytes: number;
-  resolve(value: unknown): void;
-  reject(error: unknown): void;
-  detach(): void;
-};
-type Slot = {
-  worker: Worker;
-  actors: Set<Actor>;
-  queue: Job[];
-  current?: Job;
-  failed?: Error;
-  retiring?: Promise<void>;
-  exit: Promise<void>;
-  pendingOpens: number;
-};
-type Actor = {
-  id: number;
-  key: string;
-  pathReferences: Map<string, number>;
-  moduleUrl: string;
-  inputHash: string;
-  slot: Slot;
-  references: number;
-  opened: Promise<unknown>;
-  openDispatch: DispatchState;
-  initialized: boolean;
-  closing?: Promise<void>;
 };
 
 export class SqliteWorkerError extends Error {
@@ -448,7 +416,57 @@ class SqliteWorkerBroker {
       }
       let value: unknown;
       try {
-        value = deserialize(reply.value);
+        if (reply.transfer === "start") {
+          // SAFETY: The matching worker emits this private handle; framing validates its records.
+          const handle = deserialize(reply.value) as SqliteWorkerTransferHandle;
+          if (
+            job.request.type !== "execute" ||
+            job.transfer ||
+            handle.kinds.length !== 1 ||
+            handle.kinds[0] !== "result"
+          ) {
+            throw new Error("SQLite worker returned an unexpected result transfer");
+          }
+          const transfer: NonNullable<Job["transfer"]> = {
+            id: handle.id,
+            value: undefined,
+            receiver: createSqliteWorkerTransferReceiver(handle, (record) => {
+              transfer.value = record.value;
+            }),
+          };
+          job.transfer = transfer;
+        } else if (reply.transfer === "frame") {
+          const transfer = job.transfer;
+          if (!transfer) {
+            throw new Error("SQLite worker returned an unexpected result frame");
+          }
+          // SAFETY: The matching worker emits frames; the shared receiver validates their sequence and bounds.
+          const frame = deserialize(reply.value) as SqliteWorkerTransferFrame;
+          const counts = transfer.receiver.accept(frame);
+          if (counts) {
+            if (counts.length !== 1 || counts[0]?.[1] !== 1) {
+              throw new Error("SQLite worker returned an incomplete result transfer");
+            }
+            value = transfer.value;
+            job.transfer = undefined;
+          }
+        } else {
+          if (job.transfer) {
+            throw new Error("SQLite worker ended its result transfer without completion");
+          }
+          value = deserialize(reply.value);
+        }
+        if (job.transfer) {
+          // Continue the current job through drain; enqueueing behind it would deadlock.
+          const continuation: SqliteWorkerRequest = {
+            type: "result-next",
+            id: job.request.id,
+            actor: job.request.actor,
+            transferId: job.transfer.id,
+          };
+          slot.worker.postMessage(continuation, []);
+          return;
+        }
       } catch (error) {
         this.fail(slot, error);
         return;
@@ -544,6 +562,7 @@ class SqliteWorkerBroker {
   }
 
   private finish(job: Job, error?: unknown, value?: unknown): void {
+    job.transfer = undefined;
     job.detach();
     this.requests -= 1;
     this.bytes -= job.bytes;
@@ -562,6 +581,9 @@ class SqliteWorkerBroker {
     slot.failed = new SqliteWorkerError(error.message, "unavailable");
     const current = slot.current;
     slot.current = undefined;
+    if (current) {
+      current.transfer = undefined;
+    }
     const queued = slot.queue.splice(0);
     // Join native exit before releasing any operation that might have touched SQLite.
     void this.retire(slot).then(() => {

--- a/src/infra/sqlite-worker-transfer.test.ts
+++ b/src/infra/sqlite-worker-transfer.test.ts
@@ -1,0 +1,216 @@
+import { createHash } from "node:crypto";
+import { serialize } from "node:v8";
+import { describe, expect, it, vi } from "vitest";
+import {
+  SQLITE_WORKER_MAX_RESULT_BYTES,
+  SQLITE_WORKER_TRANSFER_FRAME_BYTES,
+} from "./sqlite-worker-contract.js";
+import {
+  createSqliteWorkerTransferOwner,
+  createSqliteWorkerTransferReceiver,
+  type SqliteWorkerTransferFrame,
+  type SqliteWorkerTransferValue,
+} from "./sqlite-worker-transfer.js";
+
+const digest = (value: string) => createHash("sha256").update(value).digest("hex");
+
+describe("bounded SQLite worker value transfers", () => {
+  it.each(["one oversized row", "many rows"])(
+    "preserves a complete %s result over 64 MiB",
+    (shape) => {
+      const value = `${"x".repeat((shape === "many rows" ? 1 : 65) * 1024 * 1024)}🌊`;
+      const count = shape === "many rows" ? 65 : 1;
+      const owner = createSqliteWorkerTransferOwner();
+      const cleanup = vi.fn();
+      const records = function* (): IterableIterator<SqliteWorkerTransferValue> {
+        for (let index = 0; index < count; index += 1) {
+          yield { kind: "row", value };
+        }
+      };
+      const handle = owner.start(records(), { kinds: ["row"], cleanup });
+      let bytes = 0;
+      let values = 0;
+      let sequence = 0;
+      const receiver = createSqliteWorkerTransferReceiver(handle, ({ kind, value: restored }) => {
+        expect(kind).toBe("row");
+        expect(typeof restored).toBe("string");
+        if (typeof restored === "string") {
+          expect(restored.length).toBe(value.length);
+          expect(digest(restored)).toBe(digest(value));
+        }
+        values += 1;
+      });
+      for (;;) {
+        const frame = owner.next(handle.id);
+        expect(frame.sequence).toBe(sequence++);
+        expect(serialize(frame).byteLength).toBeLessThanOrEqual(SQLITE_WORKER_MAX_RESULT_BYTES);
+        const counts = receiver.accept(frame);
+        if (counts) {
+          expect(counts).toEqual([["row", count]]);
+          break;
+        }
+        if (frame.done) {
+          throw new Error("Expected the receiver to complete at EOF");
+        }
+        expect(frame.bytes.byteLength).toBeLessThanOrEqual(SQLITE_WORKER_TRANSFER_FRAME_BYTES);
+        expect(frame.bytes.buffer.byteLength).toBeLessThanOrEqual(
+          SQLITE_WORKER_TRANSFER_FRAME_BYTES,
+        );
+        bytes += frame.bytes.byteLength;
+      }
+      owner.end(handle.id);
+      expect(bytes).toBeGreaterThan(SQLITE_WORKER_MAX_RESULT_BYTES);
+      expect(values).toBe(count);
+      expect(cleanup).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it("transfers already serialized bytes without serializing the record again", () => {
+    const value = { unicode: "雪🌊", binary: new Uint8Array([0, 127, 255]), missing: undefined };
+    const serialized = serialize(value);
+    const owner = createSqliteWorkerTransferOwner();
+    const handle = owner.start([{ kind: "result", serialized }].values(), { kinds: ["result"] });
+    const consume = vi.fn();
+    const receiver = createSqliteWorkerTransferReceiver(handle, consume);
+    const frame = owner.next(handle.id);
+    expect(frame).toMatchObject({
+      done: false,
+      recordBytes: serialized.byteLength,
+      bytes: new Uint8Array(serialized),
+    });
+    expect(receiver.accept(frame)).toBeUndefined();
+    expect(consume).toHaveBeenCalledExactlyOnceWith({ kind: "result", value });
+    const end = owner.next(handle.id);
+    expect(receiver.accept(end)).toEqual([["result", 1]]);
+    owner.end(handle.id);
+    expect(() => receiver.accept(end)).toThrow("out of order");
+    expect(consume).toHaveBeenCalledTimes(1);
+  });
+
+  it.each(["id", "sequence", "kind", "offset", "length", "completion"] as const)(
+    "rejects invalid %s framing without consuming a value or accepting continuation",
+    (invalid) => {
+      const bytes = serialize("complete row");
+      const handle = { id: 1, kinds: ["row"] };
+      const consume = vi.fn();
+      const receiver = createSqliteWorkerTransferReceiver(handle, consume);
+      const frame: SqliteWorkerTransferFrame = {
+        id: 1,
+        sequence: 0,
+        done: false,
+        kind: "row",
+        recordBytes: bytes.byteLength,
+        offset: 0,
+        recordDone: true,
+        bytes,
+      };
+      const invalidFrame = { ...frame };
+      switch (invalid) {
+        case "id":
+          invalidFrame.id = 2;
+          break;
+        case "sequence":
+          invalidFrame.sequence = 1;
+          break;
+        case "kind":
+          invalidFrame.kind = "other";
+          break;
+        case "offset":
+          invalidFrame.offset = 1;
+          break;
+        case "length":
+          invalidFrame.recordBytes = bytes.byteLength - 1;
+          break;
+        case "completion":
+          invalidFrame.recordDone = false;
+          break;
+      }
+      expect(() => receiver.accept(invalidFrame)).toThrow(/SQLite read transfer/);
+      expect(consume).not.toHaveBeenCalled();
+      expect(() => receiver.accept({ ...frame, sequence: 1 })).toThrow("out of order");
+    },
+  );
+
+  it.each(["missing", "duplicate", "incorrect", "partial"] as const)(
+    "rejects a transfer ending with %s records",
+    (invalid) => {
+      const bytes = serialize("one row");
+      const consume = vi.fn();
+      const receiver = createSqliteWorkerTransferReceiver(
+        { id: 1, kinds: ["row", "other"] },
+        consume,
+      );
+      receiver.accept({
+        id: 1,
+        sequence: 0,
+        done: false,
+        kind: "row",
+        recordBytes: bytes.byteLength,
+        offset: 0,
+        recordDone: invalid !== "partial",
+        bytes: invalid === "partial" ? bytes.subarray(0, 1) : bytes,
+      });
+      expect(() =>
+        receiver.accept({
+          id: 1,
+          sequence: 1,
+          done: true,
+          counts:
+            invalid === "missing"
+              ? [["row", 1]]
+              : invalid === "duplicate"
+                ? [
+                    ["row", 1],
+                    ["row", 1],
+                  ]
+                : [
+                    ["row", 0],
+                    ["other", 0],
+                  ],
+        }),
+      ).toThrow("incomplete result");
+      expect(consume).toHaveBeenCalledTimes(invalid === "partial" ? 0 : 1);
+    },
+  );
+
+  it("releases an abandoned iterator before accepting another transfer", () => {
+    const released = vi.fn();
+    const cleanup = vi.fn();
+    const rows = function* () {
+      try {
+        yield { kind: "row", value: "first" };
+        yield { kind: "row", value: "second" };
+      } finally {
+        released();
+      }
+    };
+    const owner = createSqliteWorkerTransferOwner();
+    const first = owner.start(rows(), { kinds: ["row"], cleanup });
+    const receiver = createSqliteWorkerTransferReceiver(first, () => {
+      throw new Error("consumer stopped");
+    });
+    const frame = owner.next(first.id);
+    expect(frame).toMatchObject({ done: false, recordDone: true });
+    expect(() => receiver.accept(frame)).toThrow("consumer stopped");
+    expect(() => owner.end(first.id)).toThrow("before its complete result");
+    owner.cancel();
+    owner.cancel();
+    expect(released).toHaveBeenCalledTimes(1);
+    expect(cleanup).toHaveBeenCalledTimes(1);
+    const second = owner.start([].values(), { kinds: ["row"] });
+    expect(owner.next(second.id)).toMatchObject({ done: true, counts: [["row", 0]] });
+    owner.end(second.id);
+  });
+
+  it("retains failed cleanup for the actor close boundary", () => {
+    const cleanup = vi.fn().mockImplementationOnce(() => {
+      throw new Error("native reader close failed");
+    });
+    const owner = createSqliteWorkerTransferOwner();
+    owner.start([].values(), { kinds: ["row"], cleanup });
+    expect(() => owner.cancel()).toThrow("native reader close failed");
+    owner.close();
+    owner.close();
+    expect(cleanup).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/infra/sqlite-worker-transfer.ts
+++ b/src/infra/sqlite-worker-transfer.ts
@@ -1,0 +1,225 @@
+import { deserialize, serialize } from "node:v8";
+import { SQLITE_WORKER_TRANSFER_FRAME_BYTES } from "./sqlite-worker-contract.js";
+
+export type SqliteWorkerTransferHandle = { id: number; kinds: string[] };
+export type SqliteWorkerTransferValue = { kind: string; value: unknown };
+export type SqliteWorkerTransferInput =
+  | SqliteWorkerTransferValue
+  /** Already serialized bytes remain owned by the producer and immutable until release. */
+  | { kind: string; serialized: Uint8Array };
+export type SqliteWorkerTransferCounts = Array<[string, number]>;
+export type SqliteWorkerTransferFrame = { id: number; sequence: number } & (
+  | { done: true; counts: SqliteWorkerTransferCounts }
+  | {
+      done: false;
+      kind: string;
+      recordBytes: number;
+      offset: number;
+      recordDone: boolean;
+      bytes: Uint8Array;
+    }
+);
+
+type Transfer = {
+  id: number;
+  iterator: Iterator<SqliteWorkerTransferInput>;
+  cleanup?: () => void;
+  iteratorClosed: boolean;
+  cleaned: boolean;
+  counts: Map<string, number>;
+  sequence: number;
+  finished: boolean;
+  record?: { kind: string; bytes: Uint8Array; offset: number };
+};
+
+/** One owned result cursor; callers supply records and any associated cleanup. */
+export function createSqliteWorkerTransferOwner() {
+  let nextId = 0;
+  let current: Transfer | undefined;
+
+  const cleanup = (transfer: Transfer) => {
+    const errors: unknown[] = [];
+    if (!transfer.iteratorClosed) {
+      try {
+        transfer.iterator.return?.();
+        transfer.iteratorClosed = true;
+      } catch (error) {
+        errors.push(error);
+      }
+    }
+    if (!transfer.cleaned) {
+      try {
+        transfer.cleanup?.();
+        transfer.cleaned = true;
+      } catch (error) {
+        errors.push(error);
+      }
+    }
+    if (errors.length === 1) {
+      throw errors[0];
+    }
+    if (errors.length) {
+      throw new AggregateError(errors, "SQLite read transfer cleanup failed", { cause: errors[0] });
+    }
+  };
+  const cancel = () => {
+    if (current) {
+      cleanup(current);
+      current = undefined;
+    }
+  };
+  const requireTransfer = (id: number) => {
+    if (!current || current.id !== id) {
+      throw new Error("SQLite read transfer is no longer active");
+    }
+    return current;
+  };
+
+  return {
+    start(
+      iterator: Iterator<SqliteWorkerTransferInput>,
+      options: { kinds: string[]; cleanup?: () => void },
+    ): SqliteWorkerTransferHandle {
+      if (current) {
+        throw new Error("The preceding SQLite read transfer was not released");
+      }
+      current = {
+        id: ++nextId,
+        iterator,
+        cleanup: options.cleanup,
+        iteratorClosed: false,
+        cleaned: false,
+        counts: new Map(options.kinds.map((kind) => [kind, 0])),
+        sequence: 0,
+        finished: false,
+      };
+      return { id: current.id, kinds: [...current.counts.keys()] };
+    },
+    next(id: number): SqliteWorkerTransferFrame {
+      const transfer = requireTransfer(id);
+      if (transfer.finished) {
+        throw new Error("SQLite read transfer has already reached its end");
+      }
+      if (transfer.record && transfer.record.offset === transfer.record.bytes.byteLength) {
+        transfer.record = undefined;
+      }
+      if (!transfer.record) {
+        const next = transfer.iterator.next();
+        if (next.done) {
+          cleanup(transfer);
+          transfer.finished = true;
+          return { id, sequence: transfer.sequence++, done: true, counts: [...transfer.counts] };
+        }
+        const { kind } = next.value;
+        const count = transfer.counts.get(kind);
+        if (count === undefined) {
+          throw new Error("SQLite read transfer returned an unexpected record kind");
+        }
+        transfer.record = {
+          kind,
+          bytes: "serialized" in next.value ? next.value.serialized : serialize(next.value.value),
+          offset: 0,
+        };
+        transfer.counts.set(kind, count + 1);
+      }
+      const record = transfer.record;
+      const offset = record.offset;
+      const end = Math.min(record.bytes.byteLength, offset + SQLITE_WORKER_TRANSFER_FRAME_BYTES);
+      record.offset = end;
+      return {
+        id,
+        sequence: transfer.sequence++,
+        done: false,
+        kind: record.kind,
+        recordBytes: record.bytes.byteLength,
+        offset,
+        recordDone: end === record.bytes.byteLength,
+        // Bun serialization includes the backing buffer, so each frame must own only its bytes.
+        bytes: new Uint8Array(record.bytes.subarray(offset, end)),
+      };
+    },
+    end(id: number): void {
+      const transfer = requireTransfer(id);
+      if (!transfer.finished) {
+        throw new Error("SQLite read transfer ended before its complete result");
+      }
+      cancel();
+    },
+    cancel,
+    close: cancel,
+  };
+}
+
+/** Reassembles one transfer; its caller owns transport completion and cancellation. */
+export function createSqliteWorkerTransferReceiver(
+  handle: SqliteWorkerTransferHandle,
+  consume: (record: SqliteWorkerTransferValue) => void,
+): { accept(frame: SqliteWorkerTransferFrame): SqliteWorkerTransferCounts | undefined } {
+  const counts = new Map(handle.kinds.map((kind) => [kind, 0]));
+  let sequence = 0;
+  let finished = false;
+  let record: { kind: string; bytes: Uint8Array; offset: number } | undefined;
+  return {
+    accept(frame) {
+      try {
+        if (finished || frame.id !== handle.id || frame.sequence !== sequence++) {
+          throw new Error("SQLite read transfer frame is out of order");
+        }
+        if (frame.done) {
+          if (
+            record ||
+            frame.counts.length !== counts.size ||
+            frame.counts.some(([kind, count]) => counts.get(kind) !== count) ||
+            new Set(frame.counts.map(([kind]) => kind)).size !== counts.size
+          ) {
+            throw new Error("SQLite read transfer ended with an incomplete result");
+          }
+          finished = true;
+          return frame.counts;
+        }
+        const count = counts.get(frame.kind);
+        if (
+          count === undefined ||
+          !Number.isSafeInteger(frame.recordBytes) ||
+          frame.recordBytes < 1 ||
+          !Number.isSafeInteger(frame.offset) ||
+          frame.offset < 0 ||
+          frame.bytes.byteLength < 1 ||
+          frame.bytes.byteLength > SQLITE_WORKER_TRANSFER_FRAME_BYTES
+        ) {
+          throw new Error("SQLite read transfer returned an invalid frame");
+        }
+        if (!record) {
+          if (frame.offset !== 0) {
+            throw new Error("SQLite read transfer omitted the start of a record");
+          }
+          record = { kind: frame.kind, bytes: new Uint8Array(frame.recordBytes), offset: 0 };
+        }
+        const end = frame.offset + frame.bytes.byteLength;
+        if (
+          record.kind !== frame.kind ||
+          record.bytes.byteLength !== frame.recordBytes ||
+          record.offset !== frame.offset ||
+          end > frame.recordBytes ||
+          frame.recordDone !== (end === frame.recordBytes)
+        ) {
+          throw new Error("SQLite read transfer returned a discontinuous record");
+        }
+        record.bytes.set(frame.bytes, frame.offset);
+        record.offset = end;
+        if (frame.recordDone) {
+          const value: unknown = deserialize(record.bytes);
+          const kind = record.kind;
+          record = undefined;
+          consume({ kind, value });
+          counts.set(kind, count + 1);
+        }
+        return undefined;
+      } catch (error) {
+        record = undefined;
+        finished = true;
+        throw error;
+      }
+    },
+  };
+}


### PR DESCRIPTION
Related: #145851

## What Problem This Solves

Fixes an issue where callers reading large persisted SQLite results receive a worker error instead of the complete result when its serialized size exceeds 64 MiB. A normal read of three stored 24 MiB values reproduces the failure.

## Why This Change Was Made

The worker serializes each result once and transfers oversized results through the shared framing producer and receiver. The original request retains the worker until validated completion and result cleanup, so shutdown drains the transfer and a failed frame cannot publish a partial result or replay the operation. Small replies retain their existing inline path; request, queue, and frame budgets stay unchanged.

## User Impact

Callers can receive complete large records and lists through the existing SQLite worker API. This is a result-transport fix; the API still materializes each complete result in memory.

## Evidence

- Reproduced the 72 MiB stored-result failure on main, then verified complete counts and content digests through the actual worker.
- 30 focused tests pass, covering framing, inline replies, actual message backing-buffer bounds, client/global close, post-dispatch cancellation, failed-frame retirement, queued-write non-dispatch, and reopen without replay.
- Full changed gate passes, including types, typed lint, dead-export checks, storage/import guards, and existing line-count/assertion ratchets.
- Independent review through P2 found no actionable defects.

Full build passes. Actual Node 24.20.0 and Bun 1.4.2 workers pass the same 72 MiB digest/reopen proof through both source and compiled SDK entries. Compiled-worker receipts verify the built worker path; each read uses one execute plus 11 continuations.

The Bun proof caught its serializer cloning an entire Buffer subarray backing buffer. Frames now own independent Uint8Array storage on both runtimes, with actual received backing buffers bounded to about 8 MiB. Request and queue budgets are unchanged.
