### PR TITLE
fix(update): let JSON failure diagnostics finish before exit

### DIFF
--- a/docs/cli/update/repair-and-recovery.md
+++ b/docs/cli/update/repair-and-recovery.md
@@ -206,11 +206,12 @@ prove that a migration advanced. Output and heartbeats do not extend the phase
 deadline. These diagnostics do not establish that every descendant has stopped,
 and must not be used as rollback authorization.
 
-Shared CLI disposers have individual five-second deadlines. If the finalizer
-remains alive ten seconds after its terminal JSON, stderr and the ledger
-record active resource types and unsettled disposer names, then the process
-exits with its recorded outcome. A retained handle cannot withhold the
-supervisor's result indefinitely.
+Shared CLI disposers have individual five-second deadlines. Failure diagnostics
+and any interactive recovery finish before the ten-second exit grace starts.
+If the finalizer remains alive after that grace, stderr and the ledger record
+active resource types and unsettled disposer names, then the process exits with
+its recorded outcome. A retained handle cannot withhold the supervisor's result
+indefinitely.
 Both stall diagnostics also include `childProcesses`: up to eight descendant
 processes with `pid`, `parentPid`, and an executable name (`command`). Arguments,
 environment values, and executable paths are omitted. `childProcessesTruncated`
@@ -219,10 +220,8 @@ process list could not be read. A null `command` means that process's executable
 name was unavailable. Inspection runs only after a stall and adds at
 most one second to the exit bound. Phase-failure JSON includes the same fields.
 Preserve these diagnostics and the phase receipts when reporting a blocked child.
-Human repair can still wait for a recovery choice or repair agent; its exit grace
-starts after recovery finishes. Completion-cache refresh remains best effort
-when its child can be stopped within the phase budget. A phase that exceeds its
-overall deadline still fails finalization.
+Completion-cache refresh remains best effort when its child can be stopped within
+the phase budget. A phase that exceeds its overall deadline still fails finalization.
 
 Plugin artifacts that require capability consent are not installed without an
 interactive review or explicit `--accept-capabilities`. `--yes` alone does not

--- a/src/cli/update-cli/update-finalization-lifecycle.ts
+++ b/src/cli/update-cli/update-finalization-lifecycle.ts
@@ -284,9 +284,9 @@ export class UpdateFinalizationLifecycle {
     if (!hasCliProcessScope()) {
       return;
     }
-    // This timer never keeps a healthy command alive. Once output has a terminal
-    // outcome, retained handles or cleanup must not withhold EOF from supervisors.
-    const watch = () =>
+    // Recovery may still await diagnostics after terminal output; arm the watchdog
+    // from finishRecovery before unwinding resource cleanup.
+    this.deferredExitWatch = () =>
       watchCliExitAfterOutput(exitCode, () => {
         const diagnostic = JSON.stringify({
           activeResources: [...new Set(process.getActiveResourcesInfo())].toSorted(),
@@ -300,12 +300,6 @@ export class UpdateFinalizationLifecycle {
         this.recordDiagnostic(diagnostic);
         this.stopChildren();
       });
-    // Human repair may still await a recovery choice or agent after reporting failure.
-    if (this.json) {
-      watch();
-    } else {
-      this.deferredExitWatch = watch;
-    }
   }
 }
 

--- a/src/cli/update-finalization-output.process.test.ts
+++ b/src/cli/update-finalization-output.process.test.ts
@@ -319,6 +319,7 @@ describe.each(["repair", "finalize"])("update %s process output", (command) => {
       // Parse the whole pipe: accepting a suffix would hide Clack's direct stdout writes.
       const output = JSON.parse(result.stdout);
       if (scenario.endsWith("error")) {
+        expect(result.stderr, failure).not.toContain("Process still alive after terminal output");
         expect(result.stderr, failure).toContain(triageNotice);
         expect(result.stderr, failure).toContain('"promptPath":');
         expect(result.stderr, failure).toContain("triage-fixture-prompt.md");

--- a/src/cli/update-finalization-output.test-support.ts
+++ b/src/cli/update-finalization-output.test-support.ts
@@ -74,6 +74,7 @@ async function triageCommand() {
   const contextIndex = process.argv.indexOf('--update-result');
   if (contextIndex < 0) throw new Error('Missing update failure artifact');
   await fs.readFile(process.argv[contextIndex + 1], 'utf8');
+  ${scenario === "plugin-error" ? "await new Promise(resolve => setTimeout(resolve, 11_000));" : ""}
   const promptPath = path.join(process.env.OPENCLAW_STATE_DIR, 'logs', 'support', 'triage-fixture-prompt.md');
   await fs.mkdir(path.dirname(promptPath), { recursive: true });
   await fs.writeFile(promptPath, 'Synthetic update failure debugging prompt.\\n');


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where automated `update repair --json` invocations could lose failure diagnostics when plugin repair failed and diagnostic collection took longer than ten seconds.

## Why This Change Was Made

Start the existing exit watchdog after failure diagnostics and interactive recovery finish, using the same recovery boundary for JSON and human output. This removes the separate JSON timing branch while preserving the existing diagnostic and cleanup deadlines.

## User Impact

Failure diagnostics can finish within their existing budget. Stdout retains the original JSON result and failure exit status; diagnostic output stays on stderr. Stalled cleanup still triggers the ten-second watchdog.

## Evidence

The existing process fixture now delays JSON plugin-failure diagnostics for eleven seconds. On the original implementation, the real ten-second watchdog stopped the pending diagnostics child before its report was returned. The failure was observed at the new no-stall assertion, and both processes were confirmed gone afterward.

All eight selected process cases pass after the fix, including delayed JSON diagnostics, human recovery, normal JSON results, borrowed execution, and the retained-handle watchdog. The tests keep the real command registration, lifecycle, process ownership, output routing, and exit finalization; Doctor/plugin work and diagnostics content are synthetic. No operator installation or live Gateway was changed.

All 29 steps in the canonical changed gate passed, along with formatting and `git diff --check`. Fresh independent Codex review found no actionable defects through P2.
