### PR TITLE
fix(ci): balance slow runtime test jobs across existing runners

### DIFF
--- a/.agents/skills/openclaw-ci-limits/SKILL.md
+++ b/.agents/skills/openclaw-ci-limits/SKILL.md
@@ -272,6 +272,15 @@ These are intentionally guarded by `test/scripts/ci-workflow-guards.test.ts`:
   250s and co-locate split siblings, provided each original child still fits
   150s. Keep file splits, workers, process isolation and other profiles unchanged.
   Runtime consumers in ordinary bins share preparation only with other consumers;
+  hybrid main runtime-placement observations apply only after file splitting.
+  Whole pinned groups may move between existing compatible serial runtime bins
+  under a 440s budget including the existing 100s build reserve. Preserve runner
+  anchors, all descriptors and invocation/generation counts; no additional jobs,
+  builds, worker limits or test deadlines. Reapply shared admission to both bins;
+  do not bypass a failed budget or count a runtime subset as a complete parent.
+  An unfit optimization keeps the complete runnable plan and its truthful estimate.
+  Compare recipients with the donor job's fixed anchor, not only its group class.
+  Other serial, exclusive, private-QA, dist and hosted policies stay unchanged.
   Affordable generated CLI runtime children may share one preparation in an
   exclusive serial bin within the same 150s budget; fixed stripe families remain
   separate. Other hybrid exclusive/dist sharing is unchanged. Complete inventories

--- a/.github/workflows/ci-test-timings-refit.yml
+++ b/.github/workflows/ci-test-timings-refit.yml
@@ -76,6 +76,7 @@ jobs:
             scripts/ci-refit-test-timings.mts
             scripts/ci-run-timings.mjs
             scripts/lib/ci-test-timings-refit.mts
+            scripts/lib/ci-node-test-groups-codec.mts
             scripts/lib/ci-test-timings-schema.mts
             scripts/lib/vitest-shard-metadata.mts
             scripts/lib/direct-run.mjs

--- a/config/ci-test-timings.json
+++ b/config/ci-test-timings.json
@@ -144,7 +144,18 @@
       "core-unit-src-security-2": 116,
       "core-unit-src-security-3": 158,
       "core-unit-src-security-support": 24,
-      "core-unit-support": 52
+      "core-unit-support": 52,
+      "runtime-placement#2b1c0b8d48d8b50414fd067c349b2f47d081f400": 13,
+      "runtime-placement#2c4f0f682816a7ffb3ee8014fa8e16aa03a06ab4": 14,
+      "runtime-placement#5356616168e63778076bc126ea579625afa09dc8": 201,
+      "runtime-placement#75f68d733e4d254c846ecc193d2b1d729b44511b": 41,
+      "runtime-placement#7cc54c89f2c576111cfe9f8937c1e9f3c8876a7d": 12,
+      "runtime-placement#8096f17bd1f37f16ce0520c79b25fd55adb24bb4": 10,
+      "runtime-placement#964c8a634d056041fe627995ffe302457739a77d": 54,
+      "runtime-placement#9dc07ef8e9c6e5f9b68095a12c495d8ff00d7fd0": 265,
+      "runtime-placement#ac5a9db3ba50321154aeb563325047ee1fc5e62c": 79,
+      "runtime-placement#d8077c092e8ae6a94b867b0a5aec3ffe38662939": 43,
+      "runtime-placement#dedf4dae6cad3774bfcc936841002adf0fa2e5aa": 12
     },
     "github": {}
   },
@@ -360,7 +371,7 @@
     "test/skills-proposal-manual-target.e2e.test.ts": 2,
     "test/status-shared-state-readonly.e2e.test.ts": 83
   },
-  "source": "median of 3 successful CI and release-check runs: 33537556582, 33537739443, 33543106647",
+  "source": "median of 3 successful CI and release-check runs: 33537556582, 33537739443, 33543106647; runtime placement medians from successful compact jobs in runs 34668723570 and 34678360461 (the former workflow failed elsewhere)",
   "uiE2e": {
     "fileSeconds": {
       "ui/src/e2e/about.e2e.test.ts": 1,
@@ -708,6 +719,6 @@
     },
     "perFileOverheadSeconds": 0.8
   },
-  "updatedAt": "2026-09-01",
+  "updatedAt": "2026-09-12",
   "version": 1
 }

--- a/docs/ci/capacity.md
+++ b/docs/ci/capacity.md
@@ -86,6 +86,30 @@ Canonical-repo CI keeps Blacksmith as the default runner path for pushes and fir
 
 ## Measured shard weights
 
