### PR TITLE
refactor(cli): remove session-loader test injection

### DIFF
--- a/src/commands/agent-via-gateway.test.ts
+++ b/src/commands/agent-via-gateway.test.ts
@@ -20,6 +20,7 @@ import { acquireGatewayLock, type GatewayLockOptions } from "../infra/gateway-lo
 import { loggingState } from "../logging/state.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { AGENT_HARNESS_SESSION_KEY_RESERVED_MESSAGE } from "../sessions/agent-harness-session-key.js";
+import { createDeferredCore } from "../shared/deferred.js";
 import { agentCliCommand, agentViaGatewayTesting } from "./agent-via-gateway.js";
 import type { agentCommand as AgentCommand } from "./agent.js";
 
@@ -321,10 +322,12 @@ function resetAgentCliCommandMocksForTest() {
   vi.stubEnv("OPENCLAW_GATEWAY_URL", "");
   agentViaGatewayTesting.resetLazyImportsForTests();
   agentViaGatewayTesting.setGatewayAbortRetryDelaysMsForTests([0, 0, 0, 0]);
-  loadAgentSessionModuleMock.mockImplementation(
-    async () => await import("./agent/session.runtime.js"),
-  );
-  agentViaGatewayTesting.setAgentSessionModuleLoaderForTests(loadAgentSessionModuleMock);
+  // Each test observes a fresh mock generation, even after the real module was
+  // warmed; a single hoisted factory would hide later unexpected imports.
+  vi.doMock("./agent/session.runtime.js", async (importOriginal) => {
+    loadAgentSessionModuleMock();
+    return await importOriginal<typeof import("./agent/session.runtime.js")>();
+  });
   originalForceConsoleToStderr = loggingState.forceConsoleToStderr;
   loggingState.forceConsoleToStderr = false;
 }
@@ -334,6 +337,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  vi.doUnmock("./agent/session.runtime.js");
   vi.unstubAllEnvs();
   configureExecutionIdentityAdmissionSink(() => false)();
   agentViaGatewayTesting.setGatewayAbortRetryDelaysMsForTests();
@@ -355,6 +359,7 @@ describe("agentCliCommand", () => {
         zeroTimeoutGatewayRequestMs = request.timeoutMs;
       });
     } finally {
+      vi.doUnmock("./agent/session.runtime.js");
       agentViaGatewayTesting.setGatewayAbortRetryDelaysMsForTests();
       loggingState.forceConsoleToStderr = restoreForceConsoleToStderr;
     }
