### PR TITLE
fix(browser): include element refs in plain ARIA snapshots

### DIFF
--- a/extensions/browser/src/cli/browser-cli-inspect.test.ts
+++ b/extensions/browser/src/cli/browser-cli-inspect.test.ts
@@ -4,12 +4,15 @@ import fs from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { Command } from "commander";
+import { useAutoCleanupTempDirTracker } from "openclaw/plugin-sdk/test-env";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { createCliRuntimeCapture } from "../../test-support.js";
+import type { SnapshotResult } from "../browser/client.js";
 import * as browserCliSharedModule from "./browser-cli-shared.js";
 import * as cliCoreApiModule from "./core-api.js";
 
 const { defaultRuntime: runtime, resetRuntimeCapture } = createCliRuntimeCapture();
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 const configMocks = vi.hoisted(() => ({
   getRuntimeConfig: vi.fn(() => ({ browser: {} })),
@@ -17,7 +20,10 @@ const configMocks = vi.hoisted(() => ({
 
 const sharedMocks = vi.hoisted(() => ({
   callBrowserRequest: vi.fn(
-    async (_opts: unknown, params: { path?: string; query?: Record<string, unknown> }) => {
+    async (
+      _opts: unknown,
+      params: { path?: string; query?: Record<string, unknown> },
+    ): Promise<SnapshotResult> => {
       const format = params.query?.format === "aria" ? "aria" : "ai";
       if (format === "aria") {
         return {
@@ -100,6 +106,52 @@ describe("browser cli snapshot defaults", () => {
     restoreInspectSpies();
     resetRuntimeCapture();
     configMocks.getRuntimeConfig.mockReturnValue({ browser: {} });
+  });
+
+  it.each(
+    ["ax42", "7_3"].flatMap((ref) =>
+      (["plain", "json", "file"] as const).map((output) => ({ ref, output })),
+    ),
+  )("preserves the returned ARIA ref $ref in $output output", async ({ ref, output }) => {
+    const result: SnapshotResult = {
+      ok: true,
+      format: "aria",
+      targetId: "t1",
+      url: "https://example.com",
+      nodes: [{ ref, role: "textbox", name: "Entry", value: "Ready", depth: 2 }],
+    };
+    sharedMocks.callBrowserRequest.mockResolvedValueOnce(result);
+    const outputPath =
+      output === "file"
+        ? path.join(tempDirs.make("openclaw-aria-output-"), "snapshot.json")
+        : undefined;
+    await runBrowserInspect(
+      ["snapshot", "--format", "aria", ...(outputPath ? ["--out", outputPath] : [])],
+      output === "json",
+    );
+
+    if (outputPath) {
+      expect(JSON.parse(await fs.readFile(outputPath, "utf8"))).toEqual(result);
+      expect(runtime.log).toHaveBeenCalledExactlyOnceWith(outputPath);
+      expect(runtime.writeJson).not.toHaveBeenCalled();
+    } else if (output === "json") {
+      expect(runtime.writeJson).toHaveBeenCalledExactlyOnceWith(result);
+    } else {
+      expect(runtime.log).toHaveBeenCalledExactlyOnceWith(
+        `    - textbox "Entry" = "Ready" [ref=${ref}]`,
+      );
+      expect(runtime.writeJson).not.toHaveBeenCalled();
+    }
+    expect(runtime.error).not.toHaveBeenCalled();
+    expect(runtime.exit).not.toHaveBeenCalled();
+  });
+
+  it("preserves AI snapshot text while ARIA refs are rendered separately", async () => {
+    await runSnapshot([]);
+    expect(runtime.log).toHaveBeenCalledExactlyOnceWith("ok");
+    expect(runtime.writeJson).not.toHaveBeenCalled();
+    expect(runtime.error).not.toHaveBeenCalled();
+    expect(runtime.exit).not.toHaveBeenCalled();
   });
 
   it.each([

--- a/extensions/browser/src/cli/browser-cli-inspect.ts
+++ b/extensions/browser/src/cli/browser-cli-inspect.ts
@@ -242,7 +242,7 @@ export function registerBrowserInspectCommands(
               const indent = "  ".repeat(Math.min(20, n.depth));
               const name = n.name ? ` "${n.name}"` : "";
               const value = n.value ? ` = "${n.value}"` : "";
-              return `${indent}- ${n.role}${name}${value}`;
+              return `${indent}- ${n.role}${name}${value} [ref=${n.ref}]`;
             })
             .join("\n"),
         );


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators using `browser snapshot --format aria` could see an element's role and name but not its returned reference. They needed JSON output to obtain the identifier for a subsequent action.

## Why This Change Was Made

The plain-text renderer now appends each node's existing reference unchanged. Reference generation, action resolution, JSON/file output, and AI snapshots keep their existing owners and behavior. ARIA output remains inspection-only on backends that cannot bind references for actions.

Production: **+1/-1, net 0**. Tests: net +52. No new configuration, protocol, dependencies, or runtime state.

## User Impact

A returned reference is now visible alongside its node. For the synthetic button exercised by the real browser proof:

```text
Before: - button "Proof button"
After:  - button "Proof button" [ref=ax7]
```

## Evidence

The two intended parser regressions failed before the repair. All 42 parser, Chrome MCP, and Chromium owner/sibling tests pass afterward, as do changed checks and normal builds.

The paired built-CLI flow used an isolated managed Chrome profile and synthetic local page. The baseline omitted the plain-text reference while its JSON control could click the button. The candidate extracted `ax7` from plain stdout, clicked it through the registered CLI, and verified the page changed to “Clicked.” Each phase completed 13 commands with natural exit 0, no signals, complete output, and clean process/port teardown. Source/build/runtime seals were verified before and after each phase on pinned Node 24.20.0.

Independent source/evidence audits and managed P0–P2 review found no unresolved issues. This proves managed-browser behavior; Chrome MCP coverage is test-based, and no provider execution is claimed. An initial proof attempt used the shared default logfile; the accepted paired proof was repeated with a run-owned logfile. An intervening test-cache seal mismatch was retained and separately qualified before replay, without changing production or weakening the check.
