### PR TITLE
fix: prevent expired cloud forks from refreshing warm images

### DIFF
--- a/extensions/crabbox/src/crabbox-worker-warm-image-allocation.test.ts
+++ b/extensions/crabbox/src/crabbox-worker-warm-image-allocation.test.ts
@@ -591,6 +591,46 @@ describe("Crabbox durable allocation admission", () => {
     expect(owner.lookupLease(project.id)?.phase).toBe("prepared");
   });
 
+  it("does not publish image demand when a fork completes after project expiry", async () => {
+    const now = Date.now();
+    const expiresAt = now + 60_000;
+    const clock = vi.spyOn(Date, "now").mockReturnValue(now);
+    const { manager, projectContext } = fixture(false, (argv) => {
+      if (argv[2] === "fork") {
+        clock.mockReturnValue(expiresAt);
+      }
+    });
+    const owner = manager();
+    const source = projectContext("cbx_source");
+    await owner.allocate(source);
+    owner.markPrepared(source.id, "a".repeat(40));
+    await owner.capture(source);
+    const before = structuredClone(openWarmImageStore().entries()[0]!.value.image);
+    clock.mockReturnValue(now + 1_000);
+    const next = projectContext("cbx_expired");
+    const signal = new AbortController().signal;
+
+    await expect
+      .soft(
+        owner.allocate({
+          ...next,
+          signal,
+          assertCurrent: () => {
+            if (Date.now() >= expiresAt) {
+              throw new Error("project authority expired");
+            }
+          },
+        }),
+      )
+      .rejects.toThrow();
+    expect(signal.aborted).toBe(false);
+    expect(openWarmImageStore().entries()[0]!.value.image).toEqual(before);
+    expect(owner.lookupLease(next.id)).toMatchObject({
+      phase: "pending",
+      choice: { kind: "checkpoint", checkpointId: CHECKPOINT_ID },
+    });
+  });
+
   it("keeps an uncertain project capture fenced before enrollment after restart", async () => {
     const { manager, context, calls } = fixture(true);
     const owner = manager();

--- a/extensions/crabbox/src/crabbox-worker-warm-image.ts
+++ b/extensions/crabbox/src/crabbox-worker-warm-image.ts
@@ -244,37 +244,33 @@ export function createCrabboxWarmImageManager(dependencies: {
 
   const makeRoom = async (context: LeaseContext) => {
     const deadline = Date.now() + WARM_IMAGE_COMMAND_TIMEOUT_MS;
-    const candidates = openStore()
-      .entries()
+    const entries = openStore().entries();
+    if (entries.length < WARM_IMAGE_MAX_ENTRIES) {
+      return;
+    }
+    const candidates = entries
       .filter(({ value }) => !value.operation && Object.keys(value.allocations).length === 0)
       .toSorted(
         (a, b) => (a.value.image?.lastDemandAtMs ?? 0) - (b.value.image?.lastDemandAtMs ?? 0),
       );
     // Previous generations are reclaimed first, but a slot is freed only when its
     // whole profile has no images, allocations, or deletion obligations left.
-    for (const { key } of candidates) {
-      if (openStore().entries().length < WARM_IMAGE_MAX_ENTRIES) {
-        return;
-      }
-      const current = openStore().lookup(key);
-      const remaining = () => deadline - Date.now();
-      if (current?.previous && remaining() > 0) {
-        await deleteImage(context, key, current, remaining, current.previous.checkpointId);
-      }
-    }
-    for (const { key } of candidates) {
-      if (openStore().entries().length < WARM_IMAGE_MAX_ENTRIES) {
-        return;
-      }
-      const remaining = () => deadline - Date.now();
-      if (remaining() <= 0) {
-        break;
-      }
-      const current = openStore().lookup(key);
-      if (current?.image && !current.previous) {
-        await deleteImage(context, key, current, remaining);
-      } else {
-        deleteEmptyProfile(key);
+    for (const generation of ["previous", "image"] as const) {
+      for (const { key } of candidates) {
+        if (openStore().entries().length < WARM_IMAGE_MAX_ENTRIES) {
+          return;
+        }
+        const remaining = () => deadline - Date.now();
+        if (remaining() <= 0) {
+          break;
+        }
+        const current = openStore().lookup(key);
+        const image = current?.[generation];
+        if (current && image && (generation === "previous" || !current.previous)) {
+          await deleteImage(context, key, current, remaining, image.checkpointId);
+        } else if (generation === "image") {
+          deleteEmptyProfile(key);
+        }
       }
     }
     if (openStore().entries().length >= WARM_IMAGE_MAX_ENTRIES) {
@@ -616,16 +612,17 @@ export function createCrabboxWarmImageManager(dependencies: {
             ),
             { checkpointId, leaseId: context.id, provider: context.provider, slug: context.slug },
           );
-          openStore().update(owner.key, (current) =>
-            withCrabboxWarmImageGeneration(current, owner.imageGeneration, (image) => ({
+          openStore().update(owner.key, (current) => {
+            assertCurrent(context);
+            return withCrabboxWarmImageGeneration(current, owner.imageGeneration, (image) => ({
               ...image,
               state: "available",
               lastDemandAtMs:
                 owner.purpose === "session" || owner.demandAtMs === null
                   ? image.lastDemandAtMs
                   : Math.max(image.lastDemandAtMs ?? 0, owner.demandAtMs),
-            })),
-          );
+            }));
+          });
           return owner.choice;
         }
       }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a checkpoint fork that finishes after its prepared authority expires can still refresh a warm image's demand timestamp. Warm allocation also scans and decodes the full profile store twice even when it is below capacity.

## Why This Change Was Made

The existing synchronous store update now checks current authority before changing the image. Capacity handling reads the initial inventory once and shares its reclamation loop, preserving previous-generation priority, post-await rereads, deletion custody, and the cleanup deadline. Pending allocations remain available to the existing cleanup owner.

## User Impact

Expired fork work cannot make a warm image appear recently demanded. Allocations below the profile cap perform half as much initial inventory decoding without changing restart recovery or the stored representation.

## Evidence

- The regression failed on the original implementation: the expired fork resolved successfully and updated image demand. The candidate rejects it and preserves cleanup custody.
- 95 tests across five warm-image files, all changed checks, and five capacity-pressure scenarios passed.
- At 127 profiles with 256 allocations each, the probe reduced decoded profile rows from 254 to 127 and allocation validations from 65,024 to 32,512. Synthetic timings are diagnostic, not service latency claims.
- Fresh independent P0–P2 review and diff-scoped cleanup passed. Production code is three lines smaller.
