### PR TITLE
fix(tests): retain pinned selectors in unchanged plugin updates

### DIFF
--- a/scripts/e2e/lib/plugin-update/unchanged-scenario.sh
+++ b/scripts/e2e/lib/plugin-update/unchanged-scenario.sh
@@ -50,7 +50,7 @@ plugin_update_timeout_seconds="$(openclaw_e2e_read_positive_int_env OPENCLAW_PLU
 node "$probe" snapshot > /tmp/plugin-update-before.json
 
 set +e
-openclaw_e2e_maybe_timeout "${plugin_update_timeout_seconds}s" node "$entry" plugins update @example/lossless-claw > /tmp/plugin-update-output.log 2>&1
+openclaw_e2e_maybe_timeout "${plugin_update_timeout_seconds}s" node "$entry" plugins update lossless-claw > /tmp/plugin-update-output.log 2>&1
 plugin_update_status=$?
 set -e
 if [ "$plugin_update_status" -ne 0 ]; then


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the plugin-update Docker smoke fails its unchanged-record assertion after intentionally requesting a new npm selector.

## Why This Change Was Made

Target the installed plugin ID for the unchanged-update scenario. A bare npm package name requests selector replacement; the installed ID retains the recorded pinned selector. All existing record, config, payload, and no-download assertions remain intact.

## User Impact

The smoke test verifies a no-change update without mistaking supported selector replacement for a product failure. Product behavior is unchanged.

## Evidence

- The failure reproduced in [Package Acceptance](https://github.com/openclaw/openclaw/actions/runs/34695362157) after all 25 consent-scenario commands passed.
- Real isolated CLI before/after proof: the original target changed only the saved selector; the corrected target preserved the complete record, config, payload, and no-download check. The retained CLI build is `ecfbdd`; the relevant owners are byte-identical on this branch.
- All 12 selected checks and independent P2 review passed. No new tests or net production/harness LOC.
- Full [plugin-update Package Acceptance](https://github.com/openclaw/openclaw/actions/runs/34697615447) passed on this exact head (`6b56e1aa`), including final aggregate verification. The targeted scenario ran for 9m35s. Exact-head CI also passed.
