### PR TITLE
fix(ui): let the system toggle hide isolated heartbeat session rows

### DIFF
--- a/ui/src/lib/session-display.test.ts
+++ b/ui/src/lib/session-display.test.ts
@@ -2,6 +2,7 @@
 import { describe, expect, it } from "vitest";
 import {
   isCronSessionKey,
+  isHeartbeatSessionKey,
   resolveChannelSessionInfo,
   resolveSessionDisplayName,
   resolveSessionWorkContext,
@@ -25,6 +26,23 @@ describe("isCronSessionKey", () => {
     ["", false],
   ] as const)("retains automation classification for %j", (key, expected) => {
     expect(isCronSessionKey(key)).toBe(expected);
+  });
+});
+
+describe("isHeartbeatSessionKey", () => {
+  it.each([
+    ["agent:main:alerts:heartbeat", true],
+    [" AGENT:MAIN:ALERTS:HEARTBEAT ", true],
+    ["agent:architect:discord:channel:1544678697813151804:heartbeat", true],
+    // Wake-triggered re-entry collapses to repeated suffixes.
+    ["agent:main:alerts:heartbeat:heartbeat", true],
+    ["alerts:heartbeat", true],
+    ["agent:main:alerts", false],
+    ["heartbeat", true],
+    ["agent:main:heartbeatwatch", false],
+    ["", false],
+  ] as const)("retains system classification for %j", (key, expected) => {
+    expect(isHeartbeatSessionKey(key)).toBe(expected);
   });
 });
 

--- a/ui/src/lib/session-display.ts
+++ b/ui/src/lib/session-display.ts
@@ -342,6 +342,14 @@ export function isCronSessionKey(key: string): boolean {
   );
 }
 
+// The heartbeat runner keys isolated runs as `<base>:heartbeat` (and repeated
+// suffixes for wake-triggered re-entry), so the trailing segment is a stable
+// routing fact like the cron segment above.
+export function isHeartbeatSessionKey(key: string): boolean {
+  const parts = normalizeLowercaseStringOrEmpty(key).split(":").filter(Boolean);
+  return parts[parts.length - 1] === "heartbeat";
+}
+
 // Wire kinds exclude cron; labels, sorting and grouping share this display classification.
 export function resolveSessionDisplayKind(
   row: GatewaySessionRow,

--- a/ui/src/lib/sessions/navigation.test.ts
+++ b/ui/src/lib/sessions/navigation.test.ts
@@ -441,6 +441,17 @@ describe("isSystemCreatedSessionRow", () => {
       { key: "agent:main:cron:job", createdVia: "cron", createdActor: { type: "system" } },
       false,
     ],
+    [
+      // Heartbeat poll rows carry a derived title, so the provenance checks
+      // alone keep them visible and they eat a limited sidebar slot.
+      "heartbeat run row with a derived label is system",
+      {
+        key: "agent:architect:discord:channel:1544678697813151804:heartbeat",
+        createdVia: "run",
+        label: "discord:g-1544678697813151804-heartbeat",
+      },
+      true,
+    ],
   ] as const)("%s", (_name, fields, expected) => {
     expect(isSystemCreatedSessionRow({ ...base, ...fields } as GatewaySessionRow)).toBe(expected);
   });

--- a/ui/src/lib/sessions/navigation.ts
+++ b/ui/src/lib/sessions/navigation.ts
@@ -5,7 +5,7 @@ import {
 } from "@openclaw/normalization-core/string-coerce";
 import type { GatewayHelloOk } from "../../api/gateway.ts";
 import type { GatewaySessionRow, SessionsListResult } from "../../api/types.ts";
-import { isCronSessionKey } from "../session-display.ts";
+import { isCronSessionKey, isHeartbeatSessionKey } from "../session-display.ts";
 import { parseCatalogSessionKey } from "./catalog-key.ts";
 import {
   isUiGlobalSessionKey,
@@ -176,6 +176,13 @@ export function isSystemCreatedSessionRow(row: GatewaySessionRow): boolean {
   // system actor, so classifying them here would demand both toggles at once.
   if (isCronSessionKey(row.key)) {
     return false;
+  }
+  // Isolated heartbeat runs are machine-created probes that carry derived
+  // labels, so the provenance checks below would keep them visible. A
+  // user-configured base that itself ends in `:heartbeat` hides with them and
+  // returns with the same toggle.
+  if (isHeartbeatSessionKey(row.key)) {
+    return true;
   }
   if (row.createdActor?.type === "system") {
     return true;


### PR DESCRIPTION
## What Problem This Solves

Heartbeat sessions remain visible in the Control UI sidebar when both **System sessions** and **Automation sessions** are hidden. An isolated heartbeat run such as `agent:architect:discord:channel:1544678697813151804:heartbeat` also consumes one of the limited visible session slots before **Show more**.

Closes #146124.

## Root Cause

The heartbeat runner keys isolated runs as `<base>:heartbeat` (plus repeated suffixes for wake-triggered re-entry). The sidebar's System filter classifies rows through `isSystemCreatedSessionRow`, whose provenance checks never match these rows: a heartbeat poll row carries a derived label (for example `discord:g-1544678697813151804-heartbeat`), so the `label`/`displayName` guard keeps it visible regardless of the toggle. Cron rows avoid the same problem because the automation toggle classifies them from the key's `cron` segment; heartbeat rows have no equivalent classification.

## Solution

Add `isHeartbeatSessionKey` next to `isCronSessionKey` in the display-classification owner, and hide heartbeat-keyed rows with the System toggle inside `isSystemCreatedSessionRow` (right after the cron ownership check, which stays untouched).

The trailing `:heartbeat` segment is a stable routing fact stamped by the heartbeat runner, not message text, so it fits the same pattern as the existing cron segment check. A user-configured base session that itself ends in `:heartbeat` hides with these rows and returns with the same toggle; the runner's own base-key guard documents that such keys are valid configuration, and the toggle keeps them reachable.

## Evidence

Pre-fix reproduction through the filter contract: a row with key `agent:architect:discord:channel:1544678697813151804:heartbeat`, `createdVia: "run"`, and label `discord:g-1544678697813151804-heartbeat` (the issue's example metadata) returns `false` from `isSystemCreatedSessionRow`, so `sessionMatchesVisibleSessionScope` keeps it visible with `showSystem: false`. The new test case fails against the unfixed filter:

```
× |ui| isSystemCreatedSessionRow > heartbeat run row with a derived label is system
Tests  1 failed | 26 skipped (27)
```

Post-fix, the same case passes and the full touched suites are green: `ui/src/lib/sessions/navigation.test.ts` and `ui/src/lib/session-display.test.ts` (75/75, including the new `isHeartbeatSessionKey` segmentation cases and the existing cron-ownership and provenance-visibility cases), plus `ui/src/components/app-sidebar-session-navigation-logic.test.ts` for the sidebar filter consumer. `pnpm run tsgo` exits 0 and type-aware oxlint is clean on the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
