### PR TITLE
fix(daemon): install the Gateway on systemd 239 with legacy busctl output

### DIFF
--- a/src/daemon/systemd-busctl-legacy.test.ts
+++ b/src/daemon/systemd-busctl-legacy.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import { decodeLegacyBusctlOutput } from "./systemd-busctl-legacy.js";
+
+describe("decodeLegacyBusctlOutput", () => {
+  it.each([
+    ['s ":1.42"\n', "s", ":1.42"],
+    ['o "/"', "o", "/"],
+    ["u 4294967295", "u", 4294967295],
+    ["a(sb) 0", "a(sb)", []],
+  ])("wraps method reply %s", (stdout, signature, value) => {
+    expect(decodeLegacyBusctlOutput(stdout, [signature], true)).toEqual([[value]]);
+  });
+
+  it("decodes multiple flattened executions, empty arguments, and numeric boundaries", () => {
+    const stdout =
+      'a(sasbttttuii) 2 "/x" 2 "a b" "" false 0 1 2 3 4294967295 -2147483648 2147483647 "/y" 0 true 0 0 0 18446744073709551615 0 0 -1';
+    expect(decodeLegacyBusctlOutput(stdout, ["a(sasbttttuii)"], false)).toEqual([
+      [
+        ["/x", ["a b", ""], false, 0, 1, 2, 3, 4294967295, -2147483648, 2147483647],
+        ["/y", [], true, 0, 0, 0, Number(18446744073709551615n), 0, 0, -1],
+      ],
+    ]);
+  });
+
+  it("decodes v239 C escapes as bytes before UTF-8, preserving BOM and literal escapes", () => {
+    const output = String.raw`s "\357\273\277caf\303\251 \360\237\220\231 \a\b\f\n\r\t\v\'\"\\n"`;
+    expect(decodeLegacyBusctlOutput(output, ["s"], false)).toEqual([
+      "\uFEFFcafé 🐙 \x07\b\f\n\r\t\v'\"\\n",
+    ]);
+  });
+
+  it.each([
+    ["", ["s"]],
+    ['s "x"', []],
+    ['s "x"', ["o"]],
+    ['s "x"\ns "y"', ["s"]],
+    ['s "x"\n\n', ["s"]],
+    ['s "x"', ["s", "s"]],
+    ['s "x" extra', ["s"]],
+    ['s "x" ', ["s"]],
+    ['s "x""y"', ["s"]],
+    ['s "unterminated', ["s"]],
+    ["s unquoted", ["s"]],
+    ['s  "x"', ["s"]],
+    ['s "literal\nnewline"', ["s"]],
+    ['s "literalé"', ["s"]],
+    [String.raw`s "\000"`, ["s"]],
+    [String.raw`s "\400"`, ["s"]],
+    [String.raw`s "\12"`, ["s"]],
+    [String.raw`s "\x41"`, ["s"]],
+    [String.raw`s "\u0041"`, ["s"]],
+    [String.raw`s "\q"`, ["s"]],
+    [String.raw`s "\377"`, ["s"]],
+    [String.raw`s "\303"`, ["s"]],
+    [String.raw`s "\300\200"`, ["s"]],
+    [String.raw`s "\355\240\200"`, ["s"]],
+    ['o "relative"', ["o"]],
+    ['o "/bad-path"', ["o"]],
+    ['o "/trailing/"', ["o"]],
+    ["b 1", ["b"]],
+    ["b True", ["b"]],
+    ["u -1", ["u"]],
+    ["u 4294967296", ["u"]],
+    ["u 1e3", ["u"]],
+    ["u 01", ["u"]],
+    ["a{ss} 0", ["a{ss}"]],
+    ["as 16384", ["as"]],
+    ['as 2 "only one"', ["as"]],
+    ['as 0 "extra"', ["as"]],
+    ['a(sb) 1 "/x"', ["a(sb)"]],
+    ['a(sb) 1 "/x" 0', ["a(sb)"]],
+    ['a(sasbttttuii) 1 "/x" 0 false 0 0 0 18446744073709551616 0 0 0', ["a(sasbttttuii)"]],
+    ['a(sasbttttuii) 1 "/x" 0 false 0 0 0 -1 0 0 0', ["a(sasbttttuii)"]],
+    ['a(sasbttttuii) 1 "/x" 0 false 0 0 0 0 0 -2147483649 0', ["a(sasbttttuii)"]],
+    ['a(sasbttttuii) 1 "/x" 0 false 0 0 0 0 0 0 2147483648', ["a(sasbttttuii)"]],
+  ])("rejects malformed or unsupported output %s", (stdout, signatures) => {
+    expect(() =>
+      decodeLegacyBusctlOutput(stdout as string, signatures as string[], false),
+    ).toThrow();
+  });
+
+  it("bounds total values across lines and nested containers", () => {
+    const array = `as 16383${' ""'.repeat(16383)}`;
+    expect((decodeLegacyBusctlOutput(array, ["as"], false)[0] as string[]).length).toBe(16383);
+    expect(() => decodeLegacyBusctlOutput(`${array}\ns ""`, ["as", "s"], false)).toThrow();
+    expect(() =>
+      decodeLegacyBusctlOutput(`a(sb) 6000${' "" false'.repeat(6000)}`, ["a(sb)"], false),
+    ).toThrow();
+  });
+
+  it("bounds output bytes before decoding", () => {
+    const limit = 1024 * 1024;
+    expect(decodeLegacyBusctlOutput(`s "${"x".repeat(limit - 4)}"`, ["s"], false)).toHaveLength(1);
+    expect(() => decodeLegacyBusctlOutput(`s "${"x".repeat(limit - 3)}"`, ["s"], false)).toThrow();
+  });
+});

