### PR TITLE
perf(plugins): avoid full CLI backend copies for metadata reads

### DIFF
--- a/src/agents/cli-backends.ts
+++ b/src/agents/cli-backends.ts
@@ -114,7 +114,7 @@ function resolveCliBackendModelProvider(
 
 function addCliRuntimeModelBinding(
   bindings: Map<string, CliRuntimeModelBackendBinding>,
-  params: { backend: CliBackendPlugin; pluginId?: string },
+  params: { backend: Pick<CliBackendPlugin, "id" | "modelProvider">; pluginId?: string },
 ): void {
   const provider = resolveCliBackendModelProvider(params.backend);
   const runtime = normalizeBackendKey(params.backend.id);
@@ -137,7 +137,7 @@ export function listCliRuntimeModelBackendBindings(
   } = {},
 ): CliRuntimeModelBackendBinding[] {
   const bindings = new Map<string, CliRuntimeModelBackendBinding>();
-  for (const backend of cliBackendsDeps.resolveRuntimeCliBackends()) {
+  for (const backend of cliBackendsDeps.resolveRuntimeCliBackends("metadata")) {
     addCliRuntimeModelBinding(bindings, {
       backend,
       ...(backend.pluginId ? { pluginId: backend.pluginId } : {}),

--- a/src/agents/embedded-agent-runner/cli-backend-dispatch-eligibility.ts
+++ b/src/agents/embedded-agent-runner/cli-backend-dispatch-eligibility.ts
@@ -40,7 +40,10 @@ export function resolveEmbeddedCliBackendDispatchEligibility(
   // provider id directly, so resolve the configured execution runtime before
   // gating.
   const backends = new Map(
-    resolveRuntimeCliBackends().map((backend) => [normalizeProviderId(backend.id), backend]),
+    resolveRuntimeCliBackends("metadata").map((backend) => [
+      normalizeProviderId(backend.id),
+      backend,
+    ]),
   );
   const requestedProvider = normalizeProviderId(params.provider ?? "");
   const provider = backends.has(requestedProvider)

--- a/src/agents/model-selection-cli.ts
+++ b/src/agents/model-selection-cli.ts
@@ -15,7 +15,7 @@ export type CliProviderClassifier = (provider: string) => boolean;
 export function prepareCliProviderClassifier(cfg?: OpenClawConfig): CliProviderClassifier {
   const providers = new Set(
     [
-      ...resolveRuntimeCliBackends().map((backend) => backend.id),
+      ...resolveRuntimeCliBackends("metadata").map((backend) => backend.id),
       ...resolvePluginSetupCliBackendIds({ config: cfg }),
     ].map(normalizeProviderId),
   );
@@ -25,7 +25,7 @@ export function prepareCliProviderClassifier(cfg?: OpenClawConfig): CliProviderC
 /** Return true when a provider id resolves to a configured or plugin CLI backend. */
 export function isCliProvider(provider: string, cfg?: OpenClawConfig): boolean {
   const normalized = normalizeProviderId(provider);
-  const cliBackends = resolveRuntimeCliBackends();
+  const cliBackends = resolveRuntimeCliBackends("metadata");
   if (cliBackends.some((backend) => normalizeProviderId(backend.id) === normalized)) {
     return true;
   }

--- a/src/plugins/cli-backends.runtime.test.ts
+++ b/src/plugins/cli-backends.runtime.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  listCliRuntimeModelBackendBindings,
+  resolveCliBackendConfig,
+  resolveCliRuntimeCanonicalProvider,
+} from "../agents/cli-backends.js";
+import { isCliProvider } from "../agents/model-selection-cli.js";
+import { getPluginInstance } from "./plugin-instance-scope.js";
+import { createRuntimeTestRegistry } from "./registry-runtime.test-helpers.js";
+import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "./runtime.js";
+import { createPluginRuntime } from "./runtime/index.js";
+import { createPluginRecord } from "./status.test-helpers.js";
+
+describe("runtime CLI backend consumers", () => {
+  const owners: NonNullable<ReturnType<typeof getPluginInstance>>[] = [];
+
+  afterEach(async () => {
+    for (const owner of owners) {
+      await owner.dispose();
+    }
+    owners.length = 0;
+    resetPluginRuntimeStateForTest();
+  });
+
+  function registerBackend(provider: string) {
+    const builder = createRuntimeTestRegistry(createPluginRuntime());
+    const record = createPluginRecord({ id: provider });
+    const api = builder.createApi(record, { config: {} });
+    api.registerCliBackend({
+      id: "fixture-cli",
+      modelProvider: provider,
+      config: { command: `${provider}-cli` },
+      resolveModelId: ({ modelId }) => `${provider}:${modelId}`,
+      subscriptionAuthDispatch: true,
+    });
+    const owner = getPluginInstance(record);
+    if (!owner) {
+      throw new Error("Expected the registered CLI backend to have an instance");
+    }
+    owners.push(owner);
+    return { builder, owner };
+  }
+
+  it("refreshes display metadata while retained execution hooks stay with their owner", async () => {
+    const first = registerBackend("first-provider");
+    setActivePluginRegistry(first.builder.registry);
+
+    expect(isCliProvider(" FIXTURE-CLI ")).toBe(true);
+    expect(resolveCliRuntimeCanonicalProvider({ runtime: "fixture-cli" })).toBe("first-provider");
+    expect(listCliRuntimeModelBackendBindings()).toEqual([
+      { provider: "first-provider", runtime: "fixture-cli", pluginId: "first-provider" },
+    ]);
+    const retained = resolveCliBackendConfig("fixture-cli");
+    expect(retained?.config.command).toBe("first-provider-cli");
+    expect(retained?.resolveModelId?.({ modelId: "demo" })).toBe("first-provider:demo");
+
+    const second = registerBackend("second-provider");
+    setActivePluginRegistry(second.builder.registry);
+    await first.owner.dispose();
+
+    expect(resolveCliRuntimeCanonicalProvider({ runtime: "fixture-cli" })).toBe("second-provider");
+    expect(listCliRuntimeModelBackendBindings()).toEqual([
+      { provider: "second-provider", runtime: "fixture-cli", pluginId: "second-provider" },
+    ]);
+    expect(resolveCliBackendConfig("fixture-cli")?.config.command).toBe("second-provider-cli");
+    expect(() => retained?.resolveModelId?.({ modelId: "demo" })).toThrow(
+      /reloaded|disabled|retir/i,
+    );
+  });
+});

--- a/src/plugins/cli-backends.runtime.ts
+++ b/src/plugins/cli-backends.runtime.ts
@@ -8,12 +8,26 @@ type PluginCliBackendEntry = CliBackendPlugin & {
   builtWithOpenClawVersion?: string;
 };
 
+type PluginCliBackendMetadata = Pick<
+  PluginCliBackendEntry,
+  "id" | "modelProvider" | "subscriptionAuthDispatch" | "pluginId"
+>;
+
 /** Resolves CLI backends from the active runtime plugin registry. */
-export function resolveRuntimeCliBackends(): PluginCliBackendEntry[] {
+export function resolveRuntimeCliBackends(mode: "metadata"): PluginCliBackendMetadata[];
+export function resolveRuntimeCliBackends(): PluginCliBackendEntry[];
+export function resolveRuntimeCliBackends(mode?: "metadata"): PluginCliBackendMetadata[] {
   return (getActiveRuntimePluginRegistry()?.cliBackends ?? []).map((entry) =>
-    Object.assign({}, entry.backend, {
-      pluginId: entry.pluginId,
-      builtWithOpenClawVersion: entry.builtWithOpenClawVersion,
-    }),
+    mode === "metadata"
+      ? {
+          id: entry.backend.id,
+          modelProvider: entry.backend.modelProvider,
+          subscriptionAuthDispatch: entry.backend.subscriptionAuthDispatch,
+          pluginId: entry.pluginId,
+        }
+      : Object.assign({}, entry.backend, {
+          pluginId: entry.pluginId,
+          builtWithOpenClawVersion: entry.builtWithOpenClawVersion,
+        }),
   );
 }


### PR DESCRIPTION
Session display classification and canonical model bindings copy every field of each managed CLI backend, including nested execution configuration and callbacks that these consumers never use. Add a metadata projection to the existing internal resolver and move classification, model bindings, and dispatch eligibility onto it. Execution configuration and live-test lookups retain the full projection, including version metadata and owner-bound callbacks. Registry freshness, setup fallback, ordering, and subscription dispatch policy stay unchanged.

A synthetic probe through `resolveSessionDisplayModelIdentityRefCached` registers two real managed plugin modules and checks 2,000 display lookups across 1,000 model names. Sampled allocation falls from 395.5 MB to 35.2 MB (91.1%); the resolver subtree falls from 389.2 MB to 28.5 MB (92.7%). Every canonical reference remains correct, and a retained execution callback rejects after its plugin is disposed. This measures temporary allocation in the display entry point; it does not establish a retained-memory, RSS, or whole-Gateway reduction.

Validation:
- All 86 focused tests pass across CLI configuration, provider classification, model aliases, embedded CLI dispatch, and real registry replacement/callback retirement.
- The new registry replacement test also passes against the original production source, confirming the preserved lifecycle contract.
- Targeted lint over all five changed files, formatting, and `git diff --check` pass. Changed-lane classification selects core and core tests.
- Aggregate local checks were not run after host resource exhaustion; exact-head hosted CI run 34704651489 passed.
- Independent P0–P2 review completed scoped-clean with no findings.

The same profiled loop took 881.6 ms before and 80.5 ms after. Whole-process peak RSS was 622.5 MiB before and 629.1 MiB after; RSS around the measurement was 605.0/622.1 MiB for baseline and 628.6/629.1 MiB for candidate. These single profiled samples establish neither an RSS reduction nor a general throughput improvement.
