### PR TITLE
fix(ui): clear stale table copy success after a failed retry

### DIFF
--- a/docs/web/control-ui/chat.md
+++ b/docs/web/control-ui/chat.md
@@ -256,7 +256,7 @@ cancel native clipboard writes that the browser has already accepted.
 ### Markdown tables
 
 Markdown tables scroll horizontally within the conversation. **Copy table** copies
-tab-separated cells, and **Expand table** opens a larger view. In Chat, workspace
+tab-separated cells, and **Expand table** opens a larger view. If copying fails, the button clears any earlier success checkmark. In Chat, workspace
 file and session links work in either view, including Enter and Space keyboard
 activation. Following a link closes the expanded view so you can use its destination.
 

--- a/ui/src/components/markdown-tables.test.ts
+++ b/ui/src/components/markdown-tables.test.ts
@@ -167,6 +167,51 @@ describe("Markdown table interactions", () => {
     expect(copy.querySelector("svg rect")).not.toBeNull();
   });
 
+  it.each([true, false])(
+    "shows a failed current table copy without stale success (previous success: %s)",
+    async (previousSuccess) => {
+      vi.useFakeTimers();
+      const execDescriptor = Object.getOwnPropertyDescriptor(document, "execCommand");
+      const legacyCopy = vi.fn(() => false);
+      Object.defineProperty(document, "execCommand", { configurable: true, value: legacyCopy });
+      try {
+        const { owner } = interactiveOwner();
+        const copy = owner.querySelector<HTMLButtonElement>(".markdown-table__copy")!;
+        if (previousSuccess) {
+          copy.click();
+          await vi.advanceTimersByTimeAsync(0);
+          expect(copy.getAttribute("aria-label")).toBe("Copied!");
+          expect(copy.querySelector("svg path")?.getAttribute("d")).toBe("M20 6 9 17l-5-5");
+        }
+
+        writeText.mockRejectedValueOnce(
+          new DOMException("Clipboard access denied", "NotAllowedError"),
+        );
+        copy.click();
+        await vi.advanceTimersByTimeAsync(0);
+
+        expect(writeText).toHaveBeenLastCalledWith("Name\tValue\nAlpha\tOne");
+        expect(legacyCopy).toHaveBeenCalledExactlyOnceWith("copy");
+        expect(copy.getAttribute("aria-label")).toBe("Copy failed");
+        expect(copy.querySelector("svg rect")).not.toBeNull();
+        await vi.advanceTimersByTimeAsync(1500);
+        expect(copy.getAttribute("aria-label")).toBe("Copy failed");
+
+        copy.click();
+        await vi.advanceTimersByTimeAsync(0);
+        expect(copy.getAttribute("aria-label")).toBe("Copied!");
+        expect(copy.querySelector("svg path")?.getAttribute("d")).toBe("M20 6 9 17l-5-5");
+        await vi.advanceTimersByTimeAsync(500);
+        expect(copy.getAttribute("aria-label")).toBe("Copied!");
+        await vi.advanceTimersByTimeAsync(1000);
+        expect(copy.getAttribute("aria-label")).toBe("Copy table");
+        expect(copy.querySelector("svg rect")).not.toBeNull();
+      } finally {
+        restoreProperty(document, "execCommand", execDescriptor);
+      }
+    },
+  );
+
   it("restores focus after the table dialog closes", async () => {
     const { owner } = interactiveOwner();
     const expand = owner.querySelector<HTMLButtonElement>(".markdown-table__expand")!;

--- a/ui/src/components/markdown-tables.ts
+++ b/ui/src/components/markdown-tables.ts
@@ -244,9 +244,7 @@ export function handleMarkdownTableInteraction(event: Event): void {
         return;
       }
       copy.setAttribute("aria-label", t(copied ? "common.copied" : "common.copyFailed"));
-      if (copied) {
-        render(icons.check, copy);
-      }
+      render(copied ? icons.check : icons.copy, copy);
       clearTimeout(tableCopyResetTimers.get(copy));
       const resetTimer = setTimeout(
         () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users copying a Markdown table again after a successful copy would still see the success checkmark when the retry failed. The button already announced “Copy failed”, so its icon contradicted its result.

## Why This Change Was Made

The table interaction owner now renders the icon from every completed copy result. This removes the success-only branch while preserving the current-attempt guard, clipboard fallback, and reset timers. Production changes are +1/−3 lines (net −2); regression coverage adds 45 lines. The docs describe the corrected feedback.

## User Impact

A failed retry clears the earlier success checkmark and leaves the copy icon available. Successful copies still show the checkmark and reset normally.

## Evidence

The prior-success regression failed before the repair; the first-failure control passed. Afterward, all 11 table interaction tests and 10 shared clipboard tests pass. Changed-file formatting, lint, and type checks pass. The production UI build and bundle-size checks pass.

Paired Chromium runs exercised the full Control UI with synthetic mock-Gateway history. The first click used the native Clipboard API and verified the table TSV by readback. A controlled second clipboard failure preserved a sentinel: the same button showed the stale checkmark before and the copy icon afterward, with “Copy failed” in both accessibility labels. Failure captures completed 136.5 ms and 139.0 ms after initial success, before the 1500 ms reset. Both drivers exited successfully and their owned browsers/servers closed.

The attached screenshots were inspected and contain synthetic data only. This is source-mode UI proof with controlled clipboard failure; it does not claim a real browser permission-denial flow. The paired runtime owner sources are unchanged through main ecfbddbbcc819d0bb9d5ef10adf560117cf67a4a. Independent Auto Review found no actionable P0–P2 findings.

![Before: failed retry retains the success checkmark](https://github.com/user-attachments/assets/cb20fcf3-9caf-4625-a014-dab13a08ed41)

![After: failed retry restores the copy icon](https://github.com/user-attachments/assets/d868a3e3-6b83-4130-8f96-b75b79e17599)