### PR TITLE
refactor: move shared database admission into its worker

### DIFF
--- a/docs/plugins/sdk-runtime/background-work.md
+++ b/docs/plugins/sdk-runtime/background-work.md
@@ -162,6 +162,10 @@ Start agent work in the background: hook-dispatched turns for external content, 
     Warmed task and flow SQL queries run in the worker. A result describes its
     query snapshot and may be superseded by a later mutation.
 
+    The shared worker uses the canonical database opener and preserves classified
+    schema and ownership errors. Closing the shared database waits for in-flight
+    worker results and native cleanup before releasing its connection ownership.
+
     Lists sort newest first. Equal task timestamps sort by task ID descending;
     equal flow timestamps sort by flow ID ascending. Run-ID lookup retains its
     runtime preference and oldest-first selection, then uses task ID ascending

--- a/docs/reference/database-schemas/storage-changes.md
+++ b/docs/reference/database-schemas/storage-changes.md
@@ -36,8 +36,16 @@ kernels. Their existing facades retain global connection acquisition, cache and
 close behavior, and write transaction admission. Compound subagent and cron
 operations call the kernels on their already-admitted connection. Task status
 classification stays with the pure record types, so decoding does not load
-provider or plugin runtime ownership. These operations and their transaction
-callbacks remain synchronous; this separation does not move SQL to a worker.
+provider or plugin runtime ownership. Kernels and their transaction callbacks
+remain synchronous. The asynchronous task and flow read facade runs these read
+kernels in the shared-state worker.
+
+The host captures the database path, state environment, and current admission
+before awaited work. The shared worker owns its canonical connection and schema
+opening, with Gateway schema authority delegated by its live coordinator owner.
+Classified database errors survive transport, and canonical close joins worker
+operations and native cleanup. Cold registry restoration and runtime-configuration
+preparation still retain their existing main-thread behavior.
 
 SQLite worker transport preserves complete result values. Results within the
 64 MiB inline reply budget keep their existing reply path; larger results are

