### PR TITLE
fix(linux): retire sleep guards when logind disconnects

### DIFF
--- a/apps/linux/src-tauri/src/gateway_sleep.rs
+++ b/apps/linux/src-tauri/src/gateway_sleep.rs
@@ -32,8 +32,10 @@ struct HeldSuspension {
 struct CycleState {
     suspension: Option<HeldSuspension>,
     generation: u64,
+    abandoned: bool,
 }
 
+#[derive(Clone)]
 pub(crate) struct GatewaySleepCycleController {
     request_id: String,
     current_route: Arc<dyn Fn() -> Option<GatewaySleepRoute> + Send + Sync>,
@@ -42,7 +44,7 @@ pub(crate) struct GatewaySleepCycleController {
     refresh: Arc<dyn Fn() -> RefreshFuture + Send + Sync>,
     retry_delay: Arc<dyn Fn(Duration) -> DelayFuture + Send + Sync>,
     log: Arc<dyn Fn(String) + Send + Sync>,
-    state: Mutex<CycleState>,
+    state: Arc<Mutex<CycleState>>,
 }
 
 impl GatewaySleepCycleController {
@@ -75,87 +77,129 @@ impl GatewaySleepCycleController {
             refresh: Arc::new(move || Box::pin(refresh())),
             retry_delay: Arc::new(move |delay| Box::pin(retry_delay(delay))),
             log: Arc::new(log),
-            state: Mutex::new(CycleState::default()),
+            state: Arc::new(Mutex::new(CycleState::default())),
         }
     }
 
-    pub(crate) async fn will_sleep(&self) {
+    pub(crate) fn will_sleep(&self) -> (Option<u64>, impl Future<Output = ()> + '_) {
         // The production route closure exposes only locally owned loopback gateways.
-        let Some(route) = (self.current_route)() else {
-            return;
-        };
+        let route = (self.current_route)();
+        // Return this preparation's identity before it can suspend, so its guard
+        // never guesses a generation from state that another cycle may have changed.
         let generation = {
             let mut state = self
                 .state
                 .lock()
                 .expect("gateway sleep state mutex poisoned");
-            state.generation = state.generation.wrapping_add(1);
-            state.generation
+            if state.abandoned || route.is_none() {
+                None
+            } else {
+                state.generation = state.generation.wrapping_add(1);
+                Some(state.generation)
+            }
         };
-        match (self.prepare)(self.request_id.clone(), route.clone()).await {
-            Ok(SleepPrepareOutcome::Ready { suspension_id }) => {
-                if (self.current_route)().as_ref() != Some(&route) {
-                    self.log_route_changed();
+        (generation, async move {
+            let (Some(route), Some(generation)) = (route, generation) else {
+                return;
+            };
+            match (self.prepare)(self.request_id.clone(), route.clone()).await {
+                Ok(SleepPrepareOutcome::Ready { suspension_id }) => {
+                    if (self.current_route)().as_ref() != Some(&route) {
+                        self.log_route_changed();
+                        return;
+                    }
+                    let late = {
+                        let mut state = self
+                            .state
+                            .lock()
+                            .expect("gateway sleep state mutex poisoned");
+                        // Terminal loss is not a wake, even if prepare completed late.
+                        if state.abandoned {
+                            return;
+                        }
+                        if generation == state.generation {
+                            state.suspension = Some(HeldSuspension {
+                                id: suspension_id.clone(),
+                                route: route.clone(),
+                            });
+                            false
+                        } else {
+                            true
+                        }
+                    };
+                    if late {
+                        // Wake or a newer cycle won the race; do not leave the late lease active.
+                        if let Err(error) = (self.resume)(suspension_id, route).await {
+                            (self.log)(format!("gateway sleep preparation failed: {error}"));
+                        }
+                    }
+                }
+                Ok(SleepPrepareOutcome::Busy) => {
+                    (self.log)(
+                        "gateway sleep preparation skipped because the gateway is busy".into(),
+                    );
+                }
+                Err(error) => {
+                    (self.log)(format!("gateway sleep preparation failed: {error}"));
+                }
+            }
+        })
+    }
+
+    pub(crate) fn did_wake(&self) -> impl Future<Output = ()> + Send + 'static {
+        // Bind at the real wake signal, not when a spawned task eventually polls.
+        let observed_generation = self
+            .state
+            .lock()
+            .expect("gateway sleep state mutex poisoned")
+            .generation;
+        let controller = self.clone();
+        async move {
+            // Clear only the observed cycle. A newer sleep owns its own lease.
+            let (suspension, generation) = {
+                let mut state = controller
+                    .state
+                    .lock()
+                    .expect("gateway sleep state mutex poisoned");
+                if state.abandoned || state.generation != observed_generation {
                     return;
                 }
-                let late = {
-                    let mut state = self
-                        .state
-                        .lock()
-                        .expect("gateway sleep state mutex poisoned");
-                    if generation == state.generation {
-                        state.suspension = Some(HeldSuspension {
-                            id: suspension_id.clone(),
-                            route: route.clone(),
-                        });
-                        false
-                    } else {
-                        true
-                    }
-                };
-                if late {
-                    // Wake or a newer cycle won the race; do not leave the late lease active.
-                    if let Err(error) = (self.resume)(suspension_id, route).await {
-                        (self.log)(format!("gateway sleep preparation failed: {error}"));
-                    }
+                let suspension = state.suspension.take();
+                state.generation = state.generation.wrapping_add(1);
+                (suspension, state.generation)
+            };
+            if (controller.current_route)().is_none() {
+                if suspension.is_some() {
+                    controller.log_route_changed();
                 }
+                return;
             }
-            Ok(SleepPrepareOutcome::Busy) => {
-                (self.log)("gateway sleep preparation skipped because the gateway is busy".into());
-            }
-            Err(error) => {
-                (self.log)(format!("gateway sleep preparation failed: {error}"));
+
+            // The pre-sleep transport is normally dead; reconnect before attempting resume.
+            (controller.refresh)().await;
+            if let Some(suspension) = suspension {
+                if (controller.current_route)().as_ref() == Some(&suspension.route) {
+                    controller.resume_with_retries(suspension, generation).await;
+                } else {
+                    controller.log_route_changed();
+                }
             }
         }
     }
 
-    pub(crate) async fn did_wake(&self) {
-        // Clear first so a second wake or failed resume cannot reuse this cycle's lease.
-        let (suspension, generation) = {
-            let mut state = self
-                .state
-                .lock()
-                .expect("gateway sleep state mutex poisoned");
-            let suspension = state.suspension.take();
-            state.generation = state.generation.wrapping_add(1);
-            (suspension, state.generation)
-        };
-        if (self.current_route)().is_none() {
-            if suspension.is_some() {
-                self.log_route_changed();
-            }
+    pub(crate) fn abandon(&self, generation: u64) {
+        // Losing a still-sleeping cycle retires this listener's controller;
+        // a guard already transferred to real wake recovery must not call this.
+        let mut state = self
+            .state
+            .lock()
+            .expect("gateway sleep state mutex poisoned");
+        if state.generation != generation {
             return;
         }
-
-        // The pre-sleep transport is normally dead; reconnect before attempting resume.
-        (self.refresh)().await;
-        if let Some(suspension) = suspension {
-            if (self.current_route)().as_ref() == Some(&suspension.route) {
-                self.resume_with_retries(suspension, generation).await;
-            } else {
-                self.log_route_changed();
-            }
-        }
+        state.abandoned = true;
+        state.suspension = None;
+        state.generation = state.generation.wrapping_add(1);
     }
 
     fn log_route_changed(&self) {
@@ -258,7 +302,7 @@ mod tests {
             |_| {},
         );
 
-        controller.will_sleep().await;
+        controller.will_sleep().1.await;
         controller.did_wake().await;
         controller.did_wake().await;
 
@@ -294,7 +338,7 @@ mod tests {
             move |message| recorded_logs.lock().unwrap().push(message),
         );
 
-        controller.will_sleep().await;
+        controller.will_sleep().1.await;
         controller.did_wake().await;
 
         assert_eq!(resumes.load(Ordering::SeqCst), 0);
@@ -330,7 +374,7 @@ mod tests {
             move |message| recorded_logs.lock().unwrap().push(message),
         );
 
-        controller.will_sleep().await;
+        controller.will_sleep().1.await;
         controller.did_wake().await;
 
         assert_eq!(resumes.load(Ordering::SeqCst), 0);
@@ -370,7 +414,7 @@ mod tests {
             move |message| recorded_logs.lock().unwrap().push(message),
         );
 
-        controller.will_sleep().await;
+        controller.will_sleep().1.await;
         *route.lock().unwrap() = Some(local_route("ws://127.0.0.1:19001", 2));
         controller.did_wake().await;
 
@@ -411,7 +455,7 @@ mod tests {
             move |message| recorded_logs.lock().unwrap().push(message),
         );
 
-        controller.will_sleep().await;
+        controller.will_sleep().1.await;
         *route.lock().unwrap() = None;
         controller.did_wake().await;
         *route.lock().unwrap() = Some(local_route("ws://127.0.0.1:18789", 3));
@@ -423,12 +467,13 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn late_prepare_response_resumes_only_on_its_original_route() {
-        for (replacement, unchanged) in [
-            (Some(local_route("ws://127.0.0.1:18789", 1)), true),
-            (Some(local_route("ws://127.0.0.1:19001", 2)), false),
-            (None, false),
-            (Some(local_route("ws://127.0.0.1:18789", 3)), false),
+    async fn late_prepare_response_resumes_only_after_wake_on_its_original_route() {
+        for (replacement, unchanged, abandoned) in [
+            (Some(local_route("ws://127.0.0.1:18789", 1)), true, false),
+            (Some(local_route("ws://127.0.0.1:19001", 2)), false, false),
+            (None, false, false),
+            (Some(local_route("ws://127.0.0.1:18789", 3)), false, false),
+            (Some(local_route("ws://127.0.0.1:18789", 1)), true, true),
         ] {
             let route = route_state(Some("ws://127.0.0.1:18789"));
             let (release, receiver) = oneshot::channel();
@@ -439,6 +484,8 @@ mod tests {
             let prepare_started_sender = Arc::clone(&started);
             let resumed_ids = Arc::new(Mutex::new(Vec::new()));
             let resumed = Arc::clone(&resumed_ids);
+            let refreshes = Arc::new(AtomicUsize::new(0));
+            let refreshed = Arc::clone(&refreshes);
             let controller = Arc::new(GatewaySleepCycleController::new(
                 "linux-sleep-test-run".into(),
                 current_route(&route),
@@ -462,28 +509,41 @@ mod tests {
                     resumed.lock().unwrap().push(id);
                     async { Ok(()) }
                 },
-                || async {},
+                move || {
+                    refreshed.fetch_add(1, Ordering::SeqCst);
+                    async {}
+                },
                 no_delay,
                 |_| {},
             ));
 
-            let sleeping = {
-                let controller = Arc::clone(&controller);
-                tokio::spawn(async move { controller.will_sleep().await })
-            };
-            prepare_started.await.unwrap();
-            controller.did_wake().await;
+            let (generation, sleeping) = controller.will_sleep();
+            tokio::pin!(sleeping);
+            tokio::select! {
+                started = prepare_started => started.unwrap(),
+                _ = &mut sleeping => panic!("preparation completed before release"),
+            }
+            if abandoned {
+                controller.abandon(generation.unwrap());
+                // A subsequent call must not revive this listener's controller.
+                controller.will_sleep().1.await;
+            } else {
+                controller.did_wake().await;
+            }
             *route.lock().unwrap() = replacement.clone();
             release.send(()).unwrap();
-            sleeping.await.unwrap();
+            sleeping.await;
             controller.did_wake().await;
 
-            let expected = if unchanged {
+            let expected = if unchanged && !abandoned {
                 vec!["late-suspension"]
             } else {
                 vec![]
             };
             assert_eq!(*resumed_ids.lock().unwrap(), expected, "{replacement:?}");
+            if abandoned {
+                assert_eq!(refreshes.load(Ordering::SeqCst), 0);
+            }
         }
     }
 
@@ -528,7 +588,7 @@ mod tests {
                 |_| {},
             );
 
-            controller.will_sleep().await;
+            controller.will_sleep().1.await;
             controller.did_wake().await;
 
             assert_eq!(
@@ -563,7 +623,7 @@ mod tests {
             move |message| recorded_logs.lock().unwrap().push(message),
         );
 
-        controller.will_sleep().await;
+        controller.will_sleep().1.await;
         controller.did_wake().await;
 
         assert_eq!(attempts.load(Ordering::SeqCst), 3);
@@ -596,16 +656,74 @@ mod tests {
             || async {},
             move |_| {
                 let controller = delay_slot.lock().unwrap().as_ref().unwrap().clone();
-                async move { controller.will_sleep().await }
+                async move { controller.will_sleep().1.await }
             },
             |_| {},
         ));
         *controller_slot.lock().unwrap() = Some(Arc::clone(&controller));
 
-        controller.will_sleep().await;
+        controller.will_sleep().1.await;
         controller.did_wake().await;
 
         assert_eq!(attempts.load(Ordering::SeqCst), 1);
+        controller_slot.lock().unwrap().take();
+    }
+
+    #[tokio::test]
+    async fn unpolled_wake_and_stale_abandon_preserve_newer_cycle() {
+        for abandon_newer in [false, true] {
+            let route = route_state(Some("ws://127.0.0.1:18789"));
+            let prepares = Arc::new(AtomicUsize::new(0));
+            let prepared = Arc::clone(&prepares);
+            let resumed_ids = Arc::new(Mutex::new(Vec::new()));
+            let resumed = Arc::clone(&resumed_ids);
+            let refreshes = Arc::new(AtomicUsize::new(0));
+            let refreshed = Arc::clone(&refreshes);
+            let controller = GatewaySleepCycleController::new(
+                "linux-sleep-test-run".into(),
+                current_route(&route),
+                move |_, _| {
+                    let id = prepared.fetch_add(1, Ordering::SeqCst);
+                    async move {
+                        Ok(SleepPrepareOutcome::Ready {
+                            suspension_id: format!("suspension-{id}"),
+                        })
+                    }
+                },
+                move |id, _| {
+                    resumed.lock().unwrap().push(id);
+                    async { Ok(()) }
+                },
+                move || {
+                    refreshed.fetch_add(1, Ordering::SeqCst);
+                    async {}
+                },
+                no_delay,
+                |_| {},
+            );
+            let (old_generation, old_preparation) = controller.will_sleep();
+            old_preparation.await;
+            let old_wake = controller.did_wake();
+            let (new_generation, new_preparation) = controller.will_sleep();
+            new_preparation.await;
+
+            old_wake.await;
+            controller.abandon(old_generation.unwrap());
+            assert!(resumed_ids.lock().unwrap().is_empty());
+            assert_eq!(refreshes.load(Ordering::SeqCst), 0);
+            if abandon_newer {
+                controller.abandon(new_generation.unwrap());
+            }
+            controller.did_wake().await;
+
+            if abandon_newer {
+                assert!(resumed_ids.lock().unwrap().is_empty());
+                assert_eq!(refreshes.load(Ordering::SeqCst), 0);
+            } else {
+                assert_eq!(*resumed_ids.lock().unwrap(), ["suspension-1"]);
+                assert_eq!(refreshes.load(Ordering::SeqCst), 1);
+            }
+        }
     }
 
     #[tokio::test]
@@ -630,7 +748,7 @@ mod tests {
             |_| {},
         );
 
-        controller.will_sleep().await;
+        controller.will_sleep().1.await;
         controller.did_wake().await;
         controller.did_wake().await;
 

--- a/apps/linux/src-tauri/src/gateway_sleep_logind_listener.rs
+++ b/apps/linux/src-tauri/src/gateway_sleep_logind_listener.rs
@@ -8,6 +8,20 @@ use zbus::zvariant::OwnedFd;
 pub(crate) type BeginSleepCycleHook = Arc<dyn Fn() -> bool + Send + Sync>;
 pub(crate) type EndSleepCycleHook = Arc<dyn Fn() + Send + Sync>;
 
+struct SleepCycleGuard {
+    abandon: Option<(Arc<GatewaySleepCycleController>, u64)>,
+    end: EndSleepCycleHook,
+}
+
+impl Drop for SleepCycleGuard {
+    fn drop(&mut self) {
+        if let Some((controller, generation)) = &self.abandon {
+            controller.abandon(*generation);
+        }
+        (self.end)();
+    }
+}
+
 #[zbus::proxy(
     default_service = "org.freedesktop.login1",
     default_path = "/org/freedesktop/login1",
@@ -45,7 +59,7 @@ async fn run_listener_on_connection(
         .await
         .map_err(|error| format!("could not subscribe to PrepareForSleep: {error}"))?;
     let mut inhibitor = Some(acquire_inhibitor(&proxy).await?);
-    let mut cycle_began = false;
+    let mut cycle = None;
 
     while let Some(signal) = signals.next().await {
         let sleeping = signal
@@ -53,23 +67,34 @@ async fn run_listener_on_connection(
             .map_err(|error| format!("invalid PrepareForSleep signal: {error}"))?
             .sleeping;
         if sleeping {
-            cycle_began = begin_sleep_cycle();
-            controller.will_sleep().await;
+            if cycle.is_none() && begin_sleep_cycle() {
+                cycle = Some(SleepCycleGuard {
+                    abandon: None,
+                    end: Arc::clone(&end_sleep_cycle),
+                });
+            }
+            let (generation, preparation) = controller.will_sleep();
+            if let Some(cycle) = cycle.as_mut() {
+                cycle.abandon = generation.map(|generation| (Arc::clone(&controller), generation));
+            }
+            preparation.await;
             // Releasing the delay inhibitor lets logind continue into sleep.
             inhibitor.take();
         } else {
-            let controller = Arc::clone(&controller);
-            let end_sleep_cycle = Arc::clone(&end_sleep_cycle);
-            let began = cycle_began;
-            cycle_began = false;
+            let cycle = cycle.take().map(|mut cycle| {
+                // Real wake transfers recovery authority before the task can poll.
+                // Later listener loss must not abandon this already-observed wake.
+                cycle.abandon = None;
+                cycle
+            });
+            let recovery = controller.did_wake();
             // Spawn wake recovery before touching logind again: a slow or hung
             // Inhibit call must not delay reconnect/resume. Spawning also keeps
             // the signal loop consuming so a new sleep cycle can abort retries.
             tauri::async_runtime::spawn(async move {
-                controller.did_wake().await;
-                if began {
-                    end_sleep_cycle();
-                }
+                // Keep this cycle's depth until recovery ends, including cancellation.
+                let _cycle = cycle;
+                recovery.await;
             });
             // A failed re-acquire only loses the pre-sleep delay window; keep the
             // listener alive so later sleep/wake cycles are still handled.

--- a/apps/linux/src-tauri/src/gateway_ws.rs
+++ b/apps/linux/src-tauri/src/gateway_ws.rs
@@ -2690,7 +2690,7 @@ esac
                 .await;
                 let controller = controller(&fixture.client, |_| std::future::ready(()));
                 let cycle = async {
-                    controller.will_sleep().await;
+                    controller.will_sleep().1.await;
                     controller.did_wake().await;
                 };
                 fixture.drive(cycle).await;
@@ -2790,7 +2790,7 @@ esac
                     let mut fixture =
                         SleepSocketFixture::new(dashboard_handoff::local_ws_config).await;
                     let controller = controller(&fixture.client, |_| std::future::ready(()));
-                    let mut sleeping = Box::pin(controller.will_sleep());
+                    let mut sleeping = Box::pin(controller.will_sleep().1);
                     assert!(futures_util::poll!(&mut sleeping).is_pending());
                     let command = fixture.next_request().await;
                     fixture.dispatch(command).await;
@@ -2821,7 +2821,7 @@ esac
                     }
                     std::future::ready(())
                 });
-                fixture.drive(controller.will_sleep()).await;
+                fixture.drive(controller.will_sleep().1).await;
                 fixture.fail_resume.store(true, Ordering::SeqCst);
                 fixture.drive(controller.did_wake()).await;
                 let frames = fixture.finish().await;

--- a/apps/linux/src-tauri/tests/logind_sleep.rs
+++ b/apps/linux/src-tauri/tests/logind_sleep.rs
@@ -12,7 +12,7 @@ use std::os::fd::OwnedFd as StdOwnedFd;
 use std::os::unix::net::UnixStream;
 use std::path::PathBuf;
 use std::process::{Child, Command, Stdio};
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 use tokio::sync::mpsc;
 use uuid::Uuid;
@@ -20,6 +20,8 @@ use zbus::object_server::SignalEmitter;
 use zbus::zvariant::OwnedFd;
 
 const LOGIN1_PATH: &str = "/org/freedesktop/login1";
+static SYSTEM_BUS_TEST_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+static WAKE_RUNTIME: OnceLock<tokio::runtime::Runtime> = OnceLock::new();
 
 #[derive(Debug, Eq, PartialEq)]
 enum MockEvent {
@@ -166,7 +168,83 @@ async fn next_event(events: &mut mpsc::UnboundedReceiver<MockEvent>) -> MockEven
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[ignore = "requires Linux and dbus-daemon; run with cargo test -- --ignored logind"]
 async fn logind_full_sleep_cycle_releases_and_reacquires_inhibitor() {
-    let Some((_daemon, address)) = spawn_dbus_daemon() else {
+    exercise_logind_listener(None, WakeProgress::None).await;
+}
+
+#[derive(Clone, Copy, Debug)]
+enum TerminalLoss {
+    StreamEnded,
+    InvalidSignal,
+    Cancelled,
+    CancelledPreparing,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum WakeProgress {
+    None,
+    BeforePoll,
+    RefreshPending,
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "requires Linux and dbus-daemon; run with cargo test -- --ignored logind"]
+async fn logind_stream_end_retires_cycle_without_wake() {
+    exercise_logind_listener(Some(TerminalLoss::StreamEnded), WakeProgress::None).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "requires Linux and dbus-daemon; run with cargo test -- --ignored logind"]
+async fn logind_invalid_signal_retires_cycle_without_wake() {
+    exercise_logind_listener(Some(TerminalLoss::InvalidSignal), WakeProgress::None).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "requires Linux and dbus-daemon; run with cargo test -- --ignored logind"]
+async fn logind_cancellation_retires_cycle_without_wake() {
+    for loss in [TerminalLoss::Cancelled, TerminalLoss::CancelledPreparing] {
+        exercise_logind_listener(Some(loss), WakeProgress::None).await;
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "requires Linux and dbus-daemon; run with cargo test -- --ignored logind"]
+async fn logind_terminal_loss_preserves_unpolled_wake() {
+    for loss in [
+        TerminalLoss::StreamEnded,
+        TerminalLoss::InvalidSignal,
+        TerminalLoss::Cancelled,
+    ] {
+        exercise_logind_listener(Some(loss), WakeProgress::BeforePoll).await;
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "requires Linux and dbus-daemon; run with cargo test -- --ignored logind"]
+async fn logind_terminal_loss_preserves_refreshing_wake() {
+    for loss in [
+        TerminalLoss::StreamEnded,
+        TerminalLoss::InvalidSignal,
+        TerminalLoss::Cancelled,
+    ] {
+        exercise_logind_listener(Some(loss), WakeProgress::RefreshPending).await;
+    }
+}
+
+async fn exercise_logind_listener(terminal_loss: Option<TerminalLoss>, wake: WakeProgress) {
+    // DBUS_SYSTEM_BUS_ADDRESS is process-global, including under default-parallel Cargo.
+    let _serial = SYSTEM_BUS_TEST_LOCK.lock().await;
+    // The listener runs on the test runtime; one distinct wake worker lets the
+    // fixture hold recovery before its first poll without changing production hooks.
+    WAKE_RUNTIME.get_or_init(|| {
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(1)
+            .enable_all()
+            .build()
+            .expect("create fixture wake runtime");
+        tauri::async_runtime::set(runtime.handle().clone());
+        runtime
+    });
+    let Some((mut daemon, address)) = spawn_dbus_daemon() else {
         return;
     };
     let _system_bus = SystemBusAddress::set(&address);
@@ -190,6 +268,9 @@ async fn logind_full_sleep_cycle_releases_and_reacquires_inhibitor() {
     let prepare_events = event_tx.clone();
     let refresh_events = event_tx.clone();
     let resume_events = event_tx.clone();
+    let block_prepare = matches!(terminal_loss, Some(TerminalLoss::CancelledPreparing));
+    let release_refresh = Arc::new(tokio::sync::Notify::new());
+    let refresh_barrier = Arc::clone(&release_refresh);
     let controller = Arc::new(GatewaySleepCycleController::new(
         "logind-proof".into(),
         || {
@@ -202,6 +283,9 @@ async fn logind_full_sleep_cycle_releases_and_reacquires_inhibitor() {
             let events = prepare_events.clone();
             async move {
                 let _ = events.send(MockEvent::Prepare);
+                if block_prepare {
+                    std::future::pending::<()>().await;
+                }
                 Ok(SleepPrepareOutcome::Ready {
                     suspension_id: "mock-suspension".into(),
                 })
@@ -216,8 +300,12 @@ async fn logind_full_sleep_cycle_releases_and_reacquires_inhibitor() {
         },
         move || {
             let events = refresh_events.clone();
+            let barrier = Arc::clone(&refresh_barrier);
             async move {
                 let _ = events.send(MockEvent::Refresh);
+                if wake == WakeProgress::RefreshPending {
+                    barrier.notified().await;
+                }
             }
         },
         |_| std::future::ready(()),
@@ -232,7 +320,11 @@ async fn logind_full_sleep_cycle_releases_and_reacquires_inhibitor() {
     let end_sleep_cycle: EndSleepCycleHook = Arc::new(move || {
         let _ = end_events.send(MockEvent::DriverDeactivated);
     });
-    let listener = tokio::spawn(run_listener(controller, begin_sleep_cycle, end_sleep_cycle));
+    let listener = tokio::spawn(run_listener(
+        Arc::clone(&controller),
+        begin_sleep_cycle,
+        end_sleep_cycle,
+    ));
 
     assert_eq!(
         next_event(&mut events).await,
@@ -248,10 +340,110 @@ async fn logind_full_sleep_cycle_releases_and_reacquires_inhibitor() {
         .expect("emit sleep signal");
     assert_eq!(next_event(&mut events).await, MockEvent::DriverActivated);
     assert_eq!(next_event(&mut events).await, MockEvent::Prepare);
-    assert_eq!(
-        next_event(&mut events).await,
-        MockEvent::InhibitorReleased(1)
-    );
+    if !block_prepare {
+        assert_eq!(
+            next_event(&mut events).await,
+            MockEvent::InhibitorReleased(1)
+        );
+    }
+
+    if let Some(loss) = terminal_loss {
+        let mut wake_gate = None;
+        if wake == WakeProgress::BeforePoll {
+            let (entered, waiting) = tokio::sync::oneshot::channel();
+            let (release, blocked) = std::sync::mpsc::channel();
+            let gate = tauri::async_runtime::spawn(async move {
+                entered.send(()).expect("announce blocked wake worker");
+                blocked
+                    .recv_timeout(Duration::from_secs(3))
+                    .expect("wake worker was not released");
+            });
+            tokio::time::timeout(Duration::from_secs(3), waiting)
+                .await
+                .expect("wake worker did not reach gate")
+                .expect("wake worker gate dropped");
+            wake_gate = Some((release, gate));
+        }
+        if wake != WakeProgress::None {
+            MockLogin1::prepare_for_sleep(interface.signal_emitter(), false)
+                .await
+                .expect("emit real wake before terminal loss");
+            if wake == WakeProgress::BeforePoll {
+                assert_eq!(
+                    next_event(&mut events).await,
+                    MockEvent::InhibitorAcquired(2)
+                );
+            } else {
+                let waking = [next_event(&mut events).await, next_event(&mut events).await];
+                assert!(waking.contains(&MockEvent::Refresh));
+                assert!(waking.contains(&MockEvent::InhibitorAcquired(2)));
+            }
+        }
+        match loss {
+            TerminalLoss::StreamEnded => {
+                daemon.child.kill().expect("stop private system bus");
+                daemon.child.wait().expect("reap private system bus");
+            }
+            TerminalLoss::InvalidSignal => {
+                service
+                    .emit_signal(
+                        None::<&str>,
+                        LOGIN1_PATH,
+                        "org.freedesktop.login1.Manager",
+                        "PrepareForSleep",
+                        &("not a boolean",),
+                    )
+                    .await
+                    .expect("emit malformed sleep signal");
+            }
+            TerminalLoss::Cancelled | TerminalLoss::CancelledPreparing => listener.abort(),
+        }
+        let stopped = tokio::time::timeout(Duration::from_secs(3), listener)
+            .await
+            .expect("terminal listener did not stop");
+        match loss {
+            TerminalLoss::Cancelled | TerminalLoss::CancelledPreparing => {
+                assert!(stopped.unwrap_err().is_cancelled());
+            }
+            _ => assert!(stopped.unwrap().is_err(), "{loss:?}"),
+        }
+        if wake != WakeProgress::None {
+            // Recovery is still pending when the listener exits. Its cycle must
+            // remain owned by the wake task, not abandoned or ended by the listener.
+            assert_eq!(
+                next_event(&mut events).await,
+                MockEvent::InhibitorReleased(2)
+            );
+            if let Some((release, gate)) = wake_gate {
+                release.send(()).expect("release unpolled wake");
+                gate.await.expect("reap wake worker gate");
+                assert_eq!(next_event(&mut events).await, MockEvent::Refresh);
+            } else {
+                release_refresh.notify_one();
+            }
+            assert_eq!(next_event(&mut events).await, MockEvent::Resume);
+            assert_eq!(next_event(&mut events).await, MockEvent::DriverDeactivated);
+            assert!(
+                events.try_recv().is_err(),
+                "duplicate wake cleanup: {loss:?}"
+            );
+            return;
+        }
+        if block_prepare {
+            let cleanup = [next_event(&mut events).await, next_event(&mut events).await];
+            assert!(cleanup.contains(&MockEvent::DriverDeactivated));
+            assert!(cleanup.contains(&MockEvent::InhibitorReleased(1)));
+        } else {
+            assert_eq!(next_event(&mut events).await, MockEvent::DriverDeactivated);
+        }
+        // A terminal controller cannot turn a stale notification into wake recovery.
+        controller.did_wake().await;
+        assert!(
+            events.try_recv().is_err(),
+            "terminal loss must not refresh, resume, or release the driver twice: {loss:?}"
+        );
+        return;
+    }
 
     MockLogin1::prepare_for_sleep(interface.signal_emitter(), false)
         .await
@@ -278,4 +470,5 @@ async fn logind_full_sleep_cycle_releases_and_reacquires_inhibitor() {
     );
 
     listener.abort();
+    assert!(listener.await.unwrap_err().is_cancelled());
 }


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/pull/145355

Stack 2/8, now based on main after layer1 landed.
Previous: https://github.com/openclaw/openclaw/pull/146045 | Next: https://github.com/openclaw/openclaw/pull/146047

This same-repository branch is writable by maintainers with push access.

## What Problem This Solves

Linux Gateway recovery can remain blocked after the logind sleep listener disconnects or terminates.

## Why This Change Was Made

Retire the failed listener's sleep guard without consuming a later wake. Move the sleep-state API and all three WebSocket callers together.

## User Impact

A terminal listener failure no longer leaves the app indefinitely treating the machine as asleep.

## Evidence

- Includes controller and logind lifecycle regressions.
- Reused [native sleep/version run](https://github.com/openclaw/openclaw/actions/runs/34461350778): intended original failures and candidate sleep controls passed.
- Signed head `6ef43ef4b849e3c8f0165f20c9e4bd1e548d478d` replays only this layer's four-file delta onto landed layer1 `f369c90e95afb636531157e6fc4e8faa1bdff726`. Range-diff matches original `985a523` exactly.
- [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34737663052) completed successfully in attempt4, including `openclaw/ci-gate`. Three unacquired cancelled jobs were recovered individually; no source changes or gate waivers were used.
- Independent source review verified listener ownership, tuple values, and all three callers. This is not a newly executed intermediate native GUI run.

The original stack snapshot remains retained; no new platform qualification or release activation is claimed.
