### PR TITLE
chore: rebalance Gateway typecheck shards below headroom

### DIFF
--- a/test/tsconfig/tsconfig.core.test.gateway-other.json
+++ b/test/tsconfig/tsconfig.core.test.gateway-other.json
@@ -8,5 +8,12 @@
     "../../src/gateway/session-*.test.tsx",
     "../../src/gateway/*/**/*.test.ts",
     "../../src/gateway/*/**/*.test.tsx"
+  ],
+  "exclude": [
+    "../../node_modules",
+    "../../dist",
+    "../../**/dist/**",
+    "../../src/gateway/server/**/*.test.ts",
+    "../../src/gateway/server/**/*.test.tsx"
   ]
 }

--- a/test/tsconfig/tsconfig.core.test.gateway-server.json
+++ b/test/tsconfig/tsconfig.core.test.gateway-server.json
@@ -5,6 +5,8 @@
   },
   "include": [
     "../../src/gateway/server*.test.ts",
-    "../../src/gateway/server*.test.tsx"
+    "../../src/gateway/server*.test.tsx",
+    "../../src/gateway/server/**/*.test.ts",
+    "../../src/gateway/server/**/*.test.tsx"
   ]
 }


### PR DESCRIPTION
## What Problem This Solves

Main's Gateway test typecheck shard reached 701 roots, exceeding its 700-root headroom guard and failing otherwise unrelated pull-request CI.

## Why This Change Was Made

Move the complete nested `src/gateway/server` test subtree into the existing Gateway server shard. Preserve inherited generated/dependency exclusions, once-only coverage, and the existing headroom and hard limits. This creates no additional CI jobs or runners.

## User Impact

Maintainer CI can validate changes again without relaxing its resource limits. Product runtime behavior is unchanged.

## Evidence

Captured the original headroom failure. All 24 owning shard-selection and partition tests pass after the move, as does the full core graph boundary guard. Root counts change from 701 to 644 in gateway-other and 318 to 375 in gateway-server; gateway-root remains 335. Every existing root remains covered exactly once. Independent P0–P2 review is clean. Production LOC 0; test configuration +9 net. Exact-head CI will be verified before landing.
