### PR TITLE
fix(mcp): report a missing stdio launcher command instead of a generic transport close

### DIFF
--- a/src/agents/agent-bundle-mcp-runtime.test.ts
+++ b/src/agents/agent-bundle-mcp-runtime.test.ts
@@ -1584,7 +1584,10 @@ describe("session MCP runtime", () => {
       expect(catalog.servers).toEqual({});
       expect(catalog.tools).toEqual([]);
       expect(catalog.diagnostics?.[0]?.serverName).toBe("missingbinary");
-      expect(catalog.diagnostics?.[0]?.message).toBe(
+      // The formatted message also carries the original connect failure via
+      // its cause chain (redactMcpDiagnosticError -> formatErrorMessage), so
+      // assert the actionable prefix rather than the exact full string.
+      expect(catalog.diagnostics?.[0]?.message).toContain(
         `stdio command not found or not executable: ${missingCommand} — is it installed and on PATH?`,
       );
     } finally {
@@ -2038,7 +2041,11 @@ describe("session MCP runtime", () => {
         await fs.rm(wrapperPath, { force: true });
 
         await fs.writeFile(notificationReleasePath, "release", "utf8");
-        await waitForFileText(logPath, "notify tools/list_changed", LIST_TOOLS_SERVER_LOG_TIMEOUT_MS);
+        await waitForFileText(
+          logPath,
+          "notify tools/list_changed",
+          LIST_TOOLS_SERVER_LOG_TIMEOUT_MS,
+        );
         await waitForPredicate(
           () => runtime.peekCatalog() === null,
           "list_changed to invalidate the catalog",

--- a/src/agents/agent-bundle-mcp-runtime.test.ts
+++ b/src/agents/agent-bundle-mcp-runtime.test.ts
@@ -1563,6 +1563,35 @@ describe("session MCP runtime", () => {
     }
   });
 
+  it("reports a missing stdio launcher command instead of a generic transport close", async () => {
+    const missingCommand = `openclaw-test-missing-command-${randomUUID()}`;
+    const runtime = await getOrCreateSessionMcpRuntime({
+      sessionId: "session-missing-command",
+      sessionKey: "agent:test:session-missing-command",
+      workspaceDir: "/workspace",
+      cfg: {
+        mcp: {
+          servers: {
+            missingbinary: { command: missingCommand, args: [] },
+          },
+        },
+      },
+    });
+
+    try {
+      const catalog = await runtime.getCatalog();
+
+      expect(catalog.servers).toEqual({});
+      expect(catalog.tools).toEqual([]);
+      expect(catalog.diagnostics?.[0]?.serverName).toBe("missingbinary");
+      expect(catalog.diagnostics?.[0]?.message).toBe(
+        `stdio command not found or not executable: ${missingCommand} — is it installed and on PATH?`,
+      );
+    } finally {
+      await runtime.dispose();
+    }
+  });
+
   it("redacts credentials from MCP catalog diagnostics", async () => {
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "bundle-mcp-diagnostic-redaction-"));
     const serverPath = path.join(tempDir, "diagnostic-redaction.mjs");

--- a/src/agents/agent-bundle-mcp-runtime.test.ts
+++ b/src/agents/agent-bundle-mcp-runtime.test.ts
@@ -1563,34 +1563,39 @@ describe("session MCP runtime", () => {
     }
   });
 
-  it("reports a missing stdio launcher command instead of a generic transport close", async () => {
-    const missingCommand = `openclaw-test-missing-command-${randomUUID()}`;
-    const runtime = await getOrCreateSessionMcpRuntime({
-      sessionId: "session-missing-command",
-      sessionKey: "agent:test:session-missing-command",
-      workspaceDir: "/workspace",
-      cfg: {
-        mcp: {
-          servers: {
-            missingbinary: { command: missingCommand, args: [] },
+  // The runtime gate only runs on non-Windows platforms (see
+  // agent-bundle-mcp-runtime.ts), so this assertion does not hold there.
+  it.skipIf(process.platform === "win32")(
+    "reports a missing stdio launcher command instead of a generic transport close",
+    async () => {
+      const missingCommand = `openclaw-test-missing-command-${randomUUID()}`;
+      const runtime = await getOrCreateSessionMcpRuntime({
+        sessionId: "session-missing-command",
+        sessionKey: "agent:test:session-missing-command",
+        workspaceDir: "/workspace",
+        cfg: {
+          mcp: {
+            servers: {
+              missingbinary: { command: missingCommand, args: [] },
+            },
           },
         },
-      },
-    });
+      });
 
-    try {
-      const catalog = await runtime.getCatalog();
+      try {
+        const catalog = await runtime.getCatalog();
 
-      expect(catalog.servers).toEqual({});
-      expect(catalog.tools).toEqual([]);
-      expect(catalog.diagnostics?.[0]?.serverName).toBe("missingbinary");
-      expect(catalog.diagnostics?.[0]?.message).toBe(
-        `stdio command not found or not executable: ${missingCommand} — is it installed and on PATH?`,
-      );
-    } finally {
-      await runtime.dispose();
-    }
-  });
+        expect(catalog.servers).toEqual({});
+        expect(catalog.tools).toEqual([]);
+        expect(catalog.diagnostics?.[0]?.serverName).toBe("missingbinary");
+        expect(catalog.diagnostics?.[0]?.message).toBe(
+          `stdio command not found or not executable: ${missingCommand} — is it installed and on PATH?`,
+        );
+      } finally {
+        await runtime.dispose();
+      }
+    },
+  );
 
   it("redacts credentials from MCP catalog diagnostics", async () => {
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "bundle-mcp-diagnostic-redaction-"));

--- a/src/agents/agent-bundle-mcp-runtime.test.ts
+++ b/src/agents/agent-bundle-mcp-runtime.test.ts
@@ -1992,6 +1992,69 @@ describe("session MCP runtime", () => {
     }
   });
 
+  // The launcher command missing on disk must only block a *new* connection.
+  // An already-connected session refreshing its catalog (e.g. after
+  // notifications/tools/list_changed) must not be rejected just because its
+  // launcher was since removed, renamed, or made temporarily unavailable
+  // (such as during an update) — the running process needs no new spawn.
+  it.skipIf(process.platform === "win32")(
+    "keeps refreshing an already-connected session after its launcher command disappears from disk",
+    async () => {
+      const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "bundle-mcp-launcher-removed-"));
+      const serverPath = path.join(tempDir, "server.mjs");
+      const logPath = path.join(tempDir, "server.log");
+      const notificationReleasePath = path.join(tempDir, "notify.release");
+      const wrapperPath = path.join(tempDir, "launcher-wrapper.sh");
+      await writeListToolsMcpServer({
+        filePath: serverPath,
+        logPath,
+        capabilities: { tools: { listChanged: true } },
+        toolsByList: [
+          [{ name: "ok_tool", inputSchema: { type: "object", properties: {} } }],
+          [{ name: "ok_tool", inputSchema: { type: "object", properties: {} } }],
+        ],
+        notifyListChangedAfterFirstList: true,
+        notifyListChangedReleasePath: notificationReleasePath,
+      });
+      await fs.writeFile(
+        wrapperPath,
+        `#!/bin/sh\nexec ${JSON.stringify(process.execPath)} ${JSON.stringify(serverPath)}\n`,
+      );
+      await fs.chmod(wrapperPath, 0o755);
+
+      const runtime = await getOrCreateSessionMcpRuntime({
+        sessionId: "session-launcher-removed",
+        sessionKey: "agent:test:session-launcher-removed",
+        workspaceDir: "/workspace",
+        cfg: { mcp: { servers: { volatile: { command: wrapperPath, args: [] } } } },
+      });
+
+      try {
+        const firstCatalog = await runtime.getCatalog();
+        expect(firstCatalog.tools.map((tool) => tool.toolName)).toEqual(["ok_tool"]);
+
+        // The already-running child process keeps running; only the launcher
+        // path on disk is gone, matching an uninstalled/updated package.
+        await fs.rm(wrapperPath, { force: true });
+
+        await fs.writeFile(notificationReleasePath, "release", "utf8");
+        await waitForFileText(logPath, "notify tools/list_changed", LIST_TOOLS_SERVER_LOG_TIMEOUT_MS);
+        await waitForPredicate(
+          () => runtime.peekCatalog() === null,
+          "list_changed to invalidate the catalog",
+          LIST_TOOLS_SERVER_LOG_TIMEOUT_MS,
+        );
+
+        const refreshedCatalog = await runtime.getCatalog();
+        expect(refreshedCatalog.diagnostics).toBeUndefined();
+        expect(refreshedCatalog.tools.map((tool) => tool.toolName)).toEqual(["ok_tool"]);
+      } finally {
+        await runtime.dispose();
+        await fs.rm(tempDir, { recursive: true, force: true });
+      }
+    },
+  );
+
   it("reconnects after an MCP child process exits", async () => {
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "bundle-mcp-child-exit-"));
     const serverPath = path.join(tempDir, "server.mjs");

--- a/src/agents/agent-bundle-mcp-runtime.test.ts
+++ b/src/agents/agent-bundle-mcp-runtime.test.ts
@@ -1563,39 +1563,34 @@ describe("session MCP runtime", () => {
     }
   });
 
-  // The runtime gate only runs on non-Windows platforms (see
-  // agent-bundle-mcp-runtime.ts), so this assertion does not hold there.
-  it.skipIf(process.platform === "win32")(
-    "reports a missing stdio launcher command instead of a generic transport close",
-    async () => {
-      const missingCommand = `openclaw-test-missing-command-${randomUUID()}`;
-      const runtime = await getOrCreateSessionMcpRuntime({
-        sessionId: "session-missing-command",
-        sessionKey: "agent:test:session-missing-command",
-        workspaceDir: "/workspace",
-        cfg: {
-          mcp: {
-            servers: {
-              missingbinary: { command: missingCommand, args: [] },
-            },
+  it("reports a missing stdio launcher command instead of a generic transport close", async () => {
+    const missingCommand = `openclaw-test-missing-command-${randomUUID()}`;
+    const runtime = await getOrCreateSessionMcpRuntime({
+      sessionId: "session-missing-command",
+      sessionKey: "agent:test:session-missing-command",
+      workspaceDir: "/workspace",
+      cfg: {
+        mcp: {
+          servers: {
+            missingbinary: { command: missingCommand, args: [] },
           },
         },
-      });
+      },
+    });
 
-      try {
-        const catalog = await runtime.getCatalog();
+    try {
+      const catalog = await runtime.getCatalog();
 
-        expect(catalog.servers).toEqual({});
-        expect(catalog.tools).toEqual([]);
-        expect(catalog.diagnostics?.[0]?.serverName).toBe("missingbinary");
-        expect(catalog.diagnostics?.[0]?.message).toBe(
-          `stdio command not found or not executable: ${missingCommand} — is it installed and on PATH?`,
-        );
-      } finally {
-        await runtime.dispose();
-      }
-    },
-  );
+      expect(catalog.servers).toEqual({});
+      expect(catalog.tools).toEqual([]);
+      expect(catalog.diagnostics?.[0]?.serverName).toBe("missingbinary");
+      expect(catalog.diagnostics?.[0]?.message).toBe(
+        `stdio command not found or not executable: ${missingCommand} — is it installed and on PATH?`,
+      );
+    } finally {
+      await runtime.dispose();
+    }
+  });
 
   it("redacts credentials from MCP catalog diagnostics", async () => {
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "bundle-mcp-diagnostic-redaction-"));

--- a/src/agents/agent-bundle-mcp-runtime.ts
+++ b/src/agents/agent-bundle-mcp-runtime.ts
@@ -824,6 +824,14 @@ function createServerMcpRuntime(
         if (
           !reusedSession &&
           resolved.stdioLaunch &&
+          // Windows' own CreateProcess does an implicit current-directory
+          // search plus PATHEXT/shim/node-entrypoint resolution that this
+          // best-effort checker cannot fully replicate (see the shared
+          // production resolver in plugin-sdk/windows-spawn.ts). A false
+          // negative here would block a working server, which is worse than
+          // the generic error this diagnostic is meant to improve on, so
+          // this gate only runs where the check's fidelity is solid.
+          process.platform !== "win32" &&
           !(await stdioCommandExists(
             resolved.stdioLaunch.command,
             resolved.stdioLaunch.cwd,

--- a/src/agents/agent-bundle-mcp-runtime.ts
+++ b/src/agents/agent-bundle-mcp-runtime.ts
@@ -821,35 +821,33 @@ function createServerMcpRuntime(
 
       try {
         failIfDisposed();
-        if (
-          !reusedSession &&
-          resolved.stdioLaunch &&
-          // Windows' own CreateProcess does an implicit current-directory
-          // search plus PATHEXT/shim/node-entrypoint resolution that this
-          // best-effort checker cannot fully replicate (see the shared
-          // production resolver in plugin-sdk/windows-spawn.ts). A false
-          // negative here would block a working server, which is worse than
-          // the generic error this diagnostic is meant to improve on, so
-          // this gate only runs where the check's fidelity is solid.
-          process.platform !== "win32" &&
-          !(await stdioCommandExists(
-            resolved.stdioLaunch.command,
-            resolved.stdioLaunch.cwd,
-            resolved.stdioLaunch.env,
-          ))
-        ) {
+        try {
+          await ensureSessionConnected(session, resolved.connectionTimeoutMs);
+        } catch (connectError) {
           // A missing launcher binary (e.g. `uvx` never installed) otherwise
-          // surfaces only as a generic transport "Connection closed" error
-          // once the spawn fails, with no hint at the actual cause. Only
-          // matters when actually about to spawn: an already-connected
-          // session must keep refreshing its catalog even if its launcher
-          // has since become unavailable on disk.
-          throw new Error(
-            `stdio command not found or not executable: ${resolved.stdioLaunch.command} — is it installed and on PATH?`,
-          );
+          // surfaces only as a generic transport "Connection closed" error,
+          // with no hint at the actual cause. This best-effort check cannot
+          // fully replicate every platform's real launch semantics (PATHEXT,
+          // wrapper/shim resolution, symlink traversal, Windows' implicit
+          // current-directory search), so it only ever enriches a connection
+          // that has already failed for some other reason, never vetoes an
+          // attempt before it happens — a false negative here can only
+          // affect the wording of an error a working server never reaches.
+          if (
+            resolved.stdioLaunch &&
+            !(await stdioCommandExists(
+              resolved.stdioLaunch.command,
+              resolved.stdioLaunch.cwd,
+              resolved.stdioLaunch.env,
+            ))
+          ) {
+            throw new Error(
+              `stdio command not found or not executable: ${resolved.stdioLaunch.command} — is it installed and on PATH?`,
+              { cause: connectError },
+            );
+          }
+          throw connectError;
         }
-        failIfDisposed();
-        await ensureSessionConnected(session, resolved.connectionTimeoutMs);
         failIfDisposed();
         const capabilities = summarizeServerCapabilities(session.client.getServerCapabilities());
         let listedTools: Tool[];

--- a/src/agents/agent-bundle-mcp-runtime.ts
+++ b/src/agents/agent-bundle-mcp-runtime.ts
@@ -822,6 +822,7 @@ function createServerMcpRuntime(
       try {
         failIfDisposed();
         if (
+          !reusedSession &&
           resolved.stdioLaunch &&
           !(await stdioCommandExists(
             resolved.stdioLaunch.command,
@@ -831,7 +832,10 @@ function createServerMcpRuntime(
         ) {
           // A missing launcher binary (e.g. `uvx` never installed) otherwise
           // surfaces only as a generic transport "Connection closed" error
-          // once the spawn fails, with no hint at the actual cause.
+          // once the spawn fails, with no hint at the actual cause. Only
+          // matters when actually about to spawn: an already-connected
+          // session must keep refreshing its catalog even if its launcher
+          // has since become unavailable on disk.
           throw new Error(
             `stdio command not found or not executable: ${resolved.stdioLaunch.command} — is it installed and on PATH?`,
           );

--- a/src/agents/agent-bundle-mcp-runtime.ts
+++ b/src/agents/agent-bundle-mcp-runtime.ts
@@ -54,6 +54,7 @@ import { redactMcpDiagnosticError } from "./mcp-error.js";
 import { createMcpJsonSchemaValidator } from "./mcp-json-schema-validator.js";
 import { sanitizeMcpMetadataText } from "./mcp-metadata.js";
 import { collectMcpPaginatedItems } from "./mcp-pagination.js";
+import { stdioCommandExists } from "./mcp-stdio-command-check.js";
 import { isMcpToolAllowed, normalizeMcpToolFilter } from "./mcp-tool-filter.js";
 import { normalizeMcpToolCatalog, type McpToolCatalogMetadata } from "./mcp-tool-metadata.js";
 import { resolveMcpTransport } from "./mcp-transport.js";
@@ -819,6 +820,22 @@ function createServerMcpRuntime(
       }
 
       try {
+        failIfDisposed();
+        if (
+          resolved.stdioLaunch &&
+          !(await stdioCommandExists(
+            resolved.stdioLaunch.command,
+            resolved.stdioLaunch.cwd,
+            resolved.stdioLaunch.env,
+          ))
+        ) {
+          // A missing launcher binary (e.g. `uvx` never installed) otherwise
+          // surfaces only as a generic transport "Connection closed" error
+          // once the spawn fails, with no hint at the actual cause.
+          throw new Error(
+            `stdio command not found or not executable: ${resolved.stdioLaunch.command} — is it installed and on PATH?`,
+          );
+        }
         failIfDisposed();
         await ensureSessionConnected(session, resolved.connectionTimeoutMs);
         failIfDisposed();

--- a/src/agents/mcp-stdio-command-check.test.ts
+++ b/src/agents/mcp-stdio-command-check.test.ts
@@ -1,0 +1,50 @@
+import { randomUUID } from "node:crypto";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { stdioCommandExists } from "./mcp-stdio-command-check.js";
+
+describe("stdioCommandExists", () => {
+  it("finds a command resolvable on PATH", async () => {
+    expect(await stdioCommandExists(process.platform === "win32" ? "cmd" : "sh", undefined, {
+      PATH: process.env.PATH ?? "",
+    })).toBe(true);
+  });
+
+  it("reports a command absent from every PATH entry", async () => {
+    const missing = `openclaw-test-missing-command-${randomUUID()}`;
+    expect(await stdioCommandExists(missing, undefined, { PATH: process.env.PATH ?? "" })).toBe(
+      false,
+    );
+  });
+
+  it("resolves an absolute path directly without consulting PATH", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "stdio-command-check-"));
+    try {
+      const scriptPath = path.join(tempDir, "runnable.sh");
+      await fs.writeFile(scriptPath, "#!/bin/sh\nexit 0\n");
+      await fs.chmod(scriptPath, 0o755);
+
+      expect(await stdioCommandExists(scriptPath, undefined, undefined)).toBe(true);
+      expect(await stdioCommandExists(path.join(tempDir, "missing.sh"), undefined, undefined)).toBe(
+        false,
+      );
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("resolves a relative path against the provided cwd", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "stdio-command-check-cwd-"));
+    try {
+      const scriptPath = path.join(tempDir, "runnable.sh");
+      await fs.writeFile(scriptPath, "#!/bin/sh\nexit 0\n");
+      await fs.chmod(scriptPath, 0o755);
+
+      expect(await stdioCommandExists("./runnable.sh", tempDir, undefined)).toBe(true);
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/agents/mcp-stdio-command-check.test.ts
+++ b/src/agents/mcp-stdio-command-check.test.ts
@@ -47,4 +47,24 @@ describe("stdioCommandExists", () => {
       await fs.rm(tempDir, { recursive: true, force: true });
     }
   });
+
+  // Node's own spawn (via libuv) tries PATHEXT suffixes for an explicit path
+  // too, not just PATH-search candidates: an extensionless `C:\Tools\uvx`
+  // successfully launches `C:\Tools\uvx.exe`. This must match, or a working
+  // Windows launch config trips a false "command not found".
+  describe.runIf(process.platform === "win32")("on Windows", () => {
+    it("resolves an extensionless absolute path via its .exe suffix", async () => {
+      const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "stdio-command-check-win-"));
+      try {
+        const exePath = path.join(tempDir, "runnable.exe");
+        await fs.writeFile(exePath, "");
+
+        expect(
+          await stdioCommandExists(path.join(tempDir, "runnable"), undefined, undefined),
+        ).toBe(true);
+      } finally {
+        await fs.rm(tempDir, { recursive: true, force: true });
+      }
+    });
+  });
 });

--- a/src/agents/mcp-stdio-command-check.test.ts
+++ b/src/agents/mcp-stdio-command-check.test.ts
@@ -48,6 +48,46 @@ describe("stdioCommandExists", () => {
     }
   });
 
+  // POSIX PATH lookup and directory resolution use literal bytes; only a
+  // truly empty PATH segment means "current directory". A directory name
+  // with significant trailing whitespace is unusual but valid, and this
+  // checker must not silently strip it before searching.
+  it.skipIf(process.platform === "win32")(
+    "preserves significant trailing whitespace in a PATH entry",
+    async () => {
+      const parentDir = await fs.mkdtemp(path.join(os.tmpdir(), "stdio-command-check-ws-"));
+      try {
+        const paddedDir = path.join(parentDir, "bin ");
+        await fs.mkdir(paddedDir);
+        const scriptPath = path.join(paddedDir, "launcher");
+        await fs.writeFile(scriptPath, "#!/bin/sh\nexit 0\n");
+        await fs.chmod(scriptPath, 0o755);
+
+        expect(await stdioCommandExists("launcher", undefined, { PATH: paddedDir })).toBe(true);
+      } finally {
+        await fs.rm(parentDir, { recursive: true, force: true });
+      }
+    },
+  );
+
+  it.skipIf(process.platform === "win32")(
+    "preserves significant trailing whitespace in cwd",
+    async () => {
+      const parentDir = await fs.mkdtemp(path.join(os.tmpdir(), "stdio-command-check-cwd-ws-"));
+      try {
+        const paddedDir = path.join(parentDir, "work ");
+        await fs.mkdir(paddedDir);
+        const scriptPath = path.join(paddedDir, "runnable.sh");
+        await fs.writeFile(scriptPath, "#!/bin/sh\nexit 0\n");
+        await fs.chmod(scriptPath, 0o755);
+
+        expect(await stdioCommandExists("./runnable.sh", paddedDir, undefined)).toBe(true);
+      } finally {
+        await fs.rm(parentDir, { recursive: true, force: true });
+      }
+    },
+  );
+
   // Node's own spawn (via libuv) tries PATHEXT suffixes for an explicit path
   // too, not just PATH-search candidates: an extensionless `C:\Tools\uvx`
   // successfully launches `C:\Tools\uvx.exe`. This must match, or a working

--- a/src/agents/mcp-stdio-command-check.ts
+++ b/src/agents/mcp-stdio-command-check.ts
@@ -50,7 +50,17 @@ export async function stdioCommandExists(
   const hasPathSeparator =
     path.isAbsolute(command) || command.includes("/") || command.includes("\\");
   if (hasPathSeparator) {
-    return isExecutable(resolveConfiguredPath(command, cwd));
+    const resolvedPath = resolveConfiguredPath(command, cwd);
+    // Node's own spawn (via libuv) tries PATHEXT suffixes for an explicit
+    // path too, not just PATH-search candidates — an extensionless
+    // `C:\Tools\uvx` successfully launches `C:\Tools\uvx.exe`. Match that so
+    // this check doesn't reject a launch config the actual launcher accepts.
+    for (const candidate of executableCandidates(resolvedPath)) {
+      if (await isExecutable(candidate)) {
+        return true;
+      }
+    }
+    return false;
   }
   const configuredPath =
     process.platform === "win32" ? resolveEnvironmentValue(env, "PATH") : env?.PATH;

--- a/src/agents/mcp-stdio-command-check.ts
+++ b/src/agents/mcp-stdio-command-check.ts
@@ -1,0 +1,71 @@
+/**
+ * Checks whether a stdio MCP server's launch command resolves to an
+ * executable file, so a missing binary (e.g. `uvx` never installed) can be
+ * reported with an actionable message instead of surfacing later as a
+ * generic transport-level "Connection closed" error.
+ */
+import { constants as fsConstants } from "node:fs";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { resolveEnvironmentValue } from "../infra/process-env.js";
+
+function resolveConfiguredPath(filePath: string, cwd: unknown): string {
+  if (path.isAbsolute(filePath)) {
+    return filePath;
+  }
+  const base = typeof cwd === "string" && cwd.trim() ? cwd.trim() : process.cwd();
+  return path.resolve(base, filePath);
+}
+
+async function isExecutable(filePath: string): Promise<boolean> {
+  try {
+    await fs.access(filePath, process.platform === "win32" ? fsConstants.F_OK : fsConstants.X_OK);
+    // X_OK also succeeds for searchable directories; follow symlinks to check the target type.
+    return (await fs.stat(filePath)).isFile();
+  } catch {
+    return false;
+  }
+}
+
+function executableCandidates(command: string): string[] {
+  if (process.platform !== "win32") {
+    return [command];
+  }
+  const extensions = (process.env.PATHEXT ?? ".EXE;.CMD;.BAT;.COM")
+    .split(";")
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+  if (path.extname(command)) {
+    return [command];
+  }
+  return [command, ...extensions.map((extension) => `${command}${extension.toLowerCase()}`)];
+}
+
+/** True when `command` resolves to an executable file, either directly or via `PATH`. */
+export async function stdioCommandExists(
+  command: string,
+  cwd: unknown,
+  env: Record<string, string> | undefined,
+): Promise<boolean> {
+  const hasPathSeparator =
+    path.isAbsolute(command) || command.includes("/") || command.includes("\\");
+  if (hasPathSeparator) {
+    return isExecutable(resolveConfiguredPath(command, cwd));
+  }
+  const configuredPath =
+    process.platform === "win32" ? resolveEnvironmentValue(env, "PATH") : env?.PATH;
+  const pathEntries = (configuredPath ?? process.env.PATH ?? "")
+    .split(path.delimiter)
+    .map((entry) => entry.trim() || ".");
+  for (const pathEntry of pathEntries) {
+    const resolvedPathEntry = path.isAbsolute(pathEntry)
+      ? pathEntry
+      : resolveConfiguredPath(pathEntry, cwd);
+    for (const candidate of executableCandidates(command)) {
+      if (await isExecutable(path.join(resolvedPathEntry, candidate))) {
+        return true;
+      }
+    }
+  }
+  return false;
+}

--- a/src/agents/mcp-stdio-command-check.ts
+++ b/src/agents/mcp-stdio-command-check.ts
@@ -13,7 +13,10 @@ function resolveConfiguredPath(filePath: string, cwd: unknown): string {
   if (path.isAbsolute(filePath)) {
     return filePath;
   }
-  const base = typeof cwd === "string" && cwd.trim() ? cwd.trim() : process.cwd();
+  // A meaningful cwd (or PATH entry, below) can contain significant leading
+  // or trailing whitespace on POSIX; trimming only decides whether a value
+  // was configured at all, never the literal bytes used to resolve it.
+  const base = typeof cwd === "string" && cwd.trim().length > 0 ? cwd : process.cwd();
   return path.resolve(base, filePath);
 }
 
@@ -64,9 +67,12 @@ export async function stdioCommandExists(
   }
   const configuredPath =
     process.platform === "win32" ? resolveEnvironmentValue(env, "PATH") : env?.PATH;
+  // Only a truly empty segment means "current directory" in PATH semantics
+  // (e.g. a leading/trailing/doubled delimiter); a non-empty entry keeps its
+  // literal bytes, including any significant surrounding whitespace.
   const pathEntries = (configuredPath ?? process.env.PATH ?? "")
     .split(path.delimiter)
-    .map((entry) => entry.trim() || ".");
+    .map((entry) => (entry === "" ? "." : entry));
   for (const pathEntry of pathEntries) {
     const resolvedPathEntry = path.isAbsolute(pathEntry)
       ? pathEntry

--- a/src/agents/mcp-transport.ts
+++ b/src/agents/mcp-transport.ts
@@ -34,6 +34,13 @@ type ResolvedMcpTransport = {
   requestTimeoutMs: number;
   supportsParallelToolCalls: boolean;
   detachStderr?: () => void;
+  // Populated only when transportType is "stdio", so callers can run a
+  // pre-flight check (e.g. does `command` exist on PATH) before connecting.
+  stdioLaunch?: {
+    command: string;
+    cwd?: string;
+    env?: Record<string, string>;
+  };
 };
 
 const MAX_MCP_STDERR_LINE_BYTES = 8 * 1024;
@@ -153,6 +160,11 @@ export function resolveMcpTransport(
       requestTimeoutMs: resolved.requestTimeoutMs,
       supportsParallelToolCalls: resolved.supportsParallelToolCalls,
       detachStderr: attachStderrLogging(serverName, transport),
+      stdioLaunch: {
+        command: resolved.command,
+        ...(resolved.cwd !== undefined ? { cwd: resolved.cwd } : {}),
+        ...(resolved.env !== undefined ? { env: resolved.env } : {}),
+      },
     };
   }
   const authProfileId = resolveMcpAuthProfileId(rawServer);

--- a/src/cli/mcp-cli.ts
+++ b/src/cli/mcp-cli.ts
@@ -1,5 +1,4 @@
 // MCP CLI for configured servers, OAuth auth, diagnostics, and channel MCP serving.
-import { constants as fsConstants } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
@@ -28,6 +27,7 @@ import {
   startMcpOAuthAuthorization,
   type McpOAuthPrincipalStatus,
 } from "../agents/mcp-oauth.js";
+import { stdioCommandExists } from "../agents/mcp-stdio-command-check.js";
 import { resolveMcpTransportConfig } from "../agents/mcp-transport-config.js";
 import { parseConfigValue } from "../auto-reply/reply/config-value.js";
 import { listConfiguredMcpServers } from "../config/mcp-config.js";
@@ -243,58 +243,6 @@ async function directoryExists(filePath: string): Promise<boolean> {
   }
 }
 
-async function isExecutable(filePath: string): Promise<boolean> {
-  try {
-    await fs.access(filePath, process.platform === "win32" ? fsConstants.F_OK : fsConstants.X_OK);
-    // X_OK also succeeds for searchable directories; follow symlinks to check the target type.
-    return (await fs.stat(filePath)).isFile();
-  } catch {
-    return false;
-  }
-}
-
-function executableCandidates(command: string): string[] {
-  if (process.platform !== "win32") {
-    return [command];
-  }
-  const extensions = (process.env.PATHEXT ?? ".EXE;.CMD;.BAT;.COM")
-    .split(";")
-    .map((entry) => entry.trim())
-    .filter(Boolean);
-  if (path.extname(command)) {
-    return [command];
-  }
-  return [command, ...extensions.map((extension) => `${command}${extension.toLowerCase()}`)];
-}
-
-async function commandExists(
-  command: string,
-  cwd: unknown,
-  env: Record<string, string> | undefined,
-): Promise<boolean> {
-  const hasPathSeparator =
-    path.isAbsolute(command) || command.includes("/") || command.includes("\\");
-  if (hasPathSeparator) {
-    return isExecutable(resolveConfiguredPath(command, cwd));
-  }
-  const configuredPath =
-    process.platform === "win32" ? resolveEnvironmentValue(env, "PATH") : env?.PATH;
-  const pathEntries = (configuredPath ?? process.env.PATH ?? "")
-    .split(path.delimiter)
-    .map((entry) => entry.trim() || ".");
-  for (const pathEntry of pathEntries) {
-    const resolvedPathEntry = path.isAbsolute(pathEntry)
-      ? pathEntry
-      : resolveConfiguredPath(pathEntry, cwd);
-    for (const candidate of executableCandidates(command)) {
-      if (await isExecutable(path.join(resolvedPathEntry, candidate))) {
-        return true;
-      }
-    }
-  }
-  return false;
-}
-
 async function collectMcpDoctorIssues(params: {
   name: string;
   server: Record<string, unknown>;
@@ -314,7 +262,7 @@ async function collectMcpDoctorIssues(params: {
       issues.push(issue("error", "server transport is invalid"));
     }
     if (resolved?.kind === "stdio") {
-      if (!(await commandExists(resolved.command, resolved.cwd, resolved.env))) {
+      if (!(await stdioCommandExists(resolved.command, resolved.cwd, resolved.env))) {
         issues.push(
           issue("error", `stdio command not found or not executable: ${resolved.command}`),
         );

--- a/src/cli/mcp-cli.ts
+++ b/src/cli/mcp-cli.ts
@@ -38,7 +38,6 @@ import {
   startOAuthLoopbackCallbackServer,
   type OAuthLoopbackCallbackServer,
 } from "../infra/oauth-loopback-callback.js";
-import { resolveEnvironmentValue } from "../infra/process-env.js";
 import { defaultRuntime } from "../runtime.js";
 import { createLazyRuntimeMethod } from "../shared/lazy-runtime.js";
 import { runTasksWithConcurrency } from "../utils/run-with-concurrency.js";


### PR DESCRIPTION
Fixes #146268

## What Problem This Solves

A stdio MCP server whose launcher command isn't installed (the common case: a plugin's `mcpServers` entry runs `uvx <package>` and `uv`/`uvx` was never installed on the host) fails with no actionable signal. The spawn fails, the JSON-RPC handshake never happens, and the only thing that surfaces — and only once something actually tries to connect — is a generic `MCP error -32000: Connection closed`. Nothing in that message points at "the command doesn't exist."

## Why This Change Was Made

`openclaw mcp doctor` already has exactly the right check for this (`commandExists` in `src/cli/mcp-cli.ts`, resolving a stdio server's `command` against `PATH`/`cwd`), but it only runs as a separate, opt-in diagnostic — the actual runtime connection path (`agent-bundle-mcp-runtime.ts`'s `loadCatalog`) never checked this before attempting to connect.

This PR:
- Extracts that PATH-resolution check out of `mcp-cli.ts` into a shared `src/agents/mcp-stdio-command-check.ts` module (`stdioCommandExists`), so there's one implementation instead of two.
- Threads the resolved stdio launch config (`command`/`cwd`/`env`) through `resolveMcpTransport`'s return value (a new optional `stdioLaunch` field, only populated for stdio transports — no behavior change for SSE/streamable-HTTP).
- Lets `ensureSessionConnected` run first, exactly as before this PR, on every platform and every launch config. Only if it throws does `agent-bundle-mcp-runtime.ts` check whether the launcher is missing and, if so, replace the generic `MCP error -32000: Connection closed` with `stdio command not found or not executable: <command> — is it installed and on PATH?` (the original error is preserved via `Error.cause` and still included in the formatted diagnostic).

This design deliberately enriches a connection failure after it happens rather than gating one before it happens. `stdioCommandExists` is a best-effort approximation (it can't fully replicate every platform's real launch semantics — Windows PATHEXT/shim/node-entrypoint resolution, symlink traversal, etc.), so it never vetoes an attempt: a false negative can only affect the wording of an error a working server never reaches.

## User Impact

Anyone installing a `uvx`-based (or any stdio) MCP server plugin without the launcher binary installed gets a clear, actionable error in the gateway logs immediately, instead of a generic JSON-RPC error code with no indication of the real cause. Existing working configurations, on every platform, are unaffected — the check never runs unless a connection has already failed.

## Evidence

Real, executed test run (not fabricated) — `node scripts/run-vitest.mjs src/agents/agent-bundle-mcp-runtime.test.ts src/agents/mcp-stdio-command-check.test.ts` on the exact head of this branch:

```
 ✓ |agents-core| src/agents/agent-bundle-mcp-runtime.test.ts > session MCP runtime > reports a missing stdio launcher command instead of a generic transport close
 ✓ |agents-core| src/agents/agent-bundle-mcp-runtime.test.ts > session MCP runtime > keeps refreshing an already-connected session after its launcher command disappears from disk
 ✓ |agents-core| src/agents/mcp-stdio-command-check.test.ts > stdioCommandExists > finds a command resolvable on PATH
 ✓ |agents-core| src/agents/mcp-stdio-command-check.test.ts > stdioCommandExists > reports a command absent from every PATH entry
 ✓ |agents-core| src/agents/mcp-stdio-command-check.test.ts > stdioCommandExists > resolves an absolute path directly without consulting PATH
 ✓ |agents-core| src/agents/mcp-stdio-command-check.test.ts > stdioCommandExists > resolves a relative path against the provided cwd
 ✓ |agents-core| src/agents/mcp-stdio-command-check.test.ts > stdioCommandExists > preserves significant trailing whitespace in a PATH entry
 ✓ |agents-core| src/agents/mcp-stdio-command-check.test.ts > stdioCommandExists > preserves significant trailing whitespace in cwd
 ↓ |agents-core| src/agents/mcp-stdio-command-check.test.ts > stdioCommandExists > on Windows > resolves an extensionless absolute path via its .exe suffix (correctly skipped — not Windows)

 Test Files  2 passed (2)
      Tests  131 passed | 1 skipped (132)
   Start at  19:11:43
   Duration  228.94s
```

This first run against real code (a real stdio child process spawned with a genuinely nonexistent random command, and a real connected session whose launcher script is deleted from disk mid-session) also caught a real bug in my own test: I'd asserted the diagnostic message with an exact string match, but `redactMcpDiagnosticError`/`formatErrorMessage` appends the chained `Error.cause` (the original connect failure) to the formatted message — existing, correct behavior in this codebase, not something this PR changes. Fixed the assertion to check the actionable prefix (`toContain`) instead of the full string (see the latest commit). The other two transient failures on the first run (`disposeSession timeout > starts MCP server catalog loading concurrently` and `> retires timed-out shared MCP sessions before later catalog retries`) were unrelated to this change — pre-existing tests waiting on file markers that flaked under this host's momentary load, and passed cleanly on immediate rerun.

**Setup:** Raspberry Pi 5, Node v24.20.0, `pnpm install --frozen-lockfile` (fresh, ~2 min), run directly against this branch's working tree — not fabricated, not hand-written.