### PR TITLE
refactor: simplify reclaimed worker resume

### DIFF
--- a/src/gateway/server-worker-placement-resume.test.ts
+++ b/src/gateway/server-worker-placement-resume.test.ts
@@ -8,8 +8,6 @@ vi.mock("./worker-environments/workspace-sync-preflight.js", () => ({
   preflightWorkerWorkspace: workspace.preflight,
 }));
 
-import type { EmbeddedAgentRunResult } from "../agents/embedded-agent-runner/types.js";
-import { SessionManager } from "../agents/sessions/session-manager.js";
 import { upsertSessionEntryCore } from "../config/sessions/session-accessor.js";
 import { beginSessionWorkAdmission } from "../sessions/session-lifecycle-admission.js";
 import { createDeferredCore } from "../shared/deferred.js";
@@ -20,167 +18,100 @@ import { createHarness } from "./worker-environments/placement-dispatch-test-har
 import { createWorkerSessionPlacementStore } from "./worker-environments/placement-store.js";
 import * as support from "./worker-environments/service.test-support.js";
 
-async function createResumeHarness(executionMode: "worker-turn" | "remote-exec") {
-  const actual = await vi.importActual<
-    typeof import("./worker-environments/placement-dispatch.js")
-  >("./worker-environments/placement-dispatch.js");
-  runtimeFactoryMocks.createDispatch.mockImplementation(
-    actual.createWorkerPlacementDispatchService,
-  );
-  runtimeFactoryMocks.createDiskSpace.mockReturnValue({ read: vi.fn(), version: () => 0 });
-
-  const { root, stateDb, config } = support.testState;
-  const sessionTarget = {
-    agentId: REQUEST.agentId,
-    sessionId: REQUEST.sessionId,
-    sessionKey: REQUEST.sessionKey,
-    storePath: path.join(root, "sessions.sqlite"),
-  };
-  const runId = `resumed-${executionMode}-turn`;
-  const entry = {
-    sessionId: REQUEST.sessionId,
-    lifecycleRevision: "resume-generation",
-    activeWriterRunId: runId,
-    updatedAt: Date.now(),
-    worktree: { id: "resume-workspace", branch: "resume-workspace", repoRoot: root },
-  };
-  await upsertSessionEntryCore(sessionTarget, entry);
-  SessionManager.open(sessionTarget);
-  const target = {
-    ...sessionTarget,
-    canonicalKey: REQUEST.sessionKey,
-    store: { [REQUEST.sessionKey]: entry },
-    storeKeys: [REQUEST.sessionKey],
-  };
-  const worktree = { id: entry.worktree.id, ownerId: REQUEST.sessionKey, path: root };
-  moveDestinationMocks.getRuntimeConfig.mockReturnValue(config);
-  moveDestinationMocks.resolveGatewaySessionTarget.mockReturnValue(target);
-  moveDestinationMocks.resolveCanonicalSession.mockReturnValue(entry);
-  moveDestinationMocks.findManagedWorktree.mockReturnValue(worktree);
-  moveDestinationMocks.resolveExecutionMode.mockReturnValue(executionMode);
-  moveDestinationMocks.resolveSessionRuntime.mockReturnValue(
-    executionMode === "remote-exec" ? "codex" : "openclaw",
-  );
-  moveDestinationMocks.resolveSessionTarget.mockReturnValue({
-    config,
-    target,
-    entry,
-    worktree,
-    workspace: { kind: "local", path: root },
-  });
-
-  const placements = createWorkerSessionPlacementStore({ database: stateDb });
-  const previous = createHarness(stateDb, placements, { workspacePath: root });
-  const active = previous.placements.seedActive(2, executionMode);
-  if (active.state !== "active") {
-    throw new Error("Expected an active worker fixture");
-  }
-  const draining = placements.startDrain({
-    sessionId: active.sessionId,
-    environmentId: active.environmentId,
-    ownerEpoch: active.activeOwnerEpoch,
-    expectedGeneration: active.generation,
-  });
-  const reconciling = placements.startReconcile({
-    sessionId: active.sessionId,
-    environmentId: active.environmentId,
-    ownerEpoch: active.activeOwnerEpoch,
-    expectedGeneration: draining.generation,
-  });
-  const reclaimed = placements.transition({
-    sessionId: active.sessionId,
-    from: "reconciling",
-    to: "reclaimed",
-    expectedGeneration: reconciling.generation,
-  });
-  previous.markEnvironmentFailed();
-  const previousEnvironment = previous.environments.get(active.environmentId);
-  const replacement = createHarness(stateDb, placements, {
-    environmentGeneration: reclaimed.generation + 1,
-    workspacePath: root,
-  });
-  const environments = {
-    ...support.createService(support.createProvider()),
-    ...replacement.environments,
-    get: (environmentId: string) =>
-      environmentId === active.environmentId
-        ? previousEnvironment
-        : replacement.environments.get(environmentId),
-  };
-  const runtime = createGatewayWorkerPlacementRuntime({
-    placements,
-    environments,
-    gatewayNamespace: "gateway-resume-test",
-    warn: vi.fn(),
-    cancelSessionWork: vi.fn(async () => {}),
-    revokeSessionAuthority: vi.fn(),
-  });
-  const setupEntered = createDeferredCore();
-  const releaseSetup = createDeferredCore();
-  let setupSignal: AbortSignal | undefined;
-  workspace.preflight.mockImplementation(async ({ signal }: { signal?: AbortSignal }) => {
-    setupSignal = signal;
-    setupEntered.resolve();
-    await releaseSetup.promise;
-    signal?.throwIfAborted();
-  });
-  const controller = new AbortController();
-  const admission = await beginSessionWorkAdmission({
-    scope: sessionTarget.storePath,
-    identities: [REQUEST.sessionKey, REQUEST.sessionId],
-    assertAllowed: () => controller.signal.throwIfAborted(),
-    onInterrupt: (reason) => controller.abort(reason),
-  });
-  return {
-    root,
-    runId,
-    placements,
-    replacement,
-    controller,
-    admission,
-    setupEntered,
-    releaseSetup,
-    get setupSignal() {
-      return setupSignal;
-    },
-    run: (runLocal: () => Promise<EmbeddedAgentRunResult>, assertCurrent?: () => void) =>
-      admission.run(() =>
-        runtime.admissionProvider.executeTurn(
-          { ...REQUEST, runId },
-          {
-            ...REQUEST,
-            runId,
-            config,
-            sessionTarget,
-            sessionFile: REQUEST.sessionKey,
-            workspaceDir: root,
-            prompt: "Continue",
-            timeoutMs: 60_000,
-            abortSignal: controller.signal,
-          },
-          runLocal,
-          undefined,
-          assertCurrent,
-        ),
-      ),
-  };
-}
-
 describe("reclaimed worker automatic resume", () => {
   support.setupWorkerEnvironmentServiceSuite();
 
-  it("reprovisions under the waiting turn's admission and returns one remote-exec reply", async () => {
-    const fixture = await createResumeHarness("remote-exec");
-    const {
-      root,
-      runId,
+  it.each([
+    { executionMode: "remote-exec", outcome: "completed" },
+    { executionMode: "worker-turn", outcome: "stopped" },
+    { executionMode: "remote-exec", outcome: "stopped" },
+    { executionMode: "worker-turn", outcome: "superseded" },
+    { executionMode: "remote-exec", outcome: "superseded" },
+  ] as const)("resumes $executionMode until $outcome", async ({ executionMode, outcome }) => {
+    const actual = await vi.importActual<
+      typeof import("./worker-environments/placement-dispatch.js")
+    >("./worker-environments/placement-dispatch.js");
+    runtimeFactoryMocks.createDispatch.mockImplementation(
+      actual.createWorkerPlacementDispatchService,
+    );
+    runtimeFactoryMocks.createDiskSpace.mockReturnValue({ read: vi.fn(), version: () => 0 });
+
+    const { root, stateDb, config } = support.testState;
+    const runId = `resumed-${executionMode}-turn`;
+    const entry = {
+      sessionId: REQUEST.sessionId,
+      lifecycleRevision: "resume-generation",
+      activeWriterRunId: runId,
+      updatedAt: Date.now(),
+      worktree: { id: "resume-workspace", branch: "resume-workspace", repoRoot: root },
+    };
+    const target = {
+      ...REQUEST,
+      storePath: path.join(root, "sessions.sqlite"),
+      canonicalKey: REQUEST.sessionKey,
+      store: { [REQUEST.sessionKey]: entry },
+      storeKeys: [REQUEST.sessionKey],
+    };
+    await upsertSessionEntryCore(target, entry);
+    const worktree = { id: entry.worktree.id, ownerId: REQUEST.sessionKey, path: root };
+    moveDestinationMocks.getRuntimeConfig.mockReturnValue(config);
+    moveDestinationMocks.resolveGatewaySessionTarget.mockReturnValue(target);
+    moveDestinationMocks.resolveCanonicalSession.mockReturnValue(entry);
+    moveDestinationMocks.findManagedWorktree.mockReturnValue(worktree);
+    moveDestinationMocks.resolveExecutionMode.mockReturnValue(executionMode);
+    moveDestinationMocks.resolveSessionRuntime.mockReturnValue(
+      executionMode === "remote-exec" ? "codex" : "openclaw",
+    );
+    const targetOwner = await vi.importActual<
+      typeof import("./server-worker-placement-session-target.js")
+    >("./server-worker-placement-session-target.js");
+    moveDestinationMocks.resolveSessionTarget.mockImplementation(
+      targetOwner.resolveWorkerPlacementSessionTarget,
+    );
+
+    const placements = createWorkerSessionPlacementStore({ database: stateDb });
+    const previous = createHarness(stateDb, placements, { workspacePath: root });
+    const active = await previous.service.dispatch({ ...REQUEST, executionMode });
+    const placement = await previous.service.reclaim(REQUEST);
+    previous.markEnvironmentFailed();
+    const previousEnvironment = previous.environments.get(active.environmentId);
+    const replacement = createHarness(stateDb, placements, {
+      environmentGeneration: placement.generation + 1,
+      workspacePath: root,
+    });
+    const environments = {
+      ...support.createService(support.createProvider()),
+      ...replacement.environments,
+      get: (environmentId: string) =>
+        environmentId === active.environmentId
+          ? previousEnvironment
+          : replacement.environments.get(environmentId),
+    };
+    const runtime = createGatewayWorkerPlacementRuntime({
       placements,
-      replacement,
-      controller,
-      admission,
-      setupEntered,
-      releaseSetup,
-    } = fixture;
+      environments,
+      gatewayNamespace: "gateway-resume-test",
+      warn: vi.fn(),
+      cancelSessionWork: vi.fn(async () => {}),
+      revokeSessionAuthority: vi.fn(),
+    });
+    const setupEntered = createDeferredCore<AbortSignal | undefined>();
+    const releaseSetup = createDeferredCore();
+    workspace.preflight.mockImplementation(async ({ signal }: { signal?: AbortSignal }) => {
+      setupEntered.resolve(signal);
+      await releaseSetup.promise;
+      signal?.throwIfAborted();
+    });
+    const controller = new AbortController();
+    const admission = await beginSessionWorkAdmission({
+      scope: target.storePath,
+      identities: [REQUEST.sessionKey, REQUEST.sessionId],
+      assertAllowed: () => controller.signal.throwIfAborted(),
+      onInterrupt: (reason) => controller.abort(reason),
+    });
+
+    let current = true;
+    const termination = new Error(`Turn ${outcome}`);
     const runLocal = vi.fn(async () => {
       expect(controller.signal.aborted).toBe(false);
       expect(placements.get(REQUEST.sessionId)).toMatchObject({
@@ -190,12 +121,36 @@ describe("reclaimed worker automatic resume", () => {
       });
       return { payloads: [{ text: "The resumed workspace is ready." }], meta: { durationMs: 1 } };
     });
-    const pending = fixture.run(runLocal);
+    const pending = admission
+      .run(() =>
+        runtime.admissionProvider.executeTurn(
+          { ...REQUEST, runId },
+          {
+            ...REQUEST,
+            runId,
+            config,
+            sessionTarget: target,
+            sessionFile: REQUEST.sessionKey,
+            workspaceDir: root,
+            prompt: "Continue",
+            timeoutMs: 60_000,
+            abortSignal: controller.signal,
+          },
+          runLocal,
+          undefined,
+          () => {
+            if (!current) {
+              throw termination;
+            }
+          },
+        ),
+      )
+      .catch((error: unknown) => error);
     try {
-      await Promise.race([
+      const signal = await Promise.race([
         setupEntered.promise,
-        pending.then(() => {
-          throw new Error("Turn finished before replacement setup");
+        pending.then((result) => {
+          throw result;
         }),
       ]);
       expect(placements.get(REQUEST.sessionId)).toMatchObject({
@@ -203,77 +158,42 @@ describe("reclaimed worker automatic resume", () => {
         turnClaim: null,
       });
       expect(runLocal).not.toHaveBeenCalled();
+      if (outcome === "stopped") {
+        controller.abort(termination);
+        expect(signal?.aborted).toBe(true);
+      } else if (outcome === "superseded") {
+        current = false;
+      }
       releaseSetup.resolve();
-      await expect(pending).resolves.toMatchObject({
-        payloads: [{ text: "The resumed workspace is ready." }],
-      });
-      expect(runLocal).toHaveBeenCalledOnce();
-      expect(replacement.environments.createFromProfileSnapshot).toHaveBeenCalledOnce();
-      expect(placements.get(REQUEST.sessionId)).toMatchObject({
-        state: "active",
-        environmentId: replacement.ready.environmentId,
-        turnClaim: null,
-        workspaceBaseManifestRef: replacement.reconciledManifestRef,
-      });
-      expect(placements.listPendingWorkspaceResults()).toEqual([]);
-      expect(controller.signal.aborted).toBe(false);
+      if (outcome === "completed") {
+        expect(await pending).toMatchObject({
+          payloads: [{ text: "The resumed workspace is ready." }],
+        });
+        expect(runLocal).toHaveBeenCalledOnce();
+        expect(replacement.environments.createFromProfileSnapshot).toHaveBeenCalledOnce();
+        expect(placements.get(REQUEST.sessionId)).toMatchObject({
+          state: "active",
+          environmentId: replacement.ready.environmentId,
+          turnClaim: null,
+          workspaceBaseManifestRef: replacement.reconciledManifestRef,
+        });
+        expect(placements.listPendingWorkspaceResults()).toEqual([]);
+        expect(controller.signal.aborted).toBe(false);
+      } else {
+        expect(await pending).toBe(termination);
+        expect(replacement.environments.create).not.toHaveBeenCalled();
+        expect(replacement.environments.createFromProfileSnapshot).not.toHaveBeenCalled();
+        expect(runLocal).not.toHaveBeenCalled();
+        expect(placements.get(REQUEST.sessionId)).toMatchObject({
+          state: "reclaimed",
+          turnClaim: null,
+        });
+      }
     } finally {
       releaseSetup.resolve();
-      await pending.catch(() => {});
+      await pending;
       admission.release();
       closeOpenClawAgentDatabases(root);
     }
   });
-
-  it.each([
-    { executionMode: "worker-turn", outcome: "stopped" },
-    { executionMode: "remote-exec", outcome: "stopped" },
-    { executionMode: "worker-turn", outcome: "superseded" },
-    { executionMode: "remote-exec", outcome: "superseded" },
-  ] as const)(
-    "cancels $executionMode replacement setup when its waiting turn is $outcome",
-    async ({ executionMode, outcome }) => {
-      const fixture = await createResumeHarness(executionMode);
-      const { root, placements, replacement, controller, admission, setupEntered, releaseSetup } =
-        fixture;
-      let current = true;
-      const termination = new Error(`Turn ${outcome}`);
-      const runLocal = vi.fn(async () => ({ meta: { durationMs: 1 } }));
-      const pending = fixture
-        .run(runLocal, () => {
-          if (!current) {
-            throw termination;
-          }
-        })
-        .catch((error: unknown) => error);
-      try {
-        await Promise.race([
-          setupEntered.promise,
-          pending.then((result) => {
-            throw result;
-          }),
-        ]);
-        expect(placements.get(REQUEST.sessionId)?.state).toBe("reclaimed");
-        if (outcome === "stopped") {
-          controller.abort(termination);
-          expect(fixture.setupSignal?.aborted).toBe(true);
-        } else {
-          current = false;
-        }
-      } finally {
-        releaseSetup.resolve();
-        await pending;
-        admission.release();
-        closeOpenClawAgentDatabases(root);
-      }
-      expect(await pending).toBe(termination);
-      expect(replacement.environments.create).not.toHaveBeenCalled();
-      expect(replacement.environments.createFromProfileSnapshot).not.toHaveBeenCalled();
-      expect(runLocal).not.toHaveBeenCalled();
-      expect(placements.get(REQUEST.sessionId)).toMatchObject({
-        state: "reclaimed",
-        turnClaim: null,
-      });
-    },
-  );
 });

--- a/src/gateway/worker-environments/reclaimed-placement-redispatch.test.ts
+++ b/src/gateway/worker-environments/reclaimed-placement-redispatch.test.ts
@@ -1,173 +1,89 @@
 import { describe, expect, it, vi } from "vitest";
-import type { WorkerSessionPlacementRecord } from "./placement-record.js";
+import { ACTIVE_PLACEMENT } from "./placement-dispatch-coordinator.test-support.js";
+import { createDispatchEnvironmentFixtures } from "./placement-dispatch-test-fixtures.js";
 import { createReclaimedPlacementRedispatch } from "./reclaimed-placement-redispatch.js";
 
-type ReclaimedWorkerPlacement = Extract<WorkerSessionPlacementRecord, { state: "reclaimed" }>;
-
+const placement = { ...ACTIVE_PLACEMENT, state: "reclaimed" as const };
 const dispatchOptions = { assertCurrent: () => {} };
-
-const placement = {
-  state: "reclaimed",
-  sessionId: "session-1",
-  sessionKey: "agent:main:cloud-session",
-  agentId: "main",
-  environmentId: "worker:previous",
-  executionMode: "worker-turn",
-} as ReclaimedWorkerPlacement;
+const { ready } = createDispatchEnvironmentFixtures();
 
 describe("createReclaimedPlacementRedispatch", () => {
-  it("reuses the previous environment's exact profile snapshot for a fresh dispatch", async () => {
-    const active = { state: "active" } as Extract<
-      WorkerSessionPlacementRecord,
-      { state: "active" }
-    >;
-    const dispatch = vi.fn<Parameters<typeof createReclaimedPlacementRedispatch>[0]["dispatch"]>(
-      async () => active,
-    );
-    const redispatch = createReclaimedPlacementRedispatch({
-      environments: {
-        get: () =>
-          ({
-            profileId: "development",
-            providerId: "fake",
-            profileSnapshot: { machineClass: "large", settings: { region: "parent" } },
-          }) as never,
-      },
-      dispatch,
-    });
+  it.each([
+    { providerId: "fake", nodeDeviceId: null, executionMode: "worker-turn" },
+    { providerId: "device", nodeDeviceId: "paired-node", executionMode: "worker-turn" },
+    { providerId: "crabbox", nodeDeviceId: "retired-node", executionMode: "remote-exec" },
+  ] as const)(
+    "preserves the $providerId profile and resolves its $executionMode destination",
+    async ({ providerId, nodeDeviceId, executionMode }) => {
+      const environment = { ...ready, providerId, nodeDeviceId };
+      const requirement = {
+        requiredNodeCommands: ["codex.exec-server.stdio.v1"],
+        consumesWorkerSlot: false,
+      };
+      const resolveDevicePlacementRequirement = vi.fn(async () => requirement);
+      const dispatch = vi.fn(async () => ACTIVE_PLACEMENT);
+      const redispatch = createReclaimedPlacementRedispatch({
+        environments: { get: () => environment },
+        dispatch,
+        resolveDevicePlacementRequirement,
+      });
 
-    await expect(redispatch(placement, dispatchOptions)).resolves.toBe(active);
-    expect(dispatch.mock.calls[0]?.[0]).toEqual({
-      sessionId: placement.sessionId,
-      sessionKey: placement.sessionKey,
-      agentId: placement.agentId,
-      profileId: "development",
-      executionMode: "worker-turn",
-      inheritedProfile: {
-        providerId: "fake",
-        profileSnapshot: { machineClass: "large", settings: { region: "parent" } },
-      },
-    });
-  });
-
-  it("carries the exact paired node and owner-resolved requirement through redispatch", async () => {
-    const requirement = { requiredNodeCommands: [], consumesWorkerSlot: true };
-    const dispatch = vi.fn<Parameters<typeof createReclaimedPlacementRedispatch>[0]["dispatch"]>(
-      async () => ({ state: "active" }) as never,
-    );
-    const resolveDevicePlacementRequirement = vi.fn(async () => requirement);
-    const redispatch = createReclaimedPlacementRedispatch({
-      environments: {
-        get: () =>
-          ({
-            profileId: "device:paired-node",
-            providerId: "device",
-            nodeDeviceId: "paired-node",
-            profileSnapshot: { install: "bundle", settings: { device: "paired-node" } },
-          }) as never,
-      },
-      dispatch,
-      resolveDevicePlacementRequirement,
-    });
-
-    await redispatch(placement, dispatchOptions);
-
-    expect(resolveDevicePlacementRequirement).toHaveBeenCalledWith({
-      sessionId: placement.sessionId,
-      sessionKey: placement.sessionKey,
-      agentId: placement.agentId,
-      executionMode: "worker-turn",
-    });
-    expect(dispatch.mock.calls[0]?.[0]).toMatchObject({
-      deviceId: "paired-node",
-      devicePlacement: requirement,
-    });
-  });
-
-  it("revalidates a reclaimed cloud node without targeting its retired device", async () => {
-    const remotePlacement = {
-      ...placement,
-      executionMode: "remote-exec" as const,
-    } as ReclaimedWorkerPlacement;
-    const requirement = {
-      requiredNodeCommands: ["codex.exec-server.stdio.v1"],
-      consumesWorkerSlot: false,
-    };
-    const dispatch = vi.fn<Parameters<typeof createReclaimedPlacementRedispatch>[0]["dispatch"]>(
-      async () => ({ state: "active" }) as never,
-    );
-    const resolveDevicePlacementRequirement = vi.fn(async () => requirement);
-    const redispatch = createReclaimedPlacementRedispatch({
-      environments: {
-        get: () =>
-          ({
-            profileId: "cloud:development",
-            providerId: "crabbox",
-            nodeDeviceId: "retired-cloud-node",
-            profileSnapshot: { machineClass: "large", settings: { region: "parent" } },
-          }) as never,
-      },
-      dispatch,
-      resolveDevicePlacementRequirement,
-    });
-
-    await redispatch(remotePlacement, dispatchOptions);
-
-    expect(resolveDevicePlacementRequirement).toHaveBeenCalledWith({
-      sessionId: remotePlacement.sessionId,
-      sessionKey: remotePlacement.sessionKey,
-      agentId: remotePlacement.agentId,
-      executionMode: "remote-exec",
-    });
-    expect(dispatch.mock.calls[0]?.[0]).toEqual({
-      sessionId: remotePlacement.sessionId,
-      sessionKey: remotePlacement.sessionKey,
-      agentId: remotePlacement.agentId,
-      profileId: "cloud:development",
-      executionMode: "remote-exec",
-      devicePlacement: requirement,
-      inheritedProfile: {
-        providerId: "crabbox",
-        profileSnapshot: { machineClass: "large", settings: { region: "parent" } },
-      },
-    });
-  });
+      await expect(redispatch({ ...placement, executionMode }, dispatchOptions)).resolves.toBe(
+        ACTIVE_PLACEMENT,
+      );
+      const identity = {
+        sessionId: placement.sessionId,
+        sessionKey: placement.sessionKey,
+        agentId: placement.agentId,
+        executionMode,
+      };
+      expect(dispatch).toHaveBeenCalledExactlyOnceWith(
+        {
+          ...identity,
+          profileId: ready.profileId,
+          inheritedProfile: { providerId, profileSnapshot: ready.profileSnapshot },
+          ...(nodeDeviceId ? { devicePlacement: requirement } : {}),
+          ...(providerId === "device" ? { deviceId: nodeDeviceId } : {}),
+        },
+        undefined,
+        dispatchOptions.assertCurrent,
+        undefined,
+      );
+      if (nodeDeviceId) {
+        expect(resolveDevicePlacementRequirement).toHaveBeenCalledExactlyOnceWith(identity);
+      } else {
+        expect(resolveDevicePlacementRequirement).not.toHaveBeenCalled();
+      }
+    },
+  );
 
   it.each([
     { providerId: "device", executionMode: "worker-turn" },
     { providerId: "crabbox", executionMode: "remote-exec" },
   ] as const)(
-    "rejects $providerId node redispatch without its runtime requirement owner",
+    "rejects $providerId nodes without a runtime requirement owner",
     async ({ providerId, executionMode }) => {
       const dispatch = vi.fn();
       const redispatch = createReclaimedPlacementRedispatch({
-        environments: {
-          get: () =>
-            ({
-              profileId: "device:paired-node",
-              providerId,
-              nodeDeviceId: "paired-node",
-              profileSnapshot: { install: "bundle", settings: { device: "paired-node" } },
-            }) as never,
-        },
+        environments: { get: () => ({ ...ready, providerId, nodeDeviceId: "paired-node" }) },
         dispatch,
       });
-
-      await expect(
-        redispatch({ ...placement, executionMode } as ReclaimedWorkerPlacement, dispatchOptions),
-      ).rejects.toThrow("authoritative runtime requirement");
+      await expect(redispatch({ ...placement, executionMode }, dispatchOptions)).rejects.toThrow(
+        "authoritative runtime requirement",
+      );
       expect(dispatch).not.toHaveBeenCalled();
     },
   );
 
-  it("fails closed when the prior environment record is unavailable", async () => {
+  it("rejects a missing prior environment", async () => {
+    const dispatch = vi.fn();
     const redispatch = createReclaimedPlacementRedispatch({
       environments: { get: () => undefined },
-      dispatch: vi.fn(),
+      dispatch,
     });
-
     await expect(redispatch(placement, dispatchOptions)).rejects.toThrow(
-      "Reclaimed worker placement has no environment record: worker:previous",
+      "has no environment record",
     );
+    expect(dispatch).not.toHaveBeenCalled();
   });
 });

--- a/src/gateway/worker-environments/reclaimed-placement-redispatch.test.ts
+++ b/src/gateway/worker-environments/reclaimed-placement-redispatch.test.ts
@@ -6,6 +6,11 @@ import { createReclaimedPlacementRedispatch } from "./reclaimed-placement-redisp
 const placement = { ...ACTIVE_PLACEMENT, state: "reclaimed" as const };
 const dispatchOptions = { assertCurrent: () => {} };
 const { ready } = createDispatchEnvironmentFixtures();
+const profileSnapshot = {
+  machineClass: "large",
+  install: "bundle",
+  settings: { region: "parent", device: "paired-node" },
+} as const;
 
 describe("createReclaimedPlacementRedispatch", () => {
   it.each([
@@ -15,10 +20,11 @@ describe("createReclaimedPlacementRedispatch", () => {
   ] as const)(
     "preserves the $providerId profile and resolves its $executionMode destination",
     async ({ providerId, nodeDeviceId, executionMode }) => {
-      const environment = { ...ready, providerId, nodeDeviceId };
+      const profileId = `profile-${providerId}`;
+      const environment = { ...ready, providerId, nodeDeviceId, profileId, profileSnapshot };
       const requirement = {
-        requiredNodeCommands: ["codex.exec-server.stdio.v1"],
-        consumesWorkerSlot: false,
+        requiredNodeCommands: executionMode === "remote-exec" ? ["codex.exec-server.stdio.v1"] : [],
+        consumesWorkerSlot: executionMode === "worker-turn",
       };
       const resolveDevicePlacementRequirement = vi.fn(async () => requirement);
       const dispatch = vi.fn(async () => ACTIVE_PLACEMENT);
@@ -40,8 +46,8 @@ describe("createReclaimedPlacementRedispatch", () => {
       expect(dispatch).toHaveBeenCalledExactlyOnceWith(
         {
           ...identity,
-          profileId: ready.profileId,
-          inheritedProfile: { providerId, profileSnapshot: ready.profileSnapshot },
+          profileId,
+          inheritedProfile: { providerId, profileSnapshot },
           ...(nodeDeviceId ? { devicePlacement: requirement } : {}),
           ...(providerId === "device" ? { deviceId: nodeDeviceId } : {}),
         },

--- a/src/gateway/worker-environments/reclaimed-placement-redispatch.ts
+++ b/src/gateway/worker-environments/reclaimed-placement-redispatch.ts
@@ -13,48 +13,39 @@ export function createReclaimedPlacementRedispatch(params: {
 }) {
   return async (
     placement: ReclaimedWorkerPlacement,
-    options: { assertCurrent: () => void; signal?: AbortSignal },
+    { assertCurrent, signal }: { assertCurrent: () => void; signal?: AbortSignal },
   ) => {
-    options.signal?.throwIfAborted();
-    options.assertCurrent();
+    signal?.throwIfAborted();
+    assertCurrent();
     const previousEnvironment = params.environments.get(placement.environmentId);
     if (!previousEnvironment) {
       throw new Error(
         `Reclaimed worker placement has no environment record: ${placement.environmentId}`,
       );
     }
+    const { profileId, providerId, profileSnapshot, nodeDeviceId } = previousEnvironment;
+    const { sessionId, sessionKey, agentId, executionMode } = placement;
+    const identity = { sessionId, sessionKey, agentId, executionMode };
     let devicePlacement: Awaited<ReturnType<WorkerDevicePlacementRequirementResolver>> | undefined;
-    if (previousEnvironment.nodeDeviceId) {
+    if (nodeDeviceId) {
       if (!params.resolveDevicePlacementRequirement) {
         throw new Error("Node-backed redispatch has no authoritative runtime requirement");
       }
-      devicePlacement = await params.resolveDevicePlacementRequirement({
-        sessionId: placement.sessionId,
-        sessionKey: placement.sessionKey,
-        agentId: placement.agentId,
-        executionMode: placement.executionMode,
-      });
+      devicePlacement = await params.resolveDevicePlacementRequirement(identity);
     }
     return await params.dispatch(
       {
-        sessionId: placement.sessionId,
-        sessionKey: placement.sessionKey,
-        agentId: placement.agentId,
-        profileId: previousEnvironment.profileId,
-        executionMode: placement.executionMode,
+        ...identity,
+        profileId,
         ...(devicePlacement ? { devicePlacement } : {}),
-        ...(previousEnvironment.providerId === DEVICE_WORKER_PROVIDER_ID &&
-        previousEnvironment.nodeDeviceId
-          ? { deviceId: previousEnvironment.nodeDeviceId }
+        ...(providerId === DEVICE_WORKER_PROVIDER_ID && nodeDeviceId
+          ? { deviceId: nodeDeviceId }
           : {}),
-        inheritedProfile: {
-          providerId: previousEnvironment.providerId,
-          profileSnapshot: previousEnvironment.profileSnapshot,
-        },
+        inheritedProfile: { providerId, profileSnapshot },
       },
       undefined,
-      options.assertCurrent,
-      options.signal,
+      assertCurrent,
+      signal,
     );
   };
 }


### PR DESCRIPTION
Related: #146225

## What Problem This Solves

The reclaimed-worker resume repair carried duplicated fixture, dispatch, and cleanup code across its success and cancellation tests, plus repeated profile mapping. This maintainer-requested follow-up reduces that maintenance burden without changing resume behavior.

## Why This Change Was Made

One outcome table now exercises all five resume cases through the real placement/admission owners. Prior placement setup uses the existing dispatch/reclaim fixture instead of manually replaying transitions. Profile mapping tests share complete typed records, replacing partial-object casts while preserving distinct profile IDs, full profile fields, and both worker-slot requirement values. Production constructs the placement identity once and reuses the captured profile fields.

Net reduction: **167 lines** across three files—**9 production lines and 158 test lines**. All 11 focused cases remain.

## User Impact

The resume, Stop, supersession, profile selection, and cleanup contracts from #146225 are preserved. No configuration, schema, or migration changes.

## Evidence

- All 11 focused resume/profile-mapping cases passed after consolidation.
- Selected changed-file checks passed, including core/test types, lint, dead exports, schema/database/import/API guards.
- Independent Codex review through P2 found no actionable issues.
- **Live proof:** Blacksmith Testbox `tbx_01m2bbtfz0krymz0wepfpd0zwk`, Linux/Node 24.19.0, real Gateway and paired node processes, live `openai/gpt-5.6-luna` inference. The initial turn wrote a file through node execution; `sessions.reclaim` released the placement; a second `chat.send` automatically created a new environment and read the preserved file. Process ancestry included the node PID and excluded the Gateway PID. Final reclaim and process cleanup completed. The paired-device placement ran on one cloud VM; this did not test allocating a fresh VM through an AWS provider.
- Build: `node scripts/crabbox-wrapper.mjs run --keep --timing-json --shell -- 'pnpm build'` — exit 0.
- Live entry point: `node scripts/run-vitest.mjs --config test/vitest/vitest.live.config.ts test/e2e/qa-lab/runtime/reclaimed-worker-resume.live.test.ts`, with only the approved OpenAI credential forwarded to the child. The task-owned probe is retained as evidence rather than added to the product test tree. Test body: 52.6 seconds; 1 passed; wrapper exit 0.
- The Testbox lease was stopped after receipt collection; authoritative status is `completed`.
- [Testbox workflow](https://github.com/openclaw/openclaw/actions/runs/34709383423). The source receiver verified the candidate, and the tested production file's SHA-256 was `62b0d2e46b358304fa5a5ce1c9d2c65adbd94323a3610715bed1bed4178266f3`.

```text
LIVE_RESUME_PHASE=dispatched
LIVE_RESUME_PHASE=initial result=ok nodeExecution=true persistedMarker=true
LIVE_RESUME_PHASE=reclaimed
LIVE_RESUME_PHASE=resumed result=ok nodeExecution=true persistedMarker=true
LIVE_RESUME_RESULT=passed cleanup=complete
```
