### PR TITLE
fix(browser): do not await rate-limit body cancel in client-fetch

### DIFF
--- a/extensions/browser/src/browser/client-fetch.cancel-nofollow.test.ts
+++ b/extensions/browser/src/browser/client-fetch.cancel-nofollow.test.ts
@@ -1,0 +1,76 @@
+// Prove rate-limited browser-control fetches do not await a never-settling body.cancel().
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  fetchWithSsrFGuard: vi.fn(),
+  loadConfig: vi.fn(() => ({})),
+  resolveBrowserControlAuth: vi.fn(() => ({})),
+  getBridgeAuthForPort: vi.fn(() => undefined),
+}));
+
+vi.mock("openclaw/plugin-sdk/ssrf-runtime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/ssrf-runtime")>();
+  return {
+    ...actual,
+    fetchWithSsrFGuard: mocks.fetchWithSsrFGuard,
+  };
+});
+
+vi.mock("../config/config.js", async () => {
+  const actual = await vi.importActual<typeof import("../config/config.js")>("../config/config.js");
+  return { ...actual, getRuntimeConfig: mocks.loadConfig, loadConfig: mocks.loadConfig };
+});
+vi.mock("./control-auth.js", () => ({
+  resolveBrowserControlAuth: mocks.resolveBrowserControlAuth,
+}));
+vi.mock("./bridge-auth-registry.js", () => ({
+  getBridgeAuthForPort: mocks.getBridgeAuthForPort,
+}));
+
+const { fetchBrowserJson } = await import("./client-fetch.js");
+
+afterEach(() => {
+  mocks.fetchWithSsrFGuard.mockReset();
+  vi.restoreAllMocks();
+});
+
+describe("fetchBrowserJson rate-limit body cancel", () => {
+  it("rejects without waiting when unread 429 body cancel never settles", async () => {
+    let cancelStarted = false;
+    const release = vi.fn(async () => {});
+    mocks.fetchWithSsrFGuard.mockResolvedValueOnce({
+      response: {
+        ok: false,
+        status: 429,
+        bodyUsed: false,
+        body: {
+          cancel: () => {
+            cancelStarted = true;
+            return new Promise(() => {});
+          },
+        },
+      } as unknown as Response,
+      release,
+    });
+
+    const startedAt = Date.now();
+    await expect(
+      Promise.race([
+        fetchBrowserJson("http://127.0.0.1:18791/ok", { timeoutMs: 250 }),
+        new Promise<never>((_, reject) => {
+          AbortSignal.timeout(1_000).addEventListener("abort", () => {
+            reject(new Error("fetchBrowserJson hung waiting for body.cancel"));
+          });
+        }),
+      ]),
+    ).rejects.toThrow(/rate[ -]?limit/i);
+    const elapsedMs = Date.now() - startedAt;
+
+    expect(cancelStarted).toBe(true);
+    expect(release).toHaveBeenCalledOnce();
+    expect(elapsedMs).toBeLessThan(1_000);
+    console.log(
+      `[browser client-fetch cancel-nofollow proof] cancel_started=${cancelStarted} release_called=${release.mock.calls.length} elapsed_ms=${elapsedMs}`,
+    );
+  });
+});

--- a/extensions/browser/src/browser/client-fetch.rate-limit-cancel.transport.test.ts
+++ b/extensions/browser/src/browser/client-fetch.rate-limit-cancel.transport.test.ts
@@ -1,0 +1,85 @@
+// Real HTTP: production fetchBrowserJson must cancel an unread 429 body and
+// release the loopback socket without awaiting a never-ending stream.
+import http from "node:http";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const authMocks = vi.hoisted(() => ({
+  loadConfig: vi.fn(() => ({})),
+  resolveBrowserControlAuth: vi.fn(() => ({})),
+  getBridgeAuthForPort: vi.fn(() => undefined),
+}));
+
+vi.mock("../config/config.js", async () => {
+  const actual = await vi.importActual<typeof import("../config/config.js")>("../config/config.js");
+  return { ...actual, getRuntimeConfig: authMocks.loadConfig, loadConfig: authMocks.loadConfig };
+});
+vi.mock("./control-auth.js", () => ({
+  resolveBrowserControlAuth: authMocks.resolveBrowserControlAuth,
+}));
+vi.mock("./bridge-auth-registry.js", () => ({
+  getBridgeAuthForPort: authMocks.getBridgeAuthForPort,
+}));
+
+const { fetchBrowserJson } = await import("./client-fetch.js");
+
+describe("fetchBrowserJson rate-limit hanging-body transport", () => {
+  let server: http.Server;
+  let baseUrl: string;
+  let socketClosed: Promise<void>;
+  let resolveSocketClosed: () => void;
+
+  beforeEach(async () => {
+    for (const key of ["ALL_PROXY", "all_proxy", "HTTP_PROXY", "http_proxy", "HTTPS_PROXY", "https_proxy"]) {
+      vi.stubEnv(key, "");
+    }
+    socketClosed = new Promise<void>((resolve) => {
+      resolveSocketClosed = resolve;
+    });
+    server = http.createServer((_req, res) => {
+      res.socket?.once("close", () => resolveSocketClosed());
+      res.writeHead(429, { "Content-Type": "application/json" });
+      // Leave the body unread so production discardResponseBody must cancel it.
+      res.write('{"error":"rate-limited"');
+    });
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(0, "127.0.0.1", () => {
+        server.off("error", reject);
+        resolve();
+      });
+    });
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      throw new Error("expected loopback TCP address");
+    }
+    baseUrl = `http://127.0.0.1:${address.port}`;
+  });
+
+  afterEach(async () => {
+    vi.unstubAllEnvs();
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+      server.closeAllConnections();
+    });
+  });
+
+  it("rejects 429 and closes the hanging loopback socket", async () => {
+    const startedAt = Date.now();
+    await expect(fetchBrowserJson(`${baseUrl}/ok`, { timeoutMs: 2_000 })).rejects.toThrow(
+      /rate[ -]?limit/i,
+    );
+    await Promise.race([
+      socketClosed,
+      new Promise<never>((_, reject) => {
+        AbortSignal.timeout(1_000).addEventListener("abort", () => {
+          reject(new Error("loopback socket stayed open after 429 cancel"));
+        });
+      }),
+    ]);
+    const elapsedMs = Date.now() - startedAt;
+    expect(elapsedMs).toBeLessThan(1_000);
+    console.log(
+      `[browser client-fetch 429 transport proof] rejected_rate_limit=true socket_closed=true elapsed_ms=${elapsedMs}`,
+    );
+  });
+});

