### PR TITLE
improve(memory): reduce unrelated project recall reads

### DIFF
--- a/packages/memory-host-sdk/src/host/memory-recall-metadata.test.ts
+++ b/packages/memory-host-sdk/src/host/memory-recall-metadata.test.ts
@@ -1,5 +1,5 @@
 import { DatabaseSync } from "node:sqlite";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   readCuratedProjectMemoryCandidates,
   readCuratedMemoryTriggerCandidates,
@@ -13,6 +13,153 @@ import {
 import { ensureMemoryIndexSchema } from "./memory-schema.js";
 
 describe("memory recall metadata", () => {
+  it("preserves exact project eligibility through selective candidate reads", () => {
+    const db = new DatabaseSync(":memory:");
+    try {
+      ensureMemoryIndexSchema({ db, cacheEnabled: false, ftsEnabled: false });
+      const projects = [
+        null,
+        "",
+        " ; \t; ",
+        "project/a",
+        "project/aa",
+        "\ufeffproject/a\u00a0",
+        "project/a; project/b",
+        "project/a; !invalid-project-annotation",
+        "!invalid-project-annotation",
+        "project/a; ; project/a",
+        "project/\0a",
+        "project/🦞",
+        "project/'%_\\",
+        "project/\\u0000",
+        "project/\ud800",
+      ];
+      const insertChunk = db.prepare(
+        `INSERT INTO memory_index_chunks
+         (id, path, start_line, end_line, hash, model, text, embedding, updated_at)
+         VALUES (?, 'MEMORY.md', 1, 1, 'h', 'm', ?, '[]', 2)`,
+      );
+      const insertMetadata = db.prepare(
+        `INSERT INTO memory_index_chunk_recall_metadata
+         (chunk_id, importance, triggers, project_key) VALUES (?, ?, 'recall', ?)`,
+      );
+      const insertProvenance = db.prepare(
+        `INSERT INTO memory_index_chunk_provenance
+         (chunk_id, origin_class, session_kind, observed_at) VALUES (?, 'owner', 'interactive', 2)`,
+      );
+      for (const [index, project] of projects.entries()) {
+        const id = String(index).padStart(2, "0");
+        insertChunk.run(id, `fact ${id}`);
+        insertMetadata.run(id, 1, project);
+        insertProvenance.run(id);
+      }
+      expect(readCuratedMemoryTriggerCandidates(db, 64).map((row) => row.id)).toEqual(
+        projects.flatMap((_, index) =>
+          index === 7 || index === 8 ? [] : String(index).padStart(2, "0"),
+        ),
+      );
+      for (let index = 0; index < 64; index += 1) {
+        const id = `unrelated-${index}`;
+        insertChunk.run(id, "higher-ranked unrelated fact");
+        insertMetadata.run(id, 10, `unrelated-project/${index}`);
+        insertProvenance.run(id);
+      }
+      const cases = [
+        { active: [], expected: [0] },
+        { active: [" \t "], expected: [0] },
+        { active: ["project/a"], expected: [0, 3, 5, 9] },
+        { active: ["\u2003project/a\u2029", "project/a"], expected: [0, 3, 5, 9] },
+        { active: ["project/a", "project/b"], expected: [0, 3, 5, 6, 9] },
+        { active: ["project/aa"], expected: [0, 4] },
+        { active: ["project/\0a"], expected: [0, 10] },
+        { active: ["project/🦞"], expected: [0, 11] },
+        { active: ["project/'%_\\"], expected: [0, 12] },
+        { active: ["project/\\u0000"], expected: [0, 13] },
+        { active: ["project/\ud800"], expected: [0] },
+        { active: ["project/\ufffd"], expected: [0, 14] },
+        { active: ["!invalid-project-annotation", "project/a"], expected: [0, 3, 5, 9] },
+        {
+          active: [...Array.from({ length: 64 }, (_, index) => `other/${index}`), "project/a"],
+          expected: [0, 3, 5, 9],
+        },
+      ];
+      for (const { active, expected } of cases) {
+        for (const limit of [1, 2, 64]) {
+          expect(
+            readCuratedMemoryTriggerCandidates(db, limit, active).map((row) => row.id),
+            JSON.stringify({ active, limit }),
+          ).toEqual(expected.slice(0, limit).map((index) => String(index).padStart(2, "0")));
+          expect(
+            readCuratedProjectMemoryCandidates(db, limit, active).map((row) => row.id),
+            JSON.stringify({ active, limit }),
+          ).toEqual(
+            expected
+              .filter((index) => index !== 0)
+              .slice(0, limit)
+              .map((index) => String(index).padStart(2, "0")),
+          );
+        }
+      }
+    } finally {
+      db.close();
+    }
+  });
+
+  it("bounds fetched bodies when unrelated projects precede a curated candidate", () => {
+    const db = new DatabaseSync(":memory:");
+    try {
+      ensureMemoryIndexSchema({ db, cacheEnabled: false, ftsEnabled: false });
+      const body = "foreign fact ".repeat(320);
+      const insertChunk = db.prepare(
+        `INSERT INTO memory_index_chunks
+         (id, path, start_line, end_line, hash, model, text, embedding, updated_at)
+         VALUES (?, 'MEMORY.md', 1, 1, 'h', 'm', ?, '[]', 2)`,
+      );
+      const insertMetadata = db.prepare(
+        `INSERT INTO memory_index_chunk_recall_metadata
+         (chunk_id, importance, triggers, project_key) VALUES (?, ?, 'recall', ?)`,
+      );
+      const insertProvenance = db.prepare(
+        `INSERT INTO memory_index_chunk_provenance
+         (chunk_id, origin_class, session_kind, observed_at) VALUES (?, 'owner', 'interactive', 2)`,
+      );
+      for (let index = 0; index < 2_000; index += 1) {
+        const id = `foreign-${index}`;
+        insertChunk.run(id, body);
+        insertMetadata.run(id, 10, `other/${index}`);
+        insertProvenance.run(id);
+      }
+      insertChunk.run("selected", "the selected fact");
+      insertMetadata.run("selected", 1, "project/current");
+      insertProvenance.run("selected");
+
+      let fetchedBodyBytes = 0;
+      const prepare = db.prepare.bind(db);
+      const spy = vi.spyOn(db, "prepare").mockImplementation((sql) => {
+        const statement = prepare(sql);
+        const iterate = statement.iterate.bind(statement);
+        vi.spyOn(statement, "iterate").mockImplementation(function* (...values) {
+          for (const row of iterate(...values)) {
+            if (typeof row.text === "string") {
+              fetchedBodyBytes += Buffer.byteLength(row.text);
+            }
+            yield row;
+          }
+          return undefined;
+        });
+        return statement;
+      });
+      expect(readCuratedProjectMemoryCandidates(db, 1, ["project/current"])).toEqual([
+        expect.objectContaining({ id: "selected", text: "the selected fact" }),
+      ]);
+      expect(fetchedBodyBytes).toBeLessThan(Buffer.byteLength(body) * 128);
+      expect(spy.mock.calls.length).toBeLessThanOrEqual(2);
+      spy.mockRestore();
+    } finally {
+      db.close();
+    }
+  });
+
   it("stores recall metadata in a rollback-safe additive table", () => {
     const db = new DatabaseSync(":memory:");
     try {

--- a/packages/memory-host-sdk/src/host/memory-recall-metadata.ts
+++ b/packages/memory-host-sdk/src/host/memory-recall-metadata.ts
@@ -152,6 +152,7 @@ function readCuratedMemoryCandidates(params: {
   const active = params.activeProjectKeys
     ? new Set(params.activeProjectKeys.map((key) => key.trim()).filter(Boolean))
     : undefined;
+  const projectKeyPrefilter = active && active.size <= 64 ? [...active] : undefined;
   const results: ReturnType<typeof readCuratedCandidateBatch> = [];
   let cursor: { importance: number | null; path: string; id: string } | undefined;
   const batchSize = Math.max(64, limit);
@@ -164,6 +165,7 @@ function readCuratedMemoryCandidates(params: {
       cursor,
       requireProject: params.requireProject,
       requireTriggers: params.requireTriggers,
+      projectKeyPrefilter,
     });
     if (rows.length === 0) {
       break;
@@ -204,6 +206,7 @@ function readCuratedCandidateBatch(params: {
   cursor?: { importance: number | null; path: string; id: string };
   requireProject: boolean;
   requireTriggers: boolean;
+  projectKeyPrefilter?: readonly string[];
 }) {
   let query = getNodeSqliteKysely<MemoryRecallMetadataDatabase>(params.db)
     .selectFrom("memory_index_chunks as chunk")
@@ -232,6 +235,19 @@ function readCuratedCandidateBatch(params: {
   }
   if (params.requireTriggers) {
     query = query.where("metadata.triggers", "is not", null);
+  }
+  const projectKeyPrefilter = params.projectKeyPrefilter;
+  if (projectKeyPrefilter && params.cursor) {
+    // After an unfilled first batch, prune rows without any active-key substring.
+    // Matching rows still need exact split/trimmed-key checks in JS.
+    query = query.where((eb) =>
+      eb.or([
+        eb("metadata.project_key", "is", null),
+        ...projectKeyPrefilter.map((key) =>
+          eb(eb.fn<number>("instr", [eb.ref("metadata.project_key"), eb.val(key)]), ">", 0),
+        ),
+      ]),
+    );
   }
   if (params.cursor) {
     const cursor = params.cursor;


### PR DESCRIPTION
Related: #146197

## What Problem This Solves

Automatic memory recall can spend time loading thousands of facts for unrelated projects before returning the current project's facts. This delays recall before the model starts even when only a small candidate window is needed.

## Why This Change Was Made

Keep the first candidate batch unchanged. If it cannot fill the requested window, prune impossible project matches in SQLite before fetching subsequent chunk bodies. The existing JavaScript policy still checks exact semicolon-separated, trimmed keys, all-project membership, and invalid annotations; substring matches only provide a necessary-condition prefilter. More than 64 distinct normalized active keys retains the existing query path to bound SQL expressions and parameters.

No schema, migration, persisted representation, write path, transaction, manager admission, provenance policy, or public API changes.

## User Impact

Selective recall reads substantially less data when unrelated project memories rank ahead of the active project's entries. Returned facts, ordering, global trigger eligibility, and project isolation remain unchanged.

## Evidence

- 76 tests pass: the recall storage owner (3), public memory manager indexing (70), and manager provenance-repair/liveness (3).
- Boundary cases cover empty versus absent active lists, mixed and invalid scopes, substring false positives, Unicode whitespace, emoji, embedded NUL, unpaired-surrogate binding, quoted keys, and the 65-key fallback.
- The original code passes the same behavior cases but fails the new public-owner cost regression: 8,320,017 fetched body bytes exceed the 532,480-byte budget. The candidate passes with at most two queries. The boundary fixture puts 64 unrelated higher-ranked rows ahead of its cases to exercise continuation filtering.
- Independent P0–P2 review: scoped clean. Formatting and diff checks pass.
- File-backed SQLite WAL benchmark, five warmups and 25 alternating before/after sample pairs per scenario, using the actual public storage readers:

| Scenario | SELECTs | Fetched rows | Fetched body bytes | Median latency |
| --- | --- | --- | --- | --- |
| 100 unrelated + 64 eligible facts | 3 → 2 | 164 → 128 | 722,912 → 564,224 | 2.91 → 2.10 ms |
| 2,000 unrelated + 64 eligible facts | 32 → 2 | 2,048 → 128 | 9,027,584 → 564,224 | 114.18 → 5.94 ms |
| All matching, 2,064 facts | 1 → 1 | 64 → 64 | 282,112 → 282,112 | 3.92 → 3.93 ms |
| Unscoped triggers, 2,064 facts | 1 → 1 | 64 → 64 | 282,112 → 282,112 | 3.78 → 3.69 ms |

These are synthetic warm measurements, not production latency claims; the controls show no demonstrated latency improvement. Additional all-matching controls with 4, 16, 64, and 65 active keys retained the original first-window behavior (median 3.83 → 3.69, 3.89 → 3.97, 3.62 → 3.72, and 3.99 → 3.76 ms). Every before/after pair returned the same complete result hash. Schema, version, and typed rows in the three queried tables remained unchanged on the existing database through all reads. The 2,000-unrelated case's p95 fell from 210.89 to 17.44 ms; fetched bodies decreased by 93.75%.

Local checks: core production and owning packages test types, core graph boundary, formatting, scoped lint, and production unused-export scan pass. The Windows aggregate test-type launcher rejects a percent-encoded file URL before starting its compiler; the unchanged canonical packages graph passes through the direct repository typecheck runner. The broader script/full-tree export scans still report two unchanged baseline exports (`canonicalProviderName` and `listPackagedStaticExtensionAssetOutputs`); this patch adds no production exports or imports.

Maintainer disposition of the automated data-model notice: this diff changes only SELECT construction. It changes no table, column, schema version, embedding format, writer, transaction, or migration. The compatibility proof above compares schema/version/full typed rows and complete returned results before and after candidate reads on the same existing SQLite database. The path-based persistent-model classification does not describe this change; no migration is needed.
