### PR TITLE
fix(ui): remove raw object defaults from settings

### DIFF
--- a/docs/web/control-ui/feature-reference.md
+++ b/docs/web/control-ui/feature-reference.md
@@ -55,6 +55,7 @@ Control UI capabilities grouped by area, each with the Gateway RPC methods behin
   </Accordion>
   <Accordion title="Config">
     - View/edit `~/.openclaw/openclaw.json` (`config.get`, `config.set`).
+    - Structured settings show default hints on individual fields, without repeating the whole object's defaults as JSON above the controls.
     - Settings navigation starts with Ask OpenClaw, Profile, Appearance, and Notifications up top; Connections (Gateway, Channels, Communications, Talk, Devices); Agents & Tools (Agents, Labs, Models, MCP, Memory, Automation); Privacy & Security (Security, Secrets, Approvals); and System (Infrastructure, Advanced, Debug, Logs, About). Language leads the Appearance page, model defaults live on Models, and Gateway host details live on Gateway.
     - Privacy & Security: curated rows for gateway auth, exec policy, browser enablement, tool profile, device auth, and mobile pairing, above the schema-backed `security`/`approvals` sections.
     - Secrets (`/settings/secrets`) manages team-scoped secret and environment entries through `secrets.store.*`. Environment values remain visible, secret values are never returned after saving, Bulk Add accepts quoted multiline dotenv values, and mutation actions are hidden when the connected Gateway does not advertise them.

--- a/ui/src/components/config-form-collection-defaults.browser.test.ts
+++ b/ui/src/components/config-form-collection-defaults.browser.test.ts
@@ -242,7 +242,7 @@ describe("config form collection defaults", () => {
     expect(container.textContent).not.toContain("default-token");
   });
 
