### PR TITLE
fix(openai): discourage repeated GPT-Live backend work

### DIFF
--- a/docs/providers/openai/voice-and-speech.md
+++ b/docs/providers/openai/voice-and-speech.md
@@ -256,6 +256,11 @@ sidebarTitle: "Voice and speech"
     as spoken updates. Custom instructions should preserve that distinction;
     the Codex route uses its separate commentary/speakable channel contract.
 
+    Both routes instruct the voice model to wait for delegated results instead
+    of repeating the same backend request. New user follow-ups, corrections, and
+    explicit retries remain allowed. These instructions guide model behavior;
+    they do not guarantee that each request executes only once.
+
     Public transcript events are fragments,
     not completed turns. The Gateway owns persistence of bounded received-text
     snapshots; clients display captions without saving another copy. Both live

--- a/extensions/openai/realtime-quicksilver-instructions.ts
+++ b/extensions/openai/realtime-quicksilver-instructions.ts
@@ -2,6 +2,7 @@ import { isOpenAIGptLiveApiModel } from "./realtime-quicksilver.js";
 
 const OPENAI_QUICKSILVER_DELEGATION_INSTRUCTIONS = `You are OpenClaw's realtime voice layer. You have no tools of your own.
 Delegate any request that requires real work, reasoning, current information, or actions to the client through a delegation.
+Delegate each user request once and wait for its result. New user follow-ups, corrections, and explicit retries are new requests. Receipts and backend results are not user requests; do not delegate them or repeat the original request when they arrive.
 Keep the conversation natural while delegated work runs.`;
 
 const OPENAI_QUICKSILVER_CHANNEL_INSTRUCTIONS = `Context on the commentary channel is silent background. You may use it, but never read it aloud.
@@ -44,7 +45,7 @@ export function buildOpenAIQuicksilverInstructions(
 ): string {
   const channels = isOpenAIGptLiveApiModel(model)
     ? `Information in session.thinking.append is silent context. Use it when relevant, but do not read it aloud merely because it arrives.
-Information in session.commentary.append is an update to speak aloud naturally. A backend result is not a new user request; do not delegate it.
+Information in session.commentary.append is an update to speak aloud naturally.
 Instructions in session.instructions.append direct the live session. Follow those directions without reading them aloud as content. Never mention the channel or the delegation.`
     : OPENAI_QUICKSILVER_CHANNEL_INSTRUCTIONS;
   const instructions = `${OPENAI_QUICKSILVER_DELEGATION_INSTRUCTIONS}\n${channels}`;

--- a/extensions/openai/realtime-voice-provider-routing.test.ts
+++ b/extensions/openai/realtime-voice-provider-routing.test.ts
@@ -808,6 +808,7 @@ describe("OpenAI realtime voice provider routing", () => {
   it.each([
     { model: "gpt-live-test-canary", voice: "spruce", publicApi: false },
     { model: "gpt-live-1", voice: "marin", publicApi: true },
+    { model: "gpt-live-1-codex", voice: "cove", publicApi: false },
   ])(
     "passes $model voice and channel instructions to the native broker",
     async ({ model, voice, publicApi }) => {
@@ -841,6 +842,12 @@ describe("OpenAI realtime voice provider routing", () => {
         "quicksilver request",
       );
       expect(quicksilverRequest.instructions).toMatch(/^You are OpenClaw's realtime voice layer\./);
+      expect(quicksilverRequest.instructions).toContain(
+        "Delegate each user request once and wait for its result.",
+      );
+      expect(quicksilverRequest.instructions).toContain(
+        "New user follow-ups, corrections, and explicit retries are new requests.",
+      );
       if (publicApi) {
         expect(quicksilverRequest.instructions).toContain(
           "session.thinking.append is silent context",


### PR DESCRIPTION
Related: #145382, #146078

## What Problem This Solves

GPT Live can ask the backend to repeat work for one spoken request. Live browser captures showed two extra consultations across 36 user turns; an identity-traced repetition used distinct provider delegation IDs, so replay-ID filtering would not address it.

## Why This Change Was Made

The shared voice instructions now tell the model to delegate each user request once and wait for its result. New user follow-ups, corrections, and explicit retries remain allowed. Receipt/result guidance applies to both the public API and Codex routes, replacing duplicated API-only wording. The change adds no event filter, state, or configuration.

## User Impact

The voice model receives clearer guidance against repeating backend work. This is a prompt mitigation, not a guarantee that a request executes only once. It does not claim to fix speech recognition.

## Evidence

- Six baseline browser sessions completed 36 spoken requests with 38 backend consultations. Three sessions with the revised instructions completed 18 requests with 18 consultations and no repeated delegation. All requested colors were recognized; raw provider final text and delegation text matched published captions and backend input exactly.
- The same saved audio, voice, broker, synthetic backend, and completion rules were used. These real-provider tests are a bounded observation, not statistical proof of a failure rate or full agent-tool/UI coverage.
- The registered-routing regression fails with the original instruction bytes on all three selected routes. All 56 routing tests pass with the candidate, including public GPT Live, Codex GPT Live, and the existing compatible route.
- Complete selected changed-file checks pass. Fresh managed review through P2 is scoped-clean. The earlier wrong-color recognition did not recur during this follow-up, so it remains unassigned rather than being attributed to this change.
