### PR TITLE
fix(doctor): preserve explicitly configured profile workspaces

### DIFF
--- a/src/commands/doctor-state-migrations.test.ts
+++ b/src/commands/doctor-state-migrations.test.ts
@@ -4398,19 +4398,24 @@ describe("doctor legacy state migrations", () => {
     },
   );
 
-  it("reports an unused profile target without blocking a configured legacy workspace", async () => {
+  it("keeps two agents' explicitly configured profile workspaces without blocking", async () => {
     const root = makeDoctorStateDir();
     const paths = getProfileWorkspaceMigrationPaths(root);
     fs.mkdirSync(paths.legacyDir, { recursive: true });
     fs.mkdirSync(paths.targetDir, { recursive: true });
-    fs.writeFileSync(path.join(paths.legacyDir, "legacy.txt"), "configured", "utf8");
-    fs.writeFileSync(path.join(paths.targetDir, "current.txt"), "unused", "utf8");
+    fs.writeFileSync(path.join(paths.legacyDir, "legacy.txt"), "legacy-agent", "utf8");
+    fs.writeFileSync(path.join(paths.targetDir, "current.txt"), "current-agent", "utf8");
 
     const { result } = await runProfileWorkspaceDoctorMigration(root, "work", {
-      agents: { defaults: { workspace: paths.legacyDir } },
+      agents: {
+        entries: {
+          legacy: { workspace: paths.legacyDir },
+          current: { workspace: paths.targetDir },
+        },
+      },
     });
 
-    const notice = `Profile workspace: keeping configured workspace at ${paths.legacyDir}; ${paths.targetDir} is unused.`;
+    const notice = `Profile workspace: keeping configured workspace at ${paths.legacyDir}; existing workspace at ${paths.targetDir} was left unchanged.`;
     expect(result.notices).toEqual([notice]);
     expect(result.warnings).toEqual([]);
     expect(result.stepReceipts.find((receipt) => receipt.id === "profile-workspace")).toMatchObject(
@@ -4421,8 +4426,10 @@ describe("doctor legacy state migrations", () => {
         notices: [notice],
       },
     );
-    expect(fs.readFileSync(path.join(paths.legacyDir, "legacy.txt"), "utf8")).toBe("configured");
-    expect(fs.readFileSync(path.join(paths.targetDir, "current.txt"), "utf8")).toBe("unused");
+    expect(fs.readFileSync(path.join(paths.legacyDir, "legacy.txt"), "utf8")).toBe("legacy-agent");
+    expect(fs.readFileSync(path.join(paths.targetDir, "current.txt"), "utf8")).toBe(
+      "current-agent",
+    );
   });
 
   it("does nothing when the active profile has no legacy workspace", async () => {

--- a/src/commands/doctor-state-migrations.test.ts
+++ b/src/commands/doctor-state-migrations.test.ts
@@ -807,12 +807,16 @@ function getProfileWorkspaceMigrationPaths(root: string, profile = "work") {
   };
 }
 
-async function runProfileWorkspaceDoctorMigration(root: string, profile = "work") {
+async function runProfileWorkspaceDoctorMigration(
+  root: string,
+  profile = "work",
+  cfg: OpenClawConfig = {},
+) {
   const paths = getProfileWorkspaceMigrationPaths(root, profile);
   fs.mkdirSync(paths.stateDir, { recursive: true });
   const log = { info: vi.fn(), warn: vi.fn() };
   const result = await autoMigrateLegacyState({
-    cfg: {},
+    cfg,
     env: {
       HOME: root,
       OPENCLAW_HOME: root,
@@ -4343,6 +4347,82 @@ describe("doctor legacy state migrations", () => {
     expect(log.warn).toHaveBeenCalledWith(expect.stringContaining(warning));
     expect(fs.readFileSync(path.join(paths.legacyDir, "legacy.txt"), "utf8")).toBe("legacy");
     expect(fs.readFileSync(path.join(paths.targetDir, "current.txt"), "utf8")).toBe("current");
+  });
+
+  it("preserves an explicitly configured legacy profile workspace", async () => {
+    const root = makeDoctorStateDir();
+    const paths = getProfileWorkspaceMigrationPaths(root);
+    fs.mkdirSync(paths.legacyDir, { recursive: true });
+    fs.writeFileSync(path.join(paths.legacyDir, "AGENTS.md"), "configured workspace", "utf8");
+
+    const { result } = await runProfileWorkspaceDoctorMigration(root, "work", {
+      agents: { defaults: { workspace: paths.legacyDir } },
+    });
+
+    expect(fs.readFileSync(path.join(paths.legacyDir, "AGENTS.md"), "utf8")).toBe(
+      "configured workspace",
+    );
+    expect(fs.existsSync(paths.targetDir)).toBe(false);
+    expect(result.changes.some((entry) => entry.startsWith("Profile workspace:"))).toBe(false);
+    expect(result.warnings).toEqual([]);
+  });
+
+  it("preserves a legacy profile workspace configured on an agent entry", async () => {
+    const root = makeDoctorStateDir();
+    const paths = getProfileWorkspaceMigrationPaths(root);
+    fs.mkdirSync(paths.legacyDir, { recursive: true });
+
+    await runProfileWorkspaceDoctorMigration(root, "work", {
+      agents: { entries: { main: { workspace: paths.legacyDir } } },
+    });
+
+    expect(fs.existsSync(paths.legacyDir)).toBe(true);
+    expect(fs.existsSync(paths.targetDir)).toBe(false);
+  });
+
+  it.runIf(process.platform !== "win32")(
+    "preserves a legacy profile workspace configured through a symlink",
+    async () => {
+      const root = makeDoctorStateDir();
+      const paths = getProfileWorkspaceMigrationPaths(root);
+      const configuredAlias = path.join(root, "configured-workspace");
+      fs.mkdirSync(paths.legacyDir, { recursive: true });
+      fs.symlinkSync(paths.legacyDir, configuredAlias, "dir");
+
+      await runProfileWorkspaceDoctorMigration(root, "work", {
+        agents: { defaults: { workspace: configuredAlias } },
+      });
+
+      expect(fs.existsSync(paths.legacyDir)).toBe(true);
+      expect(fs.existsSync(paths.targetDir)).toBe(false);
+    },
+  );
+
+  it("reports an unused profile target without blocking a configured legacy workspace", async () => {
+    const root = makeDoctorStateDir();
+    const paths = getProfileWorkspaceMigrationPaths(root);
+    fs.mkdirSync(paths.legacyDir, { recursive: true });
+    fs.mkdirSync(paths.targetDir, { recursive: true });
+    fs.writeFileSync(path.join(paths.legacyDir, "legacy.txt"), "configured", "utf8");
+    fs.writeFileSync(path.join(paths.targetDir, "current.txt"), "unused", "utf8");
+
+    const { result } = await runProfileWorkspaceDoctorMigration(root, "work", {
+      agents: { defaults: { workspace: paths.legacyDir } },
+    });
+
+    const notice = `Profile workspace: keeping configured workspace at ${paths.legacyDir}; ${paths.targetDir} is unused.`;
+    expect(result.notices).toEqual([notice]);
+    expect(result.warnings).toEqual([]);
+    expect(result.stepReceipts.find((receipt) => receipt.id === "profile-workspace")).toMatchObject(
+      {
+        source: [],
+        target: [],
+        outcome: "skipped",
+        notices: [notice],
+      },
+    );
+    expect(fs.readFileSync(path.join(paths.legacyDir, "legacy.txt"), "utf8")).toBe("configured");
+    expect(fs.readFileSync(path.join(paths.targetDir, "current.txt"), "utf8")).toBe("unused");
   });
 
   it("does nothing when the active profile has no legacy workspace", async () => {

--- a/src/infra/state-migrations.caller-mode.test.ts
+++ b/src/infra/state-migrations.caller-mode.test.ts
@@ -399,6 +399,36 @@ describe("legacy state migration caller mode", () => {
     expect(snapshotFiles(fixture.root)).toEqual(before);
   });
 
+  it("does not request migration authority for an explicitly configured profile workspace", async () => {
+    const fixture = await makeFixture();
+    fixture.env.OPENCLAW_PROFILE = "work";
+    const source = path.join(fixture.homeDir, ".openclaw", "workspace-work");
+    fs.mkdirSync(source, { recursive: true });
+    fs.writeFileSync(
+      fixture.configPath,
+      `${JSON.stringify({ agents: { defaults: { workspace: source } } })}\n`,
+    );
+    const before = snapshotFiles(fixture.root);
+
+    const plan = await planLegacyStateMigrationsReadOnly({
+      mode: "doctor",
+      candidate: candidateAt(fixture.root),
+      snapshot: createCallerModeSnapshot(fixture),
+      env: fixture.env,
+    });
+
+    expect(plan.steps.find((step) => step.id === "profile-workspace")).toMatchObject({
+      source: [],
+      target: [],
+      requiredness: "not-required",
+      outcome: "skipped",
+    });
+    expect(plan.steps.find((step) => step.id === "profile-workspace")).not.toHaveProperty(
+      "refusal",
+    );
+    expect(snapshotFiles(fixture.root)).toEqual(before);
+  });
+
   it("binds plan targets and identity to every resolved copied config input", async () => {
     const fixture = await makeFixture();
     const intermediatePath = path.join(fixture.root, "planner-base.json");

--- a/src/infra/state-migrations.doctor.ts
+++ b/src/infra/state-migrations.doctor.ts
@@ -164,6 +164,7 @@ import {
 } from "./state-migrations.shared-auth-store.js";
 import {
   autoMigrateLegacyStateDir,
+  isLegacyProfileWorkspaceExplicitlyConfigured,
   migrateLegacyProfileWorkspace,
   resolveLegacyProfileWorkspaceMigrationPaths,
   resolvePendingLegacyStateDirMigrationPaths,
@@ -1495,8 +1496,16 @@ function buildLegacyStateMigrationPreludeSteps(params: {
       ? resolveLegacyProfileWorkspaceMigrationPaths
       : resolvePendingLegacyProfileWorkspaceMigrationPaths
   )({ env: params.env, homedir: params.homedir });
+  const profileWorkspaceIsConfigured =
+    profileWorkspace !== undefined &&
+    isLegacyProfileWorkspaceExplicitlyConfigured({
+      config: params.config,
+      source: profileWorkspace.source,
+      env: params.env,
+      homedir: params.homedir,
+    });
   const profileRefusal =
-    profileWorkspace && params.readOnlyPlanning
+    profileWorkspace && params.readOnlyPlanning && !profileWorkspaceIsConfigured
       ? {
           code: "profile-workspace-snapshot-deferred",
           message:
@@ -1506,11 +1515,20 @@ function buildLegacyStateMigrationPreludeSteps(params: {
   steps.push(
     sharedStep(
       "profile-workspace",
-      profileWorkspace ? [{ kind: "path", path: profileWorkspace.source }] : [],
-      profileWorkspace ? [{ kind: "path", path: profileWorkspace.target }] : [],
-      () => migrateLegacyProfileWorkspace({ env: params.env, homedir: params.homedir }),
+      profileWorkspace && !profileWorkspaceIsConfigured
+        ? [{ kind: "path", path: profileWorkspace.source }]
+        : [],
+      profileWorkspace && !profileWorkspaceIsConfigured
+        ? [{ kind: "path", path: profileWorkspace.target }]
+        : [],
+      () =>
+        migrateLegacyProfileWorkspace({
+          config: params.config,
+          env: params.env,
+          homedir: params.homedir,
+        }),
       profileRefusal,
-      profileWorkspace ? "conditional" : "not-required",
+      profileWorkspace && !profileWorkspaceIsConfigured ? "conditional" : "not-required",
     ),
   );
   if (params.pluginPreparation) {

--- a/src/infra/state-migrations.state-dir.ts
+++ b/src/infra/state-migrations.state-dir.ts
@@ -139,7 +139,7 @@ export function migrateLegacyProfileWorkspace(params: {
             changes: [],
             warnings: [],
             notices: [
-              `Profile workspace: keeping configured workspace at ${legacyDir}; ${targetDir} is unused.`,
+              `Profile workspace: keeping configured workspace at ${legacyDir}; existing workspace at ${targetDir} was left unchanged.`,
             ],
           }
         : { changes: [], warnings: [] };

--- a/src/infra/state-migrations.state-dir.ts
+++ b/src/infra/state-migrations.state-dir.ts
@@ -4,6 +4,9 @@ import path from "node:path";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { resolveProfileStateDir } from "../cli/profile-utils.js";
 import { resolveLegacyStateDirs, resolveNewStateDir, resolveStateDir } from "../config/paths.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { resolveIdentityPathViaExistingAncestorSync } from "./boundary-path.js";
+import { resolveUserPath } from "./home-dir.js";
 import { isWithinDir } from "./path-safety.js";
 import { logStateMigrationResult } from "./state-migrations.messages.js";
 import {
@@ -69,11 +72,40 @@ export function resolvePendingLegacyProfileWorkspaceMigrationPaths(params: {
   return paths && lstatIfPresent(paths.source) ? paths : undefined;
 }
 
-export function migrateLegacyProfileWorkspace(params: {
+export function isLegacyProfileWorkspaceExplicitlyConfigured(params: {
+  config: OpenClawConfig;
+  source: string;
   env?: NodeJS.ProcessEnv;
   homedir?: () => string;
-}): { changes: string[]; warnings: string[] } {
-  const paths = resolveLegacyProfileWorkspaceMigrationPaths(params);
+}): boolean {
+  const env = params.env ?? process.env;
+  const homedir = params.homedir ?? os.homedir;
+  const sourceIdentity = resolveIdentityPathViaExistingAncestorSync(params.source);
+  const agentWorkspaces = [
+    ...Object.values(params.config.agents?.entries ?? {}),
+    ...(params.config.agents?.list ?? []),
+  ].map((entry) => entry.workspace);
+  const configuredWorkspaces = [params.config.agents?.defaults?.workspace, ...agentWorkspaces];
+  return configuredWorkspaces.some((workspace) => {
+    const value = workspace?.trim();
+    if (!value) {
+      return false;
+    }
+    return (
+      resolveIdentityPathViaExistingAncestorSync(resolveUserPath(value, env, homedir)) ===
+      sourceIdentity
+    );
+  });
+}
+
+export function migrateLegacyProfileWorkspace(params: {
+  config?: OpenClawConfig;
+  env?: NodeJS.ProcessEnv;
+  homedir?: () => string;
+}): { changes: string[]; warnings: string[]; notices?: string[] } {
+  const env = params.env ?? process.env;
+  const homedir = params.homedir ?? os.homedir;
+  const paths = resolveLegacyProfileWorkspaceMigrationPaths({ env, homedir });
   if (!paths) {
     return { changes: [], warnings: [] };
   }
@@ -92,6 +124,25 @@ export function migrateLegacyProfileWorkspace(params: {
           `Profile workspace migration skipped: legacy path is not a directory (${legacyDir}).`,
         ],
       };
+    }
+    if (
+      params.config &&
+      isLegacyProfileWorkspaceExplicitlyConfigured({
+        config: params.config,
+        source: legacyDir,
+        env,
+        homedir,
+      })
+    ) {
+      return lstatIfPresent(targetDir)
+        ? {
+            changes: [],
+            warnings: [],
+            notices: [
+              `Profile workspace: keeping configured workspace at ${legacyDir}; ${targetDir} is unused.`,
+            ],
+          }
+        : { changes: [], warnings: [] };
     }
     if (lstatIfPresent(targetDir)) {
       return {


### PR DESCRIPTION
Related: #134570

Follow-up to #122733. The broader upgrade-recovery issue remains open; this PR owns only profile workspace migration when configuration explicitly keeps the legacy path.

## What Problem This Solves

Fixes an issue where `openclaw doctor --fix` under a named profile could move an explicitly configured workspace to the convention-derived profile state root. If both paths existed, Doctor instead emitted a blocking merge warning even though configuration already identified the live workspace.

## Why This Change Was Made

Doctor now treats explicit workspace paths in agent defaults or entries as authoritative, including paths that resolve through a symlink alias. It removes those workspaces from migration authority and leaves their contents untouched. When the convention-derived target also exists, Doctor reports only that both paths were left unchanged; it does not infer whether either path is unused.

## User Impact

Named-profile users can keep an explicitly configured workspace through upgrades and Doctor repairs. The profile workspace migration no longer moves that workspace or blocks later repairs because another workspace also exists at the convention-derived target.

## Evidence

### Data-model compatibility

- This PR adds no config key, environment variable, schema version, database migration, or stored-data rewrite. It changes only whether the existing profile-workspace migration is authorized to rename a directory.
- The published v2026.9.4 config and both existing workspace directories were consumed directly by the exact-head candidate through the public updater. Candidate migration rehearsal, config validation, migration continuation, and final Doctor all completed successfully while preserving both explicit paths and their contents.

### Published updater to exact-head candidate

- Built a release-format candidate tarball from exact head `4c9e46ab68df483b3094bd3a3491f9855ffa2875`; packaged `dist/build-info.json` recorded the same commit. Tarball SHA-256: `eb989f8f6aae0edb7c6447b85bb2185a4d103f1c99d34135c0451e23c9790870`.
- Installed the public `openclaw@2026.9.4` package in a one-time isolated home and npm prefix. `openclaw --version` reported `OpenClaw 2026.9.4 (3a9d69d)`, and the isolated two-agent config passed the published CLI's `config validate --json`.
- Ran the published updater with `openclaw --profile work update --tag file:<candidate.tgz> --yes --no-restart --json`. It completed with `status: succeeded`, moving from build `2026.9.4-release-3a9d69db306c-2026-09-10T22-53-16.719Z` to `2026.9.4-4c9e46ab68df-2026-09-12T13-40-40.239Z`.
- Candidate migration rehearsal, Doctor lint, config validation, plugin resolution, migration continuation, gateway canary, global swap, and the final actual Doctor pass all exited 0. The updater reached its finished phase without a migration repair request.

### Actual Doctor CLI behavior

The isolated config explicitly assigned one agent to the legacy source and a second agent to the convention-derived target. Running the installed candidate's actual `doctor --fix --non-interactive --yes --no-workspace-suggestions` command exited 0 and reported:

```text
Profile workspace: keeping configured workspace at <legacy-source>; existing workspace at <profile-target> was left unchanged.
Doctor complete.
```

Both marker files remained at their original paths with unchanged hashes after the published update and a second direct Doctor pass:

```text
legacy-source  4e16bef4a5b4626cdf6e0a7423ff12fd2aa0ee3da9dfa622c5ec2290de1bf293
profile-target 396f724d1bc5677822394c4ce93b98616852beabfac55e119d1cdd38ddd7e8cc
```

The two explicit workspace values also remained in the updated config. A separate fresh named profile ran the installed candidate Doctor to completion with exit 0; neither its legacy source nor its convention-derived workspace target was created.

All proof used synthetic files under a disposable temporary root. No production state, credentials, channel, database, or user identifiers were used.

### Automated validation

- Baseline `2e4391ac95ae2fb01be79378bbb4452345e8c9c3`: the new regression moved the configured source, causing `ENOENT` at its original path; the two-directory case returned no preservation notice and blocked on the existing target.
- Exact head `4c9e46ab68df483b3094bd3a3491f9855ffa2875`: focused defaults, agent-entry, symlink, two-agent target ownership, and read-only-plan regressions pass (5 tests).
- Full related regression suite: 158 tests passed across Doctor state migration and caller-mode suites.
- `node scripts/check-changed.mjs --base upstream/main -- src/infra/state-migrations.state-dir.ts src/infra/state-migrations.doctor.ts src/commands/doctor-state-migrations.test.ts src/infra/state-migrations.caller-mode.test.ts` passed core/coreTests formatting, type checks, lint, import-cycle, and migration guards.
- P2 uncommitted autoreview found no actionable issues (`patch is correct`, confidence 0.94).

### Exact-head CI note

The exact-head GitHub matrix completed with two unrelated flaky test failures; neither failing file is in this PR's state-migration/Doctor surface:

- `src/agents/cli-runner/execute.executable-invocation.test.ts`: a fixture process produced no output within its 1-second timeout under the full CI load. The same exact-head file passed locally (2/2 tests).
- `src/gateway/server-methods/models-auth-refresh.catalog.integration.test.ts`: one learned-catalog assertion observed an empty transient result under the full CI load. The same exact-head test passed locally (1/1 test).

Their shards otherwise passed 3,204 and 2,547 tests respectively. `openclaw/ci-gate` failed only as their downstream aggregate. A failed-jobs rerun was attempted after both focused reproductions passed, but GitHub restricts workflow reruns to repository administrators; no code or proof SHA was changed merely to retrigger CI.

<!-- pr-145976-current-candidate-proof -->
### Current-candidate proof (September 19)

The evidence above remains the historical published-updater proof for `4c9e46ab68df483b3094bd3a3491f9855ffa2875`; it is **not** represented as an updater run of the new revision.

The published signed head is `ce7f2f12dbfb54c57ac9994a9320cb252119bac2`, preserving the original contributor commits. Current-main runtime verification used build revision `4202b0e0448f647e8ab5e314b0a620c6e2379a23`: both commits have the identical complete Git tree `0f01c793d76283657c5763d48e63df811b937695`. The 3 changed files also match the independently API-reviewed source byte-for-byte. Current-main composition passed 131 tests across profile-workspace, caller-mode, and Doctor migration suites; changed-file checks and a fresh-cache production typecheck passed. The exact-head hosted matrix remains required; no CI failure is waived.

**Actual current-tree Doctor, isolated macOS filesystem:** built through the supported `pnpm openclaw --profile workspace145976 doctor --help` runner, then invoked the real public CLI:

```sh
node openclaw.mjs --profile workspace145976 doctor --fix --non-interactive --no-workspace-suggestions
```

- Configured missing target via a two-link dangling alias: two consecutive invocations exited 0. The legacy source and marker stayed unchanged (SHA-256 `97e11c92e1e8b74b2e55d537b0354c23a55e78402645bb6a8ee1f2c6f9bdf90a`); the target remained absent. Both symlink texts and the explicit configured workspace value remained unchanged. Sanitized real output:

```text
[state-migrations] Legacy state migration notes:
- Profile workspace: keeping configured workspace at <profile-target>; existing workspace at <legacy-source> was left unchanged.
Doctor complete.
```

- Unconfigured migration control: exited 0; the source moved to the conventional target with identical marker SHA-256 `06630bb3f33156ac9fb9e469534936010daa38c0da87c8913fdc4fec235ccf47`. Explicit workspace values remained absent. This verifies the guard did not disable ordinary migration.
- Fresh named profile: the same actual CLI exited 0 and printed `Doctor complete.`; both conventional workspace paths were absent before and after.
- Before the current-main lifecycle integration, the identical 3 changed source files also passed 5 real-filesystem scenarios / 9 public Doctor invocations: dangling leaf, dangling chain, dangling ancestor, native case-equivalent absent target, and unconfigured control. The current-tree chain/control and fresh-profile runs above cover the integrated runtime, rather than claiming the earlier build was the published head.

Current-tree Doctor aggregate receipt SHA-256: `66ca49733cea150b9e7b1c917cedb6ef3e9785d82dfa8fa147b016a8d3d22c5f`. Fresh-profile receipt SHA-256: `09742fdfe2ee054ec356bcf01c56484e2b2f2a21f4061682a49ad0451deadcae`. These checks used synthetic isolated homes/state/config with plugins disabled and external service-repair policy; no live gateway was updated or restarted. The current-candidate **published-updater** check is now completed by the v2026.9.5 proof below; the separate v2026.9.4 timeout limitation is retained explicitly.
<!-- /pr-145976-current-candidate-proof -->

<!-- pr-145976-current-updater-proof -->
### Published updater × current signed candidate: passed

Used the unmodified public `openclaw@2026.9.5` package (registry integrity verified; baseline build `2026.9.5-release-ec9c1a13db89-2026-09-18T18-51-37.323Z`) in a fresh isolated npm prefix/home. Built the candidate from signed head `ce7f2f12dbfb54c57ac9994a9320cb252119bac2` through the canonical self-contained package workflow; its tarball integrity/import-graph check passed, and packaged `dist/build-info.json` recorded that exact commit. Candidate tarball SHA-256: `0acbd0fd873601a84f4666b80e068fd42b274a3474fb5d98018fb59123a6b402`.

Ran the actual published updater, without modifying its source or verification guards:

```sh
node <published-prefix>/lib/node_modules/openclaw/openclaw.mjs   --profile workspace145976-update update   --tag <candidate.tgz> --yes --no-restart --json --timeout 900
```

Sanitized terminal result:

```text
status: ok
run.status: succeeded
before.buildId: 2026.9.5-release-ec9c1a13db89-2026-09-18T18-51-37.323Z
after.buildId: 2026.9.5-ce7f2f12dbfb-2026-09-19T17-43-17.294Z
global update: exit 0
Preparing update checks: exit 0
Checking data migrations: exit 0
Checking update health: exit 0
Checking configuration: exit 0
Checking plugins: exit 0
Checking update recovery: exit 0
Checking Gateway startup: exit 0
global install swap: exit 0
openclaw doctor: exit 0
finalize:plugins:0: exit 0
finalize:plugins:1: exit 0
```

The actual installed candidate's build metadata records `ce7f2f12dbfb54c57ac9994a9320cb252119bac2`. The fixture configured a two-link dangling alias pointing to the convention-derived **missing target**, with an existing legacy source. Before and after the full updater transaction:

```text
legacy source exists: true
source marker SHA-256: 85a0d8f6d083c3236951c8c1c643ec02995f30c1f3f192aea900014003c0a258
configured target exists: false
configured workspace value: unchanged
both symlink texts: unchanged
```

A subsequent actual installed-candidate `doctor --fix --non-interactive --no-workspace-suggestions` also exited 0 and preserved these same invariants, with the neutral configured-workspace notice. Current-tree fresh-profile and ordinary unconfigured-migration behavior are documented above. These runs use synthetic isolated state/config and disabled plugins; the only gateway process was the updater's temporary loopback canary. No live service was updated or restarted.

**Preserved limitation:** an initial v2026.9.4-published-updater attempt on this same candidate passed migration rehearsal, Doctor lint, configuration, plugin resolution, migration continuation, and gateway canary, but failed at swap because that published binary hard-caps its integrity scan at 30 seconds. Its baseline remained installed and the fixture stayed unchanged. That failed attempt is not claimed as successful proof. Published v2026.9.5 already removes the hard clamp and honors the supplied timeout; the successful run above uses that public binary unchanged. The older successful v2026.9.4 → `4c9e46ab...` evidence remains historical evidence only.

Updater result receipt SHA-256: `f5bfb02a16dfbaa85ba7f5d5cdb7851bb9e64267ff0a96789c8ee6d4f30f7cb6`. Exact-head hosted CI attempt 2 passed after the transient npm audit-service outage recovered: https://github.com/openclaw/openclaw/actions/runs/35458064583/attempts/2 . No source change or CI waiver was used for the retry.
<!-- /pr-145976-current-updater-proof -->
