### PR TITLE
fix(llama-cpp): count same-tick chunks in download speed

### DIFF
--- a/extensions/llama-cpp/src/llama-server-install.test.ts
+++ b/extensions/llama-cpp/src/llama-server-install.test.ts
@@ -207,6 +207,63 @@ describe("cached file integrity", () => {
 });
 
 describe("downloadVerifiedFile", () => {
+  it.each([
+    { label: "shared clock ticks", times: [1000, 1000, 1010], rates: [0, 0, 300_000_000] },
+    {
+      label: "shared clock ticks after an established sample",
+      times: [1010, 1010, 1030],
+      rates: [100_000_000, 100_000_000, 100_000_000],
+    },
+    {
+      label: "distinct clock ticks",
+      times: [1010, 1020, 1030],
+      rates: [100_000_000, 100_000_000, 100_000_000],
+    },
+  ])("counts every persisted byte in the rate across $label", async ({ times, rates }) => {
+    const { destination } = await createDestination();
+    const chunks = [1, 2, 3].map((value) => Buffer.alloc(1_000_000, value));
+    const payload = Buffer.concat(chunks);
+    const release = vi.fn();
+    mocks.fetchWithSsrFGuard.mockResolvedValue({
+      response: new Response(
+        new ReadableStream<Uint8Array>({
+          start(controller) {
+            for (const chunk of chunks) {
+              controller.enqueue(chunk);
+            }
+            controller.close();
+          },
+        }),
+      ),
+      release,
+    });
+    const clock = vi.spyOn(Date, "now").mockReturnValue(1000);
+    let written = 0;
+    injectFileHandle((handle) => {
+      const writeFile = handle.writeFile.bind(handle);
+      handle.writeFile = async (...args) => {
+        await writeFile(...args);
+        clock.mockReturnValue(times[written++]!);
+      };
+    });
+    const onProgress = vi.fn();
+
+    await downloadVerifiedFile({
+      url: "https://downloads.example/model.gguf",
+      destination,
+      expectedSize: payload.byteLength,
+      expectedSha256: createHash("sha256").update(payload).digest("hex"),
+      onProgress,
+    });
+
+    expect(onProgress.mock.calls.map(([progress]) => progress.bytesPerSecond)).toEqual(rates);
+    expect(onProgress.mock.calls.map(([progress]) => progress.downloadedSize)).toEqual([
+      1_000_000, 2_000_000, 3_000_000,
+    ]);
+    expect(await fs.readFile(destination)).toEqual(payload);
+    expect(release).toHaveBeenCalledOnce();
+  });
+
   it("persists complete chunks before reporting progress under positive short writes", async () => {
     const payload = Buffer.from("short writes must not truncate verified downloads");
     const { destination, root } = await createDestination();

--- a/extensions/llama-cpp/src/llama-server-install.ts
+++ b/extensions/llama-cpp/src/llama-server-install.ts
@@ -204,9 +204,9 @@ export async function downloadVerifiedFile(params: {
               rollingBytesPerSecond === 0
                 ? currentRate
                 : rollingBytesPerSecond * 0.75 + currentRate * 0.25;
+            previousSize = downloadedSize;
+            previousAt = now;
           }
-          previousSize = downloadedSize;
-          previousAt = now;
           params.onProgress?.({ downloadedSize, totalSize, bytesPerSecond: rollingBytesPerSecond });
         }
         if (params.expectedSize && downloadedSize !== params.expectedSize) {

--- a/extensions/llama-cpp/src/setup.test.ts
+++ b/extensions/llama-cpp/src/setup.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -13,11 +14,17 @@ const mocks = vi.hoisted(() => ({
   removeProfiles: vi.fn(),
   progressUpdate: vi.fn(),
   hardware: vi.fn(),
+  downloadFetch: vi.fn(),
 }));
 
 vi.mock("openclaw/plugin-sdk/provider-auth-runtime", async (importOriginal) => ({
   ...(await importOriginal<typeof import("openclaw/plugin-sdk/provider-auth-runtime")>()),
   removeProviderAuthProfilesWithLock: mocks.removeProfiles,
+}));
+
+vi.mock("openclaw/plugin-sdk/ssrf-runtime", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("openclaw/plugin-sdk/ssrf-runtime")>()),
+  fetchWithSsrFGuard: mocks.downloadFetch,
 }));
 
 vi.mock("./managed-server.js", async (importOriginal) => ({
@@ -39,6 +46,7 @@ vi.mock("./hardware.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("./hardware.js")>()),
   detectLlamaCppHardware: mocks.hardware,
 }));
+import { downloadVerifiedFile, type LlamaDownloadProgress } from "./llama-server-install.js";
 import { resolveLlamaCppCatalogArtifact, resolveLlamaCppModelCandidates } from "./model-catalog.js";
 import { detectLlamaCppSetup, prepareLlamaCppSetup, runLlamaCppSetup } from "./setup.js";
 
@@ -81,6 +89,7 @@ beforeEach(async () => {
   });
   mocks.removeProfiles.mockReset().mockResolvedValue({ version: 1, profiles: {} });
   mocks.progressUpdate.mockReset();
+  mocks.downloadFetch.mockReset();
 });
 
 afterEach(async () => {
@@ -169,6 +178,139 @@ const externalChatRoutes: Array<{
 ];
 
 describe("llama.cpp managed setup", () => {
+  it.each([
+    {
+      label: "initial shared tick",
+      times: [1000, 1000, 1010],
+      rates: [0, 0, 300_000_000],
+      mb: [0, 0, 300],
+    },
+    {
+      label: "established shared tick",
+      times: [1010, 1010, 1030],
+      rates: [100_000_000, 100_000_000, 100_000_000],
+      mb: [100, 100, 100],
+    },
+    {
+      label: "distinct ticks",
+      times: [1010, 1020, 1030],
+      rates: [100_000_000, 100_000_000, 100_000_000],
+      mb: [100, 100, 100],
+    },
+  ])(
+    "reports producer download rates during setup across $label",
+    async ({ label, times, rates, mb }) => {
+      vi.mocked(os.totalmem).mockReturnValue(4 * GIB);
+      const ctx = authContext(true);
+      requestUnconfiguredLocalMemory(ctx);
+      ctx.config.memory = {
+        search: { provider: "local", local: { modelPath: CUSTOM_EMBEDDING_MODEL } },
+      };
+      const stopped = vi.fn();
+      vi.mocked(ctx.prompter.progress).mockReturnValue({
+        update: mocks.progressUpdate,
+        stop: stopped,
+      });
+      const destination = path.join(tempRoot, "rate-embedding.gguf");
+      const chunks = [1, 2, 3].map((value) => Buffer.alloc(1_000_000, value));
+      const payload = Buffer.concat(chunks);
+      const observations: Array<Parameters<LlamaDownloadProgress>[0] & { text: string }> = [];
+      const release = vi.fn();
+      const existingEnsure = mocks.ensureModel.getMockImplementation()!;
+      mocks.ensureModel.mockImplementation(
+        async (
+          options: Parameters<typeof import("./managed-server.js").ensureLlamaCppModel>[0],
+        ) => {
+          if (!options.download || options.source !== CUSTOM_EMBEDDING_MODEL) {
+            return existingEnsure(options);
+          }
+          const report = options.onProgress;
+          if (!report) {
+            throw new Error("Selected setup download has no progress callback");
+          }
+          mocks.downloadFetch.mockResolvedValueOnce({
+            response: new Response(
+              new ReadableStream<Uint8Array>({
+                start(controller) {
+                  for (const chunk of chunks) {
+                    controller.enqueue(chunk);
+                  }
+                  controller.close();
+                },
+              }),
+            ),
+            release,
+          });
+          const clock = vi.spyOn(Date, "now").mockReturnValue(1000);
+          const actualOpen = fs.open.bind(fs);
+          let written = 0;
+          const opened = vi.spyOn(fs, "open").mockImplementation(async (...args) => {
+            const handle = await actualOpen(...args);
+            const writeFile = handle.writeFile.bind(handle);
+            handle.writeFile = async (...writeArgs) => {
+              await writeFile(...writeArgs);
+              clock.mockReturnValue(times[written++]!);
+            };
+            return handle;
+          });
+          try {
+            await downloadVerifiedFile({
+              url: "https://downloads.example/rate-embedding.gguf",
+              destination,
+              expectedSize: payload.byteLength,
+              expectedSha256: createHash("sha256").update(payload).digest("hex"),
+              onProgress: (progress) => {
+                expect(stopped).not.toHaveBeenCalled();
+                report(progress);
+                const text = mocks.progressUpdate.mock.lastCall?.[0];
+                expect(typeof text).toBe("string");
+                observations.push({ ...progress, text });
+              },
+            });
+          } finally {
+            opened.mockRestore();
+            clock.mockRestore();
+          }
+          return destination;
+        },
+      );
+
+      await runLlamaCppSetup(ctx);
+
+      expect(await fs.readFile(destination)).toEqual(payload);
+      expect(release).toHaveBeenCalledOnce();
+      expect(stopped).toHaveBeenCalledExactlyOnceWith("Managed llama.cpp server prepared");
+      expect(mocks.downloadFetch).toHaveBeenCalledOnce();
+      expect(observations.map((progress) => progress.downloadedSize)).toEqual([
+        1_000_000, 2_000_000, 3_000_000,
+      ]);
+      expect(observations.map((progress) => progress.totalSize)).toEqual([
+        3_000_000, 3_000_000, 3_000_000,
+      ]);
+      console.info(
+        "[llama-rate-proof] " +
+          JSON.stringify({
+            label,
+            execPath: process.execPath,
+            version: process.version,
+            observations,
+            fileVerified: true,
+            releaseCount: release.mock.calls.length,
+            stoppedCount: stopped.mock.calls.length,
+          }),
+      );
+      expect(observations.map((progress) => progress.bytesPerSecond)).toEqual(rates);
+      expect(
+        observations.map((progress) => Number(progress.text.match(/, (\d+) MB\/s\)$/u)?.[1])),
+      ).toEqual(mb);
+      expect(
+        observations.every((progress) =>
+          progress.text.startsWith("Downloading configured embedding model…"),
+        ),
+      ).toBe(true);
+    },
+  );
+
   it("reuses a downloaded recommendation after cancelled activation with little free disk", async () => {
     mocks.hardware.mockResolvedValue({
       platform: "darwin",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where llama.cpp setup understated download speed when multiple persisted chunks arrived during the same clock tick. Bytes written without a positive elapsed interval were missing from the next speed estimate.

## Why This Change Was Made

The sampler now advances its byte and time baselines only when it accepts a rate sample. This accounts for every persisted chunk while preserving the existing rolling average, cumulative progress, integrity checks, file publication, and cleanup.

Production: **+2/-2, net 0**. Regression tests add 199 lines. No new configuration, API, schema, dependency, or persistence behavior.

## User Impact

The setup progress message shows the correct rate across shared clock ticks. In the controlled producer-to-display cases, an initial three-chunk interval changes from 100 to 300 MB/s; an established sample remains at 100 MB/s instead of falling to 88 MB/s. Ordinary distinct-tick progress is unchanged.

## Evidence

The real downloader wrote and verified synthetic response bytes, then delivered its progress through the active setup formatter. The baseline had exactly four intended arithmetic failures and two passing controls; the candidate passed all six cases. Both used the same pinned Node 24.20.0, test bytes and strict failure oracle, with natural exits and joined cleanup.

All 61 downloader/install and setup tests passed, with no skips. Full changed checks, including production/test typechecks, doctor contracts, formatting, lint, and boundary guards, passed. Independent evidence review and managed P0–P2 review found no unresolved issues.

This is synthetic-response boundary proof with real temporary-file writes and setup formatting, not a live vendor transfer, full onboarding, or inference run. The original test-title qualification mismatch is retained separately; the exact Vitest-emitted title was bound and a fresh baseline passed before production changed. No assertion or oracle was weakened. A standalone application build was unnecessary because imports, module boundaries and packaging are unchanged.
