### PR TITLE
docs: mirror v2026.9.4 release notes in the changelog

### DIFF
--- a/CHANGELOG/2026.9.4.md
+++ b/CHANGELOG/2026.9.4.md
@@ -1,9 +1,11 @@
-<!-- openclaw-docs-mirror-v1 {"version":"2026.9.4","sources":["docs/releases/2026.9.4.md"],"sourceDigest":"sha256:42c3d7b5651626b945eb83dcad7e3beb8179b4b1889733fc5b59363fc280f3c1"} -->
+<!-- openclaw-docs-mirror-v1 {"version":"2026.9.4","sources":["docs/releases/2026.9.4.md"],"sourceDigest":"sha256:4063f732546593f79619fbe1eda330fbc14d4e38efcce398e4a713ec5ab72176"} -->
 
 ## 2026.9.4
 
 
 ### v2026.9.4
+
+**Reading formats:** [Release notes for readers](https://docs.openclaw.ai/releases/2026.9.4) · [Plain Markdown for AI agents and tools](https://raw.githubusercontent.com/openclaw/openclaw/main/CHANGELOG/2026.9.4.md).
 
 OpenClaw 2026.9.4 makes plugins and skills easier to find, and lets you turn past conversations into reusable skills through a chat you can steer.
 

--- a/CHANGELOG/2026.9.4.md
+++ b/CHANGELOG/2026.9.4.md
@@ -1,1252 +1,5334 @@
+<!-- openclaw-docs-mirror-v1 {"version":"2026.9.4","sources":["docs/releases/2026.9.4.md"],"sourceDigest":"sha256:42c3d7b5651626b945eb83dcad7e3beb8179b4b1889733fc5b59363fc280f3c1"} -->
+
 ## 2026.9.4
 
-### Highlights
 
-- **Recover from compatible failed updates:** retain the previous package and restore it with the previous configuration and service when schema and configuration checks prove rollback is safe; database migrations still require a verified pre-update backup. (#140339) Thanks @fuller-stack-dev.
-- **Plugins in one place:** discover bundled and ClawHub plugins, install them from the Control UI, and manage their setup, settings, and access in a unified Plugins workspace. (#135839, #135840, #139042, #137659, #137886, #138755, #142624, #142782) Thanks @Patrick-Erichsen.
-- **Prepared cloud sessions:** start eligible Linux sessions from prepared local projects or public GitHub repositories, and build reusable snapshots from the Control UI before starting a conversation. (#143227, #143372, #143410, #143838, #143929)
-- **Answer questions in the terminal:** use keyboard-driven choices, free-text answers, and multi-question prompts in both Gateway-connected and local TUI sessions. (#143273)
-- **GPT Image 2.5:** select the new Flare and Sunburst variants for image generation and editing through OpenAI or fal without changing your existing default model. Related #143007. (#143068, #143069) Thanks @vincentkoc.
-- **More dependable conversation history:** recover final replies after interrupted streams, retain timeout notices after reload, and prevent duplicate final answers when live chat hands off to saved history. Related #141839. (#142168, #142135, #142422) Thanks @LiuwqGit, @obviyus, @chelsealong, @von8794, and @jalehman.
-- **Voice that finishes delegated work:** return subagent results to Talk and deliver the final answer even after repeated rounds of delegation. (#129535, #142830) Thanks @vincentkoc.
-- **Externally managed configuration:** set `OPENCLAW_CONFIG_READONLY=1` to keep OpenClaw from rewriting deployment-managed configuration while preserving read-only diagnostics and ordinary runtime state. Related #140706. (#140719) Thanks @sallyom.
+### v2026.9.4
 
-### Changes
+OpenClaw 2026.9.4 makes plugins and skills easier to find, and lets you turn past conversations into reusable skills through a chat you can steer.
 
-- **Rollback and recovery:** eligible schema-neutral update failures restore the retained package, command shim, service, and pre-activation configuration, then verify the previous Gateway again. Changed database schemas, incompatible new databases, or intervening operator configuration edits block automatic rollback; a recovered update remains a failed update with a recorded rollback outcome. Use a [verified backup](https://docs.openclaw.ai/install/updating/rollback-and-recovery) before migration-bearing upgrades. (#140339) Thanks @fuller-stack-dev.
-- **Plugin organization:** browse installed plugins by category, keep detail tabs together, use short plugin-page URLs such as `/reports`, and discover installed and ClawHub skills through one search. (#142710, #142711, #142712, #142713, #143183, #143758) Thanks @Patrick-Erichsen.
-- **Cloud ready workers:** eligible local Git projects and public GitHub repository sessions can reuse prepared workers without repeating setup; private repository-only sessions and paired devices remain outside this preparation flow. The default reserve target is one per project/profile, capped at four Gateway-wide. Ready workers incur provider running-machine charges until deleted. Set `cloudWorkers.profiles.<id>.readyWorkers` or `cloudWorkers.preparedPool.maxTotal` to zero to disable the corresponding reserves. See [warm images and ready workers](https://docs.openclaw.ai/gateway/cloud-workers/warm-images#ready-workers). (#143227, #143372, #143410)
-- **Terminal question controls:** navigate choices with arrows or numbers, type an Other answer, toggle multi-select choices, and reopen a pending prompt with `/question`; local-mode questions last only for the running TUI process. (#143273)
-- **Chat navigation and composition:** use a compact left-side conversation rail with sender identities in shared-chat previews, add selected text to the main composer, and preview attached videos before sending. Related #142207, #142592, #143473. (#142227, #143486, #142543, #142623) Thanks @vyctorbrzezowski and @Patrick-Erichsen.
-- **Skill learning:** open learning from past work in a normal session that you can inspect and continue. (#142909) Thanks @obviyus.
-- **Command review:** let the automatic command reviewer allow, deny, or escalate a command using bounded conversation context while retaining the execution policy's authority. (#141987, #142279)
-- **Node runtime recovery:** offer a Node.js update when the CLI runtime is incompatible and keep diagnostics and update commands available to help repair the installation. (#142742, #143344) Thanks @jason-allen-oneal and @morrow-bluedot.
-- **Read-only deployments:** honor host-owned `OPENCLAW_CONFIG_READONLY=1` across configuration writes, setup, Doctor repairs, plugin changes, and updates; read-only configuration commands continue to work, and this mode does not make runtime state read-only. Related #140706. (#140719) Thanks @sallyom.
-- **Upcoming SDK deprecation:** `agent-harness-credential-prompt-string-argument` entered deprecation on September 9, 2026; the legacy string argument to `buildCredentialSafetyPrompt` remains supported through November 30, 2026; plugin authors should pass `{ controlToolsAvailable }`. See [credential prompt migration](https://docs.openclaw.ai/plugins/sdk-migration/removed-surfaces#credential-prompt-builder). Related #128076. (#143238) Thanks @ejc3.
-- **SDK context compatibility:** `sdk-untrusted-context-identifier-aliases` reached its September 8, 2026 removal date but remains `removal-pending`; retain the deprecated untrusted-named context aliases while published plugin readers migrate to the channel-named replacements; removal remains pending migration verification and explicit breaking-release acceptance. See [plugin compatibility](https://docs.openclaw.ai/plugins/compatibility). (#142708)
-- **Cloud snapshot controls:** build, rebuild, inspect, pin, delete, and roll back supported cloud-worker snapshots from Settings → Connections → Cloud workers → Snapshots. Active builds can be canceled with confirmation; held or pinned images remain protected. Snapshot storage and ready-worker charges still apply. (#143814, #143838, #143893, #143929)
-- **Cloud placement and diagnostics:** edit advanced worker profiles and repository defaults, inspect cloud-session machine specifications, and select native Windows workers when the backend supports them. Warm images and desktops remain Linux-only. (#143801, #143864, #143769, #143798)
-- **Deepgram voice notes:** transcribe voice notes with `flux-general-en` or `flux-general-multi` through Deepgram Flux; these models require `ffmpeg`. See [Flux configuration](https://docs.openclaw.ai/providers/deepgram#flux-models). Related #129452. (#141836) Thanks @obviyus and @safzanpirani.
-- **Slow session diagnostics:** identify the work holding a session lifecycle queue and see which artifact-cleanup preparation stage is taking time. Related #143885, #143939. (#143886, #143942)
+It also adds GPT Image 2.5 support, more control over cloud sessions, and interactive questions in the terminal, alongside fixes for updates, memory, and messaging.
 
-### Fixes
+**Release scale:** 1,558 pull requests, 20 direct commits, and 294 contributors.
 
-- **Access and content boundaries:** preserve existing WhatsApp group allowlists during security repairs, continue blocking cloud-metadata addresses when private IPv6 exceptions are enabled, bound Slack HTTP request bodies, and restrict Tlon citation retrieval to the cited post. Reject stale signed Feishu webhook callbacks, prevent attachment reads from sibling agent sandboxes, and stop pipelined MCP calls after a rejected upload. Related #107972. (#142589, #137684, #136508, #142041, #143484, #143521, #143724) Thanks @eleqtrizit, @drobison00, @pgondhi987, and @yetval.
-- **Workspace and backup safety:** preserve concurrent workspace edits, include required external configuration files in full backups, keep private update captures out of ordinary exports even after they move, and tolerate a disappearing live SQLite sidecar after its database is snapshotted. Related #141042, #143678. (#135865, #141161, #143693, #143799, #143899) Thanks @yetval, @obviyus, @LiuwqGit, @Cobblestone-Digital1, and @fuller-stack-dev.
-- **Migration recovery:** recover markerless multi-agent configurations, leave ambiguous Skill Workshop migrations available for review, explain hard-linked session migration refusals, and preserve normalized media when republishing migrated archives. Retain legacy Codex assistant messages during session SQLite import and repair the dangling Workshop review index. Related #142582, #142585, #143094, #142584, #143593, #140100. (#143202, #143141, #143195, #143595, #140296, #142522) Thanks @GitHoubi, @fahrenhe1t, @fuller-stack-dev, @ylcn91, @ikenraf, @jjjhenriksen, @RomneyDa, and @pash-openai.
-- **Doctor and authentication:** preserve source state during full lint, keep saved authentication profiles aligned during migration, scope legacy auth-profile refusals to affected providers, recover legacy node tokens with invalid scopes, and prevent stale shared OAuth refresh generations from overwriting newer credentials. Restore Zalo User policy promotion and stop Moonshot China setup from repeatedly reinstalling its provider. Related #143173, #143263, #143865, #143630. (#142839, #143310, #143599, #141477, #143429, #143860, #143742) Thanks @thien-ngn, @obviyus, @tskerpnext, @matthewmoroz, @vincentkoc, @wangmiao0668000666, and @zwyhmcn.
-- **Reply delivery and history:** recover final replies from terminated streams and earlier tool errors, retain partial failed-turn text and timeout outcomes, preserve paragraph and code-block boundaries, and report truncated Responses replies as incomplete. Preserve long transcript history across `sessions_yield`, avoid duplicate final replies during history hydration and duplicate user turns after Claude CLI resume, and retain final ChatGPT Responses frames at stream end. Related #141839, #132762, #143641. (#142168, #142135, #140833, #142778, #137381, #142422, #143598, #125977, #143722, #143960, #120902) Thanks @LiuwqGit, @obviyus, @chelsealong, @von8794, @leapdragon, @zhangguiping-xydt, @jalehman, @harjothkhara, @CK-XYZ, @ayaangazali, @rgregg, @Marvinthebored, @Peetiegonzalez, and @zenglingbiao.
-- **Chat continuity:** keep submitted images visible during history handoff, prevent cold-session switching flashes, and reconcile concurrent session updates consistently. (#143407, #134868, #143049) Thanks @jesse-merhi.
-- **Claude CLI session reuse:** keep warm sessions alive when skills-watcher readiness changes but prepared skill content is unchanged, while invalidating reuse after real skill-content changes. Related #144368. (#144402) Thanks @vincentkoc.
-- **Voice conversations:** deliver yielded and repeatedly delegated results, permit independent voice consultations from model-locked requester sessions, and truncate interrupted realtime audio at the amount actually played. Related #142483, #138592. (#129535, #142830, #142736, #138619) Thanks @vincentkoc, @RileyJJY, @jai-assistant, @LiuwqGit, @obviyus, and @fabiolr.
-- **Telegram:** retain replies when an HTTP proxy rejects its tunnel, recognize bot-ID mentions in text and photo captions, preserve code-example spacing, and stop late stall reactions after preparation is canceled. Related #140265, #141078. (#140388, #140266, #142504, #141079) Thanks @Hekzory, @obviyus, @cai-ops, and @ooiuuii.
-- **Discord:** restore delegation from guild messages, preserve ambient voice-note transcripts, show member presence immediately after reconnect, and retain repeated component captions and link emoji. Related #142832, #141054. (#143006, #142860, #141218, #142342) Thanks @Marvinthebored, @Peetiegonzalez, @obviyus, @ericcaiwx-star, @aatreya, @harshitgupta31415, @vincentkoc, and @nissl24.
-- **Slack:** resolve Enterprise workspace ownership for heartbeat DMs, keep acknowledgement reactions independent of status reactions, and avoid formatting ordinary prose as code after Windows root paths. Related #142489. (#138689, #142595, #142288) Thanks @Kimiyu-186, @sunlit-deng, and @alexjpanagis.
-- **Mattermost and Signal:** keep sibling Mattermost accounts connected during secret-reference reloads, preserve replacement previews while retracting earlier messages, and retain Signal reply quotes when streamed delivery fails. (#142193, #143621, #142600) Thanks @ceckert and @obviyus.
-- **Channel text fidelity:** preserve unknown Matrix message text and escaped mentions, decode HTML-only Teams messages correctly, retain Feishu rich-text styles and unrelated tools, and keep outbound WhatsApp response prefixes out of inbound messages. Related #140971, #138779. (#135359, #142369, #142496, #142627, #141984, #138819) Thanks @teddytennant, @obviyus, @SunnyShu0925, @hayden-cc, @sunlit-deng, @vincentkoc, and @Jackten.
-- **Android chat and folding screens:** wait for picked attachments before sending their captions, restore completed tool activity, distinguish connection state from chat readiness, and keep thinking controls, background tasks, and the branch picker inside their fold panes. Related #142805. (#143162, #142810, #143128, #141860, #141899, #142418) Thanks @ansxor, @IWhatsskill, and @vincentkoc.
-- **Mobile connection feedback:** show failures and recovery for unreachable Gateways and report battery fractions as the intended percentage. Related #141066. (#142651, #141069) Thanks @vincentkoc, @NullArbitrage, and @obviyus.
-- **Provider and model selection:** preserve authored catalog rows, exact model identities, metadata, and credentials when aliases coexist or catalogs refresh. Keep model overrides, context limits, thinking choices, vision, compaction, and tool inventories tied to the selected model and provider; hide unsupported thinking or Fast choices and preserve session lists after fallback. (#142302, #142898, #142751, #142790, #142646, #142682, #143337, #143643, #143686, #143708, #143777, #143780, #143822, #143848, #143872, #143954, #143967, #143975, #143994, #143999, #144009, #144010, #144034, #144060, #144107, #142822) Thanks @obviyus.
-- **Provider requests:** preserve Anthropic prompt-cache reuse across transient runtime context, treat Kimi quota exhaustion as a rate limit rather than an authentication failure, preserve managed Responses session affinity, and recover supported malformed streamed tool arguments and silent tool rejections. Related #140607, #142524, #140918, #135111. (#140621, #142656, #141107, #141323, #142176) Thanks @LightningWareLLC, @RileyJJY, @obviyus, @rico007, @louisfy, @alexph-dev, @lraesly, and @1Vision365-PeterTijsma.
-- **Memory:** use the selected fallback provider’s embedding model and index status, observe external LanceDB writes, and retain recall through trigger timeouts. Keep top search results stable as result limits change, give managed local embedding startup its own readiness budget, honor bounded provider cooldowns, require real query diversity for promotion, and skip unnecessary recall for inter-session deliveries. Preserve first-run setup after empty dreaming and bound pre-compaction flush context while recording when no memory-write tool exists. Related #137805, #142479, #141787, #143188, #134604, #143169, #108893, #143821. (#142364, #142609, #137806, #142567, #141808, #143193, #127031, #136984, #143590, #134959, #119624, #143903) Thanks @Yigtwxx, @obviyus, @azuretek, @ylcn91, @BsnizND, @SunnyShu0925, @dh-js, @KirDE, @ayaangazali, @linhongyu510, @scottcha, @wangmiao0668000666, @PeterHodl, @shojikumaru, @developercrocodiles, @pcpilot-dev, @LiuwqGit, and @kiagentkronos-cell.
-- **Update handoff and restart:** keep older updaters and Git installs upgrading from 2026.9.1 able to restart the Gateway; accept shipped 2026.9.2/2026.9.3 service handoffs without weakening current service-owner checks. Preserve pnpm-generation handoff and schema-upgrade restart intent, prepare managed helper schemas before readiness, replace unsupported service Node runtimes, retain restored-version verification, and prevent systemd restart hangs. Related #143204, #140821, #143543. (#142195, #142631, #143137, #143159, #142817, #140914, #143859, #143738, #144031) Thanks @jason-allen-oneal, @wangmiao0668000666, @NianJiuZst, @obviyus, @rboy1, @RomneyDa, and @IWhatsskill.
-- **Plugin updates:** converge the plugin cohort when core is already current without turning unchanged installations into needless updates, retain bundled aliases during rehearsal, avoid false Memory Core migration refusals, and explain retained official plugin pins. (#143174, #143462, #143190, #143138, #142457) Thanks @RomneyDa, @PollyBot13, and @obviyus.
-- **CLI update and transcript reliability:** allow updates when native inspection confirms no installed Gateway service, while retaining strict service-owner checks; keep transcript plaintext and JSON output free of unrelated startup warnings. Related #144356, #144357. (#144402) Thanks @vincentkoc.
-- **Update recovery feedback:** allow long Doctor finalization to finish, clear orphaned update runs instead of showing permanent progress, retain cleanup outcomes and recoverable warnings, and avoid linking unavailable reports. Preserve diagnostics when history is unavailable and require confirmation before automatic triage launches a coding agent; verified rollback follow-up actions remain opt-in. Related #139714. (#143321, #143557, #143139, #143774, #143767, #143844, #143921, #143965, #143748, #143657) Thanks @fuller-stack-dev and @Colton-Harris.
-- **Gateway responsiveness:** move cold history planning, integrity checks, and archive pruning off the main thread; keep prepared updates and post-eviction maintenance responsive; reduce memory spikes when inspecting long sessions. Reduce unused plugin and model catalog preparation, bound parallel remote workspace hashing, avoid unnecessary diagnostic copies, and keep automation delivery previews responsive. (#143332, #143226, #143379, #143434, #143602, #143175, #143783, #143846, #144095, #144017, #144109, #144014)
-- **Session retention:** stop excess cleanup once disk pressure clears, preserve history that becomes protected during cleanup, and avoid premature daily resets around daylight-saving gaps. (#143285, #142505, #142482)
-- **Browser actions:** keep existing browser sessions from timing out prematurely, preserve newer pending dialogs when older actions settle, report blocked or interrupted CLI actions, and leave browser focus intact during passive following. (#143365, #142608, #142480, #134480) Thanks @scotthuang and @obviyus.
-- **Settings and sign-in:** preserve settings drafts after deleting array rows, make agent automations editable from Settings, and request the Gateway token when a remembered device token is stale. Related #139781. (#142564, #139782, #143156) Thanks @jjjhenriksen and @vyctorbrzezowski.
-- **Plugin and skill installation:** prevent installed-plugin matches across different ClawHub registries, report newer releases for pinned installs, recover capability-consent dead ends, and retain bundled trust for development-path installs. Preserve plugin selection and restart progress, rank official catalog results consistently, refresh skill snapshots on Gateway restart, and avoid cutting off skill installation after two minutes. Related #137624, #143111, #122107. (#143644, #137892, #143125, #143516, #143000, #143671, #143730, #143731, #122110) Thanks @pfrederiksen, @vincentkoc, @LiuwqGit, @obviyus, @yxloveql, @RomneyDa, @gozu, @Patrick-Erichsen, and @sappkevin.
-- **Paired devices and Linux:** expose window discovery on the first computer action, preserve activation and observation results, open chat desktops on their assigned machines, and identify who took desktop control. Honor SSH alias ports, retain remote credential references on reconnect, and keep background-update results actionable. Related #121934. (#141277, #142900, #142907, #121938, #143736, #143953, #143831, #143828) Thanks @oywino, @obviyus, and @vincentkoc.
-- **Plugin schema typing:** preserve catchall input and output types, including transformations, in multi-account channel schemas. Related #144358. (#144402) Thanks @vincentkoc.
-- **Doctor update finalization:** allow implicit Codex preferences when the plugin is absent while retaining errors for explicitly required runtimes; finish configuration-less updates without creating a configuration file; close only Doctor’s private snapshot database before cleanup, leaving the source database open. Related #143786, #143797, #138260. Thanks @osipovia.
-- **Delegation and reset:** keep background completion wakes alive after a foreground reply, preserve subagent history when a parent thread changes, show full subagent transcripts in the task sidebar, and keep session resets responsive while stopping yielded child work. Canceled automations release their pending result waits. Related #143389. (#143866, #143869, #143747, #143916, #143832) Thanks @obviyus, @aleps001, and @pash-openai.
-- **Provider routing and search:** preserve stable routing identities for standalone OpenCode and OpenCode Go turns, retain provider turn headers for explicit sessions, preserve local-model request prefixes, and keep Gemini web search available with new API keys. Global web-search disable remains effective in session controls. Related #137257, #96974, #121401. (#143659, #143558, #143890, #137371, #111964, #121557) Thanks @HAPPYFAPTAIN, @obviyus, @RomneyDa, @vincentkoc, @gwiltschek, @dillona, @anguslogan01, @zyw02, and @cursoragent.
-- **Update ownership and cloud continuity:** stop plugin persistence and rollback actions after updater authority is lost, reject unverified Gateway replacements, preserve cloud machines across Gateway updates, and continue submitted turns across worker-runtime updates. Related #143750, #143841. (#144130, #143791, #143863, #143858, #143910) Thanks @fuller-stack-dev and @vincentkoc.
-- **Runtime and state diagnostics:** re-execute the CLI under an available supported Node runtime before refusing to start, preserve the selected Bun SQLite library in managed services, retain macOS launchd error logs, restore Linux Bun CPU diagnostics, and tolerate transient locks during read-only state access. Schema-drift failures name the repair path. Related #90711, #143800. (#143464, #143651, #142186, #143519, #143805, #143908, #143531) Thanks @RomneyDa, @Enominera, and @pash-openai.
-- **Control UI recovery:** restore Send when Stop finds an already-finished run, retain terminal sessions after interrupted restoration, report failed Review file opens, stop stale task reads after Review changes, and keep session files and embedded reports from being squeezed into nested scrolling regions. Related #143356, #143971. (#143437, #144015, #143958, #144073, #143854, #143765) Thanks @ylcn91, @obviyus, @YanHE1169, @vincentkoc, @Marvinthebored, and @Peetiegonzalez.
-- **Tool and export fidelity:** preserve flat tool arguments beside empty search wrappers, keep native image-generation hooks available, retain paginated read evidence in trajectory exports, and report the actual filesystem error when workspace writes fail. Related #143830, #115920. (#143729, #143717, #143930, #116378) Thanks @xydigitLybnnnn, @obviyus, @linhongyu510, @cp1369, @sloptop-the-terrible, and @609NFT.
+#### Installation and Onboarding
 
-### Complete contribution record
+OpenClaw can help you get past a Node version problem without replacing your computer's existing Node installation. New-agent setup also works with securely saved API keys, and the instructions for connecting a phone or removing OpenClaw now fill in steps that were missing.
 
-This audited record covers the complete 58fcf69cadd0be59ecee41b21b655f195ccda7b2..0b7ddbd9c5e97a82b6bd7a36daa8dcff984d338d history: 1,174 in-range PRs + 0 retained seed-only PRs = 1,174 unique PRs. The generation manifest also supplies direct commits as editorial input; the grouped notes above prioritize user impact.
 
-Shipped baseline exclusions: v2026.9.3 (19 PRs: #111451, #120728, #121140, #129636, #131475, #132740, #133652, #134290, #134400, #135043, #139089, #139196, #139393, #139722, #140263, #140274, #140672, #140803, #141055).
 
-#### Pull requests
 
-- **PR #142314**
-- **PR #137684** Thanks @eleqtrizit.
-- **PR #142311**
-- **PR #142288**
-- **PR #142230**
-- **PR #142290**
-- **PR #111899** Related #111407. Thanks @xialonglee and @obviyus and @MrNozz.
-- **PR #142302** Thanks @obviyus.
-- **PR #142318** Related #142244.
-- **PR #142346**
-- **PR #142339** Related #142330. Thanks @vyctorbrzezowski.
-- **PR #142305**
-- **PR #142360** Thanks @vincentkoc.
-- **PR #142291**
-- **PR #142365**
-- **PR #142187**
-- **PR #142361**
-- **PR #141266** Thanks @vincentkoc.
-- **PR #142359** Related #142351.
-- **PR #142334**
-- **PR #142342**
-- **PR #142324**
-- **PR #142363** Related #142362.
-- **PR #142366**
-- **PR #142195**
-- **PR #137565** Thanks @jalehman.
-- **PR #135411**
-- **PR #142274** Related #142211. Thanks @vyctorbrzezowski.
-- **PR #129186** Thanks @vincentkoc.
-- **PR #137686** Thanks @ly85206559 and @obviyus.
-- **PR #141689** Thanks @vincentkoc and @RomneyDa.
-- **PR #142378** Thanks @RomneyDa.
-- **PR #142354**
-- **PR #142042** Thanks @RomneyDa.
-- **PR #138350** Thanks @vyctorbrzezowski.
-- **PR #142376**
-- **PR #142385**
-- **PR #142327**
-- **PR #142353** Thanks @RomneyDa.
-- **PR #142114**
-- **PR #142369**
-- **PR #141477** Thanks @vincentkoc.
-- **PR #142381**
-- **PR #142205** Related #142204.
-- **PR #142344** Thanks @RomneyDa.
-- **PR #136508** Thanks @drobison00.
-- **PR #142246** Related #142222. Thanks @vyctorbrzezowski.
-- **PR #142348** Thanks @RomneyDa.
-- **PR #138689** Thanks @Kimiyu-186.
-- **PR #142379** Thanks @vincentkoc.
-- **PR #141221** Thanks @vincentkoc.
-- **PR #142345** Thanks @vincentkoc.
-- **PR #142388**
-- **PR #142332** Related #142212. Thanks @vyctorbrzezowski.
-- **PR #142384** Thanks @obviyus.
-- **PR #142367** Thanks @obviyus.
-- **PR #142411**
-- **PR #137668** Related #137665. Thanks @elbourne12345 and @obviyus.
-- **PR #127254**
-- **PR #142213** Related #142209. Thanks @vyctorbrzezowski.
-- **PR #142396**
-- **PR #142400** Related #142598. Thanks @hannesrudolph.
-- **PR #142374** Related #142373.
-- **PR #142402** Related #142397.
-- **PR #142420**
-- **PR #141224** Thanks @vincentkoc.
-- **PR #141860** Thanks @vincentkoc.
-- **PR #142350**
-- **PR #142437** Related #142598. Thanks @hannesrudolph.
-- **PR #142135** Related #141839. Thanks @chelsealong and @obviyus and @von8794.
-- **PR #142227** Related #142207. Thanks @vyctorbrzezowski.
-- **PR #142425** Thanks @vincentkoc.
-- **PR #142138** Thanks @fabiolr and @obviyus.
-- **PR #142415**
-- **PR #141987**
-- **PR #142431** Thanks @RomneyDa.
-- **PR #142407** Thanks @RomneyDa.
-- **PR #142410** Thanks @RomneyDa.
-- **PR #142409** Thanks @RomneyDa.
-- **PR #142084** Thanks @RomneyDa.
-- **PR #142083** Thanks @RomneyDa.
-- **PR #142082** Thanks @RomneyDa.
-- **PR #142408** Thanks @RomneyDa.
-- **PR #142081** Thanks @RomneyDa.
-- **PR #142387** Related #142386.
-- **PR #138211** Related #138176.
-- **PR #142432** Thanks @vincentkoc.
-- **PR #136462** Thanks @RomneyDa.
-- **PR #142406**
-- **PR #142371**
-- **PR #142391** Related #142390.
-- **PR #137877** Thanks @teddytennant and @obviyus.
-- **PR #142451**
-- **PR #142448** Thanks @vincentkoc.
-- **PR #142405** Thanks @vincentkoc.
-- **PR #142455** Related #142454.
-- **PR #117631**
-- **PR #142404** Related #142403.
-- **PR #142413** Related #142412.
-- **PR #142458**
-- **PR #137869** Related #128928. Thanks @teddytennant and @obviyus and @aniruddhaadak80.
-- **PR #142466**
-- **PR #142279**
-- **PR #142436**
-- **PR #141162** Thanks @vincentkoc.
-- **PR #142460**
-- **PR #142375** Thanks @obviyus.
-- **PR #142440**
-- **PR #142467** Thanks @RomneyDa.
-- **PR #142447** Related #142446.
-- **PR #141725** Related #141694. Thanks @leilei3167 and @obviyus and @markthebest12.
-- **PR #142469** Related #142468.
-- **PR #142423**
-- **PR #140719** Related #140706. Thanks @sallyom.
-- **PR #137974** Related #137959. Thanks @SunnyShu0925 and @obviyus and @Hawk5150.
-- **PR #142465**
-- **PR #142428** Thanks @RomneyDa.
-- **PR #142441** Thanks @RomneyDa.
-- **PR #142472** Thanks @RomneyDa.
-- **PR #141896** Thanks @RomneyDa.
-- **PR #141899** Thanks @vincentkoc.
-- **PR #142474** Thanks @vincentkoc.
-- **PR #137806** Related #137805. Thanks @azuretek and @obviyus.
-- **PR #142450** Related #142449.
-- **PR #142495** Related #142493.
-- **PR #142503**
-- **PR #142480**
-- **PR #142364** Thanks @Yigtwxx and @obviyus.
-- **PR #142507**
-- **PR #142426** Thanks @vincentkoc.
-- **PR #142494** Thanks @vincentkoc.
-- **PR #142456** Thanks @RomneyDa.
-- **PR #142065** Thanks @RomneyDa.
-- **PR #142475** Related #142598. Thanks @hannesrudolph.
-- **PR #142444** Related #142443.
-- **PR #142275** Related #142216. Thanks @vyctorbrzezowski.
-- **PR #137664** Thanks @ly85206559 and @obviyus.
-- **PR #142499** Thanks @vincentkoc.
-- **PR #142482**
-- **PR #129610** Thanks @jalehman.
-- **PR #142419** Related #142392. Thanks @jalehman.
-- **PR #142541** Related #142598. Thanks @hannesrudolph.
-- **PR #142249** Related #142247.
-- **PR #142525**
-- **PR #142498** Thanks @obviyus.
-- **PR #142543** Thanks @Patrick-Erichsen.
-- **PR #142544** Thanks @Patrick-Erichsen.
-- **PR #142508**
-- **PR #142519**
-- **PR #142542**
-- **PR #142505**
-- **PR #142442** Thanks @jalehman.
-- **PR #142143** Thanks @IWhatsskill and @vyctorbrzezowski.
-- **PR #142551** Thanks @RomneyDa.
-- **PR #142316** Related #142254. Thanks @vyctorbrzezowski.
-- **PR #142057** Thanks @vincentkoc.
-- **PR #137679** Thanks @teddytennant and @obviyus.
-- **PR #142496**
-- **PR #142546** Related #142539.
-- **PR #142478** Related #142477.
-- **PR #142485** Thanks @eleqtrizit.
-- **PR #137678** Thanks @teddytennant and @obviyus.
-- **PR #142576**
-- **PR #142560** Thanks @vincentkoc.
-- **PR #138303** Related #138301. Thanks @vyctorbrzezowski.
-- **PR #142578** Thanks @jalehman.
-- **PR #142438** Related #126455. Thanks @jalehman and @vyctorbrzezowski.
-- **PR #142488** Related #142487.
-- **PR #142537** Thanks @RomneyDa.
-- **PR #142561** Thanks @RomneyDa.
-- **PR #142491** Related #142490.
-- **PR #142557** Thanks @obviyus.
-- **PR #142538** Thanks @RomneyDa.
-- **PR #142520** Thanks @vincentkoc.
-- **PR #142563** Thanks @RomneyDa.
-- **PR #142562** Thanks @RomneyDa.
-- **PR #142513** Related #142512.
-- **PR #142587** Thanks @vincentkoc.
-- **PR #142372** Thanks @obviyus.
-- **PR #142338** Related #142337.
-- **PR #142570** Related #142569.
-- **PR #142568**
-- **PR #130494** Related #130456. Thanks @jalehman.
-- **PR #142602**
-- **PR #142605** Thanks @vincentkoc.
-- **PR #140680** Thanks @vincentkoc.
-- **PR #142604**
-- **PR #142504**
-- **PR #142518**
-- **PR #142614**
-- **PR #142335** Related #142287. Thanks @vyctorbrzezowski.
-- **PR #142607** Thanks @vincentkoc.
-- **PR #142527**
-- **PR #142418** Thanks @vincentkoc.
-- **PR #142601** Related #142594.
-- **PR #138667** Thanks @Szqub and @obviyus.
-- **PR #142599**
-- **PR #142630**
-- **PR #142573** Thanks @RomneyDa.
-- **PR #142066** Thanks @RomneyDa.
-- **PR #142278** Related #141838. Thanks @MoerAI and @obviyus and @von8794.
-- **PR #142609** Thanks @Yigtwxx and @obviyus.
-- **PR #137485** Related #125360. Thanks @shojikumaru and @obviyus and @noelillinger.
-- **PR #142632**
-- **PR #136545** Related #136544. Thanks @TheAngryPit and @obviyus.
-- **PR #142618**
-- **PR #142612**
-- **PR #142641** Thanks @vincentkoc.
-- **PR #142276** Thanks @vincentkoc.
-- **PR #142625** Thanks @vincentkoc.
-- **PR #142643** Thanks @RomneyDa.
-- **PR #142622** Thanks @obviyus.
-- **PR #142535**
-- **PR #142629**
-- **PR #142554**
-- **PR #142648** Thanks @RomneyDa.
-- **PR #142652** Thanks @jalehman.
-- **PR #142564**
-- **PR #142589** Thanks @eleqtrizit.
-- **PR #142620** Thanks @obviyus.
-- **PR #142666** Thanks @vincentkoc.
-- **PR #142550** Related #142510. Thanks @vyctorbrzezowski.
-- **PR #142577**
-- **PR #142536** Related #142517. Thanks @vyctorbrzezowski.
-- **PR #142667** Thanks @Patrick-Erichsen.
-- **PR #142636**
-- **PR #142600**
-- **PR #141851** Thanks @vincentkoc.
-- **PR #142684** Thanks @Patrick-Erichsen.
-- **PR #141705** Thanks @fabiolr.
-- **PR #141268** Related #141264. Thanks @ooiuuii and @obviyus.
-- **PR #142555** Related #142514. Thanks @vyctorbrzezowski.
-- **PR #142422** Thanks @jalehman.
-- **PR #142669** Thanks @fuller-stack-dev.
-- **PR #142665** Thanks @vyctorbrzezowski.
-- **PR #142500**
-- **PR #142679**
-- **PR #142041** Thanks @pgondhi987.
-- **PR #142675** Thanks @fuller-stack-dev.
-- **PR #142677** Thanks @vincentkoc.
-- **PR #142540** Related #142511. Thanks @vyctorbrzezowski.
-- **PR #142672** Thanks @fuller-stack-dev.
-- **PR #142608**
-- **PR #142690**
-- **PR #142674** Thanks @jalehman.
-- **PR #142691** Related #142689.
-- **PR #142659**
-- **PR #142523** Thanks @vincentkoc.
-- **PR #142686** Thanks @RomneyDa.
-- **PR #131805** Related #86174. Thanks @jalehman and @rqlangley.
-- **PR #142627**
-- **PR #142457** Thanks @PollyBot13 and @obviyus.
-- **PR #142634** Thanks @Patrick-Erichsen.
-- **PR #142687** Thanks @RomneyDa.
-- **PR #142685** Thanks @RomneyDa.
-- **PR #142646** Thanks @obviyus.
-- **PR #142509** Thanks @RomneyDa.
-- **PR #142635**
-- **PR #142683** Thanks @RomneyDa.
-- **PR #142703** Thanks @vincentkoc.
-- **PR #142382** Related #142380. Thanks @sercada and @obviyus.
-- **PR #142696** Related #142680. Thanks @vyctorbrzezowski.
-- **PR #142645** Thanks @vincentkoc.
-- **PR #142613** Related #142596. Thanks @vyctorbrzezowski.
-- **PR #142637** Related #142615. Thanks @vyctorbrzezowski.
-- **PR #142658** Related #142650. Thanks @vyctorbrzezowski.
-- **PR #142248** Thanks @TheAngryPit and @obviyus.
-- **PR #142682** Thanks @obviyus.
-- **PR #141852** Thanks @obviyus.
-- **PR #142708**
-- **PR #141373** Thanks @nocodet888-arch and @obviyus.
-- **PR #142730** Thanks @vincentkoc.
-- **PR #142728**
-- **PR #142731** Thanks @RomneyDa.
-- **PR #142732**
-- **PR #142733**
-- **PR #142725**
-- **PR #142727** Thanks @RomneyDa.
-- **PR #142720** Related #142716. Thanks @vyctorbrzezowski.
-- **PR #142623** Related #142592. Thanks @vyctorbrzezowski.
-- **PR #137192** Related #137190. Thanks @husodrn46 and @obviyus.
-- **PR #141315** Thanks @hugenshen and @obviyus.
-- **PR #142735** Thanks @vincentkoc.
-- **PR #142729** Thanks @vincentkoc.
-- **PR #142567** Related #142479. Thanks @ylcn91 and @obviyus and @BsnizND.
-- **PR #142763**
-- **PR #142714**
-- **PR #142752** Thanks @vincentkoc.
-- **PR #142762** Thanks @vincentkoc.
-- **PR #142775** Thanks @vincentkoc.
-- **PR #138285** Related #138277. Thanks @vyctorbrzezowski.
-- **PR #142774** Thanks @vincentkoc.
-- **PR #142777**
-- **PR #142705** Related #100537. Thanks @MasterSwords1 and @obviyus and @guarismo.
-- **PR #142628** Thanks @vincentkoc.
-- **PR #142757**
-- **PR #142707**
-- **PR #142785**
-- **PR #142779** Thanks @vincentkoc.
-- **PR #142656** Related #142524. Thanks @RileyJJY and @obviyus and @rico007.
-- **PR #142651** Thanks @vincentkoc.
-- **PR #139782** Related #139781. Thanks @jjjhenriksen and @vyctorbrzezowski.
-- **PR #142780** Thanks @vincentkoc.
-- **PR #129535** Thanks @vincentkoc.
-- **PR #142787**
-- **PR #142786** Thanks @vincentkoc.
-- **PR #142790** Thanks @obviyus.
-- **PR #142766** Thanks @obviyus.
-- **PR #142795**
-- **PR #142176** Related #135111. Thanks @lraesly and @obviyus and @1Vision365-PeterTijsma.
-- **PR #142797**
-- **PR #137311** Thanks @Alix-007 and @obviyus.
-- **PR #142796**
-- **PR #142639** Related #142593. Thanks @vyctorbrzezowski.
-- **PR #142806**
-- **PR #142801**
-- **PR #142807**
-- **PR #142778** Thanks @zhangguiping-xydt and @obviyus.
-- **PR #142368** Thanks @Glucksberg and @obviyus.
-- **PR #142738**
-- **PR #142809** Thanks @vincentkoc.
-- **PR #142671** Related #142662. Thanks @vyctorbrzezowski.
-- **PR #142816**
-- **PR #142811**
-- **PR #142803** Thanks @vincentkoc.
-- **PR #131968** Related #131944. Thanks @vyctorbrzezowski and @obviyus.
-- **PR #142818**
-- **PR #142819**
-- **PR #142823** Thanks @jalehman.
-- **PR #142694** Related #142688. Thanks @vyctorbrzezowski.
-- **PR #142827** Thanks @obviyus and @ly85206559.
-- **PR #142814**
-- **PR #142824**
-- **PR #142804**
-- **PR #142833**
-- **PR #137376** Thanks @Yigtwxx and @obviyus.
-- **PR #136266** Thanks @yetval and @obviyus.
-- **PR #142830**
-- **PR #142835** Thanks @vincentkoc.
-- **PR #142837** Thanks @jalehman.
-- **PR #142834**
-- **PR #137381** Thanks @jalehman.
-- **PR #142836**
-- **PR #142845**
-- **PR #134868** Thanks @jesse-merhi.
-- **PR #142595** Related #142489. Thanks @sunlit-deng and @alexjpanagis.
-- **PR #142843**
-- **PR #135964** Thanks @qingminglong and @obviyus.
-- **PR #142840** Thanks @obviyus.
-- **PR #142855** Thanks @vincentkoc.
-- **PR #142751**
-- **PR #136268** Thanks @yetval and @obviyus.
-- **PR #142865**
-- **PR #135865** Thanks @yetval and @obviyus.
-- **PR #142581** Thanks @aim9sour.
-- **PR #142873** Thanks @obviyus.
-- **PR #142858** Thanks @vincentkoc.
-- **PR #142846** Thanks @vincentkoc.
-- **PR #142709** Related #142704. Thanks @vincentkoc.
-- **PR #141161** Related #141042. Thanks @LiuwqGit and @Cobblestone-Digital1.
-- **PR #142849** Thanks @vincentkoc.
-- **PR #142889** Thanks @vincentkoc.
-- **PR #142887**
-- **PR #142886** Thanks @vincentkoc.
-- **PR #142812** Related #142794. Thanks @fanyangCS and @obviyus.
-- **PR #142640** Thanks @vincentkoc.
-- **PR #142899**
-- **PR #142838**
-- **PR #142856**
-- **PR #142903**
-- **PR #136181**
-- **PR #142882** Thanks @vincentkoc.
-- **PR #127746** Thanks @vincentkoc.
-- **PR #142910** Thanks @vincentkoc.
-- **PR #142904** Thanks @vincentkoc.
-- **PR #142876**
-- **PR #142919**
-- **PR #142900** Thanks @vincentkoc.
-- **PR #142891** Thanks @vincentkoc.
-- **PR #142909** Thanks @obviyus.
-- **PR #142912**
-- **PR #142907** Thanks @vincentkoc.
-- **PR #142928**
-- **PR #142906** Related #142905. Thanks @vincentkoc.
-- **PR #137576** Related #137539. Thanks @jalehman.
-- **PR #142908** Thanks @vincentkoc.
-- **PR #142913** Thanks @vincentkoc.
-- **PR #142934**
-- **PR #142917** Thanks @vincentkoc.
-- **PR #142894** Thanks @vincentkoc.
-- **PR #142926** Related #142921. Thanks @vincentkoc.
-- **PR #142944** Related #142881. Thanks @jalehman.
-- **PR #142925** Related #142923. Thanks @vincentkoc.
-- **PR #121938** Related #121934.
-- **PR #142951** Thanks @vincentkoc.
-- **PR #142911** Thanks @vincentkoc.
-- **PR #142884** Related #142883. Thanks @jalehman.
-- **PR #142955** Thanks @jalehman.
-- **PR #142960** Thanks @vincentkoc.
-- **PR #142962**
-- **PR #142839** Thanks @thien-ngn and @obviyus.
-- **PR #142930** Related #142929. Thanks @vincentkoc.
-- **PR #142958** Thanks @vincentkoc.
-- **PR #142946** Thanks @vincentkoc.
-- **PR #137334** Thanks @Alix-007 and @obviyus.
-- **PR #142961** Thanks @vincentkoc.
-- **PR #142896**
-- **PR #142978**
-- **PR #142975**
-- **PR #142808** Thanks @SunnyShu0925 and @obviyus.
-- **PR #142985**
-- **PR #127205**
-- **PR #134480** Thanks @scotthuang and @obviyus.
-- **PR #142986** Thanks @vincentkoc.
-- **PR #142963** Thanks @vincentkoc.
-- **PR #142980** Thanks @vincentkoc.
-- **PR #141218** Related #141054. Thanks @harshitgupta31415 and @vincentkoc and @nissl24.
-- **PR #142982** Thanks @vincentkoc.
-- **PR #143005** Thanks @vincentkoc.
-- **PR #142999** Thanks @vincentkoc.
-- **PR #142984** Thanks @vincentkoc.
-- **PR #135318** Related #135282. Thanks @LiuwqGit and @obviyus and @youens.
-- **PR #143014** Thanks @vincentkoc.
-- **PR #142989** Thanks @vincentkoc.
-- **PR #142995** Thanks @vincentkoc.
-- **PR #143013** Thanks @vincentkoc.
-- **PR #143004** Thanks @vincentkoc.
-- **PR #143022** Thanks @vincentkoc.
-- **PR #127031** Thanks @ayaangazali.
-- **PR #143009**
-- **PR #143025**
-- **PR #135359** Thanks @teddytennant and @obviyus.
-- **PR #142898** Thanks @obviyus.
-- **PR #143027**
-- **PR #142996** Thanks @vincentkoc.
-- **PR #143020**
-- **PR #142864** Thanks @vincentkoc.
-- **PR #142991**
-- **PR #143029** Thanks @vincentkoc.
-- **PR #143042** Thanks @vincentkoc.
-- **PR #141323** Thanks @lraesly.
-- **PR #142859** Thanks @vincentkoc.
-- **PR #143035**
-- **PR #142993** Thanks @vincentkoc.
-- **PR #143021** Thanks @vincentkoc.
-- **PR #143038** Thanks @vincentkoc.
-- **PR #143041** Thanks @vincentkoc.
-- **PR #143040** Thanks @vincentkoc.
-- **PR #143002** Thanks @vincentkoc.
-- **PR #143016** Related #143011. Thanks @vincentkoc.
-- **PR #143045**
-- **PR #143046** Thanks @vincentkoc.
-- **PR #143047**
-- **PR #143039**
-- **PR #141107** Related #140918. Thanks @louisfy and @obviyus and @alexph-dev.
-- **PR #143048**
-- **PR #143057** Thanks @vincentkoc.
-- **PR #143058** Thanks @vincentkoc.
-- **PR #133269** Thanks @xydt-juyaohui and @obviyus.
-- **PR #143055** Thanks @vincentkoc.
-- **PR #142992** Thanks @vincentkoc.
-- **PR #143062** Thanks @vincentkoc.
-- **PR #143059**
-- **PR #143063**
-- **PR #143034**
-- **PR #142933** Thanks @obviyus.
-- **PR #143071**
-- **PR #143072**
-- **PR #143068** Thanks @vincentkoc.
-- **PR #143075**
-- **PR #143076**
-- **PR #143006** Thanks @Marvinthebored and @Peetiegonzalez and @obviyus.
-- **PR #143082** Thanks @vincentkoc.
-- **PR #143085** Thanks @vincentkoc.
-- **PR #143079** Thanks @vincentkoc.
-- **PR #143084**
-- **PR #143087** Thanks @vincentkoc.
-- **PR #143051** Thanks @vincentkoc.
-- **PR #142168** Thanks @LiuwqGit and @obviyus.
-- **PR #142322** Related #142208. Thanks @SunnyShu0925 and @guarismo.
-- **PR #143000** Thanks @gozu and @obviyus.
-- **PR #143091**
-- **PR #143053** Thanks @vincentkoc.
-- **PR #142093** Thanks @pgondhi987.
-- **PR #142927** Related #142924. Thanks @vincentkoc.
-- **PR #143060**
-- **PR #142997** Related #142901. Thanks @ylcn91 and @obviyus and @Conan-Scott.
-- **PR #143052** Thanks @shakkernerd.
-- **PR #143104** Thanks @vincentkoc.
-- **PR #142193** Thanks @ceckert and @obviyus.
-- **PR #143096** Thanks @vincentkoc.
-- **PR #143105**
-- **PR #143103**
-- **PR #141289** Thanks @hugenshen and @obviyus.
-- **PR #142473**
-- **PR #143116** Thanks @vincentkoc.
-- **PR #143102** Thanks @vincentkoc.
-- **PR #143122** Thanks @vincentkoc.
-- **PR #143124** Related #143118.
-- **PR #141808** Related #141787. Thanks @SunnyShu0925 and @obviyus and @dh-js.
-- **PR #143130** Thanks @vincentkoc.
-- **PR #143129** Thanks @vincentkoc.
-- **PR #143108**
-- **PR #141756** Thanks @chelsealong and @obviyus.
-- **PR #136277** Thanks @yetval and @obviyus.
-- **PR #142631** Thanks @jason-allen-oneal.
-- **PR #143112**
-- **PR #143133**
-- **PR #141303** Thanks @hugenshen and @obviyus.
-- **PR #142237**
-- **PR #142860** Related #142832. Thanks @ericcaiwx-star and @aatreya.
-- **PR #142869** Related #142868. Thanks @Marvinthebored and @obviyus.
-- **PR #143149** Thanks @vincentkoc.
-- **PR #143148** Thanks @vincentkoc.
-- **PR #142719** Thanks @RomneyDa.
-- **PR #141771** Related #141701. Thanks @chelsealong and @tomdailey55.
-- **PR #143138**
-- **PR #143152** Thanks @vincentkoc.
-- **PR #143160** Thanks @vincentkoc.
-- **PR #142932** Related #142878. Thanks @ashawwal and @obviyus.
-- **PR #143151** Thanks @vincentkoc.
-- **PR #143117**
-- **PR #143137**
-- **PR #143154** Thanks @vincentkoc.
-- **PR #143161**
-- **PR #143156**
-- **PR #143139**
-- **PR #141307** Thanks @hugenshen and @obviyus.
-- **PR #143163** Thanks @vincentkoc.
-- **PR #143168**
-- **PR #143158** Thanks @vincentkoc.
-- **PR #143140**
-- **PR #143166** Related #143165.
-- **PR #143128**
-- **PR #143164**
-- **PR #143150** Thanks @vincentkoc.
-- **PR #143167** Thanks @Patrick-Erichsen.
-- **PR #143182** Thanks @vincentkoc.
-- **PR #142284** Thanks @obviyus.
-- **PR #143172** Thanks @vincentkoc.
-- **PR #143179** Thanks @vincentkoc.
-- **PR #143194** Thanks @vincentkoc.
-- **PR #143171** Related #143170. Thanks @vincentkoc.
-- **PR #142968** Thanks @vincentkoc.
-- **PR #143181**
-- **PR #143191**
-- **PR #143134** Thanks @vincentkoc.
-- **PR #143192** Thanks @vincentkoc.
-- **PR #143197**
-- **PR #143136** Related #141617. Thanks @yncubys.
-- **PR #143088** Thanks @ly85206559 and @obviyus.
-- **PR #143125** Related #143111. Thanks @LiuwqGit and @obviyus and @yxloveql.
-- **PR #143049**
-- **PR #143203**
-- **PR #143159**
-- **PR #120843** Thanks @vincentkoc.
-- **PR #143147** Thanks @LiuwqGit and @obviyus.
-- **PR #143209**
-- **PR #143213**
-- **PR #143221**
-- **PR #137892** Related #137624. Thanks @pfrederiksen and @vincentkoc.
-- **PR #143109**
-- **PR #128738** Thanks @Leon-SK668 and @obviyus.
-- **PR #143202** Related #142582, #142585. Thanks @GitHoubi.
-- **PR #143222** Thanks @vincentkoc.
-- **PR #142259**
-- **PR #143069** Related #143007. Thanks @vincentkoc.
-- **PR #143219** Thanks @vincentkoc.
-- **PR #143205**
-- **PR #143107** Thanks @vincentkoc.
-- **PR #143175**
-- **PR #143240**
-- **PR #138819** Related #138779. Thanks @sunlit-deng and @vincentkoc and @Jackten.
-- **PR #143247** Thanks @vincentkoc.
-- **PR #142661** Thanks @eleqtrizit.
-- **PR #143249**
-- **PR #142221**
-- **PR #143195** Related #142584. Thanks @GitHoubi.
-- **PR #143258**
-- **PR #143226**
-- **PR #143031**
-- **PR #143153** Related #143001. Thanks @syfvb.
-- **PR #143253** Thanks @vincentkoc.
-- **PR #143261**
-- **PR #142990** Thanks @vincentkoc.
-- **PR #142979** Thanks @vincentkoc.
-- **PR #143237**
-- **PR #143251**
-- **PR #143254**
-- **PR #143223**
-- **PR #143141** Related #143094. Thanks @fahrenhe1t.
-- **PR #143243**
-- **PR #143065**
-- **PR #143268**
-- **PR #142817** Related #143204. Thanks @wangmiao0668000666.
-- **PR #143272** Thanks @vincentkoc.
-- **PR #140621** Related #140607. Thanks @LightningWareLLC.
-- **PR #143207**
-- **PR #143281** Related #143252.
-- **PR #142242**
-- **PR #143174**
-- **PR #142749** Related #141279. Thanks @pengzh1 and @aevgeniou.
-- **PR #143198** Related #142868. Thanks @Marvinthebored.
-- **PR #143273**
-- **PR #143298** Thanks @vincentkoc.
-- **PR #140914** Related #140821. Thanks @NianJiuZst and @obviyus and @rboy1.
-- **PR #142742** Thanks @jason-allen-oneal and @morrow-bluedot.
-- **PR #143097**
-- **PR #143235** Thanks @obviyus.
-- **PR #143271**
-- **PR #143300**
-- **PR #143292** Related #143210. Thanks @fanyuantaier.
-- **PR #143183**
-- **PR #143302**
-- **PR #143190**
-- **PR #143287**
-- **PR #143307**
-- **PR #143288**
-- **PR #142935** Thanks @vincentkoc.
-- **PR #143238** Related #128076. Thanks @ejc3.
-- **PR #143189** Related #143186.
-- **PR #143285**
-- **PR #143269**
-- **PR #143309**
-- **PR #143308**
-- **PR #141163** Related #141123. Thanks @ly85206559 and @orangejon.
-- **PR #143260**
-- **PR #143317**
-- **PR #143316**
-- **PR #143297** Thanks @vincentkoc.
-- **PR #143320**
-- **PR #143321** Thanks @fuller-stack-dev.
-- **PR #142453** Thanks @VACInc.
-- **PR #143313**
-- **PR #143291** Related #124555. Thanks @sallyom and @sercada.
-- **PR #143299** Thanks @qingminglong and @obviyus.
-- **PR #143326** Thanks @vincentkoc.
-- **PR #143324**
-- **PR #143318** Thanks @vincentkoc.
-- **PR #143336**
-- **PR #143325**
-- **PR #143330**
-- **PR #143266**
-- **PR #143337**
-- **PR #143305**
-- **PR #143332**
-- **PR #143339**
-- **PR #143338**
-- **PR #143340**
-- **PR #137255** Thanks @sunlit-deng and @obviyus.
-- **PR #142810** Related #142805. Thanks @ansxor and @IWhatsskill.
-- **PR #143162**
-- **PR #143346**
-- **PR #142699**
-- **PR #143270**
-- **PR #143345**
-- **PR #143349**
-- **PR #140266** Related #140265. Thanks @cai-ops and @obviyus.
-- **PR #141984** Related #140971. Thanks @SunnyShu0925 and @hayden-cc.
-- **PR #143360**
-- **PR #143333** Thanks @vincentkoc.
-- **PR #141600** Thanks @DonnieFi and @IWhatsskill.
-- **PR #143358**
-- **PR #143362**
-- **PR #143352** Related #143348.
-- **PR #143319** Thanks @qingminglong and @obviyus.
-- **PR #143354** Thanks @fuller-stack-dev.
-- **PR #143282** Related #143267. Thanks @LiuwqGit and @obviyus and @jlapenna.
-- **PR #143301** Thanks @vincentkoc.
-- **PR #143365**
-- **PR #143347** Thanks @obviyus.
-- **PR #143312**
-- **PR #143146** Thanks @vincentkoc.
-- **PR #143370**
-- **PR #143369**
-- **PR #142915** Related #142848. Thanks @sunlit-deng and @obviyus and @igs-rogenlo.
-- **PR #133693** Related #133692. Thanks @ekinnee.
-- **PR #143366**
-- **PR #143379**
-- **PR #143378**
-- **PR #143380**
-- **PR #143377**
-- **PR #140388** Thanks @Hekzory and @obviyus.
-- **PR #143392**
-- **PR #143384**
-- **PR #143393**
-- **PR #143361** Thanks @fuller-stack-dev.
-- **PR #143398**
-- **PR #143373** Thanks @vincentkoc.
-- **PR #143401**
-- **PR #143394**
-- **PR #143397**
-- **PR #143402**
-- **PR #143395** Thanks @vincentkoc.
-- **PR #143400**
-- **PR #141841** Related #141807. Thanks @glenn-agent and @obviyus and @dh-js.
-- **PR #142736** Related #142483. Thanks @RileyJJY and @jai-assistant.
-- **PR #143409**
-- **PR #143081** Related #143077. Thanks @barbarhan and @obviyus.
-- **PR #143411**
-- **PR #143403**
-- **PR #143404**
-- **PR #143412**
-- **PR #143408** Related #143388.
-- **PR #143421** Thanks @RomneyDa.
-- **PR #143418**
-- **PR #143407**
-- **PR #143227**
-- **PR #143415**
-- **PR #143425** Thanks @Patrick-Erichsen.
-- **PR #143405**
-- **PR #143344**
-- **PR #143436** Thanks @RomneyDa.
-- **PR #143430** Related #143428.
-- **PR #143424** Related #142429. Thanks @obviyus and @schjonhaug.
-- **PR #143310** Related #143173. Thanks @tskerpnext.
-- **PR #143157** Thanks @vincentkoc.
-- **PR #143427**
-- **PR #143439** Related #143438.
-- **PR #143443**
-- **PR #143416**
-- **PR #143444** Thanks @RomneyDa.
-- **PR #143445** Thanks @RomneyDa.
-- **PR #143447** Thanks @RomneyDa.
-- **PR #140864** Thanks @LiuwqGit and @obviyus.
-- **PR #143456** Thanks @vincentkoc.
-- **PR #143440**
-- **PR #142802** Thanks @keshavbotagent and @obviyus.
-- **PR #141069** Related #141066. Thanks @NullArbitrage and @obviyus.
-- **PR #143459** Thanks @vincentkoc.
-- **PR #143452** Thanks @RomneyDa.
-- **PR #143450** Thanks @RomneyDa.
-- **PR #143453**
-- **PR #143458** Thanks @vincentkoc.
-- **PR #143462** Thanks @RomneyDa.
-- **PR #143469** Thanks @RomneyDa.
-- **PR #143451**
-- **PR #143472** Thanks @vincentkoc.
-- **PR #143414**
-- **PR #141277** Thanks @oywino and @obviyus.
-- **PR #143426**
-- **PR #143446** Thanks @jalehman.
-- **PR #143470**
-- **PR #143487**
-- **PR #143460**
-- **PR #143477**
-- **PR #143463**
-- **PR #143457**
-- **PR #143481**
-- **PR #143449**
-- **PR #143490**
-- **PR #139548** Thanks @srikolagani and @obviyus.
-- **PR #143497** Thanks @vincentkoc.
-- **PR #143517** Thanks @vincentkoc.
-- **PR #143515** Thanks @vincentkoc.
-- **PR #143513** Thanks @RomneyDa.
-- **PR #143514** Thanks @RomneyDa.
-- **PR #143492**
-- **PR #143507**
-- **PR #143510** Thanks @RomneyDa.
-- **PR #143520** Thanks @vincentkoc.
-- **PR #143527**
-- **PR #143522** Thanks @vincentkoc.
-- **PR #143493**
-- **PR #143529**
-- **PR #142741** Related #142737. Thanks @galiniliev.
-- **PR #143434**
-- **PR #143455**
-- **PR #143482**
-- **PR #142844** Related #140246. Thanks @Finn763 and @obviyus and @jmissig.
-- **PR #143532**
-- **PR #143537**
-- **PR #143485**
-- **PR #143193** Related #143188. Thanks @KirDE and @obviyus.
-- **PR #143544**
-- **PR #143342** Related #143177. Thanks @sunlit-deng and @obviyus and @bricelb.
-- **PR #143516** Thanks @RomneyDa.
-- **PR #143508** Thanks @RomneyDa.
-- **PR #143465** Thanks @vincentkoc.
-- **PR #143435** Thanks @vincentkoc.
-- **PR #143574**
-- **PR #143585**
-- **PR #143559**
-- **PR #143486** Related #143473. Thanks @vyctorbrzezowski.
-- **PR #143547**
-- **PR #143599** Related #143263. Thanks @obviyus and @matthewmoroz.
-- **PR #143530**
-- **PR #143491**
-- **PR #143568**
-- **PR #143557**
-- **PR #135839** Thanks @Patrick-Erichsen.
-- **PR #135840** Thanks @Patrick-Erichsen.
-- **PR #139042** Thanks @Patrick-Erichsen.
-- **PR #137659** Thanks @Patrick-Erichsen.
-- **PR #137846** Thanks @Patrick-Erichsen.
-- **PR #137856** Thanks @Patrick-Erichsen.
-- **PR #137886** Thanks @Patrick-Erichsen.
-- **PR #138755** Thanks @Patrick-Erichsen.
-- **PR #142624** Thanks @Patrick-Erichsen.
-- **PR #142710** Thanks @Patrick-Erichsen.
-- **PR #142711** Thanks @Patrick-Erichsen.
-- **PR #142712** Thanks @Patrick-Erichsen.
-- **PR #142713** Thanks @Patrick-Erichsen.
-- **PR #142782** Thanks @Patrick-Erichsen.
-- **PR #143606**
-- **PR #143613**
-- **PR #143605**
-- **PR #143600**
-- **PR #143595** Related #143593. Thanks @fuller-stack-dev.
-- **PR #143586** Thanks @vincentkoc.
-- **PR #143602**
-- **PR #143601**
-- **PR #140833** Thanks @leapdragon and @obviyus.
-- **PR #143542**
-- **PR #143603**
-- **PR #143592**
-- **PR #143579** Related #143575. Thanks @fuller-stack-dev.
-- **PR #143561** Related #143560. Thanks @masatohoshino and @obviyus.
-- **PR #143626**
-- **PR #143372**
-- **PR #143627**
-- **PR #143629**
-- **PR #132158** Thanks @stevenlee-oai.
-- **PR #143628**
-- **PR #143633**
-- **PR #143636**
-- **PR #141079** Related #141078. Thanks @ooiuuii and @obviyus.
-- **PR #143634**
-- **PR #143637**
-- **PR #143639**
-- **PR #143368**
-- **PR #143642**
-- **PR #143621**
-- **PR #143371**
-- **PR #143374**
-- **PR #143644**
-- **PR #143382**
-- **PR #140339** Thanks @fuller-stack-dev.
-- **PR #143383**
-- **PR #114662** Related #114602. Thanks @synthalorian and @obviyus and @jackatagenticforce.
-- **PR #138619** Related #138592. Thanks @LiuwqGit and @obviyus and @fabiolr.
-- **PR #143652**
-- **PR #143655**
-- **PR #143429** Thanks @obviyus.
-- **PR #125977** Thanks @ayaangazali and @obviyus.
-- **PR #143653**
-- **PR #143598** Related #132762. Thanks @harjothkhara and @obviyus and @CK-XYZ.
-- **PR #143660**
-- **PR #141836** Related #129452. Thanks @obviyus and @safzanpirani.
-- **PR #143663**
-- **PR #143651**
-- **PR #142186**
-- **PR #143657** Thanks @fuller-stack-dev.
-- **PR #143662**
-- **PR #143376** Thanks @vincentkoc.
-- **PR #143680**
-- **PR #143667** Related #143654.
-- **PR #143666**
-- **PR #92288** Thanks @ai-hpc and @obviyus.
-- **PR #143690**
-- **PR #137303** Thanks @qingminglong and @obviyus.
-- **PR #143684**
-- **PR #136466** Related #136392. Thanks @vincentkoc.
-- **PR #143697**
-- **PR #143676** Thanks @shakkernerd.
-- **PR #143698**
-- **PR #143705**
-- **PR #142522** Thanks @jjjhenriksen and @RomneyDa and @pash-openai.
-- **PR #143687**
-- **PR #143658**
-- **PR #143709** Thanks @vincentkoc.
-- **PR #143710**
-- **PR #143706**
-- **PR #143682** Related #143656. Thanks @vincentkoc.
-- **PR #143674**
-- **PR #143622**
-- **PR #143675**
-- **PR #143723**
-- **PR #143506** Related #143385. Thanks @sunlit-deng and @obviyus and @dbarbatti.
-- **PR #143720**
-- **PR #143721**
-- **PR #143695**
-- **PR #143531** Thanks @RomneyDa.
-- **PR #143567** Thanks @RomneyDa.
-- **PR #143590** Related #143169. Thanks @wangmiao0668000666 and @obviyus and @PeterHodl.
-- **PR #119624** Thanks @pcpilot-dev.
-- **PR #143519** Related #90711. Thanks @RomneyDa and @Enominera.
-- **PR #109092** Thanks @Pick-cat and @obviyus.
-- **PR #143724**
-- **PR #143726**
-- **PR #143643** Thanks @obviyus.
-- **PR #143708**
-- **PR #143722** Related #143641. Thanks @obviyus and @rgregg.
-- **PR #143734**
-- **PR #143725**
-- **PR #143671**
-- **PR #143741**
-- **PR #143749**
-- **PR #143736**
-- **PR #143693** Related #143678. Thanks @fuller-stack-dev.
-- **PR #143737**
-- **PR #143716**
-- **PR #143746**
-- **PR #143681**
-- **PR #143699**
-- **PR #143712**
-- **PR #143748**
-- **PR #143742** Related #143630. Thanks @zwyhmcn.
-- **PR #143715**
-- **PR #143763**
-- **PR #143686**
-- **PR #143773** Thanks @vincentkoc.
-- **PR #143765**
-- **PR #143762**
-- **PR #143669**
-- **PR #143775** Thanks @vincentkoc.
-- **PR #143717**
-- **PR #137147** Thanks @qingminglong and @obviyus.
-- **PR #143766**
-- **PR #143770** Thanks @vincentkoc.
-- **PR #116378** Related #115920. Thanks @sloptop-the-terrible and @obviyus and @609NFT.
-- **PR #143738** Related #143543. Thanks @RomneyDa.
-- **PR #143704** Thanks @RomneyDa.
-- **PR #143751** Thanks @RomneyDa.
-- **PR #143729** Thanks @xydigitLybnnnn and @obviyus.
-- **PR #143758** Thanks @Patrick-Erichsen.
-- **PR #143760**
-- **PR #143769**
-- **PR #143747**
-- **PR #143696** Thanks @RomneyDa.
-- **PR #143692** Thanks @RomneyDa.
-- **PR #143689** Thanks @RomneyDa.
-- **PR #143582** Thanks @RomneyDa.
-- **PR #143576** Thanks @RomneyDa.
-- **PR #143474** Thanks @RomneyDa.
-- **PR #143570** Thanks @RomneyDa.
-- **PR #143793**
-- **PR #125413**
-- **PR #143782**
-- **PR #143783**
-- **PR #143780**
-- **PR #143754**
-- **PR #122110** Related #122107. Thanks @sappkevin and @obviyus.
-- **PR #143558** Thanks @RomneyDa.
-- **PR #143795**
-- **PR #143796** Thanks @vincentkoc.
-- **PR #143805** Related #143800.
-- **PR #143815**
-- **PR #143807**
-- **PR #120902** Thanks @zenglingbiao and @obviyus.
-- **PR #143798**
-- **PR #143659** Thanks @HAPPYFAPTAIN and @obviyus.
-- **PR #143730** Thanks @Patrick-Erichsen.
-- **PR #143731** Thanks @Patrick-Erichsen.
-- **PR #143801**
-- **PR #121557** Related #121401. Thanks @zyw02 and @cursoragent and @obviyus.
-- **PR #143808**
-- **PR #143828**
-- **PR #143806**
-- **PR #143845** Thanks @vincentkoc.
-- **PR #143855** Thanks @vincentkoc.
-- **PR #143844** Thanks @fuller-stack-dev.
-- **PR #143856** Thanks @vincentkoc.
-- **PR #143835** Thanks @fuller-stack-dev.
-- **PR #143824**
-- **PR #143776**
-- **PR #143846**
-- **PR #143813**
-- **PR #143862**
-- **PR #143789**
-- **PR #143867** Thanks @vincentkoc.
-- **PR #143464**
-- **PR #143816**
-- **PR #143859**
-- **PR #143831**
-- **PR #143664** Thanks @obviyus.
-- **PR #143848**
-- **PR #143799** Thanks @fuller-stack-dev.
-- **PR #143868**
-- **PR #143863** Related #143841. Thanks @fuller-stack-dev.
-- **PR #143791** Related #143750. Thanks @vincentkoc and @fuller-stack-dev.
-- **PR #143877** Thanks @fuller-stack-dev.
-- **PR #143812**
-- **PR #143875**
-- **PR #143849**
-- **PR #143850**
-- **PR #143857** Thanks @vincentkoc.
-- **PR #143853** Thanks @vincentkoc.
-- **PR #143870** Thanks @vincentkoc.
-- **PR #143871**
-- **PR #143869**
-- **PR #137371** Related #137257. Thanks @gwiltschek and @obviyus.
-- **PR #143814**
-- **PR #143811** Thanks @RomneyDa.
-- **PR #143573** Thanks @RomneyDa.
-- **PR #143810** Thanks @RomneyDa.
-- **PR #143768**
-- **PR #143553** Thanks @RomneyDa.
-- **PR #143552** Thanks @RomneyDa.
-- **PR #143551** Thanks @RomneyDa.
-- **PR #143572** Thanks @RomneyDa.
-- **PR #143565** Thanks @RomneyDa.
-- **PR #143562** Thanks @RomneyDa.
-- **PR #143564** Thanks @RomneyDa.
-- **PR #143874**
-- **PR #143785** Thanks @obviyus.
-- **PR #143767**
-- **PR #143889**
-- **PR #143838**
-- **PR #136984** Related #134604. Thanks @linhongyu510 and @obviyus and @scottcha.
-- **PR #143533** Thanks @RomneyDa.
-- **PR #143534** Thanks @RomneyDa.
-- **PR #143536** Thanks @RomneyDa.
-- **PR #143535** Thanks @RomneyDa.
-- **PR #143914**
-- **PR #143861**
-- **PR #143887**
-- **PR #143554** Thanks @RomneyDa.
-- **PR #143854**
-- **PR #143858**
-- **PR #137422** Thanks @qingminglong and @obviyus.
-- **PR #143913**
-- **PR #143895** Thanks @vincentkoc.
-- **PR #143563** Thanks @RomneyDa.
-- **PR #138160** Thanks @SunnyShu0925 and @obviyus.
-- **PR #143919**
-- **PR #143866**
-- **PR #143886** Related #143885.
-- **PR #134959** Related #108893. Thanks @shojikumaru and @obviyus and @developercrocodiles.
-- **PR #143916** Related #143389. Thanks @obviyus and @aleps001.
-- **PR #143851**
-- **PR #111964** Related #96974. Thanks @dillona and @vincentkoc and @anguslogan01.
-- **PR #143912**
-- **PR #143901**
-- **PR #142132** Thanks @mgabor3141 and @obviyus.
-- **PR #143904** Thanks @vincentkoc.
-- **PR #143926** Thanks @vincentkoc.
-- **PR #143873** Thanks @vincentkoc.
-- **PR #143872**
-- **PR #143925**
-- **PR #139071** Thanks @qingminglong and @obviyus.
-- **PR #143777**
-- **PR #143893**
-- **PR #143923** Thanks @vincentkoc.
-- **PR #143792**
-- **PR #143774** Related #139714. Thanks @Colton-Harris.
-- **PR #143927** Thanks @vincentkoc.
-- **PR #143945**
-- **PR #143928**
-- **PR #143864**
-- **PR #143899** Thanks @fuller-stack-dev.
-- **PR #143931** Thanks @vincentkoc.
-- **PR #143922**
-- **PR #143942** Related #143939.
-- **PR #141762** Thanks @xiaoguomeiyitian and @obviyus.
-- **PR #143950** Thanks @vincentkoc.
-- **PR #143920**
-- **PR #143822**
-- **PR #143954**
-- **PR #135539** Thanks @kvnloo and @obviyus.
-- **PR #143962** Thanks @vincentkoc.
-- **PR #143910**
-- **PR #143949** Related #143947.
-- **PR #143964**
-- **PR #143921** Thanks @fuller-stack-dev.
-- **PR #143965**
-- **PR #143974**
-- **PR #143977** Thanks @vincentkoc.
-- **PR #143979** Thanks @vincentkoc.
-- **PR #143759** Related #143756.
-- **PR #143969**
-- **PR #143982** Thanks @vincentkoc.
-- **PR #141283** Thanks @north-echo and @obviyus.
-- **PR #143978**
-- **PR #143924**
-- **PR #143888**
-- **PR #143967**
-- **PR #111706** Thanks @xydt-tanshanshan and @obviyus.
-- **PR #143803**
-- **PR #143975**
-- **PR #143908** Thanks @pash-openai.
-- **PR #143832** Thanks @pash-openai.
-- **PR #143953**
-- **PR #139562** Thanks @TheCrazyLex and @obviyus.
-- **PR #140296** Related #140100. Thanks @ylcn91 and @ikenraf.
-- **PR #143983** Thanks @vincentkoc.
-- **PR #143410**
-- **PR #144004**
-- **PR #143996** Thanks @vincentkoc.
-- **PR #143997**
-- **PR #144018** Thanks @vincentkoc.
-- **PR #144002**
-- **PR #144021** Thanks @vincentkoc.
-- **PR #144030** Thanks @vincentkoc.
-- **PR #144028** Thanks @vincentkoc.
-- **PR #144033**
-- **PR #144039** Thanks @vincentkoc.
-- **PR #143958** Related #143971. Thanks @Marvinthebored and @Peetiegonzalez and @obviyus.
-- **PR #144037** Thanks @RomneyDa.
-- **PR #144051** Thanks @vincentkoc.
-- **PR #144049**
-- **PR #144050**
-- **PR #142822** Thanks @obviyus.
-- **PR #144058**
-- **PR #144032** Thanks @vincentkoc.
-- **PR #144067**
-- **PR #143929**
-- **PR #144017**
-- **PR #144007**
-- **PR #144060**
-- **PR #144014**
-- **PR #144010**
-- **PR #144012**
-- **PR #144029** Thanks @vincentkoc.
-- **PR #143930** Related #143830. Thanks @linhongyu510 and @obviyus and @cp1369.
-- **PR #144009**
-- **PR #144072** Thanks @vincentkoc.
-- **PR #144036**
-- **PR #143993**
-- **PR #143772**
-- **PR #144076**
-- **PR #144038** Related #144035.
-- **PR #144083** Thanks @vincentkoc.
-- **PR #144080**
-- **PR #144073**
-- **PR #144087**
-- **PR #144034**
-- **PR #144022**
-- **PR #144015** Thanks @vincentkoc.
-- **PR #144054**
-- **PR #141071** Related #141000. Thanks @ooiuuii and @obviyus.
-- **PR #144011**
-- **PR #144092**
-- **PR #144091** Thanks @vincentkoc.
-- **PR #143903** Related #143821. Thanks @LiuwqGit and @obviyus and @kiagentkronos-cell.
-- **PR #144075**
-- **PR #143994**
-- **PR #143521** Related #107972. Thanks @eleqtrizit and @yetval.
-- **PR #144090**
-- **PR #144089** Thanks @vincentkoc.
-- **PR #144086** Thanks @vincentkoc.
-- **PR #144024**
-- **PR #144077**
-- **PR #144096**
-- **PR #143999**
-- **PR #144095**
-- **PR #143484** Thanks @eleqtrizit.
-- **PR #144097**
-- **PR #143437** Related #143356. Thanks @ylcn91 and @obviyus and @YanHE1169.
-- **PR #144023** Thanks @vincentkoc.
-- **PR #144108**
-- **PR #144085** Thanks @vincentkoc.
-- **PR #144105** Thanks @vincentkoc.
-- **PR #143960** Thanks @Marvinthebored and @Peetiegonzalez and @obviyus.
-- **PR #144116**
-- **PR #144109**
-- **PR #144031** Thanks @IWhatsskill.
-- **PR #144107**
-- **PR #144117**
-- **PR #144115** Related #144114.
-- **PR #144110**
-- **PR #144122**
-- **PR #144120**
-- **PR #144126** Thanks @vincentkoc.
-- **PR #144088**
-- **PR #144130** Thanks @fuller-stack-dev.
-- **PR #144129** Related #144123. Thanks @vincentkoc.
-- **PR #143890** Thanks @vincentkoc.
-- **PR #143311** Thanks @vincentkoc.
-- **PR #143745** Related #143743. Thanks @vincentkoc.
-- **PR #144135**
-- **PR #143860** Related #143865. Thanks @wangmiao0668000666 and @obviyus.
-- **PR #144121**
-- **PR #144402** Thanks @vincentkoc.
+##### Start OpenClaw when Node needs attention
+
+
+If OpenClaw will not start because of Node, the software it runs on, it can now find a compatible copy already on your computer or [offer to install one just for OpenClaw](https://docs.openclaw.ai/install/node#update-from-the-cli). You approve the first installation; after that, OpenClaw can reuse it automatically. This gives you a way past the startup problem without changing Node for your other apps. Some systems, including Alpine Linux, still need manual installation. If you cannot start normally, basic help and troubleshooting commands remain available on some older Node versions.
+
+If the background service is still using an old Node after an upgrade, `openclaw gateway install` can now switch it to an available supported version. This is a separate repair from getting the command line working.
+
+
+
+###### Sources and complete change list
+
+
+**Improvements**
+
+- Avoid loading error diagnostics during healthy startup [#142371](https://github.com/openclaw/openclaw/pull/142371).
+- Offer a private Node.js update when the CLI cannot start [#142742](https://github.com/openclaw/openclaw/pull/142742). Thanks @jason-allen-oneal, @morrow-bluedot, @jialele.
+
+**Bug fixes**
+
+- Explain unusable macOS SQLite overrides [#141948](https://github.com/openclaw/openclaw/pull/141948).
+- Check the selected SQLite library during Bun installation and diagnostics [#142186](https://github.com/openclaw/openclaw/pull/142186).
+- Repair stale Gateway service Node runtimes without forcing reinstall [#143159](https://github.com/openclaw/openclaw/pull/143159). Thanks @jialele, @TheAngryPit.
+- Restore diagnostics on unsupported Node runtimes [#143344](https://github.com/openclaw/openclaw/pull/143344).
+- Reuse compatible installed Node during startup and upgrades [#143464](https://github.com/openclaw/openclaw/pull/143464). Thanks @aeoess.
+- Allow short help and version flags during Node recovery [#143485](https://github.com/openclaw/openclaw/pull/143485).
+- Preserve macOS Bun SQLite settings in managed services [#143651](https://github.com/openclaw/openclaw/pull/143651).
+
+**Documentation**
+
+- Document Node as a workaround for Bun SQLite file-release limits [#141846](https://github.com/openclaw/openclaw/pull/141846).
+- Add Node.js and Bun compatibility references [#142156](https://github.com/openclaw/openclaw/pull/142156).
+
+**Limits and compatibility**
+
+- Check SQLite behavior before accepting Node runtimes [#143312](https://github.com/openclaw/openclaw/pull/143312). Thanks @aeoess.
+
+
+
+
+
+
+##### Install on Mac, Linux, and Docker
+
+
+Mac installation no longer gets stuck in the affected Homebrew Bash setups, and people building their own [Docker image](https://docs.openclaw.ai/install/docker) can get past the missing-file error that stopped installation. Linux instructions now explain which user account should run OpenClaw so it finds the right settings, while installation help makes clear when it will start or restart the background service. For people who manage their own terminal settings, supported command-completion entries are also preserved instead of being added again.
+
+
+
+###### Sources and complete change list
+
+
+**Bug fixes**
+
+- Prevent installer hangs with newer Homebrew Bash [#141884](https://github.com/openclaw/openclaw/pull/141884).
+- Restore Docker source dependency installation [#142073](https://github.com/openclaw/openclaw/pull/142073). Thanks @vincentkoc.
+- Preserve portable shell completion hooks during installation [#143282](https://github.com/openclaw/openclaw/pull/143282). Thanks @LiuwqGit, @obviyus, @jlapenna.
+
+**Documentation**
+
+- Clarify the Node 26 recommendation for package installs [#135539](https://github.com/openclaw/openclaw/pull/135539). Thanks @kvnloo, @obviyus.
+- Clarify Gateway service account and shutdown guidance [#136266](https://github.com/openclaw/openclaw/pull/136266). Thanks @yetval, @obviyus, @abacha.
+- Explain startup and restart effects before service installation [#139562](https://github.com/openclaw/openclaw/pull/139562). Thanks @TheCrazyLex, @obviyus.
+- Clarify automatic system-Bash handling for installers [#142038](https://github.com/openclaw/openclaw/pull/142038).
+- Split Docker reference material into focused guides [#143087](https://github.com/openclaw/openclaw/pull/143087). Thanks @vincentkoc.
+
+
+
+
+
+
+##### Connect a provider and reach the first conversation
+
+
+A new agent can now use an API key you have already saved in OpenClaw's protected storage, fixing a setup failure that left ordinary chats working but new-agent setup stuck. Moonshot's China API-key setup also stops asking you to reinstall a provider that is already installed, and browser sign-in explains when you have pasted a phone setup code into the wrong place.
+
+An empty background memory check no longer makes a fresh Claw think setup is already finished, so you still get its first naming conversation.
+
+
+
+###### Sources and complete change list
+
+
+**Improvements**
+
+- Explain mobile setup codes pasted into browser sign-in [#141717](https://github.com/openclaw/openclaw/pull/141717). Thanks @DonnieFi.
+
+**Bug fixes**
+
+- Use protected provider keys in New Agent setup [#141586](https://github.com/openclaw/openclaw/pull/141586). Thanks @miguelbranco80, @IWhatsskill, @wenbiyou, @lisheguo.
+- Preserve first-run setup after empty dreaming sweeps [#141808](https://github.com/openclaw/openclaw/pull/141808). Thanks @SunnyShu0925, @obviyus, @dh-js, @ayaangazali.
+- Stop Moonshot China authentication reinstall loops [#143742](https://github.com/openclaw/openclaw/pull/143742). Thanks @zwyhmcn.
+
+**Documentation**
+
+- Align setup and rotation guidance around one Gateway secret [#141723](https://github.com/openclaw/openclaw/pull/141723).
+- Correct Gateway-host provider setup instructions [#143983](https://github.com/openclaw/openclaw/pull/143983). Thanks @vincentkoc.
+
+
+
+
+
+
+##### Choose the agent for setup
+
+
+If you have several agents, guided messaging setup now lets you choose whose workspace to configure before separately choosing who should receive the messages. You can also [choose an agent when managing setup recommendations](https://docs.openclaw.ai/cli/onboard), so you work with the intended workspace. Setup scripts still need an explicit `--agent` choice when no default is configured. The device setup instructions also explain that connecting a device and approving the commands it can run are separate steps.
+
+
+
+###### Sources and complete change list
+
+
+**Bug fixes**
+
+- Choose an agent workspace during guided channel setup [#128738](https://github.com/openclaw/openclaw/pull/128738). Thanks @Leon-SK668, @obviyus, @JunfXiao.
+- Select an agent for onboarding recommendations [#141775](https://github.com/openclaw/openclaw/pull/141775). Thanks @ChrisCantwell, @obviyus.
+- Resolve environment values for channel setup checks [#141781](https://github.com/openclaw/openclaw/pull/141781).
+- Accept agent selection after recommendation subcommands [#142019](https://github.com/openclaw/openclaw/pull/142019). Thanks @obviyus.
+
+**Documentation**
+
+- Complete node setup and command-approval instructions [#136268](https://github.com/openclaw/openclaw/pull/136268). Thanks @yetval, @obviyus, @ccaprani.
+
+
+
+
+
+
+##### Connect a phone to OpenClaw
+
+
+Phone setup help now points you to [`openclaw qr`](https://docs.openclaw.ai/cli/qr), and the [Android instructions](https://docs.openclaw.ai/platforms/android) explain how to connect to the computer running OpenClaw and set up the login your phone needs. They cover both a trusted home network and Tailscale. Use HTTPS for browser access when possible, because HTTP does not encrypt your login details or messages.
+
+
+
+###### Sources and complete change list
+
+
+**Documentation**
+
+- Correct Android pairing and browser access guidance [4ccdd7e](https://github.com/openclaw/openclaw/commit/4ccdd7e005754b426483d78d2c00064df14216a6). Thanks @yetval.
+- Point mobile setup users to the QR command in CLI help [#141756](https://github.com/openclaw/openclaw/pull/141756). Thanks @chelsealong, @obviyus, @tomdailey55.
+
+
+
+
+
+
+##### Finish importing an existing setup
+
+
+An error at the very end of an import no longer has to hide work that already finished. OpenClaw preserves completed memory-import results when the final cleanup fails, and can recognize a retry of the same request without copying everything again. If an error says the import completed, [check the report and imported files](https://docs.openclaw.ai/web/control-ui/settings) before starting over. That retry protection is temporary and does not survive restarting OpenClaw.
+
+
+
+###### Sources and complete change list
+
+
+**Bug fixes**
+
+- Preserve completed import results through cleanup errors and matching request retries [#142738](https://github.com/openclaw/openclaw/pull/142738).
+
+
+
+
+
+
+##### Remove an installation
+
+
+Removing OpenClaw now comes with instructions that match how you installed it, including Git and installations kept in their own folder. The [uninstall guide](https://docs.openclaw.ai/install/uninstall) explains which files and launchers to remove and which may be shared with other tools. Remove the background service first, and save any settings or workspaces you want to keep before deleting files.
+
+
+
+###### Sources and complete change list
+
+
+**Documentation**
+
+- Explain removal for Git and dedicated-prefix installations [#127254](https://github.com/openclaw/openclaw/pull/127254).
+- Correct uninstall help and completion guidance [#142629](https://github.com/openclaw/openclaw/pull/142629).
+
+
+
+
+
+
+##### Follow complete setup instructions
+
+
+The [first-run help](https://docs.openclaw.ai/help/faq-first-run/quick-start) separates getting started from choosing a provider or hosting service, so you can find the answer for the step you are on. Setup examples also fill in missing tools, credentials, and commands, including how to match the Mac app with the right command-line version. When you ask the setup agent to inspect a setting, it can now find names containing dots or brackets that it previously reported as missing, while keeping secret values hidden.
+
+
+
+###### Sources and complete change list
+
+
+**Bug fixes**
+
+- Read quoted configuration keys in the setup agent [#143601](https://github.com/openclaw/openclaw/pull/143601).
+
+**Documentation**
+
+- Correct setup routing, Gateway port spacing, logging styles, and existing Windows, channel, Codex, and provider guidance [#141214](https://github.com/openclaw/openclaw/pull/141214). Thanks @vincentkoc.
+- Split Why OpenClaw architecture and comparison references into focused pages [#142989](https://github.com/openclaw/openclaw/pull/142989). Thanks @vincentkoc.
+- Link workspace templates, macOS Skills, and related setup guides directly [#143022](https://github.com/openclaw/openclaw/pull/143022). Thanks @vincentkoc.
+- Correct copied setup commands, token-display instructions, memory examples, and retry and heartbeat guidance [#143029](https://github.com/openclaw/openclaw/pull/143029). Thanks @vincentkoc.
+- Split first-run FAQ into focused setup and hosting pages [#143148](https://github.com/openclaw/openclaw/pull/143148). Thanks @vincentkoc.
+- Correct Diffs installation, Ollama credentials, IMAP account examples, and CLI and tool guidance [#143179](https://github.com/openclaw/openclaw/pull/143179). Thanks @vincentkoc.
+- Clarify explicit ClawHub skill selection [#143371](https://github.com/openclaw/openclaw/pull/143371).
+- Clarify voice-call and acpx prerequisites, text-model validation, memory setup, and delegate examples [#143927](https://github.com/openclaw/openclaw/pull/143927). Thanks @vincentkoc.
+- Correct transcription models, camera flags, Matrix defaults, Signal checks, and existing media-migration guidance [#143950](https://github.com/openclaw/openclaw/pull/143950). Thanks @vincentkoc.
+- Complete remote Mac, Arcee, and plugin SDK examples and clarify documented version history [#144032](https://github.com/openclaw/openclaw/pull/144032). Thanks @vincentkoc.
+- Clarify memory CLI defaults, stop/backup/start migration steps, Reef setup, and status and group links [#144083](https://github.com/openclaw/openclaw/pull/144083). Thanks @vincentkoc.
+- Add installation prerequisites and clarify Render troubleshooting, Ollama credentials, Mac version matching, and existing client controls [#144085](https://github.com/openclaw/openclaw/pull/144085). Thanks @vincentkoc.
+
+
+
+
+
+
+
+#### The New Web UI
+
+In the web app, you can preview an earlier message before jumping back to it, bring a quote into your next reply, and see what Codex's helper agents did while working on your request. There are also fixes for the interruptions that make a conversation harder to follow, from disappearing image previews to finished tasks that still look busy.
+
+
+
+
+##### Find and organize conversations
+
+
+[Your conversation list](https://docs.openclaw.ai/web/control-ui/sessions-and-sidebar) now keeps the names you choose and avoids changing them back when an older update arrives. Chats can get a useful title even when automatic naming fails, making them easier to recognize later. If the app tries to reopen a chat you deleted, it takes you to a usable conversation instead of leaving you stuck; it does not recover the deleted messages.
+
+
+
+###### Sources and complete change list
+
+
+**Improvements**
+
+- Start ungrouped sessions from the Other heading [#142544](https://github.com/openclaw/openclaw/pull/142544). Thanks @Patrick-Erichsen.
+
+**Bug fixes**
+
+- Recover stale remembered chats when opening the web UI [#133653](https://github.com/openclaw/openclaw/pull/133653). Thanks @RomneyDa.
+- Keep readable chat titles and preserve manual names [#141600](https://github.com/openclaw/openclaw/pull/141600). Thanks @DonnieFi, @IWhatsskill, @jjjhenriksen.
+- Align sidebar session counts [#141924](https://github.com/openclaw/openclaw/pull/141924). Thanks @RomneyDa.
+- Prevent overlapping sidebar session controls [#142042](https://github.com/openclaw/openclaw/pull/142042). Thanks @RomneyDa.
+- Clear previous session timing when a new run starts [#142187](https://github.com/openclaw/openclaw/pull/142187).
+- Remove unintended underlines from Online sidebar names [#142217](https://github.com/openclaw/openclaw/pull/142217). Thanks @vyctorbrzezowski.
+- Remove phantom sidebar children after subagent deletion [#142438](https://github.com/openclaw/openclaw/pull/142438). Thanks @jalehman, @vyctorbrzezowski.
+- Finish opening the mobile sidebar after a swipe [#142578](https://github.com/openclaw/openclaw/pull/142578). Thanks @jalehman.
+- Keep session details, child breadcrumbs and history retries consistent [#143049](https://github.com/openclaw/openclaw/pull/143049).
+- Restore multi-agent session lists after model fallback [#143337](https://github.com/openclaw/openclaw/pull/143337).
+- Preserve native session actions after adoption [#143342](https://github.com/openclaw/openclaw/pull/143342). Thanks @sunlit-deng, @obviyus, @bricelb.
+- Name device and cloud sessions before their first turn [#143760](https://github.com/openclaw/openclaw/pull/143760).
+
+
+
+
+
+
+##### Move through a long conversation
+
+
+A slim [message navigator](https://docs.openclaw.ai/web/control-ui/chat) on the left lets you preview a message before jumping to it, so you can find a particular answer without scrolling through the whole conversation. In shared chats, previews also show who wrote the message when that information is available. It appears on desktop when there is enough room and covers the messages already loaded.
+
+
+
+###### Sources and complete change list
+
+
+**Improvements**
+
+- Navigate long chats with a compact per-message rail [#142227](https://github.com/openclaw/openclaw/pull/142227). Thanks @vyctorbrzezowski.
+- Show senders in shared-chat navigation previews [#143486](https://github.com/openclaw/openclaw/pull/143486). Thanks @vyctorbrzezowski.
+
+**Bug fixes**
+
+- Render Markdown in conversation rail previews [#142442](https://github.com/openclaw/openclaw/pull/142442). Thanks @jalehman.
+- Smooth the Scroll to latest transition [#142720](https://github.com/openclaw/openclaw/pull/142720). Thanks @vyctorbrzezowski.
+
+
+
+
+
+
+##### Read your saved conversation while reconnecting
+
+
+When you reload the app, it can show a saved copy of your conversation and sidebar while it reconnects, so you have something to read during the wait. [This works with remembered Gateway tokens or paired-device sign-ins](https://docs.openclaw.ai/web/control-ui/offline-and-reconnect#warm-reload); other sign-in methods still show the connection screen. Sending messages and other actions wait for the connection.
+
+If you use the same web address to connect to several Gateways, a conversation saved from another Gateway can briefly appear. Wait for the live conversation to load before relying on that view.
+
+
+
+###### Sources and complete change list
+
+
+**Improvements**
+
+- Delay and fade conversation loading placeholders [3c322522](https://github.com/openclaw/openclaw/commit/3c322522d8413702c8bfed211fb02a443e047906). Context [#134868](https://github.com/openclaw/openclaw/pull/134868). Thanks @jesse-merhi.
+- Show cached chat and sidebar content while reconnecting [#141121](https://github.com/openclaw/openclaw/pull/141121). Context [#141690](https://github.com/openclaw/openclaw/issues/141690).
+- Reduce startup JavaScript while retaining translated Settings help [#143376](https://github.com/openclaw/openclaw/pull/143376). Thanks @vincentkoc.
+
+
+
+
+
+
+##### Quote text and keep drafts readable
+
+
+Highlight a passage and choose Add to chat to put an editable quote into your draft without losing what you have already written. Quotes include up to 300 characters, and nothing is sent until you send the message yourself. Long drafts are also easier to edit because the line you are typing no longer fades out at the edge of the message box.
+
+
+
+###### Sources and complete change list
+
+
+**Improvements**
+
+- Add selected text to the main chat draft [#142543](https://github.com/openclaw/openclaw/pull/142543). Thanks @Patrick-Erichsen.
+- Translate Add to chat across 20 existing locales [#142576](https://github.com/openclaw/openclaw/pull/142576).
+
+**Bug fixes**
+
+- Fix mobile chat spacing, scrolling previews, and keyboard focus [#142143](https://github.com/openclaw/openclaw/pull/142143). Thanks @IWhatsskill, @vyctorbrzezowski.
+- Refresh attachment overflow cues after changes and resizing [#142577](https://github.com/openclaw/openclaw/pull/142577).
+- Align composer attachments with draft text [#142658](https://github.com/openclaw/openclaw/pull/142658). Thanks @vyctorbrzezowski.
+- Keep long drafts readable while typing [#142955](https://github.com/openclaw/openclaw/pull/142955). Thanks @jalehman.
+- Refresh shared-chat previews when a tab stops typing [#143400](https://github.com/openclaw/openclaw/pull/143400).
+
+
+
+
+
+
+##### Follow images and documents in chat
+
+
+Images you send stay visible while the conversation updates, and scrolling back to a recently loaded image avoids another loading placeholder when its preview is still available. Documents sit above the text that goes with them, making files easier to spot in a busy conversation. Opening a file now shows that it is loading instead of briefly claiming the preview is unavailable.
+
+
+
+###### Sources and complete change list
+
+
+**Improvements**
+
+- Place file cards above text and align participant media [#142671](https://github.com/openclaw/openclaw/pull/142671). Thanks @vyctorbrzezowski.
+
+**Bug fixes**
+
+- Keep loaded images visible when scrolling back through chat [#138303](https://github.com/openclaw/openclaw/pull/138303). Context [#138301](https://github.com/openclaw/openclaw/issues/138301). Thanks @vyctorbrzezowski.
+- Make chat attachment spacing consistent [#142246](https://github.com/openclaw/openclaw/pull/142246). Thanks @vyctorbrzezowski.
+- Prevent duplicate final replies as chat history loads [#142422](https://github.com/openclaw/openclaw/pull/142422). Thanks @jalehman.
+- Show loading progress while attachment previews resolve [#142613](https://github.com/openclaw/openclaw/pull/142613). Thanks @vyctorbrzezowski.
+- Align attachment placeholders with Open buttons [#142665](https://github.com/openclaw/openclaw/pull/142665). Thanks @vyctorbrzezowski.
+- Align sender avatars with attachment text [#142694](https://github.com/openclaw/openclaw/pull/142694). Thanks @vyctorbrzezowski.
+- Prevent duplicate bubbles after CLI history refresh [#142725](https://github.com/openclaw/openclaw/pull/142725).
+- Keep sent images visible during history loading [#143407](https://github.com/openclaw/openclaw/pull/143407).
+
+
+
+
+
+
+##### Preview videos before sending
+
+
+Selected videos can now show a still image in the message box, so you can tell similar recordings apart before sending one. The preview is made on your device without uploading the video. Sent videos also have previews in the conversation that open in Files when selected; if your browser cannot make a preview, the usual file card or icon remains.
+
+
+
+###### Sources and complete change list
+
+
+**Improvements**
+
+- Preview selected videos before sending [#142623](https://github.com/openclaw/openclaw/pull/142623). Thanks @vyctorbrzezowski.
+- Show user video previews above chat text [#142639](https://github.com/openclaw/openclaw/pull/142639). Thanks @vyctorbrzezowski.
+
+
+
+
+
+
+##### Browse files and protect newer edits
+
+
+[Files](https://docs.openclaw.ai/web/control-ui/chat) keeps search and filters within reach while you scroll through long lists. You can find files the agent changed, read, or created, and a failed preview explains why the file could not open. Phone previews also leave more room for the document while keeping its name visible.
+
+If an agent file changes after you open it for editing, Save now warns you and keeps your draft. Choose Reload to use the newer file, or Overwrite to replace it with your version. Overwrite discards the newer changes rather than combining them, and the warning cannot catch every simultaneous edit made by another program.
+
+
+
+###### Sources and complete change list
+
+
+**Bug fixes**
+
+- Protect newer workspace edits from stale editor saves [#135865](https://github.com/openclaw/openclaw/pull/135865). Context [#127592](https://github.com/openclaw/openclaw/issues/127592). Thanks @yetval, @obviyus.
+- Correct expanded file-preview tooltips [#142039](https://github.com/openclaw/openclaw/pull/142039).
+- Compact phone file previews and retain fullscreen identity [#142536](https://github.com/openclaw/openclaw/pull/142536). Thanks @vyctorbrzezowski.
+- Browse long file lists with search and filters [#143854](https://github.com/openclaw/openclaw/pull/143854).
+- Show why a file could not open [#143958](https://github.com/openclaw/openclaw/pull/143958). Thanks @Marvinthebored, @Peetiegonzalez, @obviyus.
+
+
+
+
+
+
+##### See what Codex's helper agents did
+
+
+Open a Codex helper agent in Tasks to read its conversation, see its work, and load earlier messages. You can look at a file and return without making the conversation load again. Newly created tasks also stay readable as the main chat continues, although some older tasks still lack readable history, and resetting the chat or changing Codex accounts can prevent access.
+
+
+
+###### Sources and complete change list
+
+
+**Improvements**
+
+- Read native Codex subagent transcripts in the Tasks sidebar [#143747](https://github.com/openclaw/openclaw/pull/143747).
+
+**Bug fixes**
+
+- Retain subagent transcripts across parent turns [#143869](https://github.com/openclaw/openclaw/pull/143869).
+- Preserve Review transcripts across Files navigation [#144073](https://github.com/openclaw/openclaw/pull/144073).
+
+
+
+
+
+
+##### Follow ongoing and completed work
+
+
+Finished and cancelled helper tasks stop showing their old working messages, while their summaries of changed files remain available. Long reports stay readable without hiding the button back to the conversation that started the task, and short progress updates no longer show stray formatting symbols. Agents also get clearer instructions to skip progress cards for quick questions and save them for substantial work.
+
+
+
+###### Sources and complete change list
+
+
+**Bug fixes**
+
+- Clear stale activity text when subagent tasks finish [#129610](https://github.com/openclaw/openclaw/pull/129610). Thanks @jalehman.
+- Keep tool commentary single and visible after refresh [#140834](https://github.com/openclaw/openclaw/pull/140834). Thanks @leapdragon, @obviyus.
+- Preserve paragraphs and code blocks in displayed reasoning [#142231](https://github.com/openclaw/openclaw/pull/142231).
+- Keep subagent reports above the view-only footer [#142275](https://github.com/openclaw/openclaw/pull/142275). Thanks @vyctorbrzezowski.
+- Preserve literal text in tool activity previews [#142436](https://github.com/openclaw/openclaw/pull/142436).
+- Discourage progress cards for quick requests [#142696](https://github.com/openclaw/openclaw/pull/142696). Thanks @vyctorbrzezowski.
+- Make subagent activity previews readable [#143741](https://github.com/openclaw/openclaw/pull/143741).
+
+
+
+
+
+
+##### Enlarge Dashboard and restore your layout
+
+
+Click the [Dashboard](https://docs.openclaw.ai/web/dashboards) tab to give it the full task area, then click again to return to your previous layout. Your draft and anything entered into the dashboard stay in place. Dashboard progress also follows the conversation it belongs to, so selecting a different agent elsewhere does not make running work look paused.
+
+
+
+###### Sources and complete change list
+
+
+**Improvements**
+
+- Expand Dashboard and restore the original split [#143579](https://github.com/openclaw/openclaw/pull/143579). Thanks @fuller-stack-dev.
+
+**Bug fixes**
+
+- Show activity for the dashboard widget's target session [#137255](https://github.com/openclaw/openclaw/pull/137255). Context [#137188](https://github.com/openclaw/openclaw/issues/137188). Thanks @sunlit-deng, @obviyus, @Richard355168, @benjaml4.
+
+
+
+
+
+
+##### Upload files and restore terminal tabs
+
+
+When you use Claude Code, Codex, OpenCode, or Pi in a terminal on a paired computer, choosing or dropping a file now puts its location into the terminal for you to use. You can edit it before pressing Enter. Reloading while several terminal tabs are reconnecting also keeps tabs that previously disappeared from the list.
+
+If uploads remain blocked after a crash, follow the [terminal recovery steps](https://docs.openclaw.ai/web/control-ui/panels). Stop all OpenClaw host processes sharing the upload folder on the computer running that terminal before removing the lock named in the error.
+
+
+
+###### Sources and complete change list
+
+
+**Bug fixes**
+
+- Recover terminal uploads after failed lock release [#141250](https://github.com/openclaw/openclaw/pull/141250). Context [#137116](https://github.com/openclaw/openclaw/issues/137116). Thanks @shakkernerd.
+- Insert uploaded paths into paired-node coding terminals [#142001](https://github.com/openclaw/openclaw/pull/142001). Thanks @shakkernerd.
+- Keep terminal tabs during interrupted restoration [#144015](https://github.com/openclaw/openclaw/pull/144015). Thanks @vincentkoc.
+
+**Documentation**
+
+- Translate terminal upload-path errors [#142077](https://github.com/openclaw/openclaw/pull/142077).
+
+
+
+
+
+
+##### Search and edit Settings
+
+
+In [Settings](https://docs.openclaw.ai/web/control-ui/settings), removing an earlier list item no longer throws away unfinished text in another item. Correct and save that text before leaving the page, since unfinished drafts are not kept after a reload. Number buttons also stop skipping the first allowed value, and Web search clearly stays off when the person managing OpenClaw has disabled it.
+
+
+
+###### Sources and complete change list
+
+
+**Improvements**
+
+- Open Agents settings on Overview [#142884](https://github.com/openclaw/openclaw/pull/142884). Thanks @jalehman.
+
+**Bug fixes**
+
+- Match Web search controls to the global disable setting [#121557](https://github.com/openclaw/openclaw/pull/121557). Context [#121401](https://github.com/openclaw/openclaw/issues/121401). Thanks @zyw02, @obviyus.
+- Distinguish Mac and iPad browser labels [#136545](https://github.com/openclaw/openclaw/pull/136545). Context [#136544](https://github.com/openclaw/openclaw/issues/136544). Thanks @TheAngryPit, @obviyus.
+- Keep shortened account labels valid Unicode [#137686](https://github.com/openclaw/openclaw/pull/137686). Thanks @ly85206559, @obviyus.
+- Start empty numeric settings at the first allowed value [#142201](https://github.com/openclaw/openclaw/pull/142201).
+- Keep unfinished Settings edits when list rows move [#142564](https://github.com/openclaw/openclaw/pull/142564).
+- Preserve Settings phrase matches around tag filters [#142618](https://github.com/openclaw/openclaw/pull/142618).
+- Keep agent identity fields inside their card [#143763](https://github.com/openclaw/openclaw/pull/143763).
+
+
+
+
+
+
+##### Recognize people and agents
+
+
+The mention picker keeps suggestions available while you refine a search, making it easier to choose someone for a shared chat. Agent pictures now load in the picker and Settings on token-protected connections, and changing an agent's name or emoji updates an open chat without losing your draft.
+
+
+
+###### Sources and complete change list
+
+
+**Improvements**
+
+- Simplify mention labels and improve picker layout [#142274](https://github.com/openclaw/openclaw/pull/142274). Thanks @vyctorbrzezowski.
+- Reduce repeated presence reads across watched sessions [#142612](https://github.com/openclaw/openclaw/pull/142612).
+
+**Bug fixes**
+
+- Restore picker avatars on authenticated Gateways [#140954](https://github.com/openclaw/openclaw/pull/140954). Context [#140879](https://github.com/openclaw/openclaw/issues/140879). Thanks @LiuwqGit, @obviyus, @dimonnld, @rondavis007.
+- Label shared Gateway owner presence in the web UI [#141863](https://github.com/openclaw/openclaw/pull/141863).
+- Restore saved avatars in agent settings [#142015](https://github.com/openclaw/openclaw/pull/142015). Thanks @LiuwqGit, @obviyus, @lei-happy.
+- Keep person mention suggestions available while typing [#142332](https://github.com/openclaw/openclaw/pull/142332). Thanks @vyctorbrzezowski.
+- Refresh open-chat identity after agent edits [#142581](https://github.com/openclaw/openclaw/pull/142581). Thanks @aim9sour.
+- Save smaller replacement agent avatars without size-drop rejection [#143147](https://github.com/openclaw/openclaw/pull/143147). Thanks @LiuwqGit, @obviyus, @skaneta.
+
+
+
+
+
+
+##### Read usage and system status
+
+
+Usage keeps conversation details with the correct agent and counts the conversations actually shown in the list, with the total displayed separately. If you run OpenClaw on Linux with Bun, System busyness can show CPU and delay readings again instead of leaving permanent dashes. A dash just after starting still means the first reading is not ready.
+
+
+
+###### Sources and complete change list
+
+
+**Bug fixes**
+
+- Match Usage session counts to the visible list [#141749](https://github.com/openclaw/openclaw/pull/141749).
+- Keep Usage details tied to the selected agent [#143457](https://github.com/openclaw/openclaw/pull/143457).
+- Restore CPU and delay readings on Linux Bun [#143805](https://github.com/openclaw/openclaw/pull/143805).
+
+
+
+
+
+
+##### Get back to chatting after a stalled screen
+
+
+If a reply has finished but the screen still shows Stop, clicking it can bring back the completed reply and Send button without a page reload. On phones, failed messages keep Retry or Discard visible when those actions are available, and a request that times out before replying can leave an explanation that remains after reloading. Before sending again, check whether the first request already did the work, since a connection problem can leave delivery uncertain.
+
+
+
+###### Sources and complete change list
+
+
+**Bug fixes**
+
+- Keep chat delivery recovery controls visible on mobile [#141798](https://github.com/openclaw/openclaw/pull/141798). Thanks @Takhoffman.
+- Keep no-reply timeout notices in conversation history [#142135](https://github.com/openclaw/openclaw/pull/142135). Thanks @chelsealong, @obviyus, @von8794.
+- Ask for a Gateway token after remembered device credentials fail [#143156](https://github.com/openclaw/openclaw/pull/143156).
+- Restore Send when Stop finds a finished run [#143437](https://github.com/openclaw/openclaw/pull/143437). Thanks @ylcn91, @obviyus, @YanHE1169.
+
+**Documentation**
+
+- Match connection guidance to Gateway UI labels [#141789](https://github.com/openclaw/openclaw/pull/141789).
+
+
+
+
+
+
+##### Read replies and use familiar controls
+
+
+Opening the command palette no longer blurs the conversation behind it, so you can refer to a message while choosing an action. Copying a reply gives a compact green check, GitHub links avoid empty preview popups, and the first reply no longer triggers confetti. On Mac, use Command+B, Command+F, and Command+K for the sidebar, conversation search, and command palette; the Control versions are left for text editing. Windows and Linux keep Control for these shortcuts.
+
+
+
+###### Sources and complete change list
+
+
+**Improvements**
+
+- Use a neutral border around user avatars [#138285](https://github.com/openclaw/openclaw/pull/138285). Context [#138277](https://github.com/openclaw/openclaw/issues/138277). Thanks @vyctorbrzezowski.
+- Prepare the Inbox panel before opening [#142316](https://github.com/openclaw/openclaw/pull/142316). Thanks @vyctorbrzezowski.
+- Keep background text readable behind the command palette [#142944](https://github.com/openclaw/openclaw/pull/142944). Thanks @jalehman.
+- Remove first-reply confetti from chat [#143167](https://github.com/openclaw/openclaw/pull/143167). Thanks @Patrick-Erichsen.
+
+**Bug fixes**
+
+- Offer automatic host selection in the exec picker [#137565](https://github.com/openclaw/openclaw/pull/137565). Thanks @jalehman.
+- Preserve Unicode when shortening Mermaid errors [#137669](https://github.com/openclaw/openclaw/pull/137669). Thanks @ly85206559, @obviyus.
+- Keep unavailable GitHub previews quiet [#141896](https://github.com/openclaw/openclaw/pull/141896). Thanks @RomneyDa.
+- Skip rejected read updates in restricted chats [#142043](https://github.com/openclaw/openclaw/pull/142043).
+- Match menu highlights to the active theme [#142243](https://github.com/openclaw/openclaw/pull/142243). Thanks @vyctorbrzezowski.
+- Release temporary focus handlers after using chat pickers [#142258](https://github.com/openclaw/openclaw/pull/142258).
+- Remove unintended underlines from button links [#142335](https://github.com/openclaw/openclaw/pull/142335). Thanks @vyctorbrzezowski.
+- Reject invalid custom chat message widths [#142635](https://github.com/openclaw/openclaw/pull/142635).
+- Remove duplicate tooltips from GitHub preview links [#142637](https://github.com/openclaw/openclaw/pull/142637). Thanks @vyctorbrzezowski.
+- Preserve Mac text-editing Control shortcuts [#142674](https://github.com/openclaw/openclaw/pull/142674). Thanks @jalehman.
+- Show the correct Option/Alt+Click session-selection shortcut [#143051](https://github.com/openclaw/openclaw/pull/143051). Thanks @vincentkoc.
+- Align chat actions and retain green copy confirmation [#143425](https://github.com/openclaw/openclaw/pull/143425). Thanks @Patrick-Erichsen.
+
+
+
+
+
+
+##### Get an explanation when an interactive card breaks
+
+
+OpenClaw can catch some coding mistakes in [widgets](https://docs.openclaw.ai/tools/show-widget), the small interactive apps an agent can place in chat, before they appear. If a recent card fails while you use it, the web app can show a Script error notice and tell the agent what happened, giving it a chance to help you recover.
+
+
+
+###### Sources and complete change list
+
+
+**Improvements**
+
+- Show widget script failures and notify the agent [#142225](https://github.com/openclaw/openclaw/pull/142225).
+
+**Bug fixes**
+
+- Catch widget script syntax errors before display [#141939](https://github.com/openclaw/openclaw/pull/141939).
+
+
+
+
+
+
+##### Read updated interface guidance
+
+
+More labels and help text are translated in Settings, plugin browsing, Files, and cloud-worker controls. Settings also uses available translations when you search for a field, making it easier to find an option in your chosen language.
+
+
+
+###### Sources and complete change list
+
+
+**Improvements**
+
+- Translate connection progress and setup-code guidance [#141750](https://github.com/openclaw/openclaw/pull/141750).
+- Translate Shared owner labels in the web UI [#141881](https://github.com/openclaw/openclaw/pull/141881).
+- Translate board-widget script error labels [#142147](https://github.com/openclaw/openclaw/pull/142147).
+- Translate model-discovery status and retry messages [#142334](https://github.com/openclaw/openclaw/pull/142334).
+- Refresh translations across 20 interface languages [#142699](https://github.com/openclaw/openclaw/pull/142699).
+- Refresh plugin-screen translations in 20 languages [#143622](https://github.com/openclaw/openclaw/pull/143622).
+- Refresh cloud-worker and notice translations [#143868](https://github.com/openclaw/openclaw/pull/143868).
+- Translate file and snapshot controls [#143924](https://github.com/openclaw/openclaw/pull/143924).
+- Translate snapshot-building controls and errors [#144011](https://github.com/openclaw/openclaw/pull/144011).
+
+**Bug fixes**
+
+- Apply available translations to core Settings fields [#137192](https://github.com/openclaw/openclaw/pull/137192). Context [#137190](https://github.com/openclaw/openclaw/issues/137190). Thanks @husodrn46, @obviyus.
+- Localize the picker's No matches message [#142255](https://github.com/openclaw/openclaw/pull/142255).
+- Correct parent-session and dashboard translations [#142327](https://github.com/openclaw/openclaw/pull/142327).
+
+**Documentation**
+
+- Refresh translated Gateway connection guidance [#141803](https://github.com/openclaw/openclaw/pull/141803).
+- Align maturity documentation with current product names [#142065](https://github.com/openclaw/openclaw/pull/142065). Thanks @RomneyDa.
+
+
+
+
+
+
+
+#### Updates and Maintenance
+
+Updating OpenClaw gets fixes for stalled upgrades, plugins left behind, and confusing recovery messages. There are also improvements to bringing older conversations and settings forward, backing up the files you need, and cleaning up history without getting in the way of other work.
+
+
+
+
+##### Complete an update
+
+
+Updates from recent stable releases can get past failures that prevented them from finishing or left OpenClaw stopped afterward. Updating from the browser also gets a startup fix, and active conversations are less likely to hold up an update. Some fixes only help after the newer updater is installed, so if your current version is stuck, follow the [update guidance](https://docs.openclaw.ai/cli/update/how-updates-run) rather than repeatedly trying the same failing command.
+
+
+
+###### Sources and complete change list
+
+
+**Bug fixes**
+
+- Let older updaters finish and restart the Gateway [#142195](https://github.com/openclaw/openclaw/pull/142195) Thanks @Newsstand.
+- Check Node compatibility before dev-update installation [#142248](https://github.com/openclaw/openclaw/pull/142248) Thanks @TheAngryPit, @jialele, @obviyus.
+- Correct Node compatibility advice during updates [#142322](https://github.com/openclaw/openclaw/pull/142322) Thanks @SunnyShu0925, @guarismo.
+- Allow update checks while agent databases are busy [#142419](https://github.com/openclaw/openclaw/pull/142419) Thanks @jalehman.
+- Restore restart launch after updates from the 2026.9.1 Git build 0229a108 [#142631](https://github.com/openclaw/openclaw/pull/142631) Thanks @jason-allen-oneal.
+- Follow the activated package directory during managed pnpm updates [#143137](https://github.com/openclaw/openclaw/pull/143137) Thanks @timetrvlr.
+- Preserve bundled-plugin trust during update trials [#143190](https://github.com/openclaw/openclaw/pull/143190) Thanks @DonnieFi.
+- Restore upgrades from older stable releases [#143859](https://github.com/openclaw/openclaw/pull/143859)
+- Verify the same Gateway through update checks [#143863](https://github.com/openclaw/openclaw/pull/143863) Thanks @fuller-stack-dev.
+- Fix managed-update helper startup [#144031](https://github.com/openclaw/openclaw/pull/144031) Thanks @IWhatsskill, @fuller-stack-dev.
+- Allow confirmed service-less Linux updates, keep transcript stdout clean, preserve custom root/account schema types, and reuse warm Claude CLI processes when prepared skills are unchanged [#144402](https://github.com/openclaw/openclaw/pull/144402) Thanks @vincentkoc.
+
+**Limits and compatibility**
+
+- Align package versions and extension compatibility requirements [86ef455b](https://github.com/openclaw/openclaw/commit/86ef455b05483a94947ba26777ca94a9cc5d27d9)
+
+
+
+
+
+
+##### Update an installation built from source
+
+
+If you run OpenClaw from a Git checkout, updates can recover when an upstream release tag changes, and Windows gets a fix for updates failing before they begin. Status now warns when a failed update check left its information out of date. That warning clears after the updater next fetches successfully. If your checkout has several possible update sources, the [development-channel guide](https://docs.openclaw.ai/install/development-channels) explains how to choose one.
+
+
+
+###### Sources and complete change list
+
+
+**Bug fixes**
+
+- Recover Git updates when upstream release tags move [#126816](https://github.com/openclaw/openclaw/pull/126816) Thanks @ruel225, @zhangguiping-xydt, @ToneLoke. Context [#123318](https://github.com/openclaw/openclaw/issues/123318).
+- Sync source assets with unusual filenames [#142024](https://github.com/openclaw/openclaw/pull/142024)
+- Warn when failed update fetches leave status information stale [#142199](https://github.com/openclaw/openclaw/pull/142199) Thanks @ToneLoke.
+- Fix Windows Git configuration paths for updates and cloning [#142749](https://github.com/openclaw/openclaw/pull/142749) Thanks @pengzh1, @aevgeniou, @jalehman.
+
+
+
+
+
+
+##### Recover from a failed update
+
+
+When an update fails, OpenClaw can put the previous app version back if it still works with your current settings and data. If that cannot be checked, recovery stops and leaves the available recovery files in place for inspection. An interrupted update may still need manual help. Rolling back the app does not restore your data, so [make and verify a backup before updating](https://docs.openclaw.ai/install/updating/rollback-and-recovery).
+
+
+
+###### Sources and complete change list
+
+
+**Bug fixes**
+
+- Preserve existing state when Gateway startup needs repair [#141451](https://github.com/openclaw/openclaw/pull/141451) Thanks @Lendersmark, @jerabinovich.
+- Correct version checks after failed-update recovery [#142817](https://github.com/openclaw/openclaw/pull/142817) Thanks @wangmiao0668000666.
+- Stop rollback after updater ownership is lost [#143791](https://github.com/openclaw/openclaw/pull/143791) Thanks @vincentkoc, @fuller-stack-dev.
+- Report failed temporary-copy cleanup [#143844](https://github.com/openclaw/openclaw/pull/143844) Thanks @fuller-stack-dev.
+- Stop plugin writes after update ownership loss [#144130](https://github.com/openclaw/openclaw/pull/144130) Thanks @fuller-stack-dev.
+
+**Limits and compatibility**
+
+- Guard compatible package rollback and interrupted updates, finish plugin work before restart, add copied-agent preflight, honor same-version package artifacts, and suppress unsolicited standalone restart notices [000af986](https://github.com/openclaw/openclaw/commit/000af986dc991e9cef3d10663c121503606f25cc) Thanks @fuller-stack-dev. Context [#140339](https://github.com/openclaw/openclaw/pull/140339).
+
+
+
+
+
+
+##### Clear a stuck update message
+
+
+An old “update in progress” message can stop blocking settings changes and account sign-in even when the update itself is no longer running. `openclaw update repair` can clear eligible stuck updates once it confirms the updater has stopped and OpenClaw is working. Some older requests that never got started clear automatically after a day, provided nothing still needs recovery. They remain in history as failed attempts, with guidance to retry.
+
+
+
+###### Sources and complete change list
+
+
+**Bug fixes**
+
+- Repair abandoned update runs without an unnecessary 30-minute wait [#143136](https://github.com/openclaw/openclaw/pull/143136) Thanks @yncubys, @guarismo, @SunnyShu0925.
+- Clear abandoned legacy updates that block settings writes [#143774](https://github.com/openclaw/openclaw/pull/143774) Thanks @Colton-Harris, @syfvb, @ElvisIO7, @rlosito, @alexph-dev, @aaajiao, @c0ncatenate, @unknowbug, @KingAkrej, @DasX, @jlacroix82, @mikronn2, @najef1979-code.
+
+**Documentation**
+
+- Explain automatic expiry of old update records [#143974](https://github.com/openclaw/openclaw/pull/143974)
+
+
+
+
+
+
+##### Give lengthy repairs time to finish
+
+
+Updates on larger installations now give Doctor, OpenClaw's repair tool, time to finish work that used to be cut short. Some failures to remove disposable files become warnings with cleanup advice, while problems that prevent the updated app from working still stop the update. A stuck repair can keep waiting unless you set a limit, and stopping the update may leave repair work running, so use the [repair guidance](https://docs.openclaw.ai/cli/update/repair-and-recovery) if progress stops.
+
+
+
+###### Sources and complete change list
+
+
+**Bug fixes**
+
+- Allow long update Doctor repairs to finish [#143321](https://github.com/openclaw/openclaw/pull/143321) Thanks @fuller-stack-dev.
+- Continue updates after recoverable cleanup failures [#143767](https://github.com/openclaw/openclaw/pull/143767)
+
+
+
+
+
+
+##### Choose what follows a failed update
+
+
+If an update fails but the previous installation is restored and checked, the menu defaults to Exit. You can choose to investigate or preview a report before sending it. For other interactive update failures, the repair prompt tells you which AI agent will run and that it uses your account allowance or paid tokens. You can decline, but pressing Enter accepts and leaving the prompt unanswered starts the agent after 30 seconds.
+
+Claude-assisted repairs start without project customizations that could delay them. If your repair needs those custom tools or instructions, use the manual command provided instead. The [repair-agent guide](https://docs.openclaw.ai/cli/triage) explains the choices and Claude requirements.
+
+
+
+###### Sources and complete change list
+
+
+**Improvements**
+
+- Offer a choice before automatic update repair launches an agent [#143139](https://github.com/openclaw/openclaw/pull/143139)
+
+**Bug fixes**
+
+- Make diagnosis optional after verified update rollback [#143657](https://github.com/openclaw/openclaw/pull/143657) Thanks @fuller-stack-dev.
+
+**Documentation**
+
+- Clarify update failure recovery choices [#143723](https://github.com/openclaw/openclaw/pull/143723)
+
+**Limits and compatibility**
+
+- Start direct Claude triage in safe mode with advertised support, documented for Claude Code 2.1.169 or newer [#143474](https://github.com/openclaw/openclaw/pull/143474) Thanks @RomneyDa.
+
+
+
+
+
+
+##### Understand update progress and warnings
+
+
+Update progress and the final report now agree about what happened, including when an update failed but the previous version was successfully restored. Warnings keep useful repair advice and identify leftover backup files, and a problem reading history no longer hides other update guidance. If an update stalls, more of its troubleshooting information is kept. You can [inspect the update report](https://docs.openclaw.ai/cli/update/status-and-history), or run `openclaw doctor` afterward for checks that are not needed during the update itself.
+
+
+
+###### Sources and complete change list
+
+
+**Improvements**
+
+- Identify child processes in stalled update diagnostics [#141740](https://github.com/openclaw/openclaw/pull/141740) Thanks @hannesrudolph.
+- Skip unrelated Doctor diagnostics during updates [#142675](https://github.com/openclaw/openclaw/pull/142675) Thanks @fuller-stack-dev.
+
+**Bug fixes**
+
+- Skip optional update probes and retain Doctor warnings [#141995](https://github.com/openclaw/openclaw/pull/141995) Thanks @hannesrudolph.
+- Preserve core Doctor warnings during updates [#142091](https://github.com/openclaw/openclaw/pull/142091)
+- Retain Doctor diagnostics when update finalization times out [#142672](https://github.com/openclaw/openclaw/pull/142672) Thanks @fuller-stack-dev.
+- Show refreshed commit counts before updating [#142837](https://github.com/openclaw/openclaw/pull/142837) Thanks @jalehman.
+- Keep update guidance available when history fails [#143557](https://github.com/openclaw/openclaw/pull/143557)
+- Load update history without pausing other Gateway work [#143605](https://github.com/openclaw/openclaw/pull/143605)
+- Stop advertising unavailable update-report files [#143748](https://github.com/openclaw/openclaw/pull/143748)
+- Correct agent guidance for authorized SSH updates to a different host while retaining normal approvals [#143754](https://github.com/openclaw/openclaw/pull/143754)
+- Report final update results and retained backups [#143921](https://github.com/openclaw/openclaw/pull/143921) Thanks @fuller-stack-dev.
+- Keep update progress consistent with final reports [#143965](https://github.com/openclaw/openclaw/pull/143965)
+
+**Documentation**
+
+- Split update documentation into focused guides [#142858](https://github.com/openclaw/openclaw/pull/142858) Thanks @vincentkoc.
+- Split updating guidance into focused pages [#142993](https://github.com/openclaw/openclaw/pull/142993) Thanks @vincentkoc.
+
+
+
+
+
+
+##### Update plugins when OpenClaw is already current
+
+
+Running `openclaw update` now checks eligible plugins even if the main app is already up to date, including after you updated it separately. When nothing changes, it skips unnecessary follow-up work. If you deliberately kept a plugin at a particular version, that choice stays in place and notices of newer official releases explain how to change it. Plugin updates may need a restart, and plugin downloads during an app update can extend the time OpenClaw is unavailable.
+
+
+
+###### Sources and complete change list
+
+
+**Improvements**
+
+- Skip unnecessary plugin scans during updates [#143783](https://github.com/openclaw/openclaw/pull/143783)
+
+**Bug fixes**
+
+- Report newer releases without replacing official plugin pins [#137892](https://github.com/openclaw/openclaw/pull/137892) Thanks @pfrederiksen, @vincentkoc. Context [#137624](https://github.com/openclaw/openclaw/issues/137624).
+- Show warnings for retained official plugin pins [#142457](https://github.com/openclaw/openclaw/pull/142457) Thanks @PollyBot13, @obviyus, @martins-oss.
+- Run plugin maintenance when core is already current [#143174](https://github.com/openclaw/openclaw/pull/143174) Thanks @martins-oss, @fulgerulnegru, @kesslerio, @guojiongming, @soroyue, @Sedrak-Hovhannisyan.
+- Skip redundant completion when updates change nothing [#143462](https://github.com/openclaw/openclaw/pull/143462) Thanks @RomneyDa.
+- Skip plugins already repaired under new IDs [#143861](https://github.com/openclaw/openclaw/pull/143861)
+
+
+
+
+
+
+##### Repair older settings and moved workspaces
+
+
+Doctor can bring more older settings and saved accounts forward without losing your model choices or asking you to edit configuration files by hand. It can also recognize a moved workspace and preserve its setup history, while leaving uncertain matches for review.
+
+If an older Claude conversation has not been converted to the current format, run `openclaw doctor --fix` before resuming it. The [Doctor checks guide](https://docs.openclaw.ai/cli/doctor/checks) explains that step and the cases that still need manual help.
+
+
+
+###### Sources and complete change list
+
+
+**Bug fixes**
+
+- Fix optional Codex checks, configuration-less update finalization, and private Doctor snapshot cleanup [f212072e](https://github.com/openclaw/openclaw/commit/f212072e4c6e5f67f356b4b213a0059bbdb07db2)
+- Repair moved workspaces without blocking queued messages [#133198](https://github.com/openclaw/openclaw/pull/133198) Thanks @safzanpirani, @obviyus. Context [#133172](https://github.com/openclaw/openclaw/issues/133172).
+- Preserve Unicode in shortened SQLite worker errors [#137675](https://github.com/openclaw/openclaw/pull/137675) Thanks @ly85206559, @obviyus.
+- Wait for cooperating plugins to release Doctor inspection resources through their registration-local disposal callback [#141692](https://github.com/openclaw/openclaw/pull/141692)
+- Show backup recovery guidance for unreadable Doctor state [#141776](https://github.com/openclaw/openclaw/pull/141776)
+- Stop Doctor suggesting the skill repair already underway [#141866](https://github.com/openclaw/openclaw/pull/141866)
+- Explain shallow snapshot failures and incomplete clones [#141936](https://github.com/openclaw/openclaw/pull/141936)
+- Preserve model choices and backends during Doctor migration [#142284](https://github.com/openclaw/openclaw/pull/142284) Thanks @obviyus.
+- Respect search-provider choice in missing-plugin repair; the separate release-repair path can still select Brave from environment credentials [#142640](https://github.com/openclaw/openclaw/pull/142640) Thanks @vincentkoc.
+- Correct full Doctor lint paths and preserve inspected sidecars and skill links; ordinary lint retains its separate shared-memory limitation [#142839](https://github.com/openclaw/openclaw/pull/142839) Thanks @thien-ngn, @obviyus.
+- Restore legacy multi-agent backups without manual ownership edits [#143202](https://github.com/openclaw/openclaw/pull/143202) Thanks @GitHoubi.
+- Repair legacy music-model references with Doctor [#143235](https://github.com/openclaw/openclaw/pull/143235) Thanks @obviyus.
+- Preserve saved accounts through Doctor migration [#143429](https://github.com/openclaw/openclaw/pull/143429) Thanks @obviyus.
+
+**Documentation**
+
+- Organize Doctor guidance by repair task [#141961](https://github.com/openclaw/openclaw/pull/141961) Thanks @vincentkoc.
+- Organize Doctor CLI documentation by task [#142855](https://github.com/openclaw/openclaw/pull/142855) Thanks @vincentkoc.
+
+**Limits and compatibility**
+
+- Migrate legacy Claude conversation bindings with Doctor [#143347](https://github.com/openclaw/openclaw/pull/143347) Thanks @obviyus.
+
+
+
+
+
+
+##### Bring older conversations forward
+
+
+Importing older Codex conversations now keeps assistant replies that could previously go missing, in their original order. If you already imported an affected conversation, recovery can add missing replies, but it adds them at the end rather than rebuilding the original conversation order. Repairs to attachment information also survive when saved conversation archives are recreated. If a backup-linked file blocks an import, the error points to the file and the [safe recovery steps](https://docs.openclaw.ai/cli/doctor/sqlite-maintenance#hard-linked-legacy-artifacts).
+
+
+
+###### Sources and complete change list
+
+
+**Bug fixes**
+
+- Preserve Codex replies during legacy session import [#140296](https://github.com/openclaw/openclaw/pull/140296) Thanks @ylcn91, @ikenraf. Context [#140100](https://github.com/openclaw/openclaw/issues/140100).
+- Explain hard-linked session migration refusals with recovery guidance [#143195](https://github.com/openclaw/openclaw/pull/143195) Thanks @GitHoubi.
+- Preserve repaired media metadata in session archives [#143595](https://github.com/openclaw/openclaw/pull/143595) Thanks @fuller-stack-dev.
+
+
+
+
+
+
+##### Back up all the settings files you need
+
+
+If you split your settings across several files, a full backup now includes the files your main configuration refers to, even outside the usual backup folders. It stops with repair guidance if those files cannot be captured completely. The `--only-config` option still saves just the main file.
+
+Backups also handle a disappearing temporary database file when its contents are already safely captured. A backup does not freeze the whole installation at one instant, so changes made while it runs may not all be included. Treat the archive as sensitive because settings files can contain secrets, and follow the [backup guide](https://docs.openclaw.ai/cli/backup) when checking or restoring it.
+
+
+
+###### Sources and complete change list
+
+
+**Bug fixes**
+
+- Keep backups running when snapshotted SQLite sidecars disappear [#141161](https://github.com/openclaw/openclaw/pull/141161) Thanks @LiuwqGit, @vincentkoc, @Cobblestone-Digital1, @legupsystems. Context [#141042](https://github.com/openclaw/openclaw/issues/141042). Context [#67417](https://github.com/openclaw/openclaw/issues/67417).
+- Preserve required configuration includes in full backups [#143693](https://github.com/openclaw/openclaw/pull/143693) Thanks @fuller-stack-dev.
+
+
+
+
+
+
+##### Check larger installations
+
+
+Installations with a lot of saved data get more time to finish database checks, and some checks need less temporary disk space and avoid repeated work. This helps when maintenance previously stopped before it could finish, while keeping the checks for damaged data. If something goes wrong, errors give more useful clues about where the check stopped and when Doctor may be able to help.
+
+
+
+###### Sources and complete change list
+
+
+**Improvements**
+
+- Show the last observed database integrity-check phase [#141669](https://github.com/openclaw/openclaw/pull/141669)
+- Reduce temporary disk space for applicable SQLite inspection snapshots [#141773](https://github.com/openclaw/openclaw/pull/141773)
+- Report slow session-cleanup worker operations [#142525](https://github.com/openclaw/openclaw/pull/142525)
+- Reduce database snapshot startup overhead [#144022](https://github.com/openclaw/openclaw/pull/144022)
+
+**Bug fixes**
+
+- Allow large databases more startup-check time [#141918](https://github.com/openclaw/openclaw/pull/141918)
+- Give large database inspections a size-based timeout [#142179](https://github.com/openclaw/openclaw/pull/142179)
+- Avoid redundant database scans during Doctor repair [#142669](https://github.com/openclaw/openclaw/pull/142669) Thanks @fuller-stack-dev.
+- Keep healthy memory database handles open when no repair is needed and skip GitHub credential and bootstrap-size advisories during updates [#143361](https://github.com/openclaw/openclaw/pull/143361) Thanks @fuller-stack-dev.
+- Name the Doctor repair command in SQLite startup errors [#143531](https://github.com/openclaw/openclaw/pull/143531) Thanks @RomneyDa.
+
+**Documentation**
+
+- Organize database reference and recovery guidance [#143152](https://github.com/openclaw/openclaw/pull/143152) Thanks @vincentkoc.
+
+
+
+
+
+
+##### Keep working during history cleanup
+
+
+Deleting sessions and cleaning up old conversations are less likely to pause other work while OpenClaw checks its saved data. Cleanup also checks again before deleting more history, so it can stop when enough space has been freed and leave newly protected conversations alone. Your retention settings still decide what can be removed.
+
+
+
+###### Sources and complete change list
+
+
+**Bug fixes**
+
+- Recheck protected history and disk pressure during cleanup [#142505](https://github.com/openclaw/openclaw/pull/142505) Thanks @HermanZeng.
+- Move cold session-cleanup checks off the Gateway main thread [#143226](https://github.com/openclaw/openclaw/pull/143226)
+- Stop excess session cleanup after disk pressure clears [#143285](https://github.com/openclaw/openclaw/pull/143285)
+- Move cold database checks out of history cleanup planning [#143332](https://github.com/openclaw/openclaw/pull/143332)
+- Avoid Gateway pauses during archive database reopening [#143379](https://github.com/openclaw/openclaw/pull/143379)
+- Keep session updates responsive during database reopening [#143434](https://github.com/openclaw/openclaw/pull/143434)
+- Reopen cleanup databases without blocking other work [#143602](https://github.com/openclaw/openclaw/pull/143602)
+
+
+
+
+
+
+##### Restart and shut down OpenClaw
+
+
+Linux users get fixes for restarts that stayed stuck and for conflicting settings that made OpenClaw restart over and over. Those conflicts now leave an error to fix before starting again. Shutdown also gives plugins and voice connections time to finish their cleanup and final writes, though a stuck plugin can still delay it.
+
+Reconnecting avoids repeating unnecessary [health checks](https://docs.openclaw.ai/gateway/health), while fresh checks remain available when needed.
+
+
+
+###### Sources and complete change list
+
+
+**Bug fixes**
+
+- Avoid false repair advice for masked systemd services [#137869](https://github.com/openclaw/openclaw/pull/137869) Thanks @teddytennant, @obviyus, @aniruddhaadak80. Context [#128928](https://github.com/openclaw/openclaw/issues/128928).
+- Prevent managed systemd restarts from hanging [#140914](https://github.com/openclaw/openclaw/pull/140914) Thanks @NianJiuZst, @rboy1, @obviyus. Context [#140821](https://github.com/openclaw/openclaw/issues/140821).
+- Keep affected CLI-started Gateways running after transient DNS rejections without retrying the failed operation [#141163](https://github.com/openclaw/openclaw/pull/141163) Thanks @ly85206559, @orangejon. Context [#141123](https://github.com/openclaw/openclaw/issues/141123).
+- Return service-unavailable responses when a Gateway handshake fails before WebSocket transfer [#141303](https://github.com/openclaw/openclaw/pull/141303) Thanks @hugenshen, @obviyus.
+- Wait for Talk connection cleanup during shutdown [#141706](https://github.com/openclaw/openclaw/pull/141706)
+- Keep startup logs current after plugin reloads [#141736](https://github.com/openclaw/openclaw/pull/141736)
+- Stop restart loops caused by conflicting Gateway settings [#141771](https://github.com/openclaw/openclaw/pull/141771) Thanks @chelsealong, @tomdailey55, @jalehman.
+- Keep shared Gateway state available through cleanup [#142286](https://github.com/openclaw/openclaw/pull/142286)
+- Finish pending cleanup before automatic macOS CLI exit [#142814](https://github.com/openclaw/openclaw/pull/142814)
+- Avoid repeated health collection on reconnects [#143384](https://github.com/openclaw/openclaw/pull/143384)
+- Preserve restart options during schema upgrades [#143738](https://github.com/openclaw/openclaw/pull/143738) Thanks @RomneyDa.
+
+**Documentation**
+
+- Split Gateway CLI reference by operator task [#143005](https://github.com/openclaw/openclaw/pull/143005) Thanks @vincentkoc.
+- Organize Gateway troubleshooting by symptom [#143160](https://github.com/openclaw/openclaw/pull/143160) Thanks @vincentkoc.
+
+
+
+
+
+
+##### Manage settings outside OpenClaw
+
+
+If another tool manages your OpenClaw settings, a new [read-only configuration option](https://docs.openclaw.ai/cli/config#externally-managed-config) keeps OpenClaw from overwriting them, including during automatic recovery. Set `OPENCLAW_CONFIG_READONLY=1` for both the running service and terminal commands. Conversations and other working data still need somewhere writable, and model changes can apply to the current session without changing the saved default.
+
+Settings edits after creating or changing an agent also avoid false “changed since last load” errors. Saving and applying settings remain separate, so if you turned automatic reload off, restart OpenClaw to use the changes.
+
+
+
+###### Sources and complete change list
+
+
+**Improvements**
+
+- Add a read-only mode for externally managed configuration [#140719](https://github.com/openclaw/openclaw/pull/140719) Thanks @sallyom. Context [#140706](https://github.com/openclaw/openclaw/issues/140706). Context [#103606](https://github.com/openclaw/openclaw/issues/103606).
+
+**Bug fixes**
+
+- Refresh configuration revisions after agent changes [#142169](https://github.com/openclaw/openclaw/pull/142169) Thanks @ceckert, @obviyus.
+- Explain managed-configuration refusals without crash diagnostics [#143140](https://github.com/openclaw/openclaw/pull/143140)
+
+**Documentation**
+
+- Clarify manual restart requirements in reload-off mode [#127205](https://github.com/openclaw/openclaw/pull/127205) Context [#127203](https://github.com/openclaw/openclaw/issues/127203).
+- Split Gateway configuration guidance into topic pages [#143456](https://github.com/openclaw/openclaw/pull/143456) Thanks @vincentkoc.
+
+
+
+
+
+
+##### Stop and update OpenClaw on Windows
+
+
+For Windows installations using OpenClaw’s standard launcher, stopping the scheduled Gateway task now stops the work it started too, allowing a fresh start without a leftover copy getting in the way. Early startup failures also reach the log. Custom executable wrappers or extra command-shell layers can still prevent startup. Slow Windows service checks get another chance during updates, but a check that keeps hanging can make the wait much longer; if the service cannot be checked, the update stops before replacing the app.
+
+
+
+###### Sources and complete change list
+
+
+**Bug fixes**
+
+- Stop Windows Gateway task descendants and log child failures [#141744](https://github.com/openclaw/openclaw/pull/141744) Thanks @akagifreeez, @Devin-Linux, @unknowbug.
+- Honor update timeouts for Windows service checks [#143292](https://github.com/openclaw/openclaw/pull/143292) Thanks @fanyuantaier.
+
+
+
+
+
+
+##### Find monitoring help
+
+
+The [monitoring guide](https://docs.openclaw.ai/gateway/opentelemetry) makes it easier to find help setting up monitoring, understanding what information it captures, or using that information in dashboards. The instructions are organized around those tasks, with existing links still leading to the right place.
+
+
+
+###### Sources and complete change list
+
+
+**Documentation**
+
+- Split OpenTelemetry guidance into focused pages [#142951](https://github.com/openclaw/openclaw/pull/142951) Thanks @vincentkoc.
+
+
+
+
+
+
+
+#### Messaging
+
+This update fixes several ways a conversation could lose its words, its reply, or its place. Long answers keep their formatting, Feishu document tools work again in affected chats, and Talk can bring an answer back after handing work to another agent.
+
+
+
+
+##### Replies and progress updates
+
+
+Messages arriving while OpenClaw is paused now wait until it is ready again, and unfinished replies are no longer mistaken for completed sends. If you show detailed progress, newer work stays visible instead of being crowded out by old command failures. Missing-reply notices also give a clearer explanation and a reference your administrator can use to investigate.
+
+
+
+###### Sources and complete change list
+
+
+**Bug fixes**
+
+- Hide internal finalizer placeholders in message-only groups [73ca607b1d99](https://github.com/openclaw/openclaw/commit/73ca607b1d9940ecb040527da0a3c610d15bc64a). Thanks @razvangirgiz, @obviyus, @omarshahine. Contextual provenance [#138645](https://github.com/openclaw/openclaw/pull/138645).
+- Keep unfinished replies pending during forced cleanup [#141900](https://github.com/openclaw/openclaw/pull/141900). Thanks @Takhoffman.
+- Pause message retries during Gateway suspension [#142064](https://github.com/openclaw/openclaw/pull/142064). Thanks @goutamadwant, @obviyus, @Stephane-fci.
+- Keep plans and newer activity visible after repeated command exits [#142802](https://github.com/openclaw/openclaw/pull/142802). Thanks @obviyus.
+
+**Improvements**
+
+- Add clearer missing-reply notices and run references [#136462](https://github.com/openclaw/openclaw/pull/136462). Thanks @RomneyDa, @sloptop-the-terrible.
+
+
+
+
+
+
+##### Readable long replies
+
+
+[Long replies](https://docs.openclaw.ai/concepts/streaming) break at more natural places, and code keeps its formatting when it continues into another message. Code that arrived successfully no longer causes the whole answer to be repeated at the end. Quoted examples also keep their spacing, making them easier to read and copy.
+
+
+
+###### Sources and complete change list
+
+
+**Bug fixes**
+
+- Preserve paragraph boundaries between streamed assistant messages [#140833](https://github.com/openclaw/openclaw/pull/140833). Thanks @leapdragon, @obviyus.
+- Preserve quoted code spacing when removing delivery directives [#141767](https://github.com/openclaw/openclaw/pull/141767). Thanks @Alix-007, @obviyus.
+- Preserve message-ID code examples in conversation displays [#141769](https://github.com/openclaw/openclaw/pull/141769). Thanks @Alix-007, @obviyus.
+- Preserve converted images that retain HEIC filenames [#142263](https://github.com/openclaw/openclaw/pull/142263).
+- Align short and empty code-table columns [#142406](https://github.com/openclaw/openclaw/pull/142406).
+- Keep streamed prose and code formatted without duplicate finals [#143722](https://github.com/openclaw/openclaw/pull/143722). Thanks @obviyus, @rgregg.
+
+
+
+
+
+
+##### Telegram formatting and stickers
+
+
+If you enable [Telegram rich messages](https://docs.openclaw.ai/channels/telegram), links inside lists, quotes, and expandable sections stay clickable and keep their styling. Code examples keep their spacing in messages and photo captions too. Sticker descriptions now use your chosen image model and reach your Claw in time for its first reply.
+
+
+
+###### Sources and complete change list
+
+
+**Bug fixes**
+
+- Preserve styled links and formatting in rich messages [#139976](https://github.com/openclaw/openclaw/pull/139976).
+- Honor image defaults and retain sticker descriptions [#142023](https://github.com/openclaw/openclaw/pull/142023). Thanks @obviyus.
+- Preserve code-example spacing in Telegram text and captions [#142504](https://github.com/openclaw/openclaw/pull/142504).
+
+
+
+
+
+
+##### Telegram mentions and commands
+
+
+[Telegram](https://docs.openclaw.ai/channels/telegram) recognizes mentions that tag the bot’s account in messages and photo captions. If you have native commands turned off, you can write `/think high` on one line and your request below it without losing the request. The `/think` menu also shows the setting for the agent handling that chat, and canceled attempts no longer leave a misleading “stalled” reaction afterward.
+
+
+
+###### Sources and complete change list
+
+
+**Bug fixes**
+
+- Recognize bot identity mentions in text and captions [#140266](https://github.com/openclaw/openclaw/pull/140266). Thanks @cai-ops, @obviyus.
+- Stop stale stall reactions after cancelled preparation [#141079](https://github.com/openclaw/openclaw/pull/141079). Thanks @ooiuuii, @obviyus.
+- Preserve tasks after multiline Telegram directives [#142008](https://github.com/openclaw/openclaw/pull/142008). Thanks @wangmiao0668000666, @obviyus.
+- Show the routed agent's thinking default in Telegram [#143789](https://github.com/openclaw/openclaw/pull/143789).
+
+**Documentation**
+
+- Organize Telegram documentation by task [#142963](https://github.com/openclaw/openclaw/pull/142963). Thanks @vincentkoc.
+
+
+
+
+
+
+##### Telegram replies after proxy failures
+
+
+If you connect Telegram through a proxy and it refuses the connection before a reply is sent, OpenClaw can keep that reply for another attempt when the connection returns. It still avoids resending messages whose delivery is uncertain, so this does not automatically recover every previously failed reply.
+
+
+
+###### Sources and complete change list
+
+
+**Bug fixes**
+
+- Recover queued replies after proxy tunnel refusals [#140388](https://github.com/openclaw/openclaw/pull/140388). Thanks @Hekzory, @MAG-Linares-Andalucia.
+
+
+
+
+
+
+##### Discord messages, voice notes, and progress
+
+
+In [Discord](https://docs.openclaw.ai/channels/discord) channels where your Claw can already read messages without being mentioned, voice notes now keep their spoken words in the conversation. Attachment captions also keep repeated instructions, and progress updates remain visible if the final answer cannot be sent.
+
+Requests such as checking OpenClaw’s system status can work again from server messages when you have permission, fixing a case where the request was refused despite the tool being available.
+
+
+
+###### Sources and complete change list
+
+
+**Bug fixes**
+
+- Populate member presence from startup and reconnect snapshots [#141218](https://github.com/openclaw/openclaw/pull/141218). Thanks @harshitgupta31415, @vincentkoc, @nissl24.
+- Preserve Discord commentary and progress after send failures [#141621](https://github.com/openclaw/openclaw/pull/141621). Thanks @anyech, @obviyus, @dw1161.
+- Preserve repeated Discord captions and link-button emoji [#142342](https://github.com/openclaw/openclaw/pull/142342).
+- Preserve voice-note words in Discord ambient conversations [#142860](https://github.com/openclaw/openclaw/pull/142860). Thanks @ericcaiwx-star, @aatreya, @jalehman.
+- Restore permitted system-agent delegation in Discord guild messages [#143006](https://github.com/openclaw/openclaw/pull/143006). Thanks @Marvinthebored, @Peetiegonzalez, @obviyus, @0xCyda, @lisheguo.
+
+**Documentation**
+
+- Organize Discord documentation into focused guides [#142666](https://github.com/openclaw/openclaw/pull/142666). Thanks @vincentkoc.
+
+
+
+
+
+
+##### Slack reactions and message formatting
+
+
+Slack can show its configured reaction when it picks up your mention even if you have ongoing status reactions turned off. [Messages containing Windows paths](https://docs.openclaw.ai/channels/slack/media) also keep their formatting without accidentally turning the text that follows into code.
+
+
+
+###### Sources and complete change list
+
+
+**Bug fixes**
+
+- Resolve a shared workspace for owner heartbeat DMs [#138689](https://github.com/openclaw/openclaw/pull/138689). Thanks @Kimiyu-186.
+- Keep Slack prose out of code formatting after Windows paths [#142288](https://github.com/openclaw/openclaw/pull/142288).
+- Keep Slack acknowledgements when status reactions are off [#142595](https://github.com/openclaw/openclaw/pull/142595). Thanks @sunlit-deng, @alexjpanagis.
+
+
+
+
+
+
+##### Feishu documents and formatted messages
+
+
+If a separately installed Feishu plugin stopped letting your Claw work with documents, wikis, Drive, or Bitable from chat, those tools are available again with your existing permissions. Changes to [tool and account settings](https://docs.openclaw.ai/channels/feishu/advanced-configuration) now apply to new requests without restarting OpenClaw, while work already underway keeps its earlier settings. Your Claw also receives the emphasis you put in formatted messages, links, and mentions.
+
+
+
+###### Sources and complete change list
+
+
+**Improvements**
+
+- Skip unnecessary table parsing for plain Feishu cards and stop checking over-limit cards [#141770](https://github.com/openclaw/openclaw/pull/141770). Table-heavy cases do not share a general speedup.
+
+**Bug fixes**
+
+- Restore Feishu workspace tools in message-driven runs [#141984](https://github.com/openclaw/openclaw/pull/141984). Thanks @SunnyShu0925, @hayden-cc, @lizhengwu, @jalehman, @seven7763, @itanyplus.
+- Apply updated Feishu tool settings to new turns [#141993](https://github.com/openclaw/openclaw/pull/141993).
+- Preserve Feishu inline styles in received posts [#142627](https://github.com/openclaw/openclaw/pull/142627).
+
+**Documentation**
+
+- Organize Feishu documentation by task [#143085](https://github.com/openclaw/openclaw/pull/143085). Thanks @vincentkoc.
+
+
+
+
+
+
+##### Matrix messages and reactions
+
+
+[Matrix](https://docs.openclaw.ai/channels/matrix) keeps message text that could previously be mistaken for an attachment and disappear from quoted replies or conversation history. A mention marked as plain text also stays plain when earlier code formatting is unfinished. In the terminal, reaction lists show which emoji people used instead of leaving the label blank.
+
+
+
+###### Sources and complete change list
+
+
+**Bug fixes**
+
+- Preserve Matrix text for unknown message types [#135359](https://github.com/openclaw/openclaw/pull/135359). Thanks @teddytennant, @obviyus.
+- Show Matrix reaction labels in CLI listings [#141811](https://github.com/openclaw/openclaw/pull/141811).
+- Keep escaped Matrix mentions literal after unmatched backticks [#142369](https://github.com/openclaw/openclaw/pull/142369).
+
+**Documentation**
+
+- Organize Matrix documentation into focused guides [#142996](https://github.com/openclaw/openclaw/pull/142996). Thanks @vincentkoc.
+
+
+
+
+
+
+##### Teams message text
+
+
+Your Claw now reads punctuation and symbols correctly in [Teams messages](https://docs.openclaw.ai/channels/msteams) supplied as HTML, instead of receiving formatting codes in their place. For example, a copyright symbol arrives as © rather than the code used to represent it.
+
+
+
+###### Sources and complete change list
+
+
+**Bug fixes**
+
+- Decode HTML-only Teams message text correctly [#142496](https://github.com/openclaw/openclaw/pull/142496).
+
+**Documentation**
+
+- Organize Teams documentation into focused guides [#142986](https://github.com/openclaw/openclaw/pull/142986). Thanks @vincentkoc.
+
+
+
+
+
+
+##### Signal reply quotes
+
+
+If you set [Signal](https://docs.openclaw.ai/channels/signal) to quote your message only on the first reply, that quote now stays available when an earlier send fails. The first reply that actually arrives shows what it is answering.
+
+
+
+###### Sources and complete change list
+
+
+**Documentation**
+
+- Document Signal table modes, default bullets, and block-to-code fallback [#138160](https://github.com/openclaw/openclaw/pull/138160). Thanks @SunnyShu0925, @obviyus.
+
+**Bug fixes**
+
+- Preserve Signal quotes after failed streamed sends [#142600](https://github.com/openclaw/openclaw/pull/142600).
+
+
+
+
+
+
+##### WhatsApp reply labels
+
+
+If you use a custom label at the start of your Claw’s WhatsApp replies, it no longer gets added to messages coming from other people. Your outgoing labels still work, and incoming messages keep what the sender wrote.
+
+
+
+###### Sources and complete change list
+
+
+**Bug fixes**
+
+- Keep reply prefixes out of incoming WhatsApp messages [#138819](https://github.com/openclaw/openclaw/pull/138819). Thanks @sunlit-deng, @vincentkoc, @Jackten.
+
+
+
+
+
+
+##### iMessage conversation names
+
+
+[iMessage](https://docs.openclaw.ai/channels/imessage) conversations can show familiar contact and group names, such as Alice or Family, when that information is available. Names you assigned yourself stay in place, making it easier to find the right chat without sorting through phone numbers or technical IDs.
+
+
+
+###### Sources and complete change list
+
+
+**Documentation**
+
+- Clarify current iMessage support in maturity docs [#141963](https://github.com/openclaw/openclaw/pull/141963). Thanks @RomneyDa.
+- Organize iMessage guides by setup and messaging task [#143038](https://github.com/openclaw/openclaw/pull/143038). Thanks @vincentkoc.
+
+**Bug fixes**
+
+- Show resolved iMessage contact and group names [#142128](https://github.com/openclaw/openclaw/pull/142128). Thanks @omarshahine.
+
+
+
+
+
+
+##### Mattermost connections and progress
+
+
+For Mattermost setups that store login tokens separately from account settings, editing one account no longer unnecessarily reconnects the others; settings shared by all accounts can still restart them together. A replacement progress message also stays visible while the old one is being removed, even when both contain the same plan.
+
+
+
+###### Sources and complete change list
+
+
+**Bug fixes**
+
+- Keep other Mattermost accounts connected during settings reloads [#142193](https://github.com/openclaw/openclaw/pull/142193). Thanks @ceckert, @obviyus.
+- Preserve replacement Mattermost progress previews [#143621](https://github.com/openclaw/openclaw/pull/143621).
+
+
+
+
+
+
+##### Returning to Google Chat conversations
+
+
+Replies from a resumed Google Chat conversation can use its saved destination correctly again. This fixes a case where changing capital letters in the destination caused a permission error, even though your Claw was allowed to send there.
+
+
+
+###### Sources and complete change list
+
+
+**Bug fixes**
+
+- Preserve destination casing for resumed Google Chat replies [#140418](https://github.com/openclaw/openclaw/pull/140418). Thanks @aeoess, @obviyus, @jailbirt.
+
+
+
+
+
+
+##### Nextcloud Talk reaction delays
+
+
+When diagnostic recording is enabled, a successful Nextcloud Talk reaction no longer has to wait for that recording to finish before reporting success. The recording may be incomplete, but it no longer holds up the result.
+
+
+
+###### Sources and complete change list
+
+
+**Bug fixes**
+
+- Avoid diagnostic-capture delays in Nextcloud Talk responses [#141307](https://github.com/openclaw/openclaw/pull/141307). Thanks @hugenshen, @obviyus.
+
+
+
+
+
+
+##### Missing Tlon setup details
+
+
+If a Tlon message cannot send because setup is incomplete, the error now tells you which account needs attention and which settings are missing. You can go straight to the relevant part of [Tlon setup](https://docs.openclaw.ai/channels/tlon) without guessing, and the error does not reveal your login code.
+
+
+
+###### Sources and complete change list
+
+
+**Bug fixes**
+
+- Identify missing Tlon account settings in send errors [#137664](https://github.com/openclaw/openclaw/pull/137664). Thanks @ly85206559, @obviyus.
+
+
+
+
+
+
+##### Repairing older Zalo Personal settings
+
+
+If you use multiple Zalo Personal accounts with an older setup, `openclaw doctor --fix --non-interactive` can now complete a settings repair it previously skipped. Your account profiles and explicit choices about who may message the bot stay intact.
+
+
+
+###### Sources and complete change list
+
+
+**Bug fixes**
+
+- Restore Zalo Personal policy migration [#143860](https://github.com/openclaw/openclaw/pull/143860). Thanks @wangmiao0668000666, @obviyus.
+
+
+
+
+
+
+##### Choosing and managing messaging accounts
+
+
+Account lists and health checks more accurately show which accounts your agents use. [Removing an account](https://docs.openclaw.ai/cli/channels) now reports when nothing was removed, and [message-command errors](https://docs.openclaw.ai/cli/message) explain how to choose an agent when one is needed.
+
+If you use scripts, leave out `--account` and the [directory](https://docs.openclaw.ai/cli/directory) option `--limit` when you want their defaults. Passing an empty value now causes an error; a supplied limit must be a positive whole number. Removal scripts must also handle an error when nothing was removed.
+
+
+
+###### Sources and complete change list
+
+
+**Limits and compatibility**
+
+- Reject blank account options in directory commands [#137334](https://github.com/openclaw/openclaw/pull/137334). Thanks @Alix-007, @obviyus.
+- Reject explicitly empty directory listing limits [#141738](https://github.com/openclaw/openclaw/pull/141738). Thanks @hugenshen, @obviyus.
+- Reject empty account selectors in message and channel commands [#143088](https://github.com/openclaw/openclaw/pull/143088). Thanks @ly85206559, @obviyus.
+
+**Bug fixes**
+
+- Show channel account selectors correctly in agent listings [#141724](https://github.com/openclaw/openclaw/pull/141724).
+- Give message commands a working ownership remedy [#141886](https://github.com/openclaw/openclaw/pull/141886). Thanks @Dreamer-HIT, @obviyus, @schwanncells.
+- Include implicit default accounts in health output and listBoundAccountIds [#143319](https://github.com/openclaw/openclaw/pull/143319). Thanks @qingminglong, @obviyus.
+- Preserve channel subtitles before plugins load [#143416](https://github.com/openclaw/openclaw/pull/143416).
+- Reject blank directory groups before plugin setup [#143440](https://github.com/openclaw/openclaw/pull/143440).
+- Reject unknown channel accounts during removal [#143561](https://github.com/openclaw/openclaw/pull/143561). Thanks @masatohoshino, @obviyus.
+
+**Documentation**
+
+- Split channel configuration documentation into focused pages [#142910](https://github.com/openclaw/openclaw/pull/142910). Thanks @vincentkoc.
+- Correct Matrix token and restart steps, Tlon login guidance, Yuanbao App Key instructions, and plugin publishing and SDK examples [#144018](https://github.com/openclaw/openclaw/pull/144018). Thanks @vincentkoc, @sunnyiren-max.
+
+
+
+
+
+
+##### Keep talking while your Claw delegates work
+
+
+[Talk](https://docs.openclaw.ai/nodes/talk) can keep listening while another agent works on your request, then bring the finished answer back to the same voice conversation as well as chat. This also works when the task needs more than one round of help. Keep that voice conversation open to receive the spoken result; ending it or restarting OpenClaw can leave the answer available only through chat.
+
+
+
+###### Sources and complete change list
+
+
+**Bug fixes**
+
+- Keep voice follow-ups and replies with the active task [#129186](https://github.com/openclaw/openclaw/pull/129186). Thanks @vincentkoc.
+- Return delegated answers to the active Talk session [#129535](https://github.com/openclaw/openclaw/pull/129535). Thanks @vincentkoc.
+- Deliver Talk answers after repeated delegation [#142830](https://github.com/openclaw/openclaw/pull/142830).
+
+**Documentation**
+
+- Organize Talk guidance into focused pages [#143149](https://github.com/openclaw/openclaw/pull/143149). Thanks @vincentkoc.
+
+
+
+
+
+
+##### Phone interruptions and brief audio errors
+
+
+When you interrupt your Claw on a phone call, it now uses the phone service’s playback confirmation to avoid treating an answer you never heard as already spoken. GPT-Live calls through OpenClaw can also continue after an occasional recoverable audio error, though you may hear a brief gap. Repeated failures can still end the call; see the [Voice Call guide](https://docs.openclaw.ai/plugins/voice-call) for setup and troubleshooting.
+
+
+
+###### Sources and complete change list
+
+
+**Bug fixes**
+
+- Restore the default Twilio voice for certain unrecognized names [#137678](https://github.com/openclaw/openclaw/pull/137678). Thanks @teddytennant, @obviyus.
+- Keep unknown call statuses from ending active calls [#137679](https://github.com/openclaw/openclaw/pull/137679). Thanks @teddytennant, @obviyus.
+- Track confirmed phone playback when callers interrupt [#138619](https://github.com/openclaw/openclaw/pull/138619). Thanks @LiuwqGit, @obviyus, @fabiolr, @xueqingli1.
+- Keep GPT-Live calls connected after recoverable audio errors [#140702](https://github.com/openclaw/openclaw/pull/140702). Thanks @zenglingbiao, @obviyus.
+- Return clear errors for unknown voice stream paths [#141315](https://github.com/openclaw/openclaw/pull/141315). Thanks @hugenshen, @obviyus.
+
+**Documentation**
+
+- Organize Voice Call guidance into focused topic pages [#143055](https://github.com/openclaw/openclaw/pull/143055). Thanks @vincentkoc.
+
+
+
+
+
+
+
+#### Memory
+
+Memory fixes help your Claw find remembered details and return to older conversations. There is also clearer guidance when memories cannot be saved, or when deleting a conversation leaves its memories behind.
+
+
+
+
+##### Finding remembered details
+
+
+Asking for a short list of memories no longer drops a better match just because you requested fewer results. Your Claw can also keep looking when an optional search gets stuck, and a local memory-search service gets time to start before OpenClaw gives up on it. These fixes help remembered information reach your conversation without unnecessary repair steps.
+
+
+
+###### Sources and complete change list
+
+
+**Bug fixes**
+
+- Keep top memory matches consistent at small result limits [ff1d91f](https://github.com/openclaw/openclaw/commit/ff1d91f6711b301ad0bb8f8f9485bfb05d770d84). Thanks @linhongyu510.
+- Recover memory searches after manager replacement [#141879](https://github.com/openclaw/openclaw/pull/141879).
+- Preserve Active Memory recall after optional lookup timeouts [#142567](https://github.com/openclaw/openclaw/pull/142567). Thanks @ylcn91, @obviyus, @BsnizND.
+- Allow local embedding startup before timing memory searches [#143590](https://github.com/openclaw/openclaw/pull/143590). Thanks @wangmiao0668000666, @obviyus, @PeterHodl.
+- Skip unnecessary recall for agent deliveries [#143903](https://github.com/openclaw/openclaw/pull/143903). Thanks @LiuwqGit, @obviyus, @kiagentkronos-cell, @syfvb.
+
+
+
+
+
+
+##### Setting up memory search
+
+
+OpenClaw can wait through temporary limits from your memory-search provider and use the right model when it switches to your configured backup. It also stops telling you to rebuild working memory search just because the main provider has recovered. If you change to an incompatible model, you still need to rebuild with `openclaw memory index --force`.
+
+Mac users running OpenClaw with Bun can enable native memory search with `brew install sqlite`. If you previously used a custom SQLite startup script, replace it with the `OPENCLAW_SQLITE_LIBRARY` setting to avoid a startup failure.
+
+
+
+###### Sources and complete change list
+
+
+**Improvements**
+
+- Enable native memory search with Homebrew SQLite on macOS Bun; replace custom SQLite preloads with `OPENCLAW_SQLITE_LIBRARY`, and replace the removed `OPENCLAW_CLAUDE_CLI_LOG_OUTPUT` alias with `OPENCLAW_CLI_BACKEND_LOG_OUTPUT` [#141854](https://github.com/openclaw/openclaw/pull/141854).
+
+**Bug fixes**
+
+- Respect provider cooldowns during memory indexing [#134959](https://github.com/openclaw/openclaw/pull/134959). Thanks @shojikumaru, @obviyus, @developercrocodiles.
+- Use the fallback provider's model for memory embeddings [#142364](https://github.com/openclaw/openclaw/pull/142364). Thanks @Yigtwxx, @obviyus.
+- Recognize fallback-built indexes in deep memory status [#142609](https://github.com/openclaw/openclaw/pull/142609). Thanks @Yigtwxx, @obviyus.
+
+
+
+
+
+
+##### Choosing what becomes long-term memory
+
+
+With the default settings, a note no longer becomes long-term memory simply because OpenClaw repeatedly encounters it during background scans. It must also turn up in different memory searches, helping keep incidental notes from being saved just because they keep appearing. After updating, some older notes may take longer to qualify, while memories already saved stay in place.
+
+
+
+###### Sources and complete change list
+
+
+**Bug fixes**
+
+- Require distinct recall queries for automatic memory promotion; configurations with `minUniqueQueries=0` retain their existing allowance [#119624](https://github.com/openclaw/openclaw/pull/119624). Thanks @pcpilot-dev, @RomneyDa, @sunnyandtec-ak, @zachisfine.
+
+
+
+
+
+
+##### Returning to older conversations
+
+
+[Session search](https://docs.openclaw.ai/concepts/session-search) can now open saved messages from before a conversation reset, taking you back to the original discussion instead of an empty page. Fixes also help queued replies continue after OpenClaw shortens a long conversation, so you can pick up where you left off.
+
+
+
+###### Sources and complete change list
+
+
+**Improvements**
+
+- Reduce temporary memory during long-conversation checks [#143175](https://github.com/openclaw/openclaw/pull/143175).
+
+**Bug fixes**
+
+- Open retained session search results after a reset [#141437](https://github.com/openclaw/openclaw/pull/141437). Thanks @VACInc.
+- Accept redundant offsets in anchored session-history requests [#141664](https://github.com/openclaw/openclaw/pull/141664). Thanks @FlagshipClaw, @obviyus, @VACInc, @brainatworkharris.
+- Prevent lost replies after compaction and session handoff [#141718](https://github.com/openclaw/openclaw/pull/141718). Thanks @VACInc.
+- Avoid full-history reads for delivery confirmations [#142453](https://github.com/openclaw/openclaw/pull/142453). Thanks @VACInc, @todddickerson.
+- Keep memory maintenance within the conversation context budget [#143193](https://github.com/openclaw/openclaw/pull/143193). Thanks @KirDE, @obviyus.
+
+
+
+
+
+
+##### Knowing what was saved or forgotten
+
+
+Deleting a conversation now tells you when its saved history can still appear in memory search and shows the command for [forgetting those memories](https://docs.openclaw.ai/cli/memory#memory-forget). Forgetting remains a separate step, which you need to run on the computer hosting OpenClaw, even if you deleted the conversation remotely.
+
+When an automatic memory save lacks permission to write, the logs now name the file it could not save. They also explain more reasons why [Active Memory](https://docs.openclaw.ai/concepts/active-memory) skipped a search, making missing memories easier to investigate. These are clearer warnings, so a reported save problem still needs attention.
+
+
+
+###### Sources and complete change list
+
+
+**Bug fixes**
+
+- Warn when memory flushes cannot write their target file [#127031](https://github.com/openclaw/openclaw/pull/127031). Thanks @ayaangazali, @fede-kamel, @vincentkoc.
+- Show selected recall-skip reasons in default logs [#138658](https://github.com/openclaw/openclaw/pull/138658). Thanks @DasX, @obviyus, @Oliverbot26.
+- Explain memory cleanup after deleting a session [#141841](https://github.com/openclaw/openclaw/pull/141841). Thanks @glenn-agent, @obviyus, @dh-js, @he-yufeng.
+- Check memory readiness while agent databases are busy [#142361](https://github.com/openclaw/openclaw/pull/142361).
+- Avoid unnecessary Doctor refusals for shared-memory layouts; preserve edited archives without importing their changes, and defer later event generations in that workspace [#143138](https://github.com/openclaw/openclaw/pull/143138).
+
+**Documentation**
+
+- Explain tool grants for Lossless Claw recall [#142705](https://github.com/openclaw/openclaw/pull/142705). Thanks @MasterSwords1, @obviyus, @guarismo.
+- Split Active Memory guidance into task-specific pages [#143057](https://github.com/openclaw/openclaw/pull/143057). Thanks @vincentkoc.
+
+
+
+
+
+
+##### Keep conversation-history plugins working
+
+
+If you use a [plugin to manage conversation history](https://docs.openclaw.ai/concepts/context-engine), summaries are less likely to fail because a connection closed too soon. OpenClaw also avoids unexpectedly switching to a backup plugin while a turn starts. Cancelling can still stop further changes to the conversation while the plugin finishes closing its connections.
+
+
+
+###### Sources and complete change list
+
+
+**Bug fixes**
+
+- Keep background compaction resources through cleanup [#143426](https://github.com/openclaw/openclaw/pull/143426).
+- Retain context engines through turn cleanup [#143491](https://github.com/openclaw/openclaw/pull/143491).
+- Keep compaction databases open through pending cleanup [#143592](https://github.com/openclaw/openclaw/pull/143592).
+- Keep copied context engines available through cleanup [#143626](https://github.com/openclaw/openclaw/pull/143626).
+- Keep compaction tool services available through outstanding work [#143633](https://github.com/openclaw/openclaw/pull/143633).
+
+
+
+
+
+
+##### Using memories added by other tools
+
+
+If another tool adds memories to your [LanceDB memory extension](https://docs.openclaw.ai/plugins/memory-lancedb), your Claw can find them on its next search without restarting OpenClaw. You can also list or delete those newly added memories without first having to make a change from inside OpenClaw.
+
+
+
+###### Sources and complete change list
+
+
+**Bug fixes**
+
+- Refresh LanceDB reads after external memory writes [#137806](https://github.com/openclaw/openclaw/pull/137806). Thanks @azuretek, @obviyus.
+
+**Documentation**
+
+- Clarify the existing LanceDB requirements for OpenClaw host version `>=2026.5.31` and plugin API `>=2026.9.3`, which must both pass [#142827](https://github.com/openclaw/openclaw/pull/142827). Thanks @obviyus, @ly85206559.
+
+
+
+
+
+
+
+#### Skills
+
+Skills give your Claw reusable instructions for the work you do together. This update makes them easier to find and set up, and lets you watch and guide your Claw as it looks for ways to improve skills using past conversations.
+
+
+
+
+##### Search installed skills and ClawHub together
+
+
+The [Skills page](https://docs.openclaw.ai/tools/skills) now searches your installed skills and ClawHub together, so you can see what you already have and what you can add without checking separate places. Cards show which skills are ready or need setup, and switching agents shows the skills available to that agent. You can also browse popular skills without typing a search, while clearer titles and readable descriptions make it easier to choose.
+
+
+
+###### Sources and complete change list
+
+
+**Improvements**
+
+- Search installed skills and ClawHub together [#143758](https://github.com/openclaw/openclaw/pull/143758). Thanks @Patrick-Erichsen.
+
+**Bug fixes**
+
+- Find repository skills in separate execution workspaces [#141966](https://github.com/openclaw/openclaw/pull/141966). Thanks @obviyus.
+- Show and find skills by their actual titles [#142535](https://github.com/openclaw/openclaw/pull/142535).
+- Keep ClawHub details and changelogs readable in dialogs [#142555](https://github.com/openclaw/openclaw/pull/142555). Thanks @vyctorbrzezowski.
+
+
+
+
+
+
+##### Import, install, and read skills
+
+
+When importing a skill, you can now see which files you selected and clear them before continuing. Skill windows fit the screen and keep Close within reach, making longer instructions easier to read on a phone. Installations that need more time to download or set up supporting software can also finish without being cut off as early.
+
+
+
+###### Sources and complete change list
+
+
+**Improvements**
+
+- Show and clear selected files during skill import [#142540](https://github.com/openclaw/openclaw/pull/142540). Thanks @vyctorbrzezowski.
+
+**Bug fixes**
+
+- Fit skill dialogs to content with compact Close controls [#142550](https://github.com/openclaw/openclaw/pull/142550). Thanks @vyctorbrzezowski.
+- Allow slower Control UI skill dependency installs to finish [#143000](https://github.com/openclaw/openclaw/pull/143000). Thanks @gozu, @obviyus.
+
+
+
+
+
+
+##### Learn from past conversations in a visible chat
+
+
+Choose “Learn from past conversations” in [Skill Workshop](https://docs.openclaw.ai/tools/skill-workshop) to open a chat where you can follow the work, add direction, or stop it. Auto lets your Claw apply improvements based on what it finds, while Propose leaves suggestions for you to approve. Starting this yourself does not turn on automatic self-learning, and normal model charges and access permissions still apply.
+
+Old unfinished history scans cannot resume in the new flow, so start a new learning chat instead. Your installed skills and existing proposals stay available. Workshop also explains when automatic weekly reviews are paused because scheduling is off and takes you to the setting.
+
+
+
+###### Sources and complete change list
+
+
+**Improvements**
+
+- Learn from past conversations in a steerable chat [#142909](https://github.com/openclaw/openclaw/pull/142909). Thanks @obviyus.
+- Explain paused weekly skill reviews [#142840](https://github.com/openclaw/openclaw/pull/142840). Thanks @obviyus.
+
+**Bug fixes**
+
+- Ground Workshop review targets and restore the Team Reports listing [#141575](https://github.com/openclaw/openclaw/pull/141575).
+
+**Documentation**
+
+- Split Skill Workshop documentation into focused guides [#143079](https://github.com/openclaw/openclaw/pull/143079). Thanks @vincentkoc.
+
+
+
+
+
+
+##### Keep current skill instructions available
+
+
+After restarting OpenClaw, you can continue an existing conversation with updated local skill files on its next turn. Skill lists also pick up newly installed or repaired files more reliably. Skills selected from a managed library keep their chosen version until you refresh them.
+
+New Workshop changes preserve the full descriptions that help your Claw recognize when to use a skill, instead of replacing them with short change labels. This protects future edits, but does not restore descriptions already lost or repair older pending proposals.
+
+
+
+###### Sources and complete change list
+
+
+**Bug fixes**
+
+- Refresh session skills after Gateway restarts [#122110](https://github.com/openclaw/openclaw/pull/122110). Thanks @sappkevin, @obviyus, @kashivreddy, @aspalagin.
+- Preserve full skill descriptions through Workshop updates [#140864](https://github.com/openclaw/openclaw/pull/140864). Thanks @LiuwqGit, @obviyus, @XX441, @laisonamarante, @RuiCatalao7, @thomasmoenco.
+- Refresh skill availability after installs and edits [#141979](https://github.com/openclaw/openclaw/pull/141979). Thanks @RomneyDa.
+- Show repaired skills on the first status check [#142123](https://github.com/openclaw/openclaw/pull/142123). Thanks @ericcaiwx-star, @aspalagin, @obviyus.
+- Clarify how agents should make requested repository skill edits outside Workshop [#142844](https://github.com/openclaw/openclaw/pull/142844). Thanks @Finn763, @obviyus, @jmissig.
+- Give sandboxed plugin agents readable skill paths [#143291](https://github.com/openclaw/openclaw/pull/143291). Thanks @sallyom, @sercada, @Artemeey.
+
+
+
+
+
+
+##### Use skills on cloud and remote computers
+
+
+If your Claw works on a cloud or SSH-connected computer, it now spends less time copying skills before starting, especially when you have lots of small skill files. Cloud workers can also use supported links between instruction files within the same local skill, so you do not have to duplicate those files just to get the skill working there.
+
+
+
+###### Sources and complete change list
+
+
+**Improvements**
+
+- Batch skill transfers before remote turns [#142440](https://github.com/openclaw/openclaw/pull/142440).
+
+**Bug fixes**
+
+- Deliver contained skill file aliases to cloud workers [#143378](https://github.com/openclaw/openclaw/pull/143378).
+
+
+
+
+
+
+##### Fix Workshop problems after updating
+
+
+Doctor can repair several known Workshop problems that stopped upgrades or prevented OpenClaw from starting. Run `openclaw doctor --fix` when startup asks for it. Proposals and backups that need you to identify their agent remain available for review while other repairs continue. Some older review history may be discarded if its agent cannot be identified, and affected proposals may need reviewing again.
+
+
+
+###### Sources and complete change list
+
+
+**Bug fixes**
+
+- Repair the legacy Workshop review index with Doctor [1e7797ad9836](https://github.com/openclaw/openclaw/commit/1e7797ad983683a3cd691887f1b398164ddc6282). Thanks @jjjhenriksen, @RomneyDa.
+- Continue Doctor repairs while preserving ambiguous Workshop artifacts [#143141](https://github.com/openclaw/openclaw/pull/143141). Thanks @fahrenhe1t, @GitHoubi, @cjn119-ui, @obviyus.
+- Repair recognized unfinished Workshop database upgrades [#143153](https://github.com/openclaw/openclaw/pull/143153). Thanks @syfvb, @pbergeot, @rjamoul, @cjn119-ui.
+- Ignore retired Workshop jobs during Doctor preflight [#143325](https://github.com/openclaw/openclaw/pull/143325). Thanks @cjn119-ui, @jerabinovich, @obviyus.
+
+
+
+
+
+
+##### Replace the retired video-frames helper
+
+
+The bundled `video-frames` skill and its helper script have been removed. If you use them to save still images from videos, switch to `ffmpeg` directly or install a separate frame-extraction skill. OpenClaw's video understanding can analyze a video, but does not produce those image files for you, and existing workflows are not converted automatically.
+
+
+
+###### Sources and complete change list
+
+
+**Limits and compatibility**
+
+- Retire the bundled video-frames skill and helper [#142232](https://github.com/openclaw/openclaw/pull/142232).
+
+
+
+
+
+
+
+#### Native Apps
+
+The Android app helps you keep your place while reading, see what your Claw has done, and reply from notifications. There are also clearer ways to reconnect the mobile apps, fixes for Mac setup, and changes that keep a sleeping Linux desktop from interrupting OpenClaw on another computer.
+
+
+
+
+##### Read Android conversations and follow work
+
+
+The [Android app](https://docs.openclaw.ai/platforms/android) keeps your place while a reply arrives or you resize the window. Read earlier messages without being pulled away, then use Jump to latest to catch up. You can also open tool details to see what your Claw did, while dashboard chats tuck completed steps away and leave the answer visible.
+
+Search and the sidebar show which conversation is busy, and a failed refresh keeps the conversations you already loaded. On folding phones, model settings and background tasks stay clear of the fold.
+
+
+
+###### Sources and complete change list
+
+
+**Improvements**
+
+- Translate Android chat-readiness messages [#142267](https://github.com/openclaw/openclaw/pull/142267).
+- Translate Android readiness and empty-state labels [#143203](https://github.com/openclaw/openclaw/pull/143203).
+- Refresh Android chat and activity translations [#143397](https://github.com/openclaw/openclaw/pull/143397).
+
+**Bug fixes**
+
+- Keep Android reading position while replies grow, and reveal expanded messages and code endpoints [#140759](https://github.com/openclaw/openclaw/pull/140759).
+- Show Android session refresh errors without losing loaded pages [#141603](https://github.com/openclaw/openclaw/pull/141603).
+- Keep Android Thinking and Fast controls clear of folds [#141860](https://github.com/openclaw/openclaw/pull/141860). Thanks @vincentkoc.
+- Thread activity labels follow the right conversation [#141883](https://github.com/openclaw/openclaw/pull/141883).
+- Keep Background Tasks inside foldable panes [#141899](https://github.com/openclaw/openclaw/pull/141899). Thanks @vincentkoc.
+- Keep matching Android threads in view [#142046](https://github.com/openclaw/openclaw/pull/142046).
+- Distinguish Android chat readiness from Gateway disconnection [#142182](https://github.com/openclaw/openclaw/pull/142182).
+- Keep Android branch choices inside usable fold panes [#142418](https://github.com/openclaw/openclaw/pull/142418). Thanks @vincentkoc.
+- Restore Android tool activity and fold completed work [#142810](https://github.com/openclaw/openclaw/pull/142810). Thanks @ansxor, @IWhatsskill.
+- Distinguish Android chat readiness from Gateway connection status [#143128](https://github.com/openclaw/openclaw/pull/143128).
+
+
+
+
+
+
+##### Reply from Android notifications
+
+
+Android notification replies reconnect to the saved computer for that conversation when needed. The notification now tells you whether a reply is queued, failed, or has an unknown status. Queued confirms that the app saved your reply for sending; it does not confirm delivery. If the result is unknown, open the conversation before sending again. You may still need to approve a connection-security prompt before the reply can proceed.
+
+
+
+###### Sources and complete change list
+
+
+**Improvements**
+
+- Translate Android reply status messages [#143928](https://github.com/openclaw/openclaw/pull/143928).
+
+**Bug fixes**
+
+- Keep notification actions on their saved Gateway, clarify reply status, and leave dismissed approval feedback closed [#143812](https://github.com/openclaw/openclaw/pull/143812).
+
+
+
+
+
+
+##### Send Android attachments with their captions
+
+
+Android waits for your selected files to finish loading before enabling Send, so your message cannot go out with its caption but without the attachment. If you cancel a file or it fails to load, the caption stays in place for you to keep working on.
+
+
+
+###### Sources and complete change list
+
+
+**Bug fixes**
+
+- Wait for Android attachments before sending captions and clarify import warnings [#143162](https://github.com/openclaw/openclaw/pull/143162).
+
+
+
+
+
+
+##### Reconnect the mobile apps
+
+
+When Android or iPhone cannot reach the computer running OpenClaw, the app now explains the problem and offers Retry. iPhone retries the connection you were setting up, and connections that appear to use Tailscale show relevant setup help. Android may need a moment to finish closing the previous connection before trying again.
+
+Android setup also makes the selected security option available to accessibility tools. When your Claw checks a phone or Apple Watch battery, the result now includes a clear percentage, helping avoid confusion between a full charge and one percent.
+
+
+
+###### Sources and complete change list
+
+
+**Improvements**
+
+- Refresh native connection and recovery translations [#142807](https://github.com/openclaw/openclaw/pull/142807).
+
+**Bug fixes**
+
+- Add explicit battery percentages to mobile status responses [#141069](https://github.com/openclaw/openclaw/pull/141069). Thanks @NullArbitrage, @obviyus.
+- Expose Android connection-security selection to assistive services [#142131](https://github.com/openclaw/openclaw/pull/142131).
+- Show mobile connection failures with targeted retry actions [#142651](https://github.com/openclaw/openclaw/pull/142651). Thanks @vincentkoc.
+
+
+
+
+
+
+##### Find the official mobile apps
+
+
+You can now reach the official App Store listing straight from the [iPhone setup guide](https://docs.openclaw.ai/platforms/ios). If you install Android outside Google Play, the [Android guide](https://docs.openclaw.ai/platforms/android) helps you find the app download and check that the file is intact. Downloads are attached to selected releases and may appear later than the release itself.
+
+
+
+###### Sources and complete change list
+
+
+**Documentation**
+
+- Find Android release downloads with both APK and checksum [#141762](https://github.com/openclaw/openclaw/pull/141762). Thanks @xiaoguomeiyitian, @obviyus, @tomdailey55.
+- Link the official iPhone app from its setup guide [#142132](https://github.com/openclaw/openclaw/pull/142132). Thanks @mgabor3141, @obviyus.
+
+
+
+
+
+
+##### Understand the iPhone conversation count
+
+
+The iPhone app now makes clear how many conversations are showing and how many there are in total, including in its translated messages. If some have not loaded yet, use Refresh to load the rest.
+
+
+
+###### Sources and complete change list
+
+
+**Improvements**
+
+- Clarify displayed and total iOS session counts [#142324](https://github.com/openclaw/openclaw/pull/142324).
+- Clarify localized iOS session counts; carried Wear OS typing and hold hints retain known translation errors [#142381](https://github.com/openclaw/openclaw/pull/142381).
+
+
+
+
+
+
+##### Set up and change Mac connections
+
+
+Choosing Set up later or clearing a connection on Mac now stays saved instead of bringing back the old connection when you reopen the app. If saving fails, the app tells you. Password-protected connections also show where to enter the password and try again. Older OpenClaw installations on the other computer need updating to accept a password in the field labeled Gateway token.
+
+If you prepare Mac setup from the command line, you can now read a password or token from a private file without putting it in the command itself. Setup also respects the profile you chose instead of changing the default profile. The [remote setup guide](https://docs.openclaw.ai/platforms/mac/remote) explains these options and the separate command to use when the app is already running.
+
+
+
+###### Sources and complete change list
+
+
+**Bug fixes**
+
+- Show password recovery during macOS remote onboarding [#141857](https://github.com/openclaw/openclaw/pull/141857).
+- Preserve Gateway clearing and accept file-based macOS setup credentials [#141872](https://github.com/openclaw/openclaw/pull/141872).
+- Honor selected macOS profiles in offline remote setup [#142163](https://github.com/openclaw/openclaw/pull/142163).
+
+**Documentation**
+
+- Refresh translated Gateway password instructions [#141906](https://github.com/openclaw/openclaw/pull/141906).
+- Translate Gateway settings save-failure guidance [#141962](https://github.com/openclaw/openclaw/pull/141962).
+
+
+
+
+
+
+##### Close a Mac side-panel tab with Command-W
+
+
+When you are using a side-panel tab in the Mac app, Command-W now closes that tab and leaves the main window open. You can press it again to close the next tab. When you are working in the main chat instead, the shortcut still closes the window as usual.
+
+
+
+###### Sources and complete change list
+
+
+**Bug fixes**
+
+- Close focused macOS side-panel tabs with Cmd+W [#142634](https://github.com/openclaw/openclaw/pull/142634). Thanks @Patrick-Erichsen.
+
+
+
+
+
+
+##### Troubleshoot Mac startup and repeated restarts
+
+
+If OpenClaw fails to start on Mac, its service log can now include errors that used to disappear before normal logging began. Existing installations need their background service setup refreshed before these errors appear in the log. The [Mac troubleshooting guide](https://docs.openclaw.ai/platforms/mac/bundled-gateway) explains the setup and where to look.
+
+Status and Doctor can also point out background jobs that may be repeatedly restarting OpenClaw. These checks can flag a job incorrectly, so review it before removing anything.
+
+
+
+###### Sources and complete change list
+
+
+**Bug fixes**
+
+- Diagnose stray macOS Gateway restart jobs [#142230](https://github.com/openclaw/openclaw/pull/142230). Thanks @piotx, @rondavis007, @jodok, @jarvismazz.
+- Preserve macOS Gateway startup errors in the service log [#143519](https://github.com/openclaw/openclaw/pull/143519). Thanks @RomneyDa, @Enominera, @igs-rogenlo, @lonexreb.
+
+
+
+
+
+
+##### Keep Linux connections and updates working
+
+
+Putting your Linux desktop to sleep no longer tells OpenClaw on another computer to pause, including when you connect over SSH. Saved SSH connections also use their configured port. If you keep a password or token in a separate file or environment setting, reconnecting preserves that setup so later launches can read the updated secret. Settings overwritten by an older version still need to be restored manually.
+
+The [Linux companion](https://docs.openclaw.ai/platforms/linux) also keeps update notices and tray actions available while you are using the dashboard. An update that is ready to install stays available for another try if a later check or download fails.
+
+
+
+###### Sources and complete change list
+
+
+**Bug fixes**
+
+- Keep desktop update notices and retry actions available [#121938](https://github.com/openclaw/openclaw/pull/121938). Thanks @vincentkoc.
+- Honor SSH alias ports in the Linux companion [#142900](https://github.com/openclaw/openclaw/pull/142900). Thanks @vincentkoc.
+- Keep Linux sleep from suspending remote Gateways [#142913](https://github.com/openclaw/openclaw/pull/142913). Thanks @vincentkoc.
+
+**Security and trust**
+
+- Preserve remote credential references on Linux reconnect [#142907](https://github.com/openclaw/openclaw/pull/142907). Thanks @vincentkoc.
+
+**Documentation**
+
+- Correct the Linux companion maturity description [#141955](https://github.com/openclaw/openclaw/pull/141955). Thanks @RomneyDa.
+
+
+
+
+
+
+##### Hear explanations that include code
+
+
+An explanation with a little code in it can now be read aloud instead of being skipped or replaced with a message to look at the screen. This applies to [spoken replies](https://docs.openclaw.ai/tools/tts) and [Talk](https://docs.openclaw.ai/nodes/talk) when speech is enabled. Answers that are mostly code still follow the existing rules for keeping that content on screen.
+
+
+
+###### Sources and complete change list
+
+
+**Bug fixes**
+
+- Speak ordinary Markdown explanations while retaining code-heavy reply fallback [#142415](https://github.com/openclaw/openclaw/pull/142415).
+
+
+
+
+
+
+
+#### Models and Providers
+
+You have more choices for making images and transcribing voice notes, and choosing the model behind your Claw is easier too. Model menus are searchable, saved choices keep the right settings, and the controls stop offering options a model cannot use. For people working with Codex, Claude, or their own AI server, there are also fixes for missing instructions, interrupted work, and confusing sign-in failures.
+
+
+
+
+##### Model lists from the right Gateway
+
+
+If you connect to more than one Gateway, the [model list](https://docs.openclaw.ai/concepts/models) now follows the Gateway and agent you selected, so you see the choices for the place where your work will run. Browsing the list no longer starts another search for models in the background. Refresh checks for new choices, and a failed refresh shows a warning while keeping compatible saved choices available. Update the Gateway before updating a separate command-line client. Updates to OpenClaw's model-and-price reference still need a Gateway restart before they take effect.
+
+
+
+###### Sources and complete change list
+
+
+**Improvements**
+
+- Browse the selected Gateway's model inventory [#142063](https://github.com/openclaw/openclaw/pull/142063). Thanks @obviyus.
+- Reduce first-use Copilot metadata loading [#142134](https://github.com/openclaw/openclaw/pull/142134)
+- Load less session code during model discovery [#143146](https://github.com/openclaw/openclaw/pull/143146). Thanks @vincentkoc.
+- Avoid unused preparation when browsing models [#144095](https://github.com/openclaw/openclaw/pull/144095)
+
+**Bug fixes**
+
+- Refresh model availability after token expiry or cooldown [#141727](https://github.com/openclaw/openclaw/pull/141727). Thanks @obviyus.
+- Show when refreshed model information needs a restart [#141885](https://github.com/openclaw/openclaw/pull/141885). Thanks @obviyus.
+- Warn about incomplete model refreshes [#141951](https://github.com/openclaw/openclaw/pull/141951). Thanks @obviyus.
+- Keep inference model inspection within the agent catalog [#142367](https://github.com/openclaw/openclaw/pull/142367). Thanks @obviyus.
+- Stop model selection from triggering extra provider discovery [#142375](https://github.com/openclaw/openclaw/pull/142375). Thanks @obviyus.
+- Keep internal catalog reads passive and forward explicit refreshes [#142557](https://github.com/openclaw/openclaw/pull/142557). Thanks @obviyus.
+- Restore public SDK model discovery defaults [#142620](https://github.com/openclaw/openclaw/pull/142620). Thanks @obviyus.
+- Clear stale catalog warnings when the source changes [#142622](https://github.com/openclaw/openclaw/pull/142622). Thanks @obviyus.
+- Keep saved models visible after startup [#142766](https://github.com/openclaw/openclaw/pull/142766). Thanks @obviyus.
+- Avoid unrelated provider loading during cold session resets [#143254](https://github.com/openclaw/openclaw/pull/143254)
+- Keep model catalog resources through asynchronous reads [#143492](https://github.com/openclaw/openclaw/pull/143492)
+
+**Documentation**
+
+- Clarify model status and catalog refresh guidance [#141927](https://github.com/openclaw/openclaw/pull/141927). Thanks @obviyus.
+- Translate model-refresh retry guidance [#142000](https://github.com/openclaw/openclaw/pull/142000)
+- Fix the model guide's Gateway catalog link [#142379](https://github.com/openclaw/openclaw/pull/142379). Thanks @vincentkoc.
+
+
+
+
+
+
+##### Keep the model you chose
+
+
+Saved model choices are less likely to change unexpectedly, particularly when custom models have almost identical names. Each keeps its own settings for images, tools, and the amount of text it can handle. Chats started from another chat also show the model they actually inherit, and choosing Default stays in place after a restart. Default follows the configured model and its backups; explicitly choosing a particular model keeps the chat pinned to that choice.
+
+
+
+###### Sources and complete change list
+
+
+**Bug fixes**
+
+- Align child-session model display and routing [#131805](https://github.com/openclaw/openclaw/pull/131805); contextual [#86174](https://github.com/openclaw/openclaw/issues/86174). Thanks @jalehman, @rqlangley, @wpu911.
+- Resolve Anthropic aliases consistently across status and permissions [#137376](https://github.com/openclaw/openclaw/pull/137376). Thanks @Yigtwxx, @obviyus.
+- Respect explicit visibility policies for CLI-backed models in /models [#141642](https://github.com/openclaw/openclaw/pull/141642). Thanks @IWhatsskill, @NovaUnboundAi.
+- Resolve model aliases with the selected provider plugin [#141679](https://github.com/openclaw/openclaw/pull/141679)
+- Honor the selected agent in model catalog commands [#141859](https://github.com/openclaw/openclaw/pull/141859). Thanks @obviyus.
+- Explain unavailable models before terminal selection [#142160](https://github.com/openclaw/openclaw/pull/142160). Thanks @obviyus.
+- Keep distinct model IDs and metadata visible in catalogs [#142285](https://github.com/openclaw/openclaw/pull/142285). Thanks @obviyus.
+- Show inherited models consistently across session views [#142751](https://github.com/openclaw/openclaw/pull/142751)
+- Prefer exact model metadata when aliases coexist [#143686](https://github.com/openclaw/openclaw/pull/143686)
+- Prefer exact model spelling when inferring providers [#143708](https://github.com/openclaw/openclaw/pull/143708)
+- Preserve catalog model identities and capability metadata [#143777](https://github.com/openclaw/openclaw/pull/143777)
+- Preserve distinct model entries and metadata [#143872](https://github.com/openclaw/openclaw/pull/143872)
+- Keep distinct allowed models visible [#143954](https://github.com/openclaw/openclaw/pull/143954)
+- Preserve model identities through catalog refresh [#143967](https://github.com/openclaw/openclaw/pull/143967)
+- Preserve saved model choices when reading sessions [#143975](https://github.com/openclaw/openclaw/pull/143975)
+- Preserve selected models and matching image limits [#143994](https://github.com/openclaw/openclaw/pull/143994). Thanks @elikampf.
+- Resolve configured aliases once [#143999](https://github.com/openclaw/openclaw/pull/143999)
+- Use the selected model context limit [#144009](https://github.com/openclaw/openclaw/pull/144009)
+- Use selected-model tool capabilities [#144010](https://github.com/openclaw/openclaw/pull/144010)
+- Select exact model entries before defaults [#144034](https://github.com/openclaw/openclaw/pull/144034)
+- Honor selected-model image and compaction limits [#144060](https://github.com/openclaw/openclaw/pull/144060)
+- Use selected-provider settings for tools [#144107](https://github.com/openclaw/openclaw/pull/144107)
+
+
+
+
+
+
+##### Find models and edit backup choices
+
+
+Searchable model menus make long lists easier to use without changing your choice until you select a result. Chat menus follow the account saved for that conversation, while New Session lets you preview another account you own. If a list fails to load, you can see the problem and try again.
+
+Editing backup models now preserves an inherited primary model, and removing every backup stays that way after a reload. Unavailable saved choices remain visible so you can remove them. Global defaults labels help distinguish shared settings from an individual agent's choices.
+
+
+
+###### Sources and complete change list
+
+
+**Improvements**
+
+- Search long model menus [#141894](https://github.com/openclaw/openclaw/pull/141894). Thanks @obviyus.
+- Match chat model choices to the saved or previewed account [#142165](https://github.com/openclaw/openclaw/pull/142165). Thanks @obviyus.
+- Translate global model settings guidance [#143449](https://github.com/openclaw/openclaw/pull/143449)
+
+**Bug fixes**
+
+- Discard unconfirmed fallback-model searches [#141953](https://github.com/openclaw/openclaw/pull/141953). Thanks @shakkernerd.
+- Preserve model inheritance when editing fallbacks [#141967](https://github.com/openclaw/openclaw/pull/141967). Thanks @shakkernerd, @najef1979-code.
+- Preserve case-sensitive fallback references [#141997](https://github.com/openclaw/openclaw/pull/141997). Thanks @shakkernerd.
+- Keep unavailable saved models visible but unselectable [#142048](https://github.com/openclaw/openclaw/pull/142048). Thanks @obviyus.
+- Load more default-model choices when pickers open [#142105](https://github.com/openclaw/openclaw/pull/142105). Thanks @xiaoguomeiyitian, @obviyus, @dh-js.
+- Restore model discovery in settings pickers [#142346](https://github.com/openclaw/openclaw/pull/142346). Thanks @vyctorbrzezowski.
+- Show failed model-list refreshes in the Control UI [#142372](https://github.com/openclaw/openclaw/pull/142372). Thanks @obviyus.
+- Avoid repeated model discovery when reopening Settings pickers [#142384](https://github.com/openclaw/openclaw/pull/142384). Thanks @vyctorbrzezowski.
+- Reduce model-picker lag with large catalogs [#142465](https://github.com/openclaw/openclaw/pull/142465)
+- Clarify global model defaults and agent settings [#143424](https://github.com/openclaw/openclaw/pull/143424). Thanks @obviyus, @schjonhaug.
+
+
+
+
+
+
+##### Thinking and Fast controls that match the model
+
+
+The Thinking menu now follows the effort levels offered by the selected model, so it no longer invents choices and correctly shows your saved Off setting. When OpenClaw knows that Fast cannot change a request, it disables that choice while still letting you clear an old preference. These controls make it clearer what you can adjust; actual speed, access, and charges still depend on the provider.
+
+
+
+###### Sources and complete change list
+
+
+**Bug fixes**
+
+- Hide thinking choices the selected model does not support [#141696](https://github.com/openclaw/openclaw/pull/141696). Thanks @obviyus.
+- Disable Fast when it cannot affect the selected request [#141852](https://github.com/openclaw/openclaw/pull/141852). Thanks @obviyus.
+- Use published model thinking choices across the UI [#142646](https://github.com/openclaw/openclaw/pull/142646). Thanks @obviyus.
+- Disable Fast choices that cannot change the request [#142682](https://github.com/openclaw/openclaw/pull/142682). Thanks @obviyus.
+- Keep thinking choices aligned with the model [#142790](https://github.com/openclaw/openclaw/pull/142790). Thanks @obviyus.
+- Preserve explicit thinking Off with empty choices [#142822](https://github.com/openclaw/openclaw/pull/142822). Thanks @obviyus.
+
+
+
+
+
+
+##### Keep custom AI connections pointed at the right server
+
+
+People using custom AI servers keep the connection settings they entered when model lists are refreshed, instead of having another model's settings take over. Manually added models also stay in the list. If you use a custom server in place of a provider's usual service, you may need to list the models it supports explicitly. Integrations must use current sign-in details or explicitly configured credentials; old credentials saved only with a downloaded model list no longer authorize requests.
+
+
+
+###### Sources and complete change list
+
+
+**Improvements**
+
+- Keep generated model lists out of ordinary setup for Cloudflare AI Gateway, Featherless, Hugging Face, LongCat, Meta, Mistral, NVIDIA, Synthetic, Together, Xiaomi pay-as-you-go, and Z.AI [#142202](https://github.com/openclaw/openclaw/pull/142202). Thanks @obviyus.
+
+**Bug fixes**
+
+- Honor session-affinity settings for managed OpenAI and Azure Responses proxies [#141107](https://github.com/openclaw/openclaw/pull/141107); contextual [#140918](https://github.com/openclaw/openclaw/issues/140918). Thanks @louisfy, @obviyus, @alexph-dev.
+- Preserve manual models during generated catalog refresh [#142302](https://github.com/openclaw/openclaw/pull/142302). Thanks @obviyus.
+- Preserve saved endpoints in configured model lists [#143643](https://github.com/openclaw/openclaw/pull/143643). Thanks @obviyus.
+- Preserve authored SDK routes and require current authentication instead of generated-catalog credentials [#143664](https://github.com/openclaw/openclaw/pull/143664). Thanks @obviyus.
+- Honor exact configured model settings before aliases [#143822](https://github.com/openclaw/openclaw/pull/143822)
+- Honor merged provider runtime settings [#143848](https://github.com/openclaw/openclaw/pull/143848)
+- Quiet intentional provider tuning warnings [#92288](https://github.com/openclaw/openclaw/pull/92288). Thanks @ai-hpc, @obviyus, @kingkong9817.
+
+**Limits and compatibility**
+
+- Require explicit model lists for custom provider endpoints [#142158](https://github.com/openclaw/openclaw/pull/142158). Thanks @obviyus.
+
+
+
+
+
+
+##### Reuse sign-ins and recover from login problems
+
+
+Supported OpenAI sign-in methods can reuse an account or key already saved by Codex, saving you another login or paste. Agents sharing a sign-in also handle renewal more reliably, and a renewal that finished too late for one request can help the next request succeed.
+
+If sign-in still needs attention, OpenClaw better distinguishes saved credentials from a connection that has not picked them up and tells you which computer to check. Older credentials awaiting repair no longer disable unrelated providers; use `openclaw doctor --fix` for the affected accounts.
+
+
+
+###### Sources and complete change list
+
+
+**Improvements**
+
+- Reuse supported Codex credentials during provider login [#142933](https://github.com/openclaw/openclaw/pull/142933). Thanks @obviyus.
+
+**Bug fixes**
+
+- Explain saved credentials and failed Gateway refresh separately [#131968](https://github.com/openclaw/openclaw/pull/131968); contextual [#131944](https://github.com/openclaw/openclaw/issues/131944). Thanks @vyctorbrzezowski, @obviyus.
+- Coordinate shared OAuth refresh without reusing consumed tokens [#141477](https://github.com/openclaw/openclaw/pull/141477). Thanks @vincentkoc, @kopl-blip, @100yenadmin.
+- Recognize scoped native Codex login during model discovery [#141759](https://github.com/openclaw/openclaw/pull/141759). Thanks @DonnieFi, @obviyus.
+- Reuse completed Codex sign-in refreshes [#142628](https://github.com/openclaw/openclaw/pull/142628). Thanks @vincentkoc, @kopl-blip, @zhuyankarl, @100yenadmin.
+- Keep OpenAI, xAI, and Copilot device sign-in links clickable in Slack [#142873](https://github.com/openclaw/openclaw/pull/142873). Thanks @obviyus.
+- Keep unrelated providers available during credential migration [#143310](https://github.com/openclaw/openclaw/pull/143310). Thanks @tskerpnext.
+- Keep model setup resources through background work [#143542](https://github.com/openclaw/openclaw/pull/143542)
+- Preserve case in model authentication evidence [#143780](https://github.com/openclaw/openclaw/pull/143780)
+
+
+
+
+
+
+##### Recover failed tool requests and explain what stopped
+
+
+When a model sends broken instructions for a tool, OpenClaw can try again instead of immediately abandoning the task. With Anthropic, it can also repair certain formatting mistakes. Retries are limited to cases where repeating the request is safe and may add cost. If earlier actions already happened, check their results before asking your Claw to continue.
+
+Errors also better distinguish connection problems, rejected sign-ins, and requests a provider cannot accept. Explanations stay in chat history, making it easier to understand why work stopped or a backup model was not tried.
+
+
+
+###### Sources and complete change list
+
+
+**Bug fixes**
+
+- Refresh backup model aliases after plugin reloads [0e1f60ec](https://github.com/openclaw/openclaw/commit/0e1f60ec03b06127ef2a7b81413f817985113ac1); contextual [#133633](https://github.com/openclaw/openclaw/pull/133633)
+- Preserve final ChatGPT events without a closing blank line [#120902](https://github.com/openclaw/openclaw/pull/120902). Thanks @zenglingbiao, @obviyus.
+- Stop retrying wrapped parameter rejections [#140991](https://github.com/openclaw/openclaw/pull/140991); contextual [#140987](https://github.com/openclaw/openclaw/issues/140987). Thanks @ooiuuii, @obviyus.
+- Repair string encoding in completed Anthropic tool arguments [#141323](https://github.com/openclaw/openclaw/pull/141323); contextual [#135111](https://github.com/openclaw/openclaw/issues/135111). Thanks @lraesly, @1Vision365-PeterTijsma, @infocus13, @peterkaynie, @jalehman, @MaxVidkrytaklishnya, @chrislro, @narbs.
+- Refresh the terminal footer when the model falls back [#141436](https://github.com/openclaw/openclaw/pull/141436). Thanks @ooiuuii.
+- Explain why a model fallback attempt stops [#141658](https://github.com/openclaw/openclaw/pull/141658). Thanks @von8794, @obviyus.
+- Show specific provider network errors after redaction [#141665](https://github.com/openclaw/openclaw/pull/141665). Thanks @SunnyShu0925, @obviyus, @DonnieFi.
+- Correct fallback warnings and preserve intentional silent replies [#141725](https://github.com/openclaw/openclaw/pull/141725). Thanks @leilei3167, @obviyus, @markthebest12.
+- Keep unfinished tool-call explanations in chat history [#141870](https://github.com/openclaw/openclaw/pull/141870). Thanks @Takhoffman.
+- Retry replay-safe malformed tool-call failures [#142176](https://github.com/openclaw/openclaw/pull/142176). Thanks @lraesly, @obviyus, @1Vision365-PeterTijsma, @peterkaynie, @infocus13, @MaxVidkrytaklishnya, @chrislro, @narbs.
+- Explain fallback stops after terminal timeouts [#142278](https://github.com/openclaw/openclaw/pull/142278). Thanks @MoerAI, @obviyus, @von8794.
+- Explain provider authentication and model errors in history and status [#143243](https://github.com/openclaw/openclaw/pull/143243)
+
+
+
+
+
+
+##### Reuse more of the prompt between requests
+
+
+Anthropic conversations that use tools can reuse more of the instructions and conversation text already processed, instead of repeatedly saving the same growing history again. Compatible local models also get a more reusable starting prompt when you begin another conversation with the same instructions and tools. This can avoid repeated processing, though any effect on waiting time or charges depends on the provider and workload.
+
+
+
+###### Sources and complete change list
+
+
+**Bug fixes**
+
+- Preserve reusable local-model prompt prefixes [#137371](https://github.com/openclaw/openclaw/pull/137371); contextual [#137257](https://github.com/openclaw/openclaw/issues/137257). Thanks @gwiltschek, @obviyus.
+- Preserve Anthropic cache reuse during tool continuations and omit empty thinking-disabled beta headers [#140621](https://github.com/openclaw/openclaw/pull/140621); contextual [#140607](https://github.com/openclaw/openclaw/issues/140607). Thanks @LightningWareLLC, @he-yufeng, @vincentkoc.
+
+
+
+
+
+
+##### Keep workspace instructions in Codex conversations
+
+
+[Codex conversations managed by OpenClaw](https://docs.openclaw.ai/plugins/codex-harness-runtime) regain workspace personality, preferences, skills, and memory guidance, including later edits. This applies to supported managed connections; other connection types keep their existing handling and may show a warning.
+
+Ordinary Codex chats can also recover a missing final answer after finishing work in a long conversation, without repeating those actions. Follow-ups keep fresh corrections without resending history already covered by a successful final reply.
+
+
+
+###### Sources and complete change list
+
+
+**Bug fixes**
+
+- Restore workspace instructions in managed Codex conversations [#142276](https://github.com/openclaw/openclaw/pull/142276). Thanks @vincentkoc.
+- Accept Codex Responses Lite requests without separate instructions [#142823](https://github.com/openclaw/openclaw/pull/142823). Thanks @jalehman.
+- Honor configured Codex workspace instruction limits [#142932](https://github.com/openclaw/openclaw/pull/142932). Thanks @ashawwal, @obviyus.
+- Recover final answers after tool work in long Codex conversations [#143081](https://github.com/openclaw/openclaw/pull/143081). Thanks @barbarhan, @obviyus.
+- Avoid repeated Codex history after final message delivery [#143506](https://github.com/openclaw/openclaw/pull/143506). Thanks @sunlit-deng, @dbarbatti, @obviyus.
+
+**Documentation**
+
+- Split the Codex harness reference by topic [#142803](https://github.com/openclaw/openclaw/pull/142803). Thanks @vincentkoc.
+- Split Codex runtime guidance into focused pages [#143458](https://github.com/openclaw/openclaw/pull/143458). Thanks @vincentkoc.
+
+
+
+
+
+
+##### Return to Claude and other coding-agent conversations
+
+
+Returning to a Claude conversation keeps its original chat connection and avoids a repeated user message in the affected resume cases. Claude can also stay running between turns when a skill check finds that nothing changed. In Codex chats with a fixed model choice, pasted text now reaches the agent instead of being lost.
+
+
+
+###### Sources and complete change list
+
+
+**Improvements**
+
+- Reduce cold setup for Anthropic CLI history [#142801](https://github.com/openclaw/openclaw/pull/142801)
+
+**Bug fixes**
+
+- Preserve Claude session identity when combining duplicate history [#130494](https://github.com/openclaw/openclaw/pull/130494); contextual [#130456](https://github.com/openclaw/openclaw/issues/130456). Thanks @jalehman.
+- Complete valid ACP forms with no fields [#133269](https://github.com/openclaw/openclaw/pull/133269). Thanks @xydt-juyaohui, @obviyus.
+- Keep ACP startup waits consistent through clock changes [#137303](https://github.com/openclaw/openclaw/pull/137303). Thanks @qingminglong, @obviyus.
+- Forward effective Fast settings to CLI plugins and preserve the selected account [#138667](https://github.com/openclaw/openclaw/pull/138667). Thanks @Szqub, @obviyus.
+- Keep Codex operation timeouts stable through clock corrections [#141071](https://github.com/openclaw/openclaw/pull/141071); contextual [#141000](https://github.com/openclaw/openclaw/issues/141000). Thanks @ooiuuii, @obviyus.
+- Restore pasted text in model-locked Codex sessions [#142021](https://github.com/openclaw/openclaw/pull/142021). Thanks @RomneyDa.
+- Avoid duplicate user turns after Claude resume [#143960](https://github.com/openclaw/openclaw/pull/143960). Thanks @Marvinthebored, @Peetiegonzalez, @obviyus.
+
+**Documentation**
+
+- Split ACP guidance by task [#142958](https://github.com/openclaw/openclaw/pull/142958). Thanks @vincentkoc.
+
+
+
+
+
+
+##### Use the right conversation limit for local models
+
+
+If you run models on your own server, OpenClaw now uses the conversation size reported by vLLM, SGLang, and compatible services instead of falling back to a potentially wrong limit. That helps it budget how much text to send to the model, while any limit you entered yourself still takes priority. Opening vLLM model information for the first time also avoids some unnecessary loading work.
+
+
+
+###### Sources and complete change list
+
+
+**Bug fixes**
+
+- Use advertised context limits for self-hosted models [#141113](https://github.com/openclaw/openclaw/pull/141113). Thanks @vincentkoc.
+- Avoid unnecessary loading for first-use vLLM model information [#142125](https://github.com/openclaw/openclaw/pull/142125)
+
+**Documentation**
+
+- Organize Ollama documentation into focused guides [#143004](https://github.com/openclaw/openclaw/pull/143004). Thanks @vincentkoc.
+
+
+
+
+
+
+##### Try Tencent Hy4 preview
+
+
+Tencent users can choose Hy4 preview through TokenHub or TokenPlan, and new setups select it by default when the account has access. Existing model choices stay in place, so an upgrade does not silently switch you to the preview. Its thinking options are Off or High; selecting an intermediate level such as Low uses High, which can affect waiting time and usage.
+
+
+
+###### Sources and complete change list
+
+
+**Improvements**
+
+- Add Hy4 preview to Tencent TokenHub and TokenPlan [#131598](https://github.com/openclaw/openclaw/pull/131598). Thanks @chl-0537, @hxy91819.
+
+
+
+
+
+
+##### Grok 4.6 becomes the default for new setups
+
+
+New xAI setups use Grok 4.6, as do xAI web search, X search, and code-execution tools when you have not chosen a model for them. Your explicit choices stay in place, but the new tool default can change cost or availability for your account. If an older subscription setup still uses the retired Auto choice, run `openclaw doctor --fix` or select an available model yourself.
+
+
+
+###### Sources and complete change list
+
+
+**Limits and compatibility**
+
+- Use Grok 4.6 defaults and repair retired subscription auto selections [#142136](https://github.com/openclaw/openclaw/pull/142136). Thanks @obviyus.
+
+
+
+
+
+
+##### Make one-off OpenCode requests
+
+
+OpenCode Go and Zen requests made outside an ongoing conversation no longer fail just because the service needs session information that was missing. OpenClaw supplies it automatically for the supported direct connections, including requests from the command line and supported integrations. Custom server connections keep their existing requirements.
+
+
+
+###### Sources and complete change list
+
+
+**Bug fixes**
+
+- Supply routing identity for sessionless OpenCode Go calls [#143558](https://github.com/openclaw/openclaw/pull/143558). Thanks @RomneyDa.
+- Supply routing identity for standalone OpenCode completions [#143659](https://github.com/openclaw/openclaw/pull/143659). Thanks @HAPPYFAPTAIN, @obviyus, @GDXbsv, @spectrl.
+- Preserve routing with explicit OpenCode sessions [#143890](https://github.com/openclaw/openclaw/pull/143890). Thanks @vincentkoc.
+
+
+
+
+
+
+##### Use your saved OpenRouter account with Arcee
+
+
+If you use Arcee through OpenRouter, OpenClaw now uses your matching saved OpenRouter account instead of asking for a separate Arcee credential. Your model settings stay attached to that choice, and different spellings of the same Arcee model stop looking like an unexpected model switch.
+
+
+
+###### Sources and complete change list
+
+
+**Bug fixes**
+
+- Use the selected Arcee account and preserve model settings [#142898](https://github.com/openclaw/openclaw/pull/142898). Thanks @obviyus.
+
+
+
+
+
+
+##### Tell a Kimi quota limit from a bad key
+
+
+When Kimi explicitly reports that you have used up a weekly allowance, OpenClaw no longer treats your valid key as broken. It can try a configured backup without unnecessarily blocking the provider's other models. Changing the key will not restore the allowance, though; wait for Kimi's quota window or use another provider with available capacity.
+
+
+
+###### Sources and complete change list
+
+
+**Bug fixes**
+
+- Treat explicit Kimi quota failures as rate limits [#142656](https://github.com/openclaw/openclaw/pull/142656). Thanks @RileyJJY, @obviyus, @rico007, @shaozhengkun123.
+
+
+
+
+
+
+##### Generate and edit with GPT Image 2.5
+
+
+You can [generate and edit images](https://docs.openclaw.ai/tools/image-generation) with GPT Image 2.5 Flare or Sunburst through OpenAI or fal, including custom sizes, higher quality settings, and transparent PNG or WebP output. Edits can use up to five reference images through OpenAI or sixteen through fal, and either route can return up to four images.
+
+Direct [OpenAI access](https://docs.openclaw.ai/providers/openai/image-and-video#gpt-image-2.5) needs an API key, selected explicitly if you already use a ChatGPT sign-in; fal needs its own credentials. Your default image model stays unchanged, so choose one of the new variants when you want to use it.
+
+
+
+###### Sources and complete change list
+
+
+**Improvements**
+
+- Add GPT Image 2.5 Flare and Sunburst through OpenAI [#143068](https://github.com/openclaw/openclaw/pull/143068). Thanks @vincentkoc.
+- Add GPT Image 2.5 through fal with 16-reference editing [#143069](https://github.com/openclaw/openclaw/pull/143069). Thanks @vincentkoc.
+
+
+
+
+
+
+##### Turn voice notes into text with Deepgram Flux
+
+
+You can now choose [Deepgram Flux](https://docs.openclaw.ai/providers/deepgram) to turn incoming voice notes into text your Claw can use, with English and multilingual options. Install ffmpeg on the computer running OpenClaw before selecting Flux. This is an optional choice in the existing audio settings; Nova remains the default.
+
+
+
+###### Sources and complete change list
+
+
+**Improvements**
+
+- Transcribe voice notes with Deepgram Flux [#141836](https://github.com/openclaw/openclaw/pull/141836). Thanks @obviyus, @safzanpirani.
+
+
+
+
+
+
+##### Use Gemini 3.6 Flash for web search
+
+
+Gemini web search now uses Gemini 3.6 Flash unless you chose a specific search model, helping accounts that could no longer use the old default. Your main chat model stays unchanged. Check the billing difference when upgrading, because Gemini 3 charges for each search query rather than once per prompt. There is also clearer help for [setting up Kimi search](https://docs.openclaw.ai/tools/kimi-search) and [using Ollama cloud search while keeping model conversations local](https://docs.openclaw.ai/tools/ollama-search).
+
+
+
+###### Sources and complete change list
+
+
+**Improvements**
+
+- Use Gemini 3.6 Flash for unconfigured web searches [#111964](https://github.com/openclaw/openclaw/pull/111964); contextual [#96974](https://github.com/openclaw/openclaw/issues/96974). Thanks @dillona, @vincentkoc, @anguslogan01.
+
+**Documentation**
+
+- Document search plugin installation and restarts, local Ollama model routing, browser ports, optional jq, /tell, patch syntax, approval inspection, node selection, reactions, and screen availability [#143856](https://github.com/openclaw/openclaw/pull/143856). Thanks @vincentkoc.
+
+
+
+
+
+
+##### Read usage costs with clearer estimates
+
+
+Cost reports now warn when totals may still be incomplete, so a temporary zero is less likely to look like no usage. They also distinguish the tokens used to save reusable prompts from ordinary input and fill gaps in some OpenRouter estimates. These are reporting fixes; the provider's bill remains the amount you actually owe.
+
+
+
+###### Sources and complete change list
+
+
+**Bug fixes**
+
+- Count reported cache writes separately from ordinary input [#141377](https://github.com/openclaw/openclaw/pull/141377); contextual [#141374](https://github.com/openclaw/openclaw/issues/141374). Thanks @ooiuuii, @obviyus.
+- Avoid delayed ClawRouter usage errors during diagnostic capture [#141818](https://github.com/openclaw/openclaw/pull/141818). Thanks @Alix-007, @obviyus.
+- Label incomplete usage-cost totals [#141917](https://github.com/openclaw/openclaw/pull/141917)
+- Fill missing estimates for OpenRouter routing shortcuts [#142138](https://github.com/openclaw/openclaw/pull/142138). Thanks @fabiolr, @obviyus.
+
+
+
+
+
+
+##### Get model results without waiting on diagnostics
+
+
+With diagnostic recording enabled, OpenRouter can return finished music or a usage-check error without waiting for the recording to finish. You get the result sooner even if that optional recording is incomplete. Related fixes let stopped requests finish closing their connections without cutting off cleanup.
+
+If you run `openclaw models status --probe` directly from the terminal, stop the Gateway first and wait for the command to exit before starting it again. The result can appear while the check is still closing its files and connections.
+
+
+
+###### Sources and complete change list
+
+
+**Bug fixes**
+
+- Avoid OpenRouter capture waits after music completion or usage errors [#141754](https://github.com/openclaw/openclaw/pull/141754). Thanks @Alix-007, @obviyus.
+- Retain Anthropic resources through cancellation cleanup [#143377](https://github.com/openclaw/openclaw/pull/143377)
+- Retain model probe resources through cleanup [#143658](https://github.com/openclaw/openclaw/pull/143658)
+- Keep prepared model limits and credentials when skipping discovery [#143695](https://github.com/openclaw/openclaw/pull/143695)
+
+
+
+
+
+
+##### Find the provider instructions you need
+
+
+Setting up an account or checking a provider's options is easier in the reorganized [OpenAI](https://docs.openclaw.ai/providers/openai) and [model-provider guides](https://docs.openclaw.ai/concepts/model-providers). Shorter pages take you straight to the relevant instructions, and old bookmarks still point you toward the material that moved.
+
+
+
+###### Sources and complete change list
+
+
+**Documentation**
+
+- Organize OpenAI guidance into focused task pages [#141224](https://github.com/openclaw/openclaw/pull/141224). Thanks @vincentkoc.
+- Organize model-provider documentation by setup task [#143058](https://github.com/openclaw/openclaw/pull/143058). Thanks @vincentkoc.
+
+
+
+
+
+
+
+#### Automations and Scheduling
+
+Automations are easier to manage, with direct links to edit them and names you can recognize. Scheduled tasks also get fixes for getting stuck, returning results to your chat, and staying quiet when there is nothing to report.
+
+
+
+
+##### Run scheduled tasks with your chosen tools
+
+
+Scheduled commands run by OpenClaw can work without turning off secret protection, and Codex chats can set up automations using the tools already available in the conversation. Tasks also avoid startup failures caused by model settings refreshing or an unrelated plugin being disabled. Your existing permissions still apply, and disabled plugins stay off.
+
+
+
+###### Sources and complete change list
+
+
+**Bug fixes**
+
+- Keep scheduled jobs running through runtime refreshes [84fd689](https://github.com/openclaw/openclaw/commit/84fd689763c410dc32d43302c589f09d2f22d462). Thanks @ekinnee, @84dnnvbdvp-debug.
+- Preserve usable cron models and fallback failure details [855c9de](https://github.com/openclaw/openclaw/commit/855c9de4a2a7c8015d4fa78b28d00f330c0649ba). Thanks @Marvinthebored, @obviyus.
+- Restore scheduled commands with secret egress enabled [#142074](https://github.com/openclaw/openclaw/pull/142074). Thanks @tilor, @obviyus.
+- Accept Codex catalog tool names in automation allowlists [#142382](https://github.com/openclaw/openclaw/pull/142382). Thanks @sercada, @obviyus.
+
+
+
+
+
+
+##### Fixes for stuck scheduled tasks
+
+
+A clash between scheduled tasks could make OpenClaw keep retrying until it stopped responding. That loop is fixed. Tasks that hand work to another agent also avoid a pause they could never resume, leaving OpenClaw to deliver the result through the task's existing settings.
+
+
+
+###### Sources and complete change list
+
+
+**Bug fixes**
+
+- Prevent scheduled agents from entering an unresumable yield [#135318](https://github.com/openclaw/openclaw/pull/135318). Thanks @LiuwqGit, @obviyus, @youens, @postoso, @BottaniCals.
+- Stop stalled scheduled-job reservation loops and clean up resources after failed database opens [#142741](https://github.com/openclaw/openclaw/pull/142741). Thanks @galiniliev.
+
+
+
+
+
+
+##### Background results and quiet checks
+
+
+Background commands can bring their results back to the chat after your Claw's earlier reply has finished. Routine checks with nothing to report can stay quiet instead of sending an unnecessary message.
+
+If an automation result is waiting while your Claw answers you, canceling that result can now unblock actions such as pinning the conversation. Your Claw can finish its reply without adding the canceled result to the chat.
+
+
+
+###### Sources and complete change list
+
+
+**Bug fixes**
+
+- Keep quiet heartbeats silent and report completed sends [#140115](https://github.com/openclaw/openclaw/pull/140115). Thanks @ruel225, @obviyus, @laurencebrown.
+- Release session updates after cancellation [#143832](https://github.com/openclaw/openclaw/pull/143832).
+- Keep background completions and delayed skill experience reviews working after replies, with clearer event origins in history [#143866](https://github.com/openclaw/openclaw/pull/143866).
+
+
+
+
+
+
+##### Find and edit automations
+
+
+You can jump straight to an automation's editor from Settings → Agents → Automations, even when the task is paused. Lists now show the friendly names you saved, and you can group scheduled conversations together so they are easier to find. Large automation lists also spend less time loading where results will be sent.
+
+If you manage automations from the command line, missing jobs and invalid options come with more useful guidance. Warnings also explain what to check when a saved task cannot run because scheduling is turned off.
+
+
+
+###### Sources and complete change list
+
+
+**Improvements**
+
+- Edit automations directly from an agent's settings [#139782](https://github.com/openclaw/openclaw/pull/139782). Thanks @jjjhenriksen, @vyctorbrzezowski.
+- Explain time spent loading automation lists when diagnostics are enabled [#141805](https://github.com/openclaw/openclaw/pull/141805).
+
+**Bug fixes**
+
+- Show saved friendly automation names [#142076](https://github.com/openclaw/openclaw/pull/142076).
+- Show direct automation error guidance in JSON mode [#142113](https://github.com/openclaw/openclaw/pull/142113). Thanks @DasX, @obviyus.
+- Explain how to restore automatic scheduling by enabling cron, clearing `OPENCLAW_SKIP_CRON=1` from the Gateway's launch environment, and restarting [#142185](https://github.com/openclaw/openclaw/pull/142185).
+- Reject blank automation job IDs with clear guidance [#142264](https://github.com/openclaw/openclaw/pull/142264).
+- Sort and group scheduled sessions by displayed kind [#142554](https://github.com/openclaw/openclaw/pull/142554).
+- Reduce waits for automation delivery previews [#144014](https://github.com/openclaw/openclaw/pull/144014).
+
+
+
+
+
+
+##### Daily resets and automation guides
+
+
+If you have set conversations to reset each day, they now avoid losing context too early around spring clock changes. The reset still follows the timezone of the computer running OpenClaw.
+
+Guidance is easier to find when you want to [start a task at a set time or when a command finishes](https://docs.openclaw.ai/automation/cron-jobs/schedules#schedule-types), or [set up an automatic response to an event with a hook](https://docs.openclaw.ai/automation/hooks). These guides explain existing features, with clearer instructions for choosing and setting them up.
+
+
+
+###### Sources and complete change list
+
+
+**Bug fixes**
+
+- Prevent premature daily resets near daylight-saving changes [#142482](https://github.com/openclaw/openclaw/pull/142482).
+
+**Documentation**
+
+- Document all automation schedule types and option constraints [#135964](https://github.com/openclaw/openclaw/pull/135964). Thanks @qingminglong, @obviyus.
+- Split hooks guidance into focused reference pages [#143041](https://github.com/openclaw/openclaw/pull/143041). Thanks @vincentkoc.
+- Clarify that there is no native WebSocket schedule source and legacy `cron.failureDestination` settings are not read directly [#144039](https://github.com/openclaw/openclaw/pull/144039). Thanks @vincentkoc.
+
+
+
+
+
+
+
+#### Browser and Computer Use
+
+You can keep using your browser while your Claw works in another tab, and joining it on a remote desktop takes fewer steps. This release fixes interruptions when opening windows, answering website pop-ups, and following along with work on another computer.
+
+
+
+##### Follow browser work without switching tabs
+
+
+The [Browser panel](https://docs.openclaw.ai/tools/browser) can show what your Claw is doing without switching you away from your own tab. You can still choose Open to bring its page forward. If the live view disconnects after it has started, OpenClaw refreshes the picture and tries to reconnect automatically, while keeping any image you are marking up in place. Blank pages also stop appearing as misleading preview cards in chat.
+
+
+
+###### Sources and complete change list
+
+
+**Bug fixes**
+
+- Keep browser focus during automatic panel updates [5c70585](https://github.com/openclaw/openclaw/commit/5c70585f93cf5ab22893266b22cd767e1eb9d056). Thanks @scotthuang.
+- Recover the Browser panel after stream disconnects [#141576](https://github.com/openclaw/openclaw/pull/141576). Thanks @safzanpirani, @obviyus. An open connection that never sends its first frame remains outside this repair.
+- Hide preview cards for blank and internal browser pages [#142213](https://github.com/openclaw/openclaw/pull/142213). Thanks @vyctorbrzezowski.
+
+**Documentation**
+
+- Split browser documentation into focused guides [#142984](https://github.com/openclaw/openclaw/pull/142984). Thanks @vincentkoc.
+
+
+
+
+
+##### Handle website pop-ups and longer tasks
+
+
+When a website pop-up stops a [browser command](https://docs.openclaw.ai/cli/browser), OpenClaw tells you which prompt needs an answer and which steps remain unfinished. Answering one pop-up also no longer prevents the next one from being answered. Longer tasks in an already open browser avoid the premature connection failures covered by these fixes.
+
+Cancelling cannot undo changes already made to a page. If you automate browser commands, check their reported results before continuing, because a blocked task does not always return an error status.
+
+
+
+###### Sources and complete change list
+
+
+**Bug fixes**
+
+- Report blocked and interrupted browser actions [#142480](https://github.com/openclaw/openclaw/pull/142480).
+- Keep sequential browser dialogs available for responses [#142608](https://github.com/openclaw/openclaw/pull/142608).
+- Honor existing-browser timeouts and cancellation [#143365](https://github.com/openclaw/openclaw/pull/143365).
+
+**Limits and compatibility**
+
+- Reject invalid Browser CLI mouse-button values [#140976](https://github.com/openclaw/openclaw/pull/140976). Thanks @WOLIKIMCHENG, @DilapidatedDolphin98, @obviyus. Supplied values must be exactly `left`, `right`, or `middle`.
+
+
+
+
+
+##### Find the window your Claw needs
+
+
+This release fixes [computer-use errors](https://docs.openclaw.ai/nodes/computer-use) that could stop your Claw before it had even found the right window. Supported desktop controls are available from the start, and bringing a window forward no longer looks like a failure when it worked. Your Claw still needs permission to use the computer, and the computer must support the controls it requests.
+
+If [Codex Computer Use](https://docs.openclaw.ai/plugins/codex-computer-use) cannot start because native plugins are disabled, it now explains that promptly and tells you how to enable them and retry installation.
+
+
+
+###### Sources and complete change list
+
+
+**Bug fixes**
+
+- Skip the discovery wait when native Codex plugins are disabled [#137485](https://github.com/openclaw/openclaw/pull/137485). Thanks @shojikumaru, @noelillinger, @obviyus.
+- Make supported paired-desktop actions available on the first call [#141277](https://github.com/openclaw/openclaw/pull/141277). Thanks @oywino, @obviyus. Existing vision and permission restrictions still apply.
+- Fix first-action CUA window discovery [#143736](https://github.com/openclaw/openclaw/pull/143736).
+- Fix activation results and targeted capture guidance [#143953](https://github.com/openclaw/openclaw/pull/143953). Window input uses the `observationId` returned by `get_window_state` with `includeScreenshot`, rather than a whole-desktop frame reference.
+
+
+
+
+
+##### Open a remote desktop and paste text
+
+
+Opening [Desktop from a chat](https://docs.openclaw.ai/gateway/cloud-sessions) now takes you to the computer running that chat, and the view stays connected while you type in another pane alongside it. Desktop support must be enabled, and you start by watching until you choose Take control.
+
+To paste text from your own computer, choose Take control, open Keyboard, and paste there once the connection is ready. Paste shortcuts used directly on the desktop view are sent to the remote computer. If someone else takes control, the notice now shows their signed-in name or user ID when available.
+
+
+
+###### Sources and complete change list
+
+
+**Improvements**
+
+- Show who took control of a shared desktop [#143828](https://github.com/openclaw/openclaw/pull/143828).
+
+**Bug fixes**
+
+- Paste local text through Desktop Keyboard [#141986](https://github.com/openclaw/openclaw/pull/141986).
+- Desktop follows the chat machine [#143831](https://github.com/openclaw/openclaw/pull/143831). Desktop support must be enabled; opening still starts view-only under the existing permissions.
+
+
+
+
+
+##### Close a computer session before starting the next
+
+
+Stopping OpenClaw on a connected computer now lets its active computer-use session finish closing before another one starts. If closing fails, the error stays visible so you know why a new session is blocked and what needs attention.
+
+
+
+###### Sources and complete change list
+
+
+**Bug fixes**
+
+- Wait for computer sessions to close before node shutdown [#142787](https://github.com/openclaw/openclaw/pull/142787).
+
+
+
+
+
+##### Open a desktop on an Azure cloud worker
+
+
+You can now enable desktop access for [Azure cloud workers](https://docs.openclaw.ai/gateway/cloud-workers), whether OpenClaw manages them directly or through a coordinator. Turn on the Cloud Worker Desktop lab and enable desktop access in the worker profile. Existing workers created without a desktop need to be stopped and set up again with that setting enabled. This adds Azure to the supported desktop options; GCP desktops remain unsupported.
+
+
+
+###### Sources and complete change list
+
+
+**Improvements**
+
+- Remove a redundant cloud-desktop startup request [#142172](https://github.com/openclaw/openclaw/pull/142172).
+
+**Bug fixes**
+
+- Enable desktop access for Azure cloud workers [#141895](https://github.com/openclaw/openclaw/pull/141895).
+
+**Documentation**
+
+- Update translated Azure desktop guidance [#141909](https://github.com/openclaw/openclaw/pull/141909).
+
+
+
+
+
+#### Plugins and Integrations
+
+Finding something new for your Claw is easier, whether you browse plugins or ask for a recommendation in chat. You can review and set up plugins in the browser, while cloud workers gain ways to reuse project setup, keep a computer ready for your next session, and choose Windows or macOS when your provider supports them.
+
+
+
+
+##### Browse plugins and open recommendations from chat
+
+
+You can now search installed and available plugins together, browse by purpose, and keep exploring without clicking through pages. In [chat](https://docs.openclaw.ai/web/control-ui/chat), your Claw can recommend up to three official plugins or skills and give you a card that opens their details. Recommendations need the message tool enabled, and choosing Install opens a review before anything is added. An installed plugin may still need settings or an account connection before you can use it.
+
+
+
+###### Sources and complete change list
+
+
+**Improvements**
+
+- Browse and filter ClawHub plugins in the web UI [#137659](https://github.com/openclaw/openclaw/pull/137659) — Thanks @Patrick-Erichsen.
+- Inspect plugin documentation and compatibility in detail pages [#137846](https://github.com/openclaw/openclaw/pull/137846) — Thanks @Patrick-Erichsen.
+- Include local plugins and locally backed details in discovery [#137856](https://github.com/openclaw/openclaw/pull/137856) — Thanks @Patrick-Erichsen.
+- Unify bundled and ClawHub plugin browsing [#138755](https://github.com/openclaw/openclaw/pull/138755) — Thanks @Patrick-Erichsen.
+- Add Gateway-backed ClawHub catalog discovery [#139042](https://github.com/openclaw/openclaw/pull/139042) — Thanks @Patrick-Erichsen.
+- Reuse prepared plugin catalog metadata [#142500](https://github.com/openclaw/openclaw/pull/142500)
+- Use package categories in plugin discovery [#142711](https://github.com/openclaw/openclaw/pull/142711) — Thanks @Patrick-Erichsen.
+- Group installed plugins by purpose [#142712](https://github.com/openclaw/openclaw/pull/142712) — Thanks @Patrick-Erichsen.
+- Unify plugin browsing and add ClawHub chat cards [#142782](https://github.com/openclaw/openclaw/pull/142782) — Thanks @Patrick-Erichsen.
+- Load plugin catalog pages automatically [#143731](https://github.com/openclaw/openclaw/pull/143731) — Thanks @Patrick-Erichsen.
+- Load less unused code for bundled channels [#143846](https://github.com/openclaw/openclaw/pull/143846)
+
+**Limits and compatibility**
+
+- Declare ordered plugin categories [#142710](https://github.com/openclaw/openclaw/pull/142710) — Thanks @Patrick-Erichsen.
+
+**Bug fixes**
+
+- Match installed plugins to the correct ClawHub registry [#143644](https://github.com/openclaw/openclaw/pull/143644)
+- Correct plugin ranking, bundled identities, and skill names [#143730](https://github.com/openclaw/openclaw/pull/143730) — Thanks @Patrick-Erichsen.
+
+
+
+
+
+
+##### Review and set up plugins in the browser
+
+
+You can read what a plugin does, check what it needs, and follow installation through to setup without leaving the browser. [Plugin settings](https://docs.openclaw.ai/plugins/manage-plugins) puts its configuration, permissions, and troubleshooting information together, with clearer messages when setup is unfinished. The install dialog stays with your latest choice and waits through the required restart before confirming completion. Installing or changing plugins still requires the appropriate permissions and your consent.
+
+
+
+###### Sources and complete change list
+
+
+**Improvements**
+
+- Browse and search installed plugins in the Plugins workspace [#135839](https://github.com/openclaw/openclaw/pull/135839) — Thanks @Patrick-Erichsen.
+- Manage installed plugins on dedicated settings pages [#135840](https://github.com/openclaw/openclaw/pull/135840) — Thanks @Patrick-Erichsen.
+- Install and configure plugins from their detail pages [#137886](https://github.com/openclaw/openclaw/pull/137886) — Thanks @Patrick-Erichsen.
+- Organize installed-plugin details into tabs [#142713](https://github.com/openclaw/openclaw/pull/142713) — Thanks @Patrick-Erichsen.
+
+**Bug fixes**
+
+- Clarify plugin setup states and package icons [#142624](https://github.com/openclaw/openclaw/pull/142624) — Thanks @Patrick-Erichsen, @jalehman.
+- Correct recovery commands after plugin capability-consent rejection [#143125](https://github.com/openclaw/openclaw/pull/143125) — Thanks @liuwqgit, @obviyus, @yxloveql.
+- Keep plugin selections and installation progress current [#143671](https://github.com/openclaw/openclaw/pull/143671)
+
+
+
+
+
+
+##### Get useful help when plugin commands fail
+
+
+If you manage plugins from the terminal, [error messages](https://docs.openclaw.ai/cli/plugins) now point to recovery commands for your profile or container and explain whether you need to restart OpenClaw. Plugin checks also report cleanup failures instead of claiming success, and slow catalog responses no longer keep commands waiting indefinitely.
+
+
+
+###### Sources and complete change list
+
+
+**Bug fixes**
+
+- Enforce deadlines for ClawHub metadata and error responses [#109092](https://github.com/openclaw/openclaw/pull/109092) — Thanks @Pick-cat, @obviyus.
+- Keep profile and container context in plugin recovery commands [#117631](https://github.com/openclaw/openclaw/pull/117631)
+- Release plugin resources before reporting inspection success [#141780](https://github.com/openclaw/openclaw/pull/141780)
+- Close chat plugin-inspection resources before replying [#141819](https://github.com/openclaw/openclaw/pull/141819)
+- Release Plugin Doctor resources before reporting completion [#141845](https://github.com/openclaw/openclaw/pull/141845)
+- Close Workboard connections after plugin inspections [#141858](https://github.com/openclaw/openclaw/pull/141858)
+- Recover notices for already loaded plugins [#141930](https://github.com/openclaw/openclaw/pull/141930)
+- Clarify restart requirements after installing plugins [#142129](https://github.com/openclaw/openclaw/pull/142129) — Thanks @WOLIKIMCHENG, @obviyus, @dh-js.
+- Identify changed plugin registry records in diagnostics [#142192](https://github.com/openclaw/openclaw/pull/142192)
+- Release plugin CLI resources after cleanup finishes [#142388](https://github.com/openclaw/openclaw/pull/142388)
+- Keep resources alive through plugin registration cleanup [#142636](https://github.com/openclaw/openclaw/pull/142636)
+- Preserve bundled plugin trust for development path installs [#143516](https://github.com/openclaw/openclaw/pull/143516) — Thanks @RomneyDa.
+- Report supported bundle hook layouts accurately [#143687](https://github.com/openclaw/openclaw/pull/143687)
+
+**Documentation**
+
+- Split the plugins CLI reference by task [#142980](https://github.com/openclaw/openclaw/pull/142980) — Thanks @vincentkoc.
+- Clarify default plugin package resolution [#143867](https://github.com/openclaw/openclaw/pull/143867) — Thanks @vincentkoc.
+
+**Improvements**
+
+- Skip unused installation detail work in plugin summary tables [#143105](https://github.com/openclaw/openclaw/pull/143105)
+
+
+
+
+
+
+##### Build and preview your own plugins
+
+
+People building plugins get fixes for type errors and missing supporting files that could stop a build. You can also opt into [live previews in the browser](https://docs.openclaw.ai/web/control-ui/development), seeing changes to your plugin against a real OpenClaw installation. If you wrap the multi-account configuration helper, check its updated types when rebuilding; the [SDK guide](https://docs.openclaw.ai/plugins/sdk-overview) covers development setup.
+
+
+
+###### Sources and complete change list
+
+
+**Documentation**
+
+- Document the private completion helper in the SDK catalog [#111706](https://github.com/openclaw/openclaw/pull/111706) — Thanks @xydt-tanshanshan, @obviyus, @chegherian.
+- Split provider SDK guidance into focused references [#141958](https://github.com/openclaw/openclaw/pull/141958) — Thanks @vincentkoc.
+- Organize plugin hook guidance by task [#142605](https://github.com/openclaw/openclaw/pull/142605) — Thanks @vincentkoc.
+- Split SDK migration guidance into focused pages [#142607](https://github.com/openclaw/openclaw/pull/142607) — Thanks @vincentkoc.
+- Organize the SDK overview into focused references [#142641](https://github.com/openclaw/openclaw/pull/142641) — Thanks @vincentkoc.
+- Split channel SDK guidance into focused references [#142703](https://github.com/openclaw/openclaw/pull/142703) — Thanks @vincentkoc.
+- Split plugin architecture into focused guides [#142730](https://github.com/openclaw/openclaw/pull/142730) — Thanks @vincentkoc.
+- Split the agent-harness SDK reference into focused pages [#142889](https://github.com/openclaw/openclaw/pull/142889) — Thanks @vincentkoc.
+- Split plugin entry-point documentation into focused references [#143151](https://github.com/openclaw/openclaw/pull/143151) — Thanks @vincentkoc.
+- Correct plugin examples and capability guidance [#143857](https://github.com/openclaw/openclaw/pull/143857) — Thanks @vincentkoc.
+- Correct provider catalog and Claude bundle guidance [#143895](https://github.com/openclaw/openclaw/pull/143895) — Thanks @vincentkoc.
+- Clarify plugin migration history and examples [#143982](https://github.com/openclaw/openclaw/pull/143982) — Thanks @vincentkoc.
+
+**Limits and compatibility**
+
+- Expose the actual catchall multi-account schema type [#141796](https://github.com/openclaw/openclaw/pull/141796) — Thanks @RomneyDa.
+
+**Bug fixes**
+
+- Accept interface-typed inbound hook contexts [#141934](https://github.com/openclaw/openclaw/pull/141934) — Thanks @RomneyDa.
+- Use the running Gateway SDK for sibling-checkout plugins [#142508](https://github.com/openclaw/openclaw/pull/142508)
+- Include declared assets in untracked source-plugin builds [#142527](https://github.com/openclaw/openclaw/pull/142527)
+
+**Improvements**
+
+- Develop Control UI plugins against a real Gateway with hot reload [#143052](https://github.com/openclaw/openclaw/pull/143052) — Thanks @shakkernerd.
+
+
+
+
+
+
+##### Keep plugin requests from stopping too early
+
+
+Requests using [model plugins](https://docs.openclaw.ai/plugins/sdk-runtime/models) are less likely to fail because a connection closed while work was still finishing. OpenClaw keeps those connections available through cancellation, plugin reloads, and shutdown. A plugin that cannot finish closing can still delay shutdown.
+
+
+
+###### Sources and complete change list
+
+
+**Bug fixes**
+
+- Stop advertising retired native-hook relay endpoints [#141608](https://github.com/openclaw/openclaw/pull/141608)
+- Keep model state alive through plugin completions [#141938](https://github.com/openclaw/openclaw/pull/141938)
+- Retain plugin model resources through cancellation cleanup [#142197](https://github.com/openclaw/openclaw/pull/142197)
+- Preserve plugin resources through reload cleanup [#142519](https://github.com/openclaw/openclaw/pull/142519)
+- Retain provider resources through host cleanup [#142838](https://github.com/openclaw/openclaw/pull/142838)
+- Preserve provider context while listing tools [#142896](https://github.com/openclaw/openclaw/pull/142896)
+- Release temporary plugin resources after model checks finish [#143109](https://github.com/openclaw/openclaw/pull/143109)
+- Keep local model resources through request cleanup [#143302](https://github.com/openclaw/openclaw/pull/143302)
+- Preserve plugin identity when tools are cancelled [#143305](https://github.com/openclaw/openclaw/pull/143305)
+- Keep isolated model calls alive through cleanup [#143414](https://github.com/openclaw/openclaw/pull/143414)
+- Fix runtime-specific environment listing from the CLI [#143446](https://github.com/openclaw/openclaw/pull/143446) — Thanks @jalehman.
+- Keep plugin resources through late agent cleanup [#143490](https://github.com/openclaw/openclaw/pull/143490)
+- Release model-selected plugin resources after agent work [#143725](https://github.com/openclaw/openclaw/pull/143725)
+
+**Documentation**
+
+- Split tool configuration references into focused pages [#142960](https://github.com/openclaw/openclaw/pull/142960) — Thanks @vincentkoc.
+
+**Improvements**
+
+- Reduce repeated checks when selecting plugin providers [#143091](https://github.com/openclaw/openclaw/pull/143091)
+
+**Limits and compatibility**
+
+- Retain plugin-prepared models until host work finishes [#143270](https://github.com/openclaw/openclaw/pull/143270)
+
+
+
+
+
+
+##### Finish creating and saving images, music, and video
+
+
+Image, music, and video jobs can finish and save their results even when the plugin setup that started them is replaced. Related fixes keep connections available for speech and document analysis and prevent the last part of streamed audio from being lost. Paid generation that has already started may continue after you cancel.
+
+
+
+###### Sources and complete change list
+
+
+**Bug fixes**
+
+- Remove false empty-body explanations from media-download errors [#141674](https://github.com/openclaw/openclaw/pull/141674)
+- Close music plugin resources after generation finishes [#142834](https://github.com/openclaw/openclaw/pull/142834)
+- Retain image plugin resources until generation finishes [#142843](https://github.com/openclaw/openclaw/pull/142843)
+- Retain video plugin resources until generation finishes [#142876](https://github.com/openclaw/openclaw/pull/142876)
+- Keep accepted image jobs alive through provider cleanup [#142991](https://github.com/openclaw/openclaw/pull/142991)
+- Keep music jobs alive through saving and cleanup [#143060](https://github.com/openclaw/openclaw/pull/143060)
+- Keep telephony speech providers alive through synthesis and cleanup [#143065](https://github.com/openclaw/openclaw/pull/143065)
+- Keep video providers available until background jobs finish [#143260](https://github.com/openclaw/openclaw/pull/143260)
+- Keep speech resources through synthesis and cleanup [#143313](https://github.com/openclaw/openclaw/pull/143313)
+- Keep speech providers through stream cleanup [#143369](https://github.com/openclaw/openclaw/pull/143369)
+- Keep image provider resources through cleanup [#143403](https://github.com/openclaw/openclaw/pull/143403)
+- Keep PDF provider resources through cancellation cleanup [#143460](https://github.com/openclaw/openclaw/pull/143460)
+- Keep prepared speech settings usable until host shutdown [#143493](https://github.com/openclaw/openclaw/pull/143493)
+- Keep plugin resources through media task cleanup [#143530](https://github.com/openclaw/openclaw/pull/143530)
+- Retain managed speech-summary resources through cleanup [#143627](https://github.com/openclaw/openclaw/pull/143627)
+- Preserve plugin image handlers for multiple images [#143717](https://github.com/openclaw/openclaw/pull/143717)
+
+**Documentation**
+
+- Organize text-to-speech documentation by task [#142992](https://github.com/openclaw/openclaw/pull/142992) — Thanks @vincentkoc.
+
+
+
+
+
+
+##### Use less extra memory for plugin data
+
+
+Plugins with lots of saved data use less extra memory when listing it, helping reduce the strain of a large collection. The first use after the [storage update](https://docs.openclaw.ai/reference/database-schemas#plugin-state-listing-index) may take extra time and disk space.
+
+
+
+###### Sources and complete change list
+
+
+**Improvements**
+
+- Reduce database reads during plugin-state quota checks [#142318](https://github.com/openclaw/openclaw/pull/142318)
+- Reduce temporary memory when listing plugin state [#142568](https://github.com/openclaw/openclaw/pull/142568) — Thanks @arcabotai.
+
+**Bug fixes**
+
+- Release local telemetry resources after cleanup settles [#142423](https://github.com/openclaw/openclaw/pull/142423)
+- Avoid unused private diagnostic copies in Prometheus [#144109](https://github.com/openclaw/openclaw/pull/144109)
+
+
+
+
+
+
+##### Handle large tool replies and disconnects
+
+
+If you connect external tools through [MCP](https://docs.openclaw.ai/cli/mcp), large text replies from connected devices no longer include an unnecessary duplicate copy. Stopping a standalone MCP service gives ongoing tool work time to finish cleaning up, and an accepted disconnect no longer gets stuck waiting on response cleanup. Failed disconnects still report a problem that may need attention.
+
+
+
+###### Sources and complete change list
+
+
+**Bug fixes**
+
+- Finish MCP cleanup without waiting on stalled cancellation [#141289](https://github.com/openclaw/openclaw/pull/141289) — Thanks @hugenshen, @obviyus.
+- Wait for MCP tool cleanup before resource release [#142632](https://github.com/openclaw/openclaw/pull/142632)
+- Keep MCP plugin resources available through shutdown cleanup [#143031](https://github.com/openclaw/openclaw/pull/143031)
+
+**Improvements**
+
+- Remove duplicate text from node-hosted MCP snapshots [#142518](https://github.com/openclaw/openclaw/pull/142518)
+
+**Documentation**
+
+- Split MCP documentation by task [#142995](https://github.com/openclaw/openclaw/pull/142995) — Thanks @vincentkoc.
+
+
+
+
+
+
+##### Use accurate time limits for connected devices
+
+
+Commands on [connected devices](https://docs.openclaw.ai/cli/nodes) no longer time out early or wait longer just because the system clock changed. Time spent waking the device counts toward the same limit as running the command. If you use scripts, omit numeric options when you want their defaults—passing an empty value now gives a clear error before OpenClaw contacts the device.
+
+
+
+###### Sources and complete change list
+
+
+**Bug fixes**
+
+- Keep node command timeouts stable across clock changes [#137147](https://github.com/openclaw/openclaw/pull/137147) — Thanks @qingminglong, @obviyus.
+
+**Limits and compatibility**
+
+- Reject empty numeric node command options [#137311](https://github.com/openclaw/openclaw/pull/137311) — Thanks @Alix-007, @obviyus.
+
+**Documentation**
+
+- Split Nodes documentation by task [#142779](https://github.com/openclaw/openclaw/pull/142779) — Thanks @vincentkoc.
+
+
+
+
+
+
+##### Get answers from a separate agent in Google Meet
+
+
+Google Meet and voice sessions can now ask a [separately configured agent](https://docs.openclaw.ai/plugins/google-meet/tool-and-modes) for help even when the original conversation has a locked model choice. That agent uses its own conversation without copying your earlier chat, and its own model restrictions still apply. Failed Chrome meeting starts also try to stop the audio they opened and close only newly created tabs, leaving your existing tabs alone.
+
+
+
+###### Sources and complete change list
+
+
+**Documentation**
+
+- Organize Google Meet guidance by task [#142729](https://github.com/openclaw/openclaw/pull/142729) — Thanks @vincentkoc.
+
+**Bug fixes**
+
+- Allow separate-agent consultations from model-locked sessions [#142736](https://github.com/openclaw/openclaw/pull/142736) — Thanks @RileyJJY, @jai-assistant, @jalehman.
+- Clean up Google Meet audio after Chrome startup failure [#143408](https://github.com/openclaw/openclaw/pull/143408)
+
+
+
+
+
+
+##### Send A2A work to the agent you chose
+
+
+If you use [A2A to connect agents](https://docs.openclaw.ai/channels/a2a), incoming requests now reach the agent assigned to that connection even when a new conversation begins. You can still choose a different agent for a particular conversation, and separate conversations keep their own history.
+
+
+
+###### Sources and complete change list
+
+
+**Bug fixes**
+
+- Honor A2A peer-to-agent bindings [#142485](https://github.com/openclaw/openclaw/pull/142485) — Thanks @eleqtrizit.
+
+
+
+
+
+
+##### Tell connected apps when an answer was cut short
+
+
+Apps using OpenClaw through [Chat Completions](https://docs.openclaw.ai/gateway/openai-http-api) or the [Responses API](https://docs.openclaw.ai/gateway/openresponses-http-api) can now tell when an answer stopped at its output limit. They keep the partial answer and receive a clear signal that it was cut short, including during streaming, so they can decide what to show or do next. Connected apps also get a more accurate report of which settings changed after a configuration update.
+
+
+
+###### Sources and complete change list
+
+
+**Bug fixes**
+
+- Report output-limited Chat Completions accurately [#141268](https://github.com/openclaw/openclaw/pull/141268) — Thanks @ooiuuii, @obviyus.
+- Report output-limited Responses answers as incomplete [#142778](https://github.com/openclaw/openclaw/pull/142778) — Thanks @zhangguiping-xydt, @obviyus, @ooiuuii.
+
+**Improvements**
+
+- Report effective changed paths from configuration patches [#141757](https://github.com/openclaw/openclaw/pull/141757)
+
+**Documentation**
+
+- Expose Gateway RPC method groups as headings [#143459](https://github.com/openclaw/openclaw/pull/143459) — Thanks @vincentkoc.
+- Correct Gateway reference hierarchy and model-view link [#143472](https://github.com/openclaw/openclaw/pull/143472) — Thanks @vincentkoc.
+- Split Gateway RPC guidance into focused topic pages [#143515](https://github.com/openclaw/openclaw/pull/143515) — Thanks @vincentkoc.
+
+
+
+
+
+
+##### Open Reports and plugin panels with more room
+
+
+[Reports](https://docs.openclaw.ai/plugins/team-reports) opens at the short `/reports` address inside OpenClaw, and embedded plugin pages use more of the window. Plugin panels also load in affected containers where file permissions previously got in the way.
+
+If you use separate Team Reports report or export links, change `/reports/...` to `/plugins/team-reports/...`; old links do not redirect automatically. The guide explains how to keep a custom address if you need one.
+
+
+
+###### Sources and complete change list
+
+
+**Bug fixes**
+
+- Make generated plugin panels readable by container runtime users [#142997](https://github.com/openclaw/openclaw/pull/142997) — Thanks @ylcn91, @obviyus, @Conan-Scott.
+- Let embedded reports fill the content area [#143765](https://github.com/openclaw/openclaw/pull/143765)
+
+**Limits and compatibility**
+
+- Add short plugin-tab URLs and move Team Reports HTTP defaults [#143183](https://github.com/openclaw/openclaw/pull/143183)
+
+**Improvements**
+
+- Use full page width for Team Reports [#143340](https://github.com/openclaw/openclaw/pull/143340)
+
+
+
+
+
+
+##### Reuse project setup in new cloud sessions
+
+
+New cloud sessions can [reuse a project that is already set up](https://docs.openclaw.ai/gateway/cloud-workers/warm-images), saving repeated installation and preparation work while keeping your session’s changes. You can use an eligible local project or start directly from a public GitHub repository. Starting from only a private repository URL still uses a fresh checkout; private projects already checked out locally can use the local-project route. A saved setup still needs a machine to start unless a running spare is available.
+
+Back up OpenClaw’s data before upgrading, following the [backup and rollback instructions](https://docs.openclaw.ai/reference/database-schemas/state-schema-history). Older versions cannot read the updated data format, so rolling back the app alone is not enough. Restoring the earlier backup also discards changes made after it.
+
+
+
+###### Sources and complete change list
+
+
+**Improvements**
+
+- Reuse prepared workers for public GitHub repositories [2bcb98a4b280](https://github.com/openclaw/openclaw/commit/2bcb98a4b2807cd0ac014517d4ecdad4f42e557f)
+- Reuse completed project setup across fresh cloud-worker sessions [#143227](https://github.com/openclaw/openclaw/pull/143227)
+
+
+
+
+
+
+##### Keep a cloud computer ready for your next session
+
+
+[Ready workers](https://docs.openclaw.ai/gateway/cloud-workers/warm-images#ready-workers) let your next matching session use an already running computer while OpenClaw prepares a replacement. Eligible Linux projects get one spare per project and profile by default, with a shared limit of four. These computers cost money until deletion is confirmed. Set a profile's Ready workers value to zero to disable its spares, or the shared Prepared pool limit to zero to remove unused spares without stopping active sessions.
+
+If you already use saved worker images, stop OpenClaw and any image captures it started, then follow the [Doctor upgrade step](https://docs.openclaw.ai/gateway/cloud-workers/warm-images) before starting more workers.
+
+
+
+###### Sources and complete change list
+
+
+**Improvements**
+
+- Keep prepared cloud workers ready for later sessions [#143372](https://github.com/openclaw/openclaw/pull/143372)
+- Prepare cloud workers on demand [#143838](https://github.com/openclaw/openclaw/pull/143838)
+
+**Bug fixes**
+
+- Preserve worker bundles during provisioning [#143663](https://github.com/openclaw/openclaw/pull/143663)
+
+
+
+
+
+
+##### Choose Linux, Windows, WSL2, or macOS workers
+
+
+You can choose a cloud computer’s operating system for a profile or an individual session when your provider offers it. Native Windows runs Windows commands, while WSL2 gives you a Linux environment on Windows. Mac workers on AWS require a Dedicated Host and On-Demand capacity; desktop access and reusable worker images remain Linux-only. The [operating-system guide](https://docs.openclaw.ai/gateway/cloud-workers/placement-and-machine-selection#choose-an-operating-system-and-machine-class-per-session) covers availability, with separate [setup requirements for native Windows](https://docs.openclaw.ai/gateway/cloud-workers/setup-and-bundle-installation#native-windows-prerequisites).
+
+
+
+###### Sources and complete change list
+
+
+**Improvements**
+
+- Choose provider-defined cloud-session operating systems [#142095](https://github.com/openclaw/openclaw/pull/142095)
+- Enable Windows WSL2 cloud workers with compatible Crabbox [#142679](https://github.com/openclaw/openclaw/pull/142679)
+- Run macOS cloud workers through Crabbox [#143463](https://github.com/openclaw/openclaw/pull/143463)
+- Run cloud workers on native Windows [#143769](https://github.com/openclaw/openclaw/pull/143769)
+
+**Documentation**
+
+- Translate cloud-worker operating-system controls [#142120](https://github.com/openclaw/openclaw/pull/142120)
+
+**Bug fixes**
+
+- Explain unavailable cloud operating systems [#143798](https://github.com/openclaw/openclaw/pull/143798)
+
+
+
+
+
+
+##### Set up cloud workers from Settings
+
+
+Cloud workers settings now lets administrators change advanced options, set spare-computer limits, and choose a default profile for each repository. Save your changes and restart OpenClaw to apply them. You can also hover over a cloud session to see its known operating system, CPU, and memory capacity.
+
+OpenClaw can automatically download a supported Crabbox tool when yours is missing or outdated. If your computer blocks those downloads or installations, [prepare Crabbox 0.55.0 or newer before upgrading](https://docs.openclaw.ai/gateway/config-cloud-workers#crabbox-profile), because you need it even to inspect or stop existing cloud workers.
+
+
+
+###### Sources and complete change list
+
+
+**Documentation**
+
+- Correct Node requirements in cloud-worker setup guidance [#141871](https://github.com/openclaw/openclaw/pull/141871)
+- Split Cloud Workers guidance into focused topic pages [#143158](https://github.com/openclaw/openclaw/pull/143158) — Thanks @vincentkoc.
+
+**Improvements**
+
+- Automatically prepare a supported Crabbox CLI [#143768](https://github.com/openclaw/openclaw/pull/143768)
+- Edit advanced worker settings and repository defaults [#143801](https://github.com/openclaw/openclaw/pull/143801)
+- See cloud session machine specifications [#143864](https://github.com/openclaw/openclaw/pull/143864)
+
+
+
+
+
+
+##### Save and manage prepared cloud projects
+
+
+Administrators can [save a prepared project in Settings](https://docs.openclaw.ai/gateway/cloud-workers/warm-images), watch its progress, cancel it, or pin a useful snapshot to keep it. You can choose a previous snapshot for new workers without changing computers already running. Builds use the project's committed files and setup instructions, and may reuse a suitable existing copy.
+
+Before using Recover after an interrupted capture, stop the affected worker and capture and check the saved images with your provider. Recover only clears OpenClaw's record of the interruption; it does not stop a computer or delete an image for you.
+
+
+
+###### Sources and complete change list
+
+
+**Bug fixes**
+
+- Clear cloud snapshot reservations after confirmed rejection [#142221](https://github.com/openclaw/openclaw/pull/142221)
+- Allow cloud-worker snapshots to finish before enrollment [#143288](https://github.com/openclaw/openclaw/pull/143288)
+- Clean up abandoned uploads and failed checkpoint handoffs [#143675](https://github.com/openclaw/openclaw/pull/143675)
+
+**Improvements**
+
+- Inspect and recover cloud snapshots in the Control UI [#143814](https://github.com/openclaw/openclaw/pull/143814)
+- Pin, delete, and roll back cloud-worker images [#143893](https://github.com/openclaw/openclaw/pull/143893)
+- Build project snapshots from Settings [#143929](https://github.com/openclaw/openclaw/pull/143929)
+
+
+
+
+
+
+##### Keep messages and cloud computers through updates
+
+
+You can send a message while a cloud session is setting up or syncing files and see what it is waiting for. OpenClaw keeps the message and starts it when the intended computer is ready, saving you from copying and resending it.
+
+Supported cloud computers can also keep their files, installed tools, and desktop through an [OpenClaw update](https://docs.openclaw.ai/gateway/cloud-workers/session-lifecycle). A message that has not started can continue once the worker is updated, but work already underway is not automatically repeated. The computer must support the update and reconnect; this cannot recover a machine lost by the provider.
+
+
+
+###### Sources and complete change list
+
+
+**Bug fixes**
+
+- Keep accepted messages queued through worker setup and file sync [#137576](https://github.com/openclaw/openclaw/pull/137576) — Thanks @jalehman.
+- Retain cloud-worker renewals after temporary heartbeat failures [#142194](https://github.com/openclaw/openclaw/pull/142194)
+- Keep configured cloud machines through updates [#143858](https://github.com/openclaw/openclaw/pull/143858)
+- Continue unstarted turns through worker updates [#143910](https://github.com/openclaw/openclaw/pull/143910)
+
+
+
+
+
+
+##### Copy remote workspaces with less waiting
+
+
+Saving a remote workspace with many small files can finish sooner, and its file list needs fewer bytes to transfer. Cancelling preparation stops new scanning and closes the upload connection instead of leaving it hanging, though file operations already underway may need time to finish. Oversized or changing files are also rejected earlier, without leaving a partial workspace result.
+
+
+
+###### Sources and complete change list
+
+
+**Bug fixes**
+
+- Allow long prepared workspace paths at worker launch [#142198](https://github.com/openclaw/openclaw/pull/142198)
+- Stop cancelled cloud workspace uploads from hanging [#142237](https://github.com/openclaw/openclaw/pull/142237)
+- Skip unused workspace files during worker startup [#143721](https://github.com/openclaw/openclaw/pull/143721)
+- Stop workspace scans when worker preparation is canceled [#143746](https://github.com/openclaw/openclaw/pull/143746)
+- Stop excessive reads during worker workspace capture [#143795](https://github.com/openclaw/openclaw/pull/143795)
+
+**Improvements**
+
+- Compress cloud workspace file inventories during transfer [#142242](https://github.com/openclaw/openclaw/pull/142242)
+- Capture many-file remote workspaces faster [#144017](https://github.com/openclaw/openclaw/pull/144017)
+
+
+
+
+
+
+##### See what still needs attention after cloud cleanup
+
+
+When a cloud worker fails, the error now keeps the original problem and the latest cleanup failure visible without piling up repeated messages. Stopping a computer can succeed even if saving an optional image failed, with a warning explaining what remains. Failed image deletion stays visible for retry, and charges may continue until your provider confirms deletion.
+
+
+
+###### Sources and complete change list
+
+
+**Bug fixes**
+
+- Restore Crabbox image cleanup across multiple CLI executables [#142166](https://github.com/openclaw/openclaw/pull/142166)
+- Keep cloud-worker cleanup errors current [#143345](https://github.com/openclaw/openclaw/pull/143345)
+- Separate successful Crabbox cleanup from capture warnings [#143349](https://github.com/openclaw/openclaw/pull/143349)
+
+
+
+
+
+
+##### Find and connect Codex plugins
+
+
+Owners and administrators can [search Codex plugins](https://docs.openclaw.ai/plugins/codex-native-plugins), open their setup links, and see installation, permission, and account-connection information together. Opening a setup link does not finish the step—return and submit the completion response when you are done. After connecting, use `/codex plugins refresh` to update the app list, then `/new` or `/reset` where required; refreshing does not sign in or enable an app for you.
+
+
+
+###### Sources and complete change list
+
+
+**Improvements**
+
+- Find, connect and inspect Codex plugins [#132158](https://github.com/openclaw/openclaw/pull/132158) — Thanks @stevenlee-oai.
+
+
+
+
+
+
+
+#### Security and Privacy
+
+Your Claw can make more decisions about routine commands without interrupting you, while still asking for approval when needed. There are also fixes for keeping file access within the permissions you chose, protecting shared conversation history when deleting an agent, and keeping private update records out of backups and support bundles.
+
+
+
+
+##### Decide when commands need your approval
+
+
+[Automatic command review](https://docs.openclaw.ai/tools/exec) can now let suitable routine commands run, refuse a command with an explanation, or ask you to decide. This takes effect in existing automatic and workspace modes. In OpenClaw's built-in agent, the reviewer can use part of your conversation to check whether a command fits your request. High-risk actions still need human approval, and settings that always ask remain in force.
+
+
+
+###### Sources and complete change list
+
+
+**Improvements**
+
+- Let automatic command review allow, deny, or ask [#141987](https://github.com/openclaw/openclaw/pull/141987). SDK consumers must handle denial without executing the command or automatically converting it into a human request.
+- Give command auto-review the user's conversation context [#142279](https://github.com/openclaw/openclaw/pull/142279).
+
+**Bug fixes**
+
+- Keep timed-out command review from releasing model resources before cleanup finishes [#143308](https://github.com/openclaw/openclaw/pull/143308).
+
+
+
+
+
+
+##### Keep your tool permissions in place
+
+
+Turning tools off now carries through to supported connected agents, including Copilot, even when you return to a conversation that previously allowed them. If an integration cannot honor that restriction, OpenClaw stops rather than continuing with tools enabled. Update the plugin or choose a supported agent to continue.
+
+Your Claw's instructions also allow it to use existing login details for tasks you authorize, such as signing into a website, while keeping your other permissions in place. When it cannot offer secure setup in chat, it directs you to terminal prompts that hide what you type.
+
+
+
+###### Sources and complete change list
+
+
+**Improvements**
+
+- Clarify the existing scope of Read Only permissions in the English interface [#141283](https://github.com/openclaw/openclaw/pull/141283). Thanks @north-echo and @obviyus.
+
+**Bug fixes**
+
+- Show usage for invalid approval decisions and accept unusual IDs with valid decisions [#137877](https://github.com/openclaw/openclaw/pull/137877). Thanks @teddytennant and @obviyus.
+- Remove blanket credential-use refusals and correct setup routing [#143238](https://github.com/openclaw/openclaw/pull/143238). Thanks @ejc3, @Stephane-fci, and @Sedrak-Hovhannisyan. SDK callers should replace the legacy string argument to `buildCredentialSafetyPrompt` with `{ controlToolsAvailable }`; legacy strings remain accepted through November 30, 2026.
+- Keep approval-reply interpretation resources until cleanup ends [#143307](https://github.com/openclaw/openclaw/pull/143307).
+
+**Security and trust**
+
+- Preserve disabled tools across plugin handoffs [#142093](https://github.com/openclaw/openclaw/pull/142093). Thanks @pgondhi987. For [plugin authors](https://docs.openclaw.ai/plugins/sdk-agent-harness), an empty runtime `toolsAllow` list means deny all, while an empty configuration `allow` list remains unrestricted.
+
+**Documentation**
+
+- Clarify full-mode command approval, strict inline-code review, and waiting behavior [#142368](https://github.com/openclaw/openclaw/pull/142368). Thanks @Glucksberg, @obviyus, @JKamgang, and @russellweiss. This documents existing policy; strict inline evaluation remains off by default.
+
+
+
+
+
+
+##### Fix password and device sign-in problems
+
+
+Password login now rejects blank passwords and known example values. If one prevents your Gateway from starting, replace it, restart OpenClaw, and update the apps that connect to it. Short real passwords produce a warning rather than a new startup block.
+
+More model connections can use [protected API keys](https://docs.openclaw.ai/gateway/secrets) without turning protection off. Doctor also gives administrators a working [repair for certain older device sign-in failures](https://docs.openclaw.ai/cli/devices), making it easier to reconnect affected devices.
+
+
+
+###### Sources and complete change list
+
+
+**Security and trust**
+
+- Reject placeholder Gateway passwords and audit password strength [#141720](https://github.com/openclaw/openclaw/pull/141720).
+
+**Bug fixes**
+
+- Skip unused saved credentials for eligible password-only connections [#142290](https://github.com/openclaw/openclaw/pull/142290). This applies to signed clients using read-only local shared state, without an origin-specific credential scope or another credential type.
+- Correct credential recovery notices [#142498](https://github.com/openclaw/openclaw/pull/142498). Thanks @obviyus.
+- Restore WebSocket inference through managed secret egress, and synchronize bundled autoreview authentication handling and machine-readable status output [#143354](https://github.com/openclaw/openclaw/pull/143354). Thanks @fuller-stack-dev. The helper sync also removes the external credential-scanner dependency from autoreview.
+- Recover legacy node tokens with `--no-scopes` [#143599](https://github.com/openclaw/openclaw/pull/143599). Thanks @obviyus and @matthewmoroz. The option cannot be combined with `--scope`; cleanup removes only the matching local legacy node credential.
+
+**Documentation**
+
+- Split secrets guidance into focused runtime, SecretRef, store and egress, integration, and operations guides [#143520](https://github.com/openclaw/openclaw/pull/143520). Thanks @vincentkoc.
+
+
+
+
+
+
+##### Protect incoming messages and network access
+
+
+For Slack connections using HTTP webhooks, OpenClaw now enforces limits on oversized, slow, or excessive incoming requests before processing them. Feishu and Lark webhooks also reject signed requests dated more than an hour before or after the computer's clock. Keep that clock synchronized, and check [Feishu troubleshooting](https://docs.openclaw.ai/channels/feishu/troubleshooting) if delayed deliveries are rejected. Feishu's WebSocket connection mode is unaffected.
+
+If you use [IPv4-mapped network rules](https://docs.openclaw.ai/gateway/trusted-proxy-auth) for a reverse proxy or device pairing, review the addresses you allow. Those rules now cover their full stated range, fixing connections that were wrongly rejected. Broad rules may therefore trust more addresses than before, including the computer itself; keep the allowed range as narrow as your setup needs. Other login and approval checks still apply.
+
+
+
+###### Sources and complete change list
+
+
+**Security and trust**
+
+- Enforce Slack HTTP webhook limits before processing, including a 1 MiB body limit and 30-second read deadline [c11ea063](https://github.com/openclaw/openclaw/commit/c11ea06355b094e29c9fe5fcfe309fdbaae6d17b). Thanks @drobison00. Contextual intent and review reference [#136508](https://github.com/openclaw/openclaw/pull/136508).
+- Preserve IPv6 cloud metadata blocking with proxy compatibility enabled [#137684](https://github.com/openclaw/openclaw/pull/137684). Thanks @eleqtrizit.
+- Reject malformed Tlon citations before authenticated lookups [#142041](https://github.com/openclaw/openclaw/pull/142041). Thanks @pgondhi987.
+- Reject stale signed Feishu and Lark webhook callbacks outside the fixed one-hour clock window [#143484](https://github.com/openclaw/openclaw/pull/143484). Thanks @eleqtrizit.
+
+**Limits and compatibility**
+
+- Honor IPv4-mapped network ranges in proxy and pairing rules [#137668](https://github.com/openclaw/openclaw/pull/137668). Thanks @elbourne12345 and @obviyus. Native IPv6 peers do not match these ranges, and catch-all proxy trust can still prevent correct client attribution.
+
+
+
+
+
+
+##### Keep shared files within their permissions
+
+
+When an agent is limited to its workspace, it can now send files from the current chat's sandbox without being able to attach files from another chat's sandbox. Plugins that send these attachments must identify the correct workspace, so some third-party plugins may need an update.
+
+Changing a shared conversation to draft now also blocks new file requests from readers who can no longer see it, even without separately configured user roles. Download links issued earlier remain valid until they expire, and people sharing one OpenClaw installation still need to trust one another.
+
+
+
+###### Sources and complete change list
+
+
+**Security and trust**
+
+- Prevent attachment reads from sibling sandboxes under workspace-only policy [#143521](https://github.com/openclaw/openclaw/pull/143521). Thanks @eleqtrizit, @yetval, and @yangxiansheng.
+
+**Bug fixes**
+
+- Apply draft visibility to fresh artifact reads and downloads [#143873](https://github.com/openclaw/openclaw/pull/143873). Thanks @vincentkoc.
+
+**Documentation**
+
+- Split sandboxing guidance into focused backend, workspace, image, and setup pages [#143522](https://github.com/openclaw/openclaw/pull/143522). Thanks @vincentkoc.
+- Document file-transfer approval migration and clarify SecretRef fields, the Moonshot model example, and plugin-reference navigation [#144029](https://github.com/openclaw/openclaw/pull/144029). Thanks @vincentkoc.
+
+
+
+
+
+
+##### Keep external tool apps read-only
+
+
+If you have read-only access, opening an MCP App in a separate view no longer gives you permission to run its tools. You can still view the App and use the resources you are allowed to read. For MCP tools running on the same computer, rejecting an oversized upload also stops a tool command queued behind it from running on that connection.
+
+
+
+###### Sources and complete change list
+
+
+**Security and trust**
+
+- Preserve read-only permissions in standalone MCP Apps [#142661](https://github.com/openclaw/openclaw/pull/142661). Thanks @eleqtrizit. Client tool permission is captured when the launch ticket is issued; the ongoing check concerns the live App grant.
+- Block queued MCP tool execution after rejected uploads on the authenticated loopback connection [#143724](https://github.com/openclaw/openclaw/pull/143724).
+
+
+
+
+
+
+##### Protect shared history and private update records
+
+
+[Deleting an agent](https://docs.openclaw.ai/cli/agents) now stops if another agent needs it to read shared history. Moving that history is not yet supported, so keep the agent configured. If deletion fails partway through, fix the reported storage problem and retry. Before deleting a workspace that links to a neighboring folder, check what will be removed. Deletion through the Gateway may move that linked folder to Trash too; the offline command removes only the link.
+
+[Backups and support bundles](https://docs.openclaw.ai/cli/backup) leave out recognized private update records. If you move a protected folder, keep its privacy-marker file with it. Files copied elsewhere without that marker are not protected from export.
+
+
+
+###### Sources and complete change list
+
+
+**Bug fixes**
+
+- Preserve shared history and retryable cleanup during agent deletion [#141731](https://github.com/openclaw/openclaw/pull/141731). Thanks @andrea-kingautomation.
+- Clean up deleted agents on external state volumes, with the Gateway's same-parent workspace-symlink behavior described above [#142130](https://github.com/openclaw/openclaw/pull/142130).
+
+**Security and trust**
+
+- Keep recognized private update captures out of backups and support exports [#143799](https://github.com/openclaw/openclaw/pull/143799). Thanks @fuller-stack-dev.
+- Exclude moved private capture directories when their marker stays intact, and refuse invalid markers [#143899](https://github.com/openclaw/openclaw/pull/143899). Thanks @fuller-stack-dev.
+
+
+
+
+
+
+##### Keep your WhatsApp group access choices
+
+
+Running `openclaw security audit --fix` now keeps the WhatsApp group access list you already chose, instead of adding people just because they had previously paired with your Claw. When changing an open group policy to restricted access, it can still use approved senders if you have not supplied a list. People added by an earlier repair are not removed automatically, so review your list if you were affected.
+
+
+
+###### Sources and complete change list
+
+
+**Security and trust**
+
+- Preserve WhatsApp group allowlists during security repair [#142589](https://github.com/openclaw/openclaw/pull/142589). Thanks @eleqtrizit.
+
+
+
+
+
+
+##### Understand what update checks share
+
+
+The [telemetry guide](https://docs.openclaw.ai/gateway/telemetry) now explains what an update check can reveal about your approximate location, what the local preview can show, and the documented three-month retention period. Turning off optional statistics or setting `DO_NOT_TRACK` does not stop automatic update checks. If you want to stop those requests too, use the separate controls explained in the guide. The location may be that of a VPN, proxy, or remote computer, rather than where you are sitting.
+
+
+
+###### Sources and complete change list
+
+
+**Bug fixes**
+
+- Normalize public-provider names in optional statistics and their preview, while retaining the private-provider filter and existing consent settings [#141134](https://github.com/openclaw/openclaw/pull/141134). Thanks @vincentkoc.
+
+**Documentation**
+
+- Organize Gateway security guidance into focused setup, trust, audit, and incident-response pages [#141162](https://github.com/openclaw/openclaw/pull/141162). Thanks @vincentkoc.
+- Split policy command guidance into authoring, rules, scopes, checks, attestation, and findings guides [#142961](https://github.com/openclaw/openclaw/pull/142961). Thanks @vincentkoc.
+- Explain approximate location in hosted update telemetry, preview limits, retention, and request controls [#143311](https://github.com/openclaw/openclaw/pull/143311). Thanks @vincentkoc.
+- Organize the threat catalog into focused pages while retaining shared risk context [#143517](https://github.com/openclaw/openclaw/pull/143517). Thanks @vincentkoc.
+- Clarify Anthropic setup-token login, secret scope, approvals upgrade guidance, shared rate limits, and proxy validation failures [#144030](https://github.com/openclaw/openclaw/pull/144030). Thanks @vincentkoc.
+
+
+
+
+
+
+
+#### Quality-of-Life Improvements
+
+You can now answer your Claw’s questions and enter secrets from the terminal, with clearer output to read and copy afterward. There are also fixes for starting and restoring coding workspaces, giving delegated tasks enough time, and finding the help you need when something goes wrong.
+
+
+
+
+##### Answer questions and enter secrets in the terminal
+
+
+When your Claw needs an answer, you can now choose an option or type a response directly in the [terminal](https://docs.openclaw.ai/web/tui), including while a task is waiting for your reply. Press Esc to put the question aside and `/question` to bring it back.
+
+[Secret requests](https://docs.openclaw.ai/tools/secrets) get a masked entry box that keeps what you type out of the conversation and input history. Saving a secret requires a Gateway connection, and terminal entry accepts one line at a time. Use the web app if you need to change which sites can use it. Local sessions support ordinary questions, which you should answer before closing the terminal.
+
+
+
+###### Sources and complete change list
+
+
+**Improvements**
+
+- Answer agent questions and Gateway secret requests in the terminal [#143273](https://github.com/openclaw/openclaw/pull/143273). Thanks @Sedrak-Hovhannisyan.
+
+
+
+
+
+
+##### Read and copy terminal output
+
+
+Long addresses and other text now wrap in terminal chat without gaining extra spaces, so you can copy them as written. Tables keep related values lined up, and progress indicators stop leaving repeated lines behind in narrow windows. If you use scripts to read command results, approvals JSON and transcript output also keep the unrelated announcements out of the way.
+
+
+
+###### Sources and complete change list
+
+
+**Improvements**
+
+- Load less provider runtime code during CLI startup [#142460](https://github.com/openclaw/openclaw/pull/142460).
+- Reduce duplicate work when refreshing shell completions [#143025](https://github.com/openclaw/openclaw/pull/143025).
+
+**Bug fixes**
+
+- Keep progress indicators within narrow terminals [#141401](https://github.com/openclaw/openclaw/pull/141401). Thanks @ooiuuii.
+- Restore native CLI progress indicators [#142071](https://github.com/openclaw/openclaw/pull/142071). Thanks @Xuxyyy, @obviyus.
+- Suppress approvals write announcements in JSON output [#142152](https://github.com/openclaw/openclaw/pull/142152).
+- Preserve blank lines in multiline terminal tables [#142196](https://github.com/openclaw/openclaw/pull/142196).
+- Preserve long words and email addresses in terminal chat [#142210](https://github.com/openclaw/openclaw/pull/142210).
+- Keep wrapped multiline terminal cells aligned [#142305](https://github.com/openclaw/openclaw/pull/142305).
+
+
+
+
+
+
+##### Understand command errors
+
+
+Command errors do a better job of telling you what to do next, such as supplying login details or choosing which agent to use, without making a missing option look like a broken installation. If `openclaw agent` loses its connection or times out after a task was accepted, the error gives you the task’s ID so you can check what happened before trying again. Check its conversation history and Gateway status first, because the work may have continued after the connection was lost.
+
+
+
+###### Sources and complete change list
+
+
+**Bug fixes**
+
+- Show accepted run IDs in connection-loss and timeout hints [#111899](https://github.com/openclaw/openclaw/pull/111899). Thanks @xialonglee, @MrNozz, @obviyus.
+- Distinguish command errors from CLI startup failures [#142109](https://github.com/openclaw/openclaw/pull/142109).
+- Show direct credential guidance for Gateway overrides [#142112](https://github.com/openclaw/openclaw/pull/142112). Thanks @DasX, @obviyus.
+- Show available Gateway details in full status reports [#142174](https://github.com/openclaw/openclaw/pull/142174).
+- Explain when CLI commands require an explicit agent [#143266](https://github.com/openclaw/openclaw/pull/143266).
+
+**Documentation**
+
+- Document system command port and password options [#139071](https://github.com/openclaw/openclaw/pull/139071). Thanks @qingminglong, @obviyus.
+
+
+
+
+
+
+##### Keep more useful Code Mode results
+
+
+[Code Mode](https://docs.openclaw.ai/tools/code-mode) uses less of its result space for formatting, leaving more room for the information your Claw asked for. The terminal also shows that data as written, without treating parts of it as message formatting. Code that calls itself too deeply now returns an error the Claw can work from, making it possible to correct that code and continue.
+
+
+
+###### Sources and complete change list
+
+
+**Bug fixes**
+
+- Fit compact Code Mode results and show literal JSON [#141417](https://github.com/openclaw/openclaw/pull/141417).
+- Keep recursive Code Mode cells recoverable [#141960](https://github.com/openclaw/openclaw/pull/141960). Thanks @vincentkoc.
+
+**Documentation**
+
+- Organize Code Mode guidance by task [#142425](https://github.com/openclaw/openclaw/pull/142425). Thanks @vincentkoc.
+
+
+
+
+
+
+##### Start and restore coding workspaces
+
+
+A [worktree](https://docs.openclaw.ai/concepts/managed-worktrees) gives your Claw a separate working copy of a code project. Setup retries now keep the version you originally selected, and projects with many branches keep the option to start a worktree available. You can type a branch or commit that is missing from the suggestions, with an error if it cannot be found.
+
+Saved worktrees also restore changes that replaced a file with a folder, or a folder with a file, keeping the replacement contents intact.
+
+
+
+###### Sources and complete change list
+
+
+**Bug fixes**
+
+- Validate worktree starting refs and preserve accepted commits [#135917](https://github.com/openclaw/openclaw/pull/135917). Thanks @RomneyDa.
+- Accept surrounding spaces in managed-worktree IDs [#141373](https://github.com/openclaw/openclaw/pull/141373). Thanks @nocodet888-arch, @obviyus.
+- Keep worktree sessions available in repositories with many branches [#143205](https://github.com/openclaw/openclaw/pull/143205).
+- Preserve file and folder replacements in worktree recovery [#143324](https://github.com/openclaw/openclaw/pull/143324).
+
+**Documentation**
+
+- Add worktree commands to the CLI index [#137422](https://github.com/openclaw/openclaw/pull/137422). Thanks @qingminglong, @obviyus.
+
+
+
+
+
+
+##### Keep instructions and side questions on track
+
+
+When a long `AGENTS.md` instruction file has to be shortened, an example keeps the line directly above it that explains what it is, helping keep a quotation from looking like a new instruction. The shortened instructions also recognize more Traditional Chinese rules, although the available space still limits what can be included.
+
+If you track model usage, completed `/btw` side answers can now include their reported usage in your configured diagnostics. Those side questions still sit outside the conversation’s `/usage` cost total.
+
+
+
+###### Sources and complete change list
+
+
+**Improvements**
+
+- Reduce repeated work when listing unpinned sessions [#141788](https://github.com/openclaw/openclaw/pull/141788).
+
+**Bug fixes**
+
+- Preserve adjacent example framing in shortened instructions [#137974](https://github.com/openclaw/openclaw/pull/137974). Thanks @SunnyShu0925, @obviyus, @Hawk5150.
+- Report usage from direct /btw answers [#141620](https://github.com/openclaw/openclaw/pull/141620).
+- Guide agents after rejected goal updates [#142808](https://github.com/openclaw/openclaw/pull/142808). Thanks @SunnyShu0925, @obviyus, @aminekhettat.
+- Repair native Git attribution replay before its move to session instructions [#142869](https://github.com/openclaw/openclaw/pull/142869). Thanks @Marvinthebored, @obviyus.
+- Retain Traditional Chinese rules in oversized instructions [#142915](https://github.com/openclaw/openclaw/pull/142915). Thanks @sunlit-deng, @obviyus, @igs-rogenlo.
+- Keep eligible Git co-author guidance in conditional session instructions [#143198](https://github.com/openclaw/openclaw/pull/143198). Thanks @Marvinthebored.
+- Keep side-question resources available through cleanup [#143366](https://github.com/openclaw/openclaw/pull/143366).
+
+**Documentation**
+
+- Organize the session reference by operator task [#143082](https://github.com/openclaw/openclaw/pull/143082). Thanks @vincentkoc.
+
+
+
+
+
+
+##### Time limits for delegated work
+
+
+[Subagents](https://docs.openclaw.ai/tools/subagents) are helpers your Claw can send to work on part of a task. Helpers with visible conversations now get the time selected for their first task, so longer work is not cut short by the ordinary deadline. Later messages use the normal time limit. A separate fix helps finished results return to the right agent after a restart when several agents share one Gateway.
+
+
+
+###### Sources and complete change list
+
+
+**Bug fixes**
+
+- Route restored subagent results to their saved requester [#141480](https://github.com/openclaw/openclaw/pull/141480). Thanks @aeoess, @obviyus, @laurenceputra, @toraiwa.
+- Reject incomplete subagent continuation handoffs [#141901](https://github.com/openclaw/openclaw/pull/141901). Thanks @Takhoffman.
+- Allow independent child runs to register from parent tools [#142652](https://github.com/openclaw/openclaw/pull/142652). Thanks @jalehman.
+- Honor initial visible-subagent time limits [#142812](https://github.com/openclaw/openclaw/pull/142812). Thanks @fanyangCS, @obviyus.
+
+**Documentation**
+
+- Split sub-agent guidance into focused linked pages [#142999](https://github.com/openclaw/openclaw/pull/142999). Thanks @vincentkoc.
+
+
+
+
+
+
+##### Find the help you need
+
+
+The [FAQ](https://docs.openclaw.ai/help/faq) is organized around the question you are trying to answer, and the documentation home gives you direct paths to releases, skills, automations, and building plugins. Setup examples are clearer, and repairs to older bookmarks and help links make the relevant instructions easier to reach. Simplified Chinese navigation also gains translated labels, including separate Releases and Contributing tabs.
+
+
+
+###### Sources and complete change list
+
+
+**Bug fixes**
+
+- Fix the troubleshooting link in automated support replies [#143194](https://github.com/openclaw/openclaw/pull/143194). Thanks @vincentkoc.
+- Keep example headings out of documentation maps [#143299](https://github.com/openclaw/openclaw/pull/143299). Thanks @qingminglong, @obviyus.
+- Repair documentation links in errors and troubleshooting [#143497](https://github.com/openclaw/openclaw/pull/143497). Thanks @vincentkoc.
+
+**Documentation**
+
+- Correct Windows, ChromeOS, and durable-work maturity listings [#142066](https://github.com/openclaw/openclaw/pull/142066). Thanks @RomneyDa.
+- Connect related plugin and provider guides [#143021](https://github.com/openclaw/openclaw/pull/143021). Thanks @vincentkoc.
+- Add related-guide links and Chinese label translations [#143040](https://github.com/openclaw/openclaw/pull/143040). Thanks @vincentkoc.
+- Organize the FAQ into focused topic pages [#143150](https://github.com/openclaw/openclaw/pull/143150). Thanks @vincentkoc.
+- Improve links between guides and command references [#143157](https://github.com/openclaw/openclaw/pull/143157). Thanks @vincentkoc.
+- Restore legacy documentation section links [#143586](https://github.com/openclaw/openclaw/pull/143586). Thanks @vincentkoc.
+- Clarify setup guidance, pruning defaults, and Exa modes [#143770](https://github.com/openclaw/openclaw/pull/143770). Thanks @vincentkoc.
+- Improve navigation between documentation guides [#143773](https://github.com/openclaw/openclaw/pull/143773). Thanks @vincentkoc.
+- Reorganize CLI and tool documentation [#143775](https://github.com/openclaw/openclaw/pull/143775). Thanks @vincentkoc.
+- Correct Gateway and provider setup documentation [#143796](https://github.com/openclaw/openclaw/pull/143796). Thanks @vincentkoc.
+- Add bot-loop, transcripts, Copilot, Baseten, and incident-response guides to the sidebar [#143845](https://github.com/openclaw/openclaw/pull/143845). Thanks @vincentkoc.
+- Improve Chinese documentation labels [#143853](https://github.com/openclaw/openclaw/pull/143853). Thanks @vincentkoc.
+- Improve guide links and section navigation [#143855](https://github.com/openclaw/openclaw/pull/143855). Thanks @vincentkoc.
+- Repair concept and troubleshooting links [#143923](https://github.com/openclaw/openclaw/pull/143923). Thanks @vincentkoc.
+- Improve channel and plugin guide navigation [#143926](https://github.com/openclaw/openclaw/pull/143926). Thanks @vincentkoc.
+- Simplify setup and concept documentation [#143931](https://github.com/openclaw/openclaw/pull/143931). Thanks @vincentkoc.
+- Reorganize setup and operating guides [#143977](https://github.com/openclaw/openclaw/pull/143977). Thanks @vincentkoc.
+- Clarify tool and channel reference prose [#143979](https://github.com/openclaw/openclaw/pull/143979). Thanks @vincentkoc.
+- Improve documentation tabs and headings [#144021](https://github.com/openclaw/openclaw/pull/144021). Thanks @vincentkoc.
+- Align Chinese release and contributor navigation [#144037](https://github.com/openclaw/openclaw/pull/144037). Thanks @RomneyDa, @vincentkoc.
+- Restore Windows maturity section links [#144067](https://github.com/openclaw/openclaw/pull/144067).
+- Clarify agent setup and Gateway concepts [#144086](https://github.com/openclaw/openclaw/pull/144086). Thanks @vincentkoc.
+- Improve documentation home links and wording [#144089](https://github.com/openclaw/openclaw/pull/144089). Thanks @vincentkoc.
+
+
+
+
+
+
+
+#### Other Bug Fixes
+
+OpenClaw now handles more of the interruptions that can leave you without an answer, stop a conversation from loading, or make a successful task look like it failed. Error messages and troubleshooting records also explain more of what happened.
+
+
+
+
+##### Get the answer after the work is done
+
+
+Your Claw can recover a missing final reply in more cases where the work finished but the answer never arrived, including after a lost model connection or an earlier tool error. It asks the model for an explanation without repeating completed actions, giving you another chance to see what was done.
+
+
+
+###### Sources and complete change list
+
+
+**Bug fixes**
+
+- Clarify text-only recovery for missing final answers [#141705](https://github.com/openclaw/openclaw/pull/141705). Thanks @fabiolr, @adinballew, @RomneyDa.
+- Recover final replies after interrupted provider streams [#142168](https://github.com/openclaw/openclaw/pull/142168). Thanks @liuwqgit, @obviyus, @wpu911.
+- Recover final answers after earlier tool errors [#143598](https://github.com/openclaw/openclaw/pull/143598). Thanks @harjothkhara, @obviyus, @CK-XYZ.
+
+
+
+
+
+
+##### Start fresh and reopen conversations
+
+
+Starting over with [`/new` or `/reset`](https://docs.openclaw.ai/tools/slash-commands) avoids unnecessary waits, especially in conversations where your Claw has handed work to other agents, and canceled tasks stay stopped when late results arrive. Your saved history and other conversations remain available.
+
+Old plugin messages outside the current conversation no longer stop its history from loading, and long conversations keep recent messages available when your Claw pauses to wait for other work. If a text-only reply fails partway through, the model also receives a short note about that failure when you continue, so the attempt no longer disappears from its context.
+
+
+
+###### Sources and complete change list
+
+
+**Bug fixes**
+
+- Retain failed partial-answer context for the next model request [989abf6](https://github.com/openclaw/openclaw/commit/989abf68703796dedcdd91d0ab7116684de69b8d), with contextual provenance in [#125977](https://github.com/openclaw/openclaw/pull/125977). Thanks @ayaangazali.
+- Keep inactive custom messages from breaking session history [#125413](https://github.com/openclaw/openclaw/pull/125413).
+- Keep long histories readable during yield cleanup [#137381](https://github.com/openclaw/openclaw/pull/137381), related to [issue #109638](https://github.com/openclaw/openclaw/issues/109638). Thanks @jalehman, @samrrr, @VACInc.
+- Avoid thinking-lookup delays for standalone session resets [#143281](https://github.com/openclaw/openclaw/pull/143281).
+- Keep current history readable after a reset [#143726](https://github.com/openclaw/openclaw/pull/143726).
+- Reduce repeated reset work while keeping child tasks stopped [#143916](https://github.com/openclaw/openclaw/pull/143916). Thanks @obviyus, @aleps001, @zhangguiping-xydt.
+
+
+
+
+
+
+##### Clearer file errors and command results
+
+
+When your Claw cannot save a file in its workspace, it now explains whether access was denied, the disk is full, or the location is read-only. That gives you a useful starting point for fixing the problem. Tool Search also fixes a case where a supplied file path was lost before the file could be read.
+
+On Linux, affected SSH commands can finish instead of being stopped too early. Commands on macOS and Linux also avoid a false cleanup error after successful work. Restart OpenClaw if you updated with `--no-restart` to get that cleanup fix.
+
+
+
+###### Sources and complete change list
+
+
+**Bug fixes**
+
+- Explain filesystem causes of failed workspace writes [#116378](https://github.com/openclaw/openclaw/pull/116378), related to [issue #115920](https://github.com/openclaw/openclaw/issues/115920). Thanks @sloptop-the-terrible, @obviyus, @609NFT, @geekforlife.
+- Clean up adopted Linux processes after command timeouts [#139548](https://github.com/openclaw/openclaw/pull/139548), a partial repair for [issue #97616](https://github.com/openclaw/openclaw/issues/97616). Cleanup is best effort and stops after 30 seconds. Thanks @srikolagani, @obviyus, @avp717, @Grynn, @islandpreneur007, @jinngimk-lang.
+- Let service-managed SSH commands finish normally after closing inherited file handles [#141463](https://github.com/openclaw/openclaw/pull/141463). The demonstrated repair is on Linux. Thanks @jjjhenriksen, @obviyus, @manumadrigal09, @ouioui33, @avcarp, @kaspnov.
+- Avoid false cleanup failures after successful POSIX commands [#143240](https://github.com/openclaw/openclaw/pull/143240).
+- Preserve tool arguments beside empty wrappers [#143729](https://github.com/openclaw/openclaw/pull/143729). Thanks @xydigitLybnnnn, @obviyus, @nkdmike.
+
+
+
+
+
+
+##### Troubleshoot errors and exported conversations
+
+
+OpenClaw can now wait through a brief database lock instead of immediately failing to read its saved settings. When a database problem does cause a failure or shutdown, error messages preserve more of the information needed to investigate it. [Logs](https://docs.openclaw.ai/logging) also give operators a clearer view of which work is waiting or taking time, with extra detail available when diagnostics are enabled.
+
+Exported conversations keep file-read results that were incorrectly removed, including instructions for reading the next part of a file. With the relevant diagnostic recording enabled, records also include actions taken after switching to a backup model and partial responses received before an interruption. Sensitive information is still removed, and recording size limits still apply.
+
+
+
+###### Sources and complete change list
+
+
+**Improvements**
+
+- Identify slow and failed SQLite session writes [#143451](https://github.com/openclaw/openclaw/pull/143451).
+- Identify execution threads in SQLite warnings [#143629](https://github.com/openclaw/openclaw/pull/143629).
+- Identify operations holding session queues [#143886](https://github.com/openclaw/openclaw/pull/143886).
+- Explain slow session cleanup preparation [#143942](https://github.com/openclaw/openclaw/pull/143942).
+- Clarify SQLite write and worker-release diagnostics [#144038](https://github.com/openclaw/openclaw/pull/144038). A release event alone does not establish successful cleanup or commit.
+
+**Bug fixes**
+
+- Include fallback tool activity in trajectory exports [#114662](https://github.com/openclaw/openclaw/pull/114662), related to [issue #114602](https://github.com/openclaw/openclaw/issues/114602). Thanks @synthalorian, @obviyus, @jackatagenticforce.
+- Preserve SQLite fatal diagnostics from worker threads [#143039](https://github.com/openclaw/openclaw/pull/143039).
+- Preserve partial debug captures and report shutdown storage failures [#143107](https://github.com/openclaw/openclaw/pull/143107). Thanks @vincentkoc.
+- Preserve the initiating database error during cleanup [#143574](https://github.com/openclaw/openclaw/pull/143574).
+- Wait for brief locks during state reads [#143908](https://github.com/openclaw/openclaw/pull/143908). Persistent locks can still fail. Thanks @pash-openai.
+- Keep paginated file reads in session exports [#143930](https://github.com/openclaw/openclaw/pull/143930). Thanks @linhongyu510, @obviyus, @cp1369.
+
+
+
+
+
+
+
+#### Maintainer and Internal Changes
+
+This release includes 692 maintainer-only units covering code cleanup, testing, release preparation, and contributor tools. Expand the source lists for the full change history.
+
+
+
+
+##### Internal code cleanup
+
+
+Shared code and type definitions replace duplicated logic across OpenClaw. This gives maintainers fewer places to update when changing behavior and removes unused code.
+
+
+
+###### Sources and complete change list
+
+
+The inbound-hook mapper compatibility concern is addressed by the separately documented public repair. Two terminal-writer cleanups remove private reset and closed-state helpers; compatibility with untracked consumers of private imports is not established.
+
+**Improvements**
+
+- Remove the fixed orphan-prompt strategy wrapper [746e53f2](https://github.com/openclaw/openclaw/commit/746e53f21fe9fa671030343545daf65588816dd0)
+- Simplify shared tool-summary formatting [#136181](https://github.com/openclaw/openclaw/pull/136181)
+- Remove the unused internal health-check execution path [#138211](https://github.com/openclaw/openclaw/pull/138211)
+- Remove unused Doctor health-check arguments [#141475](https://github.com/openclaw/openclaw/pull/141475). Thanks @vincentkoc.
+- Return cron activation state from its existing transaction [#141676](https://github.com/openclaw/openclaw/pull/141676). Thanks @RomneyDa.
+- Skip unused distance calculations for trailing wake names [#141683](https://github.com/openclaw/openclaw/pull/141683)
+- Type incoming Reef versions as unverified input [#141687](https://github.com/openclaw/openclaw/pull/141687). Thanks @RomneyDa.
+- Separate cron script-result parsing from execution [#141688](https://github.com/openclaw/openclaw/pull/141688)
+- Separate transcript summary persistence from live capture [#141695](https://github.com/openclaw/openclaw/pull/141695)
+- Separate prepared-runtime snapshot construction [#141711](https://github.com/openclaw/openclaw/pull/141711)
+- Remove redundant CLI binary-name resolution [#141713](https://github.com/openclaw/openclaw/pull/141713)
+- Remove unused restart test overrides [#141714](https://github.com/openclaw/openclaw/pull/141714)
+- Share HTML tag scanning between web-fetch stages [#141726](https://github.com/openclaw/openclaw/pull/141726)
+- Separate prepared-runtime retention and auth invalidation [#141728](https://github.com/openclaw/openclaw/pull/141728)
+- Unify Profile identity-save handling [#141730](https://github.com/openclaw/openclaw/pull/141730)
+- Share Slack reply preparation without changing delivery order [#141733](https://github.com/openclaw/openclaw/pull/141733)
+- Share the CLI local-onboarding decision [#141735](https://github.com/openclaw/openclaw/pull/141735)
+- Centralize native approval adapter type handling [#141737](https://github.com/openclaw/openclaw/pull/141737). Thanks @RomneyDa.
+- Centralize native WebKit bridge message types [#141764](https://github.com/openclaw/openclaw/pull/141764). Thanks @RomneyDa.
+- Share the transcript idempotency-key reader [#141772](https://github.com/openclaw/openclaw/pull/141772). Thanks @vincentkoc.
+- Remove unused UI text-formatting options [#141783](https://github.com/openclaw/openclaw/pull/141783). Thanks @vincentkoc.
+- Reuse Doctor's shared legacy source-identity comparison [#141784](https://github.com/openclaw/openclaw/pull/141784). Thanks @vincentkoc.
+- Separate model-catalog source preparation [#141810](https://github.com/openclaw/openclaw/pull/141810)
+- Share model-catalog presentation across local readers [#141815](https://github.com/openclaw/openclaw/pull/141815). Thanks @obviyus.
+- Move cached turn replay into the dedupe module [#141824](https://github.com/openclaw/openclaw/pull/141824)
+- Reuse Doctor's path-containment helper [#141828](https://github.com/openclaw/openclaw/pull/141828). Thanks @vincentkoc.
+- Simplify built-in memory runtime delegation [#141847](https://github.com/openclaw/openclaw/pull/141847)
+- Centralize memory dreaming types in the host SDK [#141873](https://github.com/openclaw/openclaw/pull/141873). Thanks @RomneyDa.
+- Share ClawHub skill response types through the protocol [#141874](https://github.com/openclaw/openclaw/pull/141874). Thanks @RomneyDa.
+- Derive conversation capability types from their resolver [#141878](https://github.com/openclaw/openclaw/pull/141878). Thanks @RomneyDa.
+- Derive inbound hook context types from their producer [#141880](https://github.com/openclaw/openclaw/pull/141880). Thanks @RomneyDa.
+- Share provider request secret-field definitions [#141882](https://github.com/openclaw/openclaw/pull/141882)
+- Reuse channel setup configuration writers [#141929](https://github.com/openclaw/openclaw/pull/141929)
+- Simplify Markdown span ordering bookkeeping [#141945](https://github.com/openclaw/openclaw/pull/141945). Thanks @vincentkoc.
+- Remove unreachable TUI streaming state [#141999](https://github.com/openclaw/openclaw/pull/141999)
+- Avoid duplicate validation when listing sessions [#142005](https://github.com/openclaw/openclaw/pull/142005)
+- Preserve plugin types during search setup [#142006](https://github.com/openclaw/openclaw/pull/142006)
+- Derive UI session types from Gateway definitions [#142025](https://github.com/openclaw/openclaw/pull/142025). Thanks @RomneyDa.
+- Derive Matrix configuration types from schemas [#142026](https://github.com/openclaw/openclaw/pull/142026). Thanks @RomneyDa.
+- Derive Nextcloud Talk types from schemas [#142027](https://github.com/openclaw/openclaw/pull/142027). Thanks @RomneyDa.
+- Derive Mattermost types from schemas [#142028](https://github.com/openclaw/openclaw/pull/142028). Thanks @RomneyDa.
+- Share activation configuration merging [#142045](https://github.com/openclaw/openclaw/pull/142045)
+- Remove an ineffective source-loader option [#142050](https://github.com/openclaw/openclaw/pull/142050)
+- Consolidate plugin install metadata classification [#142075](https://github.com/openclaw/openclaw/pull/142075)
+- Remove unused plugin-loader cache bookkeeping [#142078](https://github.com/openclaw/openclaw/pull/142078). Thanks @vincentkoc.
+- Remove unused board notice injection inputs [#142101](https://github.com/openclaw/openclaw/pull/142101)
+- Remove unused plugin install option forwarding [#142121](https://github.com/openclaw/openclaw/pull/142121)
+- Remove unused configuration path from lock handles [#142127](https://github.com/openclaw/openclaw/pull/142127). Thanks @vincentkoc.
+- Avoid recounting plugin state after quota eviction [#142148](https://github.com/openclaw/openclaw/pull/142148)
+- Share assignment detection across redaction outputs [#142183](https://github.com/openclaw/openclaw/pull/142183)
+- Remove redundant duplicate tracking from buffered replies [#142205](https://github.com/openclaw/openclaw/pull/142205)
+- Separate plugin inspection authority from resource lifetime [#142214](https://github.com/openclaw/openclaw/pull/142214)
+- Skip unused Markdown scans during reply parsing [#142220](https://github.com/openclaw/openclaw/pull/142220)
+- Reduce temporary collection work in agent rosters [#142229](https://github.com/openclaw/openclaw/pull/142229)
+- Share session-list selection logic [#142239](https://github.com/openclaw/openclaw/pull/142239)
+- Reuse the prepared plugin-tool manifest lookup [#142249](https://github.com/openclaw/openclaw/pull/142249)
+- Avoid repeating rich-reply preparation for command delivery [#142252](https://github.com/openclaw/openclaw/pull/142252)
+- Reduce repeated URL preparation in terminal messages [#142262](https://github.com/openclaw/openclaw/pull/142262)
+- Share sandbox filesystem operation encoding [#142269](https://github.com/openclaw/openclaw/pull/142269)
+- Narrow Memory Core's configuration import [#142270](https://github.com/openclaw/openclaw/pull/142270)
+- Avoid redundant HTTP conversation-history copies [#142309](https://github.com/openclaw/openclaw/pull/142309)
+- Skip unused settings preparation for reduced prompts [#142311](https://github.com/openclaw/openclaw/pull/142311)
+- Avoid duplicate copies of matching read-tool text [#142354](https://github.com/openclaw/openclaw/pull/142354)
+- Share plugin registration provenance types [#142359](https://github.com/openclaw/openclaw/pull/142359)
+- Share Android durable chat send dispatch [#142363](https://github.com/openclaw/openclaw/pull/142363)
+- Reduce temporary allocations when matching plugin commands [#142374](https://github.com/openclaw/openclaw/pull/142374)
+- Stop forwarded-avatar selection when its slots are filled [#142387](https://github.com/openclaw/openclaw/pull/142387)
+- Avoid unused copies during history image pruning [#142391](https://github.com/openclaw/openclaw/pull/142391)
+- Reuse shared configuration scans in plugin planning [#142396](https://github.com/openclaw/openclaw/pull/142396)
+- Consolidate equivalent Nodes dispatch cases [#142402](https://github.com/openclaw/openclaw/pull/142402)
+- Skip unused Telegram draft prefix preparation [#142404](https://github.com/openclaw/openclaw/pull/142404)
+- Derive Google Meet types from resolved settings [#142407](https://github.com/openclaw/openclaw/pull/142407). Thanks @RomneyDa.
+- Derive IRC configuration types from its schema [#142408](https://github.com/openclaw/openclaw/pull/142408). Thanks @RomneyDa.
+- Share plugin manifest and registry types [#142409](https://github.com/openclaw/openclaw/pull/142409). Thanks @RomneyDa.
+- Reuse Gateway types for Workshop storage [#142410](https://github.com/openclaw/openclaw/pull/142410). Thanks @RomneyDa.
+- Share bounded web response-byte reading [#142413](https://github.com/openclaw/openclaw/pull/142413)
+- Avoid redundant chat code-block preparation [#142444](https://github.com/openclaw/openclaw/pull/142444)
+- Reduce temporary Discord formatting allocations [#142447](https://github.com/openclaw/openclaw/pull/142447)
+- Avoid intermediate arrays in model-message preparation [#142450](https://github.com/openclaw/openclaw/pull/142450)
+- Remove unused prompt-based queue deduplication [#142455](https://github.com/openclaw/openclaw/pull/142455)
+- Simplify extra bootstrap file loading [#142469](https://github.com/openclaw/openclaw/pull/142469)
+- Reduce temporary Swarm roster collections [#142488](https://github.com/openclaw/openclaw/pull/142488)
+- Avoid unused display preparation during chat export [#142491](https://github.com/openclaw/openclaw/pull/142491)
+- Remove unused setup callback authentication argument [#142494](https://github.com/openclaw/openclaw/pull/142494). Thanks @vincentkoc.
+- Remove unreachable Matrix forced-reset retry [#142495](https://github.com/openclaw/openclaw/pull/142495)
+- Share diagnostic listener registration [#142499](https://github.com/openclaw/openclaw/pull/142499). Thanks @vincentkoc.
+- Consolidate Gateway restart health finalization [#142513](https://github.com/openclaw/openclaw/pull/142513)
+- Reuse prepared LINE table cells [#142542](https://github.com/openclaw/openclaw/pull/142542)
+- Reuse message preparation during chat renders [#142570](https://github.com/openclaw/openclaw/pull/142570)
+- Share startup plugin membership checks [#142587](https://github.com/openclaw/openclaw/pull/142587). Thanks @vincentkoc.
+- Simplify pending tool-result bookkeeping [#142599](https://github.com/openclaw/openclaw/pull/142599)
+- Centralize Apple Gateway error presentation overrides [#142601](https://github.com/openclaw/openclaw/pull/142601)
+- Share Go and UV skill package validation [#142625](https://github.com/openclaw/openclaw/pull/142625). Thanks @vincentkoc.
+- Extract Codex feature-list protocol types [#142648](https://github.com/openclaw/openclaw/pull/142648). Thanks @RomneyDa.
+- Simplify internal status-report formatting [#142707](https://github.com/openclaw/openclaw/pull/142707)
+- Share route restoration across Control UI pages [#142709](https://github.com/openclaw/openclaw/pull/142709). Thanks @vincentkoc.
+- Isolate model-policy integer parsing [#142804](https://github.com/openclaw/openclaw/pull/142804)
+- Reuse prepared provider ownership metadata [#142818](https://github.com/openclaw/openclaw/pull/142818)
+- Simplify outbound reply mirroring [#142819](https://github.com/openclaw/openclaw/pull/142819)
+- Simplify interactive SDK exports [#142824](https://github.com/openclaw/openclaw/pull/142824)
+- Reduce media-reference formatting overhead [#142836](https://github.com/openclaw/openclaw/pull/142836)
+- Render HTTP history without intermediate entry copies [#142856](https://github.com/openclaw/openclaw/pull/142856)
+- Remove duplicate configuration tag preparation [#142864](https://github.com/openclaw/openclaw/pull/142864). Thanks @vincentkoc.
+- Reuse plugin metadata during contribution discovery [#142975](https://github.com/openclaw/openclaw/pull/142975)
+- Remove unused plugin metadata discovery fallback [#143020](https://github.com/openclaw/openclaw/pull/143020)
+- Reuse prepared paths in Claude plugin manifest loading [#143027](https://github.com/openclaw/openclaw/pull/143027)
+- Avoid redundant JSON-mode invocation parsing [#143097](https://github.com/openclaw/openclaw/pull/143097)
+- Share sandbox filesystem parameter types [#143189](https://github.com/openclaw/openclaw/pull/143189)
+- Share host desktop status formatting [#143223](https://github.com/openclaw/openclaw/pull/143223)
+- Consolidate post-update continuation handling [#143269](https://github.com/openclaw/openclaw/pull/143269)
+- Remove obsolete node CLI timeout overrides [#143330](https://github.com/openclaw/openclaw/pull/143330)
+- Unify Android capability approval state [#143352](https://github.com/openclaw/openclaw/pull/143352)
+- Simplify Synology webhook body handling [#143360](https://github.com/openclaw/openclaw/pull/143360)
+- Reuse shared dreaming statistics types [#143368](https://github.com/openclaw/openclaw/pull/143368)
+- Share Pi and Claude transcript range reading [#143374](https://github.com/openclaw/openclaw/pull/143374)
+- Share paired-node request assembly [#143380](https://github.com/openclaw/openclaw/pull/143380)
+- Remove unused chat-history configuration argument [#143395](https://github.com/openclaw/openclaw/pull/143395). Thanks @vincentkoc.
+- Remove duplicate Automations editor state [#143405](https://github.com/openclaw/openclaw/pull/143405)
+- Unify missing-command ownership resolution [#143411](https://github.com/openclaw/openclaw/pull/143411)
+- Share wizard prompt argument construction [#143430](https://github.com/openclaw/openclaw/pull/143430)
+- Consolidate hook-source selection policy [#143439](https://github.com/openclaw/openclaw/pull/143439)
+- Avoid repeated system-message trimming [#143453](https://github.com/openclaw/openclaw/pull/143453)
+- Reuse normalized channel setup metadata [#143470](https://github.com/openclaw/openclaw/pull/143470)
+- Simplify internal CLI help context [#143477](https://github.com/openclaw/openclaw/pull/143477)
+- Avoid an extra Code Mode diagnostic array copy [#143482](https://github.com/openclaw/openclaw/pull/143482)
+- Share Doctor session migration validation [#143507](https://github.com/openclaw/openclaw/pull/143507)
+- Reuse shared channel configuration writers [#143547](https://github.com/openclaw/openclaw/pull/143547)
+- Derive sandbox settings types from validation schemas [#143551](https://github.com/openclaw/openclaw/pull/143551). Thanks @RomneyDa.
+- Derive installation record types from validation schemas [#143552](https://github.com/openclaw/openclaw/pull/143552). Thanks @RomneyDa.
+- Derive Codex configuration types from existing schemas [#143553](https://github.com/openclaw/openclaw/pull/143553). Thanks @RomneyDa.
+- Share agent configuration schemas and types [#143554](https://github.com/openclaw/openclaw/pull/143554). Thanks @RomneyDa.
+- Share Memory Wiki report and index rendering [#143568](https://github.com/openclaw/openclaw/pull/143568)
+- Centralize Policy document validation [#143600](https://github.com/openclaw/openclaw/pull/143600)
+- Share Comfy workflow polling [#143653](https://github.com/openclaw/openclaw/pull/143653)
+- Consolidate worker validation and workspace reconciliation [#143667](https://github.com/openclaw/openclaw/pull/143667)
+- Reuse shared Markdown rendering for assistant messages [#143706](https://github.com/openclaw/openclaw/pull/143706)
+- Re-export shared provider ID helpers [#143712](https://github.com/openclaw/openclaw/pull/143712)
+- Share model catalog metadata merging [#143715](https://github.com/openclaw/openclaw/pull/143715)
+- Share completion and speech-summary cleanup ownership [#143716](https://github.com/openclaw/openclaw/pull/143716)
+- Remove redundant completion media checks [#143734](https://github.com/openclaw/openclaw/pull/143734)
+- Remove obsolete Discord thread-expiry fallback [#143737](https://github.com/openclaw/openclaw/pull/143737)
+- Consolidate Matrix action parsing and invalid-operation diagnostics [#143759](https://github.com/openclaw/openclaw/pull/143759)
+- Share question validation and terminal state handling [#143766](https://github.com/openclaw/openclaw/pull/143766)
+- Remove Doctor's unused standalone transcript writer [#143772](https://github.com/openclaw/openclaw/pull/143772)
+- Share prepared completion resource cleanup [#143792](https://github.com/openclaw/openclaw/pull/143792)
+- Reuse Gateway session response types in the UI [#143803](https://github.com/openclaw/openclaw/pull/143803)
+- Consolidate fast-mode state construction [#143816](https://github.com/openclaw/openclaw/pull/143816)
+- Share thinking-default policy resolution [#143849](https://github.com/openclaw/openclaw/pull/143849)
+- Share image-request resource ownership [#143871](https://github.com/openclaw/openclaw/pull/143871)
+- Share browser action execution options [#143887](https://github.com/openclaw/openclaw/pull/143887)
+- Simplify migration stop tracking [#143912](https://github.com/openclaw/openclaw/pull/143912)
+- Simplify inference command registration [#143920](https://github.com/openclaw/openclaw/pull/143920)
+- Share desktop rendering inputs [#143922](https://github.com/openclaw/openclaw/pull/143922)
+- Share Mattermost reaction dispatch [#143949](https://github.com/openclaw/openclaw/pull/143949)
+- Remove unused terminal writer reset [#143969](https://github.com/openclaw/openclaw/pull/143969)
+- Consolidate root option forwarding [#143993](https://github.com/openclaw/openclaw/pull/143993)
+- Verify terminal closure through write behavior [#144007](https://github.com/openclaw/openclaw/pull/144007)
+- Reuse model catalog deduplication [#144012](https://github.com/openclaw/openclaw/pull/144012)
+- Simplify provider secret marker restoration [#144036](https://github.com/openclaw/openclaw/pull/144036)
+- Share realtime Talk response types [#144077](https://github.com/openclaw/openclaw/pull/144077)
+- Carry model selection together through recovery [#144088](https://github.com/openclaw/openclaw/pull/144088)
+- Avoid unused task-detail copies in notifications [#144115](https://github.com/openclaw/openclaw/pull/144115)
+- Simplify compaction setup [#144121](https://github.com/openclaw/openclaw/pull/144121)
+
+**Bug fixes**
+
+- Restore desktop lint checks [#143889](https://github.com/openclaw/openclaw/pull/143889)
+
+
+
+
+
+
+##### Test reliability and upkeep
+
+
+Tests are less prone to failures caused by timing, leftover data, or the machine running them. Reusing setup and removing duplicate checks also reduces unnecessary work for contributors.
+
+
+
+###### Sources and complete change list
+
+
+Reported timings cover different local workloads and cannot be added into a release-wide speedup. Test-only changes below do not establish new behavior in the running application.
+
+**Improvements**
+
+- Reuse the deferred-promise helper in Gateway tests [2a4d6a10](https://github.com/openclaw/openclaw/commit/2a4d6a10ae6013ece39ae581762daf13b84ff1c9)
+- Keep interactive preview actions consistent with fixture state [#138350](https://github.com/openclaw/openclaw/pull/138350). Thanks @vyctorbrzezowski.
+- Disable unrelated catalog refreshes in isolated tests [#141266](https://github.com/openclaw/openclaw/pull/141266). Thanks @vincentkoc.
+- Test the existing Parallels log-tail boundary [#141470](https://github.com/openclaw/openclaw/pull/141470)
+- Reuse provider registries in catalog-auth tests [#141682](https://github.com/openclaw/openclaw/pull/141682)
+- Avoid redundant waits in Kova authentication tests [#141693](https://github.com/openclaw/openclaw/pull/141693)
+- Synchronize terminal startup tests with history loading [#141704](https://github.com/openclaw/openclaw/pull/141704)
+- Skip browser asset preparation in config RPC tests [#141741](https://github.com/openclaw/openclaw/pull/141741)
+- Share unreachable Gateway probe test fixtures [#141758](https://github.com/openclaw/openclaw/pull/141758)
+- Clean up security-scan fixture lint violations [#141778](https://github.com/openclaw/openclaw/pull/141778)
+- Share migration-test snapshot inputs [#141782](https://github.com/openclaw/openclaw/pull/141782)
+- Avoid idle-connection waits in webhook handoff tests [#141790](https://github.com/openclaw/openclaw/pull/141790)
+- Make web-search validator fixtures independent of client defaults [#141792](https://github.com/openclaw/openclaw/pull/141792)
+- Simplify Discord recording test branches [#141804](https://github.com/openclaw/openclaw/pull/141804)
+- Keep the image-probe reply matcher private [#141823](https://github.com/openclaw/openclaw/pull/141823)
+- Compact Code Mode source-validation test matrices [#141831](https://github.com/openclaw/openclaw/pull/141831). Thanks @RomneyDa.
+- Compact CLI argument test matrices [#141832](https://github.com/openclaw/openclaw/pull/141832). Thanks @RomneyDa.
+- Compact reasoning-tag test fixtures [#141833](https://github.com/openclaw/openclaw/pull/141833). Thanks @RomneyDa.
+- Compact Control UI routing test fixtures [#141834](https://github.com/openclaw/openclaw/pull/141834). Thanks @RomneyDa.
+- Remove an unused Comfy test fixture option [#141844](https://github.com/openclaw/openclaw/pull/141844)
+- Consolidate model-command policy tests [#141861](https://github.com/openclaw/openclaw/pull/141861). Thanks @RomneyDa.
+- Test the HTML comparison script's actual response limit [#141877](https://github.com/openclaw/openclaw/pull/141877)
+- Simplify Crabbox shell-detection test tables [#141888](https://github.com/openclaw/openclaw/pull/141888). Thanks @RomneyDa.
+- Simplify Doctor plugin repair test tables [#141889](https://github.com/openclaw/openclaw/pull/141889). Thanks @RomneyDa.
+- Simplify Active Memory policy test tables [#141890](https://github.com/openclaw/openclaw/pull/141890). Thanks @RomneyDa.
+- Simplify message account-isolation test tables [#141891](https://github.com/openclaw/openclaw/pull/141891). Thanks @RomneyDa.
+- Consolidate Vitest project-loading checks [#141908](https://github.com/openclaw/openclaw/pull/141908)
+- Share fresh logger fixtures across core tests [#141911](https://github.com/openclaw/openclaw/pull/141911)
+- Remove implementation-specific configuration assertions [#141919](https://github.com/openclaw/openclaw/pull/141919)
+- Simplify Google image test fixtures [#141926](https://github.com/openclaw/openclaw/pull/141926)
+- Verify playback cache limits through writes [#141944](https://github.com/openclaw/openclaw/pull/141944)
+- Use runtime context in plugin compatibility tests [#141989](https://github.com/openclaw/openclaw/pull/141989)
+- Use controlled timing in fatal Git-outcome tests [#142009](https://github.com/openclaw/openclaw/pull/142009)
+- Compact channel account-helper test tables [#142029](https://github.com/openclaw/openclaw/pull/142029). Thanks @RomneyDa.
+- Compact execution-wrapper test fixtures [#142030](https://github.com/openclaw/openclaw/pull/142030). Thanks @RomneyDa.
+- Compact secrets runtime test matrices [#142031](https://github.com/openclaw/openclaw/pull/142031). Thanks @RomneyDa.
+- Simplify npm registry test tables [#142032](https://github.com/openclaw/openclaw/pull/142032). Thanks @RomneyDa.
+- Test scroll reset within the existing preview [#142044](https://github.com/openclaw/openclaw/pull/142044)
+- Reuse text tool-result fixtures in agent tests [#142051](https://github.com/openclaw/openclaw/pull/142051)
+- Add an Android branch-switching test scene [#142057](https://github.com/openclaw/openclaw/pull/142057). Thanks @vincentkoc.
+- Test watcher shutdown with real default intervals [#142079](https://github.com/openclaw/openclaw/pull/142079)
+- Simplify inline-command test tables [#142081](https://github.com/openclaw/openclaw/pull/142081). Thanks @RomneyDa.
+- Compact Gateway network-policy tests [#142082](https://github.com/openclaw/openclaw/pull/142082). Thanks @RomneyDa.
+- Compact CLI configuration-guard tests [#142083](https://github.com/openclaw/openclaw/pull/142083). Thanks @RomneyDa.
+- Compact WhatsApp formatting tests [#142084](https://github.com/openclaw/openclaw/pull/142084). Thanks @RomneyDa.
+- Share timestamped tool-result fixtures [#142094](https://github.com/openclaw/openclaw/pull/142094)
+- Align Mac script tests with system Bash [#142096](https://github.com/openclaw/openclaw/pull/142096)
+- Reuse deferred promises in chat lifecycle tests [#142098](https://github.com/openclaw/openclaw/pull/142098)
+- Simplify memory recall timeout test setup [#142108](https://github.com/openclaw/openclaw/pull/142108)
+- Strengthen Feishu permission-error regressions [#142117](https://github.com/openclaw/openclaw/pull/142117)
+- Reuse xAI video response fixtures [#142118](https://github.com/openclaw/openclaw/pull/142118)
+- Remove unused language-hint test options [#142119](https://github.com/openclaw/openclaw/pull/142119)
+- Share user and assistant message test fixtures [#142133](https://github.com/openclaw/openclaw/pull/142133)
+- Avoid repeated compilation in Doctor process tests [#142140](https://github.com/openclaw/openclaw/pull/142140)
+- Add bounded failure details to Code Mode polling tests [#142157](https://github.com/openclaw/openclaw/pull/142157)
+- Remove duplicate Discord retry tests [#142177](https://github.com/openclaw/openclaw/pull/142177)
+- Share timestamped assistant test inputs [#142184](https://github.com/openclaw/openclaw/pull/142184)
+- Share API-key credential test fixtures [#142245](https://github.com/openclaw/openclaw/pull/142245)
+- Share OAuth credential test fixtures [#142272](https://github.com/openclaw/openclaw/pull/142272)
+- Verify the merge method actually dispatched in tests [#142329](https://github.com/openclaw/openclaw/pull/142329)
+- Reduce the Telegram Markdown chunking test fixture [#142365](https://github.com/openclaw/openclaw/pull/142365)
+- Consolidate duplicate group-policy resolver tests [#142366](https://github.com/openclaw/openclaw/pull/142366)
+- Share cloud-agent fixtures across New Session tests [#142376](https://github.com/openclaw/openclaw/pull/142376)
+- Report successful installation in Docker test logs [#142405](https://github.com/openclaw/openclaw/pull/142405). Thanks @vincentkoc.
+- Remove unused Telegram edit-test branches [#142411](https://github.com/openclaw/openclaw/pull/142411)
+- Share plugin installation test path checks [#142448](https://github.com/openclaw/openclaw/pull/142448). Thanks @vincentkoc.
+- Remove an unreachable process-poll test branch [#142466](https://github.com/openclaw/openclaw/pull/142466)
+- Consolidate memory-flush test coverage [#142478](https://github.com/openclaw/openclaw/pull/142478)
+- Reuse compiled CLI code in message-cleanup tests [#142503](https://github.com/openclaw/openclaw/pull/142503)
+- Remove unused Doctor configuration test mocks [#142507](https://github.com/openclaw/openclaw/pull/142507)
+- Settle composer animations before alignment tests [#142509](https://github.com/openclaw/openclaw/pull/142509). Thanks @RomneyDa.
+- Remove redundant Matrix QA scenario forwarding [#142546](https://github.com/openclaw/openclaw/pull/142546)
+- Remove real timeout waits from Telegram observation tests [#142602](https://github.com/openclaw/openclaw/pull/142602)
+- Remove unused terminal mocks from skills tests [#142604](https://github.com/openclaw/openclaw/pull/142604)
+- Remove duplicate deep-transcript import stress coverage [#142614](https://github.com/openclaw/openclaw/pull/142614)
+- Share changelog fixtures in release-note verifier tests [#142659](https://github.com/openclaw/openclaw/pull/142659)
+- Clarify generated markers in live file-read tests [#142685](https://github.com/openclaw/openclaw/pull/142685). Thanks @RomneyDa.
+- Share Discord action expectations across tests [#142690](https://github.com/openclaw/openclaw/pull/142690)
+- Share Codex lifecycle test fixtures [#142732](https://github.com/openclaw/openclaw/pull/142732)
+- Remove idle delay from cleanup regression testing [#142733](https://github.com/openclaw/openclaw/pull/142733)
+- Simplify native chat test fixtures [#142757](https://github.com/openclaw/openclaw/pull/142757)
+- Reduce plugin loading in storage migration tests [#142777](https://github.com/openclaw/openclaw/pull/142777)
+- Isolate plugin inputs in migration tests [#142785](https://github.com/openclaw/openclaw/pull/142785)
+- Check live meeting-title drafts in regression tests [#142795](https://github.com/openclaw/openclaw/pull/142795)
+- Make Signal test reply policy explicit [#142796](https://github.com/openclaw/openclaw/pull/142796)
+- Reuse model fixtures in native command tests [#142797](https://github.com/openclaw/openclaw/pull/142797)
+- Share Gateway scope expectations in tests [#142806](https://github.com/openclaw/openclaw/pull/142806)
+- Share independent replay test expectations [#142816](https://github.com/openclaw/openclaw/pull/142816)
+- Simplify session tests and expose early rollback setup failures [#142833](https://github.com/openclaw/openclaw/pull/142833)
+- Share reply-dispatch test expectations [#142845](https://github.com/openclaw/openclaw/pull/142845)
+- Simplify worker lifecycle test gates [#142865](https://github.com/openclaw/openclaw/pull/142865)
+- Remove real deadline waits from Swift polling tests [#142882](https://github.com/openclaw/openclaw/pull/142882). Thanks @vincentkoc.
+- Remove real-time waits from Mermaid timeout tests [#142886](https://github.com/openclaw/openclaw/pull/142886). Thanks @vincentkoc.
+- Reuse deferred fixtures in cron lifecycle tests [#142887](https://github.com/openclaw/openclaw/pull/142887)
+- Remove duplicate OpenCode Go metadata testing [#142894](https://github.com/openclaw/openclaw/pull/142894). Thanks @vincentkoc.
+- Consolidate duplicate setup inference tests [#142899](https://github.com/openclaw/openclaw/pull/142899)
+- Advance ngrok startup deadlines in process tests [#142903](https://github.com/openclaw/openclaw/pull/142903)
+- Reuse builds in service-worker update tests [#142904](https://github.com/openclaw/openclaw/pull/142904). Thanks @vincentkoc.
+- Reduce repeated compilation in worker-cache tests [#142911](https://github.com/openclaw/openclaw/pull/142911). Thanks @vincentkoc.
+- Reduce startup work for focused fast tests [#142912](https://github.com/openclaw/openclaw/pull/142912)
+- Reduce upgrade-test configuration launches [#142917](https://github.com/openclaw/openclaw/pull/142917). Thanks @vincentkoc.
+- Reuse shared response-cancellation fixtures [#142919](https://github.com/openclaw/openclaw/pull/142919)
+- Share Google web-search test options [#142928](https://github.com/openclaw/openclaw/pull/142928)
+- Reuse Memory Wiki source-state fixtures [#142934](https://github.com/openclaw/openclaw/pull/142934)
+- Share agent-turn test input fixtures [#142962](https://github.com/openclaw/openclaw/pull/142962)
+- Reuse package fixtures in security-scan tests [#142982](https://github.com/openclaw/openclaw/pull/142982). Thanks @vincentkoc.
+- Share cron context-window test fixtures [#142985](https://github.com/openclaw/openclaw/pull/142985)
+- Remove duplicate model-usage aggregation testing [#142990](https://github.com/openclaw/openclaw/pull/142990). Thanks @vincentkoc.
+- Remove redundant worker-transform test compilation [#143009](https://github.com/openclaw/openclaw/pull/143009)
+- Reuse isolated Git fixtures in release-evidence tests [#143014](https://github.com/openclaw/openclaw/pull/143014). Thanks @vincentkoc.
+- Serialize worker-transform test sequences [#143034](https://github.com/openclaw/openclaw/pull/143034)
+- Share Codex context-engine test setup [#143035](https://github.com/openclaw/openclaw/pull/143035)
+- Build phone recovery test fixture once per suite [#143046](https://github.com/openclaw/openclaw/pull/143046). Thanks @vincentkoc.
+- Reuse Doctor plugin-repair success fixtures [#143047](https://github.com/openclaw/openclaw/pull/143047)
+- Consolidate duplicate QA Lab image-result coverage [#143048](https://github.com/openclaw/openclaw/pull/143048)
+- Remove duplicate warm chat metadata coverage [#143059](https://github.com/openclaw/openclaw/pull/143059)
+- Reuse compiled feature-plugin test fixtures [#143062](https://github.com/openclaw/openclaw/pull/143062). Thanks @vincentkoc.
+- Consolidate xAI credential-reference test fixtures [#143075](https://github.com/openclaw/openclaw/pull/143075)
+- Share Doctor routing-warning fixtures [#143076](https://github.com/openclaw/openclaw/pull/143076)
+- Share Memory Wiki session-search fixtures [#143084](https://github.com/openclaw/openclaw/pull/143084)
+- Remove obsolete WhatsApp session snapshot coverage [#143104](https://github.com/openclaw/openclaw/pull/143104). Thanks @vincentkoc.
+- Reuse remaining xAI secret-reference test fixtures [#143108](https://github.com/openclaw/openclaw/pull/143108)
+- Consolidate proof-policy identity test setup [#143112](https://github.com/openclaw/openclaw/pull/143112)
+- Reuse the diagnostics installation test package [#143116](https://github.com/openclaw/openclaw/pull/143116). Thanks @vincentkoc.
+- Consolidate provider authentication precedence tests [#143117](https://github.com/openclaw/openclaw/pull/143117)
+- Remove duplicate MiniMax M2.7 input coverage [#143122](https://github.com/openclaw/openclaw/pull/143122). Thanks @vincentkoc.
+- Share status-rendering test fixtures [#143124](https://github.com/openclaw/openclaw/pull/143124)
+- Shorten deliberate SQLite timeout test waits [#143130](https://github.com/openclaw/openclaw/pull/143130). Thanks @vincentkoc.
+- Reuse Git seed setup in Testbox tests [#143154](https://github.com/openclaw/openclaw/pull/143154). Thanks @vincentkoc.
+- Share agent-turn execution test defaults [#143166](https://github.com/openclaw/openclaw/pull/143166)
+- Remove redundant Mistral cache-cost arithmetic coverage [#143172](https://github.com/openclaw/openclaw/pull/143172). Thanks @vincentkoc.
+- Share Memory Wiki visibility test callbacks [#143181](https://github.com/openclaw/openclaw/pull/143181)
+- Reduce Telegram policy test startup overhead [#143192](https://github.com/openclaw/openclaw/pull/143192). Thanks @vincentkoc.
+- Share mcporter security-audit test inputs [#143209](https://github.com/openclaw/openclaw/pull/143209)
+- Share Codex migration request fixtures [#143221](https://github.com/openclaw/openclaw/pull/143221)
+- Remove duplicate xAI stream tests [#143222](https://github.com/openclaw/openclaw/pull/143222). Thanks @vincentkoc.
+- Reuse initial certificates in proxy lifecycle tests [#143247](https://github.com/openclaw/openclaw/pull/143247). Thanks @vincentkoc.
+- Reuse prepared CLI artifacts in Telegram QA tests [#143253](https://github.com/openclaw/openclaw/pull/143253). Thanks @vincentkoc.
+- Share ACP metadata-update test setup [#143261](https://github.com/openclaw/openclaw/pull/143261)
+- Reduce repeated manifest searches during test-worker preparation [#143271](https://github.com/openclaw/openclaw/pull/143271)
+- Remove unused Doctor catalog test setup [#143272](https://github.com/openclaw/openclaw/pull/143272). Thanks @vincentkoc.
+- Reuse certificate setup in proxy tests [#143298](https://github.com/openclaw/openclaw/pull/143298). Thanks @vincentkoc.
+- Share Codex conversation test clients [#143300](https://github.com/openclaw/openclaw/pull/143300)
+- Share Docker timeout test fixtures [#143309](https://github.com/openclaw/openclaw/pull/143309)
+- Check authoritative restart state in update tests [#143316](https://github.com/openclaw/openclaw/pull/143316)
+- Remove redundant usage-cost coverage [#143318](https://github.com/openclaw/openclaw/pull/143318). Thanks @vincentkoc.
+- Reduce media QA startup overhead [#143326](https://github.com/openclaw/openclaw/pull/143326). Thanks @vincentkoc.
+- Share Feishu reply account test fixtures [#143336](https://github.com/openclaw/openclaw/pull/143336)
+- Share Docker package-builder fixtures [#143338](https://github.com/openclaw/openclaw/pull/143338)
+- Test archive installation with real workspaces [#143339](https://github.com/openclaw/openclaw/pull/143339)
+- Reuse shared assertions in DeepSeek tests [#143346](https://github.com/openclaw/openclaw/pull/143346)
+- Share Meta and Xiaomi test guards [#143358](https://github.com/openclaw/openclaw/pull/143358)
+- Share Feishu fetched-message fixtures [#143362](https://github.com/openclaw/openclaw/pull/143362)
+- Reuse Slack approval test configuration [#143370](https://github.com/openclaw/openclaw/pull/143370)
+- Remove unused channel catalog fixtures [#143373](https://github.com/openclaw/openclaw/pull/143373). Thanks @vincentkoc.
+- Simplify Chutes test responses [#143382](https://github.com/openclaw/openclaw/pull/143382)
+- Share deferred fixtures in routing tests [#143383](https://github.com/openclaw/openclaw/pull/143383)
+- Avoid cold plugin loading in fallback tests [#143392](https://github.com/openclaw/openclaw/pull/143392)
+- Remove redundant browser annotation tests [#143402](https://github.com/openclaw/openclaw/pull/143402)
+- Exercise real inbound orchestration in Signal tests [#143412](https://github.com/openclaw/openclaw/pull/143412)
+- Reuse compiled SDK fixtures in MCP tests [#143415](https://github.com/openclaw/openclaw/pull/143415)
+- Reuse prepared CLI in JSON-error tests [#143427](https://github.com/openclaw/openclaw/pull/143427)
+- Remove duplicate Discord presence coverage [#143435](https://github.com/openclaw/openclaw/pull/143435). Thanks @vincentkoc.
+- Share image resource test setup [#143443](https://github.com/openclaw/openclaw/pull/143443)
+- Reuse pristine Git seeds in worktree tests [#143469](https://github.com/openclaw/openclaw/pull/143469). Thanks @RomneyDa.
+- Run isolated CLI cleanup tests concurrently [#143481](https://github.com/openclaw/openclaw/pull/143481)
+- Reuse TypeScript transforms in update tests [#143487](https://github.com/openclaw/openclaw/pull/143487)
+- Remove unnecessary diagnostic timeout test waiting [#143514](https://github.com/openclaw/openclaw/pull/143514). Thanks @RomneyDa.
+- Reuse source transforms in proxy exit tests [#143527](https://github.com/openclaw/openclaw/pull/143527)
+- Simplify exec-host approval test fixtures [#143529](https://github.com/openclaw/openclaw/pull/143529)
+- Share Signal quote test inputs [#143532](https://github.com/openclaw/openclaw/pull/143532)
+- Compact shell-completion test tables [#143533](https://github.com/openclaw/openclaw/pull/143533). Thanks @RomneyDa.
+- Compact reply-payload test matrices [#143534](https://github.com/openclaw/openclaw/pull/143534). Thanks @RomneyDa.
+- Compact CI concurrency test cases [#143535](https://github.com/openclaw/openclaw/pull/143535). Thanks @RomneyDa.
+- Compact Labs configuration tests [#143536](https://github.com/openclaw/openclaw/pull/143536). Thanks @RomneyDa.
+- Share Discord REST proxy test spies [#143537](https://github.com/openclaw/openclaw/pull/143537)
+- Share empty plugin metadata fixtures [#143544](https://github.com/openclaw/openclaw/pull/143544)
+- Reuse transforms across cron output tests [#143559](https://github.com/openclaw/openclaw/pull/143559)
+- Exercise Teams timeout handling through Gateway send [#143572](https://github.com/openclaw/openclaw/pull/143572). Thanks @RomneyDa.
+- Share QA mock-provider decisions [#143603](https://github.com/openclaw/openclaw/pull/143603)
+- Strengthen optional plugin-tool environment coverage [#143613](https://github.com/openclaw/openclaw/pull/143613)
+- Reuse transformed code across native Gateway tests [#143628](https://github.com/openclaw/openclaw/pull/143628)
+- Narrow Anthropic cache-check loader types [#143634](https://github.com/openclaw/openclaw/pull/143634)
+- Remove duplicate Teams threading tests [#143636](https://github.com/openclaw/openclaw/pull/143636)
+- Reuse the provider prompt error-stream fixture [#143637](https://github.com/openclaw/openclaw/pull/143637)
+- Consolidate Windows CI checks with stronger assertions [#143642](https://github.com/openclaw/openclaw/pull/143642)
+- Reuse scoped environments in wizard tests [#143652](https://github.com/openclaw/openclaw/pull/143652)
+- Share runtime spy fixtures across channel tests [#143655](https://github.com/openclaw/openclaw/pull/143655)
+- Reuse Gateway acquisition test transforms [#143660](https://github.com/openclaw/openclaw/pull/143660)
+- Remove unused formatter fixture directories [#143662](https://github.com/openclaw/openclaw/pull/143662)
+- Simplify DeepInfra catalog fixtures [#143680](https://github.com/openclaw/openclaw/pull/143680)
+- Reuse Android swarm test controller setup [#143684](https://github.com/openclaw/openclaw/pull/143684)
+- Reuse runtime spies in plugin tests [#143690](https://github.com/openclaw/openclaw/pull/143690)
+- Reuse storage fixtures in sidebar tests [#143697](https://github.com/openclaw/openclaw/pull/143697)
+- Remove obsolete Venice test environment overrides [#143720](https://github.com/openclaw/openclaw/pull/143720)
+- Share SQLite index-drift test setup [#143749](https://github.com/openclaw/openclaw/pull/143749)
+- Speed up SQLite snapshot test byte comparisons [#143751](https://github.com/openclaw/openclaw/pull/143751). Thanks @RomneyDa.
+- Simplify configuration test environment fixtures [#143815](https://github.com/openclaw/openclaw/pull/143815)
+- Remove Responses transport test globals [#143850](https://github.com/openclaw/openclaw/pull/143850)
+- Remove model planner test hooks [#143851](https://github.com/openclaw/openclaw/pull/143851)
+- Simplify image-generation test fixtures [#143862](https://github.com/openclaw/openclaw/pull/143862)
+- Remove duplicate Signal access test [#143870](https://github.com/openclaw/openclaw/pull/143870). Thanks @vincentkoc.
+- Remove models-writer test plumbing [#143874](https://github.com/openclaw/openclaw/pull/143874)
+- Cover update permission loss during discovery [#143877](https://github.com/openclaw/openclaw/pull/143877). Thanks @fuller-stack-dev.
+- Move type contracts to compiler-owned checks [#143888](https://github.com/openclaw/openclaw/pull/143888)
+- Share sidebar drag-data fixtures [#143901](https://github.com/openclaw/openclaw/pull/143901)
+- Remove duplicate Telegram history coverage [#143904](https://github.com/openclaw/openclaw/pull/143904). Thanks @vincentkoc.
+- Simplify configuration environment fixtures [#143925](https://github.com/openclaw/openclaw/pull/143925)
+- Remove duplicate WhatsApp listener tests [#143962](https://github.com/openclaw/openclaw/pull/143962). Thanks @vincentkoc.
+- Share Memory Wiki deferred fixtures [#143978](https://github.com/openclaw/openclaw/pull/143978)
+- Remove duplicate inbound-audio coverage [#143996](https://github.com/openclaw/openclaw/pull/143996). Thanks @vincentkoc.
+- Test usage authentication through owning helpers [#143997](https://github.com/openclaw/openclaw/pull/143997)
+- Reuse auto-reply promise fixtures [#144004](https://github.com/openclaw/openclaw/pull/144004)
+- Exercise shared HTTP behavior in media tests [#144024](https://github.com/openclaw/openclaw/pull/144024)
+- Remove duplicate reply cancellation coverage [#144028](https://github.com/openclaw/openclaw/pull/144028). Thanks @vincentkoc.
+- Simplify Discord directory fixtures [#144033](https://github.com/openclaw/openclaw/pull/144033)
+- Decouple UI behavior tests from class lists [#144050](https://github.com/openclaw/openclaw/pull/144050)
+- Remove duplicate login-shell PATH test [#144051](https://github.com/openclaw/openclaw/pull/144051). Thanks @vincentkoc.
+- Reuse terminal deferred fixtures [#144058](https://github.com/openclaw/openclaw/pull/144058)
+- Remove duplicate metadata scope test [#144072](https://github.com/openclaw/openclaw/pull/144072). Thanks @vincentkoc.
+- Share Slack approval configuration fixtures [#144076](https://github.com/openclaw/openclaw/pull/144076)
+- Simplify source-reply test inputs [#144080](https://github.com/openclaw/openclaw/pull/144080)
+- Reuse ClawHub HTTP test helpers [#144090](https://github.com/openclaw/openclaw/pull/144090)
+- Remove duplicate missing-exporter test [#144091](https://github.com/openclaw/openclaw/pull/144091). Thanks @vincentkoc.
+- Consolidate package-source update tests [#144097](https://github.com/openclaw/openclaw/pull/144097)
+- Remove duplicate realtime authentication test [#144105](https://github.com/openclaw/openclaw/pull/144105). Thanks @vincentkoc.
+- Reuse compiled source in startup tests [#144110](https://github.com/openclaw/openclaw/pull/144110)
+- Reuse terminal upload and queue fixtures [#144116](https://github.com/openclaw/openclaw/pull/144116)
+- Consolidate Brave startup fixtures [#144117](https://github.com/openclaw/openclaw/pull/144117)
+- Simplify Firecrawl credential fixtures [#144122](https://github.com/openclaw/openclaw/pull/144122)
+- Remove duplicate CLI session-cleanup coverage [#144126](https://github.com/openclaw/openclaw/pull/144126). Thanks @vincentkoc.
+- Simplify Quick Chat test inputs [#144135](https://github.com/openclaw/openclaw/pull/144135)
+
+**Bug fixes**
+
+- Load browser cleanup before ACP test deadlines [441f69b2](https://github.com/openclaw/openclaw/commit/441f69b21fd77839345dfe247d82cbba8135984f). Thanks @Baumus.
+- Require completed installation in Claw export fixtures [#120843](https://github.com/openclaw/openclaw/pull/120843). Thanks @vincentkoc.
+- Find Slack QA presentations by exact message timestamp [#127300](https://github.com/openclaw/openclaw/pull/127300). Thanks @RomneyDa.
+- Require completed serving evidence in managed upgrade tests [#141663](https://github.com/openclaw/openclaw/pull/141663)
+- Set explicit permissions for Doctor test state [#141672](https://github.com/openclaw/openclaw/pull/141672)
+- Restore the resize observer after multi-select tests [#141673](https://github.com/openclaw/openclaw/pull/141673)
+- Synchronize containment tests with real process stops [#141681](https://github.com/openclaw/openclaw/pull/141681)
+- Preserve onboarding-test installation failure diagnostics [#141689](https://github.com/openclaw/openclaw/pull/141689). Thanks @vincentkoc and @RomneyDa.
+- Preserve Doctor-written configuration in secret-reference tests [#141768](https://github.com/openclaw/openclaw/pull/141768)
+- Complete manifest fixtures in capability-provider tests [#141855](https://github.com/openclaw/openclaw/pull/141855)
+- Isolate plugin artifact loader test fixtures [#141887](https://github.com/openclaw/openclaw/pull/141887)
+- Preserve inbound references on queued QA replies [#141905](https://github.com/openclaw/openclaw/pull/141905)
+- Align plugin install and removal QA expectations [#141964](https://github.com/openclaw/openclaw/pull/141964). Thanks @RomneyDa.
+- Prepare Docker images for sandbox QA [#141965](https://github.com/openclaw/openclaw/pull/141965). Thanks @RomneyDa.
+- Remove QA credentials through Gateway logout [#141974](https://github.com/openclaw/openclaw/pull/141974). Thanks @RomneyDa.
+- Align Claude QA fixture with session initialization [#141978](https://github.com/openclaw/openclaw/pull/141978). Thanks @RomneyDa.
+- Select compact progress for Slack draft QA [#141980](https://github.com/openclaw/openclaw/pull/141980). Thanks @RomneyDa.
+- Target Teams QA timeouts at message activities [#141985](https://github.com/openclaw/openclaw/pull/141985). Thanks @RomneyDa.
+- Drain heartbeat wakes before plugin test teardown [#142036](https://github.com/openclaw/openclaw/pull/142036)
+- Isolate keyless model tests from host credentials [#142049](https://github.com/openclaw/openclaw/pull/142049)
+- Finish mock-provider continuations after settled work [#142060](https://github.com/openclaw/openclaw/pull/142060). Thanks @RomneyDa.
+- Remove port-reuse races from probe tests [#142088](https://github.com/openclaw/openclaw/pull/142088). Thanks @RomneyDa.
+- Correct core session status in browser fixtures [#142097](https://github.com/openclaw/openclaw/pull/142097)
+- Isolate fresh mock write scenarios from earlier completions [#142137](https://github.com/openclaw/openclaw/pull/142137)
+- Isolate mocked Chromium selection from host settings [#142150](https://github.com/openclaw/openclaw/pull/142150)
+- Use system Bash in installer tests [#142161](https://github.com/openclaw/openclaw/pull/142161)
+- Keep canonical integration fixtures on source plugins [#142171](https://github.com/openclaw/openclaw/pull/142171)
+- Wait for audio transcript completion in Gateway tests [#142178](https://github.com/openclaw/openclaw/pull/142178)
+- Wait for triage test processes before deleting fixtures [#142215](https://github.com/openclaw/openclaw/pull/142215)
+- Prepare provider runtimes before Telegram sticker tests [#142234](https://github.com/openclaw/openclaw/pull/142234)
+- Align auth and Workshop QA with current runtime behavior [#142280](https://github.com/openclaw/openclaw/pull/142280)
+- Avoid unnecessary provider discovery in sticker tests [#142281](https://github.com/openclaw/openclaw/pull/142281)
+- Finish Activity test imports before teardown [#142282](https://github.com/openclaw/openclaw/pull/142282)
+- Wait for Gateway event-log test cleanup [#142314](https://github.com/openclaw/openclaw/pull/142314)
+- Wait for startup completion in first-run recovery tests [#142339](https://github.com/openclaw/openclaw/pull/142339). Thanks @vyctorbrzezowski.
+- Keep upgrade-test registry helpers on the same version [#142353](https://github.com/openclaw/openclaw/pull/142353). Thanks @RomneyDa.
+- Refresh Telegram QA button lookup after menu edits [#142473](https://github.com/openclaw/openclaw/pull/142473)
+- Stabilize Windows Claude CLI test fixtures [#142520](https://github.com/openclaw/openclaw/pull/142520). Thanks @vincentkoc.
+- Recognize unavailable upstream models in live tests [#142561](https://github.com/openclaw/openclaw/pull/142561). Thanks @RomneyDa.
+- Show nested onboarding failures in validation logs [#142645](https://github.com/openclaw/openclaw/pull/142645). Thanks @vincentkoc.
+- Wait for settled attachment test geometry [#142728](https://github.com/openclaw/openclaw/pull/142728)
+- Stabilize Android image-decoding tests on Linux [#142752](https://github.com/openclaw/openclaw/pull/142752). Thanks @vincentkoc.
+- Synchronize cloud-worker settings browser tests [#142763](https://github.com/openclaw/openclaw/pull/142763)
+- Wait for Signal delivery completion in tests [#142775](https://github.com/openclaw/openclaw/pull/142775). Thanks @vincentkoc.
+- Exercise same-version candidates in upgrade tests [#142811](https://github.com/openclaw/openclaw/pull/142811)
+- Run packaged QA commands with the selected candidate [#142925](https://github.com/openclaw/openclaw/pull/142925). Thanks @vincentkoc.
+- Close reloaded database caches in token tests [#142978](https://github.com/openclaw/openclaw/pull/142978)
+- Isolate managed-update tests from host system services [#143013](https://github.com/openclaw/openclaw/pull/143013). Thanks @vincentkoc.
+- Close Gateway test databases across module resets [#143045](https://github.com/openclaw/openclaw/pull/143045)
+- Close skill-upload test databases during cleanup [#143071](https://github.com/openclaw/openclaw/pull/143071)
+- Stabilize Gateway compaction race test synchronization [#143072](https://github.com/openclaw/openclaw/pull/143072)
+- Prepare Gateway test startup and preserve Cron cleanup errors [#143102](https://github.com/openclaw/openclaw/pull/143102). Thanks @vincentkoc.
+- Measure attachment layout within one browser frame [#143103](https://github.com/openclaw/openclaw/pull/143103)
+- Wait for socket closure before stream-test cleanup finishes [#143133](https://github.com/openclaw/openclaw/pull/143133)
+- Allow more startup time for systemd test fixtures [#143134](https://github.com/openclaw/openclaw/pull/143134). Thanks @vincentkoc.
+- Isolate the Gateway prewarm test repository [#143161](https://github.com/openclaw/openclaw/pull/143161)
+- Close paired-device test databases before deleting files [#143168](https://github.com/openclaw/openclaw/pull/143168)
+- Clean up chat preview listeners in UI tests [#143191](https://github.com/openclaw/openclaw/pull/143191)
+- Prevent stale connections in Telegram model callback tests [#143197](https://github.com/openclaw/openclaw/pull/143197)
+- Isolate Windows media file-URL test providers [#143213](https://github.com/openclaw/openclaw/pull/143213)
+- Avoid slow-startup failures in Matrix steering tests [#143249](https://github.com/openclaw/openclaw/pull/143249)
+- Isolate subagent announcement tests [#143251](https://github.com/openclaw/openclaw/pull/143251)
+- Stabilize Doctor source-isolation tests on tmpfs [#143258](https://github.com/openclaw/openclaw/pull/143258)
+- Restore empty-transcript compaction coverage [#143317](https://github.com/openclaw/openclaw/pull/143317)
+- Allow subpixel rounding in attachment layout tests [#143333](https://github.com/openclaw/openclaw/pull/143333). Thanks @vincentkoc.
+- Close Control UI test databases before cleanup [#143398](https://github.com/openclaw/openclaw/pull/143398)
+- Close pairing test databases before cleanup [#143401](https://github.com/openclaw/openclaw/pull/143401)
+- Close token-store test databases before cleanup [#143409](https://github.com/openclaw/openclaw/pull/143409)
+- Close node-pairing test databases before cleanup [#143418](https://github.com/openclaw/openclaw/pull/143418)
+- Complete bundled plugin directory test mock [#143444](https://github.com/openclaw/openclaw/pull/143444). Thanks @RomneyDa.
+- Synchronize model catalog browser tests [#143445](https://github.com/openclaw/openclaw/pull/143445). Thanks @RomneyDa.
+- Allow Chrome tab indexing time in extension tests [#143447](https://github.com/openclaw/openclaw/pull/143447). Thanks @RomneyDa.
+- Recognize expected MCP resolver test diagnostics [#143450](https://github.com/openclaw/openclaw/pull/143450). Thanks @RomneyDa.
+- Isolate announcement test dependencies [#143465](https://github.com/openclaw/openclaw/pull/143465). Thanks @vincentkoc.
+- Recognize Slack card progress in QA checks [#143562](https://github.com/openclaw/openclaw/pull/143562). Thanks @RomneyDa.
+- Correct Telegram QA receipt and preview expectations [#143563](https://github.com/openclaw/openclaw/pull/143563). Thanks @RomneyDa.
+- Run repository CLI health scenarios exclusively [#143564](https://github.com/openclaw/openclaw/pull/143564). Thanks @RomneyDa.
+- Correct package uninstall assertions [#143565](https://github.com/openclaw/openclaw/pull/143565). Thanks @RomneyDa.
+- Accept intentional memory preparation diagnostics in QA [#143570](https://github.com/openclaw/openclaw/pull/143570). Thanks @RomneyDa.
+- Coordinate Matrix QA progress with command completion [#143573](https://github.com/openclaw/openclaw/pull/143573). Thanks @RomneyDa.
+- Isolate CLI announcement checks and await transcript replies [#143576](https://github.com/openclaw/openclaw/pull/143576). Thanks @RomneyDa.
+- Bundle Telegram QA evidence helpers [#143582](https://github.com/openclaw/openclaw/pull/143582). Thanks @RomneyDa.
+- Isolate Codex auth-refresh integration providers [#143585](https://github.com/openclaw/openclaw/pull/143585)
+- Close heartbeat test databases before fixture deletion [#143606](https://github.com/openclaw/openclaw/pull/143606)
+- Repair worker setup browser fixtures [#143666](https://github.com/openclaw/openclaw/pull/143666)
+- Align QA Lab OpenAI defaults with canonical model IDs [#143674](https://github.com/openclaw/openclaw/pull/143674)
+- Correct Discord transcript provider assertions [#143689](https://github.com/openclaw/openclaw/pull/143689). Thanks @RomneyDa.
+- Refresh model catalogs before ClawRouter assertions [#143692](https://github.com/openclaw/openclaw/pull/143692). Thanks @RomneyDa.
+- Align timeout tests with direct Claude CLI execution [#143696](https://github.com/openclaw/openclaw/pull/143696). Thanks @RomneyDa.
+- Correct Telegram model-picker recovery tests [#143704](https://github.com/openclaw/openclaw/pull/143704). Thanks @RomneyDa.
+- Wait for updater process-group cleanup in tests [#143705](https://github.com/openclaw/openclaw/pull/143705)
+- Stabilize concurrent ClawHub catalog assertions [#143710](https://github.com/openclaw/openclaw/pull/143710)
+- Consolidate config environments and isolate Doctor fixtures [#143762](https://github.com/openclaw/openclaw/pull/143762)
+- Close CLI test databases before fixture deletion [#143782](https://github.com/openclaw/openclaw/pull/143782)
+- Close Watch HTTP test databases before fixture deletion [#143793](https://github.com/openclaw/openclaw/pull/143793)
+- Serialize database test worker shutdown [#143813](https://github.com/openclaw/openclaw/pull/143813)
+- Wait for final history placeholder styles in browser tests [#143824](https://github.com/openclaw/openclaw/pull/143824)
+- Isolate legacy handoff fixtures [#143875](https://github.com/openclaw/openclaw/pull/143875)
+- Restore config drainage test collection [#143913](https://github.com/openclaw/openclaw/pull/143913)
+- Isolate Doctor runtime fixtures [#143919](https://github.com/openclaw/openclaw/pull/143919)
+- Keep hardlink fixtures on one filesystem [#143945](https://github.com/openclaw/openclaw/pull/143945)
+- Drain transcript indexing before test cleanup [#143964](https://github.com/openclaw/openclaw/pull/143964)
+- Align dependency-locking navigation tests [#144002](https://github.com/openclaw/openclaw/pull/144002)
+- Stabilize Telegram replacement-session tests [#144049](https://github.com/openclaw/openclaw/pull/144049). Thanks @crash2kx.
+- Coordinate update-ledger test shutdown [#144054](https://github.com/openclaw/openclaw/pull/144054)
+- Restore complete navigation regression guards [#144075](https://github.com/openclaw/openclaw/pull/144075)
+- Drain session fixtures before state removal [#144087](https://github.com/openclaw/openclaw/pull/144087)
+- Isolate npm-only Featured test inputs [#144092](https://github.com/openclaw/openclaw/pull/144092)
+- Keep Pi rename fixtures on one filesystem [#144096](https://github.com/openclaw/openclaw/pull/144096)
+- Isolate reset tests from ambient heartbeats [#144108](https://github.com/openclaw/openclaw/pull/144108)
+
+
+
+
+
+
+##### Automated checks and performance testing
+
+
+Automated checks avoid unrelated work when a change affects only tests. Performance reports also measure CPU use more accurately, helping maintainers distinguish product regressions from measurement errors.
+
+
+
+###### Sources and complete change list
+
+
+The later historical 2026.7.33 evaluator pin restores its 250% status allowance alongside the accounting fixes. Successful live qualification with that pin is not established here. CPU measurements whose uncertainty crosses a limit remain blocked. The CodeQL follow-up repairs the earlier hosted-runner timeout path; these scanning changes are not vulnerability fixes.
+
+**Improvements**
+
+- Add opt-in runtime memory attribution to CLI benchmarks [#127746](https://github.com/openclaw/openclaw/pull/127746). Thanks @vincentkoc.
+- Reuse verified runner archives and handle CI inventory growth [#140680](https://github.com/openclaw/openclaw/pull/140680). Thanks @vincentkoc.
+- Move macOS CodeQL to GitHub-hosted runners [#141761](https://github.com/openclaw/openclaw/pull/141761). Thanks @vincentkoc.
+- Advance the historical evaluator before its calibration correction [#142058](https://github.com/openclaw/openclaw/pull/142058). Thanks @RomneyDa.
+- Skip unrelated upgrade checks for test-only changes [#142154](https://github.com/openclaw/openclaw/pull/142154)
+- Skip unrelated UI E2E jobs for isolated unit-test changes [#142350](https://github.com/openclaw/openclaw/pull/142350)
+- Move TUI test typechecking into the command shard [#142385](https://github.com/openclaw/openclaw/pull/142385)
+- Reuse prerequisite decisions in CI test planning [#142630](https://github.com/openclaw/openclaw/pull/142630)
+- Reuse verified Bun archives in Linux CI [#142849](https://github.com/openclaw/openclaw/pull/142849). Thanks @vincentkoc.
+- Reuse Android build timestamps across CI tests and lint [#143207](https://github.com/openclaw/openclaw/pull/143207)
+
+**Bug fixes**
+
+- Update the evaluator for late-discovered processes [#141675](https://github.com/openclaw/openclaw/pull/141675). Thanks @RomneyDa.
+- Provision ripgrep for filesystem contract tests [#141794](https://github.com/openclaw/openclaw/pull/141794)
+- Let macOS security scans finish within hosted runner limits [#141851](https://github.com/openclaw/openclaw/pull/141851). Thanks @vincentkoc.
+- Preserve heap settings across scorecard builds [#141915](https://github.com/openclaw/openclaw/pull/141915). Thanks @RomneyDa.
+- Scope historical status CPU allowance to July release [#141935](https://github.com/openclaw/openclaw/pull/141935). Thanks @RomneyDa.
+- Update performance evaluator CPU measurement pin [#142053](https://github.com/openclaw/openclaw/pull/142053). Thanks @RomneyDa.
+- Update Gateway startup CPU accounting [#142085](https://github.com/openclaw/openclaw/pull/142085). Thanks @RomneyDa.
+- Update performance evaluator startup discovery [#142104](https://github.com/openclaw/openclaw/pull/142104). Thanks @RomneyDa.
+- Retry failed performance artifact uploads once [#142344](https://github.com/openclaw/openclaw/pull/142344). Thanks @RomneyDa.
+- Correct the historical 2026.7.33 Kova benchmark pin [#142348](https://github.com/openclaw/openclaw/pull/142348). Thanks @RomneyDa.
+- Bound TypeScript preflight resources on constrained CI [#142472](https://github.com/openclaw/openclaw/pull/142472). Thanks @RomneyDa.
+- Use corrected release CPU calibration [#142537](https://github.com/openclaw/openclaw/pull/142537). Thanks @RomneyDa.
+- Retain test timing estimates across inventory changes [#142719](https://github.com/openclaw/openclaw/pull/142719). Thanks @RomneyDa and @vincentkoc.
+- Reject stale or unusable CI timing samples [#143182](https://github.com/openclaw/openclaw/pull/143182). Thanks @vincentkoc.
+- Budget deferred translation catalogs separately in CI [#143219](https://github.com/openclaw/openclaw/pull/143219). Thanks @vincentkoc.
+- Enforce one deferred bundle per language [#143297](https://github.com/openclaw/openclaw/pull/143297). Thanks @vincentkoc.
+- Preserve timing identities for expanded test chunks [#143639](https://github.com/openclaw/openclaw/pull/143639)
+- Correct CPU measurement bounds in release validation [#143808](https://github.com/openclaw/openclaw/pull/143808)
+- Install search test prerequisites [#143835](https://github.com/openclaw/openclaw/pull/143835). Thanks @fuller-stack-dev.
+
+
+
+
+
+
+##### Build and package checks
+
+
+Build and package checks better recognize which dependencies and files belong in each release package. This reduces false failures when maintainers prepare plugins and check their contents.
+
+
+
+###### Sources and complete change list
+
+
+Preparation uses the frozen source manifests where required; installed-package verification retains its own manifest checks. These changes do not by themselves establish that packages were published or are available in an installed release.
+
+**Improvements**
+
+- Use pnpm's override parser in npm lock generation [#141862](https://github.com/openclaw/openclaw/pull/141862). Thanks @RomneyDa.
+- Simplify package import scanning [#142859](https://github.com/openclaw/openclaw/pull/142859). Thanks @vincentkoc.
+- Simplify package dependency path resolution [#143063](https://github.com/openclaw/openclaw/pull/143063)
+
+**Bug fixes**
+
+- Recognize extension-owned package dependencies [#141647](https://github.com/openclaw/openclaw/pull/141647). Thanks @RomneyDa.
+- Preserve version comparisons in npm dependency evidence [#141800](https://github.com/openclaw/openclaw/pull/141800). Thanks @RomneyDa.
+- Verify dependency ownership for built plugin chunks [#141876](https://github.com/openclaw/openclaw/pull/141876). Thanks @RomneyDa.
+- Use source companion manifests in package verification [#142033](https://github.com/openclaw/openclaw/pull/142033). Thanks @RomneyDa.
+- Handle nested optional plugin dependencies [#142126](https://github.com/openclaw/openclaw/pull/142126)
+- Initialize ClawHub bootstrap packaging dependencies [#142191](https://github.com/openclaw/openclaw/pull/142191)
+- Recognize Bun built-ins in package checks [#143436](https://github.com/openclaw/openclaw/pull/143436). Thanks @RomneyDa.
+- Allow shipped Markdown guides in npm checks [#143699](https://github.com/openclaw/openclaw/pull/143699)
+
+
+
+
+
+
+##### Release preparation and recovery
+
+
+Release tools make interrupted publishing easier to investigate and recover from. Checks for older releases match the features those versions contain, while mobile release jobs get fixes for build preparation and troubleshooting. The checks that read older releases directly from Git require Git 2.45 or newer.
+
+
+
+###### Sources and complete change list
+
+
+A recovered dispatch or collected publication status is an observation, not a passed validation or permission to publish. Expired dispatch witnesses can leave recovery unresolved, and separate hosts are not globally deduplicated. Omitted historical scenarios are not passed tests. Bun installation checks retain Bun when its probe succeeds and select Node only for the recognized Bun/node:sqlite rejection; other failures remain errors. Requested diagnostic maturity scorecards may be published before the workflow reports failed or blocked results. Prior-release pages and version metadata below remain historical records.
+
+**Improvements**
+
+- Prepare package artifacts before release publication [#136466](https://github.com/openclaw/openclaw/pull/136466). Thanks @vincentkoc.
+- Add the Node smoke path later replaced by runtime selection [#142034](https://github.com/openclaw/openclaw/pull/142034). Thanks @RomneyDa.
+- Add published 2026.9.3 to the Mac update feed [#142235](https://github.com/openclaw/openclaw/pull/142235)
+- Align main with published 2026.9.3 metadata [#142240](https://github.com/openclaw/openclaw/pull/142240)
+- Match default Telegram package tests to frozen source capabilities [#142378](https://github.com/openclaw/openclaw/pull/142378). Thanks @RomneyDa.
+- Add a manual Android emulator diagnostic [#142780](https://github.com/openclaw/openclaw/pull/142780). Thanks @vincentkoc.
+- Capture emulator boot diagnostics [#142809](https://github.com/openclaw/openclaw/pull/142809). Thanks @vincentkoc.
+- Retain diagnostics after emulator readiness timeout [#142835](https://github.com/openclaw/openclaw/pull/142835). Thanks @vincentkoc.
+- Complete emulator cold-boot diagnostics [#142891](https://github.com/openclaw/openclaw/pull/142891). Thanks @vincentkoc.
+- Recover release-validation dispatches after lost responses [#142927](https://github.com/openclaw/openclaw/pull/142927). Thanks @vincentkoc.
+- Move Android emulator workflows to Ubuntu KVM [#142979](https://github.com/openclaw/openclaw/pull/142979). Thanks @vincentkoc.
+- Show publication observations alongside release validation status [#143171](https://github.com/openclaw/openclaw/pull/143171). Thanks @vincentkoc.
+- Reject releases with beta tags older than stable [#143669](https://github.com/openclaw/openclaw/pull/143669)
+- Validate frozen release targets from committed source [#144023](https://github.com/openclaw/openclaw/pull/144023). Thanks @vincentkoc.
+
+**Bug fixes**
+
+- Use established session tests for historical Node checks [#141640](https://github.com/openclaw/openclaw/pull/141640). Thanks @RomneyDa.
+- Accept opted-in historical same-version updater results [#141652](https://github.com/openclaw/openclaw/pull/141652). Thanks @RomneyDa.
+- Correct release source checks and upgrade-test selection [#141746](https://github.com/openclaw/openclaw/pull/141746)
+- Validate frozen releases with their shipped scenarios [#141774](https://github.com/openclaw/openclaw/pull/141774). Thanks @RomneyDa.
+- Preserve frozen-release Gateway test client imports [#141814](https://github.com/openclaw/openclaw/pull/141814). Thanks @RomneyDa.
+- Place frozen-release test clients beside installed dependencies [#141827](https://github.com/openclaw/openclaw/pull/141827). Thanks @RomneyDa.
+- Install dependencies for the trusted native live-test harness [#141829](https://github.com/openclaw/openclaw/pull/141829). Thanks @RomneyDa.
+- Fetch release-candidate history through its canonical branch [#141840](https://github.com/openclaw/openclaw/pull/141840). Thanks @RomneyDa.
+- Recognize the July filesystem validation contract [#141892](https://github.com/openclaw/openclaw/pull/141892). Thanks @RomneyDa.
+- Keep historical Docker validation scenarios consistent [#141893](https://github.com/openclaw/openclaw/pull/141893). Thanks @RomneyDa.
+- Add maturity-result completeness checks [#141931](https://github.com/openclaw/openclaw/pull/141931). Thanks @RomneyDa.
+- Repair Gateway release-test capacity and scenario selection [#141954](https://github.com/openclaw/openclaw/pull/141954)
+- Keep frozen upgrade tests with matching helpers [#142007](https://github.com/openclaw/openclaw/pull/142007). Thanks @RomneyDa.
+- Record authorized unsupported Docker lanes as no-ops [#142020](https://github.com/openclaw/openclaw/pull/142020). Thanks @RomneyDa.
+- Publish diagnostic scorecards before reporting QA failure [#142040](https://github.com/openclaw/openclaw/pull/142040). Thanks @RomneyDa.
+- Use trusted tooling for preflight plugin plans [#142055](https://github.com/openclaw/openclaw/pull/142055). Thanks @RomneyDa.
+- Omit unsupported historical corrupt-plugin checks [#142061](https://github.com/openclaw/openclaw/pull/142061). Thanks @RomneyDa.
+- Bound ClawHub ancestry verification responses [#142072](https://github.com/openclaw/openclaw/pull/142072). Thanks @vincentkoc.
+- Install trusted tooling dependencies for plugin previews [#142103](https://github.com/openclaw/openclaw/pull/142103)
+- Keep release helpers from dirtying mobile source checks [#142115](https://github.com/openclaw/openclaw/pull/142115). Thanks @vincentkoc.
+- Keep Docker approval waits outside the publication queue [#142250](https://github.com/openclaw/openclaw/pull/142250)
+- Keep changelog credit within verified release history [#142261](https://github.com/openclaw/openclaw/pull/142261). Thanks @vincentkoc.
+- Keep Docker upgrade tests on an older starting version [#142273](https://github.com/openclaw/openclaw/pull/142273)
+- Verify closeout after separate npm and Docker recovery runs [#142291](https://github.com/openclaw/openclaw/pull/142291)
+- Restore Sparkle build-number output from symlinked checkouts [#142315](https://github.com/openclaw/openclaw/pull/142315)
+- Handle large tooling archives during mobile beta authorization [#142360](https://github.com/openclaw/openclaw/pull/142360). Thanks @vincentkoc.
+- Restore Bun execution in installation smoke checks [#142428](https://github.com/openclaw/openclaw/pull/142428). Thanks @RomneyDa.
+- Supply the release Node version to frozen installer tests [#142431](https://github.com/openclaw/openclaw/pull/142431). Thanks @RomneyDa.
+- Keep mobile beta authorization valid as main advances [#142432](https://github.com/openclaw/openclaw/pull/142432). Thanks @vincentkoc.
+- Repair helper loading for historical upgrade checks [#142441](https://github.com/openclaw/openclaw/pull/142441). Thanks @RomneyDa.
+- Align frozen 2026.7.33 Docker validation [#142456](https://github.com/openclaw/openclaw/pull/142456). Thanks @RomneyDa.
+- Match frozen onboarding tests to release helpers [#142467](https://github.com/openclaw/openclaw/pull/142467). Thanks @RomneyDa.
+- Record the reviewed Codex test scan finding [#142474](https://github.com/openclaw/openclaw/pull/142474). Thanks @vincentkoc.
+- Set mobile beta screenshot prerequisites [#142523](https://github.com/openclaw/openclaw/pull/142523). Thanks @vincentkoc.
+- Match ClawHub fixture requests to frozen candidates [#142551](https://github.com/openclaw/openclaw/pull/142551). Thanks @RomneyDa.
+- Forward release Node version to Rocky installer probes [#142562](https://github.com/openclaw/openclaw/pull/142562). Thanks @RomneyDa.
+- Select a supported runtime for Bun install checks [#142563](https://github.com/openclaw/openclaw/pull/142563). Thanks @RomneyDa.
+- Repair frozen-package update validation fixtures [#142573](https://github.com/openclaw/openclaw/pull/142573). Thanks @RomneyDa.
+- Fetch release ancestry branches independently [#142643](https://github.com/openclaw/openclaw/pull/142643). Thanks @RomneyDa.
+- Derive frozen-release expectations from selected source [#142683](https://github.com/openclaw/openclaw/pull/142683). Thanks @RomneyDa.
+- Preserve Git selection in frozen-release tests [#142686](https://github.com/openclaw/openclaw/pull/142686). Thanks @RomneyDa.
+- Match frozen-package Telegram tests to supported scenarios [#142687](https://github.com/openclaw/openclaw/pull/142687). Thanks @RomneyDa.
+- Correct frozen dirty-checkout exit expectations [#142727](https://github.com/openclaw/openclaw/pull/142727). Thanks @RomneyDa.
+- Qualify Telegram progress tests against frozen source [#142731](https://github.com/openclaw/openclaw/pull/142731). Thanks @RomneyDa.
+- Prepare Watch Rust tools for iOS beta builds [#142762](https://github.com/openclaw/openclaw/pull/142762). Thanks @vincentkoc.
+- Isolate iOS release signing keys [#142846](https://github.com/openclaw/openclaw/pull/142846). Thanks @vincentkoc.
+- Identify incompatible release-validation evidence [#142906](https://github.com/openclaw/openclaw/pull/142906). Thanks @vincentkoc.
+- Check image size limits before Vercel copying [#142908](https://github.com/openclaw/openclaw/pull/142908). Thanks @vincentkoc.
+- Match frozen bundle validation clients to source [#142926](https://github.com/openclaw/openclaw/pull/142926). Thanks @vincentkoc.
+- Stop frozen checks on committed-source read errors [#142930](https://github.com/openclaw/openclaw/pull/142930). Thanks @vincentkoc.
+- Isolate frozen-suite compatibility checks [#142935](https://github.com/openclaw/openclaw/pull/142935). Thanks @vincentkoc.
+- Accept native iOS signing keychain filenames [#142968](https://github.com/openclaw/openclaw/pull/142968). Thanks @vincentkoc.
+- Preserve the iOS signing tool environment [#143301](https://github.com/openclaw/openclaw/pull/143301). Thanks @vincentkoc.
+- Match validation runs with omitted empty inputs [#143421](https://github.com/openclaw/openclaw/pull/143421). Thanks @RomneyDa.
+- Include required plugins in candidate preparation [#143452](https://github.com/openclaw/openclaw/pull/143452). Thanks @RomneyDa.
+- Validate Anthropic cache behavior against candidate capabilities [#143508](https://github.com/openclaw/openclaw/pull/143508). Thanks @RomneyDa.
+- Match Telegram release checks to package source [#143510](https://github.com/openclaw/openclaw/pull/143510). Thanks @RomneyDa.
+- Exclude unpublished same-version upgrade baselines [#143567](https://github.com/openclaw/openclaw/pull/143567). Thanks @RomneyDa.
+- Use published plugins for correction-version upgrade baselines [#143681](https://github.com/openclaw/openclaw/pull/143681)
+- Register the 2026.9.4 plugin scan policy [#143807](https://github.com/openclaw/openclaw/pull/143807)
+- Load older candidates in Anthropic cache checks [#143810](https://github.com/openclaw/openclaw/pull/143810). Thanks @RomneyDa.
+- Match Telegram queue validation to candidate capabilities [#143811](https://github.com/openclaw/openclaw/pull/143811). Thanks @RomneyDa.
+- Validate contracts for omitted Docker test aliases [#144129](https://github.com/openclaw/openclaw/pull/144129). Thanks @vincentkoc.
+
+**Documentation**
+
+- Refresh release summaries and contribution records [685ae1b0](https://github.com/openclaw/openclaw/commit/685ae1b0c81ca9dec95e3c10f3d4b4ffffe69d46)
+- Add the 2026.9.4 changelog section [dd178db5](https://github.com/openclaw/openclaw/commit/dd178db54d088b3ee251f5e99e4081bad0f8fc51)
+- Document qualification with final release notes already committed [#141786](https://github.com/openclaw/openclaw/pull/141786)
+- Add the v2026.9.3 release documentation page [#142277](https://github.com/openclaw/openclaw/pull/142277). Thanks @hannesrudolph.
+- Align v2026.9.3 release-page framing with its announcement [#142307](https://github.com/openclaw/openclaw/pull/142307). Thanks @hannesrudolph.
+- Align release validation guidance with notes preparation [#142328](https://github.com/openclaw/openclaw/pull/142328)
+- Temporarily rename the v2026.9.3 statistics label [#142437](https://github.com/openclaw/openclaw/pull/142437). Thanks @hannesrudolph.
+- Correct ClawHub release-verification instructions [#142458](https://github.com/openclaw/openclaw/pull/142458)
+- Correct extended-stable validation instructions [#142538](https://github.com/openclaw/openclaw/pull/142538). Thanks @RomneyDa.
+- Restore the v2026.9.3 statistics label [#142541](https://github.com/openclaw/openclaw/pull/142541). Thanks @hannesrudolph.
+- Organize release validation guidance by task [#142774](https://github.com/openclaw/openclaw/pull/142774). Thanks @vincentkoc.
+- Split release-validation documentation into focused guides [#143163](https://github.com/openclaw/openclaw/pull/143163). Thanks @vincentkoc.
+- Use HTTP liveness for unauthenticated release checks [#143709](https://github.com/openclaw/openclaw/pull/143709). Thanks @vincentkoc.
+- Record landed repairs and contributor credit [#144440](https://github.com/openclaw/openclaw/pull/144440). Thanks @vincentkoc.
+
+
+
+
+
+
+##### Contributor tools and documentation
+
+
+Contributors get less repeated setup during local checks and clearer testing guides. Documentation tools preserve code examples and point errors to the right line. Normal pnpm installs now reject links to another checkout’s dependency folders. Give each source checkout its own dependencies or explicitly configure the dependency location.
+
+
+
+###### Sources and complete change list
+
+
+The dependency-install guard is bypassed when lifecycle scripts are disabled and does not lock against concurrent path replacement. Unix development runners preserve interruption signals; detached workers may still need cleanup, and Windows retains its existing handling. Tool-specific measurements do not establish faster model responses or total publication times. Generated translation records and maturity snapshots do not establish new languages, visible app changes, or blanket readiness.
+
+**Improvements**
+
+- Reuse UTF-8 truncation in SDK change reports [#141660](https://github.com/openclaw/openclaw/pull/141660)
+- Remove unused QA script test accessors [#141751](https://github.com/openclaw/openclaw/pull/141751)
+- Run package contract tests without unrelated runtime builds [#142159](https://github.com/openclaw/openclaw/pull/142159)
+- Preserve human credit in squash merge messages [#142167](https://github.com/openclaw/openclaw/pull/142167)
+- Add tooling for captioned and zoomed PR videos without audio [#142259](https://github.com/openclaw/openclaw/pull/142259)
+- Refresh selected translations with native context and retained aliases [#142260](https://github.com/openclaw/openclaw/pull/142260)
+- Load the compiler only when development checks need it [#142338](https://github.com/openclaw/openclaw/pull/142338)
+- Remove unused update-triage result metadata [#142345](https://github.com/openclaw/openclaw/pull/142345). Thanks @vincentkoc.
+- Reduce documentation sync source downloads [#142400](https://github.com/openclaw/openclaw/pull/142400). Thanks @hannesrudolph.
+- Remove obsolete people-loading translation data [#142420](https://github.com/openclaw/openclaw/pull/142420)
+- Combine duplicate architecture-checker scans [#142451](https://github.com/openclaw/openclaw/pull/142451)
+- Reuse documentation checks and validate after rebase [#142475](https://github.com/openclaw/openclaw/pull/142475). Thanks @hannesrudolph.
+- Reduce repeated lint startup for larger changes [#142691](https://github.com/openclaw/openclaw/pull/142691)
+- Synchronize a screenshot-fixture translation label [#142714](https://github.com/openclaw/openclaw/pull/142714)
+- Consolidate QA Lab YAML validation diagnostics [#143016](https://github.com/openclaw/openclaw/pull/143016). Thanks @vincentkoc.
+- Route session-history HTTP tests without full build prerequisites [#143096](https://github.com/openclaw/openclaw/pull/143096). Thanks @vincentkoc.
+- Remove unused global documentation audit indexes [#143164](https://github.com/openclaw/openclaw/pull/143164)
+- Reuse numeric flag parsing in performance tests [#143237](https://github.com/openclaw/openclaw/pull/143237)
+- Clarify CI watcher progress and timeout output [#143320](https://github.com/openclaw/openclaw/pull/143320)
+- Avoid repeated SDK export traversal [#143393](https://github.com/openclaw/openclaw/pull/143393)
+- Skip unnecessary SDK guard parsing [#143513](https://github.com/openclaw/openclaw/pull/143513). Thanks @RomneyDa.
+- Share task audit summary counting [#143682](https://github.com/openclaw/openclaw/pull/143682). Thanks @vincentkoc.
+- Share dead-code scan orchestration [#143745](https://github.com/openclaw/openclaw/pull/143745). Thanks @vincentkoc.
+- Refresh translation records for Skills screens [#143806](https://github.com/openclaw/openclaw/pull/143806)
+- Refresh snapshot translation records [#143914](https://github.com/openclaw/openclaw/pull/143914)
+- Reuse plugin metadata during docs generation [#144120](https://github.com/openclaw/openclaw/pull/144120)
+
+**Bug fixes**
+
+- Keep local test worker counts consistent across projects [#141716](https://github.com/openclaw/openclaw/pull/141716)
+- Prevent source installs from modifying another checkout's dependencies [#141719](https://github.com/openclaw/openclaw/pull/141719)
+- Label pull requests editing split documentation pages [#142677](https://github.com/openclaw/openclaw/pull/142677). Thanks @vincentkoc.
+- Extend plugin documentation label coverage [#142735](https://github.com/openclaw/openclaw/pull/142735). Thanks @vincentkoc.
+- Track shared native-translation inputs [#142786](https://github.com/openclaw/openclaw/pull/142786). Thanks @vincentkoc.
+- Distinguish declared ClawHub routes from unverified headings in audits [#143002](https://github.com/openclaw/openclaw/pull/143002). Thanks @vincentkoc.
+- Allow the approved historical pnpm pin in isolated checks [#143129](https://github.com/openclaw/openclaw/pull/143129). Thanks @vincentkoc.
+- Audit unused exports after script and root-test changes [#143268](https://github.com/openclaw/openclaw/pull/143268)
+- Preserve fenced examples during documentation formatting [#143394](https://github.com/openclaw/openclaw/pull/143394)
+- Report original source lines in documentation errors [#143404](https://github.com/openclaw/openclaw/pull/143404)
+- Detect overdue documentation during steady edits [#143455](https://github.com/openclaw/openclaw/pull/143455)
+- Distinguish interrupted development runners from completed stops [#143676](https://github.com/openclaw/openclaw/pull/143676). Thanks @shakkernerd.
+- Recover locale imports after source errors [#143776](https://github.com/openclaw/openclaw/pull/143776)
+
+**Documentation**
+
+- Organize testing guidance by task [#141221](https://github.com/openclaw/openclaw/pull/141221). Thanks @vincentkoc.
+- Refresh maturity evidence and coverage reports [#141910](https://github.com/openclaw/openclaw/pull/141910)
+- Split testing guidance into focused pages [#141968](https://github.com/openclaw/openclaw/pull/141968). Thanks @vincentkoc.
+- Validate maturity documentation routes and anchors [#141977](https://github.com/openclaw/openclaw/pull/141977). Thanks @RomneyDa.
+- Refresh maturity scorecard evidence [#142114](https://github.com/openclaw/openclaw/pull/142114)
+- Split QA automation guidance into focused pages [#142426](https://github.com/openclaw/openclaw/pull/142426). Thanks @vincentkoc.
+- Link live-test filtering guidance to its current page [#142560](https://github.com/openclaw/openclaw/pull/142560). Thanks @vincentkoc.
+- Keep SDK alias removal pending review [#142708](https://github.com/openclaw/openclaw/pull/142708)
+- Keep routine repository output inline [#142946](https://github.com/openclaw/openclaw/pull/142946). Thanks @vincentkoc.
+- Organize live-testing documentation by test task [#143042](https://github.com/openclaw/openclaw/pull/143042). Thanks @vincentkoc.
+- Split CI routing guidance into focused pages [#143053](https://github.com/openclaw/openclaw/pull/143053). Thanks @vincentkoc.
+- Refresh CI and plugin validation guidance [#143287](https://github.com/openclaw/openclaw/pull/143287)
+- Document temporary defensive-work model routing [#143698](https://github.com/openclaw/openclaw/pull/143698)
+- Consolidate contributor guidance and subsystem ownership [#143785](https://github.com/openclaw/openclaw/pull/143785). Thanks @obviyus and @vincentkoc.
+
+
+
+
+
+
+##### Reverted changes
+
+
+A change to conversation-marker spacing was undone. Both changes are listed below; the existing compact left rail remains.
+
+
+
+###### Sources and complete change list
+
+
+**Improvements**
+
+- Record the reverted conversation rail spacing adjustment [#142667](https://github.com/openclaw/openclaw/pull/142667). Thanks @Patrick-Erichsen.
+
+**Bug fixes**
+
+- Revert the canceled conversation rail spacing adjustment [#142684](https://github.com/openclaw/openclaw/pull/142684). Thanks @Patrick-Erichsen.
+
+
+
+
+
+
+

--- a/docs/releases/2026.9.4.md
+++ b/docs/releases/2026.9.4.md
@@ -14,7 +14,7 @@ OpenClaw 2026.9.4 makes plugins and skills easier to find, and lets you turn pas
 
 It also adds GPT Image 2.5 support, more control over cloud sessions, and interactive questions in the terminal, alongside fixes for updates, memory, and messaging.
 
-**Release scale:** 1,558 pull requests, 20 direct commits, and 293 contributors.
+**Release scale:** 1,558 pull requests, 20 direct commits, and 294 contributors.
 
 ## Installation and Onboarding
 

--- a/docs/releases/2026.9.4.md
+++ b/docs/releases/2026.9.4.md
@@ -10,6 +10,8 @@ keywords:
 
 # v2026.9.4
 
+**Reading formats:** [Release notes for readers](/releases/2026.9.4) · [Plain Markdown for AI agents and tools](https://raw.githubusercontent.com/openclaw/openclaw/main/CHANGELOG/2026.9.4.md).
+
 OpenClaw 2026.9.4 makes plugins and skills easier to find, and lets you turn past conversations into reusable skills through a chat you can steer.
 
 It also adds GPT Image 2.5 support, more control over cloud sessions, and interactive questions in the terminal, alongside fixes for updates, memory, and messaging.


### PR DESCRIPTION
Related: #145464

## What Problem This Solves

The v2026.9.4 changelog still shows the initial release entry instead of the detailed release notes already available in the docs, and the two formats need clear navigation between them.

## User Impact

Readers can use the formatted release notes, while AI agents and tools can consume the same complete content as plain Markdown. Links at the top of both versions identify each format.

## Why This Change Was Made

This activates the existing docs-to-changelog renderer for v2026.9.4, adds the format links, and reconciles the docs count to the reviewed 294 contributor accounts. The docs remain the editorial source; the changelog index and frozen contribution record stay unchanged.

## Evidence

- Generated the complete mirror with the landed upstream renderer; the version-scoped mirror check passes.
- Verified that the docs differ only by the contributor count, 293 → 294, and the reading-format links, and that exactly the docs page and its generated changelog changed.
- Verified byte-for-byte preservation of the root index and frozen contribution record.
- Independent autoreview at P2 or higher returned scoped-clean for the original mirror and the subsequent navigation delta, with no actionable findings.
- The navigation delta passes `git diff --check`. Across the complete PR, that check reports only trailing blank lines emitted by the upstream renderer. They are preserved to keep the mirror exactly reproducible; the complete check passes with only that EOF-whitespace category excluded.

This documentation PR does not itself update the live GitHub Release body or publish packages.
