### PR TITLE
perf(cli): reuse PowerShell choice text across aliases

### DIFF
--- a/src/cli/completion-cli.ts
+++ b/src/cli/completion-cli.ts
@@ -454,15 +454,14 @@ ${commandPathCases}
   const rootBody = completionBodies.join("");
   const choiceCompletion = [root, ...contexts]
     .filter(({ valueChoices }) => valueChoices.length > 0)
-    .flatMap(({ pathVariants, valueChoices }) =>
-      pathVariants.map((pathSegments) => {
-        const optionChoiceCases = valueChoices
-          .map(
-            ({
-              flags,
-              choices,
-              requiresValue,
-            }) => `        if ($choiceFlag -in ${formatPowerShellArray(flags)}) {
+    .flatMap(({ pathVariants, valueChoices }) => {
+      const optionChoiceCases = valueChoices
+        .map(
+          ({
+            flags,
+            choices,
+            requiresValue,
+          }) => `        if ($choiceFlag -in ${formatPowerShellArray(flags)}) {
             $matchingChoices = @(${formatPowerShellArray(choices)} | Where-Object {
                 $_.StartsWith($choicePrefix, [StringComparison]::OrdinalIgnoreCase)
             })
@@ -479,13 +478,16 @@ ${commandPathCases}
                 return
             }
         }`,
-          )
-          .join("\n");
-        return `    if ($commandPath -eq '${pathSegments.join(" ").replaceAll("'", "''")}') {
+        )
+        .join("\n");
+      return pathVariants.map(
+        (
+          pathSegments,
+        ) => `    if ($commandPath -eq '${pathSegments.join(" ").replaceAll("'", "''")}') {
 ${optionChoiceCases}
-    }`;
-      }),
-    )
+    }`,
+      );
+    })
     .join("\n");
 
   return `


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled.

</details>

## What Problem This Solves

Generating PowerShell completions repeats the same option-choice text for every alias spelling of a command path.

## Why This Change Was Made

Build each command context's choice text once and reuse it for its alias paths. Generated scripts retain choice ordering, escaping, inherited options, and optional-value behavior.

## User Impact

PowerShell completion generation does less repeated string construction. Completion behavior and generated scripts are unchanged.

## Evidence

A separate PowerShell-only comparison exercised seven command-tree cases across all four shells. All 28 complete script/tree outputs matched over four passes and 2,912 generator calls. Timing varied substantially in unchanged controls, and the first baseline process (B1) took about twice as long as the later processes, so no causal speedup percentage is claimed. In reverse order, whole-child user CPU increased 0.57% and observed process-tree peak RSS increased 12.29%.

The earlier combined Fish change was rejected and removed entirely; its timings are not evidence for this candidate. Benchmark children closed, source was restored, the worktree was removed, and the Testbox was independently verified stopped.

Oxfmt 0.66, exact template-byte equivalence, 25 selected small guards, and fresh P2 review passed. The three existing completion test files reported 66 passed, 99 skipped, and zero failed; missing PowerShell/Fish executables leave real-shell coverage unproven. Local core typechecking exceeded the fixed 6 GiB process-tree RSS cap and closed cleanly. Core production/test typechecks (including the core-test tail) and type-aware core lint remain required exact-head hosted CI obligations before landing.


Exact-head hosted follow-up: [CI 34709606789](https://github.com/openclaw/openclaw/actions/runs/34709606789) completed successfully at attempt 2 on unchanged bc19aead. Core production types, all core-test stripes including the fifth-stripe tail, and type-aware core lint passed through their actual hosted owners. One authorized retry followed a cancelled security job with no acquired runner or executed steps; its unavailable log remains an explicit evidence gap. The local 6 GiB typecheck failure is retained, not relabeled as a local pass.
