### PR TITLE
improve(ui): speed up People sorting in the sidebar

### DIFF
--- a/ui/src/components/app-sidebar-session-navigation-logic.test.ts
+++ b/ui/src/components/app-sidebar-session-navigation-logic.test.ts
@@ -6,7 +6,7 @@ import { collectKnownSessionRows, fetchSessionLineage } from "./app-sidebar-chil
 import {
   buildSidebarSessionNavigationState,
   collectSidebarSessionRowsByKey,
-  compareSidebarSessionRowsByMode,
+  createSidebarSessionRowsComparator,
   resolveSidebarMainSessionKey,
 } from "./app-sidebar-session-navigation-logic.ts";
 import { projectSessionTree } from "./app-sidebar-session-tree.ts";
@@ -103,8 +103,8 @@ function sortSidebarRows(
   createdOrder: ReadonlyMap<string, number>,
   owners?: SessionsListResult["owners"],
 ) {
-  return rows.toSorted((a, b) =>
-    compareSidebarSessionRowsByMode({ a, b, sortMode, createdOrder, owners }),
+  return rows.toSorted(
+    createSidebarSessionRowsComparator(() => ({ sortMode, createdOrder, owners })),
   );
 }
 
@@ -186,6 +186,23 @@ describe("sidebar session sort modes", () => {
       "updated-new",
       "created-new",
     ]);
+  });
+
+  it("keeps first-facet precedence and row label fallbacks across People projections", () => {
+    const alex = row("alex", 100, 1, " alex ");
+    const sam = row("sam", 100, 1, "sam");
+    alex.owner!.actor.label = "Alex";
+    sam.owner!.actor.label = "Sam";
+    const rows = [sam, alex];
+    const observed = new Map(rows.map((entry, index) => [entry.key, index]));
+    const owners: NonNullable<SessionsListResult["owners"]> = [
+      { type: "human", id: "alex", label: " " },
+      { type: "human", id: "alex", label: "Zed" },
+      { type: "human", id: "sam", label: "Sam" },
+    ];
+    expect(sortSidebarRows(rows, "people", observed, owners)).toEqual([alex, sam]);
+    owners[0] = { type: "human", id: "alex", label: "Zed" };
+    expect(sortSidebarRows(rows, "people", observed, owners)).toEqual([sam, alex]);
   });
 });
 

--- a/ui/src/components/app-sidebar-session-navigation-logic.ts
+++ b/ui/src/components/app-sidebar-session-navigation-logic.ts
@@ -61,35 +61,48 @@ export function resolveSidebarHomeAttention(
   );
 }
 
