### PR TITLE
fix: keep cloud host discovery responsive during event bursts

### DIFF
--- a/ui/src/components/desktop/desktop-session-controller.ts
+++ b/ui/src/components/desktop/desktop-session-controller.ts
@@ -87,7 +87,8 @@ export class DesktopSessionController {
             host.documentMode &&
             host.sessionKey !== null &&
             host.requestedSource === null &&
-            event.event === "sessions.changed"
+            event.event === "sessions.changed" &&
+            !(isRecord(event.payload) && event.payload.phase === "message")
               ? readSessionChangedEvent(event.payload)
               : null;
           if (changed && areUiSessionKeysEquivalent(changed.key, host.sessionKey)) {

--- a/ui/src/e2e/desktop-document-mode.e2e.test.ts
+++ b/ui/src/e2e/desktop-document-mode.e2e.test.ts
@@ -222,6 +222,39 @@ suite.define(() => {
       await page.screenshot({
         path: path.join(artifactDirectory, "session-first-frame-without-global-inventory.png"),
       });
+
+      for (let index = 0; index < 32; index += 1) {
+        await gateway.emitGatewayEvent("sessions.changed", { sessionKey, phase: "message" });
+      }
+      expect(await gateway.getRequests("sessions.describe")).toHaveLength(1);
+      expect(await gateway.getRequests("desktop.observe")).toHaveLength(1);
+      expect(await rfb.events()).toEqual(["authenticated:1"]);
+
+      const replacement = { ...environment, id: "worker-replacement" };
+      await gateway.setMethodResponse("environments.status", replacement);
+      await gateway.deferNext("sessions.describe");
+      await gateway.emitGatewayEvent("sessions.changed", { sessionKey, reason: "placement" });
+      await gateway.waitForRequest("sessions.describe", { after: 1 });
+      for (let index = 0; index < 32; index += 1) {
+        await gateway.emitGatewayEvent("sessions.changed", { sessionKey, phase: "message" });
+      }
+      expect(await gateway.getRequests("sessions.describe")).toHaveLength(2);
+      expect(await gateway.getRequests("desktop.observe")).toHaveLength(1);
+      await gateway.resolveDeferred("sessions.describe", {
+        session: { key: sessionKey, placement: { state: "active", environmentId: replacement.id } },
+      });
+      expect((await gateway.waitForRequest("desktop.observe", { after: 1 })).params).toEqual({
+        source: { kind: "environment", environmentId: replacement.id },
+        control: false,
+      });
+      await expect.poll(async () => (await rfb.events()).includes("authenticated:2")).toBe(true);
+      await gateway.setMethodResponse("environments.status", environment);
+      await gateway.emitGatewayEvent("sessions.changed", { sessionKey, phase: "start" });
+      expect((await gateway.waitForRequest("desktop.observe", { after: 2 })).params).toEqual({
+        source: { kind: "environment", environmentId: environment.id },
+        control: false,
+      });
+      expect(await gateway.getRequests("environments.list")).toHaveLength(0);
     });
   });
 

