### PR TITLE
refactor: share Memory Wiki imported-page test fixture

### DIFF
--- a/extensions/memory-wiki/src/source-page-shared.test.ts
+++ b/extensions/memory-wiki/src/source-page-shared.test.ts
@@ -3,8 +3,8 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { renderMarkdownFence, renderWikiMarkdown } from "./markdown.js";
 import { writeImportedSourcePage } from "./source-page-shared.js";
+import { buildSourcePage } from "./source-page.test-helpers.js";
 
 const { fsRootMock } = vi.hoisted(() => ({ fsRootMock: vi.fn() }));
 
@@ -18,30 +18,6 @@ vi.mock("openclaw/plugin-sdk/security-runtime", async (importOriginal) => {
     },
   };
 });
-
-function buildSourcePage(raw: string, updatedAt: string): string {
-  return renderWikiMarkdown({
-    frontmatter: {
-      pageType: "source",
-      id: "source.imported",
-      title: "imported",
-      sourceType: "memory-unsafe-local",
-      status: "active",
-      updatedAt,
-    },
-    body: [
-      "# imported",
-      "",
-      "## Content",
-      renderMarkdownFence(raw, "text"),
-      "",
-      "## Notes",
-      "<!-- openclaw:human:start -->",
-      "<!-- openclaw:human:end -->",
-      "",
-    ].join("\n"),
-  });
-}
 
 describe("writeImportedSourcePage", () => {
   let suiteRoot: string;

--- a/extensions/memory-wiki/src/source-page.test-helpers.ts
+++ b/extensions/memory-wiki/src/source-page.test-helpers.ts
@@ -1,0 +1,25 @@
+import { renderMarkdownFence, renderWikiMarkdown } from "./markdown.js";
+
+export function buildSourcePage(raw: string, updatedAt: string): string {
+  return renderWikiMarkdown({
+    frontmatter: {
+      pageType: "source",
+      id: "source.imported",
+      title: "imported",
+      sourceType: "memory-unsafe-local",
+      status: "active",
+      updatedAt,
+    },
+    body: [
+      "# imported",
+      "",
+      "## Content",
+      renderMarkdownFence(raw, "text"),
+      "",
+      "## Notes",
+      "<!-- openclaw:human:start -->",
+      "<!-- openclaw:human:end -->",
+      "",
+    ].join("\n"),
+  });
+}

--- a/extensions/memory-wiki/src/wiki-notes-read-retry.test.ts
+++ b/extensions/memory-wiki/src/wiki-notes-read-retry.test.ts
@@ -7,8 +7,8 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { applyMemoryWikiMutation } from "./apply.js";
 import { importChatGptConversations } from "./chatgpt-import.js";
 import { ingestMemoryWikiSource } from "./ingest.js";
-import { renderMarkdownFence, renderWikiMarkdown } from "./markdown.js";
 import { writeImportedSourcePage } from "./source-page-shared.js";
+import { buildSourcePage } from "./source-page.test-helpers.js";
 import { createMemoryWikiTestHarness } from "./test-helpers.js";
 
 const securityRuntimeMock = vi.hoisted(() => ({
@@ -51,30 +51,6 @@ vi.mock("openclaw/plugin-sdk/security-runtime", async (importOriginal) => {
 });
 
 const { createTempDir, createVault } = createMemoryWikiTestHarness();
-
-function buildSourcePage(raw: string, updatedAt: string): string {
-  return renderWikiMarkdown({
-    frontmatter: {
-      pageType: "source",
-      id: "source.imported",
-      title: "imported",
-      sourceType: "memory-unsafe-local",
-      status: "active",
-      updatedAt,
-    },
-    body: [
-      "# imported",
-      "",
-      "## Content",
-      renderMarkdownFence(raw, "text"),
-      "",
-      "## Notes",
-      "<!-- openclaw:human:start -->",
-      "<!-- openclaw:human:end -->",
-      "",
-    ].join("\n"),
-  });
-}
 
 async function createChatGptImportFixture(prefix: string) {
   const { rootDir, config } = await createVault({ prefix });


### PR DESCRIPTION
## What Problem This Solves

Two Memory Wiki regression suites duplicate the same imported-source page fixture. Maintaining separate copies adds unnecessary work around the same human-notes preservation behavior.

## Why This Change Was Made

Move the unchanged renderer into a narrow sibling test-support module. It keeps the same raw content, caller-supplied timestamp, Markdown rendering, and fresh argument objects. All case bodies, filesystem paths, state, clocks, mocks, and cleanup remain unchanged.

## User Impact

No user-visible or production behavior changes. Removes 23 net test/support lines without removing tests.

## Evidence

- Complete owner suites pass before and after: 19 tests on the same Node 24.19.0 binary. Native names, ancestors, order, and status match.
- Markdown sibling cohort: 51 passing tests, including the same 19 owner cases.
- Git-bound whole-source inverses reconstruct both original suites exactly; the new helper matches the original declarations.
- Renderer controls agree across both original implementations and the shared helper for eight input pairs, covering empty input, CRLF, long backtick fences, embedded human markers, whitespace, Unicode, dollar sequences, and literal timestamps. Output bytes, renderer calls, and fresh arguments match.
- Mapped extension-test checks pass, including types, lint, formatting, and static guards.
- Formatting and diff-scoped cleanup pass; fresh P2 review found no actionable findings.

No overall test-runtime improvement is claimed for this fixture extraction.
