### PR TITLE
fix(ui): keep loading shimmers at the top of chat

### DIFF
--- a/ui/src/e2e/initial-connect-splash.e2e.test.ts
+++ b/ui/src/e2e/initial-connect-splash.e2e.test.ts
@@ -254,6 +254,28 @@ describeControlUiE2e("Control UI initial connect splash E2E", () => {
         skeleton.locator(".loading-skeleton__composer"),
       ]);
 
+      for (const size of [viewport, { width: 1440, height: 1440 }, { width: 390, height: 844 }]) {
+        await page.setViewportSize(size);
+        const content = await page.locator(".content--chat").boundingBox();
+        const header = await skeleton.locator(".loading-skeleton__header").boundingBox();
+        const composer = await skeleton.locator(".loading-skeleton__composer").boundingBox();
+        expect(content).not.toBeNull();
+        expect(header).not.toBeNull();
+        expect(composer).not.toBeNull();
+        expect(header!.y - content!.y, "loading header stays at the top").toBeGreaterThanOrEqual(0);
+        expect(header!.y - content!.y, "loading header stays at the top").toBeLessThan(48);
+        const bottomGap = content!.y + content!.height - composer!.y - composer!.height;
+        expect(bottomGap, "loading composer stays inside the content area").toBeGreaterThanOrEqual(
+          0,
+        );
+        expect(bottomGap, "loading composer stays near the bottom").toBeLessThan(64);
+        await captureProof(page, `03-pending-chat-${size.width}x${size.height}`, [
+          skeleton.locator(".loading-skeleton__header"),
+          skeleton.locator(".loading-skeleton__composer"),
+        ]);
+      }
+      await page.setViewportSize(viewport);
+
       releaseChatModule();
       await page.locator("openclaw-chat-page").waitFor();
       expect(await loadingState.count()).toBe(0);

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -2214,13 +2214,12 @@ select.input {
 
 /* Pending routes reserve the content layout without exposing transient panel text. */
 .lazy-view-state--loading {
-  display: grid;
+  display: flex;
   flex: 1 1 auto;
-  place-items: center;
   min-width: 0;
   min-height: min(50dvh, 360px);
   width: 100%;
-  margin: auto;
+  margin: 0;
 }
 
 /* Lazy route load failure — a centered panel state, not a stretched callout. */


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users opening a chat would see the loading shimmers floating in the middle of the page, leaving a large blank area above the header and placing the composer placeholder halfway up the window.

## Why This Change Was Made

The shared pending-route wrapper retained the automatic margins and centered grid layout from the mascot it used to display. Let the wrapper stretch across its available content area so the existing skeleton can position its header/messages at the top and composer at the bottom. This corrects the layout introduced when skeletons replaced the mascot in #139525.

## User Impact

Chat loading now follows the conversation layout on desktop, tall windows, and mobile. The initial connection splash and loading-to-chat transition retain their existing behavior.

## Evidence

- Extended the existing real-route browser test with header/composer position assertions at 1280×900, 1440×1440, and 390×844. It fails before the fix: the header is 212.5px below the content area's top at 1280×900. All three sizes pass after the fix.
- All 18 tests in `initial-connect-splash.e2e.test.ts` and `control-ui-route-readiness.e2e.test.ts` pass, covering initial connection, route loading, mobile selection/composition, and draft preservation while history loads.
- `pnpm ui:build` passes, including UI asset budgets.
- The full `check:changed` run passes, including core test/UI typechecks, formatting, lint, i18n, and repository guards.
- Independent Codex review: no actionable findings through P2.
- The attached before/after captures use the synthetic Gateway harness. Live operator-browser verification was unavailable; no deployment is claimed.

![Before: loading skeleton floats in the middle](https://github.com/user-attachments/assets/bb32dbe7-0d82-44ea-a0dd-5022a2288e0e)

![After: header at the top and composer at the bottom](https://github.com/user-attachments/assets/b475925b-ac93-4ad0-ac4b-72d4048ffe72)

![After: mobile loading layout](https://github.com/user-attachments/assets/9ca41578-3ce2-4e2f-bf5a-542caff21cef)
