### PR TITLE
improve(workboard): aggregate statistics without loading cards

### DIFF
--- a/extensions/workboard/src/persistence-types.ts
+++ b/extensions/workboard/src/persistence-types.ts
@@ -42,6 +42,15 @@ type WorkboardBoardCardAggregate = {
   updatedAt: number;
 };
 
+export type WorkboardCardStatsAggregate = {
+  status: WorkboardCard["status"];
+  agentId: string | undefined;
+  total: number;
+  archived: number;
+  updatedAt: number;
+  oldestReadyAt: number | undefined;
+};
+
 export type WorkboardOwnerClaimResult = "updated" | "conflict" | "owner_busy";
 
 export type WorkboardCardStore = WorkboardKeyedStore & {
@@ -60,4 +69,6 @@ export type WorkboardCardStore = WorkboardKeyedStore & {
     now: number,
   ): Promise<WorkboardOwnerClaimResult>;
   listBoardAggregates(): Promise<WorkboardBoardCardAggregate[]>;
+  listStatsAggregates(boardId?: string): Promise<WorkboardCardStatsAggregate[]>;
+  hasCards(boardId: string): Promise<boolean>;
 };

--- a/extensions/workboard/src/sqlite-store.ts
+++ b/extensions/workboard/src/sqlite-store.ts
@@ -36,6 +36,7 @@ import type {
   PersistedWorkboardCard,
   PersistedWorkboardNotificationSubscription,
   WorkboardCardStore,
+  WorkboardCardStatsAggregate,
   WorkboardKeyedStore,
   WorkboardOwnerClaimResult,
 } from "./persistence-types.js";
@@ -1359,6 +1360,68 @@ class WorkboardSqliteCardStore implements WorkboardCardStore {
       archived: requiredNumber(row, "archived"),
       updatedAt: requiredNumber(row, "updated_at"),
     }));
+  }
+
+  async listStatsAggregates(boardId?: string): Promise<WorkboardCardStatsAggregate[]> {
+    let query = getNodeSqliteKysely<WorkboardCardDatabase>(this.db)
+      .selectFrom("workboard_cards")
+      .select((eb) => [
+        "status",
+        "agent_id",
+        eb.fn.countAll<number>().as("total"),
+        eb.fn
+          .sum<number>(
+            eb
+              .case()
+              .when(eb.and([eb("archived_at", "is not", null), eb("archived_at", "!=", 0)]))
+              .then(1)
+              .else(0)
+              .end(),
+          )
+          .as("archived"),
+        eb.fn.max<number>("updated_at").as("updated_at"),
+        eb.fn
+          .min<number>(
+            eb
+              .case()
+              .when(
+                eb.and([
+                  eb("status", "=", "ready"),
+                  eb.or([eb("archived_at", "is", null), eb("archived_at", "=", 0)]),
+                ]),
+              )
+              .then(eb.ref("updated_at"))
+              .else(null)
+              .end(),
+          )
+          .as("oldest_ready_at"),
+      ])
+      .groupBy(["status", "agent_id"]);
+    if (boardId !== undefined) {
+      query = query.where("board_id", "=", boardId);
+    }
+    return Array.from(iterateSqliteQuerySync(this.db, query), (row) => ({
+      // SAFETY: insertCard persists the normalized WorkboardCard status unchanged.
+      status: requiredString(row, "status") as WorkboardCard["status"],
+      agentId: stringValue(row, "agent_id"),
+      total: requiredNumber(row, "total"),
+      archived: requiredNumber(row, "archived"),
+      updatedAt: requiredNumber(row, "updated_at"),
+      oldestReadyAt: numberValue(row, "oldest_ready_at"),
+    }));
+  }
+
+  async hasCards(boardId: string): Promise<boolean> {
+    return (
+      executeSqliteQueryTakeFirstSync(
+        this.db,
+        getNodeSqliteKysely<WorkboardCardDatabase>(this.db)
+          .selectFrom("workboard_cards")
+          .select("id")
+          .where("board_id", "=", boardId)
+          .limit(1),
+      ) !== undefined
+    );
   }
 }
 

