### PR TITLE
test: share Nextcloud Talk runtime fixtures

### DIFF
--- a/extensions/nextcloud-talk/src/inbound.authz.test.ts
+++ b/extensions/nextcloud-talk/src/inbound.authz.test.ts
@@ -1,6 +1,6 @@
-// Nextcloud Talk tests cover inbound.authz plugin behavior.
 import { describe, expect, it, vi } from "vitest";
-import type { PluginRuntime, RuntimeEnv } from "../runtime-api.js";
+import { createRuntimeSpies } from "../../test-support/runtime-spies.js";
+import type { PluginRuntime } from "../runtime-api.js";
 import type { ResolvedNextcloudTalkAccount } from "./accounts.js";
 import { handleNextcloudTalkInbound } from "./inbound.js";
 import { setNextcloudTalkRuntime } from "./runtime.js";
@@ -27,13 +27,6 @@ function installInboundAuthzRuntime(params: {
       },
     },
   } as unknown as PluginRuntime);
-}
-
-function createTestRuntimeEnv(): RuntimeEnv {
-  return {
-    log: vi.fn(),
-    error: vi.fn(),
-  } as unknown as RuntimeEnv;
 }
 
 describe("nextcloud-talk inbound authz", () => {
@@ -84,7 +77,7 @@ describe("nextcloud-talk inbound authz", () => {
       message,
       account,
       config,
-      runtime: createTestRuntimeEnv(),
+      runtime: createRuntimeSpies(),
     });
 
     expect(readAllowFromStore).not.toHaveBeenCalled();
@@ -139,7 +132,7 @@ describe("nextcloud-talk inbound authz", () => {
           },
         },
       },
-      runtime: createTestRuntimeEnv(),
+      runtime: createRuntimeSpies(),
     });
 
     expect(buildMentionRegexes).not.toHaveBeenCalled();

--- a/extensions/nextcloud-talk/src/inbound.behavior.test.ts
+++ b/extensions/nextcloud-talk/src/inbound.behavior.test.ts
@@ -1,7 +1,7 @@
-// Nextcloud Talk tests cover inbound.behavior plugin behavior.
 import { createPluginRuntimeMock } from "openclaw/plugin-sdk/channel-test-helpers";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { OutboundReplyPayload, PluginRuntime, RuntimeEnv } from "../runtime-api.js";
+import { createRuntimeSpies } from "../../test-support/runtime-spies.js";
+import type { OutboundReplyPayload, PluginRuntime } from "../runtime-api.js";
 import type { ResolvedNextcloudTalkAccount } from "./accounts.js";
 import { handleNextcloudTalkInbound } from "./inbound.js";
 import { setNextcloudTalkRuntime } from "./runtime.js";
