### PR TITLE
fix(ui): keep effort selector after catalog refresh failure

### DIFF
--- a/ui/src/e2e/chat-model-controls.e2e.test.ts
+++ b/ui/src/e2e/chat-model-controls.e2e.test.ts
@@ -78,6 +78,12 @@ suite.define(() => {
       await expect
         .poll(() => composer.locator("[data-chat-model-catalog-state]").textContent())
         .toContain("Some models could not be refreshed");
+      await expect.poll(() => effort.isVisible()).toBe(true);
+      await expect.poll(() => effort.getAttribute("data-chat-thinking-value")).toBe("xhigh");
+      expect(await effortPicker.getAttribute("aria-hidden")).toBe("false");
+      expect(await effortPicker.getAttribute("class")).not.toContain(
+        "chat-controls__effort-picker--reserved",
+      );
     });
   });
 

--- a/ui/src/e2e/chat-model-controls.e2e.test.ts
+++ b/ui/src/e2e/chat-model-controls.e2e.test.ts
@@ -7,6 +7,80 @@ import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts"
 const suite = createControlUiE2eSuite({ name: "Control UI model and effort controls" });
 
 suite.define(() => {
+  it("keeps effort selectable from a usable snapshot when model refresh fails", async () => {
+    await suite.withPage({ viewport: { width: 1280, height: 900 } }, async ({ page }) => {
+      const thinkingLevels = [
+        { id: "low", label: "Low" },
+        { id: "xhigh", label: "Extra high" },
+      ];
+      const model = {
+        id: "gpt-6-astra",
+        name: "GPT-6 Astra",
+        provider: "openai",
+        available: true,
+        reasoning: true,
+        thinkingLevels,
+      };
+      const gateway = await installMockGateway(page, {
+        agentModel: "openai/gpt-6-astra",
+        models: [model],
+        methodResponses: {
+          "models.list": {
+            sequence: [
+              { models: [model] },
+              {
+                __mockError: {
+                  code: "UNAVAILABLE",
+                  message: "Model catalog refresh unavailable",
+                },
+              },
+            ],
+          },
+          "sessions.list": {
+            count: 1,
+            path: "",
+            ts: 1,
+            defaults: {
+              model: model.id,
+              modelProvider: model.provider,
+              thinkingDefault: "low",
+              thinkingLevels,
+            },
+            sessions: [
+              {
+                key: "agent:main:main",
+                kind: "direct",
+                model: model.id,
+                modelProvider: model.provider,
+                thinkingDefault: "low",
+                thinkingLevel: "xhigh",
+                thinkingLevels,
+                updatedAt: 1,
+              },
+            ],
+          },
+        },
+      });
+
+      await page.goto(`${suite.server.baseUrl}chat`);
+      const composer = page.locator(".agent-chat__input").first();
+      const effortPicker = composer.locator(".chat-controls__effort-picker");
+      const effort = composer.locator('[data-chat-thinking-select="true"]');
+      await expect.poll(() => effort.isVisible()).toBe(true);
+      await expect.poll(() => effort.getAttribute("data-chat-thinking-value")).toBe("xhigh");
+      expect(await effortPicker.getAttribute("aria-hidden")).toBe("false");
+      expect(await effortPicker.getAttribute("class")).not.toContain(
+        "chat-controls__effort-picker--reserved",
+      );
+
+      await gateway.emitGatewayEvent("chat.metadata.changed", {});
+      await composer.locator('[data-chat-model-select="true"]').click();
+      await expect
+        .poll(() => composer.locator("[data-chat-model-catalog-state]").textContent())
+        .toContain("Some models could not be refreshed");
+    });
+  });
+
   it.each(["chat", "new"])("keeps a large pending model catalog usable in /%s", async (route) => {
     await suite.withPage({ viewport: { width: 1280, height: 900 } }, async ({ page }) => {
       const models = Array.from({ length: 1_000 }, (_, index) => ({

--- a/ui/src/pages/chat/components/chat-model-controls.ts
+++ b/ui/src/pages/chat/components/chat-model-controls.ts
@@ -439,7 +439,8 @@ export function renderChatModelControls(props: ChatModelControlsProps) {
     selectionKnown,
   );
   const hasResolvableModel =
-    managedCatalog.status === "ready" &&
+    managedCatalog.hasSnapshot &&
+    (managedCatalog.status === "ready" || managedCatalog.status === "error") &&
     activeModelOption?.disabled !== true &&
     modelOptions.some((option) => !option.disabled);
   const busy =


### PR DESCRIPTION
## What Problem This Solves

When `models.list` refresh fails after the Control UI has already loaded a usable model-catalog snapshot, chat keeps the selected model but reserves/hides the effort picker. That leaves a reasoning-capable model such as `openai/gpt-6-astra` visible while its valid selected effort (`xhigh`) is stuck behind a spinner. The failed refresh should surface as a warning without discarding controls backed by the retained snapshot.

## Summary

- keep the chat effort picker available when a usable model-catalog snapshot remains after a refresh failure
- continue hiding/reserving it when no snapshot or selectable model exists
- add an E2E regression covering Astra, `xhigh`, retained snapshot, and a failed catalog refresh

## Evidence

Local verification on current upstream base `a4f011c418c`:

- focused Playwright E2E: **1 passed, 13 skipped**
- `pnpm exec oxfmt --check ui/src/pages/chat/components/chat-model-controls.ts ui/src/e2e/chat-model-controls.e2e.test.ts`: pass
- `pnpm exec oxlint ui/src/pages/chat/components/chat-model-controls.ts ui/src/e2e/chat-model-controls.e2e.test.ts`: **0 warnings, 0 errors**
- `pnpm tsgo:test:ui`: pass
- `pnpm ui:build`: pass; **902 finalized Control UI sidecars verified**
- `git diff --check`: pass

The regression starts with Astra and `xhigh`, rejects the subsequent `models.list` refresh, verifies the stale-catalog warning, and asserts that the effort picker remains visible and non-reserved.
