### PR TITLE
fix(gateway): keep chat request bursts responsive under load

### DIFF
--- a/docs/gateway/protocol/transport.md
+++ b/docs/gateway/protocol/transport.md
@@ -43,13 +43,11 @@ that supervise the Gateway as a child process, see
   the gateway closes or drops the frame. These events carry `surface`, byte
   sizes, limits, and a safe reason code, never message bodies, attachment
   contents, raw frame bytes, tokens, cookies, or secrets.
-- The Gateway offers `permessage-deflate`. Peers that negotiate it (browsers, `ws`
-  clients) receive frames of 32 KiB and up compressed. Smaller session/tool updates
-  and ordinary agent results stay raw so serial compression callbacks do not delay
-  queued RPC replies. Large histories and rosters still compress. Context takeover
-  is disabled in both directions, so
-  each frame compresses independently. Peers that do not offer the extension are
-  unaffected. Payload limits apply to the inflated size.
+- The Gateway does not negotiate `permessage-deflate`. Browsers can compress
+  even tiny requests when the extension is enabled; serial decompression then
+  delays each request behind busy event-loop turns before handler scheduling.
+  Uncompressed frames preserve responsive request bursts at the cost of more
+  bandwidth for large histories and rosters. Payload limits are unchanged.
 
 Frame shapes:
 

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -710,6 +710,10 @@ vi.mock("../commands/triage.js", () => ({ triageCommand }));
 vi.mock("../commands/triage-failure.js", () => ({ triageAfterFailure }));
 vi.mock("./update-cli/update-command-report.js", () => updateFailureActionMocks);
 
+const { prepareSqliteReadOnlyLocationSyncInProcess } =
+  await import("../infra/sqlite-readonly-location.js");
+const sqliteReadOnlyWorker = await import("../infra/sqlite-readonly-worker.js");
+const runHostReadOnlyWorker = sqliteReadOnlyWorker.runSqliteReadOnlyWorkerSync;
 const { runGatewayUpdate } = await import("../infra/update-runner.js");
 const { createUpdateRun, getUpdateRun, listUpdateRuns } =
   await import("../infra/update-run-ledger.js");
