### PR TITLE
perf(ui): defer board widget labels until their views load

### DIFF
--- a/scripts/lib/control-ui-i18n-catalog.ts
+++ b/scripts/lib/control-ui-i18n-catalog.ts
@@ -5,6 +5,7 @@ import { buildBaseHints } from "../../src/config/schema.hints.js";
 import { configHintTranslationKey } from "../../ui/src/i18n/lib/config-hint-translation.ts";
 import { registerActivityEnglish } from "../../ui/src/i18n/locales/en-activity.ts";
 import { registerAgentsHomeEnglish } from "../../ui/src/i18n/locales/en-agents-home.ts";
+import { registerBoardWidgetsEnglish } from "../../ui/src/i18n/locales/en-board-widgets.ts";
 import { registerBrowserEnglish } from "../../ui/src/i18n/locales/en-browser.ts";
 import { registerDebugEnglish } from "../../ui/src/i18n/locales/en-debug.ts";
 import { registerDesktopEnglish } from "../../ui/src/i18n/locales/en-desktop.ts";
@@ -39,6 +40,7 @@ const sourceFiles = [
   "en-agents.ts",
   "en-activity.ts",
   "en-agents-home.ts",
+  "en-board-widgets.ts",
   "en-browser.ts",
   "en-debug.ts",
   "en-desktop.ts",
@@ -70,6 +72,7 @@ export function loadControlUiSourceCatalog(): TranslationMap {
     },
     registerActivityEnglish.catalog,
     registerAgentsHomeEnglish.catalog,
+    registerBoardWidgetsEnglish.catalog,
     registerBrowserEnglish.catalog,
     registerDevicesEnglish.catalog,
     registerLoginEnglish.catalog,

--- a/ui/src/components/board/board-widget-cell-render.ts
+++ b/ui/src/components/board/board-widget-cell-render.ts
@@ -1,10 +1,13 @@
 import { html, nothing, type TemplateResult } from "lit";
 import { t } from "../../i18n/index.ts";
+import { registerBoardWidgetsEnglish } from "../../i18n/locales/en-board-widgets.ts";
 import type { BoardTab, BoardWidget } from "../../lib/board/types.ts";
 import type { BoardGrantDecision } from "../../lib/board/view-types.ts";
 import { formatUiError } from "../../lib/format-error.ts";
 import { icons } from "../icons.ts";
 import { renderBoardPendingCapabilities } from "./board-widget-capabilities.ts";
+
+registerBoardWidgetsEnglish();
 
 export const BOARD_SIZE_PRESETS = {
   sm: { w: 3, h: 3 },

--- a/ui/src/i18n/locales/en-board-widgets.ts
+++ b/ui/src/i18n/locales/en-board-widgets.ts
@@ -1,0 +1,24 @@
+import type { TranslationMap } from "../lib/types.ts";
+import { en } from "./en.ts";
+
+// Keep this suffix together so host composition preserves translation alias order.
+const enBoardWidgets = {
+  board: {
+    widget: {
+      kindWebsite: "Website",
+      websiteOpen: "Open website",
+      websiteEmbedHint: "If this site does not load here, open it in a new tab.",
+      websiteSameOrigin:
+        "Open this website in a new tab. Gateway and Control UI pages cannot be embedded in a website widget.",
+      pluginLoading: "Loading plugin widget…",
+      disabledPlugin: "Widget from disabled plugin {pluginId}",
+    },
+  },
+} satisfies TranslationMap;
+
+export const registerBoardWidgetsEnglish = Object.assign(
+  () => {
+    Object.assign(en.board.widget, enBoardWidgets.board.widget);
+  },
+  { catalog: enBoardWidgets },
+);

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -4,6 +4,7 @@ import type { TranslationMap } from "../lib/types.ts";
 import * as agentEn from "./en-agents.ts";
 
 export const en: TranslationMap & {
+  board: TranslationMap & { widget: TranslationMap };
   browser: TranslationMap & { errors: TranslationMap };
   configPage: TranslationMap;
   connection: TranslationMap;
@@ -3753,13 +3754,6 @@ export const en: TranslationMap & {
       kindHtml: "HTML",
       kindPlugin: "Plugin",
       kindReport: "Report",
-      kindWebsite: "Website",
-      websiteOpen: "Open website",
-      websiteEmbedHint: "If this site does not load here, open it in a new tab.",
-      websiteSameOrigin:
-        "Open this website in a new tab. Gateway and Control UI pages cannot be embedded in a website widget.",
-      pluginLoading: "Loading plugin widget…",
-      disabledPlugin: "Widget from disabled plugin {pluginId}",
     },
   },
   connection: {

--- a/ui/src/lib/board/widgets/index.ts
+++ b/ui/src/lib/board/widgets/index.ts
@@ -1,7 +1,10 @@
 import type { GatewayControlUiPluginWidgetKind } from "../../../api/gateway.ts";
 import type { OptionalCustomElement } from "../../../app/lazy-custom-element.ts";
 import { t } from "../../../i18n/index.ts";
+import { registerBoardWidgetsEnglish } from "../../../i18n/locales/en-board-widgets.ts";
 import type { BoardWidget } from "../types.ts";
+
+registerBoardWidgetsEnglish();
 
 type CoreBoardWidgetElement = OptionalCustomElement & {
   kind: string;


### PR DESCRIPTION
CI headroom prerequisite is on main through #146538.

Related: #130741, #146491, #146492, #146490

## What Problem This Solves

Control UI startup shipped English copy used only by lazy board-widget views and exceeded its startup JavaScript budget.

## User Impact

Initial pages download less JavaScript. Widget labels and messages stay unchanged.

## Why This Change Was Made

Register the existing six-key widget suffix from its lazy registry and render helper. The canonical host catalog composes the same fragment in its original order, preserving translation aliases and source freshness.

## Evidence

- One controlled build pair reduced startup JavaScript from **355138 B to 355018 B gzip**, with **8 requests** in both builds and the existing **355116 B** limit.
- All **9018 ordered catalog entries** match exactly and translation alias order is preserved; the **92-entry raw-copy baseline** is unchanged.
- **67 focused tests**, **2 cold-browser registration/render cases**, and **2 dashboard E2E cases** passed. Six synthetic captures are retained locally.
- Isolated **P1 review is clean**. The canonical changed gate passed.
