### PR TITLE
improve: rank CJK memory results faster

### DIFF
--- a/extensions/memory-core/src/memory/tokenize.ts
+++ b/extensions/memory-core/src/memory/tokenize.ts
@@ -34,26 +34,26 @@ export function tokenize(text: string): Set<string> {
     return new Set(ascii);
   }
 
-  // Track CJK characters with their original positions
-  const chars = Array.from(lower);
-  const cjkData: { char: string; index: number }[] = [];
-  for (const [i, char] of chars.entries()) {
+  const tokens = new Set(ascii);
+  const unigrams: string[] = [];
+  let previousCjk: string | undefined;
+  for (const char of lower) {
     if (CJK_RE.test(char)) {
-      cjkData.push({ char, index: i });
+      if (previousCjk !== undefined) {
+        tokens.add(previousCjk + char);
+      }
+      unigrams.push(char);
+      previousCjk = char;
+    } else {
+      previousCjk = undefined;
     }
   }
 
-  // Build bigrams only from originally adjacent CJK characters
-  const bigrams: string[] = [];
-  for (const [i, next] of cjkData.slice(1).entries()) {
-    const previous = cjkData[i];
-    if (previous !== undefined && next.index === previous.index + 1) {
-      bigrams.push(previous.char + next.char);
-    }
+  // Preserve insertion order: ASCII tokens, then bigrams, then unigrams.
+  for (const char of unigrams) {
+    tokens.add(char);
   }
-
-  const unigrams = cjkData.map((d) => d.char);
-  return new Set([...ascii, ...bigrams, ...unigrams]);
+  return tokens;
 }
 
 /**


### PR DESCRIPTION
## What Problem This Solves

Memory diversity ranking spends avoidable time preparing Chinese, Japanese, and Korean snippets. Dreaming deduplication shares the same tokenizer.

## Why This Change Was Made

CJK snippet tokenization materializes a code-point array, per-character/index records, a sliced record array, and separate bigram and unigram arrays before building the token set. Memory diversity ranking pays this cost for each result snippet; dreaming deduplication uses the same tokenizer through `textSimilarity`.

Scan code points once, add adjacent CJK bigrams directly to the token set, and append the collected unigrams afterward. Preserve the existing ASCII → bigram → unigram insertion order, CJK character ranges, non-CJK separator boundaries, and empty-token literal-equality fallback. The ASCII-only fast path is unchanged. This is a one-file implementation change with no configuration, storage, migration, or public API change.

## User Impact

CJK and mixed-language memory results rank faster in the measured cases, with identical tokens and final results. ASCII-only input keeps its existing fast path.

## Evidence

Actual `mergeHybridResults` calls, including importance weighting, temporal decay, and MMR enabled at lambda 0.7. Synthetic vector/keyword results; 200 total merged snippets of 700 characters:

| Runtime | Input | Before (seconds) | After (seconds) | Speedup |
| --- | --- | ---: | ---: | ---: |
| Node 24.19.0 | CJK | 0.038682 | 0.026997 | 1.43× |
| Node 26.8.2 | CJK | 0.038750 | 0.031396 | 1.23× |
| Node 24.19.0 | Mixed ASCII/CJK | 0.014444 | 0.010105 | 1.43× |
| Node 26.8.2 | Mixed ASCII/CJK | 0.012570 | 0.010870 | 1.16× |

Across 24/200 snippets and 280/700 characters, CJK/mixed cells improved 1.14–1.53×. Japanese, Korean, separated CJK, duplicate, and 16-cluster controls at 24/200 snippets × 700 characters improved 1.15–1.68×. All 44 timed cells preserved complete results, and result digests matched between runtimes.

ASCII controls were approximately neutral, with both positive and negative variation. The largest negative large-cell result was Node 24 at 200 × 280: 6.152 → 6.307 ms (+2.5%). The largest negative small-cell result was 0.208 → 0.221 ms (+13 microseconds). No claim that every workload improves.

Each cell used five warmup calls per variant, nine alternating before/after rounds, and explicit GC outside measured batches. Batches contained 20 calls at 24 snippets or five calls at 200 snippets. Timings exclude module imports, storage retrieval, and network access. Host: Windows 11, Ryzen AI MAX+ 395, 32 logical CPUs, about 64 GiB RAM; V8 13.6.233.17-node.51 / 14.6.202.34-node.28. Windows CPU accounting was too coarse for reliable small-cell CPU ratios. This measures ranking latency, not whole-search latency or complete dreaming throughput.

Eight fresh-process RSS runs used before/after/after/before order per runtime, importing only the selected variant and running 12 merges of 400 × 700-character CJK snippets. Peaks: Node 24 before 516.1–516.7 MiB, after 515.8–516.9 MiB; Node 26 before 456.4–456.7 MiB, after 445.2–458.7 MiB. Startup dominates these peaks and post-GC heap was essentially equal. No attributable RSS or retained-memory savings claim.

## Validation

- Node 24 and Node 26 each passed 131,098 exact token-order comparisons, 676 text-similarity comparisons, and 128 complete hybrid-result comparisons. Cases include all BMP code units, surrogate/combining separators, CJK/ASCII mixtures, disabled MMR, and lambda endpoints.
- Existing ordered-token, MMR, hybrid-ranking, and dreaming-phase tests passed: 104 tests across three files via `node scripts/run-vitest.mjs extensions/memory-core/src/memory/mmr.test.ts extensions/memory-core/src/memory/hybrid.test.ts extensions/memory-core/src/dreaming-phases.test.ts`. No duplicate tests were added. Fresh full-diff P2 autoreview completed scoped-clean with no findings (correctness confidence 0.99); source verification passed.
- Formatting and `git diff --check` pass. The changed-gate dry run selects extension production/test lanes. [Exact-head hosted CI passed](https://github.com/openclaw/openclaw/actions/runs/34708625144); native preparation remains required. No full local changed-gate pass is claimed.

Source identities: baseline tokenizer SHA-256 `799026d30e1b671a34b1558edf72c3d4a523006f560ae46701c0bda9dca590f2`; candidate `198fe873196189406a74d4fcc3decb9181906719186b15ba566dc1b02da6f78c`; verified benchmark harness `c1b33d6c0f733b4cf7669a901b1bc92d136c2c5e6e5f9b5f2c5f333c1fede330`. The baseline contains the landed MMR preparation change from #146120; this PR measures the additional tokenizer change separately.

## Data compatibility

This change does not modify a stored data model, vector metadata, embeddings, an index format, or a database schema. The only changed function returns a temporary `Set<string>` used by in-memory MMR ranking and dreaming snippet comparisons. Those consumers and all persistence code are unchanged. Existing stored snippets require no rewrite or migration: both runtimes passed 131,098 exact ordered-token comparisons, 676 similarity comparisons, and 128 complete ranking comparisons, and the existing dreaming-phase tests passed.
