### PR TITLE
improve(boards): batch tab writes and board removals

### DIFF
--- a/src/boards/sqlite-board-store.batching.test.ts
+++ b/src/boards/sqlite-board-store.batching.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import {
+  closeOpenClawAgentDatabasesForTest,
+  openOpenClawAgentDatabase,
+} from "../state/openclaw-agent-db.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { createTestBoardStore, readBoardHtml } from "./board-store.test-support.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+afterEach(() => {
+  closeOpenClawAgentDatabasesForTest();
+  closeOpenClawStateDatabaseForTest();
+});
+
+it("round-trips and removes a board with many tabs", async () => {
+  const store = createTestBoardStore();
+  const target = { sessionKey: "agent:main:many-tabs" };
+  const tabIds = Array.from({ length: 130 }, (_, index) => `tab-${index}`);
+  const created = await store.applyOps(
+    target,
+    tabIds.map((tabId) => ({ kind: "tab_create", tabId, title: tabId })),
+  );
+  expect(created.tabs.map((tab) => tab.tabId)).toEqual(tabIds);
+  expect(await store.getSnapshot(target)).toEqual(created);
+  expect(
+    await store.applyOps(
+      target,
+      tabIds.map((tabId) => ({ kind: "tab_delete", tabId })),
+    ),
+  ).toEqual({
+    ...target,
+    revision: 2,
+    tabs: [],
+    widgets: [],
+  });
+  expect(await store.getSnapshot(target)).toEqual({
+    ...target,
+    revision: 0,
+    tabs: [],
+    widgets: [],
+  });
+});
+
+it("rolls back late board writes and preserves surviving widget documents", async () => {
+  const stateDir = tempDirs.make("openclaw-board-batch-rollback-");
+  const env = { OPENCLAW_STATE_DIR: stateDir };
+  const sessionKey = "agent:main:batch-rollback";
+  const store = createTestBoardStore({ stateDir });
+
+  const tabIds = Array.from({ length: 130 }, (_, index) => `tab-${index}`);
+  await store.applyOps(
+    { sessionKey },
+    tabIds.map((tabId) => ({
+      kind: "tab_create",
+      tabId,
+      title: tabId,
+    })),
+  );
+  const widgetNames = tabIds.slice(0, 48);
+  for (const name of widgetNames) {
+    await store.putWidget({ sessionKey, name, content: { kind: "html", html: name } });
+  }
+  const before = await store.getSnapshot({ sessionKey });
+  const database = openOpenClawAgentDatabase({ agentId: "main", env });
+  const readRows = () => ({
+    tabs: database.db.prepare("SELECT * FROM board_tabs ORDER BY session_key, tab_id").all(),
+    widgets: database.db.prepare("SELECT * FROM board_widgets ORDER BY session_key, name").all(),
+  });
+  const beforeRows = readRows();
+  database.db.exec(`CREATE TEMP TRIGGER reject_late_tab_write BEFORE UPDATE ON board_tabs
+      WHEN NEW.tab_id = 'tab-129' BEGIN SELECT RAISE(ABORT, 'late tab write'); END;`);
+  await expect(
+    store.applyOps({ sessionKey }, [
+      {
+        kind: "tab_update",
+        tabId: "tab-0",
+        title: "changed",
+      },
+    ]),
+  ).rejects.toThrow("late tab write");
+  expect(readRows()).toEqual(beforeRows);
+  database.db.exec("DROP TRIGGER reject_late_tab_write");
+  expect(await store.getSnapshot({ sessionKey })).toEqual(before);
+
+  const removedNames = widgetNames.slice(0, -1);
+  const removeOps = removedNames.map((name) => ({ kind: "widget_remove" as const, name }));
+  database.db.exec(`CREATE TEMP TRIGGER reject_late_widget_delete BEFORE DELETE ON board_widgets
+      WHEN OLD.name = 'tab-46' BEGIN SELECT RAISE(ABORT, 'late widget delete'); END;`);
+  await expect(store.applyOps({ sessionKey }, removeOps)).rejects.toThrow("late widget delete");
+  expect(readRows()).toEqual(beforeRows);
+  database.db.exec("DROP TRIGGER reject_late_widget_delete");
+  const removed = await store.applyOps({ sessionKey }, removeOps);
+  expect(removed.widgets.map((widget) => widget.name)).toEqual(["tab-47"]);
+  expect(await store.getSnapshot({ sessionKey })).toEqual(removed);
+  expect(await readBoardHtml(store, { sessionKey }, "tab-47")).toMatchObject({
+    html: "tab-47",
+  });
+  expect(await readBoardHtml(store, { sessionKey }, "tab-46")).toBeUndefined();
+});

