### PR TITLE
fix(test): fail expired Vitest runs after clean child exits

### DIFF
--- a/docs/help/testing/suites.md
+++ b/docs/help/testing/suites.md
@@ -106,7 +106,8 @@ Native dependency policy:
       Set `OPENCLAW_VITEST_ENABLE_MAGLEV=1` to compare against stock V8
       behavior.
     - `scripts/run-vitest.mjs` terminates explicit non-watch Vitest runs
-      after 5 minutes with no stdout or stderr output. Set
+      when their configured no-output deadline expires. Expiry fails the run
+      even when the child shuts down with exit code zero. Set
       `OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=0` to disable the watchdog for
       an intentionally silent investigation.
     - `scripts/run-tsgo.mjs` leaves tsgo unbounded by default, preserving the

--- a/scripts/run-vitest.mts
+++ b/scripts/run-vitest.mts
@@ -784,7 +784,7 @@ function forwardVitestOutput(
 }
 
 /**
- * Spawns Vitest with output forwarding, watchdogs, and process-group cleanup.
+ * Joins watched Vitest processes and keeps expired deadlines failed after cooperative exits.
  */
 export function spawnWatchedVitestProcess({
   pnpmArgs,
@@ -804,7 +804,7 @@ export function spawnWatchedVitestProcess({
   if (homeMode !== "tooling") {
     assertTestHomeSelection(env, homeMode);
   }
-  let diagnosticsCompletion: Promise<void> | null = null;
+  let timeoutCompletion: Promise<boolean> | null = null;
   const directNodeArgs = resolveDirectNodeVitestArgs(pnpmArgs);
   if (workerRun && directNodeArgs) {
     // Preserve Node flags while giving the same owned child its private generation.
@@ -861,7 +861,7 @@ export function spawnWatchedVitestProcess({
         },
         onTimeout: onNoOutputTimeout,
       });
-      diagnosticsCompletion = termination.diagnostics;
+      timeoutCompletion = termination.diagnostics.then(() => true);
     },
     onForceKill: () => {
       forwardSignalToVitestProcessGroup({
@@ -887,8 +887,8 @@ export function spawnWatchedVitestProcess({
     teardownNoOutputWatchdog();
   };
   const completion = Promise.all([childCompletion, forwardedOutput])
-    .then(async ([{ code, signal, groupJoined }]) => {
-      await diagnosticsCompletion;
+    .then(async ([{ code: childCode, signal, groupJoined }]) => {
+      const code = (await timeoutCompletion) && childCode === 0 ? 1 : childCode;
       const result = unhandledErrors.finish();
       if (result) {
         writeVitestUnhandledErrorSummary(result, env);

--- a/test/scripts/run-vitest.test.ts
+++ b/test/scripts/run-vitest.test.ts
@@ -1065,46 +1065,65 @@ registerHooks({resolve(specifier, context, nextResolve) {
 
     try {
       expect(await waitForClose(watched.child)).toEqual({ code: null, signal: "SIGTERM" });
+      expect(await watched.completion).toEqual({
+        code: null,
+        signal: "SIGTERM",
+        groupJoined: true,
+      });
     } finally {
       watched.teardown();
       forceKillVitestProcessGroup(watched.child);
+      await watched.completion;
     }
   });
 
-  posixIt("stops residual process-group descendants before completing", async () => {
+  posixIt.each([
+    { timeout: false, exitCode: 0, expectedCode: 0 },
+    { timeout: true, exitCode: 0, expectedCode: 1 },
+    { timeout: true, exitCode: 7, expectedCode: 7 },
+  ])("settles descendants (timeout=$timeout, child=$exitCode)", async (row) => {
     const watchedEnv = {
       OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS: "5000",
     };
     let noOutputTimedOut = false;
-    const watched = spawnWatchedVitestProcess({
-      pnpmArgs: [
-        "exec",
-        "node",
-        "-e",
-        [
-          'const { spawn } = require("node:child_process");',
-          'process.once("SIGTERM", () => process.exit(0));',
-          'const descendant = spawn(process.execPath, ["-e",',
-          '  "setInterval(() => {}, 1000); process.send(process.pid);",',
-          '], { stdio: ["ignore", "ignore", "ignore", "ipc"] });',
-          'descendant.once("message", (pid) => {',
-          "  descendant.disconnect();",
-          "  process.stdout.write(`${pid}\\n`);",
-          "});",
-          "descendant.unref();",
-          "setInterval(() => {}, 1000);",
-        ].join("\n"),
-      ],
-      spawnParams: {
-        detached: true,
+    // Only watchdog timers are fake; child I/O, diagnostics, and group joins stay real.
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+    const { clock } = setTimeout as typeof setTimeout & { clock: { tick(ms: number): void } };
+    let watched: ReturnType<typeof spawnWatchedVitestProcess>;
+    try {
+      watched = spawnWatchedVitestProcess({
+        pnpmArgs: [
+          "exec",
+          "node",
+          "-e",
+          [
+            'const { spawn } = require("node:child_process");',
+            `process.once("SIGTERM", () => process.exit(${row.exitCode}));`,
+            'const descendant = spawn(process.execPath, ["-e",',
+            '  "setInterval(() => {}, 1000); process.send(process.pid);",',
+            '], { stdio: ["ignore", "ignore", "ignore", "ipc"] });',
+            'descendant.once("message", (pid) => {',
+            "  descendant.disconnect();",
+            "  process.stdout.write(`${pid}\\n`);",
+            "});",
+            "descendant.unref();",
+            "setInterval(() => {}, 1000);",
+          ].join("\n"),
+        ],
+        spawnParams: {
+          detached: true,
+          env: watchedEnv,
+          stdio: ["ignore", "pipe", "pipe"],
+        },
         env: watchedEnv,
-        stdio: ["ignore", "pipe", "pipe"],
-      },
-      env: watchedEnv,
-      onNoOutputTimeout: () => {
-        noOutputTimedOut = true;
-      },
-    });
+        onNoOutputTimeout: () => {
+          noOutputTimedOut = true;
+        },
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+    const rawExit = waitForClose(watched.child, LOAD_SENSITIVE_PROCESS_TIMEOUT_MS);
     let descendantPid = 0;
     const lines = createInterface({ input: watched.child.stdout! });
     const ready = new Promise<void>((resolve, reject) => {
@@ -1115,7 +1134,11 @@ registerHooks({resolve(specifier, context, nextResolve) {
           descendantPid = Number(line);
           expect(Number.isInteger(descendantPid) && descendantPid > 0).toBe(true);
           expect(isProcessAlive(descendantPid)).toBe(true);
-          process.kill(watched.child.pid!, "SIGTERM");
+          if (row.timeout) {
+            clock.tick(Number(watchedEnv.OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS));
+          } else {
+            process.kill(watched.child.pid!, "SIGTERM");
+          }
           resolve();
         } catch (error) {
           reject(error instanceof Error ? error : new Error(String(error)));
@@ -1126,7 +1149,7 @@ registerHooks({resolve(specifier, context, nextResolve) {
 
     try {
       const snapshot = await Promise.race([
-        Promise.all([ready, watched.completion]).then(([, result]) => {
+        Promise.all([ready, rawExit, watched.completion]).then(([, raw, result]) => {
           const psArgs =
             process.platform === "linux" ? ["-eL", "-o", "pgid=,state="] : ["-axo", "pgid=,state="];
           const stateResult = spawnSync("ps", psArgs, {
@@ -1143,9 +1166,9 @@ registerHooks({resolve(specifier, context, nextResolve) {
             stateResult.status === 0 &&
             rows.every(Boolean) &&
             rows
-              .filter((row) => Number(row?.[1]) === watched.child.pid)
-              .every((row) => /^[ZX]/.test(row?.[2] ?? ""));
-          return { groupStopped, noOutputTimedOut, result };
+              .filter((processRow) => Number(processRow?.[1]) === watched.child.pid)
+              .every((processRow) => /^[ZX]/.test(processRow?.[2] ?? ""));
+          return { groupStopped, noOutputTimedOut, raw, result };
         }),
         delay(LOAD_SENSITIVE_PROCESS_TIMEOUT_MS, undefined, { ref: false }).then(() => {
           throw new Error("timed out waiting for watched Vitest completion");
@@ -1154,8 +1177,9 @@ registerHooks({resolve(specifier, context, nextResolve) {
 
       expect(snapshot).toEqual({
         groupStopped: true,
-        noOutputTimedOut: false,
-        result: { code: 0, signal: null, groupJoined: true },
+        noOutputTimedOut: row.timeout,
+        raw: { code: row.exitCode, signal: null },
+        result: { code: row.expectedCode, signal: null, groupJoined: true },
       });
     } finally {
       lines.close();


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where developers or CI could receive a successful test-run exit after the no-output watchdog had terminated a stalled Vitest process. A cooperative child that handled termination and exited zero could hide the expired deadline even though its selected test never ran.

## Why This Change Was Made

The existing diagnostic completion now records the timeout outcome. After diagnostics and process cleanup join, an expired watchdog converts a zero child exit to wrapper exit 1. Nonzero child exits, signals, parent cancellation, output forwarding, and group cleanup keep their existing behavior.

Formatted production/tooling changes are +5/−5 lines (net zero). Tests change by +60/−36 lines, and the docs clarify deadline failures without assuming one timeout duration for every configuration.

## User Impact

Stalled test runs fail reliably even when the child shuts down cleanly. Successful completed runs still pass; existing failures and cancellation retain their status.

## Evidence

The maintained baseline reproduced one intended failure with three passing controls. Final owner and progress coverage passes all 179 tests. Independent Auto Review and paired raw-output/source/lifecycle audits found no actionable P0–P2 problems.

Five ordinary public-wrapper cases ran before and after the repair using native Vitest, its normal subprocess bootstrap, a real global-setup fixture, and the unchanged 120-second no-output watchdog. Both complete phases exited zero after approximately 371 seconds. Only the cooperative timeout case changed: its raw child still exited zero, but the wrapper changed from false success to exit 1 with one failure trailer. Normal completion, exit 7, native exit 143, and planned parent SIGTERM retained their outcomes. Only the normal case ran its selected test. Owned process groups, output pipes, and worker generations closed; external receipts bind the actual phase exits and elapsed times.

The first observer attempt failed qualification and remains excluded from proof. Final lint cleanup replaced a reassigned parameter with an equivalent immutable local and renamed two shadowed test callback variables. Independent analysis verified identical evaluation and outcomes; all 179 tests ran again on the final source. Native proof retains its original source hashes rather than being relabeled as execution of the later binding-only cleanup. Repository checks and fresh managed review cover the final source. This is macOS process-lifecycle proof, not a claim about every operating system.
