### PR TITLE
refactor(markdown): reuse freshly owned link spans

### DIFF
--- a/packages/markdown-core/src/ir-spans.ts
+++ b/packages/markdown-core/src/ir-spans.ts
@@ -36,25 +36,22 @@ export type MarkdownLinkSpan = {
 // Every span transform must use copyMarkdownLinkSpan so the private fact survives.
 const autoLinkedMarkdownLinks = new WeakSet<MarkdownLinkSpan>();
 
+/** Callers supply a fresh span; transforms copy before attaching provenance. */
 export function createMarkdownLinkSpan(
   span: MarkdownLinkSpan,
-  options: { autoLinked?: boolean } = {},
+  autoLinked: boolean,
 ): MarkdownLinkSpan {
-  const created = { ...span };
-  if (options.autoLinked) {
-    autoLinkedMarkdownLinks.add(created);
+  if (autoLinked) {
+    autoLinkedMarkdownLinks.add(span);
   }
-  return created;
+  return span;
 }
 
 export function copyMarkdownLinkSpan(
   span: MarkdownLinkSpan,
-  overrides: Partial<MarkdownLinkSpan> = {},
+  overrides?: Partial<MarkdownLinkSpan>,
 ): MarkdownLinkSpan {
-  return createMarkdownLinkSpan(
-    { ...span, ...overrides },
-    { autoLinked: autoLinkedMarkdownLinks.has(span) },
-  );
+  return createMarkdownLinkSpan({ ...span, ...overrides }, autoLinkedMarkdownLinks.has(span));
 }
 
 export function isAutoLinkedMarkdownLink(span: MarkdownLinkSpan): boolean {

--- a/packages/markdown-core/src/ir.ts
+++ b/packages/markdown-core/src/ir.ts
@@ -866,7 +866,7 @@ function handleLinkClose(state: RenderState) {
   }
   const start = link.labelStart;
   const end = target.text.length;
-  const span = createMarkdownLinkSpan({ start, end, href }, { autoLinked: link.autoLinked });
+  const span = createMarkdownLinkSpan({ start, end, href }, link.autoLinked);
   target.links.push(span);
 }
 


### PR DESCRIPTION
## What Problem This Solves

Markdown link construction makes a second object copy after its callers have already created a fresh span. Copies made during clipping and rendering also allocate a temporary options object just to carry private automatic-link provenance.

## Why This Change Was Made

Let the private constructor adopt the fresh span supplied by its two callers and pass automatic-link provenance as a boolean. Public transforms still create their own copy before attaching the existing private metadata. This removes three production lines and redundant constructions without changing sorting, clipping, callbacks, package exports or serialized Markdown IR.

## User Impact

No intended user-visible change. This is a small internal cleanup, not a general formatter speed or memory improvement. Authored and automatic links retain their existing distinction through rendering and chunking.

## Evidence

One Linux ABBA measurement at `6c4e02ddff89717e5819583a991aafd842137385` exercised the actual Markdown-to-Telegram HTML and chunk formatters: 20 timed cases plus eight ownership/provenance controls, with 520 full raw sample rows per phase. All output, getter/callback order and ownership observations matched without normalization. All child processes and the owned lease closed; no live Telegram messages were sent.

Results were mixed: 12 of 20 paired warm medians improved and eight regressed. Mixed-link and whitespace chunking improved by about 1.18% and 6.62%, respectively. Retained regressions include styled-link HTML (+0.0025 ms), styled-link chunking (+0.0246 ms), and 128-authored-link chunking (+0.201 ms). Ordinary HTML/chunking were +0.96%/+0.57%. Observed process-tree peak RSS rose 2.324% and was worse in both orders. These results do not establish a general speed or memory benefit.

All 86 assertions passed across five complete existing focused files. All 25 selected small checks passed, including formatting, and the diff check is clean; all 28 native validation commands closed with their process trees. Independent Codex P2 review of the unchanged final author bytes is scoped-clean. No tests or assertions changed. Full core typecheck, core-test typecheck and changed-file type-aware lint remain required from exact-head hosted CI before landing.


Exact-head hosted follow-up: [CI 34711414453](https://github.com/openclaw/openclaw/actions/runs/34711414453) completed successfully on unchanged 62556c2a. The actual core production typecheck, all core-test stripes including the fifth-stripe tail, and type-aware core Oxlint covering the changed package files passed. This completes the three hosted obligations above; it does not change the scoped ownership-cleanup claim or the retained adverse timing and RSS results.
