### PR TITLE
fix(usage): refresh model prices after catalog writes

### DIFF
--- a/docs/reference/token-use.md
+++ b/docs/reference/token-use.md
@@ -227,6 +227,10 @@ works. Agent-local `models.json` prices take precedence over explicit
 `models.providers.*.models[].cost` entries, and both override catalog estimates,
 including explicit flat and zero rates.
 
+When the Gateway writes updated agent-local `models.json` prices, subsequent
+local estimates use those rates without a restart. Recorded per-call costs keep
+their original amounts.
+
 OpenRouter `:nitro` and `:floor` routing shortcuts use the base model's catalog
 estimate when the exact shortcut has no price. Recorded costs and explicit
 prices keep their precedence. Private endpoints and other model variants do not

--- a/src/agents/models-config-state.test-support.ts
+++ b/src/agents/models-config-state.test-support.ts
@@ -4,4 +4,5 @@ import { MODELS_JSON_STATE } from "./models-config-state.js";
 export function resetModelsJsonReadyCacheForTest(): void {
   MODELS_JSON_STATE.writeQueue = new KeyedAsyncQueue();
   MODELS_JSON_STATE.readyCache.clear();
+  MODELS_JSON_STATE.costCache.clear();
 }

--- a/src/agents/models-config-state.ts
+++ b/src/agents/models-config-state.ts
@@ -1,5 +1,7 @@
 // Process-wide models.json coordination state. Dynamic imports can load this
 // module multiple times, so Symbol.for keeps write locks and ready-cache shared.
+import type { RawModelCostConfig } from "@openclaw/llm-core";
+import type { ModelProviderConfig } from "../config/types.models.js";
 import { KeyedAsyncQueue } from "../plugin-sdk/keyed-async-queue.js";
 
 const MODELS_JSON_STATE_KEY = Symbol.for("openclaw.modelsJsonState");
@@ -9,14 +11,17 @@ export type ModelsJsonReadyResult = {
   wrote: boolean;
 };
 
