### PR TITLE
fix: continue tasks when Responses requests more work

### DIFF
--- a/docs/concepts/agent-loop.md
+++ b/docs/concepts/agent-loop.md
@@ -28,6 +28,16 @@ response. If the provider sends `end_turn: false`, the loop requests another
 response even when the completed response contains only text. Existing
 cancellation, host stop decisions, and intentional tool termination still apply.
 
+Each completed or incomplete Responses response also carries an
+`openai_responses_terminal` entry in the saved assistant message's `diagnostics`.
+It records `eventType` and the provider's `endTurn` signal as
+`true`, `false`, `"absent"`, or `"invalid"`, without retaining malformed values.
+Read it alongside the message's `stopReason` and text phase. These per-response
+facts survive later responses in the same run and require no
+raw-stream logging. They record the provider signal, not whether a host stop or
+cancellation prevented continuation. Older messages without this diagnostic
+cannot establish whether the provider omitted the signal.
+
 The wait result also carries the run's `terminalReply` and, when available,
 `terminalReceipt`. A receipt with `sourceReplyDelivered: true` confirms a final
 reply reached the external source conversation. A2A announcements consume that

--- a/docs/concepts/agent-loop.md
+++ b/docs/concepts/agent-loop.md
@@ -23,6 +23,11 @@ execution, streaming, persistence.
 4. `subscribeEmbeddedAgentSession` bridges runtime events to the `agent` stream: tool events to `stream: "tool"`, assistant deltas to `stream: "assistant"`, lifecycle events to `stream: "lifecycle"` (`phase: "start" | "finishing" | "end" | "error"`).
 5. `agent.wait` (`waitForAgentRun`) waits for **lifecycle end/error** on a `runId` and returns `{ status: ok|error|timeout, startedAt, endedAt, error? }`.
 
+For embedded OpenAI Responses turns, `response.completed` finishes one model
+response. If the provider sends `end_turn: false`, the loop requests another
+response even when the completed response contains only text. Existing
+cancellation, host stop decisions, and intentional tool termination still apply.
+
 The wait result also carries the run's `terminalReply` and, when available,
 `terminalReceipt`. A receipt with `sourceReplyDelivered: true` confirms a final
 reply reached the external source conversation. A2A announcements consume that

