### PR TITLE
improve: reduce memory used by source validation

### DIFF
--- a/scripts/check-max-lines-ratchet.mts
+++ b/scripts/check-max-lines-ratchet.mts
@@ -79,14 +79,6 @@ export function isMaxLinesRule(rule: string) {
   return rule === "max-lines" || rule.endsWith("/max-lines");
 }
 
-export function hasMaxLinesDisable(source: string, filePath = "source.ts") {
-  return collectLintDisableDirectives(source, filePath).some((rules) => rules.some(isMaxLinesRule));
-}
-
-export function hasAllRuleDisable(source: string, filePath = "source.ts") {
-  return collectLintDisableDirectives(source, filePath).some((rules) => rules.length === 0);
-}
-
 function baselineWithVerifiedRenames(
   root: string,
   baseRef: string,
@@ -150,21 +142,24 @@ export function collectCurrentSuppressionState(
     .filter(Boolean)
     .filter(isGovernedSourcePath)
     .filter((filePath) => staged || fs.existsSync(path.join(root, filePath)));
-  const sources = staged
-    ? [...loadRatchetSources(root, governedPaths)]
-    : governedPaths.map((filePath): [string, string] => [
-        filePath,
-        fs.readFileSync(path.join(root, filePath), "utf8"),
-      ]);
+  const stagedSources = staged ? loadRatchetSources(root, governedPaths) : undefined;
+  const allRules: string[] = [];
+  const explicit: string[] = [];
+  for (const filePath of governedPaths) {
+    const source = stagedSources
+      ? stagedSources.get(filePath)!
+      : fs.readFileSync(path.join(root, filePath), "utf8");
+    const directives = collectLintDisableDirectives(source, filePath);
+    if (directives.some((rules) => rules.length === 0)) {
+      allRules.push(filePath);
+    }
+    if (directives.some((rules) => rules.some(isMaxLinesRule))) {
+      explicit.push(filePath);
+    }
+  }
   return {
-    allRules: sources
-      .filter(([filePath, source]) => hasAllRuleDisable(source, filePath))
-      .map(([filePath]) => filePath)
-      .toSorted(compareStrings),
-    explicit: sources
-      .filter(([filePath, source]) => hasMaxLinesDisable(source, filePath))
-      .map(([filePath]) => filePath)
-      .toSorted(compareStrings),
+    allRules: allRules.toSorted(compareStrings),
+    explicit: explicit.toSorted(compareStrings),
   };
 }
 

--- a/test/scripts/check-max-lines-ratchet.test.ts
+++ b/test/scripts/check-max-lines-ratchet.test.ts
@@ -6,8 +6,6 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   collectCurrentSuppressionState,
   collectLintDisableDirectives,
-  hasAllRuleDisable,
-  hasMaxLinesDisable,
   isGovernedSourcePath,
   main,
 } from "../../scripts/check-max-lines-ratchet.mts";
@@ -84,32 +82,23 @@ describe("check-max-lines-ratchet", () => {
     ]);
   });
 
