### PR TITLE
perf(logging): reuse redaction callbacks within each pattern scan

### DIFF
--- a/src/logging/redact.reentrancy.test.ts
+++ b/src/logging/redact.reentrancy.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { redactSensitiveText } from "../plugin-sdk/security-runtime.js";
+import { redactInputTextWithSourcePolicy } from "./redact.js";
+
+describe("nested redaction calls", () => {
+  it("keeps a programmatic matcher's current input and pattern order across nested calls", () => {
+    const inputs: string[] = [];
+    const nested: string[] = [];
+    const matcher = {
+      source: "bracketed fixture values",
+      *exec(input: string) {
+        inputs.push(input);
+        for (const match of input.matchAll(/\[(outer-[a-z]+)\]/g)) {
+          nested.push(redactSensitiveText("inside private", { patterns: [/private/g] }));
+          yield { match: match[0], groups: [match[1] ?? ""], input, offset: match.index };
+        }
+      },
+    };
+
+    expect(
+      redactSensitiveText("prefix [outer-one] [outer-two] suffix", {
+        patterns: [/prefix/g, matcher, /suffix/g],
+      }),
+    ).toBe("*** [***] [***] ***");
+    expect(inputs).toEqual(["*** [outer-one] [outer-two] suffix"]);
+    expect(nested).toEqual(["inside ***", "inside ***"]);
+  });
+
+  it("keeps each source assignment policy active after it performs nested redaction", () => {
+    const input = "API_TOKEN=computeFirst()\nAPI_TOKEN=computeSecond()";
+    const assignments: string[] = [];
+
+    expect(
+      redactInputTextWithSourcePolicy(input, undefined, (text, offset) => {
+        expect(redactSensitiveText("inside private", { patterns: [/private/g] })).toBe(
+          "inside ***",
+        );
+        assignments.push(text.slice(offset).split("\n")[0] ?? "");
+        return true;
+      }),
+    ).toBe(input);
+    expect(assignments).toEqual(expect.arrayContaining(["computeFirst()", "computeSecond()"]));
+  });
+});

--- a/src/logging/redact.ts
+++ b/src/logging/redact.ts
@@ -668,14 +668,15 @@ export function redactText(
   let next = redactFormBody(
     redactAssignmentValues(redactStructuredAuthHeaders(text, "***"), "url"),
   );
-  for (const pattern of patterns) {
-    const replace = (match: RedactMatch) =>
-      redactMatch(match, pattern, options?.preserveSourceAssignment);
+  let pattern: ResolvedRedactPattern;
+  const replace = (match: RedactMatch) =>
+    redactMatch(match, pattern, options?.preserveSourceAssignment);
+  const replaceRegex = (...args: unknown[]) => replace(readRedactMatch(args));
+  // Each replacement finishes synchronously before this invocation advances its pattern.
+  for (pattern of patterns) {
     next =
       pattern instanceof RegExp && !options?.fullContext && !chunkUnsafePatterns.has(pattern)
-        ? replacePatternBounded(next, pattern, (...args: unknown[]) =>
-            replace(readRedactMatch(args)),
-          )
+        ? replacePatternBounded(next, pattern, replaceRegex)
         : replaceRedactPattern(next, pattern, replace);
   }
   return next;


### PR DESCRIPTION
Diagnostic support snapshots create replacement closures for every redaction pattern and every string. Create those callbacks once per `redactText` invocation and reuse them as its local pattern cursor advances. Matching remains synchronous, so nested calls keep independent cursors and source-policy state. Pattern selection, masking, ordering, chunking, and full-context behavior are unchanged.

The actual `sanitizeSupportSnapshotValue` entry point processes 1,000 synthetic worker rows across 10 snapshots. Sampled allocation falls from 1,624.0 MB to 438.7 MB (73.0%); the `redactText` subtree falls from 1,501.5 MB to 312.2 MB (79.2%). Complete snapshot output hashes match, as do public SDK, bounded/full-context, and source-policy controls. This measures temporary allocation in that workload, not a retained leak or whole-Gateway saving.

Validation:
- All 262 selected tests pass across redaction, structured properties, token ordering, support snapshots, file logging, and nested calls.
- Both new nested matcher/source-policy preservation tests pass against the original production source too.
- Targeted lint over both changed files, formatting, and `git diff --check` pass. Changed-lane classification selects core and core tests.
- Aggregate local checks were not run after host resource exhaustion; exact-head hosted CI run 34705122570 passed on attempt 2. Its first attempt timed out in the unchanged CLI pool-argument rejection test; that case passed in 424 ms on the single diagnostic rerun, with no source, assertion, or timeout changes.
- Independent P0–P2 review completed scoped-clean with no findings.
