### PR TITLE
test(gateway): exercise profile authorization in lifetime fixture

### DIFF
--- a/src/gateway/server/ws-connection/authenticated-request-dispatch.lifetime.test.ts
+++ b/src/gateway/server/ws-connection/authenticated-request-dispatch.lifetime.test.ts
@@ -62,8 +62,10 @@ describe("authenticated request completion", { concurrent: false }, () => {
       }
       const { createDispatchTestHarness, createOperatorWsClient } =
         await import("./authenticated-request-dispatch.test-support.js");
+      // A profile-owned method must enter identity synchronization before its handler.
+      const method = "sessions.list";
       const harness = createDispatchTestHarness({
-        extraHandlers: { "test.lifetime": handleGatewayRequest },
+        extraHandlers: { [method]: handleGatewayRequest },
         buildRequestContext: () => ({ getRuntimeConfig: () => ({}) }),
       });
       const client = createOperatorWsClient({ socket: new EventEmitter() });
@@ -81,7 +83,7 @@ describe("authenticated request completion", { concurrent: false }, () => {
         };
       }
       const dispatch = harness.dispatcher
-        .dispatch({ type: "req", id: "held", method: "test.lifetime", params: {} }, client)
+        .dispatch({ type: "req", id: "held", method, params: {} }, client)
         .then(() => {
           dispatched = true;
           selection.OPENCLAW_STATE_DIR = restoredRoot;


### PR DESCRIPTION
## Withdrawn: the original diagnosis was incorrect

The auxiliary `test.lifetime` method already requires profile authorization. At both affected head `8da309b61d8d0af965402d83105bf5e7d54ea081` and current main, `src/gateway/methods/registry.ts` defaults non-core method descriptors to `profileAccess: "required"`. The original claim that this method skips identity synchronization was wrong.

Changing the fixture to `sessions.list` passes all 11 focused lifetime/registry tests and exact-head CI, but that does not demonstrate a repair of the original shared-worker timeout. This PR is withdrawn rather than landing an unsupported fix. Production LOC is unchanged; test LOC is +2.

The original failure remains recorded in [the profile-authorization lifetime job](https://github.com/openclaw/openclaw/actions/runs/34721103266/job/103627077571). The canonical investigation associated with #146508 is examining an in-flight Vitest mock/unmock resolution race. Its applicability to this particular failure still requires proof in the original execution order.

This also addresses the latest review's request to reconcile the root-cause claim before merge.