-export function compareSidebarSessionRowsByMode(input: {
-  a: SessionRow;
-  b: SessionRow;
+type SidebarSessionSortOptions = {
   sortMode: SidebarSessionSortMode;
   owners: SessionsListResult["owners"];
   createdOrder: ReadonlyMap<string, number>;
-}): number {
-  const { a, b } = input;
-  if (input.sortMode !== "people") {
-    return input.sortMode === "updated"
-      ? compareSessionRowsByUpdatedAt(a, b)
-      : compareSidebarSessionRowsByCreatedAt(a, b, input.createdOrder);
-  }
-  const owners = input.owners ?? [];
-  const ownerA = a.owner?.actor;
-  const ownerB = b.owner?.actor;
-  const idA = ownerA?.id?.trim() ?? "";
-  const idB = ownerB?.id?.trim() ?? "";
-  if (idA !== idB) {
-    const facetOwnerA = owners.find((candidate) => candidate.id === idA);
-    const facetOwnerB = owners.find((candidate) => candidate.id === idB);
-    const labelA = facetOwnerA?.label?.trim() || ownerA?.label?.trim() || idA;
-    const labelB = facetOwnerB?.label?.trim() || ownerB?.label?.trim() || idB;
-    const byOwner = labelA.localeCompare(labelB) || idA.localeCompare(idB);
-    if (byOwner !== 0) {
-      return byOwner;
+};
+
+export function createSidebarSessionRowsComparator(
+  readOptions: () => SidebarSessionSortOptions,
+): (a: SessionRow, b: SessionRow) => number {
+  let options: SidebarSessionSortOptions | undefined;
+  let ownerLabels: Map<string, string | undefined> | undefined;
+  return (a, b) => {
+    // An unset agent selection can resolve through navigation itself. Empty
+    // and single-row projections must not ask for sort facts before sorting.
+    const input = (options ??= readOptions());
+    if (input.sortMode !== "people") {
+      return input.sortMode === "updated"
+        ? compareSessionRowsByUpdatedAt(a, b)
+        : compareSidebarSessionRowsByCreatedAt(a, b, input.createdOrder);
     }
-  }
-  return compareSidebarSessionRowsByCreatedAt(a, b, input.createdOrder);
+    const ownerA = a.owner?.actor;
+    const ownerB = b.owner?.actor;
+    const idA = ownerA?.id?.trim() ?? "";
+    const idB = ownerB?.id?.trim() ?? "";
+    if (idA !== idB) {
+      if (!ownerLabels) {
+        ownerLabels = new Map();
+        for (const owner of input.owners ?? []) {
+          if (!ownerLabels.has(owner.id)) {
+            ownerLabels.set(owner.id, owner.label?.trim());
+          }
+        }
+      }
+      const labelA = ownerLabels.get(idA) || ownerA?.label?.trim() || idA;
+      const labelB = ownerLabels.get(idB) || ownerB?.label?.trim() || idB;
+      const byOwner = labelA.localeCompare(labelB) || idA.localeCompare(idB);
+      if (byOwner !== 0) {
+        return byOwner;
+      }
+    }
+    return compareSidebarSessionRowsByCreatedAt(a, b, input.createdOrder);
+  };
 }
 
 function compareSidebarSessionRowsByCreatedAt(

--- a/ui/src/components/app-sidebar-session-navigation.ts
+++ b/ui/src/components/app-sidebar-session-navigation.ts
@@ -35,7 +35,7 @@ import {
   applySidebarSessionOwnerFilter,
   buildReconciledSidebarZone,
   buildSidebarSessionNavigationState,
-  compareSidebarSessionRowsByMode,
+  createSidebarSessionRowsComparator,
   collectKnownSidebarSessionCatalogIds,
   collectKnownSidebarSessionGroups,
   extendSidebarSessionSelection,
@@ -109,17 +109,11 @@ export class AppSidebarSessionNavigationElement extends AppSidebarBase {
     getSessions: () => this.context?.sessions,
   });
 
-  protected readonly compareSidebarSessionRows = (
-    a: SessionsListResult["sessions"][number],
-    b: SessionsListResult["sessions"][number],
-  ) =>
-    compareSidebarSessionRowsByMode({
-      a,
-      b,
-      sortMode: this.effectiveSessionSortMode(),
-      owners: this.selectedAgentSessionResult()?.owners,
-      createdOrder: this.sessionProjection.createdOrder,
-    });
+  private readonly readSidebarSessionSortOptions = () => ({
+    sortMode: this.effectiveSessionSortMode(),
+    owners: this.selectedAgentSessionResult()?.owners,
+    createdOrder: this.sessionProjection.createdOrder,
+  });
 
   private sessionPeopleSortCapability(): boolean | undefined {
     const owners = this.selectedAgentSessionResult()?.owners;
@@ -301,7 +295,7 @@ export class AppSidebarSessionNavigationElement extends AppSidebarBase {
       showCron: this.sessionsShowCron,
       showSystem: this.sessionsShowSystem,
       statusFilter: this.sessionsStatusFilter,
-      compareSessions: this.compareSidebarSessionRows,
+      compareSessions: createSidebarSessionRowsComparator(this.readSidebarSessionSortOptions),
       highlightCurrentSession: isSessionRouteId(this.activeRouteId),
       runtimeSampledAtByRow: this.runtimeSampledAtByRow,
       loadingChildSessionKeys: this.sessionData.loadingChildSessionKeys,
@@ -660,7 +654,7 @@ export class AppSidebarSessionNavigationElement extends AppSidebarBase {
       selected,
       agentIds: roster?.agentIds ?? [selected],
       result: roster?.result,
-      compareSessions: this.compareSidebarSessionRows,
+      compareSessions: createSidebarSessionRowsComparator(this.readSidebarSessionSortOptions),
       knownSessionAttention: this.attention.knownSessionAttention(),
     });
     return this.applySessionOwnerFilter(projected, this.selectedAgentSessionResult()?.owners);

--- a/ui/src/components/app-sidebar.test.ts
+++ b/ui/src/components/app-sidebar.test.ts
@@ -1,5 +1,7 @@
 /* @vitest-environment jsdom */
 
+import { expect, it } from "vitest";
+import { AppSidebarSessionNavigationElement } from "./app-sidebar-session-navigation.ts";
 import "../test-helpers/app-sidebar-suite.ts";
 import "../test-helpers/app-sidebar-cases/agent-menu.ts";
 import "../test-helpers/app-sidebar-cases/roster-agent-first.ts";
@@ -45,3 +47,24 @@ import "../test-helpers/app-sidebar-cases/session-list-sections.ts";
 import "../test-helpers/app-sidebar-cases/sidebar-zone.ts";
 import "../test-helpers/app-sidebar-cases/transient-menus.ts";
 import "../test-helpers/app-sidebar-cases/plugin-session-list.ts";
+
+it.each([0, 1])("resolves %i sidebar rows before agent selection is available", (count) => {
+  const sidebar = document.createElement("openclaw-app-sidebar");
+  if (!(sidebar instanceof AppSidebarSessionNavigationElement)) {
+    throw new Error("expected the registered sidebar");
+  }
+  const key = "agent:main:main";
+  sidebar.sessionKey = key;
+  sidebar.sessionData.sessionsAgentId = "main";
+  sidebar.sessionData.sessionsResult = {
+    ts: 1,
+    path: "",
+    count,
+    defaults: { modelProvider: null, model: null, contextTokens: null },
+    sessions: count === 0 ? [] : [{ key, kind: "direct", updatedAt: 1 }],
+  };
+  const navigation = sidebar.getSessionNavigationState();
+  expect(navigation.selectedAgentId).toBe("main");
+  expect(navigation.activeRowKey).toBe(key);
+  expect(navigation.visibleSessionRows.map((row) => row.key)).toEqual([key]);
+});


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

This branch is in the main repository; fork collaboration settings do not apply.

</details>

## What Problem This Solves

Fixes an issue where sorting a large Control UI sidebar by People repeats owner-label searches and sidebar-state resolution for every row comparison.

## Why This Change Was Made

Each synchronous sidebar projection now creates a lazy comparator that captures its sort facts once and builds the first-occurrence owner-label lookup only when differing owners are compared. Both production callers use that owner. Empty and single-row projections retain their existing lazy state access; each subsequent projection reads fresh facts.

## User Impact

People sorting takes less work for large session lists. Owner-label fallbacks, duplicate-facet precedence, creation-order ties, selection, and loading behavior remain unchanged. There is no visual redesign or persistent cache.

## Evidence

- 447 tests passed across the sort/navigation owner and registered sidebar suites, including owner-facet refresh, blank/duplicate labels, and zero/one loaded rows before agent selection exists.
- Exact production comparator versus the preserved baseline owner from `9e267031cd9d73aea91332f9245570ddd5bebef0`, using the same compiler/dependencies on Linux x64 / Node 26.8.2. Four alternating batches include comparator/lookup construction and assert complete output plus original row-reference parity.

| Sessions / owner facets | Baseline mean | Candidate mean |
| --- | ---: | ---: |
| 100 / 60 | 0.199 ms | 0.049 ms |
| 1,000 / 60 | 2.077 ms | 0.688 ms |
| 1,000 / 8 | 0.764 ms | 0.628 ms |

Every 1,000-row/60-facet batch improved: baseline 1.91–2.29 ms, candidate 0.632–0.742 ms. Small controls exposed setup costs: ten rows/60 facets measured 0.0050→0.0072 ms, and 100 same-owner rows measured 0.0328→0.0376 ms. The benchmark excludes module startup, browser rendering, and the class callback cost; it makes no whole-render claim. Campaign measurement lanes were serialized, but the shared host had other independently owned jobs. No timing assertions were added to CI.
Independent review completed with no actionable findings. [CI run 34700632765](https://github.com/openclaw/openclaw/actions/runs/34700632765) passed for head `bec064f3564439872bacf0fbe87f7e42bc710502`, including the required gate and real-Gateway UI E2E job. Jobs tested GitHub merge `c81c5aba83208f6c3e0a37d3f2891d4a6dfa0089`, containing that head and main `81a4c771eff6cd4591ae7f9b1745d1ced399d5e6`.

Local structural guards, the core graph boundary, and UI i18n passed before host memory pressure interrupted local typechecking. Successful hosted jobs provide complete coverage for the remaining core/UI types, coercion guard, dead exports, Oxlint and Stylelint checks; the interrupted local attempt is not counted as a pass.
