### PR TITLE
fix(cron): use light context for skill collection reviews

### DIFF
--- a/src/cron/skill-collection-review-monitor.test.ts
+++ b/src/cron/skill-collection-review-monitor.test.ts
@@ -33,6 +33,7 @@ describe("resolveSkillCollectionReviewMonitorSpecs", () => {
       payload: {
         kind: "agentTurn",
         message: expect.any(String),
+        lightContext: true,
         toolsAllow: ["ls", "read", "write", "edit", "apply_patch", "exec", "process"],
       },
       schedule: {

--- a/src/cron/skill-collection-review-monitor.ts
+++ b/src/cron/skill-collection-review-monitor.ts
@@ -48,6 +48,7 @@ export function resolveSkillCollectionReviewMonitorSpecs(
       payload: {
         kind: "agentTurn",
         message: SKILL_WORKSHOP_MAINTENANCE_PROMPT,
+        lightContext: true,
         toolsAllow: [...SKILL_WORKSHOP_MAINTENANCE_TOOLS],
       },
       sessionTarget: "isolated",


### PR DESCRIPTION
Closes #146023

## What Problem This Solves

System-owned Skill Workshop collection reviews execute with file tools rooted inside the agent's Workshop directory, but their generated `agentTurn` payload currently inherits the normal workspace bootstrap context. If those bootstrap instructions point outside the restricted Workshop root, the review can follow instructions that its file-tool policy correctly rejects, causing otherwise valid maintenance runs to fail.

## Why This Change Was Made

The cron runtime already has a lightweight context mode specifically for automation turns. Setting `lightContext: true` on the canonical Skill Workshop review payload removes unrelated normal-workspace bootstrap files while preserving the maintenance prompt, existing rooted tool allowlist, isolated session target, delivery mode, schedule, and declaration identity.

Because system-owned review jobs are reconciled from this canonical specification, existing jobs also receive the corrected payload without adding a migration or a new configuration surface.

## User Impact

Automatic Skill Workshop collection reviews no longer inherit workspace bootstrap instructions that conflict with their restricted Workshop execution root. Normal interactive agent context and ordinary cron defaults are unchanged.

## Evidence

- Added a regression assertion that every generated Skill Workshop review payload has `lightContext: true`.
- Branch is based directly on current upstream `main` at `905c0899efcdbcb92805241858414ce74837aff2`.
- GitHub compare shows exactly 2 changed files with +1 line each and no unrelated changes.
- The reporter's local workaround with the same payload property successfully completed the previously failing review jobs, as documented in #146023.
- Focused repository tests could not be executed in this automation environment because outbound GitHub DNS/network access is unavailable to the local runtime, so CI is relied on for executable verification. No test result is claimed locally.