### PR TITLE
test: reuse environment capture in trigger harness

### DIFF
--- a/test/helpers/auto-reply/trigger-handling-test-harness.ts
+++ b/test/helpers/auto-reply/trigger-handling-test-harness.ts
@@ -8,6 +8,7 @@ import { clearRuntimeAuthProfileStoreSnapshots } from "../../../src/agents/auth-
 import type { EmbeddedAgentQueueMessageOutcome } from "../../../src/agents/embedded-agent-runner/runs.js";
 import { withFastReplyConfig } from "../../../src/auto-reply/reply/get-reply-fast-path.test-support.js";
 import type { OpenClawConfig } from "../../../src/config/types.openclaw.js";
+import { captureEnv } from "../../../src/test-utils/env.js";
 
 // Avoid exporting vitest mock types (TS2742 under pnpm + d.ts emit).
 type AnyMock = any;
@@ -204,45 +205,8 @@ installWebSessionMock();
 
 export const MAIN_SESSION_KEY = "agent:main:main";
 
-type TempHomeEnvSnapshot = {
-  home: string | undefined;
-  userProfile: string | undefined;
-  homeDrive: string | undefined;
-  homePath: string | undefined;
-  openclawHome: string | undefined;
-  stateDir: string | undefined;
-};
-
 let suiteTempHomeRoot = "";
 let suiteTempHomeId = 0;
-
-function snapshotTempHomeEnv(): TempHomeEnvSnapshot {
-  return {
-    home: process.env.HOME,
-    userProfile: process.env.USERPROFILE,
-    homeDrive: process.env.HOMEDRIVE,
-    homePath: process.env.HOMEPATH,
-    openclawHome: process.env.OPENCLAW_HOME,
-    stateDir: process.env.OPENCLAW_STATE_DIR,
-  };
-}
-
-function restoreTempHomeEnv(snapshot: TempHomeEnvSnapshot): void {
-  const restoreKey = (key: string, value: string | undefined) => {
-    if (value === undefined) {
-      delete process.env[key];
-      return;
-    }
-    process.env[key] = value;
-  };
-
-  restoreKey("HOME", snapshot.home);
-  restoreKey("USERPROFILE", snapshot.userProfile);
-  restoreKey("HOMEDRIVE", snapshot.homeDrive);
-  restoreKey("HOMEPATH", snapshot.homePath);
-  restoreKey("OPENCLAW_HOME", snapshot.openclawHome);
-  restoreKey("OPENCLAW_STATE_DIR", snapshot.stateDir);
-}
 
 function setTempHomeEnv(home: string): void {
   process.env.HOME = home;
@@ -280,7 +244,14 @@ afterAll(async () => {
 
 export async function withTempHome<T>(fn: (home: string) => Promise<T>): Promise<T> {
   const home = join(suiteTempHomeRoot, `case-${++suiteTempHomeId}`);
-  const snapshot = snapshotTempHomeEnv();
+  const snapshot = captureEnv([
+    "HOME",
+    "USERPROFILE",
+    "HOMEDRIVE",
+    "HOMEPATH",
+    "OPENCLAW_HOME",
+    "OPENCLAW_STATE_DIR",
+  ]);
   await fs.mkdir(join(home, ".openclaw", "agents", "main", "sessions"), { recursive: true });
   setTempHomeEnv(home);
 
@@ -302,7 +273,7 @@ export async function withTempHome<T>(fn: (home: string) => Promise<T>): Promise
     modelFallbackMocks.runWithModelFallback.mockClear();
     return await fn(home);
   } finally {
-    restoreTempHomeEnv(snapshot);
+    snapshot.restore();
   }
 }
 


### PR DESCRIPTION
Closes #145972

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Auto-reply trigger tests maintain a private copy of environment snapshot and restoration behavior already supplied by the shared test utility.

## Why This Change Was Made

Use `captureEnv` for the same six home/state keys, then restore through the captured snapshot. The key order, capture before directory creation, existing `finally` boundary, platform-specific setters, temporary roots, mock resets, and callback/error behavior are preserved. The private snapshot type and two helpers are removed.

## User Impact

No production behavior changes. Test setup has one restoration owner and 29 fewer support lines (+10/−39 in one helper). No test cases or assertions are removed, and no timing or memory improvement is claimed.

## Evidence

All 32 retained tests passed across two files: 10 environment-helper cases and 22 trigger-handling cases. The explicit-base selected gate passed all 17 checks, including three Knip scans. Scoped P2 review, deslop, and diff check passed. The focused wrapper also completed its required E2E build preparation.

An earlier ENOSPC attempt stopped during build/review preparation before tests ran or a review report was produced; its logs remain retained. The same source and commands passed after disk space was restored. Native Windows execution was not performed. Hosted CI and normal native admission remain pending publication.
