### PR TITLE
improve(workboard): claim owners without loading unrelated card history

### DIFF
--- a/extensions/workboard/src/sqlite-store-batch-read.test.ts
+++ b/extensions/workboard/src/sqlite-store-batch-read.test.ts
@@ -206,11 +206,11 @@ describe("workboard sqlite batch card read", () => {
 
   it.each([
     { fault: "later JSON", expected: "owner_busy", revisionMatches: true, targetOnly: false },
-    { fault: "later integer", expected: "native-error", revisionMatches: true, targetOnly: false },
+    { fault: "later integer", expected: "owner_busy", revisionMatches: true, targetOnly: false },
     { fault: "later integer", expected: "conflict", revisionMatches: false, targetOnly: false },
     { fault: "target integer", expected: "native-error", revisionMatches: true, targetOnly: true },
   ] as const)(
-    "keeps claim precedence for $fault: $expected",
+    "checks the claim revision and target without decoding unrelated children ($fault: $expected)",
     async ({ fault, expected, revisionMatches, targetOnly }) => {
       await withStores(async (dbPath) => {
         const stores = createWorkboardSqliteStores({ dbPath });
@@ -258,6 +258,173 @@ describe("workboard sqlite batch card read", () => {
       });
     },
   );
+
+  it.each([
+    { name: "idle", status: "todo", expected: "updated" },
+    { name: "running", status: "running", expected: "owner_busy" },
+    { name: "another owner", status: "running", agentId: "other", expected: "updated" },
+    { name: "archived", status: "running", archivedAt: 1, expected: "updated" },
+    { name: "zero archive time", status: "running", archivedAt: 0, expected: "owner_busy" },
+    { name: "active review claim", status: "review", expiresAt: 1_000_001, expected: "owner_busy" },
+    { name: "completed claim", status: "done", expiresAt: 1_000_001, expected: "updated" },
+    { name: "running execution", status: "done", execution: true, expected: "owner_busy" },
+    { name: "expired review claim", status: "review", expiresAt: 1_000_000, expected: "updated" },
+    { name: "heartbeat grace", status: "running", expiresAt: 700_000, expected: "owner_busy" },
+    { name: "reclaimable claim", status: "running", expiresAt: 699_999, expected: "updated" },
+    {
+      name: "reclaimable execution",
+      status: "done",
+      execution: true,
+      expiresAt: 699_999,
+      expected: "updated",
+    },
+    {
+      name: "claim owner overrides assignment",
+      status: "running",
+      agentId: "other",
+      expiresAt: 1_000_001,
+      expected: "owner_busy",
+    },
+    {
+      name: "another claim owner",
+      status: "running",
+      claimOwner: "other",
+      expiresAt: 1_000_001,
+      expected: "updated",
+    },
+    {
+      name: "default owner",
+      status: "running",
+      agentId: "",
+      ownerId: "workboard-dispatcher",
+      expected: "owner_busy",
+    },
+    {
+      name: "invalid future expiry",
+      status: "review",
+      expiresAt: Number.MAX_VALUE,
+      expected: "updated",
+    },
+  ])("preserves owner capacity for $name", async (scenario) => {
+    await withStores(async (dbPath) => {
+      const stores = createWorkboardSqliteStores({ dbPath });
+      const occupied = fixtureCard(0);
+      const target = fixtureCard(2);
+      occupied.status = scenario.status as WorkboardCard["status"];
+      occupied.agentId = scenario.agentId ?? "slot-owner";
+      occupied.metadata = {
+        ...occupied.metadata,
+        archivedAt: scenario.archivedAt,
+        claim:
+          scenario.expiresAt === undefined
+            ? undefined
+            : {
+                ownerId: scenario.claimOwner ?? "slot-owner",
+                token: "synthetic-claim-token",
+                claimedAt: 1,
+                lastHeartbeatAt: 1,
+                expiresAt: scenario.expiresAt,
+              },
+      };
+      if (scenario.execution) {
+        occupied.execution = {
+          id: "occupied-execution",
+          kind: "agent-session",
+          mode: "autonomous",
+          status: "running",
+          startedAt: 1,
+          updatedAt: 1,
+        };
+      }
+      try {
+        await stores.cards.register(occupied.id, { version: 1, card: occupied });
+        await stores.cards.register(target.id, { version: 1, card: target });
+        const next = { ...target, updatedAt: target.updatedAt + 1 };
+        await expect(
+          stores.cards.claimIfOwnerAvailable(
+            target.id,
+            { version: 1, card: next },
+            target.updatedAt,
+            scenario.ownerId ?? "slot-owner",
+            1_000_000,
+          ),
+        ).resolves.toBe(scenario.expected);
+        await expect(stores.cards.lookup(target.id)).resolves.toEqual({
+          version: 1,
+          card: scenario.expected === "updated" ? next : target,
+        });
+      } finally {
+        stores.close();
+      }
+    });
+  });
+
+  it("claims an available owner without reading or replacing unrelated malformed children", async () => {
+    await withStores(async (dbPath) => {
+      const stores = createWorkboardSqliteStores({ dbPath });
+      const raw = new DatabaseSync(dbPath);
+      const target = fixtureCard(2);
+      try {
+        await stores.cards.register("card-0", { version: 1, card: fixtureCard(0) });
+        await stores.cards.register(target.id, { version: 1, card: target });
+        raw
+          .prepare("UPDATE workboard_card_events SET ordinal = ? WHERE card_id = 'card-0'")
+          .run(9007199254740993n);
+        const next = { ...target, updatedAt: target.updatedAt + 1 };
+        await expect(
+          stores.cards.claimIfOwnerAvailable(
+            target.id,
+            { version: 1, card: next },
+            target.updatedAt,
+            "slot-owner",
+            3000,
+          ),
+        ).resolves.toBe("updated");
+        await expect(stores.cards.lookup(target.id)).resolves.toEqual({ version: 1, card: next });
+        await expect(stores.cards.lookup("card-0")).rejects.toMatchObject({
+          code: "ERR_OUT_OF_RANGE",
+        });
+      } finally {
+        raw.close();
+        stores.close();
+      }
+    });
+  });
+
+  it("rolls back a claim when replacing its child records fails", async () => {
+    await withStores(async (dbPath) => {
+      const stores = createWorkboardSqliteStores({ dbPath });
+      const sibling = fixtureCard(0);
+      const target = fixtureCard(2);
+      try {
+        await stores.cards.register(sibling.id, { version: 1, card: sibling });
+        await stores.cards.register(target.id, { version: 1, card: target });
+        const next = {
+          ...target,
+          title: "Claimed",
+          updatedAt: target.updatedAt + 1,
+          labels: ["changed"],
+          metadata: { ...target.metadata, comments: sibling.metadata?.comments },
+        };
+        await expect(
+          stores.cards.claimIfOwnerAvailable(
+            target.id,
+            { version: 1, card: next },
+            target.updatedAt,
+            "slot-owner",
+            3000,
+          ),
+        ).rejects.toThrow("UNIQUE constraint failed");
+        await expect(stores.cards.lookup(target.id)).resolves.toEqual({ version: 1, card: target });
+        await expect(stores.cards.lookup(sibling.id)).resolves.toEqual({
+          version: 1,
+          card: sibling,
+        });
+      } finally {
+        stores.close();
+      }
+    });
+  });
 
   it("reads each keyed collection once while preserving rows, binary order, and attachment joins", async () => {
     await withStores(async (dbPath) => {

--- a/extensions/workboard/src/sqlite-store.ts
+++ b/extensions/workboard/src/sqlite-store.ts
@@ -1299,11 +1299,16 @@ class WorkboardSqliteCardStore implements WorkboardCardStore {
         );
       for (const row of iterateSqliteQuerySync(this.db, candidates)) {
         const card = {
+          // SAFETY: insertCard persists WorkboardCard.status; this keeps readCard's required-string boundary.
           status: requiredString(row, "status") as WorkboardCard["status"],
           agentId: stringValue(row, "agent_id"),
+          // SAFETY: insertCard serializes WorkboardMetadata.claim; this keeps readMetadata's optional JSON boundary.
           metadata: { claim: parseJson(row.claim_json) as WorkboardMetadata["claim"] },
           execution: stringValue(row, "execution_id")
-            ? { status: requiredString(row, "execution_status") as WorkboardExecution["status"] }
+            ? {
+                // SAFETY: insertCard persists WorkboardExecution.status; this keeps readExecution's required-string boundary.
+                status: requiredString(row, "execution_status") as WorkboardExecution["status"],
+              }
             : undefined,
         };
         if (workboardCardConsumesOwnerSlot(card, now) && workboardCardSlotOwner(card) === ownerId) {

--- a/extensions/workboard/src/sqlite-store.ts
+++ b/extensions/workboard/src/sqlite-store.ts
@@ -1271,17 +1271,48 @@ class WorkboardSqliteCardStore implements WorkboardCardStore {
   ): Promise<WorkboardOwnerClaimResult> {
     this.validatePayload(key, value);
     return runSqliteImmediateTransactionSync(this.db, () => {
-      if (!this.matchesUpdatedAt(key, expectedUpdatedAt)) {
+      const query = getNodeSqliteKysely<WorkboardCardDatabase>(this.db);
+      const current = executeSqliteQueryTakeFirstSync(
+        this.db,
+        query
+          .selectFrom("workboard_cards")
+          .selectAll()
+          .where("id", "=", key)
+          .where("updated_at", "=", expectedUpdatedAt),
+      );
+      if (!current) {
         return "conflict";
       }
-      const rows: Row[] = this.db.prepare("SELECT * FROM workboard_cards WHERE id <> ?").all(key);
-      const preloaded = loadCardChildRows(this.db);
-      for (const row of rows) {
-        const card = readCard(this.db, row, preloaded);
+      // Child records cannot occupy an owner slot. Keep lease and owner decisions
+      // with the shared policy, after SQLite excludes archived and inactive cards.
+      const candidates = query
+        .selectFrom("workboard_cards")
+        .select(["status", "agent_id", "claim_json", "execution_id", "execution_status"])
+        .where("id", "!=", key)
+        .where((eb) => eb.or([eb("archived_at", "is", null), eb("archived_at", "=", 0)]))
+        .where((eb) =>
+          eb.or([
+            eb("status", "=", "running"),
+            eb.and([eb("execution_id", "!=", ""), eb("execution_status", "=", "running")]),
+            eb.and([eb("claim_json", "is not", null), eb("status", "!=", "done")]),
+          ]),
+        );
+      for (const row of iterateSqliteQuerySync(this.db, candidates)) {
+        const card = {
+          status: requiredString(row, "status") as WorkboardCard["status"],
+          agentId: stringValue(row, "agent_id"),
+          metadata: { claim: parseJson(row.claim_json) as WorkboardMetadata["claim"] },
+          execution: stringValue(row, "execution_id")
+            ? { status: requiredString(row, "execution_status") as WorkboardExecution["status"] }
+            : undefined,
+        };
         if (workboardCardConsumesOwnerSlot(card, now) && workboardCardSlotOwner(card) === ownerId) {
           return "owner_busy";
         }
       }
+      // Validate the target's stored tree before replacing it, without decoding
+      // unrelated cards as an incidental prerequisite for claiming this one.
+      readCard(this.db, current);
       insertCard(this.db, value.card);
       return "updated";
     });

--- a/extensions/workboard/src/store-constants.ts
+++ b/extensions/workboard/src/store-constants.ts
@@ -1,4 +1,9 @@
-import type { WorkboardCard, WorkboardClaim } from "@openclaw/workboard-contract";
+import type {
+  WorkboardCard,
+  WorkboardClaim,
+  WorkboardExecution,
+  WorkboardMetadata,
+} from "@openclaw/workboard-contract";
 import {
   isFutureDateTimestampMs,
   MAX_DATE_TIMESTAMP_MS,
@@ -33,7 +38,12 @@ export function isWorkboardClaimReclaimable(
   return Boolean(claim?.expiresAt && now - claim.expiresAt > CLAIM_RECLAIM_MS);
 }
 
-export function workboardCardConsumesOwnerSlot(card: WorkboardCard, now: number): boolean {
+type WorkboardOwnerSlotCard = Pick<WorkboardCard, "status" | "agentId"> & {
+  execution?: Pick<WorkboardExecution, "status">;
+  metadata?: Pick<WorkboardMetadata, "claim" | "archivedAt">;
+};
+
+export function workboardCardConsumesOwnerSlot(card: WorkboardOwnerSlotCard, now: number): boolean {
   const claim = card.metadata?.claim;
   const activeClaim = claim && isFutureDateTimestampMs(claim.expiresAt, { nowMs: now });
   return (
@@ -45,7 +55,7 @@ export function workboardCardConsumesOwnerSlot(card: WorkboardCard, now: number)
   );
 }
 
-export function workboardCardSlotOwner(card: WorkboardCard, now?: number): string {
+export function workboardCardSlotOwner(card: WorkboardOwnerSlotCard, now?: number): string {
   const claim = card.metadata?.claim;
   // Ready candidates pass now to ignore expired claims. Occupied slots omit it
   // so the claim owner keeps its slot through the heartbeat-reclaim grace period.


### PR DESCRIPTION
Related: #146197

## What Problem This Solves

Workboard owner claims decode every card and its child records while holding the SQLite write transaction. On a synthetic 2,000-card board, a busy-owner check fetched 32,000 rows and took a median 63.96 ms; an available-owner claim took 94.95 ms.

## Why This Change Was Made

SQLite now checks the target revision and filters out archived and inactive cards, returning only the five parent fields needed to evaluate an occupied owner slot. The existing shared owner policy still decides claim expiry, heartbeat grace, execution activity, claim-owner precedence, and default owners. The target's stored tree is validated before the existing atomic replacement runs.

This deliberately changes incidental error behavior: malformed child records on unrelated cards no longer prevent a valid claim or take precedence over an occupied-owner result. Claim-relevant parent fields still use the existing decoders and shared policy. Target validation, compare-and-set conflicts, rollback, schema, and transaction ownership remain intact; no migration is needed.

## User Impact

Starting Workboard work spends substantially less time reading unrelated history and holding the SQLite writer. Unrelated damaged child records no longer block an otherwise valid owner claim.

## Evidence

- Synthetic SQLite benchmark on Windows/Node 26.8.2, 2,000 cards with labels, events, comments, worker logs, and protocol records; five warmups followed by 15 measured samples per scenario.
- Busy owner: median 63.9571 → 0.1897 ms, p95 71.5678 → 0.6315 ms; statements 14 → 2 and fetched rows 32,000 → 2.
- Available owner: median 94.9497 → 2.5389 ms, p95 113.3660 → 3.2300 ms; statements remain 42 while fetched rows fall 32,000 → 17. These are local synthetic measurements, not a production latency guarantee.
- Focused batch-read suite: 29 tests passed. Added coverage exercises owner capacity, expiry and heartbeat-grace boundaries, archived and completed cards, running executions, claim-owner precedence, stale revisions, target corruption, unrelated malformed children, and rollback after a child-write constraint failure.
- Exact PR head `58bc6c93a7fd3d2e752c4c6c492859259e6e23b1`, Linux/Node 26.8.2: all 205 store, dispatcher, and batch-read tests passed in 53.31 seconds. The checkout remained clean and HEAD was unchanged before and after. The Windows run passed 199 tests with six baseline platform failures (five dispatcher path expectations and network-volume cleanup EPERM); those six pass on Linux. The original production code additionally fails the two regressions for unrelated malformed children, for the intended reason.
- Independent P2 autoreview: scoped-clean, no actionable findings, with final source verification. Extension production and test TypeScript lanes, scoped lint, formatting, and `git diff --check` pass. Lint used the canonical package artifacts prepared in this checkout; unchanged repository-wide guard results are reused from the Team Reports lane at the same base.

The follow-up CI correction documents the three existing typed persistence-decoder assumptions required by the assertion-safety ratchet. The guard and scoped lint now pass, and the emitted runtime AST is identical to the Linux-tested head above; it changes no runtime behavior.
- Existing-database compatibility at final head `9e976d5cec715f2c68f76604daeffcccdcdbcaeb`: the original `2a1bc8be` public store created a sealed synthetic database with 40 cards across 17 tables, including every card child collection, attachment BLOBs, board metadata, and notification subscription state. Opening independent copies with the original and candidate stores preserved the complete schema, version pragmas, migration rows, and typed table-row digests. The same busy, stale-revision, and available-owner claims returned `owner_busy`, `conflict`, and `updated`; complete public reads and every typed table-row digest matched after each operation. Busy/conflict attempts changed no rows, and the successful claim made identical expected writes. No migration was required. This valid-record compatibility proof is separate from the intentional unrelated-corrupt-child error change described above.
- Source comparison confirms `WORKBOARD_SCHEMA_SQL`, `SCHEMA_VERSION`, `insertCard`, serialization helpers, and full card/metadata/execution decoders are unchanged from the original base. The final follow-up only documents three existing typed persistence-boundary assertions; emitted runtime AST matches the 205-test head, and the assertion guard and scoped lint pass.
