### PR TITLE
perf(sessions): reuse stable parser prefixes

### DIFF
--- a/packages/session-url-contract/src/session-key.ts
+++ b/packages/session-url-contract/src/session-key.ts
@@ -10,7 +10,7 @@ export type ParsedAgentSessionKey = {
 
 /** Split the ownership head without changing opaque tail bytes or empty tail segments. */
 export function parseAgentSessionKeyParts(sessionKey: string): ParsedAgentSessionKey | null {
-  if (sessionKey.slice(0, 6).toLowerCase() !== "agent:") {
+  if (!sessionKey.startsWith("agent:") && sessionKey.slice(0, 6).toLowerCase() !== "agent:") {
     return null;
   }
   const agentIdEnd = sessionKey.indexOf(":", 6);

--- a/src/sessions/session-key-utils.ts
+++ b/src/sessions/session-key-utils.ts
@@ -67,6 +67,10 @@ const CASE_PRESERVING_PEERS: readonly CasePreservingPeerDescriptor[] = [
   { channel: "matrix", peerKinds: new Set(["channel", "group"]), span: "tail", unscoped: true },
 ];
 
+const CASE_PRESERVING_PEER_PREFIXES = CASE_PRESERVING_PEERS.map(
+  (descriptor) => `${descriptor.channel}:`,
+);
+
 const CASE_PRESERVING_PEER_PATTERNS = CASE_PRESERVING_PEERS.flatMap((descriptor) =>
   [...descriptor.peerKinds].map((peerKind) => {
     const prefix = `${escapeRegExp(descriptor.channel)}:${escapeRegExp(peerKind)}:`;
@@ -155,7 +159,12 @@ function writeNormalizedSessionKeyCache(raw: string, normalized: string): void {
 }
 
 function mayContainCasePreservingPeer(folded: string): boolean {
-  return CASE_PRESERVING_PEERS.some((descriptor) => folded.includes(`${descriptor.channel}:`));
+  for (const prefix of CASE_PRESERVING_PEER_PREFIXES) {
+    if (folded.includes(prefix)) {
+      return true;
+    }
+  }
+  return false;
 }
 
 /**


### PR DESCRIPTION
Session-key parsing repeatedly allocates fixed prefix strings while processing canonical Gateway keys. Accept the canonical `agent:` prefix before the existing mixed-case fallback, and prepare the two opaque-peer channel prefixes from the existing registry once. The shared ownership splitter, opaque-tail rules, and bounded normalization-cache behavior retain their existing contracts.

A focused comparison against `86b278d43c0352db8bd38667d962f46fca1a6b4c` ran 100,000 public parser calls over 1,000 synthetic inventory keys. Sampled core-parser allocations fell from 33,738,952 to 14,613,016 bytes (56.7%). Separate raw-parser and normalization samples fell 34.5% and 74.8%; these phases overlap and are not additive. This is entry-point allocation evidence, not a whole-Gateway or retained-memory measurement.

Validation:

- 360 existing routing, opaque-case, shared URL build/parse, and UI parser tests passed.
- All 135 baseline/candidate contract outputs and the inventory checksum match, including 32 prefix casing variants, malformed and nested owners, legacy and qualified keys, Matrix/Signal opaque IDs, and lengths around 4,096 characters.
- The same public/raw, core, UI, and URL outputs remain stable after 2,200 opaque keys exercise the existing bounded cache.
- Formatting, diff checks, and scoped lint passed. Fresh canonical P0-P2 autoreview is scoped-clean with no actionable findings.

The initial CI failure was the unchanged gateway-other test-root guard (701 roots versus its 700 limit). This branch now includes the existing main repair from #146194; the reviewed two-file optimization is patch-identical after rebase, and its owner files were unchanged between bases. Exact-head CI run 34707700998 passed, including the formerly failing capacity shard.
