### PR TITLE
fix(agents): release completed liveness join contexts

### DIFF
--- a/config/knip.config.ts
+++ b/config/knip.config.ts
@@ -118,6 +118,7 @@ const repositoryScriptEntries = [
   "scripts/e2e/lib/upgrade-survivor/mobile-pairing-client.mts!",
   "scripts/e2e/lib/upgrade-survivor/watchos-direct-node.mjs!",
   "scripts/embedded-run-abort-leak.ts!",
+  "scripts/embedded-run-liveness-leak.ts!",
   "scripts/fixtures/packed-plugin-sdk-type-smoke.ts!",
   // CI executes screenshot evidence from the workflow-owned harness copy.
   "scripts/ios-screenshot-evidence.mjs!",

--- a/package.json
+++ b/package.json
@@ -1772,6 +1772,7 @@
     "ios:version:check": "node --import ./scripts/tsx.mjs scripts/ios-sync-versioning.ts --check",
     "ios:version:sync": "node --import ./scripts/tsx.mjs scripts/ios-sync-versioning.ts --write",
     "leak:embedded-run": "node --import ./scripts/tsx.mjs --expose-gc scripts/embedded-run-abort-leak.ts",
+    "leak:embedded-run:liveness": "node --import ./scripts/tsx.mjs --expose-gc scripts/embedded-run-liveness-leak.ts",
     "lint": "node --import ./scripts/tsx.mjs scripts/run-lint.mts",
     "lint:agent:ingress-owner": "node --import ./scripts/tsx.mjs scripts/check-ingress-agent-owner-context.mts",
     "lint:all": "node scripts/run-oxlint.mjs",

--- a/scripts/embedded-run-liveness-leak.ts
+++ b/scripts/embedded-run-liveness-leak.ts
@@ -1,0 +1,94 @@
+/**
+ * Checks that a completed liveness join releases its caller while delivery is
+ * still pending. Run with:
+ * node --expose-gc --import ./scripts/tsx.mjs scripts/embedded-run-liveness-leak.ts
+ */
+import { mkdirSync } from "node:fs";
+import { setImmediate as nextTurn } from "node:timers/promises";
+import { writeHeapSnapshot } from "node:v8";
+import { joinWithRunLivenessDeadline } from "../src/agents/embedded-agent-runner/run/abortable.js";
+
+class AttemptContext {
+  payload = Array.from({ length: 10_000 }, (_, index) => index);
+  timedOut = false;
+}
+
+const snapshotDirectory = ".tmp/embedded-run-liveness-leak";
+const attemptsPerMode = 100;
+
+async function countRetained(tracked: WeakRef<AttemptContext>[]): Promise<number> {
+  for (let index = 0; index < 10; index++) {
+    await nextTurn();
+    global.gc?.();
+  }
+  return tracked.filter((reference) => reference.deref()).length;
+}
+
+function joinPendingDelivery(
+  mode: "timeout" | "abort",
+  tracked: WeakRef<AttemptContext>[],
+  releases: (() => void)[],
+): Promise<void> {
+  const attempt = new AttemptContext();
+  const controller = new AbortController();
+  const delivery = new Promise<void>((resolve) => releases.push(resolve));
+  tracked.push(new WeakRef(attempt));
+  // The two callbacks share a lexical scope, as they do in stream settlement.
+  return joinWithRunLivenessDeadline({
+    joinWork: () => {
+      if (mode === "abort") {
+        queueMicrotask(() => controller.abort());
+      }
+      return delivery;
+    },
+    runAbortSignal: controller.signal,
+    timeoutMs: mode === "timeout" ? 1 : undefined,
+    onTimeout: () => {
+      attempt.timedOut = true;
+    },
+  });
+}
+
+if (!global.gc) {
+  throw new Error("Run this harness with node --expose-gc.");
+}
+mkdirSync(snapshotDirectory, { recursive: true });
+let failed = false;
+// The production liveness timers are unref'd; keep their deadlines observable.
+const keepAlive = setInterval(() => {}, 1_000);
+try {
+  for (const mode of ["timeout", "abort"] as const) {
+    const tracked: WeakRef<AttemptContext>[] = [];
+    const releases: (() => void)[] = [];
+    const startedAt = performance.now();
+    const rssBefore = process.memoryUsage().rss;
+    await Promise.all(
+      Array.from({ length: attemptsPerMode }, () => joinPendingDelivery(mode, tracked, releases)),
+    );
+    const retainedAfterJoin = await countRetained(tracked);
+    await nextTurn();
+    writeHeapSnapshot(`${snapshotDirectory}/${mode}-${process.pid}.heapsnapshot`);
+    for (const release of releases) {
+      release();
+    }
+    releases.length = 0;
+    const retainedAfterDelivery = await countRetained(tracked);
+    const passed = retainedAfterJoin === 0 && retainedAfterDelivery === 0;
+    failed ||= !passed;
+    console.log(
+      JSON.stringify({
+        mode,
+        attempts: attemptsPerMode,
+        retainedAfterJoin,
+        retainedAfterDelivery,
+        durationMs: performance.now() - startedAt,
+        rssBefore,
+        rssAfter: process.memoryUsage().rss,
+        passed,
+      }),
+    );
+  }
+} finally {
+  clearInterval(keepAlive);
+}
+process.exitCode = failed ? 1 : 0;

--- a/scripts/embedded-run-liveness-leak.ts
+++ b/scripts/embedded-run-liveness-leak.ts
@@ -31,7 +31,9 @@ function joinPendingDelivery(
 ): Promise<void> {
   const attempt = new AttemptContext();
   const controller = new AbortController();
-  const delivery = new Promise<void>((resolve) => releases.push(resolve));
+  const delivery = new Promise<void>((resolve) => {
+    releases.push(resolve);
+  });
   tracked.push(new WeakRef(attempt));
   // The two callbacks share a lexical scope, as they do in stream settlement.
   return joinWithRunLivenessDeadline({

--- a/scripts/embedded-run-liveness-leak.ts
+++ b/scripts/embedded-run-liveness-leak.ts
@@ -1,7 +1,7 @@
 /**
  * Checks that a completed liveness join releases its caller while delivery is
  * still pending. Run with:
- * node --expose-gc --import ./scripts/tsx.mjs scripts/embedded-run-liveness-leak.ts
+ * pnpm leak:embedded-run:liveness
  */
 import { mkdirSync } from "node:fs";
 import { setImmediate as nextTurn } from "node:timers/promises";

--- a/src/agents/embedded-agent-runner/run/abortable.ts
+++ b/src/agents/embedded-agent-runner/run/abortable.ts
@@ -38,6 +38,14 @@ export function createAbortableError(signal: AbortSignal): Error {
 // not legitimate delivery work.
 export const RUN_LIVENESS_JOIN_TIMEOUT_MS = 120_000;
 
+type RunLivenessJoinCompletion = { finish: (() => void) | undefined };
+
+// Keep pending promise reactions outside the caller's closure scope so clearing
+// this completion releases the attempt even when delivery never settles.
+function finishRunLivenessJoin(completion: RunLivenessJoinCompletion): void {
+  completion.finish?.();
+}
+
 /**
  * Awaits post-turn work that must never dead-end the run: races the joined
  * promise against the run-abort signal and a liveness deadline. Timeout and
@@ -52,12 +60,11 @@ export function joinWithRunLivenessDeadline(input: {
   onTimeout: () => void;
 }): Promise<void> {
   return new Promise<void>((resolve) => {
-    let settled = false;
     const finish = (reason: "settled" | "timeout" | "abort") => {
-      if (settled) {
+      if (!completion.finish) {
         return;
       }
-      settled = true;
+      completion.finish = undefined;
       clearTimeout(timer);
       input.runAbortSignal?.removeEventListener("abort", onAbort);
       if (reason === "timeout") {
@@ -65,6 +72,8 @@ export function joinWithRunLivenessDeadline(input: {
       }
       resolve();
     };
+    const completion: RunLivenessJoinCompletion = { finish: () => finish("settled") };
+    const onSettled = finishRunLivenessJoin.bind(undefined, completion);
     const onAbort = () => finish("abort");
     const timer = setTimeout(
       () => finish("timeout"),
@@ -78,10 +87,7 @@ export function joinWithRunLivenessDeadline(input: {
     input.runAbortSignal?.addEventListener("abort", onAbort, { once: true });
     Promise.resolve()
       .then(() => input.joinWork())
-      .then(
-        () => finish("settled"),
-        () => finish("settled"),
-      );
+      .then(onSettled, onSettled);
   });
 }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where completed or cancelled embedded attempts retain their context in memory while an earlier delivery callback remains stuck.

## Why This Change Was Made

A liveness join now clears its completion callback when timeout, abort, or normal settlement wins. The pending delivery promise observes that callback through a separate module-scope function, so its reaction no longer retains the caller's attempt context after the join has ended. Existing deferred work, deadline, listener, and error behavior stays intact.

## User Impact

Gateways can release ended attempt contexts even when an associated delivery promise never settles. This addresses retained memory after stuck deliveries; it does not reduce the live context required by active work.

## Evidence

- A permanent forced-GC harness fails on the original code with 100/100 captured contexts retained after both timeout and abort. The patch releases all 100 in both modes while delivery promises remain pending; late delivery settlement remains safe.
- A separate proof through the real `settleEmbeddedAttemptStream` owner retained 20/20 full attempt inputs before the fix and 0/20 afterward. Heap retainer paths identify the pending promise reaction and captured join input.
- The same three-file contract suite passes 40/41 tests on both the untouched baseline and the candidate. The sole failure on both is Windows `EBUSY` during SQLite cleanup in the unrelated session projection persistence test. All liveness, abort, late settlement, and stream finalization cases pass. Independent P0-P2 review found no actionable findings. The byte-identical combined candidate subsequently passed all 41 contracts on Linux. The required changed gate passed initial guards, formatting, script erasability, and core typechecking before the shared validation host exhausted memory; exact-head hosted CI subsequently passed all remaining required checks.



- A combined candidate with this fix passed a live Gateway workload with 1,000 sessions, eight real OpenAI turns, two file-read tool flows, history/subscription/control-plane activity, and 992 successful session deletions. All eight retained live sessions contained exactly one persisted final response. Overall sampled allocations were effectively flat in that single paired run (9.600 GB to 9.583 GB); this does not establish a general Gateway memory reduction. The baseline's post-measurement cleanup used an incorrect keep set, so there is no valid paired retention comparison.

The permanent proof is available as `pnpm leak:embedded-run:liveness`. Both final command cases pass with zero retained contexts after timeout/abort and late delivery settlement. The command registration also makes the standalone harness reachable to repository dependency checks; exact-head hosted CI has passed.



Exact-head hosted CI passed all required gates: https://github.com/openclaw/openclaw/actions/runs/34701779939. ClawSweeper reviewed 584b29fe166a with no actionable findings.


