### PR TITLE
fix(groq): resolve manifest model during external setup

### DIFF
--- a/extensions/groq/openclaw.plugin.json
+++ b/extensions/groq/openclaw.plugin.json
@@ -5,6 +5,7 @@
     "onStartup": false
   },
   "enabledByDefault": true,
+  "providerCatalogEntry": "./provider-discovery.ts",
   "providers": ["groq"],
   "providerEndpoints": [
     {

--- a/extensions/groq/provider-discovery.test.ts
+++ b/extensions/groq/provider-discovery.test.ts
@@ -1,0 +1,30 @@
+import type { ProviderCatalogContext } from "openclaw/plugin-sdk/provider-catalog-shared";
+import { describe, expect, it } from "vitest";
+
+describe("Groq provider discovery entry", () => {
+  it("publishes manifest models through the static catalog", async () => {
+    const { default: provider } = await import("./provider-discovery.js");
+    const ctx: ProviderCatalogContext = {
+      config: {},
+      env: {},
+      resolveProviderApiKey: () => ({ apiKey: undefined }),
+      resolveProviderAuth: () => ({ apiKey: undefined, mode: "none", source: "none" }),
+    };
+
+    await expect(provider.staticCatalog?.run(ctx)).resolves.toMatchObject({
+      provider: {
+        baseUrl: "https://api.groq.com/openai/v1",
+        api: "openai-completions",
+        models: expect.arrayContaining([
+          expect.objectContaining({
+            id: "openai/gpt-oss-120b",
+            name: "GPT OSS 120B",
+            reasoning: true,
+            contextWindow: 131_072,
+            maxTokens: 65_536,
+          }),
+        ]),
+      },
+    });
+  });
+});

--- a/extensions/groq/provider-discovery.ts
+++ b/extensions/groq/provider-discovery.ts
@@ -1,0 +1,23 @@
+import { buildManifestModelProviderConfig } from "openclaw/plugin-sdk/provider-model-metadata";
+import type { ProviderPlugin } from "openclaw/plugin-sdk/provider-model-shared";
+import manifest from "./openclaw.plugin.json" with { type: "json" };
+
+const PROVIDER_ID = "groq";
+
+const groqProviderDiscovery: ProviderPlugin = {
+  id: PROVIDER_ID,
+  label: "Groq",
+  docsPath: "/providers/groq",
+  auth: [],
+  staticCatalog: {
+    order: "simple",
+    run: async () => ({
+      provider: buildManifestModelProviderConfig({
+        providerId: PROVIDER_ID,
+        catalog: manifest.modelCatalog.providers.groq,
+      }),
+    }),
+  },
+};
+
+export default groqProviderDiscovery;

--- a/scripts/lib/vitest-worker-build-entries.mts
+++ b/scripts/lib/vitest-worker-build-entries.mts
@@ -30,6 +30,7 @@ import {
   agentDatabaseHeldRuntimeEntrypoint,
   stateLeaseProcessExitRuntimeEntrypoint,
 } from "../../src/state/openclaw-state-lease-runtime.test-support.ts";
+import { groqSetupSdkEntrypoints } from "../../src/system-agent/setup-inference-groq-sdk.test-support.ts";
 import { tuiPtyRuntimeEntrypoints } from "../../src/tui/tui-pty-runtime-test-support.ts";
 import { channelIngressGatewayRestartEntrypoint } from "../../test/fixtures/channel-ingress-gateway-restart-entrypoint.ts";
 import { runtimeProcessBuildEntries } from "./runtime-process-build-entries.mts";
@@ -46,6 +47,7 @@ export const vitestWorkerBuildEntries = {
       ...cliCompactionBackendEntrypoints,
       ...publishedSdkBridgeEntrypoints,
       mcpProviderCatalogEntrypoint,
+      ...groqSetupSdkEntrypoints,
       ...Object.values(cliRecoveryEntrypoints),
       ...Object.values(updateExecutorNativeEntrypoints),
       ...Object.values(gatewayDirectStopEntrypoints),

--- a/scripts/lib/vitest-worker-declarations.mts
+++ b/scripts/lib/vitest-worker-declarations.mts
@@ -24,6 +24,8 @@ export const vitestWorkerDeclarationEntries = {
     "extensions/qa-lab/src/gateway-child-artifacts-runtime.test-support.ts",
   "plugins/loader-sdk-bridge-artifacts.test-support":
     "src/plugins/loader-sdk-bridge-artifacts.test-support.ts",
+  "system-agent/setup-inference-groq-sdk.test-support":
+    "src/system-agent/setup-inference-groq-sdk.test-support.ts",
   "agents/code-mode-retention-entrypoint.test-support":
     "src/agents/code-mode-retention-entrypoint.test-support.ts",
   "agents/command/cli-compaction-runtime.test-support":

--- a/src/system-agent/setup-inference-groq-sdk.test-support.ts
+++ b/src/system-agent/setup-inference-groq-sdk.test-support.ts
@@ -1,0 +1,14 @@
+// External Groq fixtures consume native SDK exports from the current test generation.
+const currentModuleUrl = import.meta.url;
+export const groqSetupSdkEntrypoints = [
+  {
+    currentModuleUrl,
+    sourceWorkerName: "../plugin-sdk/provider-entry",
+    distWorkerPath: "plugin-sdk/provider-entry.js",
+  },
+  {
+    currentModuleUrl,
+    sourceWorkerName: "../plugin-sdk/provider-model-metadata",
+    distWorkerPath: "plugin-sdk/provider-model-metadata.js",
+  },
+] as const;

--- a/src/system-agent/setup-inference.groq-external.integration.test.ts
+++ b/src/system-agent/setup-inference.groq-external.integration.test.ts
@@ -4,6 +4,7 @@ import http from "node:http";
 import path from "node:path";
 import { configureAiTransportHost, getAiTransportHost } from "@openclaw/ai";
 import { afterEach, expect, it } from "vitest";
+import { writePersistedInstalledPluginIndexInstallRecords } from "../plugins/installed-plugin-index-records.js";
 import { resetPluginLoaderTestStateForTest } from "../plugins/loader.test-fixtures.js";
 import { waitForPluginCacheRetirement } from "../plugins/plugin-cache.js";
 import { clearPluginMetadataLifecycleCaches } from "../plugins/plugin-metadata-lifecycle.js";
@@ -32,7 +33,18 @@ it("resolves a Groq manifest model from a global external install during setup",
     async (state) => {
       const pluginDir = state.statePath("extensions", "groq");
       await fs.cp(path.join(process.cwd(), "extensions", "groq"), pluginDir, { recursive: true });
-      await state.writeConfig({ plugins: { entries: { groq: { enabled: true } } } });
+      const config = { plugins: { entries: { groq: { enabled: true } } } };
+      await state.writeConfig(config);
+      await writePersistedInstalledPluginIndexInstallRecords(
+        {
+          groq: {
+            source: "path",
+            sourcePath: pluginDir,
+            installPath: pluginDir,
+          },
+        },
+        { config, env: state.env },
+      );
 
       const requests: Array<{ method?: string; url?: string }> = [];
       const runtimeErrors: string[] = [];

--- a/src/system-agent/setup-inference.groq-external.integration.test.ts
+++ b/src/system-agent/setup-inference.groq-external.integration.test.ts
@@ -69,6 +69,22 @@ export default defineSingleProviderPluginEntry({
   provider: {
     label: "Groq",
     docsPath: "/providers/groq",
+    auth: [{
+      methodId: "api-key",
+      label: "Groq API key",
+      optionKey: "groqApiKey",
+      flagName: "--groq-api-key",
+      envVar: "GROQ_API_KEY",
+      promptMessage: "Enter Groq API key",
+      defaultModel: "groq/openai/gpt-oss-120b",
+      wizard: {
+        choiceId: "groq-api-key",
+        choiceLabel: "Groq API key",
+        groupId: "groq",
+        groupLabel: "Groq",
+        onboardingScopes: ["text-inference"],
+      },
+    }],
     catalog: { liveModelDiscovery: true, discoveryMode: "strict" },
   },
 });

--- a/src/system-agent/setup-inference.groq-external.integration.test.ts
+++ b/src/system-agent/setup-inference.groq-external.integration.test.ts
@@ -44,6 +44,19 @@ it("resolves a Groq manifest model from a global external install during setup",
       // fixture self-contained while retaining the real Groq manifest and
       // provider-discovery entry under test.
       await fs.writeFile(
+        path.join(pluginDir, "package.json"),
+        JSON.stringify({
+          name: "@openclaw/groq-provider",
+          version: "2026.9.4",
+          type: "module",
+          openclaw: {
+            extensions: ["./index.ts"],
+            build: { bundledDist: false },
+          },
+        }),
+        "utf8",
+      );
+      await fs.writeFile(
         path.join(pluginDir, "index.ts"),
         `import { defineSingleProviderPluginEntry } from "openclaw/plugin-sdk/provider-entry";
 import manifest from "./openclaw.plugin.json" with { type: "json" };

--- a/src/system-agent/setup-inference.groq-external.integration.test.ts
+++ b/src/system-agent/setup-inference.groq-external.integration.test.ts
@@ -35,6 +35,7 @@ it("resolves a Groq manifest model from a global external install during setup",
       await state.writeConfig({ plugins: { entries: { groq: { enabled: true } } } });
 
       const requests: Array<{ method?: string; url?: string }> = [];
+      const runtimeErrors: string[] = [];
       const server = http.createServer((request, response) => {
         requests.push({ method: request.method, url: request.url });
         response.writeHead(200, { "content-type": "text/event-stream; charset=utf-8" });
@@ -83,14 +84,16 @@ it("resolves a Groq manifest model from a global external install during setup",
           surface: "gateway",
           runtime: {
             log: () => {},
-            error: () => {},
+            error: (message) => {
+              runtimeErrors.push(message);
+            },
             exit: (code) => {
               throw new Error(`exit ${code}`);
             },
           },
         });
 
-        expect(result).toMatchObject({
+        expect(result, JSON.stringify({ result, runtimeErrors, requests })).toMatchObject({
           ok: true,
           modelRef: "groq/openai/gpt-oss-120b",
         });

--- a/src/system-agent/setup-inference.groq-external.integration.test.ts
+++ b/src/system-agent/setup-inference.groq-external.integration.test.ts
@@ -4,7 +4,10 @@ import http from "node:http";
 import path from "node:path";
 import { configureAiTransportHost, getAiTransportHost } from "@openclaw/ai";
 import { afterEach, expect, it } from "vitest";
-import { writePersistedInstalledPluginIndexInstallRecords } from "../plugins/installed-plugin-index-records.js";
+import {
+  clearLoadInstalledPluginIndexInstallRecordsCache,
+  writePersistedInstalledPluginIndexInstallRecords,
+} from "../plugins/installed-plugin-index-records.js";
 import { resetPluginLoaderTestStateForTest } from "../plugins/loader.test-fixtures.js";
 import { waitForPluginCacheRetirement } from "../plugins/plugin-cache.js";
 import { clearPluginMetadataLifecycleCaches } from "../plugins/plugin-metadata-lifecycle.js";
@@ -45,6 +48,7 @@ it("resolves a Groq manifest model from a global external install during setup",
         },
         { config, env: state.env },
       );
+      clearLoadInstalledPluginIndexInstallRecordsCache();
 
       const requests: Array<{ method?: string; url?: string }> = [];
       const runtimeErrors: string[] = [];

--- a/src/system-agent/setup-inference.groq-external.integration.test.ts
+++ b/src/system-agent/setup-inference.groq-external.integration.test.ts
@@ -22,6 +22,9 @@ afterEach(async () => {
 });
 
 it("resolves a Groq manifest model from a global external install during setup", async () => {
+  clearPluginMetadataLifecycleCaches();
+  resetPluginLoaderTestStateForTest();
+  clearLoadInstalledPluginIndexInstallRecordsCache();
   await withOpenClawTestState(
     {
       label: "groq-external-setup",

--- a/src/system-agent/setup-inference.groq-external.integration.test.ts
+++ b/src/system-agent/setup-inference.groq-external.integration.test.ts
@@ -123,6 +123,20 @@ it("resolves a Groq manifest model from a global external install during setup",
           workspaceDir: state.workspaceDir,
           env: state.env,
         });
+        const runtimeProviders = (await import("../plugins/providers.runtime.js"))
+          .resolvePluginProvidersCore({
+            config,
+            workspaceDir: state.workspaceDir,
+            env: state.env,
+            mode: "setup",
+            cache: false,
+            onlyPluginIds: ["groq"],
+          })
+          .map((provider) => ({
+            pluginId: provider.pluginId,
+            id: provider.id,
+            auth: provider.auth.map((method) => method.id),
+          }));
         expect(
           result,
           JSON.stringify({
@@ -131,6 +145,7 @@ it("resolves a Groq manifest model from a global external install during setup",
             requests,
             persistedInstallRecords,
             manifestChoices,
+            runtimeProviders,
           }),
         ).toMatchObject({
           ok: true,

--- a/src/system-agent/setup-inference.groq-external.integration.test.ts
+++ b/src/system-agent/setup-inference.groq-external.integration.test.ts
@@ -11,6 +11,7 @@ import {
 import { resetPluginLoaderTestStateForTest } from "../plugins/loader.test-fixtures.js";
 import { waitForPluginCacheRetirement } from "../plugins/plugin-cache.js";
 import { clearPluginMetadataLifecycleCaches } from "../plugins/plugin-metadata-lifecycle.js";
+import { resolvePluginProvidersCore } from "../plugins/providers.runtime.js";
 import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import { activateSetupInference } from "./setup-inference-activate.js";
 
@@ -48,10 +49,24 @@ it("resolves a Groq manifest model from a global external install during setup",
         JSON.stringify({
           name: "@openclaw/groq-provider",
           version: "2026.9.4",
+          description: "OpenClaw Groq media-understanding provider.",
+          repository: {
+            type: "git",
+            url: "https://github.com/openclaw/openclaw",
+          },
           type: "module",
+          devDependencies: { "@openclaw/plugin-sdk": "workspace:*" },
           openclaw: {
             extensions: ["./index.ts"],
+            install: {
+              clawhubSpec: "clawhub:@openclaw/groq-provider",
+              npmSpec: "@openclaw/groq-provider",
+              defaultChoice: "npm",
+              minHostVersion: ">=2026.6.8",
+            },
+            compat: { pluginApi: ">=2026.9.4" },
             build: { bundledDist: false },
+            release: { publishToClawHub: true, publishToNpm: true },
           },
         }),
         "utf8",
@@ -104,6 +119,20 @@ export default defineSingleProviderPluginEntry({
         { config, env: state.env },
       );
       clearLoadInstalledPluginIndexInstallRecordsCache();
+
+      const runtimeProviders = resolvePluginProvidersCore({
+        config,
+        workspaceDir: state.workspaceDir,
+        env: state.env,
+        mode: "setup",
+        cache: false,
+        includeUntrustedWorkspacePlugins: false,
+        onlyPluginIds: ["groq"],
+      }).map((provider) => ({
+        id: provider.id,
+        pluginId: provider.pluginId,
+        auth: provider.auth.map((method) => ({ id: method.id, wizard: method.wizard })),
+      }));
 
       const requests: Array<{ method?: string; url?: string }> = [];
       const runtimeErrors: string[] = [];
@@ -164,7 +193,10 @@ export default defineSingleProviderPluginEntry({
           },
         });
 
-        expect(result, JSON.stringify({ result, runtimeErrors, requests })).toMatchObject({
+        expect(
+          result,
+          JSON.stringify({ result, runtimeErrors, requests, runtimeProviders }),
+        ).toMatchObject({
           ok: true,
           modelRef: "groq/openai/gpt-oss-120b",
         });

--- a/src/system-agent/setup-inference.groq-external.integration.test.ts
+++ b/src/system-agent/setup-inference.groq-external.integration.test.ts
@@ -21,7 +21,13 @@ it("resolves a Groq manifest model from a global external install during setup",
   await withOpenClawTestState(
     {
       label: "groq-external-setup",
-      env: { OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1" },
+      env: {
+        OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+        OPENCLAW_DISABLE_BUNDLED_SOURCE_OVERLAYS: "1",
+        OPENCLAW_BUNDLED_PLUGINS_DIR: undefined,
+        OPENCLAW_DEV_SOURCE_ROOT: undefined,
+        OPENCLAW_SKIP_PROVIDERS: undefined,
+      },
     },
     async (state) => {
       const pluginDir = state.statePath("extensions", "groq");

--- a/src/system-agent/setup-inference.groq-external.integration.test.ts
+++ b/src/system-agent/setup-inference.groq-external.integration.test.ts
@@ -4,6 +4,7 @@ import http from "node:http";
 import path from "node:path";
 import { configureAiTransportHost, getAiTransportHost } from "@openclaw/ai";
 import { afterEach, expect, it } from "vitest";
+import { resolveOpenClawPackageRootSync } from "../infra/openclaw-root.js";
 import {
   clearLoadInstalledPluginIndexInstallRecordsCache,
   writePersistedInstalledPluginIndexInstallRecords,
@@ -107,6 +108,16 @@ export default defineSingleProviderPluginEntry({
 `,
         "utf8",
       );
+      const hostRoot = resolveOpenClawPackageRootSync({
+        argv1: process.argv[1],
+        moduleUrl: import.meta.url,
+        cwd: process.cwd(),
+      });
+      if (!hostRoot) {
+        throw new Error("test host package root is unavailable");
+      }
+      await fs.mkdir(path.join(pluginDir, "node_modules"), { recursive: true });
+      await fs.symlink(hostRoot, path.join(pluginDir, "node_modules", "openclaw"), "junction");
       const config = { plugins: { entries: { groq: { enabled: true } } } };
       await state.writeConfig(config);
       await writePersistedInstalledPluginIndexInstallRecords(

--- a/src/system-agent/setup-inference.groq-external.integration.test.ts
+++ b/src/system-agent/setup-inference.groq-external.integration.test.ts
@@ -8,11 +8,9 @@ import {
   clearLoadInstalledPluginIndexInstallRecordsCache,
   writePersistedInstalledPluginIndexInstallRecords,
 } from "../plugins/installed-plugin-index-records.js";
-import { loadOpenClawPlugins } from "../plugins/loader-runtime-load.js";
 import { resetPluginLoaderTestStateForTest } from "../plugins/loader.test-fixtures.js";
 import { waitForPluginCacheRetirement } from "../plugins/plugin-cache.js";
 import { clearPluginMetadataLifecycleCaches } from "../plugins/plugin-metadata-lifecycle.js";
-import { resolvePluginProvidersCore } from "../plugins/providers.runtime.js";
 import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import { activateSetupInference } from "./setup-inference-activate.js";
 
@@ -57,6 +55,8 @@ it("resolves a Groq manifest model from a global external install during setup",
           },
           type: "module",
           devDependencies: { "@openclaw/plugin-sdk": "workspace:*" },
+          peerDependencies: { openclaw: ">=2026.9.4" },
+          peerDependenciesMeta: { openclaw: { optional: true } },
           openclaw: {
             extensions: ["./index.ts"],
             install: {
@@ -120,35 +120,6 @@ export default defineSingleProviderPluginEntry({
         { config, env: state.env },
       );
       clearLoadInstalledPluginIndexInstallRecordsCache();
-
-      const runtimeProviders = resolvePluginProvidersCore({
-        config,
-        workspaceDir: state.workspaceDir,
-        env: state.env,
-        mode: "setup",
-        cache: false,
-        includeUntrustedWorkspacePlugins: false,
-        onlyPluginIds: ["groq"],
-      }).map((provider) => ({
-        id: provider.id,
-        pluginId: provider.pluginId,
-        auth: provider.auth.map((method) => ({ id: method.id, wizard: method.wizard })),
-      }));
-      const registryDiagnostics: string[] = [];
-      const runtimeRegistry = loadOpenClawPlugins({
-        config,
-        workspaceDir: state.workspaceDir,
-        env: state.env,
-        mode: "full",
-        cache: false,
-        activate: false,
-        onlyPluginIds: ["groq"],
-        logger: {
-          info: (message) => registryDiagnostics.push(`info:${String(message)}`),
-          warn: (message) => registryDiagnostics.push(`warn:${String(message)}`),
-          error: (message) => registryDiagnostics.push(`error:${String(message)}`),
-        },
-      });
 
       const requests: Array<{ method?: string; url?: string }> = [];
       const runtimeErrors: string[] = [];
@@ -215,20 +186,6 @@ export default defineSingleProviderPluginEntry({
             result,
             runtimeErrors,
             requests,
-            runtimeProviders,
-            runtimeRegistry: {
-              plugins: runtimeRegistry.plugins.map((plugin) => ({
-                id: plugin.id,
-                source: plugin.source,
-                origin: plugin.origin,
-              })),
-              providers: runtimeRegistry.providers.map((provider) => ({
-                id: provider.id,
-                pluginId: provider.pluginId,
-              })),
-              diagnostics: runtimeRegistry.diagnostics,
-              registryDiagnostics,
-            },
           }),
         ).toMatchObject({
           ok: true,

--- a/src/system-agent/setup-inference.groq-external.integration.test.ts
+++ b/src/system-agent/setup-inference.groq-external.integration.test.ts
@@ -8,6 +8,7 @@ import {
   clearLoadInstalledPluginIndexInstallRecordsCache,
   writePersistedInstalledPluginIndexInstallRecords,
 } from "../plugins/installed-plugin-index-records.js";
+import { loadOpenClawPlugins } from "../plugins/loader-runtime-load.js";
 import { resetPluginLoaderTestStateForTest } from "../plugins/loader.test-fixtures.js";
 import { waitForPluginCacheRetirement } from "../plugins/plugin-cache.js";
 import { clearPluginMetadataLifecycleCaches } from "../plugins/plugin-metadata-lifecycle.js";
@@ -133,6 +134,21 @@ export default defineSingleProviderPluginEntry({
         pluginId: provider.pluginId,
         auth: provider.auth.map((method) => ({ id: method.id, wizard: method.wizard })),
       }));
+      const registryDiagnostics: string[] = [];
+      const runtimeRegistry = loadOpenClawPlugins({
+        config,
+        workspaceDir: state.workspaceDir,
+        env: state.env,
+        mode: "full",
+        cache: false,
+        activate: false,
+        onlyPluginIds: ["groq"],
+        logger: {
+          info: (message) => registryDiagnostics.push(`info:${String(message)}`),
+          warn: (message) => registryDiagnostics.push(`warn:${String(message)}`),
+          error: (message) => registryDiagnostics.push(`error:${String(message)}`),
+        },
+      });
 
       const requests: Array<{ method?: string; url?: string }> = [];
       const runtimeErrors: string[] = [];
@@ -195,7 +211,25 @@ export default defineSingleProviderPluginEntry({
 
         expect(
           result,
-          JSON.stringify({ result, runtimeErrors, requests, runtimeProviders }),
+          JSON.stringify({
+            result,
+            runtimeErrors,
+            requests,
+            runtimeProviders,
+            runtimeRegistry: {
+              plugins: runtimeRegistry.plugins.map((plugin) => ({
+                id: plugin.id,
+                source: plugin.source,
+                origin: plugin.origin,
+              })),
+              providers: runtimeRegistry.providers.map((provider) => ({
+                id: provider.id,
+                pluginId: provider.pluginId,
+              })),
+              diagnostics: runtimeRegistry.diagnostics,
+              registryDiagnostics,
+            },
+          }),
         ).toMatchObject({
           ok: true,
           modelRef: "groq/openai/gpt-oss-120b",

--- a/src/system-agent/setup-inference.groq-external.integration.test.ts
+++ b/src/system-agent/setup-inference.groq-external.integration.test.ts
@@ -4,7 +4,9 @@ import http from "node:http";
 import path from "node:path";
 import { configureAiTransportHost, getAiTransportHost } from "@openclaw/ai";
 import { afterEach, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { resolveOpenClawPackageRootSync } from "../infra/openclaw-root.js";
+import { createCompiledSdkHost } from "../plugins/compiled-sdk-host.test-support.js";
 import {
   clearLoadInstalledPluginIndexInstallRecordsCache,
   writePersistedInstalledPluginIndexInstallRecords,
@@ -14,6 +16,9 @@ import { waitForPluginCacheRetirement } from "../plugins/plugin-cache.js";
 import { clearPluginMetadataLifecycleCaches } from "../plugins/plugin-metadata-lifecycle.js";
 import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import { activateSetupInference } from "./setup-inference-activate.js";
+import { groqSetupSdkEntrypoints } from "./setup-inference-groq-sdk.test-support.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 afterEach(async () => {
   configureAiTransportHost({});
@@ -26,6 +31,9 @@ it("resolves a Groq manifest model from a global external install during setup",
   clearPluginMetadataLifecycleCaches();
   resetPluginLoaderTestStateForTest();
   clearLoadInstalledPluginIndexInstallRecordsCache();
+  const sdkHost = createCompiledSdkHost(groqSetupSdkEntrypoints[0], (prefix) =>
+    tempDirs.make(prefix),
+  );
   await withOpenClawTestState(
     {
       label: "groq-external-setup",
@@ -33,7 +41,7 @@ it("resolves a Groq manifest model from a global external install during setup",
         OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
         OPENCLAW_DISABLE_BUNDLED_SOURCE_OVERLAYS: "1",
         OPENCLAW_BUNDLED_PLUGINS_DIR: undefined,
-        OPENCLAW_DEV_SOURCE_ROOT: undefined,
+        OPENCLAW_DEV_SOURCE_ROOT: sdkHost,
         OPENCLAW_SKIP_PROVIDERS: undefined,
       },
     },
@@ -108,11 +116,13 @@ export default defineSingleProviderPluginEntry({
 `,
         "utf8",
       );
-      const hostRoot = resolveOpenClawPackageRootSync({
-        argv1: process.argv[1],
-        moduleUrl: import.meta.url,
-        cwd: process.cwd(),
-      });
+      const hostRoot =
+        sdkHost ??
+        resolveOpenClawPackageRootSync({
+          argv1: process.argv[1],
+          moduleUrl: import.meta.url,
+          cwd: process.cwd(),
+        });
       if (!hostRoot) {
         throw new Error("test host package root is unavailable");
       }

--- a/src/system-agent/setup-inference.groq-external.integration.test.ts
+++ b/src/system-agent/setup-inference.groq-external.integration.test.ts
@@ -1,0 +1,99 @@
+import { once } from "node:events";
+import fs from "node:fs/promises";
+import http from "node:http";
+import path from "node:path";
+import { configureAiTransportHost, getAiTransportHost } from "@openclaw/ai";
+import { afterEach, expect, it } from "vitest";
+import { resetPluginLoaderTestStateForTest } from "../plugins/loader.test-fixtures.js";
+import { waitForPluginCacheRetirement } from "../plugins/plugin-cache.js";
+import { clearPluginMetadataLifecycleCaches } from "../plugins/plugin-metadata-lifecycle.js";
+import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
+import { activateSetupInference } from "./setup-inference-activate.js";
+
+afterEach(async () => {
+  configureAiTransportHost({});
+  clearPluginMetadataLifecycleCaches();
+  resetPluginLoaderTestStateForTest();
+  await waitForPluginCacheRetirement();
+});
+
+it("resolves a Groq manifest model from a global external install during setup", async () => {
+  await withOpenClawTestState(
+    {
+      label: "groq-external-setup",
+      env: { OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1" },
+    },
+    async (state) => {
+      const pluginDir = state.statePath("extensions", "groq");
+      await fs.cp(path.join(process.cwd(), "extensions", "groq"), pluginDir, { recursive: true });
+      await state.writeConfig({ plugins: { entries: { groq: { enabled: true } } } });
+
+      const requests: Array<{ method?: string; url?: string }> = [];
+      const server = http.createServer((request, response) => {
+        requests.push({ method: request.method, url: request.url });
+        response.writeHead(200, { "content-type": "text/event-stream; charset=utf-8" });
+        const chunk = {
+          id: "chatcmpl-groq-catalog-test",
+          object: "chat.completion.chunk",
+          created: 0,
+          model: "openai/gpt-oss-120b",
+          choices: [{ index: 0, delta: { role: "assistant", content: "OK" }, finish_reason: null }],
+        };
+        const stop = { ...chunk, choices: [{ index: 0, delta: {}, finish_reason: "stop" }] };
+        response.end(
+          `data: ${JSON.stringify(chunk)}\n\ndata: ${JSON.stringify(stop)}\n\ndata: [DONE]\n\n`,
+        );
+      });
+      server.listen(0, "127.0.0.1");
+      await once(server, "listening");
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        throw new Error("loopback server has no TCP port");
+      }
+
+      const realFetch = globalThis.fetch;
+      const originalHost = getAiTransportHost();
+      configureAiTransportHost({
+        ...originalHost,
+        buildModelFetch: () => async (input, init) => {
+          const original = new Request(input, init);
+          const url = new URL(original.url);
+          expect(url.hostname).toBe("api.groq.com");
+          const replacement = new URL(original.url);
+          replacement.protocol = "http:";
+          replacement.hostname = "127.0.0.1";
+          replacement.port = String(address.port);
+          return await realFetch(new Request(replacement, original));
+        },
+      });
+
+      try {
+        const result = await activateSetupInference({
+          kind: "api-key",
+          authChoice: "groq-api-key",
+          apiKey: "test-placeholder",
+          modelRef: "groq/openai/gpt-oss-120b",
+          workspace: state.workspaceDir,
+          surface: "gateway",
+          runtime: {
+            log: () => {},
+            error: () => {},
+            exit: (code) => {
+              throw new Error(`exit ${code}`);
+            },
+          },
+        });
+
+        expect(result).toMatchObject({
+          ok: true,
+          modelRef: "groq/openai/gpt-oss-120b",
+        });
+        expect(requests).toEqual([{ method: "POST", url: "/openai/v1/chat/completions" }]);
+      } finally {
+        configureAiTransportHost(originalHost);
+        server.close();
+        await once(server, "close");
+      }
+    },
+  );
+});

--- a/src/system-agent/setup-inference.groq-external.integration.test.ts
+++ b/src/system-agent/setup-inference.groq-external.integration.test.ts
@@ -6,6 +6,7 @@ import { configureAiTransportHost, getAiTransportHost } from "@openclaw/ai";
 import { afterEach, expect, it } from "vitest";
 import {
   clearLoadInstalledPluginIndexInstallRecordsCache,
+  readPersistedInstalledPluginIndexInstallRecords,
   writePersistedInstalledPluginIndexInstallRecords,
 } from "../plugins/installed-plugin-index-records.js";
 import { resetPluginLoaderTestStateForTest } from "../plugins/loader.test-fixtures.js";
@@ -112,7 +113,26 @@ it("resolves a Groq manifest model from a global external install during setup",
           },
         });
 
-        expect(result, JSON.stringify({ result, runtimeErrors, requests })).toMatchObject({
+        const persistedInstallRecords = readPersistedInstalledPluginIndexInstallRecords({
+          env: state.env,
+        });
+        const manifestChoices = (
+          await import("../plugins/provider-auth-choices.js")
+        ).resolveManifestProviderAuthChoices({
+          config,
+          workspaceDir: state.workspaceDir,
+          env: state.env,
+        });
+        expect(
+          result,
+          JSON.stringify({
+            result,
+            runtimeErrors,
+            requests,
+            persistedInstallRecords,
+            manifestChoices,
+          }),
+        ).toMatchObject({
           ok: true,
           modelRef: "groq/openai/gpt-oss-120b",
         });

--- a/src/system-agent/setup-inference.groq-external.integration.test.ts
+++ b/src/system-agent/setup-inference.groq-external.integration.test.ts
@@ -6,7 +6,6 @@ import { configureAiTransportHost, getAiTransportHost } from "@openclaw/ai";
 import { afterEach, expect, it } from "vitest";
 import {
   clearLoadInstalledPluginIndexInstallRecordsCache,
-  readPersistedInstalledPluginIndexInstallRecords,
   writePersistedInstalledPluginIndexInstallRecords,
 } from "../plugins/installed-plugin-index-records.js";
 import { resetPluginLoaderTestStateForTest } from "../plugins/loader.test-fixtures.js";
@@ -40,6 +39,29 @@ it("resolves a Groq manifest model from a global external install during setup",
     async (state) => {
       const pluginDir = state.statePath("extensions", "groq");
       await fs.cp(path.join(process.cwd(), "extensions", "groq"), pluginDir, { recursive: true });
+      // The changed-node job uses a sparse checkout, so untouched package files
+      // such as the runtime entry may not be present. Keep this external package
+      // fixture self-contained while retaining the real Groq manifest and
+      // provider-discovery entry under test.
+      await fs.writeFile(
+        path.join(pluginDir, "index.ts"),
+        `import { defineSingleProviderPluginEntry } from "openclaw/plugin-sdk/provider-entry";
+import manifest from "./openclaw.plugin.json" with { type: "json" };
+
+export default defineSingleProviderPluginEntry({
+  id: "groq",
+  name: "Groq Provider",
+  description: "Bundled Groq provider plugin",
+  manifest,
+  provider: {
+    label: "Groq",
+    docsPath: "/providers/groq",
+    catalog: { liveModelDiscovery: true, discoveryMode: "strict" },
+  },
+});
+`,
+        "utf8",
+      );
       const config = { plugins: { entries: { groq: { enabled: true } } } };
       await state.writeConfig(config);
       await writePersistedInstalledPluginIndexInstallRecords(
@@ -105,7 +127,7 @@ it("resolves a Groq manifest model from a global external install during setup",
           runtime: {
             log: () => {},
             error: (message) => {
-              runtimeErrors.push(message);
+              runtimeErrors.push(String(message));
             },
             exit: (code) => {
               throw new Error(`exit ${code}`);
@@ -113,41 +135,7 @@ it("resolves a Groq manifest model from a global external install during setup",
           },
         });
 
-        const persistedInstallRecords = readPersistedInstalledPluginIndexInstallRecords({
-          env: state.env,
-        });
-        const manifestChoices = (
-          await import("../plugins/provider-auth-choices.js")
-        ).resolveManifestProviderAuthChoices({
-          config,
-          workspaceDir: state.workspaceDir,
-          env: state.env,
-        });
-        const runtimeProviders = (await import("../plugins/providers.runtime.js"))
-          .resolvePluginProvidersCore({
-            config,
-            workspaceDir: state.workspaceDir,
-            env: state.env,
-            mode: "setup",
-            cache: false,
-            onlyPluginIds: ["groq"],
-          })
-          .map((provider) => ({
-            pluginId: provider.pluginId,
-            id: provider.id,
-            auth: provider.auth.map((method) => method.id),
-          }));
-        expect(
-          result,
-          JSON.stringify({
-            result,
-            runtimeErrors,
-            requests,
-            persistedInstallRecords,
-            manifestChoices,
-            runtimeProviders,
-          }),
-        ).toMatchObject({
+        expect(result, JSON.stringify({ result, runtimeErrors, requests })).toMatchObject({
           ok: true,
           modelRef: "groq/openai/gpt-oss-120b",
         });


### PR DESCRIPTION
Closes #146391

## What Problem This Solves

Fresh setup cannot resolve `groq/openai/gpt-oss-120b` when Groq is installed externally and the agent model catalog is empty.

## User Impact

Operators can select Groq's manifest-backed model during fresh setup without first creating an explicit provider-model definition.

## Why This Change Was Made

Groq's refreshable catalog is excluded from entries-only static discovery, while the isolated setup probe does not activate full runtime discovery. A lightweight Groq-owned entry exposes the existing manifest catalog through the supported static-catalog contract. Live discovery and the shared discovery policy are unchanged.

The external-setup regression now supplies the two native SDK exports from the invocation's freshly compiled worker graph using the existing compiled-SDK host helper. This removes its dependency on an unrelated checkout `dist/` build. The small worker-entry registrations support this regression; no CI workflow, skip, retry, or assertion was weakened.

## Evidence

- Tested full HEAD: `c9124d5c51a72ab5e9f7f24a9c73511c9f2c58a4`.
- The previous proof SHA was incorrect and did not resolve on GitHub. This proof replaces that claim with a new run bound to the actual commit.
- Before this test-harness repair, the unchanged test passed with an existing checkout build but failed without `dist/`, matching the hosted failure: provider setup unavailable, zero requests.
- With this repair and no checkout `dist/`, the production setup path resolves the selected model and the real completion client makes exactly one loopback-intercepted Groq request.
- Negative control: A controlled negative run on this same commit, with only `providerCatalogEntry` removed from the Groq manifest, failed with `Unknown model: groq/openai/gpt-oss-120b` and zero requests. The manifest was restored byte-for-byte before the successful clean-head run; this was not a checkout of an unfixed commit.
- Groq extension lane: 6 tests passed. Adjacent setup-turn, provider-discovery, and native-loader tests: 46 tests passed across two shards.
- Targeted type-aware lint, the owning plugin/system-agent test typecheck, script typecheck, and `git diff --check` passed. Independent cross-review found no actionable issue. Autoreview found the old index-only missing-SDK defect and explicitly confirmed the working-tree repair fixed it; the reviewed repair was then staged in full and committed, resolving that finding.

## Real Behavior Proof

**HEAD:** `c9124d5c51a72ab5e9f7f24a9c73511c9f2c58a4`

**Claim:** With bundled plugins disabled and an empty agent model catalog, `activateSetupInference()` resolves `groq/openai/gpt-oss-120b` from an external Groq package and reaches the completion endpoint exactly once, without requiring checkout `dist/` artifacts.

**Exercised surface:** Unchanged `activateSetupInference()` → provider setup/auth registration → isolated embedded setup runner → entries-only catalog discovery → real OpenAI-compatible completion client. The temporary external package retains the real Groq manifest and discovery entry, with a synthetic minimal runtime registration entry. Its native SDK exports come from the test invocation's verified current-source compiled graph. Only outbound HTTP is redirected, after asserting the original hostname is `api.groq.com`; there is no model-resolution, discovery, runner, or completion-client mock.

**Environment:** Linux x86_64; Node `v24.21.0`; pnpm `12.3.4`; frozen-lockfile dependencies; no checkout `dist/`; isolated test home/state/config; synthetic credential; loopback HTTP server.

**Scenario:**

1. Install the fixture under the isolated global plugin directory and record it through the real installed-plugin index.
2. Disable bundled plugins and source overlays; leave the agent model catalog empty.
3. Select the Groq API-key setup choice and `groq/openai/gpt-oss-120b` through the production activation entry point.
4. Assert successful setup for that model and exactly one `POST /openai/v1/chat/completions` request.
5. A controlled negative run on this same commit, with only `providerCatalogEntry` removed from the Groq manifest, failed with `Unknown model: groq/openai/gpt-oss-120b` and zero requests. The manifest was restored byte-for-byte before the successful clean-head run; this was not a checkout of an unfixed commit

**Command:**

```console
git rev-parse HEAD
test ! -e dist
CI=true GITHUB_ACTIONS=true OPENCLAW_NODE_TEST_TARGETS_JSON='["src/system-agent/setup-inference.groq-external.integration.test.ts"]' OPENCLAW_NODE_TEST_PLAN_CONCURRENCY=1 OPENCLAW_VITEST_MAX_WORKERS=2 node --import tsx scripts/ci-run-node-test-shard.mts
```

**Relevant output:**

```text
c9124d5c51a72ab5e9f7f24a9c73511c9f2c58a4
DIST=absent
WORKTREE=clean
✓ |unit| src/system-agent/setup-inference.groq-external.integration.test.ts > resolves a Groq manifest model from a global external install during setup 25119ms
Test Files  1 passed (1)
Tests  1 passed (1)
[test] passed 1 Vitest shard in 71.44s
Negative-control excerpts: Unknown model: groq/openai/gpt-oss-120b; "requests":[]
```

**Artifact:** The retained local terminal evidence is excerpted above. Same-head hosted validation: https://github.com/openclaw/openclaw/actions/runs/34729442603 (passed). The [hosted Groq setup job](https://github.com/openclaw/openclaw/actions/runs/34729442603/job/103649537151) reports `Test Files 1 passed (1)`, `Tests 1 passed (1)`, and shard exit 0.

**Observed result:** The negative control reached the original model-resolution failure before transport. Restoring the catalog declaration on the clean tested head produced successful setup and exactly one expected completion request, with no checkout build present.

**Not tested:** Live Groq credentials/service, npm-registry installation, non-Linux platforms, and standalone/watch-mode Vitest. The existing source-mode host fallback is retained. Groq's full runtime compatibility is covered separately by the extension lane; adjacent discovery and native-loader regressions passed. No shared production owner or discovery semantics changed.

## Separate Review Blockers

- Hosted CI for this exact head passed: https://github.com/openclaw/openclaw/actions/runs/34729442603. The PR check rollup has no pending or failed checks (64 successful checks; other checks skipped/neutral).
- ClawSweeper revision 8 reviewed this exact head: **ready for maintainer review**, **platinum** overall, **diamond** proof confidence, and no actionable findings. [Current durable review](https://github.com/openclaw/openclaw/pull/146471#issuecomment-5649016747). No separate author-work blocker remains; maintainer review/merge remains a maintainer decision.

## Sources

- Linked issue review: https://github.com/openclaw/openclaw/issues/146391#issuecomment-5648416612
- Review addressed: https://github.com/openclaw/openclaw/pull/146471#issuecomment-5649016747
- Published proof/review contract: https://github.com/openclaw/clawsweeper/blob/34c5f1c0d8dbd0e2900228802f17219c72d9113e/CONTRIBUTING.md
- Review rubric: https://github.com/openclaw/clawsweeper/blob/34c5f1c0d8dbd0e2900228802f17219c72d9113e/prompts/review-item.md