--- a/src/daemon/systemd-busctl-legacy.ts
+++ b/src/daemon/systemd-busctl-legacy.ts
@@ -1,0 +1,159 @@
+// systemd 239's format_cmdline counts arrays and flattens structs. This adapter
+// only accepts the effective-command reader's signatures, not arbitrary D-Bus.
+const MAX_BYTES = 1024 * 1024;
+const MAX_VALUES = 16_384;
+const SIGNATURES = new Set(["s", "o", "u", "b", "as", "a(sb)", "a(sasbttttuii)"]);
+const ESCAPES: Record<string, number> = {
+  a: 7,
+  b: 8,
+  f: 12,
+  n: 10,
+  r: 13,
+  t: 9,
+  v: 11,
+  "\\": 92,
+  '"': 34,
+  "'": 39,
+};
+
+function invalid(): never {
+  throw new Error("Invalid legacy busctl output");
+}
+
+export function decodeLegacyBusctlOutput(
+  stdout: string,
+  signatures: string[],
+  methodReply: boolean,
+): unknown[] {
+  if (
+    Buffer.byteLength(stdout) > MAX_BYTES ||
+    signatures.length === 0 ||
+    signatures.length > MAX_VALUES
+  ) {
+    return invalid();
+  }
+  const lines = stdout.replace(/\r?\n$/, "").split(/\r?\n/);
+  if (lines.length !== signatures.length) {
+    return invalid();
+  }
+  let remaining = MAX_VALUES;
+  const consume = () => {
+    if (--remaining < 0) {
+      invalid();
+    }
+  };
+  return lines.map((line, index) => {
+    const signature = signatures[index];
+    if (!signature || !SIGNATURES.has(signature) || !line.startsWith(`${signature} `)) {
+      return invalid();
+    }
+    let offset = signature.length;
+    const token = (quoted: boolean): string => {
+      if (line[offset++] !== " ") {
+        return invalid();
+      }
+      if (!quoted) {
+        const start = offset;
+        while (offset < line.length && line[offset] !== " ") {
+          offset++;
+        }
+        return line.slice(start, offset);
+      }
+      if (line[offset++] !== '"') {
+        return invalid();
+      }
+      const bytes: number[] = [];
+      while (offset < line.length) {
+        const char = line.charAt(offset++);
+        if (char === '"') {
+          if (bytes.includes(0)) {
+            return invalid();
+          }
+          // Octal escapes encode UTF-8 bytes, not individual Unicode characters.
+          // Preserve a leading BOM just as the native reader/JSON do.
+          return new TextDecoder("utf-8", { fatal: true, ignoreBOM: true }).decode(
+            Uint8Array.from(bytes),
+          );
+        }
+        if (char === "\\") {
+          const escape = line[offset++];
+          if (escape === undefined) {
+            return invalid();
+          }
+          const escapedByte = Object.hasOwn(ESCAPES, escape) ? ESCAPES[escape] : undefined;
+          if (escapedByte !== undefined) {
+            bytes.push(escapedByte);
+          } else {
+            const octal = line.slice(offset - 1, offset + 2);
+            if (!/^[0-3][0-7]{2}$/.test(octal)) {
+              return invalid();
+            }
+            bytes.push(Number.parseInt(octal, 8));
+            offset += 2;
+          }
+        } else {
+          const byte = char.charCodeAt(0);
+          // cescape emits every non-ASCII/control byte as an escape.
+          if (byte < 32 || byte >= 127) {
+            return invalid();
+          }
+          bytes.push(byte);
+        }
+      }
+      return invalid();
+    };
+    const integer = (type: string): number => {
+      const raw = token(false);
+      if (!/^(?:0|[1-9][0-9]*|-[1-9][0-9]*)$/.test(raw) || raw.length > 20) {
+        return invalid();
+      }
+      const value = BigInt(raw);
+      const min = type === "i" ? -2147483648n : 0n;
+      const max = type === "i" ? 2147483647n : type === "t" ? 18446744073709551615n : 4294967295n;
+      if (value < min || value > max) {
+        return invalid();
+      }
+      // Match the numeric representation of the JSON and native readers.
+      return Number(value);
+    };
+    const read = (type: string): unknown => {
+      consume();
+      if (type.startsWith("a")) {
+        const count = integer("u");
+        if (count > remaining) {
+          return invalid();
+        }
+        return Array.from({ length: count }, () => read(type.slice(1)));
+      }
+      if (type === "(sb)") {
+        return [read("s"), read("b")];
+      }
+      if (type === "(sasbttttuii)") {
+        return ["s", "as", "b", "t", "t", "t", "t", "u", "i", "i"].map(read);
+      }
+      if (type === "s" || type === "o") {
+        const value = token(true);
+        if (type === "o" && !/^(?:\/|(?:\/[A-Za-z0-9_]+)+)$/.test(value)) {
+          return invalid();
+        }
+        return value;
+      }
+      if (type === "b") {
+        const value = token(false);
+        if (value !== "true" && value !== "false") {
+          return invalid();
+        }
+        return value === "true";
+      }
+      if (type === "u" || type === "i" || type === "t") {
+        return integer(type);
+      }
+      return invalid();
+    };
+    const value = read(signature);
+    if (offset !== line.length) {
+      return invalid();
+    }
+    return methodReply ? [value] : value;
+  });
+}

