### PR TITLE
fix(update): avoid activation timeouts on large agent databases

### DIFF
--- a/src/infra/update-candidate-state.schema-lifetime.test.ts
+++ b/src/infra/update-candidate-state.schema-lifetime.test.ts
@@ -1,0 +1,149 @@
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import * as commands from "../process/exec.js";
+import { openNodeSqliteDatabase } from "./node-sqlite.js";
+import { sqliteWorkerPreloadEnv } from "./sqlite-worker-preload.test-support.js";
+import { acquireStateDatabaseHandleExclusion } from "./state-database-coordinator.js";
+import { readUpdateStateSchemaVersions } from "./update-candidate-state.js";
+
+const dirs = useAutoCleanupTempDirTracker((cleanup) =>
+  afterEach(() => {
+    vi.restoreAllMocks();
+    cleanup();
+  }),
+);
+
+// Keep the fixture's writer open for native lock and failure probes.
+function fixture() {
+  const stateDir = fs.realpathSync(dirs.make("update-schema-lifetime-"));
+  const file = path.join(stateDir, "agents", "main", "agent", "openclaw-agent.sqlite");
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  const writer = openNodeSqliteDatabase(file);
+  writer.exec("PRAGMA user_version=3;");
+  return { stateDir, file, writer };
+}
+
+it("preserves the parent agent writer lock and excludes its uncommitted migration", async () => {
+  const { stateDir, file, writer } = fixture();
+  writer.exec("BEGIN IMMEDIATE; PRAGMA user_version=4;");
+  try {
+    const versions = await readUpdateStateSchemaVersions({ stateDir, config: {} });
+    expect(versions).toContainEqual({ path: file, userVersion: 3 });
+    const competitor = spawnSync(
+      process.execPath,
+      [
+        "--input-type=module",
+        "-e",
+        `
+        import { DatabaseSync } from 'node:sqlite';
+        const db = new DatabaseSync(process.argv[1]);
+        try {
+          db.exec('PRAGMA busy_timeout=0; BEGIN IMMEDIATE; ROLLBACK;');
+          process.exitCode = 2;
+        } catch(error) {
+          if (error.errcode !== 5) throw error;
+          process.stdout.write('writer refused');
+        } finally { db.close(); }
+      `,
+        file,
+      ],
+      { encoding: "utf8", timeout: 5000 },
+    );
+    expect(competitor.status, competitor.stderr).toBe(0);
+    expect(competitor.stdout).toBe("writer refused");
+    expect(writer.isTransaction).toBe(true);
+  } finally {
+    writer.exec("ROLLBACK;");
+    writer.close();
+  }
+});
+
+it.each(["timeout", "cancel", "read-failure", "close-failure"] as const)(
+  "settles the schema worker before releasing ownership after %s",
+  async (outcome) => {
+    const { stateDir, file, writer } = fixture();
+    const blocked = outcome === "timeout" || outcome === "cancel";
+    if (blocked) {
+      writer.exec("BEGIN EXCLUSIVE; PRAGMA user_version=4;");
+    }
+    const marker = path.join(stateDir, "native-read.json");
+    const cache = path.join(stateDir, "cache");
+    fs.mkdirSync(cache);
+    const sentinel = path.join(cache, "unrelated.txt");
+    fs.writeFileSync(sentinel, "preserved");
+    const preload = path.join(stateDir, "native-fault.cjs");
+    // Fault the real source connection inside the launched worker. A held
+    // exclusive writer exercises SQLite's blocking read, not a sleeping stand-in.
+    fs.writeFileSync(
+      preload,
+      `
+      const fs = require('node:fs'), path = require('node:path');
+      const { DatabaseSync } = require('node:sqlite');
+      const source = ${JSON.stringify(file)}, marker = ${JSON.stringify(marker)};
+      const outcome = ${JSON.stringify(outcome)};
+      const isSource = db => db.location() && path.toNamespacedPath(db.location()) === path.toNamespacedPath(source);
+      const prepare = DatabaseSync.prototype.prepare, close = DatabaseSync.prototype.close;
+      DatabaseSync.prototype.prepare = function(sql) {
+        if (isSource(this) && sql === 'PRAGMA user_version') {
+          fs.writeFileSync(marker, JSON.stringify({pid:process.pid}));
+          if (outcome === 'read-failure') throw new Error('native header read failed');
+        }
+        return prepare.call(this, sql);
+      };
+      DatabaseSync.prototype.close = function() {
+        if (isSource(this) && outcome === 'close-failure') throw new Error('native header close failed');
+        return close.call(this);
+      };
+    `,
+    );
+    const controller = new AbortController();
+    const run = commands.runCommandBuffered;
+    vi.spyOn(commands, "runCommandBuffered").mockImplementation((argv, options) => {
+      expect(options).toMatchObject({ timeoutMs: 30_000, killGraceMs: 500 });
+      return run(argv, {
+        ...options,
+        // Shorten only the test's wait; assert the real production budget above.
+        ...(outcome === "timeout" ? { timeoutMs: 2500 } : {}),
+        signal: controller.signal,
+      });
+    });
+    const operation = readUpdateStateSchemaVersions({
+      stateDir,
+      config: {},
+      env: { ...process.env, ...sqliteWorkerPreloadEnv(preload), XDG_CACHE_HOME: cache },
+    });
+    const failure =
+      outcome === "timeout"
+        ? /failed \(timeout\)/
+        : outcome === "cancel"
+          ? /failed \(signal\)/
+          : /native header (read|close) failed/;
+    const rejected = expect(operation).rejects.toThrow(failure);
+    try {
+      if (outcome === "cancel") {
+        await vi.waitFor(() => expect(fs.existsSync(marker)).toBe(true), { timeout: 10_000 });
+        controller.abort();
+      }
+      await rejected;
+      const { pid } = JSON.parse(fs.readFileSync(marker, "utf8")) as { pid: number };
+      expect(() => process.kill(pid, 0)).toThrow();
+      acquireStateDatabaseHandleExclusion({ databasePath: file, busyTimeoutMs: 0 }).release();
+      expect(fs.readdirSync(cache)).toEqual(["unrelated.txt"]);
+      expect(fs.readFileSync(sentinel, "utf8")).toBe("preserved");
+      expect(writer.prepare("PRAGMA user_version").get()).toEqual({
+        user_version: blocked ? 4 : 3,
+      });
+    } finally {
+      controller.abort();
+      await Promise.allSettled([operation, rejected]);
+      if (writer.isTransaction) {
+        writer.exec("ROLLBACK;");
+      }
+      writer.close();
+    }
+  },
+  15_000,
+);

