### PR TITLE
docs(update): explain pending plugin consent warnings

### DIFF
--- a/docs/cli/update/repair-and-recovery.md
+++ b/docs/cli/update/repair-and-recovery.md
@@ -227,9 +227,13 @@ overall deadline still fails finalization.
 Plugin artifacts that require capability consent are not installed without an
 interactive review or explicit `--accept-capabilities`. `--yes` alone does not
 accept capability changes, and JSON mode does not prompt. An unresolved review
-preserves the previous plugin, exits non-zero, and blocks any requested Gateway
-restart. This also applies when a bundled plugin moves to an external package or
-a missing configured plugin has no install record yet. Automatic repair can
+preserves the previous plugin payload and appears in `postUpdate.plugins.warnings`
+with a `PLUGIN_CAPABILITY_CONSENT_REQUIRED` outcome. When required checks pass,
+`openclaw update` can complete the core update and requested Gateway restart with
+`status: "ok"`; `update repair` reports `status: "warning"` and never restarts the
+Gateway. Both commands exit successfully. This also applies when a bundled plugin
+moves to an external package or a missing configured plugin has no install record
+yet; the unreviewed replacement is not installed. Automatic repair can
 report a deferred replacement as a notice when a usable, enabled artifact remains
 installed; that retained artifact still undergoes payload validation.
 


### PR DESCRIPTION
Related: #145946

## What Problem This Solves

Fixes documentation that incorrectly says pending plugin capability consent always fails a core update and blocks a requested Gateway restart.

## Why This Change Was Made

Match the current update and repair callers: the unreviewed plugin replacement remains uninstalled and is reported as a warning. A core update can otherwise succeed; repair reports a warning and does not restart the Gateway.

## User Impact

Operators can interpret the JSON result and follow the documented explicit-consent repair path. This changes documentation only; it grants no additional plugin permissions.

## Evidence

Checked the update producer, convergence and finalization callers, existing CLI coverage, and the consent harness/tests landed in #145946. The captured Docker result confirms a successful core update with the exact pending-consent warning. Documentation checks and independent P2 review passed.