--- a/src/daemon/systemd-command-query.test.ts
+++ b/src/daemon/systemd-command-query.test.ts
@@ -1,0 +1,199 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+
+const busctl = vi.hoisted(() => vi.fn());
+vi.mock("./systemd-exec.js", async (original) => ({
+  ...(await original<typeof import("./systemd-exec.js")>()),
+  execBusctlUser: busctl,
+  bindSystemdManagerOwner: vi.fn(),
+  systemdInspectionError: (_result: unknown, message: string) => new Error(message),
+}));
+
+import { createSystemdCommandQuery } from "./systemd-command-query.js";
+import { readSystemdServiceExecStart } from "./systemd-service-files.js";
+
+const queryEnv = { XDG_RUNTIME_DIR: "/run/user/1234" };
+const unitName = "openclaw-gateway.service";
+const callArgs = ["call", "org.test", "/unitName", "org.test.Manager", "LoadUnit", "s", unitName];
+const unavailable = () => new Error("inspection unavailable");
+const reader = (options?: Parameters<typeof createSystemdCommandQuery>[2]) =>
+  createSystemdCommandQuery(queryEnv, unitName, options, unavailable);
+const query = async (options?: Parameters<typeof createSystemdCommandQuery>[2]) =>
+  (await reader(options)).query(callArgs, ["o"]);
+const success = (stdout: string) => ({ code: 0, termination: "exit" as const, stdout, stderr: "" });
+const failure = (stderr: string) => ({ ...success(""), code: 1, stderr });
+const unsupported = failure("busctl: unrecognized option '--json=short'");
+
+beforeEach(() => {
+  busctl.mockReset();
+});
+afterEach(() => vi.restoreAllMocks());
+
+describe("systemd command query legacy compatibility", () => {
+  it("retains legacy mode only for this reader", async () => {
+    busctl.mockResolvedValueOnce(unsupported).mockResolvedValue(success('o "/unitName"'));
+    const legacy = await reader();
+    await expect(legacy.query(callArgs, ["o"])).resolves.toEqual([["/unitName"]]);
+    await legacy.query(callArgs, ["o"]);
+    expect(busctl.mock.calls[0]?.slice(0, 2)).toEqual([queryEnv, ["--json=short", ...callArgs]]);
+    expect(busctl.mock.calls[1]?.slice(0, 2)).toEqual([queryEnv, callArgs]);
+    expect(busctl.mock.calls[2]?.[1]).not.toContain("--json=short");
+    busctl.mockResolvedValueOnce(success('{"type":"o","data":["/unitName"]}'));
+    await query();
+    expect(busctl.mock.calls[3]?.[1]).toContain("--json=short");
+  });
+
+  it.each([
+    [false, { ...unsupported, stderr: "Call failed: Access denied" }],
+    [false, { ...unsupported, termination: "timeout" }],
+    [false, { ...unsupported, stdout: "unexpected output" }],
+    [false, { ...unsupported, stderr: "busctl: unrecognized option '--auto-start=no'" }],
+    [false, { ...unsupported, stderr: "prefix: busctl: unrecognized option '--json=short'" }],
+    [false, success("malformed successful reply")],
+    [true, { ...success('o "/unitName"'), code: 1, stderr: "Call failed: Access denied" }],
+    [true, { ...success('o "/unitName"'), termination: "timeout" }],
+  ])("rejects failure (legacy=%s): %j", async (legacy, result) => {
+    if (legacy) {
+      busctl.mockResolvedValueOnce(unsupported);
+    }
+    busctl.mockResolvedValue(result);
+    await expect(query()).rejects.toThrow();
+    expect(busctl).toHaveBeenCalledTimes(legacy ? 2 : 1);
+  });
+
+  it.each([
+    { first: 200, retry: 0, budgets: [1000, 800], ok: true },
+    { first: 1000, retry: 0, budgets: [1000], ok: false },
+    { first: 0, retry: 1000, budgets: [1000, 1000], ok: false },
+  ])("shares the original call deadline: %j", async ({ first, retry, budgets, ok }) => {
+    let now = 1000;
+    vi.spyOn(performance, "now").mockImplementation(() => now);
+    busctl
+      .mockImplementationOnce(async () => {
+        now += first;
+        return unsupported;
+      })
+      .mockImplementationOnce(async () => {
+        now += retry;
+        return success('o "/unitName"');
+      });
+    const result = query({ timeoutMs: 3000 });
+    if (ok) {
+      await expect(result).resolves.toEqual([["/unitName"]]);
+    } else {
+      await expect(result).rejects.toThrow();
+    }
+    expect(busctl.mock.calls.map((call) => call[2])).toEqual(budgets);
+  });
+
+  it("preserves non-activating reads and rejects revoked inspection before retry", async () => {
+    let current = true;
+    const assertCurrent = vi.fn(() => {
+      if (!current) {
+        throw unavailable();
+      }
+    });
+    const options = { requireLoaded: true, loadForInspection: { managerUid: 1234, assertCurrent } };
+    const inspected = await reader(options);
+    busctl.mockImplementationOnce(async () => {
+      current = false;
+      return unsupported;
+    });
+    await expect(inspected.query(callArgs, ["o"])).rejects.toThrow();
+    expect(busctl).toHaveBeenCalledTimes(1);
+    expect(busctl.mock.calls[0]?.[1]).toEqual(["--json=short", "--auto-start=no", ...callArgs]);
+    expect(busctl.mock.calls[0]?.[3]).toBe(assertCurrent);
+  });
+});
+
+describe("effective service inspection through legacy busctl", () => {
+  const dirs = useAutoCleanupTempDirTracker(afterEach);
+  let env: Record<string, string>;
+  let unit: string;
+  let dropIn: string;
+  let requiredFile: string;
+  let pendingReload: boolean;
+  let malformed: boolean;
+  const inspect = () => readSystemdServiceExecStart(env, { requireEffective: true });
+
+  beforeEach(async () => {
+    const home = await fs.realpath(dirs.make("openclaw-systemd-legacy-"));
+    env = { HOME: home, OPENCLAW_SYSTEMD_UNIT: "openclaw-legacy" };
+    unit = path.join(home, ".config/systemd/user/openclaw-legacy.service");
+    dropIn = `${unit}.d/override.conf`;
+    requiredFile = path.join(home, "required.env");
+    await fs.mkdir(path.dirname(dropIn), { recursive: true });
+    await fs.writeFile(unit, "[Service]\nExecStart=/local/file gateway\n");
+    await fs.writeFile(dropIn, "[Service]\nEnvironment=KEEP=override\n");
+    await fs.writeFile(requiredFile, "A=file\nREMOVE=yes\nKEEP=file\n");
+    pendingReload = false;
+    malformed = false;
+    busctl.mockImplementation(async (_env, args: string[]) => {
+      if (args.includes("--json=short")) {
+        return unsupported;
+      }
+      if (args.includes("LoadUnit")) {
+        return success('o "/org/freedesktop/systemd1/unit/openclaw_2dlegacy_2eservice"\n');
+      }
+      if (args.includes("org.freedesktop.systemd1.Unit")) {
+        return success(
+          `s ${JSON.stringify(unit)}\nas 1 ${JSON.stringify(dropIn)}\nb ${pendingReload}\ns "loaded"\n`,
+        );
+      }
+      return success(
+        malformed
+          ? 'a(sasbttttuii) 1 "broken"'
+          : [
+              String.raw`a(sasbttttuii) 1 "/usr/bin/node" 4 "/usr/bin/node" "gateway" "caf\303\251" "quoted \"value\" \\ path" false 0 0 0 0 0 0 0`,
+              `s ${JSON.stringify(env.HOME)}`,
+              'as 2 "A=inline" "REMOVE=yes"',
+              `a(sb) 2 ${JSON.stringify(requiredFile)} false ${JSON.stringify(path.join(env.HOME!, "optional.env"))} true`,
+              'as 1 "REMOVE"',
+            ].join("\n"),
+      );
+    });
+  });
+
+  it.each([false, true])(
+    "retains manager data and selected drop-ins with reloadPending=%s",
+    async (reload) => {
+      pendingReload = reload;
+      const actual = await inspect();
+      expect(actual).toMatchObject({
+        programArguments: ["/usr/bin/node", "gateway", "café", 'quoted "value" \\ path'],
+        workingDirectory: env.HOME,
+        environment: { A: "file", KEEP: "file" },
+        sourcePath: unit,
+        definitionPaths: [unit, dropIn],
+      });
+      expect(actual?.environment).not.toHaveProperty("REMOVE");
+      expect(actual?.reloadPending).toBe(reload || undefined);
+      expect(busctl).toHaveBeenCalledTimes(4);
+    },
+  );
+
+  it.each(["missing required file", "malformed reply"])(
+    "rejects %s despite a readable local unit",
+    async (reason) => {
+      malformed = reason === "malformed reply";
+      if (!malformed) {
+        await fs.unlink(requiredFile);
+      }
+      await expect(inspect()).rejects.toThrow();
+    },
+  );
+
+  it("accepts exact absence for a fresh installation without manufacturing a command", async () => {
+    await fs.unlink(unit);
+    busctl.mockImplementation(async (_env, args: string[]) =>
+      failure(
+        args.includes("--json=short")
+          ? unsupported.stderr
+          : "Call failed: Unit openclaw-legacy.service not found.",
+      ),
+    );
+    await expect(inspect()).resolves.toBeNull();
+  });
+});

