### PR TITLE
fix(ui): keep website copy out of the startup chunk

### DIFF
--- a/scripts/lib/control-ui-i18n-catalog.ts
+++ b/scripts/lib/control-ui-i18n-catalog.ts
@@ -5,6 +5,7 @@ import { buildBaseHints } from "../../src/config/schema.hints.js";
 import { configHintTranslationKey } from "../../ui/src/i18n/lib/config-hint-translation.ts";
 import { registerActivityEnglish } from "../../ui/src/i18n/locales/en-activity.ts";
 import { registerAgentsHomeEnglish } from "../../ui/src/i18n/locales/en-agents-home.ts";
+import { registerBoardWebsiteEnglish } from "../../ui/src/i18n/locales/en-board-website.ts";
 import { registerBrowserEnglish } from "../../ui/src/i18n/locales/en-browser.ts";
 import { registerDebugEnglish } from "../../ui/src/i18n/locales/en-debug.ts";
 import { registerDesktopEnglish } from "../../ui/src/i18n/locales/en-desktop.ts";
@@ -39,6 +40,7 @@ const sourceFiles = [
   "en-agents.ts",
   "en-activity.ts",
   "en-agents-home.ts",
+  "en-board-website.ts",
   "en-browser.ts",
   "en-debug.ts",
   "en-desktop.ts",
@@ -70,6 +72,7 @@ export function loadControlUiSourceCatalog(): TranslationMap {
     },
     registerActivityEnglish.catalog,
     registerAgentsHomeEnglish.catalog,
+    registerBoardWebsiteEnglish.catalog,
     registerBrowserEnglish.catalog,
     registerDevicesEnglish.catalog,
     registerLoginEnglish.catalog,

--- a/ui/src/i18n/locales/en-board-website.ts
+++ b/ui/src/i18n/locales/en-board-website.ts
@@ -1,0 +1,20 @@
+import type { TranslationMap } from "../lib/types.ts";
+import { en } from "./en.ts";
+
+const enBoardWebsite = {
+  board: {
+    widget: {
+      websiteOpen: "Open website",
+      websiteEmbedHint: "If this site does not load here, open it in a new tab.",
+      websiteSameOrigin:
+        "Open this website in a new tab. Gateway and Control UI pages cannot be embedded in a website widget.",
+    },
+  },
+} satisfies TranslationMap;
+
+export const registerBoardWebsiteEnglish = Object.assign(
+  () => {
+    Object.assign(en.board.widget, enBoardWebsite.board.widget);
+  },
+  { catalog: enBoardWebsite },
+);

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -4,6 +4,7 @@ import type { TranslationMap } from "../lib/types.ts";
 import * as agentEn from "./en-agents.ts";
 
 export const en: TranslationMap & {
+  board: TranslationMap & { widget: TranslationMap };
   browser: TranslationMap & { errors: TranslationMap };
   configPage: TranslationMap;
   connection: TranslationMap;
@@ -3754,10 +3755,6 @@ export const en: TranslationMap & {
       kindPlugin: "Plugin",
       kindReport: "Report",
       kindWebsite: "Website",
-      websiteOpen: "Open website",
-      websiteEmbedHint: "If this site does not load here, open it in a new tab.",
-      websiteSameOrigin:
-        "Open this website in a new tab. Gateway and Control UI pages cannot be embedded in a website widget.",
       pluginLoading: "Loading plugin widget…",
       disabledPlugin: "Widget from disabled plugin {pluginId}",
     },

--- a/ui/src/i18n/website-loading.test.ts
+++ b/ui/src/i18n/website-loading.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.hoisted(() => vi.resetModules());
+
+let restoreI18n: (() => Promise<void>) | undefined;
+afterEach(async () => {
+  await restoreI18n?.();
+});
+
+describe("website widget English loading", () => {
+  it("loads website fallback copy with the widget while preserving shared board labels", async () => {
+    const { captureI18nStateForTesting, createI18nManagerForTesting } =
+      await import("./lib/translate.test-support.ts");
+    restoreI18n = captureI18nStateForTesting();
+    const { en } = await import("./locales/en.ts");
+    const board = en.board;
+    const manager = createI18nManagerForTesting(async () => ({ common: { health: "Gesundheit" } }));
+    expect(manager.t("board.widget.kindWebsite")).toBe("Website");
+    expect(manager.t("board.widget.websiteOpen")).toBe("board.widget.websiteOpen");
+    expect(manager.t("board.widget.websiteEmbedHint")).toBe("board.widget.websiteEmbedHint");
+    expect(manager.t("board.widget.websiteSameOrigin")).toBe("board.widget.websiteSameOrigin");
+
+    await manager.setLocale("de");
+    await import("../lib/board/widgets/website.ts");
+
+    expect(en.board).toBe(board);
+    expect(manager.t("board.label")).toBe("Session dashboard");
+    expect(manager.t("board.widget.kindWebsite")).toBe("Website");
+    expect(manager.t("common.health")).toBe("Gesundheit");
+    expect(manager.t("board.widget.websiteOpen")).toBe("Open website");
+    expect(manager.t("board.widget.websiteEmbedHint")).toBe(
+      "If this site does not load here, open it in a new tab.",
+    );
+    expect(manager.t("board.widget.websiteSameOrigin")).toBe(
+      "Open this website in a new tab. Gateway and Control UI pages cannot be embedded in a website widget.",
+    );
+  });
+});

--- a/ui/src/lib/board/widgets/website.ts
+++ b/ui/src/lib/board/widgets/website.ts
@@ -7,9 +7,12 @@ import { renderBoardWidgetError } from "../../../components/board/board-widget-c
 import { icons } from "../../../components/icons.ts";
 import { resolveGatewayHttpOrigin } from "../../../components/sandbox-host.ts";
 import { t } from "../../../i18n/index.ts";
+import { registerBoardWebsiteEnglish } from "../../../i18n/locales/en-board-website.ts";
 import { OpenClawLightDomElement } from "../../../lit/openclaw-element.ts";
 import type { BoardWidget } from "../types.ts";
 import "./website.css";
+
+registerBoardWebsiteEnglish();
 
 class OpenClawWebsiteWidget extends OpenClawLightDomElement {
   @consume({ context: applicationContext, subscribe: true })


### PR DESCRIPTION
## What Problem This Solves

Fixes the red `control-ui-performance` job on main that blocks update-repair PRs: the Control UI startup JavaScript exceeds its existing gzip limit.

## User Impact

The initial Control UI download is smaller. Website dashboards retain the same labels, translations, sandbox behavior, and lazy activation; no operator action is required.

## Why This Change Was Made

The website widget introduced in #146312 already loads lazily, but three strings used only by that widget were added to startup English. Register that copy when the website module loads, using the existing lazy-English pattern, and keep it in the canonical host-side catalog for translation generation. The shared Website registry label stays eager.

Same-path, fixed-identity builds with Node 26.8.2, Vite 8.2.2, and Pako 3.0.1 identify the crossing:

| Landing | Parent startup gzip | Child startup gzip | Change |
| --- | ---: | ---: | ---: |
| #146312 (`5c1691edae5`) | 355,007 B | 355,122 B | +115 B; crosses 355,116 B limit |
| #146343 (`3621a16d720`) | 355,129 B | 355,143 B | +14 B |
| #146500 (`7d2d7fcd393`) | 355,143 B | 355,138 B | −5 B |

Refs #146312, #146343, #146500.

## Evidence

- CI's `pnpm ui:check-performance:base a9d273dc5f5ac320234fb6a5e032a50e40c8d399`: **355,138 B failing → 355,052 B passing**, saving 86 B with 64 B remaining under the unchanged 355,116 B enforcement limit. The narrow website boundary does not naturally provide 200 B of headroom.
- New loading regression fails before the fix: expected `board.widget.websiteOpen` before widget loading, received `Open website`; passes afterward. Existing widget activation, iframe retention, URL rejection, same-host blocking, and registry tests also pass: **3 files, 11 tests**.
- Focused command: `node scripts/run-vitest.mjs ui/src/i18n/website-loading.test.ts ui/src/lib/board/widgets/website.test.ts ui/src/lib/board/widgets/index.test.ts`.
- Complete host-side English catalog comparison preserves all **9,018 keys and values**.
- `pnpm build` passes with no `[INEFFECTIVE_DYNAMIC_IMPORT]` warnings. Its ordinary build metadata measures 355,110 B (6 B under the same limit); the comparison above uses CI's fixed identity. Emitted assets confirm the website-only copy is absent from all eight startup JS assets and present in the deferred website chunk.
- `node scripts/check-changed.mjs` passes, including core test/UI/script types, i18n, lint, and export guards. `pnpm ui:check-performance` also passes on the ordinary full build.

No budget, allowance, generated translation, or snapshot changes. Appearance is unchanged; loading and bundle assertions provide the relevant boundary proof. Historical measurements use the same worktree path because archived-source paths produced different chunk hashes and compressed totals. Maintainer autoreview and landing remain with the campaign lead.
