### PR TITLE
fix(gateway): build boot echo indexes only when needed

### DIFF
--- a/src/gateway/boot-echo-guard.ts
+++ b/src/gateway/boot-echo-guard.ts
@@ -57,9 +57,6 @@ export function setBootEchoContextForSession(sessionKey: string, bootPrompt: str
     return;
   }
   const normalizedBootPrompt = normalizeEchoComparisonText(bootPrompt);
-  if (normalizedBootPrompt.length >= MIN_ECHO_CHARS) {
-    getBootPromptChunks(normalizedBootPrompt, MIN_ECHO_CHARS);
-  }
   bootContextBySessionKey.set(sessionKey, { bootPrompt, normalizedBootPrompt });
 }
 
@@ -94,8 +91,11 @@ function containsSubstantialBootEcho(
   minLen: number = MIN_ECHO_CHARS,
 ): boolean {
   const haystack = normalizeEchoComparisonText(outboundText ?? "");
+  if (haystack.length < minLen) {
+    return false;
+  }
   const needle = normalizeEchoComparisonText(bootPrompt ?? "");
-  if (haystack.length < minLen || needle.length < minLen) {
+  if (needle.length < minLen) {
     return false;
   }
   const bootChunks = getBootPromptChunks(needle, minLen);


### PR DESCRIPTION
## What Problem This Solves

Starting a BOOT.md run eagerly materializes every overlapping 80-character comparison window, even when the run sends nothing or only a short greeting. Large boot prompts can therefore retain much more comparison data than their original text throughout the run.

## Why This Change Was Made

Build the existing echo comparison indexes when an outbound message is long enough to need them. Short outbound messages also return before normalizing the boot prompt. The same comparison owner, Unicode-safe windows, suppression rules, prompt bytes, and cleanup remain in use.

## User Impact

Concurrent boot checks that send short status messages use less memory and allocate less temporary data. Substantial boot-content echoes continue to be suppressed before delivery.

## Evidence

- All 294 existing tests pass across boot registration/cleanup, echo comparison, and the full message-tool suite, including the actual boot-to-message-tool Unicode delivery and suppression flow.
- A same-host workload with 100 active synthetic boot contexts, 38,289-character prompts, and short greetings reduced sampled allocations from 872,735,120 to 59,843,984 bytes (93.1%). Post-GC retained heap above the pre-registration level fell from 507,024,456 to 3,903,472 bytes (99.23%). Clearing the contexts returned both versions near the original heap level; this fixes unnecessary live comparison storage, not a post-cleanup leak.
- Independent P0-P2 review found no actionable findings. Required changed checks remain pending; the shared Linux validation host exhausted memory before this candidate was scheduled.


Exact-head [CI run 34700149881](https://github.com/openclaw/openclaw/actions/runs/34700149881) passed on b3f6244eec931d97ea4e95f7e5b884c88849fb98, supplying the required validation left pending by the local host failure.
