### PR TITLE
fix(codex): mirror persisted user admission

### DIFF
--- a/extensions/codex/src/app-server/transcript-mirror.admission.test.ts
+++ b/extensions/codex/src/app-server/transcript-mirror.admission.test.ts
@@ -28,6 +28,7 @@ registerCodexEventProjectorTestLifecycle();
 it.each([undefined, "transport-user-key"])(
   "reuses the admitted prompt through native mirroring (source key: %s)",
   async (idempotencyKey) => {
+    const admittedContent = "Check the admitted monitor.";
     const createUserTurnTranscriptRecorder = await loadUserTurnTranscriptRecorderFactoryForTest();
     const base = await createParams();
     const target = {
@@ -44,7 +45,7 @@ it.each([undefined, "transport-user-key"])(
         ...(idempotencyKey ? { idempotencyKey } : {}),
       },
       target: { ...target, sessionEntry: undefined },
-      beforeMessageWrite: ({ message }) => message,
+      beforeMessageWrite: ({ message }) => ({ ...message, content: admittedContent }),
     });
     await recorder.persistApproved();
     const attempt = {
@@ -92,6 +93,24 @@ it.each([undefined, "transport-user-key"])(
         return asOptionalRecord(message?.["__openclaw"])?.mirrorIdentity === "turn-1:prompt";
       });
       expect(prompts).toHaveLength(1);
+      expect(asOptionalRecord(asOptionalRecord(prompts[0])?.message)).toMatchObject({
+        content: admittedContent,
+        ...(idempotencyKey ? { idempotencyKey } : {}),
+        __openclaw: {
+          mirrorIdentity: "turn-1:prompt",
+          mirrorOrigin: "codex-app-server",
+          upstreamUserText: "Check the monitor.",
+        },
+      });
+      expect(recorder.getPersistedMessage?.()).toMatchObject({
+        content: admittedContent,
+        ...(idempotencyKey ? { idempotencyKey } : {}),
+        __openclaw: {
+          mirrorIdentity: "turn-1:prompt",
+          mirrorOrigin: "codex-app-server",
+          upstreamUserText: "Check the monitor.",
+        },
+      });
       if (idempotencyKey) {
         expect(recorder.getPersistedMessage?.()?.idempotencyKey).toBe(idempotencyKey);
       }

--- a/extensions/codex/src/app-server/user-prompt-message.ts
+++ b/extensions/codex/src/app-server/user-prompt-message.ts
@@ -81,8 +81,9 @@ export function promptSnapshot(
 export async function buildResolvedCodexUserPromptMessage(
   params: EmbeddedRunAttemptParams,
 ): Promise<MirroredUserMessage> {
-  const resolvedMessage = await params.userTurnTranscriptRecorder?.resolveMessage();
-  return buildFromPrepared(params, resolvedMessage ?? params.userTurnTranscriptRecorder?.message);
+  const recorder = params.userTurnTranscriptRecorder;
+  const resolvedMessage = recorder?.getPersistedMessage?.() ?? (await recorder?.resolveMessage());
+  return buildFromPrepared(params, resolvedMessage ?? recorder?.message);
 }
 
 export async function resolveFinalCodexMirrorMessages(params: {


### PR DESCRIPTION
Closes #145993

## What Problem This Solves

Fixes an issue where Codex prompt annotation and transcript mirroring could be skipped when a user-turn write hook changed the content that was actually admitted. The mirror fingerprinted prepared content while the host correctly validated the persisted admission.

## Why This Change Was Made

The Codex prompt builder now treats an existing persisted admission as authoritative, while retaining the prior resolved-message and raw-message fallbacks before persistence. The host validator, Codex protocol, storage schema, and historical transcripts are unchanged.

## User Impact

Codex turns with content-changing admission hooks now keep one canonical annotated and mirrored user row with the admitted content, stable identity, and original upstream prompt provenance. This does not retroactively repair historical rows.

## Evidence

- New owner-boundary regression failed on the base code in both parameterized cases because the real host annotation guard rejected the prepared-content fingerprint and no prompt row was mirrored.
- The same regression passes after the fix and verifies the annotated admitted row plus the single mirrored row, including transformed content, mirror identity/origin, upstream text, and explicit transport idempotency key.
- 135 focused tests passed across Codex transcript mirroring, user idempotency, host annotation, and user-turn recorder suites.
- `node scripts/check-changed.mjs -- <changed paths>` passed all selected formatting, lint, typecheck, extension boundary, contract, dependency, dead-export, database/media/sidecar, and import-cycle checks.
- `git diff --check` passed.
- Independent Claude autoreview and the shared exact-head adaptive review found no actionable issues.

### Live Codex proof

An isolated `openclaw agent --local` turn ran on reviewed head `b68f2c243cac7db8418bfed04baccff20371ae02` with the real Codex app-server harness and a temporary `before_message_write` plugin that changed `OPENCLAW_145993_PREPARED_INPUT` to `OPENCLAW_145993_ADMITTED_INPUT`. The run returned `PROOF_OK` and reported `agentHarnessId: codex`.

The retained SQLite transcript for synthetic session `718d2ef8-7c6a-4b5a-b566-cd7331db954d` produced this sanitized verification:

```json
{
  "canonical_user_rows": 1,
  "admitted_marker_rows": 1,
  "prepared_marker_canonical_rows": 0,
  "annotated_user_rows": 1,
  "original_native_submission_rows": 1,
  "assistant_proof_rows": 1
}
```

This proves the real Codex turn retained one canonical annotated row with the transformed admission while preserving the original native submission provenance.

AI-assisted: yes.
