### PR TITLE
perf(conversations): prepare search queries once

### DIFF
--- a/src/gateway/conversation-list.ts
+++ b/src/gateway/conversation-list.ts
@@ -216,16 +216,10 @@ async function discoverChannelAddresses(params: {
   };
 }
 
-function matchesConversationQuery(conversation: ConversationRecord, rawQuery: string): boolean {
-  const query = rawQuery.trim().toLowerCase();
-  if (!query) {
-    return true;
-  }
-  const terms = query.startsWith("@") ? [query, query.slice(1)] : [query];
-  const values = [conversation.conversationRef, conversation.target, conversation.label]
-    .filter((value): value is string => Boolean(value))
-    .map((value) => value.toLowerCase());
-  return terms.some((term) => term && values.some((value) => value.includes(term)));
+function matchesConversationQuery(conversation: ConversationRecord, query: string): boolean {
+  return [conversation.conversationRef, conversation.target, conversation.label].some((value) =>
+    value?.toLowerCase().includes(query),
+  );
 }
 
 /** Lists persisted and channel-directory addresses from the Gateway's live plugin runtime. */
@@ -259,12 +253,17 @@ export async function runGatewayConversationList(
     discovery ? { channel: discovery.channel } : {},
   );
   const currentConfig = params.readCurrentConfig?.() ?? params.config;
+  const normalizedQuery = query?.toLowerCase() ?? "";
+  const searchQuery =
+    normalizedQuery.startsWith("@") && normalizedQuery.length > 1
+      ? normalizedQuery.slice(1)
+      : normalizedQuery;
   const selected = conversations
     .filter((entry) => {
       if (
         query &&
         discovery?.discoveredConversationRefs.has(entry.conversationRef) !== true &&
-        !matchesConversationQuery(entry, query)
+        !matchesConversationQuery(entry, searchQuery)
       ) {
         return false;
       }


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

Searching a large stored conversation directory through `conversations_list` repeats query normalization and prepares searchable fields that a previous field may already have matched.

## Why This Change Was Made

Prepare the lowercase search term once per list request and lowercase address fields only until a match. For `@term`, the suffix already covers matches of the longer term; a lone `@` remains literal. Directory discovery keeps its original query, discovered references retain their query bypass, and the complete ownership/eligibility pass still runs before the result limit.

## User Impact

Queried conversation-address lists need less metadata filtering work while preserving the returned addresses and route checks. No-query and small-input controls remain recorded below; no live channel-I/O or end-to-end latency improvement is claimed.

## Evidence

- Current source at base `7292689e7f78026060491fc94923cafdec48733f`: all **7** tests in `src/gateway/conversation-list.test.ts` and the **2** selected `conversations.list` handler cases in `src/gateway/server-methods/conversations.test.ts` passed on Darwin/Node 26.8.1. Exact file and selected-title inventories were checked; the other 11 handler-file cases were unselected and are not counted.
- All **25** small guards selected by the actual changed-check owner passed individually under unchanged per-child 300s/6 GiB/64-process bounds. Matching Oxfmt 0.66, `git diff --check`, and fresh managed Codex review through P2 passed. All native children and monitors closed; the reviewed one-file diff remained unchanged.
- An earlier small-guard preflight observed 3,208,937,472 bytes free, below the unchanged 3 GiB entry floor, and launched **zero children**. After completed storage retirement restored headroom, the guards ran successfully; the focused tests were not rerun and no limit was weakened.
- **Hosted CI pending:** `tsgo:core`, `tsgo:core:test`, and changed core type-aware lint have not run locally. Merge requires their exact-head hosted CI coverage; this is not a full-validation-pass claim.

Historical isolated Linux/Node 24.19.0 measurement at `32fc009394c2824515625bc635781adc1a9e62f9` used the actual `runGatewayConversationList` owner, four fresh processes in baseline/candidate/candidate/baseline order, two warmup and seven measured batches per case, and 6,336 invocations including warmups. Full output/reference graphs matched. Additional controls verified the original directory query, discovered-reference bypass, and eligibility traversal after the result window was already full. Existing dependency injection isolates registry/directory I/O while normal module imports and eligibility code execute.

The source and dependency inputs pinned by this measurement remain unchanged; the author candidate differs from measured bytes only by arrow-layout whitespace. No retiming was performed.

Wall times are median microseconds per call. CPU and process RSS changes show forward / reverse comparisons; both comparison orders and every adverse control are retained.

| Input | Forward baseline → candidate (µs) | Reverse baseline → candidate (µs) | CPU change | RSS change |
| --- | ---: | ---: | ---: | ---: |
| Empty | 0.300 → 0.363 | 0.312 → 0.326 | +41.9% / -2.9% | +0.04% / +0.19% |
| 8 addresses, term query | 11.082 → 9.622 | 10.400 → 9.657 | +3.8% / -26.2% | +0.02% / +0.24% |
| 64 addresses, no query | 144.335 → 142.579 | 133.813 → 135.319 | +118.0% / +43.7% | +0.07% / +0.24% |
| 1,024 addresses, @term, sorted | 538.756 → 434.677 | 497.575 → 429.056 | -18.8% / -10.5% | -0.12% / +0.21% |
| 1,024 addresses, @term, reverse | 504.576 → 414.657 | 455.013 → 404.759 | -17.8% / -11.0% | -0.13% / +0.20% |
| 1,024 addresses, @term, shuffled | 510.092 → 426.686 | 455.806 → 414.154 | -16.3% / -8.3% | -0.13% / +0.20% |
| 1,024 addresses, reference hits | 1973.443 → 1778.584 | 1806.206 → 1742.336 | -9.9% / -3.6% | -0.05% / +0.10% |
| 1,024 addresses, label hits | 1262.703 → 1207.707 | 1231.311 → 1191.113 | -4.4% / -3.3% | -0.05% / +0.10% |
| 1,024 addresses, no matches | 89.105 → 48.795 | 72.911 → 54.187 | -45.1% / -29.5% | -0.02% / +0.09% |
| 1,024 addresses, lone @ | 206.036 → 162.118 | 180.426 → 171.543 | -21.4% / -4.8% | -0.02% / +0.08% |

Every queried 1,024-address case improved in both comparison orders, saving roughly 9–195 µs per list-owner call. Empty calls cost another 14–63 ns; the no-query case changed by −1.76/+1.51 µs with the recorded adverse CPU measurements. The change removes one production line.

RSS includes imports, fixtures and retained parity work, not exact per-call allocation. Native process high-water RSS was 615.2 → 615.0 MiB in the forward pair and 614.6 → 615.1 MiB in the reverse pair. These are historical owner measurements, not current-platform performance or live transport results.