@@ -78,13 +78,6 @@ function installRuntime(params?: {
   return runtime;
 }
 
-function createRuntimeEnv() {
-  return {
-    log: vi.fn(),
-    error: vi.fn(),
-  } as unknown as RuntimeEnv;
-}
-
 function requireFirstMockArg(mock: ReturnType<typeof vi.fn>, label: string): unknown {
   const [call] = mock.mock.calls;
   if (!call) {
@@ -151,7 +144,7 @@ describe("nextcloud-talk inbound behavior", () => {
   });
 
   it("logs the drop when an inbound message has an empty body", async () => {
-    const runtime = createRuntimeEnv();
+    const runtime = createRuntimeSpies();
     await handleNextcloudTalkInbound({
       message: createMessage({ text: "", mediaType: "application/pdf" }),
       account: createAccount(),
@@ -182,7 +175,7 @@ describe("nextcloud-talk inbound behavior", () => {
       message: createMessage({ timestamp: 1_736_380_800_000 }),
       account: createAccount(),
       config: { channels: { "nextcloud-talk": {} } } as CoreConfig,
-      runtime: createRuntimeEnv(),
+      runtime: createRuntimeSpies(),
       statusSink,
     });
 
@@ -211,7 +204,6 @@ describe("nextcloud-talk inbound behavior", () => {
       .find((status) => status.lastOutboundAt !== undefined);
     expect(typeof outboundStatus?.lastOutboundAt).toBe("number");
     expect(outboundStatus?.lastOutboundAt).toBeGreaterThanOrEqual(1_736_380_800_000);
-    expect(sendMessageNextcloudTalkMock).toHaveBeenCalledTimes(1);
   });
 
   it("drops unmentioned group traffic before dispatch", async () => {
@@ -224,7 +216,7 @@ describe("nextcloud-talk inbound behavior", () => {
       issueChallenge: vi.fn(),
     });
     resolveNextcloudTalkRoomKindMock.mockResolvedValue("group");
-    const runtime = createRuntimeEnv();
+    const runtime = createRuntimeSpies();
 
     await handleNextcloudTalkInbound({
       message: createMessage({
@@ -268,7 +260,7 @@ describe("nextcloud-talk inbound behavior", () => {
         issueChallenge: vi.fn(),
       });
       resolveNextcloudTalkRoomKindMock.mockResolvedValue("group");
-      const runtime = createRuntimeEnv();
+      const runtime = createRuntimeSpies();
 
       await handleNextcloudTalkInbound({
         message: createMessage({
@@ -381,7 +373,7 @@ describe("nextcloud-talk inbound behavior", () => {
       message: createMessage({ text, isGroupChat: group ?? false }),
       account,
       config,
-      runtime: createRuntimeEnv(),
+      runtime: createRuntimeSpies(),
     });
 
     expect(hasControlCommand).toHaveBeenCalledWith(command, config);
@@ -429,7 +421,7 @@ describe("nextcloud-talk inbound behavior", () => {
         },
       }),
       config: { channels: { "nextcloud-talk": {} } } as CoreConfig,
-      runtime: createRuntimeEnv(),
+      runtime: createRuntimeSpies(),
       turnAdoptionLifecycle: lifecycle,
     });
 
@@ -470,7 +462,7 @@ describe("nextcloud-talk inbound behavior", () => {
         },
       }),
       config,
-      runtime: createRuntimeEnv(),
+      runtime: createRuntimeSpies(),
     });
 
     const assembledRequest = requireFirstMockArg(

--- a/extensions/nextcloud-talk/src/monitor-runtime.abort.test.ts
+++ b/extensions/nextcloud-talk/src/monitor-runtime.abort.test.ts
@@ -1,7 +1,7 @@
-// Nextcloud Talk monitor shutdown tests cover composite abort ownership.
 import { createPluginRuntimeMock } from "openclaw/plugin-sdk/channel-test-helpers";
 import type { PluginRuntime } from "openclaw/plugin-sdk/runtime-store";
 import { describe, expect, it, vi } from "vitest";
+import { createRuntimeSpies } from "../../test-support/runtime-spies.js";
 import { monitorNextcloudTalkProvider } from "./monitor-runtime.js";
 import { setNextcloudTalkRuntime } from "./runtime.js";
 
@@ -36,7 +36,7 @@ describe("Nextcloud Talk monitor abort", () => {
           },
         },
       },
-      runtime: { error: vi.fn(), log: vi.fn(), exit: vi.fn() as never },
+      runtime: createRuntimeSpies(),
       abortSignal: abortController.signal,
       statusSink,
       createSpool,
@@ -84,7 +84,7 @@ describe("Nextcloud Talk monitor abort", () => {
           },
         },
       },
-      runtime: { error: vi.fn(), log: vi.fn(), exit: vi.fn() as never },
+      runtime: createRuntimeSpies(),
       abortSignal: abortController.signal,
       statusSink,
       createSpool: () => ({

--- a/extensions/nextcloud-talk/src/room-info.fetch-timeout.test.ts
+++ b/extensions/nextcloud-talk/src/room-info.fetch-timeout.test.ts
@@ -1,6 +1,6 @@
-// Nextcloud Talk room info lookup tests cover real HTTP timeout behavior.
 import { withServer } from "openclaw/plugin-sdk/test-env";
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
+import { createRuntimeSpies } from "../../test-support/runtime-spies.js";
 import { resolveNextcloudTalkRoomKind } from "./room-info.js";
 
 const REQUEST_TIMEOUT_MS = 500;
@@ -8,7 +8,7 @@ const REQUEST_TIMEOUT_MS = 500;
 describe("nextcloud talk room info fetch timeout", () => {
   it("bounds hanging room info GET requests", async () => {
     let received = false;
-    const runtimeError = vi.fn();
+    const runtime = createRuntimeSpies();
 
     await withServer(
       (request) => {
@@ -29,11 +29,7 @@ describe("nextcloud talk room info fetch timeout", () => {
             },
           } as never,
           roomToken: "abc123",
-          runtime: {
-            error: runtimeError,
-            exit: vi.fn(),
-            log: vi.fn(),
-          },
+          runtime,
           timeoutMs: REQUEST_TIMEOUT_MS,
         });
 
@@ -42,6 +38,6 @@ describe("nextcloud talk room info fetch timeout", () => {
     );
 
     expect(received).toBe(true);
-    expect(runtimeError).not.toHaveBeenCalled();
+    expect(runtime.error).not.toHaveBeenCalled();
   });
 });

--- a/extensions/nextcloud-talk/src/room-info.test.ts
+++ b/extensions/nextcloud-talk/src/room-info.test.ts
@@ -1,9 +1,9 @@
-// Nextcloud Talk tests cover room info plugin behavior.
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { SsrFBlockedError } from "openclaw/plugin-sdk/ssrf-runtime";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { createRuntimeSpies } from "../../test-support/runtime-spies.js";
 import type { ResolvedNextcloudTalkAccount } from "./accounts.js";
 import { resolveNextcloudTalkRoomKind } from "./room-info.js";
 
@@ -220,9 +220,7 @@ describe("nextcloud talk room info", () => {
 
   it("reads the api password from a file and logs non-ok room info responses", async () => {
     const release = vi.fn(async () => {});
-    const log = vi.fn();
-    const error = vi.fn();
-    const exit = vi.fn();
+    const runtime = createRuntimeSpies();
     const tempDir = mkdtempSync(path.join(tmpdir(), "nextcloud-talk-room-info-"));
     tempDirs.push(tempDir);
     const passwordFile = path.join(tempDir, "secret");
@@ -246,14 +244,16 @@ describe("nextcloud talk room info", () => {
         },
       } as never,
       roomToken: "room-group",
-      runtime: { log, error, exit },
+      runtime,
     });
 
     expect(kind).toBeUndefined();
     expect(requireFirstFetchParams().init?.headers?.Authorization).toBe(
       "Basic Ym90OmZpbGUtc2VjcmV0",
     );
-    expect(log).toHaveBeenCalledWith("nextcloud-talk: room lookup failed (403) token=room-group");
+    expect(runtime.log).toHaveBeenCalledWith(
+      "nextcloud-talk: room lookup failed (403) token=room-group",
+    );
     expect(release).toHaveBeenCalledTimes(1);
   });
 
@@ -274,9 +274,7 @@ describe("nextcloud talk room info", () => {
 
   it("reports malformed room info JSON with a stable channel error", async () => {
     const release = vi.fn(async () => {});
-    const log = vi.fn();
-    const error = vi.fn();
-    const exit = vi.fn();
+    const runtime = createRuntimeSpies();
     fetchWithSsrFGuard.mockResolvedValue({
       response: new Response("{ nope", {
         status: 200,
@@ -295,11 +293,11 @@ describe("nextcloud talk room info", () => {
         },
       } as never,
       roomToken: "room-malformed",
-      runtime: { log, error, exit },
+      runtime,
     });
 
     expect(kind).toBeUndefined();
-    expect(error).toHaveBeenCalledWith(
+    expect(runtime.error).toHaveBeenCalledWith(
       "nextcloud-talk: room lookup error: Error: Nextcloud Talk room info failed: malformed JSON response",
     );
     expect(release).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled so maintainers can update the branch when needed.

</details>

## What Problem This Solves

Nextcloud Talk tests repeat the same runtime-mock construction across five suites, adding fixture maintenance without additional coverage.

## Why This Change Was Made

Reuse the existing runtime-spy fixture and remove one duplicate final pairing-count assertion. The earlier count, payload, status, timeout, and lifecycle checks remain. All 52 cases are retained.

## User Impact

No user-visible behavior changes. Production code is unchanged; tests add 30 lines and remove 51 (net −21).

## Evidence

Complete baseline and candidate runs passed all 52 cases, including lifecycle and room-info retry siblings. Case identities, order, and status match within each file; cross-file scheduling differed. Targeted formatting and type-aware lint passed, followed by all 19 checks selected by the normal configured gate. The hosted receiver matched the exact base plus the five changed files, and the lease, capsule, and owned temporary resources were cleaned up.

This proof does not claim a live Nextcloud server test or a performance improvement.
