### PR TITLE
fix(gateway): keep large session lists responsive

### DIFF
--- a/src/gateway/session-identity-projection.ts
+++ b/src/gateway/session-identity-projection.ts
@@ -20,6 +20,7 @@ import { looksLikeAvatarPath } from "../shared/avatar-policy.js";
 import { SESSIONS_LIST_OWNER_LIMIT } from "../shared/session-list-limits.js";
 import type { SessionOwnerFacetIdentity } from "../shared/session-types.js";
 import { sortAndLimitBy } from "../shared/sort-and-limit.js";
+import type { SynchronousWork } from "../shared/synchronous-work.js";
 import { resolveUserProfileReference } from "../state/user-profile-list.js";
 import { buildControlUiResourcePath } from "./control-ui-contract.js";
 import { normalizeControlUiBasePath } from "./control-ui-shared.js";
@@ -190,12 +191,13 @@ export function projectSessionPeople(
 }
 
 /** Resolve navigation references within the caller-prepared visibility scope. */
-export function resolveSessionListProfileReference(
+export function* resolveSessionListProfileReference(
   reference: string,
   entries: readonly SessionEntryPair[],
   identities: Map<string, SessionActorProfileIdentity | undefined>,
   allowedProfileIds: ReadonlySet<string> | undefined,
-): Result<string | undefined, "ambiguous"> {
+  shouldYield?: () => boolean,
+): SynchronousWork<Result<string | undefined, "ambiguous">> {
   const exact = projectSessionParticipant({ type: "profile", id: reference }, identities);
   if (
     identities.get(reference) &&
@@ -208,6 +210,9 @@ export function resolveSessionListProfileReference(
   // Qualified associations outlive profile rows. Resolve over caller-visible identities
   // before time/search filters so hidden associations cannot affect the result.
   for (const [, entry] of entries) {
+    if (shouldYield?.()) {
+      yield;
+    }
     const ids = [
       sessionCreatorProfileId(entry.createdActor),
       ...(entry.participants ?? []).flatMap(({ identity }) =>

--- a/src/gateway/session-list-order.ts
+++ b/src/gateway/session-list-order.ts
@@ -3,7 +3,8 @@
 import type { SessionsListParams } from "../../packages/gateway-protocol/src/index.js";
 import { isPinnableSessionEntry } from "../config/sessions/session-pin-policy.js";
 import type { SessionEntry } from "../config/sessions/types.js";
-import { sortAndLimitBy } from "../shared/sort-and-limit.js";
+import { sortAndLimitByWork } from "../shared/sort-and-limit.js";
+import type { SynchronousWork } from "../shared/synchronous-work.js";
 
 export type SessionEntryPair = [string, SessionEntry];
 
@@ -31,10 +32,16 @@ function compareSessionEntryPairs(
   return a[0] < b[0] ? -1 : a[0] > b[0] ? 1 : 0;
 }
 
-export function sortAndLimitSessionEntries(
+export function* sortAndLimitSessionEntries(
   entries: SessionEntryPair[],
   limit: number | undefined,
   sortBy: SessionsListParams["sortBy"],
-): SessionEntryPair[] {
-  return sortAndLimitBy(entries, limit, (a, b) => compareSessionEntryPairs(a, b, sortBy));
+  shouldYield?: () => boolean,
+): SynchronousWork<SessionEntryPair[]> {
+  return yield* sortAndLimitByWork(
+    entries,
+    limit,
+    (a, b) => compareSessionEntryPairs(a, b, sortBy),
+    shouldYield,
+  );
 }

--- a/src/gateway/session-utils-core.ts
+++ b/src/gateway/session-utils-core.ts
@@ -13,6 +13,7 @@ import {
 } from "../agents/subagents/registry/subagent-run-liveness.js";
 import { isTerminalSessionStatus, type SessionEntry } from "../config/sessions.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { runSynchronousWork, type SynchronousWork } from "../shared/synchronous-work.js";
 import {
   estimateAggregateUsageCost,
   type ModelCostConfig,
@@ -275,6 +276,13 @@ export function buildStoreChildSessionIndex(params: {
   subagentRuns?: SessionListRowContext["subagentRuns"];
   excludedChildKeys?: ReadonlySet<string>;
 }): Map<string, string[]> {
+  return runSynchronousWork(buildStoreChildSessionIndexWork(params));
+}
+
+export function* buildStoreChildSessionIndexWork(
+  params: Parameters<typeof buildStoreChildSessionIndex>[0],
+  shouldYield?: () => boolean,
+): SynchronousWork<Map<string, string[]>> {
   const children = new Map<string, string[]>();
   if (params.keys.length === 0) {
     return children;
@@ -282,6 +290,9 @@ export function buildStoreChildSessionIndex(params: {
   const parents = new Set(params.keys);
   // One store pass discovers both persisted navigation and runtime-only controller links.
   for (const key of Object.keys(params.store)) {
+    if (shouldYield?.()) {
+      yield;
+    }
     const entry = params.store[key];
     if (!entry || params.excludedChildKeys?.has(key)) {
       continue;

--- a/src/gateway/session-utils-list.ts
+++ b/src/gateway/session-utils-list.ts
@@ -23,6 +23,7 @@ import {
 import { isCronRunSessionKey } from "../sessions/session-key-utils.js";
 import { SESSIONS_LIST_OWNER_LIMIT } from "../shared/session-list-limits.js";
 import type { SessionOwnerFacetIdentity } from "../shared/session-types.js";
+import { runSynchronousWork, type SynchronousWork } from "../shared/synchronous-work.js";
 import {
   projectSessionOwner,
   addSessionOwnerFacetIdentity,
@@ -42,7 +43,7 @@ import type {
 } from "./session-utils-contracts.js";
 import {
   deriveSessionTitle,
-  buildStoreChildSessionIndex,
+  buildStoreChildSessionIndexWork,
   isFinitePositiveTimestamp,
   resolveSessionChildOwners,
 } from "./session-utils-core.js";
@@ -137,7 +138,7 @@ function resolveSessionsListWindowLimit(limit: number | undefined, offset: numbe
   return Number.isFinite(windowLimit) ? Math.min(windowLimit, Number.MAX_SAFE_INTEGER) : undefined;
 }
 
-function filterSessionEntries(params: {
+function* filterSessionEntries(params: {
   cfg: OpenClawConfig;
   store: Record<string, SessionEntry>;
   targetsBySessionKey?: GatewayStoredSessionTargets;
@@ -151,16 +152,19 @@ function filterSessionEntries(params: {
   involvingActorId?: string;
   ownerFirstActorId?: string;
   projectActiveRun?: SessionListActiveRunProjector;
-}): Pick<
-  SessionEntrySelection,
-  | "ownerFacet"
-  | "entries"
-  | "people"
-  | "peopleIncomplete"
-  | "peopleSessionCount"
-  | "involvingProfileId"
-> & { ownerEntries: SessionEntryPair[] } {
-  const { cfg, store, opts, now } = params;
+  shouldYield?: () => boolean;
+}): SynchronousWork<
+  Pick<
+    SessionEntrySelection,
+    | "ownerFacet"
+    | "entries"
+    | "people"
+    | "peopleIncomplete"
+    | "peopleSessionCount"
+    | "involvingProfileId"
+  > & { ownerEntries: SessionEntryPair[] }
+> {
+  const { cfg, store, opts, now, shouldYield } = params;
   const includeGlobal = opts.includeGlobal === true;
   const includeUnknown = opts.includeUnknown === true;
   const spawnedBy = typeof opts.spawnedBy === "string" ? opts.spawnedBy : "";
@@ -186,26 +190,38 @@ function filterSessionEntries(params: {
   const configuredAgentIds = params.configuredAgentIds ?? new Set(listAgentIds(cfg));
   const identities =
     params.userProfileIdentityById ?? new Map<string, SessionActorProfileIdentity | undefined>();
-  const visibleEntries = Object.entries(store).filter(
-    ([key, entry]) => params.entryFilter?.(key, entry) ?? true,
-  );
+  // The caller owns this store snapshot and its prepared visibility filter.
+  // Allocate pairs incrementally instead of materializing every pair before the first yield.
+  const visibleEntries: SessionEntryPair[] = [];
+  for (const key of Object.keys(store)) {
+    const entry = store[key]!;
+    if (params.entryFilter?.(key, entry) ?? true) {
+      visibleEntries.push([key, entry]);
+    }
+    if (shouldYield?.()) {
+      yield;
+    }
+  }
   const allowedProfileIds =
-    opts.involvingProfileId && params.restrictProfileReferences
-      ? new Set(
-          visibleEntries.flatMap(([, entry]) => {
-            const owner = projectSessionOwner(entry, identities, cfg, configuredAgentIds)?.actor;
-            return projectSessionPeople(entry, identities, cfg, owner).map(
-              (person) => person.identity.id,
-            );
-          }),
-        )
-      : undefined;
+    opts.involvingProfileId && params.restrictProfileReferences ? new Set<string>() : undefined;
+  if (allowedProfileIds) {
+    for (const [, entry] of visibleEntries) {
+      const owner = projectSessionOwner(entry, identities, cfg, configuredAgentIds)?.actor;
+      for (const person of projectSessionPeople(entry, identities, cfg, owner)) {
+        allowedProfileIds.add(person.identity.id);
+      }
+      if (shouldYield?.()) {
+        yield;
+      }
+    }
+  }
   const profileReference = opts.involvingProfileId
-    ? resolveSessionListProfileReference(
+    ? yield* resolveSessionListProfileReference(
         opts.involvingProfileId,
         visibleEntries,
         identities,
         allowedProfileIds,
+        shouldYield,
       )
     : undefined;
   if (profileReference && !profileReference.ok) {
@@ -213,7 +229,7 @@ function filterSessionEntries(params: {
   }
   const selectedProfileId = profileReference?.value;
 
-  const candidateEntries = visibleEntries.filter(([key, entry]) => {
+  const keepCandidate = ([key, entry]: SessionEntryPair) => {
     const target = params.targetsBySessionKey?.get(key);
     const storeKey = target?.storeKey ?? key;
     if (
@@ -264,7 +280,16 @@ function filterSessionEntries(params: {
       return false;
     }
     return true;
-  });
+  };
+  const candidateEntries: SessionEntryPair[] = [];
+  for (const pair of visibleEntries) {
+    if (keepCandidate(pair)) {
+      candidateEntries.push(pair);
+    }
+    if (shouldYield?.()) {
+      yield;
+    }
+  }
   // Search batches runtime metadata; excluded rows must not participate in ownership resolution.
   const matchesSearch = search
     ? createSessionListSearchMatcher({
@@ -279,6 +304,9 @@ function filterSessionEntries(params: {
     : undefined;
 
   for (const pair of candidateEntries) {
+    if (shouldYield?.()) {
+      yield;
+    }
     const [key, entry] = pair;
     if (matchesSearch && !matchesSearch(key, entry)) {
       continue;
@@ -363,7 +391,7 @@ function isPhantomAgentStoreListEntry(key: string, entry: SessionEntry | undefin
   );
 }
 
-function selectSessionEntries(params: {
+function* selectSessionEntries(params: {
   cfg: OpenClawConfig;
   store: Record<string, SessionEntry>;
   targetsBySessionKey?: GatewayStoredSessionTargets;
@@ -378,21 +406,28 @@ function selectSessionEntries(params: {
   involvingActorId?: string;
   ownerFirstActorId?: string;
   projectActiveRun?: SessionListActiveRunProjector;
-}): SessionEntrySelection {
-  const { ownerEntries, entries: filtered, ...facets } = filterSessionEntries(params);
+  shouldYield?: () => boolean;
+}): SynchronousWork<SessionEntrySelection> {
+  const { ownerEntries, entries: filtered, ...facets } = yield* filterSessionEntries(params);
   const limit = resolveSessionsListLimit(params.opts, params.defaultLimit);
   const offset = resolveSessionsListOffset(params.opts);
   const windowLimit = resolveSessionsListWindowLimit(limit, offset);
-  const sortedWindow = sortAndLimitSessionEntries(filtered, windowLimit, params.opts.sortBy);
+  const sortedWindow = yield* sortAndLimitSessionEntries(
+    filtered,
+    windowLimit,
+    params.opts.sortBy,
+    params.shouldYield,
+  );
   const sharedEntries =
     limit === undefined ? sortedWindow.slice(offset) : sortedWindow.slice(offset, offset + limit);
   let entries = sharedEntries;
   let ownerCount = 0;
   if (params.ownerFirstActorId && offset === 0) {
-    const owned = sortAndLimitSessionEntries(
+    const owned = yield* sortAndLimitSessionEntries(
       ownerEntries,
       Math.min(limit ?? SESSIONS_LIST_OWNER_LIMIT, SESSIONS_LIST_OWNER_LIMIT),
       params.opts.sortBy,
+      params.shouldYield,
     );
     ownerCount = owned.length;
     const ownedKeys = new Set(owned.map(([key]) => key));
@@ -412,7 +447,7 @@ function selectSessionEntries(params: {
   };
 }
 
-function prepareSessionList(params: ListSessionsFromStoreParams) {
+function* prepareSessionList(params: ListSessionsFromStoreParams, shouldYield: () => boolean) {
   const { cfg, store, opts } = params;
   const now = Date.now();
   const userProfileIdentityById = new Map<string, SessionActorProfileIdentity | undefined>();
@@ -433,7 +468,7 @@ function prepareSessionList(params: ListSessionsFromStoreParams) {
     hasIncognito ||= entry.incognito === true || isIncognitoSessionKey(key);
     return true;
   };
-  const selection = selectSessionEntries({
+  const selection = yield* selectSessionEntries({
     cfg,
     store,
     targetsBySessionKey: params.targetsBySessionKey,
@@ -452,21 +487,25 @@ function prepareSessionList(params: ListSessionsFromStoreParams) {
     involvingActorId: params.involvingActorId,
     ownerFirstActorId: params.ownerFirstActorId,
     projectActiveRun: params.projectActiveRun,
+    shouldYield,
   });
   // Filtering, child links, and row display share one registry snapshot per response.
   const sharedRowContext = selection.entries.length > 0 ? getRowContext() : undefined;
   const storePath = hasIncognito ? params.storePath : (params.durableStorePath ?? params.storePath);
-  const storeChildSessionsByKey = buildStoreChildSessionIndex({
-    store,
-    keys: [
-      ...new Set(
-        selection.entries.map(([key]) => params.targetsBySessionKey.get(key)?.storeKey ?? key),
-      ),
-    ],
-    now,
-    subagentRuns: sharedRowContext?.subagentRuns,
-    excludedChildKeys: filteredSessionKeys,
-  });
+  const storeChildSessionsByKey = yield* buildStoreChildSessionIndexWork(
+    {
+      store,
+      keys: [
+        ...new Set(
+          selection.entries.map(([key]) => params.targetsBySessionKey.get(key)?.storeKey ?? key),
+        ),
+      ],
+      now,
+      subagentRuns: sharedRowContext?.subagentRuns,
+      excludedChildKeys: filteredSessionKeys,
+    },
+    shouldYield,
+  );
   populateSessionListAcpMetadata({
     cfg,
     entries: selection.entries,
@@ -489,7 +528,7 @@ function prepareSessionList(params: ListSessionsFromStoreParams) {
 
 function buildSessionsListResult(
   params: ListSessionsFromStoreParams,
-  list: ReturnType<typeof prepareSessionList>,
+  list: ReturnType<typeof prepareSessionList> extends SynchronousWork<infer T> ? T : never,
   sessions: GatewaySessionRow[],
 ): SessionsListResult {
   const { cfg, opts, modelCatalog } = params;
@@ -549,10 +588,12 @@ export function filterAndSortSessionEntries(
     involvingActorId?: string;
   } & SessionSelectionScope,
 ): [string, SessionEntry][] {
-  return selectSessionEntries({
-    ...params,
-    restrictProfileReferences: params.entryFilter !== undefined,
-  }).entries;
+  return runSynchronousWork(
+    selectSessionEntries({
+      ...params,
+      restrictProfileReferences: params.entryFilter !== undefined,
+    }),
+  ).entries;
 }
 
 /** Projects lightweight list rows while sharing the event loop with other requests. */
@@ -572,9 +613,43 @@ export async function listSessionsFromStoreAsync(
     const timing = params.projectionTiming;
     let syncStartedAt = timing ? performance.now() : 0;
     let syncPhase: "prepareSyncMs" | "rowSyncMs" | undefined = "prepareSyncMs";
+    const yieldIfNeeded = (): Promise<void> | undefined => {
+      const checkpoint = performance.now();
+      if (checkpoint - workStartedAt < SESSIONS_LIST_YIELD_INTERVAL_MS) {
+        return undefined;
+      }
+      const phase = syncPhase;
+      if (timing && phase) {
+        timing[phase] += checkpoint - syncStartedAt;
+      }
+      syncPhase = undefined;
+      return yieldToEventLoop().then(() => {
+        workStartedAt = performance.now();
+        if (timing) {
+          timing.yieldWaitMs += workStartedAt - checkpoint;
+          timing.yieldCount++;
+          syncStartedAt = workStartedAt;
+        }
+        syncPhase = phase;
+      });
+    };
     try {
       const { cfg, store, targetsBySessionKey } = params;
-      const list = prepareSessionList(params);
+      let checkedItems = 0;
+      // Sample the clock in small batches, and leave nested generators only when work is due.
+      const shouldYieldPreparation = () =>
+        ++checkedItems % 16 === 0 &&
+        performance.now() - workStartedAt >= SESSIONS_LIST_YIELD_INTERVAL_MS;
+      const preparation = prepareSessionList(params, shouldYieldPreparation);
+      let step = preparation.next();
+      while (!step.done) {
+        const pause = yieldIfNeeded();
+        if (pause) {
+          await pause;
+        }
+        step = preparation.next();
+      }
+      const list = step.value;
       const sessions: GatewaySessionRow[] = [];
       const transcriptScopes = list.entries
         .slice(0, list.transcriptFieldRows)
@@ -593,24 +668,16 @@ export async function listSessionsFromStoreAsync(
           ];
         });
       const transcriptFields = readScopedSessionTitleFieldsFromTranscriptBatch(transcriptScopes);
-      // Consume synchronous sharing facts and capture transcripts before yielding.
-      // Loading and preparation can spend the budget even for zero or one row.
-      let checkpoint = performance.now();
+      // Optional transcript reads can spend the remaining budget even for an empty page.
+      const checkpoint = performance.now();
       if (timing) {
         timing.prepareSyncMs += checkpoint - syncStartedAt;
         syncStartedAt = checkpoint;
         syncPhase = "rowSyncMs";
       }
-      if (checkpoint - workStartedAt >= SESSIONS_LIST_YIELD_INTERVAL_MS) {
-        syncPhase = undefined;
-        await yieldToEventLoop();
-        workStartedAt = performance.now();
-        if (timing) {
-          timing.yieldWaitMs += workStartedAt - checkpoint;
-          timing.yieldCount++;
-          syncStartedAt = workStartedAt;
-          syncPhase = "rowSyncMs";
-        }
+      const preparationPause = yieldIfNeeded();
+      if (preparationPause) {
+        await preparationPause;
       }
       let transcriptFieldIndex = 0;
       for (let i = 0; i < list.entries.length; i++) {
@@ -654,22 +721,10 @@ export async function listSessionsFromStoreAsync(
           }
         }
         sessions.push(row);
-        if (
-          i + 1 < list.entries.length &&
-          (checkpoint = performance.now()) - workStartedAt >= SESSIONS_LIST_YIELD_INTERVAL_MS
-        ) {
-          if (timing) {
-            timing.rowSyncMs += checkpoint - syncStartedAt;
-          }
-          syncPhase = undefined;
-          await yieldToEventLoop();
-          // Waiting behind other work is not projection work; start the next budget on resume.
-          workStartedAt = performance.now();
-          if (timing) {
-            timing.yieldWaitMs += workStartedAt - checkpoint;
-            timing.yieldCount++;
-            syncStartedAt = workStartedAt;
-            syncPhase = "rowSyncMs";
+        if (i + 1 < list.entries.length) {
+          const pause = yieldIfNeeded();
+          if (pause) {
+            await pause;
           }
         }
       }

--- a/src/gateway/session-utils.perf.test.ts
+++ b/src/gateway/session-utils.perf.test.ts
@@ -221,6 +221,7 @@ describe("session list resolver cache", () => {
       rowWorkMs: 0,
       storeWorkMs: 0,
       preparationWorkMs: 0,
+      orderingWorkMs: 0,
       keepRows: true,
       limit: 100,
       shouldYield: false,
@@ -230,6 +231,7 @@ describe("session list resolver cache", () => {
       rowWorkMs: 20,
       storeWorkMs: 0,
       preparationWorkMs: 0,
+      orderingWorkMs: 0,
       keepRows: true,
       limit: 100,
       shouldYield: true,
@@ -239,6 +241,7 @@ describe("session list resolver cache", () => {
       rowWorkMs: 0,
       storeWorkMs: 0,
       preparationWorkMs: 1,
+      orderingWorkMs: 0,
       keepRows: true,
       limit: 1,
       shouldYield: true,
@@ -248,6 +251,7 @@ describe("session list resolver cache", () => {
       rowWorkMs: 0,
       storeWorkMs: 0,
       preparationWorkMs: 1,
+      orderingWorkMs: 0,
       keepRows: false,
       limit: 1,
       shouldYield: true,
@@ -257,6 +261,7 @@ describe("session list resolver cache", () => {
       rowWorkMs: 0,
       storeWorkMs: 8,
       preparationWorkMs: 0.25,
+      orderingWorkMs: 0,
       keepRows: true,
       limit: 1,
       shouldYield: true,
@@ -266,32 +271,66 @@ describe("session list resolver cache", () => {
       rowWorkMs: 0,
       storeWorkMs: 20,
       preparationWorkMs: 0,
+      orderingWorkMs: 0,
       keepRows: true,
       limit: 1,
       shouldYield: true,
     },
+    {
+      name: "wide ordering",
+      rowWorkMs: 0,
+      storeWorkMs: 0,
+      preparationWorkMs: 0,
+      orderingWorkMs: 1,
+      keepRows: true,
+      limit: 300,
+      shouldYield: true,
+    },
   ])(
     "shares the event loop for $name",
-    async ({ rowWorkMs, storeWorkMs, preparationWorkMs, keepRows, limit, shouldYield }) => {
+    async ({
+      rowWorkMs,
+      storeWorkMs,
+      preparationWorkMs,
+      orderingWorkMs,
+      keepRows,
+      limit,
+      shouldYield,
+    }) => {
       await withStateDirEnv("openclaw-list-work-budget-", async ({ stateDir }) => {
         resetPluginRuntimeStateForTest();
         setActivePluginRegistry(createEmptyPluginRegistry());
         const cfg: OpenClawConfig = {};
         resetConfigRuntimeState();
         setRuntimeConfigSnapshot(cfg);
+        let workMs = storeWorkMs;
+        let orderingCalls = 0;
+        let orderingCallsAtControl = 0;
+        let orderingCallsBeforeRows: number | undefined;
         const store = Object.fromEntries(
-          Array.from({ length: 32 }, (_, index) => [
+          Array.from({ length: orderingWorkMs > 0 ? 2051 : 32 }, (_, index) => [
             `agent:main:budget-${index}`,
-            { sessionId: `budget-${index}`, updatedAt: index + 1 },
+            {
+              sessionId: `budget-${index}`,
+              updatedAt: index + 1,
+              // Pin reads charge ordering work before any row is projected.
+              get pinnedAt() {
+                orderingCalls++;
+                workMs += orderingWorkMs;
+                return undefined;
+              },
+            },
           ]),
         );
-        let workMs = storeWorkMs;
         let controlBeforePreparation: boolean | undefined;
+        let preparationCalls = 0;
+        let preparationCallsAtControl = 0;
         const buildRow = rowProjection.buildGatewaySessionRow;
         const clock = vi.spyOn(performance, "now").mockImplementation(() => workMs);
         const rows = vi
           .spyOn(rowProjection, "buildGatewaySessionRow")
           .mockImplementation((params) => {
+            orderingCallsBeforeRows ??= orderingCalls;
             const row = buildRow(params);
             workMs += rowWorkMs;
             return row;
@@ -300,6 +339,8 @@ describe("session list resolver cache", () => {
         const controlCallback = new Promise<void>((resolve) => {
           setImmediate(() => {
             controlRan = true;
+            preparationCallsAtControl = preparationCalls;
+            orderingCallsAtControl = orderingCalls;
             resolve();
           });
         });
@@ -311,6 +352,7 @@ describe("session list resolver cache", () => {
             store,
             entryFilter: () => {
               controlBeforePreparation ??= controlRan;
+              preparationCalls++;
               workMs += preparationWorkMs;
               return keepRows;
             },
@@ -321,6 +363,14 @@ describe("session list resolver cache", () => {
           );
           expect(controlRan).toBe(shouldYield);
           expect(controlBeforePreparation).toBe(false);
+          if (preparationWorkMs > 0 && shouldYield) {
+            expect(preparationCallsAtControl).toBeLessThan(preparationCalls);
+          }
+          if (orderingWorkMs > 0) {
+            expect(orderingCallsAtControl).toBeLessThan(
+              expectDefined(orderingCallsBeforeRows, "row projection started"),
+            );
+          }
         } finally {
           rows.mockRestore();
           clock.mockRestore();

--- a/src/shared/sort-and-limit.test.ts
+++ b/src/shared/sort-and-limit.test.ts
@@ -1,17 +1,21 @@
 import { describe, expect, it } from "vitest";
-import { sortAndLimitBy } from "./sort-and-limit.js";
+import { sortAndLimitBy, sortAndLimitByWork } from "./sort-and-limit.js";
+import { runSynchronousWork } from "./synchronous-work.js";
 
 describe("sortAndLimitBy", () => {
   it.each([1, 5, 50, 200, 201, undefined])(
     "matches stable full ordering without mutating input for limit %s",
     (limit) => {
-      const entries = Array.from({ length: 500 }, (_, id) => ({ id, rank: (id * 37) % 23 }));
+      const entries = Array.from({ length: 2051 }, (_, id) => ({ id, rank: (id * 37) % 23 }));
       const compare = (a: (typeof entries)[number], b: (typeof entries)[number]) => a.rank - b.rank;
       for (const input of [entries, entries.toReversed(), entries.toSorted(compare), []]) {
         const original = [...input];
         const sorted = input.toSorted(compare);
         const expected = limit === undefined ? sorted : sorted.slice(0, limit);
         expect(sortAndLimitBy(input, limit, compare)).toEqual(expected);
+        expect(runSynchronousWork(sortAndLimitByWork(input, limit, compare, () => true))).toEqual(
+          expected,
+        );
         expect(input).toEqual(original);
       }
     },

--- a/src/shared/sort-and-limit.ts
+++ b/src/shared/sort-and-limit.ts
@@ -1,4 +1,46 @@
+import { runSynchronousWork, type SynchronousWork } from "./synchronous-work.js";
+
 const TOP_N_LIMIT = 200;
+const SORT_RUN_SIZE = 1024;
+
+function* sortEntriesWork<T extends object>(
+  entries: T[],
+  compare: (a: T, b: T) => number,
+  shouldYield?: () => boolean,
+): SynchronousWork<T[]> {
+  if (!shouldYield || entries.length <= SORT_RUN_SIZE) {
+    return entries.toSorted(compare);
+  }
+  let sorted = entries.slice();
+  // Native sorting keeps each run cheap; merging provides checkpoints for wide windows.
+  for (let start = 0; start < sorted.length; start += SORT_RUN_SIZE) {
+    const run = sorted.slice(start, start + SORT_RUN_SIZE).toSorted(compare);
+    for (let index = 0; index < run.length; index++) {
+      sorted[start + index] = run[index]!;
+    }
+    yield;
+  }
+  let merged = sorted.slice();
+  for (let width = SORT_RUN_SIZE; width < sorted.length; width *= 2) {
+    for (let start = 0; start < sorted.length; start += width * 2) {
+      const middle = Math.min(start + width, sorted.length);
+      const end = Math.min(start + width * 2, sorted.length);
+      let left = start;
+      let right = middle;
+      for (let index = start; index < end; index++) {
+        if (shouldYield()) {
+          yield;
+        }
+        // Prefer the earlier run for equal entries, preserving the native sort's stability.
+        const takeRight =
+          left >= middle || (right < end && compare(sorted[left]!, sorted[right]!) > 0);
+        merged[index] = takeRight ? sorted[right++]! : sorted[left++]!;
+      }
+    }
+    [sorted, merged] = [merged, sorted];
+  }
+  return sorted;
+}
 
 /** Stable bounded ordering; each caller owns its comparator and validated limit. */
 export function sortAndLimitBy<T extends object>(
@@ -6,9 +48,22 @@ export function sortAndLimitBy<T extends object>(
   limit: number | undefined,
   compare: (a: T, b: T) => number,
 ): T[] {
+  return runSynchronousWork(sortAndLimitByWork(entries, limit, compare));
+}
+
+/** Checkpoints preserve stable ordering for cooperative callers. */
+export function* sortAndLimitByWork<T extends object>(
+  entries: T[],
+  limit: number | undefined,
+  compare: (a: T, b: T) => number,
+  shouldYield?: () => boolean,
+): SynchronousWork<T[]> {
   if (limit !== undefined && limit <= TOP_N_LIMIT) {
     const selected: T[] = [];
     for (const entry of entries) {
+      if (shouldYield?.()) {
+        yield;
+      }
       const first = selected[0];
       const beforeFirst = first && compare(entry, first) < 0;
       const worst = selected[limit - 1];
@@ -41,6 +96,6 @@ export function sortAndLimitBy<T extends object>(
     }
     return selected;
   }
-  const sorted = entries.toSorted(compare);
+  const sorted = yield* sortEntriesWork(entries, compare, shouldYield);
   return limit === undefined ? sorted : sorted.slice(0, limit);
 }

--- a/src/shared/synchronous-work.ts
+++ b/src/shared/synchronous-work.ts
@@ -1,0 +1,10 @@
+export type SynchronousWork<T> = Generator<void, T, void>;
+
+/** Consume the same incremental operation when the caller cannot yield. */
+export function runSynchronousWork<T>(work: SynchronousWork<T>): T {
+  let step = work.next();
+  while (!step.done) {
+    step = work.next();
+  }
+  return step.value;
+}


### PR DESCRIPTION
Related: #146166

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where users opening or searching a large session list would delay other Gateway requests while the list is prepared. With 100,000 synthetic sessions, preparation kept the event loop occupied for roughly 350–606 ms before another request could run.

## Why This Change Was Made

Filtering, people/profile resolution, ordering, and child-session indexing now share the list operation's existing 12 ms cooperative work budget. One incremental operation serves async listing and its synchronous adapters, preserving selection, visibility, paging, and stable ordering; wide async pages sort bounded native runs and merge with checkpoints, while synchronous callers retain native full sorting.

## User Impact

Large session lists let other Gateway work run between preparation batches. The measured median maximum event-loop gap falls by 93–96% at 100,000 sessions. Default listing time stays approximately unchanged; people listing costs 5% more, matching-label search is 5% faster, and wide pages cost 12–16% more total time. Smaller workloads show mixed scheduling overhead, detailed below.

## Evidence

The source-native benchmark calls the actual `listSessionsFromStoreAsync` with synthetic stores and existing target fixtures. Windows, Node v26.8.2, Ryzen AI MAX+ 395, 32 logical CPUs. Each implementation receives two warmups and seven measured calls per case, alternating baseline/candidate order in the same process: 77 samples per implementation. Fixture construction, module imports, explicit pre-sample GC, and warmups are excluded. Team CPU jobs were idle during final sampling.

Default, people, and matching-label search select 100 rows. Wide cases select 1,000 rows from 100,000 sessions with ordered or deterministically shuffled timestamps. All figures below are medians in milliseconds; gap is each call's maximum observed event-loop gap.

| Store rows | Case | Maximum loop gap, before → after (ms) | Total time, before → after (ms) | Total change |
| ---: | --- | ---: | ---: | ---: |
| 1,000 | default | 12.2 → 12.2 | 18.3 → 19.7 | 7.6% |
| 1,000 | people | 12.2 → 12.2 | 16.9 → 18.6 | 10.4% |
| 1,000 | search | 12.2 → 12.1 | 17.0 → 16.9 | -0.5% |
| 10,000 | default | 35.0 → 12.2 | 43.0 → 53.6 | 24.7% |
| 10,000 | people | 53.0 → 14.0 | 63.8 → 59.4 | -6.9% |
| 10,000 | search | 62.9 → 13.8 | 67.9 → 76.3 | 12.4% |
| 100,000 | default | 366.5 → 25.3 | 375.5 → 370.5 | -1.3% |
| 100,000 | people | 430.2 → 26.0 | 437.3 → 459.9 | 5.2% |
| 100,000 | search | 605.7 → 25.5 | 614.1 → 585.6 | -4.6% |
| 100,000 | wide-ordered | 353.3 → 24.1 | 401.2 → 448.2 | 11.7% |
| 100,000 | wide-random | 601.2 → 25.5 | 654.2 → 756.7 | 15.7% |

- The original preparation regression failed in three cases because all 32 expensive filter calls finished before the event loop ran; the candidate passes. The original wide-ordering regression likewise failed because all 4,100 comparator property reads finished before yielding; the candidate passes.
- Selected owner/visibility/people/search/paging and sorter suite: 154 passed, four existing Windows alias skips. After the final scheduling-predicate optimization, targeted performance and sorter tests: 24 passed. Stable ties and an uneven 2,051-entry merge tail are checked against native sorting through both synchronous and cooperative paths.
- Final eight-file scoped lint and `git diff --check` pass. Independent P0–P2 review of the exact frozen patch is scoped-clean.
- A separate alternating synchronous sorting comparison confirms the retained native fast path: 100,000 randomly ordered entries take 82.4/73.6 ms before/after for limit 1,000 and 88.4/83.2 ms for unlimited; ordered input takes 2.2–2.7 ms. These small differences are not claimed as a speedup.
- Local standalone typechecking was blocked by the repository's external-dependency guard on the borrowed worktree install; the guard was not bypassed. Hosted exact-head checks remain required.

This is warm synthetic preparation proof, excluding Gateway transport, response-cache hits, transcript-derived titles, live plugins, and worst-case derived-field/no-match search. Native key enumeration and GC remain indivisible, so the 12 ms budget is not a hard maximum pause guarantee.

