### PR TITLE
test(qa): sync Debug diagnostics scenario with current UI coverage

### DIFF
--- a/qa/scenarios/ui/control-ui-health-status-models.yaml
+++ b/qa/scenarios/ui/control-ui-health-status-models.yaml
@@ -12,7 +12,7 @@ scenario:
     snapshots and renders them as operator-visible diagnostics.
   successCriteria:
     - Real Chromium opens the Debug page through the Control UI shell.
-    - The browser requests status, health, last-heartbeat, and models.list with empty parameters.
+    - The browser requests status, health, and last-heartbeat with empty parameters, and models.list with agentId main and view default.
     - Status and security summary data render visibly.
     - Health, heartbeat, and model snapshot values render visibly.
   docsRefs:
@@ -25,7 +25,7 @@ scenario:
   execution:
     kind: playwright
     path: ui/src/e2e/debug-diagnostics.e2e.test.ts
-    testNamePattern: renders status, health, heartbeat, and model snapshots from the Gateway
+    testNamePattern: renders Gateway diagnostics and current work independently of session history
     summary: >-
       Real Chromium coverage for the Debug page diagnostic RPC requests and
       their visible operator snapshots.


### PR DESCRIPTION
## What Problem This Solves

The QA catalog still selects the old Debug diagnostics test name after #146207 renamed the test. The catalog guard consequently fails on main and unrelated PRs. Its description also predates the scoped `models.list` request.

## Why This Change Was Made

Update the scenario's test selector and RPC-parameter description to match the existing executable UI test. No UI, production, or test behavior changes; two metadata values change with net zero lines.

## Evidence

Reproduced the catalog alignment failure before editing. All 78 focused catalog and native-runner cases pass afterward, and independent P0–P2 review is clean. A broader local replay passed 1,642 tests; three files require a normal dependency installation instead of the borrowed worktree install. Hosted exact-head CI provides that remaining validation.
