### PR TITLE
perf(web-fetch): reduce work for attribute-light HTML

### DIFF
--- a/src/agents/tools/web-fetch-visibility.ts
+++ b/src/agents/tools/web-fetch-visibility.ts
@@ -192,7 +192,7 @@ const readHidden = createAttributeReader("hidden");
 const readClass = createAttributeReader("class");
 const readStyle = createAttributeReader("style");
 const readEncoding = createAttributeReader("encoding");
-const VISIBILITY_ATTRIBUTE_HINT = /hidden|class|style|type|[^\x00-\x7f]/i;
+const VISIBILITY_ATTRIBUTE_HINT = /hidden|class|style|type|[\u0080-\uffff]/i;
 
 function shouldRemoveElement(tagName: string, attrs: string): boolean {
   if (["meta", "template", "svg", "canvas", "iframe", "object", "embed"].includes(tagName)) {

--- a/src/agents/tools/web-fetch-visibility.ts
+++ b/src/agents/tools/web-fetch-visibility.ts
@@ -192,35 +192,27 @@ const readHidden = createAttributeReader("hidden");
 const readClass = createAttributeReader("class");
 const readStyle = createAttributeReader("style");
 const readEncoding = createAttributeReader("encoding");
+const VISIBILITY_ATTRIBUTE_HINT = /hidden|class|style|type|[^\x00-\x7f]/i;
 
 function shouldRemoveElement(tagName: string, attrs: string): boolean {
   if (["meta", "template", "svg", "canvas", "iframe", "object", "embed"].includes(tagName)) {
     return true;
   }
 
-  if (tagName === "input" && normalizeOptionalLowercaseString(readType(attrs)) === "hidden") {
+  // Only skip plain ASCII attributes; every hint still uses the complete grammar.
+  if (!VISIBILITY_ATTRIBUTE_HINT.test(attrs)) {
+    return false;
+  }
+  if (
+    (tagName === "input" && normalizeOptionalLowercaseString(readType(attrs)) === "hidden") ||
+    normalizeOptionalLowercaseString(readAriaHidden(attrs)) === "true" ||
+    readHidden(attrs) !== undefined ||
+    hasHiddenClass(readClass(attrs) ?? "")
+  ) {
     return true;
   }
-
-  if (normalizeOptionalLowercaseString(readAriaHidden(attrs)) === "true") {
-    return true;
-  }
-
-  if (readHidden(attrs) !== undefined) {
-    return true;
-  }
-
-  const className = readClass(attrs) ?? "";
-  if (hasHiddenClass(className)) {
-    return true;
-  }
-
   const style = readStyle(attrs) ?? "";
-  if (style && isStyleHidden(style)) {
-    return true;
-  }
-
-  return false;
+  return style ? isStyleHidden(style) : false;
 }
 
 const LIST_CONTAINERS = new Set(["ul", "ol", "menu"]);


### PR DESCRIPTION
## What Problem This Solves

`web_fetch` spends time checking visibility attributes on HTML elements whose attributes cannot affect visibility. Link/ID-heavy pages repeatedly pay those scans before basic extraction or Readability can consume the HTML.

## Why This Change Was Made

Add a negative prefilter at the existing visibility owner. Plain ASCII attributes without a possible visibility-name hint skip the attribute readers. Any hint or non-ASCII character still uses the complete existing parser. Recognized names, first-occurrence semantics, quoted/unquoted grammar, input-only type handling, hidden ancestry and short-circuit order are unchanged. This removes eight production lines without adding a cache, public surface or policy.

## User Impact

Less sanitizer work for attribute-light and link/ID-heavy HTML, with unchanged output. This is a bounded tradeoff, not a general `web_fetch` speed or memory claim: ordinary class/style and some Unicode pages regress, and basic extraction has mixed results.

In the historical benchmark of the original complement-ASCII expression, the 750,000-character link/ID fixture saw sanitizer wall time fall by **3.55 / 5.46 ms** in the two orders. At 32 KiB, common class/style adds **0.165 / 0.183 ms**, Unicode attributes add **0.098 / 0.123 ms**, and basic class/style text extraction adds **0.074 / 0.006 ms**. Basic link/ID text extraction reduces wall time by **0.142 / 0.118 ms**, while process CPU increases by **859 / 1,490 µs** (+60% / +87%). These costs are retained deliberately; there is no pooled score or assumption about real-site attribute frequencies.

## Evidence

- **219 existing tests passed, zero failures/skips:** sanitizer 127, basic extraction 77, actual `web_fetch.execute` with loopback HTTP 5, Readability text/Markdown integration 10.
- Before the one-line lint correction, **26 repository-selected small guards passed**, including formatting and config-docs verification. All 29 original native validation receipts closed under 300-second / 6-GiB / 64-process limits; peak observed tree RSS was 3.94 GiB. Existing Vite dynamic-import analysis warnings were retained. The correction was separately checked by five closed native receipts for membership, syntax lint, the 219 tests, formatting and diff sanity; the 26-guard run is retained prior evidence, not a claimed rerun.
- The original Codex review and fresh review of the spelling correction found no actionable P0–P2 issues. Independent verification also checked the full source, complete benchmark graphs, native receipts and output hashes.
- **Hosted obligations remain:** `tsgo:core`, `tsgo:core:test`, and the selected type-aware `run-oxlint` check. These were not run locally outside the retained resource envelope. No full build or benchmark retiming was performed for this unchanged-import sanitizer patch.
- One Linux run on Node 24.19.0 used fixed B1/C1/C2/B2 phases, 31 cases, two warmups and seven measured calls per case, plus 17 untimed controls per phase. All **1,116 invocation graphs and 68 control graphs matched exactly**, including complete output/property shape, without normalization. All cases, including adverse controls, are below. These measurements use the original complement-ASCII spelling. A subsequent lint correction expresses the same class as a positive non-ASCII UTF-16 range, with unchanged keywords and `i` flag. Exhaustive membership checks over all 65,536 code units, 48 full-match controls and the 219 focused tests pass; this corrected spelling has not been retimed. All 22 original source/context pins matched the author base before that spelling correction.
- The benchmark calls the actual `sanitizeHtml` and `extractBasicHtmlContent` entries. Fixture construction, imports, output capture and compression are excluded from invocation clocks. CPU is process user+system time; maxRSS is whole-process high-water and phase-history-sensitive, not allocation per call. These are synthetic HTML pages, not end-to-end network/provider or Readability article-selection measurements. There were no measurement retries or case/cap changes.

<details>
<summary>All 31 cases: historical original-expression medians</summary>

Each cell gives **B1 → C1 / B2 → C2**. Wall time is milliseconds; CPU is microseconds; maxRSS is MiB. Values are rounded for readability. Size suffixes are UTF-16 units; the response-cap page is entirely ASCII.

| Case | Wall ms | CPU µs | maxRSS MiB |
|---|---:|---:|---:|
| visibility-bare-4096 | 0.099 → 0.097 / 0.123 → 0.096 | 100 → 188 / 179 → 128 | 104.93 → 105.30 / 312.21 → 259.77 |
| visibility-bare-32768 | 0.436 → 0.353 / 0.436 → 0.332 | 439 → 354 / 547 → 436 | 109.30 → 109.30 / 312.21 → 259.77 |
| visibility-bare-131072 | 1.248 → 1.016 / 1.215 → 0.913 | 1504 → 1093 / 1288 → 914 | 123.17 → 121.88 / 312.21 → 259.77 |
| visibility-links-and-ids-4096 | 0.056 → 0.033 / 0.053 → 0.032 | 56 → 33 / 53 → 32 | 126.67 → 127.30 / 312.21 → 259.77 |
| visibility-links-and-ids-32768 | 0.401 → 0.237 / 0.385 → 0.224 | 402 → 238 / 386 → 225 | 126.89 → 127.30 / 312.21 → 259.77 |
| visibility-links-and-ids-131072 | 1.636 → 0.927 / 1.495 → 0.878 | 1638 → 928 / 1496 → 880 | 128.41 → 129.44 / 312.21 → 259.77 |
| visibility-long-data-4096 | 0.028 → 0.013 / 0.014 → 0.013 | 29 → 14 / 14 → 14 | 128.92 → 130.38 / 312.21 → 259.77 |
| visibility-long-data-32768 | 0.084 → 0.079 / 0.081 → 0.101 | 84 → 80 / 82 → 102 | 130.12 → 130.68 / 312.21 → 259.77 |
| visibility-long-data-131072 | 0.325 → 0.304 / 0.327 → 0.372 | 326 → 313 / 328 → 373 | 136.77 → 136.58 / 312.21 → 259.77 |
| visibility-common-class-style-4096 | 0.128 → 0.163 / 0.159 → 0.220 | 131 → 163 / 160 → 361 | 137.77 → 140.58 / 312.21 → 259.77 |
| visibility-common-class-style-32768 | 0.643 → 0.807 / 0.629 → 0.812 | 645 → 813 / 637 → 910 | 137.77 → 140.58 / 312.21 → 259.77 |
| visibility-common-class-style-131072 | 2.372 → 2.310 / 2.279 → 2.308 | 2629 → 2371 / 2342 → 2354 | 137.77 → 140.58 / 312.21 → 259.77 |
| visibility-quoted-hints-4096 | 0.046 → 0.045 / 0.045 → 0.045 | 46 → 45 / 45 → 45 | 138.18 → 140.58 / 312.21 → 259.77 |
| visibility-quoted-hints-32768 | 0.458 → 0.335 / 0.331 → 0.341 | 458 → 337 / 332 → 342 | 142.68 → 140.58 / 312.21 → 259.77 |
| visibility-quoted-hints-131072 | 1.382 → 1.479 / 1.562 → 1.356 | 1383 → 1432 / 1563 → 1352 | 159.27 → 148.32 / 312.21 → 259.77 |
| visibility-unicode-attrs-4096 | 0.063 → 0.066 / 0.076 → 0.061 | 63 → 66 / 76 → 62 | 159.27 → 152.45 / 312.21 → 259.77 |
| visibility-unicode-attrs-32768 | 0.446 → 0.544 / 0.430 → 0.552 | 448 → 544 / 430 → 554 | 159.76 → 159.84 / 312.21 → 259.77 |
| visibility-unicode-attrs-131072 | 1.799 → 1.747 / 1.689 → 1.752 | 1801 → 1756 / 1690 → 1758 | 167.43 → 167.74 / 312.21 → 259.77 |
| visibility-input-hidden-first-4096 | 0.011 → 0.010 / 0.011 → 0.010 | 12 → 11 / 12 → 11 | 170.55 → 172.74 / 312.21 → 259.77 |
| visibility-input-hidden-first-32768 | 0.057 → 0.051 / 0.053 → 0.052 | 57 → 52 / 53 → 53 | 170.55 → 172.74 / 312.21 → 259.77 |
| visibility-input-hidden-first-131072 | 0.209 → 0.183 / 0.197 → 0.193 | 210 → 184 / 197 → 193 | 170.55 → 172.74 / 312.21 → 259.77 |
| visibility-hidden-parent-4096 | 0.024 → 0.021 / 0.022 → 0.022 | 24 → 21 / 23 → 22 | 170.91 → 172.74 / 312.21 → 259.77 |
| visibility-hidden-parent-32768 | 0.105 → 0.096 / 0.098 → 0.099 | 106 → 97 / 99 → 99 | 170.91 → 172.74 / 312.21 → 259.77 |
| visibility-hidden-parent-131072 | 0.407 → 0.400 / 0.375 → 0.410 | 408 → 402 / 376 → 421 | 170.91 → 172.74 / 312.21 → 259.77 |
| visibility-links-at-response-cap | 9.881 → 6.328 / 11.054 → 5.591 | 9972 → 6441 / 11453 → 6138 | 197.19 → 194.45 / 312.21 → 259.77 |
| basic-links-and-ids-text | 0.995 → 0.854 / 0.964 → 0.846 | 1432 → 2291 / 1719 → 3209 | 233.22 → 219.70 / 312.21 → 259.77 |
| basic-links-and-ids-markdown | 0.783 → 0.768 / 0.758 → 0.787 | 783 → 769 / 759 → 787 | 233.22 → 219.70 / 312.21 → 259.77 |
| basic-common-class-style-text | 0.789 → 0.863 / 0.773 → 0.780 | 790 → 864 / 774 → 781 | 233.22 → 219.70 / 312.21 → 259.77 |
| basic-common-class-style-markdown | 0.747 → 0.757 / 0.722 → 0.744 | 748 → 758 / 722 → 744 | 233.22 → 219.70 / 312.21 → 259.77 |
| basic-quoted-hints-text | 0.589 → 0.592 / 0.583 → 0.596 | 590 → 592 / 584 → 596 | 233.22 → 219.70 / 312.21 → 259.77 |
| basic-quoted-hints-markdown | 0.556 → 0.551 / 0.546 → 0.551 | 560 → 554 / 547 → 551 | 233.22 → 219.70 / 312.21 → 259.77 |

</details>

The branch is in the upstream repository; maintainers retain normal repository write access.

CI correction: the first hosted lint run rejected the intentional ASCII complement under `eslint/no-control-regex`. The equivalent positive range removes control characters from the pattern without suppression or changed flags. Targeted repository syntax lint now passes 230 rules on the file; broad hosted gates still need the new head.
