### PR TITLE
refactor(tests): share dashboard runtime fixtures

### DIFF
--- a/src/commands/dashboard.links.test.ts
+++ b/src/commands/dashboard.links.test.ts
@@ -1,6 +1,7 @@
 // Dashboard link tests cover dashboard command URL resolution and config snapshot handling.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { dashboardCommand } from "./dashboard.js";
+import { createTestRuntime } from "./test-runtime-config-helpers.js";
 
 const readConfigFileSnapshotMock = vi.hoisted(() => vi.fn());
 const resolveGatewayPortMock = vi.hoisted(() => vi.fn());
@@ -47,11 +48,7 @@ vi.mock("../secrets/resolve.js", () => ({
   resolveSecretRefValues: resolveSecretRefValuesMock,
 }));
 
-const runtime = {
-  log: vi.fn(),
-  error: vi.fn(),
-  exit: vi.fn(),
-};
+const runtime = createTestRuntime();
 
 function resetRuntime() {
   runtime.log.mockClear();

--- a/src/commands/dashboard.test.ts
+++ b/src/commands/dashboard.test.ts
@@ -2,6 +2,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { GatewayBindMode } from "../config/types.gateway.js";
 import { dashboardCommand } from "./dashboard.js";
+import { createTestRuntime } from "./test-runtime-config-helpers.js";
 
 const mocks = vi.hoisted(() => ({
   readConfigFileSnapshot: vi.fn(),
@@ -48,11 +49,7 @@ vi.mock("./control-ui-handoff.js", async (importOriginal) => ({
   waitForControlUiDocument: mocks.waitForControlUiDocument,
 }));
 
-const runtime = {
-  log: vi.fn(),
-  error: vi.fn(),
-  exit: vi.fn(),
-};
+const runtime = createTestRuntime();
 
 type SnapshotParams = {
   token?: string;

--- a/src/commands/dashboard/json.test.ts
+++ b/src/commands/dashboard/json.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { dashboardCommand } from "../dashboard.js";
+import { createTestRuntime } from "../test-runtime-config-helpers.js";
 
 const mocks = vi.hoisted(() => ({
   copyToClipboard: vi.fn(),
@@ -52,9 +53,7 @@ const fakePassword = ["te", "st-password"].join("");
 const gatewayPasswordJsonKey = ["gateway", "Password"].join("");
 
 const runtime = {
-  error: vi.fn(),
-  exit: vi.fn(),
-  log: vi.fn(),
+  ...createTestRuntime(),
   writeJson: vi.fn(),
   writeStdout: vi.fn(),
 };


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

The Dashboard test suites each maintain their own copy of the same runtime fixture, making fixture changes unnecessarily repetitive.

## Why This Change Was Made

Reuse the existing typed `createTestRuntime` helper in all three suites. Preserve the JSON suite’s independent output writers, the distinct configuration inputs, and every existing assertion and cleanup step. The change adds 6 and removes 13 test lines; production code is unchanged.

## User Impact

No user-visible behavior change. All 36 existing Dashboard cases remain in place.

## Evidence

The three complete suites passed 36/36 on both the pristine base and the candidate, with identical case inventory and execution order. Targeted formatting and typed lint passed, followed by all 20 checks in the normal configured changed gate. Independent review found no actionable findings through P2.

These are existing synthetic test scenarios; no live Dashboard or UI verification is claimed.
