### PR TITLE
docs(skills): clarify remote gog OAuth setup for Gateway hosts

### DIFF
--- a/skills/gog/SKILL.md
+++ b/skills/gog/SKILL.md
@@ -26,11 +26,25 @@ metadata:
 
 Use `gog` for Gmail/Calendar/Drive/Contacts/Sheets/Docs. Requires OAuth setup.
 
+Prefer an already-authorized host account: run the needed command with `exec` first. Enter setup only after an auth error; confirm with `gog auth list --check` and `gog auth doctor`. Do not ask the user for passwords, client secrets, or refresh tokens in chat, and do not use the `secrets` tool for Google OAuth material.
+
 Setup (once)
 
 - `gog auth credentials /path/to/client_secret.json`
 - `gog auth add you@gmail.com --services gmail,calendar,drive,contacts,docs,sheets`
-- `gog auth list`
+- `gog auth list --check`
+
+Remote / headless Gateway hosts
+
+When the Gateway host has no local browser display:
+
+1. Prefer a live callback listener on the Gateway host. From the machine with the browser, forward the exact callback port (`ssh -L <port>:127.0.0.1:<port> user@gateway-host`), open the authorization URL `gog` prints, and let the redirect complete on that forwarded port.
+2. Use `--manual` or `--remote --step 1` / `--remote --step 2 --auth-url ...` only when a live listener is unavailable. A failed `localhost` page load after consent is expected in paste mode; paste the full callback URL into the waiting `gog` prompt, never into chat.
+3. Keep the same `GOG_HOME` / `--home` and `--client` across remote steps. Re-running step 1 creates a new PKCE state and invalidates an older callback URL.
+4. If desktop keyring is unavailable, configure the file backend (`gog auth keyring file`) and set `GOG_KEYRING_PASSWORD` in the Gateway environment so non-interactive agent/`--no-input` runs can read tokens. `gog auth doctor` reports when the password is missing.
+5. Callback received is not the same as token stored. If token exchange fails with a proxy authentication error, retry the exchange with direct egress to Google (or proxy exceptions for Google OAuth endpoints); do not treat the browser approval alone as success.
+
+Verify with `gog auth list --check` before sending mail or mutating calendar/drive state.
 
 Common commands
 

--- a/skills/gog/SKILL.md
+++ b/skills/gog/SKILL.md
@@ -39,8 +39,10 @@ Remote / headless Gateway hosts
 When the Gateway host has no local browser display:
 
 1. Prefer a live callback listener on the Gateway host. From the machine with the browser, forward the exact callback port (`ssh -L <port>:127.0.0.1:<port> user@gateway-host`), open the authorization URL `gog` prints, and let the redirect complete on that forwarded port.
-2. Use `--manual` or `--remote --step 1` / `--remote --step 2 --auth-url ...` only when a live listener is unavailable. A failed `localhost` page load after consent is expected in paste mode; paste the full callback URL into the waiting `gog` prompt, never into chat.
-3. Keep the same `GOG_HOME` / `--home` and `--client` across remote steps. Re-running step 1 creates a new PKCE state and invalidates an older callback URL.
+2. When a live listener is unavailable, pick one paste-mode path and keep callback URLs out of chat:
+   - `--manual`: `gog` waits for the full redirect URL on its interactive prompt.
+   - `--remote --step 1`: prints `auth_url` (and `state_reused`) then exits. After browser consent, finish with `--remote --step 2 --auth-url <callback-url>` using the same root flags, `--client`, scopes, and consent options. A failed `localhost` page load after consent is expected; copy the address-bar URL for step 2.
+3. Keep the same `GOG_HOME` / `--home` and `--client` across remote steps. Matching unexpired manual state may be reused (`state_reused=true`); preserve the same services/scopes/consent flags so step 2 can consume that state.
 4. If desktop keyring is unavailable, configure the file backend (`gog auth keyring file`) and set `GOG_KEYRING_PASSWORD` in the Gateway environment so non-interactive agent/`--no-input` runs can read tokens. `gog auth doctor` reports when the password is missing.
 5. Callback received is not the same as token stored. If token exchange fails with a proxy authentication error, retry the exchange with direct egress to Google (or proxy exceptions for Google OAuth endpoints); do not treat the browser approval alone as success.
 

--- a/skills/gog/SKILL.md
+++ b/skills/gog/SKILL.md
@@ -26,27 +26,27 @@ metadata:
 
 Use `gog` for Gmail/Calendar/Drive/Contacts/Sheets/Docs. Requires OAuth setup.
 
-Prefer an already-authorized host account: run the needed command with `exec` first. Enter setup only after an auth error; confirm with `gog auth list --check` and `gog auth doctor`. Do not ask the user for passwords, client secrets, or refresh tokens in chat, and do not use the `secrets` tool for Google OAuth material.
+Prefer an already-authorized host account: run the requested `gog` command first. Enter setup only after an authentication error. Never ask for passwords, client secrets, or refresh tokens in chat.
 
 Setup (once)
 
 - `gog auth credentials /path/to/client_secret.json`
 - `gog auth add you@gmail.com --services gmail,calendar,drive,contacts,docs,sheets`
-- `gog auth list --check`
+- `gog auth list`
 
 Remote / headless Gateway hosts
 
 When the Gateway host has no local browser display:
 
 1. Prefer a live callback listener on the Gateway host. From the machine with the browser, forward the exact callback port (`ssh -L <port>:127.0.0.1:<port> user@gateway-host`), open the authorization URL `gog` prints, and let the redirect complete on that forwarded port.
