### PR TITLE
fix(test): keep option operands out of inferred Vitest config

### DIFF
--- a/scripts/run-vitest.mts
+++ b/scripts/run-vitest.mts
@@ -576,7 +576,7 @@ export function resolveImplicitVitestArgs(argv: string[], cwd = process.cwd()): 
   if (collectExplicitDirectoryTargetArgs(argv, cwd).length > 0) {
     return argv;
   }
-  const testTargets = argv
+  const testTargets = collectVitestFileFilters(argv)
     .filter((arg) => !arg.startsWith("-") && arg.endsWith(".test.ts"))
     .map((arg) => toRepoRelativeArg(arg, cwd));
   if (testTargets.length > 0 && testTargets.every(isToolingDockerTestTarget)) {

--- a/test/scripts/run-vitest.test.ts
+++ b/test/scripts/run-vitest.test.ts
@@ -376,6 +376,121 @@ registerHooks({resolve(specifier, context, nextResolve) {
     ).toEqual([argv]);
   });
 
+  it.each([
+    {
+      name: "tooling",
+      options: ["--exclude", "test/scripts/run-vitest.test.ts"],
+      expectedOptions: { exclude: ["test/scripts/run-vitest.test.ts"] },
+    },
+    {
+      name: "Docker tooling",
+      options: ["--exclude", "test/scripts/docker-build-helper.test.ts"],
+      expectedOptions: { exclude: ["test/scripts/docker-build-helper.test.ts"] },
+    },
+    {
+      name: "UI",
+      options: ["--exclude", "ui/src/pages/chat/chat-send.test.ts"],
+      expectedOptions: { exclude: ["ui/src/pages/chat/chat-send.test.ts"] },
+    },
+    {
+      name: "browser UI",
+      options: ["--exclude", "ui/src/components/markdown-mermaid.runtime.browser.test.ts"],
+      expectedOptions: { exclude: ["ui/src/components/markdown-mermaid.runtime.browser.test.ts"] },
+    },
+    {
+      name: "inline",
+      options: ["--exclude=test/scripts/run-vitest.test.ts"],
+      expectedOptions: { exclude: ["test/scripts/run-vitest.test.ts"] },
+    },
+    {
+      name: "empty inline",
+      options: ["--exclude=", "test/scripts/run-vitest.test.ts"],
+      expectedOptions: { exclude: ["test/scripts/run-vitest.test.ts"] },
+    },
+    {
+      name: "comma",
+      options: [
+        "--exclude",
+        "test/scripts/run-vitest.test.ts,test/scripts/docker-build-helper.test.ts",
+      ],
+      expectedOptions: {
+        exclude: ["test/scripts/run-vitest.test.ts,test/scripts/docker-build-helper.test.ts"],
+      },
+    },
+    {
+      name: "pipe",
+      options: [
+        "--exclude",
+        "test/scripts/run-vitest.test.ts|test/scripts/docker-build-helper.test.ts",
+      ],
+      expectedOptions: {
+        exclude: ["test/scripts/run-vitest.test.ts|test/scripts/docker-build-helper.test.ts"],
+      },
+    },
+    {
+      name: "name regexp",
+      options: ["--testNamePattern", "test/scripts/(run-vitest|test-projects).test.ts"],
+      expectedOptions: { testNamePattern: "test/scripts/(run-vitest|test-projects).test.ts" },
+    },
+    {
+      name: "repeated",
+      options: [
+        "--exclude",
+        "test/scripts/run-vitest.test.ts",
+        "--exclude",
+        "test/scripts/run-vitest-progress.test.ts",
+      ],
+      expectedOptions: {
+        exclude: ["test/scripts/run-vitest.test.ts", "test/scripts/run-vitest-progress.test.ts"],
+      },
+    },
+    {
+      name: "following flag",
+      options: ["--exclude", "test/scripts/run-vitest.test.ts", "--passWithNoTests=false"],
+      expectedOptions: { exclude: ["test/scripts/run-vitest.test.ts"], passWithNoTests: false },
+    },
+    {
+      name: "missing operand before flag",
+      options: ["--exclude=", "--passWithNoTests=false"],
+      expectedOptions: { exclude: [true], passWithNoTests: false },
+    },
+    {
+      name: "native separator",
+      options: ["--", "test/scripts/run-vitest.test.ts"],
+      expectedOptions: { "--": ["test/scripts/run-vitest.test.ts"] },
+    },
+  ])(
+    "keeps $name option operands out of implicit config selection",
+    ({ options, expectedOptions }) => {
+      const argv = ["run", ...options];
+      const native = parseCLI(["vitest", ...argv]);
+
+      expect(native.filter).toEqual([]);
+      expect(native.options).toMatchObject(expectedOptions);
+      expect(resolveTestProjectsDelegationArgs(argv)).toBeNull();
+      expect(parseCLI(["vitest", ...resolveImplicitVitestArgs(argv)])).toEqual(native);
+    },
+  );
+
+  it("routes a positional UI test independently of excluded tooling files", () => {
+    const argv = [
+      "list",
+      "ui/src/pages/chat/chat-send.test.ts",
+      "--exclude",
+      "test/scripts/run-vitest.test.ts",
+      "--passWithNoTests=false",
+    ];
+    const native = parseCLI(["vitest", ...argv]);
+
+    expect(native.filter).toEqual(["ui/src/pages/chat/chat-send.test.ts"]);
+    expect(native.options.exclude).toEqual(["test/scripts/run-vitest.test.ts"]);
+    expect(native.options.passWithNoTests).toBe(false);
+    expect(resolveTestProjectsDelegationArgs(argv)).toBeNull();
+    expect(parseCLI(["vitest", ...resolveImplicitVitestArgs(argv)])).toEqual(
+      parseCLI(["vitest", "--config", "test/vitest/vitest.ui.config.ts", ...argv]),
+    );
+  });
+
   it("routes explicit tooling tests through the tooling config", () => {
     expect(resolveImplicitVitestArgs(["run", "test/scripts/run-vitest.test.ts"])).toEqual([
       "run",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where developers excluding a test file could silently run the wrong Vitest project set. For example, a separated `--exclude test/scripts/run-vitest.test.ts` inferred the tooling config, while the equivalent inline option kept the normal root configuration. Other option values ending in `.test.ts` could similarly steer configuration selection.

## Why This Change Was Made

Implicit config selection now consumes the existing positional-argument classifier, as file validation and delegation already do. Option operands and separator tails no longer masquerade as positive test selectors. Production/tooling changes are +1/−1 lines (net zero), with 115 regression-test lines and no new parsing path or configuration option.

## User Impact

Separated and inline options preserve the intended project selection. Genuine positional tooling and UI targets retain their existing routing.

## Evidence

The original regression baseline produced 12 intended failures and 2 passing controls. Final coverage passes all 189 owner tests; changed-file formatting, type, lint and boundary checks pass. Independent Auto Review and raw-evidence audit found no actionable P0–P2 issues.

Paired runs of the real public wrapper with native `list --filesOnly` show the separated form improving from 641 tooling file/project tuples to 13,804, exactly matching both explicit-root controls and the inline form. All three unchanged controls are identical across phases. All eight commands exited zero, with complete observed process-group cleanup and no supervisor signals. This is file-selection proof; it does not claim execution of those 13,804 tests.

The first proof attempt exposed a separate Vitest dependency limitation: CLI exclusions do not propagate through its file-backed workspace override list. That failed proof is retained; corrected comparisons use complete native inventories and preserve this existing dependency behavior. Candidate test validation also caught an incomplete manually constructed native-parser expectation; the final test compares against native explicit-config parsing, including its `c` alias. The native listing proof predates that test-body-only correction; production, discovery paths and file names remain identical.
