### PR TITLE
fix: support large SQLite worker commands with bounded transport

### DIFF
--- a/docs/plugins/sdk-overview/infrastructure.md
+++ b/docs/plugins/sdk-overview/infrastructure.md
@@ -137,8 +137,19 @@ while the worker is drained.
 The process-wide host starts lazily and permits at most four workers, 64 opening
 or live store clients (including clients sharing a database), 128 outstanding
 operations, and 64 MiB of queued input. Each input message is limited to 32 MiB
-and capacity exhaustion rejects with `code: "overloaded"`. Results up to 64 MiB
-use an inline reply; larger results transfer their complete serialized value
+and capacity exhaustion rejects with `code: "overloaded"`. Larger execute inputs
+arrive in 8 MiB chunks; the backend runs once after the complete command is
+validated. Factory initialization input remains a single bounded message.
+
+Commands retaining at most 64 MiB of serialized input can queue, with their full
+byte length charged until settlement. A larger command must start immediately
+on an idle worker with a reserved 32 MiB transport window; otherwise it rejects
+with `overloaded` before dispatch.
+The aggregate budget bounds admitted queue bytes and reserved transport windows,
+not the complete value held by an active oversized command or result. Once
+staging starts, the existing post-dispatch cancellation and drainage rules apply.
+
+Results up to 64 MiB use an inline reply; larger results transfer their complete serialized value
 in bounded 8 MiB chunks. Callers still materialize the complete result in memory,
 and the original operation remains owned through transfer validation and cleanup.
 Operations for one database share its connection owner

--- a/docs/reference/database-schemas/storage-changes.md
+++ b/docs/reference/database-schemas/storage-changes.md
@@ -47,6 +47,14 @@ during shutdown. Framing does not paginate or repeat the database query, truncat
 results, or change request and queue budgets. Callers still materialize their
 complete result in memory.
 
+Worker execute inputs also use bounded frames when necessary. Queued commands
+retain their full serialized-byte charge, up to the existing 64 MiB aggregate
+budget. Larger commands require immediate admission to an idle worker and reserve
+a 32 MiB transport window through settlement. Otherwise, admission returns the
+existing overload error without queuing the value or executing any part of it.
+Only complete validated input reaches the backend. The transport queue remains
+bounded; an active complete input or result still requires its materialized memory.
+
 Acquire a connection once for an operation and pass that exact connection
 through its transactional helpers. SQLite write callbacks remain synchronous:
 finish asynchronous planning first, then reread authoritative rows after write

--- a/src/infra/sqlite-store.worker.ts
+++ b/src/infra/sqlite-store.worker.ts
@@ -5,12 +5,17 @@ import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import {
   SQLITE_WORKER_MAX_RESULT_BYTES,
   type SqliteWorkerBackend,
+  type SqliteWorkerCommand,
   type SqliteWorkerOperations,
   type SqliteWorkerReply,
   type SqliteWorkerRequest,
 } from "./sqlite-worker-contract.js";
 import { assertExistingDatabaseIdentity } from "./sqlite-worker-identity.js";
