### PR TITLE
perf(imessage): reduce cold delivery imports

### DIFF
--- a/extensions/imessage/src/monitor/deliver.runtime.ts
+++ b/extensions/imessage/src/monitor/deliver.runtime.ts
@@ -3,5 +3,5 @@ export { resolveMarkdownTableMode } from "openclaw/plugin-sdk/markdown-table-run
 export {
   chunkMarkdownTextWithMode as chunkTextWithMode,
   resolveChunkMode,
-} from "openclaw/plugin-sdk/reply-runtime";
+} from "openclaw/plugin-sdk/reply-chunking";
 export { convertMarkdownTables } from "openclaw/plugin-sdk/text-chunking";


### PR DESCRIPTION
## What Problem This Solves

Cold iMessage delivery loads the reply dispatcher and agent runtime just to access text chunking helpers.

## Why This Change Was Made

Use the existing `reply-chunking` SDK entry point for `chunkMarkdownTextWithMode` and `resolveChunkMode`. Both remain exports of the same chunking implementation, and both are present in the runtime and type exports of the declared OpenClaw 2026.9.4 host floor.

## User Impact

Avoids unnecessary eager imports when loading iMessage delivery. Message formatting, chunking, approval behavior, and compatibility requirements stay the same.

## Evidence

- Original real fake-RPC fixture passed in 15.721 seconds with its existing 30-second timeout and all assertions unchanged.
- The same repair composed with the SQLite worker candidate passed that fixture in 15.939 seconds. These are individual validation timings, not a controlled speedup claim or evidence that the database change caused the earlier timeout.
- 130 existing chunking, delivery, and approval-reaction tests passed.
- Published OpenClaw 2026.9.4 tarball integrity verified; both required runtime and type exports confirmed.
- Fresh independent review found no actionable findings through P2.
- Full changed-file gate and `pnpm build` passed. The isolated built iMessage plugin import succeeded (109.5 MiB peak RSS).
