### PR TITLE
fix(gateway): install despite stale Linux session bus addresses

### DIFF
--- a/docs/gateway/index.md
+++ b/docs/gateway/index.md
@@ -242,6 +242,14 @@ sudo loginctl enable-linger $(whoami)
 
 On a headless server without a desktop session, also make sure `XDG_RUNTIME_DIR` is set (`export XDG_RUNTIME_DIR=/run/user/$(id -u)`) before retrying `systemctl --user` commands.
 
+Service definition inspection also needs the user session bus. `systemctl --user`
+can reach systemd's private socket even when that bus is missing. If installation
+or status reports an unavailable user bus, install `dbus-user-session` on
+Debian/Ubuntu, run `systemctl --user start dbus.socket`, and verify
+`busctl --user list` from the service account before retrying installation.
+An absent unit is safe to install; an unreadable existing definition must be
+repaired by its owner first.
+
 Manual user-unit example when you need a custom install path:
 
 ```ini

--- a/docs/gateway/index.md
+++ b/docs/gateway/index.md
@@ -242,13 +242,13 @@ sudo loginctl enable-linger $(whoami)
 
 On a headless server without a desktop session, also make sure `XDG_RUNTIME_DIR` is set (`export XDG_RUNTIME_DIR=/run/user/$(id -u)`) before retrying `systemctl --user` commands.
 
-Service definition inspection also needs the user session bus. `systemctl --user`
-can reach systemd's private socket even when that bus is missing. If installation
-or status reports an unavailable user bus, install `dbus-user-session` on
-Debian/Ubuntu, run `systemctl --user start dbus.socket`, and verify
-`busctl --user list` from the service account before retrying installation.
-An absent unit is safe to install; an unreadable existing definition must be
-repaired by its owner first.
+Service inspection uses the private user-manager socket when available. Broker
+queries prefer `$XDG_RUNTIME_DIR/bus` over a stale shell session-bus address.
+If neither transport reaches the manager, check `XDG_RUNTIME_DIR`, log in once
+or enable lingering, and verify `systemctl --user status`. On Debian/Ubuntu,
+`dbus-user-session` provides the user bus; start it with
+`systemctl --user start dbus.socket` if needed. An absent unit is safe to install;
+an unreadable existing definition must be repaired by its owner first.
 
 Manual user-unit example when you need a custom install path:
 

--- a/docs/gateway/index.md
+++ b/docs/gateway/index.md
@@ -242,9 +242,13 @@ sudo loginctl enable-linger $(whoami)
 
 On a headless server without a desktop session, also make sure `XDG_RUNTIME_DIR` is set (`export XDG_RUNTIME_DIR=/run/user/$(id -u)`) before retrying `systemctl --user` commands.
 
-Service inspection uses the private user-manager socket when available. Broker
-queries prefer `$XDG_RUNTIME_DIR/bus` over a stale shell session-bus address.
-If neither transport reaches the manager, check `XDG_RUNTIME_DIR`, log in once
+Service inspection preserves an explicit `DBUS_SESSION_BUS_ADDRESS` that reaches
+the user manager. Otherwise it tries `$XDG_RUNTIME_DIR/bus`, then the private
+manager socket for inspection. Install, status, and update admission reuse the
+selected route; `gateway status --deep` shows it. Update admission rechecks routes
+that timed out during earlier discovery. A socket's existence alone does
+not replace a working custom bus. If no route reaches the manager, check
+`XDG_RUNTIME_DIR`, log in once
 or enable lingering, and verify `systemctl --user status`. On Debian/Ubuntu,
 `dbus-user-session` provides the user bus; start it with
 `systemctl --user start dbus.socket` if needed. An absent unit is safe to install;

--- a/scripts/e2e/lib/doctor-install-switch/shims/busctl
+++ b/scripts/e2e/lib/doctor-install-switch/shims/busctl
@@ -61,14 +61,22 @@ while (args[commandIndex]?.startsWith("--")) {
   }
   flags.add(flag);
 }
-if (!flags.has("--json=short")) {
-  fail();
-}
-
 // This fixture owns a stopped, loaded user service and never starts a manager.
 const owner = ":1.42";
 const bus = "org.freedesktop.DBus";
 const invocation = args.slice(commandIndex);
+if (
+  flags.has("--auto-start=no") &&
+  flags.size === 1 &&
+  invocation.length === 5 &&
+  invocation.join(" ") === `get-property ${manager} ${rootObjectPath} ${manager}.Manager Version`
+) {
+  process.stdout.write('s "252.39-1~deb12u2"\n');
+  process.exit(0);
+}
+if (!flags.has("--json=short")) {
+  fail();
+}
 const unitName = `${process.env.OPENCLAW_SYSTEMD_UNIT || "openclaw-gateway"}`.replace(
   /(?:\.service)?$/u,
   ".service",

--- a/scripts/e2e/lib/upgrade-survivor/systemd-fixture.mjs
+++ b/scripts/e2e/lib/upgrade-survivor/systemd-fixture.mjs
@@ -324,6 +324,15 @@ function writeProperties(properties) {
 
 function run() {
   const [operation, ...args] = process.argv.slice(2);
+  if (
+    operation === "busctl" &&
+    args.length === 7 &&
+    args.join(" ") ===
+      `--user --auto-start=no get-property ${manager} ${root} ${manager}.Manager Version`
+  ) {
+    console.log('s "252.39-1~deb12u2"');
+    return;
+  }
   if (operation === "busctl" && inspectLoadedRuntime(args)) {
     return;
   }

--- a/scripts/e2e/lib/upgrade-survivor/update-restart-auth.sh
+++ b/scripts/e2e/lib/upgrade-survivor/update-restart-auth.sh
@@ -2,11 +2,14 @@
 
 install_update_restart_systemctl_shim() {
   local shim_dir="$npm_config_prefix/bin"
+  export XDG_RUNTIME_DIR="$shim_dir/runtime"
+  export DBUS_SESSION_BUS_ADDRESS="unix:path=$XDG_RUNTIME_DIR/bus"
   local manager_env
   manager_env="$(node <<'MANAGER_ENV'
 const keys = [
   "CI", "OPENCLAW_NO_ONBOARD", "OPENCLAW_NO_PROMPT", "OPENCLAW_SKIP_PROVIDERS",
   "OPENCLAW_SKIP_CHANNELS", "OPENCLAW_DISABLE_BONJOUR",
+  "XDG_RUNTIME_DIR", "DBUS_SESSION_BUS_ADDRESS",
 ];
 const captured = Object.fromEntries(keys.map((key) => [key, process.env[key] ?? null]));
 const registry = process.env.NPM_CONFIG_REGISTRY || process.env.npm_config_registry || null;

--- a/src/cli/daemon-cli/install.integration.test.ts
+++ b/src/cli/daemon-cli/install.integration.test.ts
@@ -446,6 +446,28 @@ describe("runDaemonInstall integration", () => {
     },
   );
 
+  it("names an unreadable Linux unit without changing config or replacing it", async () => {
+    const unit = path.join(accountHome, ".config/systemd/user/openclaw-gateway.service");
+    const readFile = fs.readFile.bind(fs);
+    vi.spyOn(fs, "readFile").mockImplementation(async (...args) => {
+      if (args[0] === unit) {
+        throw Object.assign(new Error("private-native-error-canary"), { code: "EACCES" });
+      }
+      return readFile(...args);
+    });
+    serviceMock.readCommand.mockImplementation(readSystemdServiceExecStart);
+    serviceMock.isLoaded.mockRejectedValue(new Error("Failed to get unit file state"));
+    const before = await snapshotConfig();
+    await expect(runDaemonInstall({ json: true, force: true })).rejects.toThrow("__exit__:1");
+    const output = runtimeLogs.join("\n");
+    expect(output).toContain(JSON.stringify(unit).slice(1, -1));
+    expect(output).toContain("unreadable");
+    expect(output).not.toContain("private-native-error-canary");
+    expect(await snapshotConfig()).toEqual(before);
+    expect(serviceMock.install).not.toHaveBeenCalled();
+    expect(serviceMock.isLoaded).not.toHaveBeenCalled();
+  });
+
   it.each(["fragment", "drop-in"])(
     "blocks a root-owned manager %s before config or token writes",
     async (kind) => {

--- a/src/cli/daemon-cli/install.test.ts
+++ b/src/cli/daemon-cli/install.test.ts
@@ -1,5 +1,6 @@
 import "./install.test-support.js";
 import { describe, expect, it, vi } from "vitest";
+import { ServiceInspectionError } from "../../daemon/service-inspection-error.js";
 import { withGatewayServiceUpdateAuthority } from "../../daemon/service-update-authority.js";
 
 const {
@@ -92,6 +93,18 @@ describe("runDaemonInstall", () => {
     );
     expect(replaceConfigFileMock).not.toHaveBeenCalled();
     expect(randomTokenMock).not.toHaveBeenCalled();
+    expect(installDaemonServiceAndEmitMock).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["systemd-user-bus-unavailable", "systemd user session bus"],
+    ["launchd-gui-domain-unavailable", "launchd GUI domain"],
+  ] as const)("explains %s before writing config", async (reason, detail) => {
+    service.readCommand.mockRejectedValueOnce(new ServiceInspectionError(reason));
+    await runDaemonInstall({ json: true });
+    expect(actionState.failed[0]?.message).toContain(detail);
+    expect(actionState.failed[0]?.message).not.toContain("SERVICE_DEFINITION_UNKNOWN");
+    expect(replaceConfigFileMock).not.toHaveBeenCalled();
     expect(installDaemonServiceAndEmitMock).not.toHaveBeenCalled();
   });
 

--- a/src/cli/daemon-cli/install.ts
+++ b/src/cli/daemon-cli/install.ts
@@ -22,6 +22,7 @@ import { isNodeRuntime } from "../../daemon/runtime-binary.js";
 import { resolveNodeRuntimeInfo, resolvePreferredNodePath } from "../../daemon/runtime-paths.js";
 import { readEmbeddedGatewayToken } from "../../daemon/service-audit.js";
 import { mergeGatewayServiceEnv } from "../../daemon/service-env-merge.js";
+import { sanitizeServiceInspectionError } from "../../daemon/service-inspection-error.js";
 import {
   assertServiceDefinitionWritable,
   resolveManagedGatewayServiceCommand,
@@ -183,6 +184,13 @@ export async function runDaemonInstall(opts: DaemonInstallOptions) {
     return;
   }
   const service = resolveGatewayService();
+  let existingServiceCommand: GatewayServiceCommandConfig | null;
+  try {
+    existingServiceCommand = await service.readCommand(process.env, { requireEffective: true });
+  } catch (error) {
+    fail(sanitizeServiceInspectionError(error).message);
+    return;
+  }
   let loaded;
   try {
     loaded = await service.isLoaded({ env: process.env });
@@ -192,13 +200,6 @@ export async function runDaemonInstall(opts: DaemonInstallOptions) {
       return;
     }
     loaded = false;
-  }
-  let existingServiceCommand: GatewayServiceCommandConfig | null;
-  try {
-    existingServiceCommand = await service.readCommand(process.env, { requireEffective: true });
-  } catch {
-    fail("SERVICE_DEFINITION_UNKNOWN: Service definition cannot be safely inspected.");
-    return;
   }
   const existingManagedCommand = resolveManagedGatewayServiceCommand(existingServiceCommand);
   const existingServiceEnv = existingManagedCommand?.environment;

--- a/src/cli/daemon-cli/shared.ts
+++ b/src/cli/daemon-cli/shared.ts
@@ -10,7 +10,7 @@ import { resolveDaemonContainerContext } from "../../daemon/container-context.js
 import { formatRuntimeStatus } from "../../daemon/runtime-format.js";
 import { buildPlatformServiceStartHints } from "../../daemon/runtime-hints.js";
 import type { GatewayServiceCommandConfig } from "../../daemon/service-types.js";
-import { hasSudoToRootSystemdUserManagerMismatch } from "../../daemon/systemd-exec.js";
+import { hasSudoToRootSystemdUserManagerMismatch } from "../../daemon/systemd-user-transport.js";
 import { resolveGatewayServiceMutationError } from "../../infra/gateway-supervision.js";
 import { formatCliCommand } from "../command-format.js";
 import { parsePort } from "../shared/parse-port.js";

--- a/src/cli/daemon-cli/status.print.ts
+++ b/src/cli/daemon-cli/status.print.ts
@@ -93,6 +93,12 @@ export function printDaemonStatus(status: DaemonStatus, opts: { json: boolean; d
   defaultRuntime.log(
     `${label("Service:")} ${accent(service.label)} (${serviceStatus})${diagnosticOnlySuffix}`,
   );
+  const transport = service.runtime?.systemd?.transport;
+  if (opts.deep && transport) {
+    defaultRuntime.log(
+      `${label("Systemd transport:")} ${infoText(`${transport.kind} (${transport.kind === "machine" ? transport.user : transport.address})`)}`,
+    );
+  }
   if (status.logFile) {
     defaultRuntime.log(`${label("File logs:")} ${infoText(shortenHomePath(status.logFile))}`);
   }

--- a/src/cli/update-cli/update-command-service-recovery.test-support.ts
+++ b/src/cli/update-cli/update-command-service-recovery.test-support.ts
@@ -24,6 +24,9 @@ export async function createServiceActivationFixture() {
   vi.spyOn(os, "userInfo").mockReturnValue({ ...os.userInfo(), homedir: root });
   const keys = [
     "HOME",
+    "XDG_RUNTIME_DIR",
+    "DBUS_SESSION_BUS_ADDRESS",
+    "SUDO_USER",
     "OPENCLAW_HOME",
     "OPENCLAW_STATE_DIR",
     "OPENCLAW_CONFIG_PATH",
@@ -44,6 +47,8 @@ export async function createServiceActivationFixture() {
     delete process.env[key];
   }
   process.env.HOME = root;
+  process.env.XDG_RUNTIME_DIR = path.join(root, ".runtime");
+  process.env.DBUS_SESSION_BUS_ADDRESS = `unix:path=${process.env.XDG_RUNTIME_DIR}/bus`;
   // This fixture models an installed service even though its manager calls are simulated.
   const unitPath = path.join(root, ".config/systemd/user/openclaw-gateway.service");
   await fs.mkdir(path.dirname(unitPath), { recursive: true });

--- a/src/cli/update-cli/update-command-service.integration.test.ts
+++ b/src/cli/update-cli/update-command-service.integration.test.ts
@@ -161,14 +161,40 @@ vi.mock("./update-command-service-command.js", async (importOriginal) => {
       ),
   };
 });
-vi.mock("../../process/exec.js", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("../../process/exec.js")>()),
-  runCommandWithTimeout: mocks.child,
-  runExec: vi.fn(
-    async (_command: string, _args: string[], options: { input: string | Uint8Array }) =>
-      decodeLaunchAgentPlistFixture(options.input),
-  ),
-}));
+vi.mock("../../process/exec.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../process/exec.js")>();
+  const versionProbe = [
+    "busctl",
+    "--user",
+    "--auto-start=no",
+    "get-property",
+    "org.freedesktop.systemd1",
+    "/org/freedesktop/systemd1",
+    "org.freedesktop.systemd1.Manager",
+    "Version",
+  ];
+  return {
+    ...actual,
+    runCommandWithTimeout: (...args: Parameters<typeof actual.runCommandWithTimeout>) => {
+      const [argv] = args;
+      if (argv.length === versionProbe.length && versionProbe.every((arg, i) => argv[i] === arg)) {
+        return Promise.resolve({
+          code: 0,
+          stdout: 's "252.39"',
+          stderr: "",
+          signal: null,
+          killed: false,
+          termination: "exit" as const,
+        });
+      }
+      return mocks.child(...args);
+    },
+    runExec: vi.fn(
+      async (_command: string, _args: string[], options: { input: string | Uint8Array }) =>
+        decodeLaunchAgentPlistFixture(options.input),
+    ),
+  };
+});
 vi.mock("../../infra/gateway-processes.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../../infra/gateway-processes.js")>()),
   findVerifiedGatewayListenerPidsOnPortSync: mocks.listenerPids,

--- a/src/commands/doctor-gateway-services.authority.test.ts
+++ b/src/commands/doctor-gateway-services.authority.test.ts
@@ -84,6 +84,8 @@ describe.skipIf(process.platform === "win32")("Doctor native repair authority or
     const installedEnvironmentPath = path.join(installedStateDir, "gateway.systemd.env");
     const wrapperPath = path.join(root, "openclaw-fixture");
     const systemUnits = path.join(root, "system-units");
+    const runtimeDir = path.join(root, "runtime");
+    const busAddress = `unix:path=${runtimeDir}/bus`;
     await fs.mkdir(installedStateDir, { recursive: true, mode: 0o700 });
     await fs.mkdir(path.dirname(unitPath), { recursive: true, mode: 0o755 });
     await fs.mkdir(systemUnits, { mode: 0o755 });
@@ -186,11 +188,27 @@ describe.skipIf(process.platform === "win32")("Doctor native repair authority or
         stderr: "",
       };
     });
-    edges.command.mockImplementation(async (argv) => {
+    edges.command.mockImplementation(async (argv, options) => {
       const [binary, ...args] = argv;
       let stdout: string;
       let code = 0;
-      if (binary === "busctl") {
+      if (
+        binary === "busctl" &&
+        isDeepStrictEqual(args, [
+          "--user",
+          "--auto-start=no",
+          "get-property",
+          "org.freedesktop.systemd1",
+          "/org/freedesktop/systemd1",
+          "org.freedesktop.systemd1.Manager",
+          "Version",
+        ])
+      ) {
+        expect(options).toMatchObject({
+          baseEnv: { XDG_RUNTIME_DIR: runtimeDir, DBUS_SESSION_BUS_ADDRESS: busAddress },
+        });
+        stdout = 's "252.39-1~deb12u2"\n';
+      } else if (binary === "busctl") {
         stdout = args.includes("LoadUnit")
           ? JSON.stringify({ type: "o", data: ["/org/freedesktop/systemd1/unit/fixture"] })
           : args.includes("org.freedesktop.systemd1.Unit")
@@ -257,6 +275,11 @@ describe.skipIf(process.platform === "win32")("Doctor native repair authority or
       {
         HOME: home,
         USERPROFILE: home,
+        USER: "doctor-fixture",
+        LOGNAME: "doctor-fixture",
+        SUDO_USER: undefined,
+        XDG_RUNTIME_DIR: runtimeDir,
+        DBUS_SESSION_BUS_ADDRESS: busAddress,
         OPENCLAW_HOME: undefined,
         OPENCLAW_STATE_DIR: stateDir,
         OPENCLAW_CONFIG_PATH: configPath,

--- a/src/commands/doctor-maintenance.service-inspection.test.ts
+++ b/src/commands/doctor-maintenance.service-inspection.test.ts
@@ -81,7 +81,6 @@ it.each([
     "OPENCLAW_SERVICE_KIND",
     "OPENCLAW_LAUNCHD_LABEL",
     "OPENCLAW_SYSTEMD_UNIT",
-    "XDG_RUNTIME_DIR",
     "DBUS_SESSION_BUS_ADDRESS",
     "SUDO_USER",
   ]) {
@@ -89,6 +88,7 @@ it.each([
   }
   vi.stubEnv("HOME", home);
   vi.stubEnv("USERPROFILE", home);
+  vi.stubEnv("XDG_RUNTIME_DIR", path.join(home, "runtime"));
   vi.stubEnv("USER", "svc");
   if (scenario.platform === "linux") {
     const unitDir = path.join(home, ".config/systemd/user");

--- a/src/commands/doctor-update.candidate.test.ts
+++ b/src/commands/doctor-update.candidate.test.ts
@@ -5,6 +5,7 @@ import { DatabaseSync } from "node:sqlite";
 import { afterEach, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import type { PreManagedServiceStop } from "../cli/update-cli/update-command-service-context-types.js";
+import { resolveStableNodePath } from "../infra/stable-node-path.js";
 import {
   createManagedHandoffLeaseStore,
   resolveManagedUpdateLeaseDatabasePath,
@@ -194,8 +195,9 @@ it.each([
       }
       return response;
     });
+    const stableNodePath = await resolveStableNodePath(process.execPath);
     const runCommand: CommandRunner = async (argv, options) => {
-      if (argv[0] === "git" || argv[0] === process.execPath) {
+      if (argv[0] === "git" || argv[0] === process.execPath || argv[0] === stableNodePath) {
         return actualExec.runCommandWithTimeout(argv, options);
       }
       if (argv[0] === "pnpm") {

--- a/src/daemon/service-absence.test.ts
+++ b/src/daemon/service-absence.test.ts
@@ -12,6 +12,60 @@ afterEach(() => {
 });
 
 describe("readGatewayServiceState absence", () => {
+  it("does not require a user bus to inspect a running system service", async () => {
+    mockProcessPlatform("linux");
+    const missing = () => Object.assign(new Error("missing"), { code: "ENOENT" });
+    vi.spyOn(fs, "readFile").mockRejectedValue(missing());
+    vi.spyOn(fs, "access").mockImplementation(async (file) => {
+      if (file !== "/etc/systemd/system/openclaw-gateway.service") {
+        throw missing();
+      }
+    });
+    vi.spyOn(fs, "readdir").mockResolvedValue([]);
+    vi.spyOn(await import("./exec-file.js"), "execFileUtf8").mockImplementation(
+      async (command) => ({
+        code: command === "busctl" ? 1 : 0,
+        termination: "exit",
+        stdout: command === "busctl" ? "" : "LoadState=loaded\nActiveState=active\nMainPID=42\n",
+        stderr: command === "busctl" ? "Failed to connect to bus: No such file or directory" : "",
+      }),
+    );
+    const state = await readGatewayServiceState(resolveGatewayService(), {
+      env: { HOME: "/openclaw-service-proof", DBUS_SESSION_BUS_ADDRESS: "unix:path=/proof/bus" },
+    });
+    expect(state.runtime).toMatchObject({ status: "running", pid: 42 });
+    expect(state.inspectionReason).toBeUndefined();
+  });
+
+  it.each([
+    ["user bus", "systemd-user-bus-unavailable"],
+    ["busctl", "systemd-busctl-unavailable"],
+  ])(
+    "reports missing %s instead of recommending an impossible fresh install",
+    async (missingPiece, reason) => {
+      mockProcessPlatform("linux");
+      const missing = () => Object.assign(new Error("missing"), { code: "ENOENT" });
+      vi.spyOn(fs, "readFile").mockRejectedValue(missing());
+      vi.spyOn(fs, "access").mockRejectedValue(missing());
+      vi.spyOn(fs, "readdir").mockResolvedValue([]);
+      const run = vi.spyOn(await import("./exec-file.js"), "execFileUtf8");
+      run.mockImplementation(async (command) => ({
+        code: command === "busctl" ? 1 : 0,
+        termination: command === "busctl" && missingPiece === "busctl" ? "error" : "exit",
+        errorCode: command === "busctl" && missingPiece === "busctl" ? "ENOENT" : undefined,
+        stdout:
+          command === "busctl" ? "" : "LoadState=not-found\nActiveState=inactive\nSubState=dead\n",
+        stderr: command === "busctl" ? "Failed to connect to bus: No such file or directory" : "",
+      }));
+      const state = await readGatewayServiceState(resolveGatewayService(), {
+        env: { HOME: "/openclaw-service-proof", DBUS_SESSION_BUS_ADDRESS: "unix:path=/proof/bus" },
+      });
+      expect(state.inspectionReason).toBe(reason);
+      expect(state.runtime?.missingUnit).not.toBe(true);
+      expect(state.runtime?.status).toBe("unknown");
+    },
+  );
+
   it.each(["current", "revoked", "expired"])(
     "preserves the admitted binding and deadline through an absent projection (%s)",
     async (condition) => {

--- a/src/daemon/service-absence.test.ts
+++ b/src/daemon/service-absence.test.ts
@@ -4,6 +4,15 @@ import { mockProcessPlatform } from "../test-utils/vitest-spies.js";
 import { readGatewayServiceState, resolveGatewayService, type GatewayService } from "./service.js";
 import { createMockGatewayService, mockSystemAccountHome } from "./service.test-helpers.js";
 
+const serviceEnv = (scenario: string) => ({
+  HOME: `/openclaw-service-proof/${scenario}`,
+  XDG_RUNTIME_DIR: `/openclaw-service-proof/${scenario}/runtime`,
+  DBUS_SESSION_BUS_ADDRESS: `unix:path=/openclaw-service-proof/${scenario}/bus`,
+  USER: "service",
+  LOGNAME: "service",
+  SUDO_USER: undefined,
+});
+
 beforeEach(() => {
   mockSystemAccountHome();
 });
@@ -31,7 +40,7 @@ describe("readGatewayServiceState absence", () => {
       }),
     );
     const state = await readGatewayServiceState(resolveGatewayService(), {
-      env: { HOME: "/openclaw-service-proof", DBUS_SESSION_BUS_ADDRESS: "unix:path=/proof/bus" },
+      env: serviceEnv("running-system-service"),
     });
     expect(state.runtime).toMatchObject({ status: "running", pid: 42 });
     expect(state.inspectionReason).toBeUndefined();
@@ -58,7 +67,7 @@ describe("readGatewayServiceState absence", () => {
         stderr: command === "busctl" ? "Failed to connect to bus: No such file or directory" : "",
       }));
       const state = await readGatewayServiceState(resolveGatewayService(), {
-        env: { HOME: "/openclaw-service-proof", DBUS_SESSION_BUS_ADDRESS: "unix:path=/proof/bus" },
+        env: serviceEnv(reason),
       });
       expect(state.inspectionReason).toBe(reason);
       expect(state.runtime?.missingUnit).not.toBe(true);
@@ -152,7 +161,7 @@ describe("readGatewayServiceState absence", () => {
         throw missing();
       });
       const run = vi.spyOn(await import("./exec-file.js"), "execFileUtf8");
-      run.mockImplementation(async (_command, args) => {
+      run.mockImplementation(async (command, args) => {
         const system = args.includes("--system");
         const success = (type: string, data: unknown) => ({
           code: 0,
@@ -168,6 +177,19 @@ describe("readGatewayServiceState absence", () => {
         });
         if (condition === (system ? "system-unavailable" : "user-unavailable")) {
           return failure("Failed to connect to bus: No such file or directory");
+        }
+        if (args.includes("Version")) {
+          expect(command).toBe("busctl");
+          expect(args).toEqual([
+            "--user",
+            "--auto-start=no",
+            "get-property",
+            "org.freedesktop.systemd1",
+            "/org/freedesktop/systemd1",
+            "org.freedesktop.systemd1.Manager",
+            "Version",
+          ]);
+          return { code: 0, termination: "exit", stdout: 's "252.39"', stderr: "" };
         }
         if (args.includes("GetNameOwner")) {
           return success("s", [":1.2"]);
@@ -186,7 +208,7 @@ describe("readGatewayServiceState absence", () => {
         return failure("Unexpected native query");
       });
       const result = readGatewayServiceState(resolveGatewayService(), {
-        env: { HOME: "/openclaw-service-proof", DBUS_SESSION_BUS_ADDRESS: "unix:path=/proof/bus" },
+        env: serviceEnv(condition),
         requireEffective: true,
         requireLoadedCommand: true,
       });

--- a/src/daemon/service-env-merge.ts
+++ b/src/daemon/service-env-merge.ts
@@ -11,6 +11,20 @@ export function mergeGatewayServiceEnv(
     ...baseEnv,
     ...command.environment,
   };
+  // Payload environment cannot redirect the caller's supervisor bus or account.
+  for (const key of [
+    "DBUS_SESSION_BUS_ADDRESS",
+    "XDG_RUNTIME_DIR",
+    "USER",
+    "LOGNAME",
+    "SUDO_USER",
+  ]) {
+    if (Object.hasOwn(baseEnv, key)) {
+      merged[key] = baseEnv[key];
+    } else {
+      delete merged[key];
+    }
+  }
   for (const key of [
     "OPENCLAW_LAUNCHD_LABEL",
     "OPENCLAW_SYSTEMD_UNIT",

--- a/src/daemon/service-inspection-error.ts
+++ b/src/daemon/service-inspection-error.ts
@@ -1,7 +1,7 @@
 /** Native probe facts are diagnostic only; they never grant lifecycle authority. */
 const SERVICE_INSPECTION_MESSAGES = {
   "systemd-user-bus-unavailable":
-    "The systemd user session bus is unavailable. Check XDG_RUNTIME_DIR and DBUS_SESSION_BUS_ADDRESS for the service account. On Debian/Ubuntu, install dbus-user-session and run systemctl --user start dbus.socket. For SSH sessions, enable lingering with sudo loginctl enable-linger <user>. Verify systemctl --user status and busctl --user list, then retry.",
+    "The systemd user session bus is unavailable. Check XDG_RUNTIME_DIR for the service account. Log in once or enable the user manager with sudo loginctl enable-linger <user>, then verify systemctl --user status. On Debian/Ubuntu, install dbus-user-session and run systemctl --user start dbus.socket if the runtime bus is missing. Verify busctl --user list with DBUS_SESSION_BUS_ADDRESS=unix:path=$XDG_RUNTIME_DIR/bus, then retry.",
   "systemd-busctl-unavailable":
     "The busctl executable is unavailable. Install the systemd package providing busctl and verify busctl --user list from the service account, then retry.",
   "service-manager-access-denied":

--- a/src/daemon/service-inspection-error.ts
+++ b/src/daemon/service-inspection-error.ts
@@ -1,7 +1,9 @@
 /** Native probe facts are diagnostic only; they never grant lifecycle authority. */
 const SERVICE_INSPECTION_MESSAGES = {
   "systemd-user-bus-unavailable":
-    "The systemd user session bus is unavailable. Check XDG_RUNTIME_DIR and DBUS_SESSION_BUS_ADDRESS for the service account. On Debian/Ubuntu, install dbus-user-session and start dbus.socket in that account's user manager, then retry.",
+    "The systemd user session bus is unavailable. Check XDG_RUNTIME_DIR and DBUS_SESSION_BUS_ADDRESS for the service account. On Debian/Ubuntu, install dbus-user-session and run systemctl --user start dbus.socket. For SSH sessions, enable lingering with sudo loginctl enable-linger <user>. Verify systemctl --user status and busctl --user list, then retry.",
+  "systemd-busctl-unavailable":
+    "The busctl executable is unavailable. Install the systemd package providing busctl and verify busctl --user list from the service account, then retry.",
   "service-manager-access-denied":
     "The service-manager probe could not start (EACCES/EPERM). Check executable permissions and directory access for the service account, then retry from an accessible directory.",
   "launchd-gui-domain-unavailable":
@@ -30,4 +32,20 @@ export class ServiceInspectionError extends Error {
     super(formatServiceInspectionReason(reason));
     this.name = "ServiceInspectionError";
   }
+}
+
+export class ServiceDefinitionInspectionError extends Error {
+  constructor(pathname: string) {
+    super(
+      `SERVICE_DEFINITION_UNKNOWN: Service definition ${JSON.stringify(pathname)} is unreadable. Inspect the file and its parent directory permissions as the service account; ask its owner to repair it before retrying.`,
+    );
+    this.name = "ServiceDefinitionInspectionError";
+  }
+}
+
+export function sanitizeServiceInspectionError(error: unknown): Error {
+  return error instanceof ServiceInspectionError ||
+    error instanceof ServiceDefinitionInspectionError
+    ? error
+    : new Error("SERVICE_DEFINITION_UNKNOWN: Service definition cannot be safely inspected.");
 }

--- a/src/daemon/service-process-env.integration.test.ts
+++ b/src/daemon/service-process-env.integration.test.ts
@@ -10,6 +10,7 @@ import {
   buildSystemdManagerPropertyOutput,
   buildSystemdUnitPropertyOutput,
 } from "./service.test-helpers.js";
+import { systemdOperatorBusFixtures } from "./systemd-user-bus.test-support.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -78,19 +79,26 @@ try {
     },
   );
 
-  it.each([false, true])(
-    "keeps systemctl and busctl routing with machine fallback %s",
-    async (fallback) => {
+  it.each(["direct", "stale", "machine"])(
+    "keeps systemctl and busctl routing for %s sessions",
+    async (session) => {
       await withTempDir("openclaw-manager-route-", async (temp) => {
         const home = await fs.realpath(temp);
-        const bus = fallback ? undefined : `unix:path=${home}/bus`;
+        const fallback = session === "machine";
+        const bus = fallback
+          ? undefined
+          : systemdOperatorBusFixtures.runtime.address.replace("$XDG_RUNTIME_DIR", home);
+        if (session === "stale") {
+          await fs.writeFile(path.join(home, "bus"), "");
+        }
         const source = {
           HOME: home,
           PATH: home,
           USER: "target",
           LOGNAME: "target",
           XDG_RUNTIME_DIR: fallback ? path.join(home, "missing-runtime") : home,
-          DBUS_SESSION_BUS_ADDRESS: bus,
+          DBUS_SESSION_BUS_ADDRESS:
+            session === "stale" ? systemdOperatorBusFixtures.stale.address : bus,
           BOUNDARY_PARENT_ONLY: "synthetic-parent",
         };
         const callsPath = path.join(home, "calls.jsonl");

--- a/src/daemon/service-process-env.integration.test.ts
+++ b/src/daemon/service-process-env.integration.test.ts
@@ -272,7 +272,7 @@ fs.appendFileSync(${JSON.stringify(callsPath)}, JSON.stringify({
   command: path.basename(process.argv[1]), args,
   canaries: ["BOUNDARY_PARENT_ONLY", "BOUNDARY_INLINE", "BOUNDARY_FILE", "BOUNDARY_SHARED"].map(name => Object.hasOwn(process.env, name)),
   selectors: ["OPENCLAW_SYSTEMD_UNIT", "OPENCLAW_PROFILE", "OPENCLAW_STATE_DIR"].some(name => Object.hasOwn(process.env, name)),
-  native: ${JSON.stringify(Object.entries(env).filter(([name]) => !name.startsWith("OPENCLAW_") && !name.startsWith("BOUNDARY_")))}.every(([name, value]) => process.env[name] === value),
+  native: ${JSON.stringify(Object.entries(env).filter(([name]) => !name.startsWith("OPENCLAW_") && !name.startsWith("BOUNDARY_")))}.every(([name, value]) => process.env[name] === (name === "XDG_RUNTIME_DIR" && path.basename(process.argv[1]) === "systemctl" ? undefined : value)),
   marker: process.env.OPENCLAW_CLI === "1",
 }) + "\\n");`;
       for (const command of ["systemctl", "busctl"]) {
@@ -282,7 +282,8 @@ fs.appendFileSync(${JSON.stringify(callsPath)}, JSON.stringify({
 const fs = require("node:fs"), path = require("node:path");
 ${record}
 if (${JSON.stringify(command)} === "busctl") {
-  if (args.includes("LoadUnit")) console.log(JSON.stringify({ type: "o", data: ["/org/freedesktop/systemd1/unit/boundary"] }));
+  if (JSON.stringify(args) === JSON.stringify(["--user", "--auto-start=no", "get-property", "org.freedesktop.systemd1", "/org/freedesktop/systemd1", "org.freedesktop.systemd1.Manager", "Version"])) console.log('s "252.39"');
+  else if (args.includes("LoadUnit")) console.log(JSON.stringify({ type: "o", data: ["/org/freedesktop/systemd1/unit/boundary"] }));
   else if (args.includes("org.freedesktop.systemd1.Unit")) console.log(${JSON.stringify(unitProperties)});
   else if (args.includes("org.freedesktop.systemd1.Service")) console.log(${JSON.stringify(serviceProperties)});
   else process.exit(91);
@@ -297,6 +298,7 @@ import assert from "node:assert/strict";
 import { readSystemdServiceExecStart } from ${JSON.stringify(new URL("./systemd-service-files.ts", import.meta.url).href)};
 import { mergeGatewayServiceEnv } from ${JSON.stringify(new URL("./service-env-merge.ts", import.meta.url).href)};
 import { execSystemctlUser } from ${JSON.stringify(new URL("./systemd-exec.ts", import.meta.url).href)};
+Object.defineProperty(process, "platform", { value: "linux" });
 const command = await readSystemdServiceExecStart(process.env, { requireEffective: true });
 assert.deepEqual(command.environment, {
   BOUNDARY_INLINE: "synthetic-inline", BOUNDARY_SHARED: "file-wins", BOUNDARY_FILE: "synthetic-file",

--- a/src/daemon/service-process-env.integration.test.ts
+++ b/src/daemon/service-process-env.integration.test.ts
@@ -49,6 +49,7 @@ describe.skipIf(process.platform === "win32")("native control environment bounda
           await fs.writeFile(
             path.join(home, command),
             `#!${process.execPath}
+if (process.argv.includes("Version")) { console.log('s "252.39"'); process.exit(0); }
 console.log(JSON.stringify({
   XDG_RUNTIME_DIR: process.env.XDG_RUNTIME_DIR,
   DBUS_SESSION_BUS_ADDRESS: process.env.DBUS_SESSION_BUS_ADDRESS,
@@ -61,6 +62,7 @@ console.log(JSON.stringify({
 import assert from "node:assert/strict";
 import fs from "node:fs";
 import { execSystemctlUser, execBusctlUser } from ${JSON.stringify(new URL("./systemd-exec.ts", import.meta.url).href)};
+Object.defineProperty(process, "platform", { value: "linux" });
 const callerDirectory = ${JSON.stringify(callerDirectory)};
 process.chdir(callerDirectory);
 fs.chmodSync(callerDirectory, 0o600);
@@ -68,7 +70,9 @@ try {
   for (const execute of [execSystemctlUser, execBusctlUser]) {
     const result = await execute(process.env, ["status"], 5000);
     assert.equal(result.code, 0, JSON.stringify(result));
-    assert.deepEqual(JSON.parse(result.stdout), ${JSON.stringify(native)});
+    assert.deepEqual(JSON.parse(result.stdout), execute === execSystemctlUser
+      ? { DBUS_SESSION_BUS_ADDRESS: ${JSON.stringify(native.DBUS_SESSION_BUS_ADDRESS)} }
+      : ${JSON.stringify(native)});
   }
 } finally {
   fs.chmodSync(callerDirectory, 0o700);
@@ -113,10 +117,13 @@ fs.appendFileSync(${JSON.stringify(callsPath)}, JSON.stringify({
   canary: Object.hasOwn(process.env, "BOUNDARY_PARENT_ONLY"),
   native: process.env.PATH === ${JSON.stringify(home)} && process.env.USER === "target" && process.env.DBUS_SESSION_BUS_ADDRESS === ${JSON.stringify(bus)},
 }) + "\\n");
-if (${JSON.stringify(fallback ? "No medium found" : "")} && !args.includes("--machine")) {
-  console.error("Failed to connect to bus: " + ${JSON.stringify(fallback ? "No medium found" : "")}); process.exit(1);
+if (args.includes("Version")) {
+  const available = ${JSON.stringify(fallback)} ? args.includes("--machine") : process.env.DBUS_SESSION_BUS_ADDRESS === ${JSON.stringify(bus)};
+  if (!available) { console.error("Failed to connect to bus: No medium found"); process.exit(1); }
+  console.log('s "252.39"');
+} else {
+  console.log("running");
 }
-console.log("running");
 `,
             { mode: 0o700 },
           );
@@ -125,6 +132,7 @@ console.log("running");
 import assert from "node:assert/strict";
 import { execSystemctlUser, execBusctlUser } from ${JSON.stringify(new URL("./systemd-exec.ts", import.meta.url).href)};
 process.geteuid = () => 1000;
+Object.defineProperty(process, "platform", { value: "linux" });
 const source = { ...process.env, XDG_RUNTIME_DIR: ${JSON.stringify(source.XDG_RUNTIME_DIR)}, DBUS_SESSION_BUS_ADDRESS: ${JSON.stringify(source.DBUS_SESSION_BUS_ADDRESS)} };
 for (const execute of [execSystemctlUser, execBusctlUser]) {
   const result = await execute(source, ["status"], 5000);
@@ -137,20 +145,34 @@ for (const execute of [execSystemctlUser, execBusctlUser]) {
           .trim()
           .split("\n")
           .map((line) => JSON.parse(line));
-        const expectedArgs = [
-          ["--user", "status"],
-          ...(fallback ? [["--machine", "target@", "--user", "status"]] : []),
+        const versionArgs = [
+          "--auto-start=no",
+          "get-property",
+          "org.freedesktop.systemd1",
+          "/org/freedesktop/systemd1",
+          "org.freedesktop.systemd1.Manager",
+          "Version",
         ];
-        expect(calls).toEqual(
-          ["systemctl", "busctl"].flatMap((command) =>
-            expectedArgs.map((args) => ({
-              command,
-              args,
-              canary: false,
-              native: true,
-            })),
-          ),
-        );
+        const scope = fallback ? ["--machine", "target@", "--user"] : ["--user"];
+        expect(calls).toEqual([
+          ...(session === "stale"
+            ? [
+                {
+                  command: "busctl",
+                  args: ["--user", ...versionArgs],
+                  canary: false,
+                  native: false,
+                },
+              ]
+            : []),
+          { command: "busctl", args: [...scope, ...versionArgs], canary: false, native: true },
+          ...["systemctl", "busctl"].map((command) => ({
+            command,
+            args: [...scope, "status"],
+            canary: false,
+            native: true,
+          })),
+        ]);
       });
     },
   );

--- a/src/daemon/service-runtime.ts
+++ b/src/daemon/service-runtime.ts
@@ -6,9 +6,11 @@ import {
   ServiceInspectionError,
   type ServiceInspectionReason,
 } from "./service-inspection-error.js";
+import type { SystemdUserTransport } from "./systemd-user-transport.js";
 
 /** systemd supervision fields used to spot unhealthy or given-up gateway service state. */
 type GatewayServiceSystemdRuntime = {
+  transport?: SystemdUserTransport;
   unit?: string;
   /** Native D-Bus credential of the observed user-manager connection, not the CLI UID. */
   managerUid?: number;

--- a/src/daemon/service-runtime.ts
+++ b/src/daemon/service-runtime.ts
@@ -6,7 +6,9 @@ import {
   ServiceInspectionError,
   type ServiceInspectionReason,
 } from "./service-inspection-error.js";
-import type { SystemdUserTransport } from "./systemd-user-transport.js";
+export type SystemdUserTransport =
+  | { kind: "session-bus" | "runtime-bus" | "private"; address: string; runtimeDir: string }
+  | { kind: "machine"; user: string };
 
 /** systemd supervision fields used to spot unhealthy or given-up gateway service state. */
 type GatewayServiceSystemdRuntime = {

--- a/src/daemon/service-types.ts
+++ b/src/daemon/service-types.ts
@@ -113,13 +113,18 @@ export type SystemdServiceReadBinding = {
   close: () => Promise<void>;
 };
 
+export type GatewayServiceCommandInspection =
+  | { kind: "absent" | "present" }
+  | { kind: "unavailable"; error: unknown };
+
 /** Bounded service inspection; strict reads reject unverified commands/environments and return null only for proven absence. */
 export type GatewayServiceReadOptions = {
   systemdReadBinding?: SystemdServiceReadBinding;
   timeoutMs?: number;
   requireEffective?: boolean;
-  /** Report failed effective inspection even when a read-only caller accepts the local definition. */
-  onInspectionFailure?: (reason: ServiceInspectionReason) => void;
+  /** Carry the command reader's verdict into runtime inspection without repeating it. */
+  commandInspection?: GatewayServiceCommandInspection;
+  onCommandInspection?: (inspection: GatewayServiceCommandInspection) => void;
   /** Command inspection must not load an unloaded native unit. */
   requireLoaded?: boolean;
   loadForInspection?: GatewayServiceUnitInspection;
@@ -166,13 +171,14 @@ export type ServiceDefinitionMutationCapability =
       kind: "sealed" | "unknown";
       reason: keyof typeof SERVICE_DEFINITION_REASONS;
       artifact?: ServiceDefinitionMutationArtifact;
+      path?: string;
     };
 
 export function assertServiceDefinitionWritable(capability: ServiceDefinitionMutationCapability) {
   if (capability.kind === "writable") {
     return;
   }
-  // Only allowlisted facts reach callers: paths, native errors, and extra fields can contain secrets.
+  // Native errors and extra fields can contain secrets; only recorded artifact paths are diagnostic.
   const reason = Object.hasOwn(SERVICE_DEFINITION_REASONS, capability.reason)
     ? capability.reason
     : "inspection-failed";
@@ -183,7 +189,10 @@ export function assertServiceDefinitionWritable(capability: ServiceDefinitionMut
   // Update recovery recognizes these prefixes to preserve a protected definition.
   const code =
     capability.kind === "sealed" ? "SERVICE_DEFINITION_SEALED" : "SERVICE_DEFINITION_UNKNOWN";
-  throw new Error(`${code}: [${reason}] The ${artifact} ${SERVICE_DEFINITION_REASONS[reason]}`);
+  const location = capability.path ? ` ${JSON.stringify(capability.path)}` : "";
+  throw new Error(
+    `${code}: [${reason}] The ${artifact}${location} ${SERVICE_DEFINITION_REASONS[reason]}`,
+  );
 }
 
 export type GatewayServiceCommandSnapshot = {

--- a/src/daemon/service.test.ts
+++ b/src/daemon/service.test.ts
@@ -253,6 +253,7 @@ describe("readGatewayServiceState", () => {
         }
         process.env.HOME = home;
         process.env.PATH = home;
+        process.env.XDG_RUNTIME_DIR = path.join(home, "runtime");
         const expectedPort = portSource === "config" ? 19902 : 19901;
         if (portSource === "config") {
           await fs.mkdir(path.join(home, ".openclaw"), { recursive: true });

--- a/src/daemon/service.test.ts
+++ b/src/daemon/service.test.ts
@@ -358,7 +358,7 @@ describe("readGatewayServiceState", () => {
           expect(result.blockMessage).toContain("Refusing to mutate code");
           expect(result.serviceUpdateVerdict).toMatchObject({ kind: "unavailable" });
         } else {
-          expect(result.blockMessage).toContain("Refusing to mutate code");
+          expect(result.blockMessage).toContain("busctl executable is unavailable");
           expect(result.serviceUpdateVerdict?.kind).not.toBe("absent");
         }
         expect(result.serviceMutationAllowed).toBe(false);
@@ -494,6 +494,7 @@ describe("readGatewayServiceState", () => {
     expect(readCommand).toHaveBeenCalledWith(process.env, {
       timeoutMs: undefined,
       requireEffective: true,
+      onCommandInspection: expect.any(Function),
     });
   });
 
@@ -511,7 +512,7 @@ describe("readGatewayServiceState", () => {
 
     expect(readCommand).toHaveBeenCalledWith(process.env, {
       timeoutMs: 100,
-      onInspectionFailure: expect.any(Function),
+      onCommandInspection: expect.any(Function),
     });
     expect(state.running).toBe(false);
     expect(state.runtime).toEqual({

--- a/src/daemon/service.ts
+++ b/src/daemon/service.ts
@@ -31,10 +31,7 @@ import {
   uninstallScheduledTask,
 } from "./schtasks.js";
 import { mergeGatewayServiceEnv } from "./service-env-merge.js";
-import {
-  ServiceInspectionError,
-  type ServiceInspectionReason,
-} from "./service-inspection-error.js";
+import { ServiceInspectionError } from "./service-inspection-error.js";
 import { resolveServiceEntrypoint } from "./service-layout.js";
 import {
   withGatewayServiceOperationLock,
@@ -46,6 +43,7 @@ import {
 } from "./service-runtime.js";
 import type {
   GatewayServiceCommandConfig,
+  GatewayServiceCommandInspection,
   GatewayServiceControlArgs,
   GatewayServiceEnv,
   GatewayServiceEnvArgs,
@@ -264,13 +262,20 @@ async function readGatewayServiceStateWithBinding(
   systemdReadBinding?.verify();
   let absent = await service.isAbsent?.({ env: baseEnv, timeoutMs }).catch(() => false);
   systemdReadBinding?.verify();
-  let commandInspectionReason: ServiceInspectionReason | undefined;
+  let commandInspection: GatewayServiceCommandInspection | undefined;
   const command = absent
     ? null
     : args.requireEffective
       ? await service.readCommand(baseEnv, {
           timeoutMs,
           requireEffective: true,
+          ...(!args.requireLoadedCommand
+            ? {
+                onCommandInspection: (inspection: GatewayServiceCommandInspection) => {
+                  commandInspection = inspection;
+                },
+              }
+            : {}),
           ...(systemdReadBinding ? { systemdReadBinding } : {}),
           ...(args.requireLoadedCommand ? { requireLoaded: true } : {}),
           ...(args.loadForInspection ? { loadForInspection: args.loadForInspection } : {}),
@@ -278,8 +283,8 @@ async function readGatewayServiceStateWithBinding(
       : await service
           .readCommand(baseEnv, {
             timeoutMs,
-            onInspectionFailure: (reason) => {
-              commandInspectionReason = reason;
+            onCommandInspection: (inspection) => {
+              commandInspection = inspection;
             },
           })
           .catch(() => null);
@@ -325,6 +330,7 @@ async function readGatewayServiceStateWithBinding(
     service
       .readRuntime(env, {
         timeoutMs,
+        ...(commandInspection ? { commandInspection } : {}),
         ...(systemdReadBinding ? { systemdReadBinding } : {}),
         ...(args.requireEffective && args.requireLoadedCommand ? { requireLoaded: true } : {}),
         ...(args.loadForInspection ? { loadForInspection: args.loadForInspection } : {}),
@@ -346,7 +352,6 @@ async function readGatewayServiceStateWithBinding(
   systemdReadBinding?.verify();
   return {
     inspectionReason:
-      commandInspectionReason ??
       runtime?.inspectionReason ??
       (loadState.status === "unknown" ? loadState.inspectionReason : undefined),
     installed,

--- a/src/daemon/systemd-command-query.test.ts
+++ b/src/daemon/systemd-command-query.test.ts
@@ -1,3 +1,4 @@
+import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -8,11 +9,16 @@ vi.mock("./systemd-exec.js", async (original) => ({
   ...(await original<typeof import("./systemd-exec.js")>()),
   execBusctlUser: busctl,
   bindSystemdManagerOwner: vi.fn(),
-  systemdInspectionError: (_result: unknown, message: string) => new Error(message),
+}));
+vi.mock("./systemd-peer-native.js", async (original) => ({
+  ...(await original<typeof import("./systemd-peer-native.js")>()),
+  openSystemdUserManager: vi.fn(),
 }));
 
 import { createSystemdCommandQuery } from "./systemd-command-query.js";
+import { openSystemdUserManager } from "./systemd-peer-native.js";
 import { readSystemdServiceExecStart } from "./systemd-service-files.js";
+import { systemdOperatorBusFixtures } from "./systemd-user-bus.test-support.js";
 
 const queryEnv = { XDG_RUNTIME_DIR: "/run/user/1234" };
 const unitName = "openclaw-gateway.service";
@@ -31,7 +37,60 @@ beforeEach(() => {
 });
 afterEach(() => vi.restoreAllMocks());
 
+describe("ordinary private-manager inspection", () => {
+  const dirs = useAutoCleanupTempDirTracker(afterEach);
+  it.each(["absent", "disconnected"])(
+    "closes the captured private connection when %s",
+    async (result) => {
+      vi.spyOn(process, "platform", "get").mockReturnValue("linux");
+      vi.spyOn(process, "geteuid").mockReturnValue(1000);
+      const home = dirs.make("openclaw-private-manager-");
+      const runtime = path.join(home, "runtime");
+      const socket = path.posix.join(runtime, "systemd/private");
+      vi.spyOn(fsSync, "existsSync").mockImplementation((file) => file === socket);
+      const close = vi.fn(async () => {});
+      vi.mocked(openSystemdUserManager).mockResolvedValue({
+        close,
+        verify: () => {},
+        query: async () => {
+          if (result === "disconnected") {
+            throw new Error("native-error-secret-canary");
+          }
+          return null;
+        },
+      });
+      busctl.mockResolvedValue(failure(systemdOperatorBusFixtures.stale.getUnitFileState));
+      const inspected = readSystemdServiceExecStart(
+        {
+          HOME: home,
+          XDG_RUNTIME_DIR: runtime,
+          DBUS_SESSION_BUS_ADDRESS: systemdOperatorBusFixtures.stale.address,
+        },
+        { requireEffective: true },
+      );
+      if (result === "absent") {
+        await expect(inspected).resolves.toBeNull();
+      } else {
+        await expect(inspected).rejects.toMatchObject({ reason: "systemd-user-bus-unavailable" });
+      }
+      expect(close).toHaveBeenCalledOnce();
+      expect(busctl).not.toHaveBeenCalled();
+    },
+  );
+});
+
 describe("systemd command query legacy compatibility", () => {
+  it("distinguishes the operator's manager exit transcript from an absent unit", async () => {
+    const args = [...callArgs];
+    args[4] = "GetUnitFileState";
+    busctl.mockResolvedValue(failure(systemdOperatorBusFixtures.stale.getUnitFileState));
+    await expect((await reader()).query(args, ["s"])).rejects.toMatchObject({
+      reason: "systemd-user-bus-unavailable",
+    });
+    busctl.mockResolvedValue(failure(systemdOperatorBusFixtures.runtime.getUnitFileState));
+    await expect((await reader()).query(args, ["s"])).resolves.toBeNull();
+  });
+
   it("retains legacy mode only for this reader", async () => {
     busctl.mockResolvedValueOnce(unsupported).mockResolvedValue(success('o "/unitName"'));
     const legacy = await reader();

--- a/src/daemon/systemd-command-query.test.ts
+++ b/src/daemon/systemd-command-query.test.ts
@@ -1,10 +1,10 @@
-import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 
 const busctl = vi.hoisted(() => vi.fn());
+vi.mock("./exec-file.js", () => ({ execFileUtf8: vi.fn() }));
 vi.mock("./systemd-exec.js", async (original) => ({
   ...(await original<typeof import("./systemd-exec.js")>()),
   execBusctlUser: busctl,
@@ -15,12 +15,17 @@ vi.mock("./systemd-peer-native.js", async (original) => ({
   openSystemdUserManager: vi.fn(),
 }));
 
+import { execFileUtf8 } from "./exec-file.js";
 import { createSystemdCommandQuery } from "./systemd-command-query.js";
 import { openSystemdUserManager } from "./systemd-peer-native.js";
 import { readSystemdServiceExecStart } from "./systemd-service-files.js";
-import { systemdOperatorBusFixtures } from "./systemd-user-bus.test-support.js";
+import {
+  systemdManagerVersionProbe,
+  systemdOperatorBusFixtures,
+} from "./systemd-user-bus.test-support.js";
 
-const queryEnv = { XDG_RUNTIME_DIR: "/run/user/1234" };
+const dirs = useAutoCleanupTempDirTracker(afterEach);
+let queryEnv: { HOME: string; XDG_RUNTIME_DIR: string; DBUS_SESSION_BUS_ADDRESS: string };
 const unitName = "openclaw-gateway.service";
 const callArgs = ["call", "org.test", "/unitName", "org.test.Manager", "LoadUnit", "s", unitName];
 const unavailable = () => new Error("inspection unavailable");
@@ -31,14 +36,28 @@ const query = async (options?: Parameters<typeof createSystemdCommandQuery>[2]) 
 const success = (stdout: string) => ({ code: 0, termination: "exit" as const, stdout, stderr: "" });
 const failure = (stderr: string) => ({ ...success(""), code: 1, stderr });
 const unsupported = failure("busctl: unrecognized option '--json=short'");
+let versionProbeResult = success('s "252.39"');
 
 beforeEach(() => {
   busctl.mockReset();
+  const home = dirs.make("openclaw-command-query-");
+  queryEnv = {
+    HOME: home,
+    XDG_RUNTIME_DIR: path.join(home, "runtime"),
+    DBUS_SESSION_BUS_ADDRESS: `unix:path=${home}/bus`,
+  };
+  versionProbeResult = success('s "252.39"');
+  vi.mocked(execFileUtf8)
+    .mockReset()
+    .mockImplementation(async (command, args) => {
+      await systemdManagerVersionProbe(command, args);
+      return versionProbeResult;
+    });
+  vi.mocked(openSystemdUserManager).mockReset();
 });
 afterEach(() => vi.restoreAllMocks());
 
 describe("ordinary private-manager inspection", () => {
-  const dirs = useAutoCleanupTempDirTracker(afterEach);
   it.each(["absent", "disconnected"])(
     "closes the captured private connection when %s",
     async (result) => {
@@ -47,18 +66,37 @@ describe("ordinary private-manager inspection", () => {
       const home = dirs.make("openclaw-private-manager-");
       const runtime = path.join(home, "runtime");
       const socket = path.posix.join(runtime, "systemd/private");
-      vi.spyOn(fsSync, "existsSync").mockImplementation((file) => file === socket);
+      await fs.mkdir(path.dirname(socket), { recursive: true });
+      await fs.writeFile(socket, "");
+      versionProbeResult = failure(systemdOperatorBusFixtures.stale.getUnitFileState);
+      const closeDiscovery = vi.fn(async () => {});
       const close = vi.fn(async () => {});
-      vi.mocked(openSystemdUserManager).mockResolvedValue({
-        close,
-        verify: () => {},
-        query: async () => {
-          if (result === "disconnected") {
-            throw new Error("native-error-secret-canary");
-          }
-          return null;
-        },
-      });
+      vi.mocked(openSystemdUserManager)
+        .mockResolvedValueOnce({
+          close: closeDiscovery,
+          verify: () => {},
+          query: async (args, signatures) => {
+            expect(args).toEqual([
+              "get-property",
+              "org.freedesktop.systemd1",
+              "/org/freedesktop/systemd1",
+              "org.freedesktop.systemd1.Manager",
+              "Version",
+            ]);
+            expect(signatures).toEqual(["s"]);
+            return ["252.39"];
+          },
+        })
+        .mockResolvedValue({
+          close,
+          verify: () => {},
+          query: async () => {
+            if (result === "disconnected") {
+              throw new Error("native-error-secret-canary");
+            }
+            return null;
+          },
+        });
       busctl.mockResolvedValue(failure(systemdOperatorBusFixtures.stale.getUnitFileState));
       const inspected = readSystemdServiceExecStart(
         {
@@ -73,6 +111,7 @@ describe("ordinary private-manager inspection", () => {
       } else {
         await expect(inspected).rejects.toMatchObject({ reason: "systemd-user-bus-unavailable" });
       }
+      expect(closeDiscovery).toHaveBeenCalledOnce();
       expect(close).toHaveBeenCalledOnce();
       expect(busctl).not.toHaveBeenCalled();
     },
@@ -168,7 +207,6 @@ describe("systemd command query legacy compatibility", () => {
 });
 
 describe("effective service inspection through legacy busctl", () => {
-  const dirs = useAutoCleanupTempDirTracker(afterEach);
   let env: Record<string, string>;
   let unit: string;
   let dropIn: string;
@@ -179,7 +217,12 @@ describe("effective service inspection through legacy busctl", () => {
 
   beforeEach(async () => {
     const home = await fs.realpath(dirs.make("openclaw-systemd-legacy-"));
-    env = { HOME: home, OPENCLAW_SYSTEMD_UNIT: "openclaw-legacy" };
+    env = {
+      HOME: home,
+      XDG_RUNTIME_DIR: path.join(home, "runtime"),
+      DBUS_SESSION_BUS_ADDRESS: `unix:path=${home}/bus`,
+      OPENCLAW_SYSTEMD_UNIT: "openclaw-legacy",
+    };
     unit = path.join(home, ".config/systemd/user/openclaw-legacy.service");
     dropIn = `${unit}.d/override.conf`;
     requiredFile = path.join(home, "required.env");

--- a/src/daemon/systemd-command-query.ts
+++ b/src/daemon/systemd-command-query.ts
@@ -1,5 +1,6 @@
 /** Deadline- and custody-bound effective command queries for the systemd reader. */
 import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
+import { ServiceInspectionError } from "./service-inspection-error.js";
 import type { GatewayServiceEnv, GatewayServiceReadOptions } from "./service-types.js";
 import { decodeLegacyBusctlOutput } from "./systemd-busctl-legacy.js";
 import { bindSystemdManagerOwner, execBusctlUser, systemdInspectionError } from "./systemd-exec.js";
@@ -79,6 +80,9 @@ export async function createSystemdCommandQuery(
         assertCurrent,
       );
       assertCurrent?.();
+    }
+    if (result.termination === "error" && result.errorCode === "ENOENT") {
+      throw new ServiceInspectionError("systemd-busctl-unavailable");
     }
     if (legacyOutput && (result.termination !== "exit" || performance.now() >= callDeadline)) {
       throw systemdInspectionError(result, unavailable().message);

--- a/src/daemon/systemd-command-query.ts
+++ b/src/daemon/systemd-command-query.ts
@@ -1,9 +1,18 @@
 /** Deadline- and custody-bound effective command queries for the systemd reader. */
+import fs from "node:fs";
+import path from "node:path";
 import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
 import { ServiceInspectionError } from "./service-inspection-error.js";
 import type { GatewayServiceEnv, GatewayServiceReadOptions } from "./service-types.js";
+import { assertGatewayServiceUpdateCurrent } from "./service-update-authority.js";
 import { decodeLegacyBusctlOutput } from "./systemd-busctl-legacy.js";
-import { bindSystemdManagerOwner, execBusctlUser, systemdInspectionError } from "./systemd-exec.js";
+import {
+  bindSystemdManagerOwner,
+  execBusctlUser,
+  resolveSystemdUserEnvironment,
+  systemdInspectionError,
+} from "./systemd-exec.js";
+import { openSystemdUserManager } from "./systemd-peer-native.js";
 
 export async function createSystemdCommandQuery(
   env: GatewayServiceEnv,
@@ -24,10 +33,37 @@ export async function createSystemdCommandQuery(
   ) {
     throw unavailable();
   }
+  const route = resolveSystemdUserEnvironment(env);
+  const uid = process.geteuid?.();
+  const runtime = route.XDG_RUNTIME_DIR?.trim() || `/run/user/${uid}`;
+  const privatePath = path.posix.join(runtime, "systemd/private");
+  const managerPeer =
+    !peer &&
+    !opts?.requireLoaded &&
+    process.platform === "linux" &&
+    uid &&
+    path.posix.isAbsolute(privatePath) &&
+    fs.existsSync(privatePath)
+      ? await openSystemdUserManager(
+          `unix:path=${encodeURIComponent(privatePath).replaceAll("%2F", "/")}`,
+          deadlineAt,
+        ).catch(() => {
+          assertGatewayServiceUpdateCurrent();
+          return undefined;
+        })
+      : undefined;
   let remainingCalls = inspection ? 6 : 3;
   let legacyOutput = false;
   // All manager D-Bus calls share one deadline so wedged reads reach local fallback promptly.
   const query = async (args: string[], signatures: string[]): Promise<unknown[] | null> => {
+    if (managerPeer) {
+      try {
+        return await managerPeer.query(args, signatures, deadlineAt);
+      } catch {
+        assertGatewayServiceUpdateCurrent();
+        throw new ServiceInspectionError("systemd-user-bus-unavailable");
+      }
+    }
     const assertCurrent =
       (args[0] === "call" && args[4] === "LoadUnit" ? undefined : inspection?.assertReadCurrent) ??
       inspection?.assertCurrent;
@@ -127,5 +163,12 @@ export async function createSystemdCommandQuery(
       ? await bindSystemdManagerOwner(query, inspection.managerUid, unavailable)
       : undefined);
   const destination = binding?.destination ?? manager;
-  return { query, binding, destination };
+  return {
+    query,
+    binding,
+    destination,
+    close: async () => {
+      await managerPeer?.close();
+    },
+  };
 }

--- a/src/daemon/systemd-command-query.ts
+++ b/src/daemon/systemd-command-query.ts
@@ -1,18 +1,12 @@
 /** Deadline- and custody-bound effective command queries for the systemd reader. */
-import fs from "node:fs";
-import path from "node:path";
 import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
 import { ServiceInspectionError } from "./service-inspection-error.js";
 import type { GatewayServiceEnv, GatewayServiceReadOptions } from "./service-types.js";
 import { assertGatewayServiceUpdateCurrent } from "./service-update-authority.js";
 import { decodeLegacyBusctlOutput } from "./systemd-busctl-legacy.js";
-import {
-  bindSystemdManagerOwner,
-  execBusctlUser,
-  resolveSystemdUserEnvironment,
-  systemdInspectionError,
-} from "./systemd-exec.js";
+import { bindSystemdManagerOwner, execBusctlUser, systemdInspectionError } from "./systemd-exec.js";
 import { openSystemdUserManager } from "./systemd-peer-native.js";
+import { resolveSystemdUserTransport } from "./systemd-user-transport.js";
 
 export async function createSystemdCommandQuery(
   env: GatewayServiceEnv,
@@ -33,23 +27,22 @@ export async function createSystemdCommandQuery(
   ) {
     throw unavailable();
   }
-  const route = resolveSystemdUserEnvironment(env);
-  const uid = process.geteuid?.();
-  const runtime = route.XDG_RUNTIME_DIR?.trim() || `/run/user/${uid}`;
-  const privatePath = path.posix.join(runtime, "systemd/private");
+  const transport = peer
+    ? undefined
+    : await resolveSystemdUserTransport(
+        env,
+        deadlineAt,
+        inspection?.assertReadCurrent ?? inspection?.assertCurrent,
+        opts?.requireLoaded ? "admission" : "inspection",
+      );
+  if (transport?.kind === "private" && opts?.requireLoaded) {
+    throw new ServiceInspectionError("systemd-user-bus-unavailable");
+  }
   const managerPeer =
-    !peer &&
-    !opts?.requireLoaded &&
-    process.platform === "linux" &&
-    uid &&
-    path.posix.isAbsolute(privatePath) &&
-    fs.existsSync(privatePath)
-      ? await openSystemdUserManager(
-          `unix:path=${encodeURIComponent(privatePath).replaceAll("%2F", "/")}`,
-          deadlineAt,
-        ).catch(() => {
+    !opts?.requireLoaded && transport?.kind === "private"
+      ? await openSystemdUserManager(transport.address, deadlineAt).catch(() => {
           assertGatewayServiceUpdateCurrent();
-          return undefined;
+          throw new ServiceInspectionError("systemd-user-bus-unavailable");
         })
       : undefined;
   let remainingCalls = inspection ? 6 : 3;

--- a/src/daemon/systemd-definition-mutation.test.ts
+++ b/src/daemon/systemd-definition-mutation.test.ts
@@ -785,7 +785,7 @@ describe.skipIf(process.platform === "win32")("systemd definition mutation owner
           ? "unsafe-permissions"
           : "inspection-failed";
     expect(capability).toMatchObject({ kind: "unknown", reason });
-    expect(JSON.stringify(capability)).not.toContain(root);
+    expect(capability).toMatchObject({ path: extra });
     expect(JSON.stringify(capability)).not.toContain("secret-canary");
     await expect(stage()).rejects.toThrow(`SERVICE_DEFINITION_UNKNOWN: [${reason}]`);
     expect(await fs.readFile(target, "utf8")).toContain("protected-secret-canary");
@@ -840,9 +840,11 @@ describe.skipIf(process.platform === "win32")("systemd definition mutation owner
     });
 
     const capability = await readSystemdDefinitionMutationCapability(env);
-    expect(capability).toMatchObject({ kind: "sealed" });
+    expect(capability).toMatchObject({ kind: "sealed", path: protectedPath });
     expect(JSON.stringify(capability)).not.toContain("secret-canary");
-    await expect(stage()).rejects.toThrow("SERVICE_DEFINITION_SEALED");
+    const staged = stage();
+    await expect(staged).rejects.toThrow("SERVICE_DEFINITION_SEALED");
+    await expect(staged).rejects.toThrow(JSON.stringify(protectedPath));
     expect(await fs.readFile(protectedPath)).toEqual(original);
   });
 
@@ -862,6 +864,7 @@ describe.skipIf(process.platform === "win32")("systemd definition mutation owner
       kind: "unknown",
       reason: "symlink",
       artifact: "service-file",
+      path: file,
     });
     await expect(stage()).rejects.toThrow("SERVICE_DEFINITION_UNKNOWN: [symlink]");
     expect(await fs.readlink(file)).toBe(target);

--- a/src/daemon/systemd-definition-mutation.test.ts
+++ b/src/daemon/systemd-definition-mutation.test.ts
@@ -4,16 +4,19 @@ import path from "node:path";
 import { Writable } from "node:stream";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../test/helpers/promise.js";
+import { execFileUtf8 } from "./exec-file.js";
 import {
   buildSystemdManagerPropertyOutput,
   buildSystemdUnitPropertyOutput,
 } from "./service.test-helpers.js";
+import { systemdManagerVersionProbe } from "./systemd-user-bus.test-support.js";
 
 const assertNoSystemOwnership = vi.hoisted(() =>
   vi.fn<typeof import("./systemd-system.js").assertNoSystemSystemdOwnership>(),
 );
 const busctl = vi.hoisted(() => vi.fn<typeof import("./systemd-exec.js").execBusctlUser>());
 
+vi.mock("./exec-file.js", () => ({ execFileUtf8: vi.fn() }));
 vi.mock("./systemd-system.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("./systemd-system.js")>()),
   assertNoSystemSystemdOwnership: assertNoSystemOwnership,
@@ -48,6 +51,7 @@ describe.skipIf(process.platform === "win32")("systemd definition mutation owner
 
   beforeEach(async () => {
     assertNoSystemOwnership.mockReset().mockResolvedValue(undefined);
+    vi.mocked(execFileUtf8).mockReset().mockImplementation(systemdManagerVersionProbe);
     busctl.mockReset().mockImplementation(async (serviceEnv) => ({
       code: 1,
       termination: "exit",
@@ -58,6 +62,8 @@ describe.skipIf(process.platform === "win32")("systemd definition mutation owner
     stateDir = path.join(root, "state");
     env = {
       HOME: path.join(root, "home"),
+      XDG_RUNTIME_DIR: path.join(root, "runtime"),
+      DBUS_SESSION_BUS_ADDRESS: `unix:path=${root}/bus`,
       OPENCLAW_STATE_DIR: stateDir,
       OPENCLAW_SYSTEMD_UNIT: "openclaw-owned",
     };

--- a/src/daemon/systemd-definition-mutation.ts
+++ b/src/daemon/systemd-definition-mutation.ts
@@ -96,8 +96,12 @@ async function inspect(
   const fingerprint = new Map<string, string>();
   let shared = new Set<string>();
   let sourcePath: string | undefined;
+  let artifactPath: string | undefined;
   const result = (capability: ServiceDefinitionMutationCapability) => ({
-    capability,
+    capability:
+      capability.kind !== "writable" && capability.artifact === "service-file" && artifactPath
+        ? { ...capability, path: artifactPath }
+        : capability,
     snapshots,
     fingerprint,
     shared,
@@ -141,6 +145,7 @@ async function inspect(
             : "definition-directory";
       const inspected =
         directory && !required ? ((await findExistingAncestor(file)) ?? file) : file;
+      artifactPath = inspected;
       const stat = await fs.lstat(inspected).catch((error: unknown) => {
         if (required || !hasErrnoCode(error, "ENOENT")) {
           throw error;

--- a/src/daemon/systemd-exec.ts
+++ b/src/daemon/systemd-exec.ts
@@ -23,7 +23,7 @@ async function execSystemdCommand(
   timeoutMs?: number,
 ): Promise<ExecResult> {
   return await execFileUtf8(command, args, {
-    env: env ? resolveSystemctlProcessEnv(env) : process.env,
+    env: env ? resolveSystemdUserEnvironment(env) : process.env,
     // A wedged systemd socket can leave manager commands blocked forever; the timeout
     // kills the child so status reads fail soft instead of hanging the command.
     ...(timeoutMs && timeoutMs > 0 ? { timeout: timeoutMs, killSignal: "SIGKILL" as const } : {}),
@@ -168,12 +168,8 @@ function readSystemctlEffectiveUid(): number | null {
   }
 }
 
-function resolveSystemctlProcessEnv(env: GatewayServiceEnv): NodeJS.ProcessEnv {
+export function resolveSystemdUserEnvironment(env: GatewayServiceEnv): NodeJS.ProcessEnv {
   const processEnv = { ...process.env, ...env };
-  if (processEnv.XDG_RUNTIME_DIR?.trim() && processEnv.DBUS_SESSION_BUS_ADDRESS?.trim()) {
-    return processEnv;
-  }
-
   const uid = readSystemctlEffectiveUid();
   if (uid === null || uid === 0) {
     return processEnv;
@@ -181,16 +177,18 @@ function resolveSystemctlProcessEnv(env: GatewayServiceEnv): NodeJS.ProcessEnv {
 
   const runtimeDir = processEnv.XDG_RUNTIME_DIR?.trim() || `/run/user/${uid}`;
   const busPath = path.posix.join(runtimeDir, "bus");
-  if (!fsSync.existsSync(busPath)) {
+  const hasBus = fsSync.existsSync(busPath);
+  if (!hasBus && !fsSync.existsSync(path.posix.join(runtimeDir, "systemd/private"))) {
     return processEnv;
   }
 
-  // In non-login shells the bus socket can exist while DBUS_SESSION_BUS_ADDRESS
-  // is missing. Fill it so systemctl --user reaches the right user manager.
+  // SSH, su, and tmux can retain another session's bus address.
   return {
     ...processEnv,
     XDG_RUNTIME_DIR: runtimeDir,
-    DBUS_SESSION_BUS_ADDRESS: processEnv.DBUS_SESSION_BUS_ADDRESS?.trim() || `unix:path=${busPath}`,
+    DBUS_SESSION_BUS_ADDRESS: hasBus
+      ? `unix:path=${encodeURIComponent(busPath).replaceAll("%2F", "/")}`
+      : processEnv.DBUS_SESSION_BUS_ADDRESS,
   };
 }
 

--- a/src/daemon/systemd-exec.ts
+++ b/src/daemon/systemd-exec.ts
@@ -306,8 +306,8 @@ export async function assertSystemdAvailable(
 }
 
 export async function isSystemctlAvailable(env: GatewayServiceEnv): Promise<boolean> {
-  const res = await execSystemctlUser(env, ["status"]);
-  // Cleanup uses false to permit file-only removal. An interrupted status probe
+  const res = await execSystemctl(["--version"], env);
+  // Cleanup uses false to permit file-only removal. An interrupted executable probe
   // must still attempt disable before removing a potentially loaded unit.
   return res.code === 0 || !isSystemctlMissing(res);
 }

--- a/src/daemon/systemd-exec.ts
+++ b/src/daemon/systemd-exec.ts
@@ -1,18 +1,24 @@
 /** systemctl execution, user-manager routing, and availability probes. */
-import * as fsSync from "node:fs";
-import os from "node:os";
-import path from "node:path";
 import { err, ok, type Result } from "@openclaw/normalization-core/result";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { escapeRegExp } from "../shared/regexp.js";
 import { execFileUtf8, type ExecResult } from "./exec-file.js";
-import { ServiceInspectionError } from "./service-inspection-error.js";
+import {
+  ServiceInspectionError,
+  type ServiceInspectionReason,
+} from "./service-inspection-error.js";
 import type { GatewayServiceEnv } from "./service-types.js";
 import {
   classifySystemdUnavailableDetail,
   isSystemctlMissingDetail,
   isSystemdUserBusUnavailableDetail,
 } from "./systemd-unavailable.js";
+import {
+  resolveSystemdUserTransport,
+  SYSTEMD_TRANSPORT_DEADLINE,
+} from "./systemd-user-transport.js";
+
+type SystemdExecResult = ExecResult & { inspectionReason?: ServiceInspectionReason };
 
 export type SystemdUnitScope = "system" | "user";
 
@@ -23,7 +29,7 @@ async function execSystemdCommand(
   timeoutMs?: number,
 ): Promise<ExecResult> {
   return await execFileUtf8(command, args, {
-    env: env ? resolveSystemdUserEnvironment(env) : process.env,
+    env: env ? { ...process.env, ...env } : process.env,
     // A wedged systemd socket can leave manager commands blocked forever; the timeout
     // kills the child so status reads fail soft instead of hanging the command.
     ...(timeoutMs && timeoutMs > 0 ? { timeout: timeoutMs, killSignal: "SIGKILL" as const } : {}),
@@ -49,10 +55,13 @@ export function readSystemctlDetail(result: { stdout: string; stderr: string }):
 }
 
 export function systemdInspectionError(
-  result: ExecResult,
+  result: SystemdExecResult,
   fallback: string,
   scope: SystemdUnitScope = "user",
 ): Error {
+  if (result.inspectionReason) {
+    return new ServiceInspectionError(result.inspectionReason);
+  }
   if (result.termination === "error" && ["EACCES", "EPERM"].includes(result.errorCode ?? "")) {
     return new ServiceInspectionError("service-manager-access-denied");
   }
@@ -145,140 +154,31 @@ export function isNonFatalSystemdInstallProbeError(error: unknown): boolean {
   return isSystemctlBusUnavailable(normalized) || isGenericSystemctlIsEnabledFailure(normalized);
 }
 
-function readSystemctlEnvUser(env: GatewayServiceEnv): string | null {
-  return env.USER?.trim() || env.LOGNAME?.trim() || null;
-}
-
-function readSystemctlEffectiveUser(): string | null {
-  try {
-    return os.userInfo().username;
-  } catch {
-    return null;
-  }
-}
-
-function readSystemctlEffectiveUid(): number | null {
-  if (typeof process.geteuid !== "function") {
-    return null;
-  }
-  try {
-    return process.geteuid();
-  } catch {
-    return null;
-  }
-}
-
-export function resolveSystemdUserEnvironment(env: GatewayServiceEnv): NodeJS.ProcessEnv {
-  const processEnv = { ...process.env, ...env };
-  const uid = readSystemctlEffectiveUid();
-  if (uid === null || uid === 0) {
-    return processEnv;
-  }
-
-  const runtimeDir = processEnv.XDG_RUNTIME_DIR?.trim() || `/run/user/${uid}`;
-  const busPath = path.posix.join(runtimeDir, "bus");
-  const hasBus = fsSync.existsSync(busPath);
-  if (!hasBus && !fsSync.existsSync(path.posix.join(runtimeDir, "systemd/private"))) {
-    return processEnv;
-  }
-
-  // SSH, su, and tmux can retain another session's bus address.
-  return {
-    ...processEnv,
-    XDG_RUNTIME_DIR: runtimeDir,
-    DBUS_SESSION_BUS_ADDRESS: hasBus
-      ? `unix:path=${encodeURIComponent(busPath).replaceAll("%2F", "/")}`
-      : processEnv.DBUS_SESSION_BUS_ADDRESS,
-  };
-}
-
-function isNonRootUser(user: string | null): user is string {
-  return Boolean(user && user !== "root");
-}
-
-function hasRootUserManagerEnvironment(env: GatewayServiceEnv): boolean {
-  const home = env.HOME?.trim();
-  const runtimeDir = env.XDG_RUNTIME_DIR?.trim();
-  const dbusAddress = env.DBUS_SESSION_BUS_ADDRESS?.trim();
-  return (
-    home === "/root" &&
-    runtimeDir === "/run/user/0" &&
-    Boolean(dbusAddress?.includes("/run/user/0/bus"))
-  );
-}
-
-function resolveSystemctlUserScope(env: GatewayServiceEnv): {
-  machineUser: string | null;
-  preferMachineScope: boolean;
-} {
-  const sudoUser = env.SUDO_USER?.trim() || null;
-  const envUser = readSystemctlEnvUser(env);
-  const effectiveUid = readSystemctlEffectiveUid();
-  const effectiveUser = readSystemctlEffectiveUser();
-  const isEffectiveRoot = effectiveUid === null ? effectiveUser === "root" : effectiveUid === 0;
-  const hasRootUserManager = isEffectiveRoot && hasRootUserManagerEnvironment(env);
-  const isSudoToRoot = isEffectiveRoot && !hasRootUserManager && isNonRootUser(sudoUser);
-  const machineUser = hasRootUserManager
-    ? null
-    : isSudoToRoot
-      ? sudoUser
-      : isNonRootUser(envUser)
-        ? envUser
-        : isNonRootUser(sudoUser)
-          ? sudoUser
-          : effectiveUser || envUser || sudoUser || null;
-  return {
-    machineUser,
-    preferMachineScope: isSudoToRoot,
-  };
-}
-
-/** True when root-owned paths would be paired with the sudo caller's user manager. */
-export function hasSudoToRootSystemdUserManagerMismatch(env: GatewayServiceEnv): boolean {
-  return resolveSystemctlUserScope(env).preferMachineScope;
-}
-
-/**
- * Resolves the account whose user manager owns the service operation.
- * Keep linger diagnostics on this identity so sudo never checks root while
- * systemctl targets the invoking user's manager.
- */
-export function resolveSystemdUserServiceAccount(env: GatewayServiceEnv): string | null {
-  const { machineUser } = resolveSystemctlUserScope(env);
-  return machineUser ?? readSystemctlEffectiveUser() ?? readSystemctlEnvUser(env);
-}
-
-function resolveSystemctlMachineUserScopeArgs(user: string): string[] {
-  const trimmedUser = user.trim();
-  if (!trimmedUser) {
-    return [];
-  }
-  return ["--machine", `${trimmedUser}@`, "--user"];
-}
-
-function shouldFallbackToMachineUserScope(detail: string): boolean {
-  if (!isSystemdUserBusUnavailableDetail(detail)) {
-    return false;
-  }
-  // "Permission denied" means the bus socket exists but this process cannot connect to it.
-  // The machine-scope approach targets the same bus infrastructure and will also fail,
-  // so do not trigger the fallback in this case.
-  return !detail.toLowerCase().includes("permission denied");
-}
-
 async function execSystemdUserCommand(
   command: "systemctl" | "busctl",
   env: GatewayServiceEnv,
   args: string[],
   timeoutMs?: number,
   assertCurrent?: () => void,
-): Promise<ExecResult> {
-  const { machineUser, preferMachineScope } = resolveSystemctlUserScope(env);
-  const deadline =
-    timeoutMs !== undefined && Number.isFinite(timeoutMs) && timeoutMs > 0
-      ? performance.now() + timeoutMs
-      : undefined;
-  const run = async (scopeArgs: string[]): Promise<ExecResult> => {
+): Promise<SystemdExecResult> {
+  const deadline = timeoutMs && timeoutMs > 0 ? performance.now() + timeoutMs : undefined;
+  try {
+    const transport = await resolveSystemdUserTransport(env, deadline, assertCurrent);
+    if (transport?.kind === "private" && command === "busctl") {
+      throw new ServiceInspectionError("systemd-user-bus-unavailable");
+    }
+    const childEnv =
+      !transport || transport.kind === "machine"
+        ? env
+        : {
+            ...env,
+            // systemctl otherwise prefers its private socket over the selected broker.
+            XDG_RUNTIME_DIR:
+              transport.kind === "private" || command === "busctl"
+                ? transport.runtimeDir
+                : undefined,
+            DBUS_SESSION_BUS_ADDRESS: transport.address,
+          };
     assertCurrent?.();
     const remaining = deadline === undefined ? undefined : Math.ceil(deadline - performance.now());
     if (remaining !== undefined && remaining <= 0) {
@@ -289,38 +189,22 @@ async function execSystemdUserCommand(
         stderr: "systemd user manager command deadline expired",
       };
     }
-    // The machine fallback is part of this operation, not a fresh timeout budget.
-    return await execSystemdCommand(command, [...scopeArgs, ...args], env, remaining ?? timeoutMs);
-  };
-
-  // Under sudo-to-root, prefer the invoking non-root user's scope directly via machine scope.
-  if (preferMachineScope && machineUser) {
-    const machineScopeArgs = resolveSystemctlMachineUserScopeArgs(machineUser);
-    if (machineScopeArgs.length > 0) {
-      // Do not fall through to bare --user: under sudo that can target root's user manager.
-      return await run(machineScopeArgs);
+    const scope =
+      transport?.kind === "machine" ? ["--machine", `${transport.user}@`, "--user"] : ["--user"];
+    return await execSystemdCommand(command, [...scope, ...args], childEnv, remaining);
+  } catch (error) {
+    assertCurrent?.();
+    if (!(error instanceof ServiceInspectionError)) {
+      throw error;
     }
+    return {
+      code: 1,
+      termination: error === SYSTEMD_TRANSPORT_DEADLINE ? "timeout" : "error",
+      stdout: "",
+      stderr: error.message,
+      inspectionReason: error.reason,
+    };
   }
-
-  const directResult = await run(["--user"]);
-  if (directResult.code === 0) {
-    return directResult;
-  }
-
-  const detail = readSystemctlDetail(directResult);
-  if (
-    directResult.termination !== "exit" ||
-    !machineUser ||
-    !shouldFallbackToMachineUserScope(detail)
-  ) {
-    return directResult;
-  }
-
-  const machineScopeArgs = resolveSystemctlMachineUserScopeArgs(machineUser);
-  if (machineScopeArgs.length === 0) {
-    return directResult;
-  }
-  return await run(machineScopeArgs);
 }
 
 export async function execSystemctlUser(
@@ -328,7 +212,7 @@ export async function execSystemctlUser(
   args: string[],
   timeoutMs?: number,
   assertCurrent?: () => void,
-): Promise<ExecResult> {
+): Promise<SystemdExecResult> {
   return await execSystemdUserCommand("systemctl", env, args, timeoutMs, assertCurrent);
 }
 
@@ -337,7 +221,7 @@ export async function execBusctlUser(
   args: string[],
   timeoutMs?: number,
   assertCurrent?: () => void,
-): Promise<ExecResult> {
+): Promise<SystemdExecResult> {
   return await execSystemdUserCommand("busctl", env, args, timeoutMs, assertCurrent);
 }
 

--- a/src/daemon/systemd-loaded-runtime.ts
+++ b/src/daemon/systemd-loaded-runtime.ts
@@ -13,6 +13,7 @@ import type {
 } from "./service-types.js";
 import { execBusctlUser, systemdInspectionError } from "./systemd-exec.js";
 import { resolveSystemdServiceName } from "./systemd-service-files.js";
+import { readSystemdUserTransport } from "./systemd-user-transport.js";
 
 const MANAGER = "org.freedesktop.systemd1";
 const BUS = "org.freedesktop.DBus";
@@ -254,6 +255,7 @@ export async function readLoadedSystemdServiceRuntime(
         exitCode
       ],
       systemd: {
+        transport: await readSystemdUserTransport(env),
         unit: id,
         managerUid,
         result,

--- a/src/daemon/systemd-peer-native.ts
+++ b/src/daemon/systemd-peer-native.ts
@@ -90,12 +90,24 @@ export async function openSystemdBroker(address: string, deadline: number) {
   return await openSystemdConnection(address, deadline);
 }
 
+/** Ordinary local reads authenticate the connected manager without a session broker. */
+export async function openSystemdUserManager(address: string, deadline: number) {
+  const uid = process.geteuid?.();
+  if (process.platform !== "linux" || uid === undefined || uid === 0) {
+    throw unavailable();
+  }
+  return await openSystemdConnection(address, deadline, undefined, uid);
+}
+
 async function openSystemdConnection(
   address: string,
   deadline: number,
   expected?: SystemdPeerIdentity,
+  managerUid?: number,
 ) {
   assertGatewayServiceUpdateCurrent();
+  const privatePeer = expected !== undefined || managerUid !== undefined;
+  let identity = expected;
   const native = (api ??= loadApi());
   const output: Pointer[] = [null];
   checked(native.newBus(output));
@@ -121,8 +133,8 @@ async function openSystemdConnection(
     assertGatewayServiceUpdateCurrent();
     if (
       closed ||
-      (expected &&
-        (!isPidAlive(expected.pid) || getProcessStartTime(expected.pid) !== expected.startTime))
+      (identity &&
+        (!isPidAlive(identity.pid) || getProcessStartTime(identity.pid) !== identity.startTime))
     ) {
       throw unavailable();
     }
@@ -130,21 +142,28 @@ async function openSystemdConnection(
   // Only call while owning the native queue (or before admission is published).
   const verifyConnection = () => {
     verify();
-    if (!expected) {
+    if (!privatePeer) {
       return;
     }
     const credentials: Pointer[] = [null];
     // No AUGMENT: these are kernel credentials of THIS connected private peer.
     checked(native.credentials(bus, 17, credentials)); // PID | EUID, stable sd-bus ABI.
     try {
-      const pid = [0],
-        uid = [0];
+      const pid: [number] = [0];
+      const uid: [number] = [0];
       checked(native.pid(credentials[0], pid));
       checked(native.uid(credentials[0], uid));
+      if (!identity) {
+        const startTime = getProcessStartTime(pid[0]);
+        if (uid[0] !== managerUid || pid[0] <= 0 || !isPidAlive(pid[0]) || startTime === null) {
+          throw unavailable();
+        }
+        identity = { uid: uid[0], pid: pid[0], startTime };
+      }
       if (
-        pid[0] !== expected.pid ||
-        uid[0] !== expected.uid ||
-        getProcessStartTime(expected.pid) !== expected.startTime
+        pid[0] !== identity.pid ||
+        uid[0] !== identity.uid ||
+        getProcessStartTime(identity.pid) !== identity.startTime
       ) {
         throw unavailable();
       }
@@ -154,7 +173,7 @@ async function openSystemdConnection(
   };
   try {
     checked(native.address(bus, address));
-    checked(native.client(bus, expected ? 0 : 1));
+    checked(native.client(bus, privatePeer ? 0 : 1));
     remaining(deadline);
     await invoke(native.start, bus);
     // Drive only authentication. No property read or service activation precedes credentials.
@@ -268,7 +287,7 @@ async function openSystemdConnection(
           await invoke(
             native.property,
             bus,
-            expected ? null : args[1],
+            privatePeer ? null : args[1],
             args[2],
             args[3],
             args[index + 4],
@@ -292,7 +311,9 @@ async function openSystemdConnection(
         reply: Pointer[] = [null];
       const error = Buffer.alloc(native.errorSize);
       try {
-        checked(native.newCall(bus, message, expected ? null : args[1], args[2], args[3], args[4]));
+        checked(
+          native.newCall(bus, message, privatePeer ? null : args[1], args[2], args[3], args[4]),
+        );
         checked(native.autoStart(message[0], 0));
         if (args[5] === "s" && args.length === 7) {
           checked(native.append(message[0], 115, args[6]));
@@ -308,7 +329,8 @@ async function openSystemdConnection(
             (["GetUnit", "LoadUnit"].includes(member) &&
               native.errorHasName(error, "org.freedesktop.systemd1.NoSuchUnit")) ||
             (args[4] === "GetUnitFileState" &&
-              (native.errorHasName(error, "org.freedesktop.systemd1.NoSuchUnitFile") ||
+              (native.errorHasName(error, "org.freedesktop.systemd1.NoSuchUnit") ||
+                native.errorHasName(error, "org.freedesktop.systemd1.NoSuchUnitFile") ||
                 native.errorHasName(error, "org.freedesktop.DBus.Error.FileNotFound")))
           ) {
             return null;

--- a/src/daemon/systemd-peer-native.ts
+++ b/src/daemon/systemd-peer-native.ts
@@ -93,7 +93,7 @@ export async function openSystemdBroker(address: string, deadline: number) {
 /** Ordinary local reads authenticate the connected manager without a session broker. */
 export async function openSystemdUserManager(address: string, deadline: number) {
   const uid = process.geteuid?.();
-  if (process.platform !== "linux" || uid === undefined || uid === 0) {
+  if (process.platform !== "linux" || uid === undefined) {
     throw unavailable();
   }
   return await openSystemdConnection(address, deadline, undefined, uid);

--- a/src/daemon/systemd-peer.test.ts
+++ b/src/daemon/systemd-peer.test.ts
@@ -1,4 +1,7 @@
+import fs from "node:fs/promises";
+import path from "node:path";
 import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { mockProcessPlatform } from "../test-utils/vitest-spies.js";
 import { openSystemdBroker, openSystemdPrivatePeer } from "./systemd-peer-native.js";
 import { admitSystemdServiceReadBinding } from "./systemd-peer.js";
@@ -17,6 +20,7 @@ vi.mock("./systemd-peer-native.js", () => ({
 const query = vi.fn<Awaited<ReturnType<typeof openSystemdBroker>>["query"]>();
 const closeBroker = vi.fn(async () => {});
 const closePeer = vi.fn(async () => {});
+const dirs = useAutoCleanupTempDirTracker(afterEach);
 const env = {
   HOME: "/home/test",
   XDG_RUNTIME_DIR: "/custom/runtime",
@@ -75,6 +79,21 @@ it("does not admit another route when the authored broker is unavailable", async
   expect(await admitSystemdServiceReadBinding(env, performance.now() + 1000)).toBeUndefined();
   expect(openSystemdBroker).toHaveBeenCalledOnce();
   expect(openSystemdPrivatePeer).not.toHaveBeenCalled();
+});
+
+it("authenticates through the runtime bus instead of a stale shell address", async () => {
+  const runtime = dirs.make("openclaw-broker-route-,");
+  await fs.writeFile(path.join(runtime, "bus"), "");
+  const binding = await admitSystemdServiceReadBinding(
+    { ...env, XDG_RUNTIME_DIR: runtime },
+    performance.now() + 1000,
+  );
+  expect(openSystemdBroker).toHaveBeenCalledExactlyOnceWith(
+    `unix:path=${path.posix.join(runtime, "bus").replaceAll(",", "%2C")}`,
+    expect.any(Number),
+  );
+  expect(binding).toBeDefined();
+  await binding?.close();
 });
 
 it("refuses broker loss between credential observations without reconnecting", async () => {

--- a/src/daemon/systemd-peer.test.ts
+++ b/src/daemon/systemd-peer.test.ts
@@ -3,8 +3,12 @@ import path from "node:path";
 import { afterEach, beforeEach, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { mockProcessPlatform } from "../test-utils/vitest-spies.js";
+import { execFileUtf8 } from "./exec-file.js";
 import { openSystemdBroker, openSystemdPrivatePeer } from "./systemd-peer-native.js";
 import { admitSystemdServiceReadBinding } from "./systemd-peer.js";
+import { systemdManagerVersionProbe } from "./systemd-user-bus.test-support.js";
+
+vi.mock("./exec-file.js", () => ({ execFileUtf8: vi.fn() }));
 
 vi.mock("../shared/pid-alive.js", () => ({
   getProcessStartTime: () => 100,
@@ -32,6 +36,16 @@ beforeEach(() => {
   mockProcessPlatform("linux");
   vi.spyOn(process, "geteuid").mockReturnValue(1000);
   vi.stubEnv("SUDO_USER", undefined);
+  vi.mocked(execFileUtf8).mockImplementation(async (command, args, options) => {
+    await systemdManagerVersionProbe(command, args);
+    const stale = options?.env?.DBUS_SESSION_BUS_ADDRESS === "unix:path=/tmp/dbus-stale";
+    return {
+      code: stale ? 1 : 0,
+      termination: "exit",
+      stdout: stale ? "" : 's "252.39"',
+      stderr: stale ? "No manager on this broker" : "",
+    };
+  });
   query.mockImplementation(async (args) => [
     [args[4] === "GetNameOwner" ? ":1.0" : args[4] === "GetConnectionUnixUser" ? 1000 : 1234],
   ]);
@@ -85,11 +99,26 @@ it("authenticates through the runtime bus instead of a stale shell address", asy
   const runtime = dirs.make("openclaw-broker-route-,");
   await fs.writeFile(path.join(runtime, "bus"), "");
   const binding = await admitSystemdServiceReadBinding(
-    { ...env, XDG_RUNTIME_DIR: runtime },
+    { ...env, XDG_RUNTIME_DIR: runtime, DBUS_SESSION_BUS_ADDRESS: "unix:path=/tmp/dbus-stale" },
     performance.now() + 1000,
   );
   expect(openSystemdBroker).toHaveBeenCalledExactlyOnceWith(
     `unix:path=${path.posix.join(runtime, "bus").replaceAll(",", "%2C")}`,
+    expect.any(Number),
+  );
+  expect(binding).toBeDefined();
+  await binding?.close();
+});
+
+it("preserves a working custom broker when an unrelated runtime socket exists", async () => {
+  const runtime = dirs.make("openclaw-custom-broker-");
+  await fs.writeFile(path.join(runtime, "bus"), "");
+  const binding = await admitSystemdServiceReadBinding(
+    { ...env, XDG_RUNTIME_DIR: runtime },
+    performance.now() + 1000,
+  );
+  expect(openSystemdBroker).toHaveBeenCalledExactlyOnceWith(
+    env.DBUS_SESSION_BUS_ADDRESS,
     expect.any(Number),
   );
   expect(binding).toBeDefined();
@@ -146,5 +175,31 @@ it("preserves a custom abstract local Unix route", async () => {
   );
   expect(binding).toBeDefined();
   expect(openSystemdBroker).toHaveBeenCalledWith(address, expect.any(Number));
+  await binding?.close();
+});
+
+it("admits the selected runtime bus after a stale nonlocal address", async () => {
+  const runtime = dirs.make("openclaw-nonlocal-fallback-");
+  await fs.writeFile(path.join(runtime, "bus"), "");
+  vi.mocked(execFileUtf8).mockResolvedValueOnce({
+    code: 1,
+    termination: "exit",
+    stdout: "",
+    stderr: "Failed to connect to bus: Connection refused",
+  });
+  const binding = await admitSystemdServiceReadBinding(
+    {
+      ...env,
+      XDG_RUNTIME_DIR: runtime,
+      DBUS_SESSION_BUS_ADDRESS: "tcp:host=example.invalid,port=1234",
+    },
+    performance.now() + 1000,
+  );
+  expect(binding).toBeDefined();
+  expect(openSystemdBroker).toHaveBeenCalledExactlyOnceWith(
+    `unix:path=${runtime}/bus`,
+    expect.any(Number),
+  );
+  expect(execFileUtf8).toHaveBeenCalledTimes(2);
   await binding?.close();
 });

--- a/src/daemon/systemd-peer.ts
+++ b/src/daemon/systemd-peer.ts
@@ -2,6 +2,7 @@
 import path from "node:path";
 import { getProcessStartTime, isPidAlive } from "../shared/pid-alive.js";
 import type { GatewayServiceEnv, SystemdServiceReadBinding } from "./service-types.js";
+import { resolveSystemdUserEnvironment } from "./systemd-exec.js";
 import { openSystemdBroker, openSystemdPrivatePeer } from "./systemd-peer-native.js";
 import { resolveSystemdServiceName } from "./systemd-service-files.js";
 
@@ -55,7 +56,7 @@ export async function admitSystemdServiceReadBinding(
 ): Promise<SystemdServiceReadBinding | undefined> {
   // Capture ambient selectors once; neither subsequent env mutation nor the
   // legacy machine fallback may change the broker authenticated here.
-  const route = { ...process.env, ...env };
+  const route = resolveSystemdUserEnvironment(env);
   const uid = process.geteuid?.();
   // Do not alter root/sudo, remote, or system-manager selection. Existing native
   // adapters remain responsible when no same-account private peer is available.

--- a/src/daemon/systemd-peer.ts
+++ b/src/daemon/systemd-peer.ts
@@ -2,17 +2,16 @@
 import path from "node:path";
 import { getProcessStartTime, isPidAlive } from "../shared/pid-alive.js";
 import type { GatewayServiceEnv, SystemdServiceReadBinding } from "./service-types.js";
-import { resolveSystemdUserEnvironment } from "./systemd-exec.js";
 import { openSystemdBroker, openSystemdPrivatePeer } from "./systemd-peer-native.js";
 import { resolveSystemdServiceName } from "./systemd-service-files.js";
+import { resolveSystemdUserTransport } from "./systemd-user-transport.js";
 
 const MANAGER = "org.freedesktop.systemd1";
 const BUS = "org.freedesktop.DBus";
 const unavailable = () => new Error("Original systemd manager binding is unavailable or changed.");
 
-// This optional local-PID admission must never execute a transport helper,
-// resolve a remote hostname or enter another PID namespace. Legacy adapters
-// retain their authored transport support when this narrow admission declines.
+// Native peer credentials apply only to the selected local Unix transport.
+// Other selected transports remain with their existing adapters.
 function isLocalUnixAddress(address: string): boolean {
   try {
     return address.split(";").every((entry) => {
@@ -56,15 +55,11 @@ export async function admitSystemdServiceReadBinding(
 ): Promise<SystemdServiceReadBinding | undefined> {
   // Capture ambient selectors once; neither subsequent env mutation nor the
   // legacy machine fallback may change the broker authenticated here.
-  const route = resolveSystemdUserEnvironment(env);
+  const route = { ...process.env, ...env };
   const uid = process.geteuid?.();
   // Do not alter root/sudo, remote, or system-manager selection. Existing native
   // adapters remain responsible when no same-account private peer is available.
   if (process.platform !== "linux" || uid === undefined || uid === 0 || route.SUDO_USER) {
-    return undefined;
-  }
-  const runtime = route.XDG_RUNTIME_DIR?.trim() || `/run/user/${uid}`;
-  if (!path.isAbsolute(runtime)) {
     return undefined;
   }
   const unit = `${resolveSystemdServiceName(env)}.service`;
@@ -86,13 +81,17 @@ export async function admitSystemdServiceReadBinding(
   };
   let peer: Awaited<ReturnType<typeof openSystemdPrivatePeer>> | undefined;
   try {
-    const brokerAddress =
-      route.DBUS_SESSION_BUS_ADDRESS?.trim() ||
-      `unix:path=${encodeURIComponent(path.join(runtime, "bus")).replaceAll("%2F", "/")}`;
-    if (!isLocalUnixAddress(brokerAddress)) {
+    const transport = await resolveSystemdUserTransport(route, deadline, undefined, "admission");
+    if (
+      !transport ||
+      transport.kind === "private" ||
+      transport.kind === "machine" ||
+      !path.isAbsolute(transport.runtimeDir) ||
+      !isLocalUnixAddress(transport.address)
+    ) {
       return undefined;
     }
-    broker = await openSystemdBroker(brokerAddress, deadline);
+    broker = await openSystemdBroker(transport.address, deadline);
     const destination = await query("GetNameOwner", MANAGER, "s");
     if (typeof destination !== "string" || !/^:[0-9]+\.[0-9]+$/.test(destination)) {
       throw unavailable();
@@ -110,7 +109,7 @@ export async function admitSystemdServiceReadBinding(
     }
     // Percent escaping is D-Bus address syntax, not a shell expansion. Preserve
     // authored runtime roots; never probe a different canonical manager.
-    const socket = path.join(runtime, "systemd/private");
+    const socket = path.join(transport.runtimeDir, "systemd/private");
     const address = `unix:path=${encodeURIComponent(socket).replaceAll("%2F", "/")}`;
     peer = await openSystemdPrivatePeer(address, { uid, pid, startTime }, deadline);
     if (

--- a/src/daemon/systemd-runtime.ts
+++ b/src/daemon/systemd-runtime.ts
@@ -7,10 +7,17 @@ import {
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { formatErrorMessage } from "../infra/errors.js";
 import { parseKeyValueOutput } from "./runtime-parse.js";
-import { ServiceInspectionError } from "./service-inspection-error.js";
-import type { GatewayServiceRuntime } from "./service-runtime.js";
+import {
+  sanitizeServiceInspectionError,
+  ServiceInspectionError,
+} from "./service-inspection-error.js";
+import {
+  createServiceRuntimeInspectionFailure,
+  type GatewayServiceRuntime,
+} from "./service-runtime.js";
 import type {
   GatewayServiceEnv,
+  GatewayServiceCommandInspection,
   GatewayServiceEnvArgs,
   GatewayServiceReadOptions,
 } from "./service-types.js";
@@ -19,14 +26,13 @@ import {
   execSystemctl,
   execSystemctlUser,
   isSystemctlMissing,
-  isSystemdUnitMissingDetail,
   isSystemdUnitNotEnabled,
   readSystemctlDetail,
   systemdInspectionError,
 } from "./systemd-exec.js";
 import { readLoadedSystemdServiceRuntime } from "./systemd-loaded-runtime.js";
 import { findInstalledSystemdGatewayScope } from "./systemd-scope.js";
-import { resolveSystemdServiceName } from "./systemd-service-files.js";
+import { readSystemdServiceExecStart, resolveSystemdServiceName } from "./systemd-service-files.js";
 
 type SystemdServiceInfo = {
   loadState?: string;
@@ -158,6 +164,7 @@ export async function readSystemdServiceRuntime(
   }
   const timeoutMs = opts?.timeoutMs;
   const installed = await findInstalledSystemdGatewayScope(env).catch(() => null);
+  let commandInspectionFailure: GatewayServiceRuntime | undefined;
   if (installed?.scope !== "system") {
     try {
       await assertSystemdAvailable(env, timeoutMs);
@@ -167,6 +174,25 @@ export async function readSystemdServiceRuntime(
         detail: formatErrorMessage(err),
         ...(err instanceof ServiceInspectionError ? { inspectionReason: err.reason } : {}),
       };
+    }
+    const inspection: GatewayServiceCommandInspection =
+      opts?.commandInspection ??
+      (installed
+        ? { kind: "present" }
+        : await readSystemdServiceExecStart(env, { ...opts, requireEffective: true }).then(
+            (command) => ({ kind: command ? "present" : "absent" }) as const,
+            (error: unknown) => ({ kind: "unavailable", error }) as const,
+          ));
+    if (inspection.kind === "unavailable") {
+      commandInspectionFailure = createServiceRuntimeInspectionFailure(
+        sanitizeServiceInspectionError(inspection.error),
+      );
+      if (!installed) {
+        return commandInspectionFailure;
+      }
+    }
+    if (!installed && inspection.kind === "absent") {
+      return { status: "stopped", missingUnit: true };
     }
   }
   const unitName = installed?.unitName ?? `${resolveSystemdServiceName(env)}.service`;
@@ -183,12 +209,12 @@ export async function readSystemdServiceRuntime(
       : await execSystemctlUser(env, showArgs, timeoutMs);
   if (res.code !== 0) {
     const detail = (res.stderr || res.stdout).trim();
-    const missing = res.termination === "exit" && !installed && isSystemdUnitMissingDetail(detail);
-    const error = missing ? undefined : systemdInspectionError(res, detail, installed?.scope);
+    const error = systemdInspectionError(res, detail, installed?.scope);
     return {
-      status: missing ? "stopped" : "unknown",
-      ...(!missing && detail ? { detail } : {}),
-      missingUnit: missing,
+      ...commandInspectionFailure,
+      status: "unknown",
+      ...(detail ? { detail } : {}),
+      missingUnit: false,
       ...(error instanceof ServiceInspectionError ? { inspectionReason: error.reason } : {}),
     };
   }
@@ -203,12 +229,11 @@ export async function readSystemdServiceRuntime(
         ? "stopped"
         : "unknown";
   return {
+    ...commandInspectionFailure,
     status,
-    // `systemctl show` succeeds for absent units. Preserve stopped status for
-    // staged definitions, but only affirm absence when no definition exists.
     ...(normalizeLowercaseStringOrEmpty(parsed.loadState) === "not-found" &&
     activeState === "inactive"
-      ? { missingUnit: !installed }
+      ? { missingUnit: false }
       : {}),
     state: parsed.activeState,
     subState: parsed.subState,

--- a/src/daemon/systemd-runtime.ts
+++ b/src/daemon/systemd-runtime.ts
@@ -33,6 +33,7 @@ import {
 import { readLoadedSystemdServiceRuntime } from "./systemd-loaded-runtime.js";
 import { findInstalledSystemdGatewayScope } from "./systemd-scope.js";
 import { readSystemdServiceExecStart, resolveSystemdServiceName } from "./systemd-service-files.js";
+import { readSystemdUserTransport } from "./systemd-user-transport.js";
 
 type SystemdServiceInfo = {
   loadState?: string;
@@ -192,7 +193,12 @@ export async function readSystemdServiceRuntime(
       }
     }
     if (!installed && inspection.kind === "absent") {
-      return { status: "stopped", missingUnit: true };
+      const transport = await readSystemdUserTransport(env);
+      return {
+        status: "stopped",
+        missingUnit: true,
+        ...(transport ? { systemd: { transport } } : {}),
+      };
     }
   }
   const unitName = installed?.unitName ?? `${resolveSystemdServiceName(env)}.service`;
@@ -241,6 +247,7 @@ export async function readSystemdServiceRuntime(
     lastExitStatus: parsed.execMainStatus,
     lastExitReason: parsed.execMainCode,
     systemd: {
+      transport: installed?.scope === "system" ? undefined : await readSystemdUserTransport(env),
       unit: parsed.unit ?? unitName,
       killMode: parsed.killMode,
       tasksCurrent: parsed.tasksCurrent,

--- a/src/daemon/systemd-service-files.ts
+++ b/src/daemon/systemd-service-files.ts
@@ -8,7 +8,7 @@ import { splitArgsPreservingQuotes } from "./arg-split.js";
 import { resolveGatewaySystemdServiceName } from "./constants.js";
 import { normalizeWindowsPathSeparators } from "./output.js";
 import { resolveDaemonHomeDir } from "./paths.js";
-import { ServiceInspectionError } from "./service-inspection-error.js";
+import { ServiceDefinitionInspectionError } from "./service-inspection-error.js";
 import type {
   GatewayServiceCommandConfig,
   GatewayServiceCommandSnapshot,
@@ -354,13 +354,10 @@ export async function readSystemdServiceExecStart(
   try {
     const content = await fs.readFile(unitPath, "utf8").catch((error: unknown) => {
       if (!hasErrnoCode(error, "ENOENT")) {
-        throw error;
+        throw new ServiceDefinitionInspectionError(unitPath);
       }
       return null;
     });
-    if (content === null && !opts?.requireEffective) {
-      return null;
-    }
     let execStart = "";
     let workingDirectory = "";
     let inlineEnvironment: Record<string, string> = {};
@@ -409,15 +406,18 @@ export async function readSystemdServiceExecStart(
       unitPath,
     });
     const localDefinition = content === null ? null : managedDefinition;
-    const managerRead = readSystemdManagerCommand(env, localDefinition, unsetEnvironment, opts);
-    const manager = opts?.requireEffective
-      ? await managerRead
-      : await managerRead.catch((error: unknown) => {
-          if (error instanceof ServiceInspectionError) {
-            opts?.onInspectionFailure?.(error.reason);
-          }
-          return null;
-        });
+    const manager = await readSystemdManagerCommand(env, localDefinition, unsetEnvironment, opts)
+      .then((command) => {
+        opts?.onCommandInspection?.({ kind: command || localDefinition ? "present" : "absent" });
+        return command;
+      })
+      .catch((error: unknown) => {
+        if (opts?.requireEffective) {
+          throw error;
+        }
+        opts?.onCommandInspection?.({ kind: "unavailable", error });
+        return null;
+      });
     if (manager || opts?.requireEffective || !managedDefinition.programArguments.length) {
       return manager;
     }
@@ -428,6 +428,7 @@ export async function readSystemdServiceExecStart(
       sourcePath: unitPath,
     };
   } catch (error) {
+    opts?.onCommandInspection?.({ kind: "unavailable", error });
     if (opts?.requireEffective) {
       throw error;
     }

--- a/src/daemon/systemd-service-files.ts
+++ b/src/daemon/systemd-service-files.ts
@@ -93,148 +93,152 @@ async function readSystemdManagerCommand(
   const unitName = `${resolveSystemdServiceName(env)}.service`;
   const unavailable = () => new Error("Effective systemd service command could not be inspected.");
   const inspection = opts?.requireLoaded ? opts.loadForInspection : undefined;
-  const { query, binding, destination } = await createSystemdCommandQuery(
+  const { query, binding, destination, close } = await createSystemdCommandQuery(
     env,
     unitName,
     opts,
     unavailable,
   );
-  const assertAbsentWithoutLoading = async (): Promise<null> => {
-    // Missing loaded objects do not prove an authored/native unit definition is absent.
-    if (localDefinition) {
-      throw unavailable();
-    }
-    const fileState = await query(
+  try {
+    const assertAbsentWithoutLoading = async (): Promise<null> => {
+      // Missing loaded objects do not prove an authored/native unit definition is absent.
+      if (localDefinition) {
+        throw unavailable();
+      }
+      const fileState = await query(
+        [
+          "call",
+          destination,
+          "/org/freedesktop/systemd1",
+          `${manager}.Manager`,
+          "GetUnitFileState",
+          "s",
+          unitName,
+        ],
+        ["s"],
+      );
+      if (fileState !== null) {
+        throw unavailable();
+      }
+      return null;
+    };
+    const loaded = await query(
       [
         "call",
         destination,
         "/org/freedesktop/systemd1",
         `${manager}.Manager`,
-        "GetUnitFileState",
+        opts?.requireLoaded && !inspection ? "GetUnit" : "LoadUnit",
         "s",
         unitName,
       ],
-      ["s"],
+      ["o"],
     );
-    if (fileState !== null) {
+    if (!loaded) {
+      return opts?.requireLoaded ? await assertAbsentWithoutLoading() : null;
+    }
+    const loadedUnit = loaded[0];
+    const unitPath = Array.isArray(loadedUnit) && loadedUnit.length === 1 ? loadedUnit[0] : null;
+    if (typeof unitPath !== "string" || !unitPath) {
       throw unavailable();
     }
-    return null;
-  };
-  const loaded = await query(
-    [
-      "call",
-      destination,
-      "/org/freedesktop/systemd1",
-      `${manager}.Manager`,
-      opts?.requireLoaded && !inspection ? "GetUnit" : "LoadUnit",
-      "s",
-      unitName,
-    ],
-    ["o"],
-  );
-  if (!loaded) {
-    return opts?.requireLoaded ? await assertAbsentWithoutLoading() : null;
-  }
-  const loadedUnit = loaded[0];
-  const unitPath = Array.isArray(loadedUnit) && loadedUnit.length === 1 ? loadedUnit[0] : null;
-  if (typeof unitPath !== "string" || !unitPath) {
-    throw unavailable();
-  }
-  const readProperties = (scope: "Unit" | "Service", names: string[], signatures: string[]) =>
-    query(["get-property", destination, unitPath, `${manager}.${scope}`, ...names], signatures);
-  const isStringArray = (value: unknown): value is string[] =>
-    Array.isArray(value) && value.every((entry) => typeof entry === "string");
-  const unitProperties = await readProperties(
-    "Unit",
-    ["FragmentPath", "DropInPaths", "NeedDaemonReload", "LoadState"],
-    ["s", "as", "b", "s"],
-  );
-  const [sourcePath, dropInPaths, reloadPending, loadState] = unitProperties ?? [];
-  // LoadUnit also returns objects for missing units; only LoadState proves absence.
-  if (loadState === "not-found") {
-    return opts?.requireLoaded ? await assertAbsentWithoutLoading() : null;
-  }
-  if (
-    loadState !== "loaded" ||
-    typeof sourcePath !== "string" ||
-    !sourcePath ||
-    !isStringArray(dropInPaths) ||
-    dropInPaths.some((pathname) => !pathname) ||
-    typeof reloadPending !== "boolean"
-  ) {
-    throw unavailable();
-  }
-  const properties = await readProperties(
-    "Service",
-    ["ExecStart", "WorkingDirectory", "Environment", "EnvironmentFiles", "UnsetEnvironment"],
-    ["a(sasbttttuii)", "s", "as", "a(sb)", "as"],
-  );
-  const [executions, workingDirectory, assignments, environmentFileSpecs, unsetEnvironment] =
-    properties ?? [];
-  const execution = Array.isArray(executions) && executions.length === 1 ? executions[0] : null;
-  const programArguments = Array.isArray(execution) ? execution[1] : null;
-  if (
-    !Array.isArray(execution) ||
-    execution.length !== 10 ||
-    typeof execution[0] !== "string" ||
-    execution[0].length === 0 ||
-    typeof execution[2] !== "boolean" ||
-    !execution.slice(3).every(Number.isInteger) ||
-    !isStringArray(programArguments) ||
-    programArguments.length === 0 ||
-    typeof workingDirectory !== "string" ||
-    !isStringArray(assignments) ||
-    !Array.isArray(environmentFileSpecs) ||
-    !environmentFileSpecs.every(
-      (spec): spec is [string, boolean] =>
-        Array.isArray(spec) &&
-        spec.length === 2 &&
-        typeof spec[0] === "string" &&
-        spec[0].length > 0 &&
-        typeof spec[1] === "boolean",
-    ) ||
-    !isStringArray(unsetEnvironment) ||
-    unsetEnvironment.some((assignment) => !assignment || assignment.startsWith("="))
-  ) {
-    throw unavailable();
-  }
-  const inlineEnvironment: Record<string, string> = {};
-  for (const assignment of assignments) {
-    const separator = assignment.indexOf("=");
-    if (separator <= 0) {
+    const readProperties = (scope: "Unit" | "Service", names: string[], signatures: string[]) =>
+      query(["get-property", destination, unitPath, `${manager}.${scope}`, ...names], signatures);
+    const isStringArray = (value: unknown): value is string[] =>
+      Array.isArray(value) && value.every((entry) => typeof entry === "string");
+    const unitProperties = await readProperties(
+      "Unit",
+      ["FragmentPath", "DropInPaths", "NeedDaemonReload", "LoadState"],
+      ["s", "as", "b", "s"],
+    );
+    const [sourcePath, dropInPaths, reloadPending, loadState] = unitProperties ?? [];
+    // LoadUnit also returns objects for missing units; only LoadState proves absence.
+    if (loadState === "not-found") {
+      return opts?.requireLoaded ? await assertAbsentWithoutLoading() : null;
+    }
+    if (
+      loadState !== "loaded" ||
+      typeof sourcePath !== "string" ||
+      !sourcePath ||
+      !isStringArray(dropInPaths) ||
+      dropInPaths.some((pathname) => !pathname) ||
+      typeof reloadPending !== "boolean"
+    ) {
       throw unavailable();
     }
-    inlineEnvironment[assignment.slice(0, separator)] = assignment.slice(separator + 1);
-  }
+    const properties = await readProperties(
+      "Service",
+      ["ExecStart", "WorkingDirectory", "Environment", "EnvironmentFiles", "UnsetEnvironment"],
+      ["a(sasbttttuii)", "s", "as", "a(sb)", "as"],
+    );
+    const [executions, workingDirectory, assignments, environmentFileSpecs, unsetEnvironment] =
+      properties ?? [];
+    const execution = Array.isArray(executions) && executions.length === 1 ? executions[0] : null;
+    const programArguments = Array.isArray(execution) ? execution[1] : null;
+    if (
+      !Array.isArray(execution) ||
+      execution.length !== 10 ||
+      typeof execution[0] !== "string" ||
+      execution[0].length === 0 ||
+      typeof execution[2] !== "boolean" ||
+      !execution.slice(3).every(Number.isInteger) ||
+      !isStringArray(programArguments) ||
+      programArguments.length === 0 ||
+      typeof workingDirectory !== "string" ||
+      !isStringArray(assignments) ||
+      !Array.isArray(environmentFileSpecs) ||
+      !environmentFileSpecs.every(
+        (spec): spec is [string, boolean] =>
+          Array.isArray(spec) &&
+          spec.length === 2 &&
+          typeof spec[0] === "string" &&
+          spec[0].length > 0 &&
+          typeof spec[1] === "boolean",
+      ) ||
+      !isStringArray(unsetEnvironment) ||
+      unsetEnvironment.some((assignment) => !assignment || assignment.startsWith("="))
+    ) {
+      throw unavailable();
+    }
+    const inlineEnvironment: Record<string, string> = {};
+    for (const assignment of assignments) {
+      const separator = assignment.indexOf("=");
+      if (separator <= 0) {
+        throw unavailable();
+      }
+      inlineEnvironment[assignment.slice(0, separator)] = assignment.slice(separator + 1);
+    }
 
-  await binding?.verify();
-  const managedDefinition = sourcePath === resolveSystemdUnitPath(env) ? localDefinition : null;
-  const managedOverrides =
-    !reloadPending && managedDefinition
-      ? await readSystemdDropInOverrides(
-          dropInPaths,
-          managedUnsetEnvironment,
-          env,
-          sourcePath,
-        ).catch(() => UNKNOWN_SYSTEMD_OVERRIDES)
-      : UNKNOWN_SYSTEMD_OVERRIDES;
-  return {
-    ...(await buildSystemdCommandSnapshot({
-      programArguments,
-      workingDirectory: workingDirectory.replace(/^!/, ""),
-      inlineEnvironment,
-      environmentFileSpecs,
-      unsetEnvironment,
-      env,
-      unitPath: sourcePath,
-      failOnUnavailable: opts?.requireEffective,
-    })),
-    ...(managedDefinition && managedOverrides ? { managedDefinition, managedOverrides } : {}),
-    sourcePath,
-    definitionPaths: [sourcePath, ...dropInPaths],
-    ...(reloadPending ? { reloadPending: true } : {}),
-  };
+    await binding?.verify();
+    const managedDefinition = sourcePath === resolveSystemdUnitPath(env) ? localDefinition : null;
+    const managedOverrides =
+      !reloadPending && managedDefinition
+        ? await readSystemdDropInOverrides(
+            dropInPaths,
+            managedUnsetEnvironment,
+            env,
+            sourcePath,
+          ).catch(() => UNKNOWN_SYSTEMD_OVERRIDES)
+        : UNKNOWN_SYSTEMD_OVERRIDES;
+    return {
+      ...(await buildSystemdCommandSnapshot({
+        programArguments,
+        workingDirectory: workingDirectory.replace(/^!/, ""),
+        inlineEnvironment,
+        environmentFileSpecs,
+        unsetEnvironment,
+        env,
+        unitPath: sourcePath,
+        failOnUnavailable: opts?.requireEffective,
+      })),
+      ...(managedDefinition && managedOverrides ? { managedDefinition, managedOverrides } : {}),
+      sourcePath,
+      definitionPaths: [sourcePath, ...dropInPaths],
+      ...(reloadPending ? { reloadPending: true } : {}),
+    };
+  } finally {
+    await close();
+  }
 }
 
 async function readSystemdDropInOverrides(

--- a/src/daemon/systemd-unavailable.test.ts
+++ b/src/daemon/systemd-unavailable.test.ts
@@ -2,7 +2,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { Writable } from "node:stream";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import * as processExec from "../process/exec.js";
 import { createDeferredCore } from "../shared/deferred.js";
 import { withTempDir } from "../test-utils/temp-dir.js";
@@ -22,6 +22,7 @@ import {
   isSystemctlMissingDetail,
   isSystemdUserBusUnavailableDetail,
 } from "./systemd-unavailable.js";
+import { resolveSystemdUserTransport } from "./systemd-user-transport.js";
 
 describe("classifySystemdUnavailableDetail", () => {
   it("classifies missing systemctl details", () => {
@@ -62,6 +63,18 @@ describe("classifySystemdUnavailableDetail", () => {
 });
 
 describe.skipIf(process.platform === "win32")("systemd process availability", () => {
+  beforeEach(() => vi.spyOn(process, "platform", "get").mockReturnValue("linux"));
+  afterEach(() => vi.restoreAllMocks());
+  async function managerProbe(dir: string) {
+    await fs.writeFile(
+      path.join(dir, "busctl"),
+      `#!/bin/sh
+[ "$*" = "--user --auto-start=no get-property org.freedesktop.systemd1 /org/freedesktop/systemd1 org.freedesktop.systemd1.Manager Version" ] || exit 91
+printf 's "252.39"\\n'
+`,
+      { mode: 0o700 },
+    );
+  }
   function systemctlEnv(dir: string) {
     return {
       HOME: dir,
@@ -78,6 +91,7 @@ describe.skipIf(process.platform === "win32")("systemd process availability", ()
       }
       const env = systemctlEnv(dir);
       await expect(isSystemctlAvailable(env)).resolves.toBe(false);
+      await managerProbe(dir);
       await expect(isSystemdUserServiceAvailable(env)).resolves.toBe(false);
       await expect(assertSystemdAvailable(env)).rejects.toThrow(
         errorCode === "EACCES"
@@ -104,6 +118,7 @@ describe.skipIf(process.platform === "win32")("systemd process availability", ()
         { mode: 0o700 },
       );
       const env = systemctlEnv(dir);
+      await managerProbe(dir);
       await expect(execFileUtf8("systemctl", ["--user", "status"], { env })).resolves.toEqual({
         stdout: `${output}\n`,
         stderr: "",
@@ -130,7 +145,9 @@ describe.skipIf(process.platform === "win32")("systemd process availability", ()
         { mode: 0o700 },
       );
       const env = systemctlEnv(dir);
+      await managerProbe(dir);
       const timeout = termination === "timeout" ? 500 : undefined;
+      await resolveSystemdUserTransport(env);
       const runAfterOutput = async <T>(run: () => Promise<T>): Promise<T> => {
         if (termination !== "timeout") {
           return await run();
@@ -143,7 +160,7 @@ describe.skipIf(process.platform === "win32")("systemd process availability", ()
             runCommand(argv, {
               ...(typeof options === "number" ? { timeoutMs: options } : options),
               onOutputChunk: (_chunk, stream) => {
-                if (stream === "stdout") {
+                if (stream === "stdout" && argv[0] === "systemctl") {
                   ready.resolve();
                 }
               },
@@ -202,6 +219,7 @@ describe.skipIf(process.platform === "win32")("systemd process availability", ()
       async ({ availability, disableFails }) => {
         await withTempDir("openclaw-systemctl-cleanup-", async (dir) => {
           const env = systemctlEnv(dir);
+          await managerProbe(dir);
           const unitPath = path.join(dir, ".config/systemd/user", unitName);
           const definition = "[Unit]\nDescription=Gateway cleanup fixture\n";
           await fs.mkdir(path.dirname(unitPath), { recursive: true });
@@ -213,7 +231,7 @@ describe.skipIf(process.platform === "win32")("systemd process availability", ()
                 "#!/bin/sh",
                 'printf "%s\\n" "$*" >> "$HOME/systemctl.calls"',
                 'case " $* " in',
-                '*" status "*) kill -TERM $$ ;;',
+                '*" status "*|*" --version "*) kill -TERM $$ ;;',
                 '*" is-enabled "*) printf "enabled\\n" ;;',
                 '*" disable "*)',
                 `  test -f "$HOME/.config/systemd/user/${unitName}" || exit 98`,

--- a/src/daemon/systemd-unavailable.ts
+++ b/src/daemon/systemd-unavailable.ts
@@ -29,6 +29,9 @@ export function isSystemdUserBusUnavailableDetail(detail?: string): boolean {
     normalized.includes("failed to connect to user scope bus") ||
     normalized.includes("dbus_session_bus_address") ||
     normalized.includes("xdg_runtime_dir") ||
+    normalized === "call failed: process org.freedesktop.systemd1 exited with status 1" ||
+    normalized ===
+      "call failed: the name org.freedesktop.systemd1 was not provided by any .service files" ||
     normalized.includes("enomedium") ||
     normalized.includes("no medium found")
   );
@@ -39,13 +42,11 @@ export function classifySystemdUnavailableDetail(detail?: string): SystemdUnavai
   if (!normalized) {
     return null;
   }
-  // Order matters: missing systemctl has different remediation from a live
-  // systemd install whose user bus is unavailable.
-  if (isSystemctlMissingDetail(normalized)) {
-    return "missing_systemctl";
-  }
   if (isSystemdUserBusUnavailableDetail(normalized)) {
     return "user_bus_unavailable";
+  }
+  if (isSystemctlMissingDetail(normalized)) {
+    return "missing_systemctl";
   }
   if (
     normalized.includes("systemctl --user unavailable") ||

--- a/src/daemon/systemd-user-bus.test-support.ts
+++ b/src/daemon/systemd-user-bus.test-support.ts
@@ -1,0 +1,11 @@
+// Sanitized Debian 12 / systemd 252.39 operator replies (2026-09-12).
+export const systemdOperatorBusFixtures = {
+  stale: {
+    address: "unix:path=/tmp/dbus-stale",
+    getUnitFileState: "Call failed: Process org.freedesktop.systemd1 exited with status 1",
+  },
+  runtime: {
+    address: "unix:path=$XDG_RUNTIME_DIR/bus",
+    getUnitFileState: "Call failed: No such file or directory",
+  },
+} as const;

--- a/src/daemon/systemd-user-bus.test-support.ts
+++ b/src/daemon/systemd-user-bus.test-support.ts
@@ -1,3 +1,6 @@
+import { expect } from "vitest";
+import type { ExecResult } from "./exec-file.js";
+
 // Sanitized Debian 12 / systemd 252.39 operator replies (2026-09-12).
 export const systemdOperatorBusFixtures = {
   stale: {
@@ -9,3 +12,20 @@ export const systemdOperatorBusFixtures = {
     getUnitFileState: "Call failed: No such file or directory",
   },
 } as const;
+
+export async function systemdManagerVersionProbe(
+  command: string,
+  args: string[],
+): Promise<ExecResult> {
+  expect(command).toBe("busctl");
+  expect(args).toEqual([
+    "--user",
+    "--auto-start=no",
+    "get-property",
+    "org.freedesktop.systemd1",
+    "/org/freedesktop/systemd1",
+    "org.freedesktop.systemd1.Manager",
+    "Version",
+  ]);
+  return { code: 0, termination: "exit", stdout: 's "252.39"', stderr: "" };
+}

--- a/src/daemon/systemd-user-command-deadline.test.ts
+++ b/src/daemon/systemd-user-command-deadline.test.ts
@@ -1,44 +1,52 @@
-// Direct and machine-scope attempts share the caller's one monotonic timeout.
-import { afterEach, describe, expect, it, vi } from "vitest";
+// Discovery and command dispatch share the caller's monotonic deadline and custody.
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 const exec = vi.hoisted(() => vi.fn<typeof import("./exec-file.js").execFileUtf8>());
 vi.mock("./exec-file.js", () => ({ execFileUtf8: exec }));
 import { execBusctlUser, execSystemctlUser } from "./systemd-exec.js";
 
+const environment = (name: string) => ({
+  USER: "owned",
+  LOGNAME: "owned",
+  HOME: "/test/owned",
+  XDG_RUNTIME_DIR: `/runtime/${name}`,
+  DBUS_SESSION_BUS_ADDRESS: `unix:path=/runtime/${name}/bus`,
+});
+const unavailable = {
+  code: 1,
+  termination: "exit" as const,
+  stdout: "",
+  stderr: "Failed to connect to bus: No medium found",
+};
+const success = (stdout: string) => ({ code: 0, termination: "exit" as const, stdout, stderr: "" });
+beforeEach(() => {
+  vi.spyOn(process, "platform", "get").mockReturnValue("linux");
+  vi.spyOn(process, "geteuid").mockReturnValue(1001);
+  exec.mockReset();
+});
 afterEach(() => vi.restoreAllMocks());
 
 describe("systemd user routing deadline", () => {
   it.each([450, 500])("does not give fallback a new deadline after %s ms", async (spent) => {
     let elapsed = 0;
     vi.spyOn(performance, "now").mockImplementation(() => elapsed);
-    vi.spyOn(process, "geteuid").mockReturnValue(1001);
-    exec.mockReset().mockImplementation(async (_command, args) => {
+    exec.mockImplementation(async (_command, args) => {
       if (!args.includes("--machine")) {
         elapsed += spent;
-        return {
-          code: 1,
-          termination: "exit",
-          stdout: "",
-          stderr: "Failed to connect to bus: No medium found",
-        };
+        return unavailable;
       }
-      return { code: 0, termination: "exit", stdout: "native result", stderr: "" };
+      return success(args.includes("Version") ? 's "252.39"' : "native result");
     });
     const result = await execBusctlUser(
-      {
-        USER: "owned",
-        LOGNAME: "owned",
-        HOME: "/test/owned",
-        XDG_RUNTIME_DIR: "/run/user/1001",
-        DBUS_SESSION_BUS_ADDRESS: "unix:path=/run/user/1001/bus",
-      },
-      ["--auto-start=no", "--json=short", "call", "org.freedesktop.systemd1"],
+      environment(`budget-${spent}`),
+      ["--auto-start=no", "call", "org.freedesktop.systemd1"],
       500,
     );
-    expect(exec.mock.calls[0]?.[2]?.timeout).toBe(500);
+    expect(exec.mock.calls[0]?.[2]?.timeout).toBe(166);
     if (spent === 450) {
-      expect(exec).toHaveBeenCalledTimes(2);
+      expect(exec).toHaveBeenCalledTimes(3);
       expect(exec.mock.calls[1]?.[1]).toContain("owned@");
-      expect(exec.mock.calls[1]?.[2]?.timeout).toBe(50);
+      expect(exec.mock.calls[1]?.[2]?.timeout).toBe(25);
+      expect(exec.mock.calls[2]?.[2]?.timeout).toBe(50);
       expect(result.code).toBe(0);
     } else {
       expect(exec).toHaveBeenCalledTimes(1);
@@ -50,19 +58,13 @@ describe("systemd user routing deadline", () => {
 
 it("does not dispatch machine fallback after the original stop owner retires", async () => {
   let active = true;
-  vi.spyOn(process, "geteuid").mockReturnValue(1001);
-  exec.mockReset().mockImplementation(async () => {
+  exec.mockImplementation(async () => {
     active = false;
-    return {
-      code: 1,
-      termination: "exit",
-      stdout: "",
-      stderr: "Failed to connect to bus: No medium found",
-    };
+    return unavailable;
   });
   await expect(
     execSystemctlUser(
-      { USER: "owned", HOME: "/test/owned" },
+      environment("retired-stop"),
       ["stop", "openclaw-gateway.service"],
       500,
       () => {
@@ -80,24 +82,19 @@ it.each(["current", "retired", "guard-deadline"] as const)(
   async (mode) => {
     let active = true;
     let elapsed = 0;
-    let guards = 0;
+    let firstProbeCompleted = false;
     vi.spyOn(performance, "now").mockImplementation(() => elapsed);
-    vi.spyOn(process, "geteuid").mockReturnValue(1001);
-    exec.mockReset().mockImplementation(async (_command, args) => {
+    exec.mockImplementation(async (_command, args) => {
       if (!args.includes("--machine")) {
         elapsed = 50;
         active = mode !== "retired";
-        return {
-          code: 1,
-          termination: "exit",
-          stdout: "",
-          stderr: "Failed to connect to bus: No medium found",
-        };
+        firstProbeCompleted = true;
+        return unavailable;
       }
-      return { code: 0, termination: "exit", stdout: "loaded unit", stderr: "" };
+      return success(args.includes("Version") ? 's "252.39"' : "loaded unit");
     });
     const result = execBusctlUser(
-      { USER: "owned", HOME: "/test/owned" },
+      environment(`load-${mode}`),
       [
         "--auto-start=no",
         "call",
@@ -110,11 +107,10 @@ it.each(["current", "retired", "guard-deadline"] as const)(
       ],
       500,
       () => {
-        guards++;
         if (!active) {
           throw new Error("original load owner retired");
         }
-        if (mode === "guard-deadline" && guards === 2) {
+        if (mode === "guard-deadline" && firstProbeCompleted) {
           elapsed = 500;
         }
       },
@@ -124,7 +120,9 @@ it.each(["current", "retired", "guard-deadline"] as const)(
     } else {
       expect((await result).termination).toBe(mode === "current" ? "exit" : "timeout");
     }
-    expect(exec).toHaveBeenCalledTimes(mode === "current" ? 2 : 1);
-    expect(guards).toBe(2);
+    expect(exec).toHaveBeenCalledTimes(mode === "current" ? 3 : 1);
+    expect(exec.mock.calls.filter((call) => call[1].includes("LoadUnit"))).toHaveLength(
+      mode === "current" ? 1 : 0,
+    );
   },
 );

--- a/src/daemon/systemd-user-transport.test.ts
+++ b/src/daemon/systemd-user-transport.test.ts
@@ -1,0 +1,311 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { mockProcessPlatform } from "../test-utils/vitest-spies.js";
+import { execFileUtf8 } from "./exec-file.js";
+import { mergeGatewayServiceEnv } from "./service-env-merge.js";
+import { execBusctlUser, execSystemctlUser } from "./systemd-exec.js";
+import { openSystemdUserManager } from "./systemd-peer-native.js";
+import { readSystemdServiceExecStart } from "./systemd-service-files.js";
+import { readSystemdUserTransport, resolveSystemdUserTransport } from "./systemd-user-transport.js";
+
+vi.mock("./exec-file.js", () => ({ execFileUtf8: vi.fn() }));
+vi.mock("./systemd-peer-native.js", () => ({ openSystemdUserManager: vi.fn() }));
+const dirs = useAutoCleanupTempDirTracker(afterEach);
+const success = (stdout: string) => ({ code: 0, termination: "exit" as const, stdout, stderr: "" });
+const missing = {
+  ...success(""),
+  code: 1,
+  stderr: "Failed to connect to bus: No such file or directory",
+};
+const version = 's "252.39"';
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  mockProcessPlatform("linux");
+  vi.spyOn(process, "geteuid").mockReturnValue(1000);
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllEnvs();
+});
+
+it.each(["custom", "runtime", "private", "unavailable"] as const)(
+  "shares the proven %s route across inspection and child commands",
+  async (scenario) => {
+    const home = dirs.make("openclaw-transport-");
+    const runtimeDir = path.join(home, "runtime");
+    await fs.mkdir(path.join(runtimeDir, "systemd"), { recursive: true });
+    await fs.writeFile(path.join(runtimeDir, "bus"), "unrelated socket marker");
+    if (scenario === "private") {
+      await fs.writeFile(path.join(runtimeDir, "systemd/private"), "");
+    }
+    const custom = `unix:path=${home}/custom-bus`;
+    const runtime = `unix:path=${runtimeDir}/bus`;
+    const env = {
+      HOME: home,
+      USER: "service",
+      LOGNAME: "service",
+      SUDO_USER: undefined,
+      XDG_RUNTIME_DIR: runtimeDir,
+      DBUS_SESSION_BUS_ADDRESS: custom,
+    };
+    const selected = scenario === "custom" ? custom : scenario === "runtime" ? runtime : undefined;
+    const probes: string[] = [];
+    const children: Array<{
+      command: string;
+      bus: string | undefined;
+      runtime: string | undefined;
+    }> = [];
+    vi.mocked(execFileUtf8).mockImplementation(async (command, args, options) => {
+      const bus = options?.env?.DBUS_SESSION_BUS_ADDRESS;
+      if (args.includes("Version")) {
+        expect(args).toContain("--auto-start=no");
+        probes.push(args.includes("--machine") ? "machine" : (bus ?? ""));
+        return !args.includes("--machine") && bus === selected ? success(version) : missing;
+      }
+      children.push({ command, bus, runtime: options?.env?.XDG_RUNTIME_DIR });
+      if (args.includes("LoadUnit")) {
+        return { ...missing, stderr: "Call failed: Unit openclaw-gateway.service not found." };
+      }
+      return success("");
+    });
+    const close = vi.fn(async () => {});
+    vi.mocked(openSystemdUserManager).mockResolvedValue({
+      close,
+      verify: () => {},
+      query: async (args) => (args.includes("Version") ? ["252.39"] : null),
+    });
+    if (scenario === "unavailable") {
+      await expect(resolveSystemdUserTransport(env)).rejects.toMatchObject({
+        reason: "systemd-user-bus-unavailable",
+      });
+      expect(await readSystemdUserTransport(env)).toBeUndefined();
+      expect(probes).toEqual([custom, runtime, "machine"]);
+      return;
+    }
+    await expect(readSystemdServiceExecStart(env, { requireEffective: true })).resolves.toBeNull();
+    expect((await execSystemctlUser(env, ["status"])).code).toBe(0);
+    const transport = await readSystemdUserTransport(env);
+    expect(transport?.kind).toBe(
+      scenario === "custom" ? "session-bus" : scenario === "runtime" ? "runtime-bus" : "private",
+    );
+    if (scenario === "private") {
+      expect(children).toEqual([
+        {
+          command: "systemctl",
+          bus: `unix:path=${runtimeDir}/systemd/private`,
+          runtime: runtimeDir,
+        },
+      ]);
+      expect(close).toHaveBeenCalledTimes(2);
+    } else {
+      expect((await execBusctlUser(env, ["list"])).code).toBe(0);
+      expect(children).toEqual([
+        { command: "busctl", bus: selected, runtime: runtimeDir },
+        { command: "systemctl", bus: selected, runtime: undefined },
+        { command: "busctl", bus: selected, runtime: runtimeDir },
+      ]);
+      expect(openSystemdUserManager).not.toHaveBeenCalled();
+    }
+    expect(probes).toEqual(scenario === "custom" ? [custom] : [custom, runtime]);
+    const payloadEnv = mergeGatewayServiceEnv(env, {
+      programArguments: ["node", "gateway"],
+      environment: {
+        DBUS_SESSION_BUS_ADDRESS: "unix:path=/payload/bus",
+        XDG_RUNTIME_DIR: "/payload/runtime",
+        USER: "payload",
+      },
+    });
+    expect(await resolveSystemdUserTransport(payloadEnv)).toBe(transport);
+    await fs.unlink(path.join(runtimeDir, "bus"));
+    expect(await resolveSystemdUserTransport(env)).toBe(transport);
+    expect(probes).toHaveLength(scenario === "custom" ? 1 : 2);
+  },
+);
+
+it("deduplicates concurrent discovery without retaining caller environment", async () => {
+  const home = dirs.make("openclaw-concurrent-transport-");
+  const env = {
+    HOME: home,
+    DBUS_SESSION_BUS_ADDRESS: `unix:path=${home}/bus`,
+    XDG_RUNTIME_DIR: home,
+  };
+  let release: () => void = () => {};
+  const held = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  vi.mocked(execFileUtf8).mockImplementation(async () => {
+    await held;
+    return success(version);
+  });
+  const first = resolveSystemdUserTransport(env);
+  const second = resolveSystemdUserTransport({ ...env, UNRELATED: "changed" });
+  release();
+  expect(await first).toBe(await second);
+  expect(execFileUtf8).toHaveBeenCalledOnce();
+});
+
+it("does not let a short failed discovery poison the next caller", async () => {
+  const home = dirs.make("openclaw-short-transport-");
+  const env = {
+    HOME: home,
+    DBUS_SESSION_BUS_ADDRESS: `unix:path=${home}/bus`,
+    XDG_RUNTIME_DIR: home,
+  };
+  vi.mocked(execFileUtf8).mockResolvedValue({ ...missing, termination: "timeout" });
+  await expect(resolveSystemdUserTransport(env, performance.now() + 100)).rejects.toThrow();
+  vi.mocked(execFileUtf8).mockResolvedValue(success(version));
+  await expect(resolveSystemdUserTransport(env)).resolves.toMatchObject({
+    kind: "session-bus",
+    address: env.DBUS_SESSION_BUS_ADDRESS,
+  });
+});
+
+it("stops discovery when its caller retires between probes", async () => {
+  const home = dirs.make("openclaw-retired-transport-");
+  await fs.writeFile(path.join(home, "bus"), "");
+  let current = true;
+  vi.mocked(execFileUtf8).mockImplementation(async () => {
+    current = false;
+    return missing;
+  });
+  await expect(
+    resolveSystemdUserTransport(
+      { HOME: home, XDG_RUNTIME_DIR: home, DBUS_SESSION_BUS_ADDRESS: `unix:path=${home}/custom` },
+      performance.now() + 1000,
+      () => {
+        if (!current) {
+          throw new Error("read custody retired");
+        }
+      },
+    ),
+  ).rejects.toThrow("read custody retired");
+  expect(execFileUtf8).toHaveBeenCalledOnce();
+});
+
+it("reports a lost selected private socket without reselecting or blaming the definition", async () => {
+  const home = dirs.make("openclaw-lost-private-");
+  await fs.mkdir(path.join(home, "systemd"));
+  await fs.writeFile(path.join(home, "systemd/private"), "");
+  const env = {
+    HOME: home,
+    XDG_RUNTIME_DIR: home,
+    DBUS_SESSION_BUS_ADDRESS: `unix:path=${home}/missing-bus`,
+  };
+  vi.mocked(execFileUtf8).mockResolvedValue(missing);
+  const close = vi.fn(async () => {});
+  vi.mocked(openSystemdUserManager)
+    .mockResolvedValueOnce({ close, verify: () => {}, query: async () => ["252.39"] })
+    .mockRejectedValue(new Error("Original systemd manager peer inspection is unavailable."));
+  await expect(resolveSystemdUserTransport(env)).resolves.toMatchObject({ kind: "private" });
+  const probes = vi.mocked(execFileUtf8).mock.calls.length;
+  await expect(readSystemdServiceExecStart(env, { requireEffective: true })).rejects.toMatchObject({
+    reason: "systemd-user-bus-unavailable",
+  });
+  expect(execFileUtf8).toHaveBeenCalledTimes(probes);
+  expect(close).toHaveBeenCalledOnce();
+});
+
+it("retains direct-root machine routing at the selection owner", async () => {
+  const home = dirs.make("openclaw-root-transport-");
+  vi.spyOn(process, "geteuid").mockReturnValue(0);
+  vi.spyOn(os, "userInfo").mockReturnValue({ ...os.userInfo(), username: "root" });
+  const env = {
+    HOME: home,
+    USER: "root",
+    LOGNAME: "root",
+    SUDO_USER: undefined,
+    XDG_RUNTIME_DIR: home,
+    DBUS_SESSION_BUS_ADDRESS: `unix:path=${home}/missing`,
+  };
+  vi.mocked(execFileUtf8).mockImplementation(async (command, args) => {
+    if (!args.includes("--machine")) {
+      return missing;
+    }
+    expect(args.slice(0, 3)).toEqual(["--machine", "root@", "--user"]);
+    return success(command === "busctl" ? version : "running");
+  });
+  expect((await execSystemctlUser(env, ["status"])).code).toBe(0);
+  expect(await readSystemdUserTransport(env)).toEqual({ kind: "machine", user: "root" });
+  expect(execFileUtf8).toHaveBeenCalledTimes(3);
+});
+
+it.each([true, false])(
+  "rechecks timed-out discovery for a waiting admission (private=%s)",
+  async (privateAvailable) => {
+    const home = dirs.make("openclaw-waiting-admission-");
+    if (privateAvailable) {
+      await fs.mkdir(path.join(home, "systemd"));
+      await fs.writeFile(path.join(home, "systemd/private"), "");
+    }
+    const env = {
+      HOME: home,
+      XDG_RUNTIME_DIR: home,
+      DBUS_SESSION_BUS_ADDRESS: `unix:path=${home}/custom`,
+    };
+    let release: () => void = () => {};
+    const held = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    vi.mocked(execFileUtf8)
+      .mockImplementationOnce(async () => {
+        await held;
+        return { ...missing, termination: "timeout" };
+      })
+      .mockImplementation(async (_command, args) =>
+        args.includes("--machine") ? missing : success(version),
+      );
+    vi.mocked(openSystemdUserManager).mockResolvedValue({
+      query: async () => ["252.39"],
+      close: async () => {},
+      verify: () => {},
+    });
+    const first = resolveSystemdUserTransport(env, performance.now() + 100).catch(
+      (error: unknown) => error,
+    );
+    const waiting = resolveSystemdUserTransport(env, undefined, undefined, "admission");
+    release();
+    expect(await first).toMatchObject(
+      privateAvailable ? { kind: "private" } : { reason: "systemd-user-bus-unavailable" },
+    );
+    const selected = await waiting;
+    expect(selected).toMatchObject({ kind: "session-bus", address: env.DBUS_SESSION_BUS_ADDRESS });
+    expect(await resolveSystemdUserTransport(env)).toBe(selected);
+    expect(execFileUtf8).toHaveBeenCalledTimes(privateAvailable ? 2 : 3);
+    expect(openSystemdUserManager).toHaveBeenCalledTimes(privateAvailable ? 1 : 0);
+  },
+);
+
+it("does not inherit another discovery caller's retired custody", async () => {
+  const home = dirs.make("openclaw-discovery-custody-");
+  const env = {
+    HOME: home,
+    XDG_RUNTIME_DIR: home,
+    DBUS_SESSION_BUS_ADDRESS: `unix:path=${home}/bus`,
+  };
+  let release: () => void = () => {};
+  let current = true;
+  const held = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  vi.mocked(execFileUtf8)
+    .mockImplementationOnce(async () => {
+      await held;
+      current = false;
+      return missing;
+    })
+    .mockResolvedValue(success(version));
+  const first = resolveSystemdUserTransport(env, undefined, () => {
+    if (!current) {
+      throw new Error("original discovery retired");
+    }
+  }).catch((error: unknown) => error);
+  const waiting = resolveSystemdUserTransport(env, undefined, () => {});
+  release();
+  expect(await first).toMatchObject({ message: "original discovery retired" });
+  await expect(waiting).resolves.toMatchObject({ kind: "session-bus" });
+  expect(execFileUtf8).toHaveBeenCalledTimes(2);
+});

--- a/src/daemon/systemd-user-transport.ts
+++ b/src/daemon/systemd-user-transport.ts
@@ -7,14 +7,11 @@ import {
   ServiceInspectionError,
   type ServiceInspectionReason,
 } from "./service-inspection-error.js";
+import type { SystemdUserTransport } from "./service-runtime.js";
 import type { GatewayServiceEnv } from "./service-types.js";
 import { assertGatewayServiceUpdateCurrent } from "./service-update-authority.js";
 import { decodeLegacyBusctlOutput } from "./systemd-busctl-legacy.js";
 import { openSystemdUserManager } from "./systemd-peer-native.js";
-
-export type SystemdUserTransport =
-  | { kind: "session-bus" | "runtime-bus" | "private"; address: string; runtimeDir: string }
-  | { kind: "machine"; user: string };
 
 // Reachability is a process-local routing fact, never a connection or mutation grant.
 type Selection = { transport: SystemdUserTransport; timedOut: boolean };

--- a/src/daemon/systemd-user-transport.ts
+++ b/src/daemon/systemd-user-transport.ts
@@ -1,0 +1,254 @@
+import * as fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { ABSOLUTE_DEADLINE_EXPIRED, awaitWithinDeadline } from "../utils/absolute-deadline.js";
+import { execFileUtf8 } from "./exec-file.js";
+import {
+  ServiceInspectionError,
+  type ServiceInspectionReason,
+} from "./service-inspection-error.js";
+import type { GatewayServiceEnv } from "./service-types.js";
+import { assertGatewayServiceUpdateCurrent } from "./service-update-authority.js";
+import { decodeLegacyBusctlOutput } from "./systemd-busctl-legacy.js";
+import { openSystemdUserManager } from "./systemd-peer-native.js";
+
+export type SystemdUserTransport =
+  | { kind: "session-bus" | "runtime-bus" | "private"; address: string; runtimeDir: string }
+  | { kind: "machine"; user: string };
+
+// Reachability is a process-local routing fact, never a connection or mutation grant.
+type Selection = { transport: SystemdUserTransport; timedOut: boolean };
+const transports = new Map<string, Promise<Selection>>();
+const manager = "org.freedesktop.systemd1";
+const versionArgs = [
+  "get-property",
+  manager,
+  "/org/freedesktop/systemd1",
+  `${manager}.Manager`,
+  "Version",
+];
+export const SYSTEMD_TRANSPORT_DEADLINE = new ServiceInspectionError(
+  "systemd-user-bus-unavailable",
+);
+const addressFor = (socket: string) =>
+  `unix:path=${encodeURIComponent(socket).replaceAll("%2F", "/")}`;
+const transportKey = (env: GatewayServiceEnv, uid = process.geteuid?.()) => {
+  const source = { ...process.env, ...env };
+  return JSON.stringify([
+    uid,
+    source.USER,
+    source.LOGNAME,
+    source.SUDO_USER,
+    source.XDG_RUNTIME_DIR?.trim() || `/run/user/${uid}`,
+    source.DBUS_SESSION_BUS_ADDRESS?.trim(),
+  ]);
+};
+
+/** Presentation consumes the recorded route without creating another probe. */
+export async function readSystemdUserTransport(env: GatewayServiceEnv) {
+  return (await transports.get(transportKey(env))?.catch(() => undefined))?.transport;
+}
+
+export async function resolveSystemdUserTransport(
+  env: GatewayServiceEnv,
+  deadline = performance.now() + 5000,
+  assertCurrent?: () => void,
+  purpose: "inspection" | "admission" = "inspection",
+): Promise<SystemdUserTransport | undefined> {
+  const check = () => {
+    assertGatewayServiceUpdateCurrent();
+    assertCurrent?.();
+    if (performance.now() >= deadline) {
+      throw SYSTEMD_TRANSPORT_DEADLINE;
+    }
+  };
+  const uid = process.geteuid?.();
+  const { machineUser, preferMachineScope } = resolveSystemctlUserScope(env);
+  if (preferMachineScope && machineUser) {
+    return { kind: "machine", user: machineUser };
+  }
+  if (process.platform !== "linux" || uid === undefined) {
+    return undefined;
+  }
+  check();
+  const source = { ...process.env, ...env };
+  const runtimeDir = source.XDG_RUNTIME_DIR?.trim() || `/run/user/${uid}`;
+  const explicit = source.DBUS_SESSION_BUS_ADDRESS?.trim();
+  const key = transportKey(source, uid);
+  let pending = transports.get(key);
+  const joined = pending !== undefined;
+  if (!pending) {
+    pending = select();
+    transports.set(key, pending);
+    void pending.catch(() => {
+      if (transports.get(key) === pending) {
+        transports.delete(key);
+      }
+    });
+  }
+  const discovery = pending;
+  let selected: Selection | typeof ABSOLUTE_DEADLINE_EXPIRED;
+  try {
+    selected = await awaitWithinDeadline(
+      () => discovery,
+      deadline,
+      () => performance.now(),
+    );
+  } catch (error) {
+    check();
+    // A failed shared discovery does not consume this caller's independent custody/budget.
+    if (joined) {
+      return await resolveSystemdUserTransport(env, deadline, assertCurrent, purpose);
+    }
+    throw error;
+  }
+  check();
+  if (selected === ABSOLUTE_DEADLINE_EXPIRED) {
+    throw SYSTEMD_TRANSPORT_DEADLINE;
+  }
+  // A timed-out earlier candidate remains unresolved for a later admission.
+  if (joined && purpose === "admission" && selected.timedOut) {
+    if (transports.get(key) === discovery) {
+      transports.delete(key);
+    }
+    return await resolveSystemdUserTransport(env, deadline, assertCurrent, purpose);
+  }
+  return selected.transport;
+
+  async function select(): Promise<Selection> {
+    const runtimeAddress = addressFor(path.posix.join(runtimeDir, "bus"));
+    const socket = path.posix.join(runtimeDir, "systemd/private");
+    const candidates: SystemdUserTransport[] = [
+      ...(explicit ? [{ kind: "session-bus" as const, address: explicit, runtimeDir }] : []),
+      ...(explicit !== runtimeAddress && fs.existsSync(path.posix.join(runtimeDir, "bus"))
+        ? [{ kind: "runtime-bus" as const, address: runtimeAddress, runtimeDir }]
+        : []),
+      ...(path.posix.isAbsolute(socket) && fs.existsSync(socket)
+        ? [{ kind: "private" as const, address: addressFor(socket), runtimeDir }]
+        : []),
+      ...(machineUser ? [{ kind: "machine" as const, user: machineUser }] : []),
+    ];
+    let reason: ServiceInspectionReason = "systemd-user-bus-unavailable";
+    let timedOut = false;
+    for (const [index, candidate] of candidates.entries()) {
+      check();
+      const budget = Math.max(
+        1,
+        Math.floor((deadline - performance.now()) / (candidates.length - index + 1)),
+      );
+      const until = performance.now() + budget;
+      let connection: Awaited<ReturnType<typeof openSystemdUserManager>> | undefined;
+      try {
+        let version: unknown;
+        if (candidate.kind === "private") {
+          connection = await openSystemdUserManager(candidate.address, until);
+          check();
+          [version] = (await connection.query(versionArgs, ["s"], until)) ?? [];
+        } else {
+          const scope =
+            candidate.kind === "machine"
+              ? ["--machine", `${candidate.user}@`, "--user"]
+              : ["--user"];
+          const result = await execFileUtf8(
+            "busctl",
+            [...scope, "--auto-start=no", ...versionArgs],
+            {
+              env:
+                candidate.kind === "machine"
+                  ? source
+                  : { ...source, DBUS_SESSION_BUS_ADDRESS: candidate.address },
+              timeout: budget,
+              killSignal: "SIGKILL",
+            },
+          );
+          check();
+          if (result.termination === "timeout" || result.termination === "no-output-timeout") {
+            timedOut = true;
+          }
+          if (result.termination === "exit" && result.code === 0) {
+            [version] = decodeLegacyBusctlOutput(result.stdout, ["s"], false);
+          }
+          if (result.errorCode === "ENOENT") {
+            reason = "systemd-busctl-unavailable";
+          } else if (["EACCES", "EPERM"].includes(result.errorCode ?? "")) {
+            reason = "service-manager-access-denied";
+          }
+        }
+        check();
+        if (typeof version === "string" && version.length > 0) {
+          return { transport: candidate, timedOut };
+        }
+      } catch (error) {
+        check();
+        if (error === SYSTEMD_TRANSPORT_DEADLINE) {
+          throw error;
+        }
+        timedOut ||= performance.now() >= until;
+      } finally {
+        await connection?.close();
+      }
+    }
+    check();
+    throw timedOut ? SYSTEMD_TRANSPORT_DEADLINE : new ServiceInspectionError(reason);
+  }
+}
+
+function readSystemctlEffectiveUser(): string | null {
+  try {
+    return os.userInfo().username;
+  } catch {
+    return null;
+  }
+}
+
+function isNonRootUser(user: string | null): user is string {
+  return Boolean(user && user !== "root");
+}
+
+function resolveSystemctlUserScope(env: GatewayServiceEnv): {
+  machineUser: string | null;
+  preferMachineScope: boolean;
+} {
+  const sudoUser = env.SUDO_USER?.trim() || null;
+  const envUser = env.USER?.trim() || env.LOGNAME?.trim() || null;
+  const effectiveUid = process.geteuid?.();
+  const effectiveUser = readSystemctlEffectiveUser();
+  const isEffectiveRoot =
+    effectiveUid === undefined ? effectiveUser === "root" : effectiveUid === 0;
+  const hasRootUserManager =
+    isEffectiveRoot &&
+    env.HOME?.trim() === "/root" &&
+    env.XDG_RUNTIME_DIR?.trim() === "/run/user/0" &&
+    Boolean(env.DBUS_SESSION_BUS_ADDRESS?.includes("/run/user/0/bus"));
+  const isSudoToRoot = isEffectiveRoot && !hasRootUserManager && isNonRootUser(sudoUser);
+  const machineUser = hasRootUserManager
+    ? null
+    : isSudoToRoot
+      ? sudoUser
+      : isNonRootUser(envUser)
+        ? envUser
+        : isNonRootUser(sudoUser)
+          ? sudoUser
+          : effectiveUser || envUser || sudoUser || null;
+  return {
+    machineUser,
+    preferMachineScope: isSudoToRoot,
+  };
+}
+
+/** True when root-owned paths would be paired with the sudo caller's user manager. */
+export function hasSudoToRootSystemdUserManagerMismatch(env: GatewayServiceEnv): boolean {
+  return resolveSystemctlUserScope(env).preferMachineScope;
+}
+
+/**
+ * Resolves the account whose user manager owns the service operation.
+ * Keep linger diagnostics on this identity so sudo never checks root while
+ * systemctl targets the invoking user's manager.
+ */
+export function resolveSystemdUserServiceAccount(env: GatewayServiceEnv): string | null {
+  const { machineUser } = resolveSystemctlUserScope(env);
+  return (
+    machineUser ?? readSystemctlEffectiveUser() ?? env.USER?.trim() ?? env.LOGNAME?.trim() ?? null
+  );
+}

--- a/src/daemon/systemd.test.ts
+++ b/src/daemon/systemd.test.ts
@@ -28,7 +28,7 @@ type ExecFileMock = (
 ) => unknown;
 
 const execFileMock = vi.hoisted(() => vi.fn<ExecFileMock>());
-const existsSyncMock = vi.hoisted(() => vi.fn(() => false));
+const existsSyncMock = vi.hoisted(() => vi.fn<typeof import("node:fs").existsSync>(() => false));
 const assertNoSystemSystemdOwnershipMock = vi.hoisted(() =>
   vi.fn<(unitName: string, timeoutMs?: number) => Promise<void>>(async () => {}),
 );
@@ -387,27 +387,37 @@ describe("systemd availability", () => {
     await expect(isSystemdUserServiceAvailable()).resolves.toBe(true);
   });
 
-  it("repairs missing user bus environment when the runtime bus exists", async () => {
-    mockEffectiveUid(1000);
-    existsSyncMock.mockReturnValue(true);
-    execFileMock.mockImplementation((_cmd, args, opts, cb) => {
-      assertUserSystemctlArgs(args, "status");
-      if (!opts.env) {
-        throw new Error("expected systemctl env");
-      }
-      expect(opts.env.XDG_RUNTIME_DIR).toBe("/run/user/1000");
-      expect(opts.env.DBUS_SESSION_BUS_ADDRESS).toBe("unix:path=/run/user/1000/bus");
-      cb(null, "", "");
-    });
+  it.each([
+    { socket: "bus", runtime: undefined, sessionAddress: undefined },
+    { socket: "bus", runtime: "/run/user/1000", sessionAddress: "unix:path=/tmp/dbus-stale" },
+    { socket: "systemd/private", runtime: undefined, sessionAddress: "unix:path=/tmp/dbus-stale" },
+    { socket: "systemd/private", runtime: "/run/user/1000", sessionAddress: undefined },
+  ])(
+    "uses runtime $socket despite session address $sessionAddress",
+    async ({ socket, runtime, sessionAddress }) => {
+      mockEffectiveUid(1000);
+      existsSyncMock.mockImplementation((file) => file === `/run/user/1000/${socket}`);
+      execFileMock.mockImplementation((_cmd, args, opts, cb) => {
+        assertUserSystemctlArgs(args, "status");
+        if (!opts.env) {
+          throw new Error("expected systemctl env");
+        }
+        expect(opts.env.XDG_RUNTIME_DIR).toBe("/run/user/1000");
+        expect(opts.env.DBUS_SESSION_BUS_ADDRESS).toBe(
+          socket === "bus" ? "unix:path=/run/user/1000/bus" : sessionAddress,
+        );
+        cb(null, "", "");
+      });
 
-    await expect(
-      isSystemdUserServiceAvailable({
-        USER: "debian",
-        XDG_RUNTIME_DIR: undefined,
-        DBUS_SESSION_BUS_ADDRESS: undefined,
-      }),
-    ).resolves.toBe(true);
-  });
+      await expect(
+        isSystemdUserServiceAvailable({
+          USER: "debian",
+          XDG_RUNTIME_DIR: runtime,
+          DBUS_SESSION_BUS_ADDRESS: sessionAddress,
+        }),
+      ).resolves.toBe(true);
+    },
+  );
 
   it("returns false when systemd user bus is unavailable", async () => {
     execFileMock.mockImplementation((_cmd, _args, _opts, cb) => {

--- a/src/daemon/systemd.test.ts
+++ b/src/daemon/systemd.test.ts
@@ -1179,7 +1179,10 @@ describe("readSystemdServiceRuntime", () => {
         expect(args[1]).toBe("show");
         cb(null, output, "");
       });
-    return await readSystemdServiceRuntime({ HOME: TEST_MANAGED_HOME });
+    return await readSystemdServiceRuntime(
+      { HOME: TEST_MANAGED_HOME },
+      { commandInspection: { kind: "present" } },
+    );
   }
 
   it("parses active state details", async () => {
@@ -1212,43 +1215,32 @@ describe("readSystemdServiceRuntime", () => {
     expect(runtime).toMatchObject({ status: "unknown", state, subState });
   });
 
-  it.each([
-    { loadState: "not-found", activeState: "inactive", missing: true, status: "stopped" },
-    { loadState: "loaded", activeState: "inactive", missing: false, status: "stopped" },
-    { loadState: "not-found", activeState: "active", missing: false, status: "running" },
-  ])(
-    "records native unit absence from a successful show ($loadState/$activeState)",
-    async ({ loadState, activeState, missing, status }) => {
-      const runtime = await readRuntimeFromShowOutput(
-        `LoadState=${loadState}\nActiveState=${activeState}\nSubState=${status === "running" ? "running" : "dead"}\nMainPID=0`,
+  it.each(["absent", "unavailable"] as const)(
+    "uses the recorded %s definition verdict without a competing show classification",
+    async (kind) => {
+      execFileMock.mockReset().mockImplementationOnce(systemctlUserSuccess("status"));
+      const runtime = await readSystemdServiceRuntime(
+        { HOME: TEST_MANAGED_HOME },
+        {
+          commandInspection:
+            kind === "absent"
+              ? { kind }
+              : { kind, error: new Error("definition-inspection-secret-canary") },
+        },
       );
-      expect(runtime.status).toBe(status);
-      expect(runtime.missingUnit === true).toBe(missing);
-    },
-  );
-
-  it.each(["exit", "timeout", "signal"] as const)(
-    "reports a missing unit only after a completed show command (%s)",
-    async (termination) => {
-      const detail = "Unit openclaw-gateway.service could not be found.";
-      const accessSpy = vi
-        .spyOn(fs, "access")
-        .mockRejectedValue(Object.assign(new Error("ENOENT"), { code: "ENOENT" }));
-      execFileMock
-        .mockImplementationOnce(systemctlUserSuccess("status"))
-        .mockImplementationOnce((_cmd, _args, _opts, cb) => {
-          cb(createExecFileError(detail, { termination }), "", detail);
+      if (kind === "absent") {
+        expect(runtime).toEqual({ status: "stopped", missingUnit: true });
+      } else {
+        expect(runtime).toMatchObject({
+          status: "unknown",
+          inspectionFailure: {
+            detail: "SERVICE_DEFINITION_UNKNOWN: Service definition cannot be safely inspected.",
+          },
         });
-
-      try {
-        await expect(readSystemdServiceRuntime({ HOME: TEST_MANAGED_HOME })).resolves.toEqual(
-          termination === "exit"
-            ? { status: "stopped", missingUnit: true }
-            : { status: "unknown", missingUnit: false, detail },
-        );
-      } finally {
-        accessSpy.mockRestore();
+        expect(JSON.stringify(runtime)).not.toContain("secret-canary");
+        expect(runtime.missingUnit).not.toBe(true);
       }
+      expect(execFileMock).toHaveBeenCalledOnce();
     },
   );
 
@@ -1260,7 +1252,12 @@ describe("readSystemdServiceRuntime", () => {
         cb(createExecFileError(detail, { stderr: detail }), "", detail);
       });
 
-    await expect(readSystemdServiceRuntime({ HOME: TEST_MANAGED_HOME })).resolves.toEqual({
+    await expect(
+      readSystemdServiceRuntime(
+        { HOME: TEST_MANAGED_HOME },
+        { commandInspection: { kind: "present" } },
+      ),
+    ).resolves.toEqual({
       status: "unknown",
       detail: "Permission denied while reading systemd state",
       missingUnit: false,
@@ -1286,15 +1283,18 @@ describe("readSystemdServiceRuntime", () => {
       });
 
       try {
-        await expect(readSystemdServiceRuntime({ HOME: TEST_MANAGED_HOME })).resolves.toMatchObject(
-          {
-            status: result === "error" ? "unknown" : "stopped",
-            ...(result === "error"
-              ? { detail: "Unit openclaw-gateway.service could not be found." }
-              : {}),
-            missingUnit: false,
-          },
-        );
+        await expect(
+          readSystemdServiceRuntime(
+            { HOME: TEST_MANAGED_HOME },
+            { commandInspection: { kind: "present" } },
+          ),
+        ).resolves.toMatchObject({
+          status: result === "error" ? "unknown" : "stopped",
+          ...(result === "error"
+            ? { detail: "Unit openclaw-gateway.service could not be found." }
+            : {}),
+          missingUnit: false,
+        });
       } finally {
         accessSpy.mockRestore();
       }
@@ -1393,7 +1393,10 @@ describe("readSystemdServiceRuntime", () => {
           "Id,LoadState,ActiveState,SubState,Result,NRestarts,StartLimitBurst,MainPID,ExecMainStatus,ExecMainCode,KillMode,TasksCurrent,MemoryCurrent",
         ),
       );
-    const runtime = await readSystemdServiceRuntime({ HOME: TEST_MANAGED_HOME });
+    const runtime = await readSystemdServiceRuntime(
+      { HOME: TEST_MANAGED_HOME },
+      { commandInspection: { kind: "present" } },
+    );
     expect(runtime).toEqual({
       status: "running",
       state: "active",
@@ -1415,7 +1418,10 @@ describe("readSystemdServiceRuntime", () => {
   it("passes a kill-backed timeout to systemctl when a read deadline is set", async () => {
     execFileMock.mockReset();
     execFileMock.mockImplementation(execFileResult(null, "", ""));
-    await readSystemdServiceRuntime({ HOME: TEST_MANAGED_HOME }, { timeoutMs: 1234 });
+    await readSystemdServiceRuntime(
+      { HOME: TEST_MANAGED_HOME },
+      { timeoutMs: 1234, commandInspection: { kind: "present" } },
+    );
     expect(execFileMock).toHaveBeenCalled();
     for (const call of execFileMock.mock.calls) {
       const opts = call[2] as { timeout?: number; killSignal?: string };
@@ -1427,7 +1433,10 @@ describe("readSystemdServiceRuntime", () => {
   it("leaves systemctl unbounded when no read deadline is set", async () => {
     execFileMock.mockReset();
     execFileMock.mockImplementation(execFileResult(null, "", ""));
-    await readSystemdServiceRuntime({ HOME: TEST_MANAGED_HOME });
+    await readSystemdServiceRuntime(
+      { HOME: TEST_MANAGED_HOME },
+      { commandInspection: { kind: "present" } },
+    );
     expect(execFileMock).toHaveBeenCalled();
     for (const call of execFileMock.mock.calls) {
       const opts = call[2] as { timeout?: number; killSignal?: string };
@@ -1456,7 +1465,10 @@ describe("readSystemdServiceRuntime", () => {
           "",
         ),
       );
-    const runtime = await readSystemdServiceRuntime({ HOME: TEST_MANAGED_HOME });
+    const runtime = await readSystemdServiceRuntime(
+      { HOME: TEST_MANAGED_HOME },
+      { commandInspection: { kind: "present" } },
+    );
     // ActiveState=failed collapses to the generic "stopped" status, so the raw
     // state + restart counters are what let callers detect the crash-loop give-up.
     expect(runtime.status).toBe("stopped");
@@ -1743,7 +1755,7 @@ describe("readSystemdServiceExecStart", () => {
     );
     await expect(
       readSystemdServiceExecStart({ HOME: TEST_SERVICE_HOME }, { requireEffective: true }),
-    ).rejects.toThrow("unreadable-service-secret-canary");
+    ).rejects.toThrow(`${TEST_SERVICE_HOME}/.config/systemd/user/${GATEWAY_SERVICE}`);
   });
 
   it.each([false, true])(

--- a/src/daemon/systemd.test.ts
+++ b/src/daemon/systemd.test.ts
@@ -257,6 +257,13 @@ function execFileSuccess(): ExecFileMock {
 
 type ExecFileResult = [error: ExecFileError | null, stdout: string, stderr: string];
 
+function systemctlVersionResult(result: ExecFileResult = [null, "", ""]): ExecFileMock {
+  return (_command, args, _options, done) => {
+    expect(args).toEqual(["--version"]);
+    done(...result);
+  };
+}
+
 function systemctlUserResult(result: ExecFileResult, ...command: string[]): ExecFileMock {
   return (_cmd, args, _opts, cb) => {
     assertUserSystemctlArgs(args, ...command);
@@ -4175,7 +4182,7 @@ describe("uninstallLegacySystemdUnits", () => {
   });
 
   it.each(["exit", "signal"] as const)(
-    "preserves a legacy unit file when disable fails after status %s",
+    "preserves a legacy unit file when disable fails after executable probe %s",
     async (termination) => {
       const tempHomeRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-legacy-unit-"));
       const env = { HOME: path.join(tempHomeRoot, "home") };
@@ -4196,10 +4203,11 @@ describe("uninstallLegacySystemdUnits", () => {
           mode: 0o644,
         });
         execFileMock.mockImplementation((_command, args, _options, callback) => {
-          if (args[1] === "status") {
+          if (args[0] === "--version") {
+            expect(args).toEqual(["--version"]);
             callback(
               termination === "signal"
-                ? createExecFileError("status interrupted", { termination })
+                ? createExecFileError("executable probe interrupted", { termination })
                 : null,
               "",
               "",
@@ -4282,7 +4290,7 @@ describe("uninstallUserSystemdGatewayUnit", () => {
         mode: 0o644,
       });
       execFileMock
-        .mockImplementationOnce(systemctlUserSuccess("status"))
+        .mockImplementationOnce(systemctlVersionResult())
         .mockImplementationOnce(systemctlUserSuccess("disable", "--now", GATEWAY_SERVICE))
         // A deleted unit stays loaded until the manager reloads.
         .mockImplementationOnce(systemctlUserSuccess("daemon-reload"));
@@ -4305,7 +4313,7 @@ describe("uninstallUserSystemdGatewayUnit", () => {
         mode: 0o600,
       });
       execFileMock
-        .mockImplementationOnce(systemctlUserSuccess("status"))
+        .mockImplementationOnce(systemctlVersionResult())
         .mockImplementationOnce(systemctlUserSuccess("disable", "--now", GATEWAY_SERVICE));
 
       const { write, stdout } = createWritableStreamMock();
@@ -4341,7 +4349,7 @@ describe("uninstallUserSystemdGatewayUnit", () => {
   });
 
   it.each(["exit", "signal"] as const)(
-    "preserves the unit file when disable fails after status %s",
+    "preserves the unit file when disable fails after executable probe %s",
     async (termination) => {
       await withUserUnitFixture(async ({ env, unitPath }) => {
         await fs.writeFile(unitPath, "[Unit]\nDescription=OpenClaw Gateway\n", {
@@ -4350,16 +4358,13 @@ describe("uninstallUserSystemdGatewayUnit", () => {
         });
         execFileMock
           .mockImplementationOnce(
-            systemctlUserResult(
-              [
-                termination === "signal"
-                  ? createExecFileError("status interrupted", { termination })
-                  : null,
-                "",
-                "",
-              ],
-              "status",
-            ),
+            systemctlVersionResult([
+              termination === "signal"
+                ? createExecFileError("executable probe interrupted", { termination })
+                : null,
+              "",
+              "",
+            ]),
           )
           .mockImplementationOnce(
             systemctlUserResult(
@@ -4387,7 +4392,7 @@ describe("uninstallUserSystemdGatewayUnit", () => {
         mode: 0o644,
       });
       execFileMock
-        .mockImplementationOnce(systemctlUserSuccess("status"))
+        .mockImplementationOnce(systemctlVersionResult())
         .mockImplementationOnce(systemctlUserSuccess("disable", "--now", GATEWAY_SERVICE))
         .mockImplementationOnce(
           systemctlUserResult(

--- a/src/daemon/systemd.test.ts
+++ b/src/daemon/systemd.test.ts
@@ -1271,6 +1271,10 @@ describe("isNonFatalSystemdInstallProbeError", () => {
 });
 
 describe("readSystemdServiceRuntime", () => {
+  beforeEach(() => {
+    vi.spyOn(process, "platform", "get").mockReturnValue("linux");
+  });
+
   async function readRuntimeFromShowOutput(output: string) {
     execFileMock.mockReset();
     execFileMock
@@ -1330,7 +1334,17 @@ describe("readSystemdServiceRuntime", () => {
         },
       );
       if (kind === "absent") {
-        expect(runtime).toEqual({ status: "stopped", missingUnit: true });
+        expect(runtime).toEqual({
+          status: "stopped",
+          missingUnit: true,
+          systemd: {
+            transport: {
+              kind: "session-bus",
+              address: process.env.DBUS_SESSION_BUS_ADDRESS,
+              runtimeDir: process.env.XDG_RUNTIME_DIR,
+            },
+          },
+        });
       } else {
         expect(runtime).toMatchObject({
           status: "unknown",
@@ -1510,6 +1524,11 @@ describe("readSystemdServiceRuntime", () => {
         killMode: "process",
         tasksCurrent: 807,
         memoryCurrent: 11_918_534_246,
+        transport: {
+          kind: "session-bus",
+          address: process.env.DBUS_SESSION_BUS_ADDRESS,
+          runtimeDir: process.env.XDG_RUNTIME_DIR,
+        },
       },
     });
   });

--- a/src/daemon/systemd.test.ts
+++ b/src/daemon/systemd.test.ts
@@ -28,6 +28,7 @@ type ExecFileMock = (
 ) => unknown;
 
 const execFileMock = vi.hoisted(() => vi.fn<ExecFileMock>());
+const versionFixture = vi.hoisted(() => ({ useScenarioResponse: false }));
 const existsSyncMock = vi.hoisted(() => vi.fn<typeof import("node:fs").existsSync>(() => false));
 const assertNoSystemSystemdOwnershipMock = vi.hoisted(() =>
   vi.fn<(unitName: string, timeoutMs?: number) => Promise<void>>(async () => {}),
@@ -70,7 +71,24 @@ vi.mock("./exec-file.js", () => {
       command: string,
       args: string[],
       options: Omit<ExecFileOptionsWithStringEncoding, "encoding"> = {},
-    ) => {
+    ): Promise<ExecResult> => {
+      if (args.includes("Version")) {
+        expect(command).toBe("busctl");
+        expect(args).toEqual([
+          ...(args[0] === "--machine"
+            ? ["--machine", `${options.env?.USER}@`, "--user"]
+            : ["--user"]),
+          "--auto-start=no",
+          "get-property",
+          "org.freedesktop.systemd1",
+          "/org/freedesktop/systemd1",
+          "org.freedesktop.systemd1.Manager",
+          "Version",
+        ]);
+        if (!versionFixture.useScenarioResponse) {
+          return { code: 0, termination: "exit", stdout: 's "252.39"', stderr: "" };
+        }
+      }
       let settled: ExecResult | undefined;
 
       execFileMock(command, args, { ...options, encoding: "utf8" }, (error, stdout, stderr) => {
@@ -95,6 +113,7 @@ import { splitArgsPreservingQuotes } from "./arg-split.js";
 import * as systemdExec from "./systemd-exec.js";
 import { resolveSystemdUnitPath } from "./systemd-service-files.js";
 import { parseSystemdEnvAssignments, parseSystemdExecStart } from "./systemd-unit.js";
+import { hasSudoToRootSystemdUserManagerMismatch } from "./systemd-user-transport.js";
 import {
   findInstalledSystemdGatewayScope,
   findSystemdGatewayInstallation,
@@ -284,6 +303,41 @@ function mockNodeInstallNoMediumFailure(machineUser?: string): void {
   }
 }
 
+let machineFixtureId = 0;
+function mockMachineManager(user: string): NodeJS.ProcessEnv {
+  versionFixture.useScenarioResponse = true;
+  const runtime = `/fixture/systemd-machine-${++machineFixtureId}`;
+  vi.spyOn(process, "platform", "get").mockReturnValue("linux");
+  vi.spyOn(process, "geteuid").mockReturnValue(process.getuid?.() ?? 1000);
+  const readFile = fs.readFile.bind(fs);
+  vi.spyOn(fs, "readFile").mockImplementation(async (...args) => {
+    if (typeof args[0] === "string" && args[0].startsWith("/proc/self/fdinfo/")) {
+      return "mnt_id: 1\n";
+    }
+    if (args[0] === "/proc/self/mountinfo") {
+      return "1 0 0:1 / / rw - tmpfs tmpfs rw\n";
+    }
+    return await readFile(...args);
+  });
+  execFileMock.mockReset().mockImplementation((_command, args, _options, done) => {
+    if (args.includes("Version") && !args.includes("--machine")) {
+      done(
+        createExecFileError("Failed to connect to bus: No medium found"),
+        "",
+        "Failed to connect to bus: No medium found",
+      );
+      return;
+    }
+    expect(args.slice(0, 3)).toEqual(["--machine", `${user}@`, "--user"]);
+    done(null, args.includes("Version") ? 's "252.39"' : "", "");
+  });
+  return {
+    USER: user,
+    XDG_RUNTIME_DIR: runtime,
+    DBUS_SESSION_BUS_ADDRESS: `unix:path=${runtime}/bus`,
+  };
+}
+
 function mockEffectiveUid(uid: number) {
   vi.spyOn(process, "geteuid").mockReturnValue(uid);
 }
@@ -372,9 +426,18 @@ const assertRestartSuccess = async (env: NodeJS.ProcessEnv) => {
   expect(requireFirstWrite(write)).toContain("Restarted systemd service");
 };
 
+let testFixtureId = 0;
 beforeEach(() => {
+  const runtime = `/fixture/systemd-test-${++testFixtureId}`;
+  vi.stubEnv("XDG_RUNTIME_DIR", runtime);
+  vi.stubEnv("DBUS_SESSION_BUS_ADDRESS", `unix:path=${runtime}/bus`);
+  versionFixture.useScenarioResponse = false;
   existsSyncMock.mockReset();
   existsSyncMock.mockReturnValue(false);
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllEnvs();
 });
 
 describe("systemd availability", () => {
@@ -395,24 +458,49 @@ describe("systemd availability", () => {
   ])(
     "uses runtime $socket despite session address $sessionAddress",
     async ({ socket, runtime, sessionAddress }) => {
-      mockEffectiveUid(1000);
-      existsSyncMock.mockImplementation((file) => file === `/run/user/1000/${socket}`);
+      versionFixture.useScenarioResponse = true;
+      const uid = socket === "bus" ? 1000 : 1002;
+      const runtimeDir = `/run/user/${uid}`;
+      mockEffectiveUid(uid);
+      vi.spyOn(process, "platform", "get").mockReturnValue("linux");
+      existsSyncMock.mockImplementation((file) => file === `${runtimeDir}/${socket}`);
+      vi.spyOn(
+        await import("./systemd-peer-native.js"),
+        "openSystemdUserManager",
+      ).mockResolvedValue({
+        query: async (args) => {
+          expect(args.at(-1)).toBe("Version");
+          return ["252.39"];
+        },
+        close: async () => {},
+        verify: () => {},
+      });
       execFileMock.mockImplementation((_cmd, args, opts, cb) => {
+        if (args.includes("Version")) {
+          expect(args).toContain("--auto-start=no");
+          if (
+            socket === "bus" &&
+            opts.env?.DBUS_SESSION_BUS_ADDRESS === `unix:path=${runtimeDir}/bus`
+          ) {
+            cb(null, 's "252.39"', "");
+          } else {
+            cb(createExecFileError("Failed to connect to bus"), "", "Failed to connect to bus");
+          }
+          return;
+        }
         assertUserSystemctlArgs(args, "status");
         if (!opts.env) {
           throw new Error("expected systemctl env");
         }
-        expect(opts.env.XDG_RUNTIME_DIR).toBe("/run/user/1000");
-        expect(opts.env.DBUS_SESSION_BUS_ADDRESS).toBe(
-          socket === "bus" ? "unix:path=/run/user/1000/bus" : sessionAddress,
-        );
+        expect(opts.env.XDG_RUNTIME_DIR).toBe(socket === "bus" ? undefined : runtimeDir);
+        expect(opts.env.DBUS_SESSION_BUS_ADDRESS).toBe(`unix:path=${runtimeDir}/${socket}`);
         cb(null, "", "");
       });
 
       await expect(
         isSystemdUserServiceAvailable({
           USER: "debian",
-          XDG_RUNTIME_DIR: runtime,
+          XDG_RUNTIME_DIR: runtime === undefined ? undefined : runtimeDir,
           DBUS_SESSION_BUS_ADDRESS: sessionAddress,
         }),
       ).resolves.toBe(true);
@@ -445,21 +533,13 @@ describe("systemd availability", () => {
   });
 
   it("falls back to machine user scope when --user bus is unavailable", async () => {
-    execFileMock
-      .mockImplementationOnce((_cmd, args, _opts, cb) => {
-        expect(args).toEqual(["--user", "status"]);
-        const err = createExecFileError("Failed to connect to user scope bus via local transport", {
-          stderr:
-            "Failed to connect to user scope bus via local transport: $DBUS_SESSION_BUS_ADDRESS and $XDG_RUNTIME_DIR not defined",
-        });
-        cb(err, "", "");
-      })
-      .mockImplementationOnce((_cmd, args, _opts, cb) => {
-        expect(args).toEqual(["--machine", "debian@", "--user", "status"]);
-        cb(null, "", "");
-      });
-
-    await expect(isSystemdUserServiceAvailable({ USER: "debian" })).resolves.toBe(true);
+    const env = mockMachineManager("debian");
+    await expect(isSystemdUserServiceAvailable(env)).resolves.toBe(true);
+    expect(execFileMock.mock.calls.map(([, args]) => args.at(-1))).toEqual([
+      "Version",
+      "Version",
+      "status",
+    ]);
   });
 
   it("does not fall back to machine scope when --user fails with permission denied", async () => {
@@ -526,7 +606,7 @@ describe("systemd availability", () => {
 
     const env = { SUDO_USER: "debian", USER: "root", LOGNAME: "root" };
     expect(resolveSystemdUserServiceAccount(env)).toBe("debian");
-    expect(systemdExec.hasSudoToRootSystemdUserManagerMismatch(env)).toBe(true);
+    expect(hasSudoToRootSystemdUserManagerMismatch(env)).toBe(true);
   });
 
   it("keeps root user scope when stale SUDO_USER is paired with root bus environment", async () => {
@@ -565,7 +645,7 @@ describe("systemd availability", () => {
       DBUS_SESSION_BUS_ADDRESS: "unix:path=/run/user/0/bus",
     };
     expect(resolveSystemdUserServiceAccount(env)).toBe("root");
-    expect(systemdExec.hasSudoToRootSystemdUserManagerMismatch(env)).toBe(false);
+    expect(hasSudoToRootSystemdUserManagerMismatch(env)).toBe(false);
   });
 
   it("does not let stale SUDO_USER override a sudo-u target user scope", async () => {
@@ -737,24 +817,28 @@ describe("isSystemdServiceEnabled", () => {
 
   it("throws when systemctl is-enabled fails for non-state errors", async () => {
     vi.spyOn(fs, "access").mockResolvedValue(undefined);
-    execFileMock
-      .mockImplementationOnce((_cmd, args, _opts, cb) => {
-        expect(args).toEqual(["--user", "is-enabled", "openclaw-gateway.service"]);
-        const err = new Error("Failed to connect to bus") as Error & { code?: number };
-        err.code = 1;
-        cb(err, "", "Failed to connect to bus");
-      })
-      .mockImplementationOnce((_cmd, args, _opts, cb) => {
-        expect(args[0]).toBe("--machine");
-        expect(args[1]).toMatch(/^[^@]+@$/);
-        expect(args.slice(2)).toEqual(["--user", "is-enabled", "openclaw-gateway.service"]);
-        const err = new Error("permission denied") as Error & { code?: number };
-        err.code = 1;
-        cb(err, "", "permission denied");
-      });
-    await expect(
-      isSystemdServiceEnabled({ env: { HOME: "/tmp/openclaw-test-home" } }),
-    ).rejects.toThrow("systemctl is-enabled unavailable: permission denied");
+    const env = { HOME: "/tmp/openclaw-test-home", ...mockMachineManager("debian") };
+    const probe = execFileMock.getMockImplementation();
+    if (!probe) {
+      throw new Error("missing manager fixture");
+    }
+    execFileMock.mockImplementation((command, args, options, done) => {
+      if (args.includes("Version")) {
+        probe(command, args, options, done);
+        return;
+      }
+      expect(args).toEqual([
+        "--machine",
+        "debian@",
+        "--user",
+        "is-enabled",
+        "openclaw-gateway.service",
+      ]);
+      done(createExecFileError("permission denied"), "", "permission denied");
+    });
+    await expect(isSystemdServiceEnabled({ env })).rejects.toThrow(
+      "systemctl is-enabled unavailable: permission denied",
+    );
   });
 
   it("returns false when systemctl is-enabled exits with code 4 (not-found)", async () => {
@@ -3779,10 +3863,9 @@ describe("systemd service install and uninstall", () => {
     },
   );
 
-  it("falls back to machine user scope when install activation hits a no-medium user bus failure", async () => {
+  it("retains the discovered machine user scope throughout install activation", async () => {
     await withNodeSystemdFixture(async ({ env }) => {
-      const installEnv = { ...env, USER: "debian" };
-      mockNodeInstallNoMediumFailure("debian");
+      const installEnv = { ...env, ...mockMachineManager("debian") };
 
       await installSystemdService(
         nodeSystemdServiceFixture(installEnv, {
@@ -3792,15 +3875,15 @@ describe("systemd service install and uninstall", () => {
         }),
       );
 
-      expect(execFileMock).toHaveBeenCalledTimes(5);
+      expect(
+        execFileMock.mock.calls.map(([, args]) => (args.includes("Version") ? "Version" : args[3])),
+      ).toEqual(["Version", "Version", "status", "daemon-reload", "enable", "restart"]);
     });
   });
 
-  it("uses the sudo-u target user for install activation machine-scope retry", async () => {
+  it("uses the sudo-u target user for discovered machine-scope install activation", async () => {
     await withNodeSystemdFixture(async ({ env }) => {
-      mockEffectiveUid(process.getuid?.() ?? 1000);
-      const installEnv = { ...env, USER: "openclaw", SUDO_USER: "admin" };
-      mockNodeInstallNoMediumFailure("openclaw");
+      const installEnv = { ...env, ...mockMachineManager("openclaw"), SUDO_USER: "admin" };
 
       await installSystemdService(
         nodeSystemdServiceFixture(installEnv, {
@@ -3810,7 +3893,9 @@ describe("systemd service install and uninstall", () => {
         }),
       );
 
-      expect(execFileMock).toHaveBeenCalledTimes(5);
+      expect(
+        execFileMock.mock.calls.map(([, args]) => (args.includes("Version") ? "Version" : args[3])),
+      ).toEqual(["Version", "Version", "status", "daemon-reload", "enable", "restart"]);
     });
   });
 
@@ -4574,38 +4659,10 @@ describe("systemd service control", () => {
   });
 
   it("falls back to machine user scope for restart when user bus env is missing", async () => {
-    execFileMock
-      .mockImplementationOnce((_cmd, args, _opts, cb) => {
-        assertUserSystemctlArgs(args, "status");
-        const err = createExecFileError("Failed to connect to user scope bus", {
-          stderr:
-            "Failed to connect to user scope bus via local transport: $DBUS_SESSION_BUS_ADDRESS and $XDG_RUNTIME_DIR not defined",
-        });
-        cb(err, "", "");
-      })
-      .mockImplementationOnce(systemctlMachineUserSuccess("debian", "status"))
-      .mockImplementationOnce((_cmd, args, _opts, cb) => {
-        assertUserSystemctlArgs(args, "reset-failed", GATEWAY_SERVICE);
-        const err = createExecFileError("Failed to connect to user scope bus", {
-          stderr: "Failed to connect to user scope bus",
-        });
-        cb(err, "", "");
-      })
-      .mockImplementationOnce(
-        systemctlMachineUserSuccess("debian", "reset-failed", GATEWAY_SERVICE),
-      )
-      .mockImplementationOnce((_cmd, args, _opts, cb) => {
-        assertUserSystemctlArgs(args, "restart", GATEWAY_SERVICE);
-        const err = createExecFileError("Failed to connect to user scope bus", {
-          stderr: "Failed to connect to user scope bus",
-        });
-        cb(err, "", "");
-      })
-      .mockImplementationOnce((_cmd, args, _opts, cb) => {
-        assertMachineRestartArgs(args);
-        cb(null, "", "");
-      });
-    await assertRestartSuccess({ USER: "debian" });
+    await assertRestartSuccess(mockMachineManager("debian"));
+    expect(
+      execFileMock.mock.calls.map(([, args]) => (args.includes("Version") ? "Version" : args[3])),
+    ).toEqual(["Version", "Version", "status", "reset-failed", "restart"]);
   });
 });
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -1,9 +1,9 @@
+export { resolveSystemdUserServiceAccount } from "./systemd-user-transport.js";
 /** Linux systemd user service installer, parser, and lifecycle controls. */
 export {
   isNonFatalSystemdInstallProbeError,
   isSystemdUnitActive,
   isSystemdUserServiceAvailable,
-  resolveSystemdUserServiceAccount,
   type SystemdUnitScope,
 } from "./systemd-exec.js";
 export {

--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -8337,13 +8337,17 @@ done
     });
     const { readSystemdServiceExecStart } =
       await import("../../src/daemon/systemd-service-files.js");
+    const loadedEnv = {
+      HOME: home,
+      PATH: `${binDir}:${process.env.PATH}`,
+      OPENCLAW_SYSTEMD_UNIT: serviceName,
+      XDG_RUNTIME_DIR: join(home, "runtime"),
+      DBUS_SESSION_BUS_ADDRESS: `unix:path=${join(home, "runtime", "bus")}`,
+    };
     expect(
       // The production 5s deadline budgets for native busctl; the Node shim's cold
       // spawn can exceed its per-call slice under load, so widen it here.
-      await readSystemdServiceExecStart(
-        { HOME: home, PATH: `${binDir}:${process.env.PATH}`, OPENCLAW_SYSTEMD_UNIT: serviceName },
-        { requireEffective: true, timeoutMs: 30_000 },
-      ),
+      await readSystemdServiceExecStart(loadedEnv, { requireEffective: true, timeoutMs: 30_000 }),
     ).toMatchObject({
       programArguments,
       workingDirectory: "/opt/openclaw git",
@@ -8353,13 +8357,6 @@ done
     });
 
     const definition = readFileSync(unitPath, "utf8");
-    const loadedEnv = {
-      HOME: home,
-      PATH: `${binDir}:${process.env.PATH}`,
-      OPENCLAW_SYSTEMD_UNIT: serviceName,
-      XDG_RUNTIME_DIR: join(home, "runtime"),
-      DBUS_SESSION_BUS_ADDRESS: `unix:path=${join(home, "runtime", "bus")}`,
-    };
     const loadedCommand = await readSystemdServiceExecStart(loadedEnv, {
       requireEffective: true,
       requireLoaded: true,
@@ -8464,6 +8461,8 @@ done
       HOME: home,
       PATH: `${binDir}:${process.env.PATH}`,
       OPENCLAW_SYSTEMD_UNIT: "openclaw-gateway-fixture",
+      XDG_RUNTIME_DIR: join(home, "runtime"),
+      DBUS_SESSION_BUS_ADDRESS: `unix:path=${join(home, "runtime", "bus")}`,
     };
     const { readSystemdServiceExecStart } =
       await import("../../src/daemon/systemd-service-files.js");
@@ -8483,6 +8482,17 @@ done
     ];
     const invoke = (args: string[]) =>
       spawnSync(join(binDir, "busctl"), args, { env, encoding: "utf8" });
+    const managerVersion = invoke([
+      "--user",
+      "--auto-start=no",
+      "get-property",
+      "org.freedesktop.systemd1",
+      "/org/freedesktop/systemd1",
+      "org.freedesktop.systemd1.Manager",
+      "Version",
+    ]);
+    expect(managerVersion.status, managerVersion.stderr).toBe(0);
+    expect(managerVersion.stdout.trim()).toBe('s "252.39-1~deb12u2"');
     const missing = invoke(loadArgs);
     expect(missing.status).toBe(1);
     expect(missing.stderr.trim()).toBe(`Call failed: Unit ${serviceName} not found.`);

--- a/test/scripts/upgrade-survivor-systemd.test.ts
+++ b/test/scripts/upgrade-survivor-systemd.test.ts
@@ -26,6 +26,8 @@ function fixture(customPaths = true, registry?: string, managerSetup = "") {
   };
   const env: NodeJS.ProcessEnv = {
     HOME: home,
+    XDG_RUNTIME_DIR: join(home, "runtime"),
+    DBUS_SESSION_BUS_ADDRESS: `unix:path=${join(home, "runtime", "bus")}`,
     PATH: `${home}/bin:${process.env.PATH}`,
     npm_config_prefix: home,
     NPM_CONFIG_REGISTRY: registry,
@@ -95,6 +97,21 @@ setInterval(() => {}, 1000);
 
   it("distinguishes confirmed absence from unsupported inspection and reads the generated service", async () => {
     const { home, env, systemctl, unit, paths } = fixture();
+    const managerVersion = spawnSync(
+      join(home, "bin/busctl"),
+      [
+        "--user",
+        "--auto-start=no",
+        "get-property",
+        "org.freedesktop.systemd1",
+        "/org/freedesktop/systemd1",
+        "org.freedesktop.systemd1.Manager",
+        "Version",
+      ],
+      { env, encoding: "utf8" },
+    );
+    expect(managerVersion.status, managerVersion.stderr).toBe(0);
+    expect(managerVersion.stdout.trim()).toBe('s "252.39-1~deb12u2"');
     // First install must reach the same effective reader used by the guarded writer.
     expect(await readLoadedSystemdServiceRuntime(env)).toMatchObject({ status: "unknown" });
     expect(existsSync(`${unit}.loaded-unit`)).toBe(false);

--- a/test/scripts/upgrade-survivor-systemd.test.ts
+++ b/test/scripts/upgrade-survivor-systemd.test.ts
@@ -2,7 +2,7 @@ import { spawnSync } from "node:child_process";
 import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { readLoadedSystemdServiceRuntime } from "../../src/daemon/systemd-loaded-runtime.js";
 import { readSystemdServiceRuntime } from "../../src/daemon/systemd-runtime.js";
 import {
@@ -26,8 +26,6 @@ function fixture(customPaths = true, registry?: string, managerSetup = "") {
   };
   const env: NodeJS.ProcessEnv = {
     HOME: home,
-    XDG_RUNTIME_DIR: join(home, "runtime"),
-    DBUS_SESSION_BUS_ADDRESS: `unix:path=${join(home, "runtime", "bus")}`,
     PATH: `${home}/bin:${process.env.PATH}`,
     npm_config_prefix: home,
     NPM_CONFIG_REGISTRY: registry,
@@ -48,8 +46,13 @@ function fixture(customPaths = true, registry?: string, managerSetup = "") {
         timeout: 40_000,
       },
     );
-  const installed = shell(`${managerSetup}\ninstall_update_restart_systemctl_shim`);
+  const installed = shell(
+    `${managerSetup}\ninstall_update_restart_systemctl_shim\nprintf '%s\\n' "\${XDG_RUNTIME_DIR:-}" "\${DBUS_SESSION_BUS_ADDRESS:-}"`,
+  );
   expect(installed.status, installed.stderr).toBe(0);
+  const [runtimeDir, busAddress] = installed.stdout.trimEnd().split("\n");
+  env.XDG_RUNTIME_DIR = runtimeDir || undefined;
+  env.DBUS_SESSION_BUS_ADDRESS = busAddress || undefined;
   const systemctl = (...args: string[]) =>
     spawnSync(join(home, "bin/systemctl"), ["--user", ...args], {
       env,
@@ -62,6 +65,28 @@ function fixture(customPaths = true, registry?: string, managerSetup = "") {
 }
 
 describe.skipIf(process.platform === "win32")("survivor manager fixture", () => {
+  it("publishes its manager route for a root session without bus variables", async () => {
+    const platform = vi.spyOn(process, "platform", "get").mockReturnValue("linux");
+    const uid = vi.spyOn(process, "geteuid").mockReturnValue(0);
+    try {
+      const { home, env } = fixture();
+      expect(await readSystemdServiceRuntime(env)).toMatchObject({
+        status: "stopped",
+        missingUnit: true,
+        systemd: {
+          transport: {
+            kind: "session-bus",
+            address: `unix:path=${join(home, "bin/runtime/bus")}`,
+            runtimeDir: join(home, "bin/runtime"),
+          },
+        },
+      });
+    } finally {
+      uid.mockRestore();
+      platform.mockRestore();
+    }
+  });
+
   it("keeps self-upgrade target channels enabled despite historical source suppression", async () => {
     const lane = readFileSync(
       resolve("scripts/e2e/lib/upgrade-survivor/update-run-package-self-upgrade.sh"),
@@ -252,7 +277,7 @@ setInterval(() => {}, 1000);
     writeFileSync(
       program,
       `import fs from "node:fs";
-fs.appendFileSync(${JSON.stringify(record)}, JSON.stringify({pid:process.pid, argv:process.argv.slice(2), cwd:process.cwd(), value:process.env.FIXTURE_VALUE, state:process.env.OPENCLAW_STATE_DIR, update:process.env.OPENCLAW_UPDATE_IN_PROGRESS, npmRegistry:process.env.NPM_CONFIG_REGISTRY, npmLowerRegistry:process.env.npm_config_registry, bunRegistry:process.env.BUN_CONFIG_REGISTRY, skipChannels:process.env.OPENCLAW_SKIP_CHANNELS, skipProviders:process.env.OPENCLAW_SKIP_PROVIDERS, disableBonjour:process.env.OPENCLAW_DISABLE_BONJOUR}) + "\\n");
+fs.appendFileSync(${JSON.stringify(record)}, JSON.stringify({pid:process.pid, argv:process.argv.slice(2), cwd:process.cwd(), value:process.env.FIXTURE_VALUE, state:process.env.OPENCLAW_STATE_DIR, update:process.env.OPENCLAW_UPDATE_IN_PROGRESS, npmRegistry:process.env.NPM_CONFIG_REGISTRY, npmLowerRegistry:process.env.npm_config_registry, bunRegistry:process.env.BUN_CONFIG_REGISTRY, skipChannels:process.env.OPENCLAW_SKIP_CHANNELS, skipProviders:process.env.OPENCLAW_SKIP_PROVIDERS, disableBonjour:process.env.OPENCLAW_DISABLE_BONJOUR, runtimeDir:process.env.XDG_RUNTIME_DIR, busAddress:process.env.DBUS_SESSION_BUS_ADDRESS}) + "\\n");
 process.on("SIGTERM", () => process.exit(0));
 setInterval(() => {}, 1000);
 `,
@@ -317,7 +342,12 @@ raise SystemExit(code if code >= 0 else 128 - code)
           record,
         ],
         {
-          env: { ...env, OPENCLAW_UPDATE_IN_PROGRESS: "1" },
+          env: {
+            ...env,
+            OPENCLAW_UPDATE_IN_PROGRESS: "1",
+            XDG_RUNTIME_DIR: undefined,
+            DBUS_SESSION_BUS_ADDRESS: "unix:path=/fixture/stale-bus",
+          },
           encoding: "utf8",
           timeout: 40_000,
         },
@@ -343,6 +373,8 @@ raise SystemExit(code if code >= 0 else 128 - code)
         skipChannels: "1",
         skipProviders: "1",
         disableBonjour: "1",
+        runtimeDir: env.XDG_RUNTIME_DIR,
+        busAddress: env.DBUS_SESSION_BUS_ADDRESS,
       });
       const previousPid = readFileSync(paths.pid, "utf8").trim();
       expect(await readSystemdServiceRuntime(env)).toMatchObject({
@@ -369,6 +401,8 @@ raise SystemExit(code if code >= 0 else 128 - code)
         skipChannels: "1",
         skipProviders: "1",
         disableBonjour: "1",
+        runtimeDir: env.XDG_RUNTIME_DIR,
+        busAddress: env.DBUS_SESSION_BUS_ADDRESS,
       });
       const proof = assertion();
       expect(proof.status, proof.stderr).toBe(0);

--- a/test/test-env.test.ts
+++ b/test/test-env.test.ts
@@ -84,6 +84,17 @@ afterEach(() => {
 });
 
 describe("installTestEnv", () => {
+  it("isolates native manager sockets and restores the caller runtime directory", () => {
+    const callerRuntime = path.join(createTempHome(), "runtime");
+    withEnv({ XDG_RUNTIME_DIR: callerRuntime }, () => {
+      const testEnv = installTestEnv({ mode: "hermetic" });
+      cleanupFns.push(testEnv.cleanup);
+      expect(process.env.XDG_RUNTIME_DIR).toBe(path.join(testEnv.tempHome, ".runtime"));
+      testEnv.cleanup();
+      expect(process.env.XDG_RUNTIME_DIR).toBe(callerRuntime);
+    });
+  });
+
   it.each([".openclaw", ".claude"])(
     "rolls back live staging failure at %s before another installation",
     (failedDirectory) => {

--- a/test/test-env.ts
+++ b/test/test-env.ts
@@ -218,6 +218,7 @@ function resolveRestoreEntries(): RestoreEntry[] {
     { key: "XDG_DATA_HOME", value: process.env.XDG_DATA_HOME },
     { key: "XDG_STATE_HOME", value: process.env.XDG_STATE_HOME },
     { key: "XDG_CACHE_HOME", value: process.env.XDG_CACHE_HOME },
+    { key: "XDG_RUNTIME_DIR", value: process.env.XDG_RUNTIME_DIR },
     { key: "COREPACK_HOME", value: process.env.COREPACK_HOME },
     { key: "OPENCLAW_STATE_DIR", value: process.env.OPENCLAW_STATE_DIR },
     { key: "OPENCLAW_CONFIG_PATH", value: process.env.OPENCLAW_CONFIG_PATH },
@@ -283,6 +284,7 @@ function initializeIsolatedTestEnv(tempHome: string): void {
   setTestEnvValue("XDG_DATA_HOME", path.join(tempHome, ".local", "share"));
   setTestEnvValue("XDG_STATE_HOME", path.join(tempHome, ".local", "state"));
   setTestEnvValue("XDG_CACHE_HOME", path.join(tempHome, ".cache"));
+  setTestEnvValue("XDG_RUNTIME_DIR", path.join(tempHome, ".runtime"));
 }
 
 function ensureParentDir(targetPath: string): void {


### PR DESCRIPTION
## What Problem This Solves

Fresh Linux Gateway installs can report `SERVICE_DEFINITION_UNKNOWN` when the shell carries a stale session-bus address, even though status reaches the running user manager. Replacing every explicit address with the runtime bus also breaks updates for a working custom bus when an unrelated runtime socket exists.

## User Impact

Gateway installation works with healthy, stale, or missing shell bus settings when the user manager is reachable. Working custom buses remain usable for installation and update admission. Install and status share the service inspection verdict; unavailable managers receive actionable session-repair guidance, while unreadable or foreign definitions identify the affected file.

## Why This Change Was Made

One transport owner probes `Manager.Version` without activation, preserving a working explicit address before trying the runtime bus and private socket. Existing machine/sudo routing remains at that owner. Child commands, effective-command inspection, and update admission consume the selected route; deep status exposes it. A socket's existence does not establish that another address is stale.

The owner records whether an earlier probe timed out. Later admission rechecks that unresolved preference within its own remaining deadline, including when it joined another caller's short discovery. Ordinary commands reuse the positive route. Native locality checks apply to the selected transport, and admitted peer connections retain their unique-owner, UID/PID/start-time, deadline, and authority checks.

The filesystem override, per-caller private-first decision, and duplicate command-time machine fallback were removed. Payload bus/account variables cannot redirect supervisor inspection. Private-socket reopen failures and discovery deadlines retain manager diagnostics. Existing publication backups and rollback remain unchanged; no configuration options, dependencies, protocol changes, or storage migrations were added.

Refs #146022, #145023. Reported in Discord support; no contributor code adopted.

## Evidence

The Debian 12 rig uses systemd `252.39-1~deb12u2`, a synthetic non-root account, and the built `dist/entry.js` from `/tmp`. The custom variant runs the manager on `/tmp/dbus-custom` with an unrelated broker at the runtime bus path.

```text
Before round three, built head 25e675a6d79:
  healthy:     install succeeds; runtime running; RPC true
  stale:       install succeeds; runtime running; RPC true
  private-only: install succeeds; runtime running; RPC true
  unavailable: actionable manager diagnosis
  custom bus:  Manager.Version succeeds; install/status succeed
               update admission fails
  Move only the unrelated runtime socket aside: admission succeeds
  Restore it: admission fails again

After, built head baca81d53f86297e917cebaf2b0032fca807db42:
  healthy:      install 0; running; RPC true; runtime-bus
  stale:        install 0; running; RPC true; runtime-bus
  private-only: install 0; running; RPC true; private socket
  custom:       install 0; running; RPC true; custom session-bus
  unavailable:  install 1; actionable diagnosis; no definition error
  custom update admission: loaded; command present; running;
                           selected unix:path=/tmp/dbus-custom
```

Regression tests failed before their fixes for custom-bus admission, private-socket reopen, payload route drift, timeout-dependent fallback, and nonlocal-to-local fallback. The tests preserve successful discovery sharing, per-caller deadlines, custody retirement, and both positive-fallback and wholly failed short-discovery cases. No stash was used.

The 17 initial daemon failures were outdated fixture boundaries: service absence (4), definition mutation (7), private command-query cleanup (2), availability routing (3), and child environment routing (1). Fixtures now answer the exact nonactivating Version probe while retaining unit ownership, mount, absence, cleanup, and environment-isolation assertions. No baselines, suppressions, or assertions were weakened.

Focused commands:

```sh
node scripts/run-vitest.mjs src/daemon/systemd.test.ts src/daemon/systemd-command-query.test.ts src/daemon/systemd-peer.test.ts src/daemon/systemd-peer-native.test.ts src/daemon/systemd-user-transport.test.ts src/daemon/service-process-env.integration.test.ts src/daemon/systemd-unavailable.test.ts src/daemon/service-absence.test.ts src/daemon/systemd-definition-mutation.test.ts src/daemon/systemd-user-command-deadline.test.ts src/daemon/systemd-loaded-runtime.test.ts src/daemon/service.test.ts src/daemon/service-operation-lock.test.ts src/daemon/service-env.test.ts
node scripts/run-vitest.mjs src/commands/doctor-maintenance.service-inspection.test.ts src/cli/daemon-cli/install.test.ts src/cli/daemon-cli/install.integration.test.ts src/cli/daemon-cli/install.reinstall.test.ts
node scripts/check-changed.mjs
node scripts/check-changed.mjs -- src/daemon/systemd-user-transport.ts src/daemon/systemd-user-transport.test.ts
pnpm build
```

The custom update proof invokes built `readGatewayServiceState` with effective, loaded-only admission; it does not mutate packages. A full published-driver update and native macOS/Windows execution were not rerun. Bound update and launchd diagnostic suites passed.


Validation passed: 759 focused tests across the suites and final regression runs; the full changed-file check and final delta check; `pnpm build` on the committed head; all five Debian rig variants. Autoreview was scoped clean with no accepted P0–P2 findings. The final cache regression was run with its fix hunk removed: it failed because admission retained `private` instead of selecting the working `session-bus`; after restoring the exact reviewed bytes, all 12 transport tests passed.

Final round-three numstat: production +370/-210, tests/support +955/-222, docs +7/-3. The initial consolidation removed duplicated routing decisions: production changed from +278/-136 (net +142) to +321/-200 (net +121); subsequent deadline, custody, diagnostic, and route-consistency fixes account for the final +160. No baseline or lint exception was added.

The first round-three CI run exposed an import cycle and stale synthetic-manager fixtures. The follow-up moves the transport type to the runtime contract, probes executable availability with raw `systemctl --version`, and updates Doctor/update/shim fixtures to answer the exact nonactivating Version read. Cleanup still attempts disable before deleting a potentially loaded unit; timeout tests retain the original deadline. A separate macOS fixture correction accepts the exact stable Homebrew Node executable used by post-update Doctor and still executes the real synthetic CLI.

Follow-up validation at `603e11cdc4a4f6968670810f5c32b3fd0a87a3e6`:

- `node scripts/run-vitest.mjs src/daemon/systemd-unavailable.test.ts src/daemon/systemd.test.ts`: 260 passed.
- `pnpm check:architecture`: passed, including both import-cycle checks.
- Replayed the files selected by failed CI jobs compact-small-6, -9, -16, -19, and -28 with `node scripts/run-vitest.mjs`. Selections 16, 19, and 28 passed (275, 351, and 378 tests respectively). All repaired daemon/Doctor/update/shim fixtures passed.
- Selection 6 exposed the stable-Node fixture mismatch above. Before correction: 1 failed / 5 passed, with `Unexpected candidate command: <stable-node> <fixture>/openclaw.mjs doctor --non-interactive --fix`. After correction: all six candidate-admission cases passed. The final 101-file run also passed every file that the earlier wrapper stopped before reaching.
- One unchanged macOS backup case, `backup-create.sqlite-hardlinks.test.ts` → canonical-bound hardlink alias replacement, hit its existing 120-second timeout both in selection 9 and a focused replay in original order. Neighboring snapshot tests were also slow; no daemon transport code is on this path. The same case passed in 306 ms in the previous Linux CI run. No timeout, assertion, skip, or backup code was changed; this remains a local validation gap.
- `node scripts/check-changed.mjs`: passed in full, including all three typecheck lanes, lint, and guards.
- Fresh independent P1 autoreview: scoped clean, no accepted P0/P1 findings.

The build and five Debian variants above were run on `baca81d53f86297e917cebaf2b0032fca807db42`; they were not repeated for this CI-fixture/type-location/executable-probe follow-up. The rig containers and image have been removed after proof.

The next CI run exposed two Linux-only status expectations that omitted the recorded transport, plus a survivor installer gap: its tests supplied bus variables but the actual installer did not. Linux status tests now exercise the real platform branch and assert that transport. The synthetic installer owns its exported bus selectors and captures them for restarted children, including when a systemctl caller clears the runtime directory or supplies a stale address. The fixture's strict request grammar and production transport rules are unchanged.

Before these corrections: the runtime file failed 2/243 tests, and the new root-session survivor route case failed with unavailable-manager status. After: all 249 tests in `src/daemon/systemd.test.ts` and `test/scripts/upgrade-survivor-systemd.test.ts` passed. The changed-file gate for those files and the shim installer passed, and fresh P1 review was scoped clean.

Run [34747169363](https://github.com/openclaw/openclaw/actions/runs/34747169363) completed with 114 successful jobs, 14 skipped, and four failures: the two corrected fixture areas, the aggregate gate, and inherited `agents-other: 702 test roots exceeds the 700 limit`. The exact TypeScript config yields 691 roots on this branch and 702 on published main `d7111df636966c29e339c1ea4256e0a728e03150`; this PR changes no agent test roots or shard settings. The local backup timeout passed on Linux in this run.

Prior candidate: `648953561baef9899c332c2e294394903d6c688e`. Run [34748190958](https://github.com/openclaw/openclaw/actions/runs/34748190958) first completed with 116 successful jobs, 14 skipped, and two failures: `checks-node-compact-small-10` never acquired a runner (`runner_id: 0`, zero steps), and the aggregate gate inherited that failure. All six originally failing selections, Docker upgrade-survivor, and Windows passed; the prior main-side shard overflow was absent from this run. Job-specific and failed-jobs rerun requests initially returned HTTP 500 without creating an attempt. After disk headroom recovered, GitHub accepted one full workflow rerun on the unchanged head, and the previously unexecuted small-10 job passed.

That rerun exposed three more definition fixtures missing the transport owner's Version response. The nine failing cases now reuse the strict shared probe fixture and isolated bus settings. Original wall-clock budgets, loaded-only/no-activation checks, and directory-mode assertions remain unchanged. `node scripts/run-vitest.mjs src/daemon/systemd-deadline-clock-step.test.ts src/daemon/systemd-definition-mutation.creation.test.ts src/daemon/systemd-definition-loaded.test.ts` passes all nine cases; their changed-file gate and fresh P1 review pass.

The rerun also hit an unrelated settings-storage fixture timing failure in [large-6](https://github.com/openclaw/openclaw/actions/runs/34748190958/job/103718395191): the two concurrent-first-write cases exceeded a five-second contender-readiness/ten-second child budget before their combined-data assertion. Both cases passed on the [first attempt of the same head](https://github.com/openclaw/openclaw/actions/runs/34748190958/job/103699969581) (4.833s and 5.575s). The test and storage implementation match CI's main parent byte-for-byte and have no daemon transport dependency. No assertion, timeout, or storage behavior was changed to hide this result.

Final candidate: `012ea719b454c46812d8c0ffdaa1a81367eafe9f`. [Exact-head CI run 34756359850](https://github.com/openclaw/openclaw/actions/runs/34756359850) is terminal: 114 successful jobs, 14 skipped, four failures. All six originally failing selections, the repaired nine-case daemon fixture set, architecture, Docker upgrade-survivor, and Windows passed. There are no cancelled or pending jobs.

Remaining failures are outside this diff:

- `check-test-types-core-2` and `checks-node-compact-small-1`: the new main-only `session-accessor.sqlite-reclamation-memory.test.ts` from [#146760](https://github.com/openclaw/openclaw/pull/146760). It is absent from this branch. CI main parent `f43083ea5c8bf5f13c90788df82ae7fadafa0a71` already contains the un-narrowed `onCommitRequest` union access (lines 44/50) and the runtime failure expecting a fulfilled write but receiving an empty outcome list (line 164).
- `checks-fast-baseline-ratchets`: checkout failed after the workflow's existing five attempts, before checks ran.
- `openclaw/ci-gate`: aggregate failure from those jobs.
- Separate `actionlint` workflow: trusted-base fetch timed out before lint ran ([job](https://github.com/openclaw/openclaw/actions/runs/34756359688/job/103721281126)).

All PR checks are terminal: 135 passed, 41 skipped, five failed. No baseline, assertion, timeout, or storage behavior was relaxed to conceal these outcomes. The earlier settings-storage timing failure passed on this final head. Local disk headroom recovered after the required 155-minute read-only wait; all completed work had already been committed and pushed.

<details>
<summary>Final check inventory for the exact head</summary>

| Check | Result |
| --- | --- |
| [CodeQL](https://github.com/openclaw/openclaw/runs/103721486289) | neutral |
| [Critical Quality (agent-runtime-boundary)](https://github.com/openclaw/openclaw/actions/runs/34756359736/job/103721298008) | skipped |
| [Critical Quality (channel-runtime-boundary)](https://github.com/openclaw/openclaw/actions/runs/34756359736/job/103721297714) | skipped |
| [Critical Quality (config-boundary)](https://github.com/openclaw/openclaw/actions/runs/34756359736/job/103721297938) | skipped |
| [Critical Quality (core-auth-secrets)](https://github.com/openclaw/openclaw/actions/runs/34756359736/job/103721297952) | skipped |
| [Critical Quality (gateway-runtime-boundary)](https://github.com/openclaw/openclaw/actions/runs/34756359736/job/103721297778) | skipped |
| [Critical Quality (mcp-process-runtime-boundary)](https://github.com/openclaw/openclaw/actions/runs/34756359736/job/103721297759) | skipped |
| [Critical Quality (memory-runtime-boundary)](https://github.com/openclaw/openclaw/actions/runs/34756359736/job/103721297776) | skipped |
| [Critical Quality (network-runtime-boundary)](https://github.com/openclaw/openclaw/actions/runs/34756359736/job/103721297672) | skipped |
| [Critical Quality (plugin-boundary)](https://github.com/openclaw/openclaw/actions/runs/34756359736/job/103721297855) | skipped |
| [Critical Quality (plugin-sdk-package-contract)](https://github.com/openclaw/openclaw/actions/runs/34756359736/job/103721298011) | skipped |
| [Critical Quality (plugin-sdk-reply-runtime)](https://github.com/openclaw/openclaw/actions/runs/34756359736/job/103721297657) | skipped |
| [Critical Quality (provider-runtime-boundary)](https://github.com/openclaw/openclaw/actions/runs/34756359736/job/103721297863) | skipped |
| [Critical Quality (session-diagnostics-boundary)](https://github.com/openclaw/openclaw/actions/runs/34756359736/job/103721297852) | skipped |
| [Critical Quality (ui-control-plane)](https://github.com/openclaw/openclaw/actions/runs/34756359736/job/103721281765) | skipped |
| [Critical Quality (web-media-runtime-boundary)](https://github.com/openclaw/openclaw/actions/runs/34756359736/job/103721281625) | skipped |
| [Detect iOS scan scope](https://github.com/openclaw/openclaw/actions/runs/34756359734/job/103721281098) | success |
| [Detect macOS scan scope](https://github.com/openclaw/openclaw/actions/runs/34756359841/job/103721281551) | success |
| [Detect shared OpenClawKit scan scope](https://github.com/openclaw/openclaw/actions/runs/34756359858/job/103721281547) | success |
| [Intersect shared OpenClawKit dead code](https://github.com/openclaw/openclaw/actions/runs/34756359858/job/103721521265) | skipped |
| [Opengrep OSS](https://github.com/openclaw/openclaw/runs/103721449920) | success |
| [PR context and evidence](https://github.com/openclaw/openclaw/actions/runs/34756543397/job/103721770336) | success |
| [QA Smoke CI (${{ matrix.name }})](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721445477) | skipped |
| [Scan changed paths (precise)](https://github.com/openclaw/openclaw/actions/runs/34756359804/job/103721281348) | success |
| [Scan iOS dead code](https://github.com/openclaw/openclaw/actions/runs/34756359734/job/103721449304) | skipped |
| [Scan macOS dead code](https://github.com/openclaw/openclaw/actions/runs/34756359841/job/103721446662) | skipped |
| [Scan shared kit from iOS](https://github.com/openclaw/openclaw/actions/runs/34756359858/job/103721520818) | skipped |
| [Scan shared kit from macOS](https://github.com/openclaw/openclaw/actions/runs/34756359858/job/103721521062) | skipped |
| [Security High (actions)](https://github.com/openclaw/openclaw/actions/runs/34756359633/job/103721281019) | success |
| [Security High (channel-runtime-boundary)](https://github.com/openclaw/openclaw/actions/runs/34756359633/job/103721280907) | success |
| [Security High (core-auth-secrets)](https://github.com/openclaw/openclaw/actions/runs/34756359633/job/103721281041) | success |
| [Security High (mcp-process-tool-boundary)](https://github.com/openclaw/openclaw/actions/runs/34756359633/job/103721281122) | success |
| [Security High (network-ssrf-boundary)](https://github.com/openclaw/openclaw/actions/runs/34756359633/job/103721281107) | success |
| [Security High (plugin-trust-boundary)](https://github.com/openclaw/openclaw/actions/runs/34756359633/job/103721281068) | success |
| [Security High (process-exec-boundary)](https://github.com/openclaw/openclaw/actions/runs/34756359633/job/103721281135) | success |
| [Select Critical Quality shards](https://github.com/openclaw/openclaw/actions/runs/34756359736/job/103721281143) | success |
| [[code]smith](https://backend.blacksmith.sh/track/enable-autofix?expires=1791893413&installation_model_id=10923&pr_number=146569&repository=openclaw%2Fopenclaw&return_to=https%3A%2F%2Fgithub.com%2Fopenclaw%2Fopenclaw%2Fpull%2F146569&utm_campaign=openclaw%2Fopenclaw&utm_source=codesmith-check&signature=e2a4cc8630f95e580a913849897d3d2217da89eba29a85c60421dcb88f0c645a) | skipped |
| [actionlint](https://github.com/openclaw/openclaw/actions/runs/34756359688/job/103721281126) | failure |
| [auto-response](https://github.com/openclaw/openclaw/actions/runs/34756543506/job/103721770874) | success |
| [backfill-pr-labels](https://github.com/openclaw/openclaw/actions/runs/34756543395/job/103721778564) | skipped |
| [build-artifacts](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721445076) | success |
| [check-additional-boundaries](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721445233) | success |
| [check-additional-extension-package-boundary](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721445202) | success |
| [check-additional-runtime-topology-architecture](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721445282) | success |
| [check-bundled-channel-config-metadata](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721445203) | success |
| [check-dependencies](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721445206) | success |
| [check-docs](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721445226) | success |
| [check-guards](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721445211) | success |
| [check-lint](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721445201) | success |
| [check-lint-core-1](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721445243) | success |
| [check-lint-core-2](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721445314) | success |
| [check-npm-lock](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721445185) | success |
| [check-prod-types](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721445135) | success |
| [check-prompt-snapshots](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721445246) | success |
| [check-source-contracts](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721445205) | success |
| [check-test-types](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721445223) | success |
| [check-test-types-core-1](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721445123) | success |
| [check-test-types-core-2](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721445111) | failure |
| [checks-fast-baseline-ratchets](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721445239) | failure |
| [checks-fast-bun-launcher](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721445209) | success |
| [checks-fast-bundled-protocol](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721445197) | success |
| [checks-fast-coercion-helpers](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721445307) | success |
| [checks-fast-contracts-channels](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721445132) | success |
| [checks-fast-contracts-plugins](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721445075) | success |
| [checks-node-changed-extensions-bundle-10](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721446316) | success |
| [checks-node-changed-extensions-bundle-11](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721446264) | success |
| [checks-node-changed-extensions-bundle-12](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721446399) | success |
| [checks-node-changed-extensions-bundle-13](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721446387) | success |
| [checks-node-changed-extensions-bundle-14](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721446386) | success |
| [checks-node-changed-extensions-bundle-15](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721446472) | success |
| [checks-node-changed-extensions-bundle-16](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721446446) | success |
| [checks-node-changed-extensions-bundle-17](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721446424) | success |
| [checks-node-changed-extensions-bundle-18](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721446409) | success |
| [checks-node-changed-extensions-bundle-19](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721446307) | success |
| [checks-node-changed-extensions-bundle-20](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721446411) | success |
| [checks-node-changed-extensions-bundle-22](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721446345) | success |
| [checks-node-changed-extensions-bundle-26](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721446315) | success |
| [checks-node-changed-extensions-bundle-27](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721446349) | success |
| [checks-node-changed-extensions-bundle-28](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721446375) | success |
| [checks-node-changed-extensions-bundle-29](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721446334) | success |
| [checks-node-changed-extensions-bundle-30](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721446320) | success |
| [checks-node-changed-extensions-bundle-31](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721446353) | success |
| [checks-node-changed-extensions-bundle-32](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721446365) | success |
| [checks-node-changed-extensions-bundle-33](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721446342) | success |
| [checks-node-changed-extensions-bundle-34](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721446380) | success |
| [checks-node-changed-extensions-bundle-35](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721446398) | success |
| [checks-node-changed-extensions-bundle-37](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721446290) | success |
| [checks-node-changed-extensions-bundle-38](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721446362) | success |
| [checks-node-changed-extensions-bundle-7](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721446323) | success |
| [checks-node-changed-extensions-bundle-8](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721446310) | success |
| [checks-node-changed-extensions-bundle-9](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721446288) | success |
| [checks-node-changed-extensions-config-1](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721446462) | success |
| [checks-node-changed-extensions-config-2](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721446385) | success |
| [checks-node-changed-extensions-config-3](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721446390) | success |
| [checks-node-changed-extensions-config-4](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721446370) | success |
| [checks-node-changed-extensions-config-5](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721446461) | success |
| [checks-node-changed-extensions-config-50](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721446274) | success |
| [checks-node-changed-extensions-config-53](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721446338) | success |
| [checks-node-changed-extensions-config-54](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721446343) | success |
| [checks-node-changed-extensions-config-55](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721446347) | success |
| [checks-node-changed-extensions-config-6](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721446388) | success |
| [checks-node-changed-extensions-config-78](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721446455) | success |
| [checks-node-compact-large-1](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721446246) | success |
| [checks-node-compact-large-10](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721446254) | success |
| [checks-node-compact-large-11](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721446313) | success |
| [checks-node-compact-large-12](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721446419) | success |
| [checks-node-compact-large-13](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721446382) | success |
| [checks-node-compact-large-14](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721447706) | success |
| [checks-node-compact-large-2](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721446261) | success |
| [checks-node-compact-large-3](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721446286) | success |
| [checks-node-compact-large-4](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721446332) | success |
| [checks-node-compact-large-5](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721446311) | success |
| [checks-node-compact-large-6](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721446260) | success |
| [checks-node-compact-large-7](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721446234) | success |
| [checks-node-compact-large-8](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721446263) | success |
| [checks-node-compact-large-9](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721446352) | success |
| [checks-node-compact-small-1](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721446244) | failure |
| [checks-node-compact-small-10](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721447697) | success |
| [checks-node-compact-small-11](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721446437) | success |
| [checks-node-compact-small-12](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721446427) | success |
| [checks-node-compact-small-13](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721447637) | success |
| [checks-node-compact-small-14](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721447623) | success |
| [checks-node-compact-small-15](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721447662) | success |
| [checks-node-compact-small-16](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721447636) | success |
| [checks-node-compact-small-17](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721447618) | success |
| [checks-node-compact-small-18](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721446402) | success |
| [checks-node-compact-small-19](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721447653) | success |
| [checks-node-compact-small-2](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721446253) | success |
| [checks-node-compact-small-20](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721447668) | success |
| [checks-node-compact-small-21](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721447693) | success |
| [checks-node-compact-small-22](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721446414) | success |
| [checks-node-compact-small-23](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721447900) | success |
| [checks-node-compact-small-24](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721447661) | success |
| [checks-node-compact-small-25](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721447669) | success |
| [checks-node-compact-small-26](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721447672) | success |
| [checks-node-compact-small-27](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721447723) | success |
| [checks-node-compact-small-28](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721447678) | success |
| [checks-node-compact-small-29](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721447666) | success |
| [checks-node-compact-small-3](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721446245) | success |
| [checks-node-compact-small-30](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721447683) | success |
| [checks-node-compact-small-31](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721447639) | success |
| [checks-node-compact-small-32](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721447734) | success |
| [checks-node-compact-small-33](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721447620) | success |
| [checks-node-compact-small-34](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721447714) | success |
| [checks-node-compact-small-4](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721446357) | success |
| [checks-node-compact-small-5](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721446256) | success |
| [checks-node-compact-small-6](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721446249) | success |
| [checks-node-compact-small-7](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721446252) | success |
| [checks-node-compact-small-8](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721446257) | success |
| [checks-node-compact-small-9](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721446279) | success |
| [checks-node-compat-node24](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721445647) | skipped |
| [checks-ui-e2e (${{ matrix.shard }}/${{ matrix.shard_count }})](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721445734) | skipped |
| [checks-ui-e2e-real-gateway](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721445421) | skipped |
| [checks-windows-node-test-1](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721445129) | success |
| [checks-windows-node-test-2](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721445241) | success |
| [control-ui-i18n](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721445500) | skipped |
| [control-ui-performance](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721445074) | success |
| [dependency-guard](https://github.com/openclaw/openclaw/actions/runs/34756356619/job/103721439731) | success |
| [dependency-guard-autoscrub](https://github.com/openclaw/openclaw/actions/runs/34756356619/job/103721440054) | skipped |
| [dependency-guard-detect](https://github.com/openclaw/openclaw/actions/runs/34756356619/job/103721274320) | success |
| [dispatch](https://github.com/openclaw/openclaw/actions/runs/34756543379/job/103721770214) | success |
| [docker-seed-e2e](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721445242) | success |
| [generated-doc-baselines](https://github.com/openclaw/openclaw/actions/runs/34756359688/job/103721281600) | skipped |
| [ios-build (${{ matrix.phase }})](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721445572) | skipped |
| [ios-screenshot-evidence](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721445908) | skipped |
| [ios-screenshots-${{ matrix.device_family }}](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721445502) | skipped |
| [label](https://github.com/openclaw/openclaw/actions/runs/34756543395/job/103721778754) | skipped |
| [label-issues](https://github.com/openclaw/openclaw/actions/runs/34756543395/job/103721778483) | skipped |
| [macos-swift (${{ matrix.phase }})](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721445569) | skipped |
| [matrix.check_name \|\| 'android'](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721445793) | skipped |
| [matrix.check_name \|\| 'macos-node'](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721445611) | skipped |
| [native-i18n](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721445664) | skipped |
| [needs.preflight.outputs.frozen_target == 'true' && 'checks-ui' \|\| format('checks-ui ({0}/3)', matrix.shard)](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721445436) | skipped |
| [no-tabs](https://github.com/openclaw/openclaw/actions/runs/34756359688/job/103721280989) | success |
| [openclaw/ci-gate](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103723319897) | failure |
| [pnpm-store-warmup](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721445097) | success |
| [preflight](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721315755) | success |
| [security-fast](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721315621) | success |
| [security-sensitive-guard](https://github.com/openclaw/openclaw/actions/runs/34756356817/job/103721343349) | success |
| [security-sensitive-guard-detect](https://github.com/openclaw/openclaw/actions/runs/34756356817/job/103721275752) | success |
| [skills-python](https://github.com/openclaw/openclaw/actions/runs/34756359850/job/103721445520) | skipped |

</details>


## ClawSweeper review

Skipped the P1 proposal to label typed manager failures as `SERVICE_DEFINITION_UNKNOWN`. The v2026.9.4 updater does choose ordinary restart for these diagnostics, but the candidate still rejects unknown manager state and independently requires effective-command inspection, writable definition capability, and a matching Gateway target before repair. Publication repeats those checks. Actual unreadable/sealed definition failures retain the shipped denial marker. Source review did not establish an unsafe rewrite from a manager-only failure; a published-driver fault-injection run for failure followed by recovery remains a proof gap. The Linux transport expectation finding was already addressed in this head. No code changed during landing review.

## Landing CI refresh

Fresh [CI run 34759398349](https://github.com/openclaw/openclaw/actions/runs/34759398349) completed successfully on approved head `012ea719b454c46812d8c0ffdaa1a81367eafe9f`. The native CI watcher returned `GREEN` with zero pending checks. Its preflight checkout log confirms merge `fe948e7724bdb2be507d48035ab023ecaa08105c`, with main `0a7b7fecfd7f7f525d53d3bc0656f0c12806ea03` as first parent and the approved head as second. This merge includes the main-side reclamation-memory harness correction `d4d3d6cda5d`; core-2 typechecking, compact-small-1, build, Docker proof, and Windows passed.

The first reopening event captured the previous merge commit despite the refreshed pull-request metadata. Its checkout log proved it had not tested the main correction. After confirming the recomputed merge through both GitHub's API and Git refs, a second close/reopen produced the successful run above. No source changes, empty commits, assertion retries, or gate bypasses were used.
