### PR TITLE
fix(snapshot): frame Git backup JSONL reads on LF only

### DIFF
--- a/src/snapshot/git-backup-codec.test.ts
+++ b/src/snapshot/git-backup-codec.test.ts
@@ -9,6 +9,51 @@ import {
 } from "../state/openclaw-state-db.js";
 import { dumpGitBackupDatabase, restoreGitBackupDirectory } from "./git-backup-codec.js";
 
+it("preserves literal line-separator and paragraph-separator TEXT through verify and restore", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "git-backup-u2028-"));
+  const sourcePath = path.join(root, "source.sqlite");
+  const outputPath = path.join(root, "dump");
+  const targetPath = path.join(root, "restored.sqlite");
+  const keys = ["ls", "ps", "ascii control"];
+  const values = ["lead\u2028tail", "a\u2029b", "plain"];
+  try {
+    const source = openOpenClawStateDatabase({ path: sourcePath });
+    source.db.exec('CREATE TABLE text_values ("key" TEXT PRIMARY KEY, value ANY) STRICT');
+    const insert = source.db.prepare('INSERT INTO text_values ("key", value) VALUES (?, ?)');
+    for (let index = keys.length - 1; index >= 0; index -= 1) {
+      insert.run(keys[index]!, values[index]!);
+    }
+    closeOpenClawStateDatabaseForTest();
+
+    await dumpGitBackupDatabase({
+      snapshotPath: sourcePath,
+      outputPath,
+      identity: { role: "global" },
+    });
+    const restored = await restoreGitBackupDirectory({
+      sourcePath: outputPath,
+      targetPath,
+      expectedIdentity: { role: "global" },
+    });
+    expect(restored.tables.every((table) => table.ok)).toBe(true);
+    const database = new DatabaseSync(targetPath, { readOnly: true });
+    try {
+      expect(database.prepare('SELECT "key", value FROM text_values ORDER BY "key"').all()).toEqual(
+        [
+          { key: keys[2], value: values[2] },
+          { key: keys[0], value: values[0] },
+          { key: keys[1], value: values[1] },
+        ],
+      );
+    } finally {
+      database.close();
+    }
+  } finally {
+    closeOpenClawStateDatabaseForTest();
+    await fs.rm(root, { recursive: true, force: true });
+  }
+});
+
 it("preserves NUL-bearing TEXT, storage classes, and source key order", async () => {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "git-backup-text-"));
   const sourcePath = path.join(root, "source.sqlite");

--- a/src/snapshot/git-backup-codec.ts
+++ b/src/snapshot/git-backup-codec.ts
@@ -2,9 +2,9 @@ import { createHash } from "node:crypto";
 import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
-import { createInterface } from "node:readline";
 import type { DatabaseSync } from "node:sqlite";
 import { finished } from "node:stream/promises";
+import { StringDecoder } from "node:string_decoder";
 import { openNodeSqliteDatabase } from "../infra/node-sqlite.js";
 import { applyPrivateModeSync } from "../infra/private-mode.js";
 import { assertSqliteIntegrity } from "../infra/sqlite-integrity.js";
