### PR TITLE
fix(plugins): release retired service generations after hot reload

### DIFF
--- a/src/plugins/services.retention.test-support.ts
+++ b/src/plugins/services.retention.test-support.ts
@@ -1,0 +1,108 @@
+import assert from "node:assert/strict";
+import { setImmediate } from "node:timers/promises";
+import { createEmptyPluginRegistry } from "./registry-empty.js";
+import { startPluginServices, type PluginServicesHandle } from "./services.js";
+
+const gc = globalThis.gc;
+assert.ok(gc, "The retention child requires --expose-gc");
+const scenario = process.argv[2];
+const counts = { starts: 0, stops: 0 };
+type Reference = { label: string; value: WeakRef<object> };
+
+function createUnownedControl() {
+  // End the creation frame so an async module's temporary cannot retain the control.
+  return new WeakRef({ unowned: true });
+}
+
+function createRegistry() {
+  const registry = createEmptyPluginRegistry();
+  registry.services.push({
+    pluginId: "retention-probe",
+    origin: "workspace",
+    source: "retention-probe",
+    service: {
+      id: "retention-probe",
+      start() {
+        counts.starts += 1;
+      },
+      stop() {
+        counts.stops += 1;
+      },
+    },
+  });
+  return registry;
+}
+
+async function createGenerations() {
+  const references: Reference[] = [];
+  let registry = createRegistry();
+  let handle = await startPluginServices({ registry, config: {} });
+  for (let generation = 0; generation < 8; generation += 1) {
+    references.push(
+      { label: `handle:${generation}`, value: new WeakRef(handle) },
+      { label: `registry:${generation}`, value: new WeakRef(registry) },
+    );
+    await handle.stop({ strict: true });
+    registry = createRegistry();
+    handle = await startPluginServices({ registry, config: {}, previous: handle });
+  }
+  return { handle, references };
+}
+
+class PublicationPayload {
+  publications = 0;
+}
+
+async function createPublishedHandle() {
+  const payload = new PublicationPayload();
+  const reference = new WeakRef(payload);
+  const handle = await startPluginServices({
+    registry: createRegistry(),
+    config: {},
+    throwOnStartError: true,
+    onHandle: (published: PluginServicesHandle) => {
+      assert.equal(typeof published.stop, "function");
+      payload.publications += 1;
+    },
+  });
+  assert.equal(payload.publications, 1);
+  return { handle, references: [{ label: "publication-payload", value: reference }] };
+}
+
+assert.ok(scenario === "generations" || scenario === "on-handle", "Select a retention scenario");
+const { handle, references } =
+  scenario === "generations" ? await createGenerations() : await createPublishedHandle();
+const control = createUnownedControl();
+try {
+  for (let pass = 0; pass < 8; pass += 1) {
+    await setImmediate();
+    gc();
+  }
+  assert.equal(control.deref(), undefined, "Unowned control must collect");
+  const retained = references
+    .filter(({ value }) => value.deref() !== undefined)
+    .map(({ label }) => label);
+  const beforeReload = { ...counts };
+  await handle.reload({}, new Set(["retention-probe"]));
+  assert.equal(counts.starts, beforeReload.starts + 1, "Newest service must restart");
+  assert.equal(counts.stops, beforeReload.stops + 1, "Newest service must stop before restarting");
+  assert.equal(counts.starts - counts.stops, 1, "Exactly one service must remain active");
+  console.log(
+    JSON.stringify({
+      scenario,
+      observed: references.length,
+      retained,
+      controlCollected: true,
+      newestReloadUsable: true,
+      counts,
+    }),
+  );
+  assert.deepEqual(
+    retained,
+    [],
+    "Live service handle retained completed generation or publication state",
+  );
+} finally {
+  await handle.stop({ strict: true });
+  assert.equal(counts.starts, counts.stops, "Every service start must have a settled stop");
+}