@@ -811,6 +815,7 @@ describe("update-cli", () => {
   let tempHome: TempHomeEnv | undefined;
   const tempDirs = useAutoCleanupTempDirTracker(afterEach);
   const tempDirsToCleanup = new Set<string>();
+  const fixtureStateDatabases = new Set<string>();
 
   const createCaseDir = (prefix: string) => {
     const dir = path.join(fixtureRoot, `${prefix}-${fixtureCount++}`);
@@ -820,7 +825,8 @@ describe("update-cli", () => {
 
   // Ordinary update cases model the existing schema advertised by their inspection fixture.
   const initializeExistingUpdateProfile = (env: NodeJS.ProcessEnv = process.env) => {
-    openOpenClawStateDatabase({ env });
+    const database = openOpenClawStateDatabase({ env });
+    fixtureStateDatabases.add(database.path);
     closeOpenClawStateDatabaseForTest();
   };
 
@@ -2026,6 +2032,7 @@ describe("update-cli", () => {
   };
 
   beforeEach(async () => {
+    fixtureStateDatabases.clear();
     // Clear the helper's state selector below so HOME and profile overrides keep their semantics.
     const { createTempHomeEnv } = await import("../test-utils/temp-home.js");
     tempHome = await createTempHomeEnv("openclaw-update-cli-home-");
@@ -2051,6 +2058,14 @@ describe("update-cli", () => {
     }
     restartHealthTestControl.snapshot = undefined;
     vi.resetAllMocks();
+    // These fixture-owned databases have no competing writer. Keep real snapshot
+    // staging/adoption; cold ledger and WAL-lock tests own the process boundary.
+    vi.spyOn(sqliteReadOnlyWorker, "runSqliteReadOnlyWorkerSync").mockImplementation(
+      (pathname, stagingRoot) =>
+        fixtureStateDatabases.has(path.resolve(pathname))
+          ? prepareSqliteReadOnlyLocationSyncInProcess(pathname, stagingRoot).location
+          : runHostReadOnlyWorker(pathname, stagingRoot),
+    );
     // Service simulations do not provide foreign-platform ACL libraries. Keep
     // real exclusive host creation; actual Windows runs retain the native DACL path.
     if (sqliteHostPlatform !== "win32") {

--- a/src/gateway/server-broadcast.transport.test.ts
+++ b/src/gateway/server-broadcast.transport.test.ts
@@ -1,10 +1,7 @@
-import { getEventListeners, once } from "node:events";
-import type { AddressInfo } from "node:net";
-import { rawDataToString } from "@openclaw/gateway-client/websocket-data";
+import { getEventListeners } from "node:events";
 import { describe, expect, it, vi } from "vitest";
-import { WebSocket, WebSocketServer } from "ws";
+import { WebSocket } from "ws";
 import { createGatewayBroadcaster } from "./server-broadcast.js";
-import { WS_COMPRESSION_THRESHOLD_BYTES } from "./server-constants.js";
 import { GatewayClientRegistry } from "./server/client-registry.js";
 import type { GatewayWsClient } from "./server/ws-types.js";
 import { TerminalOutputController } from "./terminal/output-flow-control.js";
@@ -58,75 +55,6 @@ const liveText = (group: AbortSignal) => ({
 });
 
 describe("broadcast transport retirement", () => {
-  it("settles a compressed queue failure once while healthy peers keep ordered delivery", async () => {
-    const server = new WebSocketServer({
-      host: "127.0.0.1",
-      port: 0,
-      perMessageDeflate: {
-        serverNoContextTakeover: true,
-        clientNoContextTakeover: true,
-        threshold: WS_COMPRESSION_THRESHOLD_BYTES,
-      },
-    });
-    await once(server, "listening");
-    const peers: WebSocket[] = [];
-    try {
-      const connect = async () => {
-        const accepted = once(server, "connection");
-        const peer = new WebSocket(`ws://127.0.0.1:${(server.address() as AddressInfo).port}`);
-        peers.push(peer);
-        await once(peer, "open");
-        const [socket] = (await accepted) as [WebSocket];
-        expect(socket.extensions).toBe("permessage-deflate");
-        return { peer, socket };
-      };
-      const broken = await connect();
-      const healthy = await connect();
-      const clients = new GatewayClientRegistry([
-        clientFor("compressed-broken", broken.socket),
-        clientFor("compressed-healthy", healthy.socket),
-      ]);
-      const { broadcast, getBufferedAmount } = createGatewayBroadcaster({ clients });
-      const received: Array<{ seq: number; payload: { index: number } }> = [];
-      healthy.peer.on("message", (data) => received.push(JSON.parse(rawDataToString(data))));
-      const owner = new AbortController();
-      sendError.mockClear();
-      const terminate = vi.spyOn(broken.socket, "terminate");
-      const payload = "x".repeat(WS_COMPRESSION_THRESHOLD_BYTES * 2);
-      for (let index = 0; index < 165; index += 1) {
-        broadcast("skills.changed", { index, payload });
-      }
-      broadcast("chat", { text: "pending" }, { liveText: liveText(owner.signal) });
-      expect(getEventListeners(owner.signal, "abort")).toHaveLength(2);
-      const closed = once(broken.peer, "close");
-      broken.socket.terminate();
-      await closed;
-      await vi.waitFor(() => expect(received).toHaveLength(166));
-      expect(received.map(({ seq }) => seq)).toEqual(
-        Array.from({ length: 166 }, (_, index) => index + 1),
-      );
-      expect(received.slice(0, 165).map(({ payload: value }) => value.index)).toEqual(
-        Array.from({ length: 165 }, (_, index) => index),
-      );
-      expect(sendError).toHaveBeenCalledExactlyOnceWith(
-        expect.stringContaining("The socket was closed while data was being compressed"),
-        { event: "skills.changed" },
-      );
-      expect(terminate).toHaveBeenCalledTimes(2); // External close and one delivery retirement.
-      expect(getEventListeners(owner.signal, "abort")).toHaveLength(0);
-      expect(broken.socket.bufferedAmount).toBeGreaterThan(0);
-      expect(getBufferedAmount("compressed-broken")).toBeUndefined();
-    } finally {
-      peers.forEach((peer) => peer.terminate());
-      for (const socket of server.clients) {
-        socket.terminate();
-      }
-      await new Promise<void>((resolve, reject) => {
-        server.close((error) => (error ? reject(error) : resolve()));
-      });
-    }
-  });
-
   it("keeps failed delivery terminal through late callbacks and permits a replacement socket", () => {
     const retired = controlledPeer("replacement");
     const replacement = controlledPeer("replacement");

--- a/src/gateway/server-constants.ts
+++ b/src/gateway/server-constants.ts
@@ -3,10 +3,6 @@
 export const MAX_PAYLOAD_BYTES = 25 * 1024 * 1024;
 export const MAX_BUFFERED_BYTES = 50 * 1024 * 1024; // per-connection send buffer limit (2x max payload)
 export const MAX_PREAUTH_PAYLOAD_BYTES = 64 * 1024;
-// Keep session/tool events and ordinary agent completions out of serial zlib
-// queues. Large transcript and roster responses still compress to keep cold
-// chat loads efficient.
-export const WS_COMPRESSION_THRESHOLD_BYTES = 32 * 1024;
 export const WEBSOCKET_OPEN_READY_STATE = 1;
 export const WEBSOCKET_CLOSE_GRACE_MS = 1_000;
 

--- a/src/gateway/server-runtime-state.ts
+++ b/src/gateway/server-runtime-state.ts
@@ -29,7 +29,7 @@ import {
 import { createSandboxHostHttpServer } from "./mcp-app-sandbox-http.js";
 import { isLoopbackHost, resolveGatewayListenHosts } from "./net.js";
 import { createGatewayPortalService, type GatewayPortalService } from "./portals/portal-service.js";
-import { MAX_PREAUTH_PAYLOAD_BYTES, WS_COMPRESSION_THRESHOLD_BYTES } from "./server-constants.js";
+import { MAX_PREAUTH_PAYLOAD_BYTES } from "./server-constants.js";
 import { attachGatewayUpgradeHandler, createGatewayHttpServer } from "./server-http.js";
 import type { GatewayRequestContext } from "./server-methods/types.js";
 import type { HookClientIpConfig, HooksRequestHandler } from "./server/hooks-request-handler.js";
@@ -307,16 +307,10 @@ export async function createGatewayHttpTransport(params: {
     // Yield between buffered frames so one RPC burst cannot monopolize the
     // event loop before other connections and HTTP probes can run.
     allowSynchronousEvents: false,
-    // Peers that offer permessage-deflate (browsers, ws clients) get large frames
-    // compressed. No context takeover keeps zlib memory per connection at one reset
-    // stream instead of a retained sliding window, and the threshold keeps small
-    // frames raw. The extension inherits maxPayload for inflated frames, so the
-    // post-auth receiver handoff must raise it too (prepareGatewayReceiverHandoff).
-    perMessageDeflate: {
-      serverNoContextTakeover: true,
-      clientNoContextTakeover: true,
-      threshold: WS_COMPRESSION_THRESHOLD_BYTES,
-    },
+    // Browsers compress even tiny requests when this extension is negotiated.
+    // Serial inflate callbacks delay each frame behind busy event-loop turns,
+    // before the bounded request-start scheduler can admit the burst.
+    perMessageDeflate: false,
   });
   const preauthConnectionBudget = createPreauthConnectionBudget();
 

--- a/src/gateway/server.public-worker-ingress.test.ts
+++ b/src/gateway/server.public-worker-ingress.test.ts
@@ -1,7 +1,6 @@
 import http from "node:http";
 import type { AddressInfo } from "node:net";
 import { rawDataToString } from "@openclaw/gateway-client/websocket-data";
-import { expectDefined } from "@openclaw/normalization-core";
 import { describe, expect, it, vi } from "vitest";
 import { WebSocket, WebSocketServer } from "ws";
 import {
@@ -50,7 +49,6 @@ const RESOLVED_AUTH: ResolvedGatewayAuth = { mode: "none", allowTailscale: false
 
 type PayloadLimited = {
   _maxPayload: number;
-  _extensions: Record<string, PayloadLimited>;
 };
 
 type RejectedWorker = {
@@ -158,16 +156,10 @@ class PublicWorkerHarness {
   readonly workerService: WorkerConnectionService;
   readonly clients = new Set<GatewayWsClient>();
   readonly connectionWork = new GatewayConnectionWork();
-  // Mirrors the production server options so a client that offers
-  // permessage-deflate negotiates it here too (server-runtime-state.ts).
   readonly wss = new WebSocketServer({
     noServer: true,
     maxPayload: 64 * 1024,
-    perMessageDeflate: {
-      serverNoContextTakeover: true,
-      clientNoContextTakeover: true,
-      threshold: 4 * 1024,
-    },
+    perMessageDeflate: false,
   });
   readonly preauthBudget: ReturnType<typeof createPreauthConnectionBudget>;
   readonly publicRateLimiter: ReturnType<typeof createAuthRateLimiter>;
@@ -335,50 +327,39 @@ describe("public worker ingress", () => {
     });
   });
 
-  it.each([
-    ["receiver", (receiver: PayloadLimited) => receiver],
-    [
-      "negotiated deflate",
-      (receiver: PayloadLimited) =>
-        expectDefined(receiver["_extensions"]["permessage-deflate"], "negotiated deflate"),
-    ],
-  ])(
-    "rejects an admitted worker before hello when the %s payload limit is unusable",
-    async (_label, selectLimit) => {
-      await withHarness({}, async (harness) => {
-        // The Gateway's own connection listener runs first; freezing the limit
-        // afterwards still precedes the connect frame that admits the worker.
-        harness.wss.on("connection", (socket) => {
-          const receiver = (socket as WebSocket & { _receiver: PayloadLimited })["_receiver"];
-          const limit = selectLimit(receiver);
-          Object.defineProperty(limit, "_maxPayload", {
-            value: limit["_maxPayload"],
-            writable: false,
-          });
+  it("rejects an admitted worker before hello when the receiver payload limit is unusable", async () => {
+    await withHarness({}, async (harness) => {
+      // The Gateway's own connection listener runs first; freezing the limit
+      // afterwards still precedes the connect frame that admits the worker.
+      harness.wss.on("connection", (socket) => {
+        const receiver = (socket as WebSocket & { _receiver: PayloadLimited })["_receiver"];
+        Object.defineProperty(receiver, "_maxPayload", {
+          value: receiver["_maxPayload"],
+          writable: false,
         });
-
-        const rejected = await rejectWorker(harness.url(), workerConnect(harness.credential));
-
-        expect(rejected).toEqual({
-          response: {
-            type: "res",
-            id: "connect-1",
-            ok: false,
-            error: {
-              code: "UNAVAILABLE",
-              message: "unsupported Gateway WebSocket receiver",
-              details: { reason: "gateway-unavailable" },
-            },
-          },
-          close: { code: 1011, reason: "gateway-unavailable" },
-        });
-        expect(harness.logWsControl.warn).toHaveBeenCalledWith(
-          "worker admission rejected reason=unsupported-websocket-receiver",
-        );
-        expect(harness.clients.size).toBe(0);
       });
-    },
-  );
+
+      const rejected = await rejectWorker(harness.url(), workerConnect(harness.credential));
+
+      expect(rejected).toEqual({
+        response: {
+          type: "res",
+          id: "connect-1",
+          ok: false,
+          error: {
+            code: "UNAVAILABLE",
+            message: "unsupported Gateway WebSocket receiver",
+            details: { reason: "gateway-unavailable" },
+          },
+        },
+        close: { code: 1011, reason: "gateway-unavailable" },
+      });
+      expect(harness.logWsControl.warn).toHaveBeenCalledWith(
+        "worker admission rejected reason=unsupported-websocket-receiver",
+      );
+      expect(harness.clients.size).toBe(0);
+    });
+  });
 
   it("returns one opaque failure while retaining precise server reasons", async () => {
     await withHarness({}, async (harness) => {

--- a/src/gateway/server/ws-connection/request-start.server.test.ts
+++ b/src/gateway/server/ws-connection/request-start.server.test.ts
@@ -1,6 +1,7 @@
 import { on, once } from "node:events";
 import type { IncomingMessage } from "node:http";
 import { performance } from "node:perf_hooks";
+import { constants as zlibConstants, deflateRawSync } from "node:zlib";
 import { rawDataToString } from "@openclaw/gateway-client/websocket-data";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { WebSocket, WebSocketServer } from "ws";
@@ -75,8 +76,10 @@ function captureGatewayConnection(port: number) {
   };
 }
 
-function maskedFrame(opcode: 0x81 | 0x88 | 0x89 | 0x8a, text: string): Buffer {
-  const payload = Buffer.from(text);
+function maskedFrame(opcode: 0x81 | 0x88 | 0x89 | 0x8a, text: string, compressed = false): Buffer {
+  const payload = compressed
+    ? deflateRawSync(Buffer.from(text), { finishFlush: zlibConstants.Z_SYNC_FLUSH }).subarray(0, -4)
+    : Buffer.from(text);
   if (payload.length >= 126) {
     throw new Error("fixture requires a short masked WebSocket frame");
   }
@@ -84,7 +87,11 @@ function maskedFrame(opcode: 0x81 | 0x88 | 0x89 | 0x8a, text: string): Buffer {
   for (let index = 0; index < payload.length; index++) {
     payload[index] = payload[index]! ^ mask[index % mask.length]!;
   }
-  return Buffer.concat([Buffer.from([opcode, 0x80 | payload.length]), mask, payload]);
+  return Buffer.concat([
+    Buffer.from([opcode | (compressed ? 0x40 : 0), 0x80 | payload.length]),
+    mask,
+    payload,
+  ]);
 }
 
 function injectReceiveChunk(stream: IncomingMessage["socket"], frames: Buffer[]) {
@@ -140,6 +147,7 @@ describe("authenticated operator request starts", () => {
       ws = await openOperatorSocket(port, token);
       await expect(sendTraceRequest(ws, "warmup")).resolves.toMatchObject({ ok: true });
       const { stream } = capture.get();
+      const compressedRequests = ws.extensions.includes("permessage-deflate");
       // This case isolates cheap-start batching. Other owner cases advance the
       // work clock to prove the elapsed-work fairness boundary independently.
       const now = performance.now();
@@ -170,6 +178,9 @@ describe("authenticated operator request starts", () => {
               method: "test.trace",
               params: {},
             }),
+            // Chrome compresses small requests whenever the extension is negotiated;
+            // the server's outbound threshold cannot keep these frames raw.
+            compressedRequests,
           ),
         ),
       );
@@ -384,16 +395,13 @@ describe("authenticated operator request starts", () => {
     },
   );
 
-  it("keeps small frames raw, compresses large frames, and accepts compressed post-auth frames above the preauth cap", async () => {
-    // Regression: the deflate extension keeps its own copy of the preauth maxPayload,
-    // so without the extension-aware handoff an authenticated compressed request above
-    // 64 KiB closed the socket with 1009 even though the receiver limit was raised.
+  it("accepts large post-auth frames without negotiating compression", async () => {
     const registry = createEmptyPluginRegistry();
     registry.gatewayHandlers["test.echo"] = async ({ req, respond }) => {
       respond(true, { echoed: (req.params as { text: string }).text });
     };
     setTestPluginRegistry(registry);
-    const token = "gateway-compression-test-token";
+    const token = "gateway-frame-limit-test-token";
     const port = await getGatewayTestPort();
     const capture = captureGatewayConnection(port);
     let server: Awaited<ReturnType<typeof startTestGatewayServer>> | undefined;
@@ -405,7 +413,7 @@ describe("authenticated operator request starts", () => {
         controlUiEnabled: false,
       });
       ws = await openOperatorSocket(port, token);
-      expect(ws.extensions).toContain("permessage-deflate");
+      expect(ws.extensions).toBe("");
       const { stream } = capture.get();
       // Cover both live session/tool events and ordinary final agent results.
       for (const sizeKiB of [6, 20]) {
@@ -437,7 +445,7 @@ describe("authenticated operator request starts", () => {
       const beforeBig = stream.bytesWritten;
       ws.send(JSON.stringify({ type: "req", id: "big", method: "test.echo", params: { text } }));
       await expect(response).resolves.toMatchObject({ ok: true, payload: { echoed: text } });
-      expect(stream.bytesWritten - beforeBig).toBeLessThan(text.length / 4);
+      expect(stream.bytesWritten - beforeBig).toBeGreaterThan(text.length);
     } finally {
       ws?.terminate();
       try {

--- a/src/gateway/server/ws-connection/request-start.test.ts
+++ b/src/gateway/server/ws-connection/request-start.test.ts
@@ -116,63 +116,46 @@ describe("Gateway request start fairness", () => {
   });
 });
 
-function receiverSocket(params: { deflate?: { _maxPayload: number } | "readonly" }): WebSocket {
-  const deflate =
-    params.deflate === "readonly"
-      ? Object.defineProperty({}, "_maxPayload", { value: MAX_PREAUTH_PAYLOAD_BYTES })
-      : params.deflate;
+function receiverSocket(readonly = false): WebSocket {
   return {
-    _receiver: {
-      _maxPayload: MAX_PREAUTH_PAYLOAD_BYTES,
-      _allowSynchronousEvents: false,
-      ...(deflate ? { _extensions: { "permessage-deflate": deflate } } : {}),
-    },
+    _receiver: Object.defineProperty({ _allowSynchronousEvents: false }, "_maxPayload", {
+      value: MAX_PREAUTH_PAYLOAD_BYTES,
+      writable: !readonly,
+    }),
   } as unknown as WebSocket;
 }
 
-function payloadLimits(socket: WebSocket): { receiver: number; deflate: number | undefined } {
+function payloadLimit(socket: WebSocket): number {
   const receiver = (
     socket as unknown as {
       _receiver: {
         _maxPayload: number;
-        _extensions?: { "permessage-deflate"?: { _maxPayload: number } };
       };
     }
   )["_receiver"];
-  return {
-    receiver: receiver["_maxPayload"],
-    deflate: receiver["_extensions"]?.["permessage-deflate"]?.["_maxPayload"],
-  };
+  return receiver["_maxPayload"];
 }
 
 describe("authenticated receiver payload limits", () => {
-  it("raises the receiver and the negotiated deflate extension together after connect", () => {
-    const socket = receiverSocket({ deflate: { _maxPayload: MAX_PREAUTH_PAYLOAD_BYTES } });
+  it("raises the receiver limit only after connect", () => {
+    const socket = receiverSocket();
     const handoff = prepareGatewayReceiverHandoff(socket, "operator");
     expect(handoff).not.toBeNull();
-    expect(payloadLimits(socket)).toEqual({
-      receiver: MAX_PREAUTH_PAYLOAD_BYTES,
-      deflate: MAX_PREAUTH_PAYLOAD_BYTES,
-    });
+    expect(payloadLimit(socket)).toBe(MAX_PREAUTH_PAYLOAD_BYTES);
     handoff?.();
-    expect(payloadLimits(socket)).toEqual({
-      receiver: MAX_PAYLOAD_BYTES,
-      deflate: MAX_PAYLOAD_BYTES,
-    });
+    expect(payloadLimit(socket)).toBe(MAX_PAYLOAD_BYTES);
   });
 
-  it("keeps working for peers that did not negotiate compression", () => {
-    const socket = receiverSocket({});
+  it("raises an admitted worker receiver limit", () => {
+    const socket = receiverSocket();
     expect(raiseGatewayReceiverPayloadLimit(socket, 1_024)).toBe(true);
-    expect(payloadLimits(socket)).toEqual({ receiver: 1_024, deflate: undefined });
+    expect(payloadLimit(socket)).toBe(1_024);
   });
 
-  it("refuses the handoff when the deflate limit cannot be raised", () => {
-    // A non-writable extension limit would silently keep the preauth cap on
-    // compressed frames, so the handshake must fail visibly instead.
-    const socket = receiverSocket({ deflate: "readonly" });
+  it("refuses the handoff when the receiver limit cannot be raised", () => {
+    const socket = receiverSocket(true);
     expect(prepareGatewayReceiverHandoff(socket, "operator")).toBeNull();
     expect(raiseGatewayReceiverPayloadLimit(socket, 1_024)).toBe(false);
-    expect(payloadLimits(socket).receiver).toBe(MAX_PREAUTH_PAYLOAD_BYTES);
+    expect(payloadLimit(socket)).toBe(MAX_PREAUTH_PAYLOAD_BYTES);
   });
 });

--- a/src/gateway/server/ws-connection/request-start.ts
+++ b/src/gateway/server/ws-connection/request-start.ts
@@ -9,9 +9,7 @@ import { MAX_PAYLOAD_BYTES } from "../../server-constants.js";
 type PayloadLimited = { _maxPayload?: number };
 type GatewayReceiver = PayloadLimited & {
   _allowSynchronousEvents?: boolean;
-  _extensions?: Record<string, PayloadLimited | undefined>;
 };
-const PERMESSAGE_DEFLATE_EXTENSION = "permessage-deflate";
 
 function hasWritablePayloadLimit(target: PayloadLimited | undefined): target is PayloadLimited {
   return (
@@ -20,36 +18,22 @@ function hasWritablePayloadLimit(target: PayloadLimited | undefined): target is 
   );
 }
 
-/**
- * Resolves the ws receiver and every payload limit an authenticated frame passes through.
- * A negotiated permessage-deflate extension checks inflated size against its own copy of
- * the server maxPayload, so raising only the receiver would still reject compressed
- * post-auth frames above the preauth cap. Null when any limit is not writable.
- */
-function gatewayReceiverPayloadLimits(
-  socket: WebSocket,
-): { receiver: GatewayReceiver; limits: PayloadLimited[] } | null {
+function gatewayReceiver(socket: WebSocket): GatewayReceiver | null {
   // SAFETY: ws owns these private per-frame fields; validate each before the handoff.
   const receiver = (socket as WebSocket & { _receiver?: GatewayReceiver })["_receiver"];
   if (!hasWritablePayloadLimit(receiver)) {
     return null;
   }
-  const deflate = receiver["_extensions"]?.[PERMESSAGE_DEFLATE_EXTENSION];
-  if (deflate === undefined) {
-    return { receiver, limits: [receiver] };
-  }
-  return hasWritablePayloadLimit(deflate) ? { receiver, limits: [receiver, deflate] } : null;
+  return receiver;
 }
 
-/** Raises the authenticated frame limit on the receiver and its deflate extension together. */
+/** Raises the authenticated frame limit after the connection is admitted. */
 export function raiseGatewayReceiverPayloadLimit(socket: WebSocket, maxPayload: number): boolean {
-  const resolved = gatewayReceiverPayloadLimits(socket);
-  if (!resolved) {
+  const receiver = gatewayReceiver(socket);
+  if (!receiver) {
     return false;
   }
-  for (const limit of resolved.limits) {
-    limit["_maxPayload"] = maxPayload;
-  }
+  receiver["_maxPayload"] = maxPayload;
   return true;
 }
 
@@ -57,11 +41,10 @@ export function prepareGatewayReceiverHandoff(
   socket: WebSocket,
   role: GatewayRole,
 ): (() => void) | null {
-  const resolved = gatewayReceiverPayloadLimits(socket);
-  if (!resolved) {
+  const receiver = gatewayReceiver(socket);
+  if (!receiver) {
     return null;
   }
-  const { receiver, limits } = resolved;
   if (
     role === "operator" &&
     (typeof receiver["_allowSynchronousEvents"] !== "boolean" ||
@@ -70,9 +53,7 @@ export function prepareGatewayReceiverHandoff(
     return null;
   }
   return () => {
-    for (const limit of limits) {
-      limit["_maxPayload"] = MAX_PAYLOAD_BYTES;
-    }
+    receiver["_maxPayload"] = MAX_PAYLOAD_BYTES;
     if (role === "operator") {
       receiver["_allowSynchronousEvents"] = true;
     }

--- a/test/vitest/vitest.cli-process-paths.mjs
+++ b/test/vitest/vitest.cli-process-paths.mjs
@@ -17,6 +17,7 @@ export const cliProcessTestFiles = [
   "src/cli/gateway-cli/run-loop.restart-liveness.process.test.ts",
   "src/cli/update-dry-run-state.process.test.ts",
   "src/cli/doctor-output.process.test.ts",
+  "src/cli/update-cli/update-command-executor-native.test.ts",
   "src/cli/update-cli/update-command-handoff.test.ts",
   "src/cli/update-cli/update-command-lease.test.ts",
   "src/cli/update-cli/update-command-migrated.test.ts",


### PR DESCRIPTION
Related: #136862

## What Problem This Solves

Fixes an issue where opening a chat on a busy Gateway could take more than 30 seconds even though its session lookup and history handlers each needed less than 200 ms. Small requests sent together reached the handlers seconds apart.

## Why This Change Was Made

Disable optional WebSocket compression. Browsers compress even tiny requests when `permessage-deflate` is negotiated, and `ws` serially awaits asynchronous inflate callbacks before delivering each frame. Event-loop load multiplies that delay across the startup burst; the server's outbound compression threshold cannot prevent it. Uncompressed frames reach the existing bounded, fair request scheduler together.

Remove the retired compression threshold and deflate-specific payload handoff. Preserve authenticated receiver limits, worker admission, and pre-auth/node control-frame yielding. Update the transport documentation.

CI follow-through also removes repeated snapshot-worker startup from the isolated updater test fixture. Only its explicitly initialized scratch databases use the real in-process snapshot primitive; other sources still use the actual worker. The native executor fixture moves to the existing serial process lane.

## User Impact

Chat startup and other request bursts remain responsive under server load. Large histories and rosters use more bandwidth because frames are uncompressed. Clients already support the server declining this optional extension; no protocol version or configuration change is needed.

## Evidence

- Actual Chrome, ten tiny requests, synthetic 100 ms work per event-loop turn: compressed replies arrived at 401–3,104 ms; uncompressed replies all arrived at 106–118 ms. Verified Chrome set the compression bit on these small requests.
- Independent 20-request `ws` reproduction: compressed 300–6,008 ms versus all uncompressed replies at 100 ms.
- Live correlation: four requests sent together reached dispatch 1.65 s, 0.53 s, and 0.41 s apart, then completed in 98–110 ms each. This locates the delay before handler scheduling.
- Extended the real Gateway burst regression to send compressed frames when negotiated, matching Chrome. It fails before the fix because only the first of 33 requests starts before the next immediate; all 33 start after the fix.
- 28 focused tests passed across request scheduling, large post-auth frame roundtrips, control/close frames, public worker ingress, and broadcast failure/backpressure recovery.
- Independent review through P2: no actionable findings.

- CI diagnosis: the original CLI lane spent 813.57 s running tests; its 493-case updater file accounted for 803.93 s. The same four heavy cases improved from 17.495 s to 4.457 s of test work with the fixture change (74.5%). Normal-wrapper wall time improved from 30.86 s to 23.50 s.
- The full 493-case updater file passed after the repair, as did 216 tests across native executor, real worker snapshots, ledger cold reads, source/exclusion, and configuration ownership. The native executor’s nine cases run in the serial process lane; the formerly failing healthy-upgrade case passed in 2.191 s. One Linux-only POSIX-lock case remains covered by Linux CI.
- The first CI attempt failed one existing native-executor readiness assertion; a diagnostic rerun made steady progress but its hosted fallback amplified the slow fixture cost. No test assertions or timeouts were relaxed.
