### PR TITLE
fix: automation results block active chats during reply completion

### DIFF
--- a/src/cron/isolated-agent/current-session-completion.test.ts
+++ b/src/cron/isolated-agent/current-session-completion.test.ts
@@ -15,10 +15,8 @@ import {
   resolveManagedOutgoingMediaArtifactDownload,
 } from "../../gateway/managed-image-attachments.js";
 import { listManagedImageRecordEntries } from "../../gateway/managed-image-record-store.js";
-import {
-  beginSessionWorkAdmission,
-  getActiveSessionLifecycleMutationCount,
-} from "../../sessions/session-lifecycle-admission.js";
+import * as sessionLifecycleAdmission from "../../sessions/session-lifecycle-admission.js";
+import { beginSessionWorkAdmission } from "../../sessions/session-lifecycle-admission.js";
 import { onSessionTranscriptUpdate } from "../../sessions/transcript-events.js";
 import { readAssistantDisplayContent } from "../../shared/assistant-display-content.js";
 import { openOpenClawStateDatabase } from "../../state/openclaw-state-db.js";
@@ -360,9 +358,10 @@ describe("current-session completion media", () => {
         identities: [fixture.scope.sessionKey, fixture.scope.sessionId],
         assertAllowed: () => {},
       });
+      const releaseSpy = vi.spyOn(sessionLifecycleAdmission, "getSessionWorkAdmissionRelease");
       const commit = fixture.commit();
       try {
-        await vi.waitFor(() => expect(getActiveSessionLifecycleMutationCount()).toBe(1));
+        await vi.waitFor(() => expect(releaseSpy).toHaveBeenCalledOnce());
         expect(fixture.records()).toEqual([]);
         await replaceSessionEntry(fixture.scope, {
           sessionId: "replacement-session",
@@ -377,6 +376,7 @@ describe("current-session completion media", () => {
       } finally {
         admission.release();
         await commit;
+        releaseSpy.mockRestore();
         fixture.unsubscribe();
       }
     });

--- a/src/gateway/server-methods/chat-send-pending-inputs.test.ts
+++ b/src/gateway/server-methods/chat-send-pending-inputs.test.ts
@@ -29,7 +29,12 @@ import { SessionTranscriptProjectionUnavailableError } from "../../config/sessio
 import { rotateAgentEventLifecycleGeneration } from "../../infra/agent-events.js";
 import { initializeGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import type { PluginHookBeforeMessageWriteEvent } from "../../plugins/types.js";
-import { getSessionWorkAdmissionRelease } from "../../sessions/session-lifecycle-admission.js";
+import { commitBackgroundResultToSession } from "../../sessions/background-session-result.js";
+import * as sessionLifecycleAdmission from "../../sessions/session-lifecycle-admission.js";
+import {
+  beginSessionWorkAdmission,
+  getSessionWorkAdmissionRelease,
+} from "../../sessions/session-lifecycle-admission.js";
 import {
   createUserTurnTranscriptRecorder,
   type UserTurnTranscriptRecorder,
@@ -59,6 +64,7 @@ describe("ordinary browser input admission", () => {
       active?: boolean;
       preserveContent?: boolean;
       transientProjectionFailures?: number;
+      dispatchAfterRelease?: () => Promise<void>;
     } = {},
   ) {
     const active = options.active !== false;
@@ -133,6 +139,7 @@ describe("ordinary browser input admission", () => {
         throw new SessionTranscriptProjectionUnavailableError(scope.sessionId);
       }
       await dispatchRelease.promise;
+      await options.dispatchAfterRelease?.();
       return {};
     });
     const context = createDirectChatContext({ getRuntimeConfig, chatQueuedTurns: new Map() });
@@ -193,6 +200,107 @@ describe("ordinary browser input admission", () => {
       },
     };
   }
+
+  it("lets an acknowledged chat finish nested admission before committing its background result", async () => {
+    const nestedController = new AbortController();
+    const commitController = new AbortController();
+    let nestedFinished = false;
+    let commitSettled = false;
+    const fixture = await createBrowserFollowupFixture({
+      active: false,
+      dispatchAfterRelease: async () => {
+        // The real gateway dispatch still owns its outer source admission here.
+        // Reply execution needs this inner admission before that outer lease can settle.
+        const nested = await beginSessionWorkAdmission({
+          scope: fixture.scope.storePath,
+          identities: [fixture.scope.sessionKey, fixture.scope.sessionId],
+          assertAllowed: () => {},
+          signal: nestedController.signal,
+        });
+        try {
+          const recorder = await fixture.dispatchedRecorder;
+          await recorder.persistApproved();
+          nestedFinished = true;
+        } finally {
+          nested.release();
+        }
+      },
+    });
+    const drainSpy = vi.spyOn(sessionLifecycleAdmission, "getSessionWorkAdmissionRelease");
+    let commit: ReturnType<typeof commitBackgroundResultToSession> | undefined;
+    try {
+      const ack = await fixture.send();
+      expect(ack).toHaveBeenCalledWith(
+        true,
+        expect.objectContaining({ status: "started" }),
+        undefined,
+        expect.anything(),
+      );
+      await fixture.dispatchedRecorder;
+      const source = loadSessionEntry(fixture.scope);
+      expect(source?.sessionId).toBe(fixture.scope.sessionId);
+      drainSpy.mockClear();
+      commit = commitBackgroundResultToSession({
+        agentId: fixture.scope.agentId,
+        sessionKey: fixture.scope.sessionKey,
+        expectedGeneration: {
+          sessionId: fixture.scope.sessionId,
+          lifecycleRevision: source?.lifecycleRevision,
+        },
+        text: "The detached review is complete.",
+        idempotencyKey: "cron-current-completion:chat-admission-review",
+        provenance: { kind: "cron", jobId: "review", runId: "chat-admission-review" },
+        config: { session: { store: fixture.scope.storePath } },
+        signal: commitController.signal,
+      });
+      void commit.then(
+        () => {
+          commitSettled = true;
+        },
+        () => {
+          commitSettled = true;
+        },
+      );
+      // Observe the real source-drain request, rather than relying on a sleep to
+      // place completion between the outer gateway lease and its inner reply lease.
+      await vi.waitFor(() =>
+        expect(drainSpy).toHaveBeenCalledWith({
+          scope: fixture.scope.storePath,
+          identities: [fixture.scope.sessionKey, fixture.scope.sessionId],
+        }),
+      );
+      expect(commitSettled).toBe(false);
+      const dispatch = fixture.finishDispatch();
+      await vi.waitFor(() => expect(nestedFinished).toBe(true));
+      await dispatch;
+      await expect(commit).resolves.toMatchObject({ ok: true });
+      const transcript = loadTranscriptEventsSync(fixture.scope);
+      expect(transcript).toHaveLength(fixture.activeTranscript.length + 2);
+      expect(listSessionPendingInputs(fixture.scope)).toEqual({ items: [], total: 0 });
+      const results = transcript
+        .filter(isRecord)
+        .filter((event) => isRecord(event.message) && event.message.model === "automation-result");
+      expect(results).toHaveLength(1);
+      expect(results[0]?.message).toMatchObject({
+        content: [{ type: "text", text: "The detached review is complete." }],
+        openclawAutomation: { kind: "cron", jobId: "review", runId: "chat-admission-review" },
+      });
+      expect(
+        getSessionWorkAdmissionRelease({
+          scope: fixture.scope.storePath,
+          identities: [fixture.scope.sessionKey, fixture.scope.sessionId],
+        }),
+      ).toBeUndefined();
+    } finally {
+      // Also break the pre-fix ownership cycle on assertion failure, so this
+      // regression can be red-run without leaving shared Gateway admission state.
+      commitController.abort();
+      nestedController.abort();
+      await fixture.cleanup();
+      await commit?.catch(() => undefined);
+      drainSpy.mockRestore();
+    }
+  });
 
   async function createMentionFixture(
     options: { active?: boolean; preserveContent?: boolean } = {},

--- a/src/sessions/background-session-result.test.ts
+++ b/src/sessions/background-session-result.test.ts
@@ -8,6 +8,7 @@ import { callGatewayHandler } from "../gateway/server-methods/skills.test-helper
 import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.js";
 import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import { commitBackgroundResultToSession } from "./background-session-result.js";
+import * as sessionLifecycleAdmission from "./session-lifecycle-admission.js";
 import {
   beginSessionWorkAdmission,
   getActiveSessionLifecycleMutationCount,
@@ -48,6 +49,9 @@ describe("commitBackgroundResultToSession", () => {
       assertAllowed: () => {},
     });
     let commitSettled = false;
+    const controller = new AbortController();
+    const releaseSpy = vi.spyOn(sessionLifecycleAdmission, "getSessionWorkAdmissionRelease");
+    let laterAdmission: ReturnType<typeof beginSessionWorkAdmission> | undefined;
     const updates: unknown[] = [];
     const unsubscribe = onSessionTranscriptUpdate((update) => updates.push(update));
     const commit = commitBackgroundResultToSession({
@@ -58,76 +62,99 @@ describe("commitBackgroundResultToSession", () => {
       idempotencyKey: "cron-current-completion:cron:job-1:1000",
       provenance: { kind: "cron", jobId: "job-1", runId: "cron:job-1:1000" },
       config: target.config,
+      signal: controller.signal,
     });
-    void commit.then(() => {
-      commitSettled = true;
-    });
+    void commit.then(
+      () => {
+        commitSettled = true;
+      },
+      () => {
+        commitSettled = true;
+      },
+    );
 
-    await vi.waitFor(() => expect(getActiveSessionLifecycleMutationCount()).toBe(1));
-    expect(commitSettled).toBe(false);
-    let laterAdmissionSettled = false;
-    const laterAdmission = beginSessionWorkAdmission({
-      scope: target.storePath,
-      identities: [target.sessionKey, target.sessionId],
-      assertAllowed: () => {},
-    });
-    void laterAdmission.then(() => {
-      laterAdmissionSettled = true;
-    });
-    await Promise.resolve();
-    expect(laterAdmissionSettled).toBe(false);
-    admission.release();
+    try {
+      await vi.waitFor(() => expect(releaseSpy).toHaveBeenCalledOnce());
+      expect(commitSettled).toBe(false);
+      let laterAdmissionSettled = false;
+      laterAdmission = beginSessionWorkAdmission({
+        scope: target.storePath,
+        identities: [target.sessionKey, target.sessionId],
+        assertAllowed: () => {},
+        signal: controller.signal,
+      });
+      void laterAdmission.then(
+        () => {
+          laterAdmissionSettled = true;
+        },
+        () => {},
+      );
+      await vi.waitFor(() => expect(laterAdmissionSettled).toBe(true));
+      expect(commitSettled).toBe(false);
+      admission.release();
+      await vi.waitFor(() => expect(releaseSpy).toHaveBeenCalledTimes(2));
+      expect(commitSettled).toBe(false);
+      (await laterAdmission).release();
 
-    const first = await commit;
-    expect(first).toMatchObject({ ok: true });
-    (await laterAdmission).release();
-    const retry = await commitBackgroundResultToSession({
-      agentId: "main",
-      sessionKey: target.sessionKey,
-      expectedGeneration: target.generation,
-      text: "Automation finished while the chat was active.",
-      idempotencyKey: "cron-current-completion:cron:job-1:1000",
-      provenance: { kind: "cron", jobId: "job-1", runId: "cron:job-1:1000" },
-      config: target.config,
-    });
-    expect(retry).toEqual(first);
-    await expect(
-      commitBackgroundResultToSession({
+      const first = await commit;
+      expect(first).toMatchObject({ ok: true });
+      const retry = await commitBackgroundResultToSession({
         agentId: "main",
         sessionKey: target.sessionKey,
         expectedGeneration: target.generation,
-        text: "A different completion must not reuse the committed run.",
+        text: "Automation finished while the chat was active.",
         idempotencyKey: "cron-current-completion:cron:job-1:1000",
         provenance: { kind: "cron", jobId: "job-1", runId: "cron:job-1:1000" },
         config: target.config,
-      }),
-    ).rejects.toThrow("conflicts with the admitted message");
-
-    const events = await loadTranscriptEvents({
-      agentId: "main",
-      sessionId: target.sessionId,
-      sessionKey: target.sessionKey,
-      storePath: target.storePath,
-    });
-    expect(events).toEqual([
-      expect.objectContaining({ type: "session" }),
-      expect.objectContaining({
-        type: "message",
-        message: expect.objectContaining({
-          api: "openclaw-transcript",
+      });
+      expect(retry).toEqual(first);
+      await expect(
+        commitBackgroundResultToSession({
+          agentId: "main",
+          sessionKey: target.sessionKey,
+          expectedGeneration: target.generation,
+          text: "A different completion must not reuse the committed run.",
           idempotencyKey: "cron-current-completion:cron:job-1:1000",
-          model: "automation-result",
-          openclawAutomation: { kind: "cron", jobId: "job-1", runId: "cron:job-1:1000" },
-          provider: "openclaw",
-          role: "assistant",
-          stopReason: "stop",
-          content: [{ type: "text", text: "Automation finished while the chat was active." }],
-          usage: expect.objectContaining({ input: 0, output: 0, totalTokens: 0 }),
+          provenance: { kind: "cron", jobId: "job-1", runId: "cron:job-1:1000" },
+          config: target.config,
         }),
-      }),
-    ]);
-    expect(updates).toHaveLength(1);
-    unsubscribe();
+      ).rejects.toThrow("conflicts with the admitted message");
+
+      const events = await loadTranscriptEvents({
+        agentId: "main",
+        sessionId: target.sessionId,
+        sessionKey: target.sessionKey,
+        storePath: target.storePath,
+      });
+      expect(events).toEqual([
+        expect.objectContaining({ type: "session" }),
+        expect.objectContaining({
+          type: "message",
+          message: expect.objectContaining({
+            api: "openclaw-transcript",
+            idempotencyKey: "cron-current-completion:cron:job-1:1000",
+            model: "automation-result",
+            openclawAutomation: { kind: "cron", jobId: "job-1", runId: "cron:job-1:1000" },
+            provider: "openclaw",
+            role: "assistant",
+            stopReason: "stop",
+            content: [{ type: "text", text: "Automation finished while the chat was active." }],
+            usage: expect.objectContaining({ input: 0, output: 0, totalTokens: 0 }),
+          }),
+        }),
+      ]);
+      expect(updates).toHaveLength(1);
+    } finally {
+      controller.abort();
+      admission.release();
+      await laterAdmission?.then(
+        (lease) => lease.release(),
+        () => {},
+      );
+      await commit.catch(() => {});
+      releaseSpy.mockRestore();
+      unsubscribe();
+    }
   });
 
   it("cancels a background completion's pure wait without waiting for old work release", async () => {
@@ -175,7 +202,6 @@ describe("commitBackgroundResultToSession", () => {
           ),
         );
         await vi.waitFor(() => expect(releaseSpy).toHaveBeenCalledOnce());
-        expect(getActiveSessionLifecycleMutationCount()).toBe(1);
         expect(prepareDisplayContent).not.toHaveBeenCalled();
         pending.push(
           admission.run(async () => {

--- a/src/sessions/background-session-result.ts
+++ b/src/sessions/background-session-result.ts
@@ -73,115 +73,131 @@ export async function commitBackgroundResultToSession(params: {
   );
   const identities = [sessionKey, expectedSessionId];
 
-  return await runExclusiveSessionLifecycleMutation({
-    scope: storePath,
-    identities,
-    signal: params.signal,
-    prepare: async () => {
-      const released = getSessionWorkAdmissionRelease({ scope: storePath, identities });
-      if (released) {
-        await racePromiseWithAbortSignal(released, params.signal);
-      }
-    },
-    run: async () => {
-      const current = loadSessionEntryReadOnly({
-        agentId: params.agentId,
-        sessionKey,
-        storePath,
-        readConsistency: "latest",
-      });
-      if (
-        current?.sessionId !== expectedSessionId ||
-        normalizeOptionalString(current.lifecycleRevision) !== expectedLifecycleRevision
-      ) {
-        return { ok: false, reason: `session rebound for sessionKey: ${sessionKey}` };
-      }
-      const unavailable = resolveSessionWorkStartError(sessionKey, current, {
-        expectedSessionId,
-      });
-      if (unavailable) {
-        return { ok: false, reason: unavailable };
-      }
-      const scope = {
-        agentId: params.agentId,
-        sessionKey,
-        sessionId: expectedSessionId,
-        storePath,
-      };
-      // A retry owns the original committed payload, including its managed-media IDs.
-      // Restaging media would conflict with the transcript's exact replay contract.
-      const prior = await findTranscriptEvent(
-        scope,
-        (event) => readTranscriptEventMessage(event)?.idempotencyKey === idempotencyKey,
-      );
-      const priorMessage = prior && readTranscriptEventMessage(prior.event);
-      const priorId = prior && readTranscriptEventId(prior.event);
-      if (prior && (!priorMessage || !priorId)) {
-        return { ok: false, reason: "background result transcript identity is unavailable" };
-      }
-      const displayContent = priorMessage
-        ? undefined
-        : (await params.prepareDisplayContent?.())?.map((block) => Object.assign({}, block));
-      const message = {
-        role: "assistant",
-        content: [{ type: "text", text }],
-        ...(displayContent ? { [ASSISTANT_DISPLAY_CONTENT_FIELD]: displayContent } : {}),
-        api: OPENCLAW_TRANSCRIPT_ARTIFACT_API,
-        provider: OPENCLAW_TRANSCRIPT_ARTIFACT_PROVIDER,
-        model: AUTOMATION_RESULT_MODEL,
-        usage: {
-          input: 0,
-          output: 0,
-          cacheRead: 0,
-          cacheWrite: 0,
-          totalTokens: 0,
-          cost: {
+  while (true) {
+    const attempt = await runExclusiveSessionLifecycleMutation<
+      BackgroundSessionResultCommit | { waitingFor: Promise<void> }
+    >({
+      scope: storePath,
+      identities,
+      signal: params.signal,
+      run: async () => {
+        params.signal?.throwIfAborted();
+        const waitingFor = getSessionWorkAdmissionRelease({ scope: storePath, identities });
+        if (waitingFor) {
+          // An admitted reply may need another admission before it can release.
+          // Drop the mutation fence before waiting so that work can finish.
+          return { waitingFor };
+        }
+        const current = loadSessionEntryReadOnly({
+          agentId: params.agentId,
+          sessionKey,
+          storePath,
+          readConsistency: "latest",
+        });
+        if (
+          current?.sessionId !== expectedSessionId ||
+          normalizeOptionalString(current.lifecycleRevision) !== expectedLifecycleRevision
+        ) {
+          return { ok: false, reason: `session rebound for sessionKey: ${sessionKey}` };
+        }
+        const unavailable = resolveSessionWorkStartError(sessionKey, current, {
+          expectedSessionId,
+        });
+        if (unavailable) {
+          return { ok: false, reason: unavailable };
+        }
+        const scope = {
+          agentId: params.agentId,
+          sessionKey,
+          sessionId: expectedSessionId,
+          storePath,
+        };
+        // A retry owns the original committed payload, including its managed-media IDs.
+        // Restaging media would conflict with the transcript's exact replay contract.
+        const prior = await findTranscriptEvent(
+          scope,
+          (event) => readTranscriptEventMessage(event)?.idempotencyKey === idempotencyKey,
+        );
+        const priorMessage = prior && readTranscriptEventMessage(prior.event);
+        const priorId = prior && readTranscriptEventId(prior.event);
+        if (prior && (!priorMessage || !priorId)) {
+          return { ok: false, reason: "background result transcript identity is unavailable" };
+        }
+        const displayContent = priorMessage
+          ? undefined
+          : (await params.prepareDisplayContent?.())?.map((block) => Object.assign({}, block));
+        const message = {
+          role: "assistant",
+          content: [{ type: "text", text }],
+          ...(displayContent ? { [ASSISTANT_DISPLAY_CONTENT_FIELD]: displayContent } : {}),
+          api: OPENCLAW_TRANSCRIPT_ARTIFACT_API,
+          provider: OPENCLAW_TRANSCRIPT_ARTIFACT_PROVIDER,
+          model: AUTOMATION_RESULT_MODEL,
+          usage: {
             input: 0,
             output: 0,
             cacheRead: 0,
             cacheWrite: 0,
-            total: 0,
-          },
-        },
-        stopReason: "stop",
-        timestamp: Date.now(),
-        idempotencyKey,
-        openclawAutomation: params.provenance,
-      } satisfies SessionTranscriptAssistantMessage & {
-        idempotencyKey: string;
-        openclawAutomation: BackgroundSessionResultProvenance;
-      };
-      const committed = await persistSessionTranscriptTurn(scope, {
-        cwd: current.spawnedCwd,
-        expectedSessionId,
-        expectedLifecycleRevision: expectedLifecycleRevision ?? null,
-        messages: [
-          {
-            message: priorMessage
-              ? { ...priorMessage, content: message.content, openclawAutomation: params.provenance }
-              : message,
-            idempotencyLookup: "scan",
-            ...(priorId ? { eventId: priorId } : {}),
-            shouldAppendInTransaction: () => {
-              params.signal?.throwIfAborted();
-              if (priorId && !readActiveTranscriptEntryAnchor({ ...scope, entryId: priorId })) {
-                throw new Error("background result no longer owns the active transcript");
-              }
-              return true;
+            totalTokens: 0,
+            cost: {
+              input: 0,
+              output: 0,
+              cacheRead: 0,
+              cacheWrite: 0,
+              total: 0,
             },
           },
-        ],
-        touchSessionEntry: true,
-        updateMode: "inline",
-        // A retry can finish media ownership after a committed append failed to publish.
-        publishWhen: params.prepareDisplayContent ? "always" : undefined,
-        config: params.config,
-        onMessageCommitted: params.onMessageCommitted,
-      });
-      const appended = committed.messages[0];
-      return appended
-        ? { ok: true, messageId: appended.messageId }
-        : { ok: false, reason: committed.rejectedReason ?? "background result was not committed" };
-    },
-  });
+          stopReason: "stop",
+          timestamp: Date.now(),
+          idempotencyKey,
+          openclawAutomation: params.provenance,
+        } satisfies SessionTranscriptAssistantMessage & {
+          idempotencyKey: string;
+          openclawAutomation: BackgroundSessionResultProvenance;
+        };
+        const committed = await persistSessionTranscriptTurn(scope, {
+          cwd: current.spawnedCwd,
+          expectedSessionId,
+          expectedLifecycleRevision: expectedLifecycleRevision ?? null,
+          messages: [
+            {
+              message: priorMessage
+                ? {
+                    ...priorMessage,
+                    content: message.content,
+                    openclawAutomation: params.provenance,
+                  }
+                : message,
+              idempotencyLookup: "scan",
+              ...(priorId ? { eventId: priorId } : {}),
+              shouldAppendInTransaction: () => {
+                params.signal?.throwIfAborted();
+                if (priorId && !readActiveTranscriptEntryAnchor({ ...scope, entryId: priorId })) {
+                  throw new Error("background result no longer owns the active transcript");
+                }
+                return true;
+              },
+            },
+          ],
+          touchSessionEntry: true,
+          updateMode: "inline",
+          // A retry can finish media ownership after a committed append failed to publish.
+          publishWhen: params.prepareDisplayContent ? "always" : undefined,
+          config: params.config,
+          onMessageCommitted: params.onMessageCommitted,
+        });
+        const appended = committed.messages[0];
+        return appended
+          ? { ok: true, messageId: appended.messageId }
+          : {
+              ok: false,
+              reason: committed.rejectedReason ?? "background result was not committed",
+            };
+      },
+    });
+    if (!("waitingFor" in attempt)) {
+      return attempt;
+    }
+    await racePromiseWithAbortSignal(attempt.waitingFor, params.signal);
+  }
 }


### PR DESCRIPTION
Related: #143624. Follow-up to #143832; distinct from the timeout/cancellation coverage in #143727.

## What Problem This Solves

Fixes an issue where users waiting for an automation result in an active chat would see neither the result nor their ongoing chat finish when reply execution needs a nested admission to that same conversation. The completed automation can remain active while waiting for delivery, which can also defer heartbeat.

## Why This Change Was Made

Wait for existing source work outside the exclusive lifecycle mutation, then reacquire the mutation and recheck source admissions before validating the conversation generation and appending. This breaks the circular wait without changing the generic lifecycle owner or cancelling legitimate source work.

This builds on current main's cancellation fix rather than reverting it: abort-aware waits, the transaction-time cancellation guard, generation checks, exact-payload idempotency, and managed-media retry ownership remain intact. This does not introduce a delivery deadline, scheduler policy, schema change, or a guarantee of progress while a conversation remains perpetually busy.

## User Impact

An already-acknowledged chat can complete its reply while a detached result waits; once the source work is idle, the saved result can appear in the same conversation exactly once. Cancellation and reset still prevent a stale result from being written into the wrong conversation generation.

## Evidence

### Minimal deterministic reproduction

The new Gateway-handler regression uses real chat admission and transcript custody with an isolated dispatch fixture (no external provider or production credentials):

1. Start a chat through `handleChatSend`, retaining its outer source-work admission.
2. Start `commitBackgroundResultToSession` for that conversation and observe its source-drain request.
3. Allow reply dispatch to acquire the nested admission it needs before releasing the outer one.
4. Require the reply to finish, pending input custody to be consumed, and exactly one automation result to appear in the transcript.

On unchanged main `0e377815489d6a6187ac504689e23efe3657c174`, step 3 cannot finish: the assertion that `nestedFinished` becomes true fails. The same regression with the fix passes.

```sh
node scripts/run-vitest.mjs src/gateway/server-methods/chat-send-pending-inputs.test.ts -t 'lets an acknowledged chat finish nested admission before committing its background result'
```

The existing owner test now also verifies that work admitted during the wait can proceed, while its still-held lease prevents an early append; provenance, deduplication, conflicting payload rejection, cancellation and generation/media protections remain covered.

### Original submission validation (September 12)

- Node 26.8.2 and pnpm 12.3.4, isolated Linux container.
- **79 tests passed** across the four focused files below, including the red/green Gateway regression.
- Core typecheck and the gateway-server, services, and other test typecheck graphs passed.
- Independent `autoreview`: scoped-clean at P0–P2; no actionable findings.
- Formatting and `git diff --check` passed; outgoing commit secret scan clean.
- Standard and typed lint passed on all four changed files (zero warnings/errors); typed lint used each file's owning production/test project. The all-core typed-lint graph exceeded the local container memory budget; owner-graph checks retain the same typed rules.

```sh
node scripts/run-vitest.mjs \
  src/sessions/background-session-result.test.ts \
  src/sessions/session-lifecycle-admission.test.ts \
  src/cron/isolated-agent/current-session-completion.test.ts \
  src/gateway/server-methods/chat-send-pending-inputs.test.ts
pnpm tsgo:core
node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.gateway-server.json --incremental
node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.services.json --incremental
node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.other.json --incremental
```

Scope: isolated Gateway-handler flow plus real admission/transcript/media boundaries. The canonical `qaRuntime` build passed on the original submitted SHA (including CLI bootstrap-import and runtime postbuild checks). A full declaration/UI build, full test suite, and live external-channel test were not run for this narrow upstream change. No deployed Gateway was changed during this contribution.

### Real Gateway-client proof (review follow-up)

**Passed on the original submitted commit `f0a9051b32a8dab0bd9b1bcca82a1267454e7b16`.** Built with the canonical `qaRuntime` target; then launched the built Gateway in a fresh Linux container (`--init --network none`), with isolated config/state/workspace and a loopback-only deterministic Chat Completions server. No production state, credentials, or external channels were mounted or used.

This second check uses an actual WebSocket client with protocol 4, a fresh challenge-signed Ed25519 device identity, the matching candidate build ID, public `chat.send`/`cron.add`/`cron.run`/`cron.runs`/`chat.history`/`sessions.list` RPCs, and **unmocked Gateway/provider dispatch**. It does not import admission internals or inject a lease.

Sequence: hold the first model response; submit a second follow-up input to the same conversation; force a current-target announce automation; observe its model response while foreground is still held and zero source results; release the foreground; require both replies, a successful delivered cron receipt, exactly one saved automation result, zero pending inputs and no active source run. Re-read history after a settling interval to check the result count remains one.

Sanitized terminal trace (milliseconds since fixture start; all message markers are synthetic):

```text
11922 gateway-ready
12061 gateway-client-connected protocol=4
12284 first-input-accepted status=started
14164 model-request FIRST_REPLY_OK (held)
14204 second-input-accepted-while-first-held status=started
14268 background-triggered accepted=true
14577 model-response BACKGROUND_RESULT_OK firstReleased=false
16193 overlap-established foregroundHeld=true backgroundModelResponded=true sourceResults=0 pendingInputs=1
16194 foreground-released / model-response FIRST_REPLY_OK
16470 model-response SECOND_REPLY_OK
18544 proof-passed cronStatus=ok delivered=true sourceResults=1
      firstUserMessages=1 secondUserMessages=1 pendingInputs=0
      sourceStatus=done sourceHasActiveRun=false sourceActiveRunCount=0
process exit=0
```

**Proof boundary:** the deterministic handler regression supplies the unchanged-main red / patched green ordering proof. This real-client run demonstrates actual dispatch, queued-input progress, delivery and terminal custody on the patch; it does not claim to observe an internal lock directly or to be a baseline runtime reproduction. The UI asset build is not part of `qaRuntime`; the read-only fixture logged an unavailable UI asset build and a network-disabled catalog refresh. Neither prevented WebSocket readiness or the asserted runtime flow. No browser-rendering, external-channel or live-model claim is made.

This addresses the requested real Gateway-client evidence without widening the four-file code change. Maintainer review and upstream CI remain separate from these local results.

### Upstream CI follow-up (September 12)

At the original head `f0a9051b32a8dab0bd9b1bcca82a1267454e7b16`, CI run [34693180134](https://github.com/openclaw/openclaw/actions/runs/34693180134) completed with two test-shard failures (the aggregate gate failed as a consequence):

| Check | Exact failure |
| --- | --- |
| [checks-node-compact-large-15](https://github.com/openclaw/openclaw/actions/runs/34693180134/job/103552113019) | `src/agents/cli-runner/execute.executable-invocation.test.ts`, “runs a verified plugin CLI script through its resolved interpreter”: `CLI exceeded timeout (1s) and was terminated`; 1 failed / 3,204 passed / 1 skipped in this shard. |
| [checks-node-compact-large-4](https://github.com/openclaw/openclaw/actions/runs/34693180134/job/103552113132) | `src/gateway/health/collector.deadline.test.ts`, “preserves healthy accounts at the deadline and retains unfinished probe work”: `Test timed out in 1000ms`; 1 failed / 4,423 passed. |

Both failures exhaust pre-existing one-second budgets in files and execution paths outside this four-file change. Neither reports a background-result/admission assertion failure. The health test subsequently passed in **8 ms on main** at `7ee4437d6134bcd7cf04bd17f9cfa1af0e05c125` ([job log](https://github.com/openclaw/openclaw/actions/runs/34697441869/job/103563334632)). This is evidence consistent with timing sensitivity, not a claim that all main CI is green or that a clean rerun has already been obtained.

No test budgets, assertions, baselines, or workflow settings were changed to mask these failures. A single failed-jobs-only rerun request was attempted through GitHub CLI but rejected for repository permissions (“Must have admin rights to Repository”). That request concerned the original head. The September 14 merge refresh below starts fresh CI; the old failed run is retained as historical evidence, not a claim about the refreshed head.


### Merge refresh (September 14)

Merged current upstream `0d081a0ee88ae9ee8c0049974ecf48a196bf5216` into the PR as `075f3189d34acade7136e2aeaca1d14cc4c386a6` without rewriting branch history. The conflict was only in the Gateway regression: upstream extracted the browser follow-up fixture. Kept that shared fixture and its new profile-binding, steering-custody, persistence and cleanup behavior; moved the existing optional `dispatchAfterRelease` hook into `chat-send-pending-inputs.test-support.ts`. The production fix is byte-identical to the originally reviewed head. The PR now touches five files because the fixture lives in a separate file.

Refresh validation:

- **111 tests passed**: the original 79 focused tests, plus 30 shared-fixture sibling/health tests and 2 executable-invocation tests. Both original CI-failing scenarios passed with their existing timeouts and assertions unchanged. This is local evidence, not a claim that upstream CI has passed.
- Gateway-server test-project typecheck, formatting, diff check, standard lint (zero warnings/errors), outgoing secret scan, independent source review and `autoreview` P0–P2 all passed.
- The refreshed typed-lint process was stopped when it reached the isolated container's 6 GiB memory budget; it produced no verdict. No lint rules or baselines were disabled. Fresh upstream CI owns verification of that lane.
- The September 12 real Gateway-client trace above remains explicitly tied to the original head. This refresh revalidates the adapted deterministic Gateway flow and its sibling callers; no new runtime build or real-client trace is claimed.
- No production installation, live data, or running Gateway was changed.

The new head triggers fresh CI; the prior failed-jobs rerun request is historical. Maintainer approval and merge remain outstanding.
