### PR TITLE
fix(plugins): reduce argument restoration allocations

### DIFF
--- a/src/plugins/plugin-instance-value-views.ts
+++ b/src/plugins/plugin-instance-value-views.ts
@@ -199,7 +199,7 @@ function restorePluginArgumentViews(
   args: unknown[],
   originals: WeakMap<object, object>,
 ): unknown[] {
-  const nodes = new Map<object, { parents: Set<object>; descriptors?: PropertyDescriptorMap }>();
+  const nodes = new Map<object, { parents?: object[]; original?: object }>();
   const replacements = new Map<object, object>();
   const visit = (value: unknown, parent?: object) => {
     if (!value || typeof value !== "object") {
@@ -229,38 +229,38 @@ function restorePluginArgumentViews(
           return;
         }
       }
-      const descriptors: PropertyDescriptorMap | undefined = original
-        ? undefined
-        : Object.getOwnPropertyDescriptors(value);
       // Caller methods and accessors can depend on this exact object's identity.
       // Keep their containers opaque instead of cloning them to restore a nested handle.
-      if (
-        descriptors &&
-        Reflect.ownKeys(descriptors).some((key) => {
-          const descriptor = descriptors[key]!;
-          return !("value" in descriptor) || typeof descriptor.value === "function";
-        })
-      ) {
-        return;
+      let children: object[] | undefined;
+      if (!original) {
+        for (const key of Reflect.ownKeys(value)) {
+          const descriptor = Object.getOwnPropertyDescriptor(value, key)!;
+          if (!("value" in descriptor) || typeof descriptor.value === "function") {
+            return;
+          }
+          if (descriptor.value && typeof descriptor.value === "object") {
+            (children ??= []).push(descriptor.value);
+          }
+        }
       }
-      node = { parents: new Set(), descriptors };
+      node = { original };
       nodes.set(value, node);
       if (original) {
         replacements.set(value, original);
-      } else {
-        for (const key of Reflect.ownKeys(descriptors!)) {
-          visit(descriptors![key]!.value, value);
+      } else if (children) {
+        for (const child of children) {
+          visit(child, value);
         }
       }
     }
     if (parent) {
-      node.parents.add(parent);
+      (node.parents ??= []).push(parent);
     }
   };
   args.forEach((value) => visit(value));
   // Copy only changed ancestors; visiting all parents also preserves cycles and shared children.
   for (const value of replacements.keys()) {
-    for (const parent of nodes.get(value)!.parents) {
+    for (const parent of nodes.get(value)!.parents ?? []) {
       if (!replacements.has(parent)) {
         replacements.set(
           parent,
@@ -270,8 +270,9 @@ function restorePluginArgumentViews(
     }
   }
   for (const [value, replacement] of replacements) {
-    const descriptors = nodes.get(value)!.descriptors;
-    if (descriptors) {
+    if (!nodes.get(value)!.original) {
+      // Descriptor copies are needed only for ancestors whose nested views changed.
+      const descriptors = Object.getOwnPropertyDescriptors(value);
       for (const key of Reflect.ownKeys(descriptors)) {
         const descriptor = descriptors[key]!;
         descriptor.value = replacements.get(descriptor.value) ?? descriptor.value;


### PR DESCRIPTION
## What Problem This Solves

Plugin calls allocate a descriptor map and parent sets for every ordinary argument container, even when no wrapped handle needs to be restored. Large nested contexts amplify this temporary allocation.

## Why This Change Was Made

The existing restoration owner now collects child values and parent links as needed, and copies property descriptors only for ancestors whose nested handles actually change. Scanning remains synchronous and does not invoke caller getters. Same-instance handles, foreign views, native receivers, cycles, shared values and opaque callback containers keep their existing behavior.

## User Impact

Repeated plugin calls allocate less temporary memory while preserving caller data and handle identity. Admission, lifecycle, persistence and public API contracts are unchanged.

## Evidence

Actual `PluginInstance.wrap` call profiling produced matching checksums and identity checks:

- 30,000 read-shaped calls: 161.81 MB → 134.61 MB sampled allocations (-16.8%).
- 3,000 nested-context calls: 1,105.20 MB → 675.68 MB (-38.9%).
- 10,000 cyclic owned-handle calls: 88.48 MB → 81.39 MB (-8.0%).

All 266 existing tests across callback, reflection, constructor, iterator and instance suites pass on both baseline and candidate. Independent P0-P2 review found no actionable findings. These measurements establish allocation reductions in the exercised call shapes; they do not establish retained-memory or whole-Gateway savings. The required changed gate passed initial checks, formatting and plugin boundaries, then was stopped during wrapper-shadowing checks to relieve shared-host memory pressure. Remaining required checks need exact-head hosted CI; combined live proof is pending.
