### PR TITLE
improve: speed up source build configuration loading

### DIFF
--- a/scripts/lib/bundled-plugin-build-entries.mjs
+++ b/scripts/lib/bundled-plugin-build-entries.mjs
@@ -286,13 +286,24 @@ function collectBundledPluginCandidates(cwd, extensionsRoot) {
     .toSorted((left, right) => left.dirName.localeCompare(right.dirName));
 }
 
+/** Share raw source discovery within one config evaluation; policy reads stay independent. */
+export function createBundledPluginBuildInventory(cwd = process.cwd()) {
+  let candidates;
+  return {
+    cwd,
+    getCandidates: () =>
+      (candidates ??= collectBundledPluginCandidates(cwd, path.join(cwd, BUNDLED_PLUGIN_ROOT_DIR))),
+  };
+}
+
 /** Collect all bundled plugin build entries for the current checkout. */
 export function collectBundledPluginBuildEntries(params = {}) {
   const cwd = params.cwd ?? process.cwd();
   const env = params.env ?? process.env;
   const extensionsRoot = path.join(cwd, BUNDLED_PLUGIN_ROOT_DIR);
   const dockerSelectedBuildIds = parseDockerSelectedPluginBuildIdFilter(env);
-  const candidates = collectBundledPluginCandidates(cwd, extensionsRoot);
+  const candidates =
+    params.getCandidates?.() ?? collectBundledPluginCandidates(cwd, extensionsRoot);
   const entries = [];
 
   for (const candidate of candidates) {
@@ -406,10 +417,10 @@ export function collectSourceCheckoutPluginBuildEntries(params = {}) {
 export function collectChannelConfigDoctorBuildEntries(params = {}) {
   const cwd = params.cwd ?? process.cwd();
   const entries = {};
-  for (const { pluginDir } of collectBundledPluginCandidates(
-    cwd,
-    path.join(cwd, BUNDLED_PLUGIN_ROOT_DIR),
-  )) {
+  const candidates =
+    params.getCandidates?.() ??
+    collectBundledPluginCandidates(cwd, path.join(cwd, BUNDLED_PLUGIN_ROOT_DIR));
+  for (const { pluginDir } of candidates) {
     const manifestPath = path.join(pluginDir, "openclaw.plugin.json");
     if (!fs.existsSync(manifestPath)) {
       continue;

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -8,6 +8,7 @@ import {
   collectChannelConfigDoctorBuildEntries,
   collectPluginDeclarationSourceEntries,
   collectSourceCheckoutPluginBuildEntries,
+  createBundledPluginBuildInventory,
 } from "./scripts/lib/bundled-plugin-build-entries.mjs";
 import { createGatewayRunChunkMetadataPlugin } from "./scripts/lib/gateway-run-chunk-metadata.mts";
 import { createManagedHandoffBuildConfig } from "./scripts/lib/managed-handoff-build-config.mts";
@@ -278,7 +279,8 @@ function nodeWorkspacePackageBuildConfig(packageDir: string, config: UserConfig 
   };
 }
 
-const bundledPluginBuildEntries = collectBundledPluginBuildEntries();
+const bundledPluginBuildInventory = createBundledPluginBuildInventory();
+const bundledPluginBuildEntries = collectBundledPluginBuildEntries(bundledPluginBuildInventory);
 const shouldBuildPrivateQaEntries = process.env.OPENCLAW_BUILD_PRIVATE_QA === "1";
 const selectedPluginSdkEntrypoints = shouldBuildPrivateQaEntries
   ? pluginSdkEntrypoints
@@ -591,9 +593,9 @@ function shouldExternalizeTerminalCoreDependency(id: string): boolean {
 
 const coreDistEntries = buildCoreDistEntries();
 const dockerE2eHarnessEntries = buildDockerE2eHarnessEntries();
-const rootBundledPluginBuildEntries = collectSourceCheckoutPluginBuildEntries().filter(
-  ({ isolated }) => !isolated,
-);
+const rootBundledPluginBuildEntries = collectSourceCheckoutPluginBuildEntries(
+  bundledPluginBuildInventory,
+).filter(({ isolated }) => !isolated);
 const bundledInventoryEntries = rootBundledPluginBuildEntries.flatMap((plugin) => {
   const sourceEntries = plugin.sourceEntries.filter(
     (source) =>
@@ -909,7 +911,7 @@ const configs: UserConfig[] = [
       name: TSDOWN_UNIFIED_CONFIG_GROUP,
       // Keep retained config repairs in their own graph: shared public SDK chunks
       // otherwise pull state-migration exports into these pre-install artifacts.
-      entry: collectChannelConfigDoctorBuildEntries(),
+      entry: collectChannelConfigDoctorBuildEntries(bundledPluginBuildInventory),
       outDir: "dist/config-doctor",
       deps: unifiedDeps,
     },


### PR DESCRIPTION
## What Problem This Solves

Source builds spend unnecessary time loading their configuration before compilation begins, especially as the bundled plugin source tree grows.

## Why This Change Was Made

Share one lazily discovered raw plugin inventory across the three selectors in a single tsdown configuration evaluation. Each selector still reads its own manifests and applies its existing policy; standalone selector calls and new configuration evaluations retain fresh discovery. This adds 13 source lines after formatting and does not introduce a process-global cache.

## User Impact

Developers get faster source-build configuration loading. Plugin selection, optional/private QA and Docker policies, retained config-only Doctor entries, and their validation errors stay unchanged. The installed updater, runtime plugin loading, operator state, and migration behavior are not changed.

The measured benefit is configuration loading, not compilation, full-build duration, Gateway latency, or memory reduction.

## Evidence

A bounded Linux/Node 24.19.0 run at base `c6739ac24924ff018e1ff892a69fbad5d47ab72e` measured actual configuration loading in default and Docker-selected modes:

| Mode / paired order | Baseline → candidate warm median | Wall change | CPU change |
| --- | ---: | ---: | ---: |
| Default / forward | 145.568 → 76.418 ms | -47.50% | -41.51% |
| Default / reverse | 106.697 → 59.834 ms | -43.92% | -34.20% |
| Docker / forward | 103.291 → 58.804 ms | -43.07% | -32.33% |
| Docker / reverse | 100.223 → 59.563 ms | -40.57% | -27.01% |

Each mode used fresh baseline/candidate/candidate/baseline processes, with an initial load, warmup, and two measured loads per process. All 32 complete load graphs and timings were retained; this small, fixed sample is descriptive. Configuration/entry/reference/descriptor structure matched exactly. The same 26 dependency filenames matched as multisets, preserving duplicates and raw producer ordering in the evidence.

A separate forwarding observer found Git inventory calls fell from 3 to 1 and extension existence checks from 30,793 to 10,379 (20,414 fewer). Manifest reads remained 692 in both versions. Six policy/freshness/error processes passed, including manifest changes with shared raw facts, new-inventory source discovery, fresh standalone calls, Docker validation, and retained Doctor entry checks. The [measurement run](https://github.com/openclaw/openclaw/actions/runs/34699600090) completed with all 22 native children closed and no resource-limit violations.

The default-forward pair increased kernel peak RSS by 2.32% and observed process-tree peak RSS by 0.48%; the other RSS pairs were lower. There is no memory-improvement claim. The measured patch has 12 added net lines; the reviewed patch differs only by one formatter line wrap.

An earlier baseline-only experiment failed an order-sensitive dependency-list oracle before candidate or measured-section samples existed. After checking the loader contract, the corrected oracle compares dependency filename multisets while preserving raw order and all other exact graph checks. The failed run remains preserved and is not counted as passing evidence.

Local validation on Node 26.8.2: all 60 tests passed across `bundled-plugin-build-entries.test.ts` (34) and `tsdown-config.test.ts` (26), all 24 selected smaller guards passed, and one full `pnpm build` passed within its fixed limits. The initial test attempt passed 58/60 because its temporary directory was inside a Git checkout, contaminating two intended no-Git fixtures; moving only task-owned temporary state outside Git made the unchanged complete run pass. Both attempts are retained. Independent Codex P2 review is scoped-clean; an initial report-output directory failure was corrected before the completed unchanged review.

Exact-head CI now covers the complete `tsgo:all` program union and all Oxlint groups. Those broad checks did not run locally. UI translation verification and Stylelint, which are additional parts of the literal `pnpm lint` command, were not run and are intentionally outside the scope of these two build-discovery files, matching CI selection. This is not a claim that the literal full lint command passed. No published-driver update matrix was run; this change does not alter updater or runtime contracts. Full-build success is validation, not an end-to-end speed comparison.
