### PR TITLE
fix(ui): hide heartbeat sessions with system filter

### DIFF
--- a/ui/src/lib/sessions/navigation.test.ts
+++ b/ui/src/lib/sessions/navigation.test.ts
@@ -123,6 +123,52 @@ describe("resolveSessionNavigation", () => {
     expect(navigation.activeRowKey).toBe("agent:main:explicit:incident-debug");
   });
 
+  it("hides heartbeat sessions with the system toggle independently of automation", () => {
+    const heartbeat: GatewaySessionRow = {
+      key: "agent:main:discord:channel:123:heartbeat",
+      kind: "direct",
+      classification: "heartbeat",
+      label: "discord:g-123-heartbeat",
+      updatedAt: 200,
+    };
+    const rows: GatewaySessionRow[] = [
+      { key: "agent:main:chat", kind: "direct", updatedAt: 300 },
+      heartbeat,
+    ];
+
+    const hidden = resolveSessionNavigation({
+      result: sessionsResult(rows),
+      resultAgentId: "main",
+      sessionKey: "agent:main:chat",
+      showCron: true,
+    });
+    expect(hidden.visibleSessions.map((row) => row.key)).toEqual(["agent:main:chat"]);
+
+    const shown = resolveSessionNavigation({
+      result: sessionsResult(rows),
+      resultAgentId: "main",
+      sessionKey: "agent:main:chat",
+      showSystem: true,
+    });
+    expect(shown.visibleSessions.map((row) => row.key)).toEqual(["agent:main:chat", heartbeat.key]);
+  });
+
+  it("keeps a selected heartbeat session visible with the system toggle off", () => {
+    const heartbeat: GatewaySessionRow = {
+      key: "agent:main:discord:channel:123:heartbeat",
+      kind: "direct",
+      classification: "heartbeat",
+      updatedAt: 200,
+    };
+
+    const navigation = resolveSessionNavigation({
+      result: sessionsResult([heartbeat]),
+      resultAgentId: "main",
+      sessionKey: heartbeat.key,
+    });
+    expect(navigation.visibleSessions).toEqual([heartbeat]);
+  });
+
   it("uses the caller's sort order before applying the recent-session projection", () => {
     const navigation = resolveSessionNavigation({
       result: sessionsResult([
@@ -436,6 +482,11 @@ describe("isSystemCreatedSessionRow", () => {
     ["run + label stays visible", { createdVia: "run", label: "My batch job" }, false],
     ["operator creation stays visible", { createdVia: "operator" }, false],
     ["legacy row without provenance stays visible", {}, false],
+    [
+      "gateway-classified heartbeat is system despite a derived label",
+      { classification: "heartbeat", label: "discord:g-123-heartbeat" },
+      true,
+    ],
     [
       "cron row with system actor is owned by the automation toggle",
       { key: "agent:main:cron:job", createdVia: "cron", createdActor: { type: "system" } },

--- a/ui/src/lib/sessions/navigation.ts
+++ b/ui/src/lib/sessions/navigation.ts
@@ -177,6 +177,9 @@ export function isSystemCreatedSessionRow(row: GatewaySessionRow): boolean {
   if (isCronSessionKey(row.key)) {
     return false;
   }
+  if (row.classification === "heartbeat") {
+    return true;
+  }
   if (row.createdActor?.type === "system") {
     return true;
   }


### PR DESCRIPTION
Closes #146124

## What Problem This Solves

Fixes an issue where operators hiding System sessions in the Control UI could still see isolated heartbeat rows. Those rows also consumed limited Team Mode sidebar slots even when Automation sessions were hidden.

## Why This Change Was Made

The shared sidebar filter now consumes the Gateway-provided `classification: heartbeat` fact. This keeps the System and Automation toggles independent, avoids treating ordinary session keys ending in `:heartbeat` as system sessions, and preserves the existing selected-session escape hatch.

## User Impact

Heartbeat sessions now disappear when System sessions are hidden, while cron sessions remain controlled only by the Automation toggle. A selected heartbeat session remains reachable even when System sessions are hidden.

## Evidence

- `ui/src/lib/sessions/navigation.test.ts`: 29/29 passed, including heartbeat classification, independent toggle behavior, and selected-session visibility.
- `ui/src/components/app-sidebar-session-navigation-logic.test.ts`: 43/43 passed.
- `src/gateway/session-classification.test.ts`: 21/21 passed.
- `pnpm tsgo:ui`: passed.
- `pnpm tsgo:test:ui`: passed.
- `oxfmt --check` on both changed files: passed.
- `git diff --check`: passed.
- Portfolio preflight: PASS on current `main`, two changed files, +54/-0, clean worktree, no merge commits.
- `node scripts/check-changed.mjs` completed conflict-marker, ratchet, dependency, formatting, boundary, and Control UI i18n gates. Its repository-wide core-test typecheck was not repeated after the focused UI test typecheck passed.
- Reporter-provided rendered Control UI proof on exact head `84315f842e1d`: [three inspected screenshots](https://github.com/openclaw/openclaw/pull/146234#issuecomment-5699248013) verify Team Mode with both filters enabled, System hidden while Automation remains enabled, and selected-heartbeat access; focused navigation 29/29, rendered proof 1/1, and production build passed.
