### PR TITLE
fix(googlechat): cancel certs response body on non-OK

### DIFF
--- a/extensions/googlechat/src/auth.cancel.transport.test.ts
+++ b/extensions/googlechat/src/auth.cancel.transport.test.ts
@@ -1,0 +1,89 @@
+// Real HTTP: production fetchChatCerts cancels an unread non-OK certs body
+// and releases the loopback socket. URL is rewritten onto loopback only so
+// the rest of fetchWithSsrFGuard + fetchChatCerts stays production.
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const rewrite = vi.hoisted(() => ({ url: "" }));
+
+vi.mock("openclaw/plugin-sdk/ssrf-runtime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/ssrf-runtime")>();
+  return {
+    ...actual,
+    fetchWithSsrFGuard: async (opts: Parameters<typeof actual.fetchWithSsrFGuard>[0]) =>
+      actual.fetchWithSsrFGuard({
+        ...opts,
+        url: rewrite.url || opts.url,
+        policy: { allowPrivateNetwork: true },
+      }),
+  };
+});
+
+vi.mock("./google-auth.runtime.js", () => ({
+  loadGoogleAuthRuntime: vi.fn().mockResolvedValue({
+    OAuth2Client: class {
+      verifySignedJwtWithCertsAsync = vi.fn();
+    },
+  }),
+  getGoogleAuthTransport: vi.fn().mockResolvedValue({}),
+  resolveValidatedGoogleChatCredentials: vi.fn().mockResolvedValue(null),
+}));
+
+const { verifyGoogleChatRequest } = await import("./auth.js");
+
+describe("Google Chat cert fetch non-OK hanging-body transport", () => {
+  afterEach(() => {
+    rewrite.url = "";
+    vi.restoreAllMocks();
+  });
+
+  it("cancels the unread 503 certs stream and closes the loopback socket", async () => {
+    let socketClosed = false;
+    const server = createServer((_req, res) => {
+      res.socket?.once("close", () => {
+        socketClosed = true;
+      });
+      res.writeHead(503, { "Content-Type": "application/json" });
+      res.write('{"error":"unavailable"');
+    });
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(0, "127.0.0.1", () => {
+        server.off("error", reject);
+        resolve();
+      });
+    });
+    const address = server.address() as AddressInfo;
+    rewrite.url = `http://127.0.0.1:${address.port}/certs`;
+
+    // Expire the process cert cache so fetchChatCerts hits the network.
+    vi.spyOn(Date, "now").mockReturnValue(Date.now() + 11 * 60 * 1000);
+
+    const startedAt = Date.now();
+    try {
+      const result = await verifyGoogleChatRequest({
+        bearer: "token",
+        audienceType: "project-number",
+        audience: "123456789",
+      });
+      expect(result).toEqual({
+        ok: false,
+        reason: "Failed to fetch Chat certs (503)",
+      });
+      await vi.waitFor(() => {
+        expect(socketClosed).toBe(true);
+      });
+      const elapsedMs = Date.now() - startedAt;
+      expect(elapsedMs).toBeLessThan(2_000);
+      console.log(
+        `[googlechat certs 503 transport proof] reason=${result.reason} socket_closed=${socketClosed} elapsed_ms=${elapsedMs}`,
+      );
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+        server.closeAllConnections();
+      });
+    }
+  });
+});

--- a/extensions/googlechat/src/auth.ts
+++ b/extensions/googlechat/src/auth.ts
@@ -120,6 +120,9 @@ async function fetchChatCerts(): Promise<Record<string, string>> {
   });
   try {
     if (!response.ok) {
+      // Non-OK cert responses leave an unread body; cancel before throw so the
+      // guarded dispatcher can release without retaining the stream (matches api.ts).
+      void response.body?.cancel().catch(() => undefined);
       throw new Error(`Failed to fetch Chat certs (${response.status})`);
     }
     const certs = await readGoogleChatCertsResponse(response);


### PR DESCRIPTION
## What Problem This Solves

Google Chat webhook auth could leave an unread Chat certs response body open when `fetchChatCerts` threw on a non-OK HTTP status. The guarded fetch dispatcher then released without cancelling the stream, matching a hole already closed on the sibling Google Chat API path.

## Why This Change Was Made

On `!response.ok`, cancel the unread body with `void response.body?.cancel().catch(() => undefined)` before throwing, matching `extensions/googlechat/src/api.ts`. Proof uses production `verifyGoogleChatRequest` → `fetchChatCerts` → real `fetchWithSsrFGuard` against a hanging 503 `node:http` loopback (URL rewritten onto loopback only so the rest of the fetch/auth path stays production).

## User Impact

**Before:** A non-OK Chat certs fetch threw while retaining an unread response stream until GC.

**After:** The unread non-OK body is cancelled before the throw; the loopback socket closes; `release()` still runs in `finally`.

## Evidence

- Changed: `extensions/googlechat/src/auth.ts`, `extensions/googlechat/src/auth.cancel.transport.test.ts`
- Production path: `verifyGoogleChatRequest` → `fetchChatCerts` → real `fetchWithSsrFGuard` → hanging 503 → `body.cancel()` → `{ ok: false, reason: "Failed to fetch Chat certs (503)" }` → socket close
- Exact head: `04fcce88caf`

## Real behavior proof

- **Behavior or issue addressed:** Non-OK Chat certs responses cancel their unread body and close the HTTP socket before webhook auth returns the certs failure.
- **Canonical reachability path:** `verifyGoogleChatRequest({ audienceType: "project-number" })` → `fetchChatCerts` → `fetchWithSsrFGuard` → hanging HTTP 503 → `response.body.cancel()` → throw/fail → socket `close`.
- **Boundary crossed:** Real TCP loopback HTTP (URL rewrite only) → production guarded fetch + `fetchChatCerts` → observable `socket_closed=true`.
- **Shared helper / provider constraint check:** Same `void response.body?.cancel().catch(() => undefined)` pattern as `withGoogleChatResponse` in `extensions/googlechat/src/api.ts`.
- **Real environment tested:** Local trusted source checkout at PR head `04fcce88caf`; Vitest extension-messaging project; real `node:http` server on `127.0.0.1`.
- **Exact steps or command run after this patch:**

```bash
node scripts/run-vitest.mjs extensions/googlechat/src/auth.cancel.transport.test.ts --reporter=verbose
```

- **Evidence after fix:**

```text
stdout | extensions/googlechat/src/auth.cancel.transport.test.ts > Google Chat cert fetch non-OK hanging-body transport > cancels the unread 503 certs stream and closes the loopback socket
[googlechat certs 503 transport proof] reason=Failed to fetch Chat certs (503) socket_closed=true elapsed_ms=0

 ✓ |extension-messaging| extensions/googlechat/src/auth.cancel.transport.test.ts > Google Chat cert fetch non-OK hanging-body transport > cancels the unread 503 certs stream and closes the loopback socket 31ms

 Test Files  1 passed (1)
      Tests  1 passed (1)
```

- **Observed result after fix:** Auth reason `Failed to fetch Chat certs (503)` and `socket_closed=true`; JWT verification is not attempted.
- **What was not tested:** Live googleapis.com cert endpoint; production webhook traffic; cancel rejection under debug capture tee.
- **Fix classification:** Root cause fix

- [x] AI-assisted (Cursor)
- [x] I understand what the code does
- [x] Change is focused and does not mix unrelated concerns
