### PR TITLE
fix: compare Gateway allocations with equal probe workloads

### DIFF
--- a/docs/reference/test/performance.md
+++ b/docs/reference/test/performance.md
@@ -120,6 +120,28 @@ on every turn, including follow-ups. The per-run timeout still bounds the whole
 workload. Health/control sampling is capped at 2,048 samples, while heap
 sampling continues until the full workload finishes.
 
+Use `--probe-rounds N` for allocation comparisons with equal probe work. It
+attempts exactly N sampler rounds and N history bursts per configured history
+client, regardless of which finishes first. Each sampler round requests
+`/readyz`, the Control UI, and `sessions.list`; `--control-plane` adds one each
+of `tasks.list`, `cron.list`, and `cron.status`. Enabling `--subscribers` adds
+one subscribe attempt per round and an unsubscribe after each successful
+subscription. History attempts total `N × historyClients × historyBurst`, capped
+at 2048 per run. Slow clients receive the same history budget as fast clients.
+Failed probes remain recorded failures; counts describe attempts, not successes.
+Omitting the flag retains adaptive probing until agent turns and mutations end.
+
+Fixed probes can finish before or after agent turns. Every configured workload
+joins before final memory and allocation capture; an exhausted load deadline
+fails the run instead of reporting a partial fixed workload as complete. Output
+records the mode and requested counts in `probeWorkload`; actual sampler and
+history counts remain in `summary.sampleCount` and `summary.historySampleCount`.
+Peak RSS is sampled during sampler rounds plus the final memory observation. If
+those rounds finish early, a later transient RSS peak can be missed; this is not
+continuous peak-RSS coverage of the entire agent workload.
+Equal request counts do not equalize their overlap with agent turns or the
+Gateway's time-dependent background work.
+
 `--heap-prof-dir` samples allocations in the Gateway's main V8 isolate, starting
 after startup, session seeding, and probe warmup. Sampling ends after the load
 and its final memory probe, before profile serialization and teardown. It uses

