### PR TITLE
fix(plugins): support native loading with Bun

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -3362,7 +3362,7 @@ src/plugins/runtime/runtime-llm-isolated.ts	3
 src/plugins/runtime/runtime-llm.runtime.ts	4
 src/plugins/runtime/runtime-taskflow.ts	1
 src/plugins/schema-validator.ts	6
-src/plugins/sdk-alias.ts	3
+src/plugins/sdk-alias.ts	2
 src/plugins/session-catalog-history-import.ts	1
 src/plugins/setup-registry.ts	11
 src/plugins/slots.ts	3

--- a/src/plugins/loader-records.sdk-compatibility.test.ts
+++ b/src/plugins/loader-records.sdk-compatibility.test.ts
@@ -5,6 +5,7 @@ import { pathToFileURL } from "node:url";
 import { afterEach, expect, it, vi } from "vitest";
 import { createTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { formatPluginLine } from "../cli/plugins-list-format.js";
+import { resolveTestNodeExecPath } from "../test-utils/node-process.js";
 import { VERSION } from "../version.js";
 import { createPluginRecord, recordPluginError } from "./loader-records.js";
 import { createEmptyPluginRegistry } from "./registry-empty.js";
@@ -68,7 +69,7 @@ it.each([
   // Native Node supplies the real error shape, without the host test process's SDK aliases.
   const result = JSON.parse(
     execFileSync(
-      process.execPath,
+      resolveTestNodeExecPath(),
       [
         "--input-type=module",
         "-e",

--- a/src/plugins/native-module-require.ts
+++ b/src/plugins/native-module-require.ts
@@ -79,7 +79,7 @@ type CapturedModuleBinding = {
   resolve: CapturedModuleResolver;
   prepare: (request: string, parent: string) => string | undefined;
 };
-type BunPluginRuntime = {
+export type BunPluginRuntime = {
   plugin(options: {
     name: string;
     setup(builder: {

--- a/src/plugins/plugin-cache-sdk.ts
+++ b/src/plugins/plugin-cache-sdk.ts
@@ -28,6 +28,7 @@ type PreparedPluginAliases = {
   cacheKey: string;
   sdkRoots: string[];
   getAliasMap: () => PluginSdkAliasMap;
+  getSourceTransformAliasMap: () => PluginSdkAliasMap;
   resolveAlias: (specifier: string) => string | undefined;
 };
 

--- a/src/plugins/plugin-module-loader-cache.ts
+++ b/src/plugins/plugin-module-loader-cache.ts
@@ -113,6 +113,7 @@ function resolvePluginModuleLoaderCacheEntry(params: ResolvePluginModuleLoaderCa
     ? {
         cacheKey: createPluginLoaderModuleCacheKey({ tryNative, aliasMap: explicit }),
         getAliasMap: () => explicit,
+        getSourceTransformAliasMap: () => explicit,
         resolveAlias: (specifier: string) => explicit[specifier],
       }
     : preparePluginLoaderAliases({
@@ -123,7 +124,9 @@ function resolvePluginModuleLoaderCacheEntry(params: ResolvePluginModuleLoaderCa
         pluginSdkResolution: params.pluginSdkResolution,
       });
   const moduleConfigCacheKey = `${tryNative ? "native" : "transform"}\0${aliases.cacheKey}`;
-  const transformOpenClawDependencies = params.transformOpenClawDependencies ?? tryNative;
+  const lazyNativeAliasFallback = tryNative && typeof Module.registerHooks !== "function";
+  const transformOpenClawDependencies =
+    params.transformOpenClawDependencies ?? (lazyNativeAliasFallback ? false : tryNative);
   const cacheKey = `${moduleConfigCacheKey}\0transform-openclaw=${transformOpenClawDependencies ? "1" : "0"}`;
   const scopedCacheKey = `${loaderFilename}::${params.cacheScopeKey ? `${params.cacheScopeKey}::` : ""}${cacheKey}`;
   return {
@@ -132,6 +135,9 @@ function resolvePluginModuleLoaderCacheEntry(params: ResolvePluginModuleLoaderCa
     resolveAlias: aliases.resolveAlias,
     tryNative,
     transformOpenClawDependencies,
+    sourceTransformAliasMap: lazyNativeAliasFallback
+      ? aliases.getSourceTransformAliasMap
+      : undefined,
     scopedCacheKey,
   };
 }
@@ -149,9 +155,12 @@ function createPluginModuleLoader(
     if (loadWithSourceTransform) {
       return loadWithSourceTransform;
     }
-    const jitiOptions = buildPluginLoaderJitiOptions(params.getAliasMap(), {
-      modulePath: params.loaderFilename,
-    });
+    const jitiOptions = buildPluginLoaderJitiOptions(
+      params.sourceTransformAliasMap?.() ?? params.getAliasMap(),
+      {
+        modulePath: params.loaderFilename,
+      },
+    );
     const jitiLoader = (params.createLoader ?? createJiti)(params.loaderFilename, {
       ...jitiOptions,
       // Source SDK aliases resolve outside node_modules, so Jiti's nativeModules
@@ -402,6 +411,7 @@ export function bindPluginInstanceModuleLoader(params: {
         specifier.startsWith(PLUGIN_SOURCE_RESOLVE_PREFIX)
       ) {
         return params.instance.run(() => {
+          // SAFETY: Generated resolver requests always encode this request/options tuple.
           const [request, options] = JSON.parse(
             decodeURIComponent(specifier.slice(PLUGIN_SOURCE_RESOLVE_PREFIX.length)),
           ) as [string, string | JitiResolveOptions];

--- a/src/plugins/plugin-sdk-native-resolver.ts
+++ b/src/plugins/plugin-sdk-native-resolver.ts
@@ -5,7 +5,7 @@ import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { isPathInside, isPathStrictlyInside } from "../infra/path-guards.js";
-import { supportsNativeModuleAliasHooks } from "./native-module-require.js";
+import { supportsNativeModuleAliasHooks, type BunPluginRuntime } from "./native-module-require.js";
 import { pluginCacheExistsSync, pluginCacheRealpathSync } from "./plugin-cache-files.js";
 import { getPluginSdkHostFacts } from "./plugin-cache-sdk.js";
 import { getPluginCache } from "./plugin-cache.js";
@@ -352,14 +352,29 @@ function listInternalCorePackageNativeAliases(
 
 function installResolver(): void {
   const native = getPluginCache().sdk.native;
+  if (installed || !(native.aliases.size || native.sdkProviders.size)) {
+    return;
+  }
+  // SAFETY: Bun exposes this synchronous public API; Node leaves the optional global absent.
+  const bun = (globalThis as typeof globalThis & { Bun?: BunPluginRuntime }).Bun;
+  if (bun) {
+    bun.plugin({
+      name: "openclaw-plugin-sdk-alias",
+      setup(builder) {
+        builder.onResolve(
+          { filter: /^(?:openclaw|@openclaw)\/plugin-sdk\//u, namespace: "file" },
+          ({ path: request, importer }) => {
+            const target = resolveAliasTargetForParentPath(request, importer);
+            return target ? { path: target, namespace: "file" } : undefined;
+          },
+        );
+      },
+    });
+  }
   const previousResolveFilename = moduleWithResolver[nodeResolveFilenameProperty];
   // Packaged runtimes without aliases must retain the runtime's native resolution path.
-  if (
-    installed ||
-    !previousResolveFilename ||
-    !(native.aliases.size || native.sdkProviders.size) ||
-    !supportsNativeModuleAliasHooks()
-  ) {
+  if (!previousResolveFilename || !supportsNativeModuleAliasHooks()) {
+    installed = Boolean(bun);
     return;
   }
   moduleWithResolver[nodeResolveFilenameProperty] = ((request, parent, isMain, options) =>

--- a/src/plugins/sdk-alias.test.ts
+++ b/src/plugins/sdk-alias.test.ts
@@ -1686,8 +1686,8 @@ describe("plugin sdk alias helpers", () => {
   it.each([
     ["node", "linux", "dist/plugins/runtime/index.js", false, true],
     ["node", "linux", "extensions/demo/index.ts", false, false],
-    ["bun", "linux", "dist/plugins/runtime/index.js", false, false],
-    ["bun", "linux", "dist/extensions/demo/index.js", true, false],
+    ["bun", "linux", "dist/plugins/runtime/index.js", false, true],
+    ["bun", "linux", "dist/extensions/demo/index.js", true, true],
     ["node", "win32", "dist/plugins/runtime/index.js", false, true],
     ["node", "win32", "dist/extensions/demo/index.js", true, true],
     ["node", "win32", "dist/extensions/demo/helper.ts", true, false],

--- a/src/plugins/sdk-alias.ts
+++ b/src/plugins/sdk-alias.ts
@@ -1256,6 +1256,8 @@ function mergeAliasMaps(
   return merged;
 }
 
+const EMPTY_ALIAS_MAP: Record<string, string> = Object.freeze({});
+
 function hasJitiNormalizedAliasMarker(aliasMap: Record<string, string>) {
   return Boolean((aliasMap as Record<symbol, unknown>)[JITI_NORMALIZED_ALIAS_SYMBOL]);
 }
@@ -1390,16 +1392,27 @@ export function preparePluginLoaderAliases(
   if (cached) {
     return cached;
   }
+  let sourceTransformAliasMap: Record<string, string> | undefined;
   let aliasMap: Record<string, string> | undefined;
   let sdkAliases: ReturnType<typeof createPluginSdkScopedAliases> | undefined;
   const getSdkAliases = () => (sdkAliases ??= createPluginSdkScopedAliases(context));
+  const getSourceTransformAliasMap = () =>
+    withPluginCache(
+      cache,
+      () =>
+        (sourceTransformAliasMap ??= mergeAliasMaps(
+          resolveBundledPluginPackagePublicSurfaceAliasMap(context),
+          resolveWorkspacePackageAliasMap(context),
+          EMPTY_ALIAS_MAP,
+        )),
+    );
   const getAliasMap = () =>
     withPluginCache(
       cache,
       () =>
         (aliasMap ??= mergeAliasMaps(
-          resolveBundledPluginPackagePublicSurfaceAliasMap(context),
-          resolveWorkspacePackageAliasMap(context),
+          getSourceTransformAliasMap(),
+          EMPTY_ALIAS_MAP,
           normalizeAliasTargets(getSdkAliases().getAliasMap()),
         )),
     );
@@ -1412,6 +1425,7 @@ export function preparePluginLoaderAliases(
       ? context.orderedKinds.map((kind) => path.join(packageRoot, kind, "plugin-sdk"))
       : [],
     getAliasMap,
+    getSourceTransformAliasMap,
     resolveAlias: (specifier: string): string | undefined => {
       if (!isPluginLoaderAliasSpecifier(specifier)) {
         return undefined;
@@ -1574,19 +1588,11 @@ export function buildPluginLoaderJitiOptions(
   };
 }
 
-function supportsNativeModuleRuntime(): boolean {
-  const versions = process.versions as { bun?: string };
-  return typeof versions.bun !== "string";
-}
-
 function isBundledPluginDistModulePath(modulePath: string): boolean {
   return modulePath.replace(/\\/g, "/").includes("/dist/extensions/");
 }
 
 function shouldPreferNativeModuleLoad(modulePath: string): boolean {
-  if (!supportsNativeModuleRuntime()) {
-    return false;
-  }
   switch (normalizeLowercaseStringOrEmpty(path.extname(modulePath))) {
     case ".js":
     case ".mjs":
@@ -1609,9 +1615,7 @@ export function resolvePluginLoaderTryNative(
   }
   return (
     shouldPreferNativeModuleLoad(modulePath) ||
-    (supportsNativeModuleRuntime() &&
-      options?.preferBuiltDist === true &&
-      modulePath.includes(`${path.sep}dist${path.sep}`))
+    (options?.preferBuiltDist === true && modulePath.includes(`${path.sep}dist${path.sep}`))
   );
 }
 


### PR DESCRIPTION
## Problem

Bun plugin loads were forced through Jiti even for compiled JavaScript. That made failed CommonJS plugins execute twice, broke published pre-split SDK bridge identity, and left late CommonJS or ESM `openclaw/plugin-sdk/*` imports without a persistent alias resolver.

## Solution

Use native-first loading for JavaScript under Bun, install a Bun `onResolve` hook that applies the existing parent-root SDK authority checks, and retain the private CJS resolver for late `createRequire` calls. When a runtime has no Node ESM module hooks and native loading falls back to Jiti, build only the non-SDK alias map eagerly and resolve SDK virtual modules on demand. Node keeps its existing `Module.registerHooks` path.

The SDK compatibility fixture now explicitly launches Node when it needs Node's diagnostic error shape, so the same test remains valid when Vitest itself runs under Bun. The assertion-safety baseline shrinks by one after removing the old Bun runtime cast.

Release-note context: compiled plugins and late SDK imports now load through the native Bun adapter while preserving Node behavior and plugin ownership boundaries.

## Validation

- Direct custom Bun: complete plugin-loader and SDK alias set, 505 passed with 1 intentional platform skip
- Node: the same set, 505 passed with 1 intentional platform skip
- `pnpm check:changed`
- Independent P0-P2 autoreview: clean

Runtime compatibility was validated with the custom Bun composite; the new file-URL suffix fix is upstream at oven-sh/bun#42469.
