### PR TITLE
improve(memory): reduce allocations when counting forget targets

### DIFF
--- a/extensions/memory-core/src/memory-forget.ts
+++ b/extensions/memory-core/src/memory-forget.ts
@@ -243,8 +243,11 @@ async function planMemoryIndex(params: {
         chunkIds.length > 0 && tableExists(db, "memory_index_chunks_fts")
           ? executeSqliteQuerySync(
               db,
-              kysely.selectFrom("memory_index_chunks_fts").select("id").where("id", "in", chunkIds),
-            ).rows.length
+              kysely
+                .selectFrom("memory_index_chunks_fts")
+                .select((eb) => eb.fn.countAll<number>().as("count"))
+                .where("id", "in", chunkIds),
+            ).rows[0]!.count
           : 0;
       const hasVectorTable = tableExists(db, "memory_index_chunks_vec");
       let embeddingCacheRows = 0;
@@ -295,13 +298,13 @@ async function planMemoryIndex(params: {
           db,
           vectorKysely
             .selectFrom("memory_index_chunks_vec")
-            .select("id")
+            .select((eb) => eb.fn.countAll<number>().as("count"))
             .where(
               "id",
               "in",
               result.value.chunks.map((chunk) => chunk.id),
             ),
-        ).rows.length;
+        ).rows[0]!.count;
       },
       { agentId: params.agentId },
       { allowExtension: true },


### PR DESCRIPTION
## What Problem This Solves

Memory-forget planning fetches every matching FTS and vector ID solely to report how many index rows will be removed. Large selections allocate thousands of result rows unnecessarily.

## Why This Change Was Made

Use Kysely `COUNT(*)` with the existing ID filters on the same read-only database owners. Chunk selection, duplicate FTS-row counting, vector loading, preview behavior, and deletion remain unchanged. No schema, migration, transaction, or retention changes.

## User Impact

Large memory-forget selections return one count row per index instead of every matching ID.

## Evidence

- Registered memory CLI parser in separate processes with production runtime and isolated synthetic SQLite, real FTS5 and sqlite-vec 0.1.9, no mocks: preview reported two selected chunks, three FTS rows (duplicate ID included), and one vector row (one selected chunk had none). Preview preserved all rows and the index revision; apply reported identical counts and retained only the unrelated survivor; repeated preview returned zero.
- Windows, Node 26.8.2; 10,000 indexed rows, 5,000 selected IDs; 31 measured warm interleaved rounds. FTS median: 50.36 → 43.71 ms (1.15×); vector median: 25.40 → 16.40 ms (1.55×). Returned rows: 5,000 → 1. Small selections were roughly unchanged; these query-level timings do not claim the same end-to-end speedup.
- Broader memory/CLI test run: 147 passed; one unrelated Windows CLI status test expects POSIX path spelling. The forget, participant, and failure-recovery files passed.
- Independent P0–P2 review: no actionable findings.

- Fresh focused forget, participant, and failure-recovery run: 28 tests passed.
- Exact-head hosted CI passed, including the required `openclaw/ci-gate` (run 34706393358). Local changed-file checks passed through formatting, assertion safety, plugin boundaries, and patch guards; a stale local build lock prevented completing the local typecheck sequence. Hosted production/test typechecks and lint passed.
