### PR TITLE
fix(anthropic): honor configured output token caps

### DIFF
--- a/extensions/anthropic/index.test.ts
+++ b/extensions/anthropic/index.test.ts
@@ -1192,6 +1192,39 @@ describe("anthropic provider replay hooks", () => {
     }
   });
 
+  it.each([
+    { maxTokensSource: "configured" as const, expectedMaxTokens: 128 },
+    { maxTokensSource: "discovered" as const, expectedMaxTokens: 128_000 },
+  ])(
+    "normalizes modern output limits using $maxTokensSource provenance",
+    async ({ maxTokensSource, expectedMaxTokens }) => {
+      const provider = await registerSingleProviderPlugin(anthropicPlugin);
+      const model: ProviderRuntimeModel = {
+        id: "claude-sonnet-4-6",
+        name: "Claude Sonnet 4.6",
+        provider: "anthropic",
+        api: "anthropic-messages",
+        baseUrl: "https://api.anthropic.com",
+        reasoning: true,
+        input: ["text", "image"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 200_000,
+        maxTokens: 128,
+        maxTokensSource,
+      };
+
+      const normalized =
+        provider.normalizeResolvedModel?.({
+          provider: "anthropic",
+          modelId: model.id,
+          model,
+        }) ?? model;
+
+      expect(normalized.maxTokens).toBe(expectedMaxTokens);
+      expect(normalized.maxTokensSource).toBe(maxTokensSource);
+    },
+  );
+
   it("keeps bare Claude CLI context plan-safe and honors explicit 1M variants", async () => {
     const provider = await registerSingleProviderPlugin(anthropicPlugin);
     const baseModel = {

--- a/extensions/anthropic/register.runtime.ts
+++ b/extensions/anthropic/register.runtime.ts
@@ -567,7 +567,11 @@ function applyAnthropicModernMaxTokens(params: {
   modelId: string;
   model: ProviderRuntimeModel;
 }): ProviderRuntimeModel | undefined {
-  if (!isAnthropic128kOutputModel(params.modelId)) {
+  // Catalog defaults must not raise an operator-configured output cap.
+  if (
+    params.model.maxTokensSource === "configured" ||
+    !isAnthropic128kOutputModel(params.modelId)
+  ) {
     return undefined;
   }
   if ((params.model.maxTokens ?? 0) >= ANTHROPIC_MODERN_MAX_OUTPUT_TOKENS) {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users configuring a smaller Anthropic output-token limit could have it silently raised to 128,000 tokens. For example, a Claude Sonnet 4.6 model configured with `maxTokens: 128` resolved to `128000`, and `infer model run --local` used that larger value as its request budget.

## Why This Change Was Made

Anthropic's catalog correction now preserves output caps already marked as configured by the host. This covers per-model limits and provider defaults while retaining the existing correction for discovered catalog metadata. Request-level thinking-budget behavior is unchanged.

## User Impact

Configured Anthropic output limits are honored as documented, including small limits used for bounded inference calls. No configuration changes are required.

## Evidence

- The registered-provider regression failed before the fix with `128000` instead of `128`; the discovered-default case passed.
- The full Anthropic extension lane passes: 603 tests across 39 files.
- Current-base changed-scope checks pass, including extension production/test typechecks and lint.
- Independent Codex autoreview is scoped-clean through P2.
- [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34697185083) passed, including `openclaw/ci-gate`.
- The built CLI at `e01b515596c1190f827d5d46ef9d17b2d038ce20` passed the isolated, network-blocked request proof below.

### Built CLI request proof

The actual `infer model run --local --agent offline --model anthropic/claude-sonnet-4-6 --thinking off` command used a synthetic prompt and configuration with a per-model cap of 128. An observer on the existing public transport-host seam intercepted the prepared request before provider HTTP:

```text
selected model maxTokens: 128
native transport factory calls: 1
intercepted requests: 1
request body: 235 bytes; exact expected-body match
body SHA256: bb3f1c4799c61ce0e876f95a698f73d0eb47b5ed04850bd929812430612ab986
native fetch calls: 0
network denials: {}
provider request sent: false
CLI exit: 1 (intentional pre-HTTP stop; reported as Connection error; signal null; not forced)
proof exit: 0
```

The serialized body contains `"max_tokens":128`, and both execution units closed with verified kernel closure. This proves the configured cap reaches the built CLI's prepared completion request. It does not exercise provider generation or establish the cause of a production incident; no production deployment is part of this PR.
