### PR TITLE
fix(browser): UTF-16-safe page text truncation

### DIFF
--- a/extensions/browser/src/browser/pw-tools-core.activity.test.ts
+++ b/extensions/browser/src/browser/pw-tools-core.activity.test.ts
@@ -77,15 +77,30 @@ describe("getPageTextViaPlaywright", () => {
       const text = "x".repeat(DEFAULT_AI_SNAPSHOT_MAX_CHARS + 1);
       installTextPage({ body: [text] });
       const result = await getPageTextViaPlaywright({ cdpUrl: "http://127.0.0.1:18792", maxChars });
+      const limit = Math.min(maxChars ?? DEFAULT_AI_SNAPSHOT_MAX_CHARS, DEFAULT_AI_SNAPSHOT_MAX_CHARS);
       expect(result).toEqual({
-        text: text.slice(
-          0,
-          Math.min(maxChars ?? DEFAULT_AI_SNAPSHOT_MAX_CHARS, DEFAULT_AI_SNAPSHOT_MAX_CHARS),
-        ),
+        text: text.slice(0, limit),
         truncated: true,
       });
     },
   );
+
+  it("does not split a trailing surrogate pair when truncating page text", async () => {
+    // "😀" is one Unicode scalar / two UTF-16 code units. maxChars=5 would
+    // leave a lone high surrogate under raw .slice(0, 5).
+    const text = "abcd😀";
+    installTextPage({ body: [text] });
+    const result = await getPageTextViaPlaywright({
+      cdpUrl: "http://127.0.0.1:18792",
+      maxChars: 5,
+    });
+    expect(result.truncated).toBe(true);
+    expect(result.text).toBe("abcd");
+    expect(result.text).not.toMatch(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])/u);
+    console.log(
+      `[browser page-text utf16 proof] maxChars=5 input=${JSON.stringify(text)} output=${JSON.stringify(result.text)} truncated=${result.truncated}`,
+    );
+  });
 
   it("does not mark text that exactly fits the budget as truncated", async () => {
     installTextPage({ body: ["Exact"] });

--- a/extensions/browser/src/browser/pw-tools-core.activity.ts
+++ b/extensions/browser/src/browser/pw-tools-core.activity.ts
@@ -2,6 +2,7 @@
  * Page inspection helpers for visible text, observed errors, network requests,
  * and console messages from Playwright page state.
  */
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { DEFAULT_AI_SNAPSHOT_MAX_CHARS, DEFAULT_BROWSER_SNAPSHOT_TIMEOUT_MS } from "./constants.js";
 import type {
   BrowserConsoleMessage,
@@ -41,7 +42,11 @@ export async function getPageTextViaPlaywright(opts: {
     timeout: DEFAULT_BROWSER_SNAPSHOT_TIMEOUT_MS,
     signal: opts.signal,
   });
-  return { text: text.slice(0, maxChars), truncated: text.length > maxChars };
+  // Match snapshot/responses: raw .slice can split a trailing surrogate pair.
+  return {
+    text: truncateUtf16Safe(text, maxChars),
+    truncated: text.length > maxChars,
+  };
 }
 
 /** Returns captured page errors, optionally clearing the per-page buffer. */


### PR DESCRIPTION
## What Problem This Solves

`getPageTextViaPlaywright` truncated visible page text with raw `.slice(0, maxChars)`. Emoji/CJK at the budget boundary can split a UTF-16 surrogate pair, producing a lone high/low surrogate in model-facing text. Sibling snapshot/responses paths already use `truncateUtf16Safe`.

## Why This Change Was Made

Replace `.slice` with `truncateUtf16Safe` from `openclaw/plugin-sdk/text-utility-runtime`, matching `pw-tools-core.responses.ts` / `pw-tools-core.snapshot.ts`.

## User Impact

**Before:** Page-text truncation could emit a broken trailing surrogate.

**After:** Truncation backs up to a code-unit boundary; emoji at the edge is dropped whole.

## Evidence

- Changed: `extensions/browser/src/browser/pw-tools-core.activity.ts`, `extensions/browser/src/browser/pw-tools-core.activity.test.ts`
- Production path: browser page-text tool → `getPageTextViaPlaywright` → `truncateUtf16Safe`

## Real behavior proof

### Behavior or issue addressed

`maxChars=5` on `"abcd😀"` returns `"abcd"` with no lone surrogate (raw `.slice` would keep a high surrogate).

### Canonical reachability path

`getPageTextViaPlaywright` → `locator.innerText` → `truncateUtf16Safe(text, maxChars)`

### Shared helper / provider constraint check

Reuses shared `truncateUtf16Safe` already used by snapshot/responses.

### Real environment tested

Local Vitest with Playwright page mocks (`installTextPage`).

### Exact steps or command run after this patch

```bash
node scripts/run-vitest.mjs extensions/browser/src/browser/pw-tools-core.activity.test.ts -t "surrogate pair" --reporter=verbose
```

### Evidence after fix

```text
[browser page-text utf16 proof] maxChars=5 input="abcd😀" output="abcd" truncated=true

 ✓ |extension-browser| ... > does not split a trailing surrogate pair when truncating page text 182ms

 Test Files  1 passed (1)
      Tests  1 passed | 12 skipped (13)
```

### Observed result after fix

Output is `"abcd"` (emoji dropped whole); no lone surrogate remains.

### What was not tested

Live Playwright against a real Chrome page with emoji near the char budget.

### Fix classification

Root cause fix

- [x] AI-assisted (Cursor)
- [x] I understand what the code does
- [x] Change is focused and does not mix unrelated concerns
