### PR TITLE
improve: resolve sessions faster in large gateways

### DIFF
--- a/src/config/sessions/session-accessor.sqlite-entry.ts
+++ b/src/config/sessions/session-accessor.sqlite-entry.ts
@@ -255,27 +255,20 @@ export function listSessionEntryRows(scope: SessionEntryListScope = {}): Session
  * acceptable degradation (health snapshots) or hides real state (migration detection).
  */
 export function listSessionEntriesReadOnly(
-  scope: SessionEntryListScope & {
-    /** Select exact persisted keys after validating the complete listing snapshot. */
-    sessionKeys?: readonly string[];
-  } = {},
+  scope: SessionEntryListScope = {},
 ): SessionEntrySummary[] {
   const resolved = resolveSqliteScope({ ...scope, sessionKey: "" });
   const result = withOpenClawAgentDatabaseReadOnly(
-    (database) =>
-      listSqliteSessionEntriesFromDatabase(
-        database,
-        resolved,
-        scope,
-        scope.sessionKeys ? new Set(scope.sessionKeys) : undefined,
-      ),
+    (database) => listSqliteSessionEntriesFromDatabase(database, resolved, scope),
     toDatabaseOptions(resolved),
   );
   return result.found ? result.value : [];
 }
 
 /** Counts durable session rows without materializing entry JSON or warming the entry cache. */