-  it("recognizes suppressions without matching reason prose", () => {
-    expect(hasMaxLinesDisable("/* oxlint-disable max-lines -- TODO: split. */\n")).toBe(true);
-    expect(hasMaxLinesDisable("// eslint-disable-next-line no-console, max-lines\n")).toBe(true);
-    expect(hasMaxLinesDisable("/* oxlint-disable */\n")).toBe(false);
-    expect(hasMaxLinesDisable("// oxlint-disable-line -- all rules\n")).toBe(false);
-    expect(hasMaxLinesDisable("/* oxlint-disable max-lines - TODO: split. */\n")).toBe(true);
-    expect(hasMaxLinesDisable("/* oxlint-disable max-lines--temporary */\n")).toBe(true);
-    expect(hasMaxLinesDisable("/* oxlint-disable - all rules */\n")).toBe(false);
-    expect(hasMaxLinesDisable("/* oxlint-disable eslint/max-lines */\n")).toBe(true);
-    expect(hasMaxLinesDisable("/* oxlint-disable\nmax-lines\n-- TODO: split. */\n")).toBe(true);
-    expect(
-      hasMaxLinesDisable(
-        "export const value = 1;\n/* oxlint-disable max-lines -- TODO: split. */\n",
-      ),
-    ).toBe(true);
-    expect(
-      hasMaxLinesDisable("if (true) {\n  const value = 1;\n  /* oxlint-disable max-lines */\n}\n"),
-    ).toBe(true);
-    expect(hasMaxLinesDisable("/* oxlint-disable no-console -- mentions max-lines */\n")).toBe(
-      false,
-    );
-    expect(hasMaxLinesDisable("// Example: oxlint-disable max-lines\n")).toBe(false);
-    expect(hasMaxLinesDisable('const example = "/* oxlint-disable max-lines */";\n')).toBe(false);
-    expect(hasAllRuleDisable("/* oxlint-disable */\n")).toBe(true);
-    expect(hasAllRuleDisable("// oxlint-disable-line -- all rules\n")).toBe(true);
-    expect(hasAllRuleDisable("/* oxlint-disable max-lines */\n")).toBe(false);
+  it.each<[string, string[][]]>([
+    ["/* oxlint-disable max-lines -- TODO: split. */\n", [["max-lines"]]],
+    ["// eslint-disable-next-line no-console, max-lines\n", [["no-console", "max-lines"]]],
+    ["/* oxlint-disable */\n", [[]]],
+    ["// oxlint-disable-line -- all rules\n", [[]]],
+    ["/* oxlint-disable max-lines - TODO: split. */\n", [["max-lines"]]],
+    ["/* oxlint-disable max-lines--temporary */\n", [["max-lines"]]],
+    ["/* oxlint-disable - all rules */\n", [[]]],
+    ["/* oxlint-disable eslint/max-lines */\n", [["eslint/max-lines"]]],
+    ["/* oxlint-disable\nmax-lines\n-- TODO: split. */\n", [["max-lines"]]],
+    ["export const value = 1;\n/* oxlint-disable max-lines -- TODO: split. */\n", [["max-lines"]]],
+    ["if (true) {\n  const value = 1;\n  /* oxlint-disable max-lines */\n}\n", [["max-lines"]]],
+    ["/* oxlint-disable no-console -- mentions max-lines */\n", [["no-console"]]],
+    ["// Example: oxlint-disable max-lines\n", []],
+    ['const example = "/* oxlint-disable max-lines */";\n', []],
+  ])("parses directive rules without matching reason prose: %j", (source, directives) => {
+    expect(collectLintDisableDirectives(source)).toEqual(directives);
   });
 
   it("limits source roots and excludes generated output", () => {
@@ -287,7 +276,10 @@ describe("check-max-lines-ratchet", () => {
     fs.rmSync(path.join(root, "src/deleted.ts"));
     expect(main(root)).toBe(0);
 
-    fs.writeFileSync(path.join(root, "src/untracked.ts"), "/* oxlint-disable max-lines */\n");
+    fs.writeFileSync(
+      path.join(root, "src/untracked.ts"),
+      "// eslint-disable-next-line eslint/max-lines\n",
+    );
     vi.spyOn(console, "error").mockImplementation(() => {});
 
     expect(main(root)).toBe(1);


### PR DESCRIPTION
Related: #145679

## What Problem This Solves

Full-tree source validation can consume about 2 GiB of memory just to collect lint suppressions, increasing contention with builds, tests and editor processes.

## Why This Change Was Made

Process working-tree files individually and parse each file's suppression directives once. Keep staged reads with the existing batched Git owner, and remove the two redundant classification wrappers. Existing enforcement tests now exercise the parser and the real validation entry point.

## User Impact

Developers get the same validation with substantially less peak memory. Suppression policy, baseline rules and generated-file exclusions are unchanged.

## Evidence

- Two full-tree Windows Node 24.19 comparisons reduced maximum RSS from 2,114,268–2,131,368 KiB to 406,556–441,180 KiB, roughly 80%. The final native candidate scan used 436,776 KiB. Every scan returned the same complete sorted state: 827 explicit suppressions and zero all-rule suppressions. Host contention makes the timings unsuitable for a precise speed claim.
- Original owner suite: 13 passed; final candidate suite: 26 passed. Both retain the existing Windows newline-filename skip. Coverage includes namespaced rules, string literals, all-rule directives, staged versus working-tree content, verified renames and baseline growth.
- An interrupted earlier candidate run failed in a Git-show fixture. A subsequent diagnostic run of unchanged final inputs, with Git subprocess tracing, completed successfully; the earlier failure is retained and its cause remains unproven.
- Selected script/test typechecks, type-aware lint, formatting and static guards passed. All three native export scans ran with unchanged scope and strict results, scheduled serially to reduce memory pressure. Their only findings reproduce exactly on the clean original revision: `canonicalProviderName` in the script/full-tree scans and `listPackagedStaticExtensionAssetOutputs` in the full-tree scan; production has zero entries.
- Independent P2 review completed clean with final source verification. Exact-head [CI 34709595582](https://github.com/openclaw/openclaw/actions/runs/34709595582) passed for `0bb1feb745d4652889154aeade96cf1d361d0de0`.
## Data compatibility

This change only alters temporary in-memory scanning. The baseline file format, `loadRatchetSnapshot`/`loadRatchetReference` readers, `writeBaseline`, `--prune` behavior, rename handling, and shrink-only enforcement are unchanged in the [exact-head diff](https://github.com/openclaw/openclaw/pull/146266/files). No stored state, schema, migration, or upgrade path changes. Complete original/candidate scans return identical sorted suppression state; the focused suite preserves staged content, verified rename, baseline growth, and real namespaced enforcement checks.

ClawSweeper reported no code or security findings but classified the scanner as a persistent data-model change. Maintainer source review rejects that classification based on the unchanged readers/writer and the compatibility evidence above; its report is not being described as a clean bot verdict.
