### PR TITLE
improve(discord): split long fenced replies faster

### DIFF
--- a/extensions/discord/src/chunk.test.ts
+++ b/extensions/discord/src/chunk.test.ts
@@ -65,9 +65,12 @@ describe("chunkDiscordText", () => {
     expect(chunks.join("")).toBe(text);
   });
 
-  it("keeps fenced code blocks balanced across chunks", () => {
+  it.each([
+    { ending: "closed", suffix: "\n```\n\nDone." },
+    { ending: "open at EOF", suffix: "" },
+  ])("keeps $ending fenced code blocks balanced across chunks", ({ suffix }) => {
     const body = Array.from({ length: 30 }, (_, i) => `console.log(${i});`).join("\n");
-    const text = `Here is code:\n\n\`\`\`js\n${body}\n\`\`\`\n\nDone.`;
+    const text = `Here is code:\n\n\`\`\`js\n${body}${suffix}`;
 
     const chunks = chunkDiscordText(text, { maxChars: 2000, maxLines: 10 });
     expect(chunks.length).toBeGreaterThan(1);
@@ -78,7 +81,7 @@ describe("chunkDiscordText", () => {
     }
 
     expect(chunks[0]).toContain("```js");
-    expect(chunks.at(-1)).toContain("Done.");
+    expect(chunks.at(-1)).toContain(suffix ? "Done." : "console.log(29);");
   });
 
   it("keeps fenced blocks intact when chunkMode is newline", () => {

--- a/extensions/discord/src/chunk.ts
+++ b/extensions/discord/src/chunk.ts
@@ -442,17 +442,35 @@ function createDiscordRanges(source: string, maxChars: number, maxLines: number)
     }
     return text + source.slice(cursor, end);
   };
+  const fenceEndingAtOrAfter = (position: number) => {
+    let low = 0;
+    let high = fences.length;
+    // The scanner emits disjoint fences in source order, including an open final fence.
+    while (low < high) {
+      const middle = low + Math.floor((high - low) / 2);
+      const range = expectDefined(fences[middle], "Discord fence range");
+      if (range.end < position) {
+        low = middle + 1;
+      } else {
+        high = middle;
+      }
+    }
+    return fences[low];
+  };
   // A partial closing line is still inside the fence until its original text is consumed.
-  const fenceAt = (position: number) =>
-    fences.find(
-      (range) =>
-        range.bodyStart - 1 <= position &&
-        (position < range.end || (position === range.end && range.closeStart === range.end)),
-    );
+  const fenceAt = (position: number) => {
+    const range = fenceEndingAtOrAfter(position);
+    return range &&
+      range.bodyStart - 1 <= position &&
+      (position < range.end || (position === range.end && range.closeStart === range.end))
+      ? range
+      : undefined;
+  };
   const cutBoundary = (start: number, end: number) => {
     const safe = boundary(start, end);
     // Keep marker lines intact and leave an opening fence with its body.
-    for (const range of fences) {
+    const range = fenceEndingAtOrAfter(safe);
+    if (range) {
       if (start < range.start && range.start < safe && safe <= range.bodyStart) {
         return range.start;
       }


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

This branch is in the main repository; fork collaboration settings do not apply.

</details>

## What Problem This Solves

Fixes an issue where splitting long Discord replies containing many fenced code blocks spends increasing CPU time searching earlier blocks before messages can be sent.

## Why This Change Was Made

The Discord chunker already records disjoint fences in source order. Its two fence queries now find the first possible range by binary search and apply their existing boundary predicates. Fence grammar, inline-code processing, synthetic closing/reopening markers, and the inclusive end of an unfinished final block retain their existing behavior.

## User Impact

Long reports containing many separate code blocks split faster. Message contents and chunk boundaries remain the same. This does not claim faster Discord network delivery or improvement for every message shape.

## Evidence

- 184 tests passed across five focused chunking, outbound, webhook, thread, and draft-preview suites. The existing balanced-fence case now also covers an unfinished final block.
- Exact public length-mode chunker, Linux x64 / Node 26.8.2, baseline `9e267031cd9d73aea91332f9245570ddd5bebef0`. Three warmups and three alternating ABBA rounds produced six batch means per version, with source preparation included. All 432 additional boundary-parity cases and all timed workloads produced identical output bytes. No timing assertions were added to CI.

| Separate fenced blocks | Input UTF-16 units | Baseline median | Candidate median |
| --- | ---: | ---: | ---: |
| 128 | 6,563 | 4.887 ms | 0.869 ms |
| 512 | 26,915 | 30.665 ms | 3.147 ms |
| 2,048 | 110,419 | 574.217 ms | 18.474 ms |

The largest baseline samples ranged from 494–611 ms versus 15–25 ms for the candidate. Small controls were mixed: eight fences measured 0.076→0.082 ms, and inline-code results overlapped. Measurements were serialized across this campaign's lanes on a shared host; these are chunker measurements, not whole-request latency. The benchmark uses the real parser and narrow equivalent SDK exports; newline mode and transport integration are covered by the owner tests. No live Discord account was used.
Independent review completed with no actionable findings. Formatting, all selected structural guards, six Doctor contract tests, extension production and test typechecking, and targeted type-aware lint passed. The initial broader local check was interrupted during WSL instability; the recovered check wrapper completed with exit 0 and all owned descendants joined. [Hosted CI run 34700981890](https://github.com/openclaw/openclaw/actions/runs/34700981890), including the required openclaw/ci-gate, passed for head `bc3670c4e91b67bd228e16e9da998ca04856c2b8`.
