### PR TITLE
refactor(channels): reuse canonical media limit resolver

### DIFF
--- a/src/channels/plugins/contracts/outbound-payload.contract.test.ts
+++ b/src/channels/plugins/contracts/outbound-payload.contract.test.ts
@@ -1,6 +1,10 @@
 // Outbound payload contract tests cover channel plugin outbound payload shape and normalization.
-import { describe, vi } from "vitest";
-import { createDirectTextMediaOutbound } from "../outbound/direct-text-media.js";
+import { describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../../config/types.openclaw.js";
+import {
+  createDirectTextMediaOutbound,
+  createScopedChannelMediaMaxBytesResolver,
+} from "../outbound/direct-text-media.js";
 import {
   installChannelOutboundPayloadContractSuite,
   type OutboundPayloadHarnessParams,
@@ -41,5 +45,261 @@ describe("outbound payload contracts", () => {
       chunking: { mode: "split", longTextLength: 5000, maxChunkLength: 4000 },
       createHarness: createDirectTextMediaHarness,
     });
+  });
+});
+
+const scopedMediaConfig: OpenClawConfig = {
+  agents: { defaults: { mediaMaxMb: 4 } },
+  channels: {
+    "media-limit-fixture": {
+      mediaMaxMb: 2,
+      accounts: {
+        default: { mediaMaxMb: 3 },
+        office: { mediaMaxMb: 1 },
+        "office-east": { mediaMaxMb: 5 },
+        zero: { mediaMaxMb: 0 },
+        nan: { mediaMaxMb: Number.NaN },
+        text: { mediaMaxMb: "1" },
+      },
+    },
+  },
+};
+
+const mediaLimitCases: Array<{
+  name: string;
+  cfg: OpenClawConfig;
+  accountId?: string | null;
+  expected: number | undefined;
+}> = [
+  { name: "no configured limit", cfg: {}, expected: undefined },
+  {
+    name: "agent default only",
+    cfg: { agents: { defaults: { mediaMaxMb: 4 } } },
+    expected: 4194304,
+  },
+  {
+    name: "channel limit before agent default",
+    cfg: scopedMediaConfig,
+    accountId: "missing",
+    expected: 2097152,
+  },
+  { name: "omitted account selects default", cfg: scopedMediaConfig, expected: 3145728 },
+  {
+    name: "null account selects default",
+    cfg: scopedMediaConfig,
+    accountId: null,
+    expected: 3145728,
+  },
+  {
+    name: "blank account selects default",
+    cfg: scopedMediaConfig,
+    accountId: "  ",
+    expected: 3145728,
+  },
+  {
+    name: "account limit before channel limit",
+    cfg: scopedMediaConfig,
+    accountId: "office",
+    expected: 1048576,
+  },
+  {
+    name: "trimmed lowercase account",
+    cfg: scopedMediaConfig,
+    accountId: " OFFICE ",
+    expected: 1048576,
+  },
+  {
+    name: "canonicalized account key",
+    cfg: scopedMediaConfig,
+    accountId: " Office / East ",
+    expected: 5242880,
+  },
+  // These characterize programmatic inputs, not configuration-schema acceptance.
+  {
+    name: "zero account limit falls through to agent default",
+    cfg: scopedMediaConfig,
+    accountId: "zero",
+    expected: 4194304,
+  },
+  {
+    name: "NaN account limit falls through to agent default",
+    cfg: scopedMediaConfig,
+    accountId: "nan",
+    expected: 4194304,
+  },
+  {
+    name: "non-number account limit falls through to channel",
+    cfg: scopedMediaConfig,
+    accountId: "text",
+    expected: 2097152,
+  },
+  {
+    name: "zero channel limit falls through to agent default",
+    cfg: {
+      agents: { defaults: { mediaMaxMb: 4 } },
+      channels: { "media-limit-fixture": { mediaMaxMb: 0 } },
+    },
+    expected: 4194304,
+  },
+  {
+    name: "NaN channel limit falls through to agent default",
+    cfg: {
+      agents: { defaults: { mediaMaxMb: 4 } },
+      channels: { "media-limit-fixture": { mediaMaxMb: Number.NaN } },
+    },
+    expected: 4194304,
+  },
+  {
+    name: "zero agent default is absent",
+    cfg: { agents: { defaults: { mediaMaxMb: 0 } } },
+    expected: undefined,
+  },
+  {
+    name: "NaN agent default is absent",
+    cfg: { agents: { defaults: { mediaMaxMb: Number.NaN } } },
+    expected: undefined,
+  },
+  {
+    name: "non-record channel section falls through to agent default",
+    cfg: { agents: { defaults: { mediaMaxMb: 4 } }, channels: { "media-limit-fixture": [] } },
+    expected: 4194304,
+  },
+  {
+    name: "fractional channel limit retains byte conversion",
+    cfg: { channels: { "media-limit-fixture": { mediaMaxMb: 0.5 } } },
+    expected: 524288,
+  },
+  {
+    name: "non-number channel limit falls through to agent default",
+    cfg: {
+      agents: { defaults: { mediaMaxMb: 4 } },
+      channels: { "media-limit-fixture": { mediaMaxMb: "2" } },
+    },
+    expected: 4194304,
+  },
+];
+
+describe("scoped channel media limits", () => {
+  it.each(mediaLimitCases)("$name", ({ name: _name, expected, ...input }) => {
+    const resolveLimit = createScopedChannelMediaMaxBytesResolver("media-limit-fixture");
+    expect(resolveLimit(input)).toBe(expected);
+  });
+
+  it("reads the configuration supplied to each call of the same resolver", () => {
+    const resolveLimit = createScopedChannelMediaMaxBytesResolver("media-limit-fixture");
+    expect(resolveLimit({ cfg: { channels: { "media-limit-fixture": { mediaMaxMb: 1 } } } })).toBe(
+      1048576,
+    );
+    expect(resolveLimit({ cfg: { channels: { "media-limit-fixture": { mediaMaxMb: 2 } } } })).toBe(
+      2097152,
+    );
+  });
+
+  it("carries selected limits and unchanged text/media options to the sender", async () => {
+    const cfg = scopedMediaConfig;
+    const textOptions = { kind: "text" };
+    const mediaOptions = { kind: "media" };
+    const send = vi.fn(async (_to: string, _text: string, _options: { kind: string }) => ({
+      messageId: "fixture-message",
+    }));
+    type BuilderInput = Parameters<
+      Parameters<typeof createDirectTextMediaOutbound>[0]["buildTextOptions"]
+    >[0];
+    const built: BuilderInput[] = [];
+    const outbound = createDirectTextMediaOutbound({
+      channel: "media-limit-fixture",
+      resolveSender: () => send,
+      resolveMaxBytes: createScopedChannelMediaMaxBytesResolver("media-limit-fixture"),
+      buildTextOptions: (options) => {
+        built.push(options);
+        return textOptions;
+      },
+      buildMediaOptions: (options) => {
+        built.push(options);
+        return mediaOptions;
+      },
+    });
+    const sendText = outbound.sendText;
+    const sendMedia = outbound.sendMedia;
+    if (!sendText || !sendMedia) {
+      throw new Error("Expected direct text and media send operations");
+    }
+    const readFile = vi.fn(async () => Buffer.from("unused"));
+    const legacyReadFile = vi.fn(async () => Buffer.from("unused-legacy"));
+    const roots = ["/tmp/media-limit-canonical-fixture"];
+    const legacyRoots = ["/tmp/media-limit-legacy-fixture"];
+    const mediaAccess = { localRoots: roots, readFile, workspaceDir: "/tmp/media-limit-workspace" };
+    const context = { cfg, to: "fixture-recipient", accountId: " OFFICE ", replyToId: "reply-1" };
+
+    const textResult = await sendText({ ...context, text: "text" });
+    const mediaResult = await sendMedia({
+      ...context,
+      text: "caption",
+      mediaUrl: "https://example.test/canonical.png",
+      mediaAccess,
+      mediaLocalRoots: legacyRoots,
+      mediaReadFile: legacyReadFile,
+    });
+    const legacyResult = await sendMedia({
+      ...context,
+      text: "legacy caption",
+      mediaUrl: "https://example.test/legacy.png",
+      mediaLocalRoots: legacyRoots,
+      mediaReadFile: legacyReadFile,
+    });
+
+    expect(built).toStrictEqual([
+      {
+        cfg,
+        mediaUrl: undefined,
+        mediaAccess: undefined,
+        mediaLocalRoots: undefined,
+        mediaReadFile: undefined,
+        accountId: " OFFICE ",
+        replyToId: "reply-1",
+        maxBytes: 1048576,
+      },
+      {
+        cfg,
+        mediaUrl: "https://example.test/canonical.png",
+        mediaAccess,
+        mediaLocalRoots: roots,
+        mediaReadFile: readFile,
+        accountId: " OFFICE ",
+        replyToId: "reply-1",
+        maxBytes: 1048576,
+      },
+      {
+        cfg,
+        mediaUrl: "https://example.test/legacy.png",
+        mediaAccess: { localRoots: legacyRoots, readFile: legacyReadFile },
+        mediaLocalRoots: legacyRoots,
+        mediaReadFile: legacyReadFile,
+        accountId: " OFFICE ",
+        replyToId: "reply-1",
+        maxBytes: 1048576,
+      },
+    ]);
+    for (const options of built) {
+      expect(options.cfg).toBe(cfg);
+    }
+    expect(built[1]?.mediaAccess).toBe(mediaAccess);
+    expect(built[1]?.mediaLocalRoots).toBe(roots);
+    expect(built[2]?.mediaLocalRoots).toBe(legacyRoots);
+    expect(send.mock.calls).toStrictEqual([
+      ["fixture-recipient", "text", textOptions],
+      ["fixture-recipient", "caption", mediaOptions],
+      ["fixture-recipient", "legacy caption", mediaOptions],
+    ]);
+    expect(send.mock.calls[0]?.[2]).toBe(textOptions);
+    expect(send.mock.calls[1]?.[2]).toBe(mediaOptions);
+    expect(send.mock.calls[2]?.[2]).toBe(mediaOptions);
+    expect([textResult, mediaResult, legacyResult]).toStrictEqual([
+      { channel: "media-limit-fixture", messageId: "fixture-message" },
+      { channel: "media-limit-fixture", messageId: "fixture-message" },
+      { channel: "media-limit-fixture", messageId: "fixture-message" },
+    ]);
+    expect(readFile).not.toHaveBeenCalled();
+    expect(legacyReadFile).not.toHaveBeenCalled();
   });
 });

