### PR TITLE
fix(cron): keep legacy inspection responsive during schema checks

### DIFF
--- a/src/commands/doctor/cron/legacy-repair.ts
+++ b/src/commands/doctor/cron/legacy-repair.ts
@@ -60,6 +60,7 @@ import { mergeLegacyCronJobs, mergeRuntimeEntryIntoConfigJob } from "./repair-pl
 import { planCronCodexRefRewriteAgainstPersistedConfig } from "./runtime-policy-migration.js";
 import {
   assertCronStateSchemaSupported,
+  assertCronStateSchemaSupportedAsync,
   rethrowSqliteSchemaVersionError,
 } from "./schema-safety.js";
 import {
@@ -138,7 +139,7 @@ export async function loadLegacyCronRepairState(params: {
   const legacyStoreDetected = await legacyCronStoreFilesExist(storePath);
   const legacyRunLogDetected = await legacyCronRunLogFilesExist(storePath);
   const legacyQuarantine = await loadLegacyCronQuarantineForMigration(storePath);
-  assertCronStateSchemaSupported(params.env);
+  await assertCronStateSchemaSupportedAsync(params.env);
   if (
     params.onlyIfLegacyDetected &&
     !legacyStoreDetected &&

--- a/src/commands/doctor/cron/schema-safety.ts
+++ b/src/commands/doctor/cron/schema-safety.ts
@@ -1,8 +1,15 @@
 import { isSqliteSchemaVersionError } from "../../../infra/sqlite-user-version.js";
-import { withExistingOpenClawStateDatabaseArtifactPreservingReadOnly } from "../../../state/openclaw-state-db-readonly.js";
+import {
+  withExistingOpenClawStateDatabaseArtifactPreservingReadOnly,
+  withExistingOpenClawStateDatabaseArtifactPreservingReadOnlyAsync,
+} from "../../../state/openclaw-state-db-readonly.js";
 
 export function assertCronStateSchemaSupported(env?: NodeJS.ProcessEnv): void {
   withExistingOpenClawStateDatabaseArtifactPreservingReadOnly(() => undefined, { env });
+}
+
+export async function assertCronStateSchemaSupportedAsync(env?: NodeJS.ProcessEnv): Promise<void> {
+  await withExistingOpenClawStateDatabaseArtifactPreservingReadOnlyAsync(() => undefined, { env });
 }
 
 export function rethrowSqliteSchemaVersionError(error: unknown): void {


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

Doctor's legacy cron inspection can block unrelated callbacks while checking a cold shared-state database, even though the inspection itself is asynchronous.

## Why This Change Was Made

Await the existing artifact-preserving SQLite reader for the loader's schema check. Keep the synchronous repair-time check, source fingerprints, transaction guards and error propagation unchanged. The full schema owner still checks both the published version and the canonical content-version marker, including committed WAL content and databases with no legacy cron files.

## User Impact

Callbacks can run while the existing snapshot worker completes. This changes scheduling, not the amount of snapshot work, and does not establish faster Gateway startup or higher throughput. The two-file change adds eight production lines without introducing a storage owner, schema change, cache or public API.

## Evidence

Matching Oxfmt 0.66, git diff sanity, and fresh managed Codex P2 review passed at author base `c6739ac24924ff018e1ff892a69fbad5d47ab72e`. The three complete existing test files passed **41 tests**: schema-safety 8, legacy-repair 6 and state-reader 27, with no failures or pending cases. All **26 actual selected small guards** passed under unchanged native bounds; all 34 validation receipts closed and joined without problems. Both candidate files are byte-identical to the measured candidate. [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34699620816) also passed, covering broad core types, core test types and changed core type-aware lint through their hosted owners; those lanes did not run locally.

The requested **published-updater × candidate validation** passed in [Package Acceptance run 34701072684](https://github.com/openclaw/openclaw/actions/runs/34701072684): released `openclaw@2026.9.3` updated to the exact candidate `77b4752b0da7aacffc389434b8a24c00203df553`, with matching package-source/build metadata. All mandatory integrity, installer, Docker and acceptance gates passed in one attempt. The first-hop schema/migration checks and both default/ops cron owners survived, followed by a candidate agent turn and an already-current second update. The jobs were created by the released CLI; this proves released-format state survival, not forced legacy JSON or byte-for-byte equality.

Doctor exit zero is supported by the executed core-step assertions and inspected released updater source, which supplies the activated candidate Doctor callback and preserves its exit code. The upload does not retain the initial update JSON, inner summary or PID chain, so initial plain success versus validated recoverable acceptance, warnings and consent-repair execution remain unobservable. The later standalone Doctor check is not used as first-hop proof. This cell does not change the historical timing qualifications below.

**Update behavior:** the installed published updater retains its existing candidate-Doctor invocation. The asynchronous cron inspection changes only how the existing snapshot reader is awaited; repair-time schema and transaction guards remain intact.

The [isolated Linux/Node 24.19.0 pilot](https://github.com/openclaw/openclaw/actions/runs/34697290450) at `0e377815489d6a6187ac504689e23efe3657c174` exercised the actual `loadLegacyCronRepairState` entry point: six fixed cases in B1/C1/C2/B2 order, 24 fresh case processes and 72 calls, including 48 measured calls. Full results, required future-schema refusals, database-family bytes, snapshot counts and staging cleanup matched. The future-WAL control had a version-17 main header with committed content-version 18 in WAL, so a header-only check would not satisfy the exercised contract.

Across four cold cases and both orders, median maximum callback gaps fell from **400.84–440.29 ms to 5.81–7.81 ms**. Each cold call still used **one snapshot**. Instrumented parent CPU increased **46.72–145.94%**; callbacks from the real 5 ms sampler contribute to that cost, and no overhead was subtracted. Cold-WAL call time in B2/C2 increased **79.98%**, from **432.71 to 778.78 ms**. Warm and missing controls were mixed: warm call time increased 104.94% in one pair and fell 51.84% in the other. Whole-child wall/CPU/RSS observations also include adverse values and are distinct from call timing.

These are two-sample medians per case/phase, not a throughput distribution or a current-platform performance claim. The shared cache lifecycle has changed since the pilot; historical timing is not proof of that newer lifecycle. All 30 native receipts closed, and the exact lease and capsule were cleaned up.

The original R1 observer failure and interleaved-stream collection failure remain retained. R1 produced no candidate comparison. R2 corrected only the task observer before a separately admitted run; the production candidate, case matrix and resource limits were unchanged. No further benchmark run is claimed.
