### PR TITLE
feat(gateway): renew TLS certificates without restarting listeners

### DIFF
--- a/docs/gateway/config-gateway.md
+++ b/docs/gateway/config-gateway.md
@@ -268,6 +268,19 @@ See [Multiple Gateways](/gateway/multiple-gateways).
 - `keyPath`: filesystem path to the TLS private key file; keep permission-restricted.
 - `caPath`: optional CA bundle path for client verification or custom trust chains.
 
+With automatic reload enabled, the Gateway watches the certificate, key, and CA
+files at their accepted paths. Replacing their contents renews all Gateway HTTPS
+listeners without disconnecting existing connections. The complete material is
+validated first; a missing, unreadable, or mismatched pair keeps the previous
+certificate serving and logs the failure. Renewal never generates missing files.
+Background observation follows atomic symlink and projected-directory replacements too.
+Changing TLS configuration or file paths still requires a Gateway restart.
+
+`gateway.reload.mode: "off"` pauses certificate renewal too. Re-enabling reload
+checks the current files, including renewals made while paused. Discovery and new
+pairing payloads use the served fingerprint. Saved remote certificate pins remain
+operator-controlled: update them before reconnecting with a renewed certificate.
+
 Client commands such as `triage`, `gateway status`, and `gateway probe` only read the public certificate to determine a local TLS pin. They never generate or repair TLS files and do not need the server private key or CA bundle. Without `certPath`, they inspect `gateway/tls/gateway-cert.pem` under the state directory. A missing or unreadable certificate supplies no implicit pin; normal connection trust checks still apply. Start the Gateway to generate a missing pair, or provide the configured certificate files before connecting.
 
 ### `gateway.reload`

--- a/docs/gateway/configuration/hot-reload.md
+++ b/docs/gateway/configuration/hot-reload.md
@@ -177,6 +177,14 @@ attached browsers stay running. Browser enablement, evaluation, SSRF policy,
 and extension relay remain restart-owned. Snapshot defaults apply to the next
 snapshot, and tab-cleanup settings apply on the next sweep.
 
