### PR TITLE
fix(test): respect process memory limits in local scheduling

### DIFF
--- a/scripts/lib/vitest-local-scheduling.mts
+++ b/scripts/lib/vitest-local-scheduling.mts
@@ -5,6 +5,8 @@ export type VitestHostInfo = {
   loadAverage1m?: number;
   totalMemoryBytes?: number;
   freeMemoryBytes?: number;
+  constrainedMemoryBytes?: number;
+  availableMemoryBytes?: number;
 };
 export type LocalVitestScheduling = {
   maxWorkers: number;
@@ -67,6 +69,8 @@ export function detectVitestHostInfo() {
     loadAverage1m: os.loadavg()[0] ?? 0,
     totalMemoryBytes: os.totalmem(),
     freeMemoryBytes: os.freemem(),
+    constrainedMemoryBytes: process.constrainedMemory(),
+    availableMemoryBytes: process.availableMemory(),
   };
 }
 
@@ -90,8 +94,21 @@ function schedulingHostInfo(): ReturnType<typeof detectVitestHostInfo> {
 }
 
 function resolveMemoryPressureWorkerLimit(system: VitestHostInfo) {
-  const freeMemoryGb = (system.freeMemoryBytes ?? 0) / 1024 ** 3;
-  if (!Number.isFinite(freeMemoryGb) || freeMemoryGb <= 0) {
+  let freeMemoryBytes = system.freeMemoryBytes;
+  if (freeMemoryBytes === undefined || !Number.isFinite(freeMemoryBytes) || freeMemoryBytes <= 0) {
+    freeMemoryBytes = Infinity;
+  }
+  const availableMemoryBytes = system.availableMemoryBytes;
+  // Zero host free memory is unknown; zero process headroom is exhausted.
+  if (
+    availableMemoryBytes !== undefined &&
+    Number.isFinite(availableMemoryBytes) &&
+    availableMemoryBytes >= 0
+  ) {
+    freeMemoryBytes = Math.min(freeMemoryBytes, availableMemoryBytes);
+  }
+  const freeMemoryGb = freeMemoryBytes / 1024 ** 3;
+  if (!Number.isFinite(freeMemoryGb)) {
     return null;
   }
   if (freeMemoryGb <= 4) {
@@ -128,7 +145,18 @@ export function resolveLocalVitestScheduling(
 
   const cpuCount = Math.max(1, system.cpuCount ?? 1);
   const loadAverage1m = Math.max(0, system.loadAverage1m ?? 0);
-  const totalMemoryGb = (system.totalMemoryBytes ?? 0) / 1024 ** 3;
+  let totalMemoryBytes = system.totalMemoryBytes ?? 0;
+  const constrainedMemoryBytes = system.constrainedMemoryBytes;
+  if (
+    constrainedMemoryBytes !== undefined &&
+    Number.isFinite(constrainedMemoryBytes) &&
+    constrainedMemoryBytes > 0
+  ) {
+    totalMemoryBytes = Number.isFinite(totalMemoryBytes)
+      ? Math.min(totalMemoryBytes, constrainedMemoryBytes)
+      : constrainedMemoryBytes;
+  }
+  const totalMemoryGb = totalMemoryBytes / 1024 ** 3;
 
   let inferred =
     cpuCount <= 2
@@ -196,11 +224,13 @@ export function resolveLocalVitestScheduling(
   }
 
   if (loadRatio >= 0.75) {
-    const maxWorkers = Math.max(2, Math.ceil(inferred * 0.75));
+    const loadWorkers = Math.max(2, Math.ceil(inferred * 0.75));
+    const maxWorkers =
+      memoryPressureLimit === null ? loadWorkers : Math.min(loadWorkers, memoryPressureLimit);
     return {
       maxWorkers,
-      fileParallelism: true,
-      throttledBySystem: maxWorkers < inferred,
+      fileParallelism: maxWorkers > 1,
+      throttledBySystem: maxWorkers < inferred || maxWorkers < loadWorkers,
     };
   }
 

--- a/scripts/lib/vitest-resource-reporter.mts
+++ b/scripts/lib/vitest-resource-reporter.mts
@@ -28,8 +28,6 @@ export default class VitestResourceReporter implements Reporter {
       arch: process.arch,
       ...detectVitestHostInfo(),
       osLogicalCpuCount: os.cpus().length,
-      constrainedMemoryBytes: process.constrainedMemory(),
-      availableMemoryBytes: process.availableMemory(),
       rootMaxWorkers: ctx.config.maxWorkers ?? null,
     });
   }

--- a/test/scripts/vitest-local-scheduling.test.ts
+++ b/test/scripts/vitest-local-scheduling.test.ts
@@ -11,39 +11,179 @@ describe("vitest scheduling host snapshot", () => {
     // Vite bundles each project config on its own, so each project gets its own copy
     // of this module. Vitest refuses a run whose projects share sequence.groupOrder
     // but disagree on maxWorkers, so two module instances that resolve while the
-    // load average moves must still agree; without a process-wide snapshot they
-    // return 12 and 3.
+    // load average and process memory readings move must still agree.
     const host = os as unknown as Record<string, unknown>;
+    const store = globalThis as Record<PropertyKey, unknown>;
+    const snapshotKey = Symbol.for("openclaw.vitestSchedulingHostInfo");
+    const savedSnapshot = Object.getOwnPropertyDescriptor(store, snapshotKey);
     const saved = {
       availableParallelism: os.availableParallelism,
       totalmem: os.totalmem,
       freemem: os.freemem,
       loadavg: os.loadavg,
     };
-    host.availableParallelism = () => 16;
-    host.totalmem = () => 512 * 1024 ** 3;
-    host.freemem = () => 256 * 1024 ** 3;
+    const constrainedMemory = vi.spyOn(process, "constrainedMemory");
+    const availableMemory = vi.spyOn(process, "availableMemory");
     try {
+      delete store[snapshotKey];
+      host.availableParallelism = () => 16;
+      host.totalmem = () => 512 * 1024 ** 3;
+      host.freemem = () => 256 * 1024 ** 3;
       host.loadavg = () => [0, 0, 0];
+      constrainedMemory.mockReturnValue(32 * 1024 ** 3);
+      availableMemory.mockReturnValue(12 * 1024 ** 3);
       vi.resetModules();
       const first = await import("../../scripts/lib/vitest-local-scheduling.mts");
       const before = first.resolveLocalVitestScheduling({});
+      expect(before.maxWorkers).toBe(4);
       host.loadavg = () => [64, 64, 64];
+      constrainedMemory.mockReturnValue(2 * 1024 ** 3);
+      availableMemory.mockReturnValue(0);
       vi.resetModules();
       const second = await import("../../scripts/lib/vitest-local-scheduling.mts");
       const after = second.resolveLocalVitestScheduling({});
       // Guard against a vacuous pass: distinct instances, and the stub drives the reading.
       expect(second).not.toBe(first);
       expect(os.loadavg()[0]).toBe(64);
-      expect(after.maxWorkers).toBe(before.maxWorkers);
-      expect(after.throttledBySystem).toBe(before.throttledBySystem);
+      expect(second.detectVitestHostInfo()).toMatchObject({
+        constrainedMemoryBytes: 2 * 1024 ** 3,
+        availableMemoryBytes: 0,
+      });
+      expect(after).toEqual(before);
     } finally {
       Object.assign(host, saved);
+      constrainedMemory.mockRestore();
+      availableMemory.mockRestore();
+      if (savedSnapshot) {
+        Object.defineProperty(store, snapshotKey, savedSnapshot);
+      } else {
+        delete store[snapshotKey];
+      }
     }
   });
 });
 
 describe("local Vitest scheduling", () => {
+  it.each([
+    [
+      "caps total memory by the process constraint",
+      { constrainedMemoryBytes: 16 * 1024 ** 3 },
+      {},
+      2,
+      false,
+    ],
+    ["limits workers by process headroom", { availableMemoryBytes: 6 * 1024 ** 3 }, {}, 2, true],
+    [
+      "retains the tighter host headroom",
+      { freeMemoryBytes: 3 * 1024 ** 3, availableMemoryBytes: 12 * 1024 ** 3 },
+      {},
+      1,
+      true,
+    ],
+    [
+      "uses process headroom when host free memory is unknown",
+      { freeMemoryBytes: 0, availableMemoryBytes: 6 * 1024 ** 3 },
+      {},
+      2,
+      true,
+    ],
+    [
+      "treats a zero process constraint as unknown",
+      { constrainedMemoryBytes: 0, availableMemoryBytes: 12 * 1024 ** 3 },
+      {},
+      8,
+      false,
+    ],
+    ["serializes exhausted process headroom", { availableMemoryBytes: 0 }, {}, 1, true],
+    [
+      "does not raise exhausted headroom under moderate load",
+      { cpuCount: 2, loadAverage1m: 1.5, freeMemoryBytes: 0, availableMemoryBytes: 0 },
+      {},
+      1,
+      true,
+    ],
+    [
+      "does not raise a host memory cap under moderate load",
+      { cpuCount: 2, loadAverage1m: 1.5, freeMemoryBytes: 3 * 1024 ** 3 },
+      {},
+      1,
+      true,
+    ],
+    [
+      "retains a valid constraint when headroom is invalid",
+      { constrainedMemoryBytes: 16 * 1024 ** 3, availableMemoryBytes: NaN },
+      {},
+      2,
+      false,
+    ],
+    [
+      "retains valid headroom when the constraint is invalid",
+      { constrainedMemoryBytes: NaN, availableMemoryBytes: 6 * 1024 ** 3 },
+      {},
+      2,
+      true,
+    ],
+    [
+      "ignores negative constraints and infinite headroom",
+      { constrainedMemoryBytes: -1, availableMemoryBytes: Infinity },
+      {},
+      8,
+      false,
+    ],
+    [
+      "ignores infinite constraints and negative headroom",
+      { constrainedMemoryBytes: Infinity, availableMemoryBytes: -1 },
+      {},
+      8,
+      false,
+    ],
+    [
+      "keeps the host ceiling with an unconstrained uint64 reading",
+      { constrainedMemoryBytes: 2 ** 64 - 1 },
+      {},
+      8,
+      false,
+    ],
+    [
+      "lets throttle opt-out ignore headroom but retain the total ceiling",
+      { constrainedMemoryBytes: 16 * 1024 ** 3, availableMemoryBytes: 0 },
+      { OPENCLAW_VITEST_DISABLE_SYSTEM_THROTTLE: "1" },
+      2,
+      false,
+    ],
+    [
+      "honors an explicit worker override despite process pressure",
+      { constrainedMemoryBytes: 16 * 1024 ** 3, availableMemoryBytes: 0 },
+      { OPENCLAW_VITEST_MAX_WORKERS: "3" },
+      3,
+      false,
+    ],
+    [
+      "honors the legacy worker override despite process pressure",
+      { constrainedMemoryBytes: 16 * 1024 ** 3, availableMemoryBytes: 0 },
+      { OPENCLAW_TEST_WORKERS: "4" },
+      4,
+      false,
+    ],
+  ] as const)("%s", (_name, readings, env, maxWorkers, throttledBySystem) => {
+    const hostInfo = {
+      cpuCount: 16,
+      totalMemoryBytes: 128 * 1024 ** 3,
+      freeMemoryBytes: 32 * 1024 ** 3,
+      loadAverage1m: 0,
+      ...readings,
+    };
+    expect(resolveLocalVitestScheduling(env, hostInfo)).toEqual({
+      maxWorkers,
+      fileParallelism: maxWorkers > 1,
+      throttledBySystem,
+    });
+    expect(resolveLocalFullSuiteProfile(env, hostInfo)).toEqual({
+      shardParallelism: maxWorkers,
+      vitestMaxWorkers: 1,
+    });
+  });
+
   it.each([
     ["uses a moderate cap on larger hosts", { RUNNER_OS: "macOS" }, 10, 64, 0, 6, false],
     [


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where developers running local test suites inside a memory-constrained process could get more concurrent test shards than the process's memory budget warrants. Physical host RAM alone can overstate the memory available to that process.

## Why This Change Was Made

Include native process memory constraints and available headroom in the existing scheduling snapshot and worker inference. Keep the tighter valid memory bound, distinguish unknown constraints from exhausted headroom, and prevent the moderate-load adjustment from raising a memory-limited worker count.

The resource reporter calls live `detectVitestHostInfo()` instead of duplicating the native memory reads; only the scheduler caches its scheduling snapshot. Explicit worker overrides, throttle opt-out semantics, the shared cross-module snapshot, raw telemetry fields, CI scheduling policy, and one Vitest worker per full-suite shard remain unchanged.

## User Impact

Automatic local test scheduling respects the memory reported as available to its process. Application runtime behavior is unchanged. This is an admission-control fix, not a measured CPU/RSS improvement or a guarantee against every OOM.

## Evidence

Remote proof used Node 24.19.0 on Linux x64, with baseline and candidate in separate processes and the same new regression tests:

| Check | Result |
| --- | --- |
| Original owners with the new tests | 38 collected: 28 passed, 10 expected worker-admission assertion failures |
| Candidate | 38 collected, 38 passed |
| Unhandled errors | 0 in both legs |
| Actual 3 GiB process constraint | Default outer shard admission changed from 2 to 1; one Vitest worker per shard in both legs |

The tests cover exhausted and unknown readings, independent valid bounds, moderate load, explicit overrides, and stable scheduling across two separately loaded copies of the same module.

The [Testbox Actions run](https://github.com/openclaw/openclaw/actions/runs/34710193358) records the lease lifecycle. Application stdout/stderr was retained client-side; the reviewer's inability to retrieve job logs is an evidence-access limitation, not an additional test failure. The complete retained captures were independently inspected.

Selected-field projections from those captures follow. Command/path fields are omitted, test-count lines have ANSI formatting removed, and no timings are presented as performance evidence:

```text
P12_PROFILE {"label":"baseline","node":"v24.19.0","nativeMemory":{"constrained":3221225472},"outerProfile":{"shardParallelism":2,"vitestMaxWorkers":1},"cgroupBefore":{"memoryMax":"3221225472"}}
Tests  10 failed | 28 passed (38)
[vitest:run] {"reason":"failed","files":1,"unhandledErrors":0}
P12_LEG {"code":1,"profile":{"label":"baseline"}}
P12_PROFILE {"label":"candidate","node":"v24.19.0","nativeMemory":{"constrained":3221225472},"outerProfile":{"shardParallelism":1,"vitestMaxWorkers":1},"cgroupBefore":{"memoryMax":"3221225472"}}
Tests  38 passed (38)
[vitest:run] {"reason":"passed","files":1,"unhandledErrors":0}
P12_LEG {"code":0,"profile":{"label":"candidate"}}
```

Complete-capture SHA-256:
- stdout, 80,423 bytes: `fa056cc232d96754f1003d0ed6befc115163d3bef3e8081756efd7ace1b56d0c`
- stderr, 19,500 bytes: `c5d0311ebbac9342b780026b3a32b2bc4efc902ac34c17ef01cfe52daf820add`

The proof used source base `12c55d1650c07d07046c3a08462f5fd0960c6e67` and candidate capsule tree `e4f7dc53f457c3ba001f2427bc16d1d23bc92ed2`.
The subsequent change only collapses one test-data tuple's whitespace; production bytes are unchanged.

Fresh independent P2 review completed. Its single unknown-host-total finding was rejected after source inspection: the existing lowest-memory-tier fallback remains conservative, rather than increasing admission. The PR's ClawSweeper review found no actionable correctness or security issue; its log-access limitation is addressed by the retained evidence above.

**Hosted CI:** the native watcher completed with `GREEN` and zero pending checks for exact head `326681be20acdb8800e7be42dce815870e20ca59` in [CI run 34711427239](https://github.com/openclaw/openclaw/actions/runs/34711427239).

**Landed:** squash-merged on September 13, 2026 at 11:58:56 UTC as [533698353132](https://github.com/openclaw/openclaw/commit/533698353132cee3845f9d172603eedb7e2d8b3f). Native review, prepare, and merge completed successfully, with the exact head and landed source verified. The initial remote changed-check invocation stopped at test-file formatting and is not relabeled as a passing invocation. No additional full suite, stress/OOM test, or performance benchmark was run by this task.