--- a/extensions/browser/src/browser/client-fetch.ts
+++ b/extensions/browser/src/browser/client-fetch.ts
@@ -302,12 +302,10 @@ function resolveBrowserToolModelHint(kind: BrowserFetchFailureKind): string | un
   return kind === "persistent" ? BROWSER_TOOL_PERSISTENT_MODEL_HINT : undefined;
 }
 
-async function discardResponseBody(res: Response): Promise<void> {
-  try {
-    await res.body?.cancel();
-  } catch {
-    // Best effort only; we're already returning a stable error message.
-  }
+function discardResponseBody(res: Response): void {
+  // Do not await cancel: teed/debug streams can leave cancel pending forever
+  // (same invariant as Google Chat fetchOk / CDP probe release).
+  void res.body?.cancel().catch(() => undefined);
 }
 
 function enhanceDispatcherPathError(url: string, err: unknown): Error {
@@ -388,7 +386,7 @@ async function fetchHttpJson<T>(
     if (!res.ok) {
       if (isRateLimitStatus(res.status)) {
         // Do not reflect upstream response text into the error surface (log/agent injection risk)
-        await discardResponseBody(res);
+        discardResponseBody(res);
         throw new BrowserServiceError(
           `${resolveBrowserRateLimitMessage(url)} ${BROWSER_TOOL_PERSISTENT_MODEL_HINT}`,
         );


### PR DESCRIPTION
## What Problem This Solves

Browser-control client rate-limit handling awaited `response.body.cancel()` before throwing. When cancel never settles (teed/debug streams), a 429 path hangs instead of failing closed with the rate-limit error and releasing the HTTP socket.

## Why This Change Was Made

Start unread-body cancellation with `void res.body?.cancel().catch(() => undefined)` and throw immediately — same Google Chat / CDP fire-and-forget cancel invariant. Proof is a real `node:http` loopback that leaves the 429 body hanging so production `fetchBrowserJson` must cancel it.

## User Impact

**Before:** A 429 browser-control response could hang waiting for body cancel and keep the socket leased.

**After:** Rate-limit error is thrown after starting cancel; the hanging loopback socket closes.

## Evidence

- Changed: `extensions/browser/src/browser/client-fetch.ts`, `extensions/browser/src/browser/client-fetch.rate-limit-cancel.transport.test.ts`
- Production path: `fetchBrowserJson` → `fetchHttpJson` → real `fetchWithSsrFGuard` → 429 hanging `node:http` body → `discardResponseBody` → `BrowserServiceError` + socket close
- Exact head: `100b53f0d08`

## Real behavior proof

- **Behavior or issue addressed:** `fetchBrowserJson` rejects a real HTTP 429 without waiting for a hanging unread body, and the loopback socket closes.
- **Canonical reachability path:** `fetchBrowserJson(http://127.0.0.1:<ephemeral>/ok)` → production `fetchWithSsrFGuard` → status 429 with incomplete JSON body → `discardResponseBody` (void cancel) → throw → socket `close`.
- **Boundary crossed:** Real TCP loopback HTTP (not a mocked `Response`) → production guarded fetch → observable `socket_closed=true`.
- **Shared helper / provider constraint check:** Matches Google Chat `fetchOk` and CDP probe release fire-and-forget cancel.
- **Real environment tested:** Local trusted source checkout at PR head `100b53f0d08`; Vitest extension-browser project; real `node:http` server on `127.0.0.1`.
- **Exact steps or command run after this patch:**

```bash
node scripts/run-vitest.mjs extensions/browser/src/browser/client-fetch.rate-limit-cancel.transport.test.ts --reporter=verbose
```

- **Evidence after fix:**

```text
stdout | extensions/browser/src/browser/client-fetch.rate-limit-cancel.transport.test.ts > fetchBrowserJson rate-limit hanging-body transport > rejects 429 and closes the hanging loopback socket
[browser client-fetch 429 transport proof] rejected_rate_limit=true socket_closed=true elapsed_ms=274

 ✓ |extension-browser| extensions/browser/src/browser/client-fetch.rate-limit-cancel.transport.test.ts > fetchBrowserJson rate-limit hanging-body transport > rejects 429 and closes the hanging loopback socket 296ms

 Test Files  1 passed (1)
      Tests  1 passed (1)
```

- **Observed result after fix:** Rate-limit rejection and `socket_closed=true` in 274ms (under the 1s hang budget).
- **What was not tested:** Live remote browser-control service returning 429 under debug capture tee.
- **Fix classification:** Root cause fix

- [x] AI-assisted (Cursor)
- [x] I understand what the code does
- [x] Change is focused and does not mix unrelated concerns
