### PR TITLE
fix(memory): reject unsafe SQL identifiers in schema params

### DIFF
--- a/packages/memory-host-sdk/src/host/memory-schema-fts.test.ts
+++ b/packages/memory-host-sdk/src/host/memory-schema-fts.test.ts
@@ -53,4 +53,47 @@ describe("memory index FTS lifecycle", () => {
       db.close();
     }
   });
+
+  it.each([
+    {
+      name: "statement break",
+      ftsTable: "ok USING fts5(text); DROP TABLE memory_index_chunks; CREATE VIRTUAL TABLE z",
+    },
+    { name: "schema-qualified", ftsTable: "aux.chunks_fts" },
+    { name: "quoted identifier", ftsTable: '"evil"' },
+  ])("rejects $name FTS table names before interpolating SQL", ({ ftsTable }) => {
+    const db = new DatabaseSync(":memory:");
+    try {
+      expect(
+        ensureMemoryIndexSchema({ db, cacheEnabled: false, ftsEnabled: true }).ftsAvailable,
+      ).toBe(true);
+      db.prepare(
+        "INSERT INTO memory_index_chunks (id, path, source, start_line, end_line, hash, model, text, embedding, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+      ).run("c1", "keep.md", "memory", 1, 1, "h", "m", "hello", "[]", 1);
+
+      expect(() =>
+        ensureMemoryIndexSchema({ db, cacheEnabled: false, ftsEnabled: true, ftsTable }),
+      ).toThrow(/not a safe SQL identifier/);
+
+      expect(db.prepare("SELECT id FROM memory_index_chunks").all()).toEqual([{ id: "c1" }]);
+    } finally {
+      db.close();
+    }
+  });
+
+  it("rejects unsafe embedding cache table names before interpolating SQL", () => {
+    const db = new DatabaseSync(":memory:");
+    try {
+      expect(() =>
+        ensureMemoryIndexSchema({
+          db,
+          cacheEnabled: true,
+          ftsEnabled: false,
+          embeddingCacheTable: "cache; DROP TABLE memory_index_chunks; --",
+        }),
+      ).toThrow(/not a safe SQL identifier/);
+    } finally {
+      db.close();
+    }
+  });
 });

--- a/packages/memory-host-sdk/src/host/memory-schema-fts.ts
+++ b/packages/memory-host-sdk/src/host/memory-schema-fts.ts
@@ -6,6 +6,20 @@ export const MEMORY_INDEX_CHUNKS_TABLE = "memory_index_chunks";
 export const MEMORY_INDEX_FTS_TABLE = "memory_index_chunks_fts";
 export const MEMORY_INDEX_PATHS_FTS_TABLE = "memory_index_paths_fts";
 
+const MEMORY_SQL_IDENTIFIER = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+/** Reject caller-supplied names that cannot be interpolated into DDL. */
+export function assertSafeMemorySqlIdentifier(name: string, label: string): string {
+  if (!MEMORY_SQL_IDENTIFIER.test(name)) {
+    throw new Error(`Memory ${label} "${name}" is not a safe SQL identifier`);
+  }
+  return name;
+}
+
+export function assertSafeMemoryFtsTableName(name: string): string {
+  return assertSafeMemorySqlIdentifier(name, "FTS table");
+}
+
 type FtsTableSchemaStatus = "missing" | "matching" | "mismatched" | "not-fts";
 
 /** Check every persisted FTS column declaration and supported table option. */