-import { createSqliteWorkerTransferOwner } from "./sqlite-worker-transfer.js";
+import {
+  createSqliteWorkerTransferOwner,
+  createSqliteWorkerTransferReceiver,
+  type SqliteWorkerTransferFrame,
+} from "./sqlite-worker-transfer.js";
 
 const port = parentPort;
 if (!port) {
@@ -19,14 +24,41 @@ if (!port) {
 const actors = new Map<number, SqliteWorkerBackend<SqliteWorkerOperations>>();
 const transfers = createSqliteWorkerTransferOwner();
 let pendingResult: { requestId: number; actor: number; transferId: number } | undefined;
+type StagedInput = {
+  requestId: number;
+  actor: number;
+  receiver: ReturnType<typeof createSqliteWorkerTransferReceiver>;
+  command: unknown;
+};
+let pendingInput: StagedInput | undefined;
 let sourceLoaderRegistered = false;
 
 async function receive(request: SqliteWorkerRequest): Promise<void> {
   let reply: SqliteWorkerReply;
   let executed = pendingResult !== undefined;
   let retire = false;
+  let completeResult = false;
+  let inputNext = false;
   try {
     let value: unknown;
+    const executeCommand = (command: unknown) => {
+      const backend = actors.get(request.actor);
+      if (!backend) {
+        throw new Error("SQLite worker actor is closed");
+      }
+      // SAFETY: The typed host command is serialized once; framing validates complete reconstruction.
+      value = backend.execute(command as SqliteWorkerCommand<SqliteWorkerOperations>);
+      executed = true;
+      completeResult = true;
+      if (isPromise(value) || (isRecord(value) && typeof value.then === "function")) {
+        retire = true;
+        if (isPromise(value)) {
+          // Retirement owns the failure; consume rejection while native exit is joined.
+          void value.catch(() => {});
+        }
+        throw new Error("SQLite worker operations must remain synchronous");
+      }
+    };
     if (request.type === "result-next") {
       if (
         pendingResult?.requestId !== request.id ||
@@ -44,6 +76,50 @@ async function receive(request: SqliteWorkerRequest): Promise<void> {
       value = frame;
     } else if (pendingResult) {
       throw new Error("SQLite worker result transfer has not finished");
+    } else if (request.type === "execute-start") {
+      retire = true;
+      if (
+        pendingInput ||
+        !actors.has(request.actor) ||
+        request.transfer.kinds.length !== 1 ||
+        request.transfer.kinds[0] !== "command"
+      ) {
+        throw new Error("SQLite worker received unexpected command staging");
+      }
+      const input: StagedInput = {
+        requestId: request.id,
+        actor: request.actor,
+        command: undefined,
+        receiver: createSqliteWorkerTransferReceiver(request.transfer, (record) => {
+          input.command = record.value;
+        }),
+      };
+      pendingInput = input;
+      inputNext = true;
+      retire = false;
+    } else if (request.type === "execute-frame") {
+      retire = true;
+      const input = pendingInput;
+      if (!input || input.requestId !== request.id || input.actor !== request.actor) {
+        throw new Error("SQLite worker command staging is no longer current");
+      }
+      // SAFETY: The matching host emits frames; the shared receiver validates sequence and bounds.
+      const frame = deserialize(request.input) as SqliteWorkerTransferFrame;
+      const counts = input.receiver.accept(frame);
+      if (counts) {
+        if (counts.length !== 1 || counts[0]?.[1] !== 1) {
+          throw new Error("SQLite worker received an incomplete command");
+        }
+        pendingInput = undefined;
+        retire = false;
+        executeCommand(input.command);
+      } else {
+        inputNext = true;
+        retire = false;
+      }
+    } else if (pendingInput) {
+      retire = true;
+      throw new Error("SQLite worker command staging has not finished");
     } else if (request.type === "open") {
       if (actors.has(request.actor)) {
         throw new Error("SQLite worker actor is already open");
@@ -82,30 +158,19 @@ async function receive(request: SqliteWorkerRequest): Promise<void> {
       }
       // SAFETY: The validated backend and its typed client own the private command contract.
       actors.set(request.actor, backend as SqliteWorkerBackend<SqliteWorkerOperations>);
-    } else {
+    } else if (request.type === "close") {
       const backend = actors.get(request.actor);
       if (!backend) {
         throw new Error("SQLite worker actor is closed");
       }
-      if (request.type === "close") {
-        await backend.close();
-        actors.delete(request.actor);
-      } else {
-        value = backend.execute(deserialize(request.input));
-        executed = true;
-        if (isPromise(value) || (isRecord(value) && typeof value.then === "function")) {
-          retire = true;
-          if (isPromise(value)) {
-            // Retirement owns the failure; consume rejection while native exit is joined.
-            void value.catch(() => {});
-          }
-          throw new Error("SQLite worker operations must remain synchronous");
-        }
-      }
+      await backend.close();
+      actors.delete(request.actor);
+    } else {
+      executeCommand(deserialize(request.input));
     }
     const serialized = serialize(value);
     if (serialized.byteLength > SQLITE_WORKER_MAX_RESULT_BYTES) {
-      if (request.type !== "execute") {
+      if (!completeResult) {
         throw new Error("SQLite worker frame exceeds the transport byte limit");
       }
       const handle = transfers.start([{ kind: "result", serialized }].values(), {
@@ -119,11 +184,13 @@ async function receive(request: SqliteWorkerRequest): Promise<void> {
         ok: true,
         value: serialized,
         ...(request.type === "result-next" ? { transfer: "frame" } : {}),
+        ...(inputNext ? { input: "next" } : {}),
       };
     }
   } catch (error) {
     transfers.cancel();
     pendingResult = undefined;
+    pendingInput = undefined;
     const failure = error instanceof Error ? error : new Error(String(error));
     const code = executed ? "outcome-unknown" : "code" in failure ? failure.code : undefined;
     reply = {

--- a/src/infra/sqlite-worker-broker-reply.ts
+++ b/src/infra/sqlite-worker-broker-reply.ts
@@ -1,0 +1,115 @@
+import { deserialize, serialize } from "node:v8";
+import type { Job } from "./sqlite-worker-broker.types.js";
+import {
+  SQLITE_WORKER_MAX_MESSAGE_BYTES,
+  type SqliteWorkerReply,
+  type SqliteWorkerRequest,
+} from "./sqlite-worker-contract.js";
+import {
+  createSqliteWorkerTransferOwner,
+  createSqliteWorkerTransferReceiver,
+  type SqliteWorkerTransferFrame,
+  type SqliteWorkerTransferHandle,
+} from "./sqlite-worker-transfer.js";
+
+export function prepareSqliteWorkerRequest(job: Job): SqliteWorkerRequest {
+  if (
+    job.request.type !== "execute" ||
+    job.request.input.byteLength <= SQLITE_WORKER_MAX_MESSAGE_BYTES
+  ) {
+    return job.request;
+  }
+  const { input, ...request } = job.request;
+  const producer = createSqliteWorkerTransferOwner();
+  const transfer = producer.start([{ kind: "command", serialized: input }].values(), {
+    kinds: ["command"],
+  });
+  job.inputTransfer = { id: transfer.id, producer };
+  job.request.input = new Uint8Array();
+  return { ...request, type: "execute-start", transfer };
+}
+
+export function decodeSqliteWorkerReplyValue(
+  job: Job,
+  reply: Extract<SqliteWorkerReply, { ok: true }>,
+):
+  | { type: "complete"; value: unknown }
+  | {
+      type: "continue";
+      request: Extract<SqliteWorkerRequest, { type: "result-next" | "execute-frame" }>;
+    } {
+  if (reply.input === "next") {
+    const transfer = job.inputTransfer;
+    if (!transfer || reply.transfer) {
+      throw new Error("SQLite worker requested unexpected command input");
+    }
+    const frame = transfer.producer.next(transfer.id);
+    const input = serialize(frame);
+    if (input.byteLength > SQLITE_WORKER_MAX_MESSAGE_BYTES) {
+      throw new Error("SQLite worker input frame exceeds the transport byte limit");
+    }
+    if (frame.done) {
+      transfer.producer.end(transfer.id);
+      job.inputTransfer = undefined;
+    }
+    return {
+      type: "continue",
+      request: { type: "execute-frame", id: job.request.id, actor: job.request.actor, input },
+    };
+  }
+  if (job.inputTransfer) {
+    throw new Error("SQLite worker completed before receiving its command input");
+  }
+  let value: unknown;
+  if (reply.transfer === "start") {
+    // SAFETY: The matching worker emits this private handle; framing validates its records.
+    const handle = deserialize(reply.value) as SqliteWorkerTransferHandle;
+    if (
+      job.request.type !== "execute" ||
+      job.transfer ||
+      handle.kinds.length !== 1 ||
+      handle.kinds[0] !== "result"
+    ) {
+      throw new Error("SQLite worker returned an unexpected result transfer");
+    }
+    const transfer: NonNullable<Job["transfer"]> = {
+      id: handle.id,
+      value: undefined,
+      receiver: createSqliteWorkerTransferReceiver(handle, (record) => {
+        transfer.value = record.value;
+      }),
+    };
+    job.transfer = transfer;
+  } else if (reply.transfer === "frame") {
+    const transfer = job.transfer;
+    if (!transfer) {
+      throw new Error("SQLite worker returned an unexpected result frame");
+    }
+    // SAFETY: The matching worker emits frames; the shared receiver validates their sequence and bounds.
+    const frame = deserialize(reply.value) as SqliteWorkerTransferFrame;
+    const counts = transfer.receiver.accept(frame);
+    if (counts) {
+      if (counts.length !== 1 || counts[0]?.[1] !== 1) {
+        throw new Error("SQLite worker returned an incomplete result transfer");
+      }
+      value = transfer.value;
+      job.transfer = undefined;
+    }
+  } else {
+    if (job.transfer) {
+      throw new Error("SQLite worker ended its result transfer without completion");
+    }
+    value = deserialize(reply.value);
+  }
+  return job.transfer
+    ? {
+        type: "continue",
+        request: {
+          type: "result-next",
+          id: job.request.id,
+          actor: job.request.actor,
+          transferId: job.transfer.id,
+        },
+      }
+    : { type: "complete", value };
+}

--- a/src/infra/sqlite-worker-broker-reply.ts
+++ b/src/infra/sqlite-worker-broker-reply.ts
@@ -4,12 +4,12 @@ import {
   SQLITE_WORKER_MAX_MESSAGE_BYTES,
   type SqliteWorkerReply,
   type SqliteWorkerRequest,
+  type SqliteWorkerTransferHandle,
 } from "./sqlite-worker-contract.js";
 import {
   createSqliteWorkerTransferOwner,
   createSqliteWorkerTransferReceiver,
   type SqliteWorkerTransferFrame,
-  type SqliteWorkerTransferHandle,
 } from "./sqlite-worker-transfer.js";
 
 export function prepareSqliteWorkerRequest(job: Job): SqliteWorkerRequest {

--- a/src/infra/sqlite-worker-broker.ts
+++ b/src/infra/sqlite-worker-broker.ts
@@ -3,7 +3,7 @@ import { createHash } from "node:crypto";
 import { realpath, stat } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
-import { deserialize, serialize } from "node:v8";
+import { serialize } from "node:v8";
 import { Worker } from "node:worker_threads";
 import { toErrorObject } from "@openclaw/normalization-core/error-coercion";
 import { createDeferredCore } from "../shared/deferred.js";
@@ -11,6 +11,10 @@ import { INCOGNITO_AGENT_SQLITE_BASENAME } from "../state/openclaw-agent-db.path
 import { ensureSqliteLibrarySelected } from "./bun-sqlite-library.js";
 import { runtimeProcessEntrypoints } from "./runtime-process-entrypoints.js";
 import { resolveRuntimeWorkerUrl } from "./runtime-worker-url.js";
+import {
+  decodeSqliteWorkerReplyValue,
+  prepareSqliteWorkerRequest,
+} from "./sqlite-worker-broker-reply.js";
 import type {
   Actor,
   DispatchState,
@@ -25,15 +29,9 @@ import {
   SqliteWorkerError,
   type SqliteWorkerOperations,
   type SqliteWorkerReply,
-  type SqliteWorkerRequest,
   type SqliteWorkerStore,
 } from "./sqlite-worker-contract.js";
 import { readDatabasePathIdentity } from "./sqlite-worker-identity.js";
-import {
-  createSqliteWorkerTransferReceiver,
-  type SqliteWorkerTransferFrame,
-  type SqliteWorkerTransferHandle,
-} from "./sqlite-worker-transfer.js";
 
 const MAX_WORKERS = 4;
 const MAX_STORES = 64;
@@ -368,57 +366,13 @@ export class SqliteWorkerBroker {
       }
       let value: unknown;
       try {
-        if (reply.transfer === "start") {
-          // SAFETY: The matching worker emits this private handle; framing validates its records.
-          const handle = deserialize(reply.value) as SqliteWorkerTransferHandle;
-          if (
-            job.request.type !== "execute" ||
-            job.transfer ||
-            handle.kinds.length !== 1 ||
-            handle.kinds[0] !== "result"
-          ) {
-            throw new Error("SQLite worker returned an unexpected result transfer");
-          }
-          const transfer: NonNullable<Job["transfer"]> = {
-            id: handle.id,
-            value: undefined,
-            receiver: createSqliteWorkerTransferReceiver(handle, (record) => {
-              transfer.value = record.value;
-            }),
-          };
-          job.transfer = transfer;
-        } else if (reply.transfer === "frame") {
-          const transfer = job.transfer;
-          if (!transfer) {
-            throw new Error("SQLite worker returned an unexpected result frame");
-          }
-          // SAFETY: The matching worker emits frames; the shared receiver validates their sequence and bounds.
-          const frame = deserialize(reply.value) as SqliteWorkerTransferFrame;
-          const counts = transfer.receiver.accept(frame);
-          if (counts) {
-            if (counts.length !== 1 || counts[0]?.[1] !== 1) {
-              throw new Error("SQLite worker returned an incomplete result transfer");
-            }
-            value = transfer.value;
-            job.transfer = undefined;
-          }
-        } else {
-          if (job.transfer) {
-            throw new Error("SQLite worker ended its result transfer without completion");
-          }
-          value = deserialize(reply.value);
-        }
-        if (job.transfer) {
-          // Continue the current job through drain; enqueueing behind it would deadlock.
-          const continuation: SqliteWorkerRequest = {
-            type: "result-next",
-            id: job.request.id,
-            actor: job.request.actor,
-            transferId: job.transfer.id,
-          };
-          slot.worker.postMessage(continuation, []);
+        const result = decodeSqliteWorkerReplyValue(job, reply);
+        if (result.type === "continue") {
+          // Continuations retain the current job and its reserved transport credits through drain.
+          slot.worker.postMessage(result.request, []);
           return;
         }
+        value = result.value;
       } catch (error) {
         this.fail(slot, error);
         return;
@@ -451,11 +405,14 @@ export class SqliteWorkerBroker {
     if (slot.failed) {
       return Promise.reject(slot.failed);
     }
+    const activeInput = body.type === "execute" && bytes > MAX_QUEUED_BYTES;
+    const reservedBytes = activeInput ? SQLITE_WORKER_MAX_MESSAGE_BYTES : bytes;
     if (
       body.type !== "close" &&
-      (bytes > SQLITE_WORKER_MAX_MESSAGE_BYTES ||
+      ((body.type !== "execute" && bytes > SQLITE_WORKER_MAX_MESSAGE_BYTES) ||
+        (activeInput && (slot.current || slot.queue.length > 0 || slot.pendingOpens > 0)) ||
         this.requests >= MAX_REQUESTS ||
-        this.bytes + this.admissionBytes + bytes > MAX_QUEUED_BYTES)
+        this.bytes + this.admissionBytes + reservedBytes > MAX_QUEUED_BYTES)
     ) {
       return Promise.reject(
         new SqliteWorkerError("SQLite worker queue capacity reached", "overloaded"),
@@ -465,7 +422,7 @@ export class SqliteWorkerBroker {
     const job: Job = {
       dispatchState,
       request: { ...body, id: ++this.nextRequest },
-      bytes,
+      bytes: reservedBytes,
       resolve: result.resolve,
       reject: result.reject,
       detach: () => signal?.removeEventListener("abort", abort),
@@ -479,7 +436,16 @@ export class SqliteWorkerBroker {
       // Once dispatched, retain the Promise until the database outcome is known.
     };
     this.requests += 1;
-    this.bytes += bytes;
+    this.bytes += reservedBytes;
+    if (activeInput) {
+      // A complete oversized value is active-operation memory, never retained in the bounded queue.
+      if (signal?.aborted) {
+        this.finish(job, signal.reason ?? new Error("SQLite worker operation canceled"));
+      } else {
+        this.dispatchJob(slot, job);
+      }
+      return result.promise;
+    }
     slot.queue.push(job);
     signal?.addEventListener("abort", abort, { once: true });
     if (signal?.aborted) {
@@ -498,11 +464,15 @@ export class SqliteWorkerBroker {
       slot.worker.unref();
       return;
     }
+    this.dispatchJob(slot, job);
+  }
+
+  private dispatchJob(slot: Slot, job: Job): void {
     slot.current = job;
     job.detach();
     slot.worker.ref();
     try {
-      slot.worker.postMessage(job.request, []);
+      slot.worker.postMessage(prepareSqliteWorkerRequest(job), []);
       if (job.dispatchState) {
         job.dispatchState.dispatched = true;
       }
@@ -514,6 +484,8 @@ export class SqliteWorkerBroker {
   }
 
   private finish(job: Job, error?: unknown, value?: unknown): void {
+    job.inputTransfer?.producer.cancel();
+    job.inputTransfer = undefined;
     job.transfer = undefined;
     job.detach();
     this.requests -= 1;
@@ -534,6 +506,8 @@ export class SqliteWorkerBroker {
     const current = slot.current;
     slot.current = undefined;
     if (current) {
+      current.inputTransfer?.producer.cancel();
+      current.inputTransfer = undefined;
       current.transfer = undefined;
     }
     const queued = slot.queue.splice(0);

--- a/src/infra/sqlite-worker-broker.types.ts
+++ b/src/infra/sqlite-worker-broker.types.ts
@@ -1,6 +1,9 @@
 import type { Worker } from "node:worker_threads";
 import type { SqliteWorkerRequest } from "./sqlite-worker-contract.js";
-import type { createSqliteWorkerTransferReceiver } from "./sqlite-worker-transfer.js";
+import type {
+  createSqliteWorkerTransferOwner,
+  createSqliteWorkerTransferReceiver,
+} from "./sqlite-worker-transfer.js";
 
 export type RequestBody = SqliteWorkerRequest extends infer Request
   ? Request extends SqliteWorkerRequest
@@ -9,6 +12,10 @@ export type RequestBody = SqliteWorkerRequest extends infer Request
   : never;
 export type DispatchState = { dispatched: boolean };
 export type Job = {
+  inputTransfer?: {
+    id: number;
+    producer: ReturnType<typeof createSqliteWorkerTransferOwner>;
+  };
   transfer?: {
     id: number;
     receiver: ReturnType<typeof createSqliteWorkerTransferReceiver>;

--- a/src/infra/sqlite-worker-contract.ts
+++ b/src/infra/sqlite-worker-contract.ts
@@ -1,3 +1,5 @@
+import type { SqliteWorkerTransferHandle } from "./sqlite-worker-transfer.js";
+
 export type SqliteWorkerOperations = Record<string, { input: unknown; output: unknown }>;
 export type SqliteWorkerCommand<Operations extends SqliteWorkerOperations> = {
   [Key in keyof Operations]: { type: Key; input: Operations[Key]["input"] };
@@ -29,6 +31,8 @@ export type SqliteWorkerRequest = {
       input: Uint8Array;
     }
   | { type: "execute"; input: Uint8Array }
+  | { type: "execute-start"; transfer: SqliteWorkerTransferHandle }
+  | { type: "execute-frame"; input: Uint8Array }
   | { type: "result-next"; transferId: number }
   | { type: "close" }
 );
@@ -36,7 +40,7 @@ export type SqliteWorkerRequest = {
 export type SqliteWorkerReply = {
   id: number;
 } & (
-  | { ok: true; value: Uint8Array; transfer?: "start" | "frame" }
+  | { ok: true; value: Uint8Array; transfer?: "start" | "frame"; input?: "next" }
   | { ok: false; retire?: true; error: { name: string; message: string; code?: string | number } }
 );
 

--- a/src/infra/sqlite-worker-contract.ts
+++ b/src/infra/sqlite-worker-contract.ts
@@ -1,4 +1,4 @@
-import type { SqliteWorkerTransferHandle } from "./sqlite-worker-transfer.js";
+export type SqliteWorkerTransferHandle = { id: number; kinds: string[] };
 
 export type SqliteWorkerOperations = Record<string, { input: unknown; output: unknown }>;
 export type SqliteWorkerCommand<Operations extends SqliteWorkerOperations> = {

--- a/src/infra/sqlite-worker-input.test.ts
+++ b/src/infra/sqlite-worker-input.test.ts
@@ -1,0 +1,292 @@
+import { createHash } from "node:crypto";
+import path from "node:path";
+import { deserialize, serialize } from "node:v8";
+import { Worker } from "node:worker_threads";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { createDeferredCore } from "../shared/deferred.js";
+import { drainGlobalSingletonLifecycleState } from "../shared/global-singleton.js";
+import {
+  SQLITE_WORKER_MAX_RESULT_BYTES,
+  SQLITE_WORKER_TRANSFER_FRAME_BYTES,
+  type SqliteWorkerReply,
+  type SqliteWorkerRequest,
+} from "./sqlite-worker-contract.js";
+import { openSqliteWorkerStore, type SqliteWorkerStore } from "./sqlite-worker-store.js";
+import type { FixtureOperations } from "./sqlite-worker-store.test-support.js";
+import type { SqliteWorkerTransferFrame } from "./sqlite-worker-transfer.js";
+
+const stores = new Set<SqliteWorkerStore<FixtureOperations>>();
+const dirs = useAutoCleanupTempDirTracker((cleanup) =>
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    try {
+      await Promise.all([...stores].map((store) => store.close()));
+    } finally {
+      stores.clear();
+      cleanup();
+    }
+  }),
+);
+const digest = (value: string) => createHash("sha256").update(value).digest("hex");
+const payload = (mib: number) => "x".repeat(mib * 1024 * 1024);
+const databasePath = () => path.join(dirs.make("sqlite-worker-input-"), "store.sqlite");
+
+async function open(file: string) {
+  const store = await openSqliteWorkerStore<FixtureOperations>({
+    moduleUrl: new URL("./sqlite-worker-store.test-support.ts", import.meta.url),
+    databasePath: file,
+    input: undefined,
+  });
+  stores.add(store);
+  return store;
+}
+
+function append(store: SqliteWorkerStore<FixtureOperations>, value: string, signal?: AbortSignal) {
+  return store.execute({ type: "append", input: { value } }, { signal });
+}
+
+async function expectRows(store: SqliteWorkerStore<FixtureOperations>, expected: string[]) {
+  const rows = await store.execute({ type: "read", input: undefined });
+  expect(rows.map((row) => ({ length: row.length, digest: digest(row) }))).toEqual(
+    expected.map((row) => ({ length: row.length, digest: digest(row) })),
+  );
+}
+
+function holdReply(matches: (reply: SqliteWorkerReply) => boolean) {
+  const held = createDeferredCore();
+  let publish: (() => void) | undefined;
+  let captured = false;
+  // oxlint-disable-next-line typescript/unbound-method -- Reflect.apply restores the emitting worker.
+  const original = Worker.prototype.emit;
+  const messages = vi.spyOn(Worker.prototype, "emit").mockImplementation(function (
+    this: Worker,
+    event: string | symbol,
+    ...args: unknown[]
+  ) {
+    const reply = args[0] as SqliteWorkerReply;
+    if (event === "message" && !captured && matches(reply)) {
+      captured = true;
+      publish = () => Reflect.apply(original, this, [event, ...args]);
+      held.resolve();
+      return true;
+    }
+    return Reflect.apply(original, this, [event, ...args]);
+  });
+  return {
+    held: held.promise,
+    release() {
+      messages.mockRestore();
+      publish?.();
+      publish = undefined;
+    },
+  };
+}
+
+function holdFirstStagedChunk() {
+  let acknowledgments = 0;
+  return holdReply((reply) => reply.ok && reply.input === "next" && ++acknowledgments === 2);
+}
+
+describe("SQLite worker staged input", () => {
+  it.each([40, 72])("snapshots and persists one %s MiB append across reopening", async (mib) => {
+    const file = databasePath();
+    const store = await open(file);
+    const value = payload(mib);
+    const inputFrames: Array<{ visible: number; backing: number }> = [];
+    const receivedFrames: Array<{ visible: number; backing: number; framed: boolean }> = [];
+    const commands: SqliteWorkerRequest["type"][] = [];
+    // oxlint-disable-next-line typescript/unbound-method -- call restores the sending worker below.
+    const originalPost = Worker.prototype.postMessage;
+    vi.spyOn(Worker.prototype, "postMessage").mockImplementation(function (
+      this: Worker,
+      request: SqliteWorkerRequest,
+      transferList,
+    ) {
+      commands.push(request.type);
+      if (request.type === "execute-frame") {
+        inputFrames.push({
+          visible: request.input.byteLength,
+          backing: request.input.buffer.byteLength,
+        });
+      }
+      return originalPost.call(this, request, transferList);
+    });
+    // oxlint-disable-next-line typescript/unbound-method -- Reflect.apply restores the emitting worker.
+    const originalEmit = Worker.prototype.emit;
+    vi.spyOn(Worker.prototype, "emit").mockImplementation(function (
+      this: Worker,
+      event: string | symbol,
+      ...args: unknown[]
+    ) {
+      const reply = args[0] as SqliteWorkerReply;
+      if (event === "message" && reply.ok) {
+        receivedFrames.push({
+          visible: reply.value.byteLength,
+          backing: reply.value.buffer.byteLength,
+          framed: reply.transfer === "frame",
+        });
+      }
+      return Reflect.apply(originalEmit, this, [event, ...args]);
+    });
+    const command = { type: "append" as const, input: { value } };
+    const admitted = store.execute(command);
+    command.input.value = "caller changed the input";
+    expect(await admitted).toMatchObject({ writes: 1 });
+    expect(commands.filter((kind) => kind === "execute-start")).toHaveLength(1);
+    expect(inputFrames.length).toBeGreaterThan(1);
+    await expectRows(store, [value]);
+    await store.close();
+    await expectRows(await open(file), [value]);
+    for (const frame of inputFrames) {
+      expect(frame.visible).toBeLessThanOrEqual(SQLITE_WORKER_TRANSFER_FRAME_BYTES + 1024);
+      expect(frame.backing).toBeLessThanOrEqual(SQLITE_WORKER_TRANSFER_FRAME_BYTES + 1024);
+    }
+    for (const frame of receivedFrames) {
+      const limit = frame.framed
+        ? SQLITE_WORKER_TRANSFER_FRAME_BYTES + 1024
+        : SQLITE_WORKER_MAX_RESULT_BYTES;
+      expect(frame.visible).toBeLessThanOrEqual(limit);
+      expect(frame.backing).toBeLessThanOrEqual(limit);
+    }
+    if (mib === 72) {
+      expect(receivedFrames.some((frame) => frame.framed)).toBe(true);
+    }
+  });
+
+  it("charges a queued 40 MiB command in full and frees its credits on cancellation", async () => {
+    const store = await open(databasePath());
+    const hold = holdReply(() => true);
+    const ahead = append(store, "ahead");
+    const cancelQueued = new AbortController();
+    const replacementCancel = new AbortController();
+    let queued: Promise<unknown> | undefined;
+    let replacement: Promise<unknown> | undefined;
+    try {
+      await Promise.race([hold.held, ahead]);
+      queued = append(store, payload(40), cancelQueued.signal);
+      await expect(append(store, payload(30))).rejects.toMatchObject({ code: "overloaded" });
+      const reason = new Error("cancel queued input");
+      cancelQueued.abort(reason);
+      await expect(queued).rejects.toBe(reason);
+      replacement = append(store, payload(30), replacementCancel.signal);
+      replacementCancel.abort(reason);
+      await expect(replacement).rejects.toBe(reason);
+      hold.release();
+      expect(await ahead).toMatchObject({ writes: 1 });
+      await expectRows(store, ["ahead"]);
+    } finally {
+      cancelQueued.abort();
+      replacementCancel.abort();
+      hold.release();
+      await Promise.allSettled([ahead, queued, replacement]);
+    }
+  });
+
+  it("reserves 32 MiB for active oversized input while preserving cancellation and queue credit", async () => {
+    const store = await open(databasePath());
+    const hold = holdFirstStagedChunk();
+    const activeCancel = new AbortController();
+    const queuedCancel = new AbortController();
+    const replacementCancel = new AbortController();
+    const value = payload(72);
+    const active = append(store, value, activeCancel.signal);
+    let queued: Promise<unknown> | undefined;
+    let replacement: Promise<unknown> | undefined;
+    try {
+      await Promise.race([hold.held, active]);
+      await expect(append(store, payload(72))).rejects.toMatchObject({ code: "overloaded" });
+      await expect(append(store, payload(40))).rejects.toMatchObject({ code: "overloaded" });
+      queued = append(store, payload(24), queuedCancel.signal);
+      await expect(append(store, payload(16))).rejects.toMatchObject({ code: "overloaded" });
+      const reason = new Error("cancel queued bytes");
+      queuedCancel.abort(reason);
+      await expect(queued).rejects.toBe(reason);
+      replacement = append(store, payload(16), replacementCancel.signal);
+      replacementCancel.abort(reason);
+      await expect(replacement).rejects.toBe(reason);
+      activeCancel.abort(new Error("owner stopped after dispatch"));
+      hold.release();
+      expect(await active).toMatchObject({ writes: 1 });
+      await expectRows(store, [value]);
+    } finally {
+      queuedCancel.abort();
+      replacementCancel.abort();
+      hold.release();
+      await Promise.allSettled([active, queued, replacement]);
+    }
+  });
+
+  it("retires failed staging before any append executes and releases credits for recovery", async () => {
+    const file = databasePath();
+    const store = await open(file);
+    // oxlint-disable-next-line typescript/unbound-method -- call restores the sending worker below.
+    const original = Worker.prototype.postMessage;
+    const post = vi.spyOn(Worker.prototype, "postMessage").mockImplementation(function (
+      this: Worker,
+      request: SqliteWorkerRequest,
+      transferList,
+    ) {
+      if (request.type === "execute-frame") {
+        post.mockRestore();
+        const frame = deserialize(request.input) as SqliteWorkerTransferFrame;
+        return original.call(
+          this,
+          { ...request, input: serialize({ ...frame, sequence: frame.sequence + 1 }) },
+          transferList,
+        );
+      }
+      return original.call(this, request, transferList);
+    });
+    const value = payload(72);
+    const staged = append(store, value);
+    const queued = append(store, "must not run");
+    try {
+      expect(await Promise.allSettled([staged, queued])).toEqual([
+        { status: "rejected", reason: expect.objectContaining({ code: "outcome-unknown" }) },
+        { status: "rejected", reason: expect.objectContaining({ code: "unavailable" }) },
+      ]);
+      stores.delete(store);
+      await expect(store.close()).rejects.toMatchObject({ code: "unavailable" });
+      const recovered = await open(file);
+      await expectRows(recovered, []);
+      expect(await append(recovered, value)).toMatchObject({ writes: 1 });
+      await expectRows(recovered, [value]);
+    } finally {
+      post.mockRestore();
+      await Promise.allSettled([staged, queued, store.close()]);
+      stores.delete(store);
+    }
+  });
+
+  it.each(["client", "global"] as const)(
+    "drains partial command staging on %s close",
+    async (kind) => {
+      const file = databasePath();
+      const store = await open(file);
+      const hold = holdFirstStagedChunk();
+      const value = payload(72);
+      const pending = append(store, value);
+      let closing: Promise<void> | undefined;
+      let closed = false;
+      try {
+        await Promise.race([hold.held, pending]);
+        closing = (
+          kind === "client" ? store.close() : drainGlobalSingletonLifecycleState("restart")
+        ).then(() => {
+          closed = true;
+        });
+        await expect(append(store, "after close")).rejects.toMatchObject({ code: "closed" });
+        expect(closed).toBe(false);
+        hold.release();
+        expect(await pending).toMatchObject({ writes: 1 });
+        await closing;
+        expect(closed).toBe(true);
+        await expectRows(await open(file), [value]);
+      } finally {
+        hold.release();
+        await Promise.allSettled([pending, closing]);
+      }
+    },
+  );
+});

--- a/src/infra/sqlite-worker-transfer.ts
+++ b/src/infra/sqlite-worker-transfer.ts
@@ -1,7 +1,8 @@
 import { deserialize, serialize } from "node:v8";
-import { SQLITE_WORKER_TRANSFER_FRAME_BYTES } from "./sqlite-worker-contract.js";
-
-export type SqliteWorkerTransferHandle = { id: number; kinds: string[] };
+import {
+  SQLITE_WORKER_TRANSFER_FRAME_BYTES,
+  type SqliteWorkerTransferHandle,
+} from "./sqlite-worker-contract.js";
 export type SqliteWorkerTransferValue = { kind: string; value: unknown };
 export type SqliteWorkerTransferInput =
   | SqliteWorkerTransferValue


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where plugins using worker-backed SQLite could not write valid commands larger than 32 MiB. Managed-flow state and wait data have no corresponding domain size limit, so moving those writes to workers otherwise rejects values accepted by the existing storage contract.

## Why This Change Was Made

The existing worker broker now stages large execute commands through the same bounded transfer primitive used for large results. The original job retains its actor and lifecycle until the complete command is validated and executed once. Small requests retain the existing path; cancellation, failure, and close release staging ownership without partially executing or replaying a command.

The 32 MiB message and 64 MiB aggregate transport budgets remain unchanged. Queued commands charge their full serialized size. Commands larger than the aggregate budget require an idle slot and reserve a 32 MiB transport window; otherwise they receive the existing overload error. The budget bounds admitted transport queues and windows, while the complete active command or result remains operation memory. This distinction is documented explicitly.

## User Impact

Plugins can write large valid SQLite values through workers while retaining bounded transport messages and backpressure. This is the transport prerequisite for the separate managed-flow mutation migration; it does not add a database schema, public size limit, or PostgreSQL backend.

## Evidence

- Seven actual-worker regression cases cover queued-byte charging, active oversized admission, competing work, cancellation, incomplete-input failure, exactly-once writes, close drainage, and reopening persisted state.
- Source and compiled worker runs on Node 24.20.0 and Bun 1.4.2 each wrote 40 MiB and 72 MiB commands, then read back 112 MiB before and after reopening with matching SHA-256 digests. Actual message frames had independently bounded backing buffers. Compiled 72 MiB writes took approximately 581 ms on Node and 1.37 s on Bun during concurrent local verification; these are observations, not benchmark guarantees.
- An isolated composition with the managed-flow caller and common state owner verified registered asynchronous create, waiting, and resume with 36 MiB state plus 36 MiB wait data, exact persisted values, and reopen. A separate canonical schema-error case verifies typed failure at staged execution and no partial write. That composition is proof of compatibility, not additional source in this PR.
- All 54 focused input and existing transport/framing tests and a fresh scoped Codex review pass on the current broker split. The current-base full build also passes, and its compiled Node/Bun workers passed the same large-command/reopen proof. The complete current-base changed-file gate passes. CI exposed a static type-import cycle; moving the transfer handle into the existing leaf contract fixes it. The complete architecture suite, correction gate, framing tests, and fresh correction review pass; emitted runtime code is equivalent to the verified build.
