### PR TITLE
fix(tests): fail config reload checks when RPC stays unavailable

### DIFF
--- a/scripts/e2e/config-reload-source-docker.sh
+++ b/scripts/e2e/config-reload-source-docker.sh
@@ -33,8 +33,9 @@ last_status=1
 while [ \"\$SECONDS\" -lt \"\$deadline\" ]; do
   if node \"\$entry\" gateway status --url ws://127.0.0.1:$PORT --token '$TOKEN' --require-rpc --timeout 30000 >'$out_file' 2>'$out_file.err'; then
     exit 0
+  else
+    last_status=\$?
   fi
-  last_status=\$?
   sleep 1
 done
 cat '$out_file.err' >&2 || true

--- a/test/scripts/e2e-shell-tempfiles.test.ts
+++ b/test/scripts/e2e-shell-tempfiles.test.ts
@@ -70,6 +70,71 @@ describe("e2e shell tempfile hygiene", () => {
     expect(offenders).toEqual([]);
   });
 
+  it.each([
+    { name: "persistent failure", succeedsAfter: 0, exitCode: 7, calls: 2 },
+    { name: "immediate success", succeedsAfter: 1, exitCode: 0, calls: 1 },
+    { name: "success after a failed probe", succeedsAfter: 2, exitCode: 0, calls: 2 },
+  ])("preserves config reload RPC status on $name", async (scenario) => {
+    const tempRoot = tempDirs.make("openclaw-config-reload-status-");
+    const script = await readFile("scripts/e2e/config-reload-source-docker.sh", "utf8");
+    const rpcFunction = script.match(/^check_rpc_status\(\) \{[\s\S]*?^\}/m)?.[0];
+    if (!rpcFunction) {
+      throw new Error("Config reload RPC status function was not found");
+    }
+    const callsPath = path.join(tempRoot, "calls.txt");
+    const result = spawnSync(
+      process.platform === "darwin" ? "/bin/bash" : "bash",
+      [
+        "-c",
+        `
+set -euo pipefail
+PORT=18789
+TOKEN=synthetic-token
+CONTAINER_NAME=synthetic-container
+docker_e2e_docker_cmd() {
+  "$BASH" -c "$PROBE_PRELUDE
+$5"
+}
+${rpcFunction}
+check_rpc_status "$OUTPUT_PATH"
+`,
+      ],
+      {
+        encoding: "utf8",
+        timeout: 5_000,
+        env: {
+          ...process.env,
+          OUTPUT_PATH: path.join(tempRoot, "rpc.log"),
+          CALLS_PATH: callsPath,
+          SUCCEEDS_AFTER: String(scenario.succeedsAfter),
+          PROBE_PRELUDE: `
+source() { :; }
+openclaw_e2e_resolve_entrypoint() { printf '%s' synthetic-entry; }
+calls=0
+SECONDS=0
+node() {
+  calls=$((calls + 1))
+  printf '%s' "$calls" > "$CALLS_PATH"
+  if [ "$SUCCEEDS_AFTER" -gt 0 ] && [ "$calls" -ge "$SUCCEEDS_AFTER" ]; then
+    return 0
+  fi
+  printf '%s\\n' 'synthetic RPC failure' >&2
+  return 7
+}
+# Advance the real loop's clock without waiting for its 120-second deadline.
+sleep() { SECONDS=$((SECONDS + 61)); }
+`,
+        },
+      },
+    );
+    expect(result.error).toBeUndefined();
+    expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(scenario.exitCode);
+    expect(await readFile(callsPath, "utf8")).toBe(String(scenario.calls));
+    if (scenario.exitCode !== 0) {
+      expect(result.stderr).toContain("synthetic RPC failure");
+    }
+  });
+
   it("preserves wizard exit status when reporting failures", async () => {
     const tempRoot = await mkdtemp(path.join(tmpdir(), "openclaw-onboard-status-test-"));
     const fixturePath = path.join(tempRoot, "wizard-status.sh");


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where maintainers running the config-reload Docker test could get a passing RPC check even when every Gateway status probe failed.

## Why This Change Was Made

The check captured the status of the completed Bash `if` statement, which was zero after an unsuccessful condition. Capture the failed command's status in its `else` branch so exhaustion returns the actual failure. Existing retry timing stays unchanged.

## User Impact

CI now fails when initial or post-reload RPC availability cannot be confirmed. No product behavior changes.

## Evidence

- The actual Bash function returned zero when all synthetic probes exited 7 before the fix; it now returns 7 and reports the error.
- Immediate success and recovery after a failed probe still pass.
- 19 tests passed across the shell harness and config-reload log checks.
- Selected formatting, type, lint, boundary, coercion, and dead-code checks passed; independent P2 review found no actionable issues.
- Product LOC: unchanged. Harness: +1; tests: +65.
