### PR TITLE
improve(logbook): batch expired frame pruning

### DIFF
--- a/extensions/logbook/src/store-prune.test.ts
+++ b/extensions/logbook/src/store-prune.test.ts
@@ -1,0 +1,171 @@
+import * as fs from "node:fs";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import type { SqliteWorkerBackend } from "openclaw/plugin-sdk/sqlite-runtime";
+import { useAutoCleanupTempDirTracker } from "openclaw/plugin-sdk/test-env";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { LogbookOperations } from "./store-contract.js";
+import { createSqliteWorkerBackend } from "./store.worker.js";
+
+const reads = vi.hoisted(() => ({ queries: 0 }));
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  return { ...actual, rmSync: vi.fn(actual.rmSync) };
+});
+vi.mock("openclaw/plugin-sdk/sqlite-runtime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/sqlite-runtime")>();
+  return {
+    ...actual,
+    openNodeSqliteDatabase: (...args: Parameters<typeof actual.openNodeSqliteDatabase>) => {
+      const database = actual.openNodeSqliteDatabase(...args);
+      const prepare = database.prepare.bind(database);
+      vi.spyOn(database, "prepare").mockImplementation((sql) => {
+        const statement = prepare(sql);
+        if (/^select\b.*\bfrom "frames"/i.test(sql)) {
+          const all = statement.all.bind(statement);
+          vi.spyOn(statement, "all").mockImplementation((...bindings) => {
+            reads.queries += 1;
+            return all(...bindings);
+          });
+          const get = statement.get.bind(statement);
+          vi.spyOn(statement, "get").mockImplementation((...bindings) => {
+            reads.queries += 1;
+            return get(...bindings);
+          });
+          const iterate = statement.iterate.bind(statement);
+          vi.spyOn(statement, "iterate").mockImplementation(function* (...bindings) {
+            reads.queries += 1;
+            yield* iterate(...bindings);
+            return undefined;
+          });
+        }
+        return statement;
+      });
+      return database;
+    },
+  };
+});
+
+const backends: SqliteWorkerBackend<LogbookOperations>[] = [];
+const databases: DatabaseSync[] = [];
+const tempDirs = useAutoCleanupTempDirTracker((cleanup) =>
+  afterEach(async () => {
+    await Promise.all(backends.splice(0).map((backend) => Promise.resolve(backend.close())));
+    databases.splice(0).forEach((database) => database.close());
+    vi.restoreAllMocks();
+    cleanup();
+  }),
+);
+const day = "2026-07-03";
+
+function seedFrames(expired: number) {
+  const dataDir = tempDirs.make("logbook-prune-");
+  const databasePath = path.join(dataDir, "logbook.sqlite");
+  const backend = createSqliteWorkerBackend({ dataDir }, { databasePath });
+  backends.push(backend);
+  const database = new DatabaseSync(databasePath);
+  databases.push(database);
+  database.exec("PRAGMA foreign_keys = ON");
+  const paths = Array.from({ length: expired + 1 }, (_, index) => {
+    const file = path.join(dataDir, "frames", `${index}.jpg`);
+    fs.writeFileSync(file, "synthetic frame");
+    backend.execute({
+      type: "insertFrame",
+      input: {
+        capturedAtMs: index,
+        day,
+        path: file,
+        screenIndex: 0,
+        byteSize: 15,
+        contentHash: `frame-${index}`,
+        idle: false,
+      },
+    });
+    return file;
+  });
+  backend.execute({
+    type: "replaceCardsInWindow",
+    input: {
+      day,
+      startMs: 0,
+      endMs: expired + 2,
+      drafts: [1, expired + 1].map((id) => ({
+        day,
+        startMs: 0,
+        endMs: expired + 2,
+        title: `Card ${id}`,
+        summary: "Retained card",
+        detail: "",
+        category: "coding",
+        distractions: [],
+        keyframeId: id,
+      })),
+    },
+  });
+  reads.queries = 0;
+  return { backend, database, paths };
+}
+
+describe("Logbook frame pruning", () => {
+  it.each([0, 1, 64, 65, 129])(
+    "prunes %i expired frames with bounded reads while retaining recent frames and cards",
+    (expired) => {
+      const { backend, database, paths } = seedFrames(expired);
+      expect(backend.execute({ type: "pruneFrames", input: { olderThanMs: expired } })).toBe(
+        expired,
+      );
+      expect(reads.queries).toBeLessThanOrEqual(1 + Math.ceil(expired / 64));
+      expect(reads.queries).toBeGreaterThan(0);
+      expect(database.prepare("SELECT id FROM frames ORDER BY id").all()).toEqual([
+        { id: expired + 1 },
+      ]);
+      expect(database.prepare("SELECT keyframe_id FROM cards ORDER BY id").all()).toEqual([
+        { keyframe_id: expired === 0 ? 1 : null },
+        { keyframe_id: expired + 1 },
+      ]);
+      expect(paths.map((file) => fs.existsSync(file))).toEqual([
+        ...Array<boolean>(expired).fill(false),
+        true,
+      ]);
+    },
+  );
+
+  it.each(["missing", "changed"] as const)(
+    "rechecks a %s frame after file removal and preserves the transaction outcome across batches",
+    async (change) => {
+      const expired = 130;
+      const { backend, database, paths } = seedFrames(expired);
+      const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
+      vi.mocked(fs.rmSync).mockImplementation((file, options) => {
+        actual.rmSync(file, options);
+        if (file === paths[expired - 1]) {
+          if (change === "missing") {
+            database.prepare("DELETE FROM frames WHERE id = ?").run(expired);
+          } else {
+            database.prepare("UPDATE frames SET path = ? WHERE id = ?").run("changed.jpg", expired);
+          }
+        }
+      });
+      const prune = () => backend.execute({ type: "pruneFrames", input: { olderThanMs: expired } });
+      if (change === "missing") {
+        expect(prune()).toBe(expired - 1);
+        expect(database.prepare("SELECT id FROM frames ORDER BY id").all()).toEqual([
+          { id: expired + 1 },
+        ]);
+      } else {
+        expect(prune).toThrow(`Logbook frame ${expired} changed path while pruning`);
+        expect(database.prepare("SELECT count(*) AS count FROM frames").get()).toEqual({
+          count: expired + 1,
+        });
+        expect(database.prepare("SELECT keyframe_id FROM cards ORDER BY id").all()).toEqual([
+          { keyframe_id: 1 },
+          { keyframe_id: expired + 1 },
+        ]);
+      }
+      expect(paths.map((file) => fs.existsSync(file))).toEqual([
+        ...Array<boolean>(expired).fill(false),
+        true,
+      ]);
+    },
+  );
+});

