### PR TITLE
perf(state): avoid incognito sentinel construction for durable reads

### DIFF
--- a/src/state/openclaw-agent-db.incognito.test.ts
+++ b/src/state/openclaw-agent-db.incognito.test.ts
@@ -11,6 +11,7 @@ import {
   closeOpenClawAgentDatabases,
   closeOpenClawAgentDatabasesForTest,
   IncognitoAgentDatabasePathCollisionError,
+  isIncognitoOpenClawAgentSqlitePath,
   listOpenClawRegisteredAgentDatabases,
   listOpenIncognitoAgentDatabases,
   openOpenClawAgentDatabase,
@@ -31,6 +32,58 @@ afterEach(() => {
 });
 
 describe("incognito agent database", () => {
+  it.runIf(process.platform === "win32")(
+    "matches mixed separators on drive and UNC roots without folding filename case",
+    () => {
+      for (const stateDir of ["C:\\incognito-state", "\\\\server\\share\\incognito-state"]) {
+        const options = { agentId: "worker", env: { OPENCLAW_STATE_DIR: stateDir } };
+        const sentinel = resolveIncognitoOpenClawAgentSqlitePath(options);
+        expect(isIncognitoOpenClawAgentSqlitePath(sentinel.replaceAll("\\", "/"), options)).toBe(
+          true,
+        );
+        expect(
+          isIncognitoOpenClawAgentSqlitePath(
+            path.join(path.dirname(sentinel), path.basename(sentinel).toUpperCase()),
+            options,
+          ),
+        ).toBe(false);
+      }
+    },
+  );
+
+  it("matches only the normalized sentinel for the current owner and state root", () => {
+    const env = { OPENCLAW_STATE_DIR: path.join(os.tmpdir(), "incognito-path-root") };
+    const options = { agentId: "worker", env };
+    const sentinel = resolveIncognitoOpenClawAgentSqlitePath(options);
+    const basename = path.basename(sentinel);
+    for (const pathname of [
+      sentinel,
+      path.relative(process.cwd(), sentinel),
+      `${sentinel}${path.sep}`,
+      `${sentinel}${path.sep}.`,
+      `${sentinel}${path.sep}..${path.sep}${basename}`,
+    ]) {
+      expect(isIncognitoOpenClawAgentSqlitePath(pathname, options), pathname).toBe(true);
+    }
+    for (const pathname of [
+      path.join(path.dirname(sentinel), "openclaw-agent.sqlite"),
+      path.join(env.OPENCLAW_STATE_DIR, basename),
+      `${sentinel}-wal`,
+      `${sentinel} `,
+      path.join(path.dirname(sentinel), basename.toUpperCase()),
+    ]) {
+      expect(isIncognitoOpenClawAgentSqlitePath(pathname, options), pathname).toBe(false);
+    }
+    expect(isIncognitoOpenClawAgentSqlitePath(sentinel, { ...options, agentId: "other" })).toBe(
+      false,
+    );
+    env.OPENCLAW_STATE_DIR = path.join(env.OPENCLAW_STATE_DIR, "changed");
+    expect(isIncognitoOpenClawAgentSqlitePath(sentinel, options)).toBe(false);
+    expect(
+      isIncognitoOpenClawAgentSqlitePath(resolveIncognitoOpenClawAgentSqlitePath(options), options),
+    ).toBe(true);
+  });
+
   it.each([false, true])(
     "rejects deletion-fenced opens and writes and retires prepared statements (held: %s)",
     (held) => {

--- a/src/state/openclaw-agent-db.paths.ts
+++ b/src/state/openclaw-agent-db.paths.ts
@@ -48,5 +48,9 @@ export function isIncognitoOpenClawAgentSqlitePath(
   pathname: string,
   options: Omit<OpenClawAgentSqlitePathOptions, "path">,
 ): boolean {
-  return path.resolve(pathname) === resolveIncognitoOpenClawAgentSqlitePath(options);
+  const resolved = path.resolve(pathname);
+  return (
+    path.basename(resolved) === INCOGNITO_AGENT_SQLITE_BASENAME &&
+    resolved === resolveIncognitoOpenClawAgentSqlitePath(options)
+  );
 }


### PR DESCRIPTION
Durable session reads repeatedly built the full incognito sentinel path before ruling out an ordinary database filename. Resolve the input once and reject a different basename before building the expected sentinel. Matching filenames still use the existing full owner/root comparison; no cache, API, or storage policy changes.

A synthetic actual-entry benchmark seeded 100 sessions with five transcript messages each, then ran 2,000 public reads per cell. Sampled allocation fell 26.6% for durable exact-entry reads (87.0 to 63.9 MB) and 21.7% for durable transcript-stat reads (113.4 to 88.8 MB). Incognito positive cells were approximately flat (+0.5%). These are one-profile-per-cell allocation measurements, not whole-Gateway or retained-memory claims.

Validation: 18 tests passed across the incognito database and session/transcript suites; the Windows drive/UNC case was skipped on Linux and is covered by passing exact-head Windows CI. The new native lexical preservation case also passed on the original owner. Durable entries and both transcript-stat cells matched their full content fingerprints. All 100 fresh-process incognito entries matched after excluding only the two real-writer clock fields, sessionStartedAt and updatedAt. Formatting and diff checks passed. Exact-head hosted CI run 34704906478 passed.

Independent P0-P2 autoreview completed scoped-clean on the frozen two-file candidate.
