### PR TITLE
refactor(skills): retire the unused status index

### DIFF
--- a/src/skills/discovery/skill-index.test.ts
+++ b/src/skills/discovery/skill-index.test.ts
@@ -1,8 +1,7 @@
-// Skill index tests cover normalized skill names and discovery index behavior.
+// Skill discovery helpers preserve name matching and prompt/command exposure.
 import { describe, expect, it } from "vitest";
 import { createFixtureSkillEntry } from "../test-support/test-helpers.js";
 import {
-  buildSkillIndexEntries,
   filterPromptVisibleSkillEntries,
   filterUserInvocableSkillEntries,
   normalizeSkillIndexName,
@@ -15,19 +14,7 @@ describe("skill index", () => {
     expect(normalizeSkillIndexName("@@")).toBe("");
   });
 
-  it("indexes entries without changing input order", () => {
-    const entries = [
-      createFixtureSkillEntry("Excel XLSX", { skillKey: "excel_xlsx" }),
-      createFixtureSkillEntry("GitHub Review"),
-    ];
-
-    expect(buildSkillIndexEntries(entries).map((entry) => entry.name)).toEqual([
-      "Excel XLSX",
-      "GitHub Review",
-    ]);
-  });
-
-  it("centralizes runtime, prompt, and command exposure policy", () => {
+  it("keeps prompt and command exposure independent of runtime visibility", () => {
     const runtimeHidden = createFixtureSkillEntry("runtime-hidden", {
       exposure: {
         includeInRuntimeRegistry: false,
@@ -54,68 +41,11 @@ describe("skill index", () => {
     });
 
     const entries = [runtimeHidden, promptHidden, commandHidden, legacyPromptHidden];
-    const indexEntries = buildSkillIndexEntries(entries);
-
-    expect(indexEntries.filter((entry) => entry.runtimeVisible).map((entry) => entry.name)).toEqual(
-      ["prompt-hidden", "command-hidden", "legacy-prompt-hidden"],
-    );
-    expect(indexEntries.filter((entry) => entry.promptVisible).map((entry) => entry.name)).toEqual([
-      "runtime-hidden",
-      "command-hidden",
-    ]);
-    expect(indexEntries.filter((entry) => entry.userInvocable).map((entry) => entry.name)).toEqual([
-      "runtime-hidden",
-      "prompt-hidden",
-      "legacy-prompt-hidden",
-    ]);
     expect(filterPromptVisibleSkillEntries(entries)).toEqual([runtimeHidden, commandHidden]);
     expect(filterUserInvocableSkillEntries(entries)).toEqual([
       runtimeHidden,
       promptHidden,
       legacyPromptHidden,
-    ]);
-  });
-
-  it("records source, bundled state, skill key, and agent filter state", () => {
-    const bundled = createFixtureSkillEntry("bundle", { source: "openclaw-bundled" });
-    const custodian = createFixtureSkillEntry("custodian", { source: "openclaw-custodian" });
-    const workspace = createFixtureSkillEntry("workspace", {
-      source: "openclaw-workspace",
-      skillKey: "workspace-key",
-    });
-
-    const indexEntries = buildSkillIndexEntries([bundled, custodian, workspace], {
-      agentSkillFilter: ["workspace"],
-    });
-
-    expect(indexEntries.find((entry) => entry.name === "bundle")).toMatchObject({
-      source: "openclaw-bundled",
-      bundled: true,
-      agentAllowed: false,
-    });
-    expect(indexEntries.find((entry) => entry.name === "custodian")).toMatchObject({
-      source: "openclaw-custodian",
-      bundled: true,
-      agentAllowed: false,
-    });
-    expect(indexEntries.find((entry) => entry.name === "workspace")).toMatchObject({
-      source: "openclaw-workspace",
-      bundled: false,
-      skillKey: "workspace-key",
-      agentAllowed: true,
-    });
-    expect(
-      buildSkillIndexEntries([bundled, custodian, workspace], {
-        agentSkillFilter: ["workspace"],
-      }).map(({ name, bundled: bundledLocal, agentAllowed }) => ({
-        name,
-        bundled: bundledLocal,
-        agentAllowed,
-      })),
-    ).toEqual([
-      { name: "bundle", bundled: true, agentAllowed: false },
-      { name: "custodian", bundled: true, agentAllowed: false },
-      { name: "workspace", bundled: false, agentAllowed: true },
     ]);
   });
 });

--- a/src/skills/discovery/skill-index.ts
+++ b/src/skills/discovery/skill-index.ts
@@ -1,26 +1,5 @@
-// Skill index helpers map normalized skill names to loaded skill entries.
-import { resolveSkillKey } from "../loading/frontmatter.js";
-import { resolveSkillSource } from "../loading/source.js";
+// Shared skill name normalization and prompt/command exposure predicates.
 import type { SkillEntry } from "../types.js";
-
-/** Indexed skill metadata used for runtime visibility and command lookup. */
-export type SkillIndexEntry = {
-  entry: SkillEntry;
-  name: string;
-  normalizedName: string;
-  skillKey: string;
-  normalizedSkillKey: string;
-  source: string;
-  bundled: boolean;
-  agentAllowed: boolean;
-  runtimeVisible: boolean;
-  promptVisible: boolean;
-  userInvocable: boolean;
-};
-
-type BuildSkillIndexOptions = {
-  agentSkillFilter?: readonly string[];
-};
 
 /** Normalizes a skill name to the comparable key used by filters and commands. */
 export function normalizeSkillIndexName(value: string): string {
@@ -33,10 +12,6 @@ export function normalizeSkillIndexName(value: string): string {
     .replace(/^-+|-+$/g, "");
 }
 
-function isSkillRuntimeVisible(entry: SkillEntry): boolean {
-  return entry.exposure?.includeInRuntimeRegistry ?? true;
-}
-
 export function isSkillPromptVisible(entry: SkillEntry): boolean {
   if (entry.exposure) {
     return entry.exposure.includeInAvailableSkillsPrompt ?? true;
@@ -47,7 +22,7 @@ export function isSkillPromptVisible(entry: SkillEntry): boolean {
   return !entry.skill.disableModelInvocation;
 }
 
-function isSkillUserInvocable(entry: SkillEntry): boolean {
+export function isSkillUserInvocable(entry: SkillEntry): boolean {
   if (entry.exposure) {
     return entry.exposure.userInvocable ?? true;
   }
@@ -63,36 +38,4 @@ export function filterPromptVisibleSkillEntries(entries: readonly SkillEntry[]):
 
 export function filterUserInvocableSkillEntries(entries: readonly SkillEntry[]): SkillEntry[] {
   return entries.filter(isSkillUserInvocable);
-}
-
-export function buildSkillIndexEntries(
-  entries: readonly SkillEntry[],
-  opts?: BuildSkillIndexOptions,
-): SkillIndexEntry[] {
-  const agentSkillSet =
-    opts?.agentSkillFilter === undefined ? undefined : new Set(opts.agentSkillFilter);
-  return entries.map((entry) => createSkillIndexEntry(entry, agentSkillSet));
-}
-
-function createSkillIndexEntry(
-  entry: SkillEntry,
-  agentSkillSet: ReadonlySet<string> | undefined,
-): SkillIndexEntry {
-  const name = entry.skill.name;
-  const skillKey = resolveSkillKey(entry.skill, entry);
-  const source = resolveSkillSource(entry.skill);
-  return {
-    entry,
-    name,
-    normalizedName: normalizeSkillIndexName(name),
-    skillKey,
-    normalizedSkillKey: normalizeSkillIndexName(skillKey),
-    source,
-    // Loader provenance owns bundled status; a matching name cannot establish source.
-    bundled: source === "openclaw-bundled" || source === "openclaw-custodian",
-    agentAllowed: agentSkillSet === undefined || agentSkillSet.has(name),
-    runtimeVisible: isSkillRuntimeVisible(entry),
-    promptVisible: isSkillPromptVisible(entry),
-    userInvocable: isSkillUserInvocable(entry),
-  };
 }

--- a/src/skills/discovery/status.test.ts
+++ b/src/skills/discovery/status.test.ts
@@ -523,45 +523,68 @@ describe("buildWorkspaceSkillStatus", () => {
     expect(skill?.commandVisible).toBe(true);
   });
 
-  it("reports skills blocked by an agent skill filter", () => {
-    const alpha: SkillEntry = {
-      skill: createCanonicalFixtureSkill({
-        name: "alpha",
-        description: "test",
-        filePath: "/tmp/alpha/SKILL.md",
-        baseDir: "/tmp/alpha",
-        source: "test",
-      }),
-      frontmatter: {},
-    };
-    const beta: SkillEntry = {
-      skill: createCanonicalFixtureSkill({
-        name: "beta",
-        description: "test",
-        filePath: "/tmp/beta/SKILL.md",
-        baseDir: "/tmp/beta",
-        source: "test",
-      }),
-      frontmatter: {},
-    };
-
-    const report = buildWorkspaceSkillStatus("/tmp/ws", {
-      entries: [alpha, beta],
+  it("preserves source, custom keys, order, and agent exclusion in status", () => {
+    const workspaceDir = tempDirs.make("openclaw-skill-status-");
+    const report = buildWorkspaceSkillStatus(workspaceDir, {
+      managedSkillsDir: path.join(workspaceDir, ".managed"),
+      entries: [
+        createEntry("workspace", {
+          source: "openclaw-workspace",
+          baseDir: path.join(workspaceDir, "workspace"),
+          metadata: { skillKey: "workspace-key" },
+        }),
+        createEntry("custodian", {
+          source: "openclaw-custodian",
+          baseDir: path.join(workspaceDir, "custodian"),
+        }),
+        createEntry("bundle", {
+          source: "openclaw-bundled",
+          baseDir: path.join(workspaceDir, "bundle"),
+        }),
+      ],
       agentId: "specialist",
-      config: {
-        agents: {
-          list: [{ id: "specialist", skills: ["alpha"] }],
-        },
-      },
+      config: { agents: { list: [{ id: "specialist", skills: ["workspace"] }] } },
     });
 
     expect(report.agentId).toBe("specialist");
-    expect(report.agentSkillFilter).toEqual(["alpha"]);
-    expect(report.skills.find((skill) => skill.name === "alpha")?.blockedByAgentFilter).toBe(false);
-    const byName = skillStatusByName(report.skills);
-    expect(requireSkillStatus(byName, "alpha").modelVisible).toBe(true);
-    expect(requireSkillStatus(byName, "beta").blockedByAgentFilter).toBe(true);
-    expect(report.skills.find((skill) => skill.name === "beta")?.modelVisible).toBe(false);
+    expect(report.agentSkillFilter).toEqual(["workspace"]);
+    expect(
+      report.skills.map(
+        ({ name, source, skillKey, bundled, blockedByAgentFilter, modelVisible }) => ({
+          name,
+          source,
+          skillKey,
+          bundled,
+          blockedByAgentFilter,
+          modelVisible,
+        }),
+      ),
+    ).toEqual([
+      {
+        name: "workspace",
+        source: "openclaw-workspace",
+        skillKey: "workspace-key",
+        bundled: false,
+        blockedByAgentFilter: false,
+        modelVisible: true,
+      },
+      {
+        name: "custodian",
+        source: "openclaw-custodian",
+        skillKey: "custodian",
+        bundled: true,
+        blockedByAgentFilter: true,
+        modelVisible: false,
+      },
+      {
+        name: "bundle",
+        source: "openclaw-bundled",
+        skillKey: "bundle",
+        bundled: true,
+        blockedByAgentFilter: true,
+        modelVisible: false,
+      },
+    ]);
   });
 
   it("classifies a mixed broken skill pack without flattening visibility reasons", () => {

--- a/src/skills/discovery/status.ts
+++ b/src/skills/discovery/status.ts
@@ -20,6 +20,8 @@ import {
   resolveSkillConfig,
   resolveSkillsInstallPreferences,
 } from "../loading/config.js";
+import { resolveSkillKey } from "../loading/frontmatter.js";
+import { resolveSkillSource } from "../loading/source.js";
 import { loadWorkspaceSkills } from "../loading/workspace-skill-loader.js";
 import { mergeRemoteNodeSkillEntries } from "../runtime/remote-skills.js";
 import type {
@@ -30,9 +32,9 @@ import type {
 } from "../types.js";
 import { resolveEffectiveAgentSkillFilter } from "./agent-filter.js";
 import {
-  buildSkillIndexEntries,
+  isSkillPromptVisible,
+  isSkillUserInvocable,
   normalizeSkillIndexName,
-  type SkillIndexEntry,
 } from "./skill-index.js";
 import type { SkillInstallOption, SkillStatusEntry, SkillStatusReport } from "./status.types.js";
 export type { SkillStatusEntry, SkillStatusReport } from "./status.types.js";
@@ -176,24 +178,20 @@ type BuildSkillStatusContext = {
   prefs: SkillsInstallPreferences;
   eligibility?: SkillEligibilityContext;
   allowBundled: ReadonlySet<string> | undefined;
-  agentSkillFilter?: string[];
+  agentSkillSet: ReadonlySet<string> | undefined;
   workspaceDir: string;
   clawhubLockRead: ClawHubSkillsLockfileStatusRead;
   managedSkillsDir: string;
   managedLockRead: ClawHubSkillsLockfileStatusRead;
 };
 
-function buildSkillStatus(
-  indexed: SkillIndexEntry,
-  context: BuildSkillStatusContext,
-): SkillStatusEntry {
-  const entry = indexed.entry;
-  const skillKey = indexed.skillKey;
-  const { config, prefs, eligibility, allowBundled, agentSkillFilter, workspaceDir } = context;
+function buildSkillStatus(entry: SkillEntry, context: BuildSkillStatusContext): SkillStatusEntry {
+  const skillKey = resolveSkillKey(entry.skill, entry);
+  const { config, prefs, eligibility, allowBundled, agentSkillSet, workspaceDir } = context;
   const skillConfig = resolveSkillConfig(config, skillKey);
   const disabled = skillConfig?.enabled === false;
   const blockedByAllowlist = !isBundledSkillAllowed(entry, allowBundled);
-  const blockedByAgentFilter = agentSkillFilter !== undefined && !indexed.agentAllowed;
+  const blockedByAgentFilter = agentSkillSet !== undefined && !agentSkillSet.has(entry.skill.name);
   const always = entry.metadata?.always === true;
   const isEnvSatisfied = (envName: string) =>
     isSkillEnvRequirementSatisfied({
@@ -202,8 +200,9 @@ function buildSkillStatus(
       primaryEnv: entry.metadata?.primaryEnv,
     });
   const isConfigSatisfied = (pathStr: string) => isSkillConfigPathTruthy(config, pathStr);
-  const skillSource = indexed.source;
-  const bundled = indexed.bundled;
+  const skillSource = resolveSkillSource(entry.skill);
+  // Loader provenance owns bundled status; a matching name cannot establish source.
+  const bundled = skillSource === "openclaw-bundled" || skillSource === "openclaw-custodian";
 
   const { emoji, homepage, required, missing, requirementsSatisfied, configChecks } =
     evaluateEntryRequirementsForCurrentPlatform({
@@ -221,7 +220,7 @@ function buildSkillStatus(
   // remote node can satisfy is not flagged incompatible.
   const platformIncompatible = missing.os.length > 0;
   const availableToAgent = eligible && !blockedByAgentFilter;
-  const userInvocable = indexed.userInvocable;
+  const userInvocable = isSkillUserInvocable(entry);
 
   // Source ownership survives canonicalization of symlinked managed installs.
   const isGlobalManagedSkill = !bundled && skillSource === "openclaw-managed";
@@ -256,7 +255,7 @@ function buildSkillStatus(
     blockedByAgentFilter,
     eligible,
     platformIncompatible,
-    modelVisible: availableToAgent && indexed.promptVisible,
+    modelVisible: availableToAgent && isSkillPromptVisible(entry),
     userInvocable,
     commandVisible: availableToAgent && userInvocable,
     requirements: required,
@@ -316,21 +315,19 @@ export function buildWorkspaceSkillStatus(
     managedParentDir === path.resolve(workspaceDir)
       ? clawhubLockRead
       : readClawHubSkillsLockfileStatusSync(managedParentDir);
-  const skillIndexEntries = buildSkillIndexEntries(skillEntries, {
-    agentSkillFilter,
-  });
+  const agentSkillSet = agentSkillFilter === undefined ? undefined : new Set(agentSkillFilter);
   return {
     workspaceDir,
     managedSkillsDir,
     agentId: opts?.agentId,
     agentSkillFilter,
-    skills: skillIndexEntries.map((entry) =>
+    skills: skillEntries.map((entry) =>
       buildSkillStatus(entry, {
         config: opts?.config,
         prefs,
         eligibility: opts?.eligibility,
         allowBundled,
-        agentSkillFilter,
+        agentSkillSet,
         workspaceDir,
         clawhubLockRead,
         managedSkillsDir,


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

Skill status reporting still creates an intermediate index record for every loaded skill, including normalized names and runtime-visibility fields that no production caller reads. The actual lookup index was retired earlier, but its projection layer remained on the `skills.status` and CLI list/info/check path.

## Why This Change Was Made

Build status rows directly from the loaded skill records. Retain the shared name normalizer and prompt/command visibility predicates, and keep the existing exact-name agent filter set with the status owner. Remove the unused intermediate type, constructor, fields, and test-only assertions. Move the meaningful source, custom-key, custodian, order, and filter coverage into the existing status-boundary test.

The final change removes **60 production lines and 47 test lines**. Formatting collapsed one function signature after measurement; the measured production patch removed 57 lines with the same behavior.

## User Impact

Status shape, order, source labels, bundled classification, skill keys, visibility/readiness reasons, install options, ClawHub linkage, and Skill Card metadata remain unchanged. This is a maintainer-requested cleanup with mixed timing results, not a blanket speedup claim.

**Update behavior:** this changes only the existing read-only skill report projection. No updater or Doctor transformations, runtime loading behavior, configuration, or storage behavior are altered.

## Evidence

Matching Oxfmt and fresh managed Codex P2 review passed at author base `f2d96c8c5231e5fee41c6c11cf45a8b816870af1`. All **71 tests in seven complete files** passed, covering the status owner, workspace loader, shared predicates, remote-node merge, CLI formatting, and Gateway caller dispatch. The Gateway caller suite mocks the status owner; it is not live Gateway proof. All **27 actual selected small guards** passed. All 34 local native receipts closed and monitors joined under the retained 300-second, 6-GiB, 64-process limits.

**Hosted CI is still required:** broad core types (`tsgo:core`), core test types (`tsgo:core:test`), and type-aware lint for the four changed files with `config/tsconfig/oxlint.core.json` did not run locally. These need actual exact-head hosted proof before landing. No build or additional benchmark was run for this pure report-owner change.

The [isolated Linux/Node 24.19.0 measurement](https://github.com/openclaw/openclaw/actions/runs/34699234499), at `c6739ac24924ff018e1ff892a69fbad5d47ab72e`, completed 13 cases in B1/C1/C2/B2 order: **520 status invocations**, comprising 52 complete controls, 104 warmups, and 364 measured calls. Entire reports and rendered JSON/text matched, including own-property/undefined shape, order, and repeated references; input records remained unchanged. The offline comparison matched the remote comparison byte-for-byte. All native children, the remote worktree, the exact lease, and the local capsule closed.

The prepared-owner cells use actual loader records. Cached-loader cells retain the normal loader cache; refreshed-loader cells invalidate that workspace through its existing owner before each timed loader/status/formatter call. Fixtures use actual on-disk skills, source tiers, custom keys, filters, missing requirements, origin/lock linkage, and cards. These seven-sample medians describe this run, not live UI responsiveness or a throughput distribution.

Large refreshed 256-entry reports saved **0.919/2.497 ms** in the two orders (42.420→41.501 ms and 43.457→40.961 ms). Costs remain visible: refreshed 64-entry reports added **0.451/0.449 ms**, with CPU **+9.52%/+23.90%**; cached 256-entry reverse order added **1.551 ms**, with CPU **+3.17%**. Prepared-owner 64-entry reverse CPU increased **71.13%** (3.287→5.625 ms). Most process RSS medians increased roughly **0.2–1.2%**. RSS is process-level, not an allocation attribution.

All paired changes below retain their signs; negative means lower candidate cost. No orders or controls are pooled.

| Case | Wall C1/B1 | Wall C2/B2 | CPU C1/B1 | CPU C2/B2 | RSS C1/B1 | RSS C2/B2 |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| owner-empty-0 | -2.28% | -0.03% | -5.26% | +0.00% | +0.42% | +0.32% |
| owner-ordinary-8 | -10.59% | -3.64% | -19.43% | -4.37% | +0.39% | +0.35% |
| owner-mixed-64 | +4.24% | +2.17% | -10.58% | +71.13% | +0.32% | +0.40% |
| owner-large-256 | -1.81% | -6.16% | -2.70% | -8.69% | +0.75% | +0.59% |
| disk-warm-empty-0 | +1.54% | +11.96% | +0.00% | +12.50% | +0.57% | +0.23% |
| disk-warm-ordinary-8 | +0.56% | -0.13% | -8.65% | -6.65% | +0.53% | +0.20% |
| disk-warm-mixed-64 | -3.84% | -2.48% | +3.25% | -3.46% | +0.68% | +0.37% |
| disk-warm-large-256 | -2.37% | +10.23% | -6.90% | +3.17% | +0.46% | +0.95% |
| disk-refresh-empty-0 | +7.77% | +2.04% | +7.88% | +1.64% | +0.79% | +1.19% |
| disk-refresh-ordinary-8 | +2.98% | +4.35% | -3.48% | -2.42% | -0.24% | +0.20% |
| disk-refresh-mixed-64 | +4.93% | +4.86% | +9.52% | +23.90% | +0.43% | +0.60% |
| disk-refresh-large-256 | -2.17% | -5.75% | -0.74% | -5.84% | +0.38% | +0.58% |
| owner-empty-filter-8 | -3.01% | -8.90% | -2.82% | -7.82% | +0.17% | +0.58% |
