### PR TITLE
fix(agents): forward ordered saved subscription credentials to CLI runs

### DIFF
--- a/docs/gateway/cli-backends.md
+++ b/docs/gateway/cli-backends.md
@@ -234,9 +234,10 @@ Normal agent turns can also use a saved subscription token without a native logi
 openclaw models auth paste-token --provider anthropic
 ```
 
-OpenClaw selects saved subscription credentials through the configured account
-order and forwards them to the CLI through a protected file descriptor. Explicit
-account selections and empty account orders remain authoritative. API keys saved
+New sessions select saved subscription credentials through the configured account
+order and forward them to the CLI through a protected file descriptor. Existing
+sessions keep their account until you select another or remove its saved profile.
+Explicit account selections and empty account orders remain authoritative. API keys saved
 for the `anthropic` provider require an explicit selection; they do not replace
 native subscription login automatically.
 

--- a/docs/gateway/cli-backends.md
+++ b/docs/gateway/cli-backends.md
@@ -220,7 +220,7 @@ Claude Code can drive a Chrome browser through the [Claude in Chrome extension](
 
 The backend maps OpenClaw `/think` levels to Claude Code's native `--effort` flag: `minimal`/`low` -> `low`, `medium` -> `medium`, and `high`/`xhigh`/`max` pass through directly. For models that allow fixed thinking budgets, it also launches Claude Code with `MAX_THINKING_TOKENS`: `off=0`, `minimal=1024`, `low=2048`, `medium=8192`, `high`/`xhigh=16384`, and `max=32768`. Positive fixed budgets disable adaptive thinking. Models that require adaptive thinking omit the fixed budget and continue to use `--effort`. `adaptive` removes configured effort flags and fixed-budget environment overrides, so Claude Code resolves effective thinking from its own environment, settings, and model defaults. Other CLI backends need their owning plugin to map the selected level before `/think` affects the spawned CLI.
 
-Before OpenClaw can use `claude-cli`, Claude Code itself must be logged in on the same host:
+For native login, sign in to Claude Code on the Gateway host:
 
 ```bash
 claude auth login
