### PR TITLE
fix(gateway): clean up TLS renewal during shutdown

### DIFF
--- a/extensions/openai/realtime-quicksilver-gateway-direct.test.ts
+++ b/extensions/openai/realtime-quicksilver-gateway-direct.test.ts
@@ -326,7 +326,8 @@ describe("GPT-Live Gateway direct transport", () => {
       expect(fetchImpl).not.toHaveBeenCalled();
 
       bridge.sendAudio(Buffer.from([0x01, 0x02]));
-      vi.useFakeTimers();
+      // Keep the integer-second expiry independent of the wall clock's fractional second.
+      vi.useFakeTimers({ now: new Date("2026-01-01T00:00:00.000Z") });
       emitSideband(connectedSocket, {
         type: "session.started",
         session: { expires_at: Math.floor(Date.now() / 1000) + 1 },
@@ -359,6 +360,7 @@ describe("GPT-Live Gateway direct transport", () => {
           parseSent(connectedSocket).filter((event) => event.type === "delegation.context.append"),
         ).toHaveLength(1),
       );
+      expect(onClose).not.toHaveBeenCalled();
       await vi.advanceTimersByTimeAsync(1_000);
       expect(onClose).toHaveBeenCalledExactlyOnceWith("completed");
     } finally {

--- a/src/gateway/server-startup-finish.ts
+++ b/src/gateway/server-startup-finish.ts
@@ -413,7 +413,7 @@ export async function finishGatewayStartup(params: {
     log: log.child("tls"),
   });
   if (tlsRenewal) {
-    registerGatewayLifetimeSidecars([tlsRenewal]);
+    registerGatewayLifetimeSidecars(tlsRenewal);
   }
   const configReloaderParams: Parameters<typeof startManagedGatewayConfigReloader>[0] = {
     onReloadEnabledChange: tlsRenewal?.setEnabled,


### PR DESCRIPTION
Superseded by #146412 (TLS lifetime registration) and #146312 (realtime fixture clock). Both merge commits are verified ancestors of current main `82ab1e1f58123a98e4506b11685fca0733fd3b49`, whose source contains the direct sidecar handle and equivalent whole-second clock. Closing this overlapping PR; its remaining pre-expiry assertion does not warrant a separate change. The causal proof and passing CI on this branch remain recorded below.

Related: #146275, #146267.

## What Problem This Solves

TLS renewal was registered with the wrong argument shape after the sidecar API became variadic, breaking type checks and preventing the shutdown owner from calling its cleanup method.

## User Impact

TLS-enabled Gateways retain their renewal cleanup during shutdown, and the affected CI type checks compile again.

## Why This Change Was Made

Pass the existing renewal handle directly to the existing Gateway lifetime owner, completing the caller migration in #146275.

CI also exposed an independent realtime test race: its rounded expiry could leave the mock session less than 50 milliseconds to live. Pin the fake clock to a whole second, retaining the one-second expiry, every existing assertion, and an explicit check that the session stays open until the deliberate expiry step.

## Evidence

The [original type failure](https://github.com/openclaw/openclaw/actions/runs/34716837412/job/103615587173) identifies the exact production call. All 13 TLS renewal and Gateway kernel lifetime tests pass with the current pinned dependencies.

The [realtime CI failure](https://github.com/openclaw/openclaw/actions/runs/34718165102/job/103619142464) was reproduced by controlling only the initial clock: a whole-second origin passes, while an end-of-second origin fails the same delegation assertion. The final fixture passes all eight direct-transport tests. The complete two-file changed check passes, including production and test type checks.

Fresh independent review of the complete two-file candidate found no actionable P0–P2 findings.
