### PR TITLE
fix(desktop): restore desktop and portal streams under Bun

### DIFF
--- a/docs/install/bun-compatibility.md
+++ b/docs/install/bun-compatibility.md
@@ -68,6 +68,7 @@ When the KNN child cannot load extensions, memory search falls back to a batched
 
 ## Known limitations
 
+- **Desktop WebSockets:** OpenClaw uses the installed `ws` transport for desktop observers and paired-node desktop/portal streams. Bun 1.4.2's built-in `ws` server adapter lacks pause/resume and the Duplex stream bridge; the installed transport preserves backpressure, payload limits, and cleanup when a desktop disconnects.
 - **Lifecycle scripts:** Bun blocks dependency lifecycle scripts unless explicitly trusted with `bun pm trust`.
 - **Package scripts:** Some scripts hardcode pnpm, so `bun run` still invokes pnpm internally.
 - **SQLite handles:** Bun 1.4.2 can retain statement handles and WAL/shared-memory files after `DatabaseSync.close()` or `Symbol.dispose()`; OpenClaw cannot finalize them through Bun's public `node:sqlite` API. See the [upstream close fix](https://github.com/oven-sh/bun/pull/40005); use Node when prompt file release matters.

--- a/scripts/lib/worker-deploy-build-plugin.mts
+++ b/scripts/lib/worker-deploy-build-plugin.mts
@@ -62,9 +62,12 @@ export function createWorkerDeployBuildPlugin(rootDir = process.cwd()) {
     path.resolve("src/infra/net/undici-dispatcher-options.ts"),
   );
   const websocketRuntimePaths = new Set(
-    ["packages/gateway-client/src/websocket.ts", "src/gateway/server-runtime-state.ts"].map(
-      (source) => fs.realpathSync(path.resolve(source)),
-    ),
+    [
+      "packages/gateway-client/src/websocket.ts",
+      "src/gateway/desktop/node-stream-broker.ts",
+      "src/gateway/desktop/observe-bridge.ts",
+      "src/gateway/server-runtime-state.ts",
+    ].map((source) => fs.realpathSync(path.resolve(source))),
   );
   const transcriptionWebsocketPath = fs.realpathSync(
     path.resolve("src/realtime-transcription/websocket-session.ts"),

--- a/src/gateway/desktop/node-stream-broker.ts
+++ b/src/gateway/desktop/node-stream-broker.ts
@@ -1,7 +1,9 @@
 import type { IncomingMessage } from "node:http";
+import { createRequire } from "node:module";
+import path from "node:path";
 import type { Duplex } from "node:stream";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
-import { createWebSocketStream, WebSocket, WebSocketServer, type RawData } from "ws";
+import type { RawData } from "ws";
 import { registerSecretValueForRedaction } from "../../logging/secret-redaction-registry.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import {
@@ -12,6 +14,13 @@ import { createOneTimeTicketStore } from "../../shared/one-time-ticket-store.js"
 import { rejectWebSocketUpgrade } from "../../shared/websocket-upgrade-reject.js";
 import type { NodeRegistry } from "../node-registry.js";
 import { startWebSocketKeepalive } from "../websocket-keepalive.js";
+
+// Node desktop and portal streams need ws's Duplex bridge, which Bun's adapter does not implement.
+const require = createRequire(import.meta.url);
+const { createWebSocketStream, WebSocket, WebSocketServer }: typeof import("ws") = require(
+  path.join(path.dirname(require.resolve("ws/package.json")), "index.js"),
+);
+type WebSocket = import("ws").WebSocket;
 
 const DEFAULT_TICKET_TTL_MS = 60_000;
 const MAX_ATTACH_FRAME_BYTES = 64 * 1024;

--- a/src/gateway/desktop/observe-bridge.ts
+++ b/src/gateway/desktop/observe-bridge.ts
@@ -1,6 +1,8 @@
 import type { IncomingMessage } from "node:http";
+import { createRequire } from "node:module";
+import path from "node:path";
 import type { Duplex } from "node:stream";
-import { WebSocket, WebSocketServer, type RawData } from "ws";
+import type { RawData } from "ws";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { createOneTimeTicketStore } from "../../shared/one-time-ticket-store.js";
 import { rejectWebSocketUpgrade } from "../../shared/websocket-upgrade-reject.js";
@@ -16,6 +18,13 @@ import {
 } from "./rfb-preauth.js";
 import { createRfbClientMessageFilter } from "./rfb-view-only-filter.js";
 import type { DesktopSessionRegistry } from "./session-registry.js";
+
+// Desktop flow control needs the installed ws receiver; Bun's server adapter omits pause/resume.
+const require = createRequire(import.meta.url);
+const { WebSocket, WebSocketServer }: typeof import("ws") = require(
+  path.join(path.dirname(require.resolve("ws/package.json")), "index.js"),
+);
+type WebSocket = import("ws").WebSocket;
 
 export const DESKTOP_OBSERVE_PATH = "/desktop/observe";
 const TOKEN_TTL_MS = 60_000;

--- a/src/gateway/desktop/websocket-runtime.test-support.ts
+++ b/src/gateway/desktop/websocket-runtime.test-support.ts
@@ -1,0 +1,181 @@
+import assert from "node:assert/strict";
+import { once } from "node:events";
+import http from "node:http";
+import path from "node:path";
+import { Duplex } from "node:stream";
+import { setTimeout as delay } from "node:timers/promises";
+import { WebSocket } from "../../../packages/gateway-client/src/websocket.js";
+import { setLoggerOverride } from "../../logging/logger.js";
+import { createNodeDesktopStreamBroker } from "./node-stream-broker.js";
+import { handleDesktopObserveUpgrade, mintDesktopObserverToken } from "./observe-bridge.js";
+
+async function until(predicate: () => boolean) {
+  const deadline = Date.now() + 2_000;
+  while (!predicate()) {
+    assert.ok(Date.now() < deadline, "desktop transport did not settle");
+    await delay(5);
+  }
+}
+
+async function listen(server: http.Server) {
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const address = server.address();
+  assert.ok(address && typeof address !== "string");
+  return `ws://127.0.0.1:${address.port}`;
+}
+
+async function observe(mode: string) {
+  const received: Buffer[] = [];
+  let releaseWrite: (() => void) | undefined;
+  let released = 0;
+  let gatewaySocket: WebSocket | undefined;
+  let closeObserver: ((code: number, reason: string) => void) | undefined;
+  const stream = new Duplex({
+    writableHighWaterMark: 1,
+    read() {},
+    write(chunk, _encoding, callback) {
+      received.push(Buffer.from(chunk));
+      releaseWrite = callback;
+    },
+  });
+  const server = http.createServer();
+  server.on("upgrade", (req, socket, head) => {
+    handleDesktopObserveUpgrade(req, socket, head, {
+      registry: {
+        claimStream: () => stream,
+        attachObserver: (_sourceKey, observer) => {
+          closeObserver = (code, reason) => observer.close(code, reason);
+          return { release: () => released++ };
+        },
+      },
+      getBufferedAmount: (ws) => {
+        gatewaySocket = ws;
+        return ws.bufferedAmount;
+      },
+    });
+  });
+  const url = await listen(server);
+  const { token } = mintDesktopObserverToken({
+    sourceKey: "worker:runtime-proof",
+    ownerEpoch: 1,
+    control: true,
+    attachment: { kind: "stream", streamId: "runtime-proof" },
+  });
+  const client = new WebSocket(`${url}/desktop/observe?token=${token}`);
+  try {
+    await once(client, "open");
+    const banner = once(client, "message");
+    stream.push(Buffer.from("RFB 003.008\n"));
+    assert.equal((await banner)[0].toString(), "RFB 003.008\n");
+
+    if (mode === "observer-backpressure") {
+      client.send(Buffer.from("first"));
+      await until(() => Boolean(releaseWrite));
+      assert.equal(gatewaySocket?.isPaused, true);
+      client.send(Buffer.from("second"));
+      await delay(25);
+      assert.equal(stream.writableLength, 5);
+      assert.equal(Buffer.concat(received).toString(), "first");
+      const firstWrite = releaseWrite;
+      releaseWrite = undefined;
+      firstWrite?.();
+      await until(() => Boolean(releaseWrite));
+      assert.equal(Buffer.concat(received).toString(), "firstsecond");
+      assert.equal(gatewaySocket?.isPaused, true);
+      const closed = once(client, "close");
+      closeObserver?.(1012, "desktop stopped");
+      assert.equal((await closed)[0], 1012);
+    } else if (mode === "observer-payload") {
+      const closed = once(client, "close");
+      client.send(Buffer.alloc(1024 * 1024 + 1));
+      assert.equal((await closed)[0], 1009);
+      assert.equal(received.length, 0);
+    } else {
+      const closed = once(client, "close");
+      client.close();
+      await closed;
+    }
+    await until(() => stream.destroyed && released === 1);
+  } finally {
+    client.terminate();
+    stream.destroy();
+    await new Promise<void>((resolve) => {
+      server.close(() => resolve());
+    });
+  }
+}
+
+async function nodeStream(kind: "desktop" | "portal") {
+  const broker = createNodeDesktopStreamBroker();
+  const binding = { nodeId: "runtime-node", connId: "runtime-connection", pairingGeneration: "1" };
+  const ticket = kind === "desktop" ? broker.mint(binding) : broker.mintPortal(binding);
+  const server = http.createServer();
+  server.on("upgrade", (req, socket, head) => {
+    void broker.handleUpgrade(req, socket, head, {
+      getForPairingGeneration: () => ({
+        ...binding,
+        client: {
+          connId: binding.connId,
+          socket: client,
+          usesSharedGatewayAuth: false,
+          connect: {
+            minProtocol: 1,
+            maxProtocol: 1,
+            client: { id: "node-host", version: "test", platform: "test", mode: "node" },
+          },
+        },
+        declaredCaps: [],
+        caps: [],
+        declaredCommands: [],
+        commands: [],
+        declaredNodePluginTools: [],
+        nodePluginTools: [],
+        nodeSkills: [],
+        connectedAtMs: 0,
+      }),
+      isConnectionCurrentPairingState: async () => true,
+    });
+  });
+  const url = await listen(server);
+  const client = new WebSocket(`${url}${ticket.attachPath}`);
+  let stream: Duplex | undefined;
+  try {
+    await once(client, "open");
+    client.send(
+      Buffer.from(JSON.stringify(kind === "desktop" ? { auth: "vnc-password" } : { ok: true })),
+    );
+    ({ stream } = await ticket.attached);
+    const incoming = once(stream, "data");
+    client.send(Buffer.from("node-to-gateway"));
+    assert.equal((await incoming)[0].toString(), "node-to-gateway");
+    const outgoing = once(client, "message");
+    stream.write(Buffer.from("gateway-to-node"));
+    assert.equal((await outgoing)[0].toString(), "gateway-to-node");
+    const closed = once(client, "close");
+    stream.on("error", () => undefined);
+    client.send(Buffer.alloc(64 * 1024 + 1));
+    assert.equal((await closed)[0], 1009);
+    await until(() => Boolean(stream?.destroyed));
+  } finally {
+    client.terminate();
+    stream?.destroy();
+    ticket.cancel();
+    await new Promise<void>((resolve) => {
+      server.close(() => resolve());
+    });
+  }
+}
+
+export async function runDesktopWebSocketRuntimeProbe(mode: string) {
+  setLoggerOverride({
+    level: "silent",
+    consoleLevel: "silent",
+    file: path.join(process.cwd(), "desktop-runtime.log"),
+  });
+  if (mode === "desktop" || mode === "portal") {
+    await nodeStream(mode);
+  } else {
+    await observe(mode);
+  }
+}

--- a/src/gateway/desktop/websocket-runtime.test.ts
+++ b/src/gateway/desktop/websocket-runtime.test.ts
@@ -1,0 +1,38 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { afterEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+
+const execFileAsync = promisify(execFile);
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+// Node CI shards do not provision Bun; selecting BUN_BIN requires real runtime proof.
+describe.runIf(Boolean(process.env.BUN_BIN))("Bun desktop WebSocket transport", () => {
+  it.each(["observer-close", "observer-backpressure", "observer-payload", "desktop", "portal"])(
+    "preserves %s through the registered upgrade handler",
+    async (mode) => {
+      const root = tempDirs.make("desktop-websocket-runtime-");
+      const fixture = new URL("./websocket-runtime.test-support.ts", import.meta.url).href;
+      const { stdout } = await execFileAsync(
+        process.env.BUN_BIN!,
+        [
+          "--no-env-file",
+          "--no-install",
+          "--eval",
+          `import assert from "node:assert/strict";
+import { runDesktopWebSocketRuntimeProbe } from ${JSON.stringify(fixture)};
+assert.ok(process.versions.bun, "This regression requires the real Bun runtime");
+await runDesktopWebSocketRuntimeProbe(${JSON.stringify(mode)});
+console.log(${JSON.stringify(`desktop-runtime-ok:${mode}`)});`,
+        ],
+        {
+          cwd: root,
+          env: { PATH: process.env.PATH, HOME: root, OPENCLAW_STATE_DIR: root },
+          timeout: 10_000,
+        },
+      );
+      expect(stdout).toContain(`desktop-runtime-ok:${mode}`);
+    },
+    15_000,
+  );
+});

--- a/test/scripts/tsdown-declaration-fixture.ts
+++ b/test/scripts/tsdown-declaration-fixture.ts
@@ -185,6 +185,8 @@ export function createFixture(
     "extensions/browser/src/browser/playwright-core.runtime.ts",
     "src/infra/net/undici-dispatcher-options.ts",
     "packages/gateway-client/src/websocket.ts",
+    "src/gateway/desktop/node-stream-broker.ts",
+    "src/gateway/desktop/observe-bridge.ts",
     "src/gateway/server-runtime-state.ts",
     "src/realtime-transcription/websocket-session.ts",
   ]) {

--- a/test/scripts/worker-deploy-build-plugin.test.ts
+++ b/test/scripts/worker-deploy-build-plugin.test.ts
@@ -135,7 +135,7 @@ console.log("portable worker syntax highlighting passed");
     }
   });
 
