### PR TITLE
fix(gateway): honor actions.sendMessage for update lifecycle notices

### DIFF
--- a/docs/install/updating.md
+++ b/docs/install/updating.md
@@ -219,6 +219,11 @@ logs the skipped notice and keeps the update outcome in the run record and
 Control UI; it does not redirect the notice to another chat or wake the rejected
 session with diagnostics.
 
+Update lifecycle notices also honor the destination account's `actions.sendMessage`
+policy. An explicit account setting overrides the channel default; when neither
+sets the flag, notices are allowed. Disabled sends are recorded as skipped notices
+without preventing the update or its Control UI report.
+
 Managed systemd or launchd updates can stop the Gateway before an intermediate
 notice is delivered. The complete four-message sequence is not guaranteed for
 those installations; the durable run report remains available after reconnect.

--- a/src/gateway/server-methods/update.test-harness.ts
+++ b/src/gateway/server-methods/update.test-harness.ts
@@ -1,11 +1,13 @@
 import { spawn } from "node:child_process";
 import fs from "node:fs/promises";
 import path from "node:path";
+import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, beforeAll, beforeEach, expect, vi } from "vitest";
 import type { ConfigFileSnapshot, OpenClawConfig } from "../../config/types.openclaw.js";
 import type { RestartSentinelPayload } from "../../infra/restart-sentinel.js";
 import type { RespawnSupervisor } from "../../infra/supervisor-markers.js";
 import type { UpdateChannel } from "../../infra/update-channels.js";
+import { getUpdateRun } from "../../infra/update-run-ledger.js";
 import { createTempHomeEnv, type TempHomeEnv } from "../../test-utils/temp-home.js";
 
 let ledgerHome: TempHomeEnv | undefined;
@@ -460,3 +462,71 @@ beforeEach(() => {
     reason: "not-git-update",
   });
 });
+
+export async function invokeUpdateRun(
+  params: Record<string, unknown>,
+  respond?: (ok: boolean, response?: unknown) => void,
+  runtimeConfig: OpenClawConfig = {
+    update: {},
+    commands: { ownerAllowFrom: ["slack:C0123ABC", "slack:C0456DEF"] },
+  },
+) {
+  const { updateHandlers } = await import("./update.js");
+  const onRespond = respond ?? (() => {});
+  await expectDefined(
+    updateHandlers["update.run"],
+    'updateHandlers["update.run"] test invariant',
+  )({
+    params,
+    respond: onRespond as never,
+    context: { getRuntimeConfig: () => runtimeConfig },
+  } as never);
+}
+
+export async function captureUpdateRunPayload(
+  params: Record<string, unknown> = {},
+  runtimeConfig?: OpenClawConfig,
+): Promise<UpdateRunPayload | undefined> {
+  let payload: UpdateRunPayload | undefined;
+  await invokeUpdateRun(
+    params,
+    (_ok: boolean, response: unknown) => {
+      payload = response as UpdateRunPayload;
+    },
+    runtimeConfig,
+  );
+  if (
+    payload?.result?.status &&
+    payload.result.status !== "ok" &&
+    payload.handoff?.status !== "started"
+  ) {
+    expect(getUpdateRun(payload.runId)).toMatchObject({
+      status: payload.result.status === "skipped" ? "skipped" : "failed",
+      phase: "finished",
+      reason: payload.result.reason,
+    });
+  }
+  return payload;
+}
+
+export function mockGlobalInstallSurface() {
+  initializeGatewayUpdateStatusMock.mockResolvedValueOnce({
+    root: "/tmp/openclaw-global",
+    status: { root: "/tmp/openclaw-global", installKind: "package", packageManager: "npm" },
+    installReceipt: null,
+  });
+  resolveUpdateInstallSurfaceMock.mockResolvedValueOnce({
+    kind: "global",
+    mode: "npm",
+    root: "/tmp/openclaw-global",
+    packageRoot: "/tmp/openclaw-global",
+  });
+}
+
+export function mockGitInstallSurface(root: string) {
+  initializeGatewayUpdateStatusMock.mockResolvedValueOnce({
+    root,
+    status: { root, installKind: "git", packageManager: "pnpm" },
+    installReceipt: null,
+  });
+}

--- a/src/gateway/server-methods/update.test.ts
+++ b/src/gateway/server-methods/update.test.ts
@@ -135,6 +135,24 @@ describe("update.run acknowledgement", () => {
       verification: { noticeDelivered: false },
     });
   });
