### PR TITLE
fix(talk): restore speech interruption during forced consults

### DIFF
--- a/extensions/openai/realtime-voice-bridge-connection.test.ts
+++ b/extensions/openai/realtime-voice-bridge-connection.test.ts
@@ -687,6 +687,13 @@ describe("OpenAI realtime voice bridge connection", () => {
 
   it.each([
     {
+      $name: "automatic audio turn responses disabled with speech interruption enabled",
+      autoRespondToAudio: false,
+      interruptResponseOnInputAudio: true,
+      expectedCreateResponse: false,
+      expectedInterruptResponse: true,
+    },
+    {
       $name: "automatic audio turn responses disabled",
       autoRespondToAudio: false,
       interruptResponseOnInputAudio: false,

--- a/extensions/openai/realtime-voice-bridge-events.test.ts
+++ b/extensions/openai/realtime-voice-bridge-events.test.ts
@@ -429,14 +429,34 @@ describe("OpenAI realtime voice bridge events", () => {
       audioFormat: REALTIME_VOICE_AUDIO_FORMAT_PCM16_24KHZ,
       providerVad: true,
     },
+    {
+      name: "provider VAD with automatic responses disabled",
+      producedAudioMs: 3_700,
+      mediaElapsedMs: 3_760,
+      bytesPerMs: 48,
+      audioFormat: REALTIME_VOICE_AUDIO_FORMAT_PCM16_24KHZ,
+      providerVad: true,
+      autoRespondToAudio: false,
+      interruptResponseOnInputAudio: true,
+    },
   ])(
     "truncates $name",
-    async ({ producedAudioMs, mediaElapsedMs, bytesPerMs, audioFormat, providerVad }) => {
+    async ({
+      producedAudioMs,
+      mediaElapsedMs,
+      bytesPerMs,
+      audioFormat,
+      providerVad,
+      autoRespondToAudio,
+      interruptResponseOnInputAudio,
+    }) => {
       const onAudio = vi.fn();
       const onClearAudio = vi.fn();
       const bridge = createNativeBridge({
         onAudio,
         onClearAudio,
+        autoRespondToAudio,
+        interruptResponseOnInputAudio,
         ...(audioFormat ? { audioFormat } : {}),
         ...(providerVad ? {} : { onMark: () => bridge.acknowledgeMark() }),
       });

--- a/src/gateway/talk-realtime-relay-session-create.ts
+++ b/src/gateway/talk-realtime-relay-session-create.ts
@@ -9,6 +9,7 @@ import {
   type RealtimeVoiceCloseReason,
 } from "../talk/provider-types.js";
 import { createRealtimeVoiceSessionHarness } from "../talk/realtime-session-harness.js";
+import { resolveRealtimeVoiceInterruptResponseOnInputAudio } from "../talk/realtime-session-policy.js";
 import type { TalkEventInput } from "../talk/talk-session-controller.js";
 import { VOICE_TRANSCRIPT_QUEUE_POLICY } from "../talk/voice-transcript.js";
 import { createTalkClientAgentConsultRunner } from "./talk-client-agent-consult.js";
@@ -219,7 +220,9 @@ export function createTalkRealtimeRelaySession(
     instructions: params.instructions,
     language: params.language,
     autoRespondToAudio: !forceAgentConsultOnFinalTranscript,
-    interruptResponseOnInputAudio: !forceAgentConsultOnFinalTranscript,
+    interruptResponseOnInputAudio: resolveRealtimeVoiceInterruptResponseOnInputAudio(
+      params.providerConfig.interruptResponseOnInputAudio,
+    ),
     tools: params.tools,
     ...(runControl.handleDelegationInput
       ? {

--- a/src/gateway/talk-realtime-relay.test.ts
+++ b/src/gateway/talk-realtime-relay.test.ts
@@ -2669,7 +2669,10 @@ describe("talk realtime gateway relay", () => {
     });
     await Promise.resolve();
 
-    expectRecordFields(bridgeRequest, { autoRespondToAudio: false });
+    expectRecordFields(bridgeRequest, {
+      autoRespondToAudio: false,
+      interruptResponseOnInputAudio: true,
+    });
 
     bridgeRequest?.onTranscript?.("user", "Can you check this?", true);
     expect(bridge.sendUserMessage).not.toHaveBeenCalledWith("Can you check this?");
@@ -2807,6 +2810,37 @@ describe("talk realtime gateway relay", () => {
     });
     stopTalkRealtimeRelaySession({ relaySessionId: session.relaySessionId, connId: "conn-1" });
   });
+
+  it.each([false, true])(
+    "respects disabled speech interruption with forced consult routing %s",
+    (forceAgentConsultOnFinalTranscript) => {
+      let bridgeRequest: RealtimeVoiceBridgeCreateRequest | undefined;
+      const provider: RealtimeVoiceProviderPlugin = {
+        id: "relay-test",
+        label: "Relay Test",
+        isConfigured: () => true,
+        createBridge: (request) => {
+          bridgeRequest = request;
+          return makeRelayTransport();
+        },
+      };
+
+      createTalkRealtimeRelaySession({
+        context: { broadcastToConnIds: vi.fn() } as never,
+        connId: "conn-1",
+        provider,
+        providerConfig: { interruptResponseOnInputAudio: false },
+        instructions: "be brief",
+        tools: [],
+        forceAgentConsultOnFinalTranscript,
+      });
+
+      expectRecordFields(bridgeRequest, {
+        autoRespondToAudio: !forceAgentConsultOnFinalTranscript,
+        interruptResponseOnInputAudio: false,
+      });
+    },
+  );
 
   it("uses the actual forced result when one native call cannot suppress responses", async () => {
     const fixture = await createSuppressionUnsupportedForcedConsultFixture(["native-call"]);


### PR DESCRIPTION
Closes #139278

<details>
<summary>Additional instructions</summary>

Allow edits from maintainers is enabled.

</details>

## What Problem This Solves

Fixes an issue where users speaking over a Talk reply would not interrupt playback through provider speech detection when `force-agent-consult` was enabled. Ordinary provider-direct sessions also ignored an explicitly disabled speech-interruption setting.

## Why This Change Was Made

Resolve the relay's interruption setting through the existing shared Talk policy, independently of consult routing. Forced consults still disable automatic provider answers, while an explicit provider `interruptResponseOnInputAudio: false` remains effective in either routing mode.

## User Impact

Talk's existing speech-interruption behavior is available during forced-consult playback. Users who explicitly turn interruption off retain that preference.

## Evidence

- Before the production change, the Gateway suite failed exactly the two relevant regression assertions: forced-consult interruption was disabled, and provider-direct routing overrode an explicit `false`. The other 131 cases passed.
- After the fix, all 220 tests passed across the Gateway relay, shared Talk policy/runtime, and native OpenAI bridge connection/events suites. The OpenAI checks exercise the actual provider with fake sockets: automatic response stays off, speech interruption is enabled, and a speech-start event truncates and clears playback. Existing echo, ownership, cleanup, and disabled-interruption cases pass.
- Changed-file formatting and lint, core and test typechecks, and the remaining dependency, boundary, schema, and safety guards passed.
- The full `check:changed` command exited 1 at the unused-export scan: `canonicalProviderName` in `scripts/crabbox-wrapper-providers.mts` and `listPackagedStaticExtensionAssetOutputs` in `scripts/lib/static-extension-assets.mts`. These scripts and the scan configuration match the base commit; existing call sites are present in the base tree. This PR does not modify those files or suppress the diagnostics.
- Independent autoreview completed with no actionable P0–P2 findings.

Validation ran on Windows with Node 24.19.0.

**Follow-up validation (2026-09-13, unchanged head `315a414788febf8a0b4c9e37a85c32390392df97`):**

- [The failed CI shard](https://github.com/openclaw/openclaw/actions/runs/34700430258/job/103571208489) reports one timeout in `src/agents/runtime-plan/resolve-auth.test.ts`: `does not borrow an unprepared API-key profile for direct subscription auth` took 1090 ms against its explicit 1000 ms timeout. The other 3132 tests in that shard passed. The aggregate CI gate failed as a consequence.
- Ran the complete auth test file once with `node scripts/run-vitest.mjs src/agents/runtime-plan/resolve-auth.test.ts`: **17/17 passed**, exit 0; the affected case took 407 ms. No retries, timeout changes, or source changes were made. The auth implementation and test are outside this PR's diff. This does not establish that the CI failure is flaky: CI used Linux, a larger concurrent shard, and merge commit `3b748295` (this head merged into `81a4c771`), whereas the local run used Windows and the PR head.
- A targeted rerun request was rejected by GitHub with HTTP 403 because this contributor account lacks repository admin rights. **Maintainer follow-up requested:** rerun `checks-node-compact-large-14` and its dependent CI gate on this head.

**Real Talk playback proof is still missing.** A read-only authentication probe reached the official OpenAI API, but the available credential was rejected with HTTP 401 `invalid_api_key`. No realtime session was created, no audio was generated, and no microphone capture was performed. The unit tests above are not live proof.

Once authorized Realtime credentials are available, the remaining validation is a real provider-to-client Talk session showing speech-start interruption during forced-consult playback without an automatic duplicate answer, and showing that explicit `interruptResponseOnInputAudio: false` suppresses that speech-start interruption. Record provider speech-start and playback-clear timing separately from later finalized-transcript consult cancellation. A sanitized recording or runtime log should be added before requesting proof clearance.