-  it("preserves WebSocket transport and lazy transcription in relocated worker output", async () => {
+  it("preserves WebSocket, desktop, and lazy transcription in relocated worker output", async () => {
     const { build } = await import("tsdown");
     const { default: buildConfigs } = await import("../../tsdown.config.ts");
     const configs = Array.isArray(buildConfigs) ? buildConfigs : [buildConfigs];
@@ -156,6 +156,7 @@ console.log("portable worker syntax highlighting passed");
       [
         `export { WebSocket } from ${JSON.stringify(path.resolve("packages/gateway-client/src/websocket.ts"))};`,
         `export { createRealtimeTranscriptionWebSocketSession } from ${JSON.stringify(path.resolve("src/realtime-transcription/websocket-session.ts"))};`,
+        `export { runDesktopWebSocketRuntimeProbe } from ${JSON.stringify(path.resolve("src/gateway/desktop/websocket-runtime.test-support.ts"))};`,
       ].join("\n"),
     );
     const bundles = await build({
@@ -196,7 +197,10 @@ import { createRequire } from "node:module";
 import { pathToFileURL } from "node:url";
 const [entry, url] = process.argv.slice(1);
 assert.throws(() => createRequire(pathToFileURL(entry)).resolve("ws/package.json"), { code: "MODULE_NOT_FOUND" });
-const { WebSocket, createRealtimeTranscriptionWebSocketSession } = await import(pathToFileURL(entry).href);
+const { WebSocket, createRealtimeTranscriptionWebSocketSession, runDesktopWebSocketRuntimeProbe } = await import(pathToFileURL(entry).href);
+for (const mode of ["observer-close", "observer-backpressure", "observer-payload", "desktop", "portal"]) {
+  await runDesktopWebSocketRuntimeProbe(mode);
+}
 const socket = new WebSocket(url + "/client", { headers: { "x-worker-proof": "client-header" } });
 await once(socket, "open");
 const message = once(socket, "message");


### PR DESCRIPTION
## What Problem This Solves

Fixes desktop observation and paired-node desktop/portal streams failing when the Gateway runs on Bun. Connecting can fail because the Duplex bridge is unsupported, while disconnecting or applying backpressure can hit missing server-side pause/resume behavior.

## Why This Change Was Made

Both Gateway stream owners now select the installed `ws` transport, following the existing Gateway client/server pattern. The standalone worker's existing transform includes both owners so its portable bundle retains the same transport without requiring an installed `ws` package at runtime.

## User Impact

Operators using the opt-in Bun runtime can open desktop and portal streams, apply backpressure, and disconnect cleanly. Existing payload limits and connection ownership remain enforced.

## Evidence

- All five native Bun 1.4.2 regression modes failed against unchanged main, then passed with this repair: observer close, backpressure, payload limit, desktop stream, and portal stream.
- All 64 focused tests passed against frozen dependencies, covering the native Bun probes, existing desktop/portal behavior, and portable worker transformation/relocation.
- A previous live deployment of this same production patch verified desktop display plus disconnect/reconnect. The upstream adoption preserves that working repair.
- Shared declaration fixtures include both new build inputs. Their four affected suites passed locally:60 tests passed,2 existing platform-specific cases skipped; hosted Linux CI covers those cases.
- The complete changed-scope gate passed, including all selected typecheck/lint/guard lanes.
- Fresh independent P0–P2 review found no actionable findings. Exact-head CI and the native prepare/merge gates are required before landing.

Related: #140490 fixes the node-host side; this change covers the Gateway desktop/portal owners.