+  it("keeps update notices off channels with actions.sendMessage disabled", async () => {
+    // The lifecycle-notice path is an outbound send: a channel configured with
+    // actions.sendMessage=false must not receive update notices even when the
+    // selected chat is a configured command owner.
+    const response = await captureUpdateRunPayload(
+      { sessionKey },
+      {
+        update: {},
+        commands: { ownerAllowFrom: ["slack:C0123ABC", "slack:C0456DEF"] },
+        channels: { slack: { actions: { sendMessage: false } } },
+      },
+    );
+    expect(response).toMatchObject({ ok: true, ackDelivered: false, ackQueued: false });
+    expect(sendGatewayLifecycleNoticeMock).not.toHaveBeenCalled();
+    expect(getUpdateRun(expectDefined(response, "update response").runId)).toMatchObject({
+      verification: { noticeDelivered: false },
+    });
+  });
 
   it.each([false, true])(
     "awaits the chat acknowledgement before updating (managed=%s)",

--- a/src/gateway/server-methods/update.test.ts
+++ b/src/gateway/server-methods/update.test.ts
@@ -25,8 +25,6 @@ import {
   withTransferredUpdateHandoff,
   runGatewayUpdateMock,
   runGatewayUpdatePreflightMock,
-  resolveUpdateInstallSurfaceMock,
-  initializeGatewayUpdateStatusMock,
   recordLatestUpdateRestartSentinelMock,
   isRestartEnabledMock,
   detectRespawnSupervisorMock,
@@ -41,82 +39,17 @@ import {
   resolveGatewayLifecycleNoticeRouteMock,
   scheduleGatewaySigusr1RestartMock,
   runPostCoreFinalizeAfterGatewayUpdateMock,
-  type UpdateRunPayload,
+  invokeUpdateRun,
+  captureUpdateRunPayload,
+  mockGlobalInstallSurface,
+  mockGitInstallSurface,
 } from "./update.test-harness.js";
-
-async function invokeUpdateRun(
-  params: Record<string, unknown>,
-  respond?: (ok: boolean, response?: unknown) => void,
-  runtimeConfig: OpenClawConfig = {
-    update: {},
-    commands: { ownerAllowFrom: ["slack:C0123ABC", "slack:C0456DEF"] },
-  },
-) {
-  const { updateHandlers } = await import("./update.js");
-  const onRespond = respond ?? (() => {});
-  await expectDefined(
-    updateHandlers["update.run"],
-    'updateHandlers["update.run"] test invariant',
-  )({
-    params,
-    respond: onRespond as never,
-    context: { getRuntimeConfig: () => runtimeConfig },
-  } as never);
-}
-
-async function captureUpdateRunPayload(
-  params: Record<string, unknown> = {},
-  runtimeConfig?: OpenClawConfig,
-): Promise<UpdateRunPayload | undefined> {
-  let payload: UpdateRunPayload | undefined;
-  await invokeUpdateRun(
-    params,
-    (_ok: boolean, response: unknown) => {
-      payload = response as UpdateRunPayload;
-    },
-    runtimeConfig,
-  );
-  if (
-    payload?.result?.status &&
-    payload.result.status !== "ok" &&
-    payload.handoff?.status !== "started"
-  ) {
-    expect(getUpdateRun(payload.runId)).toMatchObject({
-      status: payload.result.status === "skipped" ? "skipped" : "failed",
-      phase: "finished",
-      reason: payload.result.reason,
-    });
-  }
-  return payload;
-}
 
 function readCapturedPayload(): RestartSentinelPayload {
   if (!sentinelState.capturedPayload) {
     throw new Error("expected restart sentinel payload");
   }
   return sentinelState.capturedPayload;
-}
-
-function mockGlobalInstallSurface() {
-  initializeGatewayUpdateStatusMock.mockResolvedValueOnce({
-    root: "/tmp/openclaw-global",
-    status: { root: "/tmp/openclaw-global", installKind: "package", packageManager: "npm" },
-    installReceipt: null,
-  });
-  resolveUpdateInstallSurfaceMock.mockResolvedValueOnce({
-    kind: "global",
-    mode: "npm",
-    root: "/tmp/openclaw-global",
-    packageRoot: "/tmp/openclaw-global",
-  });
-}
-
-function mockGitInstallSurface(root: string) {
-  initializeGatewayUpdateStatusMock.mockResolvedValueOnce({
-    root,
-    status: { root, installKind: "git", packageManager: "pnpm" },
-    installReceipt: null,
-  });
 }
 
 describe("update.run acknowledgement", () => {
@@ -135,39 +68,65 @@ describe("update.run acknowledgement", () => {
       verification: { noticeDelivered: false },
     });
   });
-  it("keeps update notices off channels with actions.sendMessage disabled", async () => {
-    // The lifecycle-notice path is an outbound send: a channel configured with
-    // actions.sendMessage=false must not receive update notices even when the
-    // selected chat is a configured command owner.
+  it.each([
+    {
+      name: "channel disabled",
+      base: false,
+      account: undefined,
+      accountId: "work",
+      allowed: false,
+    },
+    { name: "account enabled", base: false, account: true, accountId: "work", allowed: true },
+    { name: "account disabled", base: true, account: false, accountId: "work", allowed: false },
+    { name: "unset", base: undefined, account: undefined, accountId: "work", allowed: true },
+    {
+      name: "default account enabled",
+      base: false,
+      account: true,
+      accountId: undefined,
+      allowed: true,
+    },
+    {
+      name: "default account disabled",
+      base: true,
+      account: false,
+      accountId: undefined,
+      allowed: false,
+    },
+  ])("honors update notice send policy ($name)", async ({ base, account, accountId, allowed }) => {
     const sessions = await import("../../config/sessions.js");
-    vi.mocked(sessions.extractDeliveryInfo).mockImplementationOnce(() => ({
-      deliveryContext: { channel: "telegram", to: "12345" },
+    vi.mocked(sessions.extractDeliveryInfo).mockReturnValueOnce({
+      deliveryContext: { channel: "telegram", to: "12345", accountId },
       threadId: undefined,
-    }));
-    resolveGatewayLifecycleNoticeRouteMock.mockImplementationOnce(
-      ({ deliveryContext, threadId }) =>
-        deliveryContext?.channel === "telegram" && deliveryContext.to
-          ? {
-              ...deliveryContext,
-              channel: "telegram",
-              to: deliveryContext.to,
-              threadId,
-            }
-          : undefined,
-    );
+    });
+    resolveGatewayLifecycleNoticeRouteMock.mockReturnValueOnce({
+      channel: "telegram",
+      to: "12345",
+      accountId,
+      threadId: undefined,
+    });
     const response = await captureUpdateRunPayload(
       { sessionKey: "agent:main:telegram:dm:12345" },
       {
         update: {},
         commands: { ownerAllowFrom: ["telegram:12345"] },
-        channels: { telegram: { actions: { sendMessage: false } } },
+        channels: {
+          telegram: {
+            actions: { sendMessage: base },
+            defaultAccount: "work",
+            accounts: { work: { actions: { sendMessage: account } } },
+          },
+        },
       },
     );
-    expect(response).toMatchObject({ ok: true, ackDelivered: false, ackQueued: false });
-    expect(sendGatewayLifecycleNoticeMock).not.toHaveBeenCalled();
-    expect(getUpdateRun(expectDefined(response, "update response").runId)).toMatchObject({
-      verification: { noticeDelivered: false },
-    });
+    expect(response).toMatchObject({ ok: true, ackDelivered: allowed, ackQueued: allowed });
+    expect(runGatewayUpdateMock).toHaveBeenCalledOnce();
+    expect(sendGatewayLifecycleNoticeMock).toHaveBeenCalledTimes(allowed ? 2 : 0);
+    if (!allowed) {
+      expect(getUpdateRun(expectDefined(response, "update response").runId)).toMatchObject({
+        verification: { noticeDelivered: false },
+      });
+    }
   });
 
   it.each([false, true])(

--- a/src/gateway/server-methods/update.test.ts
+++ b/src/gateway/server-methods/update.test.ts
@@ -139,12 +139,28 @@ describe("update.run acknowledgement", () => {
     // The lifecycle-notice path is an outbound send: a channel configured with
     // actions.sendMessage=false must not receive update notices even when the
     // selected chat is a configured command owner.
+    const sessions = await import("../../config/sessions.js");
+    vi.mocked(sessions.extractDeliveryInfo).mockImplementationOnce(() => ({
+      deliveryContext: { channel: "telegram", to: "12345" },
+      threadId: undefined,
+    }));
+    resolveGatewayLifecycleNoticeRouteMock.mockImplementationOnce(
+      ({ deliveryContext, threadId }) =>
+        deliveryContext?.channel === "telegram" && deliveryContext.to
+          ? {
+              ...deliveryContext,
+              channel: "telegram",
+              to: deliveryContext.to,
+              threadId,
+            }
+          : undefined,
+    );
     const response = await captureUpdateRunPayload(
-      { sessionKey },
+      { sessionKey: "agent:main:telegram:dm:12345" },
       {
         update: {},
-        commands: { ownerAllowFrom: ["slack:C0123ABC", "slack:C0456DEF"] },
-        channels: { slack: { actions: { sendMessage: false } } },
+        commands: { ownerAllowFrom: ["telegram:12345"] },
+        channels: { telegram: { actions: { sendMessage: false } } },
       },
     );
     expect(response).toMatchObject({ ok: true, ackDelivered: false, ackQueued: false });

--- a/src/gateway/update-run-notice-target.ts
+++ b/src/gateway/update-run-notice-target.ts
@@ -1,10 +1,16 @@
+import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
 import { isConfiguredCommandOwner } from "../auto-reply/command-auth.js";
+import { createAccountActionGate } from "../channels/plugins/account-action-gate.js";
+import { resolveChannelDefaultAccountId } from "../channels/plugins/helpers.js";
+import { getChannelPlugin } from "../channels/plugins/index.js";
 import { parseSessionThreadInfo } from "../config/sessions/thread-info.js";
 import type { SessionEntry } from "../config/sessions/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { SessionDeliveryRoute } from "../infra/session-delivery-queue-storage.js";
 import { getUpdateRun, recordUpdateRunVerification } from "../infra/update-run-ledger.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
+import { resolveChannelAccountEntry } from "../routing/account-lookup.js";
+import { normalizeAccountId } from "../routing/session-key.js";
 import {
   type DeliveryContext,
   deliveryContextFromSession,
@@ -23,23 +29,40 @@ type NoticeTarget =
   | { kind: "internal"; session: NoticeSession & { entry: SessionEntry } }
   | { kind: "none"; reason: string };
 
-function isChannelUpdateNoticeSendDisabled(cfg: OpenClawConfig, channel: string): boolean {
-  // SAFETY: channel config blocks are provider-discriminated; this read only
-  // inspects the optional per-channel actions.sendMessage flag.
-  const channels = cfg.channels as
-    | Record<string, { actions?: { sendMessage?: boolean } } | undefined>
-    | undefined;
-  return channels?.[channel]?.actions?.sendMessage === false;
+function isUpdateNoticeSendEnabled(cfg: OpenClawConfig, route: SessionDeliveryRoute): boolean {
+  const channel = asOptionalRecord(cfg.channels?.[route.channel]);
+  const plugin = route.accountId ? undefined : getChannelPlugin(route.channel);
+  const accountId = normalizeAccountId(
+    route.accountId ?? (plugin ? resolveChannelDefaultAccountId({ plugin, cfg }) : undefined),
+  );
+  const account = asOptionalRecord(
+    resolveChannelAccountEntry(
+      asOptionalRecord(channel?.accounts),
+      accountId,
+      route.channel,
+      normalizeAccountId,
+    ),
+  );
+  const baseSendMessage = asOptionalRecord(channel?.actions)?.sendMessage;
+  const accountSendMessage = asOptionalRecord(account?.actions)?.sendMessage;
+  return createAccountActionGate({
+    baseActions: {
+      sendMessage: typeof baseSendMessage === "boolean" ? baseSendMessage : undefined,
+    },
+    accountActions: {
+      sendMessage: typeof accountSendMessage === "boolean" ? accountSendMessage : undefined,
+    },
+  })("sendMessage");
 }
 
 export function authorizeUpdateRunNoticeTarget(
   cfg: OpenClawConfig,
   target: NoticeTarget,
 ): NoticeTarget {
-  if (target.kind === "route" && isChannelUpdateNoticeSendDisabled(cfg, target.route.channel)) {
+  if (target.kind === "route" && !isUpdateNoticeSendEnabled(cfg, target.route)) {
     return {
       kind: "none",
-      reason: `channel ${target.route.channel} has actions.sendMessage disabled; update lifecycle notices are outbound sends`,
+      reason: `update lifecycle notices are disabled by ${target.route.channel} actions.sendMessage policy`,
     };
   }
   return target.kind === "route" &&

--- a/src/gateway/update-run-notice-target.ts
+++ b/src/gateway/update-run-notice-target.ts
@@ -23,10 +23,25 @@ type NoticeTarget =
   | { kind: "internal"; session: NoticeSession & { entry: SessionEntry } }
   | { kind: "none"; reason: string };
 
+function isChannelUpdateNoticeSendDisabled(cfg: OpenClawConfig, channel: string): boolean {
+  // SAFETY: channel config blocks are provider-discriminated; this read only
+  // inspects the optional per-channel actions.sendMessage flag.
+  const channels = cfg.channels as
+    | Record<string, { actions?: { sendMessage?: boolean } } | undefined>
+    | undefined;
+  return channels?.[channel]?.actions?.sendMessage === false;
+}
+
 export function authorizeUpdateRunNoticeTarget(
   cfg: OpenClawConfig,
   target: NoticeTarget,
 ): NoticeTarget {
+  if (target.kind === "route" && isChannelUpdateNoticeSendDisabled(cfg, target.route.channel)) {
+    return {
+      kind: "none",
+      reason: `channel ${target.route.channel} has actions.sendMessage disabled; update lifecycle notices are outbound sends`,
+    };
+  }
   return target.kind === "route" &&
     !isConfiguredCommandOwner(cfg, { ...target.route, senderId: target.route.to })
     ? { kind: "none", reason: "target is not a configured command owner" }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where update lifecycle notices reached owner-approved chats even when the destination disabled `actions.sendMessage`. The initial channel-only check also suppressed notices for accounts that explicitly enabled sending over a disabled channel default, and allowed notices for accounts that explicitly disabled sending.

Related: #145998. This is a focused follow-up to #146079.

## Why This Change Was Made

The shared update notice-target authorizer now uses `createAccountActionGate` for account-first send-policy precedence. Omitted route accounts use the channel plugin's default-account resolver, and account lookup retains the channel's key policy. The configured-owner gate remains the rule for destination eligibility and is rechecked before each lifecycle notice.

The production cast was removed through record and boolean narrowing. RPC setup helpers moved into the existing test harness to satisfy the test-file line limit without removing assertions.

## User Impact

Update lifecycle notices honor the destination account's `actions.sendMessage` policy. Explicit account settings override channel defaults; unset flags allow notices. Refused notices are recorded without preventing the update or its Control UI report. No configuration options or persistence contracts changed.

## Evidence

- New table-driven `update.run` regressions cover channel-disabled, account-enabled, account-disabled, unset, configured-default-account-enabled, and configured-default-account-disabled policies.
- Before the fix, the four account-override cases failed in the expected directions; inherited-disabled and unset cases passed.
- `node scripts/run-vitest.mjs src/gateway/server-methods/update.test.ts src/gateway/update-run-notice.test.ts`: 57 tests passed.
- `node --import ./scripts/tsx.mjs scripts/check-assertion-safety-ratchet.mts --base origin/main`: passed.
- Focused oxlint on the changed TypeScript files: passed.
- `node scripts/check-changed.mjs`: passed, including core and test typechecks, focused lint, formatting, ratchets, and boundary guards.
- Maintainer fixup autoreview: scoped-clean at P1.
- Exact-head CI run [34712852005](https://github.com/openclaw/openclaw/actions/runs/34712852005) has an unrelated failure in [checks-node-changed-extensions-config-53](https://github.com/openclaw/openclaw/actions/runs/34712852005/job/103604819421): the QA scenario `control-ui-health-status-models` still names the old Debug diagnostics test. The tested main parent `e14b3ddac2e5ea9dbb450057b7436c22a012a89b` renamed that test to `renders Gateway diagnostics and current work independently of session history` without updating the scenario. This PR changes neither the scenario nor its target or validation test. No rerun was requested.
- Boundary proof uses synthetic configuration and mocked channel delivery. Live Telegram and published-driver upgrade proof were not run in this fixup.

## ClawSweeper review

Addressed the account-override finding for explicit and configured default accounts using the shared policy resolver. No finding was dismissed. Live transport and published-driver evidence remain the limitations above.

Contributor commits by @eleqtrizit (Agustin Rivera) are preserved, with contributor credit in the maintainer fixup.
