### PR TITLE
feat(browser): apply control policy without restarting the gateway

### DIFF
--- a/docs/gateway/configuration/hot-reload.md
+++ b/docs/gateway/configuration/hot-reload.md
@@ -97,6 +97,7 @@ back to OpenClaw.
 | Gateway auth limits       | `gateway.auth.rateLimit`                                                                                                                                                                                                                                           | No (retains limiter state)             |
 | Discovery visibility      | `discovery.mdns.mode`                                                                                                                                                                                                                                              | No (replaces discovery advertisements) |
 | Browser defaults          | `browser.profiles`, `browser.defaultProfile`, `browser.headless`, `browser.executablePath`, `browser.attachOnly`, `browser.cdpUrl`, `browser.noSandbox`, `browser.extraArgs`, `browser.snapshotDefaults`, `browser.tabCleanup`, `browser.allowSystemProfileImport` | No                                     |
+| Browser control policy    | `browser.enabled`, `browser.evaluateEnabled`, `browser.ssrfPolicy`                                                                                                                                                                                                 | No (replaces Browser control service)  |
 | Gateway server            | Other `gateway.*` settings (port, bind, auth mode, roles, tailscale, TLS)                                                                                                                                                                                          | **Yes**                                |
 | Infrastructure            | Other `discovery` and `browser` settings, MCP Apps listener settings, `secrets.egressProxy`, `plugins.load`, `plugins.installs`                                                                                                                                    | **Yes**                                |
 
@@ -173,9 +174,14 @@ in force until that restart completes or its rejected changes are reverted.
 
 Browser default-profile changes apply on the next request. Launch-setting
 changes replace affected managed browser processes when next used; externally
-attached browsers stay running. Browser enablement, evaluation, SSRF policy,
-and extension relay remain restart-owned. Snapshot defaults apply to the next
-snapshot, and tab-cleanup settings apply on the next sweep.
+attached browsers stay running. Browser enablement, evaluation, and SSRF policy
+changes replace only the Browser control service: pending operations cancel and
+owned Chrome processes close before the new policy applies. Attached and remote
+browser processes stay open while OpenClaw disconnects its control sessions.
+When enabled, Browser control starts again on demand; managed tabs from the
+retired process are not kept. Extension relay settings still require a Gateway
+restart. Snapshot defaults apply to the next snapshot, and tab-cleanup settings
+apply on the next sweep.
 
 Authentication rate-limit changes retain recorded failures, earned lockout
 deadlines, and pending loopback delays. New limits and loopback exemptions apply

--- a/docs/tools/browser/configuration.md
+++ b/docs/tools/browser/configuration.md
@@ -12,6 +12,15 @@ read_when:
 
 Browser settings live in `~/.openclaw/openclaw.json`.
 
