### PR TITLE
refactor: reuse channel command test runtimes

### DIFF
--- a/src/commands/channels.resolve.test.ts
+++ b/src/commands/channels.resolve.test.ts
@@ -2,6 +2,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ChannelResolverAdapter } from "../channels/plugins/types.adapters.js";
 import { channelsResolveCommand } from "./channels/resolve.js";
+import { createTestRuntime } from "./test-runtime-config-helpers.js";
 
 const mocks = vi.hoisted(() => ({
   resolveCommandSecretRefsViaGateway: vi.fn(),
@@ -51,11 +52,7 @@ vi.mock("./channel-setup/channel-plugin-resolution.js", () => ({
 }));
 
 describe("channelsResolveCommand", () => {
-  const runtime = {
-    log: vi.fn(),
-    error: vi.fn(),
-    exit: vi.fn(),
-  };
+  const runtime = createTestRuntime();
 
   beforeEach(() => {
     vi.clearAllMocks();

--- a/src/commands/channels/dead-letters.test.ts
+++ b/src/commands/channels/dead-letters.test.ts
@@ -2,10 +2,10 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import { createChannelIngressQueue } from "../../channels/message/ingress-queue.js";
-import type { RuntimeEnv } from "../../runtime.js";
 import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
+import { createTestRuntime } from "../test-runtime-config-helpers.js";
 import {
   channelsDeadLettersListCommand,
   channelsDeadLettersResubmitCommand,
@@ -22,14 +22,6 @@ async function withTempState(run: (stateDir: string) => Promise<void>): Promise<
     closeOpenClawStateDatabaseForTest();
     await fs.rm(stateDir, { recursive: true, force: true });
   }
-}
-
-function createRuntime() {
-  return {
-    log: vi.fn(),
-    error: vi.fn(),
-    exit: vi.fn(),
-  } as unknown as RuntimeEnv;
 }
 
 describe("channel dead-letter commands", () => {
@@ -54,14 +46,14 @@ describe("channel dead-letter commands", () => {
         throw new Error("Expected a claimed ingress event");
       }
       await queue.fail(claim, { reason: "handler-error", failedAt: 20 });
-      const runtime = createRuntime();
+      const runtime = createTestRuntime();
 
       await channelsDeadLettersListCommand(
         { channel: "telegram", account: "ops", json: true },
         runtime,
       );
 
-      const output = JSON.parse(String(vi.mocked(runtime.log).mock.calls[0]?.[0])) as {
+      const output = JSON.parse(String(runtime.log.mock.calls[0]?.[0])) as {
         deadLetters: Array<{ id: string; payload?: unknown; reason: string }>;
       };
       expect(output.deadLetters).toEqual([
@@ -83,7 +75,7 @@ describe("channel dead-letter commands", () => {
         throw new Error("Expected a claimed ingress event");
       }
       await queue.fail(claim, { reason: "handler-error", failedAt: 20 });
-      const runtime = createRuntime();
+      const runtime = createTestRuntime();
 
       await channelsDeadLettersResubmitCommand("event-1", { channel: "line" }, runtime);
       const replay = await queue.claimNext({ ownerId: "replay-worker" });
@@ -109,7 +101,7 @@ describe("channel dead-letter commands", () => {
     ]),
   )("rejects a $label --account at the $command boundary", async ({ account, command }) => {
     await withTempState(async () => {
-      const runtime = createRuntime();
+      const runtime = createTestRuntime();
       const action =
         command === "list"
           ? channelsDeadLettersListCommand({ channel: "telegram", account, json: true }, runtime)
@@ -133,11 +125,11 @@ describe("channel dead-letter commands", () => {
         throw new Error("Expected a claimed ingress event");
       }
       await queue.fail(claim, { reason: "handler-error", failedAt: 20 });
-      const runtime = createRuntime();
+      const runtime = createTestRuntime();
 
       await channelsDeadLettersListCommand({ channel: "telegram", json: true }, runtime);
 
-      const output = JSON.parse(String(vi.mocked(runtime.log).mock.calls[0]?.[0])) as {
+      const output = JSON.parse(String(runtime.log.mock.calls[0]?.[0])) as {
         accountId: string;
         deadLetters: Array<{ id: string }>;
       };


### PR DESCRIPTION
## What Problem This Solves

Channel command tests duplicate runtime spies and hide one fixture behind a double cast.

## Why This Change Was Made

Reuse the existing typed `createTestRuntime` helper in resolve and dead-letter tests. Preserve every assertion, runtime lifetime, queue transition, and state/environment cleanup.

## User Impact

No production behavior changes. Production LOC is unchanged; test code is reduced by 11 lines.

## Evidence

Baseline and candidate each passed all 34 cases: 9 resolve, 7 dead-letter recovery, and 18 channel-list sibling cases. Per-file case identity, order, and results match; file scheduling order differs. Independent review found no actionable issues. All 20 normal changed-file checks passed on the exact tested tree.

The first backend-status read timed out; a separately authorized read confirmed completion. A portal-sync warning remains recorded. No gate rerun, live-channel, or performance claim.