--- a/src/daemon/systemd-command-query.ts
+++ b/src/daemon/systemd-command-query.ts
@@ -1,6 +1,7 @@
 /** Deadline- and custody-bound effective command queries for the systemd reader. */
 import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
 import type { GatewayServiceEnv, GatewayServiceReadOptions } from "./service-types.js";
+import { decodeLegacyBusctlOutput } from "./systemd-busctl-legacy.js";
 import { bindSystemdManagerOwner, execBusctlUser, systemdInspectionError } from "./systemd-exec.js";
 
 export async function createSystemdCommandQuery(
@@ -23,6 +24,7 @@ export async function createSystemdCommandQuery(
     throw unavailable();
   }
   let remainingCalls = inspection ? 6 : 3;
+  let legacyOutput = false;
   // All manager D-Bus calls share one deadline so wedged reads reach local fallback promptly.
   const query = async (args: string[], signatures: string[]): Promise<unknown[] | null> => {
     const assertCurrent =
@@ -40,13 +42,47 @@ export async function createSystemdCommandQuery(
       }
       return values;
     }
-    const result = await execBusctlUser(
+    const callTimeout = Math.max(
+      1,
+      Math.floor((deadlineAt - performance.now()) / remainingCalls--),
+    );
+    const callDeadline = Math.min(deadlineAt, performance.now() + callTimeout);
+    let result = await execBusctlUser(
       env,
-      ["--json=short", ...(opts?.requireLoaded ? ["--auto-start=no"] : []), ...args],
-      Math.max(1, Math.floor((deadlineAt - performance.now()) / remainingCalls--)),
+      [
+        ...(legacyOutput ? [] : ["--json=short"]),
+        ...(opts?.requireLoaded ? ["--auto-start=no"] : []),
+        ...args,
+      ],
+      callTimeout,
       assertCurrent,
     );
     assertCurrent?.();
+    if (
+      !legacyOutput &&
+      result.termination === "exit" &&
+      result.code === 1 &&
+      result.stdout === "" &&
+      result.stderr.trim() === "busctl: unrecognized option '--json=short'"
+    ) {
+      // Option parsing failed before a manager call. Reuse this call's remaining
+      // budget; neither the retry nor later legacy calls earn a new deadline.
+      const remaining = Math.floor(callDeadline - performance.now());
+      if (remaining <= 0) {
+        throw unavailable();
+      }
+      legacyOutput = true;
+      result = await execBusctlUser(
+        env,
+        [...(opts?.requireLoaded ? ["--auto-start=no"] : []), ...args],
+        remaining,
+        assertCurrent,
+      );
+      assertCurrent?.();
+    }
+    if (legacyOutput && (result.termination !== "exit" || performance.now() >= callDeadline)) {
+      throw systemdInspectionError(result, unavailable().message);
+    }
     if (inspection && (result.termination !== "exit" || performance.now() >= deadlineAt)) {
       throw systemdInspectionError(result, unavailable().message);
     }
@@ -65,6 +101,9 @@ export async function createSystemdCommandQuery(
         return null;
       }
       throw systemdInspectionError(result, unavailable().message);
+    }
+    if (legacyOutput) {
+      return decodeLegacyBusctlOutput(result.stdout, signatures, args[0] === "call");
     }
     const properties = result.stdout
       .trim()


### PR DESCRIPTION
Closes #142940
Related: #144046 (diagnostic-only; does not restore installation)

## What Problem This Solves

Fixes an issue where users installing the Gateway on systemd 239 would receive `SERVICE_DEFINITION_UNKNOWN`, including with `--force`, despite having a working user manager.

## Why This Change Was Made

The existing manager-effective command reader now retries the exact unsupported `busctl --json=short` diagnostic using systemd 239's counted, typed text output. A finite decoder accepts only the reader's existing signatures, preserving C-escaped UTF-8 and tuple shapes; routing, inspection custody, original deadlines, and definition-mutation authority stay with the existing owners. Modern JSON queries remain the default, without a global capability cache.

This does not fall back to local unit files or reinterpret denied, timed-out, malformed, or unrelated failures. Separate updater/private-peer compatibility is not part of this installation repair.

## User Impact

Users on systemd 239 can install and reinstall the Gateway while retaining selected drop-ins, effective arguments, working directory, environment-file precedence, and unset-variable behavior. Unverifiable definitions still refuse installation. No config, dependency, schema, or default-route changes; rollback is reverting this commit.

## Evidence

- **Native before/after:** real Rocky Linux 8 systemd `239-82.el8_10.17`, PID1 and non-root user manager. Baseline ordinary/forced fresh installs failed with `SERVICE_DEFINITION_UNKNOWN`; candidate installs and ordinary/forced reinstalls succeeded with active services. [Environment, invocation, source/bundle identities, and all 46 native records](https://gist.github.com/PollyBot13/eeef7b5378172fb08381632102b9dce4).
- **Preservation/failure controls:** selected drop-ins and environment-file hashes retained across forced reinstall; quotes, backslashes, Unicode, reload state, required/optional files, precedence, and unset semantics checked. Missing required file and multiple ExecStart cases refused with unit unchanged afterward. A paused real manager failed within 2.457 seconds and recovered after resume.
- **Refreshed local regressions:** 243 tests across nine suites passed after rebasing onto upstream `9982550d`: command-query (including effective-reader integration), legacy decoder, user-command deadlines, clock-step deadlines, definition-loaded, definition-mutation, definition-mutation.creation, loaded-runtime, and unit tests. Ran installed Vitest with a local workspace-source export-alias configuration; no test or owner behavior was replaced by those aliases.
- **CI shard repair:** rebased onto upstream’s existing shard reduction; services now has 689 roots against the 700 guard. The previously failing exact-once partition test passes locally. A broader tooling-suite attempt hit its local 10-second timeout in the separate native-compiler fixture; no full tooling-suite pass is claimed.
- **Static checks/review:** four-file `oxlint`, `oxfmt --check`, `git diff --check`, and strict decoder/test `tsgo` passed. Fresh independent source/evidence review accepted the final four-file patch. Standalone `autoreview --mode local --max-priority P2` failed before a verdict because the local Codex models cache lacked `base_instructions`; that attempt is not counted as review coverage.
- **Scope and limitations:** native proof invokes actual `runDaemonInstall` and real systemctl publication/activation, with only the Gateway process replaced by a harmless interval. It does not prove packaged CLI parsing or real Gateway health. Native proof predates the base refresh. The PR patch is equivalent and the decoder is unchanged; the refreshed query also inherits upstream’s exact GetUnitFileState ENOENT absence handling, independently reviewed and covered by upstream regressions. No new native run is claimed. An optional modern-systemd fixture lacked a user D-Bus socket and produced no native success. Full build/check and the refreshed wider TypeScript graph are not claimed: the borrowed dependency install lacks some current workspace exports/dependencies, including `import-meta-resolve` for the broader `systemd.test.ts` suite. Hosted current-head checks remain the final integration gate.

Review scope: one compatibility repair, four files (+496/-3), no generalized D-Bus parser or unrelated cleanup. The decoder and command-query tests include the real effective-reader integration and failure boundaries. Please review compatibility equivalence at the service-inspection boundary; merge remains maintainer-owned.

## ClawSweeper review

Reviewed head `c4587d09b4e3cbf77030a2215db8eb9390e4a19b`: no actionable findings; no fixups or skips. The maintainer's independent review is scoped-clean at P1. The exact-head CI watcher reports green for [run 34710239518](https://github.com/openclaw/openclaw/actions/runs/34710239518). Implementation credit: @PollyBot13.
