### PR TITLE
improve(skills): share binary probes within status reports

### DIFF
--- a/src/skills/discovery/status.test.ts
+++ b/src/skills/discovery/status.test.ts
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import { withEnvAsync } from "../../test-utils/env.js";
 import { readLocalSkillCardContentSync } from "../lifecycle/clawhub.js";
 import { createCanonicalFixtureSkill } from "../test-support/test-helpers.js";
 import type { SkillEntry } from "../types.js";
@@ -13,6 +14,42 @@ type SkillStatus = ReturnType<typeof buildWorkspaceSkillStatus>["skills"][number
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 describe("buildWorkspaceSkillStatus", () => {
+  it("refreshes dependency eligibility and installer preference after a binary is installed", async () => {
+    const workspaceDir = tempDirs.make("openclaw-skill-status-");
+    const entries = ["first", "second"].map((name) =>
+      createEntry(name, {
+        baseDir: workspaceDir,
+        metadata: {
+          requires: { bins: ["brew"] },
+          install: [
+            { id: "brew", kind: "brew", formula: "fixture-tool" },
+            { id: "node", kind: "node", package: "fixture-tool" },
+          ],
+        },
+      }),
+    );
+    await withEnvAsync({ PATH: workspaceDir, PATHEXT: ".CMD" }, async () => {
+      const options = { entries, config: { skills: { install: { preferBrew: true } } } };
+      const before = buildWorkspaceSkillStatus(workspaceDir, options);
+      for (const skill of before.skills) {
+        expect(skill.eligible).toBe(false);
+        expect(skill.missing.bins).toEqual(["brew"]);
+        expect(skill.install.map((option) => option.id)).toEqual(["node"]);
+      }
+      await fs.writeFile(
+        path.join(workspaceDir, process.platform === "win32" ? "brew.CMD" : "brew"),
+        "",
+        { mode: 0o755 },
+      );
+      const after = buildWorkspaceSkillStatus(workspaceDir, options);
+      for (const skill of after.skills) {
+        expect(skill.eligible).toBe(true);
+        expect(skill.missing.bins).toEqual([]);
+        expect(skill.install.map((option) => option.id)).toEqual(["brew"]);
+      }
+    });
+  });
+
   it("reports blank env requirements as missing", () => {
     const envName = "OPENCLAW_TEST_BLANK_SKILL_STATUS";
     const original = process.env[envName];

--- a/src/skills/discovery/status.ts
+++ b/src/skills/discovery/status.ts
@@ -81,11 +81,12 @@ export function resolveSkillStatusEntry<T extends Pick<SkillStatusEntry, "name" 
 function selectPreferredInstallSpec(
   install: SkillInstallSpec[],
   prefs: SkillsInstallPreferences,
+  hasLocalBin: typeof hasBinary,
 ): SkillInstallSpec | undefined {
   const findKind = (kind: SkillInstallSpec["kind"]) => install.find((spec) => spec.kind === kind);
 
   const brewSpec = findKind("brew");
-  const brewAvailable = brewSpec && hasBinary("brew");
+  const brewAvailable = brewSpec && hasLocalBin("brew");
   return (
     (prefs.preferBrew && brewAvailable ? brewSpec : undefined) ??
     findKind("uv") ??
@@ -104,6 +105,7 @@ function selectPreferredInstallSpec(
 function normalizeInstallOptions(
   entry: SkillEntry,
   prefs: SkillsInstallPreferences,
+  hasLocalBin: typeof hasBinary,
 ): SkillInstallOption[] {
   // If the skill is explicitly OS-scoped, don't surface install actions on unsupported platforms.
   // (Installers run locally; remote OS eligibility is handled separately.)
@@ -165,7 +167,7 @@ function normalizeInstallOptions(
     return options;
   }
 
-  const preferred = selectPreferredInstallSpec(filtered, prefs);
+  const preferred = selectPreferredInstallSpec(filtered, prefs, hasLocalBin);
   if (!preferred) {
     return [];
   }
@@ -176,6 +178,7 @@ function normalizeInstallOptions(
 type BuildSkillStatusContext = {
   config?: OpenClawConfig;
   prefs: SkillsInstallPreferences;
+  hasLocalBin: typeof hasBinary;
   eligibility?: SkillEligibilityContext;
   allowBundled: ReadonlySet<string> | undefined;
   agentSkillSet: ReadonlySet<string> | undefined;
@@ -208,7 +211,7 @@ function buildSkillStatus(entry: SkillEntry, context: BuildSkillStatusContext): 
     evaluateEntryRequirementsForCurrentPlatform({
       always,
       entry,
-      hasLocalBin: hasBinary,
+      hasLocalBin: context.hasLocalBin,
       remote: eligibility?.remote,
       isEnvSatisfied,
       isConfigSatisfied,
@@ -261,7 +264,7 @@ function buildSkillStatus(entry: SkillEntry, context: BuildSkillStatusContext): 
     requirements: required,
     missing,
     configChecks,
-    install: normalizeInstallOptions(entry, prefs),
+    install: normalizeInstallOptions(entry, prefs, context.hasLocalBin),
     ...(clawhub ? { clawhub } : {}),
     ...(skillCard ? { skillCard } : {}),
   };
@@ -316,6 +319,16 @@ export function buildWorkspaceSkillStatus(
       ? clawhubLockRead
       : readClawHubSkillsLockfileStatusSync(managedParentDir);
   const agentSkillSet = agentSkillFilter === undefined ? undefined : new Set(agentSkillFilter);
+  // Missing binaries may appear between reports; reuse probes only within this synchronous read.
+  const binaryAvailability = new Map<string, boolean>();
+  const hasLocalBin = (bin: string): boolean => {
+    let available = binaryAvailability.get(bin);
+    if (available === undefined) {
+      available = hasBinary(bin);
+      binaryAvailability.set(bin, available);
+    }
+    return available;
+  };
   return {
     workspaceDir,
     managedSkillsDir,
@@ -325,6 +338,7 @@ export function buildWorkspaceSkillStatus(
       buildSkillStatus(entry, {
         config: opts?.config,
         prefs,
+        hasLocalBin,
         eligibility: opts?.eligibility,
         allowBundled,
         agentSkillSet,


### PR DESCRIPTION
Related: #145679

## What Problem This Solves

Inspecting skill status can block while repeatedly checking the same missing dependencies, especially Homebrew when many skills offer a Homebrew installer.

## Why This Change Was Made

Reuse binary availability within one synchronous status report for both requirements and installer selection. Each report starts fresh, so an installed binary becomes visible on the next request. This keeps the existing successful-probe cache and status discovery owner intact.

## User Impact

Skill status spends less time checking missing dependencies while returning the same eligibility, missing requirements, and installer choices.

## Evidence

- Actual 50 bundled skills on Windows / Node 24.19, with isolated empty directories on PATH: median complete synchronous report time changed from 261 to 182 ms with 8 PATH entries, and 636 to 403 ms with 24. These are three measured samples per case after warmup; they exclude Gateway transport and watcher reconciliation.
- In that stock empty-PATH fixture, Homebrew filesystem probes dropped from 800 to 40 and 2,400 to 120: twenty PATH scans become one.
- Ten complete report comparisons and ten native baseline parity checks passed across stock and synthetic fixtures, including installing a real binary between reports. The original fails the external one-scan-per-report budget; the candidate passes it.
- Native status, workspace status, and remote skills tests: 42 passed, 2 existing platform skips. The added test protects freshness between reports and also passes on the baseline.
- Broader baseline installer testing exposed two unchanged POSIX path-literal assertions and a fixture cleanup EPERM on Windows; no expectations were changed.
- Selected production and test typechecks, type-aware lint, formatting and static guards passed. Three native export scans retain only findings reproduced exactly on the clean original revision: `canonicalProviderName` in scripts/full-tree and `listPackagedStaticExtensionAssetOutputs` in full-tree; production has zero entries.
- Independent P2 review completed clean with final source verification. Exact-head [CI run 34709780745, attempt 2](https://github.com/openclaw/openclaw/actions/runs/34709780745) passed for `a0e38d7b2214120d3fbbbfdb9f54fd0f03b7d558`.

- CI attempt 1 had one cancelled job before any step because a self-hosted runner was not acquired; the aggregate then failed. After completion, a failed-jobs-only rerun used the existing hosted fallback and passed on the unchanged head. Earlier failure and recovery receipts are retained.
