### PR TITLE
refactor: retire unused session model cycling

### DIFF
--- a/src/agents/sessions/agent-session-base.ts
+++ b/src/agents/sessions/agent-session-base.ts
@@ -76,8 +76,6 @@ export abstract class AgentSessionBase {
   readonly sessionManager: SessionManager;
   readonly settingsManager: SettingsManager;
 
-  protected scopedModelEntries: Array<{ model: Model; thinkingLevel?: ThinkingLevel }>;
-
   // Event subscription state
   protected unsubscribeAgent?: () => void;
   private eventListeners: AgentSessionEventListener[] = [];
@@ -145,7 +143,6 @@ export abstract class AgentSessionBase {
     this.agent = config.agent;
     this.sessionManager = config.sessionManager;
     this.settingsManager = config.settingsManager;
-    this.scopedModelEntries = config.scopedModels ?? [];
     this.sessionResourceLoader = config.resourceLoader;
     this.customTools = config.customTools ?? [];
     this.cwd = config.cwd;
@@ -773,16 +770,6 @@ export abstract class AgentSessionBase {
   /** Current session display name, if set */
   get sessionName(): string | undefined {
     return this.sessionManager.getSessionName();
-  }
-
-  /** Scoped models for cycling (from --models flag) */
-  get scopedModels(): ReadonlyArray<{ model: Model; thinkingLevel?: ThinkingLevel }> {
-    return this.scopedModelEntries;
-  }
-
-  /** Update scoped models for cycling */
-  setScopedModels(scopedModels: Array<{ model: Model; thinkingLevel?: ThinkingLevel }>): void {
-    this.scopedModelEntries = scopedModels;
   }
 
   /** File-based prompt templates */

--- a/src/agents/sessions/agent-session-models.ts
+++ b/src/agents/sessions/agent-session-models.ts
@@ -6,7 +6,6 @@ import {
 import type { Model } from "../../llm/types.js";
 import type { ThinkingLevel } from "../runtime/index.js";
 import { AgentSessionPrompting } from "./agent-session-prompting.js";
-import type { ModelCycleResult } from "./agent-session-types.js";
 import { DEFAULT_THINKING_LEVEL } from "./defaults.js";
 
 const THINKING_LEVELS: ThinkingLevel[] = ["off", "minimal", "low", "medium", "high"];
@@ -16,11 +15,7 @@ export abstract class AgentSessionModels extends AgentSessionPrompting {
   // Model Management
   // =========================================================================
 
-  private async emitModelSelect(
-    nextModel: Model,
-    previousModel: Model | undefined,
-    source: "set" | "cycle",
-  ): Promise<void> {
+  private async emitModelSelect(nextModel: Model, previousModel: Model | undefined): Promise<void> {
     if (modelsAreEqual(previousModel, nextModel)) {
       return;
     }
@@ -28,21 +23,17 @@ export abstract class AgentSessionModels extends AgentSessionPrompting {
       type: "model_select",
       model: nextModel,
       previousModel,
-      source,
+      source: "set",
     });
   }
 
-  private async applyModelSwitch(
-    model: Model,
-    thinkingLevel: ThinkingLevel,
-    source: "set" | "cycle",
-  ): Promise<void> {
+  private async applyModelSwitch(model: Model, thinkingLevel: ThinkingLevel): Promise<void> {
     const previousModel = this.model;
     this.agent.state.model = model;
     this.sessionManager.appendModelChange(model.provider, model.id);
     this.settingsManager.setDefaultModelAndProvider(model.provider, model.id);
     this.setThinkingLevel(thinkingLevel);
-    await this.emitModelSelect(model, previousModel, source);
+    await this.emitModelSelect(model, previousModel);
   }
 
   /**
@@ -56,84 +47,7 @@ export abstract class AgentSessionModels extends AgentSessionPrompting {
     }
 
     const thinkingLevel = this.getThinkingLevelForModelSwitch();
-    await this.applyModelSwitch(model, thinkingLevel, "set");
-  }
-
-  /**
-   * Cycle to next/previous model.
-   * Uses scoped models (from --models flag) if available, otherwise all available models.
-   * @param direction - "forward" (default) or "backward"
-   * @returns The new model info, or undefined if only one model available
-   */
-  async cycleModel(
-    direction: "forward" | "backward" = "forward",
-  ): Promise<ModelCycleResult | undefined> {
-    if (this.scopedModelEntries.length > 0) {
-      return this.cycleScopedModel(direction);
-    }
-    return this.cycleAvailableModel(direction);
-  }
-
-  private async cycleScopedModel(
-    direction: "forward" | "backward",
-  ): Promise<ModelCycleResult | undefined> {
-    const scopedModels = this.scopedModelEntries.filter((scoped) =>
-      this.sessionModelRegistry.hasConfiguredAuth(scoped.model),
-    );
-    if (scopedModels.length <= 1) {
-      return undefined;
-    }
-
-    const currentModel = this.model;
-    let currentIndex = scopedModels.findIndex((sm) => modelsAreEqual(sm.model, currentModel));
-
-    if (currentIndex === -1) {
-      currentIndex = 0;
-    }
-    const len = scopedModels.length;
-    const nextIndex =
-      direction === "forward" ? (currentIndex + 1) % len : (currentIndex - 1 + len) % len;
-    const next = scopedModels.at(nextIndex);
-    if (!next) {
-      throw new Error("Scoped model cycle produced an invalid index");
-    }
-    const thinkingLevel = this.getThinkingLevelForModelSwitch(next.thinkingLevel);
-
-    // Apply thinking level.
-    // - Explicit scoped model thinking level overrides current session level
-    // - Undefined scoped model thinking level inherits the current session preference
-    // setThinkingLevel clamps to model capabilities.
-    await this.applyModelSwitch(next.model, thinkingLevel, "cycle");
-
-    return { model: next.model, thinkingLevel: this.thinkingLevel, isScoped: true };
-  }
-
-  private async cycleAvailableModel(
-    direction: "forward" | "backward",
-  ): Promise<ModelCycleResult | undefined> {
-    const availableModels = this.sessionModelRegistry.getAvailable();
-    if (availableModels.length <= 1) {
-      return undefined;
-    }
-
-    const currentModel = this.model;
-    let currentIndex = availableModels.findIndex((m) => modelsAreEqual(m, currentModel));
-
-    if (currentIndex === -1) {
-      currentIndex = 0;
-    }
-    const len = availableModels.length;
-    const nextIndex =
-      direction === "forward" ? (currentIndex + 1) % len : (currentIndex - 1 + len) % len;
-    const nextModel = availableModels.at(nextIndex);
-    if (!nextModel) {
-      throw new Error("Available model cycle produced an invalid index");
-    }
-
-    const thinkingLevel = this.getThinkingLevelForModelSwitch();
-    await this.applyModelSwitch(nextModel, thinkingLevel, "cycle");
-
-    return { model: nextModel, thinkingLevel: this.thinkingLevel, isScoped: false };
+    await this.applyModelSwitch(model, thinkingLevel);
   }
 
   // =========================================================================
@@ -170,27 +84,6 @@ export abstract class AgentSessionModels extends AgentSessionPrompting {
   }
 
   /**
-   * Cycle to next thinking level.
-   * @returns New level, or undefined if model doesn't support thinking
-   */
-  cycleThinkingLevel(): ThinkingLevel | undefined {
-    if (!this.supportsThinking()) {
-      return undefined;
-    }
-
-    const levels = this.getAvailableThinkingLevels();
-    const currentIndex = levels.indexOf(this.thinkingLevel);
-    const nextIndex = (currentIndex + 1) % levels.length;
-    const nextLevel = levels.at(nextIndex);
-    if (!nextLevel) {
-      return undefined;
-    }
-
-    this.setThinkingLevel(nextLevel);
-    return nextLevel;
-  }
-
-  /**
    * Get available thinking levels for current model.
    * The provider will clamp to what the specific model supports internally.
    */
@@ -208,10 +101,7 @@ export abstract class AgentSessionModels extends AgentSessionPrompting {
     return Boolean(this.model?.reasoning);
   }
 
-  private getThinkingLevelForModelSwitch(explicitLevel?: ThinkingLevel): ThinkingLevel {
-    if (explicitLevel !== undefined) {
-      return explicitLevel;
-    }
+  private getThinkingLevelForModelSwitch(): ThinkingLevel {
     if (!this.supportsThinking()) {
       return this.settingsManager.getDefaultThinkingLevel() ?? DEFAULT_THINKING_LEVEL;
     }

--- a/src/agents/sessions/agent-session-types.ts
+++ b/src/agents/sessions/agent-session-types.ts
@@ -1,4 +1,4 @@
-import type { ImageContent, Model } from "../../llm/types.js";
+import type { ImageContent } from "../../llm/types.js";
 import type {
   Agent,
   AgentEvent,
@@ -66,8 +66,6 @@ export interface AgentSessionConfig {
   sessionManager: SessionManager;
   settingsManager: SettingsManager;
   cwd: string;
-  /** Models to cycle through with Ctrl+P. */
-  scopedModels?: Array<{ model: Model; thinkingLevel?: ThinkingLevel }>;
   /** Resource loader for skills, prompts, themes, context files, and system prompt. */
   resourceLoader: ResourceLoader;
   /** SDK custom tools registered outside extensions. */
@@ -115,12 +113,4 @@ export interface PromptOptions {
   preflightResult?: (success: boolean) => void;
   /** Internal identity for a current user turn that is already durable. */
   persistedUserIdempotencyKey?: string;
-}
-
-/** Result from cycling the active model. */
-export interface ModelCycleResult {
-  model: Model;
-  thinkingLevel: ThinkingLevel;
-  /** Whether the cycle used the scoped model list. */
-  isScoped: boolean;
 }

--- a/src/agents/sessions/sdk.ts
+++ b/src/agents/sessions/sdk.ts
@@ -61,8 +61,6 @@ export interface CreateAgentSessionOptions {
   model?: Model;
   /** Thinking level. Default: from settings, else 'medium' (clamped to model capabilities) */
   thinkingLevel?: ThinkingLevel;
-  /** Models available for cycling (Ctrl+P in interactive mode) */
-  scopedModels?: Array<{ model: Model; thinkingLevel?: ThinkingLevel }>;
 
   /**
    * Optional default tool suppression mode when no explicit allowlist is provided.
@@ -531,7 +529,6 @@ async function createAgentSessionImpl(
     sessionManager,
     settingsManager,
     cwd,
-    scopedModels: options.scopedModels,
     resourceLoader,
     customTools: options.customTools,
     modelRegistry,


### PR DESCRIPTION
## What Problem This Solves

Maintainer-requested cleanup of an unused session model-selection path. AgentSession still carries model/thinking cycling methods and scoped-model state that no current internal caller uses, increasing the amount of selection and settings logic maintainers must preserve.

## Why This Change Was Made

Remove that complete private layer: cycling methods, result type, state, and factory/config plumbing. The formatted patch removes 136 lines and 4,686 bytes. Direct setters retain their persistence, clamping, errors, async structure, and event ordering.

The class/factory was intentionally removed from the public SDK before the current stable contracts. The standalone scoped-model resolver, public `model_select` source union (`set | cycle | restore`), and keybinding compatibility names remain unchanged.

## User Impact

No intended user-visible behavior change. Existing model and thinking-level selection continues through the bound direct setters. This is accepted for maintainability; it does not claim a speedup or memory saving.

## Evidence

- Fresh managed P2 review: scoped-clean across all three evidence passes. The exact patch is unchanged after the source refresh to `7292689e7f78026060491fc94923cafdec48733f`; relevant context drift was inspected.
- Current local source validation: all 159 tests passed in five complete files (SDK 34, resolver 55, extension runner 20, next-turn 22, loop correctness 28), with exact report inventories and no skipped assertions. Formatting and diff checks passed. All 25 selected small guards passed. All 35 native child processes and monitors closed successfully; no install or benchmark rerun was needed.
- Broad core types, core test types, and changed-file type-aware lint remain assigned to exact-head hosted CI.
- Historical Linux measurement at `f35d894ba5351278ce88a328d8753e6f9057a446`: 24 controls in each B1/C1/C2/B2 phase, plus 576 measured lifecycles and 48 warmups, passed full raw/normalized parity through both real factories, extension binding, guarded setters, prompt, settlement, and disposal. Transport was synthetic, and restored history used an explicit model; this does not establish real provider cleanup or fallback selection.

The historical results were predominantly adverse: 22 of 24 paired warm metric means increased. Ordinary prompt time rose from 0.209904 to 0.231517 ms (+0.0216135 ms), with both orders worse: +5.80% and +14.83%. Ordinary construction, setter, and disposal timings also increased in both orders. Observed tree peak RSS rose 3.90% on average (+12.73% and -3.84% by order). All adverse results are retained, with no noise dismissal. The historical measured patch removed 130 lines; matching formatting accounts for the final 136-line reduction.

Current CI qualification: [run 34691516626, attempt 2](https://github.com/openclaw/openclaw/actions/runs/34691516626) passed at the unchanged head. The one authorized failed-jobs rerun used the same merge checkout as attempt 1; the original seven-file CLI group passed all 275 tests, including the rejected-update case in 1,247 ms. Its original 60-second timeout remains unexplained. A separate diagnostic baseline stopped at its unchanged 64-process bound after observing 65 processes, with no completed assertion report or rejected-child capture, so it is inconclusive. No source, timeout, assertion, or resource limit changed; this is not a claimed fix or proof of flakiness.
