### PR TITLE
fix(openai): prevent GPT-Live relay audio clock drift

### DIFF
--- a/docs/providers/openai/voice-and-speech.md
+++ b/docs/providers/openai/voice-and-speech.md
@@ -279,11 +279,14 @@ sidebarTitle: "Voice and speech"
     exchanges the browser's SDP and returns only the answer SDP; it does not
     send an OAuth token, Platform key, or ephemeral client secret to the browser.
 
-    Gateway-relay WebRTC calls conceal malformed incoming audio packets and
-    continue playing later audio. One rejected audio packet send does not end
-    an otherwise connected call. Unusable codec state, unexpected stream changes,
-    and terminal connection states still end the call. Packet-drop diagnostics
-    omit raw error details.
+    Gateway-relay WebRTC paces microphone audio against a continuous sample
+    clock, so timer delays do not accumulate during longer calls. After a scheduler
+    pause, queued audio resumes at its normal pace while timestamps account for
+    the elapsed gap. Calls conceal
+    malformed incoming audio packets and continue playing later audio. One
+    rejected audio packet send does not end an otherwise connected call. Unusable
+    codec state, unexpected stream changes, and terminal connection states still
+    end the call. Packet-drop diagnostics omit raw error details.
 
     The enabled OpenAI plugin starts the broker automatically, including when
     you sign in after the Gateway has started. The broker opens a provider

