### PR TITLE
refactor: remove ClickClack test runtime wrapper

### DIFF
--- a/extensions/clickclack/src/setup-verify.test.ts
+++ b/extensions/clickclack/src/setup-verify.test.ts
@@ -1,4 +1,3 @@
-// ClickClack tests cover post-write connection verification and gateway guidance.
 import { createNonExitingRuntimeEnv } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -42,14 +41,10 @@ const configuredAccount = {
   },
 } satisfies CoreConfig;
 
-function createRuntime() {
-  return createNonExitingRuntimeEnv();
-}
-
 async function verify(
   cfg: CoreConfig = configuredAccount,
-  runtime = createRuntime(),
-): Promise<ReturnType<typeof createRuntime>> {
+  runtime = createNonExitingRuntimeEnv(),
+): Promise<ReturnType<typeof createNonExitingRuntimeEnv>> {
   await verifyClickClackAccountAfterSetup({
     cfg,
     accountId: "default",
@@ -114,7 +109,7 @@ describe("ClickClack post-write setup verification", () => {
     },
   ])("logs a warning for $name and continues", async ({ arrange, expected }) => {
     arrange();
-    const runtime = createRuntime();
+    const runtime = createNonExitingRuntimeEnv();
 
     await expect(verify(configuredAccount, runtime)).resolves.toBe(runtime);
     expect(runtime.log).toHaveBeenNthCalledWith(1, expected);


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

ClickClack setup verification tests add a local runtime wrapper that contributes no setup behavior and makes the fixture harder to follow.

## Why This Change Was Made

Call the already-imported `createNonExitingRuntimeEnv` directly and remove the forwarding function and narration comment. Keep the domain-specific `verify` helper, which supplies the saved account configuration and preserves runtime identity for assertions. Factory arguments, fresh spies, reset behavior, output order, and gateway expectations remain unchanged.

## User Impact

No user-facing behavior change. Production code is unchanged; tests change by +3/-8 lines (net -5). All eight setup-verification cases and 20 setup-core cases remain.

## Evidence

- Both complete suites passed before and after: 28/28 cases, no skips, with identical within-file case order and status. Cross-file scheduling differed and was recorded.
- Targeted formatting and type-aware lint passed. The normal changed gate passed all 19 selected checks, including all three dead-export scans.
- The configured [Blacksmith Testbox run](https://github.com/openclaw/openclaw/actions/runs/34700615102) verified the exact base-plus-one-file source tree and completed successfully; its lease was independently confirmed completed. One-shot Testbox cleanup can leave the backing Actions step marked cancelled.
- Independent scoped source review found no actionable findings.

Proof limits: client and gateway calls are mocked; no live ClickClack connection, auth, or performance claim is made. Local proof used Node 26.5.0; the configured remote gate used Node 24.19.0 and pnpm 12.3.4. Lint generated SDK boundary declarations as expected, which is not declaration-equivalence proof.