-export type ModelsJsonReadyState = {
-  fingerprint: string;
-  result: ModelsJsonReadyResult;
+export type ModelKeyNormalizer = (provider: string, model: string) => string;
+
+type ModelsJsonCostCache = {
+  providers: Record<string, ModelProviderConfig> | undefined;
+  entries: WeakMap<ModelKeyNormalizer, Map<string, RawModelCostConfig>>;
 };
 
 type ModelsJsonState = {
   writeQueue: KeyedAsyncQueue;
-  readyCache: Map<string, Promise<ModelsJsonReadyState>>;
+  readyCache: Map<string, Promise<ModelsJsonReadyResult>>;
+  costCache: Map<string, ModelsJsonCostCache>;
 };
 
 export const MODELS_JSON_STATE = (() => {
@@ -26,7 +31,8 @@ export const MODELS_JSON_STATE = (() => {
   if (!globalState[MODELS_JSON_STATE_KEY]) {
     globalState[MODELS_JSON_STATE_KEY] = {
       writeQueue: new KeyedAsyncQueue(),
-      readyCache: new Map<string, Promise<ModelsJsonReadyState>>(),
+      readyCache: new Map(),
+      costCache: new Map(),
     };
   }
   return globalState[MODELS_JSON_STATE_KEY];

--- a/src/agents/models-config.ts
+++ b/src/agents/models-config.ts
@@ -30,11 +30,7 @@ import {
 } from "./agent-scope.js";
 import { resolveAuthProfileDatabasePath } from "./auth-profiles/sqlite.js";
 import type { AuthProfileStore } from "./auth-profiles/types.js";
-import {
-  MODELS_JSON_STATE,
-  type ModelsJsonReadyResult,
-  type ModelsJsonReadyState,
-} from "./models-config-state.js";
+import { MODELS_JSON_STATE, type ModelsJsonReadyResult } from "./models-config-state.js";
 import { planOpenClawModelsJson, type PreparedModelsConfigContext } from "./models-config.plan.js";
 import { repairPluginModelCatalogTransportMetadata } from "./plugin-model-catalog-repair.js";
 import {
@@ -44,11 +40,6 @@ import {
   replacePersistedPluginModelCatalogs,
   type PersistedPluginModelCatalog,
 } from "./plugin-model-catalog.js";
-
-type PreparedOpenClawModelsJsonSource = ModelsJsonReadyResult & {
-  fingerprint: string;
-  workspaceDir?: string;
-};
 
 type ModelsConfigPluginMetadataSnapshot = Pick<
   PluginMetadataSnapshot,
@@ -280,18 +271,14 @@ function prepareModelsConfigContext(
   };
 }
 
-async function withModelsJsonWriteLock<T>(targetPath: string, run: () => Promise<T>): Promise<T> {
-  return await MODELS_JSON_STATE.writeQueue.enqueue(targetPath, run);
-}
-
 /** Ensures models.json and the agent SQLite catalog cache are current. */
-async function prepareOpenClawModelsJsonSource(
+export async function ensureOpenClawModelsJson(
   config?: OpenClawConfig,
   agentDirOverride?: string,
   options: EnsureOpenClawModelsJsonOptions = {},
-): Promise<PreparedOpenClawModelsJsonSource> {
+): Promise<ModelsJsonReadyResult> {
   const context = prepareModelsConfigContext(config, agentDirOverride, options);
-  const { agentDir, workspaceDir } = context;
+  const { agentDir } = context;
   const targetPath = path.join(agentDir, "models.json");
   const fingerprint = await buildModelsJsonFingerprint(context);
   const cacheKey = modelsJsonReadyCacheKey(targetPath, fingerprint);
@@ -299,14 +286,10 @@ async function prepareOpenClawModelsJsonSource(
   if (cached && !options.onProviderCatalogOutcome) {
     const settled = await cached;
     await ensureModelsFileModeForModelsJson(targetPath);
-    return {
-      ...settled.result,
-      fingerprint: settled.fingerprint,
-      ...(workspaceDir ? { workspaceDir } : {}),
-    };
+    return { ...settled };
   }
 
-  const pending: Promise<ModelsJsonReadyState> = withModelsJsonWriteLock(targetPath, async () => {
+  const pending = MODELS_JSON_STATE.writeQueue.enqueue(targetPath, async () => {
     // Ensure config env vars (e.g. AWS_PROFILE, AWS_ACCESS_KEY_ID) are
     // are available to provider discovery without mutating process.env.
     const existingModelsFile = await readExistingModelsFile(targetPath);
@@ -322,7 +305,7 @@ async function prepareOpenClawModelsJsonSource(
         agentDir,
         pluginCatalogWrites: plan.pluginCatalogWrites,
       });
-      return { fingerprint, result: { agentDir, wrote: wrotePluginCatalog } };
+      return { agentDir, wrote: wrotePluginCatalog };
     }
 
     if (plan.action === "noop") {
@@ -331,7 +314,7 @@ async function prepareOpenClawModelsJsonSource(
         pluginCatalogWrites: plan.pluginCatalogWrites,
       });
       await ensureModelsFileModeForModelsJson(targetPath);
-      return { fingerprint, result: { agentDir, wrote: wrotePluginCatalog } };
+      return { agentDir, wrote: wrotePluginCatalog };
     }
 
     await fs.mkdir(agentDir, { recursive: true, mode: 0o700 });
@@ -339,13 +322,14 @@ async function prepareOpenClawModelsJsonSource(
     const wroteRoot = existingRoot !== plan.contents;
     if (wroteRoot) {
       await privateFileStore(path.dirname(targetPath)).writeText("models.json", plan.contents);
+      MODELS_JSON_STATE.costCache.delete(agentDir);
     }
     await ensureModelsFileModeForModelsJson(targetPath);
     const wrotePluginCatalog = writePluginCatalogsForModelsJson({
       agentDir,
       pluginCatalogWrites: plan.pluginCatalogWrites,
     });
-    return { fingerprint, result: { agentDir, wrote: wroteRoot || wrotePluginCatalog } };
+    return { agentDir, wrote: wroteRoot || wrotePluginCatalog };
   });
   MODELS_JSON_STATE.readyCache.set(cacheKey, pending);
   try {
@@ -354,16 +338,9 @@ async function prepareOpenClawModelsJsonSource(
     const refreshedCacheKey = modelsJsonReadyCacheKey(targetPath, refreshedFingerprint);
     if (refreshedCacheKey !== cacheKey) {
       MODELS_JSON_STATE.readyCache.delete(cacheKey);
-      MODELS_JSON_STATE.readyCache.set(
-        refreshedCacheKey,
-        Promise.resolve({ fingerprint: refreshedFingerprint, result: settled.result }),
-      );
+      MODELS_JSON_STATE.readyCache.set(refreshedCacheKey, Promise.resolve(settled));
     }
-    return {
-      ...settled.result,
-      fingerprint: refreshedFingerprint,
-      ...(workspaceDir ? { workspaceDir } : {}),
-    };
+    return { ...settled };
   } catch (error) {
     if (MODELS_JSON_STATE.readyCache.get(cacheKey) === pending) {
       MODELS_JSON_STATE.readyCache.delete(cacheKey);
@@ -402,14 +379,4 @@ export async function planOpenClawModelsJsonSource(
         ? existingPluginCatalogs
         : materializePlannedPluginCatalogs(plan.pluginCatalogWrites),
   };
-}
-
-/** Ensures models.json and the agent SQLite catalog cache are current. */
-export async function ensureOpenClawModelsJson(
-  config?: OpenClawConfig,
-  agentDirOverride?: string,
-  options: EnsureOpenClawModelsJsonOptions = {},
-): Promise<ModelsJsonReadyResult> {
-  const prepared = await prepareOpenClawModelsJsonSource(config, agentDirOverride, options);
-  return { agentDir: prepared.agentDir, wrote: prepared.wrote };
 }

--- a/src/agents/models-config.write-serialization.test.ts
+++ b/src/agents/models-config.write-serialization.test.ts
@@ -5,6 +5,10 @@ import { DatabaseSync } from "node:sqlite";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { resolveInstalledPluginIndexPolicyHash } from "../plugins/installed-plugin-index-policy.js";
 import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
+import {
+  resolveModelCostConfig,
+  resolveModelCostConfigFingerprint,
+} from "../utils/usage-format.js";
 import { resolveDefaultAgentDir } from "./agent-scope.js";
 import {
   CUSTOM_PROXY_MODELS_CONFIG,
@@ -192,6 +196,58 @@ beforeEach(() => {
 });
 
 describe("models-config write serialization", () => {
+  it("refreshes cached usage prices after publishing an agent's models.json", async () => {
+    await withModelsTempHome(async (home) => {
+      const configFor = (input: number) => ({
+        models: {
+          providers: {
+            fixture: {
+              baseUrl: "https://fixture.invalid/v1",
+              models: [
+                {
+                  id: "priced",
+                  name: "Priced",
+                  reasoning: false,
+                  input: ["text" as const],
+                  cost: { input, output: 2, cacheRead: 0, cacheWrite: 0 },
+                  contextWindow: 8192,
+                  maxTokens: 4096,
+                },
+              ],
+            },
+          },
+        },
+      });
+      const firstDir = path.join(home, "first");
+      const secondDir = path.join(home, "second");
+      const config = configFor(1);
+      const options = { pluginMetadataSnapshot: createPluginMetadataSnapshot(home) };
+      const price = (agentDir: string) =>
+        resolveModelCostConfig({
+          config,
+          agentDir,
+          provider: "fixture",
+          model: "priced",
+          allowPluginNormalization: false,
+        })?.input;
+      await ensureOpenClawModelsJson(config, firstDir, options);
+      await ensureOpenClawModelsJson(configFor(5), secondDir, options);
+      expect([price(firstDir), price(secondDir)]).toEqual([1, 5]);
+      const firstFingerprint = resolveModelCostConfigFingerprint(config, firstDir);
+      const secondFingerprint = resolveModelCostConfigFingerprint(config, secondDir);
+
+      const updated = await ensureOpenClawModelsJson(configFor(9), firstDir, options);
+
+      expect(updated).toEqual({ agentDir: firstDir, wrote: true });
+      expect(await readGeneratedModelsJson(firstDir)).toEqual({
+        providers: configFor(9).models.providers,
+      });
+      expect([price(firstDir), price(secondDir)]).toEqual([9, 5]);
+      expect(resolveModelCostConfigFingerprint(config, firstDir)).not.toBe(firstFingerprint);
+      expect(resolveModelCostConfigFingerprint(config, secondDir)).toBe(secondFingerprint);
+    });
+  });
+
   it("materializes an authoritative plugin catalog replacement without mutating state", async () => {
     await withModelsTempHome(async (home) => {
       const agentDir = path.join(home, "agent");

--- a/src/utils/usage-format.ts
+++ b/src/utils/usage-format.ts
@@ -20,6 +20,7 @@ import {
   resolveAgentDir,
   tryResolveDefaultAgentId,
 } from "../agents/agent-scope-config.js";
+import { MODELS_JSON_STATE, type ModelKeyNormalizer } from "../agents/models-config-state.js";
 import { normalizeProviderMapKeys } from "../agents/models-config.merge.js";
 import type { NormalizedUsage } from "../agents/usage.js";
 import { mergeModelCost } from "../config/model-cost.js";
@@ -38,12 +39,6 @@ import {
 export { formatTokenCount } from "./token-format.js";
 export type { ModelCostConfig } from "@openclaw/llm-core";
 
-type ModelKeyNormalizer = (provider: string, model: string) => string;
-type ModelsJsonCostCache = {
-  providers: Record<string, ModelProviderConfig> | undefined;
-  entries: WeakMap<ModelKeyNormalizer, Map<string, RawModelCostConfig>>;
-};
-
 type ProviderCostIndexSource = {
   model: NonNullable<ModelProviderConfig["models"]>[number];
   providerKey: string;
@@ -59,7 +54,6 @@ type ProviderCostIndex = {
 const EMPTY_PROVIDER_COST_INDEX = new Map<string, RawModelCostConfig>();
 const MODELS_JSON_COST_CACHE_LIMIT = 128;
 
-let modelsJsonCostCacheByAgentDir = new Map<string, ModelsJsonCostCache>();
 let providerCostIndexByNormalizer = new WeakMap<
   ModelKeyNormalizer,
   WeakMap<Record<string, ModelProviderConfig>, ProviderCostIndex>
@@ -184,7 +178,7 @@ function loadModelsJsonCostIndex(options?: {
   }
   const modelsPath = path.join(agentDir, "models.json");
   try {
-    let modelsJsonCostCache = modelsJsonCostCacheByAgentDir.get(agentDir);
+    let modelsJsonCostCache = MODELS_JSON_STATE.costCache.get(agentDir);
     if (!modelsJsonCostCache) {
       const parsed = tryReadJsonSync<{
         providers?: Record<string, ModelProviderConfig>;
@@ -196,8 +190,8 @@ function loadModelsJsonCostIndex(options?: {
         providers: parsed?.providers,
         entries: new WeakMap(),
       };
-      pruneMapToMaxSize(modelsJsonCostCacheByAgentDir, MODELS_JSON_COST_CACHE_LIMIT - 1);
-      modelsJsonCostCacheByAgentDir.set(agentDir, modelsJsonCostCache);
+      pruneMapToMaxSize(MODELS_JSON_STATE.costCache, MODELS_JSON_COST_CACHE_LIMIT - 1);
+      MODELS_JSON_STATE.costCache.set(agentDir, modelsJsonCostCache);
     }
 
     const normalizeKey = options?.normalizeKey ?? normalizeRawModelKey;
@@ -395,6 +389,6 @@ export function estimateAggregateUsageCost(
 }
 
 export function resetUsageFormatCachesForTest(): void {
-  modelsJsonCostCacheByAgentDir = new Map();
+  MODELS_JSON_STATE.costCache.clear();
   providerCostIndexByNormalizer = new WeakMap();
 }


### PR DESCRIPTION
Related: #130706, #142100.

## What Problem This Solves

Fixes an issue where local usage estimates keep an agent's old model prices after OpenClaw successfully writes updated prices to its `models.json`. The file contains the new rate, but an already-warm process continues returning the old cached rate.

## Why This Change Was Made

The existing models.json owner now holds the bounded price index and invalidates the written agent immediately after successful publication. Usage readers keep their synchronous, non-polling lookup. The same cut removes unused preparation result fields and one-caller wrappers, reducing production code by 33 lines.

## User Impact

Subsequent local estimates use newly published agent prices without restarting the Gateway. Other agents retain their own cached prices, and recorded per-call costs retain their original amounts. The read-only planning path remains read-only.

## Evidence

- The regression failed on the base: after the real writer published rate 9, usage still returned rate 1; the second agent correctly remained at 5.
- 109 focused writer, pricing, fingerprint, roster, and cache tests passed. The full pinned changed-file checks and independent P2 review passed.
- A normal `pnpm build` passed. Four compiled scenarios exercised the real planner, catalog writer, and usage consumer: two-agent priming, publication and formatted cost, read-only planning, and warm reuse with caller-result isolation. No source imports or network requests occurred; all 12,092 build files and 2,130 observed module files remained unchanged.
- This is compiled owner-boundary proof, not a Gateway RPC or hosted-provider run. It covers in-process catalog publication; it adds no external-file polling.

Storage compatibility: no migration is required. Existing data compatibility is preserved and verified: the models.json planner, catalog reader, SQLite catalog owner, configuration types, and private file writer are byte-identical to the base. `models-config-state.ts` contains process-local `globalThis`/`Symbol.for` coordination with Maps, promises, and an async queue; it is not serialized or persisted. The public writer result remains `{ agentDir, wrote }`, the native state-schema guard passed unchanged at v17, and compiled read-only planning preserved exact file bytes.
