### PR TITLE
test(google-meet): bound recovery fixture readiness wait

### DIFF
--- a/extensions/google-meet/index.test.ts
+++ b/extensions/google-meet/index.test.ts
@@ -6182,7 +6182,7 @@ describe("google-meet plugin", () => {
       {
         defaultTransport: "chrome-node",
         defaultMode: "agent",
-        chrome: { reuseExistingTab: false },
+        chrome: { reuseExistingTab: false, waitForInCallMs: 1 },
       },
       {
         nodesInvokeHandler: createNodeBrowserScenario({


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

The paired-node talkback recovery test waits out the default 20-second readiness budget even though its mock cannot become ready until after the initial join returns. That wait adds no evidence to its recovery and tracked-tab assertions.

## Why This Change Was Made

Give this one fixture the same 1ms readiness budget already used by nearby blocked-readiness tests. Keep the real readiness path, every original assertion, and the production 20,000ms default unchanged. No fake clocks, helper changes, or production changes are introduced.

## User Impact

No user-facing change. In a matched local run, the recovery case decreased from 20,010ms to about 5.8ms. This is a fixture-runtime result, not a production or whole-suite performance claim. Net test-line change is zero.

## Evidence

- Corrected focused cohort: 17 selected cases passed (12 shared MeetingSessionRuntime cases and five plugin cases, including a later real-timer sibling); 166 cases were filtered.
- All 183 reported case names and their order are unchanged; the original 16 baseline passes remain passes, and the additional selected sibling changes from skipped to passed.
- Exact inverse reconstruction recovers the entire original file after removing only the new fixture field; assertions, cleanup, and default-config checks are unchanged.
- Mapped gate passed, including plugin typechecks, formatting, guards, all three dead-export scans, and targeted lint.
- Deslop and fresh independent P2 review completed without actionable findings.
