### PR TITLE
improve: keep image and PDF processing responsive

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -415,7 +415,6 @@ extensions/discord/src/voice/receive-recovery.ts	5
 extensions/discord/src/voice/sdk-runtime.ts	1
 extensions/discord/src/voice/segment.ts	1
 extensions/discord/src/voice/voice-receive.ts	1
-extensions/document-extract/document-extractor.ts	1
 extensions/duckduckgo/src/config.ts	1
 extensions/duckduckgo/src/ddg-search-provider.ts	1
 extensions/elevenlabs/config-compat.ts	2

--- a/docs/agent-runtime-architecture.md
+++ b/docs/agent-runtime-architecture.md
@@ -55,6 +55,28 @@ Gateway startup and config, plugin, or auth publication build one prepared model
 
 Standalone embedded runtimes publish the same snapshot shape at their activation boundary. A failed or stale generation is never served alongside a newer partial generation. The lifecycle owner must publish a complete replacement first.
 
+## Compute workers
+
+Code-mode execution and compaction planning use the reusable `WorkerTaskPool`.
+Their pools share a CPU admission limit of `max(1, availableParallelism() - 1)`
+within the calling isolate, reserving a CPU where possible for the Gateway. Ordered
+database and model-generation workers keep their existing independent limits.
+
+Admission includes queued, preparing, and running tasks. Each pool defaults to
+128 pending tasks and 256 MiB of producer-reported retained input; compute pools
+also share those pending limits. Producers supply known input sizes without an
+extra serialization pass. This bounds reported input retention, not total worker
+heap usage. Excess work fails with `WorkerTaskError.code = "overloaded"`.
+Cancellation retains the execution permit until the worker stops, and retains
+the input reservation until any asynchronous preparation settles.
+
+Waiting compute pools request checkpoints from code-mode host exchanges so that
+nested work can progress. Idle workers release CPU admission and retire after
+the pool's idle timeout. Local `node:diagnostics_channel` subscribers to
+`openclaw.worker.task` can observe queue, preparation, execution wall time,
+message transfer time, and pending task/input counts. These events contain no
+task inputs; execution wall time includes worker startup and host waits.
+
 ## Related
 
 - [OpenClaw agent runtime workflow](/openclaw-agent-runtime)

--- a/docs/plugins/sdk-overview/infrastructure.md
+++ b/docs/plugins/sdk-overview/infrastructure.md
@@ -100,6 +100,14 @@ For stateless computation, `sharedCompute: true` also shares an aggregate
 pools in the same isolate. Dedicated ordered pools retain their own execution
 capacity and still enforce their individual admission limits.
 
