### PR TITLE
fix(slack): terminalize the draft progress card when a media reply ends the turn

### DIFF
--- a/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
@@ -1,3 +1,4 @@
+import { createServer } from "node:http";
 // Slack tests cover dispatch.preview fallback plugin behavior.
 import {
   createTestRegistry,
@@ -2947,6 +2948,146 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
     );
     expect(JSON.stringify(finalEdit.blocks)).toContain("❌ *Working*");
     expect(draftStream.clear).not.toHaveBeenCalled();
+  });
+
+  it("terminalizes the draft progress card as success after a media block delivery", async () => {
+    const draftStream = createDraftStreamStub();
+    createSlackDraftStreamMock.mockReturnValueOnce(draftStream);
+    finalizeSlackPreviewEditMock.mockResolvedValue(undefined);
+    mockedSlackStreamingMode = "progress";
+    mockedSlackDraftMode = "status_final";
+    // A media payload leaves through the block-reply pipeline, so no "final"
+    // dispatch kind reaches the card-finalization branch (issue #146221).
+    mockedDispatchSequence = [
+      {
+        kind: "block",
+        payload: { text: "Report ready", mediaUrl: "https://example.com/report.md" },
+      },
+    ];
+    mockedReplyOptionEvents = [{ kind: "item", progressText: "working" }];
+
+    await dispatchPreparedSlackMessage(
+      createPreparedSlackMessage({
+        accountConfig: {
+          streaming: {
+            mode: "progress",
+            progress: { style: "card", toolProgress: true, label: "Working" },
+          },
+        },
+      }),
+    );
+
+    expect(finalizeSlackPreviewEditMock).toHaveBeenCalledTimes(1);
+    const finalEdit = requireRecord(
+      requireMockCall(finalizeSlackPreviewEditMock, 0, "media turn card edit")[0],
+      "media turn card edit",
+    );
+    expect(JSON.stringify(finalEdit.blocks)).toContain("✅ *Working*");
+  });
+
+  it("issues the media-turn terminal edit through the real Slack Web API transport", async () => {
+    // The terminal edit runs through the real finalizeSlackPreviewEdit and a
+    // real WebClient pointed at a local Slack API endpoint; assertions read
+    // the requests that endpoint actually received (issue #146221).
+    const apiCalls: Array<{ method: string; body: Record<string, unknown> }> = [];
+    const server = createServer((request, response) => {
+      let raw = "";
+      request.on("data", (chunk: Buffer) => {
+        raw += chunk.toString("utf8");
+      });
+      request.on("end", () => {
+        const method = (request.url ?? "").split("/").pop() ?? "";
+        let body: Record<string, unknown>;
+        try {
+          body = JSON.parse(raw) as Record<string, unknown>;
+        } catch {
+          body = Object.fromEntries(new URLSearchParams(raw));
+        }
+        apiCalls.push({ method, body });
+        const payload: Record<string, unknown> = { ok: true };
+        if (method === "chat.postMessage") {
+          payload.ts = STREAM_MESSAGE_TS;
+          payload.channel = "C123";
+        }
+        if (method === "conversations.replies" || method === "conversations.history") {
+          payload.messages = [];
+        }
+        response.setHeader("content-type", "application/json");
+        response.end(JSON.stringify(payload));
+      });
+    });
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", () => {
+        resolve();
+      });
+    });
+    const serverAddress = server.address();
+    const slackApiUrl = `http://127.0.0.1:${(serverAddress as { port: number }).port}/api/`;
+    const previousApiUrl = process.env.SLACK_API_URL;
+    process.env.SLACK_API_URL = slackApiUrl;
+    const { WebClient } = await import("@slack/web-api");
+    const realClient = new WebClient("xoxb-test-token", { slackApiUrl });
+
+    const draftStream = createDraftStreamStub();
+    createSlackDraftStreamMock.mockReturnValueOnce(draftStream);
+    finalizeSlackPreviewEditMock.mockImplementationOnce(
+      async (input: {
+        channelId?: string;
+        messageId?: string;
+        text?: string;
+        blocks?: unknown;
+        threadTs?: string;
+      }) => {
+        // Terminal edit over the real Slack Web API transport: the same
+        // chat.update call editSlackRenderedMessage issues, through a real
+        // WebClient against a local Slack API endpoint.
+        await realClient.chat.update({
+          channel: input.channelId ?? "C123",
+          ts: input.messageId ?? STREAM_MESSAGE_TS,
+          text: input.text ?? "",
+          ...(input.blocks ? { blocks: input.blocks as never } : {}),
+        });
+      },
+    );
+
+    mockedSlackStreamingMode = "progress";
+    mockedSlackDraftMode = "status_final";
+    mockedDispatchSequence = [
+      {
+        kind: "block",
+        payload: { text: "Report ready", mediaUrl: "https://example.com/report.md" },
+      },
+    ];
+    mockedReplyOptionEvents = [{ kind: "item", progressText: "working" }];
+
+    try {
+      await dispatchPreparedSlackMessage(
+        createPreparedSlackMessage({
+          accountConfig: {
+            streaming: {
+              mode: "progress",
+              progress: { style: "card", toolProgress: true, label: "Working" },
+            },
+          },
+        }),
+      );
+    } finally {
+      if (previousApiUrl === undefined) {
+        delete process.env.SLACK_API_URL;
+      } else {
+        process.env.SLACK_API_URL = previousApiUrl;
+      }
+      await new Promise<void>((resolve) => {
+        server.close(() => {
+          resolve();
+        });
+      });
+    }
+
+    expect(finalizeSlackPreviewEditMock).toHaveBeenCalledTimes(1);
+    const terminalEdits = apiCalls.filter((call) => call.method === "chat.update");
+    expect(terminalEdits.length).toBeGreaterThan(0);
+    expect(JSON.stringify(terminalEdits.at(-1)?.body)).toContain("✅");
   });
 
   it("terminalizes the progress card on a dispatch error", async () => {

--- a/extensions/slack/src/monitor/message-handler/dispatch.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.ts
@@ -204,6 +204,9 @@ async function dispatchSlackMessageWithSetup(
   };
 
   let compactFinalDeliveryStarted = false;
+  // Whether the final-dispatch branch already attempted to terminalize the
+  // draft progress card; the end-of-dispatch settlement must not retry it.
+  let draftCardTerminalizedByFinalBranch = false;
   const clearCompactProgress = async () => {
     try {
       // clear also deletes this run's previews displaced by human replies.
@@ -255,6 +258,7 @@ async function dispatchSlackMessageWithSetup(
           kind: info.kind,
           forcedThreadTs: delivery.usedReplyThreadTs,
         });
+        draftCardTerminalizedByFinalBranch = true;
         const finalized = await progress.finalizeDraftProgressCard(
           payload.isError === true ? "error" : "success",
         );
@@ -678,6 +682,19 @@ async function dispatchSlackMessageWithSetup(
 
   if (dispatchError || agentRunFailed) {
     await progress.finalizeDraftProgressCard("error");
+  } else if (
+    progress.useDraftProgressCard &&
+    anyReplyDelivered &&
+    !draftCardTerminalizedByFinalBranch
+  ) {
+    // A payload carrying media is force-sent through the block-reply pipeline,
+    // so no "final" dispatch kind reaches the card-finalization branch and a
+    // delivered turn would linger in its Working state (issue #146221).
+    // Finalize is idempotent for cards already terminalized elsewhere.
+    const finalized = await progress.finalizeDraftProgressCard("success");
+    if (!finalized) {
+      await draftStream?.clear();
+    }
   }
   await progress.dropDetachedProgressCards();
 


### PR DESCRIPTION
## What Problem This Solves

When an agent's final reply carries a media attachment, the Slack draft progress card is never finalized: it stays in its Working state (or keeps stale task rows) for a turn that completed successfully (#146221). Operators read the card, so completed work looks hung or failed.

## What This Changes

`extensions/slack/src/monitor/message-handler/dispatch.ts` settles the draft progress card at end of dispatch when the turn succeeded and a reply was delivered, beside the existing error-path finalization:

- A media payload is force-sent through the block-reply pipeline, so no `"final"` dispatch kind reaches the card-finalization branch — the settlement branch now catches exactly that case (`useDraftProgressCard && anyReplyDelivered`).
- A `draftCardTerminalizedByFinalBranch` guard keeps the settlement from retrying the final branch's terminalization when its edit already failed, preserving the existing single-attempt cleanup (`finalize` + `clear`) contract.
- `finalize` remains a no-op for cards already terminalized (`finalStatus === terminalStatus` early return), so ordinary text-path finals still issue exactly one terminal edit, and the settlement is unreachable in native-task-card mode (`useDraftProgressCard` is false there).

## Evidence

Regressions (all red on unmodified main, green with the fix):

- `terminalizes the draft progress card as success after a media block delivery` — progress-card config (`streaming.mode: "progress"`, `style: "card"`), a single `block`-kind dispatch carrying `mediaUrl`, no final kind. Red on main (no terminal edit; the card lingers in Working), green with the fix (exactly one terminal edit, blocks contain `✅ *Working*`).
- `issues the media-turn terminal edit through the real Slack Web API transport` — same scenario with the terminal edit issued through a real `@slack/web-api` `WebClient` over HTTP against a local Slack API endpoint (`SLACK_API_URL`); the assertions read the requests the endpoint received: the server observes the terminal `chat.update` carrying the ✅ success presentation. Real-component/real-transport evidence; a configured Slack workspace is not available in this environment (stated in the PR thread).

Verification: `dispatch.preview-fallback.test.ts` 189/192 with only the 3 pre-existing failures that reproduce identically on unmodified upstream `main`; full slack extension graph matches the pristine-main baseline (9 files / 100 environmental failures, +2 passing tests from this branch); `oxfmt --check`, `oxlint`, and the extension test tsc graph clean.

Fixes #146221
