### PR TITLE
fix(test): include Kova checks when agent-defaults schemas change

### DIFF
--- a/scripts/test-projects.test-support.mts
+++ b/scripts/test-projects.test-support.mts
@@ -1298,11 +1298,14 @@ function resolveExplicitSourceTestTargets(
   if (isTestFileTarget(relative)) {
     return null;
   }
-  const preciseTargets = resolvePreciseChangedTestTargets(relative, {
-    cwd,
-    forceFullImportGraph: options.forceFullImportGraph === true,
-  });
-  if (preciseTargets && preciseTargets.length > 0) {
+  const preciseTargets = [
+    ...(resolvePreciseChangedTestTargets(relative, {
+      cwd,
+      forceFullImportGraph: options.forceFullImportGraph === true,
+    }) ?? []),
+    ...resolveKovaSchemaTestTargets(relative),
+  ];
+  if (preciseTargets.length > 0) {
     return [...new Set(preciseTargets)].toSorted((left, right) => left.localeCompare(right));
   }
   if (!isTestSupportFileTarget(relative)) {
@@ -3341,6 +3344,14 @@ function resolveAppcastTargets(changedPath: string) {
   return changedPath === "appcast.xml" ? APPCAST_TEST_TARGETS : null;
 }
 
+function resolveKovaSchemaTestTargets(changedPath: string) {
+  // The workflow fixture reads schema bytes, so imports cannot express this dependency.
+  return changedPath === "src/config/zod-schema.agent-defaults.ts" ||
+    changedPath === "src/config/zod-schema.agent-defaults-base.ts"
+    ? ["test/scripts/openclaw-performance-workflow.test.ts"]
+    : [];
+}
+
 function resolvePreciseChangedTestTargets(
   changedPath: string,
   options: ChangedTestTargetOptions & { skipImportGraph?: boolean },
@@ -3463,7 +3474,10 @@ export function resolveChangedTestTargetPlan(
   }
   const plan: ChangedTestTargetPlan = {
     mode: "targets",
-    targets: [...new Set(targets)],
+    targets: uniqueOrdered([
+      ...targets,
+      ...executableChangedPaths.flatMap(resolveKovaSchemaTestTargets),
+    ]),
   };
   if (skippedBroadFallbackPaths.length > 0) {
     plan.skippedBroadFallbackPaths = [...new Set(skippedBroadFallbackPaths)];

--- a/scripts/test-projects.test-support.mts
+++ b/scripts/test-projects.test-support.mts
@@ -135,6 +135,7 @@ type ChangedTestTargetOptions = {
   combineSiblingWithImportGraph?: boolean;
   forceFullImportGraph?: boolean;
   includeExtensionImpact?: boolean;
+  watchMode?: boolean;
 };
 
 type ChangedTestTargetPlan = {
@@ -1285,7 +1286,7 @@ function includePatternMatchesAnyFile(pattern: string, files: string[]) {
 function resolveExplicitSourceTestTargets(
   targetArg: string,
   cwd: string,
-  options: Pick<ChangedTestTargetOptions, "forceFullImportGraph"> = {},
+  options: Pick<ChangedTestTargetOptions, "forceFullImportGraph" | "watchMode"> = {},
 ) {
   const relative = toRepoRelativeTarget(targetArg, cwd);
   const kind = classifyTarget(targetArg, cwd);
@@ -1303,7 +1304,7 @@ function resolveExplicitSourceTestTargets(
       cwd,
       forceFullImportGraph: options.forceFullImportGraph === true,
     }) ?? []),
-    ...resolveKovaSchemaTestTargets(relative),
+    ...(options.watchMode ? [] : resolveKovaSchemaTestTargets(relative)),
   ];
   if (preciseTargets.length > 0) {
     return [...new Set(preciseTargets)].toSorted((left, right) => left.localeCompare(right));
@@ -1320,7 +1321,7 @@ function resolveExplicitSourceTestTargets(
   ].toSorted((left, right) => left.localeCompare(right));
 }
 
-function expandExplicitSourceTestTargets(targetArgs: string[], cwd: string) {
+function expandExplicitSourceTestTargets(targetArgs: string[], cwd: string, watchMode: boolean) {
   const sourceTargetCount = targetArgs.filter((targetArg) => {
     const relative = toRepoRelativeTarget(targetArg, cwd);
     return isExistingFileTarget(targetArg, cwd) && !isTestFileTarget(relative);
@@ -1367,6 +1368,7 @@ function expandExplicitSourceTestTargets(targetArgs: string[], cwd: string) {
     }
     const targets = resolveExplicitSourceTestTargets(targetArg, cwd, {
       forceFullImportGraph,
+      watchMode,
     });
     return targets && targets.length > 0 ? targets : [targetArg];
   });
@@ -1442,7 +1444,7 @@ function isCanonicalAgentOwnerDirectoryTarget(targetArg: string, cwd: string) {
  * Finds explicit test path targets that do not match any known project plan.
  */
 export function findUnmatchedExplicitTestTargets(args: string[], cwd = process.cwd()) {
-  const { targetArgs } = parseTestProjectsArgs(args, cwd);
+  const { targetArgs, watchMode } = parseTestProjectsArgs(args, cwd);
   if (targetArgs.length === 0) {
     return [];
   }
@@ -1494,7 +1496,7 @@ export function findUnmatchedExplicitTestTargets(args: string[], cwd = process.c
       continue;
     }
 
-    const explicitSupportTargets = resolveExplicitSourceTestTargets(targetArg, cwd);
+    const explicitSupportTargets = resolveExplicitSourceTestTargets(targetArg, cwd, { watchMode });
     if (explicitSupportTargets) {
       if (explicitSupportTargets.length === 0) {
         unmatched.push({
@@ -3476,7 +3478,7 @@ export function resolveChangedTestTargetPlan(
     mode: "targets",
     targets: uniqueOrdered([
       ...targets,
-      ...executableChangedPaths.flatMap(resolveKovaSchemaTestTargets),
+      ...(options.watchMode ? [] : executableChangedPaths.flatMap(resolveKovaSchemaTestTargets)),
     ]),
   };
   if (skippedBroadFallbackPaths.length > 0) {
@@ -3522,6 +3524,7 @@ export function resolveChangedTestTargetPlanForArgs(
   return resolveChangedTestTargetPlan(changedPaths, {
     cwd,
     ...options,
+    watchMode: parseTestProjectsArgs(args, cwd).watchMode,
   });
 }
 
@@ -3878,7 +3881,7 @@ export function buildVitestRunPlans(
     );
   }
   const activeTargetArgs = expandBroadToolingScriptTargets(
-    expandExplicitSourceTestTargets(requestedTargetArgs, cwd),
+    expandExplicitSourceTestTargets(requestedTargetArgs, cwd, watchMode),
     cwd,
     watchMode,
   );

--- a/test/scripts/test-projects.test.ts
+++ b/test/scripts/test-projects.test.ts
@@ -3529,6 +3529,116 @@ describe("scripts/test-projects changed-target routing", () => {
     );
   });
 
+  describe("Kova schema selection", () => {
+    const wrapper = "src/config/zod-schema.agent-defaults.ts";
+    const base = "src/config/zod-schema.agent-defaults-base.ts";
+    const sibling = "src/config/zod-schema.agent-defaults.test.ts";
+    const baseConsumer = "src/config/base-consumer.test.ts";
+    const wrapperConsumer = "src/config/wrapper-consumer.test.ts";
+    const unrelated = "src/config/unrelated.ts";
+    const unrelatedTest = "src/config/unrelated.test.ts";
+    const kova = "test/scripts/openclaw-performance-workflow.test.ts";
+    const workflow = ".github/workflows/openclaw-performance.yml";
+    const workflowOwners = [
+      kova,
+      "test/scripts/openclaw-performance-git-lifecycle.test.ts",
+      "test/scripts/ci-git-owner.test.ts",
+      "test/scripts/ci-linux-git.test.ts",
+      "test/scripts/ci-platform-checkout.test.ts",
+      "test/scripts/ci-workflow-guards.test.ts",
+    ];
+    const files = {
+      [base]: "export const defaults = {};\n",
+      [wrapper]: 'export { defaults } from "./zod-schema.agent-defaults-base.js";\n',
+      [sibling]: 'import "./zod-schema.agent-defaults.js";\n',
+      [baseConsumer]: 'import "./zod-schema.agent-defaults-base.js";\n',
+      [wrapperConsumer]: 'import "./zod-schema.agent-defaults.js";\n',
+      [unrelated]: "export const unrelated = true;\n",
+      [unrelatedTest]: 'import "./unrelated.js";\n',
+      [workflow]: "name: performance\n",
+      ...Object.fromEntries(workflowOwners.map((file) => [file, "export {};\n"])),
+    };
+
+    it("keeps skipped import-graph paths visible with mixed broad changes", () => {
+      withTinyGitRepo(files, (cwd) => {
+        const paths = [base, "unknown/file.txt"];
+        expect(resolveChangedTestTargetPlan(paths, { cwd })).toEqual({
+          mode: "targets",
+          targets: [kova],
+          skippedBroadFallbackPaths: paths,
+        });
+        expect(resolveChangedTestTargetPlan(paths, { cwd, broad: true })).toEqual({
+          mode: "broad",
+          targets: [],
+        });
+      });
+    });
+
+    describe.each(["changed", "explicit", "ci"])("%s", (mode) => {
+      it.each([
+        { name: "wrapper only", paths: [wrapper] },
+        { name: "base only", paths: [base] },
+        { name: "both schemas", paths: [wrapper, base, wrapper] },
+        { name: "mixed workflow", paths: [workflow, wrapper, base] },
+        { name: "already selected owner", paths: [base, kova, kova] },
+        { name: "unrelated source", paths: [unrelated] },
+      ])("$name retains normal coverage and adds only the required owner", ({ paths }) => {
+        withTinyGitRepo(files, (cwd) => {
+          const options =
+            mode === "ci"
+              ? { combineSiblingWithImportGraph: true, forceFullImportGraph: true }
+              : {};
+          const args = mode === "explicit" ? paths : ["--changed", "origin/main"];
+          const plans = buildVitestRunPlans(args, cwd, () => paths, options);
+          const selected = plans.flatMap((plan) => plan.includePatterns ?? []);
+          const hasBase = paths.includes(base);
+          const hasWrapper = paths.includes(wrapper);
+          const hasWorkflow =
+            paths.includes(workflow) || (mode !== "explicit" && paths.includes(kova));
+          const normalTargets = hasBase
+            ? [baseConsumer, wrapperConsumer, sibling]
+            : hasWrapper
+              ? mode === "ci"
+                ? [sibling, wrapperConsumer]
+                : [sibling]
+              : [unrelatedTest];
+
+          // Assert the pre-existing coverage before the missing data dependency.
+          expect(selected).toEqual(expect.arrayContaining(normalTargets));
+          if (!hasBase && hasWrapper && mode !== "ci") {
+            expect(selected).not.toContain(wrapperConsumer);
+          }
+          if (mode !== "explicit") {
+            const targets = resolveChangedTargetArgs(args, cwd, () => paths, options);
+            expect(targets).toEqual(expect.arrayContaining(normalTargets));
+            expect(targets?.length).toBe(new Set(targets).size);
+          }
+          if (hasBase || hasWrapper) {
+            expect(selected).toContain(kova);
+            expect(selected.filter((file) => file === kova)).toHaveLength(1);
+            expect(plans).toContainEqual({
+              config: "test/vitest/vitest.tooling.config.ts",
+              forwardedArgs: [],
+              includePatterns: expect.arrayContaining([kova]),
+              watchMode: false,
+            });
+            expect(selected).not.toContain(unrelatedTest);
+          } else {
+            expect(selected).toEqual([unrelatedTest]);
+          }
+          if (hasWorkflow) {
+            expect(selected).toEqual(expect.arrayContaining(workflowOwners));
+          } else {
+            expect(selected.toSorted()).toEqual(
+              [...normalTargets, ...(hasBase || hasWrapper ? [kova] : [])].toSorted(),
+            );
+          }
+          expect(selected.length).toBe(new Set(selected).size);
+        });
+      });
+    });
+  });
+
   it.each(["changed", "explicit"])(
     "routes %s ui support files to the ui lane without dead include globs",
     (mode) => {

--- a/test/scripts/test-projects.test.ts
+++ b/test/scripts/test-projects.test.ts
@@ -3559,6 +3559,80 @@ describe("scripts/test-projects changed-target routing", () => {
       ...Object.fromEntries(workflowOwners.map((file) => [file, "export {};\n"])),
     };
 
+    describe("watch compatibility", () => {
+      describe.each(["changed", "explicit"])("%s", (mode) => {
+        it.each([
+          { name: "wrapper", paths: [wrapper], targets: [sibling] },
+          { name: "base", paths: [base], targets: [baseConsumer, sibling, wrapperConsumer] },
+          {
+            name: "both schemas",
+            paths: [wrapper, base],
+            targets: [baseConsumer, sibling, wrapperConsumer],
+          },
+        ])("keeps $name watch coverage in its existing suite", ({ paths, targets }) => {
+          withTinyGitRepo(files, (cwd) => {
+            const args = [
+              "--watch",
+              ...(mode === "explicit" ? paths : ["--changed", "origin/main"]),
+            ];
+            const plans = buildVitestRunPlans(args, cwd, () => paths);
+            expectSingleVitestRunPlan(plans, {
+              config: "test/vitest/vitest.runtime-config.config.ts",
+              includePatterns: expect.arrayContaining(targets),
+              watchMode: true,
+            });
+            expect(plans[0]?.includePatterns).toHaveLength(targets.length);
+            expect(findUnmatchedExplicitTestTargets(args, cwd)).toEqual([]);
+          });
+        });
+
+        it.each([
+          { flags: ["--watch=false"] },
+          { flags: ["--watch", "false"] },
+          { flags: ["--watch", "--no-watch"] },
+        ])("retains Kova for non-watch flags $flags", ({ flags }) => {
+          withTinyGitRepo(files, (cwd) => {
+            const paths = [wrapper, base];
+            const args = [
+              ...flags,
+              ...(mode === "explicit" ? paths : ["--changed", "origin/main"]),
+            ];
+            const plans = buildVitestRunPlans(args, cwd, () => paths);
+            expect(plans.every((plan) => !plan.watchMode)).toBe(true);
+            expect(plans.flatMap((plan) => plan.includePatterns ?? []).toSorted()).toEqual(
+              [baseConsumer, sibling, wrapperConsumer, kova].toSorted(),
+            );
+          });
+        });
+      });
+
+      it.each([wrapper, base])("still rejects explicitly mixed watch suites for %s", (schema) => {
+        withTinyGitRepo(files, (cwd) => {
+          expect(() => buildVitestRunPlans(["--watch", schema, kova], cwd)).toThrow(
+            "watch mode with mixed test suites is not supported",
+          );
+        });
+      });
+
+      it.each([wrapper, base])(
+        "does not admit unmatched watch source %s through Kova",
+        (schema) => {
+          withTinyGitRepo(
+            { [schema]: "export const defaults = {};\n", [kova]: "export {};\n" },
+            (cwd) => {
+              expect(findUnmatchedExplicitTestTargets([schema], cwd)).toEqual([]);
+              expect(findUnmatchedExplicitTestTargets(["--watch", schema], cwd)).toEqual([
+                expect.objectContaining({
+                  target: schema,
+                  reason: "target-matched-no-test-files",
+                }),
+              ]);
+            },
+          );
+        },
+      );
+    });
+
     it("keeps skipped import-graph paths visible with mixed broad changes", () => {
       withTinyGitRepo(files, (cwd) => {
         const paths = [base, "unknown/file.txt"];


### PR DESCRIPTION
Closes https://github.com/openclaw/openclaw/issues/146055

Related: https://github.com/openclaw/openclaw/pull/145366

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

This is a same-repository branch; maintainers can update it through repository permissions.

</details>

## What Problem This Solves

Resolves a problem where developers changing either agent-defaults schema could
run local changed-test or explicit-source checks without selecting the Kova
workflow regression test that reads those schemas.

## Why This Change Was Made

Add the existing workflow test to the normal selection for both schema owners.
Keep sibling tests, import-graph consumers, deduplication, broad fallback,
skipped-path diagnostics, and the CI combination mode intact. Watch runs retain
their existing suite: only implicit Kova coverage is omitted in watch mode.
Explicitly requested mixed suites still reject. The schemas, workflow,
performance assertions, and runner guard are unchanged.

## User Impact

Developers receive the existing Kova compatibility feedback when checking either
schema locally. Ordinary PR CI already covers this workflow through its fallback;
this change does not claim a CI coverage expansion or speedup.

## Evidence

- Nine causal regression cases on the original selector omitted Kova while
  retaining the expected schema coverage.
- Final selector owner: 562 passed, including 35 focused cases for changed,
  explicit-source, and CI-combined selection, mixed inputs, duplicate targets,
  unrelated sources, skipped-path preservation, watch behavior, and unmatched
  target admission.
- The hosted watch finding was reproduced through the public planner before
  execution. Six watch-plan cases and two unmatched-admission cases failed on
  the earlier head; all 33 selected watch/control cases passed after repair.
  False/negated-watch flags still include Kova; no persistent watcher was started.
- The unchanged checked-in-schema Kova case passed through the supported test
  wrapper on Linux. This is local workflow-boundary proof, not a benchmark or
  hosted FRV result.
- All amendment changed-file gates passed, including script/root-test typechecks,
  unused-export scans, formatting, and targeted lint. Independent scoped review
  completed with no actionable findings.
- [Amended-head CI](https://github.com/openclaw/openclaw/actions/runs/34701441964)
  passed, including the required `openclaw/ci-gate`, at
  `d756741440a4c8c33ecac212c99c72dd354fa28e`. The watcher completed green with
  superseded contexts excluded; historical checks are not relabeled as passing.

The [hosted watch finding](https://github.com/openclaw/openclaw/pull/146057#issuecomment-5646650037)
is repaired in `d756741440a4c8c33ecac212c99c72dd354fa28e`: existing parsed watch
mode now reaches both implicit additions and unmatched-target admission.
The mixed-suite watch guard is unchanged.

No full FRV, benchmark, release, or live-provider operation was dispatched.
