### PR TITLE
fix(linux): show OpenClaw as the tray menu name

### DIFF
--- a/apps/linux/src-tauri/src/main.rs
+++ b/apps/linux/src-tauri/src/main.rs
@@ -1287,6 +1287,10 @@ async fn gateway_action(
 }
 
 fn main() {
+    // AppIndicator uses the GTK application name for the tray menu heading.
+    #[cfg(target_os = "linux")]
+    gtk::glib::set_application_name("OpenClaw");
+
     let global_shortcuts_supported = tray::global_shortcuts_supported();
     let quickchat_state = quickchat::QuickChatState::new(global_shortcuts_supported);
     let quickchat_shortcut_state = quickchat_state.clone();


### PR DESCRIPTION
Related: #145593

## What Problem This Solves

Fixes the Linux tray display name showing `openclaw-desktop` instead of **OpenClaw**, observed in Omarchy.

## Why This Change Was Made

Sets GTK's human-readable application name before tray initialization. Ayatana AppIndicator uses this name for its StatusNotifierItem title and otherwise falls back to the executable name.

## User Impact

The tray menu identifies the app as **OpenClaw**. Executable names, app identifiers, configuration paths, and macOS behavior stay unchanged.

## Evidence

- Read the running app's actual D-Bus tray `Title`: `openclaw-desktop`.
- Private-session-bus probe with the installed GTK/AppIndicator backend: `Title` changed from `openclaw-desktop` to `OpenClaw` after setting the application name. This verifies the property Omarchy consumes.
- Exact before/after native app builds on a private bus with isolated HOME: inspected captures of the unmodified Omarchy **Tray icons** management row show `openclaw-desktop` before and `OpenClaw` after. This Omarchy version has no application-name heading in its context popup; the screenshots show the actual affected tray listing. The user app and Gateway were left running.
- `cargo check --locked --bin openclaw-desktop` and `cargo fmt --check` passed.
- Scoped changed-file checks and `git diff --check` passed.
- Fresh independent P0–P2 review: no actionable findings.
