### PR TITLE
fix(matrix): prevent selected Docker build import failures

### DIFF
--- a/extensions/matrix/src/matrix/actions/client.test.ts
+++ b/extensions/matrix/src/matrix/actions/client.test.ts
@@ -37,6 +37,41 @@ let withResolvedActionClient: typeof import("./client.js").withResolvedActionCli
 let withResolvedRoomAction: typeof import("./client.js").withResolvedRoomAction;
 let withStartedActionClient: typeof import("./client.js").withStartedActionClient;
 
+describe("action client lazy loading", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.doUnmock("../client-bootstrap.js");
+    vi.resetModules();
+  });
+
+  it("defers bootstrap evaluation until action work starts", async () => {
+    const evaluateBootstrap = vi.fn(async () =>
+      vi.importActual<typeof import("../client-bootstrap.js")>("../client-bootstrap.js"),
+    );
+    vi.doMock("../client-bootstrap.js", evaluateBootstrap);
+
+    const { withResolvedActionClient: runAction } = await import("./client.js");
+    expect(evaluateBootstrap).not.toHaveBeenCalled();
+
+    const client = createMockMatrixClient();
+    const run = vi.fn(async () => "first result");
+    await expect(runAction({ client }, run)).resolves.toBe("first result");
+    expect(run).toHaveBeenCalledWith(client, undefined);
+    expect(evaluateBootstrap).toHaveBeenCalledTimes(1);
+
+    const failure = new Error("action failed");
+    await expect(
+      runAction({ client }, async () => {
+        throw failure;
+      }),
+    ).rejects.toBe(failure);
+    expect(evaluateBootstrap).toHaveBeenCalledTimes(1);
+  });
+});
+
 describe("action client helpers", () => {
   beforeAll(async () => {
     ({ withResolvedActionClient, withResolvedRoomAction, withStartedActionClient } =

--- a/extensions/matrix/src/matrix/actions/client.ts
+++ b/extensions/matrix/src/matrix/actions/client.ts
@@ -1,15 +1,20 @@
 // Matrix plugin module implements client behavior.
-import { withResolvedRuntimeMatrixClient } from "../client-bootstrap.js";
+import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 import { resolveMatrixRoomId } from "../send.js";
 import type { MatrixActionClient, MatrixActionClientOpts } from "./types.js";
 
 type MatrixActionClientStopMode = "stop" | "persist" | "discard";
+
+const loadMatrixActionClientRuntime = createLazyRuntimeModule(
+  () => import("../client-bootstrap.js"),
+);
 
 export async function withResolvedActionClient<T>(
   opts: MatrixActionClientOpts,
   run: (client: MatrixActionClient["client"], abortSignal?: AbortSignal) => Promise<T>,
   mode: MatrixActionClientStopMode = "stop",
 ): Promise<T> {
+  const { withResolvedRuntimeMatrixClient } = await loadMatrixActionClientRuntime();
   return await withResolvedRuntimeMatrixClient(opts, run, mode);
 }
 

--- a/extensions/matrix/src/matrix/client.test.ts
+++ b/extensions/matrix/src/matrix/client.test.ts
@@ -93,6 +93,52 @@ function expectMatrixLoginCall(fields: Record<string, unknown>) {
   expectRecordFields(requireRecord(call[3], "Matrix login body"), fields);
 }
 
+describe("client constructor lazy loading", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.doUnmock("./client/create-client.js");
+    vi.resetModules();
+  });
+
+  it("defers constructor module evaluation and forwards each creation independently", async () => {
+    const firstClient = { id: "first client" };
+    const secondClient = { id: "second client" };
+    const failure = new Error("creation failed");
+    const createClient = vi
+      .fn()
+      .mockResolvedValueOnce(firstClient)
+      .mockResolvedValueOnce(secondClient)
+      .mockRejectedValueOnce(failure);
+    const evaluateConstructor = vi.fn(() => ({ createMatrixClient: createClient }));
+    vi.doMock("./client/create-client.js", evaluateConstructor);
+
+    const { createMatrixClient } = await import("./client.js");
+    expect(evaluateConstructor).not.toHaveBeenCalled();
+
+    const options = {
+      homeserver: "https://matrix.example.org",
+      accessToken: "synthetic-token",
+      accountId: "ops",
+      persistStorage: false,
+      encryption: true,
+      localTimeoutMs: 1234,
+    };
+    await expect(createMatrixClient(options)).resolves.toBe(firstClient);
+    const secondOptions = { ...options, accountId: "other" };
+    await expect(createMatrixClient(secondOptions)).resolves.toBe(secondClient);
+    await expect(createMatrixClient(options)).rejects.toBe(failure);
+
+    expect(createClient).toHaveBeenCalledTimes(3);
+    expect(createClient).toHaveBeenNthCalledWith(1, options);
+    expect(createClient).toHaveBeenNthCalledWith(2, secondOptions);
+    expect(createClient).toHaveBeenNthCalledWith(3, options);
+    expect(evaluateConstructor).toHaveBeenCalledTimes(1);
+  });
+});
+
 describe("resolveMatrixAuth", () => {
   beforeEach(() => {
     vi.mocked(credentialsReadModule.loadMatrixCredentials).mockReset();

--- a/extensions/matrix/src/matrix/client.ts
+++ b/extensions/matrix/src/matrix/client.ts
@@ -1,4 +1,6 @@
 // Matrix plugin module implements client behavior.
+import { createLazyRuntimeMethod, createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
+
 export type { MatrixAuth } from "./client/types.js";
 export { getMatrixScopedEnvVarNames } from "../env-vars.js";
 export {
@@ -12,7 +14,12 @@ export {
   resolveValidatedMatrixHomeserverUrl,
   validateMatrixHomeserverUrl,
 } from "./client/config.js";
-export { createMatrixClient } from "./client/create-client.js";
+const loadMatrixClientRuntime = createLazyRuntimeModule(() => import("./client/create-client.js"));
+
+export const createMatrixClient = createLazyRuntimeMethod(
+  loadMatrixClientRuntime,
+  (runtime) => runtime.createMatrixClient,
+);
 export { acquireSharedMatrixClient, stopSharedClientForAccount } from "./client/shared.js";
 export type {
   MatrixClientLeaseRole,


### PR DESCRIPTION
Fixes https://github.com/openclaw/openclaw/issues/146080

<details>
<summary>Additional instructions</summary>

This is a same-repository maintainer branch; maintainers retain normal repository edit permissions.

</details>

## What Problem This Solves

Resolves a problem where Matrix-enabled selected Docker source builds fail before image preparation can finish.

Investigation trigger: https://github.com/openclaw/openclaw/actions/runs/34647517330/job/103422565940

## Why This Change Was Made

Defer the action bootstrap and client constructor modules until their asynchronous entry points are called. The existing lazy-runtime helpers cache module loading, not client instances or operation results.

The build warning guard, plugin selection, shared-client lifecycle, authentication exports, readiness, abort handling and release modes remain unchanged.

## User Impact

Selected source builds that include Matrix can complete without the two ineffective dynamic-import failures. This change does not alter Matrix account configuration or introduce a new runtime option.

## Evidence

- On the unchanged base, the real selected `pnpm build:docker` emitted both Matrix `INEFFECTIVE_DYNAMIC_IMPORT` diagnostics and exited 1 through the existing fatal guard. The same command completed with exit 0 after the repair.
- Both cold-import regressions failed before the production fix because the deferred dependency was evaluated during owner import. They now pass, including independent constructor results, option forwarding and rejection propagation.
- Both complete owner files and seven related bootstrap, constructor, shared-client, send and probe sibling files: 204/204 tests passed before a mechanical local-name correction. The affected complete action owner then passed 11/11 again.
- The initial changed-file check found a test-local shadowed name. Aliasing that import, without changing production or assertions, resolved the four-file lint check with zero warnings/errors.
- All selected changed-file gates completed successfully, combining the initial passing checks, the targeted lint retry and the four previously unrun guards. Extension production/test typechecks passed; no gate was skipped or weakened.
- Independent scoped review found no actionable correctness issues.
- Exact-head CI passed for `437cfd7f9c16c870ae20af04c1e6c284e6d2c6a7`: https://github.com/openclaw/openclaw/actions/runs/34701317942, including the required `openclaw/ci-gate`.

Exact build selection:

```sh
OPENCLAW_INTERNAL_DOCKER_BUILD_PLUGIN_IDS=acpx,anthropic,deepseek,fireworks,google,matrix,minimax,moonshot,openai,opencode-go,openrouter,xai,zai \
OPENCLAW_RUN_NODE_SKIP_DTS_BUILD=1 pnpm build:docker
```

This is source-build and mocked owner/sibling proof, not Docker execution, live Matrix validation, full release qualification or a startup-performance measurement. Raw failure logs remain private.

### Hosted Review Input Qualification

The earlier automated review stopped at input safety without producing a review verdict. An unchanged Matrix negative test intentionally checks rejection of a URL containing embedded credentials. Its exact host-side fixture qualification landed separately in https://github.com/openclaw/clawsweeper/pull/1549 at `1853caed03ed1175b38412520c3a1f927e4674c3`; this Matrix branch remains unchanged.

The original hosted scan reported two findings, but retained detail identified only the first. The original second finding has not been recovered or retrospectively cleared. The qualification is not a waiver: the normal re-review must use the landed host policy, freshly scan the entire current input before model execution, and refuse any remaining unqualified finding. A completed review must bind this current head and final PR body.