--- a/src/claws/provenance-runtime-read.ts
+++ b/src/claws/provenance-runtime-read.ts
@@ -97,6 +97,9 @@ function isOwnershipUnknown(snapshot: ClawInstallSchemaVersionSnapshot | undefin
 }
 
 registerOpenClawStateDatabaseLifecycleListener((event) => {
+  if (event.kind === "failure-cleared") {
+    return;
+  }
   const previous = snapshotsByPath.get(event.kind === "opened" ? event.database.path : event.path);
   if (event.kind === "opened") {
     const snapshot = readSchemaVersions(event.database.db);
@@ -110,7 +113,7 @@ registerOpenClawStateDatabaseLifecycleListener((event) => {
           }
         : snapshot,
     );
-  } else if (event.kind === "open-error") {
+  } else if (event.kind === "open-error" || event.kind === "terminal-failure") {
     snapshotsByPath.set(event.path, {
       kind: "state-error",
       error: event.error,

--- a/src/cli/update-cli/update-command-fresh-preview.test.ts
+++ b/src/cli/update-cli/update-command-fresh-preview.test.ts
@@ -168,6 +168,7 @@ describe("update command admission with fresh state", () => {
     if (cleanup.includes("coordinator")) {
       vi.spyOn(initialization, "acquireLegacyUpdateInitializationFence").mockReturnValue({
         path: path.join(fixture.root, "fixture-coordinator"),
+        closed: false,
         release: legacyRelease,
       });
     }
@@ -246,6 +247,7 @@ describe("update command admission with fresh state", () => {
     });
     vi.spyOn(initialization, "acquireLegacyUpdateInitializationFence").mockReturnValue({
       path: path.join(fixture.root, "fixture-coordinator"),
+      closed: false,
       release,
     });
     await expect(updateCommand({ yes: true, json: true, restart: false })).rejects.toBe(

--- a/src/infra/sqlite-coordinator.idle.test.ts
+++ b/src/infra/sqlite-coordinator.idle.test.ts
@@ -14,6 +14,9 @@ import {
 import {
   acquireStateDatabaseCoordinator,
   acquireStateDatabaseHandleExclusion,
+  captureStateDatabaseCoordinatorRuntime,
+  resolveStateDatabaseCoordinatorPath,
+  withStateDatabaseCoordinatorRuntimeDirectory,
 } from "./state-database-coordinator.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
@@ -126,6 +129,180 @@ describe("idle SQLite coordinator connections", () => {
     vi.advanceTimersByTime(30 * 60_000);
     expect(database.isOpen).toBe(false);
   });
+
+  it("ends the released lease's custody when its connection enters the idle pool", () => {
+    const { location } = fixture();
+    const databases = observeConnections();
+    const first = tryAcquireExclusiveSqliteCoordinator(location, { keepAlive: true });
+    const database = firstConnection(databases());
+    first?.release();
+    const next = tryAcquireExclusiveSqliteCoordinator(location, { keepAlive: true });
+    try {
+      expect(databases().size).toBe(1);
+      first?.release();
+      first?.release({ keepAlive: false });
+      expect(database.isTransaction).toBe(true);
+      expect(database.isOpen).toBe(true);
+      expect(first?.closed).toBe(true);
+      expect(next?.closed).toBe(false);
+    } finally {
+      next?.release();
+    }
+    first?.release();
+    expect(next?.closed).toBe(true);
+    expect(database.isOpen).toBe(true);
+    expect(database.isTransaction).toBe(false);
+  });
+
+  it.each([false, true])(
+    "restores capture-time pooling eligibility independently of ambient scope (canonical: %s)",
+    async (canonical) => {
+      const { directory } = fixture();
+      const defaultRuntime = captureStateDatabaseCoordinatorRuntime();
+      const captured = withStateDatabaseCoordinatorRuntimeDirectory(
+        canonical ? defaultRuntime : defaultRuntime.directory,
+        captureStateDatabaseCoordinatorRuntime,
+      );
+      const params = { databasePath: path.join(directory, "state.sqlite") };
+      withStateDatabaseCoordinatorRuntimeDirectory(captured, () =>
+        acquireStateDatabaseCoordinator(params),
+      ).release();
+      const databases = observeConnections();
+      await withStateDatabaseCoordinatorRuntimeDirectory(directory, async () => {
+        await Promise.resolve();
+        const lease = withStateDatabaseCoordinatorRuntimeDirectory(captured, () =>
+          acquireStateDatabaseCoordinator(params),
+        );
+        expect(lease.path).toBe(
+          resolveStateDatabaseCoordinatorPath({
+            ...params,
+            runtimeDirectory: defaultRuntime.directory,
+            uid: typeof process.getuid === "function" ? process.getuid() : undefined,
+          }),
+        );
+        lease.release();
+        expect(lease.closed).toBe(true);
+        expect(firstConnection(databases()).isOpen).toBe(canonical);
+      });
+    },
+  );
+
+  it("retries a failed pooled release until native close finishes", () => {
+    const { location } = fixture();
+    const databases = observeConnections();
+    const lease = tryAcquireExclusiveSqliteCoordinator(location, { keepAlive: true });
+    const database = firstConnection(databases());
+    const rollback = vi.spyOn(database, "exec").mockImplementationOnce(() => {
+      throw new Error("rollback failed");
+    });
+    const close = vi.spyOn(database, "close").mockImplementationOnce(() => {
+      throw new Error("native close failed");
+    });
+    try {
+      expect(() => lease?.release()).toThrow("rollback and close both failed");
+      expect(lease?.closed).toBe(false);
+      expect(database.isOpen).toBe(true);
+      lease?.release();
+      expect(lease?.closed).toBe(true);
+      expect(database.isOpen).toBe(false);
+      expect(close).toHaveBeenCalledTimes(2);
+      const next = tryAcquireExclusiveSqliteCoordinator(location, { keepAlive: true });
+      try {
+        expect(databases().size).toBe(2);
+        lease?.release();
+        expect(close).toHaveBeenCalledTimes(2);
+        expect(next?.closed).toBe(false);
+      } finally {
+        next?.release();
+      }
+    } finally {
+      rollback.mockRestore();
+      close.mockRestore();
+      lease?.release();
+    }
+  });
+
+  it.each([false, true])(
+    "retries only unfinished forced-close custody (physically closed: %s)",
+    (physicallyClosed) => {
+      const { location } = fixture();
+      const databases = observeConnections();
+      const lease = tryAcquireExclusiveSqliteCoordinator(location, { keepAlive: true });
+      const database = firstConnection(databases());
+      const closeNative = database.close.bind(database);
+      const close = vi.spyOn(database, "close").mockImplementationOnce(() => {
+        if (physicallyClosed) {
+          closeNative();
+        }
+        throw new Error("forced native close failed");
+      });
+      const rollback = vi.spyOn(database, "exec");
+      rollback.mockClear();
+      try {
+        expect(() => lease?.release({ keepAlive: false })).toThrow("forced native close failed");
+        expect(lease?.closed).toBe(physicallyClosed);
+        expect(database.isOpen).toBe(!physicallyClosed);
+        lease?.release();
+        expect(lease?.closed).toBe(true);
+        expect(database.isOpen).toBe(false);
+        expect(close).toHaveBeenCalledTimes(physicallyClosed ? 1 : 2);
+        expect(rollback).toHaveBeenCalledExactlyOnceWith("ROLLBACK");
+        lease?.release({ keepAlive: false });
+        expect(close).toHaveBeenCalledTimes(physicallyClosed ? 1 : 2);
+      } finally {
+        close.mockRestore();
+        rollback.mockRestore();
+        lease?.release({ keepAlive: false });
+      }
+    },
+  );
+
+  it.each([tryAcquireExclusiveSqliteCoordinator, tryAcquireSharedSqliteCoordinator])(
+    "lets a non-retaining acquisition consume and close an idle handle",
+    (acquire) => {
+      const { location } = fixture();
+      const databases = observeConnections();
+      tryAcquireExclusiveSqliteCoordinator(location, { keepAlive: true })?.release();
+      const database = firstConnection(databases());
+      const retirement = acquire(location);
+      try {
+        expect(databases().size).toBe(1);
+        expect(database.isTransaction).toBe(true);
+      } finally {
+        retirement?.release();
+      }
+      expect(retirement?.closed).toBe(true);
+      expect(database.isOpen).toBe(false);
+      fs.unlinkSync(location);
+    },
+  );
+
+  it.each([false, true])(
+    "keeps no-retention sticky until the last held reference releases (retirement first: %s)",
+    (retirementFirst) => {
+      const { directory } = fixture();
+      const params = { databasePath: path.join(directory, "state.sqlite") };
+      acquireStateDatabaseCoordinator(params).release();
+      const databases = observeConnections();
+      const outer = acquireStateDatabaseCoordinator(params);
+      const retirement = acquireStateDatabaseCoordinator({ ...params, keepAlive: false });
+      const database = firstConnection(databases());
+      const [first, last] = retirementFirst ? [retirement, outer] : [outer, retirement];
+      try {
+        expect(databases().size).toBe(1);
+        first.release();
+        expect(first.closed).toBe(true);
+        expect(database.isTransaction).toBe(true);
+        last.release();
+        expect(last.closed).toBe(true);
+        expect(database.isOpen).toBe(false);
+        fs.unlinkSync(last.path);
+      } finally {
+        outer.release();
+        retirement.release();
+      }
+    },
+  );
 
   it.skipIf(process.platform === "win32").each(["replace", "delete"])(
     "locks the current file after idle pathname %s",

--- a/src/infra/sqlite-coordinator.test-support.ts
+++ b/src/infra/sqlite-coordinator.test-support.ts
@@ -1,0 +1,20 @@
+import { vi } from "vitest";
+import * as sqlite from "./node-sqlite.js";
+
+export function captureCoordinatorDatabase<T>(operation: () => T) {
+  const open = sqlite.openNodeSqliteDatabase;
+  let database: ReturnType<typeof open> | undefined;
+  const opening = vi.spyOn(sqlite, "openNodeSqliteDatabase").mockImplementationOnce((...args) => {
+    database = open(...args);
+    return database;
+  });
+  try {
+    const result = operation();
+    if (!database) {
+      throw new Error("Fixture did not open its coordinator");
+    }
+    return { result, database };
+  } finally {
+    opening.mockRestore();
+  }
+}

--- a/src/infra/sqlite-coordinator.test.ts
+++ b/src/infra/sqlite-coordinator.test.ts
@@ -8,6 +8,7 @@ import {
   ensurePrivateSqliteCoordinatorDirectory,
   tryAcquireExclusiveSqliteCoordinator,
 } from "./sqlite-coordinator.js";
+import { captureCoordinatorDatabase } from "./sqlite-coordinator.test-support.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 const loader = new URL("../../scripts/tsx.mjs", import.meta.url).href;
@@ -46,6 +47,42 @@ const acquirePeer = `
 `;
 
 describe("data-free SQLite coordinator", () => {
+  it.each([false, true])(
+    "retries only unfinished native cleanup after a close error (physically closed: %s)",
+    (physicallyClosed) => {
+      const pathname = path.join(tempDirs.make("openclaw-coordinator-close-retry-"), "lock.sqlite");
+      const { result: coordinator, database } = captureCoordinatorDatabase(() =>
+        tryAcquireExclusiveSqliteCoordinator(pathname),
+      );
+      if (!coordinator) {
+        throw new Error("Fixture coordinator was not acquired");
+      }
+      const closeNative = database.close.bind(database);
+      const close = vi.spyOn(database, "close").mockImplementationOnce(() => {
+        if (physicallyClosed) {
+          closeNative();
+        }
+        throw new Error("Fixture native close failed");
+      });
+      const exec = vi.spyOn(database, "exec");
+      try {
+        expect(() => coordinator.release()).toThrow("Fixture native close failed");
+        expect(coordinator.closed).toBe(physicallyClosed);
+        expect(database.isOpen).toBe(!physicallyClosed);
+        expect(() => coordinator.release()).not.toThrow();
+        expect(coordinator.closed).toBe(true);
+        expect(close).toHaveBeenCalledTimes(physicallyClosed ? 1 : 2);
+        expect(exec).toHaveBeenCalledExactlyOnceWith("ROLLBACK");
+        coordinator.release();
+        expect(close).toHaveBeenCalledTimes(physicallyClosed ? 1 : 2);
+      } finally {
+        close.mockRestore();
+        exec.mockRestore();
+        coordinator.release();
+      }
+    },
+  );
+
   it("leaves an existing coordinator unchanged while excluding current and default-journal peers", () => {
     const directory = tempDirs.make("openclaw-sqlite-coordinator-");
     const pathname = path.join(directory, "coordinator.sqlite");

--- a/src/infra/sqlite-coordinator.ts
+++ b/src/infra/sqlite-coordinator.ts
@@ -17,6 +17,12 @@ export class SqliteCoordinatorError extends Error {
   }
 }
 
+export type SqliteCoordinatorLease = {
+  /** This lease has relinquished custody, either to the pool or by native close. */
+  readonly closed: boolean;
+  release: (options?: { keepAlive?: false }) => void;
+};
+
 export function createSqliteLifecycleAggregateError(
   errors: unknown[],
   message: string,
@@ -227,7 +233,7 @@ function tryAcquireSqliteCoordinator(
   location: string,
   mode: "shared" | "exclusive",
   options: { busyTimeoutMs?: number; keepAlive?: boolean },
-): { release: (options?: { keepAlive?: false }) => void } | null {
+): SqliteCoordinatorLease | null {
   const busyTimeoutMs = Math.max(0, Math.trunc(options.busyTimeoutMs ?? 0));
   const reusableLocation =
     location !== "" && location !== ":memory:" && !location.startsWith("file:")
@@ -277,19 +283,25 @@ function tryAcquireSqliteCoordinator(
   }
   let released = false;
   return {
+    get closed() {
+      return released || !database.isOpen;
+    },
     release: (releaseOptions) => {
-      if (released) {
+      if (released || !database.isOpen) {
         return;
       }
-      released = true;
       const errors: unknown[] = [];
-      try {
-        database.exec("ROLLBACK");
-        if (poolLocation && database.isTransaction) {
-          throw new SqliteCoordinatorError("SQLite coordinator rollback left its transaction open");
+      if (database.isTransaction) {
+        try {
+          database.exec("ROLLBACK");
+          if (poolLocation && database.isTransaction) {
+            throw new SqliteCoordinatorError(
+              "SQLite coordinator rollback left its transaction open",
+            );
+          }
+        } catch (error) {
+          errors.push(error);
         }
-      } catch (error) {
-        errors.push(error);
       }
       let retained = false;
       if (
@@ -297,7 +309,8 @@ function tryAcquireSqliteCoordinator(
         options.keepAlive &&
         releaseOptions?.keepAlive !== false &&
         poolLocation &&
-        identity
+        identity &&
+        !failedIdleCloses.has(database)
       ) {
         try {
           retained = retainIdleCoordinator(poolLocation, database, identity);
@@ -305,7 +318,7 @@ function tryAcquireSqliteCoordinator(
           errors.push(error);
         }
       }
-      if (!retained) {
+      if (!retained && database.isOpen) {
         try {
           if (poolLocation) {
             closeIdleCoordinatorDatabase(database);
@@ -316,6 +329,8 @@ function tryAcquireSqliteCoordinator(
           errors.push(error);
         }
       }
+      // Pool handoff ends this lease; a later borrower owns the still-open handle.
+      released = retained || !database.isOpen;
       if (errors.length === 1) {
         throw errors[0];
       }
@@ -330,7 +345,7 @@ function tryAcquireSqliteCoordinator(
 export function tryAcquireExclusiveSqliteCoordinator(
   location: string,
   options: { busyTimeoutMs?: number; keepAlive?: boolean } = {},
-): { release: (options?: { keepAlive?: false }) => void } | null {
+): SqliteCoordinatorLease | null {
   return tryAcquireSqliteCoordinator(location, "exclusive", options);
 }
 
@@ -338,6 +353,6 @@ export function tryAcquireExclusiveSqliteCoordinator(
 export function tryAcquireSharedSqliteCoordinator(
   location: string,
   options: { busyTimeoutMs?: number } = {},
-): { release: () => void } | null {
+): SqliteCoordinatorLease | null {
   return tryAcquireSqliteCoordinator(location, "shared", options);
 }

--- a/src/infra/sqlite-store.worker.ts
+++ b/src/infra/sqlite-store.worker.ts
@@ -2,6 +2,7 @@ import { isPromise } from "node:util/types";
 import { deserialize, serialize } from "node:v8";
 import { parentPort } from "node:worker_threads";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { encodeOpenClawStateWorkerError } from "../state/openclaw-state-worker-error.js";
 import {
   SQLITE_WORKER_MAX_RESULT_BYTES,
   type SqliteWorkerBackend,
@@ -12,10 +13,18 @@ import {
 } from "./sqlite-worker-contract.js";
 import { assertExistingDatabaseIdentity } from "./sqlite-worker-identity.js";
 import {
+  runWithSqliteWorkerStateContext,
+  type SqliteWorkerStateContext,
+} from "./sqlite-worker-state-context.js";
+import {
   createSqliteWorkerTransferOwner,
   createSqliteWorkerTransferReceiver,
   type SqliteWorkerTransferFrame,
 } from "./sqlite-worker-transfer.js";
+import {
+  attachGatewaySchemaFenceDelegate,
+  withStateDatabaseCoordinatorRuntimeDirectory,
+} from "./state-database-coordinator.js";
 
 const port = parentPort;
 if (!port) {
@@ -31,7 +40,26 @@ type StagedInput = {
   command: unknown;
 };
 let pendingInput: StagedInput | undefined;
+const actorPaths = new Map<number, string>();
+const stateContexts = new Map<number, SqliteWorkerStateContext>();
+const gatewayFences = new Map<
+  number,
+  Awaited<ReturnType<typeof attachGatewaySchemaFenceDelegate>>
+>();
 let sourceLoaderRegistered = false;
+
+function runInActorContext<T>(actor: number, operation: () => T): T {
+  const context = stateContexts.get(actor);
+  if (!context) {
+    return operation();
+  }
+  return withStateDatabaseCoordinatorRuntimeDirectory(context.coordinatorRuntime, () =>
+    runWithSqliteWorkerStateContext(context, () => {
+      const delegate = gatewayFences.get(actor);
+      return delegate ? delegate.run(operation) : operation();
+    }),
+  );
+}
 
 async function receive(request: SqliteWorkerRequest): Promise<void> {
   let reply: SqliteWorkerReply;
@@ -41,13 +69,40 @@ async function receive(request: SqliteWorkerRequest): Promise<void> {
   let inputNext = false;
   try {
     let value: unknown;
+    if (request.type !== "result-next" && request.type !== "execute-frame") {
+      if (request.stateContext) {
+        stateContexts.set(request.actor, request.stateContext);
+      }
+      if (request.gatewaySchemaFence) {
+        retire = true;
+        if (gatewayFences.has(request.actor) || !request.stateContext) {
+          throw new Error("Gateway schema delegate does not match an admitting shared-state actor");
+        }
+        const databasePath =
+          request.type === "open" ? request.databasePath : actorPaths.get(request.actor);
+        if (!databasePath) {
+          throw new Error("Gateway schema delegate requires its open actor");
+        }
+        gatewayFences.set(
+          request.actor,
+          await attachGatewaySchemaFenceDelegate(request.gatewaySchemaFence, {
+            databasePath,
+            runtimeDirectory: request.stateContext.coordinatorRuntime.directory,
+            actorId: String(request.actor),
+          }),
+        );
+        retire = false;
+      }
+    }
     const executeCommand = (command: unknown) => {
       const backend = actors.get(request.actor);
       if (!backend) {
         throw new Error("SQLite worker actor is closed");
       }
-      // SAFETY: The typed host command is serialized once; framing validates complete reconstruction.
-      value = backend.execute(command as SqliteWorkerCommand<SqliteWorkerOperations>);
+      value = runInActorContext(request.actor, () => ({
+        // SAFETY: The typed host command is serialized once; framing validates complete reconstruction.
+        result: backend.execute(command as SqliteWorkerCommand<SqliteWorkerOperations>),
+      })).result;
       executed = true;
       completeResult = true;
       if (isPromise(value) || (isRecord(value) && typeof value.then === "function")) {
@@ -142,13 +197,16 @@ async function receive(request: SqliteWorkerRequest): Promise<void> {
       if (!isRecord(module) || typeof module[factoryName] !== "function") {
         throw new Error(`SQLite worker module must export ${factoryName}`);
       }
+      const factory = module[factoryName];
       // Module loading can yield before the factory opens native state.
       if (request.existingIdentity) {
         assertExistingDatabaseIdentity(request.databasePath, request.existingIdentity);
       }
-      const backend: unknown = await module[factoryName](deserialize(request.input), {
-        databasePath: request.databasePath,
-      });
+      const backend: unknown = await runInActorContext(request.actor, () =>
+        factory(deserialize(request.input), {
+          databasePath: request.databasePath,
+        }),
+      );
       if (
         !isRecord(backend) ||
         typeof backend.execute !== "function" ||
@@ -158,13 +216,18 @@ async function receive(request: SqliteWorkerRequest): Promise<void> {
       }
       // SAFETY: The validated backend and its typed client own the private command contract.
       actors.set(request.actor, backend as SqliteWorkerBackend<SqliteWorkerOperations>);
+      actorPaths.set(request.actor, request.databasePath);
     } else if (request.type === "close") {
       const backend = actors.get(request.actor);
       if (!backend) {
         throw new Error("SQLite worker actor is closed");
       }
-      await backend.close();
+      await runInActorContext(request.actor, () => backend.close());
       actors.delete(request.actor);
+      actorPaths.delete(request.actor);
+      stateContexts.delete(request.actor);
+      gatewayFences.get(request.actor)?.close();
+      gatewayFences.delete(request.actor);
     } else {
       executeCommand(deserialize(request.input));
     }
@@ -193,6 +256,11 @@ async function receive(request: SqliteWorkerRequest): Promise<void> {
     pendingInput = undefined;
     const failure = error instanceof Error ? error : new Error(String(error));
     const code = executed ? "outcome-unknown" : "code" in failure ? failure.code : undefined;
+    const errorContext =
+      request.stateContext ??
+      (request.type === "execute-frame" ? stateContexts.get(request.actor) : undefined);
+    const sharedState =
+      errorContext && !executed ? encodeOpenClawStateWorkerError(failure) : undefined;
     reply = {
       id: request.id,
       ok: false,
@@ -201,6 +269,7 @@ async function receive(request: SqliteWorkerRequest): Promise<void> {
         name: executed ? "SqliteWorkerError" : failure.name,
         message: failure.message,
         ...(typeof code === "string" || typeof code === "number" ? { code } : {}),
+        ...(sharedState ? { sharedState } : {}),
       },
     };
   }

--- a/src/infra/sqlite-terminal-open-latch.test.ts
+++ b/src/infra/sqlite-terminal-open-latch.test.ts
@@ -1,0 +1,63 @@
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { readStableSqliteFileGeneration } from "./sqlite-file-generation.js";
+import { createSqliteTerminalOpenLatch } from "./sqlite-terminal-open-latch.js";
+
+describe("terminal failure asynchronous generation validation", () => {
+  const tempDirs = useAutoCleanupTempDirTracker((cleanup) => afterEach(cleanup));
+
+  function fixture() {
+    const pathname = path.join(tempDirs.make("sqlite-terminal-open-latch-"), "state.sqlite");
+    fs.writeFileSync(pathname, "generation fixture");
+    const generation = readStableSqliteFileGeneration(pathname);
+    const latch = createSqliteTerminalOpenLatch({ closeByPath: () => {} });
+    const failure = new Error("recorded failure");
+    expect(latch.record(pathname, failure, generation)).toBe(true);
+    return { pathname, generation, latch, failure };
+  }
+
+  it("does not return a cleared failure after pending inspection completes", async () => {
+    const { pathname, latch } = fixture();
+    const inspection = createDeferred<boolean>();
+    const pending = latch.getAsync(pathname, () => inspection.promise);
+    latch.clear(pathname);
+    inspection.resolve(true);
+    expect(await pending).toBeUndefined();
+  });
+
+  it.each([true, false])(
+    "retains a newer failure after an older inspection reports current=%s",
+    async (current) => {
+      const { pathname, generation, latch } = fixture();
+      const inspection = createDeferred<boolean>();
+      const inspect = vi.fn(async () => true).mockImplementationOnce(() => inspection.promise);
+      const pending = latch.getAsync(pathname, inspect);
+      const replacement = new Error("newer failure");
+      expect(latch.record(pathname, replacement, generation)).toBe(true);
+      inspection.resolve(current);
+      expect(await pending).toBe(replacement);
+      expect(latch.get(pathname)).toBe(replacement);
+      expect(inspect).toHaveBeenCalledTimes(2);
+    },
+  );
+
+  it("clears only the inspected generation when it no longer matches", async () => {
+    const { pathname, latch } = fixture();
+    expect(await latch.getAsync(pathname, async () => false)).toBeUndefined();
+    expect(latch.get(pathname)).toBeUndefined();
+  });
+
+  it("retains a known failure when the inspection transport rejects", async () => {
+    const { pathname, latch, failure } = fixture();
+    const unavailable = new Error("inspection unavailable");
+    await expect(
+      latch.getAsync(pathname, async () => {
+        throw unavailable;
+      }),
+    ).rejects.toBe(unavailable);
+    expect(latch.get(pathname)).toBe(failure);
+  });
+});

--- a/src/infra/sqlite-terminal-open-latch.ts
+++ b/src/infra/sqlite-terminal-open-latch.ts
@@ -25,7 +25,7 @@ function generationMatchesPath(pathname: string, expected: SqliteFileGeneration)
  * every later open fails fast until doctor repairs the file and clears it.
  */
 export function createSqliteTerminalOpenLatch(options: {
-  closeByPath: (pathname: string) => void;
+  closeByPath: (pathname: string, error: Error) => void;
 }) {
   const failures = new Map<string, TerminalOpenFailure>();
 
@@ -42,6 +42,28 @@ export function createSqliteTerminalOpenLatch(options: {
       }
       return failure.error;
     },
+    async getAsync(
+      pathname: string,
+      isCurrentGeneration: (pathname: string, generation: SqliteFileGeneration) => Promise<boolean>,
+    ): Promise<Error | undefined> {
+      const resolvedPath = path.resolve(pathname);
+      for (;;) {
+        const failure = failures.get(resolvedPath);
+        if (!failure?.generation) {
+          return failure?.error;
+        }
+        const current = await isCurrentGeneration(resolvedPath, failure.generation);
+        // A repair or a newer failure can replace this entry while inspection runs.
+        if (failures.get(resolvedPath) !== failure) {
+          continue;
+        }
+        if (!current) {
+          failures.delete(resolvedPath);
+          return undefined;
+        }
+        return failure.error;
+      }
+    },
     record: (pathname: string, error: Error, generation?: SqliteFileGeneration): boolean => {
       const resolvedPath = path.resolve(pathname);
       if (generation && !generationMatchesPath(resolvedPath, generation)) {
@@ -49,7 +71,7 @@ export function createSqliteTerminalOpenLatch(options: {
       }
       failures.set(resolvedPath, { error, ...(generation ? { generation } : {}) });
       // Latch first. Close hooks may reenter.
-      options.closeByPath(resolvedPath);
+      options.closeByPath(resolvedPath, error);
       if (generation && !generationMatchesPath(resolvedPath, generation)) {
         failures.delete(resolvedPath);
         return false;

--- a/src/infra/sqlite-worker-broker-admission.ts
+++ b/src/infra/sqlite-worker-broker-admission.ts
@@ -1,0 +1,136 @@
+import { createHash } from "node:crypto";
+import { realpath, stat } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { serialize } from "node:v8";
+import { INCOGNITO_AGENT_SQLITE_BASENAME } from "../state/openclaw-agent-db.paths.js";
+import type {
+  PreparedSqliteWorkerOpen,
+  SqliteWorkerStoreOptions,
+  Actor,
+} from "./sqlite-worker-broker.types.js";
+import type { SqliteWorkerRequest } from "./sqlite-worker-contract.js";
+import { readDatabasePathIdentity, type DatabasePathIdentity } from "./sqlite-worker-identity.js";
+import type { SqliteWorkerStateContext } from "./sqlite-worker-state-context.js";
+import { tryCreateGatewaySchemaFenceDelegate } from "./state-database-coordinator.js";
+
+export function validateSqliteWorkerDatabaseLocator(databasePath: string): void {
+  const basename = path.basename(databasePath);
+  if (
+    !databasePath ||
+    databasePath.startsWith("file:") ||
+    basename === ":memory:" ||
+    basename === INCOGNITO_AGENT_SQLITE_BASENAME
+  ) {
+    throw new Error(
+      "SQLite worker stores require a file-backed filesystem path; in-memory and incognito databases are not supported",
+    );
+  }
+}
+
+export function captureSqliteWorkerOpen(
+  options: SqliteWorkerStoreOptions,
+  stateContext?: SqliteWorkerStateContext,
+  assertCurrent?: () => void,
+): PreparedSqliteWorkerOpen {
+  return {
+    assertCurrent,
+    moduleUrl: new URL(options.moduleUrl),
+    databasePath: path.resolve(options.databasePath),
+    input: serialize(options.input),
+    existingOnly: options.existingOnly === true,
+    ...(stateContext
+      ? {
+          stateContext: {
+            environment: { ...stateContext.environment },
+            coordinatorRuntime: { ...stateContext.coordinatorRuntime },
+          },
+        }
+      : {}),
+  };
+}
+
+function validateSqliteWorkerModuleUrl(moduleUrl: URL): void {
+  if (moduleUrl.protocol !== "file:" || moduleUrl.search || moduleUrl.hash) {
+    throw new Error("SQLite worker backend must be a static local module URL");
+  }
+}
+
+export async function prepareSqliteWorkerDatabaseAdmission(options: PreparedSqliteWorkerOpen) {
+  validateSqliteWorkerModuleUrl(options.moduleUrl);
+  const databasePath = path.resolve(options.databasePath);
+  const inputHash = createHash("sha256").update(options.input).digest("hex");
+  const identity = await readDatabasePathIdentity(databasePath);
+  return { databasePath, inputHash, identity };
+}
+
+export async function resolveOpenedSqliteWorkerIdentity(
+  databasePath: string,
+  previous: DatabasePathIdentity,
+  isOwnedElsewhere: (key: string) => boolean,
+): Promise<string> {
+  const openedIdentity = await readDatabasePathIdentity(databasePath);
+  const physical = openedIdentity.key;
+  if (openedIdentity.canonicalPath !== previous.canonicalPath) {
+    throw new Error("SQLite database canonical pathname changed during open");
+  }
+  if (!physical.startsWith("file:")) {
+    throw new Error("SQLite worker backend did not establish its database file");
+  }
+  if (isOwnedElsewhere(physical)) {
+    throw new Error("SQLite database identity collided with an existing worker owner during open");
+  }
+  if (previous.key.startsWith("file:") && physical !== previous.key) {
+    throw new Error("SQLite database file identity changed during open");
+  }
+  return physical;
+}
+
+export function findUnclaimedSharedStateActors(
+  actors: Iterable<Actor>,
+  databasePath: string,
+): Actor[] {
+  const pathname = path.resolve(databasePath);
+  return [...actors].filter(
+    (actor) =>
+      actor.stateContext !== undefined &&
+      actor.references === 0 &&
+      actor.cleanupState === "pending" &&
+      actor.databasePath === pathname,
+  );
+}
+
+export async function resolveSqliteWorkerModuleUrl(sourceUrl: URL) {
+  const modulePath = await realpath(fileURLToPath(sourceUrl));
+  const moduleUrl = pathToFileURL(modulePath).href;
+  if (!/\.[cm]?[jt]s$/.test(modulePath) || !(await stat(modulePath)).isFile()) {
+    throw new Error("SQLite worker backend must identify a JavaScript or TypeScript file");
+  }
+  return { modulePath, moduleUrl };
+}
+
+export function prepareSqliteWorkerActorContext(
+  actor: Actor | undefined,
+  request: SqliteWorkerRequest,
+): void {
+  const stateContext = request.stateContext ?? actor?.stateContext;
+  if (actor && stateContext) {
+    if (
+      actor.stateContext?.coordinatorRuntime.directory !== stateContext.coordinatorRuntime.directory
+    ) {
+      throw new Error("Shared-state worker coordinator scope changed; close its actor first");
+    }
+    request.stateContext = stateContext;
+    if (!actor.cleanupState && !actor.gatewaySchemaFence) {
+      const delegate = tryCreateGatewaySchemaFenceDelegate({
+        databasePath: actor.databasePath,
+        runtimeDirectory: stateContext.coordinatorRuntime.directory,
+        actorId: String(actor.id),
+      });
+      if (delegate) {
+        actor.gatewaySchemaFence = delegate;
+        request.gatewaySchemaFence = delegate.port;
+      }
+    }
+  }
+}

--- a/src/infra/sqlite-worker-broker-reply.ts
+++ b/src/infra/sqlite-worker-broker-reply.ts
@@ -1,7 +1,9 @@
 import { deserialize, serialize } from "node:v8";
+import { decodeOpenClawStateWorkerError } from "../state/openclaw-state-worker-error.js";
 import type { Job } from "./sqlite-worker-broker.types.js";
 import {
   SQLITE_WORKER_MAX_MESSAGE_BYTES,
+  SqliteWorkerError,
   type SqliteWorkerReply,
   type SqliteWorkerRequest,
   type SqliteWorkerTransferHandle,
@@ -112,4 +114,36 @@ export function decodeSqliteWorkerReplyValue(
         },
       }
     : { type: "complete", value };
+}
+
+export function decodeSqliteWorkerReplyError(
+  job: Job,
+  error: Extract<SqliteWorkerReply, { ok: false }>["error"],
+): Error {
+  const decoded =
+    job.request.stateContext && error.code !== "outcome-unknown"
+      ? decodeOpenClawStateWorkerError(error.sharedState)
+      : undefined;
+  const failure =
+    decoded ??
+    Object.assign(new Error(error.message), {
+      name: error.name,
+      ...(error.code === undefined ? {} : { code: error.code }),
+    });
+  return failure;
+}
+
+/** Keep the original failure and outcome classification when retirement also fails. */
+export function withSqliteWorkerCleanupFailure(failure: Error, cleanupError: unknown): Error {
+  if (cleanupError === undefined) {
+    return failure;
+  }
+  const combined = new AggregateError(
+    [failure, cleanupError],
+    "SQLite worker failure and cleanup failed",
+    { cause: failure },
+  );
+  return failure instanceof SqliteWorkerError
+    ? Object.assign(combined, { code: failure.code })
+    : combined;
 }

--- a/src/infra/sqlite-worker-broker.ts
+++ b/src/infra/sqlite-worker-broker.ts
@@ -1,29 +1,39 @@
 import { AsyncLocalStorage } from "node:async_hooks";
-import { createHash } from "node:crypto";
-import { realpath, stat } from "node:fs/promises";
-import path from "node:path";
-import { fileURLToPath, pathToFileURL } from "node:url";
-import { serialize } from "node:v8";
 import { Worker } from "node:worker_threads";
 import { toErrorObject } from "@openclaw/normalization-core/error-coercion";
 import { createDeferredCore } from "../shared/deferred.js";
-import { INCOGNITO_AGENT_SQLITE_BASENAME } from "../state/openclaw-agent-db.paths.js";
 import { ensureSqliteLibrarySelected } from "./bun-sqlite-library.js";
 import { runtimeProcessEntrypoints } from "./runtime-process-entrypoints.js";
 import { resolveRuntimeWorkerUrl } from "./runtime-worker-url.js";
 import {
+  captureSqliteWorkerOpen,
+  findUnclaimedSharedStateActors,
+  prepareSqliteWorkerActorContext,
+  prepareSqliteWorkerDatabaseAdmission,
+  resolveOpenedSqliteWorkerIdentity,
+  resolveSqliteWorkerModuleUrl,
+  validateSqliteWorkerDatabaseLocator,
+} from "./sqlite-worker-broker-admission.js";
+import {
+  decodeSqliteWorkerReplyError,
   decodeSqliteWorkerReplyValue,
   prepareSqliteWorkerRequest,
+  withSqliteWorkerCleanupFailure,
 } from "./sqlite-worker-broker-reply.js";
 import type {
   Actor,
-  DispatchState,
+  EnqueueOptions,
   Job,
+  PreparedSqliteWorkerOpen,
   RequestBody,
   Slot,
   SqliteWorkerStoreOptions,
+  StoreClient,
 } from "./sqlite-worker-broker.types.js";
-import { createSqliteWorkerClient } from "./sqlite-worker-client.js";
+import {
+  createSqliteWorkerClient,
+  runSqliteWorkerClientOperation,
+} from "./sqlite-worker-client.js";
 import {
   SQLITE_WORKER_MAX_MESSAGE_BYTES,
   SqliteWorkerError,
@@ -31,7 +41,7 @@ import {
   type SqliteWorkerReply,
   type SqliteWorkerStore,
 } from "./sqlite-worker-contract.js";
-import { readDatabasePathIdentity } from "./sqlite-worker-identity.js";
+import type { SqliteWorkerStateContext } from "./sqlite-worker-state-context.js";
 
 const MAX_WORKERS = 4;
 const MAX_STORES = 64;
@@ -43,6 +53,8 @@ export class SqliteWorkerBroker {
   private readonly actors = new Map<string, Actor>();
   private readonly slots = new Set<Slot>();
   private readonly clients = new Set<object>();
+  private readonly stores = new Map<object, StoreClient>();
+  private readonly operations = new Set<Promise<void>>();
   private nextActor = 0;
   private nextRequest = 0;
   private requests = 0;
@@ -53,19 +65,13 @@ export class SqliteWorkerBroker {
 
   open<Operations extends SqliteWorkerOperations>(
     options: SqliteWorkerStoreOptions,
+    stateContext?: SqliteWorkerStateContext,
+    assertCurrent?: () => void,
   ): Promise<SqliteWorkerStore<Operations> | undefined> {
-    const basename = path.basename(options.databasePath);
-    if (
-      !options.databasePath ||
-      options.databasePath.startsWith("file:") ||
-      basename === ":memory:" ||
-      basename === INCOGNITO_AGENT_SQLITE_BASENAME
-    ) {
-      return Promise.reject(
-        new Error(
-          "SQLite worker stores require a file-backed filesystem path; in-memory and incognito databases are not supported",
-        ),
-      );
+    try {
+      validateSqliteWorkerDatabaseLocator(options.databasePath);
+    } catch (error) {
+      return Promise.reject(toErrorObject(error, "SQLite worker database locator is invalid"));
     }
     if (this.draining) {
       return Promise.reject(new SqliteWorkerError("SQLite worker host is closing", "closed"));
@@ -77,19 +83,9 @@ export class SqliteWorkerBroker {
     }
     const client = {};
     this.clients.add(client);
-    let snapshot: {
-      moduleUrl: URL;
-      databasePath: string;
-      input: Buffer;
-      existingOnly: boolean;
-    };
+    let snapshot: PreparedSqliteWorkerOpen;
     try {
-      snapshot = {
-        moduleUrl: new URL(options.moduleUrl),
-        databasePath: path.resolve(options.databasePath),
-        input: serialize(options.input),
-        existingOnly: options.existingOnly === true,
-      };
+      snapshot = captureSqliteWorkerOpen(options, stateContext, assertCurrent);
     } catch (error) {
       this.clients.delete(client);
       return Promise.reject(toErrorObject(error, "SQLite worker input could not be serialized"));
@@ -122,25 +118,12 @@ export class SqliteWorkerBroker {
   }
 
   private async openAdmitted<Operations extends SqliteWorkerOperations>(
-    options: {
-      moduleUrl: URL;
-      databasePath: string;
-      input: Buffer;
-      existingOnly: boolean;
-    },
+    options: PreparedSqliteWorkerOpen,
     client: object,
   ): Promise<SqliteWorkerStore<Operations> | undefined> {
-    if (
-      options.moduleUrl.protocol !== "file:" ||
-      options.moduleUrl.search ||
-      options.moduleUrl.hash
-    ) {
-      throw new Error("SQLite worker backend must be a static local module URL");
-    }
-    const databasePath = path.resolve(options.databasePath);
+    const { databasePath, inputHash, identity } =
+      await prepareSqliteWorkerDatabaseAdmission(options);
     const input = options.input;
-    const inputHash = createHash("sha256").update(input).digest("hex");
-    const identity = await readDatabasePathIdentity(databasePath);
     const { key, canonicalPath } = identity;
     const admittedPaths = new Set([databasePath, canonicalPath]);
     if (
@@ -158,15 +141,17 @@ export class SqliteWorkerBroker {
       this.clients.delete(client);
       return undefined;
     }
-    const modulePath = await realpath(fileURLToPath(options.moduleUrl));
-    const moduleUrl = pathToFileURL(modulePath).href;
-    if (!/\.[cm]?[jt]s$/.test(modulePath) || !(await stat(modulePath)).isFile()) {
-      throw new Error("SQLite worker backend must identify a JavaScript or TypeScript file");
-    }
+    const { modulePath, moduleUrl } = await resolveSqliteWorkerModuleUrl(options.moduleUrl);
     let actor = this.actors.get(key);
-    if (actor?.closing) {
-      await actor.closing;
-      return this.openAdmitted(options, client);
+    if (actor?.cleanupState === "pending") {
+      if (actor.closing) {
+        await actor.closing;
+        return this.openAdmitted(options, client);
+      }
+      throw new SqliteWorkerError(
+        "SQLite worker cleanup is pending; retry close before reopening",
+        "closed",
+      );
     }
     if (actor) {
       if (actor.slot.failed) {
@@ -190,6 +175,9 @@ export class SqliteWorkerBroker {
         opened: Promise.resolve(),
         openDispatch: { dispatched: false },
         initialized: false,
+        backendClosed: false,
+        databasePath,
+        stateContext: options.stateContext,
       };
       this.actors.set(key, actor);
       slot.actors.add(actor);
@@ -209,27 +197,13 @@ export class SqliteWorkerBroker {
             : {}),
         },
         input.byteLength,
-        undefined,
-        opening.openDispatch,
+        { dispatchState: opening.openDispatch, assertCurrent: options.assertCurrent },
       ).then(async () => {
         opening.initialized = true;
-        const openedIdentity = await readDatabasePathIdentity(databasePath);
-        const physical = openedIdentity.key;
-        if (openedIdentity.canonicalPath !== canonicalPath) {
-          throw new Error("SQLite database canonical pathname changed during open");
-        }
-        if (!physical.startsWith("file:")) {
-          throw new Error("SQLite worker backend did not establish its database file");
-        }
-        const existing = this.actors.get(physical);
-        if (existing && existing !== opening) {
-          throw new Error(
-            "SQLite database identity collided with an existing worker owner during open",
-          );
-        }
-        if (key.startsWith("file:") && physical !== key) {
-          throw new Error("SQLite database file identity changed during open");
-        }
+        const physical = await resolveOpenedSqliteWorkerIdentity(databasePath, identity, (id) => {
+          const existing = this.actors.get(id);
+          return existing !== undefined && existing !== opening;
+        });
         if (physical !== key) {
           this.actors.delete(key);
           opening.key = physical;
@@ -245,28 +219,28 @@ export class SqliteWorkerBroker {
     } catch (error) {
       actor.references -= 1;
       if (!actor.references) {
-        if (actor.initialized) {
-          let cleanupFailure: { error: unknown } | undefined;
-          try {
+        let cleanupFailure: { error: unknown } | undefined;
+        try {
+          if (actor.initialized) {
             await this.closeActor(actor);
-          } catch (cleanupError) {
-            cleanupFailure = { error: cleanupError };
+          } else {
+            if (actor.openDispatch.dispatched) {
+              // A throwing factory cannot prove that all partially opened native handles closed.
+              this.fail(actor.slot, error);
+              await actor.slot.exit;
+            }
+            this.forget(actor);
+            await this.retireEmpty(actor.slot);
           }
-          if (cleanupFailure) {
-            throw new AggregateError(
-              [error, cleanupFailure.error],
-              "SQLite worker admission and cleanup failed",
-              { cause: error },
-            );
-          }
-        } else {
-          if (actor.openDispatch.dispatched) {
-            // A throwing factory cannot prove that all partially opened native handles closed.
-            this.fail(actor.slot, error);
-            await actor.slot.exit;
-          }
-          this.forget(actor);
-          await this.retireEmpty(actor.slot);
+        } catch (cleanupError) {
+          cleanupFailure = { error: cleanupError };
+        }
+        if (cleanupFailure) {
+          throw new AggregateError(
+            [error, cleanupFailure.error],
+            "SQLite worker admission and cleanup failed",
+            { cause: error },
+          );
         }
       }
       throw error;
@@ -275,21 +249,27 @@ export class SqliteWorkerBroker {
     for (const pathname of admittedPaths) {
       owned.pathReferences.set(pathname, (owned.pathReferences.get(pathname) ?? 0) + 1);
     }
-    return createSqliteWorkerClient<Operations>({
-      dispatch: (payload, signal) =>
+    let referenceReleased = false;
+    const { store, client: storeClient } = createSqliteWorkerClient<Operations>({
+      isDraining: () => this.draining !== undefined,
+      isAvailable: () => !owned.slot.failed && !owned.cleanupState,
+      dispatch: (payload, signal, scope, assertCurrent) =>
         this.enqueue(
           owned.slot,
-          { type: "execute", actor: owned.id, input: payload },
+          {
+            type: "execute",
+            actor: owned.id,
+            input: payload,
+            ...(scope?.stateContext ? { stateContext: scope.stateContext } : {}),
+          },
           payload.byteLength,
-          signal,
+          { signal, scope, assertCurrent },
         ),
       release: async () => {
-        owned.references -= 1;
-        try {
-          if (!owned.references) {
-            await this.closeActor(owned);
-          }
-        } finally {
+        if (!referenceReleased) {
+          referenceReleased = true;
+          owned.references -= 1;
+          this.stores.delete(store);
           this.clients.delete(client);
           for (const pathname of admittedPaths) {
             const references = owned.pathReferences.get(pathname) ?? 0;
@@ -300,8 +280,60 @@ export class SqliteWorkerBroker {
             }
           }
         }
+        if (!owned.references) {
+          await this.closeActor(owned);
+        }
       },
     });
+    this.stores.set(store, storeClient);
+    return store;
+  }
+
+  runOperation<Operations extends SqliteWorkerOperations, T>(
+    store: SqliteWorkerStore<Operations>,
+    operation: (scope: Pick<SqliteWorkerStore<Operations>, "execute">) => T | Promise<T>,
+    stateContext?: SqliteWorkerStateContext,
+    assertCurrent?: (commandType: PropertyKey) => void,
+  ): Promise<T> {
+    const client = this.stores.get(store);
+    if (!client || client.sealed || this.draining) {
+      return Promise.reject(new SqliteWorkerError("SQLite worker store is closed", "closed"));
+    }
+    return runSqliteWorkerClientOperation(
+      client,
+      operation,
+      stateContext,
+      (pending) => {
+        this.operations.add(pending);
+        return () => this.operations.delete(pending);
+      },
+      assertCurrent,
+    );
+  }
+
+  isAvailable(store: object): boolean {
+    return this.stores.get(store)?.isAvailable() ?? false;
+  }
+
+  hasUnclaimedSharedStateCleanup(databasePath: string): boolean {
+    return findUnclaimedSharedStateActors(this.actors.values(), databasePath).length > 0;
+  }
+
+  async closeUnclaimedSharedState(databasePath: string): Promise<void> {
+    await this.admissionTail;
+    const results = await Promise.allSettled(
+      findUnclaimedSharedStateActors(this.actors.values(), databasePath).map((actor) =>
+        this.closeActor(actor),
+      ),
+    );
+    const errors = results.flatMap((result) =>
+      result.status === "rejected" ? [result.reason] : [],
+    );
+    if (errors.length) {
+      throw new AggregateError(errors, "SQLite worker unclaimed cleanup failed", {
+        cause: errors[0],
+      });
+    }
   }
 
   private async acquireSlot(): Promise<Slot> {
@@ -341,6 +373,7 @@ export class SqliteWorkerBroker {
       actors: new Set(),
       queue: [],
       exit: exited.promise,
+      exited: false,
       pendingOpens: 1,
     };
     this.slots.add(slot);
@@ -351,10 +384,7 @@ export class SqliteWorkerBroker {
         return;
       }
       if (!reply.ok) {
-        const error = Object.assign(new Error(reply.error.message), {
-          name: reply.error.name,
-          ...(reply.error.code === undefined ? {} : { code: reply.error.code }),
-        });
+        const error = decodeSqliteWorkerReplyError(job, reply.error);
         if (job.request.type !== "execute" || reply.retire) {
           this.fail(slot, error, job.request.type !== "execute" ? error : undefined);
           return;
@@ -384,6 +414,10 @@ export class SqliteWorkerBroker {
     worker.on("error", (error) => this.fail(slot, error));
     worker.on("messageerror", (error) => this.fail(slot, error));
     worker.once("exit", (code) => {
+      slot.exited = true;
+      for (const actor of slot.actors) {
+        actor.backendClosed = true;
+      }
       this.fail(slot, new Error(`SQLite worker exited with code ${code}`));
       this.slots.delete(slot);
       exited.resolve();
@@ -396,10 +430,9 @@ export class SqliteWorkerBroker {
     slot: Slot,
     body: RequestBody,
     bytes: number,
-    signal?: AbortSignal,
-    dispatchState?: DispatchState,
+    { signal, dispatchState, scope, assertCurrent }: EnqueueOptions = {},
   ): Promise<unknown> {
-    if (this.draining && body.type !== "close") {
+    if (this.draining && body.type !== "close" && !scope?.active) {
       return Promise.reject(new SqliteWorkerError("SQLite worker host is closing", "closed"));
     }
     if (slot.failed) {
@@ -420,6 +453,7 @@ export class SqliteWorkerBroker {
     }
     const result = createDeferredCore<unknown>();
     const job: Job = {
+      assertCurrent,
       dispatchState,
       request: { ...body, id: ++this.nextRequest },
       bytes: reservedBytes,
@@ -472,14 +506,26 @@ export class SqliteWorkerBroker {
     job.detach();
     slot.worker.ref();
     try {
-      slot.worker.postMessage(prepareSqliteWorkerRequest(job), []);
+      job.assertCurrent?.();
+      const actor = [...slot.actors].find((candidate) => candidate.id === job.request.actor);
+      prepareSqliteWorkerActorContext(actor, job.request);
+      const request = prepareSqliteWorkerRequest(job);
+      slot.worker.postMessage(
+        request,
+        request.gatewaySchemaFence ? [request.gatewaySchemaFence] : [],
+      );
       if (job.dispatchState) {
         job.dispatchState.dispatched = true;
       }
     } catch (error) {
-      slot.current = undefined;
-      this.finish(job, error);
-      this.dispatch(slot);
+      if (job.request.gatewaySchemaFence) {
+        // A failed transfer cannot attest that the receiving native owner is gone.
+        this.fail(slot, error, toErrorObject(error, "SQLite worker transfer failed"));
+      } else {
+        slot.current = undefined;
+        this.finish(job, error);
+        this.dispatch(slot);
+      }
     }
   }
 
@@ -512,51 +558,104 @@ export class SqliteWorkerBroker {
     }
     const queued = slot.queue.splice(0);
     // Join native exit before releasing any operation that might have touched SQLite.
-    void this.retire(slot).then(() => {
+    const finishFailed = (cleanupError?: unknown) => {
       if (current) {
         this.finish(
           current,
-          currentError ??
-            new SqliteWorkerError(
-              `SQLite worker stopped before its result was received: ${error.message}`,
-              current.request.type === "execute" ? "outcome-unknown" : "unavailable",
-            ),
+          withSqliteWorkerCleanupFailure(
+            currentError ??
+              new SqliteWorkerError(
+                `SQLite worker stopped before its result was received: ${error.message}`,
+                current.request.type === "execute" ? "outcome-unknown" : "unavailable",
+              ),
+            cleanupError,
+          ),
         );
       }
       for (const job of queued) {
-        this.finish(job, slot.failed);
+        this.finish(job, withSqliteWorkerCleanupFailure(slot.failed ?? error, cleanupError));
       }
-    });
+    };
+    void this.retire(slot).then(() => finishFailed(), finishFailed);
   }
 
   private closeActor(actor: Actor): Promise<void> {
+    if (actor.cleanupState === "complete") {
+      return Promise.resolve();
+    }
     if (actor.closing) {
       return actor.closing;
     }
+    const firstAttempt = actor.cleanupState === undefined;
+    actor.cleanupState = "pending";
     actor.closing = (async () => {
+      const errors: unknown[] = [];
+      if (!actor.backendClosed) {
+        try {
+          await this.enqueue(actor.slot, { type: "close", actor: actor.id }, 0);
+          actor.backendClosed = true;
+        } catch (error) {
+          errors.push(error);
+          this.fail(actor.slot, error instanceof Error ? error : new Error(String(error)));
+          await actor.slot.exit;
+        }
+      } else if (firstAttempt && actor.slot.failed) {
+        errors.push(actor.slot.failed);
+      }
       try {
-        await this.enqueue(actor.slot, { type: "close", actor: actor.id }, 0);
-      } catch (error) {
-        this.fail(actor.slot, error instanceof Error ? error : new Error(String(error)));
-        await actor.slot.exit;
-        throw error;
-      } finally {
-        if (process.versions.bun) {
+        if (
+          process.versions.bun ||
+          actor.slot.failed ||
+          (!actor.slot.pendingOpens && [...actor.slot.actors].every((entry) => entry.backendClosed))
+        ) {
           // Bun retains native statements after close; keep pathname ownership until VM exit.
           await this.retire(actor.slot);
+        } else {
+          this.releaseGatewaySchemaFence(actor);
         }
+      } catch (error) {
+        errors.push(error);
+      } finally {
         this.forget(actor);
-        await this.retireEmpty(actor.slot);
       }
-    })();
+      if (errors.length === 1) {
+        throw errors[0];
+      }
+      if (errors.length > 1) {
+        throw new AggregateError(errors, "SQLite worker actor cleanup failed", {
+          cause: errors[0],
+        });
+      }
+    })().finally(() => {
+      actor.closing = undefined;
+    });
     return actor.closing;
   }
 
+  private releaseGatewaySchemaFence(actor: Actor): void {
+    const delegation = actor.gatewaySchemaFence;
+    if (!delegation) {
+      return;
+    }
+    try {
+      delegation.release();
+    } finally {
+      if (delegation.closed) {
+        actor.gatewaySchemaFence = undefined;
+      }
+    }
+  }
+
   private forget(actor: Actor): void {
+    if (actor.gatewaySchemaFence) {
+      actor.cleanupState = "pending";
+      return;
+    }
     if (this.actors.get(actor.key) === actor) {
       this.actors.delete(actor.key);
     }
     actor.slot.actors.delete(actor);
+    actor.cleanupState = "complete";
   }
 
   private async retireEmpty(slot: Slot): Promise<void> {
@@ -567,15 +666,43 @@ export class SqliteWorkerBroker {
 
   private retire(slot: Slot): Promise<void> {
     slot.retiring ??= (async () => {
-      await slot.worker.terminate();
+      const errors: unknown[] = [];
+      if (!slot.exited) {
+        try {
+          await slot.worker.terminate();
+        } catch (error) {
+          errors.push(error);
+        }
+      }
       await slot.exit;
-    })();
+      for (const actor of slot.actors) {
+        try {
+          this.releaseGatewaySchemaFence(actor);
+        } catch (error) {
+          errors.push(error);
+        }
+      }
+      if (errors.length === 1) {
+        throw errors[0];
+      }
+      if (errors.length > 1) {
+        throw new AggregateError(errors, "SQLite worker retirement cleanup failed", {
+          cause: errors[0],
+        });
+      }
+    })().finally(() => {
+      slot.retiring = undefined;
+    });
     return slot.retiring;
   }
 
   close(): Promise<void> {
     this.draining ??= (async () => {
+      for (const client of this.stores.values()) {
+        client.sealed = true;
+      }
       await this.admissionTail;
+      await Promise.allSettled(this.operations);
       const results = await Promise.allSettled(
         [...this.actors.values()].map((actor) => this.closeActor(actor)),
       );
@@ -587,6 +714,7 @@ export class SqliteWorkerBroker {
       }
     })().finally(() => {
       this.clients.clear();
+      this.stores.clear();
       this.draining = undefined;
     });
     return this.draining;

--- a/src/infra/sqlite-worker-broker.types.ts
+++ b/src/infra/sqlite-worker-broker.types.ts
@@ -1,17 +1,20 @@
 import type { Worker } from "node:worker_threads";
 import type { SqliteWorkerRequest } from "./sqlite-worker-contract.js";
+import type { SqliteWorkerStateContext } from "./sqlite-worker-state-context.js";
 import type {
   createSqliteWorkerTransferOwner,
   createSqliteWorkerTransferReceiver,
 } from "./sqlite-worker-transfer.js";
+import type { tryCreateGatewaySchemaFenceDelegate } from "./state-database-coordinator.js";
 
 export type RequestBody = SqliteWorkerRequest extends infer Request
   ? Request extends SqliteWorkerRequest
     ? Omit<Request, "id">
     : never
   : never;
-export type DispatchState = { dispatched: boolean };
+type DispatchState = { dispatched: boolean };
 export type Job = {
+  assertCurrent?: () => void;
   inputTransfer?: {
     id: number;
     producer: ReturnType<typeof createSqliteWorkerTransferOwner>;
@@ -36,11 +39,13 @@ export type Slot = {
   failed?: Error;
   retiring?: Promise<void>;
   exit: Promise<void>;
+  exited: boolean;
   pendingOpens: number;
 };
 export type Actor = {
   id: number;
   key: string;
+  databasePath: string;
   pathReferences: Map<string, number>;
   moduleUrl: string;
   inputHash: string;
@@ -49,7 +54,33 @@ export type Actor = {
   opened: Promise<unknown>;
   openDispatch: DispatchState;
   initialized: boolean;
+  backendClosed: boolean;
+  cleanupState?: "pending" | "complete";
   closing?: Promise<void>;
+  stateContext?: SqliteWorkerStateContext;
+  gatewaySchemaFence?: NonNullable<ReturnType<typeof tryCreateGatewaySchemaFenceDelegate>>;
+};
+export type OperationScope = {
+  assertCurrent?: (commandType: PropertyKey) => void;
+  active: boolean;
+  pending: Set<Promise<unknown>>;
+  stateContext?: SqliteWorkerStateContext;
+};
+export type EnqueueOptions = {
+  signal?: AbortSignal;
+  dispatchState?: DispatchState;
+  scope?: OperationScope;
+  assertCurrent?: () => void;
+};
+export type StoreClient = {
+  sealed: boolean;
+  isAvailable(): boolean;
+  scopes: Set<Promise<void>>;
+  execute(
+    command: { type: PropertyKey; input: unknown },
+    options: { signal?: AbortSignal },
+    scope?: OperationScope,
+  ): Promise<unknown>;
 };
 
 export type SqliteWorkerStoreOptions = {
@@ -57,4 +88,13 @@ export type SqliteWorkerStoreOptions = {
   databasePath: string;
   input: unknown;
   existingOnly?: boolean;
+};
+
+export type PreparedSqliteWorkerOpen = {
+  assertCurrent?: () => void;
+  moduleUrl: URL;
+  databasePath: string;
+  input: Buffer;
+  existingOnly: boolean;
+  stateContext?: SqliteWorkerStateContext;
 };

--- a/src/infra/sqlite-worker-client.ts
+++ b/src/infra/sqlite-worker-client.ts
@@ -1,55 +1,133 @@
+import { isPromise } from "node:util/types";
 import { serialize } from "node:v8";
 import { toErrorObject } from "@openclaw/normalization-core/error-coercion";
+import { createDeferredCore } from "../shared/deferred.js";
+import type { OperationScope, StoreClient } from "./sqlite-worker-broker.types.js";
 import {
   SqliteWorkerError,
   type SqliteWorkerOperations,
   type SqliteWorkerStore,
 } from "./sqlite-worker-contract.js";
+import type { SqliteWorkerStateContext } from "./sqlite-worker-state-context.js";
+
+export function runSqliteWorkerClientOperation<Operations extends SqliteWorkerOperations, T>(
+  client: StoreClient,
+  operation: (scope: Pick<SqliteWorkerStore<Operations>, "execute">) => T | Promise<T>,
+  stateContext: SqliteWorkerStateContext | undefined,
+  track: (pending: Promise<void>) => () => void,
+  assertCurrent?: (commandType: PropertyKey) => void,
+): Promise<T> {
+  const scope: OperationScope = {
+    assertCurrent,
+    active: true,
+    pending: new Set(),
+    ...(stateContext
+      ? {
+          stateContext: {
+            environment: { ...stateContext.environment },
+            coordinatorRuntime: { ...stateContext.coordinatorRuntime },
+          },
+        }
+      : {}),
+  };
+  const released = createDeferredCore();
+  client.scopes.add(released.promise);
+  const untrack = track(released.promise);
+  return (async () => {
+    try {
+      const result = operation({
+        execute: (command, options = {}) =>
+          // SAFETY: The exact admitted store retains its typed backend.
+          client.execute(command, options, scope) as Promise<
+            Operations[typeof command.type]["output"]
+          >,
+      });
+      return isPromise(result) ? await result : result;
+    } finally {
+      scope.active = false;
+      // A callback can throw after dispatch or leave a command unawaited.
+      await Promise.allSettled(scope.pending);
+      client.scopes.delete(released.promise);
+      untrack();
+      released.resolve();
+    }
+  })();
+}
 
 export function createSqliteWorkerClient<Operations extends SqliteWorkerOperations>(owner: {
-  dispatch: (payload: Buffer, signal?: AbortSignal) => Promise<unknown>;
+  isDraining: () => boolean;
+  isAvailable: () => boolean;
+  dispatch: (
+    payload: Buffer,
+    signal: AbortSignal | undefined,
+    scope: OperationScope | undefined,
+    assertCurrent: (() => void) | undefined,
+  ) => Promise<unknown>;
   release: () => Promise<void>;
-}): SqliteWorkerStore<Operations> {
+}) {
   let closed: Promise<void> | undefined;
   const pending = new Set<Promise<unknown>>();
-  return {
-    execute: (command, operationOptions = {}) => {
-      if (closed) {
+  const client: StoreClient = {
+    sealed: owner.isDraining(),
+    isAvailable: owner.isAvailable,
+    scopes: new Set(),
+    execute: (command, options, scope) => {
+      if (scope ? !scope.active : closed || client.sealed || owner.isDraining()) {
         return Promise.reject(new SqliteWorkerError("SQLite worker store is closed", "closed"));
       }
-      if (operationOptions.signal?.aborted) {
+      if (options.signal?.aborted) {
         return Promise.reject(
-          toErrorObject(operationOptions.signal.reason, "SQLite worker operation canceled"),
+          toErrorObject(options.signal.reason, "SQLite worker operation canceled"),
         );
       }
       let payload: Buffer;
+      let assertCurrent: (() => void) | undefined;
       try {
-        // Snapshot at admission, before a queued caller can mutate its input.
-        payload = serialize(command);
+        const commandType = command.type;
+        const admission = scope?.assertCurrent;
+        assertCurrent = admission ? () => admission(commandType) : undefined;
+        assertCurrent?.();
+        // The queued guard and wire command must observe the same captured type.
+        payload = serialize({ type: commandType, input: command.input });
       } catch (error) {
         return Promise.reject(
           toErrorObject(error, "SQLite worker command could not be serialized"),
         );
       }
-      // SAFETY: The typed backend owns this result.
-      const operation = owner.dispatch(payload, operationOptions.signal) as Promise<
-        Operations[typeof command.type]["output"]
-      >;
+      const operation = owner.dispatch(payload, options.signal, scope, assertCurrent);
       pending.add(operation);
+      scope?.pending.add(operation);
       void operation.then(
-        () => pending.delete(operation),
-        () => pending.delete(operation),
+        () => {
+          pending.delete(operation);
+          scope?.pending.delete(operation);
+        },
+        () => {
+          pending.delete(operation);
+          scope?.pending.delete(operation);
+        },
       );
       return operation;
     },
+  };
+  const store: SqliteWorkerStore<Operations> = {
+    execute: (command, options = {}) =>
+      // SAFETY: The typed backend owns this result.
+      client.execute(command, options) as Promise<Operations[typeof command.type]["output"]>,
     close: () => {
       if (!closed) {
+        client.sealed = true;
         closed = (async () => {
+          await Promise.allSettled(client.scopes);
           await Promise.allSettled(pending);
           await owner.release();
-        })();
+        })().catch((error: unknown) => {
+          closed = undefined;
+          throw error;
+        });
       }
       return closed;
     },
   };
+  return { store, client };
 }

--- a/src/infra/sqlite-worker-contract.ts
+++ b/src/infra/sqlite-worker-contract.ts
@@ -1,3 +1,7 @@
+import type { MessagePort } from "node:worker_threads";
+import type { OpenClawStateWorkerErrorPayload } from "../state/openclaw-state-worker-error.js";
+import type { SqliteWorkerStateContext } from "./sqlite-worker-state-context.js";
+
 export type SqliteWorkerTransferHandle = { id: number; kinds: string[] };
 
 export type SqliteWorkerOperations = Record<string, { input: unknown; output: unknown }>;
@@ -21,6 +25,8 @@ export type SqliteWorkerStore<Operations extends SqliteWorkerOperations> = {
 export type SqliteWorkerRequest = {
   id: number;
   actor: number;
+  stateContext?: SqliteWorkerStateContext;
+  gatewaySchemaFence?: MessagePort;
 } & (
   | {
       type: "open";
@@ -41,7 +47,16 @@ export type SqliteWorkerReply = {
   id: number;
 } & (
   | { ok: true; value: Uint8Array; transfer?: "start" | "frame"; input?: "next" }
-  | { ok: false; retire?: true; error: { name: string; message: string; code?: string | number } }
+  | {
+      ok: false;
+      retire?: true;
+      error: {
+        name: string;
+        message: string;
+        code?: string | number;
+        sharedState?: OpenClawStateWorkerErrorPayload;
+      };
+    }
 );
 
 export const SQLITE_WORKER_MAX_MESSAGE_BYTES = 32 * 1024 * 1024;

--- a/src/infra/sqlite-worker-shared-state.test.ts
+++ b/src/infra/sqlite-worker-shared-state.test.ts
@@ -1,0 +1,273 @@
+import { existsSync } from "node:fs";
+import { DatabaseSync, StatementSync } from "node:sqlite";
+import { Worker } from "node:worker_threads";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import {
+  closeOpenClawStateDatabaseAsync,
+  closeOpenClawStateDatabaseByPathAsync,
+} from "../state/openclaw-state-db-cache.js";
+import { openOpenClawStateDatabase } from "../state/openclaw-state-db.js";
+import { claimOpenClawStateOwnership } from "../state/openclaw-state-ownership-operations.js";
+import { OpenClawStateOwnershipError } from "../state/openclaw-state-ownership.js";
+import { captureOpenClawStateWorkerContext } from "../state/openclaw-state-worker-context.js";
+import {
+  executeOpenClawStateWorker,
+  runOpenClawStateWorkerOperation,
+} from "../state/openclaw-state-worker-store.js";
+import {
+  bindTaskFlowRecord,
+  upsertTaskFlowRowInDatabase,
+} from "../tasks/task-flow-registry.store.kernel.js";
+import * as nodeSqlite from "./node-sqlite.js";
+import { SqliteSchemaVersionError } from "./sqlite-user-version.js";
+import { closeUnclaimedSharedStateSqliteWorkers } from "./sqlite-worker-store.js";
+import { acquireGatewayLifecycleCoordinator } from "./state-database-coordinator.js";
+
+const dirs = useAutoCleanupTempDirTracker((cleanup) =>
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await closeOpenClawStateDatabaseAsync();
+    cleanup();
+  }),
+);
+
+function context() {
+  return captureOpenClawStateWorkerContext({
+    env: { OPENCLAW_STATE_DIR: dirs.make("openclaw-worker-cold-") },
+  });
+}
+
+describe("canonical shared-state worker admission", () => {
+  it.each(["create", "repair"] as const)(
+    "performs cold %s under its Gateway owner without main-thread SQL",
+    async (operation) => {
+      const captured = context();
+      const databasePath = captured.admission.databasePath;
+      if (operation === "repair") {
+        const database = openOpenClawStateDatabase({
+          path: databasePath,
+          env: captured.environment,
+        });
+        database.db.exec("DROP INDEX idx_flow_runs_owner_key");
+        await closeOpenClawStateDatabaseAsync();
+      }
+      const admission = captureOpenClawStateWorkerContext({
+        path: databasePath,
+        env: captured.environment,
+      });
+      const gateway = acquireGatewayLifecycleCoordinator({ databasePath });
+      const prepare = vi.spyOn(DatabaseSync.prototype, "prepare");
+      const exec = vi.spyOn(DatabaseSync.prototype, "exec");
+      const statements = (["get", "all", "run", "iterate"] as const).map((method) =>
+        vi.spyOn(StatementSync.prototype, method),
+      );
+      try {
+        expect(
+          await executeOpenClawStateWorker(admission, {
+            type: "flows.list",
+            input: { ownerKey: "agent:main:main" },
+          }),
+        ).toEqual([]);
+        expect(prepare).not.toHaveBeenCalled();
+        expect(exec).not.toHaveBeenCalled();
+        for (const statement of statements) {
+          expect(statement).not.toHaveBeenCalled();
+        }
+        expect(admission.admission.identity.key).toMatch(/^file:/);
+      } finally {
+        prepare.mockRestore();
+        exec.mockRestore();
+        for (const statement of statements) {
+          statement.mockRestore();
+        }
+        await closeOpenClawStateDatabaseAsync();
+        gateway.release();
+      }
+      const reopened = openOpenClawStateDatabase({ path: databasePath, env: captured.environment });
+      expect(
+        reopened.db
+          .prepare("SELECT name FROM sqlite_schema WHERE name = ?")
+          .get("idx_flow_runs_owner_key"),
+      ).toEqual({ name: "idx_flow_runs_owner_key" });
+    },
+  );
+
+  it("leaves a missing database absent for existing-only inspection", async () => {
+    const captured = context();
+    const inspect = vi.fn(async () => "inspected");
+    expect(
+      await runOpenClawStateWorkerOperation(captured, inspect, { existingOnly: true }),
+    ).toBeUndefined();
+    expect(inspect).not.toHaveBeenCalled();
+    expect(existsSync(captured.admission.databasePath)).toBe(false);
+  });
+
+  it("preserves future-schema rejection through a cold worker open", async () => {
+    const captured = context();
+    const database = openOpenClawStateDatabase({
+      path: captured.admission.databasePath,
+      env: captured.environment,
+    });
+    database.db.exec("PRAGMA user_version = 999999;");
+    await closeOpenClawStateDatabaseAsync();
+    const reopened = captureOpenClawStateWorkerContext({
+      path: captured.admission.databasePath,
+      env: captured.environment,
+    });
+    await expect(
+      executeOpenClawStateWorker(reopened, {
+        type: "flows.list",
+        input: { ownerKey: "agent:main:main" },
+      }),
+    ).rejects.toBeInstanceOf(SqliteSchemaVersionError);
+  });
+
+  it("retries failed-open native custody through the owning path drain", async () => {
+    const captured = context();
+    const databasePath = captured.admission.databasePath;
+    const database = openOpenClawStateDatabase({ path: databasePath, env: captured.environment });
+    database.db.exec("PRAGMA user_version = 999999;");
+    await closeOpenClawStateDatabaseAsync();
+    const reopened = captureOpenClawStateWorkerContext({
+      path: databasePath,
+      env: captured.environment,
+    });
+    const nativeOpen = nodeSqlite.openNodeSqliteDatabase;
+    const opened = new Map<string, DatabaseSync>();
+    const openSpy = vi
+      .spyOn(nodeSqlite, "openNodeSqliteDatabase")
+      .mockImplementation((location, ...options) => {
+        const db = nativeOpen(location, ...options);
+        opened.set(location, db);
+        return db;
+      });
+    const gateway = acquireGatewayLifecycleCoordinator({ databasePath });
+    openSpy.mockRestore();
+    const native = opened.get(gateway.path);
+    if (!native) {
+      throw new Error("Expected the owned Gateway coordinator connection");
+    }
+    const failClose = () => {
+      throw new Error("Synthetic coordinator close failed");
+    };
+    vi.spyOn(native, "close").mockImplementationOnce(failClose).mockImplementationOnce(failClose);
+    const messages = vi.spyOn(Worker.prototype, "postMessage");
+    messages.mockImplementationOnce(function (this: Worker, message, transferList) {
+      messages.mockRestore();
+      this.postMessage(message, transferList ?? []);
+      gateway.release();
+    });
+    try {
+      await expect(
+        executeOpenClawStateWorker(reopened, {
+          type: "flows.list",
+          input: { ownerKey: "agent:main:main" },
+        }),
+      ).rejects.toThrow();
+      expect(native.isOpen).toBe(true);
+      await expect(closeOpenClawStateDatabaseByPathAsync(databasePath)).rejects.toThrow();
+      expect(native.isOpen).toBe(true);
+      await closeOpenClawStateDatabaseByPathAsync(databasePath);
+      expect(native.isOpen).toBe(false);
+    } finally {
+      vi.restoreAllMocks();
+      await closeUnclaimedSharedStateSqliteWorkers(databasePath);
+      gateway.release();
+    }
+  });
+
+  it.each(["open", "execute"] as const)(
+    "preserves external ownership rejection from worker %s",
+    async (phase) => {
+      const captured = context();
+      if (phase === "execute") {
+        await executeOpenClawStateWorker(captured, {
+          type: "flows.list",
+          input: { ownerKey: "agent:main:main" },
+        });
+      }
+      claimOpenClawStateOwnership("synthetic-manager", {
+        path: captured.admission.databasePath,
+        env: { ...captured.environment, OPENCLAW_SUPERVISOR_MODE: "external" },
+      });
+      if (phase === "open") {
+        await closeOpenClawStateDatabaseAsync();
+      }
+      const reopened = captureOpenClawStateWorkerContext({
+        path: captured.admission.databasePath,
+        env: captured.environment,
+      });
+      await expect(
+        executeOpenClawStateWorker(reopened, {
+          type: "flows.list",
+          input: { ownerKey: "agent:main:main" },
+        }),
+      ).rejects.toBeInstanceOf(OpenClawStateOwnershipError);
+    },
+  );
+
+  it("opens a fresh actor for a new call after the previous worker exits", async () => {
+    const captured = context();
+    const messages = vi.spyOn(Worker.prototype, "postMessage");
+    await executeOpenClawStateWorker(captured, {
+      type: "flows.list",
+      input: { ownerKey: "agent:main:main" },
+    });
+    const worker = messages.mock.contexts[0];
+    messages.mockRestore();
+    if (!(worker instanceof Worker)) {
+      throw new Error("Expected the shared-state worker to receive its open request");
+    }
+    await worker.terminate();
+    await expect(
+      executeOpenClawStateWorker(captured, {
+        type: "flows.list",
+        input: { ownerKey: "agent:main:main" },
+      }),
+    ).rejects.toThrow();
+    expect(
+      await executeOpenClawStateWorker(captured, {
+        type: "flows.list",
+        input: { ownerKey: "agent:main:main" },
+      }),
+    ).toEqual([]);
+  });
+
+  it("reads persisted records after closing and reopening the worker", async () => {
+    const captured = context();
+    const database = openOpenClawStateDatabase({
+      path: captured.admission.databasePath,
+      env: captured.environment,
+    });
+    upsertTaskFlowRowInDatabase(
+      database.db,
+      bindTaskFlowRecord({
+        flowId: "flow-persisted",
+        ownerKey: "agent:main:main",
+        syncMode: "managed",
+        controllerId: "test/controller",
+        revision: 3,
+        status: "waiting",
+        notifyPolicy: "done_only",
+        goal: "Preserve worker state",
+        createdAt: 100,
+        updatedAt: 200,
+      }),
+    );
+    await closeOpenClawStateDatabaseAsync();
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      const reopened = captureOpenClawStateWorkerContext({
+        path: captured.admission.databasePath,
+        env: captured.environment,
+      });
+      expect(
+        await executeOpenClawStateWorker(reopened, {
+          type: "flows.read",
+          input: { ownerKey: "agent:main:main", lookup: "id", token: "flow-persisted" },
+        }),
+      ).toMatchObject({ flowId: "flow-persisted", revision: 3, goal: "Preserve worker state" });
+      await closeOpenClawStateDatabaseAsync();
+    }
+  });
+});

--- a/src/infra/sqlite-worker-state-context.ts
+++ b/src/infra/sqlite-worker-state-context.ts
@@ -1,0 +1,28 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+import type { StateDatabaseCoordinatorRuntime } from "./state-database-coordinator.js";
+
+/** Resolved host facts for the canonical shared-state owner, never authority. */
+export type SqliteWorkerStateContext = {
+  environment: {
+    OPENCLAW_STATE_DIR: string;
+    OPENCLAW_SUPERVISOR_MODE?: "external";
+  };
+  coordinatorRuntime: StateDatabaseCoordinatorRuntime;
+};
+
+const stateContexts = new AsyncLocalStorage<SqliteWorkerStateContext>();
+
+export function runWithSqliteWorkerStateContext<T>(
+  context: SqliteWorkerStateContext,
+  operation: () => T,
+): T {
+  return stateContexts.run(context, operation);
+}
+
+export function getSqliteWorkerStateContext(): SqliteWorkerStateContext {
+  const context = stateContexts.getStore();
+  if (!context) {
+    throw new Error("Shared-state SQLite requires captured host context");
+  }
+  return context;
+}

--- a/src/infra/sqlite-worker-store.test.ts
+++ b/src/infra/sqlite-worker-store.test.ts
@@ -10,19 +10,29 @@ import {
   writeFile,
 } from "node:fs/promises";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 import { Worker } from "node:worker_threads";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { createDeferredCore } from "../shared/deferred.js";
 import { drainGlobalSingletonLifecycleState } from "../shared/global-singleton.js";
 import { resolveIncognitoOpenClawAgentSqlitePath } from "../state/openclaw-agent-db.paths.js";
+import { tryAcquireExclusiveSqliteCoordinator } from "./sqlite-coordinator.js";
+import { captureCoordinatorDatabase } from "./sqlite-coordinator.test-support.js";
 import {
   SQLITE_WORKER_MAX_RESULT_BYTES,
   SQLITE_WORKER_TRANSFER_FRAME_BYTES,
   type SqliteWorkerReply,
 } from "./sqlite-worker-contract.js";
-import { openSqliteWorkerStore, type SqliteWorkerStore } from "./sqlite-worker-store.js";
+import {
+  openSharedStateSqliteWorkerStore,
+  closeUnclaimedSharedStateSqliteWorkers,
+  hasUnclaimedSharedStateSqliteCleanup,
+  openSqliteWorkerStore,
+  type SqliteWorkerStore,
+} from "./sqlite-worker-store.js";
 import type { FixtureOpenInput, FixtureOperations } from "./sqlite-worker-store.test-support.js";
+import * as coordinatorOwner from "./state-database-coordinator.js";
 
 const stores = new Set<SqliteWorkerStore<FixtureOperations>>();
 const tempDirs = useAutoCleanupTempDirTracker((cleanup) =>
@@ -72,6 +82,34 @@ function append(store: SqliteWorkerStore<FixtureOperations>, value: string) {
 
 function read(store: SqliteWorkerStore<FixtureOperations>) {
   return store.execute({ type: "read", input: undefined });
+}
+
+async function openWithGateway(file: string) {
+  const root = path.dirname(file);
+  const gateway = coordinatorOwner.acquireGatewayLifecycleCoordinator({
+    databasePath: file,
+    runtimeDirectory: root,
+  });
+  try {
+    const store = await openSharedStateSqliteWorkerStore<FixtureOperations>(
+      {
+        moduleUrl: new URL("./sqlite-worker-store.test-support.ts", import.meta.url),
+        databasePath: file,
+      },
+      {
+        environment: { OPENCLAW_STATE_DIR: root },
+        coordinatorRuntime: { directory: root, keepAlive: false },
+      },
+    );
+    if (!store) {
+      throw new Error("Fixture shared-state worker did not open");
+    }
+    stores.add(store);
+    return { store, gateway };
+  } catch (error) {
+    gateway.release();
+    throw error;
+  }
 }
 
 const nodeIt = process.versions.bun ? it.skip : it;
@@ -179,6 +217,184 @@ describe("SQLite worker store", () => {
       }
     },
   );
+
+  it("retains failed-factory custody for explicit cleanup when no Store escapes", async () => {
+    const file = databasePath();
+    const root = path.dirname(file);
+    const modulePath = path.join(root, "failed-open.mjs");
+    await writeFile(
+      modulePath,
+      `
+      import { DatabaseSync } from "node:sqlite";
+      export function createSqliteWorkerBackend(_input, context) {
+        const database = new DatabaseSync(context.databasePath);
+        database.close();
+        throw new Error("Fixture factory failed after creating its database");
+      }
+    `,
+    );
+    const unrelatedPath = databasePath();
+    const unrelated = await openWithGateway(unrelatedPath);
+    const { result: gateway, database } = captureCoordinatorDatabase(() =>
+      coordinatorOwner.acquireGatewayLifecycleCoordinator({
+        databasePath: file,
+        runtimeDirectory: root,
+      }),
+    );
+    const close = vi.spyOn(database, "close").mockImplementationOnce(() => {
+      throw new Error("Fixture native close remains open");
+    });
+    let requests = vi.spyOn(Worker.prototype, "postMessage").mockImplementationOnce(function (
+      this: Worker,
+      ...args
+    ) {
+      requests.mockRestore();
+      const result = this.postMessage(...args);
+      gateway.release();
+      return result;
+    });
+    try {
+      await expect(
+        openSharedStateSqliteWorkerStore(
+          {
+            moduleUrl: pathToFileURL(modulePath),
+            databasePath: file,
+          },
+          {
+            environment: { OPENCLAW_STATE_DIR: root },
+            coordinatorRuntime: { directory: root, keepAlive: false },
+          },
+        ),
+      ).rejects.toThrow();
+      expect(database.isOpen).toBe(true);
+      expect(hasUnclaimedSharedStateSqliteCleanup(file)).toBe(true);
+      await expect(open(file)).rejects.toThrow("close the existing store first");
+      requests = vi.spyOn(Worker.prototype, "postMessage");
+      await closeUnclaimedSharedStateSqliteWorkers(file);
+      await closeUnclaimedSharedStateSqliteWorkers(unrelatedPath);
+      expect(requests).not.toHaveBeenCalled();
+      expect(database.isOpen).toBe(false);
+      expect(hasUnclaimedSharedStateSqliteCleanup(file)).toBe(false);
+      expect(close).toHaveBeenCalledTimes(2);
+      await expect(append(unrelated.store, "unrelated actor remains open")).resolves.toMatchObject({
+        writes: 1,
+      });
+      await expect(append(await open(file), "after orphan cleanup")).resolves.toMatchObject({
+        writes: 1,
+      });
+    } finally {
+      requests.mockRestore();
+      close.mockRestore();
+      await closeUnclaimedSharedStateSqliteWorkers(file);
+      gateway.release();
+      unrelated.gateway.release();
+    }
+  });
+
+  it.each(["store", "host"] as const)(
+    "retries an open native Gateway pin through explicit %s cleanup after worker exit",
+    async (owner) => {
+      const file = databasePath();
+      const { result, database } = captureCoordinatorDatabase(() => openWithGateway(file));
+      const { store, gateway } = await result;
+      gateway.release();
+      const close = vi.spyOn(database, "close").mockImplementationOnce(() => {
+        throw new Error("Fixture native close remains open");
+      });
+      const cleanup = () =>
+        owner === "store" ? store.close() : drainGlobalSingletonLifecycleState();
+      const requests = vi.spyOn(Worker.prototype, "postMessage");
+      try {
+        await expect(cleanup()).rejects.toThrow();
+        expect(database.isOpen).toBe(true);
+        expect(close).toHaveBeenCalledTimes(1);
+        await expect(read(store)).rejects.toMatchObject({ code: "closed" });
+        await expect(open(file)).rejects.toThrow("cleanup is pending");
+        requests.mockClear();
+        await expect(cleanup()).resolves.toBeUndefined();
+        expect(database.isOpen).toBe(false);
+        expect(close).toHaveBeenCalledTimes(2);
+        expect(requests).not.toHaveBeenCalled();
+        await expect(store.close()).resolves.toBeUndefined();
+        const recovered = await open(file);
+        await expect(append(recovered, "after cleanup retry")).resolves.toMatchObject({
+          writes: 1,
+        });
+      } finally {
+        requests.mockRestore();
+        close.mockRestore();
+        await Promise.allSettled([cleanup(), store.close()]);
+        stores.delete(store);
+        gateway.release();
+      }
+    },
+  );
+
+  it("releases delegated Gateway pins when a rejected async command retires its worker", async () => {
+    const file = databasePath();
+    const { store, gateway } = await openWithGateway(file);
+    gateway.release();
+    try {
+      const failed = store.execute({
+        type: "illegalAsync",
+        input: { value: "unused", gatePath: file, reject: true },
+      });
+      const queued = read(store);
+      expect(await Promise.allSettled([failed, queued])).toEqual([
+        { status: "rejected", reason: expect.objectContaining({ code: "outcome-unknown" }) },
+        { status: "rejected", reason: expect.objectContaining({ code: "unavailable" }) },
+      ]);
+      const next = tryAcquireExclusiveSqliteCoordinator(gateway.path);
+      expect(next).not.toBeNull();
+      next?.release();
+    } finally {
+      await Promise.allSettled([store.close()]);
+      stores.delete(store);
+      gateway.release();
+    }
+  });
+
+  it("retires an empty worker even when its Gateway pin reports a cleanup failure", async () => {
+    const createDelegate = coordinatorOwner.tryCreateGatewaySchemaFenceDelegate;
+    const delegation = vi
+      .spyOn(coordinatorOwner, "tryCreateGatewaySchemaFenceDelegate")
+      .mockImplementationOnce((params) => {
+        const original = createDelegate(params);
+        if (!original) {
+          throw new Error("Fixture Gateway delegate was not acquired");
+        }
+        return {
+          port: original.port,
+          get closed() {
+            return original.closed;
+          },
+          release() {
+            original.release();
+            throw new Error("Fixture Gateway pin cleanup failed");
+          },
+        };
+      });
+    const file = databasePath();
+    const { store, gateway } = await openWithGateway(file);
+    gateway.release();
+    const events = vi.spyOn(Worker.prototype, "emit");
+    try {
+      await expect(store.close()).rejects.toThrow("Fixture Gateway pin cleanup failed");
+      expect(events.mock.calls.some(([event]) => event === "exit")).toBe(true);
+      await expect(store.close()).resolves.toBeUndefined();
+      await expect(append(await open(file), "after completed cleanup")).resolves.toMatchObject({
+        writes: 1,
+      });
+    } finally {
+      const worker = events.mock.contexts.find((context) => context instanceof Worker);
+      await worker?.terminate();
+      events.mockRestore();
+      delegation.mockRestore();
+      await Promise.allSettled([store.close()]);
+      stores.delete(store);
+      gateway.release();
+    }
+  });
 
   it.each(["memory", "absolute memory", "memory URI", "incognito", "empty"] as const)(
     "rejects a %s locator before creating a file or dispatching a worker request",

--- a/src/infra/sqlite-worker-store.ts
+++ b/src/infra/sqlite-worker-store.ts
@@ -7,6 +7,7 @@ import {
   type SqliteWorkerOperations,
   type SqliteWorkerStore,
 } from "./sqlite-worker-contract.js";
+import type { SqliteWorkerStateContext } from "./sqlite-worker-state-context.js";
 
 export {
   SqliteWorkerError,
@@ -15,6 +16,39 @@ export {
   type SqliteWorkerOperations,
   type SqliteWorkerStore,
 } from "./sqlite-worker-contract.js";
+
+/** Retain one actor through local reconciliation; the callback must not await its own close. */
+export function runSqliteWorkerStoreOperation<Operations extends SqliteWorkerOperations, T>(
+  store: SqliteWorkerStore<Operations>,
+  operation: (scope: Pick<SqliteWorkerStore<Operations>, "execute">) => T | Promise<T>,
+  stateContext?: SqliteWorkerStateContext,
+  assertCurrent?: (commandType: PropertyKey) => void,
+): Promise<T> {
+  return resolveSqliteWorkerBroker().runOperation(store, operation, stateContext, assertCurrent);
+}
+
+function resolveSqliteWorkerBroker() {
+  return resolveGlobalSingleton(
+    Symbol.for("openclaw.sqliteWorkerBroker"),
+    () => new SqliteWorkerBroker(),
+    (broker) => broker.close(),
+  );
+}
+
+/** Read the broker's recorded lifecycle state without probing native storage. */
+export function isSqliteWorkerStoreAvailable(store: object): boolean {
+  return resolveSqliteWorkerBroker().isAvailable(store);
+}
+
+/** Recorded orphan custody at its original shared-state opening path. */
+export function hasUnclaimedSharedStateSqliteCleanup(databasePath: string): boolean {
+  return resolveSqliteWorkerBroker().hasUnclaimedSharedStateCleanup(databasePath);
+}
+
+/** Explicit cleanup only; referenced actors and other opening scopes are untouched. */
+export function closeUnclaimedSharedStateSqliteWorkers(databasePath: string): Promise<void> {
+  return resolveSqliteWorkerBroker().closeUnclaimedSharedState(databasePath);
+}
 
 export function openSqliteWorkerStore<Operations extends SqliteWorkerOperations>(
   options: SqliteWorkerStoreOptions & { existingOnly: true },
@@ -36,9 +70,23 @@ export function openSqliteWorkerStore<Operations extends SqliteWorkerOperations>
       ),
     );
   }
-  return resolveGlobalSingleton(
-    Symbol.for("openclaw.sqliteWorkerBroker"),
-    () => new SqliteWorkerBroker(),
-    (broker) => broker.close(),
-  ).open<Operations>(options);
+  return resolveSqliteWorkerBroker().open<Operations>(options);
+}
+
+/** Host-internal admission for the canonical shared-state actor. */
+export function openSharedStateSqliteWorkerStore<Operations extends SqliteWorkerOperations>(
+  options: Omit<SqliteWorkerStoreOptions, "input">,
+  stateContext: SqliteWorkerStateContext,
+  assertCurrent?: () => void,
+): Promise<SqliteWorkerStore<Operations> | undefined> {
+  if (!isMainThread) {
+    return Promise.reject(
+      new SqliteWorkerError("Shared-state admission requires the host broker", "unavailable"),
+    );
+  }
+  return resolveSqliteWorkerBroker().open<Operations>(
+    { ...options, input: undefined },
+    stateContext,
+    assertCurrent,
+  );
 }

--- a/src/infra/sqlite-worker-terminal-admission.test.ts
+++ b/src/infra/sqlite-worker-terminal-admission.test.ts
@@ -1,0 +1,249 @@
+import { existsSync, mkdirSync, rmdirSync } from "node:fs";
+import { DatabaseSync, StatementSync } from "node:sqlite";
+import { Worker } from "node:worker_threads";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import {
+  clearOpenClawStateDatabaseOpenFailure,
+  closeOpenClawStateDatabaseAsync,
+  isOpenClawStateDatabaseOpen,
+  recordOpenClawStateDatabaseOpenFailure,
+} from "../state/openclaw-state-db-cache.js";
+import { captureOpenClawStateWorkerContext } from "../state/openclaw-state-worker-context.js";
+import {
+  executeOpenClawStateWorker,
+  runOpenClawStateWorkerOperation,
+} from "../state/openclaw-state-worker-store.js";
+import * as fileDescriptor from "./file-descriptor.js";
+import { readStableSqliteFileGeneration } from "./sqlite-file-generation.js";
+import type { SqliteWorkerReply } from "./sqlite-worker-contract.js";
+
+const paths = new Set<string>();
+const dirs = useAutoCleanupTempDirTracker((cleanup) =>
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await closeOpenClawStateDatabaseAsync();
+    for (const pathname of paths) {
+      clearOpenClawStateDatabaseOpenFailure(pathname);
+    }
+    paths.clear();
+    cleanup();
+  }),
+);
+
+function fixture() {
+  const env = { OPENCLAW_STATE_DIR: dirs.make("openclaw-worker-terminal-admission-") };
+  const capture = () => captureOpenClawStateWorkerContext({ env });
+  const pathname = capture().admission.databasePath;
+  paths.add(pathname);
+  return {
+    capture,
+    pathname,
+    read: () =>
+      executeOpenClawStateWorker(capture(), {
+        type: "tasks.list",
+        input: { ownerKey: "agent:main:main" },
+      }),
+  };
+}
+
+function observeMainDatabaseWork() {
+  const calls = [
+    vi.spyOn(DatabaseSync.prototype, "prepare"),
+    vi.spyOn(DatabaseSync.prototype, "exec"),
+    vi.spyOn(fileDescriptor, "hashFileDescriptorSync"),
+    ...(["get", "all", "run", "iterate"] as const).map((method) =>
+      vi.spyOn(StatementSync.prototype, method),
+    ),
+  ];
+  return {
+    expectIdle: () => {
+      for (const call of calls) {
+        expect(call).not.toHaveBeenCalled();
+      }
+    },
+    restore: () => {
+      for (const call of calls) {
+        call.mockRestore();
+      }
+    },
+  };
+}
+
+describe("shared-state worker terminal admission", () => {
+  it("rejects fresh domain reads after a parent failure with only a worker open, then recovers on clear", async () => {
+    const state = fixture();
+    const main = observeMainDatabaseWork();
+    try {
+      expect(await state.read()).toEqual([]);
+      expect(isOpenClawStateDatabaseOpen(state.pathname)).toBe(false);
+      const failure = new Error("verified shared-state failure");
+      expect(recordOpenClawStateDatabaseOpenFailure(state.pathname, failure)).toBe(true);
+      await expect(state.read()).rejects.toBe(failure);
+      clearOpenClawStateDatabaseOpenFailure(state.pathname);
+      expect(await state.read()).toEqual([]);
+      expect(isOpenClawStateDatabaseOpen(state.pathname)).toBe(false);
+      main.expectIdle();
+    } finally {
+      main.restore();
+    }
+  });
+
+  it.each(["explicit clear", "same-file update"] as const)(
+    "validates a recorded generation off-thread and admits a later read after %s",
+    async (recovery) => {
+      const state = fixture();
+      expect(await state.read()).toEqual([]);
+      await closeOpenClawStateDatabaseAsync();
+      const failure = new Error("generation-bound shared-state failure");
+      expect(
+        recordOpenClawStateDatabaseOpenFailure(
+          state.pathname,
+          failure,
+          readStableSqliteFileGeneration(state.pathname),
+        ),
+      ).toBe(true);
+      let main = observeMainDatabaseWork();
+      try {
+        await expect(state.read()).rejects.toBe(failure);
+        main.expectIdle();
+        main.restore();
+        if (recovery === "explicit clear") {
+          clearOpenClawStateDatabaseOpenFailure(state.pathname);
+        } else {
+          // Change the existing file through SQLite without changing its schema or pathname.
+          const database = new DatabaseSync(state.pathname);
+          try {
+            database.exec("PRAGMA application_id = 123");
+          } finally {
+            database.close();
+          }
+        }
+        main = observeMainDatabaseWork();
+        expect(await state.read()).toEqual([]);
+        expect(isOpenClawStateDatabaseOpen(state.pathname)).toBe(false);
+        main.expectIdle();
+      } finally {
+        main.restore();
+      }
+    },
+  );
+
+  it("retains a terminal fact when worker inspection fails, then recovers after a stable mismatch", async () => {
+    const state = fixture();
+    expect(await state.read()).toEqual([]);
+    await closeOpenClawStateDatabaseAsync();
+    const failure = new Error("generation awaiting successful inspection");
+    expect(
+      recordOpenClawStateDatabaseOpenFailure(
+        state.pathname,
+        failure,
+        readStableSqliteFileGeneration(state.pathname),
+      ),
+    ).toBe(true);
+    const { getOpenClawStateDatabaseTerminalFailureAsync } =
+      await import("../state/openclaw-state-db-cache.js");
+    const wal = `${state.pathname}-wal`;
+    mkdirSync(wal);
+    const main = observeMainDatabaseWork();
+    try {
+      await expect(
+        getOpenClawStateDatabaseTerminalFailureAsync(state.capture()),
+      ).rejects.toBeInstanceOf(Error);
+      main.expectIdle();
+    } finally {
+      main.restore();
+      rmdirSync(wal);
+    }
+    // Removing the unreadable sidecar leaves the original recorded generation intact.
+    await expect(getOpenClawStateDatabaseTerminalFailureAsync(state.capture())).resolves.toBe(
+      failure,
+    );
+    const database = new DatabaseSync(state.pathname);
+    try {
+      database.exec("PRAGMA application_id = 321");
+    } finally {
+      database.close();
+    }
+    expect(await state.read()).toEqual([]);
+  });
+
+  it("does not create absent state while checking a recorded failure or an existing-only read", async () => {
+    const state = fixture();
+    const failure = new Error("recorded failure before first open");
+    recordOpenClawStateDatabaseOpenFailure(state.pathname, failure);
+    const inspect = vi.fn(async () => "unexpected domain call");
+    const main = observeMainDatabaseWork();
+    try {
+      await expect(
+        runOpenClawStateWorkerOperation(state.capture(), inspect, { existingOnly: true }),
+      ).rejects.toBe(failure);
+      expect(existsSync(state.pathname)).toBe(false);
+      clearOpenClawStateDatabaseOpenFailure(state.pathname);
+      expect(
+        await runOpenClawStateWorkerOperation(state.capture(), inspect, { existingOnly: true }),
+      ).toBeUndefined();
+      expect(inspect).not.toHaveBeenCalled();
+      expect(existsSync(state.pathname)).toBe(false);
+      main.expectIdle();
+    } finally {
+      main.restore();
+    }
+  });
+
+  it("rejects a queued domain job before dispatch after record and clear while completing the dispatched read", async () => {
+    const state = fixture();
+    expect(await state.read()).toEqual([]);
+    const replyReady = createDeferred();
+    const queuedReady = createDeferred();
+    let publish: (() => void) | undefined;
+    const replies = vi.spyOn(Worker.prototype, "emit").mockImplementationOnce(function (
+      this: Worker,
+      event: string | symbol,
+      reply: SqliteWorkerReply,
+    ) {
+      replies.mockRestore();
+      publish = () => this.emit(event, reply);
+      replyReady.resolve();
+      return true;
+    });
+    const requests = vi.spyOn(Worker.prototype, "postMessage");
+    const active = runOpenClawStateWorkerOperation(state.capture(), (scope) =>
+      scope.execute({ type: "tasks.list", input: { ownerKey: "active" } }),
+    );
+    let queued: Promise<unknown> | undefined;
+    let draining: Promise<void> | undefined;
+    try {
+      await replyReady.promise;
+      queued = runOpenClawStateWorkerOperation(state.capture(), (scope) => {
+        const reading = scope.execute({ type: "tasks.list", input: { ownerKey: "queued" } });
+        queuedReady.resolve();
+        return reading;
+      });
+      const outcomes = Promise.allSettled([active, queued]);
+      await queuedReady.promise;
+      recordOpenClawStateDatabaseOpenFailure(state.pathname, new Error("parent terminal record"));
+      clearOpenClawStateDatabaseOpenFailure(state.pathname);
+      publish?.();
+      publish = undefined;
+      expect(await outcomes).toEqual([
+        { status: "fulfilled", value: [] },
+        {
+          status: "rejected",
+          reason: expect.objectContaining({ message: expect.stringContaining("read admission") }),
+        },
+      ]);
+      draining = closeOpenClawStateDatabaseAsync();
+      await draining;
+      expect(requests.mock.calls.filter(([request]) => request.type === "execute")).toHaveLength(1);
+      requests.mockRestore();
+      expect(await state.read()).toEqual([]);
+    } finally {
+      replies.mockRestore();
+      publish?.();
+      requests.mockRestore();
+      await Promise.allSettled([active, queued, draining]);
+    }
+  });
+});

--- a/src/infra/state-database-coordinator.test.ts
+++ b/src/infra/state-database-coordinator.test.ts
@@ -1,21 +1,160 @@
+import { once } from "node:events";
 import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
+import { Worker } from "node:worker_threads";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { resolvePathViaExistingAncestorSync } from "./boundary-path.js";
 import { sha256HexPrefixCore } from "./crypto-digest.js";
+import { tryAcquireExclusiveSqliteCoordinator } from "./sqlite-coordinator.js";
+import { captureCoordinatorDatabase } from "./sqlite-coordinator.test-support.js";
 import {
   acquireGatewayLifecycleCoordinator,
   acquireStateDatabaseCoordinator,
   acquireStateDatabaseHandleExclusion,
   resolveStateDatabaseCoordinatorPath,
+  resolveStateLifecycleRuntimeDirectory,
+  tryCreateGatewaySchemaFenceDelegate,
+  withStateDatabaseCoordinatorRuntimeDirectory,
   withStateSchemaFence,
 } from "./state-database-coordinator.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 describe("state database coordinator", () => {
+  it("retains final-reference cleanup without treating its rolled-back handle as ownership", () => {
+    const root = tempDirs.make("openclaw-coordinator-reference-retry-");
+    const params = { databasePath: path.join(root, "state.sqlite"), runtimeDirectory: root };
+    const { result: first, database } = captureCoordinatorDatabase(() =>
+      acquireGatewayLifecycleCoordinator(params),
+    );
+    const last = acquireGatewayLifecycleCoordinator(params);
+    const close = vi.spyOn(database, "close").mockImplementationOnce(() => {
+      throw new Error("Fixture native close remains open");
+    });
+    try {
+      first.release();
+      expect(first.closed).toBe(true);
+      expect(close).not.toHaveBeenCalled();
+      expect(() => last.release()).toThrow("failed to release gateway-lifecycle coordinator");
+      expect(last.closed).toBe(false);
+      expect(database.isOpen).toBe(true);
+      expect(database.isTransaction).toBe(false);
+      expect(() => acquireGatewayLifecycleCoordinator(params)).toThrow("cleanup is pending");
+      expect(
+        tryCreateGatewaySchemaFenceDelegate({ ...params, actorId: "pending" }),
+      ).toBeUndefined();
+      first.release();
+      expect(close).toHaveBeenCalledTimes(1);
+      last.release();
+      expect(last.closed).toBe(true);
+      expect(close).toHaveBeenCalledTimes(2);
+      acquireGatewayLifecycleCoordinator(params).release();
+    } finally {
+      close.mockRestore();
+      first.release();
+      last.release();
+    }
+  });
+
+  it("retains a Gateway worker fence until worker exit while sealing shutdown admission", async () => {
+    const root = tempDirs.make("openclaw-gateway-worker-fence-");
+    const params = {
+      databasePath: path.join(root, "state", "openclaw.sqlite"),
+      runtimeDirectory: path.join(root, "runtime"),
+      actorId: "shared-state-test",
+    };
+    // An actor can open before Gateway startup without opening a coordinator on main.
+    expect(tryCreateGatewaySchemaFenceDelegate(params)).toBeUndefined();
+    expect(fsSync.existsSync(params.runtimeDirectory)).toBe(false);
+    expect(
+      withStateSchemaFence(params, () => tryCreateGatewaySchemaFenceDelegate(params)),
+    ).toBeUndefined();
+
+    const gateway = acquireGatewayLifecycleCoordinator(params);
+    const nestedGateway = acquireGatewayLifecycleCoordinator(params);
+    const delegation = tryCreateGatewaySchemaFenceDelegate(params);
+    expect(delegation).toBeDefined();
+    if (!delegation) {
+      nestedGateway.release();
+      gateway.release();
+      throw new Error("Gateway did not retain its worker fence");
+    }
+    const worker = new Worker(
+      new URL("./state-database-coordinator.worker.test-support.mjs", import.meta.url),
+      {
+        execArgv: [],
+        workerData: {
+          params,
+          port: delegation.port,
+          sourceLoaderUrl: import.meta.resolve("tsx/esm/api"),
+          coordinatorUrl: new URL("./state-database-coordinator.ts", import.meta.url).href,
+        },
+        transferList: [delegation.port],
+      },
+    );
+    const ask = async (message: string) => {
+      const response = once(worker, "message");
+      worker.postMessage(message, []);
+      return (await response)[0];
+    };
+    try {
+      expect(await once(worker, "message")).toEqual(["ready"]);
+      expect(await ask("plain")).toEqual({ error: "StateSchemaMutationConflictError" });
+      expect(await ask("delegated")).toEqual({ result: "schema admitted" });
+
+      gateway.release();
+      expect(await ask("delegated")).toEqual({ result: "schema admitted" });
+      nestedGateway.release();
+      expect(tryCreateGatewaySchemaFenceDelegate(params)).toBeUndefined();
+      expect(await ask("delegated")).toEqual({ error: "StateSchemaMutationConflictError" });
+      expect(tryAcquireExclusiveSqliteCoordinator(gateway.path)).toBeNull();
+
+      const exited = once(worker, "exit");
+      worker.postMessage("close", []);
+      expect(await exited).toEqual([0]);
+      // Port closure alone does not release broker-owned custody.
+      expect(tryAcquireExclusiveSqliteCoordinator(gateway.path)).toBeNull();
+      delegation.release();
+      const next = tryAcquireExclusiveSqliteCoordinator(gateway.path);
+      expect(next).not.toBeNull();
+      next?.release();
+    } finally {
+      await worker.terminate();
+      delegation.release();
+      nestedGateway.release();
+      gateway.release();
+    }
+  });
+
+  it("uses the captured coordinator runtime directory across worker preparation", async () => {
+    const root = tempDirs.make("openclaw-coordinator-runtime-scope-");
+    const original = resolveStateLifecycleRuntimeDirectory();
+    await withStateDatabaseCoordinatorRuntimeDirectory(root, async () => {
+      await Promise.resolve();
+      const params = {
+        databasePath: path.join(root, "state", "openclaw.sqlite"),
+      };
+      const { result: coordinator, database } = captureCoordinatorDatabase(() =>
+        acquireStateDatabaseCoordinator(params),
+      );
+      try {
+        expect(coordinator.path).toBe(
+          resolveStateDatabaseCoordinatorPath({
+            ...params,
+            runtimeDirectory: root,
+            uid: typeof process.getuid === "function" ? process.getuid() : undefined,
+          }),
+        );
+      } finally {
+        coordinator.release();
+        expect(database.isOpen).toBe(false);
+      }
+    });
+    expect(resolveStateLifecycleRuntimeDirectory()).toBe(original);
+  });
+
   it.each([
     [false, false],
     [false, true],

--- a/src/infra/state-database-coordinator.ts
+++ b/src/infra/state-database-coordinator.ts
@@ -3,6 +3,8 @@ import { AsyncLocalStorage } from "node:async_hooks";
 import { realpathSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { MessageChannel, receiveMessageOnPort, type MessagePort } from "node:worker_threads";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { resolvePathViaExistingAncestorSync } from "./boundary-path.js";
 import { sha256HexPrefixCore } from "./crypto-digest.js";
 import {
@@ -10,6 +12,7 @@ import {
   ensurePrivateSqliteCoordinatorDirectory,
   runWithSqliteCoordinator,
   SqliteCoordinatorError,
+  type SqliteCoordinatorLease,
   tryAcquireExclusiveSqliteCoordinator,
   tryAcquireSharedSqliteCoordinator,
 } from "./sqlite-coordinator.js";
@@ -17,9 +20,11 @@ import {
 const heldCoordinators = new Map<
   string,
   {
-    coordinator: { release: (options?: { keepAlive?: false }) => void };
+    coordinator: SqliteCoordinatorLease;
     references: number;
     keepAlive: boolean;
+    gatewayOwners: number;
+    gatewayDelegates: Set<Int32Array>;
   }
 >();
 
@@ -33,6 +38,14 @@ type SourceReadScope = {
 };
 const sourceReadScopes = new AsyncLocalStorage<ReadonlyMap<string, SourceReadScope>>();
 const canonicalWriteScopes = new AsyncLocalStorage<ReadonlyMap<string, SourceReadScope>>();
+export type StateDatabaseCoordinatorRuntime = Readonly<{
+  directory: string;
+  keepAlive: boolean;
+}>;
+const coordinatorRuntimeDirectories = new AsyncLocalStorage<StateDatabaseCoordinatorRuntime>();
+const gatewaySchemaScopes = new AsyncLocalStorage<
+  ReadonlyMap<string, { active: boolean; assertCurrent: () => void }>
+>();
 
 type CoordinatorFamily = "gateway-lifecycle" | "state-lifecycle" | "state-handles";
 type CoordinatorOptions = {
@@ -42,6 +55,13 @@ type CoordinatorOptions = {
   uid?: number;
   busyTimeoutMs?: number;
   keepAlive?: boolean;
+};
+
+type StateDatabaseCoordinatorLease = {
+  path: string;
+  // A remaining reference can accept custody without closing the native handle.
+  readonly closed: boolean;
+  release: () => void;
 };
 
 export class StateDatabaseCoordinatorContentionError extends SqliteCoordinatorError {
@@ -62,9 +82,30 @@ export class StateSchemaMutationConflictError extends SqliteCoordinatorError {
 }
 
 export function resolveStateLifecycleRuntimeDirectory(): string {
+  const captured = coordinatorRuntimeDirectories.getStore();
+  if (captured !== undefined) {
+    return captured.directory;
+  }
   return process.platform === "win32"
     ? path.join(os.homedir(), "AppData", "Local", "OpenClaw", "locks")
     : "/tmp";
+}
+
+/** Capture the directory owner's retention policy before crossing an async or worker boundary. */
+export function captureStateDatabaseCoordinatorRuntime(): StateDatabaseCoordinatorRuntime {
+  const captured = coordinatorRuntimeDirectories.getStore();
+  return captured
+    ? { ...captured }
+    : { directory: resolveStateLifecycleRuntimeDirectory(), keepAlive: true };
+}
+
+export function withStateDatabaseCoordinatorRuntimeDirectory<T>(
+  runtime: string | StateDatabaseCoordinatorRuntime,
+  operation: () => T,
+): T {
+  const captured =
+    typeof runtime === "string" ? { directory: runtime, keepAlive: false } : { ...runtime };
+  return coordinatorRuntimeDirectories.run(captured, operation);
 }
 
 function resolveCoordinatorIdentityPath(pathname: string): string {
@@ -124,8 +165,8 @@ export function resolveStateDatabaseCoordinatorPath(params: {
 function acquireLifecycleCoordinator(
   family: CoordinatorFamily,
   params: CoordinatorOptions,
-  keepAlive = false,
-): { path: string; release: () => void } {
+  { keepAlive = false, gatewayOwner = false }: { keepAlive?: boolean; gatewayOwner?: boolean } = {},
+): StateDatabaseCoordinatorLease {
   const coordinatorPath =
     params.coordinatorPath ??
     resolveLifecycleCoordinatorPath(family, {
@@ -133,8 +174,13 @@ function acquireLifecycleCoordinator(
       runtimeDirectory: params.runtimeDirectory ?? resolveStateLifecycleRuntimeDirectory(),
       uid: params.uid ?? (typeof process.getuid === "function" ? process.getuid() : undefined),
     });
-  const held = heldCoordinators.get(coordinatorPath);
+  let held = heldCoordinators.get(coordinatorPath);
   if (held) {
+    if (held.references === 0) {
+      throw new SqliteCoordinatorError(
+        `${family} coordinator cleanup is pending; retry its close before reacquiring`,
+      );
+    }
     held.references += 1;
     held.keepAlive &&= keepAlive;
   } else {
@@ -146,37 +192,200 @@ function acquireLifecycleCoordinator(
     if (!coordinator) {
       throw new StateDatabaseCoordinatorContentionError(family);
     }
-    heldCoordinators.set(coordinatorPath, { coordinator, references: 1, keepAlive });
+    held = {
+      coordinator,
+      references: 1,
+      keepAlive,
+      gatewayOwners: 0,
+      gatewayDelegates: new Set(),
+    };
+    heldCoordinators.set(coordinatorPath, held);
+  }
+  if (gatewayOwner) {
+    held.gatewayOwners += 1;
   }
 
-  let released = false;
+  const owner = held;
+  let relinquished = false;
+  let settled = false;
   return {
     path: coordinatorPath,
+    get closed() {
+      return settled || (relinquished && owner.coordinator.closed);
+    },
     release: () => {
-      if (released) {
+      if (settled) {
         return;
       }
-      released = true;
-      const current = heldCoordinators.get(coordinatorPath);
-      if (!current) {
+      if (!relinquished) {
+        relinquished = true;
+        if (gatewayOwner) {
+          owner.gatewayOwners -= 1;
+          if (owner.gatewayOwners === 0) {
+            for (const delegate of owner.gatewayDelegates) {
+              Atomics.store(delegate, 0, 0);
+            }
+          }
+        }
+        owner.references -= 1;
+      }
+      if (owner.references > 0) {
+        settled = true;
         return;
       }
-      current.references -= 1;
-      if (current.references > 0) {
-        return;
-      }
-      heldCoordinators.delete(coordinatorPath);
       try {
-        current.coordinator.release(current.keepAlive ? undefined : { keepAlive: false });
+        owner.coordinator.release(owner.keepAlive ? undefined : { keepAlive: false });
       } catch (error) {
         throw new SqliteCoordinatorError(`failed to release ${family} coordinator`, error);
+      } finally {
+        if (owner.coordinator.closed) {
+          settled = true;
+          if (heldCoordinators.get(coordinatorPath) === owner) {
+            heldCoordinators.delete(coordinatorPath);
+          }
+        }
       }
     },
   };
 }
 
 export function acquireGatewayLifecycleCoordinator(params: CoordinatorOptions) {
-  return acquireLifecycleCoordinator("gateway-lifecycle", params);
+  return acquireLifecycleCoordinator("gateway-lifecycle", params, { gatewayOwner: true });
+}
+
+type GatewaySchemaFenceDelegateParams = Pick<
+  CoordinatorOptions,
+  "databasePath" | "runtimeDirectory" | "uid"
+> & { actorId: string };
+
+function resolveGatewaySchemaFencePath(
+  params: Pick<CoordinatorOptions, "databasePath" | "runtimeDirectory" | "uid">,
+): string {
+  return resolveLifecycleCoordinatorPath("gateway-lifecycle", {
+    databasePath: params.databasePath,
+    runtimeDirectory: params.runtimeDirectory ?? resolveStateLifecycleRuntimeDirectory(),
+    uid: params.uid ?? (typeof process.getuid === "function" ? process.getuid() : undefined),
+  });
+}
+
+/** The broker owns this pin until backend close acknowledges or worker exit joins. */
+export function tryCreateGatewaySchemaFenceDelegate(params: GatewaySchemaFenceDelegateParams) {
+  const coordinatorPath = resolveGatewaySchemaFencePath(params);
+  const owner = heldCoordinators.get(coordinatorPath);
+  if (!owner || owner.gatewayOwners === 0) {
+    return undefined;
+  }
+  const live = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT));
+  // Retain the actual native owner; a transferable message is not a new owner.
+  const retained = acquireLifecycleCoordinator("gateway-lifecycle", {
+    ...params,
+    coordinatorPath,
+  });
+  Atomics.store(live, 0, 1);
+  owner.gatewayDelegates.add(live);
+  let channel: MessageChannel | undefined;
+  try {
+    channel = new MessageChannel();
+    channel.port1.postMessage({ actorId: params.actorId, coordinatorPath, live: live.buffer });
+    channel.port1.unref();
+  } catch (error) {
+    Atomics.store(live, 0, 0);
+    owner.gatewayDelegates.delete(live);
+    channel?.port1.close();
+    channel?.port2.close();
+    return runWithSqliteCoordinator(retained, "Gateway schema delegate creation", () => {
+      throw error;
+    });
+  }
+  const { port1, port2 } = channel;
+  let revoked = false;
+  return {
+    port: port2,
+    get closed() {
+      return revoked && retained.closed;
+    },
+    release() {
+      if (!revoked) {
+        revoked = true;
+        Atomics.store(live, 0, 0);
+        owner.gatewayDelegates.delete(live);
+        port1.close();
+        port2.close();
+      }
+      retained.release();
+    },
+  };
+}
+
+/** Install before entering native SQLite; transaction callbacks remain synchronous. */
+export async function attachGatewaySchemaFenceDelegate(
+  port: MessagePort,
+  params: GatewaySchemaFenceDelegateParams,
+) {
+  const coordinatorPath = resolveGatewaySchemaFencePath(params);
+  let closed = false;
+  port.once("close", () => {
+    closed = true;
+  });
+  const live = await new Promise<Int32Array>((resolve, reject) => {
+    const onClose = () => {
+      port.off("message", onMessage);
+      reject(new SqliteCoordinatorError("Gateway schema delegate closed before admission"));
+    };
+    const onMessage = (message: unknown) => {
+      port.off("message", onMessage);
+      port.off("close", onClose);
+      if (
+        !isRecord(message) ||
+        message.actorId !== params.actorId ||
+        message.coordinatorPath !== coordinatorPath ||
+        !(message.live instanceof SharedArrayBuffer) ||
+        message.live.byteLength !== Int32Array.BYTES_PER_ELEMENT
+      ) {
+        port.close();
+        reject(new SqliteCoordinatorError("Gateway schema delegate does not match its actor"));
+        return;
+      }
+      resolve(new Int32Array(message.live));
+    };
+    port.once("close", onClose);
+    port.once("message", onMessage);
+    const queued = receiveMessageOnPort(port);
+    if (queued) {
+      onMessage(queued.message);
+    }
+  });
+  port.unref();
+  return {
+    run<T>(operation: () => T): T {
+      const scope = {
+        active: true,
+        assertCurrent() {
+          if (closed || Atomics.load(live, 0) !== 1) {
+            throw new StateSchemaMutationConflictError(
+              params.databasePath,
+              new SqliteCoordinatorError("Gateway schema delegate is no longer current"),
+            );
+          }
+        },
+      };
+      const scopes = new Map(gatewaySchemaScopes.getStore());
+      scopes.set(coordinatorPath, scope);
+      return runWithSqliteCoordinator(
+        {
+          release: () => {
+            scope.active = false;
+          },
+        },
+        "Gateway schema delegate scope",
+        () => gatewaySchemaScopes.run(scopes, operation),
+      );
+    },
+    close() {
+      closed = true;
+      port.close();
+    },
+  };
 }
 
 /** Borrow only a coordinator already owned by this process. The returned
@@ -192,13 +401,16 @@ export function retainHeldStateDatabaseCoordinator(databasePath: string) {
     : undefined;
 }
 
+const shouldKeepStateCoordinatorAlive = (params: CoordinatorOptions) =>
+  params.keepAlive !== false &&
+  params.coordinatorPath === undefined &&
+  params.runtimeDirectory === undefined &&
+  (coordinatorRuntimeDirectories.getStore()?.keepAlive ?? true);
+
 export function acquireStateDatabaseCoordinator(params: CoordinatorOptions) {
   // Caller-owned locations must remain removable immediately after release,
   // including on Windows where an idle SQLite handle blocks unlink.
-  const keepAlive =
-    params.keepAlive !== false &&
-    params.coordinatorPath === undefined &&
-    params.runtimeDirectory === undefined;
+  const keepAlive = shouldKeepStateCoordinatorAlive(params);
   // Lifecycle ownership is reentrant for nested transactions. File publication
   // is not: even this process must refuse before ownership probes touch SQLite.
   const base = resolveLifecycleCoordinatorBase({
@@ -214,13 +426,9 @@ export function acquireStateDatabaseCoordinator(params: CoordinatorOptions) {
     }
     writeScope.assertCurrent();
     // Authority callbacks can change paths; resolve again after their checks.
-    return acquireLifecycleCoordinator(
-      "state-lifecycle",
-      params,
-      params.keepAlive !== false &&
-        params.coordinatorPath === undefined &&
-        params.runtimeDirectory === undefined,
-    );
+    return acquireLifecycleCoordinator("state-lifecycle", params, {
+      keepAlive: shouldKeepStateCoordinatorAlive(params),
+    });
   } else if (heldCoordinators.has(handlesPath)) {
     throw new StateDatabaseCoordinatorContentionError("state-handles");
   }
@@ -231,7 +439,7 @@ export function acquireStateDatabaseCoordinator(params: CoordinatorOptions) {
       coordinatorPath:
         params.coordinatorPath ?? buildLifecycleCoordinatorPath("state-lifecycle", base),
     },
-    keepAlive,
+    { keepAlive },
   );
 }
 
@@ -240,12 +448,22 @@ export function withStateSchemaFence<T>(
   params: Pick<CoordinatorOptions, "databasePath" | "runtimeDirectory" | "uid">,
   operation: () => T,
 ): T {
+  const delegatePath = resolveGatewaySchemaFencePath(params);
+  const delegate = gatewaySchemaScopes.getStore()?.get(delegatePath);
+  if (delegate) {
+    if (!delegate.active) {
+      throw new SqliteCoordinatorError("Gateway schema delegate scope is closed");
+    }
+    delegate.assertCurrent();
+    return runWithSqliteCoordinator({ release() {} }, "state schema mutation", operation);
+  }
   let coordinator: ReturnType<typeof acquireGatewayLifecycleCoordinator>;
   try {
     // Never wait while the caller holds the state-lifecycle coordinator. A
     // running Gateway must win immediately so lock ordering cannot deadlock.
-    coordinator = acquireGatewayLifecycleCoordinator({
+    coordinator = acquireLifecycleCoordinator("gateway-lifecycle", {
       ...params,
+      coordinatorPath: delegatePath,
       busyTimeoutMs: 0,
     });
   } catch (error) {

--- a/src/infra/state-database-coordinator.worker.test-support.mjs
+++ b/src/infra/state-database-coordinator.worker.test-support.mjs
@@ -1,0 +1,24 @@
+import { parentPort, workerData } from "node:worker_threads";
+
+const { register } = await import(workerData.sourceLoaderUrl);
+register();
+const { attachGatewaySchemaFenceDelegate, withStateSchemaFence } = await import(
+  workerData.coordinatorUrl
+);
+const delegate = await attachGatewaySchemaFenceDelegate(workerData.port, workerData.params);
+
+parentPort.on("message", (message) => {
+  if (message === "close") {
+    delegate.close();
+    parentPort.close();
+    return;
+  }
+  try {
+    const operation = () => withStateSchemaFence(workerData.params, () => "schema admitted");
+    const result = message === "delegated" ? delegate.run(operation) : operation();
+    parentPort.postMessage({ result }, []);
+  } catch (error) {
+    parentPort.postMessage({ error: error.name }, []);
+  }
+});
+parentPort.postMessage("ready", []);

--- a/src/plugins/runtime/runtime-tasks-async.ts
+++ b/src/plugins/runtime/runtime-tasks-async.ts
@@ -1,5 +1,4 @@
-import { captureOpenClawStateDatabaseReadAdmission } from "../../state/openclaw-state-db-cache.js";
-import { resolveOpenClawStateSqlitePath } from "../../state/openclaw-state-db.paths.js";
+import { captureOpenClawStateWorkerContext } from "../../state/openclaw-state-worker-context.js";
 import {
   mapTaskFlowDetail,
   mapTaskRunAggregateSummary,
@@ -30,20 +29,19 @@ function bind(params: Binding) {
 }
 
 async function readStore(includeTasks: boolean, includeFlows: boolean) {
-  const databasePath = resolveOpenClawStateSqlitePath();
-  const context = captureOpenClawStateDatabaseReadAdmission(databasePath);
+  const context = captureOpenClawStateWorkerContext();
   // Cold restore retains canonical schema admission and failure semantics. Only
   // this first admission uses main-thread SQLite; warmed queries run in the worker.
   if (includeFlows) {
-    context.assertCurrent();
+    context.admission.assertCurrent();
     ensureTaskFlowRegistryReady();
   }
   if (includeTasks) {
-    context.assertCurrent();
+    context.admission.assertCurrent();
     ensureTaskRegistryReady();
   }
   const store = await import("../../state/openclaw-state-worker-store.js");
-  context.assertCurrent();
+  context.admission.assertCurrent();
   return { store, context };
 }
 
@@ -127,11 +125,14 @@ function bindFlows(params: Binding): BoundAsyncTaskFlowsRuntime {
   const binding = bind(params);
   const read = async (lookup: "id" | "latest" | "resolve", token?: string) => {
     const { store, context } = await readStore(true, true);
-    const result = await store.executeOpenClawStateWorker(context, {
-      type: "flows.detail",
-      input: { ownerKey: binding.sessionKey, lookup, token },
+    return store.runOpenClawStateWorkerOperation(context, async (scope) => {
+      const result = await scope.execute({
+        type: "flows.detail",
+        input: { ownerKey: binding.sessionKey, lookup, token },
+      });
+      context.admission.assertCurrent();
+      return result ? mapTaskFlowDetail(result) : undefined;
     });
-    return result ? mapTaskFlowDetail(result) : undefined;
   };
   return {
     ...binding,

--- a/src/state/openclaw-agent-db-lifecycle.ts
+++ b/src/state/openclaw-agent-db-lifecycle.ts
@@ -62,7 +62,9 @@ const cache = resolveGlobalSingleton<AgentDatabaseLifecycle>(
     generation: 0,
     failures: new Map(),
     leases: new Map(),
-    terminal: createSqliteTerminalOpenLatch({ closeByPath: closeOpenClawAgentDatabaseByPath }),
+    terminal: createSqliteTerminalOpenLatch({
+      closeByPath: (pathname) => closeOpenClawAgentDatabaseByPath(pathname),
+    }),
     unregisterExitClose: null,
     pending: new Map(),
     activePending: new Set(),

--- a/src/state/openclaw-state-db-async-lifecycle.ts
+++ b/src/state/openclaw-state-db-async-lifecycle.ts
@@ -69,8 +69,8 @@ export function createOpenClawStateDatabaseAsyncLifecycle() {
             readDatabasePathIdentitySync(candidate.identity.canonicalPath).key === identity.key
           );
         } catch {
-          // Unpublished prospective paths have no admitted worker. Keep their
-          // records without making unrelated identity lookup failures contagious.
+          // Creation can still be opening in a worker. Keep its custody until
+          // publication or drainage without spreading unrelated lookup failures.
           return false;
         }
       });

--- a/src/state/openclaw-state-db-cache.ts
+++ b/src/state/openclaw-state-db-cache.ts
@@ -19,7 +19,6 @@ import {
   prepareSqliteReadOnlyLocationSyncInProcess,
 } from "../infra/sqlite-readonly-location.js";
 import { createSqliteTerminalOpenLatch } from "../infra/sqlite-terminal-open-latch.js";
-import { isSqliteSchemaVersionError } from "../infra/sqlite-user-version.js";
 import { registerSqliteCacheExitClose } from "../infra/sqlite-wal.js";
 import type { DatabasePathIdentity } from "../infra/sqlite-worker-identity.js";
 import {
@@ -41,7 +40,8 @@ import {
   type OpenClawStateDatabase,
 } from "./openclaw-state-db-contract.js";
 import { closeTrackedStateDatabase } from "./openclaw-state-db-handle.js";
-import { assertSupportedStateSchemaVersion } from "./openclaw-state-db-schema-version.js";
+import { createOpenClawStateDatabaseRuntimeFailureOwner } from "./openclaw-state-db-runtime-failure.js";
+import type { OpenClawStateWorkerContext } from "./openclaw-state-worker-context.types.js";
 
 type StateDatabaseHandle = Pick<OpenClawStateDatabase, "db" | "path"> &
   Partial<Pick<OpenClawStateDatabase, "walMaintenance">> & {
@@ -53,6 +53,8 @@ type OpenClawStateDatabaseCloseOptions = NonNullable<
 type OpenClawStateDatabaseLifecycleEvent =
   | { kind: "opened"; database: OpenClawStateDatabase; identity: DatabasePathIdentity }
   | { kind: "closed"; path: string; identity: DatabasePathIdentity }
+  | { kind: "failure-cleared"; path: string; identity?: DatabasePathIdentity }
+  | { kind: "terminal-failure"; path: string; identity?: DatabasePathIdentity; error: Error }
   | { kind: "open-error"; path: string; identity?: DatabasePathIdentity; error: unknown };
 type StateDatabaseLifecycle = {
   cachedDatabases: Map<string, OpenClawStateDatabase>;
@@ -80,11 +82,28 @@ const stateDatabaseLifecycle = resolveGlobalSingleton<StateDatabaseLifecycle>(
     databaseIdentities: new WeakMap<DatabaseSync, DatabasePathIdentity>(),
     databaseLifecycleListeners: new Set<(event: OpenClawStateDatabaseLifecycleEvent) => void>(),
     terminalOpenLatch: createSqliteTerminalOpenLatch({
-      closeByPath: (pathname) => {
+      closeByPath: (pathname, error) => {
+        asyncResources.invalidate(pathname);
         const cached = cachedDatabases.get(pathname);
-        if (cached) {
-          evictCachedOpenClawStateDatabase(cached);
+        const errors: unknown[] = [];
+        try {
+          if (cached) {
+            evictCachedOpenClawStateDatabase(cached);
+          }
+        } catch (cleanupError) {
+          errors.push(cleanupError);
         }
+        try {
+          notifyOpenClawStateDatabaseLifecycle({
+            kind: "terminal-failure",
+            path: pathname,
+            error,
+            identity: asyncResources.knownIdentity(pathname),
+          });
+        } catch (notificationError) {
+          errors.push(notificationError);
+        }
+        throwStateDatabaseCleanupErrors(errors, "Terminal shared-state failure cleanup failed");
       },
     }),
     asyncResources: createOpenClawStateDatabaseAsyncLifecycle(),
@@ -128,20 +147,17 @@ function requireOpenClawStateDatabaseIdentity(database: StateDatabaseHandle): Da
   return identity;
 }
 
-function readSqliteDataVersion(database: OpenClawStateDatabase): number {
-  let statement = cachedDataVersionStatements.get(database);
-  if (!statement) {
-    statement = database.db /* sqlite-allow-raw -- Connection-local schema compatibility counter. */
-      .prepare("PRAGMA data_version");
-    cachedDataVersionStatements.set(database, statement);
-  }
-  // SAFETY: SQLite defines this pragma's single-column row; the value is validated below.
-  const row = statement.get() as { data_version?: unknown } | undefined;
-  if (typeof row?.data_version !== "number") {
-    throw new Error("SQLite did not return a numeric PRAGMA data_version");
-  }
-  return row.data_version;
-}
+const runtimeFailures = createOpenClawStateDatabaseRuntimeFailureOwner({
+  cachedDatabases,
+  statements: cachedDataVersionStatements,
+  dataVersions: cachedDataVersions,
+  latch: terminalOpenLatch,
+  evict: evictCachedOpenClawStateDatabase,
+  recordSchemaFailure: (pathname, error) => {
+    terminalOpenLatch.record(pathname, error);
+    notifyOpenClawStateDatabaseLifecycle({ kind: "open-error", path: pathname, error });
+  },
+});
 
 export function registerOpenClawStateDatabaseLifecycleListener(
   listener: (event: OpenClawStateDatabaseLifecycleEvent) => void,
@@ -236,7 +252,7 @@ function publishOpenClawStateDatabase(database: OpenClawStateDatabase): OpenClaw
   const { db, path: pathname } = database;
   const identity = asyncResources.publish(pathname);
   databaseIdentities.set(db, identity);
-  cachedDataVersions.set(db, readSqliteDataVersion(database));
+  runtimeFailures.recordPublishedVersion(database);
   cachedDatabases.set(pathname, database);
   notifyOpenClawStateDatabaseLifecycle({ kind: "opened", database, identity });
   registerNodeSqliteKyselyQueryErrorHandler(db, (error) => {
@@ -249,44 +265,7 @@ function publishOpenClawStateDatabase(database: OpenClawStateDatabase): OpenClaw
   return database;
 }
 
-/** Revalidate a cached owner after another connection commits to its database. */
-function getOpenClawStateDatabaseRuntimeFailure(pathname: string): Error | undefined {
-  const resolvedPath = path.resolve(pathname);
-  const latched = terminalOpenLatch.get(resolvedPath);
-  if (latched) {
-    return latched;
-  }
-  const cached = cachedDatabases.get(resolvedPath);
-  if (!cached?.db.isOpen) {
-    return undefined;
-  }
-  try {
-    const dataVersion = readSqliteDataVersion(cached);
-    if (cachedDataVersions.get(cached.db) === dataVersion) {
-      return undefined;
-    }
-    // data_version is the cheap external-commit trigger. Recheck published and
-    // content versions only when another connection changed the file.
-    assertSupportedStateSchemaVersion(cached.db, resolvedPath);
-    cachedDataVersions.set(cached.db, dataVersion);
-    return undefined;
-  } catch (error) {
-    const failure = error instanceof Error ? error : new Error(String(error));
-    if (isSqliteCorruptionError(failure)) {
-      evictCachedOpenClawStateDatabase(cached);
-      return undefined;
-    }
-    if (isSqliteSchemaVersionError(failure)) {
-      terminalOpenLatch.record(resolvedPath, failure);
-      notifyOpenClawStateDatabaseLifecycle({
-        kind: "open-error",
-        path: resolvedPath,
-        error: failure,
-      });
-    }
-    return failure;
-  }
-}
+const getOpenClawStateDatabaseRuntimeFailure = runtimeFailures.get;
 
 function getCachedOpenClawStateDatabase(pathname: string): OpenClawStateDatabase | undefined {
   const runtimeFailure = getOpenClawStateDatabaseRuntimeFailure(pathname);
@@ -326,7 +305,37 @@ export function recordOpenClawStateDatabaseOpenFailure(
 
 /** Clear a terminal open failure after doctor rewrites the database file. */
 export function clearOpenClawStateDatabaseOpenFailure(pathname: string): void {
-  terminalOpenLatch.clear(pathname);
+  const resolvedPath = path.resolve(pathname);
+  terminalOpenLatch.clear(resolvedPath);
+  asyncResources.invalidate(resolvedPath);
+  notifyOpenClawStateDatabaseLifecycle({
+    kind: "failure-cleared",
+    path: resolvedPath,
+    identity: asyncResources.knownIdentity(resolvedPath),
+  });
+}
+
+/** Validate the canonical terminal fact before acquiring a domain-operation lease. */
+export async function getOpenClawStateDatabaseTerminalFailureAsync(
+  context: OpenClawStateWorkerContext,
+): Promise<Error | undefined> {
+  context.admission.assertCurrent();
+  const failure = await terminalOpenLatch.getAsync(
+    context.admission.databasePath,
+    async (_path, generation) => {
+      const { inspectOpenClawStateDatabase } = await import("./openclaw-state-worker-store.js");
+      const matches = await inspectOpenClawStateDatabase(context, {
+        type: "database.generationMatches",
+        input: { generation },
+      });
+      if (matches === undefined) {
+        throw new Error("Recorded shared-state database generation is unavailable");
+      }
+      return matches;
+    },
+  );
+  context.admission.assertCurrent();
+  return failure;
 }
 
 /** Reject shared-state access after a process-local terminal failure. */
@@ -470,6 +479,15 @@ export function captureOpenClawStateDatabaseReadAdmission(
   pathname: string,
 ): OpenClawStateDatabaseReadAdmission {
   return asyncResources.capture(pathname);
+}
+
+/** Bind worker-created storage to its captured admission without publishing a native handle. */
+export function publishOpenClawStateDatabaseWorkerAdmission(
+  admission: OpenClawStateDatabaseReadAdmission,
+): void {
+  admission.assertCurrent();
+  asyncResources.publish(admission.databasePath);
+  admission.assertCurrent();
 }
 
 /** Drain worker resources before native checkpoint/close at one exact path. */

--- a/src/state/openclaw-state-db-open.test.ts
+++ b/src/state/openclaw-state-db-open.test.ts
@@ -8,7 +8,11 @@ import * as kyselySync from "../infra/kysely-sync.js";
 import * as nodeSqlite from "../infra/node-sqlite.js";
 import * as busyTimeout from "../infra/sqlite-busy-timeout.js";
 import * as sqliteWal from "../infra/sqlite-wal.js";
-import { acquireStateDatabaseHandleExclusion } from "../infra/state-database-coordinator.js";
+import {
+  acquireStateDatabaseHandleExclusion,
+  resolveStateDatabaseCoordinatorPath,
+  withStateDatabaseCoordinatorRuntimeDirectory,
+} from "../infra/state-database-coordinator.js";
 import {
   openClawStateDatabaseCache,
   recordOpenClawStateDatabaseOpenFailure,
@@ -96,6 +100,27 @@ describe("unpublished state database acquisition", () => {
     }
     expect(maintenanceTimerCount()).toBe(0);
   }
+
+  it("keeps the admitted coordinator directory for delayed maintenance", () => {
+    const { params, open } = acquisitionFixture();
+    const runtimeDirectory = tempDirs.make("openclaw-maintenance-scope-");
+    const database = withStateDatabaseCoordinatorRuntimeDirectory(runtimeDirectory, () =>
+      openUnpublishedStateDatabase(params),
+    );
+    const coordinatorPath = resolveStateDatabaseCoordinatorPath({
+      databasePath: params.pathname,
+      runtimeDirectory,
+      uid: typeof process.getuid === "function" ? process.getuid() : undefined,
+    });
+    try {
+      open.mockClear();
+      vi.advanceTimersByTime(30 * 60 * 1000);
+      expect(open.mock.calls.map(([location]) => location)).toContain(coordinatorPath);
+    } finally {
+      database.walMaintenance.close();
+      closeTrackedStateDatabase(database.db);
+    }
+  });
 
   it.each([
     "statement cache",

--- a/src/state/openclaw-state-db-open.ts
+++ b/src/state/openclaw-state-db-open.ts
@@ -19,7 +19,10 @@ import {
   configureSqlitePreSchemaPragmas,
   type SqliteWalMaintenance,
 } from "../infra/sqlite-wal.js";
-import { acquireStateDatabaseCoordinator } from "../infra/state-database-coordinator.js";
+import {
+  acquireStateDatabaseCoordinator,
+  resolveStateLifecycleRuntimeDirectory,
+} from "../infra/state-database-coordinator.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { openClawStateDatabaseCache } from "./openclaw-state-db-cache.js";
 import {
@@ -70,6 +73,7 @@ export function openUnpublishedStateDatabase(params: {
   recordOpenFailure: (pathname: string, error: Error) => void;
 }): OpenClawStateDatabase {
   const { busyTimeoutMs, lockFailureReporting } = params;
+  const runtimeDirectory = resolveStateLifecycleRuntimeDirectory();
   ensureOpenClawStatePermissions(params.pathname, params.env);
   const db = openTrackedStateDatabase(params.pathname);
   let walMaintenance: SqliteWalMaintenance | undefined;
@@ -95,7 +99,11 @@ export function openUnpublishedStateDatabase(params: {
           databasePath: params.pathname,
           runMaintenance: (operation) =>
             runWithSqliteCoordinator(
-              acquireStateDatabaseCoordinator({ databasePath: params.pathname, busyTimeoutMs: 0 }),
+              acquireStateDatabaseCoordinator({
+                databasePath: params.pathname,
+                runtimeDirectory,
+                busyTimeoutMs: 0,
+              }),
               "shared-state WAL maintenance",
               operation,
             ),

--- a/src/state/openclaw-state-db-runtime-failure.ts
+++ b/src/state/openclaw-state-db-runtime-failure.ts
@@ -1,0 +1,71 @@
+import path from "node:path";
+import type { DatabaseSync } from "node:sqlite";
+import { isSqliteCorruptionError } from "../infra/sqlite-error-diagnostics.js";
+import type { createSqliteTerminalOpenLatch } from "../infra/sqlite-terminal-open-latch.js";
+import { isSqliteSchemaVersionError } from "../infra/sqlite-user-version.js";
+import type { OpenClawStateDatabase } from "./openclaw-state-db-contract.js";
+import { assertSupportedStateSchemaVersion } from "./openclaw-state-db-schema-version.js";
+
+type FailureOwner = {
+  cachedDatabases: Map<string, OpenClawStateDatabase>;
+  statements: WeakMap<OpenClawStateDatabase, ReturnType<DatabaseSync["prepare"]>>;
+  dataVersions: WeakMap<DatabaseSync, number>;
+  latch: ReturnType<typeof createSqliteTerminalOpenLatch>;
+  evict(database: OpenClawStateDatabase): boolean;
+  recordSchemaFailure(pathname: string, error: Error): void;
+};
+
+/** Runtime validation uses the cache's existing handles, version counters, and terminal latch. */
+export function createOpenClawStateDatabaseRuntimeFailureOwner(owner: FailureOwner) {
+  const readDataVersion = (database: OpenClawStateDatabase): number => {
+    let statement = owner.statements.get(database);
+    if (!statement) {
+      statement =
+        database.db /* sqlite-allow-raw -- Connection-local schema compatibility counter. */
+          .prepare("PRAGMA data_version");
+      owner.statements.set(database, statement);
+    }
+    const row = statement.get();
+    if (typeof row?.data_version !== "number") {
+      throw new Error("SQLite did not return a numeric PRAGMA data_version");
+    }
+    return row.data_version;
+  };
+
+  return {
+    recordPublishedVersion: (database: OpenClawStateDatabase): void => {
+      owner.dataVersions.set(database.db, readDataVersion(database));
+    },
+    get: (pathname: string): Error | undefined => {
+      const resolvedPath = path.resolve(pathname);
+      const latched = owner.latch.get(resolvedPath);
+      if (latched) {
+        return latched;
+      }
+      const cached = owner.cachedDatabases.get(resolvedPath);
+      if (!cached?.db.isOpen) {
+        return undefined;
+      }
+      try {
+        const dataVersion = readDataVersion(cached);
+        if (owner.dataVersions.get(cached.db) === dataVersion) {
+          return undefined;
+        }
+        // A native connection's counter detects commits by other connections.
+        assertSupportedStateSchemaVersion(cached.db, resolvedPath);
+        owner.dataVersions.set(cached.db, dataVersion);
+        return undefined;
+      } catch (error) {
+        const failure = error instanceof Error ? error : new Error(String(error));
+        if (isSqliteCorruptionError(failure)) {
+          owner.evict(cached);
+          return undefined;
+        }
+        if (isSqliteSchemaVersionError(failure)) {
+          owner.recordSchemaFailure(resolvedPath, failure);
+        }
+        return failure;
+      }
+    },
+  };
+}

--- a/src/state/openclaw-state-ownership.ts
+++ b/src/state/openclaw-state-ownership.ts
@@ -53,7 +53,7 @@ export class OpenClawStateOwnershipMetadataError extends OpenClawStateOwnershipE
   }
 }
 
-class OpenClawStateExternalOwnershipError extends OpenClawStateOwnershipError {
+export class OpenClawStateExternalOwnershipError extends OpenClawStateOwnershipError {
   constructor(
     readonly databasePath: string,
     readonly managerId: string,

--- a/src/state/openclaw-state-worker-context.ts
+++ b/src/state/openclaw-state-worker-context.ts
@@ -1,0 +1,26 @@
+import path from "node:path";
+import { resolveStateDir } from "../config/state-dir.js";
+import { isGatewayExternallySupervised } from "../infra/gateway-supervision.js";
+import type { SqliteWorkerStateContext } from "../infra/sqlite-worker-state-context.js";
+import { captureStateDatabaseCoordinatorRuntime } from "../infra/state-database-coordinator.js";
+import { captureOpenClawStateDatabaseReadAdmission } from "./openclaw-state-db-cache.js";
+import { resolveOpenClawStateSqlitePath } from "./openclaw-state-db.paths.js";
+import type { OpenClawStateWorkerContext } from "./openclaw-state-worker-context.types.js";
+
+/** Capture host facts before asynchronous work, without opening SQLite. */
+export function captureOpenClawStateWorkerContext(
+  options: { path?: string; env?: NodeJS.ProcessEnv } = {},
+): OpenClawStateWorkerContext {
+  const env = options.env ?? process.env;
+  const environment: SqliteWorkerStateContext["environment"] = {
+    OPENCLAW_STATE_DIR: resolveStateDir(env),
+    ...(isGatewayExternallySupervised(env) ? { OPENCLAW_SUPERVISOR_MODE: "external" } : {}),
+  };
+  return {
+    admission: captureOpenClawStateDatabaseReadAdmission(
+      path.resolve(options.path ?? resolveOpenClawStateSqlitePath(environment)),
+    ),
+    environment,
+    coordinatorRuntime: captureStateDatabaseCoordinatorRuntime(),
+  };
+}

--- a/src/state/openclaw-state-worker-context.types.ts
+++ b/src/state/openclaw-state-worker-context.types.ts
@@ -1,0 +1,6 @@
+import type { SqliteWorkerStateContext } from "../infra/sqlite-worker-state-context.js";
+import type { OpenClawStateDatabaseReadAdmission } from "./openclaw-state-db-async-lifecycle.js";
+
+export type OpenClawStateWorkerContext = SqliteWorkerStateContext & {
+  admission: OpenClawStateDatabaseReadAdmission;
+};

--- a/src/state/openclaw-state-worker-contract.ts
+++ b/src/state/openclaw-state-worker-contract.ts
@@ -1,3 +1,4 @@
+import type { SqliteFileGeneration } from "../infra/sqlite-file-generation.js";
 import type { TaskFlowView } from "../plugins/runtime/task-domain-types.js";
 import type { TaskFlowRecord } from "../tasks/task-flow-registry.types.js";
 import type { TaskRecord, TaskRegistrySummary } from "../tasks/task-registry.types.js";
@@ -41,4 +42,9 @@ export type OpenClawStateWorkerOperations = {
     input: TaskFlowReadQuery;
     output: TaskFlowRead | undefined;
   };
+};
+
+/** Internal inspection cannot open canonical state or execute a domain command. */
+export type OpenClawStateWorkerInspectionOperations = {
+  "database.generationMatches": { input: { generation: SqliteFileGeneration }; output: boolean };
 };

--- a/src/state/openclaw-state-worker-error.test.ts
+++ b/src/state/openclaw-state-worker-error.test.ts
@@ -1,0 +1,220 @@
+import { describe, expect, it } from "vitest";
+import { SqliteSchemaVersionError } from "../infra/sqlite-user-version.js";
+import {
+  findStartupMaintenanceRequiredError,
+  StartupMaintenanceRequiredError,
+} from "../infra/startup-maintenance-required.js";
+import { OpenClawAgentDatabaseMediaMigrationRequiredError } from "./openclaw-agent-db-migration-required.js";
+import { OpenClawStateDatabaseSchemaMigrationRequiredError } from "./openclaw-state-db-schema-migration-required.js";
+import {
+  OpenClawStateExternalOwnershipError,
+  OpenClawStateOwnershipError,
+  OpenClawStateOwnershipMetadataError,
+} from "./openclaw-state-ownership.js";
+import {
+  decodeOpenClawStateWorkerError,
+  encodeOpenClawStateWorkerError,
+} from "./openclaw-state-worker-error.js";
+
+function roundTrip(error: Error): Error {
+  const payload = encodeOpenClawStateWorkerError(error);
+  if (!payload) {
+    throw new Error("expected a canonical shared-state error payload");
+  }
+  const decoded = decodeOpenClawStateWorkerError(structuredClone(payload));
+  if (!decoded) {
+    throw new Error("expected a decoded shared-state error");
+  }
+  return decoded;
+}
+
+describe("shared-state worker error transport", () => {
+  it.each([
+    {
+      error: new OpenClawStateOwnershipError("owner refused"),
+      constructor: OpenClawStateOwnershipError,
+      fields: {},
+    },
+    {
+      error: new OpenClawStateOwnershipMetadataError("/fixture/state.sqlite", "invalid metadata"),
+      constructor: OpenClawStateOwnershipMetadataError,
+      fields: { databasePath: "/fixture/state.sqlite" },
+    },
+    {
+      error: new OpenClawStateExternalOwnershipError("/fixture/state.sqlite", "fixture-manager"),
+      constructor: OpenClawStateExternalOwnershipError,
+      fields: { databasePath: "/fixture/state.sqlite", managerId: "fixture-manager" },
+    },
+  ])("preserves ownership classification for $error.name", ({ error, constructor, fields }) => {
+    const decoded = roundTrip(error);
+    expect(decoded).toBeInstanceOf(constructor);
+    expect(decoded).toBeInstanceOf(OpenClawStateOwnershipError);
+    expect(decoded).toMatchObject({ ...fields, name: error.name, message: error.message });
+  });
+
+  it.each([
+    {
+      error: new StartupMaintenanceRequiredError("legacy-session-store", "session migration"),
+      constructor: StartupMaintenanceRequiredError,
+      fields: { kind: "legacy-session-store", reason: "session store migration" },
+    },
+    {
+      error: new SqliteSchemaVersionError("newer schema"),
+      constructor: SqliteSchemaVersionError,
+      fields: { kind: "newer-schema", reason: "a newer OpenClaw build" },
+    },
+    {
+      error: new OpenClawStateDatabaseSchemaMigrationRequiredError(
+        "audit-events-v2",
+        "/fixture/state.sqlite",
+      ),
+      constructor: OpenClawStateDatabaseSchemaMigrationRequiredError,
+      fields: {
+        kind: "audit-events-v2",
+        pathname: "/fixture/state.sqlite",
+        reason: "state database schema migration",
+      },
+    },
+    {
+      error: new OpenClawAgentDatabaseMediaMigrationRequiredError("/fixture/agent.sqlite", 11),
+      constructor: OpenClawAgentDatabaseMediaMigrationRequiredError,
+      fields: {
+        kind: "agent-media",
+        pathname: "/fixture/agent.sqlite",
+        schemaVersion: 11,
+        reason: "offline media migration",
+      },
+    },
+  ])("preserves maintenance classification for $error.name", ({ error, constructor, fields }) => {
+    const decoded = roundTrip(error);
+    expect(decoded).toBeInstanceOf(constructor);
+    expect(findStartupMaintenanceRequiredError(decoded)).toBe(decoded);
+    expect(decoded).toMatchObject({
+      ...fields,
+      code: "gateway.maintenance_required",
+      name: error.name,
+      message: error.message,
+    });
+  });
+
+  it("preserves shared causes, cycles, and newer-schema precedence through aggregate wrappers", () => {
+    const repair = new OpenClawStateDatabaseSchemaMigrationRequiredError(
+      "audit-events-v2",
+      "/fixture/state.sqlite",
+    );
+    const newer = new SqliteSchemaVersionError("a newer schema wins");
+    const wrapper = Object.assign(new Error("operation failed", { cause: repair }), {
+      code: "EWRAPPED",
+    });
+    const root = new AggregateError([wrapper, repair, newer], "operation and cleanup failed", {
+      cause: wrapper,
+    });
+    repair.cause = root;
+
+    const decoded = roundTrip(root);
+    expect(decoded).toBeInstanceOf(AggregateError);
+    if (!(decoded instanceof AggregateError)) {
+      throw new Error("expected aggregate wrapper");
+    }
+    expect(decoded.cause).toBe(decoded.errors[0]);
+    const restoredWrapper: unknown = decoded.errors[0];
+    const restoredRepair: unknown = decoded.errors[1];
+    if (!(restoredWrapper instanceof Error) || !(restoredRepair instanceof Error)) {
+      throw new Error("expected restored error causes");
+    }
+    expect(restoredWrapper).toMatchObject({ code: "EWRAPPED" });
+    expect(restoredWrapper.cause).toBe(restoredRepair);
+    expect(restoredRepair.cause).toBe(decoded);
+    expect(findStartupMaintenanceRequiredError(decoded)).toBe(decoded.errors[2]);
+    expect(findStartupMaintenanceRequiredError(decoded)?.kind).toBe("newer-schema");
+  });
+
+  it("keeps scalar causes without reviving arbitrary classes or serializing object fields", () => {
+    class CustomError extends Error {}
+    const custom = Object.assign(new CustomError("custom wrapper", { cause: "detail" }), {
+      name: "CustomError",
+      code: 17,
+      privateState: { token: "fixture-not-for-transport" },
+    });
+    const original = new AggregateError(
+      [
+        new OpenClawStateOwnershipError("canonical refusal"),
+        custom,
+        "plain failure",
+        2,
+        true,
+        null,
+        undefined,
+        { token: "fixture-not-for-transport" },
+      ],
+      "multiple errors",
+    );
+    const payload = encodeOpenClawStateWorkerError(original);
+    expect(JSON.stringify(payload)).not.toContain("fixture-not-for-transport");
+    expect(payload?.nodes.every((node) => !("stack" in node))).toBe(true);
+    const decoded = roundTrip(original);
+    if (!(decoded instanceof AggregateError)) {
+      throw new Error("expected aggregate wrapper");
+    }
+    expect(decoded.errors[1]).toBeInstanceOf(Error);
+    expect(decoded.errors[1]).not.toBeInstanceOf(CustomError);
+    expect(decoded.errors[1]).toMatchObject({ name: "CustomError", code: 17, cause: "detail" });
+    expect(decoded.errors.slice(2)).toEqual(["plain failure", 2, true, null, undefined, undefined]);
+  });
+
+  it("leaves unrelated errors and name-only imitations on the ordinary transport", () => {
+    const imitation = Object.assign(new Error("imitation"), { name: "SqliteSchemaVersionError" });
+    for (const error of [
+      new Error("ordinary"),
+      imitation,
+      new AggregateError([imitation], "ordinary aggregate"),
+      { cause: new OpenClawStateOwnershipError("nested object") },
+    ]) {
+      expect(encodeOpenClawStateWorkerError(error)).toBeUndefined();
+    }
+  });
+
+  const validNode = {
+    type: "maintenance",
+    kind: "audit-events-v2",
+    name: "StartupMaintenanceRequiredError",
+    message: "migration required",
+  };
+  it.each([
+    undefined,
+    { version: 2, root: 0, nodes: [validNode] },
+    { version: 1, root: 1, nodes: [validNode] },
+    { version: 1, root: 0, nodes: [] },
+    { version: 1, root: 0, nodes: [{ ...validNode, type: "CustomError" }] },
+    { version: 1, root: 0, nodes: [{ ...validNode, kind: "unknown-migration" }] },
+    { version: 1, root: 0, nodes: [{ ...validNode, cause: { ref: 1 } }] },
+    { version: 1, root: 0, nodes: [{ ...validNode, cause: { value: {} } }] },
+    { version: 1, root: 0, nodes: [{ ...validNode, code: {} }] },
+    { version: 1, root: 0, nodes: [{ ...validNode, stack: "not transported" }] },
+    {
+      version: 1,
+      root: 0,
+      nodes: [{ type: "aggregate", name: "AggregateError", message: "missing edges" }],
+    },
+    {
+      version: 1,
+      root: 0,
+      nodes: [{ type: "error", name: "Error", message: "unrelated" }, validNode],
+    },
+    {
+      version: 1,
+      root: 0,
+      nodes: [
+        {
+          type: "agent-media-migration",
+          name: "Error",
+          message: "invalid version",
+          pathname: "/fixture/agent.sqlite",
+          schemaVersion: -1,
+        },
+      ],
+    },
+  ])("rejects malformed or noncanonical payload %#", (payload) => {
+    expect(decodeOpenClawStateWorkerError(payload)).toBeUndefined();
+  });
+});

--- a/src/state/openclaw-state-worker-error.ts
+++ b/src/state/openclaw-state-worker-error.ts
@@ -1,0 +1,341 @@
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { SqliteSchemaVersionError } from "../infra/sqlite-user-version.js";
+import { StartupMaintenanceRequiredError } from "../infra/startup-maintenance-required.js";
+import { OpenClawAgentDatabaseMediaMigrationRequiredError } from "./openclaw-agent-db-migration-required.js";
+import { OpenClawStateDatabaseSchemaMigrationRequiredError } from "./openclaw-state-db-schema-migration-required.js";
+import {
+  OpenClawStateExternalOwnershipError,
+  OpenClawStateOwnershipError,
+  OpenClawStateOwnershipMetadataError,
+} from "./openclaw-state-ownership.js";
+
+type MaintenanceKind = ConstructorParameters<typeof StartupMaintenanceRequiredError>[0];
+type StateMigrationKind = ConstructorParameters<
+  typeof OpenClawStateDatabaseSchemaMigrationRequiredError
+>[0];
+
+type ErrorValue =
+  | { ref: number }
+  | { value: string | number | boolean | null }
+  | { undefined: true };
+
+type ErrorIdentity =
+  | { type: "error" | "aggregate" | "ownership" | "newer-schema" }
+  | { type: "ownership-metadata"; databasePath: string }
+  | { type: "external-ownership"; databasePath: string; managerId: string }
+  | { type: "maintenance"; kind: MaintenanceKind }
+  | { type: "state-migration"; kind: StateMigrationKind; pathname: string }
+  | { type: "agent-media-migration"; pathname: string; schemaVersion: number };
+
+type ErrorNode = ErrorIdentity & {
+  name: string;
+  message: string;
+  code?: string | number;
+  cause?: ErrorValue;
+  errors?: ErrorValue[];
+};
+
+/** A closed error graph; references preserve shared causes and cyclic aggregates. */
+export type OpenClawStateWorkerErrorPayload = {
+  version: 1;
+  root: number;
+  nodes: ErrorNode[];
+};
+
+function identifyError(error: Error): ErrorIdentity {
+  if (error instanceof OpenClawStateOwnershipMetadataError) {
+    return { type: "ownership-metadata", databasePath: error.databasePath };
+  }
+  if (error instanceof OpenClawStateExternalOwnershipError) {
+    return {
+      type: "external-ownership",
+      databasePath: error.databasePath,
+      managerId: error.managerId,
+    };
+  }
+  if (error instanceof OpenClawStateOwnershipError) {
+    return { type: "ownership" };
+  }
+  if (error instanceof SqliteSchemaVersionError) {
+    return { type: "newer-schema" };
+  }
+  if (error instanceof OpenClawStateDatabaseSchemaMigrationRequiredError) {
+    return { type: "state-migration", kind: error.kind, pathname: error.pathname };
+  }
+  if (error instanceof OpenClawAgentDatabaseMediaMigrationRequiredError) {
+    return {
+      type: "agent-media-migration",
+      pathname: error.pathname,
+      schemaVersion: error.schemaVersion,
+    };
+  }
+  if (error instanceof StartupMaintenanceRequiredError) {
+    return { type: "maintenance", kind: error.kind };
+  }
+  return { type: error instanceof AggregateError ? "aggregate" : "error" };
+}
+
+function isScalar(value: unknown): value is string | number | boolean | null {
+  return (
+    value === null ||
+    typeof value === "string" ||
+    typeof value === "boolean" ||
+    (typeof value === "number" && Number.isFinite(value))
+  );
+}
+
+export function encodeOpenClawStateWorkerError(
+  error: unknown,
+): OpenClawStateWorkerErrorPayload | undefined {
+  if (!(error instanceof Error)) {
+    return undefined;
+  }
+  const nodes: ErrorNode[] = [];
+  const errors: Error[] = [];
+  const references = new Map<Error, number>();
+  let canonical = false;
+  const encodeValue = (value: unknown): ErrorValue => {
+    if (!(value instanceof Error)) {
+      // Arbitrary thrown objects may contain credentials or unrelated runtime state.
+      return isScalar(value) ? { value } : { undefined: true };
+    }
+    const known = references.get(value);
+    if (known !== undefined) {
+      return { ref: known };
+    }
+    const ref = errors.length;
+    references.set(value, ref);
+    errors.push(value);
+    return { ref };
+  };
+  try {
+    encodeValue(error);
+    for (const current of errors) {
+      const identity = identifyError(current);
+      canonical ||= identity.type !== "error" && identity.type !== "aggregate";
+      const code = "code" in current ? current.code : undefined;
+      nodes.push({
+        ...identity,
+        name: current.name,
+        message: current.message,
+        ...(typeof code === "string" || (typeof code === "number" && Number.isFinite(code))
+          ? { code }
+          : {}),
+        ...("cause" in current ? { cause: encodeValue(current.cause) } : {}),
+        ...(current instanceof AggregateError ? { errors: current.errors.map(encodeValue) } : {}),
+      });
+    }
+    return canonical ? { version: 1, root: 0, nodes } : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function isMaintenanceKind(kind: unknown): kind is MaintenanceKind {
+  return (
+    kind === "newer-schema" ||
+    kind === "agent-media" ||
+    kind === "agent-databases-composite-primary-key" ||
+    kind === "audit-events-v2" ||
+    kind === "legacy-workshop-review-index" ||
+    kind === "legacy-workspace" ||
+    kind === "legacy-session-store"
+  );
+}
+
+function parseIdentity(node: Record<string, unknown>): ErrorIdentity | undefined {
+  switch (node.type) {
+    case "error":
+    case "aggregate":
+    case "ownership":
+    case "newer-schema":
+      return { type: node.type };
+    case "ownership-metadata":
+      return typeof node.databasePath === "string"
+        ? { type: node.type, databasePath: node.databasePath }
+        : undefined;
+    case "external-ownership":
+      return typeof node.databasePath === "string" && typeof node.managerId === "string"
+        ? { type: node.type, databasePath: node.databasePath, managerId: node.managerId }
+        : undefined;
+    case "maintenance":
+      return isMaintenanceKind(node.kind) ? { type: node.type, kind: node.kind } : undefined;
+    case "state-migration":
+      return (node.kind === "agent-databases-composite-primary-key" ||
+        node.kind === "audit-events-v2" ||
+        node.kind === "legacy-workshop-review-index") &&
+        typeof node.pathname === "string"
+        ? { type: node.type, kind: node.kind, pathname: node.pathname }
+        : undefined;
+    case "agent-media-migration":
+      return typeof node.pathname === "string" &&
+        typeof node.schemaVersion === "number" &&
+        Number.isSafeInteger(node.schemaVersion) &&
+        node.schemaVersion >= 0
+        ? { type: node.type, pathname: node.pathname, schemaVersion: node.schemaVersion }
+        : undefined;
+    default:
+      return undefined;
+  }
+}
+
+function isErrorValue(value: unknown, count: number): value is ErrorValue {
+  if (!isRecord(value) || Object.keys(value).length !== 1) {
+    return false;
+  }
+  if ("ref" in value) {
+    return (
+      typeof value.ref === "number" &&
+      Number.isSafeInteger(value.ref) &&
+      value.ref >= 0 &&
+      value.ref < count
+    );
+  }
+  return "value" in value ? isScalar(value.value) : value.undefined === true;
+}
+
+function parseNode(value: unknown, count: number): ErrorNode | undefined {
+  if (!isRecord(value) || typeof value.name !== "string" || typeof value.message !== "string") {
+    return undefined;
+  }
+  const identity = parseIdentity(value);
+  if (!identity) {
+    return undefined;
+  }
+  const allowed = new Set([...Object.keys(identity), "name", "message", "code", "cause"]);
+  const errors: ErrorValue[] = [];
+  if (identity.type === "aggregate") {
+    allowed.add("errors");
+    if (!Array.isArray(value.errors)) {
+      return undefined;
+    }
+    for (const entry of value.errors) {
+      if (!isErrorValue(entry, count)) {
+        return undefined;
+      }
+      errors.push(entry);
+    }
+  }
+  if (
+    Object.keys(value).some((key) => !allowed.has(key)) ||
+    ("code" in value &&
+      typeof value.code !== "string" &&
+      !(typeof value.code === "number" && Number.isFinite(value.code))) ||
+    ("cause" in value && !isErrorValue(value.cause, count))
+  ) {
+    return undefined;
+  }
+  return {
+    ...identity,
+    name: value.name,
+    message: value.message,
+    ...(typeof value.code === "string" || typeof value.code === "number"
+      ? { code: value.code }
+      : {}),
+    ...(isErrorValue(value.cause, count) ? { cause: value.cause } : {}),
+    ...(identity.type === "aggregate" ? { errors } : {}),
+  };
+}
+
+function unreachableErrorNode(node: never): never {
+  throw new Error(`Unexpected shared-state worker error node: ${String(node)}`);
+}
+
+function createError(node: ErrorNode): Error {
+  switch (node.type) {
+    case "error":
+      return new Error(node.message);
+    case "aggregate":
+      return new AggregateError([], node.message);
+    case "ownership":
+      return new OpenClawStateOwnershipError(node.message);
+    case "ownership-metadata":
+      return new OpenClawStateOwnershipMetadataError(node.databasePath, "");
+    case "external-ownership":
+      return new OpenClawStateExternalOwnershipError(node.databasePath, node.managerId);
+    case "newer-schema":
+      return new SqliteSchemaVersionError(node.message);
+    case "maintenance":
+      return new StartupMaintenanceRequiredError(node.kind, node.message);
+    case "state-migration":
+      return new OpenClawStateDatabaseSchemaMigrationRequiredError(node.kind, node.pathname);
+    case "agent-media-migration":
+      return new OpenClawAgentDatabaseMediaMigrationRequiredError(
+        node.pathname,
+        node.schemaVersion,
+      );
+  }
+  return unreachableErrorNode(node);
+}
+
+export function decodeOpenClawStateWorkerError(value: unknown): Error | undefined {
+  try {
+    if (
+      !isRecord(value) ||
+      Object.keys(value).some((key) => !["version", "root", "nodes"].includes(key)) ||
+      value.version !== 1 ||
+      !Array.isArray(value.nodes) ||
+      typeof value.root !== "number" ||
+      !Number.isSafeInteger(value.root) ||
+      value.root < 0 ||
+      value.root >= value.nodes.length
+    ) {
+      return undefined;
+    }
+    const nodes: ErrorNode[] = [];
+    for (const valueNode of value.nodes) {
+      const node = parseNode(valueNode, value.nodes.length);
+      if (!node) {
+        return undefined;
+      }
+      nodes.push(node);
+    }
+    const visited = new Set<number>();
+    const pending = [value.root];
+    let canonical = false;
+    for (const ref of pending) {
+      if (visited.has(ref)) {
+        continue;
+      }
+      visited.add(ref);
+      const node = nodes[ref]!;
+      canonical ||= node.type !== "error" && node.type !== "aggregate";
+      for (const edge of [...(node.cause ? [node.cause] : []), ...(node.errors ?? [])]) {
+        if ("ref" in edge) {
+          pending.push(edge.ref);
+        }
+      }
+    }
+    if (!canonical || visited.size !== nodes.length) {
+      return undefined;
+    }
+    const errors = nodes.map(createError);
+    const decodeValue = (entry: ErrorValue): unknown =>
+      "ref" in entry ? errors[entry.ref] : "value" in entry ? entry.value : undefined;
+    for (const [index, node] of nodes.entries()) {
+      const error = errors[index]!;
+      error.name = node.name;
+      error.message = node.message;
+      if (node.code !== undefined) {
+        Object.defineProperty(error, "code", {
+          value: node.code,
+          configurable: true,
+          writable: true,
+        });
+      }
+      if (node.cause) {
+        Object.defineProperty(error, "cause", {
+          value: decodeValue(node.cause),
+          configurable: true,
+          writable: true,
+        });
+      }
+      if (error instanceof AggregateError) {
+        error.errors = (node.errors ?? []).map(decodeValue);
+      }
+    }
+    return errors[value.root];
+  } catch {
+    return undefined;
+  }
+}

--- a/src/state/openclaw-state-worker-store.ts
+++ b/src/state/openclaw-state-worker-store.ts
@@ -1,55 +1,102 @@
 import { runtimeProcessEntrypoints } from "../infra/runtime-process-entrypoints.js";
 import { resolveRuntimeWorkerUrl } from "../infra/runtime-worker-url.js";
 import type { DatabasePathIdentity } from "../infra/sqlite-worker-identity.js";
-import { openSqliteWorkerStore, type SqliteWorkerStore } from "../infra/sqlite-worker-store.js";
+import {
+  openSharedStateSqliteWorkerStore,
+  closeUnclaimedSharedStateSqliteWorkers,
+  hasUnclaimedSharedStateSqliteCleanup,
+  isSqliteWorkerStoreAvailable,
+  runSqliteWorkerStoreOperation,
+  type SqliteWorkerStore,
+} from "../infra/sqlite-worker-store.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { resolveGlobalSingleton } from "../shared/global-singleton.js";
-import type { OpenClawStateDatabaseReadAdmission } from "./openclaw-state-db-async-lifecycle.js";
 import {
+  publishOpenClawStateDatabaseWorkerAdmission,
+  getOpenClawStateDatabaseTerminalFailureAsync,
   registerOpenClawStateDatabaseAsyncResource,
   registerOpenClawStateDatabaseLifecycleListener,
 } from "./openclaw-state-db-cache.js";
-import { openOpenClawStateDatabase } from "./openclaw-state-db.js";
-import type { OpenClawStateWorkerOperations } from "./openclaw-state-worker-contract.js";
+import type { OpenClawStateWorkerContext } from "./openclaw-state-worker-context.types.js";
+import type {
+  OpenClawStateWorkerOperations,
+  OpenClawStateWorkerInspectionOperations,
+} from "./openclaw-state-worker-contract.js";
 
-type Store = SqliteWorkerStore<OpenClawStateWorkerOperations>;
+type StoreOperations = OpenClawStateWorkerOperations & OpenClawStateWorkerInspectionOperations;
+type Store = SqliteWorkerStore<StoreOperations>;
+type DomainScope = Pick<SqliteWorkerStore<OpenClawStateWorkerOperations>, "execute">;
 const log = createSubsystemLogger("state/worker");
 
 function createSharedStateWorkerOwner() {
-  const stores = new Map<string, Promise<Store>>();
-  const retiring = new Map<string, Promise<void>>();
-  async function close(identity?: DatabasePathIdentity): Promise<void> {
-    const entries = [...stores].filter(([key]) => identity === undefined || identity.key === key);
-    for (const [key, opening] of entries) {
-      stores.delete(key);
-      const closing = opening.then((store) => store.close());
-      retiring.set(key, closing);
-      void closing
-        .finally(() => {
-          if (retiring.get(key) === closing) {
-            retiring.delete(key);
-          }
-        })
-        .catch(() => {});
+  type Entry = {
+    context: OpenClawStateWorkerContext;
+    opening: Promise<Store | undefined>;
+    existingOnly: boolean;
+    store?: Store;
+    bound?: boolean;
+  };
+  const stores = new Map<string, Entry>();
+  const retiring = new Map<Entry, { pending?: Promise<void> }>();
+  const matches = (entry: Entry, identity?: DatabasePathIdentity) =>
+    identity === undefined || entry.context.admission.identity.key === identity.key;
+  const forget = (entry: Entry) => {
+    for (const [key, current] of stores) {
+      if (current === entry) {
+        stores.delete(key);
+      }
     }
-    // Broker close settles only after native cleanup or joined worker exit.
+  };
+  const hasPendingCleanup = (entry: Entry) =>
+    hasUnclaimedSharedStateSqliteCleanup(entry.context.admission.databasePath);
+  const retire = (entry: Entry) => {
+    forget(entry);
+    let attempt = retiring.get(entry);
+    if (!attempt) {
+      attempt = {};
+      retiring.set(entry, attempt);
+    }
+    if (attempt.pending) {
+      return attempt.pending;
+    }
+    const pending = entry.opening.then(
+      (store) => store?.close(),
+      () => closeUnclaimedSharedStateSqliteWorkers(entry.context.admission.databasePath),
+    );
+    attempt.pending = pending;
+    const settled = () => {
+      attempt.pending = undefined;
+      if (!hasPendingCleanup(entry)) {
+        retiring.delete(entry);
+      }
+    };
+    void pending.then(settled, settled);
+    return pending;
+  };
+  async function close(identity?: DatabasePathIdentity): Promise<void> {
+    for (const entry of stores.values()) {
+      if (matches(entry, identity)) {
+        void retire(entry);
+      }
+    }
     const settled = await Promise.allSettled(
-      [...retiring]
-        .filter(([key]) => identity === undefined || identity.key === key)
-        .map(([, closing]) => closing),
+      [...retiring.keys()].filter((entry) => matches(entry, identity)).map(retire),
     );
     const errors = settled.flatMap((result) =>
       result.status === "rejected" ? [result.reason] : [],
     );
-    if (errors.length > 0) {
+    if (errors.length) {
       throw new AggregateError(errors, "Failed to close shared-state SQLite workers");
     }
   }
   registerOpenClawStateDatabaseAsyncResource({ close });
   registerOpenClawStateDatabaseLifecycleListener((event) => {
-    if (event.kind !== "opened" && event.identity) {
+    if (event.kind !== "opened") {
       // Synchronous error eviction cannot await, but actor retirement remains
       // owned and every subsequent open or canonical drain joins it.
+      if (!event.identity) {
+        return;
+      }
       void close(event.identity).catch((error: unknown) => {
         log.warn("Shared-state worker retirement failed", { path: event.path, error });
       });
@@ -57,51 +104,78 @@ function createSharedStateWorkerOwner() {
   });
   return {
     close,
-    async open(admission: OpenClawStateDatabaseReadAdmission) {
-      const closing = retiring.get(admission.identity.key);
-      if (closing) {
-        await closing;
+    async retireFailedStore(store: Store): Promise<void> {
+      await Promise.all([...stores.values()].filter((entry) => entry.store === store).map(retire));
+    },
+    async open(
+      context: OpenClawStateWorkerContext,
+      existingOnly = false,
+    ): Promise<Store | undefined> {
+      const { admission } = context;
+      for (const [entry, attempt] of retiring) {
+        if (matches(entry, admission.identity)) {
+          if (!attempt.pending) {
+            throw new Error(
+              "Shared-state SQLite cleanup is pending; close the database before reopening",
+            );
+          }
+          await attempt.pending;
+        }
       }
       admission.assertCurrent();
-      let key = admission.identity.key;
-      let opening = stores.get(key);
-      if (!opening) {
-        // Restore can already be ready after a native close. Reuse canonical
-        // schema admission once when establishing a new worker actor as well.
-        openOpenClawStateDatabase({ path: admission.databasePath });
-        admission.assertCurrent();
-        // Native publication promotes a prospective identity without replacing
-        // its admission. Reuse the physical actor if another alias already opened it.
-        key = admission.identity.key;
-        const promotedClosing = retiring.get(key);
-        if (promotedClosing) {
-          await promotedClosing;
-          admission.assertCurrent();
-        }
-        opening = stores.get(key);
-        if (opening) {
-          return opening;
-        }
-        opening = openSqliteWorkerStore<OpenClawStateWorkerOperations>({
-          moduleUrl: resolveRuntimeWorkerUrl(runtimeProcessEntrypoints.sharedStateStore),
-          databasePath: admission.databasePath,
-          input: undefined,
-          existingOnly: true,
-        }).then((store) => {
-          if (!store) {
-            throw new Error("Admitted shared-state database is missing");
-          }
-          return store;
-        });
-        stores.set(key, opening);
-        const admitted = opening;
-        void opening.catch(() => {
-          if (stores.get(key) === admitted) {
-            stores.delete(key);
+      let entry =
+        stores.get(admission.identity.key) ??
+        [...stores.values()].find((candidate) => matches(candidate, admission.identity));
+      if (!entry) {
+        entry = {
+          context,
+          existingOnly,
+          opening: openSharedStateSqliteWorkerStore<StoreOperations>(
+            {
+              moduleUrl: resolveRuntimeWorkerUrl(runtimeProcessEntrypoints.sharedStateStore),
+              databasePath: admission.databasePath,
+              existingOnly,
+            },
+            context,
+            () => admission.assertCurrent(),
+          ),
+        };
+        stores.set(admission.identity.key, entry);
+        const admitted = entry;
+        void entry.opening.catch(() => {
+          forget(admitted);
+          if (hasPendingCleanup(admitted) && !retiring.has(admitted)) {
+            retiring.set(admitted, {});
           }
         });
       }
-      return opening;
+      const store = await entry.opening;
+      admission.assertCurrent();
+      if (!store) {
+        forget(entry);
+        return !existingOnly && entry.existingOnly ? this.open(context) : undefined;
+      }
+      entry.store = store;
+      try {
+        if (!entry.bound) {
+          publishOpenClawStateDatabaseWorkerAdmission(entry.context.admission);
+          entry.bound = true;
+        }
+      } catch (error) {
+        try {
+          await retire(entry);
+        } catch (cleanupError) {
+          throw new AggregateError(
+            [error, cleanupError],
+            "Shared-state worker binding and cleanup failed",
+            { cause: cleanupError },
+          );
+        }
+        throw error;
+      }
+      forget(entry);
+      stores.set(admission.identity.key, entry);
+      return store;
     },
   };
 }
@@ -115,12 +189,87 @@ function owner() {
 }
 
 export async function executeOpenClawStateWorker<Key extends keyof OpenClawStateWorkerOperations>(
-  context: OpenClawStateDatabaseReadAdmission,
+  context: OpenClawStateWorkerContext,
   command: { type: Key; input: OpenClawStateWorkerOperations[Key]["input"] },
 ): Promise<OpenClawStateWorkerOperations[Key]["output"]> {
-  const store = await owner().open(context);
-  context.assertCurrent();
-  const result = await store.execute(command);
-  context.assertCurrent();
+  const result = await runOpenClawStateWorkerOperation(context, (scope) => scope.execute(command));
+  context.admission.assertCurrent();
   return result;
+}
+
+/** Retain the actor through its durable result and main-process reconciliation. */
+export function runOpenClawStateWorkerOperation<T>(
+  context: OpenClawStateWorkerContext,
+  operation: (scope: DomainScope) => Promise<T>,
+  options: { existingOnly: true },
+): Promise<T | undefined>;
+export function runOpenClawStateWorkerOperation<T>(
+  context: OpenClawStateWorkerContext,
+  operation: (scope: DomainScope) => Promise<T>,
+): Promise<T>;
+export async function runOpenClawStateWorkerOperation<T>(
+  context: OpenClawStateWorkerContext,
+  operation: (scope: DomainScope) => Promise<T>,
+  options?: { existingOnly: true },
+): Promise<T | undefined> {
+  const failure = await getOpenClawStateDatabaseTerminalFailureAsync(context);
+  if (failure) {
+    throw failure;
+  }
+  const store = await owner().open(context, options?.existingOnly);
+  context.admission.assertCurrent();
+  if (!store) {
+    if (options?.existingOnly) {
+      return undefined;
+    }
+    throw new Error("Canonical shared-state worker did not open its database");
+  }
+  return runWithOpenClawStateWorkerStore(store, context, operation);
+}
+
+/** Inspect the existing file without recursively admitting a domain operation. */
+export async function inspectOpenClawStateDatabase(
+  context: OpenClawStateWorkerContext,
+  command: {
+    type: "database.generationMatches";
+    input: OpenClawStateWorkerInspectionOperations["database.generationMatches"]["input"];
+  },
+): Promise<boolean | undefined> {
+  const store = await owner().open(context, true);
+  context.admission.assertCurrent();
+  if (!store) {
+    return undefined;
+  }
+  return runWithOpenClawStateWorkerStore(store, context, (scope) =>
+    scope.execute({
+      type: "database.generationMatches",
+      input: command.input,
+    }),
+  );
+}
+
+async function runWithOpenClawStateWorkerStore<T>(
+  store: Store,
+  context: OpenClawStateWorkerContext,
+  operation: (scope: Pick<Store, "execute">) => Promise<T>,
+): Promise<T> {
+  const { admission } = context;
+  try {
+    return await runSqliteWorkerStoreOperation<StoreOperations, T>(store, operation, context, () =>
+      admission.assertCurrent(),
+    );
+  } catch (error) {
+    if (!isSqliteWorkerStoreAvailable(store)) {
+      try {
+        await owner().retireFailedStore(store);
+      } catch (cleanupError) {
+        throw new AggregateError(
+          [error, cleanupError],
+          "Shared-state operation and retirement failed",
+          { cause: cleanupError },
+        );
+      }
+    }
+    throw error;
+  }
 }

--- a/src/state/openclaw-state.worker.ts
+++ b/src/state/openclaw-state.worker.ts
@@ -1,5 +1,10 @@
+import {
+  readStableSqliteFileGeneration,
+  sameSqliteFileGeneration,
+} from "../infra/sqlite-file-generation.js";
 import { runSqliteDeferredTransactionSync } from "../infra/sqlite-transaction.js";
 import type { SqliteWorkerBackend } from "../infra/sqlite-worker-contract.js";
+import { getSqliteWorkerStateContext } from "../infra/sqlite-worker-state-context.js";
 import { mapTaskFlowView } from "../tasks/task-domain-views.js";
 import { normalizeRestoredFlowRecord } from "../tasks/task-flow-registry.records.js";
 import {
@@ -16,22 +21,50 @@ import {
   readTaskViewRecordInDatabase,
 } from "../tasks/task-registry.store.kernel.js";
 import { summarizeTaskRecords } from "../tasks/task-registry.summary.js";
-import { openOpenClawStateReadConnection } from "./openclaw-state-db-read-connection.js";
-import type { OpenClawStateWorkerOperations } from "./openclaw-state-worker-contract.js";
+import {
+  closeOpenClawStateDatabaseByPath,
+  clearOpenClawStateDatabaseOpenFailure,
+} from "./openclaw-state-db-cache.js";
+import { openOpenClawStateDatabase } from "./openclaw-state-db.js";
+import type {
+  OpenClawStateWorkerOperations,
+  OpenClawStateWorkerInspectionOperations,
+} from "./openclaw-state-worker-contract.js";
 
-/** Schema admission remains with the canonical state owner before this existing-only open. */
+export function createSqliteWorkerBackend(
+  _input: undefined,
+  context: { databasePath: string },
+): SqliteWorkerBackend<OpenClawStateWorkerOperations & OpenClawStateWorkerInspectionOperations> {
+  openOpenClawStateDatabase({
+    path: context.databasePath,
+    env: getSqliteWorkerStateContext().environment,
+  });
+  return openExistingSqliteWorkerBackend(undefined, context);
+}
+
 export function openExistingSqliteWorkerBackend(
   _input: undefined,
   context: { databasePath: string },
-): SqliteWorkerBackend<OpenClawStateWorkerOperations> {
-  const connection = openOpenClawStateReadConnection(context.databasePath, context.databasePath);
-  const { db } = connection.database;
-  const listFlows = (ownerKey: string) =>
+): SqliteWorkerBackend<OpenClawStateWorkerOperations & OpenClawStateWorkerInspectionOperations> {
+  const open = () =>
+    openOpenClawStateDatabase({
+      path: context.databasePath,
+      env: getSqliteWorkerStateContext().environment,
+    });
+  const listFlows = (db: ReturnType<typeof open>["db"], ownerKey: string) =>
     listTaskFlowRecordsForOwnerReadInDatabase(db, ownerKey).map(normalizeRestoredFlowRecord);
   const ownedFlow = (flow: ReturnType<typeof readTaskFlowRecord>, ownerKey: string) =>
     flow?.ownerKey.trim() === ownerKey ? normalizeRestoredFlowRecord(flow) : undefined;
   return {
     execute(command) {
+      if (command.type === "database.generationMatches") {
+        // Unavailable inspection retains the known failure; only a stable mismatch expires it.
+        return sameSqliteFileGeneration(
+          command.input.generation,
+          readStableSqliteFileGeneration(context.databasePath),
+        );
+      }
+      const { db } = open();
       return runSqliteDeferredTransactionSync(db, () => {
         switch (command.type) {
           case "tasks.get":
@@ -47,7 +80,7 @@ export function openExistingSqliteWorkerBackend(
             };
           }
           case "flows.list":
-            return listFlows(command.input.ownerKey);
+            return listFlows(db, command.input.ownerKey);
           case "flows.views":
             return listTaskFlowViewRecordsForOwnerInDatabase(db, command.input.ownerKey)
               .map(normalizeRestoredFlowRecord)
@@ -68,7 +101,7 @@ export function openExistingSqliteWorkerBackend(
               !flow &&
               (lookup === "latest" || (lookup === "resolve" && token?.trim() === ownerKey))
             ) {
-              const flows = listFlows(ownerKey);
+              const flows = listFlows(db, ownerKey);
               flow =
                 lookup === "resolve"
                   ? (flows.find((candidate) => !isTerminalTaskFlow(candidate)) ?? flows[0])
@@ -87,7 +120,8 @@ export function openExistingSqliteWorkerBackend(
       });
     },
     close() {
-      connection.close();
+      closeOpenClawStateDatabaseByPath(context.databasePath);
+      clearOpenClawStateDatabaseOpenFailure(context.databasePath);
     },
   };
 }


### PR DESCRIPTION
## What Problem This Solves

The first shared-state worker read still opened and repaired the canonical database on the calling thread. Worker-only reads could also ignore a terminal database failure recorded by the host when no host connection was cached, and failed cleanup could lose track of a native coordinator lease.

## Why This Change Was Made

Open and repair shared state inside the existing physical database worker actor, carrying environment and coordinator runtime facts captured by their canonical owners. Existing `runtime.tasks.async` reads use that context. The host retains live Gateway schema authority, validates its existing terminal failure record through worker inspection, and retains cleanup custody until native close or successful handoff to the existing idle pool.

No persisted schema, schema version, or row format changes. Input/result framing and current pooling limits remain intact. Inspection failures preserve a known terminal failure; only a successful generation mismatch clears it. Public synchronous APIs remain available for compatibility. Task/flow registry restoration and runtime configuration preparation still run synchronously and are separate follow-ups.

## User Impact

Canonical database opening, repair, and reads execute in the worker while shutdown and terminal database errors remain observable to callers. Existing read payloads and synchronous callers remain compatible. Plugin KV activation and bundled caller migration are separate successors.

## Evidence

- 89 focused real SQLite, public SDK, coordinator, transport, and cleanup cases passed. These include cold create/repair with reopened-index verification, terminal admission, default pool reuse, retryable cleanup, actual 40/72 MiB append/reopen, cancellation/credits, partial staging drainage, and full result transport. Existing pathname-replacement probes were excluded from this scoped local run.
- Full local changed-code gate passed, and the exact final-head packaged build passed in 6m 53.9s. Fresh independent Codex review found no actionable P0–P2 findings.
- Earlier `f1734c0f8c0e` compiled Node 24.20 SDK measurements preserved Unicode payloads and restart/reopen behavior. Four warmed public reads took 3.73 ms with all six parent SQLite method counters at zero. Bun 1.4.2 canonical cold opening/read took 343.14 ms with the same zero counters and captured default pooling. These are individual synthetic timings, not comparative benchmarks.
- Positive published-driver qualification passed on isolated Linux/Node: published `2026.9.4` synthetic task/flow rows and CLI payloads survived the real candidate update, Doctor, first Gateway startup, and restart. Actual async SDK reads and lifecycle drainage passed. The published backup was verified and restored by the candidate with identical rows. Installed runtime, lifecycle, and worker hashes matched the candidate package, and build IDs verified the artifact transition despite the unchanged package-version string. The test lease is released with zero owned containers.

The final qualified package SHA-256 is `abbe9bc0003f918048203dcb7155629043caca687ec25f3dc63d888b268dff34`, built from exact head `179469fb205e649b092c17a7baf34ab54922d621`. Its independent published-driver run passed on the first attempt. Health/readiness returned 200 and RPC succeeded. Startup telemetry still reported event-loop degradation (p99/max 23.572 seconds over a 24.013-second sample); update took 178 seconds and startup/restart took 32/30 seconds. This establishes retained-data and artifact compatibility, not whole-Gateway cold-start performance. Earlier artifact receipts remain separate.

Current head `179469fb205e` contains the reviewed shutdown composition on main `7753ffb4753f`. It preserves the landed forced-no-retention cleanup from #146160, alongside retryable failed-close custody and captured runtime facts. The complete composition passed 69 focused cases, a fresh full P0–P2 review, and the full changed-code gate. The final conflict resolution only incorporates main's native-realpath helper/tests; an independent source review confirmed no foundation ownership or retention body changed. No Windows runtime claim is inferred from the local macOS tests.

Compiler routing fixes have since landed on main, so the redundant compiler commit was removed and the PR is back to 40 files. The final read-only inventory check assigns all 10,092 roots exactly once across the same 18 compiler graphs, with infra 671 and state/logging 404 roots. No test cases or caps were removed. Exact-head CI [run 34711552584](https://github.com/openclaw/openclaw/actions/runs/34711552584) is green. The final shutdown composition has its own source/runtime proof and exact-package upgrade receipt; no old artifact is being relabeled as final-head proof.

The canonical schema owner enters `withStateSchemaFence` before its synchronous migration transaction. Captured worker context reaches the live delegate assertion at that boundary. Real create/repair tests verify the reopened index; separate canonical refusal tests cover future schema and external-manager ownership. Revoked-delegate schema effects were not live-tested; the callback-level negative fixture is not presented as that evidence. The maintainer source review accepts this bounded scope with that limitation explicit.
