### PR TITLE
fix(ui): show chat history before secondary work starts

### DIFF
--- a/docs/web/control-ui/chat.md
+++ b/docs/web/control-ui/chat.md
@@ -70,7 +70,8 @@ If a New Session model lookup does not finish within 30 seconds, the controls
 show **Models unavailable**. Open the model picker to retry; your draft stays
 in place.
 
-When you open an existing session, you can start typing as soon as its identity
+When you open an existing session, the conversation appears before supporting
+panels and pull-request details load. You can start typing as soon as its identity
 is resolved, while the transcript still shows its loading skeleton. The same
 composer keeps your draft and focus when the conversation appears. You can send
 ordinary messages and attachments while history loads: the message enters the

--- a/ui/src/pages/chat/chat-pane-session-hydration.test.ts
+++ b/ui/src/pages/chat/chat-pane-session-hydration.test.ts
@@ -1,6 +1,6 @@
 /* @vitest-environment jsdom */
 
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import { SESSION_PULL_REQUESTS_SUBSCRIBE_METHOD } from "../../lib/session-pull-requests.ts";
 import type { SessionCapability } from "../../lib/sessions/index.ts";
@@ -44,12 +44,42 @@ function createSecondaryHydrationPane() {
     return () => undefined;
   });
   state.renderLifecycle = { invalidate: vi.fn(), afterCommit } satisfies RenderLifecycle;
