### PR TITLE
fix(ui): clarify environment catalog loading

### DIFF
--- a/ui/src/e2e/new-session-page.environment-picker-loading.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.environment-picker-loading.e2e.test.ts
@@ -1,0 +1,106 @@
+import { writeFile } from "node:fs/promises";
+import path from "node:path";
+import { expect, it } from "vitest";
+import {
+  LOCAL_GIT_WORKSPACE_RESPONSES,
+  captureUiProofEnabled,
+  createNewSessionPageE2eSuite,
+  installMockGateway,
+  openEnvironmentPicker,
+} from "./new-session-page.test-support.ts";
+
+const suite = createNewSessionPageE2eSuite();
+
+async function takeScreenshot(page: Parameters<typeof openEnvironmentPicker>[0]) {
+  await page.evaluate(async () => {
+    await document.fonts.ready;
+  });
+  return page.screenshot({ animations: "disabled", scale: "css" });
+}
+
+suite.define(() => {
+  it("shows catalog skeletons, then uses provider capabilities and fallback defaults", async () => {
+    await suite.withPage(
+      { locale: "en-US", serviceWorkers: "block", viewport: { width: 1440, height: 900 } },
+      async ({ page }) => {
+        const gateway = await installMockGateway(page, {
+          operatorScopes: ["operator.admin", "operator.read", "operator.write"],
+          workspaceGit: true,
+          heldMethods: ["environments.list"],
+          methodResponses: LOCAL_GIT_WORKSPACE_RESPONSES,
+        });
+        await page.goto(`${suite.server.baseUrl}new`);
+        await gateway.waitForRequest("environments.list");
+        await openEnvironmentPicker(page);
+        const picker = page.locator("wa-popover.new-session-page__where-popover");
+        const loading = picker.locator(".new-session-page__environment-skeletons");
+        await loading.first().waitFor();
+        expect(await loading.count()).toBe(2);
+        expect(await loading.first().getAttribute("aria-busy")).toBe("true");
+        if (captureUiProofEnabled) {
+          await writeFile(
+            path.join(suite.artifactDir, "environment-picker-loading-after.png"),
+            await takeScreenshot(page),
+          );
+        }
+
+        await gateway.resolveDeferred("environments.list", {
+          environments: [
+            {
+              id: "node:studio",
+              type: "node",
+              label: "Studio Mac",
+              status: "available",
+              sessionHost: true,
+              workerSlots: { total: 2, available: 2 },
+            },
+          ],
+          profiles: [
+            {
+              id: "Daytona Crabbox",
+              providerId: "crabbox",
+              machines: [
+                { id: "small", label: "Small", cpu: 4, memoryGb: 8 },
+                { id: "large", label: "Large", cpu: 8, memoryGb: 16 },
+              ],
+            },
+            { id: "GCP", providerId: "crabbox" },
+            { id: "Machine0", providerId: "crabbox" },
+          ],
+        });
+        const daytona = picker.getByRole("button", { name: "Daytona Crabbox", exact: true });
+        await daytona.waitFor();
+        await daytona.hover();
+        const configuration = picker.locator(".new-session-page__cloud-configuration");
+        await configuration.waitFor();
+        expect(await configuration.getByText("Operating system", { exact: true }).count()).toBe(0);
+        await configuration.getByText("Machine", { exact: true }).waitFor();
+        expect(
+          await configuration.locator('[data-value="machine:small"]').getAttribute("aria-pressed"),
+        ).toBe("true");
+        expect(await picker.locator(".new-session-page__cloud-configuration").count()).toBe(1);
+        const plus = picker.locator('[data-action="manage-cloud-workers"]');
+        const chevron = daytona.locator(".new-session-page__submenu-chevron");
+        const [plusBox, chevronBox] = await Promise.all([
+          plus.boundingBox(),
+          chevron.boundingBox(),
+        ]);
+        expect(plusBox?.width).toBeLessThanOrEqual(20);
+        expect(chevronBox).not.toBeNull();
+        expect(
+          Math.abs(
+            (plusBox?.x ?? 0) +
+              (plusBox?.width ?? 0) / 2 -
+              ((chevronBox?.x ?? 0) + (chevronBox?.width ?? 0) / 2),
+          ),
+        ).toBeLessThanOrEqual(4);
+        if (captureUiProofEnabled) {
+          await writeFile(
+            path.join(suite.artifactDir, "environment-picker-capabilities-after.png"),
+            await takeScreenshot(page),
+          );
+        }
+      },
+    );
+  });
+});

