### PR TITLE
improve: reduce session host selection and desktop overhead

### DIFF
--- a/src/gateway/desktop/node-observe.integration.test.ts
+++ b/src/gateway/desktop/node-observe.integration.test.ts
@@ -437,6 +437,7 @@ describe("worker environment node desktop observe integration", () => {
         }
       });
       const transport: NodeWorkerSupervisorTransport = {
+        getCurrentNode: async (nodeId) => (proof.nodeId === nodeId ? proof : undefined),
         listCurrentNodes: async () => [proof],
         hasCurrentRunner: (nodeId) => nodeId === proof.nodeId,
         isCurrent: (candidate) =>

--- a/src/gateway/node-registry-private.ts
+++ b/src/gateway/node-registry-private.ts
@@ -59,6 +59,7 @@ type PairingLeaseResolution =
 type NodeWorkerPrivateCommand = (typeof NODE_WORKER_PRIVATE_COMMANDS)[number];
 
 export type NodeWorkerSupervisorTransport = {
+  getCurrentNode(nodeId: string): Promise<NodeWorkerSupervisorNodeProof | undefined>;
   listCurrentNodes(): Promise<readonly NodeWorkerSupervisorNodeProof[]>;
   hasCurrentRunner(nodeId: string): boolean;
   /** Diagnostic connection presence, independent of session-host eligibility. */
@@ -90,6 +91,7 @@ type NodeRegistryPrivateContext = {
   getNode: (nodeId: string) => PairingBoundNodeSession | undefined;
   isCommandAllowed: (nodeId: string, command: string) => boolean;
   listCurrentConnected: () => Promise<NodeRegistryPrivateSession[]>;
+  getCurrentConnected: (nodeId: string) => Promise<NodeRegistryPrivateSession | undefined>;
   hasCurrentPairingStateResolver: boolean;
   resolvePairingLease: (node: PairingBoundNodeSession) => Promise<PairingLeaseResolution>;
   pendingInvokes: Map<string, PendingInvoke>;
@@ -455,6 +457,10 @@ export function registerNodeRegistryPrivateRuntime(
     await invokeNodeRegistryCore(state, params, allowPrivateCommand, isCompletionAuthorized);
   state.updateRunnerInventory = (params) => updateWorkerRunnerInventory(state, params);
   state.workerSupervisorTransport = {
+    getCurrentNode: async (nodeId) => {
+      const node = await context.getCurrentConnected(nodeId);
+      return node ? resolveNodeWorkerSupervisorProof(node, state.runnerInventoryByConn) : undefined;
+    },
     listCurrentNodes: async () => {
       const current = await context.listCurrentConnected();
       return current.flatMap((node) => {

--- a/src/gateway/node-registry.test.ts
+++ b/src/gateway/node-registry.test.ts
@@ -413,9 +413,13 @@ describe("gateway/node-registry", () => {
     expect(Reflect.ownKeys(Object.getPrototypeOf(registry))).not.toContain("invokeCore");
   });
 
-  it.each([GATEWAY_CLIENT_IDS.NODE_HOST, GATEWAY_CLIENT_IDS.MACOS_APP])(
-    "binds the private dialect to the exact connection generation (%s)",
-    async (clientId) => {
+  it.each(
+    [GATEWAY_CLIENT_IDS.NODE_HOST, GATEWAY_CLIENT_IDS.MACOS_APP].flatMap((clientId) =>
+      ["fleet", "node"].map((scope) => ({ clientId, scope })),
+    ),
+  )(
+    "binds the private dialect to the exact connection generation ($clientId, $scope)",
+    async ({ clientId, scope }) => {
       let currentGeneration = "generation-a";
       const { nodeRegistry, nodeWorkerSupervisorTransport } = createPrivateNodeRegistryRuntime({
         resolveCurrentPairingState: async () => ({
@@ -423,6 +427,13 @@ describe("gateway/node-registry", () => {
           generation: currentGeneration,
         }),
       });
+      const readNodes = async () => {
+        if (scope === "fleet") {
+          return await nodeWorkerSupervisorTransport.listCurrentNodes();
+        }
+        const node = await nodeWorkerSupervisorTransport.getCurrentNode("node-1");
+        return node ? [node] : [];
+      };
       registerNodeSession(
         nodeRegistry,
         makeClient("conn-1", "node-1", [], {
@@ -432,7 +443,7 @@ describe("gateway/node-registry", () => {
         { pairingIdentity: "identity-a", pairingGeneration: "generation-a" },
       );
 
-      await expect(nodeWorkerSupervisorTransport.listCurrentNodes()).resolves.toEqual([]);
+      await expect(readNodes()).resolves.toEqual([]);
       expect(
         updateNodeRunnerInventory({
           registry: nodeRegistry,
@@ -444,7 +455,7 @@ describe("gateway/node-registry", () => {
           },
         }),
       ).toEqual({ changed: true });
-      await expect(nodeWorkerSupervisorTransport.listCurrentNodes()).resolves.toEqual([
+      await expect(readNodes()).resolves.toEqual([
         expect.objectContaining({
           nodeId: "node-1",
           connId: "conn-1",
@@ -476,7 +487,7 @@ describe("gateway/node-registry", () => {
           },
         ),
       ).not.toBeNull();
-      await expect(nodeWorkerSupervisorTransport.listCurrentNodes()).resolves.toEqual([]);
+      await expect(readNodes()).resolves.toEqual([]);
       expect(
         collectNodeCatalogRuntimeState(nodeRegistry, [
           { nodeId: "node-1", connId: "conn-1", pairingGeneration: "generation-b" },
@@ -493,7 +504,7 @@ describe("gateway/node-registry", () => {
           },
         }),
       ).toEqual({ changed: true });
-      await expect(nodeWorkerSupervisorTransport.listCurrentNodes()).resolves.toEqual([
+      await expect(readNodes()).resolves.toEqual([
         expect.objectContaining({ pairingGeneration: "generation-b" }),
       ]);
 
@@ -505,7 +516,7 @@ describe("gateway/node-registry", () => {
         }),
         { pairingIdentity: "identity-a", pairingGeneration: "generation-b" },
       );
-      await expect(nodeWorkerSupervisorTransport.listCurrentNodes()).resolves.toEqual([]);
+      await expect(readNodes()).resolves.toEqual([]);
       expect(
         updateNodeRunnerInventory({
           registry: nodeRegistry,
@@ -528,7 +539,7 @@ describe("gateway/node-registry", () => {
           },
         }),
       ).toEqual({ changed: true });
-      await expect(nodeWorkerSupervisorTransport.listCurrentNodes()).resolves.toEqual([
+      await expect(readNodes()).resolves.toEqual([
         expect.objectContaining({
           connId: "conn-2",
           pairingGeneration: "generation-b",
@@ -539,11 +550,12 @@ describe("gateway/node-registry", () => {
   );
 
   it("reports connected nodes without session hosting as ineligible, not disconnected", async () => {
+    const resolveCurrentPairingState = vi.fn(async () => ({
+      identity: "identity-a",
+      generation: "generation-a",
+    }));
     const { nodeRegistry, nodeWorkerSupervisorTransport } = createPrivateNodeRegistryRuntime({
-      resolveCurrentPairingState: async () => ({
-        identity: "identity-a",
-        generation: "generation-a",
-      }),
+      resolveCurrentPairingState,
     });
     registerNodeSession(
       nodeRegistry,
@@ -553,6 +565,10 @@ describe("gateway/node-registry", () => {
       }),
       { pairingIdentity: "identity-a", pairingGeneration: "generation-a" },
     );
+    registerNodeSession(nodeRegistry, makeClient("conn-unrelated", "node-unrelated"), {
+      pairingIdentity: "identity-a",
+      pairingGeneration: "generation-a",
+    });
     const runtime = createDeviceWorkerRuntime({
       getPairedDevice: async () => ({
         deviceId: "node-1",
@@ -572,6 +588,7 @@ describe("gateway/node-registry", () => {
       unavailableReason: "hosting-unavailable",
     });
     expect(deviceUnavailableText("node-1", availability)).toContain("enable session hosting");
+    expect(resolveCurrentPairingState).toHaveBeenCalledExactlyOnceWith("node-1");
   });
 
   it("publishes current-runner edges once across disconnect, reconnect, and replacement", () => {
@@ -1208,7 +1225,7 @@ describe("gateway/node-registry", () => {
     expect(registry.getActiveNode()?.nodeId).toBe("node-generation");
 
     currentPairingGeneration = "generation-b";
-    await expect(registry.listCurrentConnected()).resolves.toEqual([]);
+    await expect(registry.getCurrentConnected("node-generation")).resolves.toBeUndefined();
     expect(registry.getActiveNode()).toBeUndefined();
     expect(getCurrentActiveNodeContext()).toBeNull();
     expect(client.invalidated).toBe(true);
@@ -1218,46 +1235,58 @@ describe("gateway/node-registry", () => {
     });
   });
 
-  it("does not invalidate a session promoted while persistent generation is loading", async () => {
-    let resolveLookup: ((value: { identity: string; generation: string }) => void) | undefined;
-    const resolveCurrentPairingState = vi.fn(
-      () =>
-        new Promise<{ identity: string; generation: string }>((resolve) => {
-          resolveLookup = resolve;
-        }),
-    );
-    const onPairingInvalidated = vi.fn();
-    const registry = createNodeRegistry({
-      resolveCurrentPairingState,
-      onPairingInvalidated,
-    });
-    const client = makeClient("conn-generation", "node-generation");
-    registerNodeSession(registry, client, {
-      pairingIdentity: "identity-a",
-      pairingGeneration: "generation-a",
-    });
+  it.each(["promotion", "reconnection"])(
+    "does not invalidate a session after $0 while persistent generation is loading",
+    async (change) => {
+      let resolveLookup: ((value: { identity: string; generation: string }) => void) | undefined;
+      const resolveCurrentPairingState = vi.fn(
+        () =>
+          new Promise<{ identity: string; generation: string }>((resolve) => {
+            resolveLookup = resolve;
+          }),
+      );
+      const onPairingInvalidated = vi.fn();
+      const registry = createNodeRegistry({
+        resolveCurrentPairingState,
+        onPairingInvalidated,
+      });
+      const client = makeClient("conn-generation", "node-generation");
+      registerNodeSession(registry, client, {
+        pairingIdentity: "identity-a",
+        pairingGeneration: "generation-a",
+      });
 
-    const connected = registry.listCurrentConnected();
-    expect(resolveCurrentPairingState).toHaveBeenCalledWith("node-generation");
-    expect(
-      registry.updateSurface(
-        "node-generation",
-        { commands: [] },
-        {
-          expectedConnId: "conn-generation",
-          expectedPairingIdentity: "identity-a",
-          expectedPairingGeneration: "generation-a",
-          nextPairingGeneration: "generation-b",
-        },
-      ),
-    ).not.toBeNull();
-    resolveLookup?.({ identity: "identity-a", generation: "generation-a" });
+      const connected = registry.getCurrentConnected("node-generation");
+      expect(resolveCurrentPairingState).toHaveBeenCalledWith("node-generation");
+      let retainedClient = client;
+      if (change === "promotion") {
+        expect(
+          registry.updateSurface(
+            "node-generation",
+            { commands: [] },
+            {
+              expectedConnId: "conn-generation",
+              expectedPairingIdentity: "identity-a",
+              expectedPairingGeneration: "generation-a",
+              nextPairingGeneration: "generation-b",
+            },
+          ),
+        ).not.toBeNull();
+      } else {
+        retainedClient = makeClient("conn-replacement", "node-generation");
+        registerNodeSession(registry, retainedClient, {
+          pairingIdentity: "identity-a",
+          pairingGeneration: "generation-b",
+        });
+      }
+      resolveLookup?.({ identity: "identity-a", generation: "generation-a" });
 
-    await expect(connected).resolves.toEqual([]);
-    expect(registry.get("node-generation")?.pairingGeneration).toBe("generation-b");
-    expect(client.invalidated).not.toBe(true);
-    expect(onPairingInvalidated).not.toHaveBeenCalled();
-  });
+      await expect(connected).resolves.toBeUndefined();
+      expect(registry.get("node-generation")?.pairingGeneration).toBe("generation-b");
+      expect(retainedClient.invalidated).not.toBe(true);
+      expect(onPairingInvalidated).not.toHaveBeenCalled();
+    },
+  );
 
   it("revalidates the active node at the prompt projection boundary", () => {
     let currentPairingGeneration = "generation-a";
@@ -1328,7 +1357,7 @@ describe("gateway/node-registry", () => {
       pairingGeneration: "generation-a",
     });
 
-    await expect(registry.listCurrentConnected()).resolves.toEqual([]);
+    await expect(registry.getCurrentConnected("node-generation")).resolves.toBeUndefined();
     expect(client.invalidated).not.toBe(true);
     expect(registry.listConnected()).toHaveLength(1);
   });

--- a/src/gateway/node-registry.ts
+++ b/src/gateway/node-registry.ts
@@ -348,6 +348,7 @@ export class NodeRegistry {
       isCommandAllowed: (nodeId, command) =>
         this.isCommandAllowed(nodeId, command, this.options.getConfig?.()),
       listCurrentConnected: () => this.listCurrentConnected(),
+      getCurrentConnected: (nodeId) => this.getCurrentConnected(nodeId),
       hasCurrentPairingStateResolver: Boolean(this.options.resolveCurrentPairingState),
       resolvePairingLease: async (node) => {
         const current = this.nodesById.get(node.nodeId);
@@ -748,8 +749,21 @@ export class NodeRegistry {
 
   /** Resolve persistent pairing state before projecting connected sessions. */
   async listCurrentConnected(): Promise<NodeSession[]> {
+    return await this.resolveCurrentConnectedSessions(this.listConnectedSessions());
+  }
+
+  async getCurrentConnected(nodeId: string): Promise<NodeSession | undefined> {
+    const node = this.nodesById.get(nodeId);
+    return node && node.client.invalidated !== true
+      ? (await this.resolveCurrentConnectedSessions([node]))[0]
+      : undefined;
+  }
+
+  private async resolveCurrentConnectedSessions(
+    candidates: readonly PairingBoundNodeSession[],
+  ): Promise<NodeSession[]> {
     const resolved = await Promise.all(
-      this.listConnectedSessions().map((node) =>
+      candidates.map((node) =>
         this.resolvePairingLease(this.capturePairingLease(node), { invalidateStale: true }),
       ),
     );

--- a/src/gateway/node-registry.worker-launch.test.ts
+++ b/src/gateway/node-registry.worker-launch.test.ts
@@ -236,15 +236,15 @@ describe("private worker launch wire", () => {
       vi.useFakeTimers({ toFake: ["Date", "setTimeout", "clearTimeout"] });
       const controller = new AbortController();
       const startedAt = Date.now();
-      const listCurrentNodes = nodeWorkerSupervisorTransport.listCurrentNodes.bind(
+      const getCurrentNode = nodeWorkerSupervisorTransport.getCurrentNode.bind(
         nodeWorkerSupervisorTransport,
       );
       const discovery = vi
-        .spyOn(nodeWorkerSupervisorTransport, "listCurrentNodes")
-        .mockImplementationOnce(async () => {
-          const nodes = await listCurrentNodes();
+        .spyOn(nodeWorkerSupervisorTransport, "getCurrentNode")
+        .mockImplementationOnce(async (requestedNodeId) => {
+          const node = await getCurrentNode(requestedNodeId);
           vi.setSystemTime(startedAt + 10_000);
-          return nodes;
+          return node;
         });
       const sent = vi.spyOn(socket, "send");
       const unhandledRejection = vi.fn();

--- a/src/gateway/server-methods/sessions.dispatch.device.test.ts
+++ b/src/gateway/server-methods/sessions.dispatch.device.test.ts
@@ -758,6 +758,7 @@ describe("sessions.dispatch device targets", () => {
           getPairedDevice: async (deviceId) => pairedNode(deviceId),
         });
         runtime.bindNodeTransport({
+          getCurrentNode: async (nodeId) => nodes.find((node) => node.nodeId === nodeId),
           listCurrentNodes: async () => nodes,
           hasCurrentRunner: () => nodes.length > 0,
           isCurrent: () => true,

--- a/src/gateway/server-worker-environment-startup.test.ts
+++ b/src/gateway/server-worker-environment-startup.test.ts
@@ -290,6 +290,8 @@ describe("gateway worker environment startup", () => {
         commands: [],
       };
       const transport: NodeWorkerSupervisorTransport = {
+        getCurrentNode: async (candidateNodeId) =>
+          proof.nodeId === candidateNodeId ? proof : undefined,
         listCurrentNodes: async () => [proof],
         hasCurrentRunner: (candidateNodeId) => candidateNodeId === proof.nodeId,
         isCurrent: () => true,

--- a/src/gateway/worker-environments/computer-transport.test-support.ts
+++ b/src/gateway/worker-environments/computer-transport.test-support.ts
@@ -208,6 +208,7 @@ export function createHarness(sharedHost = false, withPolicy = true) {
     return { ok: true, payload: { ok: true } };
   });
   const nodeTransport = {
+    getCurrentNode: vi.fn(async (nodeId: string) => (proof.nodeId === nodeId ? proof : undefined)),
     listCurrentNodes: vi.fn(async () => [proof]),
     hasCurrentRunner: (id) => id === proof.nodeId && state.privateCurrent,
     isCurrent: (candidate) => candidate === proof && state.privateCurrent,

--- a/src/gateway/worker-environments/computer-transport.test.ts
+++ b/src/gateway/worker-environments/computer-transport.test.ts
@@ -189,7 +189,7 @@ describe("session computer transport", () => {
       const { transport, prepared } = await h.prepare();
       await transport.invoke(request("snapshot"));
       await transport.invoke(request("type"));
-      expect(h.nodeTransport.listCurrentNodes).not.toHaveBeenCalled();
+      expect(h.nodeTransport.getCurrentNode).not.toHaveBeenCalled();
       expect(h.privateInvoke).not.toHaveBeenCalled();
       expect(h.publicInvoke).toHaveBeenLastCalledWith(
         expect.objectContaining({

--- a/src/gateway/worker-environments/computer-transport.ts
+++ b/src/gateway/worker-environments/computer-transport.ts
@@ -17,7 +17,7 @@ import { invokeNodeWithReadinessRetry } from "../node-invoke-readiness.js";
 import type { NodeWorkerSupervisorTransport } from "../node-registry-private.js";
 import type { GatewayContextResolver } from "../server-methods/types.js";
 import type { WorkerSessionPlacementStore, WorkerSessionTurnClaim } from "./placement-store.js";
-import type { WorkerEnvironmentStore } from "./store.js";
+import type { WorkerEnvironmentRecord, WorkerEnvironmentStore } from "./store.js";
 import { WorkerRunnerUnavailableError } from "./tunnel-contract.js";
 import type { WorkerComputerExecutor } from "./worker-turn-computer-rpc.js";
 
@@ -71,8 +71,7 @@ export function createWorkerComputerTransportOwner(options: {
     if (!node) {
       throw new WorkerRunnerUnavailableError();
     }
-    const environmentIsCurrent = () => {
-      const current = options.store.get(environment.environmentId);
+    const environmentIsCurrent = (current: WorkerEnvironmentRecord | undefined) => {
       const currentNode = context.nodeRegistry.get(node.nodeId);
       return (
         options.resolveGatewayContext() === context &&
@@ -89,7 +88,7 @@ export function createWorkerComputerTransportOwner(options: {
       const current = options.placements.get(claim.sessionId);
       const currentEnvironment = options.store.get(environment.environmentId);
       return (
-        environmentIsCurrent() &&
+        environmentIsCurrent(currentEnvironment) &&
         options.placements.validateTurnClaim(claim) &&
         current?.state === "active" &&
         current.generation === claim.placementGeneration &&
@@ -113,9 +112,7 @@ export function createWorkerComputerTransportOwner(options: {
     // their private endpoint. A failed private probe never selects another connected computer.
     const privateNode = environment.sharedHost
       ? undefined
-      : (await nodeTransport.listCurrentNodes()).find(
-          (candidate) => candidate.nodeId === node.nodeId,
-        );
+      : await nodeTransport.getCurrentNode(node.nodeId);
     assertPlacement();
     if (!environment.sharedHost && !privateNode) {
       throw new Error("Session desktop node lacks the current private worker protocol");
@@ -174,9 +171,10 @@ export function createWorkerComputerTransportOwner(options: {
     let closing: Promise<void> | undefined;
     const activeBindings = new Set<{ close(reason: string): Promise<unknown> }>();
     const resourceBindingIsCurrent = () =>
-      environmentIsCurrent() && (!privateNode || nodeTransport.isCurrent(privateNode));
+      environmentIsCurrent(options.store.get(environment.environmentId)) &&
+      (!privateNode || nodeTransport.isCurrent(privateNode));
     const bindingIsCurrent = () =>
-      resourceBindingIsCurrent() &&
+      (!privateNode || nodeTransport.isCurrent(privateNode)) &&
       getActivePluginGatewayNodePolicyRegistry() === registry &&
       policyOwners.every((isCurrent) => isCurrent()) &&
       (privateNode !== undefined ||

--- a/src/gateway/worker-environments/device-provider.test.ts
+++ b/src/gateway/worker-environments/device-provider.test.ts
@@ -67,6 +67,9 @@ function deviceRuntime(params: {
   });
   if (params.listCurrentNodes) {
     runtime.bindNodeTransport({
+      async getCurrentNode(nodeId) {
+        return (await this.listCurrentNodes()).find((node) => node.nodeId === nodeId);
+      },
       listCurrentNodes: params.listCurrentNodes,
       hasCurrentRunner: () => true,
       ...(params.getIssue ? { getIssue: params.getIssue } : {}),

--- a/src/gateway/worker-environments/device-provider.ts
+++ b/src/gateway/worker-environments/device-provider.ts
@@ -114,12 +114,10 @@ export function createDeviceWorkerRuntime(options: DeviceWorkerRuntimeOptions) {
   const now = options.now ?? Date.now;
   let nodeTransport: NodeWorkerSupervisorTransport | undefined;
   const launchAdapter = createNodeWorkerLaunchAdapter({ getTransport: () => nodeTransport });
-  const findConnectedNode = async (deviceId: string) =>
-    (await nodeTransport?.listCurrentNodes())?.find((node) => node.nodeId === deviceId);
   const resolveAvailability = async (deviceId: string): Promise<DeviceWorkerAvailability> => {
     const [paired, connected] = await Promise.all([
       options.getPairedDevice(deviceId),
-      findConnectedNode(deviceId),
+      nodeTransport?.getCurrentNode(deviceId),
     ]);
     const current = connected && nodeTransport?.isCurrent(connected) ? connected : undefined;
     // Transport availability is runtime-neutral; only worker-turn placement consumes a slot.
@@ -163,7 +161,7 @@ export function createDeviceWorkerRuntime(options: DeviceWorkerRuntimeOptions) {
       if (!hasPairedNodeRole(paired)) {
         return { status: "unknown" };
       }
-      const connected = await findConnectedNode(deviceId);
+      const connected = await nodeTransport?.getCurrentNode(deviceId);
       if (connected) {
         return { status: "active", sharedHost: true };
       }

--- a/src/gateway/worker-environments/node-desktop-carrier.test.ts
+++ b/src/gateway/worker-environments/node-desktop-carrier.test.ts
@@ -93,6 +93,9 @@ function pendingTransport(params: {
       }),
   );
   const transport: NodeWorkerSupervisorTransport = {
+    async getCurrentNode(nodeId) {
+      return (await this.listCurrentNodes()).find((node) => node.nodeId === nodeId);
+    },
     listCurrentNodes: async () => [params.proof],
     hasCurrentRunner: (nodeId) => nodeId === params.proof.nodeId && params.isProofCurrent(),
     isCurrent: () => params.isProofCurrent(),
@@ -283,6 +286,7 @@ describe("worker node desktop carrier", () => {
     });
     carrier.bindRuntime({
       transport: {
+        getCurrentNode: async (nodeId) => (proof.nodeId === nodeId ? proof : undefined),
         listCurrentNodes: async () => [proof],
         hasCurrentRunner: (nodeId) => nodeId === proof.nodeId,
         isCurrent: () => true,
@@ -317,6 +321,7 @@ describe("worker node desktop carrier", () => {
       });
       carrier.bindRuntime({
         transport: {
+          getCurrentNode: async (nodeId) => (proof.nodeId === nodeId ? proof : undefined),
           listCurrentNodes: async () => [proof],
           hasCurrentRunner: (nodeId) => nodeId === proof.nodeId && proofCurrent,
           isCurrent: () => proofCurrent,

--- a/src/gateway/worker-environments/node-desktop-carrier.ts
+++ b/src/gateway/worker-environments/node-desktop-carrier.ts
@@ -135,8 +135,8 @@ export function createWorkerNodeDesktopCarrier(options: WorkerNodeDesktopCarrier
     signal: AbortSignal,
   ): Promise<NodeWorkerSupervisorNodeProof> => {
     signal.throwIfAborted();
-    const nodes = await raceNodeWorkerOperation(
-      capturedRuntime.transport.listCurrentNodes(),
+    const node = await raceNodeWorkerOperation(
+      capturedRuntime.transport.getCurrentNode(binding.nodeDeviceId),
       signal,
       {
         aborted: "Worker environment node desktop operation aborted",
@@ -144,7 +144,6 @@ export function createWorkerNodeDesktopCarrier(options: WorkerNodeDesktopCarrier
       },
     );
     signal.throwIfAborted();
-    const node = nodes.find((candidate) => candidate.nodeId === binding.nodeDeviceId);
     if (!node || !bindingIsCurrent(binding, capturedRuntime, node)) {
       throw new Error("Worker environment node desktop connection is not current");
     }

--- a/src/gateway/worker-environments/node-launch-adapter.test.ts
+++ b/src/gateway/worker-environments/node-launch-adapter.test.ts
@@ -122,7 +122,15 @@ function transportWith(
   invoke: NodeWorkerSupervisorTransport["invoke"],
   listCurrentNodes: NodeWorkerSupervisorTransport["listCurrentNodes"] = async () => [nodeProof()],
 ): NodeWorkerSupervisorTransport {
-  return { invoke, isCurrent: () => true, listCurrentNodes, hasCurrentRunner: () => true };
+  return {
+    invoke,
+    isCurrent: () => true,
+    async getCurrentNode(nodeId) {
+      return (await this.listCurrentNodes()).find((node) => node.nodeId === nodeId);
+    },
+    listCurrentNodes,
+    hasCurrentRunner: () => true,
+  };
 }
 
 function launchRequest(input = launchInput()) {

--- a/src/gateway/worker-environments/node-launch-adapter.ts
+++ b/src/gateway/worker-environments/node-launch-adapter.ts
@@ -261,9 +261,12 @@ export function createNodeWorkerLaunchAdapter(options: NodeWorkerLaunchAdapterOp
     deviceId: string;
     signal: AbortSignal;
   }): Promise<NodeWorkerSupervisorNodeProof> => {
-    let nodes: readonly NodeWorkerSupervisorNodeProof[];
+    let node: NodeWorkerSupervisorNodeProof | undefined;
     try {
-      nodes = await raceNodeWorkerOperation(params.transport.listCurrentNodes(), params.signal);
+      node = await raceNodeWorkerOperation(
+        params.transport.getCurrentNode(params.deviceId),
+        params.signal,
+      );
     } catch (error) {
       if (params.signal.aborted) {
         throw error;
@@ -273,7 +276,6 @@ export function createNodeWorkerLaunchAdapter(options: NodeWorkerLaunchAdapterOp
         "device worker node discovery is unavailable",
       );
     }
-    const node = nodes.find((candidate) => candidate.nodeId === params.deviceId);
     if (!node) {
       throw new NodeWorkerLaunchTransportError(
         "NOT_CONNECTED",

--- a/src/gateway/worker-environments/node-worker-bundle-installer.test.ts
+++ b/src/gateway/worker-environments/node-worker-bundle-installer.test.ts
@@ -65,6 +65,9 @@ describe("Gateway node worker bundle installer", () => {
       gatewayNamespace: "gateway-test",
       getTransport: () => ({
         hasCurrentRunner: () => false,
+        async getCurrentNode(nodeId) {
+          return (await this.listCurrentNodes()).find((candidate) => candidate.nodeId === nodeId);
+        },
         listCurrentNodes,
         isCurrent: (candidate) => candidate === node,
         invoke,
@@ -112,6 +115,7 @@ describe("Gateway node worker bundle installer", () => {
     }));
     const transport: NodeWorkerSupervisorTransport = {
       hasCurrentRunner: () => false,
+      getCurrentNode: async (nodeId) => (node.nodeId === nodeId ? node : undefined),
       listCurrentNodes: async () => [node],
       isCurrent: (candidate) => candidate === node,
       invoke,
@@ -147,6 +151,7 @@ describe("Gateway node worker bundle installer", () => {
     });
     const transport: NodeWorkerSupervisorTransport = {
       hasCurrentRunner: () => false,
+      getCurrentNode: async (nodeId) => (node.nodeId === nodeId ? node : undefined),
       listCurrentNodes: async () => [node],
       isCurrent: () => true,
       invoke: async () => ({
@@ -181,6 +186,8 @@ describe("Gateway node worker bundle installer", () => {
     }));
     const transport: NodeWorkerSupervisorTransport = {
       hasCurrentRunner: () => false,
+      getCurrentNode: async (nodeId) =>
+        [advertising, legacy].find((candidate) => candidate.nodeId === nodeId),
       listCurrentNodes: async () => [advertising, legacy],
       isCurrent: () => true,
       invoke,
@@ -218,6 +225,7 @@ describe("Gateway node worker bundle installer", () => {
       });
       const transport: NodeWorkerSupervisorTransport = {
         hasCurrentRunner: () => true,
+        getCurrentNode: async (nodeId) => (node.nodeId === nodeId ? node : undefined),
         listCurrentNodes: async () => [node],
         isCurrent: () => true,
         invoke,

--- a/src/gateway/worker-environments/node-worker-bundle-installer.ts
+++ b/src/gateway/worker-environments/node-worker-bundle-installer.ts
@@ -25,9 +25,10 @@ export function createGatewayNodeWorkerBundleInstaller(options: {
     if (!transport) {
       throw new Error("Device worker node transport is unavailable");
     }
-    const node = (
-      await racePromiseWithAbortSignal(transport.listCurrentNodes(), params.signal)
-    ).find((candidate) => candidate.nodeId === params.deviceId);
+    const node = await racePromiseWithAbortSignal(
+      transport.getCurrentNode(params.deviceId),
+      params.signal,
+    );
     params.signal?.throwIfAborted();
     if (!node) {
       throw new Error("Device worker node is not connected with the installer dialect");

--- a/src/gateway/worker-environments/node-worker-prepared-workspace-transport.ts
+++ b/src/gateway/worker-environments/node-worker-prepared-workspace-transport.ts
@@ -37,8 +37,9 @@ export function createNodeWorkerPreparedWorkspaceTransport(options: {
     if (!transport) {
       throw new Error("Prepared workspace node transport is unavailable");
     }
-    const node = (await racePromiseWithAbortSignal(transport.listCurrentNodes(), signal)).find(
-      (candidate) => candidate.nodeId === request.deviceId,
+    const node = await racePromiseWithAbortSignal(
+      transport.getCurrentNode(request.deviceId),
+      signal,
     );
     assertCurrent();
     if (!node || !transport.isCurrent(node)) {

--- a/src/gateway/worker-environments/node-worker-tunnel.test-support.ts
+++ b/src/gateway/worker-environments/node-worker-tunnel.test-support.ts
@@ -49,6 +49,9 @@ export function environment(): WorkerEnvironmentRecord {
 
 export function transport(): NodeWorkerSupervisorTransport {
   return {
+    async getCurrentNode(nodeId) {
+      return (await this.listCurrentNodes()).find((node) => node.nodeId === nodeId);
+    },
     hasCurrentRunner: () => true,
     listCurrentNodes: async () => [
       {

--- a/src/gateway/worker-environments/node-worker-tunnel.ts
+++ b/src/gateway/worker-environments/node-worker-tunnel.ts
@@ -188,9 +188,7 @@ export function createNodeWorkerTunnelManager(options: NodeWorkerTunnelManagerOp
     if (!transport) {
       throw new Error("device worker node transport is unavailable");
     }
-    const node = (await raceNodeWorkerOperation(transport.listCurrentNodes(), signal)).find(
-      (candidate) => candidate.nodeId === entry.deviceId,
-    );
+    const node = await raceNodeWorkerOperation(transport.getCurrentNode(entry.deviceId), signal);
     if (!node) {
       throw new WorkerTunnelOwnerDisconnectedError(
         "device worker node is not connected with the supervisor dialect",

--- a/src/gateway/worker-environments/node-workspace-retain-coordinator.test.ts
+++ b/src/gateway/worker-environments/node-workspace-retain-coordinator.test.ts
@@ -136,6 +136,9 @@ function createHarness(
     },
   );
   const transport: NodeWorkerSupervisorTransport = {
+    async getCurrentNode(nodeId) {
+      return (await this.listCurrentNodes()).find((entry) => entry.nodeId === nodeId);
+    },
     hasCurrentRunner: () => false,
     listCurrentNodes: async () => [params.node ?? node],
     getBundleStatus: () => currentBundleStatus,
@@ -766,6 +769,7 @@ describe("node workspace retain coordinator", () => {
       };
     });
     const transport: NodeWorkerSupervisorTransport = {
+      getCurrentNode: async (nodeId) => nodes.find((entry) => entry.nodeId === nodeId),
       listCurrentNodes: async () => nodes,
       hasCurrentRunner: () => true,
       isCurrent: () => true,

--- a/src/gateway/worker-environments/portal-node-carrier.test.ts
+++ b/src/gateway/worker-environments/portal-node-carrier.test.ts
@@ -96,6 +96,9 @@ function pendingPortalTransport(params: {
       }),
   );
   const transport: NodeWorkerSupervisorTransport = {
+    async getCurrentNode(nodeId) {
+      return (await this.listCurrentNodes()).find((node) => node.nodeId === nodeId);
+    },
     listCurrentNodes: async () => [params.proof],
     hasCurrentRunner: (nodeId) => nodeId === params.proof.nodeId && params.isProofCurrent(),
     isCurrent: () => params.isProofCurrent(),

--- a/src/gateway/worker-environments/portal-node-carrier.ts
+++ b/src/gateway/worker-environments/portal-node-carrier.ts
@@ -56,14 +56,13 @@ export function createWorkerNodePortalCarrier(options: {
     capturedRuntime: WorkerNodeCarrierRuntime,
     signal?: AbortSignal,
   ): Promise<NodeWorkerSupervisorNodeProof> => {
-    const discovery = capturedRuntime.transport.listCurrentNodes();
-    const nodes = signal
+    const discovery = capturedRuntime.transport.getCurrentNode(binding.nodeDeviceId);
+    const node = signal
       ? await raceNodeWorkerOperation(discovery, signal, {
           aborted: "Worker environment node portal owner stopped",
         })
       : await discovery;
     signal?.throwIfAborted();
-    const node = nodes.find((candidate) => candidate.nodeId === binding.nodeDeviceId);
     if (!node || !bindingIsCurrent(binding, capturedRuntime, node)) {
       throw new Error(UNSUPPORTED_NODE_PORTAL_MESSAGE);
     }

--- a/src/gateway/worker-environments/provider-provisioning-node.test.ts
+++ b/src/gateway/worker-environments/provider-provisioning-node.test.ts
@@ -46,6 +46,7 @@ describe("node worker provider provisioning", () => {
         payload: support.BOOTSTRAP_RECEIPT,
       }));
       const transport: NodeWorkerSupervisorTransport = {
+        getCurrentNode: async (nodeId) => (node.nodeId === nodeId ? node : undefined),
         hasCurrentRunner: () => true,
         listCurrentNodes: async () => [node],
         isCurrent: (candidate) => candidate === node,

--- a/src/node-host/node-worker-supervisor.admission.test.ts
+++ b/src/node-host/node-worker-supervisor.admission.test.ts
@@ -32,6 +32,9 @@ describe("node worker admission re-arm journal", () => {
     const transport: NodeWorkerSupervisorTransport = {
       isCurrent: () => true,
       hasCurrentRunner: () => true,
+      async getCurrentNode(nodeId) {
+        return (await this.listCurrentNodes()).find((node) => node.nodeId === nodeId);
+      },
       listCurrentNodes: async () => [
         {
           nodeId: "node-1",


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where choosing a session host and using its desktop perform increasing amounts of redundant work as the connected fleet grows. CUA actions also reread the same environment row within a single synchronous authority check.

## Why This Change Was Made

The node registry now resolves one named node through its existing pairing-lease validation and stale-connection invalidation owner. All eight named-node consumers use that operation; bulk inventory still uses the fleet listing. CUA reuses the environment row already read by its placement check while retaining every post-await authority check and independent resource-cleanup validation.

## User Impact

Session selection and desktop operations do less Gateway work, particularly with many connected hosts. Pairing revocation, placement ownership, reconnect behavior, and cleanup retain their existing authority checks.

## Evidence

- At 250 candidate hosts, the real registry/provider composition probe reduced registry pairing validations from 62,500 to 250. Separate provider-role and final authority checks are excluded from that count.
- A 2,200-invocation real-SQLite workload reduced snapshot environment reads from 42 to 26 and input reads from 62 to 38. These measure Gateway overhead, not end-to-end desktop latency.
- Node lookup and affected siblings: 491 tests across 23 files passed. CUA transport: 113 tests passed. The combined five-file registry/CUA run and full changed checks passed.
- Fresh independent review of the combined change passed with no actionable P0–P2 findings. Diff-scoped cleanup removed redundant fleet-search wrappers; no authority cache was introduced.
