### PR TITLE
refactor(gateway): share connection lifecycle across transports

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2689,7 +2689,7 @@ src/gateway/node-command-policy.ts	2
 src/gateway/node-invoke-system-run-approval.ts	1
 src/gateway/node-pairing-ssh-verify.ts	1
 src/gateway/node-registry-private.ts	1
-src/gateway/node-registry.ts	5
+src/gateway/node-registry.ts	4
 src/gateway/openai-agent-run-usage.ts	1
 src/gateway/openai-http.ts	27
 src/gateway/openresponses-http.ts	3
@@ -2816,7 +2816,7 @@ src/gateway/server.auth.modes.suite.ts	1
 src/gateway/server/http-listen.ts	1
 src/gateway/server/plugins-http/route-capability.ts	1
 src/gateway/server/ws-connection-diagnostics.ts	3
-src/gateway/server/ws-connection.ts	3
+src/gateway/server/ws-connection.ts	1
 src/gateway/server/ws-connection/authenticated-request-dispatch.ts	1
 src/gateway/server/ws-connection/connect-device-metadata.ts	1
 src/gateway/server/ws-connection/connect-node-session.ts	1

--- a/src/gateway/node-registry.test.ts
+++ b/src/gateway/node-registry.test.ts
@@ -118,12 +118,14 @@ function makeClient(
     sessionCapsCeiling?: string[];
     sessionCommandsCeiling?: string[];
     socket?: GatewayWsClient["socket"];
+    webSocket?: GatewayWsClient["webSocket"];
   } = {},
 ): GatewayWsClient {
   return {
     connId,
     usesSharedGatewayAuth: false,
     socket: opts.socket ?? (createTestNodeSocket(sent) as unknown as GatewayWsClient["socket"]),
+    webSocket: opts.webSocket,
     connect: {
       minProtocol: 1,
       maxProtocol: 1,
@@ -225,7 +227,7 @@ function makeConnectivitySocket(emitPong: boolean) {
       queueMicrotask(() => socket.emit("pong"));
     }
   };
-  return socket as unknown as GatewayWsClient["socket"];
+  return socket as unknown as GatewayWsClient["socket"] & NonNullable<GatewayWsClient["webSocket"]>;
 }
 
 function registerNode(registry: NodeRegistry, opts: Parameters<typeof makeClient>[3] = {}) {
@@ -1714,10 +1716,12 @@ describe("gateway/node-registry", () => {
 
   it("checks node websocket connectivity with ping/pong", async () => {
     const registry = createTestNodeRegistry();
+    const socket = makeConnectivitySocket(true);
     registerNodeSession(
       registry,
       makeClient("conn-1", "node-1", [], {
-        socket: makeConnectivitySocket(true),
+        socket,
+        webSocket: socket,
       }),
       {},
     );
@@ -1729,7 +1733,7 @@ describe("gateway/node-registry", () => {
     const registry = createTestNodeRegistry();
     const socket = makeConnectivitySocket(true);
     const ping = vi.spyOn(socket, "ping");
-    const client = makeClient("conn-invalidated", "node-1", [], { socket });
+    const client = makeClient("conn-invalidated", "node-1", [], { socket, webSocket: socket });
     registerNodeSession(registry, client, {});
     client.invalidated = true;
 
@@ -1743,12 +1747,17 @@ describe("gateway/node-registry", () => {
   it("does not report an old websocket as connected after its node reconnects", async () => {
     const registry = createTestNodeRegistry();
     const oldSocket = makeConnectivitySocket(false);
-    registerNodeSession(registry, makeClient("conn-old", "node-1", [], { socket: oldSocket }), {});
+    registerNodeSession(
+      registry,
+      makeClient("conn-old", "node-1", [], { socket: oldSocket, webSocket: oldSocket }),
+      {},
+    );
 
     const connectivity = registry.checkConnectivity("node-1", 50);
+    const newSocket = makeConnectivitySocket(true);
     const replacement = registerNodeSession(
       registry,
-      makeClient("conn-new", "node-1", [], { socket: makeConnectivitySocket(true) }),
+      makeClient("conn-new", "node-1", [], { socket: newSocket, webSocket: newSocket }),
       {},
     );
     (oldSocket as unknown as EventEmitter).emit("pong");
@@ -1781,9 +1790,10 @@ describe("gateway/node-registry", () => {
     );
 
     const connectivity = registry.checkConnectivity("node-1", 50);
+    const newSocket = makeConnectivitySocket(true);
     const replacement = registerNodeSession(
       registry,
-      makeClient("conn-new", "node-1", [], { socket: makeConnectivitySocket(true) }),
+      makeClient("conn-new", "node-1", [], { socket: newSocket, webSocket: newSocket }),
       {},
     );
     resolveProbe?.({ ok: true });
@@ -1811,7 +1821,11 @@ describe("gateway/node-registry", () => {
     };
     let frames: string[] = [];
     let socket = makeTrackedSocket(frames);
-    registerNodeSession(registry, makeClient("conn-0", "node-1", frames, { socket }), {});
+    registerNodeSession(
+      registry,
+      makeClient("conn-0", "node-1", frames, { socket, webSocket: socket }),
+      {},
+    );
 
     for (let attempt = 1; attempt <= 50; attempt += 1) {
       const previousSocket = socket;
@@ -1831,7 +1845,7 @@ describe("gateway/node-registry", () => {
       socket = makeTrackedSocket(frames);
       const replacement = registerNodeSession(
         registry,
-        makeClient(`conn-${attempt}`, "node-1", frames, { socket }),
+        makeClient(`conn-${attempt}`, "node-1", frames, { socket, webSocket: socket }),
         {},
       );
       (previousSocket as unknown as EventEmitter).emit("pong");
@@ -1864,10 +1878,12 @@ describe("gateway/node-registry", () => {
 
   it("reports stale node websocket connectivity before invoke timeout", async () => {
     const registry = createTestNodeRegistry();
+    const socket = makeConnectivitySocket(false);
     registerNodeSession(
       registry,
       makeClient("conn-1", "node-1", [], {
-        socket: makeConnectivitySocket(false),
+        socket,
+        webSocket: socket,
       }),
       {},
     );

--- a/src/gateway/node-registry.ts
+++ b/src/gateway/node-registry.ts
@@ -167,17 +167,6 @@ export type NodeConnectivityResult =
   | { ok: true }
   | { ok: false; error: { code: string; message: string } };
 
-/** Minimal websocket ping/pong surface used by connectivity checks. */
-type PingableSocket = {
-  ping?: (data?: Buffer, mask?: boolean, cb?: (err?: Error) => void) => void;
-  once?: (event: "pong" | "close" | "error", listener: (...args: unknown[]) => void) => unknown;
-  off?: (event: "pong" | "close" | "error", listener: (...args: unknown[]) => void) => unknown;
-  removeListener?: (
-    event: "pong" | "close" | "error",
-    listener: (...args: unknown[]) => void,
-  ) => unknown;
-};
-
 const SERIALIZED_EVENT_PAYLOAD = Symbol("openclaw.serializedEventPayload");
 const AUTHORIZED_SYSTEM_RUN_EVENT_GRACE_MS = 5 * 60 * 1000;
 const SLOW_CONSUMER_CLOSE_CODE = 1008;
@@ -1030,14 +1019,14 @@ export class NodeRegistry {
         : { ok: true as const };
       return currentConnectionResult(result);
     }
-    const socket = node.client.socket as PingableSocket;
+    const socket = node.client.webSocket;
     if (!this.isNodeWebSocketOpen(node)) {
       return {
         ok: false,
         error: { code: "NOT_CONNECTED", message: "node socket not open" },
       };
     }
-    if (typeof socket.ping !== "function" || typeof socket.once !== "function") {
+    if (!socket) {
       return { ok: true };
     }
 
@@ -1045,12 +1034,9 @@ export class NodeRegistry {
     return await new Promise<NodeConnectivityResult>((resolve) => {
       let settled = false;
       const cleanup = () => {
-        socket.off?.("pong", onPong);
-        socket.off?.("close", onClose);
-        socket.off?.("error", onError);
-        socket.removeListener?.("pong", onPong);
-        socket.removeListener?.("close", onClose);
-        socket.removeListener?.("error", onError);
+        socket.off("pong", onPong);
+        socket.off("close", onClose);
+        socket.off("error", onError);
       };
       const finish = (result: NodeConnectivityResult) => {
         if (settled) {
@@ -1085,11 +1071,11 @@ export class NodeRegistry {
         timeout,
       );
 
-      socket.once?.("pong", onPong);
-      socket.once?.("close", onClose);
-      socket.once?.("error", onError);
+      socket.once("pong", onPong);
+      socket.once("close", onClose);
+      socket.once("error", onError);
       try {
-        socket.ping?.(undefined, false, (err?: Error) => {
+        socket.ping(undefined, false, (err?: Error) => {
           if (err) {
             finish({
               ok: false,

--- a/src/gateway/role-policy.ts
+++ b/src/gateway/role-policy.ts
@@ -1,11 +1,7 @@
 // Gateway connection role policy.
 // Separates node-role RPCs from operator RPCs before method scope checks.
 import { isNodeRoleMethod } from "./method-scopes.js";
-
-const GATEWAY_ROLES = ["operator", "node"] as const;
-
-/** Gateway connection roles used before method-level operator scope checks. */
-export type GatewayRole = (typeof GATEWAY_ROLES)[number];
+import type { GatewayRole } from "./role-policy.types.js";
 
 /** Parses the untrusted role claim from connect params into the closed role set. */
 export function parseGatewayRole(roleRaw: unknown): GatewayRole | null {

--- a/src/gateway/role-policy.types.ts
+++ b/src/gateway/role-policy.types.ts
@@ -1,0 +1,2 @@
+/** Gateway connection roles used before method-level operator scope checks. */
+export type GatewayRole = "operator" | "node";

--- a/src/gateway/server-import-boundary.test.ts
+++ b/src/gateway/server-import-boundary.test.ts
@@ -186,14 +186,17 @@ describe("gateway startup import boundaries", () => {
     expect(readSource("src/gateway/server-reload-managed.ts")).not.toContain(
       'from "../secrets/runtime.js"',
     );
+    const connection = readSource("src/gateway/server/connection.ts");
     const wsConnection = readSource("src/gateway/server/ws-connection.ts");
     const wsGraph = collectStaticValueImportGraph("src/gateway/server/ws-connection.ts");
     expect([...wsGraph.keys()]).not.toContain(
       path.join(repoRoot, "src/gateway/server/ws-connection/message-handler.ts"),
     );
-    expect(wsConnection).not.toContain('from "../talk-realtime-relay.js"');
-    expect(wsConnection).not.toContain('from "../talk-transcription-relay.js"');
-    expect(wsConnection).toContain('from "../talk-session-registry.js"');
+    for (const source of [connection, wsConnection]) {
+      expect(source).not.toContain('from "../talk-realtime-relay.js"');
+      expect(source).not.toContain('from "../talk-transcription-relay.js"');
+    }
+    expect(connection).toContain('from "../talk-session-registry.js"');
     expect(readSource("src/gateway/server-aux-handlers.ts")).not.toMatch(
       /import\s+\{[^}]*create(?:Exec|Plugin|Secrets)[^}]*\}\s+from "\.\/server-methods\//s,
     );

--- a/src/gateway/server.node-shutdown.test.ts
+++ b/src/gateway/server.node-shutdown.test.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
 import { expect, test, vi } from "vitest";
+import { WebSocket } from "ws";
 import { WORKER_EXECUTION_CONTEXT_PROTOCOL_FEATURE } from "../../packages/gateway-protocol/src/schema/worker-admission.js";
 import { runQaGatewayFixture } from "../../test/helpers/qa-gateway-cleanup.js";
 import { writeConfigFile } from "../config/config.js";
@@ -163,6 +164,12 @@ test.for(["direct", "restart"] as const)(
               }
             },
           });
+          const ping = vi.spyOn(WebSocket.prototype, "ping");
+          await expect(
+            kernel.nodeRegistry.checkConnectivity(pairedNode.identity.deviceId),
+          ).resolves.toEqual({ ok: true });
+          expect(ping).toHaveBeenCalledOnce();
+          ping.mockRestore();
           await node.request("node.runnerInventory.update", {
             protocolFeatures: [NODE_WORKER_SUPERVISOR_PROTOCOL_FEATURE],
             workerHost: {

--- a/src/gateway/server/connection-transport.ts
+++ b/src/gateway/server/connection-transport.ts
@@ -1,0 +1,28 @@
+import type { Result } from "@openclaw/normalization-core/result";
+import type { GatewayRole } from "../role-policy.types.js";
+
+export type GatewayConnectionFrame = Buffer | ArrayBuffer | Buffer[];
+
+/** Ordered frames and transport retirement, independent of the physical connection. */
+export type GatewayConnectionTransport = {
+  /** Uses the WebSocket ready-state values; 1 means open. */
+  readonly readyState: number;
+  readonly bufferedAmount: number;
+  /**
+   * Accept frames in order. The optional callback settles after transport
+   * delivery or with an error; it is not a peer acknowledgement.
+   */
+  send(frame: string, callback?: (error?: Error) => void): void;
+  close(code?: number, reason?: string): void;
+  terminate(): void;
+  on(event: "message", listener: (data: GatewayConnectionFrame) => void): unknown;
+  off(event: "message", listener: (data: GatewayConnectionFrame) => void): unknown;
+  off(event: "close", listener: (code: number, reason: Buffer) => void): unknown;
+  once(event: "message", listener: (data: GatewayConnectionFrame) => void): unknown;
+  once(event: "close", listener: (code: number, reason: Buffer) => void): unknown;
+};
+
+/** Validate receive limits before registration; activate them only after registration. */
+export type PrepareGatewayAuthenticatedReceive = (
+  role: GatewayRole,
+) => Result<() => void, { cause: string; message: string }>;

--- a/src/gateway/server/connection.test.ts
+++ b/src/gateway/server/connection.test.ts
@@ -1,0 +1,180 @@
+import { EventEmitter } from "node:events";
+import type { IncomingMessage } from "node:http";
+import { describe, expect, it, vi } from "vitest";
+import { GATEWAY_SERVER_CAPS } from "../../../packages/gateway-protocol/src/server-capabilities.js";
+import { PROTOCOL_VERSION } from "../../../packages/gateway-protocol/src/version.js";
+import { withOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
+import { GatewayConnectionWork } from "../server-connection-work.js";
+import type { GatewayConnectionTransport } from "./connection-transport.js";
+import { attachGatewayConnection } from "./connection.js";
+import {
+  createGatewayWsTestLogger,
+  createGatewayWsTestRequestContext,
+} from "./ws-connection.test-helpers.js";
+import type { GatewayWsClient } from "./ws-types.js";
+
+describe("Gateway connection transport", () => {
+  it.each(["written", "failed"] as const)(
+    "owns admission and cleanup without WebSocket internals (hello %s)",
+    async (delivery) => {
+      await withOpenClawTestState(
+        { label: "gateway-connection-transport", layout: "state-only" },
+        async () => {
+          const incoming = new EventEmitter();
+          const frames: Array<{
+            event?: string;
+            ok?: boolean;
+            payload?: { type?: string; capabilities?: string[] };
+          }> = [];
+          const clients = new Set<GatewayWsClient>();
+          const connectionWork = new GatewayConnectionWork();
+          let readyState = 1;
+          let finishHello: ((error?: Error) => void) | undefined;
+          const socket: GatewayConnectionTransport = {
+            get readyState() {
+              return readyState;
+            },
+            bufferedAmount: 0,
+            send: (encoded, callback) => {
+              const frame = JSON.parse(encoded);
+              frames.push(frame);
+              if (frame.payload?.type === "hello-ok") {
+                finishHello = callback;
+              } else {
+                callback?.();
+              }
+            },
+            close: (code = 1000, reason = "") => {
+              if (readyState === 3) {
+                return;
+              }
+              readyState = 3;
+              const pending = finishHello;
+              finishHello = undefined;
+              pending?.(new Error("transport closed"));
+              incoming.emit("close", code, Buffer.from(reason));
+            },
+            terminate: () => socket.close(1006),
+            on: incoming.on.bind(incoming),
+            off: incoming.off.bind(incoming),
+            once: incoming.once.bind(incoming),
+          };
+          const releasePreauth = vi.fn();
+          const refreshHealthSnapshot = vi.fn(async () => ({}) as never);
+          const activateReceive = vi.fn(() => expect(clients.size).toBe(1));
+          const requestContext = {
+            ...createGatewayWsTestRequestContext(),
+            terminalSessions: { handleDisconnect: vi.fn() },
+          };
+
+          attachGatewayConnection({
+            socket,
+            connectionKind: "gateway",
+            request: { headers: { host: "127.0.0.1:19001" } } as IncomingMessage,
+            ingressAttribution: {
+              kind: "direct-local",
+              clientIp: "127.0.0.1",
+              rateLimit: { subject: { key: "127.0.0.1" }, resetOnSuccess: true },
+            },
+            addresses: { remoteAddr: "127.0.0.1" },
+            releasePreauth,
+            clients,
+            connectionWork,
+            bootId: "transport-test-boot",
+            pluginNodeCapabilities: [],
+            originCheckMetrics: { hostHeaderFallbackAccepted: 0 },
+            prepareAuthenticatedReceive: () => {
+              expect(clients.size).toBe(0);
+              return { ok: true, value: activateReceive };
+            },
+            getResolvedAuth: () => ({
+              mode: "token",
+              token: "test-token",
+              allowTailscale: false,
+            }),
+            gatewayMethods: [],
+            events: [],
+            refreshHealthSnapshot,
+            logGateway: createGatewayWsTestLogger() as never,
+            logHealth: createGatewayWsTestLogger() as never,
+            logWsControl: createGatewayWsTestLogger() as never,
+            extraHandlers: {},
+            broadcast: vi.fn(),
+            buildRequestContext: () => requestContext as never,
+          });
+
+          try {
+            expect(frames[0]).toMatchObject({
+              event: "connect.challenge",
+              payload: {
+                capabilities: [GATEWAY_SERVER_CAPS.MODEL_CATALOG_SNAPSHOT],
+              },
+            });
+            const connect = (id: string) =>
+              Buffer.from(
+                JSON.stringify({
+                  type: "req",
+                  id,
+                  method: "connect",
+                  params: {
+                    minProtocol: PROTOCOL_VERSION,
+                    maxProtocol: PROTOCOL_VERSION,
+                    client: {
+                      id: "gateway-client",
+                      version: "dev",
+                      platform: "test",
+                      mode: "backend",
+                    },
+                    role: "operator",
+                    scopes: [],
+                    auth: { token: "test-token" },
+                  },
+                }),
+              );
+
+            incoming.emit("message", connect("connect-1"));
+            incoming.emit("message", connect("connect-2"));
+            await vi.waitFor(() => expect(finishHello).toBeTypeOf("function"));
+            expect(clients.size).toBe(1);
+            expect(activateReceive).toHaveBeenCalledOnce();
+            expect(releasePreauth).toHaveBeenCalledOnce();
+            expect(frames.filter((frame) => frame.payload?.type === "hello-ok")).toHaveLength(1);
+            expect(refreshHealthSnapshot).not.toHaveBeenCalled();
+
+            const client = [...clients][0]!;
+            expect(client.socket).toBe(socket);
+            expect(client.webSocket).toBeUndefined();
+            expect(client.connectionSignal?.aborted).toBe(false);
+            requestContext.unsubscribeAllSessionEvents.mockImplementation(() => {
+              expect(client.connectionSignal?.aborted).toBe(true);
+            });
+
+            const complete = finishHello!;
+            finishHello = undefined;
+            complete(delivery === "failed" ? new Error("write failed") : undefined);
+            if (delivery === "written") {
+              await vi.waitFor(() => expect(refreshHealthSnapshot).toHaveBeenCalledOnce());
+            }
+            await connectionWork.drain();
+
+            expect(clients.size).toBe(0);
+            expect(client.connectionSignal?.aborted).toBe(true);
+            expect(releasePreauth).toHaveBeenCalledOnce();
+            expect(requestContext.unsubscribeAllSessionEvents).toHaveBeenCalledExactlyOnceWith(
+              client.connId,
+            );
+            expect(
+              requestContext.terminalSessions.handleDisconnect,
+            ).toHaveBeenCalledExactlyOnceWith(client.connId);
+            if (delivery === "failed") {
+              expect(refreshHealthSnapshot).not.toHaveBeenCalled();
+            }
+          } finally {
+            socket.terminate();
+            await connectionWork.drain();
+          }
+        },
+      );
+    },
+  );
+});

--- a/src/gateway/server/connection.ts
+++ b/src/gateway/server/connection.ts
@@ -1,0 +1,657 @@
+// Shared Gateway connection owner: admission, registration, dispatch, and tracked cleanup.
+import { randomUUID } from "node:crypto";
+import type { IncomingMessage } from "node:http";
+import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
+import { GATEWAY_SERVER_CAPS } from "../../../packages/gateway-protocol/src/server-capabilities.js";
+import { GATEWAY_STARTUP_PENDING_CLOSE_CAUSE } from "../../../packages/gateway-protocol/src/startup-unavailable.js";
+import { getRuntimeConfig } from "../../config/io.js";
+import { recordPairedNodeDisconnection } from "../../infra/device-pairing-node.js";
+import { upsertPresence } from "../../infra/system-presence.js";
+import { logRejectedLargePayload } from "../../logging/diagnostic-payload.js";
+import type { createSubsystemLogger } from "../../logging/subsystem.js";
+import { removeRemoteNodeInfo } from "../../skills/runtime/remote.js";
+import { isWebchatClient } from "../../utils/message-channel.js";
+import type { AuthRateLimiter } from "../auth-rate-limit.js";
+import type { ResolvedGatewayAuth } from "../auth.js";
+import { resolvePreauthHandshakeTimeoutMs } from "../handshake-timeouts.js";
+import type { GatewayIngressAttribution } from "../ingress-attribution.js";
+import type { GatewayMethodRegistry } from "../methods/registry.js";
+import { isLoopbackAddress } from "../net.js";
+import type { NodeReapprovalCoordinator } from "../node-reapproval-coordinator.js";
+import { clearNodeWakeState } from "../node-wake-state.js";
+import {
+  indexPluginNodeCapabilitySurfaces,
+  reconcileClientPluginNodeCapabilities,
+  type PluginNodeCapabilitySurface,
+} from "../plugin-node-capability.js";
+import type { GatewayConnectionWork } from "../server-connection-work.js";
+import {
+  WEBSOCKET_CLOSE_GRACE_MS,
+  MAX_BUFFERED_BYTES,
+  WEBSOCKET_OPEN_READY_STATE,
+} from "../server-constants.js";
+import type { GatewayRequestContext, GatewayRequestHandlers } from "../server-methods/types.js";
+import { formatError } from "../server-utils.js";
+import { cleanupTalkConnection } from "../talk-session-registry.js";
+import type { WebSocketHeartbeatDiagnostics } from "../websocket-keepalive.js";
+import { formatForLog, logWs } from "../ws-log.js";
+import { refreshClientPresence } from "./client-presence.js";
+import type {
+  GatewayConnectionTransport,
+  PrepareGatewayAuthenticatedReceive,
+} from "./connection-transport.js";
+import { getHealthVersion, incrementPresenceVersion } from "./health-state.js";
+import { broadcastPresenceSnapshot } from "./presence-events.js";
+import { sanitizeWsLogValue, stringMetaValue } from "./ws-connection-diagnostics.js";
+import {
+  buildHandshakeAuthLogKey,
+  HandshakeAuthLogLimiter,
+  shouldLimitMissingCredentialAuthLog,
+} from "./ws-connection/handshake-auth-log-limiter.js";
+import { attachGatewayWsMessageHandlerOnDemand } from "./ws-connection/message-handler-loader.js";
+import type {
+  GatewayWsMessageHandlerParams,
+  WsOriginCheckMetrics,
+} from "./ws-connection/message-handler-types.js";
+import {
+  GatewayNodeLifecycleDispatchTracker,
+  NODE_LIFECYCLE_DISPATCH_DRAIN_TIMEOUT_MS,
+} from "./ws-connection/node-lifecycle-dispatch.js";
+import { resolveSharedGatewaySessionGeneration } from "./ws-shared-generation.js";
+import { WS_HANDSHAKE_PHASES, type GatewayWsClient, type WsHandshakePhase } from "./ws-types.js";
+
+type SubsystemLogger = ReturnType<typeof createSubsystemLogger>;
+const unauthorizedCloseBeforeConnectLogLimiter = new HandshakeAuthLogLimiter();
+export type GatewayConnectionOptions = {
+  bootId: string;
+  clients: Set<GatewayWsClient>;
+  connectionWork: GatewayConnectionWork;
+  getPluginNodeCapabilities?: () => PluginNodeCapabilitySurface[];
+  // Read per connection so reloads cannot leave a stale auth snapshot.
+  getResolvedAuth: () => ResolvedGatewayAuth;
+  getRequiredSharedGatewaySessionGeneration?: () => string | undefined;
+  rateLimiter?: AuthRateLimiter;
+  browserRateLimiter?: AuthRateLimiter;
+  nodeReapprovalCoordinator?: NodeReapprovalCoordinator;
+  preauthHandshakeTimeoutMs?: number;
+  isStartupPending?: () => boolean;
+  isPendingWorkerNodeSetup?: (setupId: string, deviceId: string) => boolean;
+  gatewayMethods: string[];
+  events: string[];
+  refreshHealthSnapshot: GatewayRequestContext["refreshHealthSnapshot"];
+  logGateway: SubsystemLogger;
+  logHealth: SubsystemLogger;
+  logWsControl: SubsystemLogger;
+  extraHandlers: GatewayRequestHandlers;
+  getMethodRegistry?: () => GatewayMethodRegistry;
+  broadcast: (
+    event: string,
+    payload: unknown,
+    opts?: {
+      dropIfSlow?: boolean;
+      stateVersion?: { presence?: number; health?: number };
+    },
+  ) => void;
+  buildRequestContext: () => GatewayRequestContext;
+};
+
+type GatewayConnectionLifecycle = Pick<
+  GatewayWsMessageHandlerParams,
+  | "connectionWork"
+  | "connId"
+  | "isStartupPending"
+  | "send"
+  | "close"
+  | "isClosed"
+  | "clearHandshakeTimer"
+  | "getClient"
+  | "setClient"
+  | "setHandshakeState"
+  | "advanceHandshakePhase"
+  | "setCloseCause"
+  | "setLastFrameMeta"
+  | "logGateway"
+  | "logWsControl"
+>;
+
+type AttachGatewayConnectionParams = GatewayConnectionOptions & {
+  socket: GatewayConnectionTransport;
+  connectionKind: NonNullable<GatewayWsClient["connectionKind"]>;
+  request: IncomingMessage;
+  ingressAttribution: GatewayIngressAttribution | undefined;
+  releasePreauth: () => void;
+  addresses: Pick<
+    GatewayWsMessageHandlerParams,
+    "remoteAddr" | "remotePort" | "localAddr" | "localPort" | "endpoint"
+  >;
+  pluginNodeCapabilities: PluginNodeCapabilitySurface[];
+  pluginSurfaceBaseUrl?: string;
+  originCheckMetrics: WsOriginCheckMetrics;
+  prepareAuthenticatedReceive: PrepareGatewayAuthenticatedReceive;
+  attachTransport?: (lifecycle: GatewayConnectionLifecycle) => (() => void) | void;
+  onAuthenticated?: (
+    client: GatewayWsClient,
+    onHeartbeatTimeout: (diagnostics: WebSocketHeartbeatDiagnostics) => void,
+  ) => () => void;
+};
+
+export function attachGatewayConnection(params: AttachGatewayConnectionParams) {
+  const {
+    socket,
+    connectionKind,
+    request: upgradeReq,
+    ingressAttribution,
+    pluginNodeCapabilities,
+    pluginSurfaceBaseUrl,
+    originCheckMetrics,
+    clients,
+    connectionWork,
+    getPluginNodeCapabilities,
+    getResolvedAuth,
+    getRequiredSharedGatewaySessionGeneration = () =>
+      resolveSharedGatewaySessionGeneration(
+        getResolvedAuth(),
+        getRuntimeConfig().gateway?.trustedProxies,
+      ),
+    rateLimiter,
+    browserRateLimiter,
+    nodeReapprovalCoordinator,
+    isStartupPending,
+    isPendingWorkerNodeSetup,
+    gatewayMethods,
+    events,
+    refreshHealthSnapshot,
+    logGateway,
+    logHealth,
+    logWsControl,
+    extraHandlers,
+    getMethodRegistry,
+    broadcast,
+    buildRequestContext,
+  } = params;
+  if (connectionWork.isClosing) {
+    socket.terminate();
+    return;
+  }
+  let client: GatewayWsClient | null = null,
+    closed = false;
+  const [openedAt, connId] = [Date.now(), randomUUID()];
+  const connectionController = new AbortController();
+  const { remoteAddr, remotePort, localAddr, localPort, endpoint } = params.addresses;
+  const headerValue = (value: string | string[] | undefined) =>
+    Array.isArray(value) ? value[0] : value;
+  const requestHost = headerValue(upgradeReq.headers.host);
+  const requestOrigin = headerValue(upgradeReq.headers.origin);
+  const requestUserAgent = headerValue(upgradeReq.headers["user-agent"]);
+  const forwardedFor = headerValue(upgradeReq.headers["x-forwarded-for"]);
+  const realIp = headerValue(upgradeReq.headers["x-real-ip"]);
+  const openedDuringStartup = isStartupPending?.() === true;
+
+  logWs("in", "open", { connId, remoteAddr, remotePort, localAddr, localPort, endpoint });
+  let handshakeState: "pending" | "connected" | "failed" = "pending";
+  let lastHandshakePhase: WsHandshakePhase = "tcp_accepted";
+  let holdsPreauthBudget = true;
+  let closeCause: string | undefined;
+  let heartbeatDiagnostics: WebSocketHeartbeatDiagnostics | undefined;
+  let closeMeta: Record<string, unknown> = {};
+  let lastFrameType: string | undefined;
+  let lastFrameMethod: string | undefined;
+  let lastFrameId: string | undefined;
+  let hasReceivedPreauthFrame = false;
+  const nodeLifecycleDispatch = new GatewayNodeLifecycleDispatchTracker();
+
+  socket.once("message", () => {
+    hasReceivedPreauthFrame = true;
+  });
+
+  const advanceHandshakePhase = (next: WsHandshakePhase) => {
+    if (WS_HANDSHAKE_PHASES.indexOf(next) > WS_HANDSHAKE_PHASES.indexOf(lastHandshakePhase)) {
+      lastHandshakePhase = next;
+    }
+  };
+
+  const setCloseCause = (cause: string, meta?: Record<string, unknown>) => {
+    if (!closeCause) {
+      closeCause = cause;
+    }
+    if (meta && Object.keys(meta).length > 0) {
+      closeMeta = { ...closeMeta, ...meta };
+    }
+  };
+
+  const releasePreauthBudget = () => {
+    if (!holdsPreauthBudget) {
+      return;
+    }
+    holdsPreauthBudget = false;
+    params.releasePreauth();
+  };
+
+  const setLastFrameMeta = (meta: { type?: string; method?: string; id?: string }) => {
+    if (meta.type || meta.method || meta.id) {
+      lastFrameType = meta.type ?? lastFrameType;
+      lastFrameMethod = meta.method ?? lastFrameMethod;
+      lastFrameId = meta.id ?? lastFrameId;
+    }
+  };
+
+  let stopKeepalive: (() => void) | undefined;
+  let cleanupTransport: (() => void) | void;
+  let retainClientUntilNodeDrain = false;
+  const handshakeTimeoutMs = resolvePreauthHandshakeTimeoutMs({
+    configuredTimeoutMs: params.preauthHandshakeTimeoutMs,
+  });
+  const handshakeTimer = setTimeout(() => {
+    if (!client) {
+      handshakeState = "failed";
+      setCloseCause("handshake-timeout", {
+        handshakeMs: Date.now() - openedAt,
+        endpoint,
+        phase: lastHandshakePhase,
+      });
+      logWsControl.warn(
+        `handshake timeout conn=${connId} peer=${endpoint ?? "n/a"} remote=${remoteAddr ?? "?"} phase=${lastHandshakePhase}`,
+      );
+      if (connectionKind === "worker") {
+        close(1008, "invalid-handshake");
+      } else {
+        close();
+      }
+    }
+  }, handshakeTimeoutMs);
+
+  const retireTransport = (code = 1000, reason?: string) => {
+    if (closed) {
+      return;
+    }
+    closed = true;
+    connectionController.abort();
+    clearTimeout(handshakeTimer);
+    stopKeepalive?.();
+    cleanupTransport?.();
+    cleanupTransport = undefined;
+    releasePreauthBudget();
+    try {
+      socket.close(code, reason);
+    } catch {
+      /* ignore */
+    }
+  };
+
+  const close = (code = 1000, reason?: string) => {
+    retainClientUntilNodeDrain ||=
+      !closed && client?.connect.role === "node" && nodeLifecycleDispatch.hasActive();
+    retireTransport(code, reason);
+    if (client && !retainClientUntilNodeDrain) {
+      clients.delete(client);
+    }
+  };
+
+  let shutdownTimer: ReturnType<typeof setTimeout> | undefined;
+  const releaseConnection = connectionWork.registerConnection(() => {
+    shutdownTimer = setTimeout(() => socket.terminate(), WEBSOCKET_CLOSE_GRACE_MS);
+    shutdownTimer.unref?.();
+    close(1012, connectionKind === "worker" ? "gateway-shutdown" : "service restart");
+  });
+
+  const send = (obj: unknown) => {
+    if (closed) {
+      return { kind: "unavailable" } as const;
+    }
+    if (socket.readyState !== WEBSOCKET_OPEN_READY_STATE) {
+      close();
+      return { kind: "unavailable" } as const;
+    }
+    if (socket.bufferedAmount > MAX_BUFFERED_BYTES) {
+      logRejectedLargePayload({
+        surface: "gateway.ws.outbound_buffer",
+        bytes: socket.bufferedAmount,
+        limitBytes: MAX_BUFFERED_BYTES,
+        reason: "ws_send_buffer_close",
+      });
+      setCloseCause("outbound-buffer-exceeded", {
+        bytes: socket.bufferedAmount,
+        limitBytes: MAX_BUFFERED_BYTES,
+      });
+      close(1008, connectionKind === "worker" ? "slow-consumer" : "slow consumer");
+      socket.terminate();
+      return { kind: "unavailable" } as const;
+    }
+    let encoded: string;
+    try {
+      encoded = JSON.stringify(obj);
+    } catch (error) {
+      return { kind: "serialization", error } as const;
+    }
+    try {
+      socket.send(encoded);
+      return { kind: "sent" } as const;
+    } catch {
+      socket.terminate();
+      close();
+      return { kind: "unavailable" } as const;
+    }
+  };
+
+  const connectNonce = randomUUID();
+  if (connectionKind === "gateway") {
+    send({
+      type: "event",
+      event: "connect.challenge",
+      payload: {
+        nonce: connectNonce,
+        ts: Date.now(),
+        capabilities: [GATEWAY_SERVER_CAPS.MODEL_CATALOG_SNAPSHOT],
+      },
+    });
+  }
+  advanceHandshakePhase("ws_upgrade_started");
+
+  const isNoisySwiftPmHelperClose = (userAgent: string | undefined, remote: string | undefined) =>
+    normalizeLowercaseStringOrEmpty(userAgent).includes("swiftpm-testing-helper") &&
+    isLoopbackAddress(remote);
+
+  const isExpectedLocalAppStartupAbort = (code: number) =>
+    openedDuringStartup &&
+    (code === 1001 || code === 1006) &&
+    lastHandshakePhase === "ws_upgrade_started" &&
+    !hasReceivedPreauthFrame &&
+    lastFrameType === undefined &&
+    normalizeLowercaseStringOrEmpty(requestUserAgent).startsWith("openclaw/") &&
+    isLoopbackAddress(remoteAddr);
+
+  const handleSocketClose = async (code: number, reason: Buffer) => {
+    const durationMs = Date.now() - openedAt;
+    // Only the typed heartbeat snapshot is safe for default connected-close logs.
+    const disconnectContext = { cause: closeCause, durationMs, ...heartbeatDiagnostics };
+    const logForwardedFor = sanitizeWsLogValue(forwardedFor);
+    const logOrigin = sanitizeWsLogValue(requestOrigin);
+    const logHost = sanitizeWsLogValue(requestHost);
+    const logUserAgent = sanitizeWsLogValue(requestUserAgent);
+    const logReason = sanitizeWsLogValue(reason?.toString());
+    const handshakeIncomplete = lastHandshakePhase !== "ready";
+    const closeContext = {
+      ...disconnectContext,
+      handshake: handshakeState,
+      ...(handshakeIncomplete ? { phase: lastHandshakePhase } : {}),
+      lastFrameType,
+      lastFrameMethod,
+      lastFrameId,
+      host: logHost,
+      origin: logOrigin,
+      userAgent: logUserAgent,
+      forwardedFor: logForwardedFor,
+      remoteAddr,
+      remotePort,
+      localAddr,
+      localPort,
+      endpoint,
+      ...closeMeta,
+    };
+    if (!client) {
+      const logFn =
+        isNoisySwiftPmHelperClose(requestUserAgent, remoteAddr) ||
+        closeCause === GATEWAY_STARTUP_PENDING_CLOSE_CAUSE ||
+        isExpectedLocalAppStartupAbort(code)
+          ? logWsControl.debug
+          : logWsControl.warn;
+      const authReason = stringMetaValue(closeMeta, "authReason");
+      // Only missing shared credentials are suppressible startup retry noise.
+      const shouldLimitMissingAuthClose =
+        closeCause === "unauthorized" &&
+        shouldLimitMissingCredentialAuthLog({
+          reason: authReason,
+          authProvided: "none",
+        });
+      const closeLogDecision = shouldLimitMissingAuthClose
+        ? unauthorizedCloseBeforeConnectLogLimiter.register(
+            buildHandshakeAuthLogKey({
+              reason: authReason,
+              remoteAddr,
+              client:
+                stringMetaValue(closeMeta, "clientDisplayName") ??
+                stringMetaValue(closeMeta, "client"),
+              mode: stringMetaValue(closeMeta, "mode"),
+              authProvided: "none",
+            }),
+          )
+        : { shouldLog: true, suppressedSinceLastLog: 0 };
+      if (closeLogDecision.shouldLog) {
+        const suppressedText =
+          closeLogDecision.suppressedSinceLastLog > 0
+            ? ` suppressed=${closeLogDecision.suppressedSinceLastLog}`
+            : "";
+        logFn(
+          `closed before connect conn=${connId} peer=${endpoint ?? "n/a"} remote=${remoteAddr ?? "?"} fwd=${logForwardedFor || "n/a"} origin=${logOrigin || "n/a"} host=${logHost || "n/a"} ua=${logUserAgent || "n/a"} code=${code ?? "n/a"} reason=${logReason || "n/a"} phase=${lastHandshakePhase}${suppressedText}`,
+          closeContext,
+        );
+      }
+    }
+    if (client && isWebchatClient(client.connect.client)) {
+      logWsControl.info(
+        `webchat disconnected code=${code} reason=${logReason || "n/a"} conn=${connId}`,
+        disconnectContext,
+      );
+    }
+    if (client?.authenticatedUserId) {
+      logWsControl.info(
+        `authenticated user disconnected code=${code} reason=${logReason || "n/a"} conn=${connId} user=${formatForLog(client.authenticatedUserId)}`,
+        disconnectContext,
+      );
+    }
+    if (connectionKind === "gateway") {
+      const context = buildRequestContext();
+      cleanupTalkConnection(connId, logGateway);
+      context.unsubscribeAllSessionEvents(connId);
+      // Detach or kill owned PTY shells; detached sessions remain reattachable until reaped.
+      context.terminalSessions?.handleDisconnect(connId);
+      let currentDisconnectedNodeId: string | null = null;
+      let disconnectedNodeHistory: Parameters<typeof recordPairedNodeDisconnection>[0] | undefined;
+      if (client?.connect?.role === "node") {
+        const nodeId = client.connect.device?.id ?? client.connect.client.id;
+        const nodeSession = context.nodeRegistry.get(nodeId);
+        if (nodeSession?.connId === connId && nodeSession.pairingGeneration) {
+          disconnectedNodeHistory = {
+            nodeId: nodeSession.nodeId,
+            connectedAtMs: nodeSession.connectedAtMs,
+            disconnectedAtMs: Date.now(),
+            expectedPairingGeneration: {
+              nodeId: nodeSession.nodeId,
+              key: nodeSession.pairingGeneration,
+            },
+          };
+        }
+        // Retire I/O now, but retain revocation until admitted lifecycle work drains.
+        retainClientUntilNodeDrain = true;
+        retireTransport();
+        try {
+          if (nodeLifecycleDispatch.hasActive()) {
+            const drained = await nodeLifecycleDispatch.drain();
+            if (!drained) {
+              logGateway.warn(
+                `node lifecycle dispatch drain timed out after ${NODE_LIFECYCLE_DISPATCH_DRAIN_TIMEOUT_MS}ms conn=${connId}`,
+              );
+            }
+          }
+          currentDisconnectedNodeId = context.nodeRegistry.unregister(connId);
+        } finally {
+          retainClientUntilNodeDrain = false;
+        }
+      }
+      // Retire node-owned projections before history persistence yields; a reconnect
+      // may own this node id by the time the write finishes.
+      if (
+        client?.presenceKey &&
+        (client.connect.role !== "node" || currentDisconnectedNodeId !== null)
+      ) {
+        upsertPresence(client.presenceKey, {
+          reason: "disconnect",
+          watchedSessions: undefined,
+        });
+        broadcastPresenceSnapshot({ broadcast, incrementPresenceVersion, getHealthVersion });
+      }
+      if (currentDisconnectedNodeId) {
+        removeRemoteNodeInfo(currentDisconnectedNodeId);
+        context.nodeUnsubscribeAll(currentDisconnectedNodeId);
+        clearNodeWakeState(currentDisconnectedNodeId);
+      }
+      if (disconnectedNodeHistory && currentDisconnectedNodeId === disconnectedNodeHistory.nodeId) {
+        try {
+          await recordPairedNodeDisconnection(disconnectedNodeHistory);
+        } catch (error) {
+          logGateway.warn(
+            `failed to record node disconnect for ${disconnectedNodeHistory.nodeId}: ${formatForLog(error)}`,
+          );
+        }
+      }
+    }
+    logWs("out", "close", {
+      connId,
+      code,
+      reason: logReason,
+      ...disconnectContext,
+      handshake: handshakeState,
+      ...(handshakeIncomplete ? { phase: lastHandshakePhase } : {}),
+      lastFrameType,
+      lastFrameMethod,
+      lastFrameId,
+      endpoint,
+    });
+    close();
+  };
+  socket.once("close", (code, reason) => {
+    // Delivery subscriptions end before asynchronous node drain or history cleanup.
+    connectionController.abort();
+    clearTimeout(shutdownTimer);
+    // ws removes its client synchronously; the Gateway retains this connection
+    // until asynchronous node history and other close cleanup have settled.
+    void connectionWork
+      .trackCleanup(() => handleSocketClose(code, reason))
+      .catch((error: unknown) => {
+        logGateway.error(`websocket close cleanup failed conn=${connId}: ${formatError(error)}`);
+        close();
+      })
+      .finally(releaseConnection);
+  });
+
+  const setClient = (next: GatewayWsClient) => {
+    // Keep one socket owner when concurrent connect frames finish out of order.
+    if (closed || client) {
+      return false;
+    }
+    if (
+      next.connect.role === "node" &&
+      !reconcileClientPluginNodeCapabilities(
+        next,
+        indexPluginNodeCapabilitySurfaces(getPluginNodeCapabilities?.() ?? []),
+        () => close(1012, "node capabilities changed"),
+      )
+    ) {
+      return false;
+    }
+    if (next.worker) {
+      for (const existing of clients) {
+        if (existing.worker?.environmentId === next.worker.environmentId) {
+          existing.invalidated = true;
+          clients.delete(existing);
+          try {
+            existing.socket.terminate();
+          } catch {
+            existing.socket.close(1008, "credential-replaced");
+          }
+        }
+      }
+    }
+    releasePreauthBudget();
+    next.connectionSignal = connectionController.signal;
+    client = next;
+    clients.add(next);
+    if (
+      next.presenceKey &&
+      (next.authenticatedUserId || next.authenticatedUserProfile) &&
+      next.connect.role !== "node"
+    ) {
+      next.personPresence = { onlineSince: Date.now() };
+      refreshClientPresence(clients, next);
+    }
+    stopKeepalive = params.onAuthenticated?.(next, (diagnostics) => {
+      // A half-open control connection must release its node and worker owners.
+      heartbeatDiagnostics = diagnostics;
+      setCloseCause("heartbeat-timeout");
+      try {
+        socket.terminate();
+      } catch {
+        close();
+      }
+    });
+    return true;
+  };
+
+  const connectionLifecycle = {
+    connectionWork,
+    connId,
+    isStartupPending,
+    send,
+    close,
+    isClosed: () => closed,
+    clearHandshakeTimer: () => clearTimeout(handshakeTimer),
+    getClient: () => client,
+    setClient,
+    setHandshakeState: (next: "pending" | "connected" | "failed") => {
+      handshakeState = next;
+    },
+    advanceHandshakePhase,
+    setCloseCause,
+    setLastFrameMeta,
+    logGateway,
+    logWsControl,
+  };
+  cleanupTransport = params.attachTransport?.(connectionLifecycle);
+  if (connectionKind === "worker") {
+    return;
+  }
+
+  if (!ingressAttribution || ingressAttribution.kind === "unattributable-proxy") {
+    setCloseCause("missing-ingress-attribution");
+    logWsControl.warn(`gateway websocket missing prepared ingress attribution conn=${connId}`);
+    close(1008, "gateway ingress attribution required");
+    return;
+  }
+
+  attachGatewayWsMessageHandlerOnDemand({
+    ...connectionLifecycle,
+    socket,
+    prepareAuthenticatedReceive: params.prepareAuthenticatedReceive,
+    upgradeReq,
+    ingressAttribution,
+    bootId: params.bootId,
+    remoteAddr,
+    remotePort,
+    localAddr,
+    localPort,
+    endpoint,
+    forwardedFor,
+    realIp,
+    requestHost,
+    requestOrigin,
+    requestUserAgent,
+    pluginSurfaceBaseUrl,
+    pluginNodeCapabilities,
+    connectNonce,
+    getResolvedAuth,
+    getRequiredSharedGatewaySessionGeneration,
+    rateLimiter,
+    browserRateLimiter,
+    nodeReapprovalCoordinator,
+    isPendingWorkerNodeSetup,
+    gatewayMethods,
+    events,
+    extraHandlers,
+    getMethodRegistry,
+    buildRequestContext,
+    nodeLifecycleDispatch,
+    refreshHealthSnapshot,
+    originCheckMetrics,
+    logHealth,
+  });
+}

--- a/src/gateway/server/ws-connection.ts
+++ b/src/gateway/server/ws-connection.ts
@@ -1,714 +1,124 @@
-// Gateway WebSocket connection handler owns pre-auth limits, handshake auth, presence, and message-handler attachment.
-import { randomUUID } from "node:crypto";
-import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
-import type { WebSocket, WebSocketServer } from "ws";
+// Physical WebSocket ingress adapts into the shared Gateway connection owner.
+import type { WebSocketServer } from "ws";
 import { WORKER_PROTOCOL_MAX_PAYLOAD_BYTES } from "../../../packages/gateway-protocol/src/index.js";
-import { GATEWAY_SERVER_CAPS } from "../../../packages/gateway-protocol/src/server-capabilities.js";
-import { GATEWAY_STARTUP_PENDING_CLOSE_CAUSE } from "../../../packages/gateway-protocol/src/startup-unavailable.js";
-import { getRuntimeConfig } from "../../config/io.js";
-import { recordPairedNodeDisconnection } from "../../infra/device-pairing-node.js";
-import { touchPresence, upsertPresence } from "../../infra/system-presence.js";
+import { touchPresence } from "../../infra/system-presence.js";
 import { logRejectedLargePayload } from "../../logging/diagnostic-payload.js";
-import type { createSubsystemLogger } from "../../logging/subsystem.js";
-import { removeRemoteNodeInfo } from "../../skills/runtime/remote.js";
-import { isWebchatClient } from "../../utils/message-channel.js";
-import type { AuthRateLimiter } from "../auth-rate-limit.js";
-import type { ResolvedGatewayAuth } from "../auth.js";
-import { resolvePreauthHandshakeTimeoutMs } from "../handshake-timeouts.js";
 import { resolveHostedPluginSurfaceUrl } from "../hosted-plugin-surface-url.js";
 import { readPreparedGatewayIngressAttribution } from "../ingress-attribution.js";
-import type { GatewayMethodRegistry } from "../methods/registry.js";
-import { isLoopbackAddress } from "../net.js";
-import type { NodeReapprovalCoordinator } from "../node-reapproval-coordinator.js";
-import { clearNodeWakeState } from "../node-wake-state.js";
-import {
-  indexPluginNodeCapabilitySurfaces,
-  reconcileClientPluginNodeCapabilities,
-  type PluginNodeCapabilitySurface,
-} from "../plugin-node-capability.js";
-import type { GatewayConnectionWork } from "../server-connection-work.js";
-import {
-  WEBSOCKET_CLOSE_GRACE_MS,
-  MAX_BUFFERED_BYTES,
-  MAX_PAYLOAD_BYTES,
-  MAX_PREAUTH_PAYLOAD_BYTES,
-  WEBSOCKET_OPEN_READY_STATE,
-} from "../server-constants.js";
-import type { GatewayRequestContext, GatewayRequestHandlers } from "../server-methods/types.js";
+import { MAX_PAYLOAD_BYTES, MAX_PREAUTH_PAYLOAD_BYTES } from "../server-constants.js";
 import { formatError } from "../server-utils.js";
-import { cleanupTalkConnection } from "../talk-session-registry.js";
-import {
-  startWebSocketKeepalive,
-  type WebSocketHeartbeatDiagnostics,
-} from "../websocket-keepalive.js";
-import { formatForLog, logWs } from "../ws-log.js";
-import { refreshClientPresence } from "./client-presence.js";
-import { getHealthVersion, incrementPresenceVersion } from "./health-state.js";
+import { startWebSocketKeepalive } from "../websocket-keepalive.js";
+import { attachGatewayConnection, type GatewayConnectionOptions } from "./connection.js";
 import type { PreauthConnectionBudget } from "./preauth-connection-budget.js";
-import { broadcastPresenceSnapshot } from "./presence-events.js";
 import { takePublicWorkerIngress } from "./public-worker-ingress-context.js";
-import {
-  isWsPayloadLimitError,
-  resolveSocketAddress,
-  sanitizeWsLogValue,
-  stringMetaValue,
-} from "./ws-connection-diagnostics.js";
-import {
-  buildHandshakeAuthLogKey,
-  HandshakeAuthLogLimiter,
-  shouldLimitMissingCredentialAuthLog,
-} from "./ws-connection/handshake-auth-log-limiter.js";
-import { attachGatewayWsMessageHandlerOnDemand } from "./ws-connection/message-handler-loader.js";
-import type { WsOriginCheckMetrics } from "./ws-connection/message-handler.js";
-import {
-  GatewayNodeLifecycleDispatchTracker,
-  NODE_LIFECYCLE_DISPATCH_DRAIN_TIMEOUT_MS,
-} from "./ws-connection/node-lifecycle-dispatch.js";
+import { isWsPayloadLimitError, resolveSocketAddress } from "./ws-connection-diagnostics.js";
+import type { WsOriginCheckMetrics } from "./ws-connection/message-handler-types.js";
 import {
   attachWorkerWsMessageHandler,
   type WorkerConnectionService,
 } from "./ws-connection/worker-connection.js";
-import { resolveSharedGatewaySessionGeneration } from "./ws-shared-generation.js";
+import { prepareGatewayReceiverHandoff } from "./ws-receiver.js";
 import {
   GATEWAY_WS_CONNECTION_KIND_PROPERTY,
   GATEWAY_WS_PREAUTH_BUDGET_PROPERTY,
-  WS_HANDSHAKE_PHASES,
   type GatewayIngressWebSocket,
-  type GatewayWsClient,
-  type WsHandshakePhase,
 } from "./ws-types.js";
 
-type SubsystemLogger = ReturnType<typeof createSubsystemLogger>;
-const unauthorizedCloseBeforeConnectLogLimiter = new HandshakeAuthLogLimiter();
-type GatewayWsSharedHandlerParams = {
-  bootId: string;
+export type AttachGatewayWsConnectionHandlerParams = GatewayConnectionOptions & {
   wss: WebSocketServer;
-  clients: Set<GatewayWsClient>;
-  connectionWork: GatewayConnectionWork;
   preauthConnectionBudget: PreauthConnectionBudget;
   port: number;
   gatewayHost?: string;
   pluginSurfaceScheme?: "http" | "https";
-  getPluginNodeCapabilities?: () => PluginNodeCapabilitySurface[];
-  // Read per connection so reloads cannot leave a stale auth snapshot.
-  getResolvedAuth: () => ResolvedGatewayAuth;
-  getRequiredSharedGatewaySessionGeneration?: () => string | undefined;
-  rateLimiter?: AuthRateLimiter;
-  browserRateLimiter?: AuthRateLimiter;
-  nodeReapprovalCoordinator?: NodeReapprovalCoordinator;
-  preauthHandshakeTimeoutMs?: number;
-  isStartupPending?: () => boolean;
-  isPendingWorkerNodeSetup?: (setupId: string, deviceId: string) => boolean;
-  gatewayMethods: string[];
-  events: string[];
-  refreshHealthSnapshot: GatewayRequestContext["refreshHealthSnapshot"];
-};
-
-export type AttachGatewayWsConnectionHandlerParams = GatewayWsSharedHandlerParams & {
-  logGateway: SubsystemLogger;
-  logHealth: SubsystemLogger;
-  logWsControl: SubsystemLogger;
-  extraHandlers: GatewayRequestHandlers;
-  getMethodRegistry?: () => GatewayMethodRegistry;
-  broadcast: (
-    event: string,
-    payload: unknown,
-    opts?: {
-      dropIfSlow?: boolean;
-      stateVersion?: { presence?: number; health?: number };
-    },
-  ) => void;
-  buildRequestContext: () => GatewayRequestContext;
   workerConnectionService?: WorkerConnectionService;
 };
 
 export function attachGatewayWsConnectionHandler(params: AttachGatewayWsConnectionHandlerParams) {
-  const {
-    wss,
-    clients,
-    connectionWork,
-    preauthConnectionBudget,
-    port,
-    pluginSurfaceScheme,
-    getPluginNodeCapabilities,
-    getResolvedAuth,
-    getRequiredSharedGatewaySessionGeneration = () =>
-      resolveSharedGatewaySessionGeneration(
-        getResolvedAuth(),
-        getRuntimeConfig().gateway?.trustedProxies,
-      ),
-    rateLimiter,
-    browserRateLimiter,
-    nodeReapprovalCoordinator,
-    isStartupPending,
-    isPendingWorkerNodeSetup,
-    gatewayMethods,
-    events,
-    refreshHealthSnapshot,
-    logGateway,
-    logHealth,
-    logWsControl,
-    extraHandlers,
-    getMethodRegistry,
-    broadcast,
-    buildRequestContext,
-    workerConnectionService,
-  } = params;
   const originCheckMetrics: WsOriginCheckMetrics = { hostHeaderFallbackAccepted: 0 };
-  wss.on("connection", (socket, upgradeReq) => {
-    if (connectionWork.isClosing) {
+  params.wss.on("connection", (socket, upgradeReq) => {
+    if (params.connectionWork.isClosing) {
       socket.terminate();
       return;
     }
-    let client: GatewayWsClient | null = null,
-      closed = false;
-    const [openedAt, connId] = [Date.now(), randomUUID()];
-    const connectionController = new AbortController();
     const ingressSocket = socket as GatewayIngressWebSocket;
     const connectionKind = ingressSocket[GATEWAY_WS_CONNECTION_KIND_PROPERTY] ?? "gateway";
     const publicWorkerIngress =
       connectionKind === "worker" ? takePublicWorkerIngress(socket) : undefined;
-    const connectionPreauthBudget =
-      ingressSocket[GATEWAY_WS_PREAUTH_BUDGET_PROPERTY] ?? preauthConnectionBudget;
-    const { remoteAddr, remotePort, localAddr, localPort, endpoint } = resolveSocketAddress(socket);
-    const preauthBudgetKey = (
-      socket as WebSocket & {
-        __openclawPreauthBudgetClaimed?: boolean;
-        __openclawPreauthBudgetKey?: string;
-      }
-    )["__openclawPreauthBudgetKey"];
-    (
-      socket as WebSocket & {
-        __openclawPreauthBudgetClaimed?: boolean;
-      }
-    )["__openclawPreauthBudgetClaimed"] = true;
-    const headerValue = (value: string | string[] | undefined) =>
-      Array.isArray(value) ? value[0] : value;
-    const requestHost = headerValue(upgradeReq.headers.host);
-    const requestOrigin = headerValue(upgradeReq.headers.origin);
-    const requestUserAgent = headerValue(upgradeReq.headers["user-agent"]);
-    const forwardedFor = headerValue(upgradeReq.headers["x-forwarded-for"]);
-    const realIp = headerValue(upgradeReq.headers["x-real-ip"]);
-    const openedDuringStartup = isStartupPending?.() === true;
+    const preauthBudget =
+      ingressSocket[GATEWAY_WS_PREAUTH_BUDGET_PROPERTY] ?? params.preauthConnectionBudget;
+    const preauthBudgetKey = ingressSocket["__openclawPreauthBudgetKey"];
+    ingressSocket["__openclawPreauthBudgetClaimed"] = true;
+    const addresses = resolveSocketAddress(socket);
     const pluginNodeCapabilities =
-      connectionKind === "gateway" ? (getPluginNodeCapabilities?.() ?? []) : [];
+      connectionKind === "gateway" ? (params.getPluginNodeCapabilities?.() ?? []) : [];
     const pluginSurfaceBaseUrl =
       pluginNodeCapabilities.length > 0
         ? resolveHostedPluginSurfaceUrl({
-            port,
+            port: params.port,
             forwardedHost: upgradeReq.headers["x-forwarded-host"],
             requestHost: upgradeReq.headers.host,
             forwardedProto: upgradeReq.headers["x-forwarded-proto"],
             localAddress: upgradeReq.socket?.localAddress,
-            scheme: pluginSurfaceScheme,
+            scheme: params.pluginSurfaceScheme,
           })
         : undefined;
 
-    logWs("in", "open", { connId, remoteAddr, remotePort, localAddr, localPort, endpoint });
-    let handshakeState: "pending" | "connected" | "failed" = "pending";
-    let lastHandshakePhase: WsHandshakePhase = "tcp_accepted";
-    let holdsPreauthBudget = true;
-    let closeCause: string | undefined;
-    let heartbeatDiagnostics: WebSocketHeartbeatDiagnostics | undefined;
-    let closeMeta: Record<string, unknown> = {};
-    let lastFrameType: string | undefined;
-    let lastFrameMethod: string | undefined;
-    let lastFrameId: string | undefined;
-    let hasReceivedPreauthFrame = false;
-    const nodeLifecycleDispatch = new GatewayNodeLifecycleDispatchTracker();
-
-    socket.once("message", () => {
-      hasReceivedPreauthFrame = true;
-    });
-
-    const advanceHandshakePhase = (next: WsHandshakePhase) => {
-      if (WS_HANDSHAKE_PHASES.indexOf(next) > WS_HANDSHAKE_PHASES.indexOf(lastHandshakePhase)) {
-        lastHandshakePhase = next;
-      }
-    };
-
-    const setCloseCause = (cause: string, meta?: Record<string, unknown>) => {
-      if (!closeCause) {
-        closeCause = cause;
-      }
-      if (meta && Object.keys(meta).length > 0) {
-        closeMeta = { ...closeMeta, ...meta };
-      }
-    };
-
-    const releasePreauthBudget = () => {
-      if (!holdsPreauthBudget) {
-        return;
-      }
-      holdsPreauthBudget = false;
-      connectionPreauthBudget.release(preauthBudgetKey);
-    };
-
-    const setLastFrameMeta = (meta: { type?: string; method?: string; id?: string }) => {
-      if (meta.type || meta.method || meta.id) {
-        lastFrameType = meta.type ?? lastFrameType;
-        lastFrameMethod = meta.method ?? lastFrameMethod;
-        lastFrameId = meta.id ?? lastFrameId;
-      }
-    };
-
-    let stopKeepalive: (() => void) | undefined;
-    let cleanupWorkerConnection: (() => void) | undefined;
-    let retainClientUntilNodeDrain = false;
-    const handshakeTimeoutMs = resolvePreauthHandshakeTimeoutMs({
-      configuredTimeoutMs: params.preauthHandshakeTimeoutMs,
-    });
-    const handshakeTimer = setTimeout(() => {
-      if (!client) {
-        handshakeState = "failed";
-        setCloseCause("handshake-timeout", {
-          handshakeMs: Date.now() - openedAt,
-          endpoint,
-          phase: lastHandshakePhase,
-        });
-        logWsControl.warn(
-          `handshake timeout conn=${connId} peer=${endpoint ?? "n/a"} remote=${remoteAddr ?? "?"} phase=${lastHandshakePhase}`,
-        );
-        if (connectionKind === "worker") {
-          close(1008, "invalid-handshake");
-        } else {
-          close();
-        }
-      }
-    }, handshakeTimeoutMs);
-
-    const retireTransport = (code = 1000, reason?: string) => {
-      if (closed) {
-        return;
-      }
-      closed = true;
-      connectionController.abort();
-      clearTimeout(handshakeTimer);
-      stopKeepalive?.();
-      cleanupWorkerConnection?.();
-      releasePreauthBudget();
-      try {
-        socket.close(code, reason);
-      } catch {
-        /* ignore */
-      }
-    };
-
-    const close = (code = 1000, reason?: string) => {
-      retainClientUntilNodeDrain ||=
-        !closed && client?.connect.role === "node" && nodeLifecycleDispatch.hasActive();
-      retireTransport(code, reason);
-      if (client && !retainClientUntilNodeDrain) {
-        clients.delete(client);
-      }
-    };
-
-    let shutdownTimer: ReturnType<typeof setTimeout> | undefined;
-    const releaseConnection = connectionWork.registerConnection(() => {
-      shutdownTimer = setTimeout(() => socket.terminate(), WEBSOCKET_CLOSE_GRACE_MS);
-      shutdownTimer.unref?.();
-      close(1012, connectionKind === "worker" ? "gateway-shutdown" : "service restart");
-    });
-
-    const send = (obj: unknown) => {
-      if (closed) {
-        return { kind: "unavailable" } as const;
-      }
-      if (socket.readyState !== WEBSOCKET_OPEN_READY_STATE) {
-        close();
-        return { kind: "unavailable" } as const;
-      }
-      if (socket.bufferedAmount > MAX_BUFFERED_BYTES) {
-        logRejectedLargePayload({
-          surface: "gateway.ws.outbound_buffer",
-          bytes: socket.bufferedAmount,
-          limitBytes: MAX_BUFFERED_BYTES,
-          reason: "ws_send_buffer_close",
-        });
-        setCloseCause("outbound-buffer-exceeded", {
-          bytes: socket.bufferedAmount,
-          limitBytes: MAX_BUFFERED_BYTES,
-        });
-        close(1008, connectionKind === "worker" ? "slow-consumer" : "slow consumer");
-        socket.terminate();
-        return { kind: "unavailable" } as const;
-      }
-      let encoded: string;
-      try {
-        encoded = JSON.stringify(obj);
-      } catch (error) {
-        return { kind: "serialization", error } as const;
-      }
-      try {
-        socket.send(encoded);
-        return { kind: "sent" } as const;
-      } catch {
-        socket.terminate();
-        close();
-        return { kind: "unavailable" } as const;
-      }
-    };
-
-    const connectNonce = randomUUID();
-    if (connectionKind === "gateway") {
-      send({
-        type: "event",
-        event: "connect.challenge",
-        payload: {
-          nonce: connectNonce,
-          ts: Date.now(),
-          capabilities: [GATEWAY_SERVER_CAPS.MODEL_CATALOG_SNAPSHOT],
-        },
-      });
-    }
-    advanceHandshakePhase("ws_upgrade_started");
-
-    socket.once("error", (err) => {
-      if (isWsPayloadLimitError(err)) {
-        logRejectedLargePayload({
-          surface: client ? "gateway.ws.frame" : "gateway.ws.preauth",
-          limitBytes:
-            connectionKind === "worker"
-              ? WORKER_PROTOCOL_MAX_PAYLOAD_BYTES
-              : client
-                ? MAX_PAYLOAD_BYTES
-                : MAX_PREAUTH_PAYLOAD_BYTES,
-          reason: client ? "ws_frame_limit" : "preauth_frame_limit",
-        });
-      }
-      logWsControl.warn(`error conn=${connId} remote=${remoteAddr ?? "?"}: ${formatError(err)}`);
-      if (connectionKind === "worker") {
-        close(1008, client ? "invalid-frame" : "invalid-handshake");
-      } else {
-        close();
-      }
-    });
-
-    socket.on("pong", () => {
-      if (client?.presenceKey) {
-        touchPresence(client.presenceKey);
-      }
-    });
-
-    const isNoisySwiftPmHelperClose = (userAgent: string | undefined, remote: string | undefined) =>
-      normalizeLowercaseStringOrEmpty(userAgent).includes("swiftpm-testing-helper") &&
-      isLoopbackAddress(remote);
-
-    const isExpectedLocalAppStartupAbort = (code: number) =>
-      openedDuringStartup &&
-      (code === 1001 || code === 1006) &&
-      lastHandshakePhase === "ws_upgrade_started" &&
-      !hasReceivedPreauthFrame &&
-      lastFrameType === undefined &&
-      normalizeLowercaseStringOrEmpty(requestUserAgent).startsWith("openclaw/") &&
-      isLoopbackAddress(remoteAddr);
-
-    const handleSocketClose = async (code: number, reason: Buffer) => {
-      const durationMs = Date.now() - openedAt;
-      // Only the typed heartbeat snapshot is safe for default connected-close logs.
-      const disconnectContext = { cause: closeCause, durationMs, ...heartbeatDiagnostics };
-      const logForwardedFor = sanitizeWsLogValue(forwardedFor);
-      const logOrigin = sanitizeWsLogValue(requestOrigin);
-      const logHost = sanitizeWsLogValue(requestHost);
-      const logUserAgent = sanitizeWsLogValue(requestUserAgent);
-      const logReason = sanitizeWsLogValue(reason?.toString());
-      const handshakeIncomplete = lastHandshakePhase !== "ready";
-      const closeContext = {
-        ...disconnectContext,
-        handshake: handshakeState,
-        ...(handshakeIncomplete ? { phase: lastHandshakePhase } : {}),
-        lastFrameType,
-        lastFrameMethod,
-        lastFrameId,
-        host: logHost,
-        origin: logOrigin,
-        userAgent: logUserAgent,
-        forwardedFor: logForwardedFor,
-        remoteAddr,
-        remotePort,
-        localAddr,
-        localPort,
-        endpoint,
-        ...closeMeta,
-      };
-      if (!client) {
-        const logFn =
-          isNoisySwiftPmHelperClose(requestUserAgent, remoteAddr) ||
-          closeCause === GATEWAY_STARTUP_PENDING_CLOSE_CAUSE ||
-          isExpectedLocalAppStartupAbort(code)
-            ? logWsControl.debug
-            : logWsControl.warn;
-        const authReason = stringMetaValue(closeMeta, "authReason");
-        // Only missing shared credentials are suppressible startup retry noise.
-        const shouldLimitMissingAuthClose =
-          closeCause === "unauthorized" &&
-          shouldLimitMissingCredentialAuthLog({
-            reason: authReason,
-            authProvided: "none",
-          });
-        const closeLogDecision = shouldLimitMissingAuthClose
-          ? unauthorizedCloseBeforeConnectLogLimiter.register(
-              buildHandshakeAuthLogKey({
-                reason: authReason,
-                remoteAddr,
-                client:
-                  stringMetaValue(closeMeta, "clientDisplayName") ??
-                  stringMetaValue(closeMeta, "client"),
-                mode: stringMetaValue(closeMeta, "mode"),
-                authProvided: "none",
-              }),
-            )
-          : { shouldLog: true, suppressedSinceLastLog: 0 };
-        if (closeLogDecision.shouldLog) {
-          const suppressedText =
-            closeLogDecision.suppressedSinceLastLog > 0
-              ? ` suppressed=${closeLogDecision.suppressedSinceLastLog}`
-              : "";
-          logFn(
-            `closed before connect conn=${connId} peer=${endpoint ?? "n/a"} remote=${remoteAddr ?? "?"} fwd=${logForwardedFor || "n/a"} origin=${logOrigin || "n/a"} host=${logHost || "n/a"} ua=${logUserAgent || "n/a"} code=${code ?? "n/a"} reason=${logReason || "n/a"} phase=${lastHandshakePhase}${suppressedText}`,
-            closeContext,
-          );
-        }
-      }
-      if (client && isWebchatClient(client.connect.client)) {
-        logWsControl.info(
-          `webchat disconnected code=${code} reason=${logReason || "n/a"} conn=${connId}`,
-          disconnectContext,
-        );
-      }
-      if (client?.authenticatedUserId) {
-        logWsControl.info(
-          `authenticated user disconnected code=${code} reason=${logReason || "n/a"} conn=${connId} user=${formatForLog(client.authenticatedUserId)}`,
-          disconnectContext,
-        );
-      }
-      if (connectionKind === "gateway") {
-        const context = buildRequestContext();
-        cleanupTalkConnection(connId, logGateway);
-        context.unsubscribeAllSessionEvents(connId);
-        // Detach or kill owned PTY shells; detached sessions remain reattachable until reaped.
-        context.terminalSessions?.handleDisconnect(connId);
-        let currentDisconnectedNodeId: string | null = null;
-        let disconnectedNodeHistory:
-          | Parameters<typeof recordPairedNodeDisconnection>[0]
-          | undefined;
-        if (client?.connect?.role === "node") {
-          const nodeId = client.connect.device?.id ?? client.connect.client.id;
-          const nodeSession = context.nodeRegistry.get(nodeId);
-          if (nodeSession?.connId === connId && nodeSession.pairingGeneration) {
-            disconnectedNodeHistory = {
-              nodeId: nodeSession.nodeId,
-              connectedAtMs: nodeSession.connectedAtMs,
-              disconnectedAtMs: Date.now(),
-              expectedPairingGeneration: {
-                nodeId: nodeSession.nodeId,
-                key: nodeSession.pairingGeneration,
-              },
-            };
-          }
-          // Retire I/O now, but retain revocation until admitted lifecycle work drains.
-          retainClientUntilNodeDrain = true;
-          retireTransport();
-          try {
-            if (nodeLifecycleDispatch.hasActive()) {
-              const drained = await nodeLifecycleDispatch.drain();
-              if (!drained) {
-                logGateway.warn(
-                  `node lifecycle dispatch drain timed out after ${NODE_LIFECYCLE_DISPATCH_DRAIN_TIMEOUT_MS}ms conn=${connId}`,
-                );
-              }
-            }
-            currentDisconnectedNodeId = context.nodeRegistry.unregister(connId);
-          } finally {
-            retainClientUntilNodeDrain = false;
-          }
-        }
-        // Retire node-owned projections before history persistence yields; a reconnect
-        // may own this node id by the time the write finishes.
-        if (
-          client?.presenceKey &&
-          (client.connect.role !== "node" || currentDisconnectedNodeId !== null)
-        ) {
-          upsertPresence(client.presenceKey, {
-            reason: "disconnect",
-            watchedSessions: undefined,
-          });
-          broadcastPresenceSnapshot({ broadcast, incrementPresenceVersion, getHealthVersion });
-        }
-        if (currentDisconnectedNodeId) {
-          removeRemoteNodeInfo(currentDisconnectedNodeId);
-          context.nodeUnsubscribeAll(currentDisconnectedNodeId);
-          clearNodeWakeState(currentDisconnectedNodeId);
-        }
-        if (
-          disconnectedNodeHistory &&
-          currentDisconnectedNodeId === disconnectedNodeHistory.nodeId
-        ) {
-          try {
-            await recordPairedNodeDisconnection(disconnectedNodeHistory);
-          } catch (error) {
-            logGateway.warn(
-              `failed to record node disconnect for ${disconnectedNodeHistory.nodeId}: ${formatForLog(error)}`,
-            );
-          }
-        }
-      }
-      logWs("out", "close", {
-        connId,
-        code,
-        reason: logReason,
-        ...disconnectContext,
-        handshake: handshakeState,
-        ...(handshakeIncomplete ? { phase: lastHandshakePhase } : {}),
-        lastFrameType,
-        lastFrameMethod,
-        lastFrameId,
-        endpoint,
-      });
-      close();
-    };
-    socket.once("close", (code, reason) => {
-      // Delivery subscriptions end before asynchronous node drain or history cleanup.
-      connectionController.abort();
-      clearTimeout(shutdownTimer);
-      // ws removes its client synchronously; the Gateway retains this connection
-      // until asynchronous node history and other close cleanup have settled.
-      void connectionWork
-        .trackCleanup(() => handleSocketClose(code, reason))
-        .catch((error: unknown) => {
-          logGateway.error(`websocket close cleanup failed conn=${connId}: ${formatError(error)}`);
-          close();
-        })
-        .finally(releaseConnection);
-    });
-
-    const setClient = (next: GatewayWsClient) => {
-      // Keep one socket owner when concurrent connect frames finish out of order.
-      if (closed || client) {
-        return false;
-      }
-      if (
-        next.connect.role === "node" &&
-        !reconcileClientPluginNodeCapabilities(
-          next,
-          indexPluginNodeCapabilitySurfaces(getPluginNodeCapabilities?.() ?? []),
-          () => close(1012, "node capabilities changed"),
-        )
-      ) {
-        return false;
-      }
-      if (next.worker) {
-        for (const existing of clients) {
-          if (existing.worker?.environmentId === next.worker.environmentId) {
-            existing.invalidated = true;
-            clients.delete(existing);
-            try {
-              existing.socket.terminate();
-            } catch {
-              existing.socket.close(1008, "credential-replaced");
-            }
-          }
-        }
-      }
-      releasePreauthBudget();
-      next.connectionSignal = connectionController.signal;
-      client = next;
-      clients.add(next);
-      if (
-        next.presenceKey &&
-        (next.authenticatedUserId || next.authenticatedUserProfile) &&
-        next.connect.role !== "node"
-      ) {
-        next.personPresence = { onlineSince: Date.now() };
-        refreshClientPresence(clients, next);
-      }
-      stopKeepalive = startWebSocketKeepalive(
-        socket,
-        (diagnostics) => {
-          // A half-open control connection must release its node and worker owners.
-          heartbeatDiagnostics = diagnostics;
-          setCloseCause("heartbeat-timeout");
-          try {
-            socket.terminate();
-          } catch {
-            close();
-          }
-        },
-        upgradeReq.socket,
-      );
-      return true;
-    };
-
-    const connectionLifecycle = {
+    attachGatewayConnection({
+      ...params,
       socket,
-      connectionWork,
-      connId,
-      isStartupPending,
-      send,
-      close,
-      isClosed: () => closed,
-      clearHandshakeTimer: () => clearTimeout(handshakeTimer),
-      getClient: () => client,
-      setClient,
-      setHandshakeState: (next: "pending" | "connected" | "failed") => {
-        handshakeState = next;
-      },
-      advanceHandshakePhase,
-      setCloseCause,
-      setLastFrameMeta,
-      logGateway,
-      logWsControl,
-    };
-    if (connectionKind === "worker") {
-      cleanupWorkerConnection = attachWorkerWsMessageHandler({
-        ...connectionLifecycle,
-        service: workerConnectionService,
-        publicAdmission: publicWorkerIngress,
-      });
-      return;
-    }
-
-    const ingressAttribution = readPreparedGatewayIngressAttribution(upgradeReq);
-    if (!ingressAttribution || ingressAttribution.kind === "unattributable-proxy") {
-      setCloseCause("missing-ingress-attribution");
-      logWsControl.warn(`gateway websocket missing prepared ingress attribution conn=${connId}`);
-      close(1008, "gateway ingress attribution required");
-      return;
-    }
-
-    attachGatewayWsMessageHandlerOnDemand({
-      ...connectionLifecycle,
-      upgradeReq,
-      ingressAttribution,
-      bootId: params.bootId,
-      remoteAddr,
-      remotePort,
-      localAddr,
-      localPort,
-      endpoint,
-      forwardedFor,
-      realIp,
-      requestHost,
-      requestOrigin,
-      requestUserAgent,
-      pluginSurfaceBaseUrl,
+      connectionKind,
+      request: upgradeReq,
+      ingressAttribution: readPreparedGatewayIngressAttribution(upgradeReq),
+      releasePreauth: () => preauthBudget.release(preauthBudgetKey),
+      addresses,
       pluginNodeCapabilities,
-      connectNonce,
-      getResolvedAuth,
-      getRequiredSharedGatewaySessionGeneration,
-      rateLimiter,
-      browserRateLimiter,
-      nodeReapprovalCoordinator,
-      isPendingWorkerNodeSetup,
-      gatewayMethods,
-      events,
-      extraHandlers,
-      getMethodRegistry,
-      buildRequestContext,
-      nodeLifecycleDispatch,
-      refreshHealthSnapshot,
+      pluginSurfaceBaseUrl,
       originCheckMetrics,
-      logHealth,
+      prepareAuthenticatedReceive: (role) => prepareGatewayReceiverHandoff(socket, role),
+      onAuthenticated: (client, onHeartbeatTimeout) => {
+        client.webSocket = socket;
+        return startWebSocketKeepalive(socket, onHeartbeatTimeout, upgradeReq.socket);
+      },
+      attachTransport: (lifecycle) => {
+        socket.once("error", (err) => {
+          const client = lifecycle.getClient();
+          if (isWsPayloadLimitError(err)) {
+            logRejectedLargePayload({
+              surface: client ? "gateway.ws.frame" : "gateway.ws.preauth",
+              limitBytes:
+                connectionKind === "worker"
+                  ? WORKER_PROTOCOL_MAX_PAYLOAD_BYTES
+                  : client
+                    ? MAX_PAYLOAD_BYTES
+                    : MAX_PREAUTH_PAYLOAD_BYTES,
+              reason: client ? "ws_frame_limit" : "preauth_frame_limit",
+            });
+          }
+          params.logWsControl.warn(
+            `error conn=${lifecycle.connId} remote=${addresses.remoteAddr ?? "?"}: ${formatError(err)}`,
+          );
+          if (connectionKind === "worker") {
+            lifecycle.close(1008, client ? "invalid-frame" : "invalid-handshake");
+          } else {
+            lifecycle.close();
+          }
+        });
+        socket.on("pong", () => {
+          const client = lifecycle.getClient();
+          if (client?.presenceKey) {
+            touchPresence(client.presenceKey);
+          }
+        });
+        if (connectionKind === "worker") {
+          return attachWorkerWsMessageHandler({
+            ...lifecycle,
+            socket,
+            service: params.workerConnectionService,
+            publicAdmission: publicWorkerIngress,
+          });
+        }
+        return undefined;
+      },
     });
   });
 }

--- a/src/gateway/server/ws-connection/connect-device-proof.ts
+++ b/src/gateway/server/ws-connection/connect-device-proof.ts
@@ -6,7 +6,7 @@ import {
   normalizeDevicePublicKeyBase64Url,
 } from "../../../infra/device-identity.js";
 import type { GatewayAuthResult, ResolvedGatewayAuth } from "../../auth.js";
-import type { GatewayRole } from "../../role-policy.js";
+import type { GatewayRole } from "../../role-policy.types.js";
 import { emitGatewayAuthSecurityEvent } from "./connect-auth-security.js";
 import { resolveDeviceSignaturePayloadVersion } from "./handshake-auth-helpers.js";
 import type { GatewayConnectPhaseContext } from "./message-handler-types.js";

--- a/src/gateway/server/ws-connection/connect-policy.ts
+++ b/src/gateway/server/ws-connection/connect-policy.ts
@@ -1,7 +1,7 @@
 // WebSocket connect policy resolves Control UI pairing bypasses and missing-device identity decisions.
 import type { ConnectParams } from "../../../../packages/gateway-protocol/src/index.js";
-import type { GatewayRole } from "../../role-policy.js";
 import { roleCanSkipDeviceIdentity } from "../../role-policy.js";
+import type { GatewayRole } from "../../role-policy.types.js";
 
 export type ControlUiPairingKind = "tailscale-device" | "auth-none" | null;
 

--- a/src/gateway/server/ws-connection/connect-session.ts
+++ b/src/gateway/server/ws-connection/connect-session.ts
@@ -63,7 +63,6 @@ import type {
   DeviceAuthorizedGatewayConnect,
   GatewayConnectPhaseContext,
 } from "./message-handler-types.js";
-import { prepareGatewayReceiverHandoff } from "./request-start.js";
 
 /** Match production release versions (YYYY.M.PATCH or YYYY.M.PATCH-beta.N). */
 const RELEASED_VERSION_RE = /^\d{4}\.\d+\.\d+/;
@@ -538,10 +537,10 @@ export async function attachAuthenticatedGatewayConnect(
     }
     return;
   }
-  const handoffReceiver = prepareGatewayReceiverHandoff(socket, role);
-  if (!handoffReceiver) {
-    const message = "unsupported Gateway WebSocket receiver";
-    markHandshakeFailure("unsupported-websocket-receiver", {});
+  const handoffReceiver = context.handler.prepareAuthenticatedReceive(role);
+  if (!handoffReceiver.ok) {
+    const { cause, message } = handoffReceiver.error;
+    markHandshakeFailure(cause, {});
     sendHandshakeErrorResponse(ErrorCodes.UNAVAILABLE, message);
     await releasePendingNodePairingCleanup();
     close(1011, message);
@@ -557,7 +556,7 @@ export async function attachAuthenticatedGatewayConnect(
   }
   // Only registered operators use bounded router starts. Node lifecycle traffic,
   // workers and preauth retain native yielding and their existing queue/drain rules.
-  handoffReceiver();
+  handoffReceiver.value();
   setHandshakeState("connected");
   advanceHandshakePhase("session_attached");
   logWs("in", "connect", {

--- a/src/gateway/server/ws-connection/message-handler-loader.ts
+++ b/src/gateway/server/ws-connection/message-handler-loader.ts
@@ -1,14 +1,14 @@
-import type { RawData } from "ws";
 import { formatError } from "../../server-utils.js";
 import {
   classifyGatewayStaleInstall,
   GATEWAY_STALE_INSTALL_CLOSE_REASON,
 } from "../../stale-install.js";
+import type { GatewayConnectionFrame } from "../connection-transport.js";
 import type { GatewayWsMessageHandlerParams } from "./message-handler-types.js";
 
 export function attachGatewayWsMessageHandlerOnDemand(params: GatewayWsMessageHandlerParams): void {
-  const queued: RawData[] = [];
-  const queueMessage = (data: RawData) => {
+  const queued: GatewayConnectionFrame[] = [];
+  const queueMessage = (data: GatewayConnectionFrame) => {
     if (queued.length >= 16) {
       params.setCloseCause("message-handler-loading-overflow", { queuedFrames: queued.length });
       params.close(1008, "gateway message handler loading");
@@ -24,9 +24,9 @@ export function attachGatewayWsMessageHandlerOnDemand(params: GatewayWsMessageHa
       if (params.isClosed() || params.connectionWork.isClosing) {
         return;
       }
-      attachGatewayWsMessageHandler(params);
+      const receive = attachGatewayWsMessageHandler(params);
       for (const data of queued) {
-        params.socket.emit("message", data);
+        receive(data);
       }
     })
     .catch((error: unknown) => {

--- a/src/gateway/server/ws-connection/message-handler-types.ts
+++ b/src/gateway/server/ws-connection/message-handler-types.ts
@@ -1,5 +1,4 @@
 import type { IncomingMessage } from "node:http";
-import type { WebSocket } from "ws";
 import type {
   ConnectParams,
   RequestFrame,
@@ -16,9 +15,13 @@ import type { GatewayMethodRegistry } from "../../methods/registry.js";
 import type { NodePairingAutoApproveClientIpSource } from "../../node-pairing-auto-approve.types.js";
 import type { NodeReapprovalCoordinator } from "../../node-reapproval-coordinator.js";
 import type { PluginNodeCapabilitySurface } from "../../plugin-node-capability.js";
-import type { GatewayRole } from "../../role-policy.js";
+import type { GatewayRole } from "../../role-policy.types.js";
 import type { GatewayConnectionWork } from "../../server-connection-work.js";
 import type { GatewayRequestContext, GatewayRequestHandlers } from "../../server-methods/types.js";
+import type {
+  GatewayConnectionTransport,
+  PrepareGatewayAuthenticatedReceive,
+} from "../connection-transport.js";
 import type { GatewayWsBrowserOrigin, GatewayWsClient, WsHandshakePhase } from "../ws-types.js";
 import type { ControlUiPairingKind } from "./connect-policy.js";
 import type { resolvePairingLocality } from "./handshake-auth-helpers.js";
@@ -34,7 +37,8 @@ export type WsOriginCheckMetrics = {
 type WsSendResult = { kind: "sent" | "unavailable" } | { kind: "serialization"; error: unknown };
 
 export type GatewayWsMessageHandlerParams = {
-  socket: WebSocket;
+  socket: GatewayConnectionTransport;
+  prepareAuthenticatedReceive: PrepareGatewayAuthenticatedReceive;
   connectionWork: GatewayConnectionWork;
   upgradeReq: IncomingMessage;
   ingressAttribution: GatewayAttributedIngress;

--- a/src/gateway/server/ws-connection/message-handler.control-ui-build-admission.test.ts
+++ b/src/gateway/server/ws-connection/message-handler.control-ui-build-admission.test.ts
@@ -199,6 +199,7 @@ describe("Control UI build admission over WebSocket", () => {
       };
       attachGatewayWsMessageHandler({
         socket,
+        prepareAuthenticatedReceive: () => ({ ok: true, value: vi.fn() }),
         connectionWork,
         upgradeReq: request as IncomingMessage,
         ingressAttribution: {

--- a/src/gateway/server/ws-connection/message-handler.post-connect-health.test.ts
+++ b/src/gateway/server/ws-connection/message-handler.post-connect-health.test.ts
@@ -400,6 +400,7 @@ function attachGatewayHarness(options: {
   });
   attachGatewayWsMessageHandler({
     socket,
+    prepareAuthenticatedReceive: () => ({ ok: true, value: vi.fn() }),
     connectionWork,
     bootId: "post-connect-health-test-boot",
     upgradeReq: {

--- a/src/gateway/server/ws-connection/message-handler.suspension-admission.test.ts
+++ b/src/gateway/server/ws-connection/message-handler.suspension-admission.test.ts
@@ -101,6 +101,7 @@ function attachHarness(params: { deferSocketSend?: boolean; startupPending?: boo
 
   attachGatewayWsMessageHandler({
     socket,
+    prepareAuthenticatedReceive: () => ({ ok: true, value: vi.fn() }),
     connectionWork,
     bootId: "suspension-admission-test-boot",
     upgradeReq: {

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -1,6 +1,5 @@
 // WebSocket message handler validates frames, dispatches gateway RPCs, manages pairing, and reports responses.
 import { rawDataToString } from "@openclaw/gateway-client/websocket-data";
-import type { RawData } from "ws";
 import {
   GATEWAY_CLIENT_IDS,
   GATEWAY_CLIENT_MODES,
@@ -42,6 +41,7 @@ import { resolveNodePairingClientIpSource } from "../../node-pairing-auto-approv
 import { MAX_PREAUTH_PAYLOAD_BYTES } from "../../server-constants.js";
 import { formatForLog, logWs } from "../../ws-log.js";
 import { truncateCloseReason } from "../close-reason.js";
+import type { GatewayConnectionFrame } from "../connection-transport.js";
 import { resolveGatewayWsBrowserOrigin } from "../ws-origin-policy.js";
 import { createGatewayAuthenticatedRequestDispatcher } from "./authenticated-request-dispatch.js";
 import { isStartupNodeConnect } from "./connect-admission.js";
@@ -54,10 +54,7 @@ import type {
   GatewayConnectPhaseContext,
   GatewayWsMessageHandlerParams,
 } from "./message-handler-types.js";
-export type {
-  GatewayWsMessageHandlerParams,
-  WsOriginCheckMetrics,
-} from "./message-handler-types.js";
+export type { GatewayWsMessageHandlerParams } from "./message-handler-types.js";
 
 const GATEWAY_WORK_ADMISSION_RETRY_AFTER_MS = 1_000;
 const GATEWAY_WORK_ADMISSION_CLOSE_CODE = 1013;
@@ -175,7 +172,7 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
       .catch(onError);
   };
 
-  const handleMessage = async (data: RawData, admission?: "continuation") => {
+  const handleMessage = async (data: GatewayConnectionFrame, admission?: "continuation") => {
     if (isClosed()) {
       return;
     }
@@ -414,7 +411,7 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
   };
 
   const parsePreauthConnectFrame = (
-    data: RawData,
+    data: GatewayConnectionFrame,
   ): { id: string; params: ConnectParams } | null => {
     if (isClosed() || rawDataByteLength(data) > MAX_PREAUTH_PAYLOAD_BYTES) {
       return null;
@@ -435,7 +432,7 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
     return { id: parsed.id, params: parsed.params };
   };
 
-  const isPreparedControlConnect = (data: RawData): boolean => {
+  const isPreparedControlConnect = (data: GatewayConnectionFrame): boolean => {
     const parsed = parsePreauthConnectFrame(data);
     if (!parsed) {
       return false;
@@ -444,12 +441,14 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
     return connectParams.role !== "node" && !claimsWorkerConnectionIdentity(parsed.params);
   };
 
-  const isStartupNodePreauth = (data: RawData): boolean => {
+  const isStartupNodePreauth = (data: GatewayConnectionFrame): boolean => {
     const parsed = parsePreauthConnectFrame(data);
     return parsed ? isStartupNodeConnect(parsed.params) : false;
   };
 
-  const rejectConnectForClosedAdmission = async (data: RawData): Promise<boolean> => {
+  const rejectConnectForClosedAdmission = async (
+    data: GatewayConnectionFrame,
+  ): Promise<boolean> => {
     const parsed = parsePreauthConnectFrame(data);
     if (!parsed) {
       return false;
@@ -487,7 +486,10 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
     return true;
   };
 
-  const handleIncomingMessage = async (data: RawData, requestAdmission?: "continuation") => {
+  const handleIncomingMessage = async (
+    data: GatewayConnectionFrame,
+    requestAdmission?: "continuation",
+  ) => {
     if (getClient()) {
       await handleMessage(data, requestAdmission);
       return;
@@ -537,7 +539,7 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
     }
   };
 
-  socket.on("message", (data) => {
+  const receive = (data: GatewayConnectionFrame) => {
     // Capture receipt before any await: older requests keep their admitted lifetime,
     // while shutdown frames may only settle an exact pending node owner.
     const admission = params.connectionWork.isClosing ? "continuation" : undefined;
@@ -553,5 +555,7 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
       .catch((error: unknown) => {
         logGateway.error(`request dispatch failed conn=${connId}: ${formatForLog(error)}`);
       });
-  });
+  };
+  socket.on("message", receive);
+  return receive;
 }

--- a/src/gateway/server/ws-connection/request-start.test.ts
+++ b/src/gateway/server/ws-connection/request-start.test.ts
@@ -3,11 +3,8 @@ import { setImmediate as nextTurn } from "node:timers/promises";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { WebSocket } from "ws";
 import { MAX_PAYLOAD_BYTES, MAX_PREAUTH_PAYLOAD_BYTES } from "../../server-constants.js";
-import {
-  prepareGatewayReceiverHandoff,
-  raiseGatewayReceiverPayloadLimit,
-  scheduleGatewayRequestStart,
-} from "./request-start.js";
+import { prepareGatewayReceiverHandoff, raiseGatewayReceiverPayloadLimit } from "../ws-receiver.js";
+import { scheduleGatewayRequestStart } from "./request-start.js";
 
 const permissions: Promise<void>[] = [];
 function requestStart(bytes = 1): Promise<void> {
@@ -140,9 +137,11 @@ describe("authenticated receiver payload limits", () => {
   it("raises the receiver limit only after connect", () => {
     const socket = receiverSocket();
     const handoff = prepareGatewayReceiverHandoff(socket, "operator");
-    expect(handoff).not.toBeNull();
+    expect(handoff.ok).toBe(true);
     expect(payloadLimit(socket)).toBe(MAX_PREAUTH_PAYLOAD_BYTES);
-    handoff?.();
+    if (handoff.ok) {
+      handoff.value();
+    }
     expect(payloadLimit(socket)).toBe(MAX_PAYLOAD_BYTES);
   });
 
@@ -154,7 +153,10 @@ describe("authenticated receiver payload limits", () => {
 
   it("refuses the handoff when the receiver limit cannot be raised", () => {
     const socket = receiverSocket(true);
-    expect(prepareGatewayReceiverHandoff(socket, "operator")).toBeNull();
+    expect(prepareGatewayReceiverHandoff(socket, "operator")).toMatchObject({
+      ok: false,
+      error: { cause: "unsupported-websocket-receiver" },
+    });
     expect(raiseGatewayReceiverPayloadLimit(socket, 1_024)).toBe(false);
     expect(payloadLimit(socket)).toBe(MAX_PREAUTH_PAYLOAD_BYTES);
   });

--- a/src/gateway/server/ws-connection/request-start.ts
+++ b/src/gateway/server/ws-connection/request-start.ts
@@ -1,64 +1,7 @@
 import { performance } from "node:perf_hooks";
 import { setImmediate as nextTurn } from "node:timers/promises";
-import type { WebSocket } from "ws";
 import { runOutsideGatewayRootWorkAdmission } from "../../../process/gateway-work-admission.js";
 import { BoundedSerialQueue } from "../../../shared/bounded-serial-queue.js";
-import type { GatewayRole } from "../../role-policy.js";
-import { MAX_PAYLOAD_BYTES } from "../../server-constants.js";
-
-type PayloadLimited = { _maxPayload?: number };
-type GatewayReceiver = PayloadLimited & {
-  _allowSynchronousEvents?: boolean;
-};
-
-function hasWritablePayloadLimit(target: PayloadLimited | undefined): target is PayloadLimited {
-  return (
-    typeof target?.["_maxPayload"] === "number" &&
-    Object.getOwnPropertyDescriptor(target, "_maxPayload")?.writable === true
-  );
-}
-
-function gatewayReceiver(socket: WebSocket): GatewayReceiver | null {
-  // SAFETY: ws owns these private per-frame fields; validate each before the handoff.
-  const receiver = (socket as WebSocket & { _receiver?: GatewayReceiver })["_receiver"];
-  if (!hasWritablePayloadLimit(receiver)) {
-    return null;
-  }
-  return receiver;
-}
-
-/** Raises the authenticated frame limit after the connection is admitted. */
-export function raiseGatewayReceiverPayloadLimit(socket: WebSocket, maxPayload: number): boolean {
-  const receiver = gatewayReceiver(socket);
-  if (!receiver) {
-    return false;
-  }
-  receiver["_maxPayload"] = maxPayload;
-  return true;
-}
-
-export function prepareGatewayReceiverHandoff(
-  socket: WebSocket,
-  role: GatewayRole,
-): (() => void) | null {
-  const receiver = gatewayReceiver(socket);
-  if (!receiver) {
-    return null;
-  }
-  if (
-    role === "operator" &&
-    (typeof receiver["_allowSynchronousEvents"] !== "boolean" ||
-      Object.getOwnPropertyDescriptor(receiver, "_allowSynchronousEvents")?.writable !== true)
-  ) {
-    return null;
-  }
-  return () => {
-    receiver["_maxPayload"] = MAX_PAYLOAD_BYTES;
-    if (role === "operator") {
-      receiver["_allowSynchronousEvents"] = true;
-    }
-  };
-}
 
 // One active scheduling task is separate from these waiting budgets. Each task
 // grants start permission only; it never owns the RPC or waits for its completion.

--- a/src/gateway/server/ws-connection/worker-connection.ts
+++ b/src/gateway/server/ws-connection/worker-connection.ts
@@ -30,6 +30,7 @@ import type { GatewayConnectionWork } from "../../server-connection-work.js";
 import { MAX_RUNNING_WORKER_SESSION_TOOL_OPERATIONS } from "../../worker-environments/placement-session-tool-operations.js";
 import { runWorkerTurnAdmissionContinuation } from "../../worker-environments/placement-turn-claim-events.js";
 import type { PublicWorkerIngressContext } from "../public-worker-ingress-context.js";
+import { raiseGatewayReceiverPayloadLimit } from "../ws-receiver.js";
 import type { GatewayWsClient, WsHandshakePhase } from "../ws-types.js";
 import type { GatewayWsMessageHandlerParams } from "./message-handler-types.js";
 import {
@@ -37,7 +38,6 @@ import {
   createWorkerRpcDiagnostics,
   type GatewayRpcQueueTiming,
 } from "./request-diagnostics.js";
-import { raiseGatewayReceiverPayloadLimit } from "./request-start.js";
 import { runWorkerAdmissionBoundary } from "./worker-admission-boundary.js";
 import {
   dispatchWorkerRequest,

--- a/src/gateway/server/ws-receiver.ts
+++ b/src/gateway/server/ws-receiver.ts
@@ -1,0 +1,62 @@
+import type { WebSocket } from "ws";
+import type { GatewayRole } from "../role-policy.types.js";
+import { MAX_PAYLOAD_BYTES } from "../server-constants.js";
+import type { PrepareGatewayAuthenticatedReceive } from "./connection-transport.js";
+
+type PayloadLimited = { _maxPayload?: number };
+type GatewayReceiver = PayloadLimited & {
+  _allowSynchronousEvents?: boolean;
+};
+
+function hasWritablePayloadLimit(target: PayloadLimited | undefined): target is PayloadLimited {
+  return (
+    typeof target?.["_maxPayload"] === "number" &&
+    Object.getOwnPropertyDescriptor(target, "_maxPayload")?.writable === true
+  );
+}
+
+function gatewayReceiver(socket: WebSocket): GatewayReceiver | null {
+  // SAFETY: ws owns these private per-frame fields; validate each before the handoff.
+  const receiver = (socket as WebSocket & { _receiver?: GatewayReceiver })["_receiver"];
+  return hasWritablePayloadLimit(receiver) ? receiver : null;
+}
+
+/** Raises the authenticated frame limit after the connection is admitted. */
+export function raiseGatewayReceiverPayloadLimit(socket: WebSocket, maxPayload: number): boolean {
+  const receiver = gatewayReceiver(socket);
+  if (!receiver) {
+    return false;
+  }
+  receiver["_maxPayload"] = maxPayload;
+  return true;
+}
+
+export function prepareGatewayReceiverHandoff(
+  socket: WebSocket,
+  role: GatewayRole,
+): ReturnType<PrepareGatewayAuthenticatedReceive> {
+  const receiver = gatewayReceiver(socket);
+  if (
+    !receiver ||
+    (role === "operator" &&
+      (typeof receiver["_allowSynchronousEvents"] !== "boolean" ||
+        Object.getOwnPropertyDescriptor(receiver, "_allowSynchronousEvents")?.writable !== true))
+  ) {
+    return {
+      ok: false,
+      error: {
+        cause: "unsupported-websocket-receiver",
+        message: "unsupported Gateway WebSocket receiver",
+      },
+    };
+  }
+  return {
+    ok: true,
+    value: () => {
+      receiver["_maxPayload"] = MAX_PAYLOAD_BYTES;
+      if (role === "operator") {
+        receiver["_allowSynchronousEvents"] = true;
+      }
+    },
+  };
+}

--- a/src/gateway/server/ws-types.ts
+++ b/src/gateway/server/ws-types.ts
@@ -6,6 +6,7 @@ import type { AuthenticatedGitHubIdentitySync } from "../github-user-identity.js
 import type { GatewayOperatorRoleActor } from "../operator-role-actor.js";
 import type { PluginNodeCapabilityClient } from "../plugin-node-capability.js";
 import type { WorkerConnectionIdentity } from "../worker-environments/connection-identity.js";
+import type { GatewayConnectionTransport } from "./connection-transport.js";
 
 export type GatewayWsBrowserOrigin = {
   requestHost?: string;
@@ -29,7 +30,9 @@ export type GatewayIngressWebSocket = WebSocket & {
  * Runtime WebSocket client state tracked by the gateway server.
  */
 export type GatewayWsClient = PluginNodeCapabilityClient & {
-  socket: WebSocket;
+  socket: GatewayConnectionTransport;
+  /** Physical WS liveness capability; absent on transports without ping/pong. */
+  webSocket?: Pick<WebSocket, "ping" | "once" | "off">;
   connect: ConnectParams;
   connId: string;
   /** Host-owned transport retirement notification; never accepted from wire params. */


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/issues/142916
Replaces: https://github.com/openclaw/openclaw/pull/142931

## What Problem This Solves

Gateway connection admission, request dispatch, and cleanup were coupled to
WebSocket-specific I/O, preventing another transport from reusing the existing
authenticated lifecycle safely.

## Why This Change Was Made

Extract the existing connection lifecycle into one transport-neutral owner while
keeping WebSocket receive, receiver limits, heartbeat, socket errors, and
physical liveness in the WebSocket adapter.

The repair preserves the keepalive behavior from
https://github.com/openclaw/openclaw/pull/145191, including passing the underlying
socket to `startWebSocketKeepalive`. It adds no endpoint, config, protocol, or
persistence surface.

The ancestry-preserving refresh includes
https://github.com/openclaw/openclaw/pull/146102 and
https://github.com/openclaw/openclaw/pull/147028.

## User Impact

No intended user-visible behavior change. The Gateway gains one reusable
connection boundary without duplicating authentication, registration, request
dispatch, or disconnect cleanup.

## Evidence

- Refreshed head: `ceda70dd6ce0e069ad1a6a9ab28ed4c77b008250`
- Exact reviewed merge base: `060e856e5f9df245d63c98990fcb47e18108c6b9`
- Refresh parents: `7b0a779bb1eb1cad1f6789688ecc367ed5fa814c` and
  `060e856e5f9df245d63c98990fcb47e18108c6b9`
- Refreshed scope: 25 files; stable aggregate patch ID
  `aac1da4a5893b524768c29bca2d4111847297d95`
- All 16 production blobs are byte-identical to the reviewed source head. The
  patch ID changed from `d620e013d1321e228ec7d747b10c9ed51cfb47cf`
  only because four test/baseline files also moved on main; every per-file
  addition/deletion count is unchanged.
- Production: +870/-776, net +94. The 657-line shared lifecycle owner replaces
  roughly 660 WebSocket-owned lines; the remaining growth is the transport
  contract, adapter wiring, and receiver extraction.
- Tests: +231/-20, net +211.
- Assertion baseline: +2/-2, retaining the reviewed
  `node-registry.ts` 5->4 and `ws-connection.ts` 3->1 reductions.
- `git diff --check` passed on the refreshed head.

Focused proof command:

```bash
node scripts/run-vitest.mjs \
  src/gateway/server/connection.test.ts \
  src/gateway/server/ws-connection.test.ts \
  src/gateway/server/ws-connection/request-start.test.ts \
  src/gateway/server/ws-connection/request-start.server.test.ts \
  src/gateway/server/ws-connection/message-handler.control-ui-build-admission.test.ts \
  src/gateway/server/ws-connection/message-handler.post-connect-health.test.ts \
  src/gateway/server/ws-connection/message-handler.suspension-admission.test.ts \
  src/gateway/node-registry.test.ts \
  src/gateway/server.node-shutdown.test.ts \
  src/gateway/server-import-boundary.test.ts \
  src/gateway/server.public-worker-ingress.test.ts
```

Result on source head `7b0a779b`: 11 test files passed, 291 tests passed. The
refreshed head preserves the production blobs and exact per-file delta; exact-head
hosted CI and ClawSweeper remain required before landing.

## Scope Boundary

This PR adds no HTTPS/watch endpoint. It does not satisfy or close
https://github.com/openclaw/openclaw/issues/142916 and leaves that issue's later
security/native holds untouched.
