### PR TITLE
fix: skills requiring a binary are reported ready when a PATH directory has that binary's name

### DIFF
--- a/src/shared/config-eval.test.ts
+++ b/src/shared/config-eval.test.ts
@@ -95,55 +95,49 @@ describe("config-eval helpers", () => {
   });
 
   it("caches binary lookups until PATH changes", () => {
-    mockProcessPlatform("linux");
-    vi.stubEnv("PATH", ["/missing/bin", "/found/bin"].join(path.delimiter));
-    const accessSpy = vi.spyOn(fs, "accessSync").mockImplementation((candidate) => {
-      if (String(candidate) === path.join("/found/bin", "tool")) {
-        return undefined;
+    withTempDirSync({ prefix: "openclaw-binary-cache-" }, (root) => {
+      mockProcessPlatform("linux");
+      const missingDir = path.join(root, "missing");
+      const foundDir = path.join(root, "found");
+      const otherDir = path.join(root, "other");
+      for (const dir of [missingDir, foundDir, otherDir]) {
+        fs.mkdirSync(dir);
       }
-      throw new Error("missing");
+      const executable = path.join(foundDir, "tool");
+      fs.writeFileSync(executable, "#!/bin/sh\nexit 0\n");
+      fs.chmodSync(executable, 0o755);
+      vi.stubEnv("PATH", [missingDir, foundDir].join(path.delimiter));
+
+      expect(hasBinary("tool")).toBe(true);
+
+      // The cached positive survives the binary disappearing under an unchanged PATH.
+      fs.rmSync(executable);
+      expect(hasBinary("tool")).toBe(true);
+
+      vi.stubEnv("PATH", otherDir);
+      expect(hasBinary("tool")).toBe(false);
     });
-
-    expect(hasBinary("tool")).toBe(true);
-    expect(hasBinary("tool")).toBe(true);
-    expect(accessSpy).toHaveBeenCalledTimes(2);
-
-    vi.stubEnv("PATH", "/other/bin");
-    accessSpy.mockClear();
-    accessSpy.mockImplementation(() => {
-      throw new Error("missing");
-    });
-
-    expect(hasBinary("tool")).toBe(false);
-    expect(accessSpy).toHaveBeenCalledTimes(1);
   });
 
   it("checks PATHEXT candidates and invalidates cached hits when PATHEXT changes", () => {
-    mockProcessPlatform("win32");
-    const toolsDir = path.join(path.sep, "tools");
-    vi.stubEnv("PATH", toolsDir);
-    vi.stubEnv("PATHEXT", ".EXE;.CMD");
-    const plainCandidate = path.join(toolsDir, "tool");
-    const exeCandidate = path.join(toolsDir, "tool.EXE");
-    const cmdCandidate = path.join(toolsDir, "tool.CMD");
-    const accessSpy = vi.spyOn(fs, "accessSync").mockImplementation((candidate) => {
-      if (String(candidate) === cmdCandidate) {
-        return undefined;
-      }
-      throw new Error("missing");
+    withTempDirSync({ prefix: "openclaw-binary-pathext-" }, (toolsDir) => {
+      mockProcessPlatform("win32");
+      vi.stubEnv("PATH", toolsDir);
+      vi.stubEnv("PATHEXT", ".EXE;.CMD");
+      const cmdCandidate = path.join(toolsDir, "tool.CMD");
+      fs.writeFileSync(cmdCandidate, "@exit 0\r\n");
+      fs.chmodSync(cmdCandidate, 0o755);
+      const accessSpy = vi.spyOn(fs, "accessSync");
+
+      expect(hasBinary("tool")).toBe(true);
+      // Candidates that are not regular files never reach the permission probe.
+      expect(accessSpy.mock.calls.map(([candidate]) => String(candidate))).toEqual([cmdCandidate]);
+
+      vi.stubEnv("PATHEXT", ".EXE");
+      expect(hasBinary("tool")).toBe(false);
+      vi.stubEnv("PATHEXT", ".CMD");
+      expect(hasBinary("tool")).toBe(true);
     });
-
-    expect(hasBinary("tool")).toBe(true);
-    expect(accessSpy.mock.calls.map(([candidate]) => String(candidate))).toEqual([
-      plainCandidate,
-      exeCandidate,
-      cmdCandidate,
-    ]);
-
-    vi.stubEnv("PATHEXT", ".EXE");
-    expect(hasBinary("tool")).toBe(false);
-    vi.stubEnv("PATHEXT", ".CMD");
-    expect(hasBinary("tool")).toBe(true);
   });
 
   it.each([
@@ -169,6 +163,44 @@ describe("config-eval helpers", () => {
       });
     },
   );
+
+  it.each([
+    { platform: "linux", suffix: "" },
+    { platform: "darwin", suffix: "" },
+    { platform: "win32", suffix: ".CMD" },
+  ] as const)(
+    "reports a $platform PATH directory named like the binary as missing",
+    ({ platform, suffix }) => {
+      withTempDirSync({ prefix: "openclaw-binary-dir-" }, (binDir) => {
+        mockProcessPlatform(platform);
+        vi.stubEnv("PATH", binDir);
+        vi.stubEnv("PATHEXT", ".EXE;.CMD");
+        const candidate = path.join(binDir, `fixture-tool${suffix}`);
+        fs.mkdirSync(candidate);
+        // A searchable directory passes X_OK, which is what used to make it look installed.
+        expect(fs.accessSync(candidate, fs.constants.X_OK)).toBeUndefined();
+
+        expect(hasBinary("fixture-tool")).toBe(false);
+      });
+    },
+  );
+
+  it("accepts a PATH symlink pointing at an executable file", () => {
+    withTempDirSync({ prefix: "openclaw-binary-symlink-" }, (root) => {
+      mockProcessPlatform("linux");
+      const binDir = path.join(root, "bin");
+      const targetDir = path.join(root, "target");
+      fs.mkdirSync(binDir);
+      fs.mkdirSync(targetDir);
+      const target = path.join(targetDir, "fixture-tool");
+      fs.writeFileSync(target, "#!/bin/sh\nexit 0\n");
+      fs.chmodSync(target, 0o755);
+      fs.symlinkSync(target, path.join(binDir, "fixture-tool"));
+      vi.stubEnv("PATH", binDir);
+
+      expect(hasBinary("fixture-tool")).toBe(true);
+    });
+  });
 });
 
 describe("runtime requirements through eligibility", () => {

--- a/src/shared/config-eval.ts
+++ b/src/shared/config-eval.ts
@@ -1,6 +1,7 @@
 // Config evaluation helpers load dynamic config modules with guarded evaluation.
 import fs from "node:fs";
 import path from "node:path";
+import { isRegularFile } from "../infra/executable-path.js";
 import { isBlockedObjectKey } from "../infra/prototype-keys.js";
 
 /** Normalizes primitive config values into the truthiness rules used by requirements checks. */
@@ -178,6 +179,11 @@ export function hasBinary(bin: string): boolean {
   for (const part of parts) {
     for (const ext of extensions) {
       const candidate = path.join(part, bin + ext);
+      // X_OK also succeeds for searchable directories, so a PATH entry holding a
+      // directory named like the binary would otherwise be reported available.
+      if (!isRegularFile(candidate)) {
+        continue;
+      }
       try {
         fs.accessSync(candidate, fs.constants.X_OK);
         hasBinaryCache.add(bin);


### PR DESCRIPTION
## What Problem This Solves

Fixes: skills and hooks are reported as ready, and offered to the agent, when `PATH` contains a directory named exactly like a binary they require but no such executable is installed.

## User Impact

A skill or hook whose required binary is only matched by a same-named directory on `PATH` is now reported as missing that binary, both in `openclaw skills check` and in the skill set prepared at agent startup, instead of being offered to the agent and failing when it runs the tool. The Gmail watcher start check and skill-install prerequisite checks see the same corrected answer. Real executables, including symlinks to them, resolve as before. No config, schema or persisted state changes.

## Why This Change Was Made

Both binary probes in `src/shared/config-eval.ts` accepted any `PATH` candidate that passed an `X_OK` access check, and `X_OK` also succeeds for a searchable directory. The positive result was also cached until `PATH` or `PATHEXT` changed.

- `hasBinary` (synchronous: skill and hook status, `skills check`, Gmail watcher, install prerequisites) now requires `fs.statSync(candidate, { throwIfNoEntry: false })?.isFile()` before the permission probe. This replaces the non-Windows `existsSync` skip added in https://github.com/openclaw/openclaw/pull/145175 and keeps its intent: a missing candidate still produces no thrown error, and that now applies on every platform.
- `prepareBinaryAvailability` (asynchronous, used by skill loading at agent startup since https://github.com/openclaw/openclaw/pull/146373) runs `stat` only after `access` succeeds and requires a regular file. Both calls run inside the shared in-flight probe added in https://github.com/openclaw/openclaw/pull/149791, so concurrent preparations of the same candidate still share one `access` and one `stat`, and the entry is still evicted once settled. A missing tool still costs one `access` call per candidate, which is the bounded-IO contract its loader tests pin.

Both checks follow symlinks, the same rule `isExecutableFile` in `src/infra/executable-path.ts` applies for the other executable resolvers. The `PATH` / `PATHEXT` candidate loop and both caches are unchanged.

## Evidence

**Real CLI, before and after.** Command: `openclaw skills check --json` (run through `pnpm openclaw`). Fixture: a workspace skill with `requires.bins: ["fixture-gog-tool"]`, and a first `PATH` entry holding a directory named `fixture-gog-tool`, with no executable of that name anywhere (`command -v fixture-gog-tool` finds nothing). Config, state and home directories were isolated. No Gateway, network or credentials were used. The After rows were run on this head (`ca2c1c2213a`, clean tree). The Before row was run on the previous base `85ee6a57f09`, where the branch differed from `upstream/main` only in `src/shared/config-eval.ts` and its test, by swapping that one runtime file for the `upstream/main` copy.

| Run | `fixture-gog-skill` in `eligible` / `modelVisible` / `commandVisible` | `missingRequirements` entry |
| --- | --- | --- |
| Before (`upstream/main` owner file), directory on `PATH` | yes / yes / yes | none |
| After (this head), same directory on `PATH` | no / no / no | `{"bins": ["fixture-gog-tool"], "anyBins": [], "env": [], "config": [], "os": []}` |
| After (this head), directory replaced by a real executable (positive control) | yes / yes / yes | none |

**Regression tests** in `src/shared/config-eval.test.ts`:

- `reports a $platform PATH directory named like the binary as missing` (linux, darwin, win32) for `hasBinary`. Each case first asserts that `fs.accessSync(dir, X_OK)` succeeds, so the test can't pass without exercising the directory case.
- `prepared binary availability > reports a PATH directory named like the binary as missing` for `prepareBinaryAvailability`.
- `accepts a PATH symlink pointing at an executable file`: a control against rejecting valid symlinks.
- The existing `PATHEXT` test also asserts that only the real `tool.CMD` reaches `accessSync`.

Negative control (recorded on the previous base `85ee6a57f09`): with `upstream/main`'s `src/shared/config-eval.ts` and these tests, the result is `Tests 5 failed | 21 passed (26)`. The failures are the three `hasBinary` directory cases, the async directory case (`expected true to be false`) and the `PATHEXT` probe assertion. The symlink control passes there, as a control should.

**Checks on this head** (`ca2c1c2213a`, merged with `upstream/main` `a434e7f53f5`):

- `node scripts/run-vitest.mjs src/shared/config-eval.test.ts src/skills/loading src/hooks/config.test.ts src/hooks/gmail-watcher.test.ts`: all passed (`26`, `285` and `30` tests across the shards). This includes the `workspace-skill-loader` asynchronous preparation suites that pin per-candidate `access` calls across two concurrent preparations, and `keeps concurrent binary preparations independent when one caller is canceled`.
- `node scripts/run-vitest.mjs src/skills/discovery`: `90` tests passed.
- `pnpm tsgo:core` and `pnpm tsgo:core:test`: exit 0.
- `oxlint` and `oxfmt --check` on the changed files: clean.
- `pnpm check:max-lines-ratchet --base upstream/main`: OK.

**CI failures on the previous head** `28ab9cf63c2` are outside this change. None of the failing suites imports `src/shared/config-eval.ts`; on that CI base its only importers are `src/hooks/config.ts`, `src/skills/loading/config.ts`, `src/skills/loading/workspace-skill-loader.ts` and two tests.

- `check-additional-runtime-topology-architecture` (Madge cycle between `extensions/slack/src/monitor/ingress.ts` and `thread-resolution.ts`), `check-lint-core-5` (`typescript(unbound-method)` in `extensions/slack/src/monitor/message-handler/dispatch.ts`) and `control-ui-performance` (`startup JS gzip: 354.2 KiB exceeds 354.1 KiB`) fail with the same messages on `main` CI run https://github.com/openclaw/openclaw/actions/runs/35172520113 (`8c959deb59b`).
- `checks-node-compact-small-15`, `-24`, `-26`, `-40` and `-42` fail only in `test/scripts/` PR tooling suites (`worktree-setup`, `pr-operation-lock`, `pr-main-refresh`, `pr-wrappers`, `pr-worktree-provision`) on Git fetch output and module-resolution assertions.
- `checks-node-changed-extensions-bundle-11` fails only in `extensions/qwen/video-generation-provider.test.ts` (`expected 119999 to be 120000`).
- `openclaw/ci-gate` aggregates the failures above.

**Not run.**

- The line-cap growth ratchet inside `node scripts/check-changed.mjs` did not run. It stopped because the local git (2.34) does not support `git cat-file --batch -z`, before checking any file. CI covers this step. The changed files stay well under the cap: 296 and 360 lines.
- Windows and macOS were not exercised on real hosts. The platform test cases use a mocked `process.platform` with a real filesystem.
- The agent-startup path through `prepareBinaryAvailability` was proven with unit tests at the owner, not a live model run.
