### PR TITLE
refactor(ai): remove redundant streaming JSON recovery

### DIFF
--- a/packages/ai/src/utils/json-parse.ts
+++ b/packages/ai/src/utils/json-parse.ts
@@ -145,11 +145,7 @@ export function parseStreamingJson(partialJson: string | undefined): Record<stri
     try {
       return asNonArrayRecord(partialParse(partialJson));
     } catch {
-      try {
-        return asNonArrayRecord(partialParse(repairJson(partialJson)));
-      } catch {
-        return {};
-      }
+      return {};
     }
   }
 }


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

Streaming argument parsing retains a final recovery stage whose successful values are discarded by the public object-returning contract. It repeats string repair and partial parsing after the useful recovery paths have finished.

## Why This Change Was Made

Remove only that final repaired-partial-parse stage (four production lines). The first strict repaired parse and second raw partial parse remain unchanged. With the pinned partial-json defaults, malformed top-level objects already return their accumulated record; other top-level forms cannot become a non-array record through string-literal repair. The last stage can run, but its recovered primitive/array result becomes the same empty object.

## User Impact

The primitive-string/undefined API retains its existing output shape, Windows/Unicode/control escape handling, and partial-object behavior. Preview scheduling and authoritative terminal parsing are untouched. No boxed String or modified-built-in contract is claimed. This is a small maintainer-requested cleanup, not a hot-object speedup claim; no configuration, update, runtime loading, or storage behavior changes.

## Evidence

The [isolated Linux/Node 24.19.0 proof](https://github.com/openclaw/openclaw/actions/runs/34707836668) at `0639e2132182a9096346da6c4e36e04549331cf9` completed 1,574 calls to the actual exported parser. Every UTF-16 prefix of 32 strings plus explicit third-stage and expected-output controls produced 787 matching complete record-graph pairs. All four true third-stage controls per variant first failed strict repaired parsing and raw partial parsing, recovered only a primitive string at stage three, and still returned an empty public record.

Existing tests passed 18 cases: all 15 parser utility cases, the selected Radius SDK preview/terminal control, and both real loopback Anthropic terminal repair/rejection controls. Fifteen other Radius assertions were unselected, not counted as passing. All 14 native receipts closed with joined monitors; baseline restoration, normal worktree removal, exact lease completion, and capsule removal were verified. The proof has no timing threshold or performance claim.

Author source at `92565ebfce49843dda27a181c707559c761679d1` is byte-identical to the proved candidate. Matching Oxfmt 0.66 and fresh managed Codex P2 review passed. All 24 actual selected small guards passed; all 30 local native receipts closed with joined monitors and verified output hashes under unchanged 300-second/6-GiB/64-process limits. The valid 18-test remote proof was retained without a redundant rerun. The earlier low-disk hold occurred before any small guard launched; it remains recorded.

The three deferred broad obligations passed in the exact-head hosted run: `check-prod-types` covers `tsgo:core`; `check-test-types-core-1`, `check-test-types-core-2`, and `check-test-types` cover all five core test-type stripes plus the extensions/scripts/root tail; `check-lint-core-1` and `check-lint-core-2` cover all five type-aware core lint stripes. This is the observed hosted coverage, not a claim of a local full `pnpm lint` run.

## CI failure, investigation, and one unchanged retry

[Attempt 1](https://github.com/openclaw/openclaw/actions/runs/34709747742/attempts/1) failed in `checks-node-compact-small-16`: `keeps rejected update arguments from touching legacy state` emitted the expected invalid-timeout error and JSON, but its actual CLI child hit `spawnSync` ETIMEDOUT at the unchanged 60-second limit (test elapsed: 60.080 seconds). The seven-file group had 274 passing cases and one failure; the aggregate gate consequently failed. Its actual checkout was `82b82024bf427988901cdccff3d88c6eb9eb6a74`, merging this unchanged PR head into `937e3c9e4804112a9b96950a5ce78fd9cb993c00`. Source qualification confirms composition with the already-landed JSON suffix-truncation change preserves the raw second stage and first-token proof above.

The same test, argv, and 60-second timeout symptom occurred in [earlier CI](https://github.com/openclaw/openclaw/actions/runs/34691516626/attempts/1) at exact checkout `6fb7a7317560dd2445d0f7f279bd34bfc84dc460`, which still contained the third parse stage. That case took 60.076 seconds; the same checkout's second attempt passed all 275 cases, with this case taking 1.247 seconds. The older failure did not retain child stdout/stderr, so the same underlying cause or post-report stall is not established. An earlier instrumented baseline exceeded its 64-process envelope before target reach and remains inconclusive.

A separate [focused instrumented diagnostic](https://github.com/openclaw/openclaw/actions/runs/34712997780) on the current exact CI checkout passed all 18 cases in this test file, retaining their in-file order. Rejected update and repair children exited with status 1 and complete expected output in 492.735 and 524.869 ms. It did not replay the original seven-file worker/cache context and does not exonerate the candidate or identify the timeout's cause. Source/build binding and cleanup were verified.

After that investigation, one narrow retry of the original failed job and GitHub-managed dependents was dispatched as [attempt 2](https://github.com/openclaw/openclaw/actions/runs/34709747742/attempts/2), at unchanged PR head `5c8a27e463dc260e2ea8bec14b5fd12bb83421dc`. Attempt 2 completed successfully. The retry log confirms the same actual checkout and seven-file group: all 275 cases passed, including rejected update in 900 ms and rejected repair in 985 ms. The later groups added six passing cases and one skipped case, and the aggregate CI gate passed. Only the failed test job and aggregate gate executed again; earlier successful jobs were retained. No source, workflow, assertion, timeout, or resource-cap changes were made; the timeout is not claimed fixed or proven unrelated.
