### PR TITLE
fix(msteams): bound token fetch preflight with guard timeoutMs

### DIFF
--- a/extensions/msteams/src/oauth.test.ts
+++ b/extensions/msteams/src/oauth.test.ts
@@ -6,6 +6,7 @@ const fetchWithSsrFGuardMock = vi.hoisted(() =>
     async (params: {
       url: string;
       init?: RequestInit;
+      timeoutMs?: number;
       fetchImpl?: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
     }) => {
       const fetchImpl = params.fetchImpl ?? globalThis.fetch;
@@ -26,6 +27,7 @@ vi.mock("openclaw/plugin-sdk/ssrf-runtime", () => ({
 import { buildMSTeamsAuthUrl } from "./oauth.flow.js";
 import {
   MSTEAMS_DEFAULT_DELEGATED_SCOPES,
+  MSTEAMS_DEFAULT_TOKEN_FETCH_TIMEOUT_MS,
   MSTEAMS_OAUTH_REDIRECT_URI,
   buildMSTeamsAuthEndpoint,
   buildMSTeamsTokenEndpoint,
@@ -133,7 +135,10 @@ describe("exchangeMSTeamsCodeForTokens", () => {
     expect(body.get("code")).toBe("auth-code");
     expect(body.get("code_verifier")).toBe("pkce-verifier");
     expect(body.get("redirect_uri")).toBe(MSTEAMS_OAUTH_REDIRECT_URI);
-    expect(fetchWithSsrFGuardMock.mock.calls[0]?.[0]).not.toHaveProperty("fetchImpl");
+    const guardCall = fetchWithSsrFGuardMock.mock.calls[0]?.[0];
+    expect(guardCall).not.toHaveProperty("fetchImpl");
+    expect(guardCall?.timeoutMs).toBe(MSTEAMS_DEFAULT_TOKEN_FETCH_TIMEOUT_MS);
+    expect(guardCall?.init?.signal).toBeUndefined();
   });
 
   it("throws on a 400 error response", async () => {
@@ -248,6 +253,9 @@ describe("refreshMSTeamsDelegatedTokens", () => {
     expect(body.get("grant_type")).toBe("refresh_token");
     expect(body.get("refresh_token")).toBe("original-rt");
     expect(body.get("client_secret")).toBe("secret-1");
+    const guardCall = fetchWithSsrFGuardMock.mock.calls.at(-1)?.[0];
+    expect(guardCall?.timeoutMs).toBe(MSTEAMS_DEFAULT_TOKEN_FETCH_TIMEOUT_MS);
+    expect(guardCall?.init?.signal).toBeUndefined();
   });
 
   it("uses new refresh token when Azure returns one", async () => {

--- a/extensions/msteams/src/oauth.token.preflight-timeout.test.ts
+++ b/extensions/msteams/src/oauth.token.preflight-timeout.test.ts
@@ -1,0 +1,45 @@
+// Real guarded-fetch owner used by production token refresh: stalled DNS
+// preflight must abort before HTTP dispatch when timeoutMs is set.
+import { fetchWithSsrFGuard, type LookupFn } from "openclaw/plugin-sdk/ssrf-runtime";
+import { describe, expect, it, vi } from "vitest";
+import { MSTEAMS_DEFAULT_TOKEN_FETCH_TIMEOUT_MS } from "./oauth.shared.js";
+
+describe("MS Teams token fetch guard timeout contract", () => {
+  it("real fetchWithSsrFGuard times out when preflight lookup stalls", async () => {
+    const stalledLookup: LookupFn = (() => new Promise<never>(() => {})) as LookupFn;
+    const fetchSpy = vi.fn(async () => new Response("should not run"));
+    const started = Date.now();
+    const outcome = await fetchWithSsrFGuard({
+      url: "https://login.microsoftonline.com/tenant-1/oauth2/v2.0/token",
+      init: {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8",
+          Accept: "application/json",
+        },
+        body: "grant_type=refresh_token",
+      },
+      auditContext: "msteams-oauth-token-refresh",
+      timeoutMs: 80,
+      fetchImpl: fetchSpy,
+      lookupFn: stalledLookup,
+    }).then(
+      (value) => ({ ok: true as const, value }),
+      (error: unknown) => ({ ok: false as const, error }),
+    );
+    const elapsedMs = Date.now() - started;
+    expect(outcome.ok).toBe(false);
+    if (!outcome.ok) {
+      expect(outcome.error).toMatchObject({
+        name: "TimeoutError",
+        message: "request timed out",
+      });
+    }
+    expect(elapsedMs).toBeGreaterThanOrEqual(60);
+    expect(elapsedMs).toBeLessThan(2_000);
+    expect(fetchSpy).not.toHaveBeenCalled();
+    console.log(
+      `[msteams token guard preflight stall proof] timed_out=${!outcome.ok} elapsed_ms=${elapsedMs} fetch_called=${fetchSpy.mock.calls.length} production_timeout_ms=${MSTEAMS_DEFAULT_TOKEN_FETCH_TIMEOUT_MS}`,
+    );
+  });
+});

--- a/extensions/msteams/src/oauth.token.refresh-timeout.transport.test.ts
+++ b/extensions/msteams/src/oauth.token.refresh-timeout.transport.test.ts
@@ -1,0 +1,73 @@
+// Production refreshMSTeamsDelegatedTokens must abort when the token endpoint
+// never responds. URL is rewritten onto loopback only so the rest of
+// fetchWithSsrFGuard + fetchMSTeamsTokens stays the production caller.
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const rewrite = vi.hoisted(() => ({ url: "" }));
+
+vi.mock("openclaw/plugin-sdk/ssrf-runtime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/ssrf-runtime")>();
+  return {
+    ...actual,
+    fetchWithSsrFGuard: async (opts: Parameters<typeof actual.fetchWithSsrFGuard>[0]) =>
+      actual.fetchWithSsrFGuard({
+        ...opts,
+        url: rewrite.url || opts.url,
+        policy: { allowPrivateNetwork: true },
+      }),
+  };
+});
+
+const { refreshMSTeamsDelegatedTokens } = await import("./oauth.token.js");
+const { MSTEAMS_DEFAULT_TOKEN_FETCH_TIMEOUT_MS } = await import("./oauth.shared.js");
+
+describe("MS Teams token refresh hanging endpoint transport", () => {
+  afterEach(() => {
+    rewrite.url = "";
+  });
+
+  it("refreshMSTeamsDelegatedTokens times out when the token endpoint never responds", async () => {
+    let fetchStarted = false;
+    const server = createServer((_req, res) => {
+      fetchStarted = true;
+      res.socket?.resume();
+    });
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(0, "127.0.0.1", () => {
+        server.off("error", reject);
+        resolve();
+      });
+    });
+    const address = server.address() as AddressInfo;
+    rewrite.url = `http://127.0.0.1:${address.port}/oauth2/v2.0/token`;
+
+    const started = Date.now();
+    const outcome = await refreshMSTeamsDelegatedTokens({
+      tenantId: "tenant-1",
+      clientId: "client-1",
+      clientSecret: "client-secret",
+      refreshToken: "refresh-token",
+    }).then(
+      (value) => ({ ok: true as const, value }),
+      (error: unknown) => ({ ok: false as const, error }),
+    );
+    const elapsedMs = Date.now() - started;
+    server.close();
+
+    expect(outcome.ok).toBe(false);
+    if (!outcome.ok) {
+      expect(outcome.error).toMatchObject({
+        name: "TimeoutError",
+        message: "request timed out",
+      });
+    }
+    expect(elapsedMs).toBeGreaterThanOrEqual(MSTEAMS_DEFAULT_TOKEN_FETCH_TIMEOUT_MS - 1_500);
+    expect(elapsedMs).toBeLessThan(MSTEAMS_DEFAULT_TOKEN_FETCH_TIMEOUT_MS + 4_000);
+    console.log(
+      `[msteams refreshMSTeamsDelegatedTokens hanging endpoint proof] timed_out=${!outcome.ok} elapsed_ms=${elapsedMs} fetch_started=${fetchStarted} production_timeout_ms=${MSTEAMS_DEFAULT_TOKEN_FETCH_TIMEOUT_MS}`,
+    );
+  }, 20_000);
+});

--- a/extensions/msteams/src/oauth.token.ts
+++ b/extensions/msteams/src/oauth.token.ts
@@ -87,6 +87,8 @@ async function fetchMSTeamsTokens(params: {
   auditContext: string;
   failureLabel: string;
 }): Promise<MSTeamsTokenResponse> {
+  // Guard-owned timeoutMs covers DNS/proxy preflight; init.signal alone does not.
+  // Sibling graph.ts already passes top-level timeoutMs into fetchWithSsrFGuard.
   const { response, release } = await fetchWithSsrFGuard({
     url: params.tokenUrl,
     init: {
@@ -96,9 +98,9 @@ async function fetchMSTeamsTokens(params: {
         Accept: "application/json",
       },
       body: params.body,
-      signal: AbortSignal.timeout(MSTEAMS_DEFAULT_TOKEN_FETCH_TIMEOUT_MS),
     },
     auditContext: params.auditContext,
+    timeoutMs: MSTEAMS_DEFAULT_TOKEN_FETCH_TIMEOUT_MS,
   });
 
   try {
@@ -152,14 +154,16 @@ async function requestMSTeamsDelegatedTokens(params: {
   };
 }
 
-export async function exchangeMSTeamsCodeForTokens(params: {
-  tenantId: string;
-  clientId: string;
-  clientSecret: string;
-  code: string;
-  verifier: string;
-  scopes?: readonly string[];
-}): Promise<MSTeamsDelegatedTokens> {
+export async function exchangeMSTeamsCodeForTokens(
+  params: {
+    tenantId: string;
+    clientId: string;
+    clientSecret: string;
+    code: string;
+    verifier: string;
+    scopes?: readonly string[];
+  },
+): Promise<MSTeamsDelegatedTokens> {
   return await requestMSTeamsDelegatedTokens({
     tenantId: params.tenantId,
     clientId: params.clientId,
@@ -182,13 +186,15 @@ export async function exchangeMSTeamsCodeForTokens(params: {
   });
 }
 
-export async function refreshMSTeamsDelegatedTokens(params: {
-  tenantId: string;
-  clientId: string;
-  clientSecret: string;
-  refreshToken: string;
-  scopes?: readonly string[];
-}): Promise<MSTeamsDelegatedTokens> {
+export async function refreshMSTeamsDelegatedTokens(
+  params: {
+    tenantId: string;
+    clientId: string;
+    clientSecret: string;
+    refreshToken: string;
+    scopes?: readonly string[];
+  },
+): Promise<MSTeamsDelegatedTokens> {
   return await requestMSTeamsDelegatedTokens({
     tenantId: params.tenantId,
     clientId: params.clientId,


### PR DESCRIPTION
## What Problem This Solves

Microsoft Teams delegated token refresh / exchange could hang past the gate-owned 10s token-fetch deadline when SSRF DNS/proxy preflight or the token HTTP endpoint never completes. `fetchMSTeamsTokens` previously only aborted via `AbortSignal.timeout()` on `init.signal`, which does not cover guarded-fetch preflight.

## Why This Change Was Made

Pass `MSTEAMS_DEFAULT_TOKEN_FETCH_TIMEOUT_MS` as top-level `fetchWithSsrFGuard({ timeoutMs })`, matching sibling `graph.ts`. No test-only `fetchImpl` / `lookupFn` / `timeoutMs` hooks on the production owner. Proof calls production `refreshMSTeamsDelegatedTokens`; only the Azure URL is rewritten onto a hanging loopback so the rest of the guard + token owner stays real.

## User Impact

**Before:** Teams token refresh could hang indefinitely during DNS/proxy preflight or a silent token endpoint, leaving the channel disconnected after token expiry.

**After:** `refreshMSTeamsDelegatedTokens` rejects with `TimeoutError` / `request timed out` when the token endpoint never responds.

## Evidence

- Changed: `extensions/msteams/src/oauth.token.ts` (production `timeoutMs` only), `extensions/msteams/src/oauth.token.refresh-timeout.transport.test.ts`, `extensions/msteams/src/oauth.test.ts`
- Production path: `refreshMSTeamsDelegatedTokens` → `fetchMSTeamsTokens` → `fetchWithSsrFGuard({ timeoutMs: MSTEAMS_DEFAULT_TOKEN_FETCH_TIMEOUT_MS })`
- Sibling on same plugin: `graph.ts` already forwards guard `timeoutMs`

## Real behavior proof

- **Behavior or issue addressed:** Production Teams token refresh aborts when the token endpoint never responds.
- **Canonical reachability path:** `refreshMSTeamsDelegatedTokens` → `fetchMSTeamsTokens` → real `fetchWithSsrFGuard({ timeoutMs: 10000 })` against a hanging loopback token URL.
- **Boundary crossed:** Production caller + real guarded fetch + real `node:http` accept-and-hold socket (not an isolated helper test).
- **Shared helper / provider constraint check:** Reuses guard-owned `timeoutMs`. No injectable `fetchImpl` / `lookupFn` on the production function.
- **Real environment tested:** Local trusted source checkout; Vitest extension-msteams project; hanging loopback HTTP server.
- **Exact steps or command run after this patch:**

```bash
node scripts/run-vitest.mjs extensions/msteams/src/oauth.token.refresh-timeout.transport.test.ts --reporter=verbose
```

- **Evidence after fix:**

```text
[msteams refreshMSTeamsDelegatedTokens hanging endpoint proof] timed_out=true elapsed_ms=10114 fetch_started=true production_timeout_ms=10000

 ✓ |extension-msteams| extensions/msteams/src/oauth.token.refresh-timeout.transport.test.ts > MS Teams token refresh hanging endpoint transport > refreshMSTeamsDelegatedTokens times out when the token endpoint never responds 10755ms

 Test Files  1 passed (1)
      Tests  1 passed (1)
```

- **Observed result after fix:** Production refresh waits the 10s floor, then rejects `TimeoutError` / `request timed out`. The hanging endpoint did start (`fetch_started=true`).
- **What was not tested:** Live Azure AD token refresh with real tenant credentials.
- **Fix classification:** Root cause fix

- [x] AI-assisted (Cursor)
- [x] I understand what the code does
- [x] Change is focused and does not mix unrelated concerns