@@ -228,7 +228,19 @@ claude auth status --text
 openclaw models auth login --provider anthropic --method cli --set-default
 ```
 
-Docker installs need Claude Code installed and logged in inside the persisted container home, not only on the host. See [Claude CLI backend in Docker](/install/docker#claude-cli-backend-in-docker).
+Normal agent turns can also use a saved subscription token without a native login:
+
+```bash
+openclaw models auth paste-token --provider anthropic
+```
+
+OpenClaw selects saved subscription credentials through the configured account
+order and forwards them to the CLI through a protected file descriptor. Explicit
+account selections and empty account orders remain authoritative. API keys saved
+for the `anthropic` provider require an explicit selection; they do not replace
+native subscription login automatically.
+
+Docker installs need Claude Code and the chosen credentials inside the persisted container home, not only on the host. See [Claude CLI backend in Docker](/install/docker#claude-cli-backend-in-docker).
 
 The gateway service must resolve `claude` on `PATH`. For a nonstandard path,
 register a small wrapper backend plugin.

--- a/docs/providers/anthropic.md
+++ b/docs/providers/anthropic.md
@@ -119,8 +119,11 @@ OpenClaw release:
         Gateway startup shares the native login availability check across agent
         workspaces using the same config and environment. Explicit catalog/auth
         captures recheck availability for their own generation.
-        Explicitly selected API-key or token credentials still use protected
-        file-descriptor forwarding. Native-tool approvals remain under OpenClaw
+        Saved subscription credentials follow the configured account order and
+        use protected file-descriptor forwarding, including tokens saved with
+        `openclaw models auth paste-token --provider anthropic`. API keys saved for
+        the `anthropic` provider require an explicit account selection for CLI
+        forwarding. Native-tool approvals remain under OpenClaw
         control. Schema-valid native calls pass through OpenClaw's canonical
         tool policy before native approval. Isolated side-question completions
         and paired-node execution retain the supervised CLI path.

--- a/docs/providers/anthropic.md
+++ b/docs/providers/anthropic.md
@@ -119,11 +119,12 @@ OpenClaw release:
         Gateway startup shares the native login availability check across agent
         workspaces using the same config and environment. Explicit catalog/auth
         captures recheck availability for their own generation.
-        Saved subscription credentials follow the configured account order and
+        New sessions select saved subscription credentials by account order and
         use protected file-descriptor forwarding, including tokens saved with
         `openclaw models auth paste-token --provider anthropic`. API keys saved for
         the `anthropic` provider require an explicit account selection for CLI
-        forwarding. Native-tool approvals remain under OpenClaw
+        forwarding. Existing sessions keep their account until you select another
+        or remove its saved profile. Native-tool approvals remain under OpenClaw
         control. Schema-valid native calls pass through OpenClaw's canonical
         tool policy before native approval. Isolated side-question completions
         and paired-node execution retain the supervised CLI path.

--- a/scripts/lib/ci-node-test-plan.mts
+++ b/scripts/lib/ci-node-test-plan.mts
@@ -874,6 +874,7 @@ const KEEP_LARGE_NODE_TEST_RUNNER = new Set([
   "agentic-gateway-core-2",
   "agentic-gateway-core-3",
   "agentic-gateway-methods",
+  "agentic-gateway-server-isolated",
   "auto-reply-reply-dispatch",
   "auto-reply-reply-dispatch-core",
   "auto-reply-reply-dispatch-delivery",
@@ -2437,6 +2438,7 @@ function readCompleteSplitGenerationSeconds(
 // must enumerate exactly its config's include set so a stripe union stays a
 // complete, non-overlapping partition of the suite.
 const WHOLE_CONFIG_SPLIT_FILE_LISTERS = new Map<string, () => string[]>([
+  ["agentic-gateway-server-isolated", () => gatewayServerIsolatedTestFiles],
   ["agentic-cli-process", () => cliProcessTestFiles],
   ["agentic-agents-support", listAgentSupportTestFiles],
   [

--- a/scripts/lib/vitest-build-prerequisites.mts
+++ b/scripts/lib/vitest-build-prerequisites.mts
@@ -190,6 +190,15 @@ const runtimeConsumers = [
     mode: "runtime",
     dir: "",
   },
+  {
+    file: "src/gateway/server.chat-cli-auth.test.ts",
+    configs: [
+      "test/vitest/vitest.gateway-server-isolated.config.ts",
+      "test/vitest/vitest.gateway.config.ts",
+    ],
+    mode: "runtime",
+    dir: "",
+  },
   ...[
     "src/gateway/server-sidecar-retention.test.ts",
     "src/gateway/server.config-patch.test.ts",

--- a/src/agents/cli-execution-auth.test.ts
+++ b/src/agents/cli-execution-auth.test.ts
@@ -12,7 +12,10 @@ vi.mock("./auth-profiles/store-runtime.js", () => ({
 }));
 
 vi.mock("./auth-profiles/order.js", () => ({
-  resolveAuthProfileOrder: () => mocks.order,
+  resolveAuthProfileOrderWithMetadata: () => ({
+    profileIds: mocks.order,
+    hasExplicitOrder: false,
+  }),
 }));
 
 import { resolveCliExecutionAuthProfileId } from "./cli-execution-auth.js";

--- a/src/agents/cli-execution-auth.ts
+++ b/src/agents/cli-execution-auth.ts
@@ -1,6 +1,7 @@
 /**
  * Auth-profile forwarding shared by normal and narrow CLI-backed agent runs.
  */
+import type { CliSessionBinding } from "../config/sessions/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resolveAuthProfileOrderWithMetadata } from "./auth-profiles/order.js";
 import { loadAuthProfileStoreForRuntime } from "./auth-profiles/store-runtime.js";
@@ -33,7 +34,7 @@ export function cliBackendAcceptsAuthProfileForwarding(params: {
 }
 
 /**
- * Resolve ordered profiles and explicitly selected credentials the CLI can consume.
+ * Preserve the session account unless the user selects another or it was removed.
  * A user-locked profile must fail closed rather than run as another user.
  */
 export function resolveCliExecutionAuthProfileId(params: {
@@ -42,20 +43,37 @@ export function resolveCliExecutionAuthProfileId(params: {
   config: OpenClawConfig;
   agentDir: string;
   selected?: CliExecutionAuthProfileSelection;
+  sessionBinding?: CliSessionBinding;
   loadAuthProfileStoreForRuntime?: typeof loadAuthProfileStoreForRuntime;
 }): string | undefined {
   const loadStore = params.loadAuthProfileStoreForRuntime ?? loadAuthProfileStoreForRuntime;
   const selectedAuthProfileId = params.selected?.authProfileId?.trim();
+  const hasExplicitSelection =
+    selectedAuthProfileId && params.selected?.authProfileIdSource !== "auto";
+  const sessionAuthProfileId = params.sessionBinding?.authProfileId?.trim();
   const store = loadStore(params.agentDir, {
     readOnly: true,
     allowKeychainPrompt: false,
     externalCliProviderIds: [params.cliExecutionProvider],
-    profileId: selectedAuthProfileId,
+    profileId: hasExplicitSelection
+      ? selectedAuthProfileId
+      : (sessionAuthProfileId ?? selectedAuthProfileId),
   });
   const nativeAuthProfileIds = resolveBundledCliBackendAuthPolicy(
     params.cliExecutionProvider,
   )?.nativeAuthProfileIds;
-  if (selectedAuthProfileId && nativeAuthProfileIds?.includes(selectedAuthProfileId)) {
+  if (!hasExplicitSelection && params.sessionBinding && !sessionAuthProfileId) {
+    return undefined;
+  }
+  const retainedProfileId = hasExplicitSelection
+    ? selectedAuthProfileId
+    : sessionAuthProfileId &&
+        (store.profiles[sessionAuthProfileId] ||
+          nativeAuthProfileIds?.includes(sessionAuthProfileId))
+      ? sessionAuthProfileId
+      : undefined;
+  const nativeProfileId = retainedProfileId ?? selectedAuthProfileId;
+  if (nativeProfileId && nativeAuthProfileIds?.includes(nativeProfileId)) {
     return undefined;
   }
   const canonicalProvider = resolveCliRuntimeCanonicalProvider({
@@ -70,18 +88,18 @@ export function resolveCliExecutionAuthProfileId(params: {
         ? explicitSelection || credential.type !== "api_key"
         : params.cliExecutionProvider === GOOGLE_GEMINI_CLI_PROVIDER_ID &&
           credential.type === "api_key"));
-  if (selectedAuthProfileId && params.selected?.authProfileIdSource !== "auto") {
-    const credential = store.profiles[selectedAuthProfileId];
+  if (retainedProfileId) {
+    const credential = store.profiles[retainedProfileId];
     if (!credential) {
       throw new CliExecutionAuthProfileError(
-        `No credentials found for profile "${selectedAuthProfileId}".`,
+        `No credentials found for profile "${retainedProfileId}".`,
       );
     }
     if (acceptsCredential(credential, true)) {
-      return selectedAuthProfileId;
+      return retainedProfileId;
     }
     throw new CliExecutionAuthProfileError(
-      `CLI backend "${params.cliExecutionProvider}" cannot use auth profile "${selectedAuthProfileId}" owned by "${credential.provider}".`,
+      `CLI backend "${params.cliExecutionProvider}" cannot use auth profile "${retainedProfileId}" owned by "${credential.provider}".`,
     );
   }
 

--- a/src/agents/cli-execution-auth.ts
+++ b/src/agents/cli-execution-auth.ts
@@ -2,8 +2,9 @@
  * Auth-profile forwarding shared by normal and narrow CLI-backed agent runs.
  */
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { resolveAuthProfileOrder } from "./auth-profiles/order.js";
+import { resolveAuthProfileOrderWithMetadata } from "./auth-profiles/order.js";
 import { loadAuthProfileStoreForRuntime } from "./auth-profiles/store-runtime.js";
+import type { AuthProfileCredential } from "./auth-profiles/types.js";
 import { resolveCliBackendConfig, resolveCliRuntimeCanonicalProvider } from "./cli-backends.js";
 import { resolveBundledCliBackendAuthPolicy } from "./cli-runner/cli-backend-auth-policy.js";
 
@@ -32,7 +33,7 @@ export function cliBackendAcceptsAuthProfileForwarding(params: {
 }
 
 /**
- * Resolve native profiles and explicitly selected credentials the CLI can consume.
+ * Resolve ordered profiles and explicitly selected credentials the CLI can consume.
  * A user-locked profile must fail closed rather than run as another user.
  */
 export function resolveCliExecutionAuthProfileId(params: {
@@ -57,66 +58,58 @@ export function resolveCliExecutionAuthProfileId(params: {
   if (selectedAuthProfileId && nativeAuthProfileIds?.includes(selectedAuthProfileId)) {
     return undefined;
   }
-  if (selectedAuthProfileId) {
+  const canonicalProvider = resolveCliRuntimeCanonicalProvider({
+    runtime: params.cliExecutionProvider,
+    config: params.config,
+    includeSetupRegistry: true,
+  });
+  const acceptsCredential = (credential: AuthProfileCredential, explicitSelection: boolean) =>
+    credential.provider === params.cliExecutionProvider ||
+    (credential.provider === canonicalProvider &&
+      (params.cliExecutionProvider === CLAUDE_CLI_PROVIDER_ID
+        ? explicitSelection || credential.type !== "api_key"
+        : params.cliExecutionProvider === GOOGLE_GEMINI_CLI_PROVIDER_ID &&
+          credential.type === "api_key"));
+  if (selectedAuthProfileId && params.selected?.authProfileIdSource !== "auto") {
     const credential = store.profiles[selectedAuthProfileId];
-    if (credential?.provider === params.cliExecutionProvider) {
-      return selectedAuthProfileId;
-    }
-    // Canonical credentials require an explicit choice and the backend's registered
-    // owner. Automatic selection must not replace the CLI's native identity.
-    if (
-      credential &&
-      params.selected?.authProfileIdSource !== "auto" &&
-      (params.cliExecutionProvider === CLAUDE_CLI_PROVIDER_ID ||
-        (params.cliExecutionProvider === GOOGLE_GEMINI_CLI_PROVIDER_ID &&
-          credential.type === "api_key")) &&
-      credential.provider ===
-        resolveCliRuntimeCanonicalProvider({
-          runtime: params.cliExecutionProvider,
-          config: params.config,
-          includeSetupRegistry: true,
-        })
-    ) {
-      return selectedAuthProfileId;
-    }
-    if (params.selected?.authProfileIdSource !== "auto") {
-      if (!credential) {
-        throw new CliExecutionAuthProfileError(
-          `No credentials found for profile "${selectedAuthProfileId}".`,
-        );
-      }
+    if (!credential) {
       throw new CliExecutionAuthProfileError(
-        `CLI backend "${params.cliExecutionProvider}" cannot use auth profile "${selectedAuthProfileId}" owned by "${credential.provider}".`,
+        `No credentials found for profile "${selectedAuthProfileId}".`,
       );
     }
+    if (acceptsCredential(credential, true)) {
+      return selectedAuthProfileId;
+    }
+    throw new CliExecutionAuthProfileError(
+      `CLI backend "${params.cliExecutionProvider}" cannot use auth profile "${selectedAuthProfileId}" owned by "${credential.provider}".`,
+    );
   }
 
-  const cliProfileId = resolveAuthProfileOrder({
-    cfg: params.config,
-    store,
-    provider: params.cliExecutionProvider,
-  }).find(
-    (profileId) =>
-      store.profiles[profileId]?.provider === params.cliExecutionProvider &&
-      !nativeAuthProfileIds?.includes(profileId),
-  );
-  if (cliProfileId) {
-    return cliProfileId;
-  }
-
+  const providers = [params.cliExecutionProvider];
   if (
-    params.cliExecutionProvider !== GOOGLE_GEMINI_CLI_PROVIDER_ID ||
-    params.authProfileProvider !== GOOGLE_PROVIDER_ID
+    canonicalProvider &&
+    (params.cliExecutionProvider === CLAUDE_CLI_PROVIDER_ID ||
+      (params.cliExecutionProvider === GOOGLE_GEMINI_CLI_PROVIDER_ID &&
+        params.authProfileProvider === GOOGLE_PROVIDER_ID))
   ) {
-    return undefined;
+    providers.push(canonicalProvider);
   }
-
-  return resolveAuthProfileOrder({
-    cfg: params.config,
-    store,
-    provider: GOOGLE_PROVIDER_ID,
-  }).find((profileId) => {
-    const credential = store.profiles[profileId];
-    return credential?.provider === GOOGLE_PROVIDER_ID && credential.type === "api_key";
-  });
+  for (const provider of providers) {
+    const order = resolveAuthProfileOrderWithMetadata({
+      cfg: params.config,
+      store,
+      provider,
+      preferredProfile: selectedAuthProfileId,
+    });
+    const profileId = order.profileIds.find((id) => {
+      const credential = store.profiles[id];
+      return (
+        credential && acceptsCredential(credential, false) && !nativeAuthProfileIds?.includes(id)
+      );
+    });
+    if (profileId || order.hasExplicitOrder) {
+      return profileId;
+    }
+  }
+  return undefined;
 }

--- a/src/agents/command/attempt-execution.ts
+++ b/src/agents/command/attempt-execution.ts
@@ -880,18 +880,16 @@ export function runAgentAttempt(params: {
     harnessRuntime: agentHarnessPolicy.runtime,
     allowHarnessAuthProfileForwarding: !isCliExecutionProvider,
   });
-  const cliAuthProfileId = allowCliAuthProfileForwarding
-    ? resolveCliExecutionAuthProfileId({
-        cliExecutionProvider,
-        authProfileProvider: params.authProfileProvider,
-        config: params.cfg,
-        agentDir: params.agentDir,
-        selected: harnessAuthSelection,
-      })
-    : undefined;
-  const authProfileId = allowCliAuthProfileForwarding
-    ? cliAuthProfileId
-    : runtimeAuthPlan.forwardedAuthProfileId;
+  const authProfileId =
+    isRawModelRun && allowCliAuthProfileForwarding
+      ? resolveCliExecutionAuthProfileId({
+          cliExecutionProvider,
+          authProfileProvider: params.authProfileProvider,
+          config: params.cfg,
+          agentDir: params.agentDir,
+          selected: harnessAuthSelection,
+        })
+      : runtimeAuthPlan.forwardedAuthProfileId;
   const embeddedAgentProvider = resolveOpenAIRuntimeProvider({
     provider: params.providerOverride,
     harnessRuntime: agentHarnessPolicy.runtime,
@@ -930,8 +928,18 @@ export function runAgentAttempt(params: {
             throw createAgentRunSupersededAbortError();
           }
         }
-        const diagnosticOwner = params.deferredLifecycle?.handoffToCli();
         const cliSessionBinding = getCliSessionBinding(params.sessionEntry, cliExecutionProvider);
+        const cliAuthProfileId = allowCliAuthProfileForwarding
+          ? resolveCliExecutionAuthProfileId({
+              cliExecutionProvider,
+              authProfileProvider: params.authProfileProvider,
+              config: params.cfg,
+              agentDir: params.agentDir,
+              selected: harnessAuthSelection,
+              sessionBinding: cliSessionBinding,
+            })
+          : undefined;
+        const diagnosticOwner = params.deferredLifecycle?.handoffToCli();
         const cliProcessCwd = params.cwd ? resolveUserPath(params.cwd) : params.workspaceDir;
         const cliContinuationBody = params.opts.execApprovalContinuationPromptRange
           ? resizeExecApprovalContinuationPrompt({
@@ -1123,7 +1131,7 @@ export function runAgentAttempt(params: {
                   },
                 }
               : {}),
-            authProfileId,
+            authProfileId: cliAuthProfileId,
             bootstrapPromptWarningSignaturesSeen,
             bootstrapPromptWarningSignature,
             // Image discovery must use the original turn, before retry/history decoration.

--- a/src/auto-reply/reply/agent-runner-cli-candidate.ts
+++ b/src/auto-reply/reply/agent-runner-cli-candidate.ts
@@ -89,18 +89,6 @@ export async function runCliFallbackCandidate(
     config: params.runtimeConfig,
     agentId: params.candidateRun.agentId,
   });
-  // The CLI owner must see explicit pins before provider scoping can discard them.
-  const authProfileId = allowCliAuthProfileForwarding
-    ? resolveCliExecutionAuthProfileId({
-        cliExecutionProvider: params.cliExecutionProvider,
-        authProfileProvider: params.provider,
-        config: params.runtimeConfig,
-        agentDir: params.candidateRun.agentDir,
-        selected: params.candidateRun,
-      })
-    : resolveRunAuthProfile(params.candidateRun, params.cliExecutionProvider, {
-        config: params.runtimeConfig,
-      }).authProfileId;
   const hookMessageProvider = resolveOriginMessageProvider({
     originatingChannel: turn.followupRun.originatingChannel,
     provider: turn.sessionCtx.Provider,
@@ -178,8 +166,21 @@ export async function runCliFallbackCandidate(
         ) {
           throw createAgentRunSupersededAbortError();
         }
-        const diagnosticOwner = params.deferredLifecycle.handoffToCli();
         const cliSessionBinding = getCliSessionBinding(sessionEntry, params.cliExecutionProvider);
+        // The CLI owner must see explicit pins before provider scoping can discard them.
+        const authProfileId = allowCliAuthProfileForwarding
+          ? resolveCliExecutionAuthProfileId({
+              cliExecutionProvider: params.cliExecutionProvider,
+              authProfileProvider: params.provider,
+              config: params.runtimeConfig,
+              agentDir: params.candidateRun.agentDir,
+              selected: params.candidateRun,
+              sessionBinding: cliSessionBinding,
+            })
+          : resolveRunAuthProfile(params.candidateRun, params.cliExecutionProvider, {
+              config: params.runtimeConfig,
+            }).authProfileId;
+        const diagnosticOwner = params.deferredLifecycle.handoffToCli();
         const mediaTaskIdsBefore = getGeneratedMediaTaskIdsForSessionKey(turn.sessionKey);
         let droppedCliSessionReplacement = false;
         const candidateResult = await runCliAgentWithLifecycle({

--- a/src/auto-reply/reply/agent-runner-execution-cli-auth.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution-cli-auth.test.ts
@@ -63,16 +63,6 @@ describe("executeAgentTurn: CLI credential selection", () => {
       expected: canonicalProfile,
     },
     {
-      name: "preserves native login for automatic canonical credentials",
-      selected: canonicalProfile,
-      source: "auto",
-      primary: "anthropic",
-      provider: "claude-cli",
-      backend: "claude-cli",
-      profiles: [canonicalProfile],
-      expected: undefined,
-    },
-    {
       name: "preserves a selected native login even when a managed account exists",
       selected: nativeProfile,
       source: "user",

--- a/src/cron/isolated-agent/run-executor.ts
+++ b/src/cron/isolated-agent/run-executor.ts
@@ -652,21 +652,6 @@ function createCronPromptExecutor(
             config: params.cfgWithAgentDefaults,
             agentId: params.agentId,
           });
-          const authProfileId = allowCliAuthProfileForwarding
-            ? resolveCliExecutionAuthProfileId({
-                cliExecutionProvider: executionProvider,
-                authProfileProvider: providerOverride,
-                config: params.cfgWithAgentDefaults,
-                agentDir: params.agentDir,
-                selected: params.liveSelection.authProfileId
-                  ? {
-                      authProfileId: params.liveSelection.authProfileId,
-                      authProfileIdSource:
-                        params.liveSelection.authProfileIdSource === "user" ? "user" : "auto",
-                    }
-                  : undefined,
-              })
-            : undefined;
           // Cron intentionally reuses its durable session id as the run id; turn
           // claims stay unique via per-claim ids and the worker gate handles this
           // via credential rotation (see worker-environments/service.ts fences).
@@ -681,6 +666,22 @@ function createCronPromptExecutor(
               const cliSessionBinding = params.cronSession.isNewSession
                 ? undefined
                 : await getCliSessionBinding(params.cronSession.sessionEntry, executionProvider);
+              const authProfileId = allowCliAuthProfileForwarding
+                ? resolveCliExecutionAuthProfileId({
+                    cliExecutionProvider: executionProvider,
+                    authProfileProvider: providerOverride,
+                    config: params.cfgWithAgentDefaults,
+                    agentDir: params.agentDir,
+                    sessionBinding: cliSessionBinding,
+                    selected: params.liveSelection.authProfileId
+                      ? {
+                          authProfileId: params.liveSelection.authProfileId,
+                          authProfileIdSource:
+                            params.liveSelection.authProfileIdSource === "user" ? "user" : "auto",
+                        }
+                      : undefined,
+                  })
+                : undefined;
               const guardedCliSessionBinding =
                 cliSessionBinding && hasCliSessionReuseMetadata(cliSessionBinding)
                   ? cliSessionBinding

--- a/src/gateway/server.chat-cli-auth.test.ts
+++ b/src/gateway/server.chat-cli-auth.test.ts
@@ -7,33 +7,44 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { createWindowsCmdShimFixture } from "../test-helpers/windows-cmd-shim.js";
 import { setTestEnvValue } from "../test-utils/env.js";
 import { createOpenClawTestState } from "../test-utils/openclaw-test-state.js";
+import { loadGatewaySessionEntryReadOnly } from "./session-utils.js";
 import { disconnectGatewayClient, startGatewayWithClient } from "./test-helpers.e2e.js";
 
 // Only the external executable is a fixture. The registered Gateway, Anthropic
 // plugin, profile selection, credential transport, and transcript writer are real.
 const CLAUDE_AUTH_FIXTURE = String.raw`
 const assert = require("node:assert/strict");
