### PR TITLE
fix(update): finish Doctor repairs for older state databases

### DIFF
--- a/docs/reference/database-schemas/state-schema-history.md
+++ b/docs/reference/database-schemas/state-schema-history.md
@@ -129,6 +129,8 @@ Stop older writers and create a verified, WAL-aware backup before upgrading. Bui
 
 Schema 13 makes `cron_jobs.job_json`, `cron_jobs.state_json`, and `subagent_runs.payload_json` the canonical records. Physical columns remain only where production queries, ordering, or runtime-only updates require them. Cron jobs shrink from 75 columns to 15, and subagent runs shrink from 59 columns to six. Migration preserves failure-destination fields explicitly configured as undefined by encoding them as JSON `null`; it also normalizes legacy run-status aliases into `state_json` before removing the redundant projections.
 
+Workspace attestations merge into `workspace_setup_state`. Migration preserves attestation timestamps and generated bootstrap hashes when older databases have no `workspace_path_aliases` table. Attestation-only workspaces retain a null path until the workspace is encountered again.
+
 The shared-state `auth_profile_stores` and `auth_profile_state` singletons move into `config_machine_state` under `authProfiles.store` and `authProfiles.state`; per-agent auth tables remain unchanged. Because these rows contain credentials, secret-redacted Git backups omit the `authProfiles.` machine-state prefix.
 
 ### State schema 11

--- a/docs/reference/database-schemas/state-schema-history.md
+++ b/docs/reference/database-schemas/state-schema-history.md
@@ -8,6 +8,8 @@ title: "State schema history"
 
 ## State schema history
 
+Doctor completes recognized schema-1 databases that predate the audit ledger before later workspace and agent checks run. Missing ownership metadata or a missing audit ledger at schema 2 or newer still prevents repair.
+
 | Version | Change                                                                                                                                                                                                                                                                                                                          | First release       |
 | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------- |
 | 1       | Initial shared state database                                                                                                                                                                                                                                                                                                   | `v2026.5.30-beta.1` |

