### PR TITLE
improve(sessions): speed up shared-store health summaries

### DIFF
--- a/src/config/sessions/session-accessor.readonly.test.ts
+++ b/src/config/sessions/session-accessor.readonly.test.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { DatabaseSync, type StatementSync } from "node:sqlite";
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { trackSqliteStatementExecutions } from "../../../test/helpers/sqlite-statement-execution-counter.js";
 import {
   cleanupTempDirs,
   makeTempDir,
@@ -310,6 +311,109 @@ describe("session accessor readonly listing", () => {
         })),
       ),
     ).toEqual([exactReadFailure, exactReadFailure]);
+  });
+
+  it("batches shared-store recent payloads and participants without dropping saved entry fields", () => {
+    const env = { OPENCLAW_STATE_DIR: autoTempDirs.make("openclaw-session-summary-batch-") };
+    const storePath = path.join(env.OPENCLAW_STATE_DIR, "shared.sqlite");
+    const database = openOpenClawAgentDatabase({ agentId: "main", env, path: storePath });
+    const agentIds = Array.from({ length: 8 }, (_, index) => `worker-${index}`);
+    const participant = database.db.prepare(
+      "INSERT INTO session_participants (session_key, identity_namespace, actor_id, contribution_count, first_prompted_at, last_prompted_at) VALUES (?, ?, ?, 1, 1, 1)",
+    );
+    for (const agentId of agentIds) {
+      for (let index = 0; index < 6; index += 1) {
+        const sessionKey = `agent:${agentId}:session-${index}`;
+        replaceSessionEntrySync(
+          { agentId, env, storePath, sessionKey },
+          {
+            sessionId: `${agentId}-${index}`,
+            updatedAt: index,
+            skillsSnapshot: { prompt: "saved prompt", skills: [] },
+          },
+        );
+        participant.run(sessionKey, '{"type":"profile"}', "alice");
+      }
+    }
+    const scope = { agentId: "main", env, storePath };
+    const options = { recentLimit: 5, agentIds };
+    readSessionStoreSummaryReadOnly(scope, options);
+    const queries = trackSqliteStatementExecutions(
+      database.db,
+      ["payloads", "participants"],
+      (sql) => {
+        if (sql.includes('from "session_participants"')) {
+          return "participants";
+        }
+        if (sql.includes('select * from "session_nodes"')) {
+          return "payloads";
+        }
+        return null;
+      },
+    );
+    try {
+      const summary = readSessionStoreSummaryReadOnly(scope, options);
+      expect(summary.count).toBe(48);
+      expect(summary.recent.map(({ sessionKey }) => sessionKey)).toEqual(
+        agentIds.slice(0, 5).map((agentId) => `agent:${agentId}:session-5`),
+      );
+      for (const agentId of agentIds) {
+        const agent = expectDefined(summary.byAgent.get(agentId), "shared-store agent");
+        expect(agent.count).toBe(6);
+        expect(agent.recent.map(({ entry }) => entry.sessionId)).toEqual(
+          [5, 4, 3, 2, 1].map((index) => `${agentId}-${index}`),
+        );
+        for (const { entry } of agent.recent) {
+          expect(entry.skillsSnapshot?.prompt).toBe("saved prompt");
+          expect(entry.participants).toEqual([{ identity: { type: "profile", id: "alice" } }]);
+        }
+      }
+      expect(queries.counts.payloads).toBeLessThanOrEqual(2);
+      expect(queries.counts.participants).toBeLessThanOrEqual(2);
+    } finally {
+      queries.restore();
+    }
+  });
+
+  it("fills recent slots after unreadable settled rows and only decodes consumed participants", () => {
+    const env = { OPENCLAW_STATE_DIR: autoTempDirs.make("openclaw-session-summary-fallback-") };
+    const scope = { agentId: "main", env };
+    const keys = Array.from({ length: 8 }, (_, index) => `agent:main:entry-${index}`);
+    const participantSessionKey = expectDefined(keys[5], "participant session key");
+    for (const [index, sessionKey] of keys.entries()) {
+      replaceSessionEntrySync(
+        { ...scope, sessionKey },
+        { sessionId: `entry-${index}`, updatedAt: 8 - index },
+      );
+    }
+    const options = { recentLimit: 2, agentIds: [scope.agentId] };
+    readSessionStoreSummaryReadOnly(scope, options);
+    const database = openOpenClawAgentDatabase(scope);
+    const invalidate = database.db.prepare(
+      "UPDATE session_nodes SET entry_json = '{' WHERE session_key = ?",
+    );
+    const settle = database.db.prepare(
+      "UPDATE session_nodes SET entry_valid = 1 WHERE session_key = ?",
+    );
+    for (const sessionKey of keys.slice(0, 3)) {
+      invalidate.run(sessionKey);
+      settle.run(sessionKey);
+    }
+    database.db
+      .prepare(
+        "INSERT INTO session_participants (session_key, identity_namespace, actor_id, contribution_count, first_prompted_at, last_prompted_at) VALUES (?, ?, ?, 1, 1, 1)",
+      )
+      .run(participantSessionKey, "invalid namespace", "alice");
+    const summary = readSessionStoreSummaryReadOnly(scope, options);
+    expect(summary.count).toBe(5);
+    expect(summary.recent.map(({ sessionKey }) => sessionKey)).toEqual(keys.slice(3, 5));
+    expect(summary.byAgent.get(scope.agentId)?.recent).toEqual(summary.recent);
+
+    // Pending rows are still parsed outside the recent window, including their participants.
+    database.db
+      .prepare("UPDATE session_nodes SET entry_valid = 0 WHERE session_key = ?")
+      .run(participantSessionKey);
+    expect(() => readSessionStoreSummaryReadOnly(scope, options)).toThrow(SyntaxError);
   });
 
   it("surfaces missing canonical transcript tables through single and batched reads", async () => {

--- a/src/config/sessions/session-accessor.sqlite-summary.ts
+++ b/src/config/sessions/session-accessor.sqlite-summary.ts
@@ -1,6 +1,7 @@
 import {
-  executeSqliteQueryTakeFirstSync,
+  executeSqliteQuerySync,
   iterateSqliteQuerySync,
+  sqliteStringSet,
 } from "../../infra/kysely-sync.js";
 import { runSqliteDeferredTransactionSync } from "../../infra/sqlite-transaction.js";
 import { parseAgentSessionKey } from "../../routing/session-key.js";
@@ -10,7 +11,7 @@ import type {
   SessionAccessScope,
   SessionEntrySummary,
 } from "./session-accessor.sqlite-contract.js";
-import { projectSqliteSessionParticipants } from "./session-accessor.sqlite-participant-projection.js";
+import { projectSqliteSessionParticipantsBatch } from "./session-accessor.sqlite-participant-projection.js";
 import {
   getSessionKysely,
   resolveSqliteScope,
@@ -22,6 +23,12 @@ import {
   canonicalSessionKeyMigrationRequiredError,
 } from "./session-canonical-key.js";
 import { resolveDeliveryProvenCanonicalSessionKey } from "./store-entry.js";
+
+type SummaryCandidate = {
+  sessionKey: string;
+  entryValid: number | null;
+  agent?: SessionStoreSummary;
+};
 
 type SessionStoreSummary = { count: number; recent: SessionEntrySummary[] };
 
@@ -48,6 +55,86 @@ export function readSessionStoreSummaryReadOnly(
         const db = getSessionKysely(database.db);
         // The read transaction keeps count, ordering, and selected payloads on one
         // generation. Existing keys/indexes bound JSON work, not the cold canonical check.
+        // Small stores keep their bounded recent payloads; shared stores amortize
+        // hydration without retaining every pending row or assuming entry_valid can parse.
+        const batchSize = Math.min(
+          128,
+          Math.max(1, Math.ceil(options.recentLimit) || 1) * Math.max(1, summary.byAgent.size),
+        );
+        let candidates: SummaryCandidate[] = [];
+        const readCandidates = () => {
+          if (candidates.length === 0) {
+            return;
+          }
+          const rows = candidates;
+          candidates = [];
+          const storedRows = new Map(
+            executeSqliteQuerySync(
+              database.db,
+              db
+                .selectFrom("session_nodes")
+                .selectAll()
+                .where("session_key", "in", sqliteStringSet(rows.map((row) => row.sessionKey))),
+            ).rows.map((row) => [row.session_key, row]),
+          );
+          const selectedEntries: SessionEntrySummary[] = [];
+          for (const { sessionKey, entryValid, agent } of rows) {
+            const needsRecent =
+              summary.recent.length < options.recentLimit ||
+              (agent !== undefined && agent.recent.length < options.recentLimit);
+            if (entryValid === 1 && !needsRecent) {
+              summary.count += 1;
+              if (agent) {
+                agent.count += 1;
+              }
+              continue;
+            }
+            // Raw updates clear entry_valid. Preserve listing's warm-row semantics:
+            // skip unreadable JSON/retained placeholders, but include readable pending rows.
+            const stored = storedRows.get(sessionKey);
+            if (!stored) {
+              continue;
+            }
+            const { current_session_id: _currentSessionId, ...listRow } = stored;
+            const entry = parseSessionEntryJson(listRow);
+            if (!entry) {
+              continue;
+            }
+            summary.count += 1;
+            const selected = { sessionKey, entry };
+            selectedEntries.push(selected);
+            if (summary.recent.length < options.recentLimit) {
+              summary.recent.push(selected);
+            }
+            if (agent) {
+              agent.count += 1;
+              // The global newest rows may all belong to another agent. Select each
+              // requested owner's window in this scan, sharing each parsed payload.
+              if (agent.recent.length < options.recentLimit) {
+                agent.recent.push(selected);
+              }
+            }
+          }
+          if (selectedEntries.length === 0) {
+            return;
+          }
+          const projected = projectSqliteSessionParticipantsBatch(
+            database.db,
+            new Map(selectedEntries.map(({ sessionKey, entry }) => [sessionKey, entry])),
+          );
+          for (const { sessionKey, entry } of selectedEntries) {
+            Object.assign(entry, projected.get(sessionKey));
+            const deliveryCanonicalKey = resolveDeliveryProvenCanonicalSessionKey(
+              sessionKey,
+              entry,
+            );
+            if (deliveryCanonicalKey !== sessionKey) {
+              throw canonicalSessionKeyMigrationRequiredError(
+                `non-canonical persisted row resolves to session key ${deliveryCanonicalKey}`,
+              );
+            }
+          }
+        };
         for (const row of iterateSqliteQuerySync(
           database.db,
           db
@@ -61,54 +148,23 @@ export function readSessionStoreSummaryReadOnly(
             continue;
           }
           const agent = summary.byAgent.get(owner);
-          const needsRecent =
-            summary.recent.length < options.recentLimit ||
-            (agent !== undefined && agent.recent.length < options.recentLimit);
-          if (row.entry_valid === 1 && !needsRecent) {
+          if (
+            row.entry_valid === 1 &&
+            summary.recent.length >= options.recentLimit &&
+            (!agent || agent.recent.length >= options.recentLimit)
+          ) {
             summary.count += 1;
             if (agent) {
               agent.count += 1;
             }
             continue;
           }
-          // Raw updates clear entry_valid. Preserve listing's warm-row semantics:
-          // skip unreadable JSON/retained placeholders, but include readable pending rows.
-          const stored = executeSqliteQueryTakeFirstSync(
-            database.db,
-            db.selectFrom("session_nodes").selectAll().where("session_key", "=", row.session_key),
-          );
-          if (!stored) {
-            continue;
-          }
-          const { current_session_id: _currentSessionId, ...listRow } = stored;
-          const parsed = parseSessionEntryJson(listRow);
-          if (!parsed) {
-            continue;
-          }
-          const entry = projectSqliteSessionParticipants(database.db, row.session_key, parsed);
-          const deliveryCanonicalKey = resolveDeliveryProvenCanonicalSessionKey(
-            row.session_key,
-            entry,
-          );
-          if (deliveryCanonicalKey !== row.session_key) {
-            throw canonicalSessionKeyMigrationRequiredError(
-              `non-canonical persisted row resolves to session key ${deliveryCanonicalKey}`,
-            );
-          }
-          summary.count += 1;
-          const selected = { sessionKey: row.session_key, entry };
-          if (summary.recent.length < options.recentLimit) {
-            summary.recent.push(selected);
-          }
-          if (agent) {
-            agent.count += 1;
-            // The global newest rows may all belong to another agent. Select each
-            // requested owner's window in this scan, sharing each parsed payload.
-            if (agent.recent.length < options.recentLimit) {
-              agent.recent.push(selected);
-            }
+          candidates.push({ sessionKey: row.session_key, entryValid: row.entry_valid, agent });
+          if (candidates.length >= batchSize) {
+            readCandidates();
           }
         }
+        readCandidates();
         return summary;
       }),
     toDatabaseOptions(resolved),


### PR DESCRIPTION
## What Problem This Solves

Health and status summaries spend increasing time reading recent sessions when many agents share one SQLite store.

## Why This Change Was Made

Read recent payloads and participants in bounded batches within the existing read transaction. Keep the sorted inventory scan, complete saved entries, per-agent windows, malformed-row fallback, and participant validation behavior.

## User Impact

Shared-store summaries perform fewer database queries. Single-agent summaries also improve in the repeated-read fixture. Schema, retention, and transaction boundaries remain unchanged.

## Evidence

- All 21 cases in `src/config/sessions/session-accessor.readonly.test.ts` pass. The new shared-store regression fails on the original implementation with 40 payload reads against a budget of two, after the returned-session assertions pass.
- The new regressions preserve saved prompts and participants, fill recent slots past malformed settled rows, and validate participants only for consumed rows. Existing pending, hidden, retained, and ordering cases pass.
- Synthetic public-reader comparison on Node 26.8.2 / SQLite 3.53.4, with PR #146036's participant-query cache in both arms: 100 agents / 1,000 rows / 500 selected, median 87.63 to 46.30 ms; 10 agents, 6.67 to 4.34 ms. Seven alternating rounds, full result equality checked.
- Single-agent fixture: ten warmup equality pairs, then seven alternating blocks of 100 reads; median 0.642 to 0.578 ms per read. Each session includes an 8 KiB saved prompt and two participants. These are warm synthetic reads, not a cold-start or production distribution claim.
- Canonical core production and owning state/logging/session test types, scoped type-aware lint, formatting, and whitespace checks pass. Independent P0–P2 review is clean; only mechanical test key-check/braces corrections followed it.

- Additional canonical read compatibility proof at the same head: 60 original/candidate reader calls across 1/10/100-agent fixtures preserve both agent and shared-state databases (six before/after windows). Schema, typed row digests/counts, user_version, integrity, and main/WAL/journal hashes remain unchanged. SHM hashes are recorded diagnostically. A separate comparison correctly detects fixture-seeding writes. These verification-only calls add no timing claim.
