### PR TITLE
improve: avoid loading browser subscriptions for notification preflights

### DIFF
--- a/src/gateway/approval-web-push.test.ts
+++ b/src/gateway/approval-web-push.test.ts
@@ -6,6 +6,7 @@ import { createTestApprovalManager } from "./exec-approval-manager.test-support.
 
 const listDevicePairingMock = vi.fn();
 const listBoundWebPushSubscriptionsMock = vi.fn();
+const hasBoundWebPushSubscriptionsMock = vi.fn();
 const prepareWebPushNotificationSenderMock = vi.fn();
 const preparedWebPushSendMock = vi.fn();
 const prepareWebPushApprovalDeliveriesMock = vi.fn();
@@ -34,6 +35,7 @@ vi.mock("../infra/device-pairing-store-readonly.js", async () => {
 vi.mock("../infra/push-web.js", () => ({
   deleteWebPushApprovalDeliveryTargets: deleteWebPushApprovalDeliveryTargetsMock,
   listBoundWebPushSubscriptions: listBoundWebPushSubscriptionsMock,
+  hasBoundWebPushSubscriptions: hasBoundWebPushSubscriptionsMock,
   listTerminalWebPushApprovalDeliveryIds: listTerminalWebPushApprovalDeliveryIdsMock,
   listWebPushApprovalDeliveryTargets: listWebPushApprovalDeliveryTargetsMock,
   prepareWebPushApprovalDeliveries: prepareWebPushApprovalDeliveriesMock,
@@ -113,6 +115,7 @@ describe("approval Web Push delivery", () => {
     vi.useRealTimers();
     listDevicePairingMock.mockReturnValue({ pending: [], paired: [] });
     listBoundWebPushSubscriptionsMock.mockReturnValue([]);
+    hasBoundWebPushSubscriptionsMock.mockReturnValue(true);
     prepareWebPushNotificationSenderMock.mockResolvedValue(preparedWebPushSendMock);
     preparedWebPushSendMock.mockResolvedValue([]);
     approvalDeliveryTargets.clear();
@@ -370,9 +373,8 @@ describe("approval Web Push delivery", () => {
   it("prepares the transport before rereading current approval authority", async (testContext) => {
     const manager = createTestApprovalManager(testContext);
     const record = manager.create({ command: "echo ok" }, 60_000, "exec:authority-race");
-    const stale = boundSubscription("stale-device", "profile-stale");
     const current = boundSubscription("current-device", "profile-current");
-    listBoundWebPushSubscriptionsMock.mockReturnValueOnce([stale]).mockReturnValueOnce([current]);
+    listBoundWebPushSubscriptionsMock.mockReturnValue([current]);
     listDevicePairingMock.mockReturnValue({
       pending: [],
       paired: [pairedOperator("current-device", ["operator.approvals", "operator.read"])],
@@ -394,7 +396,18 @@ describe("approval Web Push delivery", () => {
     ).toBeLessThan(
       expectDefined(listDevicePairingMock.mock.invocationCallOrder[0], "pairing read call order"),
     );
-    expect(listBoundWebPushSubscriptionsMock).toHaveBeenCalledTimes(2);
+    expect(listBoundWebPushSubscriptionsMock).toHaveBeenCalledOnce();
+    expect(
+      expectDefined(
+        prepareWebPushNotificationSenderMock.mock.invocationCallOrder[0],
+        "transport preparation call order",
+      ),
+    ).toBeLessThan(
+      expectDefined(
+        listBoundWebPushSubscriptionsMock.mock.invocationCallOrder[0],
+        "subscription read call order",
+      ),
+    );
     expect(preparedWebPushSendMock).toHaveBeenCalledWith(
       expect.objectContaining({ subscriptions: [current] }),
     );

--- a/src/gateway/approval-web-push.ts
+++ b/src/gateway/approval-web-push.ts
@@ -14,7 +14,7 @@ import {
 } from "../infra/push-web-preferences.js";
 import {
   deleteWebPushApprovalDeliveryTargets,
-  listBoundWebPushSubscriptions,
+  hasBoundWebPushSubscriptions,
   listTerminalWebPushApprovalDeliveryIds,
   listWebPushApprovalDeliveryTargets,
   prepareWebPushApprovalDeliveries,
@@ -357,7 +357,7 @@ export function createApprovalWebPushDelivery(params: {
   return {
     /** Sends a request notification only when at least one browser has a durable binding. */
     handleRequested<TPayload>(record: ExecApprovalRecord<TPayload>): boolean | Promise<boolean> {
-      if (listBoundWebPushSubscriptions(params.stateDir).length === 0) {
+      if (!hasBoundWebPushSubscriptions(params.stateDir)) {
         return false;
       }
       const deliveryState: ApprovalWebPushDeliveryState = {

--- a/src/gateway/event-web-push.test.ts
+++ b/src/gateway/event-web-push.test.ts
@@ -11,6 +11,7 @@ import { invalidateOperatorRolePolicy } from "./operator-role-policy.js";
 const {
   listDevicePairingMock,
   listBoundWebPushSubscriptionsMock,
+  hasBoundWebPushSubscriptionsMock,
   prepareWebPushNotificationSenderMock,
   preparedWebPushSendMock,
   resolveUserProfileIdMock,
@@ -22,6 +23,7 @@ const {
 } = vi.hoisted(() => ({
   listDevicePairingMock: vi.fn(),
   listBoundWebPushSubscriptionsMock: vi.fn(),
+  hasBoundWebPushSubscriptionsMock: vi.fn(),
   prepareWebPushNotificationSenderMock: vi.fn(),
   preparedWebPushSendMock: vi.fn(),
   resolveUserProfileIdMock: vi.fn(),
@@ -59,6 +61,7 @@ vi.mock("../infra/device-pairing-store-readonly.js", async () => {
 
 vi.mock("../infra/push-web.js", () => ({
   listBoundWebPushSubscriptions: listBoundWebPushSubscriptionsMock,
+  hasBoundWebPushSubscriptions: hasBoundWebPushSubscriptionsMock,
   prepareWebPushNotificationSender: prepareWebPushNotificationSenderMock,
 }));
 
@@ -141,6 +144,7 @@ describe("event Web Push classification", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     listBoundWebPushSubscriptionsMock.mockReturnValue([boundSubscription("browser-device")]);
+    hasBoundWebPushSubscriptionsMock.mockReturnValue(true);
     listDevicePairingMock.mockReturnValue({
       pending: [],
       paired: [pairedOperator("browser-device")],
@@ -415,21 +419,22 @@ describe("event Web Push classification", () => {
 
     await vi.waitFor(() => expect(prepareWebPushNotificationSenderMock).toHaveBeenCalledOnce());
     expect(getRuntimeConfig).not.toHaveBeenCalled();
-    expect(listBoundWebPushSubscriptionsMock).toHaveBeenCalledOnce();
+    expect(listBoundWebPushSubscriptionsMock).not.toHaveBeenCalled();
     listBoundWebPushSubscriptionsMock.mockReturnValue([]);
     preparation.resolve(preparedWebPushSendMock);
-    await vi.waitFor(() => expect(listBoundWebPushSubscriptionsMock).toHaveBeenCalledTimes(2));
+    await vi.waitFor(() => expect(listBoundWebPushSubscriptionsMock).toHaveBeenCalledOnce());
     expect(getRuntimeConfig).toHaveBeenCalledOnce();
     expect(preparedWebPushSendMock).not.toHaveBeenCalled();
   });
 
   it("skips transport preparation when no subscriptions exist", async () => {
     listBoundWebPushSubscriptionsMock.mockReturnValue([]);
+    hasBoundWebPushSubscriptionsMock.mockReturnValue(false);
     const delivery = createEventWebPushDelivery({ getRuntimeConfig: () => ({}) });
 
     delivery.handleEvent("chat", { state: "final", runId: "run-1" });
 
-    await vi.waitFor(() => expect(listBoundWebPushSubscriptionsMock).toHaveBeenCalledOnce());
+    await vi.waitFor(() => expect(hasBoundWebPushSubscriptionsMock).toHaveBeenCalledOnce());
     expect(prepareWebPushNotificationSenderMock).not.toHaveBeenCalled();
     expect(preparedWebPushSendMock).not.toHaveBeenCalled();
   });

--- a/src/gateway/event-web-push.ts
+++ b/src/gateway/event-web-push.ts
@@ -14,7 +14,7 @@ import {
   webPushCategoryEnabled,
 } from "../infra/push-web-preferences.js";
 import {
-  listBoundWebPushSubscriptions,
+  hasBoundWebPushSubscriptions,
   prepareWebPushNotificationSender,
   type BoundWebPushSubscription,
 } from "../infra/push-web.js";
@@ -164,7 +164,7 @@ export function createEventWebPushDelivery(params: {
     mention?: HumanMentionWebPush,
   ): void => {
     void (async () => {
-      if (listBoundWebPushSubscriptions(params.stateDir).length === 0) {
+      if (!hasBoundWebPushSubscriptions(params.stateDir)) {
         return;
       }
       const sender = await prepareWebPushNotificationSender(params.stateDir);

--- a/src/infra/push-web-store.ts
+++ b/src/infra/push-web-store.ts
@@ -253,6 +253,22 @@ export function listWebPushSubscriptions(stateDir?: string): WebPushSubscription
   ).rows.map(webPushSubscriptionFromRow);
 }
 
+export function hasBoundWebPushSubscriptions(stateDir?: string): boolean {
+  ensureWebPushSubscriptionBindingSchema(stateDir);
+  const { db } = openOpenClawStateDatabase(webPushStateDatabaseOptions(stateDir));
+  return Boolean(
+    executeSqliteQueryTakeFirstSync(
+      db,
+      getNodeSqliteKysely<WebPushDatabase>(db)
+        .selectFrom("web_push_subscriptions")
+        .select("subscription_id")
+        .where("device_id", "is not", null)
+        .where("device_id", "!=", "")
+        .limit(1),
+    ),
+  );
+}
+
 /** Lists only subscriptions reconciled by an authenticated browser device. */
 export function listBoundWebPushSubscriptions(stateDir?: string): BoundWebPushSubscription[] {
   ensureWebPushSubscriptionBindingSchema(stateDir);

--- a/src/infra/push-web.test.ts
+++ b/src/infra/push-web.test.ts
@@ -21,6 +21,7 @@ import {
   deleteWebPushApprovalDeliveryTargets,
   findBoundWebPushSubscriptionByEndpoint,
   hashWebPushEndpoint,
+  hasBoundWebPushSubscriptions,
   listBoundWebPushSubscriptions,
   listTerminalWebPushApprovalDeliveryIds,
   listWebPushApprovalDeliveryTargets,
@@ -302,8 +303,16 @@ describe("subscription CRUD", () => {
   });
 
   it("keeps legacy unbound rows test-only until browser reconciliation", async () => {
+    expect(hasBoundWebPushSubscriptions(tmpDir)).toBe(false);
     await registerWebPushSubscription({ endpoint, keys, baseDir: tmpDir });
     expect(listBoundWebPushSubscriptions(tmpDir)).toEqual([]);
+    expect(hasBoundWebPushSubscriptions(tmpDir)).toBe(false);
+    const { db } = openOpenClawStateDatabase({
+      env: { ...process.env, OPENCLAW_STATE_DIR: tmpDir },
+    });
+    db.exec("UPDATE web_push_subscriptions SET device_id = ''");
+    expect(listBoundWebPushSubscriptions(tmpDir)).toEqual([]);
+    expect(hasBoundWebPushSubscriptions(tmpDir)).toBe(false);
 
     const rebound = await registerWebPushSubscription({
       endpoint,
@@ -311,6 +320,7 @@ describe("subscription CRUD", () => {
       binding: { deviceId: "browser-device", userProfileId: null },
       baseDir: tmpDir,
     });
+    expect(hasBoundWebPushSubscriptions(tmpDir)).toBe(true);
     expect(listBoundWebPushSubscriptions(tmpDir)).toEqual([
       {
         ...rebound,

--- a/src/infra/push-web.ts
+++ b/src/infra/push-web.ts
@@ -11,6 +11,7 @@ import {
   deleteBoundWebPushSubscription,
   deleteWebPushSubscriptionIfCurrent,
   hashWebPushEndpoint,
+  hasBoundWebPushSubscriptions,
   insertVapidKeyPairIfAbsent,
   isValidWebPushEndpoint,
   isValidWebPushKey,
@@ -49,6 +50,7 @@ export {
   WebPushSubscriptionBindingError,
   findBoundWebPushSubscriptionByEndpoint,
   listBoundWebPushSubscriptions,
+  hasBoundWebPushSubscriptions,
   setWebPushSubscriptionPreferences,
 };
 export type { BoundWebPushSubscription } from "./push-web-store.js";


### PR DESCRIPTION
## What Problem This Solves

Every eligible event or approval notification loads all bound browser subscriptions merely to decide whether Web Push transport preparation is needed. Delivery then reads subscriptions again after preparation.

## Why This Change Was Made

Add a bounded existence query to the existing Web Push store and use it for both preflights. It preserves the existing non-null, non-empty device-binding filter. Delivery still rereads current subscriptions and authority after asynchronous transport preparation.

## User Impact

Notification preflights avoid allocating full subscription lists and become faster as registered browsers grow. Actual recipients, delivery checks, and stored data remain unchanged.

## Evidence

- All 93 focused approval, event, and real-SQLite subscription tests passed. The two transport-order regressions fail with the original preflight callers and pass with this patch.
- Public subscription registration and the actual event-delivery entry point were exercised against isolated disk-backed SQLite with absent, unbound, bound, and reopened state. No paired devices were present, so no external notifications were sent; no warnings occurred.
- 31 warm alternating query rounds measured 1,000 subscriptions at 1.943 ms before / 0.166 ms after (11.7x), and 5,000 at 33.575 ms / 0.432 ms (77.7x). Returned rows fall from 5,000 to one. These synthetic-fixture query medians do not measure outbound delivery latency.
- Fresh independent P0-P2 review found no actionable defects. Hosted exact-head checks are required before landing.
- Initial hosted run hit an unrelated native-compiler fixture launch failure (`ETXTBSY`) in `check-extension-package-tsc-boundary.test.ts`; 289 tests in that shard passed. The fixture and compiler inputs are unchanged by this PR and do not load Web Push. The targeted failed-job rerun passed, and the complete exact-head hosted gate is now green; no assertions or baselines were changed.

- Full local changed-file checks also passed, including all 18 core test type graphs, production types, unused-export scans, scoped lint, and the final storage/runtime/import guards.