--- a/src/plugins/services.retention.test.ts
+++ b/src/plugins/services.retention.test.ts
@@ -1,0 +1,25 @@
+import { execFile } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+import { it } from "vitest";
+
+it.each([
+  { name: "completed service generations", scenario: "generations" },
+  { name: "completed handle publication", scenario: "on-handle" },
+])(
+  "releases $name while the newest service handle remains usable",
+  async ({ scenario }) => {
+    await promisify(execFile)(
+      process.execPath,
+      [
+        "--expose-gc",
+        "--import",
+        "tsx",
+        fileURLToPath(new URL("./services.retention.test-support.ts", import.meta.url)),
+        scenario,
+      ],
+      { timeout: 20_000 },
+    );
+  },
+  25_000,
+);

--- a/src/plugins/services.ts
+++ b/src/plugins/services.ts
@@ -87,28 +87,38 @@ type PluginServicesOwner = {
 };
 const serviceOwners = new WeakMap<PluginServicesHandle, PluginServicesOwner>();
 
-export async function startPluginServices(
-  params: {
-    registry: PluginRegistry;
-    config: OpenClawConfig;
-    workspaceDir?: string;
-    startupTrace?: NonNullable<OpenClawPluginServiceContext["startupTrace"]>;
-    broadcastPluginEvent?: GatewayPluginEventBroadcastFn;
-    getCronService?: () => PluginServiceCronHost | null | undefined;
-    oneShotStopTimeouts?: { eventDrainMs: number; serviceStopMs: number };
-    previous?: PluginServicesHandle | null;
-  } & (
-    | { throwOnStartError: true; onHandle: (handle: PluginServicesHandle) => void }
-    | { throwOnStartError?: false; onHandle?: (handle: PluginServicesHandle) => void }
-  ),
-): Promise<PluginServicesHandle> {
+// Long-lived callbacks must not capture the startup-only predecessor and publication callback.
+export async function startPluginServices({
+  registry,
+  config,
+  workspaceDir,
+  startupTrace,
+  broadcastPluginEvent,
+  getCronService,
+  oneShotStopTimeouts,
+  previous: previousHandle,
+  onHandle,
+  throwOnStartError,
+}: {
+  registry: PluginRegistry;
+  config: OpenClawConfig;
+  workspaceDir?: string;
+  startupTrace?: NonNullable<OpenClawPluginServiceContext["startupTrace"]>;
+  broadcastPluginEvent?: GatewayPluginEventBroadcastFn;
+  getCronService?: () => PluginServiceCronHost | null | undefined;
+  oneShotStopTimeouts?: { eventDrainMs: number; serviceStopMs: number };
+  previous?: PluginServicesHandle | null;
+} & (
+  | { throwOnStartError: true; onHandle: (handle: PluginServicesHandle) => void }
+  | { throwOnStartError?: false; onHandle?: (handle: PluginServicesHandle) => void }
+)): Promise<PluginServicesHandle> {
   // Failed starts still own their cleanup and remain selectable for a later retry.
   const ownedServices: OwnedPluginService[] = [];
-  const previous = params.previous && serviceOwners.get(params.previous);
+  const previous = previousHandle && serviceOwners.get(previousHandle);
   const owner: PluginServicesOwner = {
     services: ownedServices,
     attempts: previous?.attempts ?? new WeakMap(),
-    registrations: new Set(params.registry.services),
+    registrations: new Set(registry.services),
     stopped: new Set(),
     closed: false,
   };
@@ -262,7 +272,7 @@ export async function startPluginServices(
     failures: unknown[],
     deadline?: number,
   ) => {
-    const oneShotTimeouts = deadline === undefined ? params.oneShotStopTimeouts : undefined;
+    const oneShotTimeouts = deadline === undefined ? oneShotStopTimeouts : undefined;
     // One-shot registries are already scoped; every cleanup follows the drain, without changing grants.
     const afterDrain = oneShotTimeouts
       ? reversed
@@ -379,7 +389,7 @@ export async function startPluginServices(
   };
   serviceOwners.set(handle, owner);
   // The issued handle keeps retained services and failed cleanup even when startup rejects.
-  params.onHandle?.(handle);
+  onHandle?.(handle);
 
   const startService = async (
     entry: PluginServiceRegistration,
@@ -388,7 +398,7 @@ export async function startPluginServices(
     candidate = false,
   ): Promise<boolean> => {
     const service = entry.service;
-    const record = params.registry.plugins.find((plugin) => plugin.id === entry.pluginId);
+    const record = registry.plugins.find((plugin) => plugin.id === entry.pluginId);
     const instance = record && getPluginInstance(record);
     // Native service receivers retain their brands; registration owns their invocation scope.
     const runServiceCleanup = <T>(run: () => T): T =>
@@ -396,7 +406,7 @@ export async function startPluginServices(
     const traceName = `sidecars.plugin-services.${encodeStartupTraceSegment(entry.pluginId)}.${encodeStartupTraceSegment(entry.service.id)}`;
     const lease = createPluginRuntimeCapabilityLease("plugin service");
     const pluginId = entry.pluginId;
-    const broadcast = params.broadcastPluginEvent;
+    const broadcast = broadcastPluginEvent;
     // The broadcaster owns delivery and sessions.changed scheduling. Without it,
     // omit this capability so plugins can detect absence and choose their fallback.
     const gatewayEvents: OpenClawPluginServiceContext["gatewayEvents"] = broadcast
@@ -426,10 +436,9 @@ export async function startPluginServices(
       : undefined;
     const { health, revoke } = createPluginServiceHealthReporter(entry);
     lease.retain(revoke);
-    const { startupTrace, workspaceDir } = params;
-    const getCron = params.getCronService
+    const getCron = getCronService
       ? createPluginServiceCronGetter({
-          getCron: params.getCronService,
+          getCron: getCronService,
           lease,
           isStopping: () => ownedService.owner.closed || ownedService.stopRequested,
         })
@@ -518,7 +527,7 @@ export async function startPluginServices(
       id: service.id,
       pluginId: entry.pluginId,
       registration: entry,
-      registry: params.registry,
+      registry,
       stopRequested: false,
       diagnosticsExporter: serviceContext.internalDiagnostics !== undefined,
       stop: service.stop
@@ -548,9 +557,9 @@ export async function startPluginServices(
     if (existingIndex >= 0) {
       ownedServices[existingIndex] = ownedService;
     } else {
-      const declarationIndex = params.registry.services.indexOf(entry);
+      const declarationIndex = registry.services.indexOf(entry);
       const following = ownedServices.findIndex(
-        (current) => params.registry.services.indexOf(current.registration) > declarationIndex,
+        (current) => registry.services.indexOf(current.registration) > declarationIndex,
       );
       ownedServices.splice(following < 0 ? ownedServices.length : following, 0, ownedService);
     }
@@ -563,7 +572,7 @@ export async function startPluginServices(
           ownedService.startupConsumer = instance?.retainConsumer();
           const start = () => service.start(serviceContext);
           await withPluginHttpRouteRegistry(
-            params.registry,
+            registry,
             () =>
               ownedService.startupConsumer ? ownedService.startupConsumer.run(start) : start(),
             lease,
@@ -578,8 +587,7 @@ export async function startPluginServices(
       };
       // Bound candidate observation only; raw completion remains owned by the entry.
       await runBeforeDeadline(
-        () =>
-          params.startupTrace ? params.startupTrace.measure(traceName, invokeStart) : invokeStart(),
+        () => (startupTrace ? startupTrace.measure(traceName, invokeStart) : invokeStart()),
         candidate ? Date.now() + PLUGIN_SERVICE_REPLACEMENT_STOP_TIMEOUT_MS : undefined,
         "plugin service startup",
         `${entry.pluginId}/${service.id}`,
@@ -612,12 +620,12 @@ export async function startPluginServices(
   };
   let failedCount = 0;
   const startupSettled = (async () => {
-    for (const entry of params.registry.services) {
+    for (const entry of registry.services) {
       if (owner.closed) {
         break;
       }
       if (!canStart(entry)) {
-        if (params.throwOnStartError && owner.stopped.has(entry)) {
+        if (throwOnStartError && owner.stopped.has(entry)) {
           throw new Error(
             `Previous plugin service cleanup remains pending (${entry.pluginId}/${entry.service.id})`,
           );
@@ -636,19 +644,17 @@ export async function startPluginServices(
         }
       }
       const failures: unknown[] = [];
-      if (
-        !(await startService(entry, params.config, failures, params.throwOnStartError === true))
-      ) {
+      if (!(await startService(entry, config, failures, throwOnStartError === true))) {
         failedCount += 1;
-        if (params.throwOnStartError) {
+        if (throwOnStartError) {
           throw new AggregateError(failures, "plugin services failed to start");
         }
       }
     }
   })();
   await startupSettled;
-  params.startupTrace?.detail?.("sidecars.plugin-services.summary", [
-    ["serviceCount", params.registry.services.length],
+  startupTrace?.detail?.("sidecars.plugin-services.summary", [
+    ["serviceCount", registry.services.length],
     ["startedCount", ownedServices.length - failedCount],
     ["failedCount", failedCount],
   ]);

--- a/src/plugins/services.ts
+++ b/src/plugins/services.ts
@@ -90,7 +90,7 @@ const serviceOwners = new WeakMap<PluginServicesHandle, PluginServicesOwner>();
 // Long-lived callbacks must not capture the startup-only predecessor and publication callback.
 export async function startPluginServices({
   registry,
-  config,
+  config: initialConfig,
   workspaceDir,
   startupTrace,
   broadcastPluginEvent,
@@ -202,8 +202,10 @@ export async function startPluginServices({
     try {
       const invokeStop = () => {
         const record = entry.registry.plugins.find((candidate) => candidate.id === entry.pluginId);
-        const registry = record ? getPluginRecordRegistry(entry.registry, record) : entry.registry;
-        return withPluginHttpRouteRegistry(registry, () => entry.stop?.(), entry.lease);
+        const stopRegistry = record
+          ? getPluginRecordRegistry(entry.registry, record)
+          : entry.registry;
+        return withPluginHttpRouteRegistry(stopRegistry, () => entry.stop?.(), entry.lease);
       };
       const cleanup = () => {
         if (!entry.stopping) {
@@ -644,7 +646,7 @@ export async function startPluginServices({
         }
       }
       const failures: unknown[] = [];
-      if (!(await startService(entry, config, failures, throwOnStartError === true))) {
+      if (!(await startService(entry, initialConfig, failures, throwOnStartError === true))) {
         failedCount += 1;
         if (throwOnStartError) {
           throw new AggregateError(failures, "plugin services failed to start");


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users repeatedly hot-reloading plugins could accumulate retired service-generation state in a long-running Gateway even after the old services had stopped.

## Why This Change Was Made

Extract `startPluginServices` arguments before constructing its long-lived callbacks so the current handle no longer captures the entire startup argument object, including `previous` and `onHandle`. Service transfer ordering, synchronous handle publication, pending startup/cleanup, and the attempts WeakMap remain unchanged.

## User Impact

Removes a proven service-owner retention chain during plugin hot reload without adding a public API or changing plugin lifecycle behavior. This is a focused leak fix, not a claim that every plugin/module retention path is resolved.

## Evidence

Validated against frozen source `53327b667df78518138a8b21e29bded01e8b0252` with Node 24.19.0 and Vitest 5.0.0.

- Before the fix, both isolated GC regression cases failed for the intended reason with a collected unowned control: eight retired handles plus eight retired registries remained reachable, and a separate no-previous publication callback retained its payload (17 stale objects across the two cases).
- Independent heap analysis confirmed the strong paths: current handle -> reload closure -> startup arguments -> predecessor handle, recursively; and current handle -> reload closure -> startup arguments -> publication callback -> payload.
- After the fix, both GC cases pass. The newest handle remains usable for reload and stop, and all service starts have settled stops. The tests use the real owner, bounded GC/event-loop passes, WeakRefs, and no reset helpers or retained generation histories.
- All 95 focused service sibling tests pass: services, reload, replacement, return contract, diagnostics, and cron.
- Frozen-source Gateway functional baselines pass: two channel lifecycle tests and eight plugin lifecycle tests. These are functional smoke only; their retained fixtures and mocked bridges are not memory evidence.
- Fresh scoped autoreview through P2: `scoped-clean`, no findings. A follow-up naming review found only an unstaged-index issue, resolved by committing the reviewed working tree; it reported no additional P0-P2 code findings.
- Candidate formatting and `git diff --check` pass.
- The initial changed check passed its typecheck lanes, including all 18 core-test graphs, then failed on three `no-shadow` lint errors introduced by argument extraction. Commit `596b8bb87725028c53a4aac23b1eba0f91946da8` fixes only those binding names. Targeted lint now reports zero warnings/errors, both GC tests pass again, and all eight previously unrun trailing guards pass. The original failed command and CI logs are preserved; the full command was not rerun.
- The first candidate build hit its 20-minute outer deadline after spending about 16.5 minutes waiting for the artifact lock (wrapper exit 124, declaration child exit 143). The new uncontended build of `596b8bb87725028c53a4aac23b1eba0f91946da8` passed in 6m24.4s. Build provenance and both runtime stamps match that exact clean candidate.
- Native Gateway CJS pilot: one real `plugins.reload` succeeded with fresh module-scope and registration UUIDs, unchanged child PID, and service counts of two starts/one stop. Startup took 8077ms, reload took 668ms, and ordinary post-GC samples took 804ms/829ms.
- The pilot then stopped at its first retention failure: the stopped original registration survived both bounded GC samples while the unowned controls collected. Independent heap analysis attributed the surviving strong roots to separate Gateway catalog/startup-sidecar owners and a `getCronService` closure retaining the reload-operation frame, not the direct startup-argument `previous`/`onHandle` paths fixed here. The snapshot and exact failure remain preserved. These Gateway producer/cache repairs are separate work; this is not a ten-round pass or a global memory-leak fix, and no native retry or expanded production change was made.
- Native teardown passed independently: exit code 0, no signal, no early exit before teardown, and the owned process group dead. The probe controller correctly exited 1 for the preserved retention failure.
- Main movement introduced a conflict with https://github.com/openclaw/openclaw/pull/146072. Head `3ad743d2047fc2d11dfc8a8da7b3b9b37150a6b2` preserves that upstream `stopRequested` move and the reviewed extraction/aliases. Range-diff shows only changed patch context; the regression files are unchanged. Both GC regressions and all 95 service sibling tests pass on this rebased head, with zero lint warnings/errors and passing formatting/diff checks. The build and native pilot above remain evidence for `596b8bb`, not newly executed proof for the rebased head.
- Exact-head CI for `3ad743d2047fc2d11dfc8a8da7b3b9b37150a6b2` passed: https://github.com/openclaw/openclaw/actions/runs/34702370513 (attempt 2). The first attempt's only failed shard was `checks-node-compact-small-25`: the unchanged profiler `--help --help` test timed out at 120 seconds. Its owner and dependency inputs were unchanged from the prior passing candidate. The original failure log is preserved; one targeted job retry passed, followed by `openclaw/ci-gate`. No source, timeout, dependency, or CI configuration changed for the retry.
- Exact-head ClawSweeper review is complete with no findings, security findings, or before-merge items: https://github.com/openclaw/openclaw/pull/146073#issuecomment-5646699937. Its literal state is `ready` with verdict `needs-human`, the normal maintainer-review route, not an automerge-mode `pass`. Maintainer review is complete; no live-verification claim is made.

The larger multi-plugin, rollback, concurrent-request, and module-retention campaign remains separate from this three-file repair. Raw heap snapshots and local state captures are retained privately rather than published.
