### PR TITLE
perf(memory): defer chunk writer setup for empty replacements

### DIFF
--- a/extensions/memory-core/src/memory/manager-source-index-kernel.ts
+++ b/extensions/memory-core/src/memory/manager-source-index-kernel.ts
@@ -79,18 +79,19 @@ export class MemorySourceIndexKernel {
       return "forgotten";
     }
     this.clear(entry.path, source);
-    const writeChunk = createMemoryChunkWriter(this.database, {
-      path: entry.path,
-      source,
-      model,
-      now,
-    });
+    let writeChunk: ReturnType<typeof createMemoryChunkWriter> | undefined;
     let ftsStatement: StatementSync | undefined;
     for (const [index, chunk] of chunks.entries()) {
       const embedding = embeddings[index] ?? [];
       const id = hashText(
         `${source}:${entry.path}:${chunk.startLine}:${chunk.endLine}:${chunk.hash}:${model}`,
       );
+      writeChunk ??= createMemoryChunkWriter(this.database, {
+        path: entry.path,
+        source,
+        model,
+        now,
+      });
       writeChunk(id, chunk, embedding);
       if (vectorReady && embedding.length > 0) {
         replaceMemoryVectorRow({


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

This branch is in the main repository; fork collaboration settings do not apply.

</details>

## What Problem This Solves

Fixes an issue where initial memory indexing constructs and compiles three chunk-write queries for every source file, including files that produce no indexable chunks. A synthetic Gateway startup trace found 993 empty chunk sets among 1,001 session preparations.

## Why This Change Was Made

The existing source-index kernel now creates its chunk writer on the first actual chunk. Empty replacements still clear stale chunks and associated metadata and update the canonical source fingerprint and path-search projection. Workspace locks, transaction admission, tombstone checks, and publication behavior are unchanged.

## User Impact

Initial indexing of many empty session files performs less CPU work. This is a small improvement within indexing; it does not resolve the larger workspace-lock cost seen under Gateway load.

## Evidence

All eight existing native-kernel and manager chunk-writer tests passed across two files. Formatting and diff checks passed. The manager tests exercise real sync/search, empty replacements, and rollback/retry after failures in each chunk publication table.

Paired Windows x64 / Node 26.8.2 measurements compare the actual baseline and candidate kernels using the same compiled production SDK from `9e267031cd9d73aea91332f9245570ddd5bebef0`. Each sample includes a fresh in-memory SQLite database and schema, input construction, and a real transaction per replacement. Three warmups and three ABBA rounds produce six samples per version.

| Workload | Baseline median | Candidate median |
| --- | ---: | ---: |
| 1,000 new empty replacements | 305.57 ms | 214.35 ms |
| 300 existing-to-empty replacements, including identical stale seeding | 290.66 ms | 289.71 ms |
| 300 one-chunk replacements | 181.50 ms | 184.23 ms |
| 30 replacements with 32 chunks each | 103.79 ms | 98.60 ms |

All six new-empty candidate samples (184.70–229.58 ms) were below all six baseline samples (245.50–345.96 ms). The other workloads overlap and establish no improvement; the one-chunk median is 1.5% slower. Exact database snapshots match for empty and nonempty replacements. The proof also verifies stale chunk/body-search/metadata cleanup, retained source/path-search rows and siblings, rollback on final-upsert failure, and canonical tombstone rejection of a shadow write.

Measurements ran on a shared host and exclude module startup, compilation, unchanged workspace-lock admission, database close and postrun assertions. They are kernel timings, not Gateway latency or filesystem-durability measurements. No timing assertions or new test seams were added.

Independent review completed with no actionable P0-P2 findings; final source verification passed. Production and extension-test typechecks, full type-aware extension lint, architecture and SQLite boundary guards passed. The two additional local media and sidecar guards also passed. [CI run 34703456306](https://github.com/openclaw/openclaw/actions/runs/34703456306), including the required openclaw/ci-gate, passed for head `ef45d79fa67b0f49845843ad0f20a409763e7c7e`. Job checkout logs identify tested merge `3b468f405d56b90db74b183d85dad030112454df`; its kernel bytes match the reviewed and benchmarked source.

## Stored-data compatibility

This diff does not change schema versions, SQL, persisted fields, vector/embedding metadata, serialization, transaction admission, or the order of writes. It moves construction of an invocation-local query writer; native statement preparation was already lazy. Empty replacements still remove stale chunks and update source fingerprints and path-search rows.

The existing-store parity fixture seeds identical stale source/chunk/search/metadata records before replacement and compares complete baseline/candidate database snapshots. Empty and nonempty results match, including sibling retention, rollback and canonical tombstone rejection. Existing manager tests also cover real sync/search and empty replacement behavior. No migration is needed because the stored representation and mutations are unchanged. A published-driver upgrade lane was not run or claimed.