### PR TITLE
fix(update): restrict lifecycle notices to configured owners

### DIFF
--- a/docs/install/updating.md
+++ b/docs/install/updating.md
@@ -209,6 +209,13 @@ in that chat as the Gateway observes the recorded milestones:
 3. `🔁 Back on v<to>, verifying…` when the new Gateway starts verification.
 4. The final report, including successful updates.
 
+External update and restart notices go only to destinations listed in
+`commands.ownerAllowFrom`. Selecting a non-owner chat in the Control UI does not
+authorize notices to that contact. If no owner destination resolves, OpenClaw
+logs the skipped notice and keeps the update outcome in the run record and
+Control UI; it does not redirect the notice to another chat or wake the rejected
+session with diagnostics.
+
 Managed systemd or launchd updates can stop the Gateway before an intermediate
 notice is delivered. The complete four-message sequence is not guaranteed for
 those installations; the durable run report remains available after reconnect.

--- a/src/gateway/server-methods/update-chat-permission.test.ts
+++ b/src/gateway/server-methods/update-chat-permission.test.ts
@@ -44,6 +44,7 @@ describe("update.run chat restart permission", () => {
       params: {
         requester,
         sessionKey: "agent:main:slack:dm:owner:thread:123",
+        deliveryContext: { channel: "slack", to: "owner" },
       },
       context: { getRuntimeConfig: () => config },
       respond: (_ok: boolean, result: UpdateRunPayload) => {

--- a/src/gateway/server-methods/update-owner.test.ts
+++ b/src/gateway/server-methods/update-owner.test.ts
@@ -214,12 +214,6 @@ describe("update.run current owner authority", () => {
     expect(startManagedServiceUpdateHandoffMock).not.toHaveBeenCalled();
     expect(scheduleGatewaySigusr1RestartMock).not.toHaveBeenCalled();
     expect(sentinelState.capturedPayload).toBeUndefined();
-    expect(sendGatewayLifecycleNoticeMock).toHaveBeenLastCalledWith(
-      expect.objectContaining({
-        message: expect.stringContaining(
-          'openclaw config set commands.ownerAllowFrom \'["replacement","slack:owner"]\'',
-        ),
-      }),
-    );
+    expect(sendGatewayLifecycleNoticeMock).toHaveBeenCalledOnce();
   });
 });

--- a/src/gateway/server-methods/update.test-harness.ts
+++ b/src/gateway/server-methods/update.test-harness.ts
@@ -207,7 +207,12 @@ export const resolveGatewayLifecycleNoticeRouteMock = vi.fn(
     threadId?: string;
   }) =>
     deliveryContext?.channel === "slack" && deliveryContext.to
