### PR TITLE
improve(config): keep recovery responsive during health snapshots

### DIFF
--- a/src/config/io.health-state.ts
+++ b/src/config/io.health-state.ts
@@ -1,7 +1,12 @@
+import type { DatabaseSync } from "node:sqlite";
 import { formatErrorMessage } from "../infra/errors.js";
 import { executeSqliteQuerySync, getNodeSqliteKysely } from "../infra/kysely-sync.js";
 import { findStartupMaintenanceRequiredError } from "../infra/startup-maintenance-required.js";
-import { withExistingOpenClawStateDatabaseReadOnly } from "../state/openclaw-state-db-readonly.js";
+import {
+  isArtifactPreservingStateRead,
+  withExistingOpenClawStateDatabaseArtifactPreservingReadOnlyAsync,
+  withExistingOpenClawStateDatabaseReadOnly,
+} from "../state/openclaw-state-db-readonly.js";
 // Stores config health fingerprints in shared SQLite state.
 import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-db.generated.js";
 import { runOpenClawStateWriteTransaction } from "../state/openclaw-state-db.js";
@@ -71,39 +76,62 @@ function stringifyConfigHealthFingerprint(
   return value ? JSON.stringify(value) : null;
 }
 
+function readConfigHealthState(database: { db: DatabaseSync }): ConfigHealthState {
+  const healthDb = getNodeSqliteKysely<ConfigHealthDatabase>(database.db);
+  const rows = executeSqliteQuerySync(
+    database.db,
+    healthDb
+      .selectFrom("config_health_entries")
+      .select([
+        "config_path",
+        "last_known_good_json",
+        "last_promoted_good_json",
+        "last_observed_suspicious_signature",
+      ])
+      .orderBy("config_path", "asc"),
+  ).rows;
+  return {
+    entries: Object.fromEntries(
+      rows.map((row) => [
+        row.config_path,
+        {
+          lastKnownGood: parseConfigHealthFingerprint(row.last_known_good_json),
+          lastPromotedGood: parseConfigHealthFingerprint(row.last_promoted_good_json),
+          lastObservedSuspiciousSignature: row.last_observed_suspicious_signature,
+        } satisfies ConfigHealthEntry,
+      ]),
+    ),
+  };
+}
+
 export function readConfigHealthStateFromStore(deps: ConfigHealthStateDeps): ConfigHealthState {
   try {
     return (
-      withExistingOpenClawStateDatabaseReadOnly(
-        (database) => {
-          const healthDb = getNodeSqliteKysely<ConfigHealthDatabase>(database.db);
-          const rows = executeSqliteQuerySync(
-            database.db,
-            healthDb
-              .selectFrom("config_health_entries")
-              .select([
-                "config_path",
-                "last_known_good_json",
-                "last_promoted_good_json",
-                "last_observed_suspicious_signature",
-              ])
-              .orderBy("config_path", "asc"),
-          ).rows;
-          return {
-            entries: Object.fromEntries(
-              rows.map((row) => [
-                row.config_path,
-                {
-                  lastKnownGood: parseConfigHealthFingerprint(row.last_known_good_json),
-                  lastPromotedGood: parseConfigHealthFingerprint(row.last_promoted_good_json),
-                  lastObservedSuspiciousSignature: row.last_observed_suspicious_signature,
-                } satisfies ConfigHealthEntry,
-              ]),
-            ),
-          };
-        },
+      withExistingOpenClawStateDatabaseReadOnly(readConfigHealthState, {
+        env: resolveConfigHealthStateEnv(deps),
+      }) ?? {}
+    );
+  } catch (error) {
+    if (error instanceof OpenClawStateOwnershipError) {
+      throw error;
+    }
+    return {};
+  }
+}
+
+/** Keep live reads unchanged; await only an already-admitted private snapshot. */
+export async function readConfigHealthStateFromStoreAsync(
+  deps: ConfigHealthStateDeps,
+): Promise<ConfigHealthState> {
+  if (!isArtifactPreservingStateRead()) {
+    return readConfigHealthStateFromStore(deps);
+  }
+  try {
+    return (
+      (await withExistingOpenClawStateDatabaseArtifactPreservingReadOnlyAsync(
+        readConfigHealthState,
         { env: resolveConfigHealthStateEnv(deps) },
-      ) ?? {}
+      )) ?? {}
     );
   } catch (error) {
     if (error instanceof OpenClawStateOwnershipError) {

--- a/src/config/io.observe-recovery.ts
+++ b/src/config/io.observe-recovery.ts
@@ -10,9 +10,11 @@ import {
 } from "./io.clobber-snapshot.js";
 import {
   readConfigHealthStateFromStore,
+  readConfigHealthStateFromStoreAsync,
   writeConfigHealthStateToStore,
   type ConfigHealthEntry,
   type ConfigHealthFingerprint,
+  type ConfigHealthState,
 } from "./io.health-state.js";
 import {
   createConfigHealthFingerprint,
@@ -411,7 +413,10 @@ function* planSuspiciousConfigRead(
     stat,
     observedAt: now,
   });
-  const healthState = readConfigHealthStateFromStore(deps);
+  const healthState = (yield {
+    sync: () => readConfigHealthStateFromStore(deps),
+    async: () => readConfigHealthStateFromStoreAsync(deps),
+  }) as ConfigHealthState; // SAFETY: Both runners resume with the selected effect's result.
   const entry = readConfigHealthEntry(healthState, configPath);
   const backupPath = `${configPath}.bak`;
   const backupBaseline =


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

Config recovery can pause unrelated Gateway work while it checks the health of saved configuration, even though recovery preparation runs asynchronously.

## Why This Change Was Made

Use the existing asynchronous artifact-preserving snapshot reader in the async recovery effect, sharing the existing ordered health-row query with the synchronous reader. Keep synchronous recovery, ordinary live reads, snapshot/artifact ownership, error handling and final config/backup/lease commit guards unchanged; no schema, configuration, cancellation API, snapshot coalescing or new storage owner is introduced.

## User Impact

The event loop can remain responsive while the existing snapshot worker runs. This reduces blocking, not snapshot work, and does not establish a throughput or end-to-end Gateway speedup. Ordinary async recovery gains one Promise yield. The final change adds 33 production lines, compared with 34 in the measured unformatted candidate.

## Evidence

Matching Oxfmt 0.66, `git diff --check`, and fresh managed Codex review through P2 passed on the final source. Darwin/Node 26.8.1 validation passed **106 existing assertions** across `io.health-state.test.ts`, `io.observe-recovery.test.ts`, `io.snapshot.recovery.test.ts`, and `openclaw-state-db-readonly.test.ts`; **all 25 small guards** selected by the actual changed-check owner passed under unchanged per-child 300s/6 GiB/64-process limits. No dependency install or new permanent implementation-mirroring test was added.

The first small-guard phase stopped at assertion safety: the new generator-result cast raised undocumented assertions from 7 to 8. The original failure remains retained. An inline SAFETY comment documents the existing runner invariant; no assertion type, baseline, test or executable behavior changed. Fresh P2 and the selected guards passed afterward; the 106 behavioral assertions were retained without rerunning for the comment-only change. **Hosted CI remains pending** for `tsgo:core`, `tsgo:core:test`, and changed core type-aware lint because of the established local capacity limit; none is claimed passed.

One isolated Linux/Node 24.19.0 B1/C1/C2/B2 pilot at `7292689e7f78026060491fc94923cafdec48733f` exercised actual `prepareConfigRecovery` with real SQLite snapshots, plus ordinary-async and synchronous controls. Each case/phase had one warmup and two measured calls. Relative to the measured candidate, author changes are formatting and the comment-only SAFETY annotation; executable code is unchanged. Relevant owners, callers and tests were verified unchanged at `93a5d822750d726481ab2998e53b404d04e58b27`; no retiming was performed.

For the four cold snapshot cases, median maximum callback gaps dropped from **422–557 ms to 5.4–7.5 ms** in both comparisons. The real 5 ms sampler starts before the call and drains after completion; performance clocks and timers remain live. Snapshot count stays **one per cold call**. All 32 case/phase graphs, warnings, health rows, config/backup artifacts and 144 decoded SQLite artifact images passed parity/preservation checks; four additional freshness checks passed.

The tradeoffs remain explicit: cold parent CPU increases **9.7–71.6%**, including callbacks that can now run during the call. Transaction call wall time worsens **+1.51/+2.21%**, warm call wall is **−7.93/+15.68%**, and ordinary-async call wall is **+19.63/−4.70%**. Ordinary-async whole-child wall worsens **+4.70/+4.98%**, CPU **+0.74/+4.26%**, and observed tree peak RSS **+1.03/+0.99%**. Whole-child clocks include imports, setup and verification; they are separate from call clocks.

<details>
<summary>Complete eight-case paired measurements and resource observations</summary>

Each pair is B1→C1 / B2→C2. Times are median milliseconds per call; positive percentage changes in wall, CPU or gaps are adverse. These are two-sample pilot medians, not a throughput distribution. Every raw sample and both comparison orders are retained.

| Case | Wall ms, both pairs | Parent CPU change | Maximum callback gap ms, both pairs | Snapshots per call |
| --- | --- | --- | --- | --- |
| missing | 0.203→0.197 / 0.200→0.185 | +3.32% / -7.67% | 5.312→5.303 / 5.315→4.825 | 0 |
| cold-healthy | 557.343→430.149 / 424.469→426.420 | +17.69% / +55.55% | 557.457→6.113 / 424.560→7.484 | 1 |
| cold-suspicious | 442.798→414.407 / 429.619→446.835 | +9.70% / +18.43% | 433.981→7.295 / 421.852→7.094 | 1 |
| cold-wal | 433.194→435.113 / 435.904→414.934 | +71.57% / +70.64% | 433.275→5.424 / 435.976→6.718 | 1 |
| warm | 0.321→0.295 / 0.311→0.360 | -0.14% / +16.46% | 4.928→4.966 / 5.006→5.523 | 0 |
| transaction | 421.948→428.335 / 421.792→431.119 | +57.23% / +67.97% | 422.027→6.885 / 421.881→5.803 | 1 |
| ordinary-async | 0.256→0.306 / 0.332→0.316 | +17.89% / -7.11% | 4.445→4.935 / 5.552→4.413 | 0 |
| sync | 0.225→0.247 / 0.239→0.220 | +4.58% / +0.32% | 4.894→4.929 / 5.437→4.895 | 0 |

Whole-child metrics include imports, fixtures, verification, compression and timer draining. RSS is process high-water/observed tree peak, not exact per-call allocation.

| Case | Whole-child CPU change | Whole-child wall change | Kernel child max RSS change | Observed tree peak RSS change |
| --- | --- | --- | --- | --- |
| missing | +1.25% / -0.21% | -0.39% / -1.78% | +1.69% / -0.04% | +1.45% / +3.80% |
| cold-healthy | -12.52% / -0.55% | -11.69% / +3.31% | -0.33% / -0.30% | +1.43% / -1.24% |
| cold-suspicious | -11.94% / +3.73% | -11.80% / +6.79% | -0.26% / +0.25% | -0.91% / +0.71% |
| cold-wal | -0.63% / +1.00% | -1.08% / +1.03% | -0.28% / -0.46% | +1.05% / -1.61% |
| warm | +4.29% / -0.50% | +5.47% / +1.42% | +0.30% / +0.26% | -2.57% / -0.87% |
| transaction | +2.04% / +0.22% | +2.16% / +1.56% | -0.24% / -0.72% | +0.52% / +1.55% |
| ordinary-async | +0.74% / +4.26% | +4.70% / +4.98% | -0.10% / +0.12% | +1.03% / +0.99% |
| sync | +0.88% / +1.75% | +0.36% / +0.62% | -1.33% / -0.30% | -3.81% / -0.30% |

</details>

No benchmark retry, cap increase or acceptance-threshold adjustment was used. Measurement closure verified 38 successful native commands, 190 distinct PIDs and 38 groups, source/worktree cleanup and exact Testbox lease closure. Local validation and reviewer children also closed.
