### PR TITLE
fix: speed up opening chats with large tool results

### DIFF
--- a/src/gateway/server-methods/chat-history-request-budget.test.ts
+++ b/src/gateway/server-methods/chat-history-request-budget.test.ts
@@ -1,13 +1,63 @@
 import { expectDefined } from "@openclaw/normalization-core";
 import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   appendTranscriptMessage,
+  replaceTranscriptEvents,
   upsertSessionEntryCore,
 } from "../../config/sessions/session-accessor.js";
+import { reconcileSessionTranscriptIndexes } from "../../config/sessions/session-transcript-reconcile.js";
 import { withOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
 import { createDirectChatContext } from "../server-chat.agent-events.test-helpers.js";
+import { readSessionMessagesPageWithStatsAsync } from "../session-transcript-readers.js";
 import { chatHistoryHandlers } from "./chat-history-handler.js";
+
+function createHistoryRequest(
+  sessionKey: string,
+  method: "chat.history" | "chat.startup" = "chat.history",
+) {
+  const context = createDirectChatContext();
+  return async (params: Record<string, unknown>) => {
+    let result: unknown;
+    await expectDefined(
+      chatHistoryHandlers[method],
+      "history handler",
+    )({
+      params: { sessionKey, limit: 80, ...params },
+      context,
+      req: { type: "req", id: "budgeted-history", method },
+      client: null,
+      isWebchatConnect: () => false,
+      respond: (ok, payload, error) => {
+        expect(error).toBeUndefined();
+        expect(ok).toBe(true);
+        result = payload;
+      },
+    });
+    return expectDefined(asOptionalRecord(result), "history response");
+  };
+}
+
+async function writeHistoryMessages(messages: Record<string, unknown>[]) {
+  const scope = {
+    agentId: "main",
+    sessionKey: "agent:main:scan-budget",
+    sessionId: "scan-budget",
+  };
+  await upsertSessionEntryCore(scope, { sessionId: scope.sessionId, updatedAt: 1 });
+  await replaceTranscriptEvents(
+    scope,
+    messages.map((message, index) => ({
+      type: "message",
+      id: `event-${index}`,
+      parentId: index > 0 ? `event-${index - 1}` : null,
+      timestamp: new Date(index + 1).toISOString(),
+      message: { ...message, timestamp: index + 1 },
+    })),
+  );
+  await reconcileSessionTranscriptIndexes({ agentId: scope.agentId });
+  return scope;
+}
 
 describe("chat history request byte budgets", () => {
   it.each(["chat.history", "chat.startup"] as const)(
@@ -37,26 +87,7 @@ describe("chat history request byte budgets", () => {
         for (const message of messages) {
           await appendTranscriptMessage(scope, { message });
         }
-        const context = createDirectChatContext();
-        const request = async (params: Record<string, unknown>) => {
-          let result: unknown;
-          await expectDefined(
-            chatHistoryHandlers[method],
-            "history handler",
-          )({
-            params: { sessionKey: scope.sessionKey, limit: 80, ...params },
-            context,
-            req: { type: "req", id: "budgeted-history", method },
-            client: null,
-            isWebchatConnect: () => false,
-            respond: (ok, payload, error) => {
-              expect(error).toBeUndefined();
-              expect(ok).toBe(true);
-              result = payload;
-            },
-          });
-          return expectDefined(asOptionalRecord(result), "history response");
-        };
+        const request = createHistoryRequest(scope.sessionKey, method);
 
         const tail = await request({ maxBytes: 8 * 1024 });
         expect(Buffer.byteLength(JSON.stringify(tail.messages))).toBeLessThanOrEqual(8 * 1024);
@@ -82,6 +113,71 @@ describe("chat history request byte budgets", () => {
         expect(single.messages).toHaveLength(1);
         expect(JSON.stringify(single.messages)).toContain(longText);
         expect(single.hasMore).toBe(true);
+      });
+    },
+  );
+
+  it("fills a large-tool tail without serializing oversized raw history arrays", async () => {
+    await withOpenClawTestState({ scenario: "minimal" }, async () => {
+      const scope = await writeHistoryMessages(
+        Array.from({ length: 120 }, (_, index) => ({
+          role: "toolResult",
+          toolName: "read",
+          toolCallId: `call-${index}`,
+          isError: false,
+          content: [{ type: "text", text: "x".repeat(128 * 1024) }],
+        })),
+      );
+      const request = createHistoryRequest(scope.sessionKey);
+      const stringify = JSON.stringify;
+      let largestSerializedArray = 0;
+      const serialization = vi.spyOn(JSON, "stringify").mockImplementation((...args) => {
+        const result = stringify(...args);
+        if (Array.isArray(args[0]) && typeof result === "string") {
+          largestSerializedArray = Math.max(largestSerializedArray, Buffer.byteLength(result));
+        }
+        return result;
+      });
+      let response;
+      try {
+        response = await request({ maxBytes: 256 * 1024 });
+      } finally {
+        serialization.mockRestore();
+      }
+      expect(response.messages).toHaveLength(80);
+      expect(response).toMatchObject({ hasMore: true, nextOffset: 80 });
+      expect(largestSerializedArray).toBeLessThanOrEqual(256 * 1024);
+    });
+  });
+
+  it.each(["plain", "unicode"])(
+    "preserves the exact sparse-scan byte cutoff for %s rows",
+    async (kind) => {
+      await withOpenClawTestState({ scenario: "minimal" }, async () => {
+        const scope = await writeHistoryMessages(
+          Array.from({ length: 600 }, () => ({
+            role: "assistant",
+            content: "NO_REPLY",
+            providerReplay: { text: kind === "unicode" ? '🦞漢字\n"\\\ud800'.repeat(16) : "plain" },
+          })),
+        );
+        const first = await readSessionMessagesPageWithStatsAsync(scope, {
+          offset: 9,
+          maxMessages: 72,
+        });
+        const second = await readSessionMessagesPageWithStatsAsync(scope, {
+          offset: 80,
+          maxMessages: 201,
+        });
+        const cutoff =
+          Buffer.byteLength(JSON.stringify(first.messages)) +
+          Buffer.byteLength(JSON.stringify(second.messages));
+        const request = createHistoryRequest(scope.sessionKey);
+        const stopped = await request({ limit: 3, maxBytes: cutoff });
+        expect(stopped).toMatchObject({ messages: [], hasMore: true, nextOffset: 280 });
+        const continued = await request({ limit: 3, maxBytes: cutoff + 1 });
+        expect(continued).toMatchObject({ messages: [], hasMore: false });
+        expect(continued.nextOffset).toBeUndefined();
       });
     },
   );

--- a/src/gateway/session-history-tail.ts
+++ b/src/gateway/session-history-tail.ts
@@ -249,6 +249,7 @@ export async function readIncrementalChatHistoryTail(params: {
   let projectionDirty = false;
   let scanLimit = rawHistoryWindowMessages;
   let scannedBytes = 0;
+  const pendingByteChunks: unknown[][] = [];
   let nextChunkMessages = SILENT_CHAT_HISTORY_TAIL_SCAN_CHUNK_MESSAGES;
   while (offset + rawPageMessages < readPage.totalMessages) {
     if (projectionDirty && estimatedVisibleMessages >= params.max) {
@@ -302,9 +303,20 @@ export async function readIncrementalChatHistoryTail(params: {
     estimatedVisibleMessages += project(chunkRawMessages, contextMessage, false, []).projection
       .messages.length;
     projectionDirty = true;
-    scannedBytes += Buffer.byteLength(JSON.stringify(page.messages), "utf8");
-    if (rawPageMessages > rawHistoryWindowMessages && scannedBytes >= params.maxBytes) {
-      break;
+    // Count the discarded context and its comma without retaining another raw copy.
+    if (contextMessage !== undefined) {
+      scannedBytes += Buffer.byteLength(JSON.stringify(contextMessage), "utf8") + 1;
+    }
+    pendingByteChunks.push(chunkRawMessages);
+    // Ordinary pages finish before this sparse-scan budget is consulted.
+    if (rawPageMessages > rawHistoryWindowMessages) {
+      for (const messages of pendingByteChunks) {
+        scannedBytes += Buffer.byteLength(JSON.stringify(messages), "utf8");
+      }
+      pendingByteChunks.length = 0;
+      if (scannedBytes >= params.maxBytes) {
+        break;
+      }
     }
     // Grow sparse scans geometrically while bounding each indexed page's allocation.
     nextChunkMessages = Math.min(


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users opening chats with large tool results could wait longer for recent history because the server performed unnecessary serialization during backfill.

## Why This Change Was Made

The history reader now defers backfill byte accounting until its existing sparse-scan budget is actually consulted. It preserves the exact UTF-8 byte total, including overread context and array framing, while retaining only references to rows already held by the request.

## User Impact

Recent-history backfills use less CPU and avoid large temporary JSON strings. Messages, omission markers, read windows, limits, recovery behavior, and pagination remain unchanged. This does not remove the separate cost of hydrating large transcript rows for back-scroll requests.

## Evidence

- Registered-handler regression fails before the fix on a 13,267,139-byte temporary array serialization for a 256 KiB request, then passes with no serialized array exceeding that request budget.
- All 69 focused tests pass across request budgets, recovery, sequence state, and cursor behavior. Plain and Unicode fixtures preserve the exact sparse cutoff and the cutoff-plus-one continuation.
- Same-process, alternating synthetic benchmarks on Node 26.8.2: an 80-message UI-tail request with 128 KiB tool results improves from 12.81 ms to 11.64 ms median across 100 calls per variant; with 1 MiB tool results, 62.25 ms to 56.11 ms across 80 calls. A sparse-scan request crossing the budget remains equivalent (3.39 ms to 3.26 ms).
- The final implementation matches 3,036 complete handler responses across 48 synthetic scenarios, including single-row backfill, Unicode/control characters, malformed events, heartbeat/commentary boundaries, recovery, tool grouping, compactions, resets, and back-scroll cursors.
- `check:changed` passes, including core/test typechecks and repository guards. Fresh independent review through P2 reports no actionable findings.
