### PR TITLE
fix(ci): keep Gateway test roots within the compiler budget

### DIFF
--- a/test/tsconfig/tsconfig.core.test.gateway-other.json
+++ b/test/tsconfig/tsconfig.core.test.gateway-other.json
@@ -4,8 +4,6 @@
     "tsBuildInfoFile": "../../.artifacts/tsgo-cache/core-test-gateway-other.tsbuildinfo"
   },
   "include": [
-    "../../src/gateway/session-*.test.ts",
-    "../../src/gateway/session-*.test.tsx",
     "../../src/gateway/*/**/*.test.ts",
     "../../src/gateway/*/**/*.test.tsx"
   ]

--- a/test/tsconfig/tsconfig.core.test.gateway-root.json
+++ b/test/tsconfig/tsconfig.core.test.gateway-root.json
@@ -8,8 +8,6 @@
     "../../src/gateway/*.test.tsx"
   ],
   "exclude": [
-    "../../src/gateway/session-*.test.ts",
-    "../../src/gateway/session-*.test.tsx",
     "../../src/gateway/server*.test.ts",
     "../../src/gateway/server*.test.tsx"
   ]


### PR DESCRIPTION
## What Problem This Solves

The core compiler-root inventory check fails on main because the Gateway other shard has 701 test roots, exceeding its 700-root budget. Unrelated PRs inherit that failure.

## Why This Change Was Made

Return root-level session tests to the existing Gateway root graph. They moved out in #145461 when that graph had 720 roots; #145484 subsequently split server tests into a dedicated graph and freed room. This removes the session-family exception from two configs while preserving the server partition.

| Compiler graph | Before | After |
| --- | ---: | ---: |
| Gateway root | 335 | 416 |
| Gateway other | 701 | 620 |
| Gateway server | 318 | 318 |

## User Impact

Restores compiler-budget headroom without changing test cases, runtime behavior, the 700-root invariant, the 720-root runner cap, graph identities, caches, stripes, or CI job topology.

## Evidence

- The existing root-budget invariant fails on the unmodified base and passes after this change.
- Both affected native TypeScript compiler graphs pass.
- TypeScript-resolved inventories preserve all 10,078 canonical roots exactly once across the existing 18 graphs; the other graph inventories are unchanged.
- The same rebalance resolves the observed failure on the exact CI merge tree.
- Independent P0–P2 review found no actionable findings; diff checks pass.
