### PR TITLE
fix(gateway): stop TLS renewal through the shutdown owner

### DIFF
--- a/src/gateway/server-startup-finish.ts
+++ b/src/gateway/server-startup-finish.ts
@@ -413,7 +413,7 @@ export async function finishGatewayStartup(params: {
     log: log.child("tls"),
   });
   if (tlsRenewal) {
-    registerGatewayLifetimeSidecars([tlsRenewal]);
+    registerGatewayLifetimeSidecars(tlsRenewal);
   }
   const configReloaderParams: Parameters<typeof startManagedGatewayConfigReloader>[0] = {
     onReloadEnabledChange: tlsRenewal?.setEnabled,


### PR DESCRIPTION
Related: #130741

## What Problem This Solves

TLS-enabled Gateway startup registers an array as a shutdown sidecar, so cleanup cannot call the renewal monitor's `stop` method.

## User Impact

The TLS renewal monitor participates in normal Gateway shutdown without an invalid-sidecar error.

## Why This Change Was Made

Pass the renewal handle directly to the existing variadic sidecar owner. Renewal scheduling and shutdown ownership remain unchanged.

## Evidence

The original call produces TS2741 on the unchanged main source. The corrected call passes the core typecheck and all 140 focused TLS, sidecar-retention, startup, and shutdown tests. The full canonical changed gate and an isolated P1 review also pass.
