### PR TITLE
fix(signal): refuse account deletion that activates a shadowed identity

### DIFF
--- a/docs/channels/signal.md
+++ b/docs/channels/signal.md
@@ -83,7 +83,7 @@ Minimal config:
 
 Multi-account support: use `channels.signal.accounts` with per-account config and optional `name`. Each named account owns its `transport`; it does not inherit the top-level transport. The top-level transport belongs only to the implicit `default` account. See [Multi-account channels](/gateway/config-channels#multi-account-all-channels) for the shared pattern.
 
-Account keys use the normalized IDs shown by status. For example, `Work Phone` with its own `account` number runs as `work-phone` and uses its authored settings without running Doctor. If multiple keys normalize to the same ID, the exact key wins and Doctor reports the collision. Legacy aliases without their own number keep their existing inherited behavior. Doctor can clean up unambiguous keys, but refuses to rename an alias when that would activate previously ignored settings.
+Account keys use the normalized IDs shown by status. For example, `Work Phone` with its own `account` number runs as `work-phone` and uses its authored settings without running Doctor. If multiple keys normalize to the same ID, the exact key wins and Doctor reports the collision. Deletion refuses to remove that account if another stored key would then select a different identity; the error names both keys so you can resolve the collision first. Legacy aliases without their own number keep their existing inherited behavior. Doctor can clean up unambiguous keys, but refuses to rename an alias when that would activate previously ignored settings.
 
 Omitted account `dmPolicy` and `groupPolicy` inherit the channel root; explicit account policies win. If neither scope sets them, DMs use `pairing` and groups use `allowlist`.
 

--- a/docs/plugins/sdk-channel-plugins/setup-and-config.md
+++ b/docs/plugins/sdk-channel-plugins/setup-and-config.md
@@ -88,26 +88,32 @@ selection, and other channel-specific account concerns in the plugin.
 
 ### Stored account-key selection
 
-Import `resolveChannelAccountKey`, `resolveAccountKey`, `resolveNormalizedAccountEntry`, and
+Import `resolveAccountKey`, `resolveNormalizedAccountEntry`, and
 `ChannelAccountKeyPolicy` from `openclaw/plugin-sdk/account-resolution`.
 Use the selected stored key for writes so an edit preserves the operator's key
 spelling and updates the same entry that readers use.
 
 For registered channel callbacks, use
-`resolveChannelAccountKey(accounts, accountId, channelId)` to consume the selected
+`resolveAccountKey(accounts, accountId, undefined, undefined, { channelId })` to consume the selected
 manifest policy from the owning operation or Gateway snapshot. Keep that metadata
 scope active through reads, setup, and deletion. Do not import a second policy
 from the runtime plugin's manifest: another manifest may own the channel policy.
 
-`resolveAccountKey(accounts, accountId, normalizeAccountId?, policy?)` returns a
+`resolveAccountKey(accounts, accountId, normalizeAccountId?, policy?, options?)` returns a
 stored key or `undefined`:
 
-| Argument             | Meaning                                                                                                                                                                                                                              |
-| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `accounts`           | Authored account map, or `undefined`.                                                                                                                                                                                                |
-| `accountId`          | Requested account id. With a policy, routing normalization runs first and the exact canonical key wins. Without a policy, the exact requested key wins.                                                                              |
-| `normalizeAccountId` | Optional function applied to the requested id and stored keys when no policy is supplied. Omit both for case-insensitive lookup. A policy selects routing normalization.                                                             |
-| `policy`             | Optional `ChannelAccountKeyPolicy` with `canonicalAliasesRequireOwnField`, the account field that must contain its own nonempty string before a canonical-only alias is eligible. Existing case-insensitive matches remain eligible. |
+| Argument               | Meaning                                                                                                                                                                                                                              |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `accounts`             | Authored account map, or `undefined`.                                                                                                                                                                                                |
+| `accountId`            | Requested account id. With a policy, routing normalization runs first and the exact canonical key wins. Without a policy, the exact requested key wins.                                                                              |
+| `normalizeAccountId`   | Optional function applied to the requested id and stored keys when no policy is supplied. Omit both for case-insensitive lookup. A policy selects routing normalization.                                                             |
+| `policy`               | Optional `ChannelAccountKeyPolicy` with `canonicalAliasesRequireOwnField`, the account field that must contain its own nonempty string before a canonical-only alias is eligible. Existing case-insensitive matches remain eligible. |
+| `options.channelId`    | Optional channel whose selected manifest supplies the policy. An explicit `policy` takes precedence. Without a channel or selected policy, the normalizer and case-insensitive behavior stay unchanged.                              |
+| `options.allowMissing` | Return the creation target when no stored key is eligible. Reserved object keys throw before a writer can create an unreadable account.                                                                                              |
+
+The shipped v2026.9.4 SDK does not export `resolveAccountKey`; use these options
+only with a host SDK that supplies this selector and channel context. This does
+not change the behavior of the older entry-returning helpers.
 
 `resolveNormalizedAccountEntry(accounts, accountId, normalizeAccountId, policy?)`
 takes the same arguments, requires the normalizer, and returns the selected entry

--- a/docs/plugins/sdk-channel-plugins/setup-and-config.md
+++ b/docs/plugins/sdk-channel-plugins/setup-and-config.md
@@ -88,10 +88,16 @@ selection, and other channel-specific account concerns in the plugin.
 
 ### Stored account-key selection
 
-Import `resolveAccountKey`, `resolveNormalizedAccountEntry`, and
+Import `resolveChannelAccountKey`, `resolveAccountKey`, `resolveNormalizedAccountEntry`, and
 `ChannelAccountKeyPolicy` from `openclaw/plugin-sdk/account-resolution`.
 Use the selected stored key for writes so an edit preserves the operator's key
 spelling and updates the same entry that readers use.
+
+For registered channel callbacks, use
+`resolveChannelAccountKey(accounts, accountId, channelId)` to consume the selected
+manifest policy from the owning operation or Gateway snapshot. Keep that metadata
+scope active through reads, setup, and deletion. Do not import a second policy
+from the runtime plugin's manifest: another manifest may own the channel policy.
 
 `resolveAccountKey(accounts, accountId, normalizeAccountId?, policy?)` returns a
 stored key or `undefined`:
@@ -112,15 +118,14 @@ channel inheritance can then apply.
 (the authored map), and `accountId`, plus optional `normalizeAccountId`,
 `channelId`, and `accountKeyPolicy`. `channelId` selects the rule from the current
 operation's prepared plugin metadata snapshot, or the published Gateway snapshot.
-`accountKeyPolicy` supplies an explicit rule for a plugin-owned call before that
-snapshot is available; use the declaration from the plugin manifest. An explicit
-policy works without `channelId` or `normalizeAccountId` and takes precedence over
-the snapshot rule. Account-key selection precedes the existing field merge and
+`accountKeyPolicy` remains available for callers with an explicitly supplied
+policy. It works without `channelId` or `normalizeAccountId` and takes precedence
+over the snapshot rule. Account-key selection precedes the existing field merge and
 collection inheritance rules.
 
 The setup and config adapter factories accept the same optional `accountKeyPolicy`.
-Pass the manifest declaration when constructing an adapter before metadata is
-available. The scoped setup, account-name, enable, delete, and field-clear helpers
+Registered adapters use the prepared channel policy. The scoped setup,
+account-name, enable, delete, and field-clear helpers
 also accept `accountKeyPolicy`; their `accountId` is the normalized routing ID,
 not a stored spelling. The registered adapters normalize operator input before
 calling these helpers. `clearAccountEntryFields` additionally accepts `channelId`
@@ -128,7 +133,10 @@ to select prepared metadata, or an explicit policy without `channelId`.
 
 Declare the rule in
 [`channelAccountKeyPolicies`](/plugins/manifest/surfaces#channelaccountkeypolicies-reference)
-so generic channel readers and writers receive the same policy.
+so generic channel readers and writers receive the same policy. Deletion reruns
+the selector on the proposed remaining map and refuses a deletion that would
+activate a colliding row. Creation with `allowMissing: true` rejects reserved
+object keys instead of writing an account that readers cannot select.
 
 ## Other narrow channel subpaths
 

--- a/extensions/signal/src/account-selection.test.ts
+++ b/extensions/signal/src/account-selection.test.ts
@@ -186,13 +186,20 @@ describe("Signal registered account entry points", () => {
         "registered Signal enable writer",
       );
       expect(disabled.channels?.signal?.accounts?.[key]?.enabled).toBe(false);
-      const removed = signalPlugin.config.deleteAccount?.({
-        cfg: disabled,
-        accountId: "work-phone",
-      });
-      expect(removed?.channels?.signal?.accounts?.[key]).toBeUndefined();
       if (collision) {
-        expect(removed?.channels?.signal?.accounts?.["Work Phone"]).toEqual(authored);
+        expect(() =>
+          signalPlugin.config.deleteAccount?.({ cfg: disabled, accountId: "work-phone" }),
+        ).toThrow('stored keys "work-phone" and "Work Phone"');
+        expect(signalPlugin.config.resolveAccount(disabled, "work-phone").config.account).toBe(
+          "+12025550125",
+        );
+      } else {
+        const removed = expectDefined(
+          signalPlugin.config.deleteAccount?.({ cfg: disabled, accountId: "work-phone" }),
+          "registered Signal delete writer",
+        );
+        expect(removed.channels?.signal?.accounts?.[key]).toBeUndefined();
+        expect(signalPlugin.config.resolveAccount(removed, "work-phone").configured).toBe(false);
       }
     },
   );

--- a/extensions/signal/src/account-selection.ts
+++ b/extensions/signal/src/account-selection.ts
@@ -1,13 +1,12 @@
-import {
-  normalizeAccountId,
-  resolveChannelAccountKey,
-} from "openclaw/plugin-sdk/account-resolution";
+import { normalizeAccountId, resolveAccountKey } from "openclaw/plugin-sdk/account-resolution";
 
 export function resolveSignalAccountKey<T>(
   accounts: Record<string, T> | undefined,
   accountId: string,
 ): string | undefined {
-  return resolveChannelAccountKey(accounts, normalizeAccountId(accountId), "signal");
+  return resolveAccountKey(accounts, normalizeAccountId(accountId), undefined, undefined, {
+    channelId: "signal",
+  });
 }
 
 export function resolveSignalAccountEntry<T>(

--- a/extensions/signal/src/account-selection.ts
+++ b/extensions/signal/src/account-selection.ts
@@ -1,18 +1,13 @@
-import { normalizeAccountId, resolveAccountKey } from "openclaw/plugin-sdk/account-resolution";
-import manifest from "../openclaw.plugin.json" with { type: "json" };
-
-export const signalAccountKeyPolicy = manifest.channelAccountKeyPolicies.signal;
+import {
+  normalizeAccountId,
+  resolveChannelAccountKey,
+} from "openclaw/plugin-sdk/account-resolution";
 
 export function resolveSignalAccountKey<T>(
   accounts: Record<string, T> | undefined,
   accountId: string,
 ): string | undefined {
-  return resolveAccountKey(
-    accounts,
-    normalizeAccountId(accountId),
-    normalizeAccountId,
-    signalAccountKeyPolicy,
-  );
+  return resolveChannelAccountKey(accounts, normalizeAccountId(accountId), "signal");
 }
 
 export function resolveSignalAccountEntry<T>(

--- a/extensions/signal/src/accounts.ts
+++ b/extensions/signal/src/accounts.ts
@@ -8,7 +8,7 @@ import {
 } from "openclaw/plugin-sdk/account-resolution";
 import type { ReplyToMode } from "openclaw/plugin-sdk/config-contracts";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
-import { resolveSignalAccountEntry, signalAccountKeyPolicy } from "./account-selection.js";
+import { resolveSignalAccountEntry } from "./account-selection.js";
 import type { SignalAccountConfig, SignalTransportConfig } from "./account-types.js";
 import {
   allocateSignalManagedNativePort,
@@ -74,8 +74,7 @@ export function resolveSignalAccountConfig(
       | Record<string, Partial<SignalAccountConfig>>
       | undefined,
     accountId,
-    normalizeAccountId,
-    accountKeyPolicy: signalAccountKeyPolicy,
+    channelId: "signal",
     nestedObjectKeys: ["aliases"],
   });
   if (accountId === DEFAULT_ACCOUNT_ID && channelConfig?.transport) {

--- a/extensions/signal/src/setup-core.ts
+++ b/extensions/signal/src/setup-core.ts
@@ -27,11 +27,7 @@ import {
   normalizeOptionalString,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { normalizeE164 } from "openclaw/plugin-sdk/text-utility-runtime";
-import {
-  resolveSignalAccountEntry,
-  resolveSignalAccountKey,
-  signalAccountKeyPolicy,
-} from "./account-selection.js";
+import { resolveSignalAccountEntry, resolveSignalAccountKey } from "./account-selection.js";
 import type { SignalTransportConfig } from "./account-types.js";
 import { resolveDefaultSignalAccountId, resolveSignalAccount } from "./accounts.js";
 import {
@@ -317,7 +313,6 @@ export const signalCompletionNote = {
 
 const signalSetupAdapterBase = createPatchedAccountSetupAdapter<SignalSetupInput>({
   channelKey: channel,
-  accountKeyPolicy: signalAccountKeyPolicy,
   validateInput: createSetupInputPresenceValidator<SignalSetupInput>({
     validate: ({ cfg, accountId, input }) => {
       if (

--- a/extensions/signal/src/setup-transport.ts
+++ b/extensions/signal/src/setup-transport.ts
@@ -6,7 +6,7 @@ import {
   patchChannelConfigForAccount,
 } from "openclaw/plugin-sdk/setup-runtime";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
-import { resolveSignalAccountEntry, signalAccountKeyPolicy } from "./account-selection.js";
+import { resolveSignalAccountEntry } from "./account-selection.js";
 import type { SignalTransportConfig } from "./account-types.js";
 import {
   listSignalAccountIds,
@@ -313,7 +313,6 @@ export function writeSignalAccountTransport(params: {
     channel: "signal",
     accountId: params.accountId,
     patch: { transport },
-    setupSurface: { accountKeyPolicy: signalAccountKeyPolicy },
   });
   const canonical = clearLegacySignalTransportFieldsForAccount({
     cfg: next,

--- a/extensions/signal/src/shared.ts
+++ b/extensions/signal/src/shared.ts
@@ -8,7 +8,6 @@ import { createChannelPluginBase, getChatChannelMeta } from "openclaw/plugin-sdk
 import type { ChannelPlugin } from "openclaw/plugin-sdk/core";
 import { normalizeStringifiedEntries } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { normalizeE164 } from "openclaw/plugin-sdk/text-utility-runtime";
-import { signalAccountKeyPolicy } from "./account-selection.js";
 import {
   listSignalAccountIds,
   resolveDefaultSignalAccountId,
@@ -32,7 +31,6 @@ export const signalSetupWizard = createSignalSetupWizardProxy(
 
 const signalConfigAdapterBase = createScopedChannelConfigAdapter<ResolvedSignalAccount>({
   sectionKey: SIGNAL_CHANNEL,
-  accountKeyPolicy: signalAccountKeyPolicy,
   listAccountIds: (cfg) => listSignalAccountIds(cfg),
   resolveAccount: adaptScopedAccountAccessor((params) => resolveSignalAccount(params)),
   defaultAccountId: (cfg) => resolveDefaultSignalAccountId(cfg),

--- a/src/channels/plugins/account-config-mutation.test.ts
+++ b/src/channels/plugins/account-config-mutation.test.ts
@@ -3,9 +3,8 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { createChannelTestPluginBase } from "../../test-utils/channel-plugins.js";
 import {
   applyPreparedChannelAccountConfiguration,
-  applyPreparedChannelAccountRemoval,
+  applyChannelAccountRemoval,
   prepareChannelAccountConfiguration,
-  prepareChannelAccountRemoval,
 } from "./account-config-mutation.js";
 import { setAccountEnabledInConfigSection } from "./config-helpers.js";
 import { defineChannelSetupContract } from "./setup-contract.js";
@@ -18,6 +17,23 @@ const runtime = {
 } as never;
 
 describe("channel account config mutations", () => {
+  it("channels.add setup.resolveAccountId retains plugin defaults when --account is omitted", async () => {
+    const plugin = {
+      ...createChannelTestPluginBase({ id: "test-chat" }),
+      setup: {
+        resolveAccountId: ({ accountId }: { accountId?: string }) => accountId ?? "work",
+        applyAccountConfig: ({ cfg }: { cfg: OpenClawConfig }) => cfg,
+      },
+    };
+    const prepared = await prepareChannelAccountConfiguration({
+      cfg: {},
+      plugin,
+      resolveInput: () => ({}),
+      runtime,
+    });
+    expect(prepared).toMatchObject({ ok: true, value: { accountId: "work" } });
+  });
+
   it("prepares, validates, applies, and reports lifecycle changes in order", async () => {
     const callOrder: string[] = [];
     const beforePersistentEffect = vi.fn(async () => {
@@ -272,20 +288,15 @@ describe("channel account config mutations", () => {
       gateway: { startAccount: vi.fn() },
       lifecycle: { onAccountRemoved },
     } as ChannelPlugin;
-    const prepared = prepareChannelAccountRemoval({
+    const prepared = {
       plugin,
       accountId: "Work",
       action: "delete",
-    });
+    } as const;
 
-    expect(prepared).toMatchObject({
-      accountId: "work",
-      accountKey: "work",
-      shouldStopRuntime: true,
-    });
-    const result = await applyPreparedChannelAccountRemoval({
+    const result = await applyChannelAccountRemoval({
       cfg,
-      prepared,
+      ...prepared,
       runtime,
     });
 
@@ -319,9 +330,11 @@ describe("channel account config mutations", () => {
         }),
         lifecycle: { onAccountRemoved, onAccountConfigChanged },
       };
-      const result = await applyPreparedChannelAccountRemoval({
+      const result = await applyChannelAccountRemoval({
         cfg,
-        prepared: prepareChannelAccountRemoval({ plugin, accountId: "wrok", action }),
+        plugin,
+        accountId: "wrok",
+        action,
         runtime,
       });
 
@@ -355,9 +368,10 @@ describe("channel account config mutations", () => {
       }),
       lifecycle: { onAccountConfigChanged },
     };
-    const result = await applyPreparedChannelAccountRemoval({
+    const result = await applyChannelAccountRemoval({
       cfg,
-      prepared: prepareChannelAccountRemoval({ plugin, action: "disable" }),
+      plugin,
+      action: "disable",
       runtime,
     });
 
@@ -385,9 +399,10 @@ describe("channel account config mutations", () => {
       }),
       lifecycle: { onAccountRemoved },
     };
-    const result = await applyPreparedChannelAccountRemoval({
+    const result = await applyChannelAccountRemoval({
       cfg: {},
-      prepared: prepareChannelAccountRemoval({ plugin, action: "delete" }),
+      plugin,
+      action: "delete",
       runtime,
     });
 
@@ -404,15 +419,15 @@ describe("channel account config mutations", () => {
       ...createChannelTestPluginBase({ id: "test-chat" }),
       lifecycle: { onAccountConfigChanged },
     } as ChannelPlugin;
-    const prepared = prepareChannelAccountRemoval({
+    const prepared = {
       plugin,
       accountId: "default",
       action: "disable",
-    });
+    } as const;
 
-    const result = await applyPreparedChannelAccountRemoval({
+    const result = await applyChannelAccountRemoval({
       cfg: {},
-      prepared,
+      ...prepared,
       runtime,
     });
 

--- a/src/channels/plugins/account-config-mutation.test.ts
+++ b/src/channels/plugins/account-config-mutation.test.ts
@@ -3,10 +3,8 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { createChannelTestPluginBase } from "../../test-utils/channel-plugins.js";
 import {
   applyPreparedChannelAccountConfiguration,
-  applyChannelAccountRemoval,
   prepareChannelAccountConfiguration,
 } from "./account-config-mutation.js";
-import { setAccountEnabledInConfigSection } from "./config-helpers.js";
 import { defineChannelSetupContract } from "./setup-contract.js";
 import type { ChannelPlugin } from "./types.plugin.js";
 
@@ -17,23 +15,6 @@ const runtime = {
 } as never;
 
 describe("channel account config mutations", () => {
-  it("channels.add setup.resolveAccountId retains plugin defaults when --account is omitted", async () => {
-    const plugin = {
-      ...createChannelTestPluginBase({ id: "test-chat" }),
-      setup: {
-        resolveAccountId: ({ accountId }: { accountId?: string }) => accountId ?? "work",
-        applyAccountConfig: ({ cfg }: { cfg: OpenClawConfig }) => cfg,
-      },
-    };
-    const prepared = await prepareChannelAccountConfiguration({
-      cfg: {},
-      plugin,
-      resolveInput: () => ({}),
-      runtime,
-    });
-    expect(prepared).toMatchObject({ ok: true, value: { accountId: "work" } });
-  });
-
   it("prepares, validates, applies, and reports lifecycle changes in order", async () => {
     const callOrder: string[] = [];
     const beforePersistentEffect = vi.fn(async () => {
@@ -187,51 +168,6 @@ describe("channel account config mutations", () => {
     expect(prepared.ok).toBe(true);
   });
 
-  it("normalizes plugin-resolved account IDs only at the config mutation boundary", async () => {
-    const applyAccountConfig = vi.fn(({ cfg }) => cfg);
-    const onAccountConfigChanged = vi.fn();
-    const plugin = {
-      ...createChannelTestPluginBase({ id: "test-chat" }),
-      setup: {
-        resolveAccountId: () => "Work",
-        applyAccountConfig,
-      },
-      lifecycle: { onAccountConfigChanged },
-    } as ChannelPlugin;
-
-    const prepared = await prepareChannelAccountConfiguration({
-      cfg: {},
-      plugin,
-      requestedAccountId: "ignored",
-      resolveInput: () => ({ token: "token-1" }),
-      runtime,
-    });
-    expect(prepared.ok).toBe(true);
-    if (!prepared.ok) {
-      return;
-    }
-
-    const applied = await applyPreparedChannelAccountConfiguration({
-      cfg: {},
-      channel: "test-chat",
-      prepared: prepared.value,
-      runtime,
-    });
-
-    expect(applyAccountConfig).toHaveBeenCalledWith({
-      cfg: {},
-      accountId: "work",
-      input: { token: "token-1" },
-    });
-    expect(onAccountConfigChanged).toHaveBeenCalledWith({
-      prevCfg: {},
-      nextCfg: {},
-      accountId: "Work",
-      runtime,
-    });
-    expect(applied.accountId).toBe("Work");
-  });
-
   it("does not resolve input when the channel has no account setup capability", async () => {
     const resolveInput = vi.fn(() => {
       throw new Error("input should stay lazy");
@@ -250,191 +186,5 @@ describe("channel account config mutations", () => {
       error: { kind: "unsupported" },
     });
     expect(resolveInput).not.toHaveBeenCalled();
-  });
-
-  it("deletes a normalized listed account and runs its owner lifecycle hook", async () => {
-    const onAccountRemoved = vi.fn();
-    const cfg = {
-      channels: {
-        "test-chat": {
-          accounts: {
-            default: { token: "default-token" },
-            work: { token: "work-token" },
-          },
-        },
-      },
-    } satisfies OpenClawConfig;
-    const plugin = {
-      ...createChannelTestPluginBase({
-        id: "test-chat",
-        config: {
-          listAccountIds: () => ["Default", "Work"],
-          deleteAccount: ({ cfg: inputCfg, accountId }) => {
-            const channel = inputCfg.channels?.["test-chat"] as {
-              accounts?: Record<string, Record<string, unknown>>;
-            };
-            const accounts = { ...channel.accounts };
-            delete accounts[accountId];
-            return {
-              ...inputCfg,
-              channels: {
-                ...inputCfg.channels,
-                "test-chat": { ...channel, accounts },
-              },
-            };
-          },
-        },
-      }),
-      gateway: { startAccount: vi.fn() },
-      lifecycle: { onAccountRemoved },
-    } as ChannelPlugin;
-    const prepared = {
-      plugin,
-      accountId: "Work",
-      action: "delete",
-    } as const;
-
-    const result = await applyChannelAccountRemoval({
-      cfg,
-      ...prepared,
-      runtime,
-    });
-
-    expect(result.ok).toBe(true);
-    if (result.ok) {
-      expect(result.value.nextConfig.channels?.["test-chat"]).toMatchObject({
-        accounts: { default: { token: "default-token" } },
-      });
-    }
-    expect(onAccountRemoved).toHaveBeenCalledWith({
-      prevCfg: cfg,
-      accountId: "work",
-      runtime,
-    });
-  });
-
-  it.each(["delete", "disable"] as const)(
-    "rejects unknown accounts without lifecycle effects for %s",
-    async (action) => {
-      const cfg = {};
-      const onAccountRemoved = vi.fn();
-      const onAccountConfigChanged = vi.fn();
-      const plugin = {
-        ...createChannelTestPluginBase({
-          id: "test-chat",
-          config: {
-            listAccountIds: () => ["work"],
-            deleteAccount: () => cfg,
-            setAccountEnabled: () => cfg,
-          },
-        }),
-        lifecycle: { onAccountRemoved, onAccountConfigChanged },
-      };
-      const result = await applyChannelAccountRemoval({
-        cfg,
-        plugin,
-        accountId: "wrok",
-        action,
-        runtime,
-      });
-
-      expect(result).toEqual({
-        ok: false,
-        error: { kind: "unknown-account", action, accountIds: ["work"] },
-      });
-      expect(onAccountRemoved).not.toHaveBeenCalled();
-      expect(onAccountConfigChanged).not.toHaveBeenCalled();
-    },
-  );
-
-  it("disables a listed account that has no separately authored config", async () => {
-    const cfg = {
-      channels: { "test-chat": { accounts: { work: { token: "work-token" } } } },
-    } satisfies OpenClawConfig;
-    const onAccountConfigChanged = vi.fn();
-    const plugin = {
-      ...createChannelTestPluginBase({
-        id: "test-chat",
-        config: {
-          listAccountIds: () => ["default", "work"],
-          deleteAccount: () => cfg,
-          setAccountEnabled: (params) =>
-            setAccountEnabledInConfigSection({
-              ...params,
-              sectionKey: "test-chat",
-              allowTopLevel: true,
-            }),
-        },
-      }),
-      lifecycle: { onAccountConfigChanged },
-    };
-    const result = await applyChannelAccountRemoval({
-      cfg,
-      plugin,
-      action: "disable",
-      runtime,
-    });
-
-    expect(result).toMatchObject({
-      ok: true,
-      value: {
-        nextConfig: {
-          channels: {
-            "test-chat": {
-              accounts: { work: { token: "work-token" }, default: { enabled: false } },
-            },
-          },
-        },
-      },
-    });
-    expect(onAccountConfigChanged).toHaveBeenCalledOnce();
-  });
-
-  it("reports a listed account with no config to delete without removal lifecycle effects", async () => {
-    const onAccountRemoved = vi.fn();
-    const plugin = {
-      ...createChannelTestPluginBase({
-        id: "test-chat",
-        config: { deleteAccount: () => ({ channels: undefined }) },
-      }),
-      lifecycle: { onAccountRemoved },
-    };
-    const result = await applyChannelAccountRemoval({
-      cfg: {},
-      plugin,
-      action: "delete",
-      runtime,
-    });
-
-    expect(result).toEqual({
-      ok: false,
-      error: { kind: "nothing-to-remove", action: "delete", accountIds: ["default"] },
-    });
-    expect(onAccountRemoved).not.toHaveBeenCalled();
-  });
-
-  it("reports unsupported removal actions without running lifecycle hooks", async () => {
-    const onAccountConfigChanged = vi.fn();
-    const plugin = {
-      ...createChannelTestPluginBase({ id: "test-chat" }),
-      lifecycle: { onAccountConfigChanged },
-    } as ChannelPlugin;
-    const prepared = {
-      plugin,
-      accountId: "default",
-      action: "disable",
-    } as const;
-
-    const result = await applyChannelAccountRemoval({
-      cfg: {},
-      ...prepared,
-      runtime,
-    });
-
-    expect(result).toEqual({
-      ok: false,
-      error: { kind: "unsupported-action", action: "disable" },
-    });
-    expect(onAccountConfigChanged).not.toHaveBeenCalled();
   });
 });

--- a/src/channels/plugins/account-config-mutation.ts
+++ b/src/channels/plugins/account-config-mutation.ts
@@ -2,6 +2,7 @@ import { isDeepStrictEqual } from "node:util";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { err as resultError, ok, type Result } from "@openclaw/normalization-core/result";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { resolveChannelAccountKey } from "../../routing/account-lookup.js";
 import {
   DEFAULT_ACCOUNT_ID,
   normalizeAccountId,
@@ -90,12 +91,23 @@ export async function prepareChannelAccountConfiguration(params: {
     input = rawInput;
   }
 
+  const requestedAccountId =
+    params.requestedAccountId === undefined
+      ? undefined
+      : resolveChannelAccountKey(
+          undefined,
+          params.requestedAccountId,
+          params.plugin.id,
+          undefined,
+          undefined,
+          { allowMissing: true },
+        );
   const accountId =
     setup.resolveAccountId?.({
       cfg: params.cfg,
-      accountId: params.requestedAccountId,
+      accountId: requestedAccountId,
       input,
-    }) ?? normalizeAccountId(params.requestedAccountId);
+    }) ?? normalizeAccountId(requestedAccountId);
   if (setup.prepareAccountConfigInput) {
     await params.beforePersistentEffect?.();
     input = await setup.prepareAccountConfigInput({
@@ -180,46 +192,21 @@ export async function applyPreparedChannelAccountConfiguration(params: {
 
 type ChannelAccountRemovalAction = "delete" | "disable";
 
-type PreparedChannelAccountRemoval = {
-  plugin: ChannelAccountMutationPlugin;
-  action: ChannelAccountRemovalAction;
-  accountId: string;
-  accountKey: string;
-  shouldStopRuntime: boolean;
-};
-
 type ChannelAccountRemovalError =
   | { kind: "unsupported-action"; action: ChannelAccountRemovalAction }
   | { kind: "unknown-account"; action: ChannelAccountRemovalAction; accountIds: string[] }
   | { kind: "nothing-to-remove"; action: "delete"; accountIds: string[] };
 
-export function prepareChannelAccountRemoval(params: {
-  plugin: ChannelAccountMutationPlugin;
-  accountId?: string;
-  action: ChannelAccountRemovalAction;
-}): PreparedChannelAccountRemoval {
-  // normalizeAccountId maps omitted values to the literal default account, so
-  // the command's former nullish plugin-default fallback was unreachable.
-  const accountId = normalizeAccountId(params.accountId);
-  return {
-    plugin: params.plugin,
-    action: params.action,
-    accountId,
-    accountKey: accountId || DEFAULT_ACCOUNT_ID,
-    shouldStopRuntime: Boolean(
-      params.plugin.gateway?.startAccount || params.plugin.gateway?.logoutAccount,
-    ),
-  };
-}
-
-export async function applyPreparedChannelAccountRemoval(params: {
+export async function applyChannelAccountRemoval(params: {
   cfg: OpenClawConfig;
-  prepared: PreparedChannelAccountRemoval;
+  plugin: ChannelAccountMutationPlugin;
+  action: ChannelAccountRemovalAction;
+  accountId?: string;
   runtime: RuntimeEnv;
+  beforeRemoval?: () => Promise<void>;
 }): Promise<Result<{ nextConfig: OpenClawConfig }, ChannelAccountRemovalError>> {
-  const { accountId, action, plugin } = params.prepared;
-  // Capability validation stays in apply: callers must preserve the historical
-  // runtime-stop ordering before reporting an unsupported mutation.
+  const { action, plugin } = params;
+  const accountId = normalizeAccountId(params.accountId);
   if (action === "delete") {
     if (!plugin.config.deleteAccount) {
       return resultError({ kind: "unsupported-action", action });
@@ -234,10 +221,12 @@ export async function applyPreparedChannelAccountRemoval(params: {
       accountId,
     });
     const nextConfigJson = JSON.stringify(nextConfig);
-    // Compare serialized config so pruned undefined fields do not count as changes.
+    // The delete owner rejects invalid deletions. This comparison only detects
+    // no-op callbacks, including third-party adapters that return a fresh object.
     if (isDeepStrictEqual(JSON.parse(previousConfigJson), JSON.parse(nextConfigJson))) {
       return resultError({ kind: "nothing-to-remove", action, accountIds });
     }
+    await params.beforeRemoval?.();
     await plugin.lifecycle?.onAccountRemoved?.({
       prevCfg: params.cfg,
       accountId,
@@ -258,6 +247,7 @@ export async function applyPreparedChannelAccountRemoval(params: {
     accountId,
     enabled: false,
   });
+  await params.beforeRemoval?.();
   await plugin.lifecycle?.onAccountConfigChanged?.({
     prevCfg: params.cfg,
     nextCfg: nextConfig,

--- a/src/channels/plugins/account-key-policy.test.ts
+++ b/src/channels/plugins/account-key-policy.test.ts
@@ -2,20 +2,16 @@ import fs from "node:fs";
 import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterAll, afterEach, describe, expect, it } from "vitest";
-import { signalPlugin } from "../../../extensions/signal/api.js";
-import signalManifest from "../../../extensions/signal/openclaw.plugin.json" with { type: "json" };
 import { repairUnownedChannelAccountBindings } from "../../commands/doctor/shared/legacy-config-binding-repair.js";
 import { createDoctorPluginMetadataSnapshotScope } from "../../commands/doctor/shared/plugin-metadata-snapshot-scope.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { resolveOutboundMediaMaxBytes } from "../../media/configured-max-bytes.js";
-import { withPluginMetadataSnapshotScope } from "../../plugins/current-plugin-metadata-snapshot.js";
 import {
   cleanupPluginLoaderFixturesForTest,
   makePluginLoaderTempDir,
   resetPluginLoaderTestStateForTest,
   useNoBundledPlugins,
 } from "../../plugins/loader.test-fixtures.js";
-import { createPluginMetadataSnapshotFixture } from "../../plugins/plugin-metadata.test-support.js";
 import { resolveMergedAccountConfig } from "./account-helpers.js";
 import { listReadOnlyChannelPluginsForConfig } from "./read-only.js";
 
@@ -64,28 +60,6 @@ afterEach(() => resetPluginLoaderTestStateForTest());
 afterAll(() => cleanupPluginLoaderFixturesForTest());
 
 describe("prepared channel account policy entry points", () => {
-  it("channels.status Signal and core readers use the same selected manifest policy", () => {
-    const signal = {
-      account: "+12025550123",
-      accounts: { "Work Phone": { account: "+12025550124" } },
-    };
-    const snapshot = createPluginMetadataSnapshotFixture({
-      plugins: [{ id: "selected-signal-owner", channels: ["signal"] }, signalManifest],
-    });
-    withPluginMetadataSnapshotScope(snapshot, () => {
-      const coreAccount = resolveMergedAccountConfig({
-        channelId: "signal",
-        channelConfig: signal,
-        accounts: signal.accounts,
-        accountId: "work-phone",
-      });
-      expect(coreAccount.account).toBe(signal.account);
-      expect(
-        signalPlugin.config.resolveAccount({ channels: { signal } }, "work-phone").config.account,
-      ).toBe(coreAccount.account);
-    });
-  });
-
   it.each([undefined, "named-token"])(
     "channels.status manifest adapter retains its declared account rule outside metadata scope (token=%s)",
     (token) => {

--- a/src/channels/plugins/account-key-policy.test.ts
+++ b/src/channels/plugins/account-key-policy.test.ts
@@ -2,16 +2,20 @@ import fs from "node:fs";
 import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterAll, afterEach, describe, expect, it } from "vitest";
+import { signalPlugin } from "../../../extensions/signal/api.js";
+import signalManifest from "../../../extensions/signal/openclaw.plugin.json" with { type: "json" };
 import { repairUnownedChannelAccountBindings } from "../../commands/doctor/shared/legacy-config-binding-repair.js";
 import { createDoctorPluginMetadataSnapshotScope } from "../../commands/doctor/shared/plugin-metadata-snapshot-scope.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { resolveOutboundMediaMaxBytes } from "../../media/configured-max-bytes.js";
+import { withPluginMetadataSnapshotScope } from "../../plugins/current-plugin-metadata-snapshot.js";
 import {
   cleanupPluginLoaderFixturesForTest,
   makePluginLoaderTempDir,
   resetPluginLoaderTestStateForTest,
   useNoBundledPlugins,
 } from "../../plugins/loader.test-fixtures.js";
+import { createPluginMetadataSnapshotFixture } from "../../plugins/plugin-metadata.test-support.js";
 import { resolveMergedAccountConfig } from "./account-helpers.js";
 import { listReadOnlyChannelPluginsForConfig } from "./read-only.js";
 
@@ -60,6 +64,28 @@ afterEach(() => resetPluginLoaderTestStateForTest());
 afterAll(() => cleanupPluginLoaderFixturesForTest());
 
 describe("prepared channel account policy entry points", () => {
+  it("channels.status Signal and core readers use the same selected manifest policy", () => {
+    const signal = {
+      account: "+12025550123",
+      accounts: { "Work Phone": { account: "+12025550124" } },
+    };
+    const snapshot = createPluginMetadataSnapshotFixture({
+      plugins: [{ id: "selected-signal-owner", channels: ["signal"] }, signalManifest],
+    });
+    withPluginMetadataSnapshotScope(snapshot, () => {
+      const coreAccount = resolveMergedAccountConfig({
+        channelId: "signal",
+        channelConfig: signal,
+        accounts: signal.accounts,
+        accountId: "work-phone",
+      });
+      expect(coreAccount.account).toBe(signal.account);
+      expect(
+        signalPlugin.config.resolveAccount({ channels: { signal } }, "work-phone").config.account,
+      ).toBe(coreAccount.account);
+    });
+  });
+
   it.each([undefined, "named-token"])(
     "channels.status manifest adapter retains its declared account rule outside metadata scope (token=%s)",
     (token) => {

--- a/src/channels/plugins/config-helpers.ts
+++ b/src/channels/plugins/config-helpers.ts
@@ -84,7 +84,7 @@ export function setAccountEnabledInConfigSection(params: {
   const accountId = params.accountId || DEFAULT_ACCOUNT_ID;
   const channels = params.cfg.channels as Record<string, unknown> | undefined;
   const base = channels?.[params.sectionKey] as ChannelSection | undefined;
-  const accountKey = resolveChannelAccountKey(
+  const storedAccountKey = resolveChannelAccountKey(
     base?.accounts,
     accountId,
     params.sectionKey,
@@ -93,18 +93,18 @@ export function setAccountEnabledInConfigSection(params: {
     { allowMissing: true },
   );
   const hasAccounts = Boolean(base?.accounts);
-  if (params.allowTopLevel && accountKey === DEFAULT_ACCOUNT_ID && !hasAccounts) {
+  if (params.allowTopLevel && storedAccountKey === DEFAULT_ACCOUNT_ID && !hasAccounts) {
     // Legacy single-account sections store enabled at the channel root until accounts exist.
     return setTopLevelChannelEnabledInConfigSection(params);
   }
 
   const baseAccounts = base?.accounts ?? {};
-  const existing = baseAccounts[accountKey] ?? {};
+  const existing = baseAccounts[storedAccountKey] ?? {};
   return writeChannelSection(params.cfg, params.sectionKey, {
     ...base,
     accounts: {
       ...baseAccounts,
-      [accountKey]: { ...existing, enabled: params.enabled },
+      [storedAccountKey]: { ...existing, enabled: params.enabled },
     },
   });
 }
@@ -122,7 +122,7 @@ export function deleteAccountFromConfigSection(params: {
   const accountId = params.accountId || DEFAULT_ACCOUNT_ID;
   const channels = params.cfg.channels as Record<string, unknown> | undefined;
   const base = channels?.[params.sectionKey] as ChannelSection | undefined;
-  const accountKey = resolveChannelAccountKey(
+  const storedAccountKey = resolveChannelAccountKey(
     base?.accounts,
     accountId,
     params.sectionKey,
@@ -138,8 +138,20 @@ export function deleteAccountFromConfigSection(params: {
     return writeChannelSection(params.cfg, params.sectionKey, undefined);
   }
 
-  if (accountKey !== undefined) {
-    delete accounts[accountKey];
+  if (storedAccountKey !== undefined) {
+    delete accounts[storedAccountKey];
+    const remainingKey = resolveChannelAccountKey(
+      accounts,
+      accountId,
+      params.sectionKey,
+      (id) => id,
+      params.accountKeyPolicy,
+    );
+    if (remainingKey !== undefined) {
+      throw new Error(
+        `Cannot delete account "${accountId}": stored keys "${storedAccountKey}" and "${remainingKey}" resolve to the same account. Resolve the collision before deleting.`,
+      );
+    }
   }
   const baseRecord = { ...(base as Record<string, unknown>) };
   if (accountId === DEFAULT_ACCOUNT_ID) {

--- a/src/cli/command-config-snapshot.ts
+++ b/src/cli/command-config-snapshot.ts
@@ -1,7 +1,13 @@
 // CLI-owned config reads publish one complete metadata generation for later command consumers.
-import { readConfigFileSnapshotWithPluginMetadata } from "../config/config.js";
+import {
+  readConfigFileSnapshotWithPluginMetadata,
+  type ConfigFileSnapshot,
+} from "../config/config.js";
 import { adoptCurrentPluginMetadataSnapshotIfAbsent } from "../plugins/current-plugin-metadata-snapshot.js";
-import { completePluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
+import {
+  completePluginMetadataSnapshot,
+  type PluginMetadataSnapshot,
+} from "../plugins/plugin-metadata-snapshot.js";
 
 /** Reads full command config and adopts its metadata without replacing an existing owner. */
 export async function readCommandConfigSnapshot(options?: {
@@ -9,19 +15,33 @@ export async function readCommandConfigSnapshot(options?: {
   skipPluginValidation?: boolean;
 }) {
   const read = await readConfigFileSnapshotWithPluginMetadata(options);
+  return {
+    ...read,
+    pluginMetadataSnapshot: adoptCommandConfigSnapshotMetadata(
+      read.snapshot,
+      read.pluginMetadataSnapshot,
+    ),
+  };
+}
+
+/** Carries read-time metadata into subsequent command readers and writers. */
+export function adoptCommandConfigSnapshotMetadata(
+  snapshot: ConfigFileSnapshot,
+  metadataSnapshot?: PluginMetadataSnapshot,
+) {
   const pluginMetadataSnapshot = completePluginMetadataSnapshot({
-    snapshot: read.pluginMetadataSnapshot,
-    config: read.snapshot.sourceConfig,
+    snapshot: metadataSnapshot,
+    config: snapshot.sourceConfig,
     env: process.env,
-    workspaceDir: read.pluginMetadataSnapshot?.workspaceDir,
+    workspaceDir: metadataSnapshot?.workspaceDir,
   });
   if (pluginMetadataSnapshot) {
     adoptCurrentPluginMetadataSnapshotIfAbsent(pluginMetadataSnapshot, {
-      config: read.snapshot.sourceConfig,
-      compatibleConfigs: [read.snapshot.config, read.snapshot.runtimeConfig],
+      config: snapshot.sourceConfig,
+      compatibleConfigs: [snapshot.config, snapshot.runtimeConfig],
       env: process.env,
       workspaceDir: pluginMetadataSnapshot.workspaceDir,
     });
   }
-  return { ...read, pluginMetadataSnapshot };
+  return pluginMetadataSnapshot;
 }

--- a/src/cli/command-config-snapshot.ts
+++ b/src/cli/command-config-snapshot.ts
@@ -1,13 +1,7 @@
 // CLI-owned config reads publish one complete metadata generation for later command consumers.
-import {
-  readConfigFileSnapshotWithPluginMetadata,
-  type ConfigFileSnapshot,
-} from "../config/config.js";
+import { readConfigFileSnapshotWithPluginMetadata } from "../config/config.js";
 import { adoptCurrentPluginMetadataSnapshotIfAbsent } from "../plugins/current-plugin-metadata-snapshot.js";
-import {
-  completePluginMetadataSnapshot,
-  type PluginMetadataSnapshot,
-} from "../plugins/plugin-metadata-snapshot.js";
+import { completePluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
 
 /** Reads full command config and adopts its metadata without replacing an existing owner. */
 export async function readCommandConfigSnapshot(options?: {
@@ -15,33 +9,19 @@ export async function readCommandConfigSnapshot(options?: {
   skipPluginValidation?: boolean;
 }) {
   const read = await readConfigFileSnapshotWithPluginMetadata(options);
-  return {
-    ...read,
-    pluginMetadataSnapshot: adoptCommandConfigSnapshotMetadata(
-      read.snapshot,
-      read.pluginMetadataSnapshot,
-    ),
-  };
-}
-
-/** Carries read-time metadata into subsequent command readers and writers. */
-export function adoptCommandConfigSnapshotMetadata(
-  snapshot: ConfigFileSnapshot,
-  metadataSnapshot?: PluginMetadataSnapshot,
-) {
   const pluginMetadataSnapshot = completePluginMetadataSnapshot({
-    snapshot: metadataSnapshot,
-    config: snapshot.sourceConfig,
+    snapshot: read.pluginMetadataSnapshot,
+    config: read.snapshot.sourceConfig,
     env: process.env,
-    workspaceDir: metadataSnapshot?.workspaceDir,
+    workspaceDir: read.pluginMetadataSnapshot?.workspaceDir,
   });
   if (pluginMetadataSnapshot) {
     adoptCurrentPluginMetadataSnapshotIfAbsent(pluginMetadataSnapshot, {
-      config: snapshot.sourceConfig,
-      compatibleConfigs: [snapshot.config, snapshot.runtimeConfig],
+      config: read.snapshot.sourceConfig,
+      compatibleConfigs: [read.snapshot.config, read.snapshot.runtimeConfig],
       env: process.env,
       workspaceDir: pluginMetadataSnapshot.workspaceDir,
     });
   }
-  return pluginMetadataSnapshot;
+  return { ...read, pluginMetadataSnapshot };
 }

--- a/src/commands/channels.add.test.ts
+++ b/src/commands/channels.add.test.ts
@@ -4,7 +4,10 @@ import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vite
 import { getBundledChannelSetupPlugin } from "../channels/plugins/bundled.js";
 import type { ChannelPluginCatalogEntry } from "../channels/plugins/catalog.js";
 import { defineChannelSetupContract } from "../channels/plugins/setup-contract.js";
-import { patchScopedAccountConfig } from "../channels/plugins/setup-helpers.js";
+import {
+  applyAccountNameToChannelSection,
+  patchScopedAccountConfig,
+} from "../channels/plugins/setup-helpers.js";
 import type { SetupChannelsOptions } from "../channels/plugins/setup-wizard-types.js";
 import type { ChannelSetupInput } from "../channels/plugins/types.core.js";
 import type { ChannelPlugin } from "../channels/plugins/types.public.js";
@@ -12,7 +15,11 @@ import { resolveMergedAccountConfig } from "../config/channel-account-config.js"
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { PluginInstallRecord } from "../config/types.plugins.js";
 import type { PluginPackageChannelCliOption } from "../plugins/manifest.js";
+import { createPluginCache, withPluginCache } from "../plugins/plugin-cache.js";
+import * as pluginMetadata from "../plugins/plugin-metadata-snapshot.js";
+import { createPluginMetadataSnapshotFixture } from "../plugins/plugin-metadata.test-support.js";
 import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../plugins/runtime.js";
+import { resolveChannelAccountEntry } from "../routing/account-lookup.js";
 import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "../routing/session-key.js";
 import { createChannelTestPluginBase, createTestRegistry } from "../test-utils/channel-plugins.js";
 import { WizardSession } from "../wizard/session.js";
@@ -779,6 +786,75 @@ describe("channelsAddCommand", () => {
     expect(setupOptions()).not.toHaveProperty("initialSelection");
     expect(setupOptions()).not.toHaveProperty("finishAfterInitialSelection");
     expect(setupOptions().deferDeviceLinkToClient).toBe(true);
+  });
+
+  it("runChannelsSetupWizard renames the stored Signal account after hosted setup without creating a name-only account", async () => {
+    const config: OpenClawConfig = {
+      channels: {
+        signal: {
+          accounts: { "Work Phone": { account: "+12025550123", name: "Old name" } },
+        },
+      },
+    };
+    const plugin: ChannelPlugin = {
+      ...createChannelTestPluginBase({
+        id: "signal",
+        config: {
+          resolveAccount: (cfg, accountId) =>
+            resolveChannelAccountEntry(
+              cfg.channels?.signal?.accounts,
+              normalizeAccountId(accountId),
+              "signal",
+            ),
+        },
+      }),
+      setup: {
+        applyAccountName: (params) =>
+          applyAccountNameToChannelSection({ ...params, channelKey: "signal" }),
+        applyAccountConfig: ({ cfg }) => cfg,
+      },
+    };
+    const snapshot = createPluginMetadataSnapshotFixture({
+      plugins: [
+        {
+          id: "signal",
+          channels: ["signal"],
+          channelAccountKeyPolicies: {
+            signal: { canonicalAliasesRequireOwnField: "account" },
+          },
+        },
+      ],
+    });
+    const resolveMetadata = vi
+      .spyOn(pluginMetadata, "resolvePluginMetadataSnapshot")
+      .mockReturnValue(snapshot);
+    configMocks.readConfigFileSnapshot.mockResolvedValue(createTestConfigSnapshot(config));
+    channelWizardMocks.setupChannels.mockImplementationOnce(async (...args: unknown[]) => {
+      const options = args[3] as SetupChannelsOptions;
+      options.onSelection?.(["signal"]);
+      options.onAccountId?.("signal", "work-phone");
+      options.onResolvedPlugin?.("signal", plugin);
+      return config;
+    });
+    channelWizardMocks.prompter.confirm.mockResolvedValueOnce(true).mockResolvedValueOnce(false);
+    channelWizardMocks.prompter.text.mockResolvedValueOnce("Work calls");
+
+    try {
+      await using cache = createPluginCache();
+      await withPluginCache(cache, () =>
+        runChannelsSetupWizard({}, runtime, channelWizardMocks.prompter),
+      );
+
+      expect(channelWizardMocks.prompter.text).toHaveBeenCalledWith({
+        message: 'signal display name for account "work-phone"',
+        initialValue: "Old name",
+      });
+      expect(writtenChannel("signal")).toEqual({
+        accounts: { "Work Phone": { account: "+12025550123", name: "Work calls" } },
+      });
+    } finally {
+      resolveMetadata.mockRestore();
+    }
   });
 
   it.each(["authority", "write"] as const)(

--- a/src/commands/channels.add.test.ts
+++ b/src/commands/channels.add.test.ts
@@ -1938,8 +1938,12 @@ describe("channelsAddCommand", () => {
     bindPluginMetadataSnapshotCache(bootSnapshot, bootCache);
     const bootInstance = new PluginInstance("gateway-boot");
     bootCache.instances.add(bootInstance);
-    const readAccount = (cfg: OpenClawConfig, accountId = "work-phone") =>
-      resolveChannelAccountEntry(cfg.channels?.signal?.accounts, accountId, "signal");
+    const readAccount: ChannelPlugin["config"]["resolveAccount"] = (cfg, accountId) =>
+      resolveChannelAccountEntry(
+        cfg.channels?.signal?.accounts,
+        normalizeAccountId(accountId),
+        "signal",
+      );
     const bootPlugin = createChannelTestPluginBase({
       id: "signal",
       config: { resolveAccount: bootInstance.wrap(readAccount) },
@@ -1990,7 +1994,7 @@ describe("channelsAddCommand", () => {
       },
     });
     vi.mocked(ensureChannelSetupPluginInstalled).mockImplementationOnce(async ({ cfg }) => {
-      expect(readAccount(cfg)).toBeUndefined();
+      expect(readAccount(cfg, "work-phone")).toBeUndefined();
       await withPluginLifecycleLease({ env: fixture.env }, async () => {
         fixture.installPolicy();
         events.push("installed");

--- a/src/commands/channels.add.test.ts
+++ b/src/commands/channels.add.test.ts
@@ -1,6 +1,7 @@
 // Channels add tests cover guided setup, plugin install paths, and channel account config writes.
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { getBundledChannelSetupPlugin } from "../channels/plugins/bundled.js";
 import type { ChannelPluginCatalogEntry } from "../channels/plugins/catalog.js";
 import { defineChannelSetupContract } from "../channels/plugins/setup-contract.js";
@@ -14,11 +15,24 @@ import type { ChannelPlugin } from "../channels/plugins/types.public.js";
 import { resolveMergedAccountConfig } from "../config/channel-account-config.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { PluginInstallRecord } from "../config/types.plugins.js";
+import { withPluginMetadataSnapshotScope } from "../plugins/current-plugin-metadata-snapshot.js";
 import type { PluginPackageChannelCliOption } from "../plugins/manifest.js";
-import { createPluginCache, withPluginCache } from "../plugins/plugin-cache.js";
+import {
+  bindPluginMetadataSnapshotCache,
+  createPluginCache,
+  getPluginCache,
+  withPluginCache,
+} from "../plugins/plugin-cache.js";
+import { PluginInstance } from "../plugins/plugin-instance.js";
+import {
+  hasPluginLifecycleLease,
+  withPluginLifecycleLease,
+} from "../plugins/plugin-lifecycle-lease.js";
 import * as pluginMetadata from "../plugins/plugin-metadata-snapshot.js";
 import { createPluginMetadataSnapshotFixture } from "../plugins/plugin-metadata.test-support.js";
 import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../plugins/runtime.js";
+import { withPluginRuntimeGenerationScope } from "../plugins/runtime/generation-scope.js";
+import { createInstallAccountPolicyFixture } from "../plugins/test-helpers/install-account-policy.test-support.js";
 import { resolveChannelAccountEntry } from "../routing/account-lookup.js";
 import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "../routing/session-key.js";
 import { createChannelTestPluginBase, createTestRegistry } from "../test-utils/channel-plugins.js";
@@ -145,6 +159,7 @@ vi.mock("./onboard-channels.js", async () => {
 });
 
 const runtime = createTestRuntime();
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 function createSetupOptionCatalogEntry(
   id: string,
@@ -1398,6 +1413,60 @@ describe("channelsAddCommand", () => {
     expect(lifecycleMocks.onAccountConfigChanged).not.toHaveBeenCalled();
   });
 
+  it.each([undefined, "ignored"])(
+    "preserves the plugin-selected account and normalizes its config key with --account=%s",
+    async (account) => {
+      const cfg: OpenClawConfig = {};
+      const resolveAccountId = vi.fn(() => "Work");
+      const onAccountConfigChanged = vi.fn();
+      const applyAccountConfig = vi.fn(
+        ({ cfg: current, accountId, input }: ApplyAccountConfigParams) =>
+          patchScopedAccountConfig({
+            cfg: current,
+            channelKey: "preferred-chat",
+            accountId,
+            patch: { token: input.token },
+          }),
+      );
+      const plugin: ChannelPlugin = {
+        ...createChannelTestPluginBase({ id: "preferred-chat", label: "Preferred Chat" }),
+        setup: { resolveAccountId, applyAccountConfig },
+        lifecycle: { onAccountConfigChanged },
+      };
+      setActivePluginRegistry(
+        createTestRegistry([{ pluginId: "preferred-chat", plugin, source: "test" }]),
+      );
+      configMocks.readConfigFileSnapshot.mockResolvedValue(createTestConfigSnapshot(cfg));
+
+      await channelsAddCommand({ channel: "preferred-chat", account, token: "token-1" }, runtime, {
+        hasFlags: true,
+      });
+
+      expect(resolveAccountId).toHaveBeenCalledWith({
+        cfg,
+        accountId: account,
+        input: { token: "token-1" },
+      });
+      expect(applyAccountConfig).toHaveBeenCalledWith({
+        cfg,
+        accountId: "work",
+        input: { token: "token-1" },
+      });
+      expect(writtenChannel("preferred-chat")).toEqual({
+        enabled: true,
+        accounts: { work: { enabled: true, token: "token-1" } },
+      });
+      expect(onAccountConfigChanged).toHaveBeenCalledExactlyOnceWith({
+        prevCfg: cfg,
+        nextCfg: configFiles.read("/tmp/openclaw.json").snapshot.sourceConfig,
+        accountId: "Work",
+        runtime,
+      });
+      expect(runtime.log).toHaveBeenCalledWith('Added Preferred Chat account "Work".');
+      expect(runtime.error).not.toHaveBeenCalled();
+    },
+  );
+
   it.each([
     { account: "", label: "empty" },
     { account: "   ", label: "whitespace" },
@@ -1856,6 +1925,120 @@ describe("channelsAddCommand", () => {
       token: "test-token",
       workspace: "prepared-workspace",
     });
+  });
+
+  it("uses installed account policy through CLI persistence and post-write hooks while Gateway boot stays usable", async () => {
+    const fixture = createInstallAccountPolicyFixture(
+      tempDirs.make("cli-install-policy-"),
+      "signal",
+    );
+    const config = fixture.config;
+    await using bootCache = createPluginCache({ kind: "process" });
+    const bootSnapshot = fixture.readMetadata();
+    bindPluginMetadataSnapshotCache(bootSnapshot, bootCache);
+    const bootInstance = new PluginInstance("gateway-boot");
+    bootCache.instances.add(bootInstance);
+    const readAccount = (cfg: OpenClawConfig, accountId = "work-phone") =>
+      resolveChannelAccountEntry(cfg.channels?.signal?.accounts, accountId, "signal");
+    const bootPlugin = createChannelTestPluginBase({
+      id: "signal",
+      config: { resolveAccount: bootInstance.wrap(readAccount) },
+    });
+    const bootRegistry = createTestRegistry([
+      { pluginId: "signal", plugin: bootPlugin, source: "test" },
+    ]);
+    const readBoot = bootInstance.wrap(() => "Gateway available");
+    const resolveMetadata = vi
+      .spyOn(pluginMetadata, "resolvePluginMetadataSnapshot")
+      .mockImplementation((params) => fixture.readMetadata(params.config, params.workspaceDir));
+    configMocks.readConfigFileSnapshot.mockResolvedValue(createTestConfigSnapshot(config));
+    setActivePluginRegistry(createTestRegistry());
+    catalogMocks.listChannelPluginCatalogEntries.mockReturnValue([
+      {
+        ...createExternalChatCatalogEntry(),
+        id: "signal",
+        pluginId: "signal",
+        meta: { ...createExternalChatCatalogEntry().meta, id: "signal", label: "Signal" },
+      },
+    ]);
+    const events: string[] = [];
+    const setupInstance = new PluginInstance("signal-setup");
+    setupInstance.lifecycle.onDispose(() => {
+      events.push("disposed");
+    });
+    const afterAccountConfigWritten = vi.fn(
+      async ({ cfg, accountId }: Parameters<SignalAfterAccountConfigWritten>[0]) => {
+        expect(hasPluginLifecycleLease()).toBe(false);
+        expect(readAccount(cfg, accountId)).toEqual({
+          account: "+12025550123",
+          name: "Work calls",
+        });
+        events.push("post-write");
+      },
+    );
+    const setupPlugin = setupInstance.wrap<ChannelPlugin>({
+      ...createChannelTestPluginBase({ id: "signal", config: { resolveAccount: readAccount } }),
+      setup: {
+        applyAccountConfig: ({ cfg, accountId, input }) =>
+          applyAccountNameToChannelSection({
+            cfg,
+            accountId,
+            name: input.name,
+            channelKey: "signal",
+          }),
+        afterAccountConfigWritten,
+      },
+    });
+    vi.mocked(ensureChannelSetupPluginInstalled).mockImplementationOnce(async ({ cfg }) => {
+      expect(readAccount(cfg)).toBeUndefined();
+      await withPluginLifecycleLease({ env: fixture.env }, async () => {
+        fixture.installPolicy();
+        events.push("installed");
+      });
+      return { cfg, installed: true, status: "installed", pluginId: "signal" };
+    });
+    vi.mocked(loadChannelSetupPluginRegistrySnapshotForChannel).mockImplementationOnce(() => {
+      expect(hasPluginLifecycleLease()).toBe(false);
+      getPluginCache().instances.add(setupInstance);
+      expect(setupPlugin.config.resolveAccount(config, "work-phone")).toEqual({
+        account: "+12025550123",
+        name: "Old name",
+      });
+      return createTestRegistry([{ pluginId: "signal", plugin: setupPlugin, source: "test" }]);
+    });
+
+    try {
+      await using commandCache = createPluginCache();
+      await withPluginCache(commandCache, async () => {
+        const beforeInstall = fixture.readMetadata();
+        await withPluginMetadataSnapshotScope(
+          beforeInstall,
+          () =>
+            channelsAddCommand(
+              { channel: "signal", account: "work-phone", name: "Work calls" },
+              runtime,
+              { hasFlags: true },
+            ),
+          { config },
+        );
+        expect(events).toEqual(["installed", "post-write"]);
+        expect(afterAccountConfigWritten).toHaveBeenCalledOnce();
+      });
+      expect(writtenChannel("signal")).toEqual({
+        accounts: { "Work Phone": { account: "+12025550123", name: "Work calls" } },
+      });
+      expect(runtime.error).not.toHaveBeenCalled();
+      withPluginRuntimeGenerationScope(
+        { metadataSnapshot: bootSnapshot, pluginRegistry: bootRegistry },
+        () => {
+          expect(bootRegistry.channels).toHaveLength(1);
+          expect(bootPlugin.config.resolveAccount(config, "work-phone")).toBeUndefined();
+          expect(readBoot()).toBe("Gateway available");
+        },
+      );
+    } finally {
+      resolveMetadata.mockRestore();
+    }
   });
 
   it("loads external channel setup snapshots for newly installed and existing plugins", async () => {

--- a/src/commands/channels.remove.test.ts
+++ b/src/commands/channels.remove.test.ts
@@ -7,6 +7,8 @@ import {
 } from "../channels/plugins/config-helpers.js";
 import type { ChannelPlugin } from "../channels/plugins/types.plugin.js";
 import type { OpenClawConfig } from "../config/config.js";
+import { createPluginCache, withPluginCache } from "../plugins/plugin-cache.js";
+import { createPluginMetadataSnapshotFixture } from "../plugins/plugin-metadata.test-support.js";
 import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../plugins/runtime.js";
 import { createTestRegistry } from "../test-utils/channel-plugins.js";
 import {
@@ -578,22 +580,42 @@ describe("channelsRemoveCommand", () => {
         },
       },
     };
-    configMocks.readConfigFileSnapshot.mockResolvedValue(createTestConfigSnapshot(cfg));
+    const metadata = createPluginMetadataSnapshotFixture({
+      plugins: [
+        {
+          id: "external-chat",
+          channels: ["external-chat"],
+          channelAccountKeyPolicies: {
+            "external-chat": { canonicalAliasesRequireOwnField: "account" },
+          },
+        },
+      ],
+    });
+    configMocks.readConfigFileSnapshotForWrite.mockResolvedValueOnce({
+      snapshot: createTestConfigSnapshot(cfg),
+      writeOptions: {
+        basePluginMetadataSnapshot: {
+          ...metadata,
+          bundledManifestRegistry: metadata.manifestRegistry,
+        },
+      },
+    });
     plugin.config.deleteAccount = (params) =>
       deleteAccountFromConfigSection({
         ...params,
         sectionKey: "external-chat",
-        accountKeyPolicy: { canonicalAliasesRequireOwnField: "account" },
       });
     plugin.gateway = { startAccount: vi.fn() };
     const onAccountRemoved = vi.fn();
     plugin.lifecycle = { onAccountRemoved };
 
     await expect(
-      channelsRemoveCommand(
-        { channel: "external-chat", account: "work-phone", delete: true },
-        runtime,
-        { hasFlags: true },
+      withPluginCache(createPluginCache(), () =>
+        channelsRemoveCommand(
+          { channel: "external-chat", account: "work-phone", delete: true },
+          runtime,
+          { hasFlags: true },
+        ),
       ),
     ).rejects.toThrow('stored keys "work-phone" and "Work Phone"');
     expect(gatewayMocks.callGateway).not.toHaveBeenCalled();

--- a/src/commands/channels.remove.test.ts
+++ b/src/commands/channels.remove.test.ts
@@ -425,7 +425,7 @@ describe("channelsRemoveCommand", () => {
     expectNoRemoval('external-chat has no account "ghost" to remove.');
   });
 
-  it("stops an active gateway channel runtime before deleting a runtime-backed account", async () => {
+  it("channelsRemoveCommand validates deletion before stopping runtime and persisting it", async () => {
     const callOrder: string[] = [];
     configMocks.readConfigFileSnapshot.mockResolvedValue(
       createTestConfigSnapshot({
@@ -508,10 +508,10 @@ describe("channelsRemoveCommand", () => {
     });
     const writtenConfig = firstWrittenChannelsConfig();
     expect(writtenConfig?.channels?.["external-chat"]).toBeUndefined();
-    expect(callOrder).toEqual(["stop", "delete", "lifecycle", "persist", "output"]);
+    expect(callOrder).toEqual(["delete", "stop", "lifecycle", "persist", "output"]);
   });
 
-  it("stops a runtime-backed account before reporting an unsupported delete", async () => {
+  it("channelsRemoveCommand leaves runtime running when deletion is unsupported", async () => {
     const callOrder: string[] = [];
     configMocks.readConfigFileSnapshot.mockResolvedValue(
       createTestConfigSnapshot({
@@ -564,8 +564,45 @@ describe("channelsRemoveCommand", () => {
       { hasFlags: true },
     );
 
-    expect(callOrder).toEqual(["stop", "error"]);
+    expect(callOrder).toEqual(["error"]);
     expect(configMocks.writeConfigFile).not.toHaveBeenCalled();
     expect(runtime.exit).toHaveBeenCalledWith(1);
+  });
+
+  it("channelsRemoveCommand refuses a colliding delete before runtime, lifecycle, or config effects", async () => {
+    const plugin = installWorkAccountChannel();
+    const cfg = {
+      channels: {
+        "external-chat": {
+          accounts: { "Work Phone": { account: "shadow" }, "work-phone": { account: "selected" } },
+        },
+      },
+    };
+    configMocks.readConfigFileSnapshot.mockResolvedValue(createTestConfigSnapshot(cfg));
+    plugin.config.deleteAccount = (params) =>
+      deleteAccountFromConfigSection({
+        ...params,
+        sectionKey: "external-chat",
+        accountKeyPolicy: { canonicalAliasesRequireOwnField: "account" },
+      });
+    plugin.gateway = { startAccount: vi.fn() };
+    const onAccountRemoved = vi.fn();
+    plugin.lifecycle = { onAccountRemoved };
+
+    await expect(
+      channelsRemoveCommand(
+        { channel: "external-chat", account: "work-phone", delete: true },
+        runtime,
+        { hasFlags: true },
+      ),
+    ).rejects.toThrow('stored keys "work-phone" and "Work Phone"');
+    expect(gatewayMocks.callGateway).not.toHaveBeenCalled();
+    expect(onAccountRemoved).not.toHaveBeenCalled();
+    expect(configMocks.writeConfigFile).not.toHaveBeenCalled();
+    expect(runtime.log).not.toHaveBeenCalled();
+    expect(Object.keys(cfg.channels["external-chat"].accounts)).toEqual([
+      "Work Phone",
+      "work-phone",
+    ]);
   });
 });

--- a/src/commands/channels.remove.test.ts
+++ b/src/commands/channels.remove.test.ts
@@ -363,7 +363,11 @@ describe("channelsRemoveCommand", () => {
     { deleteConfig: true, label: "delete" },
     { deleteConfig: false, label: "disable" },
   ])("rejects an unknown --account before $label mutates config", async ({ deleteConfig }) => {
-    installWorkAccountChannel();
+    const plugin = installWorkAccountChannel();
+    const onAccountRemoved = vi.fn();
+    const onAccountConfigChanged = vi.fn();
+    plugin.lifecycle = { onAccountRemoved, onAccountConfigChanged };
+    plugin.gateway = { startAccount: vi.fn() };
 
     await channelsRemoveCommand(
       { channel: "external-chat", account: "ghost", delete: deleteConfig },
@@ -372,6 +376,63 @@ describe("channelsRemoveCommand", () => {
     );
 
     expectNoRemoval('external-chat has no account "ghost" to remove.');
+    expect(plugin.config.deleteAccount).not.toHaveBeenCalled();
+    expect(plugin.config.setAccountEnabled).not.toHaveBeenCalled();
+    expect(onAccountRemoved).not.toHaveBeenCalled();
+    expect(onAccountConfigChanged).not.toHaveBeenCalled();
+  });
+
+  it("disables a listed default without authored config and runs its lifecycle hook", async () => {
+    const plugin = installWorkAccountChannel();
+    plugin.config.listAccountIds = () => ["default", "work"];
+    const onAccountConfigChanged = vi.fn();
+    plugin.lifecycle = { onAccountConfigChanged };
+
+    await channelsRemoveCommand({ channel: "external-chat" }, runtime, { hasFlags: true });
+
+    expect(firstWrittenChannelsConfig()?.channels?.["external-chat"]).toEqual({
+      enabled: true,
+      accounts: {
+        work: { enabled: true, token: "token-1" },
+        default: { enabled: false },
+      },
+    });
+    expect(onAccountConfigChanged).toHaveBeenCalledExactlyOnceWith({
+      prevCfg: {
+        channels: {
+          "external-chat": {
+            enabled: true,
+            accounts: { work: { enabled: true, token: "token-1" } },
+          },
+        },
+      },
+      nextCfg: firstWrittenChannelsConfig(),
+      accountId: "default",
+      runtime,
+    });
+    expect(runtime.log).toHaveBeenCalledWith('Disabled external-chat account "default".');
+    expect(runtime.error).not.toHaveBeenCalled();
+  });
+
+  it("refuses a fresh no-op deletion result before runtime, lifecycle, or config effects", async () => {
+    const plugin = installWorkAccountChannel();
+    plugin.config.listAccountIds = () => ["default"];
+    plugin.config.deleteAccount = vi.fn(() => ({ channels: undefined }));
+    plugin.gateway = { startAccount: vi.fn() };
+    const onAccountRemoved = vi.fn();
+    plugin.lifecycle = { onAccountRemoved };
+    configMocks.readConfigFileSnapshot.mockResolvedValue(createTestConfigSnapshot({}));
+
+    await channelsRemoveCommand({ channel: "external-chat", delete: true }, runtime, {
+      hasFlags: true,
+    });
+
+    expect(plugin.config.deleteAccount).toHaveBeenCalledExactlyOnceWith({
+      cfg: {},
+      accountId: "default",
+    });
+    expectNoRemoval('external-chat account "default" has no configuration to delete.');
+    expect(onAccountRemoved).not.toHaveBeenCalled();
   });
 
   it("rejects an omitted --account when the channel has no default account", async () => {
@@ -427,48 +488,30 @@ describe("channelsRemoveCommand", () => {
     expectNoRemoval('external-chat has no account "ghost" to remove.');
   });
 
-  it("channelsRemoveCommand validates deletion before stopping runtime and persisting it", async () => {
+  it("normalizes a listed deletion before stopping runtime, running lifecycle, and persisting", async () => {
     const callOrder: string[] = [];
-    configMocks.readConfigFileSnapshot.mockResolvedValue(
-      createTestConfigSnapshot({
-        channels: {
-          "external-chat": {
-            enabled: true,
-            token: "token-1",
+    const cfg = {
+      channels: {
+        "external-chat": {
+          accounts: {
+            default: { token: "default-token" },
+            work: { token: "work-token" },
           },
         },
-      }),
-    );
-    const catalogEntry: ChannelPluginCatalogEntry = createExternalChatCatalogEntry();
-    catalogMocks.listChannelPluginCatalogEntries.mockReturnValue([catalogEntry]);
-    const deletePlugin = createExternalChatDeletePlugin();
-    const scopedPlugin = {
-      ...deletePlugin,
-      config: {
-        ...deletePlugin.config,
-        deleteAccount: vi.fn((params) => {
-          callOrder.push("delete");
-          return deletePlugin.config.deleteAccount!(params);
-        }),
       },
-      gateway: {
-        startAccount: vi.fn(),
-      },
-      lifecycle: {
-        onAccountRemoved: vi.fn(() => {
-          callOrder.push("lifecycle");
-        }),
-      },
-    } as ChannelPlugin;
-    vi.mocked(loadChannelSetupPluginRegistrySnapshotForChannel).mockReturnValue(
-      createTestRegistry([
-        {
-          pluginId: "@vendor/external-chat-plugin",
-          plugin: scopedPlugin,
-          source: "test",
-        },
-      ]),
-    );
+    };
+    const plugin = installWorkAccountChannel();
+    configMocks.readConfigFileSnapshot.mockResolvedValue(createTestConfigSnapshot(cfg));
+    plugin.config.listAccountIds = () => ["Default", "Work"];
+    plugin.config.deleteAccount = vi.fn((params) => {
+      callOrder.push("delete");
+      return deleteAccountFromConfigSection({ ...params, sectionKey: "external-chat" });
+    });
+    plugin.gateway = { startAccount: vi.fn() };
+    const onAccountRemoved = vi.fn(() => {
+      callOrder.push("lifecycle");
+    });
+    plugin.lifecycle = { onAccountRemoved };
     gatewayMocks.callGateway.mockImplementationOnce(async () => {
       callOrder.push("stop");
       return { stopped: true };
@@ -481,95 +524,60 @@ describe("channelsRemoveCommand", () => {
     });
 
     await channelsRemoveCommand(
-      {
-        channel: "external-chat",
-        account: "default",
-        delete: true,
-      },
+      { channel: "external-chat", account: "Work", delete: true },
       runtime,
       { hasFlags: true },
     );
 
+    expect(plugin.config.deleteAccount).toHaveBeenCalledExactlyOnceWith({ cfg, accountId: "work" });
     expect(gatewayMocks.callGateway).toHaveBeenCalledWith({
-      config: {
-        channels: {
-          "external-chat": {
-            enabled: true,
-            token: "token-1",
-          },
-        },
-      },
+      config: cfg,
       method: "channels.stop",
-      params: {
-        channel: "external-chat",
-        accountId: "default",
-      },
+      params: { channel: "external-chat", accountId: "work" },
       mode: "backend",
       clientName: "gateway-client",
       deviceIdentity: null,
     });
-    const writtenConfig = firstWrittenChannelsConfig();
-    expect(writtenConfig?.channels?.["external-chat"]).toBeUndefined();
-    expect(callOrder).toEqual(["delete", "stop", "lifecycle", "persist", "output"]);
-  });
-
-  it("channelsRemoveCommand leaves runtime running when deletion is unsupported", async () => {
-    const callOrder: string[] = [];
-    configMocks.readConfigFileSnapshot.mockResolvedValue(
-      createTestConfigSnapshot({
-        channels: {
-          "external-chat": {
-            enabled: true,
-            token: "token-1",
-          },
-        },
-      }),
-    );
-    catalogMocks.listChannelPluginCatalogEntries.mockReturnValue([
-      createExternalChatCatalogEntry(),
-    ]);
-    const deletePlugin = createExternalChatDeletePlugin();
-    const scopedPlugin = {
-      ...deletePlugin,
-      config: {
-        ...deletePlugin.config,
-        deleteAccount: undefined,
-      },
-      gateway: {
-        startAccount: vi.fn(),
-      },
-    } as ChannelPlugin;
-    vi.mocked(loadChannelSetupPluginRegistrySnapshotForChannel).mockReturnValue(
-      createTestRegistry([
-        {
-          pluginId: "@vendor/external-chat-plugin",
-          plugin: scopedPlugin,
-          source: "test",
-        },
-      ]),
-    );
-    gatewayMocks.callGateway.mockImplementationOnce(async () => {
-      callOrder.push("stop");
-      return { stopped: true };
-    });
-    runtime.error.mockImplementationOnce(() => {
-      callOrder.push("error");
-    });
-
-    await channelsRemoveCommand(
-      {
-        channel: "external-chat",
-        account: "default",
-        delete: true,
-      },
+    expect(onAccountRemoved).toHaveBeenCalledExactlyOnceWith({
+      prevCfg: cfg,
+      accountId: "work",
       runtime,
-      { hasFlags: true },
-    );
-
-    expect(callOrder).toEqual(["error"]);
-    expect(configMocks.writeConfigFile).not.toHaveBeenCalled();
-    expect(runtime.exit).toHaveBeenCalledWith(1);
+    });
+    expect(firstWrittenChannelsConfig()?.channels?.["external-chat"]).toEqual({
+      accounts: { default: { token: "default-token" } },
+    });
+    expect(callOrder).toEqual(["delete", "stop", "lifecycle", "persist", "output"]);
+    expect(runtime.log).toHaveBeenCalledWith('Deleted external-chat account "work".');
   });
+
+  it.each([
+    { deleteConfig: true, action: "delete" },
+    { deleteConfig: false, action: "disable" },
+  ])(
+    "leaves runtime and lifecycle untouched when $action is unsupported",
+    async ({ deleteConfig, action }) => {
+      const plugin = installWorkAccountChannel();
+      if (deleteConfig) {
+        delete plugin.config.deleteAccount;
+      } else {
+        delete plugin.config.setAccountEnabled;
+      }
+      plugin.gateway = { startAccount: vi.fn() };
+      const onAccountRemoved = vi.fn();
+      const onAccountConfigChanged = vi.fn();
+      plugin.lifecycle = { onAccountRemoved, onAccountConfigChanged };
+
+      await channelsRemoveCommand(
+        { channel: "external-chat", account: "work", delete: deleteConfig },
+        runtime,
+        { hasFlags: true },
+      );
+
+      expectNoRemoval(`Channel "external-chat" does not support ${action}.`);
+      expect(onAccountRemoved).not.toHaveBeenCalled();
+      expect(onAccountConfigChanged).not.toHaveBeenCalled();
+    },
+  );
 
   it("channelsRemoveCommand refuses a colliding delete before runtime, lifecycle, or config effects", async () => {
     const plugin = installWorkAccountChannel();

--- a/src/commands/channels/add-wizard.ts
+++ b/src/commands/channels/add-wizard.ts
@@ -21,6 +21,7 @@ import type { RuntimeEnv } from "../../runtime.js";
 import type { WizardPrompter } from "../../wizard/prompts.js";
 import { applyAgentBindings, describeBinding } from "../agents.bindings.js";
 import { resolveChannelSetupOwner } from "../channel-setup/owner.js";
+import { withCommandPluginMetadata } from "../config-validation.js";
 import type { ChannelChoice } from "../onboard-types.js";
 import { applyAccountName } from "./add-mutators.js";
 
@@ -201,28 +202,33 @@ export async function runChannelsAddWizardFlow(params: ChannelsAddWizardFlowPara
         initialValue: false,
       });
   if (wantsNames) {
-    for (const channel of selection) {
-      const accountId = accountIds[channel] ?? DEFAULT_ACCOUNT_ID;
-      const plugin = resolvedPlugins.get(channel) ?? getLoadedChannelPlugin(channel);
-      const account = plugin?.config.resolveAccount(nextConfig, accountId) as
-        | { name?: string }
-        | undefined;
-      const snapshot = plugin?.config.describeAccount?.(account, nextConfig);
-      const existingName = snapshot?.name ?? account?.name;
-      const name = await prompter.text({
-        message: `${channel} display name for account "${accountId}"`,
-        initialValue: existingName,
-      });
-      if (name?.trim()) {
-        nextConfig = applyAccountName({
-          cfg: nextConfig,
-          channel,
-          accountId,
-          name,
-          plugin,
-        });
-      }
-    }
+    await withCommandPluginMetadata(
+      { config: nextConfig, workspaceDir: params.workspaceDir },
+      async () => {
+        for (const channel of selection) {
+          const accountId = accountIds[channel] ?? DEFAULT_ACCOUNT_ID;
+          const plugin = resolvedPlugins.get(channel) ?? getLoadedChannelPlugin(channel);
+          const account = plugin?.config.resolveAccount(nextConfig, accountId) as
+            | { name?: string }
+            | undefined;
+          const snapshot = plugin?.config.describeAccount?.(account, nextConfig);
+          const existingName = snapshot?.name ?? account?.name;
+          const name = await prompter.text({
+            message: `${channel} display name for account "${accountId}"`,
+            initialValue: existingName,
+          });
+          if (name?.trim()) {
+            nextConfig = applyAccountName({
+              cfg: nextConfig,
+              channel,
+              accountId,
+              name,
+              plugin,
+            });
+          }
+        }
+      },
+    );
   }
 
   const bindTargets = selection

--- a/src/commands/channels/add.ts
+++ b/src/commands/channels/add.ts
@@ -26,6 +26,7 @@ import { createClackPrompter } from "../../wizard/clack-prompter.js";
 import { WizardCancelledError } from "../../wizard/prompts.js";
 import { normalizeExternalChannelSetupConfig } from "../channel-setup/config-compatibility.js";
 import { resolveChannelSetupOwner } from "../channel-setup/owner.js";
+import { withCommandPluginMetadata, type ConfigWriteSnapshot } from "../config-validation.js";
 import { parseAccountSelector } from "./account-selector.js";
 import { channelLabel } from "./runtime-label.js";
 import { requireValidConfigForWrite, shouldUseWizard } from "./shared.js";
@@ -137,6 +138,15 @@ async function channelsAddCommandImpl(
   if (!writeSnapshot) {
     return;
   }
+  return configureChannelAccount(writeSnapshot, opts, runtime, params);
+}
+
+async function configureChannelAccount(
+  writeSnapshot: ConfigWriteSnapshot,
+  opts: ChannelsAddOptions,
+  runtime: RuntimeEnv,
+  params?: { hasFlags?: boolean; beforePersistentEffect?: () => Promise<void> },
+) {
   const cfg = writeSnapshot.snapshot.sourceConfig;
   let nextConfig = cfg;
   let pluginRegistrySourceChanged = false;
@@ -260,90 +270,99 @@ async function channelsAddCommandImpl(
     return;
   }
 
-  const plugin = await loadScopedPlugin(channel, catalogEntry?.pluginId);
-  if (!plugin) {
-    runtime.error(
-      `${formatUnsupportedChannelActionMessage({
-        channel,
-        action: "non-interactive add",
-      })} Run ${formatCliCommand("openclaw channels add")} with no flags for guided setup.`,
-    );
-    runtime.exit(1);
-    return;
-  }
-  const prepared = await prepareChannelAccountConfiguration({
-    cfg: nextConfig,
-    plugin,
-    requestedAccountId: opts.account,
-    resolveInput: () =>
-      plugin.setupContract ? buildChannelOwnedSetupInput(opts) : buildChannelSetupInput(opts),
-    runtime,
-    ...(params?.beforePersistentEffect
-      ? { beforePersistentEffect: params.beforePersistentEffect }
-      : {}),
-  });
-  if (!prepared.ok) {
-    runtime.error(
-      prepared.error.kind === "unsupported"
-        ? `${formatUnsupportedChannelActionMessage({
-            channel,
+  const selectedChannel = channel;
+  return withCommandPluginMetadata(
+    { config: nextConfig, workspaceDir: resolveWorkspaceDir() },
+    async () => {
+      const plugin = await loadScopedPlugin(selectedChannel, catalogEntry?.pluginId);
+      if (!plugin) {
+        runtime.error(
+          `${formatUnsupportedChannelActionMessage({
+            channel: selectedChannel,
             action: "non-interactive add",
-          })} Run ${formatCliCommand("openclaw channels add")} with no flags for guided setup.`
-        : prepared.error.message,
-    );
-    runtime.exit(1);
-    return;
-  }
-  const applied = await applyPreparedChannelAccountConfiguration({
-    cfg: nextConfig,
-    channel,
-    prepared: prepared.value,
-    runtime,
-    ...(params?.beforePersistentEffect
-      ? { beforePersistentEffect: params.beforePersistentEffect }
-      : {}),
-  });
-  nextConfig = normalizeExternalChannelSetupConfig({ cfg: applied.nextConfig, channel });
+          })} Run ${formatCliCommand("openclaw channels add")} with no flags for guided setup.`,
+        );
+        runtime.exit(1);
+        return;
+      }
+      const prepared = await prepareChannelAccountConfiguration({
+        cfg: nextConfig,
+        plugin,
+        requestedAccountId: opts.account,
+        resolveInput: () =>
+          plugin.setupContract ? buildChannelOwnedSetupInput(opts) : buildChannelSetupInput(opts),
+        runtime,
+        ...(params?.beforePersistentEffect
+          ? { beforePersistentEffect: params.beforePersistentEffect }
+          : {}),
+      });
+      if (!prepared.ok) {
+        runtime.error(
+          prepared.error.kind === "unsupported"
+            ? `${formatUnsupportedChannelActionMessage({
+                channel: selectedChannel,
+                action: "non-interactive add",
+              })} Run ${formatCliCommand("openclaw channels add")} with no flags for guided setup.`
+            : prepared.error.message,
+        );
+        runtime.exit(1);
+        return;
+      }
+      const applied = await applyPreparedChannelAccountConfiguration({
+        cfg: nextConfig,
+        channel: selectedChannel,
+        prepared: prepared.value,
+        runtime,
+        ...(params?.beforePersistentEffect
+          ? { beforePersistentEffect: params.beforePersistentEffect }
+          : {}),
+      });
+      nextConfig = normalizeExternalChannelSetupConfig({
+        cfg: applied.nextConfig,
+        channel: selectedChannel,
+      });
 
-  await params?.beforePersistentEffect?.();
-  const committed = await commitConfigWithPendingPluginInstalls({
-    sourceConfig: nextConfig,
-    writeOptions: writeSnapshot.writeOptions,
-    baseHash: writeSnapshot.snapshot.hash,
-  });
-  if (committed.movedInstallRecords || pluginRegistrySourceChanged) {
-    await refreshPluginRegistryAfterConfigMutation({
-      reason: "source-changed",
-      ...(committed.movedInstallRecords ? { installRecords: committed.installRecords } : {}),
-      logger: { warn: (message) => runtime.log(message) },
-    });
-  }
-  runtime.log(
-    `Added ${plugin.meta.label ?? channelLabel(channel)} account "${applied.accountId}".`,
-  );
-  const afterAccountConfigWritten = applied.afterAccountConfigWritten;
-  if (afterAccountConfigWritten) {
-    const { runCollectedChannelOnboardingPostWriteHooks } = await loadOnboardChannels();
-    await runCollectedChannelOnboardingPostWriteHooks({
-      hooks: [
-        {
-          channel,
-          accountId: applied.accountId,
-          run: async ({ cfg: writtenCfg, runtime: hookRuntime }) =>
-            await afterAccountConfigWritten({
-              previousCfg: cfg,
-              cfg: writtenCfg,
+      await params?.beforePersistentEffect?.();
+      const committed = await commitConfigWithPendingPluginInstalls({
+        sourceConfig: nextConfig,
+        writeOptions: writeSnapshot.writeOptions,
+        baseHash: writeSnapshot.snapshot.hash,
+      });
+      if (committed.movedInstallRecords || pluginRegistrySourceChanged) {
+        await refreshPluginRegistryAfterConfigMutation({
+          reason: "source-changed",
+          ...(committed.movedInstallRecords ? { installRecords: committed.installRecords } : {}),
+          logger: { warn: (message) => runtime.log(message) },
+        });
+      }
+      runtime.log(
+        `Added ${plugin.meta.label ?? channelLabel(selectedChannel)} account "${applied.accountId}".`,
+      );
+      const afterAccountConfigWritten = applied.afterAccountConfigWritten;
+      if (afterAccountConfigWritten) {
+        const { runCollectedChannelOnboardingPostWriteHooks } = await loadOnboardChannels();
+        await runCollectedChannelOnboardingPostWriteHooks({
+          hooks: [
+            {
+              channel: selectedChannel,
               accountId: applied.accountId,
-              input: applied.input,
-              runtime: hookRuntime,
-            }),
-        },
-      ],
-      configPath: committed.path,
-      runtime,
-      ...(params?.beforePersistentEffect
-        ? { beforePersistentEffect: params.beforePersistentEffect }
-        : {}),
-    });
-  }
+              run: async ({ cfg: writtenCfg, runtime: hookRuntime }) =>
+                await afterAccountConfigWritten({
+                  previousCfg: cfg,
+                  cfg: writtenCfg,
+                  accountId: applied.accountId,
+                  input: applied.input,
+                  runtime: hookRuntime,
+                }),
+            },
+          ],
+          configPath: committed.path,
+          runtime,
+          ...(params?.beforePersistentEffect
+            ? { beforePersistentEffect: params.beforePersistentEffect }
+            : {}),
+        });
+      }
+    },
+  );
 }

--- a/src/commands/channels/remove.ts
+++ b/src/commands/channels/remove.ts
@@ -18,6 +18,7 @@ import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "../../routing/session-ke
 import { defaultRuntime, type RuntimeEnv } from "../../runtime.js";
 import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../../utils/message-channel.js";
 import { createClackPrompter } from "../../wizard/clack-prompter.js";
+import { withCommandPluginMetadata, type ConfigWriteSnapshot } from "../config-validation.js";
 import { parseAccountSelector } from "./account-selector.js";
 import { persistChannelPluginConfig } from "./plugin-config-persistence.js";
 import { channelLabel } from "./runtime-label.js";
@@ -102,6 +103,21 @@ export async function channelsRemoveCommand(
   if (!writeSnapshot) {
     return;
   }
+  return withCommandPluginMetadata(
+    {
+      config: writeSnapshot.snapshot.sourceConfig,
+      snapshot: writeSnapshot.writeOptions.basePluginMetadataSnapshot,
+    },
+    () => removeChannelAccount(writeSnapshot, opts, runtime, params),
+  );
+}
+
+async function removeChannelAccount(
+  writeSnapshot: ConfigWriteSnapshot,
+  opts: ChannelsRemoveOptions,
+  runtime: RuntimeEnv,
+  params?: { hasFlags?: boolean },
+) {
   const cfg: OpenClawConfig = writeSnapshot.snapshot.sourceConfig;
 
   const useWizard = shouldUseWizard(params);

--- a/src/commands/channels/remove.ts
+++ b/src/commands/channels/remove.ts
@@ -1,9 +1,8 @@
 // Implements guided and non-interactive disable/delete for channel accounts.
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import {
-  applyPreparedChannelAccountRemoval,
+  applyChannelAccountRemoval,
   type ChannelAccountMutationPlugin,
-  prepareChannelAccountRemoval,
 } from "../../channels/plugins/account-config-mutation.js";
 import { getChannelPlugin, normalizeChannelId } from "../../channels/plugins/index.js";
 import { listReadOnlyChannelPluginsForConfig } from "../../channels/plugins/read-only.js";
@@ -206,24 +205,20 @@ export async function channelsRemoveCommand(
     return;
   }
   const resolvedChannelId: ChatChannel = resolvedChannel;
-  const preparedRemoval = prepareChannelAccountRemoval({
+  const removal = await applyChannelAccountRemoval({
+    cfg,
     plugin,
     accountId,
     action: deleteConfig ? "delete" : "disable",
-  });
-
-  await stopGatewayRuntimeBeforeRemove({
-    cfg,
-    channel: resolvedChannelId,
-    accountId: preparedRemoval.accountKey,
-    shouldStopRuntime: preparedRemoval.shouldStopRuntime,
     runtime,
-  });
-
-  const removal = await applyPreparedChannelAccountRemoval({
-    cfg,
-    prepared: preparedRemoval,
-    runtime,
+    beforeRemoval: () =>
+      stopGatewayRuntimeBeforeRemove({
+        cfg,
+        channel: resolvedChannelId,
+        accountId,
+        shouldStopRuntime: Boolean(plugin.gateway?.startAccount || plugin.gateway?.logoutAccount),
+        runtime,
+      }),
   });
   if (!removal.ok) {
     if (removal.error.kind !== "unsupported-action") {
@@ -231,10 +226,8 @@ export async function channelsRemoveCommand(
         formatAccountRemovalErrorMessage({
           channel: resolvedChannelId,
           kind: removal.error.kind,
-          accountId: preparedRemoval.accountKey,
-          requestedAccount: useWizard
-            ? preparedRemoval.accountKey
-            : normalizeOptionalString(opts.account),
+          accountId,
+          requestedAccount: useWizard ? accountId : normalizeOptionalString(opts.account),
           accountIds: removal.error.accountIds,
         }),
       );
@@ -259,14 +252,14 @@ export async function channelsRemoveCommand(
   if (useWizard && prompter) {
     await prompter.outro(
       deleteConfig
-        ? `Deleted ${channelLabel(resolvedChannelId)} account "${preparedRemoval.accountKey}".`
-        : `Disabled ${channelLabel(resolvedChannelId)} account "${preparedRemoval.accountKey}".`,
+        ? `Deleted ${channelLabel(resolvedChannelId)} account "${accountId}".`
+        : `Disabled ${channelLabel(resolvedChannelId)} account "${accountId}".`,
     );
   } else {
     runtime.log(
       deleteConfig
-        ? `Deleted ${channelLabel(resolvedChannelId)} account "${preparedRemoval.accountKey}".`
-        : `Disabled ${channelLabel(resolvedChannelId)} account "${preparedRemoval.accountKey}".`,
+        ? `Deleted ${channelLabel(resolvedChannelId)} account "${accountId}".`
+        : `Disabled ${channelLabel(resolvedChannelId)} account "${accountId}".`,
     );
   }
 }

--- a/src/commands/config-validation.ts
+++ b/src/commands/config-validation.ts
@@ -57,7 +57,7 @@ export type ConfigWriteSnapshot = Awaited<ReturnType<typeof readConfigFileSnapsh
 export async function withCommandPluginMetadata<T>(
   params: { config: OpenClawConfig; workspaceDir?: string; snapshot?: PluginMetadataSnapshot },
   run: () => T,
-): Promise<T> {
+): Promise<Awaited<T>> {
   const [
     { completePluginMetadataSnapshot, resolvePluginMetadataSnapshot },
     { withPluginMetadataSnapshotScope },
@@ -66,7 +66,7 @@ export async function withCommandPluginMetadata<T>(
     import("../plugins/current-plugin-metadata-snapshot.js"),
   ]);
   const snapshot = completePluginMetadataSnapshot(params) ?? resolvePluginMetadataSnapshot(params);
-  return withPluginMetadataSnapshotScope(snapshot, run, {
+  return await withPluginMetadataSnapshotScope(snapshot, run, {
     config: params.config,
     workspaceDir: params.workspaceDir,
   });

--- a/src/commands/config-validation.ts
+++ b/src/commands/config-validation.ts
@@ -9,6 +9,7 @@ import {
 } from "../config/config.js";
 import { renderConfigValidationIssueLines } from "../config/issue-location.js";
 import { isPluginPackagingRuntimeOutputInvalidConfigSnapshot } from "../config/recovery-policy.js";
+import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.types.js";
 import {
   buildPluginCompatibilitySnapshotNotices,
   formatPluginCompatibilityNotice,
@@ -47,9 +48,28 @@ export async function requireValidConfigForWrite(runtime: RuntimeEnv) {
   if (!validateConfigFileSnapshot(read.snapshot, runtime)) {
     return null;
   }
-  const { adoptCommandConfigSnapshotMetadata } = await import("../cli/command-config-snapshot.js");
-  adoptCommandConfigSnapshotMetadata(read.snapshot, read.writeOptions.basePluginMetadataSnapshot);
   return read;
+}
+
+export type ConfigWriteSnapshot = Awaited<ReturnType<typeof readConfigFileSnapshotForWrite>>;
+
+/** Each command phase owns prepared facts; installation ends the preceding metadata scope. */
+export async function withCommandPluginMetadata<T>(
+  params: { config: OpenClawConfig; workspaceDir?: string; snapshot?: PluginMetadataSnapshot },
+  run: () => T,
+): Promise<T> {
+  const [
+    { completePluginMetadataSnapshot, resolvePluginMetadataSnapshot },
+    { withPluginMetadataSnapshotScope },
+  ] = await Promise.all([
+    import("../plugins/plugin-metadata-snapshot.js"),
+    import("../plugins/current-plugin-metadata-snapshot.js"),
+  ]);
+  const snapshot = completePluginMetadataSnapshot(params) ?? resolvePluginMetadataSnapshot(params);
+  return withPluginMetadataSnapshotScope(snapshot, run, {
+    config: params.config,
+    workspaceDir: params.workspaceDir,
+  });
 }
 
 function validateConfigFileSnapshot(

--- a/src/commands/config-validation.ts
+++ b/src/commands/config-validation.ts
@@ -44,7 +44,12 @@ export async function requireValidConfigFileSnapshot(
 /** Preserve native read-time ownership through commands that can write after awaits. */
 export async function requireValidConfigForWrite(runtime: RuntimeEnv) {
   const read = await readConfigFileSnapshotForWrite();
-  return validateConfigFileSnapshot(read.snapshot, runtime) ? read : null;
+  if (!validateConfigFileSnapshot(read.snapshot, runtime)) {
+    return null;
+  }
+  const { adoptCommandConfigSnapshotMetadata } = await import("../cli/command-config-snapshot.js");
+  adoptCommandConfigSnapshotMetadata(read.snapshot, read.writeOptions.basePluginMetadataSnapshot);
+  return read;
 }
 
 function validateConfigFileSnapshot(

--- a/src/commands/doctor-config-preflight.plugin-persistence.test.ts
+++ b/src/commands/doctor-config-preflight.plugin-persistence.test.ts
@@ -19,6 +19,7 @@ import {
   createPluginCache,
   getPluginCache,
   getPluginMetadataSnapshotCache,
+  runOutsidePluginCache,
   withPluginCache,
 } from "../plugins/plugin-cache.js";
 import { resolvePluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
@@ -128,12 +129,14 @@ describe("Doctor plugin persistence", () => {
   afterEach(() => closeOpenClawStateDatabaseForTest());
 
   it.each([
-    { scope: "process", replaceBeforeLease: false },
-    { scope: "operation", replaceBeforeLease: false },
-    { scope: "operation", replaceBeforeLease: true },
+    { scope: "process", replaceBeforeLease: false, independentWriter: false },
+    { scope: "operation", replaceBeforeLease: false, independentWriter: false },
+    { scope: "operation", replaceBeforeLease: true, independentWriter: false },
+    { scope: "operation", replaceBeforeLease: false, independentWriter: true },
+    { scope: "operation", replaceBeforeLease: true, independentWriter: true },
   ])(
-    "verifies a persisted registry in the $scope scope (replacement before lease: $replaceBeforeLease)",
-    async ({ scope, replaceBeforeLease }) => {
+    "verifies a persisted registry in the $scope scope (replacement before lease: $replaceBeforeLease, independent writer: $independentWriter)",
+    async ({ scope, replaceBeforeLease, independentWriter }) => {
       await withPreflightPluginFixture(async (writeVersion) => {
         const checkpointStatus = vi.spyOn(migrationCheckpoint, "readMigrationCheckpointStatus");
         onTestFinished(() => checkpointStatus.mockRestore());
@@ -150,38 +153,44 @@ describe("Doctor plugin persistence", () => {
             : undefined;
           let replaced = false;
           try {
-            const result = await runDoctorConfigPreflight({
-              migrateState: false,
-              migrateLegacyConfig: false,
-              requireStateMigrationCheckpoint: true,
-              preparePluginMetadataSnapshot: true,
-              observe: false,
-              measure: async (name, operation) => {
-                const measured = await operation();
-                if (
-                  name === "doctor.config-preflight.config-snapshot" &&
-                  siblingLease &&
-                  !replaced
-                ) {
-                  // Another owner commits after the initial read, before preflight acquires its lease.
-                  replaced = true;
-                  await writeVersion("2.0.0");
-                  await withPluginCache(createPluginCache(), async () => {
-                    const latest = await read();
-                    expect(latest.pluginMetadataSnapshot).toBeDefined();
-                    writePersistedInstalledPluginIndexWithLeaseSync(
-                      latest.pluginMetadataSnapshot!.index,
-                      {
-                        env: process.env,
-                        lease: siblingLease,
-                      },
-                    );
-                  });
-                  siblingLease.release();
-                }
-                return measured;
-              },
-            });
+            const preflight = () =>
+              runDoctorConfigPreflight({
+                migrateState: false,
+                migrateLegacyConfig: false,
+                requireStateMigrationCheckpoint: true,
+                preparePluginMetadataSnapshot: true,
+                observe: false,
+                measure: async (name, operation) => {
+                  const measured = await operation();
+                  if (
+                    name === "doctor.config-preflight.config-snapshot" &&
+                    siblingLease &&
+                    !replaced
+                  ) {
+                    // Commit after the initial read, before preflight acquires its lease.
+                    replaced = true;
+                    await writeVersion("2.0.0");
+                    const replace = () =>
+                      withPluginCache(createPluginCache(), async () => {
+                        const latest = await read();
+                        expect(latest.pluginMetadataSnapshot).toBeDefined();
+                        writePersistedInstalledPluginIndexWithLeaseSync(
+                          latest.pluginMetadataSnapshot!.index,
+                          {
+                            env: process.env,
+                            lease: siblingLease,
+                          },
+                        );
+                      });
+                    await (independentWriter ? runOutsidePluginCache(replace) : replace());
+                    siblingLease.release();
+                  }
+                  return measured;
+                },
+              });
+            const result = await (independentWriter
+              ? runOutsidePluginCache(() => withPluginCache(createPluginCache(), preflight))
+              : preflight());
             expect(result.pluginMetadataSnapshot?.registrySource).toBe("persisted");
             expect(
               result.pluginMetadataSnapshot?.manifestRegistry.plugins.find(
@@ -192,11 +201,11 @@ describe("Doctor plugin persistence", () => {
               expect(getPluginCache()).toBe(owner);
               const retained = (await read()).pluginMetadataSnapshot!;
               expect(getPluginMetadataSnapshotCache(retained)).toBe(owner);
-              expect(retained.registrySource).toBe("derived");
+              expect(retained.registrySource).toBe(independentWriter ? "derived" : "persisted");
               expect(
                 retained.manifestRegistry.plugins.find((p) => p.id === "preflight-fixture")
                   ?.version,
-              ).toBe("1.0.0");
+              ).toBe(!independentWriter && replaceBeforeLease ? "2.0.0" : "1.0.0");
             }
           } finally {
             siblingLease?.release();
@@ -326,14 +335,18 @@ describe("Doctor plugin persistence", () => {
             );
           });
           const preflight = () =>
-            runDoctorConfigPreflight({
-              migrateState: false,
-              migrateLegacyConfig: false,
-              requireStateMigrationCheckpoint: true,
-              preparePluginMetadataSnapshot: true,
-              observe: false,
-              invalidConfigNote: false,
-            });
+            runOutsidePluginCache(() =>
+              withPluginCache(createPluginCache(), () =>
+                runDoctorConfigPreflight({
+                  migrateState: false,
+                  migrateLegacyConfig: false,
+                  requireStateMigrationCheckpoint: true,
+                  preparePluginMetadataSnapshot: true,
+                  observe: false,
+                  invalidConfigNote: false,
+                }),
+              ),
+            );
           // The invoking generation remains old; the post-lease read must own the written leaf.
           await writeVersion("2.0.0");
           const result = await preflight().catch((error: unknown) => error);
@@ -377,10 +390,14 @@ describe("Doctor plugin persistence", () => {
           );
           const lease = migrationCheckpoint.acquireStartupMigrationLease();
           try {
-            writePersistedInstalledPluginIndexWithLeaseSync(leaf.index, {
-              env: process.env,
-              lease,
-            });
+            runOutsidePluginCache(() =>
+              withPluginCache(createPluginCache(), () =>
+                writePersistedInstalledPluginIndexWithLeaseSync(leaf.index, {
+                  env: process.env,
+                  lease,
+                }),
+              ),
+            );
           } finally {
             lease.release();
           }

--- a/src/commands/doctor-plugin-registry-generation-repair.test.ts
+++ b/src/commands/doctor-plugin-registry-generation-repair.test.ts
@@ -17,7 +17,11 @@ import {
   hasRetainedManagedNpmInstallMarker,
   resolveRetainedManagedNpmInstallPackageInfo,
 } from "../plugins/managed-npm-retention.js";
-import { createPluginCache, withPluginCache } from "../plugins/plugin-cache.js";
+import {
+  createPluginCache,
+  runOutsidePluginCache,
+  withPluginCache,
+} from "../plugins/plugin-cache.js";
 import { writeManagedNpmPlugin } from "../plugins/test-helpers/managed-npm-plugin.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import { maybeRepairStaleManagedNpmInstallGenerations } from "./doctor-plugin-generations.js";
@@ -68,41 +72,51 @@ afterEach(() => {
 });
 
 describe("doctor managed npm generation repair", () => {
-  it("does not restore records repaired in another metadata scope", async () => {
-    const stateDir = tempDirs.make("openclaw-doctor-plugin-scope-");
-    const env = {
-      ...process.env,
-      OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
-      OPENCLAW_STATE_DIR: stateDir,
-    };
-    await writePersistedInstalledPluginIndexInstallRecords(
-      {
-        stale: {
-          source: "path",
-          installPath: path.join(stateDir, "removed-plugin"),
-          sourcePath: path.join(stateDir, "removed-plugin"),
+  it.each([false, true])(
+    "does not restore repaired records (independent writer: %s)",
+    async (independentWriter) => {
+      const stateDir = tempDirs.make("openclaw-doctor-plugin-scope-");
+      const env = {
+        ...process.env,
+        OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+        OPENCLAW_STATE_DIR: stateDir,
+      };
+      await writePersistedInstalledPluginIndexInstallRecords(
+        {
+          stale: {
+            source: "path",
+            installPath: path.join(stateDir, "removed-plugin"),
+            sourcePath: path.join(stateDir, "removed-plugin"),
+          },
         },
-      },
-      { stateDir, candidates: [] },
-    );
-
-    await withPluginCache(createPluginCache(), async () => {
-      expect(await loadInstalledPluginIndexInstallRecords({ stateDir })).toHaveProperty("stale");
-      await withPluginCache(createPluginCache(), () =>
-        writePersistedInstalledPluginIndexInstallRecords({}, { stateDir, candidates: [] }),
+        { stateDir, candidates: [] },
       );
-      expect(readPersistedInstalledPluginIndexInstallRecords({ stateDir })).toHaveProperty("stale");
 
-      await maybeRepairPluginRegistryState({
-        config: {},
-        env,
-        prompter: { shouldRepair: true },
-        stateDir,
+      await withPluginCache(createPluginCache(), async () => {
+        expect(await loadInstalledPluginIndexInstallRecords({ stateDir })).toHaveProperty("stale");
+        const write = () =>
+          withPluginCache(createPluginCache(), () =>
+            writePersistedInstalledPluginIndexInstallRecords({}, { stateDir, candidates: [] }),
+          );
+        await (independentWriter ? runOutsidePluginCache(write) : write());
+        const retained = readPersistedInstalledPluginIndexInstallRecords({ stateDir });
+        if (independentWriter) {
+          expect(retained).toHaveProperty("stale");
+        } else {
+          expect(retained).toEqual({});
+        }
+
+        await maybeRepairPluginRegistryState({
+          config: {},
+          env,
+          prompter: { shouldRepair: true },
+          stateDir,
+        });
       });
-    });
 
-    expect(readPersistedInstalledPluginIndexInstallRecords({ stateDir })).toEqual({});
-  });
+      expect(readPersistedInstalledPluginIndexInstallRecords({ stateDir })).toEqual({});
+    },
+  );
 
   it("retires the stale flat install and prunes it after gateway shutdown", async () => {
     const stateDir = tempDirs.make("openclaw-doctor-plugin-generation-");

--- a/src/commands/onboard-quickstart-host.plugin-generation.test.ts
+++ b/src/commands/onboard-quickstart-host.plugin-generation.test.ts
@@ -9,100 +9,109 @@ import { createPluginCache, withPluginCache } from "../plugins/plugin-cache.js";
 import { withPluginLifecycleLease } from "../plugins/plugin-lifecycle-lease.js";
 import { clearPluginMetadataLifecycleCaches } from "../plugins/plugin-metadata-lifecycle.js";
 import { invalidatePluginRuntimeDiscoveryAfterConfigMutation } from "../plugins/registry-refresh.js";
+import { withPluginRuntimeGenerationScope } from "../plugins/runtime/generation-scope.js";
 import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import { runQuickstartForegroundGateway } from "./onboard-quickstart-host.js";
 
 afterEach(() => clearPluginMetadataLifecycleCaches());
 
-it("carries a plugin installed during onboarding into the first foreground Gateway inventory", async () => {
-  await withOpenClawTestState(
-    { label: "onboarding-plugin-generation", env: { OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1" } },
-    async (state) => {
-      const config: OpenClawConfig = {
-        gateway: { mode: "local", auth: { mode: "none" } },
-        agents: { defaults: { workspace: state.workspaceDir } },
-        plugins: { entries: { codex: { enabled: true } } },
-      };
-      await state.writeConfig(config);
-      // The CLI keeps this operation alive from provider selection through browser handoff.
-      await withPluginCache(createPluginCache(), async () => {
-        const readMetadata = () =>
-          resolveConfigWidePluginMetadataSnapshot({
-            config,
-            env: process.env,
-            allowCurrent: false,
-          });
-        expect(readMetadata().byPluginId.has("codex")).toBe(false);
-        const pluginRoot = state.statePath(
-          "npm",
-          "projects",
-          "codex-fixture",
-          "node_modules",
-          "@fixture",
-          "codex",
-        );
-        await fs.mkdir(pluginRoot, { recursive: true });
-        await fs.writeFile(
-          path.join(pluginRoot, "package.json"),
-          JSON.stringify({
-            name: "@fixture/codex",
-            version: "1.0.0",
-            openclaw: { extensions: ["./index.cjs"] },
-          }),
-        );
-        await fs.writeFile(
-          path.join(pluginRoot, "openclaw.plugin.json"),
-          JSON.stringify({
-            id: "codex",
-            activation: { onAgentHarnesses: ["codex"] },
-            configSchema: { type: "object", properties: {}, additionalProperties: false },
-          }),
-        );
-        await fs.writeFile(
-          path.join(pluginRoot, "index.cjs"),
-          'module.exports = { id: "codex", register() {} };\n',
-        );
-        // Package acquisition is synthetic; the install ledger and post-install invalidation are real.
-        await withPluginLifecycleLease({}, async () => {
-          await writePersistedInstalledPluginIndexInstallRecords(
-            {
-              codex: {
-                source: "npm",
-                spec: "@fixture/codex@1.0.0",
-                installPath: pluginRoot,
-                resolvedName: "@fixture/codex",
-                resolvedVersion: "1.0.0",
-              },
-            },
-            { config, env: process.env },
-          );
-          clearPluginMetadataLifecycleCaches();
-          await invalidatePluginRuntimeDiscoveryAfterConfigMutation({});
-        });
-        expect(withPluginCache(createPluginCache(), readMetadata).byPluginId.has("codex")).toBe(
-          true,
-        );
-        const inventories: boolean[] = [];
-        const readStartupConfig = async () => {
-          const read = await readConfigFileSnapshotWithPluginMetadata({ isolateEnv: true });
-          inventories.push(read.pluginMetadataSnapshot?.byPluginId.has("codex") ?? false);
-          return { config: read.snapshot.config };
+it.each([false, true])(
+  "carries an onboarding install into the first foreground Gateway inventory (pinned caller: %s)",
+  async (pinnedCaller) => {
+    await withOpenClawTestState(
+      { label: "onboarding-plugin-generation", env: { OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1" } },
+      async (state) => {
+        const config: OpenClawConfig = {
+          gateway: { mode: "local", auth: { mode: "none" } },
+          agents: { defaults: { workspace: state.workspaceDir } },
+          plugins: { entries: { codex: { enabled: true } } },
         };
-        await runQuickstartForegroundGateway(
-          { runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() } },
-          {
-            readConfigSnapshot: readStartupConfig,
-            runGateway: async () => {
-              await readStartupConfig();
-            },
-            waitForGateway: async () => ({ ok: false }),
-            runBrowserHandoff: async () => ({ handedOff: false, reason: "timeout" }),
-          },
-        );
-        expect(inventories).toEqual([true, true]);
-        // The handoff must not mutate an older generation still held by another owner.
-        expect(readMetadata().byPluginId.has("codex")).toBe(false);
-      });
-    },
-  );
-});
+        await state.writeConfig(config);
+        // The CLI keeps this operation alive from provider selection through browser handoff.
+        await withPluginCache(createPluginCache(), async () => {
+          const readMetadata = () =>
+            resolveConfigWidePluginMetadataSnapshot({
+              config,
+              env: process.env,
+              allowCurrent: false,
+            });
+          const initial = readMetadata();
+          expect(initial.byPluginId.has("codex")).toBe(false);
+          const installAndStart = async () => {
+            const pluginRoot = state.statePath(
+              "npm",
+              "projects",
+              "codex-fixture",
+              "node_modules",
+              "@fixture",
+              "codex",
+            );
+            await fs.mkdir(pluginRoot, { recursive: true });
+            await fs.writeFile(
+              path.join(pluginRoot, "package.json"),
+              JSON.stringify({
+                name: "@fixture/codex",
+                version: "1.0.0",
+                openclaw: { extensions: ["./index.cjs"] },
+              }),
+            );
+            await fs.writeFile(
+              path.join(pluginRoot, "openclaw.plugin.json"),
+              JSON.stringify({
+                id: "codex",
+                activation: { onAgentHarnesses: ["codex"] },
+                configSchema: { type: "object", properties: {}, additionalProperties: false },
+              }),
+            );
+            await fs.writeFile(
+              path.join(pluginRoot, "index.cjs"),
+              'module.exports = { id: "codex", register() {} };\n',
+            );
+            // Package acquisition is synthetic; the install ledger and post-install invalidation are real.
+            await withPluginLifecycleLease({}, async () => {
+              await writePersistedInstalledPluginIndexInstallRecords(
+                {
+                  codex: {
+                    source: "npm",
+                    spec: "@fixture/codex@1.0.0",
+                    installPath: pluginRoot,
+                    resolvedName: "@fixture/codex",
+                    resolvedVersion: "1.0.0",
+                  },
+                },
+                { config, env: process.env },
+              );
+              clearPluginMetadataLifecycleCaches();
+              await invalidatePluginRuntimeDiscoveryAfterConfigMutation({});
+            });
+            expect(withPluginCache(createPluginCache(), readMetadata).byPluginId.has("codex")).toBe(
+              true,
+            );
+            const inventories: boolean[] = [];
+            const readStartupConfig = async () => {
+              const read = await readConfigFileSnapshotWithPluginMetadata({ isolateEnv: true });
+              inventories.push(read.pluginMetadataSnapshot?.byPluginId.has("codex") ?? false);
+              return { config: read.snapshot.config };
+            };
+            await runQuickstartForegroundGateway(
+              { runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() } },
+              {
+                readConfigSnapshot: readStartupConfig,
+                runGateway: async () => {
+                  await readStartupConfig();
+                },
+                waitForGateway: async () => ({ ok: false }),
+                runBrowserHandoff: async () => ({ handedOff: false, reason: "timeout" }),
+              },
+            );
+            expect(inventories).toEqual([true, true]);
+            expect(readMetadata().byPluginId.has("codex")).toBe(!pinnedCaller);
+          };
+          await (pinnedCaller
+            ? withPluginRuntimeGenerationScope({ metadataSnapshot: initial }, installAndStart)
+            : installAndStart());
+        });
+      },
+    );
+  },
+);

--- a/src/flows/channel-setup.test.ts
+++ b/src/flows/channel-setup.test.ts
@@ -2,6 +2,8 @@
 import { expectDefined } from "@openclaw/normalization-core/expect";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { createPluginCache, getPluginCache, withPluginCache } from "../plugins/plugin-cache.js";
+import { PluginInstance } from "../plugins/plugin-instance.js";
 import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
 import { WizardCancelledError, WizardNavigationError } from "../wizard/prompts.js";
 import {
@@ -1567,7 +1569,7 @@ describe("setupChannels workspace shadow exclusion", () => {
   });
 
   it(
-    "reinstalls the external plugin via catalog when a stale channel config " +
+    "setupChannels reinstalls the external plugin via catalog when a stale channel config " +
       "declares an already-installed plugin whose runtime cannot be loaded",
     async () => {
       // Regression: users who uninstalled an externalized channel plugin
@@ -1578,7 +1580,7 @@ describe("setupChannels workspace shadow exclusion", () => {
       const configure = vi.fn(async ({ cfg }: { cfg: Record<string, unknown> }) => ({
         cfg: { ...cfg, channels: { "external-chat": { token: "secret" } } },
       }));
-      const externalChatPlugin = makeExternalChatSetupPlugin({ configure });
+
       const installedCatalogEntry = makeCatalogEntry("external-chat", "External Chat", {
         pluginId: "@vendor/external-chat-plugin",
         install: { npmSpec: "@vendor/external-chat-plugin" },
@@ -1594,8 +1596,14 @@ describe("setupChannels workspace shadow exclusion", () => {
       // resolve the plugin as expected.
       loadChannelSetupPluginRegistrySnapshotForChannel
         .mockReturnValueOnce(makePluginRegistry())
-        .mockReturnValue(
-          makePluginRegistry({
+        .mockImplementation(() => {
+          const instance = new PluginInstance("installed-channel");
+          getPluginCache().instances.add(instance);
+          const externalChatPlugin = makeExternalChatSetupPlugin({
+            configure,
+            configureInteractive: instance.wrap(configure),
+          });
+          return makePluginRegistry({
             channels: [
               {
                 pluginId: "@vendor/external-chat-plugin",
@@ -1603,8 +1611,8 @@ describe("setupChannels workspace shadow exclusion", () => {
                 plugin: externalChatPlugin,
               },
             ],
-          }),
-        );
+          });
+        });
       ensureChannelSetupPluginInstalled.mockResolvedValueOnce({
         cfg: {},
         installed: true,
@@ -1618,7 +1626,10 @@ describe("setupChannels workspace shadow exclusion", () => {
         .mockResolvedValueOnce("external-chat")
         .mockResolvedValueOnce("__done__");
 
-      await runChannelSetup({}, { note, select }, DEFERRED_CHANNEL_SETUP_OPTIONS);
+      await using cache = createPluginCache();
+      await withPluginCache(cache, () =>
+        runChannelSetup({}, { note, select }, DEFERRED_CHANNEL_SETUP_OPTIONS),
+      );
 
       expect(ensureChannelSetupPluginInstalled).toHaveBeenCalledTimes(1);
       expectExternalCatalogInstallCall();

--- a/src/flows/channel-setup.test.ts
+++ b/src/flows/channel-setup.test.ts
@@ -1,10 +1,20 @@
 // Channel setup tests cover setup flow prompts and config output.
 import { expectDefined } from "@openclaw/normalization-core/expect";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { applyAccountNameToChannelSection } from "../channels/plugins/setup-helpers.js";
+import type { ChannelOnboardingPostWriteHook } from "../channels/plugins/setup-wizard-types.js";
+import { createTestRuntime } from "../commands/test-runtime-config-helpers.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { withPluginMetadataSnapshotScope } from "../plugins/current-plugin-metadata-snapshot.js";
 import { createPluginCache, getPluginCache, withPluginCache } from "../plugins/plugin-cache.js";
 import { PluginInstance } from "../plugins/plugin-instance.js";
+import { hasPluginLifecycleLease } from "../plugins/plugin-lifecycle-lease.js";
+import * as pluginMetadata from "../plugins/plugin-metadata-snapshot.js";
 import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
+import { createInstallAccountPolicyFixture } from "../plugins/test-helpers/install-account-policy.test-support.js";
+import { resolveChannelAccountEntry } from "../routing/account-lookup.js";
 import { WizardCancelledError, WizardNavigationError } from "../wizard/prompts.js";
 import {
   makeCatalogEntry,
@@ -260,6 +270,7 @@ function runChannelSetup(
 }
 
 describe("setupChannels workspace shadow exclusion", () => {
+  const tempDirs = useAutoCleanupTempDirTracker(afterEach);
   beforeEach(() => {
     vi.clearAllMocks();
     resolveAgentWorkspaceDir.mockReturnValue("/tmp/openclaw-workspace");
@@ -1577,8 +1588,34 @@ describe("setupChannels workspace shadow exclusion", () => {
       // `channels.<id>` entry remained in their config got dead-ended with
       // "<channel> plugin not available" because the installed-catalog
       // branch did not fall back to the catalog install flow.
-      const configure = vi.fn(async ({ cfg }: { cfg: Record<string, unknown> }) => ({
-        cfg: { ...cfg, channels: { "external-chat": { token: "secret" } } },
+      const fixture = createInstallAccountPolicyFixture(
+        tempDirs.make("openclaw-wizard-install-policy-"),
+        "external-chat",
+      );
+      const cfg = fixture.config;
+      const beforeInstall = fixture.readMetadata();
+      const resolveMetadata = vi
+        .spyOn(pluginMetadata, "resolvePluginMetadataSnapshot")
+        .mockImplementation(({ config, workspaceDir }) =>
+          fixture.readMetadata(config, workspaceDir),
+        );
+      const readAccount = (config: OpenClawConfig) =>
+        resolveChannelAccountEntry(
+          asOptionalRecord(asOptionalRecord(config.channels?.["external-chat"])?.accounts),
+          "work-phone",
+          "external-chat",
+        );
+      const statusAccounts: unknown[] = [];
+      const postWriteAccounts: unknown[] = [];
+      const hooks: ChannelOnboardingPostWriteHook[] = [];
+      const configure = vi.fn(async ({ cfg: current }: { cfg: OpenClawConfig }) => ({
+        cfg: applyAccountNameToChannelSection({
+          cfg: current,
+          channelKey: "external-chat",
+          accountId: "work-phone",
+          name: "Work calls",
+        }),
+        accountId: "work-phone",
       }));
 
       const installedCatalogEntry = makeCatalogEntry("external-chat", "External Chat", {
@@ -1602,6 +1639,15 @@ describe("setupChannels workspace shadow exclusion", () => {
           const externalChatPlugin = makeExternalChatSetupPlugin({
             configure,
             configureInteractive: instance.wrap(configure),
+            getStatus: instance.wrap(async ({ cfg: current }) => {
+              const account = readAccount(current);
+              statusAccounts.push(account);
+              return { channel: "external-chat", configured: Boolean(account), statusLines: [] };
+            }),
+            afterConfigWritten: instance.wrap(({ cfg: current }) => {
+              expect(hasPluginLifecycleLease()).toBe(false);
+              postWriteAccounts.push(readAccount(current));
+            }),
           });
           return makePluginRegistry({
             channels: [
@@ -1613,11 +1659,15 @@ describe("setupChannels workspace shadow exclusion", () => {
             ],
           });
         });
-      ensureChannelSetupPluginInstalled.mockResolvedValueOnce({
-        cfg: {},
-        installed: true,
-        pluginId: "@vendor/external-chat-plugin",
-        status: "installed",
+      ensureChannelSetupPluginInstalled.mockImplementationOnce(async () => {
+        expect(hasPluginLifecycleLease()).toBe(true);
+        fixture.installPolicy();
+        return {
+          cfg,
+          installed: true,
+          pluginId: "@vendor/external-chat-plugin",
+          status: "installed",
+        };
       });
       isChannelConfigured.mockReturnValue(false);
       const note = vi.fn(async () => undefined);
@@ -1626,15 +1676,42 @@ describe("setupChannels workspace shadow exclusion", () => {
         .mockResolvedValueOnce("external-chat")
         .mockResolvedValueOnce("__done__");
 
-      await using cache = createPluginCache();
-      await withPluginCache(cache, () =>
-        runChannelSetup({}, { note, select }, DEFERRED_CHANNEL_SETUP_OPTIONS),
-      );
-
-      expect(ensureChannelSetupPluginInstalled).toHaveBeenCalledTimes(1);
-      expectExternalCatalogInstallCall();
-      expect(note).not.toHaveBeenCalledWith("external-chat plugin not available.", "Channel setup");
-      expect(configure).toHaveBeenCalledTimes(1);
+      try {
+        await using cache = createPluginCache();
+        await withPluginCache(cache, async () => {
+          const next = await withPluginMetadataSnapshotScope(beforeInstall, () => {
+            expect(readAccount(cfg)).toBeUndefined();
+            return runChannelSetup(
+              cfg,
+              { note, select },
+              {
+                ...DEFERRED_CHANNEL_SETUP_OPTIONS,
+                onPostWriteHook: (hook) => hooks.push(hook),
+              },
+            );
+          });
+          const account = { account: "+12025550123", name: "Work calls" };
+          expect(next.channels?.["external-chat"]).toEqual({ accounts: { "Work Phone": account } });
+          expect(statusAccounts.at(-1)).toEqual(account);
+          expect(hooks).toHaveLength(1);
+          await withPluginMetadataSnapshotScope(fixture.readMetadata(next), () =>
+            expectDefined(hooks[0], "collected setup hook").run({
+              cfg: next,
+              runtime: createTestRuntime(),
+            }),
+          );
+          expect(postWriteAccounts).toEqual([account]);
+        });
+        expect(ensureChannelSetupPluginInstalled).toHaveBeenCalledTimes(1);
+        expectExternalCatalogInstallCall();
+        expect(note).not.toHaveBeenCalledWith(
+          "external-chat plugin not available.",
+          "Channel setup",
+        );
+        expect(configure).toHaveBeenCalledTimes(1);
+      } finally {
+        resolveMetadata.mockRestore();
+      }
     },
   );
 

--- a/src/flows/channel-setup.ts
+++ b/src/flows/channel-setup.ts
@@ -35,6 +35,7 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { resolveBundledPluginSources } from "../plugins/bundled-sources.js";
 import { enablePluginWithCapabilityConsent } from "../plugins/enable.js";
+import { getPluginCache, withPluginCache } from "../plugins/plugin-cache.js";
 import { withPluginLifecycleLease } from "../plugins/plugin-lifecycle-lease.js";
 import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "../routing/session-key.js";
 import type { RuntimeEnv } from "../runtime.js";
@@ -234,6 +235,7 @@ export async function setupChannels(
     }
     return undefined;
   };
+  const setupCache = getPluginCache();
   const enableChannelPluginForSetup = async (channel: ChannelChoice) =>
     await withPluginLifecycleLease({}, async () => {
       const result = await enablePluginWithCapabilityConsent(next, channel, {
@@ -246,7 +248,7 @@ export async function setupChannels(
       next = result.config;
       if (result.enabled) {
         // Capture the reviewed runtime before another lifecycle operation replaces it.
-        await loadScopedChannelPlugin(channel);
+        await withPluginCache(setupCache, () => loadScopedChannelPlugin(channel));
       }
       return result;
     });
@@ -722,7 +724,9 @@ export async function setupChannels(
       const outcome = await runPluginInstallWithNavigation({ install, prompter, options });
       if (outcome.status !== "back" && outcome.value.installed) {
         next = outcome.value.cfg;
-        await loadScopedChannelPlugin(channel, outcome.value.pluginId ?? install.entry.pluginId);
+        await withPluginCache(setupCache, () =>
+          loadScopedChannelPlugin(channel, outcome.value.pluginId ?? install.entry.pluginId),
+        );
       }
       return outcome;
     });

--- a/src/flows/channel-setup.ts
+++ b/src/flows/channel-setup.ts
@@ -24,6 +24,7 @@ import {
   getTrustedChannelPluginCatalogEntry,
   listTrustedChannelPluginCatalogEntries,
 } from "../commands/channel-setup/trusted-catalog.js";
+import { withCommandPluginMetadata } from "../commands/config-validation.js";
 import { hasConfiguredCommandOwners } from "../commands/doctor-command-owner.js";
 import type { ChannelChoice } from "../commands/onboard-types.js";
 import { isChannelConfigured } from "../config/channel-configured.js";
@@ -96,30 +97,35 @@ export async function runCollectedChannelOnboardingPostWriteHooks(params: {
   }
   // Writer receipts bind the file even if config selection changes after commit.
   // Hooks execute against fresh runtime values; persisted config may contain env refs.
-  const { snapshot } = await createConfigIO({
+  const { snapshot, pluginMetadataSnapshot } = await createConfigIO({
     configPath: params.configPath,
     env: createManagedRuntimeEnvBase(),
     observe: false,
   }).readConfigFileSnapshotWithPluginMetadata({ allowCurrentPluginMetadata: false });
-  for (const hook of params.hooks) {
-    await params.beforePersistentEffect?.();
-    try {
-      if (!snapshot.exists || !snapshot.valid) {
-        const reason = snapshot.exists
-          ? formatConfigIssueSummary(snapshot.issues)
-          : "file not found";
-        throw new Error(
-          `Saved config is unavailable: ${reason}. Run openclaw doctor --fix, then retry setup.`,
-        );
+  await withCommandPluginMetadata(
+    { config: snapshot.runtimeConfig, snapshot: pluginMetadataSnapshot },
+    async () => {
+      for (const hook of params.hooks) {
+        await params.beforePersistentEffect?.();
+        try {
+          if (!snapshot.exists || !snapshot.valid) {
+            const reason = snapshot.exists
+              ? formatConfigIssueSummary(snapshot.issues)
+              : "file not found";
+            throw new Error(
+              `Saved config is unavailable: ${reason}. Run openclaw doctor --fix, then retry setup.`,
+            );
+          }
+          await hook.run({ cfg: snapshot.runtimeConfig, runtime: params.runtime });
+        } catch (err) {
+          const message = formatErrorMessage(err);
+          params.runtime.error(
+            `Channel ${hook.channel} post-setup warning for "${hook.accountId}": ${message}`,
+          );
+        }
       }
-      await hook.run({ cfg: snapshot.runtimeConfig, runtime: params.runtime });
-    } catch (err) {
-      const message = formatErrorMessage(err);
-      params.runtime.error(
-        `Channel ${hook.channel} post-setup warning for "${hook.accountId}": ${message}`,
-      );
-    }
-  }
+    },
+  );
 }
 
 export function createChannelOnboardingPostWriteHook(params: {
@@ -278,14 +284,16 @@ export async function setupChannels(
 
   const statusSummary = deferStatusUntilSelection
     ? { statusByChannel: new Map<ChannelChoice, ChannelSetupStatus>(), statusLines: [] }
-    : await collectChannelStatus({
-        cfg: next,
-        workspaceDir: resolveWorkspaceDir(),
-        options,
-        accountOverrides,
-        installedPlugins: listVisibleInstalledPlugins(),
-        resolveAdapter: getVisibleSetupFlowAdapter,
-      });
+    : await withCommandPluginMetadata({ config: next, workspaceDir: resolveWorkspaceDir() }, () =>
+        collectChannelStatus({
+          cfg: next,
+          workspaceDir: resolveWorkspaceDir(),
+          options,
+          accountOverrides,
+          installedPlugins: listVisibleInstalledPlugins(),
+          resolveAdapter: getVisibleSetupFlowAdapter,
+        }),
+      );
   const { statusByChannel, statusLines } = statusSummary;
   if (!options?.skipStatusNote && statusLines.length > 0) {
     await prompter.note(statusLines.join("\n"), t("wizard.channels.statusTitle"));
@@ -425,15 +433,29 @@ export async function setupChannels(
     return decorated;
   };
 
-  const refreshStatus = async (channel: ChannelChoice) => {
-    const adapter = getVisibleSetupFlowAdapter(channel);
-    if (!adapter) {
-      return undefined;
-    }
-    const status = await adapter.getStatus({ cfg: next, options, accountOverrides });
-    statusByChannel.set(channel, status);
-    return status;
-  };
+  const resolveSelectionContributions = () =>
+    withCommandPluginMetadata({ config: next, workspaceDir: resolveWorkspaceDir() }, () => {
+      const { entries, catalogById } = getChannelEntries();
+      return resolveChannelSetupSelectionContributions({
+        entries,
+        statusByChannel: buildStatusByChannelForSelection(catalogById),
+        resolveDisabledHint,
+      });
+    });
+
+  const refreshStatus = async (channel: ChannelChoice) =>
+    await withCommandPluginMetadata(
+      { config: next, workspaceDir: resolveWorkspaceDir() },
+      async () => {
+        const adapter = getVisibleSetupFlowAdapter(channel);
+        if (!adapter) {
+          return undefined;
+        }
+        const status = await adapter.getStatus({ cfg: next, options, accountOverrides });
+        statusByChannel.set(channel, status);
+        return status;
+      },
+    );
 
   const enableBundledPluginForSetup = async (channel: ChannelChoice): Promise<boolean> => {
     const disabledHint = resolveConfigDisabledHint(channel);
@@ -554,7 +576,10 @@ export async function setupChannels(
     await runNavigationScope({
       prompter,
       options,
-      runner,
+      runner: (scopedPrompter, scopedOptions) =>
+        withCommandPluginMetadata({ config: next, workspaceDir: resolveWorkspaceDir() }, () =>
+          runner(scopedPrompter, scopedOptions),
+        ),
       ...(onPersistentEffect ? { onPersistentEffect } : {}),
     });
 
@@ -954,7 +979,11 @@ export async function setupChannels(
         return returnToSelection();
       }
       const custom = outcome.value;
-      if (!(await applyCustomSetupResult(channel, custom))) {
+      const applied = await withCommandPluginMetadata(
+        { config: next, workspaceDir: resolveWorkspaceDir() },
+        () => applyCustomSetupResult(channel, custom),
+      );
+      if (!applied) {
         return "done";
       }
       return "done";
@@ -989,7 +1018,7 @@ export async function setupChannels(
     const skipValue = "__skip__" as const;
     const quickstartInitialValue = options?.initialSelection?.[0] ?? skipValue;
     while (true) {
-      const { entries, catalogById } = getChannelEntries();
+      const contributions = await resolveSelectionContributions();
       const choice = await prompter.select({
         message: t("wizard.channels.selectQuickstart"),
         options: [
@@ -1000,11 +1029,7 @@ export async function setupChannels(
               command: formatCliCommand("openclaw channels add"),
             }),
           },
-          ...resolveChannelSetupSelectionContributions({
-            entries,
-            statusByChannel: buildStatusByChannelForSelection(catalogById),
-            resolveDisabledHint,
-          }).map((contribution) => contribution.option),
+          ...contributions.map((contribution) => contribution.option),
         ],
         initialValue: quickstartInitialValue,
         searchable: true,
@@ -1020,15 +1045,11 @@ export async function setupChannels(
     const doneValue = "__done__" as const;
     const initialValue = options?.initialSelection?.[0] ?? quickstartDefault;
     while (true) {
-      const { entries, catalogById } = getChannelEntries();
+      const contributions = await resolveSelectionContributions();
       const choice = await prompter.select({
         message: t("wizard.channels.select"),
         options: [
-          ...resolveChannelSetupSelectionContributions({
-            entries,
-            statusByChannel: buildStatusByChannelForSelection(catalogById),
-            resolveDisabledHint,
-          }).map((contribution) => contribution.option),
+          ...contributions.map((contribution) => contribution.option),
           {
             value: doneValue,
             label: t("common.finished"),
@@ -1060,39 +1081,48 @@ export async function setupChannels(
   }
 
   if (!options?.skipDmPolicyPrompt) {
-    next = await maybeConfigureDmPolicies({
-      cfg: next,
-      selection,
-      prompter,
-      accountIdsByChannel,
-      resolveAdapter: getVisibleSetupFlowAdapter,
-    });
+    next = await withCommandPluginMetadata(
+      { config: next, workspaceDir: resolveWorkspaceDir() },
+      () =>
+        maybeConfigureDmPolicies({
+          cfg: next,
+          selection,
+          prompter,
+          accountIdsByChannel,
+          resolveAdapter: getVisibleSetupFlowAdapter,
+        }),
+    );
   }
 
   if (hasConfiguredCommandOwners(next)) {
     return next;
   }
   const ownerChannels: Array<{ id: ChannelChoice; label: string }> = [];
-  for (const id of selection) {
-    try {
-      if (
-        resolveConfigDisabledHint(id) ||
-        resolveAccountDisabledHint(id, accountIdsByChannel.get(id))
-      ) {
-        continue;
+  await withCommandPluginMetadata(
+    { config: next, workspaceDir: resolveWorkspaceDir() },
+    async () => {
+      for (const id of selection) {
+        try {
+          if (
+            resolveConfigDisabledHint(id) ||
+            resolveAccountDisabledHint(id, accountIdsByChannel.get(id))
+          ) {
+            continue;
+          }
+          // A later setup action can remove or disable an earlier selection.
+          const status = await refreshStatus(id);
+          if (status?.configured) {
+            ownerChannels.push({ id, label: getVisibleChannelPlugin(id)?.meta.label ?? id });
+          }
+        } catch (error) {
+          await prompter.note(
+            `Status unavailable (${sanitizeTerminalText(formatErrorMessage(error))}).\nRetry: ${formatCliCommand(`openclaw channels status --channel ${id}`)}`,
+            t("wizard.channels.statusTitle"),
+          );
+        }
       }
-      // A later setup action can remove or disable an earlier selection.
-      const status = await refreshStatus(id);
-      if (status?.configured) {
-        ownerChannels.push({ id, label: getVisibleChannelPlugin(id)?.meta.label ?? id });
-      }
-    } catch (error) {
-      await prompter.note(
-        `Status unavailable (${sanitizeTerminalText(formatErrorMessage(error))}).\nRetry: ${formatCliCommand(`openclaw channels status --channel ${id}`)}`,
-        t("wizard.channels.statusTitle"),
-      );
-    }
-  }
+    },
+  );
   return await maybeConfigureCommandOwner({ cfg: next, channels: ownerChannels, prompter });
 }
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -52,7 +52,11 @@ import {
 } from "../plugins/installed-plugin-index-records.js";
 import { PluginRuntimeApplicationError, getPluginRuntimeGeneration } from "../plugins/lifecycle.js";
 import { createPluginRecord } from "../plugins/loader-records.js";
-import { createPluginCache, withPluginCache } from "../plugins/plugin-cache.js";
+import {
+  createPluginCache,
+  runOutsidePluginCache,
+  withPluginCache,
+} from "../plugins/plugin-cache.js";
 import { capturePluginGenerationArtifact } from "../plugins/plugin-generation-artifact.js";
 import { PluginInstance } from "../plugins/plugin-instance.js";
 import { withPluginLifecycleLease } from "../plugins/plugin-lifecycle-lease.js";
@@ -6766,73 +6770,85 @@ describe("startGatewayConfigReloader", () => {
     },
   );
 
-  it("rejects changed durable install inputs despite a warmed caller cache", async () => {
-    const root = tempDirs.make("openclaw-reload-warm-ledger-");
-    const configPath = nodePath.join(root, "openclaw.json");
-    const config: OpenClawConfig = { plugins: { enabled: false } };
-    const snapshot = makeSnapshot({ config, sourceConfig: config, hash: "unchanged" });
-    const before = { notes: { source: "npm" as const, spec: "notes@1" } };
-    const after = { notes: { source: "npm" as const, spec: "notes@2" } };
-    const started = createDeferred();
-    const finishRuntime = createDeferred();
-    const watcher = createWatcherMock();
-    vi.spyOn(chokidar, "watch").mockReturnValue(watcher as unknown as never);
-    await withEnvAsync({ OPENCLAW_STATE_DIR: root, OPENCLAW_CONFIG_PATH: configPath }, async () => {
-      await writePersistedInstalledPluginIndexInstallRecords(before, { config });
-      await withPluginCache(createPluginCache(), async () => {
-        expect(loadInstalledPluginIndexInstallRecordsSync()).toEqual(before);
-        const accepted = vi.fn();
-        const reloader = startGatewayConfigReloader({
-          initialConfig: config,
-          initialSnapshotRawHash: snapshot.hash!,
-          initialAuthoredConfig: config,
-          initialSnapshotValid: true,
-          initialSnapshotIssues: [],
-          watchPath: configPath,
-          readSnapshot: async () => snapshot,
-          onConfigAccepted: accepted,
-          onNoopConfigCommit: async () => {},
-          onRestart: async () => {},
-          onHotReload: async (plan) => {
-            started.resolve();
-            await finishRuntime.promise;
-            return {
-              status: "applied",
-              runtime: {
-                operationId: plan.pluginLifecycle!.operationId!,
-                generation: 2,
-                pluginIds: ["notes"],
+  it.each([false, true])(
+    "rejects changed durable install inputs despite a warmed caller cache (independent writer: %s)",
+    async (independentWriter) => {
+      const root = tempDirs.make("openclaw-reload-warm-ledger-");
+      const configPath = nodePath.join(root, "openclaw.json");
+      const config: OpenClawConfig = { plugins: { enabled: false } };
+      const snapshot = makeSnapshot({ config, sourceConfig: config, hash: "unchanged" });
+      const before = { notes: { source: "npm" as const, spec: "notes@1" } };
+      const after = { notes: { source: "npm" as const, spec: "notes@2" } };
+      const started = createDeferred();
+      const finishRuntime = createDeferred();
+      const watcher = createWatcherMock();
+      vi.spyOn(chokidar, "watch").mockReturnValue(watcher as unknown as never);
+      await withEnvAsync(
+        { OPENCLAW_STATE_DIR: root, OPENCLAW_CONFIG_PATH: configPath },
+        async () => {
+          await writePersistedInstalledPluginIndexInstallRecords(before, { config });
+          await withPluginCache(createPluginCache(), async () => {
+            expect(loadInstalledPluginIndexInstallRecordsSync()).toEqual(before);
+            const accepted = vi.fn();
+            const reloader = startGatewayConfigReloader({
+              initialConfig: config,
+              initialSnapshotRawHash: snapshot.hash!,
+              initialAuthoredConfig: config,
+              initialSnapshotValid: true,
+              initialSnapshotIssues: [],
+              watchPath: configPath,
+              readSnapshot: async () => snapshot,
+              onConfigAccepted: accepted,
+              onNoopConfigCommit: async () => {},
+              onRestart: async () => {},
+              onHotReload: async (plan) => {
+                started.resolve();
+                await finishRuntime.promise;
+                return {
+                  status: "applied",
+                  runtime: {
+                    operationId: plan.pluginLifecycle!.operationId!,
+                    generation: 2,
+                    pluginIds: ["notes"],
+                  },
+                };
               },
-            };
-          },
-          log: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
-        });
-        await reloader.ready;
-        const outcome = reloader
-          .applyPluginLifecycleChange({ config, pluginIds: ["notes"], reason: "reload" })
-          .then(
-            (value) => ({ value }),
-            (error: unknown) => ({ error }),
-          );
-        try {
-          await started.promise;
-          await withPluginCache(createPluginCache(), () =>
-            writePersistedInstalledPluginIndexInstallRecords(after, { config }),
-          );
-          // This caller's old generation intentionally stays frozen after another owner writes.
-          expect(loadInstalledPluginIndexInstallRecordsSync()).toEqual(before);
-          watcher.emit("change", configPath);
-          finishRuntime.resolve();
-          expect(await outcome).toHaveProperty("error", expect.any(PluginRuntimeApplicationError));
-          expect(accepted).not.toHaveBeenCalled();
-        } finally {
-          finishRuntime.resolve();
-          await outcome;
-          await reloader.stop();
-        }
-      });
-    });
-  });
+              log: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+            });
+            await reloader.ready;
+            const outcome = reloader
+              .applyPluginLifecycleChange({ config, pluginIds: ["notes"], reason: "reload" })
+              .then(
+                (value) => ({ value }),
+                (error: unknown) => ({ error }),
+              );
+            try {
+              await started.promise;
+              const write = () =>
+                withPluginCache(createPluginCache(), () =>
+                  writePersistedInstalledPluginIndexInstallRecords(after, { config }),
+                );
+              await (independentWriter ? runOutsidePluginCache(write) : write());
+              expect(loadInstalledPluginIndexInstallRecordsSync()).toEqual(
+                independentWriter ? before : after,
+              );
+              watcher.emit("change", configPath);
+              finishRuntime.resolve();
+              expect(await outcome).toHaveProperty(
+                "error",
+                expect.any(PluginRuntimeApplicationError),
+              );
+              expect(accepted).not.toHaveBeenCalled();
+            } finally {
+              finishRuntime.resolve();
+              await outcome;
+              await reloader.stop();
+            }
+          });
+        },
+      );
+    },
+  );
 
   it.each(["matched", "manual", "source changed"] as const)(
     "preserves the completed watcher receipt only for an exact install handoff (%s)",

--- a/src/gateway/server-methods/wizard.test.ts
+++ b/src/gateway/server-methods/wizard.test.ts
@@ -60,21 +60,24 @@ import {
   whenAdmittedWizardSessionSettled,
 } from "./setup-admission.js";
 import { systemAgentHandlers } from "./system-agent.js";
-import type { GatewayRequestHandlerOptions } from "./types.js";
+import type { GatewayRequestContext, GatewayRequestHandlerOptions } from "./types.js";
 import { type SetupWizardRunner, wizardHandlers } from "./wizard.js";
 
 afterEach(() => {
   __setFsSafeTestHooksForTest(undefined);
 });
 
-function createWizardContext(
-  wizardRunner: NonNullable<GatewayRequestHandlerOptions["context"]>["wizardRunner"],
-) {
-  const wizardSessions = new Map();
+type WizardTestContext = Pick<
+  GatewayRequestContext,
+  "wizardSessions" | "wizardRunner" | "findRunningWizard" | "purgeWizardSession"
+>;
+
+function createWizardContext(wizardRunner: WizardTestContext["wizardRunner"]): WizardTestContext {
+  const wizardSessions: WizardTestContext["wizardSessions"] = new Map();
   return {
     wizardSessions,
     wizardRunner,
-    findRunningWizard: () => undefined,
+    findRunningWizard: () => null,
     purgeWizardSession: (sessionId: string) => wizardSessions.delete(sessionId),
   };
 }
@@ -90,7 +93,7 @@ function readSuccessfulResponse(respond: ReturnType<typeof vi.fn>): Record<strin
 async function invokeWizard(
   method: "wizard.start" | "wizard.next",
   params: Record<string, unknown>,
-  context: ReturnType<typeof createWizardContext>,
+  context: WizardTestContext,
 ): Promise<Record<string, unknown>> {
   const respond = vi.fn();
   const handler = expectDefined(wizardHandlers[method], `wizardHandlers[${method}] test invariant`);

--- a/src/gateway/server-methods/wizard.test.ts
+++ b/src/gateway/server-methods/wizard.test.ts
@@ -4,6 +4,20 @@ import { __setFsSafeTestHooksForTest } from "@openclaw/fs-safe/test-hooks";
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../../test/helpers/promise.js";
+import { getCurrentPluginMetadataSnapshot } from "../../plugins/current-plugin-metadata-snapshot.js";
+import {
+  bindPluginMetadataSnapshotCache,
+  createPluginCache,
+  getPluginCache,
+  type PluginCache,
+} from "../../plugins/plugin-cache.js";
+import { PluginInstance } from "../../plugins/plugin-instance.js";
+import { createPluginMetadataSnapshotFixture } from "../../plugins/plugin-metadata.test-support.js";
+import { createEmptyPluginRegistry } from "../../plugins/registry-empty.js";
+import {
+  getPluginRuntimeGenerationRegistry,
+  withPluginRuntimeGenerationScope,
+} from "../../plugins/runtime/generation-scope.js";
 import {
   getActiveGatewayRootWorkCount,
   resetGatewayWorkAdmission,
@@ -124,6 +138,96 @@ describe("wizard session lookup", () => {
 });
 
 describe("hosted wizard runtime isolation", () => {
+  it.each([
+    { flow: "setup", cancel: false },
+    { flow: "channels", cancel: false },
+    { flow: "channels", cancel: true },
+  ] as const)(
+    "wizard.start keeps $flow plugin resources separate from Gateway boot until the runner settles (cancel=$cancel)",
+    async ({ flow, cancel }) => {
+      await using bootCache = createPluginCache({ kind: "process" });
+      const metadataSnapshot = createPluginMetadataSnapshotFixture();
+      bindPluginMetadataSnapshotCache(metadataSnapshot, bootCache);
+      const pluginRegistry = createEmptyPluginRegistry();
+      const bootInstance = new PluginInstance("gateway-boot");
+      bootCache.instances.add(bootInstance);
+      const readBoot = bootInstance.wrap(() => "gateway available");
+      const wizardInstance = new PluginInstance("hosted-wizard");
+      const events: string[] = [];
+      wizardInstance.lifecycle.onDispose(() => {
+        events.push("wizard disposed");
+      });
+      const readWizard = wizardInstance.wrap(() => "post-write complete");
+      const finishPostWrite = createDeferred();
+      const observed = createDeferred<{
+        cache: PluginCache;
+        metadata: ReturnType<typeof getCurrentPluginMetadataSnapshot>;
+        registry: ReturnType<typeof getPluginRuntimeGenerationRegistry>;
+      }>();
+      const tracker = createWizardSessionTracker();
+      const runner = async (_opts: unknown, _runtime: RuntimeEnv, prompter: WizardPrompter) => {
+        const cache = getPluginCache();
+        cache.instances.add(wizardInstance);
+        observed.resolve({
+          cache,
+          metadata: getCurrentPluginMetadataSnapshot(),
+          registry: getPluginRuntimeGenerationRegistry(),
+        });
+        prompter.progress("Finishing channel setup");
+        await finishPostWrite.promise;
+        events.push(readWizard());
+      };
+      const context = { ...tracker, wizardRunner: runner, channelWizardRunner: runner };
+
+      try {
+        const start = await withPluginRuntimeGenerationScope(
+          { metadataSnapshot, pluginRegistry },
+          async () => {
+            const result = await invokeWizard(
+              "wizard.start",
+              flow === "channels" ? { flow } : { mode: "local" },
+              context,
+            );
+            expect(getPluginCache()).toBe(bootCache);
+            expect(getCurrentPluginMetadataSnapshot()).toBe(metadataSnapshot);
+            expect(getPluginRuntimeGenerationRegistry()).toBe(pluginRegistry);
+            return result;
+          },
+        );
+        expect(start).toMatchObject({ status: "running", done: false });
+        const session = expectDefined(
+          tracker.wizardSessions.get(String(start.sessionId)),
+          "hosted wizard session",
+        );
+        const scope = await observed.promise;
+        expect(scope.cache).not.toBe(bootCache);
+        expect(scope.metadata).toBeUndefined();
+        expect(scope.registry).toBeUndefined();
+
+        if (cancel) {
+          const respond = vi.fn();
+          await expectDefined(
+            wizardHandlers["wizard.cancel"],
+            "wizard.cancel test invariant",
+          )({ params: { sessionId: start.sessionId }, respond, context } as never);
+          expect(readSuccessfulResponse(respond)).toMatchObject({ status: "cancelled" });
+        }
+
+        expect(events).toEqual([]);
+        expect(readWizard()).toBe("post-write complete");
+        finishPostWrite.resolve();
+        await whenAdmittedWizardSessionSettled(session);
+        expect(events).toEqual(["post-write complete", "wizard disposed"]);
+        expect(() => readWizard()).toThrow("reloaded or disabled");
+        expect(readBoot()).toBe("gateway available");
+      } finally {
+        finishPostWrite.resolve();
+        await cancelWizardSessions(tracker.wizardSessions);
+        await wizardInstance.dispose();
+      }
+    },
+  );
+
   it.each([
     { flow: "setup", exitCode: 0, status: "done" },
     { flow: "setup", exitCode: 23, status: "error" },

--- a/src/gateway/server-methods/wizard.ts
+++ b/src/gateway/server-methods/wizard.ts
@@ -12,6 +12,8 @@ import {
   validateWizardStatusParams,
 } from "../../../packages/gateway-protocol/src/index.js";
 import type { OnboardOptions } from "../../commands/onboard-types.js";
+import { createPluginCache, withPluginCache } from "../../plugins/plugin-cache.js";
+import { runOutsidePluginRuntimeGenerationScope } from "../../plugins/runtime/generation-scope.js";
 import { createNonExitingRuntime, ExitError, type RuntimeEnv } from "../../runtime.js";
 import type { WizardPrompter } from "../../wizard/prompts.js";
 import {
@@ -57,8 +59,11 @@ export const runDefaultChannelSetupWizard: ChannelSetupWizardRunner = async (...
 };
 
 async function runHostedWizard(run: (runtime: RuntimeEnv) => Promise<void>): Promise<void> {
+  await using cache = createPluginCache();
   try {
-    await run(createNonExitingRuntime());
+    await runOutsidePluginRuntimeGenerationScope(() =>
+      withPluginCache(cache, () => run(createNonExitingRuntime())),
+    );
   } catch (error) {
     // Hosted wizards share the Gateway process; a successful CLI-style exit
     // must complete only its session, while failures remain session errors.

--- a/src/plugin-sdk/account-resolution.ts
+++ b/src/plugin-sdk/account-resolution.ts
@@ -16,5 +16,9 @@ export {
 } from "./account-core.js";
 
 export type { OpenClawConfig } from "../config/types.openclaw.js";
-export { resolveAccountEntry, resolveAccountKey } from "../routing/account-lookup.js";
+export {
+  resolveAccountEntry,
+  resolveAccountKey,
+  resolveChannelAccountKey,
+} from "../routing/account-lookup.js";
 export type { ChannelAccountKeyPolicy } from "../routing/account-lookup.js";

--- a/src/plugin-sdk/account-resolution.ts
+++ b/src/plugin-sdk/account-resolution.ts
@@ -16,9 +16,5 @@ export {
 } from "./account-core.js";
 
 export type { OpenClawConfig } from "../config/types.openclaw.js";
-export {
-  resolveAccountEntry,
-  resolveAccountKey,
-  resolveChannelAccountKey,
-} from "../routing/account-lookup.js";
+export { resolveAccountEntry, resolveAccountKey } from "../routing/account-lookup.js";
 export type { ChannelAccountKeyPolicy } from "../routing/account-lookup.js";

--- a/src/plugins/current-plugin-metadata-snapshot.test.ts
+++ b/src/plugins/current-plugin-metadata-snapshot.test.ts
@@ -23,8 +23,12 @@ import { withPluginInstallRoots } from "./install-root-context.js";
 import * as installedPluginIndexPolicy from "./installed-plugin-index-policy.js";
 import { writePersistedInstalledPluginIndexSync } from "./installed-plugin-index-store-write.js";
 import type { PluginManifestRecord } from "./manifest-registry.js";
+import { bindPluginMetadataSnapshotCache, createPluginCache } from "./plugin-cache.js";
 import * as pluginControlPlaneContext from "./plugin-control-plane-context.js";
-import { clearPluginMetadataLifecycleCaches } from "./plugin-metadata-lifecycle.js";
+import {
+  clearPluginMetadataLifecycleCaches,
+  retainGatewayPluginMetadata,
+} from "./plugin-metadata-lifecycle.js";
 import {
   restorePluginMetadataSnapshot,
   type PluginMetadataSnapshot,
@@ -821,6 +825,53 @@ describe("current plugin metadata snapshot", () => {
     clearPluginMetadataLifecycleCaches();
 
     expect(getCurrentPluginMetadataSnapshot({ config })).toBeUndefined();
+  });
+
+  it.each([false, true])(
+    "clearPluginMetadataLifecycleCaches revokes nested operation scopes across awaits (Gateway active: %s)",
+    async (gatewayActive) => {
+      const boot = createSnapshot();
+      const owner = gatewayActive ? retainGatewayPluginMetadata() : undefined;
+      if (owner) {
+        owner.publish(boot);
+        setGatewayPluginMetadataSnapshot(boot);
+      }
+      try {
+        await using outer = createPluginCache();
+        await using inner = createPluginCache();
+        const before = createSnapshot({ normalizationAlias: "before-install" });
+        const nested = createSnapshot({ normalizationAlias: "nested-before-install" });
+        const after = createSnapshot({ normalizationAlias: "after-install" });
+        bindPluginMetadataSnapshotCache(before, outer);
+        bindPluginMetadataSnapshotCache(nested, inner);
+        bindPluginMetadataSnapshotCache(after, outer);
+        await withPluginMetadataSnapshotScope(before, async () => {
+          await withPluginMetadataSnapshotScope(nested, async () => {
+            await Promise.resolve();
+            clearPluginMetadataLifecycleCaches();
+            expect(getCurrentPluginMetadataSnapshot()).toBeUndefined();
+          });
+          expect(getCurrentPluginMetadataSnapshot()).toBeUndefined();
+          withPluginMetadataSnapshotScope(after, () => {
+            expect(getCurrentPluginMetadataSnapshot()).toBe(after);
+          });
+          expect(getCurrentPluginMetadataSnapshot()).toBeUndefined();
+        });
+        if (owner) {
+          expect(getCurrentPluginMetadataSnapshot()).toBe(boot);
+        }
+      } finally {
+        await owner?.close();
+      }
+    },
+  );
+
+  it("clearPluginMetadataLifecycleCaches preserves an admitted runtime generation", () => {
+    const snapshot = createSnapshot();
+    withPluginRuntimeGenerationScope({ metadataSnapshot: snapshot }, () => {
+      clearPluginMetadataLifecycleCaches();
+      expect(getCurrentPluginMetadataSnapshot()).toBe(snapshot);
+    });
   });
 
   it("keeps derived registry snapshots as the current process snapshot", () => {

--- a/src/plugins/current-plugin-metadata-snapshot.ts
+++ b/src/plugins/current-plugin-metadata-snapshot.ts
@@ -11,7 +11,7 @@ import {
 import { resolveInstalledPluginIndexPolicyHash } from "./installed-plugin-index-policy.js";
 import {
   getPluginMetadataSnapshotCache,
-  getPluginCache,
+  getScopedPluginCaches,
   invalidatePluginCacheMetadata,
   getProcessPluginCache,
   getScopedPluginCache,
@@ -195,7 +195,7 @@ export function adoptCurrentPluginMetadataSnapshotIfAbsent(
 
 /** Installation revokes operation facts even when it runs between metadata scopes. */
 function revokeCurrentPluginMetadataSnapshotScopes(): void {
-  const caches = new Set([getPluginCache()]);
+  const caches = new Set(getScopedPluginCaches());
   const runtimeCaches = new Set();
   for (let scoped = scopedPluginMetadataSnapshot.getStore(); scoped; scoped = scoped.parent) {
     if (scoped.immutableRuntimeGeneration) {

--- a/src/plugins/current-plugin-metadata-snapshot.ts
+++ b/src/plugins/current-plugin-metadata-snapshot.ts
@@ -11,16 +11,20 @@ import {
 import { resolveInstalledPluginIndexPolicyHash } from "./installed-plugin-index-policy.js";
 import {
   getPluginMetadataSnapshotCache,
+  getPluginCache,
+  invalidatePluginCacheMetadata,
   getProcessPluginCache,
   getScopedPluginCache,
   runOutsidePluginCache,
   withPluginCache,
+  type PluginCache,
 } from "./plugin-cache.js";
 import {
   resolvePluginControlPlaneFingerprint,
   type ResolvePluginControlPlaneContextParams,
 } from "./plugin-control-plane-context.js";
 import { resolvePluginMetadataEnvFingerprint } from "./plugin-metadata-env.js";
+import { registerPluginMetadataProcessMemoLifecycleClear } from "./plugin-metadata-lifecycle.js";
 import { registerPluginMetadataSnapshotReaders } from "./plugin-metadata-snapshot-readers.js";
 import type {
   PluginMetadataSnapshot,
@@ -60,6 +64,9 @@ type PluginMetadataSnapshotCandidate = {
 };
 
 type ScopedPluginMetadataSnapshot = PluginMetadataSnapshotCandidate & {
+  snapshot: PluginMetadataSnapshot;
+  cache: PluginCache;
+  metadata: PluginCache["metadata"];
   parent?: ScopedPluginMetadataSnapshot;
 };
 
@@ -186,13 +193,30 @@ export function adoptCurrentPluginMetadataSnapshotIfAbsent(
   prepareCurrentPluginMetadataSnapshotPublication(snapshot, options)();
 }
 
+/** Installation revokes operation facts even when it runs between metadata scopes. */
+function revokeCurrentPluginMetadataSnapshotScopes(): void {
+  const caches = new Set([getPluginCache()]);
+  const runtimeCaches = new Set();
+  for (let scoped = scopedPluginMetadataSnapshot.getStore(); scoped; scoped = scoped.parent) {
+    if (scoped.immutableRuntimeGeneration) {
+      runtimeCaches.add(scoped.cache);
+    } else {
+      caches.add(scoped.cache);
+    }
+  }
+  for (const cache of caches) {
+    if (cache.kind === "operation" && !runtimeCaches.has(cache)) {
+      invalidatePluginCacheMetadata(cache);
+    }
+  }
+}
+
 function isScopedSnapshotInCurrentCache(scoped: ScopedPluginMetadataSnapshot): boolean {
+  if (!scoped.immutableRuntimeGeneration && scoped.metadata !== scoped.cache.metadata) {
+    return false;
+  }
   const cache = getScopedPluginCache();
-  return (
-    cache?.kind !== "operation" ||
-    !scoped.snapshot ||
-    getPluginMetadataSnapshotCache(scoped.snapshot) === cache
-  );
+  return cache?.kind !== "operation" || scoped.cache === cache;
 }
 
 /** Carries one owner-prepared metadata generation through nested async plugin lookups. */
@@ -235,10 +259,13 @@ export function withPluginMetadataSnapshotScope<T>(
   for (const config of options.compatibleConfigs ?? []) {
     configIdentities.add(config);
   }
-  return withPluginCache(getPluginMetadataSnapshotCache(snapshot), () =>
+  const cache = getPluginMetadataSnapshotCache(snapshot);
+  return withPluginCache(cache, () =>
     scopedPluginMetadataSnapshot.run(
       {
         snapshot,
+        cache,
+        metadata: cache.metadata,
         configFingerprint,
         envFingerprint: resolvePluginMetadataEnvFingerprint(options.env),
         compatiblePolicyHashes,
@@ -415,4 +442,8 @@ export function getCurrentPluginMetadataSnapshot(
 registerPluginMetadataSnapshotReaders({
   adoptCurrentPluginMetadataSnapshotIfAbsent,
   getCurrentPluginMetadataSnapshot,
+});
+
+registerPluginMetadataProcessMemoLifecycleClear(revokeCurrentPluginMetadataSnapshotScopes, {
+  owner: "operation",
 });

--- a/src/plugins/plugin-cache.test.ts
+++ b/src/plugins/plugin-cache.test.ts
@@ -19,6 +19,8 @@ import {
   getPluginCacheSource,
   withPluginCache,
 } from "./plugin-cache.js";
+import { PluginInstance } from "./plugin-instance.js";
+import { withPluginLifecycleLease } from "./plugin-lifecycle-lease.js";
 import { clearPluginMetadataLifecycleCaches } from "./plugin-metadata-lifecycle.js";
 import { preparePluginModule } from "./plugin-module-loader-cache.js";
 
@@ -30,6 +32,31 @@ afterEach(() => {
 });
 
 describe("plugin package facts", () => {
+  it("withPluginLifecycleLease refreshes enclosing operation facts while retaining its callbacks", async () => {
+    const root = tempDirs.make("plugin-lease-parent-");
+    const filePath = path.join(root, "catalog.json");
+    fs.writeFileSync(filePath, '{"name":"before-install"}');
+    await using cache = createPluginCache();
+    const instance = new PluginInstance("setup-owner");
+    cache.instances.add(instance);
+    const afterWrite = instance.wrap(() => "post-write usable");
+    await withPluginCache(cache, async () => {
+      expect(readPluginCacheJsonFile(filePath)).toMatchObject({
+        ok: true,
+        value: { name: "before-install" },
+      });
+      await withPluginLifecycleLease({ path: path.join(root, "state.sqlite") }, async () => {
+        fs.writeFileSync(filePath, '{"name":"after-install"}');
+        clearPluginMetadataLifecycleCaches();
+      });
+      expect(readPluginCacheJsonFile(filePath)).toMatchObject({
+        ok: true,
+        value: { name: "after-install" },
+      });
+      expect(afterWrite()).toBe("post-write usable");
+    });
+  });
+
   it.each(["regular", "boundary"] as const)(
     "shares missing %s files across reader policies until the owner changes",
     (firstPolicy) => {

--- a/src/plugins/plugin-cache.ts
+++ b/src/plugins/plugin-cache.ts
@@ -114,6 +114,51 @@ export function getPluginCacheRetention(cache: PluginCache): Promise<void> | und
   return retained?.references.size ? retained.settled.promise : undefined;
 }
 
+function createPluginMetadataCache(): PluginCache["metadata"] {
+  return {
+    current: {
+      snapshot: undefined,
+      owner: "operation",
+      configFingerprint: undefined,
+      envFingerprint: undefined,
+      defaultDiscoveryCompatible: false,
+      compatiblePolicyHashes: undefined,
+      compatibleConfigFingerprints: undefined,
+      revision: Symbol("plugin-metadata-snapshot"),
+      configIdentities: new WeakSet(),
+    },
+    snapshots: new Map(),
+    discovery: new Map(),
+    projections: new WeakMap(),
+    projectionSources: new WeakMap(),
+    completions: new WeakMap(),
+    indexFacts: new WeakMap(),
+    channelAdapters: new WeakMap(),
+    bundledChannelCatalogs: new Map(),
+    staticCatalogStates: new WeakMap(),
+    modelSuppressionResolvers: new WeakMap(),
+  };
+}
+
+/** Invalidate discovery facts without retiring callbacks owned by this operation. */
+export function invalidatePluginCacheMetadata(cache: PluginCache): void {
+  cache.metadata = createPluginMetadataCache();
+  for (const root of cache.roots.values()) {
+    root.files.clear();
+    root.checkedEntries.clear();
+    root.paths.clear();
+    root.directory = undefined;
+    root.artifacts.clear();
+    root.runtimeArtifacts.clear();
+    root.entryBoundaries.clear();
+    root.entryPaths.clear();
+  }
+  cache.rootAliases.clear();
+  cache.installRecords.clear();
+  cache.persistedInstalledIndex.clear();
+  cache.dependencyStatus = new WeakMap();
+}
+
 /** Each inventory owns its acquired facts and reusable load results; publication owns activation. */
 export function createPluginCache(options: { kind?: PluginCache["kind"] } = {}): PluginCache {
   return {
@@ -126,29 +171,7 @@ export function createPluginCache(options: { kind?: PluginCache["kind"] } = {}):
     sdk: createPluginCacheSdk(),
     setupModules: new Map(),
     instances: new Set(),
-    metadata: {
-      current: {
-        snapshot: undefined,
-        owner: "operation",
-        configFingerprint: undefined,
-        envFingerprint: undefined,
-        defaultDiscoveryCompatible: false,
-        compatiblePolicyHashes: undefined,
-        compatibleConfigFingerprints: undefined,
-        revision: Symbol("plugin-metadata-snapshot"),
-        configIdentities: new WeakSet(),
-      },
-      snapshots: new Map(),
-      discovery: new Map(),
-      projections: new WeakMap(),
-      projectionSources: new WeakMap(),
-      completions: new WeakMap(),
-      indexFacts: new WeakMap(),
-      channelAdapters: new WeakMap(),
-      bundledChannelCatalogs: new Map(),
-      staticCatalogStates: new WeakMap(),
-      modelSuppressionResolvers: new WeakMap(),
-    },
+    metadata: createPluginMetadataCache(),
     installRecords: new Map(),
     persistedInstalledIndex: new Map(),
     dependencyStatus: new WeakMap(),

--- a/src/plugins/plugin-cache.ts
+++ b/src/plugins/plugin-cache.ts
@@ -45,16 +45,18 @@ export interface PluginCache
   [Symbol.asyncDispose](): Promise<void>;
 }
 
+type PluginCacheScope = { cache: PluginCache; parent?: PluginCacheScope };
+
 const state = resolveGlobalSingleton<{
   current?: PluginCache;
-  scope: AsyncLocalStorage<PluginCache>;
+  scope: AsyncLocalStorage<PluginCacheScope>;
   snapshotOwners: WeakMap<object, PluginCache>;
   retirements: Array<{
     cache: PluginCache;
     completion: Promise<PromiseSettledResult<PluginHostCleanupResult>>;
   }>;
 }>(Symbol.for("openclaw.pluginCache"), () => ({
-  scope: new AsyncLocalStorage<PluginCache>(),
+  scope: new AsyncLocalStorage<PluginCacheScope>(),
   snapshotOwners: new WeakMap(),
   retirements: [],
 }));
@@ -190,7 +192,16 @@ export function adoptProcessPluginCache(cache: PluginCache): void {
 }
 
 export function getScopedPluginCache(): PluginCache | undefined {
-  return state.scope.getStore();
+  return state.scope.getStore()?.cache;
+}
+
+/** Installation refreshes every enclosing operation, including callers outside metadata phases. */
+export function getScopedPluginCaches(): PluginCache[] {
+  const caches: PluginCache[] = [];
+  for (let scope = state.scope.getStore(); scope; scope = scope.parent) {
+    caches.push(scope.cache);
+  }
+  return caches;
 }
 
 export function getPluginCache(): PluginCache {
@@ -198,7 +209,7 @@ export function getPluginCache(): PluginCache {
 }
 
 export function withPluginCache<T>(cache: PluginCache, run: () => T): T {
-  return state.scope.run(cache, run);
+  return state.scope.run({ cache, parent: state.scope.getStore() }, run);
 }
 
 export function runOutsidePluginCache<T>(run: () => T): T {

--- a/src/plugins/plugin-metadata-account-key-policies.test.ts
+++ b/src/plugins/plugin-metadata-account-key-policies.test.ts
@@ -18,9 +18,14 @@ afterEach(() => {
 });
 
 describe("channel account-key metadata ownership", () => {
-  it.each([true, false])(
-    "loadPluginMetadataSnapshot preserves declared owners and selects enabled policy (first enabled: %s)",
-    (firstEnabled) => {
+  it.each([
+    { firstEnabled: true, secondEnabled: true },
+    { firstEnabled: false, secondEnabled: true },
+    { firstEnabled: false, secondEnabled: false },
+  ])(
+    "loadPluginMetadataSnapshot preserves maintenance policy with enabled-owner precedence ($firstEnabled, $secondEnabled)",
+    ({ firstEnabled, secondEnabled }) => {
+      const selectedFirst = firstEnabled || !secondEnabled;
       const rootDir = makeTrackedTempDir("openclaw-account-policy-", tempDirs);
       const plugins = ["first", "second"].map((pluginId) => {
         const pluginRoot = path.join(rootDir, pluginId);
@@ -48,7 +53,7 @@ describe("channel account-key metadata ownership", () => {
           config: {
             plugins: {
               load: { paths: plugins.map((plugin) => plugin.rootDir) },
-              entries: { first: { enabled: firstEnabled }, second: { enabled: true } },
+              entries: { first: { enabled: firstEnabled }, second: { enabled: secondEnabled } },
             },
           },
           env: {
@@ -61,9 +66,9 @@ describe("channel account-key metadata ownership", () => {
         });
         expect(snapshot.owners.channels.get("selected")).toEqual(["first", "second"]);
         expect(snapshot.owners.channelAccountKeyPolicies?.get("selected")).toEqual({
-          canonicalAliasesRequireOwnField: firstEnabled ? "first" : "second",
+          canonicalAliasesRequireOwnField: selectedFirst ? "first" : "second",
         });
-        expect(snapshot.owners.channelAccountKeyPolicies?.has("inherited")).toBe(!firstEnabled);
+        expect(snapshot.owners.channelAccountKeyPolicies?.has("inherited")).toBe(!selectedFirst);
         const projected = projectPluginMetadataSnapshot(snapshot, ["second"]);
         expect(projected.owners.channelAccountKeyPolicies?.get("inherited")).toEqual({
           canonicalAliasesRequireOwnField: "second",

--- a/src/plugins/plugin-metadata-lifecycle.ts
+++ b/src/plugins/plugin-metadata-lifecycle.ts
@@ -22,7 +22,7 @@ import {
 import type { PluginMetadataSnapshot } from "./plugin-metadata-snapshot.types.js";
 import { PluginRuntimeCloseRetainedError } from "./runtime-close-error.js";
 
-const pluginMetadataProcessMemoClears = new Set<() => void>();
+const pluginMetadataProcessMemoClears = new Map<() => void, "process" | "operation">();
 type GatewayMetadataOwner = {
   cache?: PluginCache;
   phase: "booting" | "active" | "closing";
@@ -232,15 +232,21 @@ export function retainGatewayPluginMetadata() {
 
 export type GatewayPluginMetadataOwner = ReturnType<typeof retainGatewayPluginMetadata>;
 
-/** Registers a process-local plugin metadata memo clear hook. */
+/** Registers a metadata clear hook with the lifetime of its facts. */
 export function registerPluginMetadataProcessMemoLifecycleClear(
   clearProcessMemo: () => void,
+  options: { owner: "process" | "operation" } = { owner: "process" },
 ): void {
-  pluginMetadataProcessMemoClears.add(clearProcessMemo);
+  pluginMetadataProcessMemoClears.set(clearProcessMemo, options.owner);
 }
 
 /** Clears plugin metadata snapshots and registered process memo caches. */
 export function clearPluginMetadataLifecycleCaches(): void {
+  for (const [clearMemo, owner] of pluginMetadataProcessMemoClears) {
+    if (owner === "operation") {
+      clearMemo();
+    }
+  }
   // Installs and a sibling Gateway's teardown cannot retire a running inventory.
   // Pre-publication planning remains refreshable until boot metadata is pinned.
   if (
@@ -256,8 +262,10 @@ export function clearPluginMetadataLifecycleCaches(): void {
 
 function clearPluginMetadataCaches(): void {
   clearCurrentPluginMetadataSnapshot();
-  for (const clearProcessMemo of pluginMetadataProcessMemoClears) {
-    clearProcessMemo();
+  for (const [clearProcessMemo, owner] of pluginMetadataProcessMemoClears) {
+    if (owner === "process") {
+      clearProcessMemo();
+    }
   }
   resetPluginCache();
 }

--- a/src/plugins/plugin-metadata-snapshot.ts
+++ b/src/plugins/plugin-metadata-snapshot.ts
@@ -245,7 +245,17 @@ function buildPluginMetadataOwnerMaps(
     NonNullable<PluginManifestRecord["channelAccountKeyPolicies"]>[string]
   >();
   const selectedChannels = new Set<string>();
-  for (const owner of selectInstalledPluginManifestRecords(index, manifestRegistry, null)) {
+  const enabledPluginIds = new Set(
+    index.plugins.filter((plugin) => plugin.enabled).map((plugin) => plugin.pluginId),
+  );
+  // Maintenance can load a disabled owner; active owners retain runtime precedence.
+  const channelOwners = selectInstalledPluginManifestRecords(
+    index,
+    manifestRegistry,
+    null,
+    true,
+  ).toSorted((a, b) => Number(enabledPluginIds.has(b.id)) - Number(enabledPluginIds.has(a.id)));
+  for (const owner of channelOwners) {
     for (const channel of owner.channels) {
       if (selectedChannels.has(channel)) {
         continue;

--- a/src/plugins/test-helpers/install-account-policy.test-support.ts
+++ b/src/plugins/test-helpers/install-account-policy.test-support.ts
@@ -1,0 +1,62 @@
+import fs from "node:fs";
+import path from "node:path";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { clearPluginMetadataLifecycleCaches } from "../plugin-metadata-lifecycle.js";
+import { loadPluginMetadataSnapshot } from "../plugin-metadata-snapshot.js";
+import { createColdPluginFixture } from "./cold-plugin-fixtures.js";
+
+export function createInstallAccountPolicyFixture(rootDir: string, channelId: string) {
+  const pluginRoot = path.join(rootDir, "plugin");
+  fs.mkdirSync(pluginRoot);
+  const manifest = {
+    id: channelId,
+    channels: [channelId],
+    providers: [],
+    providerAuthChoices: [],
+    configSchema: { type: "object" },
+    channelConfigs: { [channelId]: { schema: { type: "object" } } },
+  };
+  createColdPluginFixture({ rootDir: pluginRoot, pluginId: channelId, channelId, manifest });
+  const config: OpenClawConfig = {
+    plugins: {
+      load: { paths: [pluginRoot] },
+      entries: { [channelId]: { enabled: true } },
+    },
+    channels: {
+      [channelId]: {
+        accounts: { "Work Phone": { account: "+12025550123", name: "Old name" } },
+      },
+    },
+  };
+  const env = {
+    ...process.env,
+    OPENCLAW_HOME: rootDir,
+    OPENCLAW_STATE_DIR: path.join(rootDir, "state"),
+    OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+  };
+  return {
+    config,
+    env,
+    readMetadata(currentConfig = config, workspaceDir?: string) {
+      return loadPluginMetadataSnapshot({
+        config: currentConfig,
+        workspaceDir,
+        env,
+        allowCurrent: false,
+        preferPersisted: false,
+      });
+    },
+    installPolicy() {
+      fs.writeFileSync(
+        path.join(pluginRoot, "openclaw.plugin.json"),
+        JSON.stringify({
+          ...manifest,
+          channelAccountKeyPolicies: {
+            [channelId]: { canonicalAliasesRequireOwnField: "account" },
+          },
+        }),
+      );
+      clearPluginMetadataLifecycleCaches();
+    },
+  };
+}

--- a/src/routing/account-lookup.test.ts
+++ b/src/routing/account-lookup.test.ts
@@ -1,7 +1,24 @@
 // Account lookup tests cover account matching by id, alias, and chat metadata.
 import { describe, expect, it } from "vitest";
 import { normalizeAccountId as normalizeRoutingAccountId } from "./account-id.js";
-import { resolveAccountEntry, resolveNormalizedAccountEntry } from "./account-lookup.js";
+import {
+  resolveAccountEntry,
+  resolveAccountKey,
+  resolveNormalizedAccountEntry,
+} from "./account-lookup.js";
+
+describe("SDK resolveAccountKey creation targets", () => {
+  it.each(["__proto__", "constructor", "prototype"])(
+    "rejects reserved %s for both plain and policy-backed setup writers",
+    (accountId) => {
+      for (const policy of [undefined, { canonicalAliasesRequireOwnField: "account" }]) {
+        expect(() =>
+          resolveAccountKey(undefined, accountId, undefined, policy, { allowMissing: true }),
+        ).toThrow(`Account id "${accountId}" is reserved`);
+      }
+    },
+  );
+});
 
 function createAccountsWithPrototypePollution() {
   const inherited = { default: { id: "polluted" } };

--- a/src/routing/account-lookup.test.ts
+++ b/src/routing/account-lookup.test.ts
@@ -1,5 +1,8 @@
 // Account lookup tests cover account matching by id, alias, and chat metadata.
 import { describe, expect, it } from "vitest";
+import { resolveAccountKey as resolvePublicAccountKey } from "../plugin-sdk/account-resolution.js";
+import { withPluginMetadataSnapshotScope } from "../plugins/current-plugin-metadata-snapshot.js";
+import { createPluginMetadataSnapshotFixture } from "../plugins/plugin-metadata.test-support.js";
 import { normalizeAccountId as normalizeRoutingAccountId } from "./account-id.js";
 import {
   resolveAccountEntry,
@@ -18,6 +21,77 @@ describe("SDK resolveAccountKey creation targets", () => {
       }
     },
   );
+});
+
+describe("SDK resolveAccountKey channel context", () => {
+  const accounts = { "Work Phone": { account: "+12025550103" } };
+  const snapshot = createPluginMetadataSnapshotFixture({
+    plugins: [
+      {
+        id: "phone-owner",
+        channels: ["phone"],
+        channelAccountKeyPolicies: { phone: { canonicalAliasesRequireOwnField: "account" } },
+      },
+    ],
+  });
+
+  it("selects the prepared policy without changing plain or explicit-policy lookups", () => {
+    withPluginMetadataSnapshotScope(snapshot, () => {
+      expect(resolvePublicAccountKey(accounts, "work-phone")).toBeUndefined();
+      expect(resolvePublicAccountKey(accounts, "WORK PHONE")).toBe("Work Phone");
+      expect(
+        resolvePublicAccountKey(accounts, "work-phone", undefined, undefined, {
+          channelId: "phone",
+        }),
+      ).toBe("Work Phone");
+      expect(
+        resolvePublicAccountKey(accounts, "work-phone", undefined, undefined, {
+          channelId: "other",
+        }),
+      ).toBeUndefined();
+      expect(
+        resolvePublicAccountKey(
+          accounts,
+          "work-phone",
+          undefined,
+          { canonicalAliasesRequireOwnField: "token" },
+          { channelId: "phone" },
+        ),
+      ).toBeUndefined();
+      expect(resolvePublicAccountKey(accounts, "work-phone", normalizeRoutingAccountId)).toBe(
+        "Work Phone",
+      );
+      expect(
+        resolvePublicAccountKey(accounts, "work-phone", () => "different", undefined, {
+          channelId: "phone",
+        }),
+      ).toBe("Work Phone");
+    });
+  });
+
+  it("uses channel policy for missing targets and rejects reserved creation through the public entry", () => {
+    withPluginMetadataSnapshotScope(snapshot, () => {
+      expect(
+        resolvePublicAccountKey(undefined, "New Phone", undefined, undefined, {
+          channelId: "phone",
+          allowMissing: true,
+        }),
+      ).toBe("new-phone");
+      expect(
+        resolvePublicAccountKey(undefined, "New Phone", undefined, undefined, {
+          allowMissing: true,
+        }),
+      ).toBe("New Phone");
+      for (const accountId of ["constructor", "__proto__", "prototype"]) {
+        expect(() =>
+          resolvePublicAccountKey(accounts, accountId, undefined, undefined, {
+            channelId: "phone",
+            allowMissing: true,
+          }),
+        ).toThrow(`Account id "${accountId}" is reserved`);
+      }
+    });
+  });
 });
 
 function createAccountsWithPrototypePollution() {

--- a/src/routing/account-lookup.ts
+++ b/src/routing/account-lookup.ts
@@ -100,6 +100,13 @@ export function resolveAccountKey<T>(
 ): string | undefined {
   const normalizer = policy ? normalizeRoutingAccountId : normalizeAccountId;
   const normalize = normalizer ?? normalizeLowercaseStringOrEmpty;
+  if (
+    options?.allowMissing &&
+    (isBlockedObjectKey(normalizeLowercaseStringOrEmpty(accountId)) ||
+      isBlockedObjectKey(normalize(accountId)))
+  ) {
+    throw new Error(`Account id "${accountId}" is reserved. Choose a different account id.`);
+  }
   const targetId = policy ? normalize(accountId) : accountId;
   // Creation uses the owner's target id, never the spelling of a rejected alias.
   const missingKey = options?.allowMissing ? targetId : undefined;

--- a/src/routing/account-lookup.ts
+++ b/src/routing/account-lookup.ts
@@ -93,15 +93,17 @@ export function resolveAccountKey<T>(
   policy?: ChannelAccountKeyPolicy,
   options?: { allowMissing?: boolean; channelId?: string },
 ): string | undefined {
-  policy ??= options?.channelId
-    ? snapshotReaderSlot
-        .getCurrentPluginMetadataSnapshot?.({
-          allowScopedSnapshot: true,
-          allowWorkspaceScopedSnapshot: true,
-        })
-        ?.owners.channelAccountKeyPolicies?.get(options.channelId)
-    : undefined;
-  const normalizer = policy ? normalizeRoutingAccountId : normalizeAccountId;
+  const effectivePolicy =
+    policy ??
+    (options?.channelId
+      ? snapshotReaderSlot
+          .getCurrentPluginMetadataSnapshot?.({
+            allowScopedSnapshot: true,
+            allowWorkspaceScopedSnapshot: true,
+          })
+          ?.owners.channelAccountKeyPolicies?.get(options.channelId)
+      : undefined);
+  const normalizer = effectivePolicy ? normalizeRoutingAccountId : normalizeAccountId;
   const normalize = normalizer ?? normalizeLowercaseStringOrEmpty;
   if (
     options?.allowMissing &&
@@ -110,7 +112,7 @@ export function resolveAccountKey<T>(
   ) {
     throw new Error(`Account id "${accountId}" is reserved. Choose a different account id.`);
   }
-  const targetId = policy ? normalize(accountId) : accountId;
+  const targetId = effectivePolicy ? normalize(accountId) : accountId;
   // Creation uses the owner's target id, never the spelling of a rejected alias.
   const missingKey = options?.allowMissing ? targetId : undefined;
   if (!accounts || typeof accounts !== "object") {
@@ -127,7 +129,7 @@ export function resolveAccountKey<T>(
       continue;
     }
     // Existing case-only matches retain precedence over newly reachable aliases.
-    if (policy && normalizeLowercaseStringOrEmpty(key) === lowercaseTarget) {
+    if (effectivePolicy && normalizeLowercaseStringOrEmpty(key) === lowercaseTarget) {
       return key;
     }
     const candidate = normalize(key);
@@ -136,15 +138,15 @@ export function resolveAccountKey<T>(
         (Boolean(normalizeOptionalAccountId(key)) && !isBlockedObjectKey(candidate))) &&
       candidate === normalized
     ) {
-      if (!policy) {
+      if (!effectivePolicy) {
         return key;
       }
       const entry = asOptionalRecord(accounts[key]);
       if (
         canonicalMatch === undefined &&
         entry &&
-        Object.hasOwn(entry, policy.canonicalAliasesRequireOwnField) &&
-        normalizeOptionalString(entry[policy.canonicalAliasesRequireOwnField])
+        Object.hasOwn(entry, effectivePolicy.canonicalAliasesRequireOwnField) &&
+        normalizeOptionalString(entry[effectivePolicy.canonicalAliasesRequireOwnField])
       ) {
         canonicalMatch = key;
       }

--- a/src/routing/account-lookup.ts
+++ b/src/routing/account-lookup.ts
@@ -40,15 +40,10 @@ export function resolveChannelAccountKey<T>(
   accountKeyPolicy?: ChannelAccountKeyPolicy,
   options?: { allowMissing?: boolean },
 ): string | undefined {
-  const policy =
-    accountKeyPolicy ??
-    snapshotReaderSlot
-      .getCurrentPluginMetadataSnapshot?.({
-        allowScopedSnapshot: true,
-        allowWorkspaceScopedSnapshot: true,
-      })
-      ?.owners.channelAccountKeyPolicies?.get(channelId);
-  return resolveAccountKey(accounts, accountId, normalizeAccountId, policy, options);
+  return resolveAccountKey(accounts, accountId, normalizeAccountId, accountKeyPolicy, {
+    ...options,
+    channelId,
+  });
 }
 
 export function resolveChannelAccountEntry<T>(
@@ -96,8 +91,16 @@ export function resolveAccountKey<T>(
   accountId: string,
   normalizeAccountId?: (accountId: string) => string,
   policy?: ChannelAccountKeyPolicy,
-  options?: { allowMissing?: boolean },
+  options?: { allowMissing?: boolean; channelId?: string },
 ): string | undefined {
+  policy ??= options?.channelId
+    ? snapshotReaderSlot
+        .getCurrentPluginMetadataSnapshot?.({
+          allowScopedSnapshot: true,
+          allowWorkspaceScopedSnapshot: true,
+        })
+        ?.owners.channelAccountKeyPolicies?.get(options.channelId)
+    : undefined;
   const normalizer = policy ? normalizeRoutingAccountId : normalizeAccountId;
   const normalize = normalizer ?? normalizeLowercaseStringOrEmpty;
   if (

--- a/src/system-agent/hosted-setup.runtime.test.ts
+++ b/src/system-agent/hosted-setup.runtime.test.ts
@@ -1,7 +1,10 @@
 import "./chat-engine.mocks.test-support.js";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../test/helpers/promise.js";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { applyAccountNameToChannelSection } from "../channels/plugins/setup-helpers.js";
 import { committedConfigFiles as hostedConfigFiles } from "../commands/committed-config.test-support.js";
+import { withCommandPluginMetadata } from "../commands/config-validation.js";
 import { getCurrentPluginMetadataSnapshot } from "../plugins/current-plugin-metadata-snapshot.js";
 import {
   bindPluginMetadataSnapshotCache,
@@ -10,12 +13,19 @@ import {
   type PluginCache,
 } from "../plugins/plugin-cache.js";
 import { PluginInstance } from "../plugins/plugin-instance.js";
-import { createPluginMetadataSnapshotFixture } from "../plugins/plugin-metadata.test-support.js";
+import {
+  hasPluginLifecycleLease,
+  withPluginLifecycleLease,
+} from "../plugins/plugin-lifecycle-lease.js";
+import * as pluginMetadata from "../plugins/plugin-metadata-snapshot.js";
 import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
 import {
   getPluginRuntimeGenerationRegistry,
   withPluginRuntimeGenerationScope,
 } from "../plugins/runtime/generation-scope.js";
+import { createInstallAccountPolicyFixture } from "../plugins/test-helpers/install-account-policy.test-support.js";
+import { resolveChannelAccountEntry } from "../routing/account-lookup.js";
+import { createChannelTestPluginBase } from "../test-utils/channel-plugins.js";
 import {
   fakeOverviewLoader,
   sharedVerifiedInferenceConfig,
@@ -686,14 +696,33 @@ describe("SystemAgentChatEngine runtime", () => {
 });
 
 describe("hosted channel post-write hooks", () => {
+  const tempDirs = useAutoCleanupTempDirTracker(afterEach);
   it("ChatWizardHost.startChannel owns plugin resources through deferred hooks without retiring Gateway boot", async () => {
     await using bootCache = createPluginCache({ kind: "process" });
-    const metadataSnapshot = createPluginMetadataSnapshotFixture();
+    const fixture = createInstallAccountPolicyFixture(
+      tempDirs.make("openclaw-hosted-install-policy-"),
+      "signal",
+    );
+    const baseConfig = fixture.config;
+    const metadataSnapshot = fixture.readMetadata();
+    const resolveMetadata = vi
+      .spyOn(pluginMetadata, "resolvePluginMetadataSnapshot")
+      .mockImplementation(({ config, workspaceDir }) => fixture.readMetadata(config, workspaceDir));
+    const readAccount = (config: OpenClawConfig, accountId = "work-phone") =>
+      resolveChannelAccountEntry(config.channels?.signal?.accounts, accountId, "signal");
     bindPluginMetadataSnapshotCache(metadataSnapshot, bootCache);
     const pluginRegistry = createEmptyPluginRegistry();
     const bootInstance = new PluginInstance("gateway-boot");
     bootCache.instances.add(bootInstance);
     const readBoot = bootInstance.wrap(() => "Gateway available");
+    pluginRegistry.channels.push({
+      pluginId: "signal",
+      source: "test",
+      plugin: createChannelTestPluginBase({
+        id: "signal",
+        config: { resolveAccount: bootInstance.wrap(readAccount) },
+      }),
+    });
     const setupInstance = new PluginInstance("chat-channel-setup");
     const events: string[] = [];
     const caches: PluginCache[] = [];
@@ -712,9 +741,11 @@ describe("hosted channel post-write hooks", () => {
       caches.push(getPluginCache());
     };
     const hook = {
-      channel: "matrix",
-      accountId: "default",
-      run: async () => {
+      channel: "signal",
+      accountId: "work-phone",
+      run: async ({ cfg }: { cfg: OpenClawConfig }) => {
+        expect(hasPluginLifecycleLease()).toBe(false);
+        expect(readAccount(cfg)).toEqual({ account: "+12025550123", name: "Work calls" });
         events.push("after-write");
         hookStarted.resolve();
         await finishHook.promise;
@@ -728,22 +759,45 @@ describe("hosted channel post-write hooks", () => {
         metadata: getCurrentPluginMetadataSnapshot(),
         registry: getPluginRuntimeGenerationRegistry(),
       });
-      return { exists: true, valid: true, hash: "setup-base-hash", config: {}, sourceConfig: {} };
+      return {
+        exists: true,
+        valid: true,
+        hash: "setup-base-hash",
+        config: baseConfig,
+        sourceConfig: baseConfig,
+      };
     });
     mocks.setupChannels.mockImplementation(
       async (
-        _config: OpenClawConfig,
+        config: OpenClawConfig,
         _runtime: unknown,
         _prompter: WizardPrompter,
         options: { onPostWriteHook?: (value: typeof hook) => void },
       ) => {
         recordPhase("setup");
+        await withCommandPluginMetadata({ config }, () => {
+          expect(readAccount(config)).toBeUndefined();
+        });
+        await withPluginLifecycleLease({ env: fixture.env }, async () => {
+          fixture.installPolicy();
+        });
+        recordPhase("installed");
         options.onPostWriteHook?.(hook);
-        return { channels: { matrix: { enabled: true } } };
+        return await withCommandPluginMetadata({ config }, () =>
+          applyAccountNameToChannelSection({
+            cfg: config,
+            channelKey: "signal",
+            accountId: "work-phone",
+            name: "Work calls",
+          }),
+        );
       },
     );
     mocks.writeWizardConfigFile.mockImplementation(async (config: OpenClawConfig) => {
       recordPhase("write");
+      expect(config.channels?.signal?.accounts).toEqual({
+        "Work Phone": { account: "+12025550123", name: "Work calls" },
+      });
       return hostedConfigFiles.write(config);
     });
     const host = new ChatWizardHost({
@@ -753,7 +807,7 @@ describe("hosted channel post-write hooks", () => {
       },
     });
     const running = withPluginRuntimeGenerationScope({ metadataSnapshot, pluginRegistry }, () =>
-      host.startChannel("matrix"),
+      host.startChannel("signal"),
     );
 
     try {
@@ -766,15 +820,27 @@ describe("hosted channel post-write hooks", () => {
       expect(await observedScope.promise).toEqual({ metadata: undefined, registry: undefined });
       expect(caches[0]).not.toBe(bootCache);
       expect(caches.slice(0, 4).every((cache) => cache === caches[0])).toBe(true);
-      expect(events).toEqual(["read", "setup", "authorize", "write", "authorize", "after-write"]);
+      expect(events).toEqual([
+        "read",
+        "setup",
+        "installed",
+        "authorize",
+        "write",
+        "authorize",
+        "after-write",
+      ]);
       expect(readSetup()).toBe("post-write complete");
       finishHook.resolve();
-      expect((await running).text).toContain("matrix is configured");
+      expect((await running).text).toContain("signal is configured");
       expect(events.slice(-2)).toEqual(["post-write complete", "disposed"]);
       expect(() => readSetup()).toThrow("reloaded or disabled");
       withPluginRuntimeGenerationScope({ metadataSnapshot, pluginRegistry }, () => {
         expect(getCurrentPluginMetadataSnapshot()).toBe(metadataSnapshot);
         expect(getPluginRuntimeGenerationRegistry()).toBe(pluginRegistry);
+        expect(pluginRegistry.channels).toHaveLength(1);
+        expect(
+          pluginRegistry.channels[0]?.plugin.config.resolveAccount(baseConfig, "work-phone"),
+        ).toBeUndefined();
         expect(readBoot()).toBe("Gateway available");
       });
     } finally {
@@ -782,6 +848,7 @@ describe("hosted channel post-write hooks", () => {
       await running;
       await setupInstance.dispose();
       host.dispose();
+      resolveMetadata.mockRestore();
     }
   });
 

--- a/src/system-agent/hosted-setup.runtime.test.ts
+++ b/src/system-agent/hosted-setup.runtime.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../test/helpers/promise.js";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { applyAccountNameToChannelSection } from "../channels/plugins/setup-helpers.js";
+import type { ChannelPlugin } from "../channels/plugins/types.public.js";
 import { committedConfigFiles as hostedConfigFiles } from "../commands/committed-config.test-support.js";
 import { withCommandPluginMetadata } from "../commands/config-validation.js";
 import { getCurrentPluginMetadataSnapshot } from "../plugins/current-plugin-metadata-snapshot.js";
@@ -24,6 +25,7 @@ import {
   withPluginRuntimeGenerationScope,
 } from "../plugins/runtime/generation-scope.js";
 import { createInstallAccountPolicyFixture } from "../plugins/test-helpers/install-account-policy.test-support.js";
+import { normalizeAccountId } from "../routing/account-id.js";
 import { resolveChannelAccountEntry } from "../routing/account-lookup.js";
 import { createChannelTestPluginBase } from "../test-utils/channel-plugins.js";
 import {
@@ -708,8 +710,12 @@ describe("hosted channel post-write hooks", () => {
     const resolveMetadata = vi
       .spyOn(pluginMetadata, "resolvePluginMetadataSnapshot")
       .mockImplementation(({ config, workspaceDir }) => fixture.readMetadata(config, workspaceDir));
-    const readAccount = (config: OpenClawConfig, accountId = "work-phone") =>
-      resolveChannelAccountEntry(config.channels?.signal?.accounts, accountId, "signal");
+    const readAccount: ChannelPlugin["config"]["resolveAccount"] = (config, accountId) =>
+      resolveChannelAccountEntry(
+        config.channels?.signal?.accounts,
+        normalizeAccountId(accountId),
+        "signal",
+      );
     bindPluginMetadataSnapshotCache(metadataSnapshot, bootCache);
     const pluginRegistry = createEmptyPluginRegistry();
     const bootInstance = new PluginInstance("gateway-boot");
@@ -745,7 +751,10 @@ describe("hosted channel post-write hooks", () => {
       accountId: "work-phone",
       run: async ({ cfg }: { cfg: OpenClawConfig }) => {
         expect(hasPluginLifecycleLease()).toBe(false);
-        expect(readAccount(cfg)).toEqual({ account: "+12025550123", name: "Work calls" });
+        expect(readAccount(cfg, "work-phone")).toEqual({
+          account: "+12025550123",
+          name: "Work calls",
+        });
         events.push("after-write");
         hookStarted.resolve();
         await finishHook.promise;
@@ -776,7 +785,7 @@ describe("hosted channel post-write hooks", () => {
       ) => {
         recordPhase("setup");
         await withCommandPluginMetadata({ config }, () => {
-          expect(readAccount(config)).toBeUndefined();
+          expect(readAccount(config, "work-phone")).toBeUndefined();
         });
         await withPluginLifecycleLease({ env: fixture.env }, async () => {
           fixture.installPolicy();

--- a/src/system-agent/hosted-setup.runtime.test.ts
+++ b/src/system-agent/hosted-setup.runtime.test.ts
@@ -1,6 +1,21 @@
 import "./chat-engine.mocks.test-support.js";
 import { describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
 import { committedConfigFiles as hostedConfigFiles } from "../commands/committed-config.test-support.js";
+import { getCurrentPluginMetadataSnapshot } from "../plugins/current-plugin-metadata-snapshot.js";
+import {
+  bindPluginMetadataSnapshotCache,
+  createPluginCache,
+  getPluginCache,
+  type PluginCache,
+} from "../plugins/plugin-cache.js";
+import { PluginInstance } from "../plugins/plugin-instance.js";
+import { createPluginMetadataSnapshotFixture } from "../plugins/plugin-metadata.test-support.js";
+import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
+import {
+  getPluginRuntimeGenerationRegistry,
+  withPluginRuntimeGenerationScope,
+} from "../plugins/runtime/generation-scope.js";
 import {
   fakeOverviewLoader,
   sharedVerifiedInferenceConfig,
@@ -13,6 +28,7 @@ import {
   type OpenClawConfig,
   type WizardPrompter,
 } from "./chat-engine.test-support.js";
+import { ChatWizardHost } from "./chat-wizard-host.js";
 
 describe("SystemAgentChatEngine runtime", () => {
   it("hosts a channel setup wizard as chat turns", async () => {
@@ -670,6 +686,105 @@ describe("SystemAgentChatEngine runtime", () => {
 });
 
 describe("hosted channel post-write hooks", () => {
+  it("ChatWizardHost.startChannel owns plugin resources through deferred hooks without retiring Gateway boot", async () => {
+    await using bootCache = createPluginCache({ kind: "process" });
+    const metadataSnapshot = createPluginMetadataSnapshotFixture();
+    bindPluginMetadataSnapshotCache(metadataSnapshot, bootCache);
+    const pluginRegistry = createEmptyPluginRegistry();
+    const bootInstance = new PluginInstance("gateway-boot");
+    bootCache.instances.add(bootInstance);
+    const readBoot = bootInstance.wrap(() => "Gateway available");
+    const setupInstance = new PluginInstance("chat-channel-setup");
+    const events: string[] = [];
+    const caches: PluginCache[] = [];
+    const readSetup = setupInstance.wrap(() => "post-write complete");
+    setupInstance.lifecycle.onDispose(() => {
+      events.push("disposed");
+    });
+    const hookStarted = createDeferred();
+    const finishHook = createDeferred();
+    const observedScope = createDeferred<{
+      metadata: ReturnType<typeof getCurrentPluginMetadataSnapshot>;
+      registry: ReturnType<typeof getPluginRuntimeGenerationRegistry>;
+    }>();
+    const recordPhase = (phase: string) => {
+      events.push(phase);
+      caches.push(getPluginCache());
+    };
+    const hook = {
+      channel: "matrix",
+      accountId: "default",
+      run: async () => {
+        events.push("after-write");
+        hookStarted.resolve();
+        await finishHook.promise;
+        events.push(readSetup());
+      },
+    };
+    mocks.readSetupConfigFileSnapshot.mockImplementation(async () => {
+      recordPhase("read");
+      getPluginCache().instances.add(setupInstance);
+      observedScope.resolve({
+        metadata: getCurrentPluginMetadataSnapshot(),
+        registry: getPluginRuntimeGenerationRegistry(),
+      });
+      return { exists: true, valid: true, hash: "setup-base-hash", config: {}, sourceConfig: {} };
+    });
+    mocks.setupChannels.mockImplementation(
+      async (
+        _config: OpenClawConfig,
+        _runtime: unknown,
+        _prompter: WizardPrompter,
+        options: { onPostWriteHook?: (value: typeof hook) => void },
+      ) => {
+        recordPhase("setup");
+        options.onPostWriteHook?.(hook);
+        return { channels: { matrix: { enabled: true } } };
+      },
+    );
+    mocks.writeWizardConfigFile.mockImplementation(async (config: OpenClawConfig) => {
+      recordPhase("write");
+      return hostedConfigFiles.write(config);
+    });
+    const host = new ChatWizardHost({
+      surface: "gateway",
+      beforePersistentApply: async () => {
+        recordPhase("authorize");
+      },
+    });
+    const running = withPluginRuntimeGenerationScope({ metadataSnapshot, pluginRegistry }, () =>
+      host.startChannel("matrix"),
+    );
+
+    try {
+      await Promise.race([
+        hookStarted.promise,
+        running.then(() => {
+          throw new Error("chat setup completed before its post-write hook");
+        }),
+      ]);
+      expect(await observedScope.promise).toEqual({ metadata: undefined, registry: undefined });
+      expect(caches[0]).not.toBe(bootCache);
+      expect(caches.slice(0, 4).every((cache) => cache === caches[0])).toBe(true);
+      expect(events).toEqual(["read", "setup", "authorize", "write", "authorize", "after-write"]);
+      expect(readSetup()).toBe("post-write complete");
+      finishHook.resolve();
+      expect((await running).text).toContain("matrix is configured");
+      expect(events.slice(-2)).toEqual(["post-write complete", "disposed"]);
+      expect(() => readSetup()).toThrow("reloaded or disabled");
+      withPluginRuntimeGenerationScope({ metadataSnapshot, pluginRegistry }, () => {
+        expect(getCurrentPluginMetadataSnapshot()).toBe(metadataSnapshot);
+        expect(getPluginRuntimeGenerationRegistry()).toBe(pluginRegistry);
+        expect(readBoot()).toBe("Gateway available");
+      });
+    } finally {
+      finishHook.resolve();
+      await running;
+      await setupInstance.dispose();
+      host.dispose();
+    }
+  });
+
   it("runs collected channel hooks after writing config", async () => {
     const hook = { channel: "matrix", accountId: "default", run: vi.fn() };
     mocks.readSetupConfigFileSnapshot.mockResolvedValue({

--- a/src/system-agent/hosted-setup.runtime.ts
+++ b/src/system-agent/hosted-setup.runtime.ts
@@ -1,5 +1,7 @@
 import { stat } from "node:fs/promises";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { createPluginCache, withPluginCache } from "../plugins/plugin-cache.js";
+import { runOutsidePluginRuntimeGenerationScope } from "../plugins/runtime/generation-scope.js";
 import { defaultRuntime, type RuntimeEnv } from "../runtime.js";
 import type { WizardPrompter } from "../wizard/prompts.js";
 import type {
@@ -57,27 +59,32 @@ export async function runHostedSetup(params: {
     | { keptCurrent: true }
   >;
 }): Promise<HostedSetupCompletion> {
-  const { readSetupConfigFileSnapshot, writeWizardConfigFile } = await loadSetupShared();
-  const snapshot = await readSetupConfigFileSnapshot();
-  if (!snapshot.exists || !snapshot.valid || !snapshot.hash) {
-    throw new Error(
-      `${params.label} requires a valid saved config snapshot. On the machine running OpenClaw, run \`openclaw doctor --fix\` and resolve any remaining validation errors; then retry.`,
-    );
-  }
-  const baseConfig = snapshot.sourceConfig ?? snapshot.config;
-  const runtime = params.runtime ?? createHostedWizardRuntime(defaultRuntime);
-  const result = await params.run({ baseConfig, runtime });
-  if ("keptCurrent" in result) {
-    return "kept-current";
-  }
-  await params.beforePersistentApply(runtime);
-  const committed = await writeWizardConfigFile(result.nextConfig, {
-    allowConfigSizeDrop: false,
-    baseHash: snapshot.hash,
-    ...(params.afterWrite ? { afterWrite: params.afterWrite } : {}),
-  });
-  await result.afterWrite?.(committed.path);
-  return "applied";
+  await using cache = createPluginCache();
+  return await runOutsidePluginRuntimeGenerationScope(() =>
+    withPluginCache(cache, async (): Promise<HostedSetupCompletion> => {
+      const { readSetupConfigFileSnapshot, writeWizardConfigFile } = await loadSetupShared();
+      const snapshot = await readSetupConfigFileSnapshot();
+      if (!snapshot.exists || !snapshot.valid || !snapshot.hash) {
+        throw new Error(
+          `${params.label} requires a valid saved config snapshot. On the machine running OpenClaw, run \`openclaw doctor --fix\` and resolve any remaining validation errors; then retry.`,
+        );
+      }
+      const baseConfig = snapshot.sourceConfig ?? snapshot.config;
+      const runtime = params.runtime ?? createHostedWizardRuntime(defaultRuntime);
+      const result = await params.run({ baseConfig, runtime });
+      if ("keptCurrent" in result) {
+        return "kept-current";
+      }
+      await params.beforePersistentApply(runtime);
+      const committed = await writeWizardConfigFile(result.nextConfig, {
+        allowConfigSizeDrop: false,
+        baseHash: snapshot.hash,
+        ...(params.afterWrite ? { afterWrite: params.afterWrite } : {}),
+      });
+      await result.afterWrite?.(committed.path);
+      return "applied";
+    }),
+  );
 }
 
 export async function runHostedChannelSetup(

--- a/test/plugins/signal-account-policy.integration.test.ts
+++ b/test/plugins/signal-account-policy.integration.test.ts
@@ -1,0 +1,50 @@
+import path from "node:path";
+import { resolveMergedAccountConfig } from "openclaw/plugin-sdk/account-resolution";
+import { describe, expect, it } from "vitest";
+import type { ChannelPlugin } from "../../src/channels/plugins/types.public.js";
+import { withPluginMetadataSnapshotScope } from "../../src/plugins/current-plugin-metadata-snapshot.js";
+import { loadPluginManifest } from "../../src/plugins/manifest.js";
+import { createPluginMetadataSnapshotFixture } from "../../src/plugins/plugin-metadata.test-support.js";
+import {
+  loadBundledPluginFacade,
+  resolveBundledPluginPublicModulePath,
+} from "../../src/test-utils/bundled-plugin-public-surface.js";
+
+describe("Signal registered account policy", () => {
+  it("uses the selected competing manifest policy in both Signal and core readers", async () => {
+    const { signalPlugin } = await loadBundledPluginFacade<{
+      signalPlugin: ChannelPlugin<{ config: { account?: string } }>;
+    }>({ pluginId: "signal", artifactBasename: "api.js" });
+    const loaded = loadPluginManifest(
+      path.dirname(
+        resolveBundledPluginPublicModulePath({
+          pluginId: "signal",
+          artifactBasename: "openclaw.plugin.json",
+        }),
+      ),
+    );
+    if (!loaded.ok) {
+      throw new Error(loaded.error);
+    }
+    const signal = {
+      account: "+12025550123",
+      accounts: { "Work Phone": { account: "+12025550124" } },
+    };
+    const snapshot = createPluginMetadataSnapshotFixture({
+      plugins: [{ id: "selected-signal-owner", channels: ["signal"] }, loaded.manifest],
+    });
+
+    withPluginMetadataSnapshotScope(snapshot, () => {
+      const coreAccount = resolveMergedAccountConfig({
+        channelId: "signal",
+        channelConfig: signal,
+        accounts: signal.accounts,
+        accountId: "work-phone",
+      });
+      expect(coreAccount.account).toBe(signal.account);
+      expect(
+        signalPlugin.config.resolveAccount({ channels: { signal } }, "work-phone").config.account,
+      ).toBe(coreAccount.account);
+    });
+  });
+});

--- a/test/setup.signal.ts
+++ b/test/setup.signal.ts
@@ -1,0 +1,9 @@
+import { afterEach, beforeEach } from "vitest";
+import manifest from "../extensions/signal/openclaw.plugin.json" with { type: "json" };
+import { setCurrentPluginMetadataSnapshot } from "../src/plugins/current-plugin-metadata.test-support.js";
+import { createPluginMetadataSnapshotFixture } from "../src/plugins/plugin-metadata.test-support.js";
+
+beforeEach(() => {
+  setCurrentPluginMetadataSnapshot(createPluginMetadataSnapshotFixture({ plugins: [manifest] }));
+});
+afterEach(() => setCurrentPluginMetadataSnapshot(undefined));

--- a/test/setup.signal.ts
+++ b/test/setup.signal.ts
@@ -1,7 +1,14 @@
+import { fileURLToPath } from "node:url";
 import { afterEach, beforeEach } from "vitest";
-import manifest from "../extensions/signal/openclaw.plugin.json" with { type: "json" };
 import { setCurrentPluginMetadataSnapshot } from "../src/plugins/current-plugin-metadata.test-support.js";
+import { loadPluginManifest } from "../src/plugins/manifest.js";
 import { createPluginMetadataSnapshotFixture } from "../src/plugins/plugin-metadata.test-support.js";
+
+const loaded = loadPluginManifest(fileURLToPath(new URL("../extensions/signal", import.meta.url)));
+if (!loaded.ok) {
+  throw new Error(loaded.error);
+}
+const manifest = loaded.manifest;
 
 beforeEach(() => {
   setCurrentPluginMetadataSnapshot(createPluginMetadataSnapshotFixture({ plugins: [manifest] }));

--- a/test/vitest/vitest.extension-signal.config.ts
+++ b/test/vitest/vitest.extension-signal.config.ts
@@ -4,7 +4,12 @@ import { createSingleChannelExtensionVitestConfig } from "./vitest.extension-con
 export function createExtensionSignalVitestConfig(
   env: Record<string, string | undefined> = process.env,
 ) {
-  return createSingleChannelExtensionVitestConfig("signal", env);
+  const config = createSingleChannelExtensionVitestConfig("signal", env);
+  config.test = {
+    ...config.test,
+    setupFiles: [...(config.test?.setupFiles ?? []), "test/setup.signal.ts"],
+  };
+  return config;
 }
 
 export default createExtensionSignalVitestConfig();


### PR DESCRIPTION
Related: #145750.

## What Problem This Solves

Fixes an issue where deleting a channel account could report success but activate a shadowed account after restart when stored keys referred to the same identity.

## Why This Change Was Made

The shared deletion operation resolves the proposed remaining accounts before any effects and rejects an ambiguous takeover. Installed plugin metadata supplies account-key policy through setup, persistence and later reads; reserved account IDs are rejected before writes.

## User Impact

Ambiguous deletion names both keys and preserves configuration. Unambiguous deletion still works, including maintenance of disabled plugins.

Consumers: channel deletion and setup use the selected plugin policy consistently.

## Evidence

Command-line deletion and cold Gateway restart reproduced the takeover and confirmed refusal, unchanged configuration and retained identity. Unambiguous deletion and reserved-ID controls passed. Registered setup, deletion and metadata tests passed; previous-release configuration retained its identity. Synthetic transport checked account selection; live channel delivery was not tested.
