### PR TITLE
fix(status): avoid database copies during ownership checks

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -3491,7 +3491,6 @@ src/state/openclaw-agent-db-permissions.ts	1
 src/state/openclaw-agent-db-readonly.ts	1
 src/state/openclaw-agent-db-registry-listing.ts	3
 src/state/openclaw-agent-db-registry.ts	7
-src/state/openclaw-agent-db-schema-helpers.ts	1
 src/state/openclaw-agent-db-schema.ts	2
 src/state/openclaw-agent-db-session-migrations.ts	4
 src/state/openclaw-agent-db-session-provenance.ts	2

--- a/docs/cli/status.md
+++ b/docs/cli/status.md
@@ -42,6 +42,18 @@ security audit, plugin compatibility, and memory-vector probes are left to
 `openclaw status --all`, `openclaw status --deep`, `openclaw security audit`,
 and `openclaw memory status --deep`.
 
+Local agent ownership checks read schema and owner metadata from one consistent
+SQLite snapshot, including committed WAL changes. They do not copy the entire
+agent database unless its journal state requires private recovery. Startup and
+migration readiness checks retain their full validation.
+
+The CLI runs in a separate process and contacts the Gateway over WebSocket, even
+for a local loopback target. `--timeout` bounds probes, not the entire status
+command. Compare `openclaw gateway call status --json` with `openclaw status --json`
+to separate the Gateway response from local report collection. Gateway
+[Prometheus RPC timings](/gateway/prometheus) exclude CLI startup and connection
+setup; a slow CLI can finish without a slow Gateway handler.
+
 For Git installs, plain status compares cached remote-tracking refs without a
 network fetch. If the latest recorded update fetch failed and no later update
 run records a completed fetch, the Update row shows

