### PR TITLE
fix(sessions): reduce metadata reload pauses for large saved prompts

### DIFF
--- a/src/config/sessions/session-accessor.sqlite-excluded-rows.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-excluded-rows.test.ts
@@ -45,10 +45,15 @@ function openDatabase(encoding?: "UTF-8" | "UTF-16le" | "UTF-16be") {
   });
 }
 
-function insertEntry(database: OpenClawAgentDatabase, key: string, id: string, json?: string) {
+function insertEntry(
+  database: OpenClawAgentDatabase,
+  key: string,
+  id: string,
+  json?: string | Buffer,
+) {
   database.db
     .prepare(
-      "INSERT INTO session_nodes (session_key, current_session_id, entry_json, updated_at) VALUES (?, ?, ?, ?)",
+      "INSERT INTO session_nodes (session_key, current_session_id, entry_json, updated_at) VALUES (?, ?, CAST(? AS TEXT), ?)",
     )
     .run(key, id, json ?? JSON.stringify({ sessionId: id, updatedAt: 1 }), 1);
 }
@@ -164,46 +169,96 @@ describe.each(readers)("SQLite $name exclusions", ({ read }) => {
 describe("SQLite exclusion survivor semantics", () => {
   describe.each(["UTF-8", "UTF-16le", "UTF-16be"] as const)("%s JSON boundaries", (encoding) => {
     it.each([
-      ["literal NUL", "\u0000"],
-      ["literal NUL and suffix", "\u0000garbage"],
-      ["valid escaped NUL", ""],
-    ])("keeps %s metadata reads consistent with full rows", (_name, suffix) => {
-      const database = openDatabase(encoding);
-      const key = "agent:main:survivor";
-      const json =
-        JSON.stringify({
-          sessionId: "raw",
-          updatedAt: 1,
-          previousSessionId: "historical",
-          label: "escaped\u0000日本語🦞",
-        }) + suffix;
-      insertEntry(database, key, "raw", json);
-      // Compare the actual full-reader contract, including older Node TEXT bindings.
-      const full = readSessionEntryStore(database, { allowCanonicalRepair: true });
-      const fullEntry = full[key];
-      expect(readSessionMaintenanceCapCandidates({ database, excludedKeys: new Set() })).toEqual(
-        full,
-      );
-      expect([...readReferencedSessionIds(database)].toSorted()).toEqual(
-        fullEntry ? ["historical", "raw"] : ["raw"],
-      );
-      expect(readSessionEntryCount(database)).toBe(Object.keys(full).length);
-      expect([...iterateSessionEntryKeys(database)]).toEqual(Object.keys(full));
-      if (fullEntry) {
-        expect(readExactSessionEntryRow(database, key, "list")?.entry).toEqual(fullEntry);
-      } else {
-        expect(() => readExactSessionEntryRow(database, key)).toThrow(
-          "invalid persisted session row",
+      ["literal NUL", "\u0000", undefined],
+      ["literal NUL and suffix", "\u0000garbage", undefined],
+      ["valid escaped NUL", "", undefined],
+      ["raw noncharacters", "", "noncharacters"],
+      ["raw high surrogate", "", "high"],
+      ["raw low surrogate", "", "low"],
+      ["raw noncharacters with NUL", "\u0000", "noncharacters"],
+      ["raw high surrogate with NUL", "\u0000", "high"],
+      ["raw low surrogate with NUL", "\u0000", "low"],
+    ] as const)(
+      "preserves %s metadata parsing and prompt projection",
+      (_name, suffix, rawLabel) => {
+        const database = openDatabase(encoding);
+        const key = "agent:main:survivor";
+        const prompt = "unused saved prompt".repeat(32);
+        const json =
+          JSON.stringify({
+            sessionId: "raw",
+            updatedAt: 1,
+            previousSessionId: "historical",
+            label: rawLabel ? "RAW_LABEL" : "escaped\u0000日本語🦞",
+            skillsSnapshot: { prompt, skills: [] },
+          }) + suffix;
+        let stored: string | Buffer = json;
+        if (rawLabel) {
+          const bytes = {
+            noncharacters: {
+              "UTF-8": "efbfbeefbfbf",
+              "UTF-16le": "feffffff",
+              "UTF-16be": "fffeffff",
+            },
+            high: { "UTF-8": "eda080", "UTF-16le": "00d8", "UTF-16be": "d800" },
+            low: { "UTF-8": "edb080", "UTF-16le": "00dc", "UTF-16be": "dc00" },
+          }[rawLabel][encoding];
+          const encode = (value: string) => {
+            const buffer = Buffer.from(value, encoding === "UTF-8" ? "utf8" : "utf16le");
+            return encoding === "UTF-16be" ? buffer.swap16() : buffer;
+          };
+          const marker = json.indexOf("RAW_LABEL");
+          stored = Buffer.concat([
+            encode(json.slice(0, marker)),
+            Buffer.from(bytes, "hex"),
+            encode(json.slice(marker + "RAW_LABEL".length)),
+          ]);
+        }
+        insertEntry(database, key, "raw", stored);
+        const storedBytes = database.db.prepare(
+          "SELECT hex(entry_json) AS bytes FROM session_nodes",
         );
-        expect(() => readExactSessionEntryRow(database, key, "list")).toThrow(
-          "invalid persisted session row",
+        const bytesBefore = storedBytes.get()?.bytes;
+        // Compare the actual full-reader contract, including older Node TEXT bindings.
+        const full = readSessionEntryStore(database, { allowCanonicalRepair: true });
+        const fullEntry = full[key];
+        const metadata = fullEntry ? { ...fullEntry } : undefined;
+        if (metadata) {
+          delete metadata.skillsSnapshot;
+          // SQLite's JSON projection normalizes raw UTF-16 noncharacters; full TEXT reads retain them.
+          if (rawLabel === "noncharacters" && encoding !== "UTF-8" && !suffix) {
+            metadata.label = "\uFFFD\uFFFD";
+          }
+        }
+        expect(readSessionMaintenanceCapCandidates({ database, excludedKeys: new Set() })).toEqual(
+          metadata ? { [key]: metadata } : {},
         );
-      }
-      expect(
-        readSessionMaintenanceCapCandidates({ database, excludedKeys: new Set([key]) }),
-      ).toEqual({});
-      expect([...readReferencedSessionIds(database, new Set([key]))]).toEqual([]);
-    });
+        expect([...readReferencedSessionIds(database)].toSorted()).toEqual(
+          fullEntry ? ["historical", "raw"] : ["raw"],
+        );
+        expect(readSessionEntryCount(database)).toBe(Object.keys(full).length);
+        expect([...iterateSessionEntryKeys(database)]).toEqual(Object.keys(full));
+        if (fullEntry) {
+          const listed = readExactSessionEntryRow(database, key, "list");
+          expect(listed?.entry).toEqual(metadata);
+          if (!suffix) {
+            expect(listed?.row.entry_json).not.toContain(prompt);
+          }
+        } else {
+          expect(() => readExactSessionEntryRow(database, key)).toThrow(
+            "invalid persisted session row",
+          );
+          expect(() => readExactSessionEntryRow(database, key, "list")).toThrow(
+            "invalid persisted session row",
+          );
+        }
+        expect(
+          readSessionMaintenanceCapCandidates({ database, excludedKeys: new Set([key]) }),
+        ).toEqual({});
+        expect([...readReferencedSessionIds(database, new Set([key]))]).toEqual([]);
+        expect(storedBytes.get()?.bytes).toBe(bytesBefore);
+      },
+    );
   });
 
   it.each([

--- a/src/config/sessions/session-accessor.sqlite-status.ts
+++ b/src/config/sessions/session-accessor.sqlite-status.ts
@@ -27,10 +27,12 @@ type SessionStatusDatabase = Pick<OpenClawAgentKyselyDatabase, "session_nodes">;
 // Metadata readers do not own prompt snapshots. Strip those bytes before JS allocation;
 // Malformed/overdepth JSON reaches the parser unchanged. Requiring an identity keeps
 // corrupt prompt-only objects distinct from the retained-window "{}" sentinel.
-// SQLite treats literal NUL as EOF; defer those rows to the full parser.
+// SQLite treats literal NUL as EOF. Plain %s stops there too; comparing encoded
+// byte lengths preserves that fallback across database encodings without an instr scan.
 export const sessionEntryMetadataJson =
   /* kysely-allow-raw: preserve raw-row parsing while omitting unused prompt payloads. */ sql<string>`CASE WHEN json_valid(entry_json)
-  THEN CASE WHEN json_type(entry_json, '$.sessionId') = 'text' AND instr(entry_json, char(0)) = 0
+  THEN CASE WHEN json_type(entry_json, '$.sessionId') = 'text'
+      AND length(CAST(entry_json AS BLOB)) = length(CAST(printf('%s', entry_json) AS BLOB))
     THEN json_remove(entry_json, '$.skillsSnapshot', '$.systemPromptReport')
     ELSE entry_json END
   ELSE entry_json END`.as("entry_json");


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled.

</details>

## What Problem This Solves

Fixes an issue where loading the Sessions list spends excessive synchronous time reading metadata when thousands of sessions contain saved prompts and the store snapshot must reload, such as after another SQLite connection commits.

## Why This Change Was Made

The metadata selector must detect literal NUL bytes before using SQLite JSON projection, because SQLite can treat NUL as the end of otherwise malformed JSON. Its `instr` search scans every byte of the saved payload.

Use the byte-length difference between the original text and SQLite's fixed `%s` formatting, which stops at NUL. Both lengths use the database's encoding. Keep JSON validity, session identity, and raw-parser fallback checks intact. Each check uses a temporary SQLite formatting buffer for one row under the existing streaming reader.

## User Impact

Session metadata reloads spend less synchronous time scanning saved prompts. Stored data, external-write freshness, session visibility, and malformed-row handling retain their existing contracts.

## Evidence

A synthetic benchmark exercised the registered `sessions.list` handler with real SQLite stores, 3,000 sessions containing about 101 MB of saved metadata, and a 100-row page. One unrelated commit from another connection preceded each request, exercising the existing snapshot invalidation path. Across 15 unprofiled repetitions on the same frozen dependencies:

| Median duration | Before | After |
| --- | ---: | ---: |
| Full request | 217.65 ms | 135.20 ms |
| Store reload and assembly | 190.95 ms | 111.37 ms |
| Fresh page sharing read | 11.28 ms | 8.50 ms |

These are local synthetic measurements; production impact depends on metadata size and reload frequency.

All 107 selected owner tests passed on each of Node 24.16.0, 26.1.0, and 26.8.2. Coverage includes malformed/overdepth JSON, stale validity markers, identity and timestamp mismatches, external commits, and raw UTF-8/UTF-16LE/UTF-16BE noncharacters and surrogate bytes with and without literal NUL. Valid metadata reads still omit saved prompts before JavaScript hydration, and reads preserve stored bytes. Separate raw-byte guard and selector parity audits passed on all three runtimes.

The full changed-file gate passed, including production/test typechecking, formatting, lint, export scans, and boundary guards. Independent P2 review and ClawSweeper found no actionable issues. [Hosted CI](https://github.com/openclaw/openclaw/actions/runs/34697672028) and the required `openclaw/ci-gate` passed for exact head `8df9c799eef8f9519378ba8ed8b739af5a83ec19`.
