### PR TITLE
chore(cli): show rejected-update subprocess diagnostics

### DIFF
--- a/src/cli/update-dry-run-state.process.test.ts
+++ b/src/cli/update-dry-run-state.process.test.ts
@@ -551,7 +551,14 @@ process.stdin.resume();
         "--json",
       ]);
 
-      expect(result.error).toBeUndefined();
+      expect(
+        result.error,
+        formatCliProcessFailure({
+          reason: `rejected ${command} arguments`,
+          stdout: result.stdout ?? "",
+          stderr: result.stderr ?? "",
+        }),
+      ).toBeUndefined();
       expect(result.status).not.toBe(0);
       expect(`${result.stdout}\n${result.stderr}`).toMatch(
         /--timeout must be a positive integer/iu,


### PR DESCRIPTION
Related: #146078

## What Problem This Solves

Resolves a problem where a rejected-update CLI subprocess failure reports only the spawn error, hiding the captured child output needed to locate the failure. CI run [34701057560, attempt 1](https://github.com/openclaw/openclaw/actions/runs/34701057560/attempts/1) hit the existing 60-second guard but did not show either output stream.

## Why This Change Was Made

The existing tabled update/repair assertion now uses the shared bounded output-tail formatter. Missing streams from process-launch errors are normalized to empty strings so diagnostic formatting cannot mask the spawn error.

## User Impact

No product behavior changes. Future failures in this process-state regression include the child's stdout and stderr. The timeout, subprocess invocation, retry policy, exit-code check, error-message check, and state-immutability assertion are unchanged.

This improves diagnostics; it does not claim to fix the original, unreproduced hang.

## Evidence

The unchanged Linux/Node 24.19.0 CI retry passed all 275 tests in the original shard. The rejected-update case completed in 1,242 ms and its repair sibling in 1,352 ms. The relevant launcher, CLI, update, and test sources match the failed CI merge snapshot.

The full process-state file passed 18/18 locally on Node 24.20.0. A bounded probe then passed 40/40 actual rejected-update invocations with fresh legacy-state fixtures, taking 633–2,108 ms each and preserving every fixture byte. The original timeout's exact stage remains unknown because the failure report omitted the captured streams.

Both affected table cases pass after this diagnostic change. Complete selected changed checks and fresh managed review through P2 pass. A direct Node launch-error probe verified that output streams can be absent, which the formatter call now handles.
