### PR TITLE
fix(ui): show a neutral placeholder while avatar images load

### DIFF
--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -102,7 +102,12 @@ page filtered to that agent. Open **Agents** in the sidebar to return to the ros
 page. See [Sidebar navigation](/web/control-ui/sessions-and-sidebar#sidebar-navigation)
 for group controls and filtering.
 
-Agent names and avatars follow agent and identity updates. Activity and previews on the page and sidebar roster refresh on session events
+Agent names and avatars follow agent and identity updates. While a configured avatar image loads,
+the avatar keeps its tinted background with no face or text. The image appears when ready;
+an emoji or generated face appears only when no image is configured or the image fails to load.
+This behavior is shared by the roster, agent switcher, identity chips, settings, and chat.
+
+Activity and previews on the page and sidebar roster refresh on session events
 and Gateway reconnects. When both are visible, they share one activity window and
 one refresh, so opening **Agents** while team mode is visible does not duplicate requests. Activity loading
 stops when neither roster is visible. Each refresh reads at most 300 sessions

--- a/ui/src/components/agent-select.test.ts
+++ b/ui/src/components/agent-select.test.ts
@@ -1,6 +1,7 @@
 /* @vitest-environment jsdom */
 
 import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../test/helpers/promise.js";
 import type { AgentIdentityResult, GatewayAgentRow } from "../api/types.ts";
 import { i18n, t } from "../i18n/index.ts";
 import { setAvatarGatewayOrigin } from "../lib/identity-avatar-context.ts";
@@ -193,11 +194,9 @@ it("fetches local avatars with the bearer credential when token auth is active",
       static override revokeObjectURL = revokeObjectURL;
     },
   );
