### PR TITLE
improve(markdown): reduce CPU work for streamed code replies

### DIFF
--- a/packages/markdown-core/src/reasoning-tags.ts
+++ b/packages/markdown-core/src/reasoning-tags.ts
@@ -463,9 +463,6 @@ export function createReasoningTagTextPartitioner(): ReasoningTagTextPartitioner
                   : 1),
             ) === -1);
         const completedBlankBlock = endedBlankBlock;
-        const retainedContainerContext = MARKDOWN_CONTAINER_LINE_RE.test(
-          source.slice(nonFinalRetainStart),
-        );
         const heldBacktick = heldBacktickStart !== undefined;
         let openingRunEnd = ownershipStart;
         while (source.charAt(openingRunEnd) === "`") {
@@ -487,8 +484,9 @@ export function createReasoningTagTextPartitioner(): ReasoningTagTextPartitioner
           nonFinalCodeSpansEnd === source.length ? nonFinalCodeSpans : undefined;
         const mayCloseTopLevelBlock =
           completedBlankBlock &&
-          (!retainedContainerContext || appendedStartsTopLevelBlock) &&
-          !nonFinalOpenEndedCode;
+          !nonFinalOpenEndedCode &&
+          (appendedStartsTopLevelBlock ||
+            !MARKDOWN_CONTAINER_LINE_RE.test(source.slice(nonFinalRetainStart)));
         if (
           (shouldTryParser || mayResolveHeldReasoning) &&
           !tableLookaheadPending &&


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where processing a long streamed fenced-code reply consumes progressively more CPU as small content deltas arrive. This affects the shared Markdown reasoning partitioner used by completions-style provider streams.

## Why This Change Was Made

Evaluate the existing retained-container predicate only when a completed blank block needs that decision. Previously, every held content delta scanned the entire retained text even when the result could not affect parsing. The predicate, parser rules, emitted boundaries, retained source, and strict-mode behavior stay identical; no new state or cache is added.

## User Impact

Long fenced-code replies require less local stream-processing work. This does not change when code ownership becomes stable or claim faster provider/network delivery.

## Evidence

- Actual incremental partitioner comparison on frozen main `2a1bc8be3db`, Node 26.8.2 on a shared Windows host. Includes partitioner creation, every `pushVisible` call and final `flush`; excludes module preparation, fixture generation and output assertions. One untimed parity run per variant precedes two ABBA cycles, four samples per variant. Samples are persisted individually.
- Cumulative median time for LF fenced code delivered in 32-character chunks: 16 KiB **15.18 → 11.55 ms**, 64 KiB **113.05 → 38.36 ms**, 128 KiB **400.17 → 83.68 ms**. At 64 KiB with 128-character chunks: **50.56 → 31.16 ms**. CRLF and CR fixtures also improve. These large fixtures measure scaling; no overall Gateway latency claim.
- All 29,869 stream/transition checks preserve exact per-push deltas, pending/strict-state behavior and code ownership. The 540 transition cells cover lists, quotes, nested containers, blank blocks, open/closed fences, tables, tags and strict-mode transitions across LF/CRLF/CR and five chunk widths.
- Plain prose is effectively unchanged (91.63 → 90.86 ms). Long inline code is 5.11 → 5.84 ms with overlapping samples; short-fence CPU samples are coarse and conflict with their wall-time improvement. No gain is claimed for those controls.
- All **202 existing tests** passed across the partitioner owner, actual completions stream and reasoning/buffering flows, shared static facade, and CLI reasoning flow. Formatting, diff checks and targeted type-aware lint passed. Independent review through P2 found no actionable issues. Exact-head [CI34708527844](https://github.com/openclaw/openclaw/actions/runs/34708527844) and the required gate passed, including build, production/test types and structural checks. Native preparation and merge completed on the unchanged reviewed head.

This uses a main-repository branch. GitHub's fork-collaboration setting does not apply.
