### PR TITLE
refactor(ui): simplify chat loading send state and tests

### DIFF
--- a/ui/src/pages/chat/chat-composer-actions.test.ts
+++ b/ui/src/pages/chat/chat-composer-actions.test.ts
@@ -3,21 +3,16 @@
 import { render } from "lit";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../../../test/helpers/promise.js";
-import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import { t } from "../../i18n/index.ts";
+import { createTestGatewayClient } from "../../test-helpers/gateway-client.ts";
 import {
   findComposerButton as button,
   findPrimaryButton as primaryButton,
   renderComposerFixture as renderComposer,
   resetComposerFixture,
 } from "./chat-composer.test-support.ts";
-import {
-  renderChatPrimaryActions,
-  type ChatRunControlsProps,
-} from "./components/chat-composer-controls.ts";
 import { getChatComposerState } from "./components/chat-composer-state.ts";
 import { renderChatComposer } from "./components/chat-composer.ts";
-import type { ComposerDictationController } from "./composer-dictation.ts";
 
 afterEach(async () => {
   await resetComposerFixture();
@@ -88,48 +83,48 @@ describe("renderChatComposer controls", () => {
     },
   );
 
-  function renderActiveDictationActions(overrides: { finishActive: ReturnType<typeof vi.fn> }) {
-    const container = document.createElement("div");
-    const cancelActive = vi.fn();
-    const handleClick = vi.fn();
-    const onSend = vi.fn<ChatRunControlsProps["onSend"]>();
-    const dictation = {
-      active: true,
-      connecting: false,
-      finalizing: false,
-      locksComposer: true,
-      finishActive: overrides.finishActive,
-      cancelActive,
-      handleClick,
-    } as unknown as ComposerDictationController;
-    render(
-      renderChatPrimaryActions({
-        canAbort: false,
-        canSend: true,
-        connected: true,
-        draft: "preexisting draft",
-        isBusy: false,
-        sending: false,
-        dictation,
-        onSend,
-      }),
-      container,
-    );
-    return { cancelActive, container, handleClick, onSend };
+  function renderDictatingComposer({
+    submitDisabledReason,
+    finalizing = false,
+  }: { submitDisabledReason?: string; finalizing?: boolean } = {}) {
+    let draft = "Typed beginning";
+    const onSend = vi.fn();
+    const { container, props } = renderComposer({
+      draft,
+      getDraft: () => draft,
+      onDraftChange: (value) => {
+        draft = value;
+      },
+      onSend: () => onSend(draft),
+      onToggleRealtimeTalk: vi.fn(),
+      submitDisabledReason,
+    });
+    const dictation = getChatComposerState(props.paneId).dictation;
+    if (!dictation) {
+      throw new Error("expected the composer dictation controller");
+    }
+    const active = vi.spyOn(dictation, "active", "get").mockReturnValue(true);
+    const locked = vi.spyOn(dictation, "locksComposer", "get").mockReturnValue(true);
+    vi.spyOn(dictation, "finalizing", "get").mockReturnValue(finalizing);
+    const finishActive = vi.spyOn(dictation, "finishActive").mockResolvedValue(true);
+    const handleClick = vi.spyOn(dictation, "handleClick");
+    const update = vi.spyOn(dictation, "update");
+    render(renderChatComposer(props), container);
+    const commit = update.mock.lastCall?.[0].onCommit;
+    if (!commit) {
+      throw new Error("expected the composer transcript callback");
+    }
+    return { container, active, locked, finishActive, handleClick, onSend, commit };
   }
 
   it("stops dictation by keeping its text without sending", () => {
-    const finishActive = vi.fn().mockResolvedValue(true);
-    const { cancelActive, container, handleClick, onSend } = renderActiveDictationActions({
-      finishActive,
-    });
+    const { container, finishActive, handleClick, onSend } = renderDictatingComposer();
     const stop = container.querySelector<HTMLButtonElement>(".chat-send-btn--dictating");
 
     expect(stop?.getAttribute("aria-label")).toBe("Stop and keep text");
     stop?.click();
 
     expect(finishActive).toHaveBeenCalledOnce();
-    expect(cancelActive).not.toHaveBeenCalled();
     expect(handleClick).not.toHaveBeenCalled();
     expect(onSend).not.toHaveBeenCalled();
   });
@@ -137,32 +132,11 @@ describe("renderChatComposer controls", () => {
   it.each([undefined, "Loading chat"])(
     "finishes locked dictation before submitting the complete composer draft with history hold %s",
     async (submitDisabledReason) => {
-      let draft = "Typed beginning";
-      const onSend = vi.fn();
-      const { container, props } = renderComposer({
-        draft,
-        getDraft: () => draft,
-        onDraftChange: (value) => {
-          draft = value;
-        },
-        onSend: () => onSend(draft),
-        onToggleRealtimeTalk: vi.fn(),
+      const { container, active, locked, finishActive, onSend, commit } = renderDictatingComposer({
         submitDisabledReason,
       });
-      const dictation = getChatComposerState(props.paneId).dictation;
-      if (!dictation) {
-        throw new Error("expected the composer dictation controller");
-      }
-      const active = vi.spyOn(dictation, "active", "get").mockReturnValue(true);
-      const locked = vi.spyOn(dictation, "locksComposer", "get").mockReturnValue(true);
-      const update = vi.spyOn(dictation, "update");
-      render(renderChatComposer(props), container);
-      const commit = update.mock.lastCall?.[0].onCommit;
-      if (!commit) {
-        throw new Error("expected the composer transcript callback");
-      }
       const finalTranscript = createDeferred<string>();
-      const finishActive = vi.spyOn(dictation, "finishActive").mockImplementation(async () => {
+      finishActive.mockImplementation(async () => {
         const transcript = await finalTranscript.promise;
         active.mockReturnValue(false);
         locked.mockReturnValue(false);
@@ -170,7 +144,7 @@ describe("renderChatComposer controls", () => {
         return true;
       });
       const textarea = container.querySelector<HTMLTextAreaElement>("textarea")!;
-      textarea.setSelectionRange(draft.length, draft.length);
+      textarea.setSelectionRange(textarea.value.length, textarea.value.length);
       pressComposerEnter(container);
       expect(onSend).not.toHaveBeenCalled();
 
@@ -189,27 +163,7 @@ describe("renderChatComposer controls", () => {
   );
 
   it("keeps Stop and Send visually stable while dictation finalizes", () => {
-    const container = document.createElement("div");
-    const dictation = {
-      active: true,
-      connecting: false,
-      finalizing: true,
-      locksComposer: true,
-      finishActive: vi.fn(),
-    } as unknown as ComposerDictationController;
-    render(
-      renderChatPrimaryActions({
-        canAbort: false,
-        canSend: true,
-        connected: true,
-        draft: "preexisting draft",
-        isBusy: false,
-        sending: false,
-        dictation,
-        onSend: vi.fn(),
-      }),
-      container,
-    );
+    const { container } = renderDictatingComposer({ finalizing: true });
 
     const stop = container.querySelector<HTMLButtonElement>(".chat-send-btn--dictating");
     const send = container.querySelector<HTMLButtonElement>(".chat-send-btn--dictation-commit");
@@ -354,7 +308,7 @@ describe("renderChatComposer controls", () => {
       const onToggleRealtimeTalk = vi.fn();
       const { container } = renderComposer({
         composerHoldToRecord,
-        gatewayClient: { request } as unknown as GatewayBrowserClient,
+        gatewayClient: createTestGatewayClient(request),
         onToggleRealtimeTalk,
         submitDisabledReason: t("chat.thread.loading"),
       });

--- a/ui/src/pages/chat/chat-send-delivery.ts
+++ b/ui/src/pages/chat/chat-send-delivery.ts
@@ -491,7 +491,7 @@ async function sendQueuedChatMessage(
       (err instanceof GatewayRequestError
         ? err.retryable
         : /gateway (?:not connected|closed)|websocket|disconnected/i.test(error));
-    if (!activeLeafChanged && recoverable) {
+    if (recoverable) {
       const failedBeforeTransport =
         err instanceof Error &&
         !(err instanceof GatewayRequestError) &&
@@ -576,10 +576,8 @@ async function sendQueuedChatMessage(
     if (!restoreCommand) {
       setState("failed", error);
     }
-    if (isVisible()) {
-      if (activeLeafChanged) {
-        void Promise.all([loadChatHistory(host), loadChatBranches(host)]);
-      }
+    if (isVisible() && activeLeafChanged) {
+      void Promise.all([loadChatHistory(host), loadChatBranches(host)]);
     }
     surfaceChatDeliveryFailure(host, sessionKey, prepared.agentId, error, {
       inline: storageMode === "durable" && !restoreCommand,

--- a/ui/src/pages/chat/chat-send-queue-state.ts
+++ b/ui/src/pages/chat/chat-send-queue-state.ts
@@ -238,7 +238,7 @@ export function finishChatDeliveryAdmission(
       routeVisible(current.agentId) &&
       (isChatBusy(host) || hasDirectSessionRun(host)))
   ) {
-    const parked = setState(host.connected && host.client ? "waiting-idle" : "waiting-reconnect");
+    const parked = setState(reconnectSafeQueuedSendState(host));
     if (!parked) {
       setChatError(host, OFFLINE_QUEUE_STORAGE_ERROR);
       return "failed";

--- a/ui/src/pages/chat/chat-send-readiness.test.ts
+++ b/ui/src/pages/chat/chat-send-readiness.test.ts
@@ -13,7 +13,16 @@ import {
 } from "./chat-send-actions.ts";
 import { handleSendChat } from "./chat-send-submit.ts";
 import { installOutboxBrowserStorage } from "./outbox-browser.test-support.ts";
-import { applyChatCacheSnapshot } from "./session-message-cache.ts";
+import { applyChatCacheSnapshot, type ChatSessionSnapshot } from "./session-message-cache.ts";
+
+function cachedTranscript(sessionId: string, displayedLeafEntryId: string): ChatSessionSnapshot {
+  return {
+    messages: [],
+    sessionId,
+    displayedLeafEntryId,
+    pagination: { hasMore: false, completeSnapshot: true },
+  };
+}
 
 beforeEach(() => {
   installOutboxBrowserStorage();
@@ -228,12 +237,7 @@ it.each([false, true])(
         "chat.send": { status: "started" },
       },
     });
-    applyChatCacheSnapshot(host, {
-      messages: [],
-      sessionId: "restored-session",
-      displayedLeafEntryId: "restored-leaf",
-      pagination: { hasMore: false, completeSnapshot: true },
-    });
+    applyChatCacheSnapshot(host, cachedTranscript("restored-session", "restored-leaf"));
     const loading = loadChatHistory(host, { startup: true, deferBranches: true });
     const sending = handleSendChat(host);
     try {
@@ -377,12 +381,7 @@ it.each([false, true])(
         "chat.send": { status: "started", messageSeq: 1 },
       },
     });
-    applyChatCacheSnapshot(host, {
-      messages: [],
-      sessionId: "cached-session",
-      displayedLeafEntryId: "cached-leaf",
-      pagination: { hasMore: false, completeSnapshot: true },
-    });
+    applyChatCacheSnapshot(host, cachedTranscript("cached-session", "cached-leaf"));
     const loading = loadChatHistory(host, { startup: true, deferBranches: true });
     const sending = [handleSendChat(host)];
     try {
@@ -458,12 +457,7 @@ it.each(["steer", "interrupt", "queue"] as const)(
         "chat.send": { status: "started", messageSeq: 1 },
       },
     });
-    applyChatCacheSnapshot(host, {
-      messages: [],
-      sessionId: "current-session",
-      displayedLeafEntryId: "cached-leaf",
-      pagination: { hasMore: false, completeSnapshot: true },
-    });
+    applyChatCacheSnapshot(host, cachedTranscript("current-session", "cached-leaf"));
     const loading = loadChatHistory(host, { startup: true, deferBranches: true });
     const sending = handleSendChat(host, undefined, { followUpMode });
     try {

--- a/ui/src/pages/chat/chat-send-submit.ts
+++ b/ui/src/pages/chat/chat-send-submit.ts
@@ -582,7 +582,6 @@ export async function handleSendChat(
       return;
     }
     let pendingSettings = getPendingChatPickerPatch(host, submittedSessionKey);
-    let waitingForSettings = Boolean(pendingSettings);
     const applyRunPolicy = hasDirectSessionRun(host) || isInitialChatHistoryUnavailable(host);
     // Only an explicit browser override replaces inherited Gateway policy.
     const followUpMode =
@@ -601,7 +600,7 @@ export async function handleSendChat(
       deliveredAttachments.length ? deliveredAttachments : undefined,
       Boolean(intent) || isChatResetCommand(message),
       submittedAtMs,
-      waitingForSettings ? "waiting-model" : reconnectSafeQueuedSendState(host),
+      pendingSettings ? "waiting-model" : reconnectSafeQueuedSendState(host),
       replyToId,
       resumedEdit?.orderKey,
       activeRunQueueMode,
@@ -640,8 +639,7 @@ export async function handleSendChat(
       // Retain a picker captured before storage, including its rejected result;
       // delivery follows the latest picker tail before issuing the request.
       pendingSettings ??= getPendingChatPickerPatch(host, submittedSessionKey);
-      waitingForSettings = Boolean(pendingSettings);
-      queued.sendState = waitingForSettings ? "waiting-model" : reconnectSafeQueuedSendState(host);
+      queued.sendState = pendingSettings ? "waiting-model" : reconnectSafeQueuedSendState(host);
     }
     const cleared =
       messageOverride == null
@@ -679,7 +677,7 @@ export async function handleSendChat(
       // A still-open edit means its stored source outlived the rejected write;
       // sending the replacement from memory would strand the original as a duplicate.
       !activeQueuedMessageEdit(host) &&
-      !waitingForSettings &&
+      !pendingSettings &&
       canSendVolatileQueueItem(host, queued, submittedSessionKey);
     if (!admittedDurably && !canSendFromMemory) {
       retireOutboxPayload(queued);


### PR DESCRIPTION
Related: #145531

## What Problem This Solves

Maintainer-requested cleanup of the Control UI chat-loading fix. The send path repeated derived state and predicates, while dictation tests used partial controller objects forced into full types, including an assertion against a method the real controller does not expose.

## Why This Change Was Made

Use the pending settings request and existing reconnect-state helper directly, simplify equivalent recovery conditions, and share typed cached-transcript and real composer/controller fixtures. Removes 56 net lines while preserving the history, connection, branch, and queue ownership checks.

## User Impact

No user-visible behavior change. Messages still enter the durable outbox while history loads, and all existing test cases remain covered.

## Evidence

- 549 focused send, settings, readiness, composer, and mention tests passed; the 94 tests in the changed test files passed again after the final fixture corrections.
- Core test and UI typechecks, formatting, repository guards, i18n verification, dead-export scans, targeted lint, and style checks passed.
- Independent Codex review found no actionable P0–P2 issues in the final diff.
- No live Gateway changes were needed for this behavior-preserving cleanup.