@@ -549,9 +549,7 @@ async function loadGitBackupTable(
      VALUES (${columns.map(() => "?").join(", ")})`,
   );
   const input = fsSync.createReadStream(inputPath);
-  const lines = createInterface({ input, crlfDelay: Infinity });
   const hash = createHash("sha256");
-  input.on("data", (chunk: Buffer) => hash.update(chunk));
   const pending: Array<ReturnType<typeof decodeSqliteValue>[]> = [];
   let pendingBytes = 0;
   let rows = 0;
@@ -574,23 +572,37 @@ async function loadGitBackupTable(
     pending.length = 0;
     pendingBytes = 0;
   };
+  // JSONL framing is LF-only: the encoder emits unescaped U+2028/U+2029 inside
+  // JSON strings, and a generic line reader would split the JSON value there.
+  const acceptLine = (line: string) => {
+    if (!line) {
+      return;
+    }
+    const parsed = JSON.parse(line) as Record<string, unknown>;
+    pending.push(columns.map((column) => decodeSqliteValue(parsed[column.name])));
+    pendingBytes += Buffer.byteLength(line);
+    rows += 1;
+    if (pendingBytes >= TABLE_BATCH_BYTES) {
+      flush();
+    }
+  };
+  let buffered = "";
+  const decoder = new StringDecoder("utf8");
   try {
-    for await (const line of lines) {
-      if (!line) {
-        continue;
-      }
-      const parsed = JSON.parse(line) as Record<string, unknown>;
-      pending.push(columns.map((column) => decodeSqliteValue(parsed[column.name])));
-      pendingBytes += Buffer.byteLength(line);
-      rows += 1;
-      if (pendingBytes >= TABLE_BATCH_BYTES) {
-        flush();
+    for await (const chunk of input) {
+      hash.update(chunk);
+      buffered += decoder.write(chunk);
+      let newlineIndex: number;
+      while ((newlineIndex = buffered.indexOf("\n")) !== -1) {
+        acceptLine(buffered.slice(0, newlineIndex));
+        buffered = buffered.slice(newlineIndex + 1);
       }
     }
+    buffered += decoder.end();
+    acceptLine(buffered);
     flush();
     return { rows, sha256: hash.digest("hex") };
   } finally {
-    lines.close();
     input.destroy();
     await finished(input).catch(() => undefined);
   }


### PR DESCRIPTION
## What Problem This Solves

`openclaw backup git create` succeeds, but `verify` and `restore` exit 1 with `Unterminated string in JSON` whenever any stored TEXT value contains a literal U+2028 (line separator) or U+2029 (paragraph separator). On 2026.9.4 a backup containing such values is created "successfully" and then cannot be verified or restored — a silent-until-recovery data availability failure for the Git backup path.

Closes #145938.

## Root Cause

The encoder emits JSON lines with LF terminators and leaves U+2028/U+2029 unescaped inside JSON string values (`JSON.stringify` does not escape them, and SQLite TEXT accepts them verbatim). The reader side, `loadGitBackupTable` in `src/snapshot/git-backup-codec.ts`, consumed the JSONL stream through `node:readline`, whose line splitting also treats U+2028/U+2029 as line terminators. A value containing one of these characters was therefore split mid-string into two lines, and the first half failed `JSON.parse` with `Unterminated string in JSON`. The generated artifact itself was valid and its manifest checksum matched, so creation never caught the divergence.

This is the same readline framing defect previously fixed for the iMessage RPC stdout framing in #90845.

## Solution

`loadGitBackupTable` now reads the JSONL stream directly and splits on LF alone, with `StringDecoder` preserving multi-byte UTF-8 sequences across chunk boundaries. A trailing line without a final LF is still processed, and empty lines are skipped as before.

Streaming and digest semantics are unchanged: the sha256 still covers every stream byte, rows still flush in bounded batched transactions, and the reader still releases the stream deterministically. Net effect: production split point narrowed to exactly what the format defines.

## Evidence

Pre-fix reproduction (head without the fix): a global state database holding the TEXT values `lead tail` (literal U+2028 between the words) and `a b` (literal U+2029) round-trips through `dumpGitBackupDatabase` — the JSONL artifact is well-formed — and then `restoreGitBackupDirectory` throws:

```
SyntaxError: Unterminated string in JSON at position 25 (line 1 column 26)
 ❯ loadGitBackupTable src/snapshot/git-backup-codec.ts:582:27
    582|       const parsed = JSON.parse(line) as Record<string, unknown>;
 ❯ restoreGitBackupDirectory src/snapshot/git-backup-codec.ts:653:22
```

That is the exact failure surfaced by `openclaw backup git verify` and `openclaw backup git restore` in the linked issue. Post-fix, the new regression test in `src/snapshot/git-backup-codec.test.ts` asserts the restored database preserves both separator-bearing values byte-for-byte alongside the ASCII control, and the full `git-backup-codec.test.ts` suite passes (the pre-existing NUL/storage-class round-trip test continues to pass, confirming no change to framing or digest behavior for the previously covered cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