--- a/packages/agent-core/src/agent-loop.responses-continuation.test.ts
+++ b/packages/agent-core/src/agent-loop.responses-continuation.test.ts
@@ -32,6 +32,8 @@ describe("Responses turn continuation", () => {
     { label: "explicit end", endTurn: true, requests: 1 },
     { label: "omitted end_turn", endTurn: undefined, requests: 1 },
     { label: "malformed end_turn", endTurn: "false", requests: 1 },
+    { label: "null end_turn", endTurn: null, requests: 1 },
+    { label: "object end_turn", endTurn: { privateValue: "do not retain" }, requests: 1 },
     { label: "incomplete response", endTurn: false, incomplete: true, requests: 1 },
     { label: "caller cancellation", endTurn: false, cancel: true, requests: 1 },
     { label: "host stop decision", endTurn: false, stop: true, requests: 1 },
@@ -142,6 +144,29 @@ describe("Responses turn continuation", () => {
       expect(requests).toHaveLength(scenario.requests);
       expect(execute).toHaveBeenCalledTimes(scenario.requests > 1 ? 1 : 0);
       expect(events.filter((event) => event.type === "agent_end")).toHaveLength(1);
+      const assistants = result
+        .filter((message) => message.role === "assistant")
+        .filter((message) => message.responseId !== undefined);
+      expect(assistants).toHaveLength(scenario.requests);
+      for (const [index, assistant] of assistants.entries()) {
+        const providerEndTurn = index === 0 ? endTurn : index !== 1;
+        expect(assistant.diagnostics).toEqual([
+          {
+            type: "openai_responses_terminal",
+            timestamp: expect.any(Number),
+            details: {
+              eventType: scenario.incomplete ? "response.incomplete" : "response.completed",
+              endTurn:
+                typeof providerEndTurn === "boolean"
+                  ? providerEndTurn
+                  : providerEndTurn === undefined
+                    ? "absent"
+                    : "invalid",
+            },
+          },
+        ]);
+      }
+      expect(JSON.stringify(requests)).not.toContain("openai_responses_terminal");
       if (scenario.requests === 3) {
         expect(result.at(-1)).toMatchObject({
           role: "assistant",

--- a/packages/agent-core/src/agent-loop.responses-continuation.test.ts
+++ b/packages/agent-core/src/agent-loop.responses-continuation.test.ts
@@ -1,0 +1,179 @@
+import { once } from "node:events";
+import type { AddressInfo } from "node:net";
+import type { ResponseCreateParamsStreaming } from "openai/resources/responses/responses.js";
+import { Type } from "typebox";
+import { describe, expect, it, vi } from "vitest";
+import { WebSocketServer } from "ws";
+import { streamOpenAICodexResponses } from "../../ai/src/providers/openai-chatgpt-responses.js";
+import { agentLoop } from "./agent-loop.js";
+import type { Message, Model } from "./llm.js";
+import type { AgentEvent, AgentTool } from "./types.js";
+
+function textItem(id: string, text: string, phase = "final_answer") {
+  return {
+    type: "message",
+    id,
+    role: "assistant",
+    status: "completed",
+    phase,
+    content: [{ type: "output_text", text, annotations: [] }],
+  };
+}
+
+describe("Responses turn continuation", () => {
+  it.each([
+    { label: "explicit continuation with final text", endTurn: false, requests: 3 },
+    {
+      label: "explicit continuation with commentary",
+      endTurn: false,
+      phase: "commentary",
+      requests: 3,
+    },
+    { label: "explicit end", endTurn: true, requests: 1 },
+    { label: "omitted end_turn", endTurn: undefined, requests: 1 },
+    { label: "malformed end_turn", endTurn: "false", requests: 1 },
+    { label: "incomplete response", endTurn: false, incomplete: true, requests: 1 },
+    { label: "caller cancellation", endTurn: false, cancel: true, requests: 1 },
+    { label: "host stop decision", endTurn: false, stop: true, requests: 1 },
+    { label: "intentional tool termination", endTurn: false, terminateTool: true, requests: 2 },
+  ])("$label", async (scenario) => {
+    const { endTurn } = scenario;
+    const controller = new AbortController();
+    const requests: ResponseCreateParamsStreaming[] = [];
+    const server = new WebSocketServer({ host: "127.0.0.1", port: 0 });
+    server.on("connection", (socket) => {
+      socket.on("message", (data) => {
+        const bytes = Buffer.isBuffer(data)
+          ? data
+          : Array.isArray(data)
+            ? Buffer.concat(data)
+            : Buffer.from(data);
+        requests.push(JSON.parse(bytes.toString("utf8")) as ResponseCreateParamsStreaming);
+        const index = requests.length;
+        const output =
+          index === 1
+            ? [textItem("msg_progress", "I am checking the result.", scenario.phase)]
+            : index === 2
+              ? [
+                  {
+                    type: "function_call",
+                    id: "fc_check",
+                    call_id: "call_check",
+                    name: "check",
+                    arguments: "{}",
+                    status: "completed",
+                  },
+                ]
+              : [textItem("msg_final", "The check passed.")];
+        socket.send(
+          JSON.stringify({
+            type: scenario.incomplete ? "response.incomplete" : "response.completed",
+            response: {
+              id: `resp_${index}`,
+              status: scenario.incomplete ? "incomplete" : "completed",
+              ...(scenario.incomplete
+                ? { incomplete_details: { reason: "max_output_tokens" } }
+                : {}),
+              ...(index === 1
+                ? endTurn === undefined
+                  ? {}
+                  : { end_turn: endTurn }
+                : { end_turn: index !== 2 }),
+              output,
+              usage: { input_tokens: 5, output_tokens: 3, total_tokens: 8 },
+            },
+          }),
+        );
+      });
+    });
+    await once(server, "listening");
+    const port = (server.address() as AddressInfo).port;
+    const model: Model<"openai-chatgpt-responses"> = {
+      id: "test-model",
+      name: "Test model",
+      provider: "openai",
+      api: "openai-chatgpt-responses",
+      baseUrl: `http://127.0.0.1:${port}/backend-api`,
+      reasoning: true,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 8192,
+      maxTokens: 256,
+    };
+    const encode = (value: object) => Buffer.from(JSON.stringify(value)).toString("base64url");
+    const apiKey = `${encode({ alg: "none", typ: "JWT" })}.${encode({ "https://api.openai.com/auth": { chatgpt_account_id: "acct-loopback" } })}.signature`;
+    const execute = vi.fn(async () => ({
+      content: [{ type: "text" as const, text: "checked" }],
+      details: {},
+    }));
+    const tool: AgentTool = {
+      name: "check",
+      label: "Check",
+      description: "Check the result",
+      parameters: Type.Object({}),
+      execute,
+    };
+    try {
+      const events: AgentEvent[] = [];
+      const stream = agentLoop(
+        [{ role: "user", content: "Check the result and report it.", timestamp: 1 }],
+        { systemPrompt: "", messages: [], tools: [tool] },
+        {
+          model,
+          convertToLlm: (messages) => messages as Message[],
+          shouldStopAfterTurn: () => scenario.stop === true,
+          afterToolCall: async () => (scenario.terminateTool ? { terminate: true } : undefined),
+        },
+        controller.signal,
+        (_model, context, options) =>
+          streamOpenAICodexResponses(model, context, {
+            ...options,
+            apiKey,
+            transport: "websocket",
+          }),
+      );
+      for await (const event of stream) {
+        events.push(event);
+        if (scenario.cancel && event.type === "turn_end") {
+          controller.abort(new Error("Caller stopped the run"));
+        }
+      }
+      const result = await stream.result();
+      expect(requests).toHaveLength(scenario.requests);
+      expect(execute).toHaveBeenCalledTimes(scenario.requests > 1 ? 1 : 0);
+      expect(events.filter((event) => event.type === "agent_end")).toHaveLength(1);
+      if (scenario.requests === 3) {
+        expect(result.at(-1)).toMatchObject({
+          role: "assistant",
+          content: [expect.objectContaining({ text: "The check passed." })],
+        });
+        expect(requests[1]?.input).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              type: "message",
+              role: "assistant",
+              phase: scenario.phase ?? "final_answer",
+              content: [expect.objectContaining({ text: "I am checking the result." })],
+            }),
+          ]),
+        );
+        expect(requests[2]?.input).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              type: "function_call_output",
+              call_id: "call_check",
+              output: "checked",
+            }),
+          ]),
+        );
+      }
+    } finally {
+      for (const socket of server.clients) {
+        socket.terminate();
+      }
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
+  });
+});