--- a/scripts/bench-gateway-concurrency.ts
+++ b/scripts/bench-gateway-concurrency.ts
@@ -157,6 +157,7 @@ type CliOptions = {
   maxHandshakeMs?: number;
   output?: string;
   pluginCount: number;
+  probeRounds?: number;
   runs: number;
   sessionCount: number;
   sessionUpdateClients: number;
@@ -218,6 +219,7 @@ const VALUE_FLAGS = new Set([
   "--max-handshake-ms",
   "--output",
   "--plugin-count",
+  "--probe-rounds",
   "--runs",
   "--session-count",
   "--session-update-clients",
@@ -323,6 +325,15 @@ function parseOptions(argv: string[] = process.argv.slice(2)): CliOptions {
       "--plugin-count",
       MAX_PLUGIN_COUNT,
     ),
+    probeRounds:
+      parseFlagValue(argv, "--probe-rounds") === undefined
+        ? undefined
+        : parseBoundedPositiveInt(
+            parseFlagValue(argv, "--probe-rounds"),
+            1,
+            "--probe-rounds",
+            MAX_SAMPLES_PER_RUN,
+          ),
     runs: parseBoundedPositiveInt(parseFlagValue(argv, "--runs"), DEFAULT_RUNS, "--runs", MAX_RUNS),
     sessionCount: parseBoundedNonNegativeInt(
       parseFlagValue(argv, "--session-count"),
@@ -379,6 +390,12 @@ function parseOptions(argv: string[] = process.argv.slice(2)): CliOptions {
   const historyMessageCount =
     Math.max(options.sessionCount, options.concurrency) * options.historyMessages;
   if (
+    options.probeRounds !== undefined &&
+    options.probeRounds * options.historyClients * options.historyBurst > MAX_SAMPLES_PER_RUN
+  ) {
+    throw new CliArgumentError("fixed history workload must not exceed 2048 requests per run");
+  }
+  if (
     historyMessageCount > 100_000 ||
     historyMessageCount * options.historyMessageChars > 256 * 1024 * 1024
   ) {
@@ -405,6 +422,7 @@ Options:
   --runs <n>         Measured gateway runs (default: ${DEFAULT_RUNS})
   --warmup <n>       Warmup gateway runs (default: ${DEFAULT_WARMUP})
   --cadence-ms <ms>  Probe cadence (default: ${DEFAULT_CADENCE_MS})
+  --probe-rounds <n> Run exactly n sampler rounds and n bursts per history client
   --timeout-ms <ms>  Per-run cap, excluding probe warmup (default: ${DEFAULT_TIMEOUT_MS})
   --entry <path>     Gateway CLI entry file (default: ${DEFAULT_ENTRY})
   --session-count <n> Seed up to ${MAX_SESSION_COUNT} distinct sessions before load
@@ -1063,6 +1081,41 @@ async function warmGatewayProbes(params: {
   );
 }
 
+async function runProbeRounds(params: {
+  rounds?: number;
+  deadlineAt: number;
+  cadenceMs: number;
+  cadenceFrom: "start" | "completion";
+  runFirst: boolean;
+  shouldContinue: () => boolean;
+  stopped: () => boolean;
+  runRound: (index: number) => Promise<void>;
+}): Promise<number> {
+  let completed = 0;
+  const hasWork = () =>
+    !params.stopped() &&
+    (params.rounds === undefined
+      ? (completed === 0 && params.runFirst) || params.shouldContinue()
+      : completed < params.rounds);
+  while (hasWork()) {
+    requireRemainingMs(params.deadlineAt, "starting gateway probe round");
+    const startedAt = performance.now();
+    await params.runRound(completed);
+    completed += 1;
+    if (!hasWork()) {
+      break;
+    }
+    const elapsed = params.cadenceFrom === "start" ? performance.now() - startedAt : 0;
+    await delay(
+      Math.min(
+        Math.max(0, params.cadenceMs - elapsed),
+        requireRemainingMs(params.deadlineAt, "pacing gateway probes"),
+      ),
+    );
+  }
+  return completed;
+}
+
 async function runGatewaySample(options: {
   cadenceMs: number;
   concurrency: number;
@@ -1077,6 +1130,7 @@ async function runGatewaySample(options: {
   historyMessages: number;
   historyMessageChars: number;
   pluginCount: number;
+  probeRounds?: number;
   sessionCount: number;
   sessionUpdateClients: number;
   sessionUpdates: number;
@@ -1101,6 +1155,8 @@ async function runGatewaySample(options: {
   let mockProvider: ChildProcessWithoutNullStreams | undefined;
   let client: Awaited<ReturnType<typeof connectGateway>> | undefined;
   const auxiliaryClients: Array<Awaited<ReturnType<typeof connectGateway>>> = [];
+  let probesStopped = false;
+  const probeJobs: Promise<unknown>[] = [];
   let gatewayOutput = { readOutput: () => "", readStderrTail: () => "" };
   let mockOutput = { readOutput: () => "", readStderrTail: () => "" };
   let result: BenchmarkRun;
@@ -1392,9 +1448,15 @@ async function runGatewaySample(options: {
           };
         }
       });
-      const sampler = (async () => {
-        for (;;) {
-          const sampleStartedAt = performance.now();
+      const sampler = runProbeRounds({
+        rounds: options.probeRounds,
+        deadlineAt: loadDeadlineAt,
+        cadenceMs: options.cadenceMs,
+        cadenceFrom: "start",
+        runFirst: true,
+        shouldContinue: () => !workloadDone() && readyz.length < MAX_SAMPLES_PER_RUN,
+        stopped: () => probesStopped,
+        runRound: async () => {
           const subscriptionKey = turnSessionKeys[readyz.length % turnSessionKeys.length];
           const [sample, subscription, controlProbes] = await Promise.all([
             sampleGateway({
@@ -1437,37 +1499,37 @@ async function runGatewaySample(options: {
             peakRssMb = Math.max(peakRssMb, readGatewayProcessRssMb(gateway?.pid) ?? 0);
             lastRssSampleAt = performance.now();
           }
-          if (workloadDone() || readyz.length >= MAX_SAMPLES_PER_RUN) {
-            break;
-          }
-          await delay(
-            Math.min(
-              Math.max(0, options.cadenceMs - (performance.now() - sampleStartedAt)),
-              requireRemainingMs(loadDeadlineAt, "sampling gateway load"),
-            ),
-          );
-        }
-      })();
+        },
+      });
+      probeJobs.push(sampler);
       const historyLoad = Promise.all(
-        historyClients.map(async (historyClient, clientIndex) => {
+        historyClients.map((historyClient, clientIndex) => {
           let offset = clientIndex * options.historyBurst;
-          while (!workloadDone() && history.length < MAX_SAMPLES_PER_RUN) {
-            const probes = await Promise.all(
-              Array.from({ length: options.historyBurst }, (_, index) =>
-                timeRpcProbe(
-                  historyClient.request,
-                  "chat.history",
-                  { sessionKey: sessionKeys[(offset + index) % sessionKeys.length] },
-                  runStartedAt,
+          const job = runProbeRounds({
+            rounds: options.probeRounds,
+            deadlineAt: loadDeadlineAt,
+            cadenceMs: options.cadenceMs,
+            cadenceFrom: "completion",
+            runFirst: false,
+            shouldContinue: () => !workloadDone() && history.length < MAX_SAMPLES_PER_RUN,
+            stopped: () => probesStopped,
+            runRound: async () => {
+              const probes = await Promise.all(
+                Array.from({ length: options.historyBurst }, (_, index) =>
+                  timeRpcProbe(
+                    historyClient.request,
+                    "chat.history",
+                    { sessionKey: sessionKeys[(offset + index) % sessionKeys.length] },
+                    runStartedAt,
+                  ),
                 ),
-              ),
-            );
-            history.push(...probes);
-            offset += options.historyBurst;
-            if (!workloadDone()) {
-              await delay(Math.min(options.cadenceMs, remainingMs(loadDeadlineAt)));
-            }
-          }
+              );
+              history.push(...probes);
+              offset += options.historyBurst;
+            },
+          });
+          probeJobs.push(job);
+          return job;
         }),
       );
       let nextUpdateIndex = 0;
@@ -1548,6 +1610,7 @@ async function runGatewaySample(options: {
       const detail = formatRunFailure(error, gatewayOutput, mockOutput);
       throw new Error(detail, { cause: error });
     } finally {
+      probesStopped = true;
       for (const auxiliaryClient of auxiliaryClients) {
         auxiliaryClient.close();
       }
@@ -1565,6 +1628,9 @@ async function runGatewaySample(options: {
         }
         gatewayExit = await stopChild(gateway);
       }
+      // A fatal turn may end Promise.all before fixed probe rounds settle.
+      // Join their closed-client failures before removing the fixture state.
+      await Promise.allSettled(probeJobs);
     }
     if (options.diagnosticsTimeline) {
       if (!gatewayExit || gatewayExit.exitCode !== 0 || gatewayExit.signal !== null) {
@@ -1785,6 +1851,15 @@ async function main(): Promise<void> {
     historyClients: options.historyClients,
     mode: "mock-streaming-agent",
     pluginCount: options.pluginCount,
+    probeWorkload: {
+      mode: options.probeRounds === undefined ? "adaptive" : "fixed-rounds",
+      samplerRoundsPerRun: options.probeRounds ?? null,
+      historyRequestsPerRun:
+        options.probeRounds === undefined
+          ? null
+          : options.probeRounds * options.historyClients * options.historyBurst,
+      peakRssSampling: "sampler-rounds-and-final-memory",
+    },
     runs,
     sessionCount: Math.max(options.sessionCount, options.concurrency),
     sessionUpdateClients: options.sessionUpdates > 0 ? options.sessionUpdateClients : 0,
@@ -1815,6 +1890,7 @@ export const testing = {
   formatRunFailure,
   requestHttp,
   runBenchmarkSamples,
+  runProbeRounds,
   runSessionTurns,
   runTurn,
   sampleGateway,

--- a/test/scripts/bench-gateway-concurrency.test.ts
+++ b/test/scripts/bench-gateway-concurrency.test.ts
@@ -5,7 +5,7 @@ import { writeFile } from "node:fs/promises";
 import { createServer as createHttpServer } from "node:http";
 import { createServer as createRawServer, type Socket } from "node:net";
 import { performance } from "node:perf_hooks";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { testing } from "../../scripts/bench-gateway-concurrency.ts";
 import {
   controlGatewayHeapProfile,
@@ -125,6 +125,8 @@ describe("gateway concurrency benchmark script", () => {
         "/tmp/gateway-heap-profiles",
         "--plugin-count",
         "50",
+        "--probe-rounds",
+        "20",
         "--session-count",
         "120",
         "--control-plane",
@@ -172,6 +174,7 @@ describe("gateway concurrency benchmark script", () => {
       maxHandshakeMs: 2_000,
       output: "concurrency.json",
       pluginCount: 50,
+      probeRounds: 20,
       runs: 2,
       sessionCount: 120,
       sessionUpdateClients: 8,
@@ -211,6 +214,21 @@ describe("gateway concurrency benchmark script", () => {
       "--session-updates must be at most 100000",
     );
     expect(testing.parseOptions([]).diagnosticsTimeline).toBe(true);
+    expect(testing.parseOptions([]).probeRounds).toBeUndefined();
+    expect(() => testing.parseOptions(["--probe-rounds", "0"])).toThrow();
+    expect(() => testing.parseOptions(["--probe-rounds", "2049"])).toThrow(
+      "--probe-rounds must be at most 2048",
+    );
+    expect(() =>
+      testing.parseOptions([
+        "--probe-rounds",
+        "205",
+        "--history-clients",
+        "2",
+        "--history-burst",
+        "5",
+      ]),
+    ).toThrow("fixed history workload must not exceed 2048 requests per run");
     expect(() =>
       testing.parseOptions(["--session-count", "10000", "--history-messages", "500"]),
     ).toThrow("synthetic history");
@@ -488,6 +506,124 @@ describe("gateway concurrency benchmark script", () => {
     expect(startedSessions).toEqual(["fast", "slow"]);
     expect(new Set(starts.map((request) => request.idempotencyKey)).size).toBe(4);
     expect(new Set(starts.map((request) => request.message)).size).toBe(4);
+  });
+
+  it("gives each fixed history client its full request budget despite different response times", async () => {
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+    const requests: string[][] = [[], []];
+    const finished: number[] = [];
+    try {
+      const jobs = requests.map((clientRequests, client) =>
+        testing
+          .runProbeRounds({
+            rounds: 3,
+            deadlineAt: performance.now() + 60_000,
+            cadenceMs: 10,
+            cadenceFrom: "completion",
+            runFirst: false,
+            shouldContinue: () => false,
+            stopped: () => false,
+            runRound: async (round) => {
+              await Promise.all(
+                Array.from({ length: 2 }, async (_, request) => {
+                  clientRequests.push(`${round}:${request}`);
+                  await new Promise<void>((resolve) => {
+                    setTimeout(resolve, client * 50);
+                  });
+                }),
+              );
+            },
+          })
+          .then((count) => {
+            finished.push(client);
+            return count;
+          }),
+      );
+      await vi.advanceTimersByTimeAsync(35);
+      expect(finished).toEqual([0]);
+      expect(requests.map((items) => items.length)).toEqual([6, 2]);
+      await vi.runAllTimersAsync();
+      expect(await Promise.all(jobs)).toEqual([3, 3]);
+      expect(requests).toEqual([
+        ["0:0", "0:1", "1:0", "1:1", "2:0", "2:1"],
+        ["0:0", "0:1", "1:0", "1:1", "2:0", "2:1"],
+      ]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("refuses the next fixed probe round when the load deadline is exhausted", async () => {
+    let now = 0;
+    const clock = vi.spyOn(performance, "now").mockImplementation(() => now);
+    const issued: number[] = [];
+    try {
+      await expect(
+        testing.runProbeRounds({
+          rounds: 2,
+          deadlineAt: 10,
+          cadenceMs: 100,
+          cadenceFrom: "start",
+          runFirst: true,
+          shouldContinue: () => true,
+          stopped: () => false,
+          runRound: async (round) => {
+            issued.push(round);
+            now = 11;
+          },
+        }),
+      ).rejects.toThrow("benchmark timed out while pacing gateway probes");
+      expect(issued).toEqual([0]);
+    } finally {
+      clock.mockRestore();
+    }
+  });
+
+  it.each([true, false])(
+    "preserves adaptive first-round behavior (runFirst=%s)",
+    async (runFirst) => {
+      const issued: number[] = [];
+      expect(
+        await testing.runProbeRounds({
+          deadlineAt: performance.now() + 60_000,
+          cadenceMs: 100,
+          cadenceFrom: "start",
+          runFirst,
+          shouldContinue: () => false,
+          stopped: () => false,
+          runRound: async (round) => {
+            issued.push(round);
+          },
+        }),
+      ).toBe(runFirst ? 1 : 0);
+      expect(issued).toEqual(runFirst ? [0] : []);
+    },
+  );
+
+  it("joins an admitted fixed round but issues no further work after teardown starts", async () => {
+    const admitted = createDeferred();
+    const release = createDeferred();
+    let stopped = false;
+    const issued: number[] = [];
+    const job = testing.runProbeRounds({
+      rounds: 10,
+      deadlineAt: performance.now() + 60_000,
+      cadenceMs: 100,
+      cadenceFrom: "completion",
+      runFirst: false,
+      shouldContinue: () => true,
+      stopped: () => stopped,
+      runRound: async (round) => {
+        issued.push(round);
+        admitted.resolve();
+        await release.promise;
+      },
+    });
+    await admitted.promise;
+    stopped = true;
+    release.resolve();
+    expect(await job).toBe(1);
+    expect(issued).toEqual([0]);
   });
 
   it("gives every gateway sample a fresh pre-warmup timeout budget", async () => {


### PR DESCRIPTION
Related: #145629

<details>
<summary>Additional instructions</summary>

This branch is in openclaw/openclaw, so repository maintainers can update it directly. This is maintainer-requested follow-up work on busy-Gateway allocation measurement.

</details>

## What Problem This Solves

Resolves a problem where developers comparing Gateway allocation and memory profiles would measure different amounts of probe work even with the same agent workload. Adaptive probing produced 101 rounds in one run and 501 in another, obscuring whether allocation changes came from the implementation or simply more requests.

## Why This Change Was Made

Adds optional `--probe-rounds N`: exactly N sampler rounds and N history bursts per client, with a bounded total history budget. All configured work joins before final memory capture; failed runs stop and join outstanding probes before releasing their fixture. Existing adaptive mode remains the default.

## User Impact

Developers can compare equal attempted request counts while retaining independent clients, cadence, deadlines, and visible failures. No production Gateway configuration or behavior changes. The documentation states that fixed probes may outlast agent turns and that sampled peak RSS can miss later transient peaks if probes finish early; equal counts do not guarantee identical timing or background activity.

## Evidence

- Focused benchmark tests: **31 passed**, including unequal client speeds, exact counts, deadline exhaustion, adaptive behavior, and teardown joining.
- Scripts and root-test TypeScript checks, graph/erasability guards, formatting, and changed-source lint passed. An initial test lint error was corrected; final lint and focused tests passed.
- Built Gateway smoke: **4 completed turns, 3 sampler rounds, 12 history requests, zero failed probes, and clean Gateway exit 0**.
- Independent review found no actionable P0–P2 findings in fixed counts, adaptive behavior, or cleanup.

Smoke shape:

```bash
node scripts/bench-gateway-concurrency.ts --concurrency 2 --turns-per-session 2 --probe-rounds 3 --history-clients 2 --history-burst 2 --stream-chunk-delay-ms 25 --no-diagnostics-timeline --output .artifacts/fixed-work-smoke.json
```


CI follow-up: the first [checks-node-compact-small-16](https://github.com/openclaw/openclaw/actions/runs/34698124192/job/103565137989) attempt timed out waiting for catalog startup in the unchanged `gateway-route-model-reuse.test.ts`. The [same test passed on the exact same main base eight minutes earlier](https://github.com/openclaw/openclaw/actions/runs/34697902346/job/103564544329), including 76 verified model requests, in a UI-only PR. The [single bounded rerun passed](https://github.com/openclaw/openclaw/actions/runs/34698124192/job/103567418347), and exact-head CI is green. No assertions, timeouts, or runtime source were changed. Native preparation accepted the hosted exact-head gates.