@@ -2671,8 +2676,10 @@ describe("agentCliCommand", () => {
       try {
         await withTempStore(async () => {
           const error = createGatewayNormalCloseError();
+          const gatewayStarted = createDeferredCore();
           callGateway.mockImplementation(
             async (request: { onAccepted?: (payload: unknown) => void }) => {
+              gatewayStarted.resolve();
               if (accepted && callGateway.mock.calls.length === 1) {
                 request.onAccepted?.({ status: "accepted", runId: "gateway-before-retry" });
                 throw createGatewayNormalCloseError();
@@ -2683,6 +2690,8 @@ describe("agentCliCommand", () => {
 
           const command = agentCliCommand({ message: "hi", to: "+1555" }, runtime);
           const rejection = expect(command).rejects.toBe(error);
+          // Module loading is not driven by fake time; observe dispatch before advancing it.
+          await gatewayStarted.promise;
           await vi.advanceTimersByTimeAsync(33_000);
           await rejection;
 
@@ -3013,6 +3022,70 @@ describe("agentCliCommand", () => {
 
     expect(callGateway).toHaveBeenCalledTimes(1);
     expect(runtime.exit).not.toHaveBeenCalledWith(1);
+  });
+
+  it("keeps a resolved session module cached until the existing lazy reset", async () => {
+    await withTempStore(async () => {
+      mockGatewaySuccessReply();
+      const run = () => agentCliCommand({ message: "hi", to: "+1555" }, runtime);
+      await expect(run()).resolves.toEqual(gatewaySuccessReply("hello"));
+      expect(loadAgentSessionModuleMock).toHaveBeenCalledOnce();
+
+      const nextGeneration = vi.fn();
+      vi.doMock("./agent/session.runtime.js", async (importOriginal) => {
+        nextGeneration();
+        return await importOriginal<typeof import("./agent/session.runtime.js")>();
+      });
+      await expect(run()).resolves.toEqual(gatewaySuccessReply("hello"));
+      expect(nextGeneration).not.toHaveBeenCalled();
+
+      agentViaGatewayTesting.resetLazyImportsForTests();
+      await expect(run()).resolves.toEqual(gatewaySuccessReply("hello"));
+      expect(nextGeneration).toHaveBeenCalledOnce();
+      expect(callGateway).toHaveBeenCalledTimes(3);
+      expect(
+        callGateway.mock.calls.map(([value]) => {
+          const request = requireRecord(value, "gateway request");
+          return requireRecord(request.params, "gateway params").sessionKey;
+        }),
+      ).toEqual(["agent:main:main", "agent:main:main", "agent:main:main"]);
+    });
+  });
+
+  it("keeps a rejected session module cached until the existing lazy reset", async () => {
+    await withTempStore(async () => {
+      const failure = new Error("synthetic session module load failure");
+      const rejectedGeneration = vi.fn(() => {
+        throw failure;
+      });
+      vi.doMock("./agent/session.runtime.js", rejectedGeneration);
+      const signals = createSignalProcess();
+      const run = () =>
+        agentCliCommand({ message: "hi", to: "+1555" }, runtime, {
+          process: signals.processLike,
+        });
+      const firstError = await run().catch((error: unknown) => error);
+      expect(firstError).toBeInstanceOf(Error);
+      expect(firstError).toMatchObject({ cause: failure });
+      expect(rejectedGeneration).toHaveBeenCalledOnce();
+
+      const nextGeneration = vi.fn();
+      vi.doMock("./agent/session.runtime.js", async (importOriginal) => {
+        nextGeneration();
+        return await importOriginal<typeof import("./agent/session.runtime.js")>();
+      });
+      await expect(run()).rejects.toBe(firstError);
+      expect(nextGeneration).not.toHaveBeenCalled();
+      expect(callGateway).not.toHaveBeenCalled();
+      expect(signals.listenerCount("SIGINT") + signals.listenerCount("SIGTERM")).toBe(0);
+
+      agentViaGatewayTesting.resetLazyImportsForTests();
+      mockGatewaySuccessReply();
+      await expect(run()).resolves.toEqual(gatewaySuccessReply("hello"));
+      expect(nextGeneration).toHaveBeenCalledOnce();
+      expect(callGateway).toHaveBeenCalledOnce();
+      expect(signals.listenerCount("SIGINT") + signals.listenerCount("SIGTERM")).toBe(0);
+    });
   });
 });
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/commands/agent-via-gateway.ts
+++ b/src/commands/agent-via-gateway.ts
@@ -147,8 +147,6 @@ type AgentGatewayCallIdentity = Pick<
   Parameters<typeof callGateway>[0],
   "clientName" | "mode" | "scopes"
 >;
-type AgentSessionModule = typeof import("./agent/session.runtime.js");
-type AgentSessionModuleLoader = () => Promise<AgentSessionModule>;
 
 function usesImplicitRemoteCompatibilityDefault(roster: RemoteGatewayRoster): boolean {
   return (
@@ -190,9 +188,6 @@ const AGENT_CLI_SIGNAL_EXIT_CODES: Record<AgentCliSignal, number> = {
 };
 const MESSAGE_FILE_DECODER = new TextDecoder("utf-8", { fatal: true });
 
-const defaultAgentSessionModuleLoader: AgentSessionModuleLoader = () =>
-  import("./agent/session.runtime.js");
-let agentSessionModuleLoader: AgentSessionModuleLoader = defaultAgentSessionModuleLoader;
 const embeddedAgentCommandLoader = createLazyPromiseLoader(
   () => import("./agent.js").then((module) => module.agentCommand),
   { cacheRejections: true },
@@ -200,9 +195,10 @@ const embeddedAgentCommandLoader = createLazyPromiseLoader(
 const localAuditModuleLoader = createLazyPromiseLoader(() => import("./agent-local-audit.js"), {
   cacheRejections: true,
 });
-const agentSessionModuleCache = createLazyPromiseLoader(() => agentSessionModuleLoader(), {
-  cacheRejections: true,
-});
+const agentSessionModuleCache = createLazyPromiseLoader(
+  () => import("./agent/session.runtime.js"),
+  { cacheRejections: true },
+);
 const runtimeConfigModuleLoader = createLazyPromiseLoader(() => import("../config/io.js"), {
   cacheRejections: true,
 });
@@ -359,11 +355,6 @@ export const agentViaGatewayTesting = {
     runtimeConfigModuleLoader.clear();
     embeddedStateLockModuleLoader.clear();
     replyPayloadModuleLoader.clear();
-    agentSessionModuleLoader = defaultAgentSessionModuleLoader;
-  },
-  setAgentSessionModuleLoaderForTests(loader: AgentSessionModuleLoader): void {
-    agentSessionModuleCache.clear();
-    agentSessionModuleLoader = loader;
   },
   setGatewayAbortRetryDelaysMsForTests(delays?: readonly number[]): void {
     gatewayAbortRetryDelaysMsForTests = delays;


### PR DESCRIPTION
## What Problem This Solves

The CLI agent command carried a mutable session-module loader solely so its tests could replace the import. That duplicated an ownership boundary already provided by the lazy promise cache and Vitest's module-mocking lifecycle.

## Why This Change Was Made

Remove the private loader injection and import the same session runtime directly through the existing lazy cache. Keep demand-driven loading, cached rejection, reset-driven generations, retry timing, abort handling and signal cleanup unchanged. Tests now replace the module at its real import boundary and explicitly cover successful and rejected cache generations.

Production: **+4/-13 (net -9)**. Tests: **+77/-4 (net +73)**. No dependency, public API, CLI flag, configuration, persistence, protocol or security-policy changes.

## User Impact

No user-visible behavior change is intended. The agent command retains the same routing, output and lifecycle behavior, with one less test-only indirection in production.

## Evidence

- The unchanged original owner suite passed **125 tests with one existing Linux-procfs skip**. The final complete owner suite passed **127 tests with the same skip**; all 126 original case identities, order and statuses were retained, with two additional passing cache-generation cases.
- Two temporary cache controls failed at their intended assertions: bypassing cache reuse and disabling rejection caching. Each exact restoration passed both cache cases, and the restored complete suite passed.
- The normal full build and enforcing `pnpm ui:check-performance` passed. Startup JavaScript was **354,832 gzip bytes against a 355,116-byte cap**, with 8 requests; CSS was **45,842 bytes against a 51,200-byte cap**. No budget or report-only override was used.
- Two separate cold processes ran the real built `node openclaw.mjs agent` command, using `--to` and `--agent main` respectively, against an isolated synthetic loopback peer. Both completed with the expected connect/RPC frames and exact output; peer, child-process and temporary-state cleanup passed. This is built-CLI/protocol proof, **not a real Gateway, live provider or model invocation**.
- The final normal two-file changed check passed **all 29 planned checks** on the configured Linux Testbox route. This is a completed command/gate result, not a claim that the cleanup-cancelled backing workflow or not-yet-created PR CI is green.
- Separate normal Codex precommit and exact-commit P0–P2 reviews returned no actionable findings. Each retained all six automatically partitioned reports; no prior review verdict was supplied to the second review.

During test migration, asynchronous mock loading exposed a fake-timer synchronization gap. The test now waits for the actual Gateway dispatch before advancing the unchanged 33-second timer. Two subsequent static-check failures were corrected with the existing typed deferred helper and its default type argument. The final owner suite and full 29-check gate passed. Earlier observer failures involving ordinary generated files or unrelated metadata changes were retained and closed with additive source/artifact checks; they were not erased by rerunning successful product proof.

The full build and cold-CLI checks preceded those final test-only typing edits; production bytes did not change. Proof is bound to this patch's tested base and installed dependencies. Exact-head CI run 34693850892 completed successfully on attempt 1 (76 successful jobs, 17 skipped), and native review-artifact validation passed. Preparation and merge remain pending.
