### PR TITLE
improve: reduce temporary allocations during agent turns

### DIFF
--- a/packages/ai/src/providers/tool-schema-json-projection.ts
+++ b/packages/ai/src/providers/tool-schema-json-projection.ts
@@ -1,4 +1,5 @@
 import { types as utilTypes } from "node:util";
+import { expectDefined } from "@openclaw/normalization-core/expect";
 import { isRecord as isJsonObject } from "@openclaw/normalization-core/record-coerce";
 
 /** JSON-safe schema value used when projecting runtime tool parameters. */
@@ -30,25 +31,35 @@ function serializeToolInputSchema(value: unknown, path: string): RuntimeToolInpu
   const nonFiniteNumber = {
     path: null as string | null,
   };
-  const paths = new WeakMap<object, string>();
+  const ancestors: object[] = [];
+  const pathLengths: number[] = [];
+  const segments = [path];
   let isRoot = true;
   let text: string | undefined;
   try {
     text = JSON.stringify(value, function (this: object, key, entry) {
       const invalidNumber = nonFiniteNumber.path === null && isNonFiniteNumberValue(entry);
       if (invalidNumber || (entry && typeof entry === "object")) {
-        const holderPath = paths.get(this);
-        const entryPath = isRoot
-          ? path
-          : holderPath === undefined
-            ? `${path}.${key}`
-            : Array.isArray(this)
-              ? `${holderPath}[${key}]`
-              : `${holderPath}.${key}`;
+        // The replacer's holder identifies when native JSON traversal returns to a parent.
+        // Keep only that ancestor path, including objects returned by toJSON.
+        while (ancestors.length > 0 && ancestors[ancestors.length - 1] !== this) {
+          ancestors.pop();
+          segments.length = expectDefined(pathLengths.pop(), "schema ancestor path length");
+        }
+        const prefixLength = segments.length;
+        if (!isRoot) {
+          if (Array.isArray(this)) {
+            segments.push("[", key, "]");
+          } else {
+            segments.push(".", key);
+          }
+        }
         if (invalidNumber) {
-          nonFiniteNumber.path = entryPath;
+          nonFiniteNumber.path = segments.join("");
+          segments.length = prefixLength;
         } else {
-          paths.set(entry, entryPath);
+          ancestors.push(entry);
+          pathLengths.push(prefixLength);
         }
       }
       isRoot = false;
@@ -90,13 +101,20 @@ const schemaMapKeywords = new Set([
 
 function inspectJsonSchema(
   schema: RuntimeToolInputSchemaJson,
-  path: string,
+  path: (string | number)[],
   violations: string[],
 ): boolean {
   if (Array.isArray(schema)) {
-    return schema.every((entry, index) =>
-      inspectJsonSchema(entry, `${path}[${index}]`, violations),
-    );
+    let index = 0;
+    for (const entry of schema) {
+      path.push("[", index++, "]");
+      const valid = inspectJsonSchema(entry, path, violations);
+      path.length -= 3;
+      if (!valid) {
+        return false;
+      }
+    }
+    return true;
   }
   if (!isJsonObject(schema)) {
     // Raw JSON numeric literals can overflow during parsing without passing
@@ -105,25 +123,35 @@ function inspectJsonSchema(
   }
   for (const key of ["$dynamicRef", "$dynamicAnchor"] as const) {
     if (key in schema) {
-      violations.push(`${path}.${key}`);
+      violations.push(`${path.join("")}.${key}`);
     }
   }
-  for (const [key, value] of Object.entries(schema)) {
+  for (const key of Object.keys(schema)) {
+    const value = schema[key];
     if (typeof value === "number" && !Number.isFinite(value)) {
       return false;
     }
     if (!value || typeof value !== "object") {
       continue;
     }
+    path.push(".", key);
     if (schemaMapKeywords.has(key) && isJsonObject(value)) {
-      for (const [schemaName, childSchema] of Object.entries(value)) {
-        if (!inspectJsonSchema(childSchema, `${path}.${key}.${schemaName}`, violations)) {
+      for (const schemaName of Object.keys(value)) {
+        const childSchema = value[schemaName];
+        if (childSchema === undefined) {
+          return false;
+        }
+        path.push(".", schemaName);
+        const valid = inspectJsonSchema(childSchema, path, violations);
+        path.length -= 2;
+        if (!valid) {
           return false;
         }
       }
-    } else if (!inspectJsonSchema(value, `${path}.${key}`, violations)) {
+    } else if (!inspectJsonSchema(value, path, violations)) {
       return false;
     }
+    path.length -= 2;
   }
   return true;
 }
@@ -140,7 +168,8 @@ export function projectRuntimeToolInputSchema(
   } else if (projection.schema.type !== undefined && projection.schema.type !== "object") {
     violations.push(`${path}.type must be "object"`);
   }
-  if (!inspectJsonSchema(projection.schema, path, violations)) {
+  // Valid schemas need no diagnostic strings; reuse this call's path while walking the JSON copy.
+  if (!inspectJsonSchema(projection.schema, [path], violations)) {
     return { schema: {}, violations: [`${path} is not a JSON value`] };
   }
   return {

--- a/packages/ai/src/utils/credential-redaction.test.ts
+++ b/packages/ai/src/utils/credential-redaction.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from "vitest";
+import { projectDiagnosticValue } from "./credential-redaction.js";
+
+describe("diagnostic descriptor snapshots", () => {
+  it("visits numeric keys before other proxy keys when bounding shared references", () => {
+    const shared = { detail: "safe" };
+    const value = new Proxy(
+      { tail: shared, 2: shared, 1: shared, "01": shared },
+      { ownKeys: () => ["tail", "2", "1", "01"] },
+    );
+
+    expect(JSON.stringify(projectDiagnosticValue(value))).toBe(
+      '{"1":{"detail":"safe"},"2":"[Circular]","tail":"[Circular]","01":"[Circular]"}',
+    );
+  });
+
+  it("captures sibling descriptors before visiting children without invoking getters", () => {
+    const getter = vi.fn(() => "must not be read");
+    const target: Record<string, unknown> = {};
+    target.first = new Proxy(
+      Object.defineProperty({ detail: "safe" }, "hostile", { enumerable: true, get: getter }),
+      {
+        ownKeys(child) {
+          target.later = "changed during child traversal";
+          return Reflect.ownKeys(child);
+        },
+      },
+    );
+    target.later = "captured before child traversal";
+
+    expect(projectDiagnosticValue(target)).toEqual({
+      first: { detail: "safe" },
+      later: "captured before child traversal",
+    });
+    expect(getter).not.toHaveBeenCalled();
+  });
+
+  it("counts symbols toward the field cap before reading a late credential discriminator", () => {
+    const descriptorKeys: PropertyKey[] = [];
+    const keys = [...Array.from({ length: 63 }, () => Symbol("field")), "value", "name"];
+    const value = new Proxy(
+      {},
+      {
+        ownKeys: () => keys,
+        getOwnPropertyDescriptor(_target, key) {
+          descriptorKeys.push(key);
+          return {
+            configurable: true,
+            enumerable: true,
+            value: key === "name" ? "password" : "synthetic-private-value",
+          };
+        },
+      },
+    );
+
+    expect(projectDiagnosticValue(value)).toEqual({ value: "<redacted>" });
+    expect(descriptorKeys).toEqual(["value"]);
+  });
+});

--- a/packages/ai/src/utils/credential-redaction.ts
+++ b/packages/ai/src/utils/credential-redaction.ts
@@ -229,13 +229,19 @@ export function projectDiagnosticValue(
     } catch {
       // Other objects follow the bounded descriptor walk below.
     }
-    const keys = Reflect.ownKeys(value).slice(0, 65);
-    const descriptors = Object.fromEntries(
-      keys.slice(0, 64).flatMap((key) => {
-        const descriptor = typeof key === "string" && Object.getOwnPropertyDescriptor(value, key);
-        return descriptor ? [[key, descriptor]] : [];
-      }),
-    );
+    const keys = Reflect.ownKeys(value);
+    // Snapshot descriptors before recursion; the map restores numeric key order from proxies.
+    const descriptors: PropertyDescriptorMap = Object.create(null);
+    for (let index = 0; index < Math.min(keys.length, 64); index += 1) {
+      const key = keys[index];
+      if (typeof key !== "string") {
+        continue;
+      }
+      const descriptor = Object.getOwnPropertyDescriptor(value, key);
+      if (descriptor) {
+        descriptors[key] = descriptor;
+      }
+    }
     state.changed ||= keys.length > 64;
     seen.add(value);
     const out = (Array.isArray(value) ? [] : {}) as Record<string, unknown>;
@@ -245,7 +251,8 @@ export function projectDiagnosticValue(
       keys.length > 64 ||
       (typeof rawName === "string" && isCredentialFieldName(normalizeDiagnosticFieldName(rawName)));
     const redactMedia = mediaPayload || keys.length > 64 || isDiagnosticMediaPayload(descriptors);
-    for (const [key, descriptor] of Object.entries(descriptors)) {
+    for (const key in descriptors) {
+      const descriptor = expectDefined(descriptors[key], "diagnostic descriptor");
       if (
         !("value" in descriptor) ||
         (!descriptor.enumerable &&

--- a/src/agents/tool-schema-projection.test.ts
+++ b/src/agents/tool-schema-projection.test.ts
@@ -46,26 +46,36 @@ describe("runtime tool input schema projection", () => {
     ]);
   });
 
-  it("reports dynamic JSON Schema keywords", () => {
+  it("reports dynamic JSON Schema keywords in traversal order with exact paths", () => {
     expect(
       projectRuntimeToolInputSchema({
         type: "object",
-        anyOf: [{ $dynamicAnchor: "root" }],
+        $dynamicAnchor: "root",
+        $dynamicRef: "#root",
+        anyOf: [{ $dynamicAnchor: "branch" }, { properties: { "": { $dynamicRef: "#empty" } } }],
         properties: {
           target: { $dynamicRef: "#target" },
+          "literal.dot[0]": { $dynamicAnchor: "literal" },
         },
       }),
     ).toEqual({
       schema: {
         type: "object",
-        anyOf: [{ $dynamicAnchor: "root" }],
+        $dynamicAnchor: "root",
+        $dynamicRef: "#root",
+        anyOf: [{ $dynamicAnchor: "branch" }, { properties: { "": { $dynamicRef: "#empty" } } }],
         properties: {
           target: { $dynamicRef: "#target" },
+          "literal.dot[0]": { $dynamicAnchor: "literal" },
         },
       },
       violations: [
+        "parameters.$dynamicRef",
+        "parameters.$dynamicAnchor",
         "parameters.anyOf[0].$dynamicAnchor",
+        "parameters.anyOf[1].properties..$dynamicRef",
         "parameters.properties.target.$dynamicRef",
+        "parameters.properties.literal.dot[0].$dynamicAnchor",
       ],
     });
   });
@@ -132,6 +142,52 @@ describe("runtime tool input schema projection", () => {
       schema: {},
       violations: ["parameters.properties..maximum is not JSON-serializable"],
     });
+  });
+
+  it("tracks repeated descendants through each toJSON replacement without rereading getters", () => {
+    const reads: string[] = [];
+    let count = 0;
+    const shared = {
+      type: "number",
+      get maximum() {
+        reads.push("maximum");
+        return count++ === 0 ? 1 : Number.POSITIVE_INFINITY;
+      },
+    };
+    const replacement = {
+      toJSON(key: string) {
+        reads.push(key);
+        return { type: "array", items: [shared] };
+      },
+    };
+
+    expect(
+      projectRuntimeToolInputSchema({
+        type: "object",
+        properties: { first: replacement, second: replacement },
+      }),
+    ).toEqual({
+      schema: {},
+      violations: ["parameters.properties.second.items[0].maximum is not JSON-serializable"],
+    });
+    expect(reads).toEqual(["first", "maximum", "second", "maximum"]);
+  });
+
+  it("finishes JSON serialization after an invalid number and preserves later getter failures", () => {
+    let reads = 0;
+    expect(
+      projectRuntimeToolInputSchema({
+        type: "object",
+        properties: {
+          first: { default: Number.NaN },
+          get later() {
+            reads++;
+            throw new Error("unreadable schema");
+          },
+        },
+      }),
+    ).toEqual({ schema: {}, violations: ["parameters is not JSON-serializable"] });
+    expect(reads).toBe(1);
   });
 
   it("reports boxed non-finite numeric schema values", () => {

--- a/src/plugins/plugin-package-metadata-capture.test.ts
+++ b/src/plugins/plugin-package-metadata-capture.test.ts
@@ -1,0 +1,74 @@
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  findPluginCapturedPackage,
+  type PluginPackageCapture,
+} from "./plugin-package-metadata-capture.js";
+
+function capturedPackage(root: string, links: string[] = []): PluginPackageCapture {
+  return {
+    destination: path.resolve(root),
+    capturedRoot: path.resolve(root),
+    sourceRoot: path.resolve(root),
+    links: new Set(links.map((link) => path.resolve(link))),
+    state: "body",
+    materialize() {},
+    captureTarget() {},
+  };
+}
+
+describe("captured package lookup", () => {
+  it.each([
+    { suffix: "", matches: true },
+    { suffix: "/lib/module.js", matches: true },
+    { suffix: "/./lib/../module.js", matches: true },
+    { suffix: "//lib///module.js", matches: true },
+    { suffix: "/../outside/module.js", matches: false },
+    { suffix: "-other/module.js", matches: false },
+    { suffix: "/node_modules", matches: false },
+    { suffix: "/lib/node_modules/dependency/module.js", matches: false },
+    { suffix: "/node_modules-other/module.js", matches: true },
+    { suffix: "/lib/node_modules.js", matches: true },
+    { suffix: "/ümlaut/module.js", matches: true },
+  ])("preserves package containment for '$suffix'", ({ suffix, matches }) => {
+    const owner = capturedPackage("fixture/owner");
+    const filename = owner.capturedRoot + suffix.replaceAll("/", path.sep);
+    expect(findPluginCapturedPackage([owner], filename)).toEqual(
+      matches ? { owner, root: owner.capturedRoot } : undefined,
+    );
+  });
+
+  it("keeps package order and resolves dependency links instead of the enclosing package", () => {
+    const parent = capturedPackage("fixture/owner");
+    const nested = capturedPackage(path.join(parent.capturedRoot, "lib"));
+    const link = path.join(parent.capturedRoot, "node_modules", "@scope", "dependency");
+    const dependency = capturedPackage("fixture/dependency", [link]);
+    const packages = [parent, nested, dependency];
+
+    expect(
+      findPluginCapturedPackage(packages, path.join(nested.capturedRoot, "module.js")),
+    ).toEqual({
+      owner: parent,
+      root: parent.capturedRoot,
+    });
+    expect(findPluginCapturedPackage(packages, path.join(link, "module.js"))).toEqual({
+      owner: dependency,
+      root: link,
+    });
+  });
+
+  it("observes link additions, removals, and package removal on the next lookup", () => {
+    const owner = capturedPackage("fixture/owner");
+    const link = path.resolve("fixture/late-link");
+    const filename = path.join(link, "module.js");
+    const packages = [owner];
+    expect(findPluginCapturedPackage(packages, filename)).toBeUndefined();
+    owner.links.add(link);
+    expect(findPluginCapturedPackage(packages, filename)).toEqual({ owner, root: link });
+    owner.links.delete(link);
+    expect(findPluginCapturedPackage(packages, filename)).toBeUndefined();
+    owner.links.add(link);
+    packages.pop();
+    expect(findPluginCapturedPackage(packages, filename)).toBeUndefined();
+  });
+});

--- a/src/plugins/plugin-package-metadata-capture.ts
+++ b/src/plugins/plugin-package-metadata-capture.ts
@@ -406,8 +406,10 @@ function visitPluginPackageTargetFiles(params: {
 type PluginPackageCaptureState = "metadata" | "entry" | "body" | { error: unknown };
 export type PluginPackageCapture = {
   destination: string;
-  capturedRoot: string;
+  /** Absolute normalized root captured by the artifact producer. */
+  readonly capturedRoot: string;
   sourceRoot: string;
+  /** Absolute normalized dependency links; additions remain visible to lookups. */
   links: Set<string>;
   state: PluginPackageCaptureState;
   materialize(entry?: string): void;
@@ -417,17 +419,34 @@ export type PluginPackageCapture = {
 export const isPluginPackageFile = (root: string, file: string) =>
   isPathInside(root, file) && !path.relative(root, file).split(path.sep).includes("node_modules");
 
+function isCapturedPackageFile(root: string, file: string): boolean {
+  if (process.platform === "win32") {
+    return isPluginPackageFile(root, file);
+  }
+  if (file === root) {
+    return true;
+  }
+  if (!file.startsWith(root) || (!root.endsWith("/") && file.charCodeAt(root.length) !== 47)) {
+    return false;
+  }
+  return !/(?:^|\/)node_modules(?:\/|$)/u.test(file.slice(root.length));
+}
+
 /** Retain the matched lookup root; dependency links need their own source-relative mapping. */
 export function findPluginCapturedPackage(
   packages: Iterable<PluginPackageCapture>,
   filename: string,
 ) {
+  // The artifact producer already normalizes captured roots and dependency links.
+  const file = process.platform === "win32" ? filename : path.resolve(filename);
   for (const owner of packages) {
-    const root = [owner.capturedRoot, ...owner.links].find((candidate) =>
-      isPluginPackageFile(candidate, filename),
-    );
-    if (root) {
-      return { owner, root };
+    if (isCapturedPackageFile(owner.capturedRoot, file)) {
+      return { owner, root: owner.capturedRoot };
+    }
+    for (const root of owner.links) {
+      if (isCapturedPackageFile(root, file)) {
+        return { owner, root };
+      }
     }
   }
   return undefined;


### PR DESCRIPTION
Related: #146006

<details>
<summary>Additional instructions</summary>

This is maintainer-requested follow-up to busy-Gateway allocation profiling. The branch is in openclaw/openclaw and directly editable by repository maintainers.

</details>

## What Problem This Solves

Resolves a problem where busy Gateways spend excessive allocation and garbage-collection work repeatedly preparing tool schemas, projecting diagnostic values, and resolving captured plugin package paths for parallel agent turns.

## Why This Change Was Made

Four bounded changes retain the existing owners and outputs:

- Schema inspection reuses a traversal path and formats diagnostic strings only when reporting a violation.
- Schema JSON serialization follows the native replacer holder with an ancestor stack instead of allocating a path string for every object.
- Diagnostic projection captures descriptors before recursion in one bounded map, avoiding intermediate slices and entry tuples while retaining numeric-key order and getter behavior.
- Captured package lookup normalizes the requested POSIX path once and uses the producer's normalized roots directly. It preserves package/link precedence, containment and node_modules exclusions, live link additions, and the existing Windows path implementation.

## User Impact

Lower temporary allocation overhead in agent tool preparation, diagnostic processing, and plugin package lookup, with no configuration, provider API, or redaction-policy changes. Microbenchmarks do not establish whole-Gateway RSS or throughput improvements.

## Evidence

- **379 focused cases passed** across schema projection/Responses normalization, credential and payload projection, provider errors, captured package lookup, and plugin-generation artifact behavior. Core/test TypeScript, boundary and changed-scope checks passed.
- Independent P0–P2 reviews found no actionable defects in either runtime commit.
- Three alternating isolated pairs measured the following sampled allocation reductions, including garbage-collected objects:

| Operation | Work per process | Sampled allocation reduction |
| --- | --- | --- |
| Schema inspection | 24,000 projections | 40.2% |
| Schema serialization, after the inspection pass | 24,000 projections | 29.2% additional |
| Diagnostic projection | 10,000 iterations | 25.6% |
| Captured package lookup on POSIX | 10,000 lookups, 5,000 matches | 99.5% |

The schema outputs and source inputs were unchanged; diagnostic checksums and lookup match counts agree. These isolated percentages are not additive. The captured-path measurements overlapped another build, so timing is directional and is not claimed here.

### Controlled Gateway workload

These pairs use common runtime base `ef87d8fd780822f124befb9900a8da2e6ed5c5f2` and fixed-work benchmark `2194c1c61f23d69ebf83098f8bbbcd5660fb757f`; the controlled candidate is `bcd9b70c187` with these runtime changes. **They do not measure fresh publication head `46e73780bb8f4bf2caa3f8c9faae409733231147`, which includes other intervening Gateway changes.** All six final file blobs and the combined patch ID were verified identical across that publication bridge.

Every run completed **512 turns across 64 parallel sessions, 100 sampler rounds, 2,000 history requests, and 1,024 session updates**, with zero failed tasks/probes and clean Gateway exit. The prescribed workload is identical; actual mock model request counts vary and are reported below. Both sides used the same task-local aggregate memory observer.

| Observation, baseline → candidate | Profiling off, primary comparison | Heap sampling on, supplementary comparison |
| --- | ---: | ---: |
| Main-isolate V8 allocation counter, bytes | 84,948,660,800 → 81,080,235,592 (**−4.55%**) | 85,477,829,056 → 80,403,510,720 (**−5.94%**) |
| Sampled allocation estimate, bytes | Not sampled | 82,202,347,184 → 77,528,388,936 (**−5.69%**) |
| Mock model requests | 2,834 → 2,843 (+9) | 2,902 → 2,821 (−81) |
| Joined workload, seconds | 135.360 → 131.967 | 154.604 → 140.423 |
| Session-list p95, milliseconds | 1,321.944 → 1,355.155 | 1,433.753 → 1,515.636 |
| Sampled peak RSS, MiB | 2,690.766 → 2,645.938 | 2,745.938 → 2,726.031 |

The primary pair supports lower observed main-isolate allocations under the fixed workload. Counters include bounded observer work and are neither retained memory nor process-wide allocation totals. RSS observations are mixed: the primary endpoint RSS increased **98.203 MiB**, while RSS after main-isolate GC decreased **16.907 MiB**. Session-list p95 increased in both pairs. Part of the sampled candidate overlapped another local build. **No RSS, latency, or throughput improvement is claimed**, and one pair per mode does not isolate allocator causality or establish a statistical speedup. Peak RSS is sampled during probe rounds and at the endpoint, so intervening peaks can be missed.

Public benchmark workload flags (the paired measurements additionally used the unchanged task-local aggregate observer):

```bash
node scripts/bench-gateway-concurrency.ts \
  --concurrency 64 --turns-per-session 8 --session-count 512 \
  --subscribers 32 --visible-observer --tool-events --control-plane \
  --history-clients 4 --history-burst 5 --history-messages 8 \
  --session-updates 1024 --probe-rounds 100 --cadence-ms 1000 \
  --timeout-ms 600000 --output .artifacts/gateway-comparison.json
```

The controlled candidate build passed in **198 seconds**. Its OpenAI plugin entry profile passed at **109.06 MiB max RSS**. The 379 focused tests, complete changed checks, and independent reviews remain passing; [publication-head CI is green](https://github.com/openclaw/openclaw/actions/runs/34700077701).

### Final publication-head validation

The [Testbox runner](https://github.com/openclaw/openclaw/actions/runs/34701608689) executed a separately fetched checkout of **`46e73780bb8f4bf2caa3f8c9faae409733231147`**, tree **`714045d42b04970685d5b4b0122351d2e23cd96a`**, using **Node 24.19.0 on Linux x64**. The build and owned package-resolution checks passed: AI loaded from this checkout's `packages/ai/dist`, the normalization package's runtime self-reference resolved locally, and its source alias resolved to this checkout's source. The earlier candidate was only a transport carrier, not the tested checkout.

- **Fixed Gateway workload passed:** 512 completed turns, 100 sampler rounds, 2,000 history requests, 1,024 session updates, and 2,844 model requests; zero failed probes and clean Gateway exit. This is functional/load proof of the fresh publication head, not a before/after performance comparison.
- **Live OpenAI proof passed:** `gpt-5.6-luna` completed **256/256 tasks across 64 parallel sessions and four waves** in **118.74 seconds**, with 171 control probes, zero task/probe failures, and 1,796 `session.tool` events. Synthetic CSV hashes, parsed and output totals, input preservation, and exact final assistant markers were verified for every task. The Gateway exited cleanly, its process group exited, and isolated state was removed. Live-provider timing is not a deterministic throughput claim.
- The first proof attempt stopped on our ownership harness incorrectly resolving a package-scoped alias from the root. The guard was corrected and the remaining checks resumed on the same build and lease, without product/source changes or a rebuild.

The custom proof command completed with exit 0, and the three captured artifacts were independently verified against these SHA-256 hashes. The Actions URL identifies the runner/hydration workflow; lease cleanup can cancel that surrounding workflow and does not change the completed custom command or captures. Only aggregate outcomes and hashes are shared here, without credentials or transcripts.

| Captured artifact | SHA-256 |
| --- | --- |
| `identity.json` | `8ce1f82c2b4983cb2edce230a62980ce3a5b9bb50f1f7b85bfffc73c895108ff` |
| `macro.json` | `916cf682c134fe199f34f470e2d9fcb26a37e40b51253dca2abd1fe61178cd25` |
| `live.json` | `d803f4aee1cc3cdeed124bda24eddfe6eb87476c4a2f5eed73b5a64d6749255d` |


