### PR TITLE
improve: avoid reading old plugin values during registration

### DIFF
--- a/src/plugin-state/plugin-state-store.kernel.ts
+++ b/src/plugin-state/plugin-state-store.kernel.ts
@@ -178,6 +178,34 @@ const pluginStateEntryQueries = new WeakMap<
   DatabaseSync,
   ReturnType<typeof prepareSqliteQuerySync<PluginStateEntryLookup, PluginStateRow>>
 >();
+const pluginStateEntryExistsQueries = new WeakMap<
+  DatabaseSync,
+  ReturnType<typeof prepareSqliteQuerySync<PluginStateEntryLookup, { entry_key: string }>>
+>();
+
+function hasPluginStateEntry(db: DatabaseSync, params: PluginStateEntryLookup): boolean {
+  let query = pluginStateEntryExistsQueries.get(db);
+  if (!query) {
+    query = prepareSqliteQuerySync<PluginStateEntryLookup, { entry_key: string }>(
+      db,
+      (parameter) => {
+        const pluginId = parameter((value) => value.pluginId);
+        const namespace = parameter((value) => value.namespace);
+        const key = parameter((value) => value.key);
+        const now = parameter((value) => value.now);
+        return getPluginStateKysely(db)
+          .selectFrom("plugin_state_entries")
+          .select("entry_key")
+          .where("plugin_id", "=", pluginId)
+          .where("namespace", "=", namespace)
+          .where("entry_key", "=", key)
+          .where((eb) => eb.or([eb("expires_at", "is", null), eb("expires_at", ">", now)]));
+      },
+    );
+    pluginStateEntryExistsQueries.set(db, query);
+  }
+  return query(params).rows.length !== 0;
+}
 
 export function selectPluginStateEntry(
   db: DatabaseSync,
@@ -656,17 +684,16 @@ export function registerPluginStateEntry(
       retention.sweepPending = deleted === PLUGIN_STATE_EXPIRY_BATCH_ROWS;
     }
   }
-  // Ordinary evicting writes enforce quotas after the upsert; they do not need
-  // to load the previous payload. Reject-new and batch counts still need existence.
+  // Quotas and batch counts need existence, never the previous JSON payload.
   const existing =
     retention || params.overflowPolicy === "reject-new"
-      ? selectPluginStateEntry(store.db, {
+      ? hasPluginStateEntry(store.db, {
           pluginId: params.pluginId,
           namespace: params.namespace,
           key: params.key,
           now,
         })
-      : undefined;
+      : false;
   if (!existing) {
     assertCanInsertPluginStateEntry({
       store,

--- a/src/plugin-state/plugin-state-store.prepared.test.ts
+++ b/src/plugin-state/plugin-state-store.prepared.test.ts
@@ -119,10 +119,14 @@ describe("plugin state prepared queries", () => {
     }
   });
 
-  it.each(["register", "registerIfAbsent"] as const)(
-    "reuses %s write and quota compilation with fresh bindings after reopening",
-    (operation) => {
-      const options = { namespace: "prepared-writes", maxEntries: 20 };
+  it.each([
+    ["register", "evict-oldest"],
+    ["register", "reject-new"],
+    ["registerIfAbsent", "evict-oldest"],
+  ] as const)(
+    "reuses %s %s write and quota compilation with fresh bindings after reopening",
+    (operation, overflowPolicy) => {
+      const options = { namespace: "prepared-writes", maxEntries: 20, overflowPolicy };
       const stores = [
         createPluginStateSyncKeyedStore<string>("discord", options),
         createPluginStateSyncKeyedStore<string>("telegram", options),


### PR DESCRIPTION
## What Problem This Solves

Overwriting large values in a plugin namespace using `reject-new`, or importing rows whose keys already exist, copies the old JSON value out of SQLite even though registration only needs to know whether the key is live.

## Why This Change Was Made

Use a connection-owned compiled existence query for those registration checks. Key, plugin, namespace, and expiry bindings remain fresh on every call. Operations that consume the previous value retain their full-row reader.

## User Impact

Large-value registration and repeated imports avoid an unnecessary payload allocation. Quota checks, expiry, transaction boundaries, stored values, import prefix recovery, and schema remain unchanged. Existing prepared-query coverage now includes `reject-new` across scopes and reopened connections.

## Evidence

Actual old/current owners on Node 26.8.2 / SQLite 3.53.4, with seven alternating timing blocks and synthetic canonical databases:

| Workload | Before | After |
| --- | ---: | ---: |
| Public overwrite, 1 MiB value | 6.24 ms | 5.44 ms |
| Eight-row import, 1 MiB values | 21.72 ms | 15.92 ms |
| Public overwrite, 1 MiB value, same physical database in both arms | 5.54 ms | 4.44 ms |

These are workload-specific measurements, not a general plugin API speedup. Small public writes had slower medians: the same-database 64-byte and 8 KiB cases were 3.28→3.47 ms and 3.09→3.23 ms. Full raw distributions are retained locally. Separate-state comparisons matched all persisted entry columns except invocation timestamps, and integrity checks passed.

- 61 plugin tests passed, three skipped, covering prepared bindings, imports, retention, expiry, and public operations.
- Core production and owning test type graphs, scoped type-aware lint, formatting, and diff checks passed.
- Independent P0–P2 review completed with no actionable findings.
