### PR TITLE
perf(plugins): reduce provider policy metadata allocations

### DIFF
--- a/src/plugins/provider-policy-ownership.test.ts
+++ b/src/plugins/provider-policy-ownership.test.ts
@@ -13,6 +13,8 @@ describe("provider policy declaration ownership", () => {
     ["orphan-alias", false],
     ["scoped-alias", false],
     ["empty-target", false],
+    ["inherited-alias", false],
+    ["hidden-alias", false],
     ["setup-only", false],
     ["setup-cli", false],
     [" ", true],
@@ -34,6 +36,11 @@ describe("provider policy declaration ownership", () => {
         "empty-target": " ",
         "": "fixture-text",
       },
+    });
+    Object.setPrototypeOf(owner.providerAuthAliases, { "inherited-alias": "fixture-text" });
+    Object.defineProperty(owner.providerAuthAliases, "hidden-alias", {
+      value: "fixture-text",
+      enumerable: false,
     });
 
     expect(listTrustedExternalProviderPolicyOwners(query, { plugins: [owner] })).toEqual(

--- a/src/plugins/provider-public-artifacts.ts
+++ b/src/plugins/provider-public-artifacts.ts
@@ -58,13 +58,27 @@ function pluginDeclaresProviderPolicyRef(
   plugin: PluginManifestRecord,
   normalizedProviderId: string,
 ): boolean {
-  const matches = (provider: string) => normalizeProviderId(provider) === normalizedProviderId;
-  return Boolean(
-    normalizedProviderId &&
-    (plugin.providers.some(matches) ||
-      plugin.cliBackends.some(matches) ||
-      plugin.contracts?.embeddingProviders?.some(matches)),
-  );
+  if (!normalizedProviderId) {
+    return false;
+  }
+  for (const provider of plugin.providers) {
+    if (normalizeProviderId(provider) === normalizedProviderId) {
+      return true;
+    }
+  }
+  for (const provider of plugin.cliBackends) {
+    if (normalizeProviderId(provider) === normalizedProviderId) {
+      return true;
+    }
+  }
+  if (plugin.contracts?.embeddingProviders) {
+    for (const provider of plugin.contracts.embeddingProviders) {
+      if (normalizeProviderId(provider) === normalizedProviderId) {
+        return true;
+      }
+    }
+  }
+  return false;
 }
 
 function pluginOwnsProviderPolicyRef(
@@ -79,7 +93,11 @@ function pluginOwnsProviderPolicyRef(
   if (!aliases) {
     return false;
   }
-  for (const [rawAlias, rawTarget] of Object.entries(aliases)) {
+  for (const rawAlias in aliases) {
+    if (!Object.hasOwn(aliases, rawAlias)) {
+      continue;
+    }
+    const rawTarget = aliases[rawAlias];
     if (
       typeof rawTarget === "string" &&
       normalizeProviderId(rawAlias) === normalizedProviderId &&


### PR DESCRIPTION
Repeated provider policy lookups build per-plugin matching callbacks and alias-entry arrays while searching manifest declarations. Scan provider, CLI, and embedding declarations directly and enumerate only own alias keys, preserving normalized matching, stable owner order, direct-artifact precedence, and plugin lifecycle behavior.

A synthetic probe through `resolveBundledProviderPolicySurface` uses 100 manifest records and a real managed plugin artifact, verifies an initial direct-alias miss and every resulting owner surface, then measures 5,000 lookups. Sampled allocation falls from 556.6 MB to 269.7 MB (51.5%); the metadata-owner subtree falls from 367.7 MB to 74.4 MB (79.8%). This measures temporary allocation in that entry point, not retained-memory or full-Gateway savings.

Validation:
- 50 of 51 focused tests pass across provider ownership, public artifacts, direct policy surfaces, and the trusted external runtime path. The sole failure is the existing OpenAI smoke expectation missing `preferredAuthRequirement: "subscription"`; the same failure was reproduced against the original production source.
- All 16 ownership contract cases pass against the original source, including the two added inherited/non-enumerable alias exclusions.
- Changed-file formatting and `git diff --check` pass. Changed-lane classification selects core and core tests. Aggregate local checks were not run after host resource exhaustion; exact-head hosted CI subsequently passed all required checks.
- Independent P0–P2 review completed scoped-clean with no findings.


Exact-head hosted CI passed: https://github.com/openclaw/openclaw/actions/runs/34702911129. ClawSweeper reviewed 0422a5faf963 with no actionable findings.

