### PR TITLE
refactor: share trajectory export test runtime

### DIFF
--- a/src/commands/export-trajectory.test.ts
+++ b/src/commands/export-trajectory.test.ts
@@ -1,8 +1,8 @@
-// Export trajectory tests cover trajectory export command output and file selection.
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ExpectedCliError } from "../cli/failure-output.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { exportTrajectoryCommand } from "./export-trajectory.js";
+import { createTestRuntime } from "./test-runtime-config-helpers.js";
 
 const mocks = vi.hoisted(() => ({
   exportTrajectoryForCommand: vi.fn(),
@@ -47,14 +47,6 @@ vi.mock("./session-store-targets.js", () => ({
   resolveExplicitSessionStorePath: mocks.resolveExplicitStorePath,
 }));
 
-function createRuntime(): RuntimeEnv {
-  return {
-    log: vi.fn(),
-    error: vi.fn(),
-    exit: vi.fn(),
-  } as unknown as RuntimeEnv;
-}
-
 async function expectTrajectoryFailure(
   execution: Promise<void>,
   runtime: RuntimeEnv,
@@ -93,7 +85,7 @@ describe("exportTrajectoryCommand", () => {
   });
 
   it("points missing session key users at the sessions command", async () => {
-    const runtime = createRuntime();
+    const runtime = createTestRuntime();
 
     await expectTrajectoryFailure(
       exportTrajectoryCommand({}, runtime),
@@ -136,7 +128,7 @@ describe("exportTrajectoryCommand", () => {
   ])(
     "rejects an encoded request containing $name before looking up its session",
     async ({ encoded, detail }) => {
-      const runtime = createRuntime();
+      const runtime = createTestRuntime();
 
       await expectTrajectoryFailure(
         exportTrajectoryCommand({ requestJsonBase64: encoded }, runtime),
@@ -150,7 +142,7 @@ describe("exportTrajectoryCommand", () => {
   );
 
   it("preserves direct options when an encoded request omits them", async () => {
-    const runtime = createRuntime();
+    const runtime = createTestRuntime();
     const requestJsonBase64 = Buffer.from(
       JSON.stringify({ output: "/tmp/export.json" }),
       "utf8",
@@ -189,7 +181,7 @@ describe("exportTrajectoryCommand", () => {
     ["empty", "", "--agent must not be blank"],
     ["whitespace-only", "   ", "--agent must not be blank"],
   ])("rejects an %s explicit agent before reading a session", async (_label, agent, message) => {
-    const runtime = createRuntime();
+    const runtime = createTestRuntime();
     mocks.getRuntimeConfig.mockReturnValue({ agents: { list: [{ id: "main" }] } });
 
     await expectTrajectoryFailure(
@@ -206,7 +198,7 @@ describe("exportTrajectoryCommand", () => {
     ["empty", ""],
     ["whitespace-only", "   "],
   ])("rejects an %s explicit store before resolving one", async (_label, store) => {
-    const runtime = createRuntime();
+    const runtime = createTestRuntime();
 
     await expectTrajectoryFailure(
       exportTrajectoryCommand({ sessionKey: "agent:main:telegram:direct:123", store }, runtime),
@@ -224,7 +216,7 @@ describe("exportTrajectoryCommand", () => {
     ["empty", "store", "", "--store must not be blank"],
     ["whitespace-only", "store", "   ", "--store must not be blank"],
   ])("rejects an %s encoded %s before reading a session", async (_label, field, value, message) => {
-    const runtime = createRuntime();
+    const runtime = createTestRuntime();
     const requestJsonBase64 = Buffer.from(
       JSON.stringify({ sessionKey: "agent:main:telegram:direct:123", [field]: value }),
       "utf8",
@@ -241,7 +233,7 @@ describe("exportTrajectoryCommand", () => {
   });
 
   it("honours a non-blank encoded store and agent", async () => {
-    const runtime = createRuntime();
+    const runtime = createTestRuntime();
     mocks.getRuntimeConfig.mockReturnValue({ agents: { list: [{ id: "main" }, { id: "work" }] } });
     mocks.resolveStorePath.mockReturnValue("/tmp/encoded-store.json");
     const requestJsonBase64 = Buffer.from(
@@ -266,7 +258,7 @@ describe("exportTrajectoryCommand", () => {
   });
 
   it("routes invalid explicit stores through the command failure owner", async () => {
-    const runtime = createRuntime();
+    const runtime = createTestRuntime();
     mocks.resolveStorePath.mockReturnValue("/tmp/missing.sqlite");
     mocks.resolveExplicitStorePath.mockImplementationOnce(() => {
       throw new Error("Session store target does not exist: /tmp/missing.sqlite");
@@ -292,7 +284,7 @@ describe("exportTrajectoryCommand", () => {
   it.each(["agent:main:telegram:direct:123", "global"])(
     "keeps a configured explicit agent as the store owner for %s",
     async (sessionKey) => {
-      const runtime = createRuntime();
+      const runtime = createTestRuntime();
       mocks.getRuntimeConfig.mockReturnValue({
         agents: { list: [{ id: "main" }, { id: "work" }] },
         session: { store: "/tmp/openclaw/agents/{agentId}/sessions/sessions.json" },
@@ -323,7 +315,7 @@ describe("exportTrajectoryCommand", () => {
   ])(
     "resolves explicit --store %s paths through the shared resolver",
     async (_name, store, resolvedStore) => {
-      const runtime = createRuntime();
+      const runtime = createTestRuntime();
       mocks.resolveStorePath.mockReturnValue(resolvedStore);
 
       await exportTrajectoryCommand(
@@ -347,7 +339,7 @@ describe("exportTrajectoryCommand", () => {
   );
 
   it("uses configured session.store when no explicit store is provided", async () => {
-    const runtime = createRuntime();
+    const runtime = createTestRuntime();
     mocks.getRuntimeConfig.mockReturnValue({
       session: { store: "/tmp/openclaw/agents/{agentId}/sessions/sessions.json" },
     });
@@ -367,7 +359,7 @@ describe("exportTrajectoryCommand", () => {
   });
 
   it("falls back through resolveStorePath when no session.store is configured", async () => {
-    const runtime = createRuntime();
+    const runtime = createTestRuntime();
 
     await exportTrajectoryCommand({ sessionKey: "agent:main:telegram:direct:123" }, runtime);
 
@@ -380,7 +372,7 @@ describe("exportTrajectoryCommand", () => {
   });
 
   it("passes blank configured session.store through the default-store resolver", async () => {
-    const runtime = createRuntime();
+    const runtime = createTestRuntime();
     mocks.getRuntimeConfig.mockReturnValue({ session: { store: "" } });
 
     await exportTrajectoryCommand({ sessionKey: "agent:main:telegram:direct:123" }, runtime);
@@ -394,7 +386,7 @@ describe("exportTrajectoryCommand", () => {
   });
 
   it("reports a missing session without resolving its transcript or exporting", async () => {
-    const runtime = createRuntime();
+    const runtime = createTestRuntime();
     mocks.loadSessionEntryReadOnly.mockReturnValue(undefined);
 
     await expectTrajectoryFailure(
@@ -408,7 +400,7 @@ describe("exportTrajectoryCommand", () => {
   });
 
   it("reports transcript target resolution failures without invoking the exporter", async () => {
-    const runtime = createRuntime();
+    const runtime = createTestRuntime();
     mocks.resolveSessionTranscriptReadTarget.mockImplementationOnce(() => {
       throw new Error("transcript target is unavailable");
     });
@@ -423,7 +415,7 @@ describe("exportTrajectoryCommand", () => {
   });
 
   it("reports exporter failures without formatting a successful result", async () => {
-    const runtime = createRuntime();
+    const runtime = createTestRuntime();
     mocks.exportTrajectoryForCommand.mockRejectedValueOnce(new Error("workspace is unavailable"));
 
     await expectTrajectoryFailure(
@@ -436,7 +428,7 @@ describe("exportTrajectoryCommand", () => {
   });
 
   it("exports SQLite sessions without probing a transcript JSONL file", async () => {
-    const runtime = createRuntime();
+    const runtime = createTestRuntime();
 
     await exportTrajectoryCommand(
       {
@@ -464,7 +456,7 @@ describe("exportTrajectoryCommand", () => {
   });
 
   it("preserves successful JSON output", async () => {
-    const runtime = createRuntime();
+    const runtime = createTestRuntime();
 
     await exportTrajectoryCommand(
       { sessionKey: "agent:main:telegram:direct:123", json: true },


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

Trajectory export command tests maintain a duplicate runtime fixture, making shared test-runtime changes harder to apply consistently.

## Why This Change Was Made

Reuse the existing typed command runtime fixture and remove the local factory, double cast, and narration comment. Fresh spies, error assertions, selector cases, and JSON output through `runtime.log` remain intact.

## User Impact

No user-facing behavior change. Production code is unchanged; tests change by +19/-27 lines (net -8). All 30 export cases and 53 CLI registration cases remain.

## Evidence

- Both complete suites passed before and after: 83/83 cases, no skips, with identical within-file case order and status.
- Targeted formatting and type-aware lint passed. The normal `check-changed` gate passed all 20 selected checks, including all three dead-export scans.
- The configured [Blacksmith Testbox run](https://github.com/openclaw/openclaw/actions/runs/34698804748) verified the exact base-plus-one-file source tree and completed successfully. Its one-shot lease was independently confirmed completed. Testbox cleanup can leave the backing Actions step marked cancelled.
- Independent scoped source review found no actionable findings.

Proof limits: exporter/session boundaries are mocked; this is not a live exporter or performance claim. Local proof used Node 26.5.0; the configured remote gate used Node 24.19.0 and pnpm 12.3.4. Both test runs retained the same Vite dynamic-import-analysis warnings. The isolated install also warned that it could not set per-worktree hooks; the existing hook selection was preserved, and install success is not claimed as hook-execution proof.
