### PR TITLE
perf(sessions): reuse stored session key parsing

### DIFF
--- a/src/gateway/session-store-key.ts
+++ b/src/gateway/session-store-key.ts
@@ -69,8 +69,8 @@ function resolveParsedSessionStoreKey(
   const rest = normalizeLowercaseStringOrEmpty(parsed.rest);
   if (
     parsedAgentId !== DEFAULT_AGENT_ID ||
-    listAgentIds(cfg).includes(DEFAULT_AGENT_ID) ||
-    (rest !== "main" && rest !== normalizeMainKey(cfg.session?.mainKey))
+    (rest !== "main" && rest !== normalizeMainKey(cfg.session?.mainKey)) ||
+    listAgentIds(cfg).includes(DEFAULT_AGENT_ID)
   ) {
     return {
       agentId: parsedAgentId,
@@ -184,17 +184,19 @@ export function resolveStoredSessionKeyForAgentStore(params: {
   if (lowered === "global" || lowered === "unknown") {
     return lowered;
   }
-  const persistedOwner = resolvePersistedSessionStoreOwnerForKey(params.cfg, raw);
-  if (
-    !parseAgentSessionKey(raw) &&
-    persistedOwner.kind === "configured" &&
-    persistedOwner.agentId === normalizeAgentId(params.agentId) &&
-    lowered !== "main" &&
-    lowered !== normalizeMainKey(params.cfg.session?.mainKey)
-  ) {
-    return raw;
+  const parsed = parseAgentSessionKey(raw);
+  if (!parsed) {
+    const persistedOwner = resolvePersistedSessionStoreOwnerForKey(params.cfg, raw);
+    if (
+      persistedOwner.kind === "configured" &&
+      persistedOwner.agentId === normalizeAgentId(params.agentId) &&
+      lowered !== "main" &&
+      lowered !== normalizeMainKey(params.cfg.session?.mainKey)
+    ) {
+      return raw;
+    }
   }
-  const key = parseAgentSessionKey(raw) ? raw : canonicalizeSessionKeyForAgent(params.agentId, raw);
+  const key = parsed ? raw : canonicalizeSessionKeyForAgent(params.agentId, raw);
   return resolveSessionStoreKey({
     cfg: params.cfg,
     sessionKey: key,


### PR DESCRIPTION
Stored session-key canonicalization parsed qualified keys repeatedly and rebuilt the configured agent roster for ordinary `agent:main:*` rows that cannot be main aliases. Reuse the parsed key before the fixed-store check, and check alias eligibility before enumerating agents. Alias routing, retired and fixed-store ownership, opaque identifiers, and canonical errors retain their existing owners.

Measured through `loadCombinedSessionStoreForGatewayCore`: 50 list projections over 1,000 writer-seeded sessions, including 100 case-sensitive Matrix room/thread keys. Original and candidate used the same fixtures; full session/owner fingerprints matched.

| Session owner | Configured agents | Original sampled allocation | Candidate | Reduction |
| --- | ---: | ---: | ---: | ---: |
| main |1 |312.1 MB |235.8 MB |24.5% |
| main |32 |960.2 MB |309.9 MB |67.7% |
| ops |1 |258.0 MB |234.7 MB |9.0% |
| ops |32 |340.0 MB |310.0 MB |8.8% |

One inspector timing sample was slower. Five unprofiled alternating pairs for that case favored the candidate in 4/5 pairs, with median wall time 1060→941ms and CPU 1233→1110ms per 100 reads.

Validation: 64 existing preservation tests passed across combined-store, lookup-owner, and selected key cases; formatting and diff checks passed. Fresh independent P0–P2 review is scoped-clean. Full core/core-test types, lint, and repository guards have not run locally; exact-head CI/native checks remain required.

Exact-head hosted CI 34704445527 passed all required checks. Independent and ClawSweeper source reviews have no actionable findings.

