### PR TITLE
fix(gateway): reduce allocation churn serving Control UI documents

### DIFF
--- a/src/gateway/control-ui-conditional.http.test.ts
+++ b/src/gateway/control-ui-conditional.http.test.ts
@@ -175,7 +175,7 @@ describe.each([
     }
     await fs.writeFile(
       path.join(root, "index.html"),
-      `<html data-openclaw-control-ui-build-id="source-build"><head><link rel="icon" href="./favicon.svg"><link rel="icon" href="${basePath}/favicon-32.png"></head></html>`,
+      `<html data-openclaw-control-ui-build-id="source-build"><head><script>const fragment = 'href="unfinished';</script><script src="./assets/app-fixture.js"></script><link href="./assets/app.css"><link rel="icon" href="./favicon.svg"><link rel="icon" href="${basePath}/favicon-32.png"></head></html>`,
     );
     server = createServer((req, res) => {
       res.setHeader(
@@ -259,6 +259,9 @@ describe.each([
       expect(document.response.headers["cache-control"]).toBe("no-cache");
       if (method === "GET") {
         const html = document.body.toString();
+        expect(html).toContain(`<script>const fragment = 'href="unfinished';</script>`);
+        expect(html).toContain(`src="${basePath}/assets/app-fixture.js"`);
+        expect(html).toContain(`href="${basePath}/assets/app.css"`);
         expect(html).not.toContain("source-build");
         expect(html.includes('data-openclaw-control-ui-build-id="fixture-build"')).toBe(
           kind === "bundled",

--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -40,6 +40,7 @@ import { safeEqualSecret } from "../security/secret-equal.js";
 import { AVATAR_MAX_BYTES, resolveAvatarMime } from "../shared/avatar-policy.js";
 import { escapeHtml } from "../shared/html-escape.js";
 import { createLazyRuntimeModule } from "../shared/lazy-runtime.js";
+import { escapeRegExp } from "../shared/regexp.js";
 import { resolveUserPath } from "../utils.js";
 import { resolveRuntimeServiceBuildId, resolveRuntimeServiceVersion } from "../version.js";
 import { gatewayAvatarImageRevision } from "./assistant-avatar-cache.js";
@@ -158,20 +159,23 @@ function rewriteControlUiIndexHtmlAssetHrefs(
   buildId?: string,
 ): string {
   const normalized = normalizeControlUiBasePath(basePath);
-  let next = html
-    .replaceAll('src="./assets/', `src="${normalized}/assets/`)
-    .replaceAll('href="./assets/', `href="${normalized}/assets/`);
+  const replacements = new Map<string, string>([
+    ['src="./assets/', `src="${normalized}/assets/`],
+    ['href="./assets/', `href="${normalized}/assets/`],
+  ]);
   for (const asset of CONTROL_UI_ROOT_PUBLIC_ASSETS) {
     const version =
       buildId && isControlUiVersionedPublicAsset(asset) ? `?v=${encodeURIComponent(buildId)}` : "";
     const assetHref = `href="${buildControlUiRootAssetPath(normalized, asset)}${version}"`;
     // Vite's portable ./ base emits relative hrefs, which the browser starts
     // resolving against a nested route before the UI can correct them.
-    next = next.replaceAll(`href="./${asset}"`, assetHref);
-    next = next.replaceAll(`href="/${asset}"`, assetHref);
-    next = next.replaceAll(`href="${buildControlUiRootAssetPath(normalized, asset)}"`, assetHref);
+    replacements.set(`href="./${asset}"`, assetHref);
+    replacements.set(`href="/${asset}"`, assetHref);
+    replacements.set(`href="${buildControlUiRootAssetPath(normalized, asset)}"`, assetHref);
   }
-  return next;
+  // Copy the document once instead of once per matching asset.
+  const pattern = new RegExp([...replacements.keys()].map(escapeRegExp).join("|"), "g");
+  return html.replace(pattern, (match) => replacements.get(match) ?? match);
 }
 
 type ControlUiAvatarMeta = {


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where serving Control UI documents repeatedly creates temporary copies of the entire HTML document for individual asset URLs.

## Why This Change Was Made

Rewrite the existing literal asset references in one pass. Every match is escaped before constructing the matcher, so unrelated raw script text cannot hide later asset references. The resulting document still supplies its inline-script CSP hashes.

## User Impact

Opening and refreshing the Control UI allocates less temporary memory. Root and nested mounts, build versions, and response content remain consistent.

## Evidence

A real HTTP handler benchmark served 900 requests using an 18 KB UI document across four root/nested mount and build variants. Sampled allocations fell from 324.59 MB to 217.44 MB (33.0%); document preparation fell from 182.01 MB to 73.80 MB (59.5%). Response body and CSP hashes matched in every variant. These are allocation measurements, without a retained-memory claim.

All 265 local conditional-HTTP and CSP tests passed. The existing HTTP fixture now includes a raw script string that reproduced a reviewer-found matcher regression before the repair. Independent P0-P2 review of the corrected change found no actionable issues. Linux contract tests also passed in the combined live candidate.

The Windows symlink fixture failed on the unchanged baseline with EPERM and passed on Linux. The first local changed gate exhausted host resources; bounded-concurrency graph, core and all core-test types passed. Remaining guards and scoped lint passed on a byte-identical WSL checkout. Exact-head CI passed, including all dead-export scans in check-dependencies.


The combined candidate passed a live Gateway workload with 1,000 sessions, eight real OpenAI turns (including two synthetic-file read tool calls), 1,200 history reads, 100 session patches, and concurrent list/UI/readiness/subscription activity. Stream, final-event, history and independent persisted-transcript checks all passed. Whole-process sampled allocations were effectively flat in this single pair (9.600 GB baseline, 9.583 GB candidate); targeted benchmark reductions should not be interpreted as a comparable overall memory reduction. Baseline final cleanup proof failed because the harness deleted its live-turn sessions; its pre-cleanup activity/allocation evidence remains valid. Corrected candidate cleanup is still running.

