### PR TITLE
refactor: share people hovercard keyboard handling

### DIFF
--- a/ui/src/components/sidebar-people.runtime.ts
+++ b/ui/src/components/sidebar-people.runtime.ts
@@ -38,7 +38,6 @@ export class SidebarPeopleRuntime {
   } | null = null;
   private readonly portal = new PortaledHovercardController(() => this.close(), 100);
   private readonly observer = new MutationObserver(() => this.sync());
-  private suppressFocus = false;
   private lastOpenAt = -Infinity;
   private readonly stopLocale: () => void;
 
@@ -60,12 +59,8 @@ export class SidebarPeopleRuntime {
         ? event.target.closest<HTMLElement>("[data-person-card]")
         : null;
     if (event.type === "keydown" && event instanceof KeyboardEvent) {
-      if (event.key === "Tab" && !event.shiftKey && event.target === this.active?.trigger) {
-        const first = this.portal.focusables()[0];
-        if (first) {
-          event.preventDefault();
-          first.focus();
-        }
+      if (event.key === "Tab") {
+        this.portal.handleTriggerKeyDown(event);
       }
       return;
     }
@@ -111,7 +106,7 @@ export class SidebarPeopleRuntime {
         return;
       }
       this.portal.schedulePointerExit();
-    } else if (event.type === "focusin" && !this.suppressFocus) {
+    } else if (event.type === "focusin" && !this.portal.restoringFocus) {
       this.activate(row, 0);
       this.portal.focusInside = true;
       this.portal.clearClose();
@@ -333,9 +328,7 @@ export class SidebarPeopleRuntime {
   }
 
   private returnFocus(): void {
-    this.suppressFocus = true;
-    this.active?.trigger.focus({ preventScroll: true });
-    this.suppressFocus = false;
+    this.portal.returnFocus(this.active?.trigger ?? null);
     this.portal.focusInside = document.activeElement === this.active?.trigger;
   }
 


### PR DESCRIPTION
## What Problem This Solves

The sidebar people hovercard kept a separate copy of keyboard-focus behavior after that behavior moved into the shared hovercard controller.

## Why This Change Was Made

Delegate Tab entry and focus restoration to the shared controller, removing seven production lines. The people card retains its document-level Escape handling and focus-before-close ordering, which keep the mobile navigation drawer open.

## User Impact

No intended appearance or navigation change. Keyboard focus still survives card updates and returns to the person link when the card closes.

## Evidence

The two existing desktop and narrow-touch browser cases pass before and after. Canonical changed checks, targeted lint, formatting and diff checks pass. Independent Codex review found no actionable P0–P2 findings. No tests were added or changed.

The attached narrow-screen captures use synthetic fixtures and retain the same layout and focus presentation. Desktop captures were also inspected and are byte-identical.

![Narrow-screen people hovercard before shared focus handling](https://github.com/user-attachments/assets/fd87e5cc-44c3-4d2a-833e-b621ca2b478e)

![Narrow-screen people hovercard after shared focus handling](https://github.com/user-attachments/assets/42ba33b1-b12b-4b29-a820-6afdef6d3732)