### PR TITLE
perf: batch child-session participant reads

### DIFF
--- a/src/config/sessions/session-accessor.sqlite-entry-read.ts
+++ b/src/config/sessions/session-accessor.sqlite-entry-read.ts
@@ -5,8 +5,12 @@ import {
 } from "../../infra/kysely-sync.js";
 import type { DB as OpenClawAgentKyselyDatabase } from "../../state/openclaw-agent-db.generated.js";
 import type { OpenClawAgentDatabase } from "../../state/openclaw-agent-db.js";
+import type { SessionEntrySummary } from "./session-accessor.sqlite-contract.js";
 import type { SqliteSessionOwnerRow } from "./session-accessor.sqlite-owner-projection.js";
-import { projectSqliteSessionParticipants } from "./session-accessor.sqlite-participant-projection.js";
+import {
+  projectSqliteSessionParticipants,
+  projectSqliteSessionParticipantsBatch,
+} from "./session-accessor.sqlite-participant-projection.js";
 import { getSessionKysely } from "./session-accessor.sqlite-scope.js";
 import {
   parseSessionEntryJson as parseSessionEntryRow,
@@ -30,21 +34,14 @@ export type ResolvedSessionEntryRow = {
     SqliteSessionOwnerRow;
 };
 
-/** Decodes a fresh owned entry, including its nested JSON, owner and participant values. */
-export function parseReadableSqliteSessionEntryRow(
+function parseReadableSessionEntryData(
   database: Pick<OpenClawAgentDatabase, "db">,
   row: ResolvedSessionEntryRow["row"],
-  projection: "full" | "list" = "full",
+  projection: "full" | "list",
 ): SessionEntry | null {
   const parsed = parseSessionEntryRow(row, projection);
   if (parsed) {
-    const entry = projectSqliteSessionParticipants(database.db, row.session_key, parsed);
-    if (resolveDeliveryProvenCanonicalSessionKey(row.session_key, entry) !== row.session_key) {
-      throw canonicalSessionKeyMigrationRequiredError(
-        `non-canonical persisted row resolves to session key ${row.session_key}`,
-      );
-    }
-    return entry;
+    return parsed;
   }
   const retainedWindow =
     row.entry_json === "{}"
@@ -62,6 +59,57 @@ export function parseReadableSqliteSessionEntryRow(
   }
   throw canonicalSessionKeyMigrationRequiredError(
     `invalid persisted session row requires repair for ${row.session_key}`,
+  );
+}
+
+function validateDeliveryCanonicalSessionEntry(
+  sessionKey: string,
+  entry: SessionEntry,
+): SessionEntry {
+  if (resolveDeliveryProvenCanonicalSessionKey(sessionKey, entry) !== sessionKey) {
+    throw canonicalSessionKeyMigrationRequiredError(
+      `non-canonical persisted row resolves to session key ${sessionKey}`,
+    );
+  }
+  return entry;
+}
+
+/** Decodes a fresh owned entry, including its nested JSON, owner and participant values. */
+export function parseReadableSqliteSessionEntryRow(
+  database: Pick<OpenClawAgentDatabase, "db">,
+  row: ResolvedSessionEntryRow["row"],
+  projection: "full" | "list" = "full",
+): SessionEntry | null {
+  const parsed = parseReadableSessionEntryData(database, row, projection);
+  return parsed
+    ? validateDeliveryCanonicalSessionEntry(
+        row.session_key,
+        projectSqliteSessionParticipants(database.db, row.session_key, parsed),
+      )
+    : null;
+}
+
+/** Projects one selected row set without repeating participant reads for each entry. */
+export function parseReadableSqliteSessionEntryRows(
+  database: Pick<OpenClawAgentDatabase, "db">,
+  rows: readonly ResolvedSessionEntryRow["row"][],
+  projection: "full" | "list" = "full",
+): SessionEntrySummary[] {
+  const parsedEntries = new Map<string, SessionEntry>();
+  for (const row of rows) {
+    const entry = parseReadableSessionEntryData(database, row, projection);
+    if (entry) {
+      parsedEntries.set(row.session_key, entry);
+    }
+  }
+  if (parsedEntries.size === 0) {
+    return [];
+  }
+  return [...projectSqliteSessionParticipantsBatch(database.db, parsedEntries)].map(
+    ([sessionKey, entry]) => ({
+      sessionKey,
+      entry: validateDeliveryCanonicalSessionEntry(sessionKey, entry),
+    }),
   );
 }
 

--- a/src/config/sessions/session-accessor.sqlite-entry-store.ts
+++ b/src/config/sessions/session-accessor.sqlite-entry-store.ts
@@ -59,6 +59,7 @@ import { resolveDeliveryProvenCanonicalSessionKey } from "./store-entry.js";
 import type { InternalSessionEntry as SessionEntry } from "./types.js";
 export {
   parseReadableSqliteSessionEntryRow,
+  parseReadableSqliteSessionEntryRows,
   readExactSessionEntryJson,
   readExactSessionEntryRow,
   readExactSessionEntryRowValidated,

--- a/src/config/sessions/session-accessor.sqlite-entry.ts
+++ b/src/config/sessions/session-accessor.sqlite-entry.ts
@@ -46,7 +46,7 @@ import {
 } from "./session-accessor.sqlite-entry-equality.js";
 import {
   collectSessionEntryLookupKeys,
-  parseReadableSqliteSessionEntryRow,
+  parseReadableSqliteSessionEntryRows,
   readExactSessionEntryRowValidated,
   readSessionEntryRow,
   readLifecycleTargetSnapshot,
@@ -213,13 +213,11 @@ export function listSessionChildEntriesReadOnly(
         .where("session_key", "!=", resolved.sessionKey)
         .orderBy("session_key", "asc"),
     ).rows;
-    return childRows.flatMap((row) => {
-      if (isInternalSessionEffectsKey(row.session_key)) {
-        return [];
-      }
-      const entry = parseReadableSqliteSessionEntryRow(database, row, scope.projection);
-      return entry ? [{ sessionKey: row.session_key, entry }] : [];
-    });
+    return parseReadableSqliteSessionEntryRows(
+      database,
+      childRows.filter((row) => !isInternalSessionEffectsKey(row.session_key)),
+      scope.projection,
+    );
   }, toDatabaseOptions(resolved));
   return result.found ? result.value : [];
 }

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -5,6 +5,7 @@ import { expectDefined } from "@openclaw/normalization-core";
 import { redactIdentifier } from "@openclaw/normalization-core/node-crypto";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createDeferred, withTestTimeout } from "../../../test/helpers/promise.js";