--- a/packages/agent-core/src/agent-loop.ts
+++ b/packages/agent-core/src/agent-loop.ts
@@ -422,6 +422,9 @@ async function runLoop(
       turnTainted ||= toolResults.some(toolResultTaintsTurn);
       hasMoreToolCalls =
         streamed.continuationRequired ||
+        (message.stopReason === "stop" &&
+          message.endTurn === false &&
+          !executedToolBatch?.terminate) ||
         (executedToolBatch !== undefined && !executedToolBatch.terminate);
       pendingMessages = executedToolBatch?.steeringMessages ?? [];
       if (executedToolBatch?.intervention) {

--- a/packages/ai/src/providers/openai-chatgpt-responses.cache.test.ts
+++ b/packages/ai/src/providers/openai-chatgpt-responses.cache.test.ts
@@ -712,11 +712,22 @@ describe("ChatGPT Responses cached transport", () => {
               phase: "before_message_stream_start",
             },
           },
+          {
+            type: "openai_responses_terminal",
+            timestamp: expect.any(Number),
+            details: { eventType: "response.completed", endTurn: "absent" },
+          },
         ],
       });
       const stickyResult = await runSession("sticky-sse-fallback");
       expect(stickyResult.stopReason).toBe("stop");
-      expect(stickyResult.diagnostics).toBeUndefined();
+      expect(stickyResult.diagnostics).toEqual([
+        {
+          type: "openai_responses_terminal",
+          timestamp: expect.any(Number),
+          details: { eventType: "response.completed", endTurn: "absent" },
+        },
+      ]);
       expect((await runSession("unrelated-sse-fallback")).stopReason).toBe("stop");
       expect(websocketUpgrades).toHaveLength(2);
 

--- a/packages/ai/src/transports/openai-responses-stream-terminal-internal.ts
+++ b/packages/ai/src/transports/openai-responses-stream-terminal-internal.ts
@@ -23,6 +23,7 @@ import type {
   ToolCall,
   Usage,
 } from "../types.js";
