### PR TITLE
improve: prepare MCP prompt names without rendering tool APIs

### DIFF
--- a/src/agents/code-mode-namespaces.test.ts
+++ b/src/agents/code-mode-namespaces.test.ts
@@ -35,6 +35,30 @@ function mcpCatalogEntry(params: {
 }
 
 describe("Code Mode MCP namespace model", () => {
+  it("describes server names without inspecting tool parameter schemas", () => {
+    const readProperties = vi.fn(() => ({ query: { type: "string" } }));
+    const catalog = [
+      mcpCatalogEntry({
+        id: "github__read_file",
+        parameters: {
+          type: "object",
+          get properties() {
+            return readProperties();
+          },
+        },
+      }),
+    ];
+
+    expect(describeCodeModeNamespacesForPrompt(catalog)).toContain("visible servers: github.");
+    expect(readProperties).not.toHaveBeenCalled();
+    expect(
+      createCodeModeNamespaceRuntime(catalog).apiFiles.find(
+        (file) => file.path === "mcp/github.d.ts",
+      )?.content,
+    ).toContain("query?: string");
+    expect(readProperties).toHaveBeenCalled();
+  });
+
   it("keeps run-owned namespace descriptors and virtual API files in sync", async () => {
     const catalog = [
       mcpCatalogEntry({

--- a/src/agents/code-mode-namespaces.ts
+++ b/src/agents/code-mode-namespaces.ts
@@ -333,9 +333,8 @@ function mcpNodeLabel(node: NonNullable<McpNamespaceServer["node"]>): string {
   return truncateUtf16Safe((node.displayName?.trim() || node.id).replace(/\s+/gu, " "), 128);
 }
 
-function createMcpNamespaceModel(
-  catalog: readonly CodeModeNamespaceCatalogEntry[],
-): McpNamespaceModel | undefined {
+// Prompt preparation needs the same server names without building tool scopes or schema docs.
+function createMcpNamespacePlan(catalog: readonly CodeModeNamespaceCatalogEntry[]) {
   const mcpEntries = catalog
     .filter((entry) => entry.source === "mcp" && entry.id && entry.mcp)
     .toSorted((a, b) => (a.id ?? "").localeCompare(b.id ?? ""));
@@ -360,26 +359,37 @@ function createMcpNamespaceModel(
   }
   const servers = [...serversByKey.values()].toSorted((a, b) => a.key.localeCompare(b.key));
   const assignedServerNames = assignMcpNamespaceServerNames(servers);
-  const serverIdentifiers = new Map<string, string>();
+  const namedServers = new Map<string, McpNamespaceServer & { identifier: string }>();
   const usedServerIdentifiers = new Set<string>();
   for (const server of servers) {
     const safeServerName = assignedServerNames.get(server.key) ?? server.safeServerName;
-    serverIdentifiers.set(
-      server.key,
-      uniqueIdentifier(toIdentifier(safeServerName, "server"), usedServerIdentifiers),
-    );
+    namedServers.set(server.key, {
+      ...server,
+      identifier: uniqueIdentifier(toIdentifier(safeServerName, "server"), usedServerIdentifiers),
+    });
+  }
+  return { entries: mcpEntries, servers: namedServers, usedServerIdentifiers };
+}
+
+function createMcpNamespaceModel(
+  catalog: readonly CodeModeNamespaceCatalogEntry[],
+): McpNamespaceModel | undefined {
+  const plan = createMcpNamespacePlan(catalog);
+  if (!plan) {
+    return undefined;
   }
   const usedToolIdentifiers = new Map<string, Set<string>>();
   const root = Object.create(null) as CodeModeNamespaceScope;
   const serverDocs = new Map<string, McpApiServerDoc>();
-  for (const entry of mcpEntries) {
+  for (const entry of plan.entries) {
     const mcp = entry.mcp;
     if (!mcp || !entry.id) {
       continue;
     }
     const serverKey = mcpNamespaceServerKey(mcp);
     const serverIdentifier =
-      serverIdentifiers.get(serverKey) ?? uniqueIdentifier("server", usedServerIdentifiers);
+      plan.servers.get(serverKey)?.identifier ??
+      uniqueIdentifier("server", plan.usedServerIdentifiers);
     const serverScope = scopeAtPath(root, [serverIdentifier]);
     serverScope.$serverName = mcp.serverName;
     let serverDoc = serverDocs.get(serverIdentifier);
@@ -490,13 +500,16 @@ function createMcpNamespaceEntry(model: McpNamespaceModel): CodeModeNamespaceRun
 function describeMcpNamespaceForPrompt(
   catalog: readonly CodeModeNamespaceCatalogEntry[],
 ): string[] {
-  const model = createMcpNamespaceModel(catalog);
-  if (!model) {
+  const plan = createMcpNamespacePlan(catalog);
+  if (!plan) {
     return [];
   }
-  const servers = model.docs.map(
-    (server) => `${server.identifier}${server.nodeLabel ? ` (node: ${server.nodeLabel})` : ""}`,
-  );
+  const servers = [...plan.servers.values()]
+    .toSorted((a, b) => a.identifier.localeCompare(b.identifier))
+    .map((server) => {
+      const nodeLabel = server.node ? mcpNodeLabel(server.node) : undefined;
+      return `${server.identifier}${nodeLabel ? ` (node: ${nodeLabel})` : ""}`;
+    });
   if (servers.length === 0) {
     return [];
   }


### PR DESCRIPTION
## What Problem This Solves

Preparing the Code Mode prompt for an MCP catalog builds tool scopes and recursively renders parameter documentation merely to list the available servers. Large catalogs repeat this unused work whenever the catalog refreshes.

## Why This Change Was Made

Share the existing server grouping and naming plan between prompt preparation and runtime construction. Prompt preparation consumes the server names directly; runtime construction still prepares callable tools and their API documentation.

## User Impact

Code Mode catalog preparation and refresh become faster, with identical prompt text, server names, callable namespaces, and generated API files.

## Evidence

- 49 focused tests passed across namespaces, registered MCP tools, QuickJS execution, and node plugin tools.
- Actual catalog preparation matched full prompt bytes and every runtime API file across small and large catalogs, nested schemas, collisions, restrictions, and refreshes.
- The regression proves that prompt preparation does not inspect tool parameter schemas while runtime documentation still includes them.
- Independent review completed cleanly against the final source.
- Required hosted CI passed at the reviewed head `562b3186c7d84717a38d788cc1721e7f3d67a657`. Local focused proof passed; broad gates used hosted CI.

Actual catalog operations, median seconds per operation:

| Synthetic catalog / operation | Node 24.19.0 before → after | Node 26.8.2 before → after |
| --- | ---: | ---: |
| 2,000 simple-schema tools / apply | 0.037938 → 0.020034 | 0.022745 → 0.014080 |
| 2,000 nested-schema tools / apply | 0.192308 → 0.021175 | 0.120167 → 0.015737 |
| 2,000 nested-schema tools / refresh | 0.155214 → 0.002471 | 0.100464 → 0.002041 |

The full matrix includes 0, 2, 100, 500, and 2,000 tools with simple and nested schemas. Two-tool cases improve on both runtimes. Empty-catalog refresh is unchanged; empty apply is approximately 9.8 → 9.6 microseconds on Node 24 and 9.7 → 10.7 microseconds on Node 26. That small absolute control cost is included rather than claiming every case improves.

Measurements ran on Windows 11 / AMD Ryzen AI MAX+ 395, using 15 warmup operations per variant and nine alternating before/after rounds, with 1,000 operations per small-catalog sample, 100 at 100 tools, and 10 at larger sizes. Full prompt bytes, namespace descriptors, and every runtime API file match, including twelve name-collision/order rotations, restriction, and rebinding. Synthetic nested schemas contain twelve array parameters with eight object fields each.

Fresh-process memory proof used before/after/after/before ordering per runtime, each running an initial apply plus 20 repeated applies over 2,000 nested-schema tools. Peak RSS was inconclusive: Node 24 measured 576–608 MiB before versus 603–645 MiB after; Node 26 measured 534–542 MiB before versus 520–542 MiB after. Cold-import working sets varied substantially, so this PR makes no claim of lower peak RSS. Observed heap-used growth from the post-import/preparation checkpoint to the post-work snapshot fell from 125–254 MiB to about 41 MiB on Node 24, and from about 222 MiB to 12 MiB on Node 26. These are heap snapshots without a final collection, not retained-heap or total-allocation measurements. The two runtimes' memory-only sequences ran concurrently; their elapsed times are excluded from latency evidence.

The performance harness runs actual Code Mode catalog application and refresh using synthetic MCP catalogs. It checks complete prompt text and runtime API files. Timings measure catalog preparation, excluding MCP server/network latency.
