### PR TITLE
improve: speed up loading long session histories

### DIFF
--- a/docs/reference/test/performance.md
+++ b/docs/reference/test/performance.md
@@ -35,8 +35,8 @@ Measure SQLite history pages and the Gateway's bounded history reader with
 synthetic conversations, including sparse markers, dense markers, and resets:
 
 ```bash
-node --import ./scripts/tsx.mjs scripts/bench-session-history.ts --samples 30 --output history.json
-node --import ./scripts/tsx.mjs scripts/bench-session-history.ts --profile sparse,trailing,reset --operation recent --analyze --samples 15 --output history-analyzed.json
+pnpm test:sessions:history:bench --samples 30 --output history.json
+pnpm test:sessions:history:bench --profile sparse,trailing,reset --operation recent --analyze --samples 15 --output history-analyzed.json
 ```
 
 The second command includes 5,000 trailing compaction markers and refreshes

--- a/docs/reference/test/performance.md
+++ b/docs/reference/test/performance.md
@@ -29,6 +29,29 @@ Native imports also need the plugin's declared dependencies and a resolvable `op
 
 ## Benchmarks
 
+<Accordion title="Session history (scripts/bench-session-history.ts)">
+
+Measure SQLite history pages and the Gateway's bounded history reader with
+synthetic conversations, including sparse markers, dense markers, and resets:
+
+```bash
+node --import ./scripts/tsx.mjs scripts/bench-session-history.ts --samples 30 --output history.json
+node --import ./scripts/tsx.mjs scripts/bench-session-history.ts --profile sparse,trailing,reset --operation recent --analyze --samples 15 --output history-analyzed.json
+```
+
+The second command includes 5,000 trailing compaction markers and refreshes
+SQLite planner statistics before reading. Compare both statistics states when
+changing a query. `--operation` selects `recent`, `page`, or `gateway-tail`;
+omitting it measures all three.
+
+Each reader runs in a fresh process. Reports separate imports, the first read
+(including database open), and warm p50/p95 wall and CPU time. OS caches are not
+flushed. SQL plans, statement counts, rows delivered to JavaScript, and JSON
+parsing counts come from a separate instrumented read. Heap deltas are
+uncollected observations, not total allocations. Fixtures are removed afterward.
+
+</Accordion>
+
 <Accordion title="Model latency (scripts/bench-model.ts)">
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -2091,6 +2091,7 @@
     "test:startup:bench:update": "node --import ./scripts/tsx.mjs scripts/test-update-cli-startup-bench.mts",
     "test:startup:gateway": "node --import ./scripts/tsx.mjs scripts/bench-gateway-startup.ts",
     "test:restart:gateway": "node --import ./scripts/tsx.mjs scripts/bench-gateway-restart.ts",
+    "test:sessions:history:bench": "node --import ./scripts/tsx.mjs scripts/bench-session-history.ts",
     "test:sessions:hydration-memory": "node --import ./scripts/tsx.mjs scripts/bench-session-manager-hydration-memory.ts",
     "test:startup:memory": "node --import ./scripts/tsx.mjs scripts/ensure-cli-startup-build.mts && node scripts/check-cli-startup-memory.mjs",
     "test:ui": "pnpm lint:ui:no-raw-window-open && node --import ./scripts/tsx.mjs scripts/ensure-playwright-chromium.mts && pnpm --dir ui test",

--- a/scripts/bench-session-history.ts
+++ b/scripts/bench-session-history.ts
@@ -5,6 +5,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { StatementSync } from "node:sqlite";
+import { mock } from "node:test";
 import { fileURLToPath } from "node:url";
 import { parseArgs } from "node:util";
 import type { TranscriptEvent } from "../src/config/sessions/session-accessor.sqlite-contract.js";
