### PR TITLE
fix(sessions): reduce allocation churn in repeated entry reads

### DIFF
--- a/src/config/sessions/session-accessor.sqlite-entry-read.ts
+++ b/src/config/sessions/session-accessor.sqlite-entry-read.ts
@@ -1,7 +1,9 @@
+import type { DatabaseSync } from "node:sqlite";
 import type { Selectable } from "kysely";
 import {
   executeSqliteQuerySync,
   executeSqliteQueryTakeFirstSync,
+  prepareSqliteQuerySync,
 } from "../../infra/kysely-sync.js";
 import type { DB as OpenClawAgentKyselyDatabase } from "../../state/openclaw-agent-db.generated.js";
 import type { OpenClawAgentDatabase } from "../../state/openclaw-agent-db.js";
@@ -24,6 +26,51 @@ import type { InternalSessionEntry as SessionEntry } from "./types.js";
 
 type OpenClawAgentDatabaseReader = Pick<OpenClawAgentDatabase, "agentId" | "db">;
 type SessionEntryRow = Selectable<OpenClawAgentKyselyDatabase["session_nodes"]>;
+
+function prepareExactSessionEntryQueries(database: DatabaseSync) {
+  const db = getSessionKysely(database);
+  return {
+    row: prepareSqliteQuerySync<string, SessionEntryRow>(database, (parameter) =>
+      db
+        .selectFrom("session_nodes")
+        .selectAll()
+        .where(
+          "session_key",
+          "=",
+          parameter((key) => key),
+        ),
+    ),
+    json: prepareSqliteQuerySync<string, Pick<SessionEntryRow, "entry_json">>(
+      database,
+      (parameter) =>
+        db
+          .selectFrom("session_nodes")
+          .select("entry_json")
+          .where(
+            "session_key",
+            "=",
+            parameter((key) => key),
+          ),
+    ),
+  };
+}
+
+// Compile fixed reads once per connection; the shared executor still owns fresh
+// bindings, statement invalidation, and schema-driven SELECT * repreparation.
+const exactSessionEntryQueries = new WeakMap<
+  DatabaseSync,
+  ReturnType<typeof prepareExactSessionEntryQueries>
+>();
+
+function getExactSessionEntryQueries(database: DatabaseSync) {
+  let queries = exactSessionEntryQueries.get(database);
+  if (!queries) {
+    queries = prepareExactSessionEntryQueries(database);
+    exactSessionEntryQueries.set(database, queries);
+  }
+  return queries;
+}
+
 export type ResolvedSessionEntryRow = {
   entry: SessionEntry;
   row: Pick<SessionEntryRow, "current_session_id" | "entry_json" | "session_key" | "updated_at"> &
@@ -88,19 +135,22 @@ export function readSessionEntryRowScan(
     }
   | undefined {
   assertCanonicalSqliteSessionKeysCurrent(database);
-  const db = getSessionKysely(database.db);
   const lookupKeys = collectSessionEntryLookupKeys(database, sessionKey);
-  if (lookupKeys.length === 0) {
+  const firstLookupKey = lookupKeys[0];
+  if (firstLookupKey === undefined) {
     return undefined;
   }
-  const rows = executeSqliteQuerySync(
-    database.db,
-    db
-      .selectFrom("session_nodes")
-      .selectAll()
-      .where("session_key", "in", lookupKeys)
-      .orderBy("session_key", "asc"),
-  ).rows;
+  const rows =
+    lookupKeys.length === 1
+      ? getExactSessionEntryQueries(database.db).row(firstLookupKey).rows
+      : executeSqliteQuerySync(
+          database.db,
+          getSessionKysely(database.db)
+            .selectFrom("session_nodes")
+            .selectAll()
+            .where("session_key", "in", lookupKeys)
+            .orderBy("session_key", "asc"),
+        ).rows;
   let selected: ResolvedSessionEntryRow | undefined;
   for (const row of rows) {
     const entry = parseReadableSqliteSessionEntryRow(database, row);
@@ -117,15 +167,15 @@ export function readExactSessionEntryRow(
   sessionKey: string,
   projection: "full" | "list" = "full",
 ): ResolvedSessionEntryRow | undefined {
-  const db = getSessionKysely(database.db);
-  const query =
+  const row =
     projection === "list"
-      ? selectSessionEntryRows(database, projection).select(["current_session_id", "updated_at"])
-      : db.selectFrom("session_nodes").selectAll();
-  const row = executeSqliteQueryTakeFirstSync(
-    database.db,
-    query.where("session_key", "=", sessionKey),
-  );
+      ? executeSqliteQueryTakeFirstSync(
+          database.db,
+          selectSessionEntryRows(database, projection)
+            .select(["current_session_id", "updated_at"])
+            .where("session_key", "=", sessionKey),
+        )
+      : getExactSessionEntryQueries(database.db).row(sessionKey).rows[0];
   if (!row) {
     return undefined;
   }
@@ -137,11 +187,7 @@ export function readExactSessionEntryJson(
   database: Pick<OpenClawAgentDatabase, "db">,
   sessionKey: string,
 ): string | undefined {
-  const db = getSessionKysely(database.db);
-  return executeSqliteQueryTakeFirstSync(
-    database.db,
-    db.selectFrom("session_nodes").select("entry_json").where("session_key", "=", sessionKey),
-  )?.entry_json;
+  return getExactSessionEntryQueries(database.db).json(sessionKey).rows[0]?.entry_json;
 }
 
 export function readExactSessionEntryRowValidated(


### PR DESCRIPTION
## What Problem This Solves

Gateways handling frequent session lookups rebuild fixed SQL queries on every read, generating unnecessary temporary allocations.

## Why This Change Was Made

Reuse the existing synchronous prepared-query owner for full rows, raw entry JSON, and ordinary single-key canonical scans. Every invocation reads current SQLite rows with fresh bindings; list and multi-key reads retain their projection and ordering rules. Compiled queries follow connection lifetime through weak keys, while the shared executor continues to own native statement invalidation.

## User Impact

Session reads allocate less temporary memory. There are no persistence, schema, update, or migration contract changes.

## Evidence

Actual-owner allocation profiling used 30,000 reads per mode and 100 isolated sessions populated through `upsertSessionEntryCore`, each with approximately 4 KB of synthetic saved prompt:

- Ordinary single-key scan: 727.41 MB → 627.84 MB allocated (-13.7%).
- Full exact row: 651.41 MB → 585.90 MB (-10.1%).
- Raw entry JSON: 235.65 MB → 165.97 MB (-29.6%).

Result checksums matched. Post-GC heap deltas remained within -131 KB to +70 KB; these measurements demonstrate allocation reduction, without establishing a retained-memory improvement. A separate connection-lifetime probe observed zero retained connections after creating, reading, and closing 100 connections with statement caching enabled.

All 49 focused tests passed across the session owner, participant, revalidation, and read-only suites. They cover current row visibility, owner-column addition and rollback, and read-only behavior. Full live Gateway/provider proof is tracked separately for the campaign.

Formatting, core and core-test typechecks, type-aware lint, and all remaining changed-gate guards passed. Host resource exhaustion interrupted the local dead-export phase; a clean-base Windows scan reproduced its script findings. Exact-head CI subsequently passed all script, production, and full-tree unused-export scans in [check-dependencies](https://github.com/openclaw/openclaw/actions/runs/34697644067/job/103563846068). No checks were disabled or baselines changed.

The combined candidate passed a live Gateway workload with 1,000 sessions, eight real OpenAI turns (including two synthetic-file read tool calls), 1,200 history reads, 100 session patches, and concurrent list/UI/readiness/subscription activity. Stream, final-event, history and independent persisted-transcript checks all passed. Whole-process sampled allocations were effectively flat in this single pair (9.600 GB baseline, 9.583 GB candidate); targeted benchmark reductions should not be interpreted as a comparable overall memory reduction. Baseline final cleanup proof failed because the harness deleted its live-turn sessions; its pre-cleanup activity/allocation evidence remains valid. Corrected candidate cleanup is still running.
