### PR TITLE
refactor: keep native handles out of reply admission claims

### DIFF
--- a/src/auto-reply/reply/dispatch-from-config.shared.test-harness.ts
+++ b/src/auto-reply/reply/dispatch-from-config.shared.test-harness.ts
@@ -149,7 +149,7 @@ const pluginConversationBindingMocks = vi.hoisted(() => ({
 }));
 const sessionStoreMocks = vi.hoisted(() => ({
   databaseEntryLoader: undefined as
-    | typeof import("../../config/sessions/session-accessor.sqlite-entry.js").loadSessionEntryWithDatabase
+    | typeof import("../../config/sessions/session-accessor.sqlite-entry.js").loadSessionEntryForAdmission
     | undefined,
   currentEntry: undefined as Record<string, unknown> | undefined,
   entriesBySessionKey: new Map<string, Record<string, unknown>>(),
@@ -549,7 +549,7 @@ vi.mock("../../config/sessions/session-accessor.sqlite-entry.js", async (importO
   ...(await importOriginal<
     typeof import("../../config/sessions/session-accessor.sqlite-entry.js")
   >()),
-  loadSessionEntryWithDatabase: (
+  loadSessionEntryForAdmission: (
     ...args: Parameters<NonNullable<typeof sessionStoreMocks.databaseEntryLoader>>
   ) =>
     sessionStoreMocks.databaseEntryLoader

--- a/src/auto-reply/reply/reply-turn-admission.database-claim.test.ts
+++ b/src/auto-reply/reply/reply-turn-admission.database-claim.test.ts
@@ -72,7 +72,7 @@ it.each(
         owner.completeWithAfterClearBarrier(release.promise);
       }
     }
-    const loaded = vi.spyOn(sessionEntries, "loadSessionEntryWithDatabase");
+    const loaded = vi.spyOn(sessionEntries, "loadSessionEntryForAdmission");
     const waiting =
       wait === "active"
         ? vi.spyOn(registry.replyRunRegistry, "waitForIdle")
@@ -96,11 +96,11 @@ it.each(
       if (observed?.type !== "return") {
         throw new Error("fixture requires a completed authoritative row read");
       }
-      const database = observed.value.databaseClaim.database;
-      expect(database.db.isOpen).toBe(true);
+      const claim = observed.value.databaseClaim;
+      expect(claim.isCurrent()).toBe(true);
       if (replacement !== "unchanged") {
-        expect(closeOpenClawAgentDatabaseByPath(database.path)).toBe(true);
-        expect(database.db.isOpen).toBe(false);
+        expect(closeOpenClawAgentDatabaseByPath(storePath)).toBe(true);
+        expect(claim.isCurrent()).toBe(false);
         if (replacement === "other-inode") {
           fs.unlinkSync(storePath);
           fs.symlinkSync(replacementPath, storePath);
@@ -112,7 +112,7 @@ it.each(
       if (replacement === "unchanged") {
         expect(result.status).toBe("owned");
         if (result.status === "owned") {
-          expect(result.databaseClaim?.database.db).toBe(database.db);
+          expect(result.databaseClaim?.incarnation).toBe(claim.incarnation);
           result.operation.complete();
         }
       } else {

--- a/src/auto-reply/reply/reply-turn-admission.store-owner.test.ts
+++ b/src/auto-reply/reply/reply-turn-admission.store-owner.test.ts
@@ -186,7 +186,7 @@ it.each([true, false])(
         if (result.status === "owned") {
           expect(result.operation.sessionId).toBe(successorId);
           expect(result.operation.agentId).toBe("main");
-          expect(result.databaseClaim?.database.db).toBe(databaseClaim.database.db);
+          expect(result.databaseClaim?.incarnation).toBe(databaseClaim.incarnation);
           result.operation.complete();
         }
       } else {

--- a/src/auto-reply/reply/reply-turn-admission.test.ts
+++ b/src/auto-reply/reply/reply-turn-admission.test.ts
@@ -147,7 +147,7 @@ describe("reply turn admission", () => {
       owner: MAIN_SESSION_RECOVERY_WORK_ADMISSION_OWNER,
       assertAllowed: () => {},
     });
-    const loadSpy = vi.spyOn(sessionEntryAccessor, "loadSessionEntryWithDatabase");
+    const loadSpy = vi.spyOn(sessionEntryAccessor, "loadSessionEntryForAdmission");
     const controller = new AbortController();
     const admission = admitTestReplyTurn({
       sessionKey,

--- a/src/auto-reply/reply/reply-turn-admission.ts
+++ b/src/auto-reply/reply/reply-turn-admission.ts
@@ -16,7 +16,7 @@ import {
   SESSION_RESTART_RECOVERY_TOMBSTONE_ERROR_CODE,
   SessionRestartRecoveryTombstoneError,
 } from "../../config/sessions/lifecycle.js";
-import { loadSessionEntryWithDatabase } from "../../config/sessions/session-accessor.sqlite-entry.js";
+import { loadSessionEntryForAdmission } from "../../config/sessions/session-accessor.sqlite-entry.js";
 import type { InternalSessionEntry, SessionEntry } from "../../config/sessions/types.js";
 import type { GatewayContextResolver } from "../../gateway/server-methods/types.js";
 import { racePromiseWithAbortSignal } from "../../infra/abort-signal.js";
@@ -256,7 +256,7 @@ export async function admitReplyTurn(
     if (
       admittedDatabaseClaim &&
       (!admittedDatabaseClaim.isCurrent() ||
-        (nextClaim && nextClaim.database.db !== admittedDatabaseClaim.database.db))
+        (nextClaim && nextClaim.incarnation !== admittedDatabaseClaim.incarnation))
     ) {
       nextClaim?.release();
       rejectLifecycleInvalidatedWork({
@@ -322,7 +322,7 @@ export async function admitReplyTurn(
               },
               assertAllowed: () => {
                 assertDatabaseOwnerCurrent();
-                const current = loadSessionEntryWithDatabase({
+                const current = loadSessionEntryForAdmission({
                   agentId: params.agentId,
                   storePath,
                   sessionKey: params.sessionKey,

--- a/src/config/sessions/session-accessor.sqlite-entry.ts
+++ b/src/config/sessions/session-accessor.sqlite-entry.ts
@@ -149,7 +149,7 @@ export function loadSessionEntry(scope: SessionAccessScope): SessionEntry | unde
 }
 
 /** Admission retains the exact owner that supplied its row across asynchronous policy work. */
-export function loadSessionEntryWithDatabase(scope: SessionAccessScope): {
+export function loadSessionEntryForAdmission(scope: SessionAccessScope): {
   entry: SessionEntry | undefined;
   databaseClaim: OpenClawAgentDatabaseClaim;
 } {

--- a/src/config/sessions/session-accessor.sqlite-identity.ts
+++ b/src/config/sessions/session-accessor.sqlite-identity.ts
@@ -1,14 +1,14 @@
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { deferSqlitePostCommitPublication } from "../../infra/sqlite-post-commit.js";
 import { emitSessionIdentityMutation } from "../../sessions/session-lifecycle-events.js";
-import type { OpenClawAgentDatabaseClaim } from "../../state/openclaw-agent-db-identity.js";
+import type { OpenClawAgentDatabase } from "../../state/openclaw-agent-db-contract.js";
 import type {
   ProjectedLifecycleMutation,
   SessionEntryRemovalPlan,
 } from "./session-accessor.sqlite-lifecycle-types.js";
 import type { SessionEntry } from "./types.js";
 
-type SessionIdentityDatabase = OpenClawAgentDatabaseClaim["database"];
+type SessionIdentityDatabase = Pick<OpenClawAgentDatabase, "agentId" | "db" | "path">;
 
 function toSessionIdentityTarget(entry: SessionEntry | undefined, sessionKeys: readonly string[]) {
   const sessionId = normalizeOptionalString(entry?.sessionId);

--- a/src/config/sessions/session-accessor.sqlite-reclamation.ts
+++ b/src/config/sessions/session-accessor.sqlite-reclamation.ts
@@ -454,7 +454,7 @@ export async function runSqliteSessionReclamation(params: {
   if (!retained.found) {
     throw new Error("SQLite session reclamation lost its prepared database");
   }
-  const { claim } = retained;
+  const { database, claim } = retained;
   try {
     const assertCommitAllowed = () => {
       claim.assertCurrent();
@@ -466,7 +466,7 @@ export async function runSqliteSessionReclamation(params: {
       ...params.plan,
       databaseOptions: {
         ...params.plan.databaseOptions,
-        path: readOpenClawAgentDatabaseIdentity(claim.database).filename,
+        path: readOpenClawAgentDatabaseIdentity(database).filename,
       },
     };
     const commitGate = new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT);
@@ -474,7 +474,7 @@ export async function runSqliteSessionReclamation(params: {
     let publishCommitted: (() => void) | undefined;
     const [workerResult] = await withSqliteReclamationAuthorization(
       commitGate,
-      claim.database.db,
+      database.db,
       () => {
         assertCommitAllowed();
         // A blocked writer may authorize before the Worker's queued request.

--- a/src/config/sessions/session-cold-storage.ts
+++ b/src/config/sessions/session-cold-storage.ts
@@ -89,7 +89,7 @@ async function runColdMutation(
   if (!retained.found) {
     throw new Error("Cold transcript operation lost its owning database");
   }
-  const { claim } = retained;
+  const { database, claim } = retained;
   try {
     const assertAllowed = () => {
       claim.assertCurrent();
@@ -98,7 +98,7 @@ async function runColdMutation(
     const commitGate = new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT);
     const [completed] = await withSqliteReclamationAuthorization(
       commitGate,
-      claim.database.db,
+      database.db,
       assertAllowed,
       (authorize) =>
         runSqliteTranscriptArchiveWorkerOperation<{

--- a/src/state/openclaw-agent-db-identity.test.ts
+++ b/src/state/openclaw-agent-db-identity.test.ts
@@ -32,13 +32,13 @@ afterEach(() => {
   fs.rmSync(directory, { recursive: true, force: true });
 });
 
-function retain(databasePath: string): OpenClawAgentDatabaseClaim {
+function retain(databasePath: string) {
   const result = retainOpenClawAgentDatabaseReadOnly({ agentId: "main", env, path: databasePath });
   if (!result.found) {
     throw new Error(`Expected existing database: ${result.reason}`);
   }
   claims.push(result.claim);
-  return result.claim;
+  return result;
 }
 
 it.runIf(process.platform !== "win32")(
@@ -48,14 +48,14 @@ it.runIf(process.platform !== "win32")(
     const alias = path.join(directory, "alias.sqlite");
     fs.symlinkSync(original.path, alias);
     const aliased = openOpenClawAgentDatabase({ agentId: "main", env, path: alias });
-    const claim = retain(alias);
+    const { claim } = retain(alias);
     const replacement = openOpenClawAgentDatabase({
       agentId: "main",
       env,
       path: path.join(directory, "replacement.sqlite"),
     });
-    const originalIdentity = retain(original.path).identity;
-    const replacementIdentity = retain(replacement.path).identity;
+    const originalIdentity = retain(original.path).claim.identity;
+    const replacementIdentity = retain(replacement.path).claim.identity;
     expect(claim.identity).toBe(originalIdentity);
     fs.unlinkSync(alias);
     fs.symlinkSync(replacement.path, alias);
@@ -68,7 +68,7 @@ it.runIf(process.platform !== "win32")(
     expect(() => claim.assertCurrent()).toThrow("no longer current");
     expect(original.db.isOpen).toBe(true);
     expect(replacement.db.isOpen).toBe(true);
-    const current = retain(alias);
+    const { claim: current } = retain(alias);
     expect(current.identity).toBe(replacementIdentity);
     expect(claim.isCurrent()).toBe(false);
   },
@@ -78,13 +78,15 @@ it("retains cold existing stores read-only without registering or creating missi
   const database = openOpenClawAgentDatabase({ agentId: "main", env });
   closeOpenClawAgentDatabaseByPath(database.path);
   const registry = listOpenClawRegisteredAgentDatabases({ env });
-  const claim = retain(database.path);
+  const { database: readOnlyDatabase, claim } = retain(database.path);
   expect(claim.isCurrent()).toBe(true);
   expect(isOpenClawAgentDatabaseOpen(database.path)).toBe(false);
-  expect(() => claim.database.db.exec("CREATE TABLE unexpected (value TEXT)")).toThrow(/readonly/);
+  expect(() => readOnlyDatabase.db.exec("CREATE TABLE unexpected (value TEXT)")).toThrow(
+    /readonly/,
+  );
   expect(listOpenClawRegisteredAgentDatabases({ env })).toEqual(registry);
   claim.release();
-  expect(claim.database.db.isOpen).toBe(false);
+  expect(readOnlyDatabase.db.isOpen).toBe(false);
   expect(() => claim.assertCurrent()).toThrow("no longer current");
 
   const missing = path.join(directory, "missing", "agent.sqlite");
@@ -97,8 +99,9 @@ it("retains cold existing stores read-only without registering or creating missi
 
 it("releases only one warm claim while revoking its retained copies", () => {
   const database = openOpenClawAgentDatabase({ agentId: "main", env });
-  const first = retain(database.path);
-  const second = retain(database.path);
+  const { claim: first } = retain(database.path);
+  const { claim: second } = retain(database.path);
+  expect(first.incarnation).toBe(second.incarnation);
   const assertCurrent = first.assertCurrent;
   first.release();
   first.release();
@@ -107,20 +110,29 @@ it("releases only one warm claim while revoking its retained copies", () => {
   expect(database.db.isOpen).toBe(true);
 });
 
-it("does not reuse incognito authority after the same sentinel is reopened", () => {
-  const sentinel = resolveIncognitoOpenClawAgentSqlitePath({ agentId: "main", env });
-  expect(retainOpenClawAgentDatabaseReadOnly({ agentId: "main", env, path: sentinel })).toEqual({
-    found: false,
-    reason: "database-missing",
-  });
-  openOpenClawAgentDatabase({ agentId: "main", env, path: sentinel });
-  const claim = retain(sentinel);
-  closeOpenClawAgentDatabaseByPath(sentinel);
-  openOpenClawAgentDatabase({ agentId: "main", env, path: sentinel });
-  const replacement = retain(sentinel);
-  expect(claim.identity).not.toBe(replacement.identity);
+it.each([false, true])("does not reuse a reopened connection claim, incognito=%s", (incognito) => {
+  const databasePath = incognito
+    ? resolveIncognitoOpenClawAgentSqlitePath({ agentId: "main", env })
+    : path.join(directory, "agent.sqlite");
+  expect(retainOpenClawAgentDatabaseReadOnly({ agentId: "main", env, path: databasePath })).toEqual(
+    {
+      found: false,
+      reason: "database-missing",
+    },
+  );
+  openOpenClawAgentDatabase({ agentId: "main", env, path: databasePath });
+  const { claim } = retain(databasePath);
+  closeOpenClawAgentDatabaseByPath(databasePath);
+  openOpenClawAgentDatabase({ agentId: "main", env, path: databasePath });
+  const { claim: replacement } = retain(databasePath);
+  expect(claim.incarnation).not.toBe(replacement.incarnation);
   expect(claim.isCurrent()).toBe(false);
   expect(replacement.isCurrent()).toBe(true);
-  expect(fs.existsSync(sentinel)).toBe(false);
-  expect(listOpenClawRegisteredAgentDatabases({ env })).toEqual([]);
+  if (incognito) {
+    expect(claim.identity).not.toBe(replacement.identity);
+    expect(fs.existsSync(databasePath)).toBe(false);
+    expect(listOpenClawRegisteredAgentDatabases({ env })).toEqual([]);
+  } else {
+    expect(claim.identity).toBe(replacement.identity);
+  }
 });

--- a/src/state/openclaw-agent-db-identity.ts
+++ b/src/state/openclaw-agent-db-identity.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { statSync } from "node:fs";
 import type { DatabaseSync } from "node:sqlite";
 import { resolveGlobalSingleton } from "../shared/global-singleton.js";
@@ -7,15 +8,19 @@ export type OpenClawAgentDatabaseIdentity = string | symbol;
 
 const identities = resolveGlobalSingleton(
   Symbol.for("openclaw.agentDatabaseIdentities"),
-  () => new WeakMap<DatabaseSync, { identity: OpenClawAgentDatabaseIdentity; filename: string }>(),
+  () =>
+    new WeakMap<
+      DatabaseSync,
+      { identity: OpenClawAgentDatabaseIdentity; incarnation: string; filename: string }
+    >(),
 );
 
-/** Prepare physical identity once at open; cached aliases must never be resolved again. */
+/** Prepare physical and connection identity once at open; cached aliases are not resolved again. */
 export function registerOpenClawAgentDatabaseIdentity(db: DatabaseSync): void {
   const filename = db.location() ?? "";
   const file = filename ? statSync(filename, { bigint: true }) : undefined;
   const identity = file ? `${file.dev}:${file.ino}` : Symbol("incognito-agent-database");
-  identities.set(db, { identity, filename });
+  identities.set(db, { identity, incarnation: randomUUID(), filename });
 }
 
 /** Reuse facts captured at open; aliases must never be resolved again at a handoff. */
@@ -28,22 +33,24 @@ export function readOpenClawAgentDatabaseIdentity(database: AgentDatabaseOwner) 
 }
 
 export type OpenClawAgentDatabaseClaim = {
-  database: AgentDatabaseOwner & { agentId: string; path: string };
   identity: OpenClawAgentDatabaseIdentity;
+  /** Changes on reopen even when the underlying file is unchanged. */
+  incarnation: string;
   isCurrent: () => boolean;
   assertCurrent: () => void;
   release: () => void;
 };
 
 export function createOpenClawAgentDatabaseClaim(
-  database: OpenClawAgentDatabaseClaim["database"],
+  database: AgentDatabaseOwner,
   release: () => void,
 ): OpenClawAgentDatabaseClaim {
   let released = false;
   const isCurrent = () => !released && database.db.isOpen;
+  const { identity, incarnation } = readOpenClawAgentDatabaseIdentity(database);
   return {
-    database,
-    identity: readOpenClawAgentDatabaseIdentity(database).identity,
+    identity,
+    incarnation,
     isCurrent,
     assertCurrent: () => {
       if (!isCurrent()) {

--- a/src/state/openclaw-agent-db-readonly.ts
+++ b/src/state/openclaw-agent-db-readonly.ts
@@ -118,17 +118,22 @@ export function openOpenClawAgentDatabaseReadOnly(
 export function retainOpenClawAgentDatabaseReadOnly(
   options: OpenClawAgentDatabaseOptions,
 ):
-  | { found: true; claim: OpenClawAgentDatabaseClaim }
+  | { found: true; database: OpenClawAgentReadOnlyDatabase; claim: OpenClawAgentDatabaseClaim }
   | { found: false; reason: "database-missing" | "schema-missing" } {
   const opened = findOpenAgentDatabase(options);
   if (opened && !opened.db.isTransaction) {
     const borrowed = borrowOpenClawAgentDatabase(options);
-    return { found: true, claim: createOpenClawAgentDatabaseClaim(opened, borrowed.release) };
+    return {
+      found: true,
+      database: opened,
+      claim: createOpenClawAgentDatabaseClaim(opened, borrowed.release),
+    };
   }
   const fresh = openOpenClawAgentDatabaseReadOnly(options);
   return fresh.found
     ? {
         found: true,
+        database: fresh.database,
         claim: createOpenClawAgentDatabaseClaim(fresh.database, fresh.database.close),
       }
     : fresh;


### PR DESCRIPTION
## What Problem This Solves

Reply admission carries a native SQLite connection inside its retained claim while waiting for session work. That couples admission to the database implementation and obstructs moving the connection owner to a worker.

## Why This Change Was Made

Prepare a connection-incarnation string once in the existing database identity record, separately from physical file identity. Reply admission compares incarnations and retains the existing current/released checks. Its private entry loader now returns an entry and opaque claim; reclamation and cold-storage owners retain native connection access separately where their existing SQL operations need it.

## User Impact

No intended behavior change. Claims on the same live connection still match; reopening the same file creates a different connection incarnation. Release remains idempotent and explicit disposal invalidates the claim. This is worker preparation: database execution remains synchronous, and no schema, persistence, transaction or public SDK compatibility contract changes.

## Evidence

230 focused cases passed: real SQLite claim acquisition/release and durable/incognito reopen, reply admission and dispatch, retained claims across writer/run/delivery waits, and existing cold-storage/reclamation worker flows. The independent P0–P2 review found no actionable issues. The full build and all changed-file gates passed, including core and test TypeScript lanes, lint, dead exports, and import-cycle checks. Exact-head CI is required before landing.
