### PR TITLE
improve: reduce work when importing long chat histories

### DIFF
--- a/src/gateway/cli-session-history.merge.ts
+++ b/src/gateway/cli-session-history.merge.ts
@@ -572,7 +572,7 @@ export function mergeImportedChatHistoryMessages(params: {
   const exactExternalIdentityIndex = new Map<string, ComparableHistoryMessage>();
   const allMessageRoleTextIndex: RoleTextIndex = new Map();
   const identitylessRoleTextIndex: RoleTextIndex = new Map();
-  const roleTextMinimumOrder = new Map<string, number>();
+  const roleTextMinimumOrder = new Map<string, Map<string, number>>();
   const localImageMediaCandidates = new Map<string, ConsumableCandidates>();
   const consumedLocalCandidates = new Set<ComparableHistoryMessage>();
   const advanceRoleTextMinimumOrder = (
@@ -589,11 +589,12 @@ export function mergeImportedChatHistoryMessages(params: {
       if (!text) {
         continue;
       }
-      const key = JSON.stringify([entry.role, text]);
-      roleTextMinimumOrder.set(
-        key,
-        Math.max(roleTextMinimumOrder.get(key) ?? 0, matched.order + 1),
-      );
+      let byText = roleTextMinimumOrder.get(entry.role);
+      if (!byText) {
+        byText = new Map();
+        roleTextMinimumOrder.set(entry.role, byText);
+      }
+      byText.set(text, Math.max(byText.get(text) ?? 0, matched.order + 1));
     }
   };
   const indexEntry = (entry: ComparableHistoryMessage) => {
@@ -675,18 +676,15 @@ export function mergeImportedChatHistoryMessages(params: {
       const index = imported.externalIdentityKey
         ? identitylessRoleTextIndex
         : allMessageRoleTextIndex;
-      const importedMinimumOrder =
-        roleTextMinimumOrder.get(JSON.stringify([imported.role, imported.text])) ?? 0;
+      const byText = imported.role ? roleTextMinimumOrder.get(imported.role) : undefined;
+      const importedMinimumOrder = imported.text ? (byText?.get(imported.text) ?? 0) : 0;
       // A user can quote the complete note. Prefer that literal local turn
       // before comparing the text after an OpenClaw-generated note.
       for (const text of [imported.text, imported.driftNoteText]) {
         if (!imported.role || !text) {
           continue;
         }
-        const minimumOrder = Math.max(
-          importedMinimumOrder,
-          roleTextMinimumOrder.get(JSON.stringify([imported.role, text])) ?? 0,
-        );
+        const minimumOrder = Math.max(importedMinimumOrder, byText?.get(text) ?? 0);
         duplicate = findRoleTextCandidate(
           index,
           { ...imported, text },


### PR DESCRIPTION
Related: #145679

## What Problem This Solves

Importing long CLI conversations repeatedly serializes message text while reconciling it with existing chat history, adding work and temporary allocations as conversations grow.

## Why This Change Was Made

The existing merge owner now indexes minimum message order by role and then text. This removes serialized composite keys while preserving exact text matching, timestamp rules, imported identities, drift-note precedence, and ordering. The production change is net two lines smaller.

## User Impact

Large conversation imports do less synchronous work while producing the same history. This change applies to the merge phase; transcript I/O and Gateway transport are outside the measured scope.

## Evidence

- All 140 focused tests pass on both original and candidate code, including registered `chat.history` and `chat.startup` import handlers.
- A differential probe of the complete exported merge function passed 20,044 comparisons, checking complete outputs, input immutability, and preserved array/message identities.
- Exploratory alternating measurements with 1,000 rows per side and roughly 8 KiB text showed 22–42% lower merge time across unique/repeated text and 0%, 50%, and 100% overlap. These synthetic Node 24.19 Linux timings were collected under host contention and are not production latency claims.
- Independent P2 review is clean. The selected changed-file gate passed core typechecking, then its test-type graph was interrupted with exit 137 during a local WSL service failure. Remaining local validation is pending recovery.
- The initial hosted run hit two updater-process timeouts outside the changed merge function's execution path. Main already contains #145757, which makes signal fixtures use their compiled runtime entrypoints without changing timeouts or assertions. The branch was refreshed to include that fix; the reviewed performance patch and its direct dependencies are unchanged. The separate cleanup timeout remains unexplained. Required checks must qualify the refreshed head before landing.
