### PR TITLE
fix(snapshot): frame Git backup records on LF only

### DIFF
--- a/src/snapshot/git-backup-codec.test.ts
+++ b/src/snapshot/git-backup-codec.test.ts
@@ -9,13 +9,31 @@ import {
 } from "../state/openclaw-state-db.js";
 import { dumpGitBackupDatabase, restoreGitBackupDirectory } from "./git-backup-codec.js";
 
-it("preserves NUL-bearing TEXT, storage classes, and source key order", async () => {
+it("preserves separator-bearing TEXT, storage classes, and source key order", async () => {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "git-backup-text-"));
   const sourcePath = path.join(root, "source.sqlite");
   const outputPath = path.join(root, "dump");
   const targetPath = path.join(root, "restored.sqlite");
-  const keys = ["\0leading", "\nline", " space", "shared\0left", "shared\0right", "雪🦀\0尾"];
-  const values = ["text\0suffix", "", null, 9_007_199_254_740_993n, Buffer.from([0, 255]), 1.25];
+  const keys = [
+    "\0leading",
+    "\nline",
+    " space",
+    "shared\0left",
+    "shared\0right",
+    "\u2028separator",
+    "\u2029separator",
+    "雪🦀\0尾",
+  ];
+  const values = [
+    "text\0suffix",
+    "",
+    null,
+    9_007_199_254_740_993n,
+    Buffer.from([0, 255]),
+    "lead\u2028tail",
+    "a\u2029b",
+    1.25,
+  ];
   const byteQuery =
     'SELECT hex("key") AS key, typeof(value) AS type, hex(value) AS bytes FROM text_values ORDER BY "key"';
   try {
@@ -45,7 +63,9 @@ it("preserves NUL-bearing TEXT, storage classes, and source key order", async ()
       { key: keys[2], value: null },
       { key: keys[3], value: { $int: "9007199254740993" } },
       { key: keys[4], value: { $hex: "00ff" } },
-      { key: keys[5], value: 1.25 },
+      { key: keys[5], value: values[5] },
+      { key: keys[6], value: values[6] },
+      { key: keys[7], value: 1.25 },
     ]);
     const restored = await restoreGitBackupDirectory({
       sourcePath: outputPath,

--- a/src/snapshot/git-backup-codec.ts
+++ b/src/snapshot/git-backup-codec.ts
@@ -2,9 +2,9 @@ import { createHash } from "node:crypto";
 import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
-import { createInterface } from "node:readline";
 import type { DatabaseSync } from "node:sqlite";
 import { finished } from "node:stream/promises";
+import { StringDecoder } from "node:string_decoder";
 import { openNodeSqliteDatabase } from "../infra/node-sqlite.js";
 import { applyPrivateModeSync } from "../infra/private-mode.js";
 import { assertSqliteIntegrity } from "../infra/sqlite-integrity.js";
@@ -549,9 +549,7 @@ async function loadGitBackupTable(
      VALUES (${columns.map(() => "?").join(", ")})`,
   );
   const input = fsSync.createReadStream(inputPath);
-  const lines = createInterface({ input, crlfDelay: Infinity });
   const hash = createHash("sha256");
-  input.on("data", (chunk: Buffer) => hash.update(chunk));
   const pending: Array<ReturnType<typeof decodeSqliteValue>[]> = [];
   let pendingBytes = 0;
   let rows = 0;
@@ -574,23 +572,37 @@ async function loadGitBackupTable(
     pending.length = 0;
     pendingBytes = 0;
   };
+  // JSONL framing is LF-only: JSON strings may contain literal U+2028/U+2029,
+  // which generic line readers also treat as line endings.
+  const acceptLine = (line: string) => {
+    if (!line) {
+      return;
+    }
+    const parsed = JSON.parse(line) as Record<string, unknown>;
+    pending.push(columns.map((column) => decodeSqliteValue(parsed[column.name])));
+    pendingBytes += Buffer.byteLength(line);
+    rows += 1;
+    if (pendingBytes >= TABLE_BATCH_BYTES) {
+      flush();
+    }
+  };
+  const decoder = new StringDecoder("utf8");
+  let buffered = "";
   try {
-    for await (const line of lines) {
-      if (!line) {
-        continue;
-      }
-      const parsed = JSON.parse(line) as Record<string, unknown>;
-      pending.push(columns.map((column) => decodeSqliteValue(parsed[column.name])));
-      pendingBytes += Buffer.byteLength(line);
-      rows += 1;
-      if (pendingBytes >= TABLE_BATCH_BYTES) {
-        flush();
+    for await (const chunk of input) {
+      hash.update(chunk);
+      buffered += decoder.write(chunk);
+      let newlineIndex: number;
+      while ((newlineIndex = buffered.indexOf("\n")) !== -1) {
+        acceptLine(buffered.slice(0, newlineIndex));
+        buffered = buffered.slice(newlineIndex + 1);
       }
     }
+    buffered += decoder.end();
+    acceptLine(buffered);
     flush();
     return { rows, sha256: hash.digest("hex") };
   } finally {
-    lines.close();
     input.destroy();
     await finished(input).catch(() => undefined);
   }


### PR DESCRIPTION
## What Problem This Solves

Git backups are written as LF-delimited JSONL, but the restore reader currently uses `node:readline`. Node also treats literal U+2028 and U+2029 characters as line endings, so a valid SQLite TEXT value containing either character is split in the middle of its JSON string. Backup creation succeeds, while verification and restoration later fail with an unterminated-JSON error.

Closes #145938.

This picks up the issue after #145963 closed unmerged because its author exceeded the repository's active-PR limit. That PR independently confirmed the same reader boundary; this submission keeps the regression within the existing codec round-trip test.

## Solution

- Read the stream through `StringDecoder` so UTF-8 characters remain intact across chunk boundaries.
- Frame records only on LF, matching the writer's JSONL contract.
- Keep hashing every original byte and preserve bounded transaction flushing.
- Extend the existing SQLite TEXT/storage-class round-trip test with literal U+2028 and U+2029 in both keys and values.

## Evidence

- `node scripts/run-vitest.mjs src/snapshot/git-backup-codec.test.ts` — 1 passed.
- `node scripts/check-changed.mjs` — format, dependency, boundary, core typecheck, and all core-test typecheck shards passed. The final repository-wide dead-export scan reported existing unused exports in untouched `scripts/crabbox-wrapper-providers.mts` and `scripts/lib/static-extension-assets.mts`.
- `git diff --check` — passed.
- `oss-preflight.ps1 -BaseRef origin/main -MaintainerCanModify yes` — no blocking finding; 2 intended files, +50/-18, no deleted files, no merge commits, current with `origin/main` at validation time.

The wider Git-backup suites were also attempted. The codec and failure-path tests reached and passed, while unrelated tests that create Git repositories were blocked by this Windows host's inherited temporary-directory ACL and broken system `git.cmd` wrapper. The 256 MiB streaming test hit the same ACL gate before exercising the changed reader.
