### PR TITLE
improve: batch exact session metadata reads

### DIFF
--- a/src/config/sessions/session-accessor.readonly.test.ts
+++ b/src/config/sessions/session-accessor.readonly.test.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { DatabaseSync, type StatementSync } from "node:sqlite";
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { trackSqliteStatementExecutions } from "../../../test/helpers/sqlite-statement-execution-counter.js";
 import {
   cleanupTempDirs,
   makeTempDir,
@@ -62,6 +63,73 @@ afterEach(() => {
 });
 
 describe("session accessor readonly listing", () => {
+  it.each([5, 40])(
+    "batches %i exact rows and participants without changing requested keys",
+    (count) => {
+      const env = { OPENCLAW_STATE_DIR: autoTempDirs.make("openclaw-exact-read-batch-") };
+      const scope = { agentId: "main", env, projection: "list" as const };
+      const keys = Array.from({ length: count }, (_, index) => `agent:main:row-${index}`);
+      keys[0] = "agent:main:row-\uFFFD";
+      for (const [index, sessionKey] of keys.entries()) {
+        replaceSessionEntrySync(
+          { ...scope, sessionKey },
+          { sessionId: `session-${index}`, updatedAt: 1 },
+        );
+        recordSessionParticipant(
+          { ...scope, sessionKey },
+          { identity: { type: "profile", id: `person-${index}` }, promptedAt: 1 },
+        );
+      }
+      // Both spellings bind to the same SQLite key, but each result retains its request spelling.
+      const requested = [
+        "agent:main:row-\uD800",
+        ...keys.toReversed(),
+        keys[0]!,
+        "agent:main:missing",
+      ];
+      expect(
+        loadExactSessionEntryReadOnly({ ...scope, sessionKey: keys[0]! })?.entry.sessionId,
+      ).toBe("session-0");
+      const database = openOpenClawAgentDatabase(scope);
+      const statements = trackSqliteStatementExecutions(
+        database.db,
+        ["entries", "participants"],
+        (sql) =>
+          sql.includes('from "session_nodes"')
+            ? "entries"
+            : sql.includes('from "session_participants"')
+              ? "participants"
+              : null,
+      );
+      try {
+        const results = loadExactSessionEntryCandidatesReadOnlyBatch(
+          requested.map((sessionKey) => ({ ...scope, sessionKeys: [sessionKey] })),
+        );
+        expect(results).toMatchObject(
+          requested.map((sessionKey) => ({
+            ok: true,
+            value: sessionKey.endsWith(":missing")
+              ? []
+              : [{ sessionKey, entry: { participantCount: 1 } }],
+          })),
+        );
+        expect(results[0]).toMatchObject({
+          value: [
+            {
+              entry: {
+                sessionId: "session-0",
+                participants: [{ identity: { type: "profile", id: "person-0" } }],
+              },
+            },
+          ],
+        });
+        expect(statements.counts).toEqual({ entries: 1, participants: 1 });
+      } finally {
+        statements.restore();
+      }
+    },
+  );
+
   it("resolves a registered exact store once per batch and observes its next owner", () => {
     const env = { OPENCLAW_STATE_DIR: autoTempDirs.make("openclaw-exact-read-target-") };
     const storePath = path.join(env.OPENCLAW_STATE_DIR, "registered.sqlite");

--- a/src/config/sessions/session-accessor.sqlite-entry-read.ts
+++ b/src/config/sessions/session-accessor.sqlite-entry-read.ts
@@ -1,15 +1,20 @@
 import type { DatabaseSync } from "node:sqlite";
+import { toUSVString } from "node:util";
+import { err, ok, type Result } from "@openclaw/normalization-core/result";
 import type { Selectable } from "kysely";
 import {
   executeSqliteQuerySync,
   executeSqliteQueryTakeFirstSync,
+  iterateSqliteQuerySync,
   prepareSqliteQuerySync,
+  sqliteStringSet,
 } from "../../infra/kysely-sync.js";
 import type { DB as OpenClawAgentKyselyDatabase } from "../../state/openclaw-agent-db.generated.js";
 import type { OpenClawAgentDatabase } from "../../state/openclaw-agent-db.js";
 import type { SessionEntrySummary } from "./session-accessor.sqlite-contract.js";
 import type { SqliteSessionOwnerRow } from "./session-accessor.sqlite-owner-projection.js";
 import {
+  createSqliteSessionParticipantProjector,
   projectSqliteSessionParticipants,
   projectSqliteSessionParticipantsBatch,
 } from "./session-accessor.sqlite-participant-projection.js";
@@ -229,6 +234,50 @@ export function readExactSessionEntryRow(
   }
   const entry = parseReadableSqliteSessionEntryRow(database, row, projection);
   return entry ? { entry, row } : undefined;
+}
+
+/** Reads exact metadata together while preserving per-row validation errors. */
+export function readExactSessionEntryListBatch(
+  database: OpenClawAgentDatabaseReader,
+  sessionKeys: readonly string[],
+): Map<string, Result<SessionEntry | undefined, unknown>> {
+  const entries = new Map<string, Result<SessionEntry | undefined, unknown>>();
+  const sessionKey = sessionKeys.length === 1 ? sessionKeys[0] : undefined;
+  if (sessionKey !== undefined) {
+    // Keep the prepared exact read when this group has no work to batch.
+    const boundKey = toUSVString(sessionKey);
+    try {
+      entries.set(boundKey, ok(readExactSessionEntryRow(database, sessionKey, "list")?.entry));
+    } catch (error) {
+      entries.set(boundKey, err(error));
+    }
+    return entries;
+  }
+  const projectParticipants = createSqliteSessionParticipantProjector(database.db, sessionKeys);
+  for (const row of iterateSqliteQuerySync(
+    database.db,
+    selectSessionEntryRows(database, "list")
+      .select(["current_session_id", "updated_at"])
+      .where("session_key", "in", sqliteStringSet(sessionKeys)),
+  )) {
+    try {
+      const parsed = parseReadableSessionEntryData(database, row, "list");
+      entries.set(
+        row.session_key,
+        ok(
+          parsed
+            ? validateDeliveryCanonicalSessionEntry(
+                row.session_key,
+                projectParticipants(row.session_key, parsed),
+              )
+            : undefined,
+        ),
+      );
+    } catch (error) {
+      entries.set(row.session_key, err(error));
+    }
+  }
+  return entries;
 }
 
 export function readExactSessionEntryJson(

--- a/src/config/sessions/session-accessor.sqlite-exact-read.ts
+++ b/src/config/sessions/session-accessor.sqlite-exact-read.ts
@@ -1,3 +1,4 @@
+import { toUSVString } from "node:util";
 import { err, ok, type Result } from "@openclaw/normalization-core/result";
 import { withOpenClawAgentDatabaseReadOnly } from "../../state/openclaw-agent-db-readonly.js";
 import {
@@ -7,6 +8,7 @@ import {
   type OpenClawAgentDatabaseOptions,
 } from "../../state/openclaw-agent-db.js";
 import type { ExactSessionEntry } from "./session-accessor.sqlite-contract.js";
+import { readExactSessionEntryListBatch } from "./session-accessor.sqlite-entry-read.js";
 import { readExactSessionEntryRowValidated } from "./session-accessor.sqlite-entry-store.js";
 import {
   resolveSqliteScope,
@@ -123,6 +125,12 @@ export function loadExactSessionEntryCandidatesReadOnlyBatch(
         // suppress healthy logical targets after a warm handle was validated.
         assertCanonicalSqliteSessionKeysCurrent(database);
         const source = { agentId: database.agentId, path: database.path };
+        const rows =
+          group.projection === "list"
+            ? readExactSessionEntryListBatch(database, [
+                ...new Set(group.requests.flatMap((request) => request.sessionKeys)),
+              ])
+            : undefined;
         const entries = new Map<string, Result<ExactSessionEntry | undefined, unknown>>();
         const readEntry = (sessionKey: string): Result<ExactSessionEntry | undefined, unknown> => {
           const cached = entries.get(sessionKey);
@@ -131,12 +139,16 @@ export function loadExactSessionEntryCandidatesReadOnlyBatch(
           }
           let result: Result<ExactSessionEntry | undefined, unknown>;
           try {
-            const entry = readExactSessionEntryRowValidated(
-              database,
-              sessionKey,
-              group.projection,
-            )?.entry;
-            result = ok(entry ? { sessionKey, entry } : undefined);
+            // SQLite binds USV strings; retain the request spelling in the returned match.
+            const row = rows?.get(toUSVString(sessionKey));
+            if (row && !row.ok) {
+              result = row;
+            } else {
+              const entry = rows
+                ? row?.value
+                : readExactSessionEntryRowValidated(database, sessionKey, group.projection)?.entry;
+              result = ok(entry ? { sessionKey, entry } : undefined);
+            }
           } catch (error) {
             result = err(error);
           }

--- a/src/config/sessions/session-accessor.sqlite-participant-projection.ts
+++ b/src/config/sessions/session-accessor.sqlite-participant-projection.ts
@@ -72,22 +72,17 @@ function readParticipantRows(database: DatabaseSync, sessionKeys?: readonly stri
   return executeSqliteQuerySync(database, query).rows;
 }
 
-function participantRecordsBySessionKey(
+function participantRowsBySessionKey(
   database: DatabaseSync,
   sessionKeys?: readonly string[],
-): Map<string, SessionParticipantRecord[]> {
-  const records = new Map<string, SessionParticipantRecord[]>();
+): Map<string, SessionParticipantRow[]> {
+  const records = new Map<string, SessionParticipantRow[]>();
   if (!tableExists(database, SESSION_PARTICIPANTS_TABLE)) {
     return records;
   }
   for (const row of readParticipantRows(database, sessionKeys)) {
     const participants = records.get(row.session_key) ?? [];
-    participants.push({
-      identity: readParticipantIdentity(row.identity_namespace, row.actor_id),
-      contributionCount: row.contribution_count,
-      firstPromptedAt: row.first_prompted_at,
-      lastPromptedAt: row.last_prompted_at,
-    });
+    participants.push(row);
     records.set(row.session_key, participants);
   }
   return records;
@@ -95,14 +90,16 @@ function participantRecordsBySessionKey(
 
 function withProjectedParticipants(
   entry: SessionEntry,
-  records: readonly SessionParticipantRecord[],
+  records: readonly SessionParticipantRow[],
 ): SessionEntry {
   if (records.length === 0) {
     return entry;
   }
   return {
     ...entry,
-    participants: records.map(({ identity }) => ({ identity })),
+    participants: records.map((row) => ({
+      identity: readParticipantIdentity(row.identity_namespace, row.actor_id),
+    })),
     participantCount: records.length,
   };
 }
@@ -114,7 +111,7 @@ export function projectSqliteSessionParticipants(
 ): SessionEntry {
   return withProjectedParticipants(
     entry,
-    participantRecordsBySessionKey(database, [sessionKey]).get(sessionKey) ?? [],
+    participantRowsBySessionKey(database, [sessionKey]).get(sessionKey) ?? [],
   );
 }
 
@@ -122,13 +119,21 @@ export function projectSqliteSessionParticipantsBatch(
   database: DatabaseSync,
   entries: ReadonlyMap<string, SessionEntry>,
 ): Map<string, SessionEntry> {
-  const records = participantRecordsBySessionKey(database, [...entries.keys()]);
+  const projectParticipants = createSqliteSessionParticipantProjector(database, [
+    ...entries.keys(),
+  ]);
   return new Map(
-    [...entries].map(([sessionKey, entry]) => [
-      sessionKey,
-      withProjectedParticipants(entry, records.get(sessionKey) ?? []),
-    ]),
+    [...entries].map(([sessionKey, entry]) => [sessionKey, projectParticipants(sessionKey, entry)]),
   );
+}
+
+/** Decode each session separately so a damaged identity does not reject unrelated exact reads. */
+export function createSqliteSessionParticipantProjector(
+  database: DatabaseSync,
+  sessionKeys: readonly string[],
+): (sessionKey: string, entry: SessionEntry) => SessionEntry {
+  const records = participantRowsBySessionKey(database, sessionKeys);
+  return (sessionKey, entry) => withProjectedParticipants(entry, records.get(sessionKey) ?? []);
 }
 
 export function listSessionParticipantsReadOnly(scope: {
@@ -140,9 +145,21 @@ export function listSessionParticipantsReadOnly(scope: {
   const resolved = resolveSqliteReadScope(scope);
   const result = withOpenClawAgentDatabaseReadOnly(
     (database) =>
-      participantRecordsBySessionKey(
-        database.db,
-        scope.sessionKey ? [scope.sessionKey] : undefined,
+      new Map(
+        [
+          ...participantRowsBySessionKey(
+            database.db,
+            scope.sessionKey ? [scope.sessionKey] : undefined,
+          ),
+        ].map(([sessionKey, rows]) => [
+          sessionKey,
+          rows.map((row) => ({
+            identity: readParticipantIdentity(row.identity_namespace, row.actor_id),
+            contributionCount: row.contribution_count,
+            firstPromptedAt: row.first_prompted_at,
+            lastPromptedAt: row.last_prompted_at,
+          })),
+        ]),
       ),
     toDatabaseOptions(resolved),
   );


### PR DESCRIPTION
Related: #145579, #145997, #146036

## What Problem This Solves

Reading a group of session metadata performs one entry query and one participant query per session: 200 queries for a 100-session group on the same database handle.

## Why This Change Was Made

Batch list-projection entries and participant rows through the existing exact-read owner, then reconstruct each request's order, spelling, duplicates, missing values, source callbacks, and per-row errors. Decode participant identities per session so a damaged identity does not suppress healthy requests. Singleton and full-entry reads retain their prepared per-row paths.

## User Impact

Grouped metadata reads perform fewer database queries. No configuration, schema, retention, or database-lifetime change is required. This PR is deferred from the current campaign; it is not accepted for landing alongside #146145.

## Evidence

- The regression fails on baseline and verifies that a 100-session list group executes one entry query plus one participant query, down from 200, using the existing statement-execution counter.
- All 29 final read-only and participant tests passed, covering malformed rows, damaged identities, order, duplicates, missing keys, and Unicode binding. Earlier unchanged-input coverage includes 18 row-persistence cases and the child-projection regression.
- Type-aware lint, formatting, whitespace checks, and independent code review passed. Component timing varied with host pressure; no isolated timing percentage is claimed.
- Required exact-head hosted CI passed in run 34703465843 at `c1166f750ae1`. OpenGrep initially failed before acquiring a runner, with zero executed steps; one infrastructure retry passed.
- Maintainer decision: defer batching and retain this PR as a draft. The 200-to-2 query reduction is real, but the isolated runs do not demonstrate a convincing Gateway benefit. Do not combine it with the scalar change under the current evidence.
- Six isolated fixed-work cases compared baseline, scalar, and batch in opposite orders. Each used 1,000 sessions, 96 tool turns, 192 Responses requests, 128 probe rounds, 1,536 history reads, and 100 updates. All functional/source/cleanup checks passed; normal indexing request counts differed.
- Batch-only setup was 9.007 / 8.724 s versus baseline 8.873 / 9.563 s. List p95 was 453.0 / 457.6 ms versus 422.4 / 472.7 ms; history p95 was 390.8 / 309.5 ms versus 273.8 / 323.3 ms (42.7% worse in the first comparison). Loop maxima were 455.6 / 491.0 ms versus 540.0 / 429.9 ms. Two samples and the interruption-delayed final baseline limit attribution; these results are not a stable latency distribution.
- Earlier combined-source runs repeatedly had higher maximum sustained stalls despite lower batch/list CPU. The combination is not accepted. Source, profiles, request counts, and recovery evidence are preserved; further work must resolve this concrete performance concern before landing.
- Actual OpenAI proof on frozen main `921594235996` plus both changes completed eight turns with matching streamed text, one final event each, RPC history, and independent post-shutdown SQLite reads. The workload included 1,000 sessions, 300 history reads, and 100 updates. All Gateway RPC checks and cleanup passed. This is combined-tree functional evidence, not exact-PR-head or paired latency proof. The observer recorded eight Responses and two embedding request creations plus five unclassified request-error notifications; its aggregate data cannot establish their timing or cause.
- Load fixtures disable dreaming and retain normal memory indexing. No operator Gateway or user state was modified.
