### PR TITLE
perf(sessions): aggregate validated inventory counts

### DIFF
--- a/src/config/sessions/session-accessor.sqlite-data-version.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-data-version.test.ts
@@ -290,6 +290,41 @@ describe("SQLite session entry cache", () => {
     expect(snapshot.entries.get(scope.sessionKey)?.skillsSnapshot).toBeUndefined();
   });
 
+  it("counts mixed validated and raw entries with the same archive filter", async () => {
+    const scope = createSessionScope("mixed-inventory-count");
+    const database = openOpenClawAgentDatabase(scope);
+    expect(readSessionEntryCount(database)).toBe(0);
+    expect(readSessionEntryCount(database, { includeArchived: false })).toBe(0);
+    for (const archived of [false, true]) {
+      await upsertSessionEntryCore(
+        { ...scope, sessionKey: "agent:main:validated-" + archived },
+        { sessionId: "validated-" + archived, updatedAt: 1, archivedAt: archived ? 1 : undefined },
+      );
+      database.db
+        .prepare(
+          "INSERT INTO session_nodes (session_key, current_session_id, entry_json, updated_at, archived_at) VALUES (?, ?, ?, 1, ?)",
+        )
+        .run(
+          "agent:main:raw-" + archived,
+          "raw-" + archived,
+          JSON.stringify({ sessionId: "raw-" + archived, updatedAt: 1 }),
+          archived ? 1 : null,
+        );
+    }
+    database.db
+      .prepare(
+        "INSERT INTO session_nodes (session_key, current_session_id, entry_json, updated_at) VALUES (?, ?, ?, 1)",
+      )
+      .run("agent:main:invalid", "invalid", "{");
+    expect(readSessionEntryCount(database)).toBe(4);
+    expect(readSessionEntryCount(database, { includeArchived: false })).toBe(2);
+    database.db
+      .prepare("UPDATE session_nodes SET entry_json = ? WHERE session_key = ?")
+      .run("{}", "agent:main:validated-false");
+    expect(readSessionEntryCount(database)).toBe(3);
+    expect(readSessionEntryCount(database, { includeArchived: false })).toBe(1);
+  });
+
   it("retains only listing metadata while full reads preserve saved prompt state", async () => {
     const scope = createSessionScope("lazy-list-projection");
     const prompt = "large skill prompt".repeat(8192);

--- a/src/config/sessions/session-accessor.sqlite-entry-inventory.ts
+++ b/src/config/sessions/session-accessor.sqlite-entry-inventory.ts
@@ -1,3 +1,4 @@
+import type { CompiledQuery } from "kysely";
 import { iterateSqliteQuerySync, sqliteStringSet } from "../../infra/kysely-sync.js";
 import type { OpenClawAgentDatabase } from "../../state/openclaw-agent-db.js";
 import { getSessionKysely } from "./session-accessor.sqlite-scope.js";
@@ -45,20 +46,54 @@ export function readSessionEntryStore(
   return store;
 }
 
+type SessionEntryCountRow = { count: number; entry_json: string | null };
+
+const countQueriesByDatabase = new WeakMap<
+  OpenClawAgentDatabase["db"],
+  Map<boolean, CompiledQuery<SessionEntryCountRow>>
+>();
+
 export function readSessionEntryCount(
   database: OpenClawAgentDatabase,
   options: { includeArchived?: boolean } = {},
 ): number {
-  const db = getSessionKysely(database.db);
-  let query = db.selectFrom("session_nodes").select(sessionEntryInventoryJson);
-  if (options.includeArchived === false) {
-    query = query.where("archived_at", "is", null);
+  const includeArchived = options.includeArchived !== false;
+  let queries = countQueriesByDatabase.get(database.db);
+  let compiled = queries?.get(includeArchived);
+  if (!compiled) {
+    const db = getSessionKysely(database.db);
+    let query = db.selectFrom("session_nodes");
+    if (!includeArchived) {
+      query = query.where("archived_at", "is", null);
+    }
+    // One statement preserves the snapshot while settled rows stay inside SQLite.
+    compiled = query
+      .where("entry_valid", "=", 1)
+      .select((eb) => [
+        eb.fn.countAll<number>().as("count"),
+        eb.val<string | null>(null).as("entry_json"),
+      ])
+      .unionAll(
+        query
+          .where("entry_valid", "!=", 1)
+          .select((eb) => eb.val(0).as("count"))
+          .select(sessionEntryInventoryJson),
+      )
+      .compile();
+    if (!queries) {
+      queries = new Map();
+      countQueriesByDatabase.set(database.db, queries);
+    }
+    queries.set(includeArchived, compiled);
   }
-  const rows = iterateSqliteQuerySync(database.db, query);
   let count = 0;
-  for (const row of rows) {
+  for (const row of iterateSqliteQuerySync(database.db, { compile: () => compiled })) {
     count +=
-      row.entry_json === null || parseSessionEntryJson({ entry_json: row.entry_json }) ? 1 : 0;
+      row.entry_json === null
+        ? row.count
+        : parseSessionEntryJson({ entry_json: row.entry_json })
+          ? 1
+          : 0;
   }
   return count;
 }


### PR DESCRIPTION
## What Problem This Solves

Session inventory counting materializes one JavaScript row per stored session even when the writer has already validated the entry. Maintenance and lifecycle counts repeat this work on populated Gateways.

## Why This Change Was Made

Aggregate writer-validated rows in SQLite and stream the remaining raw rows through the existing JSON parser. Both branches share one SQL statement and the same archive filter. Cache the two compiled query shapes weakly by connection; the existing iterator still owns each private native statement. No session data, schema, writer, transaction, retention, or recovery behavior changes.

## User Impact

Counting a large session store allocates substantially less temporary memory. Empty stores, archived entries, raw writes, malformed JSON, and retained placeholders keep their existing count semantics.

## Evidence

The actual count owner was measured on parent6d0c1c9fcf5a and the candidate using synthetic owner-written sessions, 1,000 reads per case, and identical expected counts:

- 1,000 sessions: 298.72 MB to0.99 MB sampled allocations (99.67% lower).
- 1,000 sessions excluding archived rows:243.23 MB to1.16 MB (99.52% lower).
- 100 sessions:32.53 MB to1.13 MB; empty store:2.66 MB to1.18 MB. Archive-filtered variants also improve.

These are bounded allocation samples. Instrumented wall times varied, including a slower empty-store sample; they do not establish a general latency or retained-memory improvement.

All219 tests passed across session accessors, cache/data-version behavior and raw-row/exclusion contracts. The added mixed validated/raw/archive case also passes the original implementation. During development, these tests caught and rejected an incorrect UNION column order; the final query selects the same columns in both branches. Fresh independent P0-P2 review is scoped-clean. Formatting and whitespace pass; changed-lane planning selects core and core tests. Aggregate local checks remain unrun after host resource exhaustion; exact-head hosted CI 34703977545 passed all required checks.

Connection-lifetime proof exercised both compiled modes on 30 actual owned database connections, closed their owners, and observed zero retained connections after garbage collection. This verifies cache lifetime without claiming a retained-memory size reduction.