+Hybrid main runtime bins retain their existing jobs and runner allocations while
+admitting complete measured runtime groups within 440 seconds, including the
+existing 100-second build allowance. This reserves 40 seconds of the eight-minute
+objective for checkout/setup; it does not change test deadlines or guarantee
+elapsed time. Only non-exclusive ordinary-runtime bins participate. A group can
+move to an already-required equal-or-stronger runner only with its own explicit
+worker limit. Both replacement bins must pass the shared family, group-count and
+budget checks. If no transfer fits, CI retains the complete existing plan and
+reports its over-budget estimate; an optimization cannot suppress test coverage.
+Recipient capacity must preserve the donor job's fixed runner anchor, including
+any earlier promotion of that group. Private-QA, dist, exclusive, hosted,
+and ordinary two-slot policies remain unchanged.
+
+The refit records separate runtime-placement observations from the emitted group
+descriptor, successful complete envelope and runtime-readiness marker. Configs,
+group environment, exact include set and prebuild mode define their identity;
+unrelated sibling repartitioning does not erase them. These observations use the
+same independent-run sampling rules but are consumed only after file splitting.
+They cannot reconstruct a parent or create more worker generations. Existing
+parent and exact-child timing keys keep their original meaning. Preparation is
+already included in the envelope; each job's shared runtime build is charged once.
+Unknown groups retain positive fallback costs, and native same-inventory evidence
+must verify latency, actual resources and cleanup before claiming improvement.
+
 `config/ci-test-timings.json` records CI measurements for UI and Gateway E2E files
 and compact Node groups. UI and compact packers prefer these weights over their in-source cold-start
 tables. UI E2E keys are repo-relative paths, including tests under `ui/src/pages/`,

--- a/scripts/lib/ci-node-test-plan.mts
+++ b/scripts/lib/ci-node-test-plan.mts
@@ -30,6 +30,7 @@ import {
   isUnitConfigTestFile,
 } from "../../test/vitest/vitest.unit-paths.mjs";
 import { buildVitestRunPlans, isTestFileTarget } from "../test-projects.test-support.mts";
