### PR TITLE
fix(ui): correct overlapping model selection borders

### DIFF
--- a/test/tsconfig/tsconfig.core.test.gateway-other.json
+++ b/test/tsconfig/tsconfig.core.test.gateway-other.json
@@ -4,8 +4,6 @@
     "tsBuildInfoFile": "../../.artifacts/tsgo-cache/core-test-gateway-other.tsbuildinfo"
   },
   "include": [
-    "../../src/gateway/session-*.test.ts",
-    "../../src/gateway/session-*.test.tsx",
     "../../src/gateway/*/**/*.test.ts",
     "../../src/gateway/*/**/*.test.tsx"
   ]

--- a/test/tsconfig/tsconfig.core.test.gateway-root.json
+++ b/test/tsconfig/tsconfig.core.test.gateway-root.json
@@ -8,8 +8,6 @@
     "../../src/gateway/*.test.tsx"
   ],
   "exclude": [
-    "../../src/gateway/session-*.test.ts",
-    "../../src/gateway/session-*.test.tsx",
     "../../src/gateway/server*.test.ts",
     "../../src/gateway/server*.test.tsx"
   ]

--- a/ui/docs/design-system/settings-design.md
+++ b/ui/docs/design-system/settings-design.md
@@ -16,6 +16,7 @@ Every settings surface (the `/settings` takeover pages plus the Plugins/Skills h
 - **Sections are typography, not chrome.** Grouping comes from whitespace + a small uppercase heading — never a card header.
 - **Embedded surfaces keep the rhythm.** A container that hosts sections without `.settings-page`'s centered column (tab panels, split layouts) takes `.settings-stack`; never re-space sections with page-local margin rules.
 - **Exactly one level of elevation.** A group never contains another card, callout, or bordered box. Nested detail uses `.settings-subrows` (indented rows), a stacked row, or a drill-in nav row.
+- **Section notices sit above the group.** Pass alerts through `renderSettingsSection`'s `notice` option so they appear between the heading and the group, with the standard section spacing.
 - **Row anatomy:** left is title (`--control-ui-text-md`, weight 500) over an optional one-line description (muted, sm). Right is exactly one control: toggle, select, segmented, button, plain value, or chevron (nav). Wide editors use `stacked`; controls that move inline only above the narrow-layout breakpoint use `stackedOnNarrow`.
 - **Lists are rows too.** An entity list (plugin, device, session) is a group whose rows carry an action cluster in the control slot — same anatomy as a toggle row.
 

--- a/ui/src/components/settings-ui.ts
+++ b/ui/src/components/settings-ui.ts
@@ -41,6 +41,8 @@ export type SettingsSectionProps = {
   description?: unknown;
   /** Right-aligned inline actions next to the heading (e.g. an Add button). */
   actions?: TemplateResult;
+  /** Section notice above the group, keeping bordered callouts outside the card. */
+  notice?: TemplateResult | typeof nothing;
   /** Extra count shown next to the heading. */
   count?: number;
   /** Marks the group surface as a danger zone. */
@@ -183,7 +185,7 @@ export function renderSettingsSection(props: SettingsSectionProps, rows: unknown
     .join(" ");
   return html`
     <section class="settings-section ${props.carapace ? "oc-settings-section" : ""}">
-      ${header}
+      ${header} ${props.notice ?? nothing}
       <div class=${groupClass}>${rows}</div>
     </section>
   `;

--- a/ui/src/pages/agents/panels-overview.ts
+++ b/ui/src/pages/agents/panels-overview.ts
@@ -254,6 +254,7 @@ export function renderAgentOverview(params: {
     ${renderSettingsSection(
       {
         title: t("agents.overview.modelSelection"),
+        notice: renderPanelRefreshStatus({ status: params.modelCatalogStatus }),
         actions: html`
           <button
             type="button"
@@ -274,9 +275,6 @@ export function renderAgentOverview(params: {
         `,
       },
       html`
-        ${renderPanelRefreshStatus({
-          status: params.modelCatalogStatus,
-        })}
         ${renderSettingsRow({
           title: isDefault
             ? t("agents.overview.primaryModelDefault")


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users viewing Agents → Overview would see colliding rounded borders in Model Selection when the model catalog refresh failed. The warning sat flush inside the selection card and was clipped by its outer border.

## Why This Change Was Made

Settings sections now accept a notice between their heading and group. Model Selection uses that slot for its existing refresh warning, following the settings design's single-surface rule and existing spacing tokens. The status component, primary picker, and fallback controls keep their behavior.

CI exposed an existing main-branch shard-cap failure (701 roots against the 700-root guard). This branch carried a four-line rebalance that preserved coverage and limits. The same rebalance landed in #146194 while validation ran, so the final merge contains only the UI correction and design documentation.

## User Impact

The warning and model card have separate, clean outlines. Sections without notices keep their existing layout.

## Evidence

- Real Chrome rendering of the local Control UI with synthetic data. Error and stale-only notices sit 12px above the card; normal state renders no notice and retains both model rows.
- 29 existing agent-overview and refresh-status tests passed.
- Reproduced the 701-root failure after rebasing onto current main, then passed the existing exact-once coverage check and three partition checks after the rebalance.
- Initial CI passed build, production types, all three UI shards, and seven mocked UI E2E shards. Two unrelated core failures were diagnosed: the shard cap fixed here and a compiler-fixture `ETXTBSY` execution failure. The fresh run passed both affected shards.
- Targeted lint, formatting, and i18n checks passed. Full local changed-check typechecking stopped at the borrowed-dependency boundary; hosted CI supplies isolated typecheck/build proof.
- [Final-head CI](https://github.com/openclaw/openclaw/actions/runs/34706251379) passed, including the required gate, production typechecks, build, UI unit tests, mocked UI E2E, and the real-Gateway UI suite.
- Independent Codex reviews: no actionable P0–P2 findings. ClawSweeper reviewed the final head and inspected the screenshots with no actionable findings.

Before:

![Before: warning border collides with model card](https://github.com/user-attachments/assets/4f144e1a-14ed-4b70-8688-48075a7fb6e2)

After:

![After: warning and model card have separate outlines](https://github.com/user-attachments/assets/d7e5aa17-0a0a-4859-b186-e62f9c164ba3)
