### PR TITLE
improve(terminal): speed up Windows table rendering

### DIFF
--- a/packages/terminal-core/src/display-string.ts
+++ b/packages/terminal-core/src/display-string.ts
@@ -76,9 +76,18 @@ function resolveHomeDisplayPrefix(): { home: string; prefix: string } | undefine
 /** Find a case-insensitive Windows path without changing offsets in the original string. */
 function indexOfWindowsPath(input: string, home: string, cursor: number): number {
   const foldedHome = lowercasePreservingWhitespace(home);
-  // Folding the whole display can expand Unicode and shift indices. Fixed-width slices keep
-  // replacement offsets anchored to the original string while retaining Windows casing rules.
-  for (let index = cursor; index <= input.length - home.length; index += 1) {
+  // Resolved Windows homes begin with a drive or UNC prefix. Their first backslash
+  // anchors candidates without folding the input and shifting Unicode offsets.
+  const separatorOffset = home.indexOf("\\");
+  for (
+    let separator = input.indexOf("\\", cursor + separatorOffset);
+    separator !== -1;
+    separator = input.indexOf("\\", separator + 1)
+  ) {
+    const index = separator - separatorOffset;
+    if (index > input.length - home.length) {
+      break;
+    }
     if (lowercasePreservingWhitespace(input.slice(index, index + home.length)) === foldedHome) {
       return index;
     }

--- a/packages/terminal-core/src/table.test.ts
+++ b/packages/terminal-core/src/table.test.ts
@@ -1,6 +1,5 @@
 import { spawnSync } from "node:child_process";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
 import { note as clackNote } from "@clack/prompts";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { sanitizeForLog, stripAnsi, visibleWidth } from "./ansi.js";
@@ -151,7 +150,7 @@ describe("renderTable", () => {
         process.execPath,
         [
           "--import",
-          fileURLToPath(new URL("../../../scripts/tsx.mjs", import.meta.url)),
+          new URL("../../../scripts/tsx.mjs", import.meta.url).href,
           "--input-type=module",
           "-e",
           `import { renderTable } from ${JSON.stringify(new URL("./table.ts", import.meta.url).href)};


### PR DESCRIPTION
## What Problem This Solves

Windows CLI tables spend unnecessary time checking ordinary descriptions for home paths. This affects lists such as skills and plugins, even when cells contain no paths.

## Why This Change Was Made

Use the first backslash in the resolved Windows home to locate possible matches in the original text, then retain the existing fixed-width, case-insensitive comparison. This preserves Unicode offsets, drive/UNC paths, token boundaries, and the formatter's per-render home snapshot.

The existing large-output tests also pass a file URL to Node's `--import`, allowing them to reach the renderer on Windows.

## User Impact

Long Windows tables require less formatting work and produce identical output.

## Evidence

Native Windows, Node 26.8.2; complete `renderTable` calls, two warmups and three ABBA cycles (six samples per variant), frozen baseline `7753ffb4753`:

| Workload | Before | After |
| --- | ---: | ---: |
| 128 rows of descriptions | 16.17ms | 13.28ms |
| 512 rows of descriptions | 58.77ms | 50.16ms |
| 128 rows with paths and descriptions | 23.00ms | 20.26ms |
| 128 rows with Unicode | 28.63ms | 23.90ms |

All 3,609 differential cases passed, covering drive/UNC/device homes, casing, Unicode expansion, punctuation, repeated paths and environment changes. Dense-backslash rows were neutral; short rows rose 0.041 ms. Shared-host ranges overlap for several cases. Measurements exclude startup, terminal paint and network activity.

All 140 existing table, display and skills formatter tests passed on Windows. The three child-process tests initially failed on the Windows import path; the URL repair preserves their fixtures, assertions and deadlines. Formatting, targeted type-aware lint, production types and all test type graphs pass. Independent review through P2 passed with no findings, including final source verification; an earlier attempt failed with a host MemoryError and is not counted as a pass.

Full local `check:changed` stopped on two untouched tooling exports previously reproduced on clean main: `canonicalProviderName` and `listPackagedStaticExtensionAssetOutputs`. Production export analysis and every remaining selected guard passed, including import cycles and state/sidecar checks. Required GitHub CI must pass before landing.
