### PR TITLE
fix: skip transcript reads for stale fallback notices

### DIFF
--- a/docs/concepts/model-failover.md
+++ b/docs/concepts/model-failover.md
@@ -357,6 +357,8 @@ Live model switching follows these rules:
 
 The active run carries its chosen candidate directly. Live reconciliation changes that candidate only for an explicit pending user switch, so no temporary fallback override or rollback is needed.
 
+When a recorded fallback notice belongs to a different selected model, status and session lists skip its optional transcript lookup. That stale-notice path no longer surfaces transcript-only errors or starts projection reconciliation. Matching notices still use the canonical transcript reader, including its errors and reconciliation behavior.
+
 ## User-visible fallback notices
 
 Outside group and channel conversations, OpenClaw sends a status notice in the same reply surface when a session moves onto an auto-selected fallback:

--- a/src/status/session-fallback-model.ts
+++ b/src/status/session-fallback-model.ts
@@ -1,4 +1,5 @@
 import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { resolveSelectedAndActiveModel } from "../auto-reply/model-runtime.js";
 import { readSessionTranscriptBoundedMessageTailPage } from "../config/sessions/session-accessor.sqlite-active-events.js";
 import type { SessionTranscriptReadScope } from "../config/sessions/session-accessor.types.js";
@@ -26,6 +27,14 @@ export function readSessionFallbackModel(params: {
     !entry.lastRunId ||
     !entry.fallbackNotice
   ) {
+    return undefined;
+  }
+  const selectedLabel = resolveSelectedAndActiveModel({
+    selectedProvider: params.selectedProvider,
+    selectedModel: params.selectedModel,
+    parseSelectedProvider: params.parseSelectedProvider,
+  }).selected.label;
+  if (normalizeOptionalString(entry.fallbackNotice.selectedModel) !== selectedLabel) {
     return undefined;
   }
   try {

--- a/src/status/status-text.model.test.ts
+++ b/src/status/status-text.model.test.ts
@@ -146,12 +146,50 @@ describe("buildStatusText prepared context windows", () => {
 
   it.each([
     ["stale runtime telemetry", {}],
-    ["stale resolved context", { contextTokensSource: "resolved-v1" }],
-    ["absent runtime model", { modelProvider: undefined, model: undefined }],
-  ] satisfies Array<[string, Partial<InternalSessionEntry>]>)(
+    ["stale resolved context", { entry: { contextTokensSource: "resolved-v1" } }],
+    ["absent runtime model", { entry: { modelProvider: undefined, model: undefined } }],
+    [
+      "padded selected notice",
+      {
+        entry: {
+          fallbackNotice: {
+            kind: "active",
+            selectedModel: "  deepseek/deepseek-v4-flash  ",
+            activeModel: "fallback/small-model",
+          },
+        },
+      },
+    ],
+    [
+      "literal provider-local model",
+      {
+        status: { provider: "MiXeD", model: "Vendor/Model:opaque" },
+        entry: {
+          fallbackNotice: {
+            kind: "active",
+            selectedModel: "mixed/Vendor/Model:opaque",
+            activeModel: "fallback/small-model",
+          },
+        },
+      },
+    ],
+    [
+      "legacy embedded provider",
+      {
+        entry: {
+          modelOverride: "MiXeD/Model:Case",
+          fallbackNotice: {
+            kind: "active",
+            selectedModel: "MiXeD/Model:Case",
+            activeModel: "fallback/small-model",
+          },
+        },
+      },
+    ],
+  ] satisfies Array<[string, Parameters<typeof renderTerminalFallback>[0]]>)(
     "projects a settled terminal fallback over %s without relabeling the entry",
-    async (_name, entry) => {
-      const parts = await renderTerminalFallback({ entry });
+    async (_name, params) => {
+      const parts = await renderTerminalFallback(params);
       expect(parts.text).toContain("Fallback: fallback/small-model");
       expect(parts.text).toContain("Context: 45k/128k");
       expect(parts.text).not.toContain("45k/1.0m");
@@ -192,18 +230,6 @@ describe("buildStatusText prepared context windows", () => {
       },
     ],
     [
-      "stale selected notice",
-      {
-        entry: {
-          fallbackNotice: {
-            kind: "active",
-            selectedModel: "deepseek/older-model",
-            activeModel: "fallback/small-model",
-          },
-        },
-      },
-    ],
-    [
       "unmatched active notice",
       {
         entry: {
@@ -223,6 +249,26 @@ describe("buildStatusText prepared context windows", () => {
       expect(parts.text).toContain("Context: 45k/1.0m");
     },
   );
+
+  it("skips terminal transcript access for a stale selected notice", async () => {
+    const readTail = vi.spyOn(transcriptTail, "readSessionTranscriptBoundedMessageTailPage");
+    try {
+      const parts = await renderTerminalFallback({
+        entry: {
+          fallbackNotice: {
+            kind: "active",
+            selectedModel: "deepseek/older-model",
+            activeModel: "fallback/small-model",
+          },
+        },
+      });
+      expect(parts.text).not.toContain("Fallback: fallback/small-model");
+      expect(parts.text).toContain("Context: 45k/1.0m");
+      expect(readTail).not.toHaveBeenCalled();
+    } finally {
+      readTail.mockRestore();
+    }
+  });
 
   it("retains the incoming prepared cap when it already belongs to the terminal pair", async () => {
     const parts = await renderTerminalFallback({


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where listing sessions or viewing status performs unnecessary transcript work after the selected model changes while an old fallback notice remains. An obsolete notice can also make these display paths surface transcript-only errors.

## Why This Change Was Made

The terminal-fallback helper now rejects notices for a different selected model before reading the transcript, using the existing selected-label normalization. Matching notices retain their canonical reader, terminal evidence checks, error propagation and projection-unavailable behavior.

Skipping an ineligible stale notice intentionally also skips transcript-only errors and reconciliation initiated by that optional lookup. Caller authorization, canonical session validation and the existing projection lifecycle keep their own boundaries.

## User Impact

Session lists and status avoid work that cannot contribute valid fallback metadata. Literal provider-local model IDs, embedded-provider parsing and valid fallback displays are preserved.

## Evidence

- Pre-fix real-transcript fixture: a stale notice displayed no fallback but entered the tail reader, projection, classification and visible-window owners once each. The zero-read regression failed for that reason.
- 46 status-model tests and 264 Gateway session-projection/identity tests pass, including stale no-read, notice trimming, literal model IDs, embedded-provider parsing and matching-notice error behavior.
- Independent Codex review found no actionable P0–P2 findings.
- Full `check:changed` passed.
- Ordinary Linux Crabbox proof passed on the exact PR source: a fresh real Gateway returned the expected matching/stale fallback metadata in four CLI `sessions.list` calls, alternating normal and explicit-main views. Native selected identity and transcript snapshots were unchanged after shutdown. All 12 child-command groups closed. The archive and original-source/tree/carrier receipt were independently verified.
- Exact-head CI passed: https://github.com/openclaw/openclaw/actions/runs/34698798427

The native counterexample demonstrates avoided work; it is not a latency benchmark. Remote proof used synthetic state on Node 24.19.0 and pnpm 12.3.4, with no model inference. A portal synchronization warning was retained; the finalized archive, source linkage and process closure passed independent verification.