--- a/ui/src/e2e/new-session-page.environment-metadata.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.environment-metadata.e2e.test.ts
@@ -311,6 +311,98 @@ suite.define(() => {
       expect(await selectedRow.locator(".session-menu__check svg").isVisible()).toBe(true);
       expect(await selectionLayout()).toEqual(beforeSelection);
       expect(await gateway.getRequests("node.list")).toHaveLength(0);
+
+      const beforeRefresh = (await gateway.getRequests("environments.list")).length;
+      await gateway.emitGatewayEvent("presence", {
+        presence: [{ instanceId: "other-browser", mode: "webchat", roles: ["operator"] }],
+      });
+      await page.locator("openclaw-new-session-page").evaluate(async (element) => {
+        await (element as HTMLElement & { updateComplete: Promise<unknown> }).updateComplete;
+      });
+      expect(await gateway.getRequests("environments.list")).toHaveLength(beforeRefresh);
+      expect(await selectedRow.isEnabled()).toBe(true);
+
+      const catalog = (
+        status: "available" | "unavailable",
+        available: number,
+        label = "Build runner",
+      ) => ({
+        environments: [
+          {
+            id: "node:alpha-device",
+            type: "node",
+            label,
+            status,
+            sessionHost: true,
+            workerSlots: { total: 4, available },
+          },
+        ],
+        profiles: [],
+      });
+      await gateway.deferNext("environments.list");
+      await gateway.emitGatewayEvent("node.runnerInventory.changed", { nodeId: "alpha-device" });
+      await gateway.waitForRequest("environments.list", { after: beforeRefresh });
+      for (let index = 0; index < 31; index += 1) {
+        await gateway.emitGatewayEvent("node.runnerInventory.changed", { nodeId: "alpha-device" });
+      }
+      expect(await gateway.getRequests("environments.list")).toHaveLength(beforeRefresh + 1);
+      await expect.poll(() => selectedRow.isDisabled()).toBe(true);
+      for (let cycle = 1; cycle <= 4; cycle += 1) {
+        await gateway.deferNext("environments.list");
+        await gateway.resolveDeferred(
+          "environments.list",
+          catalog("available", 2, `Build runner ${cycle}`),
+        );
+        await gateway.waitForRequest("environments.list", { after: beforeRefresh + cycle });
+        await expect.poll(() => selectedRow.textContent()).toContain(`Build runner ${cycle}`);
+        expect(await gateway.getRequests("environments.list")).toHaveLength(
+          beforeRefresh + cycle + 1,
+        );
+        expect(await selectedRow.isDisabled()).toBe(true);
+        if (cycle < 4) {
+          for (let index = 0; index < 8; index += 1) {
+            await gateway.emitGatewayEvent("node.runnerInventory.changed", {
+              nodeId: "alpha-device",
+            });
+          }
+        }
+      }
+      await gateway.resolveDeferred("environments.list", catalog("available", 0));
+      await selectedRow.hover();
+      await expect
+        .poll(() => details("alpha-device").textContent())
+        .toContain("No worker slots are available");
+      expect(await selectedRow.getAttribute("aria-pressed")).toBe("true");
+
+      // Nodes without a worker-supervisor proof still publish connection presence.
+      for (const connected of [false, true]) {
+        const previousRequests = (await gateway.getRequests("environments.list")).length;
+        await gateway.setMethodResponse(
+          "environments.list",
+          catalog(connected ? "available" : "unavailable", 4),
+        );
+        await gateway.emitGatewayEvent("presence", {
+          presence: [
+            {
+              deviceId: "alpha-device",
+              mode: "node",
+              roles: ["node"],
+              reason: connected ? "connect" : "disconnect",
+            },
+          ],
+        });
+        await gateway.waitForRequest("environments.list", { after: previousRequests });
+        await expect.poll(() => selectedRow.isEnabled()).toBe(connected);
+      }
+      for (const sessionHost of [false, true]) {
+        const previousRequests = (await gateway.getRequests("environments.list")).length;
+        const next = catalog("available", 4);
+        next.environments[0]!.sessionHost = sessionHost;
+        await gateway.setMethodResponse("environments.list", next);
+        await gateway.emitGatewayEvent("node.runnerInventory.changed", { nodeId: "alpha-device" });
+        await gateway.waitForRequest("environments.list", { after: previousRequests });
+        await expect.poll(() => selectedRow.isEnabled()).toBe(sessionHost);
+      }
     } finally {
       await context.close();
     }

--- a/ui/src/pages/new-session/cloud-profile-discovery.ts
+++ b/ui/src/pages/new-session/cloud-profile-discovery.ts
@@ -1,19 +1,1 @@
-import type { GatewayBrowserClient } from "../../api/gateway.ts";
-import { requestPlaceCatalog } from "./cloud-target.ts";
-import type { DraftCloudProfile, DraftEnvironment } from "./discovery.ts";
-
 export const CLOUD_PROFILE_RETRY_DELAYS_MS = [1_000, 3_000, 10_000, 30_000, 60_000] as const;
-
-export function discoverPlaceCatalog(
-  client: Pick<GatewayBrowserClient, "request">,
-  canWrite: boolean,
-  isAdmin: boolean,
-  runtimeId?: string,
-): Promise<{ profiles: DraftCloudProfile[]; environments: DraftEnvironment[] }> {
-  return canWrite
-    ? requestPlaceCatalog(client, runtimeId).then((catalog) => ({
-        ...catalog,
-        profiles: isAdmin ? catalog.profiles : [],
-      }))
-    : Promise.resolve({ profiles: [], environments: [] });
-}

--- a/ui/src/pages/new-session/draft-gateway-state.ts
+++ b/ui/src/pages/new-session/draft-gateway-state.ts
@@ -10,7 +10,8 @@ import { t } from "../../i18n/index.ts";
 import { isGatewayMethodAdvertised } from "../../lib/gateway-methods.ts";
 import { normalizeAgentId } from "../../lib/sessions/session-key.ts";
 import * as catalog from "./catalog-target.ts";
-import { CLOUD_PROFILE_RETRY_DELAYS_MS, discoverPlaceCatalog } from "./cloud-profile-discovery.ts";
+import { CLOUD_PROFILE_RETRY_DELAYS_MS } from "./cloud-profile-discovery.ts";
+import { requestPlaceCatalog } from "./cloud-target.ts";
 import type { DraftCloudProfile, DraftEnvironment } from "./discovery.ts";
 import { discoverGatewayName } from "./gateway-name-discovery.ts";
 import type { NewSessionRouteData } from "./location.ts";
@@ -78,6 +79,7 @@ export class DraftGatewayState {
   private catalogRetryAttempt = 0;
   private catalogRetryTimer: ReturnType<typeof globalThis.setTimeout> | undefined;
   private cloudProfileRetryAttempt = 0;
+  private cloudProfileRefresh: Promise<void> | null = null;
   private cloudProfileRetryTimer: ReturnType<typeof globalThis.setTimeout> | undefined;
   private preferenceScope = "";
   private preferenceModeValue: "local" | "loading" | "remote" = "local";
@@ -117,19 +119,25 @@ export class DraftGatewayState {
           this.gatewayRecoveryScopeValue,
           this.read().runtimeId,
         ] as const,
-      task: ([client, _connectionEpoch, canWrite, isAdmin, _recoveryScope, runtimeId]) =>
-        client ? discoverPlaceCatalog(client, canWrite, isAdmin, runtimeId) : initialState,
+      task: async ([client, _connectionEpoch, canWrite, isAdmin, _recoveryScope, runtimeId]) => {
+        if (!client) {
+          return initialState;
+        }
+        if (!canWrite) {
+          return { profiles: [], environments: [] };
+        }
+        const result = await requestPlaceCatalog(client, runtimeId);
+        return { ...result, profiles: isAdmin ? result.profiles : [] };
+      },
       onComplete: (placeCatalog) => {
         this.resetCloudProfileRetry();
         this.environmentsValue = placeCatalog.environments;
         this.applyCloudProfiles(placeCatalog.profiles);
         this.cloudProfilesReadyValue = true;
-        this.callbacks.requestUpdate();
       },
       onError: () => {
         // A failed refresh cannot invalidate this Gateway's last successful place catalog.
         this.scheduleCloudProfileRetry();
-        this.callbacks.requestUpdate();
       },
     });
   }
