### PR TITLE
fix(ai): preserve declared reasoning tiers in embedded sessions

### DIFF
--- a/packages/ai/src/model-utils.test.ts
+++ b/packages/ai/src/model-utils.test.ts
@@ -60,6 +60,17 @@ describe("calculateCost", () => {
 });
 
 describe("clampThinkingLevel", () => {
+  it.each(["anthropic-messages", "google-generative-ai", "mistral-conversations"] as const)(
+    "does not apply OpenAI compat levels to %s",
+    (api) => {
+      const model = makeModel(undefined, {
+        api,
+        compat: { supportedReasoningEfforts: ["max"] },
+      });
+      expect(clampThinkingLevel(model, "max")).toBe("high");
+    },
+  );
+
   it("downgrades explicit extended-level opt-outs", () => {
     expect(clampThinkingLevel(makeModel({ xhigh: null, max: "max" }), "xhigh")).toBe("high");
   });

--- a/packages/ai/src/model-utils.ts
+++ b/packages/ai/src/model-utils.ts
@@ -4,6 +4,7 @@ import {
   resolveClaudeNativeThinkingLevelMap,
   requiresClaudeMandatoryAdaptiveThinking,
 } from "@openclaw/llm-core";
+import { resolveOpenAIModelReasoningEfforts } from "./providers/openai-reasoning-effort.js";
 import type { Api, Model, ModelThinkingLevel, Usage } from "./types.js";
 
 /** Calculates and stores model cost fields from token usage and per-million pricing. */
@@ -47,6 +48,13 @@ export function getSupportedThinkingLevels<TApi extends Api>(
     return ["off"];
   }
   const thinkingLevelMap = resolveThinkingLevelMap(model);
+  const reasoningEfforts =
+    model.api === "openai-completions" ||
+    model.api === "openai-responses" ||
+    model.api === "azure-openai-responses" ||
+    model.api === "openai-chatgpt-responses"
+      ? resolveOpenAIModelReasoningEfforts(model)
+      : undefined;
 
   return EXTENDED_THINKING_LEVELS.filter((level) => {
     const mapped = thinkingLevelMap?.[level];
@@ -54,7 +62,7 @@ export function getSupportedThinkingLevels<TApi extends Api>(
       return false;
     }
     if (level === "xhigh" || level === "max") {
-      return mapped !== undefined;
+      return mapped !== undefined || reasoningEfforts?.includes(level) === true;
     }
     return true;
   });

--- a/packages/ai/src/providers/openai-compatible-thinking.test.ts
+++ b/packages/ai/src/providers/openai-compatible-thinking.test.ts
@@ -1,0 +1,146 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { configureAiTransportHost } from "../host.js";
+import type { Context, Model, ModelThinkingLevel } from "../types.js";
+import { streamSimpleOpenAICompletions } from "./openai-completions.js";
+import { streamSimpleOpenAIResponses } from "./openai-responses.js";
+
+const context: Context = {
+  messages: [{ role: "user", content: "Reply briefly.", timestamp: 1 }],
+};
+
+type ReasoningCase = {
+  name: string;
+  modelId?: string;
+  requested: ModelThinkingLevel;
+  compat?: Model["compat"];
+  thinkingLevelMap?: Model["thinkingLevelMap"];
+  expected: string | undefined;
+  expectedResponses?: string;
+};
+
+const cases: ReasoningCase[] = [
+  {
+    name: "known model API max default",
+    modelId: "gpt-5.6-sol",
+    requested: "max",
+    expected: "xhigh",
+    expectedResponses: "max",
+  },
+  {
+    name: "explicit compat max for a known model",
+    modelId: "gpt-5.6-sol",
+    requested: "max",
+    compat: { supportedReasoningEfforts: ["low", "medium", "high", "xhigh", "max"] },
+    expected: "max",
+  },
+  {
+    name: "declared native max",
+    requested: "max",
+    compat: { supportedReasoningEfforts: ["low", "medium", "high", "xhigh", "max"] },
+    thinkingLevelMap: { off: null, minimal: null },
+    expected: "max",
+  },
+  {
+    name: "declared xhigh",
+    requested: "xhigh",
+    compat: { supportedReasoningEfforts: ["low", "medium", "high", "xhigh"] },
+    expected: "xhigh",
+  },
+  { name: "undeclared max", requested: "max", expected: "high" },
+  { name: "plain minimal", requested: "minimal", expected: "minimal" },
+  {
+    name: "off map hole",
+    requested: "off",
+    thinkingLevelMap: { off: null },
+    expected: "minimal",
+  },
+  {
+    name: "explicit xhigh cap below max",
+    requested: "xhigh",
+    compat: { supportedReasoningEfforts: ["low", "medium", "high", "xhigh", "max"] },
+    thinkingLevelMap: { xhigh: null },
+    expected: "high",
+  },
+  {
+    name: "mapped max alias",
+    requested: "max",
+    thinkingLevelMap: { xhigh: "xhigh", max: "xhigh" },
+    expected: "xhigh",
+  },
+  {
+    name: "explicit reasoning serialization opt-out",
+    requested: "high",
+    compat: { supportsReasoningEffort: false },
+    expected: undefined,
+  },
+];
+
+describe.each(["openai-completions", "openai-responses"] as const)(
+  "%s custom reasoning at the SDK request boundary",
+  (api) => {
+    afterEach(() => configureAiTransportHost({}));
+
+    it.each(cases)("preserves $name", async (cell) => {
+      const { requested, compat, thinkingLevelMap, expected } = cell;
+      const modelId = cell.modelId ?? "custom-reasoner";
+      const expectedResponses = cell.expectedResponses ?? expected;
+      const model = {
+        id: modelId,
+        name: "Custom Reasoner",
+        api,
+        provider: "custom-provider",
+        baseUrl: "https://reasoning.example/v1",
+        reasoning: true,
+        input: ["text"],
+        contextWindow: 32_000,
+        maxTokens: 1024,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        compat,
+        thinkingLevelMap,
+      } satisfies Model;
+      const requests: {
+        model: string;
+        reasoning_effort?: string;
+        reasoning?: { effort: string };
+      }[] = [];
+      configureAiTransportHost({
+        buildModelFetch: () => async (input, init) => {
+          const request = new Request(input, init);
+          expect(request.method).toBe("POST");
+          expect(new URL(request.url).pathname).toBe(
+            api === "openai-completions" ? "/v1/chat/completions" : "/v1/responses",
+          );
+          requests.push(await request.json());
+          const event =
+            api === "openai-completions"
+              ? {
+                  id: "reply",
+                  choices: [{ index: 0, delta: { content: "OK" }, finish_reason: "stop" }],
+                }
+              : {
+                  type: "response.completed",
+                  response: { id: "reply", status: "completed", output: [] },
+                };
+          return new Response(`data: ${JSON.stringify(event)}\n\ndata: [DONE]\n\n`, {
+            headers: { "content-type": "text/event-stream" },
+          });
+        },
+      });
+
+      const options = { apiKey: "test-key", reasoning: requested };
+      const result = await (
+        api === "openai-completions"
+          ? streamSimpleOpenAICompletions({ ...model, api }, context, options)
+          : streamSimpleOpenAIResponses({ ...model, api }, context, options)
+      ).result();
+      expect(result.stopReason).toBe("stop");
+      expect(requests).toHaveLength(1);
+      expect(requests[0]?.model).toBe(modelId);
+      expect(
+        api === "openai-completions"
+          ? requests[0]?.reasoning_effort
+          : requests[0]?.reasoning?.effort,
+      ).toBe(api === "openai-responses" ? expectedResponses : expected);
+    });
+  },
+);

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -231,12 +231,7 @@ export const streamSimpleOpenAICompletions: StreamFunction<
   const clampedReasoning = options?.reasoning
     ? clampThinkingLevel(model, options.reasoning)
     : undefined;
-  const reasoningEffort =
-    clampedReasoning === "off"
-      ? undefined
-      : clampedReasoning === "max"
-        ? "xhigh"
-        : clampedReasoning;
+  const reasoningEffort = clampedReasoning === "off" ? undefined : clampedReasoning;
   const toolChoice = (options as OpenAICompletionsOptions | undefined)?.toolChoice;
 
   return streamOpenAICompletions(model, context, {

--- a/packages/ai/src/providers/openai-reasoning-effort.test.ts
+++ b/packages/ai/src/providers/openai-reasoning-effort.test.ts
@@ -9,6 +9,24 @@ import {
 } from "./openai-reasoning-effort.js";
 
 describe("OpenAI reasoning effort support", () => {
+  it.each([
+    { api: "openai-completions", expected: "xhigh", compat: undefined },
+    { api: "openai-responses", expected: "max", compat: undefined },
+    {
+      api: "openai-completions",
+      expected: "max",
+      compat: { supportedReasoningEfforts: ["low", "medium", "high", "xhigh", "max"] },
+    },
+    {
+      api: "openai-completions",
+      expected: undefined,
+      compat: { supportsReasoningEffort: false },
+    },
+  ])("uses the $api max contract with compat=$compat", ({ api, expected, compat }) => {
+    const model = { provider: "openai", id: "gpt-5.6-sol", api, compat };
+    expect(resolveOpenAIReasoningEffortForModel({ model, effort: "max" })).toBe(expected);
+  });
+
   it("recognizes GPT-5.6 model ids and deployment names", () => {
     expect(isOpenAIGpt56Model({ id: "gpt-5.6-luna" })).toBe(true);
     expect(isOpenAIGpt56Model({ id: "prod-luna", name: "GPT-5.6 (Azure)" })).toBe(true);

--- a/packages/ai/src/providers/openai-reasoning-effort.ts
+++ b/packages/ai/src/providers/openai-reasoning-effort.ts
@@ -121,12 +121,13 @@ export function resolveOpenAIModelReasoningEfforts(
   }
 
   const id = normalizeModelId(typeof model.id === "string" ? model.id : undefined);
+  const supportsMax = model.api !== "openai-completions";
   // Azure deployment capabilities must be declared until its Astra contract is verified.
   if (id === "gpt-6-astra" && model.api !== "azure-openai-responses") {
-    return GPT_6_ASTRA_REASONING_EFFORTS;
+    return supportsMax ? GPT_6_ASTRA_REASONING_EFFORTS : GPT_CODEX_REASONING_EFFORTS;
   }
   if (/^gpt-5\.6(?:-|$)/u.test(id)) {
-    return GPT_56_REASONING_EFFORTS;
+    return supportsMax ? GPT_56_REASONING_EFFORTS : GPT_52_REASONING_EFFORTS;
   }
   if (id === "gpt-5.1-codex-mini") {
     return GPT_51_CODEX_MINI_REASONING_EFFORTS;

--- a/packages/ai/src/providers/openai-responses-shared.ts
+++ b/packages/ai/src/providers/openai-responses-shared.ts
@@ -156,16 +156,7 @@ export function resolveResponsesReasoningEffort<TApi extends Api>(
   model: Model<TApi>,
   reasoning: SimpleStreamOptions["reasoning"] | undefined,
 ): ResponsesReasoningEffort | undefined {
-  if (!reasoning) {
-    return undefined;
-  }
-  const supportsRequestedEffort =
-    model.reasoning &&
-    model.thinkingLevelMap?.[reasoning] === undefined &&
-    resolveOpenAIModelReasoningEfforts(model)?.includes(reasoning);
-  const clampedReasoning = supportsRequestedEffort
-    ? reasoning
-    : clampThinkingLevel(model, reasoning);
+  const clampedReasoning = reasoning ? clampThinkingLevel(model, reasoning) : undefined;
   return clampedReasoning === "off" ? undefined : clampedReasoning;
 }
 

--- a/src/agents/sessions/sdk.test.ts
+++ b/src/agents/sessions/sdk.test.ts
@@ -849,6 +849,44 @@ describe("createAgentSession thinking level defaults", () => {
     thinkingMocks.resolveThinkingDefaultForModel.mockReturnValue("medium");
   });
 
+  it.each([
+    "openai-completions",
+    "openai-responses",
+    "azure-openai-responses",
+    "openai-chatgpt-responses",
+  ] as const)("records declared max thinking in a new embedded %s session", async (api) => {
+    const sessionManager = SessionManager.inMemory();
+    const { session } = await createAgentSessionForEmbeddedRunner(
+      {
+        model: {
+          ...testModel,
+          id: "custom-reasoner",
+          api,
+          reasoning: true,
+          thinkingLevelMap: { off: null, minimal: null },
+          compat: { supportedReasoningEfforts: ["low", "medium", "high", "xhigh", "max"] },
+        },
+        thinkingLevel: "max",
+        resourceLoader: createResourceLoader(),
+        sessionManager,
+        settingsManager: SettingsManager.inMemory(),
+        modelRegistry: createTestModelRegistry(),
+      },
+      {},
+    );
+    try {
+      expect({
+        level: session.thinkingLevel,
+        recorded: sessionManager
+          .getEntries()
+          .filter((entry) => entry.type === "thinking_level_change")
+          .map((entry) => entry.thinkingLevel),
+      }).toEqual({ level: "max", recorded: ["max"] });
+    } finally {
+      session.dispose();
+    }
+  });
+
   it("uses the provider-specific thinking default for new sessions", async () => {
     thinkingMocks.resolveThinkingDefaultForModel.mockReturnValue("off");
 


### PR DESCRIPTION
Closes #144866.
Related: #90703, #111367, #130706.

## What Problem This Solves

Fixes an issue where custom OpenAI-compatible models declare advanced reasoning tiers, but embedded session creation silently clamps `max` to `high` before recording the child transcript. Completions also remapped every surviving `max` to `xhigh`, including custom backends that explicitly declare native `max`.

## Why This Change Was Made

The shared thinking-level resolver now consumes the existing reasoning contract. Sessions and Responses use the same decision, and Completions leaves serialization to the existing provider mapping. Explicit compat declarations remain authoritative; implicit built-in defaults respect the selected API's ceiling. This removes competing policy and reduces production code by five lines.

Alex Govorov's work in #90703 informed the repair; contributor credit is preserved in the commits.

## User Impact

Explicit custom `xhigh` and `max` support survives session creation and request serialization. Native defaults remain API-specific: for `gpt-5.6-sol`, a maximum request uses `xhigh` on Completions and `max` on Responses. Undeclared-model defaults, explicit null caps, ordinary minimal/off behavior, and reasoning opt-outs remain covered.

## Evidence

- Baselines reproduced the child-session/transcript clamp and incorrect request effort, with passing sibling controls. A further hosted check exposed a real API distinction: an earlier candidate sent native `max` to Completions and received HTTP 400. That failure led to the API-specific default repair; the original source/build/proof remains preserved.
- On runtime-tested `c31caa9a769bd20a56a16e7f9606853ea1111d24`, 295 focused tests, the full cumulative changed-file checks, independent P2 review, and a normal `pnpm build` passed.
- The compiled public LLM SDK passed 20 loopback cases with exact request/wire efforts, HTTP 200, completed streaming, final `OK`, and natural exit. Explicit custom native `max` remains covered. An earlier 9/16 fixture attempt omitted the proxy reasoning opt-in and remains qualified as failed.
- Fresh hosted OpenAI calls on that same build each requested maximum reasoning: Completions sent `xhigh`, Responses sent `max`, and both received HTTP 200 with completed `OK` replies. All 12,092 build outputs remained unchanged; task credential processes and isolated state were cleaned up.
- Session proof exercises the real embedded constructor and transcript owner, not a full Gateway-to-child `sessions_spawn` run. Azure retains its existing max-to-xhigh wire alias. Broader mapping/schema proposals in the related PRs are outside this cut.

The final branch head is `75bdfcbbdcee9ed45cc9b8ea5283c989d4ecb262`, a patch-identical carry onto current main after an unrelated CI failure. The failed run tested a merge with main that had 701 Gateway test roots; #146212 restored shard headroom while retaining the limits. On the refreshed branch, all 295 focused tests, the unchanged shard inventory check, and the full changed-file gate pass. All eight changed postimages and the relevant production/caller/dependency inputs match the reviewed candidate. The normal build, compiled cases, and hosted observations remain bound to `c31caa9a769bd20a56a16e7f9606853ea1111d24`; no new build or hosted run is claimed for the mechanical carry.
