### PR TITLE
fix(sessions): reuse single-session participant queries

### DIFF
--- a/src/config/sessions/session-accessor.sqlite-participant-projection.ts
+++ b/src/config/sessions/session-accessor.sqlite-participant-projection.ts
@@ -1,6 +1,12 @@
 import type { DatabaseSync } from "node:sqlite";
-import { executeSqliteQuerySync, sqliteStringSet } from "../../infra/kysely-sync.js";
+import type { Selectable } from "kysely";
+import {
+  executeSqliteQuerySync,
+  prepareSqliteQuerySync,
+  sqliteStringSet,
+} from "../../infra/kysely-sync.js";
 import { withOpenClawAgentDatabaseReadOnly } from "../../state/openclaw-agent-db-readonly.js";
+import type { DB as OpenClawAgentKyselyDatabase } from "../../state/openclaw-agent-db.generated.js";
 import { SESSION_PARTICIPANTS_TABLE } from "../../state/openclaw-agent-session-participants-schema.js";
 import { tableExists } from "../../state/openclaw-state-db-schema-helpers.js";
 import {
@@ -21,6 +27,51 @@ export type SessionParticipantRecord = {
   lastPromptedAt: number | null;
 };
 
+type SessionParticipantRow = Selectable<OpenClawAgentKyselyDatabase["session_participants"]>;
+
+function selectParticipantRows(database: DatabaseSync) {
+  return getSessionKysely(database)
+    .selectFrom("session_participants")
+    .selectAll()
+    .orderBy("session_key")
+    .orderBy("first_prompted_at")
+    .orderBy("actor_id")
+    .orderBy("identity_namespace");
+}
+
+function prepareSingleSessionParticipantQuery(database: DatabaseSync) {
+  return prepareSqliteQuerySync<string, SessionParticipantRow>(database, (parameter) =>
+    selectParticipantRows(database).where(
+      "session_key",
+      "=",
+      parameter((sessionKey) => sessionKey),
+    ),
+  );
+}
+
+// Compiled SQL follows the connection; native statement invalidation remains executor-owned.
+const singleSessionParticipantQueries = new WeakMap<
+  DatabaseSync,
+  ReturnType<typeof prepareSingleSessionParticipantQuery>
+>();
+
+function readParticipantRows(database: DatabaseSync, sessionKeys?: readonly string[]) {
+  const sessionKey = sessionKeys?.length === 1 ? sessionKeys[0] : undefined;
+  if (sessionKey !== undefined) {
+    let query = singleSessionParticipantQueries.get(database);
+    if (!query) {
+      query = prepareSingleSessionParticipantQuery(database);
+      singleSessionParticipantQueries.set(database, query);
+    }
+    return query(sessionKey).rows;
+  }
+  let query = selectParticipantRows(database);
+  if (sessionKeys) {
+    query = query.where("session_key", "in", sqliteStringSet(sessionKeys));
+  }
+  return executeSqliteQuerySync(database, query).rows;
+}
+
 function participantRecordsBySessionKey(
   database: DatabaseSync,
   sessionKeys?: readonly string[],
@@ -29,18 +80,7 @@ function participantRecordsBySessionKey(
   if (!tableExists(database, SESSION_PARTICIPANTS_TABLE)) {
     return records;
   }
-  let query = getSessionKysely(database).selectFrom("session_participants").selectAll();
-  if (sessionKeys) {
-    query = query.where("session_key", "in", sqliteStringSet(sessionKeys));
-  }
-  for (const row of executeSqliteQuerySync(
-    database,
-    query
-      .orderBy("session_key")
-      .orderBy("first_prompted_at")
-      .orderBy("actor_id")
-      .orderBy("identity_namespace"),
-  ).rows) {
+  for (const row of readParticipantRows(database, sessionKeys)) {
     const participants = records.get(row.session_key) ?? [];
     participants.push({
       identity: readParticipantIdentity(row.identity_namespace, row.actor_id),

--- a/src/config/sessions/session-accessor.sqlite-participants.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-participants.test.ts
@@ -190,7 +190,9 @@ describe("SQLite session participants", () => {
       const scope = { agentId: "main", env: state.env, sessionKey: "agent:main:bounded" };
       await upsertSessionEntryCore(scope, { sessionId: "bounded", updatedAt: 1 });
       const database = openOpenClawAgentDatabase({ agentId: "main", env: state.env });
+      expect(loadSessionEntry(scope)).toMatchObject({ sessionId: "bounded" });
       database.db.exec("DROP TABLE session_participants");
+      expect(loadSessionEntry(scope)).toMatchObject({ sessionId: "bounded" });
       expect(listSessionParticipantsReadOnly(scope).get(scope.sessionKey)).toBeUndefined();
       expect(
         database.db


### PR DESCRIPTION
## What Problem This Solves

Every session lookup rebuilds the participant query and a JSON-encoded key set, even when it requests one session. Repeated reads allocate the same query structure again.

## Why This Change Was Made

The participant reader now compiles its single-key query once per connection and binds the current key through the existing SQLite executor. The same owner retains ordering, identity validation and aggregate projection. Multi-key and whole-store reads retain their existing path.

## User Impact

Session and participant reads allocate less temporary memory. Missing-table behavior, participant identities and statistics, and connection cleanup remain unchanged. No schema, persistence, update or migration contract changes are needed.

## Evidence

On Linux/Node 24, an actual-owner benchmark seeded 96 isolated sessions through session and participant writers, split across 0, 1 and 32 participants. Each case performed 10,000 reads through both `loadSessionEntry` and `listSessionParticipantsReadOnly`. Ordered output hashes and loop checksums matched across baseline and candidate.

| Participants | Session read allocations | Participant read allocations |
| --- | --- | --- |
| 0 | 657.00 MB → 594.58 MB (-9.5%) | 431.47 MB → 365.94 MB (-15.2%) |
| 1 | 668.58 MB → 600.98 MB (-10.1%) | 440.73 MB → 375.80 MB (-14.7%) |
| 32 | 1,037.45 MB → 976.88 MB (-5.8%) | 800.65 MB → 733.12 MB (-8.4%) |

These measurements establish allocation savings; they do not establish latency or retained-memory savings. All 66 focused tests passed across participants, session rows, read-only access and write revalidation. A disposal probe created, read and closed 100 connections with native statement caching enabled; none remained reachable after garbage collection. The changed-check prechecks, formatting, wrapper/package guards, core graph boundary and production core typecheck passed. Test typechecking did not complete before the WSL host became unresponsive under memory pressure; subsequent local lint and guard phases are unverified. Exact-head hosted CI is required to close these remaining validation gaps before landing. Independent review through P2 found no actionable findings.


Exact-head [CI run 34700126333](https://github.com/openclaw/openclaw/actions/runs/34700126333) passed on f2ee102f7a517873cb058a0dc9de5a0dce37cda1, covering the required validation that the local host interruption left incomplete.
