### PR TITLE
fix(runtime): avoid redundant synchronous work cleanup reactions

### DIFF
--- a/src/shared/async-work-scope.ts
+++ b/src/shared/async-work-scope.ts
@@ -32,7 +32,7 @@ export class AsyncWorkScope {
       throw new Error("Async work scope is closed");
     }
     // Synchronous work is removed in finally and needs no promise cleanup reactions.
-    const operation = createDeferredCore<void>();
+    const operation = createDeferredCore();
     this.pending.add(operation.promise);
     try {
       return currentWorkScope.run(this, run);

--- a/src/shared/async-work-scope.ts
+++ b/src/shared/async-work-scope.ts
@@ -31,7 +31,9 @@ export class AsyncWorkScope {
     if (this.phase === "closed") {
       throw new Error("Async work scope is closed");
     }
-    const operation = this.registerWork<void>();
+    // Synchronous work is removed in finally and needs no promise cleanup reactions.
+    const operation = createDeferredCore<void>();
+    this.pending.add(operation.promise);
     try {
       return currentWorkScope.run(this, run);
     } finally {


### PR DESCRIPTION
## What Problem This Solves

Synchronous work scopes register Promise cleanup reactions even though they already remove completed work in their finally block. Bursts of synchronous calls therefore allocate avoidable reactions and keep completed scopes reachable until the microtask queue runs.

## Why This Change Was Made

Register the existing deferred completion promise directly for synchronous work. It still protects reentrant drain and is resolved and removed in finally. Asynchronous tracking retains its existing completion handlers.

## User Impact

Busy Gateways perform fewer allocations while entering synchronous work and can release completed work scopes earlier. Return values, exceptions, cancellation context, descendant tracking, and cleanup ordering retain their existing contracts.

## Evidence

- A same-host workload of 50,000 calls through AsyncWorkScope.run reduced sampled allocations from 72,688,632 to 56,931,888 bytes (21.7%). Post-GC heap above the baseline before microtasks ran fell from 32,113,544 to 105,264 bytes.
- A separate WeakRef proof starts with 100 scopes before the measured turn. The original retains all 100 after synchronous work completes; the patch releases all 100 before the microtask queue drains. Both release them after the queue drains.
- All 28 existing owner and logical-turn resource tests pass on both the original code and candidate, covering synchronous return/throw, thenables, reentrant drain, inherited descendants, ownership, and disposal. Formatting and diff checks pass. Independent P0-P2 review found no actionable findings. The required changed gate passed initial guards and formatting on a byte-identical candidate in an isolated Linux worktree, but did not complete before the shared validation host exhausted memory. The remaining required type, lint, dead-code and selected test checks passed in [exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34700923152).



