### PR TITLE
improve(gateway): avoid scanning long replies for control prefixes

### DIFF
--- a/src/gateway/control-reply-text.test.ts
+++ b/src/gateway/control-reply-text.test.ts
@@ -4,6 +4,18 @@ import { stripSuppressedControlReplyToken } from "./control-reply-text.js";
 import { projectLiveAssistantBufferedText } from "./live-chat-projector.js";
 
 describe("control reply display projection", () => {
+  it.each(["NO_", "ANNOUNCE_", "REPLY_"])(
+    "holds whitespace-padded %s prefixes while streaming",
+    (prefix) => {
+      const text = `${" \t\n".repeat(10)}${prefix}\u00a0\ufeff`;
+      expect(projectLiveAssistantBufferedText(text)).toEqual({
+        text,
+        suppress: true,
+        pendingLeadFragment: true,
+      });
+    },
+  );
+
   it("preserves text whitespace when no control token is present", () => {
     expect(stripSuppressedControlReplyToken("  keep padded  ")).toBe("  keep padded  ");
     expect(

--- a/src/gateway/control-reply-text.ts
+++ b/src/gateway/control-reply-text.ts
@@ -8,6 +8,10 @@ const SUPPRESSED_CONTROL_REPLY_TOKENS = [
   "REPLY_SKIP",
 ] as const;
 
+const MAX_CONTROL_REPLY_TOKEN_LENGTH = Math.max(
+  ...SUPPRESSED_CONTROL_REPLY_TOKENS.map((token) => token.length),
+);
+
 const MIN_BARE_PREFIX_LENGTH_BY_TOKEN: Readonly<
   Record<(typeof SUPPRESSED_CONTROL_REPLY_TOKENS)[number], number>
 > = {
@@ -15,18 +19,6 @@ const MIN_BARE_PREFIX_LENGTH_BY_TOKEN: Readonly<
   ANNOUNCE_SKIP: 3,
   REPLY_SKIP: 3,
 };
-
-function normalizeSuppressedControlReplyFragment(text: string): string {
-  const trimmed = text.trim();
-  if (!trimmed) {
-    return "";
-  }
-  const normalized = trimmed.toUpperCase();
-  if (/[^A-Z_]/.test(normalized)) {
-    return "";
-  }
-  return normalized;
-}
 
 /**
  * Return true when a chat-visible reply is exactly an internal control token.
@@ -56,8 +48,12 @@ export function stripSuppressedControlReplyToken(text: string): string {
  */
 export function isSuppressedControlReplyLeadFragment(text: string): boolean {
   const trimmed = text.trim();
-  const normalized = normalizeSuppressedControlReplyFragment(text);
-  if (!normalized) {
+  // Uppercasing cannot shorten a reply into a valid control-token prefix.
+  if (!trimmed || trimmed.length > MAX_CONTROL_REPLY_TOKEN_LENGTH) {
+    return false;
+  }
+  const normalized = trimmed.toUpperCase();
+  if (/[^A-Z_]/.test(normalized)) {
     return false;
   }
   return SUPPRESSED_CONTROL_REPLY_TOKENS.some((token) => {
@@ -71,7 +67,7 @@ export function isSuppressedControlReplyLeadFragment(text: string): boolean {
     if (normalized.includes("_")) {
       return true;
     }
-    if (token !== SILENT_REPLY_TOKEN && trimmed !== trimmed.toUpperCase()) {
+    if (token !== SILENT_REPLY_TOKEN && trimmed !== normalized) {
       return false;
     }
     // Bare fragments are common while streaming. Require a minimum prefix so


### PR DESCRIPTION
Related: #145679

## What Problem This Solves

Live assistant-text projection repeatedly uppercases the growing reply to check whether it is a short control-token prefix. This adds work proportional to the accumulated reply on each update, even after the reply is far too long to match.

## Why This Change Was Made

Trim once and reject candidates longer than the longest control token before normalizing case. Keep classification in its existing owner, remove its redundant private normalization wrapper, and reuse the normalized text for case checks.

## User Impact

Long streamed replies spend less CPU time in live-text projection. Control-token suppression, visible text, whitespace and short-prefix behavior remain the same.

## Evidence

- The complete live-text projector passed 1,994 original/candidate output comparisons with actual imported dependencies and native-baseline parity, including control tokens, prefixes, case variants, Unicode whitespace, trailing/leading tokens and ordinary growing replies.
- Windows Node 24.19, 256 updates growing to 64 KiB of ordinary prose: median cumulative projection time changed from 3.21 to 0.87 ms. Traces growing to 256 KiB changed from 76.90 to 0.87 ms for ASCII letters and 176.07 to 5.40 ms for mixed Unicode. These synthetic source-owner measurements exclude transport and upstream normalization; short replies showed much smaller differences. Each case used six alternating measured rounds after warmup.
- Existing Gateway projection and registered agent-event suites passed on the original (233 tests) and candidate (236 tests), including three padded-prefix cases that preserve the full projection result. Both runs used the repository wrapper, one worker, unchanged dependencies, and verified source hashes.
- Independent P2 review completed with no actionable findings and final source verification. The reviewer could not inspect the unchanged token helper because its filename was excluded by the review isolation boundary; that visibility limitation is retained. The full-projector comparisons and tests used the actual dependency.
- Full exact-head [CI run 34711574040](https://github.com/openclaw/openclaw/actions/runs/34711574040) passed for `5d4e9da44446867076d25eda63acffc661af8a39`. Hosted production types, lint, formatting and build supply the selected static proof; redundant local static checks were not run under the host capacity limit.
