### PR TITLE
fix(diagnostics): identify SQLite read and reclamation stalls

### DIFF
--- a/docs/logging.md
+++ b/docs/logging.md
@@ -435,6 +435,10 @@ time or isolate a validation phase. Short writer sections can therefore remain
 quiet while this whole-operation warning exposes slow preparation between them.
 The record inherits an existing parent trace when available; it contains no
 database path, session identifier, plan content, or raw error.
+Cold-storage operations use the same warning with `reclamationKind` set to
+`cold-batch` (archive or externalize), `cold-maintain` (reclaim free pages), or
+`cold-restore` (restore a transcript). Their writer warnings carry the same Worker
+identity and numbered admission fields.
 
 ### SQLite transaction timing
 
@@ -450,6 +454,18 @@ and before `COMMIT`, including any JavaScript consumer work inside that callback
 It excludes database opening and the separately timed begin and commit steps.
 These elapsed durations do not measure SQL CPU time or establish a causal link
 to a nearby request.
+
+The operation `session.reclamation.commit-settlement` identifies the parent's
+synchronous join after it authorizes a reclamation Worker to commit. Its lock
+wait is separate from the Worker's integrity scan and deletion work. This label
+also applies to cold-storage operations using that commit boundary.
+
+Hot transcript reads identify their purpose in `operation`: `session transcript
+<purpose> read`, where `<purpose>` is `identity`, `header`, `tail`, `incremental`,
+`checkpoint`, `events`, `raw rows`, `storage rows`, or `match`. These fixed labels
+distinguish readers without retaining session IDs or transcript content. Nested
+reads remain part of the outer transaction's timing; older warnings use the
+generic `session transcript hot read` label.
 
 Immediate `BEGIN` warnings also include `beginAdmission`: `nativeAttempts` counts
 actual native `BEGIN IMMEDIATE` calls and `nativeMs` measures those calls;

--- a/src/config/sessions/session-accessor.sqlite-cold-read.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-cold-read.test.ts
@@ -1,4 +1,6 @@
+import fs from "node:fs/promises";
 import { DatabaseSync } from "node:sqlite";
+import { isMainThread, threadId } from "node:worker_threads";
 import { afterEach, expect, it, vi } from "vitest";
 import { visitSessionMessagesAsync } from "../../gateway/session-transcript-readers.js";
 import {
@@ -8,6 +10,7 @@ import {
   getNodeSqliteKysely,
 } from "../../infra/kysely-sync.js";
 import { runSqliteImmediateTransactionSync } from "../../infra/sqlite-transaction.js";
+import { flushLogger, setLoggerOverride } from "../../logging/logger.js";
 import type { DB } from "../../state/openclaw-agent-db.generated.js";
 import {
   openOpenClawAgentDatabase,
@@ -223,6 +226,50 @@ it("checks a cached identity reader when invoked after another connection archiv
       expect(() => read("user")).toThrow(/cold storage/);
     } finally {
       race.writer.close();
+    }
+  });
+});
+
+it("identifies a slow transcript matcher while retaining its hot read snapshot", async () => {
+  await withOpenClawTestState({ label: "hot-read-attribution" }, async (state) => {
+    const race = await prepareRace(state);
+    const file = state.path("hot-read.log");
+    setLoggerOverride({ level: "info", consoleLevel: "silent", file });
+    let clock = Date.now();
+    vi.spyOn(Date, "now").mockImplementation(() => clock);
+    try {
+      const found = findTranscriptEventInDatabase(race.database, race.scope.sessionId, () => {
+        expect(race.database.db.isTransaction).toBe(true);
+        clock += 1_200;
+        race.commitArchive();
+        return true;
+      });
+      expect(found).toMatchObject({ event: { id: "answer" } });
+      expect(race.database.db.isTransaction).toBe(false);
+      expect(() => loadTranscriptHeaderSync(race.scope)).toThrow(/cold storage/);
+      await flushLogger();
+      const holds = (await fs.readFile(file, "utf8"))
+        .split("\n")
+        .filter(Boolean)
+        .map((line) => JSON.parse(line) as Record<string, unknown>)
+        .filter((record) => record.message === "slow SQLite transaction hold")
+        .map((record) => record["1"]);
+      expect(holds).toEqual([
+        {
+          async: false,
+          elapsedMs: 1_200,
+          isMainThread,
+          operation: "session transcript match read",
+          pid: process.pid,
+          threadId,
+          thresholdMs: 1_000,
+        },
+      ]);
+    } finally {
+      vi.restoreAllMocks();
+      race.writer.close();
+      await flushLogger();
+      setLoggerOverride(null);
     }
   });
 });