+TLS certificate renewal watches the files at the running Gateway's accepted
+certificate, key, and CA paths. Valid replacement material updates existing and
+future HTTPS listeners, discovery, and pairing fingerprints without interrupting
+connections. Incomplete or invalid replacements keep the previous material serving.
+Reload mode `off` pauses renewal; re-enabling checks changes made while paused.
+TLS configuration and path changes still require a Gateway restart. Remote
+certificate pins remain operator-controlled; see [Gateway TLS](/gateway/config-gateway#gateway-tls).
+
 Authentication rate-limit changes retain recorded failures, earned lockout
 deadlines, and pending loopback delays. New limits and loopback exemptions apply
 to subsequent attempts; tightening the attempt limit can lock a client based on

--- a/qa/scenarios/runtime/gateway-tls-pinning.yaml
+++ b/qa/scenarios/runtime/gateway-tls-pinning.yaml
@@ -7,6 +7,8 @@ scenario:
   coverage:
     primary:
       - gateway.tls-pinning
+    secondary:
+      - gateway.config-reload-hot-apply
   objective: Verify the real Gateway TLS listener and public Node client enforce the advertised certificate fingerprint.
   successCriteria:
     - A real loopback Gateway starts with generated TLS certificate material.
@@ -14,6 +16,9 @@ scenario:
     - The public GatewayClient completes hello and a health request with the exact pin.
     - A wrong pin fails before hello completes.
     - Supplying a TLS pin to a plaintext Gateway URL fails with an explicit transport-policy error.
+    - Same-path renewal updates existing and future HTTPS siblings while a pinned connection stays open.
+    - Atomic certificate symlink retargeting is detected while previous target files remain present.
+    - Incomplete pairs retain serving and advertised material; reload off defers renewal until re-enabled.
   docsRefs:
     - docs/gateway/index.md
     - docs/gateway/discovery.md
@@ -21,13 +26,14 @@ scenario:
   codeRefs:
     - src/infra/tls/gateway.ts
     - src/gateway/server-runtime-state.ts
+    - src/gateway/server-tls-renewal.ts
     - packages/gateway-client/src/client.ts
     - test/e2e/qa-lab/runtime/gateway-tls-pinning.ts
   execution:
     kind: script
     parallelSafe: true
     path: test/e2e/qa-lab/runtime/gateway-tls-pinning.ts
-    summary: Starts a real TLS Gateway and exercises exact-pin, wrong-pin, and plaintext mismatch behavior through the public GatewayClient.
+    summary: Starts a real TLS Gateway, renews its accepted certificate paths, and verifies retained connections, sibling listeners, discovery, reload-off policy, and public client pinning.
     args:
       - --artifact-base
       - ${outputDir}

--- a/src/cli/gateway-cli/run.supervised-lock.test.ts
+++ b/src/cli/gateway-cli/run.supervised-lock.test.ts
@@ -7,12 +7,15 @@ import { TailscaleRouteOwnershipConflictError } from "../../infra/tailscale-rout
 import { OpenClawAgentDatabaseMediaMigrationRequiredError } from "../../state/openclaw-agent-db-migration-required.js";
 import { testing } from "./run.test-support.js";
 
-const loadGatewayTlsServerRuntimeMock = vi.hoisted(() =>
-  vi.fn(async () => ({ fingerprintSha256: "" })),
+const inspectGatewayTlsCertificateMock = vi.hoisted(() =>
+  vi.fn<typeof import("../../infra/tls/gateway.js").inspectGatewayTlsCertificate>(async () => ({
+    ok: false,
+    error: "public certificate missing",
+  })),
 );
 
 vi.mock("../../infra/tls/gateway.js", () => ({
-  loadGatewayTlsServerRuntime: loadGatewayTlsServerRuntimeMock,
+  inspectGatewayTlsCertificate: inspectGatewayTlsCertificateMock,
 }));
 
 function createLogger() {
@@ -236,8 +239,8 @@ describe("supervised gateway lock recovery", () => {
     },
   );
 
-  it("retries non-mutating TLS fingerprint loads until certificate material is ready", async () => {
-    loadGatewayTlsServerRuntimeMock.mockClear();
+  it("retries public certificate inspection while TLS material is unavailable", async () => {
+    inspectGatewayTlsCertificateMock.mockClear();
     const probeHealth = testing.createConfiguredGatewayHealthProbe({
       gateway: { tls: { enabled: true, autoGenerate: true } },
     });
@@ -245,14 +248,10 @@ describe("supervised gateway lock recovery", () => {
     await expect(probeHealth({ host: "127.0.0.1", port: 18789 })).resolves.toBe(false);
     await expect(probeHealth({ host: "127.0.0.1", port: 18789 })).resolves.toBe(false);
 
-    expect(loadGatewayTlsServerRuntimeMock).toHaveBeenCalledTimes(2);
-    expect(loadGatewayTlsServerRuntimeMock).toHaveBeenNthCalledWith(1, {
+    expect(inspectGatewayTlsCertificateMock).toHaveBeenCalledTimes(2);
+    expect(inspectGatewayTlsCertificateMock).toHaveBeenCalledWith({
       enabled: true,
-      autoGenerate: false,
-    });
-    expect(loadGatewayTlsServerRuntimeMock).toHaveBeenNthCalledWith(2, {
-      enabled: true,
-      autoGenerate: false,
+      autoGenerate: true,
     });
   });
 

--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -1712,6 +1712,7 @@ function createReloaderHarness(
   );
   const onConfigAccepted = vi.fn(options.onConfigAccepted ?? (async () => {}));
   const onConfigRevisionApplied = vi.fn(options.onConfigRevisionApplied ?? (() => {}));
+  const onReloadEnabledChange = vi.fn<(enabled: boolean) => void>();
   const onEffectiveConfigUnchanged = vi.fn(
     options.onEffectiveConfigUnchanged ?? (async () => ({ rollback: async () => {} })),
   );
@@ -1775,6 +1776,7 @@ function createReloaderHarness(
     onConfigChange,
     onConfigApplied,
     onConfigRevisionApplied,
+    onReloadEnabledChange,
     onConfigAccepted,
     onEffectiveConfigUnchanged,
     onNoopConfigCommit,
@@ -1790,6 +1792,7 @@ function createReloaderHarness(
     onConfigChange,
     onConfigApplied,
     onConfigRevisionApplied,
+    onReloadEnabledChange,
     onConfigAccepted,
     onEffectiveConfigUnchanged,
     onNoopConfigCommit,
@@ -3772,25 +3775,44 @@ describe("startGatewayConfigReloader", () => {
     await harness.reloader.stop();
   });
 
-  it("notifies change listeners when reload mode off skips the runtime apply", async () => {
+  it("updates reload owners only for accepted off/on policy, including skipped runtime apply", async () => {
     const initialConfig: OpenClawConfig = {
-      gateway: { reload: { mode: "off" } },
+      gateway: { reload: { mode: "hybrid" } },
     };
     const nextConfig: OpenClawConfig = {
       gateway: { reload: { mode: "off" } },
       ui: { prefs: { themeMode: "light" } },
     };
-    const readSnapshot = vi.fn(async () =>
-      makeSnapshot({ config: nextConfig, hash: "mode-off-write" }),
-    );
+    let snapshot = makeSnapshot({ config: nextConfig, hash: "mode-off-write" });
+    const readSnapshot = vi.fn(async () => snapshot);
     const harness = createReloaderHarness(readSnapshot, { initialConfig });
     await harness.reloader.ready;
+    expect(harness.onReloadEnabledChange.mock.calls).toEqual([[true]]);
 
     await flushWatcherChange(harness);
 
     expect(harness.onHotReload).not.toHaveBeenCalled();
     expect(harness.onRestart).not.toHaveBeenCalled();
     expect(harness.onConfigCandidateCommitted).toHaveBeenCalledOnce();
+    expect(harness.onReloadEnabledChange.mock.calls).toEqual([[true], [false]]);
+
+    snapshot = makeSnapshot({
+      config: initialConfig,
+      valid: false,
+      raw: '{ "gateway": { "reload": { "mode": "hybrid" }, "port": "invalid" } }',
+      hash: "invalid-reenable",
+      issues: [{ path: "gateway.port", message: "Expected number" }],
+    });
+    await flushWatcherChange(harness);
+    expect(harness.onReloadEnabledChange.mock.calls).toEqual([[true], [false]]);
+
+    // The effective runtime never changed while off, so returning to its
+    // original config must still re-enable independent reload owners.
+    snapshot = makeSnapshot({ config: initialConfig, hash: "mode-on-write" });
+    await flushWatcherChange(harness);
+    expect(harness.onReloadEnabledChange.mock.calls).toEqual([[true], [false], [true]]);
+    expect(harness.onHotReload).not.toHaveBeenCalled();
+    expect(harness.onRestart).not.toHaveBeenCalled();
     await harness.reloader.stop();
   });
 
@@ -4530,6 +4552,9 @@ describe("startGatewayConfigReloader", () => {
     const initialConfig = {
       gateway: { reload: {} },
     } satisfies OpenClawConfig;
+    const configA = {
+      gateway: { reload: { mode: "off" } },
+    } satisfies OpenClawConfig;
     const invalidConfigB = {
       gateway: { reload: {}, port: 18790 },
     } satisfies OpenClawConfig;
@@ -4537,9 +4562,9 @@ describe("startGatewayConfigReloader", () => {
       .fn<() => Promise<ConfigFileSnapshot>>()
       .mockResolvedValueOnce(
         makeSnapshot({
-          config: initialConfig,
-          sourceConfig: initialConfig,
-          runtimeConfig: initialConfig,
+          config: configA,
+          sourceConfig: configA,
+          runtimeConfig: configA,
           hash: "plugin-read-a",
         }),
       )
@@ -4580,6 +4605,7 @@ describe("startGatewayConfigReloader", () => {
     expect(readSnapshot).toHaveBeenCalledTimes(3);
     expect(harness.onConfigAccepted).not.toHaveBeenCalled();
     expect(pausedRestartDebt).toBe(true);
+    expect(harness.onReloadEnabledChange.mock.calls).toEqual([[true]]);
     expect(harness.onNoopConfigCommit).not.toHaveBeenCalled();
     expect(harness.onHotReload).not.toHaveBeenCalled();
     expect(harness.onRestart).not.toHaveBeenCalled();

--- a/src/gateway/config-reload.ts
+++ b/src/gateway/config-reload.ts
@@ -172,6 +172,8 @@ export function startGatewayConfigReloader(opts: {
   testDebounceMs?: number;
   /** Per-instance test hook for synchronizing filesystem edits with watcher startup. */
   onWatcherReady?: () => void;
+  /** Source acceptance controls ancillary reload owners even when runtime application is off. */
+  onReloadEnabledChange?: (enabled: boolean) => void;
   prepareConfigCandidate?: (params: {
     runtimeConfig: OpenClawConfig;
     sourceConfig: OpenClawConfig;
@@ -742,6 +744,7 @@ export function startGatewayConfigReloader(opts: {
       // Persisted content changed even when the runtime skipped applying it
       // (writer intent, reload mode off): change listeners still refresh.
       const notifyCommitted = () => {
+        opts.onReloadEnabledChange?.(nextSettings.mode !== "off");
         if (changedPaths.length > 0) {
           opts.onConfigCandidateCommitted?.({
             path: opts.watchPath,
@@ -1687,6 +1690,7 @@ export function startGatewayConfigReloader(opts: {
     currentReapplyRuntimeOverlays =
       initialCandidate?.reapplyRuntimeOverlays ?? ((config) => config);
     settings = resolveSettings(currentConfig);
+    opts.onReloadEnabledChange?.(settings.mode !== "off");
     currentSnapshotSlot = readLatestConfigSnapshotAuditRecord();
     // A write captured during validation owns the newer audit baseline.
     if (sourceObservation.epoch === 0) {

--- a/src/gateway/local-http-probe.test.ts
+++ b/src/gateway/local-http-probe.test.ts
@@ -20,10 +20,8 @@ test("probes configured local TLS readiness with its exact certificate pin", asy
   await withTestDir({ prefix: "openclaw-local-http-probe-" }, async (directory) => {
     const certPath = path.join(directory, "gateway-cert.pem");
     const keyPath = path.join(directory, "gateway-key.pem");
-    await Promise.all([
-      writeFile(certPath, TEST_TLS_CERT_PEM),
-      writeFile(keyPath, TEST_TLS_KEY_PEM),
-    ]);
+    // Client probes need only the public certificate; the configured private key is absent.
+    await writeFile(certPath, TEST_TLS_CERT_PEM);
     const paths: string[] = [];
     const server = createServer(
       { cert: TEST_TLS_CERT_PEM, key: TEST_TLS_KEY_PEM },

--- a/src/gateway/local-http-probe.ts
+++ b/src/gateway/local-http-probe.ts
@@ -64,7 +64,8 @@ export async function requestGatewayLocalHttpProbe(params: {
         ...(params.signal ? { signal: params.signal } : {}),
         // Self-signed local Gateway certificates are trusted only by the exact
         // configured pin below; never accept them on ordinary HTTPS requests.
-        ...(params.tlsFingerprint ? { rejectUnauthorized: false } : {}),
+        // A reused socket still carries its old certificate after listener renewal.
+        ...(params.tlsFingerprint ? { rejectUnauthorized: false, agent: false } : {}),
       },
       (res) => {
         if (params.tlsFingerprint) {
@@ -117,25 +118,17 @@ export function createConfiguredGatewayLocalProbe(
   config: OpenClawConfig,
 ): ConfiguredGatewayLocalProbe {
   const tlsConfig = config.gateway?.tls;
-  let tlsFingerprint: string | undefined;
-  let tlsFingerprintLoad: Promise<string | undefined> | null = null;
 
   const resolveTlsFingerprint = async (): Promise<string | undefined> => {
     if (tlsConfig?.enabled !== true) {
       return undefined;
     }
-    if (!tlsFingerprint) {
-      tlsFingerprintLoad ??= import("../infra/tls/gateway.js")
-        .then(({ loadGatewayTlsServerRuntime }) =>
-          loadGatewayTlsServerRuntime({ ...tlsConfig, autoGenerate: false }),
-        )
-        .then((gatewayTls) => gatewayTls.fingerprintSha256)
-        .catch(() => undefined);
-      const gatewayTls = await tlsFingerprintLoad;
-      tlsFingerprintLoad = null;
-      tlsFingerprint = gatewayTls;
-    }
-    return tlsFingerprint;
+    // Supervisor probes outlive renewals. Read only the current public certificate,
+    // never the server private key or a pin cached for a previous certificate.
+    const certificate = await import("../infra/tls/gateway.js")
+      .then(({ inspectGatewayTlsCertificate }) => inspectGatewayTlsCertificate(tlsConfig))
+      .catch(() => undefined);
+    return certificate?.ok ? certificate.value.fingerprintSha256 : undefined;
   };
 
   return {

--- a/src/gateway/server-discovery-runtime.test.ts
+++ b/src/gateway/server-discovery-runtime.test.ts
@@ -486,6 +486,59 @@ describe("startGatewayDiscovery", () => {
   });
 
   it.each(["ready", "pending"] as const)(
+    "replaces a %s advertisement when the served TLS fingerprint changes",
+    async (phase) => {
+      useDevelopmentDiscoveryEnv();
+      vi.useFakeTimers();
+      process.env.OPENCLAW_GATEWAY_DISCOVERY_ADVERTISE_TIMEOUT_MS = "10";
+      const oldAdvertisement = createDeferredCore<{ stop: () => void }>();
+      const oldStop = vi.fn();
+      const nextStop = vi.fn();
+      const advertise = vi
+        .fn<PluginGatewayDiscoveryServiceRegistration["service"]["advertise"]>()
+        .mockImplementationOnce(() =>
+          phase === "pending" ? oldAdvertisement.promise : Promise.resolve({ stop: oldStop }),
+        )
+        .mockResolvedValue({ stop: nextStop });
+      const starting = startDiscovery({
+        discovery: { mdns: { mode: "full" }, wideArea: { domain: "openclaw.internal." } },
+        gatewayTls: { enabled: true, fingerprintSha256: "old-fingerprint" },
+        gatewayDiscoveryServices: [makeDiscoveryService({ id: "bonjour", advertise })],
+      });
+      await vi.advanceTimersByTimeAsync(10);
+      const discovery = await starting;
+      try {
+        await discovery.update({ gatewayTlsFingerprintSha256: "next-fingerprint" });
+        expect(advertise).toHaveBeenCalledTimes(2);
+        expect(advertise).toHaveBeenLastCalledWith(
+          expect.objectContaining({
+            gatewayTlsEnabled: true,
+            gatewayTlsFingerprintSha256: "next-fingerprint",
+            minimal: false,
+          }),
+        );
+        expect(latestZoneParams().gatewayTlsFingerprintSha256).toBe("next-fingerprint");
+        expect(oldStop).toHaveBeenCalledTimes(phase === "ready" ? 1 : 0);
+
+        oldAdvertisement.resolve({ stop: oldStop });
+        await vi.advanceTimersByTimeAsync(0);
+        expect(oldStop).toHaveBeenCalledOnce();
+        expect(nextStop).not.toHaveBeenCalled();
+
+        await discovery.update({ gatewayTlsFingerprintSha256: "next-fingerprint" });
+        expect(advertise).toHaveBeenCalledTimes(2);
+        expect(mocks.writeWideAreaGatewayZone).toHaveBeenCalledTimes(2);
+      } finally {
+        oldAdvertisement.resolve({ stop: oldStop });
+        await vi.advanceTimersByTimeAsync(0);
+        await discovery.stop();
+      }
+      expect(oldStop).toHaveBeenCalledOnce();
+      expect(nextStop).toHaveBeenCalledOnce();
+    },
+  );
+
+  it.each(["ready", "pending"] as const)(
     "retains an unchanged %s advertisement across selective replacement",
     async (phase) => {
       useDevelopmentDiscoveryEnv();

--- a/src/gateway/server-discovery-runtime.ts
+++ b/src/gateway/server-discovery-runtime.ts
@@ -18,6 +18,7 @@ import type { GatewayPluginRuntimeClaim } from "./server-plugin-runtime-generati
 
 type DiscoveryUpdate = {
   mdnsMode?: MdnsDiscoveryMode;
+  gatewayTlsFingerprintSha256?: string;
   gatewayDiscoveryServices?: readonly PluginGatewayDiscoveryServiceRegistration[];
 };
 export type GatewayDiscovery = {
@@ -26,6 +27,7 @@ export type GatewayDiscovery = {
 };
 type DiscoveryGeneration = {
   mode: MdnsDiscoveryMode;
+  tlsFingerprint?: string;
   services: Map<
     PluginGatewayDiscoveryServiceRegistration,
     { started?: boolean; stop?: () => void | Promise<void> }
@@ -47,6 +49,7 @@ export async function startGatewayDiscovery(params: {
   logDiscovery: { info: (msg: string) => void; warn: (msg: string) => void };
 }): Promise<GatewayDiscovery> {
   let mode = params.discovery?.mdns?.mode ?? "minimal";
+  let tlsFingerprint = params.gatewayTls?.fingerprintSha256;
   const wideAreaDomain = params.discovery?.wideArea?.domain;
   let services = params.gatewayDiscoveryServices ?? [];
   let claim = params.pluginRuntimeClaim;
@@ -128,7 +131,7 @@ export async function startGatewayDiscovery(params: {
       machineDisplayName: params.machineDisplayName,
       gatewayPort: params.port,
       gatewayTlsEnabled: params.gatewayTls?.enabled ?? false,
-      gatewayTlsFingerprintSha256: params.gatewayTls?.fingerprintSha256,
+      gatewayTlsFingerprintSha256: generation.tlsFingerprint,
       gatewayDirectReachable: params.gatewayDirectReachable === true,
       sshPort: minimal ? undefined : (parseTcpPort(process.env.OPENCLAW_SSH_PORT) ?? undefined),
       tailnetDns,
@@ -246,20 +249,28 @@ export async function startGatewayDiscovery(params: {
   const update: GatewayDiscovery["update"] = (next, nextClaim = claim) => {
     const nextMode = "mdnsMode" in next ? (next.mdnsMode ?? "minimal") : mode;
     const nextServices = next.gatewayDiscoveryServices ?? services;
+    const nextTlsFingerprint = next.gatewayTlsFingerprintSha256 ?? tlsFingerprint;
     if (
       closed ||
-      (current && mode === nextMode && services === nextServices && claim === nextClaim)
+      (current &&
+        mode === nextMode &&
+        services === nextServices &&
+        claim === nextClaim &&
+        tlsFingerprint === nextTlsFingerprint)
     ) {
       return Promise.resolve();
     }
     const previous = current;
-    const retained = mode === nextMode ? previous?.services : undefined;
+    const retained =
+      mode === nextMode && tlsFingerprint === nextTlsFingerprint ? previous?.services : undefined;
     mode = nextMode;
+    tlsFingerprint = nextTlsFingerprint;
     services = nextServices;
     claim = nextClaim;
     // Exact retained registrations keep acquired and pending handles across publication.
     const generation = (current = {
       mode,
+      tlsFingerprint,
       services: new Map(services.map((entry) => [entry, retained?.get(entry) ?? {}])),
       claim,
       waiting: false,

--- a/src/gateway/server-reload-contracts.ts
+++ b/src/gateway/server-reload-contracts.ts
@@ -201,6 +201,7 @@ export type ManagedGatewayConfigReloaderParams = Omit<
 > & {
   configRevisionProjector: import("./config-revision-token.js").GatewayConfigRevisionProjector;
   minimalTestGateway: boolean;
+  onReloadEnabledChange?: (enabled: boolean) => void;
   initialConfig: OpenClawConfig;
   initialPluginInstallRecords?: Record<string, PluginInstallRecord>;
   initialCompareConfig?: OpenClawConfig;

--- a/src/gateway/server-reload-managed.ts
+++ b/src/gateway/server-reload-managed.ts
@@ -315,6 +315,7 @@ export function startManagedGatewayConfigReloader(
 
   let lastCommittedRuntimeConfig: OpenClawConfig | undefined;
   const configReloader = startGatewayConfigReloader({
+    onReloadEnabledChange: params.onReloadEnabledChange,
     initialConfig: params.initialConfig,
     initialCompareConfig: params.initialCompareConfig,
     initialSnapshotRawHash: params.initialSnapshotRawHash,

--- a/src/gateway/server-request-context.ts
+++ b/src/gateway/server-request-context.ts
@@ -250,9 +250,9 @@ export function createGatewayRequestContext(
         ? []
         : (runtimeState.configReloader.getDeferredChannelReloads?.() ?? []),
     getGatewayMethodRegistry: runtime.getAttachedGatewayMethodRegistry,
-    gatewayTlsFingerprint: runtime.gatewayTls.enabled
-      ? runtime.gatewayTls.fingerprintSha256
-      : undefined,
+    get gatewayTlsFingerprint() {
+      return runtime.gatewayTls.enabled ? runtime.gatewayTls.fingerprintSha256 : undefined;
+    },
     controlUiSessionPullRequests: runtimeState.controlUiSessionPullRequests,
     sessionViewerPresence: runtimeState.sessionViewerPresence,
     sessionCompanion: runtime.sessionCompanion,

--- a/src/gateway/server-startup-finish.ts
+++ b/src/gateway/server-startup-finish.ts
@@ -27,6 +27,7 @@ import { GATEWAY_EVENTS } from "./server-methods-list.js";
 import { refreshConnectedNodeSurfaceCaches } from "./server-methods/nodes.read.js";
 import { assertGatewayRuntimeSecurityConfig } from "./server-runtime-config.js";
 import { getRequiredSharedGatewaySessionGeneration } from "./server-shared-auth-generation.js";
+import { startGatewayTlsRenewal } from "./server-tls-renewal.js";
 import type { GatewayHttpTransport } from "./server-transport-bridge.js";
 import { disconnectDisallowedGatewayBrowserOriginClients } from "./server/ws-origin-policy.js";
 import { DEFAULT_TERMINAL_DETACH_SECONDS } from "./terminal/session-limits.js";
@@ -399,7 +400,23 @@ export async function finishGatewayStartup(params: {
       }),
     });
   };
+  const tlsRenewal = startGatewayTlsRenewal({
+    runtime: gatewayTls,
+    servers: runtime.httpServers,
+    enabled: cfgAtStart.gateway?.reload?.mode !== "off",
+    isClosing: () => lifecycle.closePreludeStarted,
+    onRenewed: async () => {
+      await runtimeState.discovery?.update({
+        gatewayTlsFingerprintSha256: gatewayTls.fingerprintSha256,
+      });
+    },
+    log: log.child("tls"),
+  });
+  if (tlsRenewal) {
+    registerGatewayLifetimeSidecars([tlsRenewal]);
+  }
   const configReloaderParams: Parameters<typeof startManagedGatewayConfigReloader>[0] = {
+    onReloadEnabledChange: tlsRenewal?.setEnabled,
     configRevisionProjector: gatewayRequestContext.configRevisionProjector,
     resolveGatewayContext: resolvePluginGatewayContext,
     minimalTestGateway,

--- a/src/gateway/server-tls-renewal.test.ts
+++ b/src/gateway/server-tls-renewal.test.ts
@@ -1,5 +1,6 @@
 import { EventEmitter } from "node:events";
 import { Server } from "node:https";
+import type { TlsOptions } from "node:tls";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { TEST_TLS_CERT_PEM, TEST_TLS_KEY_PEM } from "../../test/helpers/tls-fixture.js";
 import type { GatewayTlsRuntime } from "../infra/tls/gateway.js";
@@ -10,14 +11,21 @@ const mocks = vi.hoisted(() => ({ watchFile: vi.fn(), unwatchFile: vi.fn(), load
 vi.mock("node:fs", () => ({ watchFile: mocks.watchFile, unwatchFile: mocks.unwatchFile }));
 vi.mock("../infra/tls/gateway.js", () => ({ loadGatewayTlsServerRuntime: mocks.load }));
 
-const material = (): GatewayTlsRuntime => ({
-  enabled: true,
-  required: true,
-  certPath: "/synthetic/cert.pem",
-  keyPath: "/synthetic/key.pem",
-  fingerprintSha256: "same-leaf-fingerprint",
-  tlsOptions: { cert: TEST_TLS_CERT_PEM, key: TEST_TLS_KEY_PEM, minVersion: "TLSv1.3" },
-});
+function material() {
+  const tlsOptions: TlsOptions = {
+    cert: TEST_TLS_CERT_PEM,
+    key: TEST_TLS_KEY_PEM,
+    minVersion: "TLSv1.3",
+  };
+  return {
+    enabled: true,
+    required: true,
+    certPath: "/synthetic/cert.pem",
+    keyPath: "/synthetic/key.pem",
+    fingerprintSha256: "same-leaf-fingerprint",
+    tlsOptions,
+  } satisfies GatewayTlsRuntime;
+}
 
 function createRenewal() {
   const watcher = new EventEmitter();

--- a/src/gateway/server-tls-renewal.test.ts
+++ b/src/gateway/server-tls-renewal.test.ts
@@ -1,0 +1,112 @@
+import { EventEmitter } from "node:events";
+import { Server } from "node:https";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { TEST_TLS_CERT_PEM, TEST_TLS_KEY_PEM } from "../../test/helpers/tls-fixture.js";
+import type { GatewayTlsRuntime } from "../infra/tls/gateway.js";
+import { createDeferredCore } from "../shared/deferred.js";
+import { startGatewayTlsRenewal } from "./server-tls-renewal.js";
+
+const mocks = vi.hoisted(() => ({ watchFile: vi.fn(), unwatchFile: vi.fn(), load: vi.fn() }));
+vi.mock("node:fs", () => ({ watchFile: mocks.watchFile, unwatchFile: mocks.unwatchFile }));
+vi.mock("../infra/tls/gateway.js", () => ({ loadGatewayTlsServerRuntime: mocks.load }));
+
+const material = (): GatewayTlsRuntime => ({
+  enabled: true,
+  required: true,
+  certPath: "/synthetic/cert.pem",
+  keyPath: "/synthetic/key.pem",
+  fingerprintSha256: "same-leaf-fingerprint",
+  tlsOptions: { cert: TEST_TLS_CERT_PEM, key: TEST_TLS_KEY_PEM, minVersion: "TLSv1.3" },
+});
+
+function createRenewal() {
+  const watcher = new EventEmitter();
+  mocks.watchFile.mockImplementation((_path, _options, listener) => watcher.on("all", listener));
+  mocks.unwatchFile.mockImplementation((_path, listener) => watcher.off("all", listener));
+  const runtime = material();
+  const server = new Server(runtime.tlsOptions);
+  const publish = vi.spyOn(server, "setSecureContext");
+  const onRenewed = vi.fn(async () => {});
+  const owner = startGatewayTlsRenewal({
+    runtime,
+    servers: [server],
+    enabled: true,
+    isClosing: () => false,
+    onRenewed,
+    log: { info: vi.fn(), warn: vi.fn() },
+  });
+  if (!owner) throw new Error("TLS renewal owner was not created");
+  return { owner, runtime, publish, watcher, onRenewed };
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  mocks.load.mockReset();
+  mocks.watchFile.mockReset();
+  mocks.unwatchFile.mockReset();
+});
+afterEach(() => vi.useRealTimers());
+
+describe("TLS material renewal lifetime", () => {
+  it("joins a pending read on close without publishing it", async () => {
+    const loaded = createDeferredCore<GatewayTlsRuntime>();
+    mocks.load.mockReturnValue(loaded.promise);
+    const { owner, runtime, publish, onRenewed } = createRenewal();
+    await vi.advanceTimersByTimeAsync(300);
+    expect(mocks.load).toHaveBeenCalledOnce();
+    const stopping = owner.stop();
+    expect(mocks.unwatchFile).toHaveBeenCalledTimes(2);
+    loaded.resolve({ ...material(), fingerprintSha256: "retired" });
+    await stopping;
+    expect(publish).not.toHaveBeenCalled();
+    expect(onRenewed).not.toHaveBeenCalled();
+    expect(runtime.fingerprintSha256).toBe("same-leaf-fingerprint");
+  });
+
+  it("ignores an older read and adopts a complete CA change with the same leaf", async () => {
+    const stale = createDeferredCore<GatewayTlsRuntime>();
+    const next = material();
+    next.tlsOptions = { ...next.tlsOptions, ca: TEST_TLS_CERT_PEM };
+    mocks.load.mockReturnValueOnce(stale.promise).mockResolvedValueOnce(next);
+    const { owner, runtime, publish, watcher, onRenewed } = createRenewal();
+    const acceptedOptions = runtime.tlsOptions;
+    try {
+      await vi.advanceTimersByTimeAsync(300);
+      watcher.emit("all", "change", "/synthetic/cert.pem");
+      await vi.advanceTimersByTimeAsync(300);
+      stale.resolve({ ...material(), fingerprintSha256: "stale" });
+      await vi.advanceTimersByTimeAsync(0);
+      expect(mocks.load).toHaveBeenCalledTimes(2);
+      expect(publish).toHaveBeenCalledExactlyOnceWith(next.tlsOptions);
+      expect(runtime.tlsOptions).toBe(acceptedOptions);
+      expect(runtime.tlsOptions?.ca).toBe(TEST_TLS_CERT_PEM);
+      expect(runtime.fingerprintSha256).toBe("same-leaf-fingerprint");
+      expect(onRenewed).toHaveBeenCalledOnce();
+    } finally {
+      await owner.stop();
+    }
+  });
+
+  it("fences a read when disabled and reconciles on re-enable without another file event", async () => {
+    const stale = createDeferredCore<GatewayTlsRuntime>();
+    const next = material();
+    next.tlsOptions = { ...next.tlsOptions, ca: TEST_TLS_CERT_PEM };
+    mocks.load.mockReturnValueOnce(stale.promise).mockResolvedValueOnce(next);
+    const { owner, publish, watcher, onRenewed } = createRenewal();
+    try {
+      await vi.advanceTimersByTimeAsync(300);
+      owner.setEnabled(false);
+      stale.resolve({ ...material(), fingerprintSha256: "disabled" });
+      watcher.emit("all", "change", "/synthetic/key.pem");
+      await vi.advanceTimersByTimeAsync(300);
+      expect(publish).not.toHaveBeenCalled();
+      expect(mocks.load).toHaveBeenCalledOnce();
+      owner.setEnabled(true);
+      await vi.advanceTimersByTimeAsync(300);
+      expect(publish).toHaveBeenCalledExactlyOnceWith(next.tlsOptions);
+      expect(onRenewed).toHaveBeenCalledOnce();
+    } finally {
+      await owner.stop();
+    }
+  });
+});

--- a/src/gateway/server-tls-renewal.test.ts
+++ b/src/gateway/server-tls-renewal.test.ts
@@ -43,7 +43,9 @@ function createRenewal() {
     onRenewed,
     log: { info: vi.fn(), warn: vi.fn() },
   });
-  if (!owner) throw new Error("TLS renewal owner was not created");
+  if (!owner) {
+    throw new Error("TLS renewal owner was not created");
+  }
   return { owner, runtime, publish, watcher, onRenewed };
 }
 

--- a/src/gateway/server-tls-renewal.ts
+++ b/src/gateway/server-tls-renewal.ts
@@ -91,7 +91,7 @@ export function startGatewayTlsRenewal(params: {
   }
   requestRefresh();
   return {
-    setEnabled(next: boolean) {
+    setEnabled: (next: boolean) => {
       if (enabled !== next) {
         enabled = next;
         requestRefresh();

--- a/src/gateway/server-tls-renewal.ts
+++ b/src/gateway/server-tls-renewal.ts
@@ -1,0 +1,110 @@
+import { unwatchFile, watchFile } from "node:fs";
+import type { Server as HttpServer } from "node:http";
+import { Server as HttpsServer } from "node:https";
+import { isDeepStrictEqual } from "node:util";
+import { loadGatewayTlsServerRuntime, type GatewayTlsRuntime } from "../infra/tls/gateway.js";
+
+/** Renew only the running listener's accepted paths; TLS topology remains startup-owned. */
+export function startGatewayTlsRenewal(params: {
+  runtime: GatewayTlsRuntime;
+  servers: readonly HttpServer[];
+  enabled: boolean;
+  isClosing: () => boolean;
+  onRenewed: () => Promise<void>;
+  log: { info: (message: string) => void; warn: (message: string) => void };
+}) {
+  const { runtime } = params;
+  const options = runtime.tlsOptions;
+  if (!runtime.enabled || !options || params.isClosing()) {
+    return undefined;
+  }
+  const paths = [runtime.certPath, runtime.keyPath, runtime.caPath].filter(
+    (value): value is string => Boolean(value),
+  );
+  let enabled = params.enabled;
+  let stopped = false;
+  let epoch = 0;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let pending = Promise.resolve();
+  const isCurrent = (expected: number) =>
+    !stopped && enabled && !params.isClosing() && epoch === expected;
+  const requestRefresh = () => {
+    const expected = ++epoch;
+    clearTimeout(timer);
+    if (!isCurrent(expected)) {
+      if (!stopped && !enabled && !params.isClosing()) {
+        params.log.info("gateway TLS renewal deferred (gateway.reload.mode=off)");
+      }
+      return;
+    }
+    timer = setTimeout(() => {
+      timer = undefined;
+      pending = pending
+        .then(async () => {
+          if (!isCurrent(expected)) {
+            return;
+          }
+          const next = await loadGatewayTlsServerRuntime({
+            enabled: true,
+            autoGenerate: false,
+            certPath: runtime.certPath,
+            keyPath: runtime.keyPath,
+            caPath: runtime.caPath,
+          });
+          if (!isCurrent(expected)) {
+            return;
+          }
+          if (!next.enabled || !next.tlsOptions) {
+            throw new Error(next.error ?? "TLS renewal did not produce listener material");
+          }
+          if (isDeepStrictEqual(options, next.tlsOptions)) {
+            return;
+          }
+          // No await between ownership validation and publication. Every HTTPS
+          // sibling and future listener must use the same accepted material.
+          for (const server of params.servers) {
+            if (server instanceof HttpsServer) {
+              server.setSecureContext(next.tlsOptions);
+            }
+          }
+          Object.assign(options, next.tlsOptions);
+          runtime.fingerprintSha256 = next.fingerprintSha256;
+          await params.onRenewed().catch((error: unknown) => {
+            params.log.warn(`gateway TLS renewed but discovery refresh failed: ${String(error)}`);
+          });
+          params.log.info("gateway TLS certificate renewed without restarting listeners");
+        })
+        .catch((error: unknown) => {
+          if (isCurrent(expected)) {
+            params.log.warn(
+              `gateway TLS renewal failed; keeping accepted material: ${String(error)}`,
+            );
+          }
+        });
+    }, 300);
+    timer.unref?.();
+  };
+  // Inode watches miss certificate symlinks and projected-secret directory swaps.
+  // Poll only these accepted paths outside request handling, at most once a second.
+  for (const path of paths) {
+    watchFile(path, { interval: 1000, persistent: false }, requestRefresh);
+  }
+  requestRefresh();
+  return {
+    setEnabled(next: boolean) {
+      if (enabled !== next) {
+        enabled = next;
+        requestRefresh();
+      }
+    },
+    async stop() {
+      stopped = true;
+      epoch += 1;
+      clearTimeout(timer);
+      for (const path of paths) {
+        unwatchFile(path, requestRefresh);
+      }
+      await pending;
+    },
+  };
+}

--- a/src/infra/tls/gateway.ts
+++ b/src/infra/tls/gateway.ts
@@ -216,7 +216,7 @@ export async function inspectGatewayTlsCertificate(
   }
 }
 
-/** Server startup only: load or provision TLS material and return listener options. */
+/** Server lifecycle only: load TLS material; startup may also provision a missing pair. */
 export async function loadGatewayTlsServerRuntime(
   cfg: GatewayTlsConfig | undefined,
   log?: GatewayTlsLog,
@@ -284,6 +284,9 @@ export async function loadGatewayTlsServerRuntime(
       };
     }
 
+    const tlsOptions: tls.TlsOptions = { cert, key, ca, minVersion: "TLSv1.3" };
+    // Reject incomplete renewals before any listener can adopt mismatched material.
+    tls.createSecureContext(tlsOptions);
     return {
       enabled: true,
       required: true,
@@ -291,12 +294,7 @@ export async function loadGatewayTlsServerRuntime(
       keyPath,
       caPath,
       fingerprintSha256,
-      tlsOptions: {
-        cert,
-        key,
-        ca,
-        minVersion: "TLSv1.3",
-      },
+      tlsOptions,
     };
   } catch (error) {
     return {

--- a/test/e2e/qa-lab/runtime/gateway-tls-pinning.test.ts
+++ b/test/e2e/qa-lab/runtime/gateway-tls-pinning.test.ts
@@ -23,7 +23,10 @@ describe("Gateway TLS pinning evidence", () => {
     });
 
     expect(snapshotGatewayStartupEnv()).toEqual(gatewayStartupEnv);
-    expect(evidence.entries[0]?.result.status).toBe("pass");
+    expect(
+      evidence.entries[0]?.result.status,
+      await fs.readFile(path.join(artifactBase, "gateway-tls-pinning.log"), "utf8"),
+    ).toBe("pass");
     const proof = JSON.parse(
       await fs.readFile(path.join(artifactBase, "gateway-tls-pinning-summary.json"), "utf8"),
     ) as {

--- a/test/e2e/qa-lab/runtime/gateway-tls-pinning.ts
+++ b/test/e2e/qa-lab/runtime/gateway-tls-pinning.ts
@@ -3,9 +3,10 @@ import fs from "node:fs/promises";
 import net from "node:net";
 import os from "node:os";
 import path from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
 import tls from "node:tls";
 import { pathToFileURL } from "node:url";
-import { GatewayClient } from "@openclaw/gateway-client";
+import { GatewayClient, GatewayClientRequestError } from "@openclaw/gateway-client";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import {
   QA_EVIDENCE_FILENAME,
@@ -13,10 +14,12 @@ import {
 } from "../../../../extensions/qa-lab/api.js";
 import { normalizeTlsFingerprint } from "../../../../packages/gateway-client/src/client-address-utils.js";
 import { clearConfigCache, clearRuntimeConfigSnapshot } from "../../../../src/config/config.js";
+import { createConfiguredGatewayLocalProbe } from "../../../../src/gateway/local-http-probe.js";
 import { startGatewayServer } from "../../../../src/gateway/server.js";
 import { GATEWAY_STARTUP_MUTATED_ENV_KEYS } from "../../../../src/gateway/test-helpers.env.js";
 import { formatErrorMessage } from "../../../../src/infra/errors.js";
 import { loadGatewayTlsServerRuntime } from "../../../../src/infra/tls/gateway.js";
+import { flushLogger, resetLogger } from "../../../../src/logging/logger.js";
 import { createDeferred } from "../../../helpers/promise.js";
 import { createQaScriptEvidenceWriter } from "./script-evidence.js";
 
@@ -56,6 +59,12 @@ export type GatewayTlsPinningProof = {
   peerFingerprint: string;
   wrongPinFailure: string;
   wrongPinHelloObserved: boolean;
+  renewedFingerprint: string;
+  retainedConnection: boolean;
+  siblingListeners: number;
+  rejectedPartialRenewal: boolean;
+  reloadOffPreservedCertificate: boolean;
+  symlinkRenewal: boolean;
 };
 
 function parseOptions(argv: readonly string[]): ProducerOptions {
@@ -117,6 +126,11 @@ async function writeDiscoveryProbePlugin(
 module.exports = {
   id: ${JSON.stringify(DISCOVERY_PLUGIN_ID)},
   register(api) {
+    api.registerGatewayMethod("tls-discovery-proof.inspect", async ({ params, context, respond }) => {
+      const portal = params.portal ? await context.portalService.open({ targetPort: params.portal }) : undefined;
+      const sandboxPort = params.sandbox ? await context.ensureSandboxHostPort() : undefined;
+      respond(true, { fingerprint: context.gatewayTlsFingerprint, portalPort: portal?.listenPort, sandboxPort });
+    }, { scope: "operator.admin" });
     api.registerGatewayDiscoveryService({
       id: ${JSON.stringify(DISCOVERY_PLUGIN_ID)},
       advertise(context) {
@@ -215,22 +229,50 @@ function withTimeout<T>(promise: Promise<T>, label: string): Promise<T> {
   });
 }
 
-async function connectWithExactPin(url: string, tlsFingerprint: string): Promise<boolean> {
+async function withExactPin<T>(
+  url: string,
+  tlsFingerprint: string,
+  run: (client: GatewayClient) => Promise<T>,
+): Promise<T> {
   const hello = createDeferred<void>();
+  let hellos = 0;
+  let closes = 0;
   const client = new GatewayClient({
     url,
     tlsFingerprint,
     onConnectError: hello.reject,
-    onHelloOk: () => hello.resolve(),
+    onHelloOk: () => {
+      hellos += 1;
+      hello.resolve();
+    },
+    onClose: () => {
+      closes += 1;
+    },
   });
   try {
     client.start();
     await withTimeout(hello.promise, "Gateway exact-pin hello");
-    const health = await client.request("health", {});
-    return health !== null && typeof health === "object";
+    const result = await run(client);
+    if (hellos !== 1 || closes !== 0) {
+      throw new Error("TLS renewal replaced the retained Gateway connection");
+    }
+    return result;
   } finally {
     await client.stopAndWait().catch(() => undefined);
   }
+}
+
+async function waitForRenewalFact<T>(
+  read: () => Promise<T | undefined>,
+  label: string,
+): Promise<T> {
+  const deadline = Date.now() + CONNECTION_TIMEOUT_MS;
+  do {
+    const value = await read();
+    if (value !== undefined) return value;
+    await delay(100);
+  } while (Date.now() < deadline);
+  throw new Error(`TLS renewal proof did not observe ${label}`);
 }
 
 async function connectWithWrongPin(
@@ -293,6 +335,9 @@ export async function runGatewayTlsPinningProof(): Promise<GatewayTlsPinningProo
   const keyPath = path.join(runtimeRoot, "tls", "gateway-key.pem");
   const pluginDir = path.join(runtimeRoot, "discovery-plugin");
   const advertisementPath = path.join(runtimeRoot, "gateway-discovery-advertisement.json");
+  const gatewayLogPath = path.join(runtimeRoot, "gateway.log");
+  // Windows symlink creation requires host privileges unrelated to Gateway TLS.
+  const symlinkRenewal = process.platform !== "win32";
   let server: Awaited<ReturnType<typeof startGatewayServer>> | undefined;
 
   try {
@@ -317,17 +362,29 @@ export async function runGatewayTlsPinningProof(): Promise<GatewayTlsPinningProo
     const preparedTls = await loadGatewayTlsServerRuntime({
       enabled: true,
       autoGenerate: true,
-      certPath,
-      keyPath,
+      certPath: symlinkRenewal ? path.join(runtimeRoot, "initial", "cert.pem") : certPath,
+      keyPath: symlinkRenewal ? path.join(runtimeRoot, "initial", "key.pem") : keyPath,
     });
-    if (!preparedTls.enabled || !preparedTls.fingerprintSha256) {
+    if (
+      !preparedTls.enabled ||
+      !preparedTls.fingerprintSha256 ||
+      !preparedTls.certPath ||
+      !preparedTls.keyPath
+    ) {
       throw new Error(preparedTls.error ?? "Gateway TLS runtime did not expose a fingerprint");
+    }
+    if (symlinkRenewal) {
+      await fs.mkdir(path.dirname(certPath), { recursive: true });
+      await fs.symlink(preparedTls.certPath, certPath);
+      await fs.symlink(preparedTls.keyPath, keyPath);
     }
     await fs.mkdir(stateDir, { recursive: true });
     await fs.writeFile(
       configPath,
       `${JSON.stringify(
         {
+          logging: { file: gatewayLogPath, level: "info" },
+          agents: { defaults: { model: { primary: "openai/gpt-5.6-luna" } } },
           gateway: {
             auth: { mode: "none" },
             bind: "loopback",
@@ -359,23 +416,201 @@ export async function runGatewayTlsPinningProof(): Promise<GatewayTlsPinningProo
       sidecarStartup: "defer",
     });
     const url = `wss://127.0.0.1:${port}`;
+    const localProbe = createConfiguredGatewayLocalProbe({
+      gateway: { tls: { enabled: true, certPath, keyPath } },
+    });
+    const probeHealth = () =>
+      localProbe.requestHttp({
+        host: "127.0.0.1",
+        port,
+        pathname: "/healthz",
+        timeoutMs: 1000,
+      });
+    if ((await probeHealth())?.statusCode !== 200) {
+      throw new Error("Initial local TLS health probe failed");
+    }
     const advertisedFingerprint = await readAdvertisedFingerprint(advertisementPath);
     const peerFingerprint = await waitForPeerFingerprint(port);
     if (peerFingerprint !== advertisedFingerprint) {
       throw new Error("Gateway advertised TLS fingerprint did not match the live peer certificate");
     }
 
-    const healthResponded = await connectWithExactPin(url, advertisedFingerprint);
-    const wrongPin = `${advertisedFingerprint.slice(0, -1)}${
-      advertisedFingerprint.endsWith("0") ? "1" : "0"
-    }`;
-    const wrongPinResult = await connectWithWrongPin(url, wrongPin);
+    const replacement = await loadGatewayTlsServerRuntime({
+      enabled: true,
+      certPath: path.join(runtimeRoot, "replacement", "cert.pem"),
+      keyPath: path.join(runtimeRoot, "replacement", "key.pem"),
+    });
+    if (!replacement.enabled || !replacement.certPath || !replacement.keyPath) {
+      throw new Error(replacement.error ?? "Failed to prepare renewal certificate");
+    }
+    const nextCert = await fs.readFile(replacement.certPath);
+    const nextKey = await fs.readFile(replacement.keyPath);
+    const renewal = await withExactPin(url, advertisedFingerprint, async (client) => {
+      const inspect = (params: { portal?: number; sandbox?: boolean } = {}) =>
+        client.request<{ fingerprint: string; portalPort?: number; sandboxPort?: number }>(
+          "tls-discovery-proof.inspect",
+          params,
+        );
+      const existing = await inspect({ portal: await getFreePort() });
+      if (!existing.portalPort || existing.fingerprint !== advertisedFingerprint) {
+        throw new Error("Initial portal or enrollment fingerprint is missing");
+      }
+      await fs.writeFile(certPath, nextCert);
+      await waitForRenewalFact(async () => {
+        const log = await fs.readFile(gatewayLogPath, "utf8");
+        return log.includes("TLS renewal failed; keeping accepted material") ? true : undefined;
+      }, "rejection of the incomplete cert/key replacement");
+      for (const listener of [port, existing.portalPort]) {
+        if ((await waitForPeerFingerprint(listener)) !== advertisedFingerprint) {
+          throw new Error("An incomplete renewal changed an accepted TLS listener");
+        }
+      }
+      if (
+        (await inspect()).fingerprint !== advertisedFingerprint ||
+        (await readAdvertisedFingerprint(advertisementPath)) !== advertisedFingerprint
+      ) {
+        throw new Error("An incomplete renewal changed enrollment or discovery");
+      }
+      await fs.writeFile(keyPath, nextKey);
+      const renewedFingerprint = await waitForRenewalFact(async () => {
+        const fingerprint = await waitForPeerFingerprint(port);
+        return fingerprint === replacement.fingerprintSha256 ? fingerprint : undefined;
+      }, "the renewed listener certificate");
+      await waitForRenewalFact(
+        async () =>
+          (await readAdvertisedFingerprint(advertisementPath)) === renewedFingerprint
+            ? true
+            : undefined,
+        "the renewed discovery advertisement",
+      );
+      const later = await inspect({ portal: await getFreePort(), sandbox: true });
+      if (!later.portalPort || !later.sandboxPort || later.fingerprint !== renewedFingerprint) {
+        throw new Error("Renewal left stale enrollment or future listener material");
+      }
+      for (const listener of [existing.portalPort, later.portalPort, later.sandboxPort]) {
+        if ((await waitForPeerFingerprint(listener)) !== renewedFingerprint) {
+          throw new Error("A sibling TLS listener kept the old certificate");
+        }
+      }
+      const setReloadMode = async (mode: "hybrid" | "off") => {
+        const snapshot = await client.request<{ hash: string }>("config.get", {});
+        try {
+          await client.request("config.patch", {
+            baseHash: snapshot.hash,
+            raw: JSON.stringify({ gateway: { reload: { mode } } }),
+          });
+        } catch (error) {
+          // Off is persisted source policy; the RPC correctly reports no runtime apply.
+          if (
+            mode !== "off" ||
+            !(error instanceof GatewayClientRequestError) ||
+            error.code !== "UNAVAILABLE" ||
+            !error.message.includes("persisted but was not applied")
+          ) {
+            throw error;
+          }
+        }
+      };
+      const nextPair = await loadGatewayTlsServerRuntime({
+        enabled: true,
+        certPath: path.join(runtimeRoot, "paused", "cert.pem"),
+        keyPath: path.join(runtimeRoot, "paused", "key.pem"),
+      });
+      if (!nextPair.enabled || !nextPair.certPath || !nextPair.keyPath) {
+        throw new Error(nextPair.error ?? "Failed to prepare paused renewal");
+      }
+      await setReloadMode("off");
+      await waitForRenewalFact(
+        async () =>
+          (await fs.readFile(gatewayLogPath, "utf8")).includes("TLS renewal deferred")
+            ? true
+            : undefined,
+        "accepted reload-off policy",
+      );
+      await flushLogger();
+      const pausedLogSize = (await fs.readFile(gatewayLogPath)).length;
+      await fs.copyFile(nextPair.certPath, certPath);
+      await fs.copyFile(nextPair.keyPath, keyPath);
+      await waitForRenewalFact(async () => {
+        const laterLog = (await fs.readFile(gatewayLogPath)).subarray(pausedLogSize).toString();
+        return laterLog.includes("TLS renewal deferred") ? true : undefined;
+      }, "the paused owner's certificate observation");
+      if ((await waitForPeerFingerprint(port)) !== renewedFingerprint) {
+        throw new Error("TLS certificate changed while automatic reload was off");
+      }
+      await setReloadMode("hybrid");
+      const resumedFingerprint = await waitForRenewalFact(async () => {
+        const fingerprint = await waitForPeerFingerprint(port);
+        return fingerprint === nextPair.fingerprintSha256 ? fingerprint : undefined;
+      }, "renewal on re-enable without another certificate write");
+      for (const listener of [existing.portalPort, later.portalPort, later.sandboxPort]) {
+        if ((await waitForPeerFingerprint(listener)) !== resumedFingerprint) {
+          throw new Error("An existing HTTPS sibling missed the resumed renewal");
+        }
+      }
+      await waitForRenewalFact(
+        async () =>
+          (await readAdvertisedFingerprint(advertisementPath)) === resumedFingerprint
+            ? true
+            : undefined,
+        "the resumed discovery fingerprint",
+      );
+      let finalFingerprint = resumedFingerprint;
+      if (symlinkRenewal) {
+        const retargeted = await loadGatewayTlsServerRuntime({
+          enabled: true,
+          certPath: path.join(runtimeRoot, "retargeted", "cert.pem"),
+          keyPath: path.join(runtimeRoot, "retargeted", "key.pem"),
+        });
+        if (!retargeted.enabled || !retargeted.certPath || !retargeted.keyPath) {
+          throw new Error(retargeted.error ?? "Failed to prepare symlink renewal");
+        }
+        await fs.symlink(retargeted.certPath, `${certPath}.next`);
+        await fs.symlink(retargeted.keyPath, `${keyPath}.next`);
+        // Retain the old target files, as certificate managers do across renewals.
+        await fs.rename(`${certPath}.next`, certPath);
+        await fs.rename(`${keyPath}.next`, keyPath);
+        finalFingerprint = await waitForRenewalFact(async () => {
+          const fingerprint = await waitForPeerFingerprint(port);
+          return fingerprint === retargeted.fingerprintSha256 ? fingerprint : undefined;
+        }, "the certificate after atomic symlink retargeting");
+        for (const listener of [existing.portalPort, later.portalPort, later.sandboxPort]) {
+          if ((await waitForPeerFingerprint(listener)) !== finalFingerprint) {
+            throw new Error("An HTTPS sibling missed symlink renewal");
+          }
+        }
+        await waitForRenewalFact(
+          async () =>
+            (await readAdvertisedFingerprint(advertisementPath)) === finalFingerprint
+              ? true
+              : undefined,
+          "discovery after symlink renewal",
+        );
+      }
+      const health = await client.request("health", {});
+      if ((await localProbe.resolveWebSocketTarget(port))?.tlsFingerprint !== finalFingerprint) {
+        throw new Error("Retained local probe returned its startup certificate pin after renewal");
+      }
+      if ((await probeHealth())?.statusCode !== 200) {
+        throw new Error("Retained local health probe kept its old certificate pin after renewal");
+      }
+      return {
+        renewedFingerprint: finalFingerprint,
+        retainedConnection: true,
+        siblingListeners: 3,
+        rejectedPartialRenewal: true,
+        reloadOffPreservedCertificate: true,
+        symlinkRenewal,
+        healthResponded: health !== null && typeof health === "object",
+      };
+    });
+    const wrongPinResult = await connectWithWrongPin(url, advertisedFingerprint);
     const cleartextMismatch = await proveCleartextMismatch(port, advertisedFingerprint);
 
     return {
       advertisedFingerprint,
       cleartextMismatch,
-      healthResponded,
+      ...renewal,
       peerFingerprint,
       wrongPinFailure: wrongPinResult.error,
       wrongPinHelloObserved: wrongPinResult.helloObserved,
@@ -385,6 +620,8 @@ export async function runGatewayTlsPinningProof(): Promise<GatewayTlsPinningProo
     clearConfigCache();
     clearRuntimeConfigSnapshot();
     restoreEnvironment();
+    await flushLogger();
+    resetLogger();
     await fs.rm(runtimeRoot, { force: true, recursive: true });
   }
 }


### PR DESCRIPTION
## What Problem This Solves

Replacing certificate files previously left the running Gateway serving its startup certificate until restart. Retained local probes also cached the original pin and unnecessarily loaded server-private key material. Simply reading the newest public certificate is insufficient: files can change before a listener accepts them, making a healthy Gateway fail its probes during incomplete or paused renewal.

## Why This Change Was Made

The TLS lifecycle observes only the running Gateway's accepted certificate/key/CA paths, including atomic symlink replacements. It validates complete material before updating the existing HTTPS listener collection, preserves its shared options for future portal/sandbox listeners, and publishes the served fingerprint through discovery and request context. Invalid material leaves the accepted certificate serving. Accepted reload-off policy pauses renewal; re-enabling reconciles files changed while paused. Shutdown, disabling, and superseding an observation fence pending work.

HTTP and WebSocket probes share public-certificate inspection and a fresh pinned health request. A bounded endpoint-specific cache retains only a successfully verified serving pin alongside the current configured certificate. Ordered certificate observations prevent concurrent old and new responses from losing the replacement pin. The startup-only cache and server-private loader path are removed; cancellation remains caller-owned.

## User Impact

Renewal preserves established Gateway connections and updates existing and future HTTPS siblings. A retained probe tolerates a deferred replacement when it previously verified the still-serving certificate. A cold probe or one that missed an intermediate renewal cannot infer an unknown old certificate and remains fail-closed. Saved remote pins remain operator-controlled; update the configured fingerprint before reconnecting to a renewed certificate. TLS enablement, configured paths, and listener topology retain their restart boundary. No new settings, protocol fields, persistence, dependencies, or competing listener registry.

Review disposition: retain the documented exact-pin contract. Automatic renewal intentionally changes the fingerprint required on a later remote reconnect; saved remote pins are never silently rewritten or loosened. The old-pin rejection and updated-pin reconnection scenarios cover this compatibility tradeoff.

## Evidence

Final clean Linux proof tested **`b59a26fc93180dd6fe6f3fbdd1877c66997e6b40`** using `blacksmith-testbox`, lease `tbx_01m2bgspfh916c1pac2q9w62rd`, [run 34713695564](https://github.com/openclaw/openclaw/actions/runs/34713695564), Node 24.19.0 and pnpm 12.3.4. All eight command phases and the overall invocation exited **0**:

- Full `pnpm build`: passed in 212 seconds; `dist/build-info.json` records the exact candidate.
- Core, Gateway-root test, Gateway-server test, and root/E2E type checks: passed.
- Typed lint covering 14 production, fixture, and QA producer files: passed.
- 49 focused probe, supervisor, restart, and real HTTPS concurrency tests: passed.
- Expanded real Gateway TLS producer: passed in 20 seconds; Gateway shutdown completed cleanly in 17 ms.

The live scenario verifies three renewals, one retained pinned WSS connection, existing/new portals, lazy/existing sandbox listeners, rejected partial pairs, atomic certificate symlink retargeting, served/discovery/request-context fingerprints, reload off/on, retained HTTP and WSS health through acceptance, old-pin rejection, successful reconnection with an updated configured remote pin, and rejection of unknown cold/missed-generation pins. These are real Gateway/TLS sockets with synthetic plugin data; no live vendor or model-provider claim is made.

Before repair, real Gateway reproductions captured stale serving certificates, stale local-probe pins, missed symlink replacements, and four deferred-probe failures across HTTP/WSS and partial/paused renewal. An independent review also found concurrent old responses could suppress a verified replacement. Four real HTTPS cases cover warm/cold caches and both response completion orders; both old-first cases failed before the ordering fix and all four now pass. Independent P0–P2 review is clean after these repairs.

Source tree `48f83e9c651369342e5ef2aa87756348efead54d` stayed clean and unchanged before/after; the materialized carrier was `5b58fce5b0ee687c0778875b9f91a47f12c8b306`. Evidence archive: **20,570 bytes**, SHA-256 **`3fdfc6c303cd271026efe112c0d8033d33700616ee7e70aa8ef01aa04c08abce`**. It contains source identities, build stamp, per-phase exits, focused test results, and the live summary/log. The lease is stopped and verified completed.

The earlier `ec13d611` combined invocation exited 1 for fixture typing and callback lint even though its narrower live scenario passed; those issues and subsequent stale mock/braces failures are fixed. Final proof above supersedes that limited result. An unrelated invalid-update child-exit timeout passed unchanged on the next CI run. The independently verified baseline QA scenario-name mismatch was repaired on main by #146323.

Final-head [CI 34713661035](https://github.com/openclaw/openclaw/actions/runs/34713661035) completed successfully on `b59a26fc93180dd6fe6f3fbdd1877c66997e6b40`: 119 jobs succeeded, 15 were skipped, and none failed.

Production **+240/−56 = +184** lines; tests/support **+751/−44 = +707**; docs **+28**; QA catalog **+6**. Necessary production growth provides TLS observation lifetime and securely verified probe identity across renewal, while reusing transport, discovery, config acceptance, and shutdown owners.