-2. When a live listener is unavailable, pick one paste-mode path and keep callback URLs out of chat:
-   - `--manual`: `gog` waits for the full redirect URL on its interactive prompt.
-   - `--remote --step 1`: prints `auth_url` (and `state_reused`) then exits. After browser consent, finish with `--remote --step 2 --auth-url <callback-url>` using the same root flags, `--client`, scopes, and consent options. A failed `localhost` page load after consent is expected; copy the address-bar URL for step 2.
-3. Keep the same `GOG_HOME` / `--home` and `--client` across remote steps. Matching unexpired manual state may be reused (`state_reused=true`); preserve the same services/scopes/consent flags so step 2 can consume that state.
+2. When a live listener is unavailable, the operator picks one paste-mode path in a trusted shell on the Gateway host. Callback URLs must never enter chat or agent tool input:
+   - `--manual`: the operator pastes the full redirect URL into `gog`'s interactive prompt.
+   - `--remote --step 1`: prints `auth_url` (and `state_reused`) then exits. After browser consent, the operator runs `--remote --step 2 --auth-url <callback-url>` in the trusted shell. A failed `localhost` page load after consent is expected.
+3. Keep the same resolved config context across remote steps: `GOG_CONFIG_DIR` takes precedence over `--home`, which takes precedence over `GOG_HOME`. Also preserve `--client`, services/scopes, redirect URI, and consent options. Matching unexpired manual state may be reused (`state_reused=true`).
 4. If desktop keyring is unavailable, configure the file backend (`gog auth keyring file`) and set `GOG_KEYRING_PASSWORD` in the Gateway environment so non-interactive agent/`--no-input` runs can read tokens. `gog auth doctor` reports when the password is missing.
-5. Callback received is not the same as token stored. If token exchange fails with a proxy authentication error, retry the exchange with direct egress to Google (or proxy exceptions for Google OAuth endpoints); do not treat the browser approval alone as success.
+5. Callback received is not the same as token stored. If token exchange or identity lookup fails behind a proxy, restart from step 1 after the operator approves scoped egress or proxy exceptions for the required Google endpoints. Do not bypass host network policy or reuse failed or expired state.
 
-Verify with `gog auth list --check` before sending mail or mutating calendar/drive state.
+For diagnostics, inspect every entry reported by `gog auth list --check`; its exit status does not prove every stored token is valid. Likewise, inspect the status reported by `gog auth doctor` rather than relying only on its exit code.
 
 Common commands
 


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/pull/145886

## What Problem This Solves

Fixes an issue where operators authorizing `gog` on a remote or headless Gateway could be sent into unnecessary setup, expose an OAuth callback through agent-visible input, lose remote-step state by changing config roots, or bypass host proxy policy after browser consent.

## Why This Change Was Made

Keep the bundled `gog` skill baseline-only while making the remote OAuth path safe and actionable:

- Run the requested `gog` operation first and enter setup only after an authentication error.
- Keep callback URLs out of chat and agent tool input; the operator completes manual paste or remote step 2 in a trusted Gateway shell.
- Preserve the resolved config context across remote steps: `GOG_CONFIG_DIR`, then `--home`, then `GOG_HOME`, plus client, scopes, redirect, and consent options.
- Require operator-approved scoped egress or proxy exceptions for token exchange and identity lookup; never direct an agent to bypass host network policy.
- Treat `gog auth list --check` and `gog auth doctor` as diagnostics whose reported entries/status must be inspected, not blanket success gates.

The command catalog and OAuth implementation remain owned by gogcli.

## User Impact

Agents reuse working host authorization by default. When setup is required, remote operators get a clear listener or operator-owned paste flow without exposing OAuth material or weakening network policy.

## Evidence

Exact prepared head: `adfb2ad06426c9656d4b85c5381bce96d9e30bf6`

- `node scripts/check-changed.mjs -- skills/gog/SKILL.md` passed the docs-only changed-file lane.
- `oxfmt --check skills/gog/SKILL.md` passed.
- Final committed-branch autoreview was scoped-clean through P3.
- Direct gogcli v0.39.1 contract inspection confirmed remote step 1 exits after printing `auth_url`/`state_reused`, step 2 requires operator-supplied callback input, config-dir override precedes home overrides, identity lookup follows token exchange, and diagnostic commands report failures in output without a failure exit.
- Sanitized isolated agent proof produced these outcomes:

| Scenario | Observed instruction behavior |
| --- | --- |
| Existing authorization works | Use the result and do not enter setup. |
| Requested operation returns an auth error | Enter the bounded setup flow only then. |
| Headless host has no listener | The operator completes the paste flow in a trusted shell; callback material never enters chat or agent tools. |
| Diagnostic commands return | Inspect each entry/status; exit status alone does not prove token validity. |

No fresh browser OAuth exchange was run. Runtime code is unchanged; the strongest safe proof is the existing contributor Gateway evidence, direct upstream contract inspection, and sanitized instruction-behavior proof. Landing remains gated on exact-head ClawSweeper review and hosted CI.

## Contributor Credit

Original remote/headless implementation: @DonnieFi.

The existing-auth-first contribution from https://github.com/openclaw/openclaw/pull/145886 by @abhishek17n is incorporated, linked above, and preserved with their verified human co-author identity. No agent co-author is retained.
