### PR TITLE
fix: acknowledge committed config writes after concurrent edits

### DIFF
--- a/src/commands/doctor-config-flow.conflict.test.ts
+++ b/src/commands/doctor-config-flow.conflict.test.ts
@@ -185,9 +185,9 @@ describe("Doctor repair confirmation conflicts", () => {
           let preferredCheckedAfterRename = false;
           let sourceRecheckedAfterRename = false;
           let preferredCreated = false;
-          const rename = fsNode.promises.rename.bind(fsNode.promises);
-          vi.spyOn(fsNode.promises, "rename").mockImplementation(async (source, destination) => {
-            await rename(source, destination);
+          const renameSync = fsNode.renameSync.bind(fsNode);
+          vi.spyOn(fsNode, "renameSync").mockImplementation((source, destination) => {
+            renameSync(source, destination);
             if (destination === configPath) {
               committed = true;
             }

--- a/src/commands/doctor-gateway-services.authority.test.ts
+++ b/src/commands/doctor-gateway-services.authority.test.ts
@@ -1,3 +1,4 @@
+import fsNode from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -153,12 +154,17 @@ describe.skipIf(process.platform === "win32")("Doctor native repair authority or
     const events: string[] = [];
     const nativeActions: string[] = [];
     const unexpectedProcesses: string[] = [];
+    const renameSync = fsNode.renameSync;
+    vi.spyOn(fsNode, "renameSync").mockImplementation((source, destination) => {
+      renameSync(source, destination);
+      if (destination === configPath) {
+        events.push("config-published");
+      }
+    });
     const rename = fs.rename.bind(fs);
     vi.spyOn(fs, "rename").mockImplementation(async (source, destination) => {
       await rename(source, destination);
-      if (destination === configPath) {
-        events.push("config-published");
-      } else if (
+      if (
         [unitPath, `${unitPath}.bak`, environmentPath, installedEnvironmentPath].includes(
           String(destination),
         )
@@ -418,6 +424,9 @@ describe.skipIf(process.platform === "win32")("Doctor native repair authority or
     expect(errors).toEqual([]);
     expect(observations.embeddedTokenPersisted).toBe(true);
     expect(observations.unitBytesPreserved).toBe(false);
+    expect(observations.events).toEqual(
+      expect.arrayContaining(["config-published", "service-published"]),
+    );
     expect(observations.events.indexOf("config-published")).toBeLessThan(
       observations.events.indexOf("service-published"),
     );

--- a/src/config/io.context.ts
+++ b/src/config/io.context.ts
@@ -57,7 +57,11 @@ export type ConfigIoContext = {
     env: NodeJS.ProcessEnv;
     allowCurrentPluginMetadata?: boolean;
   }) => ValidationPluginMetadataSnapshotLoader;
-  resolveRuntimePreflightSourceConfig: (candidate: OpenClawConfig) => OpenClawConfig;
+  resolveRuntimePreflightSourceConfig: (
+    candidate: OpenClawConfig,
+    includeFileHashes?: Record<string, string>,
+    includeFileTargets?: Record<string, string>,
+  ) => OpenClawConfig;
   prepareRecoveryBackupCandidate: (
     candidate: ConfigRecoveryCandidate,
   ) => ConfigRecoveryCandidatePreparation;
@@ -131,9 +135,19 @@ export function createConfigIoContext(options: ConfigIoFactoryOptions = {}): Con
     };
   }
 
-  function resolveRuntimePreflightSourceConfig(candidate: OpenClawConfig): OpenClawConfig {
+  function resolveRuntimePreflightSourceConfig(
+    candidate: OpenClawConfig,
+    includeFileHashes?: Record<string, string>,
+    includeFileTargets?: Record<string, string>,
+  ): OpenClawConfig {
     const env = { ...deps.env } as NodeJS.ProcessEnv;
-    const resolvedIncludes = resolveConfigIncludesForRead(candidate, configPath, { ...deps, env });
+    const resolvedIncludes = resolveConfigIncludesForRead(
+      candidate,
+      configPath,
+      { ...deps, env },
+      includeFileHashes,
+      includeFileTargets,
+    );
     const resolution = resolveConfigForRead(resolvedIncludes, env, deps.lowerPrecedenceEnv);
     const contextBudgetConfig = migrateLegacyContextBudgetConfig(
       resolution.resolvedConfigRaw,

--- a/src/config/io.snapshot.ts
+++ b/src/config/io.snapshot.ts
@@ -65,6 +65,18 @@ function listResolvedIncludePaths(includeFilePathsForWatch: ReadonlySet<string>)
   return [...includeFilePathsForWatch].toSorted();
 }
 
+export function hashConfigRevision(
+  raw: string,
+  includeFileHashes: Record<string, string>,
+  includeFileTargets: Record<string, string>,
+): string {
+  const revision = createHash("sha256").update(raw);
+  for (const [includePath, includeHash] of Object.entries(includeFileHashes)) {
+    revision.update(JSON.stringify([includePath, includeFileTargets[includePath], includeHash]));
+  }
+  return revision.digest("hex");
+}
+
 export async function readConfigFileSnapshotInternal(
   context: ConfigIoContext,
   options: InternalReadOptions = {},
@@ -222,13 +234,11 @@ export async function readConfigFileSnapshotInternal(
     const snapshotRaw = raw;
     const snapshotParsed = effectiveParsed;
     // The write revision covers every authored input, without hashing runtime defaults or env.
-    const revision = createHash("sha256").update(raw);
-    for (const [includePath, includeHash] of Object.entries(includeFileHashesForWrite)) {
-      revision.update(
-        JSON.stringify([includePath, includeFileTargetsForWrite[includePath], includeHash]),
-      );
-    }
-    const snapshotHash = revision.digest("hex");
+    const snapshotHash = hashConfigRevision(
+      raw,
+      includeFileHashesForWrite,
+      includeFileTargetsForWrite,
+    );
     fallbackHash = snapshotHash;
     fallbackSourceConfig = coerceConfig(effectiveConfigRaw);
     const pluginMetadata = context.createValidationPluginMetadataSnapshotLoader({

--- a/src/config/io.types.ts
+++ b/src/config/io.types.ts
@@ -50,7 +50,7 @@ export type ConfigWriteOptions = {
   ownedConfigPathForWrite?: string;
   /** Rechecks that the config path captured at mutation start is still active. */
   assertConfigPathForWrite?: () => void;
-  /** Internal synchronous live-owner assertion; unlike path provenance, requires rename-only writes. */
+  /** Internal synchronous live-owner assertion checked at guarded publication effects. */
   assertCurrent?: () => void;
   /** Paths that must be removed from the persisted payload. */
   unsetPaths?: string[][];
@@ -90,7 +90,7 @@ export type ConfigWriteOptions = {
   lastTouchedVersionOverride?: string;
   /** Optional runtime candidate preflight; the runtime writer composes its own preflight. */
   preCommitRuntimePreflight?: (sourceConfig: OpenClawConfig) => Promise<unknown>;
-  /** Revalidate authority at the final root-file publication; requires atomic rename. */
+  /** Prepare authority before the synchronous root-file publication phase. */
   beforeCommit?: () => void | Promise<void>;
   /** Snapshot-time hashes for include files that mutation writers may update. */
   includeFileHashesForWrite?: Record<string, string>;

--- a/src/config/io.types.ts
+++ b/src/config/io.types.ts
@@ -11,11 +11,15 @@ import type { ConfigFileSnapshot, ConfigValidationIssue, OpenClawConfig } from "
 
 export type ParseConfigJson5Result = { ok: true; parsed: unknown } | { ok: false; error: string };
 
+export const configWriteCommittedSnapshot = Symbol("configWriteCommittedSnapshot");
+
 export type ConfigWriteResult = {
   persistedHash: string;
   persistedConfig: OpenClawConfig;
   /** Exact resolved source accepted before commit; absent for legacy custom writers. */
   persistedSourceConfig?: OpenClawConfig;
+  /** Internal receipt from the committed inputs, independent of later filesystem reads. */
+  [configWriteCommittedSnapshot]?: { hash: string; sourceConfig: OpenClawConfig };
 };
 
 export type ConfigWriteInputBasis = { kind: ConfigMutationBase; config: unknown };

--- a/src/config/io.write-config.test.ts
+++ b/src/config/io.write-config.test.ts
@@ -3856,7 +3856,52 @@ describe("config io write", () => {
     });
   }
 
-  for (const publication of [
+  itWithHome(
+    "rejects changed includes before copy fallback creates a missing root",
+    async (home) => {
+      const configPath = configPathForHome(home);
+      const includePath = path.join(path.dirname(configPath), "included.json");
+      await fs.mkdir(path.dirname(configPath), { recursive: true });
+      await writeConfigJson(includePath, { logging: { level: "info" } });
+      let renameDenied = false;
+      let includeChanged = false;
+      const io = createFastConfigIO(home, {
+        configPath,
+        fs: {
+          ...fsNode,
+          renameSync: (source, destination) => {
+            if (destination !== configPath) {
+              return fsNode.renameSync(source, destination);
+            }
+            renameDenied = true;
+            throw Object.assign(new Error("rename denied"), { code: "EPERM" });
+          },
+          readSync: new Proxy(fsNode.readSync, {
+            apply(target, thisArg, args) {
+              if (renameDenied && !includeChanged) {
+                fsNode.writeFileSync(includePath, JSON.stringify({ logging: { level: "debug" } }));
+                includeChanged = true;
+              }
+              return Reflect.apply(target, thisArg, args);
+            },
+          }),
+        },
+      });
+      const nextConfig = {
+        $include: "included.json",
+        gateway: { mode: "local" as const },
+      };
+
+      await expect(io.writeConfigFile(nextConfig)).rejects.toThrow("included config");
+
+      expect(renameDenied).toBe(true);
+      expect(includeChanged).toBe(true);
+      await expect(fs.stat(configPath)).rejects.toMatchObject({ code: "ENOENT" });
+      expect(await readPersistedConfig(includePath)).toEqual({ logging: { level: "debug" } });
+    },
+  );
+
+  const copyFallbackPublications = [
     "ordinary",
     "prepared-direct",
     "prepared-runtime",
@@ -3864,24 +3909,28 @@ describe("config io write", () => {
     "guarded",
     "executor-explicit",
     "executor-ambient",
-  ] as const) {
-    const guarded = publication === "guarded" || publication.startsWith("executor-");
+  ] as const;
+  for (const { publication, layout } of copyFallbackPublications.flatMap((publication) =>
+    (["plain", "include"] as const).map((layout) => ({ publication, layout })),
+  )) {
     itWithHome(
-      `${guarded ? "rejects" : "preserves"} copy fallback for ${publication} publication`,
+      `preserves copy fallback for ${publication} publication with ${layout} config`,
       async (home) => {
-        const { configPath, raw } = await writeConfigFixture(home, {
+        const { configPath } = await writeConfigFixture(home, {
           gateway: { mode: "local", port: 18789 },
+          ...(layout === "include" ? { logging: { $include: "logging.json" } } : {}),
         });
+        const includePath = path.join(path.dirname(configPath), "logging.json");
+        if (layout === "include") {
+          await writeConfigJson(includePath, { level: "info" });
+        }
         const denied = Object.assign(new Error("rename denied"), { code: "EPERM" });
         const io = createFastConfigIO(home, {
           configPath,
           fs: {
             ...fsNode,
-            promises: {
-              ...fsNode.promises,
-              rename: async () => {
-                throw denied;
-              },
+            renameSync: () => {
+              throw denied;
             },
           },
         });
@@ -3899,7 +3948,10 @@ describe("config io write", () => {
             skipPluginValidation: true,
             skipRuntimeSnapshotRefresh: true,
           };
-          const nextConfig = { gateway: { mode: "local" as const, port: 19001 } };
+          const nextConfig = {
+            gateway: { mode: "local" as const, port: 19001 },
+            ...(layout === "include" ? { logging: { level: "info" as const } } : {}),
+          };
           const write =
             publication === "prepared-runtime"
               ? writeConfigFile(nextConfig, options)
@@ -3910,28 +3962,26 @@ describe("config io write", () => {
                     writeOptions: options,
                   })
                 : io.writeConfigFile(nextConfig, options);
-          if (guarded) {
-            await expect(write).rejects.toBe(denied);
-            expect(await fs.readFile(configPath, "utf8")).toBe(raw);
-          } else {
-            await write;
-            expect(await readPersistedConfig(configPath)).toMatchObject({
-              gateway: { port: 19001 },
-            });
-            expect(
-              listConfigAuditRecordsForTests({ env: io.env, homedir: () => home }),
-            ).toContainEqual(
-              expect.objectContaining({
-                event: "config.write",
-                configPath,
-                result: "copy-fallback",
-              }),
-            );
-          }
+          await write;
+          expect(await readPersistedConfig(configPath)).toMatchObject({
+            gateway: { port: 19001 },
+            ...(layout === "include" ? { logging: { $include: "logging.json" } } : {}),
+          });
+          expect(
+            listConfigAuditRecordsForTests({ env: io.env, homedir: () => home }),
+          ).toContainEqual(
+            expect.objectContaining({
+              event: "config.write",
+              configPath,
+              result: "copy-fallback",
+            }),
+          );
         };
         const rename =
           publication === "prepared-runtime" || publication === "prepared-mutation"
-            ? vi.spyOn(fsNode.promises, "rename").mockRejectedValue(denied)
+            ? vi.spyOn(fsNode, "renameSync").mockImplementation(() => {
+                throw denied;
+              })
             : undefined;
         try {
           await withEnvAsync(
@@ -3980,6 +4030,9 @@ describe("config io write", () => {
         } else {
           expect(beforeCommit).not.toHaveBeenCalled();
         }
+        if (layout === "include") {
+          expect(await readPersistedConfig(includePath)).toEqual({ level: "info" });
+        }
       },
     );
   }
@@ -4010,13 +4063,10 @@ describe("config io write", () => {
             configPath,
             fs: {
               ...fsNode,
-              promises: {
-                ...fsNode.promises,
-                rename: async () => {
-                  releaseUpdateCommandPreflightForHandoff(fence);
-                  revoked = true;
-                  throw primaryError;
-                },
+              renameSync: () => {
+                releaseUpdateCommandPreflightForHandoff(fence);
+                revoked = true;
+                throw primaryError;
               },
             },
           });
@@ -4210,20 +4260,18 @@ describe("config io write", () => {
         OPENCLAW_TEST_FAST: "1",
       } as NodeJS.ProcessEnv;
       const readFile = fsNode.promises.readFile.bind(fsNode.promises);
-      const rename = fsNode.promises.rename.bind(fsNode.promises);
+      const rename = fsNode.renameSync;
       let committed = false;
       let rollbackReadUsedInjectedFs = false;
       const injectedFs = {
         ...fsNode,
-        promises: {
-          ...fsNode.promises,
-          rename: async (from, to) => {
-            await rename(from, to);
-            if (!committed && to === configPath) {
-              committed = true;
-              env.OPENCLAW_CONFIG_PATH = otherConfigPath;
-            }
-          },
+        promises: { ...fsNode.promises },
+        renameSync: (from, to) => {
+          rename(from, to);
+          if (!committed && to === configPath) {
+            committed = true;
+            env.OPENCLAW_CONFIG_PATH = otherConfigPath;
+          }
         },
       } satisfies typeof fsNode;
       vi.spyOn(injectedFs.promises, "readFile").mockImplementation(async (target, options) => {

--- a/src/config/io.write-config.test.ts
+++ b/src/config/io.write-config.test.ts
@@ -3910,8 +3910,11 @@ describe("config io write", () => {
     "executor-explicit",
     "executor-ambient",
   ] as const;
-  for (const { publication, layout } of copyFallbackPublications.flatMap((publication) =>
-    (["plain", "include"] as const).map((layout) => ({ publication, layout })),
+  for (const { publication, layout } of copyFallbackPublications.flatMap((publicationKind) =>
+    (["plain", "include"] as const).map((configLayout) => ({
+      publication: publicationKind,
+      layout: configLayout,
+    })),
   )) {
     itWithHome(
       `preserves copy fallback for ${publication} publication with ${layout} config`,

--- a/src/config/io.write-reread.test.ts
+++ b/src/config/io.write-reread.test.ts
@@ -76,9 +76,9 @@ describe("writeConfigFile canonical reread", () => {
       // new config into place, every subsequent sync read sees corrupt content,
       // so the canonical reread parses invalid.
       let corrupted = false;
-      const realRename = fsNode.promises.rename.bind(fsNode.promises);
-      vi.spyOn(fsNode.promises, "rename").mockImplementation(async (from, to) => {
-        await realRename(from, to);
+      const realRename = fsNode.renameSync;
+      vi.spyOn(fsNode, "renameSync").mockImplementation((from, to) => {
+        realRename(from, to);
         if (to === configPath) {
           corrupted = true;
         }
@@ -247,6 +247,16 @@ describe("writeConfigFile canonical reread", () => {
             : undefined;
         let committed = false;
         let compensationDenied = false;
+        const renameSync = fsNode.renameSync;
+        vi.spyOn(fsNode, "renameSync").mockImplementation((source, destination) => {
+          renameSync(source, destination);
+          if (destination === configPath) {
+            committed = true;
+            if (writer === "direct") {
+              env.OPENCLAW_CONFIG_PATH = `${configPath}.replacement`;
+            }
+          }
+        });
         const rename = fsNode.promises.rename.bind(fsNode.promises);
         vi.spyOn(fsNode.promises, "rename").mockImplementation(async (source, destination) => {
           if (destination === configPath && committed) {
@@ -254,12 +264,6 @@ describe("writeConfigFile canonical reread", () => {
             throw Object.assign(new Error("compensation rename denied"), { code: "EPERM" });
           }
           await rename(source, destination);
-          if (destination === configPath) {
-            committed = true;
-            if (writer === "direct") {
-              env.OPENCLAW_CONFIG_PATH = `${configPath}.replacement`;
-            }
-          }
         });
         if (writer !== "direct") {
           setRuntimeConfigSnapshotRefreshHandler({

--- a/src/config/io.write-safety.ts
+++ b/src/config/io.write-safety.ts
@@ -1,8 +1,10 @@
 import fs from "node:fs";
 import path from "node:path";
 import { asFiniteNumber } from "@openclaw/normalization-core/number-coercion";
+import { isMissingPathError } from "../infra/errors.js";
 import { replaceFileAtomic } from "../infra/replace-file.js";
 import { isRecord } from "../utils.js";
+import { hashConfigIncludeRaw } from "./includes.js";
 import { stampConfigWriteMetadata } from "./io.meta.js";
 import { hashConfigRaw, parseConfigJson5 } from "./io.read-helpers.js";
 import type { ConfigWriteOptions } from "./io.types.js";
@@ -56,11 +58,28 @@ export function assertBaseSnapshotStillCurrent(
   snapshot: ConfigFileSnapshot,
   configPath: string,
   ioFs: typeof fs,
+  includeGraph?: { hashes: Record<string, string>; targets: Record<string, string> },
 ): void {
   if (snapshot.path !== configPath) {
     throw new ConfigMutationConflictError("config path changed since last load", {
       retryable: false,
     });
+  }
+  for (const [includePath, expectedHash] of Object.entries(includeGraph?.hashes ?? {})) {
+    try {
+      const expectedTarget = includeGraph?.targets[includePath];
+      if (!expectedTarget || path.normalize(ioFs.realpathSync(includePath)) !== expectedTarget) {
+        throw new ConfigMutationConflictError("included config target changed since last load");
+      }
+      if (hashConfigIncludeRaw(ioFs.readFileSync(expectedTarget, "utf-8")) !== expectedHash) {
+        throw new ConfigMutationConflictError("included config changed since last load");
+      }
+    } catch (error) {
+      if (!isMissingPathError(error)) {
+        throw error;
+      }
+      throw new ConfigMutationConflictError("included config disappeared since last load");
+    }
   }
   // Unreadable snapshots cannot be re-read; destructive guards reject them later.
   if (snapshot.readError) {

--- a/src/config/io.write-safety.ts
+++ b/src/config/io.write-safety.ts
@@ -26,14 +26,15 @@ export function createGuardedConfigFileSystem(
   if (!assertCurrent && !publication) {
     return fsModule;
   }
+  let expectedPublication = publication;
   const assertPublication = () => {
     assertCurrent?.();
-    if (publication) {
+    if (expectedPublication) {
       assertBaseSnapshotStillCurrent(
-        publication.snapshot,
+        expectedPublication.snapshot,
         configPath,
         fsModule,
-        publication.includeGraph,
+        expectedPublication.includeGraph,
       );
     }
   };
@@ -62,15 +63,18 @@ export function createGuardedConfigFileSystem(
       if (filePath === configPath) {
         assertPublication();
       }
-      return fsModule.rmSync(filePath, options);
+      fsModule.rmSync(filePath, options);
+      if (filePath === configPath && expectedPublication) {
+        // Only this successful removal advances the captured root expectation.
+        expectedPublication = {
+          ...expectedPublication,
+          snapshot: { ...expectedPublication.snapshot, exists: false, raw: null },
+        };
+      }
     },
     openSync: (filePath, flags, mode) => {
       if (filePath === configPath) {
-        if (publication?.snapshot.exists === false) {
-          assertPublication();
-        } else {
-          assertCurrent?.();
-        }
+        assertPublication();
       }
       return fsModule.openSync(filePath, flags, mode);
     },

--- a/src/config/io.write-safety.ts
+++ b/src/config/io.write-safety.ts
@@ -18,24 +18,73 @@ export function createGuardedConfigFileSystem(
   configPath: string,
   fsModule: typeof fs,
   assertCurrent?: () => void,
+  publication?: {
+    snapshot: ConfigFileSnapshot;
+    includeGraph: { hashes: Record<string, string>; targets: Record<string, string> };
+  },
 ): typeof fs {
-  if (!assertCurrent) {
+  if (!assertCurrent && !publication) {
     return fsModule;
   }
+  const assertPublication = () => {
+    assertCurrent?.();
+    if (publication) {
+      assertBaseSnapshotStillCurrent(
+        publication.snapshot,
+        configPath,
+        fsModule,
+        publication.includeGraph,
+      );
+    }
+  };
   const directory = path.dirname(path.resolve(configPath));
   return {
     ...fsModule,
+    mkdirSync: new Proxy(fsModule.mkdirSync, {
+      apply(target, thisArg, args) {
+        assertCurrent?.();
+        return Reflect.apply(target, thisArg, args);
+      },
+    }),
+    fchmodSync: (fd, mode) => {
+      assertCurrent?.();
+      return fsModule.fchmodSync(fd, mode);
+    },
+    renameSync: (source, destination) => {
+      if (destination === configPath) {
+        assertPublication();
+      } else {
+        assertCurrent?.();
+      }
+      return fsModule.renameSync(source, destination);
+    },
+    rmSync: (filePath, options) => {
+      if (filePath === configPath) {
+        assertPublication();
+      }
+      return fsModule.rmSync(filePath, options);
+    },
+    openSync: (filePath, flags, mode) => {
+      if (filePath === configPath) {
+        if (publication?.snapshot.exists === false) {
+          assertPublication();
+        } else {
+          assertCurrent?.();
+        }
+      }
+      return fsModule.openSync(filePath, flags, mode);
+    },
     promises: {
       ...fsModule.promises,
       // Preserve mkdir's overloads while checking immediately at native dispatch.
       mkdir: new Proxy(fsModule.promises.mkdir, {
         apply(target, thisArg, args) {
-          assertCurrent();
+          assertCurrent?.();
           return Reflect.apply(target, thisArg, args);
         },
       }),
       rename: (source, destination) => {
-        assertCurrent();
+        assertCurrent?.();
         return fsModule.promises.rename(source, destination);
       },
       open: async (filePath, flags, mode) => {
@@ -44,7 +93,7 @@ export function createGuardedConfigFileSystem(
           // fs-safe observes this directory handle before applying its mode.
           const chmod = handle.chmod.bind(handle);
           handle.chmod = (nextMode) => {
-            assertCurrent();
+            assertCurrent?.();
             return chmod(nextMode);
           };
         }

--- a/src/config/io.write.ts
+++ b/src/config/io.write.ts
@@ -55,6 +55,7 @@ import {
   resolveGatewayMode,
   restoreAuthoredTildePathsForWrite,
 } from "./io.read-helpers.js";
+import { hashConfigRevision } from "./io.snapshot.js";
 import { loggedConfigWarningFingerprints, setBoundedConfigIoWarningEntry } from "./io.state.js";
 import type {
   ConfigWriteInputBasis,
@@ -62,7 +63,11 @@ import type {
   InternalConfigWriteResult,
   ReadConfigFileSnapshotInternalResult,
 } from "./io.types.js";
-import { ConfigRuntimeRefreshError, configWritePostCommitRollback } from "./io.types.js";
+import {
+  ConfigRuntimeRefreshError,
+  configWriteCommittedSnapshot,
+  configWritePostCommitRollback,
+} from "./io.types.js";
 import { logConfigWarningsOnce } from "./io.warnings.js";
 import {
   ConfigWritePostCommitError,
@@ -340,7 +345,14 @@ export async function writeConfigFileFromContext(
   const hasMetaBefore = hasConfigMeta(snapshot.parsed);
   const hasMetaAfter = hasConfigMeta(stampedOutputConfig);
   const gatewayModeBefore = resolveGatewayMode(snapshot.resolved);
-  const sourceConfigForPreflight = context.resolveRuntimePreflightSourceConfig(stampedOutputConfig);
+  const includeFileHashes: Record<string, string> = {};
+  const includeFileTargets: Record<string, string> = {};
+  const sourceConfigForPreflight = context.resolveRuntimePreflightSourceConfig(
+    stampedOutputConfig,
+    includeFileHashes,
+    includeFileTargets,
+  );
+  const committedRevision = hashConfigRevision(json, includeFileHashes, includeFileTargets);
   // Compare resolved modes: an unchanged authored $include has no local mode literal.
   const gatewayModeAfter = resolveGatewayMode(sourceConfigForPreflight);
   const suspiciousReasons = resolveConfigWriteSuspiciousReasons({
@@ -620,6 +632,10 @@ export async function writeConfigFileFromContext(
       persistedHash: nextHash,
       persistedConfig: stampedOutputConfig,
       persistedSourceConfig: sourceConfigForPreflight,
+      [configWriteCommittedSnapshot]: {
+        hash: committedRevision,
+        sourceConfig: sourceConfigForPreflight,
+      },
       [configWritePostCommitRollback]: (assertCurrent) => {
         assertCurrent();
         restoreConfigSnapshotAuditRecord({

--- a/src/config/io.write.ts
+++ b/src/config/io.write.ts
@@ -5,7 +5,7 @@ import { resolveCronJobsStorePathFromConfig } from "../cron/store.js";
 import { isVerbose } from "../global-state.js";
 import { isVitestRuntimeEnv } from "../infra/env.js";
 import { formatErrorMessage } from "../infra/errors.js";
-import { replaceFileAtomic } from "../infra/replace-file.js";
+import { replaceFileAtomicSync } from "../infra/replace-file.js";
 import {
   getUpdateDoctorConfigWriteAuthority,
   assertUpdateDoctorConfigInputHash,
@@ -482,67 +482,44 @@ export async function writeConfigFileFromContext(
   let committed = false;
   let rollbackStatus: ConfigWriteRollbackStatus = "not-restored";
   try {
-    const beforeCommit = options.beforeCommit;
     const hasCapturedIncludes = Object.keys(includeFileHashes).length > 0;
-    const requiresAtomicRename = Boolean(beforeCommit) || hasCapturedIncludes;
+    options.assertConfigPathForWrite?.();
+    if (options.baseSnapshot) {
+      assertBaseSnapshotStillCurrent(snapshot, configPath, deps.fs);
+    }
+    if (deps.fs.existsSync(configPath)) {
+      await maintainConfigBackups(configPath, deps.fs.promises, options.assertConfigPathForWrite);
+    }
+    if (options.baseSnapshot) {
+      assertBaseSnapshotStillCurrent(snapshot, configPath, deps.fs);
+    }
+    options.assertConfigPathForWrite?.();
+    await cronOwnerRefusal?.recheck();
+    options.assertConfigPathForWrite?.();
+    warnIfJSON5CommentsWillBeStripped({
+      raw: snapshot.raw,
+      filePath: configPath,
+      warn: (message) => deps.logger.warn(message),
+      skipOutputLogs: options.skipOutputLogs,
+    });
+    await options.beforeCommit?.();
     const guardedFs = createGuardedConfigFileSystem(
       configPath,
       deps.fs,
       options.assertConfigPathForWrite,
+      options.baseSnapshot || hasCapturedIncludes
+        ? { snapshot, includeGraph: { hashes: includeFileHashes, targets: includeFileTargets } }
+        : undefined,
     );
-    const result = await replaceFileAtomic({
+    // Keep rename and copy publication in one turn after asynchronous preparation.
+    const result = replaceFileAtomicSync({
       filePath: configPath,
       content: json,
       dirMode: 0o700,
       mode: 0o600,
       tempPrefix: path.basename(configPath),
-      // fs-safe's copy fallback has no final authority hook. Guarded operations
-      // must publish by rename so a failed attempt cannot continue under stale authority.
-      copyFallbackOnPermissionError: !requiresAtomicRename,
-      fileSystem: requiresAtomicRename
-        ? {
-            promises: {
-              ...guardedFs.promises,
-              rename: async (source, destination) => {
-                await beforeCommit?.();
-                options.assertConfigPathForWrite?.();
-                if (options.baseSnapshot || hasCapturedIncludes) {
-                  assertBaseSnapshotStillCurrent(snapshot, configPath, deps.fs, {
-                    hashes: includeFileHashes,
-                    targets: includeFileTargets,
-                  });
-                }
-                return guardedFs.promises.rename(source, destination);
-              },
-            },
-          }
-        : guardedFs,
-      beforeRename: async () => {
-        options.assertConfigPathForWrite?.();
-        if (options.baseSnapshot) {
-          assertBaseSnapshotStillCurrent(snapshot, configPath, deps.fs);
-        }
-        if (deps.fs.existsSync(configPath)) {
-          await maintainConfigBackups(
-            configPath,
-            deps.fs.promises,
-            options.assertConfigPathForWrite,
-          );
-        }
-        if (options.baseSnapshot) {
-          assertBaseSnapshotStillCurrent(snapshot, configPath, deps.fs);
-        }
-        options.assertConfigPathForWrite?.();
-        await cronOwnerRefusal?.recheck();
-        options.assertConfigPathForWrite?.();
-        // Warn only after backup and config-owner checks succeed.
-        warnIfJSON5CommentsWillBeStripped({
-          raw: snapshot.raw,
-          filePath: configPath,
-          warn: (message) => deps.logger.warn(message),
-          skipOutputLogs: options.skipOutputLogs,
-        });
-      },
+      copyFallbackOnPermissionError: true,
+      fileSystem: guardedFs,
     });
     committed = true;
     try {

--- a/src/config/io.write.ts
+++ b/src/config/io.write.ts
@@ -483,6 +483,8 @@ export async function writeConfigFileFromContext(
   let rollbackStatus: ConfigWriteRollbackStatus = "not-restored";
   try {
     const beforeCommit = options.beforeCommit;
+    const hasCapturedIncludes = Object.keys(includeFileHashes).length > 0;
+    const requiresAtomicRename = Boolean(beforeCommit) || hasCapturedIncludes;
     const guardedFs = createGuardedConfigFileSystem(
       configPath,
       deps.fs,
@@ -496,16 +498,19 @@ export async function writeConfigFileFromContext(
       tempPrefix: path.basename(configPath),
       // fs-safe's copy fallback has no final authority hook. Guarded operations
       // must publish by rename so a failed attempt cannot continue under stale authority.
-      copyFallbackOnPermissionError: !beforeCommit,
-      fileSystem: beforeCommit
+      copyFallbackOnPermissionError: !requiresAtomicRename,
+      fileSystem: requiresAtomicRename
         ? {
             promises: {
               ...guardedFs.promises,
               rename: async (source, destination) => {
-                await beforeCommit();
+                await beforeCommit?.();
                 options.assertConfigPathForWrite?.();
-                if (options.baseSnapshot) {
-                  assertBaseSnapshotStillCurrent(snapshot, configPath, deps.fs);
+                if (options.baseSnapshot || hasCapturedIncludes) {
+                  assertBaseSnapshotStillCurrent(snapshot, configPath, deps.fs, {
+                    hashes: includeFileHashes,
+                    targets: includeFileTargets,
+                  });
                 }
                 return guardedFs.promises.rename(source, destination);
               },

--- a/src/config/mutate.test.ts
+++ b/src/config/mutate.test.ts
@@ -15,6 +15,7 @@ import {
 import { hashConfigIncludeRaw } from "./includes.js";
 import { createConfigIO as createActualConfigIO } from "./io.factory.js";
 import type { ConfigWriteOptions } from "./io.js";
+import { configWriteCommittedSnapshot } from "./io.types.js";
 import {
   ConfigMutationConflictError,
   resolveConfigIncludeWriteBoundary,
@@ -685,20 +686,23 @@ describe("config mutate helpers", () => {
       }),
   );
 
-  it("reuses a provided snapshot and write options for replace", async () => {
+  it("replaceConfigFile preserves a legacy void writer's snapshot and write options", async () => {
     const snapshot = createSnapshot({
       hash: "hash-1",
       sourceConfig: { gateway: { auth: { mode: "token" } } },
     });
 
-    await replaceConfigFile({
+    const result = await replaceConfigFile({
       baseHash: snapshot.hash,
       nextConfig: { gateway: { auth: { mode: "token", token: "minted" } } },
       snapshot,
       writeOptions: { expectedConfigPath: snapshot.path },
     });
 
-    expect(ioMocks.readConfigFileSnapshotForWrite).toHaveBeenCalledAfter(ioMocks.writeConfigFile);
+    expect(result.persistedHash).toBeNull();
+    expect(result.nextConfig).toEqual({
+      gateway: { auth: { mode: "token", token: "minted" } },
+    });
     expect(ioMocks.writeConfigFile).toHaveBeenCalledWith(
       { gateway: { auth: { mode: "token", token: "minted" } } },
       {
@@ -998,7 +1002,7 @@ describe("config mutate helpers", () => {
     );
   });
 
-  it("returns config and revision from the same post-write snapshot", async () => {
+  it("replaceConfigFile returns the committed snapshot after an external edit", async () => {
     const snapshot = createSnapshot({
       hash: "hash-persisted",
       sourceConfig: { gateway: { auth: { mode: "token" } } },
@@ -1009,6 +1013,10 @@ describe("config mutate helpers", () => {
     ioMocks.writeConfigFile.mockResolvedValue({
       persistedSourceConfig,
       persistedHash: "hash-after",
+      [configWriteCommittedSnapshot]: {
+        hash: "committed-revision",
+        sourceConfig: { gateway: { auth: { mode: "token", token: "minted" } } },
+      },
       persistedConfig: {
         gateway: { auth: { mode: "token", token: "minted" } },
         meta: { lastTouchedVersion: "test" },
@@ -1029,10 +1037,10 @@ describe("config mutate helpers", () => {
       writeOptions: { expectedConfigPath: snapshot.path },
     });
 
-    expect(result.persistedHash).toBe("newer-hash");
+    expect(result.persistedHash).toBe("committed-revision");
     expect(result.persistedSourceConfig).toBe(persistedSourceConfig);
     expect(result.nextConfig).toEqual({
-      gateway: { auth: { mode: "token", token: "newer" } },
+      gateway: { auth: { mode: "token", token: "minted" } },
     });
   });
 

--- a/src/config/mutate.ts
+++ b/src/config/mutate.ts
@@ -54,6 +54,7 @@ import {
   rejectConfigNonFiniteNumbers,
   resolveManagedRuntimeEnvBaseline,
 } from "./io.read-helpers.js";
+import { configWriteCommittedSnapshot } from "./io.types.js";
 import { ConfigWritePostCommitError, type ConfigWriteRollbackStatus } from "./io.write-errors.js";
 import { injectExplicitlySetPaths, projectConfigWriteSource } from "./io.write-prepare.js";
 import { warnIfJSON5CommentsWillBeStripped } from "./json5-comments.js";
@@ -1199,24 +1200,10 @@ async function replaceConfigFileUnlocked(
       nextConfig,
       fallbackWriteOptions,
     );
-    const persisted = await readConfigSnapshotForMutation({
-      ownedConfigPathForWrite: snapshot.path,
-      io: params.io,
-      writeOptions: mergedWriteOptions,
-    });
-    if (!persisted.snapshot.exists || !persisted.snapshot.valid) {
-      throw new ConfigWritePostCommitError({
-        configPath: snapshot.path,
-        rollbackStatus: "not-restored",
-        cause: createInvalidConfigError(
-          snapshot.path,
-          formatInvalidConfigDetails(persisted.snapshot.issues),
-        ),
-      });
-    }
+    const committed = written?.[configWriteCommittedSnapshot];
     writeResult = {
-      persistedHash: resolveConfigSnapshotHash(persisted.snapshot),
-      persistedConfig: persisted.snapshot.sourceConfig,
+      persistedHash: committed?.hash ?? written?.persistedHash ?? null,
+      persistedConfig: committed?.sourceConfig ?? written?.persistedConfig ?? nextConfig,
       persistedSourceConfig: written?.persistedSourceConfig,
     };
   }

--- a/src/gateway/server-claws-monitors.test.ts
+++ b/src/gateway/server-claws-monitors.test.ts
@@ -1,5 +1,6 @@
 import { spawn } from "node:child_process";
 import { once } from "node:events";
+import fsNode from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -581,14 +582,14 @@ describe("Claw serving monitor cleanup", () => {
           BEFORE DELETE ON cron_jobs WHEN OLD.agent_id = 'worker'
           BEGIN SELECT RAISE(ABORT, 'synthetic monitor persistence failure'); END`);
       }
-      const rename = fs.rename.bind(fs);
+      const renameSync = fsNode.renameSync.bind(fsNode);
       const writeFailure =
         failure === "config-write"
-          ? vi.spyOn(fs, "rename").mockImplementation(async (...args) => {
+          ? vi.spyOn(fsNode, "renameSync").mockImplementation((...args) => {
               if (args[1] === current.state.configPath) {
                 throw new Error("synthetic config persistence failure");
               }
-              await rename(...args);
+              renameSync(...args);
             })
           : undefined;
       let result: Awaited<ReturnType<typeof current.apply>>;

--- a/src/gateway/server-methods/config-write-flow.ts
+++ b/src/gateway/server-methods/config-write-flow.ts
@@ -270,8 +270,7 @@ export async function commitGatewayConfigWrite(params: {
   return {
     path: resolveGatewayConfigPath(params.snapshot),
     config: result.nextConfig,
-    // Persisted hash of the re-read file (resolveConfigSnapshotHash), i.e.
-    // exactly what a follow-up config.get reports — writers ack against it.
+    // Acknowledge this commit; a later config.get can observe an external edit.
     hash: result.persistedHash,
     ...(application
       ? {

--- a/src/gateway/server-methods/config.ts
+++ b/src/gateway/server-methods/config.ts
@@ -949,8 +949,7 @@ export const configHandlers: GatewayRequestHandlers = {
       {
         ok: true,
         path: writeResult.path,
-        // Additive ack hash: matches the hash config.get would report for the
-        // persisted bytes, so writers can adopt it without a reload.
+        // Writers adopt the committed revision without a reload.
         ...(writeResult.hash
           ? { hash: context.configRevisionProjector.projectRawHash(writeResult.hash) }
           : {}),

--- a/src/gateway/server.config-patch.test.ts
+++ b/src/gateway/server.config-patch.test.ts
@@ -521,7 +521,45 @@ describe("gateway config methods", () => {
     },
   );
 
-  it("config.set pairs the canonical config and revision while another writer waits", async () => {
+  it("config.set acknowledges an include config when an external edit invalidates the reread", async () => {
+    const configFactory = await import("../config/io.factory.js");
+    const original = await getCurrentConfigObject();
+    await writeJsonFile(path.join(path.dirname(original.path), "logging.json"), { level: "info" });
+    await writeJsonFile(original.path, {
+      ...original.config,
+      logging: { $include: "logging.json" },
+      gateway: { reload: { mode: "off" } },
+    });
+    invalidateConfigGetResponseCache();
+    const draft = await getCurrentConfigObject();
+    let committed: Awaited<ReturnType<typeof getCurrentConfigObject>> | undefined;
+    const createIO = configFactory.createConfigIO;
+    vi.spyOn(configFactory, "createConfigIO").mockImplementation((options) => {
+      const io = createIO(options);
+      return {
+        ...io,
+        writeConfigFile: async (...args) => {
+          const written = await io.writeConfigFile(...args);
+          if (io.configPath === original.path) {
+            invalidateConfigGetResponseCache();
+            committed = await getCurrentConfigObject();
+            await fs.writeFile(original.path, "{ external editor incomplete\n");
+          }
+          return written;
+        },
+      };
+    });
+    const result = await rpcReq(requireClient(), "config.set", {
+      raw: JSON.stringify({ ...draft.config, ui: { prefs: { locale: "fr" } } }),
+      baseHash: draft.hash,
+    });
+    expect(result.ok, result.error?.message).toBe(true);
+    expect(committed?.config).toMatchObject({ logging: { level: "info" } });
+    expect(result.payload).toMatchObject({ config: committed?.config, hash: committed?.hash });
+    expect(await fs.readFile(original.path, "utf8")).toBe("{ external editor incomplete\n");
+  });
+
+  it("config.set pairs the committed config and revision while another writer waits", async () => {
     const configFactory = await import("../config/io.factory.js");
     const { KeyedAsyncQueue } = await import("../plugin-sdk/keyed-async-queue.js");
     const original = await getCurrentConfigObject();
@@ -537,7 +575,6 @@ describe("gateway config methods", () => {
     const canonicalRead = createDeferredCore();
     const releaseCanonicalRead = createDeferredCore();
     const competingLock = createDeferredCore();
-    let rootWritten = false;
     let pauseCanonicalRead = true;
     let observeCompetingLock = false;
     let competingWriterStarted = false;
@@ -545,7 +582,7 @@ describe("gateway config methods", () => {
     // oxlint-disable-next-line typescript/unbound-method -- The observer calls the original with its queue receiver.
     const enqueue = KeyedAsyncQueue.prototype.enqueue;
 
-    // Retain real IO and locks; pause only the post-write receipt read so the
+    // Retain real IO and locks; pause only the committed writer return so the
     // competing authenticated request has a deterministic contention window.
     const ioObservation = vi
       .spyOn(configFactory, "createConfigIO")
@@ -555,18 +592,12 @@ describe("gateway config methods", () => {
           ...io,
           writeConfigFile: async (...args) => {
             const written = await io.writeConfigFile(...args);
-            if (io.configPath === original.path) {
-              rootWritten = true;
-            }
-            return written;
-          },
-          readConfigFileSnapshotForWrite: async (...args) => {
-            if (io.configPath === original.path && rootWritten && pauseCanonicalRead) {
+            if (io.configPath === original.path && pauseCanonicalRead) {
               pauseCanonicalRead = false;
               canonicalRead.resolve();
               await releaseCanonicalRead.promise;
             }
-            return await io.readConfigFileSnapshotForWrite(...args);
+            return written;
           },
         };
       });
@@ -623,6 +654,8 @@ describe("gateway config methods", () => {
       // distinguishable from both the submitted config and the writer result.
       const written = JSON.parse(await fs.readFile(original.path, "utf8"));
       expect(written.logging.level).toBe("debug");
+      invalidateConfigGetResponseCache();
+      const committed = await getCurrentConfigObject();
       await writeJsonFile(original.path, { ...written, ui: { prefs: { locale: "fr" } } });
       invalidateConfigGetResponseCache();
       const canonical = await getCurrentConfigObject();
@@ -667,8 +700,8 @@ describe("gateway config methods", () => {
       expect(secondResult.ok, secondResult.error?.message).toBe(true);
       expect(competingWriterStarted).toBe(true);
       expect({ config: firstResult.payload?.config, hash: firstResult.payload?.hash }).toEqual({
-        config: canonical.config,
-        hash: canonical.hash,
+        config: committed.config,
+        hash: committed.hash,
       });
       const after = await getCurrentConfigObject();
       expect({ config: secondResult.payload?.config, hash: secondResult.payload?.hash }).toEqual({

--- a/src/gateway/server.config-patch.test.ts
+++ b/src/gateway/server.config-patch.test.ts
@@ -521,6 +521,76 @@ describe("gateway config methods", () => {
     },
   );
 
+  it.each(["content", "target", "missing"] as const)(
+    "config.set rejects include %s changes during runtime preflight before committing",
+    async (change) => {
+      const configFactory = await import("../config/io.factory.js");
+      const original = await getCurrentConfigObject();
+      const directory = path.dirname(original.path);
+      const first = path.join(directory, "logging-first");
+      const second = path.join(directory, "logging-second");
+      const current = path.join(directory, "logging-current");
+      await fs.mkdir(first);
+      await fs.mkdir(second);
+      await writeJsonFile(path.join(first, "logging.json"), { level: "info" });
+      await writeJsonFile(path.join(second, "logging.json"), { level: "info" });
+      await fs.symlink(first, current, "junction");
+      await writeJsonFile(original.path, {
+        ...original.config,
+        logging: { $include: "logging-current/logging.json" },
+        gateway: { reload: { mode: "off" } },
+      });
+      invalidateConfigGetResponseCache();
+      const draft = await getCurrentConfigObject();
+      const rootBefore = await fs.readFile(original.path, "utf8");
+      const createIO = configFactory.createConfigIO;
+      vi.spyOn(configFactory, "createConfigIO").mockImplementation((options) => {
+        const io = createIO(options);
+        return {
+          ...io,
+          writeConfigFile: (config, writeOptions) =>
+            io.writeConfigFile(config, {
+              ...writeOptions,
+              preCommitRuntimePreflight: async (source) => {
+                await writeOptions?.preCommitRuntimePreflight?.(source);
+                if (change === "content") {
+                  await writeJsonFile(path.join(first, "logging.json"), { level: "debug" });
+                } else if (change === "missing") {
+                  await fs.unlink(path.join(first, "logging.json"));
+                } else {
+                  await fs.unlink(current);
+                  await fs.symlink(second, current, "junction");
+                }
+              },
+            }),
+        };
+      });
+
+      const result = await rpcReq(requireClient(), "config.set", {
+        raw: JSON.stringify({ ...draft.config, ui: { prefs: { locale: "fr" } } }),
+        baseHash: draft.hash,
+      });
+
+      expect(result.ok).toBe(false);
+      expect(result.error?.message).toContain("included config");
+      expect(await fs.readFile(original.path, "utf8")).toBe(rootBefore);
+      if (change === "missing") {
+        await expect(fs.readFile(path.join(current, "logging.json"), "utf8")).rejects.toMatchObject(
+          {
+            code: "ENOENT",
+          },
+        );
+      } else {
+        expect(JSON.parse(await fs.readFile(path.join(current, "logging.json"), "utf8"))).toEqual({
+          level: change === "content" ? "debug" : "info",
+        });
+      }
+      expect(await fs.realpath(current)).toBe(
+        await fs.realpath(change === "target" ? second : first),
+      );
+    },
+  );
+
   it("config.set acknowledges an include config when an external edit invalidates the reread", async () => {
     const configFactory = await import("../config/io.factory.js");
     const original = await getCurrentConfigObject();

--- a/src/gateway/server.config-patch.test.ts
+++ b/src/gateway/server.config-patch.test.ts
@@ -522,13 +522,24 @@ describe("gateway config methods", () => {
     },
   );
 
-  it.each(
-    (["EPERM", "EEXIST"] as const).flatMap((code) =>
-      (["unchanged", "changed"] as const).map((includedContent) => ({ code, includedContent })),
+  it.each([
+    ...(["EPERM", "EEXIST"] as const).flatMap((code) =>
+      (["unchanged", "changed"] as const).flatMap((includedContent) =>
+        (["retained", "deleted"] as const).map((rootState) => ({
+          code,
+          includedContent,
+          rootState,
+        })),
+      ),
     ),
-  )(
-    "config.set handles $code copy fallback with $includedContent included content",
-    async ({ code, includedContent }) => {
+    ...(["EPERM", "EEXIST"] as const).map((code) => ({
+      code,
+      includedContent: "changed" as const,
+      rootState: "removed-by-writer" as const,
+    })),
+  ])(
+    "config.set handles $code copy fallback with $includedContent included content and $rootState root",
+    async ({ code, includedContent, rootState }) => {
       const original = await getCurrentConfigObject();
       const includePath = path.join(path.dirname(original.path), "logging.json");
       await writeJsonFile(includePath, { level: "info" });
@@ -547,11 +558,23 @@ describe("gateway config methods", () => {
           return rename(source, destination);
         }
         renameDenied = true;
-        if (includedContent === "changed") {
+        if (rootState === "deleted") {
+          fsNode.unlinkSync(original.path);
+        }
+        if (includedContent === "changed" && rootState !== "removed-by-writer") {
           fsNode.writeFileSync(includePath, JSON.stringify({ level: "debug" }));
         }
         throw Object.assign(new Error("rename denied"), { code });
       });
+      if (rootState === "removed-by-writer") {
+        const remove = fsNode.rmSync;
+        vi.spyOn(fsNode, "rmSync").mockImplementation((filePath, options) => {
+          remove(filePath, options);
+          if (filePath === original.path) {
+            fsNode.writeFileSync(includePath, JSON.stringify({ level: "debug" }));
+          }
+        });
+      }
 
       const result = await rpcReq(requireClient(), "config.set", {
         raw: JSON.stringify({ ...draft.config, ui: { prefs: { locale: "fr" } } }),
@@ -559,11 +582,20 @@ describe("gateway config methods", () => {
       });
 
       expect(renameDenied).toBe(true);
-      if (includedContent === "changed") {
+      if (includedContent === "changed" || rootState === "deleted") {
         expect(result.ok).toBe(false);
-        expect(result.error?.message).toContain("included config");
-        expect(await fs.readFile(original.path, "utf8")).toBe(rootBefore);
-        expect(JSON.parse(await fs.readFile(includePath, "utf8"))).toEqual({ level: "debug" });
+        expect(result.error?.code).toBe("INVALID_REQUEST");
+        expect(result.error?.message).toContain(
+          includedContent === "changed" ? "included config" : "config changed since last load",
+        );
+        if (rootState !== "retained") {
+          await expect(fs.stat(original.path)).rejects.toMatchObject({ code: "ENOENT" });
+        } else {
+          expect(await fs.readFile(original.path, "utf8")).toBe(rootBefore);
+        }
+        expect(JSON.parse(await fs.readFile(includePath, "utf8"))).toEqual({
+          level: includedContent === "changed" ? "debug" : "info",
+        });
       } else {
         expect(result.ok, result.error?.message).toBe(true);
         invalidateConfigGetResponseCache();

--- a/src/gateway/server.config-patch.test.ts
+++ b/src/gateway/server.config-patch.test.ts
@@ -1,5 +1,6 @@
 // Config patch tests cover control-UI config edits, secret-ref writes, auth
 // profile persistence, and rate limiting through a real Gateway owner.
+import fsNode from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
@@ -517,6 +518,65 @@ describe("gateway config methods", () => {
         expect(operations?.[0]?.changedPaths).toBeUndefined();
       } else {
         expect(await fs.readFile(includePath, "utf8")).toBe(includeBefore);
+      }
+    },
+  );
+
+  it.each(
+    (["EPERM", "EEXIST"] as const).flatMap((code) =>
+      (["unchanged", "changed"] as const).map((includedContent) => ({ code, includedContent })),
+    ),
+  )(
+    "config.set handles $code copy fallback with $includedContent included content",
+    async ({ code, includedContent }) => {
+      const original = await getCurrentConfigObject();
+      const includePath = path.join(path.dirname(original.path), "logging.json");
+      await writeJsonFile(includePath, { level: "info" });
+      await writeJsonFile(original.path, {
+        ...original.config,
+        logging: { $include: "logging.json" },
+        gateway: { reload: { mode: "off" } },
+      });
+      invalidateConfigGetResponseCache();
+      const draft = await getCurrentConfigObject();
+      const rootBefore = await fs.readFile(original.path, "utf8");
+      const rename = fsNode.renameSync;
+      let renameDenied = false;
+      vi.spyOn(fsNode, "renameSync").mockImplementation((source, destination) => {
+        if (destination !== original.path) {
+          return rename(source, destination);
+        }
+        renameDenied = true;
+        if (includedContent === "changed") {
+          fsNode.writeFileSync(includePath, JSON.stringify({ level: "debug" }));
+        }
+        throw Object.assign(new Error("rename denied"), { code });
+      });
+
+      const result = await rpcReq(requireClient(), "config.set", {
+        raw: JSON.stringify({ ...draft.config, ui: { prefs: { locale: "fr" } } }),
+        baseHash: draft.hash,
+      });
+
+      expect(renameDenied).toBe(true);
+      if (includedContent === "changed") {
+        expect(result.ok).toBe(false);
+        expect(result.error?.message).toContain("included config");
+        expect(await fs.readFile(original.path, "utf8")).toBe(rootBefore);
+        expect(JSON.parse(await fs.readFile(includePath, "utf8"))).toEqual({ level: "debug" });
+      } else {
+        expect(result.ok, result.error?.message).toBe(true);
+        invalidateConfigGetResponseCache();
+        const committed = await getCurrentConfigObject();
+        expect(result.payload).toMatchObject({ config: committed.config, hash: committed.hash });
+        expect(committed.config).toMatchObject({
+          logging: { level: "info" },
+          ui: { prefs: { locale: "fr" } },
+        });
+        expect(JSON.parse(await fs.readFile(original.path, "utf8"))).toMatchObject({
+          logging: { $include: "logging.json" },
+        });
+        expect(JSON.parse(await fs.readFile(includePath, "utf8"))).toEqual({ level: "info" });
       }
     },
   );


### PR DESCRIPTION
Related: #145660, #145939.

## What Problem This Solves

Fixes an issue where saving configuration could report failure after the write had already committed, if another edit made the subsequent read invalid.

## Why This Change Was Made

The configuration writer returns the source configuration and revision it committed. The same publication guard checks root and included files before replacement, removal and creation. Runtime application remains a separate outcome.

## User Impact

Successful saves acknowledge the committed value while later edits remain visible and stale writes still conflict. A conflict during the non-atomic copy fallback can leave the root configuration absent; its backup remains available. No configuration format or migration changes.

Consumers: configuration write responses and their command, setup and Settings continuations use the committed configuration/revision pair.

## Evidence

Registered configuration set, patch and apply tests cover acknowledgements, conflicting edits, included files and fallback races. Command-line saves preserve includes. Final checks passed 76 Gateway tests, 58 startup corpus cases and 323 configuration tests. Filesystem failures were injected; older-release replay remained unverified.
