### PR TITLE
fix(ui): remove redundant queued message notice

### DIFF
--- a/docs/concepts/queue-steering.md
+++ b/docs/concepts/queue-steering.md
@@ -66,9 +66,9 @@ browsers. The running turn keeps its original approval destination. A different
 browser identity alone does not defer the message, but changes to permissions,
 execution policy, workspace, or bound tools can require a followup turn.
 
-The Control UI labels accepted messages that are still waiting for the agent as
-queued. A visible message or send acknowledgment does not mean the active runtime
-has consumed it.
+A visible message or send acknowledgment does not mean the active runtime has
+consumed it. The Control UI shows specific notices when an accepted message is
+waiting for worker setup or workspace sync.
 
 Use `followup` or `collect` when you want messages to queue by default instead of steering the active run. Use `interrupt` when the newest prompt should replace the active run.
 

--- a/test/tsconfig/tsconfig.core.test.gateway-other.json
+++ b/test/tsconfig/tsconfig.core.test.gateway-other.json
@@ -4,8 +4,6 @@
     "tsBuildInfoFile": "../../.artifacts/tsgo-cache/core-test-gateway-other.tsbuildinfo"
   },
   "include": [
-    "../../src/gateway/session-*.test.ts",
-    "../../src/gateway/session-*.test.tsx",
     "../../src/gateway/*/**/*.test.ts",
     "../../src/gateway/*/**/*.test.tsx"
   ]

--- a/test/tsconfig/tsconfig.core.test.gateway-root.json
+++ b/test/tsconfig/tsconfig.core.test.gateway-root.json
@@ -8,8 +8,6 @@
     "../../src/gateway/*.test.tsx"
   ],
   "exclude": [
-    "../../src/gateway/session-*.test.ts",
-    "../../src/gateway/session-*.test.tsx",
     "../../src/gateway/server*.test.ts",
     "../../src/gateway/server*.test.tsx"
   ]

--- a/ui/src/e2e/new-session-page.github-projects.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.github-projects.e2e.test.ts
@@ -381,11 +381,9 @@ suite.define(() => {
       });
       await gateway.resolveDeferred("chat.startup");
       await expect.poll(() => metadataRequested).toBe(true);
-      await expect
-        .poll(async () => (await page.locator(".chat-notice").textContent())?.trim())
-        .toBe("Queued · waiting for the agent");
       const working = page.locator('.chat-working-indicator[role="status"]');
       await pollLocatorText(working).toContain("Preparing workspace…");
