### PR TITLE
perf(agents): skip inactive model runtime policy entries

### DIFF
--- a/src/agents/model-runtime-policy.test.ts
+++ b/src/agents/model-runtime-policy.test.ts
@@ -136,6 +136,34 @@ afterEach(() => {
 });
 
 describe("resolveModelRuntimePolicy", () => {
+  it.each(["alias-only", "inherited", "hidden"])(
+    "keeps wildcard policy when %s has no own enumerable runtime entry",
+    (modelId) => {
+      const models = {
+        "fixture/alias-only": { alias: "display-name" },
+        "fixture/*": { agentRuntime: { id: "wildcard-runtime" } },
+      };
+      Object.setPrototypeOf(models, {
+        "fixture/inherited": { agentRuntime: { id: "inherited-runtime" } },
+      });
+      Object.defineProperty(models, "fixture/hidden", {
+        value: { agentRuntime: { id: "hidden-runtime" } },
+        enumerable: false,
+      });
+      expect(
+        resolveModelRuntimePolicyBase({
+          config: { agents: { defaults: { models } } },
+          provider: "fixture",
+          modelId,
+        }),
+      ).toEqual({
+        policy: { id: "wildcard-runtime" },
+        source: "model",
+        matchedProvider: "fixture",
+      });
+    },
+  );
+
   it.each(["custom", ""])("merges trimmed provider policy entries for provider %j", (provider) => {
     const config: OpenClawConfig = {
       models: {

--- a/src/agents/model-runtime-policy.ts
+++ b/src/agents/model-runtime-policy.ts
@@ -127,11 +127,11 @@ function resolvePolicyMatch(
 }
 
 function modelEntryMatchKind(params: {
-  entry: Pick<ModelDefinitionConfig, "id">;
+  entryId: string;
   provider: string | undefined;
   modelId: string;
 }): ModelEntryMatchKind {
-  const entryId = params.entry.id.trim();
+  const entryId = params.entryId.trim();
   if (entryId === params.modelId) {
     return "exact";
   }
@@ -173,15 +173,21 @@ function resolveAgentModelEntryRuntimePolicy(params: {
   const callerProvider = normalizeProviderId(params.provider ?? "");
   for (const models of modelMaps) {
     const scopeMatches: AgentModelRuntimePolicyMatch[] = [];
-    for (const [key, entry] of Object.entries(models ?? {})) {
+    if (!models) {
+      continue;
+    }
+    for (const key of Object.keys(models)) {
+      const policy = models[key]?.agentRuntime;
+      if (!policy || !hasRuntimePolicy(policy)) {
+        continue;
+      }
       const matches =
         modelEntryMatchKind({
-          entry: { id: key },
+          entryId: key,
           provider: params.provider,
           modelId: modelId ?? "",
         }) === params.matchKind;
-      const policy = entry?.agentRuntime;
-      if (!matches || !policy || !hasRuntimePolicy(policy)) {
+      if (!matches) {
         continue;
       }
       scopeMatches.push({ provider: parseModelCatalogRef(key)?.provider ?? "", policy });
@@ -206,7 +212,8 @@ function resolveModelConfig(params: {
     return undefined;
   }
   return params.providerConfig.models.find(
-    (entry) => modelEntryMatchKind({ entry, provider: params.provider, modelId }) === "exact",
+    (entry) =>
+      modelEntryMatchKind({ entryId: entry.id, provider: params.provider, modelId }) === "exact",
   );
 }
 


### PR DESCRIPTION
Model runtime policy lookup builds an entry tuple and parses the model reference for every configured model, even when that entry only supplies an alias or other settings. Enumerate own model keys and skip entries without a usable runtime policy before matching. Pass the model ID directly to the existing private matcher, and migrate both callers together. Exact, wildcard, provider, agent/default, and ambiguous-match precedence stay unchanged; no cache or public API changes.

A synthetic probe through the public resolveModelRuntimePolicy entry ran 2,000 reads in each of six configurations. With 1,000 model entries and a wildcard runtime, sampled allocation fell from 1,243,645,560 to 37,302,480 bytes (97.0%). With runtime policies on 10% of those entries it fell from 1,186,085,688 to 105,725,368 bytes (91.1%). All six complete output hashes matched; empty and 100-entry configurations also reduced allocations. These are bounded allocation samples. Instrumented small-case timing varied, including a slower empty-map case, so this does not claim general latency, retained-memory, or whole-Gateway improvement.

Validation:

- All 89 focused tests passed across runtime policy, harness policy, runtime aliases, and Copilot routing.
- Three new own-enumerable/wildcard preservation cases also pass the original production source.
- Targeted type-aware lint, formatting, and diff checks passed. Changed-lane planning selects core and core tests.
- Fresh independent P0-P2 review is scoped-clean with no actionable findings.
- Full local aggregate checks remain unrun after earlier host resource exhaustion; exact-head hosted CI run 34707703355 passed.

| Model entries | Individual runtime policies | Seconds before → after | Post-cell RSS MiB before → after |
| --- | --- | --- | --- |
| 0 | None | 0.013974 → 0.035215 | 121.902 → 110.020 |
| 100 | None | 0.156876 → 0.156957 | 130.949 → 114.238 |
| 100 | Every tenth entry | 0.128925 → 0.092535 | 134.418 → 114.770 |
| 1000 | None | 1.332537 → 0.345869 | 164.508 → 122.270 |
| 1000 | Every tenth entry | 1.154469 → 0.471217 | 212.023 → 123.656 |
| 100 | Every entry | 0.071690 → 0.059007 | 211.117 → 124.211 |

Every cell also includes a wildcard runtime policy. Elapsed time covers 2,000 public resolver calls and result collection with allocation sampling active; it excludes setup, warmup, profiler start/stop, validation, hashing, and GC. RSS is sampled after validation, hashing, and explicit GC. The six cells run sequentially in each process, so these are single-pair observations, not peak RSS or isolated retained-memory measurements. The empty-map cell was slower and the 100-entry alias-only cell was effectively unchanged. These measurements do not establish general Gateway throughput or resident-memory improvements.

The initial CI failure was the unchanged gateway-other test-root guard (701 roots versus its 700 limit). This branch now includes the existing main repair from #146194; the reviewed optimization is patch-identical after rebase. Exact-head CI run 34707703355 passed, including the formerly failing capacity shard.