--- a/src/infra/update-candidate-state.schema.test.ts
+++ b/src/infra/update-candidate-state.schema.test.ts
@@ -1,0 +1,211 @@
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { openNodeSqliteDatabase } from "./node-sqlite.js";
+import { sqliteWorkerPreloadEnv } from "./sqlite-worker-preload.test-support.js";
+import {
+  readUpdateStateSchemaVersions,
+  updateStateSchemaVersionsMatch,
+} from "./update-candidate-state.js";
+
+const dirs = useAutoCleanupTempDirTracker(afterEach);
+
+it.each(["malformed", "nonregular-wal"])(
+  "refuses an indeterminate agent family: %s",
+  async (kind) => {
+    const stateDir = fs.realpathSync(dirs.make("update-schema-invalid-"));
+    const file = path.join(stateDir, "agents", "main", "agent", "openclaw-agent.sqlite");
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    if (kind === "malformed") {
+      fs.writeFileSync(file, "not a SQLite database");
+    } else {
+      const db = openNodeSqliteDatabase(file);
+      db.exec("PRAGMA journal_mode=WAL; PRAGMA user_version=3;");
+      db.close();
+      fs.mkdirSync(`${file}-wal`);
+    }
+    const before = fs.readFileSync(file);
+    await expect(readUpdateStateSchemaVersions({ stateDir, config: {} })).rejects.toThrow(
+      /State schema inspection failed/,
+    );
+    expect(fs.readFileSync(file)).toEqual(before);
+    if (kind === "nonregular-wal") {
+      expect(fs.statSync(`${file}-wal`).isDirectory()).toBe(true);
+      expect(fs.existsSync(`${file}-shm`)).toBe(false);
+    }
+  },
+);
+
+it.skipIf(process.platform === "win32")(
+  "refuses source replacement during pinned header inspection",
+  async () => {
+    const stateDir = fs.realpathSync(dirs.make("update-schema-identity-"));
+    const file = path.join(stateDir, "agents", "main", "agent", "openclaw-agent.sqlite");
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    const db = openNodeSqliteDatabase(file);
+    db.exec("PRAGMA user_version=3;");
+    db.close();
+    const preload = path.join(stateDir, "replace-source.cjs");
+    // Replace the pathname while the canonical owner still holds its original
+    // descriptor. A numeric result from that retired inode must not be published.
+    fs.writeFileSync(
+      preload,
+      `
+      const fs = require('node:fs');
+      const source = ${JSON.stringify(file)};
+      const open = fs.openSync, read = fs.readSync;
+      let descriptor, replaced = false;
+      fs.openSync = function(file, ...args) {
+        const fd = open.call(this, file, ...args);
+        if (String(file) === source) descriptor = fd;
+        return fd;
+      };
+      fs.readSync = function(fd, ...args) {
+        const count = read.call(this, fd, ...args);
+        if (fd === descriptor && !replaced) {
+          replaced = true;
+          fs.renameSync(source, source + '.retired');
+          fs.copyFileSync(source + '.retired', source);
+        }
+        return count;
+      };
+    `,
+    );
+    await expect(
+      readUpdateStateSchemaVersions({
+        stateDir,
+        config: {},
+        env: { ...process.env, ...sqliteWorkerPreloadEnv(preload) },
+      }),
+    ).rejects.toThrow(/SQLite source changed/);
+    expect(fs.readFileSync(file)).toEqual(fs.readFileSync(`${file}.retired`));
+  },
+);
+
+it("discovers an agent registered after directory enumeration in the shared snapshot", async () => {
+  const stateDir = fs.realpathSync(dirs.make("update-schema-new-agent-"));
+  const sharedPath = path.join(stateDir, "state", "openclaw.sqlite");
+  const agentPath = path.join(stateDir, "agents", "late", "agent", "openclaw-agent.sqlite");
+  fs.mkdirSync(path.dirname(sharedPath), { recursive: true });
+  fs.mkdirSync(path.join(stateDir, "agents"));
+  const shared = openNodeSqliteDatabase(sharedPath);
+  shared.exec("PRAGMA user_version=7; CREATE TABLE agent_databases(path TEXT);");
+  shared.close();
+  const before = await readUpdateStateSchemaVersions({ stateDir, config: {} });
+  const preload = path.join(stateDir, "late-registration.cjs");
+  // Insert after enumeration returns its old directory list. Only discovery
+  // from the subsequently captured shared generation can find this new store.
+  fs.writeFileSync(
+    preload,
+    `
+    const fs = require('node:fs'), path = require('node:path');
+    const { DatabaseSync } = require('node:sqlite');
+    const agents = ${JSON.stringify(path.join(stateDir, "agents"))};
+    const agent = ${JSON.stringify(agentPath)}, shared = ${JSON.stringify(sharedPath)};
+    const readdir = fs.promises.readdir;
+    fs.promises.readdir = async function(directory, ...args) {
+      const entries = await readdir.call(this, directory, ...args);
+      if (String(directory) === agents) {
+        fs.mkdirSync(path.dirname(agent), {recursive:true});
+        const db = new DatabaseSync(agent);
+        try { db.exec('PRAGMA user_version=3'); } finally { db.close(); }
+        const registry = new DatabaseSync(shared);
+        try { registry.prepare('INSERT INTO agent_databases VALUES (?)').run(agent); }
+        finally { registry.close(); }
+      }
+      return entries;
+    };
+  `,
+  );
+  const after = await readUpdateStateSchemaVersions({
+    stateDir,
+    config: {},
+    env: { ...process.env, ...sqliteWorkerPreloadEnv(preload) },
+  });
+  expect(before.some((entry) => entry.path === agentPath)).toBe(false);
+  expect(after).toContainEqual({ path: agentPath, userVersion: 3 });
+  expect(
+    updateStateSchemaVersionsMatch(before, after, {
+      sharedPath,
+      candidateSchemaVersions: { state: 7, agent: 3 },
+    }),
+  ).toBe(true);
+});
+
+it("fences WAL schema migration without copying a large registered agent payload", async () => {
+  const root = fs.realpathSync(dirs.make("update-schema-payload-"));
+  const stateDir = path.join(root, "state-owner");
+  const sharedPath = path.join(stateDir, "state", "openclaw.sqlite");
+  const agentPath = path.join(root, "external-agent.sqlite");
+  const preload = path.join(root, "bounded-source-reads.cjs");
+  const copiedShared = path.join(root, "shared-copied");
+  const cache = path.join(root, "cache");
+  fs.mkdirSync(path.dirname(sharedPath), { recursive: true });
+  fs.mkdirSync(cache);
+  const shared = openNodeSqliteDatabase(sharedPath);
+  shared.exec(`
+    PRAGMA user_version=15;
+    CREATE TABLE config_machine_state(state_key TEXT PRIMARY KEY, value_json TEXT);
+    INSERT INTO config_machine_state VALUES('state.schema.contentVersion','16');
+    CREATE TABLE agent_databases(path TEXT);
+  `);
+  shared.prepare("INSERT INTO agent_databases VALUES (?)").run(agentPath);
+  shared.close();
+  const writer = openNodeSqliteDatabase(agentPath);
+  writer.exec(`
+    PRAGMA journal_mode=WAL; PRAGMA wal_autocheckpoint=0;
+    CREATE TABLE payload(data BLOB); INSERT INTO payload VALUES(zeroblob(67108864));
+    CREATE TABLE schema_meta(meta_key TEXT PRIMARY KEY, app_version TEXT);
+    INSERT INTO schema_meta VALUES('primary','baseline');
+    PRAGMA user_version=3; PRAGMA wal_checkpoint(TRUNCATE);
+  `);
+  expect(fs.statSync(agentPath).size).toBeGreaterThan(64 * 1024 * 1024);
+  // Constrain the actual child's filesystem copy path, which differs from
+  // SQLite backup. Metadata reads remain real, including native WAL handling.
+  fs.writeFileSync(
+    preload,
+    `
+    const fs = require('node:fs');
+    const source = ${JSON.stringify(agentPath)}, shared = ${JSON.stringify(sharedPath)};
+    const marker = ${JSON.stringify(copiedShared)};
+    const open = fs.openSync, read = fs.readSync, close = fs.closeSync;
+    const sources = new Map();
+    fs.openSync = function(file, ...args) {
+      const fd = open.call(this, file, ...args);
+      if (String(file) === source || String(file) === shared) sources.set(fd, String(file));
+      return fd;
+    };
+    fs.readSync = function(fd, buffer, offset, length, position) {
+      if (sources.get(fd) === source && length > 4096) throw new Error('agent payload copy forbidden');
+      if (sources.get(fd) === shared && length > 4096) fs.writeFileSync(marker, 'copied');
+      return read.call(this, fd, buffer, offset, length, position);
+    };
+    fs.closeSync = function(fd) { sources.delete(fd); return close.call(this, fd); };
+    require('node:sqlite').backup = async () => { throw new Error('agent backup forbidden'); };
+  `,
+  );
+  const env = { ...process.env, ...sqliteWorkerPreloadEnv(preload), XDG_CACHE_HOME: cache };
+  const inspect = () => readUpdateStateSchemaVersions({ stateDir, config: {}, env });
+  try {
+    // Only WAL records the committed candidate version; the main header stays at 3.
+    writer.exec("BEGIN IMMEDIATE; PRAGMA user_version=4; COMMIT;");
+    const baseline = await inspect();
+    expect(baseline).toContainEqual({ path: agentPath, userVersion: 4 });
+    expect(baseline).toContainEqual({ path: sharedPath, userVersion: 15, contentVersion: 16 });
+    expect(baseline).toContainEqual({
+      path: path.join(stateDir, "agents", "main", "agent", "openclaw-agent.sqlite"),
+      userVersion: null,
+    });
+    expect(fs.readFileSync(copiedShared, "utf8")).toBe("copied");
+    const comparison = { sharedPath, candidateSchemaVersions: { state: 16, agent: 5 } };
+    expect(updateStateSchemaVersionsMatch(baseline, await inspect(), comparison)).toBe(true);
+    writer.exec("BEGIN IMMEDIATE; PRAGMA user_version=5; COMMIT;");
+    const migrated = await inspect();
+    expect(migrated).toContainEqual({ path: agentPath, userVersion: 5 });
+    expect(updateStateSchemaVersionsMatch(baseline, migrated, comparison)).toBe(false);
+    expect(fs.readdirSync(path.join(cache, "openclaw"))).toEqual([]);
+  } finally {
+    writer.close();
+  }
+});

