### PR TITLE
improve(memory): defer rejected fallback result construction

### DIFF
--- a/extensions/memory-core/src/memory/manager-search.test.ts
+++ b/extensions/memory-core/src/memory/manager-search.test.ts
@@ -1142,19 +1142,24 @@ describe("searchVector sqlite-vec KNN", () => {
       id: string;
       model: string;
       vector: number[];
+      path?: string;
+      source?: "memory" | "sessions";
+      startLine?: number;
+      endLine?: number;
+      text?: string;
     },
   ): void {
     db.prepare(
       "INSERT INTO memory_index_chunks (id, path, source, start_line, end_line, hash, model, text, embedding, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
     ).run(
       params.id,
-      `memory/${params.id}.md`,
-      "memory",
-      1,
-      1,
+      params.path ?? `memory/${params.id}.md`,
+      params.source ?? "memory",
+      params.startLine ?? 1,
+      params.endLine ?? 1,
       params.id,
       params.model,
-      `chunk ${params.id}`,
+      params.text ?? `chunk ${params.id}`,
       JSON.stringify(params.vector),
       1,
     );
@@ -1238,6 +1243,76 @@ describe("searchVector sqlite-vec KNN", () => {
         expect(previous.score).toBeGreaterThan(current.score);
         previous = current;
       }
+    } finally {
+      db.close();
+    }
+  });
+
+  it("preserves tied citations and UTF-16 snippets across batches when a later result wins", async () => {
+    const db = createFallbackDb();
+    const first = {
+      id: "first",
+      path: "memory/notes.md",
+      source: "memory" as const,
+      startLine: 11,
+      endLine: 13,
+      snippet: `${"a".repeat(698)}\uD83D\uDE80`,
+      score: 0.6,
+    };
+    const second = {
+      id: "second",
+      path: "sessions/history.md",
+      source: "sessions" as const,
+      startLine: 21,
+      endLine: 24,
+      snippet: "second passage",
+      score: 0.6,
+    };
+    try {
+      for (const result of [first, second]) {
+        insertFallbackChunk(db, {
+          ...result,
+          model: "target-model",
+          vector: [3, 4],
+          text: result === first ? `${result.snippet}tail` : result.snippet,
+        });
+      }
+      for (let i = 0; i < 254; i += 1) {
+        insertFallbackChunk(db, {
+          id: `filler-${i}`,
+          model: "target-model",
+          vector: [0, 1],
+        });
+      }
+      insertFallbackChunk(db, {
+        id: "late-tie",
+        model: "target-model",
+        vector: [3, 4],
+      });
+      expect(await searchVectorFixture(db, { limit: 2, snippetMaxChars: 700 })).toEqual([
+        first,
+        second,
+      ]);
+
+      const winnerPrefix = "b".repeat(699);
+      insertFallbackChunk(db, {
+        id: "late-winner",
+        model: "target-model",
+        vector: [1, 0],
+        text: `${winnerPrefix}\uD83D\uDE80tail`,
+      });
+      expect(await searchVectorFixture(db, { limit: 2, snippetMaxChars: 700 })).toEqual([
+        {
+          id: "late-winner",
+          path: "memory/late-winner.md",
+          source: "memory",
+          startLine: 1,
+          endLine: 1,
+          snippet: winnerPrefix,
+          score: 1,
+        },
+        first,
+      ]);
     } finally {
       db.close();
     }

--- a/extensions/memory-core/src/memory/manager-search.ts
+++ b/extensions/memory-core/src/memory/manager-search.ts
@@ -454,6 +454,13 @@ async function searchChunksByEmbedding(params: {
     for (const row of batch) {
       const score = cosineSimilarity(params.queryVec, parseEmbedding(row.embedding));
       if (Number.isFinite(score)) {
+        const hasRoom = topResults.length < params.limit;
+        if (!hasRoom) {
+          const lowest = topResults.at(-1);
+          if (!(lowest && score > lowest.score)) {
+            continue;
+          }
+        }
         const result: SearchRowResult = {
           id: row.id,
           path: row.path,
@@ -463,7 +470,7 @@ async function searchChunksByEmbedding(params: {
           snippet: truncateUtf16Safe(row.text, params.snippetMaxChars),
           source: row.source,
         };
-        if (topResults.length < params.limit) {
+        if (hasRoom) {
           topResults.push(result);
           if (topResults.length === params.limit) {
             topResults.sort((a, b) => b.score - a.score);


### PR DESCRIPTION
## Status: Superseded

Closed without merging. [#145693](https://github.com/openclaw/openclaw/pull/145693),
landed as [354943cc2f7e1516d90ae9d2ee7420a12a74bac9](https://github.com/openclaw/openclaw/commit/354943cc2f7e1516d90ae9d2ee7420a12a74bac9),
already performs finite-score/top-K admission before payload retrieval, result
creation, and snippet construction. That broader payload-hydration improvement
subsumes this eight-line production change.

Verified at main `5dfe8fff3340cb2212a938ab886c821228af4a45`. The 1.17-1.48%
results below describe the older `47918f787d845c1901887626e3cff14c245253e0`
comparison only, not a measured benefit on the newer SQL path. The historical
proposal and evidence are retained below.

## What Problem This Solves

On the measured older base, memory search's SQLite vector fallback constructed
result objects and snippets for scored rows that could not enter the requested
top-K results. That work was unnecessary once the retained result set was full.

## Why This Change Was Made

Check the existing admission condition before constructing a result or
truncating its snippet. Admitted rows still use the same replacement and sorting
logic. Scoring, filtering, SQL, batching, cancellation, and strict tie handling
are unchanged in this historical candidate.

## User Impact

This was a small CPU improvement to the measured SQLite vector fallback, not a
whole-search or fleet performance claim. A fixed synthetic comparison measured
median paired process CPU gains of 1.48% for short text and 1.17% for long text
at the representative k200 limit.

These results did not meet the experiment's original 5% adoption threshold.
The maintainer explicitly accepted the smaller observed gain for this minimal
change before current-source inspection established supersession. The benchmark
outcome itself is unchanged.

## Evidence

- 49 focused tests passed on Blacksmith Testbox, including the new real SQLite
  preservation case for cross-batch ties, later replacement, ordered citations,
  and surrogate-safe UTF-16 snippets:
  https://github.com/openclaw/openclaw/actions/runs/34678043956
- The fixed comparison completed all 10 cases and 50 alternating pairs, with
  400 timed searches and 160 warmups on Node 24.19.0 / Linux x64 / SQLite 3.53.3:
  https://github.com/openclaw/openclaw/actions/runs/34680377867
- Each case used 4096 dense 768-dimensional vectors, real SQLite fallback
  queries, 128- or 4096-character text, and a 700-unit snippet limit. Ordered
  results and exact scores matched. All five short-text k200 pairs improved;
  four of five long-text k200 pairs improved. No case exceeded the predeclared
  5% median-regression threshold.
- Fresh P2 autoreview of the two-file candidate was scoped-clean with no
  actionable findings.
- Physical allocation, retained memory, and RSS were not measured. Wall time
  was diagnostic only, not the adoption metric. This redundant draft was closed
  without merging or repeating application proof.