### PR TITLE
improve: prepare memory snippets once for diversity ranking

### DIFF
--- a/extensions/memory-core/src/memory/mmr.test.ts
+++ b/extensions/memory-core/src/memory/mmr.test.ts
@@ -4,10 +4,16 @@ import { applyMMRToHybridResults, DEFAULT_MMR_CONFIG } from "./mmr.js";
 import { jaccardSimilarity, textSimilarity, tokenize } from "./tokenize.js";
 
 describe("memory MMR", () => {
-  it("tokenizes mixed ASCII and CJK text", () => {
-    expect(tokenize("Hello 今天讨论 hello")).toEqual(
-      new Set(["hello", "今", "天", "讨", "论", "今天", "天讨", "讨论"]),
-    );
+  it.each([
+    {
+      text: "Hello 今天讨论 hello",
+      expected: ["hello", "今天", "天讨", "讨论", "今", "天", "讨", "论"],
+    },
+    { text: " Hello WORLD_42 hello! ", expected: ["hello", "world_42"] },
+    { text: "Привет 🙂 العربية", expected: [] },
+    { text: "中文🙂今天", expected: ["中文", "今天", "中", "文", "今", "天"] },
+  ])("tokenizes $text in stable term order", ({ text, expected }) => {
+    expect([...tokenize(text)]).toEqual(expected);
   });
 
   it("compares token sets and falls back to literal equality for empty token sets", () => {
@@ -37,6 +43,25 @@ describe("memory MMR", () => {
       ],
       expected: ["/arabic.md", "/cyrillic.md", "/ascii.md", "/tail.md"],
     },
+    {
+      name: "diversifies normalized-equal non-tokenized snippets",
+      results: [
+        ["/primary.md", 1, "Привет мир"],
+        ["/duplicate.md", 0.98, "  ПРИВЕТ МИР  "],
+        ["/diverse.md", 0.94, "Доброе утро"],
+        ["/tail.md", 0.4, "إعداد الشبكة الرئيسي"],
+      ],
+      expected: ["/primary.md", "/diverse.md", "/duplicate.md", "/tail.md"],
+    },
+    {
+      name: "keeps input order as the tie breaker for equal relevance and diversity",
+      results: [
+        ["/first.md", 1, "alpha"],
+        ["/second.md", 1, "beta"],
+        ["/third.md", 1, "gamma"],
+      ],
+      expected: ["/first.md", "/second.md", "/third.md"],
+    },
   ])("$name", ({ results, expected }) => {
     const candidates = results.map(([path, score, snippet]) => ({
       path: String(path),
@@ -53,6 +78,9 @@ describe("memory MMR", () => {
     expect(reranked.map((result) => result.score)).toEqual(
       expected.map((path) => scores.get(path)),
     );
+    for (const result of reranked) {
+      expect(result).toBe(candidates.find((candidate) => candidate.path === result.path));
+    }
   });
 
   it("keeps input order when disabled", () => {
@@ -63,6 +91,22 @@ describe("memory MMR", () => {
 
     expect(applyMMRToHybridResults(results, { enabled: false })).toEqual(results);
     expect(DEFAULT_MMR_CONFIG).toEqual({ enabled: false, lambda: 0.7 });
+  });
+
+  it("preserves repeated result objects and locations without mutating inputs", () => {
+    const primary = Object.freeze({ path: "/same.md", startLine: 1, score: 1, snippet: "alpha" });
+    const duplicate = Object.freeze({ ...primary, score: 0.98 });
+    const diverse = Object.freeze({ ...primary, score: 0.94, snippet: "beta" });
+    const tail = Object.freeze({ ...primary, score: 0.4, snippet: "gamma" });
+    const results = [primary, duplicate, diverse, primary, tail];
+    Object.freeze(results);
+
+    const reranked = applyMMRToHybridResults(results, { enabled: true, lambda: 0.7 });
+
+    expect(reranked).toHaveLength(results.length);
+    for (const [index, expected] of [primary, diverse, primary, duplicate, tail].entries()) {
+      expect(reranked[index]).toBe(expected);
+    }
   });
 
   it("preserves the reference MMR ranking while caching running similarities", () => {

--- a/extensions/memory-core/src/memory/mmr.ts
+++ b/extensions/memory-core/src/memory/mmr.ts
@@ -1,5 +1,6 @@
 // Memory Core plugin module implements mmr behavior.
-import { jaccardSimilarity, textSimilarity, tokenize } from "./tokenize.js";
+import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { jaccardSimilarity, tokenize } from "./tokenize.js";
 
 /**
  * Maximal Marginal Relevance (MMR) re-ranking algorithm.
@@ -11,9 +12,8 @@ import { jaccardSimilarity, textSimilarity, tokenize } from "./tokenize.js";
  */
 
 type MMRItem = {
-  id: string;
   score: number;
-  content: string;
+  snippet: string;
 };
 
 export type MMRConfig = {
@@ -36,6 +36,15 @@ function computeMMRScore(relevance: number, maxSimilarity: number, lambda: numbe
   return lambda * relevance - (1 - lambda) * maxSimilarity;
 }
 
+type PreparedMMRItem<T extends MMRItem> = {
+  item: T;
+  score: number;
+  tokens: Set<string>;
+  emptyTokenText: string | undefined;
+  relevance: number;
+  maxSimilarity: number;
+};
+
 /**
  * Re-rank items using Maximal Marginal Relevance (MMR).
  *
@@ -44,63 +53,44 @@ function computeMMRScore(relevance: number, maxSimilarity: number, lambda: numbe
  * 2. For each remaining slot, select the item that maximizes the MMR score
  * 3. MMR score = λ * relevance - (1-λ) * max_similarity_to_already_selected
  *
- * @param items - Items to re-rank, must have score and content
+ * @param items - Items to re-rank, must have score and snippet
  * @param config - MMR configuration (lambda, enabled)
  * @returns Re-ranked items in MMR order
  */
 function mmrRerank<T extends MMRItem>(items: T[], config: Partial<MMRConfig> = {}): T[] {
   const { enabled = DEFAULT_MMR_CONFIG.enabled, lambda = DEFAULT_MMR_CONFIG.lambda } = config;
-
-  // Early exits
   if (!enabled || items.length <= 1) {
     return [...items];
   }
-
-  // Clamp lambda to valid range
   const clampedLambda = Math.max(0, Math.min(1, lambda));
-
-  // If lambda is 1, just return sorted by relevance (no diversity penalty)
   if (clampedLambda === 1) {
     return [...items].toSorted((a, b) => b.score - a.score);
   }
-
-  // Pre-tokenize all items for efficiency
-  const tokenCache = new Map<string, Set<string>>();
-  for (const item of items) {
-    tokenCache.set(item.id, tokenize(item.content));
-  }
-
-  // Normalize scores to [0, 1] for fair comparison with similarity
-  const maxScore = Math.max(...items.map((i) => i.score));
-  const minScore = Math.min(...items.map((i) => i.score));
+  const prepared: PreparedMMRItem<T>[] = items.map((item) => {
+    const snippet = item.snippet;
+    const tokens = tokenize(snippet);
+    return {
+      item,
+      score: item.score,
+      tokens,
+      emptyTokenText: tokens.size === 0 ? normalizeLowercaseStringOrEmpty(snippet) : undefined,
+      relevance: 0,
+      maxSimilarity: 0,
+    };
+  });
+  const maxScore = Math.max(...prepared.map((item) => item.score));
+  const minScore = Math.min(...prepared.map((item) => item.score));
   const scoreRange = maxScore - minScore;
-
-  const normalizeScore = (score: number): number => {
-    if (scoreRange === 0) {
-      return 1; // All scores equal
-    }
-    return (score - minScore) / scoreRange;
-  };
-
+  for (const item of prepared) {
+    item.relevance = scoreRange === 0 ? 1 : (item.score - minScore) / scoreRange;
+  }
+  const remaining = new Set(prepared);
   const selected: T[] = [];
-  const remaining = new Set(items);
-  // Once an item has been selected, its similarity contribution to each
-  // remaining candidate never changes. Keep the running maximum so each pair
-  // is compared exactly once instead of rescanning all previously selected
-  // items on every selection round.
-  const maxSimilarityByItem = new Map<T, number>();
-
-  // Select items iteratively
   while (remaining.size > 0) {
-    let bestItem: T | null = null;
+    let bestItem: PreparedMMRItem<T> | null = null;
     let bestMMRScore = -Infinity;
-
     for (const candidate of remaining) {
-      const normalizedRelevance = normalizeScore(candidate.score);
-      const maxSim = maxSimilarityByItem.get(candidate) ?? 0;
-      const mmrScore = computeMMRScore(normalizedRelevance, maxSim, clampedLambda);
-
-      // Use original score as tiebreaker (higher is better)
+      const mmrScore = computeMMRScore(candidate.relevance, candidate.maxSimilarity, clampedLambda);
       if (
         mmrScore > bestMMRScore ||
         (mmrScore === bestMMRScore && candidate.score > (bestItem?.score ?? -Infinity))
@@ -109,34 +99,28 @@ function mmrRerank<T extends MMRItem>(items: T[], config: Partial<MMRConfig> = {
         bestItem = candidate;
       }
     }
-
-    if (bestItem) {
-      selected.push(bestItem);
-      remaining.delete(bestItem);
-      const selectedTokens = tokenCache.get(bestItem.id) ?? tokenize(bestItem.content);
-      for (const candidate of remaining) {
-        const candidateTokens = tokenCache.get(candidate.id) ?? tokenize(candidate.content);
-        const similarity =
-          candidateTokens.size === 0 && selectedTokens.size === 0
-            ? textSimilarity(candidate.content, bestItem.content)
-            : jaccardSimilarity(candidateTokens, selectedTokens);
-        const previousMax = maxSimilarityByItem.get(candidate) ?? 0;
-        if (similarity > previousMax) {
-          maxSimilarityByItem.set(candidate, similarity);
-        }
-      }
-    } else {
-      // Should never happen, but safety exit
+    if (!bestItem) {
       break;
     }
+    selected.push(bestItem.item);
+    remaining.delete(bestItem);
+    // A selected item's contribution never changes, so update each candidate's
+    // running maximum once per pair instead of rescanning selected items.
+    for (const candidate of remaining) {
+      const similarity =
+        candidate.tokens.size === 0 && bestItem.tokens.size === 0
+          ? Number(candidate.emptyTokenText === bestItem.emptyTokenText)
+          : jaccardSimilarity(candidate.tokens, bestItem.tokens);
+      if (similarity > candidate.maxSimilarity) {
+        candidate.maxSimilarity = similarity;
+      }
+    }
   }
-
   return selected;
 }
 
 /**
  * Apply MMR re-ranking to hybrid search results.
- * Adapts the generic MMR function to work with the hybrid search result format.
  */
 export function applyMMRToHybridResults<
   T extends { score: number; snippet: string; path: string; startLine: number },
@@ -144,23 +128,5 @@ export function applyMMRToHybridResults<
   if (results.length === 0) {
     return results;
   }
-
-  // Create a map from ID to original item for type-safe retrieval
-  const itemById = new Map<string, T>();
-
-  // Create MMR items with unique IDs
-  const mmrItems: MMRItem[] = results.map((r, index) => {
-    const id = `${r.path}:${r.startLine}:${index}`;
-    itemById.set(id, r);
-    return {
-      id,
-      score: r.score,
-      content: r.snippet,
-    };
-  });
-
-  const reranked = mmrRerank(mmrItems, config);
-
-  // Map back to original items using the ID
-  return reranked.map((item) => itemById.get(item.id)!);
+  return mmrRerank(results, config);
 }

--- a/extensions/memory-core/src/memory/tokenize.ts
+++ b/extensions/memory-core/src/memory/tokenize.ts
@@ -30,6 +30,9 @@ const CJK_RE = /[\u3040-\u309f\u30a0-\u30ff\u3400-\u4dbf\u4e00-\u9fff\uac00-\ud7
 export function tokenize(text: string): Set<string> {
   const lower = normalizeLowercaseStringOrEmpty(text);
   const ascii = lower.match(/[a-z0-9_]+/g) ?? [];
+  if (!CJK_RE.test(lower)) {
+    return new Set(ascii);
+  }
 
   // Track CJK characters with their original positions
   const chars = Array.from(lower);


### PR DESCRIPTION
## What Problem This Solves

Memory search with diversity ranking repeatedly prepares snippet text during pairwise comparisons. Snippets without ASCII or CJK tokens, including Cyrillic and Arabic text, trigger repeated tokenization throughout the ranking loop.

## Why This Change Was Made

Prepare each result's tokens, normalized empty-token text, relevance, and running similarity once. Rank these per-occurrence records directly and return the original results, removing the intermediate ID projection. Tokenization also skips per-character CJK processing when the text contains no CJK characters.

## User Impact

Diversity ranking uses less CPU and temporary allocation while preserving result order, scores, metadata, duplicate occurrences, and multilingual token semantics. This affects searches with MMR enabled.

## Evidence

- 41 focused tests passed, including frozen repeated-result occurrences, stable ties, multilingual behavior, and original object identity.
- 131,086 token-order cases and 122 complete hybrid-result matrices matched before/after behavior.
- Independent review completed cleanly against the final source.
- Benchmarks use the actual hybrid merge entry point. Counts refer to the merged candidate set; 400 represents disjoint results from the default 200-candidate vector and keyword legs.
- Required hosted CI passed at the reviewed head `bb69889434563e7e574a06452a0fb3fe033a1350`. Broad gates used hosted CI.

Actual hybrid merge, median milliseconds for 200 merged candidates with 700-character snippets:

| Snippet workload | Node 24.19.0 before → after | Node 26.8.2 before → after |
| --- | ---: | ---: |
| ASCII | 8.225 → 5.103 | 7.649 → 3.987 |
| CJK | 28.202 → 27.440 | 33.145 → 30.431 |
| Mixed ASCII/CJK | 9.517 → 9.183 | 9.183 → 8.489 |
| Cyrillic | 560.332 → 1.787 | 793.803 → 1.885 |
| Arabic | 663.486 → 1.918 | 622.853 → 1.768 |
| Emoji | 611.473 → 3.024 | 446.617 → 1.700 |

The Cyrillic, Arabic, and emoji fixtures contain no ASCII or CJK tokens. In this case the old pairwise fallback repeatedly tokenizes both snippets: at 200 candidates, preparation drops from 40,000 tokenizations to 200. This is a conditional benefit, not a claim that all text in those languages becomes hundreds of times faster. The 400-candidate Cyrillic/700-character case falls from 2,175.931 to 5.348 ms on Node 24 and from 2,944.039 to 6.406 ms on Node 26.

The primary matrix covers six text kinds, 24/200/400 merged candidates, and 280/700-character snippets on Windows 11 / AMD Ryzen AI MAX+ 395. Each cell checks complete output parity, uses three warmups per variant, and records nine alternating before/after rounds. Shared batch sizes target approximately 50 ms from baseline warmups, capped at 20/5/3 operations for 24/200/400 candidates. Temporal decay remains enabled. The host was busy with unrelated work during parts of the run; large paired gains are clear, but CJK and mixed cases should be treated as approximately flat to modestly improved. Some original CJK control medians were 10–27% slower under substantial variance; the targeted rerun below did not reproduce those regressions.

All 150 primary, duplicate/cluster, and attribution cells passed full-result parity. Three initially slower CJK controls were rerun in a separate process with five warmups, nine alternating rounds, and GC outside each sample. Node 26 duplicate/200/280 changed from 20.872 to 20.657 ms, clustered/200/280 from 23.080 to 20.205 ms; Node 24 clustered/24/700 changed from 3.562 to 3.260 ms. The original slower medians did not repeat. These measurements do not establish a general CJK speedup. Process CPU observations were also recorded, but Windows timer quantization and concurrent GC work make their small-cell differences unsuitable for precise claims.

Twelve fresh processes measured 12 hybrid calls at 400 candidates and 700 characters for ASCII, CJK, and Cyrillic. All output hashes matched the timing fixtures. Peak RSS includes module loading and varied substantially before the workloads, so no peak-RSS reduction is claimed. Node 26 before/after peaks were 445/447 MiB (ASCII), 463/447 MiB (CJK), and 446/448 MiB (Cyrillic); Node 24 was 506/469, 540/549, and 550/488 MiB. These are observed process peaks, not attributable retained-memory savings.

Compatibility: prepared records exist only during one ranking call. The original result objects, scores, snippets, provenance, extra metadata, and repeated occurrences retain their existing contract. Frozen-input and complete hybrid-result comparisons cover that boundary. Persisted rows, schema versions, and installed-state upgrade behavior do not change; no migration is needed.

The performance harness supplies synthetic vector and keyword results to the actual hybrid merge. It checks complete returned results, with temporal decay enabled, and excludes embedding, database, and network latency.