+import { appendAssistantMessageDiagnostic } from "../utils/diagnostics.js";
 import { captureOpenAIResponsesCompaction } from "./openai-responses-compaction-replay.js";
 import {
   OPENAI_RESPONSES_COMPACTION_REPLAY_TYPE,
@@ -350,6 +351,19 @@ export function createResponsesTerminalController(params: {
     if (terminalEventType === "response.completed" && typeof response.end_turn === "boolean") {
       output.endTurn = response.end_turn;
     }
+    appendAssistantMessageDiagnostic(output, {
+      type: "openai_responses_terminal",
+      timestamp: Date.now(),
+      details: {
+        eventType: terminalEventType,
+        endTurn:
+          typeof response.end_turn === "boolean"
+            ? response.end_turn
+            : response.end_turn === undefined
+              ? "absent"
+              : "invalid",
+      },
+    });
   };
   return {
     finalizeResponse,

--- a/packages/ai/src/transports/openai-responses-stream-terminal-internal.ts
+++ b/packages/ai/src/transports/openai-responses-stream-terminal-internal.ts
@@ -334,7 +334,7 @@ export function createResponsesTerminalController(params: {
     response: Extract<
       ResponseStreamEvent,
       { type: "response.completed" | "response.incomplete" }
-    >["response"],
+    >["response"] & { end_turn?: unknown },
     terminalEventType: "response.completed" | "response.incomplete",
   ) => {
     backfillReasoning(response.output ?? []);
@@ -347,6 +347,9 @@ export function createResponsesTerminalController(params: {
     });
     output.stopReason = terminal.stopReason;
     output.errorMessage = terminal.errorMessage;
+    if (terminalEventType === "response.completed" && typeof response.end_turn === "boolean") {
+      output.endTurn = response.end_turn;
+    }
   };
   return {
     finalizeResponse,

--- a/packages/llm-core/src/types.ts
+++ b/packages/llm-core/src/types.ts
@@ -406,6 +406,8 @@ export interface AssistantMessage {
   diagnostics?: AssistantMessageDiagnostic[]; // Redacted provider/runtime diagnostics for failures and recoveries.
   usage: Usage;
   stopReason: StopReason;
+  /** A completed provider response can explicitly request another inference with false. */
+  endTurn?: boolean;
   errorMessage?: string;
   errorCode?: string;
   errorType?: string;

--- a/packages/llm-core/src/types.ts
+++ b/packages/llm-core/src/types.ts
@@ -403,7 +403,7 @@ export interface AssistantMessage {
   responseId?: string; // Provider-specific response/message identifier when the upstream API exposes one
   providerReplay?: ProviderReplayState; // Opaque provider state carried into a compatible later request.
   turnId?: string; // Runtime-assigned stable turn identity when the provider does not expose one
-  diagnostics?: AssistantMessageDiagnostic[]; // Redacted provider/runtime diagnostics for failures and recoveries.
+  diagnostics?: AssistantMessageDiagnostic[]; // Redacted provider/runtime completion, failure, and recovery diagnostics.
   usage: Usage;
   stopReason: StopReason;
   /** A completed provider response can explicitly request another inference with false. */


### PR DESCRIPTION
## Summary

### High Level TLDR

An embedded agent can stop after a progress message even when its Responses provider explicitly requests another inference. Preserve `response.completed.response.end_turn` and continue the existing agent loop when it is `false`. Retain a bounded diagnostic on each completed/incomplete response so later inspection can distinguish an explicit flag from an absent or invalid one.

## What Problem This Solves

Fixes an issue where users asking an embedded agent to complete a task would receive a progress message followed by an idle run when the provider returned a text-only response with `end_turn: false`.

## Why This Change Was Made

The shared Responses terminal parser now carries the optional boolean into the assistant outcome. The existing loop uses it for successful responses while retaining cancellation, host stop decisions, tool termination, and the normal behavior when the field is omitted, malformed, or true. Assistant message phases remain unchanged. The existing assistant-message diagnostics carry `openai_responses_terminal` with the terminal event type and `endTurn: true | false | "absent" | "invalid"`. Malformed values are never copied. Read these facts alongside the saved message's stop reason and phase; the provider signal does not establish whether a host stop or cancellation prevented continuation.

### Root Cause

On base `7b374192653da4e57cb7487c67711c1a8b3d543b`, the parser maps a completed text response to `stop`, drops `end_turn`, and the agent loop exits because there are no tool calls or queued messages. The reproduction ends after one request before executing the requested check.

`response.completed` closes one response; it does not necessarily close the agent turn. Codex implements this provider contract in [openai/codex#19610](https://github.com/openai/codex/pull/19610), merged April 26: its Responses parser retains `end_turn`, and the sampling loop requests follow-up inference when it is false. This change supplies the missing behavior in OpenClaw's embedded loop.

Rechecked upstream `f30b8142173` before publication: the affected runtime modules are unchanged and still omit this signal.

## User Impact

Providers that send the explicit continuation signal can proceed from a progress message to tool execution and a completed answer without another user prompt. Existing endpoints that omit the field retain their current behavior. No configuration, dependency, or database schema change is required.

## Evidence

### Verification

- `pnpm build` passed on Node v24.19.0 with an independently installed frozen lockfile.
- `node scripts/check-changed.mjs -- docs/concepts/agent-loop.md packages/agent-core/src/agent-loop.ts packages/agent-core/src/agent-loop.responses-continuation.test.ts packages/ai/src/transports/openai-responses-stream-terminal-internal.ts packages/llm-core/src/types.ts` passed, including core/test type checks, lint, formatting, and the selected guards.
- The original five focused test files passed 256 tests. With the logging addition, the continuation regression and two Responses sibling files passed 159 tests, including all 11 continuation/diagnostic cases. `git diff --check` passed.
- An isolated real-parser/agent-loop → SessionManager → SQLite reopen probe recovered all three assistant diagnostics in order: `{"persistedResponses":3,"endTurn":[false,false,true],"reopenedFromSqlite":true}`.

Repeated loopback workload on the final logging candidate, Node v24.19.0, 10 warmups and 40 measured runs per case: the original version completed zero of 40 progress/tool/answer runs; the patch completed all 40 with one tool execution each. The explicit-end control used one request in both versions (p50 1.004 ms before, 1.011 ms after). The patched three-request workflow took p50 2.747 ms / p95 3.250 ms locally; the original never completed it. These synthetic timings do not measure backend latency.

### Real behavior proof

The regression runs the real native ChatGPT Responses WebSocket adapter and agent loop against a loopback WebSocket server with a harmless synthetic tool:

1. The provider sends a progress message with `end_turn: false`.
2. A second inference returns the check tool call.
3. The tool result is replayed into a third inference, which completes the answer.

Before: the new regression failed with one provider request instead of three. After: three requests, exactly one tool execution, preserved message phase and tool result replay, the completed answer, and one agent completion event. Negative cases cover explicit/omitted/malformed terminal flags, incomplete responses, cancellation, host stops, and intentional tool termination. The same regression checks each response's diagnostic, including null/object malformed values, and verifies that diagnostics are excluded from the next provider request. Before adding diagnostics, the new assertions failed because the terminal evidence was missing.

```sh
node scripts/run-vitest.mjs \
  packages/agent-core/src/agent-loop.responses-continuation.test.ts \
  packages/agent-core/src/agent-loop.test.ts \
  packages/agent-core/src/agent-loop.async-tools.test.ts \
  packages/ai/src/providers/openai-responses-shared.test.ts \
  packages/ai/src/transports/openai-responses-stream-terminal-recovery.test.ts
```

```text
Test Files  5 passed (5)
     Tests  256 passed (256)
```

### What was not tested

This is a confirmed protocol reproduction, not a proven root cause for a particular historical production incident. Historical records did not retain the raw flag. A current live synthetic backend probe completed normally without emitting `end_turn`, so it could not prove this case against that backend. No production Gateway was modified or restarted; live channel delivery and backend latency for this continuation case remain unverified.

The previous head `9be592d24dea082e86a25340f1e3856ae58f912f` failed hosted CI in [run 34717089283](https://github.com/openclaw/openclaw/actions/runs/34717089283). All 12 failed checks traced to an upstream `TS2741` in `src/gateway/server-startup-finish.ts:416`, outside this diff. Maintainer-owned [#146412](https://github.com/openclaw/openclaw/pull/146412) has since merged the matching fix. CI for the logging update is pending. Independent review remains pending.