+With Gateway hot reload enabled, changing `browser.enabled`,
+`browser.evaluateEnabled`, or `browser.ssrfPolicy` replaces only the Browser
+control service. Pending browser operations are cancelled and OpenClaw-owned
+Chrome processes close before the new policy applies. The Gateway and other
+plugins keep running. Attached and remote browser processes stay open, but
+OpenClaw disconnects its control sessions. Browser control starts again on the
+next request when enabled; managed tabs from the retired process are not kept.
+Extension relay configuration still requires a Gateway restart.
+
 ```json5
 {
   browser: {

--- a/extensions/browser/plugin-registration.ts
+++ b/extensions/browser/plugin-registration.ts
@@ -255,6 +255,11 @@ function createLazyBrowserPluginService(): OpenClawPluginService {
   };
   return {
     id: "browser-control",
+    // Policy changes drain the service's generation before adopting new values.
+    // Profile-level refresh keeps the admitted policy until this owner stops.
+    reload: {
+      configPrefixes: ["browser.enabled", "browser.evaluateEnabled", "browser.ssrfPolicy"],
+    },
     start: async (ctx) => {
       if (!isTruthyEnvValue(process.env[EAGER_BROWSER_CONTROL_SERVICE_ENV])) {
         return;

--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -329,7 +329,12 @@ describe("buildGatewayReloadPlan", () => {
           },
         } as never,
         registerService(service) {
-          registry.services.push({ pluginId: "browser", source: "test", service });
+          registry.services.push({
+            pluginId: "browser",
+            source: "test",
+            origin: "bundled",
+            service,
+          });
         },
       }),
     );
@@ -353,7 +358,7 @@ describe("buildGatewayReloadPlan", () => {
       }
       const profiles = buildGatewayReloadPlan(["browser.profiles.openclaw.headless"]);
       expect(profiles.restartGateway).toBe(false);
-      expect(profiles.restartServices.size).toBe(0);
+      expect(profiles.restartServices).toEqual(new Set());
       expect(
         buildGatewayReloadPlan(["browser.extensionRelay.allowLegacyAuth"]).restartGateway,
       ).toBe(true);

--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -58,10 +58,12 @@ import {
   runOutsidePluginCache,
   withPluginCache,
 } from "../plugins/plugin-cache.js";
+import type { OpenClawPluginDefinition } from "../plugins/plugin-definition.types.js";
 import { capturePluginGenerationArtifact } from "../plugins/plugin-generation-artifact.js";
 import { PluginInstance } from "../plugins/plugin-instance.js";
 import { withPluginLifecycleLease } from "../plugins/plugin-lifecycle-lease.js";
 import { createPluginMetadataSnapshotFixture } from "../plugins/plugin-metadata.test-support.js";
+import { loadPluginPublicArtifactModuleSync } from "../plugins/public-surface-loader.js";
 import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../plugins/runtime.js";
 import {
   captureGatewayRootWorkAdmissionContinuationScope,
@@ -317,10 +319,19 @@ describe("diffConfigPaths", () => {
 
 describe("buildGatewayReloadPlan", () => {
   const emptyRegistry = createTestRegistry([]);
-  it("reloads the registered Browser service for control policy without restarting the Gateway", async () => {
-    const { default: browser } = await import("../../extensions/browser/index.js");
+  it("reloads the registered Browser service for control policy without restarting the Gateway", () => {
+    const { default: browser } = loadPluginPublicArtifactModuleSync<{
+      default: OpenClawPluginDefinition;
+    }>({
+      pluginRoot: nodePath.resolve("extensions/browser"),
+      artifactBasename: "index.ts",
+      origin: "bundled",
+    });
+    if (!browser.register) {
+      throw new Error("Browser plugin must expose its registration entry point");
+    }
     const registry = createTestRegistry([]);
-    await browser.register(
+    browser.register(
       createTestPluginApi({
         runtime: {
           state: {

--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -40,6 +40,7 @@ import {
   createRuntimeConfigWriteApplication,
 } from "../config/runtime-write-application.js";
 import type { PluginInstallRecord } from "../config/types.plugins.js";
+import { createTestPluginApi } from "../plugin-sdk/plugin-test-api.js";
 import {
   clearCurrentPluginMetadataSnapshot,
   getCurrentPluginMetadataSnapshotState,
@@ -316,6 +317,50 @@ describe("diffConfigPaths", () => {
 
 describe("buildGatewayReloadPlan", () => {
   const emptyRegistry = createTestRegistry([]);
+  it("reloads the registered Browser service for control policy without restarting the Gateway", async () => {
+    const { default: browser } = await import("../../extensions/browser/index.js");
+    const registry = createTestRegistry([]);
+    await browser.register(
+      createTestPluginApi({
+        runtime: {
+          state: {
+            openSyncKeyedStore: () => ({ entries: () => [] }),
+            openKeyedStore: vi.fn(),
+          },
+        } as never,
+        registerService(service) {
+          registry.services.push({ pluginId: "browser", source: "test", service });
+        },
+      }),
+    );
+    registry.reloads.push({
+      pluginId: "browser",
+      source: "test",
+      registration: browser.reload ?? {},
+    });
+    setActivePluginRegistry(registry);
+    try {
+      for (const path of [
+        "browser.enabled",
+        "browser.evaluateEnabled",
+        "browser.ssrfPolicy.allowedHostnames",
+      ]) {
+        const plan = buildGatewayReloadPlan([path]);
+        expect(plan.restartGateway, path).toBe(false);
+        expect(plan.restartServices, path).toEqual(new Set(["browser-control"]));
+        expect(plan.reloadPlugins, path).toBe(false);
+        expect(plan.restartChannels.size, path).toBe(0);
+      }
+      const profiles = buildGatewayReloadPlan(["browser.profiles.openclaw.headless"]);
+      expect(profiles.restartGateway).toBe(false);
+      expect(profiles.restartServices.size).toBe(0);
+      expect(
+        buildGatewayReloadPlan(["browser.extensionRelay.allowLegacyAuth"]).restartGateway,
+      ).toBe(true);
+    } finally {
+      setActivePluginRegistry(emptyRegistry);
+    }
+  });
   it("selects only attached service owners for their declared config and preserves unknown restart policy", () => {
     const serviceRegistry = createTestRegistry([]);
     serviceRegistry.services.push({


### PR DESCRIPTION
## What Problem This Solves

Changing browser enablement, JavaScript evaluation, or browser network policy currently restarts the entire Gateway and interrupts unrelated work.

## Why This Change Was Made

Declare these settings on the existing Browser control service reload owner. The existing lifecycle cancels admitted operations, drains control sessions and closes OpenClaw-owned Chrome before adopting the new policy. The Gateway and external browser processes remain running; managed tabs from the retired process are not preserved. No new reload manager or public config is introduced.

## User Impact

Operators can change `browser.enabled`, `browser.evaluateEnabled`, and `browser.ssrfPolicy` without restarting the Gateway. Browser control returns on demand when enabled. Extension relay settings retain their existing Gateway restart boundary.

## Evidence

The actual registered Browser service/planner reproduction failed before the declaration and passes after it. All 537 Gateway reload tests and 27 Browser lifecycle/service tests pass. Independent review found no actionable P0–P2 findings. Production +5 lines; tests +61; docs +15.

Linux build, extension/core-test types, typed lint and all six real Gateway/Chromium groups passed on `0183d54eb21f61a18c0c3851069272bbde1ecbc3` in [Testbox run34702649579](https://github.com/openclaw/openclaw/actions/runs/34702649579). The held evaluation cancelled in848ms; Gateway PID9342, boot42777529-76ec-4e39-920d-3ebdaeb2fa68 and operator connection remained unchanged. Owned Chrome processes retired; external PID9341 and its original tab survived. Both children exited0 and the lease is stopped/completed. Verified receipt archive26,128bytes, SHA256 `48a2fecfcd717bb0adda96ac9efbb56d2f835ebf760f064f19f088f03a3cdf2e`; raw logs remain private, with safe summary/receipt retained.

Two test-fixture corrections resolved clean type/lint and core graph failures without changing runtime code. The subsequent import-only conflict was resolved by preserving main's import and the test's type import; registered planner and23 service-lifecycle tests pass after integration. The current rebased head `7e7f73d609a5046e98e4eda766ce049d95da88eb` has a patch-identical three-commit range and includes main's independent shard-headroom repair from #146194. The earlier unrelated701-root CI failure is explained by that moving-main issue. Final exact-head CI passed: [run34709412537](https://github.com/openclaw/openclaw/actions/runs/34709412537). The native watcher returned GREEN with zero pending checks.
