### PR TITLE
fix(backup): preserve cyclic symbolic links during archive creation

### DIFF
--- a/docs/cli/backup.md
+++ b/docs/cli/backup.md
@@ -96,7 +96,7 @@ SQLite snapshots, Git backups, and support exports. Selecting a containing or
 nested workspace does not override this rule. Selecting a capture file as config
 or as a database backup source refuses the backup. Other states' captures are
 recognized by the exact sibling layout: `<owner>/` beside
-`<owner>.update-captures/`, with an existing real owner directory. Unrelated similarly named workspace
+`<owner>.update-captures/`, with an existing owner directory, including a resolved directory link. Unrelated similarly named workspace
 directories remain included; a suffix alone does not establish ownership.
 
 Marked private directories remain excluded after their owner is removed or
@@ -104,19 +104,18 @@ renamed, or the marked directory is moved or copied. Keep the marker with the
 whole directory. Files copied out without it are not recognized by this rule.
 The fixed `.openclaw-private-update-capture` file contains exactly
 `openclaw-private-update-capture-v1` followed by a newline. Export checks inspect
-each real path component with `lstat`, stopping at the first symbolic link.
-They do not resolve that link or inspect its target to decide whether to archive
-the link entry. Valid, malformed, and unreadable markers in a link target do not
-hide the link or refuse its backup. Its original target text is preserved, and
-its target contents are not copied through the link.
+each path component with `lstat` and resolve symbolic links with cycle and depth
+limits. A resolved target's real ancestors receive the same marker checks as
+the selected path. Links to marked directories are omitted; malformed or
+unreadable real markers refuse export. Loops and dangling links have no resolved
+target and remain link entries, unless a real selected ancestor excludes them.
+Ordinary unmarked links keep their original target text without copying target
+contents through the link.
 
-A marker on a real ancestor before the link still excludes the selection. A
-malformed or unreadable real marker refuses export; a support bundle reports
-the refusal without including that input. Explicitly selected file contents,
-such as configuration, databases, and support inputs, require the same privacy
-check on both the selected path and its actual read path. Separately selected
-workspace contents also receive their own check. These checks do not parse
-workspace manifests or scan for other state roots.
+Explicit content exports, including SQLite snapshots, check the selected archive
+path and actual content source through the same classifier. A support bundle
+reports refused inputs without including their contents. These checks do not
+parse workspace manifests or scan for other state roots.
 
 The marker is an exclusion instruction, not proof of artifact ownership or
 permission to reopen, adopt, or delete it. Producers must durably write it before

--- a/docs/cli/backup.md
+++ b/docs/cli/backup.md
@@ -96,8 +96,7 @@ SQLite snapshots, Git backups, and support exports. Selecting a containing or
 nested workspace does not override this rule. Selecting a capture file as config
 or as a database backup source refuses the backup. Other states' captures are
 recognized by the exact sibling layout: `<owner>/` beside
-`<owner>.update-captures/`, with an existing owner directory. Canonical path
-aliases receive the same protection. Unrelated similarly named workspace
+`<owner>.update-captures/`, with an existing real owner directory. Unrelated similarly named workspace
 directories remain included; a suffix alone does not establish ownership.
 
 Marked private directories remain excluded after their owner is removed or
@@ -105,10 +104,19 @@ renamed, or the marked directory is moved or copied. Keep the marker with the
 whole directory. Files copied out without it are not recognized by this rule.
 The fixed `.openclaw-private-update-capture` file contains exactly
 `openclaw-private-update-capture-v1` followed by a newline. Export checks inspect
-only selected paths and their ancestors, including canonical aliases. They do
-not parse workspace manifests or scan for other state roots. A malformed or
-unreadable marker refuses export of that selection; a support bundle reports
-the refusal without including that input.
+each real path component with `lstat`, stopping at the first symbolic link.
+They do not resolve that link or inspect its target to decide whether to archive
+the link entry. Valid, malformed, and unreadable markers in a link target do not
+hide the link or refuse its backup. Its original target text is preserved, and
+its target contents are not copied through the link.
+
+A marker on a real ancestor before the link still excludes the selection. A
+malformed or unreadable real marker refuses export; a support bundle reports
+the refusal without including that input. Explicitly selected file contents,
+such as configuration, databases, and support inputs, require the same privacy
+check on both the selected path and its actual read path. Separately selected
+workspace contents also receive their own check. These checks do not parse
+workspace manifests or scan for other state roots.
 
 The marker is an exclusion instruction, not proof of artifact ownership or
 permission to reopen, adopt, or delete it. Producers must durably write it before

--- a/src/commands/backup-capture-privacy.test.ts
+++ b/src/commands/backup-capture-privacy.test.ts
@@ -15,6 +15,7 @@ import { createTempHomeEnv, type TempHomeEnv } from "../test-utils/temp-home.js"
 import { backupGitCreateCommand } from "./backup-git.js";
 import { backupSqliteCreateCommand } from "./backup-sqlite.js";
 import { verifyBackupArchive } from "./backup-verify.js";
