### PR TITLE
fix(plugins): keep workspace plugins out of auto-enable

### DIFF
--- a/src/config/plugin-auto-enable.channels.test.ts
+++ b/src/config/plugin-auto-enable.channels.test.ts
@@ -325,6 +325,50 @@ describe("applyPluginAutoEnable channels", () => {
       expect(Object.keys(result.autoEnabledReasons)).toStrictEqual([]);
     });
 
+    it.each([
+      {
+        label: "enabled entry",
+        plugins: { entries: { "workspace-telegram": { enabled: true } } },
+      },
+      {
+        label: "allowlist",
+        plugins: { allow: ["workspace-telegram"] },
+      },
+    ])("preserves a workspace channel replacement trusted by $label", ({ plugins }) => {
+      const result = applyPluginAutoEnable({
+        config: {
+          channels: { telegram: { botToken: "token" } },
+          plugins,
+        },
+        env: makeIsolatedEnv(),
+        manifestRegistry: makeRegistry([
+          {
+            id: "telegram",
+            channels: ["telegram"],
+            origin: "bundled",
+          },
+          {
+            id: "workspace-telegram",
+            channels: ["telegram"],
+            origin: "workspace",
+            channelConfigs: {
+              telegram: {
+                schema: { type: "object" },
+                preferOver: ["telegram"],
+              },
+            },
+          },
+        ]),
+      });
+
+      expect(result.config.channels?.telegram?.enabled).toBeUndefined();
+      expect(result.config.plugins?.entries?.telegram?.enabled).toBe(false);
+      expect(result.config.plugins?.entries?.["workspace-telegram"]?.enabled).toBe(
+        plugins.entries?.["workspace-telegram"]?.enabled,
+      );
+      expect(result.config.plugins?.allow).toEqual(plugins.allow);
+    });
+
     it("activates external channel plugins under plugins.entries when plugin id matches channel id", () => {
       const result = materializePluginAutoEnableCandidates({
         config: {

--- a/src/config/plugin-auto-enable.channels.test.ts
+++ b/src/config/plugin-auto-enable.channels.test.ts
@@ -269,6 +269,62 @@ describe("applyPluginAutoEnable channels", () => {
   );
 
   describe("third-party channel plugins", () => {
+    it("ignores workspace channel claims and keeps bundled channel auto-enable", () => {
+      const result = applyPluginAutoEnable({
+        config: {
+          channels: { telegram: { botToken: "token" } },
+        },
+        env: makeIsolatedEnv(),
+        manifestRegistry: makeRegistry([
+          {
+            id: "workspace-telegram",
+            channels: ["telegram"],
+            origin: "workspace",
+            channelConfigs: {
+              telegram: {
+                schema: { type: "object" },
+                label: "Workspace Telegram",
+                preferOver: ["telegram"],
+              },
+            },
+          },
+        ]),
+      });
+
+      expect(result.config.channels?.telegram?.enabled).toBe(true);
+      expect(result.config.plugins?.entries?.["workspace-telegram"]).toBeUndefined();
+      expect(result.config.plugins?.entries?.telegram).toBeUndefined();
+      expect(result.changes).toContain("Telegram configured, enabled automatically.");
+    });
+
+    it("does not materialize or allowlist workspace auto-enable candidates", () => {
+      const result = materializePluginAutoEnableCandidates({
+        config: {
+          plugins: { allow: ["mattermost"] },
+        },
+        candidates: [
+          {
+            pluginId: "workspace-telegram",
+            kind: "channel-configured",
+            channelId: "telegram",
+          },
+        ],
+        env: makeIsolatedEnv(),
+        manifestRegistry: makeRegistry([
+          {
+            id: "workspace-telegram",
+            channels: ["telegram"],
+            origin: "workspace",
+          },
+        ]),
+      });
+
+      expect(result.config.plugins?.entries?.["workspace-telegram"]).toBeUndefined();
+      expect(result.config.plugins?.allow).toEqual(["mattermost"]);
+      expect(result.changes).toStrictEqual([]);
+      expect(Object.keys(result.autoEnabledReasons)).toStrictEqual([]);
+    });
+
     it("activates external channel plugins under plugins.entries when plugin id matches channel id", () => {
       const result = materializePluginAutoEnableCandidates({
         config: {

--- a/src/config/plugin-auto-enable.channels.ts
+++ b/src/config/plugin-auto-enable.channels.ts
@@ -9,7 +9,9 @@ import {
   hasBundledChannelPackageState,
   listBundledChannelIdsForPackageState,
 } from "../channels/plugins/package-state-probes.js";
+import { normalizePluginsConfig } from "../plugins/config-state.js";
 import type { PluginDiscoveryResult } from "../plugins/discovery.types.js";
+import { hasExplicitManifestOwnerTrust } from "../plugins/manifest-owner-policy.js";
 import type { PluginManifestRegistry } from "../plugins/manifest-registry.types.js";
 import { isChannelConfigured } from "./channel-configured.js";
 import type { PluginAutoEnableCandidate } from "./plugin-auto-enable.types.js";
@@ -21,13 +23,16 @@ function normalizeManifestChannelId(channelId: string): string {
 
 function collectPluginIdsForConfiguredChannel(
   channelId: string,
+  config: OpenClawConfig,
   registry: PluginManifestRegistry,
 ): string[] {
   const normalizedChannelId = normalizeManifestChannelId(channelId);
   const builtInId = normalizeChatChannelId(normalizedChannelId);
+  const normalizedConfig = normalizePluginsConfig(config.plugins);
   const claims = registry.plugins.filter(
     (record) =>
-      record.origin !== "workspace" &&
+      (record.origin !== "workspace" ||
+        hasExplicitManifestOwnerTrust({ plugin: record, normalizedConfig })) &&
       record.channels.some((id) => normalizeManifestChannelId(id) === normalizedChannelId),
   );
 
@@ -126,7 +131,11 @@ export function resolveConfiguredChannelAutoEnableCandidates(
   const changes: PluginAutoEnableCandidate[] = [];
   for (const channelId of params.configuredChannelIds ??
     collectAutoEnableChannelIds(params.config, params.env)) {
-    for (const pluginId of collectPluginIdsForConfiguredChannel(channelId, params.registry)) {
+    for (const pluginId of collectPluginIdsForConfiguredChannel(
+      channelId,
+      params.config,
+      params.registry,
+    )) {
       changes.push({ pluginId, kind: "channel-configured", channelId });
     }
   }

--- a/src/config/plugin-auto-enable.channels.ts
+++ b/src/config/plugin-auto-enable.channels.ts
@@ -25,8 +25,10 @@ function collectPluginIdsForConfiguredChannel(
 ): string[] {
   const normalizedChannelId = normalizeManifestChannelId(channelId);
   const builtInId = normalizeChatChannelId(normalizedChannelId);
-  const claims = registry.plugins.filter((record) =>
-    record.channels.some((id) => normalizeManifestChannelId(id) === normalizedChannelId),
+  const claims = registry.plugins.filter(
+    (record) =>
+      record.origin !== "workspace" &&
+      record.channels.some((id) => normalizeManifestChannelId(id) === normalizedChannelId),
   );
 
   if (claims.length === 0) {

--- a/src/config/plugin-auto-enable.materialize.ts
+++ b/src/config/plugin-auto-enable.materialize.ts
@@ -7,6 +7,8 @@ import {
 import { findChatChannelMeta } from "../channels/chat-meta.js";
 import { normalizeChatChannelId } from "../channels/ids.js";
 import { isBlockedObjectKey } from "../infra/prototype-keys.js";
+import { normalizePluginsConfig } from "../plugins/config-state.js";
+import { hasExplicitManifestOwnerTrust } from "../plugins/manifest-owner-policy.js";
 import type { PluginManifestRegistry } from "../plugins/manifest-registry.types.js";
 import { isNativeSessionCatalogOptOutOnly } from "../plugins/native-session-catalog-config.js";
 import { isOfficialExternalPluginId } from "../plugins/official-external-plugin-catalog.js";
@@ -288,7 +290,19 @@ export function materializePluginAutoEnableCandidatesInternal(params: {
       .filter((plugin) => plugin.origin === "workspace")
       .map((plugin) => plugin.id),
   );
-  const candidates = params.candidates.filter((entry) => !workspacePluginIds.has(entry.pluginId));
+  const normalizedConfig = normalizePluginsConfig(next.plugins);
+  const preferenceCandidates = params.candidates.filter((entry) => {
+    if (!workspacePluginIds.has(entry.pluginId)) {
+      return true;
+    }
+    return hasExplicitManifestOwnerTrust({
+      plugin: { id: entry.pluginId },
+      normalizedConfig,
+    });
+  });
+  const candidates = preferenceCandidates.filter(
+    (entry) => !workspacePluginIds.has(entry.pluginId),
+  );
 
   for (const entry of candidates) {
     const builtInChannelId = resolveAutoEnableChannelId({
@@ -302,7 +316,7 @@ export function materializePluginAutoEnableCandidatesInternal(params: {
       shouldSkipPreferredPluginAutoEnable({
         config: next,
         entry,
-        configured: candidates,
+        configured: preferenceCandidates,
         env: params.env,
         registry: params.manifestRegistry,
         isPluginDenied,

--- a/src/config/plugin-auto-enable.materialize.ts
+++ b/src/config/plugin-auto-enable.materialize.ts
@@ -283,8 +283,14 @@ export function materializePluginAutoEnableCandidatesInternal(params: {
   }
 
   const preferOverCache = new Map<string, string[]>();
+  const workspacePluginIds = new Set(
+    params.manifestRegistry.plugins
+      .filter((plugin) => plugin.origin === "workspace")
+      .map((plugin) => plugin.id),
+  );
+  const candidates = params.candidates.filter((entry) => !workspacePluginIds.has(entry.pluginId));
 
-  for (const entry of params.candidates) {
+  for (const entry of candidates) {
     const builtInChannelId = resolveAutoEnableChannelId({
       entry,
       manifestRegistry: params.manifestRegistry,
@@ -296,7 +302,7 @@ export function materializePluginAutoEnableCandidatesInternal(params: {
       shouldSkipPreferredPluginAutoEnable({
         config: next,
         entry,
-        configured: params.candidates,
+        configured: candidates,
         env: params.env,
         registry: params.manifestRegistry,
         isPluginDenied,


### PR DESCRIPTION
Workspace-discovered plugins are intentionally disabled until an operator trusts them, but configured-channel auto-enable could previously turn a workspace manifest into an enabled plugin entry and could add it to a restrictive allowlist. This change keeps workspace provenance out of unattended auto-enable while preserving auto-enable for trusted plugin origins and bundled channels.

## What was wrong

1. `collectPluginIdsForConfiguredChannel` accepted workspace-origin channel claims, so a workspace manifest could displace the bundled owner of an already configured channel.
2. `materializePluginAutoEnableCandidatesInternal` accepted candidates without checking manifest origin, then wrote `plugins.entries.<id>.enabled = true`.
3. With a restrictive allowlist, the same path also inserted the workspace plugin into `plugins.allow`, creating a second explicit-looking trust signal.

## Why this design

- Exclude workspace channel claims before candidate selection so configured bundled channels continue through their normal path.
- Independently filter workspace candidates at materialization, the final producer boundary before entry and allowlist mutations.
- Pass the filtered candidate set into preference resolution so skipped workspace claims cannot affect another plugin indirectly.
- Preserve explicit operator enablement and allowlisting; this only changes unattended auto-enable behavior.

## Relationship to existing workspace trust behavior

| Existing behavior | Result after this change |
|---|---|
| Workspace plugins are discovered for inspection and explicit selection | Preserved |
| An operator explicitly enables or allowlists a workspace plugin | Preserved |
| A configured bundled channel auto-enables its bundled plugin | Preserved |
| A workspace manifest claims a configured channel and relies on auto-enable | Rejected |

## Evidence

| Check | Result |
|---|---|
| Focused regression suite before the production change | Both new security cases failed |
| `node scripts/run-vitest.mjs src/config/plugin-auto-enable.channels.test.ts` | 26/26 passed |
| `pnpm run check:changed --base upstream/main` | Passed |
| `pnpm build` | Passed |
| Scoped autoreview of the exact three-file diff | No P0-P2 findings |
| Patched Gateway with discovered, untrusted workspace replacement | Reached ready state with bundled Telegram; workspace registration marker absent |
| Patched Gateway with the same replacement explicitly enabled | Workspace registration marker emitted; workspace replacement loaded and bundled Telegram absent |

## Testing

The regression coverage verifies that an untrusted workspace claimant cannot suppress bundled Telegram auto-enable and that direct workspace candidate materialization produces no plugin entry, allowlist mutation, change message, or auto-enable reason. It also covers upgrade/existing-config behavior for both supported trust signals: explicitly enabled and explicitly allowlisted workspace replacements retain preference ordering over the bundled owner.

An inert runtime fixture was also exercised through `gateway run` on the reviewed build. With only a configured Telegram channel, the workspace manifest was discovered but its `register()` marker never appeared, while bundled Telegram loaded. With the same fixture explicitly enabled, the marker appeared and the Gateway's loaded-plugin list contained the workspace replacement instead of bundled Telegram. Both runs reached Gateway ready state before bounded shutdown.

### Gateway proof excerpt

```text
untrusted workspace replacement:
  workspace manifest discovered: yes
  WORKSPACE_PLUGIN_REGISTERED: absent
  loaded plugins: telegram
  gateway ready: yes

explicitly enabled workspace replacement:
  workspace manifest discovered: yes
  WORKSPACE_PLUGIN_REGISTERED: emitted
  loaded plugins: workspace-telegram
  bundled telegram loaded: no
  gateway ready: yes
```
