### PR TITLE
fix(gateway): exit cleanly when native shutdown drains time out

### DIFF
--- a/docs/cli/gateway/restart-and-supervision.md
+++ b/docs/cli/gateway/restart-and-supervision.md
@@ -26,6 +26,18 @@ openclaw gateway restart --wait 30s
 
 `--wait <duration>` overrides the drain budget for a plain (non-safe) restart. Accepts bare milliseconds or unit suffixes `ms`, `s`, `m`, `h`, `d` (e.g. `30s`, `5m`, `1h30m`); `--wait 0` waits indefinitely. Not compatible with `--force` or `--safe`.
 
+Native service stop deadlines still apply: the Gateway caps the drain at 315 seconds
+for systemd's 330-second limit, and 5 seconds for launchd's 20-second limit. Both
+leave time for cancellation and cleanup. These caps also apply to `--wait 0`. Longer model or
+heartbeat timeouts do not extend it. When available, the drain log reports the
+largest observed model request timeout for context.
+
+If work still ignores cancellation at the shutdown deadline, the process logs
+the remaining work categories, writes a diagnostic stability bundle, and exits
+with status `0`. It does not reuse that unfinished runtime for an in-process
+restart. This lets a requested stop finish cleanly and lets the service manager
+start a fresh Gateway for a restart.
+
 `--force` skips the active-work drain and restarts immediately. Plain `restart` normally uses the service-manager restart path.
 
 During an upgrade, restart records its reason and drain options in the existing

--- a/docs/cli/gateway/restart-and-supervision.md
+++ b/docs/cli/gateway/restart-and-supervision.md
@@ -38,6 +38,9 @@ with status `0`. It does not reuse that unfinished runtime for an in-process
 restart. This lets a requested stop finish cleanly and lets the service manager
 start a fresh Gateway for a restart.
 
+An explicit server-close failure retains exit status `1`, including when final
+provider cleanup crosses the native shutdown deadline.
+
 Foreground/manual Gateways and other supervisors retain exit status `1` when
 cleanup cannot finish before the shutdown deadline.
 

--- a/docs/cli/gateway/restart-and-supervision.md
+++ b/docs/cli/gateway/restart-and-supervision.md
@@ -32,11 +32,14 @@ leave time for cancellation and cleanup. These caps also apply to `--wait 0`. Lo
 heartbeat timeouts do not extend it. When available, the drain log reports the
 largest observed model request timeout for context.
 
-If work still ignores cancellation at the shutdown deadline, the process logs
+If work still ignores cancellation at the shutdown deadline under systemd or launchd, the process logs
 the remaining work categories, writes a diagnostic stability bundle, and exits
 with status `0`. It does not reuse that unfinished runtime for an in-process
 restart. This lets a requested stop finish cleanly and lets the service manager
 start a fresh Gateway for a restart.
+
+Foreground/manual Gateways and other supervisors retain exit status `1` when
+cleanup cannot finish before the shutdown deadline.
 
 `--force` skips the active-work drain and restarts immediately. Plain `restart` normally uses the service-manager restart path.
 

--- a/src/cli/gateway-cli/lifecycle.runtime.ts
+++ b/src/cli/gateway-cli/lifecycle.runtime.ts
@@ -3,6 +3,9 @@
 // must target the module that defines the symbol rather than a re-export facade;
 // a facade also evaluates its siblings and drags their graphs onto cold start.
 export { abortEmbeddedAgentRun } from "../../agents/embedded-agent-runner/runs.js";
