### PR TITLE
fix(gateway): avoid loopback connections for embedded config reads

### DIFF
--- a/docs/gateway/configuration/config-rpc.md
+++ b/docs/gateway/configuration/config-rpc.md
@@ -27,6 +27,11 @@ field-level docs and constraints. Use [Configuration reference](/gateway/configu
 when they need the broader config map, defaults, or links to dedicated
 subsystem references.
 
+The built-in `gateway` tool dispatches config reads directly through the Gateway
+that admitted the agent run, without opening a loopback WebSocket. Explicit
+`gatewayUrl` or `gatewayToken` overrides and standalone local agents still use
+the Gateway client. Both paths use the same config handlers and read scopes.
+
 <Note>
 Control-plane writes (`config.apply`, `config.patch`, `update.run`) are
 rate-limited to 30 requests per 60 seconds, per method, per

--- a/src/agents/tools/gateway-tool.routing.test.ts
+++ b/src/agents/tools/gateway-tool.routing.test.ts
@@ -1,0 +1,182 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../test/helpers/promise.js";
+import { clearRuntimeConfigSnapshot, setRuntimeConfigSnapshot } from "../../config/config.js";
+import type { CallGatewayOptions } from "../../gateway/call.js";
+import type {
+  GatewayRequestContext,
+  GatewayRequestOptions,
+} from "../../gateway/server-methods/types.js";
+import { withGatewayToolCallerIdentity } from "./gateway-caller-context.js";
+import { createGatewayTool } from "./gateway-tool.js";
+
+const { callGateway, handleGatewayRequest } = vi.hoisted(() => ({
+  callGateway: vi.fn<(options: CallGatewayOptions) => Promise<unknown>>(),
+  handleGatewayRequest: vi.fn<(options: GatewayRequestOptions) => Promise<void>>(),
+}));
+
+vi.mock("../../gateway/call.js", () => ({ callGateway }));
+vi.mock("../../gateway/server-methods.js", () => ({ handleGatewayRequest }));
+
+const snapshot = { hash: "revision", config: { gateway: { mode: "local" } } };
+const configReads = ["config.get", "config.schema.lookup"] as const;
+
+describe("gateway config tool routing", () => {
+  let context: GatewayRequestContext;
+  let currentContext: GatewayRequestContext | undefined;
+  let callerActive: boolean;
+
+  const runAsCaller = <T>(run: () => Promise<T>) =>
+    withGatewayToolCallerIdentity(
+      {
+        agentId: "main",
+        sessionKey: "agent:main:test",
+        operationalRunInstance: { instanceId: "instance", runId: "run" },
+        receiptAuthority: () => callerActive,
+        gatewayContextResolver: () => currentContext,
+      },
+      run,
+    );
+
+  const read = (
+    action: (typeof configReads)[number],
+    extra: Record<string, unknown> = {},
+    signal?: AbortSignal,
+  ) => createGatewayTool().execute("config-read", { action, path: "gateway", ...extra }, signal);
+
+  beforeEach(() => {
+    setRuntimeConfigSnapshot({ gateway: { mode: "local", port: 18789 } });
+    context = {
+      trackExecution: (run) => run(),
+      getRuntimeConfig: () => ({ gateway: { mode: "local" } }),
+    } as GatewayRequestContext;
+    currentContext = context;
+    callerActive = true;
+    callGateway.mockReset().mockResolvedValue(snapshot);
+    handleGatewayRequest.mockReset().mockImplementation(async ({ respond }) => {
+      respond(true, snapshot);
+    });
+  });
+
+  afterEach(() => clearRuntimeConfigSnapshot());
+
+  it.each(configReads)(
+    "dispatches admitted %s reads locally with least privilege",
+    async (action) => {
+      const result = await runAsCaller(() => read(action));
+
+      expect(result.details).toMatchObject({ ok: true });
+      expect(handleGatewayRequest).toHaveBeenCalledExactlyOnceWith(
+        expect.objectContaining({
+          req: expect.objectContaining({ method: action }),
+          context,
+          client: expect.objectContaining({
+            connect: expect.objectContaining({ scopes: ["operator.read"] }),
+          }),
+        }),
+      );
+      expect(callGateway).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each([{ gatewayUrl: "ws://127.0.0.1:18789" }, { gatewayToken: "explicit-test-token" }])(
+    "preserves explicit transport options %j",
+    async (overrides) => {
+      await runAsCaller(() => read("config.get", { ...overrides, timeoutMs: 2345 }));
+
+      expect(callGateway).toHaveBeenCalledExactlyOnceWith(
+        expect.objectContaining({
+          url: overrides.gatewayUrl,
+          token: overrides.gatewayToken,
+          timeoutMs: 2345,
+          scopes: ["operator.read"],
+        }),
+      );
+      expect(handleGatewayRequest).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(["standalone", "localEmbedded"])("retains %s transport routing", async (kind) => {
+    if (kind === "localEmbedded") {
+      context.localEmbedded = true;
+      await runAsCaller(() => read("config.get"));
+    } else {
+      await read("config.get");
+    }
+    expect(callGateway).toHaveBeenCalledOnce();
+    expect(handleGatewayRequest).not.toHaveBeenCalled();
+  });
+
+  it.each(["caller", "gateway"])("rejects retired %s before dispatch", async (owner) => {
+    await expect(
+      runAsCaller(async () => {
+        if (owner === "caller") {
+          callerActive = false;
+        } else {
+          currentContext = undefined;
+        }
+        return await read("config.get");
+      }),
+    ).rejects.toThrow(/authority.*no longer active|Gateway instance unavailable/);
+    expect(callGateway).not.toHaveBeenCalled();
+    expect(handleGatewayRequest).not.toHaveBeenCalled();
+  });
+
+  it("rejects a result after the admitting Gateway is replaced", async () => {
+    const entered = createDeferred();
+    const release = createDeferred();
+    handleGatewayRequest.mockImplementationOnce(async ({ respond }) => {
+      entered.resolve();
+      await release.promise;
+      respond(true, snapshot);
+    });
+    const pending = runAsCaller(() => read("config.get"));
+    const rejected = expect(pending).rejects.toThrow("Gateway instance unavailable");
+    await entered.promise;
+    currentContext = { ...context };
+    release.resolve();
+    await rejected;
+    expect(callGateway).not.toHaveBeenCalled();
+  });
+
+  it("preserves schema misses from the in-process router", async () => {
+    handleGatewayRequest.mockImplementationOnce(async ({ respond }) => {
+      respond(false, undefined, {
+        code: "INVALID_REQUEST",
+        message: "config schema path not found",
+      });
+    });
+    const result = await runAsCaller(() => read("config.schema.lookup"));
+    expect(result.details).toEqual({
+      ok: false,
+      code: "schema_path_not_found",
+      path: "gateway",
+      message: "config schema path not found",
+    });
+  });
+
+  it("does not dispatch a cancelled config read", async () => {
+    const controller = new AbortController();
+    controller.abort(new Error("config read cancelled"));
+    await expect(runAsCaller(() => read("config.get", {}, controller.signal))).rejects.toThrow(
+      "config read cancelled",
+    );
+    expect(handleGatewayRequest).not.toHaveBeenCalled();
+    expect(callGateway).not.toHaveBeenCalled();
+  });
+
+  it("honors the caller's deadline while a local handler is pending", async () => {
+    const release = createDeferred();
+    handleGatewayRequest.mockImplementationOnce(async ({ respond }) => {
+      await release.promise;
+      respond(true, snapshot);
+    });
+    try {
+      await expect(runAsCaller(() => read("config.get", { timeoutMs: 10 }))).rejects.toThrow(
+        "gateway request timeout for config.get",
+      );
+    } finally {
+      release.resolve();
+    }
+    expect(callGateway).not.toHaveBeenCalled();
+  });
+});

--- a/src/agents/tools/gateway-tool.ts
+++ b/src/agents/tools/gateway-tool.ts
@@ -188,10 +188,23 @@ export function createGatewayTool(options?: {
         throw new ToolInputError(`Action not available: ${action}`);
       }
       const gatewayOpts = readGatewayCallOptions(params);
+      const resolveGatewayContext = getGatewayToolCallerIdentity()?.gatewayContextResolver;
+      const callConfigGateway = (method: string, requestParams: Record<string, unknown>) =>
+        resolveGatewayContext &&
+        !gatewayOpts.gatewayUrl?.trim() &&
+        !gatewayOpts.gatewayToken?.trim() &&
+        // Retired Gateway bindings must reject locally instead of falling back to a socket.
+        resolveGatewayContext()?.localEmbedded !== true
+          ? callInProcessGatewayTool(method, requestParams, {
+              resolveGatewayContext,
+              timeoutMs: gatewayOpts.timeoutMs ?? 30_000,
+              signal,
+            })
+          : callGatewayTool(method, gatewayOpts, requestParams, { signal });
 
       if (action === "config.get") {
         const path = readToolStringParam(params, "path");
-        const snapshot = await callGatewayTool("config.get", gatewayOpts, {}, { signal });
+        const snapshot = await callConfigGateway("config.get", {});
         const result = selectGatewayConfigGetResult(snapshot, path);
         return createGatewayConfigGetToolResult(result);
       }
@@ -201,12 +214,7 @@ export function createGatewayTool(options?: {
           label: "path",
         });
         try {
-          const result = await callGatewayTool(
-            "config.schema.lookup",
-            gatewayOpts,
-            { path },
-            { signal },
-          );
+          const result = await callConfigGateway("config.schema.lookup", { path });
           return jsonResult({ ok: true, result });
         } catch (error) {
           if (isConfigSchemaPathNotFoundError(error)) {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where an agent running inside the Gateway opened another WebSocket connection to read that same Gateway's configuration. Repeated config reads paid connection and authentication overhead and could wait on the local transport under load.

## Why This Change Was Made

Route `config.get` and `config.schema.lookup` through the existing in-process dispatcher when the caller has an admitted Gateway binding. Reuse its current-authority checks, least-privilege read scope, cancellation, deadline, and typed errors. Retired bindings reject locally.

Explicit URL/token overrides and standalone local agents retain the existing Gateway client. Configuration handlers, redaction, and the model-facing tool schema are unchanged.

## User Impact

Embedded configuration reads avoid unnecessary sockets and handshakes while preserving explicit remote access and existing response behavior.

## Evidence

- The new registered-tool regression failed on the original path because neither config action reached the in-process router. It passes with the fix.
- 65 focused tests passed, covering routing, explicit overrides, standalone/embedded contexts, read scope, expired caller authority, replaced Gateway, cancellation, deadline, and schema misses.
- Synthetic comparison through the real tool and WebSocket client/server: 100 warm reads took 0.4498 seconds via loopback and 0.00330 seconds through direct dispatch. The socket arm opened 110 connections including ten warmups; the direct arm opened none. Both used identical fixed handler payloads. This measures routing overhead, not production handler latency.
- Sampled worker RSS was 607.2 MB for the socket arm and 575.8 MB for direct dispatch. Whole test-run timings include differing transform-cache warmth and are not used as a speedup claim.
- The complete changed-check gate (including core and test typechecks, lint, and architecture guards) and independent P0–P2 review passed. Full `pnpm build` passed on the same reviewed production tree. Exact-head CI supplies hosted proof.

The branch includes #146212’s shared typecheck-shard repair, with a patch-identical rebase. An earlier hosted run also failed an unchanged IPv6 portal fixture; no portal code is changed by this PR.
