### PR TITLE
refactor(ui): share the command-lane snapshot contract

### DIFF
--- a/ui/src/lib/gateway-diagnostics.ts
+++ b/ui/src/lib/gateway-diagnostics.ts
@@ -1,22 +1,9 @@
+import type { CommandLaneSnapshot } from "../../../src/process/command-queue.types.js";
 import type { GatewayBrowserClient } from "../api/gateway.ts";
 import type { HealthSnapshot, StatusSummary } from "../api/types.ts";
 import { loadModelCatalog } from "./model-catalog-store.ts";
 
-type CommandLaneBlockReason = "lane" | "group-budget" | "sibling-reservation" | null;
-
-export type CommandLaneSnapshot = {
-  lane: string;
-  queuedCount: number;
-  activeCount: number;
-  maxConcurrent: number;
-  draining: boolean;
-  generation: number;
-  group?: string;
-  groupActive?: number;
-  groupBudget?: number;
-  reservedForLane?: number;
-  blockedBy?: CommandLaneBlockReason;
-};
+export type { CommandLaneSnapshot } from "../../../src/process/command-queue.types.js";
 
 export type CommandLaneDynamicSummary = {
   laneCount: number;


### PR DESCRIPTION
## What Problem This Solves

The Debug diagnostics client repeats the scheduler's lane-snapshot type. Keeping two declarations for the same contract gives future type changes two places to drift, even though the Debug page and global overlay consume the same data.

## Why This Change Was Made

Reuse the existing import-free `src/process/command-queue.types.ts` leaf through a type-only import and re-export. The public UI name `CommandLaneSnapshot` stays intact; the dynamic summary, diagnostics envelope, requests and runtime expressions are unchanged. This avoids importing the queue implementation into the UI merely to derive a type.

Production change: **+2 / −15, net −13 lines** in one file. No tests, generated code, configuration, dependencies, RPC schema or scheduler behavior changed.

## User Impact

No user-visible, visual or runtime behavior change is intended. Existing optional fields, nullability, writable properties and `blockedBy` values are preserved. This is a type-ownership cleanup, not a runtime bug fix or performance claim.

## Evidence

Validation was performed on September 12, 2026 UTC. The pre-save candidate afterimage and tree are identical to signed commit `79269e20362193681c478b5a179fba53fbb05e76`; historical runs are not relabeled as post-commit executions.

- The existing diagnostics loader, Debug view and Gateway diagnostics suites passed on both original and candidate: **25 cases each**, unchanged tests.
- Normal UI typechecks passed on both roles. Two separate native compiler Programs, each retaining its real UI configuration and ambient inputs, verified the same independent 11-field/envelope contract against the canonical leaf: keys, optionality, nullability, writability and unions.
- The actual production Vite transform emitted **identical 821-byte JavaScript** for the original and candidate owner. The normal candidate UI build passed, including 882 compressed-sidecar checks. This is module-level runtime equality, not whole-bundle equality or a performance-budget claim.
- The existing real Chromium Debug case passed **1/1** against its mocked Gateway, covering boot/rendering, request parameters, refresh retention, offline behavior and desktop/mobile bounds. This was a candidate-only current-behavior run, not an original/candidate browser or screenshot pair.
- The normal **19-check gate** passed through configured Blacksmith Testbox on Linux Node 24.19.0/pnpm 12.3.4; the one-shot lease stopped normally. [Backing run](https://github.com/openclaw/openclaw/actions/runs/34688867132). The native gate returned 0; the backing Actions status can show cancellation during delegated cleanup and is not presented as exact-head PR CI.
- Managed P0–P2 reviews of the precommit candidate and the exact signed commit both returned scoped-clean with no actionable findings. Exact-head [CI run 34693099658](https://github.com/openclaw/openclaw/actions/runs/34693099658) completed SUCCESS: 88 successful jobs and 13 workflow-skipped jobs.

An early ad hoc compiler experiment combining both complete UI Programs failed because of its proof setup (root-directory, ambient and duplicate-global conflicts). That failure is retained; the separate real UI Programs passed without changing production or default compiler settings. No hypothetical `exactOptionalPropertyTypes` mode, original full UI build, live Gateway/provider run, exhaustive lane/focus GUI proof, or full remote post-run filesystem archive is claimed.

Synthetic Debug screenshots and video were inspected and retained as unchanged current-behavior evidence. No before/after visual difference is implied by this type-only change.
