### PR TITLE
fix(gateway): reduce completed-run cache allocation churn

### DIFF
--- a/src/gateway/agent-turn/agent-job.ts
+++ b/src/gateway/agent-turn/agent-job.ts
@@ -76,6 +76,7 @@ type DedupeObservation =
 
 type AgentJobState = {
   jobs: Map<string, AgentJobRecord>;
+  oldestCachedAt: number;
   runStarts: Map<string, number>;
   pendingErrors: Map<string, PendingAgentRunTerminal>;
   pendingTimeouts: Map<string, PendingAgentRunTerminal>;
@@ -87,6 +88,7 @@ const agentJobState = resolveGlobalSingleton<AgentJobState>(
   Symbol.for("openclaw.agentJobState"),
   () => ({
     jobs: new Map(),
+    oldestCachedAt: Infinity,
     runStarts: new Map(),
     pendingErrors: new Map(),
     pendingTimeouts: new Map(),
@@ -101,6 +103,7 @@ const agentJobState = resolveGlobalSingleton<AgentJobState>(
       clearTimeout(pending.timer);
     }
     state.jobs.clear();
+    state.oldestCachedAt = Infinity;
     state.runStarts.clear();
     state.pendingErrors.clear();
     state.pendingTimeouts.clear();
@@ -124,12 +127,18 @@ function nextAgentRunVersion(): number {
 }
 
 function pruneAgentRunCache(now = Date.now()) {
+  if (now - agentJobState.oldestCachedAt <= AGENT_RUN_CACHE_TTL_MS) {
+    return;
+  }
+  let oldestCachedAt = Infinity;
   for (const [runId, job] of agentJobs) {
     if (now - job.cachedAt <= AGENT_RUN_CACHE_TTL_MS) {
+      oldestCachedAt = Math.min(oldestCachedAt, job.cachedAt);
       continue;
     }
     agentJobs.delete(runId);
   }
+  agentJobState.oldestCachedAt = oldestCachedAt;
 }
 
 function enforceAgentRunCacheMaxEntries() {
@@ -214,6 +223,9 @@ function recordAgentRunSnapshot(
     cachedAt: entry.cachedAt,
     snapshotsBySource,
   });
+  // A lower bound remains safe when a write refreshes or eviction removes the oldest job.
+  // Recompute only once that bound can expire, without changing insertion-order eviction.
+  agentJobState.oldestCachedAt = Math.min(agentJobState.oldestCachedAt, entry.cachedAt);
   enforceAgentRunCacheMaxEntries();
   for (const waiter of agentRunWaiters.get(entry.runId) ?? []) {
     waiter();

--- a/src/gateway/agent-turn/agent-wait-dedupe.test.ts
+++ b/src/gateway/agent-turn/agent-wait-dedupe.test.ts
@@ -66,6 +66,39 @@ afterEach(() => {
 });
 
 describe("agent.wait gateway dedupe observations", () => {
+  it("expires terminal observations from their latest write without extending unrelated runs", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000_000);
+    const dedupe = new Map<string, DedupeEntry>();
+    completeRun(dedupe, "cache-refreshed");
+    completeRun(dedupe, "cache-original");
+    vi.setSystemTime(1_000_100);
+    completeRun(dedupe, "cache-refreshed");
+    // Wall-clock correction can insert an earlier expiry after newer records.
+    vi.setSystemTime(999_900);
+    completeRun(dedupe, "cache-clock-correction");
+
+    for (const [now, expected] of [
+      [1_599_900, ["ok", "ok", "ok"]],
+      [1_599_901, ["ok", "ok", "timeout"]],
+      [1_600_000, ["ok", "ok", "timeout"]],
+      [1_600_001, ["ok", "timeout", "timeout"]],
+      [1_600_100, ["ok", "timeout", "timeout"]],
+      [1_600_101, ["timeout", "timeout", "timeout"]],
+    ] as const) {
+      vi.setSystemTime(now);
+      const runIds = ["cache-refreshed", "cache-original", "cache-clock-correction"];
+      for (const [index, runId] of runIds.entries()) {
+        const waiter = waitThroughGateway({ runId, timeoutMs: 0 });
+        await waiter.promise;
+        expect(waiter.respond).toHaveBeenCalledWith(
+          true,
+          expect.objectContaining({ runId, status: expected[index] }),
+        );
+      }
+    }
+  });
+
   it("retains chat input identity when terminal writers replace admission metadata", async () => {
     const runId = "run-chat-request-identity";
     const key = `chat:${runId}`;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Gateways with thousands of recently completed runs spend excessive CPU and create temporary allocations while recording terminal results or answering `agent.wait` requests.

## Why This Change Was Made

The terminal-result cache now tracks a conservative earliest cached timestamp and scans for expired entries only when one may have reached the existing ten-minute TTL. Refreshes, backwards clock movement, insertion-order capacity eviction, and lifecycle reset preserve their existing behavior.

## User Impact

Busy Gateways do less allocation and garbage-collection work while tracking completed runs. Cached results keep their existing expiry and wait semantics.

## Evidence

- 57 tests pass across `agent-wait-dedupe`, `execution-settlement`, and `timeout-fallback`, including registered `agent.wait` checks for refreshed observations, exact TTL boundaries, and backwards clock correction.
- A 5,000-entry workload of 20,000 alternating terminal writes and waits reduced sampled allocations from 6,481,962,920 to 64,149,896 bytes (99.0%). The measured loop fell from 1,151 ms to 80 ms. These results measure transient allocation churn, not retained-memory savings.
- Independent P0-P2 review found no actionable findings. Changed formatting, guards, core typechecking, and core test typechecking passed. The dead-export gate reports `canonicalProviderName` and `listPackagedStaticExtensionAssetOutputs` in unchanged scripts; both findings reproduce on the clean 21d766 baseline with a zero-entry production scan.




The combined candidate passed a live Gateway workload with 1,000 sessions, eight real OpenAI turns (including two synthetic-file read tool calls), 1,200 history reads, 100 session patches, and concurrent list/UI/readiness/subscription activity. Stream, final-event, history and independent persisted-transcript checks all passed. Whole-process sampled allocations were effectively flat in this single pair (9.600 GB baseline, 9.583 GB candidate); targeted benchmark reductions should not be interpreted as a comparable overall memory reduction. Baseline final cleanup proof failed because the harness deleted its live-turn sessions; its pre-cleanup activity/allocation evidence remains valid. Corrected candidate cleanup is still running.
