### PR TITLE
fix: adopt Settings write revisions across draft replay

### DIFF
--- a/ui/src/app/server-prefs.ts
+++ b/ui/src/app/server-prefs.ts
@@ -3,6 +3,7 @@
 // stays authoritative when this client cannot write config (viewer scope, offline). Pending local
 // intent shadows server snapshots until the hash-free LWW ack; failed pushes degrade device-local.
 import type { GatewayBrowserClient } from "../api/gateway.ts";
+import type { ConfigPatchAck } from "../lib/config/config-gateway-operations.ts";
 import type { RuntimeConfigCapability } from "../lib/config/runtime-config-capability.ts";
 import type { ApplicationGatewaySnapshot } from "./gateway.ts";
 import { hasOperatorWriteAccess } from "./operator-access.ts";
@@ -545,7 +546,7 @@ async function drainPendingPrefs(writer: ServerUiPrefsWriter, epoch: number): Pr
               // ui.prefs is a deliberately narrow hashless LWW surface enforced by
               // hasHashlessPatchLwwStructure in the gateway. Serialization still
               // matters: a pending whole-config save must commit before this merge.
-              client.request("config.patch", {
+              client.request<ConfigPatchAck>("config.patch", {
                 raw: JSON.stringify({ ui: { prefs: batch } }),
                 ...(batch.sidebarEntries !== undefined
                   ? { replacePaths: ["ui.prefs.sidebarEntries"] }
@@ -554,6 +555,7 @@ async function drainPendingPrefs(writer: ServerUiPrefsWriter, epoch: number): Pr
               }),
             {
               waitForWritesResumed: true,
+              configWriteAck: (ack) => ack,
               canDispatch: () => {
                 if (writer.canPatch === false) {
                   return false;

--- a/ui/src/components/config-form.shared.ts
+++ b/ui/src/components/config-form.shared.ts
@@ -1,7 +1,7 @@
 import { isSensitiveConfigPath } from "../../../src/config/sensitive-paths.js";
 import type { ConfigUiHint, ConfigUiHints } from "../api/types.ts";
 import { t } from "../i18n/index.ts";
-import { hintForPath, pathKey } from "../lib/config-form-utils.ts";
+import { hintForPath, isSensitiveLeafValue, pathKey } from "../lib/config-form-utils.ts";
 
 export {
   hintForPath,
@@ -31,8 +31,6 @@ export function configFieldId(path: Array<string | number>, suffix: string): str
   return `config-field-${key}-${suffix}`;
 }
 
-const ENV_VAR_PLACEHOLDER_PATTERN = /^\$\{[^}]*\}$/;
-
 export function redactedPlaceholder(): string {
   return t("configForm.redactedPlaceholder");
 }
@@ -57,17 +55,6 @@ function enterSensitiveScanNode(state: SensitiveScanState, depth: number): boole
     return false;
   }
   return true;
-}
-
-function isEnvVarPlaceholder(value: string): boolean {
-  return ENV_VAR_PLACEHOLDER_PATTERN.test(value.trim());
-}
-
-function isSensitiveLeafValue(value: unknown): boolean {
-  if (typeof value === "string") {
-    return value.trim().length > 0 && !isEnvVarPlaceholder(value);
-  }
-  return value !== undefined && value !== null;
 }
 
 function isHintSensitive(hint: ConfigUiHint | undefined): boolean {

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -1895,6 +1895,8 @@ export const en: TranslationMap & {
       "Unsaved raw config edits — save or discard them before switching to Form.",
     rawDraftBlocksFormEdit:
       "Unsaved raw config edits could not be parsed; resolve them in the Raw editor before changing settings.",
+    rawDraftUnverified:
+      "Cannot verify the raw draft against the saved configuration; reload and retry.",
     invalidConfig: "Your configuration is invalid. Some settings may not work as expected.",
     dismissWarning: "Don't remind again",
     viewPendingChangesRaw: "View pending changes",

--- a/ui/src/lib/config-form-utils.ts
+++ b/ui/src/lib/config-form-utils.ts
@@ -4,6 +4,13 @@ import type { ConfigUiHint, ConfigUiHints } from "../api/types.ts";
 import { configHintTranslationKey } from "../i18n/lib/config-hint-translation.ts";
 import { translateActive } from "../i18n/lib/translate.ts";
 
+export function isSensitiveLeafValue(value: unknown): boolean {
+  if (typeof value === "string") {
+    return value.trim().length > 0 && !/^\$\{[^}]*\}$/.test(value.trim());
+  }
+  return value !== undefined && value !== null;
+}
+
 export type JsonSchema = {
   type?: string | string[];
   title?: string;

--- a/ui/src/lib/config/config-draft-model.test.ts
+++ b/ui/src/lib/config/config-draft-model.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment node
 import { describe, expect, it, vi } from "vitest";
 import { GatewayRequestError, type GatewayBrowserClient } from "../../api/gateway.ts";
+import * as json5Runtime from "../json5-runtime.ts";
 import {
   CONFIG_FORM_AUTO_SAVE_DEBOUNCE_MS,
   deferred,
@@ -12,12 +13,28 @@ import {
 import { createRuntimeConfigCapability } from "./runtime-config-capability.ts";
 
 describe("config draft model", () => {
-  it.each(["revert", "delete"] as const)(
-    "config.set replays an in-flight %s while preserving canonical siblings",
-    async (edit) => {
+  it.each([
+    { edit: "revert", dispose: false, unavailable: false },
+    { edit: "delete", dispose: false, unavailable: false },
+    { edit: "revert", dispose: false, unavailable: true },
+    { edit: "revert", dispose: true, unavailable: true },
+  ])(
+    "config.set replays $edit (dispose: $dispose, JSON5 unavailable: $unavailable)",
+    async ({ edit, dispose, unavailable }) => {
       vi.useFakeTimers();
       const canonical = { count: 2, ui: { prefs: { locale: "fr" } } };
       const { request, submissions, firstSet } = createDeferredSetServerMock(canonical);
+      if (unavailable) {
+        vi.spyOn(json5Runtime, "parseJson5Text").mockImplementation(JSON.parse);
+        vi.spyOn(json5Runtime, "warmJson5").mockRejectedValue(new Error("Chunk unavailable"));
+        request.mockResolvedValueOnce({
+          config: { count: 1 },
+          raw: '// operator comment\n{"count":1}',
+          hash: "hash-1",
+          valid: true,
+          issues: [],
+        });
+      }
       const { runtimeConfig } = createConfigCapabilityHarness(
         request as GatewayBrowserClient["request"],
       );
@@ -29,6 +46,9 @@ describe("config draft model", () => {
       } else {
         runtimeConfig.removeFormValue(["count"]);
       }
+      if (dispose) {
+        runtimeConfig.dispose();
+      }
       firstSet.resolve({});
       await vi.advanceTimersByTimeAsync(CONFIG_FORM_AUTO_SAVE_DEBOUNCE_MS);
 
@@ -38,8 +58,12 @@ describe("config draft model", () => {
         { count: 2 },
         { ...(edit === "revert" ? { count: 1 } : {}), ui: canonical.ui },
       ]);
-      expect(runtimeConfig.state.configFormDirty).toBe(false);
+      if (!dispose) {
+        expect(runtimeConfig.state.configFormDirty).toBe(false);
+        expect(runtimeConfig.state.configAutoSaveStatus).toBe("saved");
+      }
       runtimeConfig.dispose();
+      vi.restoreAllMocks();
     },
   );
 

--- a/ui/src/lib/config/config-draft-model.test.ts
+++ b/ui/src/lib/config/config-draft-model.test.ts
@@ -70,7 +70,7 @@ describe("config draft model", () => {
   it.each([
     ["comments", "{\n  // Keep this note.\n  count: 2,\n}\n"],
     ["semantic edit", "{ count: 3, /* keep spacing */ }\n"],
-  ])("config.set preserves an in-flight raw %s on its original base", async (_edit, raw) => {
+  ])("config.set adopts its revision and rejects stale raw %s by content", async (_edit, raw) => {
     vi.useFakeTimers();
     const canonical = { count: 2, ui: { prefs: { locale: "fr" } } };
     const { request, submissions, firstSet } = createDeferredSetServerMock(canonical);
@@ -86,8 +86,10 @@ describe("config draft model", () => {
 
     expect(runtimeConfig.state.configRaw).toBe(raw);
     expect(runtimeConfig.state.configFormDirty).toBe(true);
-    expect(runtimeConfig.state.configDraftBaseHash).toBe("hash-1");
+    expect(runtimeConfig.state.configDraftBaseHash).toBe("hash-2");
     expect(runtimeConfig.state.configSnapshot).toMatchObject({ config: canonical, hash: "hash-2" });
+    await expect(runtimeConfig.save()).resolves.toBe(false);
+    expect(runtimeConfig.state.configAutoSaveStatus).toBe("conflict");
     expect(submissions).toHaveLength(1);
     runtimeConfig.dispose();
   });

--- a/ui/src/lib/config/config-draft-model.ts
+++ b/ui/src/lib/config/config-draft-model.ts
@@ -401,9 +401,7 @@ export function assertConfigDraftCurrent(state: RuntimeConfigState): void {
   }
   const original = state.configFormOriginal ?? state.configRawOriginalParsed;
   if (!original) {
-    throw new Error(
-      "Cannot verify the raw draft against the saved configuration; reload and retry.",
-    );
+    throw new Error(t("configView.rawDraftUnverified"));
   }
   if (!configContentConflicts(original, original, canonical)) {
     return;

--- a/ui/src/lib/config/config-draft-model.ts
+++ b/ui/src/lib/config/config-draft-model.ts
@@ -318,7 +318,10 @@ export function configFormForSubmit(state: RuntimeConfigState): Record<string, u
 export type ConfigSubmittedDraft = {
   raw: string;
   form: Record<string, unknown> | null;
-  independentSnapshot?: ConfigSnapshot;
+  // Full-draft writes commit raw/form; independent writes do not submit this
+  // shared draft. Supply their pre-write source (the admitted source for a no-op), or
+  // null for a full draft or an independent write before the initial load.
+  independentSnapshot: ConfigSnapshot | null;
 };
 
 export type ConfigWriteAck = { config: Record<string, unknown>; hash: string };
@@ -394,6 +397,19 @@ function configContentConflicts(
   );
 }
 
+function configFormContentConflicts(
+  original: Record<string, unknown>,
+  current: Record<string, unknown>,
+  canonical: Record<string, unknown>,
+): boolean {
+  const before = projectConfigContent(original, canonical);
+  const draft = projectConfigContent(current, canonical);
+  return (
+    stableStringify(replayConfigDraftEdits(before, draft, canonical)) !==
+    stableStringify(replayConfigDraftEdits(before, canonical, draft))
+  );
+}
+
 export function assertConfigDraftCurrent(state: RuntimeConfigState): void {
   const canonical = resolveEditableSnapshotConfig(state.configSnapshot);
   if (!canonical || state.configDraftBaseHash !== state.configSnapshot?.hash) {
@@ -426,7 +442,7 @@ export function adoptConfigWriteAck(
     currentForm &&
     state.configFormOriginal &&
     previous &&
-    configContentConflicts(state.configFormOriginal, currentForm, previous),
+    configFormContentConflicts(state.configFormOriginal, currentForm, previous),
   );
   const draft =
     currentRaw === submitted.raw

--- a/ui/src/lib/config/config-draft-model.ts
+++ b/ui/src/lib/config/config-draft-model.ts
@@ -418,7 +418,7 @@ export function adoptConfigWriteAck(
   state: RuntimeConfigState,
   submitted: ConfigSubmittedDraft,
   ack: ConfigWriteAck,
-  options: { raw?: string } = {},
+  options: { raw?: ConfigSnapshot["raw"] } = {},
 ) {
   const acknowledgedRaw = options.raw ?? serializeConfigForm(ack.config);
   const currentRaw = serializeFormForSubmit(state);
@@ -468,7 +468,7 @@ export function adoptConfigWriteAck(
       state.lastError = "config changed since last load; re-run config.get and retry";
     }
     state.configFormDirty = true;
-    return;
+    return state.configAutoSaveStatus;
   }
   setConfigRawOriginal(state, acknowledgedRaw);
   state.configFormOriginal = cloneConfigObject(ack.config);
@@ -480,6 +480,7 @@ export function adoptConfigWriteAck(
     state.configRaw = acknowledgedRaw;
     clearConfigDraftTracking(state);
   }
+  return state.configAutoSaveStatus;
 }
 
 function syncConfigDraft(state: RuntimeConfigState, nextForm: Record<string, unknown>) {

--- a/ui/src/lib/config/config-draft-model.ts
+++ b/ui/src/lib/config/config-draft-model.ts
@@ -286,14 +286,6 @@ function coerceFormValues(value: unknown, schema: JsonSchema): unknown {
   return value;
 }
 
-/**
- * Serialize the form state for submission to `config.set` / `config.apply`.
- *
- * HTML `<input>` elements produce string `.value` properties, so numeric and
- * boolean config fields can leak into `configForm` as strings.  We coerce
- * them back to their schema-defined types before JSON serialization so the
- * gateway's Zod validation always sees correctly typed values.
- */
 export function serializeFormForSubmit(state: RuntimeConfigState): string {
   // A clean snapshot submits its raw bytes verbatim: reserializing the parsed
   // form would destroy JSON5 comments/formatting the file already has (the
@@ -301,30 +293,34 @@ export function serializeFormForSubmit(state: RuntimeConfigState): string {
   if (!state.configFormDirty && typeof state.configSnapshot?.raw === "string") {
     return state.configSnapshot.raw;
   }
+  const form = configFormForSubmit(state);
+  return form ? serializeConfigForm(form) : state.configRaw;
+}
+
+export function configFormForSubmit(state: RuntimeConfigState): Record<string, unknown> | null {
   if (state.configFormMode !== "form" || !state.configForm) {
-    return state.configRaw;
+    return null;
   }
   const schema = isRecord(state.configSchema) ? (state.configSchema as JsonSchema) : null;
   const form = schema
     ? (coerceFormValues(state.configForm, schema) as Record<string, unknown>)
     : state.configForm;
-  const sanitized = sanitizeRedactedFormForSubmit(
+  return sanitizeRedactedFormForSubmit(
     form,
     state.configFormOriginal,
     state.configRawOriginalParsed,
   );
-  return serializeConfigForm(sanitized);
 }
+
+export type ConfigSubmittedDraft = { raw: string; form: Record<string, unknown> | null };
 
 export type ConfigWriteAck = { config: Record<string, unknown>; hash: string };
 
 export function replayConfigDraftEdits(
-  submittedRaw: string,
-  currentRaw: string,
+  submitted: Record<string, unknown> | null,
+  current: Record<string, unknown> | null,
   acknowledgedConfig: Record<string, unknown>,
 ): Record<string, unknown> | null {
-  const submitted = parseConfigRawDraft(submittedRaw);
-  const current = parseConfigRawDraft(currentRaw);
   if (!submitted || !current) {
     return null;
   }
@@ -354,16 +350,13 @@ export function replayConfigDraftEdits(
 // after dispatch are replayed; a reload is not needed to repair the receipt.
 export function adoptConfigSetAck(
   state: RuntimeConfigState,
-  submittedRaw: string,
+  submitted: ConfigSubmittedDraft,
   ack: ConfigWriteAck,
 ) {
   const currentRaw = serializeFormForSubmit(state);
   let draft: Record<string, unknown> | null = cloneConfigObject(ack.config);
-  if (currentRaw !== submittedRaw) {
-    draft =
-      state.configFormMode === "raw"
-        ? null
-        : replayConfigDraftEdits(submittedRaw, currentRaw, ack.config);
+  if (currentRaw !== submitted.raw) {
+    draft = replayConfigDraftEdits(submitted.form, configFormForSubmit(state), ack.config);
   }
   const acknowledgedRaw = serializeConfigForm(ack.config);
   state.configSnapshot = {

--- a/ui/src/lib/config/config-draft-model.ts
+++ b/ui/src/lib/config/config-draft-model.ts
@@ -2,12 +2,15 @@ import {
   asNullableRecord as asConfigRecord,
   isRecord,
 } from "@openclaw/normalization-core/record-coerce";
+import { stableStringify } from "@openclaw/normalization-core/stable-stringify";
 import { GatewayRequestError } from "../../api/gateway.ts";
 import type { ConfigSnapshot } from "../../api/types.ts";
 import { coerceConfigFormNumberString } from "../../components/config-form.numeric.ts";
 import { t } from "../../i18n/index.ts";
 import {
   cloneConfigObject,
+  isSensitiveLeafValue,
+  REDACTED_SENTINEL,
   removePathValue,
   sanitizeRedactedFormForSubmit,
   schemaMayAcceptString,
@@ -312,11 +315,15 @@ export function configFormForSubmit(state: RuntimeConfigState): Record<string, u
   );
 }
 
-export type ConfigSubmittedDraft = { raw: string; form: Record<string, unknown> | null };
+export type ConfigSubmittedDraft = {
+  raw: string;
+  form: Record<string, unknown> | null;
+  independentSnapshot?: ConfigSnapshot;
+};
 
 export type ConfigWriteAck = { config: Record<string, unknown>; hash: string };
 
-export function replayConfigDraftEdits(
+function replayConfigDraftEdits(
   submitted: Record<string, unknown> | null,
   current: Record<string, unknown> | null,
   acknowledgedConfig: Record<string, unknown>,
@@ -337,7 +344,7 @@ export function replayConfigDraftEdits(
         removePathValue(draft, nextPath);
       } else if (isRecord(before[key]) && isRecord(after[key]) && isRecord(canonical[key])) {
         replay(before[key], after[key], canonical[key], nextPath);
-      } else if (JSON.stringify(before[key]) !== JSON.stringify(after[key])) {
+      } else if (stableStringify(before[key]) !== stableStringify(after[key])) {
         setPathValue(draft, nextPath, cloneConfigObject(after[key]));
       }
     }
@@ -346,19 +353,89 @@ export function replayConfigDraftEdits(
   return draft;
 }
 
-// The server owns the document belonging to this revision. Only edits made
-// after dispatch are replayed; a reload is not needed to repair the receipt.
-export function adoptConfigSetAck(
+// Redacted receipt values describe visibility, not a change to the stored secret.
+function projectConfigContent(
+  config: Record<string, unknown>,
+  canonical: Record<string, unknown>,
+): Record<string, unknown> {
+  const project = (value: unknown, visible: unknown): unknown => {
+    if (visible === REDACTED_SENTINEL && isSensitiveLeafValue(value)) {
+      return REDACTED_SENTINEL;
+    }
+    if (Array.isArray(value)) {
+      return value.map((item, index) =>
+        project(item, Array.isArray(visible) ? visible[index] : undefined),
+      );
+    }
+    if (isRecord(value)) {
+      return Object.fromEntries(
+        Object.entries(value).map(([key, item]) => [
+          key,
+          project(item, isRecord(visible) ? visible[key] : undefined),
+        ]),
+      );
+    }
+    return value;
+  };
+  return Object.fromEntries(
+    Object.entries(config).map(([key, value]) => [key, project(value, canonical[key])]),
+  );
+}
+
+function configContentConflicts(
+  original: Record<string, unknown>,
+  current: Record<string, unknown>,
+  canonical: Record<string, unknown>,
+): boolean {
+  const before = projectConfigContent(original, canonical);
+  const draft = projectConfigContent(current, canonical);
+  return (
+    stableStringify(replayConfigDraftEdits(before, canonical, draft)) !== stableStringify(draft)
+  );
+}
+
+export function assertConfigDraftCurrent(state: RuntimeConfigState): void {
+  const canonical = resolveEditableSnapshotConfig(state.configSnapshot);
+  if (!canonical || state.configDraftBaseHash !== state.configSnapshot?.hash) {
+    return;
+  }
+  const original = state.configFormOriginal ?? state.configRawOriginalParsed;
+  if (!original) {
+    throw new Error(
+      "Cannot verify the raw draft against the saved configuration; reload and retry.",
+    );
+  }
+  if (!configContentConflicts(original, original, canonical)) {
+    return;
+  }
+  const current = configFormForSubmit(state) ?? parseConfigRawDraft(state.configRaw);
+  if (!current || configContentConflicts(original, current, canonical)) {
+    throw new Error("config changed since last load; re-run config.get and retry");
+  }
+}
+
+export function adoptConfigWriteAck(
   state: RuntimeConfigState,
   submitted: ConfigSubmittedDraft,
   ack: ConfigWriteAck,
+  options: { raw?: string } = {},
 ) {
+  const acknowledgedRaw = options.raw ?? serializeConfigForm(ack.config);
   const currentRaw = serializeFormForSubmit(state);
-  let draft: Record<string, unknown> | null = cloneConfigObject(ack.config);
-  if (currentRaw !== submitted.raw) {
-    draft = replayConfigDraftEdits(submitted.form, configFormForSubmit(state), ack.config);
-  }
-  const acknowledgedRaw = serializeConfigForm(ack.config);
+  const currentForm = configFormForSubmit(state);
+  const previous = resolveEditableSnapshotConfig(submitted.independentSnapshot);
+  const staleForm = Boolean(
+    currentForm &&
+    state.configFormOriginal &&
+    previous &&
+    configContentConflicts(state.configFormOriginal, currentForm, previous),
+  );
+  const draft =
+    currentRaw === submitted.raw
+      ? cloneConfigObject(ack.config)
+      : staleForm
+        ? null
+        : replayConfigDraftEdits(submitted.form, currentForm, ack.config);
   state.configSnapshot = {
     ...state.configSnapshot,
     raw: acknowledgedRaw,
@@ -368,21 +445,39 @@ export function adoptConfigSetAck(
     config: ack.config,
     sourceConfig: ack.config,
   };
+  state.configDraftBaseHash = ack.hash;
   state.configValid = true;
   state.configIssues = [];
-  // Replaying raw text would discard comments and formatting. Keep that buffer
-  // and its old base so manual submission cannot overwrite unseen server edits.
+  state.configAutoSaveStatus = staleForm
+    ? "conflict"
+    : state.configAutoSaveStatus === "paused"
+      ? "paused"
+      : "idle";
   if (!draft) {
+    if (!staleForm) {
+      setConfigRawOriginal(state, submitted.raw);
+      state.configFormOriginal = submitted.form;
+    }
+    const original = state.configFormOriginal ?? state.configRawOriginalParsed;
+    const current = currentForm ?? parseConfigRawDraft(state.configRaw);
+    if (
+      staleForm ||
+      (original && current && configContentConflicts(original, current, ack.config))
+    ) {
+      state.configAutoSaveStatus = "conflict";
+      state.lastError = "config changed since last load; re-run config.get and retry";
+    }
     state.configFormDirty = true;
     return;
   }
   setConfigRawOriginal(state, acknowledgedRaw);
   state.configFormOriginal = cloneConfigObject(ack.config);
-  state.configDraftBaseHash = ack.hash;
   state.configForm = draft;
   state.configRaw = serializeConfigForm(draft);
-  state.configFormDirty = state.configRaw !== acknowledgedRaw;
+  state.configFormDirty = state.configRaw !== serializeConfigForm(ack.config);
   if (!state.configFormDirty) {
+    state.configAutoSaveStatus = "idle";
+    state.configRaw = acknowledgedRaw;
     clearConfigDraftTracking(state);
   }
 }

--- a/ui/src/lib/config/config-gateway-operations.test.ts
+++ b/ui/src/lib/config/config-gateway-operations.test.ts
@@ -426,7 +426,7 @@ describe("config gateway operations", () => {
     runtimeConfig.dispose();
   });
 
-  it("keeps a concurrent dirty draft on its pre-patch CAS base", async () => {
+  it("config.patch rebases a concurrent form draft onto its acknowledged revision", async () => {
     vi.useFakeTimers();
     const patchGate = deferred<unknown>();
     const request = vi.fn((method: string) => {
@@ -455,8 +455,9 @@ describe("config gateway operations", () => {
     patchGate.resolve({ config: { count: 1, patched: true }, hash: "hash-2" });
     await expect(patch).resolves.toBe(true);
 
+    expect(runtimeConfig.state.configForm).toEqual({ count: 2, patched: true });
     expect(runtimeConfig.state.configFormDirty).toBe(true);
-    expect(runtimeConfig.state.configDraftBaseHash).toBe("hash-1");
+    expect(runtimeConfig.state.configDraftBaseHash).toBe("hash-2");
     expect(runtimeConfig.state.configSnapshot?.hash).toBe("hash-2");
     expect(runtimeConfig.state.configAutoSaveStatus).toBe("idle");
     runtimeConfig.resetDraft();

--- a/ui/src/lib/config/config-gateway-operations.ts
+++ b/ui/src/lib/config/config-gateway-operations.ts
@@ -185,7 +185,7 @@ export async function executeConfigExternalMutation<T>(
   const submitted = {
     raw: state.configFormDirty ? state.configRawOriginal : serializeFormForSubmit(state),
     form: state.configFormOriginal,
-    independentSnapshot: state.configSnapshot ?? undefined,
+    independentSnapshot: state.configSnapshot,
   };
   let value: T;
   try {
@@ -244,7 +244,11 @@ export async function executeConfigExternalMutation<T>(
       }
       adoptConfigWriteAck(
         state,
-        { raw: state.configRawOriginal, form: state.configFormOriginal },
+        {
+          raw: state.configRawOriginal,
+          form: state.configFormOriginal,
+          independentSnapshot: snapshot,
+        },
         { config, hash: snapshot.hash },
         { raw: snapshot.raw },
       );
@@ -429,7 +433,7 @@ export async function submitConfigDraft(
     }
     assertConfigDraftCurrent(state);
     const raw = serializeFormForSubmit(state);
-    const submitted = { raw, form: configFormForSubmit(state) };
+    const submitted = { raw, form: configFormForSubmit(state), independentSnapshot: null };
     submittedFormRaw = state.configFormMode === "form" ? raw : null;
     const baseHash = state.configDraftBaseHash ?? state.configSnapshot?.hash;
     if (!baseHash) {
@@ -512,7 +516,11 @@ export function teardownFlushConfigDraft(
     state.configAutoSaveStatus = isConfigBaseHashConflictError(error) ? "conflict" : "error";
     return;
   }
-  const draft = { raw: serializeFormForSubmit(state), form: configFormForSubmit(state) };
+  const draft = {
+    raw: serializeFormForSubmit(state),
+    form: configFormForSubmit(state),
+    independentSnapshot: null,
+  };
   void client
     .request<ConfigWriteAck>("config.set", { raw: draft.raw, baseHash: ack.hash })
     .then((receipt) => adoptConfigWriteAck(state, draft, receipt))

--- a/ui/src/lib/config/config-gateway-operations.ts
+++ b/ui/src/lib/config/config-gateway-operations.ts
@@ -8,11 +8,11 @@ import { serializeConfigForm } from "../config-form-utils.ts";
 import { formatUiError, formatUiExternalText } from "../format-error.ts";
 import { showToast } from "../toast.ts";
 import {
-  adoptConfigSetAck,
+  adoptConfigWriteAck,
   configFormForSubmit,
+  assertConfigDraftCurrent,
   type ConfigSubmittedDraft,
   applyConfigSnapshot,
-  replayConfigDraftEdits,
   formatConfigMutationError,
   serializeFormForSubmit,
   type ConfigWriteAck,
@@ -100,7 +100,7 @@ export type ConfigPatchBuilder = (
   config: Readonly<Record<string, unknown>>,
 ) => ConfigPatchBuildResult;
 // Gateway commitGatewayConfigWrite returns persisted hashes; only a no-op patch omits one.
-type ConfigPatchAck =
+export type ConfigPatchAck =
   | { noop: true; config: Record<string, unknown> }
   | (ConfigWriteAck & { noop?: false });
 
@@ -122,6 +122,8 @@ export type RuntimeConfigExternalMutationOptions<T = unknown> = {
   dispatchError?: string;
   /** Refresh only responses that changed configuration, such as completed device authorization. */
   shouldRefresh?: (value: T) => boolean;
+  /** Select the persisted receipt for independent config.set/config.patch writes. */
+  configWriteAck?: (value: T) => ConfigPatchAck;
 };
 
 export type RuntimeConfigDispatchOptions = {
@@ -164,6 +166,7 @@ export async function executeConfigExternalMutation<T>(
   task: (client: GatewayBrowserClient) => Promise<T>,
   options: RuntimeConfigExternalMutationOptions<T>,
   refresh: () => Promise<Result<void, string>>,
+  onSubmitted?: ConfigSubmissionObserver,
 ): Promise<RuntimeConfigExternalMutationResult<T>> {
   if (!isCurrentConfigConnection(state, client, connectionEpoch)) {
     return {
@@ -179,6 +182,11 @@ export async function executeConfigExternalMutation<T>(
       error: options.dispatchError ?? "Access changed before the configuration update started.",
     };
   }
+  const submitted = {
+    raw: state.configFormDirty ? state.configRawOriginal : serializeFormForSubmit(state),
+    form: state.configFormOriginal,
+    independentSnapshot: state.configSnapshot ?? undefined,
+  };
   let value: T;
   try {
     value = await task(client);
@@ -205,10 +213,27 @@ export async function executeConfigExternalMutation<T>(
     value,
     refresh: { ok: false, error },
   });
-  if (!isCurrentConfigConnection(state, client, connectionEpoch)) {
-    return refreshFailure("Connection changed before the configuration update was refreshed.");
-  }
   try {
+    if (options.configWriteAck) {
+      const receipt = options.configWriteAck(value);
+      // A hashless no-op has no source revision. Its runtime projection cannot
+      // serve as a persisted document; read the authoritative source pair.
+      const snapshot =
+        receipt.noop === true ? await client.request<ConfigSnapshot>("config.get", {}) : null;
+      const config = snapshot ? resolveEditableSnapshotConfig(snapshot) : receipt.config;
+      const hash = receipt.noop === true ? snapshot?.hash : receipt.hash;
+      if (!config || !hash) {
+        throw new Error("Config hash missing; refresh and retry.");
+      }
+      const ack = { config, hash };
+      onSubmitted?.({ ...submitted, ack });
+      if (isCurrentConfigConnection(state, client, connectionEpoch)) {
+        adoptConfigWriteAck(state, submitted, ack, { raw: snapshot?.raw });
+      }
+    }
+    if (!isCurrentConfigConnection(state, client, connectionEpoch)) {
+      return refreshFailure("Connection changed before the configuration update was refreshed.");
+    }
     if (options.shouldRefresh && !options.shouldRefresh(value)) {
       return { ok: true, value, refresh: { ok: true } };
     }
@@ -397,6 +422,7 @@ export async function submitConfigDraft(
     if (!isCurrent() || !canSubmitDraft()) {
       return false;
     }
+    assertConfigDraftCurrent(state);
     const raw = serializeFormForSubmit(state);
     const submitted = { raw, form: configFormForSubmit(state) };
     submittedFormRaw = state.configFormMode === "form" ? raw : null;
@@ -427,11 +453,8 @@ export async function submitConfigDraft(
     if (!isCurrent()) {
       return false;
     }
-    adoptConfigSetAck(state, submitted, ack);
+    adoptConfigWriteAck(state, submitted, ack);
     state.configNeedsApply = mode !== "apply";
-    if (mode === "apply") {
-      state.configAutoSaveStatus = "idle";
-    }
     // Manual writes refresh resolved values and applied revision truth. Autosave
     // already has its authoritative hash and must not lock editors with a reload.
     if (mode !== "auto") {
@@ -440,7 +463,7 @@ export async function submitConfigDraft(
         return false;
       }
     }
-    if (mode !== "apply") {
+    if (mode !== "apply" && state.configAutoSaveStatus !== "conflict") {
       state.configAutoSaveStatus = state.configFormDirty ? "idle" : "saved";
     }
     return true;
@@ -473,26 +496,28 @@ export function teardownFlushConfigDraft(
   ack: ConfigWriteAck,
   canDispatch: () => boolean,
 ): void {
-  // Must stay synchronous: page unload destroys the context before any
-  // deferred work runs. If a JSON5 original parse is still pending, sanitize
-  // passes placeholders through; the gateway restores restorable sentinels
-  // (restoreRedactedValues) and rejects unrestorable ones, so the worst case
-  // matches not flushing at all while the common case saves the draft.
-  if (!canDispatch()) {
+  adoptConfigWriteAck(state, submitted, ack);
+  if (!canDispatch() || !state.configFormDirty) {
     return;
   }
-  const draft = replayConfigDraftEdits(submitted.form, configFormForSubmit(state), ack.config);
-  if (draft) {
-    void client
-      .request("config.set", { raw: serializeConfigForm(draft), baseHash: ack.hash })
-      .catch(() => undefined);
+  try {
+    assertConfigDraftCurrent(state);
+  } catch (error) {
+    state.lastError = formatUiError(error);
+    state.configAutoSaveStatus = isConfigBaseHashConflictError(error) ? "conflict" : "error";
+    return;
   }
+  const draft = { raw: serializeFormForSubmit(state), form: configFormForSubmit(state) };
+  void client
+    .request<ConfigWriteAck>("config.set", { raw: draft.raw, baseHash: ack.hash })
+    .then((receipt) => adoptConfigWriteAck(state, draft, receipt))
+    .catch(() => undefined);
 }
 
 export async function patchConfig(
   state: RuntimeConfigState,
   options: ConfigPatchOptions,
-  onAck?: (ack: ConfigPatchAck, snapshotAtDispatch: ConfigSnapshot) => void,
+  onSubmitted?: ConfigSubmissionObserver,
 ): Promise<boolean> {
   const client = state.client;
   const currentSnapshot = state.configSnapshot;
@@ -501,7 +526,8 @@ export async function patchConfig(
   }
   const connectionEpoch = currentConfigConnectionEpoch(state);
   const baseHash = currentSnapshot.hash;
-  if (!baseHash) {
+  const currentConfig = resolveEditableSnapshotConfig(currentSnapshot);
+  if (!baseHash || !currentConfig) {
     state.lastError = "Config hash missing; refresh and retry.";
     state.configAutoSaveStatus = "conflict";
     return false;
@@ -510,7 +536,11 @@ export async function patchConfig(
     return false;
   }
   const draftStatus = state.configFormDirty ? state.configAutoSaveStatus : "idle";
-  const draftError = state.lastError;
+  const submitted = {
+    raw: state.configRawOriginal,
+    form: state.configFormOriginal,
+    independentSnapshot: currentSnapshot,
+  };
   state.configAutoSaveStatus = "saving";
   state.lastError = null;
   state.chatError = null;
@@ -522,24 +552,29 @@ export async function patchConfig(
       note: options.note,
       ...(options.replacePaths?.length ? { replacePaths: options.replacePaths } : {}),
     });
+    const receipt = {
+      config: ack.noop === true ? currentConfig : ack.config,
+      hash: ack.noop === true ? baseHash : ack.hash,
+    };
+    onSubmitted?.({ ...submitted, ack: receipt });
     if (!isCurrentConfigConnection(state, client, connectionEpoch)) {
       return false;
     }
-    onAck?.(ack, currentSnapshot);
+    adoptConfigWriteAck(state, submitted, receipt, {
+      raw: ack.noop === true ? currentSnapshot.raw : undefined,
+    });
     if (ack.noop !== true) {
       // The commit is authoritative; polling config.get reconciles applied truth.
       state.configNeedsApply = true;
     }
-    // A patch acknowledges only its own intent; it cannot reconcile a separate
-    // stale or connection-paused draft that survived snapshot adoption.
-    const preserveDraftStatus =
-      state.configFormDirty && (draftStatus === "conflict" || draftStatus === "paused");
-    state.configAutoSaveStatus = preserveDraftStatus
-      ? draftStatus
-      : state.configFormDirty
-        ? "idle"
-        : "saved";
-    state.lastError = preserveDraftStatus ? draftError : null;
+    state.configAutoSaveStatus =
+      state.configAutoSaveStatus === "conflict"
+        ? "conflict"
+        : state.configFormDirty && draftStatus === "paused"
+          ? "paused"
+          : state.configFormDirty
+            ? "idle"
+            : "saved";
     return true;
   } catch (err) {
     if (isCurrentConfigConnection(state, client, connectionEpoch)) {
@@ -548,25 +583,6 @@ export async function patchConfig(
     }
     return false;
   }
-}
-
-export function adoptConfigPatchAck(
-  state: RuntimeConfigState,
-  ack: ConfigPatchAck,
-  snapshotAtDispatch: ConfigSnapshot,
-) {
-  const currentSnapshot = state.configSnapshot ?? snapshotAtDispatch;
-  const raw =
-    ack.noop === true ? (currentSnapshot.raw ?? state.configRaw) : serializeConfigForm(ack.config);
-  applyConfigSnapshot(state, {
-    ...currentSnapshot,
-    config: ack.config,
-    sourceConfig: ack.config,
-    hash: ack.noop === true ? currentSnapshot.hash : ack.hash,
-    raw,
-    valid: true,
-    issues: [],
-  });
 }
 
 export async function lookupConfigSchemaPath(

--- a/ui/src/lib/config/config-gateway-operations.ts
+++ b/ui/src/lib/config/config-gateway-operations.ts
@@ -9,6 +9,8 @@ import { formatUiError, formatUiExternalText } from "../format-error.ts";
 import { showToast } from "../toast.ts";
 import {
   adoptConfigSetAck,
+  configFormForSubmit,
+  type ConfigSubmittedDraft,
   applyConfigSnapshot,
   replayConfigDraftEdits,
   formatConfigMutationError,
@@ -362,7 +364,7 @@ function applyConfigSchema(state: RuntimeConfigState, res: ConfigSchemaResponse)
   state.configSchemaVersion = res.version ?? null;
 }
 
-export type ConfigSubmission = { raw: string; ack: ConfigWriteAck | null };
+export type ConfigSubmission = ConfigSubmittedDraft & { ack: ConfigWriteAck | null };
 export type ConfigSubmissionObserver = (submission: ConfigSubmission) => void;
 
 export async function submitConfigDraft(
@@ -396,6 +398,7 @@ export async function submitConfigDraft(
       return false;
     }
     const raw = serializeFormForSubmit(state);
+    const submitted = { raw, form: configFormForSubmit(state) };
     submittedFormRaw = state.configFormMode === "form" ? raw : null;
     const baseHash = state.configDraftBaseHash ?? state.configSnapshot?.hash;
     if (!baseHash) {
@@ -414,17 +417,17 @@ export async function submitConfigDraft(
       state.chatError = null;
     }
     // Dispatch bytes let reconnect recognize a committed write whose ack was lost.
-    onSubmitted?.({ raw, ack: null });
+    onSubmitted?.({ ...submitted, ack: null });
     const ack = await client.request<ConfigWriteAck>(
       mode === "apply" ? "config.apply" : "config.set",
       { raw, baseHash, ...(mode === "apply" ? { sessionKey: state.applySessionKey } : {}) },
     );
     // Report before the epoch fence: teardown can flush against this flight's ack.
-    onSubmitted?.({ raw, ack });
+    onSubmitted?.({ ...submitted, ack });
     if (!isCurrent()) {
       return false;
     }
-    adoptConfigSetAck(state, raw, ack);
+    adoptConfigSetAck(state, submitted, ack);
     state.configNeedsApply = mode !== "apply";
     if (mode === "apply") {
       state.configAutoSaveStatus = "idle";
@@ -466,7 +469,7 @@ export async function submitConfigDraft(
 export function teardownFlushConfigDraft(
   state: RuntimeConfigState,
   client: GatewayBrowserClient,
-  submittedRaw: string,
+  submitted: ConfigSubmittedDraft,
   ack: ConfigWriteAck,
   canDispatch: () => boolean,
 ): void {
@@ -478,7 +481,7 @@ export function teardownFlushConfigDraft(
   if (!canDispatch()) {
     return;
   }
-  const draft = replayConfigDraftEdits(submittedRaw, serializeFormForSubmit(state), ack.config);
+  const draft = replayConfigDraftEdits(submitted.form, configFormForSubmit(state), ack.config);
   if (draft) {
     void client
       .request("config.set", { raw: serializeConfigForm(draft), baseHash: ack.hash })

--- a/ui/src/lib/config/config-gateway-operations.ts
+++ b/ui/src/lib/config/config-gateway-operations.ts
@@ -560,7 +560,7 @@ export async function patchConfig(
     if (!isCurrentConfigConnection(state, client, connectionEpoch)) {
       return false;
     }
-    adoptConfigWriteAck(state, submitted, receipt, {
+    const adoptedStatus = adoptConfigWriteAck(state, submitted, receipt, {
       raw: ack.noop === true ? currentSnapshot.raw : undefined,
     });
     if (ack.noop !== true) {
@@ -568,7 +568,7 @@ export async function patchConfig(
       state.configNeedsApply = true;
     }
     state.configAutoSaveStatus =
-      state.configAutoSaveStatus === "conflict"
+      adoptedStatus === "conflict"
         ? "conflict"
         : state.configFormDirty && draftStatus === "paused"
           ? "paused"

--- a/ui/src/lib/config/config-gateway-operations.ts
+++ b/ui/src/lib/config/config-gateway-operations.ts
@@ -214,27 +214,17 @@ export async function executeConfigExternalMutation<T>(
     refresh: { ok: false, error },
   });
   try {
-    if (options.configWriteAck) {
-      const receipt = options.configWriteAck(value);
-      // A hashless no-op has no source revision. Its runtime projection cannot
-      // serve as a persisted document; read the authoritative source pair.
-      const snapshot =
-        receipt.noop === true ? await client.request<ConfigSnapshot>("config.get", {}) : null;
-      const config = snapshot ? resolveEditableSnapshotConfig(snapshot) : receipt.config;
-      const hash = receipt.noop === true ? snapshot?.hash : receipt.hash;
-      if (!config || !hash) {
-        throw new Error("Config hash missing; refresh and retry.");
-      }
-      const ack = { config, hash };
-      onSubmitted?.({ ...submitted, ack });
+    const receipt = options.configWriteAck?.(value);
+    if (receipt && receipt.noop !== true) {
+      onSubmitted?.({ ...submitted, ack: receipt });
       if (isCurrentConfigConnection(state, client, connectionEpoch)) {
-        adoptConfigWriteAck(state, submitted, ack, { raw: snapshot?.raw });
+        adoptConfigWriteAck(state, submitted, receipt);
       }
     }
     if (!isCurrentConfigConnection(state, client, connectionEpoch)) {
       return refreshFailure("Connection changed before the configuration update was refreshed.");
     }
-    if (options.shouldRefresh && !options.shouldRefresh(value)) {
+    if (receipt?.noop !== true && options.shouldRefresh && !options.shouldRefresh(value)) {
       return { ok: true, value, refresh: { ok: true } };
     }
     const refreshed = await refresh();
@@ -243,6 +233,21 @@ export async function executeConfigExternalMutation<T>(
     }
     if (!refreshed.ok) {
       return refreshFailure(refreshed.error);
+    }
+    if (receipt?.noop === true) {
+      // A no-op has no write revision. Reconcile only the source admitted by
+      // the read owner, without invalidating its successors as a new write.
+      const snapshot = state.configSnapshot;
+      const config = resolveEditableSnapshotConfig(snapshot);
+      if (!config || !snapshot?.hash) {
+        throw new Error("Config hash missing; refresh and retry.");
+      }
+      adoptConfigWriteAck(
+        state,
+        { raw: state.configRawOriginal, form: state.configFormOriginal },
+        { config, hash: snapshot.hash },
+        { raw: snapshot.raw },
+      );
     }
     return { ok: true, value, refresh: { ok: true } };
   } catch (error) {

--- a/ui/src/lib/config/config-noop-read.test.ts
+++ b/ui/src/lib/config/config-noop-read.test.ts
@@ -80,3 +80,99 @@ it.each([false, true])(
     }
   },
 );
+
+it("runExternalMutation preserves a retained form conflict after a hashless no-op", async () => {
+  vi.useFakeTimers();
+  const store = createConfigServerMock();
+  const request = vi.fn(async (method: string, params?: unknown) => {
+    if (method === "config.patch") {
+      return { noop: true, config: { count: 9 } };
+    }
+    if (
+      method === "config.set" &&
+      (params as { baseHash: string }).baseHash !== store.currentHash()
+    ) {
+      throw new Error("config changed since last load; re-run config.get and retry");
+    }
+    return store.request(method, params);
+  });
+  const { runtimeConfig } = createConfigCapabilityHarness(
+    request as GatewayBrowserClient["request"],
+  );
+  await runtimeConfig.ensureLoaded();
+  runtimeConfig.patchForm(["count"], 2);
+  await store.request("config.set", { raw: '{"count":9}', baseHash: "hash-1" });
+  await expect(runtimeConfig.save()).resolves.toBe(false);
+  await runtimeConfig.refresh();
+  expect(runtimeConfig.state.configAutoSaveStatus).toBe("conflict");
+  const mutation = await runtimeConfig.runExternalMutation(
+    (client) => client.request<ConfigPatchAck>("config.patch", { raw: '{"count":9}' }),
+    { configWriteAck: (value) => value },
+  );
+  expect(mutation).toMatchObject({ ok: true, refresh: { ok: true } });
+  const stateAfterNoop = {
+    status: runtimeConfig.state.configAutoSaveStatus,
+    base: runtimeConfig.state.configDraftBaseHash,
+    original: runtimeConfig.state.configFormOriginal,
+    form: runtimeConfig.state.configForm,
+  };
+  runtimeConfig.patchForm(["enabled"], true);
+  const saved = await runtimeConfig.save();
+  const final = await store.request("config.get");
+  try {
+    expect(stateAfterNoop).toMatchObject({
+      status: "conflict",
+      base: "hash-2",
+      original: { count: 1 },
+      form: { count: 2 },
+    });
+    expect(saved).toBe(false);
+    expect(final).toMatchObject({ config: { count: 9 } });
+    expect(store.submissions).toHaveLength(1);
+  } finally {
+    runtimeConfig.resetDraft();
+    runtimeConfig.dispose();
+  }
+});
+
+it("runExternalMutation replays a disjoint form edit made during the no-op source read", async () => {
+  vi.useFakeTimers();
+  const store = createConfigServerMock();
+  const started = deferred<void>();
+  const release = deferred<void>();
+  let holdRead = false;
+  const request = vi.fn(async (method: string, params?: unknown) => {
+    if (method === "config.patch") {
+      holdRead = true;
+      return { noop: true, config: { count: 1, enabled: true } };
+    }
+    const result = await store.request(method, params);
+    if (method === "config.get" && holdRead) {
+      holdRead = false;
+      started.resolve();
+      await release.promise;
+    }
+    return result;
+  });
+  const { runtimeConfig } = createConfigCapabilityHarness(
+    request as GatewayBrowserClient["request"],
+  );
+  await runtimeConfig.ensureLoaded();
+  await store.request("config.set", { raw: '{"count":1,"enabled":true}', baseHash: "hash-1" });
+  const mutation = runtimeConfig.runExternalMutation(
+    (client) => client.request<ConfigPatchAck>("config.patch", { raw: '{"enabled":true}' }),
+    { configWriteAck: (value) => value },
+  );
+  await started.promise;
+  runtimeConfig.patchForm(["count"], 2);
+  const save = runtimeConfig.save();
+  release.resolve();
+  await expect(mutation).resolves.toMatchObject({ ok: true, refresh: { ok: true } });
+  await expect(save).resolves.toBe(true);
+  expect(store.submissions.at(-1)).toMatchObject({ baseHash: "hash-2" });
+  await expect(store.request("config.get")).resolves.toMatchObject({
+    config: { count: 2, enabled: true },
+  });
+  expect(runtimeConfig.state.configAutoSaveStatus).toBe("saved");
+  runtimeConfig.dispose();
+});

--- a/ui/src/lib/config/config-noop-read.test.ts
+++ b/ui/src/lib/config/config-noop-read.test.ts
@@ -1,0 +1,82 @@
+// @vitest-environment node
+import { expect, it, vi } from "vitest";
+import type { GatewayBrowserClient } from "../../api/gateway.ts";
+import type { ConfigPatchAck } from "./config-gateway-operations.ts";
+import {
+  createConfigCapabilityHarness,
+  createConfigServerMock,
+  deferred,
+} from "./config-test-harness.ts";
+
+it.each([false, true])(
+  "runExternalMutation retires a held no-op read through refresh ownership (disconnect: %s)",
+  async (disconnect) => {
+    vi.useFakeTimers();
+    const store = createConfigServerMock();
+    const started = deferred<void>();
+    const release = deferred<void>();
+    let holdNextRead = false;
+    const request = vi.fn(async (method: string, params?: unknown) => {
+      if (method === "config.patch") {
+        return { noop: true, config: { count: 1 } };
+      }
+      if (method === "config.get" && holdNextRead) {
+        holdNextRead = false;
+        const snapshot = await store.request(method, params);
+        started.resolve();
+        await release.promise;
+        return snapshot;
+      }
+      return store.request(method, params);
+    });
+    const { runtimeConfig, publish } = createConfigCapabilityHarness(
+      request as GatewayBrowserClient["request"],
+    );
+    await runtimeConfig.ensureLoaded();
+    holdNextRead = true;
+    const mutation = runtimeConfig.runExternalMutation(
+      (client) => client.request<ConfigPatchAck>("config.patch", { raw: '{"count":1}' }),
+      { configWriteAck: (value) => value },
+    );
+    let outcome: Awaited<typeof mutation> | undefined;
+    void mutation.then((result) => {
+      outcome = result;
+    });
+    await started.promise;
+    try {
+      if (disconnect) {
+        publish(false);
+      } else {
+        await store.request("config.set", {
+          raw: '{"count":1,"enabled":true}',
+          baseHash: "hash-1",
+        });
+        await runtimeConfig.refresh();
+      }
+      await vi.advanceTimersByTimeAsync(0);
+      if (disconnect) {
+        expect(outcome).toMatchObject({ ok: true, refresh: { ok: false } });
+      }
+      release.resolve();
+      await mutation;
+      await vi.advanceTimersByTimeAsync(0);
+      expect(outcome).toMatchObject({ ok: true, refresh: { ok: !disconnect } });
+      expect(runtimeConfig.state.configFormDirty).toBe(false);
+      expect(runtimeConfig.state.configAutoSaveStatus).not.toBe("conflict");
+      expect(runtimeConfig.state.configDraftBaseHash).toBe(disconnect ? "hash-1" : "hash-2");
+      if (!disconnect) {
+        runtimeConfig.patchForm(["count"], 2);
+        await expect(runtimeConfig.save()).resolves.toBe(true);
+        expect(store.submissions.at(-1)).toMatchObject({ baseHash: "hash-2" });
+        await expect(store.request("config.get")).resolves.toMatchObject({
+          config: { count: 2, enabled: true },
+        });
+        expect(runtimeConfig.state.configAutoSaveStatus).toBe("saved");
+      }
+    } finally {
+      release.resolve();
+      await mutation;
+      runtimeConfig.dispose();
+    }
+  },
+);

--- a/ui/src/lib/config/config-patch-coordinator.ts
+++ b/ui/src/lib/config/config-patch-coordinator.ts
@@ -1,7 +1,7 @@
 import {
-  adoptConfigPatchAck,
   patchConfig,
   type ConfigPatchBuildResult,
+  type ConfigSubmissionObserver,
 } from "./config-gateway-operations.ts";
 import {
   currentConfigConnectionEpoch,
@@ -11,8 +11,7 @@ import {
 
 export function createConfigPatchCoordinator(options: {
   state: RuntimeConfigState;
-  dispatch: (task: () => Promise<boolean>) => Promise<boolean>;
-  invalidateConfigLoad: () => void;
+  dispatch: (task: (onSubmitted: ConfigSubmissionObserver) => Promise<boolean>) => Promise<boolean>;
   cancelAppliedRefresh: () => void;
   reconcileAppliedRefresh: () => void;
   reconcileDraft: () => void;
@@ -25,7 +24,7 @@ export function createConfigPatchCoordinator(options: {
   const queue = (resolveOptions: () => ConfigPatchBuildResult): Promise<boolean> => {
     options.cancelAppliedRefresh();
     return options
-      .dispatch(async () => {
+      .dispatch(async (onSubmitted) => {
         // A drained autosave can start its own refresh while this patch waits.
         options.cancelAppliedRefresh();
         const client = state.client;
@@ -41,10 +40,7 @@ export function createConfigPatchCoordinator(options: {
           if (!client || !state.configSnapshot || resolved.options.canDispatch?.() === false) {
             return false;
           }
-          const patched = await patchConfig(state, resolved.options, (ack, snapshotAtDispatch) => {
-            options.invalidateConfigLoad();
-            adoptConfigPatchAck(state, ack, snapshotAtDispatch);
-          });
+          const patched = await patchConfig(state, resolved.options, onSubmitted);
           if (isCurrentConfigConnection(state, client, epoch)) {
             failedPatch = patched ? null : resolveOptions;
             if (patched) {

--- a/ui/src/lib/config/config-patch-recovery.test.ts
+++ b/ui/src/lib/config/config-patch-recovery.test.ts
@@ -85,7 +85,7 @@ describe("config patch recovery", () => {
 
     expect(runtimeConfig.state.configAutoSaveStatus).toBe("paused");
     expect(runtimeConfig.state.configFormDirty).toBe(true);
-    expect(runtimeConfig.state.configForm).toEqual({ count: 7 });
+    expect(runtimeConfig.state.configForm).toEqual({ count: 7, enabled: false });
     expect(request.mock.calls.filter(([method]) => method === "config.set")).toHaveLength(0);
     await expect(server.store.request("config.get")).resolves.toMatchObject({
       config: { count: 1, enabled: false },
@@ -210,7 +210,7 @@ describe("config patch recovery", () => {
       expect(runtimeConfig.state.configFormMode).toBe(mode);
       expect(runtimeConfig.state.configRaw).toBe(draftRaw);
       expect(runtimeConfig.state.configFormOriginal).toEqual({ count: 1 });
-      expect(runtimeConfig.state.configDraftBaseHash).toBe("hash-1");
+      expect(runtimeConfig.state.configDraftBaseHash).toBe("hash-3");
       expect(request.mock.calls.filter(([method]) => method === "config.set")).toHaveLength(1);
       await expect(server.store.request("config.get")).resolves.toMatchObject({
         config: { count: 9, enabled: false },

--- a/ui/src/lib/config/config-write-ack.test.ts
+++ b/ui/src/lib/config/config-write-ack.test.ts
@@ -1,0 +1,414 @@
+// @vitest-environment node
+import { describe, expect, it, vi } from "vitest";
+import type { GatewayBrowserClient } from "../../api/gateway.ts";
+import type { ConfigPatchAck } from "./config-gateway-operations.ts";
+import {
+  CONFIG_FORM_AUTO_SAVE_DEBOUNCE_MS,
+  createConfigCapabilityHarness,
+  createConfigServerMock,
+  createDeferredSetServerMock,
+  deferred,
+} from "./config-test-harness.ts";
+
+describe("acknowledged config revision", () => {
+  it("config.patch through runExternalMutation before loading does not invent a pending draft", async () => {
+    const store = createConfigServerMock();
+    const request = vi.fn((method: string, params?: unknown) =>
+      store.request(method === "config.patch" ? "config.set" : method, params),
+    );
+    const { runtimeConfig } = createConfigCapabilityHarness(
+      request as GatewayBrowserClient["request"],
+    );
+    await runtimeConfig.runExternalMutation(
+      (client) =>
+        client.request<ConfigPatchAck>("config.patch", {
+          raw: '{"count":1,"enabled":true}',
+          baseHash: "hash-1",
+        }),
+      { configWriteAck: (ack) => ack },
+    );
+    expect(runtimeConfig.state.configDraftBaseHash).toBe("hash-2");
+    expect(runtimeConfig.state.configFormDirty).toBe(false);
+    expect(runtimeConfig.state.configForm).toEqual({ count: 1, enabled: true });
+    runtimeConfig.dispose();
+  });
+
+  it("an independent write cannot flush a reconnect-paused draft during disposal", async () => {
+    vi.useFakeTimers();
+    const store = createConfigServerMock();
+    const started = deferred<void>();
+    const release = deferred<void>();
+    const request = vi.fn(async (method: string, params?: unknown) => {
+      if (method === "config.patch") {
+        started.resolve();
+        await release.promise;
+        return store.request("config.set", {
+          raw: '{"count":1,"enabled":true}',
+          baseHash: "hash-1",
+        });
+      }
+      return store.request(method, params);
+    });
+    const { runtimeConfig, publish } = createConfigCapabilityHarness(
+      request as GatewayBrowserClient["request"],
+    );
+    await runtimeConfig.ensureLoaded();
+    runtimeConfig.patchForm(["count"], 2);
+    publish(false);
+    publish(true);
+    await runtimeConfig.ensureLoaded();
+    expect(runtimeConfig.state.configAutoSaveStatus).toBe("paused");
+    const mutation = runtimeConfig.runExternalMutation(
+      (client) => client.request<ConfigPatchAck>("config.patch", { raw: '{"enabled":true}' }),
+      { configWriteAck: (value) => value },
+    );
+    await started.promise;
+    runtimeConfig.dispose();
+    release.resolve();
+    await mutation;
+    await vi.advanceTimersByTimeAsync(0);
+    expect(store.submissions).toHaveLength(1);
+    await expect(store.request("config.get")).resolves.toMatchObject({
+      config: { count: 1, enabled: true },
+    });
+  });
+
+  it.each([false, true])(
+    "a hashless no-op uses a fresh source revision and reports read failure separately (failure: %s)",
+    async (failure) => {
+      const source = { count: 1, enabled: true };
+      const sourceRaw = '{\n  "count": 1,\n  "enabled": true\n}\n';
+      const submissions: Array<{ raw: string; baseHash: string }> = [];
+      let savedSnapshot: { config: Record<string, unknown>; raw: string; hash: string } | null =
+        null;
+      let reads = 0;
+      const request = vi.fn(async (method: string, params?: unknown) => {
+        if (method === "config.get") {
+          reads += 1;
+          if (reads === 1) {
+            return { config: { count: 1 }, raw: '{"count":1}', hash: "hash-1", valid: true };
+          }
+          if (failure) {
+            throw new Error("source read unavailable");
+          }
+          if (savedSnapshot) {
+            return { ...savedSnapshot, valid: true };
+          }
+          return {
+            config: { ...source, runtimeDefault: "resolved" },
+            sourceConfig: source,
+            raw: sourceRaw,
+            hash: "hash-2",
+            valid: true,
+          };
+        }
+        if (method === "config.patch") {
+          return { noop: true, config: { ...source, runtimeDefault: "resolved" } };
+        }
+        if (method === "config.set") {
+          const submission = params as { raw: string; baseHash: string };
+          submissions.push(submission);
+          savedSnapshot = {
+            config: JSON.parse(submission.raw),
+            raw: submission.raw,
+            hash: "hash-3",
+          };
+          return { config: savedSnapshot.config, hash: savedSnapshot.hash };
+        }
+        return {};
+      });
+      const { runtimeConfig } = createConfigCapabilityHarness(
+        request as GatewayBrowserClient["request"],
+      );
+      await runtimeConfig.ensureLoaded();
+      runtimeConfig.setRaw('{"count":2,"enabled":true}');
+      const result = await runtimeConfig.runExternalMutation(
+        (client) => client.request<ConfigPatchAck>("config.patch", { raw: '{"enabled":true}' }),
+        { configWriteAck: (value) => value },
+      );
+      expect(result).toMatchObject({
+        ok: true,
+        value: { noop: true },
+        refresh: failure ? { ok: false, error: "source read unavailable" } : { ok: true },
+      });
+      expect(runtimeConfig.state.configDraftBaseHash).toBe(failure ? "hash-1" : "hash-2");
+      if (!failure) {
+        expect(runtimeConfig.state.configSnapshot?.sourceConfig).toEqual(source);
+        expect(runtimeConfig.state.configSnapshot?.raw).toBe(sourceRaw);
+        await expect(runtimeConfig.save()).resolves.toBe(true);
+        expect(submissions).toEqual([{ raw: '{"count":2,"enabled":true}', baseHash: "hash-2" }]);
+      }
+      runtimeConfig.resetDraft();
+      runtimeConfig.dispose();
+    },
+  );
+
+  it.each([
+    { method: "config.set", dispose: false },
+    { method: "config.set", dispose: true },
+    { method: "config.patch", dispose: false },
+    { method: "config.patch", dispose: true },
+  ])(
+    "independent $method retains its changes and the shared form edit (dispose: $dispose)",
+    async ({ method, dispose }) => {
+      vi.useFakeTimers();
+      const store = createConfigServerMock();
+      const started = deferred<void>();
+      const release = deferred<void>();
+      let independentWrite = true;
+      const request = vi.fn(async (requestMethod: string, params?: unknown) => {
+        if (requestMethod === method && independentWrite) {
+          independentWrite = false;
+          started.resolve();
+          await release.promise;
+          return store.request("config.set", {
+            raw: '{"count":1,"enabled":true}',
+            baseHash: "hash-1",
+          });
+        }
+        return store.request(requestMethod, params);
+      });
+      const { runtimeConfig } = createConfigCapabilityHarness(
+        request as GatewayBrowserClient["request"],
+      );
+      await runtimeConfig.ensureLoaded();
+      const mutation = runtimeConfig.runExternalMutation(
+        (client) =>
+          client.request<ConfigPatchAck>(method, {
+            raw: method === "config.set" ? '{"count":1,"enabled":true}' : '{"enabled":true}',
+            baseHash: "hash-1",
+          }),
+        { configWriteAck: (value) => value },
+      );
+      await started.promise;
+      runtimeConfig.patchForm(["count"], 2);
+      if (dispose) {
+        runtimeConfig.dispose();
+      }
+      release.resolve();
+      await mutation;
+      await vi.advanceTimersByTimeAsync(CONFIG_FORM_AUTO_SAVE_DEBOUNCE_MS);
+      expect(store.submissions).toHaveLength(2);
+      expect(store.submissions[1]?.baseHash).toBe("hash-2");
+      await expect(store.request("config.get")).resolves.toMatchObject({
+        config: { count: 2, enabled: true },
+      });
+      expect(runtimeConfig.state.configDraftBaseHash).toBe("hash-3");
+      runtimeConfig.dispose();
+    },
+  );
+
+  it("a CAS patch no-op keeps the authored document and excludes runtime defaults from the next save", async () => {
+    vi.useFakeTimers();
+    const store = createConfigServerMock();
+    const started = deferred<void>();
+    const release = deferred<void>();
+    const request = vi.fn(async (method: string, params?: unknown) => {
+      if (method === "config.patch") {
+        started.resolve();
+        await release.promise;
+        return { noop: true, config: { count: 1, runtimeDefault: "resolved" } };
+      }
+      return store.request(method, params);
+    });
+    const { runtimeConfig } = createConfigCapabilityHarness(
+      request as GatewayBrowserClient["request"],
+    );
+    await runtimeConfig.ensureLoaded();
+    const originalRaw = runtimeConfig.state.configRaw;
+    const patch = runtimeConfig.patch({ raw: { count: 1 }, note: "Keep fixture count" });
+    await started.promise;
+    runtimeConfig.patchForm(["count"], 2);
+    release.resolve();
+    await expect(patch).resolves.toBe(true);
+    expect(runtimeConfig.state.configRawOriginal).toBe(originalRaw);
+    await vi.advanceTimersByTimeAsync(CONFIG_FORM_AUTO_SAVE_DEBOUNCE_MS);
+    expect(store.submissions).toHaveLength(1);
+    expect(store.submissions[0]?.baseHash).toBe("hash-1");
+    expect(JSON.parse(store.submissions[0]!.raw)).toEqual({ count: 2 });
+    runtimeConfig.dispose();
+  });
+
+  it.each([
+    { mode: "form", dispose: false },
+    { mode: "form", dispose: true },
+    { mode: "raw", dispose: false },
+    { mode: "raw", dispose: true },
+    { mode: "apply", dispose: false },
+    { mode: "apply", dispose: true },
+  ])(
+    "config.set/config.apply adopts its revision after a raw keystroke ($mode save, dispose: $dispose)",
+    async ({ mode, dispose }) => {
+      vi.useFakeTimers();
+      const { request, submissions, firstSet } = createDeferredSetServerMock();
+      const { runtimeConfig } = createConfigCapabilityHarness(((method, params) =>
+        request(
+          method === "config.apply" ? "config.set" : method,
+          params,
+        )) as GatewayBrowserClient["request"]);
+      await runtimeConfig.ensureLoaded();
+      if (mode === "raw") {
+        runtimeConfig.setRaw('{"count":2}');
+      } else {
+        runtimeConfig.patchForm(["count"], 2);
+      }
+      const saving =
+        mode === "raw"
+          ? runtimeConfig.save()
+          : mode === "apply"
+            ? runtimeConfig.apply()
+            : undefined;
+      await vi.advanceTimersByTimeAsync(CONFIG_FORM_AUTO_SAVE_DEBOUNCE_MS);
+      const raw = `${runtimeConfig.state.configRaw}\n`;
+      runtimeConfig.setRaw(raw);
+      if (dispose) {
+        runtimeConfig.dispose();
+      }
+      firstSet.resolve({});
+      await saving;
+      await vi.advanceTimersByTimeAsync(0);
+      expect(runtimeConfig.state.configDraftBaseHash).not.toBe("hash-1");
+      if (!dispose) {
+        expect(runtimeConfig.state.configRaw).toBe(raw);
+        await expect(runtimeConfig.save()).resolves.toBe(true);
+      }
+      await vi.advanceTimersByTimeAsync(0);
+      expect(submissions).toHaveLength(2);
+      expect(submissions[1]).toEqual({ raw, baseHash: "hash-2" });
+      expect(runtimeConfig.state.configDraftBaseHash).toBe("hash-3");
+      runtimeConfig.dispose();
+    },
+  );
+
+  it("config.patch adopts its revision and preserves an in-flight form edit", async () => {
+    vi.useFakeTimers();
+    const store = createConfigServerMock();
+    const started = deferred<void>();
+    const release = deferred<void>();
+    const request = vi.fn(async (method: string, params?: unknown) => {
+      if (method === "config.patch") {
+        started.resolve();
+        await release.promise;
+        return store.request("config.set", {
+          raw: '{"count":1,"enabled":true}',
+          baseHash: "hash-1",
+        });
+      }
+      return store.request(method, params);
+    });
+    const { runtimeConfig } = createConfigCapabilityHarness(
+      request as GatewayBrowserClient["request"],
+    );
+    await runtimeConfig.ensureLoaded();
+    const patch = runtimeConfig.patch({ raw: { enabled: true }, note: "Enable fixture" });
+    await started.promise;
+    runtimeConfig.patchForm(["count"], 2);
+    release.resolve();
+    await expect(patch).resolves.toBe(true);
+    expect(runtimeConfig.state.configDraftBaseHash).toBe("hash-2");
+    runtimeConfig.patchForm(["count"], 3);
+    await vi.advanceTimersByTimeAsync(CONFIG_FORM_AUTO_SAVE_DEBOUNCE_MS);
+    expect(store.submissions[1]?.baseHash).toBe("hash-2");
+    await expect(store.request("config.get")).resolves.toMatchObject({
+      config: { count: 3, enabled: true },
+    });
+    expect(runtimeConfig.state.configAutoSaveStatus).toBe("saved");
+    runtimeConfig.dispose();
+  });
+  it.each([
+    {
+      name: "missing external locale",
+      canonical: { count: 2, locale: "fr" },
+      raw: { count: 3 },
+      form: false,
+      saved: false,
+    },
+    {
+      name: "incorporated external locale",
+      canonical: { count: 2, locale: "fr" },
+      raw: { count: 3, locale: "fr" },
+      form: false,
+      saved: true,
+    },
+    {
+      name: "incorporated objects with reordered keys inside arrays",
+      canonical: { count: 2, entries: [{ id: "first", enabled: true }] },
+      raw: { entries: [{ enabled: true, id: "first" }], count: 3 },
+      form: false,
+      saved: true,
+    },
+    {
+      name: "raw to form with unseen locale",
+      canonical: { count: 2, locale: "fr" },
+      raw: { count: 3 },
+      form: true,
+      saved: false,
+    },
+    {
+      name: "external secret replaced an empty value",
+      canonical: { count: 2, secret: "__OPENCLAW_REDACTED__" },
+      raw: { count: 3, secret: "" },
+      form: false,
+      saved: false,
+    },
+    {
+      name: "external secret replaced a null value",
+      canonical: { count: 2, secret: "__OPENCLAW_REDACTED__" },
+      raw: { count: 3, secret: null },
+      form: false,
+      saved: false,
+    },
+    {
+      name: "external secret replaced an environment reference",
+      canonical: { count: 2, secret: "__OPENCLAW_REDACTED__" },
+      raw: { count: 3, secret: "${SYNTHETIC_SECRET}" },
+      form: false,
+      saved: false,
+    },
+    {
+      name: "own redacted secret object",
+      canonical: { count: 2, secret: "__OPENCLAW_REDACTED__" },
+      raw: { count: 3, secret: { token: "synthetic-secret" } },
+      form: false,
+      saved: true,
+    },
+    {
+      name: "own redacted secret array",
+      canonical: { count: 2, secret: ["__OPENCLAW_REDACTED__"] },
+      raw: { count: 3, secret: ["synthetic-secret", "new-secret"] },
+      form: false,
+      saved: true,
+    },
+  ])("config.set checks acknowledged content: $name", async ({ canonical, raw, form, saved }) => {
+    vi.useFakeTimers();
+    const { request, submissions, firstSet } = createDeferredSetServerMock(canonical);
+    const { runtimeConfig } = createConfigCapabilityHarness(
+      request as GatewayBrowserClient["request"],
+    );
+    await runtimeConfig.ensureLoaded();
+    runtimeConfig.patchForm(["count"], 2);
+    if ("secret" in raw) {
+      runtimeConfig.patchForm(
+        ["secret"],
+        Array.isArray(raw.secret) ? raw.secret.slice(0, 1) : raw.secret,
+      );
+    }
+    await vi.advanceTimersByTimeAsync(CONFIG_FORM_AUTO_SAVE_DEBOUNCE_MS);
+    runtimeConfig.setRaw(JSON.stringify(raw));
+    firstSet.resolve({});
+    await vi.advanceTimersByTimeAsync(0);
+    expect(runtimeConfig.state.configDraftBaseHash).toBe("hash-2");
+    if (form) {
+      runtimeConfig.patchForm(["count"], 4);
+    }
+    await expect(runtimeConfig.save()).resolves.toBe(saved);
+    expect(submissions).toHaveLength(saved ? 2 : 1);
+    if (saved) {
+      expect(submissions[1]?.baseHash).toBe("hash-2");
+    } else {
+      expect(runtimeConfig.state.configAutoSaveStatus).toBe("conflict");
+    }
+    runtimeConfig.resetDraft();
+    runtimeConfig.dispose();
+  });
+});

--- a/ui/src/lib/config/config-write-coordinator.test.ts
+++ b/ui/src/lib/config/config-write-coordinator.test.ts
@@ -1077,7 +1077,7 @@ describe("config write coordinator", () => {
     ]);
   });
 
-  it("config.apply skips the teardown flush behind a pending apply", async () => {
+  it("config.apply chains the final form edit from its acknowledged revision during teardown", async () => {
     vi.useFakeTimers();
     const firstApply = deferred<unknown>();
     let setCalls = 0;
@@ -1109,12 +1109,17 @@ describe("config write coordinator", () => {
     const applyPromise = runtimeConfig.apply();
     await vi.advanceTimersByTimeAsync(0);
 
-    // The gateway is about to restart; a post-apply write is meaningless.
+    // Apply can hot-reload without disconnecting this client.
     runtimeConfig.patchForm(["count"], 3);
     runtimeConfig.dispose();
     firstApply.resolve({});
     await vi.advanceTimersByTimeAsync(CONFIG_FORM_AUTO_SAVE_DEBOUNCE_MS);
     await applyPromise;
-    expect(setCalls).toBe(0);
+    expect(setCalls).toBe(1);
+    expect(request).toHaveBeenCalledWith("config.set", {
+      raw: '{\n  "count": 3\n}\n',
+      baseHash: "hash-2",
+    });
+    expect(runtimeConfig.state.configDraftBaseHash).toBe("hash-9");
   });
 });

--- a/ui/src/lib/config/config-write-coordinator.ts
+++ b/ui/src/lib/config/config-write-coordinator.ts
@@ -768,10 +768,9 @@ export function createConfigWriteCoordinator({
       // the isDisposed() guard exits its loop.
       connectionWake?.();
       // SPA teardown right after an edit must not silently drop it: fire one
-      // last save before timers die. Fire-and-forget — the request leaves
-      // synchronously (or chains once behind an in-flight save) and the
-      // stale-epoch guards skip all state mutation once the connection is
-      // invalidated below.
+      // last save before timers die, or chain once behind an in-flight save.
+      // Invalidation retires live callbacks; the retained receipt below still
+      // updates the draft, while dispatch keeps its captured admission checks.
       const client = state.client;
       const canFlush =
         state.connected && client !== null && !writesSuspended && canCallConfigMethod("config.set");

--- a/ui/src/lib/config/config-write-coordinator.ts
+++ b/ui/src/lib/config/config-write-coordinator.ts
@@ -435,7 +435,7 @@ export function createConfigWriteCoordinator({
         // requests on socket close, so nothing here can hang forever).
         // Remember the uncertain submission for reconnect reconciliation.
         hasInterruptedWrite = true;
-        interruptedWriteRaw = inFlight.submission?.raw ?? null;
+        interruptedWriteRaw = inFlight.submission?.ack ? null : (inFlight.submission?.raw ?? null);
         inFlight = null;
         autoSaveTrailing = false;
       }
@@ -527,7 +527,6 @@ export function createConfigWriteCoordinator({
         flushScheduledDraft: true,
         canDispatch: () => canDispatchConfigMutation("config.patch"),
       }),
-    invalidateConfigLoad,
     cancelAppliedRefresh,
     reconcileAppliedRefresh,
     scheduleAutoSave,
@@ -643,7 +642,7 @@ export function createConfigWriteCoordinator({
       !canDispatchConfigMutation("config.apply")
         ? Promise.resolve(false)
         : afterPendingWritesSettled(
-            async () => {
+            async (onSubmitted) => {
               bindDraftToExplicitSubmit();
               cancelAppliedRefresh();
               // Checked after the drain: a raw draft whose explicit Save is in
@@ -657,7 +656,7 @@ export function createConfigWriteCoordinator({
                 return false;
               }
               try {
-                const applied = await submitConfigDraft(state, "apply", undefined, () => {
+                const applied = await submitConfigDraft(state, "apply", onSubmitted, () => {
                   if (!canDispatchConfigMutation("config.apply")) {
                     return false;
                   }
@@ -732,7 +731,7 @@ export function createConfigWriteCoordinator({
           };
         }
         const result = await afterPendingWritesSettled<RuntimeConfigExternalMutationResult<T>>(
-          () =>
+          (onSubmitted) =>
             executeConfigExternalMutation(
               state,
               mutationClient,
@@ -744,6 +743,7 @@ export function createConfigWriteCoordinator({
                 void trackLoad("config", refresh);
                 return await refresh;
               },
+              onSubmitted,
             ),
           unavailable,
           { flushScheduledDraft: true },
@@ -774,36 +774,33 @@ export function createConfigWriteCoordinator({
       // invalidated below.
       const client = state.client;
       const canFlush =
-        state.connected &&
-        client !== null &&
-        state.configFormMode === "form" &&
-        !writesSuspended &&
-        canAutoSaveDraft() &&
-        canCallConfigMethod("config.set");
+        state.connected && client !== null && !writesSuspended && canCallConfigMethod("config.set");
       const pendingFlight = inFlight;
       cancelScheduledAutoSave();
       disposeAppliedRefresh();
-      if (canFlush && pendingFlight) {
+      if (client && pendingFlight) {
         void pendingFlight.promise.then(() => {
-          // The settled flight could not update dirty/base state past the
-          // epoch guard; a draft whose bytes differ from that submission is a
-          // newer edit and gets exactly one chained final save — never a
-          // parallel one. The save's canonical acknowledgement supplies both
-          // the document and revision for replaying that newer edit.
+          // Adopt the acknowledged pair even when permission or reconnect
+          // admission prevents a final write. Replay owns dirty/revert intent.
           const submitted = pendingFlight.submission;
           const ack = submitted?.ack ?? null;
-
-          // Bytes-vs-submission is the only trustworthy signal here: the
-          // epoch guard blocked the ack's rebase, so a revert back to the
-          // pre-save value reads configFormDirty=false while the persisted
-          // bytes are still the unreverted submission.
-          if (ack && submitted && serializeFormForSubmit(state) !== submitted.raw) {
-            teardownFlushConfigDraft(state, client, submitted, ack, () =>
-              canCallConfigMethod("config.set"),
+          if (ack && submitted) {
+            teardownFlushConfigDraft(
+              state,
+              client,
+              submitted,
+              ack,
+              () =>
+                canFlush && !autoSaveRequiresExplicitSubmit && canCallConfigMethod("config.set"),
             );
           }
         });
-      } else if (canFlush && state.configFormDirty) {
+      } else if (
+        canFlush &&
+        canAutoSaveDraft() &&
+        state.configFormDirty &&
+        state.configFormMode === "form"
+      ) {
         void submitConfigDraft(state, "auto", undefined, () => canCallConfigMethod("config.set"));
       }
       invalidateConfigConnection(state);

--- a/ui/src/lib/config/config-write-coordinator.ts
+++ b/ui/src/lib/config/config-write-coordinator.ts
@@ -792,13 +792,13 @@ export function createConfigWriteCoordinator({
           // the document and revision for replaying that newer edit.
           const submitted = pendingFlight.submission;
           const ack = submitted?.ack ?? null;
-          const submittedRaw = submitted?.raw ?? null;
+
           // Bytes-vs-submission is the only trustworthy signal here: the
           // epoch guard blocked the ack's rebase, so a revert back to the
           // pre-save value reads configFormDirty=false while the persisted
           // bytes are still the unreverted submission.
-          if (ack && submittedRaw !== null && serializeFormForSubmit(state) !== submittedRaw) {
-            teardownFlushConfigDraft(state, client, submittedRaw, ack, () =>
+          if (ack && submitted && serializeFormForSubmit(state) !== submitted.raw) {
+            teardownFlushConfigDraft(state, client, submitted, ack, () =>
               canCallConfigMethod("config.set"),
             );
           }

--- a/ui/src/pages/plugins/install-wizard-controller.ts
+++ b/ui/src/pages/plugins/install-wizard-controller.ts
@@ -2,6 +2,7 @@ import type { ApplicationContext } from "../../app/context.ts";
 import { t } from "../../i18n/index.ts";
 import { registerPluginManagementEnglish } from "../../i18n/locales/en-plugin-management.ts";
 import { serializeConfigForm } from "../../lib/config-form-utils.ts";
+import type { ConfigWriteAck } from "../../lib/config/config-draft-model.ts";
 import { resolveEditableSnapshotConfig } from "../../lib/config/config-state-model.ts";
 import type { PluginDiscoveryDetailResult, PluginListResult } from "../../lib/plugins/index.ts";
 import {
@@ -258,12 +259,15 @@ export class InstallWizardController {
             if (!config || !snapshot?.hash) {
               throw new Error(t("pluginsPage.installWizard.configSaveFailed"));
             }
-            return client.request("config.set", {
+            return client.request<ConfigWriteAck>("config.set", {
               raw: serializeConfigForm(buildPluginConfigurationSet(config, configDraft)),
               baseHash: snapshot.hash,
             });
           },
-          { canDispatch: () => this.isCurrent(attempt, state.catalogId) },
+          {
+            canDispatch: () => this.isCurrent(attempt, state.catalogId),
+            configWriteAck: (ack) => ack,
+          },
         )
       : null;
     const saved = mutation === null || mutation.ok;


### PR DESCRIPTION
Related: #145939, #145983.

## What Problem This Solves

Fixes an issue where reverting a Settings edit during autosave could leave the first value saved and falsely show “Settings changed elsewhere.” A preference no-op could also clear a real conflict and enable an unsafe overwrite.

## Why This Change Was Made

One draft operation adopts acknowledged configuration and revision together for all writes. Form replay preserves compatible changes and retains conflicting original content. Raw edits keep their exact content, and no-op refreshes use the existing ordered read mechanism.

## User Impact

Reverts save correctly; conflicting external changes stay protected until the user reloads. Reconnect-paused drafts still require explicit submission. No configuration or protocol change.

Consumers: Settings autosave, Apply, patches, preference/plugin writes and capability disposal share acknowledgement adoption.

## Evidence

Real-browser checks reproduced the revert and conflict bugs, then confirmed “Saved,” external-value preservation and safe recovery after Reload. Registered configuration capability tests passed 200 cases across eight suites, including delayed reads and disconnects. App-shutdown flushing was not proved.
