### PR TITLE
fix(kimi): normalize legacy model IDs before runtime loads

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -567,7 +567,6 @@ extensions/irc/src/setup-surface.ts	31
 extensions/kilocode/provider-models.ts	4
 extensions/kilocode/stream.ts	1
 extensions/kimi-coding/index.ts	2
-extensions/kimi-coding/provider-catalog.ts	1
 extensions/kimi-coding/provider-policy-api.ts	2
 extensions/kimi-coding/stream.ts	11
 extensions/line/src/accounts.ts	3

--- a/extensions/kimi-coding/openclaw.plugin.json
+++ b/extensions/kimi-coding/openclaw.plugin.json
@@ -6,6 +6,17 @@
   },
   "enabledByDefault": true,
   "providers": ["kimi", "kimi-code", "kimi-coding"],
+  "modelIdNormalization": {
+    "providers": {
+      "kimi": {
+        "aliases": {
+          "kimi-code": "kimi-for-coding",
+          "k2p5": "kimi-for-coding",
+          "k3[1m]": "k3"
+        }
+      }
+    }
+  },
   "providerRequest": {
     "providers": {
       "kimi": {

--- a/extensions/kimi-coding/provider-catalog.test.ts
+++ b/extensions/kimi-coding/provider-catalog.test.ts
@@ -1,5 +1,7 @@
 // Kimi Coding tests cover provider catalog plugin behavior.
+import { parseModelRef } from "openclaw/plugin-sdk/provider-model-shared";
 import { describe, expect, it } from "vitest";
+import manifest from "./openclaw.plugin.json" with { type: "json" };
 import { buildKimiCodingProvider, normalizeKimiCodingModelId } from "./provider-catalog.js";
 import { isKimiK3ModelId, KIMI_K3_MODEL_IDS } from "./provider-policy-api.js";
 
@@ -74,15 +76,24 @@ describe("kimi provider catalog", () => {
     expect(thinkingRows).toEqual([...KIMI_K3_MODEL_IDS]);
   });
 
-  it("normalizes legacy Kimi coding model ids to the stable API model id", () => {
-    expect(normalizeKimiCodingModelId("kimi-code")).toBe("kimi-for-coding");
-    expect(normalizeKimiCodingModelId("k2p5")).toBe("kimi-for-coding");
-    expect(normalizeKimiCodingModelId("kimi-for-coding")).toBe("kimi-for-coding");
-    expect(normalizeKimiCodingModelId("k3")).toBe("k3");
-    expect(normalizeKimiCodingModelId("k3[1m]")).toBe("k3");
-    expect(normalizeKimiCodingModelId("kimi-for-coding-highspeed")).toBe(
-      "kimi-for-coding-highspeed",
-    );
+  it.each([
+    ["kimi-code", "kimi-for-coding"],
+    ["k2p5", "kimi-for-coding"],
+    ["kimi-for-coding", "kimi-for-coding"],
+    ["k3", "k3"],
+    ["k3[1m]", "k3"],
+    ["kimi-for-coding-highspeed", "kimi-for-coding-highspeed"],
+  ])("normalizes %s to %s through the helper and static manifest", (input, expected) => {
+    expect(normalizeKimiCodingModelId(input)).toBe(expected);
+    expect(
+      parseModelRef(`kimi/${input}`, "kimi", {
+        manifestPlugins: [manifest],
+        allowPluginNormalization: false,
+      }),
+    ).toEqual({ provider: "kimi", model: expected });
+  });
+
+  it("recognizes K3 thinking-policy models", () => {
     expect(isKimiK3ModelId("k3")).toBe(true);
     expect(isKimiK3ModelId("K3-256K")).toBe(true);
     expect(isKimiK3ModelId("kimi-for-coding")).toBe(false);

--- a/extensions/kimi-coding/provider-catalog.ts
+++ b/extensions/kimi-coding/provider-catalog.ts
@@ -5,11 +5,13 @@ import manifest from "./openclaw.plugin.json" with { type: "json" };
 
 const KIMI_PROVIDER_ID = "kimi";
 const KIMI_CODING_CATALOG = manifest.modelCatalog.providers.kimi;
-const KIMI_LEGACY_MODEL_IDS = ["kimi-code", "k2p5"] as const;
+const KIMI_MODEL_ALIASES = new Map(
+  Object.entries(manifest.modelIdNormalization.providers.kimi.aliases),
+);
 
 export const KIMI_CODING_BASE_URL = KIMI_CODING_CATALOG.baseUrl;
 export const KIMI_CODING_DEFAULT_MODEL_ID = KIMI_CODING_CATALOG.defaultModel;
-export const KIMI_CODING_LEGACY_MODEL_IDS = KIMI_LEGACY_MODEL_IDS;
+export const KIMI_CODING_LEGACY_MODEL_IDS = ["kimi-code", "k2p5"] as const;
 
 export function buildKimiCodingProvider(): ModelProviderConfig {
   return buildManifestModelProviderConfig({
@@ -19,11 +21,5 @@ export function buildKimiCodingProvider(): ModelProviderConfig {
 }
 
 export function normalizeKimiCodingModelId(modelId: string): string {
-  // Legacy k3[1m] was retired upstream and normalizes to k3 for shipped configurations.
-  if (modelId === "k3[1m]") {
-    return "k3";
-  }
-  return KIMI_LEGACY_MODEL_IDS.includes(modelId as (typeof KIMI_LEGACY_MODEL_IDS)[number])
-    ? KIMI_CODING_DEFAULT_MODEL_ID
-    : modelId;
+  return KIMI_MODEL_ALIASES.get(modelId) ?? modelId;
 }


### PR DESCRIPTION
Related: #130706, #146183.

## What Problem This Solves

Fixes an issue where documented Kimi Coding aliases fail as unknown models on cold TTS summary selection, even though the canonical model and the loaded provider's normalization hook work. The affected aliases are `kimi-code`, `k2p5`, and `k3[1m]`.

## Why This Change Was Made

The plugin now declares those aliases in its existing static manifest contract, and its public runtime helper reads the same map. Cold catalog reads and loaded-provider normalization therefore share one policy. Existing hooks, provider IDs, public exports, and the helper's case/whitespace behavior are preserved.

The manifest and helper together add seven production lines while removing the duplicated alias policy and an obsolete type assertion. The only assertion-baseline change removes that helper's existing allowance.

## User Impact

Existing documented aliases select `kimi-for-coding` or `k3` before the provider runtime loads. Canonical IDs and explicit summary overrides continue to work; disabled, denied, unlisted, and unknown models remain rejected.

## Evidence

- All three aliases failed static parsing on the original source baseline. After the separately landed cold-catalog fix #146183, the same three aliases still failed before HTTP on its frozen compiled build; canonical controls passed.
- On `1eb087b4fd97cd65b84a325676870b768c76e9b7`, 37 focused tests and the full changed-file gate passed. Independent P2 review is scoped-clean; the final main carry has the identical reviewed patch, production/test postimages, and relevant owner inputs.
- The existing Moonshot/Kimi documentation already specifies these aliases; this repairs that contract without new configuration or stored formats.
- A single normal `pnpm build` passed on that final head. Its compiled public speech/summary path passed eleven fresh processes: six completed model-specific summaries (including all three legacy aliases) and five pre-HTTP policy/unknown-model rejections. All children exited naturally; 13,188 build files and observed module hashes remained unchanged.
- The compiled fixture uses a public transport-host seam and delegates redirected HTTP to the original guarded fetch builder. The OS sandbox allows loopback only, with a non-loopback denial control in every child. This proves compiled selection/auth/SSE boundaries, not hosted Kimi inference or native-endpoint guarding. Earlier fixture failures remain documented in #146183, including its synthetic-only HTTP 401; they are not counted as successful proof.
