### PR TITLE
perf(memory): skip revisions for archive notification discovery

### DIFF
--- a/extensions/memory-core/src/memory/manager-session-sync-ops.ts
+++ b/extensions/memory-core/src/memory/manager-session-sync-ops.ts
@@ -74,10 +74,12 @@ export abstract class MemoryManagerSessionSyncOps extends MemoryManagerWatchOps 
     }
   }
 
-  protected async listSessionCorpusEntries(): Promise<SessionTranscriptCorpusEntry[]> {
+  protected async listSessionCorpusEntries(options?: {
+    includeContentRevision?: boolean;
+  }): Promise<SessionTranscriptCorpusEntry[]> {
     const readOnly = this.database.readOnly;
     const entries = await listSessionTranscriptCorpusEntriesForAgent(this.agentId, {
-      includeContentRevision: !readOnly,
+      includeContentRevision: !readOnly && options?.includeContentRevision !== false,
       readOnly,
     });
     const archivedSessions = new Map(
@@ -164,7 +166,7 @@ export abstract class MemoryManagerSessionSyncOps extends MemoryManagerWatchOps 
 
   private async scheduleCorpusSessionFileDirty(sessionFile: string): Promise<void> {
     const resolvedSessionFile = path.resolve(sessionFile);
-    const corpusEntries = await this.listSessionCorpusEntries();
+    const corpusEntries = await this.listSessionCorpusEntries({ includeContentRevision: false });
     if (
       corpusEntries.some(
         (entry) =>

--- a/extensions/memory-core/src/memory/manager-sync-ops.startup-catchup.test-support.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.startup-catchup.test-support.ts
@@ -360,8 +360,8 @@ export class SessionStartupCatchupHarness extends MemoryManagerSyncOps {
     return 1;
   }
 
-  protected override listSessionCorpusEntries() {
-    const work = super.listSessionCorpusEntries().then(async (entries) => {
+  protected override listSessionCorpusEntries(options?: { includeContentRevision?: boolean }) {
+    const work = super.listSessionCorpusEntries(options).then(async (entries) => {
       this.corpusListCalls += 1;
       const callback = this.afterNextCorpusList;
       this.afterNextCorpusList = null;


### PR DESCRIPTION
Archive transcript notifications enumerate the session corpus to decide whether a file should be queued for indexing. That membership check also computed content revisions for every transcript, although it only uses identity, source, and path metadata.

Use the existing metadata-only corpus option for this notification path. Indexing and startup callers keep their revision reads; read-only behavior, archived identity checks, tombstones, and indexability filters stay intact. The existing test harness forwards the option.

Validation:

- At the registered transcript listener, a paired 1,000-session fixture with one archive and three measured notifications reduced sampled allocations from 147,636,424 to 20,114,424 bytes (86.4%). Both variants selected the same archive and returned identical metadata; the owned fixture was removed. This is one bounded entry-point sample, not a whole-Gateway or statistical significance claim.
- All 40 existing tests passed across startup catch-up, session sync state, and sync yield, including real SQLite-delete archive indexing and rejected artifact notifications.
- Canonical formatting and `git diff --check` passed. Fresh canonical P0–P2 autoreview returned `scoped-clean` with no actionable findings.



### Stored-data compatibility

This does not change the persistent data model, vector/embedding metadata, schema, stored values, or migration behavior. The two-file diff only passes an existing discovery option and forwards it through the test harness. The unchanged corpus owner computes identity, archive ownership, and indexability independently of contentRevision. Indexing and startup keep their existing revision reads.

Compatibility proof used the exact same populated fixture for parent and candidate: 1,000 canonical SQLite sessions and an existing archive, with identical returned metadata and archive selection. No migration or reseed occurred between measurements. All 40 existing tests passed, including real SQLite-delete archive indexing. The corpus implementation and schema files are byte-identical across the pair; the corpus owner's SHA256 is 24ae8611a491b3a6b44e3003e9d71f736149557a57fd893ebfbcd5cd651b401b. No migration is needed for this read-only query-option change.


Landing review: ClawSweeper revision2 explicitly confirms this patch has no stored-data change and no actionable findings. Its remaining path-based compatibility checklist contradicts that source conclusion. The same populated-fixture proof above satisfies compatibility; no migration applies.


Exact-head hosted CI34703268957 passed all required checks.
