### PR TITLE
improve: reduce long-history yield test setup time

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt-yield-handoff.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-yield-handoff.test.ts
@@ -3,6 +3,16 @@ import {
   loadTranscriptEventsSync,
   upsertSessionEntryCore,
 } from "../../../config/sessions/session-accessor.js";
+import {
+  resolveSqliteTranscriptScope,
+  toDatabaseOptions,
+} from "../../../config/sessions/session-accessor.sqlite-scope.js";
+import { appendTranscriptEventsInTransaction } from "../../../config/sessions/session-accessor.sqlite-transcript-store.js";
+import { sessionTranscriptIndexNeedsReconcile } from "../../../config/sessions/session-transcript-index.js";
+import {
+  openOpenClawAgentDatabase,
+  runOpenClawAgentWriteTransaction,
+} from "../../../state/openclaw-agent-db.js";
 import { withOpenClawTestState } from "../../../test-utils/openclaw-test-state.js";
 import type { AgentMessage } from "../../runtime/index.js";
 import {
@@ -42,18 +52,35 @@ describe("sessions_yield transcript handoff", () => {
           storePath: state.statePath("sessions.json"),
         };
         await upsertSessionEntryCore(target, { sessionId: target.sessionId, updatedAt: 1 });
-        const seed = SessionManager.open(target, state.workspaceDir);
-        // Large histories rebuild asynchronously after yield cleanup replaces them.
+        const seed = SessionManager.fromEntries(
+          SessionManager.open(target, state.workspaceDir).getPersistedEntries(),
+          state.workspaceDir,
+        );
+        // Seed a large clean projection in one commit; yield still owns the later rewrite.
         for (let index = 0; index < 4_001; index += 1) {
           seed.appendCustomEntry("fixture-history", { index });
         }
+        const scope = resolveSqliteTranscriptScope(target);
+        const history = seed.getPersistedEntries();
+        const databaseOptions = toDatabaseOptions(scope);
+        runOpenClawAgentWriteTransaction((database) => {
+          expect(appendTranscriptEventsInTransaction(database, scope, history)).toBe(4_002);
+        }, databaseOptions);
+        expect(
+          sessionTranscriptIndexNeedsReconcile(
+            openOpenClawAgentDatabase(databaseOptions).db,
+            target.sessionId,
+          ),
+        ).toBe(false);
         const manager = bounded
           ? SessionManager.openBounded(target, {
               cwd: state.workspaceDir,
               maxBytes: 4096,
               maxEvents: 20,
             })
-          : seed;
+          : SessionManager.open(target, state.workspaceDir);
+        expect(manager.getLeafId()).toBe(seed.getLeafId());
+        expect(manager.getAppendParentId()).toBe(seed.getAppendParentId());
         const { session } = await createTestSession({ sessionManager: manager });
         const user: AgentMessage = { role: "user", content: "Continue the task", timestamp: 1 };
         const toolResult: AgentMessage = {


### PR DESCRIPTION
## What Problem This Solves

Resolves slow CI coverage for handing a yielded session to its next attempt. Four long-history cases spent most of their test time creating the history they needed, before exercising the handoff itself.

## Why This Change Was Made

Generate the same 4,001 custom history entries through an in-memory SessionManager, then persist them through the existing batched transcript append owner in one transaction. Reopen the real runtime manager and verify the row count, clean projection and parent/leaf state before running the original yield and immediate-reopen assertions.

This preserves all four scenarios, the history threshold and the 3 MiB retained payloads. Product persistence, schemas and runtime code are unchanged; the only changed file is the test.

## User Impact

Developers get faster handoff regression coverage. End-user behavior is unchanged.

## Evidence

Local Node 24 phase measurements attributed 28.709s of 31.523s in the original four test bodies to history seeding. Batched seeding took 1.008s; complete measured bodies took 5.713s, including the extra real-manager reopen. The later uninstrumented run completed the four cases in 958ms, 673ms, 630ms and 743ms. Peak process RSS was approximately 2.34 GB in both measured runs.

All 41 focused cases passed: the four handoff cases plus retained-data and exact-suffix coverage. Changed-scope guards, core test types, dead-export checks and lint passed. Fresh independent P2 review passed with no actionable findings. Exact-head CI is required before landing.

The original and candidate phase probes preserved behavior and await ordering; temporary instrumentation was removed. Whole-wrapper timings also changed with collection/cache state, so they are not attributed solely to this fixture change. Net test delta is +27 lines; product runtime delta is zero.
