### PR TITLE
test(ai): preserve provider contracts under Bun

### DIFF
--- a/packages/ai/src/providers/mistral.bounded-stream.test.ts
+++ b/packages/ai/src/providers/mistral.bounded-stream.test.ts
@@ -243,7 +243,6 @@ async function streamMistralTerminalFixture(fixture: MistralTerminalFixture) {
       })}\n\n`,
     );
     if (fixture.abort) {
-      request.once("close", () => response.end());
       return;
     }
     response.end(fixture.done ? "data: [DONE]\n\n" : "");
@@ -283,6 +282,7 @@ async function streamMistralTerminalFixture(fixture: MistralTerminalFixture) {
     }
     return { result: await stream.result(), events };
   } finally {
+    server.closeAllConnections();
     await new Promise<void>((resolve, reject) => {
       server.close((error) => (error ? reject(error) : resolve()));
     });

--- a/packages/ai/src/providers/openai-chatgpt-responses.cache.test.ts
+++ b/packages/ai/src/providers/openai-chatgpt-responses.cache.test.ts
@@ -700,7 +700,11 @@ describe("ChatGPT Responses cached transport", () => {
         diagnostics: [
           {
             type: "provider_transport_failure",
-            error: { message: "Unexpected server response: 426" },
+            error: {
+              message: expect.stringMatching(
+                /(?:Unexpected server response: 426|Expected 101 status code)/u,
+              ),
+            },
             details: {
               configuredTransport: "auto",
               fallbackTransport: "sse",

--- a/packages/ai/src/providers/openai-chatgpt-responses.websocket-errors.test.ts
+++ b/packages/ai/src/providers/openai-chatgpt-responses.websocket-errors.test.ts
@@ -41,7 +41,7 @@ describe("ChatGPT Responses WebSocket failures", () => {
     vi.unstubAllGlobals();
   });
 
-  it("classifies an abrupt Node WebSocket disconnect as transient", async () => {
+  it("classifies an abrupt WebSocket disconnect as transient", async () => {
     const server = new WebSocketServer({ host: "127.0.0.1", port: 0 });
     server.once("connection", (socket) => {
       socket.once("message", () => socket.terminate());
@@ -58,7 +58,7 @@ describe("ChatGPT Responses WebSocket failures", () => {
 
       expect(result).toMatchObject({
         stopReason: "error",
-        errorMessage: "WebSocket error",
+        errorMessage: expect.stringMatching(/^WebSocket (?:error|closed 1006(?: .*)?)$/u),
         errorCode: "ERR_WEBSOCKET_TRANSPORT",
       });
       expect(result.diagnostics).toEqual([

--- a/packages/ai/src/transports/anthropic-transport-stream.test.ts
+++ b/packages/ai/src/transports/anthropic-transport-stream.test.ts
@@ -1127,7 +1127,7 @@ describe("anthropic transport stream", () => {
     });
     expect(acceptanceObserver).not.toHaveBeenCalled();
     expect(onResponse).toHaveBeenCalledWith(
-      { status: 429, headers: { "content-type": "text/plain;charset=UTF-8", "retry-after": "30" } },
+      { status: 429, headers: expect.objectContaining({ "retry-after": "30" }) },
       expect.objectContaining({ provider: "anthropic" }),
     );
   });


### PR DESCRIPTION
## Problem

Direct Bun execution exposed four Node-specific assumptions in AI provider tests even though the underlying provider behavior was correct: exact WebSocket error text, Fetch's implicit `content-type`, and a loopback Mistral fixture that ended its SSE response on a request lifecycle event before cancellation could win.

## Solution

Keep the provider contracts strict while making their proof runtime-neutral:

- Require the WebSocket failure class, transport code, retry classification, fallback scope, and rejected-upgrade evidence without pinning one runtime's exact error sentence.
- Keep Anthropic status and Retry-After callback evidence without requiring an implementation-added content type.
- Hold the Mistral SSE fixture open until client cancellation, then close remaining server connections during fixture cleanup.

No production AI transport code changes.

## Evidence

- Direct custom-Bun unit-support aggregate: 253 files passed; 4,606 tests passed, 1 platform skip, 0 failed.
- Former failure set: 180 passed under Bun and 180 passed under Node.
- `pnpm check:changed` passed, including package typechecking, formatting, lint, API guards, and dead-export scans.
- Independent P0-P2 review completed with no actionable findings.

## Release-note context

Test-only compatibility coverage; no user-visible behavior change.
