### PR TITLE
improve(acp): reduce metadata escaping overhead

### DIFF
--- a/src/acp/event-mapper.ts
+++ b/src/acp/event-mapper.ts
@@ -67,7 +67,7 @@ const INLINE_CONTROL_ESCAPE_MAP: Readonly<Record<string, string>> = {
 
 function escapeInlineControlChars(value: string): string {
   return value.replace(
-    /[\x00-\x1f\x7f-\x9f\u2028\u2029]/g,
+    /[\p{Cc}\u2028\u2029]/gu,
     (char) =>
       INLINE_CONTROL_ESCAPE_MAP[char] || `\\x${char.charCodeAt(0).toString(16).padStart(2, "0")}`,
   );

--- a/src/acp/event-mapper.ts
+++ b/src/acp/event-mapper.ts
@@ -66,37 +66,11 @@ const INLINE_CONTROL_ESCAPE_MAP: Readonly<Record<string, string>> = {
 };
 
 function escapeInlineControlChars(value: string): string {
-  let escaped = "";
-  for (const char of value) {
-    const codePoint = char.codePointAt(0);
-    if (codePoint === undefined) {
-      escaped += char;
-      continue;
-    }
-
-    const isInlineControl =
-      codePoint <= 0x1f ||
-      (codePoint >= 0x7f && codePoint <= 0x9f) ||
-      codePoint === 0x2028 ||
-      codePoint === 0x2029;
-    if (!isInlineControl) {
-      escaped += char;
-      continue;
-    }
-
-    const mapped = INLINE_CONTROL_ESCAPE_MAP[char];
-    if (mapped) {
-      escaped += mapped;
-      continue;
-    }
-
-    // Keep escaped control bytes readable and stable in logs/prompts.
-    escaped +=
-      codePoint <= 0xff
-        ? `\\x${codePoint.toString(16).padStart(2, "0")}`
-        : `\\u${codePoint.toString(16).padStart(4, "0")}`;
-  }
-  return escaped;
+  return value.replace(
+    /[\x00-\x1f\x7f-\x9f\u2028\u2029]/g,
+    (char) =>
+      INLINE_CONTROL_ESCAPE_MAP[char] || `\\x${char.charCodeAt(0).toString(16).padStart(2, "0")}`,
+  );
 }
 
 function escapeResourceTitle(value: string): string {


### PR DESCRIPTION
## What Problem This Solves

ACP resource links with long ordinary titles and tool calls with many arguments spend avoidable time rebuilding strings while preparing prompt and tool metadata. This reduces that local mapping cost without changing the resulting text.

## Why This Change Was Made

Replace the character-by-character rebuild with replacement over the same 67 control characters. Unicode `Cc` plus explicit U+2028/U+2029 matches the original C0/C1/DEL and separator domain. Existing named escapes, bracket escaping, Unicode and lone-surrogate handling, argument truncation, and prompt byte-limit failures remain unchanged. No cache, configuration, protocol, authorization, or error-recovery behavior is added.

The current change removes 26 lines. The original measured proposal removed 28 lines before formatting, but its explicit-range regex failed CI's `eslint/no-control-regex` rule. The incremental correction uses `/[\p{Cc}\u2028\u2029]/gu`, with no suppression, rule, or baseline change. Because that changes regex syntax and mode, the corrected source received a new full fixed-matrix measurement; the original measurements remain retained but are not attributed to this version.

## User Impact

Clean 4 KiB resource titles take about 89% less time and clean 64 KiB titles about 94% less time in the measured exported mapper calls. Dense controls cost 35–43% more, adding 31.6–36.7 microseconds for a dense 4 KiB title. All-control resource/tool cases cost 31–45% more. Ordinary text output is unchanged.

These measurements cover `extractTextFromPrompt` with serialized, SDK-validated prompt fixtures and `formatToolTitle` with real plain inputs. They do not establish overall Gateway, ACP session, or editor responsiveness gains.

## Evidence

- Corrected source: 70 existing tests passed across the mapper, ACP client, prompt-size, prompt-prefix, and translator tool-streaming files; zero failures or skips. Formatting and diff checks passed.
- Exhaustive comparison on supported Node 26.8.2 covered all 65,536 UTF-16 units, all 1,048,576 astral scalars/valid surrogate pairs, 4,096 lone-surrogate contexts, six mixed strings, and exactly 67 matching controls. The existing 29 mapper cases and two malformed SDK controls also passed; standalone global-regex membership checks reset state.
- Fresh independent P2 review found no actionable issues. The original optimization also passed all 25 selected small guards; those remain prior-revision evidence, not claimed as freshly rerun here. No full local build or install was needed.
- The supported syntax-only command `node scripts/run-oxlint.mjs --openclaw-focused-config --config .oxlintrc.json --deny eslint/no-control-regex src/acp/event-mapper.ts` passed with zero errors and warnings. The separate type-aware command exceeded the unchanged 6 GiB aggregate memory cap after 16.24 seconds and was stopped; it remains unresolved locally. No retry, larger cap, weaker assertion, or full-lint pass is claimed.
- One new bounded [corrected-source Testbox run](https://github.com/openclaw/openclaw/actions/runs/34707590655), on Linux Node 24.19.0, exercised all 29 cases in B1/C1/C2/B2 order: 58,752 mapper calls, including 45,696 measured calls and 13,056 warmups, plus eight SDK rejection checks. Every ordered semantic outcome matched without normalization. All 6,912 mapper exceptions retain raw error stacks separately, including expected source-line shifts. Independent offline recomputation matched every median and percentage.

The table gives per-invocation medians. Forward compares B1→C1; reverse compares B2→C2. Positive percentages are slower.

| Mapper case | B1 → C1 µs | B2 → C2 µs | Forward wall change | Reverse wall change |
| --- | ---: | ---: | ---: | ---: |
| `prompt-clean-8` | 1.097 → 0.649 | 1.028 → 0.849 | -40.78% | -17.43% |
| `prompt-clean-4096` | 28.262 → 3.077 | 27.030 → 2.985 | -89.11% | -88.96% |
| `prompt-clean-65536` | 534.823 → 33.726 | 573.488 → 33.877 | -93.69% | -94.09% |
| `prompt-unicode` | 0.597 → 0.503 | 0.570 → 0.392 | -15.68% | -31.09% |
| `prompt-all-67-controls` | 4.511 → 6.535 | 4.611 → 6.612 | +44.86% | +43.38% |
| `prompt-sparse-controls` | 27.759 → 3.190 | 26.441 → 2.776 | -88.51% | -89.50% |
| `prompt-dense-controls` | 89.725 → 121.280 | 85.545 → 122.264 | +35.17% | +42.92% |
| `prompt-brackets-controls` | 0.646 → 0.607 | 0.631 → 0.567 | -6.01% | -10.12% |
| `prompt-ordinary-text` | 0.146 → 0.229 | 0.139 → 0.237 | +56.73% | +70.33% |
| `prompt-empty` | 0.055 → 0.057 | 0.053 → 0.052 | +3.15% | -1.48% |
| `prompt-empty-resource-uri` | 0.348 → 0.616 | 0.578 → 0.612 | +77.39% | +5.82% |
| `prompt-multiple-resources` | 0.640 → 0.564 | 0.608 → 0.966 | -11.96% | +58.84% |
| `prompt-sdk-invalid-optional-title` | 0.242 → 0.175 | 0.216 → 0.285 | -27.67% | +32.39% |
| `prompt-separator-byte-exact` | 0.095 → 0.107 | 0.108 → 0.102 | +11.96% | -5.66% |
| `prompt-separator-byte-overflow` | 6.639 → 6.353 | 6.343 → 6.402 | -4.30% | +0.92% |
| `prompt-escaped-byte-exact` | 0.543 → 0.486 | 0.668 → 0.526 | -10.50% | -21.30% |
| `prompt-escaped-byte-overflow` | 6.220 → 5.647 | 5.484 → 5.709 | -9.22% | +4.10% |
| `prompt-unicode-byte-exact` | 0.428 → 0.351 | 0.383 → 0.376 | -18.05% | -1.80% |
| `prompt-unicode-byte-overflow` | 6.185 → 5.579 | 5.520 → 5.635 | -9.80% | +2.09% |
| `tool-clean` | 0.698 → 0.615 | 1.031 → 0.619 | -11.83% | -39.99% |
| `tool-no-args-controls` | 0.034 → 0.031 | 0.065 → 0.032 | -6.96% | -50.75% |
| `tool-empty-args` | 0.037 → 0.037 | 0.071 → 0.037 | -0.84% | -48.33% |
| `tool-all-67-controls` | 1.778 → 2.529 | 1.970 → 2.581 | +42.19% | +31.05% |
| `tool-truncate-99` | 0.779 → 0.230 | 0.738 → 0.227 | -70.52% | -69.21% |
| `tool-truncate-100` | 0.776 → 0.225 | 0.704 → 0.224 | -71.04% | -68.18% |
| `tool-truncate-101` | 1.034 → 0.499 | 0.939 → 0.499 | -51.74% | -46.85% |
| `tool-surrogate-truncation` | 0.966 → 0.446 | 0.898 → 0.416 | -53.84% | -53.70% |
| `tool-complete-surrogate-boundary` | 0.923 → 0.369 | 0.872 → 0.380 | -60.00% | -56.45% |
| `tool-many-fields` | 89.565 → 19.951 | 85.395 → 20.168 | -77.72% | -76.38% |

Dense-control CPU costs corroborate the wall-time regression. The ordinary-text negative control also regresses 56.73%/70.33%, adding only 0.083/0.098 µs; its cause is unproven. Empty-URI, multiple-resource, and other tiny controls are order-sensitive, and some CPU results reverse sign. These short samples do not prove general acceleration. All raw results, adverse controls, CPU/heap observations, and cleanup evidence remain retained; heap deltas are not allocation totals and process RSS is not per-case allocation.

All 51 exported member hashes and 11 native command receipts/stdio hashes were verified, with closed processes and joined monitors. The corrected proof archive SHA-256 is `32f5adc1477d0c3ddbde78534e7d9ff11c75688c0f085b2c682e41c8987df60e`; cleanup archive SHA-256 is `155142f00b1239ebcf4d486a75bb15e240f1b519ff779607e6169e649b948275`. The Testbox stopped, and the temporary measurement worktree and local sync capsule were removed.

The [original failed CI run](https://github.com/openclaw/openclaw/actions/runs/34703918823) and its exact lint log remain preserved. The [original explicit-range measurement](https://github.com/openclaw/openclaw/actions/runs/34701738583) is retained as history, not evidence for the corrected syntax.

Exact corrected-head [CI 34707938777](https://github.com/openclaw/openclaw/actions/runs/34707938777) passed the remaining hosted obligations: core types in check-prod-types; all core-test stripes in check-test-types-core-1/2 plus the fifth stripe in check-test-types; and type-aware core Oxlint in check-lint-core-1/2. These are hosted passes. The local 6 GiB lint failure and original failed-head CI remain preserved, not relabeled as passes.
