### PR TITLE
improve: skip integer scanning for ordinary tool arguments

### DIFF
--- a/packages/ai/src/transports/json-unsafe-integers.ts
+++ b/packages/ai/src/transports/json-unsafe-integers.ts
@@ -78,6 +78,9 @@ function isUnsafeIntegerLiteral(token: string): boolean {
 
 /** Quotes integer literals above Number.MAX_SAFE_INTEGER before JSON.parse. */
 export function quoteUnsafeIntegerLiterals(input: string): string {
+  if (!/(?:^|\D)\d{16}/.test(input)) {
+    return input;
+  }
   let out = "";
   let inString = false;
   let escaped = false;

--- a/packages/ai/src/transports/transport-stream-shared.test.ts
+++ b/packages/ai/src/transports/transport-stream-shared.test.ts
@@ -18,10 +18,19 @@ function captureError(run: () => unknown): Error & { errorCode?: string; errorBo
 }
 
 describe("parseTerminalToolCallArguments", () => {
-  it("preserves unsafe integer literals in complete object arguments", () => {
-    expect(parseTerminalToolCallArguments('{"target":9223372036854775807,"safe":42}')).toEqual({
+  it("preserves unsafe integer literals and surrounding argument values", () => {
+    expect(
+      parseTerminalToolCallArguments(
+        '{"target":9223372036854775807,"safe":42,"negative":-9223372036854775808,"fraction":9007199254740992.0,"exponent":1e20,"text":"literal 9223372036854775807 \\"quoted\\" 日本語😀","last":9007199254740992}',
+      ),
+    ).toEqual({
       target: "9223372036854775807",
       safe: 42,
+      negative: "-9223372036854775808",
+      fraction: 9007199254740992,
+      exponent: 1e20,
+      text: 'literal 9223372036854775807 "quoted" 日本語😀',
+      last: "9007199254740992",
     });
     expect(parseTerminalToolCallArguments({})).toEqual({});
   });


### PR DESCRIPTION
## What Problem This Solves

Large model-generated tool arguments pass through a character-by-character integer scanner even when they contain no integer that could exceed JavaScript's safe range. Reconstructing unchanged argument text adds work before terminal JSON parsing and during streamed argument assembly.

## Why This Change Was Made

Return the original input when a run-start regex finds no run of at least 16 ASCII digits. Every unsafe integer must contain such a run, starting at the beginning of the input or after a nondigit. Inputs with a possible unsafe integer continue through the existing scanner unchanged, preserving its handling of strings, escapes, fractions, exponents, and malformed input.

Starting the regex at digit-run boundaries also avoids repeatedly testing overlapping suffixes of 15-digit runs.

## User Impact

Large text arguments parse faster while retaining exact unsafe integer values and existing terminal validation and repair behavior. There are no config, persistence, protocol, or public API changes.

## Evidence

- 224 focused tests passed across terminal argument parsing, Responses, Chat Completions, continuation, and Anthropic transport on the final candidate.
- On Node 24.19.0 and Node 26.8.2, the immutable before/after comparison passed 1,275 lexical and strict/repair cases plus 15 actual Anthropic event, final-result, and error cases per process.
- Formatting and `git diff --check` passed. Fresh independent review found no actionable P0-P2 issues on the entire final diff; [exact-head hosted CI passed](https://github.com/openclaw/openclaw/actions/runs/34708064580).

Median milliseconds per operation, original to candidate:

| Fixture target and operation | Node 24 | Node 26 |
| --- | ---: | ---: |
| 1,048,576-character ASCII terminal arguments | 41.25 to 0.982 | 40.55 to 0.724 |
| 1,048,576-character Unicode terminal arguments | 41.89 to 1.553 | 59.14 to 0.831 |
| 1,048,576-character escaped-code terminal arguments | 40.12 to 2.040 | 53.99 to 1.713 |
| 131,072-character text containing 15-digit runs, terminal | 3.357 to 0.624 | 3.071 to 0.555 |
| 131,072-character text containing 15-digit runs, actual stream reducer | 20.14 to 13.11 | 19.51 to 11.91 |
| 131,072-character dense unsafe integers, terminal | 2.843 to 1.252 | 2.377 to 1.548 |
| 131,072-character dense unsafe integers, actual stream reducer | 16.33 to 15.17 | 15.50 to 12.99 |
| 131,072-character ASCII, actual stream reducer | 18.38 to 10.54 | 17.10 to 10.76 |

All 38 timing cells had a lower candidate median than the original, including 1,024-character controls, quoted long digits, one unsafe integer, and dense integer arrays. The dense fallback still uses the same scanner body; these measurements do not establish why its observed timing changed.

The source harness invokes terminal argument parsing and the actual Anthropic stream reducer with synthetic events and 4,096-character argument fragments. Each cell uses six warmups per variant, nine rotating/reversed rounds, shared batch sizes, and GC outside timed batches. Sizes describe fixture targets in UTF-16 code units; exact serialized argument lengths are recorded separately. Timings exclude source imports and provider/network latency. The Windows 11 host (AMD Ryzen AI MAX+ 395, 16 cores/32 threads, 64 GiB RAM) had unrelated workload, so these are paired synthetic operation measurements rather than a production latency guarantee. Small process-CPU samples reached the Windows timer resolution; the table uses wall-clock medians. No fresh-process RSS or retained-heap improvement is claimed for this candidate.

Measured scanner SHA-256: `a13f1a6b19f4057ac4e9a6314202e5bfc4ee43c11e64824a08b20cc2b2fdcbef`.