--- a/src/config/sessions/session-accessor.sqlite-contract.ts
+++ b/src/config/sessions/session-accessor.sqlite-contract.ts
@@ -18,7 +18,14 @@ export type SessionEntryStatus = NonNullable<SessionEntry["status"]>;
 
 /** Worker operation facts; no Worker object or plan payload is retained. */
 export type SqliteSessionReclamationDiagnostics = {
-  kind?: "entry" | "lifecycle-artifacts" | "history-eviction" | "historical-generation";
+  kind?:
+    | "entry"
+    | "lifecycle-artifacts"
+    | "history-eviction"
+    | "historical-generation"
+    | "cold-batch"
+    | "cold-maintain"
+    | "cold-restore";
   workerThreadId?: number;
 };
 

--- a/src/config/sessions/session-accessor.sqlite-read.ts
+++ b/src/config/sessions/session-accessor.sqlite-read.ts
@@ -72,7 +72,7 @@ export function createTranscriptIdentityReader(database: OpenClawAgentDatabase, 
       ),
   );
   return (eventId: string) =>
-    readHotSessionTranscriptSnapshot(database, sessionId, () => {
+    readHotSessionTranscriptSnapshot(database, sessionId, "identity", () => {
       const row = read(eventId).rows[0];
       return row ? { eventId: row.event_id, parentId: row.parent_id, seq: row.seq } : undefined;
     });
@@ -187,7 +187,7 @@ export function validatePreparedAssistantAppendSync(
 export function loadTranscriptHeaderSync(scope: SessionTranscriptReadScope): unknown {
   const resolved = resolveSqliteTranscriptReadScope(scope);
   const database = openOpenClawAgentDatabase(toDatabaseOptions(resolved));
-  return readHotSessionTranscriptSnapshot(database, resolved.sessionId, () => {
+  return readHotSessionTranscriptSnapshot(database, resolved.sessionId, "header", () => {
     const db = getSessionKysely(database.db);
     const row = executeSqliteQueryTakeFirstSync(
       database.db,
@@ -213,7 +213,7 @@ export function loadTranscriptTailEventsSync(
   }
   const resolved = resolveSqliteTranscriptReadScope(scope);
   const database = openOpenClawAgentDatabase(toDatabaseOptions(resolved));
-  return readHotSessionTranscriptSnapshot(database, resolved.sessionId, () => {
+  return readHotSessionTranscriptSnapshot(database, resolved.sessionId, "tail", () => {
     const db = getSessionKysely(database.db);
     return executeSqliteQuerySync(
       database.db,
@@ -237,7 +237,7 @@ export function loadTranscriptEventRowsAfterSeqSync(
 ): SessionTranscriptEventRow[] {
   const resolved = resolveSqliteTranscriptReadScope(scope);
   const database = openOpenClawAgentDatabase(toDatabaseOptions(resolved));
-  return readHotSessionTranscriptSnapshot(database, resolved.sessionId, () => {
+  return readHotSessionTranscriptSnapshot(database, resolved.sessionId, "incremental", () => {
     const db = getSessionKysely(database.db);
     let query = db
       .selectFrom("transcript_events")
@@ -261,7 +261,7 @@ export function readTranscriptEventAtSeqSync(
 ): SessionTranscriptEventRow | undefined {
   const resolved = resolveSqliteTranscriptReadScope(scope);
   const database = openOpenClawAgentDatabase(toDatabaseOptions(resolved));
-  return readHotSessionTranscriptSnapshot(database, resolved.sessionId, () => {
+  return readHotSessionTranscriptSnapshot(database, resolved.sessionId, "checkpoint", () => {
     const db = getSessionKysely(database.db);
     const row = executeSqliteQueryTakeFirstSync(
       database.db,
@@ -285,7 +285,7 @@ export function loadTranscriptEventsFromDatabase(
   sessionId: string,
   options: { beforeEventSeq?: number; projection?: "reset-boundary" } = {},
 ): TranscriptEvent[] {
-  return readHotSessionTranscriptSnapshot(database, sessionId, () => {
+  return readHotSessionTranscriptSnapshot(database, sessionId, "events", () => {
     const { beforeEventSeq } = options;
     const db = getSessionKysely(database.db);
     const rows = iterateSqliteQuerySync(
@@ -323,7 +323,7 @@ export function readTranscriptEventRows(
   sessionId: string,
   options: { afterSeq?: number } = {},
 ): SqliteTranscriptSnapshotRow[] {
-  return readHotSessionTranscriptSnapshot(database, sessionId, () => {
+  return readHotSessionTranscriptSnapshot(database, sessionId, "raw rows", () => {
     const db = getSessionKysely(database.db);
     const rows = executeSqliteQuerySync(
       database.db,
@@ -346,7 +346,7 @@ export function readTranscriptStorageRows(
   database: OpenClawAgentDatabase,
   sessionId: string,
 ): SqliteTranscriptStorageRow[] {
-  return readHotSessionTranscriptSnapshot(database, sessionId, () => {
+  return readHotSessionTranscriptSnapshot(database, sessionId, "storage rows", () => {
     const db = getSessionKysely(database.db);
     const rows = executeSqliteQuerySync(
       database.db,
@@ -628,7 +628,7 @@ export function findTranscriptEventInDatabase(
   sessionId: string,
   match: (event: TranscriptEvent) => boolean,
 ): { event: TranscriptEvent } | undefined {
-  return readHotSessionTranscriptSnapshot(database, sessionId, () => {
+  return readHotSessionTranscriptSnapshot(database, sessionId, "match", () => {
     const db = getSessionKysely(database.db);
     const rows = iterateSqliteQuerySync(
       database.db,

--- a/src/config/sessions/session-accessor.sqlite-reclamation-commit.ts
+++ b/src/config/sessions/session-accessor.sqlite-reclamation-commit.ts
@@ -125,9 +125,13 @@ function authorizeSqliteReclamationCommit(
       try {
         // The Worker already owns BEGIN IMMEDIATE. Acquiring this lock proves
         // COMMIT, ROLLBACK, or connection close finished, even after abrupt exit.
-        runSqliteImmediateTransactionSync(database, () => {
-          settled = true;
-        });
+        runSqliteImmediateTransactionSync(
+          database,
+          () => {
+            settled = true;
+          },
+          { operationLabel: "session.reclamation.commit-settlement" },
+        );
       } catch (error) {
         if (recoveredErrors.length === 0) {
           recoveredErrors.push(error);

--- a/src/config/sessions/session-cold-storage-read.ts
+++ b/src/config/sessions/session-cold-storage-read.ts
@@ -10,6 +10,16 @@ import {
 export function readHotSessionTranscriptSnapshot<T>(
   database: { db: DatabaseSync },
   sessionId: string,
+  purpose:
+    | "identity"
+    | "header"
+    | "tail"
+    | "incremental"
+    | "checkpoint"
+    | "events"
+    | "raw rows"
+    | "storage rows"
+    | "match",
   read: () => T,
 ): T {
   return runSqliteDeferredTransactionSync(
@@ -18,7 +28,7 @@ export function readHotSessionTranscriptSnapshot<T>(
       assertSessionTranscriptHot(database.db, sessionId);
       return read();
     },
-    { operationLabel: "session transcript hot read" },
+    { operationLabel: `session transcript ${purpose} read` },
   );
 }
 

--- a/src/config/sessions/session-cold-storage.test.ts
+++ b/src/config/sessions/session-cold-storage.test.ts
@@ -1,10 +1,13 @@
 import { createHash } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
+import { performance } from "node:perf_hooks";
+import { isMainThread, threadId } from "node:worker_threads";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createDeferred, withTestTimeout } from "../../../test/helpers/promise.js";
 import { createTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import { executeSqliteQuerySync, getNodeSqliteKysely } from "../../infra/kysely-sync.js";
+import { flushLogger, setLoggerOverride } from "../../logging/logger.js";
 import { beginSessionWorkAdmission } from "../../sessions/session-lifecycle-admission.js";
 import type { DB } from "../../state/openclaw-agent-db.generated.js";
 import {
@@ -374,17 +377,67 @@ describe("cold transcript storage workers", () => {
 
   it("archives several inactive sessions in one maintenance pass and restores both exactly", async () => {
     const fixture = await createBatchFixture();
-    await expect(runSessionColdStorageMaintenance({ config: fixture.config })).resolves.toEqual({
-      archivedTranscripts: 2,
-      externalizedTranscripts: 0,
-    });
-    expect(readSessionColdTranscript(fixture.database(), historicalId)).toBeDefined();
-    expect(
-      readSessionColdTranscript(fixture.database(), fixture.secondScope.sessionId),
-    ).toBeDefined();
-    await restoreSessionColdTranscript(fixture.scope);
-    await restoreSessionColdTranscript(fixture.secondScope);
-    expect(fixture.snapshot()).toEqual(fixture.original);
+    const file = path.join(path.dirname(fixture.scope.storePath), "cold-storage.log");
+    await fs.writeFile(file, "");
+    setLoggerOverride({ level: "info", consoleLevel: "silent", file });
+    let clock = 0;
+    vi.spyOn(performance, "now").mockImplementation(() => clock);
+    const originalWorker = archiveWorkers.runSqliteTranscriptArchiveWorkerOperation;
+    vi.spyOn(archiveWorkers, "runSqliteTranscriptArchiveWorkerOperation").mockImplementation(
+      (params) => {
+        const withWriteAdmission = params.withWriteAdmission;
+        if (!withWriteAdmission) {
+          return originalWorker(params);
+        }
+        let admissions = 0;
+        return originalWorker({
+          ...params,
+          withWriteAdmission: async (...args) => {
+            // Measure waiting between actual Worker admissions without delaying native work.
+            if (++admissions === 2) {
+              clock += 1_500;
+            }
+            return withWriteAdmission(...args);
+          },
+        });
+      },
+    );
+    try {
+      await expect(runSessionColdStorageMaintenance({ config: fixture.config })).resolves.toEqual({
+        archivedTranscripts: 2,
+        externalizedTranscripts: 0,
+      });
+      expect(readSessionColdTranscript(fixture.database(), historicalId)).toBeDefined();
+      expect(
+        readSessionColdTranscript(fixture.database(), fixture.secondScope.sessionId),
+      ).toBeDefined();
+      await restoreSessionColdTranscript(fixture.scope);
+      await restoreSessionColdTranscript(fixture.secondScope);
+      expect(fixture.snapshot()).toEqual(fixture.original);
+      await flushLogger();
+      const summaries = (await fs.readFile(file, "utf8"))
+        .split("\n")
+        .filter(Boolean)
+        .map((line) => JSON.parse(line) as Record<string, unknown>)
+        .filter((record) => record.message === "slow SQLite reclamation Worker operation")
+        .map((record) => record["1"]);
+      expect(summaries).toEqual(
+        ["cold-batch", "cold-restore", "cold-restore"].map((reclamationKind) => ({
+          pid: process.pid,
+          threadId,
+          isMainThread,
+          workerThreadId: expect.any(Number),
+          reclamationKind,
+          elapsedMs: 1_500,
+          outcome: "resolved",
+          exitCode: 0,
+        })),
+      );
+    } finally {
+      vi.restoreAllMocks();
+      await flushLogger();
+      setLoggerOverride(null);
+    }
   });
 
   it("leaves hot and embedded archives untouched while maintenance is disabled", async () => {

--- a/src/config/sessions/session-cold-storage.ts
+++ b/src/config/sessions/session-cold-storage.ts
@@ -26,7 +26,10 @@ import {
 import type { OpenClawConfig } from "../types.js";
 import { resolveSessionArtifactDirectory } from "./paths.js";
 import { runSqliteTranscriptArchiveWorkerOperation } from "./session-accessor.sqlite-archive.js";
-import type { SessionTranscriptReadScope } from "./session-accessor.sqlite-contract.js";
+import type {
+  SessionTranscriptReadScope,
+  SqliteSessionReclamationDiagnostics,
+} from "./session-accessor.sqlite-contract.js";
 import { readSessionStateDeleteSnapshot } from "./session-accessor.sqlite-delete-snapshot.js";
 import { withSqliteReclamationAuthorization } from "./session-accessor.sqlite-reclamation-commit.js";
 import {
@@ -96,6 +99,7 @@ async function runColdMutation(
       assertCurrent?.();
     };
     const commitGate = new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT);
+    const diagnostics: SqliteSessionReclamationDiagnostics = { kind: plan.kind };
     const [completed] = await withSqliteReclamationAuthorization(
       commitGate,
       database.db,
@@ -105,11 +109,12 @@ async function runColdMutation(
           result: SessionColdMutationResult;
           cleanupIncomplete?: boolean;
         }>({
+          diagnostics,
           expectedMessageType: "reclaimed",
           onCommitRequest: () => {
             authorize();
           },
-          withWriteAdmission: async (run) =>
+          withWriteAdmission: async (run, reclamationAdmission) =>
             runExclusiveSqliteSessionWrite(
               plan.databaseOptions,
               async () => {
@@ -122,6 +127,7 @@ async function runColdMutation(
                 await run(refusal);
               },
               "session.reclamation.worker-commit",
+              { ...diagnostics, reclamationAdmission },
             ),
           workerData: {
             type: "sqlite-transcript-archive-v2",


### PR DESCRIPTION
Related: #146213

## What Problem This Solves

Fixes missing and ambiguous diagnostics when SQLite work delays the Gateway. Cold-storage mutations did not emit the existing whole-worker timing summary, the parent's reclamation commit wait had no operation name, and nine transcript readers shared one generic slow-read label.

## Why This Change Was Made

Carry cold-batch, cold-maintain, and cold-restore kinds through the existing reclamation diagnostics. Label the existing commit-settlement transaction and give each hot transcript reader a fixed purpose through its current snapshot helper. The same log fields, thresholds, traces, and timing owners produce the records.

No query, transaction, worker lifetime, lease, integrity check, retention, configuration, or stored-data semantics change. The records include no new session identifiers, transcript contents, database paths, or raw errors.

## User Impact

Operators can distinguish cold-storage work, commit-settlement waits, and specific transcript reads when investigating a stall. Durations include waits and nested work; they are not CPU attribution or a claim that the underlying operation is faster.

## Evidence

- Extended the real cold archive/restore roundtrip. The original code emitted no cold-worker summaries; the candidate emits one cold-batch and two cold-restore summaries while preserving exact stored event/row bytes.
- The real matcher diagnostic regression fails on the original generic label and passes with the specific reader purpose, while preserving the returned event and transaction behavior.
- 92 focused runtime tests passed across cold storage, reclamation, commit settlement, writer-scope diagnostics, and all nine cold-marker snapshot race paths.
- Complete changed checks and the follow-up hot-reader checks passed, including core/test types, final-tree dead-export scans, lint, formatting, and storage/architecture guards.
- Independent P0–P2 review found no actionable findings.

This is the attribution part of the latency investigation. Retaining a reclamation connection across operations is a separate writer-lifecycle design and is not included here.

The branch includes #146212’s shared typecheck-shard repair, with a patch-identical rebase.