--- a/extensions/logbook/src/store.worker.ts
+++ b/extensions/logbook/src/store.worker.ts
@@ -45,6 +45,7 @@ import type {
 type Database = import("node:sqlite").DatabaseSync;
 
 const LOGBOOK_SQLITE_BUSY_TIMEOUT_MS = 5_000;
+const FRAME_PRUNE_BATCH_SIZE = 64;
 class LogbookDatabaseStore {
   private readonly db: Database;
   private readonly query;
@@ -247,23 +248,6 @@ class LogbookDatabaseStore {
                 updated_ms: eb.ref("excluded.updated_ms"),
               })),
             ),
-        ),
-        currentFramePath: prepareSqliteQuerySync<number, { path: string }>(db, (p) =>
-          this.query
-            .selectFrom("frames")
-            .select("path")
-            .where(
-              "id",
-              "=",
-              p((id) => id),
-            ),
-        ),
-        deleteFrame: prepareSqliteQuerySync<number>(db, (p) =>
-          this.query.deleteFrom("frames").where(
-            "id",
-            "=",
-            p((id) => id),
-          ),
         ),
       };
     } catch (error) {
@@ -591,16 +575,25 @@ class LogbookDatabaseStore {
       this.db,
       () => {
         let count = 0;
-        for (const row of rows) {
-          const current = this.statements.currentFramePath(row.id).rows[0];
-          if (!current) {
-            continue;
-          }
-          if (current.path !== row.path) {
-            throw new Error(`Logbook frame ${row.id} changed path while pruning`);
+        for (let offset = 0; offset < rows.length; offset += FRAME_PRUNE_BATCH_SIZE) {
+          const batch = rows.slice(offset, offset + FRAME_PRUNE_BATCH_SIZE);
+          const ids = batch.map((row) => row.id);
+          const currentPaths = new Map(
+            executeSqliteQuerySync(
+              this.db,
+              this.query.selectFrom("frames").select(["id", "path"]).where("id", "in", ids),
+            ).rows.map((row) => [row.id, row.path]),
+          );
+          for (const row of batch) {
+            if (currentPaths.has(row.id) && currentPaths.get(row.id) !== row.path) {
+              throw new Error(`Logbook frame ${row.id} changed path while pruning`);
+            }
           }
           // ON DELETE SET NULL clears surviving cards' keyframes in the same commit.
-          const result = this.statements.deleteFrame(row.id);
+          const result = executeSqliteQuerySync(
+            this.db,
+            this.query.deleteFrom("frames").where("id", "in", ids),
+          );
           count += Number(expectDefined(result.numAffectedRows, "Logbook pruned frame count"));
         }
         return count;


### PR DESCRIPTION
Related: #146197

## What Problem This Solves

Large Logbook retention passes do avoidable database work while removing expired screenshots, including startup cleanup after a long offline period. A 3,000-frame pass executes 6,001 separate frame SQL statements.

## Why This Change Was Made

The existing Kysely owner batches path rereads and deletions in groups of 64. It keeps the original candidate query and filesystem-removal phase, compares current paths in candidate order, and preserves missing-row skips, stale-path errors, rollback, affected-row counts, and `ON DELETE SET NULL` for surviving cards. The superseded point-read and point-delete statements are removed. Production code shrinks by seven lines.

This changes no schema, database path, version, writer ownership, transaction boundary, retention cutoff, file-removal order, migration, or recovery contract. Failed filesystem removals still preserve metadata; a late path mismatch still rolls back every metadata deletion and keyframe update.

## User Impact

Logbook removes expired screenshots and preserves timeline cards with fewer database operations. Retention and failure behavior remain the same. Filesystem work still dominates the measured Windows cleanup latency.

## Evidence

Paired actual file-backed store backend with ordinary image files created and removed on every sample; Node 26.8.2 on Windows, five warmups and 25 measured samples per variant, alternating before/after order. Remaining typed table contents match in every sample.

| Expired frames | Frame SQL statements | Frame reads | Median before → after | p95 before → after |
| --- | --- | --- | --- | --- |
| 100 | 201 → 5 | 101 → 3 | 58.33 → 61.46 ms | 73.33 → 83.32 ms |
| 1,000 | 2,001 → 33 | 1,001 → 17 | 609.88 → 584.67 ms | 688.82 → 761.48 ms |
| 3,000 | 6,001 → 95 | 3,001 → 48 | 1,559.47 → 1,482.06 ms | 1,894.41 → 2,096.94 ms |

The deterministic gain is fewer SQL executions. Both versions fetch the same number of frame rows; Windows filesystem cost and timing noise dominate the complete operation. These measurements do not establish a general latency improvement.

Validation:

- New native-owner tests cover zero work, singleton and 64-row boundaries, recent-frame retention, surviving-card keyframes, missing rows, and rollback after a late path change. All seven pass. The original implementation fails the three multirow read-budget cases for the intended reason.
- Exact-head Linux proof on Node 26.8.2: all 60 tests in the pruning, real worker, frame-I/O admission, and service lifecycle files passed, including POSIX owner-only file modes. The worktree remained clean at `0e063d14163523e4290db5cd56e2a933118f8b8a`. Windows had 59/60 passing tests; its one existing POSIX file-mode assertion fails identically on original source.
- Existing-store compatibility passed: the original owner seeded 130 frames, a batch, observations, two cards, and a Unicode/NUL standup. Candidate opening leaves schema, versions, and every typed row unchanged. Candidate and original pruning both remove 129 rows and leave identical complete typed table contents. Read/delete plans use the existing primary-key and card-keyframe indexes.
- Fresh independent P0–P2 review is clean. Production and test extension typechecks, repository guards, formatting, Doctor boundary tests, and production unused-export scan passed.
- The full changed check stops on two pre-existing, untouched script exports: `canonicalProviderName` in `scripts/crabbox-wrapper-providers.mts` and `listPackagedStaticExtensionAssetOutputs` in `scripts/lib/static-extension-assets.mts`. Scoped lint and the remaining database-first, media-download, runtime-sidecar, and import-cycle guards all passed; the dead-export exceptions remain documented separately.





