### PR TITLE
fix(update): avoid rejecting equivalent systemd unit names

### DIFF
--- a/docs/cli/update/how-updates-run.md
+++ b/docs/cli/update/how-updates-run.md
@@ -48,6 +48,11 @@ reported cause, then run the warning's exact cleanup command or
 that cannot boot or pass readiness still block completion. See
 [Status and history](/cli/update/status-and-history) to inspect recorded warnings.
 
+Linux service checks treat an implicit systemd unit name and its explicit
+installed name as the same selection, including names with or without the
+`.service` suffix. The updater still rechecks service ownership before stopping
+the Gateway.
+
 The baseline package fingerprint is best effort. If its bounded scan times out,
 the update records a warning and continues with the retained package copy.
 Rollback then verifies the restored directory identity, package version, and

--- a/src/daemon/service-operation-lock.test.ts
+++ b/src/daemon/service-operation-lock.test.ts
@@ -1,10 +1,13 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { setImmediate } from "node:timers/promises";
+import { filterStringRecord } from "@openclaw/normalization-core/record-coerce";
 import { afterEach, expect, it, vi } from "vitest";
 import { createDeferred } from "../../test/helpers/promise.js";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import * as temporaryState from "../infra/tmp-openclaw-dir.js";
+import { mergeGatewayServiceEnv } from "./service-env-merge.js";
+import { buildServiceEnvironment } from "./service-env.js";
 import {
   withGatewayServiceOperationLock,
   withSystemdServiceReadBinding,
@@ -176,6 +179,34 @@ it("retains one read binding across nested operations and closes after the outer
   });
   expect(create).toHaveBeenCalledTimes(1);
   expect(binding.close).toHaveBeenCalledTimes(1);
+});
+
+it.each([
+  { profile: undefined, bound: false },
+  { profile: undefined, bound: true },
+  { profile: "personal", bound: false },
+  { profile: "personal", bound: true },
+])("reuses service inspection after loading the installed environment: %j", async (scenario) => {
+  const env = { ...(await fixture()), OPENCLAW_PROFILE: scenario.profile };
+  vi.spyOn(process, "platform", "get").mockReturnValue("linux");
+  const binding = scenario.bound ? readBinding() : undefined;
+  const create = vi.fn(async () => binding);
+  const serviceEnv = mergeGatewayServiceEnv(env, {
+    programArguments: [process.execPath, "/opt/openclaw/openclaw.mjs", "gateway"],
+    environment: filterStringRecord(
+      buildServiceEnvironment({ env, port: 18789, platform: "linux" }),
+    ),
+  });
+  await withGatewayServiceOperationLock(env, async () => {
+    await withSystemdServiceReadBinding(env, create, async () => {});
+    await withSystemdServiceReadBinding(serviceEnv, create, async (retained) => {
+      expect(retained).toBe(binding);
+    });
+  });
+  expect(create).toHaveBeenCalledOnce();
+  if (binding) {
+    expect(binding.close).toHaveBeenCalledOnce();
+  }
 });
 
 it("rejects a conflicting manager route instead of replacing an operation binding", async () => {

--- a/src/daemon/service-operation-lock.ts
+++ b/src/daemon/service-operation-lock.ts
@@ -34,7 +34,8 @@ export async function withSystemdServiceReadBinding<T>(
   const key = JSON.stringify([
     env.HOME,
     env.OPENCLAW_PROFILE,
-    env.OPENCLAW_SYSTEMD_UNIT,
+    // Installed service metadata makes the shell's inferred unit explicit.
+    resolveSystemdServiceName(env),
     env.OPENCLAW_STATE_DIR,
     env.XDG_RUNTIME_DIR,
     env.DBUS_SESSION_BUS_ADDRESS,


### PR DESCRIPTION
Related: #145597

## What Problem This Solves

Fixes an issue where users updating a managed Linux Gateway receive `managed-service-stop-failed` even though the service has not changed. The initial inspection can infer the unit name from the profile, while the installed service environment spells out the same unit. Comparing those raw values rejects the final inspection before stopping the Gateway.

## Why This Change Was Made

Compare the resolved systemd service name using the existing resolver. Other manager selectors, authenticated binding verification, binding lifetime, and service ownership checks remain unchanged. Regression coverage uses the actual service-environment builder and merger for default and named profiles, with and without an admitted peer.

## User Impact

Managed Linux updates continue when an implicit unit name becomes explicit in the installed environment. The same unit with or without the `.service` suffix is also accepted. Genuine manager or service changes remain blocking.

This repair belongs to the updater performing native service preparation. The real published 2026.9.1 updater successfully installs the candidate; the candidate can then perform its following update without falsely rejecting the service.

## Evidence

- Reproduced in Blacksmith Testbox via Crabbox: published npm 2026.9.1 → candidate succeeds; candidate → following artifact fails with `Original systemd read scope is closed or selects a different manager` before this fix.
- Fixed packaged runs from npm 2026.9.1, 2026.9.2, 2026.9.3, and 2026.9.4 pass both hops, restart the real Gateway process each time, and leave no transaction residue. The following artifact excludes legacy compatibility chunks. The harness uses a systemctl fixture and same-schema version metadata fixtures; no release was published.
- All four new regression cases fail on the original code with the exact observed error and pass after the fix.
- Focused and sibling validation: 218 tests passed across retained native ownership, update service maintenance, and service integration; one Linux-only case is skipped by the local macOS run. The final focused unit rerun passes all 15 cases.
- Full local build and remote package build passed. Changed-file checks, core and core-test typechecking, and final independent Codex autoreview through P2 all pass.
- [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34701612904) passed for `00787e95f11cd60bc4c1bd946bc5f82d0bb88007`.
