### PR TITLE
fix: bound concurrent compute work and pending worker inputs

### DIFF
--- a/docs/agent-runtime-architecture.md
+++ b/docs/agent-runtime-architecture.md
@@ -55,6 +55,28 @@ Gateway startup and config, plugin, or auth publication build one prepared model
 
 Standalone embedded runtimes publish the same snapshot shape at their activation boundary. A failed or stale generation is never served alongside a newer partial generation. The lifecycle owner must publish a complete replacement first.
 
+## Compute workers
+
+Code-mode execution and compaction planning use the reusable `WorkerTaskPool`.
+Their pools share a CPU admission limit of `max(1, availableParallelism() - 1)`
+within the calling isolate, reserving a CPU where possible for the Gateway. Ordered
+database and model-generation workers keep their existing independent limits.
+
+Admission includes queued, preparing, and running tasks. Each pool defaults to
+128 pending tasks and 256 MiB of producer-reported retained input; compute pools
+also share those pending limits. Producers supply known input sizes without an
+extra serialization pass. This bounds reported input retention, not total worker
+heap usage. Excess work fails with `WorkerTaskError.code = "overloaded"`.
+Cancellation retains the execution permit until the worker stops, and retains
+the input reservation until any asynchronous preparation settles.
+
+Waiting compute pools request checkpoints from code-mode host exchanges so that
+nested work can progress. Idle workers release CPU admission and retire after
+the pool's idle timeout. Local `node:diagnostics_channel` subscribers to
+`openclaw.worker.task` can observe queue, preparation, execution wall time,
+message transfer time, and pending task/input counts. These events contain no
+task inputs; execution wall time includes worker startup and host waits.
+
 ## Related
 
 - [OpenClaw agent runtime workflow](/openclaw-agent-runtime)

--- a/docs/plugins/sdk-overview/infrastructure.md
+++ b/docs/plugins/sdk-overview/infrastructure.md
@@ -76,6 +76,30 @@ synchronous executor and the connection's bounded statement cache when enabled.
 Keep the prepared function with its database owner and discard it when closing
 the connection; transaction callbacks must remain synchronous.
 
+### Worker task admission
+
+`WorkerTaskPool` and `serveWorkerTasks` from
+`openclaw/plugin-sdk/process-runtime` support reusable computation workers.
+Each pool defaults to 128 outstanding tasks and 256 MiB of reported input bytes,
+including queued, preparing, and running tasks. Set `maxPendingTasks` and
+`maxPendingBytes` when constructing a pool to choose different positive limits.
+Report known retained input with `run(input, { inputBytes })`, including buffers
+captured by an input factory. Omitted `inputBytes` counts as zero; this accounting
+does not measure serialized payload size, decoded data, results, or worker heaps.
+
+Capacity exhaustion rejects `run()` with `WorkerTaskError.code = "overloaded"`
+before preparing or executing that input. Accepted work remains ordered within
+a single-worker pool. Report the rejected operation as unsuccessful; do not
+substitute an empty result or bypass the limit with synchronous execution.
+After accepted work settles, the same pool accepts new work again. A caller may
+retry a rejected operation after pressure drains and its original authority and
+deadline are revalidated; the pool does not retry it automatically.
+
+For stateless computation, `sharedCompute: true` also shares an aggregate
+128-task/256-MiB admission budget and CPU execution capacity with participating
+pools in the same isolate. Dedicated ordered pools retain their own execution
+capacity and still enforce their individual admission limits.
+
 ### SQLite worker stores
 
 Use `openSqliteWorkerStore<Operations>` from

--- a/src/agents/code-mode-worker.ts
+++ b/src/agents/code-mode-worker.ts
@@ -94,7 +94,10 @@ function getCodeModePool(url: URL): WorkerTaskPool<unknown, unknown> {
     // A runtime entry change retires its old workers; ordinary runs reuse the
     // process-stable entry while each request still creates an isolated VM.
     void sharedPool?.pool.close();
-    sharedPool = { url: url.href, pool: new WorkerTaskPool({ workerUrl: url }) };
+    sharedPool = {
+      url: url.href,
+      pool: new WorkerTaskPool({ workerUrl: url, sharedCompute: true }),
+    };
   }
   return sharedPool.pool;
 }
