### PR TITLE
perf(status): reuse scan snapshots and expose local stage timings

### DIFF
--- a/docs/cli/status.md
+++ b/docs/cli/status.md
@@ -57,6 +57,20 @@ and the last update run, or run `openclaw update` again. `openclaw status --deep
 also fetches for that check; it does not change the ledger. See
 [Release channels](/install/development-channels#checking-current-status).
 
+## Status timing
+
+Use the existing diagnostic timeline to locate time spent outside Gateway RPCs:
+
+```bash
+OPENCLAW_DIAGNOSTICS=timeline \
+OPENCLAW_DIAGNOSTICS_TIMELINE_PATH=/tmp/openclaw-status-timeline.jsonl \
+  openclaw status --json
+```
+
+The timeline includes configuration and secret resolution, agent admission,
+local session reads, Gateway probes, and summary collection. Durations include
+waiting; parallel stages overlap and should not be added together.
+
 ## Skills diagnosis
 
 `status --all` reports eligible skills and skills with missing prerequisites for

--- a/src/commands/gateway-status.test.ts
+++ b/src/commands/gateway-status.test.ts
@@ -84,7 +84,13 @@ const mocks = vi.hoisted(() => {
               linked: false,
               authAgeMs: null,
             },
-            sessions: { count: 0 },
+            sessions: {
+              paths: [],
+              count: 0,
+              defaults: { model: null, contextTokens: null },
+              recent: [],
+              byAgent: [],
+            },
           },
           presence: [
             {
@@ -131,7 +137,13 @@ const mocks = vi.hoisted(() => {
             linked: true,
             authAgeMs: 5_000,
           },
-          sessions: { count: 2 },
+          sessions: {
+            paths: [],
+            count: 2,
+            defaults: { model: null, contextTokens: null },
+            recent: [],
+            byAgent: [],
+          },
         },
         presence: [
           {
@@ -895,7 +907,13 @@ describe("gateway-status command", () => {
           linked: true,
           authAgeMs: 1_000,
         },
-        sessions: { count: 1 },
+        sessions: {
+          paths: [],
+          count: 1,
+          defaults: { model: null, contextTokens: null },
+          recent: [],
+          byAgent: [],
+        },
       },
       presence: [
         {

--- a/src/commands/status.agent-local.test.ts
+++ b/src/commands/status.agent-local.test.ts
@@ -1,20 +1,22 @@
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
-import { getAgentLocalStatuses } from "./status.agent-local.js";
+import { collectStatusLocalSnapshot } from "./status.agent-local.js";
 
-describe("getAgentLocalStatuses", () => {
+describe("collectStatusLocalSnapshot", () => {
   it("does not project the gateway's compatibility id as an explicit fleet default", async () => {
     await withOpenClawTestState({ label: "status-explicit-fleet" }, async () => {
       await expect(
-        getAgentLocalStatuses({
+        collectStatusLocalSnapshot({
           agents: { ownership: "explicit", entries: { alpha: {}, beta: {} } },
         }),
       ).resolves.toMatchObject({
-        defaultId: null,
-        ownership: "explicit",
-        selectionRequired: true,
-        agents: [{ id: "alpha" }, { id: "beta" }],
+        agentStatus: {
+          defaultId: null,
+          ownership: "explicit",
+          selectionRequired: true,
+          agents: [{ id: "alpha" }, { id: "beta" }],
+        },
       });
     });
   });
@@ -23,17 +25,19 @@ describe("getAgentLocalStatuses", () => {
     await withOpenClawTestState({ label: "status-sole-owner" }, async (state) => {
       const sessionsDir = path.join(state.root, "alpha");
       await expect(
-        getAgentLocalStatuses({
+        collectStatusLocalSnapshot({
           agents: { entries: { alpha: {} } },
           session: { store: path.join(sessionsDir, "sessions.json") },
         }),
       ).resolves.toMatchObject({
-        defaultId: "alpha",
-        ownership: "sole",
-        selectionRequired: false,
-        agents: [
-          { id: "alpha", sessionsPath: path.join(sessionsDir, "openclaw-agent.alpha.sqlite") },
-        ],
+        agentStatus: {
+          defaultId: "alpha",
+          ownership: "sole",
+          selectionRequired: false,
+          agents: [
+            { id: "alpha", sessionsPath: path.join(sessionsDir, "openclaw-agent.alpha.sqlite") },
+          ],
+        },
       });
     });
   });

--- a/src/commands/status.agent-local.ts
+++ b/src/commands/status.agent-local.ts
@@ -3,6 +3,7 @@
 
 import path from "node:path";
 import { resolveAgentWorkspaceDir } from "../agents/agent-scope.js";
+import { measureCliCommandStartup } from "../cli/command-startup-timing.js";
 import type { OpenClawConfig } from "../config/types.js";
 import { listGatewayAgentsBasic, type GatewayAgentOwnership } from "../gateway/agent-list.js";
 import { pathExists } from "../infra/fs-safe.js";
@@ -12,7 +13,7 @@ import {
   recordAgentDatabaseAdmissions,
   type AgentDatabaseAdmissionRefusal,
 } from "../state/agent-database-admission.js";
-import { readStatusSessionStores } from "../status/session-stores.js";
+import { readStatusSessionStores, STATUS_RECENT_SESSION_LIMIT } from "../status/session-stores.js";
 
 export type AgentLocalStatus = {
   id: string;
@@ -27,7 +28,7 @@ export type AgentLocalStatus = {
   lastActiveAgeMs: number | null;
 };
 
-type AgentLocalStatusesResult = {
+export type AgentLocalStatusesResult = {
   defaultId: string | null;
   ownership: GatewayAgentOwnership;
   selectionRequired: boolean;
@@ -37,16 +38,24 @@ type AgentLocalStatusesResult = {
 };
 
 /** Returns per-agent local workspace, bootstrap, session count, and last activity status. */
-export async function getAgentLocalStatuses(
-  cfg: OpenClawConfig,
-): Promise<AgentLocalStatusesResult> {
+export async function collectStatusLocalSnapshot(cfg: OpenClawConfig) {
   if (!hasAgentDatabaseAdmissions()) {
-    recordAgentDatabaseAdmissions(await evaluateAgentDatabaseAdmissions(cfg));
+    recordAgentDatabaseAdmissions(
+      await measureCliCommandStartup(
+        "status.agent-admission",
+        () => evaluateAgentDatabaseAdmissions(cfg),
+        { config: cfg },
+      ),
+    );
   }
   const agentList = listGatewayAgentsBasic(cfg);
   const now = Date.now();
 
-  const sessionStores = readStatusSessionStores(cfg, agentList.agents, 1);
+  const sessionStores = await measureCliCommandStartup(
+    "status.session-stores",
+    () => readStatusSessionStores(cfg, agentList.agents, STATUS_RECENT_SESSION_LIMIT),
+    { config: cfg },
+  );
   const statuses: AgentLocalStatus[] = [];
   for (const { agent, path: sessionsPath, count, recent } of sessionStores.byAgent) {
     const agentId = agent.id;
@@ -82,7 +91,7 @@ export async function getAgentLocalStatuses(
   }
 
   const bootstrapPendingCount = statuses.reduce((sum, s) => sum + (s.bootstrapPending ? 1 : 0), 0);
-  return {
+  const agentStatus: AgentLocalStatusesResult = {
     // The gateway keeps a projected first id for wire compatibility. Local status must
     // preserve the selection state so read-only consumers never treat that id as an owner.
     defaultId: agentList.selectionRequired ? null : agentList.defaultId,
@@ -92,4 +101,5 @@ export async function getAgentLocalStatuses(
     totalSessions: sessionStores.count,
     bootstrapPendingCount,
   };
+  return { agentStatus, sessionStores };
 }

--- a/src/commands/status.scan-memory.ts
+++ b/src/commands/status.scan-memory.ts
@@ -5,7 +5,7 @@ import { resolveMemorySearchConfig } from "../agents/memory-search.js";
 import type { OpenClawConfig } from "../config/types.js";
 import { createLazyImportLoader } from "../shared/lazy-promise.js";
 import { resolveOpenClawAgentSqlitePath } from "../state/openclaw-agent-db.paths.js";
-import type { getAgentLocalStatuses as getAgentLocalStatusesFn } from "./status.agent-local.js";
+import type { AgentLocalStatusesResult } from "./status.agent-local.js";
 import {
   resolveSharedMemoryStatusSnapshot,
   type MemoryPluginStatus,
@@ -24,7 +24,7 @@ export function resolveDefaultMemoryDatabasePath(agentId: string): string {
 /** Resolves memory index/cache status for the current status scan. */
 export async function resolveStatusMemoryStatusSnapshot(params: {
   cfg: OpenClawConfig;
-  agentStatus: Awaited<ReturnType<typeof getAgentLocalStatusesFn>>;
+  agentStatus: AgentLocalStatusesResult;
   memoryPlugin: MemoryPluginStatus;
   requireDefaultDatabasePath?: (agentId: string) => string;
 }): Promise<MemoryStatusSnapshot | null> {

--- a/src/commands/status.scan-overview.test.ts
+++ b/src/commands/status.scan-overview.test.ts
@@ -299,4 +299,30 @@ describe("collectStatusScanOverview", () => {
     });
     expect(result.runtimeDegradation).toBeNull();
   });
+
+  it("reuses runtime degradation from a successful fallback probe without another status RPC", async () => {
+    const bootstrap = await mocks.createStatusScanCoreBootstrap();
+    const gatewaySnapshot = await bootstrap.gatewayProbePromise;
+    const status = {
+      degradedSecretOwners: [],
+      degradedPlugins: [],
+      startupMigrationWarning: "fallback warning",
+    };
+    mocks.createStatusScanCoreBootstrap.mockResolvedValueOnce({
+      ...bootstrap,
+      gatewayProbePromise: Promise.resolve({
+        ...gatewaySnapshot,
+        gatewayProbe: { ok: true, status },
+      }),
+    });
+    const result = await collectStatusScanOverview({
+      commandName: "status",
+      opts: {},
+      showSecrets: false,
+      includeChannelsData: false,
+    });
+    expect(result.runtimeDegradation?.startupMigrationWarning).toBe("fallback warning");
+    expect(mocks.callGateway).not.toHaveBeenCalled();
+    expect(result.cfg).toEqual({ session: {} });
+  });
 });

--- a/src/commands/status.scan-overview.ts
+++ b/src/commands/status.scan-overview.ts
@@ -1,6 +1,7 @@
 // Shared status scan overview used by compact status, status --json, and status --all.
 // It collects config, update, gateway, channel, and local agent state before specialized callers add details.
 
+import { measureCliCommandStartup } from "../cli/command-startup-timing.js";
 import type { BestEffortConfigSnapshot } from "../config/io.js";
 import type { OpenClawConfig } from "../config/types.js";
 import { resolveGatewayAuthTokenSourceConflict } from "../gateway/auth-token-source-conflict.js";
@@ -10,9 +11,10 @@ import type { UpdateCheckResult } from "../infra/update-check.js";
 import { applyLoggingConfig } from "../logging/logger.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { createLazyImportLoader } from "../shared/lazy-promise.js";
+import type { StatusSessionStores } from "../status/session-stores.js";
 import type { StatusSummary } from "../status/types.js";
 import type { buildChannelsTable as buildChannelsTableFn } from "./status-all/channels.js";
-import type { getAgentLocalStatuses as getAgentLocalStatusesFn } from "./status.agent-local.js";
+import type { AgentLocalStatusesResult } from "./status.agent-local.js";
 import {
   buildColdStartStatusSummary,
   createStatusScanCoreBootstrap,
@@ -111,7 +113,8 @@ export type StatusScanOverviewResult = {
   channelsStatus: unknown;
   channelIssues: ReturnType<typeof collectChannelStatusIssuesFn>;
   channels: Awaited<ReturnType<typeof buildChannelsTableFn>>;
-  agentStatus: Awaited<ReturnType<typeof getAgentLocalStatusesFn>>;
+  agentStatus: AgentLocalStatusesResult;
+  sessionStores?: StatusSessionStores;
 };
 
 /** Collects the common status scan data shared by text, JSON, and status-all commands. */
@@ -154,9 +157,15 @@ export async function collectStatusScanOverview(params: {
   if (params.labels?.loadingConfig) {
     params.progress?.setLabel(params.labels.loadingConfig);
   }
-  const { snapshot } = await (
-    await import("../cli/command-config-snapshot.js")
-  ).readCommandConfigSnapshot({ observe: false, skipPluginValidation: true });
+  const { snapshot } = await measureCliCommandStartup(
+    "status.config",
+    async () =>
+      (await import("../cli/command-config-snapshot.js")).readCommandConfigSnapshot({
+        observe: false,
+        skipPluginValidation: true,
+      }),
+    { env },
+  );
   const testRuntime =
     env.VITEST === "true" || env.VITEST_POOL_ID !== undefined || env.NODE_ENV === "test";
   const coldStart = !snapshot.exists && !(params.allowMissingConfigFastPath && testRuntime);
@@ -170,20 +179,25 @@ export async function collectStatusScanOverview(params: {
     params.gatewayProbeTimeoutMs ?? resolveStatusGatewayProbeTimeoutMs(params.opts);
   const { resolvedConfig: cfg, diagnostics } = skipMissingConfig
     ? { resolvedConfig: loadedConfig, diagnostics: [] }
-    : await commandConfigResolutionModuleLoader
-        .load()
-        .then(async ({ resolveCommandConfigWithSecrets }) =>
-          resolveCommandConfigWithSecrets({
-            config: loadedConfig,
-            commandName: params.commandName,
-            targetIds: (
-              await commandSecretTargetsModuleLoader.load()
-            ).getStatusCommandSecretTargetIds(loadedConfig, env),
-            mode: "read_only_status",
-            gatewaySecretResolveTimeoutMs: gatewayProbeTimeoutMs,
-            ...(params.runtime ? { runtime: params.runtime } : {}),
-          }),
-        );
+    : await measureCliCommandStartup(
+        "status.secrets",
+        () =>
+          commandConfigResolutionModuleLoader
+            .load()
+            .then(async ({ resolveCommandConfigWithSecrets }) =>
+              resolveCommandConfigWithSecrets({
+                config: loadedConfig,
+                commandName: params.commandName,
+                targetIds: (
+                  await commandSecretTargetsModuleLoader.load()
+                ).getStatusCommandSecretTargetIds(loadedConfig, env),
+                mode: "read_only_status",
+                gatewaySecretResolveTimeoutMs: gatewayProbeTimeoutMs,
+                ...(params.runtime ? { runtime: params.runtime } : {}),
+              }),
+            ),
+        { env },
+      );
   const tokenConflict = resolveGatewayAuthTokenSourceConflict({ cfg: sourceConfig, env });
   const secretDiagnostics = tokenConflict
     ? [...diagnostics, tokenConflict.diagnostic]
@@ -199,9 +213,8 @@ export async function collectStatusScanOverview(params: {
         }),
       );
   const osSummary = resolveOsSummary();
-  const bootstrap = await createStatusScanCoreBootstrap<
-    Awaited<ReturnType<typeof getAgentLocalStatusesFn>>
-  >({
+  let sessionStores: StatusSessionStores | undefined;
+  const bootstrap = await createStatusScanCoreBootstrap<AgentLocalStatusesResult>({
     coldStart,
     cfg,
     configPath: snapshot.path,
@@ -223,9 +236,16 @@ export async function collectStatusScanOverview(params: {
         .load()
         .then(({ getUpdateCheckResult }) => getUpdateCheckResult(updateParams)),
     getAgentLocalStatuses: async (bootstrapCfg) =>
-      await statusAgentLocalModuleLoader
-        .load()
-        .then(({ getAgentLocalStatuses }) => getAgentLocalStatuses(bootstrapCfg)),
+      await measureCliCommandStartup(
+        "status.local-agents",
+        () =>
+          statusAgentLocalModuleLoader.load().then(async ({ collectStatusLocalSnapshot }) => {
+            const local = await collectStatusLocalSnapshot(bootstrapCfg);
+            sessionStores = local.sessionStores;
+            return local.agentStatus;
+          }),
+        { config: cfg, env },
+      ),
   });
 
   if (params.labels?.checkingTailscale) {
@@ -253,22 +273,31 @@ export async function collectStatusScanOverview(params: {
   params.progress?.tick();
   let runtimeDegradation: StatusScanOverviewResult["runtimeDegradation"] = null;
   if (gatewaySnapshot.gatewayReachable) {
-    const status = await gatewayCallModuleLoader.load().then(({ callGateway }) =>
-      callGateway<StatusSummary>({
-        config: cfg,
-        configPath: snapshot.path,
-        method: "status",
-        params: { includeChannelSummary: false },
-        timeoutMs: Math.min(5000, params.opts.timeoutMs ?? 10_000),
-        ...gatewaySnapshot.gatewayCallOverrides,
-      }).catch(() => null),
-    );
-    runtimeDegradation = status && {
-      degradedSecretOwners: status.degradedSecretOwners ?? [],
-      degradedPlugins: status.degradedPlugins ?? [],
-      startupMigrationWarning: status.startupMigrationWarning,
-      secretEgressProxy: status.secretEgressProxy,
-    };
+    const status =
+      gatewaySnapshot.gatewayProbe?.status ??
+      (await measureCliCommandStartup(
+        "status.gateway-degradation",
+        () =>
+          gatewayCallModuleLoader.load().then(({ callGateway }) =>
+            callGateway<StatusSummary>({
+              config: cfg,
+              configPath: snapshot.path,
+              method: "status",
+              params: { includeChannelSummary: false },
+              timeoutMs: Math.min(5000, params.opts.timeoutMs ?? 10_000),
+              ...gatewaySnapshot.gatewayCallOverrides,
+            }).catch(() => null),
+          ),
+        { config: cfg, env },
+      ));
+    runtimeDegradation = status
+      ? {
+          degradedSecretOwners: status.degradedSecretOwners ?? [],
+          degradedPlugins: status.degradedPlugins ?? [],
+          startupMigrationWarning: status.startupMigrationWarning,
+          secretEgressProxy: status.secretEgressProxy,
+        }
+      : null;
   }
 
   const tailscaleHttpsUrl = await bootstrap.resolveTailscaleHttpsUrl();
@@ -354,6 +383,7 @@ export async function collectStatusScanOverview(params: {
     channelIssues,
     channels,
     agentStatus,
+    ...(sessionStores ? { sessionStores } : {}),
   };
 }
 
@@ -361,19 +391,27 @@ export async function collectStatusScanOverview(params: {
 export async function resolveStatusSummaryFromOverview(params: {
   overview: Pick<
     StatusScanOverviewResult,
-    "skipColdStartNetworkChecks" | "cfg" | "sourceConfig" | "runtimeDegradation"
+    "skipColdStartNetworkChecks" | "cfg" | "sourceConfig" | "runtimeDegradation" | "sessionStores"
   >;
 }) {
   if (params.overview.skipColdStartNetworkChecks) {
     return buildColdStartStatusSummary();
   }
-  const summary = await statusSummaryModuleLoader.load().then(({ getStatusSummary }) =>
-    getStatusSummary({
-      config: params.overview.cfg,
-      sourceConfig: params.overview.sourceConfig,
-      // CLI scans own channel output separately; skip duplicate plugin discovery in the summary.
-      includeChannelSummary: false,
-    }),
+  const summary = await measureCliCommandStartup(
+    "status.summary",
+    () =>
+      statusSummaryModuleLoader.load().then(({ getStatusSummary }) =>
+        getStatusSummary({
+          config: params.overview.cfg,
+          sourceConfig: params.overview.sourceConfig,
+          // CLI scans own channel output separately; skip duplicate plugin discovery in the summary.
+          includeChannelSummary: false,
+          ...(params.overview.sessionStores
+            ? { sessionStores: params.overview.sessionStores }
+            : {}),
+        }),
+      ),
+    { config: params.overview.cfg },
   );
   return params.overview.runtimeDegradation
     ? { ...summary, ...params.overview.runtimeDegradation }

--- a/src/commands/status.scan-result.ts
+++ b/src/commands/status.scan-result.ts
@@ -19,6 +19,7 @@ export type StatusScanResult = Omit<
   | "gatewaySnapshot"
   | "channelsStatus"
   | "runtimeDegradation"
+  | "sessionStores"
 > &
   StatusScanGatewayResult & {
     summary: Awaited<ReturnType<typeof getStatusSummaryFn>>;

--- a/src/commands/status.scan.bootstrap-shared.ts
+++ b/src/commands/status.scan.bootstrap-shared.ts
@@ -1,6 +1,7 @@
 // Shared bootstrap for status scans.
 // Starts update, Tailscale, agent, and gateway probes with cold-start shortcuts for first-run users.
 
+import { measureCliCommandStartup } from "../cli/command-startup-timing.js";
 import type { OpenClawConfig } from "../config/types.js";
 import type { UpdateCheckResult } from "../infra/update-check.js";
 import { runExec } from "../process/exec.js";
@@ -119,19 +120,24 @@ export async function createStatusScanCoreBootstrap<TAgentStatus>(
   const agentStatusPromise = skipColdStartNetworkChecks
     ? Promise.resolve(buildColdStartAgentLocalStatuses() as TAgentStatus)
     : params.getAgentLocalStatuses(params.cfg);
-  const gatewayProbePromise = resolveGatewayProbeSnapshot({
-    cfg: params.cfg,
-    configPath: params.configPath,
-    env: params.env,
-    opts: {
-      ...params.opts,
-      ...(params.gatewayProbeTimeoutMs !== undefined
-        ? { timeoutMs: params.gatewayProbeTimeoutMs }
-        : {}),
-      ...(skipColdStartNetworkChecks ? { skipProbe: true } : {}),
-      localStatusRpcFallback: params.includeLocalStatusRpcFallback !== false,
-    },
-  });
+  const gatewayProbePromise = measureCliCommandStartup(
+    "status.gateway-probe",
+    () =>
+      resolveGatewayProbeSnapshot({
+        cfg: params.cfg,
+        configPath: params.configPath,
+        env: params.env,
+        opts: {
+          ...params.opts,
+          ...(params.gatewayProbeTimeoutMs !== undefined
+            ? { timeoutMs: params.gatewayProbeTimeoutMs }
+            : {}),
+          ...(skipColdStartNetworkChecks ? { skipProbe: true } : {}),
+          localStatusRpcFallback: params.includeLocalStatusRpcFallback !== false,
+        },
+      }),
+    { config: params.cfg, env: params.env },
+  );
 
   return {
     tailscaleMode,

--- a/src/commands/status.scan.shared.ts
+++ b/src/commands/status.scan.shared.ts
@@ -24,6 +24,7 @@ import { defaultSlotIdForKey } from "../plugins/slots.js";
 import { normalizeAgentId } from "../routing/session-key.js";
 import { createLazyImportLoader } from "../shared/lazy-promise.js";
 import { resolveTailscalePublishedHost } from "../shared/tailscale-status.js";
+import type { StatusSummary } from "../status/types.js";
 import { pickGatewaySelfPresence } from "./gateway-presence.js";
 import { isProbeReachable } from "./gateway-status/helpers.js";
 
@@ -214,7 +215,7 @@ async function applyLocalStatusRpcFallback(params: {
   // The fallback uses the gateway status RPC because it can succeed after probe handshake ambiguity.
   const status = await loadGatewayCallModule()
     .then(({ callGateway }) =>
-      callGateway({
+      callGateway<Partial<StatusSummary>>({
         config: params.cfg,
         configPath: params.configPath,
         method: "status",

--- a/src/commands/status.scan.test-helpers.ts
+++ b/src/commands/status.scan.test-helpers.ts
@@ -136,9 +136,16 @@ function createStatusUpdateModuleMock(mocks: Pick<StatusScanSharedMocks, "getUpd
 
 function createStatusAgentLocalModuleMock(
   mocks: Pick<StatusScanSharedMocks, "getAgentLocalStatuses">,
-): { getAgentLocalStatuses: StatusScanSharedMocks["getAgentLocalStatuses"] } {
+): {
+  collectStatusLocalSnapshot: (
+    cfg: OpenClawConfig,
+  ) => Promise<{ agentStatus: unknown; sessionStores: undefined }>;
+} {
   return {
-    getAgentLocalStatuses: mocks.getAgentLocalStatuses,
+    collectStatusLocalSnapshot: async (cfg) => ({
+      agentStatus: await mocks.getAgentLocalStatuses(cfg),
+      sessionStores: undefined,
+    }),
   };
 }
 

--- a/src/gateway/probe.ts
+++ b/src/gateway/probe.ts
@@ -19,6 +19,7 @@ import {
 } from "../infra/device-auth-store.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import type { SystemPresence } from "../infra/system-presence.js";
+import type { StatusSummary } from "../status/types.js";
 import { resolveSafeTimeoutDelayMs } from "../utils/timer-delay.js";
 import {
   GatewayClient,
@@ -78,7 +79,7 @@ export type GatewayProbeResult = {
   auth: GatewayProbeAuthSummary;
   server?: GatewayProbeServerSummary;
   health: unknown;
-  status: unknown;
+  status: Partial<StatusSummary> | null;
   presence: SystemPresence[] | null;
   configSnapshot: unknown;
 };
@@ -406,7 +407,7 @@ export async function probeGateway(opts: {
       missingScopeErrorDetails?: MissingScopeErrorDetails;
       verifiedRead?: boolean;
       health: unknown;
-      status: unknown;
+      status: Partial<StatusSummary> | null;
       presence: SystemPresence[] | null;
       configSnapshot: unknown;
     }) => {
@@ -555,7 +556,7 @@ export async function probeGateway(opts: {
             }
             const [health, status, presence, configSnapshot] = await Promise.all([
               client.request("health"),
-              client.request("status"),
+              client.request<Partial<StatusSummary>>("status"),
               client.request("system-presence"),
               client.request("config.get", {}),
             ]);

--- a/src/status/session-stores.ts
+++ b/src/status/session-stores.ts
@@ -2,7 +2,13 @@ import { resolveSessionStorePathCore } from "../config/sessions/paths.js";
 import { readSessionStoreSummaryReadOnly } from "../config/sessions/session-accessor.js";
 import { resolveSqliteTargetFromSessionStorePath } from "../config/sessions/session-sqlite-target.js";
 import type { OpenClawConfig } from "../config/types.js";
+import type { listGatewayAgentsBasic } from "../gateway/agent-list.js";
 import { readAgentDatabaseAdmissionRefusal } from "../state/agent-database-admission.js";
+
+export const STATUS_RECENT_SESSION_LIMIT = 10;
+export type StatusSessionStores = ReturnType<
+  typeof readStatusSessionStores<ReturnType<typeof listGatewayAgentsBasic>["agents"][number]>
+>;
 
 /** One collection owns each physical store's bounded snapshot, including its agent windows. */
 export function createStatusSessionStoreReader(

--- a/src/status/summary.read-only.test.ts
+++ b/src/status/summary.read-only.test.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { testing as cliBackendsTesting } from "../agents/cli-backends.test-support.js";
-import { getAgentLocalStatuses } from "../commands/status.agent-local.js";
+import { collectStatusLocalSnapshot } from "../commands/status.agent-local.js";
 import { clearRuntimeConfigSnapshot } from "../config/runtime-snapshot.js";
 import { resolveSessionStorePathCore } from "../config/sessions/paths.js";
 import * as sessionAccessor from "../config/sessions/session-accessor.js";
@@ -22,6 +22,7 @@ import {
   createOutboundTestPlugin,
   createTestRegistry,
 } from "../test-utils/channel-plugins.js";
+import { withEnvAsync } from "../test-utils/env.js";
 import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import { getStatusSummary } from "./summary.js";
 
@@ -151,7 +152,7 @@ describe("getStatusSummary read-only session access", () => {
           expect(readSummary).toHaveBeenCalledTimes(uniquePaths.length);
 
           readSummary.mockClear();
-          const local = await getAgentLocalStatuses(config);
+          const { agentStatus: local } = await collectStatusLocalSnapshot(config);
           expect(local.totalSessions).toBe(2);
           expect(
             local.agents.map((agent) => [
@@ -201,6 +202,58 @@ describe("getStatusSummary read-only session access", () => {
         }
       },
     );
+  });
+
+  it("shares one local session snapshot across the complete status scan", async () => {
+    await withOpenClawTestState({ prefix: "openclaw-status-scan-snapshot-" }, async (state) => {
+      const config = {
+        agents: { defaults: { heartbeat: { every: "0m" } }, entries: { main: {} } },
+        gateway: { mode: "remote" as const, remote: { url: "ws://127.0.0.1:1", token: "fixture" } },
+        plugins: { enabled: false },
+      };
+      await state.writeConfig(config);
+      const storePath = resolveSessionStorePathCore(undefined, { agentId: "main", env: state.env });
+      for (let index = 1; index <= 12; index += 1) {
+        replaceSessionEntrySync(
+          { agentId: "main", storePath, sessionKey: `agent:main:scan-${index}` },
+          {
+            sessionId: `scan-${index}`,
+            updatedAt: index,
+            skillsSnapshot: { prompt: "private fixture", skills: [] },
+          },
+        );
+      }
+      const readSummary = vi.spyOn(sessionAccessor, "readSessionStoreSummaryReadOnly");
+      try {
+        const { scanStatus } = await import("../commands/status.scan.js");
+        const timeline = state.path("status-timeline.jsonl");
+        const scan = await withEnvAsync(
+          { OPENCLAW_DIAGNOSTICS: "timeline", OPENCLAW_DIAGNOSTICS_TIMELINE_PATH: timeline },
+          () => scanStatus({ timeoutMs: 100 }),
+        );
+        expect(scan.agentStatus.totalSessions).toBe(12);
+        expect(scan.agentStatus.agents[0]?.lastUpdatedAt).toBe(12);
+        expect(scan.summary.sessions.count).toBe(12);
+        expect(scan.summary.sessions.recent.map(({ key }) => key)).toEqual(
+          Array.from({ length: 10 }, (_, index) => `agent:main:scan-${12 - index}`),
+        );
+        expect(readSummary).toHaveBeenCalledOnce();
+        expect(JSON.stringify(scan)).not.toContain("private fixture");
+        expect(scan).not.toHaveProperty("sessionStores");
+        (await import("../infra/diagnostics-timeline.js")).flushDiagnosticsTimeline();
+        const timings = fs.readFileSync(timeline, "utf8");
+        for (const stage of [
+          "status.config",
+          "status.gateway-probe",
+          "status.session-stores",
+          "status.summary",
+        ]) {
+          expect(timings).toContain(`"stage":"${stage}"`);
+        }
+      } finally {
+        readSummary.mockRestore();
+      }
+    });
   });
 
   it("keeps an authored context cap through a runtime provider alias", async () => {

--- a/src/status/summary.ts
+++ b/src/status/summary.ts
@@ -48,10 +48,12 @@ import {
 } from "../tasks/task-registry.audit.js";
 import { deliveryContextFromSession } from "../utils/delivery-context.shared.js";
 import { resolveRuntimeServiceVersion } from "../version.js";
-import { readStatusSessionStores } from "./session-stores.js";
+import {
+  readStatusSessionStores,
+  STATUS_RECENT_SESSION_LIMIT,
+  type StatusSessionStores,
+} from "./session-stores.js";
 import type { HeartbeatStatus, SessionStatus, StatusSummary } from "./types.js";
-
-const RECENT_SESSION_LIMIT = 10;
 
 const channelSummaryModuleLoader = createLazyImportLoader(
   () => import("../infra/channel-summary.js"),
@@ -370,6 +372,7 @@ export async function getStatusSummary(
     config?: OpenClawConfig;
     sourceConfig?: OpenClawConfig;
     hostDesktopStatus?: import("../gateway/desktop/host-source.js").HostDesktopStatus;
+    sessionStores?: StatusSessionStores;
   } = {},
 ): Promise<StatusSummary> {
   const { includeSensitive = true, includeChannelSummary = true } = options;
@@ -488,11 +491,13 @@ export async function getStatusSummary(
 
   const sessionDetails = includeSensitive ? await prepareSessionStatusDetails(cfg, now) : undefined;
 
-  const sessionStores = readStatusSessionStores(
-    cfg,
-    agentList.agents,
-    includeSensitive ? RECENT_SESSION_LIMIT : 0,
-  );
+  const sessionStores =
+    options.sessionStores ??
+    readStatusSessionStores(
+      cfg,
+      agentList.agents,
+      includeSensitive ? STATUS_RECENT_SESSION_LIMIT : 0,
+    );
   const byAgent = await Promise.all(
     sessionStores.byAgent.map(async ({ agent, path, count, recent }) => ({
       agentId: agent.id,
@@ -509,7 +514,7 @@ export async function getStatusSummary(
     ? await sessionDetails.buildSessionRows(
         sortAndLimitBy(
           sessionStores.recent,
-          RECENT_SESSION_LIMIT,
+          STATUS_RECENT_SESSION_LIMIT,
           compareSessionCandidatesByUpdatedAt,
         ),
       )


### PR DESCRIPTION
Related: #146177 and #146213

## What Problem This Solves

Fixes an issue where one status command reread the same physical session stores to build its agent overview and then its summary. A successful local fallback status RPC could also be followed immediately by a duplicate status request. Those local stages were difficult to distinguish from Gateway latency.

## Why This Change Was Made

Prepare one request-local session snapshot after ownership admission and reuse it for both views. Keep the prepared entries separate from the public agent summary and exclude them from the serialized scan. Reuse a fallback probe's existing status result for degradation fields; normal probes still fetch the required Gateway state.

Record fixed status stages through the existing opt-in CLI startup timeline. This introduces no new configuration, protocol, persistence, or global cache. Local configuration/session ownership remains independent from an explicitly remote Gateway.

## User Impact

Status performs fewer database reads and avoids an unnecessary fallback RPC while preserving complete counts, recent-session windows, degradation information, and text/JSON output. Operators can identify local collection delays using the documented timeline.

## Evidence

- A complete real status scan fails on the original code with two physical summary reads; the candidate reads once while preserving twelve sessions, the ten recent entries, and exclusion of saved prompt payloads from the serialized scan.
- The fallback-probe regression fails against the original overview because it makes an extra status RPC. The candidate retains degradation facts without another call.
- The full scan also verifies emitted timeline stages. All 116 tests across nine focused files passed, including text/JSON/deep/cold paths, remote probes and fallback behavior.
- Full build, the complete changed-check gate, and independent P0–P2 review passed. The narrowed probe result exposed three incomplete test fixtures; completing their existing session shape preserved counts/assertions, and all 40 Gateway-status tests and the complete test typecheck then passed. Total focused proof is 156 tests. Hosted CI binds the published head.
- The small fixture proves read elimination and output equivalence. Its source-test wall time is dominated by loading and transforms, so no production latency percentage is claimed.

The branch includes the independently landed shard-capacity repair #146212; range-diff verified a patch-identical rebase.
