### PR TITLE
fix(update): prevent lint OOMs during legacy Git upgrades

### DIFF
--- a/docs/ci/local-proof.md
+++ b/docs/ci/local-proof.md
@@ -14,6 +14,11 @@ without applying lint defaults to declaration preparation. Explicit Go settings
 remain inherited. Frozen revisions retain the workflow limits because their
 wrappers can predate this policy.
 
+On serial hosts with less than 24 GiB of memory, full lint runs core targets in
+five disjoint batches and plugins in smaller chunks. These runs retain the same
+type-aware rules and TypeScript configuration while bounding checker caches.
+Explicit split-core and parallel execution selections remain unchanged.
+
 Oxlint keeps `eslint/no-redeclare` enabled for JavaScript. For `.ts`, `.tsx`,
 `.mts`, and `.cts`, `tsgo` owns declaration validity, including intentional
 type/value pairs with the same public name. `eslint/no-var` remains enabled

--- a/scripts/run-oxlint-shards.mts
+++ b/scripts/run-oxlint-shards.mts
@@ -22,6 +22,7 @@ import {
 import { shouldPrepareExtensionPackageBoundaryArtifacts } from "./run-oxlint.mts";
 
 const DEFAULT_EXTENSION_CHUNK_SIZE = 8;
+const DEFAULT_CONSTRAINED_CORE_STRIPES = 5;
 const DEFAULT_SHARD_HEARTBEAT_MS = 30_000;
 const DEFAULT_SHARD_TIMEOUT_MS = 15 * 60_000;
 const DEFAULT_SHARD_KILL_GRACE_MS = 5_000;
@@ -86,14 +87,24 @@ export function createOxlintShards({
   splitCore = false,
   splitExtensions = false,
 }: PlatformShardOptions = {}) {
-  const coreShards = splitCore ? createCoreOxlintShards({ cwd, readDir }) : [CORE_SHARD];
+  const constrainedSerial =
+    hostResources.totalMemoryBytes < CI_PARALLEL_MIN_MEMORY_BYTES &&
+    shouldRunOxlintShardsSerial({ env, platform, hostResources });
+  const coreGroups =
+    splitCore || constrainedSerial ? createCoreOxlintShards({ cwd, readDir }) : [CORE_SHARD];
+  // Bound semantic checker caches without rebuilding the full type graph for every directory.
+  const coreShards =
+    constrainedSerial && !splitCore
+      ? Array.from({ length: DEFAULT_CONSTRAINED_CORE_STRIPES }, (_, index) =>
+          selectCoreOxlintStripe(coreGroups, {
+            index: index + 1,
+            total: DEFAULT_CONSTRAINED_CORE_STRIPES,
+          }),
+        ).flat()
+      : coreGroups;
   // Unsplit plugin lint can exceed small-host RAM even with a single lint thread.
   // Chunk serial runs; explicit stripes use independently bounded Programs that stay serial.
-  const chunkExtensions =
-    splitExtensions ||
-    platform === "win32" ||
-    (hostResources.totalMemoryBytes < CI_PARALLEL_MIN_MEMORY_BYTES &&
-      shouldRunOxlintShardsSerial({ env, platform, hostResources }));
+  const chunkExtensions = splitExtensions || platform === "win32" || constrainedSerial;
   const extensionShards = chunkExtensions
     ? createExtensionOxlintShards({ cwd, env, platform, readDir })
     : [EXTENSIONS_SHARD];

--- a/test/scripts/run-oxlint.test.ts
+++ b/test/scripts/run-oxlint.test.ts
@@ -683,6 +683,49 @@ describe("run-oxlint", () => {
     ]);
   });
 
