### PR TITLE
fix(ui): avoid redundant child-session refreshes in chat

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2786,7 +2786,8 @@ jobs:
     # The 32-class request can fit both staged SDK compilers; actual remaining
     # memory still gates overlap, with unchanged browser worker limits.
     runs-on: ${{ vars.OPENCLAW_CI_RUNNER_BACKEND == 'github' && 'ubuntu-24.04' || (vars.OPENCLAW_CI_RUNNER_BACKEND == 'hybrid' && github.run_attempt > 1) && 'ubuntu-24.04' || (github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.run_attempt > 1)) && 'ubuntu-24.04' || (github.repository == 'openclaw/openclaw' && (github.event_name != 'pull_request' || contains(fromJSON('["OWNER","MEMBER","COLLABORATOR","CONTRIBUTOR"]'), github.event.pull_request.author_association)) && 'blacksmith-32vcpu-ubuntu-2404' || 'ubuntu-24.04') }}
-    timeout-minutes: 20
+    # Hosted preparation and the complete suite need a larger job budget; test deadlines stay fixed.
+    timeout-minutes: ${{ (vars.OPENCLAW_CI_RUNNER_BACKEND == 'github' || (vars.OPENCLAW_CI_RUNNER_BACKEND == 'hybrid' && github.run_attempt > 1) || github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.run_attempt > 1) || github.repository != 'openclaw/openclaw' || (github.event_name == 'pull_request' && !contains(fromJSON('["OWNER","MEMBER","COLLABORATOR","CONTRIBUTOR"]'), github.event.pull_request.author_association))) && 40 || 20 }}
     steps:
       - *linux_node_checkout_step
       - name: Setup Node environment

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -15,6 +15,8 @@ For the published-upgrade regression gate, see [selection and routing](/ci/scope
 
 Docs-only `main` pushes skip CI. Every canonical `main` push admitted by the CI workflow selects the published-upgrade regression gate.
 
+Real-Gateway browser checks use [job budgets matched to their selected runner](/ci/runners#blacksmith-runner-capacity).
+
 | Page                                                           | Read it when                                                                                                        |
 | -------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
 | [CI pipeline jobs](/ci/pipeline)                               | The job table, the fail-fast order, and the Control UI size budgets.                                                |

--- a/docs/ci/runners.md
+++ b/docs/ci/runners.md
@@ -66,9 +66,18 @@ its 12-GiB heap: overlap requires at least two available CPUs and 25.5 GiB of
 observed remaining capacity, including 768 MiB of native headroom per compiler.
 An unknown finite-cgroup usage value or insufficient capacity keeps compilation
 serial. The requested label does not establish those facts. Browser workers,
-test inventory, build-before-test ordering, deadlines, hosted fallbacks, and job
+test inventory, build-before-test ordering, hosted fallbacks, and job
 count are unchanged; this placement adds no runner registrations. Compiler-only
 measurements do not establish CI timing; exact-head CI must measure the complete job.
+
+The real-Gateway job has a 40-minute budget when its existing routing selects
+`ubuntu-24.04`, and 20 minutes on Blacksmith. In [run 34707873095, attempt 2](https://github.com/openclaw/openclaw/actions/runs/34707873095/attempts/2),
+7m42s elapsed before the browser suite began; the 20-minute job limit then
+canceled a progressing suite before its widget cases. The hosted budget covers
+the complete setup, private artifact build, and test workload. Individual test
+and subprocess deadlines, test inventory, workers, routing, and concurrency
+limits apply unchanged on both routes. This adds no jobs or runner registrations
+and makes no claim that execution is faster.
 
 The full CLI compact bin requests the 16-class after packing, retaining its two
 Vitest workers and serial companion groups. In a controlled 2026-09-10 Linux

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -6186,6 +6186,7 @@ setImmediate(() => {
     const expectedHostedTimeouts = {
       android: 35,
       "build-artifacts": 35,
+      "checks-ui-e2e-real-gateway": 40,
     } as const;
     const routeDependentTimeoutJobs = Object.entries(jobs)
       .filter(([, job]) => {
@@ -6272,6 +6273,31 @@ setImmediate(() => {
             evaluateTimeout("android", { ...context, matrix: { task, lint } }),
             `${label}: ${task}, lint=${lint}`,
           ).toBe(extendedBudget ? 35 : 20);
+        }
+      }
+    }
+
+    const realGateway = workflow.jobs["checks-ui-e2e-real-gateway"];
+    for (const eventName of ["pull_request", "push", "workflow_dispatch"] as const) {
+      for (const repository of ["openclaw/openclaw", "contributor/openclaw"]) {
+        for (const authorAssociation of ["CONTRIBUTOR", "NONE"]) {
+          for (const runnerBackend of ["", "blacksmith", "github", "hybrid"] as const) {
+            for (const runAttempt of [1, 2]) {
+              const context = {
+                ...canonicalPullRequest,
+                eventName,
+                repository,
+                authorAssociation,
+                runnerBackend,
+                runAttempt,
+              };
+              const runner = evaluateWorkflowExpression(realGateway["runs-on"], context);
+              expect(
+                evaluateTimeout("checks-ui-e2e-real-gateway", context),
+                JSON.stringify(context),
+              ).toBe(runner === "ubuntu-24.04" ? 40 : 20);
+            }
+          }
         }
       }
     }
@@ -13855,7 +13881,6 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
     expect(uiE2eRealGateway.permissions).toEqual(uiE2e.permissions);
     expect(uiE2eRealGateway.needs).toEqual(uiE2e.needs);
     expect(uiE2eRealGateway.if).toBe(uiE2e.if);
-    expect(uiE2eRealGateway["timeout-minutes"]).toBe(20);
     expect(uiE2eRealGateway.env).toBeUndefined();
 
     const uiE2eSetup = expectDefined(

--- a/ui/src/e2e/chat-flow.active-run-follow-ups.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.active-run-follow-ups.e2e.test.ts
@@ -710,6 +710,16 @@ suite.define(() => {
     const page = await context.newPage();
     const gateway = await installMockGateway(page, {
       sessionInfo: { hasActiveRun: false, status: "done" },
+      methodResponses: {
+        "sessions.list": {
+          cases: [
+            {
+              match: { spawnedBy: "agent:main:main" },
+              response: chatSessionListResponse([]),
+            },
+          ],
+        },
+      },
     });
 
     try {
@@ -758,23 +768,28 @@ suite.define(() => {
       await expect
         .poll(async () => (await gateway.getRequests("sessions.list")).length)
         .toBeGreaterThan(sessionListsBeforeTerminal);
-      await gateway.resolveDeferred(
-        "sessions.list",
-        chatSessionListResponse([
-          {
-            activeRunIds: [],
-            hasActiveRun: false,
-            key: activeSessionKey,
-            sessionId: `session:${activeSessionKey}`,
-            kind: "direct",
-            label: "Main",
-            lastRunId: activeRunId,
-            status: "done",
-            updatedAt: Date.now(),
-          },
-        ]),
-      );
-
+      const terminalSessions = chatSessionListResponse([
+        {
+          activeRunIds: [],
+          hasActiveRun: false,
+          key: activeSessionKey,
+          sessionId: `session:${activeSessionKey}`,
+          kind: "direct",
+          label: "Main",
+          lastRunId: activeRunId,
+          status: "done",
+          updatedAt: Date.now(),
+        },
+      ]);
+      // The list publication and later descriptor/history reads share one Gateway state.
+      await gateway.setSessionsListResponse(terminalSessions);
+      await gateway.setMethodResponse("sessions.list", {
+        cases: [
+          { match: { spawnedBy: activeSessionKey }, response: chatSessionListResponse([]) },
+          { response: terminalSessions },
+        ],
+      });
+      await gateway.resolveDeferred("sessions.list", terminalSessions);
       const sends = await waitForRequests(gateway, "chat.send", 2);
       expect(requireRecord(sends[1]?.params)).toMatchObject({ message: followUp });
       await queuedRow.waitFor({ state: "detached", timeout: 10_000 });

--- a/ui/src/e2e/chat-stop-finished-run.real-gateway.e2e.test.ts
+++ b/ui/src/e2e/chat-stop-finished-run.real-gateway.e2e.test.ts
@@ -1,4 +1,4 @@
-// Fault injection withholds only this run's terminal notifications; Stop must recover from the real Gateway's no-active-run answer.
+// Withhold this run's terminal notifications and delay terminal descriptors until Stop recovers from the Gateway's no-active-run answer.
 import fs from "node:fs/promises";
 import { createServer } from "node:http";
 import path from "node:path";
@@ -192,6 +192,9 @@ suite.define(() => {
         let runId: string | undefined;
         let sockets = 0;
         let dropped = 0;
+        let delayTerminalDescriptors = true;
+        let delayedTerminalDescriptors = 0;
+        const deferredDescriptors: Array<() => void> = [];
         let stage = "create session";
         const call = async (method: string, params: Record<string, unknown>) => {
           const args = ["gateway", "call", method, "--json", "--params", JSON.stringify(params)];
@@ -292,11 +295,9 @@ suite.define(() => {
                 server.onMessage((message) => {
                   const raw = message.toString();
                   const frame: Frame = JSON.parse(raw);
+                  const request = frame.id ? pending.get(frame.id) : undefined;
                   if (frame.type === "res") {
                     received.push(frame);
-                    if (frame.id) {
-                      pending.delete(frame.id);
-                    }
                   }
                   if (terminalNotification(frame)) {
                     dropped += 1;
@@ -308,8 +309,31 @@ suite.define(() => {
                     });
                     socket.send(replacement);
                   } else {
-                    delivered.push(frame);
-                    socket.send(message);
+                    const deliver = () => {
+                      if (frame.type === "res" && frame.id) {
+                        pending.delete(frame.id);
+                      }
+                      delivered.push(frame);
+                      socket.send(message);
+                    };
+                    const session = frame.payload?.session;
+                    if (
+                      delayTerminalDescriptors &&
+                      runId &&
+                      frame.type === "res" &&
+                      frame.ok === true &&
+                      request?.method === "sessions.describe" &&
+                      request.params?.key === sessionKey &&
+                      session?.lastRunId === runId &&
+                      session.status === "done"
+                    ) {
+                      // Shared descriptor observations can settle ownership before Stop.
+                      // Delay this exact terminal fact, then deliver the real reply unchanged.
+                      delayedTerminalDescriptors += 1;
+                      deferredDescriptors.push(deliver);
+                    } else {
+                      deliver();
+                    }
                   }
                 });
               });
@@ -511,6 +535,10 @@ suite.define(() => {
                   }),
                   "Recovered ownership requires a post-Stop authoritative history response",
                 ).toBe(true);
+                delayTerminalDescriptors = false;
+                for (const deliver of deferredDescriptors.splice(0)) {
+                  deliver();
+                }
                 await page.locator(".chat-bubble").getByText(replyText, { exact: true }).waitFor();
                 await composer.fill("Next draft");
                 await page
@@ -531,6 +559,8 @@ suite.define(() => {
                 proof.browserSockets = sockets;
                 proof.connectRequests = sent.filter((frame) => frame.method === "connect").length;
                 proof.droppedTerminalNotifications = dropped;
+                proof.delayedTerminalDescriptors = delayedTerminalDescriptors;
+                proof.pendingTerminalDescriptors = deferredDescriptors.length;
                 proof.abortRequests = sent.filter((frame) => frame.method === "chat.abort").length;
                 proof.pendingBrowserRequests = pending.size;
                 proof.providerRequests = provider.requests();

--- a/ui/src/e2e/chat-swarm-lifecycle.e2e.test.ts
+++ b/ui/src/e2e/chat-swarm-lifecycle.e2e.test.ts
@@ -24,6 +24,7 @@ suite.define(() => {
       async ({ page }) => {
         const children = Array.from({ length: viewport.count }, (_, index) => ({
           key: `agent:main:subagent:completed-${index}`,
+          sessionId: `session:agent:main:subagent:completed-${index}`,
           kind: "direct",
           label: "Research worker visibility after reconnect",
           parentSessionKey: sessionKey,
@@ -42,6 +43,7 @@ suite.define(() => {
         };
         const parent = {
           key: sessionKey,
+          sessionId: `session:${sessionKey}`,
           kind: "direct",
           label: "Research comparison",
           updatedAt: 1,
@@ -147,6 +149,7 @@ suite.define(() => {
       const now = Date.now();
       const parent = {
         key: sessionKey,
+        sessionId: `session:${sessionKey}`,
         kind: "direct",
         label: "Research comparison",
         status: "running",
@@ -172,6 +175,7 @@ suite.define(() => {
       };
       const children = Array.from({ length: 30 }, (_, index) => ({
         key: `agent:${viewport.childAgent}:subagent:research-${index}`,
+        sessionId: `session:agent:${viewport.childAgent}:subagent:research-${index}`,
         kind: "direct",
         label: `Research lane ${index + 1}`,
         parentSessionKey: sessionKey,

--- a/ui/src/e2e/new-session-page.cloud-dispatch.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.cloud-dispatch.e2e.test.ts
@@ -541,8 +541,8 @@ suite.define(() => {
         await page.clock.runFor(250);
         expect(await gateway.getRequests("sessions.send")).toHaveLength(0);
       }
-      // This single-page fixture pairs each Swarm child read with its parent read.
-      // Placement updates must not add an unpaired describe for the same session.
+      // Healthy parent and child reads are independent; placement updates must
+      // not add extra parent lookups regardless of which request starts first.
       const parentReads = (await gateway.getRequests()).filter((request) => {
         const params = asNullableRecord(request.params);
         return (
@@ -550,12 +550,11 @@ suite.define(() => {
           (request.method === "sessions.list" && params?.spawnedBy === sessionKey)
         );
       });
-      for (let index = 0; index < parentReads.length; index += 2) {
-        expect(parentReads.slice(index, index + 2)).toMatchObject([
-          { method: "sessions.list", params: { spawnedBy: sessionKey } },
-          { method: "sessions.describe", params: { key: sessionKey } },
-        ]);
-      }
+      const childReads = parentReads.filter((request) => request.method === "sessions.list");
+      expect(childReads.length).toBeGreaterThan(0);
+      expect(parentReads.filter((request) => request.method === "sessions.describe")).toHaveLength(
+        childReads.length,
+      );
       const neutralRow = page.locator('[data-session-key="agent:cloud:neutral-e2e"] a');
       await neutralRow.waitFor();
       await neutralRow.click();

--- a/ui/src/e2e/session-roster-event-scope.e2e.test.ts
+++ b/ui/src/e2e/session-roster-event-scope.e2e.test.ts
@@ -100,6 +100,9 @@ suite.define(() => {
       expect((await gateway.getRequests("sessions.list")).length - before).toBe(0);
       expect(await selectedRow.textContent()).toContain("Weekly report");
 
+      const primaryQuery = { agentId: "main", limit: 200 };
+      const primaryBefore = (await gateway.getRequests("sessions.list", primaryQuery)).length;
+
       await gateway.setSessionsListResponse(
         sessionsListResponse([{ ...row, label: "Weekly report ready", updatedAt: 5 }]),
       );
@@ -109,7 +112,12 @@ suite.define(() => {
         updatedAt: 5,
       });
       await expect.poll(() => selectedRow.textContent()).toContain("Weekly report ready");
-      expect((await gateway.getRequests("sessions.list")).length - before).toBe(1);
+      await expect
+        .poll(
+          async () =>
+            (await gateway.getRequests("sessions.list", primaryQuery)).length - primaryBefore,
+        )
+        .toBe(1);
       await captureUiProof(suite, page, "roster-own-agent-updated.png");
     } finally {
       await suite.closeBrowserContext(context);

--- a/ui/src/e2e/sidebar-session-stability.e2e.test.ts
+++ b/ui/src/e2e/sidebar-session-stability.e2e.test.ts
@@ -64,6 +64,30 @@ suite.define(() => {
       await expect.poll(() => sibling.textContent()).toContain("Supporting research");
       expect(await child.getAttribute("class")).toContain("sidebar-recent-session--active");
       const childMatch = { spawnedBy: parentKey };
+      const refreshedChildren = [
+        {
+          ...childRow,
+          label: "Research completed",
+          displayName: "Research completed",
+          updatedAt: baseTime + 3,
+        },
+        {
+          ...siblingRow,
+          label: "Supporting research refreshed",
+          displayName: "Supporting research refreshed",
+          updatedAt: baseTime + 3,
+        },
+      ];
+      // Commit the change before its invalidation event so every later read sees it.
+      await gateway.setSessionsListResponse(
+        sessionsListResponse([parentRow, ...refreshedChildren]),
+      );
+      await gateway.setMethodResponse("sessions.list", {
+        cases: [
+          { match: childMatch, response: sessionsListResponse(refreshedChildren) },
+          { response: sessionsListResponse([parentRow]) },
+        ],
+      });
       const childRequests = (await gateway.getRequests("sessions.list", childMatch)).length;
       expect(childRequests).toBeGreaterThan(0);
       await gateway.deferNext("sessions.list", childMatch);
@@ -74,23 +98,7 @@ suite.define(() => {
         updatedAt: baseTime + 2,
       });
       await gateway.waitForRequest("sessions.list", { after: childRequests, match: childMatch });
-      await gateway.resolveDeferred(
-        "sessions.list",
-        sessionsListResponse([
-          {
-            ...childRow,
-            label: "Research completed",
-            displayName: "Research completed",
-            updatedAt: baseTime + 3,
-          },
-          {
-            ...siblingRow,
-            label: "Supporting research refreshed",
-            displayName: "Supporting research refreshed",
-            updatedAt: baseTime + 3,
-          },
-        ]),
-      );
+      await gateway.resolveDeferred("sessions.list", sessionsListResponse(refreshedChildren));
       // The sibling proves the new child snapshot rendered before checking the selected row.
       await expect.poll(() => sibling.textContent()).toContain("Supporting research refreshed");
       if (captureUiProofEnabled) {

--- a/ui/src/lib/sessions/index.child-event-refresh.test.ts
+++ b/ui/src/lib/sessions/index.child-event-refresh.test.ts
@@ -1,0 +1,164 @@
+// @vitest-environment node
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { expect, it, vi } from "vitest";
+import type { GatewaySessionRow } from "../../api/types.ts";
+import { createTestGatewayClient } from "../../test-helpers/gateway-client.ts";
+import {
+  createGatewayHarness,
+  createTestSessionCapability,
+  sessionsResult,
+} from "./session-capability.test-support.ts";
+
+const parent = "agent:main:parent";
+const known: GatewaySessionRow = {
+  key: "agent:worker:subagent:known",
+  sessionId: "known-session",
+  kind: "direct",
+  spawnedBy: parent,
+  updatedAt: 1,
+};
+const added: GatewaySessionRow = {
+  key: "agent:research:subagent:added",
+  sessionId: "added-session",
+  kind: "direct",
+  parentSessionKey: parent,
+  updatedAt: 2,
+};
+
+it.each([
+  {
+    name: "unrelated agent activity",
+    payload: { sessionKey: "agent:research:other", reason: "update" },
+    refresh: false,
+  },
+  {
+    name: "unrelated same-agent root",
+    payload: { sessionKey: "agent:main:other", reason: "update" },
+    refresh: false,
+  },
+  {
+    name: "cross-agent child creation",
+    payload: { sessionKey: added.key, parentSessionKey: parent, reason: "create" },
+    refresh: true,
+    rows: [added],
+  },
+  {
+    name: "new runtime-controlled child",
+    payload: { sessionKey: added.key, controlOwnerSessionKey: parent, reason: "create" },
+    refresh: true,
+    rows: [added],
+  },
+  {
+    name: "new persisted child",
+    payload: {
+      sessionKey: added.key,
+      session: { ...added, parentSessionKey: undefined, spawnedBy: parent },
+      reason: "create",
+    },
+    refresh: true,
+    rows: [added],
+  },
+  {
+    name: "known child deletion before list reconciliation",
+    payload: { sessionKey: known.key, sessionId: known.sessionId, reason: "delete" },
+    refresh: true,
+    rows: [],
+  },
+  {
+    name: "key-only lifecycle deletion",
+    payload: { sessionKey: known.key, reason: "delete" },
+    refresh: true,
+    rows: [],
+  },
+  {
+    name: "known child moved to another parent",
+    payload: {
+      sessionKey: known.key,
+      session: { ...known, spawnedBy: "agent:other:parent", updatedAt: 2 },
+      reason: "move",
+    },
+    refresh: true,
+    rows: [],
+  },
+  { name: "parent Swarm change", payload: { sessionKey: parent, reason: "swarm" }, refresh: true },
+  {
+    name: "parent change for an explicitly cross-agent child query",
+    payload: { sessionKey: parent, reason: "swarm" },
+    queryAgent: "worker",
+    refresh: true,
+  },
+  { name: "global membership invalidation", payload: { reason: "delete" }, refresh: true },
+  {
+    name: "sparse event for an unloaded child page",
+    payload: { sessionKey: "agent:research:unloaded", reason: "delete" },
+    refresh: true,
+    incomplete: true,
+  },
+  {
+    name: "off-page child reparented outside an incomplete window",
+    payload: {
+      sessionKey: "agent:research:off-page-child",
+      parentSessionKey: "agent:research:parent",
+      reason: "move",
+    },
+    refresh: true,
+    incomplete: true,
+  },
+  {
+    name: "unrelated explicit lineage in a complete window",
+    payload: {
+      sessionKey: "agent:research:other",
+      parentSessionKey: "agent:research:parent",
+      reason: "create",
+    },
+    refresh: false,
+  },
+])(
+  "refreshes a parent-scoped child query only for $name",
+  async ({ payload, refresh, rows, incomplete, queryAgent }) => {
+    vi.useFakeTimers();
+    let currentRows = [known];
+    const request = vi.fn(async (method: string, params?: unknown) => {
+      if (method !== "sessions.list") {
+        throw new Error(`Unexpected request: ${method}`);
+      }
+      const children = isRecord(params) && params.spawnedBy === parent;
+      return {
+        ...sessionsResult(children ? currentRows : [], 1),
+        hasMore: children && incomplete === true,
+        totalCount: children && incomplete ? 10_001 : children ? currentRows.length : 0,
+      };
+    });
+    const { gateway, emitEvent } = createGatewayHarness(createTestGatewayClient(request));
+    const sessions = createTestSessionCapability(gateway);
+    const query = {
+      spawnedBy: parent,
+      limit: 10_000,
+      includeGlobal: false,
+      includeUnknown: false,
+      ...(queryAgent ? { agentId: queryAgent } : {}),
+    };
+    const observer = sessions.observeList(query, () => undefined);
+    try {
+      await sessions.refresh({ agentId: "main", force: true });
+      await observer.refresh();
+      request.mockClear();
+      currentRows = rows ?? currentRows;
+      emitEvent({ type: "event", event: "sessions.changed", payload });
+      await vi.advanceTimersByTimeAsync(250);
+      const childRequests = request.mock.calls.filter(
+        ([, params]) => isRecord(params) && params.spawnedBy === parent,
+      );
+      expect(childRequests).toHaveLength(refresh ? 1 : 0);
+      if (refresh) {
+        expect(sessions.listSnapshot(query).result?.sessions.map((entry) => entry.key)).toEqual(
+          currentRows.map((entry) => entry.key),
+        );
+      }
+    } finally {
+      observer.dispose();
+      sessions.dispose();
+      vi.useRealTimers();
+    }
+  },
+);

--- a/ui/src/lib/sessions/index.ts
+++ b/ui/src/lib/sessions/index.ts
@@ -544,6 +544,7 @@ export function createSessionCapability(
         parseAgentSessionKey(eventInfo?.key)?.agentId ??
         (typeof payloadAgentId === "string" ? payloadAgentId : undefined),
       primarySnapshotApplied,
+      event: event.payload,
     });
   });
 

--- a/ui/src/lib/sessions/session-capability.ts
+++ b/ui/src/lib/sessions/session-capability.ts
@@ -214,6 +214,8 @@ export type SessionCapability = {
   observeRow: (
     target: SessionRowTarget,
     listener: (row: GatewaySessionRow | null) => void,
+    /** Matching events can omit descriptor-only fields; re-read those without watching roster revisions. */
+    options?: { onInvalidate?: () => void },
   ) => SessionRowObservation;
   /** Preserve an existing row observation through a local presentation copy. */
   inheritRow: (

--- a/ui/src/lib/sessions/session-list-query.ts
+++ b/ui/src/lib/sessions/session-list-query.ts
@@ -1,3 +1,4 @@
+import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
 import type { SessionsListResult } from "../../api/types.ts";
 import type { createSessionEventRefreshCoordinator } from "./event-refresh-coordinator.ts";
 import type {
@@ -7,12 +8,17 @@ import type {
   SessionListSnapshot,
   SessionRefreshOptions,
 } from "./session-capability.ts";
-import { normalizeAgentId } from "./session-key.ts";
+import {
+  normalizeAgentId,
+  areUiSessionKeysEquivalent,
+  parseAgentSessionKey,
+} from "./session-key.ts";
 import {
   buildSessionListParams,
   DEFAULT_SESSION_LIST_QUERY,
   normalizeManagedSessionListQuery,
 } from "./session-requests.ts";
+import { readSessionChangedEvent } from "./session-row-reconcile.ts";
 
 export function isForegroundReplacement(options: SessionRefreshOptions): boolean {
   return options.append !== true && options.backgroundHydrate !== true;
@@ -22,6 +28,52 @@ export function sessionListAgentMatcher(agentId?: string | null) {
   const normalized = agentId ? normalizeAgentId(agentId) : null;
   return (queryAgentId?: string) =>
     !normalized || !queryAgentId?.trim() || normalizeAgentId(queryAgentId) === normalized;
+}
+
+/** Capture membership before event reconciliation can remove or move a known child. */
+export function sessionListEventMatcher(payload: unknown) {
+  const info = readSessionChangedEvent(payload);
+  const event = asOptionalRecord(payload);
+  const source = asOptionalRecord(event?.session) ?? event;
+  const agentId =
+    info?.agentId ??
+    parseAgentSessionKey(info?.key)?.agentId ??
+    (typeof event?.agentId === "string" ? event.agentId : undefined);
+  const matchesAgent = sessionListAgentMatcher(agentId);
+  const owners = [
+    source?.controlOwnerSessionKey,
+    source?.spawnedBy,
+    source?.parentSessionKey,
+    event?.parentSessionKey,
+  ].filter((owner): owner is string => typeof owner === "string" && owner.trim().length > 0);
+  return (entry: ManagedSessionList): boolean => {
+    const parent = entry.scope.spawnedBy;
+    if (parent && info && areUiSessionKeysEquivalent(info.key, parent)) {
+      return true;
+    }
+    if (!matchesAgent(sessionListQueryAgentId(entry.query))) {
+      return false;
+    }
+    if (!parent || !info) {
+      return true;
+    }
+    if (
+      entry.snapshot.result?.sessions.some((row) =>
+        areUiSessionKeysEquivalent(row.key, info.key),
+      ) ||
+      owners.some((owner) => areUiSessionKeysEquivalent(owner, parent))
+    ) {
+      return true;
+    }
+    // An incomplete window cannot rule out a former child beyond its loaded page,
+    // even when a move event names its new parent explicitly.
+    const result = entry.snapshot.result;
+    return (
+      !result ||
+      result.hasMore === true ||
+      (result.totalCount ?? result.sessions.length) > result.sessions.length
+    );
+  };
 }
 
 export type QueuedSessionRefresh = {

--- a/ui/src/lib/sessions/session-reconciliation.ts
+++ b/ui/src/lib/sessions/session-reconciliation.ts
@@ -266,13 +266,14 @@ export function createSessionReconciliation(host: Host) {
     return rowIsCurrent;
   };
 
-  const observeRow: SessionCapability["observeRow"] = (target, listener) => {
+  const observeRow: SessionCapability["observeRow"] = (target, listener, options) => {
     const { roster, deletions } = host;
     if (!target.key.trim() || !target.agentId.trim()) {
       throw new Error("A session row observation requires a session key and explicit agent.");
     }
     const owned = { key: target.key.trim(), agentId: normalizeAgentId(target.agentId) };
     const registration = roster.registerRow(owned, listener, {
+      onInvalidate: options?.onInvalidate,
       isValid: (sessionId) => deletions.acceptsGeneration(owned.key, sessionId, owned.agentId),
       decorate: (row) =>
         deletions.deletionState(row.key, owned.agentId, row.sessionId)
@@ -533,7 +534,10 @@ export function createSessionReconciliation(host: Host) {
         if (reduced.admittedRow || reduced.deletedKey) {
           acceptedResult ??= reduced;
         }
-        return { row: reduced.row ?? null };
+        return {
+          row: reduced.row ?? null,
+          ...(!reduced.deletedKey ? { invalidateRevision: eventObservation.revision } : {}),
+        };
       },
       false,
       managedAdmissions,

--- a/ui/src/lib/sessions/session-roster-observations.ts
+++ b/ui/src/lib/sessions/session-roster-observations.ts
@@ -32,6 +32,7 @@ type RegisteredSessionRow = {
     retired: boolean;
   };
   listener: (row: GatewaySessionRow | null) => void;
+  onInvalidate?: () => void;
   isValid: (sessionId: string) => boolean;
   decorate: (row: GatewaySessionRow) => GatewaySessionRow | null;
 };
@@ -253,12 +254,14 @@ export function createSessionRosterObservations(
       const row =
         projected.row &&
         (held !== null || admitRead) &&
-        acceptsRow(
-          entry,
-          projected.row,
-          projected.readRevision ?? rowRevision(projected.row),
-          admitRead,
-        )
+        // Invalidation fences incoming reads; unrelated passes retain the already-held facts.
+        (projected.row === held ||
+          acceptsRow(
+            entry,
+            projected.row,
+            projected.readRevision ?? rowRevision(projected.row),
+            admitRead,
+          ))
           ? projected.row
           : null;
       const decorated = row ? entry.decorate(row) : null;
@@ -269,9 +272,10 @@ export function createSessionRosterObservations(
         identity(decorated, entry.target.agentId) === identity(row, entry.target.agentId)
           ? inheritRow(decorated, row)
           : null;
-      const invalidatedRevision = !previous.row
-        ? Math.max(previous.invalidatedRevision, projected.invalidateRevision ?? 0)
-        : previous.invalidatedRevision;
+      const invalidatedRevision =
+        !previous.row || entry.onInvalidate
+          ? Math.max(previous.invalidatedRevision, projected.invalidateRevision ?? 0)
+          : previous.invalidatedRevision;
       if (
         row !== previous.row ||
         visible !== previous.visible ||
@@ -335,7 +339,7 @@ export function createSessionRosterObservations(
           listener(snapshot);
         }
       }
-      for (const { entry, snapshot } of rowChanges) {
+      for (const { entry, previous, snapshot } of rowChanges) {
         if (!host.connection.isCurrent(scope)) {
           return;
         }
@@ -345,6 +349,13 @@ export function createSessionRosterObservations(
           entry.snapshot === snapshot
         ) {
           entry.listener(snapshot.visible);
+          if (
+            registrationIsCurrent(entry) &&
+            entry.snapshot === snapshot &&
+            snapshot.invalidatedRevision > previous.invalidatedRevision
+          ) {
+            entry.onInvalidate?.();
+          }
         }
       }
     };
@@ -397,7 +408,7 @@ export function createSessionRosterObservations(
       this: void,
       target: SessionRowTarget,
       listener: (row: GatewaySessionRow | null) => void,
-      options: Pick<RegisteredSessionRow, "isValid" | "decorate">,
+      options: Pick<RegisteredSessionRow, "isValid" | "decorate" | "onInvalidate">,
     ) {
       const entry: RegisteredSessionRow = {
         target: Object.freeze({ ...target }),

--- a/ui/src/lib/sessions/session-roster-refresh.ts
+++ b/ui/src/lib/sessions/session-roster-refresh.ts
@@ -25,6 +25,7 @@ import {
   prepareSessionRefreshOptions,
   retainSessionPaginationWindow,
   sessionListAgentMatcher,
+  sessionListEventMatcher,
   sessionListQueryAgentId,
   type ManagedSessionList,
   type QueuedSessionRefresh,
@@ -66,7 +67,11 @@ export function createSessionRosterRefresh(host: SessionRosterRefreshHost) {
   let requestRevision = 0;
   const eventRevisions = new WeakMap<
     object,
-    { revision: number; scope: SessionConnectionScope | null }
+    {
+      revision: number;
+      scope: SessionConnectionScope | null;
+      lists: ReadonlySet<ManagedSessionList>;
+    }
   >();
   const captureEvent = (payload: unknown) => {
     if (!payload || typeof payload !== "object") {
@@ -76,7 +81,11 @@ export function createSessionRosterRefresh(host: SessionRosterRefreshHost) {
     if (previous !== undefined) {
       return previous;
     }
-    const observation = { revision: ++requestRevision, scope: host.connection.capture() };
+    const observation = {
+      revision: ++requestRevision,
+      scope: host.connection.capture(),
+      lists: new Set([...managedLists.values()].filter(sessionListEventMatcher(payload))),
+    };
     eventRevisions.set(payload, observation);
     return observation;
   };
@@ -644,12 +653,25 @@ export function createSessionRosterRefresh(host: SessionRosterRefreshHost) {
     // Gateway-owned membership filters require an authoritative list refresh.
     canApplyPrimarySnapshot: () => isPrimarySessionListQuery(lastListOptions),
     invalidateManagedLists,
-    scheduleEvent(options: { agentId?: string | null; primarySnapshotApplied?: boolean } = {}) {
+    scheduleEvent(
+      options: { agentId?: string | null; primarySnapshotApplied?: boolean; event?: unknown } = {},
+    ) {
       const matchesAgent = sessionListAgentMatcher(options.agentId);
       if (!options.primarySnapshotApplied && matchesAgent(lastListOptions.agentId)) {
         eventRefreshCoordinator.schedule();
       }
-      invalidateManagedLists(options.agentId);
+      const event = options.event;
+      const affected =
+        event && typeof event === "object" ? eventRevisions.get(event)?.lists : undefined;
+      if (affected) {
+        for (const entry of managedLists.values()) {
+          if (affected.has(entry)) {
+            entry.coordinator.schedule();
+          }
+        }
+      } else {
+        invalidateManagedLists(options.agentId);
+      }
     },
     reset() {
       observations.reset();

--- a/ui/src/lib/sessions/session-row-observation.test.ts
+++ b/ui/src/lib/sessions/session-row-observation.test.ts
@@ -153,6 +153,46 @@ async function descriptorOwner(initial: GatewaySessionRow, primary = mainRow) {
 }
 
 describe("session row observations", () => {
+  it("invalidates descriptor reads only for the observed target and current connection", async () => {
+    vi.useFakeTimers();
+    const { gateway, emitEvent, publish } = createGatewayHarness(
+      createTestGatewayClient(async () => sessionsResult([], 1)),
+    );
+    const sessions = createTestSessionCapability(gateway);
+    const invalidated = vi.fn();
+    const observation = sessions.observeRow({ key: "global", agentId: "work" }, () => undefined, {
+      onInvalidate: invalidated,
+    });
+    try {
+      expect(observation.captureReconcile()(workRow)).toMatchObject({ status: "current" });
+      const pending = observation.captureReconcile();
+      const event = (agentId: string, key = "global") => ({
+        type: "event" as const,
+        event: "sessions.changed",
+        payload: { agentId, key, reason: "patch" },
+      });
+      emitEvent(event("main"));
+      emitEvent(event("work", "agent:work:unrelated"));
+      expect(invalidated).not.toHaveBeenCalled();
+      await sessions.refresh({ agentId: "main", force: true });
+      expect(invalidated).not.toHaveBeenCalled();
+      emitEvent(event("work"));
+      expect(invalidated).toHaveBeenCalledTimes(1);
+      emitEvent(event("work", "agent:work:unrelated"));
+      expect(observation.row).toEqual(workRow);
+      expect(invalidated).toHaveBeenCalledTimes(1);
+      expect(pending(workRow)).toEqual({ status: "invalidated" });
+      expect(observation.captureReconcile()(workRow)).toMatchObject({ status: "current" });
+      publish(false);
+      emitEvent(event("work"));
+      expect(invalidated).toHaveBeenCalledTimes(1);
+    } finally {
+      observation.dispose();
+      sessions.dispose();
+      vi.useRealTimers();
+    }
+  });
+
   it.each(["primary", "managed", "supplemental", "event"] as const)(
     "notifies a retired descriptor after its admitted %s successor is published",
     async (source) => {

--- a/ui/src/lib/sessions/swarm-roster.test.ts
+++ b/ui/src/lib/sessions/swarm-roster.test.ts
@@ -234,6 +234,53 @@ describe("SwarmRosterHydrator", () => {
     }
   });
 
+  it.each(["canonical", "filtered"] as const)(
+    "revalidates a changed %s parent summary received during the initial describe",
+    async (source) => {
+      vi.useFakeTimers();
+      const stale = createDeferred<GatewaySessionRow>();
+      const initial = { ...swarmParent([row(0)]), updatedAt: 1 };
+      const current = { ...swarmParent([row(0), row(1)]), updatedAt: 2 };
+      const summary = {
+        ...current,
+        swarm: {
+          ...current.swarm!,
+          groups: current.swarm!.groups.map(({ children: _children, ...group }) => group),
+        },
+      };
+      const readParent = vi.fn().mockReturnValueOnce(stale.promise).mockResolvedValue(current);
+      const sessions = sessionSource(
+        vi.fn(async () => result([], 0, 0)),
+        () => [summary],
+      );
+      const hydrator = new SwarmRosterHydrator();
+      try {
+        hydrator.update({
+          sessions,
+          readParent,
+          parentKey: initial.key,
+          sourceEpoch: 1,
+          currentRows: () => [],
+          onRows: () => undefined,
+        });
+        await vi.advanceTimersByTimeAsync(250);
+        expect(readParent).toHaveBeenCalledTimes(1);
+        if (source === "canonical") {
+          await sessions.refresh({ agentId: "main", force: true });
+        } else {
+          await sessions.refreshList({ agentId: "main", archivedFilter: "all", force: true });
+        }
+        expect(hydrator.rows).toEqual([summary]);
+        stale.resolve(initial);
+        await vi.advanceTimersByTimeAsync(0);
+        expect(readParent).toHaveBeenCalledTimes(2);
+        expect(hydrator.rows).toEqual([current]);
+      } finally {
+        hydrator.dispose();
+      }
+    },
+  );
+
   it("coalesces a changed parent summary and its event invalidation into one describe", async () => {
     vi.useFakeTimers();
     let parent = swarmParent([row(0)]);
@@ -342,6 +389,34 @@ describe("SwarmRosterHydrator", () => {
     }
   });
 
+  it("rechecks parent membership when the first child page disagrees with an earlier describe", async () => {
+    vi.useFakeTimers();
+    const firstPage = createDeferred<SessionsListResult>();
+    const initial = swarmParent([row(0)]);
+    const current = swarmParent([row(1)]);
+    const readParent = vi.fn().mockResolvedValueOnce(initial).mockResolvedValue(current);
+    const sessions = sessionSource(vi.fn(() => firstPage.promise));
+    const hydrator = new SwarmRosterHydrator();
+    try {
+      hydrator.update({
+        sessions,
+        readParent,
+        parentKey: initial.key,
+        sourceEpoch: 1,
+        currentRows: () => [],
+        onRows: () => undefined,
+      });
+      await vi.advanceTimersByTimeAsync(250);
+      expect(hydrator.rows).toEqual([initial]);
+      firstPage.resolve(result([row(1)], 0, 1));
+      await vi.advanceTimersByTimeAsync(0);
+      expect(readParent).toHaveBeenCalledTimes(2);
+      expect(hydrator.rows).toEqual([expect.objectContaining({ key: row(1).key }), current]);
+    } finally {
+      hydrator.dispose();
+    }
+  });
+
   it("clears rows when the gateway source epoch changes", () => {
     vi.useFakeTimers();
     const onRows = vi.fn();
@@ -419,7 +494,7 @@ describe("SwarmRosterHydrator", () => {
       .mockResolvedValue(result([row(0)], 0, 1));
     const hydrator = new SwarmRosterHydrator();
     const sessions = sessionSource(list);
-    const readParent = vi.fn(async () => parentRow());
+    const readParent = vi.fn(async () => swarmParent([row(0)]));
 
     hydrator.update({
       sessions,

--- a/ui/src/lib/sessions/swarm-roster.test.ts
+++ b/ui/src/lib/sessions/swarm-roster.test.ts
@@ -1,9 +1,14 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { afterEach, describe, expect, it, onTestFinished, vi } from "vitest";
 import { createDeferred } from "../../../../test/helpers/promise.js";
 import { GatewayRequestError } from "../../api/gateway.ts";
 import type { GatewaySessionRow, SessionsListResult } from "../../api/types.ts";
+import { createTestGatewayClient } from "../../test-helpers/gateway-client.ts";
 import type { SessionCapability, SessionListOptions } from "./index.ts";
-import { createSessionRowProvenance } from "./session-row-provenance.ts";
+import {
+  createGatewayHarness,
+  createTestSessionCapability,
+} from "./session-capability.test-support.ts";
 import {
   hydrateSwarmSessionRows,
   isSwarmEnabledInConfig,
@@ -14,6 +19,7 @@ import {
 function row(index: number): GatewaySessionRow {
   return {
     key: `agent:worker:subagent:${index}`,
+    sessionId: `child-session-${index}`,
     kind: "direct",
     updatedAt: index,
     spawnedBy: "agent:main:parent",
@@ -21,13 +27,62 @@ function row(index: number): GatewaySessionRow {
   };
 }
 
-function sessionSource(list: SessionCapability["list"], revision: () => number = () => 0) {
-  return {
-    get canonicalListRevision() {
-      return revision();
+function sessionSource(
+  list: SessionCapability["list"],
+  primaryRows: () => GatewaySessionRow[] = () => [],
+) {
+  const client = createTestGatewayClient(async (method, params) => {
+    if (method === "sessions.list") {
+      const rows = primaryRows();
+      return isRecord(params) && params.spawnedBy ? list(params) : result(rows, 0, rows.length);
+    }
+    return { subscribed: true };
+  });
+  const { gateway, emitEvent } = createGatewayHarness(client);
+  const sessions = createTestSessionCapability(gateway);
+  onTestFinished(() => sessions.dispose());
+  return Object.assign(sessions, {
+    publishRow(entry: GatewaySessionRow) {
+      emitEvent({
+        type: "event",
+        event: "sessions.changed",
+        payload: { key: entry.key, session: entry, reason: "patch" },
+      });
     },
-    list,
-    inheritRow: createSessionRowProvenance().inheritRow,
+    invalidateParent(key = "agent:main:parent", agentId = "main") {
+      emitEvent({
+        type: "event",
+        event: "sessions.changed",
+        payload: { key, agentId, reason: "patch" },
+      });
+    },
+  });
+}
+
+function parentRow(): GatewaySessionRow {
+  return { key: "agent:main:parent", sessionId: "parent-session", kind: "direct" };
+}
+
+function swarmParent(children: GatewaySessionRow[]): GatewaySessionRow {
+  return {
+    ...parentRow(),
+    swarm: {
+      groups: [
+        {
+          groupId: row(0).swarmGroupId!,
+          createdAt: 1,
+          queued: 0,
+          running: children.filter((child) => child.status !== "done").length,
+          done: children.filter((child) => child.status === "done").length,
+          failed: 0,
+          children: children.map((child) => ({
+            sessionKey: child.key,
+            status: child.status === "done" ? "done" : "running",
+          })),
+        },
+      ],
+      otherActiveGroups: 0,
+    },
   };
 }
 
@@ -123,6 +178,170 @@ describe("isSwarmEnabledInConfig", () => {
 });
 
 describe("SwarmRosterHydrator", () => {
+  it("keeps child requests and parent reads independent of unrelated canonical roster publications", async () => {
+    vi.useFakeTimers();
+    let children = [row(0)];
+    const detailedParent = () => swarmParent(children);
+    const list = vi.fn(async () => result(children, 0, children.length));
+    const readParent = vi.fn(async () => detailedParent());
+    const sessions = sessionSource(list, () => {
+      const parent = detailedParent();
+      return [
+        {
+          ...parent,
+          swarm: {
+            ...parent.swarm!,
+            groups: parent.swarm!.groups.map(({ children: _children, ...group }) => group),
+          },
+        },
+      ];
+    });
+    const hydrator = new SwarmRosterHydrator();
+    const params = {
+      sessions,
+      readParent,
+      parentKey: "agent:main:parent",
+      sourceEpoch: 1,
+      currentRows: () => [],
+      onRows: () => undefined,
+    };
+    try {
+      hydrator.update(params);
+      await vi.advanceTimersByTimeAsync(250);
+      expect(hydrator.rows.map((entry) => entry.key)).toEqual([row(0).key, parentRow().key]);
+      for (let publication = 0; publication < 10; publication++) {
+        await sessions.refresh({ agentId: "main", force: true });
+        hydrator.update(params);
+        await vi.advanceTimersByTimeAsync(250);
+      }
+      expect(list).toHaveBeenCalledTimes(1);
+      expect(readParent).toHaveBeenCalledTimes(1);
+      expect(hydrator.rows.find((entry) => entry.key === parentRow().key)?.swarm).toEqual(
+        detailedParent().swarm,
+      );
+
+      children = [{ ...row(1), label: "New child", status: "done" }];
+      sessions.invalidateParent();
+      await vi.advanceTimersByTimeAsync(250);
+      expect(list).toHaveBeenCalledTimes(2);
+      expect(readParent).toHaveBeenCalledTimes(2);
+      expect(hydrator.rows).toEqual([
+        expect.objectContaining({ key: row(1).key, label: "New child", status: "done" }),
+        detailedParent(),
+      ]);
+    } finally {
+      hydrator.dispose();
+    }
+  });
+
+  it("coalesces a changed parent summary and its event invalidation into one describe", async () => {
+    vi.useFakeTimers();
+    let parent = swarmParent([row(0)]);
+    const readParent = vi.fn(async () => parent);
+    const sessions = sessionSource(vi.fn(async () => result([], 0, 0)));
+    const hydrator = new SwarmRosterHydrator();
+    try {
+      hydrator.update({
+        sessions,
+        readParent,
+        parentKey: parent.key,
+        sourceEpoch: 1,
+        currentRows: () => [],
+        onRows: () => undefined,
+      });
+      await vi.advanceTimersByTimeAsync(250);
+      expect(readParent).toHaveBeenCalledTimes(1);
+      parent = swarmParent([row(0), row(1)]);
+      sessions.publishRow({
+        ...parent,
+        swarm: {
+          ...parent.swarm!,
+          groups: parent.swarm!.groups.map(({ children: _children, ...group }) => group),
+        },
+      });
+      await vi.advanceTimersByTimeAsync(250);
+      expect(readParent).toHaveBeenCalledTimes(2);
+      expect(hydrator.rows.find((entry) => entry.key === parent.key)?.swarm).toEqual(parent.swarm);
+    } finally {
+      hydrator.dispose();
+    }
+  });
+
+  it("rechecks a parent after an invalidated denial without clearing newer intent", async () => {
+    vi.useFakeTimers();
+    const stale = createDeferred<GatewaySessionRow>();
+    const initial = swarmParent([row(0)]);
+    const current = swarmParent([row(1)]);
+    const readParent = vi
+      .fn()
+      .mockResolvedValueOnce(initial)
+      .mockReturnValueOnce(stale.promise)
+      .mockResolvedValue(current);
+    const sessions = sessionSource(vi.fn(async () => result([], 0, 0)));
+    const hydrator = new SwarmRosterHydrator();
+    try {
+      hydrator.update({
+        sessions,
+        readParent,
+        parentKey: initial.key,
+        sourceEpoch: 1,
+        currentRows: () => [],
+        onRows: () => undefined,
+      });
+      await vi.advanceTimersByTimeAsync(250);
+      sessions.invalidateParent();
+      await vi.advanceTimersByTimeAsync(0);
+      expect(readParent).toHaveBeenCalledTimes(2);
+      sessions.invalidateParent();
+      stale.reject(
+        new GatewayRequestError({ code: "INVALID_REQUEST", message: "Old parent read denied" }),
+      );
+      await vi.advanceTimersByTimeAsync(0);
+      expect(readParent).toHaveBeenCalledTimes(3);
+      expect(hydrator.rows).toEqual([current]);
+    } finally {
+      hydrator.dispose();
+    }
+  });
+
+  it("queues fresh parent membership when a child-only change overlaps an older describe", async () => {
+    vi.useFakeTimers();
+    const stale = createDeferred<GatewaySessionRow>();
+    let children = [row(0)];
+    const initial = swarmParent(children);
+    const current = swarmParent([row(1)]);
+    const readParent = vi
+      .fn()
+      .mockResolvedValueOnce(initial)
+      .mockReturnValueOnce(stale.promise)
+      .mockResolvedValue(current);
+    const sessions = sessionSource(vi.fn(async () => result(children, 0, children.length)));
+    const hydrator = new SwarmRosterHydrator();
+    try {
+      hydrator.update({
+        sessions,
+        readParent,
+        parentKey: initial.key,
+        sourceEpoch: 1,
+        currentRows: () => [],
+        onRows: () => undefined,
+      });
+      await vi.advanceTimersByTimeAsync(250);
+      sessions.invalidateParent();
+      await vi.advanceTimersByTimeAsync(0);
+      expect(readParent).toHaveBeenCalledTimes(2);
+      children = [row(1)];
+      sessions.publishRow(children[0]!);
+      await vi.advanceTimersByTimeAsync(250);
+      stale.resolve(initial);
+      await vi.advanceTimersByTimeAsync(0);
+      expect(readParent).toHaveBeenCalledTimes(3);
+      expect(hydrator.rows).toEqual([expect.objectContaining({ key: row(1).key }), current]);
+    } finally {
+      hydrator.dispose();
+    }
+  });
+
   it("clears rows when the gateway source epoch changes", () => {
     vi.useFakeTimers();
     const onRows = vi.fn();
@@ -131,7 +350,7 @@ describe("SwarmRosterHydrator", () => {
 
     hydrator.update({
       sessions,
-      readParent: async () => ({ key: "agent:main:parent", kind: "direct" as const }),
+      readParent: async () => parentRow(),
       parentKey: "agent:main:parent",
       sourceEpoch: 1,
       currentRows: () => [row(0)],
@@ -141,7 +360,7 @@ describe("SwarmRosterHydrator", () => {
 
     hydrator.update({
       sessions,
-      readParent: async () => ({ key: "agent:main:parent", kind: "direct" as const }),
+      readParent: async () => parentRow(),
       parentKey: "agent:main:parent",
       sourceEpoch: 2,
       currentRows: () => [],
@@ -163,7 +382,7 @@ describe("SwarmRosterHydrator", () => {
 
     const params = {
       sessions,
-      readParent: async () => ({ key: "agent:main:parent", kind: "direct" as const }),
+      readParent: async () => parentRow(),
       parentKey: "agent:main:parent",
       sourceEpoch: 1,
       currentRows: () => currentRows,
@@ -180,7 +399,9 @@ describe("SwarmRosterHydrator", () => {
       expect.objectContaining({ status: "done" }),
     ]);
     currentRows = [{ ...running, status: "failed" }];
+    sessions.publishRow(currentRows[0]!);
     hydrator.update(params);
+    await vi.advanceTimersByTimeAsync(0);
     expect(hydrator.rows.filter((entry) => entry.key !== "agent:main:parent")).toEqual([
       expect.objectContaining({ status: "failed" }),
     ]);
@@ -198,10 +419,11 @@ describe("SwarmRosterHydrator", () => {
       .mockResolvedValue(result([row(0)], 0, 1));
     const hydrator = new SwarmRosterHydrator();
     const sessions = sessionSource(list);
+    const readParent = vi.fn(async () => parentRow());
 
     hydrator.update({
       sessions,
-      readParent: async () => ({ key: "agent:main:parent", kind: "direct" as const }),
+      readParent,
       parentKey: "agent:main:parent",
       sourceEpoch: 1,
       currentRows: () => [],
@@ -210,10 +432,46 @@ describe("SwarmRosterHydrator", () => {
     await vi.runAllTimersAsync();
 
     expect(list).toHaveBeenCalledTimes(4);
+    expect(readParent).toHaveBeenCalledTimes(1);
     expect(hydrator.rows.filter((entry) => entry.key !== "agent:main:parent")).toEqual([
       expect.objectContaining({ key: row(0).key }),
     ]);
     hydrator.dispose();
+  });
+
+  it("backs off parent failures without reloading healthy child rows", async () => {
+    vi.useFakeTimers();
+    const list = vi.fn(async () => result([row(0)], 0, 1));
+    const readParent = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("parent unavailable"))
+      .mockRejectedValueOnce(new Error("parent unavailable"))
+      .mockRejectedValueOnce(new Error("parent unavailable"))
+      .mockRejectedValueOnce(new Error("parent unavailable"))
+      .mockResolvedValue(parentRow());
+    const hydrator = new SwarmRosterHydrator();
+    try {
+      hydrator.update({
+        sessions: sessionSource(list),
+        parentKey: "agent:main:parent",
+        readParent,
+        sourceEpoch: 1,
+        currentRows: () => [],
+        onRows: () => undefined,
+      });
+      await vi.advanceTimersByTimeAsync(250);
+      expect(readParent).toHaveBeenCalledTimes(1);
+      for (const [index, delay] of [1_000, 2_000, 4_000, 8_000].entries()) {
+        await vi.advanceTimersByTimeAsync(delay - 1);
+        expect(readParent).toHaveBeenCalledTimes(index + 1);
+        await vi.advanceTimersByTimeAsync(1);
+        expect(readParent).toHaveBeenCalledTimes(index + 2);
+        expect(list).toHaveBeenCalledTimes(1);
+      }
+      expect(hydrator.rows.map((entry) => entry.key)).toEqual([row(0).key, parentRow().key]);
+    } finally {
+      hydrator.dispose();
+    }
   });
   it("fences an old global owner read and clears a denied parent without restoring stale page totals", async () => {
     vi.useFakeTimers();
@@ -225,19 +483,17 @@ describe("SwarmRosterHydrator", () => {
       key: "global",
       kind: "global",
       agentId: "main",
+      sessionId: "main-global-session",
       label: "Old owner",
     };
     const other: GatewaySessionRow = {
       key: "global",
       kind: "global",
       agentId: "other",
+      sessionId: "other-global-session",
       label: "Current owner",
     };
-    let revision = 1;
-    const sessions = sessionSource(
-      vi.fn(async () => result([], 0, 0)),
-      () => revision,
-    );
+    const sessions = sessionSource(vi.fn(async () => result([], 0, 0)));
     const hydrator = new SwarmRosterHydrator();
     const params = {
       sessions,
@@ -254,9 +510,9 @@ describe("SwarmRosterHydrator", () => {
     release(main);
     await vi.advanceTimersByTimeAsync(0);
     expect(hydrator.rows).toEqual([other]);
-    revision += 1;
     const denied = { ...params, agentId: "other", readParent: async () => null };
     hydrator.update(denied);
+    sessions.invalidateParent("global", "other");
     await vi.advanceTimersByTimeAsync(250);
     expect(hydrator.rows).toEqual([]);
     hydrator.update(denied);
@@ -271,16 +527,14 @@ describe("SwarmRosterHydrator", () => {
     });
     const parent: GatewaySessionRow = {
       key: "agent:main:parent",
+      sessionId: "parent-session",
       kind: "direct",
       swarm: {
         groups: [{ groupId: "group", createdAt: 1, queued: 0, running: 0, done: 25, failed: 5 }],
         otherActiveGroups: 0,
       },
     };
-    const sessions = sessionSource(
-      vi.fn(() => childRead),
-      () => 1,
-    );
+    const sessions = sessionSource(vi.fn(() => childRead));
     const hydrator = new SwarmRosterHydrator();
     hydrator.update({
       sessions,
@@ -304,35 +558,34 @@ describe("SwarmRosterHydrator", () => {
       const children = createDeferred<SessionsListResult>();
       const parent: GatewaySessionRow = {
         key: "agent:main:parent",
+        sessionId: "parent-session",
         kind: "direct",
         swarm: {
           groups: [{ groupId: "group", createdAt: 1, queued: 0, running: 1, done: 0, failed: 0 }],
           otherActiveGroups: 0,
         },
       };
-      let revision = 1;
       const sessions = sessionSource(
         vi
           .fn()
           .mockReturnValueOnce(children.promise)
           .mockResolvedValue(result([], 0, 0)),
-        () => revision,
       );
       const onRows = vi.fn();
       const hydrator = new SwarmRosterHydrator();
+      let currentRows = [parent];
       const params = {
         sessions,
         parentKey: parent.key,
         sourceEpoch: 1,
-        currentRows: () => [parent],
+        currentRows: () => currentRows,
         onRows,
       };
       try {
         hydrator.update({ ...params, readParent: async () => parent });
         await vi.advanceTimersByTimeAsync(250);
         expect(hydrator.rows).toEqual([parent]);
-        revision += 1;
-        hydrator.update({
+        const deniedParams = {
           ...params,
           readParent: async () => {
             if (outcome === "denied") {
@@ -343,8 +596,13 @@ describe("SwarmRosterHydrator", () => {
             }
             return null;
           },
-        });
+        };
+        hydrator.update(deniedParams);
+        sessions.invalidateParent();
         await vi.advanceTimersByTimeAsync(250);
+        expect(hydrator.rows).toEqual([]);
+        currentRows = [parent, { ...row(0), label: "Changed after denial" }];
+        hydrator.update(deniedParams);
         expect(hydrator.rows).toEqual([]);
         children.resolve(result([row(0)], 0, 1));
         await vi.advanceTimersByTimeAsync(0);
@@ -364,29 +622,13 @@ describe("hydrateSwarmSessionRows", () => {
       const offset = options.offset ?? 0;
       return result(children.slice(offset, offset + 10_000), offset, children.length);
     });
-    const currentChild = {
-      ...row(0),
-      status: "running" as const,
-      updatedAt: 2_000,
-    } satisfies GatewaySessionRow;
-    const currentRows: GatewaySessionRow[] = [
-      {
-        key: "agent:main:parent",
-        kind: "direct",
-        updatedAt: 2_000,
-      },
-      currentChild,
-    ];
-
     const rows = await hydrateSwarmSessionRows({
       sessions: sessionSource(list),
       parentKey: "agent:main:parent",
-      currentRows,
       isCurrent: () => true,
     });
 
-    expect(rows).toHaveLength(10_056);
-    expect(rows?.find((candidate) => candidate.key === currentChild.key)?.status).toBe("running");
+    expect(rows).toHaveLength(10_055);
     expect(list).toHaveBeenCalledTimes(2);
     expect(list).toHaveBeenNthCalledWith(
       1,
@@ -398,20 +640,6 @@ describe("hydrateSwarmSessionRows", () => {
       }),
     );
     expect(list).toHaveBeenNthCalledWith(2, expect.objectContaining({ offset: 10_000 }));
-  });
-
-  it("prefers the post-request server row when persisted timestamps tie", async () => {
-    const current = { ...row(0), status: "running" as const, updatedAt: 5 };
-    const fetched = { ...row(0), status: "done" as const, updatedAt: 5 };
-
-    const rows = await hydrateSwarmSessionRows({
-      sessions: sessionSource(vi.fn(async () => result([fetched], 0, 1))),
-      parentKey: "agent:main:parent",
-      currentRows: [current],
-      isCurrent: () => true,
-    });
-
-    expect(rows).toEqual([expect.objectContaining({ key: fetched.key, status: "done" })]);
   });
 
   it("restarts pagination when updated rows move across offset boundaries", async () => {
@@ -433,7 +661,6 @@ describe("hydrateSwarmSessionRows", () => {
     const rows = await hydrateSwarmSessionRows({
       sessions: sessionSource(list),
       parentKey: "agent:main:parent",
-      currentRows: [],
       isCurrent: () => true,
     });
 
@@ -475,7 +702,6 @@ describe("hydrateSwarmSessionRows", () => {
     const rows = await hydrateSwarmSessionRows({
       sessions: sessionSource(vi.fn(async () => result([row(0)], 0, 1))),
       parentKey: "agent:main:parent",
-      currentRows: [],
       isCurrent: () => false,
     });
 

--- a/ui/src/lib/sessions/swarm-roster.ts
+++ b/ui/src/lib/sessions/swarm-roster.ts
@@ -118,6 +118,7 @@ export class SwarmRosterHydrator {
   private childRows: GatewaySessionRow[] = [];
   private parentRequest: Promise<void> | null = null;
   private parentRefreshQueued = false;
+  private publishingParentRead = false;
 
   update(params: SwarmHydrationParams): void {
     const key = `${params.sourceEpoch}:${params.agentId ?? ""}:${params.parentKey}`;
@@ -218,7 +219,7 @@ export class SwarmRosterHydrator {
     this.parentSummary = summary;
     this.rows = this.parentRow ? mergeSwarmSessionRows(this.childRows, [this.parentRow]) : [];
     this.params?.onRows(this.rows);
-    if (parent && changed && this.parent && !this.parentRequest) {
+    if (parent && changed && this.parent && !this.publishingParentRead) {
       void this.readParent();
     }
   }
@@ -266,13 +267,23 @@ export class SwarmRosterHydrator {
     const generation = this.generation;
     const isCurrent = () => generation === this.generation && parent === this.parent;
     const reconcile = parent.captureReconcile();
+    const publish = (row: GatewaySessionRow | undefined) => {
+      // The describe publishes synchronously through its observation. Only external
+      // summaries should queue replacement work behind this same read.
+      this.publishingParentRead = true;
+      try {
+        return reconcile(row);
+      } finally {
+        this.publishingParentRead = false;
+      }
+    };
     const request = Promise.resolve()
       .then(() => params.readParent())
       .then((row) => {
         if (!isCurrent()) {
           return;
         }
-        const outcome = reconcile(row ?? undefined);
+        const outcome = publish(row ?? undefined);
         if (outcome.status === "invalidated") {
           this.parentRefreshQueued = true;
         } else if (outcome.status === "current") {
@@ -284,7 +295,7 @@ export class SwarmRosterHydrator {
           return;
         }
         if (error instanceof GatewayRequestError && error.code === "INVALID_REQUEST") {
-          const outcome = reconcile(undefined);
+          const outcome = publish(undefined);
           if (outcome.status === "invalidated") {
             this.parentRefreshQueued = true;
           } else if (outcome.status === "current") {
@@ -318,7 +329,6 @@ export class SwarmRosterHydrator {
     if (!params || snapshot.loading || !result || result === this.childResult) {
       return;
     }
-    const previousResult = this.childResult;
     this.childResult = result;
     const previousChildren = new Map(this.childRows.map((row) => [row.key, row]));
     const described = new Map(
@@ -345,7 +355,7 @@ export class SwarmRosterHydrator {
         (member?.groupId !== row.swarmGroupId || (row.status && member?.status !== row.status))
       );
     });
-    if (previousResult && this.parentRow && (removedMember || missingDetail)) {
+    if (this.parentRow && (removedMember || missingDetail)) {
       void this.readParent();
     }
     const generation = this.generation;

--- a/ui/src/lib/sessions/swarm-roster.ts
+++ b/ui/src/lib/sessions/swarm-roster.ts
@@ -1,11 +1,25 @@
 import { asNullableRecord } from "@openclaw/normalization-core/record-coerce";
 import { GatewayRequestError } from "../../api/gateway.ts";
-import type { GatewaySessionRow } from "../../api/types.ts";
-import { fetchChildSessionRows } from "./child-session-data.ts";
-import type { SessionCapability } from "./index.ts";
-import { normalizeAgentId, areUiSessionKeysEquivalent } from "./session-key.ts";
+import type { GatewaySessionRow, SessionsListResult } from "../../api/types.ts";
+import type { SessionCapability, SessionListSnapshot, SessionRowObservation } from "./index.ts";
+import { fetchPagedSessionRows } from "./paged-session-rows.ts";
+import {
+  normalizeAgentId,
+  areUiSessionKeysEquivalent,
+  parseAgentSessionKey,
+} from "./session-key.ts";
 
 const SWARM_SESSION_PAGE_SIZE = 10_000;
+
+function childQuery(parentKey: string) {
+  return {
+    spawnedBy: parentKey,
+    limit: SWARM_SESSION_PAGE_SIZE,
+    includeGlobal: false,
+    includeUnknown: false,
+    configuredAgentsOnly: true,
+  };
+}
 
 function readSwarmEnabled(value: unknown): boolean | undefined {
   if (typeof value === "boolean") {
@@ -55,20 +69,24 @@ export function mergeSwarmSessionRows(
 export async function hydrateSwarmSessionRows(params: {
   sessions: Pick<SessionCapability, "list" | "inheritRow">;
   parentKey: string;
-  currentRows: readonly GatewaySessionRow[];
   isCurrent: () => boolean;
+  initialResult?: SessionsListResult;
 }): Promise<GatewaySessionRow[] | null> {
-  const childRows = await fetchChildSessionRows({
-    sessions: params.sessions,
-    parentKey: params.parentKey,
+  const childRows = await fetchPagedSessionRows({
+    list: (offset) => params.sessions.list({ ...childQuery(params.parentKey), offset }),
+    initialResult: params.initialResult,
     isCurrent: params.isCurrent,
-    pageSize: SWARM_SESSION_PAGE_SIZE,
+    missingResultError: "child session list returned no result",
+    mapPageRows: (rows) => {
+      const runtimeSampledAt = Date.now();
+      return rows.map((row) => params.sessions.inheritRow({ ...row, runtimeSampledAt }, row));
+    },
   });
-  return childRows ? mergeSwarmSessionRows(params.currentRows, childRows) : null;
+  return childRows;
 }
 
 type SwarmHydrationParams = {
-  sessions: Pick<SessionCapability, "list" | "inheritRow" | "canonicalListRevision">;
+  sessions: Pick<SessionCapability, "list" | "inheritRow" | "observeRow" | "observeList">;
   agentId?: string;
   readParent: () => Promise<GatewaySessionRow | null>;
   parentKey: string;
@@ -77,132 +95,280 @@ type SwarmHydrationParams = {
   onRows: (rows: GatewaySessionRow[]) => void;
 };
 
+type SwarmRead = "parent" | "children";
+
 export class SwarmRosterHydrator {
   rows: GatewaySessionRow[] = [];
   private key = "";
-  private revision = -1;
   private generation = 0;
-  private attemptRevision = -1;
-  private attempts = 0;
-  private currentRowsByKey = new Map<string, string>();
   private timer: ReturnType<typeof setTimeout> | null = null;
+  private readonly retries: Record<
+    SwarmRead,
+    { attempts: number; timer: ReturnType<typeof setTimeout> | null }
+  > = {
+    parent: { attempts: 0, timer: null },
+    children: { attempts: 0, timer: null },
+  };
+  private params: SwarmHydrationParams | null = null;
+  private parent: SessionRowObservation | null = null;
+  private parentRow: GatewaySessionRow | null = null;
+  private parentSummary = "";
+  private children: ReturnType<SessionCapability["observeList"]> | null = null;
+  private childResult: SessionsListResult | null = null;
+  private childRows: GatewaySessionRow[] = [];
+  private parentRequest: Promise<void> | null = null;
+  private parentRefreshQueued = false;
 
   update(params: SwarmHydrationParams): void {
     const key = `${params.sourceEpoch}:${params.agentId ?? ""}:${params.parentKey}`;
-    if (this.key !== key) {
+    const changed =
+      this.key !== key ||
+      this.params?.sessions !== params.sessions ||
+      (this.parent && !this.parent.isCurrent());
+    if (changed) {
       this.reset(key);
     }
-    const currentRows = params
-      .currentRows()
-      .filter((row) => !areUiSessionKeysEquivalent(row.key, params.parentKey));
-    const currentRowsByKey = new Map(currentRows.map((row) => [row.key, JSON.stringify(row)]));
-    // A repeated page is not a new lifecycle observation. Reapplying it can
-    // overwrite a newer child fetch whose persisted timestamp did not change.
-    this.rows = mergeSwarmSessionRows(
-      this.rows,
-      currentRows.filter(
-        (row) => this.currentRowsByKey.get(row.key) !== currentRowsByKey.get(row.key),
-      ),
-    );
-    this.currentRowsByKey = currentRowsByKey;
-    params.onRows(this.rows);
-    const revision = params.sessions.canonicalListRevision;
-    if (this.attemptRevision !== revision) {
-      this.attemptRevision = revision;
-      this.attempts = 0;
+    this.params = params;
+    if (changed) {
+      // The seed only fills the initial frame. The observed child query owns all
+      // subsequent membership and field updates, including removals and denials.
+      this.childRows = params
+        .currentRows()
+        .filter((row) => !areUiSessionKeysEquivalent(row.key, params.parentKey));
+      this.rows = this.childRows;
+      params.onRows(this.rows);
     }
-    if (this.revision === revision || this.timer !== null) {
+    if (this.children || this.timer !== null) {
       return;
     }
-    this.timer = setTimeout(() => this.hydrate(params), 250);
+    this.timer = setTimeout(() => this.connect(), 250);
   }
 
   dispose(): void {
     this.reset("");
   }
 
-  private hydrate(params: SwarmHydrationParams): void {
-    const generation = ++this.generation;
-    const revision = params.sessions.canonicalListRevision;
-    const key = `${params.sourceEpoch}:${params.agentId ?? ""}:${params.parentKey}`;
-    const isCurrent = () => generation === this.generation && this.key === key;
-    const currentRowsAtStart = params
-      .currentRows()
-      .filter((row) => !areUiSessionKeysEquivalent(row.key, params.parentKey));
-    const currentRowsAtStartByKey = new Map(
-      currentRowsAtStart.map((row) => [row.key, JSON.stringify(row)]),
-    );
-    let hydrated = false;
-    let retrying = false;
-    this.attempts += 1;
-    const scheduleRetry = () => {
-      retrying = true;
-      this.revision = -1;
-      const delayMs = Math.min(30_000, 1_000 * 2 ** Math.min(this.attempts - 1, 5));
-      this.timer = setTimeout(() => {
-        this.timer = null;
+  private connect(): void {
+    this.timer = null;
+    const params = this.params;
+    if (!params) {
+      return;
+    }
+    const generation = this.generation;
+    const isCurrent = () => this.generation === generation;
+    const agentId = params.agentId ?? parseAgentSessionKey(params.parentKey)?.agentId;
+    if (!agentId) {
+      return;
+    }
+    this.parent = params.sessions.observeRow(
+      { key: params.parentKey, agentId },
+      (parent) => {
         if (isCurrent()) {
-          this.update(params);
+          this.applyParent(parent);
         }
-      }, delayMs);
-    };
-    // Counts belong to the parent read; optional child names must never hold them hostage.
-    const children = hydrateSwarmSessionRows({
-      sessions: params.sessions,
-      parentKey: params.parentKey,
-      currentRows: currentRowsAtStart,
-      isCurrent,
-    }).catch(() => null);
-    void params
-      .readParent()
-      .then((parent) => {
+      },
+      {
+        onInvalidate: () => {
+          if (isCurrent() && !this.parentRequest) {
+            void this.readParent();
+          }
+        },
+      },
+    );
+    this.children = params.sessions.observeList(childQuery(params.parentKey), (snapshot) => {
+      if (isCurrent()) {
+        this.applyChildren(snapshot);
+      }
+    });
+    // Parent counts remain independent of the optional child-name page.
+    void this.readParent();
+    void this.children.refresh().catch(() => {
+      if (isCurrent()) {
+        this.retry("children");
+      }
+    });
+  }
+
+  private applyParent(parent: GatewaySessionRow | null): void {
+    const previous = this.parentRow;
+    const summary = JSON.stringify([
+      parent?.sessionId,
+      parent?.childSessions,
+      parent?.swarm?.groups.map(({ children: _children, ...group }) => group),
+      parent?.swarm?.otherActiveGroups,
+    ]);
+    const changed = this.parentSummary !== summary;
+    // Roster/event summaries omit members. Equal summary facts retain the detailed
+    // read's membership; changed groups are re-read through the same row observation.
+    this.parentRow =
+      parent && !changed && previous?.swarm && parent.swarm
+        ? {
+            ...parent,
+            swarm: {
+              ...parent.swarm,
+              groups: parent.swarm.groups.map((group) => ({
+                ...group,
+                children:
+                  group.children ??
+                  previous.swarm?.groups.find((entry) => entry.groupId === group.groupId)?.children,
+              })),
+            },
+          }
+        : parent;
+    this.parentSummary = summary;
+    this.rows = this.parentRow ? mergeSwarmSessionRows(this.childRows, [this.parentRow]) : [];
+    this.params?.onRows(this.rows);
+    if (parent && changed && this.parent && !this.parentRequest) {
+      void this.readParent();
+    }
+  }
+
+  private recovered(owner: SwarmRead): void {
+    const retry = this.retries[owner];
+    if (retry.timer !== null) {
+      clearTimeout(retry.timer);
+    }
+    retry.timer = null;
+    retry.attempts = 0;
+  }
+
+  private retry(owner: SwarmRead): void {
+    const retry = this.retries[owner];
+    if (!this.params || retry.timer !== null) {
+      return;
+    }
+    const generation = this.generation;
+    const delay = Math.min(30_000, 1_000 * 2 ** Math.min(retry.attempts++, 5));
+    retry.timer = setTimeout(() => {
+      retry.timer = null;
+      if (owner === "parent") {
+        void this.readParent();
+      } else {
+        void this.children?.refresh().catch(() => {
+          if (generation === this.generation) {
+            this.retry(owner);
+          }
+        });
+      }
+    }, delay);
+  }
+
+  private readParent(): Promise<void> {
+    if (this.parentRequest) {
+      this.parentRefreshQueued = true;
+      return this.parentRequest;
+    }
+    const params = this.params;
+    const parent = this.parent;
+    if (!params || !parent?.isCurrent()) {
+      return Promise.resolve();
+    }
+    const generation = this.generation;
+    const isCurrent = () => generation === this.generation && parent === this.parent;
+    const reconcile = parent.captureReconcile();
+    const request = Promise.resolve()
+      .then(() => params.readParent())
+      .then((row) => {
         if (!isCurrent()) {
           return;
         }
-        hydrated = true;
-        this.revision = revision;
-        this.rows = parent ? mergeSwarmSessionRows(this.rows, [parent]) : [];
-        params.onRows(this.rows);
-        if (!parent) {
-          return;
+        const outcome = reconcile(row ?? undefined);
+        if (outcome.status === "invalidated") {
+          this.parentRefreshQueued = true;
+        } else if (outcome.status === "current") {
+          this.recovered("parent");
         }
-        void children.then((rows) => {
-          if (!isCurrent()) {
-            return;
-          }
-          const changedCurrentRows = params
-            .currentRows()
-            .filter(
-              (row) =>
-                !areUiSessionKeysEquivalent(row.key, params.parentKey) &&
-                currentRowsAtStartByKey.get(row.key) !== JSON.stringify(row),
-            );
-          this.rows = rows ? mergeSwarmSessionRows(rows, [parent], changedCurrentRows) : [parent];
-          params.onRows(this.rows);
-          if (!rows) {
-            scheduleRetry();
-          }
-        });
       })
       .catch((error: unknown) => {
         if (!isCurrent()) {
           return;
         }
         if (error instanceof GatewayRequestError && error.code === "INVALID_REQUEST") {
-          this.rows = [];
-          params.onRows(this.rows);
+          const outcome = reconcile(undefined);
+          if (outcome.status === "invalidated") {
+            this.parentRefreshQueued = true;
+          } else if (outcome.status === "current") {
+            this.recovered("parent");
+          }
+        } else {
+          this.retry("parent");
         }
-        scheduleRetry();
       })
       .finally(() => {
-        if (!isCurrent()) {
+        if (!isCurrent() || this.parentRequest !== request) {
           return;
         }
-        if (!retrying) {
-          this.timer = null;
+        this.parentRequest = null;
+        if (this.parentRefreshQueued) {
+          this.parentRefreshQueued = false;
+          void this.readParent();
         }
-        if (hydrated && this.revision !== params.sessions.canonicalListRevision) {
-          this.update(params);
+      });
+    this.parentRequest = request;
+    return request;
+  }
+
+  private applyChildren(snapshot: SessionListSnapshot): void {
+    const params = this.params;
+    const result = snapshot.result;
+    if (snapshot.error && !snapshot.loading) {
+      this.retry("children");
+      return;
+    }
+    if (!params || snapshot.loading || !result || result === this.childResult) {
+      return;
+    }
+    const previousResult = this.childResult;
+    this.childResult = result;
+    const previousChildren = new Map(this.childRows.map((row) => [row.key, row]));
+    const described = new Map(
+      this.parentRow?.swarm?.groups.flatMap((group) =>
+        (group.children ?? []).map(
+          (child) => [child.sessionKey, { ...child, groupId: group.groupId }] as const,
+        ),
+      ),
+    );
+    const changedMembers = result.sessions.filter((row) => {
+      const previous = previousChildren.get(row.key);
+      return previous?.swarmGroupId !== row.swarmGroupId || previous?.status !== row.status;
+    });
+    const currentKeys = new Set(result.sessions.map((row) => row.key));
+    const removedMember = [...described.keys()].some(
+      (key) => previousChildren.has(key) && !currentKeys.has(key),
+    );
+    // Reuse a parent read that already observed this child change. Equal aggregate
+    // counts alone cannot prove unchanged membership outside the primary page.
+    const missingDetail = changedMembers.some((row) => {
+      const member = described.get(row.key);
+      return (
+        row.swarmGroupId &&
+        (member?.groupId !== row.swarmGroupId || (row.status && member?.status !== row.status))
+      );
+    });
+    if (previousResult && this.parentRow && (removedMember || missingDetail)) {
+      void this.readParent();
+    }
+    const generation = this.generation;
+    const isCurrent = () => generation === this.generation && this.childResult === result;
+    void hydrateSwarmSessionRows({
+      sessions: params.sessions,
+      parentKey: params.parentKey,
+      initialResult: result,
+      isCurrent,
+    })
+      .then((rows) => {
+        if (!rows || !isCurrent()) {
+          return;
+        }
+        const parent = this.parentRow;
+        this.childRows = rows;
+        this.rows = parent ? mergeSwarmSessionRows(this.childRows, [parent]) : [];
+        this.recovered("children");
+        params.onRows(this.rows);
+      })
+      .catch(() => {
+        if (isCurrent()) {
+          this.retry("children");
         }
       });
   }
@@ -211,13 +377,22 @@ export class SwarmRosterHydrator {
     if (this.timer !== null) {
       clearTimeout(this.timer);
     }
+    this.parent?.dispose();
+    this.children?.dispose();
+    this.params = null;
+    this.parent = null;
+    this.parentRow = null;
+    this.parentSummary = "";
+    this.children = null;
+    this.childResult = null;
+    this.childRows = [];
+    this.parentRequest = null;
+    this.parentRefreshQueued = false;
     this.rows = [];
-    this.currentRowsByKey.clear();
     this.key = key;
-    this.revision = -1;
     this.generation += 1;
-    this.attemptRevision = -1;
-    this.attempts = 0;
+    this.recovered("parent");
+    this.recovered("children");
     this.timer = null;
   }
 }

--- a/ui/src/pages/chat/components/chat-swarm-progress.test.ts
+++ b/ui/src/pages/chat/components/chat-swarm-progress.test.ts
@@ -7,10 +7,13 @@ import { buildSessionSwarmSummary } from "../../../../../src/gateway/session-swa
 import type { GatewaySessionRow } from "../../../api/types.ts";
 import { i18n } from "../../../i18n/index.ts";
 import { pt_BR } from "../../../i18n/locales/pt-BR.ts";
-import type { SessionCapability } from "../../../lib/sessions/index.ts";
-import { sessionsResult } from "../../../lib/sessions/session-capability.test-support.ts";
-import { createSessionRowProvenance } from "../../../lib/sessions/session-row-provenance.ts";
+import {
+  createGatewayHarness,
+  createTestSessionCapability,
+  sessionsResult,
+} from "../../../lib/sessions/session-capability.test-support.ts";
 import { SwarmRosterHydrator } from "../../../lib/sessions/swarm-roster.ts";
+import { createTestGatewayClient } from "../../../test-helpers/gateway-client.ts";
 import { renderChatSwarmProgress } from "./chat-swarm-progress.ts";
 
 const parentSessionKey = "agent:main:parent";
@@ -170,26 +173,33 @@ describe("chat Swarm progress", () => {
   it("updates the same group heading through live rows, hydration, and a second child", async () => {
     vi.useFakeTimers();
     const child = session({ key: childSessionKey, status: "running" });
-    const hydrated = { ...child, label: "Review CI", updatedAt: 2 };
-    let currentRows = [child];
+    const hydrated = { ...child, sessionId: "child-session", label: "Review CI", updatedAt: 2 };
+    let serverRows: GatewaySessionRow[] = [hydrated];
     const hydrator = new SwarmRosterHydrator();
+    const client = createTestGatewayClient(async (method) =>
+      method === "sessions.list"
+        ? { ...sessionsResult(serverRows, 2), hasMore: false }
+        : { subscribed: true },
+    );
+    const { gateway, emitEvent } = createGatewayHarness(client);
+    const sessions = createTestSessionCapability(gateway);
     const container = document.createElement("div");
     document.body.append(container);
     const params = {
-      sessions: {
-        canonicalListRevision: 1,
-        list: vi.fn(async () => ({ ...sessionsResult([hydrated], 2), hasMore: false })),
-        inheritRow: createSessionRowProvenance().inheritRow,
-      } satisfies Pick<SessionCapability, "canonicalListRevision" | "list" | "inheritRow">,
+      sessions,
       parentKey: parentSessionKey,
-      readParent: async () => ({ key: parentSessionKey, kind: "direct" as const }),
+      readParent: async () => ({
+        key: parentSessionKey,
+        sessionId: "parent-session",
+        kind: "direct" as const,
+      }),
       sourceEpoch: 1,
-      currentRows: () => currentRows,
-      onRows: (sessions: GatewaySessionRow[]) =>
+      currentRows: () => [child],
+      onRows: (rows: GatewaySessionRow[]) =>
         render(
           renderChatSwarmProgress({
             sessionKey: parentSessionKey,
-            sessions: withSummary(sessions),
+            sessions: withSummary(rows),
           }),
           container,
         ),
@@ -200,11 +210,23 @@ describe("chat Swarm progress", () => {
       expect(group?.querySelector("strong")?.textContent).toBe("Subagent:");
       await vi.runAllTimersAsync();
       expect(group?.querySelector("strong")?.textContent).toBe("Review CI");
-      currentRows = [
+      serverRows = [
         hydrated,
-        session({ key: "agent:main:subagent:second", label: "Check types", status: "running" }),
+        {
+          ...session({
+            key: "agent:main:subagent:second",
+            label: "Check types",
+            status: "running",
+          }),
+          sessionId: "second-child-session",
+        },
       ];
-      hydrator.update(params);
+      emitEvent({
+        type: "event",
+        event: "sessions.changed",
+        payload: { agentId: "main", session: serverRows[1], reason: "create" },
+      });
+      await vi.advanceTimersByTimeAsync(250);
       expect(container.querySelectorAll("[data-swarm-group]")).toHaveLength(1);
       expect(group?.getAttribute("data-swarm-group")).toBe(swarmGroupId);
       expect(group?.querySelector("strong")?.textContent).toBe("Parallel tasks");
@@ -214,6 +236,7 @@ describe("chat Swarm progress", () => {
       expect(container.textContent).not.toContain(parentRunId);
     } finally {
       hydrator.dispose();
+      sessions.dispose();
     }
   });
 


### PR DESCRIPTION
Related: #146102

## What Problem This Solves

Fixes an issue where opening or viewing chat caused child sessions and their parent to reload after unrelated sidebar refreshes. Those extra requests increased Gateway load and delayed conversations while other agents were active.

## Why This Change Was Made

Swarm progress now uses the existing managed child-session query and parent-row observation. The sidebar only seeds the initial view; later canonical roster publications do not start another child-list/parent-descriptor pair. Parent counts and access checks remain independent of slow child pages, and parent and child failures retry independently.

Query invalidation follows the parent, known children, and announced ownership or navigation lineage, including cross-agent children. Incomplete windows refresh conservatively because an event naming another parent may describe a child moving out of an unloaded page. Pending descriptors retain refresh intent when newer summaries or child membership arrive, while their own publications do not create redundant reads.

Hosted real-Gateway CI uses a 40-minute job budget when its existing routing selects Ubuntu, while Blacksmith retains 20 minutes. [Run 34707873095, attempt 2](https://github.com/openclaw/openclaw/actions/runs/34707873095/attempts/2) spent 7m42s before the browser suite began, then hit its 20-minute infrastructure limit while tests were progressing and before the widget cases. Per-test and subprocess deadlines, the full inventory, workers, runner routing, and concurrency limits remain unchanged. This adds no jobs or Blacksmith registrations.

## User Impact

Chat generates less background traffic while child names, counts, status, and membership stay current. Missing or inaccessible parents remain cleared, and completed Swarm outcomes remain visible after the parent finishes or fails.

## Evidence

- Initial load plus ten unrelated canonical roster publications produced eleven child-list requests before the fix and one after. Relevant parent and child changes still refresh membership.
- Browser regression: three bursts of unrelated agent activity produce zero additional `sessions.list` calls across all queries. The selected roster still refreshes its own changes.
- Regressions cover cross-agent creation, known and off-page reparenting/deletion, pagination beyond 10,000 children, independent retry backoff, stale denied responses, and summaries or child pages overtaking a pending descriptor.
- 135 focused owner, refresh, permission, hydration, and rendering tests pass.
- All 10 browser cases pass against a freshly built production UI bundle: roster event scope, Swarm lifecycle on desktop/mobile/cross-agent sessions, and cloud dispatch.
- UI production/test type checks, targeted lint, formatting, and staged changed-file checks pass. Independent review through P2 found no remaining actionable issues.
- CI followups preserve selected-child labels and queued-message completion by committing mock state before its invalidation event and keeping child-query membership exact. All twenty associated browser cases pass across the focused runs.
- Real-Gateway Stop regression passes with its exact-run terminal descriptor delayed until after the required no-active-run abort and post-Stop history recovery. Swarm remains enabled; the real descriptor is then delivered unchanged.
- Initial CI also hit an unrelated Gateway type-shard budget failure from main. The candidate now includes main’s separate repair in #146212; this PR retains no compiler configuration change.

The following inspected synthetic captures use the same thirty-child fixture before and after the change. They show that the completed outcome and presentation remain intact; the request reduction is established by the assertions above.

| Before | After |
| --- | --- |
| ![Before: synthetic Swarm outcome with 25 completed and 5 failed children](https://github.com/user-attachments/assets/817a6f2b-901c-47eb-9031-86066cc3ba32) | ![After: the same synthetic Swarm outcome is preserved](https://github.com/user-attachments/assets/fed66315-8988-44f4-b313-40cbb9c0f896) |

Two source-equal updater timeout failures passed one unchanged diagnostic retry. The unchanged widget suite also passes locally on a fresh exact-head runtime; the canceled hosted attempt did not reach those widget cases. The budget guard failed against the old constant and passes across 96 runner-selection contexts. Pinned actionlint, repository workflow guards, targeted types/lint, standard docs links and touched-page anchors pass. The full local workflow wrapper could not bootstrap its pinned pre-commit version from the configured package index; hosted workflow/security gates remain required.

Live deployment timing will be measured after landing.
