### PR TITLE
improve: reduce repeated transcript lookup work

### DIFF
--- a/src/config/sessions/session-cold-storage-state.ts
+++ b/src/config/sessions/session-cold-storage-state.ts
@@ -1,32 +1,68 @@
 import type { DatabaseSync } from "node:sqlite";
 import type { Selectable } from "kysely";
-import { executeSqliteQueryTakeFirstSync, getNodeSqliteKysely } from "../../infra/kysely-sync.js";
+import { getNodeSqliteKysely, prepareSqliteQuerySync } from "../../infra/kysely-sync.js";
 import type { DB } from "../../state/openclaw-agent-db.generated.js";
 
 export type SessionColdArchive = Selectable<DB["session_transcript_cold_archives"]>;
+
+function createColdTranscriptQueries(db: DatabaseSync) {
+  const kysely = getNodeSqliteKysely<DB>(db);
+  return {
+    metadata: prepareSqliteQuerySync<string, Omit<SessionColdArchive, "archive_blob">>(
+      db,
+      (parameter) =>
+        kysely
+          .selectFrom("session_transcript_cold_archives")
+          .select([
+            "session_id",
+            "generation",
+            "archive_name",
+            "archive_sha256",
+            "event_count",
+            "raw_bytes",
+            "archive_bytes",
+            "last_seq",
+            "archived_at",
+            "storage",
+          ])
+          .where(
+            "session_id",
+            "=",
+            parameter((sessionId) => sessionId),
+          ),
+    ),
+    marker: prepareSqliteQuerySync<string, { session_id: string }>(db, (parameter) =>
+      kysely
+        .selectFrom("session_transcript_cold_archives")
+        .select("session_id")
+        .where(
+          "session_id",
+          "=",
+          parameter((sessionId) => sessionId),
+        ),
+    ),
+  };
+}
+
+const coldTranscriptQueries = new WeakMap<
+  DatabaseSync,
+  ReturnType<typeof createColdTranscriptQueries>
+>();
+
+function getColdTranscriptQueries(db: DatabaseSync) {
+  let queries = coldTranscriptQueries.get(db);
+  if (!queries) {
+    queries = createColdTranscriptQueries(db);
+    coldTranscriptQueries.set(db, queries);
+  }
+  return queries;
+}
 
 export function readSessionColdTranscript(
   db: DatabaseSync,
   sessionId: string,
 ): Omit<SessionColdArchive, "archive_blob"> | undefined {
-  return executeSqliteQueryTakeFirstSync(
-    db,
-    getNodeSqliteKysely<DB>(db)
-      .selectFrom("session_transcript_cold_archives")
-      .select([
-        "session_id",
-        "generation",
-        "archive_name",
-        "archive_sha256",
-        "event_count",
-        "raw_bytes",
-        "archive_bytes",
-        "last_seq",
-        "archived_at",
-        "storage",
-      ])
-      .where("session_id", "=", sessionId),
-  );
+  return getColdTranscriptQueries(db).metadata(sessionId).rows[0];
 }
 
 export class SessionTranscriptColdError extends Error {
@@ -40,15 +76,7 @@ export class SessionTranscriptColdError extends Error {
 }
 
 export function assertSessionTranscriptHot(db: DatabaseSync, sessionId: string): void {
-  if (
-    executeSqliteQueryTakeFirstSync(
-      db,
-      getNodeSqliteKysely<DB>(db)
-        .selectFrom("session_transcript_cold_archives")
-        .select("session_id")
-        .where("session_id", "=", sessionId),
-    )
-  ) {
+  if (getColdTranscriptQueries(db).marker(sessionId).rows.length > 0) {
     throw new SessionTranscriptColdError(sessionId);
   }
 }

--- a/src/config/sessions/session-transcript-index.ts
+++ b/src/config/sessions/session-transcript-index.ts
@@ -563,15 +563,9 @@ export function reconcileSessionTranscriptIndexInTransaction(
   return true;
 }
 
-/**
- * Sessions whose index needs reconcile work: flagged rebuilds, transcripts
- * that gained rows without index state (doctor imports), and watermarks
- * behind the newest row. Ordered for deterministic reconcile passes.
- */
-export function listSessionsNeedingTranscriptIndexReconcile(db: DatabaseSync): string[] {
+function selectSessionsNeedingTranscriptIndexReconcile(db: DatabaseSync) {
   const kysely = getIndexKysely(db);
-  const rows = executeSqliteQuerySync(
-    db,
+  return (
     kysely
       .selectFrom("session_windows")
       .innerJoin("transcript_events as latest", (join) =>
@@ -609,10 +603,29 @@ export function listSessionsNeedingTranscriptIndexReconcile(db: DatabaseSync): s
           ),
         ]),
       )
-      // The transcript PK makes the correlated latest-row lookup one index seek per session.
-      // Grouping transcript_events here made every healthy search rescan the entire history.
-      .orderBy("session_windows.session_id"),
-  ).rows;
+      // Ordering keeps the session-window scan and one latest-row index seek per session.
+      // Without it, SQLite can scan every transcript row even for an existence check.
+      .orderBy("session_windows.session_id")
+  );
+}
+
+/** Search needs only one pending session; the reconcile owner selects its complete work list. */
+export function hasSessionsNeedingTranscriptIndexReconcile(db: DatabaseSync): boolean {
+  return (
+    executeSqliteQueryTakeFirstSync(
+      db,
+      selectSessionsNeedingTranscriptIndexReconcile(db).limit(1),
+    ) !== undefined
+  );
+}
+
+/**
+ * Sessions whose index needs reconcile work: flagged rebuilds, transcripts
+ * that gained rows without index state (doctor imports), and watermarks
+ * behind the newest row. Ordered for deterministic reconcile passes.
+ */
+export function listSessionsNeedingTranscriptIndexReconcile(db: DatabaseSync): string[] {
+  const rows = executeSqliteQuerySync(db, selectSessionsNeedingTranscriptIndexReconcile(db)).rows;
   return rows.flatMap((row) => (typeof row.session_id === "string" ? [row.session_id] : []));
 }
 

