### PR TITLE
docs: explain model-specific thinking defaults

### DIFF
--- a/docs/tools/thinking.md
+++ b/docs/tools/thinking.md
@@ -45,8 +45,40 @@ title: "Thinking levels"
 1. Inline directive on the message (applies only to that message).
 2. Session override (set by sending a directive-only message).
 3. Per-agent default (`agents.entries.*.thinkingDefault` in config).
-4. Global default (`agents.defaults.thinkingDefault` in config).
-5. Fallback: provider-declared default when available; otherwise reasoning-capable models resolve to `medium` or the nearest supported non-`off` level for that model, and non-reasoning models stay `off`.
+4. Per-model default (`agents.defaults.models["<provider>/<model>"].params.thinking` in config).
+5. Global default (`agents.defaults.thinkingDefault` in config).
+6. Fallback: provider-declared default when available; otherwise reasoning-capable models resolve to `medium` or the nearest supported non-`off` level for that model, and non-reasoning models stay `off`.
+
+## Setting a model default
+
+Use `params.thinking` to set the default for one configured model without changing
+the default for your other models. The key must match the provider and model you
+actually select, including any model path exposed by a custom provider.
+
+For example, if your configured `opencodex-chat` provider exposes
+`devin/swe-2-high`, merge this entry into your existing model configuration:
+
+```json5
+{
+  agents: {
+    defaults: {
+      models: {
+        "opencodex-chat/devin/swe-2-high": {
+          params: { thinking: "high" },
+        },
+      },
+    },
+  },
+}
+```
+
+This example assumes that you have already configured the custom provider and
+that its endpoint supports the selected effort. A model name alone does not
+configure a provider or guarantee how the upstream service handles reasoning.
+
+An inline directive, a saved session override, or a per-agent `thinkingDefault`
+still takes precedence. Send `/think default` to clear a saved session override;
+check the per-agent setting if the model default still does not take effect.
 
 ## Setting a session default
 


### PR DESCRIPTION
Closes #146028

## What Problem This Solves

The thinking guide omits per-model defaults from its resolution order. Users may change the global default or mistake a saved session or agent override for a provider failure.

## Why This Change Was Made

Document `agents.defaults.models["<provider>/<model>"].params.thinking` between per-agent and global defaults. Add a provider-neutral configuration example and explain how to clear a session override.

## User Impact

Users can set a model's thinking default independently of other models. The example requires a configured provider and a model that supports the selected level. Runtime behavior is unchanged.

## Evidence

- Compared the precedence, model-key handling, and session-reset guidance with the current implementation and existing tests.
- Verified direct per-model defaults on a self-hosted OpenClaw 2026.9.4 Gateway: Astra low, Sol medium, Luna xhigh, and Grok high, without per-run thinking overrides. See the [verification comment](https://github.com/openclaw/openclaw/pull/146040#issuecomment-5652163659).
- Automatic fallback and override/reset execution were not covered by those live probes.
