### PR TITLE
improve(ui): reduce work when applying session updates

### DIFF
--- a/ui/src/lib/sessions/session-row-reconcile.ts
+++ b/ui/src/lib/sessions/session-row-reconcile.ts
@@ -479,16 +479,19 @@ export function reconcileSessionChangedRow(
     updatedAt: updatedAt ?? null,
     ...(sessionId ? { sessionId } : {}),
   };
+  const fields: string[] = [];
   // Optional wire fields use null as a tombstone; the explicit nullable fields keep null.
   for (const [field, value] of Object.entries(rowFields)) {
     if (value === null && !NULLABLE_SESSION_ROW_FIELDS.has(field)) {
       Reflect.deleteProperty(offered, field);
     }
+    if (value !== undefined) {
+      fields.push(field);
+    }
   }
-  const fields = [
-    ...Object.keys(rowFields).filter((field) => rowFields[field] !== undefined),
-    ...(existingFields !== existing ? thinkingMetadataFields : []),
-  ];
+  if (existingFields !== existing) {
+    fields.push(...thinkingMetadataFields);
+  }
   const reduced = reconcileSessionRow(
     offered,
     existing,


### PR DESCRIPTION
Related: #146197, #146384

## What Problem This Solves

Applying session updates enumerates every row's fields twice and allocates intermediate arrays to record the event's projected fields.

## User Impact

Session updates do less work with the same visible state. The change also reduces actual startup code, although the current hosted integration still exceeds the unchanged size budget. No migration or user action is required.

## Why This Change Was Made

Collect defined field names during the existing null-tombstone pass, then append changed thinking metadata in the original order. Null names, omitted undefined values, duplicate metadata names, and event provenance remain unchanged.

## Evidence

- All 54 existing reconciliation, permission-projection, and optimistic-provenance tests pass through the actual session capability flows.
- With the same frozen dependencies and canonical comparison against main 7d2d7fcd393, startup JavaScript falls from 1,153,053 to 1,153,039 raw bytes and 355,138 to 355,114 gzip bytes. The enforced limit is unchanged at 355,116 bytes, leaving only two bytes of headroom. Hosted CI remains a landing gate; this is an artifact-size measurement, not a latency claim.
- Independent P0-P2 review found no actionable findings. The change is confined to one production owner; existing behavior tests are retained.
- UI types, scoped lint, formatting, i18n verification, and diff checks pass. Broad core test types were not rerun for this UI-only change; required hosted CI covers its full selected scope.

Current hosted CI run 34723103248 hit the unrelated plugins-platform typecheck inventory guard: 702 test roots against the unchanged 700 target. This PR adds no tests. Existing repair #146538 moves hook tests between existing graphs without reducing coverage or raising limits; coordination is in progress before landing. The hosted startup-size job also failed at 355,134 gzip bytes, 18 above the unchanged limit. Its raw output matches the local candidate; newer main changes alter referenced chunk hashes and compression. A larger local source prototype passed 360 tests and independent review, reducing startup to 355,122 gzip bytes, still six above that old limit. The separate maintainer-owned baseline update #146526 has since merged. Repair #146538 is now in fresh CI for the type-shard overflow. This PR remains at the single-file published head until the next verified update.
