### PR TITLE
fix: skip unused Git scans when archiving worktrees

### DIFF
--- a/src/agents/worktrees/provisioned-files.ts
+++ b/src/agents/worktrees/provisioned-files.ts
@@ -257,6 +257,11 @@ export async function snapshotProvisionedFiles(
   if (files === undefined) {
     throw new Error("provisioned path ledger is unavailable");
   }
+  if (files.every((file) => file.mode === null)) {
+    commitGuard?.();
+    clearRegistryWorktreeProvisionedChunks(env, worktreeId);
+    return files.map((file) => ({ path: file.path, mode: null, chunks: 0 }));
+  }
   const ignoredUntracked = new Set(
     (
       await requireGitRaw(worktreePath, [

--- a/src/agents/worktrees/service.provisioned.test.ts
+++ b/src/agents/worktrees/service.provisioned.test.ts
@@ -7,7 +7,13 @@ import { promisify } from "node:util";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import * as commandRunner from "../../process/exec-runner.js";
 import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
-import { insertRegistryWorktree } from "./registry.js";
+import { snapshotProvisionedFiles } from "./provisioned-files.js";
+import {
+  getRegistryWorktreeProvisionedChunk,
+  getRegistryWorktreeProvisionedState,
+  insertRegistryWorktree,
+  insertRegistryWorktreeProvisionedChunk,
+} from "./registry.js";
 import { ManagedWorktreeService } from "./service.js";
 
 const execFileAsync = promisify(execFile);
@@ -74,6 +80,57 @@ describe("ManagedWorktreeService provisioned state", () => {
     closeOpenClawStateDatabaseForTest();
     await fs.rm(root, { recursive: true, force: true });
   });
+
+  it.each([false, true])(
+    "skips inventories for absent provisioned contents and restores their state (deleted=%s)",
+    async (deleted) => {
+      await fs.writeFile(path.join(repo, ".gitignore"), ".env.local\nignored/\n");
+      await fs.writeFile(path.join(repo, ".worktreeinclude"), ".env.local\n");
+      await git(repo, "add", ".gitignore", ".worktreeinclude");
+      await git(repo, "commit", "-m", "configure worktree provisioning");
+      if (deleted) {
+        await fs.writeFile(path.join(repo, ".env.local"), "synthetic provisioned bytes\n");
+      }
+      const created = await service.create({ repoRoot: repo, name: "absent", baseRef: "HEAD" });
+      const ledger = deleted ? [".env.local"] : [];
+      const expected = deleted ? [{ path: ".env.local", mode: null, chunks: 0 }] : [];
+      if (deleted) {
+        await fs.rm(path.join(created.path, ".env.local"));
+      }
+      await fs.writeFile(path.join(created.path, "README.md"), "preserved edit\n");
+      const oldChunk = { worktreeId: created.id, path: "old.local", chunkIndex: 0 };
+      const oldBytes = new TextEncoder().encode("old");
+      insertRegistryWorktreeProvisionedChunk(env, { ...oldChunk, data: oldBytes });
+      const guard = vi.fn();
+      const commands = vi.spyOn(commandRunner, "runCommandWithTimeout");
+      try {
+        await expect(
+          snapshotProvisionedFiles(env, created.id, created.path, ledger, () => {
+            throw new Error("authority changed");
+          }),
+        ).rejects.toThrow("authority changed");
+        expect(getRegistryWorktreeProvisionedChunk(env, oldChunk)).toEqual(oldBytes);
+        expect(
+          await snapshotProvisionedFiles(env, created.id, created.path, ledger, guard),
+        ).toEqual(expected);
+        expect(guard).toHaveBeenCalled();
+        expect(getRegistryWorktreeProvisionedChunk(env, oldChunk)).toBeUndefined();
+        expect(commands.mock.calls.length).toBe(0);
+      } finally {
+        commands.mockRestore();
+      }
+      const removed = await service.remove({ id: created.id, reason: "test" });
+      expect(removed.removed).toBe(true);
+      expect(getRegistryWorktreeProvisionedState(env, created.id)).toEqual(expected);
+      const restored = await service.restore({ id: created.id });
+      expect(await fs.readFile(path.join(restored.path, "README.md"), "utf8")).toBe(
+        "preserved edit\n",
+      );
+      await expect(fs.stat(path.join(restored.path, ".env.local"))).rejects.toMatchObject({
+        code: "ENOENT",
+      });
+    },
+  );
 
   it("snapshots large provisioned files without buffering them in the service", async () => {
     await fs.writeFile(path.join(repo, ".gitignore"), "large.local\n");


### PR DESCRIPTION
## What Problem This Solves

Archiving a managed worktree runs unnecessary repository inventories even when its provisioned-file ledger is empty or every provisioned file has been deleted.

## Why This Change Was Made

The provisioned snapshot owner now finishes directly after validating those absence states. It still checks current authority before clearing old chunks and returns the same sorted empty or missing-file records. Present files retain their existing Git-membership and safe-file checks.

## User Impact

Archives without provisioned file contents avoid three Git subprocesses. Worktree allocation, full snapshot checks, removal ownership, and restoration behavior stay the same.

## Evidence

- A real Git/SQLite probe with five measurements after a warm-up reduced this isolated step from 49–55 ms to 0.3–0.4 ms in a tiny repository, and from 73–74 ms to 0.2–0.5 ms with 30,000 ignored files. These are local helper timings, not an end-to-end or live latency claim.
- Regressions cover empty and all-missing ledgers, authority rejection preserving old chunks, successful cleanup, and actual service remove/restore preserving tracked edits and absent provisioned files. They pass on the candidate and fail on the original owner because it launches unnecessary Git commands.
- Focused worktree validation passes: 59 tests, with one existing Linux-only filename case skipped on macOS. Independent P2 review is clean. The complete changed-file gate passes.