--- a/extensions/workboard/src/store-core.ts
+++ b/extensions/workboard/src/store-core.ts
@@ -380,7 +380,7 @@ export class WorkboardCoreStore extends WorkboardStoreRuntime {
       if (boardId === "default") {
         throw new Error("default board cannot be deleted.");
       }
-      if ((await this.list({ boardId })).length > 0) {
+      if (await this.store.hasCards(boardId)) {
         throw new Error("board still has cards; archive it or move/delete the cards first.");
       }
       for (const entry of await this.subscriptionStore.entries()) {
@@ -393,28 +393,29 @@ export class WorkboardCoreStore extends WorkboardStoreRuntime {
   }
 
   async stats(input: WorkboardListOptions = {}, now = Date.now()): Promise<WorkboardStatsResult> {
-    const cards = await this.list(input);
-    const boardId = normalizeBoardId(input.boardId) ?? "all";
+    const boardId = normalizeBoardId(input.boardId);
+    const aggregates = await this.store.listStatsAggregates(boardId);
     const byStatus: Partial<Record<WorkboardStatus, number>> = {};
     const byAgent = Object.create(null) as Record<string, number>;
     let oldestReadyAt: number | undefined;
     let updatedAt: number | undefined;
     let archived = 0;
-    for (const card of cards) {
-      byStatus[card.status] = (byStatus[card.status] ?? 0) + 1;
-      byAgent[card.agentId ?? "(default)"] = (byAgent[card.agentId ?? "(default)"] ?? 0) + 1;
-      if (card.metadata?.archivedAt) {
-        archived += 1;
+    let total = 0;
+    for (const aggregate of aggregates) {
+      byStatus[aggregate.status] = (byStatus[aggregate.status] ?? 0) + aggregate.total;
+      const agentId = aggregate.agentId ?? "(default)";
+      byAgent[agentId] = (byAgent[agentId] ?? 0) + aggregate.total;
+      total += aggregate.total;
+      archived += aggregate.archived;
+      if (aggregate.oldestReadyAt !== undefined) {
+        oldestReadyAt = Math.min(oldestReadyAt ?? aggregate.oldestReadyAt, aggregate.oldestReadyAt);
       }
-      if (card.status === "ready" && !card.metadata?.archivedAt) {
-        oldestReadyAt = Math.min(oldestReadyAt ?? card.updatedAt, card.updatedAt);
-      }
-      updatedAt = Math.max(updatedAt ?? 0, card.updatedAt);
+      updatedAt = Math.max(updatedAt ?? 0, aggregate.updatedAt);
     }
     return {
-      id: boardId,
-      total: cards.length,
-      active: cards.length - archived,
+      id: boardId ?? "all",
+      total,
+      active: total - archived,
       archived,
       byStatus,
       byAgent,

--- a/extensions/workboard/src/store-runtime.ts
+++ b/extensions/workboard/src/store-runtime.ts
@@ -117,6 +117,8 @@ export class WorkboardStoreRuntime {
           return result;
         }),
       listBoardAggregates: () => this.runOperation(() => store.listBoardAggregates()),
+      listStatsAggregates: (boardId) => this.runOperation(() => store.listStatsAggregates(boardId)),
+      hasCards: (boardId) => this.runOperation(() => store.hasCards(boardId)),
     };
   }
 

--- a/extensions/workboard/src/store.test.ts
+++ b/extensions/workboard/src/store.test.ts
@@ -126,6 +126,8 @@ function createPausedCardStore(delegate: WorkboardCardStore) {
       async listBoardAggregates() {
         return await delegate.listBoardAggregates();
       },
+      listStatsAggregates: (boardId) => delegate.listStatsAggregates(boardId),
+      hasCards: (boardId) => delegate.hasCards(boardId),
     } satisfies WorkboardCardStore,
     pauseNextWrite() {
       const reached = createSignal();
@@ -3465,6 +3467,14 @@ describe("WorkboardStore", () => {
 
   it("scopes idempotent creates and stats by board", async () => {
     const store = createWorkboardSqliteTestStore();
+    await expect(store.stats()).resolves.toEqual({
+      id: "all",
+      total: 0,
+      active: 0,
+      archived: 0,
+      byStatus: {},
+      byAgent: {},
+    });
     const ops = await store.create({
       title: "Ops work",
       boardId: "ops",
@@ -3506,6 +3516,17 @@ describe("WorkboardStore", () => {
     expect(secondProduct.position).toBe(2000);
     const stats = await store.stats({ boardId: "product" });
     expect(stats.byAgent[prototypeAgentId]).toBe(1);
+    expect(stats.byAgent["(default)"]).toBe(1);
+    await expect(store.stats({ boardId: " PRODUCT " })).resolves.toEqual(stats);
+    await expect(store.stats({ boardId: "bad/id" })).rejects.toThrow("board id must match");
+    await expect(store.stats({ boardId: "missing" })).resolves.toEqual({
+      id: "missing",
+      total: 0,
+      active: 0,
+      archived: 0,
+      byStatus: {},
+      byAgent: {},
+    });
     const metadataBoardFirst = await store.create({
       title: "Metadata board first",
       metadata: { automation: { boardId: "metadata-board" } },
@@ -3516,13 +3537,31 @@ describe("WorkboardStore", () => {
     });
     expect(metadataBoardFirst.position).toBe(1000);
     expect(metadataBoardSecond.position).toBe(2000);
+    const defaultCard = await store.create({ title: "Default board" });
+    await expect(store.stats({ boardId: "default" })).resolves.toMatchObject({
+      id: "default",
+      total: 1,
+      byStatus: { todo: 1 },
+      byAgent: { "(default)": 1 },
+      updatedAt: defaultCard.updatedAt,
+    });
+    await expect(store.stats({ boardId: "metadata-board" })).resolves.toMatchObject({ total: 2 });
+    await expect(store.stats()).resolves.toMatchObject({
+      id: "all",
+      total: 6,
+      active: 6,
+      archived: 0,
+      byStatus: { todo: 6 },
+      byAgent: { "(default)": 5, [prototypeAgentId]: 1 },
+    });
+    await expect(store.stats({ boardId: " " })).resolves.toEqual(await store.stats());
   });
 
   it("excludes archived ready cards from active queue-age statistics", async () => {
     vi.useFakeTimers();
     try {
       vi.setSystemTime(1_000);
-      const store = createWorkboardSqliteTestStore();
+      const { store, stores } = createWorkboardSqliteTestHarness();
       const oldReady = await store.create({
         title: "Archived ready work",
         boardId: "ops",
@@ -3553,6 +3592,32 @@ describe("WorkboardStore", () => {
         archived: 1,
         byStatus: { ready: 2 },
         oldestReadyAgeMs: 2_000,
+        updatedAt: 3_000,
+      });
+      await expect(store.stats({ boardId: "ops" }, 1_000)).resolves.toMatchObject({
+        oldestReadyAgeMs: 0,
+      });
+      const epochReady = await store.create({
+        title: "Epoch ready",
+        boardId: "epoch",
+        status: "ready",
+      });
+      await stores.cards.register(epochReady.id, {
+        version: 1,
+        card: {
+          ...epochReady,
+          agentId: "",
+          updatedAt: 0,
+          metadata: { ...epochReady.metadata, archivedAt: 0 },
+        },
+      });
+      await expect(store.stats({ boardId: "epoch" }, 5_000)).resolves.toEqual({
+        id: "epoch",
+        total: 1,
+        active: 1,
+        archived: 0,
+        byStatus: { ready: 1 },
+        byAgent: { "(default)": 1 },
       });
     } finally {
       vi.useRealTimers();
@@ -4319,6 +4384,16 @@ describe("WorkboardStore", () => {
       target: "session:operator",
       eventKinds: ["completed"],
     });
+
+    await expect(store.deleteBoard("default")).rejects.toThrow("default board cannot be deleted");
+    const card = await store.create({ title: "Still on board", boardId: "ops" });
+    await store.archive(card.id, true);
+    await expect(store.deleteBoard("ops")).rejects.toThrow("board still has cards");
+    await expect(store.listNotificationSubscriptions({ boardId: "ops" })).resolves.toMatchObject({
+      subscriptions: [expect.objectContaining({ boardId: "ops" })],
+    });
+    await store.delete(card.id);
+    await store.create({ title: "Other board card", boardId: "product" });
 
     await expect(store.deleteBoard("ops")).resolves.toEqual({ deleted: true });
     await expect(store.listNotificationSubscriptions({ boardId: "ops" })).resolves.toEqual({

--- a/extensions/workboard/src/test/sqlite-store.ts
+++ b/extensions/workboard/src/test/sqlite-store.ts
@@ -51,6 +51,8 @@ function withCardHooks(
     deleteIfUpdatedAt: (key, expectedUpdatedAt) => cards.deleteIfUpdatedAt(key, expectedUpdatedAt),
     entries: () => cards.entries(),
     listBoardAggregates: () => cards.listBoardAggregates(),
+    listStatsAggregates: (boardId) => cards.listStatsAggregates(boardId),
+    hasCards: (boardId) => cards.hasCards(boardId),
   };
 }
 


### PR DESCRIPTION
Closes #146210

## What Problem This Solves

Workboard statistics and board-deletion checks become unnecessarily expensive as notes, comments, and card history grow. Even a request for one board currently loads every card and its child records before counting.

## Why This Change Was Made

The existing SQLite card store now supplies grouped counts, archive totals, and queue timestamps for statistics, and a bounded existence query for deletion. Board normalization, default-agent grouping, archive and timestamp edge cases, and deletion refusals retain their existing behavior. No schema, migration, configuration, transaction, or retention change is involved.

## User Impact

Large Workboards return statistics with substantially less synchronous database and JavaScript work. Empty-board checks no longer hydrate unrelated cards.

## Evidence

- Real SQLite proof through the registered `workboard.cards.stats` and board-deletion RPC handlers; all/default/scoped/normalized/missing boards matched the previous list-based implementation exactly. Default and occupied board deletion remained refused. This exercises the plugin handlers directly, without a network Gateway or operator state.
- Windows, Node 26.8.2; 5,000 synthetic cards, 20,000 child rows, about 78 MiB of note/comment payload; nine warm interleaved runs on the same database. Median all-board statistics: 454.48 → 47.43 ms (9.6×); single-board statistics: 462.97 → 9.32 ms (49.7×). The new queries returned 28 and 14 aggregate rows respectively. These are fixture measurements, not production latency claims.
- Existing SQLite tests extended for empty/default/all/missing/normalized boards, default/prototype-named agents, archive-zero and epoch-zero timestamps, future queue age, and archived-card deletion refusal with preserved subscriptions.
- Independent P0–P2 review: no actionable findings. The only subsequent source change adds the required explanation of the existing status-decoding type assertion.
- Broader Windows run: 177 passed, five failures in existing path expectations and SQLite cleanup cases. Their relevant paths are unchanged; exact-head hosted CI remains required.

- Fresh focused statistics, lifecycle, and batch-read run: 19 tests passed. The broader run also passed the extended occupied-board deletion/subscription test, and the registered-handler proof verified deletion refusals.
- Local changed-file checks passed through formatting, assertion safety, plugin boundaries, and patch guards. A stale local build lock prevented completing the local typecheck sequence. Exact-head hosted CI run 34707862443 passed, including production/test typechecks, lint, changed-extension tests, baseline ratchets, and the required `openclaw/ci-gate`.

- Linux/WSL, Node 26.8.2, exact published head: all 182 tests passed across store, tools, gateway, SQLite batch-read/policy, and lifecycle files (56.67 seconds). The five Windows path/cleanup failures did not recur.
- Existing-database compatibility: main at `50877be9476d` created and populated a database through its original Workboard store, then closed it. This PR reopened that same database and matched six original statistics results (all/default/scoped/normalized/missing/epoch), retained occupied-board deletion refusal, and left every persisted row, `sqlite_master` entry, `user_version`, and `schema_version` unchanged.

## Data-model review clarification

ClawSweeper's automatic detector flagged `persistence-types.ts` and `sqlite-store.ts` as possible stored-data changes. The diff only adds a private query-result type, two card-store methods, and their read queries. It changes no persisted field, table, index, serializer, version, migration, or write query. Its technical review also confirms that no schema or migration is introduced. The old-writer/new-reader proof above verifies compatibility directly; no data-model migration is required.
