### PR TITLE
fix(outbound): guard cross-provider topic mutations

### DIFF
--- a/src/infra/outbound/message-action-routing.context.test.ts
+++ b/src/infra/outbound/message-action-routing.context.test.ts
@@ -337,6 +337,31 @@ describe("runMessageAction context isolation", () => {
       message: /Cross-context messaging denied/,
     },
     {
+      name: "blocks cross-provider topic creation by default",
+      action: "topic-create" as const,
+      cfg: workspaceConfig,
+      actionParams: {
+        channel: "forum",
+        target: "@opsbot",
+        name: "Cross-provider mutation",
+      },
+      toolContext: { currentChannelId: "C12345678", currentChannelProvider: "workspace" },
+      message: /Cross-context messaging denied/,
+    },
+    {
+      name: "blocks cross-provider topic edits by default",
+      action: "topic-edit" as const,
+      cfg: workspaceConfig,
+      actionParams: {
+        channel: "forum",
+        target: "@opsbot",
+        messageThreadId: "42",
+        name: "Updated topic",
+      },
+      toolContext: { currentChannelId: "C12345678", currentChannelProvider: "workspace" },
+      message: /Cross-context messaging denied/,
+    },
+    {
       name: "blocks same-provider cross-context when disabled",
       action: "send" as const,
       cfg: {

--- a/src/infra/outbound/message-action-routing.context.test.ts
+++ b/src/infra/outbound/message-action-routing.context.test.ts
@@ -13,7 +13,7 @@ import {
 } from "./message-action-runner.test-support.js";
 
 const contextFixture = createMessageActionContextFixture();
-const { handleWorkspaceAction } = contextFixture;
+const { handleForumAction, handleWorkspaceAction } = contextFixture;
 
 describe("runMessageAction context isolation", () => {
   beforeEach(() => contextFixture.setup());
@@ -450,6 +450,68 @@ describe("runMessageAction context isolation", () => {
         agentId,
       }),
     ).rejects.toThrow(message);
+  });
+
+  it.each(["topic-create", "topic-edit"] as const)(
+    "denies cross-provider %s before provider adapter dispatch",
+    async (action) => {
+      const outcome = await runMessageAction({
+        cfg: workspaceConfig,
+        action,
+        params: {
+          channel: "forum",
+          target: "@opsbot",
+          name: "Protected topic",
+          ...(action === "topic-edit" ? { messageThreadId: "42" } : {}),
+        },
+        toolContext: {
+          currentChannelId: "C12345678",
+          currentChannelProvider: "workspace",
+        },
+        dryRun: false,
+      }).then(
+        (result) => ({ result, error: undefined }),
+        (error: unknown) => ({ result: undefined, error }),
+      );
+      expect(handleForumAction).not.toHaveBeenCalled();
+      expect(outcome.result).toBeUndefined();
+      expect(outcome.error).toBeInstanceOf(Error);
+      expect((outcome.error as Error).message).toMatch(/Cross-context messaging denied/);
+    },
+  );
+
+  it.each([
+    {
+      name: "same-context",
+      cfg: workspaceConfig,
+      toolContext: { currentChannelId: "@opsbot", currentChannelProvider: "forum" },
+    },
+    {
+      name: "explicit cross-provider opt-in",
+      cfg: {
+        ...workspaceConfig,
+        tools: { message: { crossContext: { allowAcrossProviders: true } } },
+      } as OpenClawConfig,
+      toolContext: { currentChannelId: "C12345678", currentChannelProvider: "workspace" },
+    },
+  ])("dispatches topic actions for $name", async ({ cfg, toolContext }) => {
+    for (const action of ["topic-create", "topic-edit"] as const) {
+      await expect(
+        runMessageAction({
+          cfg,
+          action,
+          params: {
+            channel: "forum",
+            target: "@opsbot",
+            name: "Allowed topic",
+            ...(action === "topic-edit" ? { messageThreadId: "42" } : {}),
+          },
+          toolContext,
+          dryRun: false,
+        }),
+      ).resolves.toMatchObject({ kind: "action", channel: "forum", action });
+    }
+    expect(handleForumAction).toHaveBeenCalledTimes(2);
   });
 
   it("retains direct-operator target-kind validation", async () => {

--- a/src/infra/outbound/message-action-runner.test-support.ts
+++ b/src/infra/outbound/message-action-runner.test-support.ts
@@ -48,6 +48,9 @@ export function createMessageActionContextFixture() {
   const handleWorkspaceAction = vi.fn(async (_ctx: ChannelMessageActionContext) =>
     jsonResult({ ok: true }),
   );
+  const handleForumAction = vi.fn(async (_ctx: ChannelMessageActionContext) =>
+    jsonResult({ ok: true }),
+  );
   const readWorkspaceTestPlugin: ChannelPlugin = {
     ...workspaceTestPlugin,
     actions: {
@@ -114,19 +117,28 @@ export function createMessageActionContextFixture() {
         toolContext.currentMessagingTarget?.replace(/^user:/i, "").toLowerCase(),
     },
   };
+  const forumActionTestPlugin: ChannelPlugin = {
+    ...forumTestPlugin,
+    actions: {
+      describeMessageTool: () => ({ actions: ["topic-create", "topic-edit"] }),
+      handleAction: handleForumAction,
+    },
+  };
   return {
     handleWorkspaceAction,
+    handleForumAction,
     setup(): void {
       setActivePluginRegistry(
         createTestRegistry([
           { pluginId: "workspace", source: "test", plugin: readWorkspaceTestPlugin },
           { pluginId: "directchat", source: "test", plugin: directChatTestPlugin },
-          { pluginId: "forum", source: "test", plugin: forumTestPlugin },
+          { pluginId: "forum", source: "test", plugin: forumActionTestPlugin },
           { pluginId: "localchat", source: "test", plugin: localChatTestPlugin },
           { pluginId: "slackdm", source: "test", plugin: resolvedDmTestPlugin },
         ]),
       );
       handleWorkspaceAction.mockClear();
+      handleForumAction.mockClear();
     },
     cleanup(): void {
       setActivePluginRegistry(createTestRegistry([]));

--- a/src/infra/outbound/outbound-policy.test.ts
+++ b/src/infra/outbound/outbound-policy.test.ts
@@ -228,7 +228,15 @@ describe("outbound policy helpers", () => {
     expectCrossContextPolicyResult(params);
   });
 
-  it.each(["edit", "delete", "pin", "unpin", "poll-vote"] satisfies ChannelMessageActionName[])(
+  it.each([
+    "edit",
+    "delete",
+    "pin",
+    "unpin",
+    "poll-vote",
+    "topic-create",
+    "topic-edit",
+  ] satisfies ChannelMessageActionName[])(
     "blocks cross-provider %s actions by default",
     (action) => {
       expectCrossContextPolicyResult({
@@ -243,7 +251,14 @@ describe("outbound policy helpers", () => {
     },
   );
 
-  it.each(["edit", "delete", "pin", "unpin"] satisfies ChannelMessageActionName[])(
+  it.each([
+    "edit",
+    "delete",
+    "pin",
+    "unpin",
+    "topic-create",
+    "topic-edit",
+  ] satisfies ChannelMessageActionName[])(
     "allows cross-provider %s actions when explicitly enabled",
     (action) => {
       expectCrossContextPolicyResult({
@@ -263,7 +278,14 @@ describe("outbound policy helpers", () => {
     },
   );
 
-  it.each(["edit", "delete", "pin", "unpin"] satisfies ChannelMessageActionName[])(
+  it.each([
+    "edit",
+    "delete",
+    "pin",
+    "unpin",
+    "topic-create",
+    "topic-edit",
+  ] satisfies ChannelMessageActionName[])(
     "allows current-context %s actions without cross-provider opt-in",
     (action) => {
       expectCrossContextPolicyResult({
@@ -348,6 +370,8 @@ describe("outbound policy helpers", () => {
     { action: "upload-file", expected: true },
     { action: "thread-reply", expected: true },
     { action: "thread-create", expected: false },
+    { action: "topic-create", expected: false },
+    { action: "topic-edit", expected: false },
   ] satisfies Array<{ action: ChannelMessageActionName; expected: boolean }>)(
     "marks supported cross-context action %j",
     ({ action, expected }) => {

--- a/src/infra/outbound/outbound-policy.ts
+++ b/src/infra/outbound/outbound-policy.ts
@@ -43,6 +43,8 @@ const CONTEXT_GUARDED_ACTIONS = new Set<ChannelMessageActionName>([
   "unpin",
   "thread-create",
   "thread-reply",
+  "topic-create",
+  "topic-edit",
   "sticker",
 ]);
 


### PR DESCRIPTION
Cross-provider topic creation and editing could bypass the outbound context policy because those actions were absent from the central guarded-action set. This change routes both mutations through the existing default-deny boundary established by https://github.com/openclaw/openclaw/pull/93358, while preserving same-context operations and the explicit operator opt-in.

## What was wrong

1. `src/infra/outbound/outbound-policy.ts` guarded sends and common message mutations, but omitted `topic-create` and `topic-edit`.
2. A tool call bound to one provider could therefore target another provider with either topic mutation without `tools.message.crossContext.allowAcrossProviders: true`.
3. Non-dry runner proof now confirms that both affected calls reached the provider action adapter under the legacy classification.

The net effect was inconsistent enforcement of the documented cross-provider default-deny policy for topic management.

## Why this design

- Enforce the rule in the shared outbound policy so every provider using the message-action runner receives the same protection.
- Reuse the existing `CONTEXT_GUARDED_ACTIONS` mechanism instead of adding provider-specific checks.
- Preserve same-context topic operations and the existing explicit cross-provider opt-in.
- Keep topic mutations out of forwarding-marker logic because they do not create ordinary outbound message content.
- Verify the final authorization effect at the adapter boundary, not only from an error message or dry-run result.

## Why this does not conflict with related work

| Related work | Governed layer | Relationship |
|---|---|---|
| https://github.com/openclaw/openclaw/pull/93358 | Central outbound cross-context policy | This change extends the same established boundary to two omitted topic actions; it does not alter provider-specific reaction, presence, or administration semantics. |

The branch is based on a revision that already contains that policy work.

## How enforcement changed

Before — v2026.9.4 (vulnerable):

```mermaid
flowchart TB
    A1["Tool call bound to Slack<br/>(current provider = slack)"] --> B1{"runMessageAction"}
    B1 --> C1{"enforceCrossContextPolicy<br/>action in CONTEXT_GUARDED_ACTIONS?"}
    C1 -- "send / edit / delete / pin / unpin" --> D1["❌ Cross-context messaging denied<br/>(config enforced)"]
    C1 -- "topic-create / topic-edit<br/>NOT in guarded set" --> E1["⏭️ early return —<br/>provider & target checks skipped"]
    E1 --> F1["✅ provider action adapter dispatched<br/>despite allowAcrossProviders: false<br/>(config ignored)"]
```

After — this PR:

```mermaid
flowchart TB
    A2["Tool call bound to Slack<br/>(current provider = slack)"] --> B2{"runMessageAction"}
    B2 --> C2{"enforceCrossContextPolicy<br/>action in CONTEXT_GUARDED_ACTIONS?"}
    C2 -- "send / edit / delete / pin / unpin" --> D2["❌ Cross-context messaging denied<br/>(unchanged)"]
    C2 -- "topic-create / topic-edit<br/>now guarded" --> G2{"Cross-provider and<br/>allowAcrossProviders: true?"}
    G2 -- "no (default)" --> H2["❌ Cross-context messaging denied<br/>0 adapter dispatches"]
    G2 -- "yes (explicit opt-in)" --> I2["✅ dispatched (unchanged)"]
    C2 -- "same provider, cross target" --> J2{"allowWithinProvider<br/>(default: true)"}
    J2 -- "true" --> I2
    J2 -- "false" --> H2
```

The only behavioral delta is the `topic-create` / `topic-edit` branch: before, it fell through the guard to dispatch; after, it joins the same deny/opt-in decision every other mutation already had. Same-context and opt-in paths are byte-identical.

## Evidence

| Path and mode | Legacy classification | Patched result | Final-effect observation |
|---|---|---|---|
| Default cross-provider `topic-create` | Allowed | Denied | Legacy-policy reproduction invoked the non-dry provider adapter once; patched head invoked it zero times |
| Default cross-provider `topic-edit` | Allowed | Denied | Legacy-policy reproduction invoked the non-dry provider adapter once; patched head invoked it zero times |
| Same-context `topic-create` / `topic-edit` | Allowed | Allowed | Patched head dispatched both actions through the provider adapter |
| Explicit `allowAcrossProviders: true` | Allowed | Allowed | Patched head dispatched both actions through the provider adapter |
| Topic mutation forwarding marker | Not applied | Not applied | Marker classification tests remain false for both actions |

The sink-level observation is the provider action adapter spy: default cross-provider calls stop before it, while preserved allowed paths reach it.

## SDK / caller upgrade contract

Callers operating within the current conversation keep access. Cross-provider callers that already set `tools.message.crossContext.allowAcrossProviders: true` also keep access. Callers that relied on the omission now fail closed and must use that existing opt-in; additionally, same-provider cross-target calls continue to honor the existing `allowWithinProvider` setting. The non-dry runner tests cover both retained paths and both newly denied mutations.

## Boundary decisions requested from maintainers

1. **Outbound-policy maintainers:** accept immediate alignment of topic mutations with the existing cross-context default-deny contract, including the upgrade impact on callers that relied on the omission.
2. **Telegram maintainers:** confirm whether the non-dry central-runner adapter proof is sufficient for this provider-independent policy change or whether release credentials for a Telegram Test Server run are required before merge.

## Testing

- `pnpm test src/infra/outbound/outbound-policy.test.ts src/infra/outbound/message-action-routing.context.test.ts` — 67 tests passed across both Vitest shards.
- Legacy-policy reproduction with the same non-dry runner tests — four expected failures: both prior dry-run bypasses and both provider-adapter dispatches were observed.
- Type-aware oxlint passed for all four touched files.
- `git diff --check` passed.
- Branch autoreview reported no actionable P0–P2 findings.
- A Telegram Test Server run was not available because the QA broker prerequisite is not configured on the contributor host; no live-provider claim is inferred from the adapter proof.