+  it.each([
+    { platform: "linux", env: { CI: "true" } },
+    { platform: "darwin", env: {} },
+    { platform: "win32", env: {} },
+  ] as const)(
+    "bounds small-host core Programs without losing targets on $platform",
+    ({ platform, env }) => {
+      const directories = ["alpha", "beta", "delta", "epsilon", "gamma", "zeta"];
+      const cwd = createTempDir("openclaw-oxlint-core-memory-");
+      for (const directory of directories) {
+        mkdirSync(join(cwd, "src", directory), { recursive: true });
+      }
+      writeFileSync(join(cwd, "src", "root.ts"), "");
+      const shards = filterOxlintShards(
+        createOxlintShards({
+          cwd,
+          env,
+          platform,
+          hostResources: CONSTRAINED_HOST,
+        }),
+        new Set(["core"]),
+      );
+
+      expect(shards).toHaveLength(5);
+      expect(shards.every((shard) => shard.args[1] === "config/tsconfig/oxlint.core.json")).toBe(
+        true,
+      );
+      const targets = shards.flatMap((shard) => shard.args.slice(2));
+      expect(targets.toSorted()).toEqual(
+        [
+          ...directories.map((directory) => `src/${directory}`),
+          "src/root.ts",
+          "ui",
+          "packages",
+        ].toSorted(),
+      );
+      expect(new Set(targets).size).toBe(targets.length);
+      expect(shouldRunOxlintShardsSerial({ env, platform, hostResources: CONSTRAINED_HOST })).toBe(
+        true,
+      );
+    },
+  );
+
   it("parses shard runner flags without forwarding them to oxlint", () => {
     const parsed = parseShardRunnerArgs([
       "--only=core",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where older Git installations cannot update because the candidate's full type-aware lint runs out of memory. The published March and January updaters hit kernel-confirmed `tsgolint` OOM kills during preflight on a 4-CPU Linux Testbox with 15 GiB of RAM, preserving the old installation but refusing the update.

## Why This Change Was Made

Use the existing stripe selector to run core targets in five serial batches when the existing resource policy identifies a memory-constrained serial host. The same type-aware rules, TypeScript configuration, targets, and Go limits apply. Explicit split-core and parallel/full selections remain unchanged. This avoids the repeated full-program setup cost of one batch per source directory.

## User Impact

Candidate lint can complete within the old updater's existing timeout on the tested constrained host. Normal developer lint also uses this bounded path on matching hosts; update callers need no new flags or configuration.

## Evidence

- The original combined core lint was killed by the kernel for memory exhaustion. Reducing to one Go worker still exhausted host headroom; that unsuitable experiment was stopped and is not counted as a passing lint run.
- All five existing core stripes passed the original candidate: 22,704 files and 263 rules, with unchanged TypeScript configuration.
- Automatic full `timeout 1200s pnpm lint` passed on Blacksmith Testbox in 12m47.60s, below the published March updater's unchanged 20-minute deadline. Maximum RSS was 13,807,928 kB (about 13.2 GiB).
- All 120 focused tests passed, including regressions that fail on the original planner and prove complete, disjoint target coverage. Full changed-file checks and independent review through P2 passed.
- The committed tree `3ef2048bcc4746714f30cf6b0127c29f08ff7ead` matches the tested candidate. Blacksmith Testbox via Crabbox: [run](https://github.com/openclaw/openclaw/actions/runs/34702491530), lease `tbx_01m2b3xn6ry3exhs7zmkr9d9yh`, now stopped.

The unchanged published March Git updater now completes the full normal update on the same constrained host. Stored channel was `dev`; command: `pnpm openclaw update --yes --no-restart --json`. Observed CLI exit was 0, configuration validated, original config bytes were unchanged, and the final candidate checkout was clean. The following update reported already current without another installation.

This replay used proof-only aggregate `0d4d6fdd3bd5175275cf1a125332e3a2428951f9`, combining this lint commit with the independently reviewed state repair from #146196; the lint production file is identical to this PR. Full lint took 777,975 ms (12m57.98s) inside the original 20-minute per-command limit. The complete setup/update/assertion wrapper exited 0 in 23m55.756s on [run34705449098](https://github.com/openclaw/openclaw/actions/runs/34705449098), lease `tbx_01m2b79pmwpebxqyh3t21ksvr6`.

Direct sanitized projection of the retained command results:

```json
{
  "before": {
    "sha": "213a704b71f4996dc82a583288ee53785215f627",
    "version": "2026.3.31"
  },
  "after": {
    "sha": "0d4d6fdd3bd5175275cf1a125332e3a2428951f9",
    "version": "2026.9.4"
  },
  "status": "ok",
  "durationMs": 1225885,
  "steps": [
    {
      "name": "preflight lint (0d4d6fdd)",
      "exitCode": 0,
      "durationMs": 777975
    },
    {
      "name": "openclaw doctor",
      "exitCode": 0,
      "durationMs": 3148
    }
  ],
  "configValid": true,
  "configBytesPreserved": true,
  "repeat": {
    "status": "skipped",
    "reason": "already-current",
    "durationMs": 1722
  },
  "resultSha256": "2f00717a4c3c52ddbc7e65f9018c3b76ae386ec6af052fd9ef5c700ef8bd9c85"
}
```

A separate March stable-to-dev channel-switch cell completed core installation but its immutable old validator rejected new bundled plugin metadata during final channel writeback. Config bytes remained intact; rerunning that exact command through the updated CLI returned 0, persisted `dev`, and left valid config and the same clean candidate. No manifest requirements were weakened. This historical false failure and explicit recovery are recorded separately from the successful normal update.

Exact-head CI [34705024480](https://github.com/openclaw/openclaw/actions/runs/34705024480) passed for `6bc0c636c0a6ab272cfcdbc6c2c43f2684845041`.
