### PR TITLE
fix(clickclack): do not await optional response body cancel

### DIFF
--- a/extensions/clickclack/src/http-client.test.ts
+++ b/extensions/clickclack/src/http-client.test.ts
@@ -1080,3 +1080,86 @@ describe("createClickClackClient websocket", () => {
     expect(result.error).toMatch(/max payload/i);
   });
 });
+
+describe("ClickClack ephemeral hanging-body HTTP transport", () => {
+  it("returns from publishEphemeral and closes a hanging loopback body", async () => {
+    let socketClosed = false;
+    const server = createServer((_req, res) => {
+      res.socket?.once("close", () => {
+        socketClosed = true;
+      });
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.write("{}");
+    });
+    const port = await listenLoopbackServer(server);
+    try {
+      const client = createClickClackClient({
+        baseUrl: `http://127.0.0.1:${port}`,
+        token: "fake",
+      });
+      const startedAt = Date.now();
+      await client.publishEphemeral({
+        workspaceId: "wsp_1",
+        type: "typing.started",
+      });
+      await vi.waitFor(() => {
+        expect(socketClosed).toBe(true);
+      });
+      const elapsedMs = Date.now() - startedAt;
+      expect(elapsedMs).toBeLessThan(1_000);
+      console.log(
+        `[clickclack ephemeral HTTP transport proof] returned=true socket_closed=${socketClosed} elapsed_ms=${elapsedMs}`,
+      );
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+        server.closeAllConnections();
+      });
+    }
+  });
+});
+
+describe("ClickClack ephemeral responseMode none cancel", () => {
+  it("returns without waiting when optional response body cancel never settles", async () => {
+    let cancelStarted = false;
+    const fetchMock = vi.fn(async () => {
+      return new Response(
+        new ReadableStream<Uint8Array>({
+          cancel() {
+            cancelStarted = true;
+            return new Promise(() => {});
+          },
+        }),
+        { status: 200 },
+      );
+    });
+    const client = createClickClackClient({
+      baseUrl: "https://clickclack.example",
+      token: "fake",
+      fetch: fetchMock,
+    });
+
+    const startedAt = Date.now();
+    await expect(
+      Promise.race([
+        client.publishEphemeral({
+          workspaceId: "wsp_1",
+          type: "typing.started",
+        }),
+        new Promise<never>((_, reject) => {
+          AbortSignal.timeout(1_000).addEventListener("abort", () => {
+            reject(new Error("publishEphemeral hung waiting for body.cancel"));
+          });
+        }),
+      ]),
+    ).resolves.toBeUndefined();
+    const elapsedMs = Date.now() - startedAt;
+
+    expect(cancelStarted).toBe(true);
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(elapsedMs).toBeLessThan(1_000);
+    console.log(
+      `[clickclack ephemeral cancel-nofollow proof] cancel_started=${cancelStarted} elapsed_ms=${elapsedMs}`,
+    );
+  });
+});

--- a/extensions/clickclack/src/http-client.ts
+++ b/extensions/clickclack/src/http-client.ts
@@ -178,11 +178,10 @@ export function createClickClackClient(options: ClientOptions) {
         );
       }
       if (requestOptions.responseMode === "none") {
-        try {
-          await response.body?.cancel();
-        } catch {
-          // A successful write does not depend on an optional response body.
-        }
+        // Do not await cancel: teed/debug streams can leave cancel pending forever
+        // (same invariant as Google Chat fetchOk). Successful writes do not need
+        // the optional response body.
+        void response.body?.cancel().catch(() => undefined);
         return undefined as T;
       }
       return await readProviderJsonResponse<T>(response, "ClickClack response", {


### PR DESCRIPTION
## What Problem This Solves

ClickClack `responseMode: "none"` (ephemeral publish) awaited `response.body.cancel()`. When cancel never settles (teed/debug streams), a successful write hangs and the HTTP socket stays open.

## Why This Change Was Made

Start optional body cancellation with `void response.body?.cancel().catch(() => undefined)` and return immediately — same Google Chat `fetchOk` invariant. Proof is production `publishEphemeral` against a real hanging `node:http` loopback body.

## User Impact

**Before:** Ephemeral/typing publishes could hang waiting for optional response-body cancel.

**After:** Publish returns after starting cancel; the hanging loopback socket closes.

## Evidence

- Changed: `extensions/clickclack/src/http-client.ts`, `extensions/clickclack/src/http-client.test.ts` (hanging-loopback describe)
- Production path: `createClickClackClient().publishEphemeral` → `request(..., { responseMode: "none" })` → real HTTP 200 with unread hanging body → fire-and-forget cancel → socket close
- Exact head: `cb9008e32bf`

## Real behavior proof

- **Behavior or issue addressed:** `publishEphemeral` returns from a real HTTP success whose unread body never ends, and the loopback socket closes.
- **Canonical reachability path:** `createClickClackClient({ baseUrl: http://127.0.0.1:<ephemeral> }).publishEphemeral` → production `request` `responseMode:"none"` → `void body.cancel()` → return → socket `close`.
- **Boundary crossed:** Real TCP loopback HTTP (not a synthetic `Response`) → production ClickClack client → observable `socket_closed=true`.
- **Shared helper / provider constraint check:** Matches Google Chat `fetchOk` / Nextcloud release-without-await-cancel invariant.
- **Real environment tested:** Local trusted source checkout at PR head `cb9008e32bf`; Vitest extensions project; real `node:http` server on `127.0.0.1`.
- **Exact steps or command run after this patch:**

```bash
node scripts/run-vitest.mjs extensions/clickclack/src/http-client.test.ts -t "hanging loopback body" --reporter=verbose
```

- **Evidence after fix:**

```text
stdout | extensions/clickclack/src/http-client.test.ts > ClickClack ephemeral hanging-body HTTP transport > returns from publishEphemeral and closes a hanging loopback body
[clickclack ephemeral HTTP transport proof] returned=true socket_closed=true elapsed_ms=73

 ✓ |extensions| extensions/clickclack/src/http-client.test.ts > ClickClack ephemeral hanging-body HTTP transport > returns from publishEphemeral and closes a hanging loopback body 89ms

 Test Files  1 passed (1)
      Tests  1 passed | 31 skipped (32)
```

- **Observed result after fix:** `returned=true socket_closed=true` in 73ms; publish does not wait for the hanging body.
- **What was not tested:** Live ClickClack deployment; debug-capture tee against a remote server.
- **Fix classification:** Root cause fix

- [x] AI-assisted (Cursor)
- [x] I understand what the code does
- [x] Change is focused and does not mix unrelated concerns