--- a/extensions/openai/realtime-quicksilver-peer.runtime.test.ts
+++ b/extensions/openai/realtime-quicksilver-peer.runtime.test.ts
@@ -41,7 +41,7 @@ function createRelayTone(): Buffer {
 type TestableAudioPeer = {
   connected: boolean;
   handleInboundRtp(packet: unknown): void;
-  mediaTimer: ReturnType<typeof setInterval> | undefined;
+  mediaTimer: ReturnType<typeof setTimeout> | undefined;
   pendingAudio: OpenAIQuicksilverPendingAudio;
   sequenceNumber: number;
   timestamp: number;
@@ -111,6 +111,25 @@ async function createInboundAudioHarness(params?: {
       Buffer.from([sequenceNumber & 0xff]),
     );
   return { decode, decodeOrder, decodePacketLoss, onAudio, onError, packet, peer, testPeer };
+}
+
+async function captureOutboundRtp(testPeer: TestableAudioPeer) {
+  const { RtpPacket } = await import("werift");
+  const packets: Array<{ atMs: number; sequenceNumber: number; timestamp: number }> = [];
+  const send = vi
+    .spyOn(testPeer.state.transceiver.sender, "sendRtp")
+    .mockImplementation(async (packet) => {
+      const rtp = Buffer.isBuffer(packet) ? RtpPacket.deSerialize(packet) : packet;
+      if (!(rtp instanceof RtpPacket)) {
+        throw new Error("Expected an RTP packet");
+      }
+      packets.push({
+        atMs: performance.now(),
+        sequenceNumber: rtp.header.sequenceNumber,
+        timestamp: rtp.header.timestamp,
+      });
+    });
+  return { packets, send };
 }
 
 describe("GPT-Live werift audio peer", () => {
@@ -401,6 +420,106 @@ describe("GPT-Live werift audio peer", () => {
       ]);
     } finally {
       peer.close();
+    }
+  });
+
+  it("keeps the RTP sample clock aligned through a minute of late timer callbacks", async () => {
+    const { onError, peer, testPeer } = await createInboundAudioHarness();
+    const { packets, send } = await captureOutboundRtp(testPeer);
+    vi.useFakeTimers({
+      toFake: ["setTimeout", "clearTimeout", "setInterval", "clearInterval", "performance"],
+    });
+    const scheduleTimeout = globalThis.setTimeout;
+    const scheduleInterval = globalThis.setInterval;
+    // Both timer APIs incur the same scheduler lateness; only a deadline can compensate.
+    const timeout = vi
+      .spyOn(globalThis, "setTimeout")
+      .mockImplementation((callback, delay, ...args) =>
+        scheduleTimeout(callback, (delay ?? 0) + 1, ...args),
+      );
+    const interval = vi
+      .spyOn(globalThis, "setInterval")
+      .mockImplementation((callback, delay, ...args) =>
+        scheduleInterval(callback, (delay ?? 0) + 1, ...args),
+      );
+    try {
+      peer.sendAudio(createRelayTone());
+      testPeer.state.peer.connectionStateChange.execute("connected");
+      expect(packets).toHaveLength(1);
+
+      await vi.advanceTimersByTimeAsync(60_000);
+
+      const first = packets[0]!;
+      expect(packets.at(-1)!.atMs - first.atMs).toBeGreaterThanOrEqual(59_980);
+      const clockErrors = packets.map((packet) =>
+        Math.abs(packet.atMs - first.atMs - ((packet.timestamp - first.timestamp) >>> 0) / 48),
+      );
+      expect(Math.max(...clockErrors)).toBeLessThanOrEqual(20);
+      expect(onError).not.toHaveBeenCalled();
+
+      const sentBeforeClose = packets.length;
+      peer.close();
+      await vi.advanceTimersByTimeAsync(100);
+      expect(packets).toHaveLength(sentBeforeClose);
+    } finally {
+      peer.close();
+      timeout.mockRestore();
+      interval.mockRestore();
+      send.mockRestore();
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps queued audio paced after a five-second scheduler pause", async () => {
+    const { onError, peer, testPeer } = await createInboundAudioHarness();
+    const { packets, send } = await captureOutboundRtp(testPeer);
+    const pendingAudio = new OpenAIQuicksilverPendingAudio();
+    const readFrame = vi.spyOn(pendingAudio, "readInto");
+    const frames = [1, 2, 3].map((value) =>
+      Buffer.alloc(OPENAI_QUICKSILVER_RELAY_FRAME_BYTES, value),
+    );
+    vi.useFakeTimers({
+      toFake: ["setTimeout", "clearTimeout", "setInterval", "clearInterval", "performance"],
+    });
+    const timerNow = performance.now.bind(performance);
+    let suspensionMs = 0;
+    const now = vi.spyOn(performance, "now").mockImplementation(() => timerNow() + suspensionMs);
+    try {
+      peer.adoptPendingAudio(pendingAudio);
+      peer.sendAudio(Buffer.concat(frames));
+      testPeer.state.peer.connectionStateChange.execute("connected");
+      expect(packets).toHaveLength(1);
+
+      suspensionMs = 5_000;
+      await vi.advanceTimersByTimeAsync(20);
+      expect(packets).toHaveLength(2);
+      expect(pendingAudio).toHaveLength(OPENAI_QUICKSILVER_RELAY_FRAME_BYTES);
+
+      await vi.advanceTimersByTimeAsync(20);
+      expect(packets).toHaveLength(3);
+      const first = packets[0]!;
+      expect(packets.map((packet) => packet.atMs - first.atMs)).toEqual([0, 5_020, 5_040]);
+      expect(packets.map((packet) => (packet.timestamp - first.timestamp) >>> 0)).toEqual([
+        0,
+        5_020 * 48,
+        5_040 * 48,
+      ]);
+      expect(
+        packets.map((packet) => (packet.sequenceNumber - first.sequenceNumber) & 0xffff),
+      ).toEqual([0, 1, 2]);
+      expect(readFrame.mock.calls.map(([frame]) => frame)).toEqual(frames);
+      expect(pendingAudio).toHaveLength(0);
+      expect(onError).not.toHaveBeenCalled();
+
+      peer.close();
+      await vi.advanceTimersByTimeAsync(100);
+      expect(packets).toHaveLength(3);
+    } finally {
+      peer.close();
+      now.mockRestore();
+      readFrame.mockRestore();
+      send.mockRestore();
+      vi.useRealTimers();
     }
   });
 

--- a/extensions/openai/realtime-quicksilver-peer.runtime.ts
+++ b/extensions/openai/realtime-quicksilver-peer.runtime.ts
@@ -177,7 +177,7 @@ export class OpenAIQuicksilverAudioPeer implements OpenAIQuicksilverAudioPeerCon
   private outboundPacketFailed = false;
   private activeInboundSsrc: number | undefined;
   private inboundRtpState: InboundRtpState = { pendingPackets: new Map() };
-  private mediaTimer: ReturnType<typeof setInterval> | undefined;
+  private mediaTimer: ReturnType<typeof setTimeout> | undefined;
   private pendingAudio = new OpenAIQuicksilverPendingAudio();
   private pendingResampledAudio = Buffer.alloc(OUTBOUND_RESAMPLE_PREROLL_SAMPLES * 2);
   private readonly inboundResampler = createStreamingPcmResampler(
@@ -266,7 +266,7 @@ export class OpenAIQuicksilverAudioPeer implements OpenAIQuicksilverAudioPeerCon
     }
     this.closed = true;
     if (this.mediaTimer) {
-      clearInterval(this.mediaTimer);
+      clearTimeout(this.mediaTimer);
       this.mediaTimer = undefined;
     }
     this.pendingAudio.clear();
@@ -462,10 +462,24 @@ export class OpenAIQuicksilverAudioPeer implements OpenAIQuicksilverAudioPeerCon
     if (this.mediaTimer || this.closed) {
       return;
     }
-    this.mediaTimer = setInterval(() => this.sendNextAudioFrame(), OPUS_FRAME_DURATION_MS);
-    this.mediaTimer.unref?.();
-    // Publish the timer before the first tick so synchronous error teardown can clear it.
-    this.sendNextAudioFrame();
+    let nextFrameAt = performance.now();
+    const tick = () => {
+      if (this.closed) {
+        return;
+      }
+      // Skip elapsed media slots after a stall without draining queued microphone audio.
+      const missedSlots = Math.max(
+        0,
+        Math.floor((performance.now() - nextFrameAt) / OPUS_FRAME_DURATION_MS),
+      );
+      this.timestamp = (this.timestamp + missedSlots * OPUS_FRAME_SAMPLES) >>> 0;
+      nextFrameAt += (missedSlots + 1) * OPUS_FRAME_DURATION_MS;
+      // Publish before sending so synchronous error teardown can cancel the next tick.
+      this.mediaTimer = setTimeout(tick, Math.max(0, nextFrameAt - performance.now()));
+      this.mediaTimer.unref?.();
+      this.sendNextAudioFrame();
+    };
+    tick();
   }
 
   private sendNextAudioFrame(): void {


### PR DESCRIPTION
Related: #145382, #145807

## What Problem This Solves

Resolves a problem where longer GPT-Live Gateway-relay calls could lose later spoken requests as outgoing microphone audio fell behind real time. Small timer delays accumulated while RTP timestamps advanced by a fixed 20 ms per packet.

## Why This Change Was Made

The existing audio peer schedules frames against monotonic deadlines. After a scheduler pause, it advances RTP time over whole missed media slots and emits one current frame, preserving queued PCM and the existing five-second retention policy without replaying overdue frames in a burst.

The timer remains published before emission so synchronous error teardown can cancel it. Immediate first-frame delivery, packet sequence numbering, codec configuration, and queue ownership are preserved; no setting or protocol message is added.

## User Impact

Gateway-relay calls avoid accumulating audio delay and resume paced audio after host pauses. This repairs the Node relay's media clock; native browser pacing and speech-recognition accuracy remain separate concerns.

## Evidence

- The one-minute regression failed the old interval implementation with 2,857 ms of RTP clock error under 1 ms callback lateness. The corrected deadline stays within its 20 ms test bound.
- A five-second-pause regression caught burst catch-up in the first deadline candidate (22 packets instead of 3). The final test checks resumed pacing, timestamp gaps, consecutive packet sequence numbers, exact retained PCM through the public queue, and close cancellation.
- All 29 peer and microphone-pipeline tests, complete selected changed-file checks, and fresh managed isolated review through P2 pass. No deslop findings remain.
- Reviewed commit `b51970518acc` passed a real OAuth/WebRTC six-turn relay case in 75.223 seconds with an intentional five-second event-loop pause between turns two and three. All six exact request captions, six matching settled consultations, and six expected final answer captions were observed. Late counters and forced terminations were zero; the single peer closed.
- Across 3,123 RTP sends, cumulative timestamp steps represented 68.600 seconds against 68.592 seconds of monotonic elapsed time: final offset -8 ms, absolute P99 10 ms, maximum sampled absolute offset 76 ms. The pause produced a 5,007 ms send gap and 5,000 ms RTP timestamp step with consecutive sequence numbers. Resumption produced 6 packets in 100 ms and 11 in 200 ms, without a backlog burst. This establishes bounded timing behavior, not uniformly sub-frame jitter.

Two pre-fix live traces lost later input in the provider's returned audio echo; one accumulated 3.064 seconds of lag measured with wall time. The corrected trace uses monotonic time, and the deterministic regression independently establishes the clock defect. The exact server mechanism is not directly observable, and resolved send promises alone do not prove receiver delivery.

The final stalled run's echo/audio was captured but was not independently transcribed. Earlier non-stalled ASR evidence retained word variations, and a native Chromium comparison misheard a color and clarified rather than losing the whole request. Those recognition limits are not attributed to this repair. These are real-provider transport tests with synthetic backend answers, not full Control UI or agent-tool inference proof or an exactly-once/perfect-recognition guarantee.

CI [run 34701057560](https://github.com/openclaw/openclaw/actions/runs/34701057560) passed on the unchanged reviewed commit. The first attempt hit an unrelated 60-second subprocess timeout in update argument validation; the single failed job and aggregate gate passed one rerun without changing source, timeouts, or assertions.
