### PR TITLE
fix(plugins): canonicalize bundled setup artifacts

### DIFF
--- a/src/plugins/setup-registry.test.ts
+++ b/src/plugins/setup-registry.test.ts
@@ -347,6 +347,58 @@ describe("setup-registry module loader", () => {
     );
   });
 
+  it("executes canonical dist setup entries instead of their staging wrappers", () => {
+    const packageRoot = makeTempDir();
+    const pluginRoot = path.join(packageRoot, "extensions", "fixture");
+    const sourceSetup = path.join(pluginRoot, "setup-api.ts");
+    const stagingSetup = path.join(
+      packageRoot,
+      "dist-runtime",
+      "extensions",
+      "fixture",
+      "setup-api.js",
+    );
+    const canonicalSetup = path.join(packageRoot, "dist", "extensions", "fixture", "setup-api.js");
+    for (const setupPath of [sourceSetup, stagingSetup, canonicalSetup]) {
+      fs.mkdirSync(path.dirname(setupPath), { recursive: true });
+      fs.writeFileSync(setupPath, "export default {};\n", "utf8");
+    }
+    fs.writeFileSync(
+      path.join(path.dirname(stagingSetup), "package.json"),
+      JSON.stringify({ openclaw: { setupEntry: "./setup-api.js" } }),
+    );
+    mocks.loadPluginManifestRegistry.mockReturnValue({
+      plugins: [
+        {
+          id: "fixture",
+          origin: "bundled",
+          rootDir: pluginRoot,
+          setupSource: sourceSetup,
+          setup: { providers: [{ id: "fixture" }] },
+        },
+      ],
+      diagnostics: [],
+    });
+    const canonicalRealPath = fs.realpathSync(canonicalSetup);
+    mocks.createJiti.mockImplementation(() => (modulePath: string) => ({
+      default: {
+        register(api: {
+          registerProvider: (provider: { id: string; label: string; auth: [] }) => void;
+        }) {
+          api.registerProvider({
+            id: "fixture",
+            label: modulePath === canonicalRealPath ? "canonical" : "staging",
+            auth: [],
+          });
+        },
+      },
+    }));
+
+    expect(resolvePluginSetupProviderCore({ provider: "fixture", env: {} })?.label).toBe(
+      "canonical",
+    );
+  });
+
   it("keeps bundled setup artifact selection independent of active runtime state", () => {
     const setupRegistrySource = fs.readFileSync(
       new URL("./setup-registry.ts", import.meta.url),

--- a/src/plugins/setup-registry.ts
+++ b/src/plugins/setup-registry.ts
@@ -34,7 +34,10 @@ import { tracePluginLifecyclePhase } from "./plugin-lifecycle-trace.js";
 import { PluginLruCache } from "./plugin-lru-cache.js";
 import { resolvePluginMetadataEnvFingerprint } from "./plugin-metadata-snapshot.js";
 import { loadPluginRegistrySnapshotWithMetadata } from "./plugin-registry.js";
-import { resolvePreferredBundledRootArtifact } from "./plugin-runtime-artifact-selection.js";
+import {
+  resolvePluginRuntimeExecutionArtifact,
+  resolvePreferredBundledRootArtifact,
+} from "./plugin-runtime-artifact-selection.js";
 import { getPluginSetupModuleLoader } from "./plugin-setup-module.js";
 import { resolvePluginRootArtifactPath } from "./root-artifact-path.js";
 import { listSetupCliBackendIds, listSetupProviderIds } from "./setup-descriptors.js";
@@ -213,11 +216,13 @@ function resolveLoadableSetupRuntimeSource(
   if (record.origin !== "bundled" || record.sourcePreferred) {
     return { source, rootDir: record.rootDir };
   }
-  return resolvePreferredBundledRootArtifact({
-    source,
-    rootDir: record.rootDir,
-    packageManifest: record.packageManifest,
-  });
+  return resolvePluginRuntimeExecutionArtifact(
+    resolvePreferredBundledRootArtifact({
+      source,
+      rootDir: record.rootDir,
+      packageManifest: record.packageManifest,
+    }),
+  );
 }
 
 function resolveDeclaredSetupRuntimeSource(record: PluginManifestRecord): string | null {


### PR DESCRIPTION
## Problem

Bundled plugin setup migrations selected `dist-runtime` staging wrappers even when the canonical `dist` artifact existed. Node's module hooks followed those wrappers into the canonical graph, but Bun captured the wrapper in an isolated plugin package and then resolved its relative import against a nonexistent temporary `dist` tree. As a result, Canvas and Voice Call setup migrations silently disappeared with `setup-entry-load-failed` diagnostics.

## Solution

Pass bundled setup artifact selection through the existing runtime execution canonicalizer. Source-preferred and installed plugins keep their current paths; bundled staging entries now use the same canonical `dist` graph as ordinary plugin execution.

The regression test creates source, staging, and canonical setup entries and verifies that the setup registry executes the canonical entry. This keeps the behavior visible in Node CI as well as direct Bun runs.

## Evidence

- Direct custom-Bun unit-fast aggregate: 1,555 files passed, 3 platform files skipped; 20,212 tests passed, 44 skipped, 0 failed.
- Bun setup migration integration: 3 passed, including Canvas and Voice Call migrations that failed before the fix.
- Setup registry selector suite: 39 passed under both Bun and Node.
- Node setup migration integration: 3 passed.
- `pnpm check:changed` passed, including formatting, lint, core and test typechecks, database guards, and runtime import-cycle checks.
- Independent P0-P2 review completed with no actionable findings.

## Release-note context

Fix bundled plugin setup migrations under Bun by resolving staging wrappers to their canonical runtime artifacts.
