### PR TITLE
improve(trajectory): trim capture windows without fetching event bodies

### DIFF
--- a/src/trajectory/runtime-store.sqlite.test.ts
+++ b/src/trajectory/runtime-store.sqlite.test.ts
@@ -2,6 +2,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { replaceSessionEntry } from "../config/sessions/session-accessor.js";
 import { executeSqliteQuerySync, getNodeSqliteKysely } from "../infra/kysely-sync.js";
@@ -121,7 +122,7 @@ describe("SQLite trajectory runtime store", () => {
     expect(events.map((event) => event.type)).toEqual(["event-3", "event-4"]);
   });
 
-  it("stops reading old event bodies once the retained byte window is full", async () => {
+  it("trims the retained byte window without fetching UTF-8 event bodies", async () => {
     const history = Array.from({ length: 64 }, (_, index) =>
       createTrajectoryEvent({ type: `old-${index}`, payloadSize: 64 * 1024 }),
     );
@@ -153,7 +154,7 @@ describe("SQLite trajectory runtime store", () => {
       appendSqliteTrajectoryRuntimeEvents({ maxRuntimeBytes, sessionId: "session-1", storePath }, [
         newest,
       ]);
-      expect(materializedEvents).toBeLessThanOrEqual(retained.length + 1);
+      expect(materializedEvents).toBe(0);
     } finally {
       prepareSpy.mockRestore();
     }
@@ -162,26 +163,48 @@ describe("SQLite trajectory runtime store", () => {
     ).resolves.toEqual(retained);
   });
 
-  it.each([0, -1])("keeps the exact UTF-8 byte window with a %i-byte adjustment", async (delta) => {
-    const events = ["old", "middle", "newest"].map((type) => {
-      const event = createTrajectoryEvent({ type });
-      event.data = { payload: "日本語🦞".repeat(20) };
-      return event;
-    });
-    const maxRuntimeBytes = events
-      .slice(-2)
-      .reduce(
-        (bytes, event) => bytes + Buffer.byteLength(JSON.stringify(event), "utf8") + 1,
-        delta,
+  it.each(
+    ["UTF-8", "UTF-16le", "UTF-16be"].flatMap((encoding) =>
+      [0, -1].map((delta) => ({ encoding, delta })),
+    ),
+  )(
+    "keeps the UTF-8 byte window in $encoding with a $delta-byte adjustment",
+    async ({ encoding, delta }) => {
+      if (encoding !== "UTF-8") {
+        storePath = path.join(tempDir, `${encoding}.sqlite`);
+        const seed = new DatabaseSync(storePath);
+        try {
+          seed.exec(
+            `PRAGMA encoding = '${encoding}'; CREATE TABLE encoding_seed (id INTEGER); DROP TABLE encoding_seed;`,
+          );
+        } finally {
+          seed.close();
+        }
+        await replaceSessionEntry(
+          { sessionKey: "agent:main:main", storePath },
+          { sessionId: "session-1", updatedAt: 10 },
+        );
+      }
+      const events = ["old", "middle", "newest"].map((type) => {
+        const event = createTrajectoryEvent({ type });
+        event.data = { payload: "日本語🦞".repeat(20) };
+        return event;
+      });
+      const maxRuntimeBytes = events
+        .slice(-2)
+        .reduce(
+          (bytes, event) => bytes + Buffer.byteLength(JSON.stringify(event), "utf8") + 1,
+          delta,
+        );
+      appendSqliteTrajectoryRuntimeEvents(
+        { maxRuntimeBytes, sessionId: "session-1", storePath },
+        events,
       );
-    appendSqliteTrajectoryRuntimeEvents(
-      { maxRuntimeBytes, sessionId: "session-1", storePath },
-      events,
-    );
-    await expect(
-      loadSqliteTrajectoryRuntimeEvents({ sessionId: "session-1", storePath }),
-    ).resolves.toEqual(events.slice(delta === 0 ? -2 : -1));
-  });
+      await expect(
+        loadSqliteTrajectoryRuntimeEvents({ sessionId: "session-1", storePath }),
+      ).resolves.toEqual(events.slice(delta === 0 ? -2 : -1));
+    },
+  );
 
   it("loads a bounded trailing window in storage order", () => {
     appendSqliteTrajectoryRuntimeEvents({ sessionId: "session-1", storePath }, [

--- a/src/trajectory/runtime-store.sqlite.ts
+++ b/src/trajectory/runtime-store.sqlite.ts
@@ -24,7 +24,7 @@ import type { TrajectoryEvent } from "./types.js";
 type SqliteTrajectoryRuntimeDatabase = Pick<
   OpenClawAgentKyselyDatabase,
   "trajectory_runtime_events"
->;
+> & { pragma_encoding: { encoding: string } };
 
 const TRAJECTORY_RUNTIME_RETENTION_MAX_AGE_MS = 14 * 24 * 60 * 60 * 1_000;
 const TRAJECTORY_RUNTIME_GLOBAL_MAX_BYTES = 512 * 1024 * 1024;
@@ -299,7 +299,22 @@ function trimSqliteTrajectoryRuntimeWindow(
     database.db,
     db
       .selectFrom("trajectory_runtime_events")
-      .select(["seq", "event_json"])
+      .select("seq")
+      .select((eb) => {
+        // octet_length reads stored byte sizes without loading overflow pages. Only
+        // UTF-8 stores match the capture budget; preserve text decoding for UTF-16.
+        const utf8 = eb(eb.selectFrom("pragma_encoding").select("encoding"), "=", "UTF-8");
+        return [
+          eb
+            .case()
+            .when(utf8)
+            .then(eb.fn<number>("octet_length", ["event_json"]))
+            .else(0)
+            .end()
+            .as("event_bytes"),
+          eb.case().when(utf8).then(null).else(eb.ref("event_json")).end().as("event_json"),
+        ];
+      })
       .where("session_id", "=", sessionId)
       .orderBy("seq", "desc"),
   );
@@ -308,7 +323,10 @@ function trimSqliteTrajectoryRuntimeWindow(
   // Retention removes an oldest prefix. Stop once the newest suffix fills the
   // UTF-8 byte budget, then close the iterator before deleting that prefix.
   for (const row of rows) {
-    retainedBytes += Buffer.byteLength(row.event_json, "utf8") + 1;
+    retainedBytes +=
+      (row.event_json === null
+        ? sqliteNumber(row.event_bytes)
+        : Buffer.byteLength(row.event_json, "utf8")) + 1;
     if (!(retainedBytes <= maxRuntimeBytes)) {
       removeThroughSeq = row.seq;
       break;


### PR DESCRIPTION
Related: #146197

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

Appending trajectory events repeatedly copies retained event bodies out of SQLite just to measure their size. Large payloads make each append spend unnecessary time enforcing the session capture budget.

## Why This Change Was Made

For UTF-8 databases, SQLite now returns stored byte lengths while the existing streamed suffix scan determines the retained window. UTF-16 databases retain the original decoded UTF-8 measurement. Inclusive boundaries, newline accounting, deletion order, transaction ownership, schema and retention policy remain unchanged.

## User Impact

Trajectory capture allocates less memory and finishes faster for large retained payloads. Existing databases need no migration.

## Evidence

- All 20 trajectory runtime-store tests pass, including exact and one-byte-under boundaries with Japanese text and emoji in UTF-8, UTF-16le and UTF-16be databases. The allocation regression fails on original production code (4 fetched event bodies versus the required zero), then passes on the candidate.
- Core production and owning test types, scoped lint, formatting, graph boundaries, config docs, native schema versions, wrapper-shadowing and auth guards pass. The Windows batch test-type launcher rejects the checkout's encoded-space URL before compilation; the same owning graph passes through the canonical direct compiler wrapper.
- The public append benchmark used synthetic file-backed stores, 64 retained large events, five warmups and 25 measured appends. Three alternating before/after rounds produced identical final event hashes in every fixture. The table shows the median of each round's median; host activity varied during measurement.

| Event payload | JSON bytes fetched per trim before → after | Median append ms before → after |
| --- | --- | --- |
| 4 KiB | 284,224 → 0 | 2.650 → 3.047 |
| 64 KiB | 4,216,384 → 0 | 8.576 → 2.654 |
| 256 KiB | 16,799,296 → 0 | 25.021 → 2.882 |

The scan count stays one. The small fixture demonstrates no latency gain; 64–256 KiB payloads improve about 69–88% in these warm synthetic runs. Production latency was not measured.

- Same-base campaign source guards passed. The script/full-tree unused-export scan reports two unchanged base exports (`canonicalProviderName` and `listPackagedStaticExtensionAssetOutputs`), so the combined changed gate is not claimed as fully passing. Exact-head CI remains required.
- Fresh independent P0–P2 review of the final diff completed scoped-clean with no findings, including the SQL encoding and byte-count contracts.

