### PR TITLE
refactor(gateway): reduce allocations during parallel sessions

### DIFF
--- a/packages/ai/src/utils/credential-redaction.test.ts
+++ b/packages/ai/src/utils/credential-redaction.test.ts
@@ -2,6 +2,47 @@ import { describe, expect, it, vi } from "vitest";
 import { projectDiagnosticValue } from "./credential-redaction.js";
 
 describe("diagnostic descriptor snapshots", () => {
+  it("keeps media and credential classification isolated through reentrant policy callbacks", () => {
+    const nested: unknown[] = [];
+    expect(
+      projectDiagnosticValue(
+        {
+          outer: { mime_type: "image/png", DATA: "QUJDRA==", "api-key": "synthetic-private" },
+          second: { Password: "synthetic-private", "safe-label": "kept" },
+        },
+        {
+          omitField(key) {
+            if (key === "outer") {
+              nested.push(
+                projectDiagnosticValue({
+                  "Access-Token": "synthetic-private",
+                  visible_key: "inner",
+                }),
+              );
+            }
+            return false;
+          },
+          projectMedia(key, media) {
+            nested.push(
+              projectDiagnosticValue({
+                input_image_url: "https://media.invalid/private",
+                safe: "media",
+              }),
+            );
+            return { [key]: { redacted: true, bytes: media.bytes } };
+          },
+        },
+      ),
+    ).toEqual({
+      outer: { mime_type: "image/png", DATA: { redacted: true, bytes: 4 } },
+      second: { "safe-label": "kept" },
+    });
+    expect(nested).toEqual([
+      { visible_key: "inner" },
+      { input_image_url: "<redacted>", safe: "media" },
+    ]);
+  });
+
   it("visits numeric keys before other proxy keys when bounding shared references", () => {
     const shared = { detail: "safe" };
     const value = new Proxy(

--- a/packages/ai/src/utils/credential-redaction.ts
+++ b/packages/ai/src/utils/credential-redaction.ts
@@ -24,6 +24,19 @@ const MEDIA_FIELD_NAME_RE = new RegExp(
 );
 const MEDIA_PAYLOAD_SUFFIX_RE = new RegExp(`^(?:${MEDIA_PAYLOAD_SUFFIXES})$`, "u");
 const MEDIA_WRAPPER_NAME_RE = /^(?:input_|output_)?(?:audio|image|video)s?(?:_|$)/iu;
+const DIAGNOSTIC_FIELD_SEPARATOR_RE = /[^a-z0-9]/g;
+const MEDIA_TYPE_RE = /^(?:input|output)?(?:audio|image|video)/u;
+const MEDIA_MIME_RE = /^(?:audio|image|video)\//iu;
+const MEDIA_ARRAY_INDEX_RE = /^(?:0|[1-9]\d*)$/u;
+const MEDIA_URL_SUFFIX_RE = /(?:uri|url)$/u;
+const MEDIA_MIME_FIELDS = [
+  "mimeType",
+  "mime_type",
+  "mediaType",
+  "media_type",
+  "contentType",
+  "content_type",
+];
 const AUTHORIZATION_VALUE_RE = /\b(Bearer|Basic)\s+[A-Za-z0-9+/._~=-]{8,}/giu;
 const JWT_VALUE_RE = /\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b/gu;
 const COOKIE_HEADER_RE = /\b((?:set-)?cookie\s*:\s*)([^\r\n]+)/giu;
@@ -93,7 +106,7 @@ function hasSensitiveProseContent(value: string): boolean {
 }
 
 function normalizeDiagnosticFieldName(value: string): string {
-  return value.toLowerCase().replaceAll(/[^a-z0-9]/g, "");
+  return value.toLowerCase().replaceAll(DIAGNOSTIC_FIELD_SEPARATOR_RE, "");
 }
 
 function isCredentialFieldName(normalized: string): boolean {
@@ -132,16 +145,16 @@ function diagnosticBytes(value: unknown, numericArrays = false): Uint8Array | un
 
 function isDiagnosticMediaPayload(descriptors: PropertyDescriptorMap): boolean {
   const type = descriptors.type?.value;
-  return (
-    (typeof type === "string" &&
-      /^(?:input|output)?(?:audio|image|video)/u.test(normalizeDiagnosticFieldName(type))) ||
-    ["mimeType", "mime_type", "mediaType", "media_type", "contentType", "content_type"].some(
-      (key) => {
-        const mime = descriptors[key]?.value;
-        return typeof mime === "string" && /^(?:audio|image|video)\//iu.test(mime);
-      },
-    )
-  );
+  if (typeof type === "string" && MEDIA_TYPE_RE.test(normalizeDiagnosticFieldName(type))) {
+    return true;
+  }
+  for (const key of MEDIA_MIME_FIELDS) {
+    const mime = descriptors[key]?.value;
+    if (typeof mime === "string" && MEDIA_MIME_RE.test(mime)) {
+      return true;
+    }
+  }
+  return false;
 }
 
 type DiagnosticMediaField =
@@ -171,11 +184,13 @@ function extractDiagnosticMediaField(
   const mediaField = MEDIA_FIELD_NAME_RE.test(normalized) || MEDIA_WRAPPER_NAME_RE.test(key);
   const contextualPayload = parentMedia && MEDIA_PAYLOAD_SUFFIX_RE.test(normalized);
   if (!privateField && !mediaField && !contextualPayload) {
-    const nestedMedia =
-      value !== null && (typeof value === "object" || /^(?:0|[1-9]\d*)$/u.test(key));
-    return parentMedia && nestedMedia ? { kind: "context" } : undefined;
+    return parentMedia &&
+      value !== null &&
+      (typeof value === "object" || MEDIA_ARRAY_INDEX_RE.test(key))
+      ? { kind: "context" }
+      : undefined;
   }
-  if (/(?:uri|url)$/u.test(normalized)) {
+  if (MEDIA_URL_SUFFIX_RE.test(normalized)) {
     return { kind: "redacted" };
   }
   const encoded = diagnosticBytes(value, true) ?? (typeof value === "string" ? value : undefined);

--- a/src/gateway/server-broadcast.serialization.test.ts
+++ b/src/gateway/server-broadcast.serialization.test.ts
@@ -79,6 +79,33 @@ afterEach(() => {
 });
 
 describe("broadcast serialization failures", () => {
+  it("keeps reentrant targeted frames separate from an in-progress fanout at the same sequence", () => {
+    const first = makeClient("first");
+    const second = makeClient("second");
+    const third = makeClient("third");
+    const peers = [first, second, third];
+    const { broadcast, broadcastToConnIds } = createGatewayBroadcaster({
+      clients: new GatewayClientRegistry(peers.map((peer) => peer.client)),
+    });
+    broadcastToConnIds("skills.changed", { reason: "prime" }, new Set(["second", "third"]));
+    peers.forEach((peer) => peer.socket.send.mockClear());
+    first.socket.send.mockImplementationOnce(() => {
+      broadcastToConnIds("skills.changed", { reason: "inner" }, new Set(["first"]));
+    });
+
+    broadcast("skills.changed", { reason: "outer" });
+
+    const encode = (reason: string, seq: number) =>
+      JSON.stringify({ type: "event", event: "skills.changed", payload: { reason }, seq });
+    expect(first.socket.send.mock.calls.map(([frame]) => frame)).toEqual([
+      encode("outer", 1),
+      encode("inner", 2),
+    ]);
+    for (const peer of [second, third]) {
+      expect(peer.socket.send.mock.calls.map(([frame]) => frame)).toEqual([encode("outer", 2)]);
+    }
+  });
+
   it.each([
     ["undefined", undefined],
     ["function", () => "omitted"],

--- a/src/gateway/server-broadcast.ts
+++ b/src/gateway/server-broadcast.ts
@@ -362,6 +362,8 @@ export function createGatewayBroadcaster(params: {
       event === "presence" ? (payload as { presence: SystemPresence[] }) : undefined;
     let projectPresence: ((client: GatewayWsClient) => SystemPresence[]) | undefined;
     let outboundEventLogged = false;
+    let lastFrameSequence = 0;
+    let lastFrame: string | undefined;
     let frameBase: FrameBase | undefined = retained?.base;
     let frameFields: Omit<FrameBase, "payloadFragment"> | undefined;
     const frameBaseFor = (value: unknown): FrameBase => {
@@ -589,7 +591,15 @@ export function createGatewayBroadcaster(params: {
             presence: projectPresence(c),
           });
         }
-        frame = frameWithSequence(base, nextSeq, payloadFragment);
+        if (!presencePayload && lastFrame !== undefined && lastFrameSequence === nextSeq) {
+          frame = lastFrame;
+        } else {
+          frame = frameWithSequence(base, nextSeq, payloadFragment);
+          if (!presencePayload) {
+            lastFrameSequence = nextSeq;
+            lastFrame = frame;
+          }
+        }
       } catch (err) {
         log.error(`broadcast serialization failed for event ${event}: ${formatErrorMessage(err)}`);
         return;

--- a/src/plugins/plugin-instance-invocation.test.ts
+++ b/src/plugins/plugin-instance-invocation.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it, vi } from "vitest";
+import { pluginInstanceInvocation } from "./plugin-instance-invocation.js";
+import { PluginInstance } from "./plugin-instance.js";
+import { createEmptyPluginRegistry } from "./registry-empty.js";
+import {
+  getPluginRuntimeGatewayRequestScope,
+  withPluginRuntimeGatewayRequestScope,
+} from "./runtime/gateway-request-scope.js";
+import { createPluginRecord } from "./status.test-helpers.js";
+
+function createOwnedInstance() {
+  const registry = createEmptyPluginRegistry();
+  const record = createPluginRecord({ id: "paired-scope" });
+  registry.plugins.push(record);
+  return new PluginInstance(record.id, { record, registry });
+}
+
+describe("independent plugin execution scope views", () => {
+  it("preserves Gateway identity through invocation exit and restores both views after rejection", async () => {
+    const instance = createOwnedInstance();
+    const unowned = new PluginInstance("unowned-scope");
+    const parent = { isWebchatConnect: () => false, revalidate: async () => {} };
+    try {
+      await withPluginRuntimeGatewayRequestScope(parent, () =>
+        instance.run(async () => {
+          const call = pluginInstanceInvocation.getStore();
+          const gateway = getPluginRuntimeGatewayRequestScope()!;
+          expect(call?.instance).toBe(instance);
+          expect(gateway.revalidate).toBe(parent.revalidate);
+          const explicit = { ...gateway, pluginSource: "explicit-child" };
+          await withPluginRuntimeGatewayRequestScope(explicit, async () => {
+            await Promise.resolve();
+            expect(getPluginRuntimeGatewayRequestScope()).toBe(explicit);
+            expect(pluginInstanceInvocation.getStore()).toBe(call);
+          });
+          expect(getPluginRuntimeGatewayRequestScope()).toBe(gateway);
+          const failure = new Error("cleanup fixture");
+          await expect(
+            pluginInstanceInvocation.exit(async () => {
+              expect(pluginInstanceInvocation.getStore()).toBeUndefined();
+              expect(getPluginRuntimeGatewayRequestScope()).toBe(gateway);
+              await unowned.run(async () => {
+                await Promise.resolve();
+                expect(pluginInstanceInvocation.getStore()?.instance).toBe(unowned);
+                expect(getPluginRuntimeGatewayRequestScope()).toBe(gateway);
+              });
+              expect(pluginInstanceInvocation.getStore()).toBeUndefined();
+              expect(getPluginRuntimeGatewayRequestScope()).toBe(gateway);
+              throw failure;
+            }),
+          ).rejects.toBe(failure);
+          expect(pluginInstanceInvocation.getStore()).toBe(call);
+          expect(getPluginRuntimeGatewayRequestScope()).toBe(gateway);
+        }),
+      );
+      expect(pluginInstanceInvocation.getStore()).toBeUndefined();
+      expect(getPluginRuntimeGatewayRequestScope()).toBeUndefined();
+    } finally {
+      await Promise.all([instance.dispose(), unowned.dispose()]);
+    }
+  });
+
+  it("isolates mutable sibling Gateway views when the admitted instance token is unchanged", async () => {
+    const instance = createOwnedInstance();
+    try {
+      await instance.run(async () => {
+        const call = pluginInstanceInvocation.getStore();
+        const parent = getPluginRuntimeGatewayRequestScope()!;
+        const originalSource = parent.pluginSource;
+        const children = await Promise.all(
+          ["left", "right"].map((source) =>
+            instance.run(async () => {
+              const child = getPluginRuntimeGatewayRequestScope()!;
+              expect(child).not.toBe(parent);
+              expect(pluginInstanceInvocation.getStore()).toBe(call);
+              child.pluginSource = source;
+              await Promise.resolve();
+              expect(getPluginRuntimeGatewayRequestScope()).toBe(child);
+              expect(child.pluginSource).toBe(source);
+              expect(parent.pluginSource).toBe(originalSource);
+              return child;
+            }),
+          ),
+        );
+        expect(children[0]).not.toBe(children[1]);
+        expect(pluginInstanceInvocation.getStore()).toBe(call);
+        expect(getPluginRuntimeGatewayRequestScope()).toBe(parent);
+      });
+    } finally {
+      await instance.dispose();
+    }
+  });
+
+  it("shares one invocation facade and Gateway view across same-version module reloads", async () => {
+    const instance = createOwnedInstance();
+    try {
+      await instance.run(async () => {
+        const call = pluginInstanceInvocation.getStore();
+        const gateway = getPluginRuntimeGatewayRequestScope();
+        vi.resetModules();
+        const duplicateInvocation = await import("./plugin-instance-invocation.js");
+        const duplicateGateway = await import("./runtime/gateway-request-scope.js");
+        expect(duplicateInvocation.pluginInstanceInvocation).toBe(pluginInstanceInvocation);
+        expect(duplicateInvocation.pluginInstanceInvocation.getStore()).toBe(call);
+        expect(duplicateGateway.getPluginRuntimeGatewayRequestScope()).toBe(gateway);
+      });
+    } finally {
+      await instance.dispose();
+      vi.resetModules();
+    }
+  });
+});

--- a/src/plugins/plugin-instance-invocation.ts
+++ b/src/plugins/plugin-instance-invocation.ts
@@ -1,9 +1,57 @@
 import { AsyncLocalStorage } from "node:async_hooks";
 import { resolveGlobalSingleton } from "../shared/global-singleton.js";
-import type { PluginInvocationInstance } from "./plugin-instance.types.js";
+import type {
+  PluginExecutionFrame,
+  PluginInstanceInvocation,
+} from "./plugin-instance-invocation.types.js";
 
-// SDK source transforms and native chunks must enter and exit the same call token.
-export const pluginInstanceInvocation = resolveGlobalSingleton(
+class InvocationFrame implements PluginExecutionFrame {
+  constructor(readonly invocation: PluginInstanceInvocation) {}
+
+  withInvocation(invocation: PluginInstanceInvocation): InvocationFrame;
+  withInvocation(invocation: undefined): undefined;
+  withInvocation(invocation: PluginInstanceInvocation | undefined): InvocationFrame | undefined {
+    if (!invocation) {
+      return undefined;
+    }
+    return invocation === this.invocation ? this : new InvocationFrame(invocation);
+  }
+}
+
+// SDK source transforms and native chunks share one private frame. The public
+// Gateway scope remains a separate object with its existing copy/identity rules.
+const pluginExecutionContext = resolveGlobalSingleton(
   Symbol.for("openclaw.pluginInstanceInvocation"),
-  () => new AsyncLocalStorage<{ instance: PluginInvocationInstance; token: object }>(),
+  () => {
+    const frames = new AsyncLocalStorage<PluginExecutionFrame | undefined>();
+    return {
+      invocation: {
+        getStore(): PluginInstanceInvocation | undefined {
+          return frames.getStore()?.invocation;
+        },
+        run<T>(invocation: PluginInstanceInvocation, run: () => T): T {
+          const current = frames.getStore();
+          return frames.run(
+            current ? current.withInvocation(invocation) : new InvocationFrame(invocation),
+            run,
+          );
+        },
+        // Cache-owned retirement drops self-call admission, never the Gateway caller.
+        exit<T>(run: () => T): T {
+          const current = frames.getStore();
+          return current?.invocation ? frames.run(current.withInvocation(undefined), run) : run();
+        },
+      },
+      getFrame(this: void): PluginExecutionFrame | undefined {
+        return frames.getStore();
+      },
+      runFrame<T>(this: void, frame: PluginExecutionFrame, run: () => T): T {
+        return frames.run(frame, run);
+      },
+    };
+  },
 );
+
+export const pluginInstanceInvocation = pluginExecutionContext.invocation;
+export const getPluginExecutionFrame = pluginExecutionContext.getFrame;
+export const runWithPluginExecutionFrame = pluginExecutionContext.runFrame;

--- a/src/plugins/plugin-instance-invocation.types.ts
+++ b/src/plugins/plugin-instance-invocation.types.ts
@@ -1,0 +1,10 @@
+import type { PluginInvocationInstance } from "./plugin-instance.types.js";
+
+export type PluginInstanceInvocation = { instance: PluginInvocationInstance; token: object };
+
+/** Each frame owner preserves its context when invocation admission enters or exits. */
+export interface PluginExecutionFrame {
+  readonly invocation: PluginInstanceInvocation | undefined;
+  withInvocation(invocation: PluginInstanceInvocation): PluginExecutionFrame;
+  withInvocation(invocation: undefined): PluginExecutionFrame | undefined;
+}

--- a/src/plugins/plugin-instance.ts
+++ b/src/plugins/plugin-instance.ts
@@ -247,14 +247,10 @@ export class PluginInstance {
 
   private enter<T>(token: object, run: () => T): T {
     const current = invocation.getStore();
-    // Node can reuse an identical store instead of copying the entire async context map.
-    const invoke = () =>
-      invocation.run(
-        current?.instance === this && current.token === token ? current : { instance: this, token },
-        run,
-      );
+    const call =
+      current?.instance === this && current.token === token ? current : { instance: this, token };
     if (!this.owner) {
-      return invoke();
+      return invocation.run(call, run);
     }
     const { record } = this.owner;
     const generation = getPluginRuntimeGenerationRegistry();
@@ -271,8 +267,9 @@ export class PluginInstance {
         pluginOrigin: record.origin,
         pluginTrustedOfficialInstall: record.trustedOfficialInstall,
       },
-      invoke,
+      run,
       registry,
+      call,
     );
   }
 

--- a/src/plugins/runtime/gateway-request-scope.ts
+++ b/src/plugins/runtime/gateway-request-scope.ts
@@ -1,11 +1,19 @@
 // Gateway request scope tracks request-local plugin runtime context across async work.
-import { AsyncLocalStorage } from "node:async_hooks";
 import type {
   GatewayContextResolver,
   GatewayRequestContext,
   GatewayRequestOptions,
 } from "../../gateway/server-methods/types.js";
 import { resolveGlobalSingleton } from "../../shared/global-singleton.js";
+import {
+  getPluginExecutionFrame,
+  pluginInstanceInvocation,
+  runWithPluginExecutionFrame,
+} from "../plugin-instance-invocation.js";
+import type {
+  PluginExecutionFrame,
+  PluginInstanceInvocation,
+} from "../plugin-instance-invocation.types.js";
 import type { PluginOrigin } from "../plugin-origin.types.js";
 import type { DeclaredProviderOwnerIndex } from "../provider-owner-index.js";
 import type { PluginRegistry } from "../registry-types.js";
@@ -66,17 +74,47 @@ type PluginRuntimePluginScope = {
   pluginTrustedOfficialInstall?: boolean;
 };
 
-const PLUGIN_RUNTIME_GATEWAY_REQUEST_SCOPE_KEY: unique symbol = Symbol.for(
-  "openclaw.pluginRuntimeGatewayRequestScope",
+// Duplicate source/built modules need the same constructor for typed frame narrowing.
+const GatewayFrameConstructor = resolveGlobalSingleton(
+  Symbol.for("openclaw.pluginGatewayExecutionFrame"),
+  () =>
+    class GatewayFrame implements PluginExecutionFrame {
+      constructor(
+        readonly gatewayScope: PluginRuntimeGatewayRequestScope,
+        readonly invocation: PluginInstanceInvocation | undefined,
+      ) {}
+
+      withInvocation(invocation: PluginInstanceInvocation | undefined): GatewayFrame {
+        return invocation === this.invocation
+          ? this
+          : new GatewayFrame(this.gatewayScope, invocation);
+      }
+    },
 );
+
+function getPluginGatewayScope(): PluginRuntimeGatewayRequestScope | undefined {
+  const frame = getPluginExecutionFrame();
+  return frame instanceof GatewayFrameConstructor ? frame.gatewayScope : undefined;
+}
+
+function runWithPluginGatewayScope<T>(
+  gatewayScope: PluginRuntimeGatewayRequestScope,
+  run: () => T,
+  invocation = pluginInstanceInvocation.getStore(),
+): T {
+  const current = getPluginExecutionFrame();
+  return runWithPluginExecutionFrame(
+    current instanceof GatewayFrameConstructor &&
+      current.gatewayScope === gatewayScope &&
+      current.invocation === invocation
+      ? current
+      : new GatewayFrameConstructor(gatewayScope, invocation),
+    run,
+  );
+}
+
 const GATEWAY_CONTEXT_RESOLVERS_KEY: unique symbol = Symbol.for("openclaw.gatewayContextResolvers");
 
-const pluginRuntimeGatewayRequestScope = resolveGlobalSingleton<
-  AsyncLocalStorage<PluginRuntimeGatewayRequestScope>
->(
-  PLUGIN_RUNTIME_GATEWAY_REQUEST_SCOPE_KEY,
-  () => new AsyncLocalStorage<PluginRuntimeGatewayRequestScope>(),
-);
 // Built plugin chunks and source Gateway code must redeem the same host-issued owner bindings.
 const gatewayContextResolvers = resolveGlobalSingleton<WeakMap<object, GatewayContextResolver>>(
   GATEWAY_CONTEXT_RESOLVERS_KEY,
@@ -142,7 +180,7 @@ export const clearGatewayContextResolver = (owner: object) => gatewayContextReso
 
 /** Carry only closure-bound node authorities into a nested request scope. */
 export function getPluginRuntimeGatewayNodeAuthorities() {
-  const scope = pluginRuntimeGatewayRequestScope.getStore();
+  const scope = getPluginGatewayScope();
   return {
     invokeWithSessionNodeAuthority: scope?.invokeWithSessionNodeAuthority,
     nodePlacementGrantAuthority: scope?.nodePlacementGrantAuthority,
@@ -194,7 +232,7 @@ export function withPluginRuntimeGatewayRequestScope<T>(
   scope: PluginRuntimeGatewayRequestScope,
   run: () => T,
 ): T {
-  return pluginRuntimeGatewayRequestScope.run(scope, run);
+  return runWithPluginGatewayScope(scope, run);
 }
 
 /** Runs detached work with its captured Gateway binding, including an explicitly unbound owner. */
@@ -205,17 +243,14 @@ export function withPluginRuntimeGatewayContextResolver<T>(
 ): T {
   // Scheduler-owned work must not retain the request-local client or context
   // that happened to exist when its timer was armed.
-  const current =
-    options?.inheritRequestScope === false
-      ? undefined
-      : pluginRuntimeGatewayRequestScope.getStore();
+  const current = options?.inheritRequestScope === false ? undefined : getPluginGatewayScope();
   const scoped: PluginRuntimeGatewayRequestScope = {
     ...current,
     isWebchatConnect: current?.isWebchatConnect ?? (() => false),
     resolveGatewayContext,
   };
   delete scoped.context;
-  return pluginRuntimeGatewayRequestScope.run(scoped, run);
+  return runWithPluginGatewayScope(scoped, run);
 }
 
 /** Runs work against an owned registry handle while preserving any gateway request facts. */
@@ -227,8 +262,8 @@ export function withPluginRuntimeRegistryScope<T>(
   if (!registry) {
     return run();
   }
-  const current = pluginRuntimeGatewayRequestScope.getStore();
-  return pluginRuntimeGatewayRequestScope.run(
+  const current = getPluginGatewayScope();
+  return runWithPluginGatewayScope(
     createRegistryScope(registry, current, declaredProviderOwners),
     run,
   );
@@ -280,8 +315,9 @@ export function withPluginRuntimePluginScope<T>(
   scope: PluginRuntimePluginScope,
   run: () => T,
   registry?: PluginRegistry,
+  invocation?: PluginInstanceInvocation,
 ): T {
-  const current = pluginRuntimeGatewayRequestScope.getStore();
+  const current = getPluginGatewayScope();
   // Instance calls combine registry and identity without adding a second async frame.
   const scoped: PluginRuntimeGatewayRequestScope = registry
     ? createRegistryScope(registry, current)
@@ -289,17 +325,17 @@ export function withPluginRuntimePluginScope<T>(
       ? { ...current }
       : { isWebchatConnect: () => false };
   applyPluginScope(scoped, scope);
-  return pluginRuntimeGatewayRequestScope.run(scoped, run);
+  return runWithPluginGatewayScope(scoped, run, invocation);
 }
 
 /** Drops only generation selection; authenticated Gateway caller and authority stay attached. */
 export function runOutsidePluginRuntimeRegistryScope<T>(run: () => T): T {
-  const current = pluginRuntimeGatewayRequestScope.getStore();
+  const current = getPluginGatewayScope();
   if (!current) {
     return run();
   }
   // Registry selection and its declared provider index belong to the same generation.
-  return pluginRuntimeGatewayRequestScope.run(
+  return runWithPluginGatewayScope(
     { ...current, pluginRegistry: undefined, declaredProviderOwners: undefined },
     run,
   );
@@ -311,7 +347,7 @@ export function runOutsidePluginRuntimeRegistryScope<T>(run: () => T): T {
 export function getPluginRuntimeGatewayRequestScope():
   | PluginRuntimeGatewayRequestScope
   | undefined {
-  return pluginRuntimeGatewayRequestScope.getStore();
+  return getPluginGatewayScope();
 }
 
 /** Reads registration/request/active registry precedence without initializing a cold runtime. */


### PR DESCRIPTION
Related: #146037

<details>
<summary>Additional instructions</summary>

Maintainer-requested follow-up to busy-Gateway allocation profiling. The publication branch is in the main repository and editable by repository maintainers.

</details>

## What Problem This Solves

Busy Gateways repeatedly copy async-context maps while entering plugin calls, create diagnostic matchers for individual fields, and rebuild identical event frames for connected clients.

## Why This Change Was Made

One private context store now carries the invocation and Gateway views together. A leaf frame contract keeps the invocation owner independent of Gateway and registry types. Gateway frames preserve their concrete scope when invocation changes, and a shared constructor preserves identity across source and built SDK modules.

Public Gateway scope objects retain their identity and mutable child/sibling isolation. Invocation exit retains the Gateway caller and its authority. Diagnostic projection reuses fixed matchers and media-field names while preserving Headers validation, descriptors, ordering and redaction limits. Broadcasts reuse one non-presence frame within an invocation when recipients have the same next sequence; recipient checks, presence projection, queues, backpressure and sequence updates keep their existing behavior.

## User Impact

Less temporary allocation during parallel agent work and control-plane traffic. This change adds no public SDK, configuration, protocol or persistence contract.

## Evidence

- 763 focused runtime tests passed across 21 files, covering invocation/retirement, mutable scope isolation, diagnostic redaction and broadcast delivery.
- All 24 compiler-shard regression cases pass on the refreshed base. Full changed checks and the complete architecture gate pass, including zero runtime and full-static import cycles.
- Fresh independent P0–P2 review found no actionable issues in the revised frame design.
- Differential diagnostic and broadcast corpora preserve output bytes, proxy traces, getter behavior, nested callbacks, recipient filtering and queue behavior.
- Matched fixed workload on baseline `92565ebfce49843dda27a181c707559c761679d1` and candidate `743717a0121595f46ddd6b7e0190adeb83a9cc54`: 64 parallel sessions, 512 turns, 32 subscribers, 100 sampler rounds, 2,000 history reads and 1,024 updates. Both completed with zero failed probes and clean exits; runner and observer hashes match.
- Unprofiled main-isolate allocated bytes fell from **74,939,702,120 to 69,764,014,160 (6.91% fewer; 5.18 GB saved)**. The baseline already includes the independently landed database-path optimization, which is excluded here. These are cumulative per-isolate allocations including bounded observer work, not retained memory or a process-wide total.
- This single pair made 2,837 versus 2,876 model requests. Whole-run duration was 154.8 versus 169.7 seconds (turn load window 122.9 versus 135.4 seconds), session-list p95 was 392 versus 630 ms, and sampled peak RSS was 2601 versus 2576 MiB. Timing was worse despite lower allocation; a concurrent host transfer could not be timed reliably, so the candidate window is not certified quiet. This PR makes no latency or general RSS improvement claim.
- Full build passed. Same-candidate source/built Gateway identity and instance-slot ownership passed. The built OpenAI entrypoint profile passed at 109.05 MiB peak RSS.
- [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34709275801) is green.
- [Fresh Linux Testbox proof](https://github.com/openclaw/openclaw/actions/runs/34709827704) independently checked out and built the publication head, verified package ownership, and passed the same 512-turn synthetic workload with all probes successful. It then passed **256 real OpenAI tasks across 64 sessions and four waves**, with 269 successful live probes. Independent host verification checked every randomized CSV hash and total, output file, unique task/wave pair and final assistant marker. Both isolated Gateways exited cleanly and their task state was removed.

The measured, built, CI-tested and live-tested candidate is `743717a0121595f46ddd6b7e0190adeb83a9cc54`. Earlier four-change prototype numbers are excluded from this PR's final attribution.