@@ -135,6 +138,13 @@ export async function runCodeModeWorker(
       {
         timeoutMs,
         signal,
+        inputBytes: isRecord(workerData)
+          ? isRecord(workerData.snapshot) && workerData.snapshot.memory instanceof Uint8Array
+            ? workerData.snapshot.memory.byteLength
+            : typeof workerData.source === "string"
+              ? workerData.source.length * 2
+              : 0
+          : 0,
         onInputConsumed: inlineHost?.onInputConsumed,
         onRequest: inlineHost
           ? async (value, context): Promise<WorkerTaskResponse> => {

--- a/src/agents/compaction-planning-worker-runtime.ts
+++ b/src/agents/compaction-planning-worker-runtime.ts
@@ -11,7 +11,7 @@ const COMPACTION_PLANNING_WORKER_TIMEOUT_MS = 60_000;
 export class CompactionPlanningWorkerError extends Error {
   constructor(
     message: string,
-    readonly code: "unavailable" | "timeout" | "failed",
+    readonly code: "unavailable" | "timeout" | "failed" | "overloaded",
   ) {
     super(message);
     this.name = "CompactionPlanningWorkerError";
@@ -22,6 +22,7 @@ const planningPool = new WorkerTaskPool<
   CompactionPlanningWorkerInput,
   CompactionPlanningWorkerValue
 >({
+  sharedCompute: true,
   workerUrl: resolveRuntimeWorkerUrl({
     currentModuleUrl: import.meta.url,
     sourceWorkerName: "compaction-planning.worker",

--- a/src/agents/prepared-model-catalog-worker.integration.test.ts
+++ b/src/agents/prepared-model-catalog-worker.integration.test.ts
@@ -877,6 +877,55 @@ describe("prepared model catalog worker boundary", () => {
     expect(loggedOut?.authStore.profiles[OPENAI_CODEX_DEFAULT_PROFILE_ID]).toBeUndefined();
   });
 
+  it("keeps accepted catalog and auth work alive after overload and permits later refresh", async () => {
+    const fixture = await createReadyWorkerFixture(0);
+    const barrier = `${fixture.marker}.hold`;
+    fs.writeFileSync(barrier, "", "utf8");
+    const catalog = fixture.snapshot.loadFullModelCatalog!();
+    void catalog.catch(() => {});
+    const accepted: ReturnType<typeof loadPreparedModelRuntimeAuth>[] = [];
+    try {
+      await waitForMarker(fixture.marker);
+      // Alternating scopes reach the worker instead of sharing the latest auth request.
+      for (let index = 0; index < 127; index += 1) {
+        const auth = loadPreparedModelRuntimeAuth(fixture.snapshot, {
+          providerIds: index % 2 === 0 ? [PROVIDER_ID] : [PROVIDER_ID, SHARED_AUTH_PROVIDER_ID],
+        });
+        void auth.catch(() => {});
+        accepted.push(auth);
+      }
+      await expect(
+        loadPreparedModelRuntimeAuth(fixture.snapshot, {
+          providerIds: [PROVIDER_ID, SHARED_AUTH_PROVIDER_ID],
+        }),
+      ).rejects.toMatchObject({ name: "WorkerTaskError", code: "overloaded" });
+      fs.rmSync(barrier);
+
+      const outcomes = await Promise.allSettled([catalog, ...accepted]);
+      expect(outcomes.filter((outcome) => outcome.status === "rejected")).toEqual([]);
+      expect((await catalog).entries).toContainEqual(
+        expect.objectContaining({ provider: PROVIDER_ID, id: "plugin-generation-v1" }),
+      );
+      fs.writeFileSync(fixture.externalAuthPath, "B", "utf8");
+      const refreshedAuth = await loadPreparedModelRuntimeAuth(fixture.snapshot, {
+        providerIds: [PROVIDER_ID],
+      });
+      expect(refreshedAuth?.authStore.profiles[EXTERNAL_AUTH_PROFILE_ID]).toMatchObject({
+        access: "v1:B",
+      });
+      const refreshedCatalog = await fixture.snapshot.loadFullModelCatalog!({ refresh: true });
+      expect(refreshedCatalog.entries).toContainEqual(
+        expect.objectContaining({
+          provider: PROVIDER_ID,
+          id: "proof-refresh-2-sqlite-true-shared-true-unrelated-true",
+        }),
+      );
+    } finally {
+      fs.rmSync(barrier, { force: true });
+      await Promise.allSettled([catalog, ...accepted]);
+    }
+  });
+
   it("shares in-flight discovery, caches completion, and explicitly refreshes prepared facts", async () => {
     const fixture = await createReadyWorkerFixture(0);
     const barrier = `${fixture.marker}.hold`;

--- a/src/agents/prepared-model-catalog-worker.ts
+++ b/src/agents/prepared-model-catalog-worker.ts
@@ -353,6 +353,10 @@ export function createPreparedModelCatalogWorker(
       assertCurrent();
     } catch (error) {
       const failure = error instanceof Error ? error : new Error(String(error));
+      if (failure instanceof WorkerTaskError && failure.code === "overloaded") {
+        // Admission pressure rejects this request without retiring the prepared generation.
+        throw failure;
+      }
       if (failure instanceof PreparedModelCatalogGenerationMismatchError) {
         // Keep the generation open, but retire only this request's pool: a delayed rejection
         // from it must not close a replacement already serving the same lifecycle plan.

--- a/src/agents/sessions/session-manager-model-context.test.ts
+++ b/src/agents/sessions/session-manager-model-context.test.ts
@@ -12,10 +12,67 @@ import {
 import { runWithSessionTranscriptReadFence } from "../../config/sessions/session-transcript-read-fence.js";
 import { waitForSessionTranscriptProjection } from "../../config/sessions/session-transcript-reconcile.js";
 import { WorkerTaskPool } from "../../infra/worker-task-pool.js";
+import { createDeferredCore } from "../../shared/deferred.js";
 import { openOpenClawAgentDatabase } from "../../state/openclaw-agent-db.js";
 import { withOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
 import { makeAgentAssistantMessage } from "../test-helpers/agent-message-fixtures.js";
 import { CURRENT_SESSION_VERSION, SessionManager } from "./session-manager.js";
+
+it("reports context queue overload without losing context and recovers in admission order", async () => {
+  await withOpenClawTestState({ label: "model-context-pressure" }, async (state) => {
+    const scope = {
+      agentId: "main",
+      sessionId: "context-pressure",
+      sessionKey: "agent:main:context-pressure",
+      storePath: path.join(state.agentDir("main"), "openclaw-agent.sqlite"),
+    };
+    await upsertSessionEntryCore(scope, { sessionId: scope.sessionId, updatedAt: 1 });
+    const source = SessionManager.open(scope);
+    source.appendMessage(makeUserMessage("retain this context", 1));
+    await waitForSessionTranscriptProjection(scope);
+    const expected = source.buildSessionContext();
+    const release = createDeferredCore();
+    const completed: number[] = [];
+    const spy = vi
+      .spyOn(WorkerTaskPool.prototype, "run")
+      .mockImplementationOnce(function (this: WorkerTaskPool<unknown, unknown>, input, options) {
+        spy.mockRestore();
+        // Hold this caller's first preparation while real pool admission fills the queue.
+        return this.run(async () => {
+          await release.promise;
+          return input;
+        }, options);
+      });
+    const accepted = Array.from({ length: 128 }, (_, index) =>
+      SessionManager.openModelContextAsync(scope).then((context) => {
+        completed.push(index);
+        return context.buildSessionContext();
+      }),
+    );
+    let reported: unknown;
+    const excess = SessionManager.openModelContextAsync(scope).catch((error: unknown) => {
+      reported = error;
+    });
+    try {
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
+      expect(reported).toMatchObject({ name: "WorkerTaskError", code: "overloaded" });
+      expect(completed).toEqual([]);
+      expect(source.buildSessionContext()).toEqual(expected);
+      release.resolve();
+      expect(await Promise.all(accepted)).toEqual(Array.from({ length: 128 }, () => expected));
+      expect(completed).toEqual(Array.from({ length: 128 }, (_, index) => index));
+      expect((await SessionManager.openModelContextAsync(scope)).buildSessionContext()).toEqual(
+        expected,
+      );
+    } finally {
+      release.resolve();
+      spy.mockRestore();
+      await Promise.allSettled([...accepted, excess]);
+    }
+  });
+});
 
 it("acquires a long sparse context with bounded queries and preserved message order", async () => {
   await withOpenClawTestState({ label: "model-context-batch" }, async (state) => {

--- a/src/config/sessions/disk-budget.physical-usage.test.ts
+++ b/src/config/sessions/disk-budget.physical-usage.test.ts
@@ -4,6 +4,8 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { Worker } from "node:worker_threads";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { WorkerTaskPool } from "../../infra/worker-task-pool.js";
+import { createDeferredCore } from "../../shared/deferred.js";
 import { withTestDir } from "../../test-helpers/temp-dir.js";
 import {
   hasRetainedSessionTranscriptArchives,
@@ -30,6 +32,60 @@ async function addSessionArtifacts(directory: string, index: number): Promise<vo
 }
 
 describe("physical session disk usage", () => {
+  it("reports scan overload before pruning archives and recovers after queued scans drain", async () => {
+    await withTestDir({ prefix: "openclaw-disk-usage-pressure-" }, async (directory) => {
+      const storePath = path.join(directory, "openclaw-agent.sqlite");
+      const archivePath = path.join(directory, "old.jsonl.deleted.2026-01-01T00-00-00.000Z.zst");
+      await fs.writeFile(storePath, Buffer.alloc(321));
+      await fs.writeFile(archivePath, Buffer.alloc(100));
+      const release = createDeferredCore();
+      const spy = vi
+        .spyOn(WorkerTaskPool.prototype, "run")
+        .mockImplementationOnce(function (this: WorkerTaskPool<unknown, unknown>, input, options) {
+          spy.mockRestore();
+          // Delay preparation, not the caller's result or the pool's capacity decision.
+          return this.run(async () => {
+            await release.promise;
+            return input;
+          }, options);
+        });
+      const accepted = Array.from({ length: 128 }, () =>
+        measureSessionPhysicalDiskUsage(storePath),
+      );
+      let reported: unknown;
+      const excess = measureSessionPhysicalDiskUsage(storePath).catch((error: unknown) => {
+        reported = error;
+      });
+      try {
+        await new Promise<void>((resolve) => {
+          setImmediate(resolve);
+        });
+        expect(reported).toMatchObject({ name: "WorkerTaskError", code: "overloaded" });
+        await expect(
+          pruneSessionTranscriptArchivesToHighWater({ storePath, highWaterBytes: 321 }),
+        ).rejects.toMatchObject({ code: "overloaded" });
+        expect((await fs.stat(archivePath)).size).toBe(100);
+        release.resolve();
+        const usage = {
+          databaseMainBytes: 321,
+          databaseWalBytes: 0,
+          sessionFilesBytes: 100,
+          totalBytes: 421,
+        };
+        expect(await Promise.all(accepted)).toEqual(Array.from({ length: 128 }, () => usage));
+        await expect(
+          pruneSessionTranscriptArchivesToHighWater({ storePath, highWaterBytes: 321 }),
+        ).resolves.toMatchObject({ removedFiles: 1, usage: { totalBytes: 321 } });
+        await expect(fs.stat(archivePath)).rejects.toMatchObject({ code: "ENOENT" });
+        expect(workers).toHaveLength(1);
+      } finally {
+        release.resolve();
+        spy.mockRestore();
+        await Promise.allSettled([...accepted, excess]);
+      }
+    });
+  });
+
   it.each(["legacy", "sqlite", "legacy-in-agent"] as const)(
     "measures and prunes the canonical session artifacts through the %s selector",
     async (selector) => {

--- a/src/infra/worker-task-capacity.ts
+++ b/src/infra/worker-task-capacity.ts
@@ -1,0 +1,84 @@
+import { availableParallelism } from "node:os";
+import { resolveGlobalSingleton } from "../shared/global-singleton.js";
+
+export const DEFAULT_WORKER_PENDING_TASKS = 128;
+export const DEFAULT_WORKER_PENDING_BYTES = 256 * 1024 * 1024;
+
+export type WorkerComputePermit = { requestCheckpoint: () => boolean };
+
+/** Shared compute admission; database and generation workers keep their own ordering. */
+export function getWorkerComputeCapacity() {
+  return resolveGlobalSingleton(Symbol.for("openclaw.workerComputeCapacity"), () => {
+    const limit = Math.max(1, availableParallelism() - 1);
+    const active = new Set<WorkerComputePermit>();
+    const waiting = new Set<() => void>();
+    let pendingTasks = 0;
+    let pendingBytes = 0;
+    let draining = false;
+    const requestCheckpoints = () => {
+      let demand = waiting.size;
+      if (demand) {
+        for (const permit of active) {
+          if (permit.requestCheckpoint() && --demand === 0) {
+            break;
+          }
+        }
+      }
+    };
+    const drain = () => {
+      if (draining) {
+        return;
+      }
+      draining = true;
+      try {
+        while (active.size < limit && waiting.size) {
+          const next = waiting.values().next().value!;
+          waiting.delete(next);
+          next();
+        }
+      } finally {
+        draining = false;
+      }
+      requestCheckpoints();
+    };
+    return {
+      admit(bytes: number): boolean {
+        if (
+          pendingTasks >= DEFAULT_WORKER_PENDING_TASKS ||
+          pendingBytes + bytes > DEFAULT_WORKER_PENDING_BYTES
+        ) {
+          return false;
+        }
+        pendingTasks++;
+        pendingBytes += bytes;
+        return true;
+      },
+      finish(bytes: number) {
+        pendingTasks--;
+        pendingBytes -= bytes;
+      },
+      acquire(
+        resume: () => void,
+        requestCheckpoint: () => boolean,
+      ): WorkerComputePermit | undefined {
+        // A newly submitting pool must not overtake an already waiting pool.
+        if (active.size >= limit || (!draining && waiting.size)) {
+          waiting.add(resume);
+          requestCheckpoints();
+          return undefined;
+        }
+        const permit = { requestCheckpoint };
+        active.add(permit);
+        return permit;
+      },
+      release(permit: WorkerComputePermit) {
+        active.delete(permit);
+        drain();
+      },
+      remove(resume: () => void) {
+        waiting.delete(resume);
+      },
+      requestCheckpoints,
+    };
+  });
+}

--- a/src/infra/worker-task-pool.test.ts
+++ b/src/infra/worker-task-pool.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { AsyncLocalStorage } from "node:async_hooks";
 import { execFile } from "node:child_process";
+import { availableParallelism } from "node:os";
 import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
 import type { Worker } from "node:worker_threads";
@@ -12,6 +13,11 @@ import type { PoolFixtureInput, PoolFixtureResult } from "./worker-task-pool.tes
 const workerUrl = new URL("./worker-task-pool.test-support.ts", import.meta.url);
 const pools: WorkerTaskPool<PoolFixtureInput, PoolFixtureResult>[] = [];
 const workers = vi.hoisted(() => [] as Worker[]);
+
+vi.mock("node:os", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("node:os")>()),
+  availableParallelism: () => 4,
+}));
 
 vi.mock("node:worker_threads", async (importOriginal) => {
   const actual = await importOriginal<typeof import("node:worker_threads")>();
@@ -48,6 +54,134 @@ afterEach(async () => {
 });
 
 describe("worker task pool", () => {
+  it("keeps canceled preparation charged until its retained input is released", async () => {
+    const pool = createPool({ workerUrl, maxPendingTasks: 1 });
+    const gate = createDeferredCore<PoolFixtureInput>();
+    const controller = new AbortController();
+    const first = pool.run(() => gate.promise, { signal: controller.signal });
+    const settled = Promise.allSettled([first]);
+    controller.abort();
+    await settled;
+    await expect(pool.run({ label: "excess" }, {})).rejects.toMatchObject({ code: "overloaded" });
+    gate.resolve({ label: "canceled" });
+    await gate.promise;
+    expect(await pool.run({ label: "recovered" }, {})).toMatchObject({ label: "recovered" });
+  });
+
+  it.each(["tasks", "bytes"] as const)(
+    "rejects excess pending %s and releases rejected inputs in caller context",
+    async (bound) => {
+      const context = new AsyncLocalStorage<string>();
+      const pool = createPool({
+        workerUrl,
+        maxPendingTasks: bound === "tasks" ? 2 : 10,
+        maxPendingBytes: 8,
+      });
+      const ready = createDeferredCore<PoolFixtureInput>();
+      const first = pool.run(() => ready.promise, { inputBytes: 4 });
+      const queued = pool.run({ label: "queued" }, { inputBytes: 4 });
+      const released: Array<string | undefined> = [];
+      let prepared = false;
+      const excess = context.run("rejected owner", () =>
+        pool.run(
+          () => {
+            prepared = true;
+            return { label: "excess" };
+          },
+          {
+            inputBytes: bound === "bytes" ? 1 : 0,
+            onInputConsumed: () => released.push(context.getStore()),
+          },
+        ),
+      );
+      const settled = Promise.allSettled([first, queued, excess]);
+      ready.resolve({ label: "first" });
+      const results = await settled;
+      expect(results[2]).toMatchObject({ status: "rejected", reason: { code: "overloaded" } });
+      expect(prepared).toBe(false);
+      expect(released).toEqual(["rejected owner"]);
+      expect(await pool.run({ label: "recovered" }, { inputBytes: 8 })).toMatchObject({
+        label: "recovered",
+      });
+    },
+  );
+
+  it("shares compute capacity across pools while ordered workers remain independent", async () => {
+    const limit = Math.max(1, availableParallelism() - 1);
+    const owner = createPool({ workerUrl, sharedCompute: true, maxWorkers: limit });
+    const waiting = createPool({ workerUrl, sharedCompute: true });
+    const independent = createPool();
+    const gate = createDeferredCore<PoolFixtureInput>();
+    const running = Array.from({ length: limit }, () => owner.run(() => gate.promise, {}));
+    let prepared = false;
+    const queued = waiting.run(() => {
+      prepared = true;
+      return { label: "waiting" };
+    }, {});
+    const settled = Promise.allSettled([...running, queued]);
+    try {
+      expect(prepared).toBe(false);
+      expect(await independent.run({ label: "ordered" }, {})).toMatchObject({ label: "ordered" });
+      expect(prepared).toBe(false);
+    } finally {
+      gate.resolve({ label: "owner" });
+      await settled;
+    }
+    expect(await queued).toMatchObject({ label: "waiting" });
+  });
+
+  it.each(["before", "during"] as const)(
+    "requests a host checkpoint for contention %s the exchange",
+    async (contention) => {
+      const context = new AsyncLocalStorage<string>();
+      let checkpointContext: string | undefined;
+      const limit = Math.max(1, availableParallelism() - 1);
+      const owner = createPool({ workerUrl, sharedCompute: true, maxWorkers: limit });
+      const waiting = createPool({ workerUrl, sharedCompute: true });
+      const gate = createDeferredCore<PoolFixtureInput>();
+      const entered = createDeferredCore();
+      const checkpoint = createDeferredCore();
+      let checkpointRequested = false;
+      const blockers = Array.from({ length: limit - 1 }, () => owner.run(() => gate.promise, {}));
+      const host = context.run("host owner", () =>
+        owner.run(
+          { label: "host", exchanges: 1 },
+          {
+            onRequest: async (_input, { yieldSignal }) => {
+              entered.resolve();
+              const requestCheckpoint = () => {
+                checkpointContext = context.getStore();
+                checkpointRequested = true;
+                checkpoint.resolve();
+              };
+              if (yieldSignal.aborted) {
+                requestCheckpoint();
+              } else {
+                yieldSignal.addEventListener("abort", requestCheckpoint, { once: true });
+              }
+              await checkpoint.promise;
+              return { input: null };
+            },
+          },
+        ),
+      );
+      const settled = Promise.allSettled([...blockers, host]);
+      if (contention === "during") {
+        await entered.promise;
+      }
+      const next = context.run("contender", () => waiting.run({ label: "next" }, {}));
+      try {
+        await expect.poll(() => checkpointRequested).toBe(true);
+        expect(checkpointContext).toBe("host owner");
+        expect(await next).toMatchObject({ label: "next" });
+      } finally {
+        checkpoint.resolve();
+        gate.resolve({ label: "blocker" });
+        await Promise.allSettled([settled, next]);
+      }
+    },
+  );
+
   it.each(["abort", "close"] as const)(
     "keeps host cancellation callbacks in the admitted caller context on %s",
     async (ending) => {

--- a/src/infra/worker-task-pool.test.ts
+++ b/src/infra/worker-task-pool.test.ts
@@ -160,7 +160,7 @@ describe("worker task pool", () => {
                 yieldSignal.addEventListener("abort", requestCheckpoint, { once: true });
               }
               await checkpoint.promise;
-              return { input: null };
+              return { input: null, timeoutMs: 10_000 };
             },
           },
         ),

--- a/src/infra/worker-task-pool.ts
+++ b/src/infra/worker-task-pool.ts
@@ -1,13 +1,21 @@
 import { AsyncLocalStorage } from "node:async_hooks";
+import { channel as createDiagnosticsChannel } from "node:diagnostics_channel";
 import { availableParallelism } from "node:os";
 import { parentPort, Worker, type Transferable, type WorkerOptions } from "node:worker_threads";
 import { toErrorObject } from "@openclaw/normalization-core/error-coercion";
 import { resolveTimerTimeoutMs } from "@openclaw/normalization-core/number-coercion";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { createDeferredCore, type Deferred } from "../shared/deferred.js";
+import {
+  DEFAULT_WORKER_PENDING_BYTES,
+  DEFAULT_WORKER_PENDING_TASKS,
+  getWorkerComputeCapacity,
+  type WorkerComputePermit,
+} from "./worker-task-capacity.js";
 
 // Reusable workers must not retain the first submitting caller's async scope.
 const runInWorkerPoolContext = AsyncLocalStorage.snapshot();
+const taskDiagnostics = createDiagnosticsChannel("openclaw.worker.task");
 
 type WorkerTaskInput<Input> = Input | (() => Input | Promise<Input>);
 export type WorkerTaskResponse = {
@@ -26,6 +34,8 @@ export type WorkerTaskRequestContext = {
 };
 
 type WorkerTaskOptions<Input> = {
+  /** Known retained input bytes, including inputs captured by a factory. No serialization pass. */
+  inputBytes?: number;
   /** When supplied, queueing and asynchronous preparation consume the execution deadline. */
   timeoutMs?: number;
   signal?: AbortSignal;
@@ -59,6 +69,14 @@ type Task<Input, Output> = Deferred<Output> & {
   abort: () => void;
   done: boolean;
   slot?: Slot<Input, Output>;
+  admitted: boolean;
+  preparing: boolean;
+  inputBytes: number;
+  computePermit?: WorkerComputePermit;
+  enqueuedAt: number;
+  startedAt?: number;
+  preparedAt?: number;
+  transferMs: number;
 };
 type Slot<Input, Output> = {
   worker?: Worker;
@@ -70,7 +88,7 @@ type Slot<Input, Output> = {
 export class WorkerTaskError extends Error {
   constructor(
     message: string,
-    readonly code: "unavailable" | "timeout" | "failed",
+    readonly code: "unavailable" | "timeout" | "failed" | "overloaded",
   ) {
     super(message);
     this.name = "WorkerTaskError";
@@ -82,6 +100,12 @@ export class WorkerTaskPool<Input, Output> {
   private readonly slots = new Set<Slot<Input, Output>>();
   private readonly queue: Task<Input, Output>[] = [];
   private readonly maxWorkers: number;
+  private readonly maxPendingTasks: number;
+  private readonly maxPendingBytes: number;
+  private pendingTasks = 0;
+  private pendingBytes = 0;
+  private readonly computeCapacity: ReturnType<typeof getWorkerComputeCapacity> | undefined;
+  private readonly resumeCompute = () => this.dispatch();
   private closedError?: Error;
   private nextTaskId = 0;
   // Idle retirement is armed from worker messages, outside any caller's turn.
@@ -96,17 +120,38 @@ export class WorkerTaskPool<Input, Output> {
       workerUrl: URL;
       workerOptions?: Omit<WorkerOptions, "eval">;
       maxWorkers?: number;
+      /** Share CPU admission with other stateless compute pools in this isolate. */
+      sharedCompute?: boolean;
+      /** Include queued, preparing, and running tasks until execution has settled. */
+      maxPendingTasks?: number;
+      maxPendingBytes?: number;
       idleTimeoutMs?: number;
       restartOnError?: boolean;
       validateResult?: (value: Output) => void;
     },
   ) {
     this.maxWorkers = options.maxWorkers ?? availableParallelism();
+    this.maxPendingTasks = options.maxPendingTasks ?? DEFAULT_WORKER_PENDING_TASKS;
+    this.maxPendingBytes = options.maxPendingBytes ?? DEFAULT_WORKER_PENDING_BYTES;
+    for (const [name, value] of Object.entries({
+      maxWorkers: this.maxWorkers,
+      maxPendingTasks: this.maxPendingTasks,
+      maxPendingBytes: this.maxPendingBytes,
+    })) {
+      if (!Number.isSafeInteger(value) || value < 1) {
+        throw new RangeError(`${name} must be a positive safe integer`);
+      }
+    }
+    this.computeCapacity = options.sharedCompute ? getWorkerComputeCapacity() : undefined;
   }
 
   run(input: WorkerTaskInput<Input>, options: WorkerTaskOptions<Input>): Promise<Output> {
     if (this.closedError) {
       return Promise.reject(this.closedError);
+    }
+    const inputBytes = options.inputBytes ?? 0;
+    if (!Number.isSafeInteger(inputBytes) || inputBytes < 0) {
+      return Promise.reject(new RangeError("inputBytes must be a nonnegative safe integer"));
     }
     // A Promise executor would let the task's timer/abort closures retain input too.
     const task: Task<Input, Output> = {
@@ -120,7 +165,23 @@ export class WorkerTaskPool<Input, Output> {
       options: { ...options },
       abort: () => this.cancel(task, toErrorObject(options.signal?.reason, "worker task aborted")),
       done: false,
+      admitted: false,
+      preparing: false,
+      inputBytes,
+      enqueuedAt: performance.now(),
+      transferMs: 0,
     };
+    if (
+      this.pendingTasks >= this.maxPendingTasks ||
+      this.pendingBytes + inputBytes > this.maxPendingBytes ||
+      (this.computeCapacity && !this.computeCapacity.admit(inputBytes))
+    ) {
+      this.finish(task, new WorkerTaskError("worker task capacity reached", "overloaded"));
+      return task.promise;
+    }
+    task.admitted = true;
+    this.pendingTasks++;
+    this.pendingBytes += inputBytes;
     if (options.timeoutMs !== undefined) {
       this.armTimeout(task, options.timeoutMs);
     }
@@ -138,6 +199,7 @@ export class WorkerTaskPool<Input, Output> {
     error: Error = new WorkerTaskError("worker task pool closed", "unavailable"),
   ): Promise<void> {
     this.closedError ??= error;
+    this.computeCapacity?.remove(this.resumeCompute);
     for (const task of this.queue.splice(0)) {
       this.finish(task, this.closedError);
     }
@@ -150,6 +212,9 @@ export class WorkerTaskPool<Input, Output> {
   }
 
   private dispatch(): void {
+    if (!this.queue.length || this.closedError) {
+      this.computeCapacity?.remove(this.resumeCompute);
+    }
     while (!this.closedError && this.queue.length) {
       let slot = [...this.slots].find((entry) => !entry.task && !entry.retiring);
       if (!slot) {
@@ -169,6 +234,22 @@ export class WorkerTaskPool<Input, Output> {
           }
           return;
         }
+      }
+      const nextTask = this.queue[0]!;
+      if (this.computeCapacity) {
+        const permit = this.computeCapacity.acquire(this.resumeCompute, () => {
+          if (nextTask.exchange && !nextTask.exchange.sent) {
+            nextTask.runInContext(() => nextTask.exchange?.pressure.abort());
+            return true;
+          }
+          return false;
+        });
+        if (!permit) {
+          return;
+        }
+        nextTask.computePermit = permit;
+      }
+      if (!slot) {
         slot = {};
         this.slots.add(slot);
       }
@@ -176,6 +257,7 @@ export class WorkerTaskPool<Input, Output> {
       const task = this.queue.shift()!;
       slot.task = task;
       task.slot = slot;
+      task.startedAt = performance.now();
       slot.worker?.ref();
       void task.runInContext(() => this.start(slot, task));
     }
@@ -217,6 +299,7 @@ export class WorkerTaskPool<Input, Output> {
     const taskInput = task.input!;
     delete task.input;
     let input: Input;
+    task.preparing = true;
     try {
       input =
         typeof taskInput === "function"
@@ -225,19 +308,27 @@ export class WorkerTaskPool<Input, Output> {
     } catch (error) {
       this.fail(slot, toErrorObject(error, "worker task preparation failed"));
       return;
+    } finally {
+      task.preparing = false;
+      if (task.done) {
+        this.releaseAdmission(task);
+      }
     }
     // A cancelled preparation may finish later, but it must never create or feed a worker.
     if (task.done) {
       return;
     }
+    task.preparedAt = performance.now();
     try {
       const worker = slot.worker ?? this.createWorker(slot);
       const transferList = task.options.transferList?.(input);
       if (!task.done) {
+        const transferStartedAt = performance.now();
         worker.postMessage(
           { input, taskId: task.id, interactive: Boolean(task.options.onRequest) },
           transferList,
         );
+        task.transferMs += performance.now() - transferStartedAt;
       }
     } catch (error) {
       this.fail(slot, new WorkerTaskError(String(error), "unavailable"));
@@ -348,6 +439,7 @@ export class WorkerTaskPool<Input, Output> {
     };
     task.exchange = exchange;
     this.dispatch();
+    this.computeCapacity?.requestCheckpoints();
     void Promise.resolve()
       .then(() => {
         if (task.done || slot.task !== task) {
@@ -425,6 +517,9 @@ export class WorkerTaskPool<Input, Output> {
     // SAFETY: Only a validated successful reply reaches finish without an error and supplies Output.
     const complete = () =>
       task.runInContext(() => {
+        if (!task.preparing) {
+          this.releaseAdmission(task);
+        }
         let completionError = error;
         try {
           // Retiring completion runs only after terminate() resolves. Queued inputs
@@ -438,6 +533,25 @@ export class WorkerTaskPool<Input, Output> {
           release?.();
         } catch (releaseError) {
           completionError ??= toErrorObject(releaseError, "worker input release failed");
+        }
+        const permit = task.computePermit;
+        task.computePermit = undefined;
+        if (permit) {
+          this.computeCapacity!.release(permit);
+        }
+        if (taskDiagnostics.hasSubscribers) {
+          const now = performance.now();
+          taskDiagnostics.publish({
+            worker: this.options.workerUrl.pathname.split("/").at(-1),
+            outcome: completionError ? "failed" : "ok",
+            queueMs: (task.startedAt ?? now) - task.enqueuedAt,
+            preparationMs:
+              task.startedAt === undefined ? 0 : (task.preparedAt ?? now) - task.startedAt,
+            runMs: task.preparedAt === undefined ? 0 : now - task.preparedAt,
+            transferMs: task.transferMs,
+            pendingTasks: this.pendingTasks,
+            pendingBytes: this.pendingBytes,
+          });
         }
         if (completionError) {
           task.reject(completionError);
@@ -454,12 +568,21 @@ export class WorkerTaskPool<Input, Output> {
         void this.retire(slot).then(complete);
         return;
       }
-      if (!this.queue.length) {
-        this.idle(slot);
-      }
     }
     complete();
     this.dispatch();
+    if (slot && !slot.task && !slot.retiring) {
+      this.idle(slot);
+    }
+  }
+
+  private releaseAdmission(task: Task<Input, Output>): void {
+    if (task.admitted) {
+      task.admitted = false;
+      this.pendingTasks--;
+      this.pendingBytes -= task.inputBytes;
+      this.computeCapacity?.finish(task.inputBytes);
+    }
   }
 
   // Reply handling restores the caller's context; idle retirement must leave it behind.


### PR DESCRIPTION
## What Problem This Solves

Part of #146166.

Fixes an issue where concurrent code-mode execution and compaction could create independent sets of CPU workers and retain an unlimited backlog, increasing Gateway contention and memory use during bursts.

## Why This Change Was Made

Compute pools share admission based on available CPU capacity, reserving one CPU where possible. Pending work is bounded by task count and producer-reported input bytes. Excess submissions return a distinct overload error. Ordered database and model-generation pools retain their independent execution limits.

Cancellation keeps execution capacity reserved until the worker stops and keeps retained preparation inputs charged until preparation settles. Waiting compute pools request bounded host checkpoints without losing the submitting caller's context. Local diagnostics expose queue, preparation, execution wall time, transfer time, and pending work counts without task contents.

## User Impact

Concurrent workloads have a shared CPU budget and bounded pending work. Overload is explicit, and compaction does not silently fall back to synchronous execution because of capacity pressure. No operator configuration, persistence, or dependency changes are required.

Catalog admission pressure rejects only the excess request. It preserves accepted catalog/auth work and later refreshes. The SDK documentation explains pending-task accounting, producer-reported byte limits, and retry behavior after pressure drains.

## Evidence

- 24 worker-pool tests and 54 code-mode/compaction tests pass, including real cancellation, snapshot transfer, and large-history responsiveness.
- Four new regression checks fail against the original pool for the expected reasons: excess task and byte admission, independent compute over-admission, and missing cross-pool checkpoints.
- Real context and disk-pruning saturation/recovery suites pass 43 tests with one existing platform skip; both new regressions fail with the original unbounded pool. Overloaded pruning preserves the archived session, and a later admitted request can prune it.
- The real catalog regression fills the 128-request queue, rejects the excess request, completes all accepted work, and verifies subsequent changed-auth/catalog refreshes. The old catalog catch rejected all 128 accepted operations. The corrected full catalog/mismatch suites pass all 31 tests on Linux in the stacked media candidate, whose pool/catalog changes are identical to this PR.
- One initial Linux catalog run missed a fixture's initial configured model. Original isolated/full suites and the final candidate full suite pass without changing that assertion or production behavior; the initial failed log is retained.
- Independent P2 reviews of the pool and final caller follow-up found no actionable findings. Scoped lint, formatting, and diff checks pass.
- Synthetic Node 26.8.2 comparison on a host reporting 32 available CPUs: two pools, 64 fixed CPU jobs per batch, three batches. The shared limit reduced maximum observed active jobs from 64 to 30, sampled peak RSS from 2,352 to 1,969 MiB, and maximum timer gap from 162 to 109 ms. Median batch time changed from 470 to 498 ms. These are synthetic observations, not a production throughput guarantee.
- An initial eight-worker cap was too restrictive on this host; the final limit uses available parallelism instead.
- Local typechecking was blocked by the repository guard against dependencies linked outside the checkout. Required hosted typecheck and CI gates must pass before landing.
