### PR TITLE
fix(whatsapp): keep healthy idle connections open

### DIFF
--- a/extensions/whatsapp/src/auto-reply.web-auto-reply.connection-and-logging.e2e.test.ts
+++ b/extensions/whatsapp/src/auto-reply.web-auto-reply.connection-and-logging.e2e.test.ts
@@ -636,6 +636,9 @@ describe("web auto-reply connection", () => {
       seedInbound: true,
       captureStatus: true,
       cleanupWithoutError: true,
+      options: {
+        transportTimeoutMs: 30,
+      },
       exercise: async ({ scripted }) => {
         await vi.advanceTimersByTimeAsync(200);
         await Promise.resolve();
@@ -689,14 +692,15 @@ describe("web auto-reply connection", () => {
       },
     },
     {
-      name: "does not let transport frames mask application silence forever",
+      name: "keeps fresh idle sessions open while transport frames continue",
+      cleanupWithoutError: true,
       exercise: async ({ scripted }) => {
         const socket = getLastWebAutoReplySessionSocket();
         for (let elapsedMs = 0; elapsedMs < 140; elapsedMs += 20) {
           socket.ws.emit("frame");
           await vi.advanceTimersByTimeAsync(20);
         }
-        await waitForScriptedListeners(scripted, 2, true);
+        expect(scripted.getListenerCount()).toBe(1);
       },
     },
     {

--- a/extensions/whatsapp/src/connection-controller.test.ts
+++ b/extensions/whatsapp/src/connection-controller.test.ts
@@ -1006,9 +1006,7 @@ describe("WhatsAppConnectionController", () => {
     }
   });
 
-  it("uses messageTimeoutMs * 4 as the app-silence window for fresh connections with no inbound", async () => {
-    // Verifies the watchdog respects appSilenceTimeoutMs = messageTimeoutMs * 4 on first open.
-    // Transport is kept well within its own timeout so only app-silence fires.
+  it("keeps idle chats connected while websocket frames remain active", async () => {
     vi.useFakeTimers();
     const msgTimeoutMs = 100;
     const controllerLocal = new WhatsAppConnectionController({
@@ -1017,7 +1015,7 @@ describe("WhatsAppConnectionController", () => {
       verbose: false,
       keepAlive: true,
       heartbeatSeconds: 1,
-      transportTimeoutMs: 10_000,
+      transportTimeoutMs: 100,
       messageTimeoutMs: msgTimeoutMs,
       watchdogCheckMs: 10,
       reconnectPolicy: {
@@ -1036,18 +1034,17 @@ describe("WhatsAppConnectionController", () => {
 
       const timeouts: string[] = [];
       await controllerLocal.openConnection({
-        connectionId: "conn-app-silence",
+        connectionId: "conn-idle-with-transport",
         createListener: async () => createListenerStub() as never,
         onWatchdogTimeout: () => timeouts.push("timeout"),
       });
 
-      // Just before messageTimeoutMs * 4 — no force-close expected
-      await vi.advanceTimersByTimeAsync(msgTimeoutMs * 4 - 20);
-      expect(timeouts).toHaveLength(0);
+      for (let elapsed = 0; elapsed < msgTimeoutMs * 8; elapsed += 80) {
+        await vi.advanceTimersByTimeAsync(80);
+        sock.ws.emit("frame");
+      }
 
-      // Past messageTimeoutMs * 4 — force-close must fire
-      await vi.advanceTimersByTimeAsync(40);
-      expect(timeouts.length).toBeGreaterThanOrEqual(1);
+      expect(timeouts).toHaveLength(0);
     } finally {
       await controllerLocal.shutdown();
       vi.useRealTimers();

--- a/extensions/whatsapp/src/connection-controller.ts
+++ b/extensions/whatsapp/src/connection-controller.ts
@@ -456,6 +456,7 @@ export class WhatsAppConnectionController {
   private readonly heartbeatSeconds: number;
   private readonly keepAlive: boolean;
   private readonly transportTimeoutMs: number;
+  private readonly messageTimeoutMs: number;
   private readonly appSilenceTimeoutMs: number;
   private readonly watchdogCheckMs: number;
   private readonly verbose: boolean;
@@ -501,6 +502,7 @@ export class WhatsAppConnectionController {
     this.keepAlive = params.keepAlive;
     this.heartbeatSeconds = params.heartbeatSeconds;
     this.transportTimeoutMs = params.transportTimeoutMs;
+    this.messageTimeoutMs = params.messageTimeoutMs;
     this.appSilenceTimeoutMs = params.messageTimeoutMs * 4;
     this.watchdogCheckMs = params.watchdogCheckMs;
     this.reconnectPolicy = params.reconnectPolicy;
@@ -1060,7 +1062,10 @@ export class WhatsAppConnectionController {
     connection.watchdogTimer = setInterval(() => {
       const now = Date.now();
       const transportStaleForMs = now - connection.lastTransportActivityAt;
-      if (transportStaleForMs <= this.transportTimeoutMs) {
+      const appBaselineAt = connection.lastInboundAt ?? connection.startedAt;
+      const appDeliveryStalledAfterReconnect =
+        connection.openedAfterRecentInbound && now - appBaselineAt > this.messageTimeoutMs;
+      if (transportStaleForMs <= this.transportTimeoutMs && !appDeliveryStalledAfterReconnect) {
         return;
       }
       const snapshot = this.getCurrentSnapshot(connection);

--- a/extensions/whatsapp/src/connection-controller.ts
+++ b/extensions/whatsapp/src/connection-controller.ts
@@ -456,7 +456,6 @@ export class WhatsAppConnectionController {
   private readonly heartbeatSeconds: number;
   private readonly keepAlive: boolean;
   private readonly transportTimeoutMs: number;
-  private readonly messageTimeoutMs: number;
   private readonly appSilenceTimeoutMs: number;
   private readonly watchdogCheckMs: number;
   private readonly verbose: boolean;
@@ -502,7 +501,6 @@ export class WhatsAppConnectionController {
     this.keepAlive = params.keepAlive;
     this.heartbeatSeconds = params.heartbeatSeconds;
     this.transportTimeoutMs = params.transportTimeoutMs;
-    this.messageTimeoutMs = params.messageTimeoutMs;
     this.appSilenceTimeoutMs = params.messageTimeoutMs * 4;
     this.watchdogCheckMs = params.watchdogCheckMs;
     this.reconnectPolicy = params.reconnectPolicy;
@@ -1062,12 +1060,7 @@ export class WhatsAppConnectionController {
     connection.watchdogTimer = setInterval(() => {
       const now = Date.now();
       const transportStaleForMs = now - connection.lastTransportActivityAt;
-      const appBaselineAt = connection.lastInboundAt ?? connection.startedAt;
-      const appSilentForMs = now - appBaselineAt;
-      const appSilenceTimeoutMs = connection.openedAfterRecentInbound
-        ? this.messageTimeoutMs
-        : this.appSilenceTimeoutMs;
-      if (transportStaleForMs <= this.transportTimeoutMs && appSilentForMs <= appSilenceTimeoutMs) {
+      if (transportStaleForMs <= this.transportTimeoutMs) {
         return;
       }
       const snapshot = this.getCurrentSnapshot(connection);


### PR DESCRIPTION
Closes #146065

## What Problem This Solves

Fixes an issue where WhatsApp users with a healthy but quiet connection would experience forced status-499 reconnects after the application-level inbound silence window elapsed, even while websocket transport frames continued to arrive.

## Why This Change Was Made

Fresh healthy connections now stay open while transport frames prove the websocket is alive. The shorter application-delivery recovery path remains active after a reconnect that follows recent inbound activity, so continuing protocol frames cannot mask a post-408 listener stall indefinitely.

## User Impact

Idle WhatsApp connections no longer churn solely because the chat is quiet. Truly stalled transports still trigger the existing watchdog recovery, and a recently active connection that reconnects but stops delivering application messages still gets a bounded recovery attempt.

## Review Follow-up

- Restored post-reconnect application-delivery recovery for `openedAfterRecentInbound` connections.
- Kept fresh idle sessions transport-driven, which is the reported status-499 false-positive case.
- Preserved transport-stall recovery unchanged.
- Added/updated production-path E2E coverage for all three cases, including the existing post-408 listener-stall scenario.

## Evidence

- Focused controller suite: 30 tests passed.
- Full WhatsApp extension suite: 104 files, 1,415 tests passed.
- `pnpm check:changed` passed, including extension/test typechecks, lint, dead-export scan, database-first guard, and import-cycle check.

The repository autoreview helper could not start because the standalone `codex` executable is not installed on the test host; its bundle preflight succeeded and the final diff was reviewed manually.

Real linked-account proof for the combined policy is still pending; the evidence above is repository integration/E2E proof and is not presented as a production Baileys capture.
