### PR TITLE
refactor: centralize media generation resource handoff

### DIFF
--- a/src/agents/tools/image-generate-tool.ts
+++ b/src/agents/tools/image-generate-tool.ts
@@ -9,7 +9,6 @@ import type {
   ImageGenerationOpenAIOptions,
   ImageGenerationProvider,
   ImageGenerationProviderOptions,
-  ImageGenerationResolution,
 } from "../../image-generation/types.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { parseImageGenerationModelRef } from "../../media-generation/model-ref.js";
@@ -48,10 +47,9 @@ import {
 } from "./media-generate-background-shared.js";
 import {
   imageGenerationTaskLifecycle,
-  runMediaGenerationTask,
+  prepareMediaGenerationTask,
   type ImageGenerationTaskHandle,
 } from "./media-generate-background.js";
-import { rethrowAfterMediaCleanup } from "./media-generation-error.js";
 import { acquireImageGenerationToolProviders } from "./media-generation-tool-providers.js";
 import {
   applyAgentDefaultModelConfig,
@@ -333,10 +331,6 @@ function validateImageGenerationCapabilities(params: {
   count: number;
   inputImageCount: number;
   maxInputImages?: number;
-  size?: string;
-  aspectRatio?: string;
-  resolution?: ImageGenerationResolution;
-  explicitResolution?: boolean;
 }) {
   const provider = params.provider;
   if (!provider) {
@@ -587,10 +581,6 @@ export function createImageGenerateTool(options?: {
           count,
           inputImageCount: imageInputs.length,
           maxInputImages,
-          size,
-          aspectRatio,
-          resolution: explicitResolution,
-          explicitResolution: Boolean(explicitResolution),
         });
         const referenceMaxBytes = resolveGeneratedMediaMaxBytes(effectiveCfg, "image");
         const loadedReferenceImages = await loadImageGenerationReferences({
@@ -623,16 +613,11 @@ export function createImageGenerateTool(options?: {
           count,
           inputImageCount: inputImages.length,
           maxInputImages,
-          size,
-          aspectRatio,
-          resolution,
-          explicitResolution: Boolean(explicitResolution),
         });
         return {
           kind: "task" as const,
           params: {
             lifecycle: imageGenerationTaskLifecycle,
-            generationLabel: "image" as const,
             sessionKey: options?.agentSessionKey,
             requesterAgentId: options?.requesterAgentId,
             requesterOrigin: options?.requesterOrigin,
@@ -687,27 +672,12 @@ export function createImageGenerateTool(options?: {
           },
         };
       };
-      let prepared: Awaited<ReturnType<typeof prepare>>;
-      try {
-        acquired.assertOpen();
-        prepared = await acquired.run(prepare);
-        if (prepared.kind === "task") {
-          // Admission is fenced after preflight; accepted work retains resources independently.
-          signal?.throwIfAborted();
-          acquired.assertOpen();
-        }
-      } catch (error) {
-        return rethrowAfterMediaCleanup(
-          error,
-          () => acquired.release(),
-          "Image preflight and cleanup failed",
-        );
-      }
-      if (prepared.kind === "result") {
-        await acquired.release();
-        return prepared.result;
-      }
-      return runMediaGenerationTask({ ...prepared.params, resources: acquired });
+      return prepareMediaGenerationTask({
+        generationLabel: "image",
+        resources: acquired,
+        signal,
+        prepare,
+      });
     },
   };
 }

--- a/src/agents/tools/media-generate-background.ts
+++ b/src/agents/tools/media-generate-background.ts
@@ -1,8 +1,4 @@
-/**
- * Image generation background task facade.
- *
- * Binds shared detached media-task lifecycle behavior to image_generate labels and completion messages.
- */
+/** Owns image, music, and video preflight, task admission, and detached completion. */
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { DeliveryContext } from "../../utils/delivery-context.types.js";
 import { recordRecentMediaGenerationTaskStartForSession } from "../media-generation-task-status-shared.js";
@@ -22,6 +18,7 @@ import {
   type MediaGenerationExecutionResult,
   type MediaGenerationTaskHandle,
 } from "./media-generate-background-shared.js";
+import type { MediaGenerateActionResult } from "./media-generate-tool-actions-shared.js";
 import { rethrowAfterMediaCleanup } from "./media-generation-error.js";
 
 /** Transferred resources belong to queued work through actual generation and persistence. */
@@ -29,6 +26,51 @@ export type MediaGenerationTaskResources = {
   run: <T>(run: () => T | Promise<T>) => Promise<T>;
   release: () => Promise<void>;
 };
+
+/** Preflight retains resources until a duplicate result releases them or task admission takes over. */
+export async function prepareMediaGenerationTask<T extends MediaGenerationExecutionResult>(params: {
+  generationLabel: "image" | "video" | "music";
+  resources?: MediaGenerationTaskResources & { assertOpen: () => void };
+  signal?: AbortSignal;
+  prepare: () => Promise<
+    | { kind: "result"; result: MediaGenerateActionResult }
+    | {
+        kind: "task";
+        params: Omit<
+          Parameters<typeof runMediaGenerationTask<T>>[0],
+          "resources" | "generationLabel"
+        >;
+      }
+  >;
+}) {
+  const { resources, signal, prepare } = params;
+  let prepared: Awaited<ReturnType<typeof prepare>>;
+  try {
+    resources?.assertOpen();
+    prepared = resources ? await resources.run(prepare) : await prepare();
+    if (prepared.kind === "task") {
+      // Cancellation fences admission; accepted work retains resources independently.
+      signal?.throwIfAborted();
+      resources?.assertOpen();
+    }
+  } catch (error) {
+    const title = `${params.generationLabel.charAt(0).toUpperCase()}${params.generationLabel.slice(1)}`;
+    return rethrowAfterMediaCleanup(
+      error,
+      () => resources?.release(),
+      `${title} preflight and cleanup failed`,
+    );
+  }
+  if (prepared.kind === "result") {
+    await resources?.release();
+    return prepared.result;
+  }
+  return runMediaGenerationTask({
+    ...prepared.params,
+    generationLabel: params.generationLabel,
+    resources,
+  });
+}
 
 /** Owns task admission and the shared foreground or detached generation lifecycle. */
 export async function runMediaGenerationTask<T extends MediaGenerationExecutionResult>(params: {
@@ -153,60 +195,37 @@ export async function runMediaGenerationTask<T extends MediaGenerationExecutionR
   }
 }
 
-/** Detached image generation task handle. */
 export type ImageGenerationTaskHandle = MediaGenerationTaskHandle;
-
-/** Shared lifecycle instance configured for image generation. */
-export const imageGenerationTaskLifecycle = createMediaGenerationTaskLifecycle({
-  toolName: "image_generate",
-  taskKind: IMAGE_GENERATION_TASK_KIND,
-  label: "Image generation",
-  queuedProgressSummary: "Queued image generation",
-  generatedLabel: "image",
-  failureProgressSummary: "Image generation failed",
-  eventSource: "image_generation",
-  announceType: "image generation task",
-  completionLabel: "image",
-});
-
-/**
- * Music generation background task facade.
- *
- * Binds shared detached media-task lifecycle behavior to music_generate labels and completion messages.
- */
-
 export type MusicGenerationTaskHandle = MediaGenerationTaskHandle;
-
-/** Shared lifecycle configured with music-specific status text and event metadata. */
-export const musicGenerationTaskLifecycle = createMediaGenerationTaskLifecycle({
-  toolName: "music_generate",
-  taskKind: MUSIC_GENERATION_TASK_KIND,
-  label: "Music generation",
-  queuedProgressSummary: "Queued music generation",
-  generatedLabel: "track",
-  failureProgressSummary: "Music generation failed",
-  eventSource: "music_generation",
-  announceType: "music generation task",
-  completionLabel: "music",
-});
-
-/**
- * Video-generation background task lifecycle adapters.
- *
- * Specializes the shared media background runner with video status text and completion metadata.
- */
-
 export type VideoGenerationTaskHandle = MediaGenerationTaskHandle;
 
-/** Shared lifecycle configured with video-specific status text and event metadata. */
-export const videoGenerationTaskLifecycle = createMediaGenerationTaskLifecycle({
-  toolName: "video_generate",
-  taskKind: VIDEO_GENERATION_TASK_KIND,
-  label: "Video generation",
-  queuedProgressSummary: "Queued video generation",
-  generatedLabel: "video",
-  failureProgressSummary: "Video generation failed",
-  eventSource: "video_generation",
-  announceType: "video generation task",
-  completionLabel: "video",
-});
+function createGenerationTaskLifecycle(
+  kind: "image" | "music" | "video",
+  taskKind: Parameters<typeof createMediaGenerationTaskLifecycle>[0]["taskKind"],
+) {
+  const title = `${kind.charAt(0).toUpperCase()}${kind.slice(1)}`;
+  return createMediaGenerationTaskLifecycle({
+    toolName: `${kind}_generate`,
+    taskKind,
+    label: `${title} generation`,
+    queuedProgressSummary: `Queued ${kind} generation`,
+    generatedLabel: kind === "music" ? "track" : kind,
+    failureProgressSummary: `${title} generation failed`,
+    eventSource: `${kind}_generation`,
+    announceType: `${kind} generation task`,
+    completionLabel: kind,
+  });
+}
+
+export const imageGenerationTaskLifecycle = createGenerationTaskLifecycle(
+  "image",
+  IMAGE_GENERATION_TASK_KIND,
+);
+export const musicGenerationTaskLifecycle = createGenerationTaskLifecycle(
+  "music",
+  MUSIC_GENERATION_TASK_KIND,
+);
+export const videoGenerationTaskLifecycle = createGenerationTaskLifecycle(
+  "video",
+  VIDEO_GENERATION_TASK_KIND,
+);

--- a/src/agents/tools/music-generate-tool.ts
+++ b/src/agents/tools/music-generate-tool.ts
@@ -28,10 +28,9 @@ import {
 } from "./media-generate-background-shared.js";
 import {
   musicGenerationTaskLifecycle,
-  runMediaGenerationTask,
+  prepareMediaGenerationTask,
   type MusicGenerationTaskHandle,
 } from "./media-generate-background.js";
-import { rethrowAfterMediaCleanup } from "./media-generation-error.js";
 import { acquireMusicGenerationToolProviders } from "./media-generation-tool-providers.js";
 import {
   applyAgentDefaultModelConfig,
@@ -153,12 +152,7 @@ function normalizeReferenceImageInputs(args: Record<string, unknown>): string[] 
 
 function validateMusicGenerationCapabilities(params: {
   provider: MusicGenerationProvider | undefined;
-  model?: string;
   inputImageCount: number;
-  lyrics?: string;
-  instrumental?: boolean;
-  durationSeconds?: number;
-  format?: MusicGenerationOutputFormat;
 }) {
   const provider = params.provider;
   if (!provider) {
@@ -424,18 +418,12 @@ export function createMusicGenerateTool(options?: {
         });
         validateMusicGenerationCapabilities({
           provider: selectedProvider,
-          model: selectedModelRef?.model ?? model ?? selectedProvider?.defaultModel,
           inputImageCount: loadedReferenceImages.length,
-          lyrics,
-          instrumental,
-          durationSeconds,
-          format,
         });
         return {
           kind: "task" as const,
           params: {
             lifecycle: musicGenerationTaskLifecycle,
-            generationLabel: "music" as const,
             sessionKey: options?.agentSessionKey,
             requesterAgentId: options?.requesterAgentId,
             requesterOrigin: options?.requesterOrigin,
@@ -490,27 +478,12 @@ export function createMusicGenerateTool(options?: {
           },
         };
       };
-      let prepared: Awaited<ReturnType<typeof prepare>>;
-      try {
-        acquired?.assertOpen();
-        prepared = acquired ? await acquired.run(prepare) : await prepare();
-        if (prepared.kind === "task") {
-          // Accepted tasks own paid work independently; cancellation applies before admission.
-          signal?.throwIfAborted();
-          acquired?.assertOpen();
-        }
-      } catch (error) {
-        return rethrowAfterMediaCleanup(
-          error,
-          () => acquired?.release(),
-          "Music preflight and cleanup failed",
-        );
-      }
-      if (prepared.kind === "result") {
-        await acquired?.release();
-        return prepared.result;
-      }
-      return runMediaGenerationTask({ ...prepared.params, resources: acquired });
+      return prepareMediaGenerationTask({
+        generationLabel: "music",
+        resources: acquired,
+        signal,
+        prepare,
+      });
     },
   };
 }

--- a/src/agents/tools/video-generate-tool.execution.ts
+++ b/src/agents/tools/video-generate-tool.execution.ts
@@ -104,6 +104,7 @@ function formatIgnoredVideoGenerationOverride(override: VideoGenerationIgnoredOv
 
 export async function loadReferenceAssets(params: {
   inputs: string[];
+  roles: string[];
   expectedKind: "image" | "video" | "audio";
   maxBytes: number;
   workspaceDir?: string;
@@ -133,9 +134,16 @@ export async function loadReferenceAssets(params: {
     }),
     mapRemote: (url) => ({ url }),
   });
-  return loaded.map(({ source, resolvedInput, rewrittenFrom }) =>
-    Object.assign({ sourceAsset: source, resolvedInput }, rewrittenFrom ? { rewrittenFrom } : {}),
-  );
+  return loaded.map(({ source, resolvedInput, rewrittenFrom }, index) => {
+    const role = params.roles[index];
+    if (role) {
+      source.role = role;
+    }
+    return Object.assign(
+      { sourceAsset: source, resolvedInput },
+      rewrittenFrom ? { rewrittenFrom } : {},
+    );
+  });
 }
 
 type LoadedReferenceAsset = Awaited<ReturnType<typeof loadReferenceAssets>>[number];

--- a/src/agents/tools/video-generate-tool.ts
+++ b/src/agents/tools/video-generate-tool.ts
@@ -28,11 +28,10 @@ import {
   type MediaGenerateBackgroundScheduler,
 } from "./media-generate-background-shared.js";
 import {
-  runMediaGenerationTask,
+  prepareMediaGenerationTask,
   videoGenerationTaskLifecycle,
   type VideoGenerationTaskHandle,
 } from "./media-generate-background.js";
-import { rethrowAfterMediaCleanup } from "./media-generation-error.js";
 import { acquireVideoGenerationToolProviders } from "./media-generation-tool-providers.js";
 import {
   applyAgentDefaultModelConfig,
@@ -575,6 +574,7 @@ export function createVideoGenerateTool(options?: {
         acquired?.assertOpen();
         const loadedReferenceImages = await loadReferenceAssets({
           inputs: imageInputs,
+          roles: imageRoles,
           expectedKind: "image",
           maxBytes: resolveGeneratedMediaMaxBytes(effectiveCfg, "image"),
           workspaceDir: options?.workspaceDir,
@@ -582,16 +582,9 @@ export function createVideoGenerateTool(options?: {
           ssrfPolicy: remoteMediaSsrfPolicy,
           signal,
         });
-        // Attach roles to the loaded image assets (positional, by index into images[]).
-        for (let i = 0; i < loadedReferenceImages.length; i++) {
-          const role = imageRoles[i];
-          const asset = loadedReferenceImages.at(i);
-          if (role && asset) {
-            asset.sourceAsset.role = role;
-          }
-        }
         const loadedReferenceVideos = await loadReferenceAssets({
           inputs: videoInputs,
+          roles: videoRoles,
           expectedKind: "video",
           maxBytes: resolveGeneratedMediaMaxBytes(effectiveCfg, "video"),
           workspaceDir: options?.workspaceDir,
@@ -599,15 +592,9 @@ export function createVideoGenerateTool(options?: {
           ssrfPolicy: remoteMediaSsrfPolicy,
           signal,
         });
-        for (let i = 0; i < loadedReferenceVideos.length; i++) {
-          const role = videoRoles[i];
-          const asset = loadedReferenceVideos.at(i);
-          if (role && asset) {
-            asset.sourceAsset.role = role;
-          }
-        }
         const loadedReferenceAudios = await loadReferenceAssets({
           inputs: audioInputs,
+          roles: audioRoles,
           expectedKind: "audio",
           maxBytes: resolveGeneratedMediaMaxBytes(effectiveCfg, "audio"),
           workspaceDir: options?.workspaceDir,
@@ -615,18 +602,10 @@ export function createVideoGenerateTool(options?: {
           ssrfPolicy: remoteMediaSsrfPolicy,
           signal,
         });
-        for (let i = 0; i < loadedReferenceAudios.length; i++) {
-          const role = audioRoles[i];
-          const asset = loadedReferenceAudios.at(i);
-          if (role && asset) {
-            asset.sourceAsset.role = role;
-          }
-        }
         return {
           kind: "task" as const,
           params: {
             lifecycle: videoGenerationTaskLifecycle,
-            generationLabel: "video" as const,
             sessionKey: options?.agentSessionKey,
             requesterAgentId: options?.requesterAgentId,
             requesterOrigin: options?.requesterOrigin,
@@ -686,27 +665,12 @@ export function createVideoGenerateTool(options?: {
           },
         };
       };
-      let prepared: Awaited<ReturnType<typeof prepare>>;
-      try {
-        acquired?.assertOpen();
-        prepared = acquired ? await acquired.run(prepare) : await prepare();
-        if (prepared.kind === "task") {
-          // Accepted tasks own paid work independently; cancellation applies before admission.
-          signal?.throwIfAborted();
-          acquired?.assertOpen();
-        }
-      } catch (error) {
-        return rethrowAfterMediaCleanup(
-          error,
-          () => acquired?.release(),
-          "Video preflight and cleanup failed",
-        );
-      }
-      if (prepared.kind === "result") {
-        await acquired?.release();
-        return prepared.result;
-      }
-      return runMediaGenerationTask({ ...prepared.params, resources: acquired });
+      return prepareMediaGenerationTask({
+        generationLabel: "video",
+        resources: acquired,
+        signal,
+        prepare,
+      });
     },
   };
 }


### PR DESCRIPTION
Closes #146087

## What Problem This Solves

Image, music, and video tools each maintained the same preparation, duplicate-result cleanup, cancellation fence, and resource handoff before invoking the shared generation task runner. Lifecycle fixes had to keep three copies aligned.

## Why This Change Was Made

Move preparation and resource transfer into the existing generation task owner and migrate all three tool factories. Build their unchanged status/completion labels in one place, assign video reference roles at their loader, and remove unused validation arguments. Provider-specific acquisition and validation remain with their existing owners, including image validation on both sides of asynchronous reference loading.

## User Impact

No intended behavior change. Foreground and detached completion, duplicate guards, cancellation, resource release, combined cleanup failures, reference ordering, and generated output remain the same. Removes 42 production code lines and 66 physical lines, including all added shared code; no test code added or removed.

## Evidence

- Six focused suites: 176 tests passed, covering the three real tool factories, cancellation, queued generation, media saving and rollback, donor resources, cleanup failures, outputs, and reference roles.
- Complete changed-file checks passed, including core and test typechecks, lint, boundary/dependency guards, and dead exports.
- Independent P0–P2 review: no findings.
- Tests used isolated synthetic provider and task boundaries, including in-memory SQLite resources; no paid generation or operator Gateway was used.
