### PR TITLE
improve: load large session contexts more efficiently

### DIFF
--- a/src/agents/sessions/session-manager-model-context.test.ts
+++ b/src/agents/sessions/session-manager-model-context.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import path from "node:path";
 import type { StatementSync } from "node:sqlite";
 import { expect, it, vi } from "vitest";
+import { DEFAULT_MISSING_TOOL_RESULT_TEXT } from "../../../packages/agent-core/src/harness/session/tool-result-pairing.js";
 import { makeUserMessage } from "../../../test/helpers/user-message.js";
 import {
   appendTranscriptEvent,
@@ -774,67 +775,94 @@ it.each([false, true])(
   },
 );
 
-it("keeps the real result when reset retention replaces a synthetic missing result", async () => {
-  await withOpenClawTestState({ label: "model-pairing" }, async (state) => {
-    const scope = {
-      agentId: "main",
-      sessionId: "pairing",
-      sessionKey: "agent:main:pairing",
-      storePath: path.join(state.agentDir("main"), "openclaw-agent.sqlite"),
-    };
-    await upsertSessionEntryCore(scope, { sessionId: scope.sessionId, updatedAt: 1 });
-    const source = SessionManager.open(scope);
-    const firstKept = source.appendMessage(
-      makeAgentAssistantMessage({
-        content: [{ type: "toolCall", id: "repeat", name: "read", arguments: {} }],
-      }),
-    );
-    source.appendMessage({
-      role: "toolResult",
-      toolCallId: "repeat",
-      toolName: "read",
-      isError: true,
-      content: [{ type: "text", text: "missing" }],
-      details: { openclawSyntheticMissingToolResult: true },
-      timestamp: 1,
-    });
-    source.appendMessage({
-      role: "toolResult",
-      toolCallId: "repeat",
-      toolName: "read",
-      isError: false,
-      content: [{ type: "text", text: "real output" }],
-      timestamp: 2,
-    });
-    source.appendMessage({
-      role: "toolResult",
-      toolCallId: "orphan",
-      toolName: "read",
-      isError: false,
-      content: [{ type: "text", text: "orphan-body:" + "x".repeat(512 * 1024) }],
-      timestamp: 3,
-    });
-    source.appendResetBoundary("new", firstKept);
-    const originalParse = JSON.parse;
-    let orphanBytes = 0;
-    const spy = vi.spyOn(JSON, "parse").mockImplementation((text, reviver) => {
-      if (typeof text === "string" && text.includes("orphan-body:")) {
-        orphanBytes += text.length;
+it.each(["details", "text", "duplicate-object", "late-array-call"])(
+  "keeps real tool output across reset (%s)",
+  async (marker) => {
+    await withOpenClawTestState({ label: "model-pairing" }, async (state) => {
+      const scope = {
+        agentId: "main",
+        sessionId: "pairing",
+        sessionKey: "agent:main:pairing",
+        storePath: path.join(state.agentDir("main"), "openclaw-agent.sqlite"),
+      };
+      await upsertSessionEntryCore(scope, { sessionId: scope.sessionId, updatedAt: 1 });
+      const source = SessionManager.open(scope);
+      const firstKept = source.appendMessage(
+        makeAgentAssistantMessage({
+          content: [
+            ...Array.from({ length: marker === "late-array-call" ? 16 : 1 }, () => ({
+              type: "text" as const,
+              text: "Reading the file",
+            })),
+            { type: "toolCall", id: "repeat", name: "read", arguments: { path: "synthetic.txt" } },
+          ],
+        }),
+      );
+      const missingResult = source.appendMessage({
+        role: "toolResult",
+        toolCallId: "repeat",
+        toolName: "read",
+        isError: true,
+        content: [
+          {
+            type: "text",
+            text: marker === "details" ? "missing" : DEFAULT_MISSING_TOOL_RESULT_TEXT,
+          },
+        ],
+        ...(marker === "details" ? { details: { openclawSyntheticMissingToolResult: true } } : {}),
+        timestamp: 1,
+      });
+      source.appendMessage({
+        role: "toolResult",
+        toolCallId: "repeat",
+        toolName: "read",
+        isError: false,
+        content: [{ type: "text", text: "real output" }],
+        timestamp: 2,
+      });
+      source.appendMessage({
+        role: "toolResult",
+        toolCallId: "orphan",
+        toolName: "read",
+        isError: false,
+        content: [{ type: "text", text: "orphan-body:" + "x".repeat(512 * 1024) }],
+        timestamp: 3,
+      });
+      source.appendResetBoundary("new", firstKept);
+      if (marker === "duplicate-object") {
+        await waitForSessionTranscriptProjection(scope);
+        const database = openOpenClawAgentDatabase({ agentId: "main", path: scope.storePath });
+        // Preserve duplicate members from imported JSON; JavaScript objects would collapse them.
+        const content = `{"part":{"type":"text","text":"ordinary"},"part":{"type":"text","text":${JSON.stringify(DEFAULT_MISSING_TOOL_RESULT_TEXT)}}}`;
+        database.db
+          .prepare(
+            "UPDATE transcript_events SET event_json = json_set(event_json, '$.message.content', json(?)) WHERE session_id = ? AND json_extract(event_json, '$.id') = ?",
+          )
+          .run(content, scope.sessionId, missingResult);
       }
-      return originalParse(text, reviver);
+      const originalParse = JSON.parse;
+      let orphanBytes = 0;
+      const spy = vi.spyOn(JSON, "parse").mockImplementation((text, reviver) => {
+        if (typeof text === "string" && text.includes("orphan-body:")) {
+          orphanBytes += text.length;
+        }
+        return originalParse(text, reviver);
+      });
+      let messages: ReturnType<SessionManager["buildSessionContext"]>["messages"];
+      try {
+        messages = SessionManager.openModelContext(scope).buildSessionContext().messages;
+      } finally {
+        spy.mockRestore();
+      }
+      expect(orphanBytes).toBe(0);
+      expect(
+        messages
+          .filter((message) => message.role === "toolResult")
+          .map((message) => message.content),
+      ).toEqual([[{ type: "text", text: "real output" }]]);
     });
-    let messages: ReturnType<SessionManager["buildSessionContext"]>["messages"];
-    try {
-      messages = SessionManager.openModelContext(scope).buildSessionContext().messages;
-    } finally {
-      spy.mockRestore();
-    }
-    expect(orphanBytes).toBe(0);
-    expect(
-      messages.filter((message) => message.role === "toolResult").map((message) => message.content),
-    ).toEqual([[{ type: "text", text: "real output" }]]);
-  });
-});
+  },
+);
 
 it.each(["reset", "compaction"])(
   "does not acquire checkpoints invalidated by %s",

--- a/src/config/sessions/session-model-context-projection.ts
+++ b/src/config/sessions/session-model-context-projection.ts
@@ -29,6 +29,17 @@ function pickJsonObject(value: Expression<string>, keys: readonly string[]): Raw
     ELSE value END) FROM json_each(${value}) WHERE key IN (${sql.join(keys)}))`;
 }
 
+function contentPropertySql(
+  event: Expression<string>,
+  property: "type" | "id" | "name" | "text",
+): RawBuilder<unknown> {
+  // Root lookups rescan array prefixes, so keep them bounded. Later elements and
+  // potentially duplicated object keys retain their own json_each value.
+  return /* kysely-allow-raw: bounded array paths avoid serializing and reparsing whole content objects. */ sql`CASE WHEN typeof(key) = 'integer' AND key < 8
+    THEN json_extract(${event}, fullkey || ${`.${property}`})
+    ELSE json_extract(value, ${`$.${property}`}) END`;
+}
+
 const TRANSCRIPT_NAVIGATION_KEYS = [
   "type",
   "id",
@@ -98,13 +109,13 @@ export function projectModelContextNavigationSql(event: Expression<string>): Raw
     "display",
   ]);
   const calls = /* kysely-allow-raw: pairing needs call identities, never tool arguments or result bodies. */ sql<string>`(SELECT json_group_array(json_object(
-    'type', json_extract(value, '$.type'), 'id', json_extract(value, '$.id'),
-    'name', json_extract(value, '$.name')))
+    'type', ${contentPropertySql(event, "type")}, 'id', ${contentPropertySql(event, "id")},
+    'name', ${contentPropertySql(event, "name")}))
     FROM json_each(${event}, '$.message.content') WHERE type = 'object'
-    AND json_extract(value, '$.type') IN ('toolCall', 'toolUse', 'functionCall'))`;
+    AND ${contentPropertySql(event, "type")} IN ('toolCall', 'toolUse', 'functionCall'))`;
   const synthetic = /* kysely-allow-raw: pairing prefers real results over synthetic missing-result placeholders. */ sql<number>`COALESCE(json_extract(${event}, ${`$.message.details.${SYNTHETIC_MISSING_TOOL_RESULT_DETAIL_KEY}`}), 0) = 1 OR EXISTS (
     SELECT 1 FROM json_each(${event}, '$.message.content') WHERE type = 'object'
-    AND json_extract(value, '$.type') = 'text' AND json_extract(value, '$.text') = ${DEFAULT_MISSING_TOOL_RESULT_TEXT})`;
+    AND ${contentPropertySql(event, "type")} = 'text' AND ${contentPropertySql(event, "text")} = ${DEFAULT_MISSING_TOOL_RESULT_TEXT})`;
   return /* kysely-allow-raw: retain readable empty bodies only for navigation outside the model window. */ sql<string>`CASE json_extract(${event}, '$.type')
     WHEN 'message' THEN json_set(${entry}, '$.message', json_set(${messageFacts},
       '$.content', json(${calls}), '$.command', '', '$.output', '',


### PR DESCRIPTION
Related: #146286

## What Problem This Solves

Loading model context from a long session spends CPU serializing and reparsing large content objects just to recover tool-call identities and missing-result markers. Large tool arguments and text blocks make this metadata-only scan expensive before the selected context is ready.

## Why This Change Was Made

Read navigation properties directly from the original JSON for the first eight array elements. Keep per-element extraction afterward so large content arrays retain linear scaling, and keep it for object-valued content so duplicate imported keys preserve their original meaning. Context selection, admission, raw transcript bytes, and payload retention are unchanged.

## User Impact

Large session contexts and reset-retained tool histories require less CPU to load. Tiny histories are effectively unchanged in the paired measurement, and this change does not reduce retained payload memory.

## Evidence

Paired real-reader measurements on the same isolated synthetic database, alternating extraction variants (Node 24.21.0, SQLite 3.53.4, eight measured samples after warmup):

| Workload | Before | After |
| --- | ---: | ---: |
| Model-context read, 2,048 large tool messages / 128 MiB, median CPU | 492.32 ms | 430.01 ms |
| Uncached reset-retention selection, same history, median CPU | 301.87 ms | 253.25 ms |
| Ordinary 1,000-message history, median wall time | 24.67 ms | 24.76 ms |
| One message containing 10,000 small blocks, median wall time | 13.34 ms | 14.34 ms |

Output hashes match throughout. The paired comparison forces the legacy per-element extraction branch while leaving the fixture and real reader identical. Model-read median RSS delta was 32,768 bytes in both variants. Wall timing on a shared host is noisier than CPU timing.

The bounded prefix matters: unrestricted root lookups rescan array prefixes and made the 10,000-block fixture take 311 ms. The final implementation keeps the existing extraction path after eight elements. Duplicate-object-key coverage demonstrably fails when its preservation guard is removed.

- 57 focused model-context, completed-turn snapshot/admission, and bounded-context tests passed, including late-array tool calls, duplicate imported keys, real/synthetic result pairing, and excluded orphan payloads.
- Independent Codex P2 review is clean after resolving the large-array performance finding.
- Final changed-file checks passed, including core/test typechecks, lint, dead exports, storage/schema checks, and import guards.
