### PR TITLE
fix: reduce large session catalog refresh overhead

### DIFF
--- a/src/config/sessions/session-accessor.sqlite-entry.ts
+++ b/src/config/sessions/session-accessor.sqlite-entry.ts
@@ -257,11 +257,20 @@ export function listSessionEntryRows(scope: SessionEntryListScope = {}): Session
  * acceptable degradation (health snapshots) or hides real state (migration detection).
  */
 export function listSessionEntriesReadOnly(
-  scope: SessionEntryListScope = {},
+  scope: SessionEntryListScope & {
+    /** Select exact persisted keys after validating the complete listing snapshot. */
+    sessionKeys?: readonly string[];
+  } = {},
 ): SessionEntrySummary[] {
   const resolved = resolveSqliteScope({ ...scope, sessionKey: "" });
   const result = withOpenClawAgentDatabaseReadOnly(
-    (database) => listSqliteSessionEntriesFromDatabase(database, resolved, scope),
+    (database) =>
+      listSqliteSessionEntriesFromDatabase(
+        database,
+        resolved,
+        scope,
+        scope.sessionKeys ? new Set(scope.sessionKeys) : undefined,
+      ),
     toDatabaseOptions(resolved),
   );
   return result.found ? result.value : [];
@@ -316,6 +325,7 @@ function listSqliteSessionEntriesFromDatabase(
   database: Pick<OpenClawAgentDatabase, "agentId" | "db" | "path">,
   resolved: ResolvedSqliteScope,
   scope: SessionEntryListScope,
+  sessionKeys?: ReadonlySet<string>,
 ): SessionEntrySummary[] {
   const projection = scope.projection ?? "full";
   const cache = !isIncognitoOpenClawAgentSqlitePath(database.path, {
@@ -327,21 +337,27 @@ function listSqliteSessionEntriesFromDatabase(
     latest: scope.readConsistency === "latest",
     projection,
   });
-  return projectSessionEntriesForListing(snapshot, projection === "list" && scope.clone !== false);
+  return projectSessionEntriesForListing(
+    snapshot,
+    projection === "list" && scope.clone !== false,
+    sessionKeys,
+  );
 }
 
 /** Applies the listing visibility and canonical-key contract to an owned snapshot. */
 export function projectSessionEntriesForListing(
   snapshot: SessionEntryCacheSnapshot,
   cloneEntries = false,
+  sessionKeys?: ReadonlySet<string>,
 ): SessionEntrySummary[] {
-  return snapshot.keys.flatMap((sessionKey) => {
+  const entries: SessionEntrySummary[] = [];
+  for (const sessionKey of snapshot.keys) {
     if (isInternalSessionEffectsKey(sessionKey)) {
-      return [];
+      continue;
     }
     const entry = snapshot.entries.get(sessionKey);
     if (!entry) {
-      return [];
+      continue;
     }
     const deliveryCanonicalKey = resolveDeliveryProvenCanonicalSessionKey(sessionKey, entry);
     if (deliveryCanonicalKey !== sessionKey) {
@@ -349,14 +365,17 @@ export function projectSessionEntriesForListing(
         `non-canonical persisted row resolves to session key ${deliveryCanonicalKey}`,
       );
     }
+    // Selection cannot hide a non-canonical row elsewhere in the same snapshot.
+    if (sessionKeys && !sessionKeys.has(sessionKey)) {
+      continue;
+    }
     // Full snapshots own their nested values; list snapshots may share cached entries.
-    return [
-      {
-        sessionKey,
-        entry: cloneEntries ? cloneSessionEntry(entry) : entry,
-      },
-    ];
-  });
+    entries.push({
+      sessionKey,
+      entry: cloneEntries ? cloneSessionEntry(entry) : entry,
+    });
+  }
+  return entries;
 }
 
 /** Lists only entries whose normalized session row has one of the requested statuses. */

--- a/src/config/sessions/session-accessor.sqlite-selected-list.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-selected-list.test.ts
@@ -1,0 +1,84 @@
+import path from "node:path";
+import { afterEach, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import {
+  closeOpenClawAgentDatabasesForTest,
+  openOpenClawAgentDatabase,
+  runOpenClawAgentWriteTransaction,
+} from "../../state/openclaw-agent-db.js";
+import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
+import { resolveInternalSessionEffectsIdentity } from "./internal-session-key.js";
+import { listSessionEntriesReadOnly } from "./session-accessor.js";
+import { writeSessionEntry } from "./session-accessor.sqlite-entry-store.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+afterEach(() => {
+  closeOpenClawAgentDatabasesForTest();
+  closeOpenClawStateDatabaseForTest();
+});
+
+function fixture() {
+  const stateDir = tempDirs.make("selected-session-list-");
+  const options = {
+    agentId: "main",
+    path: path.join(stateDir, "sessions.sqlite"),
+    env: { OPENCLAW_STATE_DIR: stateDir },
+  };
+  const database = openOpenClawAgentDatabase(options);
+  const hidden = resolveInternalSessionEffectsIdentity({ agentId: "main", runId: "hidden" });
+  runOpenClawAgentWriteTransaction((db) => {
+    for (const name of ["c", "a", "b"]) {
+      writeSessionEntry(db, `agent:main:${name}`, {
+        sessionId: `session-${name}`,
+        updatedAt: 1,
+        skillsSnapshot: { prompt: "saved prompt", skills: [] },
+      });
+    }
+    writeSessionEntry(db, hidden.sessionKey, { sessionId: hidden.sessionId, updatedAt: 1 });
+  }, options);
+  const read = (sessionKeys?: readonly string[]) =>
+    listSessionEntriesReadOnly({
+      agentId: options.agentId,
+      env: options.env,
+      storePath: options.path,
+      projection: "list",
+      sessionKeys,
+    });
+  return { database, hidden, read };
+}
+
+it.each([
+  { selection: undefined, expected: ["a", "b", "c"] },
+  { selection: ["c", "missing", "a", "c", "hidden"], expected: ["a", "c"] },
+  { selection: [], expected: [] },
+])("returns the ordered selected metadata for $selection", ({ selection, expected }) => {
+  const { hidden, read } = fixture();
+  const rows = read(
+    selection?.map((name) => (name === "hidden" ? hidden.sessionKey : `agent:main:${name}`)),
+  );
+  expect(rows.map(({ sessionKey }) => sessionKey)).toEqual(
+    expected.map((name) => `agent:main:${name}`),
+  );
+  expect(rows.every(({ entry }) => entry.skillsSnapshot === undefined)).toBe(true);
+});
+
+it.each([{ selection: [] }, { selection: ["agent:main:a"] }])(
+  "retains unrelated canonical-key errors when selecting $selection",
+  ({ selection }) => {
+    const { database, read } = fixture();
+    read();
+    // Raw DML after validation must not disappear behind an unrelated selection.
+    database.db
+      .prepare(
+        "INSERT INTO session_nodes(session_key, current_session_id, entry_json, updated_at) VALUES(?, ?, ?, ?)",
+      )
+      .run(
+        "AGENT:MAIN:UNRELATED",
+        "unrelated",
+        JSON.stringify({ sessionId: "unrelated", updatedAt: 1 }),
+        1,
+      );
+    expect(() => read(selection)).toThrow("non-canonical persisted row");
+  },
+);

--- a/src/gateway/server-methods/session-catalog-entry-snapshot.ts
+++ b/src/gateway/server-methods/session-catalog-entry-snapshot.ts
@@ -38,6 +38,8 @@ type SessionCatalogRequestEntrySnapshot = {
 export function createSessionCatalogRequestEntrySnapshot(params: {
   cfg: OpenClawConfig;
   fallbackAgentId: string;
+  /** Bound one delivery's lookups; provider planning retains the full snapshot. */
+  sessionKeys?: readonly string[];
 }): SessionCatalogRequestEntrySnapshot {
   const entriesByAgentId = new Map<string, readonly SessionEntrySummary[]>();
   const entryIndexByAgentId = new Map<string, ReadonlyMap<string, SessionEntry>>();
@@ -48,6 +50,21 @@ export function createSessionCatalogRequestEntrySnapshot(params: {
   let catalogEntries:
     | ReturnType<NonNullable<SessionCatalogEntrySnapshot["entriesForCatalog"]>>
     | undefined;
+  const entryAgentId = (sessionKey: string) =>
+    resolveAgentIdFromSessionKey(
+      sessionKey,
+      tryResolveSessionCompatibilityOwnerAgentId(params.cfg, sessionKey) ?? params.fallbackAgentId,
+    );
+  const selectedKeysByAgentId = params.sessionKeys ? new Map<string, Set<string>>() : undefined;
+  if (selectedKeysByAgentId) {
+    for (const sessionKey of new Set(params.sessionKeys)) {
+      const agentId = entryAgentId(sessionKey);
+      const keys = selectedKeysByAgentId.get(agentId) ?? new Set<string>();
+      keys.add(sessionKey);
+      keys.add(resolveStoredSessionKeyForAgentStore({ cfg: params.cfg, agentId, sessionKey }));
+      selectedKeysByAgentId.set(agentId, keys);
+    }
+  }
 
   const entriesForAgent = (rawAgentId: string): readonly SessionEntrySummary[] => {
     const agentId = normalizeAgentId(rawAgentId);
@@ -57,7 +74,14 @@ export function createSessionCatalogRequestEntrySnapshot(params: {
       }
       entriesByAgentId.set(
         agentId,
-        listSessionEntriesReadOnly({ agentId, clone: false, projection: "list" }),
+        listSessionEntriesReadOnly({
+          agentId,
+          clone: false,
+          projection: "list",
+          ...(selectedKeysByAgentId
+            ? { sessionKeys: [...(selectedKeysByAgentId.get(agentId) ?? [])] }
+            : {}),
+        }),
       );
     }
     return entriesByAgentId.get(agentId) ?? [];
@@ -91,10 +115,7 @@ export function createSessionCatalogRequestEntrySnapshot(params: {
   };
 
   const entryForSession = (sessionKey: string): SessionEntry | undefined => {
-    const agentId = resolveAgentIdFromSessionKey(
-      sessionKey,
-      tryResolveSessionCompatibilityOwnerAgentId(params.cfg, sessionKey) ?? params.fallbackAgentId,
-    );
+    const agentId = entryAgentId(sessionKey);
     const index = entryIndexForAgent(agentId);
     const canonicalKey = resolveStoredSessionKeyForAgentStore({
       cfg: params.cfg,

--- a/src/gateway/server-methods/session-catalog-privacy.test.ts
+++ b/src/gateway/server-methods/session-catalog-privacy.test.ts
@@ -4,6 +4,7 @@ import {
   type SessionCatalogHost,
 } from "../../../packages/gateway-protocol/src/index.js";
 import { resolveSessionStorePathCore } from "../../config/sessions/paths.js";
+import * as sessionAccessor from "../../config/sessions/session-accessor.js";
 import {
   deleteSessionEntryLifecycle,
   loadSessionEntryReadOnly,
@@ -203,6 +204,65 @@ const rows = (respond: ReturnType<typeof vi.fn>) =>
   );
 
 describe("catalog delivery uses current canonical privacy", () => {
+  it("materializes only delivered catalog rows while preserving full planning and fresh identity", async () => {
+    await withCatalog(async ({ call, callerId, enumerate, list, owner, replaceForeign }) => {
+      for (let index = 0; index < 24; index++) {
+        await upsertSessionEntryCore(
+          { agentId: "main", sessionKey: `agent:main:unrelated-${index}` },
+          { sessionId: `unrelated-${index}`, updatedAt: 1 },
+        );
+      }
+      type ReadPhase = "planning" | "progress" | "mutation" | "final";
+      let phase: ReadPhase = "planning";
+      const reads: Array<{ phase: ReadPhase; count: number }> = [];
+      const original = sessionAccessor.listSessionEntriesReadOnly;
+      const read = vi
+        .spyOn(sessionAccessor, "listSessionEntriesReadOnly")
+        .mockImplementation((scope) => {
+          const result = original(scope);
+          reads.push({ phase, count: result.length });
+          return result;
+        });
+      list.mockImplementation(async ({ sessionEntries, onHost }) => {
+        expect(sessionEntries?.entriesForCatalog?.()).toHaveLength(27);
+        const host = enumerate(sessionEntries);
+        phase = "progress";
+        onHost?.(host);
+        phase = "mutation";
+        await replaceForeign();
+        phase = "final";
+        return [host];
+      });
+      try {
+        const broadcast = vi.fn();
+        const response = await call(
+          "sessions.catalog.list",
+          { progressId: "delivery-budget" },
+          owner,
+          broadcast,
+        );
+        const progress = broadcast.mock.calls[0]?.[1]?.catalog.hosts[0]?.sessions;
+        expect(broadcast).toHaveBeenCalledOnce();
+        expect(progress?.map((session: { threadId: string }) => session.threadId)).toEqual([
+          "foreign",
+          "owned",
+        ]);
+        expect(
+          progress?.find((session: { threadId: string }) => session.threadId === "owned"),
+        ).toMatchObject({ createdActor: { id: callerId } });
+        expect(rows(response)).toEqual(["owned"]);
+        for (const deliveryPhase of ["progress", "final"] as const) {
+          const materializedRows = reads
+            .filter((observed) => observed.phase === deliveryPhase)
+            .reduce((total, observed) => total + observed.count, 0);
+          expect(materializedRows).toBeLessThanOrEqual(3);
+        }
+      } finally {
+        read.mockRestore();
+      }
+    });
+  });
+
   it("keeps caller-bound provider enumeration separate while sharing the same caller's work", async () => {
     await withCatalog(async ({ call, owner, foreignOwner, host, list }) => {
       const release = createDeferredCore();

--- a/src/gateway/server-methods/session-catalog-selection.test.ts
+++ b/src/gateway/server-methods/session-catalog-selection.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import { resetConfigRuntimeState, setRuntimeConfigSnapshot } from "../../config/config.js";
+import { writeSessionEntry } from "../../config/sessions/session-accessor.sqlite-entry-store.js";
+import {
+  closeOpenClawAgentDatabasesForTest,
+  runOpenClawAgentWriteTransaction,
+} from "../../state/openclaw-agent-db.js";
+import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
+import { createSessionCatalogRequestEntrySnapshot } from "./session-catalog-entry-snapshot.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+afterEach(() => {
+  resetConfigRuntimeState();
+  closeOpenClawAgentDatabasesForTest();
+  closeOpenClawStateDatabaseForTest();
+  vi.unstubAllEnvs();
+});
+
+it("selects delivery aliases across agents without narrowing provider planning", () => {
+  vi.stubEnv("OPENCLAW_STATE_DIR", tempDirs.make("catalog-delivery-selection-"));
+  const cfg = { agents: { ownership: "explicit" as const, entries: { main: {}, work: {} } } };
+  setRuntimeConfigSnapshot(cfg, cfg);
+  for (const agentId of ["main", "work"]) {
+    runOpenClawAgentWriteTransaction(
+      (database) => {
+        for (const name of ["main", "unused"]) {
+          writeSessionEntry(database, `agent:${agentId}:${name}`, {
+            sessionId: `${agentId}-${name}`,
+            updatedAt: 1,
+          });
+        }
+        if (agentId === "main") {
+          writeSessionEntry(database, "global", { sessionId: "main-global", updatedAt: 1 });
+        }
+      },
+      { agentId },
+    );
+  }
+  const hosts = [["main", "global"], ["agent:work:main"]].map((sessionKeys, index) => ({
+    hostId: `gateway:${index}`,
+    label: `Host ${index}`,
+    kind: "gateway" as const,
+    connected: true,
+    sessions: sessionKeys.map((sessionKey) => ({
+      sessionKey,
+      threadId: `thread-${sessionKey}`,
+      status: "stored" as const,
+      archived: false,
+      canContinue: true,
+      canArchive: false,
+    })),
+  }));
+  const planning = createSessionCatalogRequestEntrySnapshot({ cfg, fallbackAgentId: "main" });
+  planning.freeze();
+  expect(planning.sessionEntries.entriesForCatalog?.()).toHaveLength(5);
+  const instances = new Map();
+  for (const host of hosts) {
+    planning.captureHostInstances(host, instances);
+  }
+  const delivery = createSessionCatalogRequestEntrySnapshot({
+    cfg,
+    fallbackAgentId: "main",
+    sessionKeys: hosts.flatMap((host) => host.sessions.map((session) => session.sessionKey)),
+  });
+  expect(hosts.map((host) => delivery.projectHostSessions(host, instances))).toEqual(hosts);
+  expect(
+    delivery.sessionEntries.entriesForAgent("main").map(({ sessionKey }) => sessionKey),
+  ).toEqual(["agent:main:main", "global"]);
+  expect(
+    delivery.sessionEntries.entriesForAgent("work").map(({ sessionKey }) => sessionKey),
+  ).toEqual(["agent:work:main"]);
+});

--- a/src/gateway/server-methods/session-catalog.ts
+++ b/src/gateway/server-methods/session-catalog.ts
@@ -378,11 +378,10 @@ export const sessionCatalogHandlers: GatewayRequestHandlers = {
       const requestEntries = createSessionCatalogRequestEntrySnapshot({
         cfg: currentConfig,
         fallbackAgentId: resolvedAgent.agentId,
-        sessionKeys: result.catalogs.flatMap((catalog) =>
-          catalog.hosts.flatMap((host) =>
-            host.sessions.flatMap((session) => (session.sessionKey ? [session.sessionKey] : [])),
-          ),
-        ),
+        sessionKeys: result.catalogs
+          .flatMap((catalog) => catalog.hosts)
+          .flatMap((host) => host.sessions)
+          .flatMap(({ sessionKey }) => (sessionKey ? [sessionKey] : [])),
       });
       return {
         catalogs: result.catalogs.map((catalog) => ({

--- a/src/gateway/server-methods/session-catalog.ts
+++ b/src/gateway/server-methods/session-catalog.ts
@@ -303,7 +303,7 @@ function catalogResult(
   error?: SessionCatalog["error"],
   createSession?: NonNullable<SessionCatalog["capabilities"]["createSession"]>,
 ): SessionCatalog {
-  const result: SessionCatalog = {
+  return {
     id: provider.id,
     label: provider.label,
     capabilities: {
@@ -315,11 +315,8 @@ function catalogResult(
     },
     ...(shareRoute ? { shareRoute } : {}),
     hosts,
+    ...(error ? { error } : {}),
   };
-  if (error) {
-    result.error = error;
-  }
-  return result;
 }
 
 export const sessionCatalogHandlers: GatewayRequestHandlers = {
@@ -381,6 +378,11 @@ export const sessionCatalogHandlers: GatewayRequestHandlers = {
       const requestEntries = createSessionCatalogRequestEntrySnapshot({
         cfg: currentConfig,
         fallbackAgentId: resolvedAgent.agentId,
+        sessionKeys: result.catalogs.flatMap((catalog) =>
+          catalog.hosts.flatMap((host) =>
+            host.sessions.flatMap((session) => (session.sessionKey ? [session.sessionKey] : [])),
+          ),
+        ),
       });
       return {
         catalogs: result.catalogs.map((catalog) => ({


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where refreshing session catalogs creates unnecessary temporary objects on large Gateways, especially when several catalog views receive progress and final updates.

## Why This Change Was Made

Catalog delivery now selects metadata for the raw and canonical session keys referenced by its host rows. The existing listing owner still validates every cached row before applying that selection, including unrelated noncanonical rows, while allocating result wrappers only for selected keys.

Provider planning still receives its full frozen snapshot. Each progress and final delivery retains fresh caller policy, metadata, actor projection, and adoption-identity checks. Existing exact-row reads, cache ownership, persistence, and wire responses are unchanged; the existing read-only listing API gains only an optional selection field.

## User Impact

Large catalogs spend less work constructing temporary delivery indexes while preserving which sessions each caller can see.

## Evidence

- A permanent registered-handler regression uses real SQLite state. The provider still receives all 27 planning rows, while progress and final delivery each stay within a three-row metadata budget. It checks actor attribution and detaches a replaced session before the final response. Restoring the original handler exceeds the budget with 27 rows.
- Focused tests cover selected ordering and deduplication, hidden internal effects, empty selection, unrelated canonical-key errors, cross-agent aliases, progress lifetime, current privacy, and replacement identity.
- A synthetic real-handler run uses two agents, 3,000 sessions, a 50-row host page, and up to 32 concurrent clients. Both versions completed 493 requests with matching progress/final counts, full provider planning, and a replacement committed during progress correctly reflected in the final response.
- Whole-handler timing gains were modest in the initial paired run and varied under concurrent host load. The final candidate repeated all 493 requests successfully. No live latency, retained-heap, or OOM-resolution claim is made; the primary evidence is the deterministic reduction in delivered-row materialization.

All 69 focused tests pass on the final diff, including the refined regression and its failing original-handler counterfactual. Independent P2 review is clean. The complete changed-file gate passes. Hosted CI must qualify the published head before landing.
