### PR TITLE
fix(agents): keep the CLI session binding when an interrupted run's transcript flushed

### DIFF
--- a/src/agents/cli-runner/cli-run-settlement.test.ts
+++ b/src/agents/cli-runner/cli-run-settlement.test.ts
@@ -136,6 +136,70 @@ describe("isCliBindingFlushed", () => {
   });
 });
 
+describe("CLI session binding survives an interruption whose transcript flushed", () => {
+  it("keeps the CLI session binding when an interrupted turn's transcript flushed", () => {
+    const context = buildPreparedCliRunContext({ provider: "claude-cli" });
+    const result = buildCliRunResult({
+      context,
+      output: {
+        text: "partial reply",
+        terminalInterruption: { reason: "timeout" },
+      },
+      effectiveCliSessionId: "interrupted-but-flushed-session",
+      bindingFlushOk: true,
+      usedHistoryPrompt: false,
+      userTurnHandled: true,
+      sessionBindingDisabled: false,
+      preparedContextAgentMeta: {},
+    });
+
+    expect(result.meta.agentMeta?.clearCliSessionBinding).toBeUndefined();
+    expect(result.meta.agentMeta?.cliSessionBinding?.sessionId).toBe(
+      "interrupted-but-flushed-session",
+    );
+  });
+
+  it("still clears the CLI session binding when an interrupted turn's transcript never flushed", () => {
+    const context = buildPreparedCliRunContext({ provider: "claude-cli" });
+    const result = buildCliRunResult({
+      context,
+      output: {
+        text: "partial reply",
+        terminalInterruption: { reason: "timeout" },
+      },
+      effectiveCliSessionId: "interrupted-unflushed-session",
+      bindingFlushOk: false,
+      usedHistoryPrompt: false,
+      userTurnHandled: true,
+      sessionBindingDisabled: false,
+      preparedContextAgentMeta: {},
+    });
+
+    expect(result.meta.agentMeta?.clearCliSessionBinding).toBe(true);
+    expect(result.meta.agentMeta?.cliSessionBinding).toBeUndefined();
+  });
+
+  it("clears the CLI session binding on interruption when the flush was never probed", () => {
+    const context = buildPreparedCliRunContext({ provider: "claude-cli" });
+    const result = buildCliRunResult({
+      context,
+      output: {
+        text: "partial reply",
+        terminalInterruption: { reason: "timeout" },
+      },
+      effectiveCliSessionId: "interrupted-unprobed-session",
+      bindingFlushOk: undefined,
+      usedHistoryPrompt: false,
+      userTurnHandled: true,
+      sessionBindingDisabled: false,
+      preparedContextAgentMeta: {},
+    });
+
+    expect(result.meta.agentMeta?.clearCliSessionBinding).toBe(true);
+    expect(result.meta.agentMeta?.cliSessionBinding).toBeUndefined();
+  });
+});
+
 describe("CLI native continuity projection", () => {
   it.each(["blocked", "no-native-id", "native", "stateless"])(
     "projects only explicit native continuity from a %s result",

--- a/src/agents/cli-runner/cli-run-settlement.ts
+++ b/src/agents/cli-runner/cli-run-settlement.ts
@@ -502,11 +502,15 @@ export function buildCliRunResult(params: {
       ? effectiveCliSessionId
       : undefined;
   const terminalInterruption = output.terminalInterruption;
-  // An interrupted process cannot preserve its now-invalid native session binding.
+  // An interruption alone is not evidence the native session binding is corrupt —
+  // only a transcript that never reached disk is. `bindingFlushOk` already probes
+  // the CLI's own transcript for that; trust it to rescue an interrupted binding
+  // whose transcript flushed. `!== true` is deliberate: an unprobed flush
+  // (`undefined`) must not rescue a binding, only a positively confirmed one can.
   const cliSessionBindingCleared =
-    terminalInterruption !== undefined ||
     sessionBindingDisabled ||
-    unflushedCliSessionId !== undefined;
+    unflushedCliSessionId !== undefined ||
+    (terminalInterruption !== undefined && bindingFlushOk !== true);
   const persistedCliSessionId = cliSessionBindingCleared ? undefined : effectiveCliSessionId;
   const createdReseedReceipt =
     persistedCliSessionId &&


### PR DESCRIPTION
## The bug

A CLI-backed run that is interrupted — killed by `agents.defaults.timeoutSeconds`, or cancelled when the user steers — loses its entire conversation history. The next turn starts a brand-new Claude CLI session with nothing replayed.

From a live gateway, the turn after an interruption:

```
inputTokens = 2      (the user's whole message)
cacheRead   = 0      nothing replayed
```

and the session entry's `claudeCliSessionId` is gone.

## Root cause: two layers disagree

`cli-run-settlement.ts` clears the CLI session binding whenever the run was interrupted:

```js
// An interrupted process cannot preserve its now-invalid native session binding.
const cliSessionBindingCleared =
  terminalInterruption !== undefined || sessionBindingDisabled || unflushedCliSessionId !== undefined;
```

That is committed to the store via `agent-runner-cli-candidate.ts` → `persistCliSessionBindingResult` → `patchCliSessionBindingInStore`.

Meanwhile the gateway layer treats `status: "timeout"` as **recoverable** (`config/sessions/terminal-status.ts`) and reuses the same session node for the next visible turn. `recoverTerminalSessionEntryForVisibleTurn` never touches `cliSessionBindings` — it doesn't need to, because settlement already wiped them.

So the gateway says "resume this session" and the CLI layer has already destroyed the thing to resume. Each layer is self-consistent; together they lose the conversation.

It is also silent — the clearing path emits no log line, so this only shows up by reading `session_nodes.entry_json` directly.

## The fix

An interruption on its own is not evidence the native transcript is corrupt. A transcript that never reached disk is. The codebase already computes exactly that: `isCliBindingFlushed()` probes the CLI's own transcript for assistant content, and its result (`bindingFlushOk`) is already in scope two lines above — but only ever *adds* to the clear decision via `unflushedCliSessionId`, never rescues one.

```js
const cliSessionBindingCleared =
  sessionBindingDisabled ||
  unflushedCliSessionId !== undefined ||
  (terminalInterruption !== undefined && bindingFlushOk !== true);
```

`!== true` is deliberate: an unprobed flush (`undefined`) keeps today's clearing behaviour, so only a positively confirmed flush can rescue a binding. Warm-stdin sessions are unaffected — `isCliBindingFlushed` already returns `true` for them via `skipTranscriptProbe`.

This is the same standard `cli-runner/prepare.ts` already applies when deciding whether to trust a binding for resume, so it is not a new invariant.

## Tests

Three new cases in `cli-run-settlement.test.ts`:
- an interrupted run whose transcript **flushed** keeps its binding (this one was verified failing before the change)
- an interrupted run whose transcript did **not** flush still clears
- `bindingFlushOk === undefined` still clears

There was previously no test asserting that a second turn resumes the same CLI session id after an interruption, which is why this went unnoticed.

The five existing `cli-runner.reliability.test.ts` cases that assert clearing on timeout were each inspected and left untouched — none exercise this branch (they route through `buildCliDeliveredFailure`, `sessionBindingDisabled`, or non-timeout errors).

## Verification note

Developed and tested against 2026.9.3, where the full suite passes (`cli-run-settlement` 16/16, `cli-runner.reliability` 104/104 unchanged, `cli-session` 40/40, `agent-runner-execution-cli-sessions` 15/15, cron session-lifecycle 55/55). Cherry-picked cleanly onto current `main`; I could not re-run the suite on this base locally due to an uninstalled-dependency gap in my environment, so CI is the authority for main.
