### PR TITLE
perf(sessions): bound people facet ordering

### DIFF
--- a/src/gateway/session-identity-projection.ts
+++ b/src/gateway/session-identity-projection.ts
@@ -19,6 +19,7 @@ import { normalizeAgentId } from "../routing/session-key.js";
 import { looksLikeAvatarPath } from "../shared/avatar-policy.js";
 import { SESSIONS_LIST_OWNER_LIMIT } from "../shared/session-list-limits.js";
 import type { SessionOwnerFacetIdentity } from "../shared/session-types.js";
+import { sortAndLimitBy } from "../shared/sort-and-limit.js";
 import { resolveUserProfileReference } from "../state/user-profile-list.js";
 import { buildControlUiResourcePath } from "./control-ui-contract.js";
 import { normalizeControlUiBasePath } from "./control-ui-shared.js";
@@ -239,20 +240,23 @@ export function projectSessionPeopleFacet(
   people: Iterable<SessionPerson>,
   selectedProfileId?: string,
 ) {
-  const sortedPeople = [...people].toSorted(
-    (a, b) =>
-      b.sessionCount - a.sessionCount ||
-      (a.label ?? a.identity.id).localeCompare(b.label ?? b.identity.id) ||
-      a.identity.id.localeCompare(b.identity.id),
-  );
-  const visiblePeople = sortedPeople.slice(0, SESSIONS_LIST_OWNER_LIMIT);
+  const entries = [...people];
+  const compare = (a: SessionPerson, b: SessionPerson) =>
+    b.sessionCount - a.sessionCount ||
+    (a.label ?? a.identity.id).localeCompare(b.label ?? b.identity.id) ||
+    a.identity.id.localeCompare(b.identity.id);
+  const visiblePeople = sortAndLimitBy(entries, SESSIONS_LIST_OWNER_LIMIT, compare);
   const selected = selectedProfileId
-    ? sortedPeople.find((person) => person.identity.id === selectedProfileId)
+    ? sortAndLimitBy(
+        entries.filter((person) => person.identity.id === selectedProfileId),
+        1,
+        compare,
+      )[0]
     : undefined;
   if (selected && !visiblePeople.includes(selected)) {
     visiblePeople.splice(-1, 1, selected);
   }
-  return { people: visiblePeople, selected, overflow: sortedPeople.length > visiblePeople.length };
+  return { people: visiblePeople, selected, overflow: entries.length > visiblePeople.length };
 }
 
 export function addSessionOwnerFacetIdentity(


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

Large Activity/Sessions histories with many associated people spend unnecessary CPU preparing a people filter that displays at most 60 entries.

## Why This Change Was Made

Use the existing stable bounded sorter for the 60-person window. Keep the selected person visible even outside that window, including the comparator-best original object when duplicate selected IDs are supplied. Profile attribution, filtering and session counts retain their existing owners.

## User Impact

Large unordered people facets require less sorting work while preserving the displayed order, selected-person behavior and overflow indication. Small inputs and reverse ordering have measured costs, recorded below. Typical real-world profile counts and whole-page latency improvements have not been established.

## Evidence

- Current source at base `7292689e7f78026060491fc94923cafdec48733f`: all **13** tests in `src/gateway/session-utils-owners.test.ts` and all **7** tests in `src/shared/sort-and-limit.test.ts` passed on Darwin/Node 26.8.1. Exact file inventories were checked; none were skipped.
- Matching Oxfmt 0.66, `git diff --check`, and fresh managed Codex review through P2 passed. The one-file diff remains unchanged since review.
- The initial **25-guard local phase did not run**: it stopped before spawning a child at the unchanged 3 GiB entry floor (2,578,362,368 bytes free); that outcome is preserved. Subsequently, all **seven missing guards passed locally at this exact PR head**: changelog attribution, both wildcard-reexport guards, dependency pins, plugin boundary reporting with its failure gate, media-download helpers, and runtime-sidecar loaders. All seven native children and monitors closed successfully with source and installed dependencies unchanged. The remaining **18 selected small guards and all three broad type/type-aware lint lanes passed through their mapped hosted owners in [exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34692296198)**. These are new local results plus hosted coverage, not a claim that the original 25-guard phase ran. No guard, baseline, or resource limit was weakened.

Historical isolated Linux/Node 24.19.0 measurement at `32fc009394c2824515625bc635781adc1a9e62f9` used the actual facet owner, four fresh processes in baseline/candidate/candidate/baseline order, two warmup and seven measured batches per case, and 48,600 invocations including warmups. Full output/reference graphs and the one-shot iterable/duplicate-selected identity control matched. The source and dependency inputs pinned by this measurement remain unchanged; the author candidate differs from measured bytes only by a type-only import relocation.

Wall times below are median microseconds per call. CPU and process RSS changes show forward / reverse comparisons; both comparison orders and all adverse controls are retained.

| Input | Forward baseline → candidate (µs) | Reverse baseline → candidate (µs) | CPU change | RSS change |
| --- | ---: | ---: | ---: | ---: |
| Empty | 0.120 → 0.294 | 0.065 → 0.317 | +112.8% / +373.9% | +1.00% / -0.51% |
| 8 people, selected inside | 0.644 → 0.765 | 0.402 → 0.845 | +16.7% / +112.2% | +0.81% / -0.59% |
| 65 people, selected outside | 2.381 → 3.106 | 2.044 → 3.097 | +30.7% / +52.7% | +0.92% / -0.51% |
| 2,048 people, sorted | 44.689 → 41.667 | 45.046 → 42.344 | -7.3% / -5.7% | +0.65% / -0.58% |
| 2,048 people, reverse | 46.444 → 67.739 | 45.781 → 66.898 | +44.5% / +45.7% | +0.83% / -0.44% |
| 2,048 people, shuffled | 168.049 → 50.367 | 166.107 → 50.777 | -69.8% / -69.4% | +0.88% / -0.40% |
| 2,048 shuffled, selected inside | 164.136 → 68.061 | 165.377 → 67.374 | -58.3% / -59.1% | +1.07% / -0.47% |
| 2,048 shuffled, selected outside | 179.523 → 73.391 | 175.570 → 65.657 | -59.0% / -62.5% | +0.73% / -0.62% |
| 68 entries, duplicate selected ID | 2.139 → 3.073 | 2.178 → 4.752 | +43.7% / +117.7% | +0.73% / -0.52% |

People accumulate in first-session-encounter order while their session counts continue changing, so the producer does not guarantee rank-sorted input. The shuffled 2,048-person cases save roughly 96–118 µs per facet call; the reverse-ordered case costs about 21 µs. This bounds selection using the existing helper and adds four production lines.

RSS includes imports, fixtures and retained parity work, not exact per-call allocation. Native process high-water RSS was 349.5 → 352.0 MiB in the forward pair and 350.0 → 347.9 MiB in the reverse pair. These are scoped owner measurements, not live UI or current-platform performance results.
