### PR TITLE
improve(memory): speed up filename search across large indexes

### DIFF
--- a/extensions/memory-core/src/memory/manager-search.test.ts
+++ b/extensions/memory-core/src/memory/manager-search.test.ts
@@ -503,6 +503,64 @@ describe("searchKeyword FTS MATCH fallback", () => {
 });
 
 describe("searchPathKeyword", () => {
+  it.each([
+    ["unicode61", "common"],
+    ["unicode61", "README.md"],
+    ["trigram", "common"],
+    ["trigram", "README.md"],
+  ] as const)(
+    "resolves first chunks only within the retained %s window for %s",
+    async (ftsTokenizer, query) => {
+      const { db } = createMemorySearchDb({ ftsTokenizer });
+      try {
+        db.prepare(
+          "INSERT INTO memory_index_sources (path, source, hash, mtime, size) VALUES (?, 'memory', '', 0, 0)",
+        ).run("memory/common/00-empty/README.md");
+        for (let index = 0; index < 64; index++) {
+          for (let chunk = 2; chunk >= 0; chunk--) {
+            insertKeywordFixture(db, {
+              id: `path-${index}-chunk-${chunk}`,
+              path: `memory/common/${String(index).padStart(3, "0")}/README.md`,
+              source: index % 2 === 0 ? "memory" : "sessions",
+              startLine: chunk * 5 + 1,
+              endLine: chunk * 5 + 4,
+              text: `body ${index}/${chunk}`,
+            });
+          }
+        }
+        let examinedChunkLines = 0;
+        db.function("observe_path_chunk_line", (line) => {
+          examinedChunkLines++;
+          return line;
+        });
+        db.exec(`
+          ALTER TABLE memory_index_chunks RENAME TO observed_chunks;
+          CREATE VIEW memory_index_chunks AS
+            SELECT id, path, source, observe_path_chunk_line(start_line) AS start_line,
+                   end_line, text FROM observed_chunks;
+        `);
+
+        const results = await searchPathKeywordFixture(db, query, {
+          ftsTokenizer,
+          limit: 2,
+          sourceFilter: {
+            sql: " AND memory_index_paths_fts.source IN (?)",
+            params: ["memory"],
+          },
+        });
+
+        expect(results.map(({ id, snippet }) => ({ id, snippet }))).toEqual([
+          { id: "path-0-chunk-0", snippet: "body 0/0" },
+          { id: "path-2-chunk-0", snippet: "body 2/0" },
+        ]);
+        expect(examinedChunkLines).toBeGreaterThan(0);
+        expect(examinedChunkLines).toBeLessThanOrEqual(16);
+      } finally {
+        db.close();
+      }
+    },
+  );
+
   it("returns the first scoped chunk and reserves exact precedence for path identifiers", async () => {
     const { db, schema } = createMemorySearchDb();
     try {

--- a/extensions/memory-core/src/memory/manager-search.ts
+++ b/extensions/memory-core/src/memory/manager-search.ts
@@ -664,8 +664,8 @@ export async function searchPathKeyword(params: {
     exact_path_specificity: ExactPathSpecificity;
   };
   // ASCII identifiers use the path FTS plan before suffix filtering; Unicode
-  // forms keep the LIKE fallback. Live chunks are joined before LIMIT so an
-  // empty indexed file cannot consume an exact-result slot.
+  // forms keep the LIKE fallback. Exclude empty files before LIMIT, then order
+  // their first chunks only for the retained paths in the same read snapshot.
   const loadExactRows = (useLexicalCandidates: boolean): ExactPathRow[] => {
     const qualifiedPatternClause = exactCandidatePatterns
       .map(() => `${pathColumn} LIKE ? ESCAPE '\\'`)
@@ -701,6 +701,11 @@ export async function searchPathKeyword(params: {
           `), exact_paths AS MATERIALIZED (\n` +
           `  SELECT path, source, exact_path_specificity FROM scored_paths\n` +
           `   WHERE exact_path_specificity > 0\n` +
+          `     AND EXISTS (SELECT 1 FROM memory_index_chunks live\n` +
+          `                  WHERE live.path = scored_paths.path\n` +
+          `                    AND live.source = scored_paths.source)\n` +
+          `   ORDER BY exact_path_specificity DESC, path ASC, source ASC\n` +
+          `   LIMIT ?\n` +
           `)\n` +
           `SELECT c.id, exact_paths.path, exact_paths.source,\n` +
           `       c.start_line, c.end_line, c.text, exact_paths.exact_path_specificity\n` +
@@ -713,8 +718,7 @@ export async function searchPathKeyword(params: {
           `     LIMIT 1\n` +
           `  )\n` +
           ` ORDER BY exact_paths.exact_path_specificity DESC,\n` +
-          `          exact_paths.path ASC, exact_paths.source ASC\n` +
-          ` LIMIT ?`,
+          `          exact_paths.path ASC, exact_paths.source ASC`,
       )
       .all(...candidateParams, exactPathQuery, exactPathLimit) as ExactPathRow[];
   };
@@ -777,22 +781,32 @@ export async function searchPathKeyword(params: {
       ...filter.params,
       ...params.sourceFilter.params,
     ];
+    // Filter empty sources before LIMIT, then resolve first chunks only for the
+    // retained paths. Keep both phases in the same statement's read snapshot.
     return params.db
       .prepare(
-        `SELECT c.id, ${params.pathFtsTable}.path, ${params.pathFtsTable}.source,\n` +
-          `       c.start_line, c.end_line, c.text,\n` +
-          `       ${matchQuery ? `bm25(${params.pathFtsTable})` : "0"} AS rank\n` +
-          `  FROM ${params.pathFtsTable}\n` +
+        `WITH retained_paths AS MATERIALIZED (\n` +
+          `  SELECT ${params.pathFtsTable}.path, ${params.pathFtsTable}.source,\n` +
+          `         ${matchQuery ? `bm25(${params.pathFtsTable})` : "0"} AS rank\n` +
+          `    FROM ${params.pathFtsTable}\n` +
+          `   WHERE ${matchQuery ? `${params.pathFtsTable} MATCH ?` : "1=1"}${filter.sql}${params.sourceFilter.sql}${qualifiedSpecificityClause}\n` +
+          `     AND EXISTS (SELECT 1 FROM memory_index_chunks live\n` +
+          `                  WHERE live.path = ${params.pathFtsTable}.path\n` +
+          `                    AND live.source = ${params.pathFtsTable}.source)\n` +
+          `   ORDER BY rank ASC, ${params.pathFtsTable}.path ASC, ${params.pathFtsTable}.source ASC\n` +
+          `   LIMIT ?\n` +
+          `)\n` +
+          `SELECT c.id, retained_paths.path, retained_paths.source,\n` +
+          `       c.start_line, c.end_line, c.text, retained_paths.rank\n` +
+          `  FROM retained_paths\n` +
           `  JOIN memory_index_chunks c ON c.id = (\n` +
           `    SELECT candidate.id FROM memory_index_chunks candidate\n` +
-          `     WHERE candidate.path = ${params.pathFtsTable}.path\n` +
-          `       AND candidate.source = ${params.pathFtsTable}.source\n` +
+          `     WHERE candidate.path = retained_paths.path\n` +
+          `       AND candidate.source = retained_paths.source\n` +
           `     ORDER BY candidate.start_line, candidate.end_line, candidate.id\n` +
           `     LIMIT 1\n` +
           `  )\n` +
-          ` WHERE ${matchQuery ? `${params.pathFtsTable} MATCH ?` : "1=1"}${filter.sql}${params.sourceFilter.sql}${qualifiedSpecificityClause}\n` +
-          ` ORDER BY rank ASC, ${params.pathFtsTable}.path ASC, ${params.pathFtsTable}.source ASC\n` +
-          ` LIMIT ?`,
+          ` ORDER BY retained_paths.rank ASC, retained_paths.path ASC, retained_paths.source ASC`,
       )
       .all(...queryParams, exactPathQuery, resultLimit) as PathLexicalRow[];
   };


### PR DESCRIPTION
Related: #145739

<details>
<summary>Additional instructions</summary>

The branch is in openclaw/openclaw and remains editable by repository maintainers.

</details>

## What Problem This Solves

Memory searches for common path terms or filenames such as `README.md` slow down when many indexed files match, especially when each file contains many chunks. Finding the first chunk of every matching file does unnecessary work when only a small result window is needed.

## Why This Change Was Made

Select the ordered, bounded set of paths with live chunks before resolving their first chunks. Exact filename and lexical searches both retain their existing source filters, ranking, exact-result headroom, and first-chunk tie rules within one SQLite statement and read snapshot.

## User Impact

Faster path and filename retrieval on larger memory indexes, with identical results and no configuration or data migration.

## Evidence

- All 112 tests passed across the search owner, search orchestration, and keyword retrieval suites. Four work-bound cases cover both tokenizers and both query paths; the original queries examined 98 or 106 chunk lines against a bound of 16, while the candidate passes with identical selected chunks.
- Extension production types, the three affected tests' type graph, scoped type-aware lint, formatting, and `git diff --check` passed. Independent P0–P2 review completed with no findings.
- Repository ratchets passed: 827 existing maximum-lines exceptions, 492/492 environment variables, and 3,882 files with 11,475 existing assertion exceptions; no baseline changes.
- Direct calls to the original owner at `81a4c771` and candidate owner used the same canonical schema and fixtures. Seven alternating measured rounds followed two warmups per variant; every result object matched. Node 26.8.2 / SQLite 3.53.4, synthetic in-memory stores, 1 KiB chunks, mixed sources, and empty indexed files:

| Query | Files × chunks per nonempty file | Original median | Candidate median |
| --- | ---: | ---: | ---: |
| `common` | 1,000 × 1 | 7.39 ms | 7.33 ms |
| `common` | 1,000 × 40 | 31.49 ms | 28.74 ms |
| `common` | 10,000 × 20 | 182.95 ms | 113.66 ms |
| `README.md` | 1,000 × 1 | 14.40 ms | 11.67 ms |
| `README.md` | 1,000 × 40 | 62.43 ms | 45.11 ms |
| `README.md` | 10,000 × 20 | 369.71 ms | 217.09 ms |

Background host work was present, so these are operation-level measurements rather than whole-Gateway throughput claims. SQLite statement counters independently show the 10,000-file lexical sort count falling from 10,001 to 9; exact and exact-lexical counts each fall from 10,001 to 201 with the existing 200-result headroom. VM-step counts do not uniformly decrease. The newer Node counter API is used only in the external proof harness.

Sixty additional comparisons used read-only canonical SQLite files with both tokenizers, source scopes, exact/Unicode/short queries, escaped substring characters, and the MATCH fallback. Full result objects matched; schema, every table's row digest, `user_version`, integrity checks, and main-file hashes remained unchanged. Hosted CI remains the landing gate.

### Data-model and upgrade compatibility

The `unknown-data-model-change` classification in review does not describe a persisted-model change in this patch. The two changed production queries are read-only SELECTs. Their materialized CTEs exist for one statement; they do not create a table, index, stored projection, or migration. The canonical schema, schema versions, stored rows, codecs, store routing, write behavior, transaction boundaries, and recovery paths are unchanged. This fits the storage checkpoint's [bounded query-plan improvement exception](https://github.com/openclaw/openclaw/blob/8f245e208d22485ed4e6ccf8c734105af94e297b/docs/reference/database-schemas/storage-changes.md#review-checkpoint-for-material-changes).

The existing compatibility proof explicitly checked both readers against the same preexisting files:

1. Create two synthetic SQLite files with the unchanged canonical Memory Core schema, one per tokenizer. Each contains 1,038 source rows and 4,002 chunk rows, including empty sources and Unicode paths. Seed and checkpoint the fixtures, close the writer, and capture schema, all 19 table digests (including FTS shadow tables), `user_version`, and the complete file SHA-256.
2. Reopen each file with `DatabaseSync(..., { readOnly: true })`. Run the candidate query owner followed by the original `81a4c771` owner for each of 30 cases. Both owners use the same infrastructure. The matrix covers all/memory/sessions scopes, lexical and exact searches, Unicode, short terms, escaped characters, absence, and the MATCH fallback.
3. Assert equality of every complete result object. Recheck all schema/row digests and `user_version`, require `PRAGMA integrity_check` to return `ok`, then close the reader and compare the complete file hash.

| Fixture | Original/candidate comparisons | File SHA-256 before and after |
| --- | ---: | --- |
| unicode61 | 30 passed | `4d61f402b843f1efefe49b6bce9981ddcf2f97fbe63bd034a1872ae19ec59406` |
| trigram | 30 passed | `b77380f2c30ce6cbfc3a35efd1e516e029be1acaa6529851cff0cad9732afcbb` |

All comparisons and invariants passed. The measured candidate source SHA-256 is `74c042a4c6d5a10822e0e9d994ca58a94953b0e8044761132144f93d7229924d`, rechecked against head `8f245e208d22485ed4e6ccf8c734105af94e297b`. Existing files need no migration, and the original reader can still read the identical bytes after candidate queries. This is query/data compatibility proof; a published-release updater smoke test was not run because no updater or migration behavior changes here.