-  it("shows a top-level object default without nesting the section", () => {
+  it("shows inherited child defaults without an object JSON summary or nested section", () => {
     const container = document.createElement("div");
     const onPatch = vi.fn();
     const onRemove = vi.fn();
@@ -272,7 +272,7 @@ describe("config form collection defaults", () => {
       container,
     );
 
-    expect(container.textContent).toContain('Default: {"mode":"balanced"}');
+    expect(container.textContent).not.toContain('{"mode":"balanced"}');
     expect(container.querySelector("details")).toBeNull();
     expect(onPatch).not.toHaveBeenCalled();
 
@@ -295,7 +295,7 @@ describe("config form collection defaults", () => {
       container,
     );
 
-    expect(container.textContent).toContain('Using default: {"mode":"balanced"}');
+    expect(container.textContent).not.toContain('{"mode":"balanced"}');
     expect(container.querySelector("details")).toBeNull();
     expect(
       expectElement(container.querySelector<HTMLInputElement>("input"), "inherited mode")
@@ -380,7 +380,7 @@ describe("config form collection defaults", () => {
       ),
       "explicit profile object",
     );
-    expect(profile.textContent).toContain('Default: {"enabled":true,"mode":"balanced"}');
+    expect(profile.textContent).not.toContain('{"enabled":true,"mode":"balanced"}');
     expect(onPatch).not.toHaveBeenCalled();
 
     onRemove.mockClear();
@@ -407,9 +407,7 @@ describe("config form collection defaults", () => {
       ),
       "inherited profile object",
     );
-    expect(inheritedProfile.textContent).toContain(
-      'Using default: {"enabled":true,"mode":"balanced"}',
-    );
+    expect(inheritedProfile.textContent).not.toContain('{"enabled":true,"mode":"balanced"}');
     const enabledRow = expectElement(
       Array.from(inheritedProfile.querySelectorAll(".settings-row")).find((row) =>
         row.textContent?.includes("Enabled"),

--- a/ui/src/components/config-form.node.collection.ts
+++ b/ui/src/components/config-form.node.collection.ts
@@ -29,7 +29,6 @@ import {
 import { renderMapField } from "./config-form.node.collection-map.ts";
 import {
   renderCollectionDefaultDescription,
-  renderFlatDefaultRow,
   renderFieldRow,
   renderTags,
   schemaWithDefault,
@@ -80,7 +79,6 @@ export function renderObject(
     fallback && typeof fallback === "object" && !Array.isArray(fallback)
       ? (fallback as Record<string, unknown>)
       : {};
-  const defaultDescription = renderCollectionDefaultDescription(params, fallback);
   const entries = objectPropertyKeys(schema)
     .map((key) => [key, objectPropertySchema(schema, key)] as const)
     .filter((entry): entry is readonly [string, ConfigNodeRenderParams["schema"]] =>
@@ -181,7 +179,7 @@ export function renderObject(
   // Top-level objects and label-less contexts emit rows directly into the
   // surrounding settings-group so row dividers stay sibling-driven.
   if (path.length === 1 || params.showLabel === false) {
-    return html`${path.length === 1 ? renderFlatDefaultRow(defaultDescription) : nothing}${fields}`;
+    return fields;
   }
 
   // Nested objects get collapsible treatment as an indented sub-block.
@@ -191,11 +189,6 @@ export function renderObject(
         <div class="settings-row__text">
           <span class="settings-row__title">${label}</span>
           ${help ? html`<span class="settings-row__desc">${help}</span>` : nothing}
-          ${
-            schema.default !== undefined
-              ? html`<span class="settings-row__desc">${defaultDescription}</span>`
-              : nothing
-          }
           ${renderTags(tags)}
         </div>
         <div class="settings-row__control">

--- a/ui/src/components/config-form.node.shared.ts
+++ b/ui/src/components/config-form.node.shared.ts
@@ -256,21 +256,6 @@ export function renderFieldRow(params: {
   `;
 }
 
-export function renderFlatDefaultRow(
-  description: TemplateResult | typeof nothing,
-): TemplateResult | typeof nothing {
-  if (description === nothing) {
-    return nothing;
-  }
-  return html`
-    <div class="settings-row">
-      <div class="settings-row__text">
-        <span class="settings-row__desc">${description}</span>
-      </div>
-    </div>
-  `;
-}
-
 export function renderCollectionDefaultDescription(
   params: ConfigNodeRenderParams,
   effectiveValue: unknown,

--- a/ui/src/e2e/config-form-defaults.e2e.test.ts
+++ b/ui/src/e2e/config-form-defaults.e2e.test.ts
@@ -152,7 +152,7 @@ suite.define(() => {
         await expect.poll(() => payloadRow.textContent()).toContain('Default: {"mode":"balanced"}');
         await expect
           .poll(() => profileBlock.textContent())
-          .toContain('Default: {"enabled":true,"mode":"balanced"}');
+          .not.toContain('{"enabled":true,"mode":"balanced"}');
         await expect.poll(() => retriesRow.getByRole("spinbutton").inputValue()).toBe("9");
         await expect.poll(() => tagsBlock.textContent()).toContain('Default: ["stable","default"]');
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users opening Settings → Automation → Commands see a raw JSON default object above controls that already explain the individual settings. The same redundant summary also appears on nested structured settings.

## Why This Change Was Made

Remove object-level default summaries from the shared structured-settings renderer and delete the helper used only for that extra row. Individual field defaults, inherited-value editing, array summaries, and dedicated JSON editors retain their existing behavior.

## User Impact

Structured settings open directly on readable controls without a redundant JSON object. Configuration values and Gateway behavior do not change.

## Evidence

- Updated existing top-level and nested-object browser assertions: both fail on the original renderer and pass after the fix.
- 72 targeted Chromium tests passed across collection defaults, the config form renderer, and scalar integrity. These cover inherited values, sibling preservation, and typed control selections.
- `node scripts/check-changed.mjs` passed, including type checks, formatting, translation verification, dead-export checks, and targeted lint.
- Built the UI and passed the config-defaults mocked-Gateway E2E, including saving cleared scalar overrides and reloading the saved config. The first CI run exposed an additional stale object-summary assertion in this flow; it is now updated.
- The first CI run also hit the pre-existing Gateway shard headroom failure. Rebased onto the main fix from #146194; the exact failing shard-coverage guard now passes locally. No shard changes are included in this PR.
- [Final exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34707236192) passed, including the required `openclaw/ci-gate`. ClawSweeper reviewed the same head with no actionable findings.
- Independent Codex review: no actionable findings through P2.
- Before/after captured in Chrome using the local mock Gateway and a synthetic Commands object default. Both Auto selections and individual default hints remain visible. No production Gateway changes were made.

Before:

![Before: raw default JSON above Commands controls](https://github.com/user-attachments/assets/7719fb01-6bac-4d1a-9ad3-7e32a8e0818c)

After:

![After: Commands starts directly with individual controls](https://github.com/user-attachments/assets/939b2517-9006-41a4-80b6-e1b27c1443c2)