-const { readFileSync } = require("node:fs");
+const { randomUUID } = require("node:crypto");
+const { appendFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } = require("node:fs");
+const { join } = require("node:path");
 const { createInterface } = require("node:readline");
 const send = (message) => process.stdout.write(JSON.stringify(message) + "\n");
+const nativeRoot = process.env.CLAUDE_CONFIG_DIR;
+const nativeLogin = existsSync(join(nativeRoot, ".credentials.json"));
 if (process.argv.includes("--version")) {
   process.stdout.write("2.1.226 (Claude Code fixture)\n");
   process.exit(0);
 }
 if (process.argv.includes("auth")) {
-  send({ loggedIn: false });
+  send({ loggedIn: nativeLogin });
   process.exit(0);
 }
 const descriptor = process.env.CLAUDE_CODE_OAUTH_TOKEN_FILE_DESCRIPTOR;
 let reply = "No managed credential supplied.";
+if (nativeLogin) {
+  reply = "Native account reply.";
+}
 if (descriptor !== undefined) {
   assert.equal(descriptor, "3");
-  assert.equal(readFileSync(3, "utf8"), "synthetic-pasted-anthropic-token");
-  reply = "Saved account reply.";
+  const token = readFileSync(3, "utf8");
+  assert.ok(["synthetic-pasted-anthropic-token", "synthetic-replacement-anthropic-token"].includes(token));
+  reply = token === "synthetic-replacement-anthropic-token"
+    ? "Replacement account reply." : "Saved account reply.";
 }
 for (const name of ["ANTHROPIC_API_KEY", "CLAUDE_CODE_OAUTH_TOKEN", "CLAUDE_CODE_API_KEY_FILE_DESCRIPTOR"]) {
   assert.equal(process.env[name], undefined);
 }
