### PR TITLE
improve: reduce diagnostic overhead during agent turns

### DIFF
--- a/packages/ai/src/utils/credential-redaction.test.ts
+++ b/packages/ai/src/utils/credential-redaction.test.ts
@@ -1,6 +1,36 @@
 import { describe, expect, it, vi } from "vitest";
 import { projectDiagnosticValue } from "./credential-redaction.js";
 
+describe("diagnostic Headers projection", () => {
+  it("retains retry timing from native headers without reading overridden methods", () => {
+    const getter = vi.fn(() => {
+      throw new Error("must not be read");
+    });
+    const headers = new Headers({
+      "retry-after": "7",
+      "retry-after-ms": "8500",
+      authorization: "synthetic-private",
+    });
+    for (const key of ["has", "get", "constructor", Symbol.toStringTag]) {
+      Object.defineProperty(headers, key, { get: getter });
+    }
+
+    expect(projectDiagnosticValue({ headers })).toEqual({
+      headers: { "retry-after-ms": 8500 },
+    });
+    expect(getter).not.toHaveBeenCalled();
+  });
+
+  it("still projects own data when a Headers prototype has no native slots", () => {
+    const value = Object.assign(Object.create(Headers.prototype), {
+      detail: "safe",
+      authorization: "synthetic-private",
+    });
+
+    expect(projectDiagnosticValue(value)).toEqual({ detail: "safe" });
+  });
+});
+
 describe("diagnostic descriptor snapshots", () => {
   it("keeps media and credential classification isolated through reentrant policy callbacks", () => {
     const nested: unknown[] = [];

--- a/packages/ai/src/utils/credential-redaction.ts
+++ b/packages/ai/src/utils/credential-redaction.ts
@@ -236,11 +236,14 @@ export function projectDiagnosticValue(
       return "[Truncated]";
     }
     try {
-      // Brand-check without provider getters; retain only numeric retry timing.
-      Headers.prototype.has.call(value, "retry-after");
-      const seconds = parseRetryAfterHeadersSeconds(value);
-      state.changed = true;
-      return seconds === undefined ? {} : { "retry-after-ms": seconds * 1000 };
+      // Node Headers requires this prototype brand; avoid throwing for ordinary objects.
+      if (Function.prototype[Symbol.hasInstance].call(Headers, value)) {
+        // Keep native slot validation without reading provider getters.
+        Headers.prototype.has.call(value, "retry-after");
+        const seconds = parseRetryAfterHeadersSeconds(value);
+        state.changed = true;
+        return seconds === undefined ? {} : { "retry-after-ms": seconds * 1000 };
+      }
     } catch {
       // Other objects follow the bounded descriptor walk below.
     }


### PR DESCRIPTION
## What Problem This Solves

Diagnostic projection spends avoidable CPU on every agent turn with tool schemas: ordinary objects construct and catch a native Headers brand-check exception.

## User Impact

The candidate reduces diagnostic projection CPU while preserving redaction, retry timing, and diagnostic output on the supported Node runtime. No configuration or migration is required. **This remains a draft because end-to-end latency results are mixed.**

## Why This Change Was Made

Check the same intrinsic prototype prerequisite before native Headers slot validation. Ordinary objects proceed directly to the existing descriptor projection; native Headers and prototype-only objects retain their existing behavior.

## Evidence

- Public `toTrajectoryToolDefinitions` component benchmark: 32 tools, seven samples of 100 projections per process, B,C,C,B order. Median time fell 65.7%/65.4%, with identical output hashes. These are component measurements, not Gateway latency claims.
- 349 focused tests passed across projection, provider errors, retry timing, payload redaction, and trajectory recording. Cases cover overridden Headers getters and prototype-only objects without native slots. Fresh independent P0-P2 review found no actionable code findings.
- Rebased onto `b405e7f644106306d2d3965ecf22335fdbe15716` after #146412 fixed the inherited TLS type error; the two-file patch is unchanged. All focused tests and the full changed-check plan now pass, including core/test typechecks, lint, dead-export scans, and repository guards.
- One controlled Testbox campaign at the rebased candidate: B1,C1,C2,B2, each with 1,000 sessions, 96 tool turns, 192 mock Responses, 2,432 scheduled observations, 1,536 history requests, 100 updates, and four subscribers. Dreaming/heartbeats disabled, ordinary indexing enabled. Every request/release/observer schedule, foreground count, source hash, compiled-code check, and cleanup assertion passed; all 107 artifact hashes and identical instrumentation independently verified. [Controlled run](https://github.com/openclaw/openclaw/actions/runs/34720129396).
- Controlled projection sampled CPU fell **65.2% in both pairs** (1,265 to 440 ms; 1,246 to 433 ms). Pair 1 aggregate tails improved, but its final-release phase worsened. **Pair 2 p95/p99/max worsened for all eight observed methods**: fixed-deadline-to-completion p95 for session listing rose 602 to 811 ms (+34.9%), history 749 to 913 ms (+21.8%), and subscriptions 620 to 876 ms (+41.2%). All-turn settlement was 158/20 ms later. No general latency or throughput improvement is established.
- Controlled indexing varied: B1/C2 had 161 embedding requests and 171 items; C1/B2 had 192 requests and 202 items. Whole-run attribution is therefore limited. Fixed observers also permit more overlap than the earlier response-paced workload. No limits were widened and no favorable rerun was performed.
- Original four-arm evidence at `e44efce4` remains preserved: projection CPU and several p95 measures improved, but control-plane p99 worsened in both pairs. That mock emitted tool event arrays immediately, probes were response-paced, and `turnsDurationMs` joined probes as well as turns. The newer controlled baseline cannot identify pacing as the sole cause of those adverse tails.
- Eight real OpenAI turns previously passed stream/final-event, RPC-history, and independent post-shutdown SQLite checks with no failed Gateway samples. Six unclassified Responses transport error notifications remain unexplained; functional success is not a zero-transport-error claim. Both task-owned leases are stopped. [Original mock/live run](https://github.com/openclaw/openclaw/actions/runs/34718019821).
