### PR TITLE
fix(cli): reject explicitly blank config batch sources

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2230,7 +2230,7 @@ src/cli/config-cli-path.ts	5
 src/cli/config-cli-runner.ts	3
 src/cli/config-cli.ts	8
 src/cli/config-model-validation.ts	7
-src/cli/config-set-input.ts	2
+src/cli/config-set-input.ts	1
 src/cli/connect-cli.ts	1
 src/cli/cron-cli/list-jobs.ts	4
 src/cli/cron-cli/register.cron-add.ts	1

--- a/docs/cli/config.md
+++ b/docs/cli/config.md
@@ -300,6 +300,8 @@ SecretRef assignments are rejected on unsupported runtime-mutable surfaces (for 
 
 Batch parsing always uses the batch payload (`--batch-json`/`--batch-file`) as the source of truth; `--strict-json` / `--json` do not change batch parsing behavior.
 
+Supplying either batch option selects batch mode. Empty or whitespace-only values are rejected; omit both options to use positional `<path> <value>` mode.
+
 Batch assignments apply in order, then validation checks the final config. A SecretRef replaced by a later assignment is not resolved or counted in dry-run output, even with `--allow-exec`. Providers that remain in a changed provider collection still receive command-path trust checks.
 
 JSON path/value mode also works for SecretRefs and providers directly:

--- a/src/cli/config-cli.integration.test.ts
+++ b/src/cli/config-cli.integration.test.ts
@@ -33,6 +33,79 @@ function installRuntimeSchemaReadHook(hook: () => void | Promise<void>): void {
 }
 
 describe("config cli integration", () => {
+  it.each([
+    {
+      name: "empty inline batch",
+      args: ["gateway.port", "19001", "--batch-json="],
+      error: "Failed to parse --batch-json",
+    },
+    {
+      name: "whitespace inline batch",
+      args: ["gateway.port", "19001", "--batch-json", " \t"],
+      error: "Failed to parse --batch-json",
+    },
+    {
+      name: "empty batch file path",
+      args: ["gateway.port", "19001", "--batch-file="],
+      error: "--batch-file must not be empty",
+    },
+    {
+      name: "whitespace batch file path",
+      args: ["gateway.port", "19001", "--batch-file", " \t"],
+      error: "--batch-file must not be empty",
+    },
+    {
+      name: "positional input without batch options",
+      args: ["gateway.port", "19001"],
+      error: null,
+    },
+    {
+      name: "valid inline batch without positional input",
+      args: ["--batch-json", '[{"path":"gateway.port","value":19001}]'],
+      error: null,
+    },
+  ])("honors config set batch input selection for $name", async ({ args, error }) => {
+    const raw = '{"agents":{"entries":{"main":{}}},"gateway":{"port":18789}}\n';
+    await withConfigFileHarness(
+      "openclaw-config-cli-batch-presence-",
+      raw,
+      async ({ configPath }) => {
+        const command = runRegisteredConfigCommand([
+          "config",
+          "set",
+          ...args,
+          "--dry-run",
+          "--json",
+        ]);
+        if (error) {
+          await expect(command).rejects.toMatchObject({ name: "ExitError", code: 1 });
+        } else {
+          await command;
+        }
+
+        expect(registeredRuntimeLogs).toHaveLength(1);
+        const result = JSON.parse(registeredRuntimeLogs[0] ?? "");
+        expect(result).toMatchObject({
+          ok: error === null,
+          operations: error === null ? 1 : 0,
+          configPath,
+          inputModes: error === null ? ["json"] : [],
+        });
+        if (error) {
+          expect(result.errors).toEqual([
+            { kind: "schema", message: expect.stringContaining(error) },
+          ]);
+          expect(registeredRuntimeErrors).toHaveLength(1);
+          expect(registeredRuntimeErrors[0]).toContain(error);
+        } else {
+          expect(result.errors ?? []).toEqual([]);
+          expect(registeredRuntimeErrors).toEqual([]);
+        }
+        expect(fs.readFileSync(configPath, "utf8")).toBe(raw);
+      },
+    );
+  });
+
   it("renders actionable paths for real dotted model-key validation failures", async () => {
     const configForAlias = (alias: string | number) => ({
       agents: {

--- a/src/cli/config-set-input.ts
+++ b/src/cli/config-set-input.ts
@@ -91,9 +91,7 @@ export function readConfigMutationFileSync(
 }
 
 export function hasBatchMode(opts: ConfigSetOptions): boolean {
-  return Boolean(
-    normalizeOptionalString(opts.batchJson) || normalizeOptionalString(opts.batchFile),
-  );
+  return opts.batchJson !== undefined || opts.batchFile !== undefined;
 }
 
 export function hasRefBuilderOptions(opts: ConfigSetOptions): boolean {
@@ -211,10 +209,9 @@ export function parseConfigSetCurrentExpectation(
 
 export function parseBatchSource(opts: ConfigSetOptions): ConfigSetBatchEntry[] | null {
   // Batch mode is exclusive because each entry carries its own value/ref/provider mode.
-  const batchJson = normalizeOptionalString(opts.batchJson);
-  const batchFile = normalizeOptionalString(opts.batchFile);
-  const hasInline = Boolean(batchJson);
-  const hasFile = Boolean(batchFile);
+  const batchJson = opts.batchJson;
+  const hasInline = batchJson !== undefined;
+  const hasFile = opts.batchFile !== undefined;
   if (!hasInline && !hasFile) {
     return null;
   }
@@ -222,7 +219,7 @@ export function parseBatchSource(opts: ConfigSetOptions): ConfigSetBatchEntry[] 
     throw new Error("Use either --batch-json or --batch-file, not both.");
   }
   if (hasInline) {
-    return parseBatchEntries(batchJson as string, "--batch-json");
+    return parseBatchEntries(batchJson, "--batch-json");
   }
   const pathname = normalizeStringifiedOptionalString(opts.batchFile) ?? "";
   if (!pathname) {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators supplying an explicitly empty `--batch-json` or `--batch-file` alongside otherwise valid positional arguments could silently get a different config update. For example, `openclaw config set gateway.port 19001 --batch-json= --dry-run --json` reported success for one positional operation instead of rejecting the requested batch source.

## Why This Change Was Made

The batch input owner used normalized content to decide whether the option was present, in both mode selection and source parsing. It now selects by option presence and lets the existing JSON5/file validation reject empty content. This removes the fall-through to positional assignment and restores the existing empty-file-path diagnostic. The redundant type assertion is removed with an exact shrink of its assertion baseline.

This repairs source selection; the earlier empty-array rejection in #116833 prevents zero-operation writes after a batch has been parsed. Both contracts remain intact, along with batch exclusivity, file-size limits, valid input behavior, and ref/provider validation.

## User Impact

Explicitly blank batch sources return an actionable error and failure status. Valid positional and batch commands keep their existing behavior. No options, config schema, auth policy, database contract, or write mechanism change. Formatted production delta is **+5/−8, net −3**; tests add 73 lines, docs add two, and assertion metadata shrinks from two assertions to one.

## Evidence

- Before the fix, the real registered Commander integration had four intended failures and two passing controls. Six ordinary built CLI dry-runs independently showed the same bug: all four empty/whitespace source forms incorrectly returned exit 0 and one operation. Every config byte readback was unchanged.
- All six candidate regression cases and 54 owner/sibling tests pass, including existing valid batches, exclusivity, file-boundary and error behavior.
- All 31 final changed gates passed, including core/test typechecks, core/script lint, formatting and guards. Independent source/dedup/carry review and managed P0–P2 review are clean.
- The normal baseline and candidate builds passed in 284.9s and 302.9s. The same six supported CLI commands on the built candidate now produce four natural exit-1 structured failures with zero operations; both valid controls retain the complete baseline JSON after normalizing only their temporary config paths. All six config files remain byte-identical.
- Native build/CLI exits and unchanged source/generated artifacts are retained. The original assertion-baseline gate failure was resolved by the exact 2→1 shrink. A separate post-run verifier initially expected stderr without pnpm’s normal exit-1 trailer; that failed verifier is retained, while the approved CLI driver and raw results passed without a rerun.

The native CLI proof covers isolated dry-runs, not persistent writes or an operator Gateway. The changed owner constructs the same operations before the existing dry-run/write boundary.
