### PR TITLE
fix(telegram): defer transcript echo until message admission

### DIFF
--- a/extensions/telegram/src/bot-message-context.audio-transcript.test-support.ts
+++ b/extensions/telegram/src/bot-message-context.audio-transcript.test-support.ts
@@ -7,7 +7,9 @@ const DEFAULT_WORKSPACE = "/tmp/openclaw";
 const DEFAULT_MENTION_PATTERN = "\\bbot\\b";
 
 vi.mock("./media-understanding.runtime.js", () => ({
-  transcribeFirstAudio: (...args: unknown[]) => transcribeFirstAudioMock(...args),
+  resolveTelegramPreflightAudioTranscript: (...args: unknown[]) =>
+    transcribeFirstAudioMock(...args),
+  sendTelegramPreflightAudioTranscriptEcho: vi.fn(async () => undefined),
 }));
 
 const { buildTelegramMessageContextForTest } =

--- a/extensions/telegram/src/bot-message-context.body.test.ts
+++ b/extensions/telegram/src/bot-message-context.body.test.ts
@@ -21,8 +21,8 @@ vi.mock("./sticker-vision.runtime.js", () => ({
 vi.mock("./media-understanding.runtime.js", () => ({
   resolveTelegramPreflightAudioTranscript: (...args: unknown[]) =>
     transcribeFirstAudioMock(...args),
-  sendTelegramPreflightAudioTranscriptEcho: (...args: unknown[]) =>
-    sendTelegramPreflightAudioTranscriptEchoMock(...args),
+  sendTelegramPreflightAudioTranscriptEcho: (params: unknown) =>
+    sendTelegramPreflightAudioTranscriptEchoMock(params),
 }));
 vi.mock("openclaw/plugin-sdk/hook-runtime", async () => {
   const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/hook-runtime")>(

--- a/extensions/telegram/src/bot-message-context.body.test.ts
+++ b/extensions/telegram/src/bot-message-context.body.test.ts
@@ -5,10 +5,12 @@ import { normalizeAllowFrom } from "./bot-access.js";
 const {
   resolveStickerVisionSupportRuntimeMock,
   transcribeFirstAudioMock,
+  sendTelegramPreflightAudioTranscriptEchoMock,
   triggerInternalHookMock,
 } = vi.hoisted(() => ({
   resolveStickerVisionSupportRuntimeMock: vi.fn(async (_params: unknown) => false),
   transcribeFirstAudioMock: vi.fn(),
+  sendTelegramPreflightAudioTranscriptEchoMock: vi.fn(async () => undefined),
   triggerInternalHookMock: vi.fn<(event: unknown) => Promise<void>>(async () => undefined),
 }));
 
@@ -17,7 +19,10 @@ vi.mock("./sticker-vision.runtime.js", () => ({
     resolveStickerVisionSupportRuntimeMock(params),
 }));
 vi.mock("./media-understanding.runtime.js", () => ({
-  transcribeFirstAudio: (...args: unknown[]) => transcribeFirstAudioMock(...args),
+  resolveTelegramPreflightAudioTranscript: (...args: unknown[]) =>
+    transcribeFirstAudioMock(...args),
+  sendTelegramPreflightAudioTranscriptEcho: (...args: unknown[]) =>
+    sendTelegramPreflightAudioTranscriptEchoMock(...args),
 }));
 vi.mock("openclaw/plugin-sdk/hook-runtime", async () => {
   const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/hook-runtime")>(
@@ -641,6 +646,7 @@ describe("resolveTelegramInboundBody", () => {
 
   it("transcribes when the group sender is authorized", async () => {
     transcribeFirstAudioMock.mockReset();
+    sendTelegramPreflightAudioTranscriptEchoMock.mockClear();
     transcribeFirstAudioMock.mockResolvedValueOnce("hey bot please help");
     const logger = createLogger();
     const result = await resolveGroup({
@@ -648,7 +654,11 @@ describe("resolveTelegramInboundBody", () => {
       patterns: BOT_PATTERN,
       allowFrom: ["46"],
       message: voiceMessage("voice-2", 2),
-      overrides: audioOverrides("/tmp/voice-2.ogg", { patterns: BOT_PATTERN }),
+      overrides: audioOverrides("/tmp/voice-2.ogg", {
+        patterns: BOT_PATTERN,
+        echo: true,
+        accountId: "primary",
+      }),
     });
 
     expect(transcribeFirstAudioMock).toHaveBeenCalledTimes(1);
@@ -656,6 +666,35 @@ describe("resolveTelegramInboundBody", () => {
       '[Audio transcript (machine-generated, untrusted)]: "hey bot please help"',
     );
     expect(result?.effectiveWasMentioned).toBe(true);
+    expect(sendTelegramPreflightAudioTranscriptEchoMock).toHaveBeenCalledWith({
+      transcript: "hey bot please help",
+      cfg: expect.any(Object),
+      accountId: "primary",
+      originatingTo: "telegram:-1001234567890",
+      messageThreadId: undefined,
+    });
+  });
+
+  it("does not echo a preflight transcript for an unmentioned group message", async () => {
+    transcribeFirstAudioMock.mockReset();
+    sendTelegramPreflightAudioTranscriptEchoMock.mockClear();
+    transcribeFirstAudioMock.mockResolvedValueOnce("ambient voice note");
+
+    const result = await resolveGroup({
+      logger: createLogger(),
+      patterns: BOT_PATTERN,
+      allowFrom: ["46"],
+      message: voiceMessage("voice-unmentioned", 3),
+      overrides: audioOverrides("/tmp/voice-unmentioned.ogg", {
+        patterns: BOT_PATTERN,
+        echo: true,
+        accountId: "primary",
+      }),
+    });
+
+    expect(transcribeFirstAudioMock).toHaveBeenCalledTimes(1);
+    expect(result).toBeNull();
+    expect(sendTelegramPreflightAudioTranscriptEchoMock).not.toHaveBeenCalled();
   });
 
   it("admits a transcript participant mention despite a whitespace-only audio caption", async () => {
@@ -688,6 +727,7 @@ describe("resolveTelegramInboundBody", () => {
 
   it("transcribes DM voice notes via preflight (not only groups)", async () => {
     transcribeFirstAudioMock.mockReset();
+    sendTelegramPreflightAudioTranscriptEchoMock.mockClear();
     transcribeFirstAudioMock.mockResolvedValueOnce("hello from a voice note");
     const result = await resolvePrivate(
       voiceMessage("voice-dm-1", 10),
@@ -705,6 +745,13 @@ describe("resolveTelegramInboundBody", () => {
       '[Audio transcript (machine-generated, untrusted)]: "hello from a voice note"',
     );
     expect(result?.bodyText).not.toContain("<media:audio>");
+    expect(sendTelegramPreflightAudioTranscriptEchoMock).toHaveBeenCalledWith({
+      transcript: "hello from a voice note",
+      cfg: expect.any(Object),
+      accountId: "primary",
+      originatingTo: "telegram:42",
+      messageThreadId: undefined,
+    });
   });
 
   it("passes DM topic thread IDs through audio preflight context", async () => {

--- a/extensions/telegram/src/bot-message-context.body.test.ts
+++ b/extensions/telegram/src/bot-message-context.body.test.ts
@@ -10,7 +10,7 @@ const {
 } = vi.hoisted(() => ({
   resolveStickerVisionSupportRuntimeMock: vi.fn(async (_params: unknown) => false),
   transcribeFirstAudioMock: vi.fn(),
-  sendTelegramPreflightAudioTranscriptEchoMock: vi.fn(async () => undefined),
+  sendTelegramPreflightAudioTranscriptEchoMock: vi.fn(async (_params: unknown) => undefined),
   triggerInternalHookMock: vi.fn<(event: unknown) => Promise<void>>(async () => undefined),
 }));
 

--- a/extensions/telegram/src/bot-message-context.body.ts
+++ b/extensions/telegram/src/bot-message-context.body.ts
@@ -299,7 +299,7 @@ export async function resolveTelegramInboundBody(params: {
 
   if (needsPreflightTranscription) {
     try {
-      const { transcribeFirstAudio } = await loadMediaUnderstandingRuntime();
+      const { resolveTelegramPreflightAudioTranscript } = await loadMediaUnderstandingRuntime();
       const tempCtx: MsgContext = {
         Provider: "telegram",
         Surface: "telegram",
@@ -309,7 +309,7 @@ export async function resolveTelegramInboundBody(params: {
         MessageThreadId: replyThreadId,
         media: materializedMedia,
       };
-      preflightTranscript = await transcribeFirstAudio({
+      preflightTranscript = await resolveTelegramPreflightAudioTranscript({
         ctx: tempCtx,
         cfg,
         agentDir: undefined,
@@ -457,6 +457,17 @@ export async function resolveTelegramInboundBody(params: {
       );
     }
     return null;
+  }
+
+  if (preflightTranscript) {
+    const { sendTelegramPreflightAudioTranscriptEcho } = await loadMediaUnderstandingRuntime();
+    await sendTelegramPreflightAudioTranscriptEcho({
+      transcript: preflightTranscript,
+      cfg,
+      accountId: accountId ?? "default",
+      originatingTo,
+      messageThreadId: replyThreadId === undefined ? undefined : String(replyThreadId),
+    });
   }
 
   return {

--- a/extensions/telegram/src/media-understanding.runtime.ts
+++ b/extensions/telegram/src/media-understanding.runtime.ts
@@ -1,12 +1,21 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 // Telegram plugin module implements media understanding behavior.
 import {
   describeImageWithModel as describeImageWithModelImpl,
   transcribeFirstAudio as transcribeFirstAudioImpl,
 } from "openclaw/plugin-sdk/media-runtime";
+import { createChannelPreflightAudio } from "openclaw/plugin-sdk/media-understanding-runtime";
 
 type DescribeImageWithModel =
   typeof import("openclaw/plugin-sdk/media-runtime").describeImageWithModel;
 type TranscribeFirstAudio = typeof import("openclaw/plugin-sdk/media-runtime").transcribeFirstAudio;
+
+const telegramPreflightAudio = createChannelPreflightAudio({
+  channel: "telegram",
+  isAudio: (value: { kind?: string; contentType?: string }) =>
+    value.kind === "audio" || value.contentType?.startsWith("audio/") === true,
+  transcribeFirstAudio: transcribeFirstAudioImpl,
+});
 
 export async function describeImageWithModel(
   ...args: Parameters<DescribeImageWithModel>
@@ -14,8 +23,18 @@ export async function describeImageWithModel(
   return await describeImageWithModelImpl(...args);
 }
 
-export async function transcribeFirstAudio(
+export async function resolveTelegramPreflightAudioTranscript(
   ...args: Parameters<TranscribeFirstAudio>
 ): ReturnType<TranscribeFirstAudio> {
-  return await transcribeFirstAudioImpl(...args);
+  return await telegramPreflightAudio.resolve({ request: args[0] });
+}
+
+export async function sendTelegramPreflightAudioTranscriptEcho(params: {
+  transcript: string;
+  cfg: OpenClawConfig;
+  accountId: string;
+  originatingTo: string;
+  messageThreadId?: string;
+}): Promise<void> {
+  await telegramPreflightAudio.send(params);
 }


### PR DESCRIPTION
Closes #146311

## What Problem This Solves

Fixes an issue where Telegram users running multiple bot accounts in a mention-gated group would see transcript echoes from every bot after sending one voice note, even though only the addressed bot admitted the message.

## Why This Change Was Made

Telegram now uses the shared deferred preflight-audio behavior: transcription remains available before mention detection, but the user-visible transcript echo is held until the message passes the existing command and mention admission gates. Direct messages and admitted group messages retain the configured echo behavior and account/topic routing.

## User Impact

Only the Telegram bot that admits a voice message echoes its transcript. Unaddressed bots can still inspect the transcript for mention detection without leaking a duplicate reply into the group.

## Evidence

- `bot-message-context.body.test.ts`: 40/40 passed, including admitted group, rejected group, DM, and forum-topic routing cases.
- `bot-message-context.group-body.test.ts`: 24/24 passed.
- `media-understanding-runtime.test.ts`: 6/6 passed.
- Oxfmt and `git diff --check` passed.
- Portfolio preflight completed with no BLOCK; its two WARNs were the expected pre-push missing tracking branch and seven intentional replaced lines.