-  return { afterCommit, commitEffects, listBranches, pane, patch, request, state };
+  const frames = new Map<number, FrameRequestCallback>();
+  let nextFrame = 0;
+  vi.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {
+    frames.set(++nextFrame, callback);
+    return nextFrame;
+  });
+  vi.spyOn(window, "cancelAnimationFrame").mockImplementation((id) => {
+    frames.delete(id);
+  });
+  const runAnimationFrame = () => {
+    const callbacks = [...frames.values()];
+    frames.clear();
+    if (callbacks.length === 0) {
+      throw new Error("expected a queued animation frame");
+    }
+    for (const callback of callbacks) {
+      callback(0);
+    }
+  };
+  return {
+    afterCommit,
+    commitEffects,
+    listBranches,
+    pane,
+    patch,
+    request,
+    runAnimationFrame,
+    state,
+  };
 }
 
 describe("chat pane session hydration", () => {
-  it("starts secondary RPCs together only after the transcript commit", async () => {
-    const { afterCommit, commitEffects, listBranches, pane, request, state } =
+  afterEach(() => vi.restoreAllMocks());
+
+  it("lets the committed transcript paint before starting secondary RPCs together", async () => {
+    const { afterCommit, commitEffects, listBranches, pane, request, runAnimationFrame, state } =
       createSecondaryHydrationPane();
     const transcript = deferred<boolean>();
 
@@ -69,6 +99,18 @@ describe("chat pane session hydration", () => {
     commitEffects[0]!(complete);
     await Promise.resolve();
 
+    expect(request).not.toHaveBeenCalled();
+    expect(listBranches).not.toHaveBeenCalled();
+    expect(complete).not.toHaveBeenCalled();
+
+    runAnimationFrame();
+    await Promise.resolve();
+    expect(request).not.toHaveBeenCalled();
+    expect(listBranches).not.toHaveBeenCalled();
+    expect(complete).not.toHaveBeenCalled();
+
+    runAnimationFrame();
+    await Promise.resolve();
     expect(listBranches).toHaveBeenCalledOnce();
     expect(request.mock.calls.map(([method]) => method)).toEqual([
       "session.discussion.info",
@@ -107,8 +149,31 @@ describe("chat pane session hydration", () => {
     expect(afterCommit).toHaveBeenCalledOnce();
   });
 
+  it("drops secondary work when the session changes between commit and paint", async () => {
+    const { commitEffects, listBranches, pane, patch, request, runAnimationFrame, state } =
+      createSecondaryHydrationPane();
+    const transcript = deferred<boolean>();
+    pane.deferSessionHydrationUntilTranscript(state.sessionKey, transcript.promise);
+    transcript.resolve(true);
+    await transcript.promise;
+    await Promise.resolve();
+
+    const complete = vi.fn();
+    commitEffects[0]!(complete);
+    runAnimationFrame();
+    state.sessionKey = "agent:work:replacement";
+    runAnimationFrame();
+    await Promise.resolve();
+
+    expect(request).not.toHaveBeenCalled();
+    expect(listBranches).not.toHaveBeenCalled();
+    expect(patch).not.toHaveBeenCalled();
+    expect(complete).toHaveBeenCalledOnce();
+  });
+
   it("resumes deferred companion and discussion hydration when a retained pane returns", async () => {
-    const { commitEffects, pane, request, state } = createSecondaryHydrationPane();
+    const { commitEffects, pane, request, runAnimationFrame, state } =
+      createSecondaryHydrationPane();
     const transcript = deferred<boolean>();
 
     pane.deferSessionHydrationUntilTranscript(state.sessionKey, transcript.promise);
@@ -123,6 +188,9 @@ describe("chat pane session hydration", () => {
     pane.presented = true;
     expect(commitEffects).toHaveLength(1);
     commitEffects[0]!(vi.fn());
+    expect(request).not.toHaveBeenCalled();
+    runAnimationFrame();
+    runAnimationFrame();
     await Promise.resolve();
 
     const methods = request.mock.calls.map(([method]) => method);
@@ -136,7 +204,8 @@ describe("chat pane session hydration", () => {
   ])(
     "acknowledges unread only after deferred transcript hydration $name",
     async ({ committed, expectedPatches }) => {
-      const { commitEffects, pane, patch, state } = createSecondaryHydrationPane();
+      const { commitEffects, pane, patch, runAnimationFrame, state } =
+        createSecondaryHydrationPane();
       const transcript = deferred<boolean>();
       state.sessionsResult = {
         sessions: [
@@ -160,6 +229,10 @@ describe("chat pane session hydration", () => {
       expect(commitEffects).toHaveLength(1);
 
       commitEffects[0]!(vi.fn());
+      expect(patch).not.toHaveBeenCalled();
+      runAnimationFrame();
+      expect(patch).not.toHaveBeenCalled();
+      runAnimationFrame();
       await Promise.resolve();
       expect(patch).toHaveBeenCalledTimes(expectedPatches);
     },

--- a/ui/src/pages/chat/chat-pane-session.ts
+++ b/ui/src/pages/chat/chat-pane-session.ts
@@ -40,6 +40,7 @@ import {
   dismissChatPullRequest,
   listDismissedChatPullRequests,
 } from "./components/chat-pull-requests.ts";
+import { scheduleControlUiAfterPaint } from "./performance.ts";
 import { scheduleChatScroll } from "./scroll.ts";
 
 export abstract class ChatPaneSession extends ChatPaneTaskSuggestions {
@@ -206,8 +207,8 @@ export abstract class ChatPaneSession extends ChatPaneTaskSuggestions {
       }
       this.pendingDeferredSessionHydration = null;
       // These affordances do not shape the transcript. Start them together only
-      // after the authoritative history has committed so they cannot delay chat paint.
-      state.renderLifecycle.afterCommit((complete) => {
+      // after the transcript paints; a DOM commit still runs before the browser can paint.
+      scheduleControlUiAfterPaint(state, () => {
         if (isCurrent() && this.presented) {
           this.deferredSessionHydrationActive = false;
           if (historyCommitted) {
@@ -222,7 +223,6 @@ export abstract class ChatPaneSession extends ChatPaneTaskSuggestions {
         } else {
           retireIfCurrent();
         }
-        complete();
       });
     };
     void transcriptLoad.then(scheduleHydration, () => scheduleHydration(false));


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users opening a conversation could keep seeing its loading state while secondary chat work ran, even after the history response and DOM update completed.

## Why This Change Was Made

The secondary branch, discussion, companion, and pull-request hydration used Lit's DOM-commit boundary, which runs before the browser paints. Route that work through the existing lifecycle-owned after-paint scheduler, retaining session/generation checks and cancellation. This also keeps unread acknowledgement behind the first transcript paint.

## User Impact

The conversation gets a frame on screen before secondary work starts. Supporting panels still load, and switching or hiding the pane preserves their existing ownership and resume behavior.

## Evidence

A Chromium probe opened the actual Control UI against a mocked Gateway, held the initial history response, then measured response release to the first animation frame containing the transcript. Three fresh contexts per condition used the same synthetic conversation. A controlled 250 ms synchronous workload in secondary companion hydration reproduces the blocked first frame; the patched probe also waits for that work to finish.

| Condition | Before median | After median |
| --- | ---: | ---: |
| No added secondary work | 37.2 ms | 35.5 ms |
| 250 ms secondary workload | 288.3 ms | 39.1 ms |

The stressed first frame is about 86% sooner. This is a controlled browser scheduling measurement, not a live-server latency claim. The settled before/after screenshots show the preserved UI.

The regression fails on the original code because secondary RPCs start at DOM commit. All 62 focused hydration, retained-pane, and lifecycle tests pass after the change, including a session switch between commit and paint.

The existing real-Gateway loading benchmark passes on both the pinned base and candidate, covering selected transcript priority, restored Home, pagination, narrow layouts, and avatar caching. An initial attempt lacked the built UI, and the first candidate attempt stalled while importing the separate Home panel; both attempts are retained. After building each version and comparing base/candidate separately, both completed without test or timeout changes.

`check:changed`, `pnpm ui:build` (including startup-size checks), and independent Codex review through P2 passed. Exact-head CI remains the landing gate.

![Before: settled synthetic conversation after secondary work](https://github.com/user-attachments/assets/dbd077c9-ac5e-4038-b584-249c68f9acd3)

![After: same synthetic conversation, painted before secondary work](https://github.com/user-attachments/assets/ca47fea0-8f5d-4969-bb66-2f32793a1cdb)