### PR TITLE
improve: keep large streamed JSON previews responsive

### DIFF
--- a/packages/ai/src/utils/json-parse.test.ts
+++ b/packages/ai/src/utils/json-parse.test.ts
@@ -41,6 +41,21 @@ describe("json-parse repairJson invalid \\u escapes", () => {
     });
   });
 
+  it.each([
+    ["recent path after long text", `${"x".repeat(1024)} C:/root`, "\\nfile\\ttab"],
+    ["path at the lookbehind boundary", `C:/${"x".repeat(157)}`, "\\nfile\ttab"],
+    ["path outside the lookbehind boundary", `C:/${"x".repeat(158)}`, "\nfile\ttab"],
+    ["old path in long text", `C:/${"x".repeat(1024)}`, "\nfile\ttab"],
+  ] as const)("uses the recent prefix for %s", (_name, prefix, suffix) => {
+    const input = `{"content":"${prefix}\\nfile\\ttab"}`;
+    const expected = { content: `${prefix}${suffix}` };
+    expect(parseStreamingJson(input)).toEqual(expected);
+    expect(parseJsonWithRepair(input)).toEqual(expected);
+    expect(JSON.parse(repairJson(input, { preserveValidControlEscapes: true }))).toEqual({
+      content: `${prefix}\nfile\ttab`,
+    });
+  });
+
   it("recovers streaming tool-call arguments instead of dropping them to {}", () => {
     // LaTeX-style \u (\underline) is a valid string value the model may emit in args.
     const args = '{"cmd":"\\underline{x}"}';

--- a/packages/ai/src/utils/json-parse.ts
+++ b/packages/ai/src/utils/json-parse.ts
@@ -89,14 +89,14 @@ export function repairJson(
         continue;
       }
 
-      if (
-        !preserveValidControlEscapes &&
-        JSON_CONTROL_ESCAPES.has(nextChar) &&
-        looksLikeWindowsPathPrefix(stringValuePrefix)
-      ) {
-        repaired += "\\\\";
-        stringValuePrefix += "\\";
-        continue;
+      if (!preserveValidControlEscapes && JSON_CONTROL_ESCAPES.has(nextChar)) {
+        // Only this suffix can influence the Windows-path heuristic.
+        stringValuePrefix = stringValuePrefix.slice(-160);
+        if (looksLikeWindowsPathPrefix(stringValuePrefix)) {
+          repaired += "\\\\";
+          stringValuePrefix += "\\";
+          continue;
+        }
       }
 
       if (VALID_JSON_ESCAPES.has(nextChar)) {
@@ -123,8 +123,7 @@ export function parseJsonWithRepair(json: string): unknown {
 }
 
 function looksLikeWindowsPathPrefix(prefix: string): boolean {
-  const tail = prefix.slice(-160);
-  return /(?:^|[^A-Za-z0-9])[A-Za-z]:(?:[\\/][^"\\/:*?<>|\r\n]*)*$/.test(tail);
+  return /(?:^|[^A-Za-z0-9])[A-Za-z]:(?:[\\/][^"\\/:*?<>|\r\n]*)*$/.test(prefix);
 }
 
 /**


### PR DESCRIPTION
Related: #107693, #114925

## What Problem This Solves

Large streamed tool arguments containing repeated escaped newlines or tabs spend excessive time preparing JSON previews. The path-repair heuristic retains the entire preceding string value even though it only examines the last 160 characters.

## Why This Change Was Made

Retain that suffix at the existing heuristic checkpoint instead of repeatedly slicing an ever-growing prefix. The repair algorithm, Windows-path heuristic, partial JSON fallback, and authoritative terminal parsing keep their existing behavior.

## User Impact

Large streamed tool arguments can produce previews with less repeated string work. Final arguments and the distinction between preview repair and authoritative JSON escapes remain unchanged.

## Evidence

The benchmark uses the actual Anthropic stream reducer with synthetic events and 4,096-character fragments. Both Node 24 and Node 26 passed 3,400 repair-option cases and five complete small streaming fixtures before timing.

222 focused tests passed across JSON repair and Anthropic, Responses, and Chat Completions transport paths. Added semantic coverage protects recent versus stale Windows-path prefixes, including the exact 160-character lookbehind edge. All 22 paired timing cells passed complete final-result/error/event-count parity on Node 24.19.0 and Node 26.8.2. An additional three multi-fragment cases per runtime compare every emitted event snapshot, including preview checkpoints and final arguments.

Actual Anthropic stream reducer, median milliseconds before → after:

| Source content / workload | Node 24.19.0 | Node 26.8.2 |
| --- | ---: | ---: |
| 128 Ki characters, escaped code | 43.138 → 13.429 | 45.887 → 13.971 |
| 1 Mi characters, escaped code | 7,777.286 → 180.391 | 7,382.974 → 196.632 |
| 1 Mi characters, ASCII | 155.502 → 147.690 | 251.064 → 233.055 |
| 1 Mi characters, Unicode | 200.082 → 188.717 | 294.981 → 270.093 |
| 1 Mi characters, Windows paths | 106.983 → 104.802 | 182.687 → 181.363 |
| 1 Mi characters, literal Unicode escapes | 117.506 → 121.379 | 173.304 → 170.864 |

The large escaped fixture serializes to 1,184,553 UTF-16 code units. Each cell uses a complete warmup per variant and five alternating before/after rounds. Timings include argument assembly, preview repair, terminal parsing and emitted-event handling, with provider/network time excluded. GC was not forced during timing runs. Host: Windows 11, AMD Ryzen AI MAX+ 395, 16 cores/32 threads, 64 GiB RAM. Unrelated host load makes small differences less precise. Not every control improved: the Node 24 128 Ki-character path fixture measured 7.092 → 8.859 ms, and the large literal-Unicode-escape fixture was about 3% slower; the large path control did not repeat the smaller path regression.

Eight fresh processes, before/after/after/before per runtime, imported only the selected variant and ran one large escaped-code flow. Initial RSS was comparable within each runtime (about 115 MiB on Node 24 and 133 MiB on Node 26). Observed process peaks fell from 490–544 to 246 MiB on Node 24 and from 535–565 to 230–234 MiB on Node 26. All final-output hashes matched. These are peak-process observations for this fixture, not a claim about retained heap or all workloads.

Fresh independent P2 review completed cleanly against the final source. [Exact-head hosted CI passed](https://github.com/openclaw/openclaw/actions/runs/34707890196). Native maintainer gates remain required before landing.

This is a bounded change to the current repair owner. The related PRs propose different parsing or recovery behavior; this change preserves the existing behavior and does not replace those proposals. No configuration, persistence, dependency, or provider protocol change is involved.
