### PR TITLE
improve: save large Team Reports with fewer database writes

### DIFF
--- a/extensions/team-reports/src/store.test.ts
+++ b/extensions/team-reports/src/store.test.ts
@@ -140,14 +140,28 @@ describe("Team Reports storage", () => {
     expect(await store.listPersonDays("ALICE")).toMatchObject([
       { dayKey: "2026-08-20", githubTotal: 1, commits: 1, discordMessages: 2 },
     ]);
-    await expect(
-      store.upsertPeriod({
-        report: report("2026-08-20", ["alice", "alice"]),
-        markdown: "failed refresh",
-      }),
-    ).rejects.toThrow();
-    expect((await store.getPeriod("day", "2026-08-20"))?.markdown).toBe("original");
-    expect(await store.listPersonDays("bob")).toHaveLength(1);
+    const lateDuplicate = [
+      "alice",
+      ...Array.from({ length: 3000 }, (_, index) => `new-${index}`),
+      "ALICE",
+    ];
+    for (const logins of [["alice", "alice"], lateDuplicate]) {
+      await expect(
+        store.upsertPeriod({
+          report: report("2026-08-20", logins),
+          markdown: "failed refresh",
+        }),
+      ).rejects.toThrow();
+      expect(await store.getPeriod("day", "2026-08-20")).toEqual({
+        report: report(),
+        summary,
+        markdown: "original",
+      });
+      expect((await store.listPersonDaysSince("2026-08-20")).map((day) => day.login)).toEqual([
+        "alice",
+        "bob",
+      ]);
+    }
     const refreshed = report("2026-08-20", ["alice"]);
     refreshed.members[0]!.github.commits = 3;
     refreshed.members[0]!.github.total = 3;
@@ -228,8 +242,8 @@ describe("Team Reports storage", () => {
   it("lists all logins since an inclusive day without the individual timeline limit", async () => {
     const { store } = await openStore();
     const logins = Array.from(
-      { length: 30 },
-      (_, index) => `member-${String(index).padStart(2, "0")}`,
+      { length: 3000 },
+      (_, index) => `member-${String(index).padStart(4, "0")}`,
     );
     await store.upsertPeriod({ report: report("2026-08-18", ["older"]), markdown: "older" });
     await store.upsertPeriod({ report: report("2026-08-19", logins), markdown: "boundary" });
@@ -241,7 +255,7 @@ describe("Team Reports storage", () => {
     ]);
     expect(days[1]).toEqual({
       dayKey: "2026-08-19",
-      login: "member-00",
+      login: "member-0000",
       githubTotal: 1,
       commits: 1,
       prsOpened: 0,
@@ -254,6 +268,11 @@ describe("Team Reports storage", () => {
       discordMessages: 2,
     });
     expect(await store.listPersonDaysSince("2026-08-21")).toEqual([]);
+    await store.upsertPeriod({ report: report("2026-08-19", []), markdown: "empty roster" });
+    expect((await store.listPersonDaysSince("2026-08-19")).map((day) => day.login)).toEqual([
+      "latest",
+    ]);
+    expect((await store.getPeriod("day", "2026-08-19"))?.report.members).toEqual([]);
   });
 
   it("reads a complete month of individually valid reports across the worker boundary", async () => {

--- a/extensions/team-reports/src/store.worker.ts
+++ b/extensions/team-reports/src/store.worker.ts
@@ -33,6 +33,9 @@ import {
 } from "./store-schema.js";
 import type { Period, ReportDocument, SummaryDocument } from "./types.js";
 
+// Bound each 12-column person-day insert to 768 parameters.
+const PERSON_DAY_INSERT_BATCH_SIZE = 64;
+
 type PeriodRow = {
   period: Period;
   period_key: string;
@@ -151,10 +154,12 @@ class TeamReportsDatabase {
             .deleteFrom("team_reports_person_days")
             .where("day_key", "=", report.period.key),
         );
-        for (const person of people) {
+        for (let start = 0; start < people.length; start += PERSON_DAY_INSERT_BATCH_SIZE) {
           executeSqliteQuerySync(
             this.db,
-            this.query.insertInto("team_reports_person_days").values(person),
+            this.query
+              .insertInto("team_reports_person_days")
+              .values(people.slice(start, start + PERSON_DAY_INSERT_BATCH_SIZE)),
           );
         }
       }


### PR DESCRIPTION
Related: #146197

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Refreshing Team Reports for a large roster spends unnecessary time saving each person's daily activity separately. A 3,000-member daily report previously required 3,002 write statements.

## Why This Change Was Made

The existing Team Reports worker now inserts person-day rows in batches of 64, with at most 768 bound parameters per statement. The report update, removal of the previous roster, and every insertion remain in the same synchronous transaction, including rollback on a duplicate normalized login. Schema, API, retention, and update behavior are unchanged.

## User Impact

Large team reports save with fewer SQLite operations. A 3,000-member report now uses 49 write statements, while empty rosters still remove stale people and a failed refresh preserves the previous report and roster.

## Evidence

- All 10 Team Reports store tests passed through the registered SQLite worker. Extended existing cases cover 3,000 members, empty replacement, and rollback when a duplicate normalized login occurs after 3,000 unique rows.
- Fresh independent P2 review completed with no findings.
- Paired local measurements used separate file-backed WAL databases and real workers, 10 warmups, 25 measured replacements per variant, and alternating order. Complete reports and person counts were verified. Write counts exclude startup, migrations, and transaction control.

| Members | Write statements before → after | Median ms before → after | p95 ms before → after |
| --- | --- | --- | --- |
| 1 | 3 → 3 | 1.888 → 2.552 | 4.324 → 9.508 |
| 100 | 102 → 4 | 2.322 → 1.704 | 3.738 → 2.180 |
| 1,000 | 1,002 → 18 | 18.190 → 10.373 | 32.509 → 24.867 |
| 3,000 | 3,002 → 49 | 48.622 → 30.050 | 63.758 → 36.993 |

The 100–3,000-member median improved 26.6–43.0% on Windows with Node 26.8.2. These are synthetic local measurements under concurrent host activity; the one-member case shows no demonstrated benefit and production latency was not measured.

Extension production and test typechecks, scoped lint, formatting, plugin boundaries, dependency checks, all six Doctor contract tests, and the database-first, media, runtime-sidecar, and import-cycle guards passed. Lint used locally generated canonical extension boundary artifacts. `git diff --check` passed.

The production unused-export scan passed. The script/full-tree unused-export guard reported `canonicalProviderName` in `scripts/crabbox-wrapper-providers.mts` and `listPackagedStaticExtensionAssetOutputs` in `scripts/lib/static-extension-assets.mts`; both files are unchanged from the base commit. The combined changed-check command therefore does not have a complete passing result.
