### PR TITLE
fix(docs): restore publishing without changing existing anchors

### DIFF
--- a/package.json
+++ b/package.json
@@ -2249,7 +2249,7 @@
     "@shikijs/core": "4.4.3",
     "@shikijs/engine-javascript": "4.4.3",
     "@shikijs/engine-oniguruma": "4.4.3",
-    "@sindresorhus/slugify": "3.0.1",
+    "@sindresorhus/slugify": "2.2.1",
     "@types/express": "5.0.6",
     "@types/hosted-git-info": "3.0.5",
     "@types/jsdom": "30.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -401,8 +401,8 @@ importers:
         specifier: 4.4.3
         version: 4.4.3
       '@sindresorhus/slugify':
-        specifier: 3.0.1
-        version: 3.0.1
+        specifier: 2.2.1
+        version: 2.2.1
       '@types/express':
         specifier: 5.0.6
         version: 5.0.6
@@ -5133,13 +5133,13 @@ packages:
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
     engines: {node: '>=18'}
 
-  '@sindresorhus/slugify@3.0.1':
-    resolution: {integrity: sha512-N1oPvN6sytRKZCskv0L+vSyvnUYi9JplPXZ90lT6EBsijjHrUdoXttb0Lna6pw1TWMe8vlajQnLDtU9KYHqtDg==}
-    engines: {node: '>=20'}
+  '@sindresorhus/slugify@2.2.1':
+    resolution: {integrity: sha512-MkngSCRZ8JdSOCHRaYd+D01XhvU3Hjy6MGl06zhOk614hp9EOAp5gIkBeQg7wtmxpitU6eAL4kdiRMcJa2dlrw==}
+    engines: {node: '>=12'}
 
-  '@sindresorhus/transliterate@2.3.1':
-    resolution: {integrity: sha512-gVaaGtKYMYAMmI8buULVH3A2TXVJ98QiwGwI7ddrWGuGidGC2uRt4FHs22+8iROJ0QTzju9CuMjlVsrvpqsdhA==}
-    engines: {node: '>=20'}
+  '@sindresorhus/transliterate@1.6.0':
+    resolution: {integrity: sha512-doH1gimEu3A46VX6aVxpHTeHrytJAG6HgdxntYnCFiIFHEM/ZGpG8KiZGBChchjQmG0XFIBL552kBTjVcMZXwQ==}
+    engines: {node: '>=12'}
 
   '@slack/bolt@5.1.0':
     resolution: {integrity: sha512-lSQzEs/OMDVIbTVb+ZXZa7zsYGvnB1d58CnK55vdYdVeSmHMON1RjSgPf3lGUE9lYhNTUIjbFCrCrsJ1j5SAUA==}
@@ -12549,12 +12549,14 @@ snapshots:
 
   '@sindresorhus/merge-streams@4.0.0': {}
 
-  '@sindresorhus/slugify@3.0.1':
+  '@sindresorhus/slugify@2.2.1':
     dependencies:
-      '@sindresorhus/transliterate': 2.3.1
+      '@sindresorhus/transliterate': 1.6.0
       escape-string-regexp: 5.0.0
 
-  '@sindresorhus/transliterate@2.3.1': {}
+  '@sindresorhus/transliterate@1.6.0':
+    dependencies:
+      escape-string-regexp: 5.0.0
 
   '@slack/bolt@5.1.0(@types/express@5.0.6)(supports-color@10.2.2)(undici@7.29.1)':
     dependencies:

--- a/test/scripts/docs-markdown.test.ts
+++ b/test/scripts/docs-markdown.test.ts
@@ -2,6 +2,16 @@ import { describe, expect, it } from "vitest";
 import { createDocsMarkdown, parseDocsDocument } from "../../scripts/lib/docs-markdown.mjs";
 
 describe("docs Markdown rendering", () => {
+  it("preserves published acronym and localized component anchors", () => {
+    // A slugify upgrade must preserve targets in the publisher's MDX and locales too.
+    const document = parseDocsDocument(
+      '<ParamField body="APIUsage">Usage</ParamField>\n\n' +
+        '<Accordion title="سلوك إعادة المحاولة">Retry</Accordion>',
+    );
+
+    expect(document.ids).toEqual(["param-apiusage", "slwk-ieadt-almhawlt"]);
+  });
+
   it.each(["", "> "].flatMap((quote) => ["html", "jsx"].map((kind) => ({ quote, kind }))))(
     "keeps list fences after multiline $kind with prefix $quote",
     ({ quote, kind }) => {


### PR DESCRIPTION
## What Problem This Solves

Fixes docs publishing stopping after the dependency refresh in #146258 because source and publisher slugify versions diverged.

## User Impact

Docs updates can sync again while existing English, localized, and MDX component links keep their published targets.

## Why This Change Was Made

Restore the source-owned slugify pin to 2.2.1 and regenerate only its dependency closure in the pnpm lock. This follows the [existing maintainer direction](https://github.com/openclaw/docs/pull/172#issuecomment-5577912409) to retain 2.2.1 until a coordinated compatibility migration. The other dependency upgrades, shared parser, and sync dependency guard remain unchanged. A focused regression covers the acronym and Arabic component anchors affected by 3.0.1.

## Evidence

- Reproduced the exact `docs sync changed unrelated publisher dependencies` failure through the real sync CLI against an isolated copy of publisher main `7980b7c`: npm also changed transliterate from 1.6.0 to 2.3.1. With this fix, that CLI succeeds and the publisher manifest and npm lock remain byte-identical to its main branch. The isolated run reused a ClawHub source snapshot; it did not publish or deploy.
- Identical shared parser bytes produce `param-api-usage` / `slwk-aeadt-almhawlt` with 3.0.1 and retain `param-apiusage` / `slwk-ieadt-almhawlt` with 2.2.1. Before/after assertions fail then pass, respectively.
- All 37 focused docs parser and docs-sync tests pass. pnpm 12.3.4 lock regeneration and frozen-lock validation, repository formatting, and `git diff --check` pass.
- Independent review found no actionable P0–P2 findings. Full product suites and hosted deployment were not run for this scoped dependency repair.
