### PR TITLE
test(browser): answer cursor query in depth fixture

### DIFF
--- a/extensions/browser/src/browser/cdp.test.ts
+++ b/extensions/browser/src/browser/cdp.test.ts
@@ -911,6 +911,10 @@ describe("cdp", () => {
     const wsPort = await startWsServerWithMessages((msg, socket) => {
       if (msg.method === "Accessibility.getFullAXTree") {
         socket.send(JSON.stringify({ id: msg.id, result: { nodes } }));
+      } else if (msg.method === "Runtime.evaluate") {
+        socket.send(
+          JSON.stringify({ id: msg.id, error: { code: -32000, message: "unavailable" } }),
+        );
       }
     });
 


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

The CDP snapshot depth fixture waits five seconds for a cursor query that its synthetic WebSocket server never answers. The wait contributes no depth-rendering coverage.

## Why This Change Was Made

Return a CDP error for Runtime.evaluate in this fixture so the existing cursor-query catch and empty-map fallback execute immediately. The 1,000-node tree, requested depth of 50,000, real WebSocket transport, and all three depth assertions remain unchanged. The dedicated command-timeout test still covers the real deadline and socket closure.

## User Impact

No production behavior changes. This adds four test lines and removes an artificial wait from one existing test.

## Evidence

All 100 cases across cdp.test.ts, cdp.internal.test.ts, and cdp.helpers.internal.test.ts passed before and after, with identical ordered case identities and no skips. In this local pair, the depth case took 5,007 ms before and 4.6 ms after; this is not an overall suite speedup claim.

The mapped extension-test gate and fresh scoped review passed. The first gate attempt stopped on host disk exhaustion during SDK declaration generation; after disk recovery, the unchanged complete mapped gate passed. Exact source inversion confirms only the responder was added.
