### PR TITLE
improve: reduce repeated HTTP client module resolution

### DIFF
--- a/scripts/lib/worker-deploy-build-plugin.mts
+++ b/scripts/lib/worker-deploy-build-plugin.mts
@@ -23,7 +23,8 @@ export function getPlaywrightUserAgent() { return getUserAgent(); }`;
 const UNDICI_REQUIRE_BOOTSTRAP = [
   'import { createRequire } from "node:module";',
   "const requireUndici = createRequire(import.meta.url);\n",
-  'return requireUndici("undici/index.js") as typeof import("undici");',
+  'let undiciModule: typeof import("undici") | undefined;\n',
+  'return (undiciModule ??= requireUndici("undici/index.js") as typeof import("undici"));',
 ] as const;
 const WORKER_UNDICI_IMPORT = 'import * as bundledUndici from "undici/index.js";';
 const WS_REQUIRE_BOOTSTRAP = `require(
@@ -136,7 +137,8 @@ export function createWorkerDeployBuildPlugin(rootDir = process.cwd()) {
         return code
           .replace(UNDICI_REQUIRE_BOOTSTRAP[0], WORKER_UNDICI_IMPORT)
           .replace(UNDICI_REQUIRE_BOOTSTRAP[1], "")
-          .replace(UNDICI_REQUIRE_BOOTSTRAP[2], "return bundledUndici;");
+          .replace(UNDICI_REQUIRE_BOOTSTRAP[2], "")
+          .replace(UNDICI_REQUIRE_BOOTSTRAP[3], "return bundledUndici;");
       }
       if (
         resolvedId !== coreBundlePath ||

--- a/src/infra/net/undici-dispatcher-options.ts
+++ b/src/infra/net/undici-dispatcher-options.ts
@@ -7,6 +7,7 @@ import { resolveUndiciAutoSelectFamilyConnectOptions } from "./undici-family-pol
 
 const TEST_UNDICI_RUNTIME_DEPS_KEY = "__OPENCLAW_TEST_UNDICI_RUNTIME_DEPS__";
 const requireUndici = createRequire(import.meta.url);
+let undiciModule: typeof import("undici") | undefined;
 
 type UndiciAgentOptions = ConstructorParameters<typeof import("undici").Agent>[0];
 type UndiciProxyAgentOptions = ConstructorParameters<typeof import("undici").ProxyAgent>[0];
@@ -28,7 +29,7 @@ export function loadUndiciModule(
     return override as typeof import("undici");
   }
   // Bun substitutes a partial built-in for bare undici; require the installed API.
-  return requireUndici("undici/index.js") as typeof import("undici");
+  return (undiciModule ??= requireUndici("undici/index.js") as typeof import("undici"));
 }
 
 function createHttp1ProxyClient(origin: URL, poolOptions: object): import("undici").Dispatcher {

--- a/src/infra/net/undici-runtime.test.ts
+++ b/src/infra/net/undici-runtime.test.ts
@@ -1,5 +1,8 @@
 import { EventEmitter } from "node:events";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { execNodeEvalSync } from "../../test-utils/node-process.js";
 import {
   registerActiveManagedProxyUrl,
   stopActiveManagedProxyRegistration,
@@ -132,6 +135,73 @@ function invokeProxyClientFactory(options: Record<string, unknown>): void {
 }
 
 describe("installed dispatcher lifecycle", () => {
+  it("loads lazily, retries failed initialization, and reuses the installed API behind overrides", () => {
+    const runtimeUrl = pathToFileURL(path.resolve("src/infra/net/undici-runtime.ts")).href;
+    const packageUrl = pathToFileURL(path.resolve("package.json")).href;
+    const output = execNodeEvalSync(
+      `
+      import assert from "node:assert/strict";
+      import { EventEmitter } from "node:events";
+      import { createRequire, registerHooks } from "node:module";
+
+      let resolutions = 0;
+      const hook = registerHooks({
+        resolve(specifier, context, nextResolve) {
+          if (
+            specifier === "undici/index.js" &&
+            context.parentURL?.split("?")[0].endsWith("/undici-dispatcher-options.ts")
+          ) {
+            resolutions++;
+            if (resolutions === 1) {
+              throw new Error("fixture Undici initialization failure");
+            }
+          }
+          return nextResolve(specifier, context);
+        },
+      });
+      const overrideKey = ${JSON.stringify(TEST_UNDICI_RUNTIME_DEPS_KEY)};
+      class OverrideAgent extends EventEmitter {}
+      const override = {
+        Agent: OverrideAgent,
+        EnvHttpProxyAgent: OverrideAgent,
+        ProxyAgent: OverrideAgent,
+        fetch() {},
+      };
+      const dispatchers = [];
+      try {
+        const { createHttp1Agent } = await import(${JSON.stringify(runtimeUrl)});
+        assert.equal(resolutions, 0, "import must leave Undici unloaded");
+        globalThis[overrideKey] = override;
+        assert.ok(createHttp1Agent() instanceof OverrideAgent);
+        assert.equal(resolutions, 0, "override must leave Undici unloaded");
+        delete globalThis[overrideKey];
+
+        assert.throws(() => createHttp1Agent(), /fixture Undici initialization failure/);
+        // Another Gateway consumer can load Undici before this owner retries.
+        // This avoids Node's first-loader parent cache masking repeated resolution.
+        createRequire(${JSON.stringify(packageUrl)})("undici/index.js");
+        dispatchers.push(createHttp1Agent());
+        assert.equal(resolutions, 2, "initialization must retry after a failure");
+
+        globalThis[overrideKey] = override;
+        assert.ok(createHttp1Agent() instanceof OverrideAgent);
+        delete globalThis[overrideKey];
+        dispatchers.push(createHttp1Agent());
+        assert.equal(dispatchers[1].constructor, dispatchers[0].constructor);
+        assert.equal(resolutions, 2, "warm native construction must reuse the installed API");
+        console.log("ok");
+      } finally {
+        delete globalThis[overrideKey];
+        hook.deregister();
+        await Promise.all(dispatchers.map((dispatcher) => dispatcher.destroy()));
+      }
+      `,
+      { imports: ["tsx"] },
+    );
+
+    expect(output.trim()).toBe("ok");
+  });
+
   it.each([
     ["close", "closed"],
     ["destroy", "destroyed"],

--- a/test/scripts/worker-deploy-build-plugin.test.ts
+++ b/test/scripts/worker-deploy-build-plugin.test.ts
@@ -294,6 +294,7 @@ export async function createAttachedBrowserToolRuntime(params) {
     expect(transformed).not.toContain('import { createRequire } from "node:module";');
     expect(transformed).not.toContain("const requireUndici = createRequire(import.meta.url);");
     expect(transformed).not.toContain('requireUndici("undici/index.js")');
+    expect(transformed).not.toContain("undiciModule");
   });
 
   it("leaves fs-safe native package resolution to the dependency", () => {
@@ -314,10 +315,7 @@ export async function createAttachedBrowserToolRuntime(params) {
     expect(() =>
       plugin.transform.call(
         { error: fail },
-        source.replace(
-          'return requireUndici("undici/index.js")',
-          'return changedUndici("undici/index.js")',
-        ),
+        source.replace('requireUndici("undici/index.js")', 'changedUndici("undici/index.js")'),
         dispatcherPath,
       ),
     ).toThrow("undici dispatcher bootstrap changed");


### PR DESCRIPTION
## What Problem This Solves

Gateway HTTP clients can repeatedly resolve the installed Undici package when another consumer loaded it first. With the plugin host's module resolver active, this adds allocation and synchronous work each time a dispatcher is constructed.

## Why This Change Was Made

Keep the successfully loaded module in its existing owner while retaining lazy initialization, retry after a failed load, and test override precedence. Update the worker build transform to consume its existing bundled Undici namespace and remove the native loader and cache together.

## User Impact

Less repeated module resolution during HTTP client construction. Connection, proxy, TLS, timeout, and dispatcher cleanup behavior remain governed by their existing owners.

## Evidence

- Node 24.19 regression fails on the original owner: a warm construction resolves the package a third time rather than retaining the successful second load. The candidate passes lazy-load, failed-load retry, prior-parent loading, late override, and dispatcher cleanup assertions.
- All 14 Undici runtime tests and 15 worker build tests pass, including the complete staged worker graph. Targeted core type-aware lint, formatting, and diff checks pass.
- An external source-owner loopback probe served 1,800 responses with exact response and close parity and all sockets closed, using the installed Undici package and one actual plugin-host alias resolver. Median 72-request batches changed from 116.13 to 107.34 ms with one connection and 158.78 to 133.99 ms with two connections. These are local source-owner measurements, not built-Gateway latency guarantees.
- Separate allocation sampling attributed 1,894,624 bytes to repeated loading before and 8,240 bytes after; these are sampled allocations, not retained heap.
- Independent P2 review completed scoped-clean with final source verification and no findings.
- [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34703028211) passed, including the full candidate build, production and test type checks, lint, guards, and selected test suites. A separate original built-Gateway load benchmark hit its existing two-second shutdown deadline; it is not counted as passing performance evidence for this change.
