### PR TITLE
fix(gateway): retain late events after agent cancellation

### DIFF
--- a/src/gateway/server-chat.agent-events.test.ts
+++ b/src/gateway/server-chat.agent-events.test.ts
@@ -6076,9 +6076,6 @@ describe("agent event handler", () => {
 
       handler(received);
 
-      expect(resolveSessionKeyForRun.mock.calls).toEqual(
-        Array.from({ length: stream === "lifecycle" ? 2 : 1 }, () => [runId, { agentId: "work" }]),
-      );
       if (hidden) {
         expect(broadcast).not.toHaveBeenCalled();
         expect(nodeSendToSession).not.toHaveBeenCalled();

--- a/src/gateway/server-chat.retired-projection.test.ts
+++ b/src/gateway/server-chat.retired-projection.test.ts
@@ -1,0 +1,287 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  emitAgentEvent,
+  getAgentEventLifecycleGeneration,
+  onAgentRuntimeEvent,
+  resetAgentEventsForTest,
+  withAgentRunLifecycleGeneration,
+} from "../infra/agent-events.js";
+import { clearAgentRunContext, registerAgentRunContext } from "../infra/agent-run-registry.js";
+import { registerChatRun } from "./server-chat.agent-events.test-helpers.js";
+import {
+  createAgentEventHandler,
+  createChatRunState,
+  createSessionEventSubscriberRegistry,
+  createSessionMessageSubscriberRegistry,
+} from "./server-chat.js";
+
+const sessionFixture = vi.hoisted(() => ({ updatedAt: 50 }));
+
+vi.mock("../config/io.js", () => ({ getRuntimeConfig: () => ({}) }));
+vi.mock("../infra/heartbeat-visibility.js", () => ({
+  resolveHeartbeatVisibility: () => ({ showOk: false, showAlerts: true, useIndicator: true }),
+}));
+vi.mock("./session-utils.js", async () => {
+  const { resolveSessionStoreIdentity } = await import("./session-store-key.js");
+  return {
+    loadGatewaySessionEntryReadOnly: (sessionKey: string, options?: { agentId?: string }) => {
+      const cfg = { agents: { entries: { main: {}, delivery: {} } } };
+      const identity = resolveSessionStoreIdentity({ cfg, sessionKey, agentId: options?.agentId });
+      return {
+        cfg,
+        ...identity,
+        store: {},
+        entry: { sessionId: "session", verboseLevel: "off", updatedAt: sessionFixture.updatedAt },
+      };
+    },
+    loadGatewaySessionLifecycleSnapshot: () => ({ row: null }),
+  };
+});
+
+describe("retired execution event projection", () => {
+  beforeEach(() => {
+    resetAgentEventsForTest();
+    sessionFixture.updatedAt = 50;
+  });
+
+  function createReceiver() {
+    const broadcast = vi.fn();
+    const broadcastToConnIds = vi.fn();
+    const nodeSendToSession = vi.fn();
+    const chatRunState = createChatRunState();
+    const sessionMessageSubscribers = createSessionMessageSubscriberRegistry();
+    sessionMessageSubscribers.subscribe("selected", "agent:delivery:late");
+    const handler = createAgentEventHandler({
+      broadcast,
+      broadcastToConnIds,
+      nodeSendToSession,
+      chatRunState,
+      agentRunSeq: new Map(),
+      toolEventRecipients: chatRunState.toolEventRecipients,
+      sessionMessageSubscribers,
+      sessionEventSubscribers: createSessionEventSubscriberRegistry(),
+      clearAgentRunContext,
+      resolveSessionKeyForRun: () => {
+        throw new Error("Event lost its producer route");
+      },
+      loadGatewaySessionLifecycleSnapshotForEvent: () => ({ row: null }),
+      persistGatewaySessionLifecycleEventForEvent: async () => {},
+    });
+    const errors: unknown[] = [];
+    const observe = (event: Parameters<typeof handler>[0]) => {
+      try {
+        handler(event);
+      } catch (error) {
+        errors.push(error);
+      }
+    };
+    return {
+      handler,
+      observe,
+      errors,
+      broadcast,
+      broadcastToConnIds,
+      nodeSendToSession,
+      chatRunState,
+    };
+  }
+
+  it.each([false, true])("preserves hidden heartbeat tool suppression (%s)", (isHeartbeat) => {
+    const receiver = createReceiver();
+    const unsubscribe = onAgentRuntimeEvent(receiver.observe);
+    try {
+      withAgentRunLifecycleGeneration(getAgentEventLifecycleGeneration(), () => {
+        registerAgentRunContext("late", {
+          agentId: "delivery",
+          sessionKey: "agent:delivery:late",
+          sessionId: "session",
+          isControlUiVisible: false,
+          projectSessionMessages: true,
+          isHeartbeat,
+          verboseLevel: "full",
+          registeredAt: 100,
+        });
+        clearAgentRunContext("late");
+        emitAgentEvent({
+          runId: "late",
+          stream: "tool",
+          data: {
+            phase: "result",
+            name: "read",
+            toolCallId: "finished",
+            result: { value: "retained" },
+          },
+        });
+      });
+    } finally {
+      unsubscribe();
+      receiver.handler.dispose();
+      expect(receiver.errors).toEqual([]);
+    }
+    const delivered = receiver.broadcastToConnIds.mock.calls.filter(([name]) => name === "agent");
+    expect(delivered).toHaveLength(isHeartbeat ? 0 : 1);
+    expect(receiver.broadcast).not.toHaveBeenCalled();
+  });
+
+  it("preserves run verbosity until a newer session preference replaces it", () => {
+    const receiver = createReceiver();
+    const unsubscribe = onAgentRuntimeEvent(receiver.observe);
+    try {
+      withAgentRunLifecycleGeneration(getAgentEventLifecycleGeneration(), () => {
+        registerAgentRunContext("verbose", {
+          agentId: "delivery",
+          sessionKey: "agent:delivery:late",
+          sessionId: "session",
+          verboseLevel: "full",
+          registeredAt: 100,
+        });
+        clearAgentRunContext("verbose");
+        emitAgentEvent({
+          runId: "verbose",
+          stream: "tool",
+          data: {
+            phase: "result",
+            name: "read",
+            toolCallId: "finished",
+            result: { value: "retained" },
+          },
+        });
+      });
+    } finally {
+      unsubscribe();
+      receiver.handler.dispose();
+      expect(receiver.errors).toEqual([]);
+    }
+    const delivered = receiver.nodeSendToSession.mock.calls.filter(([, name]) => name === "agent");
+    expect(delivered).toHaveLength(1);
+    expect(delivered[0]?.[2]).toMatchObject({ data: { result: { value: "retained" } } });
+  });
+
+  const alert = `Service outage requires action. ${"Repair is still required. ".repeat(20)}`;
+  it.each([
+    { text: "HEARTBEAT_OK", expected: undefined },
+    { text: `HEARTBEAT_OK ${alert}`, expected: alert.trim() },
+  ])("preserves heartbeat final ACK/alert policy after cleanup ($text)", ({ text, expected }) => {
+    const receiver = createReceiver();
+    const unsubscribe = onAgentRuntimeEvent(receiver.observe);
+    try {
+      withAgentRunLifecycleGeneration(getAgentEventLifecycleGeneration(), () => {
+        registerAgentRunContext("heartbeat", {
+          agentId: "delivery",
+          sessionKey: "agent:delivery:late",
+          sessionId: "session",
+          isHeartbeat: true,
+        });
+        clearAgentRunContext("heartbeat");
+        emitAgentEvent({ runId: "heartbeat", stream: "assistant", data: { text, delta: text } });
+        emitAgentEvent({ runId: "heartbeat", stream: "lifecycle", data: { phase: "end" } });
+      });
+    } finally {
+      unsubscribe();
+      receiver.handler.dispose();
+      expect(receiver.errors).toEqual([]);
+    }
+    const chat = receiver.broadcast.mock.calls.filter(([name]) => name === "chat");
+    expect(chat.filter(([, payload]) => payload.state === "delta")).toEqual([]);
+    const final = chat.filter(([, payload]) => payload.state === "final");
+    expect(final).toHaveLength(1);
+    if (expected) {
+      expect(final[0]?.[1]).toMatchObject({ message: { content: [{ text: expected }] } });
+    } else {
+      expect(final[0]?.[1].message).toBeUndefined();
+    }
+  });
+
+  it.each([false, undefined])(
+    "keeps heartbeat alias suppression separate from source flags (%s)",
+    (sourceFlag) => {
+      const receiver = createReceiver();
+      const unsubscribe = onAgentRuntimeEvent(receiver.observe);
+      try {
+        withAgentRunLifecycleGeneration(getAgentEventLifecycleGeneration(), () => {
+          registerAgentRunContext("client", {
+            agentId: "delivery",
+            sessionKey: "agent:delivery:late",
+            isHeartbeat: true,
+          });
+          registerAgentRunContext("source", {
+            agentId: "delivery",
+            sessionKey: "agent:delivery:late",
+            isHeartbeat: sourceFlag,
+            verboseLevel: "full",
+          });
+          registerChatRun(receiver.chatRunState, "source", "agent:delivery:late", "client", {
+            agentId: "delivery",
+          });
+          emitAgentEvent({
+            runId: "source",
+            stream: "assistant",
+            data: { text: "A source event", delta: "A source event" },
+          });
+          emitAgentEvent({
+            runId: "source",
+            stream: "tool",
+            data: {
+              phase: "result",
+              name: "read",
+              toolCallId: "late",
+              result: { value: "retained" },
+            },
+          });
+        });
+      } finally {
+        unsubscribe();
+        receiver.handler.dispose();
+        expect(receiver.errors).toEqual([]);
+      }
+      const source = receiver.broadcast.mock.calls.find(
+        ([name, payload]) => name === "agent" && payload.stream === "assistant",
+      )?.[1];
+      expect(source).toBeDefined();
+      if (sourceFlag === undefined) {
+        expect(source).not.toHaveProperty("isHeartbeat");
+      } else {
+        expect(source).toHaveProperty("isHeartbeat", sourceFlag);
+      }
+      expect(
+        receiver.nodeSendToSession.mock.calls.filter(
+          ([, name, payload]) => name === "agent" && payload.stream === "tool",
+        ),
+      ).toEqual([]);
+    },
+  );
+
+  it("uses the selected agent for newer global-session verbosity", () => {
+    sessionFixture.updatedAt = 200;
+    const receiver = createReceiver();
+    const unsubscribe = onAgentRuntimeEvent(receiver.observe);
+    try {
+      withAgentRunLifecycleGeneration(getAgentEventLifecycleGeneration(), () => {
+        registerAgentRunContext("global-run", {
+          agentId: "delivery",
+          sessionKey: "global",
+          verboseLevel: "full",
+          registeredAt: 100,
+        });
+        clearAgentRunContext("global-run");
+        emitAgentEvent({
+          runId: "global-run",
+          stream: "tool",
+          data: {
+            phase: "result",
+            name: "read",
+            toolCallId: "late",
+            result: { value: "retained" },
+          },
+        });
+      });
+    } finally {
+      unsubscribe();
+      receiver.handler.dispose();
+      expect(receiver.errors).toEqual([]);
+    }
+    expect(receiver.nodeSendToSession.mock.calls.filter(([, name]) => name === "agent")).toEqual(
+      [],
+    );
+  });
+});

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -146,26 +146,25 @@ function projectToolSearchCodeEventForChannelPayload<T extends { data?: unknown 
   return { ...payload, data: projectedData };
 }
 
-function resolveHeartbeatContext(runId: string, sourceRunId?: string) {
+function resolveHeartbeatFlag(runId: string, sourceRunId?: string, captured?: boolean) {
   const primary = getAgentRunContext(runId);
-  if (primary?.isHeartbeat) {
-    return primary;
+  const source = sourceRunId && sourceRunId !== runId ? getAgentRunContext(sourceRunId) : primary;
+  if (primary?.isHeartbeat || source?.isHeartbeat) {
+    return true;
   }
-  if (sourceRunId && sourceRunId !== runId) {
-    const source = getAgentRunContext(sourceRunId);
-    if (source?.isHeartbeat) {
-      return source;
-    }
-  }
-  return primary;
+  // Captured source facts fill cleanup gaps; a live client heartbeat still wins.
+  return source ? primary?.isHeartbeat : (captured ?? primary?.isHeartbeat);
 }
 
 /**
  * Check if heartbeat ACK/noise should be hidden from interactive chat surfaces.
  */
-function shouldHideHeartbeatChatOutput(runId: string, sourceRunId?: string): boolean {
-  const runContext = resolveHeartbeatContext(runId, sourceRunId);
-  if (!runContext?.isHeartbeat) {
+function shouldHideHeartbeatChatOutput(
+  runId: string,
+  sourceRunId?: string,
+  captured?: boolean,
+): boolean {
+  if (!resolveHeartbeatFlag(runId, sourceRunId, captured)) {
     return false;
   }
 
@@ -177,10 +176,6 @@ function shouldHideHeartbeatChatOutput(runId: string, sourceRunId?: string): boo
     // Default to suppressing if we can't load config
     return true;
   }
-}
-
-function shouldSuppressHeartbeatToolEvents(runId: string, sourceRunId?: string): boolean {
-  return Boolean(resolveHeartbeatContext(runId, sourceRunId)?.isHeartbeat);
 }
 
 function shouldMirrorAssistantEventToHiddenSessionMessages(data: unknown): boolean {
@@ -204,8 +199,9 @@ function normalizeHeartbeatChatFinalText(params: {
   runId: string;
   sourceRunId?: string;
   text: string;
+  isHeartbeat?: boolean;
 }): { suppress: boolean; text: string } {
-  if (!shouldHideHeartbeatChatOutput(params.runId, params.sourceRunId)) {
+  if (!shouldHideHeartbeatChatOutput(params.runId, params.sourceRunId, params.isHeartbeat)) {
     return { suppress: false, text: params.text };
   }
 
@@ -800,6 +796,7 @@ export function createAgentEventHandler({
             {
               agentId: terminalAgentId,
               controlUiVisible: isControlUiVisible,
+              isHeartbeat: resolveHeartbeatFlag(clientRunId, evt.runId, evt.isHeartbeat),
               firstAssistantTimingEntry: finished,
               abortErrorMessage: readToolValidationErrorSummary(evt.data?.toolErrorSummary),
               yielded: yieldedWaiting ? true : undefined,
@@ -944,7 +941,11 @@ export function createAgentEventHandler({
     sourceRunId: string,
     seq: number,
     text: string,
-    opts?: { controlUiVisible?: boolean; firstAssistantTimingEntry?: ChatRunEntry },
+    opts?: {
+      controlUiVisible?: boolean;
+      firstAssistantTimingEntry?: ChatRunEntry;
+      isHeartbeat?: boolean;
+    },
   ) => {
     cancelPendingChatDeltaFlush(clientRunId);
     const run = chatRunState.getOrCreate(clientRunId);
@@ -1001,6 +1002,7 @@ export function createAgentEventHandler({
     seq: number,
     delayMs: number,
     controlUiVisible: boolean | undefined,
+    isHeartbeat: boolean | undefined,
   ) => {
     const run = chatRunState.getOrCreate(clientRunId);
     const flush = () => {
@@ -1010,7 +1012,10 @@ export function createAgentEventHandler({
         return;
       }
       const projected = chatRunState.resolveBuffer(clientRunId);
-      if (projected.suppress || shouldHideHeartbeatChatOutput(clientRunId, sourceRunId)) {
+      if (
+        projected.suppress ||
+        shouldHideHeartbeatChatOutput(clientRunId, sourceRunId, isHeartbeat)
+      ) {
         return;
       }
       broadcastChatDelta(sessionKey, agentId, clientRunId, sourceRunId, seq, projected.text, {
@@ -1027,7 +1032,7 @@ export function createAgentEventHandler({
     sourceRunId: string,
     seq: number,
     input: NonNullable<ReturnType<typeof resolveAssistantTextInput>>,
-    opts?: { controlUiVisible?: boolean; isCurrent?: () => boolean },
+    opts?: { controlUiVisible?: boolean; isCurrent?: () => boolean; isHeartbeat?: boolean },
   ) => {
     const run = chatRunState.getOrCreate(clientRunId);
     if (input.managedMediaUrls?.length) {
@@ -1065,12 +1070,16 @@ export function createAgentEventHandler({
         seq,
         LIVE_TEXT_PACING_MS - (now - run.deltaSentAt),
         opts?.controlUiVisible,
+        opts?.isHeartbeat,
       );
       return;
     }
     const projected = chatRunState.resolveBuffer(clientRunId);
     const mergedText = projected.text;
-    if (projected.suppress || shouldHideHeartbeatChatOutput(clientRunId, sourceRunId)) {
+    if (
+      projected.suppress ||
+      shouldHideHeartbeatChatOutput(clientRunId, sourceRunId, opts?.isHeartbeat)
+    ) {
       return;
     }
     broadcastChatDelta(sessionKey, agentId, clientRunId, sourceRunId, seq, mergedText, opts);
@@ -1079,7 +1088,7 @@ export function createAgentEventHandler({
   const resolveBufferedChatTextState = (
     clientRunId: string,
     sourceRunId: string,
-    options?: { final?: boolean; suppressLeadFragments?: boolean },
+    options?: { final?: boolean; suppressLeadFragments?: boolean; isHeartbeat?: boolean },
   ) => {
     const bufferedText = chatRunState
       .resolveBuffer(clientRunId, { final: options?.final })
@@ -1088,6 +1097,7 @@ export function createAgentEventHandler({
       runId: clientRunId,
       sourceRunId,
       text: bufferedText,
+      isHeartbeat: options?.isHeartbeat,
     });
     const projected = projectLiveAssistantBufferedText(normalizedHeartbeatText.text.trim(), {
       suppressLeadFragments: options?.suppressLeadFragments,
@@ -1104,7 +1114,11 @@ export function createAgentEventHandler({
     clientRunId: string,
     sourceRunId: string,
     seq: number,
-    opts?: { controlUiVisible?: boolean; firstAssistantTimingEntry?: ChatRunEntry },
+    opts?: {
+      controlUiVisible?: boolean;
+      firstAssistantTimingEntry?: ChatRunEntry;
+      isHeartbeat?: boolean;
+    },
     resolved?: { text: string; shouldSuppressSilent: boolean },
   ) => {
     cancelPendingChatDeltaFlush(clientRunId);
@@ -1118,10 +1132,12 @@ export function createAgentEventHandler({
         }
       : resolveBufferedChatTextState(clientRunId, sourceRunId, {
           suppressLeadFragments: true,
+          isHeartbeat: opts?.isHeartbeat,
         });
     const shouldSuppressHeartbeatStreaming = shouldHideHeartbeatChatOutput(
       clientRunId,
       sourceRunId,
+      opts?.isHeartbeat,
     );
     if (!text || shouldSuppressSilent || shouldSuppressHeartbeatStreaming) {
       return;
@@ -1182,11 +1198,13 @@ export function createAgentEventHandler({
       abortErrorMessage?: string;
       yielded?: true;
       errorObservation?: unknown;
+      isHeartbeat?: boolean;
     },
   ) => {
     const { text, shouldSuppressSilent } = resolveBufferedChatTextState(clientRunId, sourceRunId, {
       final: true,
       suppressLeadFragments: false,
+      isHeartbeat: opts?.isHeartbeat,
     });
     // Flush any paced delta so streaming clients receive the complete text
     // before the final event.
@@ -1379,20 +1397,25 @@ export function createAgentEventHandler({
     }
   };
 
-  const resolveToolVerboseLevel = (runId: string, sessionKey?: string) => {
-    const runContext = getAgentRunContext(runId);
-    const runVerbose = normalizeVerboseLevel(runContext?.verboseLevel);
+  const resolveToolVerboseLevel = (
+    event: AgentEventRuntimePayload,
+    sessionKey: string | undefined,
+    agentId: string | undefined,
+  ) => {
+    const runContext = getAgentRunContext(event.runId);
+    const runVerbose = normalizeVerboseLevel(runContext?.verboseLevel ?? event.verboseLevel);
+    const registeredAt = runContext?.registeredAt ?? event.registeredAt;
     if (!sessionKey) {
       return runVerbose ?? "off";
     }
     try {
-      const { cfg, entry } = loadGatewaySessionEntryReadOnly(sessionKey, { clone: false });
+      const { cfg, entry } = loadGatewaySessionEntryReadOnly(sessionKey, { agentId, clone: false });
       const sessionVerbose = normalizeVerboseLevel(entry?.verboseLevel);
       const sessionUpdatedAt = typeof entry?.updatedAt === "number" ? entry.updatedAt : undefined;
       const sessionChangedAfterRunStarted =
         sessionUpdatedAt !== undefined &&
-        runContext?.registeredAt !== undefined &&
-        sessionUpdatedAt >= runContext.registeredAt;
+        registeredAt !== undefined &&
+        sessionUpdatedAt >= registeredAt;
       if (sessionVerbose && (!runVerbose || sessionChangedAfterRunStarted)) {
         return sessionVerbose;
       }
@@ -1423,12 +1446,13 @@ export function createAgentEventHandler({
       evt.projectSessionLifecycle ?? runContext?.projectSessionLifecycle ?? true;
     const projectSessionMessages =
       evt.projectSessionMessages ?? runContext?.projectSessionMessages ?? true;
-    const isHeartbeat = runContext?.isHeartbeat;
     const restartRecoverySessionKey = RESTART_RECOVERY_LIFECYCLE_PHASES.has(lifecyclePhase ?? "")
       ? (eventSessionKey ?? sessionKey)
       : undefined;
     const restartRecoveryAgentId = evt.agentId ?? sessionAgentId;
     const clientRunId = chatLink?.clientRunId ?? evt.runId;
+    const isHeartbeat = runContext?.isHeartbeat ?? evt.isHeartbeat;
+    const heartbeatPolicy = resolveHeartbeatFlag(clientRunId, evt.runId, evt.isHeartbeat);
     // A detached worker may reuse its correlation id under a new claim.
     // Retire its old text before the new owner can append or flush it.
     if (chatRunState.runs.get(clientRunId)?.bufferIsCurrent?.() === false) {
@@ -1492,9 +1516,10 @@ export function createAgentEventHandler({
     const last = agentRunSeq.get(evt.runId) ?? 0;
     const isToolEvent = evt.stream === "tool";
     const isItemEvent = evt.stream === "item";
-    const toolVerbose = isToolEvent ? resolveToolVerboseLevel(evt.runId, sessionKey) : "off";
-    const suppressHeartbeatToolEvents =
-      isToolEvent && shouldSuppressHeartbeatToolEvents(clientRunId, evt.runId);
+    const toolVerbose = isToolEvent
+      ? resolveToolVerboseLevel(evt, sessionKey, sessionAgentId)
+      : "off";
+    const suppressHeartbeatToolEvents = isToolEvent && heartbeatPolicy === true;
     if (last > 0 && evt.seq !== last + 1 && isControlUiVisible) {
       flushBufferedAgentDeltaIfNeeded(clientRunId);
       broadcast(
@@ -1687,6 +1712,7 @@ export function createAgentEventHandler({
             evt.seq,
             {
               controlUiVisible: isControlUiVisible,
+              isHeartbeat: heartbeatPolicy,
             },
           );
         }
@@ -1800,6 +1826,7 @@ export function createAgentEventHandler({
           {
             controlUiVisible: isControlUiVisible,
             isCurrent,
+            isHeartbeat: heartbeatPolicy,
           },
         );
       }

--- a/src/infra/agent-event-execution-context.ts
+++ b/src/infra/agent-event-execution-context.ts
@@ -1,0 +1,80 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+import { resolveGlobalSingleton } from "../shared/global-singleton.js";
+import type { AgentRunContext } from "./agent-run-registry.types.js";
+
+type Routing = Pick<
+  AgentRunContext,
+  | "agentId"
+  | "sessionKey"
+  | "sessionId"
+  | "completionSource"
+  | "isControlUiVisible"
+  | "projectSessionLifecycle"
+  | "projectSessionMessages"
+  | "mainSessionRestartRecovery"
+  | "lifecycleStartedAt"
+  | "lifecycleGeneration"
+  | "isHeartbeat"
+  | "verboseLevel"
+  | "registeredAt"
+>;
+
+type RoutingRecord = { owner: WeakRef<AgentRunContext>; routing: Routing };
+type ExecutionContext = {
+  lifecycleGeneration: string;
+  onceByRun: Map<string, Promise<unknown>>;
+  // v2026.9.4 updaters can retain scopes created before routing was captured.
+  routingByRun?: Map<string, RoutingRecord>;
+};
+
+export function getAgentEventExecutionContext() {
+  return resolveGlobalSingleton(
+    Symbol.for("openclaw.agentEvents.executionContext"),
+    () => new AsyncLocalStorage<ExecutionContext>(),
+  );
+}
+
+/** Registration owns routing updates; cancellation may clear live authority before callbacks settle. */
+export function recordAgentEventRouting(
+  runId: string,
+  context: AgentRunContext,
+  predecessor?: AgentRunContext,
+): void {
+  const scope = getAgentEventExecutionContext().getStore();
+  if (!scope || scope.lifecycleGeneration !== context.lifecycleGeneration) {
+    return;
+  }
+  const routing = {
+    agentId: context.agentId,
+    sessionKey: context.sessionKey,
+    sessionId: context.sessionId,
+    completionSource: context.completionSource,
+    isControlUiVisible: context.isControlUiVisible,
+    projectSessionLifecycle: context.projectSessionLifecycle,
+    projectSessionMessages: context.projectSessionMessages,
+    mainSessionRestartRecovery: context.mainSessionRestartRecovery,
+    lifecycleStartedAt: context.lifecycleStartedAt,
+    lifecycleGeneration: context.lifecycleGeneration,
+    isHeartbeat: context.isHeartbeat,
+    verboseLevel: context.verboseLevel,
+    registeredAt: context.registeredAt,
+  };
+  const routingByRun = (scope.routingByRun ??= new Map());
+  const record = routingByRun.get(runId);
+  const previousOwner = record?.owner.deref();
+  if (
+    record &&
+    (previousOwner === context ||
+      (predecessor !== undefined &&
+        previousOwner === predecessor &&
+        record.routing.lifecycleGeneration !== context.lifecycleGeneration))
+  ) {
+    // Only an accepted replacement of this exact registration can rebind its outer scope.
+    if (previousOwner !== context) {
+      record.owner = new WeakRef(context);
+    }
+    record.routing = routing;
+  } else {
+    routingByRun.set(runId, { owner: new WeakRef(context), routing });
+  }
+}

--- a/src/infra/agent-events.routing.test.ts
+++ b/src/infra/agent-events.routing.test.ts
@@ -1,0 +1,247 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+import { beforeEach, describe, expect, it } from "vitest";
+import { createAgentCommandLifecycle } from "../agents/command/lifecycle.js";
+import { resolveGlobalSingleton } from "../shared/global-singleton.js";
+import {
+  emitAgentEvent,
+  emitAgentEventForOwner,
+  emitAgentEventIfCurrent,
+  rotateAgentEventLifecycleGeneration,
+  getAgentEventLifecycleGeneration,
+  onAgentRuntimeEvent,
+  resetAgentEventsForTest,
+  withAgentRunLifecycleGeneration,
+  type AgentEventRuntimePayload,
+} from "./agent-events.js";
+import {
+  claimAgentRunContext,
+  clearAgentRunContext,
+  getAgentRunContext,
+  registerAgentRunContext,
+  releaseAgentRunContext,
+} from "./agent-run-registry.js";
+
+describe("agent event routing after cancellation", () => {
+  beforeEach(() => resetAgentEventsForTest());
+
+  it.each([
+    { name: "visible", hidden: false, messages: true },
+    { name: "hidden private", hidden: true, messages: false },
+    { name: "hidden session subscribers", hidden: true, messages: true },
+  ])("keeps producer routing after context cleanup ($name)", async ({ hidden, messages }) => {
+    const runId = "cancelled-run";
+    const sessionKey = "agent:delivery:conversation";
+    const generation = getAgentEventLifecycleGeneration();
+    const events: AgentEventRuntimePayload[] = [];
+    const unsubscribe = onAgentRuntimeEvent((event) => events.push(event));
+    try {
+      await withAgentRunLifecycleGeneration(generation, async () => {
+        registerAgentRunContext(runId, {
+          agentId: "delivery",
+          sessionKey,
+          sessionId: "original-session",
+          isControlUiVisible: !hidden,
+          projectSessionMessages: messages,
+          projectSessionLifecycle: false,
+        });
+        // Registration follows admission; compaction can rebind before the first event.
+        await Promise.resolve();
+        registerAgentRunContext(runId, { sessionId: "compacted-session" });
+        const lifecycle = createAgentCommandLifecycle({
+          runId,
+          lifecycleGeneration: () => generation,
+          startedAt: 1,
+          state: {
+            currentTurnUserMessagePersisted: true,
+            lifecycleFinishing: false,
+            lifecycleEnded: false,
+          },
+        });
+        clearAgentRunContext(runId);
+        expect(getAgentRunContext(runId)).toBeUndefined();
+        emitAgentEvent({ runId, stream: "tool", data: { phase: "result", toolCallId: "held" } });
+        lifecycle.emitBasicError(new Error("cancelled"), { aborted: true, stopReason: "rpc" });
+      });
+    } finally {
+      unsubscribe();
+    }
+    expect(events).toHaveLength(2);
+    expect(events[0]).toMatchObject({ agentId: "delivery", controlUiVisible: !hidden });
+    expect(events[0]?.sessionKey).toBe(hidden ? undefined : sessionKey);
+    expect(events[0]?.deliverySessionKey).toBe(hidden ? sessionKey : undefined);
+    expect(events[0]?.projectSessionMessages).toBe(messages);
+    const serialized = JSON.stringify(events[0]);
+    const wire = JSON.parse(serialized);
+    expect(wire).not.toHaveProperty("deliverySessionKey");
+    if (hidden) {
+      expect(wire).not.toHaveProperty("sessionKey");
+    }
+    expect(events[1]).toMatchObject({
+      agentId: "delivery",
+      sessionKey,
+      sessionId: "compacted-session",
+      controlUiVisible: !hidden,
+      projectSessionMessages: messages,
+      projectSessionLifecycle: false,
+      data: { executionSettled: true, aborted: true, stopReason: "rpc" },
+    });
+    expect(getAgentRunContext(runId)).toBeUndefined();
+    expect(Object.keys(events[1]!)).not.toContain("controlUiVisible");
+    expect(Object.keys(events[1]!)).not.toContain("projectSessionMessages");
+  });
+
+  it("shares compaction updates across nested scopes without inheriting a reused run", async () => {
+    const generation = getAgentEventLifecycleGeneration();
+    const events: AgentEventRuntimePayload[] = [];
+    const unsubscribe = onAgentRuntimeEvent((event) => events.push(event));
+    const emit = () =>
+      emitAgentEventIfCurrent({ runId: "shared", stream: "lifecycle", data: { phase: "end" } });
+    try {
+      await withAgentRunLifecycleGeneration(generation, async () => {
+        registerAgentRunContext("shared", {
+          agentId: "first",
+          sessionKey: "agent:first:one",
+          sessionId: "before",
+        });
+        await withAgentRunLifecycleGeneration(generation, async () => {
+          registerAgentRunContext("shared", { sessionId: "after-compaction" });
+          await Promise.resolve();
+        });
+        clearAgentRunContext("shared");
+        expect(emit()).toBe(true);
+        await withAgentRunLifecycleGeneration(generation, async () => {
+          registerAgentRunContext("shared", {
+            agentId: "second",
+            sessionKey: "agent:second:two",
+            sessionId: "second-session",
+          });
+          expect(emit()).toBe(true);
+        });
+        // The old execution cannot stamp an event with its replacement's live identity.
+        expect(emit()).toBe(false);
+        clearAgentRunContext("shared");
+      });
+      await withAgentRunLifecycleGeneration(generation, async () => {
+        expect(emit()).toBe(true);
+      });
+    } finally {
+      unsubscribe();
+    }
+    expect(events).toHaveLength(3);
+    expect(events[0]).toMatchObject({ agentId: "first", sessionId: "after-compaction" });
+    expect(events[1]).toMatchObject({ agentId: "second", sessionId: "second-session" });
+    expect(events[2]?.agentId).toBeUndefined();
+    expect(events[2]?.sessionKey).toBeUndefined();
+  });
+
+  it("never lets routing provenance revive a released claim or rotated execution", () => {
+    const generation = getAgentEventLifecycleGeneration();
+    const events: AgentEventRuntimePayload[] = [];
+    const unsubscribe = onAgentRuntimeEvent((event) => events.push(event));
+    try {
+      withAgentRunLifecycleGeneration(generation, () => {
+        const claim = claimAgentRunContext(
+          "owned",
+          { agentId: "delivery", sessionKey: "agent:delivery:owned" },
+          { exclusive: true, trackOwner: true, ownsContext: true },
+        );
+        expect(claim).toBeDefined();
+        const event = { runId: "owned", stream: "tool", data: { phase: "result" } };
+        emitAgentEventForOwner(event, claim!);
+        clearAgentRunContext("owned", generation, claim);
+        releaseAgentRunContext("owned", claim);
+        expect(getAgentRunContext("owned")).toBeUndefined();
+        emitAgentEventForOwner(event, claim!);
+        rotateAgentEventLifecycleGeneration();
+        expect(emitAgentEventIfCurrent(event)).toBe(false);
+      });
+    } finally {
+      unsubscribe();
+    }
+    expect(events).toHaveLength(1);
+  });
+
+  it("extends a retained v2026.9.4 scope without replacing its execution owner", async () => {
+    const lifecycleGeneration = getAgentEventLifecycleGeneration();
+    // Released updaters can retain this exact shape while loading current runtime aliases.
+    const storage = resolveGlobalSingleton(
+      Symbol.for("openclaw.agentEvents.executionContext"),
+      () =>
+        new AsyncLocalStorage<{
+          lifecycleGeneration: string;
+          onceByRun: Map<string, Promise<unknown>>;
+        }>(),
+    );
+    const legacy = { lifecycleGeneration, onceByRun: new Map<string, Promise<unknown>>() };
+    const events: AgentEventRuntimePayload[] = [];
+    const unsubscribe = onAgentRuntimeEvent((event) => events.push(event));
+    try {
+      await storage.run(legacy, async () => {
+        registerAgentRunContext("updater", {
+          agentId: "delivery",
+          sessionKey: "agent:delivery:update",
+        });
+        await withAgentRunLifecycleGeneration(lifecycleGeneration, async () => {
+          registerAgentRunContext("updater", { sessionId: "current-session" });
+        });
+        clearAgentRunContext("updater");
+        emitAgentEvent({ runId: "updater", stream: "lifecycle", data: { phase: "end" } });
+        expect(storage.getStore()).toBe(legacy);
+      });
+    } finally {
+      unsubscribe();
+    }
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      agentId: "delivery",
+      sessionKey: "agent:delivery:update",
+      sessionId: "current-session",
+    });
+  });
+
+  it("routes outer settlement after an admitted queued generation handoff", async () => {
+    const previousGeneration = getAgentEventLifecycleGeneration();
+    const events: AgentEventRuntimePayload[] = [];
+    const unsubscribe = onAgentRuntimeEvent((event) => events.push(event));
+    const accepted: boolean[] = [];
+    try {
+      await withAgentRunLifecycleGeneration(previousGeneration, async () => {
+        registerAgentRunContext("queued", {
+          agentId: "delivery",
+          sessionKey: "agent:delivery:queued",
+          sessionId: "queued-before",
+        });
+        const currentGeneration = rotateAgentEventLifecycleGeneration();
+        await withAgentRunLifecycleGeneration(currentGeneration, async () => {
+          claimAgentRunContext("queued", {
+            agentId: "delivery",
+            sessionKey: "agent:delivery:queued",
+            sessionId: "admitted-after",
+            lifecycleGeneration: currentGeneration,
+          });
+        });
+        const terminal = {
+          runId: "queued",
+          lifecycleGeneration: currentGeneration,
+          stream: "lifecycle",
+          data: { phase: "end", executionSettled: true },
+        };
+        accepted.push(emitAgentEventIfCurrent(terminal));
+        clearAgentRunContext("queued", currentGeneration);
+        accepted.push(emitAgentEventIfCurrent(terminal));
+        expect(emitAgentEventIfCurrent({ runId: "queued", stream: "tool", data: {} })).toBe(false);
+      });
+    } finally {
+      unsubscribe();
+    }
+    expect(accepted).toEqual([true, true]);
+    expect(events).toHaveLength(2);
+    for (const event of events) {
+      expect(event).toMatchObject({
+        agentId: "delivery",
+        sessionKey: "agent:delivery:queued",
+        sessionId: "admitted-after",
+      });
+    }
+  });
+});

--- a/src/infra/agent-events.ts
+++ b/src/infra/agent-events.ts
@@ -1,7 +1,10 @@
 // Stores and broadcasts agent lifecycle and streaming events.
-import { AsyncLocalStorage } from "node:async_hooks";
 import { resolveGlobalSingleton } from "../shared/global-singleton.js";
 import { notifyListeners, registerListener } from "../shared/listeners.js";
+import {
+  getAgentEventExecutionContext,
+  recordAgentEventRouting,
+} from "./agent-event-execution-context.js";
 import { hasInvalidLifecycleStartTimestamp } from "./agent-event-lifecycle.js";
 import { createAgentRunStaleLifecycleError } from "./agent-lifecycle-error.js";
 import {
@@ -12,6 +15,7 @@ import {
   resetAgentRunRegistryForTest,
   rotateAgentRunRegistryLifecycleGeneration,
 } from "./agent-run-registry.js";
+import type { AgentRunContext } from "./agent-run-registry.types.js";
 import { recordAgentRunOutputTokens } from "./agent-run-usage.js";
 
 /** Approval event phase for request/resolution transitions. */
@@ -81,6 +85,9 @@ export type AgentEventRuntimePayload = AgentEventPayload & {
   readonly mainSessionRestartRecovery?: true;
   readonly projectSessionLifecycle?: boolean;
   readonly projectSessionMessages?: boolean;
+  readonly isHeartbeat?: boolean;
+  readonly verboseLevel?: AgentRunContext["verboseLevel"];
+  readonly registeredAt?: number;
 };
 
 type AgentEventListener = (evt: AgentEventRuntimePayload) => void;
@@ -101,12 +108,6 @@ type AgentEventState = {
 };
 
 const AGENT_EVENT_STATE_KEY = Symbol.for("openclaw.agentEvents.state");
-const AGENT_EVENT_EXECUTION_CONTEXT_KEY = Symbol.for("openclaw.agentEvents.executionContext");
-
-type AgentEventExecutionContext = {
-  lifecycleGeneration: string;
-  onceByRun: Map<string, Promise<unknown>>;
-};
 
 function getAgentEventState(): AgentEventState {
   return resolveGlobalSingleton<AgentEventState>(AGENT_EVENT_STATE_KEY, () => ({
@@ -123,20 +124,16 @@ registerAgentRunSequenceResetHandler((runId) => {
   getAgentEventState().seqByRun.delete(runId);
 });
 
-function getAgentEventExecutionContext() {
-  return resolveGlobalSingleton<AsyncLocalStorage<AgentEventExecutionContext>>(
-    AGENT_EVENT_EXECUTION_CONTEXT_KEY,
-    () => new AsyncLocalStorage<AgentEventExecutionContext>(),
-  );
-}
-
 /** Runs one execution with immutable ownership inherited by every emitted stream event. */
 export function withAgentRunLifecycleGeneration<T>(lifecycleGeneration: string, run: () => T): T {
   const storage = getAgentEventExecutionContext();
   const parent = storage.getStore();
   const onceByRun =
     parent?.lifecycleGeneration === lifecycleGeneration ? parent.onceByRun : new Map();
-  return storage.run({ lifecycleGeneration, onceByRun }, run);
+  // Same-registration records share compaction updates, while a nested reused
+  // run id replaces only its own binding. Neither scope retains live authority.
+  const routingByRun = new Map(parent?.routingByRun);
+  return storage.run({ lifecycleGeneration, onceByRun, routingByRun }, run);
 }
 
 /** Shares one operation across fallback attempts that belong to the same admitted run. */
@@ -232,8 +229,8 @@ function enrichAgentEvent(
     return undefined;
   }
   const context = getAgentRunContext(event.runId);
-  const executionLifecycleGeneration =
-    event.lifecycleGeneration ?? getAgentEventExecutionContext().getStore()?.lifecycleGeneration;
+  const scope = getAgentEventExecutionContext().getStore();
+  const executionLifecycleGeneration = event.lifecycleGeneration ?? scope?.lifecycleGeneration;
   const ownedLifecycleGeneration = executionLifecycleGeneration ?? context?.lifecycleGeneration;
   if (
     executionLifecycleGeneration &&
@@ -248,31 +245,49 @@ function enrichAgentEvent(
   if (hasInvalidLifecycleStartTimestamp(event.stream, event.data)) {
     return undefined;
   }
+  const record = scope?.routingByRun?.get(event.runId);
+  const captured =
+    record?.routing.lifecycleGeneration === ownedLifecycleGeneration ? record : undefined;
+  if (captured && context && captured.owner.deref() !== context) {
+    return undefined;
+  }
+  const routing = context ?? captured?.routing;
   let data = event.data;
-  if (context && event.stream === "lifecycle") {
-    if (context.completionSource) {
-      data = { ...data, completionSource: context.completionSource };
+  if (routing && event.stream === "lifecycle") {
+    if (routing.completionSource) {
+      data = { ...data, completionSource: routing.completionSource };
     }
     if (data.phase === "start") {
-      context.lifecycleStartedAt = data.startedAt as number;
+      if (context) {
+        context.lifecycleStartedAt = data.startedAt as number;
+      }
     } else if (
       (data.phase === "end" || data.phase === "error") &&
       data.startedAt === undefined &&
-      context.lifecycleStartedAt !== undefined
+      routing.lifecycleStartedAt !== undefined
     ) {
       // Preserve this run's identity after a newer run takes over its session.
-      data = { ...data, startedAt: context.lifecycleStartedAt };
+      data = { ...data, startedAt: routing.lifecycleStartedAt };
     }
+  }
+  if (context) {
+    recordAgentEventRouting(event.runId, context);
   }
   const nextSeq = (state.seqByRun.get(event.runId) ?? 0) + 1;
   state.seqByRun.set(event.runId, nextSeq);
   if (context) {
     context.lastActiveAt = Date.now();
   }
-  const isControlUiVisible = context?.isControlUiVisible ?? true;
+  const isControlUiVisible = routing?.isControlUiVisible ?? true;
   const eventSessionKey =
     typeof event.sessionKey === "string" && event.sessionKey.trim() ? event.sessionKey : undefined;
-  const deliverySessionKey = eventSessionKey ?? context?.sessionKey;
+  // Hidden subscribers retain owner-bound routing without exposing a public session key.
+  const deliverySessionKey =
+    claimId !== undefined
+      ? (eventSessionKey ?? routing?.sessionKey)
+      : !isControlUiVisible && event.stream !== "lifecycle"
+        ? routing?.sessionKey
+        : undefined;
   // Hidden channel-routed runs should not leak live assistant/tool traffic into
   // Control UI, but lifecycle events still need the session key so gateway
   // listeners can persist terminal session state even if run-context lookup is
@@ -280,16 +295,16 @@ function enrichAgentEvent(
   // emitted on the lifecycle stream with `phase: "error"`; the separate error
   // stream remains redacted for hidden runs because it is observational only.
   const preserveSessionKey = isControlUiVisible || event.stream === "lifecycle";
-  const sessionKey = preserveSessionKey ? (eventSessionKey ?? context?.sessionKey) : undefined;
+  const sessionKey = preserveSessionKey ? (eventSessionKey ?? routing?.sessionKey) : undefined;
   // Stamp lifecycle events with the owning sessionId (see AgentEventPayload) at
   // emit time, since the run context can be cleared before the terminal persists.
   const sessionId =
-    event.stream === "lifecycle" ? (event.sessionId ?? context?.sessionId) : event.sessionId;
+    event.stream === "lifecycle" ? (event.sessionId ?? routing?.sessionId) : event.sessionId;
   const lifecycleGeneration =
     event.stream === "lifecycle"
       ? (ownedLifecycleGeneration ?? currentLifecycleGeneration)
       : ownedLifecycleGeneration;
-  const agentId = event.agentId ?? context?.agentId;
+  const agentId = event.agentId ?? routing?.agentId;
   const enriched: AgentEventRuntimePayload = {
     ...event,
     data,
@@ -307,41 +322,30 @@ function enrichAgentEvent(
       enumerable: false,
     });
   }
-  if (context?.isControlUiVisible !== undefined) {
-    Object.defineProperty(enriched, "controlUiVisible", {
-      value: context.isControlUiVisible,
-      enumerable: false,
-    });
-  }
-  if (context?.projectSessionLifecycle !== undefined) {
-    Object.defineProperty(enriched, "projectSessionLifecycle", {
-      value: context.projectSessionLifecycle,
-      enumerable: false,
-    });
-  }
-  if (context?.projectSessionMessages !== undefined) {
-    Object.defineProperty(enriched, "projectSessionMessages", {
-      value: context.projectSessionMessages,
-      enumerable: false,
-    });
-  }
-  if (context?.mainSessionRestartRecovery === true) {
-    Object.defineProperty(enriched, "mainSessionRestartRecovery", {
-      value: true,
-      enumerable: false,
-    });
+  for (const [key, value] of Object.entries({
+    controlUiVisible: routing?.isControlUiVisible,
+    projectSessionLifecycle: routing?.projectSessionLifecycle,
+    projectSessionMessages: routing?.projectSessionMessages,
+    mainSessionRestartRecovery: routing?.mainSessionRestartRecovery,
+    isHeartbeat: routing?.isHeartbeat,
+    verboseLevel: routing?.verboseLevel,
+    registeredAt: routing?.registeredAt,
+  })) {
+    if (value !== undefined) {
+      Object.defineProperty(enriched, key, { value, enumerable: false });
+    }
   }
   if (claimId !== undefined) {
     Object.defineProperty(enriched, "contextClaimId", {
       value: claimId,
       enumerable: false,
     });
-    if (deliverySessionKey) {
-      Object.defineProperty(enriched, "deliverySessionKey", {
-        value: deliverySessionKey,
-        enumerable: false,
-      });
-    }
+  }
+  if (deliverySessionKey) {
+    Object.defineProperty(enriched, "deliverySessionKey", {
+      value: deliverySessionKey,
+      enumerable: false,
+    });
   }
   return enriched;
 }

--- a/src/infra/agent-run-registry.ts
+++ b/src/infra/agent-run-registry.ts
@@ -3,6 +3,7 @@ import { randomUUID } from "node:crypto";
 import { normalizeAgentId, parseAgentSessionKey } from "../routing/session-key.js";
 import { resolveGlobalSingleton } from "../shared/global-singleton.js";
 import { registerListener } from "../shared/listeners.js";
+import { recordAgentEventRouting } from "./agent-event-execution-context.js";
 import {
   AgentRunApprovalLeases,
   type AgentRunApprovalClosureReason,
@@ -94,6 +95,14 @@ export function registerAgentRunSequenceResetHandler(handler: (runId: string) =>
   getAgentRunRegistryState().sequenceResetHandler = handler;
 }
 
+function storeRunContext(runId: string, context: AgentRunContext, predecessor?: AgentRunContext) {
+  // Callers supply a fresh record; scheduler leases never transfer with its metadata.
+  context.capacityWaits = undefined;
+  context.registeredAt ??= Date.now();
+  getAgentRunRegistryState().contexts.set(runId, context);
+  recordAgentEventRouting(runId, context, predecessor);
+}
+
 /** Registers or merges per-run context used by later agent event emissions. */
 export function registerAgentRunContext(
   runId: string,
@@ -115,13 +124,7 @@ export function registerAgentRunContext(
   }
   const existing = state.contexts.get(runId);
   if (!existing) {
-    state.contexts.set(runId, {
-      ...context,
-      // Scheduler leases belong to this instance, never copied metadata.
-      capacityWaits: undefined,
-      lifecycleGeneration,
-      registeredAt: context.registeredAt ?? Date.now(),
-    });
+    storeRunContext(runId, { ...context, lifecycleGeneration });
     bumpAgentRunIndexVersion();
     return;
   }
@@ -185,6 +188,7 @@ export function registerAgentRunContext(
   if (runIndexChanged) {
     bumpAgentRunIndexVersion();
   }
+  recordAgentEventRouting(runId, existing);
 }
 
 /** Claims a run id for a newly admitted execution, replacing stale ownership. */
@@ -265,12 +269,7 @@ export function claimAgentRunContext(
     }
     return claimId;
   }
-  state.contexts.set(runId, {
-    ...context,
-    capacityWaits: undefined,
-    lifecycleGeneration,
-    registeredAt: context.registeredAt ?? Date.now(),
-  });
+  storeRunContext(runId, { ...context, lifecycleGeneration }, existing);
   state.sequenceResetHandler?.(runId);
   clearAgentRunUsage(runId);
   bumpAgentRunIndexVersion();

--- a/test/vitest/vitest.gateway-server-paths.mjs
+++ b/test/vitest/vitest.gateway-server-paths.mjs
@@ -25,6 +25,7 @@ export const gatewayMethodsIsolatedTestFiles = [
 // Gateway server tests that replace a module the Gateway reaches only through
 // re-exports. These need both a fresh graph and the plain Vitest runner.
 export const gatewayServerIsolatedTestFiles = [
+  "src/gateway/server-chat.retired-projection.test.ts",
   "src/gateway/server.sessions.compaction-read-errors.test.ts",
 ];
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where canceling a run with multiple configured agents could drop late tool events and its final execution-settled event. The Gateway lost the run's route during cleanup and then failed agent selection while dispatching those events.

## Why This Change Was Made

The existing async execution scope now retains routing and presentation facts from the exact registered run. Live execution claims still close normally. Accepted queued-generation handoffs, compaction, and scopes retained by released updaters keep their existing behavior.

The Gateway consumes those retained facts for hidden subscribers, heartbeat suppression, and per-run verbosity. Explicit agent selection also reaches the session lookup for unscoped keys. Shared registry creation and metadata projection replace duplicated paths.

## User Impact

Late cleanup and settlement events reach the correct agent and session, with the existing privacy, heartbeat, and verbosity rules preserved. No configuration, database schema, protocol, or dependency change is introduced.

## Evidence

- A real built Gateway with two configured agents reproduced the lost cancellation events and `AGENT_SELECTION_REQUIRED` dispatch errors.
- Regressions failed before their repairs, covering retained routing, hidden subscribers, released updater scopes, queued generation handoff, heartbeat/verbosity, and explicit global-session ownership.
- 113 focused tests and all 31 selected checks passed; independent P2 review is clean. The new module-mocking Gateway test is registered in the isolated suite. CI exposed an older fallback-lookup count assertion; its test-only correction retains all routing/privacy checks and passes the complete 227-test event suite, 20 selected checks, and P2 review.
- Full build passed on `fe9d042716a4729de236f80bb810497de69e5dfc`. The original failing live scenario passed unchanged: 43 model requests covering three successive source/schema reloads, Code Mode settlement, cancellation, and five delivery cases. The Gateway kept one PID and shut down cleanly. The native runtime replay also passed: 12 requests across three refreshes and six requests through cancellation. It retained the question, steering text/image, and completed actions; canceled background processes exited within 144 ms while the Gateway remained healthy. All processes and sockets closed. These flows use isolated state and local synthetic model/channel services.
- Net production +110 lines for the execution-scoped routing owner and complete projection handoff; tests +531, test-routing support +1. The change retains no live authority or global routing cache.

The follow-up commit `7132b7441fa493301be4e1fbd752c60e025896fa` deletes only that three-line test assertion. Every production and dependency file is identical to the built and live-tested `fe9d042` commit.
