### PR TITLE
fix(tts): avoid synthesis for unsupported remote output

### DIFF
--- a/docs/cli/infer.md
+++ b/docs/cli/infer.md
@@ -228,6 +228,7 @@ Notes:
 
 - `tts status` only supports `--gateway` (it reflects gateway-managed TTS state).
 - Local and loopback-Gateway `tts convert --output` copies stage beside the destination and replace it only after success; a failed copy leaves an existing file unchanged.
+- Remote-Gateway `tts convert --output` is rejected before requesting speech synthesis.
 - Use `tts convert --provider <id>` when selecting a provider without overriding its model.
 - Use `tts providers`, `tts voices`, `tts personas`, `tts set-provider`, and `tts set-persona` to inspect and configure TTS behavior.
 

--- a/src/cli/capability-cli.test.ts
+++ b/src/cli/capability-cli.test.ts
@@ -3799,6 +3799,7 @@ describe("capability cli", () => {
     ).rejects.toThrow("exit 1");
 
     expectRuntimeErrorContains("--output is not supported for remote gateway TTS yet");
+    expect(mocks.callGateway).not.toHaveBeenCalled();
   });
 
   it.each(["local", "gateway"] as const)(

--- a/src/cli/capability-cli/tts-runtime.ts
+++ b/src/cli/capability-cli/tts-runtime.ts
@@ -58,6 +58,11 @@ export async function runTtsConvert(params: {
     const gatewayConnection = buildGatewayConnectionDetailsWithResolvers({
       config: getRuntimeConfig(),
     });
+    if (params.output && !isLoopbackHost(new URL(gatewayConnection.url).hostname)) {
+      throw new Error(
+        `--output is not supported for remote gateway TTS yet (gateway target: ${gatewayConnection.url}).`,
+      );
+    }
     const result: {
       audioPath?: string;
       provider?: string;
@@ -76,12 +81,6 @@ export async function runTtsConvert(params: {
     });
     let outputPath = result.audioPath;
     if (params.output && result.audioPath) {
-      const gatewayHost = new URL(gatewayConnection.url).hostname;
-      if (!isLoopbackHost(gatewayHost)) {
-        throw new Error(
-          `--output is not supported for remote gateway TTS yet (gateway target: ${gatewayConnection.url}).`,
-        );
-      }
       const target = path.resolve(params.output);
       await copyTtsOutputAtomically(result.audioPath, target);
       outputPath = target;


### PR DESCRIPTION
Related: #132548

## What Problem This Solves

Fixes an issue where users running `infer tts convert --gateway --output` against a remote Gateway would request speech synthesis and then receive an unsupported-output error. The rejected command could consume provider time and usage without producing the requested local file.

## Why This Change Was Made

Validate the existing remote-output restriction before calling `tts.convert`. The current CLI test now also verifies that rejection sends no Gateway request.

## User Impact

Unsupported remote-output requests fail before synthesis. Local and loopback output copying keeps its existing atomic publication behavior. Remote artifact transfer remains the separate feature tracked in #132548 and PR #132560; this fix does not close that request.

## Evidence

The registered CLI regression failed on the original ordering because it sent one `tts.convert` request. After the fix, all four focused cases passed, covering remote rejection, Gateway overrides without local output, and existing-file preservation on local and loopback copy failures. The Gateway boundary is mocked; no live provider request was made.

`node scripts/check-changed.mjs -- src/cli/capability-cli/tts-runtime.ts src/cli/capability-cli.test.ts docs/cli/infer.md` and `git diff --check` passed. Fresh independent Codex review found no actionable defects through P2.

The branch was refreshed with the shared shard-cap repair in #146194 without changing this fix; all 24 existing shard-inventory tests passed. [Refreshed-head CI](https://github.com/openclaw/openclaw/actions/runs/34707914808) is green.