+let currentHistory;
 createInterface({ input: process.stdin }).on("line", (line) => {
   const message = JSON.parse(line);
   if (message.type === "control_request" && message.request.subtype === "initialize") {
@@ -41,11 +52,35 @@ createInterface({ input: process.stdin }).on("line", (line) => {
       subtype: "success", request_id: message.request_id, response: { commands: [], models: [] },
     } });
   } else if (message.type === "user") {
-    send({ type: "assistant", message: {
-      role: "assistant", content: [{ type: "text", text: reply }],
-    } });
+    const resumeIndex = process.argv.indexOf("--resume");
+    const sessionId = process.argv[(resumeIndex >= 0 ? resumeIndex : process.argv.indexOf("--session-id")) + 1];
+    const projectDir = join(nativeRoot, "projects", process.cwd().replace(/[^a-zA-Z0-9]/g, "-"));
+    mkdirSync(projectDir, { recursive: true });
+    const historyPath = join(projectDir, sessionId + ".jsonl");
+    const resumedHistory = currentHistory ?? (resumeIndex >= 0
+      ? readFileSync(historyPath, "utf8").trim().split("\n").map((line) => JSON.parse(line)) : []);
+    appendFileSync(join(nativeRoot, "turns.jsonl"), JSON.stringify({
+      sessionId, resume: resumeIndex >= 0, savedToken: descriptor !== undefined,
+      resumedHistory,
+    }) + "\n");
+    const remembered = JSON.stringify(resumedHistory).match(/native-history-[a-f0-9-]+/);
+    const turnReply = nativeLogin && descriptor === undefined && remembered
+      ? "Native history: " + remembered[0] + "." : reply;
+    const userUuid = message.uuid;
+    const assistantUuid = randomUUID();
+    const assistantMessage = {
+      role: "assistant", content: [{ type: "text", text: turnReply }],
+    };
+    const rows = [
+      { type: "user", uuid: userUuid, parentUuid: resumedHistory.at(-1)?.uuid ?? null,
+        message: message.message },
+      { type: "assistant", uuid: assistantUuid, parentUuid: userUuid, message: assistantMessage },
+    ].map((row) => ({ ...row, sessionId, cwd: process.cwd(), timestamp: new Date().toISOString(), isSidechain: false }));
+    currentHistory = [...resumedHistory, ...rows];
+    writeFileSync(historyPath, currentHistory.map((row) => JSON.stringify(row)).join("\n") + "\n");
+    send({ type: "assistant", uuid: assistantUuid, message: assistantMessage });
     send({ type: "result", subtype: "success", is_error: false,
-      result: reply, session_id: message.session_id });
+      result: turnReply, session_id: sessionId });
   }
 });
 `;
@@ -53,9 +88,16 @@ createInterface({ input: process.stdin }).on("line", (line) => {
 const cases: {
   name: string;
   order: NonNullable<OpenClawConfig["auth"]>["order"];
-  credential: AuthProfileCredential;
+  credential?: AuthProfileCredential;
+  nativeContinuity?: boolean;
   reply: string;
 }[] = [
+  {
+    name: "keeps native account history when a saved token appears and uses it for a new session",
+    order: undefined,
+    nativeContinuity: true,
+    reply: "Native account reply.",
+  },
   {
     name: "uses a saved canonical paste-token without an explicit account selection or native login",
     order: undefined,
@@ -82,119 +124,299 @@ const cases: {
   },
 ];
 
-it.each(cases)("chat.send $name", { timeout: 90_000 }, async ({ order, credential, reply }) => {
-  // Each case changes startup auth configuration and owns an empty native-login root.
-  const state = await createOpenClawTestState({
-    label: "chat-cli-auth",
-    env: {
-      PATH: process.env.PATH,
-      CLAUDE_CONFIG_DIR: undefined,
-      ANTHROPIC_API_KEY: undefined,
-      ANTHROPIC_OAUTH_TOKEN: undefined,
-      CLAUDE_CODE_OAUTH_TOKEN: undefined,
-      CLAUDE_CODE_OAUTH_TOKEN_FILE_DESCRIPTOR: undefined,
-      CLAUDE_CODE_API_KEY_FILE_DESCRIPTOR: undefined,
-      OPENCLAW_TEST_MINIMAL_GATEWAY: undefined,
-      OPENCLAW_DISABLE_BUNDLED_PLUGINS: undefined,
-      OPENCLAW_BUNDLED_PLUGINS_DIR: path.join(process.cwd(), "extensions"),
-      OPENCLAW_TEST_TRUST_BUNDLED_PLUGINS_DIR: "1",
-      OPENCLAW_SKIP_CHANNELS: "1",
-      OPENCLAW_SKIP_GMAIL_WATCHER: "1",
-      OPENCLAW_SKIP_CRON: "1",
-      OPENCLAW_SKIP_CANVAS_HOST: "1",
-      OPENCLAW_SKIP_BROWSER_CONTROL_SERVER: "1",
-      OPENCLAW_SKIP_PROVIDERS: "1",
-      OPENCLAW_GATEWAY_TOKEN: undefined,
-      OPENCLAW_GATEWAY_PASSWORD: undefined,
-    },
-  });
-  let gateway: Awaited<ReturnType<typeof startGatewayWithClient>> | undefined;
-  try {
-    const binDir = state.path("bin");
-    const scriptPath = path.join(binDir, "claude.cjs");
-    await fs.mkdir(binDir);
-    if (process.platform === "win32") {
-      await createWindowsCmdShimFixture({
-        shimPath: path.join(binDir, "claude.cmd"),
-        scriptPath,
-        shimLine: `"${process.execPath}" "%~dp0\\claude.cjs" %*`,
-      });
-    } else {
-      await fs.writeFile(
-        path.join(binDir, "claude"),
-        `#!${process.execPath}\n${CLAUDE_AUTH_FIXTURE}`,
-        {
-          mode: 0o755,
-        },
-      );
-    }
-    await fs.writeFile(scriptPath, CLAUDE_AUTH_FIXTURE);
-    setTestEnvValue("PATH", [binDir, process.env.PATH].filter(Boolean).join(path.delimiter));
-    setTestEnvValue("CLAUDE_CONFIG_DIR", state.path("native-claude"));
-    await state.writeAuthProfiles({
-      version: 1,
-      profiles: { "anthropic:pasted": credential },
-    });
-    const modelRef = "anthropic/claude-sonnet-4-6";
-    const token = "chat-cli-auth-test";
-    const cfg = {
-      ...(order ? { auth: { order } } : {}),
-      agents: {
-        defaults: {
-          workspace: state.workspaceDir,
-          skipBootstrap: true,
-          heartbeat: { every: "0m" },
-          model: { primary: modelRef },
-          models: { [modelRef]: { agentRuntime: { id: "claude-cli" } } },
-        },
+it.each(cases)(
+  "chat.send $name",
+  { timeout: 90_000 },
+  async ({ order, credential, reply, nativeContinuity }) => {
+    // Each case changes startup auth configuration and owns an empty native-login root.
+    const state = await createOpenClawTestState({
+      label: "chat-cli-auth",
+      env: {
+        PATH: process.env.PATH,
+        CLAUDE_CONFIG_DIR: undefined,
+        ANTHROPIC_API_KEY: undefined,
+        ANTHROPIC_OAUTH_TOKEN: undefined,
+        CLAUDE_CODE_OAUTH_TOKEN: undefined,
+        CLAUDE_CODE_OAUTH_TOKEN_FILE_DESCRIPTOR: undefined,
+        CLAUDE_CODE_API_KEY_FILE_DESCRIPTOR: undefined,
+        OPENCLAW_TEST_MINIMAL_GATEWAY: undefined,
+        OPENCLAW_DISABLE_BUNDLED_PLUGINS: undefined,
+        OPENCLAW_BUNDLED_PLUGINS_DIR: path.join(process.cwd(), "extensions"),
+        OPENCLAW_TEST_TRUST_BUNDLED_PLUGINS_DIR: "1",
+        OPENCLAW_SKIP_CHANNELS: "1",
+        OPENCLAW_SKIP_GMAIL_WATCHER: "1",
+        OPENCLAW_SKIP_CRON: "1",
+        OPENCLAW_SKIP_CANVAS_HOST: "1",
+        OPENCLAW_SKIP_BROWSER_CONTROL_SERVER: "1",
+        OPENCLAW_SKIP_PROVIDERS: "1",
+        OPENCLAW_GATEWAY_TOKEN: undefined,
+        OPENCLAW_GATEWAY_PASSWORD: undefined,
       },
-      plugins: {
-        enabled: true,
-        allow: ["anthropic"],
-        entries: { anthropic: { enabled: true, config: { sessionCatalog: { enabled: false } } } },
-        slots: { memory: "none" },
-      },
-      tools: { profile: "minimal" },
-      gateway: { auth: { mode: "token", token } },
-    } satisfies OpenClawConfig;
-    gateway = await startGatewayWithClient({
-      cfg,
-      configPath: state.configPath,
-      token,
-      scopes: ["operator.admin", "operator.read", "operator.write"],
     });
-    await gateway.server.startupSettled;
-    const sessionKey = `agent:main:cli-auth-${randomUUID()}`;
-    const accepted = await gateway.client.request<{ runId: string; status: string }>("chat.send", {
-      sessionKey,
-      message: "Reply using the saved account.",
-      deliver: false,
-      idempotencyKey: randomUUID(),
-    });
-    expect(accepted.status).toBe("started");
-    const completed = await gateway.client.request<{ status: string }>(
-      "agent.wait",
-      { runId: accepted.runId, timeoutMs: 30_000 },
-      { timeoutMs: 35_000 },
-    );
-    expect(completed.status).toBe("ok");
-    const history = await gateway.client.request<{ messages: unknown[] }>("chat.history", {
-      sessionKey,
-    });
-    expect(history.messages).toContainEqual(
-      expect.objectContaining({
-        role: "assistant",
-        content: expect.arrayContaining([{ type: "text", text: reply }]),
-      }),
-    );
-  } finally {
+    let gateway: Awaited<ReturnType<typeof startGatewayWithClient>> | undefined;
     try {
-      if (gateway) {
+      const binDir = state.path("bin");
+      const scriptPath = path.join(binDir, "claude.cjs");
+      await fs.mkdir(binDir);
+      if (process.platform === "win32") {
+        await createWindowsCmdShimFixture({
+          shimPath: path.join(binDir, "claude.cmd"),
+          scriptPath,
+          shimLine: `"${process.execPath}" "%~dp0\\claude.cjs" %*`,
+        });
+      } else {
+        await fs.writeFile(
+          path.join(binDir, "claude"),
+          `#!${process.execPath}\n${CLAUDE_AUTH_FIXTURE}`,
+          {
+            mode: 0o755,
+          },
+        );
+      }
+      await fs.writeFile(scriptPath, CLAUDE_AUTH_FIXTURE);
+      setTestEnvValue("PATH", [binDir, process.env.PATH].filter(Boolean).join(path.delimiter));
+      const nativeRoot = path.join(state.home, ".claude");
+      setTestEnvValue("CLAUDE_CONFIG_DIR", nativeRoot);
+      await fs.mkdir(nativeRoot);
+      if (nativeContinuity) {
+        await fs.writeFile(
+          path.join(nativeRoot, ".credentials.json"),
+          JSON.stringify({
+            claudeAiOauth: {
+              accessToken: "synthetic-native-login-token",
+              refreshToken: "synthetic-native-refresh-token",
+              expiresAt: Date.now() + 3_600_000,
+              scopes: ["user:inference", "user:profile"],
+              subscriptionType: "max",
+            },
+          }),
+        );
+      }
+      await state.writeAuthProfiles({
+        version: 1,
+        profiles: credential ? { "anthropic:pasted": credential } : {},
+      });
+      const modelRef = "anthropic/claude-sonnet-4-6";
+      const token = "chat-cli-auth-test";
+      const cfg = {
+        ...(order ? { auth: { order } } : {}),
+        agents: {
+          defaults: {
+            workspace: state.workspaceDir,
+            skipBootstrap: true,
+            heartbeat: { every: "0m" },
+            model: { primary: modelRef },
+            models: { [modelRef]: { agentRuntime: { id: "claude-cli" } } },
+          },
+        },
+        plugins: {
+          enabled: true,
+          allow: ["anthropic"],
+          entries: { anthropic: { enabled: true, config: { sessionCatalog: { enabled: false } } } },
+          slots: { memory: "none" },
+        },
+        tools: { profile: "minimal" },
+        gateway: { auth: { mode: "token", token } },
+      } satisfies OpenClawConfig;
+      gateway = await startGatewayWithClient({
+        cfg,
+        configPath: state.configPath,
+        token,
+        scopes: ["operator.admin", "operator.read", "operator.write"],
+      });
+      await gateway.server.startupSettled;
+      const sessionKey = `agent:main:cli-auth-${randomUUID()}`;
+      const sendTurn = async (
+        client: NonNullable<typeof gateway>["client"],
+        turnSessionKey: string,
+        message: string,
+        expectedReply: string,
+      ) => {
+        const accepted = await client.request<{ runId: string; status: string }>("chat.send", {
+          sessionKey: turnSessionKey,
+          message,
+          deliver: false,
+          idempotencyKey: randomUUID(),
+        });
+        expect(accepted.status).toBe("started");
+        const completed = await client.request<{ status: string }>(
+          "agent.wait",
+          { runId: accepted.runId, timeoutMs: 30_000 },
+          { timeoutMs: 35_000 },
+        );
+        expect(completed.status).toBe("ok");
+        const history = await client.request<{ messages: unknown[] }>("chat.history", {
+          sessionKey: turnSessionKey,
+        });
+        expect(history.messages).toContainEqual(
+          expect.objectContaining({
+            role: "assistant",
+            content: expect.arrayContaining([{ type: "text", text: expectedReply }]),
+          }),
+        );
+      };
+      const marker = `native-history-${randomUUID()}`;
+      await sendTurn(
+        gateway.client,
+        sessionKey,
+        nativeContinuity ? `Remember ${marker}.` : "Reply using the saved account.",
+        reply,
+      );
+      if (nativeContinuity) {
+        const original =
+          loadGatewaySessionEntryReadOnly(sessionKey).entry?.cliSessionBindings?.["claude-cli"];
+        expect(original?.sessionId).toBeTruthy();
+        expect(original?.authProfileId).toBeUndefined();
+        await state.writeAuthProfiles({
+          version: 1,
+          profiles: {
+            "anthropic:pasted": {
+              type: "token",
+              provider: "anthropic",
+              token: "synthetic-pasted-anthropic-token",
+            },
+          },
+        });
         await disconnectGatewayClient(gateway.client);
-        await gateway.server.close({ reason: "CLI auth test cleanup" });
+        await gateway.server.close({ reason: "Verify persisted native account continuity" });
+        gateway = await startGatewayWithClient({
+          cfg,
+          configPath: state.configPath,
+          token,
+          scopes: ["operator.admin", "operator.read", "operator.write"],
+        });
+        await gateway.server.startupSettled;
+        await sendTurn(
+          gateway.client,
+          sessionKey,
+          "Recall the marker from our previous turn.",
+          `Native history: ${marker}.`,
+        );
+        const resumed =
+          loadGatewaySessionEntryReadOnly(sessionKey).entry?.cliSessionBindings?.["claude-cli"];
+        expect(resumed?.sessionId).toBe(original?.sessionId);
+        expect(resumed?.authProfileId).toBe(original?.authProfileId);
+        const savedSessionKey = `agent:main:cli-auth-${randomUUID()}`;
+        await sendTurn(
+          gateway.client,
+          savedSessionKey,
+          "Reply using the saved account.",
+          "Saved account reply.",
+        );
+        const saved =
+          loadGatewaySessionEntryReadOnly(savedSessionKey).entry?.cliSessionBindings?.[
+            "claude-cli"
+          ];
+        expect(saved?.authProfileId).toBe("anthropic:pasted");
+
+        await gateway.client.request("sessions.patch", {
+          key: sessionKey,
+          model: `${modelRef}@anthropic:pasted`,
+        });
+        await sendTurn(
+          gateway.client,
+          sessionKey,
+          "Reply using my explicit account selection.",
+          "Saved account reply.",
+        );
+        const explicitlySelected =
+          loadGatewaySessionEntryReadOnly(sessionKey).entry?.cliSessionBindings?.["claude-cli"];
+        expect(explicitlySelected?.authProfileId).toBe("anthropic:pasted");
+        expect(explicitlySelected?.sessionId).not.toBe(original?.sessionId);
+
+        const replacement = {
+          type: "token",
+          provider: "anthropic",
+          token: "synthetic-replacement-anthropic-token",
+        } satisfies AuthProfileCredential;
+        await state.writeAuthProfiles({
+          version: 1,
+          profiles: {
+            "anthropic:pasted": {
+              type: "token",
+              provider: "anthropic",
+              token: "synthetic-pasted-anthropic-token",
+            },
+            "anthropic:replacement": replacement,
+          },
+          order: { anthropic: ["anthropic:replacement", "anthropic:pasted"] },
+        });
+        await sendTurn(
+          gateway.client,
+          savedSessionKey,
+          "Keep our existing account despite the new default.",
+          "Saved account reply.",
+        );
+        const retained =
+          loadGatewaySessionEntryReadOnly(savedSessionKey).entry?.cliSessionBindings?.[
+            "claude-cli"
+          ];
+        expect(retained?.authProfileId).toBe(saved?.authProfileId);
+        expect(retained?.sessionId).toBe(saved?.sessionId);
+
+        await state.writeAuthProfiles({
+          version: 1,
+          profiles: { "anthropic:replacement": replacement },
+          order: { anthropic: ["anthropic:replacement"] },
+        });
+        await sendTurn(
+          gateway.client,
+          savedSessionKey,
+          "Use the available account after my old account was removed.",
+          "Replacement account reply.",
+        );
+        const replaced =
+          loadGatewaySessionEntryReadOnly(savedSessionKey).entry?.cliSessionBindings?.[
+            "claude-cli"
+          ];
+        expect(replaced?.authProfileId).toBe("anthropic:replacement");
+        expect(replaced?.sessionId).not.toBe(saved?.sessionId);
+        const turns: {
+          sessionId: string;
+          resume: boolean;
+          savedToken: boolean;
+          resumedHistory: unknown[];
+        }[] = (await fs.readFile(path.join(nativeRoot, "turns.jsonl"), "utf8"))
+          .trim()
+          .split("\n")
+          .map((line) => JSON.parse(line));
+        expect(turns).toHaveLength(6);
+        expect(turns[0]).toMatchObject({
+          sessionId: original?.sessionId,
+          resume: false,
+          savedToken: false,
+        });
+        expect(turns[1]).toMatchObject({
+          sessionId: original?.sessionId,
+          resume: true,
+          savedToken: false,
+        });
+        expect(JSON.stringify(turns[1]?.resumedHistory)).toContain(marker);
+        expect(turns[2]).toMatchObject({ resume: false, savedToken: true, resumedHistory: [] });
+        expect(turns[2]?.sessionId).not.toBe(original?.sessionId);
+        expect(turns[3]).toMatchObject({
+          sessionId: explicitlySelected?.sessionId,
+          resume: false,
+          savedToken: true,
+          resumedHistory: [],
+        });
+        expect(turns[4]).toMatchObject({ sessionId: saved?.sessionId, savedToken: true });
+        expect(turns[5]).toMatchObject({
+          sessionId: replaced?.sessionId,
+          resume: false,
+          savedToken: true,
+          resumedHistory: [],
+        });
       }
     } finally {
-      await state.cleanup();
+      try {
+        if (gateway) {
+          await disconnectGatewayClient(gateway.client);
+          await gateway.server.close({ reason: "CLI auth test cleanup" });
+        }
+      } finally {
+        await state.cleanup();
+      }
     }
-  }
-});
+  },
+);

--- a/src/gateway/server.chat-cli-auth.test.ts
+++ b/src/gateway/server.chat-cli-auth.test.ts
@@ -1,0 +1,200 @@
+import { randomUUID } from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { expect, it } from "vitest";
+import type { AuthProfileCredential } from "../agents/auth-profiles/types.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { createWindowsCmdShimFixture } from "../test-helpers/windows-cmd-shim.js";
+import { setTestEnvValue } from "../test-utils/env.js";
+import { createOpenClawTestState } from "../test-utils/openclaw-test-state.js";
+import { disconnectGatewayClient, startGatewayWithClient } from "./test-helpers.e2e.js";
+
+// Only the external executable is a fixture. The registered Gateway, Anthropic
+// plugin, profile selection, credential transport, and transcript writer are real.
+const CLAUDE_AUTH_FIXTURE = String.raw`
+const assert = require("node:assert/strict");
+const { readFileSync } = require("node:fs");
+const { createInterface } = require("node:readline");
+const send = (message) => process.stdout.write(JSON.stringify(message) + "\n");
+if (process.argv.includes("--version")) {
+  process.stdout.write("2.1.226 (Claude Code fixture)\n");
+  process.exit(0);
+}
+if (process.argv.includes("auth")) {
+  send({ loggedIn: false });
+  process.exit(0);
+}
+const descriptor = process.env.CLAUDE_CODE_OAUTH_TOKEN_FILE_DESCRIPTOR;
+let reply = "No managed credential supplied.";
+if (descriptor !== undefined) {
+  assert.equal(descriptor, "3");
+  assert.equal(readFileSync(3, "utf8"), "synthetic-pasted-anthropic-token");
+  reply = "Saved account reply.";
+}
+for (const name of ["ANTHROPIC_API_KEY", "CLAUDE_CODE_OAUTH_TOKEN", "CLAUDE_CODE_API_KEY_FILE_DESCRIPTOR"]) {
+  assert.equal(process.env[name], undefined);
+}
+createInterface({ input: process.stdin }).on("line", (line) => {
+  const message = JSON.parse(line);
+  if (message.type === "control_request" && message.request.subtype === "initialize") {
+    send({ type: "control_response", response: {
+      subtype: "success", request_id: message.request_id, response: { commands: [], models: [] },
+    } });
+  } else if (message.type === "user") {
+    send({ type: "assistant", message: {
+      role: "assistant", content: [{ type: "text", text: reply }],
+    } });
+    send({ type: "result", subtype: "success", is_error: false,
+      result: reply, session_id: message.session_id });
+  }
+});
+`;
+
+const cases: {
+  name: string;
+  order: NonNullable<OpenClawConfig["auth"]>["order"];
+  credential: AuthProfileCredential;
+  reply: string;
+}[] = [
+  {
+    name: "uses a saved canonical paste-token without an explicit account selection or native login",
+    order: undefined,
+    credential: { type: "token", provider: "anthropic", token: "synthetic-pasted-anthropic-token" },
+    reply: "Saved account reply.",
+  },
+  {
+    name: "uses a saved canonical paste-token selected by the canonical account order",
+    order: { anthropic: ["anthropic:pasted"] },
+    credential: { type: "token", provider: "anthropic", token: "synthetic-pasted-anthropic-token" },
+    reply: "Saved account reply.",
+  },
+  {
+    name: "honors an explicit empty CLI account order despite a saved canonical paste-token",
+    order: { "claude-cli": [] },
+    credential: { type: "token", provider: "anthropic", token: "synthetic-pasted-anthropic-token" },
+    reply: "No managed credential supplied.",
+  },
+  {
+    name: "leaves native authentication in charge when only a canonical API key is saved",
+    order: undefined,
+    credential: { type: "api_key", provider: "anthropic", key: "synthetic-pasted-anthropic-key" },
+    reply: "No managed credential supplied.",
+  },
+];
+
+it.each(cases)("chat.send $name", { timeout: 90_000 }, async ({ order, credential, reply }) => {
+  // Each case changes startup auth configuration and owns an empty native-login root.
+  const state = await createOpenClawTestState({
+    label: "chat-cli-auth",
+    env: {
+      PATH: process.env.PATH,
+      CLAUDE_CONFIG_DIR: undefined,
+      ANTHROPIC_API_KEY: undefined,
+      ANTHROPIC_OAUTH_TOKEN: undefined,
+      CLAUDE_CODE_OAUTH_TOKEN: undefined,
+      CLAUDE_CODE_OAUTH_TOKEN_FILE_DESCRIPTOR: undefined,
+      CLAUDE_CODE_API_KEY_FILE_DESCRIPTOR: undefined,
+      OPENCLAW_TEST_MINIMAL_GATEWAY: undefined,
+      OPENCLAW_DISABLE_BUNDLED_PLUGINS: undefined,
+      OPENCLAW_BUNDLED_PLUGINS_DIR: path.join(process.cwd(), "extensions"),
+      OPENCLAW_TEST_TRUST_BUNDLED_PLUGINS_DIR: "1",
+      OPENCLAW_SKIP_CHANNELS: "1",
+      OPENCLAW_SKIP_GMAIL_WATCHER: "1",
+      OPENCLAW_SKIP_CRON: "1",
+      OPENCLAW_SKIP_CANVAS_HOST: "1",
+      OPENCLAW_SKIP_BROWSER_CONTROL_SERVER: "1",
+      OPENCLAW_SKIP_PROVIDERS: "1",
+      OPENCLAW_GATEWAY_TOKEN: undefined,
+      OPENCLAW_GATEWAY_PASSWORD: undefined,
+    },
+  });
+  let gateway: Awaited<ReturnType<typeof startGatewayWithClient>> | undefined;
+  try {
+    const binDir = state.path("bin");
+    const scriptPath = path.join(binDir, "claude.cjs");
+    await fs.mkdir(binDir);
+    if (process.platform === "win32") {
+      await createWindowsCmdShimFixture({
+        shimPath: path.join(binDir, "claude.cmd"),
+        scriptPath,
+        shimLine: `"${process.execPath}" "%~dp0\\claude.cjs" %*`,
+      });
+    } else {
+      await fs.writeFile(
+        path.join(binDir, "claude"),
+        `#!${process.execPath}\n${CLAUDE_AUTH_FIXTURE}`,
+        {
+          mode: 0o755,
+        },
+      );
+    }
+    await fs.writeFile(scriptPath, CLAUDE_AUTH_FIXTURE);
+    setTestEnvValue("PATH", [binDir, process.env.PATH].filter(Boolean).join(path.delimiter));
+    setTestEnvValue("CLAUDE_CONFIG_DIR", state.path("native-claude"));
+    await state.writeAuthProfiles({
+      version: 1,
+      profiles: { "anthropic:pasted": credential },
+    });
+    const modelRef = "anthropic/claude-sonnet-4-6";
+    const token = "chat-cli-auth-test";
+    const cfg = {
+      ...(order ? { auth: { order } } : {}),
+      agents: {
+        defaults: {
+          workspace: state.workspaceDir,
+          skipBootstrap: true,
+          heartbeat: { every: "0m" },
+          model: { primary: modelRef },
+          models: { [modelRef]: { agentRuntime: { id: "claude-cli" } } },
+        },
+      },
+      plugins: {
+        enabled: true,
+        allow: ["anthropic"],
+        entries: { anthropic: { enabled: true, config: { sessionCatalog: { enabled: false } } } },
+        slots: { memory: "none" },
+      },
+      tools: { profile: "minimal" },
+      gateway: { auth: { mode: "token", token } },
+    } satisfies OpenClawConfig;
+    gateway = await startGatewayWithClient({
+      cfg,
+      configPath: state.configPath,
+      token,
+      scopes: ["operator.admin", "operator.read", "operator.write"],
+    });
+    await gateway.server.startupSettled;
+    const sessionKey = `agent:main:cli-auth-${randomUUID()}`;
+    const accepted = await gateway.client.request<{ runId: string; status: string }>("chat.send", {
+      sessionKey,
+      message: "Reply using the saved account.",
+      deliver: false,
+      idempotencyKey: randomUUID(),
+    });
+    expect(accepted.status).toBe("started");
+    const completed = await gateway.client.request<{ status: string }>(
+      "agent.wait",
+      { runId: accepted.runId, timeoutMs: 30_000 },
+      { timeoutMs: 35_000 },
+    );
+    expect(completed.status).toBe("ok");
+    const history = await gateway.client.request<{ messages: unknown[] }>("chat.history", {
+      sessionKey,
+    });
+    expect(history.messages).toContainEqual(
+      expect.objectContaining({
+        role: "assistant",
+        content: expect.arrayContaining([{ type: "text", text: reply }]),
+      }),
+    );
+  } finally {
+    try {
+      if (gateway) {
+        await disconnectGatewayClient(gateway.client);
+        await gateway.server.close({ reason: "CLI auth test cleanup" });
+      }
+    } finally {
+      await state.cleanup();
+    }
+  }
+});

--- a/test/scripts/ci-node-test-plan.test.ts
+++ b/test/scripts/ci-node-test-plan.test.ts
@@ -38,6 +38,7 @@ import { createGatewayClientVitestConfig } from "../vitest/vitest.gateway-client
 import { createGatewayCoreVitestConfig } from "../vitest/vitest.gateway-core.config.ts";
 import { createGatewayMethodsIsolatedVitestConfig } from "../vitest/vitest.gateway-methods-isolated.config.ts";
 import { createGatewayMethodsVitestConfig } from "../vitest/vitest.gateway-methods.config.ts";
+import { createGatewayServerIsolatedVitestConfig } from "../vitest/vitest.gateway-server-isolated.config.ts";
 import { isGatewayServerTestFile } from "../vitest/vitest.gateway-server-paths.mjs";
 import { createGatewayServerVitestConfig } from "../vitest/vitest.gateway-server.config.ts";
 import { createMediaUnderstandingVitestConfig } from "../vitest/vitest.media-understanding.config.ts";
@@ -1481,6 +1482,9 @@ describe("scripts/lib/ci-node-test-plan.mts", () => {
       ...listMatchedTestFiles(createGatewayMethodsVitestConfig({})),
       ...listMatchedTestFiles(createGatewayMethodsIsolatedVitestConfig({})),
     ];
+    const gatewayServerIsolatedOwnerFiles = listMatchedTestFiles(
+      createGatewayServerIsolatedVitestConfig({}),
+    );
     const compactGroups = compact.flatMap((shard) => shard.groups);
     const pullRequestCompactGroups = pullRequestCompact.flatMap((shard) => shard.groups);
     const expectedGroupNames = base.flatMap((shard) =>
@@ -1563,6 +1567,8 @@ describe("scripts/lib/ci-node-test-plan.mts", () => {
           );
         } else if (owner.shardName === "agentic-gateway-methods") {
           expect(actual.toSorted()).toEqual(gatewayMethodsOwnerFiles.toSorted());
+        } else if (owner.shardName === "agentic-gateway-server-isolated") {
+          expect(actual.toSorted()).toEqual(gatewayServerIsolatedOwnerFiles.toSorted());
         }
       }
     }
@@ -1579,6 +1585,7 @@ describe("scripts/lib/ci-node-test-plan.mts", () => {
         .concat(
           embeddedBaseOwnerFiles,
           gatewayMethodsOwnerFiles,
+          gatewayServerIsolatedOwnerFiles,
           listMatchedTestFiles(createCliProcessVitestConfig({})),
           listMatchedTestFiles(createPluginSdkVitestConfig({})),
           listMatchedTestFiles(createPluginSdkLightVitestConfig({})),
@@ -1596,6 +1603,7 @@ describe("scripts/lib/ci-node-test-plan.mts", () => {
         .concat(
           embeddedBaseOwnerFiles,
           gatewayMethodsOwnerFiles,
+          gatewayServerIsolatedOwnerFiles,
           listMatchedTestFiles(createCliProcessVitestConfig({})),
           listMatchedTestFiles(createPluginSdkVitestConfig({})),
           listMatchedTestFiles(createPluginSdkLightVitestConfig({})),

--- a/test/vitest/vitest.gateway-server-isolated.config.ts
+++ b/test/vitest/vitest.gateway-server-isolated.config.ts
@@ -25,8 +25,7 @@ export function createGatewayServerIsolatedVitestConfig(
     test: {
       ...sharedTest,
       name: "gateway-server-isolated",
-      // These files replace a module the Gateway reaches through re-exports, so a
-      // neighbour that already bound the real implementation would defeat the mock.
+      // Keep each file's real or mocked Gateway modules out of neighboring graphs.
       isolate: true,
       runner: undefined,
       setupFiles: [resolveRepoRootPath("test/setup.env.ts")],

--- a/test/vitest/vitest.gateway-server-paths.mjs
+++ b/test/vitest/vitest.gateway-server-paths.mjs
@@ -22,11 +22,12 @@ export const gatewayMethodsIsolatedTestFiles = [
   "src/gateway/server-methods/usage.sessions-usage.test.ts",
 ];
 
-// Gateway server tests that replace a module the Gateway reaches only through
-// re-exports. These need both a fresh graph and the plain Vitest runner.
+// Gateway server tests that need a private module graph and the plain Vitest runner.
 export const gatewayServerIsolatedTestFiles = [
   "src/gateway/server-chat.retired-projection.test.ts",
   "src/gateway/server-plugin-subagent-runtime.overrides.test.ts",
+  // Loads the real plugin runtime that neighboring server tests replace with mocks.
+  "src/gateway/server.chat-cli-auth.test.ts",
   "src/gateway/server.sessions.compaction-read-errors.test.ts",
 ];
 


### PR DESCRIPTION
## What Problem This Solves

A saved subscription token was dropped before CLI execution unless the account was explicitly selected. Default turns reported “Not logged in” and used the configured fallback (#144793).

## Why This Change Was Made

The shared selector forwards saved subscription credentials using account order. This restores 2026.9.1 behavior and reverses the forwarding restriction from #144266. @MasterSwords1 for awareness.

## User Impact

New sessions use saved subscription tokens without an account selection or native login file. Existing sessions keep their account and history until the user selects another account or the stored profile is removed.

## Evidence

- Token-only default: before, all 10 turns failed at 1/2/3/4 concurrency; after, all succeeded without fallback.
- Native conversation: before, saving a token and restarting switched accounts and omitted history; after, the real CLI resumed the same native session with prior history. Fresh sessions and explicit changes used the saved token.
- Registered `chat.send` → `agent.wait` → `chat.history` and recording endpoints exercised both paths. All 16 valid saved-config fixtures reached readiness; the invalid legacy fixture was rejected. Published 2026.9.1 passed the token-only cases.

## Compatibility

Explicit pins, native selections and empty orders retain their meaning. Provider API keys require explicit selection for this subscription route. Cross-account history protection and fallback policy are unchanged. No schema, config-key or API changes.

## Consumers

- Chat replies and scheduled turns: keep the session account.
- Direct CLI turns: preserve scoped credentials for every supported backend.
- System-agent setup: uses the ordered saved credential; verified conversations retain their bound route.
- Integration-test scheduling: prepares runtime artifacts using existing runner capacity.

## Invalidation

Each turn reads current credentials and the session binding; saving tokens or changing account order preserves an existing account, while profile removal or a new session permits selection, and restart restores the saved binding.

## Contention

No new lock or queue. Real CLI overlap at 2/3/4 turns passed; Gateway health responded within 0.8 seconds.

## Tests

Five registered chat cases cover defaults, native continuity, explicit changes, account order/removal, empty order and API-key-only setup. All 152 direct CLI cases pass. Timing and planner baselines are unchanged.
