### PR TITLE
improve: avoid empty plugin expiry scans

### DIFF
--- a/src/plugin-state/plugin-state-store.expiry.test.ts
+++ b/src/plugin-state/plugin-state-store.expiry.test.ts
@@ -39,6 +39,34 @@ afterAll(async () => {
 });
 
 describe("plugin state expiry cleanup", () => {
+  it("rechecks expiry time and newly written rows after an empty namespace cleanup", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+    const scope = { pluginId: "discord", namespace: "fresh-expiry" };
+    const store = createPluginStateKeyedStore(scope.pluginId, {
+      namespace: scope.namespace,
+      maxEntries: 10,
+    });
+    seedPluginStateEntriesForTests([{ ...scope, key: "future", value: 1, expiresAt: 1_200 }]);
+    await store.register("permanent", 2);
+    expect(sweepExpiredPluginStateEntries()).toBe(0);
+
+    vi.setSystemTime(1_200);
+    await store.register("permanent", 3);
+    expect(sweepExpiredPluginStateEntries()).toBe(0);
+    await expect(store.lookup("future")).resolves.toBeUndefined();
+
+    seedPluginStateEntriesForTests([
+      { ...scope, key: "new-expired", value: 4, expiresAt: 1_100 },
+      { ...scope, namespace: "sibling", key: "expired", value: 5, expiresAt: 1_100 },
+    ]);
+    await store.register("permanent", 6);
+    expect(sweepExpiredPluginStateEntries()).toBe(1);
+    await expect(store.entries()).resolves.toEqual([
+      { key: "permanent", value: 6, createdAt: 1_200 },
+    ]);
+  });
+
   it("registerIfAbsent replaces an expired target beyond the namespace cleanup batch", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(1_200);

--- a/src/plugin-state/plugin-state-store.kernel.ts
+++ b/src/plugin-state/plugin-state-store.kernel.ts
@@ -263,12 +263,42 @@ export function deletePluginStateEntry(
   return Number(result.numAffectedRows ?? 0);
 }
 
+const pluginStateExpiryQueries = new WeakMap<
+  DatabaseSync,
+  ReturnType<typeof prepareSqliteQuerySync<number, { expires_at: number | bigint | null }>>
+>();
+
 export function deleteExpiredPluginStateEntries(
   db: DatabaseSync,
   now: number,
   scope?: { pluginId: string; namespace: string },
 ): number {
   const kysely = getPluginStateKysely(db);
+  if (scope) {
+    let query = pluginStateExpiryQueries.get(db);
+    if (!query) {
+      query = prepareSqliteQuerySync<number, { expires_at: number | bigint | null }>(
+        db,
+        (parameter) =>
+          kysely
+            .selectFrom("plugin_state_entries")
+            .select("expires_at")
+            .where("expires_at", "is not", null)
+            .where(
+              "expires_at",
+              "<=",
+              parameter((value) => value),
+            )
+            .limit(1),
+      );
+      pluginStateExpiryQueries.set(db, query);
+    }
+    // The expiry index can prove there is nothing due without scanning the namespace.
+    // Only compilation is retained; expiry is checked in the caller's current transaction.
+    if (query(now).rows.length === 0) {
+      return 0;
+    }
+  }
   let expiredEntries = kysely
     .selectFrom("plugin_state_entries")
     .select(["plugin_id", "namespace", "entry_key"])


### PR DESCRIPTION
Related: #145677

## What Problem This Solves

Plugin keyed-store writes repeatedly scan their namespace for expired entries, including large stores whose entries are permanent or all expire in the future. This adds work inside every registration transaction.

## Why This Change Was Made

The existing expiry index can cheaply establish that no entries are currently expired. Scoped cleanup now checks that index before running its unchanged namespace cleanup. The query is compiled once per connection; its result and time binding are reread on every call in the existing transaction. Global sweeps and the 1,024-row cleanup bound remain unchanged.

This is a bounded query-plan improvement using the existing schema, with no new stored representation, migration, retention policy, transaction boundary, or consistency change.

## User Impact

Plugin writes avoid unnecessary namespace scans when no expiry work is due. Existing expired rows still use the same bounded cleanup, sibling isolation, and rollback behavior.

## Evidence

- Node 26.8.2 / SQLite 3.53.4, Windows x64, canonical plugin schema; paired actual-owner runs against base `81a4c771eff6cd4591ae7f9b1745d1ced399d5e6`. Seven alternating rounds, 500 kernel or 100 public registrations per round, with persisted-row equality excluding invocation wall-clock `created_at`.
- Median registration time in microseconds:

| Namespace rows / sibling rows | Kernel before → after | Public owner before → after |
| --- | ---: | ---: |
| 100 / 0 | 124.72 → 73.49 | 6,220.36 → 5,928.84 |
| 3,000 / 0 | 805.67 → 483.83 | 6,844.85 → 6,363.16 |
| 30,000 / 0 | 7,921.82 → 5,014.10 | 12,560.48 → 10,177.80 |
| 100 / 30,000 | 2,254.74 → 1,894.04 | 7,466.03 → 7,214.64 |

- An isolated expiry-step probe used the covering expiry index: 30,000 permanent entries, 1.88 → 0.008 ms; all-future entries, 2.69 → 0.009 ms. Fixtures that already had expiry work show the added probe overhead: 30,000 live namespace rows with 100,000 expired sibling rows took 2.08 → 2.17 ms; 30,000 live plus 2,000 locally expired rows took 3.44 → 3.46 ms. These synthetic timings include background host variability and do not measure whole-Gateway throughput.
- 30 focused tests passed across expiry, retention, prepared-query lifecycle, and Doctor imports. New coverage checks expiry advancing after an empty result and newly inserted expired rows; existing coverage checks bounded replacement, siblings, and transaction rollback.
- Core production and the canonical state/logging test type graph passed. Scoped type-aware lint passed after renaming a shadowed callback parameter. Independent P0–P2 autoreview completed with no actionable findings; the subsequent change was that binding-name-only lint correction.
- The multi-shard test-type launcher refuses a percent-encoded Windows checkout URL before launching its compiler; the owning test graph was checked directly through the existing `run-tsgo` wrapper. Hosted required CI remains the landing gate.
- Max-lines and environment-count ratchets passed (827 grandfathered suppressions; 492/492 environment variables).