@@ -131,9 +132,9 @@ async function trace(read: () => Promise<unknown>) {
   const queries = new Map<string, QueryTrace>();
   const originalParse = JSON.parse;
   const originalStringify = JSON.stringify;
-  // Native methods are restored unchanged and invoked with the original statement receiver.
-  // oxlint-disable-next-line typescript/unbound-method
-  const { get: originalGet, all: originalAll, iterate: originalIterate } = StatementSync.prototype;
+  const originalGet = mock.method(StatementSync.prototype, "get");
+  const originalAll = mock.method(StatementSync.prototype, "all");
+  const originalIterate = mock.method(StatementSync.prototype, "iterate");
   let jsonParseCalls = 0;
   let jsonParseBytes = 0;
   let jsonStringifyCalls = 0;
@@ -176,7 +177,7 @@ async function trace(read: () => Promise<unknown>) {
       value(this: StatementSync, ...args: unknown[]) {
         const record = query(this, args);
         const start = performance.now();
-        const result: unknown = Reflect.apply(original, this, args);
+        const result: unknown = Reflect.apply(original.bind(this), undefined, args);
         record.elapsedMs += performance.now() - start;
         record.rows += Array.isArray(result) ? result.length : result === undefined ? 0 : 1;
         return result;
@@ -188,7 +189,7 @@ async function trace(read: () => Promise<unknown>) {
     writable: true,
     *value(this: StatementSync, ...args: unknown[]) {
       const record = query(this, args);
-      const iterator = Reflect.apply(originalIterate, this, args);
+      const iterator = Reflect.apply(originalIterate.bind(this), undefined, args);
       try {
         while (true) {
           const start = performance.now();
@@ -210,9 +211,9 @@ async function trace(read: () => Promise<unknown>) {
   } finally {
     JSON.parse = originalParse;
     JSON.stringify = originalStringify;
-    StatementSync.prototype.get = originalGet;
-    StatementSync.prototype.all = originalAll;
-    StatementSync.prototype.iterate = originalIterate;
+    originalGet.mock.restore();
+    originalAll.mock.restore();
+    originalIterate.mock.restore();
   }
   return { queries: [...queries.values()], jsonParseCalls, jsonParseBytes, jsonStringifyCalls };
 }

--- a/scripts/bench-session-history.ts
+++ b/scripts/bench-session-history.ts
@@ -1,0 +1,411 @@
+// Synthetic session-history owner benchmark. No operator state is read or changed.
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { StatementSync } from "node:sqlite";
+import { fileURLToPath } from "node:url";
+import { parseArgs } from "node:util";
+import type { TranscriptEvent } from "../src/config/sessions/session-accessor.sqlite-contract.js";
+import { parseStrictIntegerOption } from "./lib/strict-integer-option.ts";
+
+const profiles = {
+  small: { messages: 80, markers: false, reset: false },
+  long: { messages: 10_000, markers: false, reset: false },
+  sparse: { messages: 10_000, markers: false, reset: false },
+  markers: { messages: 10_000, markers: true, reset: false },
+  reset: { messages: 10_000, markers: true, reset: true },
+  trailing: { messages: 5_000, markers: false, reset: false },
+} as const;
+type Profile = keyof typeof profiles;
+const operations = ["recent", "page", "gateway-tail"] as const;
+type Operation = (typeof operations)[number];
+const { values } = parseArgs({
+  options: {
+    profile: { type: "string" },
+    samples: { type: "string", default: "30" },
+    output: { type: "string" },
+    worker: { type: "string" },
+    operation: { type: "string" },
+    analyze: { type: "boolean" },
+    help: { type: "boolean" },
+  },
+});
+const samples = parseStrictIntegerOption({
+  fallback: 30,
+  label: "--samples",
+  min: 1,
+  raw: values.samples,
+});
+
+function scopeFor(stateDir: string, profile: Profile) {
+  const sessionId = `bench-${profile}`;
+  return {
+    agentId: "main",
+    sessionId,
+    sessionKey: `agent:main:${sessionId}`,
+    storePath: path.join(stateDir, "agents/main/sessions/sessions.json"),
+    env: { ...process.env, OPENCLAW_STATE_DIR: stateDir },
+  };
+}
+
+function fixture(profile: Profile): TranscriptEvent[] {
+  const spec = profiles[profile];
+  const events: TranscriptEvent[] = [{ type: "session", version: 3, id: `bench-${profile}` }];
+  let parentId: string | null = null;
+  const append = (event: Record<string, unknown> & { id: string }) => {
+    events.push({ ...event, parentId, timestamp: "2026-09-01T00:00:00.000Z" });
+    parentId = event.id;
+  };
+  for (let index = 0; index < spec.messages; index += 1) {
+    if (spec.reset && index === spec.messages - 1000) {
+      append({
+        type: "reset",
+        id: "reset",
+        reason: "new",
+        firstKeptEntryId: `message-${index - 2}`,
+      });
+    }
+    append({
+      type: "message",
+      id: `message-${index}`,
+      message: {
+        role: index % 2 === 0 ? "user" : "assistant",
+        content: [{ type: "text", text: `Synthetic message ${index}: ${"x".repeat(1024)}` }],
+      },
+    });
+    if (spec.markers) {
+      append({
+        type: "custom_message",
+        id: `marker-${index}`,
+        customType: "benchmark-notice",
+        content: `Synthetic notice ${index}`,
+        display: index % 2 === 0,
+      });
+    }
+    if (profile === "sparse" && index % 1000 === 0) {
+      append({ type: "compaction", id: `compaction-${index}`, summary: "Synthetic compaction" });
+    }
+  }
+  if (profile === "trailing") {
+    for (let index = 0; index < 5000; index += 1) {
+      append({ type: "compaction", id: `trailing-${index}`, summary: "Synthetic compaction" });
+    }
+  }
+  return events;
+}
+
+function percentile(numbers: number[], percent: number): number {
+  const ordered = numbers.toSorted((a, b) => a - b);
+  return Number(
+    (ordered[Math.max(0, Math.ceil((percent / 100) * ordered.length) - 1)] ?? 0).toFixed(3),
+  );
+}
+
+type Sample = { wallMs: number; cpuMs: number; heapDeltaBytes: number; rssBytes: number };
+async function measure(read: () => Promise<unknown>): Promise<Sample> {
+  const before = process.memoryUsage();
+  const cpu = process.cpuUsage();
+  const start = performance.now();
+  await read();
+  const wallMs = performance.now() - start;
+  const usedCpu = process.cpuUsage(cpu);
+  const after = process.memoryUsage();
+  return {
+    wallMs,
+    cpuMs: (usedCpu.user + usedCpu.system) / 1000,
+    heapDeltaBytes: after.heapUsed - before.heapUsed,
+    rssBytes: after.rss,
+  };
+}
+
+type QueryTrace = {
+  sql: string;
+  calls: number;
+  rows: number;
+  elapsedMs: number;
+  bindings: unknown[];
+};
+async function trace(read: () => Promise<unknown>) {
+  const queries = new Map<string, QueryTrace>();
+  const originalParse = JSON.parse;
+  const originalStringify = JSON.stringify;
+  // Native methods are restored unchanged and invoked with the original statement receiver.
+  // oxlint-disable-next-line typescript/unbound-method
+  const { get: originalGet, all: originalAll, iterate: originalIterate } = StatementSync.prototype;
+  let jsonParseCalls = 0;
+  let jsonParseBytes = 0;
+  let jsonStringifyCalls = 0;
+  const query = (statement: StatementSync, bindings: unknown[]) => {
+    const sql = statement.sourceSQL;
+    let record = queries.get(sql);
+    if (!record) {
+      record = { sql, calls: 0, rows: 0, elapsedMs: 0, bindings };
+      queries.set(sql, record);
+    }
+    record.calls += 1;
+    return record;
+  };
+  Object.defineProperty(JSON, "parse", {
+    configurable: true,
+    writable: true,
+    value(...args: unknown[]) {
+      jsonParseCalls += 1;
+      if (typeof args[0] === "string") {
+        jsonParseBytes += Buffer.byteLength(args[0]);
+      }
+      return Reflect.apply(originalParse, JSON, args);
+    },
+  });
+  Object.defineProperty(JSON, "stringify", {
+    configurable: true,
+    writable: true,
+    value(...args: unknown[]) {
+      jsonStringifyCalls += 1;
+      return Reflect.apply(originalStringify, JSON, args);
+    },
+  });
+  for (const [name, original] of [
+    ["get", originalGet],
+    ["all", originalAll],
+  ] as const) {
+    Object.defineProperty(StatementSync.prototype, name, {
+      configurable: true,
+      writable: true,
+      value(this: StatementSync, ...args: unknown[]) {
+        const record = query(this, args);
+        const start = performance.now();
+        const result: unknown = Reflect.apply(original, this, args);
+        record.elapsedMs += performance.now() - start;
+        record.rows += Array.isArray(result) ? result.length : result === undefined ? 0 : 1;
+        return result;
+      },
+    });
+  }
+  Object.defineProperty(StatementSync.prototype, "iterate", {
+    configurable: true,
+    writable: true,
+    *value(this: StatementSync, ...args: unknown[]) {
+      const record = query(this, args);
+      const iterator = Reflect.apply(originalIterate, this, args);
+      try {
+        while (true) {
+          const start = performance.now();
+          const next = iterator.next();
+          record.elapsedMs += performance.now() - start;
+          if (next.done) {
+            break;
+          }
+          record.rows += 1;
+          yield next.value;
+        }
+      } finally {
+        iterator.return?.();
+      }
+    },
+  });
+  try {
+    await read();
+  } finally {
+    JSON.parse = originalParse;
+    JSON.stringify = originalStringify;
+    StatementSync.prototype.get = originalGet;
+    StatementSync.prototype.all = originalAll;
+    StatementSync.prototype.iterate = originalIterate;
+  }
+  return { queries: [...queries.values()], jsonParseCalls, jsonParseBytes, jsonStringifyCalls };
+}
+
+async function worker(stateDir: string, profile: Profile, operation: Operation) {
+  const scope = scopeFor(stateDir, profile);
+  const importStarted = performance.now();
+  const history = await import("../src/config/sessions/session-accessor.sqlite-history-events.js");
+  const gateway =
+    operation === "gateway-tail"
+      ? await import("../src/gateway/session-history-tail.js")
+      : undefined;
+  const { openOpenClawAgentDatabase, closeOpenClawAgentDatabasesForTest } =
+    await import("../src/state/openclaw-agent-db.js");
+  const importMs = performance.now() - importStarted;
+  const read = async () => {
+    if (gateway) {
+      const result = await gateway.readIncrementalChatHistoryTail({
+        entry: undefined,
+        readScope: scope,
+        effectiveMaxChars: 8000,
+        max: 20,
+        maxBytes: 256 * 1024,
+      });
+      assert.ok(result.projected.length >= 20);
+      return { returned: result.projected.length, total: result.readPage.totalMessages };
+    }
+    const result =
+      operation === "recent"
+        ? history.readRecentSessionTranscriptHistoryEvents(scope, {
+            maxMessages: 20,
+            maxLines: 20,
+            maxBytes: 256 * 1024,
+          })
+        : history.readSessionTranscriptHistoryEventPage(scope, {
+            maxMessages: 20,
+            offset: 40,
+            maxBytes: 256 * 1024,
+          });
+    assert.equal(result.events.length, 20);
+    return { returned: result.events.length, total: result.totalMessages };
+  };
+  try {
+    // A fresh child has no history/module/statement cache; the OS page cache is not flushed.
+    const firstRead = await measure(read);
+    for (let index = 0; index < 5; index += 1) {
+      await read();
+    }
+    const timings: Sample[] = [];
+    for (let index = 0; index < samples; index += 1) {
+      timings.push(await measure(read));
+    }
+    const traced = await trace(read);
+    const database = openOpenClawAgentDatabase({ agentId: "main", env: scope.env });
+    const queries = traced.queries.map(({ bindings, ...record }) => {
+      const explain = database.db.prepare(`EXPLAIN QUERY PLAN ${record.sql}`);
+      return { ...record, plan: Reflect.apply(explain.all.bind(explain), undefined, bindings) };
+    });
+    console.log(
+      JSON.stringify({
+        profile,
+        operation,
+        importMs,
+        firstRead,
+        warm: {
+          samples,
+          p50Ms: percentile(
+            timings.map((sample) => sample.wallMs),
+            50,
+          ),
+          p95Ms: percentile(
+            timings.map((sample) => sample.wallMs),
+            95,
+          ),
+          cpuP50Ms: percentile(
+            timings.map((sample) => sample.cpuMs),
+            50,
+          ),
+          cpuP95Ms: percentile(
+            timings.map((sample) => sample.cpuMs),
+            95,
+          ),
+          heapDeltaP50Bytes: percentile(
+            timings.map((sample) => sample.heapDeltaBytes),
+            50,
+          ),
+          maxRssBytes: Math.max(...timings.map((sample) => sample.rssBytes)),
+        },
+        result: await read(),
+        trace: { ...traced, queries },
+      }),
+    );
+  } finally {
+    closeOpenClawAgentDatabasesForTest(stateDir);
+  }
+}
+
+async function main() {
+  if (values.help) {
+    console.log(
+      "Usage: node --import tsx scripts/bench-session-history.ts [--profile small,long,sparse,markers,reset,trailing] [--operation recent|page|gateway-tail] [--samples 30] [--analyze] [--output report.json]\nReports a fresh-process first read and warm p50/p95, CPU, RSS, heap deltas, and separate SQL/JSON tracing. Fixtures are synthetic and automatically removed; OS caches are not flushed.",
+    );
+    return;
+  }
+  const selected = values.profile
+    ? values.profile.split(",")
+    : Object.keys(profiles).filter((profile) => profile !== "trailing");
+  for (const name of selected) {
+    assert.ok(Object.hasOwn(profiles, name), `Unknown profile ${name}`);
+  }
+  const selectedOperations = values.operation ? [values.operation as Operation] : operations;
+  for (const operation of selectedOperations) {
+    assert.ok(operations.includes(operation), `Unknown operation ${operation}`);
+  }
+  if (values.worker) {
+    assert.ok(values.profile && Object.hasOwn(profiles, values.profile));
+    assert.ok(operations.includes(values.operation as Operation));
+    await worker(values.worker, values.profile as Profile, values.operation as Operation);
+    return;
+  }
+  const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-history-benchmark-"));
+  const configPath = path.join(stateDir, "openclaw.json");
+  fs.writeFileSync(configPath, "{}\n");
+  process.env.OPENCLAW_STATE_DIR = stateDir;
+  process.env.OPENCLAW_CONFIG_PATH = configPath;
+  const { replaceTranscriptEvents } =
+    await import("../src/config/sessions/session-accessor.sqlite-transcript-write.js");
+  const { waitForSessionTranscriptProjection } =
+    await import("../src/config/sessions/session-transcript-reconcile.js");
+  const { openOpenClawAgentDatabase, closeOpenClawAgentDatabasesForTest } =
+    await import("../src/state/openclaw-agent-db.js");
+  const { closeOpenClawStateDatabaseForTest } = await import("../src/state/openclaw-state-db.js");
+  const results: unknown[] = [];
+  try {
+    for (const name of selected) {
+      const profile = name as Profile;
+      await replaceTranscriptEvents(scopeFor(stateDir, profile), fixture(profile));
+      await waitForSessionTranscriptProjection(scopeFor(stateDir, profile));
+      if (values.analyze) {
+        openOpenClawAgentDatabase({
+          agentId: "main",
+          env: scopeFor(stateDir, profile).env,
+        }).db.exec("ANALYZE");
+      }
+      closeOpenClawAgentDatabasesForTest(stateDir);
+      closeOpenClawStateDatabaseForTest();
+      for (const operation of selectedOperations) {
+        const child = spawnSync(
+          process.execPath,
+          [
+            "--import",
+            "tsx",
+            fileURLToPath(import.meta.url),
+            "--worker",
+            stateDir,
+            "--profile",
+            profile,
+            "--operation",
+            operation,
+            "--samples",
+            String(samples),
+          ],
+          { env: process.env, encoding: "utf8", maxBuffer: 16 * 1024 * 1024 },
+        );
+        if (child.status !== 0) {
+          throw new Error(child.stderr || child.stdout || String(child.error));
+        }
+        const result: unknown = JSON.parse(child.stdout);
+        results.push(result);
+        console.error(`${profile}/${operation} measured`);
+      }
+    }
+    const report = {
+      schemaVersion: 1,
+      node: process.version,
+      platform: `${process.platform}-${process.arch}`,
+      cpus: os.cpus()[0]?.model,
+      methodology:
+        "Fresh-process first read excludes module import and includes database open. OS caches are not flushed. Warm samples exclude setup and tracing. Heap deltas are uncollected observations, not allocation totals. Trace counts rows delivered to JS, not rows scanned inside SQLite.",
+      profiles,
+      analyzed: values.analyze ?? false,
+      results,
+    };
+    const output = `${JSON.stringify(report, null, 2)}\n`;
+    if (values.output) {
+      fs.writeFileSync(path.resolve(values.output), output);
+    }
+    console.log(output);
+  } finally {
+    closeOpenClawAgentDatabasesForTest(stateDir);
+    closeOpenClawStateDatabaseForTest();
+    fs.rmSync(stateDir, { recursive: true, force: true });
+  }
+}
+
+await main();

--- a/src/config/sessions/session-accessor.sqlite-active-events.ts
+++ b/src/config/sessions/session-accessor.sqlite-active-events.ts
@@ -8,7 +8,6 @@ import {
 import {
   getActiveTranscriptKysely,
   parseActiveTranscriptMessageRow,
-  readTranscriptProjectionGeneration,
   withCurrentProjectionSnapshot,
   type SessionTranscriptMessageEvent,
 } from "./session-accessor.sqlite-active-projection.js";
@@ -257,7 +256,7 @@ export function readSessionTranscriptVisibleMessageDeltaCore(
       database: projection.database,
       ...projection.resolved,
     });
-    const generation = readTranscriptProjectionGeneration(projection);
+    const generation = projection.generation;
     if (!generation) {
       return { kind: "missing" };
     }
@@ -496,7 +495,7 @@ export function readSessionTranscriptBoundedMessageTailPage(
   return withCurrentProjectionSnapshot(scope, (projection) => {
     const visible = resolveVisibleMessagePositions(projection);
     const snapshot = {
-      generation: readTranscriptProjectionGeneration(projection),
+      generation: projection.generation,
       indexedSeq: projection.state.indexedSeq,
     };
     const totalMessages = visible.total;

--- a/src/config/sessions/session-accessor.sqlite-active-projection.ts
+++ b/src/config/sessions/session-accessor.sqlite-active-projection.ts
@@ -31,6 +31,7 @@ type ActiveTranscriptDatabase = Pick<
 
 export type CurrentTranscriptProjection = {
   database: OpenClawAgentDatabase;
+  generation: string | undefined;
   resolved: ReturnType<typeof resolveSqliteTranscriptReadScope>;
   state: SessionTranscriptProjectionState;
 };
@@ -72,28 +73,41 @@ export function parseActiveTranscriptMessageRow(row: {
   };
 }
 
-export function readTranscriptProjectionGeneration(
-  projection: CurrentTranscriptProjection,
+function readEmptyTranscriptGeneration(
+  database: OpenClawAgentDatabase,
+  sessionId: string,
 ): string | undefined {
   return executeSqliteQueryTakeFirstSync(
-    projection.database.db,
-    getActiveTranscriptKysely(projection.database)
+    database.db,
+    getActiveTranscriptKysely(database)
       .selectFrom("transcript_rewrite_watermarks")
       .select("generation")
-      .where("session_id", "=", projection.resolved.sessionId),
+      .where("session_id", "=", sessionId),
   )?.generation;
 }
 
 function readProjectionSnapshot(
   database: OpenClawAgentDatabase,
   sessionId: string,
-): { latestSeq: number; state?: SessionTranscriptProjectionState } | undefined {
+):
+  | {
+      generation: string | undefined;
+      latestSeq: number;
+      state?: SessionTranscriptProjectionState;
+    }
+  | undefined {
   const row = executeSqliteQueryTakeFirstSync(
     database.db,
     getActiveTranscriptKysely(database)
       .selectFrom("transcript_events as latest")
       .leftJoin("session_transcript_index_state as state", "state.session_id", "latest.session_id")
+      .leftJoin(
+        "transcript_rewrite_watermarks as watermark",
+        "watermark.session_id",
+        "latest.session_id",
+      )
       .select([
+        "watermark.generation",
         "latest.seq as latest_seq",
         "state.active_event_count",
         "state.active_message_count",
@@ -109,6 +123,7 @@ function readProjectionSnapshot(
     return undefined;
   }
   return {
+    generation: row.generation ?? undefined,
     latestSeq: row.latest_seq,
     ...(typeof row.indexed_seq === "number"
       ? {
@@ -139,7 +154,12 @@ export function withCurrentProjectionSnapshot<T>(
       if (!snapshot) {
         return {
           kind: "value" as const,
-          value: read({ database, resolved, state: EMPTY_PROJECTION_STATE }),
+          value: read({
+            database,
+            generation: readEmptyTranscriptGeneration(database, resolved.sessionId),
+            resolved,
+            state: EMPTY_PROJECTION_STATE,
+          }),
         };
       }
       if (
@@ -150,7 +170,12 @@ export function withCurrentProjectionSnapshot<T>(
       ) {
         return {
           kind: "value" as const,
-          value: read({ database, resolved, state: snapshot.state }),
+          value: read({
+            database,
+            generation: snapshot.generation,
+            resolved,
+            state: snapshot.state,
+          }),
         };
       }
       return { kind: "unavailable" as const };

--- a/src/config/sessions/session-accessor.sqlite-display-position.ts
+++ b/src/config/sessions/session-accessor.sqlite-display-position.ts
@@ -8,7 +8,6 @@ import {
 } from "../../sessions/transcript-display-position.js";
 import {
   getActiveTranscriptKysely,
-  readTranscriptProjectionGeneration,
   type CurrentTranscriptProjection,
 } from "./session-accessor.sqlite-active-projection.js";
 import type { TranscriptEvent } from "./session-accessor.sqlite-contract.js";
@@ -17,7 +16,7 @@ import { resolveSqliteSessionTranscriptReadFence } from "./session-transcript-re
 export function readTranscriptDisplaySource(
   projection: CurrentTranscriptProjection,
 ): string | undefined {
-  const generation = readTranscriptProjectionGeneration(projection);
+  const generation = projection.generation;
   return generation
     ? createTranscriptDisplaySource([
         "sqlite",

--- a/src/config/sessions/session-accessor.sqlite-history-events.ts
+++ b/src/config/sessions/session-accessor.sqlite-history-events.ts
@@ -11,7 +11,6 @@ import type {
 } from "./session-accessor.sqlite-active-events.js";
 import {
   getActiveTranscriptKysely,
-  readTranscriptProjectionGeneration,
   withCurrentProjectionSnapshot,
   type CurrentTranscriptProjection,
   type SessionTranscriptMessageEvent,
@@ -69,14 +68,33 @@ function resolveVisibleHistoryProjection(
   }
   const visibleMessages = resolveVisibleMessagePositions(projection);
   const db = getActiveTranscriptKysely(projection.database);
+  const lastMessagePosition = db
+    .selectFrom("session_transcript_active_events")
+    .select("active_position")
+    .where("session_id", "=", projection.resolved.sessionId)
+    .where("message_position", "is not", null)
+    .orderBy("message_position", "desc")
+    .limit(1);
   const rows = executeSqliteQuerySync(
     projection.database.db,
     db
       .selectFrom("session_transcript_active_events as active")
-      .innerJoin("transcript_event_identities as identity", (join) =>
-        join
-          .onRef("identity.session_id", "=", "active.session_id")
-          .onRef("identity.seq", "=", "active.event_seq"),
+      .innerJoin(
+        db
+          .selectFrom("transcript_event_identities")
+          .select(["session_id", "event_id", "seq", "event_type"])
+          .modifyEnd(
+            // Whole-session reads select marker types; reset windows join their bounded active rows.
+            /* kysely-allow-raw: preserve selective canonical index access after ANALYZE. */
+            visibleMessages.boundaryActivePosition === undefined
+              ? sql`INDEXED BY idx_agent_transcript_event_sequence`
+              : sql`INDEXED BY idx_agent_transcript_event_identity_sequence`,
+          )
+          .as("identity"),
+        (join) =>
+          join
+            .onRef("identity.session_id", "=", "active.session_id")
+            .onRef("identity.seq", "=", "active.event_seq"),
       )
       .innerJoin("transcript_events as event", (join) =>
         join
@@ -91,13 +109,21 @@ function resolveVisibleHistoryProjection(
       ])
       .select((eb) =>
         eb
-          .selectFrom("session_transcript_active_events as next")
-          .select("next.message_position")
-          .whereRef("next.session_id", "=", "active.session_id")
-          .whereRef("next.active_position", ">", "active.active_position")
-          .where("next.message_position", "is not", null)
-          .orderBy("next.active_position", "asc")
-          .limit(1)
+          .case()
+          // Resolve the last message once so trailing markers cannot rescan an empty suffix.
+          .when("active.active_position", "<", lastMessagePosition)
+          .then(
+            eb
+              .selectFrom("session_transcript_active_events as next")
+              .select("next.message_position")
+              .whereRef("next.session_id", "=", "active.session_id")
+              .whereRef("next.active_position", ">", "active.active_position")
+              .where("next.message_position", "is not", null)
+              .orderBy("next.active_position", "asc")
+              .limit(1),
+          )
+          .else(null)
+          .end()
           .as("next_message_position"),
       )
       .where("active.session_id", "=", projection.resolved.sessionId)
@@ -466,7 +492,7 @@ export function readRecentSessionTranscriptHistoryEvents(
 ): SessionTranscriptMessageEventPage {
   return withCurrentProjectionSnapshot(scope, (projection) => {
     const history = resolveVisibleHistoryProjection(projection);
-    const generation = readTranscriptProjectionGeneration(projection);
+    const generation = projection.generation;
     const deltaCursor = generation
       ? createTranscriptRawDeltaCursor({
           agentId: projection.resolved.agentId,

--- a/src/config/sessions/session-accessor.sqlite-reset-window.ts
+++ b/src/config/sessions/session-accessor.sqlite-reset-window.ts
@@ -11,7 +11,6 @@ import { pruneMapToMaxSize } from "../../infra/map-size.js";
 import {
   getActiveTranscriptKysely,
   parseActiveTranscriptMessageRow,
-  readTranscriptProjectionGeneration,
   type CurrentTranscriptProjection,
   type SessionTranscriptMessageEvent,
 } from "./session-accessor.sqlite-active-projection.js";
@@ -258,7 +257,7 @@ export function resolveTranscriptBoundaryWindow(
   }
   const key = `${projection.database.path}\0${projection.resolved.sessionId}\0${scope}`;
   const cached = resetMessageWindowCache.get(key);
-  const generation = readTranscriptProjectionGeneration(projection);
+  const generation = projection.generation;
   if (cached) {
     if (cached.generation === generation && cached.indexedSeq === projection.state.indexedSeq) {
       return cached.window;

--- a/src/gateway/server-methods/chat-history-handler.test.ts
+++ b/src/gateway/server-methods/chat-history-handler.test.ts
@@ -541,6 +541,10 @@ describe("chat history exact-entry snapshots", () => {
               parseSpy.mock.calls.some(([value]) => value.includes(skillsSnapshot.prompt)),
             ).toBe(false);
             await pending;
+            expect(
+              parseSpy.mock.calls.filter(([value]) => value.includes('"sessionId":"history-child"'))
+                .length,
+            ).toBeLessThanOrEqual(1);
             const [ok, payload, error] = expectDefined(respond.mock.calls[0], "history response");
             expect(error).toBeUndefined();
             expect(ok).toBe(true);

--- a/src/gateway/server-methods/chat-history-handler.ts
+++ b/src/gateway/server-methods/chat-history-handler.ts
@@ -396,7 +396,6 @@ async function handleChatHistoryRequest({
     ? loadGatewaySessionEntryReadOnly(sessionKey, {
         agentId: sessionAgentId,
         clone: false,
-        includeStoreChildEntries: true,
         projection: "list",
       })
     : null;


### PR DESCRIPTION
Related: #126914

## What Problem This Solves

Loading a long conversation can block the Gateway while SQLite scans unrelated transcript payloads or repeatedly searches beyond the final message. Chat history also decodes child-session metadata twice per request, making session switches more expensive for parents with many children.

## Why This Change Was Made

Keep the canonical history reader and its existing SQLite snapshot. Select the existing marker-type index for whole-session reads and the sequence index for reset windows, skip next-message searches beyond the final active message, and carry the generation already read by the snapshot. The post-await authorization check still rereads the selected session and verifies current access and identity; child metadata is loaded once for the response.

The change preserves history ordering, cursors, byte limits, malformed-data guards, and reset behavior. It adds no schema, migration, or persisted state. A reusable synthetic benchmark records SQL plans, statement/row counts, JSON work, and separate first-read and warm timing.

## User Impact

Conversations with many markers open substantially faster, ordinary page reads perform less SQL, and parents with many child sessions avoid duplicate decoding.

## Evidence

Warm p50 through the real SQLite history reader, requesting 20 events with planner statistics present (Node 26.8.2, Apple M3 Ultra, 15 samples):

| Synthetic history | Before | After |
| --- | ---: | ---: |
| 10 markers among 10,000 messages | 13.951 ms | 0.613 ms |
| 5,000 trailing compaction markers | 613.591 ms | 9.173 ms |
| Post-reset window | 3.929 ms | 3.735 ms |

Ordinary recent reads execute 5 SQL statements instead of 9; dense marked histories execute 7 instead of 12. Selected-event and total counts match across all 18 comparisons; event JSON parsing remains bounded to the requested page. Dense custom-marker metadata still takes about 30 ms in the 5,000-visible-marker fixture.

A controlled alternating benchmark of the 1,000-child session recheck fell from 5.466 to 0.193 ms. The full registered history handler decodes 1,000 child rows instead of 2,000 and returned every child. Its separate before/after median was 14.61 to 8.54 ms.

Timings use synthetic isolated stores on a shared host. Warm timings exclude tracing; OS caches were not flushed. The benchmark reports first-open and RSS separately, and these results do not claim an RSS reduction.

```bash
pnpm test:sessions:history:bench --samples 30 --output history.json
pnpm test:sessions:history:bench --profile sparse,trailing,reset --operation recent --analyze --samples 15 --output history-analyzed.json
```

- Focused history, active-projection, context-eligibility, Gateway-handler, and bounded-session-manager suites: 98 tests passed. The child-decoding regression failed for both history and startup before the repair.
- Independent Codex autoreview: no actionable P0–P2 findings.
- Script formatting, lint, typecheck, and erasability passed.
- `node scripts/check-changed.mjs` passed, including core/test/script types, changed-file lint, and repository guards.
- Benchmark CI repair: all 25 suppression-inventory and package-script tests passed with no new suppression allowance; SQL/JSON traces match the earlier measurements exactly.
- Production and full-tree unused-file scans passed for the registered benchmark entrypoint.