+import { rebalanceRuntimeTestJobs } from "./ci-runtime-test-placement.mts";
 import { readCompactGroupTimings } from "./ci-test-timings.mts";
 import { listTrackedTestFiles } from "./list-test-files.mts";
 import {
@@ -44,6 +45,7 @@ import {
   estimateVitestTestFileSeconds as stripeFileWeight,
   estimateVitestToolingFileSeconds as toolingFileWeight,
   parseCompactSplitTimingKey,
+  runtimePlacementTimingKey,
 } from "./vitest-shard-metadata.mts";
 
 export type NodeTestShardGroup = {
@@ -206,6 +208,9 @@ const COMPACT_LARGE_NODE_TEST_JOB_SECONDS = 200;
 const COMPACT_SMALL_NODE_TEST_JOB_SECONDS = 276;
 const COMPACT_PARALLEL_NODE_TEST_JOB_SECONDS = 360;
 const COMPACT_EXPANDED_NODE_TEST_JOB_SECONDS = 210;
+// Includes the existing 100s runtime build; reserve 40s of the eight-minute
+// objective for checkout/setup. This is admission, never a test deadline.
+const COMPACT_HYBRID_RUNTIME_JOB_SECONDS = 440;
 const COMPACT_GITHUB_GROUP_SECONDS_SCALE = 1.6;
 const COMPACT_HYBRID_GROUP_SECONDS_SCALE = 0.87;
 // Split groups above this hosted prediction before packing. Hybrid reuses the
@@ -2867,7 +2872,7 @@ function createCompactNodeTestShardBundles(
   );
   const groupsByRunner = new Map<string, [NodeTestShardGroup, ...NodeTestShardGroup[]]>();
   const synthesizedSplitSeconds = new Map<string, number>();
-  const runnerRank = (group: NodeTestShardGroup) =>
+  const runnerRank = (group: Pick<NodeTestShardGroup, "runner">) =>
     [BUNDLED_NODE_TEST_RUNNER, DEFAULT_NODE_TEST_RUNNER, EXTRA_LARGE_NODE_TEST_RUNNER].indexOf(
       group.runner,
     );
@@ -2993,6 +2998,16 @@ function createCompactNodeTestShardBundles(
       .filter((family): family is string => family !== undefined);
     return new Set(families).size === families.length;
   };
+  const admitsCompactBin = (
+    groups: NodeTestShardGroup[],
+    secondsCap: number,
+    seconds = estimateBinSeconds,
+    { sharedFamily = false, parallel = false } = {},
+  ) =>
+    groups.length > 0 &&
+    (sharedFamily || hasDistinctStripeFamilies(groups)) &&
+    (parallel || groups.length <= COMPACT_NODE_TEST_JOB_GROUPS) &&
+    seconds(groups) <= secondsCap;
   const usesBlacksmithCapacity = (runner: string) =>
     isBlacksmithProfile ||
     (options.runnerBackend === "hybrid" &&
@@ -3063,9 +3078,10 @@ function createCompactNodeTestShardBundles(
       const secondsCap = parallel ? COMPACT_PARALLEL_NODE_TEST_JOB_SECONDS : serialSecondsCap;
       return (
         isExclusiveCompactGroup(candidate[0]) === exclusive &&
-        (sharesSerialCliBudget || hasDistinctStripeFamilies(combined)) &&
-        (parallel || candidate.length < COMPACT_NODE_TEST_JOB_GROUPS) &&
-        estimateBinSeconds(combined) <= secondsCap
+        admitsCompactBin(combined, secondsCap, estimateBinSeconds, {
+          sharedFamily: sharesSerialCliBudget,
+          parallel,
+        })
       );
     };
     const bins = packNodeTestGroups(anchorGroups, canShareCompactJob, packsHostedTooling);
@@ -3247,6 +3263,44 @@ function createCompactNodeTestShardBundles(
     throw new Error(
       `compact ${options.runnerBackend ?? "blacksmith"} node test plan exceeds ${COMPACT_NODE_TEST_JOB_CAP} jobs (${compactJobs.length} planned)`,
     );
+  }
+
+  if (options.runnerBackend === "hybrid" && compactMode === "push") {
+    const timings = readCompactGroupTimings("blacksmith");
+    const runtimeJobs = compactJobs.filter(
+      (job) =>
+        job.pretestBuildMode === "runtime" &&
+        !job.requiresDist &&
+        job.planConcurrency === 1 &&
+        runnerRank(job) >= 0 &&
+        job.groups.every(
+          (group) => group.pretestBuildMode === "runtime" && !isExclusiveCompactGroup(group),
+        ),
+    );
+    const measured = (group: NodeTestShardGroup) => {
+      const key = runtimePlacementTimingKey(group);
+      return key === undefined ? undefined : timings[key];
+    };
+    if (runtimeJobs.some((job) => job.groups.some((group) => measured(group) !== undefined))) {
+      // Observe complete existing envelopes only after splitting/packing. These
+      // floors cannot feed a runtime cost back into ordinary stripe generation.
+      const cost = (groups: NodeTestShardGroup[]) =>
+        VITEST_PRETEST_BUILD_SECONDS.runtime +
+        groups.reduce(
+          (total, group) =>
+            total +
+            Math.max(
+              estimateStripeSeconds(group),
+              measured(group) === undefined
+                ? estimateCompactGroupSeconds(group, "hybrid")
+                : Math.round(measured(group)! * COMPACT_HYBRID_GROUP_SECONDS_SCALE),
+            ),
+          0,
+        );
+      const admits = (groups: NodeTestShardGroup[]) =>
+        admitsCompactBin(groups, COMPACT_HYBRID_RUNTIME_JOB_SECONDS, cost);
+      rebalanceRuntimeTestJobs(runtimeJobs, { cost, admits, runnerRank });
+    }
   }
 
   return compactJobs.toSorted((a, b) => a.checkName.localeCompare(b.checkName));

--- a/scripts/lib/ci-runtime-test-placement.mts
+++ b/scripts/lib/ci-runtime-test-placement.mts
@@ -1,0 +1,56 @@
+import type { CompactNodeTestShard, NodeTestShardGroup } from "./ci-node-test-plan.mts";
+
+// Optimize complete existing jobs only; an unavailable placement never removes
+// work or changes a runner anchor. The planner owns the shared admission policy.
+export function rebalanceRuntimeTestJobs(
+  jobs: CompactNodeTestShard[],
+  {
+    cost,
+    admits,
+    runnerRank,
+  }: {
+    cost: (groups: NodeTestShardGroup[]) => number;
+    admits: (groups: NodeTestShardGroup[]) => boolean;
+    runnerRank: (job: Pick<CompactNodeTestShard, "runner">) => number;
+  },
+) {
+  for (const donor of jobs.toSorted((a, b) => cost(b.groups) - cost(a.groups))) {
+    if (admits(donor.groups)) {
+      continue;
+    }
+    let best:
+      | { recipient: CompactNodeTestShard; group: NodeTestShardGroup; maximum: number }
+      | undefined;
+    for (const group of donor.groups) {
+      // An inherited job allowance could increase on a different host.
+      if (group.env?.OPENCLAW_VITEST_MAX_WORKERS === undefined) {
+        continue;
+      }
+      const remaining = donor.groups.filter((entry) => entry !== group);
+      if (!admits(remaining)) {
+        continue;
+      }
+      for (const recipient of jobs) {
+        // A group may already have a stronger placement than its declared class.
+        if (recipient === donor || runnerRank(recipient) < runnerRank(donor)) {
+          continue;
+        }
+        const combined = [...recipient.groups, group];
+        const maximum = Math.max(cost(remaining), cost(combined));
+        if (admits(combined) && (!best || maximum < best.maximum)) {
+          best = { recipient, group, maximum };
+        }
+      }
+    }
+    if (best) {
+      const { recipient, group } = best;
+      donor.groups = donor.groups.filter((entry) => entry !== group);
+      recipient.groups = [...recipient.groups, group];
+    }
+  }
+  for (const job of jobs) {
+    // An over-budget unchanged plan is still runnable; estimates are not gates
+    // for test coverage. Only proposed replacements must satisfy admission.
+    job.predictedSeconds = Math.ceil(cost(job.groups));
+  }
+}

--- a/scripts/lib/ci-test-timings-refit.mts
+++ b/scripts/lib/ci-test-timings-refit.mts
@@ -1,6 +1,7 @@
 import { stripVTControlCharacters } from "node:util";
+import { decodeNodeTestGroups } from "./ci-node-test-groups-codec.mts";
 import type { CiTestTimings } from "./ci-test-timings-schema.mts";
-import { parseCompactSplitTimingKey } from "./vitest-shard-metadata.mts";
+import { parseCompactSplitTimingKey, runtimePlacementTimingKey } from "./vitest-shard-metadata.mts";
 
 export type CiTimingRun = {
   id: number;
@@ -12,6 +13,56 @@ export type CiTimingRun = {
 };
 
 type Samples = Map<string, number[]>;
+
+type RuntimeTimingGroup = {
+  shard_name: string;
+  timing_key?: string;
+  configs: string[];
+  includePatterns: string[];
+  env?: Record<string, string>;
+};
+
+function readRuntimeTimingGroups(text: string): RuntimeTimingGroup[] {
+  const encoded = new Set(
+    [
+      ...text.matchAll(
+        /\d{4}-\d\d-\d\dT[\d:.]+Z\s+OPENCLAW_NODE_TEST_GROUPS_GZIP_BASE64: (\S+)$/gmu,
+      ),
+    ].map((match) => match[1]!),
+  );
+  if (encoded.size !== 1) {
+    return [];
+  }
+  try {
+    const groups = decodeNodeTestGroups([...encoded][0]!);
+    const strings = (value: unknown): value is string[] =>
+      Array.isArray(value) && value.every((entry) => typeof entry === "string");
+    return groups.filter((group): group is RuntimeTimingGroup => {
+      if (typeof group !== "object" || group === null) {
+        return false;
+      }
+      return (
+        "shard_name" in group &&
+        typeof group.shard_name === "string" &&
+        (!("timing_key" in group) || typeof group.timing_key === "string") &&
+        "configs" in group &&
+        strings(group.configs) &&
+        group.configs.length > 0 &&
+        "includePatterns" in group &&
+        strings(group.includePatterns) &&
+        group.includePatterns.length > 0 &&
+        (!("env" in group) ||
+          (typeof group.env === "object" &&
+            group.env !== null &&
+            !Array.isArray(group.env) &&
+            Object.values(group.env).every((value) => typeof value === "string")))
+      );
+    });
+  } catch {
+    // Historical/malformed descriptors cannot supply a placement identity.
+    return [];
+  }
+}
 const MIN_PRUNE_RUNS = 3;
 
 function median(values: number[]): number {
@@ -78,7 +129,23 @@ function readCompactLog(
 ) {
   const profile = labels.some((label) => label.startsWith("blacksmith-")) ? "blacksmith" : "github";
   const starts = new Map<string, number>();
+  const descriptors = readRuntimeTimingGroups(text);
+  const runtimeModes = new Map<string, "runtime" | "private-qa">();
   for (const line of text.split("\n")) {
+    const readiness =
+      /\[shard:([^\]]+)\] \[test\] preparing (runtime|private-qa) runtime before Vitest workers/u.exec(
+        line,
+      );
+    if (readiness) {
+      const matches = descriptors.filter((group) => group.shard_name === readiness[1]);
+      if (matches.length === 1) {
+        const group = matches[0]!;
+        const key = group.timing_key ?? group.shard_name;
+        if (starts.has(key)) {
+          runtimeModes.set(key, readiness[2] === "private-qa" ? "private-qa" : "runtime");
+        }
+      }
+    }
     const event =
       /(\d{4}-\d\d-\d\dT[\d:.]+Z)\s+.*?\[shard:([^\]]+)\] (begin|end \(exit (\d+)\))/u.exec(line);
     if (!event) {
@@ -90,6 +157,7 @@ function readCompactLog(
     const exitCode = event[4];
     if (action === "begin") {
       starts.set(key, Date.parse(timestamp));
+      runtimeModes.delete(key);
       continue;
     }
     const started = starts.get(key);
@@ -97,6 +165,14 @@ function readCompactLog(
       // Preserve the workload as executed. Packed plans may be serial or
       // concurrent, and admission must use the wrapper span it actually ran.
       recordSample(samples[profile], key, (Date.parse(timestamp) - started) / 1000);
+      const matches = descriptors.filter((group) => (group.timing_key ?? group.shard_name) === key);
+      const placementKey =
+        matches.length === 1
+          ? runtimePlacementTimingKey({ ...matches[0]!, pretestBuildMode: runtimeModes.get(key) })
+          : undefined;
+      if (placementKey) {
+        recordSample(samples[profile], placementKey, (Date.parse(timestamp) - started) / 1000);
+      }
     }
     starts.delete(key);
   }

--- a/scripts/lib/vitest-shard-metadata.mts
+++ b/scripts/lib/vitest-shard-metadata.mts
@@ -9,6 +9,26 @@ export const VITEST_PRETEST_BUILD_SECONDS: Record<VitestPretestBuildMode, number
   "private-qa": 104,
 };
 
+// Placement observations cannot become parent samples or influence file splitting.
+// Configs own this identity: generated stripe names can change around the same readers.
+export function runtimePlacementTimingKey(group: {
+  configs: readonly string[];
+  env?: Readonly<Record<string, string>>;
+  includePatterns?: readonly string[];
+  pretestBuildMode?: VitestPretestBuildMode;
+}): string | undefined {
+  if (!group.pretestBuildMode || !group.includePatterns?.length) {
+    return undefined;
+  }
+  const identity = JSON.stringify({
+    configs: group.configs,
+    env: Object.entries(group.env ?? {}).toSorted(([a], [b]) => a.localeCompare(b)),
+    includePatterns: group.includePatterns.toSorted(),
+    pretestBuildMode: group.pretestBuildMode,
+  });
+  return `runtime-placement#${createHash("sha1").update(identity).digest("hex")}`;
+}
+
 export type VitestShardTimingSpec = {
   config: string;
   env?: NodeJS.ProcessEnv;

--- a/test/scripts/ci-test-timings.test.ts
+++ b/test/scripts/ci-test-timings.test.ts
@@ -13,12 +13,24 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { stripVTControlCharacters } from "node:util";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { encodeNodeTestGroups } from "../../scripts/lib/ci-node-test-groups-codec.mts";
+import {
+  type CompactNodeTestShard,
+  type NodeTestShardGroup,
+  createNodeTestShardBundles,
+  isExclusiveCompactShardName,
+} from "../../scripts/lib/ci-node-test-plan.mts";
+import { rebalanceRuntimeTestJobs } from "../../scripts/lib/ci-runtime-test-placement.mts";
 import { refitTestTimings, type CiTimingRun } from "../../scripts/lib/ci-test-timings-refit.mts";
 import {
   ciTestTimingsSchema,
   type CiTestTimings,
 } from "../../scripts/lib/ci-test-timings-schema.mts";
-import { createCompactSplitTimingGeneration } from "../../scripts/lib/vitest-shard-metadata.mts";
+import * as testTimings from "../../scripts/lib/ci-test-timings.mts";
+import {
+  createCompactSplitTimingGeneration,
+  runtimePlacementTimingKey,
+} from "../../scripts/lib/vitest-shard-metadata.mts";
 
 function uiLog(files: Record<string, number>, overhead = 0.6) {
   const body = Object.values(files).reduce((sum, value) => sum + value, 0);
@@ -58,6 +70,219 @@ const baseline: CiTestTimings = {
 };
 
 const sampleNow = "2026-08-28T12:00:00.000Z";
+
+describe("runtime placement observations", () => {
+  const reader = {
+    configs: ["test/vitest/reader.config.ts"],
+    env: { OPENCLAW_VITEST_MAX_WORKERS: "2" },
+    includePatterns: ["src/reader.test.ts"],
+    pretestBuildMode: "runtime" as const,
+  };
+  const key = runtimePlacementTimingKey(reader)!;
+  function runtimeLog(
+    id: number,
+    overrides: Partial<Omit<typeof reader, "pretestBuildMode">> & {
+      pretestBuildMode?: "runtime" | "private-qa";
+    } = {},
+  ) {
+    const group = { ...reader, ...overrides };
+    const generation = createCompactSplitTimingGeneration({
+      ...group,
+      parentShardName: "fixture-parent",
+      stripes: [group.includePatterns, [`src/ordinary-${id}.test.ts`]],
+    });
+    const descriptor = {
+      ...group,
+      shard_name: `reader-${id}`,
+      timing_key: generation.timingKeys[0]!,
+    };
+    const [begin, end] = compactLog(20, descriptor.timing_key).split("\n");
+    return [
+      `2026-08-27T23:00:00Z   OPENCLAW_NODE_TEST_GROUPS_GZIP_BASE64: ${encodeNodeTestGroups([descriptor])}`,
+      begin,
+      `2026-08-27T23:00:01Z [shard:${descriptor.shard_name}] [test] preparing ${group.pretestBuildMode} runtime before Vitest workers`,
+      end,
+      compactLog(5, generation.timingKeys[1]!),
+    ].join("\n");
+  }
+  const sample = (id: number, text: string) =>
+    timingRun(id, [
+      {
+        kind: "compact",
+        labels: ["blacksmith-8vcpu-ubuntu-2404"],
+        text,
+      },
+    ]);
+
+  it("retains runtime placement through sibling repartition without changing parent totals", () => {
+    const first = sample(1, runtimeLog(1));
+    const second = sample(
+      2,
+      runtimeLog(2)
+        .split("\n")
+        .map((line) => `job\tstep\t${line}`)
+        .join("\n"),
+    );
+    expect(refitTestTimings([first]).timings.compactGroupSeconds.blacksmith[key]).toBeUndefined();
+    const result = refitTestTimings([first, second]).timings.compactGroupSeconds.blacksmith;
+    expect(result).toEqual({ "fixture-parent": 25, [key]: 20 });
+    expect(
+      refitTestTimings([{ ...first, logs: [...first.logs, ...first.logs] }]).timings
+        .compactGroupSeconds.blacksmith[key],
+    ).toBeUndefined();
+  });
+
+  it.each([
+    { configs: ["test/vitest/different.config.ts"] },
+    { env: { OPENCLAW_VITEST_MAX_WORKERS: "3" } },
+    { includePatterns: ["src/different.test.ts"] },
+    { pretestBuildMode: "private-qa" as const },
+  ])("does not merge runtime placement with changed ownership %j", (change) => {
+    const result = refitTestTimings([sample(1, runtimeLog(1)), sample(2, runtimeLog(2, change))]);
+    expect(
+      Object.keys(result.timings.compactGroupSeconds.blacksmith).filter((entry) =>
+        entry.startsWith("runtime-placement#"),
+      ),
+    ).toEqual([]);
+  });
+
+  it.each(["failed", "missing readiness", "malformed descriptor"])(
+    "rejects %s runtime placement evidence",
+    (kind) => {
+      const runs = [1, 2].map((id) => {
+        let text = runtimeLog(id);
+        if (kind === "failed") {
+          text = text.replaceAll("end (exit 0)", "end (exit 1)");
+        }
+        if (kind === "missing readiness") {
+          text = text
+            .split("\n")
+            .filter((line) => !line.includes("[test] preparing"))
+            .join("\n");
+        }
+        if (kind === "malformed descriptor") {
+          text = text.replace(/BASE64: \S+/u, "BASE64: invalid");
+        }
+        return sample(id, text);
+      });
+      expect(refitTestTimings(runs).timings.compactGroupSeconds.blacksmith[key]).toBeUndefined();
+    },
+  );
+
+  it("admits runtime placement without changing current groups, slots, builds or runner anchors", () => {
+    const blacksmith = testTimings.readCompactGroupTimings("blacksmith");
+    const withoutPlacement = Object.fromEntries(
+      Object.entries(blacksmith).filter(([entry]) => !entry.startsWith("runtime-placement#")),
+    );
+    const spy = vi.spyOn(testTimings, "readCompactGroupTimings");
+    const options = {
+      compactMode: "push" as const,
+      runnerBackend: "hybrid",
+      includeReleaseOnlyPluginShards: false,
+    };
+    try {
+      spy.mockImplementation((profile) => (profile === "blacksmith" ? withoutPlacement : {}));
+      const before = createNodeTestShardBundles(options);
+      spy.mockImplementation((profile) => (profile === "blacksmith" ? blacksmith : {}));
+      const after = createNodeTestShardBundles(options);
+      const groups = (jobs: typeof before) =>
+        jobs
+          .flatMap((job) => job.groups)
+          .map((group) => JSON.stringify(group))
+          .toSorted();
+      expect(groups(after)).toEqual(groups(before));
+      expect(
+        after.map((job) => [job.checkName, job.runner, job.planConcurrency, job.pretestBuildMode]),
+      ).toEqual(
+        before.map((job) => [job.checkName, job.runner, job.planConcurrency, job.pretestBuildMode]),
+      );
+      const changed = after.filter(
+        (job, index) => JSON.stringify(job.groups) !== JSON.stringify(before[index]!.groups),
+      );
+      expect(changed).toHaveLength(2);
+      for (const job of changed) {
+        expect(job.predictedSeconds).toBeLessThanOrEqual(440);
+        expect(job.planConcurrency).toBe(1);
+        expect(job.groups.every((group) => !isExclusiveCompactShardName(group.shard_name))).toBe(
+          true,
+        );
+      }
+      const crossing = changed.flatMap((job) =>
+        job.groups.filter((group) => group.runner !== job.runner),
+      );
+      expect(crossing.length).toBeGreaterThan(0);
+      expect(crossing.every((group) => group.env?.OPENCLAW_VITEST_MAX_WORKERS === "2")).toBe(true);
+      spy.mockImplementation((profile) =>
+        profile === "blacksmith"
+          ? Object.fromEntries(
+              Object.entries(blacksmith).map(([entry, value]) => [
+                entry,
+                entry.startsWith("runtime-placement#") ? 1_000 : value,
+              ]),
+            )
+          : {},
+      );
+      const unfit = createNodeTestShardBundles(options);
+      expect(groups(unfit)).toEqual(groups(before));
+      expect(unfit.map((job) => [job.checkName, job.runner, job.groups])).toEqual(
+        before.map((job) => [job.checkName, job.runner, job.groups]),
+      );
+      expect(unfit.some((job) => (job.predictedSeconds ?? 0) > 440)).toBe(true);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it.each(["medium", "strong"])(
+    "preserves the runtime placement donor anchor against %s capacity",
+    (recipientRunner) => {
+      const group = (name: string, pinned = false): NodeTestShardGroup => ({
+        shard_name: name,
+        configs: ["test/vitest/reader.config.ts"],
+        includePatterns: [`src/${name}.test.ts`],
+        pretestBuildMode: "runtime",
+        requiresDist: false,
+        runner: "small",
+        ...(pinned ? { env: { OPENCLAW_VITEST_MAX_WORKERS: "2" } } : {}),
+      });
+      const moved = group("moved", true);
+      const retained = group("retained");
+      const spare = group("spare");
+      const job = (
+        name: string,
+        runner: string,
+        groups: NodeTestShardGroup[],
+      ): CompactNodeTestShard => ({
+        checkName: name,
+        shardName: name,
+        runner,
+        groups,
+        requiresDist: false,
+        pretestBuildMode: "runtime",
+        planConcurrency: 1,
+        predictedSeconds: 0,
+      });
+      const jobs = [
+        job("donor", "strong", [moved, retained]),
+        job("recipient", recipientRunner, [spare]),
+      ];
+      const cost = (groups: NodeTestShardGroup[]) =>
+        100 + groups.reduce((sum, entry) => sum + (entry === spare ? 50 : 200), 0);
+      rebalanceRuntimeTestJobs(jobs, {
+        cost,
+        admits: (groups) => groups.length > 0 && cost(groups) <= 440,
+        runnerRank: ({ runner }) => ["small", "medium", "strong"].indexOf(runner),
+      });
+      expect(jobs.map((entry) => entry.runner)).toEqual(["strong", recipientRunner]);
+      expect(jobs.map((entry) => entry.groups)).toEqual(
+        recipientRunner === "strong" ? [[retained], [spare, moved]] : [[moved, retained], [spare]],
+      );
+      expect(jobs.map((entry) => entry.predictedSeconds)).toEqual(
+        recipientRunner === "strong" ? [300, 350] : [500, 150],
+      );
+    },
+  );
+});
 
 function samplerRun(id: number, overrides: Record<string, unknown> = {}) {
   return {

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -3676,6 +3676,30 @@ NODE
   );
 
   it.skipIf(process.platform === "win32")(
+    "defers timing refits when only the runtime group codec changes on main",
+    () => {
+      const workflow = readWorkflow(".github/workflows/ci-test-timings-refit.yml");
+      const publisher = expectDefined(
+        workflow.jobs.refit.steps.find(
+          (step: WorkflowStep) => step.uses === "./.github/actions/publish-generated-pr",
+        ),
+        "timing refit publisher",
+      );
+      const result = runGeneratedPublisherScenario(null, {
+        invalidationPaths: publisher.with["invalidation-paths"],
+        updateSource: "scripts/lib/ci-node-test-groups-codec.mts",
+      });
+
+      expect(result.branchExists).toBe(false);
+      expect(result.mainGeneratedA).toBe("old-a");
+      expect(result.mergeCalls).toBe("");
+      expect(result.summary).toContain(
+        "Deferred stale generated output because generator inputs changed on main.",
+      );
+    },
+  );
+
+  it.skipIf(process.platform === "win32")(
     "publishes after unrelated source changes when input invalidation is disabled",
     () => {
       const result = runGeneratedPublisherScenario(null, {

--- a/test/scripts/generated-publisher.test-support.ts
+++ b/test/scripts/generated-publisher.test-support.ts
@@ -78,7 +78,7 @@ export type GeneratedPublisherOptions = {
   overlapPolicy?: string;
   stalePrHeadOnce?: boolean;
   stalePrViewHeadOnce?: boolean;
-  updateSource?: boolean;
+  updateSource?: boolean | string;
 };
 export function prepareGeneratedPublisherFixture(
   root: string,
@@ -132,10 +132,13 @@ export function prepareGeneratedPublisherFixture(
       );
     }
     if (options.updateSource) {
-      writeFileSync(path.join(updater, "source", "input.txt"), "newer-input\n", "utf8");
+      const sourcePath =
+        typeof options.updateSource === "string" ? options.updateSource : "source/input.txt";
+      mkdirSync(path.dirname(path.join(updater, sourcePath)), { recursive: true });
+      writeFileSync(path.join(updater, sourcePath), "newer-input\n", "utf8");
     }
     if (!options.updateSourceBeforeAutoMerge) {
-      runGit(updater, ["add", "generated", "source"]);
+      runGit(updater, ["add", "--all"]);
       runGit(updater, ["commit", "-m", "update base"]);
       runGit(updater, ["push", "origin", "main"]);
     }


### PR DESCRIPTION
## What Problem This Solves

Resolves a CI imbalance where a runtime test job remains busy for roughly eleven minutes while another compatible runtime job finishes much earlier. The planner's existing estimates lose the measured cost of an individual group after file splitting.

## Why This Change Was Made

Record stable measurements for complete runtime groups after splitting, then move whole groups between compatible existing jobs. The planner keeps runner capacity, worker limits, preparation mode and the complete test inventory. A group that cannot fit remains runnable with an honest over-budget estimate.

The timing refit still requires qualifying measurements from two distinct runs. The added seed measurements come from successful compact jobs; one containing workflow failed in an unrelated job. Placement measurements stay separate from the weights that determine file splitting. The current plan moves the startup corpus as one group, changing the two affected jobs from six/six groups to five/seven while retaining the 27-job matrix.

## User Impact

Developers get a shorter runtime-test critical path with the existing runner allocation. Product runtime behavior and configuration are unchanged.

## Evidence

- 198 planner/refit owner tests passed, including regressions for preserving coverage when no transfer fits and rejecting a destination smaller than the donor's fixed runner. Changed-scope checks and independent P2 review passed.
- Addressed the timing-publisher review finding: a codec-only input change now defers stale generated output. The real publisher regression failed before the fix and passed afterward with two related controls. Changed checks, pinned actionlint, Git-owner/composite guards and independent P2 review passed. Full local `check:workflows` remains unavailable because the pinned Python prerequisite is missing; hosted validation is required.
- Four complete native Linux job runs preserved all 12 groups, 18 files and 366 passing cases per placement. Raw case multisets, effective worker settings and compiled input hashes matched; native cleanup, source checks and observed process/OOM checks passed.
- On the same 2-CPU, 7.60-GiB AWS host, maximum per-job build plus test time changed from **1,179.16s to 806.01s (31.6% lower)**. Before: 1,179.16s / 416.76s; after: 775.82s / 806.01s. Source fetch, installation and transfer time are excluded.

This is relative performance evidence, not a claim that AWS or current CI completed within eight minutes. The AWS CPU was slower than the corresponding CI runners. Each job used fresh named caches; OS page-cache/order effects remained uncontrolled. A diagnostic interruption corrected the benchmark's assumption that parameterized test display names are unique; the completed baseline was preserved and independently revalidated before continuing. Exact-head CI and subsequent main timing remain the landing/monitoring gates.

The change adds 206 net tooling lines for measurement/placement ownership, one workflow line, 252 test/support lines, 11 timing-data lines and 33 documentation/skill lines; product runtime delta is zero. The remaining CLI and ordinary multi-group tails are separate ongoing work.

The initial exact-head CI run failed in an unchanged CLI-process test with a 60-second `spawnSync` timeout while checking rejected update arguments ([job log](https://github.com/openclaw/openclaw/actions/runs/34693401938/job/103552700992)). The placement optimization is inactive for that PR profile and excludes this independent group. The stalled phase is unlocalized; it is not reported as fixed. A later run failed the unchanged UI heap-retention child at its existing 20-second guard ([job](https://github.com/openclaw/openclaw/actions/runs/34696814975/job/103561677643)). Local phase/pattern tracing attributed most measured payload work to the shared AWS-key matcher, but did not reproduce that timeout. Main subsequently landed the owner repair in [#145810](https://github.com/openclaw/openclaw/pull/145810), including fast candidate admission. This branch was refreshed onto main `2bfa3ebc98b8` with both commits patch-identical. The unchanged 9-case UI file passes locally, and the refreshed hosted UI job now passes: the two heap cases took **5.479s / 5.368s**, with **10.856s** for the file ([job](https://github.com/openclaw/openclaw/actions/runs/34700553747/job/103571513986)). The earlier file took 39.369s with one timed-out case. Both jobs used two logical CPUs, three UI workers and Node 24.19; differing run/source/cache conditions prevent isolated attribution. The remaining exact-head checks must finish before landing.

## Maintainer Performance Decision

The latest review identifies uncertainty about translating the AWS comparison into an eight-minute CI result, with no actionable patch defect. Accept that limitation for this incremental change: the complete inventory, runner allocation, capacity admission and worker limits remain protected. The eight-minute objective is a target for the wider optimization effort, not a result claimed by this PR. After required exact-head CI passes, merge this measured relative improvement and inspect the first fresh main cycle; revise or revert placement if actual runtime tails regress. No extra sharding or cache infrastructure is part of this decision.
