### PR TITLE
perf(state): avoid redundant admission path normalization

### DIFF
--- a/src/state/agent-database-admission.ts
+++ b/src/state/agent-database-admission.ts
@@ -1,4 +1,3 @@
-import path from "node:path";
 import {
   listAgentIds,
   tryResolveAmbientOwnerAgentId,
@@ -30,7 +29,7 @@ const refusalsByState = new Map<
 >();
 
 function stateKey(options: AdmissionOptions): string {
-  return path.resolve(resolveOpenClawStateSqlitePath(options.env ?? process.env));
+  return resolveOpenClawStateSqlitePath(options.env ?? process.env);
 }
 
 /** Ownership is derived from the inspected file; missing or corrupt metadata keeps normal refusal. */

--- a/src/state/openclaw-state-db.paths.ts
+++ b/src/state/openclaw-state-db.paths.ts
@@ -9,7 +9,7 @@ export function resolveOpenClawStateSqliteDir(env: NodeJS.ProcessEnv = process.e
 
 /** Resolve the shared state SQLite file path. */
 export function resolveOpenClawStateSqlitePath(env: NodeJS.ProcessEnv = process.env): string {
-  return path.join(resolveOpenClawStateSqliteDir(env), "openclaw.sqlite");
+  return path.join(resolveStateDir(env), "state", "openclaw.sqlite");
 }
 
 /** Resolve the state owner directory for a canonical or explicit shared database path. */


### PR DESCRIPTION
Database admission lookups repeatedly normalize the shared SQLite filename while checking whether an agent can use its database. Build the filename with one join and use that owner's already absolute, normalized result as the admission key. Each lookup still resolves the current environment and working directory and reads the existing startup admission decision.

A focused comparison against `88a5a5e8ad23212519a2372ced22078c82b46e3e` ran 100,000 iterations through the public admission/assertion entries. Sampled allocations fell from 509,613,520 to 302,545,920 bytes (40.6%); median time across five unprofiled repetitions fell from 400.9 to 271.3 ms. This is a bounded entry-point measurement, with no whole-Gateway or retained-memory claim.

Validation:

- 96 existing tests passed across admission ownership, home resolution, config paths, and shared SQLite filename/default-home behavior.
- Baseline and candidate passed 8 native Linux and 12 native Windows path cases, including cwd-relative overrides, tilde, drive-relative paths, UNC, and Windows namespace paths.
- Public-entry checks preserve environment mutation, cwd mutation, diagnostic/startup precedence, and new startup decision replacement; Linux and Windows candidate source hashes match.
- Formatting, diff checks, and scoped lint passed. Fresh canonical P0-P2 autoreview is scoped-clean with no actionable findings.

- Exact-head hosted CI run 34704652530 passed on attempt 2. The first attempt failed in an unchanged Windows managed-handoff publication fixture; the single diagnostic rerun passed without source, assertion, or timeout changes.
