### PR TITLE
ci: fix Debug diagnostics QA scenario selection

### DIFF
--- a/qa/scenarios/ui/control-ui-health-status-models.yaml
+++ b/qa/scenarios/ui/control-ui-health-status-models.yaml
@@ -25,7 +25,7 @@ scenario:
   execution:
     kind: playwright
     path: ui/src/e2e/debug-diagnostics.e2e.test.ts
-    testNamePattern: renders status, health, heartbeat, and model snapshots from the Gateway
+    testNamePattern: renders Gateway diagnostics and current work independently of session history
     summary: >-
       Real Chromium coverage for the Debug page diagnostic RPC requests and
       their visible operator snapshots.


### PR DESCRIPTION
Refs #146207.

<details>
<summary>Additional instructions</summary>

Maintainers can update this same-repository branch.

</details>

## What Problem This Solves

Resolves a problem where pull requests containing the Debug diagnostics test rename fail `checks-node-changed-extensions-config-53`, blocking the aggregate CI gate. This is a maintainer-requested repair of the existing main CI blocker: [failed run](https://github.com/openclaw/openclaw/actions/runs/34711954119/job/103602293746).

The mismatch is present at main commit `77292356e9a`. Git history identifies `1a2e8cddfcd` (#146207) as the commit that renamed the test.

## Why This Change Was Made

Update the QA scenario's `execution.testNamePattern` to the current Debug diagnostics test name. Scenario YAML owns test selection; the existing guard correctly rejected the stale selector. Only this catalog entry references the old title.

## User Impact

Restores selection of the Debug diagnostics browser test through the QA scenario catalog and removes this CI blocker. No application behavior changes.

## Evidence

Ran the existing regression guard before and after the one-line catalog repair:

```text
node scripts/run-vitest.mjs extensions/qa-lab/src/test-file-scenario-runner.native.test.ts

Before (exit 1):
control-ui-health-status-models testNamePattern matches an executable test:
expected false to be true
Test Files  1 failed (1)
Tests       1 failed | 19 passed (20)

After (exit 0):
Test Files  1 passed (1)
Tests       20 passed (20)
```

The guard checks every declared Playwright selector against an executable test. The test source, assertions, baselines, and checker are unchanged.

The reported CI job uses `vitest.extension-qa.config.ts`, shard `1/3`. Replayed its wrapper locally with the same config and shard selection:

```bash
OPENCLAW_NODE_TEST_CONFIGS_JSON='["test/vitest/vitest.extension-qa.config.ts"]' \
OPENCLAW_NODE_TEST_ENV_JSON='{"OPENCLAW_NODE_TEST_VITEST_ARGS_JSON":"[\"--shard=1/3\"]"}' \
OPENCLAW_VITEST_SHARD_NAME=changed-extensions-config-53 \
OPENCLAW_NODE_TEST_PLAN_CONCURRENCY=1 \
node --import tsx scripts/ci-run-node-test-shard.mts
```

```text
Test Files  83 passed (83)
Tests       1672 passed | 1 skipped (1673)
[shard:changed-extensions-config-53] end (exit 0)
```

The skipped case is the existing Linux-only shell startup environment test (`gateway-child.test.ts`); this local run is on macOS. The lead completed independent Codex review of this exact head with a scoped-clean P1 verdict; landing is in progress.

`git diff --check` passed. `node scripts/check-changed.mjs` passed formatting, all typechecks, and the preceding guards, then failed in lint's declaration preparation:

```text
Error: Declaration input escapes checkout: <ancestor-install>/node_modules/punycode/package.json
This checkout is nested inside another install.
Repeating pnpm install will not isolate ancestor lookup.
[check:changed] FAILED (exit 1)
```

The existing guard at `scripts/lib/tsdown-declaration-boundary.mts:56` requires a separate physical checkout outside ancestor installations. That is outside this task's assigned-worktree restriction. No guard, dependency layout, or baseline was changed; import-cycle checking after the failed lint step was not reached.

## Known Gaps

The PR is ready and mergeable at `d7248fffa5958967934b5bce0dd2cda5732b0595`. The exact-head watcher returned GREEN for [pull-request CI run 34714051588](https://github.com/openclaw/openclaw/actions/runs/34714051588), including a successful `openclaw/ci-gate`. Its selected preflight and security checks passed; the other job lanes were skipped. This does not replace the focused regression and shard evidence above or claim a fresh browser/full-suite run.

The local nested-install declaration/lint limitation above remains recorded. No dependency layout, guard, or baseline was changed. Native prepare will verify the hosted gates before merge.

## ClawSweeper review

ClawSweeper has acknowledged the PR but has not published findings for this head. No items were applied or skipped, and no code changed during landing preparation. No re-review was requested.