--- a/ui/src/pages/new-session/cloud-target.test.ts
+++ b/ui/src/pages/new-session/cloud-target.test.ts
@@ -199,6 +199,55 @@ describe("cloud target menu", () => {
     );
   });
 
+  it("uses the first machine as the displayed default when a provider omits one", () => {
+    const container = document.createElement("div");
+    render(
+      renderCloudProfileMenuItems({
+        profiles: [
+          {
+            id: "daytona",
+            providerId: "crabbox",
+            machines: [
+              { id: "small", label: "Small", cpu: 4, memoryGb: 8 },
+              { id: "large", label: "Large", cpu: 8, memoryGb: 16 },
+            ],
+          },
+        ],
+        selectedId: "daytona",
+        compact: true,
+        submitting: false,
+        onSelect: vi.fn(),
+      }),
+      container,
+    );
+    expect(
+      container.querySelector('[data-value="machine:small"]')?.getAttribute("aria-pressed"),
+    ).toBe("true");
+  });
+
+  it("omits the operating-system heading when a provider exposes only machines", () => {
+    const container = document.createElement("div");
+    render(
+      renderCloudProfileMenuItems({
+        profiles: [
+          {
+            id: "daytona",
+            providerId: "crabbox",
+            machines: [{ id: "small", label: "Small", cpu: 4, memoryGb: 8 }],
+          },
+        ],
+        selectedId: "daytona",
+        compact: true,
+        submitting: false,
+        onSelect: vi.fn(),
+      }),
+      container,
+    );
+    const configuration = container.querySelector(".new-session-page__cloud-configuration");
+    expect(configuration?.textContent).not.toContain("Operating system");
+    expect(configuration?.textContent).toContain("Machine");
+  });
+
   it("forwards configuration choices and disables them while submitting", () => {
     const container = document.createElement("div");
     const onSelectMachine = vi.fn();

--- a/ui/src/pages/new-session/cloud-target.ts
+++ b/ui/src/pages/new-session/cloud-target.ts
@@ -12,6 +12,7 @@ import type {
 } from "./discovery.ts";
 import {
   cloudMachinesForOs,
+  defaultCloudMachine,
   defaultCloudOs,
   readDraftCloudProfiles,
   readDraftEnvironments,
@@ -262,7 +263,7 @@ export function renderCloudProfileMenuItems(params: {
     const machine =
       (selected && params.selectedMachine
         ? machines.find((option) => option.id === params.selectedMachine)
-        : undefined) ?? machines.find((option) => option.default);
+        : undefined) ?? defaultCloudMachine(profile, osId);
 
     const item = renderSessionMenuItem(
       {
@@ -374,26 +375,32 @@ function renderCloudConfiguration(params: {
     class="new-session-page__cloud-configuration"
     aria-label=${params.profile.id}
   >
-    <div class="new-session-page__environment-heading">${t("newSession.operatingSystem")}</div>
-    <div
-      class="new-session-page__cloud-choice-list"
-      role="group"
-      aria-label=${t("newSession.operatingSystem")}
-    >
-      ${
-        fixedOs
-          ? html`<span class="new-session-page__fixed-os" data-value=${`os:${fixedOs.id}`}
-              >${fixedOs.label}</span
-            >`
-          : renderCloudOsMenuItems({
-              operatingSystems,
-              selectedId: params.selectedOs,
-              suggestedId: params.suggested ? defaultCloudOs(params.profile) : undefined,
-              submitting: params.submitting,
-              onSelect: params.onSelectOs,
-            })
-      }
-    </div>
+    ${
+      operatingSystems.length
+        ? html`<div class="new-session-page__environment-heading">
+              ${t("newSession.operatingSystem")}
+            </div>
+            <div
+              class="new-session-page__cloud-choice-list"
+              role="group"
+              aria-label=${t("newSession.operatingSystem")}
+            >
+              ${
+                fixedOs
+                  ? html`<span class="new-session-page__fixed-os" data-value=${`os:${fixedOs.id}`}
+                      >${fixedOs.label}</span
+                    >`
+                  : renderCloudOsMenuItems({
+                      operatingSystems,
+                      selectedId: params.selectedOs,
+                      suggestedId: params.suggested ? defaultCloudOs(params.profile) : undefined,
+                      submitting: params.submitting,
+                      onSelect: params.onSelectOs,
+                    })
+              }
+            </div>`
+        : nothing
+    }
     ${
       params.machines.length
         ? html`<div class="new-session-page__environment-heading">${t("newSession.machine")}</div>
@@ -409,7 +416,7 @@ function renderCloudConfiguration(params: {
                       machines: params.machines,
                       selectedId: params.selectedMachine,
                       suggestedId: params.suggested
-                        ? params.machines.find((machine) => machine.default)?.id
+                        ? defaultCloudMachine(params.profile, params.selectedOs)?.id
                         : undefined,
                       submitting: params.submitting,
                       onSelect: params.onSelectMachine,

--- a/ui/src/pages/new-session/discovery.ts
+++ b/ui/src/pages/new-session/discovery.ts
@@ -230,6 +230,15 @@ export function cloudMachinesForOs(profile: DraftCloudProfile, os: string): Draf
   return (profile.machines ?? []).filter((machine) => !machine.os || machine.os === os);
 }
 
+/** Providers that omit a marked default still present their first catalog choice as the default. */
+export function defaultCloudMachine(
+  profile: DraftCloudProfile,
+  os = defaultCloudOs(profile),
+): DraftMachineOption | undefined {
+  const machines = cloudMachinesForOs(profile, os);
+  return machines.find((machine) => machine.default) ?? machines[0];
+}
+
 const ENVIRONMENT_STATUSES = new Set<EnvironmentStatus>([
   "available",
   "unavailable",

--- a/ui/src/pages/new-session/draft-cloud-machine-state.ts
+++ b/ui/src/pages/new-session/draft-cloud-machine-state.ts
@@ -1,4 +1,9 @@
-import { cloudMachinesForOs, defaultCloudOs, type DraftCloudProfile } from "./discovery.ts";
+import {
+  cloudMachinesForOs,
+  defaultCloudMachine,
+  defaultCloudOs,
+  type DraftCloudProfile,
+} from "./discovery.ts";
 
 type CloudOverride = { os?: string; machineClass?: string };
 
@@ -76,7 +81,9 @@ export class DraftCloudMachineState {
     }
     this.applyPending(
       profileId,
-      machine.default === true ? undefined : machine.id,
+      defaultCloudMachine(profile, this.selectedOs(profile))?.id === machine.id
+        ? undefined
+        : machine.id,
       this.resolveOs(profileId),
     );
     onChange?.();

--- a/ui/src/pages/new-session/target-controls.ts
+++ b/ui/src/pages/new-session/target-controls.ts
@@ -139,6 +139,7 @@ export function renderNewSessionPlaceControls({
             place.modelControl.cloudRuntimeUnsupportedReason(profile),
           submitting,
           pendingPlacement,
+          catalogLoading: place.canWrite() && gateway.cloudProfilesPending,
           isAdmin: place.isAdmin(),
           ...browser.popoverCallbacks("where"),
           onSelectDevice: (deviceId) => place.selectDevice(deviceId),

--- a/ui/src/pages/new-session/where-chip.test.ts
+++ b/ui/src/pages/new-session/where-chip.test.ts
@@ -95,6 +95,18 @@ function renderPicker(
 }
 
 describe("Where chip", () => {
+  it("shows device and cloud skeletons while the catalog loads", () => {
+    const container = renderPicker(
+      true,
+      undefined,
+      { environments: null, cloudProfiles: [] },
+      { catalogLoading: true },
+    );
+    expect(container.querySelectorAll(".new-session-page__environment-skeletons")).toHaveLength(2);
+    expect(container.querySelector('[data-section="devices"]')).not.toBeNull();
+    expect(container.querySelector('[data-section="cloud"]')).not.toBeNull();
+  });
+
   it.each([
     { label: "Work MacBook Pro", platform: "darwin", icon: deviceIcons.laptop, form: "laptop" },
     {

--- a/ui/src/pages/new-session/where-chip.ts
+++ b/ui/src/pages/new-session/where-chip.ts
@@ -16,6 +16,7 @@ import {
 } from "./device-placement.ts";
 import {
   cloudMachinesForOs,
+  defaultCloudMachine,
   defaultCloudOs,
   type DraftCloudProfile,
   type DraftEnvironment,
@@ -69,7 +70,7 @@ export function resolveWhereChip(params: {
     const selectedOsId = params.os || defaultOs;
     const operatingSystems = profile?.operatingSystems ?? [];
     const cloudMachines = profile ? cloudMachinesForOs(profile, selectedOsId) : [];
-    const defaultMachine = cloudMachines.find((machine) => machine.default === true);
+    const defaultMachine = profile ? defaultCloudMachine(profile, selectedOsId) : undefined;
     const selectedMachine = params.machineClass
       ? cloudMachines.find((machine) => machine.id === params.machineClass)
       : defaultMachine;
@@ -144,6 +145,19 @@ function environmentDeviceIcon(device?: DevicePlacementOption) {
   return html`<span class="new-session-page__device-icon" data-form=${form}>${icon}</span>`;
 }
 
+function renderEnvironmentSkeletons(section: "devices" | "cloud") {
+  return html`<div
+    class="new-session-page__environment-skeletons"
+    role="status"
+    aria-label=${t("common.loading")}
+    aria-busy="true"
+    data-section=${section}
+  >
+    <span class="skeleton new-session-page__environment-skeleton-row" aria-hidden="true"></span>
+    <span class="skeleton new-session-page__environment-skeleton-row" aria-hidden="true"></span>
+  </div>`;
+}
+
 export function renderWhereChip(params: {
   autoPlacementMode?: "least-busy" | "eligible-order";
   state: WhereChipState;
@@ -163,6 +177,7 @@ export function renderWhereChip(params: {
   popoverOpen: boolean;
   popoverHiding: boolean;
   isAdmin: boolean;
+  catalogLoading?: boolean;
   onGuardTransition: (event: MouseEvent) => void;
   onPopoverShow: () => void;
   onPopoverHide: () => void;
@@ -244,6 +259,8 @@ export function renderWhereChip(params: {
     );
   const busy = params.submitting || params.pendingPlacement;
   const destinationDisabled = busy;
+  const showDeviceSkeletons = params.catalogLoading && devices.length === 0;
+  const showCloudSkeletons = params.isAdmin && params.catalogLoading && cloudProfiles.length === 0;
   let cleanupScrollFade: (() => void) | undefined;
   const bindScrollFade = (element: Element | undefined) => {
     cleanupScrollFade?.();
@@ -451,14 +468,15 @@ export function renderWhereChip(params: {
                 destinationDisabled,
               );
             })}
+            ${showDeviceSkeletons ? renderEnvironmentSkeletons("devices") : nothing}
             ${
-              cloudProfiles.length || showMissingCloud
+              cloudProfiles.length || showMissingCloud || showCloudSkeletons
                 ? html`<div
                     class="new-session-page__environment-heading new-session-page__devices-heading"
                   >
                     <span>${t("newSession.cloud")}</span>
                     ${
-                      params.isAdmin
+                      params.isAdmin && !showCloudSkeletons
                         ? html`<button
                             type="button"
                             class="new-session-page__connect-device"
@@ -491,6 +509,7 @@ export function renderWhereChip(params: {
               profileDisabledReason: params.cloudProfileDisabledReason,
               onSelect: params.onSelectCloudProfile,
             })}
+            ${showCloudSkeletons ? renderEnvironmentSkeletons("cloud") : nothing}
             ${
               showMissingCloud
                 ? renderSessionMenuItem(
@@ -510,7 +529,12 @@ export function renderWhereChip(params: {
                 : nothing
             }
             ${
-              !showLocal && devices.length === 0 && cloudProfiles.length === 0 && !showMissingCloud
+              !showLocal &&
+              devices.length === 0 &&
+              cloudProfiles.length === 0 &&
+              !showMissingCloud &&
+              !showDeviceSkeletons &&
+              !showCloudSkeletons
                 ? html`<div class="new-session-page__environment-empty" role="status">
                     ${t("newSession.environmentSearchEmpty")}
                   </div>`

--- a/ui/src/styles/new-session.css
+++ b/ui/src/styles/new-session.css
@@ -848,6 +848,21 @@ wa-popover.new-session-page__where-popover::part(body) {
   font-size: var(--control-ui-text-sm);
 }
 
+.new-session-page__environment-skeletons {
+  display: grid;
+  gap: 8px;
+  padding: 6px 12px;
+}
+
+.new-session-page__environment-skeleton-row {
+  display: block;
+  height: 14px;
+}
+
+.new-session-page__environment-skeleton-row:nth-child(2) {
+  width: 72%;
+}
+
 .new-session-page__menu-chevron {
   display: inline-flex;
   margin-left: auto;
@@ -1481,10 +1496,11 @@ wa-popover.new-session-page__where-popover::part(body) {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  flex: 0 0 24px;
-  width: 24px;
-  height: 24px;
-  padding: 3px;
+  flex: 0 0 20px;
+  width: 20px;
+  height: 20px;
+  margin-right: -4px;
+  padding: 2px;
   border: 0;
   border-radius: 50%;
   color: inherit;
@@ -1498,8 +1514,8 @@ wa-popover.new-session-page__where-popover::part(body) {
 
 .new-session-page__connect-device svg {
   display: block;
-  width: 16px;
-  height: 16px;
+  width: 14px;
+  height: 14px;
 }
 
 .new-session-page__cloud-choice-list + .new-session-page__environment-heading {


### PR DESCRIPTION
## What problem this solves

The New Session environment picker appeared mostly empty while its catalog loaded. Cloud providers without configuration metadata also displayed an empty operating-system section, and providers without a marked default machine did not show a selected default.

## What changed

- Show device and cloud skeleton rows while the catalog request is pending.
- Render each configuration heading only when that capability has options.
- Treat the first available machine as the displayed default when a provider supplies no explicit default.
- Align and reduce the size of the device/cloud management plus icons.

The Crabbox extension already supplies this catalog in this repository, so the fix is in the shared picker and covers Daytona, GCP, Machine0, and other providers consistently.

## Validation

- `pnpm exec vitest run --config ui/vitest.config.ts ui/src/pages/new-session/where-chip.test.ts ui/src/pages/new-session/cloud-target.test.ts ui/src/pages/new-session/discovery.test.ts`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/new-session-page.environment-picker-loading.e2e.test.ts`
- `pnpm lint:ui:styles`
- `pnpm lint:ui:lit`
- `pnpm lint:ui:no-raw-window-open`

Visual before/after proof is attached in the first PR comment.