+For a plugin-owned worker, pass `package: { name, distWorkerPath }` to
+`resolveRuntimeWorkerUrl` from the same SDK subpath. Use the plugin's
+`package.json` name and a worker path relative to its `dist` directory. The
+descriptor then supports bundled and standalone installations, including renamed
+installation directories. Declare the worker's source entry in
+[`openclaw.build.workerEntries`](/plugins/dependency-resolution#native-imports-from-a-standalone-source-build)
+so package builds emit it.
+
 ### SQLite worker stores
 
 Use `openSqliteWorkerStore<Operations>` from

--- a/docs/plugins/sdk-overview/infrastructure.md
+++ b/docs/plugins/sdk-overview/infrastructure.md
@@ -100,14 +100,6 @@ For stateless computation, `sharedCompute: true` also shares an aggregate
 pools in the same isolate. Dedicated ordered pools retain their own execution
 capacity and still enforce their individual admission limits.
 
-For a plugin-owned worker, pass `package: { name, distWorkerPath }` to
-`resolveRuntimeWorkerUrl` from the same SDK subpath. Use the plugin's
-`package.json` name and a worker path relative to its `dist` directory. The
-descriptor then supports bundled and standalone installations, including renamed
-installation directories. Declare the worker's source entry in
-[`openclaw.build.workerEntries`](/plugins/dependency-resolution#native-imports-from-a-standalone-source-build)
-so package builds emit it.
-
 ### SQLite worker stores
 
 Use `openSqliteWorkerStore<Operations>` from
@@ -184,6 +176,16 @@ checks cannot protect against an uncoordinated filesystem replacement.
 Each client retains its admitted lexical and canonical pathnames through
 drainage and close. The backend's opening paths remain pinned for its native
 lifetime; released secondary aliases do not accumulate while other clients live.
+
+### Computation worker entrypoints
+
+For a plugin-owned worker, pass `package: { name, distWorkerPath }` to
+`resolveRuntimeWorkerUrl` from the same SDK subpath. Use the plugin's
+`package.json` name and a worker path relative to its `dist` directory. The
+descriptor then supports bundled and standalone installations, including renamed
+installation directories. Declare the worker's source entry in
+[`openclaw.build.workerEntries`](/plugins/dependency-resolution#native-imports-from-a-standalone-source-build)
+so package builds emit it.
 
 ### Webhook body rejection
 

--- a/docs/plugins/sdk-overview/infrastructure.md
+++ b/docs/plugins/sdk-overview/infrastructure.md
@@ -76,6 +76,30 @@ synchronous executor and the connection's bounded statement cache when enabled.
 Keep the prepared function with its database owner and discard it when closing
 the connection; transaction callbacks must remain synchronous.
 
+### Worker task admission
+
+`WorkerTaskPool` and `serveWorkerTasks` from
+`openclaw/plugin-sdk/process-runtime` support reusable computation workers.
+Each pool defaults to 128 outstanding tasks and 256 MiB of reported input bytes,
+including queued, preparing, and running tasks. Set `maxPendingTasks` and
+`maxPendingBytes` when constructing a pool to choose different positive limits.
+Report known retained input with `run(input, { inputBytes })`, including buffers
+captured by an input factory. Omitted `inputBytes` counts as zero; this accounting
+does not measure serialized payload size, decoded data, results, or worker heaps.
+
+Capacity exhaustion rejects `run()` with `WorkerTaskError.code = "overloaded"`
+before preparing or executing that input. Accepted work remains ordered within
+a single-worker pool. Report the rejected operation as unsuccessful; do not
+substitute an empty result or bypass the limit with synchronous execution.
+After accepted work settles, the same pool accepts new work again. A caller may
+retry a rejected operation after pressure drains and its original authority and
+deadline are revalidated; the pool does not retry it automatically.
+
+For stateless computation, `sharedCompute: true` also shares an aggregate
+128-task/256-MiB admission budget and CPU execution capacity with participating
+pools in the same isolate. Dedicated ordered pools retain their own execution
+capacity and still enforce their individual admission limits.
+
 ### SQLite worker stores
 
 Use `openSqliteWorkerStore<Operations>` from

--- a/docs/tools/pdf.md
+++ b/docs/tools/pdf.md
@@ -85,6 +85,7 @@ Used for every other provider.
 
 Details:
 
+- Local extraction runs in a reusable worker so PDF text and image processing do not block the Gateway. Cancelling the agent run stops queued or active extraction.
 - Encrypted PDFs open with the top-level `password` parameter.
 - If the model has no image input and there is no extractable text, the tool errors.
 - If image rendering fails, OpenClaw drops the images and continues with the extracted text.

--- a/extensions/document-extract/document-extractor-worker-entrypoint.ts
+++ b/extensions/document-extract/document-extractor-worker-entrypoint.ts
@@ -1,0 +1,5 @@
+export const documentExtractorWorkerEntrypoint = {
+  currentModuleUrl: import.meta.url,
+  sourceWorkerName: "document-extractor.worker",
+  distWorkerPath: "extensions/document-extract/document-extractor.worker.js",
+} as const;

--- a/extensions/document-extract/document-extractor-worker-entrypoint.ts
+++ b/extensions/document-extract/document-extractor-worker-entrypoint.ts
@@ -1,5 +1,9 @@
 export const documentExtractorWorkerEntrypoint = {
   currentModuleUrl: import.meta.url,
   sourceWorkerName: "document-extractor.worker",
+  package: {
+    name: "@openclaw/document-extract-plugin",
+    distWorkerPath: "document-extractor.worker.js",
+  },
   distWorkerPath: "extensions/document-extract/document-extractor.worker.js",
 } as const;

--- a/extensions/document-extract/document-extractor.runtime.test.ts
+++ b/extensions/document-extract/document-extractor.runtime.test.ts
@@ -1,0 +1,222 @@
+// Document Extract tests cover document extractor plugin behavior.
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { createEngineMock, openPdfMock, pdfDocument } = vi.hoisted(() => ({
+  createEngineMock: vi.fn(),
+  openPdfMock: vi.fn(),
+  pdfDocument: {
+    pageCount: 2,
+    extract: vi.fn(),
+    destroy: vi.fn(),
+  },
+}));
+
+vi.mock("clawpdf", () => ({
+  createEngine: createEngineMock,
+}));
+
+import { extractPdfContent } from "./document-extractor.runtime.js";
+
+function request(overrides = {}) {
+  return {
+    buffer: Buffer.from("%PDF-1.4"),
+    mimeType: "application/pdf",
+    maxPages: 2,
+    maxPixels: 100,
+    minTextChars: 10,
+    ...overrides,
+  };
+}
+
+describe("PDF document extractor", () => {
+  afterAll(() => {
+    vi.doUnmock("clawpdf");
+    vi.resetModules();
+  });
+
+  beforeEach(() => {
+    createEngineMock.mockResolvedValue({ open: openPdfMock });
+    openPdfMock.mockReset();
+    openPdfMock.mockResolvedValue(pdfDocument);
+    pdfDocument.pageCount = 2;
+    pdfDocument.extract.mockReset();
+    pdfDocument.destroy.mockReset();
+  });
+
+  it("extracts text first and renders each fallback page with its own pixel budget", async () => {
+    pdfDocument.extract
+      .mockResolvedValueOnce({ text: "", images: [] })
+      .mockResolvedValueOnce({
+        text: "",
+        images: [
+          {
+            type: "image",
+            bytes: Uint8Array.from(Buffer.from("!png1?")).subarray(1, 5),
+            mimeType: "image/png",
+            page: 1,
+            width: 5,
+            height: 10,
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        text: "",
+        images: [
+          {
+            type: "image",
+            bytes: Uint8Array.from(Buffer.from("png2")),
+            mimeType: "image/png",
+            page: 2,
+            width: 5,
+            height: 10,
+          },
+        ],
+      });
+    const extractor = { extract: extractPdfContent };
+
+    const input = request({ buffer: Buffer.from("!%PDF-1.4?").subarray(1, -1) });
+    const result = await extractor.extract(input);
+
+    if (!result) {
+      throw new Error("Expected PDF extraction result");
+    }
+    expect(openPdfMock).toHaveBeenCalledWith(expect.any(Uint8Array));
+    expect(Buffer.from(openPdfMock.mock.calls[0]?.[0] ?? [])).toEqual(input.buffer);
+    expect(pdfDocument.extract).toHaveBeenNthCalledWith(1, {
+      mode: "text",
+      maxPages: 2,
+      maxTextChars: 200_000,
+    });
+    // Each page renders in its own extract() call, with the aggregate pixel cap
+    // allocated across selected pages so later pages are not starved.
+    expect(pdfDocument.extract).toHaveBeenNthCalledWith(2, {
+      mode: "images",
+      pages: [1],
+      image: { maxDimension: 10_000, maxPixels: 50, forms: true },
+    });
+    expect(pdfDocument.extract).toHaveBeenNthCalledWith(3, {
+      mode: "images",
+      pages: [2],
+      image: { maxDimension: 10_000, maxPixels: 50, forms: true },
+    });
+    expect(result).toEqual({
+      text: "",
+      images: [
+        { type: "image", data: "cG5nMQ==", mimeType: "image/png" },
+        { type: "image", data: "cG5nMg==", mimeType: "image/png" },
+      ],
+    });
+    expect(pdfDocument.destroy).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips image fallback when enough text is extracted", async () => {
+    pdfDocument.extract.mockResolvedValueOnce({ text: "enough text", images: [] });
+    const extractor = { extract: extractPdfContent };
+
+    const result = await extractor.extract(request({ minTextChars: 5 }));
+
+    expect(result).toEqual({ text: "enough text", images: [] });
+    expect(pdfDocument.extract).toHaveBeenCalledTimes(1);
+    expect(pdfDocument.destroy).toHaveBeenCalledTimes(1);
+  });
+
+  it("opens encrypted PDFs with the request password", async () => {
+    pdfDocument.extract.mockResolvedValueOnce({ text: "enough text", images: [] });
+    const extractor = { extract: extractPdfContent };
+
+    await extractor.extract(request({ password: "secret" }));
+
+    expect(openPdfMock).toHaveBeenCalledWith(expect.any(Uint8Array), { password: "secret" });
+    expect(pdfDocument.destroy).toHaveBeenCalledTimes(1);
+  });
+
+  it("normalizes clawpdf password errors", async () => {
+    openPdfMock.mockRejectedValueOnce(
+      Object.assign(new Error("bad password"), { code: "password" }),
+    );
+    const extractor = { extract: extractPdfContent };
+
+    await expect(extractor.extract(request({ password: "wrong" }))).rejects.toThrow(
+      "PDF requires a password or password is incorrect.",
+    );
+    expect(pdfDocument.destroy).not.toHaveBeenCalled();
+  });
+
+  it("filters selected pages and renders them one page per image call", async () => {
+    pdfDocument.extract
+      .mockResolvedValueOnce({ text: "", images: [] })
+      .mockResolvedValueOnce({ text: "", images: [] })
+      .mockResolvedValueOnce({ text: "", images: [] });
+    const extractor = { extract: extractPdfContent };
+
+    const result = await extractor.extract(request({ pageNumbers: [3, 2, 0, 1], maxPages: 2 }));
+
+    expect(result).toEqual({ text: "", images: [] });
+    expect(pdfDocument.extract).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ mode: "text", pages: [2, 1] }),
+    );
+    expect(pdfDocument.extract).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ mode: "images", pages: [2] }),
+    );
+    expect(pdfDocument.extract).toHaveBeenNthCalledWith(
+      3,
+      expect.objectContaining({ mode: "images", pages: [1] }),
+    );
+  });
+
+  it("rejects selected pages outside the PDF page count before extraction", async () => {
+    pdfDocument.pageCount = 1;
+    pdfDocument.extract.mockResolvedValueOnce({ text: "", images: [] });
+    const extractor = { extract: extractPdfContent };
+
+    await expect(extractor.extract(request({ pageNumbers: [2] }))).rejects.toThrow(
+      "No requested PDF pages exist in this 1-page document.",
+    );
+    expect(pdfDocument.extract).not.toHaveBeenCalled();
+    expect(pdfDocument.destroy).toHaveBeenCalledTimes(1);
+
+    await expect(extractor.extract(request({ pageNumbers: [] }))).resolves.toEqual({
+      text: "",
+      images: [],
+    });
+    expect(pdfDocument.destroy).toHaveBeenCalledTimes(2);
+  });
+
+  it("reports image fallback failures and returns extracted text", async () => {
+    const onImageExtractionError = vi.fn();
+    const failure = new Error("render failed");
+    pdfDocument.extract
+      .mockResolvedValueOnce({ text: "short", images: [] })
+      .mockRejectedValueOnce(failure);
+    const extractor = { extract: extractPdfContent };
+
+    const result = await extractor.extract(request({ onImageExtractionError }));
+
+    expect(result).toEqual({ text: "short", images: [] });
+    expect(onImageExtractionError).toHaveBeenCalledWith(failure);
+    expect(pdfDocument.destroy).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    { label: "empty", text: "", reportError: true },
+    { label: "whitespace-only", text: " \t\n", reportError: false },
+  ])("surfaces image fallback failures for $label PDF text", async ({ text, reportError }) => {
+    const { PdfBudgetError } = await vi.importActual<typeof import("clawpdf")>("clawpdf");
+    const onImageExtractionError = vi.fn();
+    const failure = new PdfBudgetError("renderPixels", 100);
+    pdfDocument.extract.mockResolvedValueOnce({ text, images: [] }).mockRejectedValueOnce(failure);
+    const overrides = reportError ? { onImageExtractionError } : {};
+
+    await expect(extractPdfContent(request(overrides))).rejects.toMatchObject({
+      message: "PDF image extraction failed with no extractable text.",
+      cause: failure,
+    });
+    expect(onImageExtractionError).toHaveBeenCalledTimes(reportError ? 1 : 0);
+    if (reportError) {
+      expect(onImageExtractionError).toHaveBeenCalledWith(failure);
+    }
+    expect(pdfDocument.destroy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/extensions/document-extract/document-extractor.runtime.ts
+++ b/extensions/document-extract/document-extractor.runtime.ts
@@ -1,0 +1,126 @@
+// Document Extract plugin module implements document extractor behavior.
+import type { PdfDocument, PdfEngine, PdfImage } from "clawpdf";
+import type {
+  DocumentExtractedImage,
+  DocumentExtractionRequest,
+  DocumentExtractionResult,
+} from "openclaw/plugin-sdk/document-extractor";
+
+const MAX_EXTRACTED_TEXT_CHARS = 200_000;
+const MAX_RENDER_DIMENSION = 10_000;
+
+let pdfEnginePromise: Promise<PdfEngine> | null = null;
+
+async function loadPdfEngine(): Promise<PdfEngine> {
+  if (!pdfEnginePromise) {
+    pdfEnginePromise = import("clawpdf")
+      .then(({ createEngine }) => createEngine())
+      .catch((err: unknown) => {
+        pdfEnginePromise = null;
+        throw new Error("Dependency clawpdf is required for PDF extraction", {
+          cause: err,
+        });
+      });
+  }
+  return pdfEnginePromise;
+}
+
+function toDocumentImage({ bytes, mimeType }: PdfImage): DocumentExtractedImage {
+  const data = Buffer.from(bytes.buffer, bytes.byteOffset, bytes.byteLength).toString("base64");
+  return { type: "image", data, mimeType };
+}
+
+function isPdfPasswordError(err: unknown): boolean {
+  return err !== null && typeof err === "object" && "code" in err && err.code === "password";
+}
+
+async function openPdfDocument(params: {
+  engine: PdfEngine;
+  input: Uint8Array;
+  password?: string;
+}): Promise<PdfDocument> {
+  try {
+    return params.password
+      ? await params.engine.open(params.input, { password: params.password })
+      : await params.engine.open(params.input);
+  } catch (err) {
+    if (isPdfPasswordError(err)) {
+      throw new Error("PDF requires a password or password is incorrect.", { cause: err });
+    }
+    throw err;
+  }
+}
+
+export async function extractPdfContent(
+  request: DocumentExtractionRequest,
+): Promise<DocumentExtractionResult> {
+  const engine = await loadPdfEngine();
+  const pdf = await openPdfDocument({
+    engine,
+    input: request.buffer,
+    ...(request.password ? { password: request.password } : {}),
+  });
+  try {
+    const pages = request.pageNumbers
+      ? request.pageNumbers
+          .filter((p) => Number.isInteger(p) && p >= 1 && p <= pdf.pageCount)
+          .slice(0, request.maxPages)
+      : undefined;
+    if (request.pageNumbers?.length && pages?.length === 0) {
+      throw new Error(`No requested PDF pages exist in this ${pdf.pageCount}-page document.`);
+    }
+    const pageSelection = pages ? { pages } : { maxPages: request.maxPages };
+
+    const textResult = await pdf.extract({
+      mode: "text",
+      ...pageSelection,
+      maxTextChars: MAX_EXTRACTED_TEXT_CHARS,
+    });
+    const text = textResult.text;
+
+    if (text.trim().length >= request.minTextChars) {
+      return { text, images: [] };
+    }
+
+    // clawpdf's image render budget (maxPixels) is shared across every page in one
+    // extract() call: the first page consumes it and later pages collapse to 1x1
+    // PNGs that vision models reject. Render each page separately, allocating the
+    // remaining aggregate budget across pages that still need rendering.
+    const imagePages =
+      pages ?? Array.from({ length: Math.min(pdf.pageCount, request.maxPages) }, (_, i) => i + 1);
+
+    try {
+      const images: DocumentExtractedImage[] = [];
+      let remainingPixels = request.maxPixels;
+      for (const [index, pageNumber] of imagePages.entries()) {
+        if (remainingPixels <= 0) {
+          break;
+        }
+        const pagesRemaining = imagePages.length - index;
+        const maxPixelsPerPage = Math.max(1, Math.ceil(remainingPixels / pagesRemaining));
+        const imageResult = await pdf.extract({
+          mode: "images",
+          pages: [pageNumber],
+          image: {
+            maxDimension: MAX_RENDER_DIMENSION,
+            maxPixels: maxPixelsPerPage,
+            forms: true,
+          },
+        });
+        for (const image of imageResult.images) {
+          images.push(toDocumentImage(image));
+          remainingPixels -= image.width * image.height;
+        }
+      }
+      return { text, images };
+    } catch (err) {
+      request.onImageExtractionError?.(err);
+      if (!text.trim()) {
+        throw new Error("PDF image extraction failed with no extractable text.", { cause: err });
+      }
+      return { text, images: [] };
+    }
+  } finally {
+    pdf.destroy();
+  }
+}

--- a/extensions/document-extract/document-extractor.test-support.ts
+++ b/extensions/document-extract/document-extractor.test-support.ts
@@ -1,0 +1,28 @@
+/** A small real PDF with independently selectable text and vector pages. */
+export function createPdfFixture(pageContents: string[]): Buffer {
+  const objects = [
+    "<< /Type /Catalog /Pages 2 0 R >>",
+    `<< /Type /Pages /Count ${pageContents.length} /Kids [${pageContents.map((_, index) => `${4 + index * 2} 0 R`).join(" ")}] >>`,
+    "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>",
+  ];
+  for (const [index, content] of pageContents.entries()) {
+    objects.push(
+      `<< /Type /Page /Parent 2 0 R /MediaBox [0 0 600 800] /Resources << /Font << /F1 3 0 R >> >> /Contents ${5 + index * 2} 0 R >>`,
+      `<< /Length ${Buffer.byteLength(content)} >>\nstream\n${content}\nendstream`,
+    );
+  }
+  let pdf = "%PDF-1.4\n";
+  const offsets = [0];
+  for (const [index, object] of objects.entries()) {
+    offsets.push(Buffer.byteLength(pdf));
+    pdf += `${index + 1} 0 obj\n${object}\nendobj\n`;
+  }
+  const xref = Buffer.byteLength(pdf);
+  pdf += `xref\n0 ${objects.length + 1}\n0000000000 65535 f \n`;
+  pdf += offsets
+    .slice(1)
+    .map((offset) => `${String(offset).padStart(10, "0")} 00000 n \n`)
+    .join("");
+  pdf += `trailer\n<< /Size ${objects.length + 1} /Root 1 0 R >>\nstartxref\n${xref}\n%%EOF\n`;
+  return Buffer.from(pdf);
+}

--- a/extensions/document-extract/document-extractor.test.ts
+++ b/extensions/document-extract/document-extractor.test.ts
@@ -1,234 +1,95 @@
-// Document Extract tests cover document extractor plugin behavior.
-import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Worker } from "node:worker_threads";
+import { afterAll, describe, expect, it, vi } from "vitest";
+import { createPdfFixture } from "./document-extractor.test-support.js";
 
-const { createEngineMock, openPdfMock, pdfDocument } = vi.hoisted(() => ({
-  createEngineMock: vi.fn(),
-  openPdfMock: vi.fn(),
-  pdfDocument: {
-    pageCount: 2,
-    extract: vi.fn(),
-    destroy: vi.fn(),
-  },
-}));
-
-vi.mock("clawpdf", () => ({
-  createEngine: createEngineMock,
-}));
+const workers = vi.hoisted(() => [] as Worker[]);
+vi.mock("node:worker_threads", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:worker_threads")>();
+  return {
+    ...actual,
+    Worker: class extends actual.Worker {
+      constructor(...args: ConstructorParameters<typeof actual.Worker>) {
+        super(...args);
+        workers.push(this);
+      }
+    },
+  };
+});
 
 import { createPdfDocumentExtractor } from "./document-extractor.js";
 
-function request(overrides = {}) {
-  return {
-    buffer: Buffer.from("%PDF-1.4"),
-    mimeType: "application/pdf",
-    maxPages: 2,
-    maxPixels: 100,
-    minTextChars: 10,
-    ...overrides,
-  };
-}
+afterAll(async () => {
+  await Promise.all(workers.splice(0).map((worker) => worker.terminate()));
+});
 
-describe("PDF document extractor", () => {
-  afterAll(() => {
-    vi.doUnmock("clawpdf");
-    vi.resetModules();
-  });
+const fixture = createPdfFixture([
+  "BT /F1 24 Tf 50 700 Td (First PDF page) Tj ET",
+  "BT /F1 24 Tf 50 700 Td (Second PDF page) Tj ET",
+]);
+const request = {
+  buffer: fixture,
+  mimeType: "application/pdf",
+  maxPages: 2,
+  maxPixels: 100_000,
+  minTextChars: 1,
+};
 
-  beforeEach(() => {
-    createEngineMock.mockResolvedValue({ open: openPdfMock });
-    openPdfMock.mockReset();
-    openPdfMock.mockResolvedValue(pdfDocument);
-    pdfDocument.pageCount = 2;
-    pdfDocument.extract.mockReset();
-    pdfDocument.destroy.mockReset();
-  });
-
-  it("declares PDF support", () => {
+describe("PDF document extractor worker", () => {
+  it("extracts selected pages through the public plugin and preserves the caller's buffer", async () => {
     const extractor = createPdfDocumentExtractor();
-    const { extract, ...descriptor } = extractor;
-    expect(extract).toBeInstanceOf(Function);
-    expect(descriptor).toEqual({
-      id: "pdf",
-      label: "PDF",
-      mimeTypes: ["application/pdf"],
-      autoDetectOrder: 10,
-    });
+    expect(extractor).toMatchObject({ id: "pdf", mimeTypes: ["application/pdf"] });
+    const source = Buffer.concat([Buffer.from("prefix"), fixture, Buffer.from("suffix")]);
+    const buffer = source.subarray(6, -6);
+    const result = await extractor.extract({ ...request, buffer, pageNumbers: [2] });
+    expect(result?.text).toContain("Second PDF page");
+    expect(result?.text).not.toContain("First PDF page");
+    expect(result?.images).toEqual([]);
+    expect(buffer).toEqual(fixture);
   });
 
-  it("extracts text first and renders each fallback page with its own pixel budget", async () => {
-    pdfDocument.extract
-      .mockResolvedValueOnce({ text: "", images: [] })
-      .mockResolvedValueOnce({
-        text: "",
-        images: [
-          {
-            type: "image",
-            bytes: Uint8Array.from(Buffer.from("!png1?")).subarray(1, 5),
-            mimeType: "image/png",
-            page: 1,
-            width: 5,
-            height: 10,
-          },
-        ],
-      })
-      .mockResolvedValueOnce({
-        text: "",
-        images: [
-          {
-            type: "image",
-            bytes: Uint8Array.from(Buffer.from("png2")),
-            mimeType: "image/png",
-            page: 2,
-            width: 5,
-            height: 10,
-          },
-        ],
-      });
+  it("renders real pages within the aggregate pixel budget", async () => {
+    const result = await createPdfDocumentExtractor().extract({ ...request, minTextChars: 10_000 });
+    expect(result?.images).toHaveLength(2);
+    const pixels = result!.images.reduce((total, image) => {
+      const png = Buffer.from(image.data, "base64");
+      expect(png.subarray(1, 4).toString()).toBe("PNG");
+      return total + png.readUInt32BE(16) * png.readUInt32BE(20);
+    }, 0);
+    expect(pixels).toBeLessThanOrEqual(request.maxPixels);
+    expect(pixels).toBeGreaterThan(request.maxPixels / 2);
+  });
+
+  it("cancels queued or active extraction and allows the next document to succeed", async () => {
     const extractor = createPdfDocumentExtractor();
-
-    const input = request({ buffer: Buffer.from("!%PDF-1.4?").subarray(1, -1) });
-    const result = await extractor.extract(input);
-
-    if (!result) {
-      throw new Error("Expected PDF extraction result");
+    await extractor.extract(request);
+    const abort = new AbortController();
+    const reason = new Error("owning turn cancelled");
+    const timer = setTimeout(() => abort.abort(reason), 0);
+    try {
+      await expect(
+        extractor.extract({
+          ...request,
+          minTextChars: 10_000,
+          maxPixels: 4_000_000,
+          signal: abort.signal,
+        }),
+      ).rejects.toBe(reason);
+    } finally {
+      clearTimeout(timer);
     }
-    expect(openPdfMock).toHaveBeenCalledWith(expect.any(Uint8Array));
-    expect(Buffer.from(openPdfMock.mock.calls[0]?.[0] ?? [])).toEqual(input.buffer);
-    expect(pdfDocument.extract).toHaveBeenNthCalledWith(1, {
-      mode: "text",
-      maxPages: 2,
-      maxTextChars: 200_000,
+    await expect(extractor.extract({ ...request, signal: abort.signal })).rejects.toBe(reason);
+    await expect(extractor.extract(request)).resolves.toMatchObject({
+      text: expect.stringContaining("First PDF page"),
     });
-    // Each page renders in its own extract() call, with the aggregate pixel cap
-    // allocated across selected pages so later pages are not starved.
-    expect(pdfDocument.extract).toHaveBeenNthCalledWith(2, {
-      mode: "images",
-      pages: [1],
-      image: { maxDimension: 10_000, maxPixels: 50, forms: true },
+  });
+
+  it("preserves invalid-document errors without poisoning later extraction", async () => {
+    const extractor = createPdfDocumentExtractor();
+    await expect(
+      extractor.extract({ ...request, buffer: Buffer.from("invalid PDF") }),
+    ).rejects.toThrow(/PDF|document/i);
+    await expect(extractor.extract(request)).resolves.toMatchObject({
+      text: expect.stringContaining("Second PDF page"),
     });
-    expect(pdfDocument.extract).toHaveBeenNthCalledWith(3, {
-      mode: "images",
-      pages: [2],
-      image: { maxDimension: 10_000, maxPixels: 50, forms: true },
-    });
-    expect(result).toEqual({
-      text: "",
-      images: [
-        { type: "image", data: "cG5nMQ==", mimeType: "image/png" },
-        { type: "image", data: "cG5nMg==", mimeType: "image/png" },
-      ],
-    });
-    expect(pdfDocument.destroy).toHaveBeenCalledTimes(1);
-  });
-
-  it("skips image fallback when enough text is extracted", async () => {
-    pdfDocument.extract.mockResolvedValueOnce({ text: "enough text", images: [] });
-    const extractor = createPdfDocumentExtractor();
-
-    const result = await extractor.extract(request({ minTextChars: 5 }));
-
-    expect(result).toEqual({ text: "enough text", images: [] });
-    expect(pdfDocument.extract).toHaveBeenCalledTimes(1);
-    expect(pdfDocument.destroy).toHaveBeenCalledTimes(1);
-  });
-
-  it("opens encrypted PDFs with the request password", async () => {
-    pdfDocument.extract.mockResolvedValueOnce({ text: "enough text", images: [] });
-    const extractor = createPdfDocumentExtractor();
-
-    await extractor.extract(request({ password: "secret" }));
-
-    expect(openPdfMock).toHaveBeenCalledWith(expect.any(Uint8Array), { password: "secret" });
-    expect(pdfDocument.destroy).toHaveBeenCalledTimes(1);
-  });
-
-  it("normalizes clawpdf password errors", async () => {
-    openPdfMock.mockRejectedValueOnce(
-      Object.assign(new Error("bad password"), { code: "password" }),
-    );
-    const extractor = createPdfDocumentExtractor();
-
-    await expect(extractor.extract(request({ password: "wrong" }))).rejects.toThrow(
-      "PDF requires a password or password is incorrect.",
-    );
-    expect(pdfDocument.destroy).not.toHaveBeenCalled();
-  });
-
-  it("filters selected pages and renders them one page per image call", async () => {
-    pdfDocument.extract
-      .mockResolvedValueOnce({ text: "", images: [] })
-      .mockResolvedValueOnce({ text: "", images: [] })
-      .mockResolvedValueOnce({ text: "", images: [] });
-    const extractor = createPdfDocumentExtractor();
-
-    const result = await extractor.extract(request({ pageNumbers: [3, 2, 0, 1], maxPages: 2 }));
-
-    expect(result).toEqual({ text: "", images: [] });
-    expect(pdfDocument.extract).toHaveBeenNthCalledWith(
-      1,
-      expect.objectContaining({ mode: "text", pages: [2, 1] }),
-    );
-    expect(pdfDocument.extract).toHaveBeenNthCalledWith(
-      2,
-      expect.objectContaining({ mode: "images", pages: [2] }),
-    );
-    expect(pdfDocument.extract).toHaveBeenNthCalledWith(
-      3,
-      expect.objectContaining({ mode: "images", pages: [1] }),
-    );
-  });
-
-  it("rejects selected pages outside the PDF page count before extraction", async () => {
-    pdfDocument.pageCount = 1;
-    pdfDocument.extract.mockResolvedValueOnce({ text: "", images: [] });
-    const extractor = createPdfDocumentExtractor();
-
-    await expect(extractor.extract(request({ pageNumbers: [2] }))).rejects.toThrow(
-      "No requested PDF pages exist in this 1-page document.",
-    );
-    expect(pdfDocument.extract).not.toHaveBeenCalled();
-    expect(pdfDocument.destroy).toHaveBeenCalledTimes(1);
-
-    await expect(extractor.extract(request({ pageNumbers: [] }))).resolves.toEqual({
-      text: "",
-      images: [],
-    });
-    expect(pdfDocument.destroy).toHaveBeenCalledTimes(2);
-  });
-
-  it("reports image fallback failures and returns extracted text", async () => {
-    const onImageExtractionError = vi.fn();
-    const failure = new Error("render failed");
-    pdfDocument.extract
-      .mockResolvedValueOnce({ text: "short", images: [] })
-      .mockRejectedValueOnce(failure);
-    const extractor = createPdfDocumentExtractor();
-
-    const result = await extractor.extract(request({ onImageExtractionError }));
-
-    expect(result).toEqual({ text: "short", images: [] });
-    expect(onImageExtractionError).toHaveBeenCalledWith(failure);
-    expect(pdfDocument.destroy).toHaveBeenCalledTimes(1);
-  });
-
-  it.each([
-    { label: "empty", text: "", reportError: true },
-    { label: "whitespace-only", text: " \t\n", reportError: false },
-  ])("surfaces image fallback failures for $label PDF text", async ({ text, reportError }) => {
-    const { PdfBudgetError } = await vi.importActual<typeof import("clawpdf")>("clawpdf");
-    const onImageExtractionError = vi.fn();
-    const failure = new PdfBudgetError("renderPixels", 100);
-    pdfDocument.extract.mockResolvedValueOnce({ text, images: [] }).mockRejectedValueOnce(failure);
-    const overrides = reportError ? { onImageExtractionError } : {};
-
-    await expect(createPdfDocumentExtractor().extract(request(overrides))).rejects.toMatchObject({
-      message: "PDF image extraction failed with no extractable text.",
-      cause: failure,
-    });
-    expect(onImageExtractionError).toHaveBeenCalledTimes(reportError ? 1 : 0);
-    if (reportError) {
-      expect(onImageExtractionError).toHaveBeenCalledWith(failure);
-    }
-    expect(pdfDocument.destroy).toHaveBeenCalledTimes(1);
   });
 });

--- a/extensions/document-extract/document-extractor.ts
+++ b/extensions/document-extract/document-extractor.ts
@@ -1,130 +1,17 @@
-// Document Extract plugin module implements document extractor behavior.
-import type { PdfDocument, PdfEngine, PdfImage } from "clawpdf";
+import type { DocumentExtractorPlugin } from "openclaw/plugin-sdk/document-extractor";
+import { resolveRuntimeWorkerUrl, WorkerTaskPool } from "openclaw/plugin-sdk/process-runtime";
+import { documentExtractorWorkerEntrypoint } from "./document-extractor-worker-entrypoint.js";
 import type {
-  DocumentExtractedImage,
-  DocumentExtractionRequest,
-  DocumentExtractionResult,
-  DocumentExtractorPlugin,
-} from "openclaw/plugin-sdk/document-extractor";
+  DocumentExtractorWorkerReply,
+  DocumentExtractorWorkerRequest,
+} from "./document-extractor.worker.js";
 
-const MAX_EXTRACTED_TEXT_CHARS = 200_000;
-const MAX_RENDER_DIMENSION = 10_000;
-
-let pdfEnginePromise: Promise<PdfEngine> | null = null;
-
-async function loadPdfEngine(): Promise<PdfEngine> {
-  if (!pdfEnginePromise) {
-    pdfEnginePromise = import("clawpdf")
-      .then(({ createEngine }) => createEngine())
-      .catch((err: unknown) => {
-        pdfEnginePromise = null;
-        throw new Error("Dependency clawpdf is required for PDF extraction", {
-          cause: err,
-        });
-      });
-  }
-  return pdfEnginePromise;
-}
-
-function toDocumentImage({ bytes, mimeType }: PdfImage): DocumentExtractedImage {
-  const data = Buffer.from(bytes.buffer, bytes.byteOffset, bytes.byteLength).toString("base64");
-  return { type: "image", data, mimeType };
-}
-
-function isPdfPasswordError(err: unknown): boolean {
-  return Boolean(err && typeof err === "object" && (err as { code?: unknown }).code === "password");
-}
-
-async function openPdfDocument(params: {
-  engine: PdfEngine;
-  input: Uint8Array;
-  password?: string;
-}): Promise<PdfDocument> {
-  try {
-    return params.password
-      ? await params.engine.open(params.input, { password: params.password })
-      : await params.engine.open(params.input);
-  } catch (err) {
-    if (isPdfPasswordError(err)) {
-      throw new Error("PDF requires a password or password is incorrect.", { cause: err });
-    }
-    throw err;
-  }
-}
-
-async function extractPdfContent(
-  request: DocumentExtractionRequest,
-): Promise<DocumentExtractionResult> {
-  const engine = await loadPdfEngine();
-  const pdf = await openPdfDocument({
-    engine,
-    input: request.buffer,
-    ...(request.password ? { password: request.password } : {}),
-  });
-  try {
-    const pages = request.pageNumbers
-      ? request.pageNumbers
-          .filter((p) => Number.isInteger(p) && p >= 1 && p <= pdf.pageCount)
-          .slice(0, request.maxPages)
-      : undefined;
-    if (request.pageNumbers?.length && pages?.length === 0) {
-      throw new Error(`No requested PDF pages exist in this ${pdf.pageCount}-page document.`);
-    }
-    const pageSelection = pages ? { pages } : { maxPages: request.maxPages };
-
-    const textResult = await pdf.extract({
-      mode: "text",
-      ...pageSelection,
-      maxTextChars: MAX_EXTRACTED_TEXT_CHARS,
-    });
-    const text = textResult.text;
-
-    if (text.trim().length >= request.minTextChars) {
-      return { text, images: [] };
-    }
-
-    // clawpdf's image render budget (maxPixels) is shared across every page in one
-    // extract() call: the first page consumes it and later pages collapse to 1x1
-    // PNGs that vision models reject. Render each page separately, allocating the
-    // remaining aggregate budget across pages that still need rendering.
-    const imagePages =
-      pages ?? Array.from({ length: Math.min(pdf.pageCount, request.maxPages) }, (_, i) => i + 1);
-
-    try {
-      const images: DocumentExtractedImage[] = [];
-      let remainingPixels = request.maxPixels;
-      for (const [index, pageNumber] of imagePages.entries()) {
-        if (remainingPixels <= 0) {
-          break;
-        }
-        const pagesRemaining = imagePages.length - index;
-        const maxPixelsPerPage = Math.max(1, Math.ceil(remainingPixels / pagesRemaining));
-        const imageResult = await pdf.extract({
-          mode: "images",
-          pages: [pageNumber],
-          image: {
-            maxDimension: MAX_RENDER_DIMENSION,
-            maxPixels: maxPixelsPerPage,
-            forms: true,
-          },
-        });
-        for (const image of imageResult.images) {
-          images.push(toDocumentImage(image));
-          remainingPixels -= image.width * image.height;
-        }
-      }
-      return { text, images };
-    } catch (err) {
-      request.onImageExtractionError?.(err);
-      if (!text.trim()) {
-        throw new Error("PDF image extraction failed with no extractable text.", { cause: err });
-      }
-      return { text, images: [] };
-    }
-  } finally {
-    pdf.destroy();
-  }
-}
+const pool = new WorkerTaskPool<DocumentExtractorWorkerRequest, DocumentExtractorWorkerReply>({
+  workerUrl: resolveRuntimeWorkerUrl(documentExtractorWorkerEntrypoint),
+  // One reusable PDFium heap bounds simultaneous document rendering memory.
+  maxWorkers: 1,
+  sharedCompute: true,
+});
 
 export function createPdfDocumentExtractor(): DocumentExtractorPlugin {
   return {
@@ -132,6 +19,20 @@ export function createPdfDocumentExtractor(): DocumentExtractorPlugin {
     label: "PDF",
     mimeTypes: ["application/pdf"],
     autoDetectOrder: 10,
-    extract: extractPdfContent,
+    extract: async ({ signal, onImageExtractionError, ...request }) => {
+      const reply = await pool.run(request, {
+        timeoutMs: 180_000,
+        signal,
+        inputBytes: request.buffer.byteLength,
+      });
+      signal?.throwIfAborted();
+      for (const error of reply.imageErrors) {
+        onImageExtractionError?.(error);
+      }
+      if (reply.status === "failed") {
+        throw reply.error;
+      }
+      return reply.result;
+    },
   };
 }

--- a/extensions/document-extract/document-extractor.worker.ts
+++ b/extensions/document-extract/document-extractor.worker.ts
@@ -1,0 +1,35 @@
+import type {
+  DocumentExtractionRequest,
+  DocumentExtractionResult,
+} from "openclaw/plugin-sdk/document-extractor";
+import { serveWorkerTasks } from "openclaw/plugin-sdk/process-runtime";
+import { extractPdfContent } from "./document-extractor.runtime.js";
+
+export type DocumentExtractorWorkerRequest = Omit<
+  DocumentExtractionRequest,
+  "signal" | "onImageExtractionError"
+>;
+export type DocumentExtractorWorkerReply = { imageErrors: Error[] } & (
+  | { status: "ok"; result: DocumentExtractionResult }
+  | { status: "failed"; error: Error }
+);
+
+serveWorkerTasks<DocumentExtractorWorkerReply>(async (input) => {
+  // SAFETY: The plugin-owned pool sends this private request shape; both sides are built together.
+  const request = input as DocumentExtractorWorkerRequest;
+  const imageErrors: Error[] = [];
+  try {
+    const result = await extractPdfContent({
+      ...request,
+      onImageExtractionError: (error) =>
+        imageErrors.push(error instanceof Error ? error : new Error(String(error))),
+    });
+    return { status: "ok", result, imageErrors };
+  } catch (error) {
+    return {
+      status: "failed",
+      error: error instanceof Error ? error : new Error(String(error)),
+      imageErrors,
+    };
+  }
+});

--- a/extensions/document-extract/package.json
+++ b/extensions/document-extract/package.json
@@ -11,6 +11,9 @@
     "@openclaw/plugin-sdk": "workspace:*"
   },
   "openclaw": {
+    "build": {
+      "workerEntries": ["./document-extractor.worker.ts"]
+    },
     "extensions": [
       "./index.ts"
     ]

--- a/scripts/lib/runtime-process-build-entries.mts
+++ b/scripts/lib/runtime-process-build-entries.mts
@@ -1,3 +1,4 @@
+import { documentExtractorWorkerEntrypoint } from "../../extensions/document-extract/document-extractor-worker-entrypoint.ts";
 import { vectorKnnProcessEntrypoint } from "../../extensions/memory-core/src/memory/manager-search-knn-entrypoint.ts";
 import {
   createRuntimeProcessBuildEntries,
@@ -6,5 +7,8 @@ import {
 
 export const runtimeProcessBuildEntries = {
   ...runtimeProcessCoreBuildEntries,
-  ...createRuntimeProcessBuildEntries([vectorKnnProcessEntrypoint]),
+  ...createRuntimeProcessBuildEntries([
+    vectorKnnProcessEntrypoint,
+    documentExtractorWorkerEntrypoint,
+  ]),
 };

--- a/scripts/lib/vitest-worker-declarations.mts
+++ b/scripts/lib/vitest-worker-declarations.mts
@@ -1,6 +1,8 @@
 // Declaration paths are shared metadata; only the runner imports their build values.
 export const runtimeProcessDeclarationEntries = {
   "infra/runtime-process-entrypoints": "src/infra/runtime-process-entrypoints.ts",
+  "extensions/document-extract/document-extractor-worker-entrypoint":
+    "extensions/document-extract/document-extractor-worker-entrypoint.ts",
   "extensions/memory-core/manager-search-knn-entrypoint":
     "extensions/memory-core/src/memory/manager-search-knn-entrypoint.ts",
 };

--- a/src/agents/code-mode-worker.ts
+++ b/src/agents/code-mode-worker.ts
@@ -94,7 +94,10 @@ function getCodeModePool(url: URL): WorkerTaskPool<unknown, unknown> {
     // A runtime entry change retires its old workers; ordinary runs reuse the
     // process-stable entry while each request still creates an isolated VM.
     void sharedPool?.pool.close();
-    sharedPool = { url: url.href, pool: new WorkerTaskPool({ workerUrl: url }) };
+    sharedPool = {
+      url: url.href,
+      pool: new WorkerTaskPool({ workerUrl: url, sharedCompute: true }),
+    };
   }
   return sharedPool.pool;
 }
@@ -135,6 +138,13 @@ export async function runCodeModeWorker(
       {
         timeoutMs,
         signal,
+        inputBytes: isRecord(workerData)
+          ? isRecord(workerData.snapshot) && workerData.snapshot.memory instanceof Uint8Array
+            ? workerData.snapshot.memory.byteLength
+            : typeof workerData.source === "string"
+              ? workerData.source.length * 2
+              : 0
+          : 0,
         onInputConsumed: inlineHost?.onInputConsumed,
         onRequest: inlineHost
           ? async (value, context): Promise<WorkerTaskResponse> => {

--- a/src/agents/compaction-planning-worker-runtime.ts
+++ b/src/agents/compaction-planning-worker-runtime.ts
@@ -11,7 +11,7 @@ const COMPACTION_PLANNING_WORKER_TIMEOUT_MS = 60_000;
 export class CompactionPlanningWorkerError extends Error {
   constructor(
     message: string,
-    readonly code: "unavailable" | "timeout" | "failed",
+    readonly code: "unavailable" | "timeout" | "failed" | "overloaded",
   ) {
     super(message);
     this.name = "CompactionPlanningWorkerError";
@@ -22,6 +22,7 @@ const planningPool = new WorkerTaskPool<
   CompactionPlanningWorkerInput,
   CompactionPlanningWorkerValue
 >({
+  sharedCompute: true,
   workerUrl: resolveRuntimeWorkerUrl({
     currentModuleUrl: import.meta.url,
     sourceWorkerName: "compaction-planning.worker",

--- a/src/agents/prepared-model-catalog-worker.integration.test.ts
+++ b/src/agents/prepared-model-catalog-worker.integration.test.ts
@@ -877,6 +877,55 @@ describe("prepared model catalog worker boundary", () => {
     expect(loggedOut?.authStore.profiles[OPENAI_CODEX_DEFAULT_PROFILE_ID]).toBeUndefined();
   });
 
+  it("keeps accepted catalog and auth work alive after overload and permits later refresh", async () => {
+    const fixture = await createReadyWorkerFixture(0);
+    const barrier = `${fixture.marker}.hold`;
+    fs.writeFileSync(barrier, "", "utf8");
+    const catalog = fixture.snapshot.loadFullModelCatalog!();
+    void catalog.catch(() => {});
+    const accepted: ReturnType<typeof loadPreparedModelRuntimeAuth>[] = [];
+    try {
+      await waitForMarker(fixture.marker);
+      // Alternating scopes reach the worker instead of sharing the latest auth request.
+      for (let index = 0; index < 127; index += 1) {
+        const auth = loadPreparedModelRuntimeAuth(fixture.snapshot, {
+          providerIds: index % 2 === 0 ? [PROVIDER_ID] : [PROVIDER_ID, SHARED_AUTH_PROVIDER_ID],
+        });
+        void auth.catch(() => {});
+        accepted.push(auth);
+      }
+      await expect(
+        loadPreparedModelRuntimeAuth(fixture.snapshot, {
+          providerIds: [PROVIDER_ID, SHARED_AUTH_PROVIDER_ID],
+        }),
+      ).rejects.toMatchObject({ name: "WorkerTaskError", code: "overloaded" });
+      fs.rmSync(barrier);
+
+      const outcomes = await Promise.allSettled([catalog, ...accepted]);
+      expect(outcomes.filter((outcome) => outcome.status === "rejected")).toEqual([]);
+      expect((await catalog).entries).toContainEqual(
+        expect.objectContaining({ provider: PROVIDER_ID, id: "plugin-generation-v1" }),
+      );
+      fs.writeFileSync(fixture.externalAuthPath, "B", "utf8");
+      const refreshedAuth = await loadPreparedModelRuntimeAuth(fixture.snapshot, {
+        providerIds: [PROVIDER_ID],
+      });
+      expect(refreshedAuth?.authStore.profiles[EXTERNAL_AUTH_PROFILE_ID]).toMatchObject({
+        access: "v1:B",
+      });
+      const refreshedCatalog = await fixture.snapshot.loadFullModelCatalog!({ refresh: true });
+      expect(refreshedCatalog.entries).toContainEqual(
+        expect.objectContaining({
+          provider: PROVIDER_ID,
+          id: "proof-refresh-2-sqlite-true-shared-true-unrelated-true",
+        }),
+      );
+    } finally {
+      fs.rmSync(barrier, { force: true });
+      await Promise.allSettled([catalog, ...accepted]);
+    }
+  });
+
   it("shares in-flight discovery, caches completion, and explicitly refreshes prepared facts", async () => {
     const fixture = await createReadyWorkerFixture(0);
     const barrier = `${fixture.marker}.hold`;

--- a/src/agents/prepared-model-catalog-worker.ts
+++ b/src/agents/prepared-model-catalog-worker.ts
@@ -353,6 +353,10 @@ export function createPreparedModelCatalogWorker(
       assertCurrent();
     } catch (error) {
       const failure = error instanceof Error ? error : new Error(String(error));
+      if (failure instanceof WorkerTaskError && failure.code === "overloaded") {
+        // Admission pressure rejects this request without retiring the prepared generation.
+        throw failure;
+      }
       if (failure instanceof PreparedModelCatalogGenerationMismatchError) {
         // Keep the generation open, but retire only this request's pool: a delayed rejection
         // from it must not close a replacement already serving the same lifecycle plan.

--- a/src/agents/sessions/session-manager-model-context.test.ts
+++ b/src/agents/sessions/session-manager-model-context.test.ts
@@ -12,10 +12,67 @@ import {
 import { runWithSessionTranscriptReadFence } from "../../config/sessions/session-transcript-read-fence.js";
 import { waitForSessionTranscriptProjection } from "../../config/sessions/session-transcript-reconcile.js";
 import { WorkerTaskPool } from "../../infra/worker-task-pool.js";
+import { createDeferredCore } from "../../shared/deferred.js";
 import { openOpenClawAgentDatabase } from "../../state/openclaw-agent-db.js";
 import { withOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
 import { makeAgentAssistantMessage } from "../test-helpers/agent-message-fixtures.js";
 import { CURRENT_SESSION_VERSION, SessionManager } from "./session-manager.js";
+
+it("reports context queue overload without losing context and recovers in admission order", async () => {
+  await withOpenClawTestState({ label: "model-context-pressure" }, async (state) => {
+    const scope = {
+      agentId: "main",
+      sessionId: "context-pressure",
+      sessionKey: "agent:main:context-pressure",
+      storePath: path.join(state.agentDir("main"), "openclaw-agent.sqlite"),
+    };
+    await upsertSessionEntryCore(scope, { sessionId: scope.sessionId, updatedAt: 1 });
+    const source = SessionManager.open(scope);
+    source.appendMessage(makeUserMessage("retain this context", 1));
+    await waitForSessionTranscriptProjection(scope);
+    const expected = source.buildSessionContext();
+    const release = createDeferredCore();
+    const completed: number[] = [];
+    const spy = vi
+      .spyOn(WorkerTaskPool.prototype, "run")
+      .mockImplementationOnce(function (this: WorkerTaskPool<unknown, unknown>, input, options) {
+        spy.mockRestore();
+        // Hold this caller's first preparation while real pool admission fills the queue.
+        return this.run(async () => {
+          await release.promise;
+          return input;
+        }, options);
+      });
+    const accepted = Array.from({ length: 128 }, (_, index) =>
+      SessionManager.openModelContextAsync(scope).then((context) => {
+        completed.push(index);
+        return context.buildSessionContext();
+      }),
+    );
+    let reported: unknown;
+    const excess = SessionManager.openModelContextAsync(scope).catch((error: unknown) => {
+      reported = error;
+    });
+    try {
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
+      expect(reported).toMatchObject({ name: "WorkerTaskError", code: "overloaded" });
+      expect(completed).toEqual([]);
+      expect(source.buildSessionContext()).toEqual(expected);
+      release.resolve();
+      expect(await Promise.all(accepted)).toEqual(Array.from({ length: 128 }, () => expected));
+      expect(completed).toEqual(Array.from({ length: 128 }, (_, index) => index));
+      expect((await SessionManager.openModelContextAsync(scope)).buildSessionContext()).toEqual(
+        expected,
+      );
+    } finally {
+      release.resolve();
+      spy.mockRestore();
+      await Promise.allSettled([...accepted, excess]);
+    }
+  });
+});
 
 it("acquires a long sparse context with bounded queries and preserved message order", async () => {
   await withOpenClawTestState({ label: "model-context-batch" }, async (state) => {

--- a/src/agents/tools/pdf-tool.runtime-abort.test.ts
+++ b/src/agents/tools/pdf-tool.runtime-abort.test.ts
@@ -88,6 +88,9 @@ describe("PDF tool prepared-runtime cancellation", () => {
       );
 
       await vi.waitFor(() => expect(completeMock).toHaveBeenCalledOnce());
+      expect(vi.mocked(pdfExtractModule.extractPdfContent).mock.calls[0]?.[0].signal).toBe(
+        controller.signal,
+      );
       const options = completeMock.mock.calls[0]?.[2];
       expect(options?.signal).toBe(controller.signal);
       const assertion = expect(execution).rejects.toThrow("PDF provider cancelled");

--- a/src/agents/tools/pdf-tool.ts
+++ b/src/agents/tools/pdf-tool.ts
@@ -597,6 +597,7 @@ export function createPdfTool(options?: {
         // document after the owning agent run has been cancelled.
         signal?.throwIfAborted();
         const extracted = await extractPdfContent({
+          ...(signal ? { signal } : {}),
           buffer: pdf.buffer,
           maxPages: configuredMaxPages,
           maxPixels: PDF_MAX_PIXELS,

--- a/src/config/sessions/disk-budget.physical-usage.test.ts
+++ b/src/config/sessions/disk-budget.physical-usage.test.ts
@@ -4,6 +4,8 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { Worker } from "node:worker_threads";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { WorkerTaskPool } from "../../infra/worker-task-pool.js";
+import { createDeferredCore } from "../../shared/deferred.js";
 import { withTestDir } from "../../test-helpers/temp-dir.js";
 import {
   hasRetainedSessionTranscriptArchives,
@@ -30,6 +32,60 @@ async function addSessionArtifacts(directory: string, index: number): Promise<vo
 }
 
 describe("physical session disk usage", () => {
+  it("reports scan overload before pruning archives and recovers after queued scans drain", async () => {
+    await withTestDir({ prefix: "openclaw-disk-usage-pressure-" }, async (directory) => {
+      const storePath = path.join(directory, "openclaw-agent.sqlite");
+      const archivePath = path.join(directory, "old.jsonl.deleted.2026-01-01T00-00-00.000Z.zst");
+      await fs.writeFile(storePath, Buffer.alloc(321));
+      await fs.writeFile(archivePath, Buffer.alloc(100));
+      const release = createDeferredCore();
+      const spy = vi
+        .spyOn(WorkerTaskPool.prototype, "run")
+        .mockImplementationOnce(function (this: WorkerTaskPool<unknown, unknown>, input, options) {
+          spy.mockRestore();
+          // Delay preparation, not the caller's result or the pool's capacity decision.
+          return this.run(async () => {
+            await release.promise;
+            return input;
+          }, options);
+        });
+      const accepted = Array.from({ length: 128 }, () =>
+        measureSessionPhysicalDiskUsage(storePath),
+      );
+      let reported: unknown;
+      const excess = measureSessionPhysicalDiskUsage(storePath).catch((error: unknown) => {
+        reported = error;
+      });
+      try {
+        await new Promise<void>((resolve) => {
+          setImmediate(resolve);
+        });
+        expect(reported).toMatchObject({ name: "WorkerTaskError", code: "overloaded" });
+        await expect(
+          pruneSessionTranscriptArchivesToHighWater({ storePath, highWaterBytes: 321 }),
+        ).rejects.toMatchObject({ code: "overloaded" });
+        expect((await fs.stat(archivePath)).size).toBe(100);
+        release.resolve();
+        const usage = {
+          databaseMainBytes: 321,
+          databaseWalBytes: 0,
+          sessionFilesBytes: 100,
+          totalBytes: 421,
+        };
+        expect(await Promise.all(accepted)).toEqual(Array.from({ length: 128 }, () => usage));
+        await expect(
+          pruneSessionTranscriptArchivesToHighWater({ storePath, highWaterBytes: 321 }),
+        ).resolves.toMatchObject({ removedFiles: 1, usage: { totalBytes: 321 } });
+        await expect(fs.stat(archivePath)).rejects.toMatchObject({ code: "ENOENT" });
+        expect(workers).toHaveLength(1);
+      } finally {
+        release.resolve();
+        spy.mockRestore();
+        await Promise.allSettled([...accepted, excess]);
+      }
+    });
+  });
+
   it.each(["legacy", "sqlite", "legacy-in-agent"] as const)(
     "measures and prunes the canonical session artifacts through the %s selector",
     async (selector) => {

--- a/src/infra/runtime-process-entrypoints.ts
+++ b/src/infra/runtime-process-entrypoints.ts
@@ -4,6 +4,11 @@ const currentModuleUrl = import.meta.url;
 export const SQLITE_READONLY_CHILD_ARG = "--openclaw-sqlite-readonly-child";
 
 export const runtimeProcessEntrypoints = {
+  imageProcessor: {
+    currentModuleUrl,
+    sourceWorkerName: "../media/image-processor.worker",
+    distWorkerPath: "media/image-processor.worker.js",
+  },
   sharedStateStore: {
     currentModuleUrl,
     sourceWorkerName: "../state/openclaw-state.worker",

--- a/src/infra/runtime-worker-url.test.ts
+++ b/src/infra/runtime-worker-url.test.ts
@@ -1,5 +1,5 @@
 import { execFile } from "node:child_process";
-import { writeFile } from "node:fs/promises";
+import { link, writeFile } from "node:fs/promises";
 import { createRequire } from "node:module";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
@@ -49,6 +49,51 @@ describe("resolveRuntimeWorkerUrl", () => {
         ),
       ).toBe(path.join(candidateRoot, "dist/agents/code-mode.worker.js"));
     }
+  });
+
+  it("selects plugin package paths with hardlinked manifests, renamed directories, and chunks", async () => {
+    await withTempDir("openclaw-renamed-worker-package-", async (root) => {
+      const entry = {
+        sourceWorkerName: "store.worker",
+        distWorkerPath: "extensions/store/store.worker.js",
+        package: { name: "@openclaw/store", distWorkerPath: "src/store.worker.js" },
+      };
+      await writeFile(path.join(root, "package-store.json"), "{}");
+      await link(path.join(root, "package-store.json"), path.join(root, "package.json"));
+      for (const packageName of ["openclaw", "@openclaw/store"]) {
+        await writeFile(path.join(root, "package.json"), JSON.stringify({ name: packageName }));
+        for (const modulePath of ["dist/index.js", "dist/.setup/shared-abc.mjs"]) {
+          const currentModuleUrl = pathToFileURL(path.join(root, modulePath)).href;
+          expect(fileURLToPath(resolveRuntimeWorkerUrl({ ...entry, currentModuleUrl }))).toBe(
+            path.join(
+              root,
+              "dist",
+              packageName === entry.package.name
+                ? entry.package.distWorkerPath
+                : entry.distWorkerPath,
+            ),
+          );
+          expect(fileURLToPath(resolveRuntimeWorkerUrl({ ...entry, currentModuleUrl, root }))).toBe(
+            path.join(root, "dist", entry.distWorkerPath),
+          );
+        }
+      }
+      await writeFile(path.join(root, "package.json"), "invalid-json");
+      expect(() =>
+        resolveRuntimeWorkerUrl({
+          ...entry,
+          currentModuleUrl: pathToFileURL(path.join(root, "dist/index.js")).href,
+        }),
+      ).toThrow("Cannot resolve runtime worker package");
+      expect(
+        fileURLToPath(
+          resolveRuntimeWorkerUrl({
+            ...entry,
+            currentModuleUrl: pathToFileURL(path.join(root, "src/entry.ts")).href,
+          }),
+        ),
+      ).toBe(path.join(root, "src/store.worker.ts"));
+    });
   });
 });
 

--- a/src/infra/runtime-worker-url.ts
+++ b/src/infra/runtime-worker-url.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
+import { readRootJsonObjectSync } from "@openclaw/fs-safe/json";
 import { isBunRuntime } from "../daemon/runtime-binary.js";
 
 /** Resolve an explicit installed root, source sibling, or stable packaged worker path. */
@@ -8,6 +9,8 @@ export function resolveRuntimeWorkerUrl(params: {
   sourceWorkerName: string;
   distWorkerPath: string;
   root?: string;
+  /** Package-local output when the nearest dist belongs to this package. */
+  package?: { name: string; distWorkerPath: string };
 }): URL {
   if (params.root !== undefined) {
     return pathToFileURL(path.join(params.root, "dist", params.distWorkerPath));
@@ -18,7 +21,24 @@ export function resolveRuntimeWorkerUrl(params: {
   const distIndex = normalized.lastIndexOf(distMarker);
   if (distIndex >= 0) {
     const distRoot = currentPath.slice(0, distIndex + distMarker.length);
-    return pathToFileURL(path.join(distRoot, params.distWorkerPath));
+    let workerPath = params.distWorkerPath;
+    if (params.package) {
+      const packageRoot = path.resolve(distRoot, "..");
+      const manifest = readRootJsonObjectSync({
+        rootDir: packageRoot,
+        relativePath: "package.json",
+        boundaryLabel: "runtime worker package",
+        rejectHardlinks: false,
+      });
+      if (!manifest.ok) {
+        throw new Error(`Cannot resolve runtime worker package: ${packageRoot}/package.json`);
+      }
+      // Standalone plugins keep their own dist root, including shared build chunks.
+      if (manifest.value.name === params.package.name) {
+        workerPath = params.package.distWorkerPath;
+      }
+    }
+    return pathToFileURL(path.join(distRoot, workerPath));
   }
   const extension = path.extname(currentPath) || ".js";
   return new URL(`./${params.sourceWorkerName}${extension}`, params.currentModuleUrl);

--- a/src/infra/worker-task-capacity.ts
+++ b/src/infra/worker-task-capacity.ts
@@ -1,0 +1,84 @@
+import { availableParallelism } from "node:os";
+import { resolveGlobalSingleton } from "../shared/global-singleton.js";
+
+export const DEFAULT_WORKER_PENDING_TASKS = 128;
+export const DEFAULT_WORKER_PENDING_BYTES = 256 * 1024 * 1024;
+
+export type WorkerComputePermit = { requestCheckpoint: () => boolean };
+
+/** Shared compute admission; database and generation workers keep their own ordering. */
+export function getWorkerComputeCapacity() {
+  return resolveGlobalSingleton(Symbol.for("openclaw.workerComputeCapacity"), () => {
+    const limit = Math.max(1, availableParallelism() - 1);
+    const active = new Set<WorkerComputePermit>();
+    const waiting = new Set<() => void>();
+    let pendingTasks = 0;
+    let pendingBytes = 0;
+    let draining = false;
+    const requestCheckpoints = () => {
+      let demand = waiting.size;
+      if (demand) {
+        for (const permit of active) {
+          if (permit.requestCheckpoint() && --demand === 0) {
+            break;
+          }
+        }
+      }
+    };
+    const drain = () => {
+      if (draining) {
+        return;
+      }
+      draining = true;
+      try {
+        while (active.size < limit && waiting.size) {
+          const next = waiting.values().next().value!;
+          waiting.delete(next);
+          next();
+        }
+      } finally {
+        draining = false;
+      }
+      requestCheckpoints();
+    };
+    return {
+      admit(bytes: number): boolean {
+        if (
+          pendingTasks >= DEFAULT_WORKER_PENDING_TASKS ||
+          pendingBytes + bytes > DEFAULT_WORKER_PENDING_BYTES
+        ) {
+          return false;
+        }
+        pendingTasks++;
+        pendingBytes += bytes;
+        return true;
+      },
+      finish(bytes: number) {
+        pendingTasks--;
+        pendingBytes -= bytes;
+      },
+      acquire(
+        resume: () => void,
+        requestCheckpoint: () => boolean,
+      ): WorkerComputePermit | undefined {
+        // A newly submitting pool must not overtake an already waiting pool.
+        if (active.size >= limit || (!draining && waiting.size)) {
+          waiting.add(resume);
+          requestCheckpoints();
+          return undefined;
+        }
+        const permit = { requestCheckpoint };
+        active.add(permit);
+        return permit;
+      },
+      release(permit: WorkerComputePermit) {
+        active.delete(permit);
+        drain();
+      },
+      remove(resume: () => void) {
+        waiting.delete(resume);
+      },
+      requestCheckpoints,
+    };
+  });
+}

--- a/src/infra/worker-task-pool.test.ts
+++ b/src/infra/worker-task-pool.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { AsyncLocalStorage } from "node:async_hooks";
 import { execFile } from "node:child_process";
+import { availableParallelism } from "node:os";
 import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
 import type { Worker } from "node:worker_threads";
@@ -12,6 +13,11 @@ import type { PoolFixtureInput, PoolFixtureResult } from "./worker-task-pool.tes
 const workerUrl = new URL("./worker-task-pool.test-support.ts", import.meta.url);
 const pools: WorkerTaskPool<PoolFixtureInput, PoolFixtureResult>[] = [];
 const workers = vi.hoisted(() => [] as Worker[]);
+
+vi.mock("node:os", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("node:os")>()),
+  availableParallelism: () => 4,
+}));
 
 vi.mock("node:worker_threads", async (importOriginal) => {
   const actual = await importOriginal<typeof import("node:worker_threads")>();
@@ -48,6 +54,134 @@ afterEach(async () => {
 });
 
 describe("worker task pool", () => {
+  it("keeps canceled preparation charged until its retained input is released", async () => {
+    const pool = createPool({ workerUrl, maxPendingTasks: 1 });
+    const gate = createDeferredCore<PoolFixtureInput>();
+    const controller = new AbortController();
+    const first = pool.run(() => gate.promise, { signal: controller.signal });
+    const settled = Promise.allSettled([first]);
+    controller.abort();
+    await settled;
+    await expect(pool.run({ label: "excess" }, {})).rejects.toMatchObject({ code: "overloaded" });
+    gate.resolve({ label: "canceled" });
+    await gate.promise;
+    expect(await pool.run({ label: "recovered" }, {})).toMatchObject({ label: "recovered" });
+  });
+
+  it.each(["tasks", "bytes"] as const)(
+    "rejects excess pending %s and releases rejected inputs in caller context",
+    async (bound) => {
+      const context = new AsyncLocalStorage<string>();
+      const pool = createPool({
+        workerUrl,
+        maxPendingTasks: bound === "tasks" ? 2 : 10,
+        maxPendingBytes: 8,
+      });
+      const ready = createDeferredCore<PoolFixtureInput>();
+      const first = pool.run(() => ready.promise, { inputBytes: 4 });
+      const queued = pool.run({ label: "queued" }, { inputBytes: 4 });
+      const released: Array<string | undefined> = [];
+      let prepared = false;
+      const excess = context.run("rejected owner", () =>
+        pool.run(
+          () => {
+            prepared = true;
+            return { label: "excess" };
+          },
+          {
+            inputBytes: bound === "bytes" ? 1 : 0,
+            onInputConsumed: () => released.push(context.getStore()),
+          },
+        ),
+      );
+      const settled = Promise.allSettled([first, queued, excess]);
+      ready.resolve({ label: "first" });
+      const results = await settled;
+      expect(results[2]).toMatchObject({ status: "rejected", reason: { code: "overloaded" } });
+      expect(prepared).toBe(false);
+      expect(released).toEqual(["rejected owner"]);
+      expect(await pool.run({ label: "recovered" }, { inputBytes: 8 })).toMatchObject({
+        label: "recovered",
+      });
+    },
+  );
+
+  it("shares compute capacity across pools while ordered workers remain independent", async () => {
+    const limit = Math.max(1, availableParallelism() - 1);
+    const owner = createPool({ workerUrl, sharedCompute: true, maxWorkers: limit });
+    const waiting = createPool({ workerUrl, sharedCompute: true });
+    const independent = createPool();
+    const gate = createDeferredCore<PoolFixtureInput>();
+    const running = Array.from({ length: limit }, () => owner.run(() => gate.promise, {}));
+    let prepared = false;
+    const queued = waiting.run(() => {
+      prepared = true;
+      return { label: "waiting" };
+    }, {});
+    const settled = Promise.allSettled([...running, queued]);
+    try {
+      expect(prepared).toBe(false);
+      expect(await independent.run({ label: "ordered" }, {})).toMatchObject({ label: "ordered" });
+      expect(prepared).toBe(false);
+    } finally {
+      gate.resolve({ label: "owner" });
+      await settled;
+    }
+    expect(await queued).toMatchObject({ label: "waiting" });
+  });
+
+  it.each(["before", "during"] as const)(
+    "requests a host checkpoint for contention %s the exchange",
+    async (contention) => {
+      const context = new AsyncLocalStorage<string>();
+      let checkpointContext: string | undefined;
+      const limit = Math.max(1, availableParallelism() - 1);
+      const owner = createPool({ workerUrl, sharedCompute: true, maxWorkers: limit });
+      const waiting = createPool({ workerUrl, sharedCompute: true });
+      const gate = createDeferredCore<PoolFixtureInput>();
+      const entered = createDeferredCore();
+      const checkpoint = createDeferredCore();
+      let checkpointRequested = false;
+      const blockers = Array.from({ length: limit - 1 }, () => owner.run(() => gate.promise, {}));
+      const host = context.run("host owner", () =>
+        owner.run(
+          { label: "host", exchanges: 1 },
+          {
+            onRequest: async (_input, { yieldSignal }) => {
+              entered.resolve();
+              const requestCheckpoint = () => {
+                checkpointContext = context.getStore();
+                checkpointRequested = true;
+                checkpoint.resolve();
+              };
+              if (yieldSignal.aborted) {
+                requestCheckpoint();
+              } else {
+                yieldSignal.addEventListener("abort", requestCheckpoint, { once: true });
+              }
+              await checkpoint.promise;
+              return { input: null };
+            },
+          },
+        ),
+      );
+      const settled = Promise.allSettled([...blockers, host]);
+      if (contention === "during") {
+        await entered.promise;
+      }
+      const next = context.run("contender", () => waiting.run({ label: "next" }, {}));
+      try {
+        await expect.poll(() => checkpointRequested).toBe(true);
+        expect(checkpointContext).toBe("host owner");
+        expect(await next).toMatchObject({ label: "next" });
+      } finally {
+        checkpoint.resolve();
+        gate.resolve({ label: "blocker" });
+        await Promise.allSettled([settled, next]);
+      }
+    },
+  );
+
   it.each(["abort", "close"] as const)(
     "keeps host cancellation callbacks in the admitted caller context on %s",
     async (ending) => {

--- a/src/infra/worker-task-pool.test.ts
+++ b/src/infra/worker-task-pool.test.ts
@@ -160,7 +160,7 @@ describe("worker task pool", () => {
                 yieldSignal.addEventListener("abort", requestCheckpoint, { once: true });
               }
               await checkpoint.promise;
-              return { input: null };
+              return { input: null, timeoutMs: 10_000 };
             },
           },
         ),

--- a/src/infra/worker-task-pool.ts
+++ b/src/infra/worker-task-pool.ts
@@ -1,13 +1,21 @@
 import { AsyncLocalStorage } from "node:async_hooks";
+import { channel as createDiagnosticsChannel } from "node:diagnostics_channel";
 import { availableParallelism } from "node:os";
 import { parentPort, Worker, type Transferable, type WorkerOptions } from "node:worker_threads";
 import { toErrorObject } from "@openclaw/normalization-core/error-coercion";
 import { resolveTimerTimeoutMs } from "@openclaw/normalization-core/number-coercion";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { createDeferredCore, type Deferred } from "../shared/deferred.js";
+import {
+  DEFAULT_WORKER_PENDING_BYTES,
+  DEFAULT_WORKER_PENDING_TASKS,
+  getWorkerComputeCapacity,
+  type WorkerComputePermit,
+} from "./worker-task-capacity.js";
 
 // Reusable workers must not retain the first submitting caller's async scope.
 const runInWorkerPoolContext = AsyncLocalStorage.snapshot();
+const taskDiagnostics = createDiagnosticsChannel("openclaw.worker.task");
 
 type WorkerTaskInput<Input> = Input | (() => Input | Promise<Input>);
 export type WorkerTaskResponse = {
@@ -26,6 +34,8 @@ export type WorkerTaskRequestContext = {
 };
 
 type WorkerTaskOptions<Input> = {
+  /** Known retained input bytes, including inputs captured by a factory. No serialization pass. */
+  inputBytes?: number;
   /** When supplied, queueing and asynchronous preparation consume the execution deadline. */
   timeoutMs?: number;
   signal?: AbortSignal;
@@ -59,6 +69,14 @@ type Task<Input, Output> = Deferred<Output> & {
   abort: () => void;
   done: boolean;
   slot?: Slot<Input, Output>;
+  admitted: boolean;
+  preparing: boolean;
+  inputBytes: number;
+  computePermit?: WorkerComputePermit;
+  enqueuedAt: number;
+  startedAt?: number;
+  preparedAt?: number;
+  transferMs: number;
 };
 type Slot<Input, Output> = {
   worker?: Worker;
@@ -70,7 +88,7 @@ type Slot<Input, Output> = {
 export class WorkerTaskError extends Error {
   constructor(
     message: string,
-    readonly code: "unavailable" | "timeout" | "failed",
+    readonly code: "unavailable" | "timeout" | "failed" | "overloaded",
   ) {
     super(message);
     this.name = "WorkerTaskError";
@@ -82,6 +100,12 @@ export class WorkerTaskPool<Input, Output> {
   private readonly slots = new Set<Slot<Input, Output>>();
   private readonly queue: Task<Input, Output>[] = [];
   private readonly maxWorkers: number;
+  private readonly maxPendingTasks: number;
+  private readonly maxPendingBytes: number;
+  private pendingTasks = 0;
+  private pendingBytes = 0;
+  private readonly computeCapacity: ReturnType<typeof getWorkerComputeCapacity> | undefined;
+  private readonly resumeCompute = () => this.dispatch();
   private closedError?: Error;
   private nextTaskId = 0;
   // Idle retirement is armed from worker messages, outside any caller's turn.
@@ -96,17 +120,38 @@ export class WorkerTaskPool<Input, Output> {
       workerUrl: URL;
       workerOptions?: Omit<WorkerOptions, "eval">;
       maxWorkers?: number;
+      /** Share CPU admission with other stateless compute pools in this isolate. */
+      sharedCompute?: boolean;
+      /** Include queued, preparing, and running tasks until execution has settled. */
+      maxPendingTasks?: number;
+      maxPendingBytes?: number;
       idleTimeoutMs?: number;
       restartOnError?: boolean;
       validateResult?: (value: Output) => void;
     },
   ) {
     this.maxWorkers = options.maxWorkers ?? availableParallelism();
+    this.maxPendingTasks = options.maxPendingTasks ?? DEFAULT_WORKER_PENDING_TASKS;
+    this.maxPendingBytes = options.maxPendingBytes ?? DEFAULT_WORKER_PENDING_BYTES;
+    for (const [name, value] of Object.entries({
+      maxWorkers: this.maxWorkers,
+      maxPendingTasks: this.maxPendingTasks,
+      maxPendingBytes: this.maxPendingBytes,
+    })) {
+      if (!Number.isSafeInteger(value) || value < 1) {
+        throw new RangeError(`${name} must be a positive safe integer`);
+      }
+    }
+    this.computeCapacity = options.sharedCompute ? getWorkerComputeCapacity() : undefined;
   }
 
   run(input: WorkerTaskInput<Input>, options: WorkerTaskOptions<Input>): Promise<Output> {
     if (this.closedError) {
       return Promise.reject(this.closedError);
+    }
+    const inputBytes = options.inputBytes ?? 0;
+    if (!Number.isSafeInteger(inputBytes) || inputBytes < 0) {
+      return Promise.reject(new RangeError("inputBytes must be a nonnegative safe integer"));
     }
     // A Promise executor would let the task's timer/abort closures retain input too.
     const task: Task<Input, Output> = {
@@ -120,7 +165,23 @@ export class WorkerTaskPool<Input, Output> {
       options: { ...options },
       abort: () => this.cancel(task, toErrorObject(options.signal?.reason, "worker task aborted")),
       done: false,
+      admitted: false,
+      preparing: false,
+      inputBytes,
+      enqueuedAt: performance.now(),
+      transferMs: 0,
     };
+    if (
+      this.pendingTasks >= this.maxPendingTasks ||
+      this.pendingBytes + inputBytes > this.maxPendingBytes ||
+      (this.computeCapacity && !this.computeCapacity.admit(inputBytes))
+    ) {
+      this.finish(task, new WorkerTaskError("worker task capacity reached", "overloaded"));
+      return task.promise;
+    }
+    task.admitted = true;
+    this.pendingTasks++;
+    this.pendingBytes += inputBytes;
     if (options.timeoutMs !== undefined) {
       this.armTimeout(task, options.timeoutMs);
     }
@@ -138,6 +199,7 @@ export class WorkerTaskPool<Input, Output> {
     error: Error = new WorkerTaskError("worker task pool closed", "unavailable"),
   ): Promise<void> {
     this.closedError ??= error;
+    this.computeCapacity?.remove(this.resumeCompute);
     for (const task of this.queue.splice(0)) {
       this.finish(task, this.closedError);
     }
@@ -150,6 +212,9 @@ export class WorkerTaskPool<Input, Output> {
   }
 
   private dispatch(): void {
+    if (!this.queue.length || this.closedError) {
+      this.computeCapacity?.remove(this.resumeCompute);
+    }
     while (!this.closedError && this.queue.length) {
       let slot = [...this.slots].find((entry) => !entry.task && !entry.retiring);
       if (!slot) {
@@ -169,6 +234,22 @@ export class WorkerTaskPool<Input, Output> {
           }
           return;
         }
+      }
+      const nextTask = this.queue[0]!;
+      if (this.computeCapacity) {
+        const permit = this.computeCapacity.acquire(this.resumeCompute, () => {
+          if (nextTask.exchange && !nextTask.exchange.sent) {
+            nextTask.runInContext(() => nextTask.exchange?.pressure.abort());
+            return true;
+          }
+          return false;
+        });
+        if (!permit) {
+          return;
+        }
+        nextTask.computePermit = permit;
+      }
+      if (!slot) {
         slot = {};
         this.slots.add(slot);
       }
@@ -176,6 +257,7 @@ export class WorkerTaskPool<Input, Output> {
       const task = this.queue.shift()!;
       slot.task = task;
       task.slot = slot;
+      task.startedAt = performance.now();
       slot.worker?.ref();
       void task.runInContext(() => this.start(slot, task));
     }
@@ -217,6 +299,7 @@ export class WorkerTaskPool<Input, Output> {
     const taskInput = task.input!;
     delete task.input;
     let input: Input;
+    task.preparing = true;
     try {
       input =
         typeof taskInput === "function"
@@ -225,19 +308,27 @@ export class WorkerTaskPool<Input, Output> {
     } catch (error) {
       this.fail(slot, toErrorObject(error, "worker task preparation failed"));
       return;
+    } finally {
+      task.preparing = false;
+      if (task.done) {
+        this.releaseAdmission(task);
+      }
     }
     // A cancelled preparation may finish later, but it must never create or feed a worker.
     if (task.done) {
       return;
     }
+    task.preparedAt = performance.now();
     try {
       const worker = slot.worker ?? this.createWorker(slot);
       const transferList = task.options.transferList?.(input);
       if (!task.done) {
+        const transferStartedAt = performance.now();
         worker.postMessage(
           { input, taskId: task.id, interactive: Boolean(task.options.onRequest) },
           transferList,
         );
+        task.transferMs += performance.now() - transferStartedAt;
       }
     } catch (error) {
       this.fail(slot, new WorkerTaskError(String(error), "unavailable"));
@@ -348,6 +439,7 @@ export class WorkerTaskPool<Input, Output> {
     };
     task.exchange = exchange;
     this.dispatch();
+    this.computeCapacity?.requestCheckpoints();
     void Promise.resolve()
       .then(() => {
         if (task.done || slot.task !== task) {
@@ -425,6 +517,9 @@ export class WorkerTaskPool<Input, Output> {
     // SAFETY: Only a validated successful reply reaches finish without an error and supplies Output.
     const complete = () =>
       task.runInContext(() => {
+        if (!task.preparing) {
+          this.releaseAdmission(task);
+        }
         let completionError = error;
         try {
           // Retiring completion runs only after terminate() resolves. Queued inputs
@@ -438,6 +533,25 @@ export class WorkerTaskPool<Input, Output> {
           release?.();
         } catch (releaseError) {
           completionError ??= toErrorObject(releaseError, "worker input release failed");
+        }
+        const permit = task.computePermit;
+        task.computePermit = undefined;
+        if (permit) {
+          this.computeCapacity!.release(permit);
+        }
+        if (taskDiagnostics.hasSubscribers) {
+          const now = performance.now();
+          taskDiagnostics.publish({
+            worker: this.options.workerUrl.pathname.split("/").at(-1),
+            outcome: completionError ? "failed" : "ok",
+            queueMs: (task.startedAt ?? now) - task.enqueuedAt,
+            preparationMs:
+              task.startedAt === undefined ? 0 : (task.preparedAt ?? now) - task.startedAt,
+            runMs: task.preparedAt === undefined ? 0 : now - task.preparedAt,
+            transferMs: task.transferMs,
+            pendingTasks: this.pendingTasks,
+            pendingBytes: this.pendingBytes,
+          });
         }
         if (completionError) {
           task.reject(completionError);
@@ -454,12 +568,21 @@ export class WorkerTaskPool<Input, Output> {
         void this.retire(slot).then(complete);
         return;
       }
-      if (!this.queue.length) {
-        this.idle(slot);
-      }
     }
     complete();
     this.dispatch();
+    if (slot && !slot.task && !slot.retiring) {
+      this.idle(slot);
+    }
+  }
+
+  private releaseAdmission(task: Task<Input, Output>): void {
+    if (task.admitted) {
+      task.admitted = false;
+      this.pendingTasks--;
+      this.pendingBytes -= task.inputBytes;
+      this.computeCapacity?.finish(task.inputBytes);
+    }
   }
 
   // Reply handling restores the caller's context; idle retirement must leave it behind.

--- a/src/media/document-extractors.runtime.test.ts
+++ b/src/media/document-extractors.runtime.test.ts
@@ -93,6 +93,37 @@ describe("extractDocumentContent", () => {
     expect(extractionError.cause).toBe(cause);
   });
 
+  it("forwards cancellation and does not try another extractor after the owner aborts", async () => {
+    const abort = new AbortController();
+    const reason = new Error("owning turn cancelled");
+    const first = vi.fn(async (request: DocumentExtractionRequest) => {
+      expect(request.signal).toBe(abort.signal);
+      abort.abort(reason);
+      throw reason;
+    });
+    const second = vi.fn();
+    resolvePluginDocumentExtractorsMock.mockReturnValue(
+      [first, second].map((extract, index) => ({
+        id: `pdf-${index}`,
+        pluginId: "document-extract",
+        label: "PDF",
+        mimeTypes: ["application/pdf"],
+        extract,
+      })),
+    );
+    await expect(
+      extractPdfContent({
+        buffer: Buffer.from("pdf"),
+        maxPages: 1,
+        maxPixels: 100,
+        minTextChars: 1,
+        signal: abort.signal,
+      }),
+    ).rejects.toBe(reason);
+    expect(first).toHaveBeenCalledOnce();
+    expect(second).not.toHaveBeenCalled();
+  });
+
   it("replaces cached document extractor callbacks when plugin metadata changes", async () => {
     const oldExtract = vi.fn().mockResolvedValue({ text: "retired", images: [] });
     const newExtract = vi.fn().mockResolvedValue({ text: "replacement", images: [] });

--- a/src/media/document-extractors.runtime.ts
+++ b/src/media/document-extractors.runtime.ts
@@ -19,7 +19,9 @@ export async function extractDocumentContent(
   },
 ): Promise<(DocumentExtractionResult & { extractor: string }) | null> {
   const mimeType = normalizeLowercaseStringOrEmpty(params.mimeType);
+  params.signal?.throwIfAborted();
   const extractors = await documentExtractorLoader.load(params.config);
+  params.signal?.throwIfAborted();
   // Keep config and loader-only fields out of plugin calls; extractors receive the SDK request shape.
   const request: DocumentExtractionRequest = {
     buffer: params.buffer,
@@ -29,6 +31,7 @@ export async function extractDocumentContent(
     minTextChars: params.minTextChars,
     ...(params.password ? { password: params.password } : {}),
     ...(params.pageNumbers ? { pageNumbers: params.pageNumbers } : {}),
+    ...(params.signal ? { signal: params.signal } : {}),
     ...(params.onImageExtractionError
       ? { onImageExtractionError: params.onImageExtractionError }
       : {}),
@@ -43,6 +46,7 @@ export async function extractDocumentContent(
     }
     try {
       const result = await extractor.extract(request);
+      params.signal?.throwIfAborted();
       if (result) {
         return {
           ...result,
@@ -50,6 +54,7 @@ export async function extractDocumentContent(
         };
       }
     } catch (error) {
+      params.signal?.throwIfAborted();
       errors.push(error);
     }
   }

--- a/src/media/image-ops.rastermill-adapter.test.ts
+++ b/src/media/image-ops.rastermill-adapter.test.ts
@@ -12,6 +12,7 @@ describe("image ops Rastermill adapter", () => {
       vi.doUnmock("rastermill");
       vi.doUnmock("@silvia-odwyer/photon-node");
       vi.doUnmock("../infra/resolve-system-bin.js");
+      vi.doUnmock("../infra/worker-task-pool.js");
       vi.resetModules();
     });
 
@@ -30,11 +31,11 @@ describe("image ops Rastermill adapter", () => {
         readImageProbeFromHeader: vi.fn(() => ({ width: 1, height: 1, format: "jpeg" })),
       }));
 
-      const { resizeToJpeg } = await import("./image-ops.js");
+      const { createLocalImageProcessor } = await import("./image-processor-config.js");
 
       await expect(
-        resizeToJpeg({ buffer: Buffer.from("input"), maxSide: 1, quality: 80 }),
-      ).resolves.toEqual(Buffer.from("jpeg"));
+        createLocalImageProcessor("auto").encode(Buffer.from("input"), { format: "jpeg" }),
+      ).resolves.toEqual({ data: Buffer.from("jpeg") });
       expect(photonModuleFactory).not.toHaveBeenCalled();
     });
 
@@ -54,11 +55,12 @@ describe("image ops Rastermill adapter", () => {
         resolveSystemBin,
       }));
 
-      const { resizeToJpeg, MAX_IMAGE_INPUT_PIXELS } = await import("./image-ops.js");
+      const { createLocalImageProcessor, MAX_IMAGE_INPUT_PIXELS } =
+        await import("./image-processor-config.js");
 
       await expect(
-        resizeToJpeg({ buffer: Buffer.from("input"), maxSide: 1, quality: 80 }),
-      ).resolves.toEqual(Buffer.from("jpeg"));
+        createLocalImageProcessor("auto").encode(Buffer.from("input"), { format: "jpeg" }),
+      ).resolves.toEqual({ data: Buffer.from("jpeg") });
 
       expect(createRastermill).toHaveBeenCalledWith({
         execution: "auto",
@@ -80,34 +82,44 @@ describe("image ops Rastermill adapter", () => {
       expect(resolveSystemBin).toHaveBeenLastCalledWith("powershell", { trust: "strict" });
     });
 
-    it("exposes Rastermill unavailable errors through the SDK alias", async () => {
+    it("preserves native fallback and the SDK unavailable classification when the worker declines", async () => {
       const actualRastermill = await vi.importActual<typeof import("rastermill")>("rastermill");
       const unavailableError = new actualRastermill.RastermillUnavailableError(
         "encode",
         "Image processor unavailable",
         [new Error("missing backend")],
       );
-      const createRastermill = vi.fn(() => ({
-        encode: vi.fn(async () => {
-          throw unavailableError;
-        }),
-      }));
-
+      const encode = vi.fn(async () => {
+        throw unavailableError;
+      });
       vi.doMock("rastermill", () => ({
         ...actualRastermill,
-        createRastermill,
-        readImageMetadataFromHeader: vi.fn(() => ({ width: 1, height: 1 })),
-        readImageProbeFromHeader: vi.fn(() => ({ width: 1, height: 1, format: "png" })),
+        createRastermill: vi.fn(() => ({ encode })),
       }));
-
-      const { isImageProcessorUnavailableError, resizeToJpeg } = await import("./image-ops.js");
-
+      vi.doMock("../infra/worker-task-pool.js", () => ({
+        WorkerTaskPool: class {
+          async run() {
+            return {
+              kind: "failed",
+              unavailable: true,
+              error: new Error("internal codec unavailable"),
+            };
+          }
+        },
+      }));
+      const { createImageProcessor, isImageProcessorUnavailableError } =
+        await import("./image-ops.js");
+      const input = Buffer.from("input");
+      const options = { format: "jpeg" as const };
       await expect(
-        resizeToJpeg({ buffer: Buffer.from("input"), maxSide: 1, quality: 80 }).then(
-          () => false,
-          (error: unknown) => isImageProcessorUnavailableError(error),
-        ),
+        createImageProcessor()
+          .encode(input, options)
+          .then(
+            () => false,
+            (error: unknown) => isImageProcessorUnavailableError(error),
+          ),
       ).resolves.toBe(true);
+      expect(encode).toHaveBeenCalledWith(input, options);
     });
   });
 

--- a/src/media/image-ops.ts
+++ b/src/media/image-ops.ts
@@ -1,15 +1,16 @@
 // Image operation helpers normalize image transforms and adapter calls.
 import {
-  createRastermill,
   isRastermillUnavailableError,
   RastermillUnavailableError,
   readImageProbeFromHeader as readRastermillImageProbeFromHeader,
   type ImageProbe,
   type ImageMetadata,
 } from "rastermill";
-import { resolveSystemBin } from "../infra/resolve-system-bin.js";
-import { resolvePreferredOpenClawTmpDir } from "../infra/tmp-openclaw-dir.js";
-import { createLazyRuntimeModule } from "../shared/lazy-runtime.js";
+import { MAX_IMAGE_INPUT_PIXELS } from "./image-processor-config.js";
+import { convertBmpToPngWithWorker, createImageProcessor } from "./image-processor.js";
+
+export { MAX_IMAGE_INPUT_PIXELS } from "./image-processor-config.js";
+export { createImageProcessor } from "./image-processor.js";
 
 export type { ImageMetadata, ImageProbe };
 
@@ -39,27 +40,6 @@ type ResizeToJpegParams = {
 
 /** Ordered JPEG quality ladder used when shrinking generated or attached images. */
 export const IMAGE_REDUCE_QUALITY_STEPS = [85, 75, 65, 55, 45, 35] as const;
-/** Shared input/output pixel cap for Rastermill-backed image operations. */
-export const MAX_IMAGE_INPUT_PIXELS = 25_000_000;
-
-const loadPhotonRuntime = createLazyRuntimeModule(() => import("./photon.runtime.js"));
-
-/** Creates a Rastermill processor with OpenClaw temp-dir, pixel-limit, and command trust policy. */
-export function createImageProcessor() {
-  return createRastermill({
-    execution: "auto",
-    limits: {
-      inputPixels: MAX_IMAGE_INPUT_PIXELS,
-      outputPixels: MAX_IMAGE_INPUT_PIXELS,
-    },
-    temp: {
-      rootDir: resolvePreferredOpenClawTmpDir(),
-      prefix: "openclaw-img-",
-    },
-    commandResolver: (command) =>
-      resolveSystemBin(command, { trust: command === "powershell" ? "strict" : "standard" }),
-  });
-}
 
 /** Detects either OpenClaw's wrapper error or Rastermill's native unavailable error. */
 export function isImageProcessorUnavailableError(err: unknown): boolean {
@@ -160,7 +140,7 @@ export async function convertImageToPng(buffer: Buffer): Promise<Buffer> {
     }
 
     try {
-      return (await loadPhotonRuntime()).convertBmpToPngWithPhoton(buffer);
+      return await convertBmpToPngWithWorker(buffer);
     } catch {
       throw error;
     }

--- a/src/media/image-ops.worker.test.ts
+++ b/src/media/image-ops.worker.test.ts
@@ -1,0 +1,78 @@
+import type { Worker } from "node:worker_threads";
+import { encodePngRgba } from "rastermill";
+import { afterAll, describe, expect, it, vi } from "vitest";
+
+const workers = vi.hoisted(() => [] as Worker[]);
+vi.mock("node:worker_threads", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:worker_threads")>();
+  return {
+    ...actual,
+    Worker: class extends actual.Worker {
+      constructor(...args: ConstructorParameters<typeof actual.Worker>) {
+        super(...args);
+        workers.push(this);
+      }
+    },
+  };
+});
+
+import { createImageProcessor, getImageMetadata, resizeToJpeg } from "./image-ops.js";
+
+afterAll(async () => {
+  await Promise.all(workers.splice(0).map((worker) => worker.terminate()));
+});
+
+const png = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+a2ioAAAAASUVORK5CYII=",
+  "base64",
+);
+
+describe("image worker", () => {
+  it("returns encoded Buffer bytes without detaching the caller's input view", async () => {
+    const source = Buffer.concat([Buffer.from("prefix"), png, Buffer.from("suffix")]);
+    const input = source.subarray(6, -6);
+    const jpeg = await resizeToJpeg({ buffer: input, maxSide: 1, quality: 80 });
+    expect(Buffer.isBuffer(jpeg)).toBe(true);
+    expect(jpeg.subarray(0, 2)).toEqual(Buffer.from([0xff, 0xd8]));
+    await expect(getImageMetadata(jpeg)).resolves.toEqual({ width: 1, height: 1 });
+    expect(input).toEqual(png);
+  });
+
+  it("lets owner cancellation preempt image work and serves the next request", async () => {
+    const processor = createImageProcessor();
+    await processor.encode(png, { format: "jpeg" });
+    const largePng = encodePngRgba(new Uint8Array(1024 * 1024 * 4).fill(255), 1024, 1024, 1);
+    const abort = new AbortController();
+    const reason = new Error("owning turn cancelled");
+    const timer = setTimeout(() => abort.abort(reason), 0);
+    try {
+      await expect(
+        processor.encode(largePng, { format: "jpeg", signal: abort.signal }),
+      ).rejects.toBe(reason);
+    } finally {
+      clearTimeout(timer);
+    }
+    await expect(processor.encode(png, { format: "jpeg", signal: abort.signal })).rejects.toBe(
+      reason,
+    );
+    await expect(processor.encode(png, { format: "jpeg" })).resolves.toMatchObject({
+      format: "jpeg",
+      width: 1,
+      height: 1,
+    });
+  });
+
+  it("preserves public image validation errors across the worker boundary", async () => {
+    const processor = createImageProcessor();
+    await expect(
+      processor.encode(Buffer.from("invalid image"), { format: "jpeg" }),
+    ).rejects.toMatchObject({
+      code: "RASTERMILL_UNDECODABLE",
+    });
+    const oversized = Buffer.from(png);
+    oversized.writeUInt32BE(25_000_001, 16);
+    await expect(processor.transparency(oversized)).rejects.toMatchObject({
+      code: "RASTERMILL_INPUT_TOO_LARGE",
+    });
+  });
+});

--- a/src/media/image-processor-config.ts
+++ b/src/media/image-processor-config.ts
@@ -1,0 +1,22 @@
+import { createRastermill, type ImageExecutionMode } from "rastermill";
+import { resolveSystemBin } from "../infra/resolve-system-bin.js";
+import { resolvePreferredOpenClawTmpDir } from "../infra/tmp-openclaw-dir.js";
+
+/** Shared input/output pixel cap for Rastermill-backed image operations. */
+export const MAX_IMAGE_INPUT_PIXELS = 25_000_000;
+
+export function createLocalImageProcessor(execution: ImageExecutionMode) {
+  return createRastermill({
+    execution,
+    limits: {
+      inputPixels: MAX_IMAGE_INPUT_PIXELS,
+      outputPixels: MAX_IMAGE_INPUT_PIXELS,
+    },
+    temp: {
+      rootDir: resolvePreferredOpenClawTmpDir(),
+      prefix: "openclaw-img-",
+    },
+    commandResolver: (command) =>
+      resolveSystemBin(command, { trust: command === "powershell" ? "strict" : "standard" }),
+  });
+}

--- a/src/media/image-processor.ts
+++ b/src/media/image-processor.ts
@@ -1,0 +1,95 @@
+import {
+  RastermillError,
+  RastermillUnavailableError,
+  type ImageInput,
+  type Rastermill,
+} from "rastermill";
+import { runtimeProcessEntrypoints } from "../infra/runtime-process-entrypoints.js";
+import { resolveRuntimeWorkerUrl } from "../infra/runtime-worker-url.js";
+import { WorkerTaskPool } from "../infra/worker-task-pool.js";
+import { createLocalImageProcessor } from "./image-processor-config.js";
+import type {
+  ImageProcessorOperation,
+  ImageProcessorReply,
+  ImageProcessorRequest,
+} from "./image-processor.types.js";
+
+const pool = new WorkerTaskPool<ImageProcessorRequest, ImageProcessorReply>({
+  workerUrl: resolveRuntimeWorkerUrl(runtimeProcessEntrypoints.imageProcessor),
+  // Each Photon instance retains a WASM heap; serialize transforms rather than multiply decodes.
+  maxWorkers: 1,
+  sharedCompute: true,
+});
+
+async function runImageTask(
+  input: ImageInput,
+  operation: ImageProcessorOperation,
+  signal?: AbortSignal,
+): Promise<ImageProcessorReply> {
+  const reply = await pool.run(
+    () => ({
+      ...operation,
+      // The caller may reuse its Buffer. Transfer a dedicated copy only after admission.
+      input: Uint8Array.from(input instanceof ArrayBuffer ? new Uint8Array(input) : input),
+    }),
+    {
+      timeoutMs: 180_000,
+      signal,
+      inputBytes: input.byteLength,
+      transferList: (request) => [request.input.buffer],
+    },
+  );
+  // Structured cloning preserves Error messages but drops Rastermill's public error codes.
+  if (reply.kind === "failed" && reply.code && !reply.unavailable) {
+    reply.error = new RastermillError(reply.code, reply.error.message, { cause: reply.error });
+  }
+  return reply;
+}
+
+/** Keep cheap probes local and move in-process image computation off the caller's event loop. */
+export function createImageProcessor(): Rastermill {
+  const local = createLocalImageProcessor("auto");
+  return {
+    probe: (input) => local.probe(input),
+    transparency: async (input) => {
+      const reply = await runImageTask(input, { kind: "transparency" });
+      if (reply.kind === "failed") {
+        throw reply.unavailable
+          ? new RastermillUnavailableError("transparency", reply.error.message, [reply.error])
+          : reply.error;
+      }
+      if (reply.kind !== "transparency") {
+        throw new Error("Unexpected image worker result");
+      }
+      return reply.value;
+    },
+    encode: async (input, options) => {
+      const { signal, ...workerOptions } = options ?? {};
+      const reply = await runImageTask(input, { kind: "encode", options: workerOptions }, signal);
+      signal?.throwIfAborted();
+      if (reply.kind === "failed") {
+        if (!reply.unavailable) {
+          throw reply.error;
+        }
+        // Preserve Rastermill's native-codec and alpha policy when its internal backend declines.
+        return local.encode(input, options);
+      }
+      if (reply.kind !== "encode") {
+        throw new Error("Unexpected image worker result");
+      }
+      const { data, ...value } = reply.value;
+      return { ...value, data: Buffer.from(data.buffer, data.byteOffset, data.byteLength) };
+    },
+  };
+}
+
+export async function convertBmpToPngWithWorker(input: Buffer): Promise<Buffer> {
+  const reply = await runImageTask(input, { kind: "bmpToPng" });
+  if (reply.kind === "failed") {
+    throw reply.error;
+  }
+  if (reply.kind !== "bmpToPng") {
+    throw new Error("Unexpected image worker result");
+  }
+  return Buffer.from(reply.value.buffer, reply.value.byteOffset, reply.value.byteLength);
+}

--- a/src/media/image-processor.types.ts
+++ b/src/media/image-processor.types.ts
@@ -1,0 +1,19 @@
+import type {
+  EncodedImage,
+  EncodeOptions,
+  ImageTransparency,
+  RastermillErrorCode,
+} from "rastermill";
+
+export type ImageProcessorOperation =
+  | { kind: "encode"; options?: EncodeOptions }
+  | { kind: "transparency" }
+  | { kind: "bmpToPng" };
+
+export type ImageProcessorRequest = { input: Uint8Array<ArrayBuffer> } & ImageProcessorOperation;
+
+export type ImageProcessorReply =
+  | { kind: "encode"; value: Omit<EncodedImage, "data"> & { data: Uint8Array<ArrayBuffer> } }
+  | { kind: "transparency"; value: ImageTransparency }
+  | { kind: "bmpToPng"; value: Uint8Array<ArrayBuffer> }
+  | { kind: "failed"; error: Error; code?: RastermillErrorCode; unavailable: boolean };

--- a/src/media/image-processor.worker.ts
+++ b/src/media/image-processor.worker.ts
@@ -1,0 +1,48 @@
+import { isRastermillError, isRastermillUnavailableError } from "rastermill";
+import { serveWorkerTasks } from "../infra/worker-task-pool.js";
+import { createLocalImageProcessor } from "./image-processor-config.js";
+import type { ImageProcessorReply, ImageProcessorRequest } from "./image-processor.types.js";
+
+// Native codecs stay in the caller, whose subprocess lifetime survives worker cancellation.
+const processor = createLocalImageProcessor("internal");
+
+serveWorkerTasks<ImageProcessorReply>(
+  async (input) => {
+    // SAFETY: The owning image pool is the sole sender and builds this private request with the worker.
+    const request = input as ImageProcessorRequest;
+    try {
+      switch (request.kind) {
+        case "encode": {
+          const value = await processor.encode(request.input, request.options);
+          return { kind: request.kind, value: { ...value, data: Uint8Array.from(value.data) } };
+        }
+        case "transparency":
+          return { kind: request.kind, value: await processor.transparency(request.input) };
+        case "bmpToPng": {
+          const { convertBmpToPngWithPhoton } = await import("./photon.runtime.js");
+          return {
+            kind: request.kind,
+            value: Uint8Array.from(convertBmpToPngWithPhoton(Buffer.from(request.input))),
+          };
+        }
+        default:
+          throw new Error("Unsupported image worker operation");
+      }
+    } catch (error) {
+      return {
+        kind: "failed",
+        error: error instanceof Error ? error : new Error(String(error)),
+        ...(isRastermillError(error) ? { code: error.code } : {}),
+        unavailable: isRastermillUnavailableError(error),
+      };
+    }
+  },
+  {
+    transferList: (reply) =>
+      reply.kind === "encode"
+        ? [reply.value.data.buffer]
+        : reply.kind === "bmpToPng"
+          ? [reply.value.buffer]
+          : [],
+  },
+);

--- a/src/media/input-files.fetch-guard.test.ts
+++ b/src/media/input-files.fetch-guard.test.ts
@@ -720,6 +720,9 @@ describe("input file MIME sniffing", () => {
 
       await vi.advanceTimersByTimeAsync(1);
       await pending;
+      const signal = extractPdfContentMock.mock.calls[0]?.[0]?.signal as AbortSignal;
+      expect(signal.aborted).toBe(true);
+      expect(signal.reason).toEqual(new Error("PDF extraction timed out after 1ms"));
     } finally {
       vi.useRealTimers();
     }

--- a/src/media/input-files.ts
+++ b/src/media/input-files.ts
@@ -7,6 +7,7 @@ import {
 import { canonicalizeBase64, estimateBase64DecodedBytes } from "@openclaw/media-core/base64";
 import { parseMediaContentLength } from "@openclaw/media-core/content-length";
 import { detectMime, normalizeMimeType } from "@openclaw/media-core/mime";
+import { toErrorObject } from "@openclaw/normalization-core/error-coercion";
 import { resolveTimerTimeoutMs } from "@openclaw/normalization-core/number-coercion";
 import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
@@ -261,23 +262,34 @@ function decodeTextContent(buffer: Buffer, charset: string | undefined, maxChars
   }
 }
 
-function withInputFileTimeout<T>(params: {
-  task: Promise<T>;
+async function withInputFileTimeout<T>(params: {
+  task: (signal: AbortSignal) => Promise<T>;
   timeoutMs: number;
   label: string;
+  signal?: AbortSignal;
 }): Promise<T> {
   const timeoutMs = resolveTimerTimeoutMs(params.timeoutMs, 1);
-  let timeout: NodeJS.Timeout | undefined;
-  const timedOut = new Promise<never>((_, reject) => {
-    timeout = setTimeout(() => {
-      reject(new Error(`${params.label} timed out after ${timeoutMs}ms`));
-    }, timeoutMs);
+  const controller = new AbortController();
+  const signal = params.signal
+    ? AbortSignal.any([params.signal, controller.signal])
+    : controller.signal;
+  signal.throwIfAborted();
+  let onAbort!: () => void;
+  const cancelled = new Promise<never>((_, reject) => {
+    onAbort = () => reject(toErrorObject(signal.reason, "Input file extraction aborted"));
+    signal.addEventListener("abort", onAbort, { once: true });
   });
-  return Promise.race([params.task, timedOut]).finally(() => {
-    if (timeout) {
-      clearTimeout(timeout);
-    }
-  });
+  const timeout = setTimeout(
+    () => controller.abort(new Error(`${params.label} timed out after ${timeoutMs}ms`)),
+    timeoutMs,
+  );
+  try {
+    // Legacy extractors may not cooperate, but the worker also receives the deadline cancellation.
+    return await Promise.race([params.task(signal), cancelled]);
+  } finally {
+    clearTimeout(timeout);
+    signal.removeEventListener("abort", onAbort);
+  }
 }
 
 /** Validates image bytes and converts HEIC/HEIF to JPEG, keeping the original Buffer otherwise. */
@@ -393,6 +405,7 @@ export async function extractFileContentFromSource(params: {
     charset,
     limits,
     config: params.config,
+    ...(signal ? { signal } : {}),
   });
   signal?.throwIfAborted();
   return extracted;
@@ -407,8 +420,10 @@ export async function extractFileContentFromBuffer(params: {
   limits: InputFileLimits;
   config?: OpenClawConfig;
   classification?: AttachmentClassification;
+  signal?: AbortSignal;
 }): Promise<InputFileExtractResult> {
   const { buffer, limits } = params;
+  params.signal?.throwIfAborted();
   const filename = params.filename || "file";
   if (buffer.byteLength > limits.maxBytes) {
     throw new Error(`File too large: ${buffer.byteLength} bytes (limit: ${limits.maxBytes} bytes)`);
@@ -419,6 +434,7 @@ export async function extractFileContentFromBuffer(params: {
   const classification =
     params.classification ??
     (await classifyAttachmentBytes({ buffer, declaredMime: params.mimeType }));
+  params.signal?.throwIfAborted();
   const mimeType = classification.mime;
   const charset = classification.charset ?? params.charset;
 
@@ -433,16 +449,19 @@ export async function extractFileContentFromBuffer(params: {
     const extracted = await withInputFileTimeout({
       label: "PDF extraction",
       timeoutMs: limits.timeoutMs,
-      task: extractPdfContent({
-        buffer,
-        maxPages: limits.pdf.maxPages,
-        maxPixels: limits.pdf.maxPixels,
-        minTextChars: limits.pdf.minTextChars,
-        ...(params.config ? { config: params.config } : {}),
-        onImageExtractionError: (err) => {
-          logWarn(`media: PDF image extraction skipped, ${String(err)}`);
-        },
-      }),
+      signal: params.signal,
+      task: (signal) =>
+        extractPdfContent({
+          buffer,
+          signal,
+          maxPages: limits.pdf.maxPages,
+          maxPixels: limits.pdf.maxPixels,
+          minTextChars: limits.pdf.minTextChars,
+          ...(params.config ? { config: params.config } : {}),
+          onImageExtractionError: (err) => {
+            logWarn(`media: PDF image extraction skipped, ${String(err)}`);
+          },
+        }),
     });
     const text = extracted.text ? truncateUtf16Safe(extracted.text, limits.maxChars) : "";
     return {

--- a/src/media/pdf-extract.ts
+++ b/src/media/pdf-extract.ts
@@ -19,6 +19,7 @@ export async function extractPdfContent(params: {
   minTextChars: number;
   password?: string;
   pageNumbers?: number[];
+  signal?: AbortSignal;
   config?: OpenClawConfig;
   onImageExtractionError?: (error: unknown) => void;
 }): Promise<PdfExtractedContent> {

--- a/src/plugins/document-extractor-types.ts
+++ b/src/plugins/document-extractor-types.ts
@@ -14,6 +14,8 @@ export type DocumentExtractionRequest = {
   minTextChars: number;
   password?: string;
   pageNumbers?: number[];
+  /** Cancels queued extraction and stops active work when supported by the extractor. */
+  signal?: AbortSignal;
   onImageExtractionError?: (error: unknown) => void;
 };
 

--- a/test/plugin-npm-runtime-build.test.ts
+++ b/test/plugin-npm-runtime-build.test.ts
@@ -102,7 +102,18 @@ describe("plugin npm runtime build planning", () => {
         },
       }),
     );
-    writeFileSync(path.join(packageDir, "index.ts"), 'export default { id: "worker-fixture" };\n');
+    writeFileSync(
+      path.join(packageDir, "index.ts"),
+      `import { resolveRuntimeWorkerUrl } from ${JSON.stringify(path.join(repoRoot, "src/infra/runtime-worker-url.ts").replaceAll("\\", "/"))};
+` +
+        `export const workerUrl = resolveRuntimeWorkerUrl({
+          currentModuleUrl: import.meta.url,
+          sourceWorkerName: "store.worker",
+          distWorkerPath: "extensions/worker-fixture/src/store.worker.js",
+          package: { name: "@openclaw/worker-fixture", distWorkerPath: "src/store.worker.js" },
+        });
+`,
+    );
     writeFileSync(
       path.join(packageDir, "src/store.worker.ts"),
       'import { parentPort, isMainThread } from "node:worker_threads";\n' +
@@ -113,7 +124,8 @@ describe("plugin npm runtime build planning", () => {
       await buildPluginNpmRuntime({ repoRoot, packageDir, logLevel: "silent" }),
     );
     expect(plan.runtimeExtensions).toEqual(["./dist/index.js"]);
-    const worker = new Worker(path.join(packageDir, "dist/src/store.worker.js"));
+    const { workerUrl } = await import(pathToFileURL(path.join(packageDir, "dist/index.js")).href);
+    const worker = new Worker(workerUrl);
     try {
       const result = await new Promise((resolve, reject) => {
         worker.once("message", resolve);

--- a/test/scripts/tsdown-declaration-fixture.ts
+++ b/test/scripts/tsdown-declaration-fixture.ts
@@ -9,6 +9,7 @@ import {
   TSDOWN_NON_SDK_DTS_CONFIG_GROUPS,
   TSDOWN_PLUGIN_SDK_DTS_CONFIG_GROUPS,
 } from "../../scripts/lib/tsdown-config-groups.mts";
+import { runtimeProcessDeclarationEntries } from "../../scripts/lib/vitest-worker-declarations.mts";
 import { materializeDeclarationPackages } from "./declaration-fixture-packages.js";
 import { createScriptTestHarness } from "./test-helpers.js";
 
@@ -163,9 +164,8 @@ export function createFixture(
   });
   // These owners derive runtime inputs from import.meta.url; keep that graph inside the fixture.
   const runtimeEntryOwners = new Set([
-    "src/infra/runtime-process-entrypoints.ts",
+    ...Object.values(runtimeProcessDeclarationEntries),
     "src/infra/update-managed-service-handoff-runtime-assets.ts",
-    "extensions/memory-core/src/memory/manager-search-knn-entrypoint.ts",
     "packages/normalization-core/src/mountinfo-path.ts",
     "packages/normalization-core/src/record-coerce.ts",
   ]);

--- a/test/scripts/vitest-worker-artifacts.test-support.ts
+++ b/test/scripts/vitest-worker-artifacts.test-support.ts
@@ -254,7 +254,7 @@ export function workerProbe(
       const launcherArgv = inject('launcherArgv');
       expect(path.isAbsolute(launcherArgv[1])).toBe(true);
       expect(path.basename(launcherArgv[1])).toBe('vitest.mjs');
-      expect(Object.values(runtimeProcessBuildEntries)).toHaveLength(Object.keys(runtimeProcessEntrypoints).length + 1);
+      expect(Object.values(runtimeProcessBuildEntries)).toHaveLength(Object.keys(runtimeProcessEntrypoints).length + 2);
       for (const source of Object.values(runtimeProcessBuildEntries)) {
         expect(source).not.toContain('/dist/');
         expect(source).toMatch(/\\.ts$/);

--- a/test/tsconfig/tsconfig.core.test.infra.json
+++ b/test/tsconfig/tsconfig.core.test.infra.json
@@ -14,6 +14,7 @@
     "../../dist",
     "../../**/dist/**",
     "../../src/infra/outbound/**",
+    "../../src/infra/sqlite-*.test.ts",
     "../../src/infra/update-managed-service-handoff-database.test.ts",
     "../../src/infra/package-update-activation-journal.test.ts"
   ]

--- a/test/tsconfig/tsconfig.core.test.state-logging.json
+++ b/test/tsconfig/tsconfig.core.test.state-logging.json
@@ -10,6 +10,7 @@
     "../../src/logging/**/*.test.tsx",
     "../../src/shared/**/*.test.ts",
     "../../src/shared/**/*.test.tsx",
+    "../../src/infra/sqlite-*.test.ts",
     "../../src/infra/update-managed-service-handoff-database.test.ts",
     "../../src/infra/package-update-activation-journal.test.ts",
     "../../src/config/sessions/**/*.test.ts",


### PR DESCRIPTION
Related: #146166. Uses the admission owner from #146067.

## What Problem This Solves

Fixes an issue where image conversion and PDF attachment extraction could block the event loop and delay cancellation while processing large media.

## Why This Change Was Made

Runs image computation and plugin-owned PDF extraction in reusable workers, with one worker per backend to bound simultaneous WASM heaps. Preserves native image codec fallback and forwards PDF tool cancellation and attachment deadlines to the worker.

## User Impact

Media processing leaves the caller responsive, and cancelling a request stops its worker work. Results retain existing image formats, PDF page selection, pixel budgets, and error behavior. Worker startup and memory costs depend on the backend.

Accepted tradeoff: image and PDF backends each keep one reusable worker and share the existing compute admission limit (128 pending tasks and 256 MiB of declared retained inputs across participating pools). Saturation returns an explicit overload error. Each media request has a 180-second deadline covering queueing and execution; caller cancellation or a shorter attachment deadline can end it earlier. Sustained overload or exceptionally slow documents can therefore fail instead of waiting indefinitely. This is intentional within the requested worker migration; no new configuration or persistent state is introduced.

## Evidence

One paired comparison using the actual shipped build outputs on Linux, Node 26.8.2, with four available CPUs and six concurrent warm requests per flow:

| Flow | Longest timer gap | Six-request batch | First request | Peak process RSS |
| --- | ---: | ---: | ---: | ---: |
| Image resize | 1,335 → 6.66 ms | 1,333 → 691 ms | 470 → 320 ms | 380 → 345 MiB |
| PDF extraction/rendering | 914 → 6.56 ms | 911 → 613 ms | 293 → 354 ms | 308 → 347 MiB |

Image fixture: 1600×1200 PNG resized to an 800px JPEG. PDF fixture: eight pages with 2,000 rectangles each, rendered within a four-million-pixel budget. JPEG bytes and all eight rendered PDF pages were checked, with no extraction errors. This single paired run demonstrates responsiveness; throughput and startup figures are workload-specific. PDF isolation increased first-request time and memory. This is build-output proof, not an npm installation smoke test.

- The final native build passes, including all 92 plugin builds. The resolver, built image/PDF and prepared-catalog integration suites pass all 48 tests, including overload recovery, cancellation and scoped reload siblings.
- Earlier focused source proof passes 74 tests across nine files; a subsequent 16-test worker/password regression run also passes. The image cancellation reproduction fails on the baseline and passes with workers.
- Independent P2 reviews of the media implementation and final package-layout correction found no actionable findings.
- The package metadata reader accepts hardlinked manifests, matching existing plugin metadata handling. Both a real two-link manifest probe and the resolver regression fail before this correction and pass afterward. Formatting, diff checks and core typed lint pass; local extension/test typed lint stopped at a dependency-boundary input-change guard for an ACP SDK declaration. The local failure remains recorded; the final signed head has now passed hosted production/test type, lint and package-boundary checks.
- Actual built PDF extraction passes from root-bundled, standalone package-local, and renamed package directories. Each six-request batch validates all eight rendered pages. The original standalone extraction fails with the expected missing-worker error. The generic package-build regression now starts the real worker through its built caller's resolved URL; it fails with the original resolver and passes with the fix. Manifest identity selects the package-local path, preserving explicit-root and source resolution.
- Hosted attempt 1 at b248e203 had four failures in an unchanged Gateway alias fixture. The parent CI and the unchanged candidate's native run both pass the same 34-file, 431-test shard in the same order. One bounded rerun at that same head passed the full required CI gate. The package-layout follow-up requires its own exact-head CI before merge.
- Earlier native declaration and worker-artifact proof passes 22 selected tests across four files: complete declaration resolution, both transform layouts, real borrower sharing, responsive verification, and draining reads after failure. Thirty-six unrelated cases were explicitly filtered out. Earlier Windows checks stopped at the declaration-boundary guard for borrowed dependencies, without bypassing it.