--- a/src/config/sessions/session-transcript-search.test.ts
+++ b/src/config/sessions/session-transcript-search.test.ts
@@ -418,6 +418,7 @@ describe("searchSessionTranscripts", () => {
     const pending = () => listSessionsNeedingTranscriptIndexReconcile(db);
 
     expect(pending()).toEqual([]);
+    expect(search("indexed").indexing).toBe(false);
 
     executeSqliteQuerySync(
       db,
@@ -427,6 +428,8 @@ describe("searchSessionTranscripts", () => {
         .where("session_id", "=", "session-1"),
     );
     expect(pending()).toEqual(["session-1"]);
+    expect(search("indexed").indexing).toBe(true);
+    await waitForSearchReconcile("indexed");
 
     executeSqliteQuerySync(
       db,
@@ -436,12 +439,15 @@ describe("searchSessionTranscripts", () => {
         .where("session_id", "=", "session-1"),
     );
     expect(pending()).toEqual(["session-1"]);
+    expect(search("indexed").indexing).toBe(true);
+    await waitForSearchReconcile("indexed");
 
     executeSqliteQuerySync(
       db,
       kysely.deleteFrom("session_transcript_index_state").where("session_id", "=", "session-1"),
     );
     expect(pending()).toEqual(["session-1"]);
+    expect(search("indexed").indexing).toBe(true);
   });
 
   it("sweeps orphaned index rows during reconcile", async () => {

--- a/src/config/sessions/session-transcript-search.ts
+++ b/src/config/sessions/session-transcript-search.ts
@@ -10,7 +10,7 @@ import { withOpenClawAgentDatabaseReadOnly } from "../../state/openclaw-agent-db
 import type { DB } from "../../state/openclaw-agent-db.generated.js";
 import { truncateUtf16Safe } from "../../utils.js";
 import { resolveSqliteReadScope, toDatabaseOptions } from "./session-accessor.sqlite-scope.js";
-import { listSessionsNeedingTranscriptIndexReconcile } from "./session-transcript-index.js";
+import { hasSessionsNeedingTranscriptIndexReconcile } from "./session-transcript-index.js";
 import {
   isSessionTranscriptIndexReconcileRunning,
   startSessionTranscriptIndexReconcile,
@@ -68,12 +68,12 @@ export function searchSessionTranscripts(params: {
       runSqliteDeferredTransactionSync(
         database.db,
         () => {
-          const dirtySessions = listSessionsNeedingTranscriptIndexReconcile(database.db);
-          if (dirtySessions.length > 0) {
+          const hasDirtySessions = hasSessionsNeedingTranscriptIndexReconcile(database.db);
+          if (hasDirtySessions) {
             startSessionTranscriptIndexReconcile(databaseOptions);
           }
           const indexing =
-            dirtySessions.length > 0 || isSessionTranscriptIndexReconcileRunning(databaseOptions);
+            hasDirtySessions || isSessionTranscriptIndexReconcileRunning(databaseOptions);
           const limit = Math.min(Math.max(1, params.limit ?? 10), SEARCH_LIMIT_MAX);
           // Shared databases hold multiple logical agents. Filter before LIMIT;
           // reserved global/unknown sentinels retain their store-wide scope.


### PR DESCRIPTION
Closes #146313
Related: #146281

## What Problem This Solves

Transcript search spends time collecting every session awaiting indexing even though the request only needs to report whether indexing is pending. Repeated history and statistics reads also rebuild the same cold-state queries, adding overhead as session inventories grow.

## Why This Change Was Made

Search and reconciliation share the existing ordered readiness query. Search stops after one matching session; reconciliation keeps its complete ordered list. Cold metadata and hot-marker queries compile once per database connection and bind the current session ID on every execution through the existing SQLite executor.

This retains the original index plan, per-operation transactions, current-state checks, and archive/restore behavior. No schema, retention, dependency, or durability setting changes.

## User Impact

Lower overhead for transcript search while many sessions need indexing, and for repeated transcript statistics and bounded history reads. Results, cold-read errors, and indexing behavior remain the same. Benefits vary by workload; some small and late-dirty fixtures were slower.

## Evidence

Pre-landing public-entry synthetic comparisons on Windows x64, Node 26.8.2 / SQLite 3.53.4, with seven alternating timing blocks and the same current infrastructure in both arms:

| Fixture | Before | After |
| --- | ---: | ---: |
| Search, 1,000 dirty sessions | 2.569 ms | 0.863 ms |
| Search, 1,000 healthy sessions | 1.533 ms | 1.451 ms |
| 1,000 individual hot-session statistics reads | 380.03 ms | 317.34 ms |
| 1,000 read-only batch statistics reads | 256.47 ms | 235.29 ms |
| 1,000 bounded tail reads | 274.53 ms | 256.12 ms |

Counterexamples are retained: one healthy-session search measured 0.506 to 0.551 ms; late-dirty search over 1,000 sessions with 100 events each measured 5.426 to 6.055 ms; the 100-session long-history tail measured 23.305 to 23.473 ms. These are descriptive synthetic timings, not whole-Gateway throughput or Node-upgrade gains.

Public results matched, including cold refusal identity, missing/duplicate statistics scopes, and indexing flags. Database schema, rows, persisted-file fingerprints, and integrity were unchanged during timed read intervals. Search used real reconciliation scheduling and drained its workers outside timing. An initial unordered query changed SQLite's join plan and was discarded; final code retains the original ordered window scan and indexed latest-row seek.

All 110 selected tests passed across seven files: search, archive/restore, synchronous cold-write refusal, cold lifecycle, archive races, watermark isolation, and the shared SQLite executor. The Gateway archive race passed in 8.793 seconds and the cross-store snapshot race in 6.347 seconds.

Independent P0–P2 review found no actionable issues. Core production types, the state-logging test type graph, scoped type-aware lint, formatting, diff checks, and native schema guard passed. The existing watermark test now checks public search indexing after separate missing, dirty, and lagging state changes, draining reconciliation between cases so a prior worker cannot mask a failure.

## Review disposition and CI repair

The maintainer landing decision accepts this bounded read-path tradeoff: repeated-reader savings and the reduction from 2.569 to 0.863 ms with 1,000 dirty sessions justify the patch while the measured small/late-dirty regressions remain visible above. The largest reported counterexample adds about 0.63 ms to a 5.43 ms late-dirty search. This is not evidence of a universal or whole-Gateway speedup. Existing transaction, authority, statement-lifecycle, and reconciliation owners are preserved. ClawSweeper found no source correctness or security defect; its throughput caveat is retained as a limitation of the claim, not an unresolved implementation defect.

The first hosted run also exposed a baseline QA metadata failure introduced by #146207: a UI test was renamed without updating its scenario selector. The scenario now names the executable diagnostics test and accurately describes its scoped `models.list` request. The original selector failure reproduced on baseline main; the complete native scenario-runner now passes 19 tests with one existing Windows symlink skip. No test assertion or baseline was weakened. This repair is separate from the SQLite timing results.

## Final integrated-main remeasurement

Merged and remeasured at b64cfc4c133551a565c29195991c148492494da3, using Node 26.8.2 / SQLite 3.53.4 on Windows x64. Both arms use the same integrated infrastructure; seven alternating timing blocks retain complete result/error checks and storage fingerprint invariance.

| Fixture | Before | After |
| --- | ---: | ---: |
| Search, 1,000 dirty sessions | 2.433 ms | 1.127 ms |
| 1,000 individual hot-session statistics reads | 249.302 ms | 223.728 ms |
| 1,000 read-only batch statistics reads | 186.742 ms | 178.941 ms |
| 1,000 bounded tail reads | 212.911 ms | 212.305 ms |
| Long-history batch statistics, 100 sessions | 43.839 ms | 46.435 ms |
| Search, 100 sessions with only the last dirty | 0.810 ms | 0.976 ms |
| Search, 1,000 sessions × 100 events with only the last dirty | 4.831 ms | 5.266 ms |

The large dirty-inventory search improves 53.7%; repeated individual hot statistics improve 10.3%. Tails are essentially unchanged. Small/healthy/late-dirty searches include regressions, as does the long-history batch statistics route. The bounded workload tradeoff remains accepted; these numbers do not establish a universal or whole-Gateway speedup.

All 27 fixture/route comparisons completed with matching public results and unchanged schema, typed rows, and persisted files during read intervals. Real reconciliation workers drained outside timing. Final integrated-main validation passed all 16 search tests and four selected archive-race tests; fourteen unrelated cold-read cases were excluded by the name filter. The Gateway restoration race passed in 3.429 seconds and the cross-store snapshot race in 2.483 seconds. Three canonical synthetic databases passed integrity checks with zero WAL bytes after checkpoint.

Before landing, 129 local cases passed across the SQLite/session and QA runs, with one existing Windows QA skip. Exact-head CI run 34712978242 completed successfully, and fresh independent/ClawSweeper reviews had no remaining findings. Native merge recovery completed after a concurrent main update rejected the initial merge request; the final receipt and owned cleanup are complete.