### PR TITLE
improve: avoid loading memory origins before deletion

### DIFF
--- a/extensions/memory-core/src/memory-entry-origins.test.ts
+++ b/extensions/memory-core/src/memory-entry-origins.test.ts
@@ -61,12 +61,15 @@ describe("memory entry origins", () => {
     };
   }
 
-  it("lazily restores the additive origins table without changing the agent schema version", () => {
+  it("lazily restores the additive origins table without changing the agent schema version", async () => {
+    expect(deleteMemoryEntryOrigins({ agentId: "main", entryKeys: ["candidate"] })).toBe(0);
+    await expect(fs.access(resolveOpenClawAgentSqlitePath({ agentId: "main" }))).rejects.toThrow();
     const db = openOpenClawAgentDatabase({ agentId: "main" }).db;
     const version = db.prepare("PRAGMA user_version").get();
     db.exec("DROP TABLE IF EXISTS memory_entry_origins");
 
     expect(listMemoryEntryOrigins({ agentId: "main" })).toEqual([]);
+    expect(deleteMemoryEntryOrigins({ agentId: "main", entryKeys: ["candidate"] })).toBe(0);
     expect(
       db.prepare("SELECT name FROM sqlite_schema WHERE name = 'memory_entry_origins'").get(),
     ).toBeUndefined();
@@ -198,6 +201,15 @@ describe("memory entry origins", () => {
     const priorEntry = "- Keep the original deployment target.";
     const original = [origin("candidate", "session-2"), origin("prior", "session-1")];
     recordMemoryEntryOrigins({ agentId: "main", origins: original });
+    for (const filter of [
+      { entryKeys: [] },
+      { entryKeys: ["candidate"], sessionIds: [] },
+      { entryKeys: ["missing"] },
+      { entryKeys: ["candidate"], sessionIds: ["session-1"] },
+    ]) {
+      expect(deleteMemoryEntryOrigins({ agentId: "main", ...filter })).toBe(0);
+    }
+    expect(listMemoryEntryOrigins({ agentId: "main" })).toEqual(original);
     const rollback = reserveMemoryEntryOrigins({
       agentIds: ["main"],
       previousMemory: `${buildPromotionMarker("prior")}\n${priorEntry}\n`,

--- a/extensions/memory-core/src/memory-entry-origins.ts
+++ b/extensions/memory-core/src/memory-entry-origins.ts
@@ -233,7 +233,24 @@ export function deleteMemoryEntryOrigins(params: {
   entryKeys: readonly string[];
   sessionIds?: readonly string[];
 }): number {
-  if (listMemoryEntryOrigins(params).length === 0) {
+  if (params.entryKeys.length === 0 || params.sessionIds?.length === 0) {
+    return 0;
+  }
+  const existing = withOpenClawAgentDatabaseReadOnly(({ db }) => {
+    if (!ensuredDatabases.has(db) && !tableExists(db, "memory_entry_origins")) {
+      return false;
+    }
+    let query = getNodeSqliteKysely<MemoryOriginDatabase>(db)
+      .selectFrom("memory_entry_origins")
+      .select("entry_key")
+      .where("agent_id", "=", params.agentId)
+      .where("entry_key", "in", params.entryKeys);
+    if (params.sessionIds) {
+      query = query.where("session_id", "in", params.sessionIds);
+    }
+    return executeSqliteQuerySync(db, query.limit(1)).rows.length > 0;
+  }, params);
+  if (!existing.found || !existing.value) {
     return 0;
   }
   const db = openMemoryOriginDatabase(params.agentId);


### PR DESCRIPTION
## What Problem This Solves

Deleting memory-entry origins first loads, sorts, and maps every matching origin merely to check whether any exist. Large origin sets therefore pay for a full read before deletion.

## Why This Change Was Made

Use a bounded existence query through the existing read-only database owner, retaining the agent, entry-key, and optional session filters. Empty filters and missing databases/tables still return zero without creating storage. The transactional deletion remains unchanged.

## User Impact

Memory-origin deletion does less work while preserving its filtering, rollback, and lazy-storage behavior. No schema or persisted-format changes.

## Evidence

- All 44 focused origins, forget, phase-signal, and consolidation tests passed.
- Isolated real disk-backed SQLite proof exercised missing databases/tables, empty/disjoint filters, scoped/full/repeated deletion, reservation rollback, and pruning. Schema stayed unchanged.
- Eleven warm interleaved rounds measured the full deletion, excluding seeding: 1,000 origins took 3.123 ms before / 0.956 ms after (3.27x); 10,000 took 29.095 ms / 5.812 ms (5.01x). The preflight returns one row instead of 10,000. These are local synthetic-fixture medians.
- Fresh independent P0-P2 review found no actionable defects. Hosted exact-head checks are required before landing.
- Full changed-file checks passed, including production/test types, unused-export scans, scoped lint, storage/runtime guards, and import-cycle checks.