--- a/src/channels/plugins/outbound/direct-text-media.ts
+++ b/src/channels/plugins/outbound/direct-text-media.ts
@@ -37,26 +37,11 @@ function readNumberField(record: Record<string, unknown> | undefined, key: strin
 }
 
 /**
- * Resolves an account-scoped channel media byte limit.
- */
-function resolveScopedChannelMediaMaxBytes(params: {
-  cfg: OpenClawConfig;
-  accountId?: string | null;
-  resolveChannelLimitMb: (params: { cfg: OpenClawConfig; accountId: string }) => number | undefined;
-}): number | undefined {
-  return resolveChannelMediaMaxBytes({
-    cfg: params.cfg,
-    resolveChannelLimitMb: params.resolveChannelLimitMb,
-    accountId: params.accountId,
-  });
-}
-
-/**
  * Builds a media byte-limit resolver for channels with `mediaMaxMb` config.
  */
 export function createScopedChannelMediaMaxBytesResolver(channel: string) {
   return (params: { cfg: OpenClawConfig; accountId?: string | null }) =>
-    resolveScopedChannelMediaMaxBytes({
+    resolveChannelMediaMaxBytes({
       cfg: params.cfg,
       accountId: params.accountId,
       resolveChannelLimitMb: ({ cfg, accountId }) => {


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Keep maintainer edits enabled where GitHub supports that setting for this branch.

</details>

## What Problem This Solves

The public channel media-limit factory had an extra private forwarding layer that added maintenance indirection without owning different behavior.

## Why This Change Was Made

Call the existing `resolveChannelMediaMaxBytes` owner directly while retaining the public factory and outbound adapter. Account normalization, account/channel selection, fallback truthiness and byte conversion remain with their existing owners. Public-factory and sender-option regression coverage exercises those boundaries without introducing a test-only production seam.

Production code is reduced by **15 lines**; tests add **260 net lines**. No configuration, dependency, storage, protocol, auth policy or public SDK surface changes are intended.

## User Impact

No user-visible behavior change is intended. Existing SDK consumers retain the same factory and adapter signatures, media limits and media-access precedence, including existing zero/NaN fallback behavior. This is internal maintenance cleanup; there is no migration or new operator action.

## Evidence

- Original production and candidate production each passed the same **53 tests**: 27 payload/factory cases, 8 delivery-sanitization cases and 18 SDK-contract cases. Per-file names, order and statuses matched exactly.
- Two normal `pnpm build:plugin-sdk:dts` runs produced identical **published** declarations: all **349 paths, modes and 3,554,184 bytes**, including `media-runtime.d.ts` and shared chunks. Raw group-cache outputs were retained separately from the canonical sanitizer's published output; no comparison-time normalization was used.
- The normal two-path changed gate passed all **32 selected checks**, including all four typechecks and both lint phases, on [Testbox run 34687308071](https://github.com/openclaw/openclaw/actions/runs/34687308071). The delegated command exited 0 and its owned lease stopped as completed. The backing Actions step can show cancellation after that provider-owned stop.
- Exact-head [CI run 34692585108](https://github.com/openclaw/openclaw/actions/runs/34692585108) completed SUCCESS at `30cb7a0f09a4055e436cf87d871bcb6cc2f5df0e`: 114 successful jobs and 17 workflow-skipped jobs, including successful `openclaw/ci-gate`.
- The separate authenticated exact-commit review of `30cb7a0f09a4055e436cf87d871bcb6cc2f5df0e` completed all **13 automatic passes**, with no actionable **P0–P2** findings and unchanged source/context. An earlier precommit review had an incomplete supplemental proof summary; it is retained as source-scoped advice, not counted as a complete proof-context certificate. The exact-commit review received corrected complete proof context and an explicit account of that gap, without the prior verdict.

The tests, declaration builds and changed gate ran before the signed save on the identical tree now held by this commit; they are not relabeled as clean-commit executions. They exercise source/adapter contracts and public declarations, not credentialed channel end-to-end flows or installed third-party plugins. Malformed/programmatic values characterize the function boundary, not configuration-schema acceptance. No later-main execution is claimed. Exact-head hosted CI is green; native landing qualification remains the final step.
