### PR TITLE
improve: reuse transcript statistics query compilation

### DIFF
--- a/src/config/sessions/session-accessor.sqlite-cold-read.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-cold-read.test.ts
@@ -309,7 +309,7 @@ it("copies one source snapshot when a peer archives during cross-store canonical
     const destinationOptions = {
       agentId: "main",
       env: state.env,
-      path: state.path("destination.sqlite"),
+      path: state.statePath("destination.sqlite"),
     };
     const entry = { sessionId: race.scope.sessionId, updatedAt: 1 };
     await replaceSessionEntry({ ...race.scope, storePath: destinationOptions.path }, entry);

--- a/src/config/sessions/session-accessor.sqlite-read.ts
+++ b/src/config/sessions/session-accessor.sqlite-read.ts
@@ -370,6 +370,47 @@ function sqliteTranscriptJsonlByteSize() {
     + CASE WHEN COUNT(*) > 0 THEN COUNT(*) - 1 ELSE 0 END`.as("size_bytes");
 }
 
+function createTranscriptStatsQueries(database: Pick<OpenClawAgentDatabase, "db">) {
+  const db = getSessionKysely(database.db);
+  return {
+    events: prepareSqliteQuerySync<
+      string,
+      { event_count: number; max_seq: number | null; size_bytes: number }
+    >(database.db, (parameter) =>
+      db
+        .selectFrom("transcript_events")
+        .select((eb) => [
+          eb.fn.count<number>("seq").as("event_count"),
+          eb.fn.max<number>("seq").as("max_seq"),
+          sqliteTranscriptJsonlByteSize(),
+        ])
+        .where(
+          "session_id",
+          "=",
+          parameter((sessionId) => sessionId),
+        ),
+    ),
+    session: prepareSqliteQuerySync<
+      string,
+      { transcript_observed_at: number | null; transcript_updated_at: number | null }
+    >(database.db, (parameter) =>
+      db
+        .selectFrom("session_windows")
+        .select(["transcript_observed_at", "transcript_updated_at"])
+        .where(
+          "session_id",
+          "=",
+          parameter((sessionId) => sessionId),
+        ),
+    ),
+  };
+}
+
+const transcriptStatsQueries = new WeakMap<
+  OpenClawAgentDatabase["db"],
+  ReturnType<typeof createTranscriptStatsQueries>
+>();
+
 /** Reads transcript freshness and byte size without materializing event rows. */
 function readTranscriptStatsFromDatabase(
   database: Pick<OpenClawAgentDatabase, "db">,
@@ -379,25 +420,13 @@ function readTranscriptStatsFromDatabase(
     database.db,
     () => {
       const cold = readSessionColdTranscript(database.db, sessionId);
-      const db = getSessionKysely(database.db);
-      const row = executeSqliteQueryTakeFirstSync(
-        database.db,
-        db
-          .selectFrom("transcript_events")
-          .select((eb) => [
-            eb.fn.count<number>("seq").as("event_count"),
-            eb.fn.max<number>("seq").as("max_seq"),
-            sqliteTranscriptJsonlByteSize(),
-          ])
-          .where("session_id", "=", sessionId),
-      );
-      const session = executeSqliteQueryTakeFirstSync(
-        database.db,
-        db
-          .selectFrom("session_windows")
-          .select(["transcript_observed_at", "transcript_updated_at"])
-          .where("session_id", "=", sessionId),
-      );
+      let queries = transcriptStatsQueries.get(database.db);
+      if (!queries) {
+        queries = createTranscriptStatsQueries(database);
+        transcriptStatsQueries.set(database.db, queries);
+      }
+      const row = queries.events(sessionId).rows[0];
+      const session = queries.session(sessionId).rows[0];
       return {
         eventCount: cold?.event_count ?? row?.event_count ?? 0,
         ...(session?.transcript_updated_at !== null && session?.transcript_updated_at !== undefined


### PR DESCRIPTION
## What Problem This Solves

Usage inventories and memory diagnostics repeatedly rebuild the same transcript count/size and mutation-timestamp queries for every session. The SQLite statement cache avoids native preparation, but the Kysely query construction and compilation still recur during large inventories.

## Why This Change Was Made

Keep both compiled queries with the physical connection and bind the session ID afresh. The existing per-session read transaction, cold-archive precedence, byte accounting, and writable/read-only acquisition routes remain unchanged.

The covering cross-store archive-race test also placed its destination database outside the fixture's cleanup scope. Move that distinct database under `state.statePath`, allowing the existing cleanup owner to close it on Windows. No timeout or assertion changes.

## User Impact

Large session-statistics inventories spend less time constructing queries. No schema, persistence, retention, or transaction change; there is no cached statistics value to invalidate.

## Evidence

Actual old/current owners on Node 26.8.2 / SQLite 3.53.4, seven alternating public timing blocks:

| Workload | Before | After |
| --- | ---: | ---: |
| Individual public reads across 1,000 short sessions | 360.67 ms | 279.97 ms |
| Read-only batch across 1,000 short sessions | 267.57 ms | 245.65 ms |
| Read-only batch across 100 large histories | 87.17 ms | 78.37 ms |

The same physical connection with the actual private kernel measured 37.90→27.89 ms for 1,000 short sessions and 36.46→24.41 ms for 1,000 cold sessions over eleven alternating blocks. Public results are mixed: 100 short sessions were about 2% slower, and the large-payload batch was 8% slower. These fixtures do not establish a uniform dashboard speedup.

Full output equality covers missing/duplicate identities and zero/null timestamps. Canonical database schemas, typed row digests, user_version, database/WAL/journal bytes, and integrity remain unchanged.

- 90 stats/consumer/executor cases verified across focused runs: byte accounting, cold archive races, usage inventory, and prepared-query binding/reentry/invalidation.
- The cross-store case timed out at 120 seconds on both clean main and the initial candidate; correcting cleanup ownership passes in 7.51 seconds under the original budget.
- Core production and relevant test type graphs, scoped type-aware lint, formatting, and schema/diff checks passed.
- Final independent P0–P2 review, including the fixture repair, found no actionable issues.
