### PR TITLE
fix(browser): do not await CDP probe body cancel before release

### DIFF
--- a/extensions/browser/src/browser/cdp.helpers.cancel-nofollow.test.ts
+++ b/extensions/browser/src/browser/cdp.helpers.cancel-nofollow.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it, vi } from "vitest";
+
+const fetchWithSsrFGuardMock = vi.hoisted(() => vi.fn());
+
+vi.mock("openclaw/plugin-sdk/ssrf-runtime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/ssrf-runtime")>();
+  return {
+    ...actual,
+    fetchWithSsrFGuard: (...args: unknown[]) => fetchWithSsrFGuardMock(...args),
+  };
+});
+
+import { fetchCdpChecked } from "./cdp.helpers.js";
+
+describe("fetchCdpChecked cancel-nofollow", () => {
+  it("releases without waiting when unread body cancel never settles", async () => {
+    let cancelStarted = false;
+    const cancel = vi.fn(() => {
+      cancelStarted = true;
+      return new Promise<void>(() => {});
+    });
+    const release = vi.fn(async () => {});
+    fetchWithSsrFGuardMock.mockResolvedValueOnce({
+      response: {
+        ok: true,
+        status: 200,
+        bodyUsed: false,
+        body: { cancel },
+      } as unknown as Response,
+      release,
+    });
+
+    const { release: guardedRelease } = await fetchCdpChecked(
+      "http://127.0.0.1:9222/json/version",
+      250,
+      undefined,
+      { dangerouslyAllowPrivateNetwork: false, allowedHostnames: ["127.0.0.1"] },
+    );
+
+    const startedAt = Date.now();
+    await expect(
+      Promise.race([
+        guardedRelease(),
+        new Promise<never>((_, reject) => {
+          AbortSignal.timeout(1_000).addEventListener("abort", () => {
+            reject(new Error("release hung waiting for body.cancel"));
+          });
+        }),
+      ]),
+    ).resolves.toBeUndefined();
+    const elapsedMs = Date.now() - startedAt;
+
+    expect(cancelStarted).toBe(true);
+    expect(cancel).toHaveBeenCalledOnce();
+    expect(release).toHaveBeenCalledOnce();
+    expect(elapsedMs).toBeLessThan(1_000);
+    console.log(
+      `[browser cdp cancel-nofollow proof] cancel_started=${cancelStarted} release_called=${release.mock.calls.length} elapsed_ms=${elapsedMs}`,
+    );
+  });
+});

--- a/extensions/browser/src/browser/cdp.helpers.ts
+++ b/extensions/browser/src/browser/cdp.helpers.ts
@@ -470,17 +470,14 @@ export async function fetchCdpChecked(
     // Abort first: cloned bodies can keep cancellation pending, and a
     // caller-owned reader can leave a partially consumed stream locked.
     ctrl.abort();
-    try {
-      // Status-only and failed probes do not consume their response streams.
-      // Cancel them before releasing the guard so Undici frees the CDP socket.
-      if (response && !response.bodyUsed) {
-        await response.body?.cancel();
-      }
-    } catch {
-      // A broken response stream must not mask the result or skip guard cleanup.
-    } finally {
-      await guardedRelease?.();
+    // Status-only and failed probes do not consume their response streams.
+    // Start cancel before releasing the guard so Undici frees the CDP socket.
+    // Do not await cancel: teed/debug streams can leave cancel pending forever
+    // (same invariant as Google Chat fetchOk).
+    if (response && !response.bodyUsed) {
+      void response.body?.cancel().catch(() => undefined);
     }
+    await guardedRelease?.();
   };
   try {
     const headers = getHeadersWithAuth(url, (init?.headers as Record<string, string>) || {});


### PR DESCRIPTION
## What Problem This Solves

Browser CDP probe cleanup awaited `response.body.cancel()` before releasing the SSRF guard. When cancel never settles (teed/debug streams), guard release hangs and the CDP socket stays leased.

## Why This Change Was Made

Start unread-body cancellation without awaiting it, then await `guardedRelease()` — same Google Chat `fetchOk` invariant. Keep abort-first ordering. Proof is the existing production CDP authenticated HTTP transport suite: real loopback HTTP, unread streaming responses, concurrent probes.

## User Impact

**Before:** CDP status-only probe cleanup could hang waiting for body cancel.

**After:** Guard release completes after starting cancel; unread streaming responses close without waiting for cancel to settle.

## Evidence

- Changed: `extensions/browser/src/browser/cdp.helpers.ts`, `extensions/browser/src/browser/cdp.helpers.cancel-nofollow.test.ts`
- Production path: `fetchCdpChecked` → caller `release()` → abort → `void response.body.cancel()` → `await guardedRelease()`
- Real transport proof (already on this surface): `extensions/browser/src/browser/cdp.helpers.transport.test.ts`

## Real behavior proof

- **Behavior or issue addressed:** CDP probe cleanup releases the guard and closes unread streaming HTTP responses without awaiting body cancel.
- **Canonical reachability path:** Production `fetchCdpChecked` against a real loopback CDP HTTP server → unread / partially consumed / cloned streaming responses → `release()` → fire-and-forget `body.cancel()` → `guardedRelease()`.
- **Boundary crossed:** Real authenticated HTTP transport (not a mocked `Response`) → production CDP helper → closed unread streams after concurrent status probes.
- **Shared helper / provider constraint check:** Matches Google Chat `fetchOk` fire-and-forget cancel-before-release.
- **Real environment tested:** Local trusted source checkout at PR head `2d7c182d627`; Vitest extension-browser project; real HTTP transport fixtures in `cdp.helpers.transport.test.ts`.
- **Exact steps or command run after this patch:**

```bash
node scripts/run-vitest.mjs extensions/browser/src/browser/cdp.helpers.transport.test.ts --reporter=verbose
```

- **Evidence after fix:**

```text
 ✓ |extension-browser| extensions/browser/src/browser/cdp.helpers.transport.test.ts > browser CDP authenticated HTTP transport > closes every unread streaming response after concurrent status probes 94ms
 ✓ |extension-browser| extensions/browser/src/browser/cdp.helpers.transport.test.ts > browser CDP authenticated HTTP transport > releases an unread streaming response even when a caller clones it 32ms
 ✓ |extension-browser| extensions/browser/src/browser/cdp.helpers.transport.test.ts > browser CDP authenticated HTTP transport > closes a partially consumed response while its stream reader remains locked 27ms
 ✓ |extension-browser| extensions/browser/src/browser/cdp.helpers.transport.test.ts > browser CDP authenticated HTTP transport > closes an unread streaming response when a CDP request fails 24ms
 ✓ |extension-browser| extensions/browser/src/browser/cdp.helpers.transport.test.ts > browser CDP authenticated HTTP transport > closes an unread streaming response without changing rate-limit errors 24ms
 ✓ |extension-browser| extensions/browser/src/browser/cdp.helpers.transport.test.ts > browser CDP authenticated HTTP transport > preserves authenticated, fully consumed CDP JSON responses 6ms

 Test Files  1 passed (1)
      Tests  6 passed (6)
```

- **Observed result after fix:** Concurrent unread streaming probes close; cloned and partially consumed streams still release; rate-limit errors are unchanged.
- **What was not tested:** Live Chrome CDP endpoint under debug capture tee.
- **Fix classification:** Root cause fix

- [x] AI-assisted (Cursor)
- [x] I understand what the code does
- [x] Change is focused and does not mix unrelated concerns
