### PR TITLE
fix(sqlite): unblock Windows cleanup after state shutdown

### DIFF
--- a/src/infra/sqlite-coordinator.idle.test.ts
+++ b/src/infra/sqlite-coordinator.idle.test.ts
@@ -195,38 +195,56 @@ describe("idle SQLite coordinator connections", () => {
     },
   );
 
-  it("rechecks idle eligibility after an authority callback changes the runtime location", () => {
-    const { directory } = fixture();
-    const params: { databasePath: string; runtimeDirectory?: string } = {
-      databasePath: path.join(directory, "state.sqlite"),
-    };
-    const exclusion = acquireStateDatabaseHandleExclusion(params);
-    let changeRuntime = false;
-    let coordinatorPath: string | undefined;
-    try {
-      exclusion.runWithCanonicalWrites(
-        () => {
-          if (changeRuntime) {
-            params.runtimeDirectory = directory;
-          }
-        },
-        () => {
-          changeRuntime = true;
-          const databases = observeConnections();
-          const coordinator = acquireStateDatabaseCoordinator(params);
-          coordinatorPath = coordinator.path;
-          coordinator.release();
-          expect([...databases()].every((database) => !database.isOpen)).toBe(true);
-        },
-      );
-    } finally {
-      exclusion.release();
-    }
-    expect(coordinatorPath).toBeDefined();
-    if (coordinatorPath) {
-      fs.unlinkSync(coordinatorPath);
-    }
-  });
+  it.each(["runtimeDirectory", "coordinatorPath", "keepAlive"] as const)(
+    "rechecks idle eligibility after an authority callback changes %s",
+    (override) => {
+      const { directory } = fixture();
+      const params: Parameters<typeof acquireStateDatabaseCoordinator>[0] = {
+        databasePath: path.join(directory, "state.sqlite"),
+      };
+      const prepared = acquireStateDatabaseCoordinator({
+        databasePath: params.databasePath,
+        runtimeDirectory: override === "keepAlive" ? undefined : directory,
+        keepAlive: false,
+      });
+      const expectedPath = prepared.path;
+      prepared.release();
+      const exclusion = acquireStateDatabaseHandleExclusion(params);
+      let changeRuntime = false;
+      let coordinatorPath: string | undefined;
+      try {
+        exclusion.runWithCanonicalWrites(
+          () => {
+            if (changeRuntime) {
+              if (override === "runtimeDirectory") {
+                params.runtimeDirectory = directory;
+              } else if (override === "coordinatorPath") {
+                params.coordinatorPath = expectedPath;
+              } else {
+                params.keepAlive = false;
+              }
+            }
+          },
+          () => {
+            changeRuntime = true;
+            const databases = observeConnections();
+            const coordinator = acquireStateDatabaseCoordinator(params);
+            coordinatorPath = coordinator.path;
+            coordinator.release();
+            expect(coordinatorPath).toBe(expectedPath);
+            expect(databases().size).toBe(1);
+            expect([...databases()].every((database) => !database.isOpen)).toBe(true);
+          },
+        );
+      } finally {
+        exclusion.release();
+      }
+      expect(coordinatorPath).toBeDefined();
+      if (coordinatorPath) {
+        fs.unlinkSync(coordinatorPath);
+      }
+    },
+  );
 
   it.skipIf(process.platform === "win32")(
     "reopens an idle file after its access mode changes",

--- a/src/infra/sqlite-coordinator.ts
+++ b/src/infra/sqlite-coordinator.ts
@@ -227,11 +227,15 @@ function tryAcquireSqliteCoordinator(
   location: string,
   mode: "shared" | "exclusive",
   options: { busyTimeoutMs?: number; keepAlive?: boolean },
-): { release: () => void } | null {
+): { release: (options?: { keepAlive?: false }) => void } | null {
   const busyTimeoutMs = Math.max(0, Math.trunc(options.busyTimeoutMs ?? 0));
-  const poolLocation =
-    options.keepAlive && location !== "" && location !== ":memory:" && !location.startsWith("file:")
+  const reusableLocation =
+    location !== "" && location !== ":memory:" && !location.startsWith("file:")
       ? path.resolve(location)
+      : undefined;
+  const poolLocation =
+    reusableLocation && (options.keepAlive || idleCoordinators.has(reusableLocation))
+      ? reusableLocation
       : undefined;
   const before = poolLocation ? readCoordinatorIdentity(poolLocation) : undefined;
   const idle = poolLocation ? takeIdleCoordinator(poolLocation) : undefined;
@@ -273,7 +277,7 @@ function tryAcquireSqliteCoordinator(
   }
   let released = false;
   return {
-    release: () => {
+    release: (releaseOptions) => {
       if (released) {
         return;
       }
@@ -288,7 +292,13 @@ function tryAcquireSqliteCoordinator(
         errors.push(error);
       }
       let retained = false;
-      if (errors.length === 0 && poolLocation && identity) {
+      if (
+        errors.length === 0 &&
+        options.keepAlive &&
+        releaseOptions?.keepAlive !== false &&
+        poolLocation &&
+        identity
+      ) {
         try {
           retained = retainIdleCoordinator(poolLocation, database, identity);
         } catch (error) {
@@ -320,7 +330,7 @@ function tryAcquireSqliteCoordinator(
 export function tryAcquireExclusiveSqliteCoordinator(
   location: string,
   options: { busyTimeoutMs?: number; keepAlive?: boolean } = {},
-): { release: () => void } | null {
+): { release: (options?: { keepAlive?: false }) => void } | null {
   return tryAcquireSqliteCoordinator(location, "exclusive", options);
 }
 

--- a/src/infra/state-database-coordinator.ts
+++ b/src/infra/state-database-coordinator.ts
@@ -198,7 +198,13 @@ export function acquireStateDatabaseCoordinator(params: CoordinatorOptions) {
     }
     writeScope.assertCurrent();
     // Authority callbacks can change paths; resolve again after their checks.
-    return acquireLifecycleCoordinator("state-lifecycle", params, keepAlive);
+    return acquireLifecycleCoordinator(
+      "state-lifecycle",
+      params,
+      params.keepAlive !== false &&
+        params.coordinatorPath === undefined &&
+        params.runtimeDirectory === undefined,
+    );
   } else if (heldCoordinators.has(handlesPath)) {
     throw new StateDatabaseCoordinatorContentionError("state-handles");
   }

--- a/src/infra/state-database-coordinator.ts
+++ b/src/infra/state-database-coordinator.ts
@@ -15,7 +15,11 @@ import {
 
 const heldCoordinators = new Map<
   string,
-  { coordinator: { release: () => void }; references: number }
+  {
+    coordinator: { release: (options?: { keepAlive?: false }) => void };
+    references: number;
+    keepAlive: boolean;
+  }
 >();
 
 type SourceReadScope = {
@@ -36,6 +40,7 @@ type CoordinatorOptions = {
   runtimeDirectory?: string;
   uid?: number;
   busyTimeoutMs?: number;
+  keepAlive?: boolean;
 };
 
 export class StateDatabaseCoordinatorContentionError extends SqliteCoordinatorError {
@@ -115,6 +120,7 @@ function acquireLifecycleCoordinator(
   const held = heldCoordinators.get(coordinatorPath);
   if (held) {
     held.references += 1;
+    held.keepAlive &&= keepAlive;
   } else {
     ensurePrivateSqliteCoordinatorDirectory(path.dirname(coordinatorPath), `${family} coordinator`);
     const coordinator = tryAcquireExclusiveSqliteCoordinator(coordinatorPath, {
@@ -124,7 +130,7 @@ function acquireLifecycleCoordinator(
     if (!coordinator) {
       throw new StateDatabaseCoordinatorContentionError(family);
     }
-    heldCoordinators.set(coordinatorPath, { coordinator, references: 1 });
+    heldCoordinators.set(coordinatorPath, { coordinator, references: 1, keepAlive });
   }
 
   let released = false;
@@ -145,7 +151,7 @@ function acquireLifecycleCoordinator(
       }
       heldCoordinators.delete(coordinatorPath);
       try {
-        current.coordinator.release();
+        current.coordinator.release(current.keepAlive ? undefined : { keepAlive: false });
       } catch (error) {
         throw new SqliteCoordinatorError(`failed to release ${family} coordinator`, error);
       }
@@ -173,7 +179,10 @@ export function retainHeldStateDatabaseCoordinator(databasePath: string) {
 export function acquireStateDatabaseCoordinator(params: CoordinatorOptions) {
   // Caller-owned locations must remain removable immediately after release,
   // including on Windows where an idle SQLite handle blocks unlink.
-  const keepAlive = params.coordinatorPath === undefined && params.runtimeDirectory === undefined;
+  const keepAlive =
+    params.keepAlive !== false &&
+    params.coordinatorPath === undefined &&
+    params.runtimeDirectory === undefined;
   // Lifecycle ownership is reentrant for nested transactions. File publication
   // is not: even this process must refuse before ownership probes touch SQLite.
   const base = resolveLifecycleCoordinatorBase({
@@ -189,11 +198,7 @@ export function acquireStateDatabaseCoordinator(params: CoordinatorOptions) {
     }
     writeScope.assertCurrent();
     // Authority callbacks can change paths; resolve again after their checks.
-    return acquireLifecycleCoordinator(
-      "state-lifecycle",
-      params,
-      params.coordinatorPath === undefined && params.runtimeDirectory === undefined,
-    );
+    return acquireLifecycleCoordinator("state-lifecycle", params, keepAlive);
   } else if (heldCoordinators.has(handlesPath)) {
     throw new StateDatabaseCoordinatorContentionError("state-handles");
   }

--- a/src/state/claw-package-adoption.test.ts
+++ b/src/state/claw-package-adoption.test.ts
@@ -1,6 +1,7 @@
 import { writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
+import { runNodeScript } from "../../test/helpers/run-node-script.js";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { applyClawPackageRemovals, planClawPackageRemovals } from "../claws/package-remove.js";
 import {
@@ -9,15 +10,17 @@ import {
   readClawPackageRefs,
 } from "../claws/provenance.js";
 import type { ClawAddPlan } from "../claws/types.js";
+import { createNodeEvalArgs } from "../test-utils/node-process.js";
 import { markClawPackageIndependentlyOwned } from "./claw-package-adoption.js";
-import {
-  acquireClawPackageLifecycleLease,
-  withClawPackageLifecycleLease,
-} from "./claw-package-lifecycle-lease.js";
+import { acquireClawPackageLifecycleLease } from "./claw-package-lifecycle-lease.js";
 import { closeOpenClawStateDatabaseForTest } from "./openclaw-state-db.js";
 
-afterEach(() => closeOpenClawStateDatabaseForTest());
-const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+const tempDirs = useAutoCleanupTempDirTracker((cleanup) => {
+  afterEach(() => {
+    closeOpenClawStateDatabaseForTest();
+    cleanup();
+  });
+});
 
 const packageIntegrity = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
 
@@ -250,26 +253,24 @@ describe("Claw package independent adoption", () => {
   it("releases a package lease when process exit bypasses async cleanup", async () => {
     const env = { OPENCLAW_STATE_DIR: tempDirs.make("claw-exit-lease-") };
     const artifact = { kind: "plugin", source: "clawhub", ref: "@acme/audit" } as const;
-    const existingExitListeners = new Set(process.listeners("exit"));
-
-    await expect(
-      withClawPackageLifecycleLease(
-        artifact,
-        async () => {
-          const exitCleanup = process
-            .listeners("exit")
-            .find((listener) => !existingExitListeners.has(listener));
-          expect(exitCleanup).toBeTypeOf("function");
-          exitCleanup?.(1);
-          throw new Error("simulated process exit");
-        },
-        { env, required: true },
+    const moduleUrl = new URL("./claw-package-lifecycle-lease.ts", import.meta.url).href;
+    const result = await runNodeScript(
+      createNodeEvalArgs(
+        `
+          import { withClawPackageLifecycleLease } from ${JSON.stringify(moduleUrl)};
+          await withClawPackageLifecycleLease(
+            ${JSON.stringify(artifact)},
+            async () => { process.exit(23); },
+            { required: true },
+          );
+        `,
+        { imports: ["tsx"] },
       ),
-    ).rejects.toThrow("simulated process exit");
-
-    expect(
-      process.listeners("exit").filter((listener) => !existingExitListeners.has(listener)),
-    ).toEqual([]);
+      { ...process.env, ...env },
+      60_000,
+    );
+    expect(result.error).toBeUndefined();
+    expect(result.status, result.stderr).toBe(23);
     const nextLease = acquireClawPackageLifecycleLease(artifact, { env, required: true });
     expect(nextLease).not.toBeNull();
     nextLease?.release();

--- a/src/state/openclaw-state-db-cache.ts
+++ b/src/state/openclaw-state-db-cache.ts
@@ -378,6 +378,9 @@ function retireOpenClawStateDatabaseHandle(
   const coordinator = acquireStateDatabaseCoordinator({
     databasePath: database.path,
     busyTimeoutMs,
+    // Retirement releases physical custody, including an idle coordinator that
+    // would otherwise keep retired database paths or relocated Windows homes undeletable.
+    keepAlive: false,
   });
   runWithSqliteCoordinator(coordinator, "state database retirement", () => {
     // Refused acquisition leaves both cache and physical ownership untouched.

--- a/src/state/openclaw-state-db-cache.ts
+++ b/src/state/openclaw-state-db-cache.ts
@@ -379,7 +379,7 @@ function retireOpenClawStateDatabaseHandle(
     databasePath: database.path,
     busyTimeoutMs,
     // Retirement releases physical custody, including an idle coordinator that
-    // would otherwise keep retired database paths or relocated Windows homes undeletable.
+    // would otherwise keep temporary or relocated Windows homes undeletable.
     keepAlive: false,
   });
   runWithSqliteCoordinator(coordinator, "state database retirement", () => {

--- a/src/state/openclaw-state-db.coordinator.test.ts
+++ b/src/state/openclaw-state-db.coordinator.test.ts
@@ -3,9 +3,11 @@ import { createHash } from "node:crypto";
 import { once } from "node:events";
 import fs from "node:fs";
 import path from "node:path";
+import type { DatabaseSync } from "node:sqlite";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { stopChildProcess } from "../../test/helpers/stop-child-process.js";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { requireNodeSqlite } from "../infra/node-sqlite.js";
 import {
   acquireStateDatabaseCoordinator,
   acquireStateDatabaseHandleExclusion,
@@ -88,6 +90,70 @@ function sqliteBytes(databasePath: string) {
 }
 
 describe("shared-state transaction lifecycle participation", () => {
+  it.each(["idle", "held"] as const)(
+    "closes the %s retirement coordinator only after its last owner releases",
+    (custody) => {
+      const root = tempDirs.make("openclaw-state-retirement-custody-");
+      const database = openOpenClawStateDatabase({ path: path.join(root, "openclaw.sqlite") });
+      const sqlite = requireNodeSqlite();
+      const observed = vi.spyOn(sqlite.DatabaseSync.prototype, "exec");
+      let coordinatorDatabase: DatabaseSync | undefined;
+      let coordinatorPath: string | undefined;
+      try {
+        const warm = acquireStateDatabaseCoordinator({ databasePath: database.path });
+        coordinatorPath = warm.path;
+        const connections = new Set(
+          observed.mock.contexts.filter((context) => context instanceof sqlite.DatabaseSync),
+        );
+        expect(connections.size).toBe(1);
+        coordinatorDatabase = connections.values().next().value;
+        warm.release();
+      } finally {
+        observed.mockRestore();
+      }
+      if (!coordinatorDatabase || !coordinatorPath) {
+        throw new Error("Warm state coordinator did not expose its native connection");
+      }
+      const unrelated = acquireStateDatabaseCoordinator({
+        databasePath: path.join(root, "unrelated.sqlite"),
+        runtimeDirectory: root,
+      });
+      const peer = new sqlite.DatabaseSync(unrelated.path);
+      const outer =
+        custody === "held"
+          ? acquireStateDatabaseCoordinator({ databasePath: database.path })
+          : undefined;
+      const samePathPeer = outer ? new sqlite.DatabaseSync(coordinatorPath) : undefined;
+      try {
+        expect(coordinatorDatabase.isOpen).toBe(true);
+        expect(closeOpenClawStateDatabaseByPath(database.path)).toBe(true);
+        expect(database.db.isOpen).toBe(false);
+        if (outer) {
+          expect(coordinatorDatabase.isTransaction).toBe(true);
+          expect(() => samePathPeer?.exec("BEGIN EXCLUSIVE")).toThrow(/locked/);
+          outer.release();
+          samePathPeer?.exec("BEGIN EXCLUSIVE; ROLLBACK");
+          samePathPeer?.close();
+        }
+        expect(coordinatorDatabase.isOpen).toBe(false);
+        fs.unlinkSync(coordinatorPath);
+        expect(() => peer.exec("BEGIN EXCLUSIVE")).toThrow(/locked/);
+        unrelated.release();
+        peer.exec("BEGIN EXCLUSIVE; ROLLBACK");
+      } finally {
+        outer?.release();
+        if (samePathPeer?.isOpen) {
+          samePathPeer.close();
+        }
+        unrelated.release();
+        peer.close();
+        if (coordinatorDatabase.isOpen) {
+          coordinatorDatabase.close();
+        }
+      }
+    },
+  );
+
   it.each(
     ["path", "all"].flatMap((scope) =>
       ["cached", "retained"].map((custody) => ({ scope, custody })),


### PR DESCRIPTION
Related: #145634

## What Problem This Solves

Resolves a problem where Windows cleanup can fail after explicit state shutdown because a pooled coordinator handle remains open. In the Gateway archive-race fixture, removing its temporary home stalls on the coordinator lock file and times out after 120 seconds.

## Why This Change Was Made

Explicit state retirement now consumes and closes its idle coordinator through the existing acquisition and release owner. Active same-process owners retain their lock until the final normal release, and pooling eligibility is recalculated after an authority callback can select a caller-owned path.

The package-exit regression now exercises an actual child process exit and required lease reacquisition, replacing a test-order-dependent choice of process exit listener. Its fixture closes state before deleting the directory.

## User Impact

Explicit retirement releases idle coordinator resources; caller-owned runtime locations and temporary or relocated homes can be removed once all active owners release. Ordinary writes retain their existing idle coordinator reuse, and active same-path or unrelated owners keep their locks.

## Evidence

- Both idle/held retirement regressions fail on the original source because the native coordinator remains open, then pass with the fix. Active same-path and unrelated peers stay excluded until their owning releases.
- All three warm-destination callback cases fail before the callback repair and pass afterward: `runtimeDirectory`, `coordinatorPath`, and `keepAlive`. They now extend the existing idle-eligibility test; its final suite passed 15 tests with three existing platform skips.
- Shared-state retirement (13 tests), package adoption (8 tests), and the related coordinator suites passed. Existing platform skips were preserved; overlapping reruns are not added to these counts.
- The original, unchanged Gateway test, `retries Gateway visitation when a peer archives after async restoration`, passed on Windows with Node 26.8.2 in 11.129 seconds under its existing 120-second budget, including all body assertions and fixture cleanup.
- The child-exit lease test passed in 2.617 seconds. Temporarily omitting exit registration makes it fail on required reacquisition after the child reaches its expected exit code 23; the mutation was restored before validation.
- Core production, state/session test, and infra test type graphs; scoped type-aware lint; formatting; and transaction/schema guards passed. Earlier full-source conflict-marker and ratchet guards passed before the callback/test follow-up.
- Initial independent P0–P2 review and fresh independent review of the callback/test delta both passed. The delta was reviewed in a task-owned Linux checkout with a byte-identical patch after Windows source-snapshot memory failures. Only a retirement-comment wording correction followed review; the reviewed production and test bytes remain unchanged.

Exact-head hosted CI remains the landing gate. No schema, config, data migration, or transaction-boundary change is involved.