--- a/src/infra/update-candidate-state.test.ts
+++ b/src/infra/update-candidate-state.test.ts
@@ -298,7 +298,10 @@ it.runIf(process.platform !== "win32")(
     await fs.symlink(symlinkTarget, path.join(source, "link"), "dir");
     const filesystemPath = path.join(source, "external", "x", "openclaw-agent.sqlite");
     const lexicalPath = path.join(source, "x", "openclaw-agent.sqlite");
-    await createDatabase(filesystemPath, "UPDATE evidence SET value = 'filesystem';");
+    await createDatabase(
+      filesystemPath,
+      "UPDATE evidence SET value = 'filesystem'; PRAGMA user_version = 4;",
+    );
     await createDatabase(lexicalPath, "UPDATE evidence SET value = 'lexical';");
     await createDatabase(
       shared,
@@ -310,6 +313,12 @@ it.runIf(process.platform !== "win32")(
     insert.run("lexical", lexicalPath);
     registry.close();
 
+    const versions = await readUpdateStateSchemaVersions({ stateDir: source, config: {} });
+    expect(versions).toContainEqual({
+      path: `${source}${path.sep}link${path.sep}..${path.sep}x${path.sep}openclaw-agent.sqlite`,
+      userVersion: 4,
+    });
+    expect(versions).toContainEqual({ path: lexicalPath, userVersion: 3 });
     await runSnapshotWorker({ stateDir: source, targetStateDir: target, config: {} });
 
     const copiedRegistry = openNodeSqliteDatabase(path.join(target, "state", "openclaw.sqlite"));

--- a/src/infra/update-candidate-state.ts
+++ b/src/infra/update-candidate-state.ts
@@ -19,7 +19,10 @@ import { openNodeSqliteDatabase } from "./node-sqlite.js";
 import { hasNodeErrorCode, normalizeWindowsPathPreservingCase } from "./path-guards.js";
 import { runtimeProcessEntrypoints } from "./runtime-process-entrypoints.js";
 import { resolveRuntimeWorkerArgv, resolveRuntimeWorkerUrl } from "./runtime-worker-url.js";
-import { prepareSqliteReadOnlyLocationSyncInProcess } from "./sqlite-readonly-location.js";
+import {
+  inspectSqliteSchemaHeaderInProcess,
+  prepareSqliteReadOnlyLocationSyncInProcess,
+} from "./sqlite-readonly-location.js";
 import { readSqliteUserVersion } from "./sqlite-user-version.js";
 import {
   UPDATE_CANDIDATE_PLUGIN_PLAN_FILENAME,
@@ -302,7 +305,7 @@ export async function readUpdateCandidateStateInventoryInProcess(
   return measure();
 }
 
-/** Missing databases stay explicit so creation is schema-checked and loss blocks rollback. */
+/** Inspect only in the update child: source closes must not release Gateway POSIX locks. */
 export async function readUpdateStateSchemaVersionsInProcess(
   input: StateInput,
 ): Promise<UpdateStateSchemaVersion[]> {
@@ -313,30 +316,38 @@ export async function readUpdateStateSchemaVersionsInProcess(
   const inspected = new Map<string, Omit<UpdateStateSchemaVersion, "path">>();
   for (const [identity, discovery] of files) {
     const file = discovery.spellings[0];
+    // Missing stores stay explicit so creation is checked and loss blocks rollback.
+    if (!(await fileExists(file))) {
+      inspected.set(identity, { userVersion: null });
+      continue;
+    }
+    if (file !== shared) {
+      // Reuse the native WAL-aware owner inside this child, avoiding both agent
+      // payload copies and a nested worker with a separate cleanup lifetime.
+      const { userVersion } = await inspectSqliteSchemaHeaderInProcess(file);
+      inspected.set(identity, { userVersion });
+      continue;
+    }
     inspected.set(
       identity,
-      (await fileExists(file))
-        ? await withStateDatabaseSnapshot(file, (location) => {
-            const db = openNodeSqliteDatabase(location, { readOnly: true });
-            try {
-              if (file === shared) {
-                collectRegisteredPaths(db, shared, files);
-              }
-              return {
-                userVersion: readSqliteUserVersion(db),
-                ...(file === shared ? { contentVersion: readStateSchemaContentVersion(db) } : {}),
-              };
-            } finally {
-              db.close();
-            }
-          })
-        : { userVersion: null },
+      await withStateDatabaseSnapshot(file, (location) => {
+        const db = openNodeSqliteDatabase(location, { readOnly: true });
+        try {
+          collectRegisteredPaths(db, shared, files);
+          return {
+            userVersion: readSqliteUserVersion(db),
+            contentVersion: readStateSchemaContentVersion(db),
+          };
+        } finally {
+          db.close();
+        }
+      }),
     );
   }
   return publishStateDatabaseVersions(files, inspected);
 }
 
-/** Schema fencing reads private copies in a child under a fixed inspection deadline. */
+/** Fence schema versions in one child under a fixed inspection deadline. */
 export async function readUpdateStateSchemaVersions({
   root,
   nodeRunner = process.execPath,


### PR DESCRIPTION
Related: #145412, #145541, #144542

## What Problem This Solves

Fixes an issue where users updating from the Control UI can time out before activation when agent databases contain large histories. An observed 2026.9.3 update with 5.4 GB of live state completed candidate build, rehearsal, Doctor, config/plugin validation, and canary, then exceeded the schema-inspection deadline before mutation.

## Why This Change Was Made

Activation and rollback schema fencing copied every agent database to obtain its version. The versions worker now reuses the WAL-aware native header reader introduced by #145541 inside its existing isolated child. Shared state still uses a private snapshot for registered-agent discovery and deferred content versions. The response retains exactly the same decision inputs: raw paths, nullable `userVersion`, and shared `contentVersion`; rollback comparisons and previous-runtime support checks are unchanged.

The 30-second deadline remains. Native source connections stay outside the Gateway process so their closure cannot release its POSIX locks. The canonical reader retains private recovery for hot journals and incomplete WAL families, which can still require payload copies; this change does not promise bounded recovery time for those cases. Issue #145412 and PR #145541 addressed startup preflight, not this activation fence. Open PR #144542 separately addresses snapshot staging and inspection budgets; those controls are unchanged here.

## User Impact

Updates driven by a runtime containing this change can inspect normal live agent schemas without copying their histories. An unsafe rollback remains refused after candidate schema migration or when a newly created store exceeds the retained runtime's support.

**Old-driver first hop:** merging this repair does not let an already affected installed updater repair itself. Its pre-activation inspection still runs old code. That host needs one controlled manual bootstrap to a containing commit before subsequent updates can use the fix. This PR does not update or restart any deployed Gateway.

## Evidence

- A 64 MiB agent regression calls `readUpdateStateSchemaVersions` with payload copies forbidden in the actual child. It fails on the original source with `agent payload copy forbidden` and passes with the repair. Its version changes exist only in WAL; unchanged-state comparison passes and post-migration comparison refuses rollback.
- Shared snapshot and deferred content-version behavior, registrations added after directory enumeration, missing stores, raw symlink traversal, source replacement, malformed/incomplete families, parent writer locks, exclusive-writer timeout/cancellation, native read/close failure, and cleanup are covered through real SQLite/process boundaries.
- Initial focused run: **37 passed**. Final broader run: **182 passed, 6 skipped**, covering the SQLite header/snapshot/cancellation owners, update inspection, preflight artifacts, migrated-state handling, and rollback/executor flows. Five Windows path cases and one Linux-only lock probe were skipped on macOS; the new parent-lock probe passed on macOS.
- Full package build passed: `mise exec -- node --import ./scripts/tsx.mjs scripts/build-all.mts`.
- Full changed-file gate passed, including core production/test types, type-aware lint, formatting, and repository guards: `mise exec -- node scripts/check-changed.mjs -- src/infra/update-candidate-state.ts src/infra/update-candidate-state.schema.test.ts src/infra/update-candidate-state.schema-lifetime.test.ts src/infra/update-candidate-state.test.ts`. Final type-aware lint and `git diff --check` also passed.
- Released-worker comparison using the official `openclaw@2026.9.3` tarball (SHA-1/SHA-512 verified): its unguarded worker and the built candidate return identical paths, nullable agent versions, and shared content versions. With raw agent copies forbidden, the published worker fails and the candidate succeeds. A separate child confirms main-file version 3 while both readers report WAL-committed version 4; shared snapshot use and staging cleanup also pass.
- Fresh autoreview through P2: **scoped-clean**, no actionable findings. No dependency or lockfile changes are included.

The large-database regression proves the absence of the copy operation, not throughput on the original 5.4 GB host. The released-worker comparison covers the activation-fence boundary. The full isolated published-driver upgrade proof below supplements that comparison; no deployed Gateway or manual bootstrap was exercised.

## Crabbox published-driver upgrade proof

Passed for head `0520fc025a57eda907e55c7162f90314ceabefce` using the repository's `legacy-operator-state` Docker lane on Blacksmith Testbox.

- Provider: `blacksmith-testbox`; lease: `tbx_01m2b1s97ab70f18ethpcm48aq`.
- [Testbox lifecycle run](https://github.com/openclaw/openclaw/actions/runs/34700633883). The executed command returned exit 0 in 10m43.768s, including packaging and Docker setup. Crabbox's external portal synchronization subsequently timed out; the command exit and timing receipt report success.
- Source: detached checkout of the full head SHA; tree `100684b6f493d25ca501333121612698a87d9243`. The installed candidate's reported build ID, `2026.9.4-0520fc025a57-2026-09-12T14-59-02.984Z`, matches its exported build metadata.
- Driver: unmodified npm `openclaw@2026.9.3`. The published CLI and Gateway created the isolated operator state and completed a baseline agent turn before the update. No deployed operator data was copied.

| Observation | Result |
| --- | --- |
| Installed updater command | `openclaw update --tag file:/tmp/openclaw-current.tgz --yes --json --no-restart` |
| Terminal update | `status=ok`, `mode=npm`, 197,458 ms; all nine core steps exited 0 |
| Durable update record | `status=succeeded`, `phase=finished`, terminal timestamp present, `reason=null` |
| Process completion | Published 2026.9.3 updater exited 0; captured candidate Doctor and post-core processes exited 0 |
| Shared schema/content version | 16 → 17 |
| Existing main-agent schema/content version | 19 → 20, verified before candidate Gateway probes |
| Operator-state assertions | Agent roster, approvals policy, workspace skill, and both cron jobs preserved; default-owner job resolves to `main`; explicit `ops` owner preserved |
| Candidate behavior | Health/readiness HTTP 200, `ready=true`, no failing components, Gateway version 2026.9.4, candidate agent turn completed against the synthetic provider |
| Plugin convergence | Discord updated, configured DuckDuckGo repaired; final plugin status `ok`, no integrity drifts |
| Second update and Doctor | `already-current`, no package mutation or repair required; Doctor clean |

Rollback-state reporting from the real update:

```json
{
  "status": "ok",
  "recovery": {
    "serviceRestartSafe": true,
    "version": "2026.9.4"
  },
  "run": {
    "phase": "finished",
    "status": "succeeded",
    "reason": null
  }
}
```

No rollback step or `packageRollbackVerified` was reported. The update retained the candidate after schema migration. This successful-upgrade lane does not exercise forced rollback or unsafe-rollback refusal; the existing regression coverage remains the evidence for those refusal decisions.

Reproduction in a task-owned detached checkout of the head on the lease:

```sh
OPENCLAW_DOCKER_E2E_SELECTED_SHA=0520fc025a57eda907e55c7162f90314ceabefce \
OPENCLAW_UPGRADE_SURVIVOR_PUBLISHED_BASELINE=1 \
OPENCLAW_UPGRADE_SURVIVOR_BASELINE_SPEC=openclaw@2026.9.3 \
OPENCLAW_UPGRADE_SURVIVOR_CANDIDATE=current \
OPENCLAW_UPGRADE_SURVIVOR_SCENARIO=legacy-operator-state \
bash scripts/e2e/upgrade-survivor-docker.sh
```

The lane starts the candidate Gateway explicitly after `--no-restart`; it does not prove managed-service restart. It uses ordinary synthetic operator state and a synthetic provider endpoint, not the original 5.4 GB host. It does not compare all existing transcript bytes or resume the baseline conversation. The old-driver manual-bootstrap limitation on already affected large installations remains. No production Gateway was changed.

Retained evidence includes the complete command log, `summary.json`, `update.json`, schema snapshots, process-start/exit receipts, readiness/status results, and candidate build metadata. This supplements the earlier worker-boundary comparison with the full published-driver × candidate update result.
