### PR TITLE
fix(plugins): reduce loaded facade lookup allocations

### DIFF
--- a/src/plugin-sdk/facade-resolution-shared.ts
+++ b/src/plugin-sdk/facade-resolution-shared.ts
@@ -11,6 +11,7 @@ import {
   resolveBundledPluginSourcePublicSurfacePath,
   resolvePluginRootPublicSurfacePath,
 } from "../plugins/public-surface-runtime.js";
+import type { PluginRecord } from "../plugins/registry-types.js";
 import { getPluginRegistryForContext } from "../plugins/runtime/gateway-request-scope.js";
 
 export type BundledPluginPublicSurfaceParams = {
@@ -27,6 +28,8 @@ export type FacadeModuleLocationLike = {
   origin?: PluginManifestRecord["origin"];
 };
 
+const RUNTIME_FACADE_MATCH_TIERS = ["id", "folder", "channel"] as const;
+
 /** An executing instance wins over metadata and bundled fallbacks, including a missing surface. */
 export function resolveRuntimeFacadeModuleLocation(
   params: BundledPluginPublicSurfaceParams,
@@ -34,24 +37,39 @@ export function resolveRuntimeFacadeModuleLocation(
   if (params.env !== undefined && params.env !== process.env) {
     return undefined;
   }
-  const records =
-    getPluginRegistryForContext()?.plugins.filter(
-      (record) => record.status === "loaded" && record.rootDir,
-    ) ?? [];
-  const candidates = [
-    records.filter((record) => record.id === params.dirName),
-    records.filter((record) => path.basename(record.rootDir!) === params.dirName),
-    records.filter((record) => record.channelIds.includes(params.dirName)),
-  ].find((matches) => matches.length);
-  if (!candidates) {
+  const records = getPluginRegistryForContext()?.plugins;
+  if (!records) {
     return undefined;
   }
-  if (candidates.length !== 1) {
-    throw new Error(
-      `Plugin public surface ${params.dirName} has ambiguous runtime ownership; use its plugin id.`,
-    );
+  let owner: PluginRecord | undefined;
+  for (const tier of RUNTIME_FACADE_MATCH_TIERS) {
+    for (const record of records) {
+      if (record.status !== "loaded" || !record.rootDir) {
+        continue;
+      }
+      const matches =
+        tier === "id"
+          ? record.id === params.dirName
+          : tier === "folder"
+            ? path.basename(record.rootDir) === params.dirName
+            : record.channelIds.includes(params.dirName);
+      if (!matches) {
+        continue;
+      }
+      if (owner) {
+        throw new Error(
+          `Plugin public surface ${params.dirName} has ambiguous runtime ownership; use its plugin id.`,
+        );
+      }
+      owner = record;
+    }
+    if (owner) {
+      break;
+    }
   }
-  const owner = candidates[0]!;
+  if (!owner) {
+    return undefined;
+  }
   const modulePath = resolvePluginRootPublicSurfacePath({
     pluginRoot: owner.rootDir!,
     pluginId: owner.id,

--- a/src/plugins/public-surface-generation.test.ts
+++ b/src/plugins/public-surface-generation.test.ts
@@ -114,6 +114,53 @@ function prepare(
 }
 
 describe("managed plugin public surfaces", () => {
+  it.each(["id", "folder", "channel"] as const)(
+    "selects the unique loaded %s owner before considering lower-priority aliases",
+    (tier) => {
+      const parent = fs.realpathSync(temp.make("openclaw-public-owner-priority-"));
+      const dirName = "runtime-selected";
+      const prepareOwner = (name: string, folder: string, id: string) => {
+        const root = path.join(parent, name, folder);
+        fs.mkdirSync(root, { recursive: true });
+        writeSource(root, name, "js");
+        const active = prepare(root, id, "global", "js");
+        active.record.channelIds.push(dirName);
+        return active;
+      };
+      const winner = prepareOwner(
+        "winner",
+        tier === "folder" ? dirName : "winner-root",
+        tier === "id" ? dirName : "winner",
+      );
+      const first = prepareOwner(
+        "first",
+        tier === "id" || tier === "channel" ? dirName : "first-root",
+        tier === "channel" ? dirName : "first",
+      );
+      const second = prepareOwner("second", tier === "id" ? dirName : "second-root", "second");
+      if (tier === "channel") {
+        first.record.status = "disabled";
+        second.record.status = "disabled";
+      }
+      winner.registry.plugins.unshift(first.record, second.record);
+      winner.publish();
+      const load = () =>
+        loadBundledPluginPublicSurfaceModuleSyncCore<Pick<PublicApi, "read">>({
+          dirName,
+          artifactBasename: "api.js",
+        });
+      expect(load().read()).toBe("winner");
+
+      winner.registry.plugins.push(
+        createPluginRecord({
+          ...winner.record,
+          rootDir: path.join(parent, "duplicate", path.basename(winner.record.rootDir!)),
+        }),
+      );
+      expect(load).toThrow(/ambiguous runtime ownership/);
+    },
+  );
+
   it.each(["global", "bundled"] as const)(
     "resolves native filesystem dist APIs without losing their managed owner (%s)",
     (origin) => {


### PR DESCRIPTION
## What Problem This Solves

Runtime facade lookup constructs every ID, folder, and channel candidate list on each provider-policy request, even when an exact loaded plugin ID already determines the owner. This repeats temporary allocations and lower-priority matching work on the live request path.

## Why This Change Was Made

Scan the current runtime records in priority order and stop after checking the winning group for ambiguity. The executing registry remains authoritative, including when its selected owner lacks the requested public surface. Custom environments, loaded-state checks, artifact resolution, and facade cache ownership retain their existing behavior.

## User Impact

Repeated plugin policy lookups allocate less temporary data while resolving the same managed plugin instance. No public API, configuration, persistence, import topology, or lifecycle changes are introduced.

## Evidence

- All 89 tests pass across facade loading, facade runtime, public-surface loading, and managed plugin generations. Three added public-loader cases verify ID/folder/channel precedence and ambiguity using generated tiny plugin APIs; all three also pass on the original production code.
- A workload through resolveDirectBundledProviderPolicySurface with an actual captured plugin module, 100 runtime records, and 10,000 validated policy lookups reduced sampled allocations from 382,246,096 to 320,282,496 bytes (16.2%). Allocations beneath resolveRuntimeFacadeModuleLocation fell from 214,633,688 to 158,595,072 bytes (26.1%). This measures temporary allocation in the loaded-plugin policy path, not a retained-memory leak or full Gateway improvement.
- Independent P0-P2 review found no actionable findings. Formatting and git diff checks pass. Full changed checks have not run locally under the campaign's restriction on aggregate checks after shared WSL failures; exact-head hosted CI subsequently completed the remaining required proof.



Exact-head hosted CI is green: https://github.com/openclaw/openclaw/actions/runs/34702033366. The initial small-16 job timed out after 60 seconds in the unchanged rejected-update process test. That test passed on the unchanged baseline in 539 ms and in the single diagnostic rerun in 1080 ms; all 275 tests in the rerun passed. No timeout, expectation, or source workaround was added. Initial failure evidence is retained. ClawSweeper's exact-head review found no actionable defects.