+export { listActiveEmbeddedRunSessionIds } from "../../agents/embedded-agent-runner/active-run-projections.js";
+export { getDiagnosticSessionActivitySnapshot } from "../../logging/diagnostic-run-activity.js";
+export { LAUNCH_AGENT_EXIT_TIMEOUT_SECONDS } from "../../daemon/launchd-plist.js";
 export {
   respawnGatewayProcessForUpdate,
   restartGatewayProcessWithFreshPid,

--- a/src/cli/gateway-cli/run-loop.test.ts
+++ b/src/cli/gateway-cli/run-loop.test.ts
@@ -5,6 +5,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../../test/helpers/promise.js";
 import { createTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import type { HostedGatewayStop } from "../../daemon/hosted-stop.js";
+import { LAUNCH_AGENT_EXIT_TIMEOUT_SECONDS } from "../../daemon/launchd-plist.js";
+import { buildSystemdUnit } from "../../daemon/systemd-unit.js";
+import { GatewayConnectionWork } from "../../gateway/server-connection-work.js";
 import type { GatewayServer, GatewayStartupOperation } from "../../gateway/server-public.js";
 import type { GatewayActiveWorkSnapshot } from "../../infra/gateway-active-work.js";
 import type { GatewayBootLifecycleCompletion } from "../../infra/gateway-boot-lifecycle.js";
@@ -173,6 +176,9 @@ const gatewayLog = {
   error: vi.fn(),
 };
 const flushLogger = vi.fn(async () => {});
+const writeDiagnosticStabilityBundleForFailureSync = vi.fn(() => ({
+  message: "stability bundle recorded",
+}));
 const hasManagedProviderLocalServices = vi.fn(() => false);
 const stopManagedProviderLocalServices = vi.fn(async () => {});
 const cancelShutdownHardExitWatchdog = vi.fn();
@@ -288,6 +294,10 @@ vi.mock("../../logging/subsystem.js", () => ({
 
 vi.mock("../../logging/logger.js", () => ({
   flushLogger: () => flushLogger(),
+}));
+
+vi.mock("../../logging/diagnostic-stability-bundle.js", () => ({
+  writeDiagnosticStabilityBundleForFailureSync,
 }));
 
 vi.mock("../../agents/provider-runtime-lifecycle.js", () => ({
@@ -1533,6 +1543,104 @@ describe("runGatewayLoop", () => {
     });
   });
 
+  it.each<{
+    signal: "SIGTERM" | "SIGUSR1";
+    honorsAbort: boolean;
+    supervisor: "systemd" | "launchd";
+    waitMs?: number;
+  }>([
+    { signal: "SIGTERM", honorsAbort: false, supervisor: "systemd" },
+    { signal: "SIGTERM", honorsAbort: true, supervisor: "systemd" },
+    { signal: "SIGUSR1", honorsAbort: false, supervisor: "systemd" },
+    { signal: "SIGTERM", honorsAbort: false, supervisor: "launchd" },
+    { signal: "SIGUSR1", honorsAbort: false, supervisor: "launchd" },
+    { signal: "SIGUSR1", honorsAbort: false, supervisor: "systemd", waitMs: 0 },
+    { signal: "SIGUSR1", honorsAbort: false, supervisor: "systemd", waitMs: 600_000 },
+  ])(
+    "bounds $supervisor $signal cleanup when a long provider call honors abort=$honorsAbort (wait=$waitMs)",
+    async ({ signal, honorsAbort, supervisor, waitMs }) => {
+      vi.clearAllMocks();
+      const unit = buildSystemdUnit({ programArguments: ["openclaw", "gateway", "run"] });
+      const stopTimeoutMs =
+        supervisor === "launchd"
+          ? LAUNCH_AGENT_EXIT_TIMEOUT_SECONDS * 1_000
+          : Number(unit.match(/^TimeoutStopSec=(\d+)$/m)?.[1]) * 1_000;
+      const successStatuses = unit
+        .match(/^SuccessExitStatus=(.+)$/m)?.[1]
+        ?.split(" ")
+        .map(Number);
+      if (supervisor === "systemd") {
+        process.env.OPENCLAW_SYSTEMD_UNIT = "openclaw-gateway.service";
+        setPlatform("linux");
+      } else {
+        process.env.OPENCLAW_LAUNCHD_LABEL = "ai.openclaw.gateway";
+        setPlatform("darwin");
+      }
+      if (waitMs !== undefined) {
+        consumeGatewaySigusr1RestartIntent.mockReturnValueOnce({ waitMs });
+      }
+      await withIsolatedSignals(async ({ captureSignal }) => {
+        const provider = createDeferredCore();
+        const connectionWork = new GatewayConnectionWork();
+        void connectionWork.track(() => provider.promise);
+        connectionWork.signal.addEventListener("abort", () => {
+          if (honorsAbort) {
+            provider.resolve();
+          }
+        });
+        const close = vi.fn<GatewayCloseFn>(async () => {
+          await connectionWork.drain();
+        });
+        const { start, started } = createSignaledStart(close);
+        const { runtime } = createRuntimeWithExitSignal();
+        await runLoopWithStart({ start, runtime });
+        await waitForStart(started);
+        const active = createActiveWorkSnapshot({ embeddedRuns: 1 });
+        createGatewayActiveWorkSnapshot.mockReturnValue(active);
+        waitForGatewayActiveWork.mockImplementationOnce(async (timeoutMs, options) => {
+          options?.onSnapshot?.(active);
+          await new Promise<void>((resolve) => {
+            setTimeout(resolve, timeoutMs);
+          });
+          return { drained: false, snapshot: active };
+        });
+        vi.useFakeTimers();
+        try {
+          setTimeout(() => provider.resolve(), 600_000);
+          captureSignal(signal)();
+          const deadlineMs =
+            signal === "SIGTERM" || waitMs !== undefined
+              ? stopTimeoutMs - 5_000
+              : Math.min(310_000, stopTimeoutMs - 5_000);
+          expect(deadlineMs).toBeLessThan(stopTimeoutMs);
+          await vi.advanceTimersByTimeAsync(deadlineMs - 1);
+          expect(connectionWork.signal.aborted).toBe(true);
+          if (!honorsAbort) {
+            expect(runtime.exit).not.toHaveBeenCalled();
+          }
+          await vi.advanceTimersByTimeAsync(1);
+          expect(runtime.exit).toHaveBeenCalledExactlyOnceWith(0);
+          expect(successStatuses).toContain(runtime.exit.mock.calls[0]?.[0]);
+          expect(start).toHaveBeenCalledOnce();
+          if (!honorsAbort) {
+            expect(gatewayLog.warn).toHaveBeenCalledWith(
+              expect.stringMatching(/abandoning.*embeddedRuns=1/),
+            );
+            expect(writeDiagnosticStabilityBundleForFailureSync).toHaveBeenCalledWith(
+              signal === "SIGTERM"
+                ? "gateway.stop_shutdown_timeout"
+                : "gateway.restart_shutdown_timeout",
+              undefined,
+            );
+          }
+        } finally {
+          vi.clearAllTimers();
+          vi.useRealTimers();
+        }
+      });
+    },
+  );
+
   it("still closes and exits when the direct-shutdown active-work drain fails", async () => {
     vi.clearAllMocks();
 
@@ -1554,6 +1662,92 @@ describe("runGatewayLoop", () => {
         restartExpectedMs: null,
       });
       expect(runtime.exit).toHaveBeenCalledWith(0);
+    });
+  });
+
+  it("bounds managed provider service cleanup after server close", async () => {
+    vi.clearAllMocks();
+    hasManagedProviderLocalServices.mockReturnValue(true);
+    stopManagedProviderLocalServices.mockReturnValue(new Promise<void>(() => {}));
+    await withIsolatedSignals(async ({ captureSignal }) => {
+      const { close, runtime } = await createSignaledLoopHarness();
+      vi.useFakeTimers();
+      try {
+        captureSignal("SIGTERM")();
+        await vi.advanceTimersByTimeAsync(324_999);
+        expect(close).toHaveBeenCalledOnce();
+        expect(stopManagedProviderLocalServices).toHaveBeenCalledOnce();
+        expect(runtime.exit).not.toHaveBeenCalled();
+        await vi.advanceTimersByTimeAsync(1);
+        expect(runtime.exit).toHaveBeenCalledExactlyOnceWith(0);
+        expect(writeDiagnosticStabilityBundleForFailureSync).toHaveBeenCalledWith(
+          "gateway.stop_shutdown_timeout",
+          undefined,
+        );
+      } finally {
+        vi.clearAllTimers();
+        vi.useRealTimers();
+      }
+    });
+  });
+
+  it("bounds abandoned cleanup after a managed update parks the native service", async () => {
+    vi.clearAllMocks();
+    process.env.OPENCLAW_SYSTEMD_UNIT = "openclaw-gateway.service";
+    setPlatform("linux");
+    consumeGatewaySigusr1RestartIntent.mockReturnValueOnce({
+      force: true,
+      reason: "update.run",
+      successorOwner: managedUpdateSuccessorOwner,
+    });
+    cancelManagedServiceUpdateHandoff.mockResolvedValue("restart-after-exit");
+    await withIsolatedSignals(async ({ captureSignal }) => {
+      const { close, start, runtime } = await createSignaledLoopHarness();
+      close.mockReturnValue(new Promise<void>(() => {}));
+      vi.useFakeTimers();
+      try {
+        captureSignal("SIGUSR1")();
+        await vi.advanceTimersByTimeAsync(9_999);
+        expect(requestManagedServiceUpdateHandoffPark).toHaveBeenCalledWith(
+          managedUpdateSuccessorOwner,
+        );
+        expect(close).toHaveBeenCalledOnce();
+        expect(runtime.exit).not.toHaveBeenCalled();
+        await vi.advanceTimersByTimeAsync(1);
+        expect(runtime.exit).toHaveBeenCalledExactlyOnceWith(0);
+        expect(start).toHaveBeenCalledOnce();
+        expect(commitManagedServiceUpdateHandoff).toHaveBeenCalledWith(
+          managedUpdateSuccessorOwner,
+          "restore",
+        );
+        expect(writeDiagnosticStabilityBundleForFailureSync).toHaveBeenCalledWith(
+          "gateway.restart_shutdown_timeout",
+          undefined,
+        );
+      } finally {
+        vi.clearAllTimers();
+        vi.useRealTimers();
+      }
+    });
+  });
+
+  it("retains external supervisor recovery when timeout prevents a restart handoff", async () => {
+    vi.clearAllMocks();
+    process.env.OPENCLAW_SUPERVISOR_MODE = "external";
+    consumeGatewaySigusr1RestartIntent.mockReturnValueOnce({ force: true });
+    await withIsolatedSignals(async ({ captureSignal }) => {
+      const { close, runtime } = await createSignaledLoopHarness();
+      close.mockReturnValue(new Promise<void>(() => {}));
+      vi.useFakeTimers();
+      try {
+        captureSignal("SIGUSR1")();
+        await vi.advanceTimersByTimeAsync(325_000);
+        expect(writeGatewayRestartHandoffSync).not.toHaveBeenCalled();
+        expect(runtime.exit).toHaveBeenCalledExactlyOnceWith(1);
+      } finally {
+        vi.clearAllTimers();
+        vi.useRealTimers();
+      }
     });
   });
 
@@ -1995,7 +2189,7 @@ describe("runGatewayLoop", () => {
       });
       expectRestartCloseCall(closeSecond, DEFAULT_RESTART_DEFERRAL_TIMEOUT_MS);
       expect(markGatewaySigusr1RestartHandled).toHaveBeenCalledTimes(2);
-      expect(abortActiveCronTaskRuns).toHaveBeenCalledTimes(2);
+      expect(abortActiveCronTaskRuns).toHaveBeenCalledTimes(3);
       expect(waitForActiveCronTaskRuns).toHaveBeenCalledTimes(2);
       expect(waitForActiveCronJobs).toHaveBeenCalledTimes(2);
       expect(advanceCronActiveJobGeneration).toHaveBeenCalledTimes(2);
@@ -2010,7 +2204,10 @@ describe("runGatewayLoop", () => {
         start.mock.invocationCallOrder[1] ?? Infinity,
       );
       expect(advanceCronActiveJobGeneration.mock.invocationCallOrder[0] ?? Infinity).toBeLessThan(
-        abortActiveCronTaskRuns.mock.invocationCallOrder[0] ?? Infinity,
+        abortActiveCronTaskRuns.mock.invocationCallOrder[1] ?? Infinity,
+      );
+      expect(abortActiveCronTaskRuns.mock.invocationCallOrder[0] ?? Infinity).toBeLessThan(
+        closeFirst.mock.invocationCallOrder[0] ?? Infinity,
       );
       expect(waitForActiveCronJobs.mock.invocationCallOrder[0] ?? Infinity).toBeLessThan(
         retireActiveCronTaskRunTracking.mock.invocationCallOrder[0] ?? Infinity,

--- a/src/cli/gateway-cli/run-loop.test.ts
+++ b/src/cli/gateway-cli/run-loop.test.ts
@@ -1695,6 +1695,53 @@ describe("runGatewayLoop", () => {
     });
   });
 
+  it.each(["systemd", "launchd"] as const)(
+    "preserves a recorded close failure when %s final cleanup crosses the deadline",
+    async (supervisor) => {
+      vi.clearAllMocks();
+      const deadlineMs =
+        supervisor === "launchd" ? LAUNCH_AGENT_EXIT_TIMEOUT_SECONDS * 1_000 - 5_000 : 325_000;
+      if (supervisor === "systemd") {
+        process.env.OPENCLAW_SYSTEMD_UNIT = "openclaw-gateway.service";
+        setPlatform("linux");
+      } else {
+        process.env.OPENCLAW_LAUNCHD_LABEL = "ai.openclaw.gateway";
+        setPlatform("darwin");
+      }
+      hasManagedProviderLocalServices.mockReturnValue(true);
+      stopManagedProviderLocalServices.mockImplementation(
+        () =>
+          new Promise<void>((resolve) => {
+            setTimeout(resolve, 2_000);
+          }),
+      );
+      await withIsolatedSignals(async ({ captureSignal }) => {
+        const { close, runtime } = await createSignaledLoopHarness();
+        close.mockImplementationOnce(async () => {
+          await new Promise<void>((resolve) => {
+            setTimeout(resolve, deadlineMs - 1_000);
+          });
+          throw new Error("close owner failed");
+        });
+        vi.useFakeTimers();
+        try {
+          captureSignal("SIGTERM")();
+          await vi.advanceTimersByTimeAsync(deadlineMs - 1);
+          expect(gatewayLog.error).toHaveBeenCalledWith(
+            "shutdown step failed (gateway server close): close owner failed",
+          );
+          expect(stopManagedProviderLocalServices).toHaveBeenCalledOnce();
+          expect(runtime.exit).not.toHaveBeenCalled();
+          await vi.advanceTimersByTimeAsync(1);
+          expect(runtime.exit).toHaveBeenCalledExactlyOnceWith(1);
+        } finally {
+          vi.clearAllTimers();
+          vi.useRealTimers();
+        }
+      });
+    },
+  );
+
   it.each([true, false])(
     "bounds abandoned cleanup after managed parking (restore commit=%s)",
     async (restoreCommitted) => {

--- a/src/cli/gateway-cli/run-loop.test.ts
+++ b/src/cli/gateway-cli/run-loop.test.ts
@@ -1691,45 +1691,51 @@ describe("runGatewayLoop", () => {
     });
   });
 
-  it("bounds abandoned cleanup after a managed update parks the native service", async () => {
-    vi.clearAllMocks();
-    process.env.OPENCLAW_SYSTEMD_UNIT = "openclaw-gateway.service";
-    setPlatform("linux");
-    consumeGatewaySigusr1RestartIntent.mockReturnValueOnce({
-      force: true,
-      reason: "update.run",
-      successorOwner: managedUpdateSuccessorOwner,
-    });
-    cancelManagedServiceUpdateHandoff.mockResolvedValue("restart-after-exit");
-    await withIsolatedSignals(async ({ captureSignal }) => {
-      const { close, start, runtime } = await createSignaledLoopHarness();
-      close.mockReturnValue(new Promise<void>(() => {}));
-      vi.useFakeTimers();
-      try {
-        captureSignal("SIGUSR1")();
-        await vi.advanceTimersByTimeAsync(9_999);
-        expect(requestManagedServiceUpdateHandoffPark).toHaveBeenCalledWith(
-          managedUpdateSuccessorOwner,
-        );
-        expect(close).toHaveBeenCalledOnce();
-        expect(runtime.exit).not.toHaveBeenCalled();
-        await vi.advanceTimersByTimeAsync(1);
-        expect(runtime.exit).toHaveBeenCalledExactlyOnceWith(0);
-        expect(start).toHaveBeenCalledOnce();
-        expect(commitManagedServiceUpdateHandoff).toHaveBeenCalledWith(
-          managedUpdateSuccessorOwner,
-          "restore",
-        );
-        expect(writeDiagnosticStabilityBundleForFailureSync).toHaveBeenCalledWith(
-          "gateway.restart_shutdown_timeout",
-          undefined,
-        );
-      } finally {
-        vi.clearAllTimers();
-        vi.useRealTimers();
-      }
-    });
-  });
+  it.each([true, false])(
+    "bounds abandoned cleanup after managed parking (restore commit=%s)",
+    async (restoreCommitted) => {
+      vi.clearAllMocks();
+      process.env.OPENCLAW_SYSTEMD_UNIT = "openclaw-gateway.service";
+      setPlatform("linux");
+      consumeGatewaySigusr1RestartIntent.mockReturnValueOnce({
+        force: true,
+        reason: "update.run",
+        successorOwner: managedUpdateSuccessorOwner,
+      });
+      cancelManagedServiceUpdateHandoff
+        .mockResolvedValueOnce("restart-after-exit")
+        .mockResolvedValue("restored-in-process");
+      commitManagedServiceUpdateHandoff.mockResolvedValueOnce(restoreCommitted);
+      await withIsolatedSignals(async ({ captureSignal }) => {
+        const { close, start, runtime } = await createSignaledLoopHarness();
+        close.mockReturnValue(new Promise<void>(() => {}));
+        vi.useFakeTimers();
+        try {
+          captureSignal("SIGUSR1")();
+          await vi.advanceTimersByTimeAsync(9_999);
+          expect(requestManagedServiceUpdateHandoffPark).toHaveBeenCalledWith(
+            managedUpdateSuccessorOwner,
+          );
+          expect(close).toHaveBeenCalledOnce();
+          expect(runtime.exit).not.toHaveBeenCalled();
+          await vi.advanceTimersByTimeAsync(1);
+          expect(runtime.exit).toHaveBeenCalledExactlyOnceWith(0);
+          expect(start).toHaveBeenCalledOnce();
+          expect(commitManagedServiceUpdateHandoff).toHaveBeenCalledWith(
+            managedUpdateSuccessorOwner,
+            "restore",
+          );
+          expect(writeDiagnosticStabilityBundleForFailureSync).toHaveBeenCalledWith(
+            "gateway.restart_shutdown_timeout",
+            undefined,
+          );
+        } finally {
+          vi.clearAllTimers();
+          vi.useRealTimers();
+        }
+      });
+    },
+  );
 
   it("retains external supervisor recovery when timeout prevents a restart handoff", async () => {
     vi.clearAllMocks();

--- a/src/cli/gateway-cli/run-loop.test.ts
+++ b/src/cli/gateway-cli/run-loop.test.ts
@@ -1546,10 +1546,11 @@ describe("runGatewayLoop", () => {
   it.each<{
     signal: "SIGTERM" | "SIGUSR1";
     honorsAbort: boolean;
-    supervisor: "systemd" | "launchd";
+    supervisor: "systemd" | "launchd" | "foreground";
     waitMs?: number;
   }>([
     { signal: "SIGTERM", honorsAbort: false, supervisor: "systemd" },
+    { signal: "SIGTERM", honorsAbort: false, supervisor: "foreground" },
     { signal: "SIGTERM", honorsAbort: true, supervisor: "systemd" },
     { signal: "SIGUSR1", honorsAbort: false, supervisor: "systemd" },
     { signal: "SIGTERM", honorsAbort: false, supervisor: "launchd" },
@@ -1572,7 +1573,7 @@ describe("runGatewayLoop", () => {
       if (supervisor === "systemd") {
         process.env.OPENCLAW_SYSTEMD_UNIT = "openclaw-gateway.service";
         setPlatform("linux");
-      } else {
+      } else if (supervisor === "launchd") {
         process.env.OPENCLAW_LAUNCHD_LABEL = "ai.openclaw.gateway";
         setPlatform("darwin");
       }
@@ -1619,8 +1620,11 @@ describe("runGatewayLoop", () => {
             expect(runtime.exit).not.toHaveBeenCalled();
           }
           await vi.advanceTimersByTimeAsync(1);
-          expect(runtime.exit).toHaveBeenCalledExactlyOnceWith(0);
-          expect(successStatuses).toContain(runtime.exit.mock.calls[0]?.[0]);
+          const expectedExit = supervisor === "foreground" && !honorsAbort ? 1 : 0;
+          expect(runtime.exit).toHaveBeenCalledExactlyOnceWith(expectedExit);
+          if (supervisor !== "foreground") {
+            expect(successStatuses).toContain(runtime.exit.mock.calls[0]?.[0]);
+          }
           expect(start).toHaveBeenCalledOnce();
           if (!honorsAbort) {
             expect(gatewayLog.warn).toHaveBeenCalledWith(
@@ -1665,7 +1669,7 @@ describe("runGatewayLoop", () => {
     });
   });
 
-  it("bounds managed provider service cleanup after server close", async () => {
+  it("reports failure when foreground provider service cleanup times out after server close", async () => {
     vi.clearAllMocks();
     hasManagedProviderLocalServices.mockReturnValue(true);
     stopManagedProviderLocalServices.mockReturnValue(new Promise<void>(() => {}));
@@ -1679,7 +1683,7 @@ describe("runGatewayLoop", () => {
         expect(stopManagedProviderLocalServices).toHaveBeenCalledOnce();
         expect(runtime.exit).not.toHaveBeenCalled();
         await vi.advanceTimersByTimeAsync(1);
-        expect(runtime.exit).toHaveBeenCalledExactlyOnceWith(0);
+        expect(runtime.exit).toHaveBeenCalledExactlyOnceWith(1);
         expect(writeDiagnosticStabilityBundleForFailureSync).toHaveBeenCalledWith(
           "gateway.stop_shutdown_timeout",
           undefined,

--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -71,6 +71,14 @@ const gatewayLifecycleRuntimeLoader = createLazyImportLoader<GatewayLifecycleRun
 
 const loadGatewayLifecycleRuntimeModule = () => gatewayLifecycleRuntimeLoader.load();
 
+// Blocker descriptions can contain task identities and request origins.
+function formatDrainCounts(snapshot: GatewayActiveWorkSnapshot): string {
+  return Object.entries(snapshot.counts)
+    .filter(([name, count]) => name !== "totalActive" && count > 0)
+    .map(([name, count]) => `${name}=${count}`)
+    .join(" ");
+}
+
 async function waitForGatewayPortReady(host: string, port: number): Promise<boolean> {
   return await new Promise<boolean>((resolve) => {
     const socket = net.createConnection({ host, port });
@@ -369,7 +377,7 @@ export async function runGatewayLoop(params: {
       return false;
     }
   };
-  const forceExitAfterStabilityBundle = async (reason: string) => {
+  const forceExitAfterStabilityBundle = async (reason: string, exitCode = 1) => {
     void hostLifecycle?.retire();
     try {
       writeStabilityBundle(reason);
@@ -382,9 +390,9 @@ export async function runGatewayLoop(params: {
       if (restoration) {
         params.completeBoot?.({ outcome: "forced_stop", reason });
         if (restoration === "restart-after-exit") {
-          await exitProcessAfterLogFlush(1, owner, "restore");
+          await exitProcessAfterLogFlush(exitCode, owner, "restore");
         } else {
-          exitProcess(1);
+          exitProcess(exitCode);
         }
       }
     }
@@ -563,6 +571,11 @@ export async function runGatewayLoop(params: {
   // turn to settle before systemd resorts to SIGKILL.
   const SUPERVISOR_STOP_TIMEOUT_MS = 330_000;
   const SHUTDOWN_TIMEOUT_MS = SUPERVISOR_STOP_TIMEOUT_MS - 5_000;
+  const nativeStopBudget = supervisorMode === "systemd" || supervisorMode === "launchd";
+  const acceptedShutdownTimeoutMs =
+    supervisorMode === "launchd"
+      ? eagerLifecycleRuntime.LAUNCH_AGENT_EXIT_TIMEOUT_SECONDS * 1_000 - 5_000
+      : SHUTDOWN_TIMEOUT_MS;
   const clearPendingStartupForceExitTimer = () => {
     clearTimeout(pendingStartupForceExitTimer ?? undefined);
     pendingStartupForceExitTimer = null;
@@ -674,14 +687,20 @@ export async function runGatewayLoop(params: {
     }
     let forceExitTimer: ReturnType<typeof setTimeout> | null = null;
     let hardExitWatchdog: ShutdownHardExitWatchdog | null = null;
+    let lastDrainCounts = "not observed";
     const armForceExitTimer = (forceExitMs: number) => {
       if (forceExitTimer) {
         return;
       }
       forceExitTimer = setTimeout(() => {
-        gatewayLog.error("shutdown timed out; exiting without full cleanup");
+        // Other supervisors still need failure recovery when no restart handoff was committed.
+        const cleanExit = action !== "restart" || nativeStopBudget;
+        gatewayLog.warn(
+          `shutdown deadline reached; abandoning unfinished cleanup and active work before ${action}; last observed: ${lastDrainCounts}; exiting ${cleanExit ? "cleanly" : "for supervisor recovery"}`,
+        );
         void forceExitAfterStabilityBundle(
           isRestart ? "gateway.restart_shutdown_timeout" : "gateway.stop_shutdown_timeout",
+          cleanExit ? 0 : 1,
         );
       }, forceExitMs);
       if (params.ownsProcessLifecycle === true) {
@@ -705,7 +724,7 @@ export async function runGatewayLoop(params: {
       forceActiveRestartExit = () => {
         clearForceExitTimer();
         if (!getManagedUpdateOwner()) {
-          armForceExitTimer(SHUTDOWN_TIMEOUT_MS);
+          armForceExitTimer(acceptedShutdownTimeoutMs);
         }
       };
     }
@@ -718,33 +737,39 @@ export async function runGatewayLoop(params: {
         | "restart-after-exit"
         | undefined;
       let shutdownFailed = false;
-      const restartDrainTimeoutMs = isRestart ? resolveRestartDrainTimeoutMs(restartIntent) : 0;
+      const requestedRestartDrainTimeoutMs = isRestart
+        ? resolveRestartDrainTimeoutMs(restartIntent)
+        : 0;
+      const restartDrainTimeoutMs = nativeStopBudget
+        ? Math.min(
+            requestedRestartDrainTimeoutMs ?? Infinity,
+            acceptedShutdownTimeoutMs - RESTART_CLOSE_REPLY_DRAIN_SHUTDOWN_RESERVE_MS,
+          )
+        : requestedRestartDrainTimeoutMs;
       const restartDrainDeadlineAt =
         isRestart && restartDrainTimeoutMs !== undefined
           ? Date.now() + restartDrainTimeoutMs
           : undefined;
       // Managed helpers must reach native parking before either exit watchdog can arm.
       if (!isRestart) {
-        armForceExitTimer(SHUTDOWN_TIMEOUT_MS);
+        armForceExitTimer(acceptedShutdownTimeoutMs);
       } else if (restartDrainTimeoutMs !== undefined && !getManagedUpdateOwner()) {
-        // Allow extra time for draining active turns on explicitly capped restarts.
-        armForceExitTimer(restartDrainTimeoutMs + SHUTDOWN_TIMEOUT_MS);
+        armForceExitTimer(
+          restartDrainTimeoutMs +
+            (nativeStopBudget
+              ? RESTART_CLOSE_REPLY_DRAIN_SHUTDOWN_RESERVE_MS
+              : SHUTDOWN_TIMEOUT_MS),
+        );
       }
 
       const drainTimeoutMs = isRestart
         ? restartDrainTimeoutMs
-        : Math.max(0, SHUTDOWN_TIMEOUT_MS - RESTART_CLOSE_REPLY_DRAIN_SHUTDOWN_RESERVE_MS);
+        : Math.max(0, acceptedShutdownTimeoutMs - RESTART_CLOSE_REPLY_DRAIN_SHUTDOWN_RESERVE_MS);
       const drainBudget =
         drainTimeoutMs === undefined ? "without a timeout" : `with timeout ${drainTimeoutMs}ms`;
-      // The canonical inventory owns these category counts. Blocker descriptions
-      // can contain task identities and request origins; never include them here.
-      const formatDrainCounts = (snapshot: GatewayActiveWorkSnapshot) =>
-        Object.entries(snapshot.counts)
-          .filter(([name, count]) => name !== "totalActive" && count > 0)
-          .map(([name, count]) => `${name}=${count}`)
-          .join(" ");
       let lastPendingWarningAt: number | undefined;
       const reportDrainSnapshot = (snapshot: GatewayActiveWorkSnapshot) => {
+        lastDrainCounts = formatDrainCounts(snapshot) || "no active work";
         const now = Date.now();
         if (lastPendingWarningAt === undefined) {
           lastPendingWarningAt = now;
@@ -752,6 +777,21 @@ export async function runGatewayLoop(params: {
             gatewayLog.info(
               `draining active work before ${action} ${drainBudget}: ${formatDrainCounts(snapshot)}`,
             );
+            const requestTimeoutMs = Math.max(
+              0,
+              ...eagerLifecycleRuntime
+                .listActiveEmbeddedRunSessionIds()
+                .map(
+                  (sessionId) =>
+                    eagerLifecycleRuntime.getDiagnosticSessionActivitySnapshot({ sessionId })
+                      ?.activeModelCallRequestTimeoutMs ?? 0,
+                ),
+            );
+            if (requestTimeoutMs > 0) {
+              gatewayLog.info(
+                `largest observed model request timeout is ${requestTimeoutMs}ms; shutdown drain budget remains ${drainBudget}`,
+              );
+            }
           }
         } else if (
           !snapshot.idle &&
@@ -813,6 +853,7 @@ export async function runGatewayLoop(params: {
                 return;
               }
               drainTimedOut = true;
+              eagerLifecycleRuntime.abortActiveCronTaskRuns("Gateway restarting.");
               gatewayLog.warn(
                 `active-work drain timeout reached; proceeding with restart: ${formatDrainCounts(drain.snapshot)}`,
               );
@@ -838,6 +879,8 @@ export async function runGatewayLoop(params: {
               gatewayLog.warn(
                 `gateway active-work drain timeout reached; proceeding with shutdown: ${formatDrainCounts(activeWorkDrain.snapshot)}`,
               );
+              eagerLifecycleRuntime.abortEmbeddedAgentRun(undefined, { mode: "all" });
+              eagerLifecycleRuntime.abortActiveCronTaskRuns("Gateway stopping.");
             }
           } catch (err) {
             gatewayLog.warn(
@@ -877,12 +920,13 @@ export async function runGatewayLoop(params: {
           }
         }
 
-        if (
-          isRestart &&
-          !forceExitTimer &&
-          (!managedUpdateOwner || managedUpdateCancellation === "restored-in-process")
-        ) {
-          armForceExitTimer(SHUTDOWN_TIMEOUT_MS);
+        if (isRestart && !forceExitTimer) {
+          armForceExitTimer(
+            nativeStopBudget
+              ? Math.max(0, (restartDrainDeadlineAt ?? Date.now()) - Date.now()) +
+                  RESTART_CLOSE_REPLY_DRAIN_SHUTDOWN_RESERVE_MS
+              : SHUTDOWN_TIMEOUT_MS,
+          );
         }
         const closeDrainTimeoutMs = !isRestart
           ? null
@@ -929,7 +973,6 @@ export async function runGatewayLoop(params: {
           }
         } else {
           await hostLifecycle?.retire();
-          clearForceExitTimer();
           if (isRestart && shutdownFailed) {
             await forceExitAfterStabilityBundle("gateway.restart_close_failed");
           } else {
@@ -947,6 +990,7 @@ export async function runGatewayLoop(params: {
             await releaseLockIfHeld();
             await exitProcessAfterLogFlush(shutdownFailed ? 1 : 0);
           }
+          clearForceExitTimer();
         }
       }
     })();

--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -205,6 +205,7 @@ export async function runGatewayLoop(params: {
   let startupOperations = createGatewayStartupOperations();
   let terminalHostedStop: ReturnType<typeof createGatewayHostLifecycle> | undefined;
   let shuttingDown = false;
+  let forcedExitStarted = false;
   let restartResolver: (() => void) | null = null;
   // The HTTP server can report ready before params.start returns its close handle.
   // Defer lifecycle signals from that window until the loop can close and advance.
@@ -330,7 +331,7 @@ export async function runGatewayLoop(params: {
         continue;
       }
       // Restoring the helper does not make a failed generation reusable.
-      if (code === 0 && !committedGenericSuccessor && initialOwner) {
+      if (code === 0 && !forcedExitStarted && !committedGenericSuccessor && initialOwner) {
         return reacquireAndResumeInProcessRestart(getManagedUpdateOwner() ?? owner);
       }
       exitProcess(code);
@@ -378,6 +379,10 @@ export async function runGatewayLoop(params: {
     }
   };
   const forceExitAfterStabilityBundle = async (reason: string, exitCode = 1) => {
+    if (forcedExitStarted) {
+      return;
+    }
+    forcedExitStarted = true;
     void hostLifecycle?.retire();
     try {
       writeStabilityBundle(reason);
@@ -401,12 +406,15 @@ export async function runGatewayLoop(params: {
     alreadyCancelledOwner?: GatewayRestartIntent["successorOwner"],
   ): Promise<void> => {
     for (;;) {
+      if (forcedExitStarted) {
+        return;
+      }
       const restartRequest = activeRestartRequest;
       const restartOwner = restartRequest?.restartIntent?.successorOwner;
       const restoration = sameManagedUpdateOwner(restartOwner, alreadyCancelledOwner)
         ? "restored-in-process"
         : await cancelManagedUpdateHandoffBeforeRecovery(restartOwner);
-      if (!restoration) {
+      if (!restoration || forcedExitStarted) {
         return;
       }
       if (restoration === "restart-after-exit") {
@@ -419,6 +427,9 @@ export async function runGatewayLoop(params: {
       try {
         lock = await acquireGatewayLock({ port: params.lockPort });
       } catch (err) {
+        if (forcedExitStarted) {
+          return;
+        }
         if (activeRestartRequest !== restartRequest) {
           continue;
         }
@@ -426,7 +437,7 @@ export async function runGatewayLoop(params: {
         exitProcess(1);
         return;
       }
-      if (activeRestartRequest === restartRequest) {
+      if (!forcedExitStarted && activeRestartRequest === restartRequest) {
         activeRestartRequest = null;
         shuttingDown = false;
         restartResolver?.();
@@ -445,6 +456,9 @@ export async function runGatewayLoop(params: {
     cancelled = false,
   ): Promise<void> => {
     await releaseLockIfHeld();
+    if (forcedExitStarted) {
+      return;
+    }
     // Lock release may yield while a managed update upgrades this restart.
     const restartReason = activeRestartRequest?.restartReason;
     params.completeBoot?.({

--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -707,14 +707,12 @@ export async function runGatewayLoop(params: {
         return;
       }
       forceExitTimer = setTimeout(() => {
-        // Other supervisors still need failure recovery when no restart handoff was committed.
-        const cleanExit = action !== "restart" || nativeStopBudget;
         gatewayLog.warn(
-          `shutdown deadline reached; abandoning unfinished cleanup and active work before ${action}; last observed: ${lastDrainCounts}; exiting ${cleanExit ? "cleanly" : "for supervisor recovery"}`,
+          `shutdown deadline reached; abandoning unfinished cleanup and active work before ${action}; last observed: ${lastDrainCounts}; exiting ${nativeStopBudget ? "cleanly" : "with incomplete cleanup"}`,
         );
         void forceExitAfterStabilityBundle(
           isRestart ? "gateway.restart_shutdown_timeout" : "gateway.stop_shutdown_timeout",
-          cleanExit ? 0 : 1,
+          nativeStopBudget ? 0 : 1,
         );
       }, forceExitMs);
       if (params.ownsProcessLifecycle === true) {

--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -702,17 +702,19 @@ export async function runGatewayLoop(params: {
     let forceExitTimer: ReturnType<typeof setTimeout> | null = null;
     let hardExitWatchdog: ShutdownHardExitWatchdog | null = null;
     let lastDrainCounts = "not observed";
+    let shutdownFailed = false;
     const armForceExitTimer = (forceExitMs: number) => {
       if (forceExitTimer) {
         return;
       }
       forceExitTimer = setTimeout(() => {
+        const cleanExit = nativeStopBudget && !shutdownFailed;
         gatewayLog.warn(
-          `shutdown deadline reached; abandoning unfinished cleanup and active work before ${action}; last observed: ${lastDrainCounts}; exiting ${nativeStopBudget ? "cleanly" : "with incomplete cleanup"}`,
+          `shutdown deadline reached; abandoning unfinished cleanup and active work before ${action}; last observed: ${lastDrainCounts}; exiting ${cleanExit ? "cleanly" : "with incomplete cleanup"}`,
         );
         void forceExitAfterStabilityBundle(
           isRestart ? "gateway.restart_shutdown_timeout" : "gateway.stop_shutdown_timeout",
-          nativeStopBudget ? 0 : 1,
+          cleanExit ? 0 : 1,
         );
       }, forceExitMs);
       if (params.ownsProcessLifecycle === true) {
@@ -748,7 +750,6 @@ export async function runGatewayLoop(params: {
         | "restored-in-process"
         | "restart-after-exit"
         | undefined;
-      let shutdownFailed = false;
       const requestedRestartDrainTimeoutMs = isRestart
         ? resolveRestartDrainTimeoutMs(restartIntent)
         : 0;


### PR DESCRIPTION
Fixes #146110.

Reported by @waynegault (#146110).

<details>
<summary>Additional instructions</summary>

Maintainers can push to this same-repository branch.

</details>

## What Problem This Solves

Fixes an issue where stopping or restarting a Gateway with long-running calls in flight exhausts the drain budget, exits with status 1, and leaves the systemd unit failed. Restart could also spend a second full shutdown budget after draining, outliving the native service deadline.

## Why This Change Was Made

The process owner now treats native deadline abandonment as a requested clean exit, logs the last observed work categories, and retains the existing diagnostic stability bundle. Abandoned cleanup cannot authorize an in-process restart if a managed restore commit fails. Raw execution and cleanup joins stay intact: unfinished work cannot be mistaken for safely retired resources or reused by an in-process restart.

Native drains follow the generated service contracts: at most 315 seconds for systemd (330-second stop limit), and 5 seconds for launchd (20-second stop limit), each followed by the existing 10-second cleanup reserve. Stop deadlines cancel remaining embedded/reply and cron work; restart deadlines cancel cron work while preserving the server owner's session-recovery ordering. A parked managed update receives a bounded cleanup window and retains its existing restoration handoff. The stop watchdog stays armed through final provider-service cleanup. Available model timeout diagnostics explain long calls without extending the native budget.

## User Impact

On systemd and launchd, a Gateway stop or restart with long-running calls in flight now abandons them at the drain deadline and exits cleanly instead of failing the unit. Native supervision can start a fresh process for a restart. Calls that honor cancellation still settle normally.

Foreground/manual shutdown timeouts continue to report failure with exit status `1`; only systemd/launchd deadline abandonment uses exit status `0`.

Native service deadlines also cap explicit oversized waits and `--wait 0`; the documentation describes that limit. Explicit close failures continue to report failure.

## Evidence

The new regressions were run against the original production files by reversing only the task's production patch, then restoring it without stash or branch changes:

```text
node scripts/run-vitest.mjs src/cli/gateway-cli/run-loop.test.ts -t 'bounds '
Before: 8 failed | 2 passed | 85 skipped
  SIGTERM: expected exit 0, received 1
  SIGUSR1/final cleanup/managed parking: no exit by the deadline
  Oversized native wait: cancellation had not reached the active call

node scripts/run-vitest.mjs src/cli/gateway-cli/run-loop.test.ts
After: 98 passed
```

Additional focused proof passed: server shutdown/close/connection ownership, cron cancellation, systemd unit rendering, real HTTP abort propagation, provider request cancellation, and embedded-run abort behavior (350 tests across nine files, including the 98 run-loop cases). The exit assertion uses the generated systemd unit's `SuccessExitStatus` contract.

Linux native service proof passed on [Blacksmith Testbox](https://github.com/openclaw/openclaw/actions/runs/34704298219), with a generated systemd user unit and unchanged production timers. The fixture uses the real process shutdown owner and connection-work join, with a synthetic HTTP provider adapter that deliberately ignores cancellation and holds its response for ten minutes. It asserts that provider execution and server close did not settle before process exit.

The stop cell passed: abort at approximately 315 seconds, exit 0 at approximately 325 seconds, `Result=success`, `ExecMainStatus=0`, `ActiveState=inactive`, and a successful subsequent start with a fresh PID. Reload-triggered restart also passed: abort at approximately 300 seconds, exit 0 at approximately 310 seconds, and an automatic successor ready at 317 seconds with `NRestarts=1` and `Result=success`. Both `gateway.stop_shutdown_timeout` and `gateway.restart_shutdown_timeout` stability bundles were verified. The fixture unit and all its processes were removed afterward.

`pnpm build` passed for `0d8a155986a`. The status-only follow-up passed `node scripts/check-changed.mjs`, including strict core/test typechecking, targeted lint, and all selected guards. The final run-loop invocation passed 98 tests, and the full nine-file selection passed all 350 tests.

The Linux timing and exit behavior exercised above are unchanged by the later macOS budget and managed-restore fallback corrections. The two macOS budget cases fail on original source at launchd's actual deadline and pass with the repair. A separate restore-commit-failure regression failed on the first patch and now passes: abandoned cleanup can never authorize in-process runtime reuse.

The initial HTTP fixture allowed the client's own idle timeout to settle work; it was rejected as abandonment proof and corrected to stream harmless body chunks while keeping the response unfinished.

Known limits: observed model timeout metadata is optional and does not cover every operation. An already-running older Gateway retains its old shutdown code through the first update hop. This change does not alter persistent recovery, native handoff ownership checks, or the separate hard-kill fallback for a blocked main thread. Foreground/manual Gateways and all other non-native shutdowns retain exit status `1` when cleanup times out. Successful foreground cleanup still exits `0`.

The foreground SIGTERM and final provider-service cleanup regressions both failed on `0d8a155986a` with expected exit `1`, received `0`; both pass after restricting the timeout status to the existing native-supervisor predicate. Existing systemd/launchd cases still require exit `0`, an abandonment log, and the stability bundle.

Exact-head [CI run 34709002958](https://github.com/openclaw/openclaw/actions/runs/34709002958) passed for `483dfaf9397f8e377a29b695d9475cdbff004b80`. Bounded fallback polling confirmed 100 passing checks, 43 skipped, and none pending or failed. The initial watcher stopped on a Labeler run that was cancelled and superseded by a skipped Labeler run; no source-related CI failures occurred.


## ClawSweeper review

Applied the recorded-close-failure finding: the native deadline now preserves a server-close failure that was already observed while final provider cleanup is still pending. A bounded two-second cleanup reproduces the race for both systemd and launchd. With the regression alone on `483dfaf9397f8e377a29b695d9475cdbff004b80`, both cases failed with expected exit `1`, received `0`; after the fix, the full run-loop file passed all 100 tests. Commands: `node scripts/run-vitest.mjs src/cli/gateway-cli/run-loop.test.ts -t 'preserves a recorded close failure'` (before) and `node scripts/run-vitest.mjs src/cli/gateway-cli/run-loop.test.ts` (after).

No additional live launchd or published-driver upgrade campaign was run for this status fixup. The existing Linux systemd proof and simulated launchd deadline cases cover bounded abandonment; live launchd and first-hop published-driver validation remain explicit evidence limits. An older running Gateway still executes its old shutdown code on the first update hop.

The fixup is `31e3321fd58ba43f6755ef73b6f1627de7992451`. Independent review of the fixup was scoped-clean through P2. Changed-file validation passed core and test typechecking and all selected guards; its initial lint failure was limited to two implicit timer-handle returns in the new test. Block-bodied callbacks fixed those errors, targeted lint and both regression cases passed again, and all remaining guards completed successfully.

The completed ClawSweeper review of `31e3321fd58ba43f6755ef73b6f1627de7992451` confirms the close-failure finding is resolved and reports no actionable code findings. Its remaining live launchd and published-driver evidence requests are skipped for this scoped, maintainer-directed landing and remain the limitations described above.