+import { backupCreateCommand } from "./backup.js";
 import { createTestRuntime } from "./test-runtime-config-helpers.js";
 
 describe("private update capture exclusion", () => {
@@ -232,8 +233,14 @@ describe("private update capture exclusion", () => {
     }
   });
 
-  it.each(["valid", "invalid with duplicate", "valid with duplicate"])(
-    "checks a %s lexical marker before deduplicating an outward workspace alias",
+  it.each([
+    "valid",
+    "invalid with duplicate",
+    "valid with duplicate",
+    "valid via alias",
+    "invalid via alias",
+  ])(
+    "backupCreateCommand respects the link-entry boundary for a %s outward workspace selection",
     async (mode) => {
       const outside = path.join(home.home, "unmarked-target");
       const marked = path.join(home.home, "marked-parent");
@@ -246,8 +253,13 @@ describe("private update capture exclusion", () => {
       await fs.writeFile(marker, markerBytes);
       const raw = path.join(outside, "outward.txt");
       await fs.writeFile(raw, "synthetic outward bytes");
-      const alias = path.join(marked, "workspace");
+      let alias = path.join(marked, "workspace");
       await fs.symlink(outside, alias, process.platform === "win32" ? "junction" : "dir");
+      if (mode.endsWith("via alias")) {
+        const markedAlias = path.join(home.home, "marked-alias");
+        await fs.symlink(marked, markedAlias, process.platform === "win32" ? "junction" : "dir");
+        alias = path.join(markedAlias, "workspace");
+      }
       await fs.writeFile(
         path.join(stateDir, "openclaw.json"),
         JSON.stringify({
@@ -266,13 +278,13 @@ describe("private update capture exclusion", () => {
         `${path.basename(home.home)}-outward.tar.gz`,
       );
       try {
-        if (mode.startsWith("invalid")) {
-          await expect(createBackupArchive({ output })).rejects.toThrow(
+        if (mode.startsWith("invalid") && !mode.endsWith("via alias")) {
+          await expect(backupCreateCommand(createTestRuntime(), { output })).rejects.toThrow(
             "Private update capture marker",
           );
           await expect(fs.stat(output)).rejects.toMatchObject({ code: "ENOENT" });
         } else {
-          const result = await createBackupArchive({ output });
+          const result = await backupCreateCommand(createTestRuntime(), { output });
           const entries: string[] = [];
           await tar.t({
             file: result.archivePath,
@@ -281,13 +293,15 @@ describe("private update capture exclusion", () => {
             },
           });
           expect(entries.some((entry) => entry.endsWith("/outward.txt"))).toBe(
-            mode.includes("duplicate"),
+            mode.includes("duplicate") || mode.endsWith("via alias"),
           );
           expect(entries.some((entry) => entry.endsWith("/healthy.txt"))).toBe(true);
           await verifyBackupArchive(result.archivePath);
-          expect(result.skipped).toContainEqual(
-            expect.objectContaining({ kind: "workspace", sourcePath: alias, reason: "private" }),
-          );
+          if (!mode.endsWith("via alias")) {
+            expect(result.skipped).toContainEqual(
+              expect.objectContaining({ kind: "workspace", sourcePath: alias, reason: "private" }),
+            );
+          }
         }
         expect(await fs.readFile(raw, "utf8")).toBe("synthetic outward bytes");
         expect(await fs.readFile(marker, "utf8")).toBe(markerBytes);

--- a/src/commands/backup-capture-privacy.test.ts
+++ b/src/commands/backup-capture-privacy.test.ts
@@ -13,6 +13,7 @@ import { OPENCLAW_STATE_SCHEMA_VERSION } from "../state/openclaw-state-db-contra
 import { OPENCLAW_STATE_SCHEMA_SQL } from "../state/openclaw-state-schema.js";
 import { createTempHomeEnv, type TempHomeEnv } from "../test-utils/temp-home.js";
 import { backupGitCreateCommand } from "./backup-git.js";
+import { backupRestoreCommand } from "./backup-restore.js";
 import { backupSqliteCreateCommand } from "./backup-sqlite.js";
 import { verifyBackupArchive } from "./backup-verify.js";
 import { backupCreateCommand } from "./backup.js";
@@ -80,7 +81,7 @@ describe("private update capture exclusion", () => {
     },
   );
 
-  it("excludes another state's paired capture root from a public archive", async () => {
+  it.each([false, true])("backupCreateCommand: linked capture owner=%s", async (linkedOwner) => {
     const otherState = path.join(home.home, "profile-b");
     const otherCapture = `${otherState}.update-captures`;
     const healthy = `${otherCapture}-notes`;
@@ -88,6 +89,14 @@ describe("private update capture exclusion", () => {
     const unowned = path.join(home.home, "research.update-captures");
     for (const directory of [otherState, path.join(otherCapture, "run"), healthy, unowned]) {
       await fs.mkdir(directory, { recursive: true });
+    }
+    if (linkedOwner) {
+      await fs.rename(otherState, otherState + "-target");
+      await fs.symlink(
+        otherState + "-target",
+        otherState,
+        process.platform === "win32" ? "junction" : "dir",
+      );
     }
     const privateFile = path.join(otherCapture, "run", "private-b.txt");
     await fs.writeFile(privateFile, "synthetic private B bytes");
@@ -105,7 +114,8 @@ describe("private update capture exclusion", () => {
       `${path.basename(home.home)}-cross-state.tar.gz`,
     );
     try {
-      const result = await createBackupArchive({ output });
+      const runtime = createTestRuntime();
+      const result = await backupCreateCommand(runtime, { output, verify: true });
       const entries: string[] = [];
       await tar.t({
         file: result.archivePath,
@@ -114,6 +124,23 @@ describe("private update capture exclusion", () => {
         },
       });
       await verifyBackupArchive(result.archivePath);
+      const restored = path.join(home.home, "restored-paired");
+      await backupRestoreCommand(runtime, { archive: result.archivePath, target: restored });
+      const workspace = result.assets.find((asset) => asset.kind === "workspace");
+      expect(workspace).toBeDefined();
+      if (workspace) {
+        await expect(
+          fs.stat(
+            path.join(
+              restored,
+              workspace.archivePath,
+              "profile-b.update-captures",
+              "run",
+              "private-b.txt",
+            ),
+          ),
+        ).rejects.toMatchObject({ code: "ENOENT" });
+      }
       expect(entries.some((entry) => entry.endsWith("/healthy-b.txt"))).toBe(true);
       expect(entries.some((entry) => entry.endsWith("/research.txt"))).toBe(true);
       expect(await fs.readFile(privateFile, "utf8")).toBe("synthetic private B bytes");
@@ -239,78 +266,70 @@ describe("private update capture exclusion", () => {
     "valid with duplicate",
     "valid via alias",
     "invalid via alias",
-  ])(
-    "backupCreateCommand respects the link-entry boundary for a %s outward workspace selection",
-    async (mode) => {
-      const outside = path.join(home.home, "unmarked-target");
-      const marked = path.join(home.home, "marked-parent");
-      await fs.mkdir(outside);
-      await fs.mkdir(marked);
-      const marker = path.join(marked, ".openclaw-private-update-capture");
-      const markerBytes = mode.startsWith("invalid")
-        ? "incomplete"
-        : "openclaw-private-update-capture-v1\n";
-      await fs.writeFile(marker, markerBytes);
-      const raw = path.join(outside, "outward.txt");
-      await fs.writeFile(raw, "synthetic outward bytes");
-      let alias = path.join(marked, "workspace");
-      await fs.symlink(outside, alias, process.platform === "win32" ? "junction" : "dir");
-      if (mode.endsWith("via alias")) {
-        const markedAlias = path.join(home.home, "marked-alias");
-        await fs.symlink(marked, markedAlias, process.platform === "win32" ? "junction" : "dir");
-        alias = path.join(markedAlias, "workspace");
-      }
-      await fs.writeFile(
-        path.join(stateDir, "openclaw.json"),
-        JSON.stringify({
-          agents: {
-            ownership: "explicit",
-            entries: {
-              main: { workspace: alias },
-              healthy: { workspace: `${captureRoot}-notes` },
-              ...(mode.includes("duplicate") ? { independent: { workspace: outside } } : {}),
-            },
+  ])("backupCreateCommand checks real and resolved ancestors for a %s workspace", async (mode) => {
+    const outside = path.join(home.home, "unmarked-target");
+    const marked = path.join(home.home, "marked-parent");
+    await fs.mkdir(outside);
+    await fs.mkdir(marked);
+    const marker = path.join(marked, ".openclaw-private-update-capture");
+    const markerBytes = mode.startsWith("invalid")
+      ? "incomplete"
+      : "openclaw-private-update-capture-v1\n";
+    await fs.writeFile(marker, markerBytes);
+    const raw = path.join(outside, "outward.txt");
+    await fs.writeFile(raw, "synthetic outward bytes");
+    let alias = path.join(marked, "workspace");
+    await fs.symlink(outside, alias, process.platform === "win32" ? "junction" : "dir");
+    if (mode.endsWith("via alias")) {
+      const markedAlias = path.join(home.home, "marked-alias");
+      await fs.symlink(marked, markedAlias, process.platform === "win32" ? "junction" : "dir");
+      alias = path.join(markedAlias, "workspace");
+    }
+    await fs.writeFile(
+      path.join(stateDir, "openclaw.json"),
+      JSON.stringify({
+        agents: {
+          ownership: "explicit",
+          entries: {
+            main: { workspace: alias },
+            healthy: { workspace: `${captureRoot}-notes` },
+            ...(mode.includes("duplicate") ? { independent: { workspace: outside } } : {}),
           },
-        }),
-      );
-      const output = path.join(
-        path.dirname(home.home),
-        `${path.basename(home.home)}-outward.tar.gz`,
-      );
-      try {
-        if (mode.startsWith("invalid") && !mode.endsWith("via alias")) {
-          await expect(backupCreateCommand(createTestRuntime(), { output })).rejects.toThrow(
-            "Private update capture marker",
-          );
-          await expect(fs.stat(output)).rejects.toMatchObject({ code: "ENOENT" });
-        } else {
-          const result = await backupCreateCommand(createTestRuntime(), { output });
-          const entries: string[] = [];
-          await tar.t({
-            file: result.archivePath,
-            onReadEntry: (entry) => {
-              entries.push(entry.path);
-            },
-          });
-          expect(entries.some((entry) => entry.endsWith("/outward.txt"))).toBe(
-            mode.includes("duplicate") || mode.endsWith("via alias"),
-          );
-          expect(entries.some((entry) => entry.endsWith("/healthy.txt"))).toBe(true);
-          await verifyBackupArchive(result.archivePath);
-          if (!mode.endsWith("via alias")) {
-            expect(result.skipped).toContainEqual(
-              expect.objectContaining({ kind: "workspace", sourcePath: alias, reason: "private" }),
-            );
-          }
-        }
-        expect(await fs.readFile(raw, "utf8")).toBe("synthetic outward bytes");
-        expect(await fs.readFile(marker, "utf8")).toBe(markerBytes);
-        expect(await fs.realpath(alias)).toBe(await fs.realpath(outside));
-      } finally {
-        await fs.rm(output, { force: true });
+        },
+      }),
+    );
+    const output = path.join(path.dirname(home.home), `${path.basename(home.home)}-outward.tar.gz`);
+    try {
+      if (mode.startsWith("invalid")) {
+        await expect(backupCreateCommand(createTestRuntime(), { output })).rejects.toThrow(
+          "Private update capture marker",
+        );
+        await expect(fs.stat(output)).rejects.toMatchObject({ code: "ENOENT" });
+      } else {
+        const result = await backupCreateCommand(createTestRuntime(), { output });
+        const entries: string[] = [];
+        await tar.t({
+          file: result.archivePath,
+          onReadEntry: (entry) => {
+            entries.push(entry.path);
+          },
+        });
+        expect(entries.some((entry) => entry.endsWith("/outward.txt"))).toBe(
+          mode.includes("duplicate"),
+        );
+        expect(entries.some((entry) => entry.endsWith("/healthy.txt"))).toBe(true);
+        await verifyBackupArchive(result.archivePath);
+        expect(result.skipped).toContainEqual(
+          expect.objectContaining({ kind: "workspace", sourcePath: alias, reason: "private" }),
+        );
       }
-    },
-  );
+      expect(await fs.readFile(raw, "utf8")).toBe("synthetic outward bytes");
+      expect(await fs.readFile(marker, "utf8")).toBe(markerBytes);
+      expect(await fs.realpath(alias)).toBe(await fs.realpath(outside));
+    } finally {
+      await fs.rm(output, { force: true });
+    }
+  });
 
   it.each(["unpaired", "current", "other"])(
     "refuses publication for an invalid privacy marker in a %s capture directory",

--- a/src/commands/backup-capture-privacy.test.ts
+++ b/src/commands/backup-capture-privacy.test.ts
@@ -150,6 +150,27 @@ describe("private update capture exclusion", () => {
     }
   });
 
+  it.each([false, true])(
+    "backupCreateCommand: linked capture root, onlyConfig=%s",
+    async (onlyConfig) => {
+      const owner = path.join(home.home, "other-state");
+      const target = path.join(home.home, "legacy-data");
+      await fs.mkdir(owner);
+      await fs.mkdir(target);
+      const configPath = path.join(target, "config.json");
+      await fs.writeFile(configPath, "{}");
+      const captureAlias = owner + ".update-captures";
+      await fs.symlink(target, captureAlias, process.platform === "win32" ? "junction" : "dir");
+      vi.stubEnv("OPENCLAW_CONFIG_PATH", path.join(captureAlias, "config.json"));
+      const output = path.join(home.home, "capture-alias.tar.gz");
+      await expect(
+        backupCreateCommand(createTestRuntime(), { output, onlyConfig, verify: true }),
+      ).rejects.toThrow("Private update captures are excluded from backups and support exports.");
+      await expect(fs.stat(output)).rejects.toMatchObject({ code: "ENOENT" });
+      expect(await fs.readFile(configPath, "utf8")).toBe("{}");
+    },
+  );
+
   it.each(["parent", "nested alias"])(
     "excludes marked orphaned and relocated artifacts from a %s workspace",
     async (selection) => {

--- a/src/infra/backup-create.test.ts
+++ b/src/infra/backup-create.test.ts
@@ -3375,7 +3375,7 @@ describe("createBackupArchive", () => {
       marker,
     })),
   ])(
-    "backupCreateCommand preserves and reports $label links through backupRestoreCommand",
+    "backupCreateCommand applies privacy to $label links through backupRestoreCommand",
     async ({ relative, targetExists, directory, internal, cyclic, marker }) => {
       await withOpenClawTestState(
         { layout: "state-only", prefix: "openclaw-backup-symbolic-link-", scenario: "minimal" },
@@ -3402,12 +3402,35 @@ describe("createBackupArchive", () => {
             await fs.symlink("ordinary-link", targetPath);
           }
           const runtime = createTestRuntime();
-          const result = await backupCreateCommand(runtime, {
-            output: state.path("backup.tar.gz"),
-            includeWorkspace: false,
-            verify: true,
-          });
+          const output = state.path("backup.tar.gz");
+          const create = () =>
+            backupCreateCommand(runtime, { output, includeWorkspace: false, verify: true });
+          if (marker && marker !== "valid") {
+            await expect(create()).rejects.toThrow("Private update capture marker");
+            await expect(fs.stat(output)).rejects.toMatchObject({ code: "ENOENT" });
+            return;
+          }
+          const result = await create();
           const entries = await listArchiveEntryDetails(result.archivePath);
+          if (marker) {
+            expect(
+              entries.some(
+                (entry) =>
+                  entry.path.endsWith("/ordinary-link") || entry.path.includes("/outside-target"),
+              ),
+            ).toBe(false);
+            expect(result.externalSymbolicLinks ?? []).toEqual([]);
+            const restored = state.path("restored");
+            await backupRestoreCommand(runtime, { archive: result.archivePath, target: restored });
+            const asset = expectDefined(
+              result.assets.find((asset) => asset.kind === "state"),
+              "state asset",
+            );
+            await expect(
+              fs.lstat(path.join(restored, asset.archivePath, "ordinary-link")),
+            ).rejects.toMatchObject({ code: "ENOENT" });
+            return;
+          }
           const link = expectDefined(
             entries.find((entry) => entry.path.endsWith("/state/ordinary-link")),
             "archived ordinary link",
@@ -4014,7 +4037,7 @@ describe("createBackupArchive", () => {
             });
           if (privateTarget) {
             await expect(create()).rejects.toThrow(
-              "Private update captures are excluded from backups and support exports.",
+              "SQLite hardlink journal owner may be outside the backup inventory",
             );
             expect(await fs.readdir(outputDir)).toEqual([]);
             expect(db.prepare("SELECT value FROM durable_state WHERE id = 1").get()).toEqual({

--- a/src/infra/backup-create.test.ts
+++ b/src/infra/backup-create.test.ts
@@ -3423,7 +3423,7 @@ describe("createBackupArchive", () => {
             const restored = state.path("restored");
             await backupRestoreCommand(runtime, { archive: result.archivePath, target: restored });
             const asset = expectDefined(
-              result.assets.find((asset) => asset.kind === "state"),
+              result.assets.find((candidate) => candidate.kind === "state"),
               "state asset",
             );
             await expect(

--- a/src/infra/backup-create.test.ts
+++ b/src/infra/backup-create.test.ts
@@ -3314,7 +3314,15 @@ describe("createBackupArchive", () => {
     );
   });
 
-  it.runIf(process.platform !== "win32").each([
+  it.runIf(process.platform !== "win32").each<{
+    label: string;
+    relative: boolean;
+    targetExists: boolean;
+    directory: boolean;
+    internal: boolean;
+    cyclic?: boolean;
+    marker?: "valid" | "malformed" | "unreadable";
+  }>([
     {
       label: "absolute file",
       relative: false,
@@ -3358,9 +3366,17 @@ describe("createBackupArchive", () => {
       internal: true,
       cyclic: true,
     },
+    ...(["valid", "malformed", "unreadable"] as const).map((marker) => ({
+      label: `${marker} marked directory`,
+      relative: false,
+      targetExists: true,
+      directory: true,
+      internal: false,
+      marker,
+    })),
   ])(
     "backupCreateCommand preserves and reports $label links through backupRestoreCommand",
-    async ({ relative, targetExists, directory, internal, cyclic }) => {
+    async ({ relative, targetExists, directory, internal, cyclic, marker }) => {
       await withOpenClawTestState(
         { layout: "state-only", prefix: "openclaw-backup-symbolic-link-", scenario: "minimal" },
         async (state) => {
@@ -3370,6 +3386,13 @@ describe("createBackupArchive", () => {
           if (directory) {
             await fs.mkdir(targetPath);
             await fs.writeFile(path.join(targetPath, "external.txt"), "outside\n");
+            if (marker) {
+              await fs.writeFile(
+                path.join(targetPath, ".openclaw-private-update-capture"),
+                marker === "malformed" ? "invalid" : "openclaw-private-update-capture-v1\n",
+                { mode: marker === "unreadable" ? 0o000 : 0o600 },
+              );
+            }
           } else if (targetExists) {
             await fs.writeFile(targetPath, "target\n");
           }

--- a/src/infra/backup-create.test.ts
+++ b/src/infra/backup-create.test.ts
@@ -3939,7 +3939,7 @@ describe("createBackupArchive", () => {
     );
   });
 
-  it("sanitizes every in-state symlink and hardlink alias of a canonical agent SQLite DB", async () => {
+  it.each([false, true])("backupCreateCommand: private agent DB=%s", async (privateTarget) => {
     if (process.platform === "win32") {
       return;
     }
@@ -3954,10 +3954,18 @@ describe("createBackupArchive", () => {
         const outputDir = state.path("backups");
         const extractDir = state.path("extract");
         const agentDir = state.statePath("agents", "main", "agent");
-        const backingDbPath = path.join(agentDir, "backing-agent.sqlite");
+        const backingDir = privateTarget ? state.path("private-agent-db") : agentDir;
+        const backingDbPath = path.join(backingDir, "backing-agent.sqlite");
         const linkedDbPath = path.join(agentDir, "openclaw-agent.sqlite");
         const hardlinkedDbPath = state.statePath("plugins", "dedicated", "._agent-alias.sqlite");
         await fs.mkdir(agentDir, { recursive: true });
+        await fs.mkdir(backingDir, { recursive: true });
+        if (privateTarget) {
+          await fs.writeFile(
+            path.join(backingDir, ".openclaw-private-update-capture"),
+            "openclaw-private-update-capture-v1\n",
+          );
+        }
         await fs.mkdir(path.dirname(hardlinkedDbPath), { recursive: true });
         await fs.mkdir(outputDir, { recursive: true });
         await fs.mkdir(extractDir, { recursive: true });
@@ -3993,14 +4001,28 @@ describe("createBackupArchive", () => {
         expect((await fs.stat(hardlinkedDbPath)).nlink).toBeGreaterThan(1);
         expect((await fs.stat(`${backingDbPath}-wal`)).size).toBeGreaterThan(0);
         await expect(fs.stat(`${linkedDbPath}-wal`)).rejects.toMatchObject({ code: "ENOENT" });
-        await expect(fs.stat(`${hardlinkedDbPath}-wal`)).rejects.toMatchObject({ code: "ENOENT" });
+        await expect(fs.stat(`${hardlinkedDbPath}-wal`)).rejects.toMatchObject({
+          code: "ENOENT",
+        });
 
         try {
-          const result = await createBackupArchive({
-            output: outputDir,
-            includeWorkspace: false,
-            nowMs: Date.UTC(2026, 4, 9, 8, 34, 40),
-          });
+          const create = () =>
+            backupCreateCommand(createTestRuntime(), {
+              output: outputDir,
+              includeWorkspace: false,
+              verify: true,
+            });
+          if (privateTarget) {
+            await expect(create()).rejects.toThrow(
+              "Private update captures are excluded from backups and support exports.",
+            );
+            expect(await fs.readdir(outputDir)).toEqual([]);
+            expect(db.prepare("SELECT value FROM durable_state WHERE id = 1").get()).toEqual({
+              value: "committed-in-wal",
+            });
+            return;
+          }
+          const result = await create();
           const entries = await listArchiveEntryDetails(result.archivePath);
           const archivedDbEntries = entries.filter(
             (entry) =>

--- a/src/infra/backup-create.test.ts
+++ b/src/infra/backup-create.test.ts
@@ -3350,9 +3350,17 @@ describe("createBackupArchive", () => {
       directory: false,
       internal: true,
     },
+    {
+      label: "cyclic relative",
+      relative: true,
+      targetExists: false,
+      directory: false,
+      internal: true,
+      cyclic: true,
+    },
   ])(
     "backupCreateCommand preserves and reports $label links through backupRestoreCommand",
-    async ({ relative, targetExists, directory, internal }) => {
+    async ({ relative, targetExists, directory, internal, cyclic }) => {
       await withOpenClawTestState(
         { layout: "state-only", prefix: "openclaw-backup-symbolic-link-", scenario: "minimal" },
         async (state) => {
@@ -3367,6 +3375,9 @@ describe("createBackupArchive", () => {
           }
           const linkpath = relative ? path.relative(state.stateDir, targetPath) : targetPath;
           await fs.symlink(linkpath, state.statePath("ordinary-link"));
+          if (cyclic) {
+            await fs.symlink("ordinary-link", targetPath);
+          }
           const runtime = createTestRuntime();
           const result = await backupCreateCommand(runtime, {
             output: state.path("backup.tar.gz"),
@@ -3392,7 +3403,11 @@ describe("createBackupArchive", () => {
           await backupRestoreCommand(runtime, { archive: result.archivePath, target: restored });
           const restoredLink = path.join(restored, link.path);
           expect(await fs.readlink(restoredLink)).toBe(linkpath);
-          if (internal) {
+          if (cyclic) {
+            expect(await fs.readlink(path.join(path.dirname(restoredLink), "target.txt"))).toBe(
+              "ordinary-link",
+            );
+          } else if (internal) {
             expect(await fs.readFile(restoredLink, "utf8")).toBe("target\n");
           } else if (!targetExists) {
             await expect(fs.stat(restoredLink)).rejects.toMatchObject({ code: "ENOENT" });

--- a/src/infra/backup-sqlite-snapshot.ts
+++ b/src/infra/backup-sqlite-snapshot.ts
@@ -35,6 +35,7 @@ import {
   rewriteLegacyAuditBackupCheckpoints,
   type LegacyAuditBackupSnapshot,
 } from "./state-migrations.audit-backup.js";
+import { assertNotUpdateCapturePath } from "./update-capture-paths.js";
 
 type SqliteBackupAsset = {
   sourcePath: string;
@@ -358,6 +359,8 @@ export async function createBackupSqliteSnapshotPlan(params: {
     const genericGroup = genericGroups.get(archiveSourcePath);
     const sourceDatabasePath =
       canonicalSource?.sourcePath ?? genericGroup?.sourcePath ?? archiveSourcePath;
+    assertNotUpdateCapturePath(archiveSourcePath, params.inventory.stateDir);
+    assertNotUpdateCapturePath(sourceDatabasePath, params.inventory.stateDir);
     const sourcePath = path.join(params.tempDir, `openclaw-state-db-${snapshots.length}.sqlite`);
     try {
       const capture = () =>

--- a/src/infra/update-capture-paths.test.ts
+++ b/src/infra/update-capture-paths.test.ts
@@ -115,4 +115,32 @@ describe("private capture marker admission", () => {
     );
     expect(replaced).toBe(true);
   });
+  it.each(["hop/../raw.txt", "hop/../../hop/../raw.txt"])(
+    "assertNotUpdateCapturePath resolves target components in order: %s",
+    (target) => {
+      const privateDir = path.join(root, "private");
+      fs.mkdirSync(path.join(privateDir, "child"), { recursive: true });
+      fs.writeFileSync(path.join(privateDir, markerName), markerContent);
+      fs.writeFileSync(path.join(privateDir, "raw.txt"), "private bytes");
+      fs.symlinkSync(
+        path.join(privateDir, "child"),
+        path.join(root, "hop"),
+        process.platform === "win32" ? "junction" : "dir",
+      );
+      const alias = path.join(root, "alias");
+      fs.symlinkSync(target, alias);
+      expect(() => assertNotUpdateCapturePath(alias, stateDir)).toThrow(
+        "Private update captures are excluded",
+      );
+    },
+  );
+  it("assertNotUpdateCapturePath preserves an unresolved target with a trailing directory separator", () => {
+    const privateDir = path.join(root, "private");
+    fs.mkdirSync(privateDir);
+    fs.writeFileSync(path.join(privateDir, markerName), markerContent);
+    fs.writeFileSync(path.join(privateDir, "raw.txt"), "private bytes");
+    const alias = path.join(root, "alias");
+    fs.symlinkSync("private/raw.txt/", alias);
+    expect(() => assertNotUpdateCapturePath(alias, stateDir)).not.toThrow();
+  });
 });

--- a/src/infra/update-capture-paths.ts
+++ b/src/infra/update-capture-paths.ts
@@ -70,17 +70,17 @@ type CapturePath = { path: string; directory: boolean };
 
 function resolveCapturePath(
   sourcePath: string,
-  directories = new Set<string>(),
+  entries = new Map<string, boolean>(),
 ): CapturePath | undefined {
   const activeLinks = new Set<string>();
   function resolve(
     candidate: string,
-    ancestors: Set<string>,
+    inspected: Map<string, boolean>,
     depth: number,
   ): CapturePath | undefined {
     const root = path.parse(candidate).root;
     let current: CapturePath = { path: root, directory: true };
-    ancestors.add(root);
+    inspected.set(root, true);
     const separators = path.sep === "\\" ? /[\\/]/ : /\//;
     for (const component of candidate.slice(root.length).split(separators)) {
       if (!current.directory) {
@@ -103,38 +103,37 @@ function resolveCapturePath(
         });
       }
       if (stat.isSymbolicLink()) {
+        inspected.set(entry, false);
         if (activeLinks.has(entry) || depth === 40) {
           return undefined;
         }
         activeLinks.add(entry);
         const link = fs.readlinkSync(entry);
-        const targetAncestors = new Set<string>();
+        const targetEntries = new Map<string, boolean>();
         // Keep target components in filesystem order: an earlier link changes what '..' means.
         const target = resolve(
           path.isAbsolute(link) ? link : current.path + path.sep + link,
-          targetAncestors,
+          targetEntries,
           depth + 1,
         );
         activeLinks.delete(entry);
         if (!target) {
           return undefined;
         }
-        for (const ancestor of targetAncestors) {
-          ancestors.add(ancestor);
+        for (const [targetPath, realDirectory] of targetEntries) {
+          inspected.set(targetPath, realDirectory);
         }
         current = target;
       } else {
         current = { path: entry, directory: stat.isDirectory() };
-        if (current.directory) {
-          ancestors.add(entry);
-        }
+        inspected.set(entry, current.directory);
       }
     }
     return current;
   }
   return resolve(
     path.isAbsolute(sourcePath) ? sourcePath : process.cwd() + path.sep + sourcePath,
-    directories,
+    entries,
     0,
   );
 }
@@ -150,18 +149,20 @@ function isPairedCapturePath(directory: string): boolean {
 
 /** One admission decision over real ancestors and safely resolved link targets. */
 export function isUpdateCapturePath(sourcePath: string, stateDir: string): boolean {
-  const ancestors = new Set<string>();
-  resolveCapturePath(sourcePath, ancestors);
+  const entries = new Map<string, boolean>();
+  resolveCapturePath(sourcePath, entries);
   const captureRoot = resolveUpdateCaptureRoot(stateDir);
   const resolvedRoot = resolveCapturePath(captureRoot)?.path;
   let captured = false;
-  for (const ancestor of ancestors) {
-    // A prior exclusion must not hide an invalid marker on another real ancestor.
-    captured = hasPrivacyMarker(ancestor) || captured;
+  for (const [entryPath, realDirectory] of entries) {
+    // Logical names establish legacy ownership; only real directories can carry markers.
+    if (realDirectory) {
+      captured = hasPrivacyMarker(entryPath) || captured;
+    }
     captured =
-      ancestor === captureRoot ||
-      ancestor === resolvedRoot ||
-      isPairedCapturePath(ancestor) ||
+      entryPath === captureRoot ||
+      entryPath === resolvedRoot ||
+      isPairedCapturePath(entryPath) ||
       captured;
   }
   return captured;

--- a/src/infra/update-capture-paths.ts
+++ b/src/infra/update-capture-paths.ts
@@ -5,7 +5,6 @@ import { openRootFileSync, readFileDescriptorBoundedSync } from "./boundary-file
 import { resolvePathViaExistingAncestorSync } from "./boundary-path.js";
 import { hasErrnoCode } from "./errno.js";
 import { sameFileMutationFingerprint } from "./file-descriptor.js";
-import { isPathInside } from "./path-guards.js";
 import {
   UPDATE_CAPTURE_PRIVACY_MARKER,
   UPDATE_CAPTURE_PRIVACY_MARKER_CONTENT,
@@ -17,9 +16,6 @@ function hasPrivacyMarker(directory: string): boolean {
   const markerPath = path.join(directory, UPDATE_CAPTURE_PRIVACY_MARKER);
   let before: fs.BigIntStats;
   try {
-    if (!fs.lstatSync(directory).isDirectory()) {
-      return false;
-    }
     before = fs.lstatSync(markerPath, { bigint: true });
   } catch (error) {
     if (hasErrnoCode(error, "ENOENT") || hasErrnoCode(error, "ENOTDIR")) {
@@ -33,10 +29,9 @@ function hasPrivacyMarker(directory: string): boolean {
     if (!before.isFile()) {
       throw new Error("Marker must be a regular file");
     }
-    const canonicalDirectory = resolvePathViaExistingAncestorSync(directory);
     const opened = openRootFileSync({
-      absolutePath: path.join(canonicalDirectory, UPDATE_CAPTURE_PRIVACY_MARKER),
-      rootPath: canonicalDirectory,
+      absolutePath: markerPath,
+      rootPath: directory,
       boundaryLabel: "private update capture marker",
       maxBytes: MARKER_BYTES.length,
     });
@@ -66,79 +61,64 @@ function hasPrivacyMarker(directory: string): boolean {
   }
 }
 
-function isMarkedCapturePath(candidate: string): boolean {
-  // Only selected ancestors. Never parse workspace manifests or enumerate roots.
-  let marked = false;
-  for (let ancestor = candidate; ; ancestor = path.dirname(ancestor)) {
-    if (hasPrivacyMarker(ancestor)) {
-      marked = true;
-    }
-    if (path.dirname(ancestor) === ancestor) {
-      return marked;
-    }
-  }
-}
-
 const CAPTURE_SUFFIX = ".update-captures";
 
 export function resolveUpdateCaptureRoot(stateDir: string): string {
   return `${path.resolve(stateDir)}${CAPTURE_SUFFIX}`;
 }
 
-function isPairedCapturePath(candidate: string): boolean {
-  // Only inspect the selected path's ancestors, not other profiles or a global registry.
-  // The sibling directory anchors the reserved layout; it is not writer authority.
-  for (
-    let ancestor = candidate;
-    path.dirname(ancestor) !== ancestor;
-    ancestor = path.dirname(ancestor)
-  ) {
-    const name = path.basename(ancestor);
-    if (name.length <= CAPTURE_SUFFIX.length || !name.endsWith(CAPTURE_SUFFIX)) {
-      continue;
+function isPairedCapturePath(directory: string): boolean {
+  const name = path.basename(directory);
+  if (name.length <= CAPTURE_SUFFIX.length || !name.endsWith(CAPTURE_SUFFIX)) {
+    return false;
+  }
+  try {
+    return fs.lstatSync(directory.slice(0, -CAPTURE_SUFFIX.length)).isDirectory();
+  } catch (error) {
+    if (hasErrnoCode(error, "ENOENT") || hasErrnoCode(error, "ENOTDIR")) {
+      return false;
     }
-    try {
-      if (fs.statSync(ancestor.slice(0, -CAPTURE_SUFFIX.length)).isDirectory()) {
-        return true;
-      }
-    } catch (error) {
-      if (!hasErrnoCode(error, "ENOENT") && !hasErrnoCode(error, "ENOTDIR")) {
-        throw error;
-      }
+    throw error;
+  }
+}
+
+/** Inspect real ancestors up to the first link; link targets are separate source selections. */
+export function isUpdateCapturePath(sourcePath: string, stateDir: string): boolean {
+  const ancestors: string[] = [];
+  for (let ancestor = path.resolve(sourcePath); ; ancestor = path.dirname(ancestor)) {
+    ancestors.push(ancestor);
+    if (path.dirname(ancestor) === ancestor) {
+      break;
     }
   }
-  return false;
+  const captureRoot = resolveUpdateCaptureRoot(stateDir);
+  let captured = false;
+  for (const ancestor of ancestors.toReversed()) {
+    try {
+      if (!fs.lstatSync(ancestor).isDirectory()) {
+        return captured;
+      }
+    } catch (error) {
+      if (hasErrnoCode(error, "ENOENT") || hasErrnoCode(error, "ENOTDIR")) {
+        return captured;
+      }
+      throw new Error("Private update capture marker is unreadable; export refused.", {
+        cause: error,
+      });
+    }
+    // Inspect every real marker even after an earlier ancestor excludes the source.
+    captured = hasPrivacyMarker(ancestor) || captured;
+    captured = ancestor === captureRoot || isPairedCapturePath(ancestor) || captured;
+  }
+  return captured;
 }
 
-/** Exact managed roots, not a basename filter that hides unrelated workspace files. */
-export function isUpdateCapturePath(sourcePath: string, stateDir: string): boolean {
-  const roots = new Set([
-    resolveUpdateCaptureRoot(stateDir),
-    resolveUpdateCaptureRoot(resolvePathViaExistingAncestorSync(stateDir)),
-  ]);
-  const candidate = path.resolve(sourcePath);
-  const canonical = resolvePathViaExistingAncestorSync(sourcePath);
-  // A valid child marker or legacy root must not hide a malformed ancestor.
-  // Evaluate both alias spellings before any exclusion can short-circuit.
-  const marked = isMarkedCapturePath(candidate);
-  const canonicalMarked = canonical !== candidate && isMarkedCapturePath(canonical);
-  const isSelectedStateCapture = [...roots].some((root) => {
-    const resolvedRoot = resolvePathViaExistingAncestorSync(root);
-    return [root, resolvedRoot].some(
-      (boundary) => isPathInside(boundary, candidate) || isPathInside(boundary, canonical),
-    );
-  });
-  return (
-    marked ||
-    canonicalMarked ||
-    isSelectedStateCapture ||
-    isPairedCapturePath(candidate) ||
-    isPairedCapturePath(canonical)
-  );
-}
-
+/** Admit selected file contents, including the actual read path; not ordinary link entries. */
 export function assertNotUpdateCapturePath(sourcePath: string, stateDir: string): void {
-  if (isUpdateCapturePath(sourcePath, stateDir)) {
+  const selectedPrivate = isUpdateCapturePath(sourcePath, stateDir);
+  const readPath = resolvePathViaExistingAncestorSync(sourcePath);
+  const readPrivate = readPath !== sourcePath && isUpdateCapturePath(readPath, stateDir);
+  if (selectedPrivate || readPrivate) {
     throw new Error("Private update captures are excluded from backups and support exports.");
   }
 }

--- a/src/infra/update-capture-paths.ts
+++ b/src/infra/update-capture-paths.ts
@@ -2,7 +2,6 @@
 import fs from "node:fs";
 import path from "node:path";
 import { openRootFileSync, readFileDescriptorBoundedSync } from "./boundary-file-read.js";
-import { resolvePathViaExistingAncestorSync } from "./boundary-path.js";
 import { hasErrnoCode } from "./errno.js";
 import { sameFileMutationFingerprint } from "./file-descriptor.js";
 import {
@@ -67,58 +66,109 @@ export function resolveUpdateCaptureRoot(stateDir: string): string {
   return `${path.resolve(stateDir)}${CAPTURE_SUFFIX}`;
 }
 
-function isPairedCapturePath(directory: string): boolean {
-  const name = path.basename(directory);
-  if (name.length <= CAPTURE_SUFFIX.length || !name.endsWith(CAPTURE_SUFFIX)) {
-    return false;
-  }
-  try {
-    return fs.lstatSync(directory.slice(0, -CAPTURE_SUFFIX.length)).isDirectory();
-  } catch (error) {
-    if (hasErrnoCode(error, "ENOENT") || hasErrnoCode(error, "ENOTDIR")) {
-      return false;
+type CapturePath = { path: string; directory: boolean };
+
+function resolveCapturePath(
+  sourcePath: string,
+  directories = new Set<string>(),
+): CapturePath | undefined {
+  const activeLinks = new Set<string>();
+  function resolve(
+    candidate: string,
+    ancestors: Set<string>,
+    depth: number,
+  ): CapturePath | undefined {
+    const root = path.parse(candidate).root;
+    let current: CapturePath = { path: root, directory: true };
+    ancestors.add(root);
+    const separators = path.sep === "\\" ? /[\\/]/ : /\//;
+    for (const component of candidate.slice(root.length).split(separators)) {
+      if (!current.directory) {
+        return undefined;
+      }
+      const entry = path.resolve(current.path, component);
+      let stat: fs.Stats;
+      try {
+        stat = fs.lstatSync(entry);
+      } catch (error) {
+        if (
+          hasErrnoCode(error, "ENOENT") ||
+          hasErrnoCode(error, "ENOTDIR") ||
+          hasErrnoCode(error, "ELOOP")
+        ) {
+          return undefined;
+        }
+        throw new Error("Private update capture marker is unreadable; export refused.", {
+          cause: error,
+        });
+      }
+      if (stat.isSymbolicLink()) {
+        if (activeLinks.has(entry) || depth === 40) {
+          return undefined;
+        }
+        activeLinks.add(entry);
+        const link = fs.readlinkSync(entry);
+        const targetAncestors = new Set<string>();
+        // Keep target components in filesystem order: an earlier link changes what '..' means.
+        const target = resolve(
+          path.isAbsolute(link) ? link : current.path + path.sep + link,
+          targetAncestors,
+          depth + 1,
+        );
+        activeLinks.delete(entry);
+        if (!target) {
+          return undefined;
+        }
+        for (const ancestor of targetAncestors) {
+          ancestors.add(ancestor);
+        }
+        current = target;
+      } else {
+        current = { path: entry, directory: stat.isDirectory() };
+        if (current.directory) {
+          ancestors.add(entry);
+        }
+      }
     }
-    throw error;
+    return current;
   }
+  return resolve(
+    path.isAbsolute(sourcePath) ? sourcePath : process.cwd() + path.sep + sourcePath,
+    directories,
+    0,
+  );
 }
 
-/** Inspect real ancestors up to the first link; link targets are separate source selections. */
+function isPairedCapturePath(directory: string): boolean {
+  const name = path.basename(directory);
+  return (
+    name.length > CAPTURE_SUFFIX.length &&
+    name.endsWith(CAPTURE_SUFFIX) &&
+    resolveCapturePath(directory.slice(0, -CAPTURE_SUFFIX.length))?.directory === true
+  );
+}
+
+/** One admission decision over real ancestors and safely resolved link targets. */
 export function isUpdateCapturePath(sourcePath: string, stateDir: string): boolean {
-  const ancestors: string[] = [];
-  for (let ancestor = path.resolve(sourcePath); ; ancestor = path.dirname(ancestor)) {
-    ancestors.push(ancestor);
-    if (path.dirname(ancestor) === ancestor) {
-      break;
-    }
-  }
+  const ancestors = new Set<string>();
+  resolveCapturePath(sourcePath, ancestors);
   const captureRoot = resolveUpdateCaptureRoot(stateDir);
+  const resolvedRoot = resolveCapturePath(captureRoot)?.path;
   let captured = false;
-  for (const ancestor of ancestors.toReversed()) {
-    try {
-      if (!fs.lstatSync(ancestor).isDirectory()) {
-        return captured;
-      }
-    } catch (error) {
-      if (hasErrnoCode(error, "ENOENT") || hasErrnoCode(error, "ENOTDIR")) {
-        return captured;
-      }
-      throw new Error("Private update capture marker is unreadable; export refused.", {
-        cause: error,
-      });
-    }
-    // Inspect every real marker even after an earlier ancestor excludes the source.
+  for (const ancestor of ancestors) {
+    // A prior exclusion must not hide an invalid marker on another real ancestor.
     captured = hasPrivacyMarker(ancestor) || captured;
-    captured = ancestor === captureRoot || isPairedCapturePath(ancestor) || captured;
+    captured =
+      ancestor === captureRoot ||
+      ancestor === resolvedRoot ||
+      isPairedCapturePath(ancestor) ||
+      captured;
   }
   return captured;
 }
 
-/** Admit selected file contents, including the actual read path; not ordinary link entries. */
 export function assertNotUpdateCapturePath(sourcePath: string, stateDir: string): void {
-  const selectedPrivate = isUpdateCapturePath(sourcePath, stateDir);
-  const readPath = resolvePathViaExistingAncestorSync(sourcePath);
-  const readPrivate = readPath !== sourcePath && isUpdateCapturePath(readPath, stateDir);
-  if (selectedPrivate || readPrivate) {
+  if (isUpdateCapturePath(sourcePath, stateDir)) {
     throw new Error("Private update captures are excluded from backups and support exports.");
   }
 }

--- a/src/infra/update-capture-paths.ts
+++ b/src/infra/update-capture-paths.ts
@@ -17,6 +17,9 @@ function hasPrivacyMarker(directory: string): boolean {
   const markerPath = path.join(directory, UPDATE_CAPTURE_PRIVACY_MARKER);
   let before: fs.BigIntStats;
   try {
+    if (!fs.lstatSync(directory).isDirectory()) {
+      return false;
+    }
     before = fs.lstatSync(markerPath, { bigint: true });
   } catch (error) {
     if (hasErrnoCode(error, "ENOENT") || hasErrnoCode(error, "ENOTDIR")) {


### PR DESCRIPTION
## What Problem This Solves

A state directory containing `loop-a -> loop-b -> loop-a` makes `openclaw backup create --verify --json` fail with `Private update capture marker is unreadable; export refused.` No archive is created.

## Why This Change Was Made

The decision `whether a selected path is a private update-capture location` is made by exactly one mechanism at `src/infra/update-capture-paths.ts:151`. It resolves links component by component with `lstat`, cycle detection, and a depth limit, retains each selected entry name for legacy capture ownership, and checks real selected and resolved directories for privacy markers. The separate canonical scan is removed.

Resolved marked targets remain excluded. Linked directory owners and capture-root aliases still protect legacy capture contents. SQLite snapshots use the same assertion before copying selected contents. The separate update-time backup work in #144005 writes privacy markers and uses this classifier.

## User Impact

Cyclic and dangling links no longer prevent backup creation. Their original link text is preserved. Marked targets and private capture contents stay out of archives, while ordinary unmarked links retain the behavior from #141925.

## Evidence

- Pinned main `c1a39f89`: real CLI exits 1 with the reported error and no archive. Head `6c58557e`: cycle/dangling creation, verification, and restoration succeed with exact links and payload.
- The marked-target archive omits the link and private bytes, then verifies and restores on v2026.9.4. A linked sibling owner also excludes legacy capture contents. Malformed and unreadable real markers refuse without publishing an archive.
- Head `057dbc07`: config selected through a private capture-root alias refuses export with no archive. A containing-workspace archive omits the alias and private bytes, then verifies and restores on both current code and v2026.9.4 with healthy bytes intact.
- All 199 targeted tests passed, including component ordering, repeated links, trailing separators, archive privacy, and support exports. Complete dispositions and compatibility details are retained in `consumers.md`.

## Compatibility

The archive format is unchanged. Capture-root alias and marked-target archives restore on v2026.9.4 with zero links and exact healthy bytes. Plain and portable relative-link archives retain their passing compatibility checks.

Only cyclic/dangling-link output receives the additional old-reader allowance. v2026.9.4 cannot restore preserved cycles and reports `Backup restore failed; the incomplete target was cleaned: <restore-target>`; the updated reader restores them. Existing restrictions on ordinary absolute links predate this fix. No shim is added. Focused CLI proof runs on macOS; Windows junction coverage depends on CI.

## Consumers

- Backup inventory and archive creation preserve unresolved links while excluding resolved private targets and real private ancestors.
- Legacy capture exclusion recognizes sibling owners and capture roots reached through directory links.
- SQLite archive snapshots apply the same content admission before capture or reuse.

## Invalidation

None. Each call inspects current filesystem metadata; no cached classification or persistent state changes.

## Contention

No lock, queue, transaction, or asynchronous publication changes.

## Tests

`backupCreateCommand` and `backupRestoreCommand` cover marked-target omission, linked-owner exclusion, capture-root alias refusal, loop/dangling preservation, and restored bytes. Real and resolved marker refusals remain covered. The canonical database alias test retains refusal of an incomplete hardlink inventory and the unmarked sanitation control. No tests were deleted.

**Follow-ups:** Add command-level coverage for path-resolution edge cases and test path separators on native Windows.
