### PR TITLE
improve(skills): load pinned library revisions in one query

### DIFF
--- a/src/skills/library/selection.ts
+++ b/src/skills/library/selection.ts
@@ -24,6 +24,7 @@ import {
   resolveSkillLibraryActor,
   selectSkillLibraryRevision,
   selectSkillLibraryRevisionMetadata,
+  selectSkillLibraryRevisionMetadataBatch,
   skillLibraryDb,
   type SkillLibraryAuthority,
 } from "./store.js";
@@ -205,53 +206,48 @@ export function loadSkillLibrarySelection(
   if (selections.length > SKILL_LIBRARY_MAX_SELECTIONS) {
     throw new SkillLibraryError("LIMIT", "Invalid session skill selection.");
   }
-  const entries = readSkillLibraryStore(
-    (db) =>
-      selections.map((selection) => {
-        const revision = selectSkillLibraryRevisionMetadata(
-          db,
-          selection.skillId,
-          selection.revision,
+  const entries = readSkillLibraryStore((db) => {
+    const revisions = selectSkillLibraryRevisionMetadataBatch(db, selections);
+    return selections.map((selection, index) => {
+      const revision = revisions[index];
+      if (!revision) {
+        throw new SkillLibraryError(
+          "NOT_FOUND",
+          "A pinned skill revision is unavailable; restore the library artifact or detach it explicitly.",
         );
-        if (!revision) {
-          throw new SkillLibraryError(
-            "NOT_FOUND",
-            "A pinned skill revision is unavailable; restore the library artifact or detach it explicitly.",
-          );
-        }
-        const baseDir = skillLibraryRevisionDir(selection.skillId, selection.revision, options.env);
-        const filePath = path.join(baseDir, "SKILL.md");
-        const content = fs.readFileSync(filePath, "utf8");
-        const frontmatter = parseSkillFrontmatter(content);
-        const metadata = resolveSkillManifestMetadata(frontmatter);
-        const invocation = resolveSkillInvocationPolicy(frontmatter);
-        const name = selection.name;
-        return {
-          skill: materializeSkill({
-            content,
-            frontmatter,
-            name,
-            description: revision.description,
-            baseDir,
-            filePath,
-            source: "openclaw-library",
-            sourceOptions: { source: "openclaw-library" },
-          }),
+      }
+      const baseDir = skillLibraryRevisionDir(selection.skillId, selection.revision, options.env);
+      const filePath = path.join(baseDir, "SKILL.md");
+      const content = fs.readFileSync(filePath, "utf8");
+      const frontmatter = parseSkillFrontmatter(content);
+      const metadata = resolveSkillManifestMetadata(frontmatter);
+      const invocation = resolveSkillInvocationPolicy(frontmatter);
+      const name = selection.name;
+      return {
+        skill: materializeSkill({
+          content,
           frontmatter,
-          invocation,
-          // Untrusted frontmatter can constrain executable eligibility, but cannot claim global credentials/config.
-          metadata: {
-            skillKey: name,
-            os: metadata?.os,
-            requires: metadata?.requires,
-          },
-          disableCommandDispatch: true,
-          syncSourceDir: baseDir,
-          syncDirName: `library-${selection.skillId}-${selection.revision}`,
-        } satisfies SkillEntry;
-      }),
-    options,
-  );
+          name,
+          description: revision.description,
+          baseDir,
+          filePath,
+          source: "openclaw-library",
+          sourceOptions: { source: "openclaw-library" },
+        }),
+        frontmatter,
+        invocation,
+        // Untrusted frontmatter can constrain executable eligibility, but cannot claim global credentials/config.
+        metadata: {
+          skillKey: name,
+          os: metadata?.os,
+          requires: metadata?.requires,
+        },
+        disableCommandDispatch: true,
+        syncSourceDir: baseDir,
+        syncDirName: `library-${selection.skillId}-${selection.revision}`,
+      } satisfies SkillEntry;
+    });
+  }, options);
   if (!entries) {
     throw new SkillLibraryError(
       "NOT_FOUND",

--- a/src/skills/library/service.test.ts
+++ b/src/skills/library/service.test.ts
@@ -2,6 +2,7 @@ import { createHash } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { constants } from "node:sqlite";
+import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { SKILL_LIBRARY_MAX_FILE_BYTES } from "../../../packages/gateway-protocol/src/schema/skill-library.js";
 import { trackSqliteStatementExecutions } from "../../../test/helpers/sqlite-statement-execution-counter.js";
@@ -127,7 +128,7 @@ describe("profile-owned skill publication and selection", () => {
     const { alice, options, stateDir } = fixture();
     const saved = await saveSkillLibrary(alice, draft(), options);
     const pins = seedSkillLibrarySelection(alice, options);
-    await saveSkillLibrary(
+    const updated = await saveSkillLibrary(
       alice,
       {
         ...draft(),
@@ -137,6 +138,25 @@ describe("profile-owned skill publication and selection", () => {
       },
       options,
     );
+    const originalPin = expectDefined(pins[0], "original selected revision");
+    const mixedRevisions = [
+      { ...originalPin, revision: updated.entry.revision },
+      originalPin,
+      originalPin,
+    ];
+    expect(
+      loadSkillLibrarySelection(mixedRevisions, options).map((entry) => entry.skill.filePath),
+    ).toEqual(
+      mixedRevisions.map((pin) =>
+        path.join(skillLibraryRevisionDir(pin.skillId, pin.revision, options.env), "SKILL.md"),
+      ),
+    );
+    expect(() =>
+      loadSkillLibrarySelection(
+        [originalPin, { ...originalPin, revision: "0".repeat(64) }],
+        options,
+      ),
+    ).toThrow(expect.objectContaining({ code: "NOT_FOUND" }));
     const { listSkillCommandsForWorkspace } = await import("../discovery/chat-commands.js");
     withEnv({ OPENCLAW_STATE_DIR: stateDir }, () => {
       const cfg = { agents: { defaults: { skills: [] } } };
@@ -724,6 +744,24 @@ describe("library admission and imports", () => {
     const selected = seedSkillLibrarySelection(bob, options);
     expect(library.defaultSelectionNotice).toContain("detach");
     expect(selected).toHaveLength(64);
+    const revisionReads = trackSqliteStatementExecutions(
+      openOpenClawStateDatabase(options).db,
+      ["revisions"],
+      (sql) =>
+        sql.startsWith("select ") && sql.includes('from "skill_library_revisions"')
+          ? "revisions"
+          : null,
+    );
+    try {
+      const ordered = selected.toReversed();
+      expect(loadSkillLibrarySelection(ordered, options).map((entry) => entry.skill.name)).toEqual(
+        ordered.map((pin) => pin.name),
+      );
+      expect(revisionReads.counts.revisions).toBe(1);
+      expect(revisionReads.rowCounts.revisions).toBe(64);
+    } finally {
+      revisionReads.restore();
+    }
     const omitted = library.entries.find(
       (entry) => !selected.some((pin) => pin.skillId === entry.skillId),
     )!;

--- a/src/skills/library/store.ts
+++ b/src/skills/library/store.ts
@@ -1,7 +1,10 @@
 import { randomUUID } from "node:crypto";
 import type { DatabaseSync } from "node:sqlite";
 import type { SelectQueryBuilder } from "kysely";
-import type { SkillLibraryEntry } from "../../../packages/gateway-protocol/src/schema/skill-library.js";
+import type {
+  SkillLibraryEntry,
+  SkillLibrarySelection,
+} from "../../../packages/gateway-protocol/src/schema/skill-library.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { authorizeOperatorScopesForRequiredScope } from "../../gateway/method-scopes.js";
 import { resolveOperatorRolePolicyForAssignment } from "../../gateway/operator-role-policy.js";
@@ -220,6 +223,33 @@ export function selectSkillLibraryRevisionMetadata(
     db,
     skillLibraryRevisionQuery(db, skillId, revision).select("description"),
   );
+}
+
+/** Resolve a bounded session selection in its original order, including repeated pins. */
+export function selectSkillLibraryRevisionMetadataBatch(
+  db: DatabaseSync,
+  selections: readonly Pick<SkillLibrarySelection, "skillId" | "revision">[],
+) {
+  const rows = executeSqliteQuerySync(
+    db,
+    skillLibraryDb(db)
+      .selectFrom("skill_library_revisions")
+      .select(["skill_id", "revision", "description"])
+      .where((eb) =>
+        eb.or(
+          selections.map((pin) =>
+            eb.and([eb("skill_id", "=", pin.skillId), eb("revision", "=", pin.revision)]),
+          ),
+        ),
+      ),
+  ).rows;
+  const metadata = new Map(
+    rows.map((row) => [
+      JSON.stringify([row.skill_id, row.revision]),
+      { description: row.description },
+    ]),
+  );
+  return selections.map((pin) => metadata.get(JSON.stringify([pin.skillId, pin.revision])));
 }
 
 export function selectSkillLibraryOwner(db: DatabaseSync, profileId: string) {


### PR DESCRIPTION
Related: #146197

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Rebuilding a session's selected skill snapshot performs one SQLite revision lookup per pinned skill. A session using the maximum 64 library skills repeats that query 64 times on an uncached load.

## Why This Change Was Made

The skill-library store resolves the exact skill/revision pairs in one bounded Kysely query, then restores the selection's original order and repeated pins. Snapshot loading keeps its existing cache, immutable artifact reads, and missing-revision errors. This is a read-only query change with no schema, persistence, or update migration changes.

## User Impact

Sessions with multiple pinned library skills spend less time rebuilding their skill snapshots while continuing to use the selected revisions after newer revisions are published or library access changes.

## Evidence

- A 64-pin fixture measured 64 uncached loads after 5 warmups on Windows with Node v26.8.2. Revision queries across all 69 loads fell from 4,416 to 69 (64 to 1 per load). Both versions returned 4,416 revision rows with identical full-result hashes. Median load time fell from 13.973 ms to 11.955 ms; p95 fell from 19.347 ms to 15.079 ms. Timing is local fixture evidence, not a cross-platform guarantee.
- The existing service fixture now checks bounded query execution, exact row count, selection order, repeated pins, mixed revisions of one skill, and missing pinned revisions. The process-persistence test preserves the original selected bytes across replacement, rename, removal, and process restart.
- Focused service and persistence tests on Ubuntu with Node v26.8.2 at exact PR head `397a8984b22e1ee75de3c7851c844c1307cccb33`: all 21 tests passed, including process interruption and recovery. The Windows run passed 17, skipped 2 POSIX tests, and reproduced 2 unchanged-baseline failures (revision-directory rename `EPERM` and ZIP executable-bit handling); both failing tests pass on Linux.
- Changed-file formatting, `git diff --check`, core production types, the owning services test type graph, core-test graph boundaries, and scoped lint pass. The Windows shard launcher rejects the checkout's encoded-space URL before starting the compiler; running that same services graph through the canonical `scripts/run-tsgo.mjs` wrapper passes without changing guards or source.
- Independent review of the final three-file diff completed scoped-clean through P2 with no findings.
- Same-base campaign guards passed for coercion, deprecated APIs, database-first storage, media helpers, runtime sidecars, import cycles, configuration docs, wrapper shadowing, native schema versions, webhook handling, and pairing ownership/scope. The production unused-export scan passed, but the script/full-tree scan reported two unchanged baseline exports (`canonicalProviderName` and `listPackagedStaticExtensionAssetOutputs`); the combined changed gate is not claimed as a full pass. Exact-head CI remains required before landing.
## Existing Stored Data Compatibility

No migration is required. The production diff only changes `loadSkillLibrarySelection` to batch its existing read and adds the store-owned metadata query. Schema definitions, storage versions, publication/update writers, transactions, serialized `SkillLibrarySelection` fields, and artifact paths are unchanged. The new `JSON.stringify([skillId, revision])` creates an in-memory Map key; it writes no serialized state.

A disposable Ubuntu proof used archived baseline source `2a1bc8be3db54e101d6a5c6d91081a80149db22d` to create a synthetic existing store, three skills, four revisions, and five serialized pins including mixed revisions and a duplicate. The exact PR head `397a8984b22e1ee75de3c7851c844c1307cccb33` consumed that same store and pin bytes without conversion. Its complete loader output matched the baseline byte-for-byte (SHA-256 `b7aade953e717f564dd07caffa2ac524a9f23f971cb0b785444cd6f91f9c5b5d`). Before and after loading, the full SQLite schema digest, `user_version=17`, `schema_version=221`, every table's row count and typed-value digest, serialized pin digest, and all four immutable artifact byte hashes were unchanged. The existing process-persistence suite additionally passes across replacement, rename, removal, restart, and interrupted publication. This evidence addresses the stored-data classifier's conservative flag on `selection.ts`; no data-model change or migration was introduced.