@@ -207,7 +215,24 @@ export class DraftGatewayState {
       : undefined;
   }
 
-  refreshCloudProfiles() {
+  refreshCloudProfiles(): Promise<void> {
+    if (this.cloudProfileTask.status === TaskStatus.PENDING) {
+      const queued =
+        this.cloudProfileRefresh ??
+        this.cloudProfileTask.taskComplete
+          .catch(() => undefined)
+          .then(() => {
+            if (this.cloudProfileRefresh === queued) {
+              this.cloudProfileRefresh = null;
+              return this.refreshCloudProfiles();
+            }
+            return undefined;
+          });
+      this.cloudProfileRefresh = queued;
+      return queued;
+    }
+    globalThis.clearTimeout(this.cloudProfileRetryTimer);
+    this.cloudProfileRetryTimer = undefined;
     return this.cloudProfileTask.run();
   }
 
@@ -297,6 +322,7 @@ export class DraftGatewayState {
   }
 
   invalidateDiscovery(resetHostSelection: boolean, submissionOutcome: SubmissionOutcomeReason) {
+    this.cloudProfileRefresh = null;
     // Retire pending results synchronously; Lit may not run hostUpdate before they settle.
     void this.cloudProfileTask.run([null, -1, false, false, ""]);
     this.cloudProfilesValue = [];
@@ -462,6 +488,7 @@ export class DraftGatewayState {
   }
 
   disconnect() {
+    this.cloudProfileRefresh = null;
     this.gatewaySource = null;
     this.gatewayClientValue = null;
     this.gatewayConnectedValue = false;

--- a/ui/src/pages/new-session/new-session-page.ts
+++ b/ui/src/pages/new-session/new-session-page.ts
@@ -37,7 +37,7 @@ import {
   closeSessionMenus,
   createControllerHost,
   isPlaceTopologyEvent,
-  presenceStateSignature,
+  nodePresenceStateSignature,
 } from "./new-session-runtime.ts";
 import type { SubmissionOutcomeReason } from "./session-placement-recovery-state.ts";
 import { renderAgentSelect, renderNewSessionPlaceControls } from "./target-controls.ts";
@@ -189,7 +189,7 @@ export class NewSessionPage extends OpenClawLightDomElement {
       .effect(
         () => this.context?.gateway,
         (gateway) => {
-          this.presenceSignature = presenceStateSignature(
+          this.presenceSignature = nodePresenceStateSignature(
             readPresenceEntries(gateway.snapshot.hello?.snapshot) ?? [],
           );
           return gateway.subscribeEvents((event) => {
@@ -205,7 +205,7 @@ export class NewSessionPage extends OpenClawLightDomElement {
             if (!presence) {
               return;
             }
-            const signature = presenceStateSignature(presence);
+            const signature = nodePresenceStateSignature(presence);
             if (signature !== this.presenceSignature) {
               this.presenceSignature = signature;
               void this.gateway.refreshCloudProfiles();

--- a/ui/src/pages/new-session/new-session-runtime.ts
+++ b/ui/src/pages/new-session/new-session-runtime.ts
@@ -15,11 +15,11 @@ export function isPlaceTopologyEvent(event: string): boolean {
   return PLACE_TOPOLOGY_EVENTS.has(event);
 }
 
-export function presenceStateSignature(entries: PresenceEntry[]): string {
+export function nodePresenceStateSignature(entries: PresenceEntry[]): string {
   const states = new Map<string, "connected" | "offline">();
   for (const entry of entries) {
     const id = (entry.deviceId ?? entry.instanceId)?.trim().toLowerCase();
-    if (!id || entry.mode?.trim().toLowerCase() === "gateway") {
+    if (!id || !entry.roles?.includes("node")) {
       continue;
     }
     states.set(id, entry.reason?.trim().toLowerCase() === "disconnect" ? "offline" : "connected");


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where New Session repeatedly reloads its environment catalog during presence and inventory bursts, and Desktop reloads placement for every transcript message. Continuous inventory traffic can keep capacity labels stale while requests accumulate.

## Why This Change Was Made

New Session tracks node presence, coalesces catalog events into one pending request plus one trailing refresh, and publishes each completed result. Desktop ignores transcript-only session notifications while preserving placement and lifecycle refreshes. The redundant catalog wrapper and duplicate update notifications are removed.

## User Impact

Host availability keeps updating during sustained traffic without piling up catalog requests. Ordinary browser/operator presence and chat transcript messages no longer trigger unrelated discovery work. Non-hosting node reconnects and explicit desktop target selection still work.

## Evidence

- A 32-event inventory burst fell from 32 catalog requests to two; 32 transcript events fell from 32 placement lookups to zero.
- Continuous inventory traffic stayed at one pending request while every capacity label progressed; the baseline accumulated up to 30 pending requests with stale labels.
- 74 unit tests, 19 bundled browser E2Es, an additional hosting/reconnect case, and full changed checks passed. Independent source-blind validation passed six behavior clauses at two burst sizes.
- The signed-in Chrome extension relay also passed: zero refreshes for operator presence, one pending plus one trailing catalog request for 32 events, progressive labels in four continuous cycles, zero desktop lookups for 32 transcript messages, and exactly one lookup/observation for a real placement change. The noVNC canvas rendered and no page errors occurred.
- Fresh independent P0–P2 review and diff-scoped cleanup passed.

Unrelated browser presence, with the same synthetic catalog before and after:

**Before**

![Before: Build machine availability after browser presence](https://github.com/user-attachments/assets/6ee7ba19-d95e-4d64-9d62-6dbe6ec4a783)

**After**

![After: Build machine availability after browser presence](https://github.com/user-attachments/assets/969cc4f5-6ff8-4815-98eb-810cd7a6e99c)

Exact-head CI passed on attempt 2. The first attempt hit an unrelated 60-second timeout in the unchanged CLI updater subprocess test; its source and runtime matched the base. One targeted job rerun passed without source or test changes.
