### PR TITLE
refactor(cron): share CLI integer validation

### DIFF
--- a/src/cli/cron-cli/register.cron-add.ts
+++ b/src/cli/cron-cli/register.cron-add.ts
@@ -1,9 +1,5 @@
 // Cron status/list/add command registration and create-payload normalization.
 import {
-  parseStrictNonNegativeInteger,
-  parseStrictPositiveInteger,
-} from "@openclaw/normalization-core/number-coercion";
-import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
   readNonBlankString,
@@ -28,6 +24,8 @@ import {
   parseCronCommandArgv,
   parseCronCommandEnv,
   parseCronFallbacks,
+  parseCronIntegerOption,
+  parseCronNoOutputTimeoutOption,
   parseCronToolsAllow,
   printCronJson,
   printCronList,
@@ -184,18 +182,14 @@ export function registerCronAddCommand(cron: Command) {
                     "Use --script-timeout-seconds for script jobs, not --timeout-seconds.",
                   );
                 }
-                const scriptTimeoutSeconds = parseStrictPositiveInteger(opts.scriptTimeoutSeconds);
-                if (opts.scriptTimeoutSeconds !== undefined && scriptTimeoutSeconds === undefined) {
-                  throw new CronCliError(
-                    "Invalid --script-timeout-seconds (must be a positive integer).",
-                  );
-                }
-                const scriptToolBudget = parseStrictPositiveInteger(opts.scriptToolBudget);
-                if (opts.scriptToolBudget !== undefined && scriptToolBudget === undefined) {
-                  throw new CronCliError(
-                    "Invalid --script-tool-budget (must be a positive integer).",
-                  );
-                }
+                const scriptTimeoutSeconds = parseCronIntegerOption(
+                  opts.scriptTimeoutSeconds,
+                  "--script-timeout-seconds",
+                );
+                const scriptToolBudget = parseCronIntegerOption(
+                  opts.scriptToolBudget,
+                  "--script-tool-budget",
+                );
                 return {
                   kind: "script" as const,
                   timeoutSeconds: scriptTimeoutSeconds,
@@ -204,35 +198,17 @@ export function registerCronAddCommand(cron: Command) {
                   script: await readCronPayloadScript(scriptPath),
                 };
               }
