### PR TITLE
improve: make large file edits faster

### DIFF
--- a/src/agents/sessions/tools/edit-diff.test.ts
+++ b/src/agents/sessions/tools/edit-diff.test.ts
@@ -244,18 +244,22 @@ describe("fuzzy edit source-span mapping", () => {
     expect(result.finalContent).toBe("const value = 2;\r\nnext\r\n");
   });
 
-  it("keeps exact and fuzzy replacements in original coordinates", () => {
-    const result = applyEditsPreservingLineEndings(
-      "const a\u00A0= 1;\nconst b = 2;\n",
-      [
+  it.each(["fuzzy first", "exact first"])(
+    "keeps mixed replacements in original coordinates with %s",
+    (order) => {
+      const edits = [
         { oldText: "const a = 1;", newText: "const a = 3;" },
         { oldText: "const b = 2;", newText: "const b = 4;" },
-      ],
-      "test.ts",
-    );
+      ];
+      const result = applyEditsPreservingLineEndings(
+        "const a\u00A0= 1;\nconst b = 2;\n",
+        order === "exact first" ? edits.toReversed() : edits,
+        "test.ts",
+      );
 
-    expect(result.finalContent).toBe("const a = 3;\nconst b = 4;\n");
-  });
+      expect(result.finalContent).toBe("const a = 3;\nconst b = 4;\n");
+    },
+  );
 });
 
 describe("applyEditsToNormalizedContent fuzzy uniqueness", () => {

--- a/src/agents/sessions/tools/edit-diff.ts
+++ b/src/agents/sessions/tools/edit-diff.ts
@@ -17,9 +17,9 @@ import { resolveLocalPathToCwd, resolveToCwd } from "./path-utils.js";
 
 interface FuzzyBoundary {
   /** Original offset when the normalized boundary begins a replacement. */
-  start?: number;
+  readonly start?: number;
   /** Original offset when the normalized boundary ends a replacement. */
-  end?: number;
+  readonly end?: number;
 }
 
 interface FuzzyNormalizedFile {
@@ -118,7 +118,7 @@ function buildFuzzyBoundaries(
     for (let offset = sourceLineStart; offset <= keptLineEnd; offset++) {
       const boundary = nfkcBoundaries[offset];
       if (boundary) {
-        boundaries[normalizedLineStart + offset - sourceLineStart] = { ...boundary };
+        boundaries[normalizedLineStart + offset - sourceLineStart] = boundary;
       }
     }
 
@@ -137,7 +137,7 @@ function buildFuzzyBoundaries(
     }
 
     const afterNewline = nfkcBoundaries[sourceLineEnd + 1];
-    boundaries[normalizedLineEnd + 1] = afterNewline ? { ...afterNewline } : undefined;
+    boundaries[normalizedLineEnd + 1] = afterNewline;
     normalizedLineStart = normalizedLineEnd + 1;
     sourceLineStart = sourceLineEnd + 1;
   }

--- a/src/agents/sessions/tools/edit-diff.ts
+++ b/src/agents/sessions/tools/edit-diff.ts
@@ -278,8 +278,7 @@ export function stripBom(content: string): { bom: string; text: string } {
     : { bom: "", text: content };
 }
 
-function countOccurrences(content: string, oldText: string): number {
-  const fuzzyContent = normalizeForFuzzyMatch(content);
+function countOccurrences(fuzzyContent: string, oldText: string): number {
   const fuzzyOldText = normalizeForFuzzyMatch(oldText);
   if (!fuzzyOldText) {
     return 0;
@@ -490,7 +489,7 @@ function getUnsafeFuzzyBoundaryError(path: string, editIndex: number, totalEdits
  * Apply one or more exact-text replacements to LF-normalized content.
  *
  * All edits are matched against the same original content. Replacements are
- * then applied in reverse order so offsets remain stable. Fuzzy matching is
+ * assembled from original spans so offsets remain stable. Fuzzy matching is
  * lookup-only: replacements always splice into the original content.
  */
 function applyEdits(normalizedContent: string, edits: Edit[], path: string): AppliedEdits {
@@ -516,9 +515,10 @@ function applyEdits(normalizedContent: string, edits: Edit[], path: string): App
   const matchedEdits: MatchedEdit[] = [];
   for (const [i, edit] of normalizedEdits.entries()) {
     const matchResult = fuzzyFindText(normalizedContent, edit.oldText, fuzzyFile);
-    const occurrences = matchResult.usedFuzzyMatch
-      ? countOccurrences(normalizedContent, edit.oldText)
-      : countExactOccurrences(replacementBaseContent, edit.oldText);
+    const occurrences =
+      fuzzyFile && matchResult.usedFuzzyMatch
+        ? countOccurrences(fuzzyFile.text, edit.oldText)
+        : countExactOccurrences(replacementBaseContent, edit.oldText);
     if (occurrences > 1) {
       throw getDuplicateError(path, i, normalizedEdits.length, occurrences);
     }

--- a/src/agents/sessions/tools/edit-diff.ts
+++ b/src/agents/sessions/tools/edit-diff.ts
@@ -24,7 +24,7 @@ interface FuzzyBoundary {
 
 interface FuzzyNormalizedFile {
   text: string;
-  boundaries: Array<FuzzyBoundary | undefined>;
+  boundaries: Array<FuzzyBoundary | undefined> | undefined;
 }
 
 const fuzzyGraphemeSegmenter = new Intl.Segmenter("en", { granularity: "grapheme" });
@@ -95,7 +95,10 @@ function buildNfkcBoundaries(
   return boundaries;
 }
 
-function buildFuzzyNormalizedFile(text: string): FuzzyNormalizedFile | undefined {
+function buildFuzzyBoundaries(
+  text: string,
+  normalizedText: string,
+): FuzzyNormalizedFile["boundaries"] {
   const authoritativeNfkc = text.normalize("NFKC");
   const nfkcBoundaries = buildNfkcBoundaries(text, authoritativeNfkc);
   if (!nfkcBoundaries) {
@@ -139,11 +142,10 @@ function buildFuzzyNormalizedFile(text: string): FuzzyNormalizedFile | undefined
     sourceLineStart = sourceLineEnd + 1;
   }
 
-  const normalizedText = normalizeForFuzzyMatch(text);
   if (boundaries.length > normalizedText.length + 1) {
     return undefined;
   }
-  return { text: normalizedText, boundaries };
+  return boundaries;
 }
 
 function translateFuzzySpan(
@@ -152,8 +154,8 @@ function translateFuzzySpan(
   fuzzyLength: number,
 ): { originalStart: number; originalLength: number } | undefined {
   const fuzzyEnd = fuzzyStart + fuzzyLength;
-  const originalStart = normalized.boundaries[fuzzyStart]?.start;
-  const originalEnd = normalized.boundaries[fuzzyEnd]?.end;
+  const originalStart = normalized.boundaries?.[fuzzyStart]?.start;
+  const originalEnd = normalized.boundaries?.[fuzzyEnd]?.end;
   if (originalStart === undefined || originalEnd === undefined) {
     return undefined;
   }
@@ -244,6 +246,10 @@ function fuzzyFindText(
     };
   }
 
+  // Source boundaries matter only after normalized text actually matches.
+  if (normalizedFile && !normalizedFile.boundaries) {
+    normalizedFile.boundaries = buildFuzzyBoundaries(content, normalizedFile.text);
+  }
   const translated = normalizedFile
     ? translateFuzzySpan(normalizedFile, fuzzyIndex, fuzzyOldText.length)
     : undefined;
@@ -502,7 +508,9 @@ function applyEdits(normalizedContent: string, edits: Edit[], path: string): App
   const needsFuzzyMapping = normalizedEdits.some(
     (edit) => !normalizedContent.includes(edit.oldText),
   );
-  const fuzzyFile = needsFuzzyMapping ? buildFuzzyNormalizedFile(normalizedContent) : undefined;
+  const fuzzyFile: FuzzyNormalizedFile | undefined = needsFuzzyMapping
+    ? { text: normalizeForFuzzyMatch(normalizedContent), boundaries: undefined }
+    : undefined;
   const replacementBaseContent = normalizedContent;
 
   const matchedEdits: MatchedEdit[] = [];

--- a/src/agents/sessions/tools/edit-replacements.ts
+++ b/src/agents/sessions/tools/edit-replacements.ts
@@ -33,9 +33,22 @@ function getLineSpans(content: string): LineSpan[] {
 function getReplacementLineRange(lines: LineSpan[], replacement: TextReplacement) {
   const replacementStart = replacement.matchIndex;
   const replacementEnd = replacement.matchIndex + replacement.matchLength;
-  const startLine = lines.findIndex(
-    (line) => replacementStart >= line.start && replacementStart < line.end,
-  );
+  let lower = 0;
+  let upper = lines.length;
+  while (lower < upper) {
+    const middle = Math.floor((lower + upper) / 2);
+    const line = lines[middle];
+    if (!line) {
+      throw new Error("Replacement range is outside the base content.");
+    }
+    if (line.end <= replacementStart) {
+      lower = middle + 1;
+    } else {
+      upper = middle;
+    }
+  }
+  const firstLine = lines[lower];
+  const startLine = firstLine && replacementStart >= firstLine.start ? lower : -1;
   if (startLine === -1) {
     throw new Error("Replacement range is outside the base content.");
   }
@@ -59,15 +72,15 @@ export function applyReplacements(
   replacements: TextReplacement[],
   offset = 0,
 ): string {
-  let result = content;
-  for (const replacement of replacements.toReversed()) {
+  const parts: string[] = [];
+  let cursor = 0;
+  for (const replacement of replacements) {
     const matchIndex = replacement.matchIndex - offset;
-    result =
-      result.slice(0, matchIndex) +
-      replacement.newText +
-      result.slice(matchIndex + replacement.matchLength);
+    parts.push(content.slice(cursor, matchIndex), replacement.newText);
+    cursor = matchIndex + replacement.matchLength;
   }
-  return result;
+  parts.push(content.slice(cursor));
+  return parts.join("");
 }
 
 function groupReplacementsByLine(


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

Large file edits spend unnecessary time preparing Unicode mappings, recounting normalized matches, and assembling multiple replacements. Even a request whose text is absent can wait for a full source-position map before preview or execution reports the error.

## Why This Change Was Made

Prepare normalized text once, build source boundaries only after a fuzzy match exists, and reuse immutable completed boundary records and normalized text when validating subsequent edits. Assemble replacements from the original spans in one pass and locate their starting lines with binary search; matching, error precedence, original coordinates, line endings, and persisted-file verification keep their existing contracts.

## User Impact

Missing edits return sooner, and large batches of fuzzy, Unicode, or exact edits do less repeated work. Files retain untouched bytes and original line endings, and invalid or ambiguous edits still fail before any write.

## Evidence

The final source passed 82 focused tests across edit matching, execution, and formatting; the repository core tsgo lane; formatting; and git diff --check. Fresh independent P2 review of the entire PR, including the complete final candidate, completed cleanly.

The actual computeEditsDiff preview and createEditToolDefinition(...).execute entry points matched the original in 56 parity cases per runtime, plus eight source-range cases including NaN, Infinity, negative/EOF starts, invalid ranges, and empty input. Coverage includes normalized-empty and duplicate-before-unsafe errors, NFKC expansions, combining sequences, multiple replacements, no-ops, mixed line endings, BOM, returned diffs/errors, write counts, and final bytes. All 32 final timing cells also checked parity.

Final original → combined medians, **milliseconds**, for approximately 1 MiB files:

| Edits / target | Node 24 preview | Node 24 execution | Node 26 preview | Node 26 execution |
| --- | --- | --- | --- | --- |
| 1 / fuzzy match | 386.88 → 319.77 | 383.66 → 322.83 | 364.11 → 268.12 | 373.23 → 296.04 |
| 1 / exact match | 25.60 → 26.94 | 53.22 → 54.82 | 23.14 → 23.19 | 44.10 → 45.64 |
| 1 / Unicode match | 330.58 → 273.76 | 379.56 → 312.34 | 374.93 → 280.36 | 390.93 → 297.99 |
| 1 / last target absent | 292.11 → 11.62 | 295.08 → 12.95 | 337.00 → 10.44 | 355.88 → 11.63 |
| 50 / fuzzy match | 669.22 → 318.45 | 733.10 → 360.42 | 644.16 → 283.86 | 693.96 → 322.59 |
| 50 / exact match | 53.50 → 43.76 | 104.49 → 79.83 | 46.68 → 40.62 | 84.61 → 71.77 |
| 50 / Unicode match | 761.61 → 311.46 | 746.88 → 302.76 | 717.55 → 282.01 | 846.80 → 367.98 |
| 50 / last target absent | 587.83 → 261.07 | 588.83 → 273.32 | 650.73 → 296.62 | 587.19 → 283.22 |

Both runtimes use the same synthetic in-memory filesystem fixtures. Requested fixture size is 1,048,576; actual lengths range from 1,048,050 to 1,048,575 UTF-16 code units depending on target shape and count, and UTF-8 lengths are recorded separately. Fuzzy targets fold nonbreaking spaces; Unicode targets also include combining sequences and NFKC expansions. For a missing target in a batch, the last edit is absent after validating its earlier siblings; no write occurs.

Method: Node 24.19.0 / V8 13.6 and Node 26.8.2 / V8 14.6, five warmups per variant, nine alternating before/after rounds, GC outside timed samples, full wall/CPU samples retained. Host: Windows 11, Ryzen AI MAX+ 395, 16 cores/32 threads, 64 GiB RAM. Imports, disk, and network latency are excluded. Shared-host contention widens some ranges, so these are fixture measurements, not a universal speedup claim.

Observed slower final controls: Node 24, 1 exact edit, preview: 25.60 → 26.94 ms (+1.34 ms); Node 24, 1 exact edit, execute: 53.22 → 54.82 ms (+1.61 ms); Node 26, 1 exact edit, preview: 23.14 → 23.19 ms (+0.06 ms); Node 26, 1 exact edit, execute: 44.10 → 45.64 ms (+1.55 ms). Earlier small-fixture and incremental measurements also varied in both directions.

Incremental attribution used separate preserved baselines and fixtures: preparing fuzzy counts once improved 50-edit fuzzy cases by about 1.6–2.0×; adding replacement joining and binary line lookup improved 50-edit exact cases by about 1.12–1.26×. Fresh batched single-edit join controls measured an additional 0.59 ms execution time on Node 24 and 0.09 ms on Node 26. These increments are not multiplied into the final table.

Memory evidence is limited to those incremental comparisons, **not combined original-to-final RSS**. For count reuse alone, two fresh 50-fuzzy-edit processes per variant/runtime measured peak RSS of 638–641 → 649–714 MiB on Node 24, and 636–703 → 530–575 MiB on Node 26. For additional joining/searching with 50 exact edits, peaks were 326 → 305 MiB and 297–298 → 249–259 MiB respectively. Processes ran in before/after/after/before order and loaded only the selected variant; peaks include imports and warmups. Different fixtures and baselines prevent a combined RSS or retained-heap reduction claim.

CI recovery: earlier test-root-cap drift was fixed by rebasing. The subsequent unchanged 50d884 head failed four Gateway alias command-selection cases outside this diff; the same two files in their original order passed locally (32 tests). Root cause remains unproven, and no unrelated test or cache workaround was added. The optional Linux probe was not run without exact dependencies. The final head bd6f3cd4 passed [hosted CI](https://github.com/openclaw/openclaw/actions/runs/34710100140): 114 successful jobs, including the required openclaw/ci-gate, with 17 intentionally skipped. Fresh ClawSweeper review also found no actionable issues. Native maintainer gates own landing; no full local changed-gate pass is claimed.