--- a/src/boards/sqlite-board-store.kernel.ts
+++ b/src/boards/sqlite-board-store.kernel.ts
@@ -49,6 +49,7 @@ type StoredBoard = {
 
 const ensuredBoardDatabases = new WeakSet<DatabaseSync>();
 const presentBoardDatabases = new WeakSet<DatabaseSync>();
+const BOARD_WRITE_BATCH_SIZE = 64;
 
 // Read-only connections cannot run the lazy DDL, and a pre-existing v13 DB has
 // no board tables until the first write. Reads must treat that as "no boards",
@@ -143,26 +144,28 @@ function upsertTabs(
 ): void {
   const db = getNodeSqliteKysely<BoardDatabase>(database.db);
   const createdBy = new Map(previous.tabRows.map((row) => [row.tab_id, row.created_by]));
-  for (const tab of next.tabs) {
+  for (let index = 0; index < next.tabs.length; index += BOARD_WRITE_BATCH_SIZE) {
     executeSqliteQuerySync(
       database.db,
       db
         .insertInto("board_tabs")
-        .values({
-          session_key: next.sessionKey,
-          tab_id: tab.tabId,
-          title: tab.title,
-          position: tab.position,
-          chat_dock: tab.chatDock,
-          created_by: createdBy.get(tab.tabId) ?? "agent",
-          revision: next.revision,
-        })
-        .onConflict((conflict) =>
-          conflict.columns(["session_key", "tab_id"]).doUpdateSet({
+        .values(
+          next.tabs.slice(index, index + BOARD_WRITE_BATCH_SIZE).map((tab) => ({
+            session_key: next.sessionKey,
+            tab_id: tab.tabId,
             title: tab.title,
             position: tab.position,
             chat_dock: tab.chatDock,
+            created_by: createdBy.get(tab.tabId) ?? "agent",
             revision: next.revision,
+          })),
+        )
+        .onConflict((conflict) =>
+          conflict.columns(["session_key", "tab_id"]).doUpdateSet({
+            title: (eb) => eb.ref("excluded.title"),
+            position: (eb) => eb.ref("excluded.position"),
+            chat_dock: (eb) => eb.ref("excluded.chat_dock"),
+            revision: (eb) => eb.ref("excluded.revision"),
           }),
         ),
     );
@@ -226,16 +229,19 @@ function deleteRemovedWidgets(
 ): void {
   const db = getNodeSqliteKysely<BoardDatabase>(database.db);
   const widgetNames = new Set(next.widgets.map((widget) => widget.name));
-  for (const row of previous.widgetRows) {
-    if (!widgetNames.has(row.name)) {
-      executeSqliteQuerySync(
-        database.db,
-        db
-          .deleteFrom("board_widgets")
-          .where("session_key", "=", next.sessionKey)
-          .where("name", "=", row.name),
-      );
-    }
+  const removed = previous.widgetRows.filter((row) => !widgetNames.has(row.name));
+  for (let index = 0; index < removed.length; index += BOARD_WRITE_BATCH_SIZE) {
+    executeSqliteQuerySync(
+      database.db,
+      db
+        .deleteFrom("board_widgets")
+        .where("session_key", "=", next.sessionKey)
+        .where(
+          "name",
+          "in",
+          removed.slice(index, index + BOARD_WRITE_BATCH_SIZE).map((row) => row.name),
+        ),
+    );
   }
 }
 
@@ -246,16 +252,19 @@ function deleteRemovedTabs(
 ): void {
   const db = getNodeSqliteKysely<BoardDatabase>(database.db);
   const tabIds = new Set(next.tabs.map((tab) => tab.tabId));
-  for (const row of previous.tabRows) {
-    if (!tabIds.has(row.tab_id)) {
-      executeSqliteQuerySync(
-        database.db,
-        db
-          .deleteFrom("board_tabs")
-          .where("session_key", "=", next.sessionKey)
-          .where("tab_id", "=", row.tab_id),
-      );
-    }
+  const removed = previous.tabRows.filter((row) => !tabIds.has(row.tab_id));
+  for (let index = 0; index < removed.length; index += BOARD_WRITE_BATCH_SIZE) {
+    executeSqliteQuerySync(
+      database.db,
+      db
+        .deleteFrom("board_tabs")
+        .where("session_key", "=", next.sessionKey)
+        .where(
+          "tab_id",
+          "in",
+          removed.slice(index, index + BOARD_WRITE_BATCH_SIZE).map((row) => row.tab_id),
+        ),
+    );
   }
 }
 


### PR DESCRIPTION
Related: #146197

## What Problem This Solves

Editing a board repeats a tab write for every existing tab and a deletion for every removed tab or widget. Larger boards spend unnecessary time applying otherwise small layout edits.

## Why This Change Was Made

Batch tab upserts and exact removals in groups of 64 inside the existing SQLite transaction. Validation, revisions, created_by values, table deletion order, and widget layout timestamps remain unchanged. No schema, migration, API, grant, or persistence-semantics changes.

## User Impact

Larger boards need fewer database operations when reordering tabs or removing content. Small boards also issue fewer writes, but their measured latency is effectively unchanged.

## Evidence

Measured through the public SqliteBoardStore with file-backed synthetic fixtures, 5 warmups and 25 alternating baseline/candidate samples. Full returned snapshots match on every pair:

| Tabs reordered | Writes before → after | Median before → after |
| --- | --- | --- |
| 1 | 1 → 1 | 2.820 → 3.086 ms |
| 8 | 8 → 1 | 2.859 → 2.836 ms |
| 32 | 32 → 1 | 4.645 → 4.390 ms |
| 100 | 100 → 2 | 5.471 → 3.863 ms |
| 1,000 | 1,000 → 16 | 30.058 → 15.816 ms |

Small-board latency differences are within local run variance; the demonstrated latency gain is for larger boards. Widget count remains capped at 48 and layout UPDATEs are unchanged. In the existing-store parity fixture, deleting 129 tabs while relocating 8 widgets drops total writes from 138 to 12; removing 7 of those widgets drops writes from 9 to 3.

Validation:
- Public owner tests cover 130-tab round trips/deletion, 48-widget state, late-batch upsert failure, aborted widget deletion, complete typed-row rollback, and surviving widget documents.
- Windows owner suite: 43 passed; five unchanged tests encounter EPERM during temp-directory cleanup. The exact same five failures reproduce with the original main kernel. All 48 owner tests across four files pass on Linux at the exact PR head, including those five cases.
- Baseline-created existing board data: 130 tabs and BLOB-bearing Unicode widgets round-trip unchanged on candidate reads. Full board rows (including timestamps and created_by), public snapshots and documents match the original after reorder/update, tab deletion with widget moves, and widget deletion. Schema and user_version remain unchanged; no migration or read-time write.
- Core production and canonical owning test type graphs, final scoped lint, and the changed guards passed. The full-tree dead-export scan reports the same two unchanged script exports as the prior campaign; its production scan passed. Independent P2 review completed with no findings.