@@ -139,6 +153,7 @@ export const MEMORY_PATH_FTS_TRIGGER_DEFINITIONS = [
 ] as const;
 
 export function rebuildMemoryChunkFts(db: DatabaseSync, ftsTable: string): void {
+  assertSafeMemoryFtsTableName(ftsTable);
   db.exec(`
     DELETE FROM ${ftsTable};
     INSERT INTO ${ftsTable} (
@@ -157,6 +172,7 @@ export function ensureMemoryChunkFtsSchema(params: {
 }): void {
   // Body and path indexes have incompatible columns and maintenance triggers.
   // Reject SQLite's case-insensitive path alias before replacing either index.
+  assertSafeMemoryFtsTableName(params.ftsTable);
   if (params.ftsTable.toLowerCase() === MEMORY_INDEX_PATHS_FTS_TABLE.toLowerCase()) {
     throw new Error(`Memory body FTS table "${params.ftsTable}" collides with the path FTS index`);
   }
@@ -202,6 +218,7 @@ export function ensureMemoryChunkFtsSchema(params: {
 }
 
 export function dropDisabledMemoryFts(db: DatabaseSync, ftsTable: string, enabled: boolean): void {
+  assertSafeMemoryFtsTableName(ftsTable);
   if (enabled) {
     return;
   }

--- a/packages/memory-host-sdk/src/host/memory-schema.ts
+++ b/packages/memory-host-sdk/src/host/memory-schema.ts
@@ -7,6 +7,8 @@ import {
   MEMORY_INDEX_STATE_TABLE,
 } from "./memory-schema-base.js";
 import {
+  assertSafeMemoryFtsTableName,
+  assertSafeMemorySqlIdentifier,
   dropDisabledMemoryFts,
   dropMemoryPathFtsTriggers,
   ensureMemoryChunkFtsSchema,
@@ -601,8 +603,11 @@ export function ensureMemoryIndexSchema(params: {
   ftsEnabled: boolean;
   ftsTokenizer?: "unicode61" | "trigram";
 }): { ftsAvailable: boolean; ftsError?: string } {
-  const embeddingCacheTable = params.embeddingCacheTable ?? MEMORY_EMBEDDING_CACHE_TABLE;
-  const ftsTable = params.ftsTable ?? MEMORY_INDEX_FTS_TABLE;
+  const embeddingCacheTable = assertSafeMemorySqlIdentifier(
+    params.embeddingCacheTable ?? MEMORY_EMBEDDING_CACHE_TABLE,
+    "embedding cache table",
+  );
+  const ftsTable = assertSafeMemoryFtsTableName(params.ftsTable ?? MEMORY_INDEX_FTS_TABLE);
   params.db.exec(
     buildMemoryIndexStrictSchema({
       embeddingCacheTable,


### PR DESCRIPTION
## What Problem This Solves

`ensureMemoryIndexSchema` still accepts deprecated caller-supplied `ftsTable` and `embeddingCacheTable` strings and interpolates them into `db.exec` DDL. SQLite cannot bind identifiers. A plugin or doctor caller that forwards an unsanitized name can change the statement (statement-break names, schema-qualified names, quoted fragments). Canonical shipped names (`memory_index_chunks_fts`, `chunks_fts`, `embedding_cache`) are safe; the public optional params are not.

This is package-side hardening on those public params only. Compile-time table constants are not treated as attackers.

## Evidence

Live `tsx` against the patched Memory Host SDK (`node:sqlite` `:memory:`):

```console
$ pnpm exec tsx /tmp/proof-f062.mjs
canonical_ok true chunks 1
custom_ok true chunks 1
injection_rejected Error: Memory FTS table "ok USING fts5(text); DROP TABLE memory_index_chunks; CREATE VIRTUAL TABLE z" is not a safe SQL identifier
chunks_after_reject 1
cache_injection_rejected Error: Memory embedding cache table "cache; DROP TABLE memory_index_chunks; --" is not a safe SQL identifier
```

Before the patch the same injection name returned `{ ftsAvailable: false, ftsError: "near \"fts5\": syntax error" }` instead of rejecting the identifier. A bad `embeddingCacheTable` threw a raw SQLite syntax error after interpolation.

## Real behavior proof

- **Behavior or issue addressed:** Deprecated `ftsTable` / `embeddingCacheTable` params are interpolated into Memory Host SDK `db.exec` DDL. Reject anything outside `[A-Za-z_][A-Za-z0-9_]*` before the first statement runs.
- **Real environment tested:** macOS, Node v22, worktree `/tmp/oc-f062` at `498becf2e88` on `origin/main`.
- **Exact steps or command run after this patch:** `pnpm exec tsx /tmp/proof-f062.mjs` importing `ensureMemoryIndexSchema` and calling it with the canonical names, the shipped custom names, then the statement-break payloads.
- **Evidence after fix:** terminal output from that command:

  ```console
  canonical_ok true chunks 1
  custom_ok true chunks 1
  injection_rejected Error: Memory FTS table "ok USING fts5(text); DROP TABLE memory_index_chunks; CREATE VIRTUAL TABLE z" is not a safe SQL identifier
  chunks_after_reject 1
  cache_injection_rejected Error: Memory embedding cache table "cache; DROP TABLE memory_index_chunks; --" is not a safe SQL identifier
  ```

- **Observed result after fix:** Canonical and shipped custom names still open. Injection names throw before DDL. The inserted chunk row is still present after the reject.
- **What was not tested:** A live gateway doctor run that forwards operator config into these deprecated params.

## Summary

Allowlist only. No identifier quoting (avoids the schema-qualified quoting bugs that blocked #64995 / #65452). Existing collision tests for `memory_index_chunks` and `memory_index_paths_fts` still return `ftsAvailable: false` without dropping rows.

Related:
- #20656 (closed; treated compile-time constants as hostile)
- #64995 / #65452 (closed superseded; Claw noted package-side hardening still missing)
- #110216 introduced the public `ftsTable` interpolation
- #115775 moved reconcile into `ensureMemoryChunkFtsSchema`
