### PR TITLE
improve(test): avoid 10-second waits in Nextcloud error-body coverage

### DIFF
--- a/extensions/nextcloud-talk/src/send.fetch-timeout.test.ts
+++ b/extensions/nextcloud-talk/src/send.fetch-timeout.test.ts
@@ -1,7 +1,9 @@
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import { withServer } from "openclaw/plugin-sdk/test-env";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { resolveNextcloudTalkAccount } from "./accounts.js";
 import { probeNextcloudTalkBotResponseFeature } from "./bot-preflight.js";
+import * as guardedResponse from "./guarded-response.js";
 import { sendMessageNextcloudTalk, sendReactionNextcloudTalk } from "./send.js";
 import type { CoreConfig } from "./types.js";
 
@@ -51,6 +53,74 @@ async function expectHangingTalkRequestTimesOut(params: {
   );
 }
 
+function captureStalledErrorBodyDeadline() {
+  const readBody = guardedResponse.readNextcloudTalkErrorBody;
+  const ready = createDeferred<void>();
+  let refreshes = 0;
+  let fires = 0;
+  let delay: number | undefined;
+  let fireDeadline: (() => void) | undefined;
+  let restoreRefresh: (() => void) | undefined;
+  const bodySpy = vi
+    .spyOn(guardedResponse, "readNextcloudTalkErrorBody")
+    .mockImplementationOnce((...args) => {
+      const schedule = globalThis.setTimeout;
+      const timerSpy = vi
+        .spyOn(globalThis, "setTimeout")
+        .mockImplementationOnce((callback, ms, ...timerArgs) => {
+          const timer = schedule(callback, ms, ...timerArgs);
+          delay = ms;
+          const refresh = timer.refresh.bind(timer);
+          const refreshSpy = vi.spyOn(timer, "refresh").mockImplementation(() => {
+            const result = refresh();
+            refreshes += 1;
+            if (refreshes === 2) {
+              ready.resolve();
+            }
+            return result;
+          });
+          restoreRefresh = () => refreshSpy.mockRestore();
+          fireDeadline = () => {
+            clearTimeout(timer);
+            fires += 1;
+            callback(...timerArgs);
+          };
+          return timer;
+        });
+      try {
+        // The idle timer is installed synchronously; socket timers stay outside this scope.
+        return readBody(...args);
+      } finally {
+        timerSpy.mockRestore();
+      }
+    });
+  return {
+    ready: ready.promise,
+    assertReady() {
+      // Refresh precedes each reader.read(); this observes the next read, not its byte count.
+      expect(refreshes).toBeGreaterThanOrEqual(2);
+      expect(bodySpy).toHaveBeenCalledOnce();
+      expect(delay).toBe(10_000);
+      expect(fires).toBe(0);
+    },
+    fire() {
+      expect(fires).toBe(0);
+      if (!fireDeadline) {
+        throw new Error("expected the native error-body deadline");
+      }
+      fireDeadline();
+      expect(fires).toBe(1);
+    },
+    restore() {
+      try {
+        restoreRefresh?.();
+      } finally {
+        bodySpy.mockRestore();
+      }
+    },
+  };
+}
+
 describe("nextcloud-talk send error responses", () => {
   it.each(["message", "reaction", "preflight"])(
     "redacts reflected credentials and drops incomplete %s error bodies",
@@ -81,16 +151,46 @@ describe("nextcloud-talk send error responses", () => {
           },
           async (baseUrl) => {
             const cfg = createTalkConfig(baseUrl);
-            const result =
+            const deadline = mode === "stalled" ? captureStalledErrorBodyDeadline() : undefined;
+            const pending =
               operation === "preflight"
-                ? await probeNextcloudTalkBotResponseFeature({
+                ? probeNextcloudTalkBotResponseFeature({
                     account: resolveNextcloudTalkAccount({ cfg }),
                   })
-                : await (
-                    operation === "message"
-                      ? sendMessageNextcloudTalk("room:abc123", "hello", { cfg })
-                      : sendReactionNextcloudTalk("room:abc123", "m-1", "ok", { cfg })
+                : (operation === "message"
+                    ? sendMessageNextcloudTalk("room:abc123", "hello", { cfg })
+                    : sendReactionNextcloudTalk("room:abc123", "m-1", "ok", { cfg })
                   ).catch((error: unknown) => error);
+            let settled = false;
+            const operationSettled = pending.then(
+              () => {
+                settled = true;
+              },
+              () => {
+                settled = true;
+              },
+            );
+            let result: Awaited<typeof pending>;
+            try {
+              if (deadline) {
+                const readyFirst = await Promise.race([
+                  deadline.ready.then(() => true),
+                  operationSettled.then(() => false),
+                ]);
+                expect(readyFirst).toBe(true);
+                expect(settled).toBe(false);
+                deadline.assertReady();
+                deadline.fire();
+              }
+              result = await pending;
+            } finally {
+              try {
+                // Keep the real native deadline as the fallback if readiness assertions fail.
+                await pending.catch(() => undefined);
+              } finally {
+                deadline?.restore();
+              }
+            }
             const message =
               typeof result === "object" && result !== null && "message" in result
                 ? result.message


### PR DESCRIPTION
## What Problem This Solves

Nextcloud Talk's error-response tests wait roughly ten real seconds for each of three stalled-body variants. They need to verify safe handling of incomplete error bodies, but the wall-clock wait adds about thirty seconds to the focused test file.

## Why This Change Was Made

The stalled variants observe the existing body reader's synchronous timer registration, retain its real native handle and fixed 10,000-ms deadline, and release the actual owner callback after the next read is observed and the operation is confirmed unsettled. The original promise is forwarded unchanged, and spies are restored in `finally`.

This is test-only. Real HTTP requests/responses, all message/reaction/preflight operations, all four response modes, and every original assertion remain. Production deadlines and the separate 50-ms fetch-timeout tests are unchanged; no broad fake clock or production testing seam is introduced.

## User Impact

Faster focused test feedback with the same error-body regression coverage. There is no application behavior change.

## Evidence

- All five original cases pass before and after, with identical ordered names/statuses. All three operations still exercise complete, display-boundary, oversized, and stalled responses.
- In one controlled focused pair, the three targeted cases changed from 10,065/10,018/10,011 ms to 63/10/33 ms. Wrapper elapsed changed from 46.40 s to 15.04 s, including variable native preparation. These are focused observations, not an overall-suite runtime claim.
- All 41 existing response-body and Nextcloud guarded-response sibling tests pass.
- Bounded helper controls verify original promise identity, withheld firing, one actual callback, synchronous-failure restoration, and premature-settlement rejection.
- Mapped changed checks and fresh independent P2 review pass. The first gate flagged an unbound method reference; explicit receiver binding fixed it without suppression, and the final five-case confirmation passes.

Scope: one test file, net +100 test lines. Task-private helper controls and raw proof remain outside the repository.