+      expect(await page.locator(".chat-notice").count()).toBe(0);
       if (artifactDir) {
         await writeFile(
           path.join(artifactDir, "preparing.png"),

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -5425,7 +5425,6 @@ export const en: TranslationMap & {
         "Use arrow keys or Home and End to choose a marker, Enter or Space to jump, and Escape to return to the conversation. Tab leaves the rail.",
     },
     pendingInputs: {
-      waitingForAgent: "Queued · waiting for the agent",
       waitingForWorkspaceSync: "Received · waiting for workspace sync",
       waitingForWorkerSetup: "Received · waiting for worker setup",
       resuming:

--- a/ui/src/pages/chat/chat-pending-inputs.test.ts
+++ b/ui/src/pages/chat/chat-pending-inputs.test.ts
@@ -96,7 +96,7 @@ describe("server-owned pending input display", () => {
   });
 
   it.each([
-    { state: "queued", runId: undefined, notice: "Queued · waiting for the agent" },
+    { state: "queued", runId: undefined, notice: undefined },
     {
       state: "interrupted",
       runId: "run-queued",
@@ -868,7 +868,7 @@ describe("server-owned pending input display", () => {
     });
   });
 
-  it("labels unconsumed input as queued between its acceptance time and later output", () => {
+  it("keeps unconsumed input in order without a generic queue notice", () => {
     const earlier = { role: "assistant", content: "Earlier reply", timestamp: 50 };
     const later = { role: "assistant", content: "Later reply", timestamp: 150 };
     const items = buildChatItems({
@@ -890,11 +890,6 @@ describe("server-owned pending input display", () => {
         kind: "group",
         role: "user",
         messages: [{ message: { content: "Keep my accepted input" } }],
-      },
-      {
-        kind: "notice",
-        timestamp: input.acceptedAt,
-        text: "Queued · waiting for the agent",
       },
       { kind: "group", role: "assistant", messages: [{ message: later }] },
     ]);

--- a/ui/src/pages/chat/chat-pending-inputs.ts
+++ b/ui/src/pages/chat/chat-pending-inputs.ts
@@ -64,18 +64,18 @@ export function buildPendingInputItems(
       ),
     );
     if (input.state === "queued") {
-      items.push({
-        kind: "notice",
-        key: `pending-input:${input.id}:state`,
-        timestamp: input.acceptedAt,
-        text: t(
-          input.runId && (workerSetupPending || workspaceSyncPendingRunIds.includes(input.runId))
-            ? workerSetupPending
+      if (input.runId && (workerSetupPending || workspaceSyncPendingRunIds.includes(input.runId))) {
+        items.push({
+          kind: "notice",
+          key: `pending-input:${input.id}:state`,
+          timestamp: input.acceptedAt,
+          text: t(
+            workerSetupPending
               ? "chat.pendingInputs.waitingForWorkerSetup"
-              : "chat.pendingInputs.waitingForWorkspaceSync"
-            : "chat.pendingInputs.waitingForAgent",
-        ),
-      });
+              : "chat.pendingInputs.waitingForWorkspaceSync",
+          ),
+        });
+      }
       continue;
     }
     items.push({

--- a/ui/src/pages/chat/chat-thread.test.ts
+++ b/ui/src/pages/chat/chat-thread.test.ts
@@ -179,9 +179,7 @@ it("invalidates cached custody notices when workspace sync ownership changes", (
   expect(waiting.filter((item) => item.kind === "notice").map((item) => item.text)).toEqual([
     "Received · waiting for workspace sync",
   ]);
-  expect(active.filter((item) => item.kind === "notice").map((item) => item.text)).toEqual([
-    "Queued · waiting for the agent",
-  ]);
+  expect(active.filter((item) => item.kind === "notice")).toEqual([]);
 });
 
 function queuedSend(


### PR DESCRIPTION
Related: #144694

## What Problem This Solves

Fixes an issue where users waiting for an agent would see an unhelpful “Queued · waiting for the agent” line in the conversation, including alongside a more specific startup indicator such as “Preparing workspace…”.

## Why This Change Was Made

Remove the generic queued-message notice and its unused English string. Keep the specific worker setup and workspace sync notices, interruption and cancellation feedback, and existing message delivery behavior. Update the queue documentation and existing rendering and browser assertions.

Initial CI exposed an unrelated test-shard capacity regression from main. Return top-level Gateway session tests to the existing `gateway-root` graph, which has space following the server-test split. This two-file rebalance preserves all test coverage, graph identities, cache paths, compiler concurrency, and the existing limits.

## User Impact

The chat stays cleaner while messages wait, with the actual startup progress still visible. Pending messages and attachments continue to appear once and retain their order.

## Evidence

- 308 focused pending-input and chat-thread tests passed. Three updated assertions failed on the original code because it rendered the generic notice.
- All five GitHub-project browser scenarios passed, covering project/worktree startup, attachment continuity, canonical message promotion, and actionable preparation failures.
- `node scripts/check-changed.mjs` passed, including core-test/UI type checks, i18n verification, formatting, dead-export scans, and scoped lint.
- All 24 shard-owner tests passed after the rebalance; the 308 UI tests and five browser scenarios also passed again on the refreshed base.
- The existing shard inventory regression reproduced the baseline failure (`gateway-other: 701 test roots exceeds the 700 limit`). After moving the complete 81-test session family, Gateway other/root/server inventories are 620/416/318, with all 10,077 canonical test roots assigned exactly once across 18 graphs.
- Independent review found no actionable P0–P2 findings.
- Inspected synthetic browser captures below show the same preparation state before and after the change.

| Before | After |
| --- | --- |
| ![Before: generic queue notice above workspace progress](https://github.com/user-attachments/assets/9ca5a018-cef2-4d5e-8511-e4d79dabb370) | ![After: workspace progress without the generic notice](https://github.com/user-attachments/assets/15e9a59c-c7b0-49b1-99d3-9cdeb0aa0450) |

Initial CI run [34705371165](https://github.com/openclaw/openclaw/actions/runs/34705371165/job/103584472843) failed the pre-existing Gateway test-root capacity check above; this is why the small shard rebalance is included.

Final exact-head CI for `ebe742afe0d1ed54a756c49cedbe4d3589185923` passed in [run 34706234734](https://github.com/openclaw/openclaw/actions/runs/34706234734); the watcher returned `GREEN` with zero pending checks. The refreshed ClawSweeper review found no actionable issues and accepted the visual proof.