-  const fetchMock = vi.fn().mockResolvedValue({
-    ok: true,
-    blob: async () => new Blob(["avatar"], { type: "image/png" }),
-  });
-  vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+  const response = createDeferred<Response>();
+  const fetchMock = vi.fn<typeof fetch>().mockReturnValue(response.promise);
+  vi.stubGlobal("fetch", fetchMock);
 
   setAvatarGatewayOrigin(globalThis.location.origin, ["tok"]);
   const element = await createAgentSelect({
@@ -205,21 +204,30 @@ it("fetches local avatars with the bearer credential when token auth is active",
   });
 
   try {
-    // The generated fallback renders while the authenticated fetch is in flight.
-    await waitForFast(() =>
-      expect(element.querySelector(".identity-avatar__agent-face")).not.toBeNull(),
-    );
+    const avatar = element.querySelector(".agent-select__trigger .agent-select__avatar");
+    expect(avatar?.classList).toContain("is-pending");
+    expect(avatar?.classList).not.toContain("is-fallback");
     expect(fetchMock).toHaveBeenCalledWith(`${globalThis.location.origin}/avatar/alpha`, {
       credentials: "include",
       headers: { Authorization: "Bearer tok" },
       signal: expect.any(AbortSignal),
     });
 
+    response.resolve(
+      new Response(new Uint8Array([1, 2, 3]), { headers: { "content-type": "image/png" } }),
+    );
     await waitForFast(() => {
       expect(
         element.querySelector<HTMLImageElement>(".agent-select__avatar img")?.getAttribute("src"),
       ).toBe("blob:agent-avatar");
     });
+    expect(avatar?.classList).toContain("is-pending");
+    avatar?.querySelector("img")?.dispatchEvent(new Event("load"));
+    expect(avatar?.classList).not.toContain("is-pending");
+    element.accessibleLabel = "Choose an agent";
+    await element.updateComplete;
+    expect(avatar?.classList).not.toContain("is-pending");
+    expect(avatar?.classList).not.toContain("is-fallback");
     expect(createObjectURL).toHaveBeenCalledTimes(1);
 
     element.remove();
@@ -227,6 +235,7 @@ it("fetches local avatars with the bearer credential when token auth is active",
     setAvatarGatewayOrigin(null);
     expect(revokeObjectURL).toHaveBeenCalledWith("blob:agent-avatar");
   } finally {
+    response.resolve(new Response(null, { status: 404 }));
     element.remove();
     vi.unstubAllGlobals();
   }
@@ -253,7 +262,7 @@ it("refetches a failed local avatar after the auth credential rotates", async ()
 
   try {
     await waitForFast(() => expect(fetchMock).toHaveBeenCalledTimes(1));
-    expect(element.querySelector(".agent-select__avatar img")).toBeNull();
+    await waitForFast(() => expect(element.querySelector(".agent-select__avatar img")).toBeNull());
 
     setAvatarGatewayOrigin(globalThis.location.origin, ["tok2"]);
     await element.updateComplete;

--- a/ui/src/components/identity-avatar-view.test.ts
+++ b/ui/src/components/identity-avatar-view.test.ts
@@ -135,7 +135,8 @@ describe("shared identity avatar view", () => {
 
     const wrapper = container.querySelector<HTMLElement>(".test-avatar");
     expect(view.pending).toBe(true);
-    expect(wrapper?.classList.contains("is-fallback")).toBe(true);
+    expect(wrapper?.classList.contains("is-pending")).toBe(true);
+    expect(wrapper?.classList.contains("is-fallback")).toBe(false);
 
     const image = await vi.waitFor(() => {
       const element = container.querySelector<HTMLImageElement>(".test-avatar__image");
@@ -153,6 +154,16 @@ describe("shared identity avatar view", () => {
 
     image.dispatchEvent(new Event("load"));
     expect(wrapper?.classList.contains("is-fallback")).toBe(false);
+    renderAvatar(
+      resolveIdentityAvatarView({
+        id: "profile-ada",
+        name: "Ada Lovelace",
+        profileAvatarUrl: "/api/users/profile-ada/avatar?v=7",
+      }),
+      container,
+    );
+    expect(container.querySelector("img")).toBe(image);
+    expect(wrapper?.getAttribute("data-avatar-state")).toBe("loaded");
 
     image.dispatchEvent(new Event("error"));
     expect(wrapper?.classList.contains("is-fallback")).toBe(true);
@@ -161,7 +172,7 @@ describe("shared identity avatar view", () => {
     expect(wrapper?.classList.contains("is-fallback")).toBe(false);
   });
 
-  it("retains its existing image while a newer avatar revision loads", async () => {
+  it("reuses its image element with a neutral placeholder while a newer revision loads", async () => {
     setAvatarGatewayOrigin("https://gateway.example.test", ["avatar-token"]);
     vi.spyOn(globalThis, "fetch").mockImplementation(
       async () =>
@@ -198,7 +209,7 @@ describe("shared identity avatar view", () => {
       }),
       container,
     );
-    expect(container.querySelector(".test-avatar")?.classList.contains("is-fallback")).toBe(true);
+    expect(container.querySelector(".test-avatar")?.classList.contains("is-pending")).toBe(true);
 
     const secondImage = await vi.waitFor(() => {
       const image = container.querySelector<HTMLImageElement>(".test-avatar__image");
@@ -276,6 +287,91 @@ describe("shared identity avatar view", () => {
 });
 
 describe("shared agent avatar view", () => {
+  it.each([false, true])(
+    "hides an existing fallback as soon as an image is configured (authenticated=%s)",
+    async (authenticated) => {
+      const response = createDeferred<Response>();
+      if (authenticated) {
+        setAvatarGatewayOrigin("https://gateway.example.test", ["avatar-token"]);
+        vi.spyOn(globalThis, "fetch").mockReturnValue(response.promise);
+      }
+      const container = document.createElement("div");
+      render(renderAgentIdentityAvatar({ id: "hydrated", textAvatar: "🦀" }), container);
+      const wrapper = container.querySelector(".identity-avatar--agent")!;
+      expect(wrapper.classList.contains("is-fallback")).toBe(true);
+      render(
+        renderAgentIdentityAvatar({ id: "hydrated", textAvatar: "🦀", avatar: "/avatar/hydrated" }),
+        container,
+      );
+      expect(container.querySelector(".identity-avatar--agent")).toBe(wrapper);
+      expect(wrapper.classList.contains("is-pending")).toBe(true);
+      expect(wrapper.classList.contains("is-fallback")).toBe(false);
+      response.resolve(new Response(null, { status: 404 }));
+      if (authenticated) {
+        await vi.waitFor(() => expect(wrapper.classList.contains("is-fallback")).toBe(true));
+      }
+      render(nothing, container);
+    },
+  );
+
+  it.each([undefined, "🦀"])(
+    "keeps a configured image neutral until it loads (%s)",
+    (textAvatar) => {
+      const container = document.createElement("div");
+      const agent = { id: "pending", avatar: "/avatar/pending?v=1", textAvatar };
+      const update = (className = "") =>
+        render(renderAgentIdentityAvatar(agent, className), container);
+      update();
+      const wrapper = container.querySelector(".identity-avatar--agent")!;
+      const image = container.querySelector("img")!;
+      expect(wrapper.classList.contains("is-pending")).toBe(true);
+      expect(wrapper.classList.contains("is-fallback")).toBe(false);
+      image.dispatchEvent(new Event("load"));
+      update("renamed-surface");
+      expect(container.querySelector("img")).toBe(image);
+      expect(wrapper.classList.contains("is-pending")).toBe(false);
+      expect(wrapper.classList.contains("is-fallback")).toBe(false);
+      agent.avatar = "/avatar/pending?v=2";
+      update("renamed-surface");
+      expect(wrapper.classList.contains("is-pending")).toBe(true);
+      image.dispatchEvent(new Event("error"));
+      update();
+      expect(wrapper.classList.contains("is-pending")).toBe(false);
+      expect(wrapper.classList.contains("is-fallback")).toBe(true);
+      render(nothing, container);
+    },
+  );
+
+  it("recognizes a cached image at mount without waiting for another load event", async () => {
+    vi.spyOn(HTMLImageElement.prototype, "complete", "get").mockReturnValue(true);
+    vi.spyOn(HTMLImageElement.prototype, "naturalWidth", "get").mockReturnValue(32);
+    const container = document.createElement("div");
+    render(renderAgentIdentityAvatar({ id: "cached", avatar: "/avatar/cached" }), container);
+    await Promise.resolve();
+    expect(
+      container.querySelector(".identity-avatar--agent")?.classList.contains("is-pending"),
+    ).toBe(false);
+    expect(
+      container.querySelector(".identity-avatar--agent")?.getAttribute("data-avatar-state"),
+    ).toBe("loaded");
+    render(nothing, container);
+  });
+
+  it("reveals the fallback when authenticated loading fails without an image event", async () => {
+    setAvatarGatewayOrigin("https://gateway.example.test", ["avatar-token"]);
+    const response = createDeferred<Response>();
+    vi.spyOn(globalThis, "fetch").mockReturnValue(response.promise);
+    const container = document.createElement("div");
+    render(renderAgentIdentityAvatar({ id: "failure", avatar: "/avatar/failure" }), container);
+    const wrapper = container.querySelector(".identity-avatar--agent")!;
+    expect(wrapper.classList.contains("is-pending")).toBe(true);
+    response.resolve(new Response(null, { status: 404 }));
+    await vi.waitFor(() => expect(wrapper.classList.contains("is-fallback")).toBe(true));
+    expect(wrapper.classList.contains("is-pending")).toBe(false);
+    expect(wrapper.getAttribute("data-avatar-state")).toBe("failed");
+    render(nothing, container);
+  });
+
   it.each(["openclaw", "crestodian"])(
     "keeps the product mark for system agent %s even with a configured avatar or image error",
     async (id) => {
@@ -336,6 +432,9 @@ describe("shared agent avatar view", () => {
   it("uses explicit emoji before the same face used for a missing image", async () => {
     const container = document.createElement("div");
     render(renderAgentIdentityAvatar({ id: "forge", textAvatar: "🛠️" }), container);
+    expect(
+      container.querySelector(".identity-avatar--agent")?.getAttribute("data-avatar-state"),
+    ).toBe("none");
     expect(container.querySelector("img, svg")).toBeNull();
     expect(container.querySelector(".identity-avatar__text")?.getAttribute("data-avatar")).toBe(
       "🛠️",

--- a/ui/src/components/identity-avatar-view.ts
+++ b/ui/src/components/identity-avatar-view.ts
@@ -1,7 +1,6 @@
-import { html, nothing, type Part } from "lit";
-import { directive } from "lit/directive.js";
+import { html, noChange, nothing, type AttributePart } from "lit";
+import { Directive, directive } from "lit/directive.js";
 import { guard } from "lit/directives/guard.js";
-import { live } from "lit/directives/live.js";
 import { until, UntilDirective } from "lit/directives/until.js";
 import { isReservedSystemAgentId } from "../../../src/system-agent/agent-id.js";
 import { inferControlUiPublicAssetPath } from "../app/public-assets.ts";
@@ -38,37 +37,73 @@ export function resolveIdentityAvatarView(identity: IdentityAvatarInput): Identi
   };
 }
 
-/** Reconcile changed images without overwriting event fallback on unchanged rerenders. */
-export function identityAvatarClass(
-  className: string,
-  view: Pick<IdentityAvatarView, "imageUrl" | "pending">,
-) {
-  return guard([className, view.imageUrl, view.pending], () =>
-    live(`${className}${view.pending ? " is-fallback" : ""}`),
-  );
+type AvatarState = "none" | "pending" | "loaded" | "failed";
+
+function setAvatarState(element: Element, state: AvatarState) {
+  element.setAttribute("data-avatar-state", state);
+  element.classList.toggle("is-pending", state === "pending");
+  element.classList.toggle("is-fallback", state === "none" || state === "failed");
 }
+
+class IdentityAvatarClassDirective extends Directive {
+  private hasImage = false;
+
+  override render(className: string, _view: Pick<IdentityAvatarView, "imageUrl" | "pending">) {
+    return className;
+  }
+
+  override update(part: AttributePart, [className, view]: Parameters<this["render"]>) {
+    if (!view.imageUrl) {
+      setAvatarState(part.element, view.pending ? "pending" : "none");
+    } else if (!this.hasImage) {
+      setAvatarState(part.element, "pending");
+    }
+    this.hasImage = Boolean(view.imageUrl);
+    const state = part.element.getAttribute("data-avatar-state");
+    return `${className}${state === "pending" ? " is-pending" : state === "none" || state === "failed" ? " is-fallback" : ""}`;
+  }
+}
+
+/** Preserve image-event state when Lit reconciles an unchanged source. */
+export const identityAvatarClass = directive(IdentityAvatarClassDirective);
 
 function settleIdentityAvatarImage(event: Event, fallbackSelector: string, failed: boolean): void {
   const image = event.currentTarget;
   if (!(image instanceof HTMLImageElement)) {
     return;
   }
-  image.closest<HTMLElement>(fallbackSelector)?.classList.toggle("is-fallback", failed);
+  const wrapper = image.closest(fallbackSelector);
+  if (wrapper) {
+    setAvatarState(wrapper, failed ? "failed" : "loaded");
+  }
 }
 
 // Each rendered image owns its resource until replacement or disconnect.
 class IdentityAvatarImageDirective extends UntilDirective<unknown> {
-  private part?: Part;
+  private part?: AttributePart;
   private sourceUrl?: string;
   private imageUrl: IdentityAvatarView["imageUrl"] = null;
   private release?: () => void;
   private value: unknown = nothing;
+  private resolvedUrl: string | null = null;
+  private fallbackSelector = "";
 
-  override render(_imageUrl: IdentityAvatarView["imageUrl"], _sourceUrl?: string) {
+  override render(
+    _imageUrl: IdentityAvatarView["imageUrl"],
+    _sourceUrl: string | undefined,
+    _fallbackSelector: string,
+  ) {
     return nothing;
   }
 
-  override update(part: Part, [value, sourceUrl]: [IdentityAvatarView["imageUrl"], string?]) {
+  override update(
+    part: AttributePart,
+    [value, sourceUrl, fallbackSelector]: [
+      IdentityAvatarView["imageUrl"],
+      string | undefined,
+      string,
+    ],
+  ) {
     // Only Gateway avatars need reacquisition; public image URLs stay on the page.
     const inputUrl = sourceUrl ?? (typeof value === "string" ? value : undefined);
     const avatarUrl = inputUrl
@@ -76,6 +111,7 @@ class IdentityAvatarImageDirective extends UntilDirective<unknown> {
       : null;
     const imageUrl = avatarUrl && value === inputUrl ? resolveAvatarImageUrl(avatarUrl) : value;
     this.part = part;
+    this.fallbackSelector = fallbackSelector;
     this.sourceUrl = avatarUrl ?? undefined;
     if (imageUrl !== this.imageUrl || !this.release) {
       const release = this.isConnected ? retainAvatarImageUrl(imageUrl) : undefined;
@@ -87,7 +123,47 @@ class IdentityAvatarImageDirective extends UntilDirective<unknown> {
           ? imageUrl
           : (imageUrl?.then((url) => url ?? nothing) ?? nothing);
     }
-    return super.update(part, [this.value, nothing]);
+    const result = super.update(part, [this.value, nothing]);
+    this.reconcileSource(result, false);
+    return result;
+  }
+
+  override setValue(value: unknown) {
+    super.setValue(value);
+    this.reconcileSource(value, true);
+  }
+
+  private reconcileSource(value: unknown, settled: boolean) {
+    if (value === noChange || !this.part) {
+      return;
+    }
+    const image = this.part.element;
+    if (!(image instanceof HTMLImageElement)) {
+      return;
+    }
+    const url = typeof value === "string" ? value : null;
+    if (url !== this.resolvedUrl || !url) {
+      this.resolvedUrl = url;
+      const wrapper = image.closest(this.fallbackSelector);
+      if (wrapper) {
+        setAvatarState(wrapper, !url && settled ? "failed" : "pending");
+      }
+    }
+    // Attribute directives run before src is committed; cached decodes need no new event.
+    queueMicrotask(() => {
+      if (
+        url &&
+        this.resolvedUrl === url &&
+        image.getAttribute("src") === url &&
+        image.complete &&
+        image.naturalWidth > 0
+      ) {
+        const wrapper = image.closest(this.fallbackSelector);
+        if (wrapper) {
+          setAvatarState(wrapper, "loaded");
+        }
+      }
+    });
   }
 
   override disconnected() {
@@ -99,7 +175,7 @@ class IdentityAvatarImageDirective extends UntilDirective<unknown> {
   override reconnected() {
     if (this.part) {
       const imageUrl = this.sourceUrl ? resolveAvatarImageUrl(this.sourceUrl) : this.imageUrl;
-      this.setValue(this.update(this.part, [imageUrl, this.sourceUrl]));
+      this.setValue(this.update(this.part, [imageUrl, this.sourceUrl, this.fallbackSelector]));
     }
     super.reconnected();
   }
@@ -129,7 +205,7 @@ export function renderIdentityAvatarImage({
   }
   return html`<img
     class=${className ?? nothing}
-    src=${identityAvatarImage(view.imageUrl, view.sourceUrl)}
+    src=${identityAvatarImage(view.imageUrl, view.sourceUrl, fallbackSelector)}
     alt=${alt}
     aria-hidden=${ariaHidden ? "true" : nothing}
     referrerpolicy="no-referrer"
@@ -143,7 +219,13 @@ export function renderIdentityAvatarImage({
 
 /** Agent images and emoji share one fallback across every surface. */
 export function renderAgentIdentityAvatar(
-  agent: { id: string; name?: string; avatar?: string | null; textAvatar?: string | null },
+  agent: {
+    id: string;
+    name?: string;
+    avatar?: string | null;
+    textAvatar?: string | null;
+    pending?: boolean;
+  },
   className = "",
   onImageError?: () => void,
 ) {
@@ -155,11 +237,12 @@ export function renderAgentIdentityAvatar(
       aria-hidden=${agent.name ? nothing : "true"}
     />`;
   }
-  const imageUrl = agent.avatar ? (resolveAvatarImageUrl(agent.avatar) ?? agent.avatar) : null;
+  const imageUrl =
+    agent.avatar && !agent.pending ? (resolveAvatarImageUrl(agent.avatar) ?? agent.avatar) : null;
   const view = {
     imageUrl,
     sourceUrl: agent.avatar ?? undefined,
-    pending: typeof imageUrl !== "string",
+    pending: agent.pending ?? imageUrl !== null,
   };
   return html`<span
     class=${identityAvatarClass(`identity-avatar--agent ${className}`, view)}

--- a/ui/src/components/sidebar-agent-card.ts
+++ b/ui/src/components/sidebar-agent-card.ts
@@ -35,10 +35,8 @@ class SidebarAgentCard extends OpenClawLightDomContentsElement {
 
   private renderContent() {
     const sourceUrl = this.avatarUrl;
-    const avatarUrl =
-      sourceUrl && (!sourceUrl.startsWith("/") || this.avatarAuthReady)
-        ? this.avatarLoader.resolve(sourceUrl)
-        : null;
+    const pending = Boolean(sourceUrl?.startsWith("/") && !this.avatarAuthReady);
+    const avatarUrl = sourceUrl && !pending ? this.avatarLoader.resolve(sourceUrl) : null;
     const menuLabel = this.switcherAvailable
       ? t("agentChip.switchAgent")
       : t("agentChip.menuLabel");
@@ -73,7 +71,7 @@ class SidebarAgentCard extends OpenClawLightDomContentsElement {
               this.environment ? "sidebar-agent-card__avatar--environment" : ""
             }"
           >
-            ${renderAgentIdentityAvatar({ id: this.agentId, avatar: avatarUrl, textAvatar: this.avatarText }, "", sourceUrl ? this.avatarLoader.imageErrorHandler(sourceUrl) : undefined)}
+            ${renderAgentIdentityAvatar({ id: this.agentId, avatar: avatarUrl, textAvatar: this.avatarText, pending }, "", sourceUrl ? this.avatarLoader.imageErrorHandler(sourceUrl) : undefined)}
             ${
               this.menuUnread && !this.menuOpen
                 ? html`<span

--- a/ui/src/e2e/agent-select-avatar-timeout.e2e.test.ts
+++ b/ui/src/e2e/agent-select-avatar-timeout.e2e.test.ts
@@ -1,7 +1,8 @@
 // Control UI tests cover bounded authenticated agent-picker avatar fetches.
 import path from "node:path";
-import type { Page } from "playwright";
+import type { Page, Route } from "playwright";
 import { beforeEach, expect, it } from "vitest";
+import type { AgentSelect } from "../components/agent-select.ts";
 import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
 import {
@@ -36,81 +37,123 @@ async function screenshot(page: Page, name: string) {
 }
 
 suite.define(() => {
-  it("aborts a stalled authenticated avatar request and keeps the generated face", async () => {
-    await suite.withPage(createControlUiE2eContextOptions(), async ({ page }) => {
-      await page.clock.install();
+  it.each(["timeout", "loaded", "invalid image"] as const)(
+    "keeps the avatar blank while pending, then handles %s without layout shifts",
+    async (outcome) => {
+      await suite.withPage(createControlUiE2eContextOptions(), async ({ page }) => {
+        await page.clock.install();
 
-      let avatarRequestCount = 0;
-      let avatarAuthorization: string | undefined;
-      const failedAvatarRequests: string[] = [];
-      page.on("requestfailed", (request) => {
-        if (new URL(request.url()).pathname === "/avatar/main") {
-          failedAvatarRequests.push(request.failure()?.errorText ?? "unknown");
+        let avatarRequestCount = 0;
+        let avatarAuthorization: string | undefined;
+        let avatarRoute: Route | undefined;
+        const failedAvatarRequests: string[] = [];
+        page.on("requestfailed", (request) => {
+          if (new URL(request.url()).pathname === "/avatar/main") {
+            failedAvatarRequests.push(request.failure()?.errorText ?? "unknown");
+          }
+        });
+        await page.route(/\/avatar\/main$/, (route) => {
+          avatarRequestCount += 1;
+          avatarAuthorization = route.request().headers().authorization;
+          avatarRoute = route;
+          // Hold the response until the pending avatar has been inspected.
+        });
+        const gateway = await installMockGateway(page, {
+          methodResponses: {
+            "agent.identity.get": {
+              cases: [
+                {
+                  match: { agentId: "main" },
+                  response: {
+                    agentId: "main",
+                    avatar: "/avatar/main",
+                    avatarStatus: "local",
+                    name: "Main agent",
+                  },
+                },
+                {
+                  match: { agentId: "writer" },
+                  response: {
+                    agentId: "writer",
+                    avatar: "",
+                    avatarStatus: "none",
+                    name: "Writer",
+                  },
+                },
+              ],
+            },
+            "agents.list": {
+              agents: [
+                { id: "main", name: "OpenClaw" },
+                { id: "writer", name: "Writer" },
+              ],
+              defaultId: "main",
+              mainKey: "main",
+              scope: "agent",
+            },
+          },
+        });
+
+        const response = await page.goto(`${suite.server.baseUrl}settings/agents`);
+        expect(response?.status()).toBe(200);
+        await gateway.waitForRequest("agent.identity.get");
+        await expect.poll(() => avatarRequestCount).toBe(1);
+        const picker = page.locator("openclaw-agent-select");
+        const avatar = picker.locator(".agent-select__trigger .agent-select__avatar");
+        const fallback = avatar.locator(".identity-avatar__fallback");
+        await expect.poll(() => avatar.getAttribute("data-avatar-state")).toBe("pending");
+        await expect.poll(() => fallback.isVisible()).toBe(false);
+        const pendingBox = await avatar.boundingBox();
+        expect(pendingBox?.width).toBeGreaterThan(0);
+        expect(avatarAuthorization).toBe("Bearer e2e-device-token");
+        await screenshot(page, "01-request-stalled.png");
+
+        if (outcome === "timeout") {
+          await page.clock.runFor(30_000);
+          await expect.poll(() => failedAvatarRequests.length).toBe(1);
+        } else {
+          if (!avatarRoute) {
+            throw new Error("Avatar request was not intercepted");
+          }
+          await avatarRoute.fulfill({
+            contentType: "image/svg+xml",
+            body:
+              outcome === "loaded"
+                ? '<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32"><circle cx="16" cy="16" r="16" fill="coral"/></svg>'
+                : "not an image",
+          });
         }
-      });
-      await page.route(/\/avatar\/main$/, (route) => {
-        avatarRequestCount += 1;
-        avatarAuthorization = route.request().headers().authorization;
-        // Leave the route unanswered. The page-owned deadline must cancel it.
-      });
-      const gateway = await installMockGateway(page, {
-        methodResponses: {
-          "agent.identity.get": {
-            cases: [
-              {
-                match: { agentId: "main" },
-                response: {
-                  agentId: "main",
-                  avatar: "/avatar/main",
-                  avatarStatus: "local",
-                  name: "Main agent",
-                },
-              },
-              {
-                match: { agentId: "writer" },
-                response: {
-                  agentId: "writer",
-                  avatar: "",
-                  avatarStatus: "none",
-                  name: "Writer",
-                },
-              },
-            ],
-          },
-          "agents.list": {
-            agents: [
-              { id: "main", name: "OpenClaw" },
-              { id: "writer", name: "Writer" },
-            ],
-            defaultId: "main",
-            mainKey: "main",
-            scope: "agent",
-          },
-        },
-      });
+        if (outcome === "loaded") {
+          await expect.poll(() => avatar.getAttribute("data-avatar-state")).toBe("loaded");
+          expect(await avatar.locator("img").isVisible()).toBe(true);
+          expect(await fallback.isVisible()).toBe(false);
+        } else {
+          await expect
+            .poll(() => avatar.locator(".identity-avatar__agent-face").isVisible())
+            .toBe(true);
+        }
+        const settledBox = await avatar.boundingBox();
+        expect(settledBox?.width).toBe(pendingBox?.width);
+        expect(settledBox?.height).toBe(pendingBox?.height);
 
-      const response = await page.goto(`${suite.server.baseUrl}settings/agents`);
-      expect(response?.status()).toBe(200);
-      await gateway.waitForRequest("agent.identity.get");
-      await expect.poll(() => avatarRequestCount).toBe(1);
-      const picker = page.locator("openclaw-agent-select");
-      await expect
-        .poll(() => picker.locator(".identity-avatar__agent-face").first().count())
-        .toBe(1);
-      expect(avatarAuthorization).toBe("Bearer e2e-device-token");
-      await screenshot(page, "01-request-stalled.png");
-
-      await page.clock.runFor(30_000);
-      await expect.poll(() => failedAvatarRequests.length).toBe(1);
-      await expect.poll(() => picker.locator(".agent-select__avatar img").count()).toBe(0);
-      await expect
-        .poll(() => picker.locator(".identity-avatar__agent-face").first().count())
-        .toBe(1);
-
-      // A later render must use the cached miss instead of launching another fetch.
-      await picker.locator(".agent-select__trigger").click();
-      expect(avatarRequestCount).toBe(1);
-      await screenshot(page, "02-timeout-fallback.png");
-    });
-  });
+        // Updating the label rerenders the existing image without changing its source.
+        await picker.evaluate(async (element: AgentSelect) => {
+          element.accessibleLabel = "Choose agent";
+          await element.updateComplete;
+        });
+        await expect
+          .poll(() => picker.locator(".agent-select__trigger").getAttribute("aria-label"))
+          .toMatch(/^Choose agent:/);
+        await picker.locator(".agent-select__trigger").click();
+        if (outcome === "loaded") {
+          expect(await avatar.getAttribute("data-avatar-state")).toBe("loaded");
+          expect(await fallback.isVisible()).toBe(false);
+        } else {
+          expect(await avatar.locator(".identity-avatar__agent-face").isVisible()).toBe(true);
+        }
+        expect(avatarRequestCount).toBe(1);
+        await screenshot(page, `02-${outcome.replaceAll(" ", "-")}.png`);
+      });
+    },
+  );
 });

--- a/ui/src/e2e/chat-agent-avatar.real-gateway.e2e.test.ts
+++ b/ui/src/e2e/chat-agent-avatar.real-gateway.e2e.test.ts
@@ -87,8 +87,9 @@ suite.define(() => {
       );
     }
     const dashboard = await owner.cli(["dashboard", "--json"]);
-    expect(dashboard.code, dashboard.stderr).toBe(0);
-    const issued = new URL((JSON.parse(dashboard.stdout) as { browserUrl: string }).browserUrl);
+    const handoff: { browserUrl: string; reason?: string } = JSON.parse(dashboard.stdout);
+    expect(dashboard.code, handoff.reason ?? dashboard.stderr).toBe(0);
+    const issued = new URL(handoff.browserUrl);
     const url = new URL(controlUiSessionUrl(suite.server.baseUrl, sessionKey, "chat"));
     url.hash = issued.hash;
     await suite.withPage(

--- a/ui/src/e2e/profile-page.e2e.test.ts
+++ b/ui/src/e2e/profile-page.e2e.test.ts
@@ -316,7 +316,7 @@ suite.define(() => {
         );
 
         await gateway.waitForRequest("agent.identity.get");
-        const image = page.locator(".profile-hero__avatar-image");
+        const image = page.locator(".profile-hero__avatar .identity-avatar__image");
         await image.waitFor({ timeout: 10_000 });
         await expect.poll(() => image.getAttribute("src")).toMatch(/^blob:/u);
         await expect
@@ -497,7 +497,7 @@ suite.define(() => {
         await expect(page.locator(".sidebar-identity-card__name")).toHaveText(updatedDisplayName);
         expect(
           await originalSidebarImage?.evaluate((image) =>
-            image.closest(".viewer-avatar")?.classList.contains("is-fallback"),
+            image.closest(".viewer-avatar")?.classList.contains("is-pending"),
           ),
         ).toBe(true);
         expect(await originalSidebarImage?.evaluate((image) => image.isConnected)).toBe(true);

--- a/ui/src/lib/identity-avatar-loader.ts
+++ b/ui/src/lib/identity-avatar-loader.ts
@@ -222,7 +222,8 @@ export class IdentityAvatarController implements ReactiveController {
       return cached.url;
     }
     const route: { url: string | null; result: typeof result; release?: () => void } = {
-      url: null,
+      // Keep the configured source visible to renderers until the shared fetch settles.
+      url: value,
       result,
       release: retainAvatarImageUrl(result),
     };

--- a/ui/src/pages/agents/view.identity-avatar.test.ts
+++ b/ui/src/pages/agents/view.identity-avatar.test.ts
@@ -118,8 +118,9 @@ it("fetches a persisted settings avatar with the bearer credential", async () =>
   const view = await createView();
 
   try {
-    expect(avatarImage(view)).toBeNull();
-    await expectAvatarFallback(view);
+    const avatar = view.querySelector(".agent-identity-editor__avatar .identity-avatar--agent");
+    expect(avatar?.classList).toContain("is-pending");
+    expect(avatar?.classList).not.toContain("is-fallback");
     expect(fetchAvatar).toHaveBeenCalledWith(
       `${globalThis.location.origin}/avatar/beta?v=1`,
       expect.objectContaining({
@@ -133,6 +134,9 @@ it("fetches a persisted settings avatar with the bearer credential", async () =>
     await waitForFast(() => {
       expect(avatarImage(view)?.getAttribute("src")).toBe("blob:settings-avatar-1");
     });
+    expect(avatar?.classList).toContain("is-pending");
+    avatarImage(view)?.dispatchEvent(new Event("load"));
+    expect(avatar?.classList).not.toContain("is-pending");
     expect(fetchAvatar).toHaveBeenCalledOnce();
     expect(createObjectURL).toHaveBeenCalledOnce();
   } finally {

--- a/ui/src/pages/chat/chat-avatar.test.ts
+++ b/ui/src/pages/chat/chat-avatar.test.ts
@@ -208,7 +208,7 @@ describe("renderChatAvatar", () => {
     renderUser();
     const slot = container.querySelector<HTMLElement>(".chat-avatar-slot");
     const image = slot?.querySelector("img");
-    expect(slot?.classList.contains("is-fallback")).toBe(true);
+    expect(slot?.classList.contains("is-pending")).toBe(true);
     expect(image?.hasAttribute("src")).toBe(false);
     expect(slot?.querySelector(".chat-avatar--sender-initials")?.textContent?.trim()).toBe("H");
     await expect(resolveAvatarImageUrl(avatarUrl)).resolves.toBeNull();
@@ -831,7 +831,7 @@ describe("attributed sender avatars", () => {
       }),
       container,
     );
-    expect(container.querySelector(".chat-avatar-slot")?.classList.contains("is-fallback")).toBe(
+    expect(container.querySelector(".chat-avatar-slot")?.classList.contains("is-pending")).toBe(
       true,
     );
     const secondImage = await vi.waitFor(() => {
@@ -924,13 +924,16 @@ describe("attributed sender avatars", () => {
       render(renderChatAvatar("user", undefined, undefined, sender), container);
 
     renderSender();
-    expect(container.querySelector(".chat-avatar-slot")?.classList.contains("is-fallback")).toBe(
+    expect(container.querySelector(".chat-avatar-slot")?.classList.contains("is-pending")).toBe(
       true,
     );
     expect(container.querySelector(".chat-avatar--sender-initials")?.textContent?.trim()).toBe("H");
     await vi.waitFor(() => {
       expect(fetchAvatar).toHaveBeenCalledOnce();
       expect(container.querySelector(".chat-avatar-slot img")?.hasAttribute("src")).toBe(false);
+      expect(container.querySelector(".chat-avatar-slot")?.classList.contains("is-fallback")).toBe(
+        true,
+      );
     });
     expect(fetchAvatar).toHaveBeenCalledWith(
       `${gatewayOrigin}/api/users/${sender.id}/avatar`,

--- a/ui/src/pages/profile/profile-hero.test.ts
+++ b/ui/src/pages/profile/profile-hero.test.ts
@@ -20,14 +20,12 @@ afterEach(() => {
   document.body.replaceChildren();
 });
 
-it("keeps the connected person's hero independent of the default agent and live name updates", () => {
+it("keeps the connected person's hero independent of the default agent and live name updates", async () => {
   const props = {
     row: { id: "clipper", name: "Clipper" },
     identity: null,
     user: { id: "person-1", name: "Ada", email: "ada@example.test" },
-    resolveImageUrl: vi.fn(() => null),
-    failedAvatarUrl: null,
-    onAvatarError: vi.fn(),
+    avatarLoader: { resolve: vi.fn(() => null), imageErrorHandler: vi.fn(() => vi.fn()) },
   };
   render(renderProfileHero(props), container);
   expect(container.querySelector(".profile-hero__name")?.textContent).toBe("Ada");
@@ -38,12 +36,16 @@ it("keeps the connected person's hero independent of the default agent and live 
 
   render(renderProfileHero({ ...props, user: { ...props.user, name: "Ada Lovelace" } }), container);
   expect(container.querySelector(".profile-hero__name")?.textContent).toBe("Ada Lovelace");
-  expect(props.resolveImageUrl).not.toHaveBeenCalled();
+  expect(props.avatarLoader.resolve).not.toHaveBeenCalled();
 
   render(renderProfileHero({ ...props, user: null }), container);
   expect(container.querySelector(".profile-hero__name")?.textContent).toBe("Clipper");
   expect(container.querySelector(".profile-hero__handle")?.textContent).toContain("@clipper");
-  expect(container.querySelector(".profile-hero__avatar-mascot svg")).not.toBeNull();
+  await waitForFast(() =>
+    expect(
+      container.querySelector(".profile-hero__avatar .identity-avatar__agent-face"),
+    ).not.toBeNull(),
+  );
 
   render(renderProfileHero({ ...props, user: { id: "gateway-owner" } }), container);
   expect(container.querySelector(".profile-hero__name")?.textContent).toBe(t("nav.owner"));

--- a/ui/src/pages/profile/profile-hero.ts
+++ b/ui/src/pages/profile/profile-hero.ts
@@ -1,19 +1,19 @@
 import { html, nothing } from "lit";
 import type { AgentIdentityResult, AgentsListResult } from "../../api/types.ts";
 import type { AuthenticatedUser } from "../../app/user-profile.ts";
-import { icons } from "../../components/icons.ts";
+import { renderAgentIdentityAvatar } from "../../components/identity-avatar-view.ts";
 import { renderSettingsGroup } from "../../components/settings-ui.ts";
 import { t } from "../../i18n/index.ts";
-import { resolveAgentAvatarUrl, resolveAssistantTextAvatar } from "../../lib/avatar.ts";
+import { resolveAgentTextAvatar } from "../../lib/agents/display.ts";
+import { resolveAgentAvatarUrl } from "../../lib/avatar.ts";
+import type { IdentityAvatarController } from "../../lib/identity-avatar-loader.ts";
 import "../../components/viewer-facepile.ts";
 
 export type ProfileHeroProps = {
   user?: AuthenticatedUser | null;
   row: AgentsListResult["agents"][number];
   identity: AgentIdentityResult | null | undefined;
-  resolveImageUrl: (avatarUrl: string) => string | null;
-  failedAvatarUrl: string | null;
-  onAvatarError: (avatarUrl: string) => void;
+  avatarLoader: Pick<IdentityAvatarController, "resolve" | "imageErrorHandler">;
 };
 
 function renderHeroAvatar(props: ProfileHeroProps, name: string) {
@@ -24,23 +24,16 @@ function renderHeroAvatar(props: ProfileHeroProps, name: string) {
     ></openclaw-viewer-avatar>`;
   }
   const avatarUrl = resolveAgentAvatarUrl(props.row, props.identity);
-  const textAvatar =
-    resolveAssistantTextAvatar(props.identity?.avatar) ??
-    resolveAssistantTextAvatar(props.row.identity?.emoji) ??
-    resolveAssistantTextAvatar(props.row.identity?.avatar);
-  const imageUrl = avatarUrl?.startsWith("/") ? props.resolveImageUrl(avatarUrl) : avatarUrl;
-  if (avatarUrl && avatarUrl !== props.failedAvatarUrl && imageUrl) {
-    return html`<img
-      class="profile-hero__avatar-image"
-      src=${imageUrl}
-      alt=${name}
-      @error=${() => props.onAvatarError(avatarUrl)}
-    />`;
-  }
-  if (textAvatar) {
-    return html`<span class="profile-hero__avatar-text">${textAvatar}</span>`;
-  }
-  return html`<span class="profile-hero__avatar-mascot" aria-hidden="true">${icons.lobster}</span>`;
+  return renderAgentIdentityAvatar(
+    {
+      id: props.row.id,
+      name,
+      avatar: avatarUrl ? props.avatarLoader.resolve(avatarUrl) : null,
+      textAvatar: resolveAgentTextAvatar(props.row, props.identity),
+    },
+    "",
+    avatarUrl ? props.avatarLoader.imageErrorHandler(avatarUrl) : undefined,
+  );
 }
 
 export function renderProfileHero(props: ProfileHeroProps) {

--- a/ui/src/pages/profile/profile-page.test.ts
+++ b/ui/src/pages/profile/profile-page.test.ts
@@ -516,15 +516,17 @@ it("falls back to the text avatar when the hero image fails to load", async () =
   const page = mountProfilePage(harness.context);
 
   await page.updateComplete;
-  const image = page.querySelector<HTMLImageElement>(".profile-hero__avatar-image");
+  const avatar = page.querySelector(".profile-hero__avatar .identity-avatar--agent")!;
+  const image = avatar.querySelector("img");
   expect(image?.getAttribute("src")).toBe("data:image/png;base64,unloadable");
-  expect(page.querySelector(".profile-hero__avatar-text")).toBeNull();
+  expect(avatar.classList).toContain("is-pending");
 
   image?.dispatchEvent(new Event("error"));
   await page.updateComplete;
 
-  expect(page.querySelector(".profile-hero__avatar-image")).toBeNull();
-  expect(page.querySelector(".profile-hero__avatar-text")?.textContent).toBe("🦞");
+  expect(avatar.querySelector("img")).toBeNull();
+  expect(avatar.classList).toContain("is-fallback");
+  expect(avatar.querySelector(".identity-avatar__text")?.getAttribute("data-avatar")).toBe("🦞");
 });
 
 it("fetches a protected hero avatar with the current Control UI credential", async () => {
@@ -572,7 +574,9 @@ it("fetches a protected hero avatar with the current Control UI credential", asy
       signal: expect.any(AbortSignal),
     });
     expect(
-      page.querySelector<HTMLImageElement>(".profile-hero__avatar-image")?.getAttribute("src"),
+      page
+        .querySelector<HTMLImageElement>(".profile-hero__avatar .identity-avatar__image")
+        ?.getAttribute("src"),
     ).toBe("blob:hero-avatar");
   });
 

--- a/ui/src/pages/profile/profile-page.ts
+++ b/ui/src/pages/profile/profile-page.ts
@@ -71,7 +71,6 @@ export class ProfilePage extends OpenClawLightDomElement {
   @state() private identityLoading = false;
   @state() private identityBusy: IdentityChange["kind"] | null = null;
   @state() private identityError: string | null = null;
-  @state() private failedHeroAvatarUrl: string | null = null;
 
   private client: GatewayBrowserClient | null = null;
   private connected = false;
@@ -378,11 +377,7 @@ export class ProfilePage extends OpenClawLightDomElement {
       row,
       user: this.selfUser,
       identity: this.context.agentIdentity.get(agentId),
-      resolveImageUrl: (avatarUrl) => this.heroAvatarLoader.resolve(avatarUrl),
-      failedAvatarUrl: this.failedHeroAvatarUrl,
-      onAvatarError: (avatarUrl) => {
-        this.failedHeroAvatarUrl = avatarUrl;
-      },
+      avatarLoader: this.heroAvatarLoader,
     });
   }
 

--- a/ui/src/styles/identity-avatar.css
+++ b/ui/src/styles/identity-avatar.css
@@ -25,7 +25,17 @@
 }
 
 .identity-avatar--agent:not(.is-fallback) > .identity-avatar__image + .identity-avatar__fallback,
-.identity-avatar--agent.is-fallback > .identity-avatar__image {
+.identity-avatar--agent.is-fallback > .identity-avatar__image,
+.identity-avatar--agent.is-pending > * {
+  visibility: hidden;
+}
+
+:is(.identity-avatar--agent, .viewer-avatar, .chat-author-avatar, .chat-avatar-slot).is-pending {
+  background: var(--secondary);
+  border-radius: var(--radius-full);
+}
+
+:is(.viewer-avatar, .chat-author-avatar, .chat-avatar-slot).is-pending > * {
   visibility: hidden;
 }
 

--- a/ui/src/styles/profile.css
+++ b/ui/src/styles/profile.css
@@ -32,21 +32,9 @@
   font-size: 42px;
 }
 
-.profile-hero__avatar-image {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-}
-
-.profile-hero__avatar-text {
+.profile-hero__avatar > .identity-avatar--agent {
   font-size: 42px;
   line-height: 1;
-}
-
-.profile-hero__avatar-mascot svg {
-  width: 56px;
-  height: 56px;
-  display: block;
 }
 
 .profile-hero__name {

--- a/ui/src/test-helpers/app-sidebar-cases/agent-menu.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/agent-menu.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../../test/helpers/promise.js";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { AgentsListResult } from "../../api/types.ts";
 import { createAgentIdentityCapability } from "../../lib/agents/identity.ts";
@@ -24,6 +25,26 @@ function pointerEvent(type: "pointerenter" | "pointerleave", pointerType = "mous
 }
 
 describe("AppSidebar agent chip", () => {
+  it("keeps a configured avatar blank while waiting for authentication", async () => {
+    const gateway = createGatewayHarness({} as GatewayBrowserClient);
+    gateway.publish({ hello: null });
+    const fetchAvatar = vi.spyOn(globalThis, "fetch");
+    const { sidebar } = await mountSidebar(
+      gateway.gateway,
+      createSessions("main", ["agent:main:main"]),
+      "panel",
+      {
+        ...TWO_AGENTS,
+        agents: [{ id: "main", identity: { avatarUrl: "/avatar/main", emoji: "🦞" } }],
+      },
+    );
+    const avatar = sidebar.querySelector(".sidebar-agent-card__avatar .identity-avatar--agent");
+    expect(avatar?.classList).toContain("is-pending");
+    expect(avatar?.classList).not.toContain("is-fallback");
+    expect(avatar?.querySelector("img")).toBeNull();
+    expect(fetchAvatar).not.toHaveBeenCalled();
+  });
+
   it("loads the workspace identity used by the Agents editor", async () => {
     const request = vi.fn().mockResolvedValue({
       agentId: "main",
@@ -648,10 +669,8 @@ describe("AppSidebar agent chip", () => {
         static override revokeObjectURL = vi.fn();
       },
     );
-    const fetchMock = vi.fn().mockResolvedValue({
-      ok: true,
-      blob: async () => new Blob(["avatar"], { type: "image/png" }),
-    });
+    const response = createDeferred<Response>();
+    const fetchMock = vi.fn<typeof fetch>().mockReturnValue(response.promise);
     vi.stubGlobal("fetch", fetchMock);
     setAvatarGatewayOrigin(globalThis.location.origin, ["secret-token"]);
     try {
@@ -678,7 +697,13 @@ describe("AppSidebar agent chip", () => {
         ...(menu?.querySelectorAll<HTMLElement>(".sidebar-agent-menu__agent-switch") ?? []),
       ].find((row) => row.textContent?.includes("research"));
       expect(researchRow).toBeDefined();
+      const avatar = researchRow?.querySelector(".agent-select__avatar");
+      expect(avatar?.classList).toContain("is-pending");
+      expect(avatar?.classList).not.toContain("is-fallback");
 
+      response.resolve(
+        new Response(new Uint8Array([1, 2, 3]), { headers: { "content-type": "image/png" } }),
+      );
       await vi.waitFor(() => {
         expect(
           researchRow
@@ -686,6 +711,9 @@ describe("AppSidebar agent chip", () => {
             ?.getAttribute("src"),
         ).toBe("blob:agent-avatar");
       });
+      expect(avatar?.classList).toContain("is-pending");
+      avatar?.querySelector("img")?.dispatchEvent(new Event("load"));
+      expect(avatar?.classList).not.toContain("is-pending");
       expect(createObjectURL).toHaveBeenCalledTimes(1);
       expect(fetchMock).toHaveBeenCalledWith(
         `${globalThis.location.origin}/avatar/research?v=140879`,
@@ -694,6 +722,7 @@ describe("AppSidebar agent chip", () => {
         }),
       );
     } finally {
+      response.resolve(new Response(null, { status: 404 }));
       setAvatarGatewayOrigin(null);
       vi.unstubAllGlobals();
     }


### PR DESCRIPTION
Related: #141476

<details>
<summary>Additional instructions</summary>

This branch is in the main repository, so maintainers can edit it directly. GitHub’s fork-collaboration toggle applies only to cross-repository PRs.

</details>

## What Problem This Solves

Fixes an issue where users opening agent surfaces would briefly see fallback faces or emoji while configured avatar images were still loading. It affected authenticated images in the sidebar, switcher, New conversation menu, Agents home, identity chips, settings, and chat.

## Why This Change Was Made

The shared renderer now distinguishes absent, pending, loaded, and failed images. Pending images keep a neutral background in the same box; only missing or failed images reveal fallback artwork. Controllers preserve configured sources during authenticated fetches, and the Profile agent avatar now uses the shared renderer instead of its separate image/failure path.

Image state survives unchanged-source rerenders, including the promise-to-blob handoff. Cached decoded images become loaded before paint, and adding an image to an existing fallback enters pending immediately. Existing resource leases, system-agent product marks, and the chat `img.chat-avatar.assistant` contract remain intact.

## User Impact

Configured avatars appear without flashing another identity first or shifting layout. Agents without an image still show their emoji or stable generated face. Updated Control UI documentation describes this behavior; release-owned changelogs are untouched.

## Evidence

- 1,241 unit tests passed across 17 renderer, sidebar/roster, Agents home, settings/Profile, and chat suites.
- 16 browser tests passed: delayed success/timeout/invalid-image states, emoji surfaces, Profile, and the isolated real-Gateway workspace-avatar flow beside a persisted assistant reply.
- Build and performance gate, i18n verification, architecture checks, and changed-file checks passed. The regression tests failed on the original behavior; the final review has no actionable findings.
- Production: +137/−69 (net +68); tests/support: +302/−108 (net +194); docs: +6/−1 (net +5). Removing the Profile avatar's duplicate failure path offsets part of the shared lifecycle change.

```text
startup JS gzip vs baseline: 352566 B (baseline 354540 B + growth allowance 512 B = growth limit 355052 B; build-variance allowance 64 B; enforcement limit 355116 B; max committed baseline 358400 B)
```

Synthetic `sidebar-roster` fixture at 1280×800, with avatar requests held by Playwright. Extra Agents home and chip/switcher captures are retained locally; the mock was stopped by port after capture.

Before: fallback artwork appears during the held image request.

![Before: fallback avatar while image request is pending](https://github.com/user-attachments/assets/be57a795-dc01-4580-b7cb-0016328715af)

After: a neutral placeholder occupies the same box while the request is pending.

![After: neutral pending avatar](https://github.com/user-attachments/assets/bb8df9b2-8dc6-4361-a654-7820bb07b652)

After the response: the configured image fills the same box.

![After: loaded configured avatar](https://github.com/user-attachments/assets/50c2c225-9333-451a-97e7-f11a0d505475)

Validation notes: the first real-Gateway attempt stopped at `dashboard --json` before browser assertions, with exit 1 and no stderr. The test now includes its structured failure reason in diagnostics; the final full rerun passed. No timeouts, retries, baselines, or assertions were weakened.
