### PR TITLE
fix(sessions): reduce allocation pressure in large session lists

### DIFF
--- a/src/gateway/server.sessions.list-store-materialization.test.ts
+++ b/src/gateway/server.sessions.list-store-materialization.test.ts
@@ -5,6 +5,7 @@
 import path from "node:path";
 import { expect, test, vi } from "vitest";
 import { createDeferred } from "../../test/helpers/promise.js";
+import * as agentScope from "../agents/agent-scope.js";
 import * as sessionsConfig from "../config/sessions.js";
 import { canPrewarmCombinedSessionStoresForGateway } from "../config/sessions/combined-store-gateway.js";
 import * as sessionAccessor from "../config/sessions/session-accessor.js";
@@ -80,6 +81,38 @@ test("sessions.list reuses prepared store targets for sharing", async () => {
   } finally {
     discoverySpy.mockRestore();
   }
+});
+
+test("sessions.list keeps roster enumeration bounded as ordinary rows grow", async () => {
+  await createSessionStoreDir();
+  testState.agentsConfig = { list: [{ id: "main", default: true }, { id: "work" }] };
+  const rosterReads: number[] = [];
+  for (const rows of [20, 200]) {
+    const entries: Record<string, ReturnType<typeof sessionStoreEntry>> = {
+      main: sessionStoreEntry("sess-main", { updatedAt: 1_781_000_000_001 }),
+    };
+    for (let index = 0; index < rows; index++) {
+      entries[`agent:main:ordinary-${index}`] = sessionStoreEntry(`ordinary-${index}`, {
+        updatedAt: 1_781_000_000_000 - index,
+      });
+    }
+    await writeSessionStore({ entries });
+    expect((await directSessionReq("sessions.list", LIST_PARAMS)).ok).toBe(true);
+    const roster = vi.spyOn(agentScope, "listAgentIds");
+    try {
+      const result = await directSessionReq<SessionsListResult>("sessions.list", LIST_PARAMS);
+      expect(result.ok).toBe(true);
+      expect(result.payload?.totalCount).toBe(rows + 1);
+      expect(result.payload?.sessions.map(({ key }) => key)).toEqual([
+        "agent:main:main",
+        ...Array.from({ length: Math.min(rows, 99) }, (_, index) => `agent:main:ordinary-${index}`),
+      ]);
+      rosterReads.push(roster.mock.calls.length);
+    } finally {
+      roster.mockRestore();
+    }
+  }
+  expect(rosterReads[1]).toBeLessThanOrEqual(rosterReads[0]!);
 });
 
 test("sessions.list keeps cold and warm transcript title batches valid beyond the database handle cap", async () => {

--- a/src/gateway/session-store-key.ts
+++ b/src/gateway/session-store-key.ts
@@ -67,10 +67,11 @@ function resolveParsedSessionStoreKey(
 ): { agentId: string; sessionKey: string } {
   const parsedAgentId = normalizeAgentId(parsed.agentId);
   const rest = normalizeLowercaseStringOrEmpty(parsed.rest);
+  // Only legacy main aliases need the configured roster to resolve ownership.
   if (
     parsedAgentId !== DEFAULT_AGENT_ID ||
-    listAgentIds(cfg).includes(DEFAULT_AGENT_ID) ||
-    (rest !== "main" && rest !== normalizeMainKey(cfg.session?.mainKey))
+    (rest !== "main" && rest !== normalizeMainKey(cfg.session?.mainKey)) ||
+    listAgentIds(cfg).includes(DEFAULT_AGENT_ID)
   ) {
     return {
       agentId: parsedAgentId,


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled.

</details>

## What Problem This Solves

Fixes unnecessary allocation pressure when users load a large Sessions list for the main agent.

## Why This Change Was Made

Session-key resolution enumerated the configured agent roster before checking whether an ordinary `agent:main:…` key could be a main-session alias. Check the existing suffix condition first so only genuine main aliases need the roster lookup. The existing canonicalization and ownership checks still handle those aliases.

## User Impact

Large session lists create fewer temporary roster objects while retaining the existing session-key, owner, and pagination results.

## Evidence

A synthetic fixture exercised the registered `sessions.list` handler with a canonical keyed two-agent roster, 3,000 sessions, realistic saved and retained metadata, and a 100-row page.

| Per request | Before | After |
| --- | ---: | ---: |
| Roster enumerations | 3,201 | 1 |
| Estimated allocations attributed to roster enumeration | 4.18 MB | 2.7 KB |
| Estimated total allocations | 33.38 MB | 29.27 MB |

Allocation estimates come from separate V8 heap-sampling runs with the same warmups, 20 warm handler requests, a 1 KiB sampling interval, and minor/major-GC-collected objects included. Count spies were absent from timing and allocation runs. The total allocation estimate is secondary evidence; the eliminated roster enumerations are deterministic.

Sequential timing on the busy shared host did not establish a latency improvement. These synthetic results do not claim a production speedup or retained-heap reduction.

The registered-handler regression preserves the page and main alias while growing ordinary rows from 20 to 200. It fails before the fix because roster enumeration grows from 64 to 402, and passes after the fix with non-growing work. All 278 selected permanent tests passed, including existing main/custom-main/global and retired-owner coverage.

The complete changed-file gate passed, including production/test typechecking, formatting, lint, export scans, and boundary guards. Fresh independent P2 review and ClawSweeper found no actionable issues. [Hosted CI](https://github.com/openclaw/openclaw/actions/runs/34702262284) and the required `openclaw/ci-gate` passed for exact head `205e1a14d945531ecc4ec630a68b3fecf60db629`.
