### PR TITLE
refactor: simplify plugin reload ownership and tests

### DIFF
--- a/src/agents/subagents/swarm/swarm-scheduler.ts
+++ b/src/agents/subagents/swarm/swarm-scheduler.ts
@@ -290,9 +290,7 @@ export function releaseSwarmRun(runId: string): boolean {
     return false;
   }
   const previouslyFull = location.lane.active.size >= location.lane.limit;
-  if (!location.lane.active.delete(runId)) {
-    return false;
-  }
+  location.lane.active.delete(runId);
   runLocations.delete(runId);
   publishLaneCapacityChange(location.lane, previouslyFull);
   pumpLane(location.lane);
@@ -306,9 +304,6 @@ export function removeQueuedSwarmRun(runId: string): boolean {
     return false;
   }
   const index = location.lane.queue.indexOf(location.item);
-  if (index < 0) {
-    return false;
-  }
   location.lane.queue.splice(index, 1);
   runLocations.delete(runId);
   void finalizeRemovedRun(location.item);

--- a/src/cli/plugins-cli.install.test.ts
+++ b/src/cli/plugins-cli.install.test.ts
@@ -51,6 +51,7 @@ import {
   writePersistedInstalledPluginIndexInstallRecordsWithLeaseMock,
 } from "./plugins-cli-test-helpers.js";
 import { runPluginInstallCommand } from "./plugins-install-command.js";
+import { createCliTtyMock } from "./test-runtime-capture.js";
 
 // Default-selector assertions describe a stable build; beta cases set their own identity.
 const coreVersion = vi.hoisted(() => ({ value: "2026.8.1" }));
