### PR TITLE
fix(doctor): avoid redundant cleanup after session imports

### DIFF
--- a/docs/cli/doctor/sqlite-maintenance.md
+++ b/docs/cli/doctor/sqlite-maintenance.md
@@ -110,8 +110,10 @@ Staging is removed when the operation finishes and is never used as a runtime
 store or resumed after an interruption; retries use the original sources and
 committed session data. After import, Doctor checkpoints and incrementally vacuums databases that already
 support auto-vacuum, retaining full integrity and foreign-key checks before and
-after cleanup. Databases without auto-vacuum still need a full `VACUUM` to enable
-it. Incremental cleanup frees unused pages but does not repack partially filled
+after cleanup. If a database is already in incremental auto-vacuum mode, has no
+free pages, and has no WAL to checkpoint, import finalization verifies it once
+and leaves its contents unchanged. Databases without auto-vacuum still need a
+full `VACUUM` to enable it. Incremental cleanup frees unused pages but does not repack partially filled
 pages; explicit session and shared-state `compact` modes still run a full `VACUUM`.
 
 The regular `openclaw doctor` pass also reports canonical SQLite transcripts

--- a/src/commands/doctor-sqlite-compact.test.ts
+++ b/src/commands/doctor-sqlite-compact.test.ts
@@ -1,0 +1,86 @@
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { openNodeSqliteDatabase } from "../infra/node-sqlite.js";
+import * as sqliteIntegrity from "../infra/sqlite-integrity.js";
+import { compactDoctorSqliteFile } from "./doctor-sqlite-compact.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+afterEach(() => vi.restoreAllMocks());
+
+function createCompactDatabase(): string {
+  const sqlitePath = path.join(tempDirs.make("doctor-compact-noop-"), "store.sqlite");
+  const database = openNodeSqliteDatabase(sqlitePath);
+  try {
+    database.exec(`
+      PRAGMA auto_vacuum = INCREMENTAL;
+      PRAGMA journal_mode = WAL;
+      CREATE TABLE payload (id INTEGER PRIMARY KEY, body TEXT);
+      INSERT INTO payload VALUES (1, 'preserved');
+    `);
+  } finally {
+    database.close();
+  }
+  return sqlitePath;
+}
+
+describe("import-finalize compaction", () => {
+  it("verifies an already compact store once without rewriting it", () => {
+    const sqlitePath = createCompactDatabase();
+    const before = fs.readFileSync(sqlitePath);
+    const integrity = vi.spyOn(sqliteIntegrity, "assertSqliteIntegrity");
+    const afterSuccess = vi.fn();
+
+    const result = compactDoctorSqliteFile({
+      sqlitePath,
+      operation: "import-finalize",
+      afterSuccess,
+    });
+
+    expect(result.before).toMatchObject({ autoVacuum: 2, freelistPages: 0, walSizeBytes: 0 });
+    expect(result.after).toEqual(result.before);
+    expect(result.integrityCheck).toBe("ok");
+    expect(result.reclaimedBytes).toBe(0);
+    // Each call scans the entire file: a no-op must not double that I/O budget.
+    expect(integrity).toHaveBeenCalledTimes(1);
+    expect(fs.readFileSync(sqlitePath)).toEqual(before);
+    expect(afterSuccess).toHaveBeenCalledOnce();
+  });
+
+  it("still rejects foreign-key corruption when there is nothing to compact", () => {
+    const sqlitePath = createCompactDatabase();
+    const database = openNodeSqliteDatabase(sqlitePath);
+    try {
+      database.exec(`PRAGMA foreign_keys = OFF;
+        CREATE TABLE child (parent_id INTEGER REFERENCES payload(id));
+        INSERT INTO child VALUES (99);`);
+    } finally {
+      database.close();
+    }
+    const afterSuccess = vi.fn();
+    expect(() =>
+      compactDoctorSqliteFile({ sqlitePath, operation: "import-finalize", afterSuccess }),
+    ).toThrow(/foreign_key_check failed/);
+    expect(afterSuccess).not.toHaveBeenCalled();
+  });
+
+  it("does not skip a busy WAL checkpoint on a store with no free pages", () => {
+    const sqlitePath = createCompactDatabase();
+    const reader = openNodeSqliteDatabase(sqlitePath);
+    const writer = openNodeSqliteDatabase(sqlitePath);
+    try {
+      reader.exec("BEGIN; SELECT * FROM payload;");
+      writer.exec("INSERT INTO payload VALUES (2, 'pending checkpoint');");
+      expect(writer.prepare("PRAGMA freelist_count").get()?.freelist_count).toBe(0);
+      expect(fs.statSync(`${sqlitePath}-wal`).size).toBeGreaterThan(0);
+      expect(() =>
+        compactDoctorSqliteFile({ sqlitePath, operation: "import-finalize", busyTimeoutMs: 0 }),
+      ).toThrow(/checkpoint remained busy/);
+    } finally {
+      reader.exec("ROLLBACK;");
+      reader.close();
+      writer.close();
+    }
+  });
+});

