### PR TITLE
improve(markdown): prepare long newline-chunked replies faster

### DIFF
--- a/packages/markdown-core/src/chunk-text.ts
+++ b/packages/markdown-core/src/chunk-text.ts
@@ -73,9 +73,9 @@ function findPreferredRangeEnd(text: string, start: number, end: number): number
     return paragraphEnd;
   }
 
-  const newlineIndex = text.lastIndexOf("\n", end - 1);
-  if (newlineIndex >= start) {
-    return newlineIndex + 1;
+  const newlineIndex = slice.lastIndexOf("\n");
+  if (newlineIndex >= 0) {
+    return start + newlineIndex + 1;
   }
 
   for (let index = end - 1; index > start; index -= 1) {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where splitting a long paragraph with newline-preferred chunking takes progressively more CPU as the message grows. This affects the public text-chunking helper and Zalouser sends configured for newline chunking.

## Why This Change Was Made

Search the current chunk's existing text slice for its last newline. The previous search repeatedly scanned the entire preceding message when the current window contained no newline. Paragraph, newline, whitespace, and Unicode boundary selection stay identical.

## User Impact

Long paragraphs prepare for delivery faster. This is a local chunk-preparation improvement; network delivery time is not measured.

## Evidence

- Differential comparison: 40,000 generated cases preserve exact ranges and reconstruct the original text, including whitespace, astral characters, unmatched surrogates, fractional limits, non-positive limits, and hard/preferred modes.
- Node 26.8.2 on Windows, frozen main `2a1bc8be3db`, three warmups and three ABBA cycles, six samples per variant. A 2,000-character limit matches Zalouser's default. Median per-call preparation times for paragraphs without newlines: 16,000 characters 0.0302 → 0.0145 ms; 128,000 characters 1.526 → 0.126 ms; 512,000 characters 22.478 → 0.565 ms. Large fixtures measure scaling, not typical message size.
- Newline-rich, paragraph-separated, and hard-split controls show overlapping timing samples on this shared host. No overall Gateway latency claim.
- All 33 existing tests passed across Markdown Core, the public text-chunking SDK, and Zalouser send behavior. The repository worker build also passed. Formatting and git diff checks passed. Independent review through P2 found no actionable issues. Production and core-test typechecks and preceding structural checks passed. The full changed-check command stopped at two unused exports in untouched scripts (`canonicalProviderName` and `listPackagedStaticExtensionAssetOutputs`); a clean-baseline rerun reproduced both. The remaining targeted type-aware lint and all selected guards passed separately. Exact-head [CI34707941957](https://github.com/openclaw/openclaw/actions/runs/34707941957) and the required gate passed. Native preparation and merge completed on the unchanged reviewed head.

This uses a main-repository branch. GitHub's fork-collaboration setting does not apply.