@@ -79,8 +80,7 @@ vi.mock("../version.js", async (importOriginal) => ({
 const CLI_STATE_ROOT = "/tmp/openclaw-state";
 const ORIGINAL_OPENCLAW_STATE_DIR = process.env.OPENCLAW_STATE_DIR;
 const ORIGINAL_OPENCLAW_NIX_MODE = process.env.OPENCLAW_NIX_MODE;
-const ORIGINAL_STDIN_TTY = Object.getOwnPropertyDescriptor(process.stdin, "isTTY");
-const ORIGINAL_STDOUT_TTY = Object.getOwnPropertyDescriptor(process.stdout, "isTTY");
+const { set: setTty, restore: restoreTty } = createCliTtyMock();
 const PROFILE_STATE_ROOT = "/tmp/openclaw-ledger-profile";
 
 function mockNpmChannelMetadata(name: string, beta?: string, latest?: string): void {
@@ -472,30 +472,6 @@ function recordHookInstallCall(callIndex = 0): PersistedInstallRecord {
 
 function runtimeLogsContain(fragment: string): boolean {
   return pluginsCliRuntimeLogs.some((line) => line.includes(fragment));
-}
-
-function setTty(value: boolean): void {
-  Object.defineProperty(process.stdin, "isTTY", {
-    value,
-    configurable: true,
-  });
-  Object.defineProperty(process.stdout, "isTTY", {
-    value,
-    configurable: true,
-  });
-}
-
-function restoreTty(): void {
-  if (ORIGINAL_STDIN_TTY) {
-    Object.defineProperty(process.stdin, "isTTY", ORIGINAL_STDIN_TTY);
-  } else {
-    Reflect.deleteProperty(process.stdin, "isTTY");
-  }
-  if (ORIGINAL_STDOUT_TTY) {
-    Object.defineProperty(process.stdout, "isTTY", ORIGINAL_STDOUT_TTY);
-  } else {
-    Reflect.deleteProperty(process.stdout, "isTTY");
-  }
 }
 
 const NON_CLAWHUB_INSTALL_FORCE_FLAG = "--force";

--- a/src/cli/plugins-cli.policy.test.ts
+++ b/src/cli/plugins-cli.policy.test.ts
@@ -29,6 +29,7 @@ import {
   configWriteMock,
   writePersistedInstalledPluginIndexInstallRecordsWithLeaseMock,
 } from "./plugins-cli-test-helpers.js";
+import { createCliTtyMock } from "./test-runtime-capture.js";
 
 const inventory = vi.hoisted(() => ({ load: vi.fn(), hostedCatalog: vi.fn() }));
 
@@ -232,14 +233,9 @@ describe("plugins cli policy mutations", () => {
         }
         return receipt;
       });
-      const streams = [process.stdin, process.stdout].map((stream) => ({
-        stream,
-        descriptor: Object.getOwnPropertyDescriptor(stream, "isTTY"),
-      }));
+      const tty = createCliTtyMock();
       try {
-        for (const { stream } of streams) {
-          Object.defineProperty(stream, "isTTY", { value: true, configurable: true });
-        }
+        tty.set(true);
         await withEnvAsync(mode ? { [mode]: "1" } : {}, async () => {
           const reload = runPluginsCommand([
             "plugins",
@@ -255,13 +251,7 @@ describe("plugins cli policy mutations", () => {
           }
         });
       } finally {
-        for (const { stream, descriptor } of streams) {
-          if (descriptor) {
-            Object.defineProperty(stream, "isTTY", descriptor);
-          } else {
-            Reflect.deleteProperty(stream, "isTTY");
-          }
-        }
+        tty.restore();
       }
       expect(pluginLifecycleGatewayMock).toHaveBeenCalledExactlyOnceWith(
         "plugins.reload",

--- a/src/cli/plugins-cli.update.test.ts
+++ b/src/cli/plugins-cli.update.test.ts
@@ -37,34 +37,10 @@ import {
   writePersistedInstalledPluginIndexInstallRecordsWithLeaseMock,
 } from "./plugins-cli-test-helpers.js";
 import { registerPluginsCli } from "./plugins-cli.js";
+import { createCliTtyMock } from "./test-runtime-capture.js";
 
 const ORIGINAL_OPENCLAW_NIX_MODE = process.env.OPENCLAW_NIX_MODE;
-const ORIGINAL_STDIN_TTY = Object.getOwnPropertyDescriptor(process.stdin, "isTTY");
-const ORIGINAL_STDOUT_TTY = Object.getOwnPropertyDescriptor(process.stdout, "isTTY");
-
-function setTty(value: boolean): void {
-  Object.defineProperty(process.stdin, "isTTY", {
-    value,
-    configurable: true,
-  });
-  Object.defineProperty(process.stdout, "isTTY", {
-    value,
-    configurable: true,
-  });
-}
-
-function restoreTty(): void {
-  if (ORIGINAL_STDIN_TTY) {
-    Object.defineProperty(process.stdin, "isTTY", ORIGINAL_STDIN_TTY);
-  } else {
-    Reflect.deleteProperty(process.stdin, "isTTY");
-  }
-  if (ORIGINAL_STDOUT_TTY) {
-    Object.defineProperty(process.stdout, "isTTY", ORIGINAL_STDOUT_TTY);
-  } else {
-    Reflect.deleteProperty(process.stdout, "isTTY");
-  }
-}
+const { set: setTty, restore: restoreTty } = createCliTtyMock();
 
 function createTrackedPluginConfig(params: {
   pluginId: string;

--- a/src/cli/test-runtime-capture.ts
+++ b/src/cli/test-runtime-capture.ts
@@ -44,6 +44,29 @@ export function createCliRuntimeCapture(): CliRuntimeCapture {
   };
 }
 
+export function createCliTtyMock() {
+  const streams = [process.stdin, process.stdout].map((stream) => ({
+    stream,
+    descriptor: Object.getOwnPropertyDescriptor(stream, "isTTY"),
+  }));
+  return {
+    set: (value: boolean) => {
+      for (const { stream } of streams) {
+        Object.defineProperty(stream, "isTTY", { value, configurable: true });
+      }
+    },
+    restore: () => {
+      for (const { stream, descriptor } of streams) {
+        if (descriptor) {
+          Object.defineProperty(stream, "isTTY", descriptor);
+        } else {
+          Reflect.deleteProperty(stream, "isTTY");
+        }
+      }
+    },
+  };
+}
+
 export async function mockRuntimeModule<TModule extends { defaultRuntime: OutputRuntimeEnv }>(
   loadActual: () => Promise<TModule>,
   defaultRuntime: TModule["defaultRuntime"],

--- a/src/gateway/server-close.ts
+++ b/src/gateway/server-close.ts
@@ -92,16 +92,13 @@ async function triggerGatewayLifecycleHookWithTimeout(params: {
   hookName: "gateway:shutdown" | "gateway:pre-restart";
   timeoutMs: number;
 }): Promise<"completed" | "timeout"> {
-  let timeout: ReturnType<typeof setTimeout> | undefined;
   const hookPromise = params.cleanupWork.track(() => triggerInternalHook(params.event));
   void hookPromise.catch(() => undefined);
+  const timeout = createTimeoutRace(params.timeoutMs, () => "timeout" as const);
   try {
     const result = await Promise.race([
       hookPromise.then(() => "completed" as const),
-      new Promise<"timeout">((resolve) => {
-        timeout = setTimeout(() => resolve("timeout"), params.timeoutMs);
-        timeout.unref?.();
-      }),
+      timeout.promise,
     ]);
     if (result === "timeout") {
       shutdownLog.warn(
@@ -110,9 +107,7 @@ async function triggerGatewayLifecycleHookWithTimeout(params: {
     }
     return result;
   } finally {
-    if (timeout) {
-      clearTimeout(timeout);
-    }
+    timeout.clear();
   }
 }
 
@@ -181,20 +176,14 @@ async function waitForHttpClose(params: {
 }): Promise<boolean> {
   const timeout = createTimeoutRace(params.timeoutMs, () => false as const);
   try {
-    return await Promise.race([
-      params.closePromise.then(
-        () => true,
-        (err: unknown) => {
-          throw err;
-        },
-      ),
-      timeout.promise,
-    ]).catch((err: unknown) => {
-      const detail = err instanceof Error ? err.message : String(err);
-      shutdownLog.warn(`${params.label}: ${detail}`);
-      recordShutdownWarning(params.warnings, params.label);
-      return true;
-    });
+    return await Promise.race([params.closePromise.then(() => true), timeout.promise]).catch(
+      (err: unknown) => {
+        const detail = err instanceof Error ? err.message : String(err);
+        shutdownLog.warn(`${params.label}: ${detail}`);
+        recordShutdownWarning(params.warnings, params.label);
+        return true;
+      },
+    );
   } finally {
     timeout.clear();
   }
@@ -319,59 +308,38 @@ export async function prepareGatewayClose(
   // info, and the completion line below reports duration and outcome.
   shutdownLog.debug(`shutdown started: ${reason}`);
 
-  try {
-    await shutdownStep("update-check", () => params.updateCheckStop?.(), warnings);
-    await measureCloseStep("config-reloader", () =>
-      shutdownStep("config-reloader", () => params.configReloader.stop(), warnings),
-    );
-    await measureCloseStep("gateway-shutdown-hook", () =>
+  const triggerLifecycleHook = (action: "shutdown" | "pre-restart", timeoutMs: number) => {
+    const hookName = `gateway:${action}` as const;
+    return measureCloseStep(`gateway-${action}-hook`, () =>
       shutdownStep(
-        "gateway:shutdown",
+        hookName,
         async () => {
-          const shutdownEvent = createInternalHookEvent("gateway", "shutdown", "gateway:shutdown", {
-            reason,
-            restartExpectedMs,
-          });
           const result = await triggerGatewayLifecycleHookWithTimeout({
             cleanupWork,
-            event: shutdownEvent,
-            hookName: "gateway:shutdown",
-            timeoutMs: GATEWAY_SHUTDOWN_HOOK_TIMEOUT_MS,
+            event: createInternalHookEvent("gateway", action, hookName, {
+              reason,
+              restartExpectedMs,
+            }),
+            hookName,
+            timeoutMs,
           });
           if (result === "timeout") {
-            recordShutdownWarning(warnings, "gateway:shutdown");
+            recordShutdownWarning(warnings, hookName);
           }
         },
         warnings,
       ),
     );
+  };
+
+  try {
+    await shutdownStep("update-check", () => params.updateCheckStop?.(), warnings);
+    await measureCloseStep("config-reloader", () =>
+      shutdownStep("config-reloader", () => params.configReloader.stop(), warnings),
+    );
+    await triggerLifecycleHook("shutdown", GATEWAY_SHUTDOWN_HOOK_TIMEOUT_MS);
     if (restartExpectedMs !== null) {
-      await measureCloseStep("gateway-pre-restart-hook", () =>
-        shutdownStep(
-          "gateway:pre-restart",
-          async () => {
-            const preRestartEvent = createInternalHookEvent(
-              "gateway",
-              "pre-restart",
-              "gateway:pre-restart",
-              {
-                reason,
-                restartExpectedMs,
-              },
-            );
-            const result = await triggerGatewayLifecycleHookWithTimeout({
-              cleanupWork,
-              event: preRestartEvent,
-              hookName: "gateway:pre-restart",
-              timeoutMs: GATEWAY_PRE_RESTART_HOOK_TIMEOUT_MS,
-            });
-            if (result === "timeout") {
-              recordShutdownWarning(warnings, "gateway:pre-restart");
-            }
-          },
-          warnings,
-        ),
-      );
+      await triggerLifecycleHook("pre-restart", GATEWAY_PRE_RESTART_HOOK_TIMEOUT_MS);
     }
     const drainTimeoutMs =
       typeof opts?.drainTimeoutMs === "number" && Number.isFinite(opts.drainTimeoutMs)

--- a/src/gateway/server-methods/channels.status.test.ts
+++ b/src/gateway/server-methods/channels.status.test.ts
@@ -17,6 +17,7 @@ import {
   createChannelTestPluginBase,
   createTestRegistry,
 } from "../../test-utils/channel-plugins.js";
+import type { GatewayEventLoopHealth } from "../server/event-loop-health.js";
 import { requireGatewayRecord } from "../test-helpers.assertions.js";
 import type { GatewayRequestHandlerOptions } from "./types.js";
 
@@ -485,15 +486,13 @@ describe("channelsHandlers channels.status", () => {
     plugin.config.resolveAccount = refuse;
     mocks.listChannelPlugins.mockReturnValue([plugin]);
     const account = { accountId: "recorded", configured: true, running: false };
-    const respond = vi.fn();
-    const options = createOptions({ probe: true }, { respond });
+    const options = createOptions({});
     options.context.getRuntimeSnapshot = () => ({
       channels: { whatsapp: account },
       channelAccounts: { whatsapp: { recorded: account } },
       reloadingChannels: new Map([["whatsapp", "recorded"]]),
     });
-    await expectDefined(channelsHandlers["channels.status"], "channel status handler")(options);
-    const payload = requireRespondPayload(respond);
+    const payload = await runChannelsStatus({ probe: true }, { context: options.context });
     expect(firstChannelAccount(payload, "whatsapp")).toEqual(account);
     expect(payload.channelDefaultAccountId).toEqual({ whatsapp: "recorded" });
     expect(payload.partial).toBe(true);
@@ -666,10 +665,7 @@ describe("channelsHandlers channels.status", () => {
     const probeAccount = vi.fn(async () => ({ ok: true }));
     mocks.listChannelPlugins.mockReturnValue([createChannelPlugin({ probeAccount })]);
 
-    await expectDefined(
-      channelsHandlers["channels.status"],
-      'channelsHandlers["channels.status"] test invariant',
-    )(createOptions({ probe: true, timeoutMs: 999_999 }));
+    await runChannelsStatus({ probe: true, timeoutMs: 999_999 });
 
     const probeArgs = requireGatewayRecord(requireFirstCallArg(probeAccount), "probe args");
     expect(probeArgs.timeoutMs).toBe(30_000);
@@ -832,16 +828,11 @@ describe("channelsHandlers channels.status", () => {
           probe,
         }),
       );
-      const respond = vi.fn();
-      const run = expectDefined(
-        channelsHandlers["channels.status"],
-        'channelsHandlers["channels.status"] test invariant',
-      )(createOptions({ probe: true, timeoutMs: 1000 }, { respond }));
+      const run = runChannelsStatus({ probe: true, timeoutMs: 1000 });
 
       await vi.advanceTimersByTimeAsync(1000);
-      await run;
+      const payload = await run;
 
-      const payload = requireRespondPayload(respond);
       expect(
         requireGatewayRecord(firstChannelAccount(payload, "hanging").probe, "hanging probe")
           .timedOut,
@@ -891,26 +882,12 @@ describe("channelsHandlers channels.status", () => {
       running: false,
       terminalDisconnect: true,
     });
-    const respond = vi.fn();
 
-    await expectDefined(
-      channelsHandlers["channels.status"],
-      'channelsHandlers["channels.status"] test invariant',
-    )(createOptions({ probe: false, timeoutMs: 2000 }, { respond }));
+    const payload = await runChannelsStatus({ probe: false, timeoutMs: 2000 });
 
-    expect(respond).toHaveBeenCalledWith(
-      true,
-      expect.objectContaining({
-        channelAccounts: {
-          whatsapp: [
-            expect.objectContaining({
-              healthState: "terminal-disconnect",
-            }),
-          ],
-        },
-      }),
-      undefined,
-    );
+    expect(payload.channelAccounts).toEqual({
+      whatsapp: [expect.objectContaining({ healthState: "terminal-disconnect" })],
+    });
   });
 
   it("annotates unhealthy channel snapshots and includes event-loop health", async () => {
@@ -925,7 +902,7 @@ describe("channelsHandlers channels.status", () => {
       lastStartAt: now - 60 * 60_000,
       lastTransportActivityAt: now - 40 * 60_000,
     });
-    const eventLoop = {
+    const eventLoop: GatewayEventLoopHealth = {
       degraded: true,
       degradedSinceMs: 61_000,
       reasons: ["event_loop_delay"],
@@ -935,29 +912,14 @@ describe("channelsHandlers channels.status", () => {
       utilization: 1,
       cpuCoreRatio: 1,
     };
-    const respond = vi.fn();
+    const options = createOptions({});
+    options.context.getEventLoopHealth = () => eventLoop;
 
-    await expectDefined(
-      channelsHandlers["channels.status"],
-      'channelsHandlers["channels.status"] test invariant',
-    )(
-      createOptions(
-        { probe: false, timeoutMs: 2000 },
-        {
-          respond,
-          context: {
-            getRuntimeConfig: mocks.getRuntimeConfig,
-            getRuntimeSnapshot: () => ({
-              channels: {},
-              channelAccounts: {},
-            }),
-            getEventLoopHealth: () => eventLoop,
-          } as never,
-        },
-      ),
+    const payload = await runChannelsStatus(
+      { probe: false, timeoutMs: 2000 },
+      { context: options.context },
     );
 
-    const payload = requireRespondPayload(respond);
     expect(payload.eventLoop).toBe(eventLoop);
     expect(firstChannelAccount(payload, "whatsapp").healthState).toBe("stale-socket");
   });

--- a/src/gateway/server-methods/claws-packages.ts
+++ b/src/gateway/server-methods/claws-packages.ts
@@ -12,12 +12,10 @@ import {
 } from "../../claws/package-remove-plan.js";
 import { applyClawPackageRemovals, planClawPackageRemovals } from "../../claws/package-remove.js";
 import { readClawInstallRecord } from "../../claws/provenance.js";
-import {
-  capturePluginRuntimeApplications,
-  projectPluginRuntimeFailure,
-} from "../../plugins/lifecycle.js";
+import { projectPluginRuntimeFailure } from "../../plugins/lifecycle.js";
 import { readAgentDeletionJournal } from "../../state/agent-deletion-journal.js";
 import {
+  captureGatewayPluginRuntimeApplications,
   pluginLifecycleError,
   withGatewayPluginLifecycleLease,
 } from "./plugins-lifecycle-error.js";
@@ -55,7 +53,7 @@ export const clawsPackageHandlers = {
       return;
     }
     const input = parsed.data;
-    let captured: ReturnType<typeof capturePluginRuntimeApplications> | undefined;
+    let captured: ReturnType<typeof captureGatewayPluginRuntimeApplications> | undefined;
     try {
       const applyRuntime = context.applyPluginLifecycleChange;
       if (!applyRuntime) {
@@ -81,17 +79,7 @@ export const clawsPackageHandlers = {
           throw new Error("Claw package cleanup no longer owns the current removal state.");
         }
       };
-      assertCurrent();
-      captured = capturePluginRuntimeApplications((change) => {
-        assertCurrent();
-        return applyRuntime({
-          ...change,
-          assertInvokerOwned: () => {
-            assertCurrent();
-            change.assertInvokerOwned?.();
-          },
-        });
-      });
+      captured = captureGatewayPluginRuntimeApplications(applyRuntime, assertCurrent);
       const applyOwnedRuntime = captured.applyRuntime;
       const { runtimeFailure, ...removed } = await withGatewayPluginLifecycleLease(
         signal,

--- a/src/gateway/server-methods/plugins-lifecycle-error.ts
+++ b/src/gateway/server-methods/plugins-lifecycle-error.ts
@@ -10,8 +10,10 @@ import {
   readInstallPolicyWarningErrorDetails,
 } from "../../../packages/gateway-protocol/src/install-policy-warning-error-details.js";
 import {
+  capturePluginRuntimeApplications,
   PluginInstallPersistedError,
   projectPluginRuntimeFailure,
+  type PluginLifecycleRuntimeApply,
   type PluginRuntimeApplication,
 } from "../../plugins/lifecycle.js";
 import { ManagedPluginLifecycleError } from "../../plugins/management-lifecycle-error.js";
@@ -20,6 +22,23 @@ import {
   type PluginLifecycleLeaseContext,
 } from "../../plugins/plugin-lifecycle-lease.js";
 import { OpenClawStateLeaseError } from "../../state/openclaw-state-lease.js";
+
+export function captureGatewayPluginRuntimeApplications(
+  applyRuntime: PluginLifecycleRuntimeApply,
+  assertCurrent: () => void,
+) {
+  assertCurrent();
+  return capturePluginRuntimeApplications((change) => {
+    assertCurrent();
+    return applyRuntime({
+      ...change,
+      assertInvokerOwned: () => {
+        assertCurrent();
+        change.assertInvokerOwned?.();
+      },
+    });
+  });
+}
 
 class GatewayPluginLifecycleBusyError extends Error {
   constructor(cause: OpenClawStateLeaseError) {
@@ -71,10 +90,6 @@ export function pluginLifecycleError(error: unknown, application?: PluginRuntime
   const failure = projectPluginRuntimeFailure(error, application);
   const cause = error instanceof PluginInstallPersistedError ? error.cause : error;
   const lifecycleError = cause instanceof ManagedPluginLifecycleError ? cause : undefined;
-  const trustCode =
-    lifecycleError?.code && isClawHubTrustErrorCode(lifecycleError.code)
-      ? lifecycleError.code
-      : undefined;
   const installDetails = lifecycleError?.capabilityConsent
     ? buildCapabilityConsentErrorDetails(lifecycleError.capabilityConsent)
     : lifecycleError?.installPolicyWarning
@@ -84,9 +99,9 @@ export function pluginLifecycleError(error: unknown, application?: PluginRuntime
         })
       : lifecycleError
         ? buildClawHubTrustErrorDetails({
-            ...(trustCode ? { code: trustCode } : {}),
-            ...(lifecycleError.version ? { version: lifecycleError.version } : {}),
-            ...(lifecycleError.warning ? { warning: lifecycleError.warning } : {}),
+            code: isClawHubTrustErrorCode(lifecycleError.code) ? lifecycleError.code : undefined,
+            version: lifecycleError.version,
+            warning: lifecycleError.warning,
           })
         : undefined;
   const refusal =

--- a/src/gateway/server-methods/plugins-mutations.test.ts
+++ b/src/gateway/server-methods/plugins-mutations.test.ts
@@ -90,11 +90,9 @@ const capabilityConsent = {
 
 describe("plugin management Gateway mutation handlers", () => {
   beforeEach(() => {
-    managementMocks.install.mockReset();
-    managementMocks.refreshMetadata.mockReset();
-    managementMocks.reload.mockReset();
-    managementMocks.setEnabled.mockReset();
-    managementMocks.uninstall.mockReset();
+    for (const mock of Object.values(managementMocks)) {
+      mock.mockReset();
+    }
   });
 
   it.each([
@@ -470,13 +468,9 @@ describe("plugin management Gateway mutation handlers", () => {
     });
   });
 
-  it.each([
-    { mode: "off", restartRequired: false },
-    { mode: "restart", restartRequired: false },
-    { mode: "hot", restartRequired: false },
-  ] as const)(
-    "reports restartRequired=$restartRequired for $mode reload mode",
-    async ({ mode, restartRequired }) => {
+  it.each(["off", "restart", "hot"] as const)(
+    "reports restartRequired=false for %s reload mode",
+    async (mode) => {
       managementMocks.setEnabled.mockResolvedValue({
         application,
         plugin: { ...workboard, enabled: true, state: "enabled" },
@@ -489,89 +483,54 @@ describe("plugin management Gateway mutation handlers", () => {
         { gateway: { reload: { mode } } },
       );
 
-      expect(result.response).toMatchObject({ ok: true, restartRequired });
+      expect(result.response).toMatchObject({ ok: true, restartRequired: false });
     },
   );
 
-  it("classifies known enablement policy failures as invalid requests", async () => {
-    managementMocks.setEnabled.mockRejectedValue(
-      new ManagedPluginLifecycleError("Plugin is blocked"),
-    );
-
-    const result = await callHandler("plugins.setEnabled", {
-      pluginId: "workboard",
-      enabled: true,
-    });
-
-    expect(result.error).toMatchObject({
+  it.each([
+    {
+      error: new ManagedPluginLifecycleError("Plugin is blocked"),
       code: "INVALID_REQUEST",
-      message: "Plugin is blocked",
-    });
-  });
-
-  it("classifies unexpected enablement persistence failures as unavailable", async () => {
-    managementMocks.setEnabled.mockRejectedValue(new Error("rename EACCES"));
+    },
+    { error: new Error("rename EACCES"), code: "UNAVAILABLE" },
+  ])("classifies enablement failures as $code", async ({ error, code }) => {
+    const message = error.message;
+    managementMocks.setEnabled.mockRejectedValue(error);
 
     const result = await callHandler("plugins.setEnabled", {
       pluginId: "workboard",
       enabled: true,
     });
 
-    expect(result.error).toMatchObject({
-      code: "UNAVAILABLE",
-      message: "rename EACCES",
-    });
+    expect(result.error).toMatchObject({ code, message });
   });
 
-  it("forwards ClawHub risk acknowledgement and the reviewed-surface token", async () => {
-    managementMocks.install.mockResolvedValue({
-      application,
-      plugin: { ...workboard, id: "diffs", name: "Diffs", enabled: true, state: "enabled" },
-    });
-
-    await callHandler("plugins.install", {
+  it.each([
+    {
       source: "clawhub",
       packageName: "@openclaw/diffs",
       version: "1.2.3",
       acknowledgeCapabilities: { reviewToken },
-    });
-
-    expect(managementMocks.install).toHaveBeenCalledWith(
-      expect.objectContaining({
-        request: {
-          source: "clawhub",
-          packageName: "@openclaw/diffs",
-          version: "1.2.3",
-          acknowledgeCapabilities: { reviewToken },
-        },
-      }),
-    );
-  });
-
-  it("forwards install-policy acknowledgement and the exact reviewed-surface token", async () => {
-    managementMocks.install.mockResolvedValue({
-      application,
-      plugin: { ...workboard, id: "diffs", name: "Diffs", enabled: true, state: "enabled" },
-    });
-
-    await callHandler("plugins.install", {
+    },
+    {
       source: "official",
       pluginId: "diffs",
       acknowledgeInstallPolicyWarning: true,
       acknowledgeCapabilities: { reviewToken },
-    });
+    },
+  ])(
+    "forwards $source install acknowledgements and the exact reviewed-surface token",
+    async (request) => {
+      managementMocks.install.mockResolvedValue({
+        application,
+        plugin: { ...workboard, id: "diffs", name: "Diffs", enabled: true, state: "enabled" },
+      });
 
-    expect(managementMocks.install).toHaveBeenCalledWith(
-      expect.objectContaining({
-        request: {
-          source: "official",
-          pluginId: "diffs",
-          acknowledgeInstallPolicyWarning: true,
-          acknowledgeCapabilities: { reviewToken },
-        },
-      }),
-    );
-  });
+      await callHandler("plugins.install", structuredClone(request));
+
+      expect(managementMocks.install).toHaveBeenCalledWith(expect.objectContaining({ request }));
+    },
+  );
 
   it("returns tokenless structured install policy warning details", async () => {
     managementMocks.install.mockRejectedValue(

--- a/src/gateway/server-methods/plugins-mutations.ts
+++ b/src/gateway/server-methods/plugins-mutations.ts
@@ -10,10 +10,7 @@ import type {
   PluginsUninstallResult,
 } from "../../../packages/gateway-protocol/src/schema/plugins.js";
 import { pluginInstallRequiresLocalHost } from "../../plugins/install-source-plan.js";
-import {
-  capturePluginRuntimeApplications,
-  type PluginRuntimeApplication,
-} from "../../plugins/lifecycle.js";
+import type { PluginRuntimeApplication } from "../../plugins/lifecycle.js";
 import { ManagedPluginLifecycleError } from "../../plugins/management-lifecycle-error.js";
 import {
   installManagedPlugin,
@@ -23,6 +20,7 @@ import {
 } from "../../plugins/management-mutations.js";
 import { uninstallManagedPlugin } from "../../plugins/management-uninstall.js";
 import {
+  captureGatewayPluginRuntimeApplications,
   pluginLifecycleError,
   withGatewayPluginLifecycleLease,
 } from "./plugins-lifecycle-error.js";
@@ -51,7 +49,7 @@ function lifecycleHandler<T>(
     if (!assertValidParams(params, validate, method, respond)) {
       return;
     }
-    let captured: ReturnType<typeof capturePluginRuntimeApplications> | undefined;
+    let captured: ReturnType<typeof captureGatewayPluginRuntimeApplications> | undefined;
     try {
       const applyRuntime = context.applyPluginLifecycleChange;
       if (!applyRuntime) {
@@ -61,17 +59,7 @@ function lifecycleHandler<T>(
         signal?.throwIfAborted();
         sessionMutationCommitGuard?.();
       };
-      beforePersistentApply();
-      captured = capturePluginRuntimeApplications((change) => {
-        beforePersistentApply();
-        return applyRuntime({
-          ...change,
-          assertInvokerOwned: () => {
-            beforePersistentApply();
-            change.assertInvokerOwned?.();
-          },
-        });
-      });
+      captured = captureGatewayPluginRuntimeApplications(applyRuntime, beforePersistentApply);
       const lifecycle: PluginLifecycleOptions = {
         applyRuntime: captured.applyRuntime,
         beforePersistentApply,

--- a/src/gateway/server-methods/plugins.lifecycle-contention.test.ts
+++ b/src/gateway/server-methods/plugins.lifecycle-contention.test.ts
@@ -83,7 +83,6 @@ it.each(["direct", "nested"] as const)(
       const held = createDeferred();
       const beginDrain = createDeferred();
       let current = true;
-      let reloadFinished = false;
       const logReload = { warn: vi.fn(), info: vi.fn() };
       const tracker = createGatewayActiveWorkTracker({
         params: { logReload },
@@ -94,7 +93,6 @@ it.each(["direct", "nested"] as const)(
           held.resolve();
           await beginDrain.promise;
           await tracker.waitForActiveWorkBeforeChannelReload(["discord"], () => current, true);
-          reloadFinished = true;
         }, "reload:config"),
       );
       await held.promise;
@@ -118,7 +116,6 @@ it.each(["direct", "nested"] as const)(
           recordsBefore,
         );
         await reload;
-        expect(reloadFinished).toBe(true);
         expect(logReload.warn).toHaveBeenCalledExactlyOnceWith(
           expect.stringContaining("deferring until 1 gateway request(s) complete"),
         );

--- a/src/gateway/server-plugin-reload.activation.test-support.ts
+++ b/src/gateway/server-plugin-reload.activation.test-support.ts
@@ -6,8 +6,10 @@ import { registerPluginHttpRoute } from "../plugins/http-registry.js";
 import { getPluginInstance } from "../plugins/plugin-instance-scope.js";
 import { createDeferredCore } from "../shared/deferred.js";
 import { createChannelTestPluginBase } from "../test-utils/channel-plugins.js";
-import { createChannelManager } from "./server-channels.js";
-import type { RecoveryFixtureFactory } from "./server-plugin-reload.recovery.test-support.js";
+import {
+  createRecoveryChannelManager,
+  type RecoveryFixtureFactory,
+} from "./server-plugin-reload.recovery.test-support.js";
 
 export async function verifyPreparedSidecarRecovery(
   createFixture: RecoveryFixtureFactory,
@@ -66,12 +68,7 @@ export async function verifyPreparedSidecarRecovery(
       },
     },
   ];
-  const manager = createChannelManager({
-    getRuntimeConfig: fixture.getConfig,
-    getPluginRegistry: () => fixture.registryOwner.registry,
-    channelLogs: {},
-    channelRuntimeEnvs: {},
-  });
+  const manager = createRecoveryChannelManager(fixture);
   fixture.runtime.channelManager = manager;
   let stopping: Promise<void> | undefined;
   try {
@@ -283,12 +280,7 @@ export async function verifyIndependentPostCommitActivation(
       throw failure;
     };
   }
-  const manager = createChannelManager({
-    getRuntimeConfig: fixture.getConfig,
-    getPluginRegistry: () => fixture.registryOwner.registry,
-    channelLogs: {},
-    channelRuntimeEnvs: {},
-  });
+  const manager = createRecoveryChannelManager(fixture);
   fixture.runtime.channelManager = manager;
   const channelIds = ["first-channel", "healthy-channel", "removed-channel"];
   try {
@@ -385,12 +377,7 @@ export async function verifyLifecycleHookSettlement(
       });
     },
   });
-  const manager = createChannelManager({
-    getRuntimeConfig: fixture.getConfig,
-    getPluginRegistry: () => fixture.registryOwner.registry,
-    channelLogs: {},
-    channelRuntimeEnvs: {},
-  });
+  const manager = createRecoveryChannelManager(fixture);
   fixture.runtime.channelManager = manager;
   await manager.startChannel("hook-dependent");
   const reloading = fixture.reload().catch((error: unknown) => error);
@@ -484,12 +471,7 @@ export async function verifyIndependentRollbackRestoration(
       },
     }),
   }));
-  const manager = createChannelManager({
-    getRuntimeConfig: fixture.getConfig,
-    getPluginRegistry: () => fixture.registryOwner.registry,
-    channelLogs: {},
-    channelRuntimeEnvs: {},
-  });
+  const manager = createRecoveryChannelManager(fixture);
   fixture.runtime.channelManager = manager;
   try {
     await manager.startChannel("first-restore");

--- a/src/gateway/server-plugin-reload.managed-candidate.test-support.ts
+++ b/src/gateway/server-plugin-reload.managed-candidate.test-support.ts
@@ -9,8 +9,10 @@ import {
 import { startPluginServices } from "../plugins/services.js";
 import { createDeferredCore } from "../shared/deferred.js";
 import { createChannelTestPluginBase } from "../test-utils/channel-plugins.js";
-import { createChannelManager } from "./server-channels.js";
-import type { RecoveryFixtureFactory } from "./server-plugin-reload.recovery.test-support.js";
+import {
+  createRecoveryChannelManager,
+  type RecoveryFixtureFactory,
+} from "./server-plugin-reload.recovery.test-support.js";
 import { GatewayConfigReloadSupersededError } from "./server-reload-contracts.js";
 
 export async function verifyManagedCandidateRetirement(
@@ -288,12 +290,7 @@ export async function verifyGatewayCleanupRetry(
       }
     },
   });
-  const manager = createChannelManager({
-    getRuntimeConfig: fixture.getConfig,
-    channelLogs: {},
-    channelRuntimeEnvs: {},
-    getPluginRegistry: () => fixture.registryOwner.registry,
-  });
+  const manager = createRecoveryChannelManager(fixture);
   if (withChannels) {
     fixture.runtime.channelManager = manager;
     await manager.startChannel(channelIds.first);

--- a/src/gateway/server-plugin-reload.recovery.test-support.ts
+++ b/src/gateway/server-plugin-reload.recovery.test-support.ts
@@ -306,6 +306,15 @@ export type RecoveryFixtureFactory = (
   options?: Parameters<typeof createPluginReloadRecoveryFixture>[1],
 ) => ReturnType<typeof createPluginReloadRecoveryFixture>;
 
+export function createRecoveryChannelManager(fixture: Awaited<ReturnType<RecoveryFixtureFactory>>) {
+  return createChannelManager({
+    getRuntimeConfig: fixture.getConfig,
+    getPluginRegistry: () => fixture.registryOwner.registry,
+    channelLogs: {},
+    channelRuntimeEnvs: {},
+  });
+}
+
 export async function verifyMalformedReloadFailureReceipt(
   createRecoveryFixture: RecoveryFixtureFactory,
   boundary: "prepare" | "committed",
@@ -420,12 +429,7 @@ export async function verifyChannelReplacementContracts(
       });
     },
   });
-  const manager = createChannelManager({
-    getRuntimeConfig: fixture.getConfig,
-    getPluginRegistry: () => fixture.registryOwner.registry,
-    channelLogs: {},
-    channelRuntimeEnvs: {},
-  });
+  const manager = createRecoveryChannelManager(fixture);
   fixture.runtime.channelManager = manager;
   try {
     await manager.startChannel(channelId);
@@ -484,12 +488,7 @@ export async function verifyColdAccountReplacement(createRecoveryFixture: Recove
       });
     },
   });
-  const manager = createChannelManager({
-    getRuntimeConfig: fixture.getConfig,
-    getPluginRegistry: () => fixture.registryOwner.registry,
-    channelLogs: {},
-    channelRuntimeEnvs: {},
-  });
+  const manager = createRecoveryChannelManager(fixture);
   fixture.runtime.channelManager = manager;
   setActiveDegradedSecretOwners([
     {
@@ -564,12 +563,7 @@ export async function verifyChannelCleanupFailureFence(
       });
     },
   });
-  const manager = createChannelManager({
-    getRuntimeConfig: fixture.getConfig,
-    getPluginRegistry: () => fixture.registryOwner.registry,
-    channelLogs: {},
-    channelRuntimeEnvs: {},
-  });
+  const manager = createRecoveryChannelManager(fixture);
   fixture.runtime.channelManager = manager;
   await manager.startChannel("cleanup-first");
   await manager.startChannel("cleanup-sibling");

--- a/src/gateway/server-plugin-reload.recovery.test.ts
+++ b/src/gateway/server-plugin-reload.recovery.test.ts
@@ -46,6 +46,7 @@ import {
 } from "./server-plugin-reload.managed-candidate.test-support.js";
 import { verifyGatewayMemoryReplacement } from "./server-plugin-reload.memory.test-support.js";
 import {
+  createRecoveryChannelManager,
   createPluginReloadRecoveryFixture,
   verifyChannelReplacementContracts,
   verifyColdAccountReplacement,
@@ -252,12 +253,7 @@ it.each(["OPENCLAW_SKIP_CHANNELS", "OPENCLAW_SKIP_PROVIDERS"])(
         }
       },
     });
-    const manager = createChannelManager({
-      getRuntimeConfig: fixture.getConfig,
-      channelLogs: {},
-      channelRuntimeEnvs: {},
-      getPluginRegistry: () => fixture.registryOwner.registry,
-    });
+    const manager = createRecoveryChannelManager(fixture);
     fixture.runtime.channelManager = manager;
     cleanups.push(() => manager.stopChannel(channelId));
     await expect(fixture.reload()).rejects.toMatchObject({ details: { committed: false } });

--- a/src/gateway/server-plugin-reload.suspension.test-support.ts
+++ b/src/gateway/server-plugin-reload.suspension.test-support.ts
@@ -17,8 +17,10 @@ import {
 } from "../process/gateway-work-admission.js";
 import { createDeferredCore } from "../shared/deferred.js";
 import { createChannelTestPluginBase } from "../test-utils/channel-plugins.js";
-import { createChannelManager } from "./server-channels.js";
-import type { RecoveryFixtureFactory } from "./server-plugin-reload.recovery.test-support.js";
+import {
+  createRecoveryChannelManager,
+  type RecoveryFixtureFactory,
+} from "./server-plugin-reload.recovery.test-support.js";
 
 export async function verifyReversibleFenceRecovery(
   createRecoveryFixture: RecoveryFixtureFactory,
@@ -57,12 +59,7 @@ export async function verifyReversibleFenceRecovery(
       });
     },
   });
-  const manager = createChannelManager({
-    getRuntimeConfig: fixture.getConfig,
-    getPluginRegistry: () => fixture.registryOwner.registry,
-    channelLogs: {},
-    channelRuntimeEnvs: {},
-  });
+  const manager = createRecoveryChannelManager(fixture);
   fixture.runtime.channelManager = manager;
   const instance = getPluginInstance(fixture.previousRegistry.plugins[0]!);
   assert(instance);

--- a/src/gateway/server-plugin-reload.ts
+++ b/src/gateway/server-plugin-reload.ts
@@ -164,29 +164,14 @@ export async function reloadGatewayPlugins(
   const skipChannels =
     isTruthyEnvValue(params.env?.OPENCLAW_SKIP_CHANNELS) ||
     isTruthyEnvValue(params.env?.OPENCLAW_SKIP_PROVIDERS);
-  const stopReplacedChannels = async () => {
-    for (const { plugin } of previousRegistry.channels) {
-      if (!channelTargets.has(plugin.id)) {
-        continue;
-      }
-      await cleanup(`Plugin channel ${plugin.id} cleanup failed`, () =>
-        channelManager.stopChannel(plugin.id, undefined, {
-          manual: false,
-          strict: true,
-          routeHandoff: true,
-        }),
-      );
-    }
-  };
-  const stopReplacedServices = async (services: PluginServicesHandle | null | undefined) => {
-    await cleanup("Plugin service cleanup failed", async () => {
+  const stopReplacedServices = (services: PluginServicesHandle | null | undefined) =>
+    cleanup("Plugin service cleanup failed", async () => {
       await services?.stop({
         strict: true,
         deadlineAtMs: Date.now() + PLUGIN_SERVICE_REPLACEMENT_STOP_TIMEOUT_MS,
         pluginIds: changedPluginIds,
       });
     });
-  };
   const startReplacedChannels = async (registry: typeof previousRegistry, errors: unknown[]) => {
     for (const { plugin } of registry.channels) {
       if (skipChannels || !channelTargets.has(plugin.id)) {
@@ -409,7 +394,18 @@ export async function reloadGatewayPlugins(
     await cleanup("Plugin stop hook failed", () =>
       runLifecycleHooks(previousRegistry, false, previousConfig),
     );
-    await stopReplacedChannels();
+    for (const { plugin } of previousRegistry.channels) {
+      if (!channelTargets.has(plugin.id)) {
+        continue;
+      }
+      await cleanup(`Plugin channel ${plugin.id} cleanup failed`, () =>
+        channelManager.stopChannel(plugin.id, undefined, {
+          manual: false,
+          strict: true,
+          routeHandoff: true,
+        }),
+      );
+    }
     await stopReplacedServices(previousServices);
     for (const record of previousRegistry.plugins) {
       if (changedPluginIds.has(record.id)) {

--- a/src/gateway/server-startup-post-attach.test.ts
+++ b/src/gateway/server-startup-post-attach.test.ts
@@ -12,7 +12,7 @@ import {
 import { createDeferred } from "../../test/helpers/promise.js";
 import * as configPaths from "../config/paths.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { writeRestartSentinel } from "../infra/restart-sentinel.js";
+import { hasRestartSentinel, writeRestartSentinel } from "../infra/restart-sentinel.js";
 import type { PluginHookGatewayContext, PluginHookHandlerMap } from "../plugins/hook-types.js";
 import { createHookRunner } from "../plugins/hooks.js";
 import { createMockPluginRegistry } from "../plugins/hooks.test-fixtures.js";
@@ -1493,9 +1493,9 @@ describe("startGatewayPostAttachRuntime", () => {
       );
 
       expect(
-        await testing.hasRestartSentinelFast({
+        await hasRestartSentinel({
           OPENCLAW_STATE_DIR: stateDir,
-        } as NodeJS.ProcessEnv),
+        }),
       ).toBe(true);
     } finally {
       closeOpenClawStateDatabaseForTest();
@@ -1523,9 +1523,9 @@ describe("startGatewayPostAttachRuntime", () => {
       });
       try {
         await expect(
-          testing.hasRestartSentinelFast({
+          hasRestartSentinel({
             OPENCLAW_STATE_DIR: stateDir,
-          } as NodeJS.ProcessEnv),
+          }),
         ).resolves.toBe(true);
         expect(
           existsSync.mock.calls.filter((call) => String(call[0]).startsWith(stateDir)),

--- a/src/gateway/server-startup-post-attach.ts
+++ b/src/gateway/server-startup-post-attach.ts
@@ -304,14 +304,10 @@ function scheduleTranscriptsAutoStartSidecar(params: {
   };
 }
 
-async function hasRestartSentinelFast(env: NodeJS.ProcessEnv = process.env): Promise<boolean> {
-  return await hasRestartSentinel(env);
-}
-
 async function refreshLatestUpdateRestartSentinelIfPresent(): Promise<Awaited<
   ReturnType<typeof refreshLatestUpdateRestartSentinel>
 > | null> {
-  if (!(await hasRestartSentinelFast())) {
+  if (!(await hasRestartSentinel())) {
     return null;
   }
   return await (await loadGatewayRestartSentinelModule()).refreshLatestUpdateRestartSentinel();
@@ -662,12 +658,10 @@ export async function startGatewaySidecars(params: {
   const shouldStartPluginServices =
     params.pluginRuntimeClaim?.isCurrent() !== false &&
     params.shouldStartPluginServices?.() !== false;
-  let pluginServicesStopRequested = false;
-  let pluginServicesOwner: PluginServicesHandle | undefined;
-  let resolvePluginServicesOwner: ((handle: PluginServicesHandle | null) => void) | undefined;
   if (shouldStartPluginServices) {
+    let pluginServicesStopRequested = false;
     const ownedPluginServices = createDeferredCore<PluginServicesHandle | null>();
-    pluginServicesOwner = {
+    const pluginServicesOwner: PluginServicesHandle = {
       reload: async (config, serviceIds) => {
         const handle = await ownedPluginServices.promise;
         if (pluginServicesStopRequested || !handle) {
@@ -678,8 +672,7 @@ export async function startGatewaySidecars(params: {
       stop: (options) => {
         pluginServicesStopRequested = true;
         // Pending startup owns no services and may be waiting on this replacement.
-        resolvePluginServicesOwner?.(null);
-        resolvePluginServicesOwner = undefined;
+        ownedPluginServices.resolve(null);
         // Share the service owner, never a caller's expired replacement deadline.
         const stopPromise = ownedPluginServices.promise.then((handle) => handle?.stop(options));
         const deadlineAtMs = options?.strict ? options.deadlineAtMs : undefined;
@@ -711,12 +704,9 @@ export async function startGatewaySidecars(params: {
         });
       },
     };
-    resolvePluginServicesOwner = ownedPluginServices.resolve;
     // Startup may outlive a replacement deadline. Final shutdown retains this
     // owner without making startup rejoin its pending service cleanup.
     params.onPluginServices?.(pluginServicesOwner);
-  }
-  if (shouldStartPluginServices) {
     await measureStartup(params.startupTrace, "sidecars.plugin-services", async () => {
       try {
         const { startPluginServices } = await import("../plugins/services.js");
@@ -726,8 +716,7 @@ export async function startGatewaySidecars(params: {
           params.pluginRuntimeClaim?.isCurrent() === false ||
           params.shouldStartPluginServices?.(pluginServicesOwner) === false
         ) {
-          resolvePluginServicesOwner?.(null);
-          resolvePluginServicesOwner = undefined;
+          ownedPluginServices.resolve(null);
           return;
         }
         await startPluginServices({
@@ -738,8 +727,7 @@ export async function startGatewaySidecars(params: {
           broadcastPluginEvent: params.broadcastPluginEvent,
           getCronService: params.getCronService,
           onHandle: (handle) => {
-            resolvePluginServicesOwner?.(handle);
-            resolvePluginServicesOwner = undefined;
+            ownedPluginServices.resolve(handle);
             // Transfer the pending owner to the real service handle before startup yields.
             // A replacement or same-claim recovery must keep its own published handle.
             if (
@@ -751,8 +739,7 @@ export async function startGatewaySidecars(params: {
           },
         });
       } catch (err) {
-        resolvePluginServicesOwner?.(null);
-        resolvePluginServicesOwner = undefined;
+        ownedPluginServices.resolve(null);
         params.log.warn(`plugin services failed to start: ${String(err)}`);
       }
     });
@@ -844,7 +831,7 @@ export async function startGatewaySidecars(params: {
         if (!shouldCheckRestartSentinel() || isStopped()) {
           return;
         }
-        if (!(await hasRestartSentinelFast()) || isStopped()) {
+        if (!(await hasRestartSentinel()) || isStopped()) {
           return;
         }
         restartSentinelWake = scheduleRestartSentinelWakeAfterReady({
@@ -1677,7 +1664,6 @@ export async function startGatewayPostAttachRuntime(
 }
 
 export const testing = {
-  hasRestartSentinelFast,
   prewarmConfiguredPrimaryModel,
   hydrateConfiguredExternalCliAuth,
   publishConfiguredModelRuntimeSnapshots,

--- a/src/plugins/native-module-require.ts
+++ b/src/plugins/native-module-require.ts
@@ -29,18 +29,6 @@ type ResolveFilename = (
 ) => string;
 const moduleWithResolver = Module as typeof Module & {
   _resolveFilename?: ResolveFilename;
-  registerHooks?: (options: {
-    resolve?: (
-      specifier: string,
-      context: { parentURL?: string | undefined },
-      nextResolve: (
-        specifier: string,
-        context?: { parentURL?: string | undefined },
-      ) => {
-        url: string;
-      },
-    ) => { shortCircuit?: boolean; url: string };
-  }) => { deregister: () => void };
 };
 
 let nativeAliasHookSupport: boolean | undefined;
@@ -70,13 +58,8 @@ export function supportsNativeModuleAliasHooks(): boolean {
   return (nativeAliasHookSupport = retainsParent);
 }
 
-type CapturedModuleResolver = (
-  request: string,
-  parent: string,
-  resolve: () => string,
-) => string | undefined;
 type CapturedModuleBinding = {
-  resolve: CapturedModuleResolver;
+  resolve: (request: string, parent: string, resolve: () => string) => string | undefined;
   prepare: (request: string, parent: string) => string | undefined;
 };
 export type BunPluginRuntime = {
@@ -103,6 +86,26 @@ const capturedModuleResolvers = resolveGlobalSingleton(
   }),
 );
 
+function resolveCapturedPluginModule(
+  resolve: (owner: CapturedModuleBinding) => string | undefined,
+): string | undefined {
+  if (capturedModuleResolvers.resolving) {
+    return undefined;
+  }
+  capturedModuleResolvers.resolving = true;
+  try {
+    for (const owner of capturedModuleResolvers.owners) {
+      const target = resolve(owner);
+      if (target) {
+        return target;
+      }
+    }
+  } finally {
+    capturedModuleResolvers.resolving = false;
+  }
+  return undefined;
+}
+
 /** Captured parents retain their resolver while their instance's consumers drain. */
 export function registerCapturedPluginModuleResolver(binding: CapturedModuleBinding): () => void {
   if (!capturedModuleResolvers.installed) {
@@ -112,21 +115,9 @@ export function registerCapturedPluginModuleResolver(binding: CapturedModuleBind
       name: "openclaw-plugin-source-capture",
       setup(builder) {
         builder.onResolve({ filter: /.*/, namespace: "file" }, ({ path: request, importer }) => {
-          if (!capturedModuleResolvers.resolving) {
-            capturedModuleResolvers.resolving = true;
-            try {
-              for (const owner of capturedModuleResolvers.owners) {
-                const target = owner.prepare(request, importer);
-                if (target) {
-                  return { path: target, namespace: "file" };
-                }
-              }
-            } finally {
-              capturedModuleResolvers.resolving = false;
-            }
-          }
+          const target = resolveCapturedPluginModule((owner) => owner.prepare(request, importer));
           // Package selection stays native; owners redirect only captured physical source paths.
-          return undefined;
+          return target ? { path: target, namespace: "file" } : undefined;
         });
       },
     });
@@ -135,23 +126,13 @@ export function registerCapturedPluginModuleResolver(binding: CapturedModuleBind
     if (!bun) {
       const previous = moduleWithResolver["_resolveFilename"]!;
       moduleWithResolver["_resolveFilename"] = (request, parent, isMain, options) => {
-        if (!capturedModuleResolvers.resolving && parent?.filename) {
-          capturedModuleResolvers.resolving = true;
-          try {
-            for (const owner of capturedModuleResolvers.owners) {
-              const target = owner.resolve(request, parent.filename, () =>
-                previous(request, parent, isMain, options),
-              );
-              if (target) {
-                return target;
-              }
-            }
-          } finally {
-            // Original-source Jiti lookup can itself call the native resolver.
-            capturedModuleResolvers.resolving = false;
-          }
-        }
-        return previous(request, parent, isMain, options);
+        const filename = parent?.filename;
+        const target = filename
+          ? resolveCapturedPluginModule((owner) =>
+              owner.resolve(request, filename, () => previous(request, parent, isMain, options)),
+            )
+          : undefined;
+        return target ?? previous(request, parent, isMain, options);
       };
     }
     capturedModuleResolvers.installed = true;

--- a/src/plugins/plugin-sdk-native-resolver.ts
+++ b/src/plugins/plugin-sdk-native-resolver.ts
@@ -25,18 +25,6 @@ type ResolveFilename = (
 
 type ModuleWithResolver = typeof Module & {
   _resolveFilename?: ResolveFilename;
-  registerHooks?: (options: {
-    resolve?: (
-      specifier: string,
-      context: { parentURL?: string | undefined; conditions: readonly string[] },
-      nextResolve: (
-        specifier: string,
-        context?: { parentURL?: string | undefined },
-      ) => {
-        url: string;
-      },
-    ) => { shortCircuit?: boolean; url: string };
-  }) => { deregister: () => void };
 };
 
 /** Resolver install options for CJS `_resolveFilename` and modern ESM loader hooks. */
@@ -254,13 +242,6 @@ function isWithinRoot(candidate: string, root: string): boolean {
   return isPathInside(root, normalizePathForBoundary(candidate));
 }
 
-function resolveAliasTargetForParent(
-  request: string,
-  parent: NodeJS.Module | undefined,
-): string | undefined {
-  return resolveAliasTargetForParentPath(request, parent?.filename);
-}
-
 function resolveAliasTargetForParentUrl(
   request: string,
   parentUrl: string | undefined,
@@ -305,10 +286,7 @@ function resolveAliasTargetForParentPath(
   return entries.find((entry) => isWithinRoot(parentFilename, entry.parentRoot))?.target;
 }
 
-function listInternalCorePackageNativeAliases(
-  options: InstallOpenClawPluginSdkNativeResolverOptions,
-  packageRoot = resolveInternalCorePackageHostRoot(resolveLoaderModulePath(options)),
-): Array<{
+function listInternalCorePackageNativeAliases(packageRoot: string): Array<{
   request: string;
   target: string;
   parentRoots: string[];
@@ -378,7 +356,7 @@ function installResolver(): void {
     return;
   }
   moduleWithResolver[nodeResolveFilenameProperty] = ((request, parent, isMain, options) =>
-    resolveAliasTargetForParent(request, parent) ??
+    resolveAliasTargetForParentPath(request, parent?.filename) ??
     previousResolveFilename(request, parent, isMain, options)) satisfies ResolveFilename;
   moduleWithResolver.registerHooks?.({
     resolve(specifier, context, nextResolve) {
@@ -457,7 +435,7 @@ function registerInternalCorePackageNativeAliases(
   if (registeredInternalCorePackageHosts.has(packageRoot)) {
     return;
   }
-  for (const alias of listInternalCorePackageNativeAliases(options, packageRoot)) {
+  for (const alias of listInternalCorePackageNativeAliases(packageRoot)) {
     registerNativeAlias(alias);
   }
   registeredInternalCorePackageHosts.add(packageRoot);

--- a/src/plugins/services.reload.test.ts
+++ b/src/plugins/services.reload.test.ts
@@ -100,13 +100,7 @@ describe("plugin service reload", () => {
       entered.resolve();
       return release.promise;
     });
-    const registry = createEmptyPluginRegistry();
-    registry.services.push({
-      pluginId: "exporter",
-      origin: "workspace",
-      source: "test",
-      service: { id: "exporter", start, stop },
-    });
+    const registry = createRegistry([{ id: "exporter", start, stop }], "exporter");
     const handle = await startPluginServices({
       registry,
       config: configFor("https://first.example"),
@@ -245,19 +239,18 @@ describe("plugin service reload", () => {
   it("applies each queued service reload to the current service instance", async () => {
     const configs: OpenClawConfig[] = [];
     const stop = vi.fn();
-    const registry = createEmptyPluginRegistry();
-    registry.services.push({
-      pluginId: "exporter",
-      source: "test",
-      origin: "workspace",
-      service: {
-        id: "exporter",
-        start: (ctx) => {
-          configs.push(ctx.config);
+    const registry = createRegistry(
+      [
+        {
+          id: "exporter",
+          start: (ctx) => {
+            configs.push(ctx.config);
+          },
+          stop,
         },
-        stop,
-      },
-    });
+      ],
+      "exporter",
+    );
     const initial = configFor("https://initial.example");
     const first = configFor("https://first.example");
     const second = configFor("https://second.example");
@@ -276,13 +269,7 @@ describe("plugin service reload", () => {
     const stop = vi.fn(() => {
       throw new Error("cleanup refused");
     });
-    const registry = createEmptyPluginRegistry();
-    registry.services.push({
-      pluginId: "exporter",
-      origin: "workspace",
-      source: "test",
-      service: { id: "exporter", start, stop },
-    });
+    const registry = createRegistry([{ id: "exporter", start, stop }], "exporter");
     const handle = await startPluginServices({ registry, config: {} });
     handles.add(handle);
     await expect(handle.reload({}, new Set(["exporter"]))).rejects.toThrow();
@@ -305,13 +292,9 @@ describe("plugin service reload", () => {
         process.off(event, listener);
       });
       const queuedStart = vi.fn();
-      const registry = createEmptyPluginRegistry();
-      registry.services.push(
-        {
-          pluginId: "candidate",
-          origin: "workspace",
-          source: "test",
-          service: {
+      const registry = createRegistry(
+        [
+          {
             id: "held",
             start: async (context) => {
               contexts.push(context);
@@ -326,13 +309,9 @@ describe("plugin service reload", () => {
             },
             stop,
           },
-        },
-        {
-          pluginId: "candidate",
-          origin: "workspace",
-          source: "test",
-          service: { id: "queued", start: queuedStart },
-        },
+          { id: "queued", start: queuedStart },
+        ],
+        "candidate",
       );
       const startupTrace = createGatewayStartupTrace(createSubsystemLogger("test/service-startup"));
       const broadcastPluginEvent = vi.fn();
@@ -504,16 +483,7 @@ describe("plugin service reload", () => {
         }),
       };
       const sibling = { id: "sibling", start: vi.fn(), stop: vi.fn() };
-      const registry = createEmptyPluginRegistry();
-      for (const entry of [service, sibling]) {
-        registry.services.push({
-          pluginId: "plugin:test",
-          service: entry,
-          source: "test",
-          origin: "workspace",
-          rootDir: "/plugins/test-plugin",
-        });
-      }
+      const registry = createRegistry([service, sibling]);
       const initialConfig: OpenClawConfig = {};
       const reloadConfig: OpenClawConfig = {};
       const successorConfig: OpenClawConfig = {};

--- a/src/plugins/services.replacement.test.ts
+++ b/src/plugins/services.replacement.test.ts
@@ -558,10 +558,7 @@ describe("plugin service replacement", () => {
 
   it("bounds strict cleanup and fences timed-out service routes, events, and health", async () => {
     vi.useFakeTimers();
-    let releaseCleanup: (() => void) | undefined;
-    const cleanupReleased = new Promise<void>((resolve) => {
-      releaseCleanup = resolve;
-    });
+    const cleanupDeferred = createDeferredCore();
     const received = vi.fn();
     const siblingStop = vi.fn();
     const broadcastPluginEvent = vi.fn();
@@ -578,7 +575,7 @@ describe("plugin service replacement", () => {
           registerPluginHttpRoute({ path: "/owned-route", auth: "plugin", handler: vi.fn() });
         },
         stop: async (ctx) => {
-          await cleanupReleased;
+          await cleanupDeferred.promise;
           ctx.serviceHealth?.reportFailure(new Error("late stale failure"));
           for (const run of [
             () => ctx.gatewayEvents?.emit("late", {}, { scope: "operator.read" }),
@@ -654,7 +651,7 @@ describe("plugin service replacement", () => {
         }),
       ]);
 
-      releaseCleanup?.();
+      cleanupDeferred.resolve();
       await Promise.resolve();
       await Promise.resolve();
       queuePluginSessionsChanged({ sessionKey: "agent:main:main" });
@@ -667,7 +664,7 @@ describe("plugin service replacement", () => {
       expect(registry.httpRoutes).toEqual([]);
       expect(nestedRegistry.httpRoutes).toEqual([]);
     } finally {
-      releaseCleanup?.();
+      cleanupDeferred.resolve();
       await stopping;
       vi.useRealTimers();
     }
@@ -738,10 +735,7 @@ describe("plugin service replacement", () => {
   it("honors a replacement deadline inherited after ownership consumed most of its budget", async () => {
     vi.useFakeTimers();
     const broadcastPluginEvent = vi.fn();
-    let releaseCleanup: (() => void) | undefined;
-    const cleanupReleased = new Promise<void>((resolve) => {
-      releaseCleanup = resolve;
-    });
+    const cleanup = createDeferredCore();
     let context: OpenClawPluginServiceContext | undefined;
     const registry = createRegistry([
       {
@@ -751,7 +745,7 @@ describe("plugin service replacement", () => {
           registerPluginHttpRoute({ path: "/deadline-route", auth: "plugin", handler: vi.fn() });
         },
         stop: async (serviceContext) => {
-          await cleanupReleased;
+          await cleanup.promise;
           serviceContext.gatewayEvents?.emit("late", {}, { scope: "operator.read" });
         },
       },
@@ -782,7 +776,7 @@ describe("plugin service replacement", () => {
       );
       expect(broadcastPluginEvent).not.toHaveBeenCalled();
     } finally {
-      releaseCleanup?.();
+      cleanup.resolve();
       await stopping;
       vi.useRealTimers();
     }
@@ -790,10 +784,7 @@ describe("plugin service replacement", () => {
 
   it("bounds strict shutdown while startup is unsettled and revokes its late continuation", async () => {
     vi.useFakeTimers();
-    let releaseStartup: (() => void) | undefined;
-    const startupReleased = new Promise<void>((resolve) => {
-      releaseStartup = resolve;
-    });
+    const startup = createDeferredCore();
     const broadcastPluginEvent = vi.fn();
     const lateFailures: unknown[] = [];
     let lifecycleHandle: PluginServicesHandle | undefined;
@@ -801,7 +792,7 @@ describe("plugin service replacement", () => {
       {
         id: "blocked-startup",
         start: async (ctx) => {
-          await startupReleased;
+          await startup.promise;
           ctx.serviceHealth?.reportFailure(new Error("late startup failure"));
           for (const run of [
             () => ctx.gatewayEvents?.emit("late", {}, { scope: "operator.read" }),
@@ -846,7 +837,7 @@ describe("plugin service replacement", () => {
         message: expect.stringContaining("plugin service startup settlement timed out"),
       });
 
-      releaseStartup?.();
+      startup.resolve();
       await starting;
       await stopping;
       expect(lateFailures).toHaveLength(2);
@@ -854,7 +845,7 @@ describe("plugin service replacement", () => {
       expect(listPluginServiceHealthFailures(registry)).toEqual([]);
       expect(registry.httpRoutes).toEqual([]);
     } finally {
-      releaseStartup?.();
+      startup.resolve();
       await starting;
       await stopping;
       vi.useRealTimers();

--- a/src/plugins/services.test-support.ts
+++ b/src/plugins/services.test-support.ts
@@ -1,6 +1,6 @@
+import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { PluginOrigin } from "./plugin-origin.types.js";
 import { createEmptyPluginRegistry } from "./registry.js";
-import type { startPluginServices } from "./services.js";
 import type { OpenClawPluginService } from "./types.js";
 
 export function createRegistry(
@@ -15,9 +15,8 @@ export function createRegistry(
     source: "test",
     origin,
     rootDir: "/plugins/test-plugin",
-  })) as typeof registry.services;
+  }));
   return registry;
 }
 
-export const createServiceConfig = () =>
-  ({}) as Parameters<typeof startPluginServices>[0]["config"];
+export const createServiceConfig = (): OpenClawConfig => ({});

--- a/src/plugins/services.ts
+++ b/src/plugins/services.ts
@@ -262,9 +262,6 @@ export async function startPluginServices(
     failures: unknown[],
     deadline?: number,
   ) => {
-    for (const entry of reversed) {
-      entry.stopRequested = true;
-    }
     const oneShotTimeouts = deadline === undefined ? params.oneShotStopTimeouts : undefined;
     // One-shot registries are already scoped; every cleanup follows the drain, without changing grants.
     const afterDrain = oneShotTimeouts
@@ -322,6 +319,7 @@ export async function startPluginServices(
         }
         for (const entry of selected) {
           entry.reloading = reloading;
+          entry.stopRequested = true;
         }
         const failures: unknown[] = [];
         try {


### PR DESCRIPTION
Related: #145484, #145816

## What Problem This Solves

Plugin reload and recovery accumulated duplicated lifecycle dispatch, resolver handling, and regression fixtures. This cleanup makes the existing ownership rules easier to follow while retaining the recovery fixes from #145816.

## Why This Change Was Made

Use the existing timeout and deferred owners, share the captured-module resolver loop and Gateway runtime-application guard composition, and remove one-use adapters and duplicated traversal. Consolidate repeated CLI TTY, channel, and service fixtures while preserving behavioral assertions.

The diff removes 298 lines overall: 107 production lines and 191 test/support lines. It retains the older-Node diagnostic fallback and both Bun resolver paths because they serve real runtime contracts.

## User Impact

No intended behavior change. Plugin replacement, cancellation, shutdown deadlines, cleanup ownership, warnings, and runtime receipts retain their existing semantics. No configuration, schema, dependency, or public SDK changes.

## Evidence

- The focused baseline and final runs preserve all 1,118 tests across CLI, scheduler/spawn, Gateway admission/reload, module resolution, and plugin services.
- Actual Bun 1.4.0 and 1.4.2 resolver fixtures verify aliases, identity, deferred dependencies, and captured generations.
- Independent full-diff review through P2 found no actionable issues.
- Full `pnpm build` passed, including native loading of 52 built plugin control-plane modules and Doctor import checks. Build metadata matches commit `93eb12ecbf473b31f3f4da7479cf7606ca021950`.
- Five isolated live Gateway cells passed on Node 26.5.0 and actual Bun 1.4.2/1.4.0: source/helper reload, rejected replacement retaining the working generation, successful retry, disabled plugins, read-only refresh, late-start cleanup, watcher contention, and pending old-stop rollback/retry. Contention returned in 20 ms; the pending-stop timeout retained its original owner and the next replacement succeeded. All five Gateway processes exited and all seven ports were rebound successfully.

- Complete `check:changed` passed locally with all selected checks enabled. The initial standalone Testbox attempt ended with exit 255 during test-type checks without a diagnostic; it is not counted as passing.
- [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34700875546) passed on `93eb12ecbf473b31f3f4da7479cf7606ca021950`. ClawSweeper also found no actionable defect on this head.

- Post-merge verification on main `6a6f500613c93c2fe26e13708c34f9ca63a186a3`: all 26 changed files match the reviewed candidate, and 119 focused scheduler, mutation, native-loader, and service tests passed.

The live cells use synthetic plugins and isolated state. Pre-readiness ownership, internal shutdown-hook deadlines, SDK alias boundaries, and swarm membership remain covered by focused owner tests; external provider inference is outside this cleanup's scope.
