### PR TITLE
fix(config): preserve concurrent settings after Control UI autosave

### DIFF
--- a/test/vitest/vitest.ui-e2e.config.ts
+++ b/test/vitest/vitest.ui-e2e.config.ts
@@ -74,6 +74,7 @@ export const uiE2ePrivateServerTestFiles = [
   "ui/src/e2e/community-invite-showing.e2e.test.ts",
   "ui/src/e2e/composer-draft-store.e2e.test.ts",
   "ui/src/e2e/composer-recovery-fences.e2e.test.ts",
+  "ui/src/e2e/config-raw-save.e2e.test.ts",
   "ui/src/e2e/control-ui-shell-routing.e2e.test.ts",
   "ui/src/e2e/cron-duration-save.real-gateway.e2e.test.ts",
   "ui/src/e2e/cron-loading.e2e.test.ts",

--- a/ui/src/e2e/agent-config-save.e2e.test.ts
+++ b/ui/src/e2e/agent-config-save.e2e.test.ts
@@ -239,7 +239,7 @@ suite.define(() => {
     });
   });
 
-  it("stages skill changes from the inherited allowlist", async () => {
+  it("config.set stages skill changes from the inherited allowlist", async () => {
     await suite.withPage(createControlUiE2eContextOptions(), async ({ page }) => {
       const config = {
         agents: {
@@ -314,7 +314,10 @@ suite.define(() => {
         },
       });
       expect(params.baseHash).toBe("agent-config-hash-1");
-      await gateway.resolveDeferred("config.set", { hash: "agent-config-hash-2" });
+      await gateway.resolveDeferred("config.set", {
+        config: JSON.parse(String(params.raw)),
+        hash: "agent-config-hash-2",
+      });
     });
   });
 });

--- a/ui/src/e2e/cloud-workers-settings.e2e.test.ts
+++ b/ui/src/e2e/cloud-workers-settings.e2e.test.ts
@@ -595,7 +595,7 @@ suite.define(() => {
       replacePaths: ["cloudWorkers.profiles.pending.settings.setupEnv"],
     },
   ])(
-    "preserves Advanced edits after $name and deletes project defaults",
+    "config.set preserves Advanced edits after $name and deletes project defaults",
     async ({ replacement, description, replacePaths }) => {
       const context = await suite.browser.newContext({ locale: "en-US", serviceWorkers: "block" });
       const page = await context.newPage();
@@ -710,7 +710,11 @@ suite.define(() => {
           "config.get",
           configResponse(savedConfig, "cloud-workers-raw-saved"),
         );
-        await gateway.resolveDeferred("config.set", { ok: true, hash: "cloud-workers-raw-saved" });
+        await gateway.resolveDeferred("config.set", {
+          ok: true,
+          hash: "cloud-workers-raw-saved",
+          config: savedConfig,
+        });
         await expect.poll(() => rawSave.isDisabled()).toBe(true);
         expect(await gateway.getRequests("config.set")).toHaveLength(1);
         await page.reload();

--- a/ui/src/e2e/config-raw-save.e2e.test.ts
+++ b/ui/src/e2e/config-raw-save.e2e.test.ts
@@ -1,0 +1,54 @@
+import { expect, it } from "vitest";
+import { installMockGateway, startControlUiE2eServer } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+
+const suite = createControlUiE2eSuite({
+  name: "Control UI Raw save parser loading E2E",
+  startServer: () => startControlUiE2eServer(undefined, { source: true }),
+  startServerBeforeBrowser: true,
+});
+
+suite.define(() => {
+  it("config.set adopts Raw saves while the JSON5 parser is unavailable", async () => {
+    await suite.withPage({ serviceWorkers: "block" }, async ({ page }) => {
+      let parserRequests = 0;
+      await page.route(/\/json5(?:\.js|\/dist\/index\.mjs)/, async (route) => {
+        parserRequests += 1;
+        await route.abort();
+      });
+      const gateway = await installMockGateway(page, {
+        methodResponses: {
+          "config.get": {
+            config: { logging: { level: "info" } },
+            raw: '{"logging":{"level":"info"}}',
+            hash: "original",
+            valid: true,
+            issues: [],
+          },
+        },
+      });
+      await page.goto(`${suite.server.baseUrl}settings/advanced`);
+      await page.getByRole("button", { name: "Raw", exact: true }).click();
+      const raw = page.locator(".config-raw-field textarea");
+      const save = page.getByRole("button", { name: "Save", exact: true });
+      for (const [index, level] of ["debug", "warn"].entries()) {
+        const getsBeforeSave = (await gateway.getRequests("config.get")).length;
+        await raw.fill(`{ logging: { level: "${level}" } }`);
+        await save.click();
+        const request = await gateway.waitForRequest("config.set", { after: index });
+        expect(request.params).toMatchObject({
+          baseHash: index === 0 ? "original" : "mock-config-hash-1",
+        });
+        await expect
+          .poll(async () => (await gateway.getRequests("config.get")).length)
+          .toBeGreaterThan(getsBeforeSave);
+        await expect.poll(() => raw.isEnabled()).toBe(true);
+      }
+      await expect.poll(() => save.isEnabled()).toBe(false);
+      expect(parserRequests).toBeGreaterThan(0);
+      await page.reload();
+      await page.getByRole("button", { name: "Raw", exact: true }).click();
+      await expect.poll(() => raw.inputValue()).toContain('"warn"');
+    });
+  });
+});

--- a/ui/src/e2e/config-safe-write.e2e.test.ts
+++ b/ui/src/e2e/config-safe-write.e2e.test.ts
@@ -514,7 +514,7 @@ suite.define(() => {
     );
   });
 
-  it("refreshes config after reconnect and client replacement before the next save", async () => {
+  it("config.set refreshes config after reconnect and client replacement before the next save", async () => {
     await suite.withPage(
       {
         colorScheme: "dark",
@@ -601,7 +601,10 @@ suite.define(() => {
           tools: {},
         });
         expect(await gateway.getRequests("config.set")).toHaveLength(setsBeforeEdit + 1);
-        await gateway.resolveDeferred("config.set", { hash: "snapshot-saved" });
+        await gateway.resolveDeferred("config.set", {
+          config: JSON.parse(String(save.raw)),
+          hash: "snapshot-saved",
+        });
         await expect
           .poll(() => page.locator("openclaw-settings-save-indicator").textContent())
           .toContain("Saved");
@@ -610,7 +613,7 @@ suite.define(() => {
     );
   });
 
-  it("keeps a dirty draft and adopts an opaque revision after an unchanged reconnect", async () => {
+  it("config.set keeps a dirty draft and adopts an opaque revision after an unchanged reconnect", async () => {
     await suite.withPage(
       {
         colorScheme: "dark",
@@ -704,7 +707,10 @@ suite.define(() => {
             "hmac-sha256:v1:opaque-next",
           ),
         );
-        await gateway.resolveDeferred("config.set", { hash: "hmac-sha256:v1:opaque-next" });
+        await gateway.resolveDeferred("config.set", {
+          config: JSON.parse(String(save.raw)),
+          hash: "hmac-sha256:v1:opaque-next",
+        });
         await expect.poll(() => endpoint.inputValue()).toBe("retained-draft");
       },
     );

--- a/ui/src/e2e/memory-settings-engine.e2e.test.ts
+++ b/ui/src/e2e/memory-settings-engine.e2e.test.ts
@@ -53,7 +53,7 @@ const memoryPlugins = [
 ];
 
 suite.define(() => {
-  it("keeps the default engine first and drains Off before selecting it", async () => {
+  it("config.set keeps the default engine first and drains Off before selecting it", async () => {
     await suite.withPage(
       {
         colorScheme: "dark",
@@ -102,7 +102,11 @@ suite.define(() => {
               path: path.join(uiProofArtifactDir, "00-off-write-draining.png"),
             });
         }
-        await gateway.resolveDeferred("config.set", { ok: true, hash: "mock-config-hash-1" });
+        await gateway.resolveDeferred("config.set", {
+          ok: true,
+          hash: "mock-config-hash-1",
+          config: JSON.parse(String(pendingOffSave.params.raw)),
+        });
         const enableRequest = await gateway.waitForRequest("plugins.setEnabled");
         expect(enableRequest.params).toEqual({ pluginId: "memory-core", enabled: true });
 

--- a/ui/src/e2e/memory-settings-engine.e2e.test.ts
+++ b/ui/src/e2e/memory-settings-engine.e2e.test.ts
@@ -102,11 +102,7 @@ suite.define(() => {
               path: path.join(uiProofArtifactDir, "00-off-write-draining.png"),
             });
         }
-        await gateway.resolveDeferred("config.set", {
-          ok: true,
-          hash: "mock-config-hash-1",
-          config: JSON.parse(String(pendingOffSave.params.raw)),
-        });
+        await gateway.resolveDeferred("config.set");
         const enableRequest = await gateway.waitForRequest("plugins.setEnabled");
         expect(enableRequest.params).toEqual({ pluginId: "memory-core", enabled: true });
 

--- a/ui/src/e2e/plugins-config-mutation.e2e.test.ts
+++ b/ui/src/e2e/plugins-config-mutation.e2e.test.ts
@@ -67,7 +67,7 @@ const workboardEnabled = {
 };
 
 suite.define(() => {
-  it("drains a pending draft before re-enabling an accepted external plugin without review", async () => {
+  it("config.set drains a pending draft before re-enabling an accepted external plugin without review", async () => {
     await suite.withPage(
       {
         colorScheme: "dark",
@@ -136,7 +136,11 @@ suite.define(() => {
 
         const pendingDraft = await gateway.waitForRequest("config.set");
         expect(pendingDraft.params).toMatchObject({ baseHash: "config-hash-1" });
-        await gateway.resolveDeferred("config.set", { ok: true, hash: "config-hash-2" });
+        await gateway.resolveDeferred("config.set", {
+          ok: true,
+          hash: "config-hash-2",
+          config: JSON.parse(String(pendingDraft.params.raw)),
+        });
 
         const enableRequest = await gateway.waitForRequest("plugins.setEnabled");
         expect(enableRequest.params).toEqual({ pluginId: "workboard", enabled: true });

--- a/ui/src/e2e/plugins-config-mutation.e2e.test.ts
+++ b/ui/src/e2e/plugins-config-mutation.e2e.test.ts
@@ -136,11 +136,7 @@ suite.define(() => {
 
         const pendingDraft = await gateway.waitForRequest("config.set");
         expect(pendingDraft.params).toMatchObject({ baseHash: "config-hash-1" });
-        await gateway.resolveDeferred("config.set", {
-          ok: true,
-          hash: "config-hash-2",
-          config: JSON.parse(String(pendingDraft.params.raw)),
-        });
+        await gateway.resolveDeferred("config.set");
 
         const enableRequest = await gateway.waitForRequest("plugins.setEnabled");
         expect(enableRequest.params).toEqual({ pluginId: "workboard", enabled: true });

--- a/ui/src/features/github-connections/github-identity-controller.test.ts
+++ b/ui/src/features/github-connections/github-identity-controller.test.ts
@@ -236,7 +236,7 @@ describe("GitHubIdentityController", () => {
   it.each([
     { mode: "managed" as const, expectedProfileId: "ghp_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" },
     { mode: "inherit" as const, expectedProfileId: undefined },
-  ])("flushes a pending config draft before $mode and refreshes both edits", async (action) => {
+  ])("config.set drains drafts before $mode and refreshes both edits", async (action) => {
     vi.useFakeTimers();
     const order: string[] = [];
     let hashCounter = 1;
@@ -259,7 +259,7 @@ describe("GitHubIdentityController", () => {
       if (method === "config.set") {
         storedConfig = JSON.parse((params as { raw: string }).raw) as Record<string, unknown>;
         hashCounter += 1;
-        return { hash: `hash-${hashCounter}` };
+        return { config: storedConfig, hash: `hash-${hashCounter}` };
       }
       if (method === "secrets.store.set" || method === "secrets.store.delete") {
         return { ok: true };

--- a/ui/src/lib/config/config-draft-model.test.ts
+++ b/ui/src/lib/config/config-draft-model.test.ts
@@ -6,12 +6,123 @@ import {
   deferred,
   createGatewayHarness,
   createConfigServerMock,
+  createDeferredSetServerMock,
   createConfigCapabilityHarness,
 } from "./config-test-harness.ts";
 import { createRuntimeConfigCapability } from "./runtime-config-capability.ts";
 
 describe("config draft model", () => {
-  it("serializes schema-coerced form values with the draft base hash", async () => {
+  it.each(["revert", "delete"] as const)(
+    "config.set replays an in-flight %s while preserving canonical siblings",
+    async (edit) => {
+      vi.useFakeTimers();
+      const canonical = { count: 2, ui: { prefs: { locale: "fr" } } };
+      const { request, submissions, firstSet } = createDeferredSetServerMock(canonical);
+      const { runtimeConfig } = createConfigCapabilityHarness(
+        request as GatewayBrowserClient["request"],
+      );
+      await runtimeConfig.ensureLoaded();
+      runtimeConfig.patchForm(["count"], 2);
+      await vi.advanceTimersByTimeAsync(CONFIG_FORM_AUTO_SAVE_DEBOUNCE_MS);
+      if (edit === "revert") {
+        runtimeConfig.patchForm(["count"], 1);
+      } else {
+        runtimeConfig.removeFormValue(["count"]);
+      }
+      firstSet.resolve({});
+      await vi.advanceTimersByTimeAsync(CONFIG_FORM_AUTO_SAVE_DEBOUNCE_MS);
+
+      expect(submissions).toHaveLength(2);
+      expect(submissions[1]?.baseHash).toBe("hash-2");
+      expect(submissions.map(({ raw }) => JSON.parse(raw))).toEqual([
+        { count: 2 },
+        { ...(edit === "revert" ? { count: 1 } : {}), ui: canonical.ui },
+      ]);
+      expect(runtimeConfig.state.configFormDirty).toBe(false);
+      runtimeConfig.dispose();
+    },
+  );
+
+  it.each([
+    ["comments", "{\n  // Keep this note.\n  count: 2,\n}\n"],
+    ["semantic edit", "{ count: 3, /* keep spacing */ }\n"],
+  ])("config.set preserves an in-flight raw %s on its original base", async (_edit, raw) => {
+    vi.useFakeTimers();
+    const canonical = { count: 2, ui: { prefs: { locale: "fr" } } };
+    const { request, submissions, firstSet } = createDeferredSetServerMock(canonical);
+    const { runtimeConfig } = createConfigCapabilityHarness(
+      request as GatewayBrowserClient["request"],
+    );
+    await runtimeConfig.ensureLoaded();
+    runtimeConfig.patchForm(["count"], 2);
+    await vi.advanceTimersByTimeAsync(CONFIG_FORM_AUTO_SAVE_DEBOUNCE_MS);
+    runtimeConfig.setRaw(raw);
+    firstSet.resolve({});
+    await vi.advanceTimersByTimeAsync(CONFIG_FORM_AUTO_SAVE_DEBOUNCE_MS);
+
+    expect(runtimeConfig.state.configRaw).toBe(raw);
+    expect(runtimeConfig.state.configFormDirty).toBe(true);
+    expect(runtimeConfig.state.configDraftBaseHash).toBe("hash-1");
+    expect(runtimeConfig.state.configSnapshot).toMatchObject({ config: canonical, hash: "hash-2" });
+    expect(submissions).toHaveLength(1);
+    runtimeConfig.dispose();
+  });
+
+  it.each([
+    { edit: "replace", dispose: false },
+    { edit: "delete", dispose: false },
+    { edit: "replace", dispose: true },
+    { edit: "delete", dispose: true },
+  ])(
+    "config.set retains a redacted object's child $edit (dispose: $dispose)",
+    async ({ edit, dispose }) => {
+      vi.useFakeTimers();
+      const canonical = {
+        count: 1,
+        channels: { googlechat: { serviceAccount: "__OPENCLAW_REDACTED__" } },
+        ui: { prefs: { locale: "fr" } },
+      };
+      const { request, submissions, firstSet } = createDeferredSetServerMock(canonical);
+      const { runtimeConfig } = createConfigCapabilityHarness(
+        request as GatewayBrowserClient["request"],
+      );
+      await runtimeConfig.ensureLoaded();
+      const account = { project_id: "fixture-project", client_email: "before@example.invalid" };
+      const path = ["channels", "googlechat", "serviceAccount"];
+      runtimeConfig.patchForm(path, account);
+      await vi.advanceTimersByTimeAsync(CONFIG_FORM_AUTO_SAVE_DEBOUNCE_MS);
+      if (edit === "delete") {
+        runtimeConfig.removeFormValue([...path, "client_email"]);
+      } else {
+        runtimeConfig.patchForm([...path, "client_email"], "after@example.invalid");
+      }
+      if (dispose) {
+        runtimeConfig.dispose();
+      }
+      firstSet.resolve({});
+      await vi.advanceTimersByTimeAsync(CONFIG_FORM_AUTO_SAVE_DEBOUNCE_MS);
+
+      expect(submissions).toHaveLength(2);
+      expect(submissions[1]?.baseHash).toBe("hash-2");
+      expect(submissions.map(({ raw }) => JSON.parse(raw))).toEqual([
+        { count: 1, channels: { googlechat: { serviceAccount: account } } },
+        {
+          ...canonical,
+          channels: {
+            googlechat: {
+              serviceAccount: {
+                project_id: "fixture-project",
+                ...(edit === "replace" ? { client_email: "after@example.invalid" } : {}),
+              },
+            },
+          },
+        },
+      ]);
+      runtimeConfig.dispose();
+    },
+  );
+
+  it("config.set serializes schema-coerced form values with the draft base hash", async () => {
     const submitted: Array<{ method: string; params: unknown }> = [];
     let configGetCount = 0;
     const request = vi.fn(async (method: string, params?: unknown) => {
@@ -43,7 +154,7 @@ describe("config draft model", () => {
         };
       }
       submitted.push({ method, params });
-      return {};
+      return { config: JSON.parse((params as { raw: string }).raw), hash: "hash-2" };
     });
     const client = { request } as unknown as GatewayBrowserClient;
     const { gateway } = createGatewayHarness(client);
@@ -99,7 +210,7 @@ describe("config draft model", () => {
         };
       }
       submitted.push({ method, params });
-      return { hash: "hash-2" };
+      return { config: JSON.parse((params as { raw: string }).raw), hash: "hash-2" };
     });
     const client = { request } as unknown as GatewayBrowserClient;
     const { gateway } = createGatewayHarness(client);
@@ -116,7 +227,7 @@ describe("config draft model", () => {
     runtimeConfig.dispose();
   });
 
-  it("submits only decimal numeric spellings as numbers", async () => {
+  it("config.set submits only decimal numeric spellings as numbers", async () => {
     const submitted: Array<{ method: string; params: unknown }> = [];
     const request = vi.fn(async (method: string, params?: unknown) => {
       if (method === "config.get") {
@@ -162,7 +273,7 @@ describe("config draft model", () => {
         };
       }
       submitted.push({ method, params });
-      return { hash: "hash-2" };
+      return { config: JSON.parse((params as { raw: string }).raw), hash: "hash-2" };
     });
     const client = { request } as unknown as GatewayBrowserClient;
     const { gateway } = createGatewayHarness(client);
@@ -210,7 +321,7 @@ describe("config draft model", () => {
     runtimeConfig.dispose();
   });
 
-  it("preserves 64-bit id strings through the form submit roundtrip", async () => {
+  it("config.set preserves 64-bit id strings through the form submit roundtrip", async () => {
     const submitted: Array<{ method: string; params: unknown }> = [];
     const request = vi.fn(async (method: string, params?: unknown) => {
       if (method === "config.get") {
@@ -253,7 +364,7 @@ describe("config draft model", () => {
         };
       }
       submitted.push({ method, params });
-      return { hash: "hash-2" };
+      return { config: JSON.parse((params as { raw: string }).raw), hash: "hash-2" };
     });
     const client = { request } as unknown as GatewayBrowserClient;
     const { gateway } = createGatewayHarness(client);
@@ -279,7 +390,7 @@ describe("config draft model", () => {
     runtimeConfig.dispose();
   });
 
-  it("stages inherited agent overrides and the default through the public capability", async () => {
+  it("config.set stages inherited agent overrides and the default through the public capability", async () => {
     const submitted: Array<{ method: string; params: unknown }> = [];
     const request = vi.fn(async (method: string, params?: unknown) => {
       if (method === "config.get") {
@@ -298,7 +409,7 @@ describe("config draft model", () => {
         };
       }
       submitted.push({ method, params });
-      return { hash: "hash-2" };
+      return { config: JSON.parse((params as { raw: string }).raw), hash: "hash-2" };
     });
     const client = { request } as unknown as GatewayBrowserClient;
     const { gateway } = createGatewayHarness(client);

--- a/ui/src/lib/config/config-draft-model.ts
+++ b/ui/src/lib/config/config-draft-model.ts
@@ -358,10 +358,13 @@ export function adoptConfigSetAck(
   ack: ConfigWriteAck,
 ) {
   const currentRaw = serializeFormForSubmit(state);
-  const preserveRawDraft = state.configFormMode === "raw" && currentRaw !== submittedRaw;
-  const draft = preserveRawDraft
-    ? null
-    : replayConfigDraftEdits(submittedRaw, currentRaw, ack.config);
+  let draft: Record<string, unknown> | null = cloneConfigObject(ack.config);
+  if (currentRaw !== submittedRaw) {
+    draft =
+      state.configFormMode === "raw"
+        ? null
+        : replayConfigDraftEdits(submittedRaw, currentRaw, ack.config);
+  }
   const acknowledgedRaw = serializeConfigForm(ack.config);
   state.configSnapshot = {
     ...state.configSnapshot,

--- a/ui/src/lib/config/config-draft-model.ts
+++ b/ui/src/lib/config/config-draft-model.ts
@@ -316,43 +316,78 @@ export function serializeFormForSubmit(state: RuntimeConfigState): string {
   return serializeConfigForm(sanitized);
 }
 
-/**
- * Adopts a successful write ack as the authoritative local snapshot BEFORE
- * any reload: the submitted bytes are on disk under the acked hash, so the
- * raw/hash/originals must never keep describing the pre-save file (a failed
- * best-effort reload would otherwise leave stale-bytes paths alive — e.g.
- * apply re-submitting the old raw, or a revert-during-reload comparing
- * clean). Server-resolved values (secret redaction) still refresh via the
- * follow-up reload, which is purely cosmetic from here on.
- */
+export type ConfigWriteAck = { config: Record<string, unknown>; hash: string };
+
+export function replayConfigDraftEdits(
+  submittedRaw: string,
+  currentRaw: string,
+  acknowledgedConfig: Record<string, unknown>,
+): Record<string, unknown> | null {
+  const submitted = parseConfigRawDraft(submittedRaw);
+  const current = parseConfigRawDraft(currentRaw);
+  if (!submitted || !current) {
+    return null;
+  }
+  const draft = cloneConfigObject(acknowledgedConfig);
+  const replay = (
+    before: Record<string, unknown>,
+    after: Record<string, unknown>,
+    canonical: Record<string, unknown>,
+    path: string[],
+  ) => {
+    for (const key of new Set([...Object.keys(before), ...Object.keys(after)])) {
+      const nextPath = [...path, key];
+      if (!Object.hasOwn(after, key)) {
+        removePathValue(draft, nextPath);
+      } else if (isRecord(before[key]) && isRecord(after[key]) && isRecord(canonical[key])) {
+        replay(before[key], after[key], canonical[key], nextPath);
+      } else if (JSON.stringify(before[key]) !== JSON.stringify(after[key])) {
+        setPathValue(draft, nextPath, cloneConfigObject(after[key]));
+      }
+    }
+  };
+  replay(submitted, current, acknowledgedConfig, []);
+  return draft;
+}
+
+// The server owns the document belonging to this revision. Only edits made
+// after dispatch are replayed; a reload is not needed to repair the receipt.
 export function adoptConfigSetAck(
   state: RuntimeConfigState,
   submittedRaw: string,
-  ackHash: string,
+  ack: ConfigWriteAck,
 ) {
-  const parsed = parseConfigRawDraft(submittedRaw);
+  const currentRaw = serializeFormForSubmit(state);
+  const preserveRawDraft = state.configFormMode === "raw" && currentRaw !== submittedRaw;
+  const draft = preserveRawDraft
+    ? null
+    : replayConfigDraftEdits(submittedRaw, currentRaw, ack.config);
+  const acknowledgedRaw = serializeConfigForm(ack.config);
   state.configSnapshot = {
     ...state.configSnapshot,
-    raw: submittedRaw,
-    hash: ackHash,
+    raw: acknowledgedRaw,
+    hash: ack.hash,
     valid: true,
     issues: [],
-    ...(parsed ? { config: parsed, sourceConfig: parsed } : {}),
+    config: ack.config,
+    sourceConfig: ack.config,
   };
   state.configValid = true;
   state.configIssues = [];
-  setConfigRawOriginal(state, submittedRaw);
-  if (parsed) {
-    state.configFormOriginal = cloneConfigObject(parsed);
+  // Replaying raw text would discard comments and formatting. Keep that buffer
+  // and its old base so manual submission cannot overwrite unseen server edits.
+  if (!draft) {
+    state.configFormDirty = true;
+    return;
   }
-  state.configDraftBaseHash = ackHash;
+  setConfigRawOriginal(state, acknowledgedRaw);
+  state.configFormOriginal = cloneConfigObject(ack.config);
+  state.configDraftBaseHash = ack.hash;
+  state.configForm = draft;
+  state.configRaw = serializeConfigForm(draft);
+  state.configFormDirty = state.configRaw !== acknowledgedRaw;
   if (!state.configFormDirty) {
-    // Clean drafts snap to the persisted bytes, mirroring what a reload's
-    // non-preserving snapshot application would do.
-    state.configRaw = submittedRaw;
-    if (parsed) {
-      state.configForm = cloneConfigObject(parsed);
-    }
+    clearConfigDraftTracking(state);
   }
 }
 

--- a/ui/src/lib/config/config-draft-revision.test.ts
+++ b/ui/src/lib/config/config-draft-revision.test.ts
@@ -18,7 +18,7 @@ describe("config draft revision ownership", () => {
     { start: "raw", revert: "none", next: "form", saved: false },
     { start: "form", revert: "form", next: "form", saved: false },
   ] as const)(
-    "preserves external changes after $start editing, $revert revert and $next editing",
+    "config.set preserves external changes after $start editing, $revert revert and $next editing",
     async ({ start, revert, next, saved }) => {
       vi.useFakeTimers();
       let storedRaw = '{"count":1,"note":"original"}\n';
@@ -34,7 +34,7 @@ describe("config draft revision ownership", () => {
           }
           storedRaw = submission.raw;
           hash = "revision-saved";
-          return { hash };
+          return { config: JSON.parse(storedRaw), hash };
         }
         return {};
       });

--- a/ui/src/lib/config/config-gateway-operations.test.ts
+++ b/ui/src/lib/config/config-gateway-operations.test.ts
@@ -12,6 +12,51 @@ import {
 import { createRuntimeConfigCapability } from "./runtime-config-capability.ts";
 
 describe("config gateway operations", () => {
+  it.each(["config.set", "config.apply"] as const)(
+    "%s adopts the canonical receipt before saving an in-flight edit",
+    async (method) => {
+      vi.useFakeTimers();
+      const ack = deferred<unknown>();
+      const server = createConfigServerMock();
+      const canonical = { count: 2, ui: { prefs: { locale: "fr" } } };
+      let firstWrite = true;
+      const request = vi.fn(async (operation: string, params?: unknown) => {
+        if (operation === method && firstWrite) {
+          firstWrite = false;
+          await server.request(operation, params);
+          await ack.promise;
+          return { config: canonical, hash: "hash-2" };
+        }
+        if (operation === "config.get" && !firstWrite) {
+          return { config: canonical, hash: "hash-2", valid: true, issues: [] };
+        }
+        return server.request(operation, params);
+      });
+      const { runtimeConfig } = createConfigCapabilityHarness(
+        request as GatewayBrowserClient["request"],
+      );
+      await runtimeConfig.ensureLoaded();
+      runtimeConfig.patchForm(["count"], 2);
+      const applied = method === "config.apply" ? runtimeConfig.apply() : undefined;
+      await vi.advanceTimersByTimeAsync(CONFIG_FORM_AUTO_SAVE_DEBOUNCE_MS);
+      runtimeConfig.patchForm(["count"], 3);
+      ack.resolve({});
+      if (applied) {
+        await expect(applied).resolves.toBe(true);
+      }
+      await vi.advanceTimersByTimeAsync(CONFIG_FORM_AUTO_SAVE_DEBOUNCE_MS);
+
+      expect(server.submissions).toHaveLength(2);
+      expect(server.submissions[1]?.baseHash).toBe("hash-2");
+      expect(server.submissions.map(({ raw }) => JSON.parse(raw))).toEqual([
+        { count: 2 },
+        { ...canonical, count: 3 },
+      ]);
+      expect(runtimeConfig.state.configFormDirty).toBe(false);
+      runtimeConfig.dispose();
+    },
+  );
+
   it("copies the config path when opening the file fails", async () => {
     const writeText = vi.fn(async () => undefined);
     vi.stubGlobal("navigator", { clipboard: { writeText } } as unknown as Navigator);
@@ -80,7 +125,7 @@ describe("config gateway operations", () => {
     runtimeConfig.dispose();
   });
 
-  it("does not report Saved while edits made during the reload are still dirty", async () => {
+  it("config.set does not report Saved while edits made during the reload are still dirty", async () => {
     vi.useFakeTimers();
     let hashCounter = 1;
     let storedRaw = '{\n  "count": 1\n}\n';
@@ -104,7 +149,7 @@ describe("config gateway operations", () => {
       if (method === "config.set") {
         storedRaw = (params as { raw: string }).raw;
         hashCounter += 1;
-        return Promise.resolve({ hash: `hash-${hashCounter}` });
+        return Promise.resolve({ config: JSON.parse(storedRaw), hash: `hash-${hashCounter}` });
       }
       return Promise.resolve({});
     });
@@ -133,11 +178,11 @@ describe("config gateway operations", () => {
     runtimeConfig.dispose();
   });
 
-  it("keeps process-local needsApply when the post-save reload fails", async () => {
+  it("config.set keeps process-local needsApply when the post-save reload fails", async () => {
     vi.useFakeTimers();
     let failReloads = false;
     let hashCounter = 1;
-    const request = vi.fn(async (method: string) => {
+    const request = vi.fn(async (method: string, params?: unknown) => {
       if (method === "config.get") {
         if (failReloads) {
           throw new Error("gateway went away");
@@ -154,7 +199,7 @@ describe("config gateway operations", () => {
       }
       if (method === "config.set") {
         hashCounter += 1;
-        return { hash: `hash-${hashCounter}` };
+        return { config: JSON.parse((params as { raw: string }).raw), hash: `hash-${hashCounter}` };
       }
       return {};
     });
@@ -176,7 +221,7 @@ describe("config gateway operations", () => {
     second.runtimeConfig.dispose();
   });
 
-  it("keeps saving against the ack hash while reloads fail", async () => {
+  it("config.set keeps saving against the ack hash while reloads fail", async () => {
     vi.useFakeTimers();
     let failReloads = false;
     let hashCounter = 1;
@@ -198,7 +243,7 @@ describe("config gateway operations", () => {
         const { raw, baseHash } = params as { raw: string; baseHash: string };
         submissions.push({ raw, baseHash });
         hashCounter += 1;
-        return { hash: `hash-${hashCounter}` };
+        return { config: JSON.parse((params as { raw: string }).raw), hash: `hash-${hashCounter}` };
       }
       return {};
     });
@@ -221,7 +266,7 @@ describe("config gateway operations", () => {
     runtimeConfig.dispose();
   });
 
-  it("applies the acked bytes when the post-save reload failed", async () => {
+  it("config.set applies the acked bytes when the post-save reload failed", async () => {
     vi.useFakeTimers();
     let failReloads = false;
     let hashCounter = 1;
@@ -241,13 +286,13 @@ describe("config gateway operations", () => {
       }
       if (method === "config.set") {
         hashCounter += 1;
-        return { hash: `hash-${hashCounter}` };
+        return { config: JSON.parse((params as { raw: string }).raw), hash: `hash-${hashCounter}` };
       }
       if (method === "config.apply") {
         const { raw, baseHash } = params as { raw: string; baseHash: string };
         applySubmissions.push({ raw, baseHash });
         hashCounter += 1;
-        return { hash: `hash-${hashCounter}` };
+        return { config: JSON.parse((params as { raw: string }).raw), hash: `hash-${hashCounter}` };
       }
       return {};
     });
@@ -269,7 +314,7 @@ describe("config gateway operations", () => {
     runtimeConfig.dispose();
   });
 
-  it("saves a revert made after acknowledgement on the new base", async () => {
+  it("config.set saves a revert made after acknowledgement on the new base", async () => {
     vi.useFakeTimers();
     let hashCounter = 1;
     let storedRaw = '{\n  "count": 1\n}\n';
@@ -290,7 +335,7 @@ describe("config gateway operations", () => {
         submissions.push({ raw, baseHash });
         storedRaw = raw;
         hashCounter += 1;
-        return Promise.resolve({ hash: `hash-${hashCounter}` });
+        return Promise.resolve({ config: JSON.parse(storedRaw), hash: `hash-${hashCounter}` });
       }
       return Promise.resolve({});
     });

--- a/ui/src/lib/config/config-gateway-operations.ts
+++ b/ui/src/lib/config/config-gateway-operations.ts
@@ -10,9 +10,10 @@ import { showToast } from "../toast.ts";
 import {
   adoptConfigSetAck,
   applyConfigSnapshot,
-  clearConfigDraftTracking,
+  replayConfigDraftEdits,
   formatConfigMutationError,
   serializeFormForSubmit,
+  type ConfigWriteAck,
 } from "./config-draft-model.ts";
 import {
   beginConfigRead,
@@ -97,10 +98,9 @@ export type ConfigPatchBuilder = (
   config: Readonly<Record<string, unknown>>,
 ) => ConfigPatchBuildResult;
 // Gateway commitGatewayConfigWrite returns persisted hashes; only a no-op patch omits one.
-type ConfigPatchAck = { config: Record<string, unknown> } & (
-  | { noop: true }
-  | { noop?: false; hash: string }
-);
+type ConfigPatchAck =
+  | { noop: true; config: Record<string, unknown> }
+  | (ConfigWriteAck & { noop?: false });
 
 export type RuntimeConfigExternalMutationResult<T> =
   | {
@@ -362,7 +362,7 @@ function applyConfigSchema(state: RuntimeConfigState, res: ConfigSchemaResponse)
   state.configSchemaVersion = res.version ?? null;
 }
 
-export type ConfigSubmission = { raw: string; ackHash: string | null };
+export type ConfigSubmission = { raw: string; ack: ConfigWriteAck | null };
 export type ConfigSubmissionObserver = (submission: ConfigSubmission) => void;
 
 export async function submitConfigDraft(
@@ -414,22 +414,17 @@ export async function submitConfigDraft(
       state.chatError = null;
     }
     // Dispatch bytes let reconnect recognize a committed write whose ack was lost.
-    onSubmitted?.({ raw, ackHash: null });
-    const ack = await client.request<{ hash: string }>(
+    onSubmitted?.({ raw, ack: null });
+    const ack = await client.request<ConfigWriteAck>(
       mode === "apply" ? "config.apply" : "config.set",
       { raw, baseHash, ...(mode === "apply" ? { sessionKey: state.applySessionKey } : {}) },
     );
     // Report before the epoch fence: teardown can flush against this flight's ack.
-    onSubmitted?.({ raw, ackHash: ack.hash });
+    onSubmitted?.({ raw, ack });
     if (!isCurrent()) {
       return false;
     }
-    // Compare before adoption: edits and reverts made in flight retain their intent.
-    state.configFormDirty = serializeFormForSubmit(state) !== raw;
-    if (!state.configFormDirty) {
-      clearConfigDraftTracking(state);
-    }
-    adoptConfigSetAck(state, raw, ack.hash);
+    adoptConfigSetAck(state, raw, ack);
     state.configNeedsApply = mode !== "apply";
     if (mode === "apply") {
       state.configAutoSaveStatus = "idle";
@@ -465,13 +460,14 @@ export async function submitConfigDraft(
 
 /**
  * Teardown flush after an in-flight save: submits the latest draft once,
- * based only on that flight's own in-memory ack hash. Callers skip the flush
- * entirely (fail closed) when no in-memory ack hash exists.
+ * replaying edits on that flight's canonical acknowledgement. Callers skip
+ * the flush when no acknowledgement exists.
  */
 export function teardownFlushConfigDraft(
   state: RuntimeConfigState,
   client: GatewayBrowserClient,
-  baseHash: string,
+  submittedRaw: string,
+  ack: ConfigWriteAck,
   canDispatch: () => boolean,
 ): void {
   // Must stay synchronous: page unload destroys the context before any
@@ -482,8 +478,12 @@ export function teardownFlushConfigDraft(
   if (!canDispatch()) {
     return;
   }
-  const raw = serializeFormForSubmit(state);
-  void client.request("config.set", { raw, baseHash }).catch(() => undefined);
+  const draft = replayConfigDraftEdits(submittedRaw, serializeFormForSubmit(state), ack.config);
+  if (draft) {
+    void client
+      .request("config.set", { raw: serializeConfigForm(draft), baseHash: ack.hash })
+      .catch(() => undefined);
+  }
 }
 
 export async function patchConfig(

--- a/ui/src/lib/config/config-state-model.test.ts
+++ b/ui/src/lib/config/config-state-model.test.ts
@@ -188,7 +188,7 @@ describe("config state model", () => {
     runtimeConfig.dispose();
   });
 
-  it("preserves process-local needsApply after saving through an older Gateway", async () => {
+  it("config.set retains process-local needsApply without applied revision metadata", async () => {
     vi.useFakeTimers();
     const request = vi.fn(async (method: string) => {
       if (method === "config.get") {
@@ -200,7 +200,7 @@ describe("config state model", () => {
           issues: [],
         };
       }
-      return method === "config.set" ? { hash: "hash-2" } : {};
+      return method === "config.set" ? { config: { count: 2 }, hash: "hash-2" } : {};
     });
     const { runtimeConfig } = createConfigCapabilityHarness(
       request as GatewayBrowserClient["request"],

--- a/ui/src/lib/config/config-test-harness.ts
+++ b/ui/src/lib/config/config-test-harness.ts
@@ -88,7 +88,7 @@ export function createConfigServerMock() {
         appliedHash = `hash-${hashCounter}`;
       }
       // Like the real gateway: ack with the persisted snapshot hash.
-      return { hash: `hash-${hashCounter}` };
+      return { config: JSON.parse(storedRaw), hash: `hash-${hashCounter}` };
     }
     return {};
   });
@@ -99,7 +99,7 @@ export function createConfigServerMock() {
  * createConfigServerMock variant whose FIRST config.set stays pending until
  * `firstSet` resolves — for exercising mid-flight edits/reverts/teardown.
  */
-export function createDeferredSetServerMock() {
+export function createDeferredSetServerMock(firstAckConfig?: Record<string, unknown>) {
   const firstSet = deferred<unknown>();
   let hashCounter = 1;
   let storedRaw = '{\n  "count": 1\n}\n';
@@ -118,9 +118,9 @@ export function createDeferredSetServerMock() {
     if (method === "config.set") {
       const { raw, baseHash } = params as { raw: string; baseHash: string };
       submissions.push({ raw, baseHash });
-      storedRaw = raw;
+      storedRaw = submissions.length === 1 && firstAckConfig ? JSON.stringify(firstAckConfig) : raw;
       hashCounter += 1;
-      const ack = { hash: `hash-${hashCounter}` };
+      const ack = { config: JSON.parse(storedRaw), hash: `hash-${hashCounter}` };
       return submissions.length === 1 ? firstSet.promise.then(() => ack) : Promise.resolve(ack);
     }
     if (method === "config.apply") {
@@ -128,7 +128,7 @@ export function createDeferredSetServerMock() {
       applySubmissions.push({ raw, baseHash });
       storedRaw = raw;
       hashCounter += 1;
-      return Promise.resolve({ hash: `hash-${hashCounter}` });
+      return Promise.resolve({ config: JSON.parse(storedRaw), hash: `hash-${hashCounter}` });
     }
     return Promise.resolve({});
   });

--- a/ui/src/lib/config/config-write-coordinator.test.ts
+++ b/ui/src/lib/config/config-write-coordinator.test.ts
@@ -15,7 +15,7 @@ import {
 } from "./config-test-harness.ts";
 
 describe("config write coordinator", () => {
-  it("rebinds a retained draft to an opaque revision when the reconnect base is unchanged", async () => {
+  it("config.set rebinds a retained draft to an opaque revision when the reconnect base is unchanged", async () => {
     vi.useFakeTimers();
     let hash = "legacy-raw-hash";
     const raw = '{\n  "count": 1\n}\n';
@@ -26,7 +26,7 @@ describe("config write coordinator", () => {
       }
       if (method === "config.set") {
         submissions.push(params as { raw: string; baseHash: string });
-        return { hash: "opaque-next" };
+        return { config: JSON.parse((params as { raw: string }).raw), hash: "opaque-next" };
       }
       return {};
     });
@@ -50,7 +50,7 @@ describe("config write coordinator", () => {
     runtimeConfig.dispose();
   });
 
-  it("keeps the old revision and conflicts when the reconnect base changed", async () => {
+  it("config.set keeps the old revision and conflicts when the reconnect base changed", async () => {
     vi.useFakeTimers();
     let hash = "legacy-raw-hash";
     let raw = '{\n  "count": 1\n}\n';
@@ -65,7 +65,7 @@ describe("config write coordinator", () => {
         if (submission.baseHash !== hash) {
           throw new Error("config changed since last load; re-run config.get and retry");
         }
-        return { hash: "opaque-next" };
+        return { config: JSON.parse((params as { raw: string }).raw), hash: "opaque-next" };
       }
       return {};
     });
@@ -436,7 +436,7 @@ describe("config write coordinator", () => {
     runtimeConfig.dispose();
   });
 
-  it("flushes a scheduled autosave when a write barrier runs before the debounce", async () => {
+  it("config.set flushes a scheduled autosave when a write barrier runs before the debounce", async () => {
     vi.useFakeTimers();
     const setGate = deferred<unknown>();
     const methods: string[] = [];
@@ -472,14 +472,14 @@ describe("config write coordinator", () => {
     expect(methods.filter((method) => method === "config.set")).toHaveLength(1);
     expect(drained).toBe(false);
 
-    setGate.resolve({ hash: "hash-2" });
+    setGate.resolve({ config: { count: 2 }, hash: "hash-2" });
     await drain;
     expect(drained).toBe(true);
     expect(runtimeConfig.state.configSnapshot?.hash).toBe("hash-2");
     runtimeConfig.dispose();
   });
 
-  it("serializes external mutations after scheduled drafts and refreshes before resolving", async () => {
+  it("config.set serializes external mutations after scheduled drafts and refreshes before resolving", async () => {
     vi.useFakeTimers();
     const order: string[] = [];
     let storedConfig: Record<string, unknown> = { count: 1 };
@@ -499,7 +499,7 @@ describe("config write coordinator", () => {
         order.push("config.set");
         storedConfig = JSON.parse((params as { raw: string }).raw) as Record<string, unknown>;
         hash = "hash-2";
-        return { hash };
+        return { config: storedConfig, hash };
       }
       if (method === "plugins.setEnabled") {
         order.push("plugins.setEnabled");
@@ -531,7 +531,7 @@ describe("config write coordinator", () => {
     runtimeConfig.dispose();
   });
 
-  it("rechecks external mutation access after pending config writes settle", async () => {
+  it("config.set rechecks external mutation access after pending config writes settle", async () => {
     vi.useFakeTimers();
     const firstSet = deferred<unknown>();
     const methods: string[] = [];
@@ -568,7 +568,7 @@ describe("config write coordinator", () => {
     );
     await vi.waitFor(() => expect(methods).toEqual(["config.set"]));
     canDispatch = false;
-    firstSet.resolve({ hash: "hash-2" });
+    firstSet.resolve({ config: { count: 2 }, hash: "hash-2" });
 
     await expect(result).resolves.toEqual({
       ok: false,
@@ -792,7 +792,7 @@ describe("config write coordinator", () => {
     runtimeConfig.dispose();
   });
 
-  it("retries a background mutation when suspension begins during its write drain", async () => {
+  it("config.set retries a background mutation when suspension begins during its write drain", async () => {
     vi.useFakeTimers();
     const firstSet = deferred<unknown>();
     const methods: string[] = [];
@@ -825,7 +825,7 @@ describe("config write coordinator", () => {
       { waitForWritesResumed: true },
     );
     runtimeConfig.setWritesSuspended(true);
-    firstSet.resolve({ hash: "hash-2" });
+    firstSet.resolve({ config: { count: 2 }, hash: "hash-2" });
     await vi.advanceTimersByTimeAsync(0);
     expect(methods).toEqual(["config.set"]);
 
@@ -839,9 +839,12 @@ describe("config write coordinator", () => {
     runtimeConfig.dispose();
   });
 
-  it("flushes a pre-ack revert during disposal", async () => {
+  it("config.set flushes a pre-ack revert during disposal with canonical siblings", async () => {
     vi.useFakeTimers();
-    const { request, submissions, firstSet } = createDeferredSetServerMock();
+    const { request, submissions, firstSet } = createDeferredSetServerMock({
+      count: 2,
+      ui: { prefs: { locale: "fr" } },
+    });
     const { runtimeConfig } = createConfigCapabilityHarness(
       request as GatewayBrowserClient["request"],
     );
@@ -862,7 +865,11 @@ describe("config write coordinator", () => {
     await vi.advanceTimersByTimeAsync(0);
 
     expect(submissions).toHaveLength(2);
-    expect(submissions[1]).toEqual({ raw: '{\n  "count": 1\n}\n', baseHash: "hash-2" });
+    expect(submissions[1]?.baseHash).toBe("hash-2");
+    expect(submissions.map(({ raw }) => JSON.parse(raw))).toEqual([
+      { count: 2 },
+      { count: 1, ui: { prefs: { locale: "fr" } } },
+    ]);
   });
 
   it("does not write when an edit is reverted within the debounce window", async () => {
@@ -1070,7 +1077,7 @@ describe("config write coordinator", () => {
     ]);
   });
 
-  it("skips the teardown flush behind a pending apply", async () => {
+  it("config.apply skips the teardown flush behind a pending apply", async () => {
     vi.useFakeTimers();
     const firstApply = deferred<unknown>();
     let setCalls = 0;
@@ -1086,10 +1093,10 @@ describe("config write coordinator", () => {
       }
       if (method === "config.set") {
         setCalls += 1;
-        return Promise.resolve({ hash: "hash-9" });
+        return Promise.resolve({ config: { count: 3 }, hash: "hash-9" });
       }
       if (method === "config.apply") {
-        return firstApply.promise.then(() => ({ hash: "hash-2" }));
+        return firstApply.promise.then(() => ({ config: { count: 2 }, hash: "hash-2" }));
       }
       return Promise.resolve({});
     });

--- a/ui/src/lib/config/config-write-coordinator.ts
+++ b/ui/src/lib/config/config-write-coordinator.ts
@@ -194,7 +194,7 @@ export function createConfigWriteCoordinator({
     const submit = task((submission) => {
       flight.submission = submission;
       // Keep the ack for teardown, but only a live flight may retire older loads.
-      if (submission.ackHash && !isDisposed() && inFlight === flight) {
+      if (submission.ack && !isDisposed() && inFlight === flight) {
         invalidateConfigLoad();
       }
     });
@@ -621,7 +621,7 @@ export function createConfigWriteCoordinator({
                   state,
                   "save",
                   (submission) => {
-                    if (submission.ackHash === null) {
+                    if (submission.ack === null) {
                       patches.clear();
                     }
                     onSubmitted(submission);
@@ -788,17 +788,17 @@ export function createConfigWriteCoordinator({
           // The settled flight could not update dirty/base state past the
           // epoch guard; a draft whose bytes differ from that submission is a
           // newer edit and gets exactly one chained final save — never a
-          // parallel one. Applies and external mutations never register submission
-          // info: only this save's own ack is a safe CAS base for a final flush.
+          // parallel one. The save's canonical acknowledgement supplies both
+          // the document and revision for replaying that newer edit.
           const submitted = pendingFlight.submission;
-          const ackHash = submitted?.ackHash ?? null;
+          const ack = submitted?.ack ?? null;
           const submittedRaw = submitted?.raw ?? null;
           // Bytes-vs-submission is the only trustworthy signal here: the
           // epoch guard blocked the ack's rebase, so a revert back to the
           // pre-save value reads configFormDirty=false while the persisted
           // bytes are still the unreverted submission.
-          if (ackHash && submittedRaw !== null && serializeFormForSubmit(state) !== submittedRaw) {
-            teardownFlushConfigDraft(state, client, ackHash, () =>
+          if (ack && submittedRaw !== null && serializeFormForSubmit(state) !== submittedRaw) {
+            teardownFlushConfigDraft(state, client, submittedRaw, ack, () =>
               canCallConfigMethod("config.set"),
             );
           }

--- a/ui/src/lib/config/config-write-recovery.test.ts
+++ b/ui/src/lib/config/config-write-recovery.test.ts
@@ -58,7 +58,7 @@ function createRecoveryHarness(
     }
     storedRaw = submission.raw;
     hash = "explicit-save";
-    return { hash };
+    return { config: JSON.parse(storedRaw), hash };
   });
   const { runtimeConfig, publish } = createConfigCapabilityHarness(
     request as GatewayBrowserClient["request"],

--- a/ui/src/lib/config/runtime-config-capability.test.ts
+++ b/ui/src/lib/config/runtime-config-capability.test.ts
@@ -13,7 +13,7 @@ import {
 import { createRuntimeConfigCapability } from "./runtime-config-capability.ts";
 
 describe("runtime config capability", () => {
-  it("does not stage a default agent after access downgrades", async () => {
+  it("config.set does not stage a default agent after access downgrades", async () => {
     const request = vi.fn(async (method: string) => {
       if (method === "config.get") {
         return {
@@ -30,7 +30,7 @@ describe("runtime config capability", () => {
           issues: [],
         };
       }
-      return { hash: "hash-2" };
+      return {};
     });
     const client = { request } as unknown as GatewayBrowserClient;
     const { gateway, publish } = createGatewayHarness(client);
@@ -319,7 +319,7 @@ describe("runtime config capability", () => {
     runtimeConfig.dispose();
   });
 
-  it("discards an applied-hash poll superseded by a config write", async () => {
+  it("config.set discards an applied-hash poll superseded by a config write", async () => {
     vi.useFakeTimers();
     const stalePoll = deferred<ConfigSnapshot>();
     let getCount = 0;
@@ -339,7 +339,9 @@ describe("runtime config capability", () => {
           issues: [],
         });
       }
-      return Promise.resolve(method === "config.set" ? { hash: "hash-2" } : {});
+      return Promise.resolve(
+        method === "config.set" ? { config: { count: 2 }, hash: "hash-2" } : {},
+      );
     });
     const { runtimeConfig } = createConfigCapabilityHarness(
       request as GatewayBrowserClient["request"],
@@ -619,7 +621,7 @@ describe("runtime config capability", () => {
     runtimeConfig.dispose();
   });
 
-  it("reconciles an uncertain in-flight save without autosaving its trailing draft", async () => {
+  it("config.set reconciles an uncertain in-flight save without autosaving its trailing draft", async () => {
     vi.useFakeTimers();
     let committedRaw = '{\n  "count": 1\n}\n';
     let hash = "hash-1";
@@ -645,7 +647,7 @@ describe("runtime config capability", () => {
         }
         committedRaw = (params as { raw: string }).raw;
         hash = "hash-3";
-        return Promise.resolve({ hash });
+        return Promise.resolve({ config: JSON.parse(committedRaw), hash });
       }
       return Promise.resolve({});
     });
@@ -904,7 +906,7 @@ describe("runtime config capability", () => {
     runtimeConfig.dispose();
   });
 
-  it("recovers a manual save whose ack was lost to a disconnect", async () => {
+  it("config.set recovers a manual save whose ack was lost to a disconnect", async () => {
     vi.useFakeTimers();
     let committedRaw = '{\n  "count": 1\n}\n';
     let hash = "hash-1";
@@ -928,7 +930,7 @@ describe("runtime config capability", () => {
           return new Promise(() => {});
         }
         hash = "hash-3";
-        return Promise.resolve({ hash });
+        return Promise.resolve({ config: JSON.parse(committedRaw), hash });
       }
       return Promise.resolve({});
     });
@@ -958,7 +960,7 @@ describe("runtime config capability", () => {
     runtimeConfig.dispose();
   });
 
-  it("retries reconciliation on the next reconnect when the reload fails", async () => {
+  it("config.set retries reconciliation on the next reconnect when the reload fails", async () => {
     vi.useFakeTimers();
     let committedRaw = '{\n  "count": 1\n}\n';
     let hash = "hash-1";
@@ -986,7 +988,7 @@ describe("runtime config capability", () => {
           return new Promise(() => {});
         }
         hash = "hash-3";
-        return Promise.resolve({ hash });
+        return Promise.resolve({ config: JSON.parse(committedRaw), hash });
       }
       return Promise.resolve({});
     });

--- a/ui/src/lib/skills/index.test.ts
+++ b/ui/src/lib/skills/index.test.ts
@@ -898,7 +898,7 @@ describe("skill mutations", () => {
     },
   );
 
-  it("serializes skill changes after pending settings drafts and refreshes both owners", async () => {
+  it("config.set serializes skill changes after pending settings drafts and refreshes both owners", async () => {
     const { state, request } = createState();
     const methods: string[] = [];
     let storedConfig: Record<string, unknown> = { count: 1 };
@@ -917,7 +917,7 @@ describe("skill mutations", () => {
       if (method === "config.set") {
         storedConfig = JSON.parse((params as { raw: string }).raw) as Record<string, unknown>;
         hash = "hash-2";
-        return { hash };
+        return { config: storedConfig, hash };
       }
       if (method === "skills.update") {
         storedConfig = { ...storedConfig, skillEnabled: true };
@@ -952,7 +952,7 @@ describe("skill mutations", () => {
     }
   });
 
-  it("does not dispatch a queued skill update after access changes", async () => {
+  it("config.set does not dispatch a queued skill update after access changes", async () => {
     const { state, request } = createState();
     const firstSet = createDeferred<unknown>();
     const methods: string[] = [];
@@ -996,7 +996,7 @@ describe("skill mutations", () => {
       const mutation = updateSkillEnabled(state, "github", true, () => canDispatch);
       await waitForFast(() => expect(methods).toEqual(["config.set"]));
       canDispatch = false;
-      firstSet.resolve({ hash: "hash-2" });
+      firstSet.resolve({ config: { count: 2 }, hash: "hash-2" });
       await mutation;
 
       expect(methods).toEqual(["config.set"]);

--- a/ui/src/pages/agents/identity-actions.test.ts
+++ b/ui/src/pages/agents/identity-actions.test.ts
@@ -68,7 +68,7 @@ describe("agent identity actions", () => {
     expect(state.identityDraft.avatar).toBeNull();
   });
 
-  it("flushes a pending config draft before agents.update and refreshes afterward", async () => {
+  it("config.set flushes a pending config draft before agents.update and refreshes afterward", async () => {
     vi.useFakeTimers();
     const order: string[] = [];
     let config: Record<string, unknown> = { pending: false };
@@ -89,7 +89,7 @@ describe("agent identity actions", () => {
         order.push(method);
         config = JSON.parse((params as { raw: string }).raw) as Record<string, unknown>;
         hash = "hash-2";
-        return { hash };
+        return { config, hash };
       }
       if (method === "agents.update") {
         order.push(method);

--- a/ui/src/pages/config/meeting-capture.test.ts
+++ b/ui/src/pages/config/meeting-capture.test.ts
@@ -77,7 +77,7 @@ async function mount(
       };
     }
     if (method === "config.set") {
-      return { hash: "two" };
+      return { config: JSON.parse((_params as { raw: string }).raw), hash: "two" };
     }
     return {};
   };

--- a/ui/src/pages/model-setup/model-setup-page.test.ts
+++ b/ui/src/pages/model-setup/model-setup-page.test.ts
@@ -473,7 +473,7 @@ describe("ModelSetupPage catalog icons", () => {
     );
   });
 
-  it("flushes a pending config draft before activation review and refreshes afterward", async () => {
+  it("config.set flushes a pending config draft before activation review and refreshes afterward", async () => {
     vi.useFakeTimers();
     const { context, client, request, runtimeConfig } = createContext();
     const order: string[] = [];
@@ -495,7 +495,7 @@ describe("ModelSetupPage catalog icons", () => {
         order.push(method);
         config = JSON.parse((params as { raw: string }).raw) as Record<string, unknown>;
         hash = "hash-2";
-        return { hash };
+        return { config, hash };
       }
       if (method === "openclaw.setup.activate.start") {
         order.push(method);
@@ -543,7 +543,7 @@ describe("ModelSetupPage catalog icons", () => {
     runtimeConfig.dispose();
   });
 
-  it("owns the complete wizard action between draft flush and authoritative refresh", async () => {
+  it("config.set owns the complete wizard action between draft flush and authoritative refresh", async () => {
     const { context, client, request, runtimeConfig } = createContext();
     const order: string[] = [];
     let config: Record<string, unknown> = { pending: false };
@@ -563,7 +563,7 @@ describe("ModelSetupPage catalog icons", () => {
       if (method === "config.set") {
         config = JSON.parse((params as { raw: string }).raw) as Record<string, unknown>;
         hash = "hash-2";
-        return { hash };
+        return { config, hash };
       }
       if (method === "openclaw.setup.auth.start") {
         return { sessionId: "wizard-session", done: false, status: "running" };

--- a/ui/src/pages/plugins/plugins-page.test.ts
+++ b/ui/src/pages/plugins/plugins-page.test.ts
@@ -248,7 +248,7 @@ describe("PluginsPage", () => {
   });
 
   it.each(["install", "enable", "uninstall"] as const)(
-    "flushes a pending config draft before plugin %s and refreshes afterward",
+    "config.set flushes a pending config draft before plugin %s and refreshes afterward",
     async (action) => {
       vi.useFakeTimers();
       const method =
@@ -292,7 +292,7 @@ describe("PluginsPage", () => {
           order.push(requestMethod);
           config = JSON.parse((params as { raw: string }).raw) as Record<string, unknown>;
           hash = "hash-2";
-          return { hash };
+          return { config, hash };
         }
         if (requestMethod === method) {
           order.push(requestMethod);


### PR DESCRIPTION
Related: #145660, #145904.

## What Problem This Solves

Fixes an issue where a second Settings autosave could remove an unrelated configuration-file edit even though both saves succeeded. A concurrent French locale setting disappeared in the reproduced case.

## Why This Change Was Made

The UI adopts canonical configuration and revision together, then replays only form edits made while the save was pending. Disposal uses the same replay. Unchanged submissions adopt the acknowledgement directly, avoiding a dependency on lazy text parsing.

## User Impact

Autosave preserves concurrent settings and in-flight user edits. Newer raw drafts keep their content and stale-write protection. No configuration or protocol change.

Consumers: Settings Save, Apply and final capability saves consume complete configuration acknowledgements.

## Evidence

Real-browser and Gateway checks reproduced the lost locale, then retained it through both saves. Ordinary autosave and stale raw rejection passed. Two Raw saves with the parser blocked reproduced a self-conflict before the correction and succeeded afterward. The registered Raw Save regression and 92 focused configuration tests passed.
