### PR TITLE
improve: avoid loading plugin state values for record counts

### DIFF
--- a/docs/plugins/sdk-runtime/state-and-system.md
+++ b/docs/plugins/sdk-runtime/state-and-system.md
@@ -132,6 +132,10 @@ The runtime config snapshot, durable plugin-scoped storage, system utilities, ev
 
     Current host factories provide `lookupMany`, but the public store types keep it optional for existing third-party adapters and declared older host versions. A plugin supporting those hosts must check the method and use its existing sequential `lookup` path when absent; never retry a failed bulk read through that path. Matrix, Microsoft Teams, and Voice Call retain this compatibility until their declared minimum host supplies the capability. Do not import a new helper export from an older host just to detect this method.
 
+    `count()` returns the number of live stored rows in the runtime-bound plugin and namespace without loading or decoding their JSON values. A row expires when its expiry timestamp is at or before the call's cutoff. Counting does not delete expired rows, create a missing database, or join the writable database lifecycle. Corrupt JSON still occupies a live row and is counted; `lookup` and `entries` retain their decoding errors. Database acquisition and query failures propagate with operation `count`. A count and a later write are separate operations; the write remains responsible for enforcing capacity.
+
+    Current host factories provide `count`, but it remains optional in the public async and synchronous store types for shipped hosts and adapters through the next Plugin SDK major. Callers supporting those stores can use `store.count ? await store.count() : (await store.entries()).length`; synchronous callers omit `await`. The fallback retains the older store's enumeration and decoding behavior. Only fall back when the method is absent, never after a failed count.
+
     `openSyncKeyedStore<T>(...)` remains available for callers that cannot await, with its existing synchronous return values and errors. It is deprecated through the `next-plugin-sdk-major` compatibility gate. See [Synchronous keyed store migration](/plugins/sdk-runtime/state-and-system#synchronous-keyed-store-migration).
 
     `openBlobStore<TMetadata>(...)` stores bounded binary payloads in shared SQLite without base64 or file sidecars. It requires per-entry, per-namespace byte, and row limits; copies byte arrays at the API boundary; and lists metadata without loading every BLOB. `register(...)` is an explicit upsert, including for expired keys. `registerIfAbsent(...)` provides collision-safe creation: an expired key remains occupied until its owner claims it with `deleteExpiredKey(key)` or `deleteExpired()`, preserving metadata needed to remove related named artifacts after the SQLite commit. Any row with a TTL is transient and excluded from backup/restore even before it expires; omit TTL for durable, restorable state. Host fuses cap each BLOB at 100 MiB, each plugin at 512 MiB of physically stored BLOBs, and each plugin at 50,000 physically stored rows, including expired rows awaiting owner cleanup. Use `registerIfAbsent(...)` with `overflowPolicy: "reject-new"` when external materializations must not be silently orphaned by replacement or eviction.
@@ -175,7 +179,7 @@ callbacks inside the transaction containing the authoritative read and mutation.
 Finish asynchronous planning before calling these methods; do not make their
 callbacks async or replace atomic operations with separate lookups and writes.
 Returning `undefined` from an updater leaves the entry unchanged. `update`,
-`deleteIf`, and `lookupMany` remain optional in public store types, so preserve
+`deleteIf`, `lookupMany`, and `count` remain optional in public store types, so preserve
 capability checks for supported older hosts and third-party adapters.
 
 This deprecation adds editor annotations, documentation, and compatibility

--- a/extensions/clickclack/src/discussions/binding-store.ts
+++ b/extensions/clickclack/src/discussions/binding-store.ts
@@ -109,9 +109,7 @@ export class ClickClackDiscussionBindingStore {
   }
 
   hasCapacity(sessionKey: string): boolean {
-    return (
-      this.get(sessionKey) !== undefined || this.#store.entries().length < MAX_DISCUSSION_BINDINGS
-    );
+    return this.get(sessionKey) !== undefined || this.count() < MAX_DISCUSSION_BINDINGS;
   }
 
   getByChannel(
@@ -162,6 +160,10 @@ export class ClickClackDiscussionBindingStore {
 
   entries(): Array<{ sessionKey: string; binding: ClickClackDiscussionBinding }> {
     return this.#store.entries().map((entry) => ({ sessionKey: entry.key, binding: entry.value }));
+  }
+
+  count(): number {
+    return this.#store.count?.() ?? this.#store.entries().length;
   }
 
   detachedCount(): number {

--- a/extensions/clickclack/src/discussions/service.ts
+++ b/extensions/clickclack/src/discussions/service.ts
@@ -641,7 +641,7 @@ export class ClickClackDiscussionService {
     // Without a gateway-event subscription (no broadcaster in this process),
     // bindings fall back to the interval poll or renames would never reconcile.
     const needsBindingPoll =
-      this.#unsubscribeSessionsChanged === undefined && this.#store.entries().length > 0;
+      this.#unsubscribeSessionsChanged === undefined && this.#store.count() > 0;
     if (this.#closed || (!hasPendingOpens && !needsBindingPoll)) {
       if (this.#timer) {
         clearInterval(this.#timer);

--- a/extensions/memory-wiki/src/import-runs-state.ts
+++ b/extensions/memory-wiki/src/import-runs-state.ts
@@ -441,7 +441,8 @@ export function createMemoryWikiImportRunStateStore(
       );
     },
     async rowCount() {
-      return (await openStore().entries()).length;
+      const store = openStore();
+      return (await store.count?.()) ?? (await store.entries()).length;
     },
   };
 }

--- a/extensions/reef/src/state.ts
+++ b/extensions/reef/src/state.ts
@@ -425,6 +425,9 @@ export class ReviewApprovalStore {
       throw new Error("Reef review retention requires atomic plugin-state deleteIf");
     }
     while (true) {
+      if (this.#store.count && this.#store.count() < this.#maxEntries) {
+        return;
+      }
       const entries = this.#store.entries();
       if (entries.length < this.#maxEntries) {
         return;

--- a/extensions/voice-call/src/manager/store.test.ts
+++ b/extensions/voice-call/src/manager/store.test.ts
@@ -46,7 +46,7 @@ function installStateRuntime({
   bulkReads?: boolean;
   beforeOperation?: (
     namespace: string,
-    operation: "register" | "entries",
+    operation: "register" | "entries" | "count",
     key?: string,
   ) => Promise<void>;
 } = {}): void {
@@ -67,12 +67,16 @@ function installStateRuntime({
                 await beforeOperation(options.namespace, "entries");
                 return backingStore.entries();
               },
+              async count() {
+                await beforeOperation(options.namespace, "count");
+                return (await backingStore.count?.()) ?? (await backingStore.entries()).length;
+              },
             }
           : backingStore;
         if (bulkReads) {
           return store;
         }
-        const { lookupMany: _lookupMany, ...legacy } = store;
+        const { lookupMany: _lookupMany, count: _count, ...legacy } = store;
         return legacy;
       },
     },
@@ -423,11 +427,11 @@ describe("voice-call call record store", () => {
   it("propagates pruning rejection and preserves restore versus status read errors", async () => {
     const storePath = createTestStorePath();
     const call = CallRecordSchema.parse(makePersistedCall({ callId: "call-read-error" }));
-    const failure = new Error("delayed SQLite listing rejected");
+    const failure = new Error("delayed SQLite read rejected");
     installStateRuntime({
       beforeOperation: async (_namespace, operation) => {
         await Promise.resolve();
-        if (operation === "entries") {
+        if (operation === "entries" || operation === "count") {
           throw failure;
         }
       },

--- a/extensions/voice-call/src/manager/store.ts
+++ b/extensions/voice-call/src/manager/store.ts
@@ -278,6 +278,9 @@ async function deleteCallRecordEventRows(
 
 /** Keep only the newest bounded call record events. */
 async function pruneCallRecordEvents(stores: CallRecordStateStores): Promise<void> {
+  if (stores.events.count && (await stores.events.count()) <= MAX_CALL_RECORD_EVENTS) {
+    return;
+  }
   const rows = await stores.events.entries();
   if (rows.length <= MAX_CALL_RECORD_EVENTS) {
     return;

--- a/src/plugin-state/plugin-state-store.errors.test.ts
+++ b/src/plugin-state/plugin-state-store.errors.test.ts
@@ -147,6 +147,8 @@ describe("plugin state open errors", () => {
           await expect(store.lookupMany(["key"])).resolves.toEqual([
             { ok: false, error: expect.objectContaining({ ...expected, operation: "lookup" }) },
           ]);
+          expect(sync.count()).toBe(1);
+          await expect(store.count()).resolves.toBe(1);
         }
         let callbackCalled = false;
         for (const stateStore of [sync, store]) {

--- a/src/plugin-state/plugin-state-store.expiry.test.ts
+++ b/src/plugin-state/plugin-state-store.expiry.test.ts
@@ -39,6 +39,30 @@ afterAll(async () => {
 });
 
 describe("plugin state expiry cleanup", () => {
+  it("counts live rows in its namespace without deleting expired rows", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+    const scope = { pluginId: "discord", namespace: "count-expiry" };
+    seedPluginStateEntriesForTests([
+      { ...scope, key: "permanent", value: 1 },
+      { ...scope, key: "future", value: 2, expiresAt: 1_200 },
+      { ...scope, key: "boundary", value: 3, expiresAt: 1_000 },
+      { ...scope, key: "expired", value: 4, expiresAt: 999 },
+      { ...scope, namespace: "sibling", key: "permanent", value: 5 },
+      { ...scope, pluginId: "telegram", key: "permanent", value: 6 },
+    ]);
+    const options = { namespace: scope.namespace, maxEntries: 10 };
+    const sync = createPluginStateSyncKeyedStore(scope.pluginId, options);
+    const store = createPluginStateKeyedStore(scope.pluginId, options);
+
+    expect(sync.count()).toBe(2);
+    await expect(store.count()).resolves.toBe(2);
+    vi.setSystemTime(1_200);
+    expect(sync.count()).toBe(1);
+    await expect(store.count()).resolves.toBe(1);
+    expect(sweepExpiredPluginStateEntries()).toBe(3);
+  });
+
   it("rechecks expiry time and newly written rows after an empty namespace cleanup", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(1_000);

--- a/src/plugin-state/plugin-state-store.fresh-store.test.ts
+++ b/src/plugin-state/plugin-state-store.fresh-store.test.ts
@@ -19,7 +19,7 @@ afterEach(() => {
 
 async function expectPluginStateReadFailure(
   promise: Promise<unknown>,
-  expected: { operation: "entries" | "lookup"; path: string },
+  expected: { operation: "entries" | "lookup" | "count"; path: string },
 ): Promise<void> {
   let storeError: unknown;
   try {
@@ -52,6 +52,7 @@ describe("plugin state fresh-store reads", () => {
         await expect(store.lookup("k")).resolves.toBeUndefined();
         await expect(store.lookupMany(["k"])).resolves.toEqual([{ ok: true, value: undefined }]);
         await expect(store.entries()).resolves.toEqual([]);
+        await expect(store.count()).resolves.toBe(0);
         expect(
           pluginStateEntriesInKeyRange({
             pluginId: "discord",
@@ -103,6 +104,10 @@ describe("plugin state fresh-store reads", () => {
         });
         await expectPluginStateReadFailure(store.entries(), {
           operation: "entries",
+          path: databasePath,
+        });
+        await expectPluginStateReadFailure(store.count(), {
+          operation: "count",
           path: databasePath,
         });
       },

--- a/src/plugin-state/plugin-state-store.kernel.ts
+++ b/src/plugin-state/plugin-state-store.kernel.ts
@@ -335,7 +335,7 @@ const pluginStateNamespaceCountQueries = new WeakMap<
   ReturnType<typeof prepareSqliteQuerySync<PluginStateNamespaceCountParams, PluginStateCountRow>>
 >();
 
-function countLivePluginStateNamespaceEntries(
+export function countLivePluginStateNamespaceEntries(
   db: DatabaseSync,
   params: PluginStateNamespaceCountParams,
 ): number {

--- a/src/plugin-state/plugin-state-store.runtime.test.ts
+++ b/src/plugin-state/plugin-state-store.runtime.test.ts
@@ -101,6 +101,8 @@ describe("plugin runtime state proxy", () => {
         maxEntries: 10,
       });
       await expect(telegramStore.lookup("k")).resolves.toBeUndefined();
+      await expect(telegramStore.count?.()).resolves.toBe(0);
+      await expect(store.count?.()).resolves.toBe(1);
       await expect(telegramStore.lookupMany?.(["k"])).resolves.toEqual([
         { ok: true, value: undefined },
       ]);

--- a/src/plugin-state/plugin-state-store.sqlite.ts
+++ b/src/plugin-state/plugin-state-store.sqlite.ts
@@ -38,6 +38,7 @@ import {
   deleteExpiredPluginStateEntries,
   allocatePluginStateNamespaceCreatedAt,
   countLivePluginStateEntries,
+  countLivePluginStateNamespaceEntries,
   readPluginStateRetention,
   enforcePostRegisterLimits,
   assertCanInsertPluginStateEntry,
@@ -887,6 +888,36 @@ export function pluginStateDoctorEntriesInKeyRange(params: {
       return entry;
     },
   );
+}
+
+export function pluginStateCount(params: {
+  pluginId: string;
+  namespace: string;
+  env?: NodeJS.ProcessEnv;
+}): number {
+  const pathname = resolveOpenClawStateSqlitePath(params.env ?? process.env);
+  try {
+    return (
+      withPluginStateDatabaseReadOnly(
+        "count",
+        ({ db }) =>
+          countLivePluginStateNamespaceEntries(db, {
+            pluginId: params.pluginId,
+            namespace: params.namespace,
+            now: Date.now(),
+          }),
+        envOptions(params.env),
+      ) ?? 0
+    );
+  } catch (error) {
+    throw wrapPluginStateError(
+      error,
+      "count",
+      "PLUGIN_STATE_READ_FAILED",
+      "Failed to count plugin state entries.",
+      pathname,
+    );
+  }
 }
 
 export function pluginStateEntries(params: {

--- a/src/plugin-state/plugin-state-store.test.ts
+++ b/src/plugin-state/plugin-state-store.test.ts
@@ -668,6 +668,7 @@ describe("plugin state keyed store", () => {
         }),
       ).toMatchObject([{ key: "k", value: { ok: true } }]);
       expect(countPluginStateLiveEntries("discord")).toBe(1);
+      await expect(store.count()).resolves.toBe(1);
       expect(isOpenClawStateDatabaseOpen()).toBe(false);
     });
   });
@@ -691,6 +692,7 @@ describe("plugin state keyed store", () => {
         ]);
         await expect(store.lookupMany([])).resolves.toEqual([]);
         await expect(store.entries()).resolves.toEqual([]);
+        await expect(store.count()).resolves.toBe(0);
         expect(countPluginStateLiveEntries("discord", state.env)).toBe(0);
         expect(existsSync(databasePath)).toBe(false);
       },

--- a/src/plugin-state/plugin-state-store.ts
+++ b/src/plugin-state/plugin-state-store.ts
@@ -9,6 +9,7 @@ import {
   pluginStateImportBatch,
   pluginStateClear,
   pluginStateConsume,
+  pluginStateCount,
   pluginStateDelete,
   pluginStateDeleteIf,
   pluginStateEntries,
@@ -180,6 +181,7 @@ function createKeyedStoreForPluginId<T>(
     consume: async (...args) => store.consume(...args),
     delete: async (...args) => store.delete(...args),
     entries: async () => store.entries(),
+    count: async () => store.count(),
     clear: async () => store.clear(),
   };
 }
@@ -305,6 +307,9 @@ function createSyncKeyedStoreForPluginId<T>(
         namespace,
         ...(env ? { env } : {}),
       }) as PluginStateEntry<T>[];
+    },
+    count() {
+      return pluginStateCount({ pluginId, namespace, ...(env ? { env } : {}) });
     },
     clear() {
       pluginStateClear({ pluginId, namespace, ...(env ? { env } : {}) });

--- a/src/plugin-state/plugin-state-store.types.ts
+++ b/src/plugin-state/plugin-state-store.types.ts
@@ -29,6 +29,8 @@ export type PluginStateKeyedStore<T> = {
   consume(key: string): Promise<T | undefined>;
   delete(key: string): Promise<boolean>;
   entries(): Promise<PluginStateEntry<T>[]>;
+  /** Counts live stored rows without decoding values; absent on older hosts and adapters. */
+  count?: () => Promise<number>;
   clear(): Promise<void>;
 };
 
@@ -53,6 +55,8 @@ export type PluginStateSyncKeyedStore<T> = {
   consume(key: string): T | undefined;
   delete(key: string): boolean;
   entries(): PluginStateEntry<T>[];
+  /** Counts live stored rows without decoding values; absent on older hosts and adapters. */
+  count?: () => number;
   clear(): void;
 };
 
@@ -85,6 +89,7 @@ export type PluginStateStoreOperation =
   | "consume"
   | "delete"
   | "entries"
+  | "count"
   | "clear"
   | "sweep"
   | "probe"


### PR DESCRIPTION
## What Problem This Solves

Plugins load and decode every stored value just to count records or decide whether capacity cleanup is necessary. Large Memory Wiki import histories make these reads especially expensive.

## Why This Change Was Made

Expose the existing SQLite namespace count through an optional keyed-store `count()` operation and use it in Memory Wiki, ClickClack, Reef, and Voice Call. It counts live rows without decoding JSON, creating a missing database, or deleting expired rows. Actual eviction and capacity enforcement stay with the existing write owners.

The optional method preserves older hosts and third-party adapters: callers enumerate only when the method is absent, and count errors propagate. Corrupt JSON still occupies a row and counts; value-reading operations retain their decoding errors. This contract is documented. No schema or persisted-format changes.

## User Impact

Record counts and under-capacity checks allocate less memory and finish faster as plugin state grows. Retention decisions and older-host support remain intact.

## Evidence

- 158 focused tests passed across nine core and plugin files, including TTL boundaries, namespace isolation, read-only lifecycle, errors, retention, and older-host adapters.
- Live isolated SQLite proof exercised the actual Memory Wiki `rowCount()` adapter against native and older-host stores. Missing databases returned zero without creating storage.
- With 17,431-byte JSON rows, 21 warm interleaved rounds measured 1,000 rows at 30.818 ms before / 0.621 ms after (49.6x), and 5,000 rows at 140.402 ms / 0.713 ms (196.9x). The count query returns one row instead of 5,000 payloads. These are local synthetic-fixture medians, not whole-application timings.
- Actual ClickClack binding-store proof at 10,000 rows rejected a new binding, allowed an existing binding, and reopened capacity after deletion, with native/older-host parity.
- Fresh independent P0-P2 review found no actionable defects. Hosted exact-head checks are required before landing.
- Exact-head hosted CI passed ([run 34710494541](https://github.com/openclaw/openclaw/actions/runs/34710494541)), including the required gate. GitHub automated review completed with no findings.
- A duplicate broader local check run was stopped after the complete exact-head hosted gate passed. Its partial run passed core production types and earlier guards; it is not reported as a full local pass. The 158 focused tests and live SQLite probes completed successfully.