--- a/src/commands/doctor-sqlite-compact.ts
+++ b/src/commands/doctor-sqlite-compact.ts
@@ -48,18 +48,27 @@ export function compactDoctorSqliteFile(
     database.exec("PRAGMA trusted_schema = OFF;");
     options.validateBeforeMutation?.(database);
     const before = readCompactSnapshot(database, options.sqlitePath);
-    assertSqliteIntegrity(database, options.sqlitePath);
-    checkpointDoctorSqliteFile(database, options.sqlitePath);
-    database.exec("PRAGMA auto_vacuum = INCREMENTAL;");
-    // NONE databases need a full rewrite to add pointer maps. Existing auto-vacuum
-    // stores can release free pages without repacking; explicit compact still repacks.
-    database.exec(
-      options.operation === "import-finalize" && before.autoVacuum !== 0
-        ? "PRAGMA incremental_vacuum;"
-        : "VACUUM;",
-    );
-    checkpointDoctorSqliteFile(database, options.sqlitePath);
-    const { integrityCheck } = assertSqliteIntegrity(database, options.sqlitePath);
+    let { integrityCheck } = assertSqliteIntegrity(database, options.sqlitePath);
+    const alreadyCompact =
+      options.operation === "import-finalize" &&
+      before.autoVacuum === 2 &&
+      before.freelistPages === 0 &&
+      before.walSizeBytes === 0;
+    // A verified no-op needs neither a file mutation nor a second full-file scan.
+    // Explicit compaction still repacks partially filled pages.
+    if (!alreadyCompact) {
+      checkpointDoctorSqliteFile(database, options.sqlitePath);
+      database.exec("PRAGMA auto_vacuum = INCREMENTAL;");
+      // NONE databases need a full rewrite to add pointer maps. Existing auto-vacuum
+      // stores can release free pages without repacking; explicit compact still repacks.
+      database.exec(
+        options.operation === "import-finalize" && before.autoVacuum !== 0
+          ? "PRAGMA incremental_vacuum;"
+          : "VACUUM;",
+      );
+      checkpointDoctorSqliteFile(database, options.sqlitePath);
+      ({ integrityCheck } = assertSqliteIntegrity(database, options.sqlitePath));
+    }
     const after = readCompactSnapshot(database, options.sqlitePath);
     const beforeBytes = before.dbSizeBytes + before.walSizeBytes;
     const afterBytes = after.dbSizeBytes + after.walSizeBytes;


### PR DESCRIPTION
Related: #146512

## Summary

### High Level TLDR

Doctor now avoids a second full database scan when import finalization has no cleanup to perform. It still validates the database before accepting it.

## What Problem This Solves

Session imports repeat expensive compaction checks even when an incremental-vacuum database has no free pages and no WAL to checkpoint.

## User Impact

Eligible imports perform one full integrity/foreign-key check instead of two. Explicit compaction still repacks the database, and imports with pending cleanup retain the existing checkpoint, vacuum, and post-cleanup validation path.

## Why This Change Was Made

**Root Cause:** `compactDoctorSqliteFile` always entered the mutation-and-revalidation sequence after reading the database's compaction state. The import-finalization no-op case can retain its initial validation without changing the file. This is separate from the ordinary runtime-open verification reuse in #146512.

The change uses the existing `import-finalize` operation; installed update drivers need no new flag or result format. Ownership validation, connection cleanup, and success callbacks remain in their existing order.

## Evidence

### Data-model compatibility proof

**Upgrade compatibility is verified for this patch and its existing-state path.** Schema definitions, persisted representations, migration owners, updater markers, and result contracts are unchanged by this PR. The exact-head published-driver test below verified the upstream agent-schema migration from 19 to 20, unchanged shared-state schema 17, preserved sessions and cron ownership, healthy Gateway startup, clean Doctor, and an idempotent second update. The real-SQLite regression additionally verified byte-for-byte unchanged database contents for the eligible no-op path.

### Published updater × candidate compatibility — September 13, 2026

**Passed on exact head `94df065ae06870a876fe9b980db13fa47334d96b`.** The maintained `legacy-operator-state` upgrade-survivor scenario ran on a clean, public-network-only AWS Crabbox sandbox with no credential hydration. It installed published `openclaw@2026.9.4`, created its operator state before the update, and invoked that installed release's real `openclaw update --tag <candidate-tarball> --yes --json --no-restart` against the package built from this PR. This is synthetic seeded installed-state proof, not a production-data replay.

- Actual updater result: `status=ok`, `candidateInstallMode=updater`, `updateOutcome=success`; all nine updater steps exited 0. Baseline build `2026.9.4-release-3a9d69db306c-2026-09-10T22-53-16.719Z` became candidate build `2026.9.4-94df065ae068-2026-09-13T03-39-24.125Z`—the equal package version strings do not substitute for this build identity.
- Existing agent database migrated **19 → 20**; shared-state database stayed **17 → 17**. Automatic migration was verified before candidate probes, with session/state survival, both cron owners, the Discord plugin, and a mock-backed candidate agent turn preserved. These schema versions and migrations predate this PR; its schema definitions, migration owners, updater markers, and result contracts are unchanged.
- Gateway started and passed health/readiness/status probes; Doctor was clean. A second actual update returned `skipped / already-current`, no steps and no package mutations. The formerly bundled-plugin Doctor scenario also passed.
- The complete survivor reported `status=passed`, no failure, and **40 completed phases**. Some generic phase wrappers are no-ops for this scenario; this is not mobile or OS-managed-service proof.
- Fresh focused tests: **254 passed, 2 platform-specific skips** across the compaction, session-import, and upgrade-plugin-registry files. Full package build and tarball integrity checks passed. Exact-head [CI run 34732356828, attempt 2](https://github.com/openclaw/openclaw/actions/runs/34732356828/attempts/2) is green.

<details>
<summary>Commands and captured compatibility result</summary>

Run identity: `run_88ee76b22272d2734249fbdc254a4089`, provider `aws`, lease `cbx_2d33384edb7b`, Linux / Node 24.19.0. Source head was checked by the trusted bootstrap before dependencies or PR code executed. The run exited 0; tests, build, package check, and survivor together took 19m10.595s. Broker artifact upload failed, so the key captured results are embedded here rather than claiming an available attachment.

`pnpm test src/commands/doctor-sqlite-compact.test.ts src/commands/doctor-session-sqlite.test.ts test/scripts/upgrade-survivor-plugin-registry.test.ts`

`OPENCLAW_DOCKER_E2E_SELECTED_SHA=94df065ae06870a876fe9b980db13fa47334d96b OPENCLAW_UPGRADE_SURVIVOR_PUBLISHED_BASELINE=1 OPENCLAW_UPGRADE_SURVIVOR_BASELINE_SPEC=openclaw@2026.9.4 OPENCLAW_UPGRADE_SURVIVOR_SCENARIO=legacy-operator-state OPENCLAW_UPGRADE_SURVIVOR_CANDIDATE=current OPENCLAW_UPGRADE_SURVIVOR_LIVE_OPENAI=0 bash scripts/e2e/upgrade-survivor-docker.sh`

`summary.json`: `status=passed; candidate.kind=tarball; candidateInstallMode=updater; updateOutcome=success; scenario=legacy-operator-state; failure=null`.

`schema-before.json → schema-after.json`: agent `userVersion/contentVersion 19/19 → 20/20`; state `17/17 → 17/17`.

`update.json`: global update, candidate migration rehearsal, candidate doctor lint, candidate config validation, candidate plugin resolution, candidate migration continuation, candidate gateway canary, global install swap, and openclaw doctor: **each exitCode=0**.

`update-noop.json`: `{"status":"skipped","reason":"already-current","steps":[]}`.

</details>


### Verification

- Regression fails on base `75fbe37c23f4dde083f6bbc868908a97f211f855`: expected one full integrity check, observed two.
- Doctor session-import, shared-state compaction, and focused compaction suites: **255 passed, 2 skipped**. Includes real SQLite corruption rejection, busy-WAL refusal, import/recovery, and explicit-compaction coverage.
- Changed-file checks, including core and core-test typechecks, formatting, lint, and repository guards: passed.
- Independent autoreview: no actionable P0–P2 findings.

**Real behavior proof:** On Linux with Node 24.19.0, a 1.003 GiB SQLite fixture with incremental auto-vacuum, zero free pages, and no WAL was exercised through the actual compaction owner. Four paired warm samples per version, alternating order after warmup:

| No-op import cleanup | Base | Candidate |
| --- | ---: | ---: |
| Median elapsed | 258.5 ms | 127.0 ms |
| Logical read volume | 2.008 GiB | 1.004 GiB |
| Full integrity checks | 2 | 1 |

The regression also checks unchanged database bytes and successful completion callbacks.

<details>
<summary>Reproduce the benchmark fixture on base and PR head</summary>

Run from each checkout with its dependencies installed, discarding sample 0. The reported comparison used the same fixture with alternating base/candidate calls.

```sh
node --import ./scripts/tsx.mjs --input-type=module <<'JS'
import { DatabaseSync } from 'node:sqlite';
import { mkdtempSync, rmSync } from 'node:fs';
import { tmpdir } from 'node:os';
import { join } from 'node:path';
import { performance } from 'node:perf_hooks';
import { compactDoctorSqliteFile } from './src/commands/doctor-sqlite-compact.ts';
const root = mkdtempSync(join(tmpdir(), 'doctor-noop-bench-'));
const sqlitePath = join(root, 'fixture.sqlite');
const db = new DatabaseSync(sqlitePath);
db.exec('PRAGMA auto_vacuum=INCREMENTAL; PRAGMA journal_mode=WAL; CREATE TABLE payload(id INTEGER PRIMARY KEY, body BLOB); BEGIN;');
const insert = db.prepare('INSERT INTO payload(body) VALUES(zeroblob(1048576))');
for (let i = 0; i < 1024; i++) insert.run();
db.exec('COMMIT;');
db.close();
try {
  for (let sample = 0; sample < 5; sample++) {
    const start = performance.now();
    const result = compactDoctorSqliteFile({ sqlitePath, operation: 'import-finalize' });
    console.log({ sample, elapsedMs: performance.now() - start, ...result });
  }
} finally {
  rmSync(root, { recursive: true });
}
JS
```

</details>

**Remaining proof limits:** No production/customer-state replay, authenticated external-provider test, Windows/macOS execution, or OS-managed service restart was performed. The published-updater × exact-candidate cell above covers seeded pre-existing operator state with a manual restart fixture. The benchmark timing remains specific to eligible compaction, not an end-to-end Doctor speedup.

