### PR TITLE
test(agents): reuse fresh nonzero usage fixtures

### DIFF
--- a/src/agents/embedded-agent-runner/provider-prompt-state.test.ts
+++ b/src/agents/embedded-agent-runner/provider-prompt-state.test.ts
@@ -6,6 +6,7 @@ import {
   type Model,
 } from "openclaw/plugin-sdk/llm";
 import { describe, expect, it, vi } from "vitest";
+import { createZeroUsageFixture } from "../test-helpers/usage-fixtures.js";
 import {
   clearProviderPromptState,
   getProviderPromptState,
@@ -28,14 +29,7 @@ function createResultStream(stopReason: "error" | "stop") {
     api: model.api,
     provider: model.provider,
     model: model.id,
-    usage: {
-      input: 1,
-      output: 1,
-      cacheRead: 0,
-      cacheWrite: 0,
-      totalTokens: 2,
-      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-    },
+    usage: { ...createZeroUsageFixture(), input: 1, output: 1, totalTokens: 2 },
     stopReason,
     ...(stopReason === "error" ? { errorMessage: "context length exceeded" } : {}),
     timestamp: 1,
@@ -233,14 +227,7 @@ describe("provider prompt state", () => {
       api: model.api,
       provider: model.provider,
       model: model.id,
-      usage: {
-        input: 1,
-        output: 1,
-        cacheRead: 0,
-        cacheWrite: 0,
-        totalTokens: 2,
-        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-      },
+      usage: { ...createZeroUsageFixture(), input: 1, output: 1, totalTokens: 2 },
       stopReason: "error",
       errorMessage: "connection dropped after dispatch",
       timestamp: 1,
@@ -304,14 +291,7 @@ describe("provider prompt state", () => {
       api: model.api,
       provider: model.provider,
       model: model.id,
-      usage: {
-        input: 1,
-        output: 1,
-        cacheRead: 0,
-        cacheWrite: 0,
-        totalTokens: 2,
-        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-      },
+      usage: { ...createZeroUsageFixture(), input: 1, output: 1, totalTokens: 2 },
       stopReason: "stop",
       timestamp: 1,
     });

--- a/src/agents/embedded-agent-runner/run.overflow-context-recovery.test.ts
+++ b/src/agents/embedded-agent-runner/run.overflow-context-recovery.test.ts
@@ -6,6 +6,7 @@ import type { AssistantMessage } from "../../llm/types.js";
 import { buildAssistantFailoverSignal } from "../embedded-agent-helpers/assistant-message-failures.js";
 import { classifyFailoverSignal } from "../failover/classify.js";
 import { SessionManager } from "../sessions/session-manager.js";
+import { createZeroUsageFixture } from "../test-helpers/usage-fixtures.js";
 import { makeAttemptResult } from "./run.overflow-compaction.fixture.js";
 import { createEmbeddedRunContextRecoveryState } from "./run/context-recovery-state.js";
 import { recoverEmbeddedRunOverflow } from "./run/overflow-context-recovery.js";
@@ -96,14 +97,7 @@ function makeAssistantMessage(
     api: "openai-responses",
     provider: "openai",
     model: "gpt-5.6-luna",
-    usage: input.usage ?? {
-      input: 1,
-      output: 0,
-      cacheRead: 0,
-      cacheWrite: 0,
-      totalTokens: 1,
-      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-    },
+    usage: input.usage ?? { ...createZeroUsageFixture(), input: 1, totalTokens: 1 },
     stopReason: input.stopReason,
     errorMessage: input.errorMessage,
     timestamp: 1,
@@ -347,14 +341,7 @@ describe("recoverEmbeddedRunOverflow", () => {
   it("recovers a canonical zero-output length overflow", async () => {
     const assistantOverflowCandidate = makeAssistantMessage({
       stopReason: "length",
-      usage: {
-        input: 199_000,
-        output: 0,
-        cacheRead: 0,
-        cacheWrite: 0,
-        totalTokens: 199_000,
-        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-      },
+      usage: { ...createZeroUsageFixture(), input: 199_000, totalTokens: 199_000 },
     });
     const result = await recoverEmbeddedRunOverflow(
       makeInput({ promptError: null, assistantOverflowCandidate }),


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

Five embedded-runner test inputs repeat complete token-usage and cost records even though an existing fixture already supplies their unchanged zero-valued fields.

## Why This Change Was Made

Reuse the existing fresh usage factory and keep each nonzero input, output, and total explicit. This preserves field order and a newly allocated nested cost object for each input. The optional usage fallback remains inside the nullish branch, preserving supplied usage identity and avoiding eager allocation. No assertions, production code, helper implementation, or expected outputs change.

## User Impact

No production behavior changes. The focused batch removes 33 net test lines across two files, including the imports. It preserves the 199,000-token zero-output overflow fixture and its recovery assertions; no usage totals are computed from other fixture values.

## Evidence

All 45 cases passed before and after across provider-prompt-state.test.ts, run.overflow-context-recovery.test.ts, and the adjacent run/overflow-context-recovery.test.ts ownership test, with identical ordered file/case names and statuses. Exact whole-file inversion recovers both original files. Static inspection of the existing factory and literal composition confirms property order, values, explicit totals, nested freshness, and lazy fallback semantics.

The complete mapped changed gate and fresh independent review passed. This is fixture consolidation; no runtime-performance improvement is claimed.


CI investigation: attempt 1 encountered an unrelated Linux CLI process timeout in the rejected-update-arguments case after the expected error and JSON were emitted. The exact CI merge source passed all 18 original-order cases locally on Node 24.19.0/macOS, but that diagnostic does not reproduce or explain the Linux failure. The single investigated failed-jobs replay of the same run and unchanged head completed successfully, retaining the original Linux shard order and environment. This success does not establish a fix for the original CLI timeout. No timeout, assertion, or production change was made; the first-attempt logs are preserved.