-      ? { ...deliveryContext, channel: "slack", to: deliveryContext.to, threadId }
+      ? {
+          ...deliveryContext,
+          channel: "slack",
+          to: deliveryContext.to.replace(/^slack:/, ""),
+          threadId,
+        }
       : undefined,
 );
 vi.mock("../server-restart-sentinel-notice.js", () => ({

--- a/src/gateway/server-methods/update.test.ts
+++ b/src/gateway/server-methods/update.test.ts
@@ -47,7 +47,10 @@ import {
 async function invokeUpdateRun(
   params: Record<string, unknown>,
   respond?: (ok: boolean, response?: unknown) => void,
-  runtimeConfig: OpenClawConfig = { update: {} },
+  runtimeConfig: OpenClawConfig = {
+    update: {},
+    commands: { ownerAllowFrom: ["slack:C0123ABC", "slack:C0456DEF"] },
+  },
 ) {
   const { updateHandlers } = await import("./update.js");
   const onRespond = respond ?? (() => {});
@@ -119,6 +122,20 @@ function mockGitInstallSurface(root: string) {
 describe("update.run acknowledgement", () => {
   const sessionKey = "agent:main:slack:dm:C0123ABC:thread:1234567890.123456";
 
+  it("keeps an operator update out of the selected non-owner chat", async () => {
+    const response = await captureUpdateRunPayload(
+      { sessionKey },
+      { commands: { ownerAllowFrom: ["telegram:12345"] } },
+    );
+    expect(response).toMatchObject({ ok: true, ackDelivered: false, ackQueued: false });
+    expect(runGatewayUpdateMock).toHaveBeenCalledOnce();
+    expect(sendGatewayLifecycleNoticeMock).not.toHaveBeenCalled();
+    expect(getUpdateRun(expectDefined(response, "update response").runId)).toMatchObject({
+      origin: { sessionKey },
+      verification: { noticeDelivered: false },
+    });
+  });
+
   it.each([false, true])(
     "awaits the chat acknowledgement before updating (managed=%s)",
     async (managed) => {
@@ -188,7 +205,7 @@ describe("update.run acknowledgement", () => {
         expect.objectContaining({
           sessionKey,
           channel: "slack",
-          to: "slack:C0123ABC",
+          to: "C0123ABC",
           threadId: "1234567890.123456",
           message: `⬆️ Updating OpenClaw 1.0.0 → ${managed ? "2.0.0" : "the latest release"}. The gateway stays available while the update is validated; you'll get a message here when it finishes.`,
           deliveryIntentId: expect.stringMatching(/^update-run-ack:/),
@@ -215,7 +232,7 @@ describe("update.run acknowledgement", () => {
     expect(sendGatewayLifecycleNoticeMock).toHaveBeenCalledTimes(2);
     expect(sendGatewayLifecycleNoticeMock).toHaveBeenLastCalledWith(
       expect.objectContaining({
-        to: "slack:C0456DEF",
+        to: "C0456DEF",
         message: expect.stringContaining("⚠️ OpenClaw update failed: build-failed."),
       }),
     );

--- a/src/gateway/server-methods/update.ts
+++ b/src/gateway/server-methods/update.ts
@@ -119,7 +119,8 @@ export const updateHandlers: GatewayRequestHandlers = {
             (sessionKey && isInternalMessageChannel(requesterChannel ?? deliveryContext?.channel))
           ? "control-ui"
           : "api";
-    const config = context.getRuntimeConfig();
+    const getConfig = context.getRuntimeConfig;
+    const config = getConfig();
     const noticeTarget = resolveUpdateRunNoticeTarget({
       cfg: config,
       sessionKey,
@@ -179,7 +180,7 @@ export const updateHandlers: GatewayRequestHandlers = {
       if (!requester?.channel || isInternalMessageChannel(requester.channel)) {
         return false;
       }
-      const currentConfig = context.getRuntimeConfig();
+      const currentConfig = getConfig();
       const reason = !isConfiguredCommandOwner(currentConfig, requester)
         ? "owner_required"
         : !isRestartEnabled(currentConfig)
@@ -216,7 +217,7 @@ export const updateHandlers: GatewayRequestHandlers = {
       return;
     }
     const { createUpdateRunNotifier } = await import("../update-run-notice.runtime.js");
-    const notify = createUpdateRunNotifier(run, config, context.deps, noticeTarget);
+    const notify = createUpdateRunNotifier(run, getConfig, context.deps, noticeTarget);
     const sentinelMeta: UpdateRestartSentinelMeta = {
       runId,
       ...(sessionKey ? { sessionKey } : {}),

--- a/src/gateway/server-restart-sentinel-notice.test.ts
+++ b/src/gateway/server-restart-sentinel-notice.test.ts
@@ -1,6 +1,7 @@
 // Exercises restart-notice retries against the real SQLite outbound queue.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { upsertSessionEntryCore } from "../config/sessions/session-accessor.js";
 import { getDeliveryQueueEntryStatus } from "../infra/delivery-queue-sqlite.js";
 import { runOutboundDeliveryInternal } from "../infra/outbound/deliver-queue.js";
 import { PlatformMessageNotDispatchedError } from "../infra/outbound/deliver-types.js";
@@ -32,6 +33,8 @@ import { createDeferredCore } from "../shared/deferred.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import { createOutboundTestPlugin, createTestRegistry } from "../test-utils/channel-plugins.js";
 import { captureEnv, setTestEnvValue } from "../test-utils/env.js";
+import { normalizeSessionDeliveryState } from "../utils/delivery-context.shared.js";
+import { resolveUpdateRunNoticeTarget } from "./update-run-notice-target.js";
 
 const mocks = vi.hoisted(() => ({
   sendDurableMessageBatch: vi.fn(),
@@ -156,60 +159,95 @@ describe("restart sentinel notice recovery", () => {
     });
   }
 
-  it("sends only the four update milestones across repeated phases and successor startup", async () => {
-    const { createUpdateRunNotifier } = await import("./update-run-notice.runtime.js");
-    setActivePluginRegistry(
-      createTestRegistry([
+  it.each(["owner", "non-owner", "no-owners", "control-ui"] as const)(
+    "sends the four update milestones only to a configured owner (%s)",
+    async (destination) => {
+      const { createUpdateRunNotifier } = await import("./update-run-notice.runtime.js");
+      setActivePluginRegistry(
+        createTestRegistry([
+          {
+            pluginId: "matrix",
+            source: "test",
+            plugin: createOutboundTestPlugin({
+              id: "matrix",
+              outbound: {
+                deliveryMode: "direct",
+                sendText: async () => ({ channel: "matrix", messageId: "notice" }),
+              },
+            }),
+          },
+        ]),
+      );
+      mocks.sendDurableMessageBatch.mockImplementation(async (request) => {
+        await markAttempt(request);
+        return { status: "sent", results: [{ channel: "matrix", messageId: "notice" }] };
+      });
+      const cfg = {
+        commands: {
+          ownerAllowFrom: destination === "no-owners" ? [] : ["matrix:@owner:example.org"],
+        },
+      };
+      const sessionKey = "agent:main:matrix:direct:contact";
+      await upsertSessionEntryCore(
+        { agentId: "main", sessionKey },
         {
-          pluginId: "matrix",
-          source: "test",
-          plugin: createOutboundTestPlugin({
-            id: "matrix",
-            outbound: {
-              deliveryMode: "direct",
-              sendText: async () => ({ channel: "matrix", messageId: "notice" }),
+          sessionId: "update-contact",
+          updatedAt: 1,
+          delivery: normalizeSessionDeliveryState({
+            context: {
+              channel: "matrix",
+              to: destination === "owner" ? "@owner:example.org" : "@contact:example.org",
             },
           }),
         },
-      ]),
-    );
-    mocks.sendDurableMessageBatch.mockImplementation(async (request) => {
-      await markAttempt(request);
-      return { status: "sent", results: [{ channel: "matrix", messageId: "notice" }] };
-    });
-    let run = createUpdateRun({
-      trigger: "chat",
-      before: { version: "2026.9.1" },
-      target: { version: "2026.9.2" },
-      origin: { deliveryContext: { channel: "matrix", to: "room:update" } },
-    });
-    const notify = createUpdateRunNotifier(run, {}, {});
-    await notify(run, "ack");
-    await notify(run, "ack");
-    for (const phase of ["staging", "validating", "activating"] as const) {
-      run = recordUpdateRunPhase(run.runId, phase);
+      );
+      let run = createUpdateRun({
+        trigger: destination === "control-ui" ? "control-ui" : "chat",
+        before: { version: "2026.9.1" },
+        target: { version: "2026.9.2" },
+        origin: destination === "control-ui" ? {} : { sessionKey },
+      });
+      const target = resolveUpdateRunNoticeTarget({ cfg, sessionKey: run.origin.sessionKey });
+      expect.soft(target.kind).toBe(destination === "owner" ? "route" : "none");
+      const notify = createUpdateRunNotifier(run, () => cfg, {});
+      await notify(run, "ack");
+      await notify(run, "ack");
+      for (const phase of ["staging", "validating", "activating"] as const) {
+        run = recordUpdateRunPhase(run.runId, phase);
+        await notify(run, "activating");
+      }
       await notify(run, "activating");
-    }
-    await notify(run, "activating");
-    run = recordUpdateRunPhase(run.runId, "verifying");
-    run = recordUpdateRunVerification(run.runId, { booted: true, runningVersion: "2026.9.2" });
-    const successor = createUpdateRunNotifier(run, {}, {});
-    await successor(run, "verifying");
-    await successor(run, "verifying");
-    run = finishUpdateRun(run.runId, { status: "succeeded", after: { version: "2026.9.2" } });
-    await successor(run, "finished");
-    await notify(run, "finished");
-    expect(
-      mocks.sendDurableMessageBatch.mock.calls.map(([request]) => request.payloads[0].text),
-    ).toEqual([
-      "⬆️ Updating OpenClaw 2026.9.1 → 2026.9.2. The gateway stays available while the update is validated; you'll get a message here when it finishes.",
-      "⏳ Restarting the gateway now (v2026.9.1 → v2026.9.2)…",
-      "🔁 Back on v2026.9.2, verifying…",
-      renderUpdateRunReport(run).markdown,
-    ]);
-    expect(getUpdateRun(run.runId)?.verification.noticeDelivered).toBe(true);
-    expect(mocks.recoveryDeliver).not.toHaveBeenCalled();
-  });
+      run = recordUpdateRunPhase(run.runId, "verifying");
+      run = recordUpdateRunVerification(run.runId, { booted: true, runningVersion: "2026.9.2" });
+      const successor = createUpdateRunNotifier(run, () => cfg, {});
+      await successor(run, "verifying");
+      await successor(run, "verifying");
+      run = finishUpdateRun(run.runId, { status: "succeeded", after: { version: "2026.9.2" } });
+      await successor(run, "finished");
+      await notify(run, "finished");
+      expect(
+        mocks.sendDurableMessageBatch.mock.calls.map(([request]) => request.payloads[0].text),
+      ).toEqual(
+        destination === "owner"
+          ? [
+              "⬆️ Updating OpenClaw 2026.9.1 → 2026.9.2. The gateway stays available while the update is validated; you'll get a message here when it finishes.",
+              "⏳ Restarting the gateway now (v2026.9.1 → v2026.9.2)…",
+              "🔁 Back on v2026.9.2, verifying…",
+              renderUpdateRunReport(run).markdown,
+            ]
+          : [],
+      );
+      expect(getUpdateRun(run.runId)?.verification.noticeDelivered).toBe(destination === "owner");
+      if (destination !== "owner") {
+        for (const kind of ["ack", "activating", "verifying", "finished"]) {
+          expect(
+            deliveryQueueStorage.findDeliveryIntentOwner(`update-run-${kind}:${run.runId}`),
+          ).toBeNull();
+        }
+      }
+      expect(mocks.recoveryDeliver).not.toHaveBeenCalled();
+    },
+  );
 
   it.each(["sent", "suppressed", "failed", "throw"] as const)(
     "reports %s lifecycle delivery without starting inline recovery",

--- a/src/gateway/server-restart-sentinel.test.ts
+++ b/src/gateway/server-restart-sentinel.test.ts
@@ -502,7 +502,9 @@ vi.mock("../logging/subsystem.js", async () => {
   return {
     ...actual,
     createSubsystemLogger: vi.fn((subsystem: string) =>
-      subsystem === "gateway/restart-sentinel" ? logger : actual.createSubsystemLogger(subsystem),
+      subsystem === "gateway/restart-sentinel" || subsystem === "gateway/update-run"
+        ? logger
+        : actual.createSubsystemLogger(subsystem),
     ),
   };
 });
@@ -637,6 +639,14 @@ function mockRestartContinuation(
 
 let testState: OpenClawTestState;
 
+function setNoticeOwner(owner: string) {
+  const loadSession = mocks.loadSessionEntry.getMockImplementation()!;
+  mocks.loadSessionEntry.mockImplementation((key) => {
+    const session = loadSession(key);
+    return { ...session, cfg: { ...session.cfg, commands: { ownerAllowFrom: [owner] } } };
+  });
+}
+
 describe("scheduleRestartSentinelWake", () => {
   const expectedGeneratedMediaContext: RuntimeContextFragment[] = [
     {
@@ -691,7 +701,7 @@ describe("scheduleRestartSentinelWake", () => {
     mocks.parseSessionThreadInfo.mockReturnValue({ baseSessionKey: null, threadId: undefined });
     mocks.loadSessionEntry.mockReset();
     mocks.loadSessionEntry.mockImplementation((sessionKey: string) => ({
-      cfg: {},
+      cfg: { commands: { ownerAllowFrom: ["+15550002"] } },
       agentId: "main",
       entry: { sessionId: sessionKey, updatedAt: 0 },
       store: {},
@@ -861,6 +871,50 @@ describe("scheduleRestartSentinelWake", () => {
     expect(mocks.recordInboundSessionAndDispatchReply).not.toHaveBeenCalled();
     expect(mocks.logWarn).not.toHaveBeenCalled();
   });
+
+  it.each(["update", "restart"] as const)(
+    "records a non-owner %s notice without delivery or a diagnostic wake",
+    async (kind) => {
+      const sessionKey = "agent:main:whatsapp:direct:+15550002";
+      const run =
+        kind === "update"
+          ? createUpdateRun({ trigger: "control-ui", origin: { sessionKey } })
+          : undefined;
+      const session = mocks.loadSessionEntry(sessionKey);
+      mocks.loadSessionEntry.mockReturnValue({
+        ...session,
+        cfg: { commands: { ownerAllowFrom: ["telegram:12345"] } },
+      });
+      mocks.readRestartSentinel.mockResolvedValue({
+        version: 1,
+        revision: 123,
+        payload: {
+          kind,
+          status: "ok",
+          ts: 123,
+          sessionKey,
+          deliveryContext: { channel: "whatsapp", to: "+15550002", accountId: "acct-2" },
+          ...(run ? { stats: { mode: "npm", runId: run.runId } } : {}),
+        },
+      });
+
+      await scheduleRestartSentinelWake({ deps: {} });
+
+      expect(mocks.deliverOutboundPayloads).not.toHaveBeenCalled();
+      expect(mocks.enqueueDeliveryOnce).not.toHaveBeenCalled();
+      expect(mocks.enqueueSessionDelivery).not.toHaveBeenCalled();
+      expect(mocks.requestHeartbeat).not.toHaveBeenCalled();
+      expect(mocks.appendAssistantMessageToSessionTranscript).not.toHaveBeenCalled();
+      expect(mocks.clearRestartSentinelIfRevision).toHaveBeenCalledWith(123);
+      expect(mocks.logWarn).toHaveBeenCalledWith(
+        expect.stringContaining("target is not a configured command owner"),
+        expect.objectContaining({ runId: run?.runId }),
+      );
+      if (run) {
+        expect(getUpdateRun(run.runId)?.verification.noticeDelivered).toBe(false);
+      }
+    },
+  );
 
   it.each([
     { terminal: false, channel: "webchat" },
@@ -1122,7 +1176,7 @@ describe("scheduleRestartSentinelWake", () => {
       try {
         if (updateRun) {
           const { createUpdateRunNotifier } = await import("./update-run-notice.runtime.js");
-          const ack = await createUpdateRunNotifier(updateRun, {}, {})(updateRun, "ack");
+          const ack = await createUpdateRunNotifier(updateRun, () => ({}), {})(updateRun, "ack");
           expect.soft(ack).toEqual({ delivered: true, owned: true });
           expect
             .soft(getUpdateRun(updateRun.runId)?.steps)
@@ -1288,6 +1342,7 @@ describe("scheduleRestartSentinelWake", () => {
       mocks.deliveryContextFromSession.mockReturnValue({ channel: "telegram", to: "chat-123" });
       mocks.readRestartSentinel.mockResolvedValue({ version: 1, revision: 123, payload });
       mocks.resolveOutboundTarget.mockReturnValue({ ok: true, to: "chat-123" });
+      setNoticeOwner("telegram:chat-123");
 
       await scheduleRestartSentinelWake({ deps: {} as never });
 
@@ -2781,7 +2836,7 @@ describe("scheduleRestartSentinelWake", () => {
       },
     } as Awaited<ReturnType<typeof mocks.readRestartSentinel>>);
     mocks.loadSessionEntry.mockReturnValue({
-      cfg: {},
+      cfg: { commands: { ownerAllowFrom: ["+15550002"] } },
       entry: {
         sessionId: "agent:main:main",
         updatedAt: Date.now(),
@@ -2825,7 +2880,7 @@ describe("scheduleRestartSentinelWake", () => {
 
   it("does not dispatch a queued agentTurn continuation after the session key changes", async () => {
     const activeEntry: LoadedSessionEntry = {
-      cfg: {},
+      cfg: { commands: { ownerAllowFrom: ["+15550002"] } },
       entry: {
         sessionId: "old-session-id",
         updatedAt: Date.now(),
@@ -2837,7 +2892,7 @@ describe("scheduleRestartSentinelWake", () => {
       legacyKey: undefined,
     };
     const replacementEntry: LoadedSessionEntry = {
-      cfg: {},
+      cfg: { commands: { ownerAllowFrom: ["+15550002"] } },
       entry: {
         sessionId: "new-session-id",
         updatedAt: Date.now(),
@@ -2895,7 +2950,7 @@ describe("scheduleRestartSentinelWake", () => {
       "thread-42",
     );
     mocks.loadSessionEntry.mockReturnValue({
-      cfg: {},
+      cfg: { commands: { ownerAllowFrom: ["+15550002"] } },
       entry: {
         sessionId: "agent:main:main",
         updatedAt: Date.now(),
@@ -2933,7 +2988,7 @@ describe("scheduleRestartSentinelWake", () => {
         sessionKey: "agent:main:group",
         deliveryContext: {
           channel: "telegram",
-          to: "telegram:-1001",
+          to: "-1001",
           accountId: "default",
         },
         ts: 123,
@@ -2959,7 +3014,8 @@ describe("scheduleRestartSentinelWake", () => {
       storeKeys: ["agent:main:group"],
       legacyKey: undefined,
     });
-    mocks.resolveOutboundTarget.mockReturnValue({ ok: true as const, to: "telegram:-1001" });
+    mocks.resolveOutboundTarget.mockReturnValue({ ok: true as const, to: "-1001" });
+    setNoticeOwner("-1001");
 
     await scheduleRestartSentinelWake({ deps: {} as never });
 
@@ -2971,7 +3027,7 @@ describe("scheduleRestartSentinelWake", () => {
       {
         ChatType: "group",
         OriginatingChannel: "telegram",
-        OriginatingTo: "telegram:-1001",
+        OriginatingTo: "-1001",
       },
     );
   });
@@ -3009,14 +3065,15 @@ describe("scheduleRestartSentinelWake", () => {
     });
     mocks.deliveryContextFromSession.mockReturnValue({
       channel: "telegram",
-      to: "telegram:-1003826723328:topic:13757",
+      to: "-1003826723328:topic:13757",
       accountId: "default",
       threadId: 13757,
     });
     mocks.resolveOutboundTarget.mockReturnValue({
       ok: true as const,
-      to: "telegram:-1003826723328:topic:13757",
+      to: "-1003826723328:topic:13757",
     });
+    setNoticeOwner("-1003826723328:topic:13757");
 
     await scheduleRestartSentinelWake({ deps: {} as never });
 
@@ -3041,7 +3098,7 @@ describe("scheduleRestartSentinelWake", () => {
         Surface: "webchat",
         ChatType: "group",
         OriginatingChannel: "telegram",
-        OriginatingTo: "telegram:-1003826723328:topic:13757",
+        OriginatingTo: "-1003826723328:topic:13757",
         ExplicitDeliverRoute: false,
         MessageThreadId: "13757",
       },
@@ -3114,13 +3171,14 @@ describe("scheduleRestartSentinelWake", () => {
     } as unknown as Awaited<ReturnType<typeof mocks.readRestartSentinel>>);
     mocks.deliveryContextFromSession.mockReturnValue({
       channel: "telegram",
-      to: "telegram:200482621",
+      to: "200482621",
       accountId: "default",
     });
     mocks.resolveOutboundTarget.mockReturnValue({
       ok: true as const,
-      to: "telegram:200482621",
+      to: "200482621",
     });
+    setNoticeOwner("200482621");
 
     await scheduleRestartSentinelWake({ deps: {} as never });
 
@@ -3132,7 +3190,7 @@ describe("scheduleRestartSentinelWake", () => {
       {
         Body: "continue",
         OriginatingChannel: "telegram",
-        OriginatingTo: "telegram:200482621",
+        OriginatingTo: "200482621",
       },
     );
   });
@@ -3168,32 +3226,6 @@ describe("scheduleRestartSentinelWake", () => {
       intent: "immediate",
       reason: "wake",
       sessionKey: "agent:main:main",
-    });
-  });
-
-  it("enqueues systemEvent continuation without stale partial delivery context", async () => {
-    mockRestartContinuation(
-      {
-        kind: "systemEvent",
-        text: "continue after restart",
-      },
-      "thread-42",
-    );
-    mocks.resolveOutboundTarget.mockReturnValueOnce({
-      ok: false,
-      error: new Error("missing route"),
-    });
-
-    await scheduleRestartSentinelWake({ deps: {} as never });
-
-    expect(mocks.enqueueSystemEvent).toHaveBeenNthCalledWith(2, "continue after restart", {
-      sessionKey: "agent:main:main",
-      deliveryContext: {
-        channel: "whatsapp",
-        to: "+15550002",
-        accountId: "acct-2",
-        threadId: "thread-42",
-      },
     });
   });
 
@@ -3309,26 +3341,30 @@ describe("scheduleRestartSentinelWake", () => {
     expect(mocks.requestHeartbeat).not.toHaveBeenCalled();
   });
 
-  it("falls back to a session wake when restart routing cannot resolve a destination", async () => {
-    mockRestartContinuation({
-      kind: "agentTurn",
-      message: "continue",
-    });
-    mocks.resolveOutboundTarget.mockReturnValueOnce({
-      ok: false,
-      error: new Error("missing route"),
-    });
+  it.each([
+    { kind: "agentTurn", message: "continue" },
+    { kind: "systemEvent", text: "continue" },
+  ] as const)(
+    "records an unroutable $kind notice without a diagnostic wake",
+    async (continuation) => {
+      mockRestartContinuation(continuation, "thread-42");
+      mocks.resolveOutboundTarget.mockReturnValueOnce({
+        ok: false,
+        error: new Error("missing route"),
+      });
 
-    await scheduleRestartSentinelWake({ deps: {} as never });
+      await scheduleRestartSentinelWake({ deps: {} });
 
-    expect(mocks.recordInboundSessionAndDispatchReply).not.toHaveBeenCalled();
-    expect(mockCallArg(mocks.enqueueSystemEvent, 1)).toBe("continue");
-    expectNthSystemEventFields(1, {
-      sessionKey: "agent:main:main",
-    });
-    expect(mocks.requestHeartbeat).toHaveBeenCalledTimes(2);
-    expect(mocks.logWarn).not.toHaveBeenCalled();
-  });
+      expect(mocks.enqueueDeliveryOnce).not.toHaveBeenCalled();
+      expect(mocks.enqueueSessionDelivery).not.toHaveBeenCalled();
+      expect(mocks.recordInboundSessionAndDispatchReply).not.toHaveBeenCalled();
+      expect(mocks.requestHeartbeat).not.toHaveBeenCalled();
+      expect(mocks.clearRestartSentinelIfRevision).toHaveBeenCalled();
+      expect(mocks.logWarn).toHaveBeenCalledWith("lifecycle notice skipped: no delivery target", {
+        runId: undefined,
+      });
+    },
+  );
 
   it("keeps the sentinel file when durable continuation handoff fails", async () => {
     mockRestartContinuation({
@@ -3465,6 +3501,7 @@ describe("scheduleRestartSentinelWake", () => {
       (await actualSentinel.readRestartSentinel()) as RestartSentinel,
     );
     mocks.resolveOutboundTarget.mockReturnValue({ ok: true, to: "room-77" });
+    setNoticeOwner("telegram:room-77");
     await scheduleRestartSentinelWake({ deps: {} as never });
     expect(mocks.loadSessionEntry).toHaveBeenCalledWith(sessionKey);
     expect(mocks.resolveSystemMainSessionTarget).not.toHaveBeenCalled();
@@ -3568,6 +3605,26 @@ describe("scheduleRestartSentinelWake", () => {
     expect(mocks.requestHeartbeat).toHaveBeenCalled();
   });
 
+  it("keeps a targetless Control UI update out of the ambient chat", async () => {
+    const run = createUpdateRun({ trigger: "control-ui" });
+    finishUpdateRun(run.runId, { status: "succeeded" });
+    mocks.deliveryContextFromSession.mockReturnValue({ channel: "whatsapp", to: "+15550002" });
+    mocks.readRestartSentinel.mockResolvedValue({
+      version: 1,
+      revision: 123,
+      payload: { kind: "update", status: "ok", ts: 123, stats: { runId: run.runId } },
+    });
+
+    await scheduleRestartSentinelWake({ deps: {} });
+
+    expect(mocks.enqueueDeliveryOnce).not.toHaveBeenCalled();
+    expect(mocks.enqueueSessionDelivery).not.toHaveBeenCalled();
+    expect(mocks.deliverOutboundPayloads).not.toHaveBeenCalled();
+    expect(mocks.resolveSystemMainSessionTarget).not.toHaveBeenCalled();
+    expect(mocks.clearRestartSentinelIfRevision).toHaveBeenCalledWith(123);
+    expect(getUpdateRun(run.runId)?.verification.noticeDelivered).toBe(false);
+  });
+
   it.each(["config-patch", "config-apply"] as const)(
     "consumes a targetless %s acknowledgement without waking an agent",
     async (kind) => {
@@ -3662,6 +3719,7 @@ describe("scheduleRestartSentinelWake", () => {
         mocks.deliveryContextFromSession.mockReturnValue(context);
       }
       mocks.resolveOutboundTarget.mockReturnValue({ ok: true, to: "123" });
+      setNoticeOwner("telegram:123");
       mocks.readRestartSentinel.mockResolvedValue({
         version: 1,
         revision: 123,
@@ -3864,6 +3922,7 @@ describe("scheduleRestartSentinelWake", () => {
       ok: true as const,
       to: params?.to ?? "missing",
     }));
+    setNoticeOwner("channel:qa-room");
 
     await scheduleRestartSentinelWake({ deps: {} as never });
 
@@ -3890,7 +3949,7 @@ describe("scheduleRestartSentinelWake", () => {
     });
     mocks.loadSessionEntry
       .mockReturnValueOnce({
-        cfg: {},
+        cfg: { commands: { ownerAllowFrom: ["room:!MixedCase:example.org"] } },
         entry: {
           sessionId: "agent:main:matrix:channel:!lowercased:example.org:thread:$thread-event",
           updatedAt: 0,

--- a/src/gateway/server-restart-sentinel.ts
+++ b/src/gateway/server-restart-sentinel.ts
@@ -65,7 +65,10 @@ import {
 import { finalizeRestartUpdateRun } from "./server-restart-update-run.js";
 import { loadSessionEntry } from "./session-utils.js";
 import { runStartupTasks, type StartupTask } from "./startup-tasks.js";
-import { resolveUpdateRunNoticeTarget } from "./update-run-notice-target.js";
+import {
+  recordUpdateRunNoticeSkipped,
+  resolveUpdateRunNoticeTarget,
+} from "./update-run-notice-target.js";
 
 const log = createSubsystemLogger("gateway/restart-sentinel");
 const RESTART_CONTINUATION_BUSY_RETRY_DELAY_MS = process.env.VITEST ? 1 : 6_000;
@@ -485,6 +488,15 @@ async function loadRestartSentinelStartupTask(params: {
     }
 
     if (!routedSessionKey) {
+      if (
+        updateRun?.trigger === "control-ui" &&
+        !updateRun.origin.sessionKey &&
+        !updateRun.origin.deliveryContext
+      ) {
+        recordUpdateRunNoticeSkipped(updateRun.runId, "no delivery target");
+        await clearRestartSentinelIfRevision(sentinelRevision);
+        return { status: "ran" as const };
+      }
       const targetlessCliOutcome =
         payload.kind === "update" &&
         updateRun?.trigger === "cli" &&
@@ -523,6 +535,12 @@ async function loadRestartSentinelStartupTask(params: {
       explicitDeliveryContext: sessionKey ? payload.deliveryContext : undefined,
       threadId: sessionKey ? payload.threadId : undefined,
     });
+    if (target.kind === "none") {
+      recordUpdateRunNoticeSkipped(updateRunId, target.reason);
+      // A diagnostic wake would bypass the same owner-only notice decision.
+      await clearRestartSentinelIfRevision(sentinelRevision);
+      return { status: "ran" as const };
+    }
     const route = target.kind === "route" ? target.route : undefined;
     const deliveryContext =
       normalizeDeliveryContext(route) ?? (sessionKey ? wakeDeliveryContext : undefined);

--- a/src/gateway/update-run-notice-target.ts
+++ b/src/gateway/update-run-notice-target.ts
@@ -1,7 +1,10 @@
+import { isConfiguredCommandOwner } from "../auto-reply/command-auth.js";
 import { parseSessionThreadInfo } from "../config/sessions/thread-info.js";
 import type { SessionEntry } from "../config/sessions/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { SessionDeliveryRoute } from "../infra/session-delivery-queue-storage.js";
+import { getUpdateRun, recordUpdateRunVerification } from "../infra/update-run-ledger.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
 import {
   type DeliveryContext,
   deliveryContextFromSession,
@@ -14,10 +17,28 @@ import { resolveGatewayLifecycleNoticeRoute } from "./server-restart-sentinel-no
 import { loadSessionEntry } from "./session-utils.js";
 
 type NoticeSession = ReturnType<typeof loadSessionEntry>;
+const log = createSubsystemLogger("gateway/update-run");
 type NoticeTarget =
   | { kind: "route"; route: SessionDeliveryRoute }
   | { kind: "internal"; session: NoticeSession & { entry: SessionEntry } }
-  | { kind: "none" };
+  | { kind: "none"; reason: string };
+
+export function authorizeUpdateRunNoticeTarget(
+  cfg: OpenClawConfig,
+  target: NoticeTarget,
+): NoticeTarget {
+  return target.kind === "route" &&
+    !isConfiguredCommandOwner(cfg, { ...target.route, senderId: target.route.to })
+    ? { kind: "none", reason: "target is not a configured command owner" }
+    : target;
+}
+
+export function recordUpdateRunNoticeSkipped(runId: string | undefined, reason: string): void {
+  log.warn(`lifecycle notice skipped: ${reason}`, { runId });
+  if (runId && getUpdateRun(runId)?.verification.noticeDelivered !== true) {
+    recordUpdateRunVerification(runId, { noticeDelivered: false });
+  }
+}
 
 /** Resolve the origin once; internal sessions intentionally have no external delivery context. */
 export function resolveUpdateRunNoticeTarget(params: {
@@ -48,7 +69,7 @@ export function resolveUpdateRunNoticeTarget(params: {
   ) {
     return session?.entry
       ? { kind: "internal", session: { ...session, entry: session.entry } }
-      : { kind: "none" };
+      : { kind: "none", reason: "no delivery target" };
   }
   const route = resolveGatewayLifecycleNoticeRoute({
     cfg: params.cfg,
@@ -56,5 +77,10 @@ export function resolveUpdateRunNoticeTarget(params: {
     // Ambient recovery keeps the persisted system route thread; origin keys can supply hints.
     threadId: params.threadId ?? (params.sessionKey ? threadId : undefined),
   });
-  return route ? { kind: "route", route: { ...route, chatType } } : { kind: "none" };
+  return authorizeUpdateRunNoticeTarget(
+    params.cfg,
+    route
+      ? { kind: "route", route: { ...route, chatType } }
+      : { kind: "none", reason: "no delivery target" },
+  );
 }

--- a/src/gateway/update-run-notice.runtime.ts
+++ b/src/gateway/update-run-notice.runtime.ts
@@ -11,17 +11,21 @@ import type { UpdateRunRecord } from "../infra/update-run-record.js";
 import { renderUpdateRunNotice, type UpdateRunNoticeKind } from "../infra/update-run-report.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { sendGatewayLifecycleNotice } from "./server-restart-sentinel-notice.js";
-import { resolveUpdateRunNoticeTarget } from "./update-run-notice-target.js";
+import {
+  authorizeUpdateRunNoticeTarget,
+  recordUpdateRunNoticeSkipped,
+  resolveUpdateRunNoticeTarget,
+} from "./update-run-notice-target.js";
 
 const log = createSubsystemLogger("gateway/update-run");
 
 /** Prepare routing before an update can replace lazily loaded channel modules. */
 export function createUpdateRunNotifier(
   initial: UpdateRunRecord,
-  cfg: OpenClawConfig = getRuntimeConfig(),
+  getConfig: () => OpenClawConfig = getRuntimeConfig,
   deps: CliDeps = createDefaultDeps(),
   target = resolveUpdateRunNoticeTarget({
-    cfg,
+    cfg: getConfig(),
     sessionKey: initial.origin.sessionKey,
     explicitDeliveryContext: initial.origin.deliveryContext,
     threadId: initial.origin.deliveryContext?.threadId,
@@ -43,21 +47,27 @@ export function createUpdateRunNotifier(
       if (!message || recorded) {
         return { delivered: false, owned: recorded };
       }
+      const cfg = getConfig();
+      const currentTarget = authorizeUpdateRunNoticeTarget(cfg, target);
+      if (currentTarget.kind === "none") {
+        recordUpdateRunNoticeSkipped(run.runId, currentTarget.reason);
+        return { delivered: false, owned: false };
+      }
       // Admission, the watcher, and successor startup share permanent delivery
       // ownership. A repeated phase or sentinel revision cannot send a fifth message.
       const deliveryIntentId = `update-run-${milestone}:${run.runId}`;
-      let delivered = false;
-      if (target.kind === "route") {
+      let delivered: boolean;
+      if (currentTarget.kind === "route") {
         delivered = await sendGatewayLifecycleNotice({
-          ...target.route,
+          ...currentTarget.route,
           cfg,
           deps,
           sessionKey,
           message,
           deliveryIntentId,
         });
-      } else if (target.kind === "internal") {
-        const internal = target.session;
+      } else {
+        const internal = currentTarget.session;
         const notice = await appendAssistantMessageToSessionTranscript({
           agentId: internal.agentId,
           sessionKey: internal.canonicalKey,
@@ -75,7 +85,8 @@ export function createUpdateRunNotifier(
       if (delivered && kind === "finished") {
         recordUpdateRunVerification(run.runId, { noticeDelivered: true });
       }
-      const custody = target.kind === "route" ? findDeliveryIntentOwner(deliveryIntentId) : null;
+      const custody =
+        currentTarget.kind === "route" ? findDeliveryIntentOwner(deliveryIntentId) : null;
       const owned = delivered || custody?.status === "pending" || custody?.status === "completed";
       if (owned && kind !== "finished") {
         recordUpdateRunStep(run.runId, {

--- a/src/gateway/update-run-notice.test.ts
+++ b/src/gateway/update-run-notice.test.ts
@@ -37,7 +37,7 @@ describe("host-owned update notices", () => {
         updatedAt: 1,
       });
       const run = createUpdateRun({ trigger: "chat", origin: { sessionKey: target.sessionKey } });
-      const notify = createUpdateRunNotifier(run, {}, {});
+      const notify = createUpdateRunNotifier(run, () => ({}), {});
       if (replaced) {
         await upsertSessionEntryCore(target, {
           sessionId: target.sessionId,


### PR DESCRIPTION
Fixes #145998

Reported by @adembektas (#145998).

## What Problem This Solves

Fixes an issue where operators updating OpenClaw could send progress and failure diagnostics to an ordinary chat contact when the run inherited that contact's session. The Control UI passes its selected session to `update.run`, and restart recovery could also turn a failed notice route into a diagnostic session wake.

## Why This Change Was Made

The shared notice-target owner now checks the resolved destination with `isConfiguredCommandOwner`, the same predicate used for chat update execution. The notifier checks current configuration again before queuing each milestone. A rejected or missing target records `noticeDelivered: false` and a warning containing the run ID and reason; restart recovery consumes that notice without a diagnostic wake or continuation to the rejected session. Targetless Control UI runs stay in the run record instead of borrowing the system session's chat.

This is a **security-posture tightening to owner-only external notices**. Destinations that cannot be matched to `commands.ownerAllowFrom`, including group/channel destinations or opaque DM addresses that do not identify a configured owner, lose these notices. Maintainers should object if that is not the intended policy. Internal transcript/Control UI reports and the notice text remain unchanged. No configuration options, dependencies, schema, update-driver, or retention changes.

## User Impact

Update and restart notices are delivered only to configured owners; other sessions never receive them. Selecting a non-owner conversation does not prevent an authorized operator update. Its outcome remains available through the run record and Control UI.

## Evidence

Focused tests exercise the real target resolver/notifier and SQLite notice queue, the `update.run` handler, restart sentinel recovery, and restart verification:

```sh
node scripts/run-vitest.mjs src/gateway/update-run-notice.test.ts src/gateway/server-restart-sentinel-notice.test.ts src/gateway/server-restart-sentinel.test.ts src/gateway/server-restart-update-run.test.ts src/gateway/server-methods/update.test.ts src/gateway/server-methods/update-owner.test.ts src/gateway/server-methods/update-chat-permission.test.ts
# Test Files 7 passed; Tests 220 passed
```

The final regression cases were run with only the four production-file changes reversed, then with that same patch reapplied:

```sh
node scripts/run-vitest.mjs src/gateway/server-restart-sentinel-notice.test.ts src/gateway/server-restart-sentinel.test.ts src/gateway/server-methods/update.test.ts src/gateway/server-methods/update-owner.test.ts -t 'four update milestones|non-owner|unroutable|targetless Control UI|rechecks after awaited acknowledgement'
# Before: 11 failed | 1 passed (the configured-owner case)
# After:  12 passed
```

Before repair, the non-owner received all four milestone messages, both sentinel cases delivered to the contact, missing-route continuations woke the session, the targetless Control UI run queued an ambient-chat notice, and owner revocation still allowed the final diagnostic. After repair, those sends/wakes are absent and non-delivery is recorded. The configured-owner sequence remains unchanged.

The required `node scripts/check-changed.mjs` completed with exit 0, including production/test types, lint, dead exports, import cycles, and policy guards. An initial line-limit and redundant-assignment lint failure was fixed without changing limits or suppressions. `git diff --check` is clean.

`node scripts/watch-pr-ci.mjs 146079 81a3b663dede372a0422a5542e059011485417ae` returned `GREEN`. [CI run 34701093926](https://github.com/openclaw/openclaw/actions/runs/34701093926) completed successfully on that exact head. No CI job repair or manual rerun was needed.

### Origin trace and the idle-UI question

Source checked at main snapshot `f2d96c8c5231e5fee41c6c11cf45a8b816870af1`:

- Chat: `/update` forwards the command session at `src/auto-reply/reply/commands-update.ts:21-29`; `src/agents/harness/host-capability.ts:209-218` supplies the admitted attempt's session/route; `src/agents/tools/gateway-tool.ts:156-176` forwards it.
- Control UI: `ui/src/app/bootstrap.ts:286` supplies the selected session; `ui/src/app/overlays-updates.ts:512,540-542` sends it with `update.run`. The handler resolves the destination at `src/gateway/server-methods/update.ts:123-128` before the requester execution gate at `175-183`.
- Automatic campaign: `src/infra/update-startup.ts:794-804` creates only `{ campaignId }`. Manual campaign adoption retains the UI/chat origin (`src/gateway/server-methods/update.ts:277-313`).
- Restart: `src/infra/update-restart-sentinel-payload.ts:68-70` carries the origin, and `src/gateway/server-restart-sentinel.ts:510-528,570-584` previously resolved ambient delivery or fell back to a diagnostic wake.

No idle-browser update trigger was found. Reconnect/events/polling refresh status or existing runs (`ui/src/app/overlays-updates.ts:435-489`). The native fallback requires a previously requested native update. Independently enabled Gateway auto-update campaigns can apply on their countdown (`src/infra/update-startup.ts:1027-1039`, `src/infra/update-campaign.ts:203-242`). Reporter logs/configuration are still needed to attribute their actual trigger.

### Known gaps

No live WhatsApp/Telegram delivery or published-driver installation replay was run; this repair changes candidate notice routing, not update execution. Existing durable outbound entries admitted before this policy are not rewritten; their recovery remains with the existing queue owner. Direct replies to explicitly requested chat commands retain command authorization; this change gates lifecycle notification dispatch and its restart-wake fallback. The lead performs autoreview and decides whether to land.


### ClawSweeper review

Reviewed head: `81a3b663dede372a0422a5542e059011485417ae`. No code fixups applied. The landing decision accepts the documented owner-only routing policy, including suppression of unsupported destinations and rejected restart continuations. Skipped queue-wide revocation changes: this repair checks current owners at target resolution and before each milestone; it does not add final-transport revocation or change durable queue recovery. Notices already admitted can therefore outlive a later owner change. The scoped review found no actionable P0/P1 defect in this diff. Live-channel/final-transport revocation proof and a published-driver installation replay remain explicit gaps; the accepted evidence is the focused before/after regression suite and green exact-head CI. No re-review requested because code is unchanged.
