### PR TITLE
fix(test): reuse idle transform caches across scheduler slots

### DIFF
--- a/scripts/lib/vitest-cache-slots.mts
+++ b/scripts/lib/vitest-cache-slots.mts
@@ -11,8 +11,8 @@ type CacheSpec = {
 
 /** A slot remains borrowed through retries and the process owner's final join. */
 export function createVitestCacheSlots(concurrency: number, platform = process.platform) {
-  const available = Array.from({ length: concurrency }, (_, index) => index);
-  let nextSlot = concurrency;
+  const idleSlots = new Map<string, number[]>();
+  let nextSlot = 0;
   return async <T extends CacheSpec, R extends { groupJoined: boolean }>(
     spec: T,
     run: (assigned: T) => Promise<R>,
@@ -25,8 +25,12 @@ export function createVitestCacheSlots(concurrency: number, platform = process.p
     ) {
       return run(spec);
     }
-    const slot = available.pop() ?? nextSlot++;
     const configKey = createHash("sha256").update(path.resolve(spec.config)).digest("hex");
+    const cacheKey = path.join(path.resolve(spec.cacheAssignment.root), configKey);
+    const available = idleSlots.get(cacheKey) ?? [];
+    idleSlots.set(cacheKey, available);
+    // Fresh indices stay global: distinct root spellings may alias one directory.
+    const slot = available.pop() ?? nextSlot++;
     const result = await run({
       ...spec,
       cacheAssignment: { ...spec.cacheAssignment, leased: true },

--- a/test/scripts/vitest-cache-slots.test.ts
+++ b/test/scripts/vitest-cache-slots.test.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { createVitestCacheSlots } from "../../scripts/lib/vitest-cache-slots.mts";
 import type { VitestCacheAssignment } from "../../scripts/test-projects.test-support.mts";
@@ -12,6 +13,104 @@ const spec = {
 const cachePath = (assigned: typeof spec) => assigned.env.OPENCLAW_VITEST_FS_MODULE_CACHE_PATH;
 
 describe("Vitest cache slot ownership", () => {
+  it("reuses an idle config cache while another config occupies its former scheduler slot", async () => {
+    const run = createVitestCacheSlots(2, "linux");
+    const first = createDeferred<{ groupJoined: boolean }>();
+    const peer = createDeferred<{ groupJoined: boolean }>();
+    const third = createDeferred<{ groupJoined: boolean }>();
+    const paths: string[] = [];
+    const start = (config: string, completion: typeof first) =>
+      run({ ...spec, config }, (assigned) => {
+        paths.push(cachePath(assigned));
+        return completion.promise;
+      });
+    const pendingFirst = start("a.config.ts", first);
+    const pendingPeer = start("b.config.ts", peer);
+    let pendingThird: Promise<{ groupJoined: boolean }> | undefined;
+    try {
+      first.resolve({ groupJoined: true });
+      await pendingFirst;
+      pendingThird = start("c.config.ts", third);
+      peer.resolve({ groupJoined: true });
+      await pendingPeer;
+      await run({ ...spec, config: "a.config.ts" }, async (assigned) => {
+        expect(cachePath(assigned)).toBe(paths[0]);
+        expect(cachePath(assigned)).not.toBe(paths[2]);
+        return { groupJoined: true };
+      });
+      expect(new Set(paths).size).toBe(3);
+    } finally {
+      first.resolve({ groupJoined: true });
+      peer.resolve({ groupJoined: true });
+      third.resolve({ groupJoined: true });
+      await Promise.all([pendingFirst, pendingPeer, pendingThird]);
+    }
+  });
+
+  it("reuses lexical root and config aliases without sharing live leases", async () => {
+    const run = createVitestCacheSlots(2, "linux");
+    const first = createDeferred<{ groupJoined: boolean }>();
+    let firstPath: string | undefined;
+    const pending = run(spec, (assigned) => {
+      firstPath = cachePath(assigned);
+      return first.promise;
+    });
+    const alias = {
+      ...spec,
+      config: "test/vitest/../vitest/vitest.tooling.config.ts",
+      cacheAssignment: {
+        kind: "scheduler",
+        root: "/cache/unused/..",
+      } satisfies VitestCacheAssignment,
+    };
+    try {
+      await run(alias, async (assigned) => {
+        expect(cachePath(assigned)).not.toBe(firstPath);
+        return { groupJoined: true };
+      });
+      first.resolve({ groupJoined: true });
+      await pending;
+      await run(alias, async (assigned) => {
+        expect(cachePath(assigned)).toBe(firstPath);
+        return { groupJoined: true };
+      });
+    } finally {
+      first.resolve({ groupJoined: true });
+      await pending;
+    }
+  });
+
+  it("keeps fresh indices distinct across root spellings even after an unjoined lease", async () => {
+    const run = createVitestCacheSlots(2, "linux");
+    const first = createDeferred<{ groupJoined: boolean }>();
+    const paths: string[] = [];
+    const pending = run(spec, (assigned) => {
+      paths.push(cachePath(assigned));
+      return first.promise;
+    });
+    // These names may be symlinks to the same root; suffixes must remain distinct.
+    const alias = {
+      ...spec,
+      cacheAssignment: { kind: "scheduler", root: "/cache-alias" } satisfies VitestCacheAssignment,
+    };
+    try {
+      await run(alias, async (assigned) => {
+        paths.push(cachePath(assigned));
+        return { groupJoined: false };
+      });
+      first.resolve({ groupJoined: false });
+      await pending;
+      await run(spec, async (assigned) => {
+        paths.push(cachePath(assigned));
+        return { groupJoined: true };
+      });
+      expect(new Set(paths.map((value) => path.basename(path.dirname(value)))).size).toBe(3);
+    } finally {
+      first.resolve({ groupJoined: false });
+      await pending;
+    }
+  });
+
   it("holds concurrent leases until joined and reuses a failed command's completed slot", async () => {
     const run = createVitestCacheSlots(2, "linux");
     const first = createDeferred<{ groupJoined: boolean; code: number }>();


### PR DESCRIPTION
## What Problem This Solves

Developers running mixed Vitest shards can pay for duplicate transforms even when a compatible cache is idle. A different shard can take the former scheduler slot, causing the next invocation of the same config to use another cache directory.

## Why This Change Was Made

Pool idle cache slots by resolved cache root and config, while keeping fresh indices globally unique. This reuses an available compatible directory without changing scheduling order, concurrency, test membership, or isolation. Global indices preserve separation when different root spellings alias the same physical directory.

A lease is still held through preflight, retries, and verified process-group completion. Rejected or unjoined leases remain retired; caller-owned, serial, watch, and Windows paths keep their existing behavior.

## User Impact

Mixed local test runs avoid unnecessary duplicate cache population. Application behavior is unchanged. This change makes no percentage speedup or full-suite runtime claim.

## Evidence

- Added regression fails on the original allocator at the intended cache-path equality; all 10 allocator cases pass with the fix.
- All 9 selected existing preflight, retry, and lifecycle integration cases pass. Mapped changed checks and independent P2 review pass.
- A supervised synthetic repeated-workload pilot completed four sides with the same 263-case multiset per side. Both baselines populated two byte-identical 39-file caches for the repeated config; both candidates reused one 39-file directory, whose final writes preceded the second invocation.
- All observed command groups were reconciled absent, and the candidate source was restored unchanged. The pilot establishes cache reuse and avoided duplicate storage work, not a timed benchmark result: completion labels differed from the initial prediction, compilation cost varied, and another shard remained the critical path.

Scope: two files, net +4 tooling lines and +99 regression-test lines. The pilot reporter, driver, and evidence remain outside the repository.
