### PR TITLE
fix(qa): restore Control UI diagnostics scenario execution

### DIFF
--- a/qa/scenarios/ui/control-ui-health-status-models.yaml
+++ b/qa/scenarios/ui/control-ui-health-status-models.yaml
@@ -25,7 +25,7 @@ scenario:
   execution:
     kind: playwright
     path: ui/src/e2e/debug-diagnostics.e2e.test.ts
-    testNamePattern: renders status, health, heartbeat, and model snapshots from the Gateway
+    testNamePattern: renders Gateway diagnostics and current work independently of session history
     summary: >-
       Real Chromium coverage for the Debug page diagnostic RPC requests and
       their visible operator snapshots.


### PR DESCRIPTION
Related: #146207, #146271

## What Problem This Solves

Resolves a problem where the Control UI diagnostics QA scenario selects no executable test after the diagnostics test was expanded and renamed in #146207. The scenario registry check fails on main-derived CI, including the merge commit for #146271. This is a maintainer-requested repair of that execution mapping.

## Why This Change Was Made

Update the scenario's test-name selector to the current diagnostics test title. The existing UI assertions, registry assertion, scenario coverage IDs, and runner behavior stay intact.

## User Impact

QA operators can select the existing diagnostics browser flow again. There is no product UI behavior change.

## Evidence

- Before/after selector proof parses the YAML and applies the actual registry assertion's test-name extraction and regular-expression semantics: the old selector matches zero executable tests, while the repaired selector matches exactly the intended existing test.
- All 18 on-disk Playwright scenario patterns match executable test names using those unchanged assertion semantics. This is lightweight selector parity, not a Vitest or browser execution claim.
- Parsed YAML differs only in the selector; the complete UI test and native runner/assertion files are unchanged.
- Installed `oxfmt --check` and `git diff --check` pass.
- Fresh independent P2 review is clean with final source verification.
- [Exact-head CI 34712744098](https://github.com/openclaw/openclaw/actions/runs/34712744098) completed successfully for `b08f9eacf6d7373244ff0532023e360be67cac2b`, including the originally failing extension-config shard, production/test types, lint, build artifacts, and QA Smoke.
- The isolated author checkout has no installed dependencies; the native changed-check dry run reported that dependency gap. Hosted CI supplies executable registry/check validation. Browser execution was not repeated locally because UI behavior and assertions are unchanged.

Original failure: [CI job 103602263430](https://github.com/openclaw/openclaw/actions/runs/34711928486/job/103602263430), on merge commit `19202d8b824d414f80e8f0159a16e804788bff25`.