--- a/docs/gateway/prometheus.md
+++ b/docs/gateway/prometheus.md
@@ -178,6 +178,13 @@ They measure elapsed time, not CPU time. Early acknowledgments and responses
 after handler return are distinct from completed agent work. See
 [Gateway RPC timing semantics](/gateway/opentelemetry#gateway-rpc).
 
+Receipt begins after the connected client's request frame passes validation.
+These timings exclude CLI startup, local diagnostics, connection/authentication
+setup, and event-loop delay before request dispatch. Histograms record completed
+observations: an unfinished handler has no handler-duration sample yet. Compare
+request counts, completed timings, and event-loop observations when investigating
+a timeout; low handler latency alone does not establish a responsive client path.
+
 RPC method labels contain canonical core method names, `other` for plugin
 methods, or `unknown`. Outcome totals aggregate by phase and outcome without a
 method dimension. Each method with all four timings occupies five aggregate

--- a/src/infra/sqlite-readonly-location.ts
+++ b/src/infra/sqlite-readonly-location.ts
@@ -628,6 +628,7 @@ function prepareReadOnlySourceSyncInProcess(
 export function readSqliteSchemaHeaderFromSnapshot(
   prepared: PreparedSqliteReadOnlyLocation,
   signal?: AbortSignal,
+  agentSchemaVersionForOwnership?: number,
 ): SqliteSchemaHeader {
   return runWithSqliteCoordinator(
     {
@@ -643,7 +644,7 @@ export function readSqliteSchemaHeaderFromSnapshot(
       const database = openNodeSqliteDatabase(prepared.location, { readOnly: true });
       try {
         setSqliteBusyTimeout(database, OPENCLAW_SQLITE_BUSY_TIMEOUT_MS);
-        return readSqliteSchemaHeader(database);
+        return readSqliteSchemaHeader(database, agentSchemaVersionForOwnership);
       } finally {
         database.close();
       }
@@ -653,7 +654,11 @@ export function readSqliteSchemaHeaderFromSnapshot(
 
 /** Fixed metadata inspection in the read-only child; no payload scan or backup
  * unless source journal state requires private recovery/artifact preservation. */
-export function inspectSqliteSchemaHeaderInProcess(pathname: string, stagingRoot?: string) {
+export function inspectSqliteSchemaHeaderInProcess(
+  pathname: string,
+  stagingRoot?: string,
+  agentSchemaVersionForOwnership?: number,
+) {
   return withSqliteSourceHandleAsync(pathname, async () => {
     const canonicalPath = fs.realpathSync.native(pathname);
     const mode = readSourceJournalMode(canonicalPath);
@@ -664,7 +669,7 @@ export function inspectSqliteSchemaHeaderInProcess(pathname: string, stagingRoot
         return withSqliteSourceReadDatabase(canonicalPath, (database) => {
           try {
             setSqliteBusyTimeout(database, SQLITE_SOURCE_READ_BUSY_TIMEOUT_MS);
-            return readSqliteSchemaHeader(database);
+            return readSqliteSchemaHeader(database, agentSchemaVersionForOwnership);
           } catch (error) {
             readError = error;
             throw error;
@@ -686,7 +691,7 @@ export function inspectSqliteSchemaHeaderInProcess(pathname: string, stagingRoot
     // An incomplete WAL family would create source sidecars on native open.
     // The existing snapshot owner also handles hot rollback recovery privately.
     const prepared = await prepareReadOnlySourceInProcess(canonicalPath, stagingRoot);
-    return readSqliteSchemaHeaderFromSnapshot(prepared);
+    return readSqliteSchemaHeaderFromSnapshot(prepared, undefined, agentSchemaVersionForOwnership);
   });
 }
 

--- a/src/infra/sqlite-readonly-location.worker.ts
+++ b/src/infra/sqlite-readonly-location.worker.ts
@@ -14,6 +14,8 @@ async function runWorker(): Promise<void> {
   const mode = process.argv[3];
   const pathname = process.argv[4];
   const stagingRoot = process.argv[5];
+  const agentSchemaVersionForOwnership =
+    process.argv[6] === undefined ? undefined : Number(process.argv[6]);
   if ((mode !== "sync" && mode !== "async" && mode !== "schema-header") || !pathname) {
     process.exitCode = 1;
     process.stdout.write(
@@ -26,7 +28,18 @@ async function runWorker(): Promise<void> {
   }
   try {
     if (mode === "schema-header") {
-      const header = await inspectSqliteSchemaHeaderInProcess(pathname, stagingRoot);
+      if (
+        agentSchemaVersionForOwnership !== undefined &&
+        (!Number.isSafeInteger(agentSchemaVersionForOwnership) ||
+          agentSchemaVersionForOwnership < 0)
+      ) {
+        throw new Error("SQLite schema header requires a valid supported agent schema version");
+      }
+      const header = await inspectSqliteSchemaHeaderInProcess(
+        pathname,
+        stagingRoot,
+        agentSchemaVersionForOwnership,
+      );
       process.stdout.write(JSON.stringify({ ok: true, header }));
       return;
     }

--- a/src/infra/sqlite-readonly-worker.ts
+++ b/src/infra/sqlite-readonly-worker.ts
@@ -75,6 +75,21 @@ type SqliteReadOnlyWorkerResult =
   | { ok: false; message: string };
 type SqliteReadOnlyWorkerOutput = { failure?: string; stderr: string; stdout: string };
 
+function isAgentSchemaMeta(value: unknown): boolean {
+  return (
+    value === null ||
+    (typeof value === "object" &&
+      !Array.isArray(value) &&
+      Object.keys(value).length === 3 &&
+      "agentId" in value &&
+      (value.agentId === null || typeof value.agentId === "string") &&
+      "role" in value &&
+      (value.role === null || typeof value.role === "string") &&
+      "schemaVersion" in value &&
+      (value.schemaVersion === null || typeof value.schemaVersion === "number"))
+  );
+}
+
 function isSqliteReadOnlyWorkerResult(value: unknown): value is SqliteReadOnlyWorkerResult {
   if (!value || typeof value !== "object" || Array.isArray(value)) {
     return false;
@@ -90,8 +105,11 @@ function isSqliteReadOnlyWorkerResult(value: unknown): value is SqliteReadOnlyWo
       "userVersion" in header &&
       typeof header.userVersion === "number" &&
       Number.isInteger(header.userVersion) &&
-      Object.keys(header).every((key) => key === "userVersion" || key === "writerAppVersion") &&
-      (!("writerAppVersion" in header) || typeof header.writerAppVersion === "string")
+      Object.keys(header).every(
+        (key) => key === "userVersion" || key === "writerAppVersion" || key === "agentSchemaMeta",
+      ) &&
+      (!("writerAppVersion" in header) || typeof header.writerAppVersion === "string") &&
+      (!("agentSchemaMeta" in header) || isAgentSchemaMeta(header.agentSchemaMeta))
     );
   }
   return (
@@ -174,6 +192,7 @@ function sqliteReadOnlyWorkerArgv(
   pathname: string,
   mode: SqliteReadOnlyWorkerMode,
   stagingRoot?: string,
+  agentSchemaVersionForOwnership?: number,
 ) {
   const workerUrl = resolveRuntimeWorkerUrl(runtimeProcessEntrypoints.sqliteReadOnly);
   return [
@@ -181,13 +200,21 @@ function sqliteReadOnlyWorkerArgv(
     SQLITE_READONLY_CHILD_ARG,
     mode,
     path.resolve(pathname),
-    ...(stagingRoot ? [stagingRoot] : []),
+    ...(stagingRoot || agentSchemaVersionForOwnership !== undefined ? [stagingRoot ?? ""] : []),
+    ...(agentSchemaVersionForOwnership !== undefined
+      ? [String(agentSchemaVersionForOwnership)]
+      : []),
   ];
 }
 
 export function runSqliteReadOnlyWorker(
   pathname: string,
-  options: { mode: "schema-header"; stagingRoot?: string; signal?: AbortSignal },
+  options: {
+    mode: "schema-header";
+    stagingRoot?: string;
+    signal?: AbortSignal;
+    agentSchemaVersionForOwnership?: number;
+  },
 ): Promise<SqliteSchemaHeader>;
 export function runSqliteReadOnlyWorker(
   pathname: string,
@@ -195,14 +222,24 @@ export function runSqliteReadOnlyWorker(
 ): Promise<string>;
 export function runSqliteReadOnlyWorker(
   pathname: string,
-  options: { mode: SqliteReadOnlyWorkerMode; stagingRoot?: string; signal?: AbortSignal },
+  options: {
+    mode: SqliteReadOnlyWorkerMode;
+    stagingRoot?: string;
+    signal?: AbortSignal;
+    agentSchemaVersionForOwnership?: number;
+  },
 ): Promise<string | SqliteSchemaHeader> {
   return new Promise<string | SqliteSchemaHeader>((resolve, reject) => {
     const { timeoutMs, size } = readSqliteSnapshotBudget(pathname);
     let output: SqliteReadOnlyWorkerOutput = { stderr: "", stdout: "" };
     const child = execFile(
       process.execPath,
-      sqliteReadOnlyWorkerArgv(pathname, options.mode, options.stagingRoot),
+      sqliteReadOnlyWorkerArgv(
+        pathname,
+        options.mode,
+        options.stagingRoot,
+        options.agentSchemaVersionForOwnership,
+      ),
       {
         encoding: "utf8",
         timeout: timeoutMs,

--- a/src/infra/sqlite-schema-header.test.ts
+++ b/src/infra/sqlite-schema-header.test.ts
@@ -164,8 +164,8 @@ describe("schema-header native reader lifetime", () => {
       const writer = new (requireNodeSqlite().DatabaseSync)(pathname);
       writer.exec(`
         PRAGMA journal_mode=WAL; PRAGMA wal_autocheckpoint=0;
-        CREATE TABLE schema_meta(meta_key TEXT PRIMARY KEY, app_version TEXT);
-        INSERT INTO schema_meta VALUES('primary','writer-7');
+        CREATE TABLE schema_meta(meta_key TEXT PRIMARY KEY, app_version TEXT, role TEXT, agent_id TEXT, schema_version INTEGER);
+        INSERT INTO schema_meta VALUES('primary','writer-7','agent','owner-7',7);
         PRAGMA user_version=7;
       `);
       // Faults and native pauses are installed in the actual child, not a
@@ -228,7 +228,10 @@ describe("schema-header native reader lifetime", () => {
       const controller = new AbortController();
       const cancellation = new Error("header inspection cancelled");
       let settled = false;
-      const operation = inspectSqliteSchemaHeader(pathname, { signal: controller.signal });
+      const operation = inspectSqliteSchemaHeader(pathname, {
+        signal: controller.signal,
+        agentSchemaVersionForOwnership: 8,
+      });
       void operation.then(
         () => {
           settled = true;
@@ -242,9 +245,9 @@ describe("schema-header native reader lifetime", () => {
           timeout: 10_000,
         });
         expectSourceExcluded(pathname);
-        // This newer pair commits between the child's two metadata queries.
+        // New version and ownership facts commit between the child's metadata queries.
         writer.exec(
-          "BEGIN IMMEDIATE; PRAGMA user_version=8; UPDATE schema_meta SET app_version='writer-8'; COMMIT;",
+          "BEGIN IMMEDIATE; PRAGMA user_version=8; UPDATE schema_meta SET app_version='writer-8', agent_id='owner-8', schema_version=8; COMMIT;",
         );
         fs.writeFileSync(marker("read-release"), "resume");
         await vi.waitFor(() => expect(fs.existsSync(marker("close"))).toBe(true), {
@@ -269,6 +272,7 @@ describe("schema-header native reader lifetime", () => {
             await expect(operation).resolves.toEqual({
               userVersion: 7,
               writerAppVersion: "writer-7",
+              agentSchemaMeta: { role: "agent", agentId: "owner-7", schemaVersion: 7 },
             });
           }
         }

--- a/src/infra/sqlite-schema-header.ts
+++ b/src/infra/sqlite-schema-header.ts
@@ -1,4 +1,8 @@
 import type { DatabaseSync } from "node:sqlite";
+import {
+  readExistingAgentSchemaMeta,
+  type ExistingAgentSchemaMeta,
+} from "../state/openclaw-agent-db-metadata.js";
 import type { DB as OpenClawAgentKyselyDatabase } from "../state/openclaw-agent-db.generated.js";
 import { executeSqliteQueryTakeFirstSync, getNodeSqliteKysely } from "./kysely-sync.js";
 import { runSqliteDeferredTransactionSync } from "./sqlite-transaction.js";
@@ -8,6 +12,7 @@ import { configureSqliteReadOnlyPragmas } from "./sqlite-wal.js";
 export type SqliteSchemaHeader = {
   userVersion: number;
   writerAppVersion?: string;
+  agentSchemaMeta?: ExistingAgentSchemaMeta | null;
 };
 
 export function readSqliteWriterAppVersion(database: DatabaseSync): string | undefined {
@@ -29,12 +34,23 @@ export function readSqliteWriterAppVersion(database: DatabaseSync): string | und
   }
 }
 
-/** Read both metadata values from one fresh SQLite read transaction, including WAL. */
-export function readSqliteSchemaHeader(database: DatabaseSync): SqliteSchemaHeader {
+/** Read version and requested ownership facts from one fresh transaction, including WAL. */
+export function readSqliteSchemaHeader(
+  database: DatabaseSync,
+  agentSchemaVersionForOwnership?: number,
+): SqliteSchemaHeader {
   configureSqliteReadOnlyPragmas(database);
   return runSqliteDeferredTransactionSync(database, () => {
     const userVersion = readSqliteUserVersion(database);
     const writerAppVersion = readSqliteWriterAppVersion(database);
-    return { userVersion, ...(writerAppVersion ? { writerAppVersion } : {}) };
+    return {
+      userVersion,
+      ...(writerAppVersion ? { writerAppVersion } : {}),
+      // A newer schema may have a different metadata contract; its version alone refuses admission.
+      ...(agentSchemaVersionForOwnership !== undefined &&
+      userVersion <= agentSchemaVersionForOwnership
+        ? { agentSchemaMeta: readExistingAgentSchemaMeta(database) }
+        : {}),
+    };
   });
 }

--- a/src/infra/sqlite-snapshot-source.ts
+++ b/src/infra/sqlite-snapshot-source.ts
@@ -27,7 +27,7 @@ import {
  * must use their snapshot owner: a child cannot borrow that source authority. */
 export async function inspectSqliteSchemaHeader(
   pathname: string,
-  options: { signal?: AbortSignal } = {},
+  options: { signal?: AbortSignal; agentSchemaVersionForOwnership?: number } = {},
 ) {
   options.signal?.throwIfAborted();
   if (
@@ -35,7 +35,11 @@ export async function inspectSqliteSchemaHeader(
     hasStateDatabaseSourceExclusion(pathname)
   ) {
     const prepared = await prepareSqliteReadOnlyLocation(pathname, options);
-    return readSqliteSchemaHeaderFromSnapshot(prepared, options.signal);
+    return readSqliteSchemaHeaderFromSnapshot(
+      prepared,
+      options.signal,
+      options.agentSchemaVersionForOwnership,
+    );
   }
   // Reserve cleanup ownership before launch even if only journal recovery will
   // need a copy. Cancellation joins the child before deleting unpublished bytes.
@@ -47,6 +51,7 @@ export async function inspectSqliteSchemaHeader(
       mode: "schema-header",
       stagingRoot,
       signal: options.signal,
+      agentSchemaVersionForOwnership: options.agentSchemaVersionForOwnership,
     });
     options.signal?.throwIfAborted();
   } catch (error) {

--- a/src/state/openclaw-agent-db-metadata.ts
+++ b/src/state/openclaw-agent-db-metadata.ts
@@ -2,6 +2,7 @@ import type { DatabaseSync } from "node:sqlite";
 import { normalizeNullableString } from "@openclaw/normalization-core/string-coerce";
 import { executeSqliteQueryTakeFirstSync, getNodeSqliteKysely } from "../infra/kysely-sync.js";
 import type { DB as OpenClawAgentKyselyDatabase } from "./openclaw-agent-db.generated.js";
+import { tableExists } from "./openclaw-state-db-schema-helpers.js";
 
 export type ExistingAgentSchemaMeta = {
   agentId: string | null;
@@ -11,10 +12,7 @@ export type ExistingAgentSchemaMeta = {
 
 /** Read ownership metadata without loading runtime schema or migration owners. */
 export function readExistingAgentSchemaMeta(db: DatabaseSync): ExistingAgentSchemaMeta | null {
-  const schemaMetaTable = db
-    .prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'schema_meta'")
-    .get();
-  if (!schemaMetaTable) {
+  if (!tableExists(db, "schema_meta")) {
     return null;
   }
   const row = executeSqliteQueryTakeFirstSync(

--- a/src/state/openclaw-agent-db-metadata.ts
+++ b/src/state/openclaw-agent-db-metadata.ts
@@ -1,0 +1,35 @@
+import type { DatabaseSync } from "node:sqlite";
+import { normalizeNullableString } from "@openclaw/normalization-core/string-coerce";
+import { executeSqliteQueryTakeFirstSync, getNodeSqliteKysely } from "../infra/kysely-sync.js";
+import type { DB as OpenClawAgentKyselyDatabase } from "./openclaw-agent-db.generated.js";
+
+export type ExistingAgentSchemaMeta = {
+  agentId: string | null;
+  role: string | null;
+  schemaVersion: number | null;
+};
+
+/** Read ownership metadata without loading runtime schema or migration owners. */
+export function readExistingAgentSchemaMeta(db: DatabaseSync): ExistingAgentSchemaMeta | null {
+  const schemaMetaTable = db
+    .prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'schema_meta'")
+    .get();
+  if (!schemaMetaTable) {
+    return null;
+  }
+  const row = executeSqliteQueryTakeFirstSync(
+    db,
+    getNodeSqliteKysely<Pick<OpenClawAgentKyselyDatabase, "schema_meta">>(db)
+      .selectFrom("schema_meta")
+      .select(["role", "schema_version", "agent_id"])
+      .where("meta_key", "=", "primary"),
+  );
+  if (!row) {
+    return null;
+  }
+  return {
+    agentId: normalizeNullableString(row.agent_id),
+    role: typeof row.role === "string" ? row.role : null,
+    schemaVersion: typeof row.schema_version === "number" ? row.schema_version : null,
+  };
+}

--- a/src/state/openclaw-agent-db-schema-helpers.ts
+++ b/src/state/openclaw-agent-db-schema-helpers.ts
@@ -1,5 +1,4 @@
 import type { DatabaseSync } from "node:sqlite";
-import { normalizeNullableString } from "@openclaw/normalization-core/string-coerce";
 import { MEMORY_INDEX_CHUNK_PROVENANCE_TABLE } from "../../packages/memory-host-sdk/src/host/memory-schema-provenance.js";
 import { MEMORY_INDEX_CHUNK_RECALL_METADATA_TABLE } from "../../packages/memory-host-sdk/src/host/memory-schema-recall.js";
 import {
@@ -29,6 +28,10 @@ import {
   AGENT_MEDIA_SCHEMA_VERSION,
   OPENCLAW_AGENT_SCHEMA_VERSION,
 } from "./openclaw-agent-db-contract.js";
+import {
+  readExistingAgentSchemaMeta,
+  type ExistingAgentSchemaMeta,
+} from "./openclaw-agent-db-metadata.js";
 import { OpenClawAgentDatabaseMediaMigrationRequiredError } from "./openclaw-agent-db-migration-required.js";
 import {
   ensureSessionAdditiveColumns,
@@ -57,11 +60,7 @@ import {
   STANDING_INTENTS_TABLE,
 } from "./openclaw-agent-standing-intents-schema.js";
 
-type ExistingAgentSchemaMeta = {
-  agentId: string | null;
-  role: string | null;
-  schemaVersion: number | null;
-};
+export { readExistingAgentSchemaMeta } from "./openclaw-agent-db-metadata.js";
 
 export function migratedSessionColumn(
   columns: ReadonlySet<string>,
@@ -286,26 +285,6 @@ export function assertCanonicalAgentPersistenceVersion(
       `OpenClaw agent database ${pathname} uses schema version ${userVersion}; stop active agents and run openclaw doctor --fix to migrate session identities before using it.`,
     );
   }
-}
-
-export function readExistingAgentSchemaMeta(db: DatabaseSync): ExistingAgentSchemaMeta | null {
-  const schemaMetaTable = db
-    .prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'schema_meta'")
-    .get();
-  if (!schemaMetaTable) {
-    return null;
-  }
-  const row = db
-    .prepare("SELECT role, schema_version, agent_id FROM schema_meta WHERE meta_key = 'primary'")
-    .get() as { agent_id?: unknown; role?: unknown; schema_version?: unknown } | undefined;
-  if (!row) {
-    return null;
-  }
-  return {
-    agentId: normalizeNullableString(row.agent_id),
-    role: typeof row.role === "string" ? row.role : null,
-    schemaVersion: typeof row.schema_version === "number" ? row.schema_version : null,
-  };
 }
 
 export function assertExistingAgentSchemaOwner(

--- a/src/state/openclaw-agent-db.test.ts
+++ b/src/state/openclaw-agent-db.test.ts
@@ -5310,7 +5310,7 @@ describe("openclaw agent database", () => {
     {
       kind: "malformed ownership metadata",
       schema: "CREATE TABLE schema_meta (meta_key TEXT);",
-      expectedError: /no such column: role/,
+      expectedError: /no such column: (?:role\b|"role")/,
     },
   ])(
     "preserves the refusal for a populated v0 database with $kind",

--- a/src/state/openclaw-database-preflight.artifacts.test.ts
+++ b/src/state/openclaw-database-preflight.artifacts.test.ts
@@ -156,11 +156,16 @@ describe("schema preflight source artifacts", () => {
     }
   }, 20_000);
 
-  it.each([0, 8 * 1024 * 1024])(
-    "reads fresh WAL metadata without copying %i bytes of unrelated payload",
-    async (payloadBytes) => {
+  it.each([
+    { payloadBytes: 0, admission: false },
+    { payloadBytes: 8 * 1024 * 1024, admission: false },
+    { payloadBytes: 8 * 1024 * 1024, admission: true },
+  ])(
+    "reads fresh WAL metadata without copying $payloadBytes bytes of unrelated payload (admission=$admission)",
+    async ({ payloadBytes, admission }) => {
       const root = tempDirs.make("openclaw-header-preflight-");
-      const pathname = path.join(root, "agent.sqlite");
+      const pathname = path.join(root, "agents", "main", "agent", "openclaw-agent.sqlite");
+      fs.mkdirSync(path.dirname(pathname), { recursive: true });
       const preload = path.join(root, "no-backup.cjs");
       fs.writeFileSync(
         preload,
@@ -170,8 +175,8 @@ describe("schema preflight source artifacts", () => {
       writer.exec(`
         PRAGMA journal_mode = WAL;
         PRAGMA wal_autocheckpoint = 0;
-        CREATE TABLE schema_meta (meta_key TEXT PRIMARY KEY, app_version TEXT);
-        INSERT INTO schema_meta VALUES ('primary', 'original');
+        CREATE TABLE schema_meta (meta_key TEXT PRIMARY KEY, app_version TEXT, role TEXT, agent_id TEXT, schema_version INTEGER);
+        INSERT INTO schema_meta VALUES ('primary', 'original', 'agent', 'main', ${supportedVersions.agent});
         CREATE TABLE payload (data BLOB);
         INSERT INTO payload VALUES (zeroblob(${payloadBytes}));
         PRAGMA user_version = ${supportedVersions.agent};
@@ -182,27 +187,44 @@ describe("schema preflight source artifacts", () => {
       }
       try {
         for (const increment of [1, 2]) {
-          const foundVersion = supportedVersions.agent + increment;
+          const foundVersion = supportedVersions.agent + (admission ? 0 : increment);
           writer.exec(`BEGIN IMMEDIATE; PRAGMA user_version = ${foundVersion};`);
-          writer.prepare("UPDATE schema_meta SET app_version = ?").run(`writer-${increment}`);
+          writer
+            .prepare("UPDATE schema_meta SET app_version = ?, agent_id = ?")
+            .run(`writer-${increment}`, increment === 1 ? "other" : "main");
           writer.exec("COMMIT;");
           const before = sourceArtifacts([pathname], [pathname]);
           const result = await preflightOpenClawDatabaseSchemas({
             env: { OPENCLAW_STATE_DIR: path.join(root, "absent-state") },
             supportedVersions,
             configuredAgentDatabaseCandidatePaths: [pathname],
+            ...(admission ? { agentAdmissionConfig: { agents: { entries: { main: {} } } } } : {}),
           });
           expect(result).toEqual({
-            incompatible: [
-              {
-                kind: "agent",
-                path: pathname,
-                foundVersion,
-                supportedVersion: supportedVersions.agent,
-                writerAppVersion: `writer-${increment}`,
-              },
-            ],
+            incompatible: admission
+              ? []
+              : [
+                  {
+                    kind: "agent",
+                    path: pathname,
+                    foundVersion,
+                    supportedVersion: supportedVersions.agent,
+                    writerAppVersion: `writer-${increment}`,
+                  },
+                ],
             indeterminate: [],
+            ...(admission && increment === 1
+              ? {
+                  agentRefusals: [
+                    expect.objectContaining({
+                      agentId: "main",
+                      paths: [pathname],
+                      embeddedOwnerId: "other",
+                      code: "agent-database-ownership-mismatch",
+                    }),
+                  ],
+                }
+              : {}),
           });
           expect(sourceArtifacts([pathname], [pathname])).toEqual(before);
         }

--- a/src/state/openclaw-database-preflight.ts
+++ b/src/state/openclaw-database-preflight.ts
@@ -34,6 +34,7 @@ import {
 } from "./agent-database-admission.js";
 import { OPENCLAW_AGENT_SCHEMA_VERSION } from "./openclaw-agent-db-contract.js";
 import { assertOpenClawAgentDatabaseForMaintenance } from "./openclaw-agent-db-maintenance.js";
+import type { ExistingAgentSchemaMeta } from "./openclaw-agent-db-metadata.js";
 import { isPersistentOpenClawAgentDatabasePath } from "./openclaw-agent-db-registry.js";
 import {
   assertCanonicalAgentPersistenceVersion,
@@ -579,17 +580,24 @@ export async function preflightOpenClawDatabaseSchemas(options: {
       inspectedAgentTargets.add(inspectionKey);
       let agentVersion: number;
       let writerAppVersion: string | undefined;
-      if (
-        !options.requireStartupMigrationReadiness &&
-        !options.verifyCurrentSchemaShape &&
-        !options.agentAdmissionConfig
-      ) {
-        const header = await inspectSqliteSchemaHeader(realAgentPath, { signal: options.signal });
+      let agentSchemaMeta: ExistingAgentSchemaMeta | null | undefined;
+      const inspectOwnership =
+        options.agentAdmissionConfig !== undefined &&
+        row.agentId !== undefined &&
+        listAgentIds(options.agentAdmissionConfig).includes(row.agentId);
+      if (!options.requireStartupMigrationReadiness && !options.verifyCurrentSchemaShape) {
+        const header = await inspectSqliteSchemaHeader(realAgentPath, {
+          signal: options.signal,
+          ...(inspectOwnership
+            ? { agentSchemaVersionForOwnership: options.supportedVersions.agent }
+            : {}),
+        });
         options.signal?.throwIfAborted();
         agentVersion = header.userVersion;
         writerAppVersion = header.writerAppVersion;
+        agentSchemaMeta = header.agentSchemaMeta;
       } else {
-        // Full readiness and ownership admission retain their private snapshot.
+        // Full readiness retains its private snapshot; diagnostics need only bounded metadata.
         agentSnapshot = await prepareSqliteReadOnlyLocation(realAgentPath, {
           signal: options.signal,
         });
@@ -598,18 +606,15 @@ export async function preflightOpenClawDatabaseSchemas(options: {
         agentDatabase.exec(`PRAGMA busy_timeout = ${OPENCLAW_SQLITE_BUSY_TIMEOUT_MS};`);
         agentVersion = readSqliteUserVersion(agentDatabase);
         writerAppVersion = readWriterAppVersion(agentDatabase);
+        if (inspectOwnership && agentVersion <= options.supportedVersions.agent) {
+          agentSchemaMeta = readExistingAgentSchemaMeta(agentDatabase);
+        }
       }
-      if (
-        agentDatabase &&
-        agentVersion <= options.supportedVersions.agent &&
-        options.agentAdmissionConfig &&
-        row.agentId &&
-        listAgentIds(options.agentAdmissionConfig).includes(row.agentId)
-      ) {
+      if (agentVersion <= options.supportedVersions.agent && inspectOwnership && row.agentId) {
         const refusal = inspectAgentDatabaseAdmission({
           agentId: row.agentId,
           path: agentPath,
-          metadata: readExistingAgentSchemaMeta(agentDatabase),
+          metadata: agentSchemaMeta ?? null,
         });
         if (refusal) {
           (result.agentRefusals ??= []).push(refusal);


### PR DESCRIPTION
Related: #145541

## What Problem This Solves

Fixes an issue where users running `openclaw status` could wait tens of seconds while large agent databases were copied merely to check their ownership. That work happens in the CLI before its report is ready, so Gateway RPC latency metrics do not capture the entire delay.

## Why This Change Was Made

Admission-only preflight reads supported schema versions and owner metadata in one consistent, read-only SQLite transaction through the existing metadata worker. The metadata decoder has one lightweight owner shared with runtime schema helpers. Committed WAL changes remain visible; recovery-required journal states still use the existing private-snapshot path.

Full startup, migration, explicit copied-database validation, and writable-open integrity checks retain their existing behavior. No schema, configuration, persistence, or writer-lifecycle change is introduced. The update driver and rollback data format are unchanged.

## User Impact

Status ownership checks no longer copy ordinary agent databases in proportion to stored transcript size. Wrong-owner and newer-schema refusals remain intact. The CLI and metrics documentation now distinguishes local report collection and connection setup from Gateway handler timing.

## Evidence

- The real-worker regression forbids full payload backups while checking an 8 MiB active-WAL database. It fails on the original admission path and passes after this change; wrong-owner metadata committed in WAL is rejected, and a later corrected owner is observed.
- A concurrent-writer regression verifies that schema version and owner come from the same read transaction. Source artifacts, cancellation, native-close failures, and journal-recovery behavior remain covered.
- 116 focused tests passed across preflight, admission, schema-header, and read-only-worker suites.
- Full `pnpm build`, `node scripts/check-changed.mjs`, targeted docs MDX/format checks, and `git diff --check` passed. The assertion baseline shrinks by one because the extracted decoder uses the existing typed query owner instead of a result cast.
- Independent review through P2 found no actionable issues. A patch-identical rebase preserves the reviewed implementation.

This removes one demonstrated source of CLI latency. It does not claim to eliminate other local collection costs or Gateway event-loop pressure.

CI follow-through: the moved table probe now reuses the existing schema-introspection helper; the complete architecture check passed. The full agent-database suite passed 145 tests (four platform cases skipped locally) after accepting SQLite’s quoted and unquoted rendering of the same missing column. Production code is unchanged after its successful full build. The branch includes the independently landed shard-capacity repair #146212; range-diff verified the reviewed patches were unchanged by that rebase.

Maintainer scope assessment: the generic stored-data warning is not applicable. No schema, persisted representation, migration writer, or writer-lifecycle contract changes here. ClawSweeper's current technical review independently reaches that same conclusion and explicitly says the earlier migration-proof blocker does not apply. The real-worker tests preserve the source database family while reading fresh owner metadata. This is the read-only, semantics-preserving exception in the storage-change checkpoint; no execution gate or validation policy is being waived.