--- a/src/state/openclaw-state-db-schema-v13-widerow.ts
+++ b/src/state/openclaw-state-db-schema-v13-widerow.ts
@@ -159,13 +159,16 @@ export function migrateJsonCanonicalWideRowsV13(
     // Attestation-only workspaces borrow their path from an alias when one
     // exists; the legacy attestation table never stored a path, so orphans
     // keep a NULL path and heal it when the workspace next appears.
+    const workspacePath = tableExists(db, "workspace_path_aliases")
+      ? `(SELECT alias.workspace_path FROM workspace_path_aliases alias
+           WHERE alias.workspace_key = a.workspace_key LIMIT 1)`
+      : "NULL";
     db.exec(`
       INSERT INTO workspace_setup_state (
         workspace_key, workspace_path, attested_at_ms, attestation_updated_at_ms
       )
       SELECT a.workspace_key,
-             (SELECT alias.workspace_path FROM workspace_path_aliases alias
-               WHERE alias.workspace_key = a.workspace_key LIMIT 1),
+             ${workspacePath},
              a.attested_at_ms,
              a.updated_at_ms
         FROM workspace_attestations a

--- a/src/state/openclaw-state-db.test.ts
+++ b/src/state/openclaw-state-db.test.ts
@@ -2489,9 +2489,14 @@ describe("openclaw state database", () => {
     },
   );
 
-  it.each(["runtime open", "doctor repair"] as const)(
-    "migrates v12 wide rows to canonical JSON through %s without changing hydrated jobs",
-    (migrationPath) => {
+  it.each([
+    { migrationPath: "runtime open", hasPathAliases: true },
+    { migrationPath: "doctor repair", hasPathAliases: true },
+    { migrationPath: "runtime open", hasPathAliases: false },
+    { migrationPath: "doctor repair", hasPathAliases: false },
+  ] as const)(
+    "migrates legacy wide rows through $migrationPath with path aliases $hasPathAliases without changing hydrated jobs",
+    ({ migrationPath, hasPathAliases }) => {
       const stateDir = createTempStateDir();
       const options = { env: { OPENCLAW_STATE_DIR: stateDir } };
       const databasePath = materializeCurrentStateDatabase(stateDir);
@@ -2621,13 +2626,22 @@ describe("openclaw state database", () => {
       insertLegacyAttestation.run("wk-setup", 1_000, 1_100);
       insertLegacyAttestation.run("wk-alias", 2_000, 2_100);
       insertLegacyAttestation.run("wk-orphan", 3_000, 3_100);
-      legacy
-        .prepare(
-          `INSERT INTO workspace_path_aliases (
-             alias_key, alias_path, workspace_key, workspace_path, updated_at_ms
-           ) VALUES (?, ?, ?, ?, ?)`,
-        )
-        .run("wk-alias-link", "/tmp/wk-alias-link", "wk-alias", "/tmp/wk-alias", 2_200);
+      if (hasPathAliases) {
+        legacy
+          .prepare(
+            `INSERT INTO workspace_path_aliases (
+               alias_key, alias_path, workspace_key, workspace_path, updated_at_ms
+             ) VALUES (?, ?, ?, ?, ?)`,
+          )
+          .run("wk-alias-link", "/tmp/wk-alias-link", "wk-alias", "/tmp/wk-alias", 2_200);
+      } else {
+        legacy.exec(`
+          DROP TABLE workspace_path_aliases;
+          PRAGMA user_version = 1;
+          UPDATE schema_meta SET schema_version = 1, app_version = '2026.6.35'
+           WHERE meta_key = 'primary';
+        `);
+      }
       const insertLegacyHash = legacy.prepare(
         "INSERT INTO workspace_generated_bootstrap_hashes (workspace_key, filename, sha256) VALUES (?, ?, ?)",
       );
@@ -2661,6 +2675,12 @@ describe("openclaw state database", () => {
       if (migrationPath === "doctor repair") {
         expect(repairOpenClawStateDatabaseSchema(options)).toEqual({
           changes: [
+            ...(!hasPathAliases
+              ? [
+                  "Migrated cloud worker placements to execution modes",
+                  "Migrated shared state session watch cursors → provenance column (0 ambient, 0 sentinels removed)",
+                ]
+              : []),
             "Consolidated shared state tables (v13)",
             "Qualified historical cron creator attribution as unknown (v14)",
           ],
@@ -2811,7 +2831,7 @@ describe("openclaw state database", () => {
       ).toEqual([
         {
           workspace_key: "wk-alias",
-          workspace_path: "/tmp/wk-alias",
+          workspace_path: hasPathAliases ? "/tmp/wk-alias" : null,
           version: null,
           bootstrap_seeded_at: null,
           setup_completed_at: null,

--- a/src/state/openclaw-state-db.test.ts
+++ b/src/state/openclaw-state-db.test.ts
@@ -5860,32 +5860,81 @@ INSERT INTO macos_port_guardian_records VALUES (4242, 18789, '/usr/bin/ssh', 're
     }
   });
 
-  it("lets normal open create an audit ledger for a pre-v2 database", () => {
-    const stateDir = createTempStateDir();
-    const databasePath = createLegacyAuditStateDatabase(stateDir);
-    const options = { env: { OPENCLAW_STATE_DIR: stateDir } };
-    const { DatabaseSync } = requireNodeSqlite();
-    const legacy = new DatabaseSync(databasePath);
-    legacy.exec("DROP TABLE audit_events");
-    legacy.close();
+  it.each(["runtime open", "doctor repair"] as const)(
+    "completes a recognized pre-v2 schema through %s before read-only consumers",
+    (migrationPath) => {
+      const stateDir = createTempStateDir();
+      const databasePath = createLegacyAuditStateDatabase(stateDir);
+      const options = { env: { OPENCLAW_STATE_DIR: stateDir } };
+      const { DatabaseSync } = requireNodeSqlite();
+      const legacy = new DatabaseSync(databasePath);
+      legacy.exec(`
+      DROP TABLE audit_events;
+      CREATE TABLE workspace_setup_state (
+        workspace_key TEXT NOT NULL PRIMARY KEY, workspace_path TEXT NOT NULL,
+        version INTEGER NOT NULL, bootstrap_seeded_at TEXT, setup_completed_at TEXT,
+        updated_at INTEGER NOT NULL
+      );
+      INSERT INTO workspace_setup_state VALUES ('legacy-workspace', '/tmp/legacy-workspace', 1,
+        '2026-06-01T00:00:00.000Z', NULL, 100);
+    `);
+      legacy.close();
 
-    expect(detectOpenClawStateDatabaseSchemaMigrations(options)).toEqual([]);
-    expect(repairOpenClawStateDatabaseSchema(options)).toEqual({
-      changes: [],
-      warnings: [],
-    });
-    const beforeOpen = new DatabaseSync(databasePath, { readOnly: true });
-    expect(readSqliteNumberPragma(beforeOpen, "user_version")).toBe(1);
-    beforeOpen.close();
+      expect(detectOpenClawStateDatabaseSchemaMigrations(options)).toEqual([]);
+      if (migrationPath === "doctor repair") {
+        expect(repairOpenClawStateDatabaseSchema(options).warnings).toEqual([]);
+      } else {
+        openOpenClawStateDatabase(options);
+        closeOpenClawStateDatabaseForTest();
+      }
+      const repaired = new DatabaseSync(databasePath, { readOnly: true });
+      try {
+        assertOpenClawStateDatabaseForMaintenance(repaired, { pathname: databasePath });
+        expect(readSqliteNumberPragma(repaired, "user_version")).toBe(
+          OPENCLAW_STATE_SCHEMA_VERSION,
+        );
+        expect(
+          repaired
+            .prepare(
+              "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'audit_events'",
+            )
+            .get(),
+        ).toEqual({ name: "audit_events" });
+        expect(repaired.prepare("SELECT * FROM workspace_setup_state").get()).toMatchObject({
+          workspace_key: "legacy-workspace",
+          workspace_path: "/tmp/legacy-workspace",
+          version: 1,
+          bootstrap_seeded_at: "2026-06-01T00:00:00.000Z",
+          updated_at: 100,
+        });
+      } finally {
+        repaired.close();
+      }
+      expect(listOpenClawRegisteredAgentDatabases(options)).toEqual([]);
+    },
+  );
 
-    const opened = openOpenClawStateDatabase(options);
-    expect(
-      opened.db
-        .prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'audit_events'")
-        .get(),
-    ).toEqual({ name: "audit_events" });
-    expect(readSqliteNumberPragma(opened.db, "user_version")).toBe(OPENCLAW_STATE_SCHEMA_VERSION);
-  });
+  it.each(["missing", "foreign"] as const)(
+    "does not claim pre-v2 state with %s ownership metadata",
+    (ownership) => {
+      const stateDir = createTempStateDir();
+      const databasePath = createLegacyAuditStateDatabase(stateDir);
+      const { DatabaseSync } = requireNodeSqlite();
+      const legacy = new DatabaseSync(databasePath);
+      legacy.exec("DROP TABLE audit_events;");
+      legacy.exec(
+        ownership === "missing"
+          ? "DROP TABLE schema_meta;"
+          : "UPDATE schema_meta SET role = 'agent', agent_id = 'worker-1';",
+      );
+      legacy.close();
+      const before = fs.readFileSync(databasePath);
+      expect(
+        repairOpenClawStateDatabaseSchema({ env: { OPENCLAW_STATE_DIR: stateDir } }).warnings,
+      ).toEqual([expect.stringContaining("expected global")]);
+      expect(fs.readFileSync(databasePath)).toEqual(before);
+    },
+  );
 
   it("refuses to rebuild a noncanonical audit table with unknown data columns", () => {
     const stateDir = createTempStateDir();

--- a/src/state/openclaw-state-db.ts
+++ b/src/state/openclaw-state-db.ts
@@ -50,6 +50,7 @@ import {
 } from "./openclaw-state-db-fast-path.js";
 import {
   assertOpenClawStateDatabaseForMaintenance,
+  assertOpenClawStateDatabaseOwner,
   markCurrentStateSchemaVersion,
   openClawStateMigrationAssertions,
   resolveDatabasePath,
@@ -155,6 +156,10 @@ function repairStateSchema(
         const applied = repairAdmittedSchema();
         applied.push(...recoverOrphanTaskDeliveryRows(db, pathname));
         const previousVersion = readStateSchemaMigrationVersion(db);
+        const preAuditSchema = previousVersion === 1 && !tableExists(db, "audit_events");
+        if (preAuditSchema) {
+          assertOpenClawStateDatabaseOwner(db, { pathname });
+        }
         if (previousVersion === OPENCLAW_STATE_SCHEMA_VERSION) {
           for (const name of verifyAndRepairCanonicalSqliteIndexes(
             db,
@@ -202,7 +207,9 @@ function repairStateSchema(
           );
         }
         assertCanonicalStateSchemaShape(db, pathname);
-        if (tableExists(db, "audit_events")) {
+        // Recognized schema-1 stores predate audit; Doctor must finish their schema
+        // before its later read-only workspace and agent readers can consume it.
+        if (preAuditSchema || tableExists(db, "audit_events")) {
           ensureAdditiveStateColumns(db);
           for (const migration of versionedStateMigrations) {
             if (migration.migrate(db, previousVersion)) {

--- a/test/tsconfig/tsconfig.core.test.gateway-other.json
+++ b/test/tsconfig/tsconfig.core.test.gateway-other.json
@@ -4,8 +4,6 @@
     "tsBuildInfoFile": "../../.artifacts/tsgo-cache/core-test-gateway-other.tsbuildinfo"
   },
   "include": [
-    "../../src/gateway/session-*.test.ts",
-    "../../src/gateway/session-*.test.tsx",
     "../../src/gateway/*/**/*.test.ts",
     "../../src/gateway/*/**/*.test.tsx"
   ]

--- a/test/tsconfig/tsconfig.core.test.gateway-root.json
+++ b/test/tsconfig/tsconfig.core.test.gateway-root.json
@@ -8,8 +8,6 @@
     "../../src/gateway/*.test.tsx"
   ],
   "exclude": [
-    "../../src/gateway/session-*.test.ts",
-    "../../src/gateway/session-*.test.tsx",
     "../../src/gateway/server*.test.ts",
     "../../src/gateway/server*.test.tsx"
   ]


### PR DESCRIPTION
Related: #130466, #108663

<details>
<summary>Additional instructions</summary>

The branch is in this repository and maintainers can edit it directly.

</details>

## What Problem This Solves

Fixes an issue where users updating an existing OpenClaw 2026.6.35 installation would stop in Doctor with agent-registry and workspace errors when their state database predates the audit ledger. Doctor could report successful table retirements while leaving the database at schema 1, so later readers could not use it.

## Why This Change Was Made

The existing schema-repair owner now completes canonical migrations for recognized schema-1 databases before Doctor's read-only consumers run. Global ownership metadata remains required, and missing audit data in schema 2 or newer still refuses repair. The schema-13 migration also preserves attestation-only workspaces when older databases have no workspace alias table.

These are repairs to the existing migration contract. Schema versions and audit collection policy retain their existing meaning.

## User Impact

Older installations can complete Doctor's shared-state repair and continue updating. Workspace setup data, attestation timestamps, and generated bootstrap hashes remain available after migration. Missing or foreign ownership metadata is reported without changing the database.

## Evidence

- Reproduced the failure through a genuine v2026.6.35 Git installation and its installed updater. Candidate build steps passed, but Doctor left legacy state unreadable and the update rolled back.
- Repaired a consistent copy of the captured failed database through normal `openclaw doctor --non-interactive --fix`: Doctor completed, shared schema reached 17, SQLite `quick_check` returned `ok`, and config validation passed. [Blacksmith Testbox backing run](https://github.com/openclaw/openclaw/actions/runs/34701993709).
- A fresh v2026.6.35 source install updated through its own CLI to exact commit `c8bd41dbb4315e9a1242f6914e14412c441cd05f`. Doctor exited 0; the candidate CLI and config validation passed; the checkout stayed clean. Its next update returned `skipped` / `already-current`. [Blacksmith Testbox backing run](https://github.com/openclaw/openclaw/actions/runs/34704372439), wrapper exit 0.
- Eleven focused migration regressions pass locally and on Linux, including read-only readiness after Doctor, preserved workspace data, absent aliases, rejected foreign/missing ownership, and rejected missing newer audit data. The new Doctor readiness case failed before this repair.
- Changed checks passed, including core and core-test typechecking, focused lint, documentation checks, and native/shared schema consistency. These checks validated state-repair tree `78447d69279a03dc17a9888c1e88fca92ea3e8c3`; the subsequent CI-only commit leaves that production change unchanged.
- Independent Codex review found no actionable P0–P2 findings.

The [first PR CI run](https://github.com/openclaw/openclaw/actions/runs/34705372576) also exposed an existing main-branch test inventory overflow: the Gateway “other” typecheck graph had 701 roots against its unchanged 700-root guard. CI merge tree `251faf9ab251deb1439987adaa80d460a462faf8` had the same Gateway graph configuration as its main parent `211ff046c28b28ed91725d3c5bd96c4a59ef7675`. A separate four-line CI repair moves the complete session-test family back to the Gateway root graph, retaining every test exactly once and preserving the limits. The failure reproduced on main; all 24 graph-owner tests, both affected compiler graphs, changed checks, and independent review pass after the rebalance.