+import { trackSqliteStatementExecutions } from "../../../test/helpers/sqlite-statement-execution-counter.js";
 import { cleanupTempDirs, makeTempDir } from "../../../test/helpers/temp-dir.js";
 import { makeUserMessage } from "../../../test/helpers/user-message.js";
 import type { MsgContext } from "../../auto-reply/templating.js";
@@ -1196,6 +1197,10 @@ describe("session accessor seam", () => {
         { agentId: "main", sessionKey: childSessionKey, storePath },
         { ...lineage, sessionId: childSessionKey, updatedAt: 43 },
       );
+      recordSessionParticipant(
+        { agentId: "main", sessionKey: childSessionKey, storePath },
+        { identity: { type: "agent", id: childSessionKey }, promptedAt: 43 },
+      );
     }
     const databasePath = expectDefined(
       resolveSqliteTargetFromSessionStorePath(storePath, { agentId: "main" }).path,
@@ -1210,16 +1215,30 @@ describe("session accessor seam", () => {
       .run("agent:main:unrelated-session", "unrelated-session", unrelatedEntryJson, 1);
 
     const parse = vi.spyOn(JSON, "parse");
+    const participantReads = trackSqliteStatementExecutions(database.db, ["participants"], (sql) =>
+      sql.includes('from "session_participants"') ? "participants" : null,
+    );
     try {
-      expect(
-        listSessionChildEntriesReadOnly({ agentId: "main", sessionKey, storePath }).map(
-          (child) => child.sessionKey,
-        ),
-      ).toEqual([
+      const children = listSessionChildEntriesReadOnly({ agentId: "main", sessionKey, storePath });
+      expect(children.map((child) => child.sessionKey)).toEqual([
         "agent:main:focused-both-child",
         "agent:main:focused-parent-child",
         "agent:main:focused-spawned-child",
       ]);
+      expect(
+        children.map(({ sessionKey: childKey, entry }) => ({
+          sessionKey: childKey,
+          participants: entry.participants,
+          participantCount: entry.participantCount,
+        })),
+      ).toEqual(
+        children.map(({ sessionKey: childKey }) => ({
+          sessionKey: childKey,
+          participants: [{ identity: { type: "agent", id: childKey } }],
+          participantCount: 1,
+        })),
+      );
+      expect(participantReads.counts.participants).toBeLessThanOrEqual(1);
       expect(parse.mock.calls.filter(([value]) => value === unrelatedEntryJson)).toHaveLength(0);
       expect(
         resolveSessionEntrySelection({ agentId: "main", sessionKey, storePath }),
@@ -1246,6 +1265,7 @@ describe("session accessor seam", () => {
       ).toMatchObject({ agentId: "main", sessionId: "focused-session", sessionKey });
       expect(parse.mock.calls.filter(([value]) => value === unrelatedEntryJson)).toHaveLength(0);
     } finally {
+      participantReads.restore();
       parse.mockRestore();
     }
   });


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

Listing child sessions slows down as a parent accumulates children. A local fixture with 5,000 children and 10,000 participant records took about 299 ms per child-list read.

## Why This Change Was Made

The existing session-entry read owner now parses the selected children together and uses the existing participant batch projection. This removes a participant query and schema probe for every child while preserving canonical-key validation, ordering, participant metadata, and the existing single-entry read path.

The change only affects reading existing data. It adds no schema, migration, configuration, transaction, retention, or storage-format changes.

## User Impact

Workflows that list a session's children spend less time reading their participant metadata. Existing full and list projections retain their results, including invalid-participant failures and handling of a missing participant table.

## Evidence

Paired measurements call the actual `listSessionChildEntriesReadOnly` owner on the same canonical on-disk SQLite fixture, comparing the saved baseline at `5678830c8960fdc808f22665551ad8ffba42016d` with this change. Node 26.8.2 / SQLite 3.53.4 on Windows; two participants per child, three warmups, eleven alternating samples per implementation, and equal-result assertions:

| Children | Baseline median | Candidate median |
| --- | ---: | ---: |
| 10 | 1.09 ms | 0.57 ms |
| 100 | 5.66 ms | 2.22 ms |
| 1,000 | 62.09 ms | 25.67 ms |
| 5,000 | 299.14 ms | 110.22 ms |

At 5,000 children, participant queries and participant-table schema probes each fall from 5,000 to one. Tail latency for that fixture fell from 321.62 to 117.86 ms. These are local storage-owner measurements, not end-to-end Gateway timings.

- Six selected owner and sibling tests pass across three files. The extended regression fails against the baseline because it executes three participant reads instead of at most one. The filter intentionally excludes the remaining 179 cases.
- Additional public-owner probes preserve full/list results, empty results, invalid-participant failures, and a missing participant table without creating it.
- Core production and full core-test typechecks, formatting, scoped type-aware lint, `git diff --check`, and the remaining changed-file architecture/schema guards pass. Production Knip reports zero unused exports.
- Full-tree/script Knip remains non-green on existing tooling exports: `canonicalProviderName` in `scripts/crabbox-wrapper-providers.mts` and `listPackagedStaticExtensionAssetOutputs` in `scripts/lib/static-extension-assets.mts`. Their owners, importers, and relevant Knip configurations match the baseline; this change does not affect those tooling imports.
- Independent review completed through P2 with one tombstone finding, rejected after exact-source and runtime verification. For a retained `{}` row with `entry_valid=-1`, a matching retained window, and a surviving participant, both baseline and candidate point readers return `null`; both public child-list readers return `[]` for full and list projections. The parser's retained-window branch returns `null`, so the alleged tombstone reconstruction and participant exposure do not occur.

### Existing-data read compatibility

At exact head `4dc1accd5866da1c59ffaae07c771ba9704d4f4a`, a separate probe reopened the existing canonical disk fixture through fresh read-only connections, with no cached writable agent handle. Baseline and candidate public child-list readers returned equal complete results for both full and list projections: 5,000 children and 10,000 participants. Before/after checks preserved every row digest across all 156 tables (15,011 rows), schema digests, `user_version` (agent 20 / shared state 17), SQLite `schema_version` (112 / 212), and both database files' SHA-256 values.

The initial read-only inspection created empty WAL and 32 KiB SHM connection-bookkeeping files; those are recorded separately from persisted database bytes. No writer, migration, repair, or checkpoint was opened for the comparison. This verifies existing-data read compatibility for the changed owner; it is not a release migration claim. The [storage checkpoint](https://github.com/openclaw/openclaw/blob/4dc1accd5866da1c59ffaae07c771ba9704d4f4a/docs/reference/database-schemas/storage-changes.md#review-checkpoint-for-material-changes) explicitly excludes bounded read-only query improvements preserving existing semantics.

Exact-head CI run [34697682973](https://github.com/openclaw/openclaw/actions/runs/34697682973) initially failed before executing `check-guards`: the Matrix crypto dependency download hit `ECONNRESET`, followed by its installer error-handler `ReferenceError`. All other substantive jobs passed. The single rerun succeeded: [check-guards job 103566149884](https://github.com/openclaw/openclaw/actions/runs/34697682973/job/103566149884) and [aggregate CI gate 103566502394](https://github.com/openclaw/openclaw/actions/runs/34697682973/job/103566502394) are green. The complete run finished successfully on the same exact head, attempt 2; no dependency or source change was needed.