### PR TITLE
refactor(gateway): use validated send request types

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2772,7 +2772,7 @@ src/gateway/server-methods/plugin-approval.ts	3
 src/gateway/server-methods/plugin-host-hooks.ts	1
 src/gateway/server-methods/question.ts	2
 src/gateway/server-methods/restart-request.ts	8
-src/gateway/server-methods/send.ts	5
+src/gateway/server-methods/send.ts	2
 src/gateway/server-methods/session-catalog-terminal-start.ts	1
 src/gateway/server-methods/session-catalog.ts	5
 src/gateway/server-methods/session-create-initial-turn.ts	2

--- a/src/gateway/server-methods/send.ts
+++ b/src/gateway/server-methods/send.ts
@@ -13,7 +13,6 @@ import {
   validatePollParams,
   validateSendParams,
 } from "../../../packages/gateway-protocol/src/index.js";
-import type { MessageActionParams } from "../../../packages/gateway-protocol/src/index.js";
 import { sendDurableMessageBatchCore } from "../../channels/message/runtime.js";
 import type { ConversationReadInvocationOrigin } from "../../channels/plugins/conversation-read-origin.js";
 import { resolveChannelDefaultAccountId } from "../../channels/plugins/helpers.js";
@@ -931,12 +930,10 @@ function scheduleDeliveredSourceReplyTranscriptMirror(params: {
 }
 
 export const sendHandlers: GatewayRequestHandlers = {
-  "message.action": async ({ params, respond, context, client }) => {
-    const p = params;
-    if (!assertValidParams(p, validateMessageActionParams, "message.action", respond)) {
+  "message.action": async ({ params: request, respond, context, client }) => {
+    if (!assertValidParams(request, validateMessageActionParams, "message.action", respond)) {
       return;
     }
-    const request = p as MessageActionParams;
     const trustedContext = resolveTrustedMessageActionToolContext({ client, request });
     if (!trustedContext.ok) {
       respond(false, undefined, trustedContext.error);
@@ -1234,32 +1231,10 @@ export const sendHandlers: GatewayRequestHandlers = {
       },
     });
   },
-  send: async ({ params, respond, context, client }) => {
-    const p = params;
-    if (!assertValidParams(p, validateSendParams, "send", respond)) {
+  send: async ({ params: request, respond, context, client }) => {
+    if (!assertValidParams(request, validateSendParams, "send", respond)) {
       return;
     }
-    const request = p as {
-      to: string;
-      message?: string;
-      mediaUrl?: string;
-      mediaUrls?: string[];
-      buffer?: string;
-      filename?: string;
-      contentType?: string;
-      asVoice?: boolean;
-      gifPlayback?: boolean;
-      channel?: string;
-      accountId?: string;
-      agentId?: string;
-      replyToId?: string;
-      threadId?: string;
-      forceDocument?: boolean;
-      silent?: boolean;
-      parseMode?: "HTML";
-      sessionKey?: string;
-      idempotencyKey: string;
-    };
     const to = normalizeOptionalString(request.to) ?? "";
     const message = request.message?.trim() ? request.message : "";
     const mediaUrl = normalizeOptionalString(request.mediaUrl);
@@ -1553,25 +1528,10 @@ export const sendHandlers: GatewayRequestHandlers = {
       },
     });
   },
-  poll: async ({ params, respond, context, client }) => {
-    const p = params;
-    if (!assertValidParams(p, validatePollParams, "poll", respond)) {
+  poll: async ({ params: request, respond, context, client }) => {
+    if (!assertValidParams(request, validatePollParams, "poll", respond)) {
       return;
     }
-    const request = p as {
-      to: string;
-      question: string;
-      options: string[];
-      maxSelections?: number;
-      durationSeconds?: number;
-      durationHours?: number;
-      silent?: boolean;
-      isAnonymous?: boolean;
-      threadId?: string;
-      channel?: string;
-      accountId?: string;
-      idempotencyKey: string;
-    };
     await withMessageOperationRoute({
       context,
       prefix: "poll",


### PR DESCRIPTION
Closes #146200

## What Problem This Solves

The send, poll, and message.action handlers repeat protocol request types after their schema validators have already established those exact types. The extra declarations and casts can conceal drift between handlers and the protocol owner.

## Why This Change Was Made

Use each existing validator type predicate directly, removing two handwritten request declarations, three redundant assertions, and intermediate aliases. Keep each guard and early return in its existing first-action position. Shrink only the send handler assertion-baseline row from five to two.

## User Impact

No intended behavior change. Validation errors, option forwarding, authorization, delivery, and idempotency are preserved. Removes 40 production code/physical lines; no tests added or removed, and no baseline exception added.

## Evidence

- Existing send handler suite: 131 tests passed before and after the cutover, exercising all three handlers.
- Complete changed-file checks passed, including typechecks, lint, assertion ratchet, dead exports, and import guards.
- Independent P0–P2 review: no findings. Reviewed schema-derived validator signatures and the exact baseline shrink.
- Proof uses isolated handler boundaries; no live channel or operator Gateway used.
- CI recovery: the [original hosted job](https://github.com/openclaw/openclaw/actions/runs/34706053148/job/103586309124) failed because its main parent already had 701 gateway-other test roots against the 700-root headroom check. The PR adds no tests. Rebased onto the independently landed shard rebalance in #146194; the two-file reduction is unchanged (`git range-diff` reports `=`). The repaired owner suite (24 tests), send suite (131 tests), and both affected compiler graphs pass; all tests and the 700/720 limits are retained. Fresh exact-head CI passed on the rebased head; native merge completed.