-              const timeoutSeconds = parseStrictNonNegativeInteger(opts.timeoutSeconds);
-              if (opts.timeoutSeconds !== undefined && timeoutSeconds === undefined) {
-                throw new CronCliError(
-                  "Invalid --timeout-seconds (must be a non-negative integer).",
-                );
-              }
+              const timeoutSeconds = parseCronIntegerOption(
+                opts.timeoutSeconds,
+                "--timeout-seconds",
+                "non-negative",
+              );
               if (commandShell || commandArgv) {
-                const rawNoOutputTimeoutSeconds =
-                  opts.noOutputTimeoutSeconds ??
-                  (typeof opts.outputTimeoutSeconds === "string" ||
-                  typeof opts.outputTimeoutSeconds === "number"
-                    ? opts.outputTimeoutSeconds
-                    : undefined);
-                const noOutputTimeoutSeconds =
-                  parseStrictPositiveInteger(rawNoOutputTimeoutSeconds);
-                if (
-                  rawNoOutputTimeoutSeconds !== undefined &&
-                  noOutputTimeoutSeconds === undefined
-                ) {
-                  throw new CronCliError(
-                    "Invalid --no-output-timeout-seconds (must be a positive integer).",
-                  );
-                }
-                const outputMaxBytes = parseStrictPositiveInteger(opts.outputMaxBytes);
-                if (opts.outputMaxBytes !== undefined && outputMaxBytes === undefined) {
-                  throw new CronCliError(
-                    "Invalid --output-max-bytes (must be a positive integer).",
-                  );
-                }
+                const noOutputTimeoutSeconds = parseCronNoOutputTimeoutOption(opts);
+                const outputMaxBytes = parseCronIntegerOption(
+                  opts.outputMaxBytes,
+                  "--output-max-bytes",
+                );
                 return {
                   kind: "command" as const,
                   argv: commandArgv ?? ["sh", "-lc", commandShell ?? ""],

--- a/src/cli/cron-cli/register.cron-edit-options.ts
+++ b/src/cli/cron-cli/register.cron-edit-options.ts
@@ -1,8 +1,4 @@
 import {
-  parseStrictNonNegativeInteger,
-  parseStrictPositiveInteger,
-} from "@openclaw/normalization-core/number-coercion";
-import {
   normalizeOptionalString,
   readNonBlankString,
 } from "@openclaw/normalization-core/string-coerce";
@@ -14,6 +10,8 @@ import {
   parseCronCommandArgv,
   parseCronCommandEnv,
   parseCronFallbacks,
+  parseCronIntegerOption,
+  parseCronNoOutputTimeoutOption,
   parseCronToolsAllow,
 } from "./shared.js";
 import { parseCronThreadIdOption } from "./thread-id-shared.js";
@@ -62,32 +60,19 @@ export async function resolveCronEditPayloadDeliveryPatch(
     throw new CronCliError("Use --fallbacks or --clear-fallbacks, not both");
   }
   const toolsAllow = parseCronToolsAllow(opts.tools);
-  const timeoutSeconds = parseStrictNonNegativeInteger(opts.timeoutSeconds);
+  const timeoutSeconds = parseCronIntegerOption(
+    opts.timeoutSeconds,
+    "--timeout-seconds",
+    "non-negative",
+  );
   const hasTimeoutSeconds = timeoutSeconds !== undefined;
-  if (opts.timeoutSeconds !== undefined && !hasTimeoutSeconds) {
-    throw new CronCliError("Invalid --timeout-seconds (must be a non-negative integer).");
-  }
-  const rawNoOutputTimeoutSeconds =
-    opts.noOutputTimeoutSeconds ??
-    (typeof opts.outputTimeoutSeconds === "string" || typeof opts.outputTimeoutSeconds === "number"
-      ? opts.outputTimeoutSeconds
-      : undefined);
-  const noOutputTimeoutSeconds = parseStrictPositiveInteger(rawNoOutputTimeoutSeconds);
-  if (rawNoOutputTimeoutSeconds !== undefined && noOutputTimeoutSeconds === undefined) {
-    throw new CronCliError("Invalid --no-output-timeout-seconds (must be a positive integer).");
-  }
-  const outputMaxBytes = parseStrictPositiveInteger(opts.outputMaxBytes);
-  if (opts.outputMaxBytes !== undefined && outputMaxBytes === undefined) {
-    throw new CronCliError("Invalid --output-max-bytes (must be a positive integer).");
-  }
-  const scriptTimeoutSeconds = parseStrictPositiveInteger(opts.scriptTimeoutSeconds);
-  if (opts.scriptTimeoutSeconds !== undefined && scriptTimeoutSeconds === undefined) {
-    throw new CronCliError("Invalid --script-timeout-seconds (must be a positive integer).");
-  }
-  const scriptToolBudget = parseStrictPositiveInteger(opts.scriptToolBudget);
-  if (opts.scriptToolBudget !== undefined && scriptToolBudget === undefined) {
-    throw new CronCliError("Invalid --script-tool-budget (must be a positive integer).");
-  }
+  const noOutputTimeoutSeconds = parseCronNoOutputTimeoutOption(opts);
+  const outputMaxBytes = parseCronIntegerOption(opts.outputMaxBytes, "--output-max-bytes");
+  const scriptTimeoutSeconds = parseCronIntegerOption(
+    opts.scriptTimeoutSeconds,
+    "--script-timeout-seconds",
+  );
+  const scriptToolBudget = parseCronIntegerOption(opts.scriptToolBudget, "--script-tool-budget");
 
   const hasWebhookDelivery = Boolean(webhookUrl);
   const hasDeliveryModeFlag =

--- a/src/cli/cron-cli/register.cron-edit.ts
+++ b/src/cli/cron-cli/register.cron-edit.ts
@@ -1,4 +1,3 @@
-import { parseStrictPositiveInteger } from "@openclaw/normalization-core/number-coercion";
 // Cron edit command registration and patch construction for existing jobs.
 import {
   normalizeOptionalLowercaseString,
@@ -27,6 +26,7 @@ import {
 import {
   getCronChannelOptions,
   handleCronCliError,
+  parseCronIntegerOption,
   warnIfCronSchedulerDisabled,
   requireCronJobId,
 } from "./shared.js";
@@ -399,13 +399,10 @@ export function registerCronEditCommand(cron: Command) {
           } else if (failureAlertFlag === true || hasFailureAlertFields) {
             const failureAlert: Record<string, unknown> = {};
             if (hasFailureAlertAfter) {
-              const after = parseStrictPositiveInteger(opts.failureAlertAfter);
-              if (after === undefined) {
-                throw new CronCliError(
-                  "Invalid --failure-alert-after (must be a positive integer).",
-                );
-              }
-              failureAlert.after = after;
+              failureAlert.after = parseCronIntegerOption(
+                opts.failureAlertAfter,
+                "--failure-alert-after",
+              );
             }
             if (hasFailureAlertChannel) {
               failureAlert.channel = normalizeOptionalLowercaseString(opts.failureAlertChannel);

--- a/src/cli/cron-cli/register.cron-simple.ts
+++ b/src/cli/cron-cli/register.cron-simple.ts
@@ -1,7 +1,5 @@
 // Cron simple command registration: remove, toggle, show, runs, and run-now.
 import {
-  parseStrictNonNegativeInteger,
-  parseStrictPositiveInteger,
   resolvePositiveTimerTimeoutMs,
   resolveTimerTimeoutMs,
 } from "@openclaw/normalization-core/number-coercion";
@@ -23,6 +21,7 @@ import {
   enrichCronJsonWithStatus,
   formatCronLookupMiss,
   handleCronCliError,
+  parseCronIntegerOption,
   printCronJson,
   printCronShow,
   requireCronJobId,
@@ -238,15 +237,8 @@ export function registerCronSimpleCommands(cron: Command) {
             );
           }
           const id = requireCronJobId(argId ?? flagId, "Pass it positionally or with --id.");
-          const limit = parseStrictPositiveInteger(opts.limit ?? "50");
-          if (limit === undefined) {
-            throw new CronCliError("Invalid --limit (must be a positive integer).");
-          }
-          const offset =
-            opts.offset === undefined ? undefined : parseStrictNonNegativeInteger(opts.offset);
-          if (opts.offset !== undefined && offset === undefined) {
-            throw new CronCliError("Invalid --offset (must be a non-negative integer).");
-          }
+          const limit = parseCronIntegerOption(opts.limit ?? "50", "--limit");
+          const offset = parseCronIntegerOption(opts.offset, "--offset", "non-negative");
           if (typeof opts.runId === "string" && !opts.runId.trim()) {
             throw new CronCliError("--run-id must not be blank");
           }

--- a/src/cli/cron-cli/shared.ts
+++ b/src/cli/cron-cli/shared.ts
@@ -1,6 +1,8 @@
 // Shared cron CLI formatting, parsing, delivery preview, and warning helpers.
 import {
   MAX_DATE_TIMESTAMP_MS,
+  parseStrictNonNegativeInteger,
+  parseStrictPositiveInteger,
   resolveExpiresAtMsFromDurationMs,
   timestampMsToIsoString,
 } from "@openclaw/normalization-core/number-coercion";
@@ -35,6 +37,31 @@ import { isJsonOutputModeActive } from "../json-output-mode.js";
 import { exitCliAfterOutput } from "../one-shot-exit.js";
 import { parseDurationMs as parseSharedDurationMs } from "../parse-duration.js";
 import { CronCliError } from "./cron-cli-error.js";
+
+export function parseCronIntegerOption(
+  value: unknown,
+  flag: string,
+  kind: "positive" | "non-negative" = "positive",
+): number | undefined {
+  const parsed =
+    kind === "non-negative"
+      ? parseStrictNonNegativeInteger(value)
+      : parseStrictPositiveInteger(value);
+  if (value !== undefined && parsed === undefined) {
+    throw new CronCliError(`Invalid ${flag} (must be a ${kind} integer).`);
+  }
+  return parsed;
+}
+
+export function parseCronNoOutputTimeoutOption(opts: Record<string, unknown>): number | undefined {
+  // Commander strips the leading no- from this option's attribute name.
+  const raw =
+    opts.noOutputTimeoutSeconds ??
+    (typeof opts.outputTimeoutSeconds === "string" || typeof opts.outputTimeoutSeconds === "number"
+      ? opts.outputTimeoutSeconds
+      : undefined);
+  return parseCronIntegerOption(raw, "--no-output-timeout-seconds");
+}
 
 function parseCronArgv(value: unknown, flag: string): string[] | undefined {
   if (typeof value !== "string") {


### PR DESCRIPTION
Closes #146198

## What Problem This Solves

Automation add, edit, and history commands repeat integer validation and flag-specific diagnostics. The no-output timeout also has two copies of its Commander attribute handling, which must stay aligned.

## Why This Change Was Made

Use the existing cron CLI parsing owner for strict positive/non-negative values and error formatting. Share the unchanged no-output attribute fallback. Keep validation at the same call sites so option precedence and errors before Gateway access remain unchanged.

## User Impact

No intended behavior change. Omitted options, explicit zero timeouts and offsets, positive-only limits, default history limits, and error messages are preserved. Removes 26 production code lines (23 physical lines), including the shared implementation. No tests added or removed.

## Evidence

- Four existing CLI suites: 412 tests passed, including invalid numeric forms, zero/omitted timeouts, positive-only limits, history offsets, and failure alerts.
- Complete changed-file checks passed, including typechecks, lint, dependency/boundary guards, dead exports, and import cycles.
- Independent P0–P2 review: no findings. Inspected the strict normalization functions and Commander 15 option attribute naming.
- Isolated CLI/Gateway mock boundaries; no operator Gateway or live state used.