-export function countSessionEntryRowsReadOnly(scope: SessionEntryListScope = {}): number {
+export function countSessionEntryRowsReadOnly(
+  scope: Omit<SessionEntryListScope, "sessionKeys"> = {},
+): number {
   const resolved = resolveSqliteScope({ ...scope, sessionKey: "" });
   const result = withOpenClawAgentDatabaseReadOnly((database) => {
     const db = getSessionKysely(database.db);
@@ -323,7 +316,6 @@ function listSqliteSessionEntriesFromDatabase(
   database: Pick<OpenClawAgentDatabase, "agentId" | "db" | "path">,
   resolved: ResolvedSqliteScope,
   scope: SessionEntryListScope,
-  sessionKeys?: ReadonlySet<string>,
 ): SessionEntrySummary[] {
   const projection = scope.projection ?? "full";
   const cache = !isIncognitoOpenClawAgentSqlitePath(database.path, {
@@ -339,7 +331,7 @@ function listSqliteSessionEntriesFromDatabase(
     iterateSessionEntriesForListing(
       snapshot,
       projection === "list" && scope.clone !== false,
-      sessionKeys,
+      scope.sessionKeys ? new Set(scope.sessionKeys) : undefined,
     ),
   );
 }
@@ -390,7 +382,7 @@ export function listSessionEntriesByStatus(
 
 /** Lists transcript-bearing SQLite sessions, including retained rows from session-id rotation. */
 export function listSessionTranscriptInstances(
-  scope: SessionEntryListScope = {},
+  scope: Omit<SessionEntryListScope, "sessionKeys"> = {},
   options: SessionTranscriptInstanceListOptions = {},
 ): SessionTranscriptInstance[] {
   const resolved = resolveSqliteScope({ ...scope, sessionKey: "" });

--- a/src/config/sessions/session-accessor.sqlite-selected-list.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-selected-list.test.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-import { afterEach, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import {
   closeOpenClawAgentDatabasesForTest,
@@ -7,8 +7,9 @@ import {
   runOpenClawAgentWriteTransaction,
 } from "../../state/openclaw-agent-db.js";
 import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
+import { normalizeSessionDeliveryState } from "../../utils/delivery-context.shared.js";
 import { resolveInternalSessionEffectsIdentity } from "./internal-session-key.js";
-import { listSessionEntriesReadOnly } from "./session-accessor.js";
+import { listSessionEntriesCore, listSessionEntriesReadOnly } from "./session-accessor.js";
 import { writeSessionEntry } from "./session-accessor.sqlite-entry-store.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
@@ -18,7 +19,7 @@ afterEach(() => {
   closeOpenClawStateDatabaseForTest();
 });
 
-function fixture() {
+function fixture(list: typeof listSessionEntriesReadOnly) {
   const stateDir = tempDirs.make("selected-session-list-");
   const options = {
     agentId: "main",
@@ -38,47 +39,82 @@ function fixture() {
     writeSessionEntry(db, hidden.sessionKey, { sessionId: hidden.sessionId, updatedAt: 1 });
   }, options);
   const read = (sessionKeys?: readonly string[]) =>
-    listSessionEntriesReadOnly({
+    list({
       agentId: options.agentId,
       env: options.env,
       storePath: options.path,
       projection: "list",
       sessionKeys,
     });
-  return { database, hidden, read };
+  return { database, hidden, options, read };
 }
 
-it.each([
-  { selection: undefined, expected: ["a", "b", "c"] },
-  { selection: ["c", "missing", "a", "c", "hidden"], expected: ["a", "c"] },
-  { selection: [], expected: [] },
-])("returns the ordered selected metadata for $selection", ({ selection, expected }) => {
-  const { hidden, read } = fixture();
-  const rows = read(
-    selection?.map((name) => (name === "hidden" ? hidden.sessionKey : `agent:main:${name}`)),
-  );
-  expect(rows.map(({ sessionKey }) => sessionKey)).toEqual(
-    expected.map((name) => `agent:main:${name}`),
-  );
-  expect(rows.every(({ entry }) => entry.skillsSnapshot === undefined)).toBe(true);
-});
-
-it.each([{ selection: [] }, { selection: ["agent:main:a"] }])(
-  "retains unrelated canonical-key errors when selecting $selection",
-  ({ selection }) => {
-    const { database, read } = fixture();
+describe.each([
+  { mode: "readonly", list: listSessionEntriesReadOnly },
+  { mode: "core", list: listSessionEntriesCore },
+])("selected $mode listing", ({ list }) => {
+  it.each([
+    { selection: undefined, expected: ["a", "b", "c"] },
+    { selection: ["c", "missing", "a", "c", "hidden", "malformed"], expected: ["a", "c"] },
+    { selection: [], expected: [] },
+  ])("returns the ordered selected metadata for $selection", ({ selection, expected }) => {
+    const { database, hidden, options, read } = fixture(list);
+    runOpenClawAgentWriteTransaction((db) => {
+      writeSessionEntry(db, "agent:main:malformed", { sessionId: "malformed", updatedAt: 1 });
+    }, options);
     read();
-    // Raw DML after validation must not disappear behind an unrelated selection.
     database.db
-      .prepare(
-        "INSERT INTO session_nodes(session_key, current_session_id, entry_json, updated_at) VALUES(?, ?, ?, ?)",
-      )
-      .run(
-        "AGENT:MAIN:UNRELATED",
-        "unrelated",
-        JSON.stringify({ sessionId: "unrelated", updatedAt: 1 }),
-        1,
-      );
-    expect(() => read(selection)).toThrow("non-canonical persisted row");
-  },
-);
+      .prepare("UPDATE session_nodes SET entry_json = ? WHERE session_key = ?")
+      .run("{", "agent:main:malformed");
+    const rows = read(
+      selection?.map((name) => (name === "hidden" ? hidden.sessionKey : `agent:main:${name}`)),
+    );
+    expect(rows.map(({ sessionKey }) => sessionKey)).toEqual(
+      expected.map((name) => `agent:main:${name}`),
+    );
+    expect(rows.every(({ entry }) => entry.skillsSnapshot === undefined)).toBe(true);
+  });
+
+  it.each([{ selection: [] }, { selection: ["agent:main:a"] }])(
+    "retains unrelated canonical-key errors when selecting $selection",
+    ({ selection }) => {
+      const { database, read } = fixture(list);
+      read();
+      // Raw DML after validation must not disappear behind an unrelated selection.
+      database.db
+        .prepare(
+          "INSERT INTO session_nodes(session_key, current_session_id, entry_json, updated_at) VALUES(?, ?, ?, ?)",
+        )
+        .run(
+          "AGENT:MAIN:UNRELATED",
+          "unrelated",
+          JSON.stringify({ sessionId: "unrelated", updatedAt: 1 }),
+          1,
+        );
+      expect(() => read(selection)).toThrow("non-canonical persisted row");
+    },
+  );
+
+  it("validates unrelated warm delivery aliases before selecting listing keys", () => {
+    const { database, options, read } = fixture(list);
+    const canonicalKey = "agent:main:matrix:channel:!MixedCase:example.org";
+    const legacyKey = canonicalKey.toLowerCase();
+    runOpenClawAgentWriteTransaction((db) => {
+      writeSessionEntry(db, legacyKey, { sessionId: legacyKey, updatedAt: 1 });
+    }, options);
+    read();
+    const entry = {
+      sessionId: legacyKey,
+      updatedAt: 1,
+      delivery: normalizeSessionDeliveryState({
+        context: { channel: "matrix", to: "!MixedCase:example.org" },
+      }),
+    };
+    database.db
+      .prepare("UPDATE session_nodes SET entry_json = ? WHERE session_key = ?")
+      .run(JSON.stringify(entry), legacyKey);
+    expect(() => read(["agent:main:a"])).toThrow(
+      `non-canonical persisted row resolves to session key ${canonicalKey}`,
+    );
+  });
+});

--- a/src/config/sessions/session-accessor.types.ts
+++ b/src/config/sessions/session-accessor.types.ts
@@ -75,7 +75,10 @@ export type SessionEntryReadScope = SessionAccessScope & {
   projection?: "full" | "list";
 };
 
-export type SessionEntryListScope = Partial<Omit<SessionEntryReadScope, "sessionKey">>;
+export type SessionEntryListScope = Partial<Omit<SessionEntryReadScope, "sessionKey">> & {
+  /** Select exact persisted keys after validating the complete listing snapshot. */
+  sessionKeys?: readonly string[];
+};
 
 export type ResolvedSessionEntryAccessTarget = {
   /** Agent owner inferred from the canonical session key. */

--- a/src/gateway/session-utils-store-lookup.test.ts
+++ b/src/gateway/session-utils-store-lookup.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync } from "node:fs";
+import { existsSync, mkdirSync } from "node:fs";
 import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import { resetConfigRuntimeState, setRuntimeConfigSnapshot } from "../config/config.js";
@@ -7,6 +7,7 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
   closeOpenClawAgentDatabasesForTest,
   openOpenClawAgentDatabase,
+  resolveOpenClawAgentSqlitePath,
 } from "../state/openclaw-agent-db.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import { withStateDirEnv } from "../test-helpers/state-dir-env.js";
@@ -35,8 +36,10 @@ import type {
 import {
   createGatewaySessionEntryReader,
   prepareGatewaySessionStoreTargetsReadOnly,
+  resolveGatewaySessionStoreTarget,
   resolveGatewaySessionStoreTargetWithStore,
   resolveGatewaySessionStoreTargetsReadOnly,
+  type GatewaySessionStoreCache,
 } from "./session-utils-store-lookup.js";
 import { loadGatewaySessionEntryReadOnly } from "./session-utils-store.js";
 import {
@@ -82,6 +85,70 @@ async function withGlobalSessions(mainKey: string, run: (cfg: OpenClawConfig) =>
 }
 
 describe("global session lookup ownership", () => {
+  it("retains alias rejection after a canonical row becomes malformed in a warm store", async () => {
+    await withGlobalSessions("main", async (cfg) => {
+      const alias = "agent:main:main";
+      await replaceSessionEntry(
+        { agentId: "main", sessionKey: alias },
+        { sessionId: "retained-alias", updatedAt: 1 },
+      );
+      resolveGatewaySessionStoreTargetWithStore({ cfg, key: "agent:main:global" });
+      openOpenClawAgentDatabase({ agentId: "main" })
+        .db.prepare("UPDATE session_nodes SET entry_json = ? WHERE session_key = ?")
+        .run("{", "global");
+
+      expect(() => resolveGatewaySessionStoreTarget({ cfg, key: alias })).toThrow(
+        "non-canonical persisted row resolves to session key global",
+      );
+    });
+  });
+
+  it("keeps different candidate listings separate within the same store cache", async () => {
+    await withGlobalSessions("main", async (cfg) => {
+      const storeCache: GatewaySessionStoreCache = new Map();
+      for (const key of ["global", "agent:main:global", "global"]) {
+        const target = resolveGatewaySessionStoreTargetWithStore({
+          cfg,
+          key,
+          agentId: "main",
+          projection: "list",
+          listCandidatesOnly: true,
+          storeCache,
+        });
+        expect(Object.keys(target.store)).toEqual([key]);
+        expect(target.store[key]?.sessionId).toBe(`main-${key}`);
+      }
+    });
+  });
+
+  it.each([
+    { agentId: "main", clone: undefined, createsDatabase: true },
+    { agentId: "main", clone: false, createsDatabase: false },
+    { agentId: "retired", clone: undefined, createsDatabase: false },
+  ])("preserves scalar database admission for $agentId (clone: $clone)", async (scenario) => {
+    await withStateDirEnv("gateway-scalar-store-admission-", async ({ stateDir }) => {
+      const cfg: OpenClawConfig = {
+        agents: { ownership: "explicit", entries: { main: {} } },
+        session: { store: path.join(stateDir, "agents", "{agentId}", "sessions", "sessions.json") },
+      };
+      const key = `agent:${scenario.agentId}:dashboard:new-session`;
+      const target = resolveGatewaySessionStoreTarget({
+        cfg,
+        key,
+        clone: scenario.clone,
+      });
+      expect(target).toEqual({
+        agentId: scenario.agentId,
+        canonicalKey: key,
+        storeKeys: [key],
+        storePath: path.join(stateDir, "agents", scenario.agentId, "sessions", "sessions.json"),
+      });
+      expect(existsSync(resolveOpenClawAgentSqlitePath({ agentId: scenario.agentId }))).toBe(
+        scenario.createsDatabase,
+      );
+    });
+  });
+
   it("keeps a child-relative parent distinct from qualified parent owners", async () => {
     await withGlobalSessions("main", async (cfg) => {
       await replaceSessionEntry(
@@ -245,7 +312,7 @@ describe("global session lookup ownership", () => {
     },
   );
 
-  it.each(["single", "batch", "read-only"] as const)(
+  it.each(["single", "target", "batch", "read-only"] as const)(
     "rejects contradictory key and fixed-store owners through %s reads",
     async (mode) => {
       await withGlobalSessions("main", async (cfg) => {
@@ -258,7 +325,9 @@ describe("global session lookup ownership", () => {
               })
             : mode === "single"
               ? resolveGatewaySessionStoreTargetWithStore({ cfg: config, key, agentId })
-              : loadGatewaySessionEntryReadOnly(key, { agentId });
+              : mode === "target"
+                ? resolveGatewaySessionStoreTarget({ cfg: config, key, agentId })
+                : loadGatewaySessionEntryReadOnly(key, { agentId });
         };
         for (const key of ["agent:main:main", "agent:main:global"]) {
           expect.soft(() => read(cfg, key, "research")).toThrow('belongs to "main"');

--- a/src/gateway/session-utils-store-lookup.ts
+++ b/src/gateway/session-utils-store-lookup.ts
@@ -147,6 +147,7 @@ type GatewaySessionStoreLookupParams = {
   projection?: SessionEntryListScope["projection"];
   readOnly?: boolean;
   exactRead?: boolean;
+  listCandidatesOnly?: boolean;
   deferCanonicalValidation?: boolean;
   includeStoreChildEntries?: boolean;
   store?: Record<string, SessionEntry>;
@@ -195,6 +196,7 @@ function prepareGatewaySessionStoreLookup(
     options: {
       readOnly: configured ? params.readOnly : true,
       ...(params.exactRead ? { exactKeys: scanTargets } : {}),
+      ...(params.listCandidatesOnly ? { listKeys: scanTargets } : {}),
       ...(params.projection ? { projection: params.projection } : {}),
       ...(params.storeCache ? { cache: params.storeCache } : {}),
     },
@@ -289,6 +291,7 @@ function prepareExplicitDeletedLegacyMainStoreTarget(
       options: {
         readOnly: true,
         ...(params.exactRead ? { exactKeys: lookupSeeds } : {}),
+        ...(params.listCandidatesOnly ? { listKeys: lookupSeeds } : {}),
         ...(params.projection ? { projection: params.projection } : {}),
         ...(params.storeCache ? { cache: params.storeCache } : {}),
       },
@@ -377,6 +380,7 @@ function prepareGatewaySessionStoreTarget(
         // Arbitrary stale keys must not materialize process-lifetime incognito state.
         readOnly: true,
         ...(params.exactRead ? { exactKeys: [canonicalKey] } : {}),
+        ...(params.listCandidatesOnly ? { listKeys: [canonicalKey] } : {}),
         ...(params.projection ? { projection: params.projection } : {}),
         ...(params.storeCache ? { cache: params.storeCache } : {}),
       },
@@ -614,7 +618,7 @@ export function resolveGatewaySessionStoreTarget(params: {
   clone?: boolean;
   store?: Record<string, SessionEntry>;
 }): GatewaySessionStoreTarget {
-  // Only keys and store metadata escape; omit large prompt snapshots without changing read mode.
+  // Keep listing validation and read mode while avoiding unrelated entry clones.
   const {
     store: _store,
     readSource: _readSource,
@@ -622,6 +626,7 @@ export function resolveGatewaySessionStoreTarget(params: {
   } = resolveGatewaySessionStoreTargetWithStore({
     ...params,
     projection: "list",
+    listCandidatesOnly: true,
   });
   return target;
 }

--- a/src/gateway/session-utils-store-read.ts
+++ b/src/gateway/session-utils-store-read.ts
@@ -87,13 +87,14 @@ function loadGatewaySessionLookupStore(
     readOnly?: boolean;
     cache?: GatewaySessionStoreCache;
     exactKeys?: readonly string[];
+    listKeys?: readonly string[];
     projection?: SessionEntryListScope["projection"];
     readSource?: SessionEntryReadSource;
   } = {},
 ): GatewaySessionStoreView {
   const cache = options.cache;
   const cacheKey = cache
-    ? `${storePath}\u0000${agentId ?? ""}\u0000${clone === false ? "0" : "1"}\u0000${options.readOnly}\u0000${options.projection ?? "full"}\u0000${options.exactKeys?.join("\u0001") ?? ""}`
+    ? `${storePath}\u0000${agentId ?? ""}\u0000${clone === false ? "0" : "1"}\u0000${options.readOnly}\u0000${options.projection ?? "full"}\u0000${options.exactKeys?.join("\u0001") ?? ""}\u0000${options.listKeys ? JSON.stringify(options.listKeys) : ""}`
     : "";
   if (cache) {
     const cached = cache.get(cacheKey);
@@ -112,6 +113,7 @@ function loadGatewaySessionLookupStoreUncached(
   agentId?: string,
   options: {
     exactKeys?: readonly string[];
+    listKeys?: readonly string[];
     readOnly?: boolean;
     projection?: SessionEntryListScope["projection"];
     readSource?: SessionEntryReadSource;
@@ -150,6 +152,7 @@ function loadGatewaySessionLookupStoreUncached(
           ...(agentId ? { agentId } : {}),
           ...(clone === false ? { clone: false } : {}),
           ...(options.projection ? { projection: options.projection } : {}),
+          ...(options.listKeys ? { sessionKeys: options.listKeys } : {}),
           storePath,
         }).map(({ sessionKey, entry }) => [sessionKey, entry]),
       ),


### PR DESCRIPTION
Related: #145579, #146020

## What Problem This Solves

Resolving one session copies unrelated session entries as the store grows. Creation, recovery, reset, and compaction need only the selected session's storage address.

## Why This Change Was Made

Extend the existing selected-key listing owner to writable/core reads and pass scalar Gateway lookups' existing alias candidates through it. Complete snapshot validation still precedes selection and cloning. Request-local caches distinguish selected keys; alias errors, malformed-row handling, and database admission remain unchanged.

## User Impact

Large session stores spend less time resolving individual sessions. No configuration or database migration is required. The scoped benefit is session creation and lookup work; maximum sustained pauses remain an explicit tradeoff below.

## Evidence

- Seven alternating component pairs with 1,000 sessions and 100 mixed existing/missing lookups reduced median time from 382.99 to 106.37 ms (72.2%). Every pair improved and all target metadata matched. This is a component result, not an end-to-end latency claim.
- The regression fails on baseline for the two newly supported writable-selection cases. A warm-store corruption probe preserves migration rejection for an invalid canonical row alongside a valid alias.
- All 55 lookup, selected-list, and catalog tests passed on the frozen benchmark base. After rebasing over #146068's iterator change, all 54 lookup, selected-list, creation-snapshot, and atomic-initialization integration tests passed. The iterator is eagerly consumed; performance and provider evidence remains bound to the earlier frozen source.
- Type-aware lint, core typechecking, formatting, whitespace checks, and independent code review passed. The mechanical iterator integration received separate source review.
- Hosted CI initially failed four plugin model-override cases before session lookup. Both unchanged base and PR head passed the identical 34-file, 431-test shared-worker shard in the original hosted order, plus isolated override suites. The hosted failure remains unexplained. One informed unchanged-head diagnostic rerun passed, and required exact-head CI is green in run 34703522766 at `3c8580b4b7d`. No assertions or policy were changed.
- Maintainer decision: land scalar lookup alone; defer batching in #146148. Seven component pairs and the isolated Gateway runs support this targeted creation improvement. They do not establish a general sustained-latency improvement or absence of regression.
- Isolated workload: 1,000 sessions, 96 tool turns, 192 Responses requests, 128 fixed probe rounds, 1,536 history reads, and 100 updates per case. Order was baseline/scalar/batch, then batch/scalar/baseline. All six functional and source checks passed. Normal indexing remained enabled; its request counts differed.

| Metric | Baseline, two cases | Scalar only, two cases |
| --- | --- | --- |
| Session setup | 8.873 / 9.563 s | 7.488 / 7.339 s (15.6% / 23.3% less) |
| Session-list p95 | 422.4 / 472.7 ms | 417.5 / 458.5 ms |
| Event-loop p95 | 424.9 / 390.1 ms | 352.8 / 356.0 ms |
| Event-loop maximum | 540.0 / 429.9 ms | 589.3 / 490.7 ms |

- Maximum pauses increased by 49.3 and 60.8 ms. History p95 and active duration were mixed. Two samples do not establish an extreme-tail distribution; baseline maxima themselves differed by 110.1 ms. The later baseline ran after interruption recovery, weakening paired attribution. This uncertainty is retained and accepted for the smaller, consistently observed creation benefit.
- The local controller disappeared after scalar case 2 completed its measurements and Gateway shutdown. Its complete measurement was retained, functional/source/owned-cleanup checks were recovered, and only the unstarted baseline case ran afterward. The original controller exit is unavailable; no successful original exit was invented. All owned Gateway processes and fixtures were confirmed gone.
- Earlier combined-source experiments repeatedly increased sustained peak stalls despite lower component CPU. Those results remain valid contrary evidence; accepting this scalar-only change does not validate the combination. The final archive contains 104 hash-verified evidence files, including profiles, exact work counts, source manifests, and recovery records.
- Actual OpenAI proof on frozen main `921594235996` plus both changes completed eight turns with matching streamed text, one final event each, RPC history, and independent post-shutdown SQLite reads. The workload included 1,000 sessions, 300 history reads, and 100 updates. All Gateway RPC checks and cleanup passed. This is combined-tree functional evidence, not exact-PR-head or paired latency proof. The observer recorded eight Responses and two embedding request creations plus five unclassified request-error notifications; its aggregate data cannot establish their timing or cause.
- Load fixtures disable dreaming and retain normal memory indexing. No operator Gateway or user state was modified.
