### PR TITLE
improve: avoid repeated source loading in repair tests

### DIFF
--- a/src/infra/update-managed-service-handoff-lifecycle.test-support.ts
+++ b/src/infra/update-managed-service-handoff-lifecycle.test-support.ts
@@ -65,6 +65,7 @@ export type ManagedServiceCommandTiming = {
 export type ManagedServiceManagerBoundaryResult = {
   helperExitCode?: number | null;
   repairEffects?: {
+    packagedReadOnly: boolean;
     firstSpawn: boolean;
     secondSpawn: boolean;
     firstExec: boolean;

--- a/src/infra/update-managed-service-handoff-lifecycle.test.ts
+++ b/src/infra/update-managed-service-handoff-lifecycle.test.ts
@@ -485,6 +485,7 @@ describe("managed service update handoff", () => {
       expect(commands).toEqual([]);
       expect(parentSignal).toBeNull();
       expect(repairEffects, log).toEqual({
+        packagedReadOnly: true,
         firstSpawn: true,
         secondSpawn: !revoke,
         firstExec: true,

--- a/src/infra/update-managed-service-handoff-repair.test-support.ts
+++ b/src/infra/update-managed-service-handoff-repair.test-support.ts
@@ -10,7 +10,10 @@ import {
 } from "../../test/helpers/openai-responses-sse.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { withServer } from "../plugin-sdk/test-helpers/http-test-server.js";
-import { runtimeProcessEntrypoints } from "./runtime-process-entrypoints.js";
+import {
+  runtimeProcessEntrypoints,
+  SQLITE_READONLY_CHILD_ARG,
+} from "./runtime-process-entrypoints.js";
 import { resolveRuntimeWorkerArgv } from "./runtime-worker-url.js";
 import type {
   ManagedRepairBoundary,
@@ -19,6 +22,7 @@ import type {
 
 export function readManagedRepairEffects(root: string) {
   return {
+    packagedReadOnly: existsSync(path.join(root, "repair-readonly-packaged")),
     firstSpawn: existsSync(path.join(root, "repair-spawn-first")),
     secondSpawn: existsSync(path.join(root, "repair-spawn-second")),
     firstExec: existsSync(path.join(root, "candidate", "repair-first-exec.txt")),
@@ -87,9 +91,30 @@ function managedRepairSpawnPreload(root: string): string {
   const snapshotWorkerArgs = resolveRuntimeWorkerArgv(
     new URL("./update-candidate-state.worker.ts", import.meta.url),
   );
+  const readOnlyWorkerArgs = resolveRuntimeWorkerArgv(
+    new URL(`./${runtimeProcessEntrypoints.sqliteReadOnly.sourceWorkerName}.ts`, import.meta.url),
+  );
   return `const fs = require("node:fs");
     const childProcess = require("node:child_process");
     const spawn = childProcess.spawn;
+    const spawnSync = childProcess.spawnSync;
+    const readOnlyWorkerArgs = ${JSON.stringify(readOnlyWorkerArgs)};
+    childProcess.spawnSync = function(command, args, options) {
+      // Keep each fresh, source-neutral snapshot; only replace its TS loader with this build's worker.
+      if (command !== process.execPath || !Array.isArray(args) ||
+          args.length !== readOnlyWorkerArgs.length + 4 ||
+          !readOnlyWorkerArgs.every((arg, index) => args[index] === arg) ||
+          args[readOnlyWorkerArgs.length] !== ${JSON.stringify(SQLITE_READONLY_CHILD_ARG)} ||
+          args[readOnlyWorkerArgs.length + 1] !== "sync") {
+        return spawnSync.apply(this, arguments);
+      }
+      const result = spawnSync.call(this, command,
+        [${JSON.stringify(path.resolve("dist", runtimeProcessEntrypoints.sqliteReadOnly.distWorkerPath))}, ...args.slice(readOnlyWorkerArgs.length)], options);
+      if (result.status === 0 && result.pid > 0) {
+        fs.writeFileSync(${JSON.stringify(path.join(root, "repair-readonly-packaged"))}, String(result.pid));
+      }
+      return result;
+    };
     const snapshotWorkerArgs = ${JSON.stringify(snapshotWorkerArgs)};
     childProcess.spawn = function(command, args, options) {
       // Rehearsal strips NODE_OPTIONS; carry the recorder only to its owned repair and supervisor workers.


### PR DESCRIPTION
## What Problem This Solves

Managed-service repair tests repeatedly load TypeScript for fresh read-only SQLite snapshot children even though their fixture already builds the packaged workers. In a retained attribution probe, 18 such source-worker operations occupied 19.282 seconds of six callback-to-event intervals totaling 21.384 seconds. Those are whole child-operation measurements, not isolated import timings.

## Why This Change Was Made

Extend the fixture's existing packaged-worker route to the synchronous read-only worker. Match the canonical source argv prefix, Node executable, operation marker, sync mode and argument count, then replace only the loader prefix with the current build's worker. Every snapshot still runs in a fresh process with identical database/staging arguments, options and result handling. All four existing requester-authority scenarios require a receipt from a successful real packaged child.

## User Impact

No application behavior changes. This removes unnecessary source loading from the repair test fixture while retaining fresh authority reads, snapshot isolation, revocation checks and existing deadlines. Runtime production delta is zero; test/support delta is +28/-1. No shard, runner, cache, schema or compiler-root change.

## Evidence

The four targeted cases passed, followed by all 177 lifecycle cases in their original order without skips. Both used the normal native wrapper and current-source runtime build on Node 24.20.0. Packaged worker and generation identities were verified; observed child processes had exited and generation directories were removed after each run. Canonical changed type, structural, export, format and lint gates passed. Independent P2 review returned no actionable findings.

The focused run took 100.55 seconds in Vitest; the full run took 606.65 seconds. Earlier instrumented probes are not matched controls, so no isolated speedup or eight-minute CI claim is made. CI on this PR will provide the relevant shared-runner measurement. Existing assertions cover the exact child result and authority behavior; the new receipt also fails on the original fixture, which never routes this operation through the packaged worker.

Final exact-head CI [34712523589](https://github.com/openclaw/openclaw/actions/runs/34712523589) passed at a5f74a89461da30673363dbb1525cdba8e162422. The Linux changed-test job took 344 seconds assigned on two logical CPUs / 8,220,487,680 bytes; all 177 lifecycle cases passed in 219.51 seconds of Vitest, and the four repair cases took 20.102/12.262/10.596/9.632 seconds. Both Windows jobs passed (617 and 700 seconds assigned). These are observed candidate times, not matched baseline deltas. ClawSweeper's exact-head review found no actionable defects or before-merge moves.
