### PR TITLE
fix(agents): recover legacy default via materialized systemAgent after explicit-roster persistence

### DIFF
--- a/src/agents/agent-scope-config.test.ts
+++ b/src/agents/agent-scope-config.test.ts
@@ -16,6 +16,8 @@ import {
   resolveSoleAgentId,
   tryResolveAmbientOwnerAgentId,
   tryResolveDefaultAgentId,
+  tryResolveDiscoveryDefaultAgentId,
+  tryResolveLegacyCompatibilityAgentId,
   tryResolveSoleAgentId,
 } from "./agent-scope-config.js";
 
@@ -170,6 +172,97 @@ describe("agent roster resolution", () => {
         hint: "Set talk.agentId.",
       }),
     ).toThrow("Set talk.agentId.");
+  });
+
+  it("recovers the persisted legacy default for discovery surfaces through systemAgent", () => {
+    // Doctor persists multi-agent upgrades with explicit ownership while materializing
+    // the retired default agent's surfaces into agents.defaults.systemAgent. After restart
+    // the process-only retained id is gone, so the discovery default must recover the
+    // same principal from the persisted assignment (regression: `openclaw agents list
+    // --json` reported isDefault=false for every agent and legacy integrations got
+    // "default agent not detected").
+    const persistedFleet = {
+      agents: {
+        ownership: "explicit" as const,
+        defaults: { systemAgent: { agentId: "ops" } },
+        entries: { ops: {}, research: {} },
+      },
+    } satisfies OpenClawConfig;
+
+    expect(tryResolveDiscoveryDefaultAgentId(persistedFleet)).toBe("ops");
+  });
+
+  it("keeps strict compatibility resolution ownerless in explicit fleets", () => {
+    // Strict ownership resolution must keep failing closed even when a system agent is
+    // configured; only discovery projections may treat the system agent as the default.
+    const ownerlessFleet = {
+      agents: { ownership: "explicit" as const, entries: { ops: {}, research: {} } },
+    } satisfies OpenClawConfig;
+    expect(tryResolveLegacyCompatibilityAgentId(ownerlessFleet)).toBeUndefined();
+    expect(tryResolveDiscoveryDefaultAgentId(ownerlessFleet)).toBeUndefined();
+
+    const configuredSystemAgent = {
+      agents: {
+        ownership: "explicit" as const,
+        defaults: { systemAgent: { agentId: "ops" } },
+        entries: { ops: {}, research: {} },
+      },
+    } satisfies OpenClawConfig;
+    expect(tryResolveLegacyCompatibilityAgentId(configuredSystemAgent)).toBeUndefined();
+
+    const staleSystemAgent = {
+      agents: {
+        ownership: "explicit" as const,
+        defaults: { systemAgent: { agentId: "retired-agent" } },
+        entries: { ops: {}, research: {} },
+      },
+    } satisfies OpenClawConfig;
+    expect(tryResolveDiscoveryDefaultAgentId(staleSystemAgent)).toBeUndefined();
+
+    const blankSystemAgent = {
+      agents: {
+        ownership: "explicit" as const,
+        defaults: { systemAgent: { agentId: "  " } },
+        entries: { ops: {}, research: {} },
+      },
+    } satisfies OpenClawConfig;
+    expect(tryResolveDiscoveryDefaultAgentId(blankSystemAgent)).toBeUndefined();
+  });
+
+  it("keeps a raw legacy default marker ahead of the configured system agent", () => {
+    const config = {
+      agents: {
+        defaults: { systemAgent: { agentId: "beta" } },
+        entries: { alpha: { default: true }, beta: {} },
+      },
+    } satisfies OpenClawConfig;
+
+    expect(tryResolveLegacyCompatibilityAgentId(config)).toBe("alpha");
+    expect(tryResolveDiscoveryDefaultAgentId(config)).toBe("alpha");
+  });
+
+  it("resolves the discovery default across a persisted multi-agent upgrade restart", () => {
+    // Mirror doctor-config-flow's persistence: migrate a legacy list with one default
+    // marker, then drop the process-only migration sidecar (structuredClone) and stamp
+    // explicit ownership exactly as the persisted on-disk config looks after restart.
+    const rawConfig = {
+      agents: {
+        list: [
+          { id: "ops", default: true, workspace: "/srv/ops" },
+          { id: "research", model: "openai/research" },
+        ],
+      },
+    };
+    const migrated = migratePersistedImplicitMainRoster(rawConfig, {
+      materializeWorkspace: true,
+    }).config as OpenClawConfig;
+    expect(migrated.agents?.defaults?.systemAgent?.agentId).toBe("ops");
+
+    const persisted = structuredClone(migrated);
+    persisted.agents = { ...persisted.agents, ownership: "explicit" as const };
+    expect(persisted.agents?.entries?.ops).not.toHaveProperty("default");
+    expect(tryResolveLegacyCompatibilityAgentId(persisted)).toBeUndefined();
+    expect(tryResolveDiscoveryDefaultAgentId(persisted)).toBe("ops");
   });
 
   it("resolves the default agent directory through the ambient owner", () => {

--- a/src/agents/agent-scope-config.ts
+++ b/src/agents/agent-scope-config.ts
@@ -273,6 +273,27 @@ export function tryResolveLegacyCompatibilityAgentId(cfg: OpenClawConfig): strin
   return value;
 }
 
+/**
+ * Default identity for agent discovery/listing surfaces (CLI list summary, `isDefault`).
+ *
+ * Prefer the legacy compatibility owner. When an explicit fleet has no legacy owner —
+ * typically right after Doctor persisted a multi-agent upgrade and stripped the retired
+ * default marker — use the persisted `agents.defaults.systemAgent` assignment when it names
+ * a roster member: that is the principal the upgrade materialized from the retired default.
+ *
+ * This fallback is intentionally NOT part of {@link tryResolveLegacyCompatibilityAgentId}:
+ * strict ownership resolution must keep failing closed in explicit fleets even when a
+ * system agent is configured, so only discovery projections may use it.
+ */
+export function tryResolveDiscoveryDefaultAgentId(cfg: OpenClawConfig): string | undefined {
+  const compatibilityAgentId = tryResolveLegacyCompatibilityAgentId(cfg);
+  if (compatibilityAgentId) {
+    return compatibilityAgentId;
+  }
+  const systemAgentId = normalizeOptionalString(cfg.agents?.defaults?.systemAgent?.agentId);
+  return systemAgentId && listAgentIds(cfg).includes(systemAgentId) ? systemAgentId : undefined;
+}
+
 /** Resolves the owner for ambient system work and explicit requests. */
 export function tryResolveAmbientOwnerAgentId(
   cfg: OpenClawConfig,

--- a/src/agents/agent-scope.ts
+++ b/src/agents/agent-scope.ts
@@ -56,6 +56,7 @@ export {
   resolveSoleAgentId,
   tryResolveAmbientOwnerAgentId,
   tryResolveLegacyCompatibilityAgentId,
+  tryResolveDiscoveryDefaultAgentId,
   tryResolveSoleAgentId,
   tryResolveDefaultAgentId,
   AgentSelectionRequiredError,

--- a/src/commands/agents.commands.list.test.ts
+++ b/src/commands/agents.commands.list.test.ts
@@ -112,6 +112,27 @@ describe("agentsListCommand", () => {
     expect(summary).not.toHaveProperty("providers");
   });
 
+  it("marks the materialized system agent as default in an explicit multi-agent fleet", async () => {
+    // Regression: after doctor persists a multi-agent legacy roster, ownership is explicit
+    // and raw default markers are stripped; the retired default's identity survives only
+    // in agents.defaults.systemAgent. The JSON summaries must still expose exactly one
+    // isDefault row instead of all-false, which broke legacy CLI integrations.
+    requireValidConfigMock.mockResolvedValueOnce({
+      agents: {
+        ownership: "explicit" as const,
+        defaults: { systemAgent: { agentId: "main" } },
+        entries: { main: {}, wuse: {}, hermes: {} },
+      },
+    } satisfies OpenClawConfig);
+
+    const runtime = createRuntime();
+    await agentsListCommand({ json: true }, runtime);
+
+    const summaries = runtime.json[0] as Array<{ id: string; isDefault: boolean }>;
+    expect(summaries.filter((s) => s.isDefault).map((s) => s.id)).toEqual(["main"]);
+    expect(summaries.find((s) => s.id === "wuse")?.isDefault).toBe(false);
+  });
+
   it("renders roots, children, missing rows, and dangling creators as a tree", async () => {
     requireValidConfigMock.mockResolvedValueOnce({
       agents: {

--- a/src/commands/agents.config.ts
+++ b/src/commands/agents.config.ts
@@ -9,6 +9,7 @@ import {
   resolveAgentConfig,
   resolveAgentDir,
   resolveAgentWorkspaceDir,
+  tryResolveDiscoveryDefaultAgentId,
   tryResolveLegacyCompatibilityAgentId,
   toAgentEntriesRecord,
 } from "../agents/agent-scope.js";
@@ -59,7 +60,7 @@ export function findAgentEntryIndex(list: AgentEntry[], agentId: string): number
 
 /** Build config-derived summaries for text/JSON agent listing. */
 export function buildAgentSummaries(cfg: OpenClawConfig): AgentSummary[] {
-  const defaultAgentId = tryResolveLegacyCompatibilityAgentId(cfg);
+  const defaultAgentId = tryResolveDiscoveryDefaultAgentId(cfg);
   const configuredAgents = listAgentEntries(cfg);
   const orderedIds =
     configuredAgents.length > 0


### PR DESCRIPTION
Closes #146195

## What Problem This Solves

Fixes an issue where users with a multi-agent config on the legacy `agents.list` roster would lose the default agent shown by `openclaw agents list` after Doctor persisted the canonical `agents.entries` roster. On every subsequent process start, `openclaw agents list --json` reported `isDefault: false` for every agent, and legacy integrations shelling out to that command failed with "openclaw default agent 未探测到" (observed with the Coze desktop bridge; cloud side `70004 get claw failed`). The same regression re-triggered after each upgrade, even when the config was manually repaired once.

## Why This Change Was Made

The persisted upgrade deliberately strips `entries.*.default` markers and stamps `agents.ownership: "explicit"`, while materializing the retired default agent's surfaces — including `agents.defaults.systemAgent.agentId` — via `materializeLegacyDefaultAgentRoles()`. The strict compatibility resolver only knew two sources for the default identity:

1. a retained legacy id kept in a **process-only** WeakMap (`legacy.default-agent-owner-state.ts`, explicitly upgrade-only), and
2. a raw `default: true` marker, which is refused once ownership is explicit.

After a restart both sources are empty, even though the same identity was durably written to `agents.defaults.systemAgent.agentId` during migration.

The change adds a discovery-only helper `tryResolveDiscoveryDefaultAgentId`: legacy compatibility owner first, then the persisted `agents.defaults.systemAgent.agentId` when it names an existing roster member. `buildAgentSummaries` (the `openclaw agents list` text/JSON projection, including `isDefault`) uses it.

Boundary: the fallback is intentionally NOT added to `tryResolveLegacyCompatibilityAgentId`, because strict ownership resolution must keep failing closed in explicit fleets even with a system agent configured (`resolveSessionAgentIdsStrict` contract, locked by `src/plugin-sdk/agent-scope-runtime.test.ts` — an earlier revision of this PR violated that contract and CI caught it). Blank/stale system-agent ids also resolve to `undefined`.

Non-goals: Doctor's roster persistence, ownership stamping, and marker retirement are unchanged; strict/session/routing ownership semantics are unchanged.

## User Impact

Multi-agent installs that crossed the legacy-list → canonical-entries migration keep a stable default agent in `openclaw agents list` across restarts and upgrades. Legacy CLI integrations reading the JSON `isDefault` field work without manual config edits. Because existing broken persisted configs already contain the materialized `agents.defaults.systemAgent.agentId`, the fix self-heals them on the next release without config surgery. Explicit fleets with no system agent are unaffected.

## Evidence

- Reproduction, backup timeline (2026-08-21 legacy list with `main.default: true` → 2026-09-03 explicit roster, all `isDefault=false`), and integration logs: #146195.
- New regression tests in `src/agents/agent-scope-config.test.ts`: discovery default via materialized systemAgent; strict compatibility resolver stays ownerless in explicit fleets (including when systemAgent is set, blank, or stale); raw legacy marker precedence over systemAgent; a full persisted-upgrade restart round-trip (`agents.list` default → migration → drop process-only sidecar → stamp explicit → discovery still returns the materialized owner while strict resolution stays undefined).
- Projection-level test in `src/commands/agents.commands.list.test.ts` locks the exact user-visible symptom: exactly one JSON summary row (`main`) has `isDefault: true` in an explicit `{main, wuse, hermes}` fleet with materialized systemAgent.
- Local verification (vitest 5, Node 26.0): touched suites pass — agent-scope-config, agents command list, plugin-sdk agent-scope-runtime, doctor-config-flow (117 passed, 1 skipped); broader regression batches pass (routing, gateway health, gateway agent-list, security audit, exec-approvals: 488 passed). `pnpm tsgo:core` clean; oxlint clean on changed files. CI evidence will be appended by bots.
